### PR TITLE
Update xf_keyboard.c

### DIFF
--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -102,6 +102,13 @@ void xf_kbd_send_key(xfContext* xfc, BOOL down, BYTE keycode)
 
 	if (rdp_scancode == RDP_SCANCODE_UNKNOWN)
 	{
+		//recognize a power button push, exit immediately returning 124 (keycode valule for power button)
+		if (keycode == 0x7c )
+        	{
+		fprintf(stderr,"Power Button\n");
+		exit(124);
+		}
+
 		fprintf(stderr, "Unknown key with X keycode 0x%02x\n", keycode);
 	}
 	else if (rdp_scancode == RDP_SCANCODE_PAUSE &&


### PR DESCRIPTION
The power button is trapped by the xfreerdp when in fullscreen mode.  I would like xfreerdp to exit immediately and give the calling program some idea of what happened.  Exit code of 124 is given.  This is the x keycode for the power button.  "Power Button" is sent to stderr.  Either one of these can be inspected by a calling program and the information used for proper control.