### PR TITLE
core: handle transport->recv_callback correctly

### DIFF
--- a/libfreerdp-core/transport.c
+++ b/libfreerdp-core/transport.c
@@ -347,7 +347,10 @@ int transport_check_fds(rdpTransport* transport)
 		stream_set_pos(received, length);
 		stream_seal(received);
 		stream_set_pos(received, 0);
-		status = transport->recv_callback(transport, received, transport->recv_extra);
+		
+		if (transport->recv_callback(transport, received, transport->recv_extra) == False)
+			status = -1;
+	
 		stream_free(received);
 
 		if (status < 0)


### PR DESCRIPTION
the boolean return value of transport->recv_callback was directly assigned to "int status" in transport_check_fds.
now status is set to -1 if transport->recv_callback returns False.

this was also the reason for the long delays on logoff followed by these messages:
"SSL_read: I/O error" (with --sec nla|tls)
"recv: Connection reset by peer" + "send: Broken pipe" (with --sec rdp)
