### PR TITLE
Allow to read ber integers with fancy size when the result is ignored

### DIFF
--- a/libfreerdp/crypto/ber.c
+++ b/libfreerdp/crypto/ber.c
@@ -373,10 +373,7 @@ BOOL ber_read_integer(STREAM* s, UINT32* value)
 	if (value == NULL)
 	{
 		// even if we don't care the integer value, check the announced size
-		if(length < 1 || length > 8)
-			return FALSE;
-		stream_seek(s, length);
-		return TRUE;
+		return stream_skip(s, length);
 	}
 
 	if (length == 1)
@@ -405,6 +402,7 @@ BOOL ber_read_integer(STREAM* s, UINT32* value)
 	}
 	else
 	{
+		printf("%s: should implement reading an integer with length=%d\n", __FUNCTION__, length);
 		return FALSE;
 	}
 


### PR DESCRIPTION
The serial number of certificate is a BER integer, but some people reported me that it can have a length of 19. This fix relaxes checks when reading a BER integer.
