### PR TITLE
rdpsnd: show message when plugin was successfully loaded

### DIFF
--- a/channels/rdpsnd/rdpsnd_main.c
+++ b/channels/rdpsnd/rdpsnd_main.c
@@ -505,8 +505,11 @@ static void rdpsnd_process_connect(rdpSvcPlugin* plugin)
 		{
 			default_data[0].data[0] = "alsa";
 			default_data[0].data[1] = "default";
-			rdpsnd_load_device_plugin(rdpsnd, "alsa", default_data);
+			if(rdpsnd_load_device_plugin(rdpsnd, "alsa", default_data))
+				printf("rdpsnd: successfully loaded alsa plugin\n");
 		}
+		else
+			printf("rdpsnd: successfully loaded pulseaudio plugin\n");
 	}
 	if (rdpsnd->device == NULL)
 	{


### PR DESCRIPTION
Helps to inform the user which plugin is actually be used. Fixes #523
