### PR TITLE
utils/debug: renamed DEBUG to DEBUG_MSG

### DIFF
--- a/client/X11/xfreerdp.c
+++ b/client/X11/xfreerdp.c
@@ -665,7 +665,7 @@ UINT32 xf_detect_cpu()
 
 	if (edx & (1<<26)) 
 	{
-		DEBUG("SSE2 detected");
+		DEBUG_MSG("SSE2 detected");
 		cpu_opt |= CPU_SSE2;
 	}
 

--- a/include/freerdp/utils/debug.h
+++ b/include/freerdp/utils/debug.h
@@ -28,9 +28,9 @@
 #define DEBUG_WARN(fmt, ...) DEBUG_PRINT("Warning %s (%d): ", fmt, ## __VA_ARGS__)
 
 #ifdef WITH_DEBUG
-#define DEBUG(fmt, ...)	DEBUG_PRINT("DBG %s (%d): ", fmt, ## __VA_ARGS__)
+#define DEBUG_MSG(fmt, ...)	DEBUG_PRINT("DBG %s (%d): ", fmt, ## __VA_ARGS__)
 #else
-#define DEBUG(fmt, ...) DEBUG_NULL(fmt, ## __VA_ARGS__)
+#define DEBUG_MSG(fmt, ...) DEBUG_NULL(fmt, ## __VA_ARGS__)
 #endif
 
 #endif /* FREERDP_UTILS_DEBUG_H */

--- a/libfreerdp/utils/msusb.c
+++ b/libfreerdp/utils/msusb.c
@@ -285,7 +285,7 @@ MSUSB_CONFIG_DESCRIPTOR* msusb_msconfig_read(BYTE* data, UINT32 data_size, UINT3
 
 	if (lenConfiguration != 0x9 || typeConfiguration != 0x2)
 	{
-		DEBUG("%s: len and type must be 0x9 and 0x2 , but it is 0x%x and 0x%x", 
+		DEBUG_MSG("%s: len and type must be 0x9 and 0x2 , but it is 0x%x and 0x%x", 
 			lenConfiguration, typeConfiguration);
 	}
 


### PR DESCRIPTION
DEBUG definition is often used to enable debugging in libraries or frameworks and it's also often default in toolchains to have -DDEBUG set if compiling a debug build.
To avoid redefinition errors/warning DEBUG shouldn't be defined in freerdp.
This pull request renames DEBUG to DEBUG_MSG.
