### PR TITLE
send RDP_NEG_REQ also in the case of a null server certificate

### DIFF
--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -794,6 +794,7 @@ void nego_process_negotiation_failure(rdpNego* nego, wStream* s)
 
 		case SSL_NOT_ALLOWED_BY_SERVER:
 			DEBUG_NEGO("Error: SSL_NOT_ALLOWED_BY_SERVER");
+			nego->sendNegoData = TRUE;
 			break;
 
 		case SSL_CERT_NOT_ON_SERVER:
@@ -933,6 +934,7 @@ void nego_init(rdpNego* nego)
 	nego->transport->ReceiveCallback = nego_recv;
 	nego->transport->ReceiveExtra = (void*) nego;
 	nego->cookie_max_length = DEFAULT_COOKIE_MAX_LENGTH;
+	nego->sendNegoData = FALSE;
 	nego->flags = 0;
 }
 


### PR DESCRIPTION
In the case of an RDP server with security set to "RDP" level and null server certificate, the negotiations will return error code SSL_NOT_ALLOWED_BY_SERVER.  In that case, we still want to send the RDP_NEG_REQ negotiation request -- otherwise things like multimonitor layout cannot be passed to the server.   This results in Span Mode rather than True Multimonitor Mode (and probably some other effects as well).
