### PR TITLE
Fix for server CPU issue.

### DIFF
--- a/server/X11/xf_event.c
+++ b/server/X11/xf_event.c
@@ -61,7 +61,7 @@ void xf_set_event(xfEventQueue* event_queue)
 		printf("xf_set_event: error\n");
 }
 
-void xf_clear_event(xfEventQueue* event_queue)
+void xf_clear_events(xfEventQueue* event_queue)
 {
 	int length;
 
@@ -72,6 +72,16 @@ void xf_clear_event(xfEventQueue* event_queue)
 		if (length != 4)
 			printf("xf_clear_event: error\n");
 	}
+}
+
+void xf_clear_event(xfEventQueue* event_queue)
+{
+	int length;
+
+	length = read(event_queue->pipe_fd[0], &length, 4);
+
+	if (length != 4)
+		printf("xf_clear_event: error\n");
 }
 
 void xf_event_push(xfEventQueue* event_queue, xfEvent* event)
@@ -115,6 +125,9 @@ xfEvent* xf_event_pop(xfEventQueue* event_queue)
 
 	if (event_queue->count < 1)
 		return NULL;
+
+	/* remove event signal */
+	xf_clear_event(event_queue);
 
 	event = event_queue->events[0];
 	(event_queue->count)--;


### PR DESCRIPTION
The pipe used for signalling in the event queue was not properly
cleared when popping events, causing the select() in the main
loop to return immediately after the first event was queued,
instead of blocking for the next event.
