### PR TITLE
Fix extended mouse event to register the click for forward/back buttons

### DIFF
--- a/server/X11/xf_input.c
+++ b/server/X11/xf_input.c
@@ -123,10 +123,24 @@ void xf_input_extended_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UINT
 {
 #ifdef WITH_XTEST
 	xfPeerContext* xfp = (xfPeerContext*) input->context;
+	int button = 0;
+	BOOL down = FALSE;
 	xfInfo* xfi = xfp->info;
 
 	XTestGrabControl(xfi->display, True);
 	XTestFakeMotionEvent(xfi->display, 0, x, y, CurrentTime);
+
+	if (flags & PTR_XFLAGS_BUTTON1)
+		button = 8;
+	else if (flags & PTR_XFLAGS_BUTTON2)
+		button = 9;
+
+	if (flags & PTR_XFLAGS_DOWN)
+		down = TRUE;
+
+	if (button != 0)
+		XTestFakeButtonEvent(xfi->display, button, down, 0);
+
 	XTestGrabControl(xfi->display, False);
 #endif
 }


### PR DESCRIPTION
This is my first github submission, so hopefully I got everything right…  If not, I'm happy to fix it and re-submit.

For X11 clients, the extended mouse buttons (back / forward) do not seem to be passed through to the RDP server.  I've been having this problem with a Logitech m510 mouse and multiple Ubuntu versions connecting to a Windows 8 machine.  The back buttons work locally (in firefox, etc.) but are not passed to the RDP server.  This problem has also been reported by others in both FreeRDP and Remmina:
http://forums.debian.net/viewtopic.php?f=30&t=104772
http://sourceforge.net/mailarchive/message.php?msg_id=29017116

The following pull request addressed this topic, at least partially.  However, while the patch recognized the button events in xf_event.c, it did not actually apply them in xf_input_extended_mouse_event in xf_input.c.
https://github.com/FreeRDP/FreeRDP/pull/533

I've made a simple adjustment to xf_input.c to correct this issue, and the back and forward buttons work correctly now.  Submitting the updated code for inclusion in the master branch.
