### PR TITLE
xfreerdp: fix a possible re-size race condition

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -231,13 +231,6 @@ static void xf_desktop_resize(rdpContext* context)
 				xfc->drawing = xfc->primary;
 	}
 
-	if (!xfc->fullscreen)
-	{
-		if (xfc->window)
-			xf_ResizeDesktopWindow(xfc, xfc->window, settings->DesktopWidth, settings->DesktopHeight);
-	}
-	else
-	{
 #ifdef WITH_XRENDER
 		if (!xfc->settings->SmartSizing)
 		{
@@ -245,6 +238,14 @@ static void xf_desktop_resize(rdpContext* context)
 			xfc->scaledHeight = xfc->height;
 		}
 #endif
+
+	if (!xfc->fullscreen)
+	{
+		if (xfc->window)
+			xf_ResizeDesktopWindow(xfc, xfc->window, settings->DesktopWidth, settings->DesktopHeight);
+	}
+	else
+	{
 		XSetFunction(xfc->display, xfc->gc, GXcopy);
 		XSetFillStyle(xfc->display, xfc->gc, FillSolid);
 		XSetForeground(xfc->display, xfc->gc, 0);


### PR DESCRIPTION
In case of server side initiated desktop resize it could happen that the
client was "scaling" even if smart-sizing was disabled. The reason for
this was that the "scaled" width and height was set when the X Configure
event arrived but not in xf_desktop_resize.
