### PR TITLE
rdpsnd->Initialize requires two arguments

### DIFF
--- a/server/Mac/mf_rdpsnd.c
+++ b/server/Mac/mf_rdpsnd.c
@@ -161,7 +161,7 @@ BOOL mf_peer_rdpsnd_init(mfPeerContext* context)
 	
 	context->rdpsnd->Activated = mf_peer_rdpsnd_activated;
 	
-	context->rdpsnd->Initialize(context->rdpsnd);
+	context->rdpsnd->Initialize(context->rdpsnd, TRUE);
 	
 	return TRUE;
 }


### PR DESCRIPTION
Fixes rdpsnd->Initialize() to have two arguments.  Fixes compilation on XCode 5.

It would seem that two arguments are required for call.  To build on XCode 5, I have added the TRUE value to run on it's own Thread.
