### PR TITLE
utils/pcap: Don't allocate memory for data in pcap_get_next_record_header

### DIFF
--- a/libfreerdp/utils/pcap.c
+++ b/libfreerdp/utils/pcap.c
@@ -136,7 +136,6 @@ boolean pcap_get_next_record_header(rdpPcap* pcap, pcap_record* record)
 
 	pcap_read_record_header(pcap, &record->header);
 	record->length = record->header.incl_len;
-	record->data = xmalloc(record->length);
 
 	return true;
 }


### PR DESCRIPTION
pcap_get_next_record_header shouldn't allocate memory for the data.

This fixes a leak in tfreerdp-server.
