### PR TITLE
Compatibility cmdline fix

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -509,7 +509,7 @@ static char** freerdp_command_line_parse_comma_separated_values(char* list, int*
 	int index;
 	int nCommas;
 
-	nArgs = nCommas = 0;
+	nCommas = 0;
 
 	assert(NULL != count);
 
@@ -1080,7 +1080,8 @@ BOOL freerdp_client_detect_command_line(int argc, char** argv, DWORD* flags)
 	if (posix_cli_status <= COMMAND_LINE_STATUS_PRINT)
 		return compatibility;
 
-	if (windows_cli_count >= posix_cli_count)
+	/* Check, if this may be windows style syntax... */
+	if (windows_cli_count && (windows_cli_count >= posix_cli_count))
 	{
 		*flags = COMMAND_LINE_SEPARATOR_COLON;
 		*flags |= COMMAND_LINE_SIGIL_SLASH | COMMAND_LINE_SIGIL_PLUS_MINUS;
@@ -1189,7 +1190,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 			return status;
 	}
 
-	arg = CommandLineFindArgumentA(args, "v");
+	CommandLineFindArgumentA(args, "v");
 
 	arg = args;
 

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1081,8 +1081,9 @@ BOOL freerdp_client_detect_command_line(int argc, char** argv, DWORD* flags)
 		return compatibility;
 
 	/* Check, if this may be windows style syntax... */
-	if (windows_cli_count && (windows_cli_count >= posix_cli_count))
+	if (windows_cli_count && (windows_cli_count >= posix_cli_count) || (windows_cli_status <= COMMAND_LINE_STATUS_PRINT))
 	{
+		windows_cli_count = 1;
 		*flags = COMMAND_LINE_SEPARATOR_COLON;
 		*flags |= COMMAND_LINE_SIGIL_SLASH | COMMAND_LINE_SIGIL_PLUS_MINUS;
 	}

--- a/client/common/compatibility.c
+++ b/client/common/compatibility.c
@@ -122,16 +122,20 @@ void freerdp_client_old_parse_hostname(char* str, char** ServerHostname, UINT32*
 
 int freerdp_client_old_process_plugin(rdpSettings* settings, ADDIN_ARGV* args)
 {
+	int args_handled = 0;
 	if (strcmp(args->argv[0], "cliprdr") == 0)
 	{
+		args_handled++;
 		settings->RedirectClipboard = TRUE;
 		WLog_WARN(TAG,  "--plugin cliprdr -> +clipboard");
 	}
 	else if (strcmp(args->argv[0], "rdpdr") == 0)
 	{
+		args_handled++;
 		if (args->argc < 2)
-			return -1;
+			return 1;
 
+		args_handled++;
 		if ((strcmp(args->argv[1], "disk") == 0) ||
 			(strcmp(args->argv[1], "drive") == 0))
 		{
@@ -159,21 +163,26 @@ int freerdp_client_old_process_plugin(rdpSettings* settings, ADDIN_ARGV* args)
 	}
 	else if (strcmp(args->argv[0], "drdynvc") == 0)
 	{
+		args_handled++;
 		freerdp_client_add_dynamic_channel(settings, args->argc - 1, &args->argv[1]);
 	}
 	else if (strcmp(args->argv[0], "rdpsnd") == 0)
 	{
+		args_handled++;
 		if (args->argc < 2)
-			return -1;
+			return 1;
 
+		args_handled++;
 		freerdp_addin_replace_argument_value(args, args->argv[1], "sys", args->argv[1]);
 		freerdp_client_add_static_channel(settings, args->argc, args->argv);
 	}
 	else if (strcmp(args->argv[0], "rail") == 0)
 	{
+		args_handled++;
 		if (args->argc < 2)
-			return -1;
+			return 1;
 
+		args_handled++;
 		settings->RemoteApplicationProgram = _strdup(args->argv[1]);
 	}
 	else
@@ -181,14 +190,12 @@ int freerdp_client_old_process_plugin(rdpSettings* settings, ADDIN_ARGV* args)
 		freerdp_client_add_static_channel(settings, args->argc, args->argv);
 	}
 
-	return 1;
+	return args_handled;
 }
 
 int freerdp_client_old_command_line_pre_filter(void* context, int index, int argc, LPCSTR* argv)
 {
-	rdpSettings* settings;
-
-	settings = (rdpSettings*) context;
+	rdpSettings* settings = (rdpSettings*) context;
 
 	if (index == (argc - 1))
 	{
@@ -217,6 +224,7 @@ int freerdp_client_old_command_line_pre_filter(void* context, int index, int arg
 
 	if (strcmp("--plugin", argv[index]) == 0)
 	{
+		int args_handled = 0;
 		int length;
 		char *a, *p;
 		int i, j, t;
@@ -232,7 +240,7 @@ int freerdp_client_old_command_line_pre_filter(void* context, int index, int arg
 			return -1;
 
 		args = (ADDIN_ARGV*) malloc(sizeof(ADDIN_ARGV));
-		args->argv = (char**) malloc(sizeof(char*) * 5);
+		args->argv = (char**) calloc(argc, sizeof(char*));
 		args->argc = 1;
 
 		args->argv[0] = _strdup(argv[t]);
@@ -241,10 +249,10 @@ int freerdp_client_old_command_line_pre_filter(void* context, int index, int arg
 		{
 			i = 0;
 			index += 2;
-			args->argc = 1;
 
 			while ((index < argc) && (strcmp("--", argv[index]) != 0))
 			{
+				args_handled ++;
 				args->argc = 1;
 
 				for (j = 0, p = (char*) argv[index]; (j < 4) && (p != NULL); j++)
@@ -283,7 +291,7 @@ int freerdp_client_old_command_line_pre_filter(void* context, int index, int arg
 					args->argc++;
 				}
 
-				if (settings && settings->instance)
+				if (settings)
 				{
 					freerdp_client_old_process_plugin(settings, args);
 				}
@@ -296,19 +304,16 @@ int freerdp_client_old_command_line_pre_filter(void* context, int index, int arg
 		{
 			if (settings)
 			{
-				if (settings->instance)
-				{
-					freerdp_client_old_process_plugin(settings, args);
-				}
+				args_handled = freerdp_client_old_process_plugin(settings, args);
 			}
 		}
 
-		for (i = 0; i < args->argc; i++)
+		for (i = 0; i < argc; i++)
 			free(args->argv[i]);
 		free(args->argv);
 		free(args);
 
-		return (index - old_index);
+		return (index - old_index) + args_handled;
 	}
 
 	return 0;

--- a/client/common/compatibility.c
+++ b/client/common/compatibility.c
@@ -243,8 +243,6 @@ int freerdp_client_old_command_line_pre_filter(void* context, int index, int arg
 		args->argv = (char**) calloc(argc, sizeof(char*));
 		args->argc = 1;
 
-		args->argv[0] = _strdup(argv[t]);
-
 		if ((index < argc - 1) && strcmp("--data", argv[index + 1]) == 0)
 		{
 			i = 0;
@@ -254,6 +252,7 @@ int freerdp_client_old_command_line_pre_filter(void* context, int index, int arg
 			{
 				args_handled ++;
 				args->argc = 1;
+				args->argv[0] = _strdup(argv[t]);
 
 				for (j = 0, p = (char*) argv[index]; (j < 4) && (p != NULL); j++)
 				{
@@ -296,6 +295,9 @@ int freerdp_client_old_command_line_pre_filter(void* context, int index, int arg
 					freerdp_client_old_process_plugin(settings, args);
 				}
 
+				for (i = 0; i < args->argc; i++)
+					free(args->argv[i]);
+				memset(args->argv, 0, argc * sizeof(char*));
 				index++;
 				i++;
 			}
@@ -304,12 +306,12 @@ int freerdp_client_old_command_line_pre_filter(void* context, int index, int arg
 		{
 			if (settings)
 			{
+				args->argv[0] = _strdup(argv[t]);
 				args_handled = freerdp_client_old_process_plugin(settings, args);
+				free (args->argv[0]);
 			}
 		}
 
-		for (i = 0; i < argc; i++)
-			free(args->argv[i]);
 		free(args->argv);
 		free(args);
 

--- a/client/common/compatibility.c
+++ b/client/common/compatibility.c
@@ -204,11 +204,10 @@ int freerdp_client_old_command_line_pre_filter(void* context, int index, int arg
 				return -1;
 			}
 
-			if (settings)
-			{
-				freerdp_client_old_parse_hostname((char*) argv[index],
-						&settings->ServerHostname, &settings->ServerPort);
-			}
+			freerdp_client_old_parse_hostname((char*) argv[index],
+					&settings->ServerHostname, &settings->ServerPort);
+
+			return 2;
 		}
 		else
 		{

--- a/client/common/compatibility.c
+++ b/client/common/compatibility.c
@@ -266,6 +266,9 @@ int freerdp_client_old_command_line_pre_filter(void* context, int index, int arg
 					if (p != NULL)
 					{
 						p = strchr(p, ':');
+					}
+					if (p != NULL)
+					{
 						length = (int) (p - a);
 						args->argv[j + 1] = (char*) malloc(length + 1);
 						CopyMemory(args->argv[j + 1], a, length);


### PR DESCRIPTION
Fixed parsing and detection of old command line.
Tested the command lines from #2172, #2306 and the referenced external issues.

The fix is (mostly) restricted to compatibility command line, but also fixes detection of version and help arguments in windows and posix command line versions.

Obsoletes #2305, which does not properly fix command line detection and keeps compatibility parsing broken.