### PR TITLE
Fix for #574: Timezone redirection

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -48,6 +48,7 @@
 #cmakedefine WITH_DEBUG_RFX
 #cmakedefine WITH_DEBUG_SCARD
 #cmakedefine WITH_DEBUG_SVC
+#cmakedefine WITH_DEBUG_TIMEZONE
 #cmakedefine WITH_DEBUG_TRANSPORT
 #cmakedefine WITH_DEBUG_WND
 #cmakedefine WITH_DEBUG_X11

--- a/libfreerdp-core/timezone.c
+++ b/libfreerdp-core/timezone.c
@@ -55,6 +55,10 @@ void rdp_write_system_time(STREAM* s, SYSTEM_TIME* system_time)
 	stream_write_uint16(s, system_time->wMinute); /* wMinute */
 	stream_write_uint16(s, system_time->wSecond); /* wSecond */
 	stream_write_uint16(s, system_time->wMilliseconds); /* wMilliseconds */
+	DEBUG_TIMEZONE("Time: y=%d,m=%d,dow=%d,d=%d, %02d:%02d:%02d.%03d",
+		system_time->wYear, system_time->wMonth, system_time->wDayOfWeek,
+		system_time->wDay, system_time->wHour, system_time->wMinute,
+		system_time->wSecond, system_time->wMilliseconds);
 }
 
 /**
@@ -133,7 +137,13 @@ void rdp_write_client_time_zone(STREAM* s, rdpSettings* settings)
 
 	/* UTC = LocalTime + Bias <-> Bias = UTC - LocalTime */
 
-	bias = 1440 - clientTimeZone->bias;
+	/* Translate from biases used throughout libfreerdp-locale/timezone.c
+	 * to what RDP expects, which is minutes *west* of UTC.
+	 * Though MS-RDPBCGR specifies bias as unsigned, two's complement
+	 * (a negative integer) works fine for zones east of UTC.
+	 */
+	if (clientTimeZone->bias <= 720) bias = -(clientTimeZone->bias);
+	else bias = 1440 - clientTimeZone->bias;
 	stream_write_uint32(s, bias); /* Bias */
 
 	/* standardName (64 bytes) */
@@ -141,13 +151,17 @@ void rdp_write_client_time_zone(STREAM* s, rdpSettings* settings)
 	stream_write_zero(s, 64 - standardNameLength);
 
 	rdp_write_system_time(s, &clientTimeZone->standardDate); /* StandardDate */
+	DEBUG_TIMEZONE("bias=%d stdName='%s' dlName='%s'",
+		bias, clientTimeZone->standardName, clientTimeZone->daylightName);
 
 	sbias = clientTimeZone->standardBias - clientTimeZone->bias;
 	if (sbias < 0)
 		bias2c = (uint32) sbias;
 	else
 		bias2c = ~((uint32) sbias) + 1;
+	/* Note that StandardBias is ignored if no valid standardDate is provided. */
 	stream_write_uint32(s, bias2c); /* StandardBias */
+	DEBUG_TIMEZONE("StandardBias=%d", bias2c);
 
 	/* daylightName (64 bytes) */
 	stream_write(s, daylightName, daylightNameLength);
@@ -156,12 +170,13 @@ void rdp_write_client_time_zone(STREAM* s, rdpSettings* settings)
 	rdp_write_system_time(s, &clientTimeZone->daylightDate); /* DaylightDate */
 
 	sbias = clientTimeZone->daylightBias - clientTimeZone->bias;
-
 	if (sbias < 0)
 		bias2c = (uint32) sbias;
 	else
 		bias2c = ~((uint32) sbias) + 1;
+	/* Note that DaylightBias is ignored if no valid daylightDate is provided. */
 	stream_write_uint32(s, bias2c); /* DaylightBias */
+	DEBUG_TIMEZONE("DaylightBias=%d", bias2c);
 
 	xfree(standardName);
 	xfree(daylightName);

--- a/libfreerdp-core/timezone.h
+++ b/libfreerdp-core/timezone.h
@@ -21,6 +21,7 @@
 #define __TIMEZONE_H
 
 #include "rdp.h"
+#include "config.h"
 
 #include <freerdp/freerdp.h>
 #include <freerdp/utils/stream.h>
@@ -31,5 +32,11 @@ void rdp_write_system_time(STREAM* s, SYSTEM_TIME* system_time);
 void rdp_get_client_time_zone(STREAM* s, rdpSettings* settings);
 boolean rdp_read_client_time_zone(STREAM* s, rdpSettings* settings);
 void rdp_write_client_time_zone(STREAM* s, rdpSettings* settings);
