### PR TITLE
compat: fix plugin load for plugins without data argument

### DIFF
--- a/client/common/compatibility.c
+++ b/client/common/compatibility.c
@@ -269,6 +269,11 @@ int freerdp_client_old_command_line_pre_filter(void* context, int index, int arg
 				index++;
 				i++;
 			}
+		} else {
+				if (settings->instance)
+				{
+					freerdp_client_old_process_plugin(settings, args);
+				}
 		}
 
 		return (index - old_index);


### PR DESCRIPTION
This is required for cliprdr for example.
