### PR TITLE
Move main loop and async channel from client to freerdp library

### DIFF
--- a/client/Android/FreeRDPCore/jni/android_event.h
+++ b/client/Android/FreeRDPCore/jni/android_event.h
@@ -54,21 +54,19 @@ struct _ANDROID_EVENT_QUEUE
 {
 	int size;
 	int count;
-	int pipe_fd[2];
-	ANDROID_EVENT **events;
+	HANDLE event;
+	ANDROID_EVENT** events;
 };
 typedef struct _ANDROID_EVENT_QUEUE ANDROID_EVENT_QUEUE;
 
-int android_is_event_set(ANDROID_EVENT_QUEUE * queue);
-void android_set_event(ANDROID_EVENT_QUEUE * queue);
-void android_clear_event(ANDROID_EVENT_QUEUE * queue);
-void android_push_event(freerdp * inst, ANDROID_EVENT* event);
-ANDROID_EVENT* android_peek_event(ANDROID_EVENT_QUEUE * queue);
-ANDROID_EVENT* android_pop_event(ANDROID_EVENT_QUEUE * queue);
-int android_process_event(ANDROID_EVENT_QUEUE * queue, freerdp * inst);
-BOOL android_get_fds(freerdp * inst, void ** read_fds,
-		int * read_count, void ** write_fds, int * write_count);
-BOOL android_check_fds(freerdp * inst);
+int android_is_event_set(ANDROID_EVENT_QUEUE* queue);
+void android_set_event(ANDROID_EVENT_QUEUE* queue);
+void android_clear_event(ANDROID_EVENT_QUEUE* queue);
+void android_push_event(freerdp* inst, ANDROID_EVENT* event);
+ANDROID_EVENT* android_peek_event(ANDROID_EVENT_QUEUE* queue);
+ANDROID_EVENT* android_pop_event(ANDROID_EVENT_QUEUE* queue);
+int android_process_event(ANDROID_EVENT_QUEUE* queue, freerdp* inst);
+BOOL android_check_handles(freerdp* inst);
 ANDROID_EVENT_KEY* android_event_key_new(int flags, UINT16 scancode);
 ANDROID_EVENT_KEY* android_event_unicodekey_new(UINT16 key);
 ANDROID_EVENT_CURSOR* android_event_cursor_new(UINT16 flags, UINT16 x, UINT16 y);
@@ -79,7 +77,7 @@ void android_event_unicodekey_free(ANDROID_EVENT_KEY* event);
 void android_event_cursor_free(ANDROID_EVENT_CURSOR* event);
 void android_event_disconnect_free(ANDROID_EVENT* event);
 void android_event_clipboard_free(ANDROID_EVENT_CLIPBOARD* event);
-void android_event_queue_init(freerdp * inst);
-void android_event_queue_uninit(freerdp * inst);
+void android_event_queue_init(freerdp* inst);
+void android_event_queue_uninit(freerdp* inst);
 
 #endif /* FREERDP_ANDROID_EVENT_H */

--- a/client/Android/FreeRDPCore/jni/android_freerdp.c
+++ b/client/Android/FreeRDPCore/jni/android_freerdp.c
@@ -5,7 +5,7 @@
    Copyright 2013 Thincast Technologies GmbH, Author: Martin Fleisz
    Copyright 2013 Thincast Technologies GmbH, Author: Armin Novak
 
-   This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. 
+   This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
    If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
@@ -68,7 +68,6 @@ void android_OnChannelConnectedEventHandler(rdpContext* context, ChannelConnecte
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
-
 	}
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
@@ -88,7 +87,6 @@ void android_OnChannelDisconnectedEventHandler(rdpContext* context, ChannelDisco
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
-
 	}
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
@@ -110,39 +108,32 @@ void android_begin_paint(rdpContext* context)
 
 void android_end_paint(rdpContext* context)
 {
-	androidContext *ctx = (androidContext*)context;
+	androidContext* ctx = (androidContext*)context;
 	rdpSettings* settings = context->instance->settings;
-	
 	DEBUG_ANDROID("ui_update");
-
 	assert(ctx);
 	assert(settings);
 	assert(context->instance);
-
 	DEBUG_ANDROID("width=%d, height=%d, bpp=%d", settings->DesktopWidth,
-			settings->DesktopHeight, settings->ColorDepth);
-	
+				  settings->DesktopHeight, settings->ColorDepth);
 	freerdp_callback("OnGraphicsUpdate", "(IIIII)V", context->instance,
-		0, 0, settings->DesktopWidth, settings->DesktopHeight);
+					 0, 0, settings->DesktopWidth, settings->DesktopHeight);
 }
 
 void android_desktop_resize(rdpContext* context)
 {
 	DEBUG_ANDROID("ui_desktop_resize");
-
 	assert(context);
 	assert(context->settings);
 	assert(context->instance);
-
 	freerdp_callback("OnGraphicsResize", "(IIII)V",
-			context->instance, context->settings->DesktopWidth,
-			context->settings->DesktopHeight, context->settings->ColorDepth);
+					 context->instance, context->settings->DesktopWidth,
+					 context->settings->DesktopHeight, context->settings->ColorDepth);
 }
 
 BOOL android_pre_connect(freerdp* instance)
 {
 	DEBUG_ANDROID("android_pre_connect");
-
 	rdpSettings* settings = instance->settings;
 	BOOL bitmap_cache = settings->BitmapCacheEnabled;
 	settings->OrderSupport[NEG_DSTBLT_INDEX] = TRUE;
@@ -169,37 +160,27 @@ BOOL android_pre_connect(freerdp* instance)
 	settings->OrderSupport[NEG_POLYGON_CB_INDEX] = FALSE;
 	settings->OrderSupport[NEG_ELLIPSE_SC_INDEX] = FALSE;
 	settings->OrderSupport[NEG_ELLIPSE_CB_INDEX] = FALSE;
-
 	settings->FrameAcknowledge = 10;
-
 	PubSub_SubscribeChannelConnected(instance->context->pubSub,
-			(pChannelConnectedEventHandler) android_OnChannelConnectedEventHandler);
-
+									 (pChannelConnectedEventHandler) android_OnChannelConnectedEventHandler);
 	PubSub_SubscribeChannelDisconnected(instance->context->pubSub,
-			(pChannelDisconnectedEventHandler) android_OnChannelDisconnectedEventHandler);
-
+										(pChannelDisconnectedEventHandler) android_OnChannelDisconnectedEventHandler);
 	freerdp_register_addin_provider(freerdp_channels_load_static_addin_entry, 0);
 	freerdp_client_load_addins(instance->context->channels, instance->settings);
-
 	freerdp_channels_pre_connect(instance->context->channels, instance);
-
 	return TRUE;
 }
 
 static BOOL android_post_connect(freerdp* instance)
 {
 	UINT32 gdi_flags;
-	rdpSettings *settings = instance->settings;
-
+	rdpSettings* settings = instance->settings;
 	DEBUG_ANDROID("android_post_connect");
-
 	assert(instance);
 	assert(settings);
-
 	freerdp_callback("OnSettingsChanged", "(IIII)V", instance,
-			settings->DesktopWidth, settings->DesktopHeight,
-			settings->ColorDepth);
-
+					 settings->DesktopWidth, settings->DesktopHeight,
+					 settings->ColorDepth);
 	instance->context->cache = cache_new(settings);
 
 	if (instance->settings->ColorDepth > 16)
@@ -208,15 +189,11 @@ static BOOL android_post_connect(freerdp* instance)
 		gdi_flags = CLRBUF_16BPP;
 
 	gdi_init(instance, gdi_flags, NULL);
-
 	instance->update->BeginPaint = android_begin_paint;
 	instance->update->EndPaint = android_end_paint;
 	instance->update->DesktopResize = android_desktop_resize;
-
 	freerdp_channels_post_connect(instance->context->channels, instance);
-
 	freerdp_callback("OnConnectionSuccess", "(I)V", instance);
-
 	return TRUE;
 }
 
@@ -231,13 +208,11 @@ BOOL android_authenticate(freerdp* instance, char** username, char** password, c
 	DEBUG_ANDROID("Authenticate user:");
 	DEBUG_ANDROID("  Username: %s", *username);
 	DEBUG_ANDROID("  Domain: %s", *domain);
-
 	JNIEnv* env;
 	jboolean attached = jni_attach_thread(&env);
 	jobject jstr1 = create_string_builder(env, *username);
 	jobject jstr2 = create_string_builder(env, *domain);
 	jobject jstr3 = create_string_builder(env, *password);
-
 	jboolean res = freerdp_callback_bool_result("OnAuthenticate", "(ILjava/lang/StringBuilder;Ljava/lang/StringBuilder;Ljava/lang/StringBuilder;)Z", instance, jstr1, jstr2, jstr3);
 
 	if (res == JNI_TRUE)
@@ -255,7 +230,7 @@ BOOL android_authenticate(freerdp* instance, char** username, char** password, c
 
 		if (*password == NULL)
 			free(*password);
-		
+
 		*password = get_string_from_string_builder(env, jstr3);
 	}
 
@@ -272,15 +247,13 @@ BOOL android_verify_certificate(freerdp* instance, char* subject, char* issuer, 
 	DEBUG_ANDROID("\tIssuer: %s", issuer);
 	DEBUG_ANDROID("\tThumbprint: %s", fingerprint);
 	DEBUG_ANDROID("The above X.509 certificate could not be verified, possibly because you do not have "
-		"the CA certificate in your certificate store, or the certificate has expired."
-		"Please look at the documentation on how to create local certificate store for a private CA.\n");
-
+				  "the CA certificate in your certificate store, or the certificate has expired."
+				  "Please look at the documentation on how to create local certificate store for a private CA.");
 	JNIEnv* env;
 	jboolean attached = jni_attach_thread(&env);
 	jstring jstr1 = (*env)->NewStringUTF(env, subject);
 	jstring jstr2 = (*env)->NewStringUTF(env, issuer);
 	jstring jstr3 = (*env)->NewStringUTF(env, fingerprint);
-
 	jboolean res = freerdp_callback_bool_result("OnVerifyCertificate", "(ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z", instance, jstr1, jstr2, jstr3);
 
 	if (attached == JNI_TRUE)
@@ -296,107 +269,55 @@ BOOL android_verify_changed_certificate(freerdp* instance, char* subject, char* 
 
 static void* jni_input_thread(void* arg)
 {
-	HANDLE event[3];
+	HANDLE event[2];
 	wMessageQueue* queue;
 	freerdp* instance = (freerdp*) arg;
-	androidContext *aCtx = (androidContext*)instance->context;
-	
+	androidContext* aCtx = (androidContext*)instance->context;
 	assert(NULL != instance);
 	assert(NULL != aCtx);
-														  
 	DEBUG_ANDROID("Start.");
-
 	queue = freerdp_get_message_queue(instance, FREERDP_INPUT_MESSAGE_QUEUE);
-	event[0] = CreateFileDescriptorEvent(NULL, FALSE, FALSE, aCtx->event_queue->pipe_fd[0]);
-	event[1] = CreateFileDescriptorEvent(NULL, FALSE, FALSE, aCtx->event_queue->pipe_fd[1]);
-	event[2] = freerdp_get_message_queue_event_handle(instance, FREERDP_INPUT_MESSAGE_QUEUE);
-			
+	event[0] = aCtx->event_queue->event;
+	event[1] = freerdp_get_message_queue_event_handle(instance, FREERDP_INPUT_MESSAGE_QUEUE);
+
 	do
 	{
-		DWORD rc = WaitForMultipleObjects(3, event, FALSE, INFINITE);
-		if ((rc < WAIT_OBJECT_0) || (rc > WAIT_OBJECT_0 + 2))
+		DWORD rc = WaitForMultipleObjects(2, event, FALSE, INFINITE);
+
+		if ((rc < WAIT_OBJECT_0) || (rc > WAIT_OBJECT_0 + 1))
 			continue;
-	
-		if (rc == WAIT_OBJECT_0 + 2)
+
+		if (rc == WAIT_OBJECT_0 + 1)
 		{
 			wMessage msg;
-
 			MessageQueue_Peek(queue, &msg, FALSE);
+
 			if (msg.id == WMQ_QUIT)
 				break;
 		}
-		if (android_check_fds(instance) != TRUE)
+
+		if (android_check_handles(instance) != TRUE)
 			break;
 	}
-	while(1);
+	while (1);
 
 	DEBUG_ANDROID("Quit.");
-	
 	MessageQueue_PostQuit(queue, 0);
 	ExitThread(0);
 	return NULL;
 }
 
-static void* jni_channels_thread(void* arg)
-{     
-	int status;
-	HANDLE event;
-	rdpChannels* channels;
-	freerdp* instance = (freerdp*) arg;
-	
-	assert(NULL != instance);
-											  
-	DEBUG_ANDROID("Start.");
-
-	channels = instance->context->channels;
-	event = freerdp_channels_get_event_handle(instance);
-
-	while (WaitForSingleObject(event, INFINITE) == WAIT_OBJECT_0)
-	{
-		status = freerdp_channels_process_pending_messages(instance);
-
-		if (!status)
-			break;
-	}
-	
-	DEBUG_ANDROID("Quit.");
-
-	ExitThread(0);
-	return NULL;
-} 
-
 static int android_freerdp_run(freerdp* instance)
 {
-	int i;
-	int fds;
-	int max_fds;
-	int rcount;
-	int wcount;
-	int fd_input_event;
 	HANDLE input_event = NULL;
-	void* rfds[32];
-	void* wfds[32];
-	fd_set rfds_set;
-	fd_set wfds_set;
-	int select_status;
-	struct timeval timeout;
-
 	const rdpSettings* settings = instance->context->settings;
-
 	HANDLE input_thread;
-	HANDLE channels_thread;
-	
 	BOOL async_input = settings->AsyncInput;
-	BOOL async_channels = settings->AsyncChannels;
 	BOOL async_transport = settings->AsyncTransport;
-
 	DEBUG_ANDROID("AsyncUpdate=%d", settings->AsyncUpdate);
 	DEBUG_ANDROID("AsyncInput=%d", settings->AsyncInput);
 	DEBUG_ANDROID("AsyncChannels=%d", settings->AsyncChannels);
 	DEBUG_ANDROID("AsyncTransport=%d", settings->AsyncTransport);
-
-	memset(rfds, 0, sizeof(rfds));
-	memset(wfds, 0, sizeof(wfds));
 
 	if (!freerdp_connect(instance))
 	{
@@ -407,108 +328,41 @@ static int android_freerdp_run(freerdp* instance)
 	if (async_input)
 	{
 		input_thread = CreateThread(NULL, 0,
-				(LPTHREAD_START_ROUTINE) jni_input_thread, instance, 0, NULL);
-	}
-	      
-	if (async_channels)
-	{
-		channels_thread = CreateThread(NULL, 0,
-				(LPTHREAD_START_ROUTINE) jni_channels_thread, instance, 0, NULL);
+									(LPTHREAD_START_ROUTINE) jni_input_thread, instance, 0, NULL);
 	}
 
 	((androidContext*)instance->context)->is_connected = TRUE;
+
 	while (!freerdp_shall_disconnect(instance))
 	{
-		rcount = 0;
-		wcount = 0;
+		DWORD ev;
+		ev = freerdp_wait_for_event(instance, INFINITE);
 
-		if (!async_transport)
-		{
-			if (freerdp_get_fds(instance, rfds, &rcount, wfds, &wcount) != TRUE)
-			{
-				DEBUG_ANDROID("Failed to get FreeRDP file descriptor\n");
-				break;
-			}
-		}
-
-		if (!async_channels)
-		{
-			if (freerdp_channels_get_fds(instance->context->channels, instance, rfds, &rcount, wfds, &wcount) != TRUE)
-			{
-				DEBUG_ANDROID("Failed to get channel manager file descriptor\n");
-				break;
-			}
-		}
-
-		if (!async_input)
-		{
-			if (android_get_fds(instance, rfds, &rcount, wfds, &wcount) != TRUE)
-			{
-				DEBUG_ANDROID("Failed to get android file descriptor\n");
-				break;
-			}
-		}
-		else
-		{
-			input_event = freerdp_get_message_queue_event_handle(instance, FREERDP_INPUT_MESSAGE_QUEUE);
-			fd_input_event = GetEventFileDescriptor(input_event);
-			rfds[rcount++] = (void*) (long) fd_input_event;
-		}
-
-		max_fds = 0;
-		FD_ZERO(&rfds_set);
-		FD_ZERO(&wfds_set);
-
-		for (i = 0; i < rcount; i++)
-		{
-			fds = (int)(long)(rfds[i]);
-
-			if (fds > max_fds)
-				max_fds = fds;
-
-			FD_SET(fds, &rfds_set);
-		}
-
-		if (max_fds == 0)
-			break;
-
-		timeout.tv_sec = 1;
-		timeout.tv_usec = 0;
-
-		select_status = select(max_fds + 1, &rfds_set, NULL, NULL, &timeout);
-
-		if (select_status == 0)
+		if (WAIT_TIMEOUT == ev)
 			continue;
-		else if (select_status == -1)
+		else if (WAIT_FAILED == ev)
 		{
-			/* these are not really errors */
-			if (!((errno == EAGAIN) ||
-				(errno == EWOULDBLOCK) ||
-				(errno == EINPROGRESS) ||
-				(errno == EINTR))) /* signal occurred */
-			{
-				DEBUG_ANDROID("android_run: select failed\n");
-				break;
-			}
+			DEBUG_ANDROID("android_run: select failed");
+			break;
 		}
-		
+
 		if (freerdp_shall_disconnect(instance))
 			break;
 
 		if (!async_transport)
 		{
-			if (freerdp_check_fds(instance) != TRUE)
+			if (freerdp_check_handles(instance) != TRUE)
 			{
-				DEBUG_ANDROID("Failed to check FreeRDP file descriptor\n");
+				DEBUG_ANDROID("Failed to check FreeRDP file descriptor");
 				break;
 			}
 		}
 
 		if (!async_input)
 		{
-			if (android_check_fds(instance) != TRUE)
+			if (android_check_handles(instance) != TRUE)
 			{
-				DEBUG_ANDROID("Failed to check android file descriptor\n");
+				DEBUG_ANDROID("Failed to check android file descriptor");
 				break;
 			}
 		}
@@ -517,40 +371,22 @@ static int android_freerdp_run(freerdp* instance)
 			if (WaitForSingleObject(input_event, 0) == WAIT_OBJECT_0)
 			{
 				if (!freerdp_message_queue_process_pending_messages(instance,
-							FREERDP_INPUT_MESSAGE_QUEUE))
+						FREERDP_INPUT_MESSAGE_QUEUE))
 				{
 					DEBUG_ANDROID("User Disconnect");
 					break;
 				}
 			}
 		}
-
-		if (!async_channels)
-		{
-			if (freerdp_channels_check_fds(instance->context->channels, instance) != TRUE)
-			{
-				DEBUG_ANDROID("Failed to check channel manager file descriptor\n");
-				break;
-			}
-		}
 	}
 
 	DEBUG_ANDROID("Prepare shutdown...");
-
 	// issue another OnDisconnecting here in case the disconnect was initiated by the server and not our client
 	freerdp_callback("OnDisconnecting", "(I)V", instance);
-	
 	DEBUG_ANDROID("Close channels...");
 	freerdp_channels_close(instance->context->channels, instance);
-
 	DEBUG_ANDROID("Cleanup threads...");
 
-	if (async_channels)
-	{
-		WaitForSingleObject(channels_thread, INFINITE);
-		CloseHandle(channels_thread);
-	}
- 
 	if (async_input)
 	{
 		wMessageQueue* input_queue = freerdp_get_message_queue(instance, FREERDP_INPUT_MESSAGE_QUEUE);
@@ -562,37 +398,28 @@ static int android_freerdp_run(freerdp* instance)
 	DEBUG_ANDROID("Disconnecting...");
 	freerdp_disconnect(instance);
 	freerdp_callback("OnDisconnected", "(I)V", instance);
-
 	DEBUG_ANDROID("Quit.");
-
 	return 0;
 }
 
 static void* android_thread_func(void* param)
 {
 	freerdp* instance = param;
-	
 	DEBUG_ANDROID("Start.");
-
 	assert(instance);
-
 	android_freerdp_run(instance);
-
 	DEBUG_ANDROID("Quit.");
-
 	ExitThread(0);
 	return NULL;
 }
 
-JNIEXPORT jint JNICALL jni_freerdp_new(JNIEnv *env, jclass cls)
+JNIEXPORT jint JNICALL jni_freerdp_new(JNIEnv* env, jclass cls)
 {
 	freerdp* instance;
-
 #if defined(WITH_GPROF)
 	setenv("CPUPROFILE_FREQUENCY", "200", 1);
 	monstartup("libfreerdp-android.so");
 #endif
-
 	// create instance
 	instance = freerdp_new();
 	instance->PreConnect = android_pre_connect;
@@ -601,101 +428,83 @@ JNIEXPORT jint JNICALL jni_freerdp_new(JNIEnv *env, jclass cls)
 	instance->Authenticate = android_authenticate;
 	instance->VerifyCertificate = android_verify_certificate;
 	instance->VerifyChangedCertificate = android_verify_changed_certificate;
-
 	// create context
 	instance->ContextSize = sizeof(androidContext);
 	instance->ContextNew = android_context_new;
 	instance->ContextFree = android_context_free;
 	freerdp_context_new(instance);
-
 	return (jint) instance;
 }
 
-JNIEXPORT void JNICALL jni_freerdp_free(JNIEnv *env, jclass cls, jint instance)
+JNIEXPORT void JNICALL jni_freerdp_free(JNIEnv* env, jclass cls, jint instance)
 {
 	freerdp* inst = (freerdp*)instance;
-
 	freerdp_context_free(inst);
 	freerdp_free(inst);
-
 #if defined(WITH_GPROF)
 	moncleanup();
 #endif
 }
 
-JNIEXPORT jboolean JNICALL jni_freerdp_connect(JNIEnv *env, jclass cls, jint instance)
+JNIEXPORT jboolean JNICALL jni_freerdp_connect(JNIEnv* env, jclass cls, jint instance)
 {
 	freerdp* inst = (freerdp*)instance;
 	androidContext* ctx = (androidContext*)inst->context;
-
 	assert(inst);
 	assert(ctx);
-
 	ctx->thread = CreateThread(NULL, 0,
-			(LPTHREAD_START_ROUTINE)android_thread_func, inst, 0, NULL);
-
+							   (LPTHREAD_START_ROUTINE)android_thread_func, inst, 0, NULL);
 	return JNI_TRUE;
 }
 
-JNIEXPORT jboolean JNICALL jni_freerdp_disconnect(JNIEnv *env, jclass cls, jint instance)
+JNIEXPORT jboolean JNICALL jni_freerdp_disconnect(JNIEnv* env, jclass cls, jint instance)
 {
 	freerdp* inst = (freerdp*)instance;
 	androidContext* ctx = (androidContext*)inst->context;
 	ANDROID_EVENT* event = (ANDROID_EVENT*)android_event_disconnect_new();
-
 	assert(inst);
 	assert(ctx);
 	assert(event);
-
 	android_push_event(inst, event);
-
 	WaitForSingleObject(ctx->thread, INFINITE);
 	CloseHandle(ctx->thread);
 	ctx->thread = NULL;
-
 	freerdp_callback("OnDisconnecting", "(I)V", instance);
-
 	return (jboolean) JNI_TRUE;
 }
 
-JNIEXPORT void JNICALL jni_freerdp_cancel_connection(JNIEnv *env, jclass cls, jint instance)
+JNIEXPORT void JNICALL jni_freerdp_cancel_connection(JNIEnv* env, jclass cls, jint instance)
 {
 	jni_freerdp_disconnect(env, cls, instance);
 }
 
-JNIEXPORT void JNICALL jni_freerdp_set_data_directory(JNIEnv *env, jclass cls, jint instance, jstring jdirectory)
+JNIEXPORT void JNICALL jni_freerdp_set_data_directory(JNIEnv* env, jclass cls, jint instance, jstring jdirectory)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
-
-	const jbyte *directory = (*env)->GetStringUTFChars(env, jdirectory, NULL);
-
+	rdpSettings* settings = inst->settings;
+	const jbyte* directory = (*env)->GetStringUTFChars(env, jdirectory, NULL);
 	free(settings->HomePath);
 	free(settings->ConfigPath);
-
 	int config_dir_len = strlen(directory) + 10; /* +9 chars for /.freerdp and +1 for \0 */
 	char* config_dir_buf = (char*)malloc(config_dir_len);
 	strcpy(config_dir_buf, directory);
 	strcat(config_dir_buf, "/.freerdp");
 	settings->HomePath = strdup(directory);
 	settings->ConfigPath = config_dir_buf;	/* will be freed by freerdp library */
-
 	(*env)->ReleaseStringUTFChars(env, jdirectory, directory);
 }
 
-JNIEXPORT void JNICALL jni_freerdp_set_connection_info(JNIEnv *env, jclass cls, jint instance,
-						   jstring jhostname, jstring jusername, jstring jpassword, jstring jdomain, jint width, jint height,
-						   jint color_depth, jint port, jboolean console, jint security, jstring jcertname)
+JNIEXPORT void JNICALL jni_freerdp_set_connection_info(JNIEnv* env, jclass cls, jint instance,
+		jstring jhostname, jstring jusername, jstring jpassword, jstring jdomain, jint width, jint height,
+		jint color_depth, jint port, jboolean console, jint security, jstring jcertname)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
-
-	const jbyte *hostname = (*env)->GetStringUTFChars(env, jhostname, NULL);
-	const jbyte *username = (*env)->GetStringUTFChars(env, jusername, NULL);
-	const jbyte *password = (*env)->GetStringUTFChars(env, jpassword, NULL);
-	const jbyte *domain = (*env)->GetStringUTFChars(env, jdomain, NULL);
-	const jbyte *certname = (*env)->GetStringUTFChars(env, jcertname, NULL);
-
+	rdpSettings* settings = inst->settings;
+	const jbyte* hostname = (*env)->GetStringUTFChars(env, jhostname, NULL);
+	const jbyte* username = (*env)->GetStringUTFChars(env, jusername, NULL);
+	const jbyte* password = (*env)->GetStringUTFChars(env, jpassword, NULL);
+	const jbyte* domain = (*env)->GetStringUTFChars(env, jdomain, NULL);
+	const jbyte* certname = (*env)->GetStringUTFChars(env, jcertname, NULL);
 	DEBUG_ANDROID("hostname: %s", (char*) hostname);
 	DEBUG_ANDROID("username: %s", (char*) username);
 	DEBUG_ANDROID("password: %s", (char*) password);
