### PR TITLE
Respond to DYNVC_CLOSE like described in MS-RDPEDYC 

### DIFF
--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -293,7 +293,7 @@ static int drdynvc_process_close_request(drdynvcPlugin* drdynvc, int Sp, int cbC
 	dvcman_close_channel(drdynvc->channel_mgr, ChannelId);
 	
 	data_out = Stream_New(NULL, 4);
-	value = (CLOSE_REQUEST_PDU << 4) | (cbChId & 0x02);
+	value = (CLOSE_REQUEST_PDU << 4) | (cbChId & 0x03);
 	Stream_Write_UINT8(data_out, value);
 	drdynvc_write_variable_uint(data_out, ChannelId);
 	error = svc_plugin_send((rdpSvcPlugin*) drdynvc, data_out);


### PR DESCRIPTION
Based on pull request #1475

When the DVC server manager initiates closing a channel, it sends a Close Request PDU that specifies the ChannelId to the DVC client manager. The client responds with a Close Response PDU that specifies the ChannelId.

The client response was missing.

fixes #1375
