### PR TITLE
Rename tcp-functions as they are conflicting with qemu functions

### DIFF
--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -441,7 +441,7 @@ BOOL transport_bio_buffered_drain(BIO *bio)
 	return status >= 0;
 }
 
-void tcp_get_ip_address(rdpTcp* tcp)
+void freerdp_tcp_get_ip_address(rdpTcp* tcp)
 {
 	BYTE* ip;
 	socklen_t length;
@@ -467,7 +467,7 @@ void tcp_get_ip_address(rdpTcp* tcp)
 	tcp->settings->ClientAddress = _strdup(tcp->ip_address);
 }
 
-void tcp_get_mac_address(rdpTcp* tcp)
+void freerdp_tcp_get_mac_address(rdpTcp* tcp)
 {
 #ifdef LINUX
 	BYTE* mac;
@@ -531,7 +531,7 @@ int uds_connect(const char* path)
 #endif
 }
 
-BOOL tcp_connect(rdpTcp* tcp, const char* hostname, int port, int timeout)
+BOOL freerdp_tcp_connect(rdpTcp* tcp, const char* hostname, int port, int timeout)
 {
 	int status;
 	UINT32 option_value;
@@ -678,8 +678,8 @@ BOOL tcp_connect(rdpTcp* tcp, const char* hostname, int port, int timeout)
 
 	SetEventFileDescriptor(tcp->event, tcp->sockfd);
 
-	tcp_get_ip_address(tcp);
-	tcp_get_mac_address(tcp);
+	freerdp_tcp_get_ip_address(tcp);
+	freerdp_tcp_get_mac_address(tcp);
 
 	option_value = 1;
 	option_len = sizeof(option_value);
@@ -708,7 +708,7 @@ BOOL tcp_connect(rdpTcp* tcp, const char* hostname, int port, int timeout)
 
 	if (!tcp->ipcSocket)
 	{
-		if (!tcp_set_keep_alive_mode(tcp))
+		if (!freerdp_tcp_set_keep_alive_mode(tcp))
 			return FALSE;
 	}
 
@@ -724,7 +724,7 @@ BOOL tcp_connect(rdpTcp* tcp, const char* hostname, int port, int timeout)
 	return TRUE;
 }
 