@@ -705,7 +514,6 @@ JNIEXPORT void JNICALL jni_freerdp_set_connection_info(JNIEnv *env, jclass cls, 
 	DEBUG_ANDROID("color depth: %d", color_depth);
 	DEBUG_ANDROID("port: %d", port);
 	DEBUG_ANDROID("security: %d", security);
-
 	settings->DesktopWidth = width;
 	settings->DesktopHeight = height;
 	settings->ColorDepth = color_depth;
@@ -733,7 +541,6 @@ JNIEXPORT void JNICALL jni_freerdp_set_connection_info(JNIEnv *env, jclass cls, 
 		settings->CertificateName = strdup(certname);
 
 	settings->ConsoleSession = (console == JNI_TRUE) ? TRUE : FALSE;
-
 	settings->SoftwareGdi = TRUE;
 	settings->BitmapCacheV3Enabled = TRUE;
 
@@ -770,26 +577,24 @@ JNIEXPORT void JNICALL jni_freerdp_set_connection_info(JNIEnv *env, jclass cls, 
 
 	// set US keyboard layout
 	settings->KeyboardLayout = 0x0409;
-
 	(*env)->ReleaseStringUTFChars(env, jhostname, hostname);
 	(*env)->ReleaseStringUTFChars(env, jusername, username);
 	(*env)->ReleaseStringUTFChars(env, jpassword, password);
 	(*env)->ReleaseStringUTFChars(env, jdomain, domain);
 	(*env)->ReleaseStringUTFChars(env, jcertname, certname);
-
 	return;
 }
 
 JNIEXPORT void JNICALL jni_freerdp_set_performance_flags(
-	JNIEnv *env, jclass cls, jint instance, jboolean remotefx,
+	JNIEnv* env, jclass cls, jint instance, jboolean remotefx,
 	jboolean disableWallpaper, jboolean disableFullWindowDrag,
 	jboolean disableMenuAnimations, jboolean disableTheming,
 	jboolean enableFontSmoothing, jboolean enableDesktopComposition)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
-	
+	rdpSettings* settings = inst->settings;
 	DEBUG_ANDROID("remotefx: %d", (remotefx == JNI_TRUE) ? 1 : 0);
+
 	if (remotefx == JNI_TRUE)
 	{
 		settings->RemoteFxCodec = TRUE;
@@ -811,27 +616,22 @@ JNIEXPORT void JNICALL jni_freerdp_set_performance_flags(
 	settings->DisableThemes = (disableTheming == JNI_TRUE) ? TRUE : FALSE;
 	settings->AllowFontSmoothing = (enableFontSmoothing == JNI_TRUE) ? TRUE : FALSE;
 	settings->AllowDesktopComposition = (enableDesktopComposition == JNI_TRUE) ? TRUE : FALSE;
-
 	/* Create performance flags from settings */
 	freerdp_performance_flags_make(settings);
-
 	DEBUG_ANDROID("performance_flags: %04X", settings->PerformanceFlags);
 }
 
-JNIEXPORT void JNICALL jni_freerdp_set_advanced_settings(JNIEnv *env, jclass cls,
+JNIEXPORT void JNICALL jni_freerdp_set_advanced_settings(JNIEnv* env, jclass cls,
 		jint instance, jstring jRemoteProgram, jstring jWorkDir,
 		jboolean async_channel, jboolean async_transport, jboolean async_input,
 		jboolean async_update)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
-
-	const jbyte *remote_program = (*env)->GetStringUTFChars(env, jRemoteProgram, NULL);
-	const jbyte *work_dir = (*env)->GetStringUTFChars(env, jWorkDir, NULL);
-
+	rdpSettings* settings = inst->settings;
+	const jbyte* remote_program = (*env)->GetStringUTFChars(env, jRemoteProgram, NULL);
+	const jbyte* work_dir = (*env)->GetStringUTFChars(env, jWorkDir, NULL);
 	DEBUG_ANDROID("Remote Program: %s", (char*) remote_program);
 	DEBUG_ANDROID("Work Dir: %s", (char*) work_dir);
-
 	/* Enable async mode. */
 	settings->AsyncUpdate = async_update;
 	settings->AsyncChannels = async_channel;
@@ -848,95 +648,81 @@ JNIEXPORT void JNICALL jni_freerdp_set_advanced_settings(JNIEnv *env, jclass cls
 	(*env)->ReleaseStringUTFChars(env, jWorkDir, work_dir);
 }
 
-JNIEXPORT void JNICALL jni_freerdp_set_drive_redirection(JNIEnv *env, jclass cls, jint instance, jstring jpath)
+JNIEXPORT void JNICALL jni_freerdp_set_drive_redirection(JNIEnv* env, jclass cls, jint instance, jstring jpath)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 	char* args[] = {"drive", "Android", ""};
-
-	const jbyte *path = (*env)->GetStringUTFChars(env, jpath, NULL);
+	const jbyte* path = (*env)->GetStringUTFChars(env, jpath, NULL);
 	DEBUG_ANDROID("drive redirect: %s", (char*)path);
-
 	args[2] = (char*)path;
 	freerdp_client_add_device_channel(settings, 3, args);
 	settings->DeviceRedirection = TRUE;
-
 	(*env)->ReleaseStringUTFChars(env, jpath, path);
 }
 
-JNIEXPORT void JNICALL jni_freerdp_set_sound_redirection(JNIEnv *env,
+JNIEXPORT void JNICALL jni_freerdp_set_sound_redirection(JNIEnv* env,
 		jclass cls, jint instance, jint redirect)
 {
 	char** p;
 	int count = 1;
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
-
+	rdpSettings* settings = inst->settings;
 	DEBUG_ANDROID("sound: %s",
-			redirect ? ((redirect == 1) ? "Server" : "Redirect") : "None");
-
+				  redirect ? ((redirect == 1) ? "Server" : "Redirect") : "None");
 	settings->AudioPlayback = (redirect == 2) ? TRUE : FALSE;
 	settings->RemoteConsoleAudio = (redirect == 1) ? TRUE : FALSE;
+
 	if (settings->AudioPlayback)
 	{
 		p = malloc(sizeof(char*));
 		p[0] = "rdpsnd";
-
 		freerdp_client_add_static_channel(settings, count, p);
-
 		free(p);
 	}
 }
 
-JNIEXPORT void JNICALL jni_freerdp_set_microphone_redirection(JNIEnv *env,
+JNIEXPORT void JNICALL jni_freerdp_set_microphone_redirection(JNIEnv* env,
 		jclass cls, jint instance, jboolean enable)
 {
 	char** p;
 	int count = 1;
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
-
+	rdpSettings* settings = inst->settings;
 	DEBUG_ANDROID("microphone redirect: %s", enable ? "TRUE" : "FALSE");
-
 	settings->AudioCapture = enable;
+
 	if (enable)
 	{
 		p = malloc(sizeof(char*));
 		p[0] = "audin";
-
 		freerdp_client_add_dynamic_channel(settings, count, p);
-
 		free(p);
 	}
 }
 
-JNIEXPORT void JNICALL jni_freerdp_set_clipboard_redirection(JNIEnv *env, jclass cls, jint instance, jboolean enable)
+JNIEXPORT void JNICALL jni_freerdp_set_clipboard_redirection(JNIEnv* env, jclass cls, jint instance, jboolean enable)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
-
+	rdpSettings* settings = inst->settings;
 	DEBUG_ANDROID("clipboard redirect: %s", enable ? "TRUE" : "FALSE");
-
 	settings->RedirectClipboard = enable ? TRUE : FALSE;
 }
 
-JNIEXPORT void JNICALL jni_freerdp_set_gateway_info(JNIEnv *env, jclass cls, jint instance, jstring jgatewayhostname, jint port, 
-													jstring jgatewayusername, jstring jgatewaypassword, jstring jgatewaydomain)
+JNIEXPORT void JNICALL jni_freerdp_set_gateway_info(JNIEnv* env, jclass cls, jint instance, jstring jgatewayhostname, jint port,
+		jstring jgatewayusername, jstring jgatewaypassword, jstring jgatewaydomain)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
-
-	const jbyte *gatewayhostname = (*env)->GetStringUTFChars(env, jgatewayhostname, NULL);
-	const jbyte *gatewayusername = (*env)->GetStringUTFChars(env, jgatewayusername, NULL);
-	const jbyte *gatewaypassword = (*env)->GetStringUTFChars(env, jgatewaypassword, NULL);
-	const jbyte *gatewaydomain = (*env)->GetStringUTFChars(env, jgatewaydomain, NULL);
-
+	rdpSettings* settings = inst->settings;
+	const jbyte* gatewayhostname = (*env)->GetStringUTFChars(env, jgatewayhostname, NULL);
+	const jbyte* gatewayusername = (*env)->GetStringUTFChars(env, jgatewayusername, NULL);
+	const jbyte* gatewaypassword = (*env)->GetStringUTFChars(env, jgatewaypassword, NULL);
+	const jbyte* gatewaydomain = (*env)->GetStringUTFChars(env, jgatewaydomain, NULL);
 	DEBUG_ANDROID("gatewayhostname: %s", (char*) gatewayhostname);
 	DEBUG_ANDROID("gatewayport: %d", port);
 	DEBUG_ANDROID("gatewayusername: %s", (char*) gatewayusername);
 	DEBUG_ANDROID("gatewaypassword: %s", (char*) gatewaypassword);
 	DEBUG_ANDROID("gatewaydomain: %s", (char*) gatewaydomain);
-
 	settings->GatewayHostname = strdup(gatewayhostname);
 	settings->GatewayPort     = port;
 	settings->GatewayUsername = strdup(gatewayusername);
@@ -945,7 +731,6 @@ JNIEXPORT void JNICALL jni_freerdp_set_gateway_info(JNIEnv *env, jclass cls, jin
 	settings->GatewayUsageMethod = TSC_PROXY_MODE_DIRECT;
 	settings->GatewayEnabled = TRUE;
 	settings->GatewayUseSameCredentials = FALSE;
-
 	(*env)->ReleaseStringUTFChars(env, jgatewayhostname, gatewayhostname);
 	(*env)->ReleaseStringUTFChars(env, jgatewayusername, gatewayusername);
 	(*env)->ReleaseStringUTFChars(env, jgatewaypassword, gatewaypassword);
@@ -957,11 +742,9 @@ static void copy_pixel_buffer(UINT8* dstBuf, UINT8* srcBuf, int x, int y, int wi
 	int i;
 	int length;
 	int scanline;
-	UINT8 *dstp, *srcp;
-	
+	UINT8* dstp, *srcp;
 	length = width * bpp;
 	scanline = wBuf * bpp;
-
 	srcp = (UINT8*) &srcBuf[(scanline * y) + (x * bpp)];
 	dstp = (UINT8*) &dstBuf[(scanline * y) + (x * bpp)];
 
@@ -974,14 +757,13 @@ static void copy_pixel_buffer(UINT8* dstBuf, UINT8* srcBuf, int x, int y, int wi
 }
 
 JNIEXPORT jboolean JNICALL jni_freerdp_update_graphics(
-	JNIEnv *env, jclass cls, jint instance, jobject bitmap, jint x, jint y, jint width, jint height)
+	JNIEnv* env, jclass cls, jint instance, jobject bitmap, jint x, jint y, jint width, jint height)
 {
-
 	int ret;
 	void* pixels;
 	AndroidBitmapInfo info;
 	freerdp* inst = (freerdp*)instance;
-	rdpGdi *gdi = inst->context->gdi;
+	rdpGdi* gdi = inst->context->gdi;
 
 	if ((ret = AndroidBitmap_getInfo(env, bitmap, &info)) < 0)
 	{
@@ -996,71 +778,59 @@ JNIEXPORT jboolean JNICALL jni_freerdp_update_graphics(
 	}
 
 	copy_pixel_buffer(pixels, gdi->primary_buffer, x, y, width, height, gdi->width, gdi->height, gdi->bytesPerPixel);
-
 	AndroidBitmap_unlockPixels(env, bitmap);
-
 	return JNI_TRUE;
 }
 
 JNIEXPORT void JNICALL jni_freerdp_send_key_event(
-	JNIEnv *env, jclass cls, jint instance, jint keycode, jboolean down)
+	JNIEnv* env, jclass cls, jint instance, jint keycode, jboolean down)
 {
 	DWORD scancode;
 	ANDROID_EVENT* event;
-
 	freerdp* inst = (freerdp*)instance;
-
 	scancode = GetVirtualScanCodeFromVirtualKeyCode(keycode, 4);
 	int flags = (down == JNI_TRUE) ? KBD_FLAGS_DOWN : KBD_FLAGS_RELEASE;
 	flags |= (scancode & KBDEXT) ? KBD_FLAGS_EXTENDED : 0;
 	event = (ANDROID_EVENT*) android_event_key_new(flags, scancode & 0xFF);
-
 	android_push_event(inst, event);
-
 	DEBUG_ANDROID("send_key_event: %d, %d", (int)scancode, flags);
 }
 
 JNIEXPORT void JNICALL jni_freerdp_send_unicodekey_event(
-	JNIEnv *env, jclass cls, jint instance, jint keycode)
+	JNIEnv* env, jclass cls, jint instance, jint keycode)
 {
 	ANDROID_EVENT* event;
-
 	freerdp* inst = (freerdp*)instance;
 	event = (ANDROID_EVENT*) android_event_unicodekey_new(keycode);
 	android_push_event(inst, event);
-
 	DEBUG_ANDROID("send_unicodekey_event: %d", keycode);
 }
 
 JNIEXPORT void JNICALL jni_freerdp_send_cursor_event(
-	JNIEnv *env, jclass cls, jint instance, jint x, jint y, jint flags)
+	JNIEnv* env, jclass cls, jint instance, jint x, jint y, jint flags)
 {
 	ANDROID_EVENT* event;
-
 	freerdp* inst = (freerdp*)instance;
 	event = (ANDROID_EVENT*) android_event_cursor_new(flags, x, y);
 	android_push_event(inst, event);
-
 	DEBUG_ANDROID("send_cursor_event: (%d, %d), %d", x, y, flags);
 }
 
-JNIEXPORT void JNICALL jni_freerdp_send_clipboard_data(JNIEnv *env, jclass cls, jint instance, jstring jdata)
+JNIEXPORT void JNICALL jni_freerdp_send_clipboard_data(JNIEnv* env, jclass cls, jint instance, jstring jdata)
 {
 	ANDROID_EVENT* event;
 	freerdp* inst = (freerdp*)instance;
-	const jbyte *data = jdata != NULL ? (*env)->GetStringUTFChars(env, jdata, NULL) : NULL;
-	int data_length = data ? strlen(data) : 0;      
-
+	const jbyte* data = jdata != NULL ? (*env)->GetStringUTFChars(env, jdata, NULL) : NULL;
+	int data_length = data ? strlen(data) : 0;
 	event = (ANDROID_EVENT*) android_event_clipboard_new((void*)data, data_length);
 	android_push_event(inst, event);
-
 	DEBUG_ANDROID("send_clipboard_data: (%s)", data);
 
 	if (data)
 		(*env)->ReleaseStringUTFChars(env, jdata, data);
 }
 
-JNIEXPORT jstring JNICALL jni_freerdp_get_version(JNIEnv *env, jclass cls)
+JNIEXPORT jstring JNICALL jni_freerdp_get_version(JNIEnv* env, jclass cls)
 {
 	return (*env)->NewStringUTF(env, GIT_REVISION);
 }

--- a/client/Android/FreeRDPCore/jni/android_freerdp.c
+++ b/client/Android/FreeRDPCore/jni/android_freerdp.c
@@ -336,13 +336,21 @@ static int android_freerdp_run(freerdp* instance)
 	while (!freerdp_shall_disconnect(instance))
 	{
 		DWORD ev;
-		ev = freerdp_wait_for_event(instance, INFINITE);
+		DWORD count;
+		HANDLE *handles;
+
+		count = freerdp_get_and_lock_handles(instance, &handles);
+		if (count > 0)
+		{
+			ev = WaitForMultipleObjects(count, handles, FALSE, INFINITE);
+			freerdp_unlock_handles(instance, handles, count);
+		}
 
 		if (WAIT_TIMEOUT == ev)
 			continue;
 		else if (WAIT_FAILED == ev)
 		{
-			DEBUG_ANDROID("android_run: select failed");
+			DEBUG_ANDROID("android_run: WaitForMultipleObjects failed");
 			break;
 		}
 

--- a/client/DirectFB/dfreerdp.c
+++ b/client/DirectFB/dfreerdp.c
@@ -262,11 +262,20 @@ int dfreerdp_run(freerdp* instance)
 
 	while (1)
 	{
-		DWORD ev = freerdp_wait_for_event(instance, INFINITE);
+		DWORD ev;
+		DWORD count;
+		HANDLE *handles;
+
+		count = freerdp_get_and_lock_handles(instance, &handles);
+		if (count > 0)
+		{
+			ev = WaitForMultipleObjects(count, handles, FALSE, INFINITE);
+			freerdp_unlock_handles(instance, handles, count);
+		}
 
 		if (WAIT_FAILED == ev)
 		{
-			WLog_ERR(TAG, "dfreerdp_run: freerdp_wait_for_event failed");
+			WLog_ERR(TAG, "dfreerdp_run: WaitForMultipleObjects failed");
 			break;
 		}
 

--- a/client/DirectFB/dfreerdp.h
+++ b/client/DirectFB/dfreerdp.h
@@ -54,6 +54,7 @@ typedef struct df_pointer dfPointer;
 
 struct df_info
 {
+	HANDLE xev;
 	int read_fds;
 	DFBResult err;
 	IDirectFB* dfb;

--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -150,7 +150,7 @@ DWORD mac_client_thread(void* param)
 
 		while (1)
 		{
-			status = freerdp_wait_for_events(instance, INFINITE);
+			status = freerdp_wait_for_event(instance, INFINITE);
 
 			if (WaitForSingleObject(mfc->stopEvent, 0) == WAIT_OBJECT_0)
 			{

--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -69,19 +69,15 @@ DWORD mac_client_thread(void* param);
 {
 	rdpSettings* settings;
 	EmbedWindowEventArgs e;
-
 	[self initializeView];
-
 	context = rdp_context;
 	mfc = (mfContext*) rdp_context;
 	instance = context->instance;
 	settings = context->settings;
-
 	EventArgsInit(&e, "mfreerdp");
 	e.embed = TRUE;
 	e.handle = (void*) self;
 	PubSub_OnEmbedWindow(context->pubSub, context, &e);
-
 	NSScreen* screen = [[NSScreen screens] objectAtIndex:0];
 	NSRect screenFrame = [screen frame];
 
@@ -93,9 +89,7 @@ DWORD mac_client_thread(void* param);
 
 	mfc->client_height = instance->settings->DesktopHeight;
 	mfc->client_width = instance->settings->DesktopWidth;
-
 	mfc->thread = CreateThread(NULL, 0, mac_client_thread, (void*) context, 0, &mfc->mainThreadId);
-	
 	return 0;
 }
 
@@ -105,24 +99,23 @@ DWORD mac_client_update_thread(void* param)
 	wMessage message;
 	wMessageQueue* queue;
 	rdpContext* context = (rdpContext*) param;
-	
 	status = 1;
 	queue = freerdp_get_message_queue(context->instance, FREERDP_UPDATE_MESSAGE_QUEUE);
-	
+
 	while (MessageQueue_Wait(queue))
 	{
 		while (MessageQueue_Peek(queue, &message, TRUE))
 		{
 			status = freerdp_message_queue_process_message(context->instance, FREERDP_UPDATE_MESSAGE_QUEUE, &message);
-			
+
 			if (!status)
 				break;
 		}
-		
+
 		if (!status)
 			break;
 	}
-	
+
 	ExitThread(0);
 	return 0;
 }
@@ -133,24 +126,23 @@ DWORD mac_client_input_thread(void* param)
 	wMessage message;
 	wMessageQueue* queue;
 	rdpContext* context = (rdpContext*) param;
-	
 	status = 1;
 	queue = freerdp_get_message_queue(context->instance, FREERDP_INPUT_MESSAGE_QUEUE);
-	
+
 	while (MessageQueue_Wait(queue))
 	{
 		while (MessageQueue_Peek(queue, &message, TRUE))
 		{
 			status = freerdp_message_queue_process_message(context->instance, FREERDP_INPUT_MESSAGE_QUEUE, &message);
-			
+
 			if (!status)
 				break;
 		}
-		
+
 		if (!status)
 			break;
 	}
-	
+
 	ExitThread(0);
 	return 0;
 }
@@ -166,28 +158,28 @@ DWORD mac_client_thread(void* param)
 		HANDLE updateEvent;
 		HANDLE updateThread;
 		HANDLE channelsEvent;
-		
+
 		DWORD nCount;
 		rdpContext* context = (rdpContext*) param;
 		mfContext* mfc = (mfContext*) context;
 		freerdp* instance = context->instance;
 		MRDPView* view = mfc->view;
 		rdpSettings* settings = context->settings;
-		
+
 		status = freerdp_connect(context->instance);
-		
+
 		if (!status)
 		{
 			[view setIs_connected:0];
 			return 0;
 		}
-		
+
 		[view setIs_connected:1];
-		
+
 		nCount = 0;
-		
+
 		events[nCount++] = mfc->stopEvent;
-		
+
 		if (settings->AsyncUpdate)
 		{
 			updateThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) mac_client_update_thread, context, 0, NULL);
@@ -196,7 +188,7 @@ DWORD mac_client_thread(void* param)
 		{
 			events[nCount++] = updateEvent = freerdp_get_message_queue_event_handle(instance, FREERDP_UPDATE_MESSAGE_QUEUE);
 		}
-		
+
 		if (settings->AsyncInput)
 		{
 			inputThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) mac_client_input_thread, context, 0, NULL);
@@ -205,19 +197,19 @@ DWORD mac_client_thread(void* param)
 		{
 			events[nCount++] = inputEvent = freerdp_get_message_queue_event_handle(instance, FREERDP_INPUT_MESSAGE_QUEUE);
 		}
-		
+
 		events[nCount++] = channelsEvent = freerdp_channels_get_event_handle(instance);
-		
+
 		while (1)
 		{
 			status = WaitForMultipleObjects(nCount, events, FALSE, INFINITE);
-			
+
 			if (WaitForSingleObject(mfc->stopEvent, 0) == WAIT_OBJECT_0)
 			{
 				freerdp_disconnect(instance);
 				break;
 			}
-			
+
 			if (!settings->AsyncUpdate)
 			{
 				if (WaitForSingleObject(updateEvent, 0) == WAIT_OBJECT_0)
@@ -225,7 +217,7 @@ DWORD mac_client_thread(void* param)
 					update_activity_cb(instance);
 				}
 			}
-			
+
 			if (!settings->AsyncInput)
 			{
 				if (WaitForSingleObject(inputEvent, 0) == WAIT_OBJECT_0)
@@ -233,13 +225,13 @@ DWORD mac_client_thread(void* param)
 					input_activity_cb(instance);
 				}
 			}
-			
+
 			if (WaitForSingleObject(channelsEvent, 0) == WAIT_OBJECT_0)
 			{
 				freerdp_channels_process_pending_messages(instance);
 			}
 		}
-		
+
 		if (settings->AsyncUpdate)
 		{
 			wMessageQueue* updateQueue = freerdp_get_message_queue(instance, FREERDP_UPDATE_MESSAGE_QUEUE);
@@ -247,7 +239,7 @@ DWORD mac_client_thread(void* param)
 			WaitForSingleObject(updateThread, INFINITE);
 			CloseHandle(updateThread);
 		}
-		
+
 		if (settings->AsyncInput)
 		{
 			wMessageQueue* inputQueue = freerdp_get_message_queue(instance, FREERDP_INPUT_MESSAGE_QUEUE);
@@ -255,7 +247,7 @@ DWORD mac_client_thread(void* param)
 			WaitForSingleObject(inputThread, INFINITE);
 			CloseHandle(inputThread);
 		}
-		
+
 		ExitThread(0);
 		return 0;
 	}
@@ -264,12 +256,12 @@ DWORD mac_client_thread(void* param)
 - (id)initWithFrame:(NSRect)frame
 {
 	self = [super initWithFrame:frame];
-	
+
 	if (self)
 	{
 		// Initialization code here.
 	}
-	
+
 	return self;
 }
 
@@ -283,15 +275,11 @@ DWORD mac_client_thread(void* param)
 	if (!initialized)
 	{
 		cursors = [[NSMutableArray alloc] initWithCapacity:10];
-
 		// setup a mouse tracking area
-		NSTrackingArea * trackingArea = [[NSTrackingArea alloc] initWithRect:[self visibleRect] options:NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved | NSTrackingCursorUpdate | NSTrackingEnabledDuringMouseDrag | NSTrackingActiveWhenFirstResponder owner:self userInfo:nil];
-
+		NSTrackingArea* trackingArea = [[NSTrackingArea alloc] initWithRect:[self visibleRect] options:NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved | NSTrackingCursorUpdate | NSTrackingEnabledDuringMouseDrag | NSTrackingActiveWhenFirstResponder owner:self userInfo:nil];
 		[self addTrackingArea:trackingArea];
-
 		// Set the default cursor
 		currentCursor = [NSCursor arrowCursor];
-
 		initialized = YES;
 	}
 }
@@ -312,144 +300,132 @@ DWORD mac_client_thread(void* param)
 	return YES;
 }
 
-- (void) mouseMoved:(NSEvent *)event
+- (void) mouseMoved:(NSEvent*)event
 {
 	[super mouseMoved:event];
-	
+
 	if (!is_connected)
 		return;
-	
+
 	NSPoint loc = [event locationInWindow];
 	int x = (int) loc.x;
 	int y = (int) loc.y;
-
 	mf_scale_mouse_event(context, instance->input, PTR_FLAGS_MOVE, x, y);
 }
 
-- (void)mouseDown:(NSEvent *) event
+- (void)mouseDown:(NSEvent*) event
 {
 	[super mouseDown:event];
-	
+
 	if (!is_connected)
 		return;
-	
+
 	NSPoint loc = [event locationInWindow];
 	int x = (int) loc.x;
 	int y = (int) loc.y;
-	
 	mf_scale_mouse_event(context, instance->input, PTR_FLAGS_DOWN | PTR_FLAGS_BUTTON1, x, y);
 }
 
-- (void) mouseUp:(NSEvent *) event
+- (void) mouseUp:(NSEvent*) event
 {
 	[super mouseUp:event];
-	
+
 	if (!is_connected)
 		return;
-	
+
 	NSPoint loc = [event locationInWindow];
 	int x = (int) loc.x;
 	int y = (int) loc.y;
-	
 	mf_scale_mouse_event(context, instance->input, PTR_FLAGS_BUTTON1, x, y);
 }
 
