### PR TITLE
winpr: fix semaphore_t definition

### DIFF
--- a/winpr/handle/handle.c
+++ b/winpr/handle/handle.c
@@ -27,7 +27,7 @@
 #include <mach/mach.h>
 #include <mach/semaphore.h>
 #include <mach/task.h>
-#define winpr_sem_t semaphore_td
+#define winpr_sem_t semaphore_t
 #else
 #include <pthread.h>
 #include <semaphore.h>

--- a/winpr/synch/semaphore.c
+++ b/winpr/synch/semaphore.c
@@ -27,7 +27,7 @@
 #include <mach/mach.h>
 #include <mach/semaphore.h>
 #include <mach/task.h>
-#define winpr_sem_t semaphore_td
+#define winpr_sem_t semaphore_t
 #else
 #include <pthread.h>
 #include <semaphore.h>


### PR DESCRIPTION
I think semaphore_td was a typo. This fixes compilation on Mac OS X.
