### PR TITLE
Return FALSE instead of exit() in libfreerdp

### DIFF
--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -220,7 +220,7 @@ static BOOL freerdp_peer_initialize(freerdp_peer* client)
 		{
 			WLog_ERR(TAG, "Key sizes > 2048 are currently not supported for RDP security.");
 			WLog_ERR(TAG, "Set a different key file than %s", settings->RdpKeyFile);
-			exit(1);
+			return FALSE;
 		}
 	}
 


### PR DESCRIPTION
Fixes a warning anpotential problems with libfreerdp:
libfreerdp1_2.x86_64: W: shared-lib-calls-exit /usr/lib64/libfreerdp.so.1.2.0 exit@GLIBC_2.2.5
This library package calls exit() or _exit(), probably in a non-fork() context. Doing so from a library is strongly discouraged - when a library function calls exit(), it prevents the calling program from handling the error, reporting it to the user, closing files properly, and cleaning up any state that the program has. It is preferred for the library to return an actual error code and let the calling program decide how to handle the situation.