### PR TITLE
Fix segmentation fault in URBDRC

### DIFF
--- a/channels/urbdrc/client/urbdrc_main.c
+++ b/channels/urbdrc/client/urbdrc_main.c
@@ -908,6 +908,8 @@ static int urbdrc_on_new_channel_connection(IWTSListenerCallback* pListenerCallb
 	URBDRC_CHANNEL_CALLBACK* callback;
 	WLog_VRB(TAG, "");
 	callback = (URBDRC_CHANNEL_CALLBACK*) malloc(sizeof(URBDRC_CHANNEL_CALLBACK));
+	memset(callback, 0, sizeof(URBDRC_CHANNEL_CALLBACK));
+
 	callback->iface.OnDataReceived = urbdrc_on_data_received;
 	callback->iface.OnClose = urbdrc_on_close;
 	callback->plugin = listener_callback->plugin;


### PR DESCRIPTION
I've encountered segmentation fault while trying to redirect USB device and traced it to missing memset() after malloc() in urbdrc_main.c.
Maybe it was the cause for issues #2078 and #2113.