-BOOL tcp_disconnect(rdpTcp* tcp)
+BOOL freerdp_tcp_disconnect(rdpTcp* tcp)
 {
 	if (tcp->sockfd != -1)
 	{
@@ -737,7 +737,7 @@ BOOL tcp_disconnect(rdpTcp* tcp)
 	return TRUE;
 }
 
-BOOL tcp_set_blocking_mode(rdpTcp* tcp, BOOL blocking)
+BOOL freerdp_tcp_set_blocking_mode(rdpTcp* tcp, BOOL blocking)
 {
 #ifndef _WIN32
 	int flags;
@@ -784,7 +784,7 @@ BOOL tcp_set_blocking_mode(rdpTcp* tcp, BOOL blocking)
 	return TRUE;
 }
 
-BOOL tcp_set_keep_alive_mode(rdpTcp* tcp)
+BOOL freerdp_tcp_set_keep_alive_mode(rdpTcp* tcp)
 {
 #ifndef _WIN32
 	UINT32 option_value;
@@ -844,7 +844,7 @@ BOOL tcp_set_keep_alive_mode(rdpTcp* tcp)
 	return TRUE;
 }
 
-int tcp_attach(rdpTcp* tcp, int sockfd)
+int freerdp_tcp_attach(rdpTcp* tcp, int sockfd)
 {
 	tcp->sockfd = sockfd;
 	SetEventFileDescriptor(tcp->event, tcp->sockfd);
@@ -881,7 +881,7 @@ int tcp_attach(rdpTcp* tcp, int sockfd)
 	return 0;
 }
 
-HANDLE tcp_get_event_handle(rdpTcp* tcp)
+HANDLE freerdp_tcp_get_event_handle(rdpTcp* tcp)
 {
 	if (!tcp)
 		return NULL;
@@ -889,7 +889,7 @@ HANDLE tcp_get_event_handle(rdpTcp* tcp)
 	return tcp->event;
 }
 
-int tcp_wait_read(rdpTcp* tcp, DWORD dwMilliSeconds)
+int freerdp_tcp_wait_read(rdpTcp* tcp, DWORD dwMilliSeconds)
 {
 	int status;
 
@@ -927,7 +927,7 @@ int tcp_wait_read(rdpTcp* tcp, DWORD dwMilliSeconds)
 	return status;
 }
 
-int tcp_wait_write(rdpTcp* tcp, DWORD dwMilliSeconds)
+int freerdp_tcp_wait_write(rdpTcp* tcp, DWORD dwMilliSeconds)
 {
 	int status;
 
@@ -965,7 +965,7 @@ int tcp_wait_write(rdpTcp* tcp, DWORD dwMilliSeconds)
 	return status;
 }
 
-rdpTcp* tcp_new(rdpSettings* settings)
+rdpTcp* freerdp_tcp_new(rdpSettings* settings)
 {
 	rdpTcp* tcp;
 
@@ -998,7 +998,7 @@ out_free:
 	return NULL;
 }
 
-void tcp_free(rdpTcp* tcp)
+void freerdp_tcp_free(rdpTcp* tcp)
 {
 	if (!tcp)
 		return;

--- a/libfreerdp/core/tcp.h
+++ b/libfreerdp/core/tcp.h
@@ -58,18 +58,18 @@ struct rdp_tcp
 	HANDLE event;
 };
 
-BOOL tcp_connect(rdpTcp* tcp, const char* hostname, int port, int timeout);
-BOOL tcp_disconnect(rdpTcp* tcp);
-int tcp_read(rdpTcp* tcp, BYTE* data, int length);
-int tcp_write(rdpTcp* tcp, BYTE* data, int length);
-int tcp_wait_read(rdpTcp* tcp, DWORD dwMilliSeconds);
-int tcp_wait_write(rdpTcp* tcp, DWORD dwMilliSeconds);
-BOOL tcp_set_blocking_mode(rdpTcp* tcp, BOOL blocking);
-BOOL tcp_set_keep_alive_mode(rdpTcp* tcp);
-int tcp_attach(rdpTcp* tcp, int sockfd);
-HANDLE tcp_get_event_handle(rdpTcp* tcp);
+BOOL freerdp_tcp_connect(rdpTcp* tcp, const char* hostname, int port, int timeout);
+BOOL freerdp_tcp_disconnect(rdpTcp* tcp);
+int freerdp_tcp_read(rdpTcp* tcp, BYTE* data, int length);
+int freerdp_tcp_write(rdpTcp* tcp, BYTE* data, int length);
+int freerdp_tcp_wait_read(rdpTcp* tcp, DWORD dwMilliSeconds);
+int freerdp_tcp_wait_write(rdpTcp* tcp, DWORD dwMilliSeconds);
+BOOL freerdp_tcp_set_blocking_mode(rdpTcp* tcp, BOOL blocking);
+BOOL freerdp_tcp_set_keep_alive_mode(rdpTcp* tcp);
+int freerdp_tcp_attach(rdpTcp* tcp, int sockfd);
+HANDLE freerdp_tcp_get_event_handle(rdpTcp* tcp);
 
-rdpTcp* tcp_new(rdpSettings* settings);
-void tcp_free(rdpTcp* tcp);
+rdpTcp* freerdp_tcp_new(rdpSettings* settings);
+void freerdp_tcp_free(rdpTcp* tcp);
 
 #endif /* __TCP_H */

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -71,7 +71,7 @@ wStream* transport_send_stream_init(rdpTransport* transport, int size)
 
 void transport_attach(rdpTransport* transport, int sockfd)
 {
-	tcp_attach(transport->TcpIn, sockfd);
+	freerdp_tcp_attach(transport->TcpIn, sockfd);
 	transport->SplitInputOutput = FALSE;
 	transport->TcpOut = transport->TcpIn;
 	transport->frontBio = transport->TcpIn->bufferedBio;
@@ -443,14 +443,14 @@ BOOL transport_connect(rdpTransport* transport, const char* hostname, UINT16 por
 	{
 		transport->layer = TRANSPORT_LAYER_TSG;
 		transport->SplitInputOutput = TRUE;
-		transport->TcpOut = tcp_new(settings);
+		transport->TcpOut = freerdp_tcp_new(settings);
 
-		if (!tcp_connect(transport->TcpIn, settings->GatewayHostname, settings->GatewayPort, timeout) ||
-				!tcp_set_blocking_mode(transport->TcpIn, FALSE))
+		if (!freerdp_tcp_connect(transport->TcpIn, settings->GatewayHostname, settings->GatewayPort, timeout) ||
+				!freerdp_tcp_set_blocking_mode(transport->TcpIn, FALSE))
 			return FALSE;
 
-		if (!tcp_connect(transport->TcpOut, settings->GatewayHostname, settings->GatewayPort, timeout) ||
-				!tcp_set_blocking_mode(transport->TcpOut, FALSE))
+		if (!freerdp_tcp_connect(transport->TcpOut, settings->GatewayHostname, settings->GatewayPort, timeout) ||
+				!freerdp_tcp_set_blocking_mode(transport->TcpOut, FALSE))
 			return FALSE;
 
 		if (!transport_tsg_connect(transport, hostname, port))
@@ -460,7 +460,7 @@ BOOL transport_connect(rdpTransport* transport, const char* hostname, UINT16 por
 	}
 	else
 	{
-		status = tcp_connect(transport->TcpIn, hostname, port, timeout);
+		status = freerdp_tcp_connect(transport->TcpIn, hostname, port, timeout);
 		transport->SplitInputOutput = FALSE;
 		transport->TcpOut = transport->TcpIn;
 		transport->frontBio = transport->TcpIn->bufferedBio;
@@ -554,11 +554,11 @@ static int transport_wait_for_read(rdpTransport* transport)
 
 	if (tcpIn->readBlocked)
 	{
-		return tcp_wait_read(tcpIn, 10);
+		return freerdp_tcp_wait_read(tcpIn, 10);
 	}
 	else if (tcpIn->writeBlocked)
 	{
-		return tcp_wait_write(tcpIn, 10);
+		return freerdp_tcp_wait_write(tcpIn, 10);
 	}
 
 	USleep(1000);
@@ -572,11 +572,11 @@ static int transport_wait_for_write(rdpTransport* transport)
 
 	if (tcpOut->writeBlocked)
 	{
-		return tcp_wait_write(tcpOut, 10);
+		return freerdp_tcp_wait_write(tcpOut, 10);
 	}
 	else if (tcpOut->readBlocked)
 	{
-		return tcp_wait_read(tcpOut, 10);
+		return freerdp_tcp_wait_read(tcpOut, 10);
 	}
 
 	USleep(1000);
@@ -942,12 +942,12 @@ void transport_get_fds(rdpTransport* transport, void** rfds, int* rcount)
 
 void transport_get_read_handles(rdpTransport* transport, HANDLE* events, DWORD* count)
 {
-	events[*count] = tcp_get_event_handle(transport->TcpIn);
+	events[*count] = freerdp_tcp_get_event_handle(transport->TcpIn);
 	(*count)++;
 
 	if (transport->SplitInputOutput)
 	{
-		events[*count] = tcp_get_event_handle(transport->TcpOut);
+		events[*count] = freerdp_tcp_get_event_handle(transport->TcpOut);
 		(*count)++;
 	}
 
@@ -1067,12 +1067,12 @@ BOOL transport_set_blocking_mode(rdpTransport* transport, BOOL blocking)
 
 	if (transport->SplitInputOutput)
 	{
-		status &= tcp_set_blocking_mode(transport->TcpIn, blocking);
-		status &= tcp_set_blocking_mode(transport->TcpOut, blocking);
+		status &= freerdp_tcp_set_blocking_mode(transport->TcpIn, blocking);
+		status &= freerdp_tcp_set_blocking_mode(transport->TcpOut, blocking);
 	}
 	else
 	{
-		status &= tcp_set_blocking_mode(transport->TcpIn, blocking);
+		status &= freerdp_tcp_set_blocking_mode(transport->TcpIn, blocking);
 	}
 
 	if (transport->layer == TRANSPORT_LAYER_TSG || transport->layer == TRANSPORT_LAYER_TSG_TLS)
@@ -1166,7 +1166,7 @@ rdpTransport* transport_new(rdpSettings* settings)
 	if (!transport->log)
 		goto out_free;
 
-	transport->TcpIn = tcp_new(settings);
+	transport->TcpIn = freerdp_tcp_new(settings);
 
 	if (!transport->TcpIn)
 		goto out_free;
@@ -1217,7 +1217,7 @@ out_free_receivebuffer:
 out_free_receivepool:
 	StreamPool_Free(transport->ReceivePool);
 out_free_tcpin:
-	tcp_free(transport->TcpIn);
+	freerdp_tcp_free(transport->TcpIn);
 out_free:
 	free(transport);
 	return NULL;
@@ -1247,10 +1247,10 @@ void transport_free(rdpTransport* transport)
 	transport->TlsOut = NULL;
 
 	if (transport->TcpIn)
-		tcp_free(transport->TcpIn);
+		freerdp_tcp_free(transport->TcpIn);
 
 	if (transport->TcpOut != transport->TcpIn)
-		tcp_free(transport->TcpOut);
+		freerdp_tcp_free(transport->TcpOut);
 
 	transport->TcpIn = NULL;
 	transport->TcpOut = NULL;


### PR DESCRIPTION
I´m currently writing a new ui Backend for QEMU that enables RDP access via FreeRDP. The tcp-functions are conflicting existing symbols in qemu and both are exported.

So as changing the names within FreeRDP is less complex than changing them in qemu I decided renaming those functions in my fork of FreeRDP.

Please mainstream this change.

Thank you.
