### PR TITLE
add wm-class option

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -288,7 +288,10 @@ xfWindow* xf_CreateDesktopWindow(xfInfo* xfi, char* name, int width, int height,
 		if (class_hints != NULL)
 		{
 			class_hints->res_name = "xfreerdp";
-			class_hints->res_class = "xfreerdp";
+			if (xfi->instance->settings->wm_class != NULL)
+				class_hints->res_class = xfi->instance->settings->wm_class;
+			else 
+				class_hints->res_class = "xfreerdp";
 			XSetClassHint(xfi->display, window->handle, class_hints);
 			XFree(class_hints);
 		}
@@ -423,14 +426,19 @@ xfWindow* xf_CreateWindow(xfInfo* xfi, rdpWindow* wnd, int x, int y, int width, 
 
 	if (class_hints != NULL)
 	{
-		char* class;
-		class = xmalloc(sizeof(rail_window_class));
-		snprintf(class, sizeof(rail_window_class), "RAIL:%08X", id);
+                char* class = NULL;
+                if (xfi->instance->settings->wm_class != NULL)
+                        class_hints->res_class = xfi->instance->settings->wm_class;
+                else {
+                        class = malloc(sizeof(rail_window_class));
+                        snprintf(class, sizeof(rail_window_class), "RAIL:%08X", id);
+                        class_hints->res_class = class;
+                }
 		class_hints->res_name = "RAIL";
-		class_hints->res_class = class;
 		XSetClassHint(xfi->display, window->handle, class_hints);
 		XFree(class_hints);
-		xfree(class);
+                if (class)
+                        free(class);
 	}
 
 	XSetWMProtocols(xfi->display, window->handle, &(xfi->WM_DELETE_WINDOW), 1);

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -291,7 +291,8 @@ struct rdp_settings
 	boolean mouse_motion; /* 86 */
 	char* window_title; /* 87 */
 	uint64 parent_window_xid; /* 88 */
-	uint32 paddingD[112 - 89]; /* 89 */
+	char* wm_class; /* 89 */
+	uint32 paddingD[112 - 90]; /* 90 */
 
 	/* Internal Parameters */
 	char* home_path; /* 112 */

--- a/libfreerdp-utils/args.c
+++ b/libfreerdp-utils/args.c
@@ -133,6 +133,7 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 				"  --ignore-certificate: ignore verification of logon certificate\n"
 				"  --sec: force protocol security (rdp, tls or nla)\n"
 				"  --secure-checksum: use salted checksums with Standard RDP encryption\n"
+				"  --wm-class: set window WM_CLASS hint\n"
 				"  --version: print version information\n"
 				"\n", argv[0]);
 			return FREERDP_ARGS_PARSE_HELP; //TODO: What is the correct return
@@ -665,6 +666,16 @@ int freerdp_parse_args(rdpSettings* settings, int argc, char** argv,
 		{
 			settings->secure_checksum = true;
 		}
+ 		else if (strcmp("--wm-class", argv[index]) == 0)
+ 		{
+ 			index++;
+ 			if (index == argc)
+ 			{
+ 				printf("missing WM_CLASS value\n");
+ 				return -1;
+ 			}
+ 			settings->wm_class = xstrdup(argv[index]);
+ 		}
 		else if (strcmp("--version", argv[index]) == 0)
 		{
 			if (strlen(FREERDP_VERSION_SUFFIX))


### PR DESCRIPTION
This change adds support for a --wm-class option that sets the corresponding property on the X11 window. This helps application launchers, like the Unity launcher, keep track of a remote application and distinguish 2 xfreerdp instances from each other