-- (void) rightMouseDown:(NSEvent *)event
+- (void) rightMouseDown:(NSEvent*)event
 {
 	[super rightMouseDown:event];
-	
+
 	if (!is_connected)
 		return;
-	
+
 	NSPoint loc = [event locationInWindow];
 	int x = (int) loc.x;
 	int y = (int) loc.y;
-	
 	mf_scale_mouse_event(context, instance->input, PTR_FLAGS_DOWN | PTR_FLAGS_BUTTON2, x, y);
 }
 
-- (void) rightMouseUp:(NSEvent *)event
+- (void) rightMouseUp:(NSEvent*)event
 {
 	[super rightMouseUp:event];
-	
+
 	if (!is_connected)
 		return;
-	
+
 	NSPoint loc = [event locationInWindow];
 	int x = (int) loc.x;
 	int y = (int) loc.y;
-	
 	mf_scale_mouse_event(context, instance->input, PTR_FLAGS_BUTTON2, x, y);
 }
 
-- (void) otherMouseDown:(NSEvent *)event
+- (void) otherMouseDown:(NSEvent*)event
 {
 	[super otherMouseDown:event];
-	
+
 	if (!is_connected)
 		return;
-	
+
 	NSPoint loc = [event locationInWindow];
 	int x = (int) loc.x;
 	int y = (int) loc.y;
-	
 	mf_scale_mouse_event(context, instance->input, PTR_FLAGS_DOWN | PTR_FLAGS_BUTTON3, x, y);
 }
 
-- (void) otherMouseUp:(NSEvent *)event
+- (void) otherMouseUp:(NSEvent*)event
 {
 	[super otherMouseUp:event];
-	
+
 	if (!is_connected)
 		return;
-	
+
 	NSPoint loc = [event locationInWindow];
 	int x = (int) loc.x;
 	int y = (int) loc.y;
-	
 	mf_scale_mouse_event(context, instance->input, PTR_FLAGS_BUTTON3, x, y);
 }
 
-- (void) scrollWheel:(NSEvent *)event
+- (void) scrollWheel:(NSEvent*)event
 {
 	UINT16 flags;
-	
 	[super scrollWheel:event];
-	
+
 	if (!is_connected)
 		return;
-	
+
 	NSPoint loc = [event locationInWindow];
 	int x = (int) loc.x;
 	int y = (int) loc.y;
-	
 	flags = PTR_FLAGS_WHEEL;
-
 	/* 1 event = 120 units */
 	int units = [event deltaY] * 120;
 
 	/* send out all accumulated rotations */
-	while(units != 0)
+	while (units != 0)
 	{
 		/* limit to maximum value in WheelRotationMask (9bit signed value) */
 		int step = MIN(MAX(-256, units), 255);
-
 		mf_scale_mouse_event(context, instance->input, flags | ((UINT16)step & WheelRotationMask), x, y);
 		units -= step;
 	}
 }
 
-- (void) mouseDragged:(NSEvent *)event
+- (void) mouseDragged:(NSEvent*)event
 {
 	[super mouseDragged:event];
-	
+
 	if (!is_connected)
 		return;
-	
+
 	NSPoint loc = [event locationInWindow];
 	int x = (int) loc.x;
 	int y = (int) loc.y;
-	
 	// send mouse motion event to RDP server
 	mf_scale_mouse_event(context, instance->input, PTR_FLAGS_MOVE, x, y);
 }
@@ -477,7 +453,6 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 	 * provided by OS X and check for a character to key code mismatch: for instance,
 	 * when the output character is '0' for the key code corresponding to the 'i' key.
 	 */
-	
 #if 0
 	switch (keyChar)
 	{
@@ -485,18 +460,21 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 		case 0x00A7: /* section sign */
 			if (keyCode == APPLE_VK_ISO_Section)
 				keyCode = APPLE_VK_ANSI_Grave;
+
 			break;
-			
+
 		case 0x00ED: /* latin small letter i with acute */
 		case 0x00CD: /* latin capital letter i with acute */
 			if (keyCode == APPLE_VK_ANSI_Grave)
 				keyCode = APPLE_VK_ISO_Section;
+
 			break;
 	}
+
 #endif
-	
+
 	/* Perform keycode correction for all ISO keyboards */
-	
+
 	if (type == APPLE_KEYBOARD_TYPE_ISO)
 	{
 		if (keyCode == APPLE_VK_ANSI_Grave)
@@ -504,11 +482,11 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 		else if (keyCode == APPLE_VK_ISO_Section)
 			keyCode = APPLE_VK_ANSI_Grave;
 	}
-	
+
 	return keyCode;
 }
 
-- (void) keyDown:(NSEvent *) event
+- (void) keyDown:(NSEvent*) event
 {
 	DWORD keyCode;
 	DWORD keyFlags;
@@ -516,36 +494,33 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 	DWORD scancode;
 	unichar keyChar;
 	NSString* characters;
-	
+
 	if (!is_connected)
 		return;
-	
+
 	keyFlags = KBD_FLAGS_DOWN;
 	keyCode = [event keyCode];
-	
 	characters = [event charactersIgnoringModifiers];
-	
+
 	if ([characters length] > 0)
 	{
 		keyChar = [characters characterAtIndex:0];
 		keyCode = fixKeyCode(keyCode, keyChar, mfc->appleKeyboardType);
 	}
-	
+
 	vkcode = GetVirtualKeyCodeFromKeycode(keyCode + 8, KEYCODE_TYPE_APPLE);
 	scancode = GetVirtualScanCodeFromVirtualKeyCode(vkcode, 4);
 	keyFlags |= (scancode & KBDEXT) ? KBDEXT : 0;
 	scancode &= 0xFF;
 	vkcode &= 0xFF;
-	
 #if 0
 	WLog_ERR(TAG,  "keyDown: keyCode: 0x%04X scancode: 0x%04X vkcode: 0x%04X keyFlags: %d name: %s",
-	       keyCode, scancode, vkcode, keyFlags, GetVirtualKeyName(vkcode));
+			 keyCode, scancode, vkcode, keyFlags, GetVirtualKeyName(vkcode));
 #endif
-	
 	freerdp_input_send_keyboard_event(instance->input, keyFlags, scancode);
 }
 
-- (void) keyUp:(NSEvent *) event
+- (void) keyUp:(NSEvent*) event
 {
 	DWORD keyCode;
 	DWORD keyFlags;
@@ -559,9 +534,8 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 
 	keyFlags = KBD_FLAGS_RELEASE;
 	keyCode = [event keyCode];
-	
 	characters = [event charactersIgnoringModifiers];
-	
+
 	if ([characters length] > 0)
 	{
 		keyChar = [characters characterAtIndex:0];
@@ -573,12 +547,10 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 	keyFlags |= (scancode & KBDEXT) ? KBDEXT : 0;
 	scancode &= 0xFF;
 	vkcode &= 0xFF;
-
 #if 0
 	WLog_DBG(TAG,  "keyUp: key: 0x%04X scancode: 0x%04X vkcode: 0x%04X keyFlags: %d name: %s",
-	       keyCode, scancode, vkcode, keyFlags, GetVirtualKeyName(vkcode));
+			 keyCode, scancode, vkcode, keyFlags, GetVirtualKeyName(vkcode));
 #endif
-
 	freerdp_input_send_keyboard_event(instance->input, keyFlags, scancode);
 }
 
@@ -596,16 +568,14 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 	keyFlags = 0;
 	key = [event keyCode] + 8;
 	modFlags = [event modifierFlags] & NSDeviceIndependentModifierFlagsMask;
-
 	vkcode = GetVirtualKeyCodeFromKeycode(key, KEYCODE_TYPE_APPLE);
 	scancode = GetVirtualScanCodeFromVirtualKeyCode(vkcode, 4);
 	keyFlags |= (scancode & KBDEXT) ? KBDEXT : 0;
 	scancode &= 0xFF;
 	vkcode &= 0xFF;
-
 #if 0
 	WLog_DBG(TAG,  "flagsChanged: key: 0x%04X scancode: 0x%04X vkcode: 0x%04X extended: %d name: %s modFlags: 0x%04X",
-	       key - 8, scancode, vkcode, keyFlags, GetVirtualKeyName(vkcode), modFlags);
+			 key - 8, scancode, vkcode, keyFlags, GetVirtualKeyName(vkcode), modFlags);
 
 	if (modFlags & NSAlphaShiftKeyMask)
 		WLog_DBG(TAG,  "NSAlphaShiftKeyMask");
@@ -627,6 +597,7 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 
 	if (modFlags & NSHelpKeyMask)
 		WLog_DBG(TAG,  "NSHelpKeyMask");
+
 #endif
 
 	if ((modFlags & NSAlphaShiftKeyMask) && !(kbdModFlags & NSAlphaShiftKeyMask))
@@ -676,12 +647,12 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 		if (argv[i])
 			free(argv[i]);
 	}
-	
+
 	if (!is_connected)
 		return;
-	
+
 	gdi_free(context->instance);
-	
+
 	if (pixel_data)
 		free(pixel_data);
 }
