### PR TITLE
libfreerdp-core: Limit multifrag max size to 0xFFFF

### DIFF
--- a/docs/README.ios
+++ b/docs/README.ios
@@ -52,6 +52,14 @@ If you want to specify an output directory add CONFIGURATION_BUILD_DIR=<output-p
 
 * If using XCode choose "Open Other" from the welcome screen, browse to the FreeRDP root directory and select FreeRDP.xcodeproj.
 
+* If you switch between platforms (OS and SIMULATOR) please remove CMakeCache.txt and CMakeFiles/ before calling cmake again.
+  Otherwise build errors might occur (this seems to be a bug with cmake or the cmake scripts). To switch between platforms do:
+
+  rm CMakeCache.txt
+  rm -rf CMakeFiles/
+
+  before you run a new cmake command with the desired platform.
+
 
 cmake variables
 ===============

--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -2195,8 +2195,6 @@ BOOL rdp_read_multifragment_update_capability_set(wStream* s, UINT16 length, rdp
 		return FALSE;
 
 	stream_read_UINT32(s, multifragMaxRequestSize); /* MaxRequestSize (4 bytes) */
-	if (settings->MultifragMaxRequestSize < multifragMaxRequestSize)
-		settings->MultifragMaxRequestSize = multifragMaxRequestSize;
 
 	return TRUE;
 }

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -375,7 +375,7 @@ rdpSettings* freerdp_settings_new(void* instance)
 
 		settings->VirtualChannelChunkSize = CHANNEL_CHUNK_LENGTH;
 
-		settings->MultifragMaxRequestSize = 0x200000;
+		settings->MultifragMaxRequestSize = 0xFFFF;
 
 		settings->GatewayUseSameCredentials = TRUE;
 


### PR DESCRIPTION
The next version of MS-RDPBCGR will limit this value to a maximum of 0xFFFF (just as mstsc does currently). Fixes #1182 
