### PR TITLE
pcap: fix timstamps to use gettimeofday

### DIFF
--- a/include/freerdp/utils/pcap.h
+++ b/include/freerdp/utils/pcap.h
@@ -22,7 +22,6 @@
 
 #include <freerdp/api.h>
 #include <freerdp/types.h>
-#include <freerdp/utils/stopwatch.h>
 
 struct _pcap_header
 {
@@ -59,7 +58,6 @@ struct rdp_pcap
 {
 	FILE* fp;
 	char* name;
-	STOPWATCH* sw;
 	boolean write;
 	int file_size;
 	int record_count;


### PR DESCRIPTION
pcap used utils/stopwatch to save a record's timestamp which is not suitable because stopwatch measures cpu time and not the wall-clock time
also fixed the sleep calculation in the tfreerdp test server
