### PR TITLE
Fixed SetLastError test.

### DIFF
--- a/winpr/libwinpr/error/test/TestErrorSetLastError.c
+++ b/winpr/libwinpr/error/test/TestErrorSetLastError.c
@@ -60,6 +60,11 @@ int TestErrorSetLastError(int argc, char* argv[])
 	DWORD error;
 	HANDLE threads[4];
 
+	/* We must initialize WLog here. It will check for settings
+	 * in the environment and if the variables are not set, the last
+	 * error state is changed... */
+	WLog_GetRoot();
+
 	SetLastError(ERROR_ACCESS_DENIED);
 
 	error = GetLastError();


### PR DESCRIPTION
WLog initialisation checks environment variables, which may not exist
and therefore set an error. So initialise it before doing tests.