### PR TITLE
Fixed NULL check in freerdp_device_collection_find

### DIFF
--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -154,6 +154,9 @@ RDPDR_DEVICE* freerdp_device_collection_find(rdpSettings* settings, const char* 
 	{
 		device = (RDPDR_DEVICE*) settings->DeviceArray[index];
 
+		if (NULL == device->Name)
+			continue;
+
 		if (strcmp(device->Name, name) == 0)
 			return device;
 	}


### PR DESCRIPTION
Fixes a issue, where a command line crashes the client. The device channels may not have a name.
Example command line: `xfreerdp /v:<server> /u:<user> /p:<pwd> /printer +drives`
