### PR TITLE
libfreerdp-crypto: add missing link libraries 

### DIFF
--- a/libfreerdp/crypto/CMakeLists.txt
+++ b/libfreerdp/crypto/CMakeLists.txt
@@ -43,7 +43,7 @@ set(${MODULE_PREFIX}_LIBS
 if(MONOLITHIC_BUILD)
 	set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} winpr)
 else()
-	set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} winpr-sspi winpr-library)
+	set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} winpr-sspi winpr-library winpr-path winpr-file)
 endif()
 
 if(WIN32)


### PR DESCRIPTION
missing link libraries fixes build
