### PR TITLE
winpr: improve and fix locking for data structures

### DIFF
--- a/winpr/include/winpr/collections.h
+++ b/winpr/include/winpr/collections.h
@@ -58,7 +58,7 @@ struct _wQueue
 	int tail;
 	int size;
 	void** array;
-	HANDLE mutex;
+	CRITICAL_SECTION lock;
 	HANDLE event;
 
 	wObject object;
@@ -67,8 +67,8 @@ typedef struct _wQueue wQueue;
 
 WINPR_API int Queue_Count(wQueue* queue);
 
-WINPR_API BOOL Queue_Lock(wQueue* queue);
-WINPR_API BOOL Queue_Unlock(wQueue* queue);
+WINPR_API void Queue_Lock(wQueue* queue);
+WINPR_API void Queue_Unlock(wQueue* queue);
 
 WINPR_API HANDLE Queue_Event(wQueue* queue);
 
@@ -93,7 +93,7 @@ struct _wStack
 	int size;
 	int capacity;
 	void** array;
-	HANDLE mutex;
+	CRITICAL_SECTION lock;
 	BOOL synchronized;
 	wObject object;
 };
@@ -125,7 +125,7 @@ struct _wArrayList
 
 	int size;
 	void** array;
-	HANDLE mutex;
+	CRITICAL_SECTION lock;
 
 	wObject object;
 };
@@ -137,8 +137,8 @@ WINPR_API BOOL ArrayList_IsFixedSized(wArrayList* arrayList);
 WINPR_API BOOL ArrayList_IsReadOnly(wArrayList* arrayList);
 WINPR_API BOOL ArrayList_IsSynchronized(wArrayList* arrayList);
 
-WINPR_API BOOL ArrayList_Lock(wArrayList* arrayList);
-WINPR_API BOOL ArrayList_Unlock(wArrayList* arrayList);
+WINPR_API void ArrayList_Lock(wArrayList* arrayList);
+WINPR_API void ArrayList_Unlock(wArrayList* arrayList);
 
 WINPR_API void* ArrayList_GetItem(wArrayList* arrayList, int index);
 WINPR_API void ArrayList_SetItem(wArrayList* arrayList, int index, void* obj);
@@ -165,7 +165,7 @@ WINPR_API void ArrayList_Free(wArrayList* arrayList);
 struct _wDictionary
 {
 	BOOL synchronized;
-	HANDLE mutex;
+	CRITICAL_SECTION lock;
 };
 typedef struct _wDictionary wDictionary;
 
@@ -184,7 +184,7 @@ struct _wListDictionaryItem
 struct _wListDictionary
 {
 	BOOL synchronized;
-	HANDLE mutex;
+	CRITICAL_SECTION lock;
 
 	wListDictionaryItem* head;
 };
@@ -227,7 +227,7 @@ typedef int (*REFERENCE_FREE)(void* context, void* ptr);
 struct _wReferenceTable
 {
 	UINT32 size;
-	HANDLE mutex;
+	CRITICAL_SECTION lock;
 	void* context;
 	BOOL synchronized;
 	wReference* array;
@@ -246,7 +246,7 @@ WINPR_API void ReferenceTable_Free(wReferenceTable* referenceTable);
 struct _wCountdownEvent
 {
 	DWORD count;
-	HANDLE mutex;
+	CRITICAL_SECTION lock;
 	HANDLE event;
 	DWORD initialCount;
 };
@@ -271,7 +271,7 @@ struct _wBufferPool
 	int size;
 	int capacity;
 	void** array;
-	HANDLE mutex;
+	CRITICAL_SECTION lock;
 	int fixedSize;
 	DWORD alignment;
 	BOOL synchronized;
@@ -292,7 +292,7 @@ struct _wObjectPool
 	int size;
 	int capacity;
 	void** array;
-	HANDLE mutex;
+	CRITICAL_SECTION lock;
 	wObject object;
 	BOOL synchronized;
 };
@@ -330,7 +330,7 @@ struct _wMessageQueue
 	int size;
 	int capacity;
 	wMessage* array;
