### PR TITLE
Fix glib cmake script and only call OnOpen callback if set

### DIFF
--- a/channels/drdynvc/client/dvcman.c
+++ b/channels/drdynvc/client/dvcman.c
@@ -409,7 +409,8 @@ int dvcman_open_channel(IWTSVirtualChannelManager* pChannelMgr, UINT32 ChannelId
 	if (channel->status == 0)
 	{
 		pCallback = channel->channel_callback;
-		pCallback->OnOpen(pCallback);
+		if (pCallback->OnOpen)
+			pCallback->OnOpen(pCallback);
 	}
 
 	return 0;

--- a/channels/tsmf/client/tsmf_main.c
+++ b/channels/tsmf/client/tsmf_main.c
@@ -329,6 +329,7 @@ static int tsmf_on_new_channel_connection(IWTSListenerCallback *pListenerCallbac
 	ZeroMemory(callback, sizeof(TSMF_CHANNEL_CALLBACK));
 	callback->iface.OnDataReceived = tsmf_on_data_received;
 	callback->iface.OnClose = tsmf_on_close;
+	callback->iface.OnOpen = NULL;
 	callback->plugin = listener_callback->plugin;
 	callback->channel_mgr = listener_callback->channel_mgr;
 	callback->channel = pChannel;

--- a/cmake/FindGlib.cmake
+++ b/cmake/FindGlib.cmake
@@ -28,11 +28,10 @@ find_library(Gobject_LIBRARY
 			 PATHS ${Glib_PKGCONF_LIBRARY_DIRS} ${GLIB_ROOT_DIR}
 			)
 
-# Glib-related libraries also use a separate config header, which is in lib dir
+# Glib-related libraries also use a separate config header, which is relative to lib dir
 find_path(GlibConfig_INCLUDE_DIR
 		  NAMES glibconfig.h
-		  PATHS ${Glib_PKGCONF_INCLUDE_DIRS} /usr ${GLIB_ROOT_DIR}
-		  PATH_SUFFIXES lib/glib-2.0/include glib-2.0/include
+		  PATHS ${Glib_PKGCONF_INCLUDE_DIRS} ${GLIB_ROOT_DIR}
 		 )
 
 # Set the include dir variables and the libraries and let libfind_process do the rest.


### PR DESCRIPTION
Find glibconfig.h cmake script should use pkgconfig information instead of a hard coded path to /usr/lib. There may be a better way to handle this, but I found on my 64-bit system with both 32-bit and 64-bit versions of glib installed that the wrong version(32-bit) of glibconfig.h was being used and causing a compile error.

the OnOpen callback should be called when set to avoid a segfault.
I was getting a segfault when trying to use tsmf, so I fixed that case here. It looks like there might be a few other cases where we should make sure that the OnOpen function pointer gets set to NULL as well.
