### PR TITLE
cmake: use CMAKE_DL_LIBS instead of dl for portability

### DIFF
--- a/client/X11/CMakeLists.txt
+++ b/client/X11/CMakeLists.txt
@@ -93,6 +93,6 @@ target_link_libraries(xfreerdp freerdp-kbd)
 target_link_libraries(xfreerdp freerdp-rail)
 target_link_libraries(xfreerdp freerdp-channels)
 target_link_libraries(xfreerdp freerdp-utils)
-target_link_libraries(xfreerdp ${X11_LIBRARIES} dl)
+target_link_libraries(xfreerdp ${X11_LIBRARIES} ${CMAKE_DL_LIBS})
 
 install(TARGETS xfreerdp DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/client/test/CMakeLists.txt
+++ b/client/test/CMakeLists.txt
@@ -23,4 +23,4 @@ add_executable(freerdp-test
 target_link_libraries(freerdp-test freerdp-core)
 target_link_libraries(freerdp-test freerdp-gdi)
 target_link_libraries(freerdp-test freerdp-utils)
-target_link_libraries(freerdp-test freerdp-channels dl)
+target_link_libraries(freerdp-test freerdp-channels ${CMAKE_DL_LIBS})


### PR DESCRIPTION
dl linking issue reported from freebsd users
