### PR TITLE
Offer to disable bulk compression when using remoteFx

### DIFF
--- a/include/freerdp/update.h
+++ b/include/freerdp/update.h
@@ -68,6 +68,7 @@ struct _BITMAP_UPDATE
 	UINT32 count;
 	UINT32 number;
 	BITMAP_DATA* rectangles;
+	BOOL skipCompression;
 };
 typedef struct _BITMAP_UPDATE BITMAP_UPDATE;
 
@@ -104,6 +105,7 @@ struct _SURFACE_BITS_COMMAND
 	UINT32 height;
 	UINT32 bitmapDataLength;
 	BYTE* bitmapData;
+	BOOL skipCompression;
 };
 typedef struct _SURFACE_BITS_COMMAND SURFACE_BITS_COMMAND;
 

--- a/libfreerdp/core/fastpath.c
+++ b/libfreerdp/core/fastpath.c
@@ -865,7 +865,7 @@ wStream* fastpath_update_pdu_init_new(rdpFastPath* fastpath)
 	return s;
 }
 
-BOOL fastpath_send_update_pdu(rdpFastPath* fastpath, BYTE updateCode, wStream* s)
+BOOL fastpath_send_update_pdu(rdpFastPath* fastpath, BYTE updateCode, wStream* s, BOOL skipCompression)
 {
 	int fragment;
 	UINT16 maxLength;
@@ -886,7 +886,7 @@ BOOL fastpath_send_update_pdu(rdpFastPath* fastpath, BYTE updateCode, wStream* s
 
 	maxLength = FASTPATH_MAX_PACKET_SIZE - 20;
 
-	if (settings->CompressionEnabled)
+	if (settings->CompressionEnabled && !skipCompression)
 	{
 		CompressionMaxSize = bulk_compression_max_size(rdp->bulk);
 		maxLength = (maxLength < CompressionMaxSize) ? maxLength : CompressionMaxSize;
@@ -955,7 +955,7 @@ BOOL fastpath_send_update_pdu(rdpFastPath* fastpath, BYTE updateCode, wStream* s
 		if (rdp->sec_flags & SEC_SECURE_CHECKSUM)
 			fpUpdatePduHeader.secFlags |= FASTPATH_OUTPUT_SECURE_CHECKSUM;
 
-		if (settings->CompressionEnabled)
+		if (settings->CompressionEnabled && !skipCompression)
 		{
 			if (bulk_compress(rdp->bulk, pSrcData, SrcSize, &pDstData, &DstSize, &compressionFlags) >= 0)
 			{
@@ -1054,18 +1054,21 @@ rdpFastPath* fastpath_new(rdpRdp* rdp)
 {
 	rdpFastPath* fastpath;
 
-	fastpath = (rdpFastPath*) malloc(sizeof(rdpFastPath));
+	fastpath = (rdpFastPath*) calloc(1, sizeof(rdpFastPath));
+	if (!fastpath)
+		return NULL;
 
-	if (fastpath)
-	{
-		ZeroMemory(fastpath, sizeof(rdpFastPath));
-
-		fastpath->rdp = rdp;
-		fastpath->fragmentation = -1;
-		fastpath->fs = Stream_New(NULL, FASTPATH_MAX_PACKET_SIZE);
-	}
+	fastpath->rdp = rdp;
+	fastpath->fragmentation = -1;
+	fastpath->fs = Stream_New(NULL, FASTPATH_MAX_PACKET_SIZE);
+	if (!fastpath->fs)
+		goto out_free;
 
 	return fastpath;
+
+out_free:
+	free(fastpath);
+	return NULL;
 }
 
 void fastpath_free(rdpFastPath* fastpath)

--- a/libfreerdp/core/fastpath.h
+++ b/libfreerdp/core/fastpath.h
@@ -161,7 +161,7 @@ BOOL fastpath_send_input_pdu(rdpFastPath* fastpath, wStream* s);
 
 wStream* fastpath_update_pdu_init(rdpFastPath* fastpath);
 wStream* fastpath_update_pdu_init_new(rdpFastPath* fastpath);
-BOOL fastpath_send_update_pdu(rdpFastPath* fastpath, BYTE updateCode, wStream* s);
+BOOL fastpath_send_update_pdu(rdpFastPath* fastpath, BYTE updateCode, wStream* s, BOOL skipCompression);
 
 BOOL fastpath_send_surfcmd_frame_marker(rdpFastPath* fastpath, UINT16 frameAction, UINT32 frameId);
 

--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -617,7 +617,7 @@ static void update_end_paint(rdpContext* context)
 	if (update->numberOrders > 0)
 	{
 		WLog_ERR(TAG,  "sending %d orders", update->numberOrders);
-		fastpath_send_update_pdu(context->rdp->fastpath, FASTPATH_UPDATETYPE_ORDERS, s);
+		fastpath_send_update_pdu(context->rdp->fastpath, FASTPATH_UPDATETYPE_ORDERS, s, FALSE);
 	}
 
 	update->combineUpdates = FALSE;
@@ -863,7 +863,7 @@ static void update_send_surface_command(rdpContext* context, wStream* s)
 	update = fastpath_update_pdu_init(rdp->fastpath);
 	Stream_EnsureRemainingCapacity(update, Stream_GetPosition(s));
 	Stream_Write(update, Stream_Buffer(s), Stream_GetPosition(s));
-	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_SURFCMDS, update);
+	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_SURFCMDS, update, FALSE);
 	Stream_Release(update);
 }
 
@@ -878,7 +878,7 @@ static void update_send_surface_bits(rdpContext* context, SURFACE_BITS_COMMAND* 
 	Stream_EnsureRemainingCapacity(s, SURFCMD_SURFACE_BITS_HEADER_LENGTH + (int) surfaceBitsCommand->bitmapDataLength);
 	update_write_surfcmd_surface_bits_header(s, surfaceBitsCommand);
 	Stream_Write(s, surfaceBitsCommand->bitmapData, surfaceBitsCommand->bitmapDataLength);
-	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_SURFCMDS, s);
+	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_SURFCMDS, s, surfaceBitsCommand->skipCompression);
 
 	update_force_flush(context);
 
@@ -894,7 +894,7 @@ static void update_send_surface_frame_marker(rdpContext* context, SURFACE_FRAME_
 
 	s = fastpath_update_pdu_init(rdp->fastpath);
 	update_write_surfcmd_frame_marker(s, surfaceFrameMarker->frameAction, surfaceFrameMarker->frameId);
-	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_SURFCMDS, s);
+	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_SURFCMDS, s, FALSE);
 
 	update_force_flush(context);
 
@@ -921,7 +921,7 @@ static void update_send_surface_frame_bits(rdpContext* context, SURFACE_BITS_COM
 	if (last)
 		update_write_surfcmd_frame_marker(s, SURFACECMD_FRAMEACTION_END, frameId);
 
-	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_SURFCMDS, s);
+	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_SURFCMDS, s, cmd->skipCompression);
 
 	update_force_flush(context);
 
