### PR TITLE
xfreerdp: use _aligned_free instead of free

### DIFF
--- a/client/X11/xf_gdi.c
+++ b/client/X11/xf_gdi.c
@@ -258,7 +258,7 @@ Pixmap xf_brush_new(xfContext* xfc, int width, int height, int bpp, BYTE* data)
 		XFree(image);
 
 		if (cdata != data)
-			free(cdata);
+			_aligned_free(cdata);
 
 		XFreeGC(xfc->display, gc);
 	}


### PR DESCRIPTION
Use _aligned_free to release memory allocated with
freerdp_image_convert().

Fixes #2075
