### PR TITLE
Fix server-side protocol negociation

### DIFF
--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -918,20 +918,16 @@ BOOL nego_send_negotiation_response(rdpNego* nego)
 	bm = Stream_GetPosition(s);
 	Stream_Seek(s, length);
 
-	if ((nego->SelectedProtocol == PROTOCOL_RDP) && !settings->RdpSecurity)
+	if (nego->SelectedProtocol & PROTOCOL_FAILED_NEGO)
 	{
+		UINT32 errorCode = (nego->SelectedProtocol & ~PROTOCOL_FAILED_NEGO);
 		flags = 0;
 
 		Stream_Write_UINT8(s, TYPE_RDP_NEG_FAILURE);
 		Stream_Write_UINT8(s, flags); /* flags */
 		Stream_Write_UINT16(s, 8); /* RDP_NEG_DATA length (8) */
 
-		/*
-		 * TODO: Check for other possibilities,
-		 *       like SSL_NOT_ALLOWED_BY_SERVER.
-		 */
-		WLog_ERR(TAG, "client supports only Standard RDP Security");
-		Stream_Write_UINT32(s, SSL_REQUIRED_BY_SERVER);
+		Stream_Write_UINT32(s, errorCode);
 		length += 8;
 		status = FALSE;
 	}

--- a/libfreerdp/core/nego.h
+++ b/libfreerdp/core/nego.h
@@ -34,7 +34,9 @@ enum RDP_NEG_PROTOCOLS
 	PROTOCOL_RDP = 0x00000000,
 	PROTOCOL_TLS = 0x00000001,
 	PROTOCOL_NLA = 0x00000002,
-	PROTOCOL_EXT = 0x00000008
+	PROTOCOL_EXT = 0x00000008,
+
+	PROTOCOL_FAILED_NEGO = 0x80000000 /* only used internally, not on the wire */
 };
 
 /* Protocol Security Negotiation Failure Codes */


### PR DESCRIPTION
Before this patch, RDP security was (wrongly) the fallback when negociating a
security protocol between the client and the server. For example when a client
was claiming TLS-only when connecting to a FreeRDP based-server with RDP security only,
the result of the negociation was that the server started to do RDP security.
The expected behaviour is to send a nego failure packet with error code
SSL_NOT_ALLOWED_BY_SERVER. This patch fixes this.

We also try to handle all cases of failed negociation and return the corresponding
error code.