### PR TITLE
Address bitmap related crashes.

### DIFF
--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -355,7 +355,7 @@ void rdp_write_info_packet(wStream* s, rdpSettings* settings)
 		flags |= INFO_REMOTECONSOLEAUDIO;
 
 	if (settings->CompressionEnabled)
-		flags |= INFO_COMPRESSION | INFO_PACKET_COMPR_TYPE_RDP6;
+		flags |= INFO_COMPRESSION | INFO_PACKET_COMPR_TYPE_64K;
 
 	if (settings->Domain)
 	{


### PR DESCRIPTION
After tracing bitmap related crashes (such as in issue #1570, but there are many more symptoms), I believe that the root cause problem is that the RDP6 decompression is not quite correct.

In the meantime I recommend switching back to 64K compression, which seems to address the crashes.

To reproduce the crashes, please carry out the following:
1) Connect to a Windows 8.1 server in bitmap mode - also happens with other servers but 8.1 seems easiest.
2) Loop a non-MMR video or other source of continuous screen updates so that you get frequent bitmap updates
3) Wait a few minutes at most and you should see the crash.

The sequence of events leading to the crash looks like:
RDP6 Compressed Data -> Bad decompression -> RLE bitmap decode fails -> no bitmap
