### PR TITLE
core/capabilities: Enable other codecs when RemoteFX is used

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -2506,7 +2506,7 @@ void rdp_write_rfx_client_capability_container(wStream* s, rdpSettings* settings
 	UINT32 captureFlags;
 	BYTE codecMode;
 
-	captureFlags = settings->RemoteFxOnly ? CARDP_CAPS_CAPTURE_NON_CAC : 0;
+	captureFlags = settings->RemoteFxOnly ? 0 : CARDP_CAPS_CAPTURE_NON_CAC;
 	codecMode = settings->RemoteFxCodecMode;
 
 	stream_write_UINT16(s, 49); /* codecPropertiesLength */


### PR DESCRIPTION
CARDP_CAPS_CAPTURE_NON_CAC tells the server to send other codecs as well if RemoteFX is used. This should be on per default and only be disabled if RemoteFxOnly is set (eg when capturing a RemoteFX session).
