### PR TITLE
Ber Encoding Issue

### DIFF
--- a/include/freerdp/crypto/ber.h
+++ b/include/freerdp/crypto/ber.h
@@ -54,10 +54,9 @@
 
 FREERDP_API BOOL ber_read_length(wStream* s, int* length);
 FREERDP_API int ber_write_length(wStream* s, int length);
-FREERDP_API int _ber_skip_length(int length);
-FREERDP_API int ber_get_content_length(int length);
+FREERDP_API int _ber_sizeof_length(int length);
 FREERDP_API BOOL ber_read_universal_tag(wStream* s, BYTE tag, BOOL pc);
-FREERDP_API void ber_write_universal_tag(wStream* s, BYTE tag, BOOL pc);
+FREERDP_API int ber_write_universal_tag(wStream* s, BYTE tag, BOOL pc);
 FREERDP_API BOOL ber_read_application_tag(wStream* s, BYTE tag, int* length);
 FREERDP_API void ber_write_application_tag(wStream* s, BYTE tag, int length);
 FREERDP_API BOOL ber_read_application_tag(wStream* s, BYTE tag, int* length);
@@ -65,21 +64,21 @@ FREERDP_API BOOL ber_read_enumerated(wStream* s, BYTE* enumerated, BYTE count);
 FREERDP_API void ber_write_enumerated(wStream* s, BYTE enumerated, BYTE count);
 FREERDP_API BOOL ber_read_contextual_tag(wStream* s, BYTE tag, int* length, BOOL pc);
 FREERDP_API int ber_write_contextual_tag(wStream* s, BYTE tag, int length, BOOL pc);
-FREERDP_API int ber_skip_contextual_tag(int length);
+FREERDP_API int ber_sizeof_contextual_tag(int length);
 FREERDP_API BOOL ber_read_sequence_tag(wStream* s, int* length);
 FREERDP_API int ber_write_sequence_tag(wStream* s, int length);
-FREERDP_API int ber_skip_sequence(int length);
-FREERDP_API int ber_skip_sequence_tag(int length);
+FREERDP_API int ber_sizeof_sequence(int length);
+FREERDP_API int ber_sizeof_sequence_tag(int length);
 FREERDP_API BOOL ber_read_bit_string(wStream* s, int* length, BYTE* padding);
-FREERDP_API void ber_write_octet_string(wStream* s, const BYTE* oct_str, int length);
+FREERDP_API int ber_write_octet_string(wStream* s, const BYTE* oct_str, int length);
 FREERDP_API BOOL ber_read_octet_string_tag(wStream* s, int* length);
 FREERDP_API int ber_write_octet_string_tag(wStream* s, int length);
-FREERDP_API int ber_skip_octet_string(int length);
+FREERDP_API int ber_sizeof_octet_string(int length);
 FREERDP_API BOOL ber_read_BOOL(wStream* s, BOOL* value);
 FREERDP_API void ber_write_BOOL(wStream* s, BOOL value);
 FREERDP_API BOOL ber_read_integer(wStream* s, UINT32* value);
 FREERDP_API int ber_write_integer(wStream* s, UINT32 value);
 FREERDP_API BOOL ber_read_integer_length(wStream* s, int* length);
-FREERDP_API int ber_skip_integer(UINT32 value);
+FREERDP_API int ber_sizeof_integer(UINT32 value);
 
 #endif /* FREERDP_CRYPTO_BER_H */

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -101,6 +101,9 @@ SECURITY_STATUS credssp_decrypt_public_key_echo(rdpCredssp* credssp);
 SECURITY_STATUS credssp_encrypt_ts_credentials(rdpCredssp* credssp);
 SECURITY_STATUS credssp_decrypt_ts_credentials(rdpCredssp* credssp);
 
