### PR TITLE
codec: fixed and accelerated RemoteFX ycbcr-to-rgb decoder

### DIFF
--- a/libfreerdp-codec/rfx_decode.c
+++ b/libfreerdp-codec/rfx_decode.c
@@ -98,19 +98,17 @@ void rfx_decode_ycbcr_to_rgb(sint16* y_r_buf, sint16* cb_g_buf, sint16* cr_b_buf
 	 */
 	for (i = 0; i < 4096; i++)
 	{
-		y = (y_r_buf[i] >> 5) + 128;
+		y = y_r_buf[i] + 4096; // 128<<5 = 4096 so that we can >> 5 over the sum
 		cb = cb_g_buf[i];
 		cr = cr_b_buf[i];
-		/* 1.403 >> 5 = 0.000010110011100(b) */
-		r = y + ((cr >> 5) + (cr >> 7) + (cr >> 8) + (cr >> 11) + (cr >> 12) + (cr >> 13));
-		y_r_buf[i] = MINMAX(r, 0, 255);
-		/* 0.344 >> 5 = 0.000000101100000(b), 0.714 >> 5 = 0.000001011011011(b) */
-		g = y - ((cb >> 7) + (cb >> 9) + (cb >> 10)) -
-			((cr >> 6) + (cr >> 8) + (cr >> 9) + (cr >> 11) + (cr >> 12) + (cr >> 13));
-		cb_g_buf[i] = MINMAX(g, 0, 255);
-		/* 1.77 >> 5 = 0.000011100010100(b) */
-		b = y + ((cb >> 5) + (cb >> 6) + (cb >> 7) + (cb >> 11) + (cb >> 13));
-		cr_b_buf[i] = MINMAX(b, 0, 255);
+
+		r = y + cr*1.403f;
+		g = y - cb*0.344f - cr*0.714f;
+		b = y + cb*1.770f;
+
+		y_r_buf[i]  = MINMAX(r>>5, 0, 255);
+		cb_g_buf[i] = MINMAX(g>>5, 0, 255);
+		cr_b_buf[i] = MINMAX(b>>5, 0, 255);
 	}
 }
 


### PR DESCRIPTION
The current ycbcr decoder was loosing some bits because cr/cb was multiplied by
the shifted factors.
Instead one should multiply by the non-shifted factors and shift the result.
The effects of these lost bits are easily seen by comparing the colors of a
RemoteFX session with the colors of a plain RDP session - they are just wrong ;)

I've replaced the bit-magic from the non non-accelerated version (rfx_decode.c)
and replaced it with simple float multiplications using the compiler's implicit
integer conversions. On several test machines this was even a little bit faster.

The accelerated SSE2 ycbcr decoder (rfx_sse2.c) was completely changed in order
to make use of the SSE2 signed 16-bit integer multiplication.
Fortunately the factors in the conversion matrix are so small that we can
easily shift them to the maximum possible 16-bit signed integer value without
loosing any information and use _mm_mulhi_epi16 which takes the upper 16 bits
of the 32-bit result.

The SSE2 ycbcr decoder is now much simpler and about 40 percent faster.
