### PR TITLE
Fix possible integer overflow in license_read_scope_list()

### DIFF
--- a/libfreerdp/core/license.c
+++ b/libfreerdp/core/license.c
@@ -670,6 +670,9 @@ BOOL license_read_scope_list(wStream* s, SCOPE_LIST* scopeList)
 
 	Stream_Read_UINT32(s, scopeCount); /* ScopeCount (4 bytes) */
 
+        if (Stream_GetRemainingLength(s) / sizeof(LICENSE_BLOB) < scopeCount)
+                return FALSE;  /* Avoid overflow in malloc */
+
 	scopeList->count = scopeCount;
 	scopeList->array = (LICENSE_BLOB*) malloc(sizeof(LICENSE_BLOB) * scopeCount);
 


### PR DESCRIPTION
On 32-bit arches sizeof(LICENSE_BLOB) \* scopeCount > SIZE_MAX and cause an overflow. This will result in a buffer-overflow later in license_read_binary_blob.

Not sure if this cause a server crash or a client crash though
