### PR TITLE
Wait for single object portable thread and mutex timeout

### DIFF
--- a/winpr/libwinpr/synch/wait.c
+++ b/winpr/libwinpr/synch/wait.c
@@ -167,6 +167,7 @@ DWORD WaitForSingleObject(HANDLE hHandle, DWORD dwMilliseconds)
 	}
 	else if (Type == HANDLE_TYPE_MUTEX)
 	{
+		int status;
 		WINPR_MUTEX* mutex;
 
 		mutex = (WINPR_MUTEX*) Object;


### PR DESCRIPTION
Implements missing timeout functionality for non linux systems and fixes return value on timeout.
