### PR TITLE
wfreerdp: fix gdi polyline mistake.

### DIFF
--- a/client/Windows/wf_gdi.c
+++ b/client/Windows/wf_gdi.c
@@ -521,12 +521,18 @@ void wf_gdi_polyline(wfContext* wfc, POLYLINE_ORDER* polyline)
 
 	if (polyline->numPoints > 0)
 	{
+		POINT temp;
+
+		temp.x = polyline->xStart;
+		temp.y = polyline->yStart;
 		pts = (POINT*) malloc(sizeof(POINT) * polyline->numPoints);
 
 		for (i = 0; i < (int) polyline->numPoints; i++)
 		{
-			pts[i].x = polyline->points[i].x;
-			pts[i].y = polyline->points[i].y;
+			temp.x += polyline->points[i].x;
+			temp.y += polyline->points[i].y;
+			pts[i].x = temp.x;
+			pts[i].y = temp.y;
 
 			if (wfc->drawing == wfc->primary)
 				wf_invalidate_region(wfc, pts[i].x, pts[i].y, pts[i].x + 1, pts[i].y + 1);


### PR DESCRIPTION
Points in POLYLINE_ORDER are delta-encoded points.
ref: [MS-RDPEGDI] 2.2.2.3.1.1.1.4
