### PR TITLE
libfreerdp-core/mcs: fixed protocol error+segfault

### DIFF
--- a/libfreerdp/core/mcs.c
+++ b/libfreerdp/core/mcs.c
@@ -850,7 +850,7 @@ BOOL mcs_send_attach_user_confirm(rdpMcs* mcs)
 	s = Stream_New(NULL, length);
 	settings = mcs->transport->settings;
 
-	mcs->userId = MCS_GLOBAL_CHANNEL_ID + 1 + settings->ChannelCount;
+	mcs->userId = MCS_GLOBAL_CHANNEL_ID + 1 + mcs->channelCount;
 
 	mcs_write_domain_mcspdu_header(s, DomainMCSPDU_AttachUserConfirm, length, 2);
 


### PR DESCRIPTION
wrong channelcount pointer was referenced in the server
mcs attach user confirm pdu
