### PR TITLE
xfreerdp: fix RDP order color conversion

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -656,6 +656,14 @@ void xf_unlock_x11(xfContext* xfc, BOOL display)
 	}
 }
 
+static void xf_calculate_color_shifts(UINT32 mask, UINT8* rsh, UINT8* lsh)
+{
+    for (*lsh = 0; !(mask & 1); mask >>= 1)
+        (*lsh)++;
+    for (*rsh = 8; mask; mask >>= 1)
+        (*rsh)--;
+}
+
 BOOL xf_get_pixmap_info(xfContext* xfc)
 {
 	int i;
@@ -720,7 +728,7 @@ BOOL xf_get_pixmap_info(xfContext* xfc)
 		}
 	}
 
-	if (vi)
+	if (xfc->visual)
 	{
 		/*
 		 * Detect if the server visual has an inverted colormap
@@ -730,6 +738,11 @@ BOOL xf_get_pixmap_info(xfContext* xfc)
 		{
 			xfc->invert = TRUE;
 		}
+
+		/* calculate color shifts required for rdp order color conversion */
+		xf_calculate_color_shifts(vi->red_mask, &xfc->red_shift_r, &xfc->red_shift_l);
+		xf_calculate_color_shifts(vi->green_mask, &xfc->green_shift_r, &xfc->green_shift_l);
+		xf_calculate_color_shifts(vi->blue_mask, &xfc->blue_shift_r, &xfc->blue_shift_l);
 	}
 
 	XFree(vis);
@@ -1294,7 +1307,7 @@ void* xf_input_thread(void *arg)
 	while(1)
 	{
 		status = WaitForMultipleObjects(2, event, FALSE, INFINITE);
-		
+
 		if(status == WAIT_OBJECT_0 + 1)
 		{
 			do

--- a/client/X11/xf_gdi.h
+++ b/client/X11/xf_gdi.h
@@ -27,5 +27,6 @@
 
 void xf_gdi_register_update_callbacks(rdpUpdate* update);
 void xf_gdi_bitmap_update(rdpContext* context, BITMAP_UPDATE* bitmapUpdate);
+UINT32 xf_convert_rdp_order_color(xfContext* xfc, UINT32 color);
 
 #endif /* __XF_GDI_H */

--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -35,6 +35,7 @@
 #include <freerdp/codec/jpeg.h>
 
 #include "xf_graphics.h"
+#include "xf_gdi.h"
 
 #include <freerdp/log.h>
 #define TAG CLIENT_TAG("x11")
@@ -381,8 +382,8 @@ void xf_Glyph_BeginDraw(rdpContext* context, int x, int y, int width, int height
 {
 	xfContext* xfc = (xfContext*) context;
 
-	bgcolor = freerdp_convert_gdi_order_color(bgcolor, context->settings->ColorDepth, xfc->format, xfc->palette);
-	fgcolor = freerdp_convert_gdi_order_color(fgcolor, context->settings->ColorDepth, xfc->format, xfc->palette);
+	bgcolor = xf_convert_rdp_order_color(xfc, bgcolor);
+	fgcolor = xf_convert_rdp_order_color(xfc, fgcolor);
 
 	xf_lock_x11(xfc, FALSE);
 

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -132,6 +132,13 @@ struct xf_context
 	UINT16 frame_x2;
 	UINT16 frame_y2;
 
+	UINT8 red_shift_l;
+	UINT8 red_shift_r;
+	UINT8 green_shift_l;
+	UINT8 green_shift_r;
+	UINT8 blue_shift_l;
+	UINT8 blue_shift_r;
+
 	int XInputOpcode;
 
 #ifdef WITH_XRENDER


### PR DESCRIPTION
Note: /gdi:sw was working fine, this commit fixes /gdi:hw
- calculate color channel shifts based on X11 visual color masks
- fast path to skip conversion if visual color masks equal rdp color masks
- successfully tested 8/15/16/24/32 bpp rdp sessions on 16/24/32 bpp visuals
