### PR TITLE
Assorted tsmf and gstreamer fixes

### DIFF
--- a/channels/tsmf/client/tsmf_ifman.c
+++ b/channels/tsmf/client/tsmf_ifman.c
@@ -127,8 +127,6 @@ int tsmf_ifman_check_format_support_request(TSMF_IFMAN* ifman)
 	return 0;
 }
 
-static TSMF_PRESENTATION* pexisted = 0;
-
 int tsmf_ifman_on_new_presentation(TSMF_IFMAN* ifman)
 {
 	int status = 0;
@@ -136,15 +134,16 @@ int tsmf_ifman_on_new_presentation(TSMF_IFMAN* ifman)
 
 	DEBUG_DVC("");
 
-	if (pexisted)
+	presentation = tsmf_presentation_find_by_id(Stream_Pointer(ifman->input));
+	if (presentation)
 	{
+		DEBUG_DVC("Presentation already exists");
 		ifman->output_pending = FALSE;
 		return 0;
 
 	}
 
 	presentation = tsmf_presentation_new(Stream_Pointer(ifman->input), ifman->channel_callback);
-	pexisted = presentation;
 
 	if (presentation == NULL)
 		status = 1;
@@ -283,8 +282,8 @@ int tsmf_ifman_shutdown_presentation(TSMF_IFMAN* ifman)
 
 	if (presentation)
 		tsmf_presentation_free(presentation);
-
-	pexisted = 0;
+	else
+		DEBUG_WARN("unknown presentation id");
 
 	Stream_EnsureRemainingCapacity(ifman->output, 4);
 	Stream_Write_UINT32(ifman->output, 0); /* Result */


### PR DESCRIPTION
- tsmf audio volume fixes
  - The first audio volume message is received before everything is
    initialized.  Cache this data until we're ready.
  - Handle the cases of gstreamer unitialized/partially ready/
    fully ready.
  - Default to 50% as a fallback if the above fails.
- Improved detection of the primary monitor.
- Fix an unexpected shutdown when the server asks us to resize the media
  overlay to (width=0,height=0).
- Permit multiple presentations - required for repeat of audio files
  and also is seen in some video cases.
- Several leak fixes.
- Fix logging related compile warnings and other usage of PRIu64.
