### PR TITLE
Fixes for redirected-drive cut, mode, read/write

### DIFF
--- a/channels/drive/client/drive_file.h
+++ b/channels/drive/client/drive_file.h
@@ -108,11 +108,11 @@ struct _DRIVE_FILE
 
 DRIVE_FILE* drive_file_new(const char* base_path, const char* path, UINT32 id,
 	UINT32 DesiredAccess, UINT32 CreateDisposition, UINT32 CreateOptions);
-void drive_file_free(DRIVE_FILE* file);
+int drive_file_free(DRIVE_FILE* file, BOOL recursive);
 
 BOOL drive_file_seek(DRIVE_FILE* file, UINT64 Offset);
 BOOL drive_file_read(DRIVE_FILE* file, BYTE* buffer, UINT32* Length);
-BOOL drive_file_write(DRIVE_FILE* file, BYTE* buffer, UINT32 Length);
+BOOL drive_file_write(DRIVE_FILE* file, const BYTE* buffer, UINT32 Length);
 BOOL drive_file_query_information(DRIVE_FILE* file, UINT32 FsInformationClass, wStream* output);
 BOOL drive_file_set_information(DRIVE_FILE* file, UINT32 FsInformationClass, UINT32 Length, wStream* input);
 BOOL drive_file_query_directory(DRIVE_FILE* file, UINT32 FsInformationClass, BYTE InitialQuery,


### PR DESCRIPTION
Several changes to drive redirection.  Most importantly, without this fix if you cut a folder from your redirected drive and paste it to the desktop, you'll lose all its contents.  This is because the RDP server requests that the drive be deleted _before_ it does the copy.  mstsc treated this premature delete-pending request on the directory as an error; freerdp happily did as ordered and recursively deleted the directory and returned "success".

Also included in this patch:  it will set the file mode appropriately (assuming the filesystem on your redirected storage supports it!); also read and write will not fail if an interrupt is received or for EAGAIN/EINTR.

I recommend this both for stable-1.1 and master branches.
