### PR TITLE
wlfreerdp: add keyboard and mouse wheel support, fix races

### DIFF
--- a/client/Wayland/wlf_input.h
+++ b/client/Wayland/wlf_input.h
@@ -28,10 +28,12 @@ typedef struct wlf_input wlfInput;
 
 struct wlf_input
 {
-	rdpInput *input;
+	rdpInput* input;
+	UINT16 last_x;
+	UINT16 last_y;
 
-	struct wl_pointer *pointer;
-	struct wl_keyboard *keyboard;
+	struct wl_pointer* pointer;
+	struct wl_keyboard* keyboard;
 };
 
 wlfInput* wlf_CreateInput(wlfContext* wlfc);

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -48,11 +48,11 @@ void wl_begin_paint(rdpContext* context)
 
 void wl_end_paint(rdpContext* context)
 {
-	char *data;
 	rdpGdi* gdi;
 	wlfDisplay* display;
 	wlfWindow* window;
 	wlfContext* context_w;
+	void* data;
 
 	gdi = context->gdi;
 	if (gdi->primary->hdc->hwnd->invalid->null)


### PR DESCRIPTION
This commit does the following :
- fix the keyboard logic (which now fully works), add
  support for vertical mouse wheel events ;
- make the rendering a bit more efficient ;
- fix some race conditions which could crash wlfreerdp ;
- improve the code style.

Signed-off-by: Manuel Bachmann tarnyko@tarnyko.net