+#define ber_sizeof_sequence_octet_string(length) ber_sizeof_contextual_tag(ber_sizeof_octet_string(length)) + ber_sizeof_octet_string(length)
+#define ber_write_sequence_octet_string(stream, context, value, length) ber_write_contextual_tag(stream, context, ber_sizeof_octet_string(length), TRUE) + ber_write_octet_string(stream, value, length)
+
 /**
  * Initialize NTLMSSP authentication module (client).
  * @param credssp
@@ -112,7 +115,7 @@ int credssp_ntlm_client_init(rdpCredssp* credssp)
 	int length;
 	freerdp* instance;
 	rdpSettings* settings;
-	
+
 	settings = credssp->settings;
 	instance = (freerdp*) settings->instance;
 
@@ -238,7 +241,7 @@ int credssp_client_authenticate(rdpCredssp* credssp)
 	ZeroMemory(&output_buffer, sizeof(SecBuffer));
 	ZeroMemory(&credssp->ContextSizes, sizeof(SecPkgContext_Sizes));
 
-	/* 
+	/*
 	 * from tspkg.dll: 0x00000132
 	 * ISC_REQ_MUTUAL_AUTH
 	 * ISC_REQ_CONFIDENTIALITY
@@ -456,7 +459,7 @@ int credssp_server_authenticate(rdpCredssp* credssp)
 	ZeroMemory(&output_buffer_desc, sizeof(SecBufferDesc));
 	ZeroMemory(&credssp->ContextSizes, sizeof(SecPkgContext_Sizes));
 
-	/* 
+	/*
 	 * from tspkg.dll: 0x00000112
 	 * ASC_REQ_MUTUAL_AUTH
 	 * ASC_REQ_CONFIDENTIALITY
@@ -783,24 +786,24 @@ SECURITY_STATUS credssp_decrypt_public_key_echo(rdpCredssp* credssp)
 	return SEC_E_OK;
 }
 
-int credssp_skip_ts_password_creds(rdpCredssp* credssp)
+int credssp_sizeof_ts_password_creds(rdpCredssp* credssp)
 {
 	int length;
 	int ts_password_creds_length = 0;
 
-	length = ber_skip_octet_string(credssp->identity.DomainLength * 2);
-	length += ber_skip_contextual_tag(length);
+	length = ber_sizeof_octet_string(credssp->identity.DomainLength * 2);
+	length += ber_sizeof_contextual_tag(length);
 	ts_password_creds_length += length;
 
-	length = ber_skip_octet_string(credssp->identity.UserLength * 2);
-	length += ber_skip_contextual_tag(length);
+	length = ber_sizeof_octet_string(credssp->identity.UserLength * 2);
+	length += ber_sizeof_contextual_tag(length);
 	ts_password_creds_length += length;
 
-	length = ber_skip_octet_string(credssp->identity.PasswordLength * 2);
-	length += ber_skip_contextual_tag(length);
+	length = ber_sizeof_octet_string(credssp->identity.PasswordLength * 2);
+	length += ber_sizeof_contextual_tag(length);
 	ts_password_creds_length += length;
 
-	length = ber_skip_sequence(ts_password_creds_length);
+	length = ber_sizeof_sequence(ts_password_creds_length);
 
 	return length;
 }
@@ -842,47 +845,41 @@ void credssp_read_ts_password_creds(rdpCredssp* credssp, wStream* s)
 	credssp->identity.Flags = SEC_WINNT_AUTH_IDENTITY_UNICODE;
 }
 
-void credssp_write_ts_password_creds(rdpCredssp* credssp, wStream* s)
+int credssp_write_ts_password_creds(rdpCredssp* credssp, wStream* s)
 {
-	int length;
+	int size = 0;
+	int innerSize = credssp_sizeof_ts_password_creds(credssp);
 
-	length = credssp_skip_ts_password_creds(credssp);
+	if (innerSize > Stream_GetRemainingLength(s))
+	{
+		printf("\033[91m[ ERROR ] Not enough space allocated for ts_password_creds\033[0m");
+	}
 
 	/* TSPasswordCreds (SEQUENCE) */
-	length = ber_get_content_length(length);
-	ber_write_sequence_tag(s, length);
+
+	size += ber_write_sequence_tag(s, innerSize);
 
 	/* [0] domainName (OCTET STRING) */
-	ber_write_contextual_tag(s, 0, credssp->identity.DomainLength * 2 + 2, TRUE);
-	ber_write_octet_string(s, (BYTE*) credssp->identity.Domain, credssp->identity.DomainLength * 2);
+	size += ber_write_sequence_octet_string(s, 0, (BYTE*) credssp->identity.Domain, credssp->identity.DomainLength * 2);
 
 	/* [1] userName (OCTET STRING) */
