### PR TITLE
rdpdr: use host name for redirected drives if set

### DIFF
--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -506,8 +506,10 @@ static void rdpdr_process_connect(rdpdrPlugin* rdpdr)
 
 	rdpdr->devman = devman_new(rdpdr);
 	settings = (rdpSettings*) rdpdr->channelEntryPoints.pExtendedData;
-
-	strncpy(rdpdr->computerName, settings->ComputerName, sizeof(rdpdr->computerName) - 1);
+	if (settings->ClientHostname)
+		strncpy(rdpdr->computerName, settings->ClientHostname, sizeof(rdpdr->computerName) - 1);
+	else
+		strncpy(rdpdr->computerName, settings->ComputerName, sizeof(rdpdr->computerName) - 1);
 
 	for (index = 0; index < settings->DeviceCount; index++)
 	{


### PR DESCRIPTION
When a client set the host name, redirected drives would still be shown
as coming from the computer name. For example if the computer the client
run on is called "foo" and the client set the /host-name to "bar" any
redirected drive is shown as "driveX on foo".

Now the host name is used for drives when set.