### PR TITLE
Handle Drdynvc Version 3

### DIFF
--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -182,7 +182,10 @@ static int drdynvc_process_capability_request(drdynvcPlugin* drdynvc, int Sp, in
 	stream_seek(s, 1); /* pad */
 	stream_read_UINT16(s, drdynvc->version);
 
-	if (drdynvc->version == 2)
+	/* RDP8 servers offer version 3, though Microsoft forgot to document it
+	 * in their early documents.  It behaves the same as version 2.
+	 */
+	if ((drdynvc->version == 2) || (drdynvc->version == 3))
 	{
 		stream_read_UINT16(s, drdynvc->PriorityCharge0);
 		stream_read_UINT16(s, drdynvc->PriorityCharge1);


### PR DESCRIPTION
When you connect to an RDP8 server, Microsoft's server now says it's using drdynvc version 3 rather than version 2.  This was not documented in the MS-RDP\* documents (though a correction is pending), but Microsoft assures me that version 3 was for an extension that never got completed and it should be parsed and handled the same way as version 2.
