### PR TITLE
Each bitmap send by the server contains color depth. Even if we negotiated 8bpp server can send bitmap which has 16bpp.

### DIFF
--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -43,7 +43,7 @@ void xf_Bitmap_New(rdpContext* context, rdpBitmap* bitmap)
 	if (bitmap->data != NULL)
 	{
 		data = freerdp_image_convert(bitmap->data, NULL,
-				bitmap->width, bitmap->height, xfi->srcBpp, xfi->bpp, xfi->clrconv);
+				bitmap->width, bitmap->height, bitmap->bpp, xfi->bpp, xfi->clrconv);
 
 		if (bitmap->ephemeral != true)
 		{


### PR DESCRIPTION
Fix a crash using bpp from the bitmap data to allocate image instead of negotiated color depth.