+
+#ifdef WITH_DEBUG_TIMEZONE
+#define DEBUG_TIMEZONE(fmt, ...) DEBUG_CLASS(TIMEZONE, fmt, ## __VA_ARGS__)
+#else
+#define DEBUG_TIMEZONE(fmt, ...) DEBUG_NULL(fmt, ## __VA_ARGS__)
+#endif
 
 #endif /* __TIMEZONE_H */

--- a/libfreerdp-locale/liblocale.h
+++ b/libfreerdp-locale/liblocale.h
@@ -29,4 +29,10 @@
 #define DEBUG_KBD(fmt, ...) DEBUG_NULL(fmt, ## __VA_ARGS__)
 #endif
 
+#ifdef WITH_DEBUG_TIMEZONE
+#define DEBUG_TIMEZONE(fmt, ...) DEBUG_CLASS(TIMEZONE, fmt, ## __VA_ARGS__)
+#else
+#define DEBUG_TIMEZONE(fmt, ...) DEBUG_NULL(fmt, ## __VA_ARGS__)
+#endif
+
 #endif /* __LIBLOCALE_H */

--- a/libfreerdp-locale/timezone.c
+++ b/libfreerdp-locale/timezone.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 
 #include "config.h"
+#include "liblocale.h"
 
 #include <freerdp/utils/time.h>
 #include <freerdp/utils/memory.h>
@@ -809,7 +810,7 @@ static const TIME_ZONE_ENTRY TimeZoneTable[] =
 		(TIME_ZONE_RULE_ENTRY*) &TimeZoneRuleTable_43, 2
 	},
 	{
-		"GTB Standard Time", 120, true, "(UTC+02:00) Athens, Bucharest",
+		"GTB Standard Time", 120, true, "(UTC+02:00) Athens, Bucharest, Istanbul",
 		"GTB Standard Time", "GTB Daylight Time",
 		(TIME_ZONE_RULE_ENTRY*) &TimeZoneRuleTable_44, 1
 	},
@@ -1264,13 +1265,14 @@ const WINDOWS_TZID_ENTRY WindowsTimeZoneIdTable[] =
 	{ "GTB Standard Time", "Europe/Athens" },
 	{ "GTB Standard Time", "Europe/Bucharest" },
 	{ "GTB Standard Time", "Europe/Chisinau" },
+	{ "GTB Standard Time", "Europe/Istanbul" },
 	{ "Hawaiian Standard Time", "Etc/GMT+10" },
 	{ "Hawaiian Standard Time", "Pacific/Fakaofo" },
 	{ "Hawaiian Standard Time", "Pacific/Honolulu" },
 	{ "Hawaiian Standard Time", "Pacific/Johnston" },
 	{ "Hawaiian Standard Time", "Pacific/Rarotonga" },
 	{ "Hawaiian Standard Time", "Pacific/Tahiti" },
-	{ "India Standard Time", "Asia/Calcutta" },
+	{ "India Standard Time", "Asia/Calcutta Asia/Kolkata" },
 	{ "Iran Standard Time", "Asia/Tehran" },
 	{ "Israel Standard Time", "Asia/Jerusalem" },
 	{ "Jordan Standard Time", "Asia/Amman" },
@@ -1299,7 +1301,7 @@ const WINDOWS_TZID_ENTRY WindowsTimeZoneIdTable[] =
 	{ "N. Central Asia Standard Time", "Asia/Novosibirsk Asia/Novokuznetsk Asia/Omsk" },
 	{ "N. Central Asia Standard Time", "Asia/Novosibirsk" },
 	{ "Namibia Standard Time", "Africa/Windhoek" },
-	{ "Nepal Standard Time", "Asia/Katmandu" },
+	{ "Nepal Standard Time", "Asia/Katmandu Asia/Kathmandu" },
 	{ "New Zealand Standard Time", "Antarctica/South_Pole Antarctica/McMurdo" },
 	{ "New Zealand Standard Time", "Pacific/Auckland" },
 	{ "Newfoundland Standard Time", "America/St_Johns" },
@@ -1309,7 +1311,7 @@ const WINDOWS_TZID_ENTRY WindowsTimeZoneIdTable[] =
 	{ "Pacific SA Standard Time", "Antarctica/Palmer" },
 	{ "Pacific Standard Time (Mexico)", "America/Santa_Isabel" },
 	{ "Pacific Standard Time", "America/Los_Angeles" },
