### PR TITLE
libfreerdp-utils/pcap: open pcap in binary mode

### DIFF
--- a/libfreerdp/utils/pcap.c
+++ b/libfreerdp/utils/pcap.c
@@ -158,7 +158,7 @@ rdpPcap* pcap_open(char* name, BOOL write)
 {
 	rdpPcap* pcap;
 
-	FILE* pcap_fp = fopen(name, write ? "w+" : "r");
+	FILE* pcap_fp = fopen(name, write ? "w+b" : "rb");
 
 	if (pcap_fp == NULL)
 	{


### PR DESCRIPTION
Use 'b' in fopen's mode string to force binary (untranslated) mode
when reading or writing the pcap file.
This is required on WIN32 and maybe on other non POSIX conforming
systems.

This fixes the mstsc internal error disconnect followed by a crash
of the sample server when latter is used to serve a pcap file on
WIN32.