@@ -690,20 +661,15 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 {
 	if (!context)
 		return;
-	
+
 	if (self->bitmap_context)
 	{
 		CGContextRef cgContext = [[NSGraphicsContext currentContext] graphicsPort];
 		CGImageRef cgImage = CGBitmapContextCreateImage(self->bitmap_context);
-		
 		CGContextSaveGState(cgContext);
-		
 		CGContextClipToRect(cgContext, CGRectMake(rect.origin.x, rect.origin.y, rect.size.width, rect.size.height));
-
 		CGContextDrawImage(cgContext, CGRectMake(0, 0, [self bounds].size.width, [self bounds].size.height), cgImage);
-		
 		CGContextRestoreGState(cgContext);
-		
 		CGImageRelease(cgImage);
 	}
 	else
@@ -724,67 +690,58 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 	NSData* formatData;
 	const char* formatType;
 	NSPasteboardItem* item;
-	
 	changeCount = (int) [pasteboard_rd changeCount];
-	
+
 	if (changeCount == pasteboard_changecount)
 		return;
-	
+
 	pasteboard_changecount = changeCount;
-	
 	NSArray* items = [pasteboard_rd pasteboardItems];
-		
+
 	if ([items count] < 1)
 		return;
-	
+
 	item = [items objectAtIndex:0];
-	
 	/**
 	 * System-Declared Uniform Type Identifiers:
 	 * https://developer.apple.com/library/ios/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html
 	 */
-	
 	formatMatch = FALSE;
-	
+
 	for (NSString* type in [item types])
 	{
 		formatType = [type UTF8String];
-		
+
 		if (strcmp(formatType, "public.utf8-plain-text") == 0)
 		{
 			formatData = [item dataForType:type];
 			formatId = ClipboardRegisterFormat(mfc->clipboard, "UTF8_STRING");
-		
 			/* length does not include null terminator */
-			
 			size = (UINT32) [formatData length];
 			data = (BYTE*) malloc(size + 1);
 			[formatData getBytes:data length:size];
 			data[size] = '\0';
 			size++;
-			
 			ClipboardSetData(mfc->clipboard, formatId, (void*) data, size);
 			formatMatch = TRUE;
-			
 			break;
 		}
 	}
-	
+
 	if (!formatMatch)
 		ClipboardEmpty(mfc->clipboard);
-	
+
 	if (mfc->clipboardSync)
 		mac_cliprdr_send_client_format_list(mfc->cliprdr);
 }
 
 - (void) pause
 {
-	dispatch_async(dispatch_get_main_queue(), ^{
+	dispatch_async(dispatch_get_main_queue(), ^ {
 		[self->pasteboard_timer invalidate];
 	});
-	
 	NSArray* trackingAreas = self.trackingAreas;
-	
+
 	for (NSTrackingArea* ta in trackingAreas)
 	{
 		[self removeTrackingArea:ta];
@@ -793,11 +750,10 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 
 - (void)resume
 {
-	dispatch_async(dispatch_get_main_queue(), ^{
+	dispatch_async(dispatch_get_main_queue(), ^ {
 		self->pasteboard_timer = [NSTimer scheduledTimerWithTimeInterval:0.5 target:self selector:@selector(onPasteboardTimerFired:) userInfo:nil repeats:YES];
 	});
-	
-	NSTrackingArea * trackingArea = [[NSTrackingArea alloc] initWithRect:[self visibleRect] options:NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved | NSTrackingCursorUpdate | NSTrackingEnabledDuringMouseDrag | NSTrackingActiveWhenFirstResponder owner:self userInfo:nil];
+	NSTrackingArea* trackingArea = [[NSTrackingArea alloc] initWithRect:[self visibleRect] options:NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved | NSTrackingCursorUpdate | NSTrackingEnabledDuringMouseDrag | NSTrackingActiveWhenFirstResponder owner:self userInfo:nil];
 	[self addTrackingArea:trackingArea];
 	[trackingArea release];
 }
@@ -814,10 +770,9 @@ void mac_OnChannelConnectedEventHandler(rdpContext* context, ChannelConnectedEve
 {
 	rdpSettings* settings = context->settings;
 	mfContext* mfc = (mfContext*) context;
-	
+
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
-		
 	}
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
@@ -830,7 +785,6 @@ void mac_OnChannelConnectedEventHandler(rdpContext* context, ChannelConnectedEve
 	}
 	else if (strcmp(e->name, ENCOMSP_SVC_CHANNEL_NAME) == 0)
 	{
-		
 	}
 }
 
@@ -838,10 +792,9 @@ void mac_OnChannelDisconnectedEventHandler(rdpContext* context, ChannelDisconnec
 {
 	rdpSettings* settings = context->settings;
 	mfContext* mfc = (mfContext*) context;
-	
+
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
-		
 	}
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
@@ -854,18 +807,15 @@ void mac_OnChannelDisconnectedEventHandler(rdpContext* context, ChannelDisconnec
 	}
 	else if (strcmp(e->name, ENCOMSP_SVC_CHANNEL_NAME) == 0)
 	{
-		
 	}
 }
 
 BOOL mac_pre_connect(freerdp* instance)
 {
 	rdpSettings* settings;
-
 	instance->update->BeginPaint = mac_begin_paint;
 	instance->update->EndPaint = mac_end_paint;
 	instance->update->DesktopResize = mac_desktop_resize;
-
 	settings = instance->settings;
 
 	if (!settings->ServerHostname)
@@ -876,10 +826,8 @@ BOOL mac_pre_connect(freerdp* instance)
 	}
 
 	settings->SoftwareGdi = TRUE;
-
 	settings->OsMajorType = OSMAJORTYPE_MACINTOSH;
 	settings->OsMinorType = OSMINORTYPE_MACINTOSH;
-
 	ZeroMemory(settings->OrderSupport, 32);
 	settings->OrderSupport[NEG_DSTBLT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_PATBLT_INDEX] = TRUE;
@@ -905,17 +853,12 @@ BOOL mac_pre_connect(freerdp* instance)
 	settings->OrderSupport[NEG_POLYGON_CB_INDEX] = FALSE;
 	settings->OrderSupport[NEG_ELLIPSE_SC_INDEX] = FALSE;
 	settings->OrderSupport[NEG_ELLIPSE_CB_INDEX] = FALSE;
-	
 	PubSub_SubscribeChannelConnected(instance->context->pubSub,
-					 (pChannelConnectedEventHandler) mac_OnChannelConnectedEventHandler);
-	
+									 (pChannelConnectedEventHandler) mac_OnChannelConnectedEventHandler);
 	PubSub_SubscribeChannelDisconnected(instance->context->pubSub,
-					    (pChannelDisconnectedEventHandler) mac_OnChannelDisconnectedEventHandler);
-
+										(pChannelDisconnectedEventHandler) mac_OnChannelDisconnectedEventHandler);
 	freerdp_client_load_addins(instance->context->channels, instance->settings);
-
 	freerdp_channels_pre_connect(instance->context->channels, instance);
-	
 	return TRUE;
 }
 
@@ -926,9 +869,7 @@ BOOL mac_post_connect(freerdp* instance)
 	rdpSettings* settings;
 	rdpPointer rdp_pointer;
 	mfContext* mfc = (mfContext*) instance->context;
-
 	MRDPView* view = (MRDPView*) mfc->view;
-	
 	ZeroMemory(&rdp_pointer, sizeof(rdpPointer));
 	rdp_pointer.size = sizeof(rdpPointer);
 	rdp_pointer.New = mf_Pointer_New;
@@ -936,46 +877,33 @@ BOOL mac_post_connect(freerdp* instance)
 	rdp_pointer.Set = mf_Pointer_Set;
 	rdp_pointer.SetNull = mf_Pointer_SetNull;
 	rdp_pointer.SetDefault = mf_Pointer_SetDefault;
-	
 	settings = instance->settings;
-	
 	flags = CLRCONV_ALPHA | CLRCONV_RGB555;
-	
 	//if (settings->ColorDepth > 16)
-		flags |= CLRBUF_32BPP;
+	flags |= CLRBUF_32BPP;
 	//else
 	//	flags |= CLRBUF_16BPP;
-	
 	gdi_init(instance, flags, NULL);
 	gdi = instance->context->gdi;
-	
 	view->bitmap_context = mac_create_bitmap_context(instance->context);
-	
 	pointer_cache_register_callbacks(instance->update);
 	graphics_register_pointer(instance->context->graphics, &rdp_pointer);
-
 	freerdp_channels_post_connect(instance->context->channels, instance);
-
 	/* setup pasteboard (aka clipboard) for copy operations (write only) */
 	view->pasteboard_wr = [NSPasteboard generalPasteboard];
-	
 	/* setup pasteboard for read operations */
-	dispatch_async(dispatch_get_main_queue(), ^{
+	dispatch_async(dispatch_get_main_queue(), ^ {
 		view->pasteboard_rd = [NSPasteboard generalPasteboard];
 		view->pasteboard_changecount = -1;
 	});
-	
 	[view resume];
-	
 	mfc->appleKeyboardType = mac_detect_keyboard_type();
-
 	return TRUE;
 }
 
 BOOL mac_authenticate(freerdp* instance, char** username, char** password, char** domain)
 {
 	PasswordDialog* dialog = [PasswordDialog new];
-
 	dialog.serverHostname = [NSString stringWithCString:instance->settings->ServerHostname encoding:NSUTF8StringEncoding];
 
 	if (*username)
@@ -991,7 +919,6 @@ BOOL mac_authenticate(freerdp* instance, char** username, char** password, char*
 		const char* submittedUsername = [dialog.username cStringUsingEncoding:NSUTF8StringEncoding];
 		*username = malloc((strlen(submittedUsername) + 1) * sizeof(char));
 		strcpy(*username, submittedUsername);
-
 		const char* submittedPassword = [dialog.password cStringUsingEncoding:NSUTF8StringEncoding];
 		*password = malloc((strlen(submittedPassword) + 1) * sizeof(char));
 		strcpy(*password, submittedPassword);
@@ -1012,47 +939,39 @@ void mf_Pointer_New(rdpContext* context, rdpPointer* pointer)
 	MRDPCursor* mrdpCursor = [[MRDPCursor alloc] init];
 	mfContext* mfc = (mfContext*) context;
 	MRDPView* view = (MRDPView*) mfc->view;
-	
 	rect.size.width = pointer->width;
 	rect.size.height = pointer->height;
 	rect.origin.x = pointer->xPos;
 	rect.origin.y = pointer->yPos;
-	
 	cursor_data = (BYTE*) malloc(rect.size.width * rect.size.height * 4);
 	mrdpCursor->cursor_data = cursor_data;
-	
 	freerdp_image_copy_from_pointer_data(cursor_data, PIXEL_FORMAT_ARGB32,
-					     pointer->width * 4, 0, 0, pointer->width, pointer->height,
-					     pointer->xorMaskData, pointer->andMaskData, pointer->xorBpp, NULL);
-	
+										 pointer->width * 4, 0, 0, pointer->width, pointer->height,
+										 pointer->xorMaskData, pointer->andMaskData, pointer->xorBpp, NULL);
 	/* store cursor bitmap image in representation - required by NSImage */
-	bmiRep = [[NSBitmapImageRep alloc] initWithBitmapDataPlanes:(unsigned char **) &cursor_data
-											pixelsWide:rect.size.width
-											pixelsHigh:rect.size.height
-											bitsPerSample:8
-											samplesPerPixel:4
-											hasAlpha:YES
-											isPlanar:NO
-											colorSpaceName:NSDeviceRGBColorSpace
-											bitmapFormat:0
-											bytesPerRow:rect.size.width * 4
-											bitsPerPixel:0];
+	bmiRep = [[NSBitmapImageRep alloc] initWithBitmapDataPlanes:(unsigned char**) &cursor_data
+			  pixelsWide:rect.size.width
+			  pixelsHigh:rect.size.height
+			  bitsPerSample:8
+			  samplesPerPixel:4
+			  hasAlpha:YES
+			  isPlanar:NO
+			  colorSpaceName:NSDeviceRGBColorSpace
+			  bitmapFormat:0
+			  bytesPerRow:rect.size.width * 4
+			  bitsPerPixel:0];
 	mrdpCursor->bmiRep = bmiRep;
-	
 	/* create an image using above representation */
 	image = [[NSImage alloc] initWithSize:[bmiRep size]];
 	[image addRepresentation: bmiRep];
 	[image setFlipped:NO];
 	mrdpCursor->nsImage = image;
-	
 	/* need hotspot to create cursor */
 	hotSpot.x = pointer->xPos;
 	hotSpot.y = pointer->yPos;
-	
 	cursor = [[NSCursor alloc] initWithImage: image hotSpot:hotSpot];
 	mrdpCursor->nsCursor = cursor;
 	mrdpCursor->pointer = pointer;
-	
 	/* save cursor for later use in mf_Pointer_Set() */
 	ma = view->cursors;
 	[ma addObject:mrdpCursor];
@@ -1063,7 +982,7 @@ void mf_Pointer_Free(rdpContext* context, rdpPointer* pointer)
 	mfContext* mfc = (mfContext*) context;
 	MRDPView* view = (MRDPView*) mfc->view;
 	NSMutableArray* ma = view->cursors;
-	
+
 	for (MRDPCursor* cursor in ma)
 	{
 		if (cursor->pointer == pointer)
@@ -1082,7 +1001,6 @@ void mf_Pointer_Set(rdpContext* context, rdpPointer* pointer)
 {
 	mfContext* mfc = (mfContext*) context;
 	MRDPView* view = (MRDPView*) mfc->view;
-
 	NSMutableArray* ma = view->cursors;
 
 	for (MRDPCursor* cursor in ma)
@@ -1099,7 +1017,6 @@ void mf_Pointer_Set(rdpContext* context, rdpPointer* pointer)
 
 void mf_Pointer_SetNull(rdpContext* context)
 {
-	
 }
 
 void mf_Pointer_SetDefault(rdpContext* context)
@@ -1113,34 +1030,32 @@ CGContextRef mac_create_bitmap_context(rdpContext* context)
 {
 	CGContextRef bitmap_context;
 	rdpGdi* gdi = context->gdi;
-	
 	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-	
+
 	if (gdi->bytesPerPixel == 2)
 	{
 		bitmap_context = CGBitmapContextCreate(gdi->primary_buffer,
-						       gdi->width, gdi->height, 5, gdi->width * gdi->bytesPerPixel,
-						       colorSpace, kCGBitmapByteOrder16Little | kCGImageAlphaNoneSkipFirst);
+											   gdi->width, gdi->height, 5, gdi->width * gdi->bytesPerPixel,
+											   colorSpace, kCGBitmapByteOrder16Little | kCGImageAlphaNoneSkipFirst);
 	}
 	else
 	{
 		bitmap_context = CGBitmapContextCreate(gdi->primary_buffer,
-						       gdi->width, gdi->height, 8, gdi->width * gdi->bytesPerPixel,
-						       colorSpace, kCGBitmapByteOrder32Little | kCGImageAlphaNoneSkipFirst);
+											   gdi->width, gdi->height, 8, gdi->width * gdi->bytesPerPixel,
+											   colorSpace, kCGBitmapByteOrder32Little | kCGImageAlphaNoneSkipFirst);
 	}
-	
+
 	CGColorSpaceRelease(colorSpace);
-	
 	return bitmap_context;
 }
 
 void mac_begin_paint(rdpContext* context)
 {
 	rdpGdi* gdi = context->gdi;
-	
+
 	if (!gdi)
 		return;
-	
+
 	gdi->primary->hdc->hwnd->invalid->null = 1;
 }
 
@@ -1152,12 +1067,11 @@ void mac_end_paint(rdpContext* context)
 	int ww, wh, dw, dh;
 	mfContext* mfc = (mfContext*) context;
 	MRDPView* view = (MRDPView*) mfc->view;
-
 	gdi = context->gdi;
-	
+
 	if (!gdi)
 		return;
-	
+
 	ww = mfc->client_width;
 	wh = mfc->client_height;
 	dw = mfc->context.settings->DesktopWidth;
@@ -1165,12 +1079,11 @@ void mac_end_paint(rdpContext* context)
 
 	if ((!context) || (!context->gdi))
 		return;
-	
+
 	if (context->gdi->primary->hdc->hwnd->invalid->null)
 		return;
 
 	invalid = gdi->primary->hdc->hwnd->invalid;
-
 	newDrawRect.origin.x = invalid->x;
 	newDrawRect.origin.y = invalid->y;
 	newDrawRect.size.width = invalid->w;
@@ -1192,9 +1105,7 @@ void mac_end_paint(rdpContext* context)
 	}
 
 	windows_to_apple_cords(mfc->view, &newDrawRect);
-
 	[view setNeedsDisplayInRect:newDrawRect];
-
 	gdi->primary->hdc->hwnd->ninvalid = 0;
 }
 
@@ -1203,22 +1114,17 @@ void mac_desktop_resize(rdpContext* context)
 	mfContext* mfc = (mfContext*) context;
 	MRDPView* view = (MRDPView*) mfc->view;
 	rdpSettings* settings = context->settings;
-	
 	/**
 	 * TODO: Fix resizing race condition. We should probably implement a message to be
 	 * put on the update message queue to be able to properly flush pending updates,
 	 * resize, and then continue with post-resizing graphical updates.
 	 */
-	
 	CGContextRef old_context = view->bitmap_context;
 	view->bitmap_context = NULL;
 	CGContextRelease(old_context);
-	
 	mfc->width = settings->DesktopWidth;
 	mfc->height = settings->DesktopHeight;
-	
 	gdi_resize(context->gdi, mfc->width, mfc->height);
-	
 	view->bitmap_context = mac_create_bitmap_context(context);
 }
 
@@ -1227,16 +1133,15 @@ static void update_activity_cb(freerdp* instance)
 	int status;
 	wMessage message;
 	wMessageQueue* queue;
-	
 	status = 1;
 	queue = freerdp_get_message_queue(instance, FREERDP_UPDATE_MESSAGE_QUEUE);
-	
+
 	if (queue)
 	{
 		while (MessageQueue_Peek(queue, &message, TRUE))
 		{
 			status = freerdp_message_queue_process_message(instance, FREERDP_UPDATE_MESSAGE_QUEUE, &message);
-			
+
 			if (!status)
 				break;
 		}
@@ -1252,7 +1157,6 @@ static void input_activity_cb(freerdp* instance)
 	int status;
 	wMessage message;
 	wMessageQueue* queue;
-
 	status = 1;
 	queue = freerdp_get_message_queue(instance, FREERDP_INPUT_MESSAGE_QUEUE);
 

--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -150,7 +150,15 @@ DWORD mac_client_thread(void* param)
 
 		while (1)
 		{
-			status = freerdp_wait_for_event(instance, INFINITE);
+			DWORD count;
+			HANDLE *handles;
+
+			count = freerdp_get_and_lock_handles(instance, &handles);
+			if (count > 0)
+			{
+				status = WaitForMultipleObjects(count, handles, FALSE, INFINITE);
+				freerdp_unlock_handles(instance, handles, count);
+			}
 
 			if (WaitForSingleObject(mfc->stopEvent, 0) == WAIT_OBJECT_0)
 			{

--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -92,33 +92,6 @@ DWORD mac_client_thread(void* param);
 	return 0;
 }
 
-DWORD mac_client_update_thread(void* param)
-{
-	int status;
-	wMessage message;
-	wMessageQueue* queue;
-	rdpContext* context = (rdpContext*) param;
-	status = 1;
-	queue = freerdp_get_message_queue(context->instance, FREERDP_UPDATE_MESSAGE_QUEUE);
-
-	while (MessageQueue_Wait(queue))
-	{
-		while (MessageQueue_Peek(queue, &message, TRUE))
-		{
-			status = freerdp_message_queue_process_message(context->instance, FREERDP_UPDATE_MESSAGE_QUEUE, &message);
-
-			if (!status)
-				break;
-		}
-
-		if (!status)
-			break;
-	}
-
-	ExitThread(0);
-	return 0;
-}
-
 DWORD mac_client_input_thread(void* param)
 {
 	int status;
@@ -151,14 +124,9 @@ DWORD mac_client_thread(void* param)
 	@autoreleasepool
 	{
 		int status;
-		HANDLE events[4];
 		HANDLE inputEvent;
 		HANDLE inputThread;
-		HANDLE updateEvent;
-		HANDLE updateThread;
-		HANDLE channelsEvent;
 
-		DWORD nCount;
 		rdpContext* context = (rdpContext*) param;
 		mfContext* mfc = (mfContext*) context;
 		freerdp* instance = context->instance;
@@ -174,10 +142,6 @@ DWORD mac_client_thread(void* param)
 		}
 
 		[view setIs_connected:1];
-
-		nCount = 0;
-
-		events[nCount++] = mfc->stopEvent;
 
 		if (settings->AsyncInput)
 		{

--- a/client/Sample/freerdp.c
+++ b/client/Sample/freerdp.c
@@ -130,11 +130,20 @@ int tfreerdp_run(freerdp* instance)
 
 	while (1)
 	{
-		DWORD ev = freerdp_wait_for_event(instance, INFINITE);
+		DWORD ev;
+		DWORD count;
+		HANDLE *handles;
+
+		count = freerdp_get_and_lock_handles(instance, &handles);
+		if (count > 0)
+		{
+			ev = WaitForMultipleObjects(count, handles, FALSE, INFINITE);
+			freerdp_unlock_handles(instance, handles, count);
+		}
 
 		if (WAIT_FAILED == ev)
 		{
-			WLog_ERR(TAG, "tfreerdp_run: freerdp_wait_for_event failed");
+			WLog_ERR(TAG, "tfreerdp_run: WaitForMultipleObjects failed");
 			break;
 		}
 
@@ -159,11 +168,20 @@ void* tf_client_thread_proc(freerdp* instance)
 
 	while (1)
 	{
-		DWORD ev = freerdp_wait_for_event(instance, INFINITE);
+		DWORD ev;
+		DWORD count;
+		HANDLE *handles;
+
+		count = freerdp_get_and_lock_handles(instance, &handles);
+		if (count > 0)
+		{
+			ev = WaitForMultipleObjects(count, handles, FALSE, INFINITE);
+			freerdp_unlock_handles(instance, handles, count);
+		}
 
 		if (WAIT_FAILED == ev)
 		{
-			WLog_ERR(TAG, "tfreerdp_run: freerdp_wait_for_event failed");
+			WLog_ERR(TAG, "tfreerdp_run: WaitForMultipleObjects failed");
 			break;
 		}
 

--- a/client/Sample/freerdp.c
+++ b/client/Sample/freerdp.c
@@ -63,7 +63,6 @@ int tf_context_new(freerdp* instance, rdpContext* context)
 
 void tf_context_free(freerdp* instance, rdpContext* context)
 {
-
 }
 
 void tf_begin_paint(rdpContext* context)
@@ -84,11 +83,8 @@ BOOL tf_pre_connect(freerdp* instance)
 {
 	tfContext* tfc;
 	rdpSettings* settings;
-
 	tfc = (tfContext*) instance->context;
-
 	settings = instance->settings;
-
 	settings->OrderSupport[NEG_DSTBLT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_PATBLT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_SCRBLT_INDEX] = TRUE;
@@ -111,103 +107,40 @@ BOOL tf_pre_connect(freerdp* instance)
 	settings->OrderSupport[NEG_POLYGON_CB_INDEX] = TRUE;
 	settings->OrderSupport[NEG_ELLIPSE_SC_INDEX] = TRUE;
 	settings->OrderSupport[NEG_ELLIPSE_CB_INDEX] = TRUE;
-
 	freerdp_channels_pre_connect(instance->context->channels, instance);
-
 	return TRUE;
 }
 
 BOOL tf_post_connect(freerdp* instance)
 {
 	rdpGdi* gdi;
-
 	gdi_init(instance, CLRCONV_ALPHA | CLRCONV_INVERT | CLRBUF_16BPP | CLRBUF_32BPP, NULL);
 	gdi = instance->context->gdi;
-
 	instance->update->BeginPaint = tf_begin_paint;
 	instance->update->EndPaint = tf_end_paint;
-
 	freerdp_channels_post_connect(instance->context->channels, instance);
-
 	return TRUE;
 }
 
 int tfreerdp_run(freerdp* instance)
 {
-	int i;
-	int fds;
-	int max_fds;
-	int rcount;
-	int wcount;
-	void* rfds[32];
-	void* wfds[32];
-	fd_set rfds_set;
-	fd_set wfds_set;
 	rdpChannels* channels;
-
 	channels = instance->context->channels;
-
 	freerdp_connect(instance);
 
 	while (1)
 	{
-		rcount = 0;
-		wcount = 0;
+		DWORD ev = freerdp_wait_for_event(instance, INFINITE);
 
-		ZeroMemory(rfds, sizeof(rfds));
-		ZeroMemory(wfds, sizeof(wfds));
-
-		if (!freerdp_get_fds(instance, rfds, &rcount, wfds, &wcount))
+		if (WAIT_FAILED == ev)
 		{
-			WLog_ERR(TAG, "Failed to get FreeRDP file descriptor");
+			WLog_ERR(TAG, "tfreerdp_run: freerdp_wait_for_event failed");
 			break;
 		}
 
-		if (!freerdp_channels_get_fds(channels, instance, rfds, &rcount, wfds, &wcount))
-		{
-			WLog_ERR(TAG, "Failed to get channel manager file descriptor");
-			break;
-		}
-
-		max_fds = 0;
-		FD_ZERO(&rfds_set);
-		FD_ZERO(&wfds_set);
-
-		for (i = 0; i < rcount; i++)
-		{
-			fds = (int)(long)(rfds[i]);
-
-			if (fds > max_fds)
-				max_fds = fds;
-
-			FD_SET(fds, &rfds_set);
-		}
-
-		if (max_fds == 0)
-			break;
-
-		if (select(max_fds + 1, &rfds_set, &wfds_set, NULL, NULL) == -1)
-		{
-			/* these are not really errors */
-			if (!((errno == EAGAIN) ||
-				(errno == EWOULDBLOCK) ||
-				(errno == EINPROGRESS) ||
-				(errno == EINTR))) /* signal occurred */
-			{
-				WLog_ERR(TAG, "tfreerdp_run: select failed");
-				break;
-			}
-		}
-
-		if (!freerdp_check_fds(instance))
+		if (!freerdp_check_handles(instance))
 		{
 			WLog_ERR(TAG, "Failed to check FreeRDP file descriptor");
-			break;
-		}
-
-		if (!freerdp_channels_check_fds(channels, instance))
-		{
-			WLog_ERR(TAG, "Failed to check channel manager file descriptor");
 			break;
 		}
 	}
@@ -215,86 +148,28 @@ int tfreerdp_run(freerdp* instance)
 	freerdp_channels_close(channels, instance);
 	freerdp_channels_free(channels);
 	freerdp_free(instance);
-
 	return 0;
 }
 
 void* tf_client_thread_proc(freerdp* instance)
 {
-	int i;
-	int fds;
-	int max_fds;
-	int rcount;
-	int wcount;
-	void* rfds[32];
-	void* wfds[32];
-	fd_set rfds_set;
-	fd_set wfds_set;
 	rdpChannels* channels;
-
 	channels = instance->context->channels;
-
 	freerdp_connect(instance);
 
 	while (1)
 	{
-		rcount = 0;
-		wcount = 0;
+		DWORD ev = freerdp_wait_for_event(instance, INFINITE);
 
-		ZeroMemory(rfds, sizeof(rfds));
-		ZeroMemory(wfds, sizeof(wfds));
-
-		if (!freerdp_get_fds(instance, rfds, &rcount, wfds, &wcount))
+		if (WAIT_FAILED == ev)
 		{
-			WLog_ERR(TAG, "Failed to get FreeRDP file descriptor");
+			WLog_ERR(TAG, "tfreerdp_run: freerdp_wait_for_event failed");
 			break;
 		}
 
-		if (!freerdp_channels_get_fds(channels, instance, rfds, &rcount, wfds, &wcount))
-		{
-			WLog_ERR(TAG, "Failed to get channel manager file descriptor");
-			break;
-		}
-
-		max_fds = 0;
-		FD_ZERO(&rfds_set);
-		FD_ZERO(&wfds_set);
-
-		for (i = 0; i < rcount; i++)
-		{
-			fds = (int)(long)(rfds[i]);
-
-			if (fds > max_fds)
-				max_fds = fds;
-
-			FD_SET(fds, &rfds_set);
-		}
-
-		if (max_fds == 0)
-			break;
-
-		if (select(max_fds + 1, &rfds_set, &wfds_set, NULL, NULL) == -1)
-		{
-			/* these are not really errors */
-			if (!((errno == EAGAIN) ||
-				(errno == EWOULDBLOCK) ||
-				(errno == EINPROGRESS) ||
-				(errno == EINTR))) /* signal occurred */
-			{
-				WLog_ERR(TAG, "tfreerdp_run: select failed");
-				break;
-			}
-		}
-
-		if (!freerdp_check_fds(instance))
+		if (!freerdp_check_handles(instance))
 		{
 			WLog_ERR(TAG, "Failed to check FreeRDP file descriptor");
-			break;
-		}
-
-		if (!freerdp_channels_check_fds(channels, instance))
-		{
-			WLog_ERR(TAG, "Failed to check channel manager file descriptor");
 			break;
 		}
 	}
@@ -302,7 +177,6 @@ void* tf_client_thread_proc(freerdp* instance)
 	freerdp_channels_close(channels, instance);
 	freerdp_channels_free(channels);
 	freerdp_free(instance);
-
 	ExitThread(0);
 	return NULL;
 }
@@ -313,18 +187,14 @@ int main(int argc, char* argv[])
 	HANDLE thread;
 	freerdp* instance;
 	rdpChannels* channels;
-
 	instance = freerdp_new();
 	instance->PreConnect = tf_pre_connect;
 	instance->PostConnect = tf_post_connect;
-
 	instance->ContextSize = sizeof(tfContext);
 	instance->ContextNew = tf_context_new;
 	instance->ContextFree = tf_context_free;
 	freerdp_context_new(instance);
-
 	channels = instance->context->channels;
-
 	status = freerdp_client_settings_parse_command_line(instance->settings, argc, argv);
 
 	if (status < 0)
@@ -333,11 +203,8 @@ int main(int argc, char* argv[])
 	}
 
 	freerdp_client_load_addins(instance->context->channels, instance->settings);
-
 	thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)
-			tf_client_thread_proc, instance, 0, NULL);
-
+						  tf_client_thread_proc, instance, 0, NULL);
 	WaitForSingleObject(thread, INFINITE);
-
 	return 0;
 }

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -156,11 +156,20 @@ int wlfreerdp_run(freerdp* instance)
 
 	while (1)
 	{
-		DWORD ev = freerdp_wait_for_event(instance, INFINITE);
+		DWORD ev;
+		DWORD count;
+		HANDLE *handles;
+
+		count = freerdp_get_and_lock_handles(instance, &handles);
+		if (count > 0)
+		{
+			ev = WaitForMultipleObjects(count, handles, FALSE, INFINITE);
+			freerdp_unlock_handles(instance, handles, count);
+		}
 
 		if (WAIT_FAILED == ev)
 		{
-			WLog_INFO(TAG,  "Quit due to freerdp_wait_for_event");
+			WLog_INFO(TAG,  "Quit due to WaitForMultipleObjects");
 			break;
 		}
 

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -29,19 +29,16 @@
 int wl_context_new(freerdp* instance, rdpContext* context)
 {
 	context->channels = freerdp_channels_new();
-
 	return 0;
 }
 
 void wl_context_free(freerdp* instance, rdpContext* context)
 {
-
 }
 
 void wl_begin_paint(rdpContext* context)
 {
 	rdpGdi* gdi;
-
 	gdi = context->gdi;
 	gdi->primary->hdc->hwnd->invalid->null = 1;
 }
@@ -52,12 +49,11 @@ void wl_end_paint(rdpContext* context)
 	wlfDisplay* display;
 	wlfWindow* window;
 	wlfContext* context_w;
-	void* data;
 	INT32 x, y;
 	UINT32 w, h;
 	int i;
-
 	gdi = context->gdi;
+
 	if (gdi->primary->hdc->hwnd->invalid->null)
 		return;
 
@@ -65,15 +61,14 @@ void wl_end_paint(rdpContext* context)
 	y = gdi->primary->hdc->hwnd->invalid->y;
 	w = gdi->primary->hdc->hwnd->invalid->w;
 	h = gdi->primary->hdc->hwnd->invalid->h;
-
 	context_w = (wlfContext*) context;
 	display = context_w->display;
 	window = context_w->window;
 
 	for (i = 0; i < h; i++)
 		memcpy(window->data + ((i+y)*(gdi->width*4)) + x*4,
-		       gdi->primary_buffer + ((i+y)*(gdi->width*4)) + x*4,
-		       w*4);
+			   gdi->primary_buffer + ((i+y)*(gdi->width*4)) + x*4,
+			   w*4);
 
 	wlf_RefreshDisplay(display);
 }
@@ -83,17 +78,12 @@ BOOL wl_pre_connect(freerdp* instance)
 	wlfDisplay* display;
 	wlfInput* input;
 	wlfContext* context;
-
 	freerdp_channels_pre_connect(instance->context->channels, instance);
-
 	context = (wlfContext*) instance->context;
-
 	display = wlf_CreateDisplay();
 	context->display = display;
-
 	input = wlf_CreateInput(context);
 	context->input = input;
-
 	return TRUE;
 }
 
@@ -102,40 +92,32 @@ BOOL wl_post_connect(freerdp* instance)
 	rdpGdi* gdi;
 	wlfWindow* window;
 	wlfContext* context;
-
 	gdi_init(instance, CLRCONV_ALPHA | CLRCONV_INVERT | CLRBUF_32BPP, NULL);
 	gdi = instance->context->gdi;
-
 	context = (wlfContext*) instance->context;
 	window = wlf_CreateDesktopWindow(context, "FreeRDP", gdi->width, gdi->height, FALSE);
-
-	 /* fill buffer with first image here */
-	window->data = malloc (gdi->width * gdi->height *4);
+	/* fill buffer with first image here */
+	window->data = malloc(gdi->width * gdi->height *4);
 	memcpy(window->data, (void*) gdi->primary_buffer, gdi->width * gdi->height * 4);
 	instance->update->BeginPaint = wl_begin_paint;
 	instance->update->EndPaint = wl_end_paint;
-
-	 /* put Wayland data in the context here */
+	/* put Wayland data in the context here */
 	context->window = window;
-
 	freerdp_channels_post_connect(instance->context->channels, instance);
-
 	wlf_UpdateWindowArea(context, window, 0, 0, gdi->width, gdi->height);
-
 	return TRUE;
 }
 
 BOOL wl_verify_certificate(freerdp* instance, char* subject, char* issuer, char* fingerprint)
 {
 	char answer;
-
 	printf("Certificate details:\n");
 	printf("\tSubject: %s\n", subject);
 	printf("\tIssuer: %s\n", issuer);
 	printf("\tThumbprint: %s\n", fingerprint);
 	printf("The above X.509 certificate could not be verified, possibly because you do not have "
-		"the CA certificate in your certificate store, or the certificate has expired. "
-		"Please look at the documentation on how to create local certificate store for a private CA.\n");
+		   "the CA certificate in your certificate store, or the certificate has expired. "
+		   "Please look at the documentation on how to create local certificate store for a private CA.\n");
 
 	while (1)
 	{
@@ -145,8 +127,10 @@ BOOL wl_verify_certificate(freerdp* instance, char* subject, char* issuer, char*
 		if (feof(stdin))
 		{
 			printf("\nError: Could not read answer from stdin.");
+
 			if (instance->settings->CredentialsFromStdin)
 				printf(" - Run without parameter \"--from-stdin\" to set trust.");
+
 			printf("\n");
 			return FALSE;
 		}
@@ -159,6 +143,7 @@ BOOL wl_verify_certificate(freerdp* instance, char* subject, char* issuer, char*
 		{
 			break;
 		}
+
 		printf("\n");
 	}
 
@@ -167,88 +152,33 @@ BOOL wl_verify_certificate(freerdp* instance, char* subject, char* issuer, char*
 
 int wlfreerdp_run(freerdp* instance)
 {
-	int i;
-	int fds;
-	int max_fds;
-	int rcount;
-	int wcount;
-	void* rfds[32];
-	void* wfds[32];
-	fd_set rfds_set;
-	fd_set wfds_set;
-
-	ZeroMemory(rfds, sizeof(rfds));
-	ZeroMemory(wfds, sizeof(wfds));
-
 	freerdp_connect(instance);
 
 	while (1)
 	{
-		rcount = 0;
-		wcount = 0;
-		if (freerdp_get_fds(instance, rfds, &rcount, wfds, &wcount) != TRUE)
+		DWORD ev = freerdp_wait_for_event(instance, INFINITE);
+
+		if (WAIT_FAILED == ev)
 		{
-			printf("Failed to get FreeRDP file descriptor");
-			break;
-		}
-		if (freerdp_channels_get_fds(instance->context->channels, instance, rfds, &rcount, wfds, &wcount) != TRUE)
-		{
-			printf("Failed to get FreeRDP file descriptor");
+			WLog_INFO(TAG,  "Quit due to freerdp_wait_for_event");
 			break;
 		}
 
-		max_fds = 0;
-		FD_ZERO(&rfds_set);
-		FD_ZERO(&wfds_set);
-
-		for (i = 0; i < rcount; i++)
+		if (freerdp_check_handles(instance) != TRUE)
 		{
-			fds = (int)(long)(rfds[i]);
-
-			if (fds > max_fds)
-				max_fds = fds;
-
-			FD_SET(fds, &rfds_set);
-		}
-
-		if (max_fds == 0)
-			break;
-
-		if (select(max_fds + 1, &rfds_set, &wfds_set, NULL, NULL) == -1)
-		{
-			if (!((errno == EAGAIN) ||
-				(errno == EWOULDBLOCK) ||
-				(errno == EINPROGRESS) ||
-				(errno == EINTR)))
-			{
-				printf("wlfreerdp_run: select failed\n");
-				break;
-			}
-		}
-
-		if (freerdp_check_fds(instance) != TRUE)
-		{
-			printf("Failed to check FreeRDP file descriptor\n");
-			break;
-		}
-		if (freerdp_channels_check_fds(instance->context->channels, instance) != TRUE)
-		{
-			printf("Failed to check channel manager file descriptor\n");
+			WLog_ERR(TAG, "Failed to check FreeRDP file descriptor");
 			break;
 		}
 	}
 
 	wlfContext* context;
-
 	context = (wlfContext*) instance->context;
 	wlf_DestroyWindow(context, context->window);
 	wlf_DestroyInput(context, context->input);
 	wlf_DestroyDisplay(context, context->display);
-
 	freerdp_channels_close(instance->context->channels, instance);
 	freerdp_channels_free(instance->context->channels);
 	freerdp_free(instance);
-
 	return 0;
 }
 
@@ -256,27 +186,21 @@ int main(int argc, char* argv[])
 {
 	int status;
 	freerdp* instance;
-
 	instance = freerdp_new();
 	instance->PreConnect = wl_pre_connect;
 	instance->PostConnect = wl_post_connect;
 	instance->VerifyCertificate = wl_verify_certificate;
-
 	instance->ContextSize = sizeof(wlfContext);
 	instance->ContextNew = wl_context_new;
 	instance->ContextFree = wl_context_free;
 	freerdp_context_new(instance);
-
 	status = freerdp_client_settings_parse_command_line_arguments(instance->settings, argc, argv);
-
 	status = freerdp_client_settings_command_line_status_print(instance->settings, status, argc, argv);
 
 	if (status)
 		exit(0);
 
 	freerdp_client_load_addins(instance->context->channels, instance->settings);
-
 	wlfreerdp_run(instance);
-
 	return 0;
 }

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -675,6 +675,8 @@ DWORD WINAPI wf_client_thread(LPVOID lpParam)
 	while (1)
 	{
 		DWORD ev;
+		DWORD count;
+		HANDLE *handles;
 
 		if (freerdp_focus_required(instance))
 		{
@@ -682,7 +684,12 @@ DWORD WINAPI wf_client_thread(LPVOID lpParam)
 			wf_event_focus_in(wfc);
 		}
 
-		ev = freerdp_wait_for_event(instance, INFINITE);
+		count = freerdp_get_and_lock_handles(instance, &handles);
+		if (count > 0)
+		{
+			ev = WaitForMultipleObjects(count, handles, FALSE, INFINITE);
+			freerdp_unlock_handles(instance, handles, count);
+		}
 
 		if (!async_transport)
 		{

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -110,7 +110,7 @@ static void xf_draw_screen_scaled(xfContext* xfc, int x, int y, int w, int h)
 	Picture windowPicture;
 	Picture primaryPicture;
 	XRenderPictureAttributes pa;
-	XRenderPictFormat *picFormat;
+	XRenderPictFormat* picFormat;
 	double xScalingFactor;
 	double yScalingFactor;
 	int x2;
@@ -130,23 +130,20 @@ static void xf_draw_screen_scaled(xfContext* xfc, int x, int y, int w, int h)
 
 	xScalingFactor = xfc->width / (double)xfc->scaledWidth;
 	yScalingFactor = xfc->height / (double)xfc->scaledHeight;
-
 	XSetFillStyle(xfc->display, xfc->gc, FillSolid);
 	XSetForeground(xfc->display, xfc->gc, 0);
-
 	/* Black out possible space between desktop and window borders */
 	{
 		XRectangle box1 = { 0, 0, xfc->window->width, xfc->window->height };
 		XRectangle box2 = { xfc->offset_x, xfc->offset_y, xfc->scaledWidth, xfc->scaledHeight };
 		Region reg1 = XCreateRegion();
 		Region reg2 = XCreateRegion();
-
-		XUnionRectWithRegion( &box1, reg1, reg1);
-		XUnionRectWithRegion( &box2, reg2, reg2);
+		XUnionRectWithRegion(&box1, reg1, reg1);
+		XUnionRectWithRegion(&box2, reg2, reg2);
 
 		if (XSubtractRegion(reg1, reg2, reg1) && !XEmptyRegion(reg1))
 		{
-			XSetRegion( xfc->display, xfc->gc, reg1);
+			XSetRegion(xfc->display, xfc->gc, reg1);
 			XFillRectangle(xfc->display, xfc->window->handle, xfc->gc, 0, 0, xfc->window->width, xfc->window->height);
 			XSetClipMask(xfc->display, xfc->gc, None);
 		}
@@ -154,15 +151,11 @@ static void xf_draw_screen_scaled(xfContext* xfc, int x, int y, int w, int h)
 		XDestroyRegion(reg1);
 		XDestroyRegion(reg2);
 	}
-
 	picFormat = XRenderFindVisualFormat(xfc->display, xfc->visual);
-
 	pa.subwindow_mode = IncludeInferiors;
 	primaryPicture = XRenderCreatePicture(xfc->display, xfc->primary, picFormat, CPSubwindowMode, &pa);
 	windowPicture = XRenderCreatePicture(xfc->display, xfc->window->handle, picFormat, CPSubwindowMode, &pa);
-
 	XRenderSetPictureFilter(xfc->display, primaryPicture, FilterBilinear, 0, 0);
-
 	transform.matrix[0][0] = XDoubleToFixed(xScalingFactor);
 	transform.matrix[0][1] = XDoubleToFixed(0.0);
 	transform.matrix[0][2] = XDoubleToFixed(0.0);
@@ -172,7 +165,6 @@ static void xf_draw_screen_scaled(xfContext* xfc, int x, int y, int w, int h)
 	transform.matrix[2][0] = XDoubleToFixed(0.0);
 	transform.matrix[2][1] = XDoubleToFixed(0.0);
 	transform.matrix[2][2] = XDoubleToFixed(1.0);
-
 	/* calculate and fix up scaled coordinates */
 	x2 = x + w;
 	y2 = y + h;
@@ -180,7 +172,6 @@ static void xf_draw_screen_scaled(xfContext* xfc, int x, int y, int w, int h)
 	y = floor(y / yScalingFactor) - 1;
 	w = ceil(x2 / xScalingFactor) + 1 - x;
 	h = ceil(y2 / yScalingFactor) + 1 - y;
-
 	XRenderSetPictureTransform(xfc->display, primaryPicture, &transform);
 	XRenderComposite(xfc->display, PictOpSrc, primaryPicture, 0, windowPicture, x, y, 0, 0, xfc->offset_x + x, xfc->offset_y + y, w, h);
 	XRenderFreePicture(xfc->display, primaryPicture);
@@ -190,11 +181,12 @@ static void xf_draw_screen_scaled(xfContext* xfc, int x, int y, int w, int h)
 BOOL xf_picture_transform_required(xfContext* xfc)
 {
 	if (xfc->offset_x || xfc->offset_y ||
-	    xfc->scaledWidth != xfc->width ||
-	    xfc->scaledHeight != xfc->height)
+			xfc->scaledWidth != xfc->width ||
+			xfc->scaledHeight != xfc->height)
 	{
 		return TRUE;
 	}
+
 	return FALSE;
 }
 #endif /* WITH_XRENDER defined */
@@ -208,10 +200,12 @@ void xf_draw_screen(xfContext* xfc, int x, int y, int w, int h)
 	}
 
 #ifdef WITH_XRENDER
+
 	if (xf_picture_transform_required(xfc)) {
 		xf_draw_screen_scaled(xfc, x, y, w, h);
 		return;
 	}
+
 #endif
 	XCopyArea(xfc->display, xfc->primary, xfc->window->handle, xfc->gc, x, y, w, h, x, y);
 }
@@ -227,16 +221,19 @@ static void xf_desktop_resize(rdpContext* context)
 		BOOL same = (xfc->primary == xfc->drawing) ? TRUE : FALSE;
 		XFreePixmap(xfc->display, xfc->primary);
 		xfc->primary = XCreatePixmap(xfc->display, xfc->drawable, xfc->width, xfc->height, xfc->depth);
+
 		if (same)
-				xfc->drawing = xfc->primary;
+			xfc->drawing = xfc->primary;
 	}
 
 #ifdef WITH_XRENDER
+
 	if (!xfc->settings->SmartSizing)
 	{
 		xfc->scaledWidth = xfc->width;
 		xfc->scaledHeight = xfc->height;
 	}
+
 #endif
 
 	if (!xfc->fullscreen)
@@ -269,12 +266,10 @@ void xf_sw_end_paint(rdpContext* context)
 	HGDI_RGN cinvalid;
 	xfContext* xfc = (xfContext*) context;
 	rdpGdi* gdi = context->gdi;
-
 	x = gdi->primary->hdc->hwnd->invalid->x;
 	y = gdi->primary->hdc->hwnd->invalid->y;
 	w = gdi->primary->hdc->hwnd->invalid->w;
 	h = gdi->primary->hdc->hwnd->invalid->h;
-
 	ninvalid = gdi->primary->hdc->hwnd->ninvalid;
 	cinvalid = gdi->primary->hdc->hwnd->cinvalid;
 
@@ -286,11 +281,8 @@ void xf_sw_end_paint(rdpContext* context)
 				return;
 
 			xf_lock_x11(xfc, FALSE);
-
 			XPutImage(xfc->display, xfc->primary, xfc->gc, xfc->image, x, y, x, y, w, h);
-
 			xf_draw_screen(xfc, x, y, w, h);
-
 			xf_unlock_x11(xfc, FALSE);
 		}
 		else
