### PR TITLE
Spelling correction

### DIFF
--- a/client/X11/xfreerdp.c
+++ b/client/X11/xfreerdp.c
@@ -516,7 +516,7 @@ boolean xf_pre_connect(freerdp* instance)
 			fprintf(stderr, "--authonly, but no -p password. Please provide one.\n");
 			exit(1);
 		}
-		fprintf(stderr, "%s:%d: Authenication only. Don't connect to X.\n", __FILE__, __LINE__);
+		fprintf(stderr, "%s:%d: Authentication only. Don't connect to X.\n", __FILE__, __LINE__);
 		// Avoid XWindows initialization and configuration below.
 		return true;
 	}


### PR DESCRIPTION
Authenication=>Authentication

This change is already in master, part of a much larger fix.
