### PR TITLE
Basic port to Solaris

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+#include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xatom.h>
 

--- a/libfreerdp-kbd/layouts_xkb.c
+++ b/libfreerdp-kbd/layouts_xkb.c
@@ -22,6 +22,7 @@
 #include <string.h>
 
 #ifdef WITH_XKBFILE
+#include <X11/Xlib.h>
 #include <X11/XKBlib.h>
 #include <X11/extensions/XKBfile.h>
 #include <X11/extensions/XKBrules.h>


### PR DESCRIPTION
Basic port to solaris - gets FreeRDP to compile with gcc and fixes small bug in window creation.
