### PR TITLE
Add -march=i686 for 32 bit builds as otherwise defaults to i386 which do...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,9 @@ endif()
 
 # Compiler-specific flags
 if(CMAKE_COMPILER_IS_GNUCC)
+	if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+    	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=i686")
+	endif()
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 	CHECK_C_COMPILER_FLAG (-Wno-unused-result Wno-unused-result)
 	if(Wno-unused-result)


### PR DESCRIPTION
Add -march=i686 for 32 bit builds as otherwise defaults to i386 which does not supply one of the compare and swap intrinsics.

This may be obsolete as I note someone has made a chnage to avoid the relevant compare and swap.
