### PR TITLE
codec/rfx: use function pointer for rlgr codec

### DIFF
--- a/include/freerdp/codec/rfx.h
+++ b/include/freerdp/codec/rfx.h
@@ -106,6 +106,8 @@ struct _RFX_CONTEXT
 	void (*quantization_encode)(INT16* buffer, const UINT32* quantization_values);
 	void (*dwt_2d_decode)(INT16* buffer, INT16* dwt_buffer);
 	void (*dwt_2d_encode)(INT16* buffer, INT16* dwt_buffer);
+	int (*rlgr_decode)(RLGR_MODE mode, const BYTE* data, int data_size, INT16* buffer, int buffer_size);
+	int (*rlgr_encode)(RLGR_MODE mode, const INT16* data, int data_size, BYTE* buffer, int buffer_size);
 
 	/* private definitions */
 	RFX_CONTEXT_PRIV* priv;

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -45,6 +45,7 @@
 #include "rfx_encode.h"
 #include "rfx_quantization.h"
 #include "rfx_dwt.h"
+#include "rfx_rlgr.h"
 
 #include "rfx_sse2.h"
 #include "rfx_neon.h"
@@ -240,6 +241,8 @@ RFX_CONTEXT* rfx_context_new(void)
 	context->quantization_encode = rfx_quantization_encode;	
 	context->dwt_2d_decode = rfx_dwt_2d_decode;
 	context->dwt_2d_encode = rfx_dwt_2d_encode;
+	context->rlgr_decode = rfx_rlgr_decode;
+	context->rlgr_encode = rfx_rlgr_encode;
 
 	RFX_INIT_SIMD(context);
 	

--- a/libfreerdp/codec/rfx_decode.c
+++ b/libfreerdp/codec/rfx_decode.c
@@ -103,7 +103,7 @@ static void rfx_decode_component(RFX_CONTEXT* context, const UINT32* quantizatio
 	PROFILER_ENTER(context->priv->prof_rfx_decode_component);
 
 	PROFILER_ENTER(context->priv->prof_rfx_rlgr_decode);
-		rfx_rlgr_decode(context->mode, data, size, buffer, 4096);
+		context->rlgr_decode(context->mode, data, size, buffer, 4096);
 	PROFILER_EXIT(context->priv->prof_rfx_rlgr_decode);
 
 	PROFILER_ENTER(context->priv->prof_rfx_differential_decode);

--- a/libfreerdp/codec/rfx_encode.c
+++ b/libfreerdp/codec/rfx_encode.c
@@ -209,7 +209,7 @@ static void rfx_encode_component(RFX_CONTEXT* context, const UINT32* quantizatio
 	PROFILER_EXIT(context->priv->prof_rfx_differential_encode);
 
 	PROFILER_ENTER(context->priv->prof_rfx_rlgr_encode);
-		*size = rfx_rlgr_encode(context->mode, data, 4096, buffer, buffer_size);
+		*size = context->rlgr_encode(context->mode, data, 4096, buffer, buffer_size);
 	PROFILER_EXIT(context->priv->prof_rfx_rlgr_encode);
 
 	PROFILER_EXIT(context->priv->prof_rfx_encode_component);


### PR DESCRIPTION
Option to switch the rlgr implementation during runtime - exactly
like we do it with the ycbcr, dwt and quantization functions.