-	HANDLE mutex;
+	CRITICAL_SECTION lock;
 	HANDLE event;
 };
 typedef struct _wMessageQueue wMessageQueue;
@@ -427,7 +427,7 @@ typedef struct _wEventType wEventType;
 
 struct _wPubSub
 {
-	HANDLE mutex;
+	CRITICAL_SECTION lock;
 	BOOL synchronized;
 
 	int size;
@@ -436,8 +436,8 @@ struct _wPubSub
 };
 typedef struct _wPubSub wPubSub;
 
-WINPR_API BOOL PubSub_Lock(wPubSub* pubSub);
-WINPR_API BOOL PubSub_Unlock(wPubSub* pubSub);
+WINPR_API void PubSub_Lock(wPubSub* pubSub);
+WINPR_API void PubSub_Unlock(wPubSub* pubSub);
 
 WINPR_API wEventType* PubSub_GetEventTypes(wPubSub* pubSub, int* count);
 WINPR_API void PubSub_AddEventTypes(wPubSub* pubSub, wEventType* events, int count);

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -24,6 +24,7 @@
 #include <winpr/winpr.h>
 #include <winpr/wtypes.h>
 #include <winpr/endian.h>
+#include <winpr/synch.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -236,7 +237,7 @@ struct _wStreamPool
 	int uCapacity;
 	wStream** uArray;
 
-	HANDLE mutex;
+	CRITICAL_SECTION lock;
 	BOOL synchronized;
 	size_t defaultSize;
 };

--- a/winpr/libwinpr/utils/collections/PubSub.c
+++ b/winpr/libwinpr/utils/collections/PubSub.c
@@ -46,14 +46,14 @@ wEventType* PubSub_GetEventTypes(wPubSub* pubSub, int* count)
  * Methods
  */
 
-BOOL PubSub_Lock(wPubSub* pubSub)
+void PubSub_Lock(wPubSub* pubSub)
 {
-	return (WaitForSingleObject(pubSub->mutex, INFINITE) == WAIT_OBJECT_0) ? TRUE : FALSE;
+	EnterCriticalSection(&pubSub->lock);
 }
 
-BOOL PubSub_Unlock(wPubSub* pubSub)
+void PubSub_Unlock(wPubSub* pubSub)
 {
-	return ReleaseMutex(pubSub->mutex);
+	LeaveCriticalSection(&pubSub->lock);
 }
 
 wEventType* PubSub_FindEventType(wPubSub* pubSub, const char* EventName)
@@ -202,7 +202,7 @@ wPubSub* PubSub_New(BOOL synchronized)
 		pubSub->synchronized = synchronized;
 
 		if (pubSub->synchronized)
-			pubSub->mutex = CreateMutex(NULL, FALSE, NULL);
+			InitializeCriticalSection(&pubSub->lock);
 
 		pubSub->count = 0;
 		pubSub->size = 64;
@@ -219,7 +219,7 @@ void PubSub_Free(wPubSub* pubSub)
 	if (pubSub)
 	{
 		if (pubSub->synchronized)
-			CloseHandle(pubSub->mutex);
+			DeleteCriticalSection(&pubSub->lock);
 
 		if (pubSub->events)
 			free(pubSub->events);

--- a/winpr/libwinpr/utils/collections/StreamPool.c
+++ b/winpr/libwinpr/utils/collections/StreamPool.c
@@ -118,7 +118,7 @@ wStream* StreamPool_Take(wStreamPool* pool, size_t size)
 	BOOL found = FALSE;
 
 	if (pool->synchronized)
-		WaitForSingleObject(pool->mutex, INFINITE);
+		EnterCriticalSection(&pool->lock);
 
 	if (size == 0)
 		size = pool->defaultSize;
@@ -153,7 +153,7 @@ wStream* StreamPool_Take(wStreamPool* pool, size_t size)
 	StreamPool_AddUsed(pool, s);
 
 	if (pool->synchronized)
-		ReleaseMutex(pool->mutex);
+		LeaveCriticalSection(&pool->lock);
 
 	return s;
 }
