### PR TITLE
Fix crash when connecting using smartcard authentication

### DIFF
--- a/channels/rdpdr/smartcard/scard_operations.c
+++ b/channels/rdpdr/smartcard/scard_operations.c
@@ -1077,16 +1077,52 @@ static uint32 handle_GetAttrib(IRP* irp)
 #endif
 
 	rv = SCardGetAttrib(hCard, dwAttrId, attrLen == 0 ? NULL : (uint8*) &pbAttr, &attrLen);
+	if( rv != SCARD_S_SUCCESS ) {
+#ifdef SCARD_AUTOALLOCATE
+		if(dwAttrLen == 0)
+		{
+			attrLen = 0;
+		}
+		else
+		{
+			attrLen = SCARD_AUTOALLOCATE;
+		}
+#endif
+	}
 
 	if(dwAttrId == SCARD_ATTR_DEVICE_FRIENDLY_NAME_A && rv == SCARD_E_UNSUPPORTED_FEATURE)
 	{
 		rv = SCardGetAttrib(hCard, SCARD_ATTR_DEVICE_FRIENDLY_NAME_W,
 			attrLen == 0 ? NULL : (uint8*) &pbAttr, &attrLen);
+		if( rv != SCARD_S_SUCCESS ) {
+#ifdef SCARD_AUTOALLOCATE
+			if(dwAttrLen == 0)
+			{
+				attrLen = 0;
+			}
+			else
+			{
+				attrLen = SCARD_AUTOALLOCATE;
+			}
+#endif
+		}
 	}
 	if(dwAttrId == SCARD_ATTR_DEVICE_FRIENDLY_NAME_W && rv == SCARD_E_UNSUPPORTED_FEATURE)
 	{
 		rv = SCardGetAttrib(hCard, SCARD_ATTR_DEVICE_FRIENDLY_NAME_A,
 			attrLen == 0 ? NULL : (uint8*) &pbAttr, &attrLen);
+		if( rv != SCARD_S_SUCCESS ) {
+#ifdef SCARD_AUTOALLOCATE
+			if(dwAttrLen == 0)
+			{
+				attrLen = 0;
+			}
+			else
+			{
+				attrLen = SCARD_AUTOALLOCATE;
+			}
+#endif
+		}
 	}
 	if(attrLen > dwAttrLen && pbAttr != NULL)
 	{


### PR DESCRIPTION
The fix is a little ugly with copy/paste sections, sorry, but without it, attrLen is being set sometimes even when a failure code is returned from libpcsc. The failure code appears to be correct, and the attrLen is bogus. Because of the non-zero attrLen, on the second retry, with an attrLen > 0, libpcsc (correctly) sets pbAttr, but to a non-NULL pointer (since it is not set for auto-allocate at this point). But if this buffer is too small (which it can conceivably be), then it can still return an error, now pbAttr is set to a bogus value too and rv shows a failure. Then the final code that checks for an error sees there is an error and attempts to free a bogus pbAttr causing a crash.

The problem appeared when I updated libpcsclite to debian version 1.8.1-4. I'm not sure what version I had before that, but whatever it was, this problem wasn't present with that version of libpcsclite.
