### PR TITLE
fix --no-nego

### DIFF
--- a/libfreerdp-core/nego.c
+++ b/libfreerdp-core/nego.c
@@ -165,6 +165,10 @@ boolean nego_security_connect(rdpNego* nego)
 			DEBUG_NEGO("nego_security_connect with PROTOCOL_RDP");
 			nego->security_connected = transport_connect_rdp(nego->transport);
 		}
+		else
+		{
+			DEBUG_NEGO("cannot connect security layer because no protocol has been selected yet.");
+		}
 	}
 	return nego->security_connected;
 }


### PR DESCRIPTION
Was broken since 0bb4dc5f, which fixed #670. That issue was in turn caused by introducing --no-nego.
Now it only connects with selected protocol (instead of highest enabled protocol), and --no-nego selects highest enabled protocol in the very beginning.
