### PR TITLE
Adjust the X11 code to work with the new GDI color

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -794,6 +794,7 @@ BOOL xf_pre_connect(freerdp *instance)
 	xfc->grab_keyboard = settings->GrabKeyboard;
 	xfc->fullscreen_toggle = settings->ToggleFullscreen;
 	xf_detect_monitors(xfc, settings);
+	xfc->colormap = DefaultColormap(xfc->display, xfc->screen_number);
 	return TRUE;
 }
 

--- a/client/X11/xf_gdi.c
+++ b/client/X11/xf_gdi.c
@@ -214,6 +214,28 @@ BOOL xf_set_rop3(xfContext* xfc, int rop3)
 	return TRUE;
 }
 
+unsigned long xf_gdi_get_color(xfContext* xfc, GDI_COLOR color)
+{
+	XColor x11_color;
+
+	x11_color.flags = DoRed | DoGreen | DoBlue;
+	GetRGB32(x11_color.red, x11_color.green, x11_color.blue, color);
+	x11_color.red = x11_color.red << 8;
+	x11_color.green = x11_color.green << 8;
+	x11_color.blue = x11_color.blue << 8;
+
+	if (XAllocColor(xfc->display, xfc->colormap, &x11_color) != 0)
+	{
+		XFreeColors(xfc->display, xfc->colormap, &x11_color.pixel, 1, 0);
+	}
+	else
+	{
+		x11_color.pixel = BlackPixel(xfc->display, xfc->screen_number);
+	}
+
+	return x11_color.pixel;
+}
+
 Pixmap xf_brush_new(xfContext* xfc, int width, int height, int bpp, BYTE* data)
 {
 	Pixmap bitmap;
@@ -338,7 +360,9 @@ void xf_gdi_patblt(rdpContext* context, PATBLT_ORDER* patblt)
 	xf_set_rop3(xfc, gdi_rop3_code(patblt->bRop));
 
 	foreColor = freerdp_color_convert_drawing_order_color_to_gdi_color(patblt->foreColor, context->settings->ColorDepth, xfc->clrconv);
+	foreColor = xf_gdi_get_color(xfc, foreColor);
 	backColor = freerdp_color_convert_drawing_order_color_to_gdi_color(patblt->backColor, context->settings->ColorDepth, xfc->clrconv);
+	backColor = xf_gdi_get_color(xfc, backColor);
 
 	if (brush->style == GDI_BS_SOLID)
 	{
@@ -458,6 +482,7 @@ void xf_gdi_opaque_rect(rdpContext* context, OPAQUE_RECT_ORDER* opaque_rect)
 	xf_lock_x11(xfc, FALSE);
 
 	color = freerdp_color_convert_drawing_order_color_to_gdi_color(opaque_rect->color, context->settings->ColorDepth, xfc->clrconv);
+	color = xf_gdi_get_color(xfc, color);
 
 	XSetFunction(xfc->display, xfc->gc, GXcopy);
 	XSetFillStyle(xfc->display, xfc->gc, FillSolid);
@@ -492,6 +517,7 @@ void xf_gdi_multi_opaque_rect(rdpContext* context, MULTI_OPAQUE_RECT_ORDER* mult
 	xf_lock_x11(xfc, FALSE);
 
 	color = freerdp_color_convert_drawing_order_color_to_gdi_color(multi_opaque_rect->color, context->settings->ColorDepth, xfc->clrconv);
+	color = xf_gdi_get_color(xfc, color);
 
 	XSetFunction(xfc->display, xfc->gc, GXcopy);
 	XSetFillStyle(xfc->display, xfc->gc, FillSolid);
@@ -534,6 +560,7 @@ void xf_gdi_line_to(rdpContext* context, LINE_TO_ORDER* line_to)
 
 	xf_set_rop2(xfc, line_to->bRop2);
 	color = freerdp_color_convert_drawing_order_color_to_gdi_color(line_to->penColor, context->settings->ColorDepth, xfc->clrconv);
+	color = xf_gdi_get_color(xfc, color);
 
 	XSetFillStyle(xfc->display, xfc->gc, FillSolid);
 	XSetForeground(xfc->display, xfc->gc, color);
@@ -584,6 +611,7 @@ void xf_gdi_polyline(rdpContext* context, POLYLINE_ORDER* polyline)
 
 	xf_set_rop2(xfc, polyline->bRop2);
 	color = freerdp_color_convert_drawing_order_color_to_gdi_color(polyline->penColor, context->settings->ColorDepth, xfc->clrconv);
+	color = xf_gdi_get_color(xfc, color);
 
 	XSetFillStyle(xfc->display, xfc->gc, FillSolid);
 	XSetForeground(xfc->display, xfc->gc, color);
@@ -680,7 +708,9 @@ void xf_gdi_mem3blt(rdpContext* context, MEM3BLT_ORDER* mem3blt)
 	bitmap = (xfBitmap*) mem3blt->bitmap;
 	xf_set_rop3(xfc, gdi_rop3_code(mem3blt->bRop));
 	foreColor = freerdp_color_convert_drawing_order_color_to_gdi_color(mem3blt->foreColor, context->settings->ColorDepth, xfc->clrconv);
+	foreColor = xf_gdi_get_color(xfc, foreColor);
 	backColor = freerdp_color_convert_drawing_order_color_to_gdi_color(mem3blt->backColor, context->settings->ColorDepth, xfc->clrconv);
+	backColor = xf_gdi_get_color(xfc, backColor);
 
 	if (brush->style == GDI_BS_PATTERN)
 	{
@@ -753,6 +783,7 @@ void xf_gdi_polygon_sc(rdpContext* context, POLYGON_SC_ORDER* polygon_sc)
 
 	xf_set_rop2(xfc, polygon_sc->bRop2);
 	brush_color = freerdp_color_convert_drawing_order_color_to_gdi_color(polygon_sc->brushColor, context->settings->ColorDepth, xfc->clrconv);
+	brush_color = xf_gdi_get_color(xfc, brush_color);
 
 	npoints = polygon_sc->numPoints + 1;
 	points = malloc(sizeof(XPoint) * npoints);
@@ -814,7 +845,9 @@ void xf_gdi_polygon_cb(rdpContext* context, POLYGON_CB_ORDER* polygon_cb)
 	brush = &(polygon_cb->brush);
 	xf_set_rop2(xfc, polygon_cb->bRop2);
 	foreColor = freerdp_color_convert_drawing_order_color_to_gdi_color(polygon_cb->foreColor, context->settings->ColorDepth, xfc->clrconv);
+	foreColor = xf_gdi_get_color(xfc, foreColor);
 	backColor = freerdp_color_convert_drawing_order_color_to_gdi_color(polygon_cb->backColor, context->settings->ColorDepth, xfc->clrconv);
+	backColor = xf_gdi_get_color(xfc, backColor);
 
 	npoints = polygon_cb->numPoints + 1;
 	points = malloc(sizeof(XPoint) * npoints);

--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -398,6 +398,9 @@ void xf_Glyph_BeginDraw(rdpContext* context, int x, int y, int width, int height
 
 	xf_lock_x11(xfc, FALSE);
 
+	fgcolor = xf_gdi_get_color(xfc, fgcolor);
+	bgcolor = xf_gdi_get_color(xfc, bgcolor);
+
 	XSetFunction(xfc->display, xfc->gc, GXcopy);
 	XSetFillStyle(xfc->display, xfc->gc, FillSolid);
 	XSetForeground(xfc->display, xfc->gc, fgcolor);

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -243,6 +243,8 @@ void xf_unlock_x11(xfContext* xfc, BOOL display);
 void xf_draw_screen_scaled(xfContext* xfc, int x, int y, int w, int h, BOOL scale);
 void xf_transform_window(xfContext* xfc);
 
+unsigned long xf_gdi_get_color(xfContext* xfc, GDI_COLOR color);
+
 FREERDP_API DWORD xf_exit_code_from_disconnect_reason(DWORD reason);
 
 #endif /* __XFREERDP_H */


### PR DESCRIPTION
representation.
- client/X11/xf_gdi.c:
  Use freerdp_color_convert_drawing_order_color_to_gdi_color() to convert
  from drawing order color representation to GDI color representation
  troughout.
- client/X11/xf_graphics.c: Likewise.
