### PR TITLE
Don't include CMakeDetermineSystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,6 @@ include(CheckCmakeCompat)
 include(CheckIncludeFiles)
 include(CheckLibraryExists)
 include(CheckStructHasMember)
-include(CMakeDetermineSystem)
 include(FindPkgConfig)
 include(TestBigEndian)
 


### PR DESCRIPTION
According to [1] this is an cmake "internal" module and shouldn't be
included directly.

[1]  http://public.kitware.com/Bug/view.php?id=13796#c31892
