### PR TITLE
winpr/pool: zero thread pool on creation

### DIFF
--- a/winpr/libwinpr/pool/pool.c
+++ b/winpr/libwinpr/pool/pool.c
@@ -154,7 +154,7 @@ PTP_POOL CreateThreadpool(PVOID reserved)
 	if (pCreateThreadpool)
 		return pCreateThreadpool(reserved);
 #else
-	pool = (PTP_POOL) malloc(sizeof(TP_POOL));
+	pool = (PTP_POOL) calloc(1, sizeof(TP_POOL));
 
 	if (pool)
 		InitializeThreadpool(pool);


### PR DESCRIPTION
If not set to zero, the thread pool might not be initialized properly and application segfaults on access (initialization code checks for !pool->Threads).
