### PR TITLE
libwinpr-utils: Use criticalsection with spincount

### DIFF
--- a/winpr/libwinpr/utils/collections/ArrayList.c
+++ b/winpr/libwinpr/utils/collections/ArrayList.c
@@ -390,7 +390,7 @@ wArrayList* ArrayList_New(BOOL synchronized)
 
 		arrayList->array = (void**) malloc(sizeof(void*) * arrayList->capacity);
 
-		InitializeCriticalSection(&arrayList->lock);
+		InitializeCriticalSectionAndSpinCount(&arrayList->lock, 4000);
 
 		ZeroMemory(&arrayList->object, sizeof(wObject));
 	}

--- a/winpr/libwinpr/utils/collections/BufferPool.c
+++ b/winpr/libwinpr/utils/collections/BufferPool.c
@@ -134,7 +134,7 @@ wBufferPool* BufferPool_New(BOOL synchronized, int fixedSize, DWORD alignment)
 		pool->synchronized = synchronized;
 
 		if (pool->synchronized)
-			InitializeCriticalSection(&pool->lock);
+			InitializeCriticalSectionAndSpinCount(&pool->lock, 4000);
 
 		if (!pool->fixedSize)
 		{

--- a/winpr/libwinpr/utils/collections/CountdownEvent.c
+++ b/winpr/libwinpr/utils/collections/CountdownEvent.c
@@ -158,7 +158,7 @@ wCountdownEvent* CountdownEvent_New(DWORD initialCount)
 	{
 		countdown->count = initialCount;
 		countdown->initialCount = initialCount;
-		InitializeCriticalSection(&countdown->lock);
+		InitializeCriticalSectionAndSpinCount(&countdown->lock, 4000);
 		countdown->event = CreateEvent(NULL, TRUE, FALSE, NULL);
 
 		if (countdown->count == 0)

--- a/winpr/libwinpr/utils/collections/MessageQueue.c
+++ b/winpr/libwinpr/utils/collections/MessageQueue.c
@@ -194,7 +194,7 @@ wMessageQueue* MessageQueue_New()
 		queue->array = (wMessage*) malloc(sizeof(wMessage) * queue->capacity);
 		ZeroMemory(queue->array, sizeof(wMessage) * queue->capacity);
 
-		InitializeCriticalSection(&queue->lock);
+		InitializeCriticalSectionAndSpinCount(&queue->lock, 4000);
 		queue->event = CreateEvent(NULL, TRUE, FALSE, NULL);
 	}
 

--- a/winpr/libwinpr/utils/collections/ObjectPool.c
+++ b/winpr/libwinpr/utils/collections/ObjectPool.c
@@ -119,7 +119,7 @@ wObjectPool* ObjectPool_New(BOOL synchronized)
 		pool->synchronized = synchronized;
 
 		if (pool->synchronized)
-			InitializeCriticalSection(&pool->lock);
+			InitializeCriticalSectionAndSpinCount(&pool->lock, 4000);
 
 		pool->size = 0;
 		pool->capacity = 32;

--- a/winpr/libwinpr/utils/collections/PubSub.c
+++ b/winpr/libwinpr/utils/collections/PubSub.c
@@ -202,7 +202,7 @@ wPubSub* PubSub_New(BOOL synchronized)
 		pubSub->synchronized = synchronized;
 
 		if (pubSub->synchronized)
-			InitializeCriticalSection(&pubSub->lock);
+			InitializeCriticalSectionAndSpinCount(&pubSub->lock, 4000);
 
 		pubSub->count = 0;
 		pubSub->size = 64;

--- a/winpr/libwinpr/utils/collections/Queue.c
+++ b/winpr/libwinpr/utils/collections/Queue.c
@@ -243,7 +243,7 @@ wQueue* Queue_New(BOOL synchronized, int capacity, int growthFactor)
 		queue->array = (void**) malloc(sizeof(void*) * queue->capacity);
 		ZeroMemory(queue->array, sizeof(void*) * queue->capacity);
 
-		InitializeCriticalSection(&queue->lock);
+		InitializeCriticalSectionAndSpinCount(&queue->lock, 4000);
 		queue->event = CreateEvent(NULL, TRUE, FALSE, NULL);
 
 		ZeroMemory(&queue->object, sizeof(wObject));

--- a/winpr/libwinpr/utils/collections/Reference.c
+++ b/winpr/libwinpr/utils/collections/Reference.c
@@ -154,7 +154,7 @@ wReferenceTable* ReferenceTable_New(BOOL synchronized, void* context, REFERENCE_
 		ZeroMemory(referenceTable->array, sizeof(wReference) * referenceTable->size);
 
 		referenceTable->synchronized = synchronized;
-		InitializeCriticalSection(&referenceTable->lock);
+		InitializeCriticalSectionAndSpinCount(&referenceTable->lock, 4000);
 	}
 
 	return referenceTable;

--- a/winpr/libwinpr/utils/collections/Stack.c
+++ b/winpr/libwinpr/utils/collections/Stack.c
@@ -153,7 +153,7 @@ wStack* Stack_New(BOOL synchronized)
 		stack->synchronized = synchronized;
 
 		if (stack->synchronized)
-			InitializeCriticalSection(&stack->lock);
+			InitializeCriticalSectionAndSpinCount(&stack->lock, 4000);
 
 		stack->size = 0;
 		stack->capacity = 32;

--- a/winpr/libwinpr/utils/collections/StreamPool.c
+++ b/winpr/libwinpr/utils/collections/StreamPool.c
@@ -323,7 +323,7 @@ wStreamPool* StreamPool_New(BOOL synchronized, size_t defaultSize)
 		pool->synchronized = synchronized;
 		pool->defaultSize = defaultSize;
 
-		InitializeCriticalSection(&pool->lock); 
+		InitializeCriticalSectionAndSpinCount(&pool->lock, 4000);
 
 		pool->aSize = 0;
 		pool->aCapacity = 32;


### PR DESCRIPTION
Use InitializeCriticalSectionAndSpinCount instead of IntializeCriticalSection.
Using spin counts for critical sections of short duration enables the calling
thread to avoid the wait operation in most situations which can dramatically
improve the overall performance on multiprocessor systems.

On Linux this change has no effect because the new winpr critical section
implementation does not use the SpinCount field under Linux because the NPTL
synchronization primitives are implemented using the extremely performant
futex system calls which have this magic already built in.

However, on Mac OS X this change improved the overall performance of the
multithreaded RemoteFX decoder by 25 percent.

I've used a SpinCount of 4000 which avoided 99 percent of the wait calls.
This value is also used by Microsoft's heap manager for its per-heap
critical sections.

Note: This change requires pull request #1397 to be merged.
