### PR TITLE
winpr-comm: ignore errors on TIOCGICOUNT during the port initialization.

### DIFF
--- a/channels/serial/client/serial_main.c
+++ b/channels/serial/client/serial_main.c
@@ -175,7 +175,7 @@ static void serial_process_irp_create(SERIAL_DEVICE* serial, IRP* irp)
 
 	if (!serial->hComm || (serial->hComm == INVALID_HANDLE_VALUE))
 	{
-		WLog_Print(serial->log, WLOG_WARN, "CreateFile failure: %s last-error: Ox%lX\n", serial->device.name, GetLastError());
+		WLog_Print(serial->log, WLOG_WARN, "CreateFile failure: %s last-error: 0x%lX\n", serial->device.name, GetLastError());
 
 		irp->IoStatus = STATUS_UNSUCCESSFUL;
 		goto error_handle;

--- a/winpr/libwinpr/comm/comm.c
+++ b/winpr/libwinpr/comm/comm.c
@@ -1373,9 +1373,17 @@ HANDLE CommCreateFileA(LPCSTR lpDeviceName, DWORD dwDesiredAccess, DWORD dwShare
 
 	if (ioctl(pComm->fd, TIOCGICOUNT, &(pComm->counters)) < 0)
 	{
-		CommLog_Print(WLOG_WARN, "TIOCGICOUNT ioctl failed, errno=[%d] %s", errno, strerror(errno));
-		SetLastError(ERROR_IO_DEVICE);
-		goto error_handle;
+		CommLog_Print(WLOG_WARN, "TIOCGICOUNT ioctl failed, errno=[%d] %s.", errno, strerror(errno));
+		CommLog_Print(WLOG_WARN, "could not read counters.");
+
+		/* could not initialize counters but keep on. 
+		 *
+		 * Not all drivers, especially for USB to serial
+		 * adapters (e.g. those based on pl2303), does support
+		 * this call.
+		 */
+
+		ZeroMemory(&(pComm->counters), sizeof(struct serial_icounter_struct));
 	}
 
 


### PR DESCRIPTION
Drivers for some USB to serial adapters doesn't support the TIOCGICOUNT ioctl (e.g. pl2303). This modification go over this issue during the port initialization and let a chance to applications to deal with this issue.
