### PR TITLE
Solaris 10 compilation issues

### DIFF
--- a/libfreerdp-locale/timezone.c
+++ b/libfreerdp-locale/timezone.c
@@ -1598,7 +1598,7 @@ void freerdp_time_zone_detect(TIME_ZONE_INFO* clientTimeZone)
 {
 	time_t t;
 	struct tm* local_time;
-	TIME_ZONE_ENTRY* timezone;
+	TIME_ZONE_ENTRY* tz;
 
 	time(&t);
 	local_time = localtime(&t);
@@ -1628,18 +1628,18 @@ void freerdp_time_zone_detect(TIME_ZONE_INFO* clientTimeZone)
 		clientTimeZone->daylightBias = clientTimeZone->bias + 60;
 	}
 
-	timezone = freerdp_detect_windows_time_zone(clientTimeZone->bias);
+	tz = freerdp_detect_windows_time_zone(clientTimeZone->bias);
 
-	if (timezone != NULL)
+	if (tz!= NULL)
 	{
-		clientTimeZone->bias = timezone->Bias;
-		sprintf(clientTimeZone->standardName, "%s", timezone->StandardName);
-		sprintf(clientTimeZone->daylightName, "%s", timezone->DaylightName);
+		clientTimeZone->bias = tz->Bias;
+		sprintf(clientTimeZone->standardName, "%s", tz->StandardName);
+		sprintf(clientTimeZone->daylightName, "%s", tz->DaylightName);
 
-		if ((timezone->SupportsDST) && (timezone->RuleTableCount > 0))
+		if ((tz->SupportsDST) && (tz->RuleTableCount > 0))
 		{
 			TIME_ZONE_RULE_ENTRY* rule;
-			rule = freerdp_get_current_time_zone_rule(timezone->RuleTable, timezone->RuleTableCount);
+			rule = freerdp_get_current_time_zone_rule(tz->RuleTable, tz->RuleTableCount);
 
 			if (rule != NULL)
 			{
@@ -1666,7 +1666,7 @@ void freerdp_time_zone_detect(TIME_ZONE_INFO* clientTimeZone)
 			}
 		}
 
-		xfree(timezone);
+		xfree(tz);
 	}
 	else
 	{

--- a/libfreerdp-utils/memory.c
+++ b/libfreerdp-utils/memory.c
@@ -141,6 +141,8 @@ wchar_t* xwcsdup(const wchar_t* wstr)
 
 #ifdef _WIN32
 	mem = _wcsdup(wstr);
+#elif sun
+	mem = wsdup(wstr);
 #else
 	mem = wcsdup(wstr);
 #endif


### PR DESCRIPTION
timezone.c:  local variable 'timezone' shadowed global variable of same name
memory.c  wide-string copy function on Solaris 10 is 'wsdup'
