### PR TITLE
Harden capability parsing

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -3156,7 +3156,7 @@ BOOL rdp_read_capability_sets(wStream* s, rdpSettings* settings, UINT16 numberCa
 	Stream_GetPointer(s, mark);
 	count = numberCapabilities;
 
-	while (numberCapabilities > 0)
+	while (numberCapabilities > 0 && Stream_GetRemainingLength(s) >= 4)
 	{
 		Stream_GetPointer(s, bm);
 
@@ -3340,6 +3340,11 @@ BOOL rdp_read_capability_sets(wStream* s, rdpSettings* settings, UINT16 numberCa
 	rdp_print_capability_sets(s, numberCapabilities, TRUE);
 	Stream_SetPointer(s, em);
 #endif
+	if (numberCapabilities)
+	{
+		fprintf(stderr, "%s: strange we haven't read the number of announced capacity sets, read=%d expected=%d\n",
+				__FUNCTION__, count-numberCapabilities, count);
+	}
 
 	return TRUE;
 }


### PR DESCRIPTION
Don't check only the number of capabilities but also the remaining size in the stream.
