### PR TITLE
Bluetooth Keyboard Fix

### DIFF
--- a/client/iOS/Controllers/RDPSessionViewController.h
+++ b/client/iOS/Controllers/RDPSessionViewController.h
@@ -57,7 +57,7 @@
     AdvancedKeyboardView* _advanced_keyboard_view;
     BOOL _advanced_keyboard_visible;
     BOOL _requesting_advanced_keyboard;
-    CGFloat _keyboard_height_delta;
+    CGFloat _keyboard_last_height;
     
     // delayed mouse move event sending
     NSTimer* _mouse_move_event_timer;


### PR DESCRIPTION
There in an issue when using a bluetooth keyboard during an RDP Session on iOS.

The view was incorrectly calculating the height of the keyboard when using a bluetooth keyboard resulting in a large black area.
