### PR TITLE
X11 aync input shutdown fix

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1327,7 +1327,10 @@ void* xf_input_thread(void* arg)
 		}
 		else if (ev == WAIT_OBJECT_0 + 1)
 		{
-			if (!freerdp_message_queue_process_pending_messages(instance, FREERDP_INPUT_MESSAGE_QUEUE))
+			wMessage msg;
+			MessageQueue_Peek(queue, &msg, FALSE);
+
+			if (msg.id == WMQ_QUIT)
 				break;
 		}
 	}


### PR DESCRIPTION
Fixed the thread shutdown for async input. Now checking input queue for MSG_QUIT to shut down thread when initiated by some connection error.
