### PR TITLE
Offscreen fix

### DIFF
--- a/libfreerdp-cache/bitmap.c
+++ b/libfreerdp-cache/bitmap.c
@@ -38,7 +38,7 @@ void update_gdi_memblt(rdpUpdate* update, MEMBLT_ORDER* memblt)
 	rdpBitmap* bitmap;
 	rdpCache* cache = (rdpCache*) update->cache;
 
-	if (memblt->cacheIndex == 0xFF)
+	if (memblt->cacheId == 0xFF)
 		bitmap = offscreen_cache_get(cache->offscreen, memblt->cacheIndex);
 	else
 		bitmap = bitmap_cache_get(cache->bitmap, memblt->cacheId, memblt->cacheIndex);
@@ -52,7 +52,7 @@ void update_gdi_mem3blt(rdpUpdate* update, MEM3BLT_ORDER* mem3blt)
 	rdpBitmap* bitmap;
 	rdpCache* cache = (rdpCache*) update->cache;
 
-	if (mem3blt->cacheIndex == 0xFF)
+	if (mem3blt->cacheId == 0xFF)
 		bitmap = offscreen_cache_get(cache->offscreen, mem3blt->cacheIndex);
 	else
 		bitmap = bitmap_cache_get(cache->bitmap, mem3blt->cacheId, mem3blt->cacheIndex);

--- a/libfreerdp-cache/offscreen.c
+++ b/libfreerdp-cache/offscreen.c
@@ -32,6 +32,9 @@ void update_gdi_create_offscreen_bitmap(rdpUpdate* update, CREATE_OFFSCREEN_BITM
 	IFCALL(cache->offscreen->OffscreenBitmapSize, update, &size);
 	bitmap = (rdpBitmap*) xzalloc(size);
 
+	bitmap->width = create_offscreen_bitmap->cx;
+	bitmap->height = create_offscreen_bitmap->cy;
+
 	IFCALL(cache->offscreen->OffscreenBitmapNew, update, bitmap);
 	prevBitmap = offscreen_cache_get(cache->offscreen, create_offscreen_bitmap->id);
 


### PR DESCRIPTION
Get the right dimension when creating offscreen.
Offscreen is still selected by cacheId.

After that there is still another problem I do not know how to fix (I prevent crash in 1ccbbdba20bb6aae6310626618006d1f0e9fd6b4 but it do not fix the problem), sometime server recreate offscreen it already have switch to. So freerdp try to draw on a distroyed pixmap.

My way to test this problem is to connect to windows XP with MS Outlook 2007 opened in it. There is draw problems everytime I resize part of the display in Outlook.  
