### PR TITLE
tsmf-ffmpeg: Update to latest versions of api (Fix #285)

### DIFF
--- a/channels/drdynvc/tsmf/ffmpeg/tsmf_ffmpeg.c
+++ b/channels/drdynvc/tsmf/ffmpeg/tsmf_ffmpeg.c
@@ -59,7 +59,7 @@ static boolean tsmf_ffmpeg_init_context(ITSMFDecoder* decoder)
 {
 	TSMFFFmpegDecoder* mdecoder = (TSMFFFmpegDecoder*) decoder;
 
-	mdecoder->codec_context = avcodec_alloc_context();
+	mdecoder->codec_context = avcodec_alloc_context3(NULL);
 	if (!mdecoder->codec_context)
 	{
 		DEBUG_WARN("avcodec_alloc_context failed.");
@@ -179,9 +179,9 @@ static boolean tsmf_ffmpeg_prepare(ITSMFDecoder* decoder)
 {
 	TSMFFFmpegDecoder* mdecoder = (TSMFFFmpegDecoder*) decoder;
 
-	if (avcodec_open(mdecoder->codec_context, mdecoder->codec) < 0)
+	if (avcodec_open2(mdecoder->codec_context, mdecoder->codec, NULL) < 0)
 	{
-		DEBUG_WARN("avcodec_open failed.");
+		DEBUG_WARN("avcodec_open2 failed.");
 		return false;
 	}
 
@@ -366,19 +366,29 @@ static boolean tsmf_ffmpeg_decode_audio(ITSMFDecoder* decoder, const uint8* data
 			}
 			dst += mdecoder->decoded_size;
 		}
+		
 		frame_size = mdecoder->decoded_size_max - mdecoder->decoded_size;
 #if LIBAVCODEC_VERSION_MAJOR < 52 || (LIBAVCODEC_VERSION_MAJOR == 52 && LIBAVCODEC_VERSION_MINOR <= 20)
 		len = avcodec_decode_audio2(mdecoder->codec_context,
-			(int16_t*) dst, &frame_size,
-			src, src_size);
+			(int16_t*) dst, &frame_size, src, src_size);
 #else
 		{
+            AVFrame* decoded_frame = avcodec_alloc_frame();
+			int got_frame = 0;
 			AVPacket pkt;
 			av_init_packet(&pkt);
 			pkt.data = (uint8*) src;
 			pkt.size = src_size;
-			len = avcodec_decode_audio3(mdecoder->codec_context,
-				(int16_t*) dst, &frame_size, &pkt);
+			len = avcodec_decode_audio4(mdecoder->codec_context, decoded_frame, &got_frame, &pkt);
+			
+			if (len >= 0 && got_frame)
+			{
+	            frame_size = av_samples_get_buffer_size(NULL, mdecoder->codec_context->channels,
+					decoded_frame->nb_samples, mdecoder->codec_context->sample_fmt, 1);
+				memcpy(dst, decoded_frame->data[0], frame_size);
+			}
+			
+			av_free(decoded_frame);
 		}
 #endif
 		if (len <= 0 || frame_size <= 0)


### PR DESCRIPTION
Note that this adds an alloc of memory in audio decode as avcodec_decode_audio4 takes AVFrame; I couldn't figure out how to get the API to directly decode into our destination buffer. 

This should obviate the need to re-align for SSE, so that logic could be re-optimized.
