### PR TITLE
Better handling of --version and --help (don't print errors for these)

### DIFF
--- a/client/X11/xfreerdp.c
+++ b/client/X11/xfreerdp.c
@@ -455,7 +455,8 @@ boolean xf_pre_connect(freerdp* instance)
 	xfInfo* xfi;
 	boolean bitmap_cache;
 	rdpSettings* settings;
-
+	int arg_parse_result;
+	
 	xfi = (xfInfo*) xzalloc(sizeof(xfInfo));
 	((xfContext*) instance->context)->xfi = xfi;
 
@@ -463,11 +464,15 @@ boolean xf_pre_connect(freerdp* instance)
 	xfi->context = (xfContext*) instance->context;
 	xfi->context->settings = instance->settings;
 	xfi->instance = instance;
-
-	if (freerdp_parse_args(instance->settings, instance->context->argc, instance->context->argv,
-			xf_process_plugin_args, instance->context->channels, xf_process_client_args, xfi) < 0)
+	
+	arg_parse_result = freerdp_parse_args(instance->settings, instance->context->argc,instance->context->argv,
+				xf_process_plugin_args, instance->context->channels, xf_process_client_args, xfi);
+	
+	if (arg_parse_result < 0)
 	{
-		printf("failed to parse arguments.\n");
+		if (arg_parse_result == FREERDP_ARGS_PARSE_FAILURE)
+			printf("failed to parse arguments.\n");
+		
 		exit(XF_EXIT_PARSE_ARGUMENTS);
 	}
 

--- a/include/freerdp/utils/args.h
+++ b/include/freerdp/utils/args.h
@@ -24,6 +24,15 @@
 #include <freerdp/types.h>
 #include <freerdp/settings.h>
 
+
+typedef enum _FREERDP_ARGS_PARSE_RESULT
+{
+	FREERDP_ARGS_PARSE_FAILURE = -1,
+	FREERDP_ARGS_PARSE_HELP = -2,
+	FREERDP_ARGS_PARSE_VERSION = -3,
+} FREERDP_ARGS_PARSE_RESULT;
+
+
 /* Returns 1 if succeed, otherwise returns zero */
 typedef int (*ProcessPluginArgs) (rdpSettings* settings, const char* name,
 	RDP_PLUGIN_DATA* plugin_data, void* user_data);

--- a/libfreerdp-utils/args.c
+++ b/libfreerdp-utils/args.c
@@ -36,7 +36,7 @@
  * @param plugin_user_data pointer to be passed to the plugin_callback function.
  * @param ui_callback function to be called when a UI-specific argument is being processed.
  * @param ui_user_data pointer to be passed to the ui_callback function.
- * @return number of arguments that has been parsed, or 0 if error occurred.
+ * @return number of arguments that were parsed, or FREERDP_ARGS_PARSE_RESULT on failure or --version/--help
  */
 int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 	ProcessPluginArgs plugin_callback, void* plugin_user_data,
@@ -103,7 +103,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 				"  --sec: force protocol security (rdp, tls or nla)\n"
 				"  --version: print version information\n"
 				"\n", argv[0]);
-			return -1; //TODO: What is the correct return
+			return FREERDP_ARGS_PARSE_HELP; //TODO: What is the correct return
 		}
 		else if (strcmp("-a", argv[index]) == 0)
 		{
@@ -111,7 +111,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing color depth\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			settings->color_depth = atoi(argv[index]);
 		}
@@ -121,7 +121,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing username\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			settings->username = xstrdup(argv[index]);
 		}
@@ -131,7 +131,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing password\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			settings->password = xstrdup(argv[index]);
 			settings->autologon = 1;
@@ -149,7 +149,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing domain\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			settings->domain = xstrdup(argv[index]);
 		}
@@ -159,7 +159,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing shell\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			settings->shell = xstrdup(argv[index]);
 		}
@@ -169,7 +169,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing directory\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			settings->directory = xstrdup(argv[index]);
 		}
@@ -179,7 +179,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing dimensions\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 
 			if (strncmp("workarea", argv[index], 1) == 0)
