### PR TITLE
xfreerdp: a quick workaround for some issues with TS Remote App.

### DIFF
--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -28,6 +28,17 @@
 #include "xf_window.h"
 #include "xf_rail.h"
 
+void xf_rail_enable_remoteapp_mode(xfInfo* xfi)
+{
+	if (xfi->remote_app == false)
+	{
+		xfi->remote_app = true;
+		xfi->drawable = DefaultRootWindow(xfi->display);
+		xf_DestroyWindow(xfi, xfi->window);
+		xfi->window = NULL;
+	}
+}
+
 void xf_rail_paint(xfInfo* xfi, rdpRail* rail, sint32 uleft, sint32 utop, uint32 uright, uint32 ubottom)
 {
 	xfWindow* xfw;
@@ -74,6 +85,8 @@ void xf_rail_CreateWindow(rdpRail* rail, rdpWindow* window)
 	xfWindow* xfw;
 
 	xfi = (xfInfo*) rail->extra;
+
+	xf_rail_enable_remoteapp_mode(xfi);
 
 	xfw = xf_CreateWindow((xfInfo*) rail->extra, window,
 			window->windowOffsetX, window->windowOffsetY,
@@ -365,6 +378,11 @@ void xf_process_rail_exec_result_event(xfInfo* xfi, rdpChannels* channels, RDP_E
 	{
 		printf("RAIL exec error: execResult=%s NtError=0x%X\n",
 			error_code_names[exec_result->execResult], exec_result->rawResult);
+		xfi->disconnect = True;
+	}
+	else
+	{
+		xf_rail_enable_remoteapp_mode(xfi);
 	}
 }
 

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -107,6 +107,7 @@ struct xf_info
 	xfWorkArea workArea;
 	int current_desktop;
 	boolean remote_app;
+	boolean disconnect;
 	HCLRCONV clrconv;
 	Window parent_window;
 


### PR DESCRIPTION
Currently in Remote App mode we have no option to interact with the
remote desktop host before the first RAIL window is created.

In many situations this interaction possibility is absolutely required.
One example is that screen which gets displayed if another user is logged on.
It requires clicking a button in pre-RAIL mode so that the currently logged
on user gets notified to confirm or deny the connection.

Another example is the option to log on graphically (e.g. for hosts that
don't support NLA) without predefined credentials.

Also if the administrator sets the "User must change password at next logon"
option there is currently no way to do this in TS Remote App mode.

This change basically lets xfreerdp create the main window in Remote App mode
like in a normal session and xfi->remote_app is not set to true initially.

As soon as the rail exec result event or the first rail window creation
request is received (whatever comes first) the main window gets destroyed and
xfi->remote_app is set to true.

The second change is to disconnect immediately if the rail exec result event
reports an error, e.g. if the specified app cannot be found or if it is not
in the list of allowed applications.

This fixes FreeRDP github issue #143 and issue #308.

I'm aware that this is not the most elegant solution but it is definitely an
improvement and probably good enough for 1.0.
A nicer solution would be hiding the main window and only displaying it if
no rail exec result or rail window creation event is received after a certain
timeout ...
