### PR TITLE
Fix unclean SSL disconnection

### DIFF
--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -152,7 +152,8 @@ static int bio_rdp_tls_read(BIO* bio, char* buf, int size)
 				break;
 
 			case SSL_ERROR_SYSCALL:
-				status = 0;
+				BIO_clear_flags(bio, BIO_FLAGS_SHOULD_RETRY);
+				status = -1;
 				break;
 		}
 	}


### PR DESCRIPTION
This patch prevent an infinite loop when the remote peer disconnects the socket without cleanly closing the SSL connection.
