### PR TITLE
Use stream_attach() so that the 'size' field in the stream structure is properly set.

### DIFF
--- a/libfreerdp-core/certificate.c
+++ b/libfreerdp-core/certificate.c
@@ -427,7 +427,7 @@ boolean certificate_read_server_certificate(rdpCertificate* certificate, uint8* 
 	uint32 dwVersion;
 
 	s = stream_new(0);
-	s->p = s->data = server_cert;
+	stream_attach(s, server_cert, length);
 
 	if (length < 1)
 	{


### PR DESCRIPTION
This allows to assert in stream API that we don't try to access memory outside stream buffer.
