### PR TITLE
Apply correct exit code to xfreerdp application for certain log offs

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1558,7 +1558,7 @@ DWORD xf_exit_code_from_disconnect_reason(DWORD reason)
 	else if (reason >= 0x10c9 && reason <= 0x1193)
 		reason = XF_EXIT_RDP;
 	/* There's no need to test protocol-independent codes: they match */
-	else if (!(reason <= 0xB))
+	else if (!(reason <= 0xC))
 		reason = XF_EXIT_UNKNOWN;
 
 	return reason;


### PR DESCRIPTION
When the user logs off of certain OSs(ie. Windows 2008 R2) then the disconnect reason was being incorrectly treated as an unknown exit code. This change allows the correct exit code to be passed from the application in these cases.