### PR TITLE
Fixes for ber_write_integer().

### DIFF
--- a/libfreerdp-core/ber.c
+++ b/libfreerdp-core/ber.c
@@ -383,11 +383,18 @@ int ber_write_integer(STREAM* s, uint32 value)
 		stream_write_uint8(s, value);
 		return 2;
 	}
-	else if (value <= 0xFFFF)
+	else if (value < 0xFF80)
 	{
 		ber_write_length(s, 2);
 		stream_write_uint16_be(s, value);
 		return 3;
+	}
+	else if (value < 0xFF8000)
+	{
+		ber_write_length(s, 3);
+		stream_write_uint8(s, (value >> 16));
+		stream_write_uint16_be(s, (value & 0xFFFF));
+		return 4;
 	}
 	else if (value <= 0xFFFFFFFF)
 	{


### PR DESCRIPTION
According to specification bits from the first octet and bit 8 from thesecond octet (if there is more than one octet) shall not all be ones.
Before that change integer >= 0xFF80 was encoded into two bytes instead of three.
While here also add support for encoding integers into three bytes.
