### PR TITLE
libfreerdp-utils: fix freerdp_append_shared_library_suffix on OS X

### DIFF
--- a/libfreerdp-utils/file.c
+++ b/libfreerdp-utils/file.c
@@ -156,7 +156,8 @@ char* freerdp_append_shared_library_suffix(char* file_path)
 	}
 	else
 	{
-		path = xstrdup(file_path);
+		path = xmalloc(file_path_length + shared_lib_suffix_length + 1);
+		sprintf(path, "%s%s", file_path, SHARED_LIB_SUFFIX);	
 	}
 
 	return path;


### PR DESCRIPTION
libfreerdp-utils: make freerdp_append_shared_library_suffix work when file_path is shorter than the suffix, which is true for 'rail' and '.dylib'.
