### PR TITLE
xfreerdp: fix problem with SetPosition

### DIFF
--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -322,16 +322,30 @@ void xf_Pointer_SetDefault(rdpContext* context)
 void xf_Pointer_SetPosition(rdpContext* context, UINT32 x, UINT32 y)
 {
 	xfContext* xfc = (xfContext*) context;
+	XWindowAttributes current;
+	XSetWindowAttributes tmp;
 
-	if (!xfc->focused)
+	if (!xfc->focused || !xfc->window)
 		return;
 
 	xf_lock_x11(xfc, FALSE);
 
-	if (xfc->window)
-		XWarpPointer(xfc->display, None, xfc->window->handle, 0, 0, 0, 0, x, y);
+	if (XGetWindowAttributes(xfc->display, xfc->window->handle, &current) == 0)
+		goto out;
 
-	xf_unlock_x11(xfc, FALSE);
+	tmp.event_mask = (current.your_event_mask & ~(PointerMotionMask));
+	if (XChangeWindowAttributes(xfc->display, xfc->window->handle, CWEventMask, &tmp) == 0)
+		goto out;
+
+	XWarpPointer(xfc->display, None, xfc->window->handle, 0, 0, 0, 0, x, y);
+
+	tmp.event_mask = current.your_event_mask;
+	XChangeWindowAttributes(xfc->display, xfc->window->handle, CWEventMask, &tmp);
+
+out:
+		xf_unlock_x11(xfc, FALSE);
+		return;
+
 }
 
 /* Glyph Class */


### PR DESCRIPTION
Since XWarpPointer generates an pointer motion event, as if the mouse
was moved by hand, xfreerdp sends back the received mouse position to
the server. This behavior is wrong since pointer positions set via
server pointer update pdu shouldn't get sent back to the server
(it's not a "real" mouse move).

To fix this problem change the x windows event mask to not handle
pointer motion events before setting the new pointer position and change
it back again afterwards.

Possible downside of this is that some pointer motion events might get
lost but this shouldn't be noticeable.

Thanks to @nfedera for the neat idea with the attributes ;).