### PR TITLE
Fix conflicting define

### DIFF
--- a/include/freerdp/channels/wtsvc.h
+++ b/include/freerdp/channels/wtsvc.h
@@ -37,11 +37,7 @@
 
 #include <winpr/winpr.h>
 #include <winpr/wtypes.h>
-
 #include <winpr/wtsapi.h>
-
-#define WTSVirtualEventHandle	3 /* Extended */
-#define WTSVirtualChannelReady	4 /* Extended */
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
WTSVirtualEventHandle and WTSVirtualChannelReady are already defined in wtsapi.h and with different values.
