### PR TITLE
fix per-device CAL licensing

### DIFF
--- a/include/freerdp/crypto/crypto.h
+++ b/include/freerdp/crypto/crypto.h
@@ -132,10 +132,10 @@ extern const BYTE tssk_modulus[];
 extern const BYTE tssk_privateExponent[];
 extern const BYTE tssk_exponent[];
 
-FREERDP_API void crypto_rsa_public_encrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* exponent, BYTE* output);
-FREERDP_API void crypto_rsa_public_decrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* exponent, BYTE* output);
-FREERDP_API void crypto_rsa_private_encrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* private_exponent, BYTE* output);
-FREERDP_API void crypto_rsa_private_decrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* private_exponent, BYTE* output);
+FREERDP_API int crypto_rsa_public_encrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* exponent, BYTE* output);
+FREERDP_API int crypto_rsa_public_decrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* exponent, BYTE* output);
+FREERDP_API int crypto_rsa_private_encrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* private_exponent, BYTE* output);
+FREERDP_API int crypto_rsa_private_decrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* private_exponent, BYTE* output);
 FREERDP_API void crypto_reverse(BYTE* data, int length);
 FREERDP_API void crypto_nonce(BYTE* nonce, int size);
 

--- a/libfreerdp/core/license.c
+++ b/libfreerdp/core/license.c
@@ -28,8 +28,8 @@
 
 #include "license.h"
 
-//#define LICENSE_NULL_CLIENT_RANDOM		1
-#define LICENSE_NULL_PREMASTER_SECRET		1
+/* #define LICENSE_NULL_CLIENT_RANDOM		1 */
+/* #define LICENSE_NULL_PREMASTER_SECRET		1 */
 
 #ifdef WITH_DEBUG_LICENSE
 
@@ -195,7 +195,7 @@ BOOL license_send(rdpLicense* license, wStream* s, BYTE type)
 	 * Using EXTENDED_ERROR_MSG_SUPPORTED here would cause mstsc to crash when
 	 * running in server mode! This flag seems to be incorrectly documented.
 	 */
-	flags = PREAMBLE_VERSION_3_0;
+	flags = PREAMBLE_VERSION_3_0 | EXTENDED_ERROR_MSG_SUPPORTED;
 
 	rdp_write_header(license->rdp, s, length, MCS_GLOBAL_CHANNEL_ID);
 	rdp_write_security_header(s, sec_flags);
@@ -409,7 +409,7 @@ void license_get_server_rsa_public_key(rdpLicense* license)
 
 	license->ModulusLength = ModulusLength;
 	license->Modulus = (BYTE*) malloc(ModulusLength);
-	ZeroMemory(license->Modulus, ModulusLength);
+	memcpy(license->Modulus, Modulus, ModulusLength);
 }
 
 void license_encrypt_premaster_secret(rdpLicense* license)
@@ -430,14 +430,15 @@ void license_encrypt_premaster_secret(rdpLicense* license)
 
 	EncryptedPremasterSecret = (BYTE*) malloc(license->ModulusLength);
 	ZeroMemory(EncryptedPremasterSecret, license->ModulusLength);
+	license->EncryptedPremasterSecret->type = BB_RANDOM_BLOB;
+	license->EncryptedPremasterSecret->length = PREMASTER_SECRET_LENGTH;
 
 #ifndef LICENSE_NULL_PREMASTER_SECRET
-	crypto_rsa_public_encrypt(license->PremasterSecret, PREMASTER_SECRET_LENGTH,
+	license->EncryptedPremasterSecret->length =
+		crypto_rsa_public_encrypt(license->PremasterSecret, PREMASTER_SECRET_LENGTH,
 			license->ModulusLength, license->Modulus, license->Exponent, EncryptedPremasterSecret);
 #endif
 
-	license->EncryptedPremasterSecret->type = BB_RANDOM_BLOB;
-	license->EncryptedPremasterSecret->length = PREMASTER_SECRET_LENGTH;
 	license->EncryptedPremasterSecret->data = EncryptedPremasterSecret;
 }
 
