### PR TITLE
core: improve fast-path multifragment handling

### DIFF
--- a/libfreerdp/core/fastpath.c
+++ b/libfreerdp/core/fastpath.c
@@ -48,7 +48,6 @@
  * two less significant bits of the first byte.
  */
 
-#define FASTPATH_MAX_PACKET_SIZE 0x3FFF
 
 #ifdef WITH_DEBUG_RDP
 static const char* const FASTPATH_UPDATETYPE_STRINGS[] =

--- a/libfreerdp/core/fastpath.h
+++ b/libfreerdp/core/fastpath.h
@@ -20,6 +20,22 @@
 #ifndef __FASTPATH_H
 #define __FASTPATH_H
 
+/*
+ * Fast-Path has 15 bits available for length information which would lead to a
+ * maximal pdu size of 0x8000. However in practice only 14 bits are used
+ * this isn't documented anywhere but it looks like most implementations will
+ * fail if fast-path packages > 0x3FFF arrive.
+ */
+#define FASTPATH_MAX_PACKET_SIZE 0x3FFF
+
+/*
+ *  The following size guarantees that no fast-path PDU fragmentation occurs.
+ *  It was calculated by subtracting 128 from FASTPATH_MAX_PACKET_SIZE.
+ *  128 was chosen because it includes all required and optional headers as well as
+ *  possible paddings and some extra bytes for safety.
+ */
+#define FASTPATH_FRAGMENT_SAFE_SIZE 0x3F80
+
 typedef struct rdp_fastpath rdpFastPath;
 
 #include "rdp.h"


### PR DESCRIPTION
- make sure fast-path packages are not fragmented if no
  multifragment support was announced
- handle special server side case where the multifragment size
  received from the client is smaller than one maximum fast-path
  PDU size
