### PR TITLE
xfreerdp: fix polyline

### DIFF
--- a/client/X11/xf_gdi.c
+++ b/client/X11/xf_gdi.c
@@ -706,7 +706,6 @@ void xf_gdi_polyline(rdpContext* context, POLYLINE_ORDER* polyline)
 	int npoints;
 	UINT32 color;
 	XPoint* points;
-	XPoint tmp;
 	int width, height;
 	xfContext* xfc = (xfContext*) context;
 
@@ -721,15 +720,13 @@ void xf_gdi_polyline(rdpContext* context, POLYLINE_ORDER* polyline)
 	npoints = polyline->numDeltaEntries + 1;
 	points = malloc(sizeof(XPoint) * npoints);
 
-	points[0].x = tmp.x = polyline->xStart;
-	points[0].y = tmp.y = polyline->yStart;
+	points[0].x = polyline->xStart;
+	points[0].y = polyline->yStart;
 
 	for (i = 0; i < polyline->numDeltaEntries; i++)
 	{
-		tmp.x += polyline->points[i].x;
-		tmp.y += polyline->points[i].y;
-		points[i + 1].x = tmp.x;
-		points[i + 1].y = tmp.y;
+		points[i + 1].x = polyline->points[i].x;
+		points[i + 1].y = polyline->points[i].y;
 	}
 
 	XDrawLines(xfc->display, xfc->drawing, xfc->gc, points, npoints, CoordModePrevious);


### PR DESCRIPTION
X11 gdi polyline has been broken by commit 3de5c62.
We don't need to convert the point coordinates if XDrawLines is called with
coordinate mode CoordModePrevious.
This fixes issue #2214
