### PR TITLE
Removing TS Gateway breaking BIO_clear_flags() call

### DIFF
--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -168,7 +168,8 @@ static int bio_rdp_tls_read(BIO* bio, char* buf, int size)
 			case SSL_ERROR_SYSCALL:
 				error = WSAGetLastError();
 				if ((error == WSAEWOULDBLOCK) || (error == WSAEINTR) ||
-					(error == WSAEINPROGRESS) || (error == WSAEALREADY))
+					(error == WSAEINPROGRESS) || (error == WSAEALREADY) ||
+					(error == 0))
 				{
 					BIO_set_flags(bio, (BIO_FLAGS_READ | BIO_FLAGS_SHOULD_RETRY));
 				}


### PR DESCRIPTION
The current master/HEAD does not work correctly with terminal server gateways when a particular BIO_clear_flags() function is called.

According to @Ofloo in #2056: 

> The issue appeared between 01c557d .. 3fce288 "Fix unclean SSL disconnection"
> 01c557d works fine
> 3fce288 gives me this error and doesn't even show a window just that error

I tried reverting the commit. Git couldn't auto merge, so decided to debug the few changed lines. I've narrowed the problem down to a single function call. This pull request simply removes the function call causing the problem. I'm not sure this is the ideal/correct/best/reasonable fix for this issue, but the removal of this single function call gives me a working FreeRDP installation. I'm hoping one of the project maintainers can say "OMG that's perfect/wrong!" and we can get this corrected.

An example of my command line and the failing results:

```
$ xfreerdp /g:tsg.mywork.com /v:rdp.mywork.com /u:username /p:password /d:mywork /w:1280 /h:1024 /cert-ignore
[00:17:40:522] [18375:18376] [INFO][com.freerdp.core.gateway.tsg] - TS Gateway Connection Success
[00:17:40:664] [18375:18376] [ERROR][com.freerdp.core] - freerdp_set_last_error 0x2000D
$
```

I don't know which version of Windows Terminal Server I'm connecting to, but can find out if that's relevant.

Thanks!
