### PR TITLE
Fixed issue rfx problem: no rects #1738.

### DIFF
--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -619,7 +619,20 @@ static BOOL rfx_process_message_region(RFX_CONTEXT* context, RFX_MESSAGE* messag
 
 	if (message->numRects < 1)
 	{
-		DEBUG_WARN("no rects.");
+		/* Unfortunately, it isn't documented.
+		It seems that server asks to clip whole session when numRects = 0.
+		Issue: https://github.com/FreeRDP/FreeRDP/issues/1738 */
+
+		DEBUG_WARN("no rects. Clip whole session.");
+		message->numRects = 1;
+		message->rects = (RFX_RECT*) realloc(message->rects, message->numRects * sizeof(RFX_RECT));
+		if (!message->rects)
+			return FALSE;
+		message->rects->x = 0;
+		message->rects->y = 0;
+		message->rects->width = context->width;
+		message->rects->height = context->height;
+
 		return TRUE;
 	}
 


### PR DESCRIPTION
Added clipping of whole session in case when server sends zero rects.

Guys, it seems to fix #1738 we have to pass clipping rect with size of session. Unfortunately, I didn't found any document about this for 2012 R2, but this definitely fixes this issue in my env. Seems that this case works for windows because its clipping functions works with whole window when numRects = 0.
