### PR TITLE
force or ignore optional dependencies in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/)
 
 include(AutoVersioning)
 include(ConfigOptions)
+include(FindOptionalPackage)
 
 # Soname versioning - 0.0.0 since it is not being managed yet
 set(FREERDP_VERSION_MAJOR "0")
@@ -79,9 +80,9 @@ find_package(OpenSSL REQUIRED)
 
 if(NOT WIN32)
 	find_package(ZLIB REQUIRED)
-	find_package(ALSA)
-	find_package(PulseAudio)
-	find_package(Cups)
+	find_optional_package(ALSA)
+	find_optional_package(PulseAudio)
+	find_optional_package(Cups)
 endif()
 
 # Endian

--- a/cmake/FindOptionalPackage.cmake
+++ b/cmake/FindOptionalPackage.cmake
@@ -1,0 +1,34 @@
+# - FindOptionalPackage
+# Enable or disable optional packages. Also force optional packages.
+#
+#  This module defines the following variables:
+#
+
+#=============================================================================
+# Copyright 2011 Nils Andresen <nils@nils-andresen.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+
+macro(find_optional_package _normal_package)
+	STRING(TOUPPER ${_normal_package} _upper_package)
+	OPTION(WITH_${_upper_package} "Force dependencies to ${_normal_package}" OFF)
+	OPTION(WITHOUT_${_upper_package} "Never depend on ${_normal_package}" OFF)
+
+	if(WITH_${_upper_package})
+		find_package(${_normal_package} REQUIRED)
+	elseif(NOT WITHOUT_${_upper_package})
+		find_package(${_normal_package})
+	endif(WITH_${_upper_package})
+endmacro(find_optional_package)


### PR DESCRIPTION
cmake: added find_optional_package module to force or ignore optional dependencies
