### PR TITLE
libfreerdp-codec: rfx quantization decode fix

### DIFF
--- a/libfreerdp-codec/rfx_quantization.c
+++ b/libfreerdp-codec/rfx_quantization.c
@@ -45,7 +45,7 @@ void rfx_quantization_decode(sint16* buffer, const uint32* quantization_values)
 	rfx_quantization_decode_block(buffer + 3584, 256, quantization_values[6] - 6); /* HH2 */
 	rfx_quantization_decode_block(buffer + 3840, 64, quantization_values[2] - 6); /* HL3 */
 	rfx_quantization_decode_block(buffer + 3904, 64, quantization_values[1] - 6); /* LH3 */
-	rfx_quantization_decode_block(buffer + 3868, 64, quantization_values[3] - 6); /* HH3 */
+	rfx_quantization_decode_block(buffer + 3968, 64, quantization_values[3] - 6); /* HH3 */
 	rfx_quantization_decode_block(buffer + 4032, 64, quantization_values[0] - 6); /* LL3 */
 }
 

--- a/libfreerdp-codec/rfx_sse2.c
+++ b/libfreerdp-codec/rfx_sse2.c
@@ -249,7 +249,7 @@ static void rfx_quantization_decode_sse2(sint16* buffer, const uint32* quantizat
 	rfx_quantization_decode_block_sse2(buffer + 3584, 256, quantization_values[6] - 6); /* HH2 */
 	rfx_quantization_decode_block_sse2(buffer + 3840, 64, quantization_values[2] - 6); /* HL3 */
 	rfx_quantization_decode_block_sse2(buffer + 3904, 64, quantization_values[1] - 6); /* LH3 */
-	rfx_quantization_decode_block_sse2(buffer + 3868, 64, quantization_values[3] - 6); /* HH3 */
+	rfx_quantization_decode_block_sse2(buffer + 3968, 64, quantization_values[3] - 6); /* HH3 */
 	rfx_quantization_decode_block_sse2(buffer + 4032, 64, quantization_values[0] - 6); /* LL3 */
 }
 


### PR DESCRIPTION
- the incorrect offset also causes an unaligned access with sse2,
  on i386 it may segv on _mm_load_sil128

(i double checked the spec [ms-rdprfx] 4.2.4.2, HH3 starts @0xf80 / 3968, so bug is typo)
