### PR TITLE
build: make ffmpeg optional on os x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,10 +111,12 @@ if(NOT WIN32)
 	find_optional_package(PulseAudio)
 	find_optional_package(PCSC)
 	find_suggested_package(Cups)
-	find_suggested_package(FFmpeg)
 
 	if(NOT APPLE)
+		find_suggested_package(FFmpeg)
 		find_suggested_package(ALSA)
+	else(NOT APPLE)
+		find_optional_package(FFmpeg)
 	endif()
 endif()
 


### PR DESCRIPTION
FFMPEG isn't installed per default on os x so it should be optional
instead of suggested.
