### PR TITLE
cmake: Fix ffmpeg detection code

### DIFF
--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -13,13 +13,11 @@ if (PKG_CONFIG_FOUND)
 endif ( PKG_CONFIG_FOUND )
 
 # avcodec
-find_path(AVCODEC_INCLUDE_DIR avcodec.h PATHS ${AVCODEC_INCLUDE_DIRS}
-          PATH_SUFFIXES libavcodec )
+find_path(AVCODEC_INCLUDE_DIR libavcodec/avcodec.h PATHS ${AVCODEC_INCLUDE_DIRS})
 find_library(AVCODEC_LIBRARY avcodec PATHS ${AVCODEC_LIBRARY_DIRS})
 
 # avutil
-find_path(AVUTIL_INCLUDE_DIR avutil.h PATHS ${AVUTIL_INCLUDE_DIRS}
-          PATH_SUFFIXES libavutil )
+find_path(AVUTIL_INCLUDE_DIR libavutil/avutil.h PATHS ${AVUTIL_INCLUDE_DIRS})
 find_library(AVUTIL_LIBRARY avutil PATHS ${AVUTIL_LIBRARY_DIRS})
 
 if(AVCODEC_INCLUDE_DIR AND AVCODEC_LIBRARY)


### PR DESCRIPTION
ffmpeg headers are supposed to be referenced as libavcodec/avcodec.h.
Therefore, we actually need to find the path to the libavcodec directory, not
avcodec.h.

This should resolve an issue with Fedora reported on the freerdp-devel mailing list.