@@ -165,7 +165,7 @@ wStream* StreamPool_Take(wStreamPool* pool, size_t size)
 void StreamPool_Return(wStreamPool* pool, wStream* s)
 {
 	if (pool->synchronized)
-		WaitForSingleObject(pool->mutex, INFINITE);
+		EnterCriticalSection(&pool->lock);
 
 	if ((pool->aSize + 1) >= pool->aCapacity)
 	{
@@ -177,7 +177,7 @@ void StreamPool_Return(wStreamPool* pool, wStream* s)
 	StreamPool_RemoveUsed(pool, s);
 
 	if (pool->synchronized)
-		ReleaseMutex(pool->mutex);
+		LeaveCriticalSection(&pool->lock);
 }
 
 /**
@@ -186,7 +186,7 @@ void StreamPool_Return(wStreamPool* pool, wStream* s)
 
 void StreamPool_Lock(wStreamPool* pool)
 {
-	WaitForSingleObject(pool->mutex, INFINITE);
+	EnterCriticalSection(&pool->lock);
 }
 
 /**
@@ -195,7 +195,7 @@ void StreamPool_Lock(wStreamPool* pool)
 
 void StreamPool_Unlock(wStreamPool* pool)
 {
-	ReleaseMutex(pool->mutex);
+	LeaveCriticalSection(&pool->lock);
 }
 
 /**
@@ -241,7 +241,7 @@ wStream* StreamPool_Find(wStreamPool* pool, BYTE* ptr)
 	wStream* s = NULL;
 	BOOL found = FALSE;
 
-	WaitForSingleObject(pool->mutex, INFINITE);
+	EnterCriticalSection(&pool->lock);
 
 	for (index = 0; index < pool->uSize; index++)
 	{
@@ -254,7 +254,7 @@ wStream* StreamPool_Find(wStreamPool* pool, BYTE* ptr)
 		}
 	}
 
-	ReleaseMutex(pool->mutex);
+	LeaveCriticalSection(&pool->lock);
 
 	return (found) ? s : NULL;
 }
@@ -294,7 +294,7 @@ void StreamPool_Release(wStreamPool* pool, BYTE* ptr)
 void StreamPool_Clear(wStreamPool* pool)
 {
 	if (pool->synchronized)
-		WaitForSingleObject(pool->mutex, INFINITE);
+		EnterCriticalSection(&pool->lock);
 
 	while (pool->aSize > 0)
 	{
@@ -303,7 +303,7 @@ void StreamPool_Clear(wStreamPool* pool)
 	}
 
 	if (pool->synchronized)
-		ReleaseMutex(pool->mutex);
+		LeaveCriticalSection(&pool->lock);
 }
 
 /**
@@ -323,8 +323,7 @@ wStreamPool* StreamPool_New(BOOL synchronized, size_t defaultSize)
 		pool->synchronized = synchronized;
 		pool->defaultSize = defaultSize;
 
-		if (pool->synchronized)
-			pool->mutex = CreateMutex(NULL, FALSE, NULL);
+		InitializeCriticalSection(&pool->lock); 
 
 		pool->aSize = 0;
 		pool->aCapacity = 32;
@@ -344,8 +343,7 @@ void StreamPool_Free(wStreamPool* pool)
 	{
 		StreamPool_Clear(pool);
 
-		if (pool->synchronized)
-			CloseHandle(pool->mutex);
+		DeleteCriticalSection(&pool->lock);
 
 		free(pool->aArray);
 		free(pool->uArray);


### PR DESCRIPTION
- Improved/completed(almost) winpr's critical section implementation
- Replaced WaitForSingleObject locking with critical sections

Note:
WaitForSingleObject should _never_ be used for granular low-contention
locks as it _always_ enters the kernel.

Just replacing WaitForSingleObject locking in Bufferpool with
EnterCriticalSection boosts the multithreaded rfx decoder
performance by almost 400% on win32.
