### PR TITLE
Fix for issue 540: ctrl-enter toggles fullscreen

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -386,6 +386,8 @@ static boolean xf_event_FocusOut(xfInfo* xfi, XEvent* event, boolean app)
 	if (event->xfocus.mode == NotifyWhileGrabbed)
 		XUngrabKeyboard(xfi->display, CurrentTime);
 
+	xf_kbd_clear(xfi);
+
 	if (app)
 		xf_rail_send_activate(xfi, event->xany.window, false);
 

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -28,10 +28,15 @@
 
 void xf_kbd_init(xfInfo* xfi)
 {
-	memset(xfi->pressed_keys, 0, 256 * sizeof(boolean));
+	xf_kbd_clear(xfi);
 	xfi->keyboard_layout_id = xfi->instance->settings->kbd_layout;
 	xfi->keyboard_layout_id = freerdp_keyboard_init(xfi->keyboard_layout_id);
 	xfi->instance->settings->kbd_layout = xfi->keyboard_layout_id;
+}
+
+void xf_kbd_clear(xfInfo* xfi)
+{
+	memset(xfi->pressed_keys, 0, 256 * sizeof(boolean));
 }
 
 void xf_kbd_set_keypress(xfInfo* xfi, uint8 keycode, KeySym keysym)

--- a/client/X11/xf_keyboard.h
+++ b/client/X11/xf_keyboard.h
@@ -25,6 +25,7 @@
 #include "xfreerdp.h"
 
 void xf_kbd_init(xfInfo* xfi);
+void xf_kbd_clear(xfInfo* xfi);
 void xf_kbd_set_keypress(xfInfo* xfi, uint8 keycode, KeySym keysym);
 void xf_kbd_unset_keypress(xfInfo* xfi, uint8 keycode);
 void xf_kbd_release_all_keypress(xfInfo* xfi);


### PR DESCRIPTION
Clear xfi->pressed_keys when window loses focus.
This would prevent a held alt key from putting the app into fullscreen if the
users sends ctrl+enter when the app regains focus.
