### PR TITLE
Intermittent crash Linux & Solaris with RAIL; add missing system library for sem_* on Solaris

### DIFF
--- a/libfreerdp-utils/CMakeLists.txt
+++ b/libfreerdp-utils/CMakeLists.txt
@@ -60,5 +60,8 @@ target_link_libraries(freerdp-utils ${CMAKE_THREAD_LIBS_INIT})
 if(WIN32)
 	target_link_libraries(freerdp-utils ws2_32)
 endif()
+if(${CMAKE_SYSTEM_NAME} MATCHES SunOS)
+	target_link_libraries(freerdp-utils rt)
+endif()
 
 install(TARGETS freerdp-utils DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Added -lrt which is a required library for the sem_*() functions
Fixed xf_window.c to not return null for zero-width windows - rather coerce values to be valid as was already being done for height and width. This fixes intermittent crashs on Solars and Linux.
