### PR TITLE
crypto: fix fingerprint

### DIFF
--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -355,7 +355,7 @@ char* crypto_cert_fingerprint(X509* xcert)
 		sprintf(p, "%02x:", fp[i]);
 		p = &fp_buffer[(i + 1) * 3];
 	}
-	DEBUG_MSG(p, "%02x", fp[i]);
+	sprintf(p, "%02x", fp[i]);
 
 	return fp_buffer;
 }


### PR DESCRIPTION
Latest logging changes introduced a problem with fingerprint generation.
The last byte wasn't added.
