### PR TITLE
Harden WWW-Authenticate parsing

### DIFF
--- a/libfreerdp/core/gateway/http.c
+++ b/libfreerdp/core/gateway/http.c
@@ -206,7 +206,7 @@ char* http_encode_authorization_line(char* AuthScheme, char* AuthParam)
 	char* line;
 	int length;
 
-	length = strlen("Authorization") + strlen(AuthScheme) + strlen(AuthParam) + 3;
+	length = strlen("Authorization: ") + strlen(AuthScheme) + 1 + strlen(AuthParam);
 	line = (char*) malloc(length + 1);
 	if (!line)
 		return NULL;
@@ -369,23 +369,19 @@ BOOL http_response_parse_header_field(HttpResponse* http_response, char* name, c
 	{
 		char* separator;
 
-		separator = strstr(value, "=\"");
-
-		if (separator != NULL)
-		{
-			/* WWW-Authenticate: parameter with spaces="value" */
-			return FALSE;
-		}
-
 		separator = strchr(value, ' ');
 
 		if (separator != NULL)
 		{
-			/* WWW-Authenticate: NTLM base64token */
-
+			/*
+			 * WWW-Authenticate: Basic realm="<realm>"
+			 * WWW-Authenticate: NTLM <base64token>
+			 */
 			*separator = '\0';
 			http_response->AuthScheme = _strdup(value);
 			http_response->AuthParam = _strdup(separator + 1);
+			if (!http_response->AuthScheme || !http_response->AuthParam)
+				return FALSE;
 			*separator = ' ';
 
 			return TRUE;

--- a/libfreerdp/core/gateway/ncacn_http.c
+++ b/libfreerdp/core/gateway/ncacn_http.c
@@ -99,7 +99,8 @@ int rpc_ncacn_http_recv_in_channel_response(rdpRpc* rpc)
 
 	http_response = http_response_recv(rpc->TlsIn);
 
-	if (http_response->AuthParam)
+	if (http_response->AuthScheme && (_stricmp(http_response->AuthScheme, "ntlm") == 0) &&
+			http_response->AuthParam)
 	{
 		ntlm_token_data = NULL;
 		crypto_base64_decode((BYTE*) http_response->AuthParam, strlen(http_response->AuthParam),
@@ -231,7 +232,9 @@ int rpc_ncacn_http_recv_out_channel_response(rdpRpc* rpc)
 	http_response = http_response_recv(rpc->TlsOut);
 
 	ntlm_token_data = NULL;
-	if (http_response && http_response->AuthParam)
+	if (http_response &&
+			http_response->AuthScheme && (_stricmp(http_response->AuthScheme, "ntlm") == 0) &&
+			http_response->AuthParam)
 	{
 		crypto_base64_decode((BYTE*) http_response->AuthParam, strlen(http_response->AuthParam),
 				&ntlm_token_data, &ntlm_token_length);


### PR DESCRIPTION
This patch ensures that authorizations are NTLM ones.
