### PR TITLE
Fixing unresolved "wcsdup" when compile on Mac OS X

### DIFF
--- a/libfreerdp-utils/memory.c
+++ b/libfreerdp-utils/memory.c
@@ -143,6 +143,10 @@ wchar_t* xwcsdup(const wchar_t* wstr)
 	mem = _wcsdup(wstr);
 #elif sun
 	mem = wsdup(wstr);
+#elif defined(__APPLE__) && defined(__MACH__)
+	mem = xmalloc(wcslen(wstr));
+	if (mem != NULL)
+		wcscpy(mem, wstr);
 #else
 	mem = wcsdup(wstr);
 #endif


### PR DESCRIPTION
There is no wcsdup function on OS X SnowLeopard. 
http://lists.apple.com/archives/objc-language/2008/Mar/msg00031.html

This patch implements it by wcslen and wcscpy functions.
Related to issue #559
