### PR TITLE
Add missing config.h to types.h

### DIFF
--- a/include/freerdp/types.h
+++ b/include/freerdp/types.h
@@ -26,6 +26,7 @@
 #endif
 
 /* Base Types */
+#include "config.h"
 
 #ifdef HAVE_LIMITS_H
 #include <limits.h>


### PR DESCRIPTION
Without config.h the various HAVE_\* macros are not used properly and this causes a compilation error on OSX Mountain Lion.

See https://github.com/mxcl/homebrew/issues/13353

Thanks!
