### PR TITLE
Changed return value check for XGetWindowProperty

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -94,7 +94,7 @@ boolean xf_GetWindowProperty(xfInfo* xfi, Window window, Atom property, int leng
 			property, 0, length, False, AnyPropertyType,
 			&actual_type, &actual_format, nitems, bytes, prop);
 
-	if (status != Success)
+	if (status == None)
 		return False;
 
 	return True;


### PR DESCRIPTION
XGetWindowProperty return None if the property isn't found.
So raise an error is None is returned. Otherwise the property
was returned.
