### PR TITLE
Fixed string size calculation in winpr_HexDump

### DIFF
--- a/winpr/libwinpr/utils/print.c
+++ b/winpr/libwinpr/utils/print.c
@@ -38,7 +38,7 @@ void winpr_HexDump(const char* tag, int level, const BYTE* data, int length)
 	const BYTE* p = data;
 	int i, line, offset = 0;
 	const size_t llen = (length > WINPR_HEXDUMP_LINE_LENGTH) ? WINPR_HEXDUMP_LINE_LENGTH : length;
-	size_t blen = 5 + llen * 5;
+	size_t blen = 7 + WINPR_HEXDUMP_LINE_LENGTH * 5;
 	size_t pos = 0;
 	char* buffer = malloc(blen);
 


### PR DESCRIPTION
Fixes a bug introduced with #2036 
