### PR TITLE
xfreerdp-server: fix compilation when xdamage is disabled

### DIFF
--- a/server/X11/xf_peer.c
+++ b/server/X11/xf_peer.c
@@ -47,8 +47,10 @@ xfInfo* xf_info_init()
 	xfInfo* xfi;
 	int pf_count;
 	int vi_count;
+#ifdef WITH_XDAMAGE
 	int damage_event;
 	int damage_error;
+#endif
 	XVisualInfo* vi;
 	XVisualInfo* vis;
 	XVisualInfo template;
@@ -121,7 +123,9 @@ xfInfo* xf_info_init()
 	xfi->clrconv->alpha = 1;
 
 	XSelectInput(xfi->display, DefaultRootWindow(xfi->display), SubstructureNotifyMask);
+#ifdef WITH_XDAMAGE
 	XDamageQueryExtension(xfi->display, &damage_event, &damage_error);
+#endif 
 
 	return xfi;
 }


### PR DESCRIPTION
xfreerdp-server seems to be built by default. This pull request fixes compilation of xfreerdp-server when xdamage (WITH_XDAMAGE) is disabled.

Without this the following linker error is thrown:
xf_peer.c:(.text+0x574): undefined reference to `XDamageQueryExtension'
