### PR TITLE
Update drdynvc_main.c

### DIFF
--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -531,6 +531,7 @@ static void* drdynvc_virtual_channel_client_thread(void* arg)
 			{
 				data = (wStream*) message.wParam;
 				drdynvc_order_recv(drdynvc, data);
+				Stream_Free(data, TRUE);
 			}
 		}
 	}


### PR DESCRIPTION
Fixed memory leak. To test it connect a Windows 8.1 VM using xfreerdp or wfreerdp with the command line: xfreerdp /gfx /u:user /p:password /v:hostname and play a youtube video.
