### PR TITLE
Correct spelling of "experiance" in documentation.

### DIFF
--- a/client/X11/xfreerdp.1.xml
+++ b/client/X11/xfreerdp.1.xml
@@ -200,7 +200,7 @@
         <term>-x <replaceable class="parameter">flag</replaceable></term>
         <listitem>
           <para>
-            Set the experiance performance flags.
+            Set the experience performance flags.
             <replaceable class="parameter">flag</replaceable> can be one of:
             <itemizedlist>
               <listitem>


### PR DESCRIPTION
"experiance" is spelled incorrectly in xfreerdp.1.xml
