### PR TITLE
client/x11: fixed incorrect size calculation

### DIFF
--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -134,7 +134,7 @@ void xf_Bitmap_Decompress(rdpContext* context, rdpBitmap* bitmap,
 
 	xfi = ((xfContext*) context)->xfi;
 
-	size = width * height * (bpp + 7) / 8;
+	size = width * height * ((bpp + 7) / 8);
 
 	if (bitmap->data == NULL)
 		bitmap->data = (BYTE*) malloc(size);


### PR DESCRIPTION
xf_Bitmap_Decompress used the same calculation like gdi_Bitmap_Decompress
see #1310
