### PR TITLE
Changes for Ubuntu Lucid compilability (GCC 4.3.3 and cmake 2.8.[0,1])

### DIFF
--- a/cmake/FindOpenSSL.cmake
+++ b/cmake/FindOpenSSL.cmake
@@ -26,7 +26,9 @@
 
 if (UNIX)
   find_package(PkgConfig QUIET)
-  pkg_check_modules(_OPENSSL QUIET openssl)
+  # QUIET option not recognized by cmake 2.8.0 or 2.8.1
+  #pkg_check_modules(_OPENSSL QUIET openssl)
+  pkg_check_modules(_OPENSSL openssl)
 endif (UNIX)
 
 # http://www.slproweb.com/products/Win32OpenSSL.html

--- a/winpr/libwinpr/interlocked/interlocked.c
+++ b/winpr/libwinpr/interlocked/interlocked.c
@@ -297,7 +297,7 @@ LONGLONG InterlockedCompareExchange64(LONGLONG volatile *Destination, LONGLONG E
 
 LONGLONG InterlockedCompareExchange64(LONGLONG volatile *Destination, LONGLONG Exchange, LONGLONG Comperand)
 {
-#ifdef __GNUC__
+#if defined(__GNUC__) && defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8)
 	return __sync_val_compare_and_swap(Destination, Comperand, Exchange);
 #else
 	return 0;


### PR DESCRIPTION
Two changes:
1) gcc 4.3.3 doesn't support _sync_val_compare_and_swap_8.  The code now checks the GCC built-in __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 before attempting to use it.
2) cmake 2.8.0 and 2.8.1 apparently don't support the QUIET option to pkg_check_modules.
