### PR TITLE
Fix misplaced sec_trailer in rpc_auth_3 PDU

### DIFF
--- a/libfreerdp/core/gateway/rpc_bind.c
+++ b/libfreerdp/core/gateway/rpc_bind.c
@@ -300,27 +300,25 @@ int rpc_send_rpc_auth_3_pdu(rdpRpc* rpc)
 	auth_3_pdu->pfc_flags = PFC_FIRST_FRAG | PFC_LAST_FRAG | PFC_CONC_MPX;
 	auth_3_pdu->call_id = 2;
 
-	offset = 20;
-
 	auth_3_pdu->max_xmit_frag = rpc->max_xmit_frag;
 	auth_3_pdu->max_recv_frag = rpc->max_recv_frag;
 
-	offset += 4;
+	offset = 20;
 	auth_3_pdu->auth_verifier.auth_pad_length = rpc_offset_align(&offset, 4);
 
 	auth_3_pdu->auth_verifier.auth_type = RPC_C_AUTHN_WINNT;
 	auth_3_pdu->auth_verifier.auth_level = RPC_C_AUTHN_LEVEL_PKT_INTEGRITY;
 	auth_3_pdu->auth_verifier.auth_reserved = 0x00;
 	auth_3_pdu->auth_verifier.auth_context_id = 0x00000000;
+	offset += (8 + auth_3_pdu->auth_length);
 
-	auth_3_pdu->frag_length = 20 + 4 +
-			auth_3_pdu->auth_verifier.auth_pad_length + auth_3_pdu->auth_length + 8;
+	auth_3_pdu->frag_length = offset;
 
 	buffer = (BYTE*) malloc(auth_3_pdu->frag_length);
 
-	CopyMemory(buffer, auth_3_pdu, 24);
+	CopyMemory(buffer, auth_3_pdu, 20);
 
-	offset = 24;
+	offset = 20;
 	rpc_offset_pad(&offset, auth_3_pdu->auth_verifier.auth_pad_length);
 
 	CopyMemory(&buffer[offset], &auth_3_pdu->auth_verifier.auth_type, 8);


### PR DESCRIPTION
This fixes the placement of the sec_trailer when sending an rpc_auth_3 PDU; it was shifted by 4 bytes.
This was caused by writing 24 bytes from the rpcconn_rpc_auth_3_hdr_t, although there are only 20 bytes defined in it before the auth_verifier element.
It did work because there is a strict requirement in [MS-RPCE] 2.2.2.11 on how to calculate the start of the sec_trailer. The resulting PDU structure still fulfilled that requirement, even though there was no other indication of those extra bytes in the PDU.
