### PR TITLE
Fix out of bounds memory access with /printer:foo

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -290,7 +290,7 @@ int freerdp_client_add_device_channel(rdpSettings* settings, int count, char** p
 		printer->Type = RDPDR_DTYP_PRINT;
 		printer->Name = _strdup(params[1]);
 
-		if (params[2])
+		if (count > 2)
 			printer->DriverName = _strdup(params[2]);
 
 		freerdp_device_collection_add(settings, (RDPDR_DEVICE*) printer);


### PR DESCRIPTION
Printer redirection command line parser was checking the wrong way if
a printer driver name was specified, causing the to segfault if no driver
name was given.
