### PR TITLE
channels: fix memory leak in stream pools.

### DIFF
--- a/channels/drdynvc/client/dvcman.c
+++ b/channels/drdynvc/client/dvcman.c
@@ -476,7 +476,7 @@ int dvcman_receive_channel_data_first(IWTSVirtualChannelManager* pChannelMgr, UI
 		Stream_Release(channel->dvc_data);
 
 	channel->dvc_data = StreamPool_Take(channel->dvcman->pool, length);
-	Stream_AddRef(channel->dvc_data);
+	channel->dvc_data_length = length;
 
 	return 0;
 }
@@ -508,7 +508,7 @@ int dvcman_receive_channel_data(IWTSVirtualChannelManager* pChannelMgr, UINT32 C
 
 		Stream_Write(channel->dvc_data, Stream_Pointer(data), dataSize);
 
-		if (((size_t) Stream_GetPosition(channel->dvc_data)) >= Stream_Capacity(channel->dvc_data))
+		if (((size_t) Stream_GetPosition(channel->dvc_data)) >= channel->dvc_data_length)
 		{
 			Stream_SealLength(channel->dvc_data);
 			Stream_SetPosition(channel->dvc_data, 0);

--- a/channels/drdynvc/client/dvcman.h
+++ b/channels/drdynvc/client/dvcman.h
@@ -82,6 +82,7 @@ struct _DVCMAN_CHANNEL
 	IWTSVirtualChannelCallback* channel_callback;
 
 	wStream* dvc_data;
+	UINT32 dvc_data_length;
 	CRITICAL_SECTION lock;
 };
 typedef struct _DVCMAN_CHANNEL DVCMAN_CHANNEL;

--- a/libfreerdp/utils/svc_plugin.c
+++ b/libfreerdp/utils/svc_plugin.c
@@ -106,7 +106,6 @@ static void svc_plugin_process_received(rdpSvcPlugin* plugin, void* pData, UINT3
 			Stream_Release(plugin->data_in);
 
 		plugin->data_in = StreamPool_Take(plugin->pool, totalLength);
-		Stream_AddRef(plugin->data_in);
 	}
 
 	s = plugin->data_in;


### PR DESCRIPTION
1. StreamPool_Take already initialize reference count to 1 and Stream_AddRef should not follow
2. Stream_Capacity should not be used as packet length indicator because the stream is from the pool and could be larger than requested length
