### PR TITLE
possible fix for #467

### DIFF
--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -109,7 +109,11 @@ int xf_kbd_read_keyboard_state(xfInfo* xfi)
 		XQueryPointer(xfi->display, xfi->window->handle,
 			&wdummy, &wdummy, &dummy, &dummy, &dummy, &dummy, &state);
 	}
-
+	else
+	{
+		XQueryPointer(xfi->display, DefaultRootWindow(xfi->display),
+			&wdummy, &wdummy, &dummy, &dummy, &dummy, &dummy, &state);
+  	}
 	return state;
 }
 


### PR DESCRIPTION
This is a possible fix #467, "Toggle keys (Numlock, Capslock, etc) can never be set in remote app mode." I'm not an X programmer so I don't know if this is exactly correct or not, but my testing shows that it works for me. The toggle keys work fine in remote app mode with this change.
