### PR TITLE
kill the last remaining select() in libfreerdp

### DIFF
--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -505,8 +505,12 @@ BOOL tcp_connect(rdpTcp* tcp, const char* hostname, int port, int timeout)
 	}
 	else
 	{
+#ifdef HAVE_POLL_H
+		struct pollfd pollfds;
+#else
 		fd_set cfds;
 		struct timeval tv;
+#endif
 
 		tcp->socketBio = BIO_new(BIO_s_connect());
 
@@ -530,14 +534,24 @@ BOOL tcp_connect(rdpTcp* tcp, const char* hostname, int port, int timeout)
 
 		if (status <= 0)
 		{
+#ifdef HAVE_POLL_H
+			pollfds.fd = tcp->sockfd;
+			pollfds.events = POLLOUT;
+			pollfds.revents = 0;
+			do
+			{
+				status = poll(&pollfds, 1, timeout * 1000);
+			}
+			while ((status < 0) && (errno == EINTR));
+#else
 			FD_ZERO(&cfds);
 			FD_SET(tcp->sockfd, &cfds);
 
 			tv.tv_sec = timeout;
 			tv.tv_usec = 0;
 
-			status = select(tcp->sockfd + 1, NULL, &cfds, NULL, &tv);
-
+			status = _select(tcp->sockfd + 1, NULL, &cfds, NULL, &tv);
+#endif
 			if (status == 0)
 			{
 				return FALSE; /* timeout */


### PR DESCRIPTION
also use _select() that is EINTR safe
