### PR TITLE
Initialize lpWideCharStr parameter when using ConvertToUnicode

### DIFF
--- a/channels/drive/client/drive_file.c
+++ b/channels/drive/client/drive_file.c
@@ -601,6 +601,7 @@ BOOL drive_file_query_directory(DRIVE_FILE* file, UINT32 FsInformationClass, BYT
 
 	DEBUG_SVC("  pattern %s matched %s", file->pattern, ent_path);
 	free(ent_path);
+	ent_path = NULL;
 
 	length = ConvertToUnicode(CP_UTF8, 0, ent->d_name, -1, &ent_path, 0) * 2;
 

--- a/channels/drive/client/drive_main.c
+++ b/channels/drive/client/drive_main.c
@@ -391,7 +391,7 @@ static void drive_process_irp_query_volume_information(DRIVE_DEVICE* disk, IRP* 
 	struct STAT st;
 	char* volumeLabel = {"FREERDP"};
 	char* diskType = {"FAT32"};
-	WCHAR* outStr;
+	WCHAR* outStr = NULL;
 	int length;
 
 	stream_read_UINT32(irp->input, FsInformationClass);

--- a/channels/printer/client/printer_main.c
+++ b/channels/printer/client/printer_main.c
@@ -235,9 +235,9 @@ void printer_register(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints, rdpPrinter* pri
 	char* port;
 	UINT32 Flags;
 	int DriverNameLen;
-	WCHAR* DriverName;
+	WCHAR* DriverName = NULL;
 	int PrintNameLen;
-	WCHAR* PrintName;
+	WCHAR* PrintName = NULL;
 	UINT32 CachedFieldsLen;
 	BYTE* CachedPrinterConfigData;
 	PRINTER_DEVICE* printer_dev;

--- a/channels/rail/client/rail_orders.c
+++ b/channels/rail/client/rail_orders.c
@@ -70,7 +70,7 @@ static const char* const RAIL_ORDER_TYPE_STRINGS[] =
 
 void rail_string_to_unicode_string(rdpRailOrder* rail_order, char* string, RAIL_UNICODE_STRING* unicode_string)
 {
-	WCHAR* buffer;
+	WCHAR* buffer = NULL;
 	int length = 0;
 
 	if (unicode_string->string != NULL)

--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -92,7 +92,7 @@ static void rdpdr_send_client_announce_reply(rdpdrPlugin* rdpdr)
 static void rdpdr_send_client_name_request(rdpdrPlugin* rdpdr)
 {
 	STREAM* data_out;
-	WCHAR* computerNameW;
+	WCHAR* computerNameW = NULL;
 	size_t computerNameLenW;
 
 	if (!rdpdr->computerName[0])

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -533,7 +533,7 @@ static BYTE* xf_cliprdr_process_requested_raw(BYTE* data, int* size)
 static BYTE* xf_cliprdr_process_requested_unicodetext(BYTE* data, int* size)
 {
 	char* inbuf;
-	WCHAR* outbuf;
+	WCHAR* outbuf = NULL;
 	int out_size;
 
 	inbuf = (char*) lf2crlf(data, size);

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -655,13 +655,13 @@ BOOL gcc_read_client_core_data(STREAM* s, rdpSettings* settings, UINT16 blockLen
 void gcc_write_client_core_data(STREAM* s, rdpSettings* settings)
 {
 	UINT32 version;
-	WCHAR* clientName;
+	WCHAR* clientName = NULL;
 	int clientNameLength;
 	BYTE connectionType;
 	UINT16 highColorDepth;
 	UINT16 supportedColorDepths;
 	UINT16 earlyCapabilityFlags;
-	WCHAR* clientDigProductId;
+	WCHAR* clientDigProductId = NULL;
 	int clientDigProductIdLength;
 
 	gcc_write_user_data_header(s, CS_CORE, 216);

--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -164,9 +164,9 @@ BOOL rdp_read_extended_info_packet(STREAM* s, rdpSettings* settings)
 void rdp_write_extended_info_packet(STREAM* s, rdpSettings* settings)
 {
 	int clientAddressFamily;
-	WCHAR* clientAddress;
+	WCHAR* clientAddress = NULL;
 	int cbClientAddress;
-	WCHAR* clientDir;
+	WCHAR* clientDir = NULL;
 	int cbClientDir;
 	int cbAutoReconnectLen;
 

--- a/libfreerdp/core/timezone.c
+++ b/libfreerdp/core/timezone.c
@@ -119,8 +119,8 @@ void rdp_write_client_time_zone(STREAM* s, rdpSettings* settings)
 	UINT32 bias;
 	INT32 sbias;
 	UINT32 bias2c;
-	WCHAR* standardName;
-	WCHAR* daylightName;
+	WCHAR* standardName = NULL;
+	WCHAR* daylightName = NULL;
 	int standardNameLength;
 	int daylightNameLength;
 	TIME_ZONE_INFO* clientTimeZone;

--- a/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
@@ -291,9 +291,16 @@ void ntlm_construct_challenge_target_info(NTLM_CONTEXT* context)
 	UNICODE_STRING DnsDomainName;
 	UNICODE_STRING DnsComputerName;
 
+	NbDomainName.Buffer = NULL;
 	ntlm_get_target_computer_name(&NbDomainName, ComputerNameNetBIOS);
+
+	NbComputerName.Buffer = NULL;
 	ntlm_get_target_computer_name(&NbComputerName, ComputerNameNetBIOS);
+
+	DnsDomainName.Buffer = NULL;
 	ntlm_get_target_computer_name(&DnsDomainName, ComputerNameDnsDomain);
+
+	DnsComputerName.Buffer = NULL;
 	ntlm_get_target_computer_name(&DnsComputerName, ComputerNameDnsHostname);
 
 	AvPairsCount = 5;

--- a/winpr/libwinpr/sspi/sspi.c
+++ b/winpr/libwinpr/sspi/sspi.c
@@ -440,7 +440,7 @@ SecurityFunctionTableW* sspi_GetSecurityFunctionTableWByNameW(const SEC_WCHAR* N
 
 SecurityFunctionTableW* sspi_GetSecurityFunctionTableWByNameA(const SEC_CHAR* Name)
 {
-	SEC_WCHAR* NameW;
+	SEC_WCHAR* NameW = NULL;
 	SecurityFunctionTableW* table;
 
 	ConvertToUnicode(CP_UTF8, 0, Name, -1, &NameW, 0);


### PR DESCRIPTION
This patch ensure that lpWideCharStr is initialized by callers of
ConvertToUnicode
