### PR TITLE
libwinpr: attempt to fix TerminateThread(...).

### DIFF
--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -580,6 +580,7 @@ BOOL TerminateThread(HANDLE hThread, DWORD dwExitCode)
 	WLog_ERR(TAG, "Function not supported on this platform!");
 #endif
 	pthread_mutex_unlock(&thread->mutex);
+        set_event(thread);
 	return TRUE;
 }
 

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -580,7 +580,7 @@ BOOL TerminateThread(HANDLE hThread, DWORD dwExitCode)
 	WLog_ERR(TAG, "Function not supported on this platform!");
 #endif
 	pthread_mutex_unlock(&thread->mutex);
-        set_event(thread);
+	set_event(thread);
 	return TRUE;
 }
 


### PR DESCRIPTION
The following sequence should not hang forever anymore: TerminateThread(thread, 0); WaitForSingleObject(thread, INFINTE);

This should fix the fact that xfreerdp hangs while signing out of a RDP session after to have used a redirected COM port.

Please double check, I'm not familiar enough with the internal events used by a thread. I just noticed the following line in WaitForSingleObject():

		status = waitOnFd(thread->pipe_fd[0], dwMilliseconds);

