### PR TITLE
build: check libavcodec api version

### DIFF
--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -5,6 +5,9 @@
 #  FFMPEG_INCLUDE_DIRS  - combined include directories
 #  FFMPEG_LIBRARIES    - combined libraries to link
 
+set(REQUIRED_AVCODEC_VERSION 0.8)
+set(REQUIRED_AVCODEC_API_VERSION 53.25.0)
+
 include(FindPkgConfig)
 
 if (PKG_CONFIG_FOUND)
@@ -30,6 +33,14 @@ endif()
 
 
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(FFmpeg DEFAULT_MSG AVUTIL_FOUND AVCODEC_FOUND)
+
+if (AVCODEC_VERSION)
+	if (${AVCODEC_VERSION} VERSION_LESS ${REQUIRED_AVCODEC_API_VERSION})
+		message(FATAL_ERROR "libavcodec version >= ${REQUIRED_AVCODEC_VERSION} (API >= ${REQUIRED_AVCODEC_API_VERSION}) is required")
+	endif()
+else()
+		message("Note: To build libavcodec version >= ${REQUIRED_AVCODEC_VERSION} (API >= ${REQUIRED_AVCODEC_API_VERSION}) is required")
+endif()
 
 if(FFMPEG_FOUND)
 	set(FFMPEG_INCLUDE_DIRS ${AVCODEC_INCLUDE_DIR} ${AVUTIL_INCLUDE_DIR})


### PR DESCRIPTION
If pkg-config is available libavcodec api version is checked and
cmake fails if the required version isn't available.

In case pkg-config isn't available a notification message with the
required version is printed.

This fixes/prevents #740.