-	ber_write_contextual_tag(s, 1, credssp->identity.UserLength * 2 + 2, TRUE);
-	ber_write_octet_string(s, (BYTE*) credssp->identity.User, credssp->identity.UserLength * 2);
+	size += ber_write_sequence_octet_string(s, 1, (BYTE*) credssp->identity.User, credssp->identity.UserLength * 2);
 
 	/* [2] password (OCTET STRING) */
-	ber_write_contextual_tag(s, 2, credssp->identity.PasswordLength * 2 + 2, TRUE);
-	ber_write_octet_string(s, (BYTE*) credssp->identity.Password, credssp->identity.PasswordLength * 2);
+	size += ber_write_sequence_octet_string(s, 2, (BYTE*) credssp->identity.Password, credssp->identity.PasswordLength * 2);
+
+	return size;
 }
 
-int credssp_skip_ts_credentials(rdpCredssp* credssp)
+int credssp_sizeof_ts_credentials(rdpCredssp* credssp)
 {
-	int length;
-	int ts_password_creds_length;
-	int ts_credentials_length = 0;
+	int size = 0;
 
-	length = ber_skip_integer(0);
-	length += ber_skip_contextual_tag(length);
-	ts_credentials_length += length;
+	size += ber_sizeof_integer(1);
+	size += ber_sizeof_contextual_tag(ber_sizeof_integer(1));
+	size += ber_sizeof_sequence_octet_string(ber_sizeof_sequence(credssp_sizeof_ts_password_creds(credssp)));
 
-	ts_password_creds_length = credssp_skip_ts_password_creds(credssp);
-	length = ber_skip_octet_string(ts_password_creds_length);
-	length += ber_skip_contextual_tag(length);
-	ts_credentials_length += length;
-
-	length = ber_skip_sequence(ts_credentials_length);
-
-	return length;
+	return size;
 }
 
 void credssp_read_ts_credentials(rdpCredssp* credssp, PSecBuffer ts_credentials)
@@ -909,28 +906,27 @@ void credssp_read_ts_credentials(rdpCredssp* credssp, PSecBuffer ts_credentials)
 	Stream_Free(s, FALSE);
 }
 
