### PR TITLE
Extended plugin system to be able to link/load plugins statically, credit goes to Mike McDonald from Quest Software

### DIFF
--- a/include/freerdp/utils/load_plugin.h
+++ b/include/freerdp/utils/load_plugin.h
@@ -29,5 +29,7 @@ FREERDP_API boolean freerdp_close_library(void* library);
 FREERDP_API void* freerdp_load_library_symbol(const char* file, const char* name);
 FREERDP_API void* freerdp_load_plugin(const char* name, const char* entry_name);
 FREERDP_API void* freerdp_load_channel_plugin(rdpSettings* settings, const char* name, const char* entry_name);
+FREERDP_API boolean freerdp_register_static_plugin(const char* name, const char* entry_name, void* entry_addr);
+FREERDP_API void* freerdp_load_static_plugin(const char* name, const char* entry_name);
 
 #endif /* __LOAD_PLUGIN_UTILS_H */

--- a/include/freerdp/utils/svc_plugin.h
+++ b/include/freerdp/utils/svc_plugin.h
@@ -60,9 +60,15 @@ FREERDP_API int svc_plugin_send_event(rdpSvcPlugin* plugin, RDP_EVENT* event);
 #define DEBUG_SVC(fmt, ...) DEBUG_NULL(fmt, ## __VA_ARGS__)
 #endif
 
+#ifdef WITH_STATIC_PLUGINS
+#define DEFINE_SVC_PLUGIN_ENTRY(_prefix) int _prefix##_entry(PCHANNEL_ENTRY_POINTS pEntryPoints)
+#else
+#define DEFINE_SVC_PLUGIN_ENTRY(_prefix) int VirtualChannelEntry(PCHANNEL_ENTRY_POINTS pEntryPoints)
+#endif
+
 #define DEFINE_SVC_PLUGIN(_prefix, _name, _options) \
 \
-int VirtualChannelEntry(PCHANNEL_ENTRY_POINTS pEntryPoints) \
+DEFINE_SVC_PLUGIN_ENTRY(_prefix) \
 { \
 	_prefix##Plugin* _p; \
 \


### PR DESCRIPTION
This commit extends the plugin system so that plugins can be compiled into the freerdp binary.
Things that are still to do:
- Configure CMake to allow static linking of plugins
- New arguments for client apps that use static plugins
- Implement registration of static plugins using the new freerdp_register_static_plugin function
