### PR TITLE
Added detect of uncompressed data in CACHE_BITMAP_REV3_ORDER. According ...

### DIFF
--- a/libfreerdp/cache/bitmap.c
+++ b/libfreerdp/cache/bitmap.c
@@ -136,6 +136,7 @@ void update_gdi_cache_bitmap_v3(rdpContext* context, CACHE_BITMAP_V3_ORDER* cach
 {
 	rdpBitmap* bitmap;
 	rdpBitmap* prevBitmap;
+	BOOL isCompressed = TRUE;
 	rdpCache* cache = context->cache;
 	BITMAP_DATA_EX* bitmapData = &cacheBitmapV3->bitmapData;
 
@@ -149,13 +150,9 @@ void update_gdi_cache_bitmap_v3(rdpContext* context, CACHE_BITMAP_V3_ORDER* cach
 		cacheBitmapV3->bitmapData.bpp = context->instance->settings->ColorDepth;
 	}
 
-	// According to http://msdn.microsoft.com/en-us/library/gg441209.aspx
-	// CACHE_BITMAP_REV3_ORDER::bitmapData::codecID = 0x00 (uncompressed)
-	BOOL isCompressed = TRUE;
-	if (bitmapData->codecID == RDP_CODEC_ID_NONE)
-	{
-		isCompressed = FALSE;
-	}
+	/* According to http://msdn.microsoft.com/en-us/library/gg441209.aspx
+	 * CACHE_BITMAP_REV3_ORDER::bitmapData::codecID = 0x00 (uncompressed) */
+	isCompressed = (bitmapData->codecID != RDP_CODEC_ID_NONE);
 
 	bitmap->Decompress(context, bitmap,
 			bitmapData->data, bitmap->width, bitmap->height,


### PR DESCRIPTION
According to http://msdn.microsoft.com/en-us/library/gg441209.aspx - RDP_CODEC_ID_NONE means that this is uncompressed data. This fix allowed me to enable BitmapCachingV3 with NSCodec on Android without crashes :-).
