### PR TITLE
Wrong max socket value fix

### DIFF
--- a/libfreerdp/utils/tcp.c
+++ b/libfreerdp/utils/tcp.c
@@ -182,10 +182,14 @@ int freerdp_tcp_write(int sockfd, BYTE* data, int length)
 int freerdp_tcp_wait_read(int sockfd)
 {
 	fd_set fds;
-
+	if(sockfd<1)
+	{
+	    printf("Invalid socket to watch: %d\n",sockfd);
+	    return 0 ;	    
+	}
 	FD_ZERO(&fds);
 	FD_SET(sockfd, &fds);
-	select(1, &fds, NULL, NULL, NULL);
+	select(sockfd+1, &fds, NULL, NULL, NULL);
 
 	return 0;
 }
@@ -193,10 +197,15 @@ int freerdp_tcp_wait_read(int sockfd)
 int freerdp_tcp_wait_write(int sockfd)
 {
 	fd_set fds;
+	if(sockfd<1)
+	{
+	    printf("Invalid socket to watch: %d\n",sockfd);
+	    return 0;
+	}
 
 	FD_ZERO(&fds);
 	FD_SET(sockfd, &fds);
-	select(1, NULL, &fds, NULL, NULL);
+	select(sockfd+1, NULL, &fds, NULL, NULL);
 
 	return 0;
 }


### PR DESCRIPTION
The max socket value must be set to the highest socket value + 1 according to man page for select(). ( nfds  is the highest-numbered file descriptor in any of the three sets, plus 1.)
