### PR TITLE
login and synchronize fix

### DIFF
--- a/libfreerdp/core/fastpath.c
+++ b/libfreerdp/core/fastpath.c
@@ -221,8 +221,9 @@ static BOOL fastpath_recv_update(rdpFastPath* fastpath, BYTE updateCode, UINT32 
 
 		case FASTPATH_UPDATETYPE_SYNCHRONIZE:
 			if (!fastpath_recv_update_synchronize(fastpath, s))
-				return FALSE;
-			IFCALL(update->Synchronize, context);
+				printf("fastpath_recv_update_synchronize failure but we continue\n");				
+			else
+				IFCALL(update->Synchronize, context);			
 			break;
 
 		case FASTPATH_UPDATETYPE_SURFCMDS:

--- a/libfreerdp/crypto/ber.c
+++ b/libfreerdp/crypto/ber.c
@@ -40,7 +40,7 @@ BOOL ber_read_length(STREAM* s, int* length)
 
 		if (byte == 1)
 			stream_read_BYTE(s, *length);
-		if (byte == 2)
+		else if (byte == 2)
 			stream_read_UINT16_be(s, *length);
 		else
 			return FALSE;


### PR DESCRIPTION
This fix solves two problems:
- Authentication denied with TLS based authentication
- Empty synchronize that terminated the session.
