### PR TITLE
codec/rfx: removed unused queue TileQueue

### DIFF
--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -156,7 +156,6 @@ RFX_CONTEXT* rfx_context_new(void)
 	ZeroMemory(context->priv, sizeof(RFX_CONTEXT_PRIV));
 
 	context->priv->TilePool = Queue_New(TRUE, -1, -1);
-	context->priv->TileQueue = Queue_New(TRUE, -1, -1);
 
 	/*
 	 * align buffers to 16 byte boundary (needed for SSE/NEON instructions)
@@ -254,7 +253,6 @@ void rfx_context_free(RFX_CONTEXT* context)
 	free(context->quants);
 
 	Queue_Free(context->priv->TilePool);
-	Queue_Free(context->priv->TileQueue);
 
 	rfx_profiler_print(context);
 	rfx_profiler_free(context);

--- a/libfreerdp/codec/rfx_types.h
+++ b/libfreerdp/codec/rfx_types.h
@@ -40,7 +40,6 @@
 struct _RFX_CONTEXT_PRIV
 {
 	wQueue* TilePool;
-	wQueue* TileQueue;
 
 	BOOL UseThreads;
 	DWORD MinThreadCount;


### PR DESCRIPTION
Declared, created, deleted but not used:

```
git grep TileQueue
libfreerdp/codec/rfx_types.h: wQueue* TileQueue;
libfreerdp/codec/rfx.c:       context->priv->TileQueue = Queue_New(TRUE, -1, -1);
libfreerdp/codec/rfx.c:       Queue_Free(context->priv->TileQueue);
```
