### PR TITLE
Memory errors resulting from too-large copy in ArrayList

### DIFF
--- a/winpr/libwinpr/utils/collections/ArrayList.c
+++ b/winpr/libwinpr/utils/collections/ArrayList.c
@@ -148,7 +148,9 @@ void ArrayList_Shift(wArrayList* arrayList, int index, int count)
 	}
 	else if (count < 0)
 	{
-		MoveMemory(&arrayList->array[index], &arrayList->array[index - count], (arrayList->size + count) * sizeof(void*));
+		int chunk = arrayList->size - index + count;
+		if (chunk > 0)
+			MoveMemory(&arrayList->array[index], &arrayList->array[index - count], chunk * sizeof(void*));
 		arrayList->size += count;
 	}
 }


### PR DESCRIPTION
ArrayList_Shift was copying too large a chunk of data when shifting downward (negative count), which would eventually cause memory errors:  segfaults or mysterious failure in realloc.
