### PR TITLE
wtsapi: add TestWtsApiExtra

### DIFF
--- a/cmake/ConfigOptions.cmake
+++ b/cmake/ConfigOptions.cmake
@@ -1,3 +1,4 @@
+include(CMakeDependentOption)
 
 if((CMAKE_SYSTEM_PROCESSOR MATCHES "i386|i686|x86|AMD64") AND (CMAKE_SIZEOF_VOID_P EQUAL 4))
 	set(TARGET_ARCH "x86")
@@ -59,6 +60,8 @@ endif()
 option(WITH_SMARTCARD_INSPECT "Enable SmartCard API Inspector" OFF)
 
 option(BUILD_TESTING "Build unit tests" OFF)
+CMAKE_DEPENDENT_OPTION(TESTS_WTSAPI_EXTRA "Build extra WTSAPI tests (interactive)" OFF "BUILD_TESTING" ON)
+
 option(WITH_SAMPLE "Build sample code" OFF)
 
 option(WITH_CLIENT "Build client binaries" ON)

--- a/winpr/libwinpr/wtsapi/test/.gitignore
+++ b/winpr/libwinpr/wtsapi/test/.gitignore
@@ -1,3 +1,4 @@
 TestWtsApi
 TestWtsApi.c
-
+TestWtsApiExtra
+TestWtsApiExtra.c

--- a/winpr/libwinpr/wtsapi/test/CMakeLists.txt
+++ b/winpr/libwinpr/wtsapi/test/CMakeLists.txt
@@ -8,11 +8,10 @@ set(${MODULE_PREFIX}_TESTS
 	TestWtsApiEnumerateProcesses.c
 	TestWtsApiEnumerateSessions.c
 	TestWtsApiQuerySessionInformation.c
-	TestWtsApiLogoffSession.c
 	TestWtsApiShutdownSystem.c
 	TestWtsApiSessionNotification.c
 	TestWtsApiWaitSystemEvent.c
-	TestWtsApiVirtualChannel.c)
+	)
 
 create_test_sourcelist(${MODULE_PREFIX}_SRCS
 	${${MODULE_PREFIX}_DRIVER}
@@ -32,3 +31,36 @@ endforeach()
 
 set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "WinPR/Test")
 
