### PR TITLE
Fixed command line with .rdp file

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -986,7 +986,7 @@ int freerdp_client_parse_command_line_arguments(int argc, char** argv, rdpSettin
 
 	arg = CommandLineFindArgumentA(args, "v");
 
-	if (!(arg->Flags & COMMAND_LINE_VALUE_PRESENT))
+	if (!settings->ConnectionFile && !(arg->Flags & COMMAND_LINE_VALUE_PRESENT))
 	{
 		printf("error: server hostname was not specified with /v:<server>[:port]\n");
 		return COMMAND_LINE_ERROR_MISSING_ARGUMENT;

--- a/client/common/compatibility.c
+++ b/client/common/compatibility.c
@@ -186,7 +186,10 @@ int freerdp_client_old_command_line_pre_filter(void* context, int index, int arg
 			{
 				return -1;
 			}
-
+			if (_stricmp(&(argv[index])[strlen(argv[index])- 4], ".rdp") == 0)
+			{
+				return -1;
+			}
 			freerdp_client_old_parse_hostname((char*) argv[index], &settings->ServerHostname, &settings->ServerPort);
 		}
 		else


### PR DESCRIPTION
Now clients can be called with a .rdp file again like xfreerdp test.rdp
