### PR TITLE
drdynvc: make audin and tsmf config data parsers recognize path-based plugin loading

### DIFF
--- a/channels/drdynvc/audin/audin_main.c
+++ b/channels/drdynvc/audin/audin_main.c
@@ -471,7 +471,7 @@ static boolean audin_process_plugin_data(IWTSPlugin* pPlugin, RDP_PLUGIN_DATA* d
 	AUDIN_PLUGIN* audin = (AUDIN_PLUGIN*) pPlugin;
 	RDP_PLUGIN_DATA default_data[2] = { { 0 }, { 0 } };
 
-	if (data->data[0] && strcmp((char*)data->data[0], "audin") == 0)
+	if (data->data[0] && (strcmp((char*)data->data[0], "audin") == 0 || strstr((char*)data->data[0], "/audin.") != NULL) )
 	{
 		if (data->data[1] && strcmp((char*)data->data[1], "format") == 0)
 		{

--- a/channels/drdynvc/tsmf/tsmf_main.c
+++ b/channels/drdynvc/tsmf/tsmf_main.c
@@ -401,7 +401,7 @@ static void tsmf_process_plugin_data(IWTSPlugin* pPlugin, RDP_PLUGIN_DATA* data)
 {
 	TSMF_PLUGIN* tsmf = (TSMF_PLUGIN*) pPlugin;
 
-	if (data->data[0] && strcmp((char*)data->data[0], "tsmf") == 0)
+	if (data->data[0] && ( strcmp((char*)data->data[0], "tsmf") == 0 || strstr((char*)data->data[0], "/tsmf.") != NULL) )
 	{
 		if (data->data[1] && strcmp((char*)data->data[1], "decoder") == 0)
 		{


### PR DESCRIPTION
Not sure if this is the best way to do this, but some way of loading plugin data when loading a plugin by its pathname is needed.
