### PR TITLE
arm build: use "-fPIC" when building libwinpr-makecert.a

### DIFF
--- a/winpr/tools/makecert/CMakeLists.txt
+++ b/winpr/tools/makecert/CMakeLists.txt
@@ -23,6 +23,12 @@ set(${MODULE_PREFIX}_SRCS makecert.c)
 include_directories(${ZLIB_INCLUDE_DIRS})
 include_directories(${OPENSSL_INCLUDE_DIR})
 
+if(CMAKE_COMPILER_IS_GNUCC)
+        if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
+                set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+        endif()
+endif()
+
 add_library(${MODULE_NAME} STATIC ${${MODULE_PREFIX}_SRCS}) 
 
 set(${MODULE_PREFIX}_LIBS


### PR DESCRIPTION
If we are on an ARM device, and are linking with this
temporary library, it may fail if "-fPIC" has not been used
to create position-independent object files.

Signed-off-by: Manuel Bachmann manuel.bachmann@open.eurogiciel.org
