### PR TITLE
Call redraw only when region is invalidated

### DIFF
--- a/client/iOS/FreeRDP/ios_freerdp_ui.m
+++ b/client/iOS/FreeRDP/ios_freerdp_ui.m
@@ -106,7 +106,8 @@ void ios_ui_end_paint(rdpContext * context)
 	rdpGdi *gdi = context->gdi;
 	CGRect dirty_rect = CGRectMake(gdi->primary->hdc->hwnd->invalid->x, gdi->primary->hdc->hwnd->invalid->y, gdi->primary->hdc->hwnd->invalid->w, gdi->primary->hdc->hwnd->invalid->h);
 	
-	[mfi->session performSelectorOnMainThread:@selector(setNeedsDisplayInRectAsValue:) withObject:[NSValue valueWithCGRect:dirty_rect] waitUntilDone:NO];
+	if (gdi->primary->hdc->hwnd->invalid->null == 0)
+		[mfi->session performSelectorOnMainThread:@selector(setNeedsDisplayInRectAsValue:) withObject:[NSValue valueWithCGRect:dirty_rect] waitUntilDone:NO];
 }
 
 


### PR DESCRIPTION
Added a condition to redraw a rect only when region is invalidated. For example. this avoids a redraw when only the cursor changes on the remote machine.
