### PR TITLE
server redirection

### DIFF
--- a/libfreerdp-core/connection.c
+++ b/libfreerdp-core/connection.c
@@ -169,6 +169,12 @@ boolean rdp_client_redirect(rdpRdp* rdp)
 		settings->domain = redirection->domain.ascii;
 	}
 
+	if (redirection->flags & LB_PASSWORD)
+	{
+		xfree(settings->password);
+		settings->password = redirection->password.ascii;
+	}
+
 	return rdp_client_connect(rdp);
 }
 

--- a/libfreerdp-core/rdp.c
+++ b/libfreerdp-core/rdp.c
@@ -637,13 +637,23 @@ static boolean rdp_recv_tpkt_pdu(rdpRdp* rdp, STREAM* s)
 			printf("Error: TODO\n");
 			return false;
 		}
-		if (securityHeader & SEC_ENCRYPT)
+		if (securityHeader & (SEC_ENCRYPT|SEC_REDIRECTION_PKT))
 		{
 			if (!rdp_decrypt(rdp, s, length - 4))
 			{
 				printf("rdp_decrypt failed\n");
 				return false;
 			}
+		}
+		if (securityHeader & SEC_REDIRECTION_PKT)
+		{
+			/*
+			 * [MS-RDPBCGR] 2.2.13.2.1
+			 *  - no share control header, nor the 2 byte pad
+			 */
+			s->p -= 2;
+			rdp_recv_enhanced_security_redirection_packet(rdp, s);
+			return true;
 		}
 	}
 


### PR DESCRIPTION
- for --sec rdp, if SEC_REDIRECTION_PKT is set:
  - it implies encrypted packet, so decrypt it
  - it also implies TS_STANDARD_SECURITY_SERVER_REDIRECTION, which slightly differs from TS_ENHANCED_SECURITY_SERVER_REDIRECTION
- if set, need to send the password as well to the redirected server

tested on ws2k3r2 so far
