### PR TITLE
Added define guards for _rotl and related bit rotation functions

### DIFF
--- a/winpr/include/winpr/crt.h
+++ b/winpr/include/winpr/crt.h
@@ -32,21 +32,29 @@
 
 #ifndef _WIN32
 
+#ifndef _rotl
 static INLINE UINT32 _rotl(UINT32 value, int shift) {
 	return (value << shift) | (value >> (32 - shift));
 }
+#endif
 
+#ifndef _rotl64
 static INLINE UINT64 _rotl64(UINT64 value, int shift) {
 	return (value << shift) | (value >> (64 - shift));
 }
+#endif
 
+#ifndef _rotr
 static INLINE UINT32 _rotr(UINT32 value, int shift) {
 	return (value >> shift) | (value << (32 - shift));
 }
+#endif
 
+#ifndef _rotr64
 static INLINE UINT64 _rotr64(UINT64 value, int shift) {
 	return (value >> shift) | (value << (64 - shift));
 }
+#endif
 
 #if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 2))
 


### PR DESCRIPTION
Added define guards for _rotl and related bit rotation functions ,which collided with function definitions in x86intrin.h 
