### PR TITLE
channels/rdpdr/disk: fix os x compilation issues

### DIFF
--- a/channels/rdpdr/disk/disk_file.h
+++ b/channels/rdpdr/disk/disk_file.h
@@ -30,6 +30,12 @@
 #define OPEN open
 #define LSEEK lseek
 #define FSTAT fstat
+#elif defined __APPLE__
+#define STAT stat
+#define OPEN open
+#define LSEEK lseek
+#define FSTAT fstat
+#define O_LARGEFILE 0
 #else
 #define STAT stat64
 #define OPEN open64


### PR DESCRIPTION
os x does not need/have stat/lseek/open/64 and O_LARGEFILE
