### PR TITLE
winpr: fixed build warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,11 @@ if(NOT IOS AND NOT ANDROID)
 	find_package(Threads REQUIRED)
 endif()
 
+list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+check_library_exists(pthread pthread_tryjoin_np "" HAVE_PTHREAD_GNU_EXT)
+list(REMOVE_ITEM CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+
+
 if(UNIX OR CYGWIN)
 	check_include_files(sys/eventfd.h HAVE_AIO_H)
 	check_include_files(sys/eventfd.h HAVE_EVENTFD_H)

--- a/winpr/libwinpr/synch/CMakeLists.txt
+++ b/winpr/libwinpr/synch/CMakeLists.txt
@@ -18,13 +18,8 @@
 set(MODULE_NAME "winpr-synch")
 set(MODULE_PREFIX "WINPR_SYNCH")
 
-INCLUDE (CheckLibraryExists) 
-list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
-check_library_exists(pthread pthread_tryjoin_np "" HAVE_PTHREAD_GNU_EXT)
-list(REMOVE_ITEM CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
-
 if(HAVE_PTHREAD_GNU_EXT)
-	add_definitions(-D_GNU_SOURCE -DHAVE_PTHREAD_GNU_EXT)
+	add_definitions(-D_GNU_SOURCE)
 endif(HAVE_PTHREAD_GNU_EXT)
 	
 include_directories(../thread)


### PR DESCRIPTION
- moved pthread_tryjoin_np to toplevel CMakeLists.txt
- removed duplicated -DHAVE_PTHREAD_GNU_EXT
