### PR TITLE
Crash fix.

### DIFF
--- a/client/common/client.c
+++ b/client/common/client.c
@@ -70,8 +70,8 @@ void freerdp_client_context_free(rdpContext* context)
 {
 	freerdp* instance = context->instance;
 
-	free(instance->pClientEntryPoints);
 	freerdp_context_free(instance);
+	free(instance->pClientEntryPoints);
 	freerdp_free(instance);
 }
 


### PR DESCRIPTION
instance->pClientEntryPoints was being deleted before the call to freerdp_context_free() which uses that pointer.
