### PR TITLE
Fix assertion abort when no CN is present in certificate

### DIFF
--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -865,8 +865,7 @@ void tls_print_certificate_name_mismatch_error(char* hostname, char* common_name
 	int index;
 
 	assert(NULL != hostname);
-	assert(NULL != common_name);
-	
+
 	fprintf(stderr, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n");
 	fprintf(stderr, "@           WARNING: CERTIFICATE NAME MISMATCH!           @\n");
 	fprintf(stderr, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n");
@@ -874,17 +873,14 @@ void tls_print_certificate_name_mismatch_error(char* hostname, char* common_name
 	fprintf(stderr, "does not match %s given in the certificate:\n", alt_names_count < 1 ? "the name" : "any of the names");
 	fprintf(stderr, "Common Name (CN):\n");
 	fprintf(stderr, "\t%s\n", common_name ? common_name : "no CN found in certificate");
-	if (alt_names_count > 1)
+	if (alt_names_count > 0)
 	{
 		assert(NULL != alt_names);
 		fprintf(stderr, "Alternative names:\n");
-		if (alt_names_count > 1)
+		for (index = 0; index < alt_names_count; index++)
 		{
-			for (index = 0; index < alt_names_count; index++)
-			{
-				assert(alt_names[index]);
-				fprintf(stderr, "\t %s\n", alt_names[index]);
-			}
+			assert(alt_names[index]);
+			fprintf(stderr, "\t %s\n", alt_names[index]);
 		}
 	}
 	fprintf(stderr, "A valid certificate for the wrong name should NOT be trusted!\n");


### PR DESCRIPTION
Triggered by Windows Server 2012 Admin-Mode with MS-recommended AD CA
Certificate setup, which would cause the CN to be absent, and a single
subjectAltName to be present.

This also actually lists the subjectAltNames in the error message.
