### PR TITLE
Allow fullscreen toggle per default

### DIFF
--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -238,6 +238,7 @@ rdpSettings* freerdp_settings_new(void* instance)
 		settings->SaltedChecksum = TRUE;
 		settings->ServerPort = 3389;
 		settings->DesktopResize = TRUE;
+		settings->ToggleFullscreen = TRUE;
 
 		settings->PerformanceFlags =
 				PERF_DISABLE_FULLWINDOWDRAG |


### PR DESCRIPTION
The recently added option toggle-fullscreen disabled fullscreen toggle per default. This enables fullscreen toggle again. It can be disabled with -toggle-fullscreen.
