### PR TITLE
Fix default path of extensions so it is easier for packaging.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,9 @@ set(FREERDP_KEYMAP_PATH "${FREERDP_DATA_PATH}/keymaps")
 # Path to put plugins
 set(FREERDP_PLUGIN_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/freerdp")
 
+# Path to put extensions
+set(FREERDP_EXTENSION_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/freerdp/extensions")
+
 # Include directories
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_SOURCE_DIR}/include)

--- a/libfreerdp-core/CMakeLists.txt
+++ b/libfreerdp-core/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_definitions(-DEXT_PATH="/usr/lib/freerdp/extensions")
+add_definitions(-DEXT_PATH="${FREERDP_EXTENSION_PATH}")
 
 include_directories(${OPENSSL_INCLUDE_DIR})
 include_directories(${ZLIB_INCLUDE_DIRS})


### PR DESCRIPTION
Due to Multi-arch requirement, we need to be able to assign the
extensions path by prefix. This patch adds the support to change
the default extensions path base on prefix.

Signed-off-by: Ying-Chun Liu (PaulLiu) paul.liu@canonical.com
