### PR TITLE
winpr: CloseHandle did not release the thread TCB

### DIFF
--- a/winpr/libwinpr/handle/handle.c
+++ b/winpr/libwinpr/handle/handle.c
@@ -139,6 +139,9 @@ BOOL CloseHandle(HANDLE hObject)
 		WINPR_THREAD* thread;
 
 		thread = (WINPR_THREAD*) Object;
+		if (thread->started) {
+			pthread_detach(thread->thread);
+		}
 		free(thread);
 
 		return TRUE;

--- a/winpr/libwinpr/synch/wait.c
+++ b/winpr/libwinpr/synch/wait.c
@@ -255,6 +255,8 @@ DWORD WaitForSingleObject(HANDLE hHandle, DWORD dwMilliseconds)
 			else
 				status = pthread_join(thread->thread, &thread_status);
 
+			thread->started = FALSE;
+
 			if (status != 0)
 			{
 				fprintf(stderr, "WaitForSingleObject: pthread_join failure: [%d] %s\n",


### PR DESCRIPTION
This resulted in huge memory leaks - 8MB per thread, depending on the system's default stack size.
The leak happend even if CloseHandle() was correctly used to "detach" the thread but WaitForSingleObject was never called.
