### PR TITLE
#234 redirect should use FDQN instead of netbios name when possible

### DIFF
--- a/libfreerdp-core/connection.c
+++ b/libfreerdp-core/connection.c
@@ -135,6 +135,9 @@ boolean rdp_client_redirect(rdpRdp* rdp)
 	if (redirection->flags & LB_TARGET_NET_ADDRESS) {
 		xfree(settings->hostname);
 		settings->hostname = redirection->targetNetAddress.ascii;
+        } else if (redirection->flags & LB_TARGET_FQDN) {
+                xfree(settings->hostname);
+                settings->hostname = redirection->targetFQDN.ascii;
 	} else if (redirection->flags & LB_TARGET_NETBIOS_NAME) {
 		xfree(settings->hostname);
 		settings->hostname = redirection->targetNetBiosName.ascii;


### PR DESCRIPTION
If the redirecting server provides a FQDN and netbios name, but no IP address, the netbios name is attempted. If the search path isn't present on the client, the redirect fails because of DNS resolution failure.

https://github.com/FreeRDP/FreeRDP/issues/234
