### PR TITLE
Unbreak WITH_DEBUG_X11_LOCAL_MOVESIZE without WITH_DEBUG_X11

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -32,7 +32,7 @@
 
 #include "xf_event.h"
 
-#ifdef WITH_DEBUG_X11
+#if defined(WITH_DEBUG_X11) || defined(WITH_DEBUG_X11_LOCAL_MOVESIZE)
 static const char* const X11_EVENT_STRINGS[] =
 {
 	"", "",


### PR DESCRIPTION
WITH_DEBUG_X11_LOCAL_MOVESIZE is broken when building with WITH_DEBUG_X11=OFF:

```
/home/ch/Source/FreeRDP/client/X11/xf_event.c: In function `xf_event_suppress_events':
/home/ch/Source/FreeRDP/client/X11/xf_event.c:838:6: error: `X11_EVENT_STRINGS' undeclared (first use in this function)
/home/ch/Source/FreeRDP/client/X11/xf_event.c:838:6: note: each undeclared identifier is reported only once for each function it appears in
make[2]: *** [client/X11/CMakeFiles/xfreerdp.dir/xf_event.c.o] Error 1
make[2]: Leaving directory `/home/ch/Source/FreeRDP/obj-x86_64-linux-gnu'
make[1]: *** [client/X11/CMakeFiles/xfreerdp.dir/all] Error 2
make[1]: Leaving directory `/home/ch/Source/FreeRDP/obj-x86_64-linux-gnu'
make: *** [all] Error 2
```

This commit fixes it.
