### PR TITLE
Fix _aligned_realloc() when resizing to smaller size

### DIFF
--- a/winpr/libwinpr/crt/alignment.c
+++ b/winpr/libwinpr/crt/alignment.c
@@ -27,7 +27,10 @@
 
 #ifndef _WIN32
 
-#define WINPR_ALIGNED_MALLOC_SIGNATURE		0x0BA0BAB
+#define WINPR_ALIGNED_MEM_SIGNATURE		0x0BA0BAB
+
+#define WINPR_ALIGNED_MEM_STRUCT_FROM_PTR(_memptr) \
+	(WINPR_ALIGNED_MEM*) (((size_t)(((BYTE*) _memptr) - sizeof(WINPR_ALIGNED_MEM))));
 
 #include <stdlib.h>
 
@@ -39,12 +42,13 @@
 #include <malloc.h>
 #endif
 
-struct _aligned_meminfo
+struct winpr_aligned_mem
 {
 	UINT32 sig;
 	size_t size;
 	void* base_addr;
 };
+typedef struct winpr_aligned_mem WINPR_ALIGNED_MEM;
 
 void* _aligned_malloc(size_t size, size_t alignment)
 {
@@ -58,13 +62,14 @@ void* _aligned_realloc(void* memblock, size_t size, size_t alignment)
 
 void* _aligned_recalloc(void* memblock, size_t num, size_t size, size_t alignment)
 {
-	return NULL;
+	return _aligned_offset_recalloc(memblock, num, size, alignment, 0);
 }
 
 void* _aligned_offset_malloc(size_t size, size_t alignment, size_t offset)
 {
-	void* memptr, *tmpptr;
-	struct _aligned_meminfo *ameminfo;
+	void* base;
+	void* memblock;
+	WINPR_ALIGNED_MEM* pMem;
 
 	/* alignment must be a power of 2 */
 	if (alignment % 2 == 1)
@@ -79,25 +84,27 @@ void* _aligned_offset_malloc(size_t size, size_t alignment, size_t offset)
 		alignment = sizeof(void*);
 
 	/* malloc size + alignment to make sure we can align afterwards */
-	tmpptr = malloc(size + alignment + sizeof(struct _aligned_meminfo));
+	base = malloc(size + alignment + sizeof(WINPR_ALIGNED_MEM));
 
-	if (!tmpptr)
+	if (!base)
 		return NULL;
 
-	memptr = (void *)((((size_t)((PBYTE)tmpptr + alignment + offset + sizeof(struct _aligned_meminfo)) & ~(alignment - 1)) - offset));
+	memblock = (void*)((((size_t)(((BYTE*) base) + alignment + offset + sizeof(WINPR_ALIGNED_MEM)) & ~(alignment - 1)) - offset));
 
-	ameminfo = (struct _aligned_meminfo*) (((size_t)((PBYTE)memptr - sizeof(struct _aligned_meminfo))));
-	ameminfo->sig = WINPR_ALIGNED_MALLOC_SIGNATURE;
-	ameminfo->base_addr = tmpptr;
-	ameminfo->size = size;
+	pMem = WINPR_ALIGNED_MEM_STRUCT_FROM_PTR(memblock);
+	pMem->sig = WINPR_ALIGNED_MEM_SIGNATURE;
+	pMem->base_addr = base;
+	pMem->size = size;
 
-	return memptr;
+	return memblock;
 }
 
 void* _aligned_offset_realloc(void* memblock, size_t size, size_t alignment, size_t offset)
 {
-	void* newmem;
-	struct _aligned_meminfo* ameminfo;
+	size_t copySize;
+	void* newMemblock;
+	WINPR_ALIGNED_MEM* pMem;
+	WINPR_ALIGNED_MEM* pNewMem;
 
 	if (!memblock)
 		return _aligned_offset_malloc(size, alignment, offset);
@@ -108,52 +115,98 @@ void* _aligned_offset_realloc(void* memblock, size_t size, size_t alignment, siz
 		return NULL;
 	}
 
-	/*  The following is not very performant but a simple and working solution */
-	newmem = _aligned_offset_malloc(size, alignment, offset);
+	newMemblock = _aligned_offset_malloc(size, alignment, offset);
 
-	if (!newmem)
+	if (!newMemblock)
 		return NULL;
 
-	ameminfo = (struct _aligned_meminfo*) (((size_t)((PBYTE)memblock - sizeof(struct _aligned_meminfo))));
+	pMem = WINPR_ALIGNED_MEM_STRUCT_FROM_PTR(memblock);
+	pNewMem = WINPR_ALIGNED_MEM_STRUCT_FROM_PTR(newMemblock);
 
-	if (ameminfo->sig != WINPR_ALIGNED_MALLOC_SIGNATURE)
+	if (pMem->sig != WINPR_ALIGNED_MEM_SIGNATURE)
 	{
 		fprintf(stderr, "_aligned_offset_realloc: memory block was not allocated by _aligned_malloc!\n");
 		return NULL;
 	}
 
-	CopyMemory(newmem, memblock, ameminfo->size);
+	copySize = (pNewMem->size < pMem->size) ? pNewMem->size : pMem->size;
+
+	CopyMemory(newMemblock, memblock, copySize);
 	_aligned_free(memblock);
 
-	return newmem;
+	return newMemblock;
 }
 
 void* _aligned_offset_recalloc(void* memblock, size_t num, size_t size, size_t alignment, size_t offset)
 {
-	return NULL;
+	size_t copySize;
+	void* newMemblock;
+	WINPR_ALIGNED_MEM* pMem;
+	WINPR_ALIGNED_MEM* pNewMem;
+
+	if (!memblock)
+		return _aligned_offset_malloc(size, alignment, offset);
+
+	if (size == 0)
+	{
+		_aligned_free(memblock);
+		return NULL;
+	}
+
+	newMemblock = _aligned_offset_malloc(size, alignment, offset);
+
+	if (!newMemblock)
+		return NULL;
+
+	pMem = WINPR_ALIGNED_MEM_STRUCT_FROM_PTR(memblock);
+	pNewMem = WINPR_ALIGNED_MEM_STRUCT_FROM_PTR(newMemblock);
+
+	if (pMem->sig != WINPR_ALIGNED_MEM_SIGNATURE)
+	{
+		fprintf(stderr, "_aligned_offset_recalloc: memory block was not allocated by _aligned_malloc!\n");
+		return NULL;
+	}
+
+	ZeroMemory(newMemblock, pNewMem->size);
+	_aligned_free(memblock);
+
+	return newMemblock;
 }
 
 size_t _aligned_msize(void* memblock, size_t alignment, size_t offset)
 {
-	return 0;
+	WINPR_ALIGNED_MEM* pMem;
+
+	if (!memblock)
+		return 0;
+
+	pMem = WINPR_ALIGNED_MEM_STRUCT_FROM_PTR(memblock);
+
+	if (pMem->sig != WINPR_ALIGNED_MEM_SIGNATURE)
+	{
+		fprintf(stderr, "_aligned_msize: memory block was not allocated by _aligned_malloc!\n");
+		return 0;
+	}
+
+	return pMem->size;
 }
 
 void _aligned_free(void* memblock)
 {
-	struct _aligned_meminfo* ameminfo;
+	WINPR_ALIGNED_MEM* pMem;
 
 	if (!memblock)
 		return;
 
-	ameminfo = (struct _aligned_meminfo*) (((size_t)((PBYTE)memblock - sizeof(struct _aligned_meminfo))));
+	pMem = WINPR_ALIGNED_MEM_STRUCT_FROM_PTR(memblock);
 
-	if (ameminfo->sig != WINPR_ALIGNED_MALLOC_SIGNATURE)
+	if (pMem->sig != WINPR_ALIGNED_MEM_SIGNATURE)
 	{
 		fprintf(stderr, "_aligned_free: memory block was not allocated by _aligned_malloc!\n");
 		return;
 	}
 
-	free(ameminfo->base_addr);
+	free(pMem->base_addr);
 }
 
 #endif


### PR DESCRIPTION
Fix issue #1952 affecting the current master, causing crashes on GDI bitmap updates.
