### PR TITLE
Revised 2003r2 farm compatibility support

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1418,6 +1418,13 @@ void* xf_thread(void* param)
 	async_channels = settings->AsyncChannels;
 	async_transport = settings->AsyncTransport;
 
+	#ifdef WITH_DEBUG_REDIR
+		if (async_transport)
+		{
+			fprintf(stderr, "using async transport");
+		}
+	#endif
+
 	if (async_update)
 	{
 		update_thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) xf_update_thread, instance, 0, NULL);
@@ -1523,10 +1530,14 @@ void* xf_thread(void* param)
 		}
 
 		if (!async_transport)
-		{
+		{	 if (xfc->disconnect || freerdp_shall_disconnect(instance))
+			{
+				fprintf(stderr, "XfreeRDP synchronous connection closing\n");
+			}	
+
 			if (freerdp_check_fds(instance) != TRUE)
 			{
-				fprintf(stderr, "Failed to check FreeRDP file descriptor\n");
+				fprintf(stderr, "Failed to check FreeRDP file descriptor while closing synchronously\n");
 				break;
 			}
 		}

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -295,14 +295,17 @@ BOOL rdp_client_redirect(rdpRdp* rdp)
 	rdp_reset(rdp);
 
 	rdp_redirection_apply_settings(rdp);
-
+	
 	if (settings->RedirectionFlags & LB_LOAD_BALANCE_INFO)
 	{
 		nego_set_routing_token(rdp->nego, settings->LoadBalanceInfo, settings->LoadBalanceInfoLength);
+		#ifdef WITH_DEBUG_REDIR
+			fprintf(stderr, "Using token based routing\n");
+		#endif
 	}
-	else
-	{
-		if (settings->RedirectionFlags & LB_TARGET_NET_ADDRESS)
+	
+	// this used to be an else against the token routing, however for 2003 we may get both LB info & a noredirect for a token based initial connect
+	if (settings->RedirectionFlags & LB_TARGET_NET_ADDRESS)
 		{
 			free(settings->ServerHostname);
 			settings->ServerHostname = _strdup(settings->TargetNetAddress);
@@ -317,7 +320,7 @@ BOOL rdp_client_redirect(rdpRdp* rdp)
 			free(settings->ServerHostname);
 			settings->ServerHostname = _strdup(settings->RedirectionTargetNetBiosName);
 		}
-	}
+	// end of token routed alternative branch...
 
 	if (settings->RedirectionFlags & LB_USERNAME)
 	{

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -218,6 +218,9 @@ BOOL freerdp_check_fds(freerdp* instance)
 
 	if (status < 0)
 	{
+#ifdef WITH_DEBUG_REDIR
+		fprintf(stderr, "Exiting due to fds check fail\n");
+#endif
 		TerminateEventArgs e;
 		rdpContext* context = instance->context;
 

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -74,6 +74,10 @@ BOOL transport_disconnect(rdpTransport* transport)
 {
 	BOOL status = TRUE;
 
+	#ifdef WITH_DEBUG_REDIR
+		fprintf(stderr, "Disconnecting server..\n");
+	#endif
+
 	if (!transport)
 		return FALSE;
 
@@ -336,6 +340,10 @@ BOOL transport_connect(rdpTransport* transport, const char* hostname, UINT16 por
 	rdpSettings* settings = transport->settings;
 
 	transport->async = settings->AsyncTransport;
+
+	#ifdef WITH_DEBUG_REDIR
+		fprintf(stderr, "Connecting server..\n");
+	#endif
 
 	if (transport->settings->GatewayEnabled)
 	{
@@ -905,6 +913,12 @@ int transport_check_fds(rdpTransport* transport)
 		 */
 
 		recv_status = transport->ReceiveCallback(transport, received, transport->ReceiveExtra);
+
+		if (recv_status == -1) //ignore errr for 2003 farm compatibility. 
+		{
+			DEBUG_REDIR("Callback status overridden: -1\n");
+			return 0;
+		}
 
 		if (recv_status == 1)
 		{


### PR DESCRIPTION
Attempts to fix issue #1309 
The current code does not handle 2003r2 enterprise server farms, either in token or IP routing modes.
This X11 based fix attempts to address it.
I have had to include a hack to avoid the client exiting due to an invalid file descriptor, which needs further investigation & fixing before it can be included fully as it will cause other instability/errors.

I have tested under debian X11 (not exhaustively) with farm 2003r2, 2008r2 for token & ip based routing.
Some changes were made to the X specific client code, it is likely something similar may need applying before they would work too.
