### PR TITLE
[bug fix] position setting kbd_type,kbd_subtype and kbd_fn_keys

### DIFF
--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -56,10 +56,10 @@ boolean freerdp_connect(freerdp* instance)
 
 	rdp = instance->context->rdp;
 
+	IFCALLRET(instance->PreConnect, status, instance);
+
 	/* Advanced settings for keyboard layout */
 	freerdp_keyboard_set_layout_code(rdp->mcs->transport->settings);
-
-	IFCALLRET(instance->PreConnect, status, instance);
 
 	extension_load_and_init_plugins(rdp->extension);
 	extension_pre_connect(rdp->extension);


### PR DESCRIPTION
bug fix:
  I mistaked the position setting kbd_type,kbd_subtype and kbd_fn_keys.
  After kbd_layout has been set, I set them.
  There is a failure in my test method.
