### PR TITLE
Issue #847: protocol deadlock in NLA 

### DIFF
--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -1104,28 +1104,28 @@ void credssp_send(rdpCredssp* credssp)
 	/* [1] negoTokens (NegoData) */
 	if (nego_tokens_length > 0)
 	{
-		length = der_get_content_length(nego_tokens_length);
-		length -= der_write_contextual_tag(s, 1, length, TRUE); /* NegoData */
-		length -= der_write_sequence_tag(s, length); /* SEQUENCE OF NegoDataItem */
-		length -= der_write_sequence_tag(s, length); /* NegoDataItem */
-		length -= der_write_contextual_tag(s, 0, length, TRUE); /* [0] negoToken */
-		der_write_octet_string(s, (BYTE*) credssp->negoToken.pvBuffer, length); /* OCTET STRING */
+		length = nego_tokens_length;
+		length -= der_write_contextual_tag(s, 1, der_get_content_length(length), TRUE); /* NegoData */
+		length -= der_write_sequence_tag(s, der_get_content_length(length)); /* SEQUENCE OF NegoDataItem */
+		length -= der_write_sequence_tag(s, der_get_content_length(length)); /* NegoDataItem */
+		length -= der_write_contextual_tag(s, 0, der_get_content_length(length), TRUE); /* [0] negoToken */
+		der_write_octet_string(s, (BYTE*) credssp->negoToken.pvBuffer, credssp->negoToken.cbBuffer); /* OCTET STRING */
 	}
 
 	/* [2] authInfo (OCTET STRING) */
 	if (auth_info_length > 0)
 	{
-		length = ber_get_content_length(auth_info_length);
-		length -= ber_write_contextual_tag(s, 2, length, TRUE);
+		length = auth_info_length;
+		length -= ber_write_contextual_tag(s, 2, ber_get_content_length(length), TRUE);
 		ber_write_octet_string(s, credssp->authInfo.pvBuffer, credssp->authInfo.cbBuffer);
 	}
 
 	/* [3] pubKeyAuth (OCTET STRING) */
 	if (pub_key_auth_length > 0)
 	{
-		length = ber_get_content_length(pub_key_auth_length);
-		length -= ber_write_contextual_tag(s, 3, length, TRUE);
-		ber_write_octet_string(s, credssp->pubKeyAuth.pvBuffer, length);
+		length = pub_key_auth_length;
+		length -= ber_write_contextual_tag(s, 3, ber_get_content_length(length), TRUE);
+		ber_write_octet_string(s, credssp->pubKeyAuth.pvBuffer, credssp->pubKeyAuth.cbBuffer);
 	}
 
 	transport_write(credssp->transport, s);

--- a/libfreerdp/crypto/ber.c
+++ b/libfreerdp/crypto/ber.c
@@ -84,7 +84,7 @@ int _ber_skip_length(int length)
 
 int ber_get_content_length(int length)
 {
-	if (length - 1 > 0x7F)
+	if (length > 0x81)
 		return length - 4;
 	else
 		return length - 2;

--- a/libfreerdp/crypto/der.c
+++ b/libfreerdp/crypto/der.c
@@ -56,9 +56,9 @@ int der_write_length(STREAM* s, int length)
 
 int der_get_content_length(int length)
 {
-	if (length > 0x7F && length <= 0xFF)
+	if (length > 0x81 && length <= 0x102)
 		return length - 3;
-	else if (length > 0xFF)
+	else if (length > 0x102)
 		return length - 4;
 	else
 		return length - 2;


### PR DESCRIPTION
fix ber_get_content_length and der_get_content_length to work for values
around 0x80 and 0x100
Fix nego_token, auth_info and pub_key_auth content length calculation in
credssp_send to fix a lockup in NLA protocol.
