### PR TITLE
winpr/process: handle PIDs <= 0 in TerminateProcess

### DIFF
--- a/winpr/libwinpr/thread/process.c
+++ b/winpr/libwinpr/thread/process.c
@@ -448,7 +448,7 @@ BOOL TerminateProcess(HANDLE hProcess, UINT uExitCode)
 
 	process = (WINPR_PROCESS*) hProcess;
 
-	if (!process)
+	if (!process || (process->pid <= 0))
 		return FALSE;
 
 	if (kill(process->pid, SIGTERM))


### PR DESCRIPTION
TerminateProcess shouldn't call kill if the PID is <=0 because this has
unwanted effects (and is not what TerminateProcess should do):

* with PID == 0 any process in the same process group gets the signal
  sent
* with PID == -1 *every* processes that the running users has
  permissions to gets the signal sent
* with PID < -1 the process within the same process group and -PID gets
  the signal send

For more details see kill(2).