### PR TITLE
set CMAKE_COMPILER_ID to GNU in iOS toolchain

### DIFF
--- a/cmake/iOSToolchain.cmake
+++ b/cmake/iOSToolchain.cmake
@@ -46,8 +46,8 @@ endif (CMAKE_UNAME)
 # Force the compilers to gcc for iOS
 if(NOT CMAKE_C_COMPILER)
 	include (CMakeForceCompiler)
-	CMAKE_FORCE_C_COMPILER (gcc gcc)
-	CMAKE_FORCE_CXX_COMPILER (g++ g++)
+	CMAKE_FORCE_C_COMPILER (gcc GNU)
+	CMAKE_FORCE_CXX_COMPILER (g++ GNU)
 endif()
 
 # Skip the platform compiler checks for cross compiling


### PR DESCRIPTION
The current ios toolchain is GNU based but the iOSToolchain.cmake
set the CMAKE_COMPILER_ID to gcc which isn't known by cmake.
