### PR TITLE
transport: exit transport loop when the session is activated.

### DIFF
--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1153,7 +1153,10 @@ static int rdp_recv_callback(rdpTransport* transport, wStream* s, void* extra)
 			status = rdp_recv_pdu(rdp, s);
 
 			if ((status >= 0) && (rdp->finalize_sc_pdus == FINALIZE_SC_COMPLETE))
+			{
 				rdp_client_transition_to_state(rdp, CONNECTION_STATE_ACTIVE);
+				return 2;
+			}
 			break;
 
 		case CONNECTION_STATE_ACTIVE:

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -1071,12 +1071,13 @@ int transport_check_fds(rdpTransport* transport)
 		 */
 
 		recv_status = transport->ReceiveCallback(transport, received, transport->ReceiveExtra);
-
-		if (recv_status == 1)
-		{
-			return 1; /* session redirection */
-		}
 		Stream_Release(received);
+
+		/* session redirection or activation */
+		if (recv_status == 1 || recv_status == 2)
+		{
+			return recv_status;
+		}
 
 		if (recv_status < 0)
 			return -1;


### PR DESCRIPTION
Previously, the transport_check_fds() looped until all pending PDUs had been received. In case after the session was activated and some important virtual channel PDUs (such as the DRDYNVC server-to-client capability request PDU) immediately followed, the client did not have the chance the call PostConnect (and thus the channel plugins were not initialized), causing those virtual channel PDUs be discarded and DRDYNVC not initialized. This was a race condition and did not always reproducible.

This simple change quits the transport_check_fds() loop whenever the client state is transit into active to give the client a chance to immediately call PostConnect before processing any further PDUs.
