### PR TITLE
Minor optimization in Drive Channel

### DIFF
--- a/channels/drive/client/drive_main.c
+++ b/channels/drive/client/drive_main.c
@@ -795,8 +795,7 @@ int DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
 			if (*dev > 'B')
                         {
 				/* Suppress disk drives A and B to avoid pesty messages */
-				_snprintf(buf, sizeof(buf) - 4, "%s", drive->Name);
-				len = strlen(buf);
+				len = _snprintf(buf, sizeof(buf) - 4, "%s", drive->Name);
 				buf[len] = '_';
 				buf[len + 1] = dev[0];
 				buf[len + 2] = 0;


### PR DESCRIPTION
DeviceServiceEntry when setting up to share all drives. Removed the call to strlen() and use
the return value from _snprintf
