### PR TITLE
SmartCard

### DIFF
--- a/winpr/libwinpr/smartcard/smartcard_pcsc.c
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.c
@@ -143,7 +143,9 @@ static int g_StartedEventRefCount = 0;
 
 static BOOL g_SCardAutoAllocate = FALSE;
 static BOOL g_PnP_Notification = TRUE;
+#ifdef __MACOSX__
 static unsigned int OSXVersion = 0;
+#endif
 
 /**
  * g_LockTransactions: enable pcsc-lite SCardBeginTransaction/SCardEndTransaction.
@@ -1885,12 +1887,13 @@ WINSCARDAPI LONG WINAPI PCSC_SCardStatus_Internal(SCARDHANDLE hCard,
 		{
 			if (pcchReaderLenAlloc)
 			{
+#ifdef __MAXOSX__
 				/**
 				* Workaround for SCardStatus Bug in MAC OS X Yosemite
 				*/
 				if (OSXVersion == 0x10100000)
 					pcsc_cchReaderLen++;
-
+#endif
 				*pMszReaderNames = (LPSTR) calloc(1, pcsc_cchReaderLen);
 
 				if (!*pMszReaderNames)
@@ -2809,10 +2812,14 @@ int PCSC_InitializeSCardApi(void)
 	g_PCSC.pfnSCardEndTransaction = (void*) GetProcAddress(g_PCSCModule, "SCardEndTransaction");
 	g_PCSC.pfnSCardStatus = (void*) GetProcAddress(g_PCSCModule, "SCardStatus");
 	g_PCSC.pfnSCardGetStatusChange = (void*) GetProcAddress(g_PCSCModule, "SCardGetStatusChange");
+#ifdef __MACOSX__
 	if (OSXVersion >= 0x10050600)
 		g_PCSC.pfnSCardControl = (void*) GetProcAddress(g_PCSCModule, "SCardControl132");
 	else
 		g_PCSC.pfnSCardControl = (void*) GetProcAddress(g_PCSCModule, "SCardControl");
+#else
+	g_PCSC.pfnSCardControl = (void*) GetProcAddress(g_PCSCModule, "SCardControl");
+#endif
 	g_PCSC.pfnSCardTransmit = (void*) GetProcAddress(g_PCSCModule, "SCardTransmit");
 	g_PCSC.pfnSCardListReaderGroups = (void*) GetProcAddress(g_PCSCModule, "SCardListReaderGroups");
 	g_PCSC.pfnSCardListReaders = (void*) GetProcAddress(g_PCSCModule, "SCardListReaders");


### PR DESCRIPTION
- Check for NULL parameters in PCSC_ConvertReaderNameToWinSCard (Issue #2184)
- Remove masking of dwEventState as it is not needed under Linux and MacOSX and it helps in ThinLinc environment
- Workaround for Mac OS X Yosemite (10.10) SCardStatus Bug (Issue #2184)
- Since Mac OS Tiger (10.5.6), Apple introduced new function for SCardControl calls named SCardControl132(), the old SCardControl doesn't work (cf. https://opensource.apple.com/source/SmartCardServices/SmartCardServices-55111/src/PCSC/winscard_clnt.c)

Tested successfully in Linux, Mac OS X and ThinLinc environment.
There is still a bug under Mac OS X Yosemite (10.10) with SCardGetAttrib calls. Apple is aware of this problem (and also for the SCardStatus bug) but no ETA for a patch.