-void credssp_write_ts_credentials(rdpCredssp* credssp, wStream* s)
+int credssp_write_ts_credentials(rdpCredssp* credssp, wStream* s)
 {
-	int length;
-	int ts_password_creds_length;
-
-	length = credssp_skip_ts_credentials(credssp);
-	ts_password_creds_length = credssp_skip_ts_password_creds(credssp);
+	int size = 0;
+	int innerSize = credssp_sizeof_ts_credentials(credssp);
 
 	/* TSCredentials (SEQUENCE) */
-	length = ber_get_content_length(length);
-	length -= ber_write_sequence_tag(s, length);
+	size += ber_write_sequence_tag(s, innerSize);
 
 	/* [0] credType (INTEGER) */
-	length -= ber_write_contextual_tag(s, 0, 3, TRUE);
-	length -= ber_write_integer(s, 1);
+	size += ber_write_contextual_tag(s, 0, ber_sizeof_integer(1), TRUE);
+	size += ber_write_integer(s, 1);
 
 	/* [1] credentials (OCTET STRING) */
-	length -= 1;
-	length -= ber_write_contextual_tag(s, 1, length, TRUE);
-	length -= ber_write_octet_string_tag(s, ts_password_creds_length);
 
-	credssp_write_ts_password_creds(credssp, s);
+	int passwordSize = ber_sizeof_sequence(credssp_sizeof_ts_password_creds(credssp));
+
+	size += ber_write_contextual_tag(s, 1, ber_sizeof_octet_string(passwordSize), TRUE);
+	size += ber_write_octet_string_tag(s, passwordSize);
+	size += credssp_write_ts_password_creds(credssp, s);
+
+	return size;
 }
 
 /**
@@ -943,7 +939,7 @@ void credssp_encode_ts_credentials(rdpCredssp* credssp)
 	wStream* s;
 	int length;
 
-	length = credssp_skip_ts_credentials(credssp);
+	length = ber_sizeof_sequence(credssp_sizeof_ts_credentials(credssp));
 	sspi_SecBufferAlloc(&credssp->ts_credentials, length);
 
 	s = Stream_New(credssp->ts_credentials.pvBuffer, length);
@@ -1029,41 +1025,40 @@ SECURITY_STATUS credssp_decrypt_ts_credentials(rdpCredssp* credssp)
 	return SEC_E_OK;
 }
 
-int credssp_skip_nego_token(int length)
+int credssp_sizeof_nego_token(int length)
 {
-	length = der_skip_octet_string(length);
-	length += der_skip_contextual_tag(length);
+	length = ber_sizeof_octet_string(length);
+	length += ber_sizeof_contextual_tag(length);
 	return length;
 }
 
-int credssp_skip_nego_tokens(int length)
+int credssp_sizeof_nego_tokens(int length)
 {
-	length = credssp_skip_nego_token(length);
-	length += der_skip_sequence_tag(length);
-	length += der_skip_sequence_tag(length);
-	length += der_skip_contextual_tag(length);
+	length = credssp_sizeof_nego_token(length);
+	length += ber_sizeof_sequence_tag(length);
+	length += ber_sizeof_sequence_tag(length);
+	length += ber_sizeof_contextual_tag(length);
 	return length;
 }
 
-int credssp_skip_pub_key_auth(int length)
+int credssp_sizeof_pub_key_auth(int length)
 {
-	length = ber_skip_octet_string(length);
-	length += ber_skip_contextual_tag(length);
+	length = ber_sizeof_octet_string(length);
+	length += ber_sizeof_contextual_tag(length);
 	return length;
 }
 
-int credssp_skip_auth_info(int length)
+int credssp_sizeof_auth_info(int length)
 {
-	length = ber_skip_octet_string(length);
-	length += ber_skip_contextual_tag(length);
+	length = ber_sizeof_octet_string(length);
+	length += ber_sizeof_contextual_tag(length);
 	return length;
 }
 
-int credssp_skip_ts_request(int length)
+int credssp_sizeof_ts_request(int length)
 {
-	length += ber_skip_integer(2);
-	length += ber_skip_contextual_tag(3);
-	length += der_skip_sequence_tag(length);
+	length += ber_sizeof_integer(2);
+	length += ber_sizeof_contextual_tag(3);
 	return length;
 }
 
@@ -1081,18 +1076,18 @@ void credssp_send(rdpCredssp* credssp)
 	int pub_key_auth_length;
 	int auth_info_length;
 
-	nego_tokens_length = (credssp->negoToken.cbBuffer > 0) ? credssp_skip_nego_tokens(credssp->negoToken.cbBuffer) : 0;
-	pub_key_auth_length = (credssp->pubKeyAuth.cbBuffer > 0) ? credssp_skip_pub_key_auth(credssp->pubKeyAuth.cbBuffer) : 0;
-	auth_info_length = (credssp->authInfo.cbBuffer > 0) ? credssp_skip_auth_info(credssp->authInfo.cbBuffer) : 0;
+	nego_tokens_length = (credssp->negoToken.cbBuffer > 0) ? credssp_sizeof_nego_tokens(credssp->negoToken.cbBuffer) : 0;
+	pub_key_auth_length = (credssp->pubKeyAuth.cbBuffer > 0) ? credssp_sizeof_pub_key_auth(credssp->pubKeyAuth.cbBuffer) : 0;
+	auth_info_length = (credssp->authInfo.cbBuffer > 0) ? credssp_sizeof_auth_info(credssp->authInfo.cbBuffer) : 0;
 
 	length = nego_tokens_length + pub_key_auth_length + auth_info_length;
-	ts_request_length = credssp_skip_ts_request(length);
 
-	s = Stream_New(NULL, ts_request_length);
+	ts_request_length = credssp_sizeof_ts_request(length);
+
+	s = Stream_New(NULL, ber_sizeof_sequence(ts_request_length));
 
 	/* TSRequest */
-	length = der_get_content_length(ts_request_length);
-	der_write_sequence_tag(s, length); /* SEQUENCE */
+	ber_write_sequence_tag(s, ts_request_length); /* SEQUENCE */
 
 	/* [0] version */
 	ber_write_contextual_tag(s, 0, 3, TRUE);
