### PR TITLE
libfreerdp-core: fixed transport

### DIFF
--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -874,7 +874,7 @@ int transport_check_fds(rdpTransport* transport)
 	{
 		status = transport_read_nonblocking(transport);
 
-		if (status <= 0)
+		if (status < 0 || Stream_GetPosition(transport->ReceiveBuffer) == 0)
 			return status;
 
 		while ((pos = Stream_GetPosition(transport->ReceiveBuffer)) > 0)


### PR DESCRIPTION
Commit 1daea0d0dc9eb63b6bb1e525e49de82800d34751 introduced an
error: If transport_read_nonblocking returns 0 we may not return
without checking if the ReceiveBuffer is empty.