@@ -306,14 +298,11 @@ void xf_sw_end_paint(rdpContext* context)
 				y = cinvalid[i].y;
 				w = cinvalid[i].w;
 				h = cinvalid[i].h;
-
 				XPutImage(xfc->display, xfc->primary, xfc->gc, xfc->image, x, y, x, y, w, h);
-
 				xf_draw_screen(xfc, x, y, w, h);
 			}
 
 			XFlush(xfc->display);
-
 			xf_unlock_x11(xfc, FALSE);
 		}
 	}
@@ -323,9 +312,7 @@ void xf_sw_end_paint(rdpContext* context)
 			return;
 
 		xf_lock_x11(xfc, FALSE);
-
 		xf_rail_paint(xfc, x, y, x + w - 1, y + h - 1);
-
 		xf_unlock_x11(xfc, FALSE);
 	}
 }
@@ -334,25 +321,20 @@ void xf_sw_desktop_resize(rdpContext* context)
 {
 	rdpGdi* gdi = context->gdi;
 	xfContext* xfc = (xfContext*) context;
-
 	xf_lock_x11(xfc, TRUE);
-
 	xfc->width = context->settings->DesktopWidth;
 	xfc->height = context->settings->DesktopHeight;
-
 	gdi_resize(gdi, xfc->width, xfc->height);
 
 	if (xfc->image)
 	{
 		xfc->image->data = NULL;
 		XDestroyImage(xfc->image);
-
 		xfc->image = XCreateImage(xfc->display, xfc->visual, xfc->depth, ZPixmap, 0,
-				(char*) gdi->primary_buffer, gdi->width, gdi->height, xfc->scanline_pad, 0);
+								  (char*) gdi->primary_buffer, gdi->width, gdi->height, xfc->scanline_pad, 0);
 	}
 
 	xf_desktop_resize(context);
-
 	xf_unlock_x11(xfc, TRUE);
 }
 
@@ -380,11 +362,8 @@ void xf_hw_end_paint(rdpContext* context)
 			y = xfc->hdc->hwnd->invalid->y;
 			w = xfc->hdc->hwnd->invalid->w;
 			h = xfc->hdc->hwnd->invalid->h;
-
 			xf_lock_x11(xfc, FALSE);
-
 			xf_draw_screen(xfc, x, y, w, h);
-
 			xf_unlock_x11(xfc, FALSE);
 		}
 		else
@@ -398,7 +377,6 @@ void xf_hw_end_paint(rdpContext* context)
 
 			ninvalid = xfc->hdc->hwnd->ninvalid;
 			cinvalid = xfc->hdc->hwnd->cinvalid;
-
 			xf_lock_x11(xfc, FALSE);
 
 			for (i = 0; i < ninvalid; i++)
@@ -407,12 +385,10 @@ void xf_hw_end_paint(rdpContext* context)
 				y = cinvalid[i].y;
 				w = cinvalid[i].w;
 				h = cinvalid[i].h;
-
 				xf_draw_screen(xfc, x, y, w, h);
 			}
 
 			XFlush(xfc->display);
-
 			xf_unlock_x11(xfc, FALSE);
 		}
 	}
@@ -425,11 +401,8 @@ void xf_hw_end_paint(rdpContext* context)
 		y = xfc->hdc->hwnd->invalid->y;
 		w = xfc->hdc->hwnd->invalid->w;
 		h = xfc->hdc->hwnd->invalid->h;
-
 		xf_lock_x11(xfc, FALSE);
-
 		xf_rail_paint(xfc, x, y, x + w - 1, y + h - 1);
-
 		xf_unlock_x11(xfc, FALSE);
 	}
 }
@@ -438,23 +411,11 @@ void xf_hw_desktop_resize(rdpContext* context)
 {
 	xfContext* xfc = (xfContext*) context;
 	rdpSettings* settings = xfc->settings;
-
 	xf_lock_x11(xfc, TRUE);
-
 	xfc->width = settings->DesktopWidth;
 	xfc->height = settings->DesktopHeight;
-
 	xf_desktop_resize(context);
-
 	xf_unlock_x11(xfc, TRUE);
-}
-
-BOOL xf_get_fds(freerdp *instance, void **rfds, int *rcount, void **wfds, int *wcount)
-{
-	xfContext* xfc = (xfContext*) instance->context;
-	rfds[*rcount] = (void *)(long)(xfc->xfds);
-	(*rcount)++;
-	return TRUE;
 }
 
 BOOL xf_process_x_events(freerdp* instance)
@@ -463,7 +424,6 @@ BOOL xf_process_x_events(freerdp* instance)
 	XEvent xevent;
 	int pending_status;
 	xfContext* xfc = (xfContext*) instance->context;
-
 	status = TRUE;
 	pending_status = TRUE;
 
@@ -477,13 +437,13 @@ BOOL xf_process_x_events(freerdp* instance)
 		{
 			ZeroMemory(&xevent, sizeof(xevent));
 			XNextEvent(xfc->display, &xevent);
-
 			status = xf_event_process(instance, &xevent);
 
 			if (!status)
 				return status;
 		}
 	}
+
 	return status;
 }
 
@@ -492,9 +452,7 @@ void xf_create_window(xfContext* xfc)
 	XEvent xevent;
 	int width, height;
 	char* windowTitle;
-
 	ZeroMemory(&xevent, sizeof(xevent));
-
 	width = xfc->width;
 	height = xfc->height;
 
@@ -534,6 +492,7 @@ void xf_create_window(xfContext* xfc)
 		}
 
 #ifdef WITH_XRENDER
+
 		if (xfc->settings->SmartSizing)
 		{
 			if (xfc->fullscreen)
@@ -548,15 +507,17 @@ void xf_create_window(xfContext* xfc)
 			{
 				if (xfc->settings->SmartSizingWidth)
 					width = xfc->settings->SmartSizingWidth;
+
 				if (xfc->settings->SmartSizingHeight)
 					height = xfc->settings->SmartSizingHeight;
 			}
+
 			xfc->scaledWidth = width;
 			xfc->scaledHeight = height;
 		}
+
 #endif
 		xfc->window = xf_CreateDesktopWindow(xfc, windowTitle, width, height, xfc->settings->Decorations);
-
 		free(windowTitle);
 
 		if (xfc->fullscreen)
@@ -575,27 +536,20 @@ void xf_create_window(xfContext* xfc)
 void xf_toggle_fullscreen(xfContext* xfc)
 {
 	WindowStateChangeEventArgs e;
-
 	xf_lock_x11(xfc, TRUE);
-
 	XDestroyWindow(xfc->display, xfc->window->handle);
-
 	xfc->fullscreen = (xfc->fullscreen) ? FALSE : TRUE;
-
 	xf_create_window(xfc);
-
 	xf_unlock_x11(xfc, TRUE);
-
 	EventArgsInit(&e, "xfreerdp");
 	e.state = xfc->fullscreen ? FREERDP_WINDOW_STATE_FULLSCREEN : 0;
-	PubSub_OnWindowStateChange(((rdpContext *) xfc)->pubSub, xfc, &e);
+	PubSub_OnWindowStateChange(((rdpContext*) xfc)->pubSub, xfc, &e);
 }
 
 void xf_toggle_control(xfContext* xfc)
 {
 	EncomspClientContext* encomsp;
 	ENCOMSP_CHANGE_PARTICIPANT_CONTROL_LEVEL_PDU pdu;
-
 	encomsp = xfc->encomsp;
 
 	if (!encomsp)
@@ -608,7 +562,6 @@ void xf_toggle_control(xfContext* xfc)
 		pdu.Flags |= ENCOMSP_REQUEST_INTERACT;
 
 	encomsp->ChangeParticipantControlLevel(encomsp, &pdu);
-
 	xfc->controlToggle = !xfc->controlToggle;
 }
 
@@ -621,7 +574,6 @@ void xf_encomsp_init(xfContext* xfc, EncomspClientContext* encomsp)
 {
 	xfc->encomsp = encomsp;
 	encomsp->custom = (void*) xfc;
-
 	encomsp->ParticipantCreated = xf_encomsp_participant_created;
 }
 
@@ -658,10 +610,11 @@ void xf_unlock_x11(xfContext* xfc, BOOL display)
 
 static void xf_calculate_color_shifts(UINT32 mask, UINT8* rsh, UINT8* lsh)
 {
-    for (*lsh = 0; !(mask & 1); mask >>= 1)
-        (*lsh)++;
-    for (*rsh = 8; mask; mask >>= 1)
-        (*rsh)--;
+	for (*lsh = 0; !(mask & 1); mask >>= 1)
+		(*lsh)++;
+
+	for (*rsh = 8; mask; mask >>= 1)
+		(*rsh)--;
 }
 
 BOOL xf_get_pixmap_info(xfContext* xfc)
@@ -669,13 +622,12 @@ BOOL xf_get_pixmap_info(xfContext* xfc)
 	int i;
 	int vi_count;
 	int pf_count;
-	XVisualInfo *vi;
-	XVisualInfo *vis;
+	XVisualInfo* vi;
+	XVisualInfo* vis;
 	XVisualInfo template;
-	XPixmapFormatValues *pf;
-	XPixmapFormatValues *pfs;
+	XPixmapFormatValues* pf;
+	XPixmapFormatValues* pfs;
 	XWindowAttributes window_attributes;
-
 	pfs = XListPixmapFormats(xfc->display, &pf_count);
 
 	if (!pfs)
@@ -697,7 +649,6 @@ BOOL xf_get_pixmap_info(xfContext* xfc)
 	}
 
 	XFree(pfs);
-
 	ZeroMemory(&template, sizeof(template));
 	template.class = TrueColor;
 	template.screen = xfc->screen_number;
@@ -721,6 +672,7 @@ BOOL xf_get_pixmap_info(xfContext* xfc)
 	for (i = 0; i < vi_count; i++)
 	{
 		vi = vis + i;
+
 		if (vi->visual == window_attributes.visual)
 		{
 			xfc->visual = vi->visual;
@@ -755,22 +707,19 @@ BOOL xf_get_pixmap_info(xfContext* xfc)
 	return TRUE;
 }
 
-static int (*_def_error_handler)(Display *, XErrorEvent *);
+static int (*_def_error_handler)(Display*, XErrorEvent*);
 
 int xf_error_handler(Display* d, XErrorEvent* ev)
 {
 	char buf[256];
-
 	int do_abort = TRUE;
 	XGetErrorText(d, ev->error_code, buf, sizeof(buf));
-
 	WLog_ERR(TAG, "%s", buf);
 
 	if (do_abort)
 		abort();
 
 	_def_error_handler(d, ev);
-
 	return FALSE;
 }
 
@@ -793,6 +742,11 @@ static void xf_post_disconnect(freerdp* instance)
 		return;
 
 	xfc = (xfContext*) instance->context;
+
+	if (!instance->settings->AsyncInput)
+	{
+		freerdp_remove_handle(instance, xfc->xev);
+	}
 
 	if (xfc->mutex)
 	{
@@ -817,8 +771,8 @@ void xf_check_extensions(xfContext* context)
 	int xkb_major = XkbMajorVersion;
 	int xkb_minor = XkbMinorVersion;
 
-	if (XkbLibraryVersion( &xkb_major, &xkb_minor ) && XkbQueryExtension(context->display, &xkb_opcode, &xkb_event,
-	    &xkb_error, &xkb_major, &xkb_minor))
+	if (XkbLibraryVersion(&xkb_major, &xkb_minor) && XkbQueryExtension(context->display, &xkb_opcode, &xkb_event,
+			&xkb_error, &xkb_major, &xkb_minor))
 	{
 		context->xkbAvailable = TRUE;
 	}
@@ -827,8 +781,9 @@ void xf_check_extensions(xfContext* context)
 	{
 		int xrender_event_base;
 		int xrender_error_base;
-		if (XRenderQueryExtension (context->display, &xrender_event_base,
-			&xrender_error_base))
+
+		if (XRenderQueryExtension(context->display, &xrender_event_base,
+								  &xrender_error_base))
 		{
 			context->xrenderAvailable = TRUE;
 		}
@@ -851,17 +806,13 @@ BOOL xf_pre_connect(freerdp* instance)
 	rdpChannels* channels;
 	rdpSettings* settings;
 	xfContext* xfc = (xfContext*) instance->context;
-
 	xfc->codecs = instance->context->codecs;
 	xfc->settings = instance->settings;
 	xfc->instance = instance;
-
 	settings = instance->settings;
 	channels = instance->context->channels;
-
 	settings->OsMajorType = OSMAJORTYPE_UNIX;
 	settings->OsMinorType = OSMINORTYPE_NATIVE_XSERVER;
-
 	ZeroMemory(settings->OrderSupport, 32);
 	settings->OrderSupport[NEG_DSTBLT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_PATBLT_INDEX] = TRUE;
@@ -887,7 +838,6 @@ BOOL xf_pre_connect(freerdp* instance)
 	settings->OrderSupport[NEG_POLYGON_CB_INDEX] = (settings->SoftwareGdi) ? FALSE : TRUE;
 	settings->OrderSupport[NEG_ELLIPSE_SC_INDEX] = FALSE;
 	settings->OrderSupport[NEG_ELLIPSE_CB_INDEX] = FALSE;
-
 	xfc->UseXThreads = TRUE;
 
 	if (xfc->UseXThreads)
@@ -916,20 +866,18 @@ BOOL xf_pre_connect(freerdp* instance)
 	}
 
 	xf_check_extensions(xfc);
-
 	xfc->mutex = CreateMutex(NULL, FALSE, NULL);
-
 	PubSub_SubscribeChannelConnected(instance->context->pubSub,
-			(pChannelConnectedEventHandler) xf_OnChannelConnectedEventHandler);
+									 (pChannelConnectedEventHandler) xf_OnChannelConnectedEventHandler);
 	PubSub_SubscribeChannelDisconnected(instance->context->pubSub,
-			(pChannelDisconnectedEventHandler) xf_OnChannelDisconnectedEventHandler);
-
+										(pChannelDisconnectedEventHandler) xf_OnChannelDisconnectedEventHandler);
 	freerdp_client_load_addins(channels, instance->settings);
 	freerdp_channels_pre_connect(channels, instance);
 
 	if (!settings->Username)
 	{
-		char *login_name = getlogin();
+		char* login_name = getlogin();
+
 		if (login_name)
 		{
 			settings->Username = _strdup(login_name);
@@ -968,12 +916,15 @@ BOOL xf_pre_connect(freerdp* instance)
 	xfc->WM_PROTOCOLS = XInternAtom(xfc->display, "WM_PROTOCOLS", False);
 	xfc->WM_DELETE_WINDOW = XInternAtom(xfc->display, "WM_DELETE_WINDOW", False);
 	xfc->WM_STATE = XInternAtom(xfc->display, "WM_STATE", False);
-
 	xf_keyboard_init(xfc);
-
 	instance->context->cache = cache_new(instance->settings);
+	xfc->xev = CreateFileDescriptorEvent(NULL, FALSE, FALSE, ConnectionNumber(xfc->display));
 
-	xfc->xfds = ConnectionNumber(xfc->display);
+	if (!settings->AsyncInput)
+	{
+		freerdp_add_handle(instance, xfc->xev);
+	}
+
 	xfc->screen_number = DefaultScreen(xfc->display);
 	xfc->screen = ScreenOfDisplay(xfc->display, xfc->screen_number);
 	xfc->depth = DefaultDepthOfScreen(xfc->screen);
@@ -983,10 +934,8 @@ BOOL xf_pre_connect(freerdp* instance)
 	xfc->fullscreen = settings->Fullscreen;
 	xfc->grab_keyboard = settings->GrabKeyboard;
 	xfc->fullscreen_toggle = settings->ToggleFullscreen;
-
 	xf_detect_monitors(xfc, settings);
 	xfc->colormap = DefaultColormap(xfc->display, xfc->screen_number);
-
 	xfc->format = PIXEL_FORMAT_XRGB32;
 
 	if (xfc->depth == 32)
@@ -1008,7 +957,7 @@ BOOL xf_pre_connect(freerdp* instance)
  * It will be called only if the connection was initialized properly, and will continue the initialization based on the
  * newly created connection.
  */
-BOOL xf_post_connect(freerdp *instance)
+BOOL xf_post_connect(freerdp* instance)
 {
 	UINT32 flags;
 	XGCValues gcv;
@@ -1017,7 +966,6 @@ BOOL xf_post_connect(freerdp *instance)
 	rdpSettings* settings;
 	ResizeWindowEventArgs e;
 	xfContext* xfc = (xfContext*) instance->context;
-
 	cache = instance->context->cache;
 	channels = instance->context->channels;
 	settings = instance->settings;
@@ -1026,7 +974,6 @@ BOOL xf_post_connect(freerdp *instance)
 		return FALSE;
 
 	xf_register_graphics(instance->context->graphics);
-
 	flags = CLRCONV_ALPHA;
 
 	if (xfc->bpp > 16)
@@ -1037,9 +984,7 @@ BOOL xf_post_connect(freerdp *instance)
 	if (settings->SoftwareGdi)
 	{
 		rdpGdi* gdi;
-
 		gdi_init(instance, flags, NULL);
-
 		gdi = instance->context->gdi;
 		xfc->primary_buffer = gdi->primary_buffer;
 	}
@@ -1052,7 +997,6 @@ BOOL xf_post_connect(freerdp *instance)
 
 	xfc->width = settings->DesktopWidth;
 	xfc->height = settings->DesktopHeight;
-
 #ifdef WITH_XRENDER
 	xfc->scaledWidth = xfc->width;
 	xfc->scaledHeight = xfc->height;
@@ -1079,7 +1023,6 @@ BOOL xf_post_connect(freerdp *instance)
 		xfc->remote_app = TRUE;
 
 	xf_create_window(xfc);
-
 	ZeroMemory(&gcv, sizeof(gcv));
 
 	if (xfc->modifierMap)
@@ -1096,9 +1039,8 @@ BOOL xf_post_connect(freerdp *instance)
 	XSetForeground(xfc->display, xfc->gc, BlackPixelOfScreen(xfc->screen));
 	XFillRectangle(xfc->display, xfc->primary, xfc->gc, 0, 0, xfc->width, xfc->height);
 	XFlush(xfc->display);
-
 	xfc->image = XCreateImage(xfc->display, xfc->visual, xfc->depth, ZPixmap, 0,
-			(char*) xfc->primary_buffer, xfc->width, xfc->height, xfc->scanline_pad, 0);
+							  (char*) xfc->primary_buffer, xfc->width, xfc->height, xfc->scanline_pad, 0);
 
 	if (settings->SoftwareGdi)
 	{
@@ -1124,17 +1066,15 @@ BOOL xf_post_connect(freerdp *instance)
 		palette_cache_register_callbacks(instance->update);
 		instance->update->BitmapUpdate = xf_gdi_bitmap_update;
 	}
+
 	instance->update->PlaySound = xf_play_sound;
 	instance->update->SetKeyboardIndicators = xf_keyboard_set_indicators;
-
 	xfc->clipboard = xf_clipboard_new(xfc);
 	freerdp_channels_post_connect(channels, instance);
-
 	EventArgsInit(&e, "xfreerdp");
 	e.width = settings->DesktopWidth;
 	e.height = settings->DesktopHeight;
-	PubSub_OnResizeWindow(((rdpContext *) xfc)->pubSub, xfc, &e);
-
+	PubSub_OnResizeWindow(((rdpContext*) xfc)->pubSub, xfc, &e);
 	return TRUE;
 }
 
@@ -1150,7 +1090,7 @@ BOOL xf_post_connect(freerdp *instance)
  *  @param domain - unused
  *  @return TRUE if a password was successfully entered. See freerdp_passphrase_read() for more details.
  */
-BOOL xf_authenticate(freerdp *instance, char **username, char **password, char **domain)
+BOOL xf_authenticate(freerdp* instance, char** username, char** password, char** domain)
 {
 	// FIXME: seems this callback may be called when 'username' is not known.
 	// But it doesn't do anything to fix it...
@@ -1175,14 +1115,13 @@ BOOL xf_authenticate(freerdp *instance, char **username, char **password, char *
 BOOL xf_verify_certificate(freerdp* instance, char* subject, char* issuer, char* fingerprint)
 {
 	char answer;
-
 	WLog_INFO(TAG, "Certificate details:");
 	WLog_INFO(TAG, "\tSubject: %s", subject);
 	WLog_INFO(TAG, "\tIssuer: %s", issuer);
 	WLog_INFO(TAG, "\tThumbprint: %s", fingerprint);
 	WLog_INFO(TAG, "The above X.509 certificate could not be verified, possibly because you do not have "
-		   "the CA certificate in your certificate store, or the certificate has expired. "
-		   "Please look at the documentation on how to create local certificate store for a private CA.");
+			  "the CA certificate in your certificate store, or the certificate has expired. "
+			  "Please look at the documentation on how to create local certificate store for a private CA.");
 
 	while (1)
 	{
@@ -1192,8 +1131,10 @@ BOOL xf_verify_certificate(freerdp* instance, char* subject, char* issuer, char*
 		if (feof(stdin))
 		{
 			WLog_INFO(TAG, "Error: Could not read answer from stdin.");
+
 			if (instance->settings->CredentialsFromStdin)
 				WLog_INFO(TAG, " - Run without parameter \"--from-stdin\" to set trust.");
+
 			WLog_INFO(TAG, "");
 			return FALSE;
 		}
@@ -1223,7 +1164,6 @@ int xf_logon_error_info(freerdp* instance, UINT32 data, UINT32 type)
 void xf_window_free(xfContext* xfc)
 {
 	rdpContext* context = (rdpContext*) xfc;
-
 	xf_keyboard_free(xfc);
 
 	if (xfc->gc)
@@ -1287,29 +1227,27 @@ void xf_window_free(xfContext* xfc)
 	}
 }
 
-void* xf_input_thread(void *arg)
+void* xf_input_thread(void* arg)
 {
 	DWORD status;
 	DWORD nCount;
 	HANDLE events[2];
 	XEvent xevent;
 	wMessage msg;
-	wMessageQueue *queue;
+	wMessageQueue* queue;
 	int pending_status = 1;
 	int process_status = 1;
 	freerdp* instance = (freerdp*) arg;
 	xfContext* xfc = (xfContext*) instance->context;
-
 	queue = freerdp_get_message_queue(instance, FREERDP_INPUT_MESSAGE_QUEUE);
-
 	nCount = 0;
 	events[nCount++] = MessageQueue_Event(queue);
-	events[nCount++] = CreateFileDescriptorEvent(NULL, FALSE, FALSE, xfc->xfds);
+	events[nCount++] = xfc->xev;
 
-	while(1)
+	while (1)
 	{
 		status = WaitForMultipleObjects(nCount, events, FALSE, INFINITE);
-		
+
 		if (WaitForSingleObject(events[0], 0) == WAIT_OBJECT_0)
 		{
 			if (MessageQueue_Peek(queue, &msg, FALSE))
@@ -1330,12 +1268,9 @@ void* xf_input_thread(void *arg)
 				if (pending_status)
 				{
 					xf_lock_x11(xfc, FALSE);
-
 					ZeroMemory(&xevent, sizeof(xevent));
 					XNextEvent(xfc->display, &xevent);
-
 					process_status = xf_event_process(instance, &xevent);
-
 					xf_unlock_x11(xfc, FALSE);
 
 					if (!process_status)
@@ -1346,38 +1281,11 @@ void* xf_input_thread(void *arg)
 
 			if (!process_status)
 				break;
-
 		}
 	}
 
 	CloseHandle(events[1]);
-
 	MessageQueue_PostQuit(queue, 0);
-	ExitThread(0);
-	return NULL;
-}
-
-void* xf_channels_thread(void *arg)
-{
-	int status;
-	xfContext* xfc;
-	HANDLE event;
-	rdpChannels *channels;
-	freerdp *instance = (freerdp *) arg;
-	assert(NULL != instance);
-	xfc = (xfContext *) instance->context;
-	assert(NULL != xfc);
-	channels = instance->context->channels;
-	event = freerdp_channels_get_event_handle(instance);
-
-	while (WaitForSingleObject(event, INFINITE) == WAIT_OBJECT_0)
-	{
-		status = freerdp_channels_process_pending_messages(instance);
-
-		if (!status)
-			break;
-	}
-
 	ExitThread(0);
 	return NULL;
 }
@@ -1412,16 +1320,17 @@ BOOL xf_auto_reconnect(freerdp* instance)
 
 		/* Attempt the next reconnect */
 		WLog_INFO(TAG,  "Attempting reconnect (%u of %u)", num_retries, max_retries);
+
 		if (freerdp_reconnect(instance))
 		{
 			xfc->disconnect = FALSE;
 			return TRUE;
 		}
+
 		sleep(5);
 	}
 
 	WLog_ERR(TAG,  "Maximum reconnect retries exceeded");
-
 	return FALSE;
 }
 
@@ -1432,39 +1341,21 @@ BOOL xf_auto_reconnect(freerdp* instance)
  *  @param instance - pointer to the rdp_freerdp structure that contains the session's settings
  *  @return A code from the enum XF_EXIT_CODE (0 if successful)
  */
-void* xf_thread(void *param)
+void* xf_thread(void* param)
 {
-	int i;
-	int fds;
 	xfContext* xfc;
-	int max_fds;
-	int rcount;
-	int wcount;
 	BOOL status;
 	int exit_code;
-	void *rfds[32];
-	void *wfds[32];
-	fd_set rfds_set;
-	fd_set wfds_set;
-	freerdp *instance;
-	int fd_input_event;
+	freerdp* instance;
 	HANDLE input_event;
-	int select_status;
 	BOOL async_input;
-	BOOL async_channels;
-	BOOL async_transport;
 	HANDLE input_thread;
-	HANDLE channels_thread;
-	rdpChannels *channels;
-	rdpSettings *settings;
-	struct timeval timeout;
+	rdpChannels* channels;
+	rdpSettings* settings;
 	exit_code = 0;
 	input_event = NULL;
-	instance = (freerdp *) param;
+	instance = (freerdp*) param;
 	assert(NULL != instance);
-	ZeroMemory(rfds, sizeof(rfds));
-	ZeroMemory(wfds, sizeof(wfds));
-	ZeroMemory(&timeout, sizeof(struct timeval));
 	status = freerdp_connect(instance);
 	xfc = (xfContext*) instance->context;
 	assert(NULL != xfc);
@@ -1494,23 +1385,19 @@ void* xf_thread(void *param)
 	channels = instance->context->channels;
 	settings = instance->context->settings;
 	async_input = settings->AsyncInput;
-	async_channels = settings->AsyncChannels;
-	async_transport = settings->AsyncTransport;
 
 	if (async_input)
 	{
 		input_thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) xf_input_thread, instance, 0, NULL);
-	}
-
-	if (async_channels)
-	{
-		channels_thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) xf_channels_thread, instance, 0, NULL);
+		input_event = freerdp_get_message_queue_event_handle(instance, FREERDP_INPUT_MESSAGE_QUEUE);
+		freerdp_add_handle(instance, input_thread);
+		freerdp_add_handle(instance, input_event);
 	}
 
 	while (!xfc->disconnect && !freerdp_shall_disconnect(instance))
 	{
-		rcount = 0;
-		wcount = 0;
+		DWORD ev;
+
 		/*
 		 * win8 and server 2k12 seem to have some timing issue/race condition
 		 * when a initial sync request is send to sync the keyboard inidcators
@@ -1522,97 +1409,21 @@ void* xf_thread(void *param)
 			xf_keyboard_focus_in(xfc);
 		}
 
-		if (!async_transport)
+		ev = freerdp_wait_for_event(instance, INFINITE);
+
+		if (WAIT_FAILED == ev)
 		{
-			if (!freerdp_get_fds(instance, rfds, &rcount, wfds, &wcount))
-			{
-				WLog_ERR(TAG,  "Failed to get FreeRDP file descriptor");
-				exit_code = XF_EXIT_CONN_FAILED;
-				break;
-			}
-		}
-
-		if (!async_channels)
-		{
-			if (!freerdp_channels_get_fds(channels, instance, rfds, &rcount, wfds, &wcount))
-			{
-				WLog_ERR(TAG,  "Failed to get channel manager file descriptor");
-				exit_code = XF_EXIT_CONN_FAILED;
-				break;
-			}
-		}
-
-		if (!async_input)
-		{
-			if (!xf_get_fds(instance, rfds, &rcount, wfds, &wcount))
-			{
-				WLog_ERR(TAG,  "Failed to get xfreerdp file descriptor");
-				exit_code = XF_EXIT_CONN_FAILED;
-				break;
-			}
-		}
-		else
-		{
-			input_event = freerdp_get_message_queue_event_handle(instance, FREERDP_INPUT_MESSAGE_QUEUE);
-			fd_input_event = GetEventFileDescriptor(input_event);
-			rfds[rcount++] = (void *)(long) fd_input_event;
-		}
-
-		max_fds = 0;
-		FD_ZERO(&rfds_set);
-		FD_ZERO(&wfds_set);
-
-		for (i = 0; i < rcount; i++)
-		{
-			fds = (int)(long)(rfds[i]);
-
-			if (fds > max_fds)
-				max_fds = fds;
-
-			FD_SET(fds, &rfds_set);
-		}
-
-		if (max_fds == 0)
+			WLog_INFO(TAG,  "Quit due to freerdp_wait_for_event");
 			break;
-
-		timeout.tv_sec = 1;
-		timeout.tv_usec = 0;
-		select_status = select(max_fds + 1, &rfds_set, NULL, NULL, &timeout);
-
-		if (select_status == 0)
-		{
-			continue; /* select timeout */
-		}
-		else if (select_status == -1)
-		{
-			/* these are not really errors */
-			if (!((errno == EAGAIN) || (errno == EWOULDBLOCK) ||
-					(errno == EINPROGRESS) || (errno == EINTR))) /* signal occurred */
-			{
-				WLog_ERR(TAG,  "xfreerdp_run: select failed");
-				break;
-			}
 		}
 
