### PR TITLE
dsp: rewrite api to reduce memory allocations.

### DIFF
--- a/channels/rdpsnd/alsa/rdpsnd_alsa.c
+++ b/channels/rdpsnd/alsa/rdpsnd_alsa.c
@@ -45,7 +45,8 @@ struct rdpsnd_alsa_plugin
 	int wformat;
 	int block_size;
 	int latency;
-	ADPCM adpcm;
+
+	FREERDP_DSP_CONTEXT* dsp_context;
 };
 
 static void rdpsnd_alsa_set_params(rdpsndAlsaPlugin* alsa)
@@ -169,7 +170,7 @@ static void rdpsnd_alsa_open(rdpsndDevicePlugin* device, rdpsndFormat* format, i
 	}
 	else
 	{
-		memset(&alsa->adpcm, 0, sizeof(ADPCM));
+		freerdp_dsp_context_reset_adpcm(alsa->dsp_context);
 		rdpsnd_alsa_set_format(device, format, latency);
 	}
 }
@@ -193,6 +194,7 @@ static void rdpsnd_alsa_free(rdpsndDevicePlugin* device)
 
 	rdpsnd_alsa_close(device);
 	xfree(alsa->device_name);
+	freerdp_dsp_context_free(alsa->dsp_context);
 	xfree(alsa);
 }
 
@@ -229,10 +231,7 @@ static void rdpsnd_alsa_set_volume(rdpsndDevicePlugin* device, uint32 value)
 static void rdpsnd_alsa_play(rdpsndDevicePlugin* device, uint8* data, int size)
 {
 	rdpsndAlsaPlugin* alsa = (rdpsndAlsaPlugin*)device;
-	uint8* decoded_data;
-	int decoded_size;
 	uint8* src;
-	uint8* resampled_data;
 	int len;
 	int error;
 	int frames;
@@ -246,14 +245,13 @@ static void rdpsnd_alsa_play(rdpsndDevicePlugin* device, uint8* data, int size)
 
 	if (alsa->wformat == 0x11)
 	{
-		decoded_data = dsp_decode_ima_adpcm(&alsa->adpcm,
-			data, size, alsa->source_channels, alsa->block_size, &decoded_size);
-		size = decoded_size;
-		src = decoded_data;
+		alsa->dsp_context->decode_ima_adpcm(alsa->dsp_context,
+			data, size, alsa->source_channels, alsa->block_size);
+		size = alsa->dsp_context->adpcm_size;
+		src = alsa->dsp_context->adpcm_buffer;
 	}
 	else
 	{
-		decoded_data = NULL;
 		src = data;
 	}
 
@@ -268,17 +266,17 @@ static void rdpsnd_alsa_play(rdpsndDevicePlugin* device, uint8* data, int size)
 	if ((alsa->source_rate == alsa->actual_rate) &&
 		(alsa->source_channels == alsa->actual_channels))
 	{
-		resampled_data = NULL;
 	}
 	else
 	{
-		resampled_data = dsp_resample(src, alsa->bytes_per_channel,
+		alsa->dsp_context->resample(alsa->dsp_context, src, alsa->bytes_per_channel,
 			alsa->source_channels, alsa->source_rate, size / sbytes_per_frame,
-			alsa->actual_channels, alsa->actual_rate, &frames);
+			alsa->actual_channels, alsa->actual_rate);
+		frames = alsa->dsp_context->resampled_frames;
 		DEBUG_SVC("resampled %d frames at %d to %d frames at %d",
 			size / sbytes_per_frame, alsa->source_rate, frames, alsa->actual_rate);
 		size = frames * rbytes_per_frame;
-		src = resampled_data;
+		src = alsa->dsp_context->resampled_buffer;
 	}
 
 	pindex = src;
@@ -303,11 +301,6 @@ static void rdpsnd_alsa_play(rdpsndDevicePlugin* device, uint8* data, int size)
 		}
 		pindex += error * rbytes_per_frame;
 	}
-
-	if (resampled_data)
-		xfree(resampled_data);
-	if (decoded_data)
-		xfree(decoded_data);
 }
 
 static void rdpsnd_alsa_start(rdpsndDevicePlugin* device)
@@ -352,6 +345,8 @@ int FreeRDPRdpsndDeviceEntry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints)
 	alsa->source_channels = 2;
 	alsa->actual_channels = 2;
 	alsa->bytes_per_channel = 2;
+
+	alsa->dsp_context = freerdp_dsp_context_new();
 
 	pEntryPoints->pRegisterRdpsndDevice(pEntryPoints->rdpsnd, (rdpsndDevicePlugin*)alsa);
 

--- a/channels/rdpsnd/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/pulse/rdpsnd_pulse.c
@@ -41,7 +41,8 @@ struct rdpsnd_pulse_plugin
 	int format;
 	int block_size;
 	int latency;
-	ADPCM adpcm;
+
+	FREERDP_DSP_CONTEXT* dsp_context;
 };
 
 static void rdpsnd_pulse_context_state_callback(pa_context* context, void* userdata)
