### PR TITLE
Refine the extension loading code.

### DIFF
--- a/libfreerdp-core/extension.c
+++ b/libfreerdp-core/extension.c
@@ -194,6 +194,12 @@ int extension_post_connect(rdpExtension* ext)
 	return 0;
 }
 
+void extension_load_and_init_plugins(rdpExtension* extension)
+{
+	extension_load_plugins(extension);
+	extension_init_plugins(extension);
+}
+
 rdpExtension* extension_new(freerdp* instance)
 {
 	rdpExtension* extension = NULL;
@@ -203,9 +209,6 @@ rdpExtension* extension_new(freerdp* instance)
 		extension = xnew(rdpExtension);
 
 		extension->instance = instance;
-
-		extension_load_plugins(extension);
-		extension_init_plugins(extension);
 	}
 
 	return extension;

--- a/libfreerdp-core/extension.h
+++ b/libfreerdp-core/extension.h
@@ -48,6 +48,7 @@ FREERDP_API int extension_post_connect(rdpExtension* extension);
 
 FREERDP_API rdpExtension* extension_new(freerdp* instance);
 FREERDP_API void extension_free(rdpExtension* extension);
+FREERDP_API void extension_load_and_init_plugins(rdpExtension* extension);
 
 #endif /* __EXTENSION_H */
 

--- a/libfreerdp-core/freerdp.c
+++ b/libfreerdp-core/freerdp.c
@@ -54,7 +54,7 @@ boolean freerdp_connect(freerdp* instance)
 
 	IFCALLRET(instance->PreConnect, status, instance);
 
-	rdp->extension = extension_new(instance);
+	extension_load_and_init_plugins(rdp->extension);
 	extension_pre_connect(rdp->extension);
 
 	if (status != true)

--- a/libfreerdp-core/rdp.c
+++ b/libfreerdp-core/rdp.c
@@ -915,7 +915,8 @@ rdpRdp* rdp_new(freerdp* instance)
 
 		if (instance != NULL)
 			instance->settings = rdp->settings;
-		
+
+		rdp->extension = extension_new(instance);
 		rdp->transport = transport_new(rdp->settings);
 		rdp->license = license_new(rdp);
 		rdp->input = input_new(rdp);


### PR DESCRIPTION
The extension loading code is fixed by commit
48ad5feb0a6ad831d863f89ed74b443021e54303

However, it looks weird that the extension is not initialized in rdp_new().
So we split the load/init steps out of new step. Thus to achieve the
same result that 48ad5feb0a6ad831d863f89ed74b443021e54303 des.

Signed-off-by: Ying-Chun Liu (PaulLiu) paul.liu@canonical.com
