### PR TITLE
added missing defined() in #elif

### DIFF
--- a/libfreerdp/locale/timezone.c
+++ b/libfreerdp/locale/timezone.c
@@ -1665,7 +1665,7 @@ void freerdp_time_zone_detect(TIME_ZONE_INFO* clientTimeZone)
 		clientTimeZone->bias = (UINT32) (local_time->tm_gmtoff / 60);
 	else
 		clientTimeZone->bias = (UINT32) (1440 + (INT32) (local_time->tm_gmtoff / 60));
-#elif sun
+#elif defined(sun)
 	if (local_time->tm_isdst > 0)
 		clientTimeZone->bias = (UINT32) (altzone / 3600);
 	else

--- a/libfreerdp/primitives/prim_colors.c
+++ b/libfreerdp/primitives/prim_colors.c
@@ -26,7 +26,7 @@
 #include <freerdp/primitives.h>
 #ifdef WITH_SSE2
 #include <emmintrin.h>
-#elif WITH_NEON
+#elif defined(WITH_NEON)
 #include <arm_neon.h>
 #endif /* WITH_SSE2 else WITH_NEON */
 #include "prim_internal.h"

--- a/libfreerdp/utils/file.c
+++ b/libfreerdp/utils/file.c
@@ -54,7 +54,7 @@
 
 #ifdef _WIN32
 #define SHARED_LIB_SUFFIX	".dll"
-#elif __APPLE__
+#elif defined(__APPLE__)
 #define SHARED_LIB_SUFFIX	".dylib"
 #else
 #define SHARED_LIB_SUFFIX	".so"

--- a/libfreerdp/utils/passphrase.c
+++ b/libfreerdp/utils/passphrase.c
@@ -32,7 +32,7 @@ char* freerdp_passphrase_read(const char* prompt, char* buf, size_t bufsiz, int 
 	return NULL;
 }
 
-#elif (!ANDROID)
+#elif !defined(ANDROID)
 
 #include <fcntl.h>
 #include <stdio.h>

--- a/libfreerdp/utils/signal.c
+++ b/libfreerdp/utils/signal.c
@@ -37,7 +37,7 @@ int freerdp_handle_signals(void)
 	return -1;
 }
 
-#elif (!ANDROID)
+#elif !defined(ANDROID)
 
 volatile sig_atomic_t terminal_needs_reset = 0;
 int terminal_fildes = 0;

--- a/winpr/libwinpr/path/path.c
+++ b/winpr/libwinpr/path/path.c
@@ -57,7 +57,7 @@
 
 #ifdef _WIN32
 #define SHARED_LIBRARY_EXT		SHARED_LIBRARY_EXT_DLL
-#elif __APPLE__
+#elif defined(__APPLE__)
 #define SHARED_LIBRARY_EXT		SHARED_LIBRARY_EXT_DYLIB
 #else
 #define SHARED_LIBRARY_EXT		SHARED_LIBRARY_EXT_SO
@@ -881,7 +881,7 @@ PCSTR PathGetSharedLibraryExtensionA(unsigned long dwFlags)
 	{
 #ifdef _WIN32
 		return SharedLibraryExtensionDotDllA;
-#elif __APPLE__
+#elif defined(__APPLE__)
 		if (dwFlags & PATH_SHARED_LIB_EXT_APPLE_SO)
 			return SharedLibraryExtensionDotSoA;
 		else
@@ -894,7 +894,7 @@ PCSTR PathGetSharedLibraryExtensionA(unsigned long dwFlags)
 	{
 #ifdef _WIN32
 		return SharedLibraryExtensionDllA;
-#elif __APPLE__
+#elif defined(__APPLE__)
 		if (dwFlags & PATH_SHARED_LIB_EXT_APPLE_SO)
 			return SharedLibraryExtensionSoA;
 		else
@@ -939,7 +939,7 @@ PCWSTR PathGetSharedLibraryExtensionW(unsigned long dwFlags)
 	{
 #ifdef _WIN32
 		return SharedLibraryExtensionDotDllW;
-#elif __APPLE__
+#elif defined(__APPLE__)
 		if (dwFlags & PATH_SHARED_LIB_EXT_APPLE_SO)
 			return SharedLibraryExtensionDotSoW;
 		else
@@ -952,7 +952,7 @@ PCWSTR PathGetSharedLibraryExtensionW(unsigned long dwFlags)
 	{
 #ifdef _WIN32
 		return SharedLibraryExtensionDllW;
-#elif __APPLE__
+#elif defined(__APPLE__)
 		if (dwFlags & PATH_SHARED_LIB_EXT_APPLE_SO)
 			return SharedLibraryExtensionSoW;
 		else


### PR DESCRIPTION
gcc >= 4.4 requires a condition in #elif.

We often had something like: 
# ifdef COND_X
# elif  COND_Y
# endif

In most cases the #elif should be #elif defined(COND_Y) to check if COND_Y is defined.
