### PR TITLE
Ffmpeg 2.1

### DIFF
--- a/channels/tsmf/client/ffmpeg/tsmf_ffmpeg.c
+++ b/channels/tsmf/client/ffmpeg/tsmf_ffmpeg.c
@@ -54,7 +54,11 @@ typedef struct _TSMFFFmpegDecoder
 	ITSMFDecoder iface;
 
 	int media_type;
+#if LIBAVCODEC_VERSION_MAJOR < 55
 	enum CodecID codec_id;
+#else
+	enum AVCodecID codec_id;
+#endif
 	AVCodecContext* codec_context;
 	AVCodec* codec;
 	AVFrame* frame;


### PR DESCRIPTION
Issue #1385

With these changes, freerdp builds against ffmpeg-2.1 on Gentoo (current ~amd64 branch). The test suite passes, but I'm unsure if that excersises the ffmpeg interface. Build and tests are verified to not have broken against ffmpeg-1.2.4.

I am not sure how to properly verify runtime functionality, so please test carefully.
