### PR TITLE
Removed autosharing of all disk drives during redirect of any drive.

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -297,7 +297,6 @@ int freerdp_client_add_device_channel(rdpSettings* settings, int count, char** p
 		if (count < 3)
 			return -1;
 
-		settings->RedirectDrives = TRUE;
 		settings->DeviceRedirection = TRUE;
 
 		drive = (RDPDR_DRIVE*) calloc(1, sizeof(RDPDR_DRIVE));


### PR DESCRIPTION
According to issue #1843 we shouldn't redirect all disk drives every time when we redirected one drive. 
This flag settings->RedirectDrives means that we will redirect root as media (All drives), so I don't think that it is correct to enable it each time we added redirection of specific drive.
settings->RedirectDrives should be set to TRUE only when +drives option is specified.
Please, correct me if I'm wrong.  