@@ -949,7 +949,7 @@ static void update_send_synchronize(rdpContext* context)
 
 	s = fastpath_update_pdu_init(rdp->fastpath);
 	Stream_Zero(s, 2); /* pad2Octets (2 bytes) */
-	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_SYNCHRONIZE, s);
+	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_SYNCHRONIZE, s, FALSE);
 	Stream_Release(s);
 }
 
@@ -968,7 +968,7 @@ static void update_send_bitmap_update(rdpContext* context, BITMAP_UPDATE* bitmap
 
 	s = fastpath_update_pdu_init(rdp->fastpath);
 	update_write_bitmap_update(update, s, bitmapUpdate);
-	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_BITMAP, s);
+	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_BITMAP, s, bitmapUpdate->skipCompression);
 
 	update_force_flush(context);
 
@@ -1502,7 +1502,7 @@ static void update_send_pointer_system(rdpContext* context, POINTER_SYSTEM_UPDAT
 	else
 		updateCode = FASTPATH_UPDATETYPE_PTR_DEFAULT;
 
-	fastpath_send_update_pdu(rdp->fastpath, updateCode, s);
+	fastpath_send_update_pdu(rdp->fastpath, updateCode, s, FALSE);
 	Stream_Release(s);
 }
 
@@ -1534,7 +1534,7 @@ static void update_send_pointer_color(rdpContext* context, POINTER_COLOR_UPDATE*
 
 	s = fastpath_update_pdu_init(rdp->fastpath);
         update_write_pointer_color(s, pointer_color);
-	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_COLOR, s);
+	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_COLOR, s, FALSE);
 	Stream_Release(s);
 }
 
@@ -1546,7 +1546,7 @@ static void update_send_pointer_new(rdpContext* context, POINTER_NEW_UPDATE* poi
 	s = fastpath_update_pdu_init(rdp->fastpath);
 	Stream_Write_UINT16(s, pointer_new->xorBpp); /* xorBpp (2 bytes) */
         update_write_pointer_color(s, &pointer_new->colorPtrAttr);
-	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_POINTER, s);
+	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_POINTER, s, FALSE);
 	Stream_Release(s);
 }
 
@@ -1557,7 +1557,7 @@ static void update_send_pointer_cached(rdpContext* context, POINTER_CACHED_UPDAT
 
 	s = fastpath_update_pdu_init(rdp->fastpath);
 	Stream_Write_UINT16(s, pointer_cached->cacheIndex); /* cacheIndex (2 bytes) */
-	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_CACHED, s);
+	fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_CACHED, s, FALSE);
 	Stream_Release(s);
 }
 


### PR DESCRIPTION
This patch adds a skipCompression field in surface commands struct so that we can disable bulk compression with remoteFx.
