### PR TITLE
channels: fix possible overflow in logging

### DIFF
--- a/include/freerdp/channels/log.h
+++ b/include/freerdp/channels/log.h
@@ -28,8 +28,8 @@
 		wLogMessage msg; \
 		wLog *log; \
 		\
-		strncat(tag, "com.freerdp.channels.", sizeof(tag)); \
-		strncat(tag, dbg_str, sizeof(tag) - sizeof("com.freerdp.channels.")); \
+		strncat(tag, "com.freerdp.channels.", sizeof(tag) - 1); \
+		strncat(tag, dbg_str, sizeof(tag) - 1 - sizeof("com.freerdp.channels.")); \
 		log = WLog_Get(tag); \
 		\
 		msg.Type = WLOG_MESSAGE_TEXT; \


### PR DESCRIPTION
Fixes clang compiler warning:

"warning: the value of the size argument in 'strncat' is too large,
might lead to a buffer overflow [-Wstrncat-size]"

strncat requires an extra byte for '\0' so dest needs to have a size of
n+1