+if(TESTS_WTSAPI_EXTRA)
+
+set(MODULE_NAME "TestWtsApiExtra")
+set(MODULE_PREFIX "TEST_WTSAPI_EXTRA")
+
+set(${MODULE_PREFIX}_DRIVER ${MODULE_NAME}.c)
+
+set(${MODULE_PREFIX}_TESTS
+		TestWtsApiExtraDisconnectSession.c
+		TestWtsApiExtraDynamicVirtualChannel.c
+		TestWtsApiExtraLogoffSession.c
+		TestWtsApiExtraSendMessage.c
+		TestWtsApiExtraVirtualChannel.c
+		)
+
+create_test_sourcelist(${MODULE_PREFIX}_SRCS
+	${${MODULE_PREFIX}_DRIVER}
+	${${MODULE_PREFIX}_TESTS})
+
+add_executable(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
+
+target_link_libraries(${MODULE_NAME} winpr)
+
+set_target_properties(${MODULE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${TESTING_OUTPUT_DIRECTORY}")
+
+foreach(test ${${MODULE_PREFIX}_TESTS})
+	get_filename_component(TestName ${test} NAME_WE)
+	add_test(${TestName} ${TESTING_OUTPUT_DIRECTORY}/${MODULE_NAME} ${TestName})
+	set_tests_properties(${TestName} PROPERTIES LABELS "WTSAPI_EXTRA")
+endforeach()
+
+set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "WinPR/Test")
+endif()

--- a/winpr/libwinpr/wtsapi/test/TestWtsApiExtraDisconnectSession.c
+++ b/winpr/libwinpr/wtsapi/test/TestWtsApiExtraDisconnectSession.c
@@ -1,0 +1,22 @@
+
+#include <winpr/crt.h>
+#include <winpr/error.h>
+#include <winpr/wtsapi.h>
+
+int TestWtsApiExtraDisconnectSession(int argc, char* argv[])
+{
+	BOOL bSuccess;
+	HANDLE hServer;
+
+	hServer = WTS_CURRENT_SERVER_HANDLE;
+
+	bSuccess = WTSDisconnectSession(hServer, WTS_CURRENT_SESSION, FALSE);
+
+	if (!bSuccess)
+	{
+		printf("WTSDisconnectSession failed: %d\n", (int) GetLastError());
+		return -1;
+	}
+
+	return 0;
+}

--- a/winpr/libwinpr/wtsapi/test/TestWtsApiExtraDynamicVirtualChannel.c
+++ b/winpr/libwinpr/wtsapi/test/TestWtsApiExtraDynamicVirtualChannel.c
@@ -3,7 +3,7 @@
 #include <winpr/error.h>
 #include <winpr/wtsapi.h>
 
-int TestWtsApiVirtualChannel(int argc, char* argv[])
+int TestWtsApiExtraDynamicVirtualChannel(int argc, char* argv[])
 {
 	BOOL bSuccess;
 	ULONG length;
@@ -14,22 +14,24 @@ int TestWtsApiVirtualChannel(int argc, char* argv[])
 
 	length = sizeof(buffer);
 
-	hVirtualChannel = WTSVirtualChannelOpen(WTS_CURRENT_SERVER_HANDLE, WTS_CURRENT_SESSION, "RDPDBG");
+	hVirtualChannel = WTSVirtualChannelOpenEx( WTS_CURRENT_SESSION, "ECHO",WTS_CHANNEL_OPTION_DYNAMIC);
 
-	if (!hVirtualChannel)
+
+	if (hVirtualChannel == INVALID_HANDLE_VALUE)
 	{
 		printf("WTSVirtualChannelOpen failed: %d\n", (int) GetLastError());
-		//return -1;
+		return -1;
 	}
-
+	printf("WTSVirtualChannelOpen opend");
 	bytesWritten = 0;
 	bSuccess = WTSVirtualChannelWrite(hVirtualChannel, (PCHAR) buffer, length, &bytesWritten);
 
 	if (!bSuccess)
 	{
 		printf("WTSVirtualChannelWrite failed: %d\n", (int) GetLastError());
-		//return -1;
+		return -1;
 	}
+	printf("WTSVirtualChannelWrite written");
 
 	bytesRead = 0;
 	bSuccess = WTSVirtualChannelRead(hVirtualChannel, 5000, (PCHAR) buffer, length, &bytesRead);
@@ -37,13 +39,14 @@ int TestWtsApiVirtualChannel(int argc, char* argv[])
 	if (!bSuccess)
 	{
 		printf("WTSVirtualChannelRead failed: %d\n", (int) GetLastError());
-		//return -1;
+		return -1;
 	}
+	printf("WTSVirtualChannelRead read");
 
 	if (!WTSVirtualChannelClose(hVirtualChannel))
 	{
 		printf("WTSVirtualChannelClose failed\n");
-		//return -1;
+		return -1;
 	}
 
 	return 0;

--- a/winpr/libwinpr/wtsapi/test/TestWtsApiExtraLogoffSession.c
+++ b/winpr/libwinpr/wtsapi/test/TestWtsApiExtraLogoffSession.c
@@ -3,7 +3,7 @@
 #include <winpr/error.h>
 #include <winpr/wtsapi.h>
 
-int TestWtsApiLogoffSession(int argc, char* argv[])
+int TestWtsApiExtraLogoffSession(int argc, char* argv[])
 {
 	BOOL bSuccess;
 	HANDLE hServer;
@@ -12,12 +12,12 @@ int TestWtsApiLogoffSession(int argc, char* argv[])
 	sessionId = 123;
 	hServer = WTS_CURRENT_SERVER_HANDLE;
 
-	bSuccess = WTSLogoffSession(hServer, sessionId, FALSE);
+	bSuccess = WTSLogoffSession(hServer, WTS_CURRENT_SESSION, FALSE);
 
 	if (!bSuccess)
 	{
 		printf("WTSLogoffSession failed: %d\n", (int) GetLastError());
-		//return -1;
+		return -1;
 	}
 
 	return 0;

--- a/winpr/libwinpr/wtsapi/test/TestWtsApiExtraSendMessage.c
+++ b/winpr/libwinpr/wtsapi/test/TestWtsApiExtraSendMessage.c
@@ -1,0 +1,29 @@
+
+#include <winpr/crt.h>
+#include <winpr/error.h>
+#include <winpr/wtsapi.h>
+#include <winpr/user.h>
+
+#define TITLE "thats the title"
+#define MESSAGE "thats the message"
+
+int TestWtsApiExtraSendMessage(int argc, char* argv[])
+{
+	BOOL bSuccess;
+	HANDLE hServer;
+	DWORD result;
+
+	hServer = WTS_CURRENT_SERVER_HANDLE;
+
+	bSuccess = WTSSendMessage(hServer, WTS_CURRENT_SESSION,TITLE,strlen(TITLE) + 1, MESSAGE, strlen(MESSAGE) + 1, MB_CANCELTRYCONTINUE, 3 , &result,TRUE);
+
+	if (!bSuccess)
+	{
+		printf("WTSSendMessage failed: %d\n", (int) GetLastError());
+		return -1;
+	}
+
+	printf("WTSSendMessage got result: %d\n", (int) result);
+
+	return 0;
+}

--- a/winpr/libwinpr/wtsapi/test/TestWtsApiExtraVirtualChannel.c
+++ b/winpr/libwinpr/wtsapi/test/TestWtsApiExtraVirtualChannel.c
@@ -1,0 +1,53 @@
+
+#include <winpr/crt.h>
+#include <winpr/error.h>
+#include <winpr/wtsapi.h>
+
+int TestWtsApiExtraVirtualChannel(int argc, char* argv[])
+{
+	BOOL bSuccess;
+	ULONG length;
+	ULONG bytesRead;
+	ULONG bytesWritten;
+	BYTE buffer[1024];
+	HANDLE hVirtualChannel;
+
+	length = sizeof(buffer);
+
+	hVirtualChannel = WTSVirtualChannelOpen(WTS_CURRENT_SERVER_HANDLE, WTS_CURRENT_SESSION, "sample");
+
+	if (hVirtualChannel == INVALID_HANDLE_VALUE)
+	{
+		printf("WTSVirtualChannelOpen failed: %d\n", (int) GetLastError());
+		return -1;
+	}
+	printf("WTSVirtualChannelOpen opend");
+	bytesWritten = 0;
+	bSuccess = WTSVirtualChannelWrite(hVirtualChannel, (PCHAR) buffer, length, &bytesWritten);
+
+	if (!bSuccess)
+	{
+		printf("WTSVirtualChannelWrite failed: %d\n", (int) GetLastError());
+		return -1;
+	}
+	printf("WTSVirtualChannelWrite written");
+
+	bytesRead = 0;
+	bSuccess = WTSVirtualChannelRead(hVirtualChannel, 5000, (PCHAR) buffer, length, &bytesRead);
+
+	if (!bSuccess)
+	{
+		printf("WTSVirtualChannelRead failed: %d\n", (int) GetLastError());
+		return -1;
+	}
+	printf("WTSVirtualChannelRead read");
+
+	if (!WTSVirtualChannelClose(hVirtualChannel))
+	{
+		printf("WTSVirtualChannelClose failed\n");
+		return -1;
+	}
+
+	return 0;
+}
+


### PR DESCRIPTION
wtsapi: add TestWtsApiExtra

Move wtsapi tests that only make sense when run within a session
("interactive") to TestWtsApiExtra since they either brake automated
builds or don't make sense if the return value isn't checked.

TestWtsApiExtra is not build by default but can be enabled by specifying
-DTESTS_WTSAPI_EXTRA=ON (this option is only available if BUILD_TESTING
is enabled).

The tests set the ctest label WTSAPI_EXTRA and can therefore also
be run explicitly with ctest -L WTSAPI_EXTRA.