### PR TITLE
server/Sample: fix color depth negotiation

### DIFF
--- a/server/Sample/sfreerdp.c
+++ b/server/Sample/sfreerdp.c
@@ -655,6 +655,7 @@ static void* test_peer_mainloop(void* arg)
 	client->settings->PrivateKeyFile = _strdup("server.key");
 	client->settings->NlaSecurity = FALSE;
 	client->settings->RemoteFxCodec = TRUE;
+	client->settings->ColorDepth = 32;
 	client->settings->SuppressOutput = TRUE;
 	client->settings->RefreshRect = TRUE;
 


### PR DESCRIPTION
Fixes server side color negotiation for the Sample server.
Related to d8afffd3a801174a8948e72f55ce0a7bca4510ff
