### PR TITLE
Further fix to issue 574\685 after change to daylight savings time.

### DIFF
--- a/libfreerdp/locale/timezone.c
+++ b/libfreerdp/locale/timezone.c
@@ -1640,7 +1640,7 @@ TIME_ZONE_RULE_ENTRY* freerdp_get_current_time_zone_rule(TIME_ZONE_RULE_ENTRY* r
 
 	for (i = 0; i < (int) count; i++)
 	{
-		if ((rules[i].TicksStart <= windows_time) && (windows_time >= rules[i].TicksEnd))
+		if ((rules[i].TicksStart >= windows_time) && (windows_time >= rules[i].TicksEnd))
 		{
 			/*fprintf(stderr, "Got rule %d from table at %p with count %u\n", i, rules, count);*/
 			return &rules[i];
@@ -1657,14 +1657,14 @@ void freerdp_time_zone_detect(TIME_ZONE_INFO* clientTimeZone)
 	TIME_ZONE_ENTRY* tz;
 	struct tm* local_time;
 
+	clientTimeZone->standardBias = 0;
+	
 	time(&t);
 	local_time = localtime(&t);
 
 #ifdef HAVE_TM_GMTOFF
-	if (local_time->tm_gmtoff >= 0)
-		clientTimeZone->bias = (UINT32) (local_time->tm_gmtoff / 60);
-	else
-		clientTimeZone->bias = (UINT32) (1440 + (INT32) (local_time->tm_gmtoff / 60));
+    clientTimeZone->bias = timezone / 60;
+	DEBUG_TIMEZONE("tzname[std]: %s, tzname[dst]: %s, timezone: %ld, Daylight: %d", tzname[0], tzname[1], timezone, daylight);
 #elif defined(sun)
 	if (local_time->tm_isdst > 0)
 		clientTimeZone->bias = (UINT32) (altzone / 3600);
@@ -1673,19 +1673,6 @@ void freerdp_time_zone_detect(TIME_ZONE_INFO* clientTimeZone)
 #else
 	clientTimeZone->bias = 0;
 #endif
-	if (local_time->tm_isdst > 0)
-	{
-		clientTimeZone->standardBias = clientTimeZone->bias - 60;
-		clientTimeZone->daylightBias = clientTimeZone->bias;
-	}
-	else
-	{
-		clientTimeZone->standardBias = clientTimeZone->bias;
-		clientTimeZone->daylightBias = clientTimeZone->bias + 60;
-	}
-	DEBUG_TIMEZONE("Bias: %d, StandardBias: %d, DaylightBias: %d",
-		clientTimeZone->bias, clientTimeZone->standardBias,
-		clientTimeZone->daylightBias);
 
 	tz = freerdp_detect_windows_time_zone(clientTimeZone->bias);
 
@@ -1694,8 +1681,7 @@ void freerdp_time_zone_detect(TIME_ZONE_INFO* clientTimeZone)
 		DEBUG_TIMEZONE("tz: Id='%s' Bias=%d DST=%d dn='%s' sn='%s' dln='%s'",
 			tz->Id, tz->Bias, tz->SupportsDST, tz->DisplayName,
 			tz->StandardName, tz->DaylightName);
-		/* Not printed: RuleTable, RuleTableCount */
-		clientTimeZone->bias = tz->Bias;
+
 		sprintf(clientTimeZone->standardName, "%s", tz->StandardName);
 		sprintf(clientTimeZone->daylightName, "%s", tz->DaylightName);
 
@@ -1704,11 +1690,9 @@ void freerdp_time_zone_detect(TIME_ZONE_INFO* clientTimeZone)
 			TIME_ZONE_RULE_ENTRY* rule;
 			rule = freerdp_get_current_time_zone_rule(tz->RuleTable, tz->RuleTableCount);
 
-			/* issue #574 -- temporarily disabled this block as it seems to be setting the wrong time
 			if (rule != NULL)
 			{
-				clientTimeZone->standardBias = 0;
-				clientTimeZone->daylightBias = rule->DaylightDelta;
+				clientTimeZone->daylightBias = -rule->DaylightDelta;
 
 				clientTimeZone->standardDate.wYear = rule->StandardDate.wYear;
 				clientTimeZone->standardDate.wMonth = rule->StandardDate.wMonth;
@@ -1728,9 +1712,7 @@ void freerdp_time_zone_detect(TIME_ZONE_INFO* clientTimeZone)
 				clientTimeZone->daylightDate.wSecond = rule->DaylightDate.wSecond;
 				clientTimeZone->daylightDate.wMilliseconds = rule->DaylightDate.wMilliseconds;
 			}
-			*/
 		}
-
 		free(tz);
 	}
 	else

--- a/libfreerdp/utils/time.c
+++ b/libfreerdp/utils/time.c
@@ -43,7 +43,7 @@ UINT64 freerdp_windows_gmtime()
 UINT64 freerdp_get_windows_time_from_unix_time(time_t unix_time)
 {
 	UINT64 windows_time;
-	windows_time = (unix_time * 10000000) + 621355968000000000ULL;
+	windows_time = ((UINT64)unix_time * 10000000) + 621355968000000000ULL;
 	return windows_time;
 }
 


### PR DESCRIPTION
There appear to be some additional problems with the impact of daylight savings time kicking in. Calculations of BIAS, Standard BIAS & Daylight BIAS are wrong when compared to values dispatched from mstsc.

This is showing up with Outlook 2010 meeting appointments, for example select America\Vancouver, appointments, once accepted get assigned an hour early.

I have also applied a fix to correctly send the Timezone information currently commented out of code referencing this issue number in libfreerdp_locale/timezone.c function freerdp_time_zone_detect()
