### PR TITLE
fix client_hostname argument truncated: fix issues #570, #555

### DIFF
--- a/libfreerdp-core/gcc.c
+++ b/libfreerdp-core/gcc.c
@@ -488,7 +488,8 @@ boolean gcc_read_client_core_data(STREAM* s, rdpSettings* settings, uint16 block
 	/* clientName (32 bytes, null-terminated unicode, truncated to 15 characters) */
 	str = freerdp_uniconv_in(settings->uniconv, stream_get_tail(s), 32);
 	stream_seek(s, 32);
-	snprintf(settings->client_hostname, sizeof(settings->client_hostname), "%s", str);
+	snprintf(settings->client_hostname, 31, "%s", str);
+	settings->client_hostname[31] = 0;
 	xfree(str);
 
 	stream_read_uint32(s, settings->kbd_type); /* keyboardType */
@@ -1208,4 +1209,3 @@ void gcc_write_client_monitor_data(STREAM* s, rdpSettings* settings)
 		}
 	}
 }
-

--- a/libfreerdp-core/settings.c
+++ b/libfreerdp-core/settings.c
@@ -174,7 +174,8 @@ rdpSettings* settings_new(void* instance)
 		settings->frame_acknowledge = 2;
 
 		settings->uniconv = freerdp_uniconv_new();
-		gethostname(settings->client_hostname, sizeof(settings->client_hostname) - 1);
+		gethostname(settings->client_hostname, 31);
+		settings->client_hostname[31] = 0;
 		settings->mouse_motion = true;
 
 		settings->client_auto_reconnect_cookie = xnew(ARC_CS_PRIVATE_PACKET);

--- a/libfreerdp-utils/args.c
+++ b/libfreerdp-utils/args.c
@@ -266,8 +266,8 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 				printf("missing client hostname\n");
 				return FREERDP_ARGS_PARSE_FAILURE;
 			}
-			strncpy(settings->client_hostname, argv[index], sizeof(settings->client_hostname) - 1);
-			settings->client_hostname[sizeof(settings->client_hostname) - 1] = 0;
+			strncpy(settings->client_hostname, argv[index], 31);
+			settings->client_hostname[31] = 0;
 		}
 		else if (strcmp("-o", argv[index]) == 0)
 		{


### PR DESCRIPTION
As the fix is easy and issue #555 seems to be bothering some users, i did the fix, if you want to apply it.
