### PR TITLE
libfreerdp-core: server synchronized access to dvc channel seq.

### DIFF
--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -691,7 +691,7 @@ HANDLE WINAPI FreeRDP_WTSOpenServerA(LPSTR pServerName)
 
 		vcm->queue = MessageQueue_New(NULL);
 
-		vcm->dvc_channel_id_seq = 1;
+		vcm->dvc_channel_id_seq = 0;
 		vcm->dynamicVirtualChannels = ArrayList_New(TRUE);
 
 		client->ReceiveChannelData = WTSReceiveChannelData;
@@ -991,7 +991,7 @@ HANDLE WINAPI FreeRDP_WTSVirtualChannelOpenEx(DWORD SessionId, LPSTR pVirtualNam
 	channel->receiveData = Stream_New(NULL, client->settings->VirtualChannelChunkSize);
 	channel->queue = MessageQueue_New(NULL);
 
-	channel->channelId = vcm->dvc_channel_id_seq++;
+	channel->channelId = InterlockedIncrement(&vcm->dvc_channel_id_seq);
 	ArrayList_Add(vcm->dynamicVirtualChannels, channel);
 
 	s = Stream_New(NULL, 64);

--- a/libfreerdp/core/server.h
+++ b/libfreerdp/core/server.h
@@ -90,7 +90,7 @@ struct WTSVirtualChannelManager
 
 	rdpPeerChannel* drdynvc_channel;
 	BYTE drdynvc_state;
-	UINT32 dvc_channel_id_seq;
+	LONG dvc_channel_id_seq;
 
 	wArrayList* dynamicVirtualChannels;
 };


### PR DESCRIPTION
More than one DVC could be requested from different threads, thus the ChannelID sequence number must be synchronized.
