### PR TITLE
Fix for 8-byte compare-and-swap on older GCC

### DIFF
--- a/winpr/libwinpr/interlocked/interlocked.c
+++ b/winpr/libwinpr/interlocked/interlocked.c
@@ -271,7 +271,7 @@ LONGLONG InterlockedCompareExchange64(LONGLONG volatile *Destination, LONGLONG E
 	return previousValue;
 }
 
-#elif ANDROID
+#elif ANDROID || (defined(__GNUC__) && !defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8))
 
 #include <pthread.h>
 


### PR DESCRIPTION
This changes a macro so that the mutex-based version of InterlockedCompareExchange64 is used on older versions of GCC that do not support the 8-byte sync_val_compare_and_swap builtin.  Gcc provides built-in macros to make the decision easy at compile time.

I've tested this fix...it works.  (An earlier version fell back to placeholder code which didn't do the operation correctly.)
