### PR TITLE
Don't forget to SetLastError() on disconnection

### DIFF
--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -368,12 +368,7 @@ BOOL ReadFile(HANDLE hFile, LPVOID lpBuffer, DWORD nNumberOfBytesToRead,
 
 			if (io_status == 0)
 			{
-				switch (errno)
-				{
-					case ECONNRESET:
-						SetLastError(ERROR_BROKEN_PIPE);
-						break;
-				}
+				SetLastError(ERROR_BROKEN_PIPE);
 				status = FALSE;
 			}
 			else if (io_status < 0)
@@ -384,6 +379,9 @@ BOOL ReadFile(HANDLE hFile, LPVOID lpBuffer, DWORD nNumberOfBytesToRead,
 				{
 					case EWOULDBLOCK:
 						SetLastError(ERROR_NO_DATA);
+						break;
+					default:
+						SetLastError(ERROR_BROKEN_PIPE);
 						break;
 				}
 			}


### PR DESCRIPTION
Otherwise if the last error was a ERROR_NO_DATA we have no indication that the pipe has been closed.

And most of the time, the caller will enter an infinite read() loop.
