### PR TITLE
Added lock key synchronization to wfreerdp

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -738,6 +738,12 @@ DWORD WINAPI wf_client_thread(LPVOID lpParam)
 		rcount = 0;
 		wcount = 0;
 
+		if (freerdp_focus_required(instance))
+		{
+			wf_event_focus_in(wfc);
+			wf_event_focus_in(wfc);
+		}
+
 		if (!async_transport)
 		{
 			if (freerdp_get_fds(instance, rfds, &rcount, wfds, &wcount) != TRUE)

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -254,6 +254,7 @@ FREERDP_API freerdp* freerdp_new(void);
 FREERDP_API void freerdp_free(freerdp* instance);
 
 FREERDP_API BOOL freerdp_focus_required(freerdp* instance);
+FREERDP_API void freerdp_set_focus(freerdp* instance);
 
 FREERDP_API UINT32 freerdp_get_last_error(rdpContext* context);
 FREERDP_API void freerdp_set_last_error(rdpContext* context, UINT32 lastError);

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -358,6 +358,14 @@ FREERDP_API BOOL freerdp_focus_required(freerdp* instance)
 	return bRetCode;
 }
 
+void freerdp_set_focus(freerdp* instance)
+{
+	rdpRdp* rdp;
+
+	rdp = instance->context->rdp;
+	rdp->resendFocus = TRUE;
+}
+
 void freerdp_get_version(int* major, int* minor, int* revision)
 {
 	if (major != NULL)


### PR DESCRIPTION
I've added @nigel62's patches from #1191 to wfreerdp. Only thing is I don't know how to read mouse pointer position in windows, so every time lock keys are synced the pointer is set to left top corner. If someone knowes and has time, I would be so happy if she/he could tell me!
