### PR TITLE
remove multimon/span logic from cmdline.c and move to new combined logic...

### DIFF
--- a/client/common/client.c
+++ b/client/common/client.c
@@ -130,6 +130,19 @@ static BOOL freerdp_client_settings_post_process(rdpSettings* settings)
 			}
 		}
 	}
+	
+	/* Moved logic for Multimon and Span monitors to force fullscreen, so
+	 * that the rdp file also triggers this functionality */
+	if (settings->SpanMonitors)
+	{
+		settings->UseMultimon = TRUE;
+		settings->Fullscreen = TRUE;
+	}
+	else if (settings->UseMultimon)
+	{
+		settings->Fullscreen = TRUE;
+	}
+	
 	return TRUE;
 
 out_error:

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1281,8 +1281,6 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 		CommandLineSwitchCase(arg, "multimon")
 		{
 			settings->UseMultimon = TRUE;
-			settings->SpanMonitors = FALSE;
-			settings->Fullscreen = TRUE;
 
 			if (arg->Flags & COMMAND_LINE_VALUE_PRESENT)
 			{
@@ -1294,9 +1292,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 		}
 		CommandLineSwitchCase(arg, "span")
 		{
-			settings->UseMultimon = TRUE;
 			settings->SpanMonitors = TRUE;
-			settings->Fullscreen = TRUE;
 		}
 		CommandLineSwitchCase(arg, "workarea")
 		{


### PR DESCRIPTION
Re-write of https://github.com/FreeRDP/FreeRDP/pull/1976 for new cmdline/rdp file combined logic: 

Move multimon/span logic from 'cmdline.c' to 'client.c' in the new combined_logic section.  

As a result of this now matching behavior, FreeRPD aligns with the behavior of M$ when opening RDWeb connections via RDP file. (RDWeb's generated rdp files have multimon set to TRUE, but do not specify any screen geometry, because multimon is supposed to imply fullscreen).
