### PR TITLE
Apply GatewayUseSameCredentials logic to RDP file parsing as well

### DIFF
--- a/client/common/client.c
+++ b/client/common/client.c
@@ -123,8 +123,34 @@ int freerdp_client_settings_parse_command_line(rdpSettings* settings, int argc, 
 	{
 		status = freerdp_client_settings_parse_assistance_file(settings, settings->AssistanceFile);
 	}
+	
+	/* This function will call logic that is applicable to the settings
+	 * from command line parsing AND the rdp file parsing */
+	status = freerdp_client_combined_logic(settings);
 
 	return status;
+}
+
+int freerdp_client_combined_logic(rdpSettings* settings)
+{
+	/* Moved GatewayUseSameCredentials logic outside of cmdline.c, so 
+	 * that the rdp file also triggers this functionality */
+	if (settings->GatewayEnabled)
+	{
+		if (settings->GatewayUseSameCredentials)
+		{
+			if (settings->Username)
+				settings->GatewayUsername = _strdup(settings->Username);
+
+			if (settings->Domain)
+				settings->GatewayDomain = _strdup(settings->Domain);
+
+			if (settings->Password)
+				settings->GatewayPassword = _strdup(settings->Password);
+		}
+	}
+	
+	return 0;
 }
 
 int freerdp_client_settings_parse_connection_file(rdpSettings* settings, const char* filename)

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1905,21 +1905,6 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 
 	freerdp_performance_flags_make(settings);
 
-	if (settings->GatewayEnabled)
-	{
-		if (settings->GatewayUseSameCredentials)
-		{
-			if (settings->Username)
-				settings->GatewayUsername = _strdup(settings->Username);
-
-			if (settings->Domain)
-				settings->GatewayDomain = _strdup(settings->Domain);
-
-			if (settings->Password)
-				settings->GatewayPassword = _strdup(settings->Password);
-		}
-	}
-
 	if (settings->SupportGraphicsPipeline)
 	{
 		settings->FastPathOutput = TRUE;


### PR DESCRIPTION
Commit removes GatewayUseSameCredentials logic from cmdline.c, and places it after both cmdline and rpd file have been parsed. This provides proper GatewayUseSameCredentials support for the rdp file.

I have a feeling there are going to be more cases where there is logic in cmdline.c that is not yet replicated for the RDP file (this is my 2nd change that addresses this type of scenario).