@@ -297,7 +298,7 @@ static void rdpsnd_pulse_open(rdpsndDevicePlugin* device, rdpsndFormat* format, 
 	pa_threaded_mainloop_unlock(pulse->mainloop);
 	if (state == PA_STREAM_READY)
 	{
-		memset(&pulse->adpcm, 0, sizeof(ADPCM));
+		freerdp_dsp_context_reset_adpcm(pulse->dsp_context);
 		DEBUG_SVC("connected");
 	}
 	else
@@ -329,6 +330,7 @@ static void rdpsnd_pulse_free(rdpsndDevicePlugin* device)
 		pulse->mainloop = NULL;
 	}
 	xfree(pulse->device_name);
+	freerdp_dsp_context_free(pulse->dsp_context);
 	xfree(pulse);
 }
 
@@ -398,23 +400,20 @@ static void rdpsnd_pulse_play(rdpsndDevicePlugin* device, uint8* data, int size)
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)device;
 	int len;
 	int ret;
-	uint8* decoded_data;
 	uint8* src;
-	int decoded_size;
 
 	if (!pulse->stream)
 		return;
 
 	if (pulse->format == 0x11)
 	{
-		decoded_data = dsp_decode_ima_adpcm(&pulse->adpcm,
-			data, size, pulse->sample_spec.channels, pulse->block_size, &decoded_size);
-		size = decoded_size;
-		src = decoded_data;
+		pulse->dsp_context->decode_ima_adpcm(pulse->dsp_context,
+			data, size, pulse->sample_spec.channels, pulse->block_size);
+		size = pulse->dsp_context->adpcm_size;
+		src = pulse->dsp_context->adpcm_buffer;
 	}
 	else
 	{
-		decoded_data = NULL;
 		src = data;
 	}
 
@@ -440,9 +439,6 @@ static void rdpsnd_pulse_play(rdpsndDevicePlugin* device, uint8* data, int size)
 		size -= len;
 	}
 	pa_threaded_mainloop_unlock(pulse->mainloop);
-
-	if (decoded_data)
-		xfree(decoded_data);
 }
 
 static void rdpsnd_pulse_start(rdpsndDevicePlugin* device)
@@ -479,6 +475,8 @@ int FreeRDPRdpsndDeviceEntry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints)
 		else
 			pulse->device_name = NULL;
 	}
+
+	pulse->dsp_context = freerdp_dsp_context_new();
 
 	pulse->mainloop = pa_threaded_mainloop_new();
 	if (!pulse->mainloop)

--- a/include/freerdp/utils/dsp.h
+++ b/include/freerdp/utils/dsp.h
@@ -29,14 +29,34 @@ struct _ADPCM
 };
 typedef struct _ADPCM ADPCM;
 
-FREERDP_API uint8* dsp_resample(uint8* src, int bytes_per_sample,
-	uint32 schan, uint32 srate, int sframes,
-	uint32 rchan, uint32 rrate, int * prframes);
+typedef struct _FREERDP_DSP_CONTEXT FREERDP_DSP_CONTEXT;
+struct _FREERDP_DSP_CONTEXT
+{
+	uint8* resampled_buffer;
+	uint32 resampled_size;
+	uint32 resampled_frames;
+	uint32 resampled_maxlength;
 
-FREERDP_API uint8* dsp_decode_ima_adpcm(ADPCM* adpcm,
-	uint8* src, int size, int channels, int block_size, int* out_size);
-FREERDP_API uint8* dsp_encode_ima_adpcm(ADPCM* adpcm,
-	uint8* src, int size, int channels, int block_size, int* out_size);
+	uint8* adpcm_buffer;
+	uint32 adpcm_size;
+	uint32 adpcm_maxlength;
+
+	ADPCM adpcm;
+
+	void (*resample)(FREERDP_DSP_CONTEXT* context,
+		const uint8* src, int bytes_per_sample,
+		uint32 schan, uint32 srate, int sframes,
+		uint32 rchan, uint32 rrate);
+
+	void (*decode_ima_adpcm)(FREERDP_DSP_CONTEXT* context,
+		const uint8* src, int size, int channels, int block_size);
+	void (*encode_ima_adpcm)(FREERDP_DSP_CONTEXT* context,
+		const uint8* src, int size, int channels, int block_size);
+};
+
+FREERDP_API FREERDP_DSP_CONTEXT* freerdp_dsp_context_new(void);
+FREERDP_API void freerdp_dsp_context_free(FREERDP_DSP_CONTEXT* context);
+#define freerdp_dsp_context_reset_adpcm(_c) memset(&_c->adpcm, 0, sizeof(ADPCM))
 
 #endif /* __DSP_UTILS_H */
 


### PR DESCRIPTION
1. Reducing memory allocation by introducing new context and reuse the audio buffer each time when resample or ADPCM encode/decode are called.
2. Put resample and ADPCM APIs into the context so that future optimations (like SSE2) are easier to write.
