### PR TITLE
Server-side AutoDetect fixes

### DIFF
--- a/include/freerdp/autodetect.h
+++ b/include/freerdp/autodetect.h
@@ -26,8 +26,7 @@ typedef struct rdp_autodetect rdpAutoDetect;
 typedef BOOL (*pRTTMeasureRequest)(rdpContext* context, UINT16 sequenceNumber);
 typedef BOOL (*pRTTMeasureResponse)(rdpContext* context, UINT16 sequenceNumber);
 typedef BOOL (*pBandwidthMeasureStart)(rdpContext* context, UINT16 sequenceNumber);
-typedef BOOL (*pBandwidthMeasurePayload)(rdpContext* context, UINT16 payloadLength, UINT16 sequenceNumber);
-typedef BOOL (*pBandwidthMeasureStop)(rdpContext* context, UINT16 payloadLength, UINT16 sequenceNumber);
+typedef BOOL (*pBandwidthMeasureStop)(rdpContext* context, UINT16 sequenceNumber);
 typedef BOOL (*pBandwidthMeasureResults)(rdpContext* context, UINT16 sequenceNumber);
 typedef BOOL (*pNetworkCharacteristicsResult)(rdpContext* context, UINT16 sequenceNumber);
 
@@ -49,11 +48,10 @@ struct rdp_autodetect
 	ALIGN64 pRTTMeasureRequest RTTMeasureRequest; /* 16 */
 	ALIGN64 pRTTMeasureResponse RTTMeasureResponse; /* 17 */
 	ALIGN64 pBandwidthMeasureStart BandwidthMeasureStart; /* 18 */
-	ALIGN64 pBandwidthMeasurePayload BandwidthMeasurePayload; /* 19 */
-	ALIGN64 pBandwidthMeasureStop BandwidthMeasureStop; /* 20 */
-	ALIGN64 pBandwidthMeasureResults BandwidthMeasureResults; /* 21 */
-	ALIGN64 pNetworkCharacteristicsResult NetworkCharacteristicsResult; /* 22 */
-	UINT64 paddingB[32 - 23]; /* 23 */
+	ALIGN64 pBandwidthMeasureStop BandwidthMeasureStop; /* 19 */
+	ALIGN64 pBandwidthMeasureResults BandwidthMeasureResults; /* 20 */
+	ALIGN64 pNetworkCharacteristicsResult NetworkCharacteristicsResult; /* 21 */
+	UINT64 paddingB[32 - 22]; /* 22 */
 };
 
 

--- a/libfreerdp/core/autodetect.h
+++ b/libfreerdp/core/autodetect.h
@@ -39,6 +39,10 @@ rdpAutoDetect* autodetect_new(void);
 void autodetect_free(rdpAutoDetect* autodetect);
 
 void autodetect_register_server_callbacks(rdpAutoDetect* autodetect);
+BOOL autodetect_send_connecttime_rtt_measure_request(rdpContext* context, UINT16 sequenceNumber);
+BOOL autodetect_send_connecttime_bandwidth_measure_start(rdpContext* context, UINT16 sequenceNumber);
+BOOL autodetect_send_bandwidth_measure_payload(rdpContext* context, UINT16 payloadLength, UINT16 sequenceNumber);
+BOOL autodetect_send_connecttime_bandwidth_measure_stop(rdpContext* context, UINT16 payloadLength, UINT16 sequenceNumber);
 
 #define AUTODETECT_TAG FREERDP_TAG("core.autodetect")
 


### PR DESCRIPTION
1. Fixes the misused of different requestType field for Continuous/ConnectTime scenarios.
2. the bandwidth payload message is only valid for ConnectTime scenario so it should not be exposed to external API. 
3. Add internal ConnectTime autodetect API for future implementation.
