### PR TITLE
winpr: check added if handle is NULL

### DIFF
--- a/winpr/libwinpr/handle/handle.h
+++ b/winpr/libwinpr/handle/handle.h
@@ -47,6 +47,9 @@ static inline BOOL winpr_Handle_GetInfo(HANDLE handle, ULONG* pType, PVOID* pObj
 {
 	WINPR_HANDLE* wHandle;
 
+	if (handle == NULL)
+		return FALSE;
+
 	wHandle = (WINPR_HANDLE*) handle;
 
 	*pType = wHandle->Type;


### PR DESCRIPTION
If you call xfreerdp with invalid arguments, a segfault happens at cleanup, caused by the null-pointer in this line in GetExitCodeThread:
        *lpExitCode = thread->dwExitCode;
