### PR TITLE
Fix freerdp_channels_free for clients with multiple active connections

### DIFF
--- a/libfreerdp/core/client.c
+++ b/libfreerdp/core/client.c
@@ -100,6 +100,8 @@ void freerdp_channels_free(rdpChannels* channels)
 {
 	int index;
 	CHANNEL_OPEN_DATA* pChannelOpenData;
+	ULONG_PTR* pKeys;
+	int nkeys;
 
 	if (channels->queue)
 	{
@@ -116,14 +118,20 @@ void freerdp_channels_free(rdpChannels* channels)
 			free(pChannelOpenData->pInterface);
 			pChannelOpenData->pInterface = NULL;
 		}
+
+		HashTable_Remove(g_OpenHandles, (void*) (UINT_PTR)pChannelOpenData->OpenHandle);
+
 	}
 
 	if (g_OpenHandles)
 	{
-		HashTable_Free(g_OpenHandles);
-		DeleteCriticalSection(&g_channels_lock);
-
-		g_OpenHandles = NULL;
+		nkeys = HashTable_GetKeys(g_OpenHandles, &pKeys);
+		free(pKeys);
+		if ( nkeys == 0 ) {
+			HashTable_Free(g_OpenHandles);
+			DeleteCriticalSection(&g_channels_lock);
+			g_OpenHandles = NULL;
+		}
 	}
 
 	free(channels);


### PR DESCRIPTION
When a client disconnects from a server and its channel structures are removed, the global hash g_OpenHandles should not be destroyed. Only freed channels must be removed from the hash.