### PR TITLE
Init extensions in pre_connect stage.

### DIFF
--- a/libfreerdp-core/freerdp.c
+++ b/libfreerdp-core/freerdp.c
@@ -52,9 +52,10 @@ boolean freerdp_connect(freerdp* instance)
 
 	rdp = instance->context->rdp;
 
-	extension_pre_connect(rdp->extension);
-
 	IFCALLRET(instance->PreConnect, status, instance);
+
+	rdp->extension = extension_new(instance);
+	extension_pre_connect(rdp->extension);
 
 	if (status != true)
 	{

--- a/libfreerdp-core/rdp.c
+++ b/libfreerdp-core/rdp.c
@@ -916,7 +916,6 @@ rdpRdp* rdp_new(freerdp* instance)
 		if (instance != NULL)
 			instance->settings = rdp->settings;
 		
-		rdp->extension = extension_new(instance);
 		rdp->transport = transport_new(rdp->settings);
 		rdp->license = license_new(rdp);
 		rdp->input = input_new(rdp);


### PR DESCRIPTION
Due to the client is parsing the args in pre_connect,
we should start loading the extensions after client parsing the args.

Signed-off-by: Ying-Chun Liu (PaulLiu) paul.liu@canonical.com