-		if (!async_transport)
+		if (!freerdp_check_handles(instance))
 		{
-			if (!freerdp_check_fds(instance))
-			{
-				if (xf_auto_reconnect(instance))
-					continue;
+			if (xf_auto_reconnect(instance))
+				continue;
 
-				WLog_ERR(TAG,  "Failed to check FreeRDP file descriptor");
-				break;
-			}
-		}
-
-		if (!async_channels)
-		{
-			if (!freerdp_channels_check_fds(channels, instance))
-			{
-				WLog_ERR(TAG,  "Failed to check channel manager file descriptor");
-				break;
-			}
+			WLog_ERR(TAG,  "Failed to check FreeRDP file descriptor");
+			break;
 		}
 
 		if (!async_input)
@@ -1636,29 +1447,25 @@ void* xf_thread(void *param)
 			}
 		}
 	}
+
 	/* Close the channels first. This will signal the internal message pipes
 	 * that the threads should quit. */
 	freerdp_channels_close(channels, instance);
 
 	if (async_input)
 	{
-		wMessageQueue *input_queue = freerdp_get_message_queue(instance, FREERDP_INPUT_MESSAGE_QUEUE);
+		wMessageQueue* input_queue = freerdp_get_message_queue(instance, FREERDP_INPUT_MESSAGE_QUEUE);
 		MessageQueue_PostQuit(input_queue, 0);
 		WaitForSingleObject(input_thread, INFINITE);
+		freerdp_remove_handle(instance, input_thread);
+		freerdp_remove_handle(instance, input_event);
 		CloseHandle(input_thread);
-	}
-
-	if (async_channels)
-	{
-		WaitForSingleObject(channels_thread, INFINITE);
-		CloseHandle(channels_thread);
 	}
 
 	if (!exit_code)
 		exit_code = freerdp_error_info(instance);
 
 	freerdp_disconnect(instance);
-
 	ExitThread(exit_code);
 	return NULL;
 }
@@ -1666,16 +1473,16 @@ void* xf_thread(void *param)
 DWORD xf_exit_code_from_disconnect_reason(DWORD reason)
 {
 	if (reason == 0 || (reason >= XF_EXIT_PARSE_ARGUMENTS && reason <= XF_EXIT_CONN_FAILED))
-		return reason;
+				return reason;
 	/* License error set */
 	else if (reason >= 0x100 && reason <= 0x10A)
-		reason -= 0x100 + XF_EXIT_LICENSE_INTERNAL;
+				 reason -= 0x100 + XF_EXIT_LICENSE_INTERNAL;
 	/* RDP protocol error set */
 	else if (reason >= 0x10c9 && reason <= 0x1193)
-		reason = XF_EXIT_RDP;
+				 reason = XF_EXIT_RDP;
 	/* There's no need to test protocol-independent codes: they match */
 	else if (!(reason <= 0xB))
-		reason = XF_EXIT_UNKNOWN;
+				 reason = XF_EXIT_UNKNOWN;
 
 	return reason;
 }
@@ -1683,7 +1490,6 @@ DWORD xf_exit_code_from_disconnect_reason(DWORD reason)
 void xf_TerminateEventHandler(rdpContext* context, TerminateEventArgs* e)
 {
 	wMessageQueue* queue;
-
 	xfContext* xfc = (xfContext*) context;
 
 	if (context->settings->AsyncInput)
@@ -1710,17 +1516,16 @@ static void xf_ZoomingChangeEventHandler(rdpContext* context, ZoomingChangeEvent
 		return;
 
 	if (w < 10)
-		w = 10;
+				w = 10;
 
 	if (h < 10)
-		h = 10;
+				h = 10;
 
 	if (w == xfc->scaledWidth && h == xfc->scaledHeight)
 		return;
 
 	xfc->scaledWidth = w;
 	xfc->scaledHeight = h;
-
 	xf_draw_screen(xfc, 0, 0, xfc->width, xfc->height);
 }
 
@@ -1733,7 +1538,6 @@ static void xf_PanningChangeEventHandler(rdpContext* context, PanningChangeEvent
 
 	xfc->offset_x += e->dx;
 	xfc->offset_y += e->dy;
-
 	xf_draw_screen(xfc, 0, 0, xfc->width, xfc->height);
 }
 #endif
@@ -1750,12 +1554,11 @@ static void xfreerdp_client_global_init()
 
 static void xfreerdp_client_global_uninit()
 {
-
 }
 
 static int xfreerdp_client_start(rdpContext* context)
 {
-	xfContext* xfc = (xfContext *) context;
+	xfContext* xfc = (xfContext*) context;
 	rdpSettings* settings = context->settings;
 
 	if (!settings->ServerHostname)
@@ -1763,6 +1566,7 @@ static int xfreerdp_client_start(rdpContext* context)
 		WLog_ERR(TAG,  "error: server hostname was not specified with /v:<server>[:port]");
 		return -1;
 	}
+
 	xfc->disconnect = FALSE;
 	xfc->thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) xf_thread,
 							   context->instance, 0, NULL);
@@ -1775,8 +1579,9 @@ static int xfreerdp_client_stop(rdpContext* context)
 
 	if (context->settings->AsyncInput)
 	{
-		wMessageQueue *queue;
+		wMessageQueue* queue;
 		queue = freerdp_get_message_queue(context->instance, FREERDP_INPUT_MESSAGE_QUEUE);
+
 		if (queue)
 			MessageQueue_PostQuit(queue, 0);
 	}
@@ -1798,9 +1603,7 @@ static int xfreerdp_client_new(freerdp* instance, rdpContext* context)
 {
 	xfContext* xfc;
 	rdpSettings* settings;
-
 	xfc = (xfContext*) instance->context;
-
 	instance->PreConnect = xf_pre_connect;
 	instance->PostConnect = xf_post_connect;
 	instance->PostDisconnect = xf_post_disconnect;
@@ -1808,17 +1611,13 @@ static int xfreerdp_client_new(freerdp* instance, rdpContext* context)
 	instance->VerifyCertificate = xf_verify_certificate;
 	instance->LogonErrorInfo = xf_logon_error_info;
 	context->channels = freerdp_channels_new();
-
 	settings = instance->settings;
 	xfc->settings = instance->context->settings;
-
 	PubSub_SubscribeTerminate(context->pubSub, (pTerminateEventHandler) xf_TerminateEventHandler);
-
 #ifdef WITH_XRENDER
 	PubSub_SubscribeZoomingChange(context->pubSub, (pZoomingChangeEventHandler) xf_ZoomingChangeEventHandler);
 	PubSub_SubscribePanningChange(context->pubSub, (pPanningChangeEventHandler) xf_PanningChangeEventHandler);
 #endif
-
 	return 0;
 }
 

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -81,7 +81,7 @@ struct xf_context
 
 	GC gc;
 	int bpp;
-	int xfds;
+	HANDLE xev;
 	int depth;
 	int width;
 	int height;

--- a/client/iOS/FreeRDP/ios_freerdp.h
+++ b/client/iOS/FreeRDP/ios_freerdp.h
@@ -1,8 +1,8 @@
 /*
  RDP run-loop
- 
+
  Copyright 2013 Thincast Technologies GmbH, Authors: Martin Fleisz, Dorian Johnson
- 
+
  This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
  If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
@@ -22,7 +22,7 @@ typedef struct mf_info mfInfo;
 typedef struct mf_context
 {
 	rdpContext _p;
-	
+
 	mfInfo* mfi;
 	rdpSettings* settings;
 } mfContext;
@@ -34,14 +34,15 @@ struct mf_info
 	freerdp* instance;
 	mfContext* context;
 	rdpContext* _context;
-	
+
 	// UI
 	RDPSession* session;
-	
+
 	// Graphics
 	CGContextRef bitmap_context;
-	
+
 	// Events
+	HANDLE event_handle_consumer;
 	int event_pipe_producer, event_pipe_consumer;
 
 	// Tracking connection state
@@ -59,8 +60,8 @@ enum MF_EXIT_CODE
 
 	MF_EXIT_CONN_FAILED = 128,
 	MF_EXIT_CONN_CANCELED = 129,
-    MF_EXIT_LOGON_TIMEOUT = 130,
-	
+	MF_EXIT_LOGON_TIMEOUT = 130,
+
 	MF_EXIT_UNKNOWN = 255
 };
 

--- a/client/iOS/FreeRDP/ios_freerdp.m
+++ b/client/iOS/FreeRDP/ios_freerdp.m
@@ -106,9 +106,17 @@ int ios_run_freerdp(freerdp* instance)
 	while (!freerdp_shall_disconnect(instance))
 	{
 		DWORD ev;
+		DWORD count;
+		HANDLE *handles;
 		pool = [[NSAutoreleasePool alloc] init];
 
-		ev = freerdp_wait_for_event(instance, INFINITE);
+		count = freerdp_get_and_lock_handles(instance, &handles);
+		if (count > 0)
+		{
+			ev = WaitForMultipleObjects(count, handles, FALSE, INFINITE);
+			freerdp_unlock_handles(instance, handles, count);
+		}
+
 		// timeout?
 		if (WAIT_TIMEOUT == ev)
 		{
@@ -116,7 +124,7 @@ int ios_run_freerdp(freerdp* instance)
 		}
 		else if (WAIT_FAILED == ev)
 		{
-			NSLog(@"%s: freerdp_wait_for_event failed!", __func__);
+			NSLog(@"%s: WaitForMultipleObjects failed!", __func__);
 			break;
 		}
 

--- a/client/iOS/FreeRDP/ios_freerdp.m
+++ b/client/iOS/FreeRDP/ios_freerdp.m
@@ -1,8 +1,8 @@
 /*
  RDP run-loop
- 
+
  Copyright 2013 Thincast Technologies GmbH, Authors: Martin Fleisz, Dorian Johnson
- 
+
  This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
  If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
@@ -23,20 +23,18 @@
 #pragma mark Connection helpers
 
 static BOOL ios_pre_connect(freerdp* instance)
-{	
-	rdpSettings* settings = instance->settings;	
-
+{
+	rdpSettings* settings = instance->settings;
 	settings->AutoLogonEnabled = settings->Password && (strlen(settings->Password) > 0);
-	
+
 	// Verify screen width/height are sane
 	if ((settings->DesktopWidth < 64) || (settings->DesktopHeight < 64) || (settings->DesktopWidth > 4096) || (settings->DesktopHeight > 4096))
 	{
 		NSLog(@"%s: invalid dimensions %d %d", __func__, settings->DesktopWidth, settings->DesktopHeight);
 		return FALSE;
 	}
-	
+
 	BOOL bitmap_cache = settings->BitmapCacheEnabled;
-	
 	settings->OrderSupport[NEG_DSTBLT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_PATBLT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_SCRBLT_INDEX] = TRUE;
@@ -61,31 +59,23 @@ static BOOL ios_pre_connect(freerdp* instance)
 	settings->OrderSupport[NEG_POLYGON_CB_INDEX] = FALSE;
 	settings->OrderSupport[NEG_ELLIPSE_SC_INDEX] = FALSE;
 	settings->OrderSupport[NEG_ELLIPSE_CB_INDEX] = FALSE;
-	
 	settings->FrameAcknowledge = 10;
-
 	freerdp_client_load_addins(instance->context->channels, instance->settings);
-
 	freerdp_channels_pre_connect(instance->context->channels, instance);
-
 	return TRUE;
 }
 
 static BOOL ios_post_connect(freerdp* instance)
 {
 	mfInfo* mfi = MFI_FROM_INSTANCE(instance);
-
 	instance->context->cache = cache_new(instance->settings);
-    
 	// Graphics callbacks
 	ios_allocate_display_buffer(mfi);
 	instance->update->BeginPaint = ios_ui_begin_paint;
 	instance->update->EndPaint = ios_ui_end_paint;
 	instance->update->DesktopResize = ios_ui_resize_window;
-		
 	// Channel allocation
 	freerdp_channels_post_connect(instance->context->channels, instance);
-
 	[mfi->session performSelectorOnMainThread:@selector(sessionDidConnect) withObject:nil waitUntilDone:YES];
 	return TRUE;
 }
@@ -98,137 +88,67 @@ int ios_run_freerdp(freerdp* instance)
 	mfContext* context = (mfContext*)instance->context;
 	mfInfo* mfi = context->mfi;
 	rdpChannels* channels = instance->context->channels;
-		
 	mfi->connection_state = TSXConnectionConnecting;
-	
+
 	if (!freerdp_connect(instance))
 	{
 		NSLog(@"%s: inst->rdp_connect failed", __func__);
 		return mfi->unwanted ? MF_EXIT_CONN_CANCELED : MF_EXIT_CONN_FAILED;
 	}
-	
+
 	if (mfi->unwanted)
 		return MF_EXIT_CONN_CANCELED;
 
 	mfi->connection_state = TSXConnectionConnected;
-			
 	// Connection main loop
 	NSAutoreleasePool* pool;
-	int i;
-	int fds;
-	int max_fds;
-	int rcount;
-	int wcount;
-	void* rfds[32];
-	void* wfds[32];
-	fd_set rfds_set;
-	fd_set wfds_set;
-	struct timeval timeout;
-	int select_status;
-	
-	memset(rfds, 0, sizeof(rfds));
-	memset(wfds, 0, sizeof(wfds));
 
 	while (!freerdp_shall_disconnect(instance))
 	{
-		rcount = wcount = 0;
-		
+		DWORD ev;
 		pool = [[NSAutoreleasePool alloc] init];
 
-		if (freerdp_get_fds(instance, rfds, &rcount, wfds, &wcount) != TRUE)
+		ev = freerdp_wait_for_event(instance, INFINITE);
+		// timeout?
+		if (WAIT_TIMEOUT == ev)
 		{
-			NSLog(@"%s: inst->rdp_get_fds failed", __func__);
+			continue;
+		}
+		else if (WAIT_FAILED == ev)
+		{
+			NSLog(@"%s: freerdp_wait_for_event failed!", __func__);
 			break;
 		}
 
-		if (freerdp_channels_get_fds(channels, instance, rfds, &rcount, wfds, &wcount) != TRUE)
-		{
-			NSLog(@"%s: freerdp_chanman_get_fds failed", __func__);
-			break;
-		}
-
-		if (ios_events_get_fds(mfi, rfds, &rcount, wfds, &wcount) != TRUE)
-		{
-			NSLog(@"%s: ios_events_get_fds", __func__);
-			break;
-		}
-		
-		max_fds = 0;
-		FD_ZERO(&rfds_set);
-		FD_ZERO(&wfds_set);
-		
-		for (i = 0; i < rcount; i++)
-		{
-			fds = (int)(long)(rfds[i]);
-			
-			if (fds > max_fds)
-				max_fds = fds;
-			
-			FD_SET(fds, &rfds_set);
-		}
-        
-		if (max_fds == 0)
-			break;
-	
-        timeout.tv_sec = 1;
-        timeout.tv_usec = 0;
-
-        select_status = select(max_fds + 1, &rfds_set, NULL, NULL, &timeout);
-        
-        // timeout?
-        if (select_status == 0)
-	{
-            continue;
-	}
-        else if (select_status == -1)
-	{
-		/* these are not really errors */
-		if (!((errno == EAGAIN) ||
-			(errno == EWOULDBLOCK) ||
-			(errno == EINPROGRESS) ||
-			(errno == EINTR))) /* signal occurred */
-		{
-				NSLog(@"%s: select failed!", __func__);
-				break;
-			}
-		}
-		
 		// Check the libfreerdp fds
-		if (freerdp_check_fds(instance) != true)
+		if (freerdp_check_handles(instance) != true)
 		{
-			NSLog(@"%s: inst->rdp_check_fds failed.", __func__);
+			NSLog(@"%s: inst->rdp_check_handles failed.", __func__);
 			break;
 		}
-		
+
 		// Check input event fds
-		if (ios_events_check_fds(mfi, &rfds_set) != TRUE)
+		if (ios_events_check_handles(mfi) != TRUE)
 		{
 			// This event will fail when the app asks for a disconnect.
-			//NSLog(@"%s: ios_events_check_fds failed: terminating connection.", __func__);
-			break;
-		}
-		
-		// Check channel fds
-		if (freerdp_channels_check_fds(channels, instance) != TRUE)
-		{
-			NSLog(@"%s: freerdp_chanman_check_fds failed", __func__);
+			//NSLog(@"%s: ios_events_check_handles failed: terminating connection.", __func__);
 			break;
 		}
 
-		[pool release]; pool = nil;
-	}	
+		[pool release];
+		pool = nil;
+	}
 
 	CGContextRelease(mfi->bitmap_context);
-	mfi->bitmap_context = NULL;	
+	mfi->bitmap_context = NULL;
 	mfi->connection_state = TSXConnectionDisconnected;
-	
 	// Cleanup
 	freerdp_channels_close(channels, instance);
 	freerdp_disconnect(instance);
 	gdi_free(instance);
 	cache_free(instance->context->cache);
-	
-	[pool release]; pool = nil;
+	[pool release];
+	pool = nil;
 	return MF_EXIT_SUCCESS;
 }
 
@@ -241,7 +161,6 @@ int ios_context_new(freerdp* instance, rdpContext* context)
 	((mfContext*) context)->mfi = mfi;
 	context->channels = freerdp_channels_new();
 	ios_events_create_pipe(mfi);
-	
 	mfi->_context = context;
 	mfi->context = (mfContext*)context;
 	mfi->context->settings = instance->settings;
@@ -263,25 +182,21 @@ void ios_context_free(freerdp* instance, rdpContext* context)
 freerdp* ios_freerdp_new()
 {
 	freerdp* inst = freerdp_new();
-	
 	inst->PreConnect = ios_pre_connect;
 	inst->PostConnect = ios_post_connect;
 	inst->Authenticate = ios_ui_authenticate;
 	inst->VerifyCertificate = ios_ui_check_certificate;
 	inst->VerifyChangedCertificate = ios_ui_check_changed_certificate;
-    
 	inst->ContextSize = sizeof(mfContext);
 	inst->ContextNew = ios_context_new;
 	inst->ContextFree = ios_context_free;
 	freerdp_context_new(inst);
-    
 	// determine new home path
 	NSString* home_path = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) lastObject];
 	free(inst->settings->HomePath);
 	free(inst->settings->ConfigPath);
 	inst->settings->HomePath = strdup([home_path UTF8String]);
 	inst->settings->ConfigPath = strdup([[home_path stringByAppendingPathComponent:@".freerdp"] UTF8String]);
-
 	return inst;
 }
 
@@ -299,6 +214,5 @@ void ios_init_freerdp()
 
 void ios_uninit_freerdp()
 {
-
 }
 

--- a/client/iOS/FreeRDP/ios_freerdp_events.h
+++ b/client/iOS/FreeRDP/ios_freerdp_events.h
@@ -17,7 +17,7 @@
 BOOL ios_events_send(mfInfo* mfi, NSDictionary * event_description);
 
 // For connection runloop: use to poll for queued input events
-BOOL ios_events_check_handles(mfInfo* mfi, fd_set* rfds);
+BOOL ios_events_check_handles(mfInfo* mfi);
 BOOL ios_events_create_pipe(mfInfo* mfi);
 void ios_events_free_pipe(mfInfo* mfi);
 

--- a/client/iOS/FreeRDP/ios_freerdp_events.h
+++ b/client/iOS/FreeRDP/ios_freerdp_events.h
@@ -17,8 +17,7 @@
 BOOL ios_events_send(mfInfo* mfi, NSDictionary * event_description);
 
 // For connection runloop: use to poll for queued input events
-BOOL ios_events_get_fds(mfInfo* mfi, void ** read_fds, int * read_count, void ** write_fds, int * write_count);
-BOOL ios_events_check_fds(mfInfo* mfi, fd_set* rfds);
+BOOL ios_events_check_handles(mfInfo* mfi, fd_set* rfds);
 BOOL ios_events_create_pipe(mfInfo* mfi);
 void ios_events_free_pipe(mfInfo* mfi);
 

