### PR TITLE
fastpath: refactor fastpath updates and merge fragmented codes.

### DIFF
--- a/libfreerdp-core/fastpath.h
+++ b/libfreerdp-core/fastpath.h
@@ -99,11 +99,9 @@ STREAM* fastpath_input_pdu_init(rdpFastPath* fastpath, uint8 eventFlags, uint8 e
 boolean fastpath_send_input_pdu(rdpFastPath* fastpath, STREAM* s);
 
 STREAM* fastpath_update_pdu_init(rdpFastPath* fastpath);
-boolean fastpath_send_update_pdu(rdpFastPath* fastpath, STREAM* s);
-boolean fastpath_send_fragmented_update_pdu(rdpFastPath* fastpath, STREAM* s);
+boolean fastpath_send_update_pdu(rdpFastPath* fastpath, uint8 updateCode, STREAM* s);
 
 boolean fastpath_send_surfcmd_frame_marker(rdpFastPath* fastpath, uint16 frameAction, uint32 frameId);
-boolean fastpath_send_surfcmd_surface_bits(rdpFastPath* fastpath, SURFACE_BITS_COMMAND* cmd);
 
 rdpFastPath* fastpath_new(rdpRdp* rdp);
 void fastpath_free(rdpFastPath* fastpath);


### PR DESCRIPTION
There used to be 3 different functions (fastpath_send_update_pdu, fastpath_send_fragmented_update_pdu, fastpath_send_surface_bits_command) which all did similar stuff and had quite a few duplicated codes and logic. This commit merged them into a single function and provides a simpler and cleaner internal fastpath API.
