### PR TITLE
Change TZ Daylight Savings Time start date for US

### DIFF
--- a/libfreerdp/locale/timezone.c
+++ b/libfreerdp/locale/timezone.c
@@ -76,7 +76,7 @@ typedef struct _TIME_ZONE_ENTRY TIME_ZONE_ENTRY;
 static const TIME_ZONE_RULE_ENTRY TimeZoneRuleTable_3[] =
 {
 	{ 633031380000000000ULL, 180000000000ULL, 60, { 0, 10, 0, 1, 2, 0 }, { 0, 4, 0, 1, 2, 0 }, },
-	{ 3155378292000000000ULL, 633032244000000000ULL, 60, { 0, 11, 0, 1, 2, 0 }, { 0, 3, 0, 1, 2, 0 }, }
+	{ 3155378292000000000ULL, 633032244000000000ULL, 60, { 0, 11, 0, 1, 2, 0 }, { 0, 3, 0, 2, 2, 0 }, }
 };
 
 static const TIME_ZONE_RULE_ENTRY TimeZoneRuleTable_4[] =
@@ -87,7 +87,7 @@ static const TIME_ZONE_RULE_ENTRY TimeZoneRuleTable_4[] =
 static const TIME_ZONE_RULE_ENTRY TimeZoneRuleTable_5[] =
 {
 	{ 633031380000000000ULL, 180000000000ULL, 60, { 0, 10, 0, 1, 2, 0 }, { 0, 4, 0, 1, 2, 0 }, },
-	{ 3155378292000000000ULL, 633032244000000000ULL, 60, { 0, 11, 0, 1, 2, 0 }, { 0, 3, 0, 1, 2, 0 }, }
+	{ 3155378292000000000ULL, 633032244000000000ULL, 60, { 0, 11, 0, 1, 2, 0 }, { 0, 3, 0, 2, 2, 0 }, }
 };
 
 static const TIME_ZONE_RULE_ENTRY TimeZoneRuleTable_7[] =
@@ -98,13 +98,13 @@ static const TIME_ZONE_RULE_ENTRY TimeZoneRuleTable_7[] =
 static const TIME_ZONE_RULE_ENTRY TimeZoneRuleTable_8[] =
 {
 	{ 633031380000000000ULL, 180000000000ULL, 60, { 0, 10, 0, 1, 2, 0 }, { 0, 4, 0, 1, 2, 0 }, },
-	{ 3155378292000000000ULL, 633032244000000000ULL, 60, { 0, 11, 0, 1, 2, 0 }, { 0, 3, 0, 1, 2, 0 }, }
+	{ 3155378292000000000ULL, 633032244000000000ULL, 60, { 0, 11, 0, 1, 2, 0 }, { 0, 3, 0, 2, 2, 0 }, }
 };
 
 static const TIME_ZONE_RULE_ENTRY TimeZoneRuleTable_10[] =
 {
 	{ 633031380000000000ULL, 180000000000ULL, 60, { 0, 10, 0, 1, 2, 0 }, { 0, 4, 0, 1, 2, 0 }, },
-	{ 3155378292000000000ULL, 633032244000000000ULL, 60, { 0, 11, 0, 1, 2, 0 }, { 0, 3, 0, 1, 2, 0 }, }
+	{ 3155378292000000000ULL, 633032244000000000ULL, 60, { 0, 11, 0, 1, 2, 0 }, { 0, 3, 0, 2, 2, 0 }, }
 };
 
 static const TIME_ZONE_RULE_ENTRY TimeZoneRuleTable_11[] =
@@ -121,7 +121,7 @@ static const TIME_ZONE_RULE_ENTRY TimeZoneRuleTable_14[] =
 static const TIME_ZONE_RULE_ENTRY TimeZoneRuleTable_15[] =
 {
 	{ 633031380000000000ULL, 632716884000000000ULL, 60, { 0, 10, 0, 1, 2, 0 }, { 0, 4, 0, 1, 2, 0 }, },
-	{ 3155378292000000000ULL, 633032244000000000ULL, 60, { 0, 11, 0, 1, 2, 0 }, { 0, 3, 0, 1, 2, 0 }, }
+	{ 3155378292000000000ULL, 633032244000000000ULL, 60, { 0, 11, 0, 1, 2, 0 }, { 0, 3, 0, 2, 2, 0 }, }
 };
 
 static const TIME_ZONE_RULE_ENTRY TimeZoneRuleTable_17[] =


### PR DESCRIPTION
Daylight savings time is now encoded to start the first sunday in march.
US Daylight Standard Time begins on the second sunday in march.  
Changed data for US eastern, US central, US Mountain, US Pacific and Alaska Time Zones.