### PR TITLE
libfreerdp-utils/core: use "dylib" as plugin extension on OSX

### DIFF
--- a/libfreerdp-core/extension.c
+++ b/libfreerdp-core/extension.c
@@ -39,7 +39,13 @@
 #define DLSYM(f, n) dlsym(f, n)
 #define DLCLOSE(f) dlclose(f)
 #define PATH_SEPARATOR '/'
+
+#ifdef __APPLE__
+#define PLUGIN_EXT "dylib"
+#else
 #define PLUGIN_EXT "so"
+#endif 
+
 #endif
 
 static uint32 FREERDP_CC extension_register_plugin(rdpExtPlugin* plugin)

--- a/libfreerdp-utils/load_plugin.c
+++ b/libfreerdp-utils/load_plugin.c
@@ -40,7 +40,12 @@
 #define DLSYM(f, n) dlsym(f, n)
 #define DLCLOSE(f) dlclose(f)
 #define PATH_SEPARATOR '/'
+
+#ifdef __APPLE__
+#define PLUGIN_EXT "dylib"
+#else
 #define PLUGIN_EXT "so"
+#endif 
 
 #endif
 


### PR DESCRIPTION
Use dylib as file extension for plugins on OSX (instead of .so)
