### PR TITLE
core/capabilities: remove misplaced/useless code

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -3309,8 +3309,6 @@ BOOL rdp_read_capability_sets(wStream* s, rdpSettings* settings, UINT16 numberCa
 	UINT16 length;
 	BYTE *bm, *em;
 
-	BOOL foundMultifragmentUpdate = FALSE;
-
 	Stream_GetPointer(s, mark);
 	count = numberCapabilities;
 
@@ -3457,7 +3455,6 @@ BOOL rdp_read_capability_sets(wStream* s, rdpSettings* settings, UINT16 numberCa
 			case CAPSET_TYPE_MULTI_FRAGMENT_UPDATE:
 				if (!rdp_read_multifragment_update_capability_set(s, length, settings))
 					return FALSE;
-				foundMultifragmentUpdate = TRUE;
 				break;
 
 			case CAPSET_TYPE_LARGE_POINTER:
@@ -3504,15 +3501,6 @@ BOOL rdp_read_capability_sets(wStream* s, rdpSettings* settings, UINT16 numberCa
 	{
 		WLog_ERR(TAG,  "strange we haven't read the number of announced capacity sets, read=%d expected=%d",
 				 count-numberCapabilities, count);
-	}
-
-	/**
-	 * If we never received a multifragment update capability set,
-	 * then the peer doesn't support fragmentation.
-	 */
-	if (!foundMultifragmentUpdate)
-	{
-		settings->MultifragMaxRequestSize = 0;
 	}
 
 #ifdef WITH_DEBUG_CAPABILITIES


### PR DESCRIPTION
Commit 0357a38e3129b67093c7c055c7eaa242ce293673 has added some code without any effect.
That commit added code to rdp_read_capability_sets() to check if CAPSET_TYPE_MULTI_FRAGMENT_UPDATE was not received which caused settings->MultifragMaxRequestSize to be set to 0.

- this was done in the wrong place because we do these kind of checks in rdp_recv_confirm_active() by consulting the variable settings->ReceivedCapabilities[]
- the code had no effect at all because MultifragMaxRequestSize gets set to FASTPATH_FRAGMENT_SAFE_SIZE in rdp_recv_confirm_active()  if the CAPSET_TYPE_MULTI_FRAGMENT_UPDATE was not received.