### PR TITLE
build: ignore unresolved symbols on OS X. Fixes #677

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,10 +108,18 @@ endif()
 
 # Mac OS X
 if(APPLE)
-	include_directories(/opt/local/include)
-	link_directories(/opt/local/lib)
-	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -mmacosx-version-min=10.4")
-	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -framework CoreFoundation")
+	if(IS_DIRECTORY /opt/local/include)
+		include_directories(/opt/local/include)
+		link_directories(/opt/local/lib)
+	endif()
+	
+	option(WITH_CLANG "Build using clang" OFF)
+	if(WITH_CLANG)
+		set(CMAKE_C_COMPILER "clang")
+	endif()
+	
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mmacosx-version-min=10.4")
+	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl-framework,CoreFoundation")	
 endif()
 
 if(NOT WIN32)

--- a/winpr/CMakeLists.txt
+++ b/winpr/CMakeLists.txt
@@ -17,6 +17,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if (APPLE)
+	# flat_namespace should be avoided, but is required for -undefined warning. Since WinPR currently has
+	# a lot of undefined symbols in use, use this hack until they're filled out.
+	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-flat_namespace,-undefined,warning")	
+endif()
+
 add_subdirectory(crt)
 add_subdirectory(utils)
 add_subdirectory(heap)


### PR DESCRIPTION
Also adds an option on OS X to use the clang compiler.

We should remove the winpr/CMakeList.txt changes once WinPR is more complete
