### PR TITLE
libfreerdp-core: fix incorrect num lock state when connecting

### DIFF
--- a/libfreerdp-core/connection.c
+++ b/libfreerdp-core/connection.c
@@ -503,9 +503,6 @@ boolean rdp_client_connect_finalize(rdpRdp* rdp)
 		return false;
 	if (!rdp_send_client_control_pdu(rdp, CTRLACTION_REQUEST_CONTROL))
 		return false;
-
-	rdp->input->SynchronizeEvent(rdp->input, 0);
-
 	if (!rdp_send_client_persistent_key_list_pdu(rdp))
 		return false;
 	if (!rdp_send_client_font_list_pdu(rdp, FONTLIST_FIRST | FONTLIST_LAST))


### PR DESCRIPTION
The incorrect state was caused by sending a SynchronizeEvent with flags=0 during connection finalization, which should not even be done according to [MS-RDPBCGR].

This fixes issue #330.
