### PR TITLE
Fixed buffer size checks in h264_decompress

### DIFF
--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -353,7 +353,8 @@ int xf_SurfaceCommand_H264(xfContext* xfc, RdpgfxClientContext* context, RDPGFX_
 	DstData = surface->data;
 
 	status = h264_decompress(xfc->codecs->h264, bs->data, bs->length, &DstData,
-			surface->format, surface->scanline , surface->height, meta->regionRects, meta->numRegionRects);
+							 surface->format, surface->scanline , surface->width,
+							 surface->height, meta->regionRects, meta->numRegionRects);
 
 	if (status < 0)
 	{

--- a/include/freerdp/codec/h264.h
+++ b/include/freerdp/codec/h264.h
@@ -61,7 +61,8 @@ extern "C" {
 FREERDP_API int h264_compress(H264_CONTEXT* h264, BYTE* pSrcData, UINT32 SrcSize, BYTE** ppDstData, UINT32* pDstSize);
 
 FREERDP_API int h264_decompress(H264_CONTEXT* h264, BYTE* pSrcData, UINT32 SrcSize,
-		BYTE** ppDstData, DWORD DstFormat, int nDstStep, int nDstHeight, RDPGFX_RECT16* regionRects, int numRegionRect);
+		BYTE** ppDstData, DWORD DstFormat, int nDstStep, int nDstWidth, int nDstHeight,
+		RDPGFX_RECT16* regionRects, int numRegionRect);
 
 FREERDP_API int h264_context_reset(H264_CONTEXT* h264);
 

--- a/libfreerdp/codec/h264.c
+++ b/libfreerdp/codec/h264.c
@@ -435,7 +435,6 @@ int h264_decompress(H264_CONTEXT* h264, BYTE* pSrcData, UINT32 SrcSize,
 	int width, height;
 	BYTE* pYUVPoint[3];
 	RDPGFX_RECT16* rect;
-	int UncompressedSize;
 	primitives_t *prims = primitives_get();
 
 	if (!h264)
@@ -451,11 +450,6 @@ int h264_decompress(H264_CONTEXT* h264, BYTE* pSrcData, UINT32 SrcSize,
 
 	if ((status = h264->subsystem->Decompress(h264, pSrcData, SrcSize)) < 0)
 		return status;
-
-	UncompressedSize = h264->width * h264->height * 4;
-
-	if (UncompressedSize > (nDstStep * nDstHeight))
-		return -1;
 
 	pYUVData = h264->pYUVData;
 	iStride = h264->iStride;

--- a/libfreerdp/codec/h264.c
+++ b/libfreerdp/codec/h264.c
@@ -423,7 +423,8 @@ static H264_CONTEXT_SUBSYSTEM g_Subsystem_libavcodec =
 #endif
 
 int h264_decompress(H264_CONTEXT* h264, BYTE* pSrcData, UINT32 SrcSize,
-		BYTE** ppDstData, DWORD DstFormat, int nDstStep, int nDstHeight, RDPGFX_RECT16* regionRects, int numRegionRects)
+		BYTE** ppDstData, DWORD DstFormat, int nDstStep, int nDstWidth,
+		int nDstHeight, RDPGFX_RECT16* regionRects, int numRegionRects)
 {
 	int index;
 	int status;
@@ -457,6 +458,18 @@ int h264_decompress(H264_CONTEXT* h264, BYTE* pSrcData, UINT32 SrcSize,
 	for (index = 0; index < numRegionRects; index++)
 	{
 		rect = &(regionRects[index]);
+
+		/* Check, if the ouput rectangle is valid in decoded h264 frame. */
+		if ((rect->right > h264->width) || (rect->left > h264->width))
+			return -1;
+		if ((rect->top > h264->height) || (rect->bottom > h264->height))
+			return -1;
+
+		/* Check, if the output rectangle is valid in destination buffer. */
+		if ((rect->right > nDstWidth) || (rect->left > nDstWidth))
+			return -1;
+		if ((rect->bottom > nDstHeight) || (rect->top > nDstHeight))
+			return -1;
 
 		width = rect->right - rect->left;
 		height = rect->bottom - rect->top;

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -356,7 +356,8 @@ int gdi_SurfaceCommand_H264(rdpGdi* gdi, RdpgfxClientContext* context, RDPGFX_SU
 	DstData = surface->data;
 
 	status = h264_decompress(gdi->codecs->h264, bs->data, bs->length, &DstData,
-			PIXEL_FORMAT_XRGB32, surface->scanline , surface->height, meta->regionRects, meta->numRegionRects);
+			PIXEL_FORMAT_XRGB32, surface->scanline , surface->width, surface->height,
+			meta->regionRects, meta->numRegionRects);
 
 	if (status < 0)
 	{


### PR DESCRIPTION
The buffer size checks in ```h264_decompress``` were broken.
The assumption, that the decoded h264 frame must be smaller than the output buffer is wrong.
Instead check, that the desired output rectangle is a valid region in the decoded h264 frame as well as the output buffer.