### PR TITLE
winpr: offset support in _aligned_offset_malloc

### DIFF
--- a/winpr/libwinpr/crt/alignment.c
+++ b/winpr/libwinpr/crt/alignment.c
@@ -36,7 +36,7 @@
 #endif
 
 struct _aligned_meminfo {
-	UINT32 size;
+	size_t size;
 	void *base_addr;
 };
 


### PR DESCRIPTION
Added support to handle offset parameter in _aligned_offset_ functions.
fixes #1299
