### PR TITLE
Reading RDP File: changed fullscreen constants to reflect the current states from Technet

### DIFF
--- a/client/common/file.c
+++ b/client/common/file.c
@@ -801,12 +801,12 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 		 *
 		 * Values:
 		 *
-		 * 0: The remote session will appear in a window.
-		 * 1: The remote session will appear full screen.
+		 * 1: The remote session will appear in a window.
+		 * 2: The remote session will appear full screen.
 		 */
 
 		freerdp_set_param_bool(settings, FreeRDP_Fullscreen,
-				(file->ScreenModeId == 1) ? TRUE : FALSE);
+				(file->ScreenModeId == 2) ? TRUE : FALSE);
 	}
 
 	if (~((size_t) file->LoadBalanceInfo))


### PR DESCRIPTION
The current constants cause an issue with interpreting the fullscreen (screen_mode_id:2) and windowed mode flags (screen_mode_id:1) in RDP files.

These updated values we're taken from: http://technet.microsoft.com/en-us/library/ff393692(v=ws.10).aspx
