### PR TITLE
/kbd: option should be unsigned

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1165,17 +1165,17 @@ int freerdp_client_parse_command_line_arguments(int argc, char** argv, rdpSettin
 		}
 		CommandLineSwitchCase(arg, "kbd")
 		{
-			int id;
+			unsigned long int id;
 			char* pEnd;
 
-			id = strtol(arg->Value, &pEnd, 16);
+			id = strtoul(arg->Value, &pEnd, 16);
 
 			if (pEnd != (arg->Value + strlen(arg->Value)))
 				id = 0;
 
 			if (id == 0)
 			{
-				id = freerdp_map_keyboard_layout_name_to_id(arg->Value);
+				id = (unsigned long int) freerdp_map_keyboard_layout_name_to_id(arg->Value);
 
 				if (!id)
 				{
@@ -1183,7 +1183,7 @@ int freerdp_client_parse_command_line_arguments(int argc, char** argv, rdpSettin
 				}
 			}
 
-			settings->KeyboardLayout = id;
+			settings->KeyboardLayout = (UINT32) id;
 		}
 		CommandLineSwitchCase(arg, "kbd-type")
 		{


### PR DESCRIPTION
The /kbd: number passed to freerdp should be treated as _unsigned_ so that it can correctly parse numbers like (0x)E0010411, which is used to select the Japanese input method and keyboard.
