### PR TITLE
Fixes timezone API definition issues on Windows

### DIFF
--- a/winpr/include/winpr/timezone.h
+++ b/winpr/include/winpr/timezone.h
@@ -62,7 +62,9 @@ WINPR_API BOOL TzSpecificLocalTimeToSystemTime(LPTIME_ZONE_INFORMATION lpTimeZon
 
 #endif
 
-#if !defined(_WIN32) || (defined(_WIN32) && (_WIN32_WINNT < 0x0600)) /* Windows Vista */
+// GetDynamicTimeZoneInformation is provided by the SDK if _WIN32_WINNT >= 0x0600 in SDKs above 7.1A
+// and incorrectly if _WIN32_WINNT >= 0x0501 in older SDKs
+#if !defined(_WIN32) || (defined(_WIN32) && (defined(NTDDI_WIN8) && _WIN32_WINNT < 0x0600 || !defined(NTDDI_WIN8) && _WIN32_WINNT < 0x0501)) /* Windows Vista */
 
 WINPR_API DWORD GetDynamicTimeZoneInformation(PDYNAMIC_TIME_ZONE_INFORMATION pTimeZoneInformation);
 WINPR_API BOOL SetDynamicTimeZoneInformation(const DYNAMIC_TIME_ZONE_INFORMATION* lpTimeZoneInformation);

--- a/winpr/libwinpr/timezone/timezone.c
+++ b/winpr/libwinpr/timezone/timezone.c
@@ -59,7 +59,9 @@ BOOL TzSpecificLocalTimeToSystemTime(LPTIME_ZONE_INFORMATION lpTimeZoneInformati
 
 #endif
 
-#if !defined(_WIN32) || (defined(_WIN32) && (_WIN32_WINNT < 0x0600)) /* Windows Vista */
+// GetDynamicTimeZoneInformation is provided by the SDK if _WIN32_WINNT >= 0x0600 in SDKs above 7.1A
+// and incorrectly if _WIN32_WINNT >= 0x0501 in older SDKs
+#if !defined(_WIN32) || (defined(_WIN32) && (defined(NTDDI_WIN8) && _WIN32_WINNT < 0x0600 || !defined(NTDDI_WIN8) && _WIN32_WINNT < 0x0501)) /* Windows Vista */
 
 DWORD GetDynamicTimeZoneInformation(PDYNAMIC_TIME_ZONE_INFORMATION pTimeZoneInformation)
 {


### PR DESCRIPTION
GetDynamicTimeZoneInformation, SetDynamicTimeZoneInformation and
GetTimeZoneInformationForYear are provided by the Windows SDK accordingly
with ethe MSDN cocumentation for SDK with versions above 7.1A.

Those functions are incorrectly included by the 7.1A SDK if _WIN32_WINNT

> = 0x0501 instead of _WIN32_WINNT >= 0x0600.

The issue arises when building with an XP compatible toolset (e.g.
v120_xp).
