### PR TITLE
remove redundant or useless (?) checks for NULL pointer

### DIFF
--- a/client/X11/xfreerdp.c
+++ b/client/X11/xfreerdp.c
@@ -888,16 +888,11 @@ void xf_window_free(xfInfo* xfi)
 
 	if (context != NULL)
 	{
-		if (context->cache != NULL)
-		{
 			cache_free(context->cache);
 			context->cache = NULL;
-		}
-		if (context->rail != NULL)
-		{
+
 			rail_free(context->rail);
 			context->rail = NULL;
-		}
 	}
 
 	if (xfi->rfx_context) 
@@ -917,8 +912,7 @@ void xf_free(xfInfo* xfi)
 {
 	xf_window_free(xfi);
 
-	if (xfi->bmp_codec_none != NULL)
-		xfree(xfi->bmp_codec_none);
+	xfree(xfi->bmp_codec_none);
 
 	XCloseDisplay(xfi->display);
 

--- a/libfreerdp-utils/memory.c
+++ b/libfreerdp-utils/memory.c
@@ -103,7 +103,6 @@ void* xrealloc(void* ptr, size_t size)
 
 void xfree(void* ptr)
 {
-	if (ptr != NULL)
 		free(ptr);
 }
 


### PR DESCRIPTION
Remove redundant if(NULL) checks in client/X11/xfreerdp.c (already checked inside of cache_free(), rail_free() and xfree() )

Besides "ptr=NULL; free(ptr);" does nothing (the standard C free() function is supposed to do nothing on NULL, not to crash) so there should be no need to check for NULL in xfree(), in libfreerdp-utils/memory.c. 

Am I misunderstanding something ? or ignoring some platform-specific issue ?
