### PR TITLE
cmake fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,11 @@ if(NOT CMAKE_BUILD_TYPE)
    set(CMAKE_BUILD_TYPE "Release")
 endif()
 
+# Set default libdir
+if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+	set(CMAKE_INSTALL_LIBDIR "lib")
+endif()
+
 # Compiler-specific flags
 if(CMAKE_COMPILER_IS_GNUCC)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unused-but-set-variable")
@@ -90,7 +95,7 @@ test_big_endian(BIG_ENDIAN)
 set(FREERDP_KEYMAP_PATH "${CMAKE_INSTALL_PREFIX}/freerdp/keymaps")
 
 # Path to put plugins
-set(FREERDP_PLUGIN_PATH "${CMAKE_INSTALL_PREFIX}/lib/freerdp")
+set(FREERDP_PLUGIN_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/freerdp")
 
 # Include directories
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/client/X11/CMakeLists.txt
+++ b/client/X11/CMakeLists.txt
@@ -52,8 +52,6 @@ if(Xcursor_FOUND)
 	target_link_libraries(xfreerdp ${Xext_LIBRARIES})
 endif()
 
-INSTALL_PROGRAMS(/bin FILES xfreerdp)
-
 target_link_libraries(xfreerdp freerdp-core)
 target_link_libraries(xfreerdp freerdp-gdi)
 target_link_libraries(xfreerdp freerdp-kbd)
@@ -61,3 +59,5 @@ target_link_libraries(xfreerdp freerdp-rail)
 target_link_libraries(xfreerdp freerdp-chanman)
 target_link_libraries(xfreerdp freerdp-utils)
 target_link_libraries(xfreerdp ${X11_LIBRARIES})
+
+install(TARGETS xfreerdp DESTINATION bin)

--- a/libfreerdp-cache/CMakeLists.txt
+++ b/libfreerdp-cache/CMakeLists.txt
@@ -32,4 +32,4 @@ set_target_properties(freerdp-cache PROPERTIES VERSION ${FREERDP_VERSION_FULL} S
 
 target_link_libraries(freerdp-cache freerdp-utils)
 
-install(TARGETS freerdp-cache DESTINATION lib)
+install(TARGETS freerdp-cache DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libfreerdp-chanman/CMakeLists.txt
+++ b/libfreerdp-chanman/CMakeLists.txt
@@ -26,5 +26,5 @@ add_library(freerdp-chanman SHARED ${FREERDP_CHANMAN_SRCS})
 set_target_properties(freerdp-chanman PROPERTIES VERSION ${FREERDP_VERSION_FULL} SOVERSION ${FREERDP_VERSION} PREFIX "lib")
 target_link_libraries(freerdp-chanman freerdp-utils)
 
-install(TARGETS freerdp-chanman DESTINATION lib)
+install(TARGETS freerdp-chanman DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/libfreerdp-core/CMakeLists.txt
+++ b/libfreerdp-core/CMakeLists.txt
@@ -105,4 +105,4 @@ endif()
 target_link_libraries(freerdp-core ${OPENSSL_LIBRARIES})
 target_link_libraries(freerdp-core freerdp-utils)
 
-install(TARGETS freerdp-core DESTINATION lib)
+install(TARGETS freerdp-core DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libfreerdp-gdi/CMakeLists.txt
+++ b/libfreerdp-gdi/CMakeLists.txt
@@ -41,4 +41,4 @@ target_link_libraries(freerdp-gdi freerdp-rfx)
 
 set_target_properties(freerdp-gdi PROPERTIES VERSION ${FREERDP_VERSION_FULL} SOVERSION ${FREERDP_VERSION} PREFIX "lib")
 
-install(TARGETS freerdp-gdi DESTINATION lib)
+install(TARGETS freerdp-gdi DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libfreerdp-kbd/CMakeLists.txt
+++ b/libfreerdp-kbd/CMakeLists.txt
@@ -40,5 +40,5 @@ add_definitions(-DKEYMAP_PATH="${FREERDP_KEYMAP_PATH}")
 
 set_target_properties(freerdp-kbd PROPERTIES VERSION ${FREERDP_VERSION_FULL} SOVERSION ${FREERDP_VERSION} PREFIX "lib")
 
-install(TARGETS freerdp-kbd DESTINATION lib)
+install(TARGETS freerdp-kbd DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/libfreerdp-rail/CMakeLists.txt
+++ b/libfreerdp-rail/CMakeLists.txt
@@ -29,4 +29,4 @@ set_target_properties(freerdp-rail PROPERTIES VERSION ${FREERDP_VERSION_FULL} SO
 
 target_link_libraries(freerdp-rail freerdp-utils)
 
-install(TARGETS freerdp-rail DESTINATION lib)
+install(TARGETS freerdp-rail DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libfreerdp-rfx/CMakeLists.txt
+++ b/libfreerdp-rfx/CMakeLists.txt
@@ -51,4 +51,4 @@ if(WITH_SSE2)
 	target_link_libraries(freerdp-rfx freerdp-rfx-sse2)
 endif()
 
-install(TARGETS freerdp-rfx DESTINATION lib)
+install(TARGETS freerdp-rfx DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libfreerdp-utils/CMakeLists.txt
+++ b/libfreerdp-utils/CMakeLists.txt
@@ -54,4 +54,4 @@ if(WIN32)
 	target_link_libraries(freerdp-utils ws2_32)
 endif()
 
-install(TARGETS freerdp-utils DESTINATION lib)
+install(TARGETS freerdp-utils DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Adding -O0 to CFLAGS makes this harder to package for linux distros since the only way to disable it is to patch CMakeLists.txt.
