### PR TITLE
Fixes cleanup when closing a dynamic channel.

### DIFF
--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -321,11 +321,8 @@ static int dvcman_write_channel(IWTSVirtualChannel* pChannel, UINT32 cbSize, BYT
 static int dvcman_close_channel_iface(IWTSVirtualChannel* pChannel)
 {
 	DVCMAN_CHANNEL* channel = (DVCMAN_CHANNEL*) pChannel;
-	DVCMAN* dvcman = channel->dvcman;
 
 	WLog_DBG(TAG, "id=%d", channel->channel_id);
-
-	ArrayList_Remove(dvcman->channels, channel);
 
 	return 1;
 }
@@ -429,6 +426,8 @@ int dvcman_close_channel(IWTSVirtualChannelManager* pChannelMgr, UINT32 ChannelI
 		if (ichannel->Close)
 			ichannel->Close(ichannel);
 	}
+
+	ArrayList_Remove(dvcman->channels, channel);
 
 	return 0;
 }


### PR DESCRIPTION
The resource cleanup was executed twice for each dynamic channel.
Now cleaning up the resources by array list free callback and only
when closing the channel.

@awakecoding Hope the list cleanup in ```dvcman_close_channel_iface``` is the place to do it?