### PR TITLE
fix "mcode" check in cliprdr_thread_func()

### DIFF
--- a/client/Windows/wf_cliprdr.c
+++ b/client/Windows/wf_cliprdr.c
@@ -350,7 +350,7 @@ static void *cliprdr_thread_func(void *arg)
 		return NULL;
 	}
 
-	while ((mcode = GetMessage(&msg, 0, 0, 0) != 0))
+	while ((mcode = GetMessage(&msg, 0, 0, 0)) != 0)
 	{
 		if (mcode == -1)
 		{


### PR DESCRIPTION
Priority of the '!=' is higher than '=' operator
