### PR TITLE
build: improve wayland detection

### DIFF
--- a/cmake/FindWayland.cmake
+++ b/cmake/FindWayland.cmake
@@ -8,10 +8,12 @@
 #
 #     WAYLAND_INCLUDE_DIR  - where to find wayland-client.h, etc.
 #     WAYLAND_LIBRARY      - the Wayland client library
+#     WAYLAND_VERSION      - wayland client version if found and pkg-config was used
 #
 
 #=============================================================================
 # Copyright 2014 Manuel Bachmann <tarnyko@tarnyko.net>
+# Copyright 2015 Bernhard Miklautz <bernhard.miklautz@shacknet.at>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,21 +28,38 @@
 # limitations under the License.
 #=============================================================================
 
+set(REQUIRED_WAYLAND_CLIENT_VERSION 0.95)
+include(FindPkgConfig)
+
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(WAYLAND wayland-client)
+endif()
+
 find_path(WAYLAND_INCLUDE_DIR NAMES wayland-client.h
+          PATHS ${WAYLAND_INCLUDE_DIRS}
           DOC "The Wayland include directory"
 )
 
 find_library(WAYLAND_LIBRARY NAMES wayland-client
+          PATHS ${WAYLAND_LIBRARY_DIRS}
           DOC "The Wayland client library"
 )
 
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(WAYLAND DEFAULT_MSG WAYLAND_LIBRARY WAYLAND_INCLUDE_DIR)
 
-if(WAYLAND_FOUND)
-  set( WAYLAND_LIBRARIES ${WAYLAND_LIBRARY} )
-  set( WAYLAND_INCLUDE_DIRS ${WAYLAND_INCLUDE_DIR} )
+if(WAYLAND_VERSION)
+	if (${WAYLAND_VERSION} VERSION_LESS ${REQUIRED_WAYLAND_CLIENT_VERSION})
+		message(WARNING "Installed wayland version ${WAYLAND_VERSION} is too old - minimum required version ${REQUIRED_WAYLAND_CLIENT_VERSION}")
+		set(WAYLAND_FOUND FALSE)
+	endif()
+else()
+		message(WARNING "Couldn't detect wayland version - no version check is done")
 endif()
 
-mark_as_advanced(WAYLAND_INCLUDE_DIR WAYLAND_LIBRARY)
+if(WAYLAND_FOUND)
+  set(WAYLAND_LIBRARIES ${WAYLAND_LIBRARY})
+  set(WAYLAND_INCLUDE_DIRS ${WAYLAND_INCLUDE_DIR})
+endif()
 
+mark_as_advanced(WAYLAND_INCLUDE_DIR WAYLAND_LIBRARY WAYLAND_VERSION)


### PR DESCRIPTION
* add support to check wayland client version
* set minimum required version to 0.95

This fixes build problems when wayland libraries where found (automatically detected as recommended feature)
but the installed version was to old to build the wayland client.