### PR TITLE
handle user@corp.net username correctly

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -706,21 +706,12 @@ int freerdp_parse_username(char* username, char** user, char** domain)
 	}
 	else
 	{
-		p = strchr(username, '@');
-
-		if (p)
-		{
-			length = p - username;
-			*user = (char*) malloc(length + 1);
-			strncpy(*user, username, length);
-			(*user)[length] = '\0';
-			*domain = _strdup(&p[1]);
-		}
-		else
-		{
-			*user = _strdup(username);
-			*domain = NULL;
-		}
+		/* Do not break up the name for '@'; both credSSP and the
+		 * ClientInfo PDU expect 'user@corp.net' to be transmitted
+		 * as username 'user@corp.net', domain empty.
+		 */
+		*user = _strdup(username);
+		*domain = NULL;
 	}
 
 	return 0;


### PR DESCRIPTION
For a user whose pre-Windows2000 logon name (e.g. CORP\james) is different than their post-Windows2000 logon name (e.g. jimmy@corp.net), freerdp-1.1 was not allowing a logon using the latter as a username.  It turns out that both credSSP and clientInfoPDU expect usernames of the form "n@d" to be passed directly rather than breaking them up into separate user and domain fields.  This was confirmed with mstsc & netmon by examining the data passed from mstsc to the RDP server.

This small patch should be ported to master also.
