### PR TITLE
winpr: more fixes for named pipes

### DIFF
--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -254,6 +254,7 @@ HANDLE CreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, 
 	pNamedPipe->clientfd = socket(PF_LOCAL, SOCK_STREAM, 0);
 	pNamedPipe->serverfd = -1;
 	pNamedPipe->ServerMode = FALSE;
+	pNamedPipe->dwRefCount = 1;
 
 	ZeroMemory(&s, sizeof(struct sockaddr_un));
 	s.sun_family = AF_UNIX;

--- a/winpr/libwinpr/handle/handle.c
+++ b/winpr/libwinpr/handle/handle.c
@@ -169,19 +169,22 @@ BOOL CloseHandle(HANDLE hObject)
 
 		pipe = (WINPR_NAMED_PIPE*) Object;
 
-		if (pipe->ServerMode)
-		{
-			assert(pipe->dwRefCount);
+		assert(pipe->dwRefCount);
 
-			if (--pipe->dwRefCount == 0)
+		if (--pipe->dwRefCount == 0)
+		{
+			if (pipe->pfnRemoveBaseNamedPipeFromList)
 			{
 				pipe->pfnRemoveBaseNamedPipeFromList(pipe);
-
-				if (pipe->pBaseNamedPipe)
-				{
-					CloseHandle((HANDLE) pipe->pBaseNamedPipe);
-				}
 			}
+			if (pipe->pBaseNamedPipe)
+			{
+				CloseHandle((HANDLE) pipe->pBaseNamedPipe);
+			}
+		}
+		else
+		{
+			return TRUE;
 		}
 
 		if (pipe->clientfd != -1)


### PR DESCRIPTION
- refcount must be set to 1 in createFile
- refcount must be considered in client and server mode
- only call pfnRemoveBaseNamedPipeFromList if the pfn is not NULL
- don't free handle if refcount is not zero
