### PR TITLE
xfreerdp: fix glyph index primary drawing order

### DIFF
--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -377,7 +377,7 @@ void xf_Glyph_Draw(rdpContext* context, rdpGlyph* glyph, int x, int y)
 	xf_unlock_x11(xfc, FALSE);
 }
 
-void xf_Glyph_BeginDraw(rdpContext* context, int x, int y, int width, int height, UINT32 bgcolor, UINT32 fgcolor)
+void xf_Glyph_BeginDraw(rdpContext* context, int x, int y, int width, int height, UINT32 bgcolor, UINT32 fgcolor, BOOL fOpRedundant)
 {
 	xfContext* xfc = (xfContext*) context;
 
@@ -390,13 +390,18 @@ void xf_Glyph_BeginDraw(rdpContext* context, int x, int y, int width, int height
 	bgcolor = xf_gdi_get_color(xfc, bgcolor);
 
 	XSetFunction(xfc->display, xfc->gc, GXcopy);
-	XSetFillStyle(xfc->display, xfc->gc, FillSolid);
-	XSetForeground(xfc->display, xfc->gc, fgcolor);
-	XFillRectangle(xfc->display, xfc->drawing, xfc->gc, x, y, width, height);
+
+	if (width && height)
+	{
+		XSetFillStyle(xfc->display, xfc->gc, FillSolid);
+		XSetForeground(xfc->display, xfc->gc, fgcolor);
+		XFillRectangle(xfc->display, xfc->drawing, xfc->gc, x, y, width, height);
+	}
 
 	XSetForeground(xfc->display, xfc->gc, bgcolor);
 	XSetBackground(xfc->display, xfc->gc, fgcolor);
-	XSetFillStyle(xfc->display, xfc->gc, FillStippled);
+
+	XSetFillStyle(xfc->display, xfc->gc, fOpRedundant ? FillOpaqueStippled : FillStippled);
 
 	xf_unlock_x11(xfc, FALSE);
 }

--- a/include/freerdp/graphics.h
+++ b/include/freerdp/graphics.h
@@ -123,7 +123,7 @@ FREERDP_API void Pointer_SetDefault(rdpContext* context);
 typedef void (*pGlyph_New)(rdpContext* context, rdpGlyph* glyph);
 typedef void (*pGlyph_Free)(rdpContext* context, rdpGlyph* glyph);
 typedef void (*pGlyph_Draw)(rdpContext* context, rdpGlyph* glyph, int x, int y);
-typedef void (*pGlyph_BeginDraw)(rdpContext* context, int x, int y, int width, int height, UINT32 bgcolor, UINT32 fgcolor);
+typedef void (*pGlyph_BeginDraw)(rdpContext* context, int x, int y, int width, int height, UINT32 bgcolor, UINT32 fgcolor, BOOL fOpRedundant);
 typedef void (*pGlyph_EndDraw)(rdpContext* context, int x, int y, int width, int height, UINT32 bgcolor, UINT32 fgcolor);
 
 struct rdp_glyph
@@ -149,7 +149,7 @@ FREERDP_API rdpGlyph* Glyph_Alloc(rdpContext* context);
 FREERDP_API void Glyph_New(rdpContext* context, rdpGlyph* glyph);
 FREERDP_API void Glyph_Free(rdpContext* context, rdpGlyph* glyph);
 FREERDP_API void Glyph_Draw(rdpContext* context, rdpGlyph* glyph, int x, int y);
-FREERDP_API void Glyph_BeginDraw(rdpContext* context, int x, int y, int width, int height, UINT32 bgcolor, UINT32 fgcolor);
+FREERDP_API void Glyph_BeginDraw(rdpContext* context, int x, int y, int width, int height, UINT32 bgcolor, UINT32 fgcolor, BOOL fOpRedundant);
 FREERDP_API void Glyph_EndDraw(rdpContext* context, int x, int y, int width, int height, UINT32 bgcolor, UINT32 fgcolor);
 
 /* Graphics Module */

--- a/libfreerdp/core/graphics.c
+++ b/libfreerdp/core/graphics.c
@@ -186,9 +186,9 @@ void Glyph_Draw(rdpContext* context, rdpGlyph* glyph, int x, int y)
 	context->graphics->Glyph_Prototype->Draw(context, glyph, x, y);
 }
 
-void Glyph_BeginDraw(rdpContext* context, int x, int y, int width, int height, UINT32 bgcolor, UINT32 fgcolor)
+void Glyph_BeginDraw(rdpContext* context, int x, int y, int width, int height, UINT32 bgcolor, UINT32 fgcolor, BOOL fOpRedundant)
 {
-	context->graphics->Glyph_Prototype->BeginDraw(context, x, y, width, height, bgcolor, fgcolor);
+	context->graphics->Glyph_Prototype->BeginDraw(context, x, y, width, height, bgcolor, fgcolor, fOpRedundant);
 }
 
 void Glyph_EndDraw(rdpContext* context, int x, int y, int width, int height, UINT32 bgcolor, UINT32 fgcolor)

--- a/libfreerdp/gdi/graphics.c
+++ b/libfreerdp/gdi/graphics.c
@@ -261,11 +261,13 @@ void gdi_Glyph_Draw(rdpContext* context, rdpGlyph* glyph, int x, int y)
 			gdi_glyph->bitmap->height, gdi_glyph->hdc, 0, 0, GDI_DSPDxax);
 }
 
-void gdi_Glyph_BeginDraw(rdpContext* context, int x, int y, int width, int height, UINT32 bgcolor, UINT32 fgcolor)
+void gdi_Glyph_BeginDraw(rdpContext* context, int x, int y, int width, int height, UINT32 bgcolor, UINT32 fgcolor, BOOL fOpRedundant)
 {
 	GDI_RECT rect;
 	HGDI_BRUSH brush;
 	rdpGdi* gdi = context->gdi;
+
+	/* TODO: handle fOpRedundant! See xf_Glyph_BeginDraw() */
 
 	bgcolor = freerdp_convert_gdi_order_color(bgcolor, gdi->srcBpp, gdi->format, gdi->palette);
 	fgcolor = freerdp_convert_gdi_order_color(fgcolor, gdi->srcBpp, gdi->format, gdi->palette);


### PR DESCRIPTION
The fOpRedundant field of the GlyphIndex primary drawing order (MS-RDPEGDI, chapter 2.2.2.2.1.1.2.13) was neglected which resulted in some severe text rendering errors.
