### PR TITLE
Extract shared code in RAIL channel

### DIFF
--- a/channels/rail/client/CMakeLists.txt
+++ b/channels/rail/client/CMakeLists.txt
@@ -18,6 +18,8 @@
 define_channel_client("rail")
 
 set(${MODULE_PREFIX}_SRCS
+    ../rail_common.h
+    ../rail_common.c
 	rail_main.c
 	rail_main.h
 	rail_orders.c

--- a/channels/rail/client/rail_main.c
+++ b/channels/rail/client/rail_main.c
@@ -104,9 +104,9 @@ static void rail_process_addin_args(rdpRailOrder* rail_order, rdpSettings* setti
 			rail_order->exec.flags |= RAIL_EXEC_FLAG_FILE;
 	}
 
-	rail_string_to_unicode_string(rail_order, settings->RemoteApplicationProgram, &rail_order->exec.exeOrFile);
-	rail_string_to_unicode_string(rail_order, settings->ShellWorkingDirectory, &rail_order->exec.workingDir);
-	rail_string_to_unicode_string(rail_order, settings->RemoteApplicationCmdLine, &rail_order->exec.arguments);
+	rail_string_to_unicode_string(settings->RemoteApplicationProgram, &rail_order->exec.exeOrFile);
+	rail_string_to_unicode_string(settings->ShellWorkingDirectory, &rail_order->exec.workingDir);
+	rail_string_to_unicode_string(settings->RemoteApplicationCmdLine, &rail_order->exec.arguments);
 
 	rail_send_client_exec_order(rail_order);
 }

--- a/channels/rail/client/rail_main.h
+++ b/channels/rail/client/rail_main.h
@@ -29,27 +29,7 @@
 
 #include <winpr/stream.h>
 
