### PR TITLE
Bug in cursor support for RemoteApps

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -626,6 +626,9 @@ void xf_DestroyWindow(xfInfo* xfi, xfWindow* window)
 	if (window == NULL)
 		return;
 
+	if (xfi->window == window)
+		xfi->window = NULL;
+
 	if (window->gc)
 		XFreeGC(xfi->display, window->gc);
 


### PR DESCRIPTION
In some cases we receive a pointer update for a window that has been destroyed, such as a popup.  This would result in an X server error. Reset current window when window is destroyed.