@@ -1044,11 +1045,11 @@ void license_send_platform_challenge_response_packet(rdpLicense* license)
 	fprintf(stderr, "\n");
 
 	fprintf(stderr, "HardwareId:\n");
-	winpr_HexDump(license->HardwareId, 20);
+	winpr_HexDump(license->HardwareId, HWID_LENGTH);
 	fprintf(stderr, "\n");
 
 	fprintf(stderr, "EncryptedHardwareId:\n");
-	winpr_HexDump(license->EncryptedHardwareId->data, 20);
+	winpr_HexDump(license->EncryptedHardwareId->data, HWID_LENGTH);
 	fprintf(stderr, "\n");
 #endif
 

--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -207,7 +207,7 @@ exit:
 	return status;
 }
 
-static void crypto_rsa_common(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* exponent, int exponent_size, BYTE* output)
+static int crypto_rsa_common(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* exponent, int exponent_size, BYTE* output)
 {
 	BN_CTX* ctx;
 	int output_length;
@@ -250,41 +250,43 @@ static void crypto_rsa_common(const BYTE* input, int length, UINT32 key_length, 
 	BN_free(&mod);
 	BN_CTX_free(ctx);
 	free(input_reverse);
+
+	return output_length;
 }
 
-static void crypto_rsa_public(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* exponent, BYTE* output)
+static int crypto_rsa_public(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* exponent, BYTE* output)
 {
-	crypto_rsa_common(input, length, key_length, modulus, exponent, EXPONENT_MAX_SIZE, output);
+	return crypto_rsa_common(input, length, key_length, modulus, exponent, EXPONENT_MAX_SIZE, output);
 }
 
-static void crypto_rsa_private(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* private_exponent, BYTE* output)
+static int crypto_rsa_private(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* private_exponent, BYTE* output)
 {
-	crypto_rsa_common(input, length, key_length, modulus, private_exponent, key_length, output);
+	return crypto_rsa_common(input, length, key_length, modulus, private_exponent, key_length, output);
 }
 
-void crypto_rsa_public_encrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* exponent, BYTE* output)
+int crypto_rsa_public_encrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* exponent, BYTE* output)
 {
-	crypto_rsa_public(input, length, key_length, modulus, exponent, output);
+	return crypto_rsa_public(input, length, key_length, modulus, exponent, output);
 }
 
-void crypto_rsa_public_decrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* exponent, BYTE* output)
+int crypto_rsa_public_decrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* exponent, BYTE* output)
 {
-	crypto_rsa_public(input, length, key_length, modulus, exponent, output);
+	return crypto_rsa_public(input, length, key_length, modulus, exponent, output);
 }
 
-void crypto_rsa_private_encrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* private_exponent, BYTE* output)
+int crypto_rsa_private_encrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* private_exponent, BYTE* output)
 {
-	crypto_rsa_private(input, length, key_length, modulus, private_exponent, output);
+	return crypto_rsa_private(input, length, key_length, modulus, private_exponent, output);
 }
 
-void crypto_rsa_private_decrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* private_exponent, BYTE* output)
+int crypto_rsa_private_decrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* private_exponent, BYTE* output)
 {
-	crypto_rsa_private(input, length, key_length, modulus, private_exponent, output);
+	return crypto_rsa_private(input, length, key_length, modulus, private_exponent, output);
 }
 
-void crypto_rsa_decrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* private_exponent, BYTE* output)
+int crypto_rsa_decrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus, const BYTE* private_exponent, BYTE* output)
 {
-	crypto_rsa_common(input, length, key_length, modulus, private_exponent, key_length, output);
+	return crypto_rsa_common(input, length, key_length, modulus, private_exponent, key_length, output);
 }
 
 void crypto_reverse(BYTE* data, int length)


### PR DESCRIPTION
This patch fixes per-device CAL RDP licensing.  The changes include:
- having the crypto_rsa routines return the length of the encrypted block
- adding the EXTENDED_ERROR_MSG_SUPPORTED flag during licensing
- copy the certificate's modulus as an encryption parameter, rather than zeroes
- save the length of the encrypted pieces passed back and forth, which is not a constant
