### PR TITLE
core client side: set flag to crypt license

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -449,6 +449,8 @@ static BOOL rdp_client_establish_keys(rdpRdp* rdp)
 	if (status < 0)
 		goto end;
 
+	rdp->do_crypt_license = TRUE;
+
 	/* now calculate encrypt / decrypt and update keys */
 	if (!security_establish_keys(settings->ClientRandom, rdp))
 		goto end;


### PR DESCRIPTION
Client side code always tells the server that it is capable of processing
encrypted licensing packages (SEC_LICENSE_ENCRYPT_SC) but didn't set
the recently added flag to indicate that.

Fixes #2196
