### PR TITLE
fixed: serial redirect not work #2333 

### DIFF
--- a/channels/serial/client/serial_main.c
+++ b/channels/serial/client/serial_main.c
@@ -805,13 +805,13 @@ int DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
 				assert(FALSE);
 
 				WLog_Print(serial->log, WLOG_DEBUG, "Unknown server's serial driver: %s. SerCx2 will be used", driver);
-				serial->ServerSerialDriverId = SerialDriverSerCx2Sys;
+				serial->ServerSerialDriverId = SerialDriverSerialSys;
 			}
 		}
 		else
 		{
 			/* default driver */
-			serial->ServerSerialDriverId = SerialDriverSerCx2Sys;
+			serial->ServerSerialDriverId = SerialDriverSerialSys;
 		}
 
 

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -580,6 +580,7 @@ BOOL TerminateThread(HANDLE hThread, DWORD dwExitCode)
 	WLog_ERR(TAG, "Function not supported on this platform!");
 #endif
 	pthread_mutex_unlock(&thread->mutex);
+        set_event(thread);
 	return TRUE;
 }
 

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -580,7 +580,7 @@ BOOL TerminateThread(HANDLE hThread, DWORD dwExitCode)
 	WLog_ERR(TAG, "Function not supported on this platform!");
 #endif
 	pthread_mutex_unlock(&thread->mutex);
-        set_event(thread);
+	set_event(thread);
 	return TRUE;
 }
 


### PR DESCRIPTION
fixed: serial redirect not work #2333

Two fixes:
1. xfreerdp doesn't hang anymore on session's Sign Out when a COM port is redirected. This was due to TerminateThread() which was never returning (TeminateThread() in only used by serial_main.c as of today).

2. Fixed how to use select() without a timeout.

One change:

1. Made SerialDriverSerialSys the default underlying 'driver' instead of the more restrictive SerialDriverSerCx2Sys.