### PR TITLE
Fix remote app in xfreerdp.

### DIFF
--- a/client/X11/xf_monitor.c
+++ b/client/X11/xf_monitor.c
@@ -163,7 +163,12 @@ BOOL xf_detect_monitors(xfContext* xfc)
 	}
 #endif
 
-	if (!xf_GetWorkArea(xfc))
+	/* WORKAROUND: With Remote Application Mode - using NET_WM_WORKAREA
+ 	 * causes issues with the ability to fully size the window vertically
+ 	 * (the bottom of the window area is never updated). So, we just set
+ 	 * the workArea to match the full Screen width/height.
+	 */
+	if (settings->RemoteApplicationMode || !xf_GetWorkArea(xfc))
 	{
 		xfc->workArea.x = 0;
 		xfc->workArea.y = 0;

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -886,14 +886,20 @@ void xf_SetWindowVisibilityRects(xfContext* xfc, xfAppWindow* appWindow, RECTANG
 void xf_UpdateWindowArea(xfContext* xfc, xfAppWindow* appWindow, int x, int y, int width, int height)
 {
 	int ax, ay;
+	UINT32 translatedWindowOffsetX;
+	UINT32 translatedWindowOffsetY;
 
-	ax = x + appWindow->visibleOffsetX;
-	ay = y + appWindow->visibleOffsetY;
+	/* Translate the server rail window offset to a local offset */
+	translatedWindowOffsetX = (appWindow->windowOffsetX - appWindow->localWindowOffsetCorrX);
+	translatedWindowOffsetY = (appWindow->windowOffsetY - appWindow->localWindowOffsetCorrY);
 
-	if (ax + width > appWindow->visibleOffsetX + appWindow->width)
-		width = (appWindow->visibleOffsetX + appWindow->width - 1) - ax;
-	if (ay + height > appWindow->visibleOffsetY + appWindow->height)
-		height = (appWindow->visibleOffsetY + appWindow->height - 1) - ay;
+	ax = x + translatedWindowOffsetX;
+	ay = y + translatedWindowOffsetY;
+
+	if (ax + width > translatedWindowOffsetX + appWindow->width)
+		width = (translatedWindowOffsetX + appWindow->width - 1) - ax;
+	if (ay + height > translatedWindowOffsetY + appWindow->height)
+		height = (translatedWindowOffsetY + appWindow->height - 1) - ay;
 
 	xf_lock_x11(xfc, TRUE);
 

--- a/client/X11/xf_window.h
+++ b/client/X11/xf_window.h
@@ -118,6 +118,9 @@ struct xf_app_window
 	UINT32 numVisibilityRects;
 	RECTANGLE_16* visibilityRects;
 
+	UINT32 localWindowOffsetCorrX;
+	UINT32 localWindowOffsetCorrY;
+
 	GC gc;
 	int shmid;
 	Window handle;


### PR DESCRIPTION
Remove use of the visibleOffset for local window positioning, this completely breaks the display of all windows except for the main application window. Instead, just maintain a local offset correction of the windowOffset. NOTE: I originally made the visibleOffset change in the past on the main window, but things have been broken now that the window routines for the main window and all other windows have been combined. Basically, all pop-up windows, etc. were always displaying the wrong thing.

Also, apply workaround to determining the workArea for remote app mode. Trying to use NET_WM_WORKAREA seems to somehow prevent the window from being able to get sized correctly. This was very evident if you maximized a window as the bottom of the window would never be updated.

For reference, I did all of my testing on a stock CentOS 6.6 system.