### PR TITLE
SSPI NTLM Unicode Conversion Fix

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -52,10 +52,9 @@ void ntlm_SetContextWorkstation(NTLM_CONTEXT* context, char* Workstation)
 		GetComputerNameExA(ComputerNameNetBIOS, Workstation, &nSize);
 	}
 
-	context->Workstation.Length = strlen(Workstation) * 2;
-	context->Workstation.Buffer = (PWSTR) malloc(context->Workstation.Length);
-	MultiByteToWideChar(CP_ACP, 0, Workstation, strlen(Workstation),
-			context->Workstation.Buffer, context->Workstation.Length / 2);
+	context->Workstation.Length = ConvertToUnicode(CP_UTF8, 0,
+			Workstation, -1, &context->Workstation.Buffer, 0) - 1;
+	context->Workstation.Length *= 2;
 
 	if (nSize > 0)
 		free(Workstation);
@@ -63,17 +62,16 @@ void ntlm_SetContextWorkstation(NTLM_CONTEXT* context, char* Workstation)
 
 void ntlm_SetContextServicePrincipalNameW(NTLM_CONTEXT* context, LPWSTR ServicePrincipalName)
 {
-	context->ServicePrincipalName.Length = lstrlenW(ServicePrincipalName) * 2;
+	context->ServicePrincipalName.Length = _wcslen(ServicePrincipalName) * 2;
 	context->ServicePrincipalName.Buffer = (PWSTR) malloc(context->ServicePrincipalName.Length);
 	CopyMemory(context->ServicePrincipalName.Buffer, ServicePrincipalName, context->ServicePrincipalName.Length);
 }
 
 void ntlm_SetContextServicePrincipalNameA(NTLM_CONTEXT* context, char* ServicePrincipalName)
 {
-	context->ServicePrincipalName.Length = strlen(ServicePrincipalName) * 2;
-	context->ServicePrincipalName.Buffer = (PWSTR) malloc(context->ServicePrincipalName.Length);
-	MultiByteToWideChar(CP_ACP, 0, ServicePrincipalName, strlen(ServicePrincipalName),
-			context->ServicePrincipalName.Buffer, context->ServicePrincipalName.Length / 2);
+	context->ServicePrincipalName.Length = ConvertToUnicode(CP_UTF8, 0,
+			ServicePrincipalName, -1, &context->ServicePrincipalName.Buffer, 0) - 1;
+	context->ServicePrincipalName.Length *= 2;
 }
 
 void ntlm_SetContextTargetName(NTLM_CONTEXT* context, char* TargetName)
@@ -88,10 +86,9 @@ void ntlm_SetContextTargetName(NTLM_CONTEXT* context, char* TargetName)
 		CharUpperA(TargetName);
 	}
 
-	context->TargetName.cbBuffer = strlen(TargetName) * 2;
-	context->TargetName.pvBuffer = (void*) malloc(context->TargetName.cbBuffer);
-	MultiByteToWideChar(CP_ACP, 0, TargetName, strlen(TargetName),
-			(LPWSTR) context->TargetName.pvBuffer, context->TargetName.cbBuffer / 2);
+	context->TargetName.cbBuffer = ConvertToUnicode(CP_UTF8, 0,
+			TargetName, -1, (LPWSTR*) &context->TargetName.pvBuffer, 0) - 1;
+	context->TargetName.cbBuffer *= 2;
 
 	if (nSize > 0)
 		free(TargetName);
