### PR TITLE
codec/rfx: Fixed bufferpool size used for RemoteFX

### DIFF
--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -137,6 +137,7 @@ static void rfx_profiler_print(RFX_CONTEXT* context)
 	PROFILER_PRINT_FOOTER;
 }
 
+
 RFX_CONTEXT* rfx_context_new(void)
 {
 	HKEY hKey;
@@ -159,8 +160,8 @@ RFX_CONTEXT* rfx_context_new(void)
 	/*
 	 * align buffers to 16 byte boundary (needed for SSE/NEON instructions)
 	 *
-	 * y_r_buffer, cb_g_buffer, cr_b_buffer: 64 * 64 * 4 = 16384 (0x4000)
-	 * dwt_buffer: 32 * 32 * 2 * 2 * 4 = 16384, maximum sub-band width is 32
+	 * y_r_buffer, cb_g_buffer, cr_b_buffer: 64 * 64 * sizeof(INT16) = 8192 (0x2000)
+	 * dwt_buffer: 32 * 32 * 2 * 2 * sizeof(INT16) = 8192, maximum sub-band width is 32
 	 *
 	 * Additionally we add 32 bytes (16 in front and 16 at the back of the buffer)
 	 * in order to allow optimized functions (SEE, NEON) to read from positions 
@@ -168,7 +169,7 @@ RFX_CONTEXT* rfx_context_new(void)
 	 * performed at the BufferPool_Take function calls in rfx_encode/decode.c.
 	 */
 
-	context->priv->BufferPool = BufferPool_New(TRUE, 16384 + 32, 16);
+	context->priv->BufferPool = BufferPool_New(TRUE, 8192 + 32, 16);
 
 #ifdef _WIN32
 	{


### PR DESCRIPTION
y_r_buffer, cb_g_buffer, cr_b_buffer and dwt_buffer are all word arrays (16bit)
but obviously the bufferpool size was calculated based on the wrong assumption
that these are 32 bit values in commit 37a59efbe36c1e6dc200251e13492f20f63ff8b9
