### PR TITLE
core: fix pointer caps, slowpath kbd and a gcc fix

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -936,12 +936,17 @@ BOOL rdp_read_pointer_capability_set(wStream* s, UINT16 length, rdpSettings* set
 	UINT16 colorPointerCacheSize;
 	UINT16 pointerCacheSize;
 
-	if (length < 10)
+	if (length < 8)
 		return FALSE;
 
 	Stream_Read_UINT16(s, colorPointerFlag); /* colorPointerFlag (2 bytes) */
 	Stream_Read_UINT16(s, colorPointerCacheSize); /* colorPointerCacheSize (2 bytes) */
-	Stream_Read_UINT16(s, pointerCacheSize); /* pointerCacheSize (2 bytes) */
+
+	/* pointerCacheSize is optional */
+	if (length >= 10)
+		Stream_Read_UINT16(s, pointerCacheSize); /* pointerCacheSize (2 bytes) */
+	else
+		pointerCacheSize = 0;
 
 	if (colorPointerFlag == FALSE)
 		settings->ColorPointerFlag = FALSE;

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -291,8 +291,9 @@ void gcc_write_conference_create_response(wStream* s, wStream* userData)
 	per_write_choice(s, 0);
 	per_write_object_identifier(s, t124_02_98_oid);
 
-	/* ConnectData::connectPDU (OCTET_STRING) */
-	per_write_length(s, Stream_GetPosition(userData) + 2);
+	/* ConnectPDULength */
+	/* This length MUST be ignored by the client according to [MS-RDPBCGR] */
+	per_write_length(s, 0);
 
 	/* ConnectGCCPDU */
 	per_write_choice(s, 0x14);


### PR DESCRIPTION
- According to MS-RDPBCGR 2.2.7.1.5 the pointerCacheSize is optional and its absence or a zero value indicates missing client support for  the New Pointer Update.
- Fixed and added some comments regarding the meaning of the KBDFLAGS_DOWN  keyboard flag and how it is currently used in the code.
- The slow path keyboard input now generates the same keyboard flags as the corresponding fast path code.
- Some arbitrary value was used for the ConnectPDULength in the GCC Conference Create Response. According to MS-RDPBCGR 4.1.4 this value must  be ignored by the client so we encode a zero value instead.
