### PR TITLE
Index out of range crash fixes.

### DIFF
--- a/libfreerdp-cache/brush.c
+++ b/libfreerdp-cache/brush.c
@@ -78,7 +78,7 @@ void* brush_cache_get(rdpBrushCache* brush, uint32 index, uint32* bpp)
 
 	if (*bpp == 1)
 	{
-		if (index > brush->maxMonoEntries)
+		if (index >= brush->maxMonoEntries)
 		{
 			printf("invalid brush (%d bpp) index: 0x%04X\n", *bpp, index);
 			return NULL;
@@ -89,7 +89,7 @@ void* brush_cache_get(rdpBrushCache* brush, uint32 index, uint32* bpp)
 	}
 	else
 	{
-		if (index > brush->maxEntries)
+		if (index >= brush->maxEntries)
 		{
 			printf("invalid brush (%d bpp) index: 0x%04X\n", *bpp, index);
 			return NULL;
@@ -114,7 +114,7 @@ void brush_cache_put(rdpBrushCache* brush, uint32 index, void* entry, uint32 bpp
 
 	if (bpp == 1)
 	{
-		if (index > brush->maxMonoEntries)
+		if (index >= brush->maxMonoEntries)
 		{
 			printf("invalid brush (%d bpp) index: 0x%04X\n", bpp, index);
 			return;
@@ -130,7 +130,7 @@ void brush_cache_put(rdpBrushCache* brush, uint32 index, void* entry, uint32 bpp
 	}
 	else
 	{
-		if (index > brush->maxEntries)
+		if (index >= brush->maxEntries)
 		{
 			printf("invalid brush (%d bpp) index: 0x%04X\n", bpp, index);
 			return;

--- a/libfreerdp-cache/nine_grid.c
+++ b/libfreerdp-cache/nine_grid.c
@@ -51,7 +51,7 @@ void* nine_grid_cache_get(rdpNineGridCache* nine_grid, uint32 index)
 {
 	void* entry;
 
-	if (index > nine_grid->maxEntries)
+	if (index >= nine_grid->maxEntries)
 	{
 		printf("invalid NineGrid index: 0x%04X\n", index);
 		return NULL;
@@ -72,7 +72,7 @@ void nine_grid_cache_put(rdpNineGridCache* nine_grid, uint32 index, void* entry)
 {
 	void* prevEntry;
 
-	if (index > nine_grid->maxEntries)
+	if (index >= nine_grid->maxEntries)
 	{
 		printf("invalid NineGrid index: 0x%04X\n", index);
 		return;

--- a/libfreerdp-cache/offscreen.c
+++ b/libfreerdp-cache/offscreen.c
@@ -71,7 +71,7 @@ rdpBitmap* offscreen_cache_get(rdpOffscreenCache* offscreen_cache, uint32 index)
 {
 	rdpBitmap* bitmap;
 
-	if (index > offscreen_cache->maxEntries)
+	if (index >= offscreen_cache->maxEntries)
 	{
 		printf("invalid offscreen bitmap index: 0x%04X\n", index);
 		return NULL;
@@ -90,7 +90,7 @@ rdpBitmap* offscreen_cache_get(rdpOffscreenCache* offscreen_cache, uint32 index)
 
 void offscreen_cache_put(rdpOffscreenCache* offscreen, uint32 index, rdpBitmap* bitmap)
 {
-	if (index > offscreen->maxEntries)
+	if (index >= offscreen->maxEntries)
 	{
 		printf("invalid offscreen bitmap index: 0x%04X\n", index);
 		return;
@@ -104,7 +104,7 @@ void offscreen_cache_delete(rdpOffscreenCache* offscreen, uint32 index)
 {
 	rdpBitmap* prevBitmap;
 
-	if (index > offscreen->maxEntries)
+	if (index >= offscreen->maxEntries)
 	{
 		printf("invalid offscreen bitmap index (delete): 0x%04X\n", index);
 		return;

--- a/libfreerdp-cache/palette.c
+++ b/libfreerdp-cache/palette.c
@@ -32,7 +32,7 @@ void* palette_cache_get(rdpPaletteCache* palette_cache, uint32 index)
 {
 	void* entry;
 
-	if (index > palette_cache->maxEntries)
+	if (index >= palette_cache->maxEntries)
 	{
 		printf("invalid color table index: 0x%04X\n", index);
 		return NULL;
@@ -51,7 +51,7 @@ void* palette_cache_get(rdpPaletteCache* palette_cache, uint32 index)
 
 void palette_cache_put(rdpPaletteCache* palette_cache, uint32 index, void* entry)
 {
-	if (index > palette_cache->maxEntries)
+	if (index >= palette_cache->maxEntries)
 	{
 		printf("invalid color table index: 0x%04X\n", index);
 		return;


### PR DESCRIPTION
Fix for index out of range crashes when index is equal to max number of entries in the various cache types.

Changed > to >= in a few places to prevent problems.