@@ -1102,27 +1097,25 @@ void credssp_send(rdpCredssp* credssp)
 	if (nego_tokens_length > 0)
 	{
 		length = nego_tokens_length;
-		length -= der_write_contextual_tag(s, 1, der_get_content_length(length), TRUE); /* NegoData */
-		length -= der_write_sequence_tag(s, der_get_content_length(length)); /* SEQUENCE OF NegoDataItem */
-		length -= der_write_sequence_tag(s, der_get_content_length(length)); /* NegoDataItem */
-		length -= der_write_contextual_tag(s, 0, der_get_content_length(length), TRUE); /* [0] negoToken */
-		der_write_octet_string(s, (BYTE*) credssp->negoToken.pvBuffer, credssp->negoToken.cbBuffer); /* OCTET STRING */
+
+		length -= ber_write_contextual_tag(s, 1, ber_sizeof_sequence(ber_sizeof_sequence(ber_sizeof_sequence_octet_string(credssp->negoToken.cbBuffer))), TRUE); /* NegoData */
+		length -= ber_write_sequence_tag(s, ber_sizeof_sequence(ber_sizeof_sequence_octet_string(credssp->negoToken.cbBuffer))); /* SEQUENCE OF NegoDataItem */
+		length -= ber_write_sequence_tag(s, ber_sizeof_sequence_octet_string(credssp->negoToken.cbBuffer)); /* NegoDataItem */
+		length -= ber_write_sequence_octet_string(s, 0, (BYTE*) credssp->negoToken.pvBuffer, credssp->negoToken.cbBuffer); /* OCTET STRING */
 	}
 
 	/* [2] authInfo (OCTET STRING) */
 	if (auth_info_length > 0)
 	{
 		length = auth_info_length;
-		length -= ber_write_contextual_tag(s, 2, ber_get_content_length(length), TRUE);
-		ber_write_octet_string(s, credssp->authInfo.pvBuffer, credssp->authInfo.cbBuffer);
+		length -= ber_write_sequence_octet_string(s, 2, credssp->authInfo.pvBuffer, credssp->authInfo.cbBuffer);
 	}
 
 	/* [3] pubKeyAuth (OCTET STRING) */
 	if (pub_key_auth_length > 0)
 	{
 		length = pub_key_auth_length;
-		length -= ber_write_contextual_tag(s, 3, ber_get_content_length(length), TRUE);
-		ber_write_octet_string(s, credssp->pubKeyAuth.pvBuffer, credssp->pubKeyAuth.cbBuffer);
+		length -= ber_write_sequence_octet_string(s, 3, credssp->pubKeyAuth.pvBuffer, credssp->pubKeyAuth.cbBuffer);
 	}
 
 	transport_write(credssp->transport, s);