-	{ "Pacific Standard Time", "America/Tijuana" },
+	{ "Pacific Standard Time", "America/Tijuana America/Ensenada" },
 	{ "Pacific Standard Time", "America/Vancouver America/Dawson America/Whitehorse" },
 	{ "Pacific Standard Time", "PST8PDT" },
 	{ "Pakistan Standard Time", "Asia/Karachi" },
@@ -1361,13 +1363,13 @@ const WINDOWS_TZID_ENTRY WindowsTimeZoneIdTable[] =
 	{ "SA Western Standard Time", "America/St_Vincent" },
 	{ "SA Western Standard Time", "America/Tortola" },
 	{ "SA Western Standard Time", "Etc/GMT+4" },
-	{ "Samoa Standard Time", "Pacific/Apia" },
+	{ "Samoa Standard Time", "Pacific/Apia Pacific/Samoa" },
 	{ "SE Asia Standard Time", "Antarctica/Davis" },
 	{ "SE Asia Standard Time", "Asia/Bangkok" },
 	{ "SE Asia Standard Time", "Asia/Hovd" },
 	{ "SE Asia Standard Time", "Asia/Jakarta Asia/Pontianak" },
 	{ "SE Asia Standard Time", "Asia/Phnom_Penh" },
-	{ "SE Asia Standard Time", "Asia/Saigon" },
+	{ "SE Asia Standard Time", "Asia/Saigon Asia/Ho_Chi_Minh" },
 	{ "SE Asia Standard Time", "Asia/Vientiane" },
 	{ "SE Asia Standard Time", "Etc/GMT-7" },
 	{ "SE Asia Standard Time", "Indian/Christmas" },
@@ -1403,7 +1405,7 @@ const WINDOWS_TZID_ENTRY WindowsTimeZoneIdTable[] =
 	{ "Tonga Standard Time", "Etc/GMT-13" },
 	{ "Tonga Standard Time", "Pacific/Enderbury" },
 	{ "Tonga Standard Time", "Pacific/Tongatapu" },
-	{ "Turkey Standard Time", "Europe/Istanbul" },
+	/* { "Turkey Standard Time", "Europe/Istanbul" }, */
 	{ "Ulaanbaatar Standard Time", "Asia/Ulaanbaatar Asia/Choibalsan" },
 	{ "Ulaanbaatar Standard Time", "Asia/Ulaanbaatar" },
 	{ "US Eastern Standard Time", "America/Indianapolis "
@@ -1683,11 +1685,18 @@ void freerdp_time_zone_detect(TIME_ZONE_INFO* clientTimeZone)
 		clientTimeZone->standardBias = clientTimeZone->bias;
 		clientTimeZone->daylightBias = clientTimeZone->bias + 60;
 	}
+	DEBUG_TIMEZONE("sbias=%d, bias=%d, stdBias=%d, dlBias=%d",
+		sbias, clientTimeZone->bias, clientTimeZone->standardBias,
+		clientTimeZone->daylightBias);
 
 	tz = freerdp_detect_windows_time_zone(clientTimeZone->bias);
 
 	if (tz!= NULL)
 	{
+		DEBUG_TIMEZONE("tz: Id='%s' Bias=%d DST=%d dn='%s' sn='%s' dln='%s'",
+			tz->Id, tz->Bias, tz->SupportsDST, tz->DisplayName,
+			tz->StandardName, tz->DaylightName);
+		/* Not printed: RuleTable, RuleTableCount */
 		clientTimeZone->bias = tz->Bias;
 		sprintf(clientTimeZone->standardName, "%s", tz->StandardName);
 		sprintf(clientTimeZone->daylightName, "%s", tz->DaylightName);
@@ -1729,6 +1738,7 @@ void freerdp_time_zone_detect(TIME_ZONE_INFO* clientTimeZone)
 	else
 	{
 		/* could not detect timezone, fallback to using GMT */
+		DEBUG_TIMEZONE("tz not found, using GMT.");
 		sprintf(clientTimeZone->standardName, "%s", "GMT Standard Time");
 		sprintf(clientTimeZone->daylightName, "%s", "GMT Daylight Time");
 	}


### PR DESCRIPTION
The last fix for this problem was _close_ but when you wrap across east of UTC, it was decrementing the day, basically because the bias is an offset in minutes west of UTC.  It's necessary to send a negative bias (i.e. 2's complement) for zones east of UTC rather than a large positive bias that crosses the international date line.

Also, I added a few synonyms for time zones common on Linux, e.g. Kolkata for Calcutta, and fixed Istanbul, which is now grouped with Athens and Bucharest.