@@ -200,7 +200,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 					if (settings->percent_screen <= 0 || settings->percent_screen > 100)
 					{
 						printf("invalid geometry percentage\n");
-						return -1;
+						return FREERDP_ARGS_PARSE_FAILURE;
 					}
 				}
 				else
@@ -224,7 +224,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing window title\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 
 			settings->window_title = xstrdup(argv[index]);
@@ -235,7 +235,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing port number\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			settings->port = atoi(argv[index]);
 		}
@@ -245,7 +245,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing keyboard layout id\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			sscanf(argv[index], "%X", &(settings->kbd_layout));
 		}
@@ -259,7 +259,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing client hostname\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			strncpy(settings->client_hostname, argv[index], sizeof(settings->client_hostname) - 1);
 			settings->client_hostname[sizeof(settings->client_hostname) - 1] = 0;
@@ -316,7 +316,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing GDI backend\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			if (strncmp("sw", argv[index], 1) == 0) /* software */
 			{
@@ -329,7 +329,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			else
 			{
 				printf("unknown GDI backend\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 		}
 		else if (strcmp("--rfx", argv[index]) == 0)
@@ -347,7 +347,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing RemoteFX mode flag\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			if (argv[index][0] == 'v') /* video */
 			{
@@ -360,7 +360,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			else
 			{
 				printf("unknown RemoteFX mode flag\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 		}
 		else if (strcmp("--nsc", argv[index]) == 0)
@@ -373,7 +373,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing file name\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			settings->dump_rfx_file = xstrdup(argv[index]);
 			settings->dump_rfx = true;
@@ -384,7 +384,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing file name\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			settings->play_rfx_file = xstrdup(argv[index]);
 			settings->play_rfx = true;
@@ -430,7 +430,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing performance flag\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			if (argv[index][0] == 'm') /* modem */
 			{
@@ -462,7 +462,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing parent window XID\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 
 			settings->parent_window_xid = strtoul(argv[index], NULL, 16);
@@ -470,7 +470,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (settings->parent_window_xid == 0)
 			{
 				printf("invalid parent window XID\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 		}
 		else if (strcmp("--no-rdp", argv[index]) == 0)
@@ -491,7 +491,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing protocol security\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			if (strncmp("rdp", argv[index], 1) == 0) /* Standard RDP */
 			{
@@ -517,7 +517,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			else
 			{
 				printf("unknown protocol security\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 		}
 		else if (strcmp("--plugin", argv[index]) == 0)
@@ -527,7 +527,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing plugin name\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			plugin_data = NULL;
 			if (index < argc - 1 && strcmp("--data", argv[index + 1]) == 0)
@@ -567,7 +567,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (plugin_callback != NULL)
 			{
 				if (!plugin_callback(settings, argv[t], plugin_data, plugin_user_data))
-					return -1;
+					return FREERDP_ARGS_PARSE_FAILURE;
 			}
 		}
 		else if (strcmp("--ext", argv[index]) == 0)
@@ -576,12 +576,12 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 			if (index == argc)
 			{
 				printf("missing extension name\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			if (num_extensions >= sizeof(settings->extensions) / sizeof(struct rdp_ext_set))
 			{
 				printf("maximum extensions reached\n");
-				return -1;
+				return FREERDP_ARGS_PARSE_FAILURE;
 			}
 			snprintf(settings->extensions[num_extensions].name,
 				sizeof(settings->extensions[num_extensions].name),
@@ -603,7 +603,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 		else if (strcmp("--version", argv[index]) == 0)
 		{
 			printf("This is FreeRDP version %s\n", FREERDP_VERSION_FULL);
-			return -1;
+			return FREERDP_ARGS_PARSE_VERSION;
 		}
 		else if (argv[index][0] != '-')
 		{
@@ -662,7 +662,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 				if (t == 0)
 				{
 					printf("invalid option: %s\n", argv[index]);
-					return -1;
+					return FREERDP_ARGS_PARSE_FAILURE;
 				}
 				index += t - 1;
 			}
@@ -670,5 +670,5 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 		index++;
 	}
 	printf("missing server name\n");
-	return -1;
+	return FREERDP_ARGS_PARSE_FAILURE;
 }


### PR DESCRIPTION
Change freerdp_parse_args to return different values for error vs --help/--version, and change xfreerdp to only report real errors
