### PR TITLE
Standard RDP Security Layer Levels/Method Overhaul

### DIFF
--- a/client/Android/FreeRDPCore/jni/android_freerdp.c
+++ b/client/Android/FreeRDPCore/jni/android_freerdp.c
@@ -745,9 +745,7 @@ JNIEXPORT void JNICALL jni_freerdp_set_connection_info(JNIEnv *env, jclass cls, 
 			settings->TlsSecurity = FALSE;
 			settings->NlaSecurity = FALSE;
 			settings->ExtSecurity = FALSE;
-			settings->DisableEncryption = TRUE;
-			settings->EncryptionMethods = ENCRYPTION_METHOD_40BIT | ENCRYPTION_METHOD_128BIT | ENCRYPTION_METHOD_FIPS;
-			settings->EncryptionLevel = ENCRYPTION_LEVEL_CLIENT_COMPATIBLE;
+			settings->UseRdpSecurityLayer = TRUE;
 			break;
 
 		case 2:

--- a/client/common/compatibility.c
+++ b/client/common/compatibility.c
@@ -695,9 +695,7 @@ int freerdp_client_parse_old_command_line_arguments(int argc, char** argv, rdpSe
 				settings->RdpSecurity = TRUE;
 				settings->TlsSecurity = FALSE;
 				settings->NlaSecurity = FALSE;
-				settings->DisableEncryption = FALSE;
-				settings->EncryptionMethods = ENCRYPTION_METHOD_40BIT | ENCRYPTION_METHOD_56BIT | ENCRYPTION_METHOD_128BIT | ENCRYPTION_METHOD_FIPS;
-				settings->EncryptionLevel = ENCRYPTION_LEVEL_CLIENT_COMPATIBLE;
+				settings->UseRdpSecurityLayer = FALSE;
 			}
 			else if (strncmp("tls", arg->Value, 1) == 0) /* TLS */
 			{

--- a/client/iOS/Models/RDPSession.m
+++ b/client/iOS/Models/RDPSession.m
@@ -158,9 +158,7 @@ NSString* TSXSessionDidFailToConnectNotification = @"TSXSessionDidFailToConnect"
             settings->TlsSecurity = FALSE;
             settings->NlaSecurity = FALSE;
             settings->ExtSecurity = FALSE;
-            settings->DisableEncryption = TRUE;
-            settings->EncryptionMethods = ENCRYPTION_METHOD_40BIT | ENCRYPTION_METHOD_128BIT | ENCRYPTION_METHOD_FIPS;
-            settings->EncryptionLevel = ENCRYPTION_LEVEL_CLIENT_COMPATIBLE;
+            settings->UseRdpSecurityLayer = TRUE;
             break;
 
         default:

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -529,7 +529,7 @@ typedef struct _RDPDR_PARALLEL RDPDR_PARALLEL;
 #define FreeRDP_SupportGraphicsPipeline				142
 #define FreeRDP_SupportDynamicTimeZone				143
 #define FreeRDP_SupportHeartbeatPdu				144
-#define FreeRDP_DisableEncryption				192
+#define FreeRDP_UseRdpSecurityLayer				192
 #define FreeRDP_EncryptionMethods				193
 #define FreeRDP_ExtEncryptionMethods				194
 #define FreeRDP_EncryptionLevel					195
@@ -860,7 +860,7 @@ struct rdp_settings
 	UINT64 padding0192[192 - 145]; /* 145 */
 
 	/* Client/Server Security Data */
-	ALIGN64 BOOL DisableEncryption; /* 192 */
+	ALIGN64 BOOL UseRdpSecurityLayer; /* 192 */
 	ALIGN64 UINT32 EncryptionMethods; /* 193 */
 	ALIGN64 UINT32 ExtEncryptionMethods; /* 194 */
 	ALIGN64 UINT32 EncryptionLevel; /* 195 */

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -682,8 +682,8 @@ BOOL freerdp_get_param_bool(rdpSettings* settings, int id)
 		case FreeRDP_SupportDynamicTimeZone:
 			return settings->SupportDynamicTimeZone;
 
-		case FreeRDP_DisableEncryption:
-			return settings->DisableEncryption;
+		case FreeRDP_UseRdpSecurityLayer:
+			return settings->UseRdpSecurityLayer;
 
 		case FreeRDP_ConsoleSession:
 			return settings->ConsoleSession;
@@ -1075,8 +1075,8 @@ int freerdp_set_param_bool(rdpSettings* settings, int id, BOOL param)
 			settings->SupportDynamicTimeZone = param;
 			break;
 
-		case FreeRDP_DisableEncryption:
-			settings->DisableEncryption = param;
+		case FreeRDP_UseRdpSecurityLayer:
+			settings->UseRdpSecurityLayer = param;
 			break;
 
 		case FreeRDP_ConsoleSession:

--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -3537,7 +3537,7 @@ BOOL rdp_recv_get_active_header(rdpRdp* rdp, wStream* s, UINT16* pChannelId)
 	if (rdp->disconnect)
 		return TRUE;
 
-	if (rdp->settings->DisableEncryption)
+	if (rdp->settings->UseRdpSecurityLayer)
 	{
 		if (!rdp_read_security_header(s, &securityFlags))
 			return FALSE;

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -398,7 +398,7 @@ static BOOL rdp_client_establish_keys(rdpRdp* rdp)
 
 	settings = rdp->settings;
 
-	if (!settings->DisableEncryption)
+	if (!settings->UseRdpSecurityLayer)
 	{
 		/* no RDP encryption */
 		return TRUE;
@@ -515,7 +515,7 @@ BOOL rdp_server_establish_keys(rdpRdp* rdp, wStream* s)
 	BYTE* priv_exp;
 	BOOL ret = FALSE;
 
-	if (!rdp->settings->DisableEncryption)
+	if (!rdp->settings->UseRdpSecurityLayer)
 	{
 		/* No RDP Security. */
 		return TRUE;

--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -590,7 +590,7 @@ BOOL rdp_recv_client_info(rdpRdp* rdp, wStream* s)
 	if ((securityFlags & SEC_INFO_PKT) == 0)
 		return FALSE;
 
-	if (rdp->settings->DisableEncryption)
+	if (rdp->settings->UseRdpSecurityLayer)
 	{
 		if (securityFlags & SEC_REDIRECTION_PKT)
 		{

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -348,7 +348,7 @@ static int peer_recv_tpkt_pdu(freerdp_peer* client, wStream* s)
 	if (rdp->disconnect)
 		return 0;
  
-	if (rdp->settings->DisableEncryption)
+	if (rdp->settings->UseRdpSecurityLayer)
 	{
 		if (!rdp_read_security_header(s, &securityFlags))
 			return -1;
@@ -485,7 +485,7 @@ static int peer_recv_callback(rdpTransport* transport, wStream* s, void* extra)
 			break;
 
 		case CONNECTION_STATE_RDP_SECURITY_COMMENCEMENT:
-			if (rdp->settings->DisableEncryption)
+			if (rdp->settings->UseRdpSecurityLayer)
 			{
 				if (!rdp_server_establish_keys(rdp, s))
 					return -1;

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1040,7 +1040,7 @@ static int rdp_recv_tpkt_pdu(rdpRdp* rdp, wStream* s)
 		rdp->autodetect->bandwidthMeasureByteCount += length;
 	}
 
-	if (rdp->settings->DisableEncryption)
+	if (rdp->settings->UseRdpSecurityLayer)
 	{
 		if (!rdp_read_security_header(s, &securityFlags))
 			return -1;

--- a/libfreerdp/core/security.c
+++ b/libfreerdp/core/security.c
@@ -422,7 +422,6 @@ BOOL security_establish_keys(const BYTE* client_random, rdpRdp* rdp)
 		CryptoSha1 sha1;
 		BYTE client_encrypt_key_t[CRYPTO_SHA1_DIGEST_LENGTH + 1];
 		BYTE client_decrypt_key_t[CRYPTO_SHA1_DIGEST_LENGTH + 1];
-		WLog_INFO(TAG,  "FIPS Compliant encryption level.");
 		sha1 = crypto_sha1_init();
 		if (!sha1)
 		{

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -232,7 +232,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 		settings->KeyboardSubType = 0;
 		settings->KeyboardFunctionKey = 12;
 		settings->KeyboardLayout = 0;
-		settings->DisableEncryption = FALSE;
+		settings->UseRdpSecurityLayer = FALSE;
 		settings->SaltedChecksum = TRUE;
 		settings->ServerPort = 3389;
 		settings->GatewayPort = 443;

--- a/server/Sample/sfreerdp.c
+++ b/server/Sample/sfreerdp.c
@@ -4,6 +4,7 @@
  *
  * Copyright 2011 Marc-Andre Moreau <marcandre.moreau@gmail.com>
  * Copyright 2011 Vic Lee
+ * Copyright 2014 Norbert Federa <norbert.federa@thincast.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -347,19 +348,19 @@ static BOOL test_sleep_tsdiff(UINT32 *old_sec, UINT32 *old_usec, UINT32 new_sec,
 
 	*old_sec = new_sec;
 	*old_usec = new_usec;
-	
-	while (usec < 0) 
+
+	while (usec < 0)
 	{
 		usec += 1000000;
 		sec--;
 	}
-	
+
 	if (sec > 0)
 		Sleep(sec * 1000);
-	
+
 	if (usec > 0)
 		USleep(usec);
-	
+
 	return TRUE;
 }
 
@@ -669,7 +670,15 @@ static void* test_peer_mainloop(void* arg)
 	/* Initialize the real server settings here */
 	client->settings->CertificateFile = _strdup("server.crt");
 	client->settings->PrivateKeyFile = _strdup("server.key");
+	client->settings->RdpKeyFile = _strdup("server.key");
+	client->settings->RdpSecurity = TRUE;
+	client->settings->TlsSecurity = TRUE;
 	client->settings->NlaSecurity = FALSE;
+	client->settings->EncryptionLevel = ENCRYPTION_LEVEL_CLIENT_COMPATIBLE;
+	/* client->settings->EncryptionLevel = ENCRYPTION_LEVEL_HIGH; */
+	/* client->settings->EncryptionLevel = ENCRYPTION_LEVEL_LOW; */
+	/* client->settings->EncryptionLevel = ENCRYPTION_LEVEL_FIPS; */
+
 	client->settings->RemoteFxCodec = TRUE;
 	client->settings->ColorDepth = 32;
 	client->settings->SuppressOutput = TRUE;
@@ -844,7 +853,7 @@ int main(int argc, char* argv[])
 
 	if (argc > 1)
 		test_pcap_file = argv[1];
-	
+
 	if (argc > 2 && !strcmp(argv[2], "--fast"))
 		test_dump_rfx_realtime = FALSE;
 


### PR DESCRIPTION
[MS-RDPBCGR] Section 5.3 describes the encryption level and method values for standard RDP security.
Looking at the current usage of these values in the FreeRDP code gives me reason to believe that there is a certain lack of understanding of how these values should be handled.

The encryption level is only configured on the server side in the "Encryption Level" setting found in the Remote Desktop Session Host Configuration RDP-Tcp properties dialog.
This value is never transferred from the client to the server over the wire!
The possible options are "None", "Low", "Client Compatible", "High" and "FIPS Compliant".
The client receices this value in the Server Security Data block (TS_UD_SC_SEC1), probably only for informational purposes and maybe to give the client the possibility to verify if the server's decision for the encryption method confirms to the server's encryption level.
The possible encryption methods are "NONE", "40BIT", "56BIT", "128BIT" and "FIPS" and the RDP client advertises the ones it supports to the server in the Client Security Data block (TS_UD_CS_SEC).
The server's configured encryption level value restricts the possible final encryption method.
Something that I was not able to find in the documentation is the priority level of the individual encryption methods based on which the server makes its final method decision if there are several options.
My analysis with Windows Servers reveiled that the order is 128, 56, 40, FIPS.
The server only chooses FIPS if the level is "FIPS Comliant" or if it is the only method advertised by the client.

Bottom line:
- FreeRDP's client side does not need to set settings->EncryptionLevel (which was done quite frequently).
- FreeRDP's server side does not have to set the supported encryption methods list in settings->EncryptionMethods

Changes in this commit:

Removed unnecessary/confusing changes of EncryptionLevel/Methods settings

Refactor settings->DisableEncryption
- This value actually means "Advanced RDP Encryption (NLA/TLS) is NOT used"
- The old name caused lots of confusion among developers
- Renamed it to "UseRdpSecurityLayer" (the compare logic stays untouched)

Any client's setting of settings->EncryptionMethods were annihilated
- All clients "want" to set all supported methods
- Some clients forgot 56bit because 56bit was not supported at the time the  code was written
- settings->EncryptionMethods was overwritten anyways in nego_connect()
- Removed all client side settings of settings->EncryptionMethods. The default is "None" (0)
- Changed nego_connect() to advertise all supported methods if settings->EncryptionMethods is 0 (None)
- Added a commandline option /encryption-methods:comma separated list of the values "40", "56", "128", "FIPS". E.g. /encryption-methods:56,128
- Print warning if server chooses non-advertised method

Verify received level and method in client's gcc_read_server_security_data
- Only accept valid/known encryption methods
- Verify encryption level/method combinations according to MS-RDPBCGR 5.3.2

Server implementations can now set settings->EncryptionLevel
- The default for settings->EncryptionLevel is 0 (None)
- nego_send_negotiation_response() changes it to ClientCompatible in that case
- default to ClientCompatible if the server implementation set an invalid level

Fix server's gcc_write_server_security_data
- Verify server encryption level value set by server implementations
- Choose rdp encryption method based on level and supported client methods
- Moved FIPS to the lowest priority (only used if other methods are possible)

Updated sample server
- Support RDP Security (RdpKeyFile was not set)
- Added commented sample code for setting the security level
