### PR TITLE
fix multimon and span flags-freerdp always spans monitors follow up to #1691

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -45,6 +45,7 @@ COMMAND_LINE_ARGUMENT_A args[] =
 	{ "h", COMMAND_LINE_VALUE_REQUIRED, "<height>", "768", NULL, -1, NULL, "Height" },
 	{ "size", COMMAND_LINE_VALUE_REQUIRED, "<width>x<height>", "1024x768", NULL, -1, NULL, "Screen size" },
 	{ "f", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Fullscreen mode" },
+	{ "span", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Span mode" },
 	{ "bpp", COMMAND_LINE_VALUE_REQUIRED, "<depth>", "16", NULL, -1, NULL, "Session bpp (color depth)" },
 	{ "kbd", COMMAND_LINE_VALUE_REQUIRED, "0x<layout id> or <layout name>", NULL, NULL, -1, NULL, "Keyboard layout" },
 	{ "kbd-list", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT, NULL, NULL, NULL, -1, NULL, "List keyboard layouts" },

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -405,7 +405,7 @@ void gcc_write_client_data_blocks(wStream* s, rdpSettings* settings)
 
 	if (settings->NegotiationFlags & EXTENDED_CLIENT_DATA_SUPPORTED)
 	{
-		if (settings->SpanMonitors)
+		if (!settings->SpanMonitors)
 		{
 			gcc_write_client_monitor_data(s, settings);
 		}


### PR DESCRIPTION
Add span flag so that /span is recognized in cmdline.c
Add negation to settings->SpanMonitors so that the multimon flag takes effect