### PR TITLE
Add arguments for managing tls ciphers & netmon

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -127,6 +127,8 @@ COMMAND_LINE_ARGUMENT_A args[] =
 	{ "sec-tls", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "tls protocol security" },
 	{ "sec-nla", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "nla protocol security" },
 	{ "sec-ext", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "nla extended protocol security" },
+	{ "tls-ciphers", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "List of permitted openssl ciphers - see ciphers(1)" },
+	{ "tls-ciphers-netmon", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Use tls ciphers that netmon can parse" },
 	{ "cert-name", COMMAND_LINE_VALUE_REQUIRED, "<name>", NULL, NULL, -1, NULL, "certificate name" },
 	{ "cert-ignore", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "ignore certificate" },
 	{ "pcb", COMMAND_LINE_VALUE_REQUIRED, "<blob>", NULL, NULL, -1, NULL, "Preconnection Blob" },
@@ -1752,6 +1754,14 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 		CommandLineSwitchCase(arg, "sec-ext")
 		{
 			settings->ExtSecurity = arg->Value ? TRUE : FALSE;
+		}
+		CommandLineSwitchCase(arg, "tls-ciphers")
+		{
+			settings->PermittedTLSCiphers = _strdup(arg->Value);
+		}
+		CommandLineSwitchCase(arg, "tls-ciphers-netmon")
+		{
+			settings->PermittedTLSCiphers = arg->Value ? _strdup("ALL:!ECDH") : NULL;
 		}
 		CommandLineSwitchCase(arg, "cert-name")
 		{

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -974,7 +974,8 @@ struct rdp_settings
 	ALIGN64 char* AuthenticationServiceClass; /* 1098 */
 	ALIGN64 BOOL DisableCredentialsDelegation; /* 1099 */
 	ALIGN64 BOOL AuthenticationLevel; /* 1100 */
-	UINT64 padding1152[1152 - 1101]; /* 1101 */
+	ALIGN64 char* PermittedTLSCiphers; /* 1101 */
+	UINT64 padding1152[1152 - 1102]; /* 1102 */
 
 	/* Connection Cookie */
 	ALIGN64 BOOL MstscCookieMode; /* 1152 */

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -825,6 +825,7 @@ void freerdp_settings_free(rdpSettings* settings)
 		free(settings->MonitorDefArray);
 		free(settings->ClientAddress);
 		free(settings->ClientDir);
+		free(settings->PermittedTLSCiphers);
 		free(settings->CertificateFile);
 		free(settings->PrivateKeyFile);
 		free(settings->ConnectionFile);

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -591,6 +591,13 @@ BOOL tls_prepare(rdpTls* tls, BIO *underlying, const SSL_METHOD *method, int opt
 	SSL_CTX_set_options(tls->ctx, options);
 	SSL_CTX_set_read_ahead(tls->ctx, 1);
 
+	if (tls->settings->PermittedTLSCiphers) {
+		if(!SSL_CTX_set_cipher_list(tls->ctx, tls->settings->PermittedTLSCiphers)) {
+			fprintf(stderr, "SSL_CTX_set_cipher_list %s failed\n", tls->settings->PermittedTLSCiphers);
+			return FALSE;
+		}
+	}
+ 
 	tls->bio = BIO_new_rdp_tls(tls->ctx, clientMode);
 
 	if (BIO_get_ssl(tls->bio, &tls->ssl) < 0)


### PR DESCRIPTION
This adds 2 arguments:
    /tls-ciphers                List of permitted openssl ciphers - see ciphers(1)
    /tls-ciphers-netmon         Use tls ciphers that netmon can parse

With KB2919355, client/server negotiate the use of TLS cipher TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, which works fine except that netmon can't parse it.
By adding commandline /tls-ciphers-netmon, we restrict the available ciphers to a list that netmon can
deal with.  Also adds /tls-ciphers, which accepts a string arg, for further customization.
