### PR TITLE
pcap: fix several segfaults with NULL pcap file handle

### DIFF
--- a/libfreerdp-core/freerdp.c
+++ b/libfreerdp-core/freerdp.c
@@ -42,8 +42,9 @@ boolean freerdp_connect(freerdp* instance)
 	{
 		if (instance->settings->dump_rfx)
 		{
-			instance->update->dump_rfx = instance->settings->dump_rfx;
 			instance->update->pcap_rfx = pcap_open(instance->settings->dump_rfx_file, True);
+			if (instance->update->pcap_rfx)
+				instance->update->dump_rfx = True;
 		}
 
 		IFCALL(instance->PostConnect, instance);
@@ -55,11 +56,12 @@ boolean freerdp_connect(freerdp* instance)
 			pcap_record record;
 
 			s = stream_new(1024);
-			instance->update->play_rfx = instance->settings->play_rfx;
 			instance->update->pcap_rfx = pcap_open(instance->settings->play_rfx_file, False);
+			if (instance->update->pcap_rfx)
+				instance->update->play_rfx = True;
 			update = instance->update;
 
-			while (pcap_has_next_record(update->pcap_rfx))
+			while (instance->update->play_rfx && pcap_has_next_record(update->pcap_rfx))
 			{
 				pcap_get_next_record_header(update->pcap_rfx, &record);
 

--- a/libfreerdp-utils/pcap.c
+++ b/libfreerdp-utils/pcap.c
@@ -134,6 +134,13 @@ rdpPcap* pcap_open(char* name, boolean write)
 {
 	rdpPcap* pcap;
 
+	FILE *pcap_fp = fopen(name, write ? "w+" : "r");
+	if (pcap_fp == NULL)
+	{
+		perror("opening pcap dump");
+		return NULL;
+	}
+
 	pcap = (rdpPcap*) xzalloc(sizeof(rdpPcap));
 
 	if (pcap != NULL)
@@ -141,10 +148,10 @@ rdpPcap* pcap_open(char* name, boolean write)
 		pcap->name = name;
 		pcap->write = write;
 		pcap->record_count = 0;
+		pcap->fp = pcap_fp;
 
 		if (write)
 		{
-			pcap->fp = fopen(name, "w+");
 			pcap->header.magic_number = 0xA1B2C3D4;
 			pcap->header.version_major = 2;
 			pcap->header.version_minor = 4;
@@ -156,7 +163,6 @@ rdpPcap* pcap_open(char* name, boolean write)
 		}
 		else
 		{
-			pcap->fp = fopen(name, "r");
 			fseek(pcap->fp, 0, SEEK_END);
 			pcap->file_size = (int) ftell(pcap->fp);
 			fseek(pcap->fp, 0, SEEK_SET);

--- a/server/X11/xfreerdp.c
+++ b/server/X11/xfreerdp.c
@@ -26,6 +26,7 @@
 #include "xfreerdp.h"
 
 char* xf_pcap_file = NULL;
+boolean xf_pcap_dump_realtime = True;
 
 void xf_server_main_loop(freerdp_listener* instance)
 {
@@ -99,6 +100,9 @@ int main(int argc, char* argv[])
 
 	if (argc > 1)
 		xf_pcap_file = argv[1];
+
+	if (argc > 2 && !strcmp(argv[2], "--fast"))
+		xf_pcap_dump_realtime = False;
 
 	/* Open the server socket and start listening. */
 	if (instance->Open(instance, NULL, 3389))

--- a/server/test/tfreerdp.c
+++ b/server/test/tfreerdp.c
@@ -299,6 +299,9 @@ void tf_peer_dump_rfx(freerdp_peer* client)
 	client->update->pcap_rfx = pcap_open(test_pcap_file, False);
 	pcap_rfx = client->update->pcap_rfx;
 
+	if (pcap_rfx == NULL)
+		return;
+
 	prev_seconds = prev_useconds = 0;
 
 	while (pcap_has_next_record(pcap_rfx))


### PR DESCRIPTION
- pcap_open did not return NULL if fopen failed
- libfreerdp-core, tfreerdp-server and xfreerdp-server did not check the pcap_open result
- also fixed the sleep calculation in the xfreerdp-server
