### PR TITLE
Add support with new args for client hostname

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -54,6 +54,7 @@ COMMAND_LINE_ARGUMENT_A args[] =
 	{ "admin", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "console", "Admin (or console) session" },
 	{ "restricted-admin", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "restrictedAdmin", "Restricted admin mode" },
 	{ "pth", COMMAND_LINE_VALUE_REQUIRED, "<password hash>", NULL, NULL, -1, "pass-the-hash", "Pass the hash (restricted admin mode)" },
+	{ "client-hostname", COMMAND_LINE_VALUE_REQUIRED, "<name>", NULL, NULL, -1, NULL, "Client Hostname to send to server" },
 	{ "multimon", COMMAND_LINE_VALUE_OPTIONAL, NULL, NULL, NULL, -1, NULL, "Use multiple monitors" },
 	{ "workarea", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Use available work area" },
 	{ "monitors", COMMAND_LINE_VALUE_REQUIRED, "<0,1,2...>", NULL, NULL, -1, NULL, "Select monitors to use" },
@@ -1244,6 +1245,10 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 			settings->ConsoleSession = TRUE;
 			settings->RestrictedAdminModeRequired = TRUE;
 			settings->PasswordHash = _strdup(arg->Value);
+		}
+		CommandLineSwitchCase(arg, "client-hostname")
+		{
+			settings->ClientHostname = _strdup(arg->Value);
 		}
 		CommandLineSwitchCase(arg, "kbd")
 		{

--- a/client/common/compatibility.c
+++ b/client/common/compatibility.c
@@ -490,6 +490,7 @@ int freerdp_client_parse_old_command_line_arguments(int argc, char** argv, rdpSe
 		CommandLineSwitchCase(arg, "n")
 		{
 			settings->ClientHostname = _strdup(arg->Value);
+			fprintf(stderr, "-n -> /client-hostname:%s\n", arg->Value);
 		}
 		CommandLineSwitchCase(arg, "o")
 		{


### PR DESCRIPTION
The old -n argument did not otherwise have a new command line option.  This adds support for that via /client-hostname.
