### PR TITLE
core: Don't sent persistent key list if deact/react

### DIFF
--- a/libfreerdp/core/activation.c
+++ b/libfreerdp/core/activation.c
@@ -279,6 +279,14 @@ BOOL rdp_recv_deactivate_all(rdpRdp* rdp, wStream* s)
 {
 	UINT16 lengthSourceDescriptor;
 
+	if (rdp->state == CONNECTION_STATE_ACTIVE)
+	{
+		rdp->deactivation_reactivation = TRUE;
+	}
+	else
+	{
+		rdp->deactivation_reactivation = FALSE;
+	}
 	/*
 	 * Windows XP can send short DEACTIVATE_ALL PDU that doesn't contain
 	 * the following fields.

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -587,8 +587,15 @@ BOOL rdp_client_connect_finalize(rdpRdp* rdp)
 		return FALSE;
 	if (!rdp_send_client_control_pdu(rdp, CTRLACTION_REQUEST_CONTROL))
 		return FALSE;
-	if (!rdp_send_client_persistent_key_list_pdu(rdp))
-		return FALSE;
+	/**
+	 * [MS-RDPBCGR] 2.2.1.17
+	 * Client persistent key list must be sent if a bitmap is
+	 * stored in persistent bitmap cache or the server has advertised support for bitmap
+	 * host cache and a deactivation reactivation sequence is *not* in progress.
+	 */
+	if (!rdp->deactivation_reactivation && rdp->settings->BitmapCachePersistEnabled)
+		if (!rdp_send_client_persistent_key_list_pdu(rdp))
+			return FALSE;
 	if (!rdp_send_client_font_list_pdu(rdp, FONTLIST_FIRST | FONTLIST_LAST))
 		return FALSE;
 

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -157,6 +157,7 @@ struct rdp_rdp
 	UINT32 finalize_sc_pdus;
 	BOOL disconnect;
 	BOOL resendFocus;
+	BOOL deactivation_reactivation;
 };
 
 BOOL rdp_read_security_header(wStream* s, UINT16* flags);


### PR DESCRIPTION
Client persistent key list should not be sent if deactivation-
reactivation sequence is in progress. See [MS-RDPBCGR] 2.2.1.17
for details.

fixes #1229
