### PR TITLE
Time zone clock skew fix

### DIFF
--- a/libfreerdp-locale/timezone.c
+++ b/libfreerdp-locale/timezone.c
@@ -1605,9 +1605,9 @@ void freerdp_time_zone_detect(TIME_ZONE_INFO* clientTimeZone)
 
 #ifdef HAVE_TM_GMTOFF
 	if (local_time->tm_gmtoff >= 0)
-		clientTimeZone->bias = (uint32) (local_time->tm_gmtoff / 60);
+		clientTimeZone->bias = (uint32) (-1 * local_time->tm_gmtoff / 60);
 	else
-		clientTimeZone->bias = (uint32) ((-1 * local_time->tm_gmtoff) / 60 + 720);
+		clientTimeZone->bias = (uint32) ((-1 * local_time->tm_gmtoff) / 60);
 #elif sun
 	if (local_time->tm_isdst > 0)
 		clientTimeZone->bias = (uint32) (altzone / 3600);


### PR DESCRIPTION
Hi FreeRDP maintainers!

I've got a system where other clients seem to do clock skew just fine, but from FreeRDP it doesn't seem to work properly.  With the latest code as of May 15, here is what I am experiencing:

Time Zone name     Local Time     Windows Time   # of hours off
America/New York   03:45:00 AM 03:45:00 PM      12
America/Chicago     02:45:00 PM 02:45:00 AM      12
America/Denver       01:45:00 PM 01:45:00 AM     12 
Europe/London        08:49:00 PM 06:49:00 PM      -2
Europe/Moscow      11:49:00 PM 02:49:00 PM      -9
Asia/Singapore        03:51:00 AM 11:51:00 PM     -16
America/Sao_Paulo 04:53:00 PM 07:53:00 PM      3

My commit seems to fix it so that the clock skew seems to work correctly with all of these time zone strings.

I welcome comments and criticism :)

-Mattymo
