### PR TITLE
core: fix problem with data for unknown channel

### DIFF
--- a/libfreerdp/core/client.c
+++ b/libfreerdp/core/client.c
@@ -242,8 +242,6 @@ int freerdp_channels_data(freerdp* instance, UINT16 channelId, BYTE* data, int d
 
 	for (index = 0; index < mcs->channelCount; index++)
 	{
-		channel = &mcs->channels[index];
-
 		if (mcs->channels[index].ChannelId == channelId)
 		{
 			channel = &mcs->channels[index];


### PR DESCRIPTION
Some buggy server(s) send data for channels that weren't announced or
negotiated. When processing this data FreeRDP had a problem and always
used the last channel in the channels list even if it wasn't responsible
for the data. Depending on how the channel handled the data this could
lead to different kind of problems and also segmentation faults.

Now data for unknown channels is ignored and not processed further.
