### PR TITLE
Fixes libwinpr build issue on Windows

### DIFF
--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -605,6 +605,7 @@ char* GetNamedPipeUnixDomainSocketFilePathA(LPCSTR lpName)
 
 int UnixChangeFileMode(const char* filename, int flags)
 {
+#ifndef _WIN32
 	mode_t fl = 0;
 
 	fl |= (flags & 0x4000) ? S_ISUID : 0;
@@ -621,5 +622,7 @@ int UnixChangeFileMode(const char* filename, int flags)
 	fl |= (flags & 0x0001) ? S_IXOTH : 0;
 
 	return chmod(filename, fl);
+#else
+	return 0;
+#endif
 }
-


### PR DESCRIPTION
Adds conditional statements in file.c to solve a Posix portability
issue on Windows introduced with the following commit:

913d532e0d3456945236567af00e8119564307ff
