### PR TITLE
x11/client: win8/server 2k12 fix for kbd sync

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1407,8 +1407,14 @@ void* xf_thread(void* param)
 		rcount = 0;
 		wcount = 0;
 
+		/*
+		 * win8 and server 2k12 seem to have some timing issue/race condition
+		 * when a initial sync request is send to sync the keyboard inidcators
+		 * sending the sync event twice fixed this problem
+		 */
 		if (freerdp_focus_required(instance))
 		{
+			xf_kbd_focus_in(xfc);
 			xf_kbd_focus_in(xfc);
 		}
 


### PR DESCRIPTION
Keyboard indicator sync (caps lock/num lock/..) didn't work properly
on reconnect for windows 8 and windows 2012 server.

fixes #773
