### PR TITLE
Fix multiple cases of use of uninitialized vars

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -114,6 +114,8 @@ void xf_SendClientEvent(xfContext *xfc, xfWindow *window, Atom atom, unsigned in
 	unsigned int i;
 	va_list argp;
 	va_start(argp, numArgs);
+
+	ZeroMemory(&xevent, sizeof(XEvent));
 	xevent.xclient.type = ClientMessage;
 	xevent.xclient.serial = 0;
 	xevent.xclient.send_event = False;

--- a/libfreerdp/core/graphics.c
+++ b/libfreerdp/core/graphics.c
@@ -37,7 +37,8 @@ rdpBitmap* Bitmap_Alloc(rdpContext* context)
 
 	if (bitmap)
 	{
-		CopyMemory(bitmap, context->graphics->Bitmap_Prototype, sizeof(rdpBitmap));
+		ZeroMemory(bitmap, graphics->Bitmap_Prototype->size);
+		CopyMemory(bitmap, graphics->Bitmap_Prototype, sizeof(rdpBitmap));
 		bitmap->data = NULL;
 	}
 
@@ -99,7 +100,8 @@ rdpPointer* Pointer_Alloc(rdpContext* context)
 
 	if (pointer)
 	{
-		CopyMemory(pointer, context->graphics->Pointer_Prototype, sizeof(rdpPointer));
+		ZeroMemory(pointer, graphics->Pointer_Prototype->size);
+		CopyMemory(pointer, graphics->Pointer_Prototype, sizeof(rdpPointer));
 	}
 
 	return pointer;
@@ -165,7 +167,8 @@ rdpGlyph* Glyph_Alloc(rdpContext* context)
 
 	if (glyph)
 	{
-		CopyMemory(glyph, context->graphics->Glyph_Prototype, sizeof(rdpGlyph));
+		ZeroMemory(glyph, graphics->Glyph_Prototype->size);
+		CopyMemory(glyph, graphics->Glyph_Prototype, sizeof(rdpGlyph));
 	}
 
 	return glyph;

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -184,6 +184,9 @@ static int peer_recv_tpkt_pdu(freerdp_peer* client, wStream* s)
 		return -1;
 	}
 
+	if (rdp->disconnect)
+		return 0;
+ 
 	if (rdp->settings->DisableEncryption)
 	{
 		if (!rdp_read_security_header(s, &securityFlags))

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -989,6 +989,9 @@ static int rdp_recv_tpkt_pdu(rdpRdp* rdp, wStream* s)
 		return -1;
 	}
 
+	if (rdp->disconnect)
+		return 0;
+ 
 	if (rdp->settings->DisableEncryption)
 	{
 		if (!rdp_read_security_header(s, &securityFlags))


### PR DESCRIPTION
- Zeroing xevent helped address some erratic behavior.
- valgrind complained about using xfBitmap uninitialized
  during shutdown, traced it back to the initialization.
  Bitmap_Prototype->size > sizeof(rdpBitmap).
- Early exit from recv_tpkt_pdu is necessary to address
  a shutdown crash - the channelId value was being used
  without being set in the disconnect case.
