### PR TITLE
core: add update callback for the surface frame marker command

### DIFF
--- a/client/X11/xf_gdi.c
+++ b/client/X11/xf_gdi.c
@@ -613,6 +613,11 @@ void xf_gdi_mem3blt(rdpContext* context, MEM3BLT_ORDER* mem3blt)
 
 }
 
+void xf_gdi_surface_frame_marker(rdpContext* context, uint16 frame_action, uint32 frame_id)
+{
+
+}
+
 void xf_gdi_surface_bits(rdpContext* context, SURFACE_BITS_COMMAND* surface_bits_command)
 {
 	int i, tx, ty;
@@ -768,5 +773,6 @@ void xf_gdi_register_update_callbacks(rdpUpdate* update)
 	primary->EllipseCB = NULL;
 
 	update->SurfaceBits = xf_gdi_surface_bits;
+	update->SurfaceFrameMarker = xf_gdi_surface_frame_marker;
 }
 

--- a/include/freerdp/update.h
+++ b/include/freerdp/update.h
@@ -130,6 +130,7 @@ typedef void (*pSuppressOutput)(rdpContext* context, uint8 allow, RECTANGLE_16* 
 
 typedef void (*pSurfaceCommand)(rdpContext* context, STREAM* s);
 typedef void (*pSurfaceBits)(rdpContext* context, SURFACE_BITS_COMMAND* surface_bits_command);
+typedef void (*pSurfaceFrameMarker)(rdpContext* context, uint16 frameAction, uint32 frameId);
 
 struct rdp_update
 {
@@ -159,7 +160,8 @@ struct rdp_update
 
 	pSurfaceCommand SurfaceCommand; /* 64 */
 	pSurfaceBits SurfaceBits; /* 65 */
-	uint32 paddingE[80 - 66]; /* 66 */
+	pSurfaceFrameMarker SurfaceFrameMarker; /* 66 */
+	uint32 paddingE[80 - 67]; /* 67 */
 
 	/* internal */
 

--- a/libfreerdp-core/surface.c
+++ b/libfreerdp-core/surface.c
@@ -54,6 +54,8 @@ static int update_recv_surfcmd_frame_marker(rdpUpdate* update, STREAM* s)
 	stream_read_uint16(s, frameAction);
 	stream_read_uint32(s, frameId);
 
+	IFCALL(update->SurfaceFrameMarker, update->context, frameAction, frameId);
+
 	return 6;
 }
 


### PR DESCRIPTION
- clients will need this to present the offscreen to the display
  in the correct state in order to avoid flickering and artefacts
  and to do frame acknowledgement.
- added empty callback to xfreerdp.