--- a/libfreerdp/crypto/ber.c
+++ b/libfreerdp/crypto/ber.c
@@ -30,7 +30,7 @@ BOOL ber_read_length(wStream* s, int* length)
 {
 	BYTE byte;
 
-	if(Stream_GetRemainingLength(s) < 1)
+	if (Stream_GetRemainingLength(s) < 1)
 		return FALSE;
 	Stream_Read_UINT8(s, byte);
 
@@ -38,7 +38,7 @@ BOOL ber_read_length(wStream* s, int* length)
 	{
 		byte &= ~(0x80);
 
-		if(Stream_GetRemainingLength(s) < byte)
+		if (Stream_GetRemainingLength(s) < byte)
 			return FALSE;
 
 		if (byte == 1)
@@ -63,33 +63,29 @@ BOOL ber_read_length(wStream* s, int* length)
 
 int ber_write_length(wStream* s, int length)
 {
-	if (length > 0x7F)
+	if (length > 0xFF)
 	{
-		Stream_Write_UINT8(s, 0x82);
+		Stream_Write_UINT8(s, 0x80 ^ 2);
 		Stream_Write_UINT16_BE(s, length);
 		return 3;
 	}
-	else
+	if (length > 0x7F)
 	{
+		Stream_Write_UINT8(s, 0x80 ^ 1);
 		Stream_Write_UINT8(s, length);
-		return 1;
+		return 2;
 	}
+	Stream_Write_UINT8(s, length);
+	return 1;
 }
 
-int _ber_skip_length(int length)
+int _ber_sizeof_length(int length)
 {
-	if (length > 0x80)
+	if (length > 0xFF)
 		return 3;
-	else
-		return 1;
-}
-
-int ber_get_content_length(int length)
-{
-	if (length > 0x81)
-		return length - 4;
-	else
-		return length - 2;
+	if (length > 0x7F)
+		return 2;
+	return 1;
 }
 
 /**
@@ -103,7 +99,7 @@ BOOL ber_read_universal_tag(wStream* s, BYTE tag, BOOL pc)
 {
 	BYTE byte;
 
-	if(Stream_GetRemainingLength(s) < 1)
+	if (Stream_GetRemainingLength(s) < 1)
 		return FALSE;
 	Stream_Read_UINT8(s, byte);
 
@@ -120,9 +116,10 @@ BOOL ber_read_universal_tag(wStream* s, BYTE tag, BOOL pc)
  * @param pc primitive (FALSE) or constructed (TRUE)
  */
 
-void ber_write_universal_tag(wStream* s, BYTE tag, BOOL pc)
+int ber_write_universal_tag(wStream* s, BYTE tag, BOOL pc)
 {
 	Stream_Write_UINT8(s, (BER_CLASS_UNIV | BER_PC(pc)) | (BER_TAG_MASK & tag));
+	return 1;
 }
 
 /**
@@ -138,14 +135,14 @@ BOOL ber_read_application_tag(wStream* s, BYTE tag, int* length)
 
 	if (tag > 30)
 	{
-		if(Stream_GetRemainingLength(s) < 1)
+		if (Stream_GetRemainingLength(s) < 1)
 			return FALSE;
 		Stream_Read_UINT8(s, byte);
 
 		if (byte != ((BER_CLASS_APPL | BER_CONSTRUCT) | BER_TAG_MASK))
 			return FALSE;
 
-		if(Stream_GetRemainingLength(s) < 1)
+		if (Stream_GetRemainingLength(s) < 1)
 			return FALSE;
 		Stream_Read_UINT8(s, byte);
 
@@ -156,7 +153,7 @@ BOOL ber_read_application_tag(wStream* s, BYTE tag, int* length)
 	}
 	else
 	{
-		if(Stream_GetRemainingLength(s) < 1)
+		if (Stream_GetRemainingLength(s) < 1)
 			return FALSE;
 		Stream_Read_UINT8(s, byte);
 
@@ -195,7 +192,7 @@ BOOL ber_read_contextual_tag(wStream* s, BYTE tag, int* length, BOOL pc)
 {
 	BYTE byte;
 
-	if(Stream_GetRemainingLength(s) < 1)
+	if (Stream_GetRemainingLength(s) < 1)
 		return FALSE;
 	Stream_Read_UINT8(s, byte);
 
@@ -211,19 +208,19 @@ BOOL ber_read_contextual_tag(wStream* s, BYTE tag, int* length, BOOL pc)
 int ber_write_contextual_tag(wStream* s, BYTE tag, int length, BOOL pc)
 {
 	Stream_Write_UINT8(s, (BER_CLASS_CTXT | BER_PC(pc)) | (BER_TAG_MASK & tag));
-	return ber_write_length(s, length) + 1;
+	return 1 + ber_write_length(s, length);
 }
 
-int ber_skip_contextual_tag(int length)
+int ber_sizeof_contextual_tag(int length)
 {
-	return _ber_skip_length(length) + 1;
+	return 1 + _ber_sizeof_length(length);
 }
 
 BOOL ber_read_sequence_tag(wStream* s, int* length)
 {
 	BYTE byte;
 
-	if(Stream_GetRemainingLength(s) < 1)
+	if (Stream_GetRemainingLength(s) < 1)
 		return FALSE;
 	Stream_Read_UINT8(s, byte);
 
@@ -242,24 +239,24 @@ BOOL ber_read_sequence_tag(wStream* s, int* length)
 int ber_write_sequence_tag(wStream* s, int length)
 {
 	Stream_Write_UINT8(s, (BER_CLASS_UNIV | BER_CONSTRUCT) | (BER_TAG_MASK & BER_TAG_SEQUENCE));
-	return ber_write_length(s, length) + 1;
+	return 1 + ber_write_length(s, length);
 }
 
-int ber_skip_sequence(int length)
+int ber_sizeof_sequence(int length)
 {
-	return 1 + _ber_skip_length(length) + length;
+	return 1 + _ber_sizeof_length(length) + length;
 }
 
-int ber_skip_sequence_tag(int length)
+int ber_sizeof_sequence_tag(int length)
 {
-	return 1 + _ber_skip_length(length);
+	return 1 + _ber_sizeof_length(length);
 }
 
 BOOL ber_read_enumerated(wStream* s, BYTE* enumerated, BYTE count)
 {
 	int length;
 
-	if(!ber_read_universal_tag(s, BER_TAG_ENUMERATED, FALSE) ||
+	if (!ber_read_universal_tag(s, BER_TAG_ENUMERATED, FALSE) ||
 		!ber_read_length(s, &length))
 		return FALSE;
 
@@ -284,11 +281,11 @@ void ber_write_enumerated(wStream* s, BYTE enumerated, BYTE count)
 
 BOOL ber_read_bit_string(wStream* s, int* length, BYTE* padding)
 {
-	if(!ber_read_universal_tag(s, BER_TAG_BIT_STRING, FALSE) ||
+	if (!ber_read_universal_tag(s, BER_TAG_BIT_STRING, FALSE) ||
 		!ber_read_length(s, length))
 		return FALSE;
 
-	if(Stream_GetRemainingLength(s) < 1)
+	if (Stream_GetRemainingLength(s) < 1)
 		return FALSE;
 	Stream_Read_UINT8(s, *padding);
 	return TRUE;
@@ -301,11 +298,14 @@ BOOL ber_read_bit_string(wStream* s, int* length, BYTE* padding)
  * @param length string length
  */
 
-void ber_write_octet_string(wStream* s, const BYTE* oct_str, int length)
+int ber_write_octet_string(wStream* s, const BYTE* oct_str, int length)
 {
-	ber_write_universal_tag(s, BER_TAG_OCTET_STRING, FALSE);
-	ber_write_length(s, length);
+	int size = 0;
+	size += ber_write_universal_tag(s, BER_TAG_OCTET_STRING, FALSE);
+	size += ber_write_length(s, length);
 	Stream_Write(s, oct_str, length);
+	size += length;
+	return size;
 }
 
 BOOL ber_read_octet_string_tag(wStream* s, int* length)
@@ -319,12 +319,12 @@ int ber_write_octet_string_tag(wStream* s, int length)
 {
 	ber_write_universal_tag(s, BER_TAG_OCTET_STRING, FALSE);
 	ber_write_length(s, length);
-	return 1 + _ber_skip_length(length);
+	return 1 + _ber_sizeof_length(length);
 }
 
-int ber_skip_octet_string(int length)
+int ber_sizeof_octet_string(int length)
 {
-	return 1 + _ber_skip_length(length) + length;
+	return 1 + _ber_sizeof_length(length) + length;
 }
 
 /**
@@ -421,48 +421,52 @@ int ber_write_integer(wStream* s, UINT32 value)
 {
 	ber_write_universal_tag(s, BER_TAG_INTEGER, FALSE);
 
-	if (value <= 0xFF)
+	if (value <  0x80)
 	{
 		ber_write_length(s, 1);
 		Stream_Write_UINT8(s, value);
-		return 2;
+		return 3;
 	}
-	else if (value < 0xFF80)
+	else if (value <  0x8000)
 	{
 		ber_write_length(s, 2);
 		Stream_Write_UINT16_BE(s, value);
-		return 3;
+		return 4;
 	}
-	else if (value < 0xFF8000)
+	else if (value <  0x800000)
 	{
 		ber_write_length(s, 3);
 		Stream_Write_UINT8(s, (value >> 16));
 		Stream_Write_UINT16_BE(s, (value & 0xFFFF));
-		return 4;
+		return 5;
 	}
-	else if (value <= 0xFFFFFFFF)
+	else if (value <  0x80000000)
 	{
 		ber_write_length(s, 4);
 		Stream_Write_UINT32_BE(s, value);
-		return 5;
+		return 6;
 	}
 
 	return 0;
 }
 
-int ber_skip_integer(UINT32 value)
+int ber_sizeof_integer(UINT32 value)
 {
-	if (value <= 0xFF)
+	if (value < 0x80)
 	{
-		return _ber_skip_length(1) + 2;
+		return 3;
 	}
-	else if (value <= 0xFFFF)
+	else if (value < 0x8000)
 	{
-		return _ber_skip_length(2) + 3;
+		return 4;
 	}
-	else if (value <= 0xFFFFFFFF)
+	else if (value < 0x800000)
 	{
-		return _ber_skip_length(4) + 5;
+		return 5;
+	}
+	else if (value < 0x80000000)
+	{
+		return 6;
 	}
 
 	return 0;


### PR DESCRIPTION
We were experiencing a really hard to track down issue in FreeRDP that seemed to occur when the Username + Domain + Password hit around the 127 character mark. NLA authentication would appear to succeed, but the next SSL_Read would fail and the server would report a protocol error:

SSL_read: Failure in SSL library (protocol error?)
SSL_read: error:14094438:SSL routines:SSL3_READ_BYTES:tlsv1 alert internal error

I span up FreeRDP in valgrind and it revealed the following issue:

==16046== Invalid write of size 1
==16046==    at 0x402689F: memcpy (mc_replace_strmem.c:497)
==16046==    by 0x44291FC: ber_write_octet_string (ber.c:308)
==16046==    by 0x43D0078: credssp_write_ts_password_creds (nla.c:864)
==16046==    by 0x43D02B0: credssp_write_ts_credentials (nla.c:932)
==16046==    by 0x43D0315: credssp_encode_ts_credentials (nla.c:949)
==16046==    by 0x43D034C: credssp_encrypt_ts_credentials (nla.c:960)
==16046==    by 0x43CF0E4: credssp_client_authenticate (nla.c:350)
==16046==    by 0x43CF88D: credssp_authenticate (nla.c:630)
==16046==    by 0x43FD750: transport_connect_nla (transport.c:157)
==16046==    by 0x43D150A: nego_security_connect (nego.c:180)
==16046==    by 0x43D1434: nego_connect (nego.c:159)
==16046==    by 0x43F50EA: rdp_client_connect (connection.c:141)
==16046==  Address 0x6bf5868 is 1 bytes after a block of size 143 alloc'd
==16046==    at 0x4024F20: malloc (vg_replace_malloc.c:236)
==16046==    by 0x4481BED: sspi_SecBufferAlloc (sspi.c:213)
==16046==    by 0x43D02EB: credssp_encode_ts_credentials (nla.c:946)
==16046==    by 0x43D034C: credssp_encrypt_ts_credentials (nla.c:960)
==16046==    by 0x43CF0E4: credssp_client_authenticate (nla.c:350)
==16046==    by 0x43CF88D: credssp_authenticate (nla.c:630)
==16046==    by 0x43FD750: transport_connect_nla (transport.c:157)
==16046==    by 0x43D150A: nego_security_connect (nego.c:180)
==16046==    by 0x43D1434: nego_connect (nego.c:159)
==16046==    by 0x43F50EA: rdp_client_connect (connection.c:141)
==16046==    by 0x43E8303: freerdp_connect (freerdp.c:86)
==16046==    by 0x6F160FD: lxrdp_connect (xrdp-freerdp.c:88)

ber_write_octet_string was attempting to write into a buffer which was not quite big enough.

I tracked the issue down to the BER Encoding, which does not behave correctly around several of the boundary conditions. After pouring over the spec for a while I fixed the way length is encoded and this revealed a second issue: that the ber_skip and ber_write methods would often return contradicting sizes, and that the get_content_length method would not behave deterministically for lengths around 127.

Now (in nla.c) instead of calculating the overall length for the buffer size and then subtracting the width of the header and length components to use for the inner sequence, this patch does the reverse - measuring the inner packet size when creating a sequence and then adding the necessary length for the sequence encoding when actually creating a buffer to store the result. This behaves itself and correctly creates the right buffer size for each packet although it is marginally less efficient. Given more time I could probably come up with something a lot sexier that removes the need to measure and then write as separate passes (this would be the preferred architecture) but sadly I am doing this at work and I have a million and one other things to do that are all top priority. This fix seems to work, even if it is not optimal. Hopefully you might see a follow up pull request if I get some spare time. ;)

As an aside, I have also changed the way integers are written in ber.c. The specification says that they should be two's complement but there is no two's complement handling in the code. Ideally this should be expanded to handle non-uints but for now I just ensure that the most significant bit is never set to 1 and the number is always a positive representation. This didn't seem to affect the protocol negotiation either way however I include this for completeness.
