### PR TITLE
Free incompletely initialized dvcs.

### DIFF
--- a/channels/drdynvc/client/dvcman.c
+++ b/channels/drdynvc/client/dvcman.c
@@ -376,16 +376,13 @@ int dvcman_create_channel(IWTSVirtualChannelManager* pChannelMgr, UINT32 Channel
 			{
 				DEBUG_WARN("channel rejected by plugin");
 
-				channel->status = 1;
-				ArrayList_Add(dvcman->channels, channel);
+				free(channel);
 				return 1;
 			}
 		}
 	}
 
-	channel->status = 1;
-	ArrayList_Add(dvcman->channels, channel);
-
+	free(channel);
 	return 1;
 }
 


### PR DESCRIPTION
If dynamic channels are not completely initialized, the server will
reuse those channel numbers for new channels.
This causes interesting problems when the server asks for a channel
by number, as we can end up with multiple channels with the same number.

This effectively reverts part of 8095bec3, so depending on what problem was being solved there, we may need to devise another solution.

Log example of the problem:
DBG_DVC drdynvc_process_receive (341): Cmd=0x1
DBG_DVC drdynvc_process_create_request (249): ChannelId=0 ChannelName=PNPDR
DBG_DVC drdynvc_process_create_request (265): no listener
DBG_DVC drdynvc_process_receive (341): Cmd=0x1
DBG_DVC drdynvc_process_create_request (249): ChannelId=0 ChannelName=TSMF
DBG_DVC tsmf_on_new_channel_connection (378):
DBG_DVC dvcman_create_channel (415): listener TSMF created new channel 0
DBG_DVC drdynvc_process_create_request (260): channel created
DBG_DVC drdynvc_process_receive (341): Cmd=0x3
DBG_DVC drdynvc_process_data (311): ChannelId=0
Warning dvcman_receive_channel_data (517): ChannelId 0 not ready!

In this log, we received data intended for TSMF, but the channel lookup
found the incompletely initialized PNPDR.
