### PR TITLE
Change multimon/span logic in the rdp file parsing to match the command ...

### DIFF
--- a/client/common/file.c
+++ b/client/common/file.c
@@ -775,20 +775,19 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 		 */
 		fileHasFullscreen = ((file->ScreenModeId == 2) ? TRUE : FALSE);
 	}
-	//Changes below cause RDP file to match cmdline implementation
+	/* Changes below cause RDP file to match cmdline implementation */
 	if( fileHasSpanMonitors )
 		freerdp_set_param_bool(settings, FreeRDP_SpanMonitors, TRUE);
-	//span monitors' should also result in 'useMultimon'.
+	/* span monitors' should also result in 'useMultimon'. */
 	if( fileHasMultimon || fileHasSpanMonitors )
 		freerdp_set_param_bool(settings, FreeRDP_UseMultimon, TRUE);
-	//span monitors' or 'useMultimon' should also result in fullscreen.
+	/* span monitors' or 'useMultimon' should also result in fullscreen. */
 	if( fileHasFullscreen || fileHasMultimon || fileHasSpanMonitors )
 		freerdp_set_param_bool(settings, FreeRDP_Fullscreen, TRUE);
 
 		
 	if (~((size_t) file->Domain))
 		freerdp_set_param_string(settings, FreeRDP_Domain, file->Domain);
-
 
 	if (~((size_t) file->Username))
 	{


### PR DESCRIPTION
Change multimon/span logic in the rdp file parsing to match the command line parsing.

New functionality:
- Span will trigger multimon AND fullscreen.
- Multimon alone will also trigger fullscreen.

As a result of this now matching behavior, FreeRPD aligns with the behavior of M$ when opening RDWeb connections. (RDWeb's generated rdp files have multimon set to TRUE, but do not specify any screen geometry, because multimon is supposed to imply fullscreen).