-struct rdp_rail_order
-{
-	rdpSettings* settings;
-	void* plugin;
-	RAIL_HANDSHAKE_ORDER handshake;
-	RAIL_CLIENT_STATUS_ORDER client_status;
-	RAIL_EXEC_ORDER exec;
-	RAIL_EXEC_RESULT_ORDER exec_result;
-	RAIL_SYSPARAM_ORDER sysparam;
-	RAIL_ACTIVATE_ORDER activate;
-	RAIL_SYSMENU_ORDER sysmenu;
-	RAIL_SYSCOMMAND_ORDER syscommand;
-	RAIL_NOTIFY_EVENT_ORDER notify_event;
-	RAIL_MINMAXINFO_ORDER minmaxinfo;
-	RAIL_LOCALMOVESIZE_ORDER localmovesize;
-	RAIL_WINDOW_MOVE_ORDER window_move;
-	RAIL_LANGBAR_INFO_ORDER langbar_info;
-	RAIL_GET_APPID_REQ_ORDER get_appid_req;
-	RAIL_GET_APPID_RESP_ORDER get_appid_resp;
-};
-typedef struct rdp_rail_order rdpRailOrder;
+#include "../rail_common.h"
 
 struct rail_plugin
 {
@@ -61,10 +41,6 @@ typedef struct rail_plugin railPlugin;
 void rail_send_channel_event(void* rail_object, UINT16 event_type, void* param);
 void rail_send_channel_data(void* rail_object, void* data, size_t length);
 
-#ifdef WITH_DEBUG_RAIL
-#define DEBUG_RAIL(fmt, ...) DEBUG_CLASS(RAIL, fmt, ## __VA_ARGS__)
-#else
-#define DEBUG_RAIL(fmt, ...) DEBUG_NULL(fmt, ## __VA_ARGS__)
-#endif
+
 
 #endif /* FREERDP_CHANNEL_CLIENT_RAIL_MAIN_H */

--- a/channels/rail/client/rail_orders.h
+++ b/channels/rail/client/rail_orders.h
@@ -23,40 +23,6 @@
 
 #include "rail_main.h"
 
-#define RAIL_ORDER_TYPE_EXEC			0x0001
-#define RAIL_ORDER_TYPE_ACTIVATE		0x0002
-#define RAIL_ORDER_TYPE_SYSPARAM		0x0003
-#define RAIL_ORDER_TYPE_SYSCOMMAND		0x0004
-#define RAIL_ORDER_TYPE_HANDSHAKE		0x0005
-#define RAIL_ORDER_TYPE_NOTIFY_EVENT		0x0006
-#define RAIL_ORDER_TYPE_WINDOW_MOVE		0x0008
-#define RAIL_ORDER_TYPE_LOCALMOVESIZE		0x0009
-#define RAIL_ORDER_TYPE_MINMAXINFO		0x000A
-#define RAIL_ORDER_TYPE_CLIENT_STATUS		0x000B
-#define RAIL_ORDER_TYPE_SYSMENU			0x000C
-#define RAIL_ORDER_TYPE_LANGBAR_INFO		0x000D
-#define RAIL_ORDER_TYPE_EXEC_RESULT		0x0080
-#define RAIL_ORDER_TYPE_GET_APPID_REQ		0x000E
-#define RAIL_ORDER_TYPE_GET_APPID_RESP		0x000F
-
-#define RAIL_PDU_HEADER_LENGTH			4
-
-/* Fixed length of PDUs, excluding variable lengths */
-#define RAIL_HANDSHAKE_ORDER_LENGTH		4 /* fixed */
-#define RAIL_CLIENT_STATUS_ORDER_LENGTH		4 /* fixed */
-#define RAIL_EXEC_ORDER_LENGTH			8 /* variable */
-#define RAIL_SYSPARAM_ORDER_LENGTH		4 /* variable */
-#define RAIL_ACTIVATE_ORDER_LENGTH		5 /* fixed */
-#define RAIL_SYSMENU_ORDER_LENGTH		8 /* fixed */
-#define RAIL_SYSCOMMAND_ORDER_LENGTH		6 /* fixed */
-#define RAIL_NOTIFY_EVENT_ORDER_LENGTH		12 /* fixed */
-#define RAIL_WINDOW_MOVE_ORDER_LENGTH		12 /* fixed */
-#define RAIL_GET_APPID_REQ_ORDER_LENGTH		4 /* fixed */
-#define RAIL_LANGBAR_INFO_ORDER_LENGTH		4 /* fixed */
-
-void rail_string_to_unicode_string(rdpRailOrder* rail_order, char* string, RAIL_UNICODE_STRING* unicode_string);
-
-BOOL rail_read_handshake_order(wStream* s, RAIL_HANDSHAKE_ORDER* handshake);
 BOOL rail_read_server_exec_result_order(wStream* s, RAIL_EXEC_RESULT_ORDER* exec_result);
 BOOL rail_read_server_sysparam_order(wStream* s, RAIL_SYSPARAM_ORDER* sysparam);
 BOOL rail_read_server_minmaxinfo_order(wStream* s, RAIL_MINMAXINFO_ORDER* minmaxinfo);
@@ -64,7 +30,6 @@ BOOL rail_read_server_localmovesize_order(wStream* s, RAIL_LOCALMOVESIZE_ORDER* 
 BOOL rail_read_server_get_appid_resp_order(wStream* s, RAIL_GET_APPID_RESP_ORDER* get_appid_resp);
 BOOL rail_read_langbar_info_order(wStream* s, RAIL_LANGBAR_INFO_ORDER* langbar_info);
 
-void rail_write_handshake_order(wStream* s, RAIL_HANDSHAKE_ORDER* handshake);
 void rail_write_client_status_order(wStream* s, RAIL_CLIENT_STATUS_ORDER* client_status);
 void rail_write_client_exec_order(wStream* s, RAIL_EXEC_ORDER* exec);
 void rail_write_client_sysparam_order(wStream* s, RAIL_SYSPARAM_ORDER* sysparam);

--- a/channels/rail/rail_common.c
+++ b/channels/rail/rail_common.c
@@ -1,0 +1,102 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * RAIL common functions
+ *
+ * Copyright 2011 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+ * Copyright 2011 Roman Barabanov <romanbarabanov@gmail.com>
+ * Copyright 2011 Vic Lee
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "rail_common.h"
+
+#include <winpr/crt.h>
+
+const char* const RAIL_ORDER_TYPE_STRINGS[] =
+{
+	"",
+	"Execute",
+	"Activate",
+	"System Parameters Update",
+	"System Command",
+	"Handshake",
+	"Notify Event",
+	"",
+	"Window Move",
+	"Local Move/Size",
+	"Min Max Info",
+	"Client Status",
+	"System Menu",
+	"Language Bar Info",
+	"Get Application ID Request",
+	"Get Application ID Response",
+	"Execute Result"
+};
+
+
+void rail_string_to_unicode_string(char* string, RAIL_UNICODE_STRING* unicode_string)
+{
+	WCHAR* buffer = NULL;
+	int length = 0;
+
+	if (unicode_string->string != NULL)
+		free(unicode_string->string);
+
+	unicode_string->string = NULL;
+	unicode_string->length = 0;
+
+	if (string == NULL || strlen(string) < 1)
+		return;
+
+	length = ConvertToUnicode(CP_UTF8, 0, string, -1, &buffer, 0) * 2;
+
+	unicode_string->string = (BYTE*) buffer;
+	unicode_string->length = (UINT16) length;
+}
+
+BOOL rail_read_pdu_header(wStream* s, UINT16* orderType, UINT16* orderLength)
+{
+	if (Stream_GetRemainingLength(s) < 4)
+		return FALSE;
+	Stream_Read_UINT16(s, *orderType); /* orderType (2 bytes) */
+	Stream_Read_UINT16(s, *orderLength); /* orderLength (2 bytes) */
+	return TRUE;
+}
+
+void rail_write_pdu_header(wStream* s, UINT16 orderType, UINT16 orderLength)
+{
+	Stream_Write_UINT16(s, orderType); /* orderType (2 bytes) */
+	Stream_Write_UINT16(s, orderLength); /* orderLength (2 bytes) */
+}
+
+wStream* rail_pdu_init(int length)
+{
+	wStream* s;
+	s = Stream_New(NULL, length + RAIL_PDU_HEADER_LENGTH);
+	Stream_Seek(s, RAIL_PDU_HEADER_LENGTH);
+	return s;
+}
+
+BOOL rail_read_handshake_order(wStream* s, RAIL_HANDSHAKE_ORDER* handshake)
+{
+	if (Stream_GetRemainingLength(s) < 4)
+		return FALSE;
+	Stream_Read_UINT32(s, handshake->buildNumber); /* buildNumber (4 bytes) */
+	return TRUE;
+}
+
+void rail_write_handshake_order(wStream* s, RAIL_HANDSHAKE_ORDER* handshake)
+{
+	Stream_Write_UINT32(s, handshake->buildNumber); /* buildNumber (4 bytes) */
+}
+

--- a/channels/rail/rail_common.h
+++ b/channels/rail/rail_common.h
@@ -1,0 +1,82 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * RAIL Virtual Channel Plugin
+ *
+ * Copyright 2011 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+ * Copyright 2011 Roman Barabanov <romanbarabanov@gmail.com>
+ * Copyright 2011 Vic Lee
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_RAIL_COMMON_H
+#define FREERDP_CHANNEL_RAIL_COMMON_H
+
+#include <freerdp/rail.h>
+
+#ifdef WITH_DEBUG_RAIL
+#define DEBUG_RAIL(fmt, ...) DEBUG_CLASS(RAIL, fmt, ## __VA_ARGS__)
+#else
+#define DEBUG_RAIL(fmt, ...) DEBUG_NULL(fmt, ## __VA_ARGS__)
+#endif
+
+extern const char* const RAIL_ORDER_TYPE_STRINGS[];
+
+
+#define RAIL_PDU_HEADER_LENGTH			4
+
+/* Fixed length of PDUs, excluding variable lengths */
+#define RAIL_HANDSHAKE_ORDER_LENGTH		4 /* fixed */
+#define RAIL_CLIENT_STATUS_ORDER_LENGTH		4 /* fixed */
+#define RAIL_EXEC_ORDER_LENGTH			8 /* variable */
+#define RAIL_SYSPARAM_ORDER_LENGTH		4 /* variable */
+#define RAIL_ACTIVATE_ORDER_LENGTH		5 /* fixed */
+#define RAIL_SYSMENU_ORDER_LENGTH		8 /* fixed */
+#define RAIL_SYSCOMMAND_ORDER_LENGTH		6 /* fixed */
+#define RAIL_NOTIFY_EVENT_ORDER_LENGTH		12 /* fixed */
+#define RAIL_WINDOW_MOVE_ORDER_LENGTH		12 /* fixed */
+#define RAIL_GET_APPID_REQ_ORDER_LENGTH		4 /* fixed */
+#define RAIL_LANGBAR_INFO_ORDER_LENGTH		4 /* fixed */
+
+struct rdp_rail_order
+{
+	rdpSettings* settings;
+	void* plugin;
+	RAIL_HANDSHAKE_ORDER handshake;
+	RAIL_CLIENT_STATUS_ORDER client_status;
+	RAIL_EXEC_ORDER exec;
+	RAIL_EXEC_RESULT_ORDER exec_result;
+	RAIL_SYSPARAM_ORDER sysparam;
+	RAIL_ACTIVATE_ORDER activate;
+	RAIL_SYSMENU_ORDER sysmenu;
+	RAIL_SYSCOMMAND_ORDER syscommand;
+	RAIL_NOTIFY_EVENT_ORDER notify_event;
+	RAIL_MINMAXINFO_ORDER minmaxinfo;
+	RAIL_LOCALMOVESIZE_ORDER localmovesize;
+	RAIL_WINDOW_MOVE_ORDER window_move;
+	RAIL_LANGBAR_INFO_ORDER langbar_info;
+	RAIL_GET_APPID_REQ_ORDER get_appid_req;
+	RAIL_GET_APPID_RESP_ORDER get_appid_resp;
+};
+typedef struct rdp_rail_order rdpRailOrder;
+
+
+void rail_string_to_unicode_string(char* string, RAIL_UNICODE_STRING* unicode_string);
+BOOL rail_read_handshake_order(wStream* s, RAIL_HANDSHAKE_ORDER* handshake);
+void rail_write_handshake_order(wStream* s, RAIL_HANDSHAKE_ORDER* handshake);
+
+wStream* rail_pdu_init(int length);
+BOOL rail_read_pdu_header(wStream* s, UINT16* orderType, UINT16* orderLength);
+void rail_write_pdu_header(wStream* s, UINT16 orderType, UINT16 orderLength);
+
+#endif /* FREERDP_CHANNEL_RAIL_COMMON_H */

--- a/include/freerdp/rail.h
+++ b/include/freerdp/rail.h
@@ -157,13 +157,13 @@ struct _RAIL_UNICODE_STRING
 };
 typedef struct _RAIL_UNICODE_STRING RAIL_UNICODE_STRING;
 
-struct _HIGH_CONTRAST
+struct _RAIL_HIGH_CONTRAST
 {
 	UINT32 flags;
 	UINT32 colorSchemeLength;
 	RAIL_UNICODE_STRING colorScheme;
 };
-typedef struct _HIGH_CONTRAST HIGH_CONTRAST;
+typedef struct _RAIL_HIGH_CONTRAST RAIL_HIGH_CONTRAST;
 
 /* RAIL Orders */
 
@@ -208,7 +208,7 @@ struct _RAIL_SYSPARAM_ORDER
 	RECTANGLE_16 workArea;
 	RECTANGLE_16 displayChange;
 	RECTANGLE_16 taskbarPos;
-	HIGH_CONTRAST highContrast;
+	RAIL_HIGH_CONTRAST highContrast;
 	BOOL setScreenSaveActive;
 	BOOL setScreenSaveSecure;
 };


### PR DESCRIPTION
This patch starts a code mutualisation for a RAIL server-side implementation. The file rail_common.c contains code that is shared by both client and server.
