### PR TITLE
careful with passwd in compatibility.c

### DIFF
--- a/client/common/compatibility.c
+++ b/client/common/compatibility.c
@@ -473,7 +473,9 @@ int freerdp_client_parse_old_command_line_arguments(int argc, char** argv, rdpSe
 		CommandLineSwitchCase(arg, "p")
 		{
 			settings->Password = _strdup(arg->Value);
-			fprintf(stderr, "-p %s -> /p:%s\n", arg->Value, arg->Value);
+			fprintf(stderr, "-p ****** -> /p:******\n");
+			/* Hide the value from 'ps'. */
+			FillMemory(arg->Value, strlen(arg->Value), '*');
 		}
 		CommandLineSwitchCase(arg, "s")
 		{


### PR DESCRIPTION
Do not print password to command-line or leave it visible in 'ps' when in (deprecated) old command-line style.  cmdline.c handles it correctly.  It would also be nice to also disguise the length of the password, but that requires a larger and more risky change (adding '\0' in the string is not sufficient).
