### PR TITLE
core: request RemoteFX-only data if --dump-rfx is specified

### DIFF
--- a/libfreerdp-core/capabilities.c
+++ b/libfreerdp-core/capabilities.c
@@ -1427,7 +1427,7 @@ void rdp_write_rfx_client_capability_container(STREAM* s, rdpSettings* settings)
 
 	/* TS_RFX_CLNT_CAPS_CONTAINER */
 	stream_write_uint32(s, 49); /* length */
-	stream_write_uint32(s, CARDP_CAPS_CAPTURE_NON_CAC); /* captureFlags */
+	stream_write_uint32(s, captureFlags); /* captureFlags */
 	stream_write_uint32(s, 37); /* capsLength */
 
 	/* TS_RFX_CAPS */


### PR DESCRIPTION
The variable captureFlags was already correctly set if --dump-rfx
was specified but simply not used.
