### PR TITLE
codec/rfx: removed unnecessary WaitForSingleObject

### DIFF
--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -312,8 +312,7 @@ RFX_TILE* rfx_tile_pool_take(RFX_CONTEXT* context)
 {
 	RFX_TILE* tile = NULL;
 
-	if (WaitForSingleObject(Queue_Event(context->priv->TilePool), 0) == WAIT_OBJECT_0)
-		tile = Queue_Dequeue(context->priv->TilePool);
+	tile = Queue_Dequeue(context->priv->TilePool);
 
 	if (!tile)
 	{


### PR DESCRIPTION
The WaitForSingleObject call on TilePool's event is called with a zero time-out
interval and the event is a manual reset event ... thus no locking or waiting
is involved anyways and Queue_Dequeue may very well return NULL independently
of calling WaitForSingleObject which is already correctly handled.
