### PR TITLE
Removed library prefix on Windows def files.

### DIFF
--- a/client/common/module.def
+++ b/client/common/module.def
@@ -1,3 +1,3 @@
-LIBRARY		"libfreerdp-client"
+LIBRARY		"freerdp-client"
 EXPORTS
 

--- a/server/common/module.def
+++ b/server/common/module.def
@@ -1,3 +1,3 @@
-LIBRARY		"libfreerdp-server"
+LIBRARY		"freerdp-server"
 EXPORTS
 


### PR DESCRIPTION
This change seems to be necessary after PR #1965. On Windows there's no more "lib" prefix on dll naming.
