### PR TITLE
Clipboard fix 

### DIFF
--- a/channels/cliprdr/client/cliprdr_format.c
+++ b/channels/cliprdr/client/cliprdr_format.c
@@ -291,13 +291,13 @@ void cliprdr_process_format_list(cliprdrPlugin* cliprdr, wStream* s, UINT32 data
 
 void cliprdr_process_format_list_response(cliprdrPlugin* cliprdr, wStream* s, UINT32 dataLen, UINT16 msgFlags)
 {
-	/* where is this documented? */
+	/* http://msdn.microsoft.com/en-us/library/hh872154.aspx */
 	wMessage* event;
 
 	if ((msgFlags & CB_RESPONSE_FAIL) != 0)
 	{
-		/* In case of an error the clipboard will cease to operate.
-		 * Post this event to reenable the plugin. */
+		/* In case of an error the clipboard will not be synchronized with the server.
+		 * Post this event to restart format negociation and data transfer. */
 		event = freerdp_event_new(CliprdrChannel_Class, CliprdrChannel_MonitorReady, NULL, NULL);
 		svc_plugin_send_event((rdpSvcPlugin*) cliprdr, event);
 	}


### PR DESCRIPTION
Fixes issue #1410, #568
- The package size of the format list package in '''cliprdr_process_format_list_event''' was calculated incorrectly, resulting in error responses from the server.
- The error handling in case of a error response from the server was commented out (and out of sync with current master). The purpose of posting the event '''CliprdrChannel_MonitorReady''' is to retry clipboard format negotiation and data transfer with the server. The message sequence can be found at http://msdn.microsoft.com/en-us/library/hh872154.aspx
