### PR TITLE
xfreerdp: fix xf_GetWindowProperty

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -95,6 +95,12 @@ boolean xf_GetWindowProperty(xfInfo* xfi, Window window, Atom property, int leng
 	if (status != Success)
 		return False;
 
+	if (actual_type == None)
+	{
+		DEBUG_WARN("Property %lu does not exist", property);
+		return False;
+	}
+
 	return True;
 }
 


### PR DESCRIPTION
xf_GetWindowProperty should return False if the specified property does not exist.
It is not sufficient to simply check for the return value of XGetWindowProperty.
XGetWindowProperty also returns Success if the specified property does not exist.
However, it will return "None" to the actual_type_return parameter in that case.
This change fixes several crashes with some (exotic) window managers.
