### PR TITLE
Adds some support for valgrind helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,6 +345,12 @@ if(NOT WIN32)
 	list(REMOVE_ITEM CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 endif()
 
+if(WITH_VALGRIND_MEMCHECK)
+    check_include_files(valgrind/memcheck.h HAVE_VALGRIND_MEMCHECK_H)
+else()
+    unset(HAVE_VALGRIND_MEMCHECK_H CACHE)
+endif()
+
 if(UNIX OR CYGWIN)
 	check_include_files(sys/eventfd.h HAVE_AIO_H)
 	check_include_files(sys/eventfd.h HAVE_EVENTFD_H)

--- a/cmake/ConfigOptions.cmake
+++ b/cmake/ConfigOptions.cmake
@@ -44,6 +44,10 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	set(CMAKE_COMPILER_IS_CLANG 1)
 endif()
 
+if(NOT WIN32)
+    option(WITH_VALGRIND_MEMCHECK "Compile with valgrind helpers." OFF)
+endif()
+
 if(MSVC)
 	option(WITH_NATIVE_SSPI "Use native SSPI modules" ON)
 	option(WITH_WINMM "Use Windows Multimedia" ON)

--- a/config.h.in
+++ b/config.h.in
@@ -25,6 +25,7 @@
 #cmakedefine HAVE_TM_GMTOFF
 #cmakedefine HAVE_AIO_H
 #cmakedefine HAVE_PTHREAD_GNU_EXT
+#cmakedefine HAVE_VALGRIND_MEMCHECK_H
 
 
 /* Options */

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -31,6 +31,10 @@
 
 #include <freerdp/crypto/tls.h>
 
+#ifdef HAVE_VALGRIND_MEMCHECK_H
+#include <valgrind/memcheck.h>
+#endif
+
 static CryptoCert tls_get_certificate(rdpTls* tls, BOOL peer)
 {
 	CryptoCert cert;
@@ -464,6 +468,10 @@ int tls_read(rdpTls* tls, BYTE* data, int length)
 				break;
 		}
 	}
+
+#ifdef HAVE_VALGRIND_MEMCHECK_H
+	VALGRIND_MAKE_MEM_DEFINED(data, status);
+#endif
 
 	return status;
 }


### PR DESCRIPTION
This patch adds an option to compile freerdp in a valgrind compliant way.
The purpose is to ease memchecking when connecting with TLS. We mark bytes retrieved from SSL_read() as plainly defined to prevent the undefined contamination.
With the patch and the option activated you get a single warning at connection during the handshake, and nothing after.
