### PR TITLE
only process msg channel pdu if msg channel is set

### DIFF
--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1050,7 +1050,7 @@ static int rdp_recv_tpkt_pdu(rdpRdp* rdp, wStream* s)
 			Stream_SetPosition(s, nextPosition);
 		}
 	}
-	else if (channelId == rdp->mcs->messageChannelId)
+	else if (rdp->mcs->messageChannelId && channelId == rdp->mcs->messageChannelId)
 	{
 		return rdp_recv_message_channel_pdu(rdp, s);
 	}


### PR DESCRIPTION
In case there is no message channel messageChannelId is 0. In this case it can happen that channels with (invalid) id 0 are processed by rdp_recv_message_channel_pdu instead of the regular path where unknown/invalid channels are handled.
