### PR TITLE
Only sent frame acknowledge if the server supports it

### DIFF
--- a/libfreerdp-core/surface.c
+++ b/libfreerdp-core/surface.c
@@ -64,7 +64,7 @@ static int update_recv_surfcmd_frame_marker(rdpUpdate* update, STREAM* s)
 
 	IFCALL(update->SurfaceFrameMarker, update->context, marker);
 
-	if (update->context->rdp->settings->frame_acknowledge > 0 && marker->frameAction == SURFACECMD_FRAMEACTION_END)
+	if (update->context->rdp->settings->received_caps[CAPSET_TYPE_FRAME_ACKNOWLEDGE] && update->context->rdp->settings->frame_acknowledge > 0 && marker->frameAction == SURFACECMD_FRAMEACTION_END)
 	{
 		update_send_frame_acknowledge(update->context->rdp, marker->frameId);
 	}


### PR DESCRIPTION
If the servers doesn't announce CAPSET_TYPE_FRAME_ACKNOWLEDGE
frame acknowledgements should not be sent even if enabled on the command line (e.g. with --frame-ack 2).

Otherwise we get an 
ERRINFO_UNKNOWN_DATA_PDU_TYPE (0x000010C9):
Unknown pduType2 field in a received Share Data Header (section 2.2.8.1.1.1.2).
