### PR TITLE
libfreerdp-core: enable ipv6 listener.

### DIFF
--- a/libfreerdp/core/listener.c
+++ b/libfreerdp/core/listener.c
@@ -132,9 +132,6 @@ static BOOL freerdp_listener_open(freerdp_listener* instance, const char* bind_a
 
 		inet_ntop(ai->ai_family, sin_addr, addr, sizeof(addr));
 
-		if (strcmp(addr, "::") == 0)
-			continue;
-
 		option_value = 1;
 
 		if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (void*) &option_value, sizeof(option_value)) == -1)


### PR DESCRIPTION
This shouldn't be necessary. I have tested ipv6 connection and it works fine.
