### PR TITLE
xfreerdp: fix cliprdr SelectionNotify enless loop

### DIFF
--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -770,7 +770,7 @@ int xf_cliprdr_send_client_format_list(xfClipboard* clipboard)
 
 	free(formats);
 
-	if (clipboard->owner != xfc->drawable)
+	if (clipboard->owner && clipboard->owner != xfc->drawable)
 	{
 		/* Request the owner for TARGETS, and wait for SelectionNotify event */
 		XConvertSelection(xfc->display, clipboard->clipboard_atom,


### PR DESCRIPTION
xf_cliprdr_process_selection_notify calls xf_cliprdr_send_client_format_list
if the SelectionNotify event property was None.
xf_cliprdr_send_client_format_list called XConvertSelection even if there
was no clipboard owner. In that case the XServer generates a SelectionNotify
event to the requestor (us) with property None and so on ...

The most obvious fix is to ensure that XConvertSelection is not called if
the owner is None which is done in this commit.
