### PR TITLE
gdi: in gdi_free, use gdi_DeleteDC to release gdi->hdc instead of incorrect gdi_DeleteObject (fix memory leak and crash when calling gdi_free)

### DIFF
--- a/libfreerdp-gdi/gdi.c
+++ b/libfreerdp-gdi/gdi.c
@@ -1186,7 +1186,7 @@ void gdi_free(rdpInst* inst)
 	if (gdi)
 	{
 		gdi_bitmap_free(gdi->primary);
-		gdi_DeleteObject((HGDIOBJECT) gdi->hdc);
+		gdi_DeleteDC(gdi->hdc);
 		free(gdi->clrconv);
 		free(gdi);
 	}


### PR DESCRIPTION
gdi: in gdi_free, use gdi_DeleteDC to release gdi->hdc instead of incorrect gdi_DeleteObject
