### PR TITLE
winpr: fix build with visual studio < 2012

### DIFF
--- a/winpr/include/winpr/spec.h
+++ b/winpr/include/winpr/spec.h
@@ -25,6 +25,9 @@
 #ifdef _WIN32
 
 #include <specstrings.h>
+#ifndef _COM_Outptr_
+#define _COM_Outptr_
+#endif
 
 #else
 


### PR DESCRIPTION
_COM_Outptr_ was introduced in visual studio 2012.
