### PR TITLE
Apply glyph fragment offset after fragment

### DIFF
--- a/libfreerdp/cache/glyph.c
+++ b/libfreerdp/cache/glyph.c
@@ -48,6 +48,7 @@ void update_process_glyph(rdpContext* context, BYTE* data, int* index,
 
 	if ((ulCharInc == 0) && (!(flAccel & SO_CHAR_INC_EQUAL_BM_BASE)))
 	{
+		/* Contrary to fragments, the offset is added before the glyph. */
 		(*index)++;
 		offset = data[*index];
 
@@ -111,17 +112,18 @@ void update_process_glyph_fragments(rdpContext* context, BYTE* data, UINT32 leng
 
 				if (fragments != NULL)
 				{
+					for (n = 0; n < (int) size; n++)
+					{
+						update_process_glyph(context, fragments, &n, &x, &y, cacheId, ulCharInc, flAccel);
+					}
+
+					/* Contrary to glyphs, the offset is added after the fragment. */
 					if ((ulCharInc == 0) && (!(flAccel & SO_CHAR_INC_EQUAL_BM_BASE)))
 					{
 						if (flAccel & SO_VERTICAL)
 							y += data[index + 2];
 						else
 							x += data[index + 2];
-					}
-
-					for (n = 0; n < (int) size; n++)
-					{
-						update_process_glyph(context, fragments, &n, &x, &y, cacheId, ulCharInc, flAccel);
 					}
 				}
 


### PR DESCRIPTION
It appears the server expects the offset for a glyph fragment to be applied after the fragment rather than before it.  Note that this is different than individual glyph offsets, which are expected to be applied before the glyph.

You can see the addressed defect by connecting to a pre-RemoteFX server, opening a very wide text window (e.g. an Outlook Express window) and typing a long set of words including spaces.  Around the 120th letter the space will start jumping around in the string.  The space character is implemented as a fragment offset, and without this fix it is being prepended to the second fragment rather than postpended (e.g. at the cursor), so the space jumps foward in the string to the fragment boundary.
