### PR TITLE
Restore window size by percent

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -43,7 +43,7 @@ COMMAND_LINE_ARGUMENT_A args[] =
 	{ "port", COMMAND_LINE_VALUE_REQUIRED, "<number>", NULL, NULL, -1, NULL, "Server port" },
 	{ "w", COMMAND_LINE_VALUE_REQUIRED, "<width>", "1024", NULL, -1, NULL, "Width" },
 	{ "h", COMMAND_LINE_VALUE_REQUIRED, "<height>", "768", NULL, -1, NULL, "Height" },
-	{ "size", COMMAND_LINE_VALUE_REQUIRED, "<width>x<height>", "1024x768", NULL, -1, NULL, "Screen size" },
+	{ "size", COMMAND_LINE_VALUE_REQUIRED, "<width>x<height> or <percent>%", "1024x768", NULL, -1, NULL, "Screen size" },
 	{ "f", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Fullscreen mode" },
 	{ "bpp", COMMAND_LINE_VALUE_REQUIRED, "<depth>", "16", NULL, -1, NULL, "Session bpp (color depth)" },
 	{ "kbd", COMMAND_LINE_VALUE_REQUIRED, "0x<layout id> or <layout name>", NULL, NULL, -1, NULL, "Keyboard layout" },
@@ -1270,6 +1270,14 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 				*p = '\0';
 				settings->DesktopWidth = atoi(str);
 				settings->DesktopHeight = atoi(&p[1]);
+			}
+			else
+			{
+				p = strchr(str, '%');
+				if(p)
+				{
+					settings->PercentScreen = atoi(str);
+				}
 			}
 
 			free(str);


### PR DESCRIPTION
1.0 had the ability to specifiy window geometry by a percentage.
The support is still there, just needed command line support.
Example in 1.1 syntax: /size:85%
