### PR TITLE
Fix connection when no cookie is given

### DIFF
--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -1139,7 +1139,13 @@ BOOL nego_set_routing_token(rdpNego* nego, BYTE* RoutingToken, DWORD RoutingToke
 BOOL nego_set_cookie(rdpNego* nego, char* cookie)
 {
 	if (nego->cookie)
+	{
 		free(nego->cookie);
+		nego->cookie = 0;
+	}
+
+	if (!cookie)
+		return TRUE;
 
 	nego->cookie = _strdup(cookie);
 	if (!nego->cookie)


### PR DESCRIPTION
This patch corrects a regression introduced in 2edd8bee1208aef77f92209f737c376063681bf7
