### PR TITLE
xfreerdp: fix non-xinerama fullscreen issue (issue #266)

### DIFF
--- a/client/X11/xf_monitor.c
+++ b/client/X11/xf_monitor.c
@@ -51,7 +51,12 @@ boolean xf_detect_monitors(xfInfo* xfi, rdpSettings* settings)
 		xfi->workArea.height = HeightOfScreen(xfi->screen);
 	}
 
-	if (settings->workarea)
+	if (settings->fullscreen)
+	{
+		settings->width = WidthOfScreen(xfi->screen);
+		settings->height = HeightOfScreen(xfi->screen);	
+	}
+	else if (settings->workarea)
 	{
 		settings->width = xfi->workArea.width;
 		settings->height = xfi->workArea.height;
@@ -112,8 +117,11 @@ boolean xf_detect_monitors(xfInfo* xfi, rdpSettings* settings)
 		vscreen->area.bottom = MAX(vscreen->monitors[i].area.bottom, vscreen->area.bottom);
 	}
 
-	settings->width = vscreen->area.right - vscreen->area.left + 1;
-	settings->height = vscreen->area.bottom - vscreen->area.top + 1;
+	if (settings->num_monitors)
+	{
+		settings->width = vscreen->area.right - vscreen->area.left + 1;
+		settings->height = vscreen->area.bottom - vscreen->area.top + 1;
+	}
 
 	return true;
 }

--- a/client/X11/xfreerdp.c
+++ b/client/X11/xfreerdp.c
@@ -293,12 +293,6 @@ void xf_create_window(xfInfo* xfi)
 
 	if (xfi->remote_app != true)
 	{
-		if (xfi->fullscreen)
-		{
-			width = xfi->fullscreen ? WidthOfScreen(xfi->screen) : xfi->width;
-			height = xfi->fullscreen ? HeightOfScreen(xfi->screen) : xfi->height;
-		}
-
 		if (xfi->instance->settings->window_title != NULL)
 		{
 			win_title = xmalloc(sizeof(xfi->instance->settings->window_title));


### PR DESCRIPTION
If fullscreen==true then settings->width and settings->height are
calculated in xf_monitor.c based on the vscreen->area which is in
turn calculated using xinerama functions.
Thus if xinerama is not used this will result in width=height=1.
