### PR TITLE
Fixed keyboard_x11.c and keymaps to have proper keycodes for windows keys on OS X

### DIFF
--- a/keymaps/macosx
+++ b/keymaps/macosx
@@ -58,11 +58,11 @@ keyboard "macosx"
 	VK_OEM_2	<52>
 	VK_SPACE	<57>
         VK_LWIN         <63>
-        VK_RWIN         <69>
+        VK_RWIN         <71>
 	VK_LCONTROL	<67>
 	VK_LMENU	<66>
 	VK_LSHIFT	<64>
-	VK_RMENU	<71>
+	VK_RMENU	<69>
 	VK_RSHIFT	<68>
 	VK_F1		<130>
 	VK_F2		<128>

--- a/libfreerdp/locale/keyboard_x11.c
+++ b/libfreerdp/locale/keyboard_x11.c
@@ -283,9 +283,9 @@ const UINT32 KEYCODE_TO_VKCODE_MACOSX[256] =
 	VK_LMENU, /* 66 */
 	VK_LCONTROL, /* 67 */
 	VK_RSHIFT, /* 68 */
-	0, /* 69 */
+	VK_RMENU, /* 69 */
 	0, /* 70 */
-	VK_RMENU, /* 71 */
+	VK_RWIN, /* 71 */
 	0, /* 72 */
 	VK_DECIMAL, /* 73 */
 	0, /* 74 */


### PR DESCRIPTION
VK_LWIN = 0x3f/63
VK_RWIN = 0x47/71
VK_RMENU = 0x45/69