@@ -517,16 +514,12 @@ SECURITY_STATUS SEC_ENTRY ntlm_InitializeSecurityContextA(PCredHandle phCredenti
 		PSecBufferDesc pInput, ULONG Reserved2, PCtxtHandle phNewContext,
 		PSecBufferDesc pOutput, PULONG pfContextAttr, PTimeStamp ptsExpiry)
 {
-	int length;
 	SECURITY_STATUS status;
 	SEC_WCHAR* pszTargetNameW = NULL;
 
 	if (pszTargetName != NULL)
 	{
-		length = strlen(pszTargetName);
-		pszTargetNameW = (PWSTR) malloc((length + 1) * 2);
-		MultiByteToWideChar(CP_ACP, 0, pszTargetName, length, pszTargetNameW, length);
-		pszTargetNameW[length] = 0;
+		ConvertToUnicode(CP_UTF8, 0, pszTargetName, -1, &pszTargetNameW, 0);
 	}
 
 	status = ntlm_InitializeSecurityContextW(phCredential, phContext, pszTargetNameW, fContextReq,

--- a/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
@@ -176,6 +176,7 @@ NTLM_AV_PAIR* ntlm_av_pair_add_copy(NTLM_AV_PAIR* pAvPairList, NTLM_AV_PAIR* pAv
 void ntlm_get_target_computer_name(PUNICODE_STRING pName, COMPUTER_NAME_FORMAT type)
 {
 	char* name;
+	int length;
 	DWORD nSize = 0;
 
 	GetComputerNameExA(type, NULL, &nSize);
@@ -185,11 +186,9 @@ void ntlm_get_target_computer_name(PUNICODE_STRING pName, COMPUTER_NAME_FORMAT t
 	if (type == ComputerNameNetBIOS)
 		CharUpperA(name);
 
-	pName->Length = strlen(name) * 2;
-	pName->Buffer = (PWSTR) malloc(pName->Length);
-	MultiByteToWideChar(CP_ACP, 0, name, strlen(name),
-			(LPWSTR) pName->Buffer, pName->Length / 2);
+	length = ConvertToUnicode(CP_UTF8, 0, name, -1, &pName->Buffer, 0);
 
+	pName->Length = (length - 1) / 2;
 	pName->MaximumLength = pName->Length;
 
 	free(name);

--- a/winpr/libwinpr/sspi/sspi.c
+++ b/winpr/libwinpr/sspi/sspi.c
@@ -288,10 +288,7 @@ void sspi_SetAuthIdentity(SEC_WINNT_AUTH_IDENTITY* identity, char* user, char* d
 
 	if (user)
 	{
-		identity->UserLength = MultiByteToWideChar(CP_UTF8, 0, user, strlen(user), NULL, 0);
-		identity->User = (UINT16*) malloc((identity->UserLength + 1) * sizeof(WCHAR));
-		MultiByteToWideChar(CP_UTF8, 0, user, identity->UserLength, (LPWSTR) identity->User, identity->UserLength * sizeof(WCHAR));
-		identity->User[identity->UserLength] = 0;
+		identity->UserLength = ConvertToUnicode(CP_UTF8, 0, user, -1, &identity->User, 0) - 1;
 	}
 	else
 	{
@@ -301,10 +298,7 @@ void sspi_SetAuthIdentity(SEC_WINNT_AUTH_IDENTITY* identity, char* user, char* d
 
 	if (domain)
 	{
-		identity->DomainLength = MultiByteToWideChar(CP_UTF8, 0, domain, strlen(domain), NULL, 0);
-		identity->Domain = (UINT16*) malloc((identity->DomainLength + 1) * sizeof(WCHAR));
-		MultiByteToWideChar(CP_UTF8, 0, domain, identity->DomainLength, (LPWSTR) identity->Domain, identity->DomainLength * sizeof(WCHAR));
-		identity->Domain[identity->DomainLength] = 0;
+		identity->DomainLength = ConvertToUnicode(CP_UTF8, 0, domain, -1, &identity->Domain, 0) - 1;
 	}
 	else
 	{
@@ -314,10 +308,7 @@ void sspi_SetAuthIdentity(SEC_WINNT_AUTH_IDENTITY* identity, char* user, char* d
 
 	if (password != NULL)
 	{
-		identity->PasswordLength = MultiByteToWideChar(CP_UTF8, 0, password, strlen(password), NULL, 0);
-		identity->Password = (UINT16*) malloc((identity->PasswordLength + 1) * sizeof(WCHAR));
-		MultiByteToWideChar(CP_UTF8, 0, password, identity->PasswordLength, (LPWSTR) identity->Password, identity->PasswordLength * sizeof(WCHAR));
-		identity->Password[identity->PasswordLength] = 0;
+		identity->PasswordLength = ConvertToUnicode(CP_UTF8, 0, password, -1, &identity->Password, 0) - 1;
 	}
 	else
 	{
@@ -439,14 +430,10 @@ SecurityFunctionTableW* sspi_GetSecurityFunctionTableWByNameW(const SEC_WCHAR* N
 
 SecurityFunctionTableW* sspi_GetSecurityFunctionTableWByNameA(const SEC_CHAR* Name)
 {
-	int length;
 	SEC_WCHAR* NameW;
 	SecurityFunctionTableW* table;
 
-	length = strlen(Name);
-	NameW = (SEC_WCHAR*) malloc((length + 1) * 2);
-	MultiByteToWideChar(CP_ACP, 0, Name, length, (LPWSTR) NameW, length);
-	NameW[length] = 0;
+	ConvertToUnicode(CP_UTF8, 0, Name, -1, &NameW, 0);
 
 	table = sspi_GetSecurityFunctionTableWByNameW(NameW);
 	free(NameW);


### PR DESCRIPTION
Fix unicode conversion in SSPI modules

This fixes issue #856 for credentials containing umlauts