--- a/client/iOS/FreeRDP/ios_freerdp_events.m
+++ b/client/iOS/FreeRDP/ios_freerdp_events.m
@@ -1,9 +1,9 @@
 /*
- RDP event queuing 
- 
+ RDP event queuing
+
  Copyright 2013 Thincast Technologies GmbH, Author: Dorian Johnson
- 
- This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. 
+
+ This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
  If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
@@ -13,59 +13,59 @@
 #pragma mark Sending compacted input events (from main thread)
 
 // While this function may be called from any thread that has an autorelease pool allocated, it is not threadsafe: caller is responsible for synchronization
-BOOL ios_events_send(mfInfo* mfi, NSDictionary * event_description)
-{		
-	NSData * encoded_description = [NSKeyedArchiver archivedDataWithRootObject:event_description];
-	
-	if ([encoded_description length] > 32000 || (mfi->event_pipe_producer == -1) )
+BOOL ios_events_send(mfInfo* mfi, NSDictionary* event_description)
+{
+	NSData* encoded_description = [NSKeyedArchiver archivedDataWithRootObject:event_description];
+
+	if ([encoded_description length] > 32000 || (mfi->event_pipe_producer == -1))
 		return FALSE;
-	
+
 	uint32_t archived_data_len = (uint32_t)[encoded_description length];
-	
+
 	//NSLog(@"writing %d bytes to input event pipe", archived_data_len);
-	
+
 	if (write(mfi->event_pipe_producer, &archived_data_len, 4) == -1)
 	{
 		NSLog(@"%s: Failed to write length descriptor to pipe.", __func__);
 		return FALSE;
 	}
-	
+
 	if (write(mfi->event_pipe_producer, [encoded_description bytes], archived_data_len) == -1)
 	{
 		NSLog(@"%s: Failed to write %d bytes into the event queue (event type: %@).", __func__, (int)[encoded_description length], [event_description objectForKey:@"type"]);
 		return FALSE;
 	}
-	
-	return TRUE;	
+
+	return TRUE;
 }
 
 
 #pragma mark -
 #pragma mark Processing compacted input events (from connection thread runloop)
 
-static BOOL ios_events_handle_event(mfInfo* mfi, NSDictionary * event_description)
+static BOOL ios_events_handle_event(mfInfo* mfi, NSDictionary* event_description)
 {
-	NSString * event_type = [event_description objectForKey:@"type"];
+	NSString* event_type = [event_description objectForKey:@"type"];
 	BOOL should_continue = TRUE;
 	freerdp* instance = mfi->instance;
-	
+
 	if ([event_type isEqualToString:@"mouse"])
-	{        
-		instance->input->MouseEvent(instance->input, 
-                                    [[event_description objectForKey:@"flags"] unsignedShortValue],
-                                    [[event_description objectForKey:@"coord_x"] unsignedShortValue],
-                                    [[event_description objectForKey:@"coord_y"] unsignedShortValue]);
+	{
+		instance->input->MouseEvent(instance->input,
+									[[event_description objectForKey:@"flags"] unsignedShortValue],
+									[[event_description objectForKey:@"coord_x"] unsignedShortValue],
+									[[event_description objectForKey:@"coord_y"] unsignedShortValue]);
 	}
 	else if ([event_type isEqualToString:@"keyboard"])
 	{
 		if ([[event_description objectForKey:@"subtype"] isEqualToString:@"scancode"])
-			instance->input->KeyboardEvent(instance->input, 
-                                           [[event_description objectForKey:@"flags"] unsignedShortValue],
-                                           [[event_description objectForKey:@"scancode"] unsignedShortValue]);
+			instance->input->KeyboardEvent(instance->input,
+										   [[event_description objectForKey:@"flags"] unsignedShortValue],
+										   [[event_description objectForKey:@"scancode"] unsignedShortValue]);
 		else if ([[event_description objectForKey:@"subtype"] isEqualToString:@"unicode"])
 			instance->input->UnicodeKeyboardEvent(instance->input,
-                                                  [[event_description objectForKey:@"flags"] unsignedShortValue],
-                                                  [[event_description objectForKey:@"unicode_char"] unsignedShortValue]);
+												  [[event_description objectForKey:@"flags"] unsignedShortValue],
+												  [[event_description objectForKey:@"unicode_char"] unsignedShortValue]);
 		else
 			NSLog(@"%s: doesn't know how to send keyboard input with subtype %@", __func__, [event_description objectForKey:@"subtype"]);
 	}
@@ -73,73 +73,68 @@ static BOOL ios_events_handle_event(mfInfo* mfi, NSDictionary * event_descriptio
 		should_continue = FALSE;
 	else
 		NSLog(@"%s: unrecognized event type: %@", __func__, event_type);
-	
+
 	return should_continue;
 }
 
-BOOL ios_events_check_fds(mfInfo* mfi, fd_set* rfds)
-{	
-	if ( (mfi->event_pipe_consumer == -1) || !FD_ISSET(mfi->event_pipe_consumer, rfds))
+BOOL ios_events_check_handles(mfInfo* mfi)
+{
+	if (mfi->event_pipe_consumer == -1)
 		return TRUE;
-	
+
+	if (WaitForSingleObject(mfi->event_handle_consumer, 0) != WAIT_OBJECT_0)
+		return TRUE;
+
 	uint32_t archived_data_length = 0;
 	ssize_t bytes_read;
-	
 	// First, read the length of the blob
 	bytes_read = read(mfi->event_pipe_consumer, &archived_data_length, 4);
-	
+
 	if (bytes_read == -1 || archived_data_length < 1 || archived_data_length > 32000)
 	{
 		NSLog(@"%s: just read length descriptor. bytes_read=%ld, archived_data_length=%u", __func__, bytes_read, archived_data_length);
 		return FALSE;
 	}
-	
+
 	//NSLog(@"reading %d bytes from input event pipe", archived_data_length);
-	
-	NSMutableData * archived_object_data = [[NSMutableData alloc] initWithLength:archived_data_length];
+	NSMutableData* archived_object_data = [[NSMutableData alloc] initWithLength:archived_data_length];
 	bytes_read = read(mfi->event_pipe_consumer, [archived_object_data mutableBytes], archived_data_length);
-	
+
 	if (bytes_read != archived_data_length)
 	{
 		NSLog(@"%s: attempted to read data; read %ld bytes but wanted %d bytes.", __func__, bytes_read, archived_data_length);
 		[archived_object_data release];
 		return FALSE;
 	}
-	
+
 	id unarchived_object_data = [NSKeyedUnarchiver unarchiveObjectWithData:archived_object_data];
 	[archived_object_data release];
-	
 	return ios_events_handle_event(mfi, unarchived_object_data);
-}
-
-BOOL ios_events_get_fds(mfInfo* mfi, void ** read_fds, int * read_count, void ** write_fds, int * write_count)
-{
-	read_fds[*read_count] = (void *)(long)(mfi->event_pipe_consumer);
-	(*read_count)++;
-	return TRUE;
 }
 
 // Sets up the event pipe
 BOOL ios_events_create_pipe(mfInfo* mfi)
 {
 	int pipe_fds[2];
-	
+
 	if (pipe(pipe_fds) == -1)
 	{
 		NSLog(@"%s: pipe failed.", __func__);
 		return FALSE;
 	}
-	
+
 	mfi->event_pipe_consumer = pipe_fds[0];
 	mfi->event_pipe_producer = pipe_fds[1];
+	mfi->event_handle_consumer = CreateFileDescriptorEvent(NULL, FALSE, FALSE, mfi->event_pipe_consumer);
+	freerdp_add_handle(mfi->instance, mfi->event_handle_consumer);
 	return TRUE;
 }
 
 void ios_events_free_pipe(mfInfo* mfi)
 {
 	int consumer_fd = mfi->event_pipe_consumer, producer_fd = mfi->event_pipe_producer;
-	
+	freerdp_remove_handle(mfi->instance, mfi->event_handle_consumer);
 	mfi->event_pipe_consumer = mfi->event_pipe_producer = -1;
 	close(producer_fd);
-	close(consumer_fd);	
+	close(consumer_fd);
 }

--- a/include/freerdp/channels/channels.h
+++ b/include/freerdp/channels/channels.h
@@ -37,21 +37,20 @@ FREERDP_API void freerdp_channels_free(rdpChannels* channels);
 FREERDP_API int freerdp_channels_client_load(rdpChannels* channels, rdpSettings* settings,
 		void* entry, void* data);
 FREERDP_API int freerdp_channels_load_plugin(rdpChannels* channels, rdpSettings* settings,
-	const char* name, void* data);
+		const char* name, void* data);
 FREERDP_API int freerdp_channels_pre_connect(rdpChannels* channels, freerdp* instance);
 FREERDP_API int freerdp_channels_post_connect(rdpChannels* channels, freerdp* instance);
-FREERDP_API BOOL freerdp_channels_get_fds(rdpChannels* channels, freerdp* instance, void** read_fds,
-	int* read_count, void** write_fds, int* write_count);
-FREERDP_API BOOL freerdp_channels_check_fds(rdpChannels* channels, freerdp* instance);
+FREERDP_API int freerdp_channels_post_disconnect(rdpChannels* channels, freerdp* instance);
+
+FREERDP_API BOOL freerdp_channels_check_handles(rdpChannels* channels, freerdp* instance);
 FREERDP_API void freerdp_channels_close(rdpChannels* channels, freerdp* instance);
 
 FREERDP_API void* freerdp_channels_get_static_channel_interface(rdpChannels* channels, const char* name);
 
-FREERDP_API HANDLE freerdp_channels_get_event_handle(freerdp* instance);
 FREERDP_API int freerdp_channels_process_pending_messages(freerdp* instance);
 
 FREERDP_API int freerdp_channels_data(freerdp* instance,
-		UINT16 channelId, BYTE* data, int dataSize, int flags, int totalSize);
+									  UINT16 channelId, BYTE* data, int dataSize, int flags, int totalSize);
 
 FREERDP_API PWtsApiFunctionTable FreeRDP_InitWtsApi(void);
 

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -248,9 +248,9 @@ FREERDP_API BOOL freerdp_shall_disconnect(freerdp* instance);
 FREERDP_API BOOL freerdp_disconnect(freerdp* instance);
 FREERDP_API BOOL freerdp_reconnect(freerdp* instance);
 
-/* Wait for a handle registered with freerdp_add_handle to be signalled.
- * If return is FALSE, quit the event loop. */
-FREERDP_API DWORD freerdp_wait_for_event(freerdp* instance, DWORD timeout);
+FREERDP_API DWORD freerdp_get_and_lock_handles(freerdp* instance, HANDLE** handles);
+FREERDP_API DWORD freerdp_unlock_handles(freerdp* instance, HANDLE* handles, DWORD count);
+
 /* Process pending events in main loop. */
 FREERDP_API BOOL freerdp_check_handles(freerdp* instance);
 

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -49,6 +49,7 @@ typedef RDP_CLIENT_ENTRY_POINTS_V1 RDP_CLIENT_ENTRY_POINTS;
 #include <freerdp/extension.h>
 
 #include <winpr/stream.h>
+#include <winpr/collections.h>
 
 #include <freerdp/input.h>
 #include <freerdp/update.h>
@@ -127,7 +128,9 @@ struct rdp_context
 	ALIGN64 rdpMetrics* metrics; /* 41 */
 	ALIGN64 rdpCodecs* codecs; /* 42 */
 	ALIGN64 rdpAutoDetect* autodetect; /* 43 */
-	UINT64 paddingC[64 - 44]; /* 44 */
+	ALIGN64 wArrayList* eventHandles; /* 44 */
+	ALIGN64 HANDLE insertHandle; /* 45 */
+	UINT64 paddingC[64 - 46]; /* 46 */
 
 	UINT64 paddingD[96 - 64]; /* 64 */
 	UINT64 paddingE[128 - 96]; /* 96 */
@@ -207,7 +210,7 @@ struct rdp_freerdp
 											   Callback for certificate validation.
 											   Used to verify that an unknown certificate is trusted. */
 	ALIGN64 pVerifyChangedCertificate VerifyChangedCertificate; /**< (offset 52)
-															 Callback for changed certificate validation. 
+															 Callback for changed certificate validation.
 															 Used when a certificate differs from stored fingerprint.
 															 If returns TRUE, the new fingerprint will be trusted and old thrown out. */
 
@@ -245,8 +248,15 @@ FREERDP_API BOOL freerdp_shall_disconnect(freerdp* instance);
 FREERDP_API BOOL freerdp_disconnect(freerdp* instance);
 FREERDP_API BOOL freerdp_reconnect(freerdp* instance);
 
-FREERDP_API BOOL freerdp_get_fds(freerdp* instance, void** rfds, int* rcount, void** wfds, int* wcount);
-FREERDP_API BOOL freerdp_check_fds(freerdp* instance);
+/* Wait for a handle registered with freerdp_add_handle to be signalled.
+ * If return is FALSE, quit the event loop. */
+FREERDP_API DWORD freerdp_wait_for_event(freerdp* instance, DWORD timeout);
+/* Process pending events in main loop. */
+FREERDP_API BOOL freerdp_check_handles(freerdp* instance);
+
+/* Register / Unregister event sources for main loop. */
+FREERDP_API BOOL freerdp_add_handle(freerdp* instance, HANDLE handle);
+FREERDP_API BOOL freerdp_remove_handle(freerdp* instance, HANDLE handle);
 
 FREERDP_API wMessageQueue* freerdp_get_message_queue(freerdp* instance, DWORD id);
 FREERDP_API HANDLE freerdp_get_message_queue_event_handle(freerdp* instance, DWORD id);

--- a/libfreerdp/core/activation.c
+++ b/libfreerdp/core/activation.c
@@ -57,9 +57,7 @@ BOOL rdp_recv_server_synchronize_pdu(rdpRdp* rdp, wStream* s)
 BOOL rdp_send_server_synchronize_pdu(rdpRdp* rdp)
 {
 	wStream* s;
-
 	s = rdp_data_pdu_init(rdp);
-
 	rdp_write_synchronize_pdu(s, rdp->settings);
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_SYNCHRONIZE, rdp->mcs->userId);
 }
@@ -67,7 +65,6 @@ BOOL rdp_send_server_synchronize_pdu(rdpRdp* rdp)
 BOOL rdp_recv_client_synchronize_pdu(rdpRdp* rdp, wStream* s)
 {
 	UINT16 messageType;
-
 	rdp->finalize_sc_pdus |= FINALIZE_SC_SYNCHRONIZE_PDU;
 
 	if (Stream_GetRemainingLength(s) < 4)
@@ -80,18 +77,14 @@ BOOL rdp_recv_client_synchronize_pdu(rdpRdp* rdp, wStream* s)
 
 	/* targetUser (2 bytes) */
 	Stream_Seek_UINT16(s);
-
 	return TRUE;
 }
 
 BOOL rdp_send_client_synchronize_pdu(rdpRdp* rdp)
 {
 	wStream* s;
-
 	s = rdp_data_pdu_init(rdp);
-
 	rdp_write_synchronize_pdu(s, rdp->settings);
-
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_SYNCHRONIZE, rdp->mcs->userId);
 }
 
@@ -103,7 +96,6 @@ BOOL rdp_recv_control_pdu(wStream* s, UINT16* action)
 	Stream_Read_UINT16(s, *action); /* action (2 bytes) */
 	Stream_Seek_UINT16(s); /* grantId (2 bytes) */
 	Stream_Seek_UINT32(s); /* controlId (4 bytes) */
-
 	return TRUE;
 }
 
@@ -118,7 +110,7 @@ BOOL rdp_recv_server_control_pdu(rdpRdp* rdp, wStream* s)
 {
 	UINT16 action;
 
-	if(rdp_recv_control_pdu(s, &action) == FALSE)
+	if (rdp_recv_control_pdu(s, &action) == FALSE)
 		return FALSE;
 
 	switch (action)
@@ -139,36 +131,28 @@ BOOL rdp_recv_server_control_pdu(rdpRdp* rdp, wStream* s)
 BOOL rdp_send_server_control_cooperate_pdu(rdpRdp* rdp)
 {
 	wStream* s;
-
 	s = rdp_data_pdu_init(rdp);
-
 	Stream_Write_UINT16(s, CTRLACTION_COOPERATE); /* action (2 bytes) */
 	Stream_Write_UINT16(s, 0); /* grantId (2 bytes) */
 	Stream_Write_UINT32(s, 0); /* controlId (4 bytes) */
-
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_CONTROL, rdp->mcs->userId);
 }
 
 BOOL rdp_send_server_control_granted_pdu(rdpRdp* rdp)
 {
 	wStream* s;
-
 	s = rdp_data_pdu_init(rdp);
-
 	Stream_Write_UINT16(s, CTRLACTION_GRANTED_CONTROL); /* action (2 bytes) */
 	Stream_Write_UINT16(s, rdp->mcs->userId); /* grantId (2 bytes) */
 	Stream_Write_UINT32(s, 0x03EA); /* controlId (4 bytes) */
-
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_CONTROL, rdp->mcs->userId);
 }
 
 BOOL rdp_send_client_control_pdu(rdpRdp* rdp, UINT16 action)
 {
 	wStream* s;
-
 	s = rdp_data_pdu_init(rdp);
 	rdp_write_client_control_pdu(s, action);
-
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_CONTROL, rdp->mcs->userId);
 }
 
@@ -193,17 +177,14 @@ void rdp_write_client_persistent_key_list_pdu(wStream* s, rdpSettings* settings)
 	Stream_Write_UINT8(s, PERSIST_FIRST_PDU | PERSIST_LAST_PDU); /* bBitMask (1 byte) */
 	Stream_Write_UINT8(s, 0); /* pad1 (1 byte) */
 	Stream_Write_UINT16(s, 0); /* pad3 (2 bytes) */
-
 	/* entries */
 }
 
 BOOL rdp_send_client_persistent_key_list_pdu(rdpRdp* rdp)
 {
 	wStream* s;
-
 	s = rdp_data_pdu_init(rdp);
 	rdp_write_client_persistent_key_list_pdu(s, rdp->settings);
-
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_BITMAP_CACHE_PERSISTENT_LIST, rdp->mcs->userId);
 }
 
@@ -226,10 +207,8 @@ void rdp_write_client_font_list_pdu(wStream* s, UINT16 flags)
 BOOL rdp_send_client_font_list_pdu(rdpRdp* rdp, UINT16 flags)
 {
 	wStream* s;
-
 	s = rdp_data_pdu_init(rdp);
 	rdp_write_client_font_list_pdu(s, flags);
-
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_FONT_LIST, rdp->mcs->userId);
 }
 
@@ -251,7 +230,7 @@ BOOL rdp_recv_client_font_map_pdu(rdpRdp* rdp, wStream* s)
 {
 	rdp->finalize_sc_pdus |= FINALIZE_SC_FONT_MAP_PDU;
 
-	if(Stream_GetRemainingLength(s) >= 8)
+	if (Stream_GetRemainingLength(s) >= 8)
 	{
 		Stream_Seek_UINT16(s); /* numberEntries (2 bytes) */
 		Stream_Seek_UINT16(s); /* totalNumEntries (2 bytes) */
@@ -265,14 +244,11 @@ BOOL rdp_recv_client_font_map_pdu(rdpRdp* rdp, wStream* s)
 BOOL rdp_send_server_font_map_pdu(rdpRdp* rdp)
 {
 	wStream* s;
-
 	s = rdp_data_pdu_init(rdp);
-
 	Stream_Write_UINT16(s, 0); /* numberEntries (2 bytes) */
 	Stream_Write_UINT16(s, 0); /* totalNumEntries (2 bytes) */
 	Stream_Write_UINT16(s, FONTLIST_FIRST | FONTLIST_LAST); /* mapFlags (2 bytes) */
 	Stream_Write_UINT16(s, 4); /* entrySize (2 bytes) */
-
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_FONT_MAP, rdp->mcs->userId);
 }
 
@@ -308,14 +284,14 @@ BOOL rdp_recv_deactivate_all(rdpRdp* rdp, wStream* s)
 
 			Stream_Seek(s, lengthSourceDescriptor); /* sourceDescriptor (should be 0x00) */
 		}
-		while(0);
+		while (0);
 	}
 
 	rdp_client_transition_to_state(rdp, CONNECTION_STATE_CAPABILITIES_EXCHANGE);
 
 	while (rdp->state != CONNECTION_STATE_ACTIVE)
 	{
-		if (rdp_check_fds(rdp) < 0)
+		if (rdp_check_handles(rdp) < 0)
 			return FALSE;
 
 		if (rdp->disconnect)
@@ -329,18 +305,13 @@ BOOL rdp_send_deactivate_all(rdpRdp* rdp)
 {
 	wStream* s;
 	BOOL status;
-
 	s = Stream_New(NULL, 1024);
 	rdp_init_stream_pdu(rdp, s);
-
 	Stream_Write_UINT32(s, rdp->settings->ShareId); /* shareId (4 bytes) */
 	Stream_Write_UINT16(s, 1); /* lengthSourceDescriptor (2 bytes) */
 	Stream_Write_UINT8(s, 0); /* sourceDescriptor (should be 0x00) */
-
 	status = rdp_send_pdu(rdp, s, PDU_TYPE_DEACTIVATE_ALL, rdp->mcs->userId);
-
 	Stream_Free(s, TRUE);
-
 	return status;
 }
 

--- a/libfreerdp/core/client.h
+++ b/libfreerdp/core/client.h
@@ -104,6 +104,9 @@ struct rdp_channels
 	wMessageQueue* queue;
 
 	DrdynvcClientContext* drdynvc;
+
+	HANDLE* thread;
+	HANDLE* stopEvent;
 };
 
 #endif /* FREERDP_CORE_CLIENT_H */

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -211,7 +211,7 @@ BOOL freerdp_add_handle(freerdp* instance, HANDLE handle)
 
 BOOL freerdp_remove_handle(freerdp* instance, HANDLE handle)
 {
-	BOOL rc;;
+	BOOL rc;
 	rdpContext* ctx = (rdpContext*)instance->context;
 	SetEvent(ctx->insertHandle);
 	ArrayList_Lock(ctx->eventHandles);

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -37,40 +37,40 @@
 #ifdef WITH_DEBUG_RDP
 const char* DATA_PDU_TYPE_STRINGS[80] =
 {
-		"?", "?", /* 0x00 - 0x01 */
-		"Update", /* 0x02 */
-		"?", "?", "?", "?", "?", "?", "?", "?", /* 0x03 - 0x0A */
-		"?", "?", "?", "?", "?", "?", "?", "?", "?", /* 0x0B - 0x13 */
-		"Control", /* 0x14 */
-		"?", "?", "?", "?", "?", "?", /* 0x15 - 0x1A */
-		"Pointer", /* 0x1B */
-		"Input", /* 0x1C */
-		"?", "?", /* 0x1D - 0x1E */
-		"Synchronize", /* 0x1F */
-		"?", /* 0x20 */
-		"Refresh Rect", /* 0x21 */
-		"Play Sound", /* 0x22 */
-		"Suppress Output", /* 0x23 */
-		"Shutdown Request", /* 0x24 */
-		"Shutdown Denied", /* 0x25 */
-		"Save Session Info", /* 0x26 */
-		"Font List", /* 0x27 */
-		"Font Map", /* 0x28 */
-		"Set Keyboard Indicators", /* 0x29 */
-		"?", /* 0x2A */
-		"Bitmap Cache Persistent List", /* 0x2B */
-		"Bitmap Cache Error", /* 0x2C */
-		"Set Keyboard IME Status", /* 0x2D */
-		"Offscreen Cache Error", /* 0x2E */
-		"Set Error Info", /* 0x2F */
-		"Draw Nine Grid Error", /* 0x30 */
-		"Draw GDI+ Error", /* 0x31 */
-		"ARC Status", /* 0x32 */
-		"?", "?", "?", /* 0x33 - 0x35 */
-		"Status Info", /* 0x36 */
-		"Monitor Layout" /* 0x37 */
-		"FrameAcknowledge", "?", "?", /* 0x38 - 0x40 */
-		"?", "?", "?", "?", "?", "?" /* 0x41 - 0x46 */
+	"?", "?", /* 0x00 - 0x01 */
+	"Update", /* 0x02 */
+	"?", "?", "?", "?", "?", "?", "?", "?", /* 0x03 - 0x0A */
+	"?", "?", "?", "?", "?", "?", "?", "?", "?", /* 0x0B - 0x13 */
+	"Control", /* 0x14 */
+	"?", "?", "?", "?", "?", "?", /* 0x15 - 0x1A */
+	"Pointer", /* 0x1B */
+	"Input", /* 0x1C */
+	"?", "?", /* 0x1D - 0x1E */
+	"Synchronize", /* 0x1F */
+	"?", /* 0x20 */
+	"Refresh Rect", /* 0x21 */
+	"Play Sound", /* 0x22 */
+	"Suppress Output", /* 0x23 */
+	"Shutdown Request", /* 0x24 */
+	"Shutdown Denied", /* 0x25 */
+	"Save Session Info", /* 0x26 */
+	"Font List", /* 0x27 */
+	"Font Map", /* 0x28 */
+	"Set Keyboard Indicators", /* 0x29 */
+	"?", /* 0x2A */
+	"Bitmap Cache Persistent List", /* 0x2B */
+	"Bitmap Cache Error", /* 0x2C */
+	"Set Keyboard IME Status", /* 0x2D */
+	"Offscreen Cache Error", /* 0x2E */
+	"Set Error Info", /* 0x2F */
+	"Draw Nine Grid Error", /* 0x30 */
+	"Draw GDI+ Error", /* 0x31 */
+	"ARC Status", /* 0x32 */
+	"?", "?", "?", /* 0x33 - 0x35 */
+	"Status Info", /* 0x36 */
+	"Monitor Layout" /* 0x37 */
+	"FrameAcknowledge", "?", "?", /* 0x38 - 0x40 */
+	"?", "?", "?", "?", "?", "?" /* 0x41 - 0x46 */
 };
 #endif
 
@@ -86,6 +86,7 @@ BOOL rdp_read_security_header(wStream* s, UINT16* flags)
 	/* Basic Security Header */
 	if (Stream_GetRemainingLength(s) < 4)
 		return FALSE;
+
 	Stream_Read_UINT16(s, *flags); /* flags */
 	Stream_Seek(s, 2); /* flagsHi (unused) */
 	return TRUE;
@@ -140,7 +141,6 @@ BOOL rdp_read_share_control_header(wStream* s, UINT16* length, UINT16* type, UIN
 void rdp_write_share_control_header(wStream* s, UINT16 length, UINT16 type, UINT16 channel_id)
 {
 	length -= RDP_PACKET_HEADER_MAX_LENGTH;
-
 	/* Share Control Header */
 	Stream_Write_UINT16(s, length); /* totalLength */
 	Stream_Write_UINT16(s, type | 0x10); /* pduType */
@@ -148,7 +148,7 @@ void rdp_write_share_control_header(wStream* s, UINT16 length, UINT16 type, UINT
 }
 
 BOOL rdp_read_share_data_header(wStream* s, UINT16* length, BYTE* type, UINT32* shareId,
-					BYTE* compressedType, UINT16* compressedLength)
+								BYTE* compressedType, UINT16* compressedLength)
 {
 	if (Stream_GetRemainingLength(s) < 12)
 		return FALSE;
@@ -161,7 +161,6 @@ BOOL rdp_read_share_data_header(wStream* s, UINT16* length, BYTE* type, UINT32* 
 	Stream_Read_UINT8(s, *type); /* pduType2, Data PDU Type (1 byte) */
 	Stream_Read_UINT8(s, *compressedType); /* compressedType (1 byte) */
 	Stream_Read_UINT16(s, *compressedLength); /* compressedLength (2 bytes) */
-
 	return TRUE;
 }
 
@@ -170,7 +169,6 @@ void rdp_write_share_data_header(wStream* s, UINT16 length, BYTE type, UINT32 sh
 	length -= RDP_PACKET_HEADER_MAX_LENGTH;
 	length -= RDP_SHARE_CONTROL_HEADER_LENGTH;
 	length -= RDP_SHARE_DATA_HEADER_LENGTH;
-
 	/* Share Data Header */
 	Stream_Write_UINT32(s, share_id); /* shareId (4 bytes) */
 	Stream_Write_UINT8(s, 0); /* pad1 (1 byte) */
@@ -251,10 +249,8 @@ BOOL rdp_set_error_info(rdpRdp* rdp, UINT32 errorInfo)
 	{
 		ErrorInfoEventArgs e;
 		rdpContext* context = rdp->instance->context;
-
 		rdp->context->LastError = MAKE_FREERDP_ERROR(ERRINFO, errorInfo);
 		rdp_print_errinfo(rdp->errorInfo);
-
 		EventArgsInit(&e, "freerdp");
 		e.code = rdp->errorInfo;
 		PubSub_OnErrorInfo(context->pubSub, context, &e);
@@ -293,9 +289,7 @@ BOOL rdp_read_header(rdpRdp* rdp, wStream* s, UINT16* length, UINT16* channelId)
 	UINT16 initiator;
 	enum DomainMCSPDU MCSPDU;
 	enum DomainMCSPDU domainMCSPDU;
-
 	MCSPDU = (rdp->settings->ServerMode) ? DomainMCSPDU_SendDataRequest : DomainMCSPDU_SendDataIndication;
-
 	*length = tpkt_read_header(s);
 
 	if (!tpdu_read_header(s, &code, &li))
@@ -315,7 +309,7 @@ BOOL rdp_read_header(rdpRdp* rdp, wStream* s, UINT16* length, UINT16* channelId)
 	if (!per_read_choice(s, &choice))
 		return FALSE;
 
-	domainMCSPDU = (enum DomainMCSPDU) (choice >> 2);
+	domainMCSPDU = (enum DomainMCSPDU)(choice >> 2);
 
 	if (domainMCSPDU != MCSPDU)
 	{
@@ -325,7 +319,7 @@ BOOL rdp_read_header(rdpRdp* rdp, wStream* s, UINT16* length, UINT16* channelId)
 
 	MCSPDU = domainMCSPDU;
 
-	if ((size_t) (*length - 8) > Stream_GetRemainingLength(s))
+	if ((size_t)(*length - 8) > Stream_GetRemainingLength(s))
 		return FALSE;
 
 	if (MCSPDU == DomainMCSPDU_DisconnectProviderUltimatum)
@@ -352,7 +346,6 @@ BOOL rdp_read_header(rdpRdp* rdp, wStream* s, UINT16* length, UINT16* channelId)
 			 * when the user logs off like they should. Map DisconnectProviderUltimatum
 			 * to a ERRINFO_LOGOFF_BY_USER when the errinfo code is ERRINFO_SUCCESS.
 			 */
-
 			if (reason == MCS_Reason_provider_initiated)
 				rdp_set_error_info(rdp, ERRINFO_RPC_INITIATED_DISCONNECT);
 			else if (reason == MCS_Reason_user_requested)
@@ -363,11 +356,9 @@ BOOL rdp_read_header(rdpRdp* rdp, wStream* s, UINT16* length, UINT16* channelId)
 
 		WLog_ERR(TAG,  "DisconnectProviderUltimatum: reason: %d", reason);
 		rdp->disconnect = TRUE;
-
 		EventArgsInit(&e, "freerdp");
 		e.code = 0;
 		PubSub_OnTerminate(context->pubSub, context, &e);
-
 		return TRUE;
 	}
 
@@ -399,13 +390,11 @@ void rdp_write_header(rdpRdp* rdp, wStream* s, UINT16 length, UINT16 channelId)
 {
 	int body_length;
 	enum DomainMCSPDU MCSPDU;
-
 	MCSPDU = (rdp->settings->ServerMode) ? DomainMCSPDU_SendDataIndication : DomainMCSPDU_SendDataRequest;
 
 	if ((rdp->sec_flags & SEC_ENCRYPT) && (rdp->settings->EncryptionMethods == ENCRYPTION_METHOD_FIPS))
 	{
 		int pad;
-
 		body_length = length - RDP_PACKET_HEADER_MAX_LENGTH - 16;
 		pad = 8 - (body_length % 8);
 
@@ -431,7 +420,6 @@ static UINT32 rdp_security_stream_out(rdpRdp* rdp, wStream* s, int length, UINT3
 {
 	BYTE* data;
 	UINT32 pad = 0;
-
 	sec_flags |= rdp->sec_flags;
 
 	if (sec_flags != 0)
@@ -443,16 +431,15 @@ static UINT32 rdp_security_stream_out(rdpRdp* rdp, wStream* s, int length, UINT3
 			if (rdp->settings->EncryptionMethods == ENCRYPTION_METHOD_FIPS)
 			{
 				data = Stream_Pointer(s) + 12;
-
 				length = length - (data - Stream_Buffer(s));
 				Stream_Write_UINT16(s, 0x10); /* length */
 				Stream_Write_UINT8(s, 0x1); /* TSFIPS_VERSION 1*/
-
 				/* handle padding */
 				pad = 8 - (length % 8);
 
 				if (pad == 8)
 					pad = 0;
+
 				if (pad)
 					memset(data+length, 0, pad);
 
@@ -613,9 +600,7 @@ BOOL rdp_recv_server_set_keyboard_indicators_pdu(rdpRdp* rdp, wStream* s)
 
 	Stream_Read_UINT16(s, unitId); /* unitId (2 bytes) */
 	Stream_Read_UINT16(s, ledFlags); /* ledFlags (2 bytes) */
-
 	IFCALL(context->update->SetKeyboardIndicators, context, ledFlags);
-
 	return TRUE;
 }
 
@@ -699,7 +684,6 @@ BOOL rdp_recv_monitor_layout_pdu(rdpRdp* rdp, wStream* s)
 	}
 
 	free(monitorDefArray);
-
 	return TRUE;
 }
 
@@ -752,7 +736,6 @@ int rdp_recv_data_pdu(rdpRdp* rdp, wStream* s)
 		if (bulk_decompress(rdp->bulk, Stream_Pointer(s), SrcSize, &pDstData, &DstSize, compressedType))
 		{
 			cs = StreamPool_Take(rdp->transport->ReceivePool, DstSize);
-
 			Stream_SetPosition(cs, 0);
 			Stream_Write(cs, pDstData, DstSize);
 			Stream_SealLength(cs);
@@ -777,71 +760,85 @@ int rdp_recv_data_pdu(rdpRdp* rdp, wStream* s)
 		case DATA_PDU_TYPE_UPDATE:
 			if (!update_recv(rdp->update, cs))
 				return -1;
+
 			break;
 
 		case DATA_PDU_TYPE_CONTROL:
 			if (!rdp_recv_server_control_pdu(rdp, cs))
 				return -1;
+
 			break;
 
 		case DATA_PDU_TYPE_POINTER:
 			if (!update_recv_pointer(rdp->update, cs))
 				return -1;
+
 			break;
 
 		case DATA_PDU_TYPE_SYNCHRONIZE:
 			if (!rdp_recv_synchronize_pdu(rdp, cs))
 				return -1;
+
 			break;
 
 		case DATA_PDU_TYPE_PLAY_SOUND:
 			if (!update_recv_play_sound(rdp->update, cs))
 				return -1;
+
 			break;
 
 		case DATA_PDU_TYPE_SHUTDOWN_DENIED:
 			if (!rdp_recv_server_shutdown_denied_pdu(rdp, cs))
 				return -1;
+
 			break;
 
 		case DATA_PDU_TYPE_SAVE_SESSION_INFO:
 			if (!rdp_recv_save_session_info(rdp, cs))
 				return -1;
+
 			break;
 
 		case DATA_PDU_TYPE_FONT_MAP:
 			if (!rdp_recv_font_map_pdu(rdp, cs))
 				return -1;
+
 			break;
 
 		case DATA_PDU_TYPE_SET_KEYBOARD_INDICATORS:
 			if (!rdp_recv_server_set_keyboard_indicators_pdu(rdp, cs))
 				return -1;
+
 			break;
 
 		case DATA_PDU_TYPE_SET_KEYBOARD_IME_STATUS:
 			if (!rdp_recv_server_set_keyboard_ime_status_pdu(rdp, cs))
 				return -1;
+
 			break;
 
 		case DATA_PDU_TYPE_SET_ERROR_INFO:
 			if (!rdp_recv_set_error_info_data_pdu(rdp, cs))
 				return -1;
+
 			break;
 
 		case DATA_PDU_TYPE_ARC_STATUS:
 			if (!rdp_recv_server_auto_reconnect_status_pdu(rdp, cs))
 				return -1;
+
 			break;
 
 		case DATA_PDU_TYPE_STATUS_INFO:
 			if (!rdp_recv_server_status_info_pdu(rdp, cs))
 				return -1;
+
 			break;
 
 		case DATA_PDU_TYPE_MONITOR_LAYOUT:
 			if (!rdp_recv_monitor_layout_pdu(rdp, cs))
 				return -1;
+
 			break;
 
 		default:
@@ -906,8 +903,8 @@ int rdp_recv_out_of_sequence_pdu(rdpRdp* rdp, wStream* s)
 		return rdp_recv_enhanced_security_redirection_packet(rdp, s);
 	}
 	else if (type == PDU_TYPE_FLOW_RESPONSE ||
-		 type == PDU_TYPE_FLOW_STOP ||
-		 type == PDU_TYPE_FLOW_TEST)
+			 type == PDU_TYPE_FLOW_STOP ||
+			 type == PDU_TYPE_FLOW_TEST)
 	{
 		return 0;
 	}
@@ -959,10 +956,8 @@ BOOL rdp_decrypt(rdpRdp* rdp, wStream* s, int length, UINT16 securityFlags)
 		Stream_Read_UINT16(s, len); /* 0x10 */
 		Stream_Read_UINT8(s, version); /* 0x1 */
 		Stream_Read_UINT8(s, pad);
-
 		sig = Stream_Pointer(s);
 		Stream_Seek(s, 8);	/* signature */
-
 		length -= 12;
 
 		if (!security_fips_decrypt(Stream_Pointer(s), length, rdp))
@@ -1035,7 +1030,7 @@ static int rdp_recv_tpkt_pdu(rdpRdp* rdp, wStream* s)
 
 	if (rdp->disconnect)
 		return 0;
- 
+
 	if (rdp->autodetect->bandwidthMeasureStarted)
 	{
 		rdp->autodetect->bandwidthMeasureByteCount += length;
@@ -1062,7 +1057,6 @@ static int rdp_recv_tpkt_pdu(rdpRdp* rdp, wStream* s)
 			 *  - no share control header, nor the 2 byte pad
 			 */
 			Stream_Rewind(s, 2);
-
 			return rdp_recv_enhanced_security_redirection_packet(rdp, s);
 		}
 	}
@@ -1077,7 +1071,6 @@ static int rdp_recv_tpkt_pdu(rdpRdp* rdp, wStream* s)
 				return -1;
 
 			nextPosition += pduLength;
-
 			rdp->settings->PduSource = pduSource;
 
 			switch (pduType)
@@ -1088,17 +1081,19 @@ static int rdp_recv_tpkt_pdu(rdpRdp* rdp, wStream* s)
 						WLog_ERR(TAG,  "rdp_recv_data_pdu failed");
 						return -1;
 					}
+
 					break;
 
 				case PDU_TYPE_DEACTIVATE_ALL:
 					if (!rdp_recv_deactivate_all(rdp, s))
 						return -1;
+
 					break;
 
 				case PDU_TYPE_SERVER_REDIRECTION:
 					return rdp_recv_enhanced_security_redirection_packet(rdp, s);
 					break;
-					
+
 				case PDU_TYPE_FLOW_RESPONSE:
 				case PDU_TYPE_FLOW_STOP:
 				case PDU_TYPE_FLOW_TEST:
@@ -1129,7 +1124,6 @@ static int rdp_recv_fastpath_pdu(rdpRdp* rdp, wStream* s)
 {
 	UINT16 length;
 	rdpFastPath* fastpath;
-
 	fastpath = rdp->fastpath;
 
 	if (!fastpath_read_header_rdp(fastpath, s, &length))
@@ -1170,14 +1164,14 @@ static int rdp_recv_callback(rdpTransport* transport, wStream* s, void* extra)
 	int status = 0;
 	rdpRdp* rdp = (rdpRdp*) extra;
 
-	/* 
+	/*
 	 * At any point in the connection sequence between when all
 	 * MCS channels have been joined and when the RDP connection
 	 * enters the active state, an auto-detect PDU can be received
 	 * on the MCS message channel.
 	 */
 	if ((rdp->state > CONNECTION_STATE_MCS_CHANNEL_JOIN) &&
-		(rdp->state < CONNECTION_STATE_ACTIVE))
+			(rdp->state < CONNECTION_STATE_ACTIVE))
 	{
 		if (rdp_client_connect_auto_detect(rdp, s))
 			return 0;
@@ -1188,16 +1182,19 @@ static int rdp_recv_callback(rdpTransport* transport, wStream* s, void* extra)
 		case CONNECTION_STATE_NEGO:
 			if (!rdp_client_connect_mcs_connect_response(rdp, s))
 				status = -1;
+
 			break;
 
 		case CONNECTION_STATE_MCS_ATTACH_USER:
 			if (!rdp_client_connect_mcs_attach_user_confirm(rdp, s))
 				status = -1;
+
 			break;
 
 		case CONNECTION_STATE_MCS_CHANNEL_JOIN:
 			if (!rdp_client_connect_mcs_channel_join_confirm(rdp, s))
 				status = -1;
+
 			break;
 
 		case CONNECTION_STATE_LICENSING:
@@ -1216,6 +1213,7 @@ static int rdp_recv_callback(rdpTransport* transport, wStream* s, void* extra)
 				rdp_client_transition_to_state(rdp, CONNECTION_STATE_ACTIVE);
 				return 2;
 			}
+
 			break;
 
 		case CONNECTION_STATE_ACTIVE:
@@ -1245,11 +1243,8 @@ BOOL rdp_send_error_info(rdpRdp* rdp)
 		return TRUE;
 
 	s = rdp_data_pdu_init(rdp);
-
 	Stream_Write_UINT32(s, rdp->errorInfo); /* error id (4 bytes) */
-
 	status = rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_SET_ERROR_INFO, 0);
-
 	return status;
 }
 
@@ -1265,11 +1260,10 @@ void rdp_set_blocking_mode(rdpRdp* rdp, BOOL blocking)
 	transport_set_blocking_mode(rdp->transport, blocking);
 }
 
-int rdp_check_fds(rdpRdp* rdp)
+int rdp_check_handles(rdpRdp* rdp)
 {
 	int status;
-
-	status = transport_check_fds(rdp->transport);
+	status = transport_check_handles(rdp->transport);
 
 	if (status == 1)
 	{
@@ -1289,7 +1283,6 @@ rdpRdp* rdp_new(rdpContext* context)
 	rdpRdp* rdp;
 	DWORD flags;
 	BOOL newSettings = FALSE;
-
 	rdp = (rdpRdp*) calloc(1, sizeof(rdpRdp));
 
 	if (!rdp)
@@ -1297,7 +1290,6 @@ rdpRdp* rdp_new(rdpContext* context)
 
 	rdp->context = context;
 	rdp->instance = context->instance;
-
 	flags = 0;
 
 	if (context->ServerMode)
@@ -1306,14 +1298,16 @@ rdpRdp* rdp_new(rdpContext* context)
 	if (!context->settings)
 	{
 		context->settings = freerdp_settings_new(flags);
+
 		if (!context->settings)
 			goto out_free;
+
 		newSettings = TRUE;
 	}
 
 	rdp->settings = context->settings;
 	rdp->settings->instance = context->instance;
-	
+
 	if (context->instance)
 		context->instance->settings = rdp->settings;
 
@@ -1321,55 +1315,64 @@ rdpRdp* rdp_new(rdpContext* context)
 
 	if (!rdp->transport)
 		goto out_free_settings;
-	
-	rdp->transport->rdp = rdp;
 
+	rdp->transport->rdp = rdp;
 	rdp->license = license_new(rdp);
+
 	if (!rdp->license)
 		goto out_free_transport;
 
 	rdp->input = input_new(rdp);
+
 	if (!rdp->input)
 		goto out_free_license;
 
 	rdp->update = update_new(rdp);
+
 	if (!rdp->update)
 		goto out_free_input;
 
 	rdp->fastpath = fastpath_new(rdp);
+
 	if (!rdp->fastpath)
 		goto out_free_update;
 
 	rdp->nego = nego_new(rdp->transport);
+
 	if (!rdp->nego)
 		goto out_free_fastpath;
 
 	rdp->mcs = mcs_new(rdp->transport);
+
 	if (!rdp->mcs)
 		goto out_free_nego;
 
 	rdp->redirection = redirection_new();
+
 	if (!rdp->redirection)
 		goto out_free_mcs;
 
 	rdp->autodetect = autodetect_new();
+
 	if (!rdp->autodetect)
 		goto out_free_redirection;
 
 	rdp->heartbeat = heartbeat_new();
+
 	if (!rdp->heartbeat)
 		goto out_free_autodetect;
 
 	rdp->multitransport = multitransport_new();
+
 	if (!rdp->multitransport)
 		goto out_free_heartbeat;
 
 	rdp->bulk = bulk_new(context);
+
 	if (!rdp->bulk)
 		goto out_free_multitransport;
 
 	return rdp;
-
 out_free_multitransport:
 	multitransport_free(rdp->multitransport);
 out_free_heartbeat:
@@ -1393,8 +1396,10 @@ out_free_license:
 out_free_transport:
 	transport_free(rdp->transport);
 out_free_settings:
+
 	if (newSettings)
 		freerdp_settings_free(rdp->settings);
+
 out_free:
 	free(rdp);
 	return NULL;
@@ -1404,12 +1409,9 @@ void rdp_reset(rdpRdp* rdp)
 {
 	rdpContext* context;
 	rdpSettings* settings;
-
 	context = rdp->context;
 	settings = rdp->settings;
-
 	bulk_reset(rdp->bulk);
-
 	crypto_rc4_free(rdp->rc4_decrypt_key);
 	rdp->rc4_decrypt_key = NULL;
 	crypto_rc4_free(rdp->rc4_encrypt_key);
@@ -1420,19 +1422,16 @@ void rdp_reset(rdpRdp* rdp)
 	rdp->fips_decrypt = NULL;
 	crypto_hmac_free(rdp->fips_hmac);
 	rdp->fips_hmac = NULL;
-
 	mcs_free(rdp->mcs);
 	nego_free(rdp->nego);
 	license_free(rdp->license);
 	transport_free(rdp->transport);
-
 	free(settings->ServerRandom);
 	settings->ServerRandom = NULL;
 	free(settings->ServerCertificate);
 	settings->ServerCertificate = NULL;
 	free(settings->ClientAddress);
 	settings->ClientAddress = NULL;
-
 	rdp->transport = transport_new(context);
 	rdp->transport->rdp = rdp;
 	rdp->license = license_new(rdp);

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -182,8 +182,8 @@ void rdp_write_security_header(wStream* s, UINT16 flags);
 BOOL rdp_read_share_control_header(wStream* s, UINT16* length, UINT16* type, UINT16* channel_id);
 void rdp_write_share_control_header(wStream* s, UINT16 length, UINT16 type, UINT16 channel_id);
 
-BOOL rdp_read_share_data_header(wStream* s, UINT16* length, BYTE* type, UINT32* share_id, 
-			BYTE *compressed_type, UINT16 *compressed_len);
+BOOL rdp_read_share_data_header(wStream* s, UINT16* length, BYTE* type, UINT32* share_id,
+								BYTE* compressed_type, UINT16* compressed_len);
 
 void rdp_write_share_data_header(wStream* s, UINT16 length, BYTE type, UINT32 share_id);
 
@@ -214,7 +214,7 @@ int rdp_recv_out_of_sequence_pdu(rdpRdp* rdp, wStream* s);
 void rdp_read_flow_control_pdu(wStream* s, UINT16* type);
 
 void rdp_set_blocking_mode(rdpRdp* rdp, BOOL blocking);
-int rdp_check_fds(rdpRdp* rdp);
+int rdp_check_handles(rdpRdp* rdp);
 
 rdpRdp* rdp_new(rdpContext* context);
 void rdp_reset(rdpRdp* rdp);

--- a/libfreerdp/core/transport.h
+++ b/libfreerdp/core/transport.h
@@ -50,12 +50,12 @@ typedef struct rdp_transport rdpTransport;
 #include <freerdp/settings.h>
 
 
-typedef int (*TransportRecv) (rdpTransport* transport, wStream* stream, void* extra);
+typedef int (*TransportRecv)(rdpTransport* transport, wStream* stream, void* extra);
 
 struct rdp_transport
 {
 	TRANSPORT_LAYER layer;
-	BIO *frontBio;
+	BIO* frontBio;
 	rdpTsg* tsg;
 	rdpTcp* TcpIn;
 	rdpTcp* TcpOut;
@@ -99,12 +99,10 @@ BOOL transport_accept_nla(rdpTransport* transport);
 void transport_stop(rdpTransport* transport);
 int transport_read_pdu(rdpTransport* transport, wStream* s);
 int transport_write(rdpTransport* transport, wStream* s);
-void transport_get_fds(rdpTransport* transport, void** rfds, int* rcount);
-int transport_check_fds(rdpTransport* transport);
+int transport_check_handles(rdpTransport* transport);
 BOOL transport_set_blocking_mode(rdpTransport* transport, BOOL blocking);
 void transport_set_gateway_enabled(rdpTransport* transport, BOOL GatewayEnabled);
 void transport_set_nla_mode(rdpTransport* transport, BOOL NlaMode);
-void transport_get_read_handles(rdpTransport* transport, HANDLE* events, DWORD* count);
 BOOL tranport_is_write_blocked(rdpTransport* transport);
 int tranport_drain_output_buffer(rdpTransport* transport);
 

--- a/scripts/format_code.sh
+++ b/scripts/format_code.sh
@@ -30,9 +30,9 @@ if [ $# -le 0 ]; then
   exit 2
 fi
 
-$ASTYLE --lineend=linux --mode=c --indent=force-tab=4 --brackets=linux --pad-header \
+$ASTYLE --lineend=linux --mode=c --indent=force-tab=4 --pad-header \
 							   --indent-switches --indent-cases --indent-preprocessor \
 							   --indent-col1-comments --delete-empty-lines --break-closing-brackets \
-							   --align-pointer=type --indent-labels --brackets=break \
+							   --align-pointer=type --indent-labels \
 							   --unpad-paren --break-blocks $@
 							   exit $?

--- a/server/shadow/Win/win_rdp.c
+++ b/server/shadow/Win/win_rdp.c
@@ -191,37 +191,16 @@ void* shw_client_thread(void* arg)
 	channels = instance->context->channels;
 
 	while (1)
-	{
-		rcount = 0;
-		wcount = 0;
+	{	
+		DWORD ev = freerdp_wait_for_event(instance, INFINITE);
 
-		if (!freerdp_get_fds(instance, rfds, &rcount, wfds, &wcount))
-		{
-			WLog_ERR(TAG, "Failed to get FreeRDP file descriptor");
-			break;
-		}
-
-		if (!freerdp_channels_get_fds(channels, instance, rfds, &rcount, wfds, &wcount))
-		{
-			WLog_ERR(TAG, "Failed to get channels file descriptor");
-			break;
-		}
-
-		fds_count = 0;
-		
-		for (index = 0; index < rcount; index++)
-			fds[fds_count++] = rfds[index];
-
-		for (index = 0; index < wcount; index++)
-			fds[fds_count++] = wfds[index];
-
-		if (MsgWaitForMultipleObjects(fds_count, fds, FALSE, 1000, QS_ALLINPUT) == WAIT_FAILED)
+		if (WAIT_FAILED == ev)
 		{
 			WLog_ERR(TAG, "MsgWaitForMultipleObjects failure: 0x%08X", GetLastError());
 			break;
 		}
 
-		if (!freerdp_check_fds(instance))
+		if (!freerdp_check_handles(instance))
 		{
 			WLog_ERR(TAG, "Failed to check FreeRDP file descriptor");
 			break;
@@ -229,12 +208,6 @@ void* shw_client_thread(void* arg)
 
 		if (freerdp_shall_disconnect(instance))	
 		{
-			break;
-		}
-
-		if (!freerdp_channels_check_fds(channels, instance))
-		{
-			WLog_ERR(TAG, "Failed to check channels file descriptor");
 			break;
 		}
 	}

--- a/server/shadow/Win/win_rdp.c
+++ b/server/shadow/Win/win_rdp.c
@@ -191,8 +191,17 @@ void* shw_client_thread(void* arg)
 	channels = instance->context->channels;
 
 	while (1)
-	{	
-		DWORD ev = freerdp_wait_for_event(instance, INFINITE);
+	{
+		DWORD ev;
+		DWORD count;
+		HANDLE *handles;
+
+		count = freerdp_get_and_lock_handles(instance, &handles);
+		if (count > 0)
+		{
+			ev = WaitForMultipleObjects(count, handles, FALSE, INFINITE);
+			freerdp_unlock_handles(instance, handles, count);
+		}
 
 		if (WAIT_FAILED == ev)
 		{


### PR DESCRIPTION
This pull replaces the ```select``` and ```*_fds``` functions used by clients with functions allowing to
* Register event handles to main loop 
* Remove event handles to main loop
* A function waiting for an event to happen

The current implementation of async channels has also been moved to the library automatically adding support to all clients.

This pull changes a lot of files and all clients, so please check for breakage.
I'd welcome feedback on the current modifications, if something is missing / could be done better let me know.