### PR TITLE
winpr: stream ctest and missing read/peek types

### DIFF
--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -50,53 +50,109 @@ WINPR_API void Stream_EnsureRemainingCapacity(wStream* s, size_t size);
 WINPR_API wStream* Stream_New(BYTE* buffer, size_t size);
 WINPR_API void Stream_Free(wStream* s, BOOL bFreeBuffer);
 
-#define Stream_Read_UINT8(_s, _v) do { _v = \
-	*_s->pointer++; } while (0)
+#define _stream_read_n8(_t, _s, _v, _p) do { _v = \
+	(_t)(*_s->pointer); \
+	_s->pointer += _p; } while (0)
 
-#define Stream_Read_UINT16(_s, _v) do { _v = \
-	(UINT16)(*_s->pointer) + \
-	(((UINT16)(*(_s->pointer + 1))) << 8); \
-	_s->pointer += 2; } while (0)
+#define _stream_read_n16_le(_t, _s, _v, _p) do { _v = \
+	(_t)(*_s->pointer) + \
+	(((_t)(*(_s->pointer + 1))) << 8); \
+	if (_p) _s->pointer += 2; } while (0)
 
-#define Stream_Read_INT16(_s, _v) do { _v = \
-	(INT16)(*_s->pointer) + \
-	(((INT16)(*(_s->pointer + 1))) << 8); \
-	_s->pointer += 2; } while (0)
+#define _stream_read_n16_be(_t, _s, _v, _p) do { _v = \
+	(((_t)(*_s->pointer)) << 8) + \
+	(_t)(*(_s->pointer + 1)); \
+	if (_p) _s->pointer += 2; } while (0)
 
-#define Stream_Read_UINT16_BE(_s, _v) do { _v = \
-	(((UINT16)(*_s->pointer)) << 8) + \
-	(UINT16)(*(_s->pointer + 1)); \
-	_s->pointer += 2; } while (0)
+#define _stream_read_n32_le(_t, _s, _v, _p) do { _v = \
+	(_t)(*_s->pointer) + \
+	(((_t)(*(_s->pointer + 1))) << 8) + \
+	(((_t)(*(_s->pointer + 2))) << 16) + \
+	(((_t)(*(_s->pointer + 3))) << 24); \
+	if (_p) _s->pointer += 4; } while (0)
 
-#define Stream_Read_UINT32(_s, _v) do { _v = \
-	(UINT32)(*_s->pointer) + \
-	(((UINT32)(*(_s->pointer + 1))) << 8) + \
-	(((UINT32)(*(_s->pointer + 2))) << 16) + \
-	(((UINT32)(*(_s->pointer + 3))) << 24); \
-	_s->pointer += 4; } while (0)
+#define _stream_read_n32_be(_t, _s, _v, _p) do { _v = \
+	(((_t)(*(_s->pointer))) << 24) + \
+	(((_t)(*(_s->pointer + 1))) << 16) + \
+	(((_t)(*(_s->pointer + 2))) << 8) + \
+	(((_t)(*(_s->pointer + 3)))); \
+	if (_p) _s->pointer += 4; } while (0)
 
-#define Stream_Read_UINT32_BE(_s, _v) do { _v = \
-	(((UINT32)(*(_s->pointer))) << 24) + \
-	(((UINT32)(*(_s->pointer + 1))) << 16) + \
-	(((UINT32)(*(_s->pointer + 2))) << 8) + \
-	(((UINT32)(*(_s->pointer + 3)))); \
-	_s->pointer += 4; } while (0)
+#define _stream_read_n64_le(_t, _s, _v, _p) do { _v = \
+	(_t)(*_s->pointer) + \
+	(((_t)(*(_s->pointer + 1))) << 8) + \
+	(((_t)(*(_s->pointer + 2))) << 16) + \
+	(((_t)(*(_s->pointer + 3))) << 24) + \
+	(((_t)(*(_s->pointer + 4))) << 32) + \
+	(((_t)(*(_s->pointer + 5))) << 40) + \
+	(((_t)(*(_s->pointer + 6))) << 48) + \
+	(((_t)(*(_s->pointer + 7))) << 56); \
+	if (_p) _s->pointer += 8; } while (0)
 
-#define Stream_Read_UINT64(_s, _v) do { _v = \
-	(UINT64)(*_s->pointer) + \
-	(((UINT64)(*(_s->pointer + 1))) << 8) + \
-	(((UINT64)(*(_s->pointer + 2))) << 16) + \
-	(((UINT64)(*(_s->pointer + 3))) << 24) + \
-	(((UINT64)(*(_s->pointer + 4))) << 32) + \
-	(((UINT64)(*(_s->pointer + 5))) << 40) + \
-	(((UINT64)(*(_s->pointer + 6))) << 48) + \
-	(((UINT64)(*(_s->pointer + 7))) << 56); \
-	_s->pointer += 8; } while (0)
+#define _stream_read_n64_be(_t, _s, _v, _p) do { _v = \
+	(((_t)(*(_s->pointer))) << 56) + \
+	(((_t)(*(_s->pointer + 1))) << 48) + \
+	(((_t)(*(_s->pointer + 2))) << 40) + \
+	(((_t)(*(_s->pointer + 3))) << 32) + \
+	(((_t)(*(_s->pointer + 4))) << 24) + \
+	(((_t)(*(_s->pointer + 5))) << 16) + \
+	(((_t)(*(_s->pointer + 6))) << 8) + \
+	(((_t)(*(_s->pointer + 7)))); \
+	if (_p) _s->pointer += 8; } while (0)
+
+
+#define Stream_Read_UINT8(_s, _v) _stream_read_n8(UINT8, _s, _v, 1)
+#define Stream_Read_INT8(_s, _v) _stream_read_n8(INT8, _s, _v, 1)
+
+#define Stream_Read_UINT16(_s, _v) _stream_read_n16_le(UINT16, _s, _v, 1)
+#define Stream_Read_INT16(_s, _v) _stream_read_n16_le(INT16, _s, _v, 1)
+
+#define Stream_Read_UINT16_BE(_s, _v) _stream_read_n16_be(UINT16, _s, _v, 1)
+#define Stream_Read_INT16_BE(_s, _v) _stream_read_n16_be(INT16, _s, _v, 1)
+
+#define Stream_Read_UINT32(_s, _v) _stream_read_n32_le(UINT32, _s, _v, 1)
+#define Stream_Read_INT32(_s, _v) _stream_read_n32_le(INT32, _s, _v, 1)
+
+#define Stream_Read_UINT32_BE(_s, _v) _stream_read_n32_be(UINT32, _s, _v, 1)
+#define Stream_Read_INT32_BE(_s, _v) _stream_read_n32_be(INT32, _s, _v, 1)
+
+#define Stream_Read_UINT64(_s, _v) _stream_read_n64_le(UINT64, _s, _v, 1)
+#define Stream_Read_INT64(_s, _v) _stream_read_n64_le(INT64, _s, _v, 1)
+
+#define Stream_Read_UINT64_BE(_s, _v) _stream_read_n64_be(UINT64, _s, _v, 1)
+#define Stream_Read_INT64_BE(_s, _v) _stream_read_n64_be(INT64, _s, _v, 1)
 
 #define Stream_Read(_s, _b, _n) do { \
 	memcpy(_b, (_s->pointer), (_n)); \
 	_s->pointer += (_n); \
 	} while (0)
+
+
+#define Stream_Peek_UINT8(_s, _v) _stream_read_n8(UINT8, _s, _v, 0)
+#define Stream_Peek_INT8(_s, _v) _stream_read_n8(INT8, _s, _v, 0)
+
+#define Stream_Peek_UINT16(_s, _v) _stream_read_n16_le(UINT16, _s, _v, 0)
+#define Stream_Peek_INT16(_s, _v) _stream_read_n16_le(INT16, _s, _v, 0)
+
+#define Stream_Peek_UINT16_BE(_s, _v) _stream_read_n16_be(UINT16, _s, _v, 0)
+#define Stream_Peek_INT16_BE(_s, _v) _stream_read_n16_be(INT16, _s, _v, 0)
+
+#define Stream_Peek_UINT32(_s, _v) _stream_read_n32_le(UINT32, _s, _v, 0)
+#define Stream_Peek_INT32(_s, _v) _stream_read_n32_le(INT32, _s, _v, 0)
+
+#define Stream_Peek_UINT32_BE(_s, _v) _stream_read_n32_be(UINT32, _s, _v, 0)
+#define Stream_Peek_INT32_BE(_s, _v) _stream_read_n32_be(INT32, _s, _v, 0)
+
+#define Stream_Peek_UINT64(_s, _v) _stream_read_n64_le(UINT64, _s, _v, 0)
+#define Stream_Peek_INT64(_s, _v) _stream_read_n64_le(INT64, _s, _v, 0)
+
+#define Stream_Peek_UINT64_BE(_s, _v) _stream_read_n64_be(UINT64, _s, _v, 0)
+#define Stream_Peek_INT64_BE(_s, _v) _stream_read_n64_be(INT64, _s, _v, 0)
+
+#define Stream_Peek(_s, _b, _n) do { \
+	memcpy(_b, (_s->pointer), (_n)); \
+	} while (0)
+
 
 #define Stream_Write_UINT8(_s, _v) do { \
 	*_s->pointer++ = (UINT8)(_v); } while (0)
@@ -135,35 +191,6 @@ WINPR_API void Stream_Free(wStream* s, BOOL bFreeBuffer);
 	_s->pointer += (_n); \
 	} while (0)
 
-#define Stream_Peek_UINT8(_s, _v) do { _v = \
-	*_s->pointer; } while (0)
-
-#define Stream_Peek_UINT16(_s, _v) do { _v = \
-	(UINT16)(*_s->pointer) + \
-	(((UINT16)(*(_s->pointer + 1))) << 8); \
-	} while (0)
-
-#define Stream_Peek_UINT32(_s, _v) do { _v = \
-	(UINT32)(*_s->pointer) + \
-	(((UINT32)(*(_s->pointer + 1))) << 8) + \
-	(((UINT32)(*(_s->pointer + 2))) << 16) + \
-	(((UINT32)(*(_s->pointer + 3))) << 24); \
-	} while (0)
-
-#define Stream_Peek_UINT64(_s, _v) do { _v = \
-	(UINT64)(*_s->pointer) + \
-	(((UINT64)(*(_s->pointer + 1))) << 8) + \
-	(((UINT64)(*(_s->pointer + 2))) << 16) + \
-	(((UINT64)(*(_s->pointer + 3))) << 24) + \
-	(((UINT64)(*(_s->pointer + 4))) << 32) + \
-	(((UINT64)(*(_s->pointer + 5))) << 40) + \
-	(((UINT64)(*(_s->pointer + 6))) << 48) + \
-	(((UINT64)(*(_s->pointer + 7))) << 56); \
-	} while (0)
-
-#define Stream_Peek(_s, _b, _n) do { \
-	memcpy(_b, (_s->pointer), (_n)); \
-	} while (0)
 
 #define Stream_Seek(_s,_offset)		_s->pointer += (_offset)
 #define Stream_Rewind(_s,_offset)	_s->pointer -= (_offset)

--- a/winpr/libwinpr/utils/test/CMakeLists.txt
+++ b/winpr/libwinpr/utils/test/CMakeLists.txt
@@ -11,6 +11,7 @@ set(${MODULE_PREFIX}_TESTS
 	TestQueue.c
 	TestPrint.c
 	TestPubSub.c
+	TestStream.c
 	TestBitStream.c
 	TestArrayList.c
 	TestLinkedList.c

--- a/winpr/libwinpr/utils/test/TestStream.c
+++ b/winpr/libwinpr/utils/test/TestStream.c
@@ -1,0 +1,275 @@
+
+#include <winpr/crt.h>
+#include <winpr/print.h>
+#include <winpr/stream.h>
+
+static BOOL TestStream_Verify(wStream* s, int mincap, int len, int pos)
+{
+	if (Stream_Buffer(s) == NULL)
+	{
+		printf("stream buffer is null\n");
+		return FALSE;
+	}
+	if (Stream_Pointer(s) == NULL)
+	{
+		printf("stream pointer is null\n");
+		return FALSE;
+	}
+	if (Stream_Pointer(s) < Stream_Buffer(s))
+	{
+		printf("stream pointer (%p) or buffer (%p) is invalid\n",
+			Stream_Pointer(s), Stream_Buffer(s));
+		return FALSE;
+	}
+	if (Stream_Capacity(s) < mincap) {
+		printf("stream capacity is %ld but minimum expected value is %d\n",
+			Stream_Capacity(s), mincap);
+		return FALSE;
+	}
+	if (Stream_Length(s) != len) {
+		printf("stream has unexpected length (%ld instead of %d)\n",
+			Stream_Length(s), len);
+		return FALSE;
+	}
+	if (Stream_GetPosition(s) != pos)
+	{
+		printf("stream has unexpected position (%ld instead of %d)\n",
+			Stream_GetPosition(s), pos);
+		return FALSE;
+	}
+	if (Stream_GetPosition(s) > Stream_Length(s))
+	{
+		printf("stream position (%ld) exceeds length (%ld)\n",
+			Stream_GetPosition(s), Stream_Length(s));
+		return FALSE;
+	}
+	if (Stream_GetPosition(s) > Stream_Capacity(s))
+	{
+		printf("stream position (%ld) exceeds capacity (%ld)\n",
+			Stream_GetPosition(s), Stream_Capacity(s));
+		return FALSE;
+	}
+	if (Stream_Length(s) > Stream_Capacity(s))
+	{
+		printf("stream length (%ld) exceeds capacity (%ld)\n",
+			Stream_Length(s), Stream_Capacity(s));
+		return FALSE;
+	}
+	if (Stream_GetRemainingLength(s) != len - pos)
+	{
+		printf("stream remaining length (%ld instead of %d)\n",
+			Stream_GetRemainingLength(s), len - pos);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+
+static BOOL TestStream_Create(int count, BOOL selfAlloc)
+{
+	int i, len, cap, pos;
+	wStream *s = NULL;
+	void* buffer = NULL;
+
+	for (i = 0; i < count; i++)
+	{
+		len = cap = i+1;
+		pos = 0;
+
+		if (selfAlloc)
+		{
+			if (!(buffer = malloc(cap)))
+			{
+				printf("%s: failed to allocate buffer of size %d\n", __FUNCTION__, cap);
+				goto fail;
+			}
+		}
+
+		if (!(s = Stream_New(selfAlloc ? buffer : NULL, len)))
+		{
+			printf("%s: Stream_New failed for stream #%d\n", __FUNCTION__, i);
+			goto fail;
+		}
+
+		if (!TestStream_Verify(s, cap, len, pos))
+		{
+			goto fail;
+		}
+
+		for (pos = 0; pos < len; pos++)
+		{
+			Stream_SetPosition(s, pos);
+			Stream_SealLength(s);
+			if (!TestStream_Verify(s, cap, pos, pos))
+			{
+				goto fail;
+			}
+		}
+
+		if (selfAlloc)
+		{
+			memset(buffer, i%256, cap);
+			if (memcmp(buffer, Stream_Buffer(s), cap))
+			{
+				printf("%s: buffer memory corruption\n", __FUNCTION__);
+				goto fail;
+			}
+		}
+
+		Stream_Free(s, buffer ? FALSE : TRUE);
+		free(buffer);
+	}
+
+	return TRUE;
+
+fail:
+	free(buffer);
+	if (s)
+	{
+		Stream_Free(s, buffer ? FALSE : TRUE);
+	}
+
+	return FALSE;
+}
+
+static BOOL TestStream_Extent(UINT32 maxSize)
+{
+	int i;
+	wStream *s = NULL;
+	BOOL result = FALSE;
+
+	if (!(s = Stream_New(NULL, 1)))
+	{
+		printf("%s: Stream_New failed\n", __FUNCTION__);
+		return FALSE;
+	}
+
+	for (i = 1; i < maxSize; i++)
+	{
+		if (i % 2)
+			Stream_EnsureRemainingCapacity(s, i);
+		else
+			Stream_EnsureCapacity(s, i);
+
+		Stream_SetPosition(s, i);
+		Stream_SealLength(s);
+
+		if (!TestStream_Verify(s, i, i, i))
+		{
+			printf("%s: failed to verify stream in iteration %d\n", __FUNCTION__, i);
+			goto fail;
+		}
+	}
+
+	result = TRUE;
+
+fail:
+	if (s)
+	{
+		Stream_Free(s, TRUE);
+	}
+
+	return result;
+}
+
+#define Stream_Peek_UINT8_BE	Stream_Peek_UINT8
+#define Stream_Read_UINT8_BE	Stream_Read_UINT8
+#define Stream_Peek_INT8_BE	Stream_Peek_UINT8
+#define Stream_Read_INT8_BE	Stream_Read_UINT8
+
+#define TestStream_PeekAndRead(_s, _r, _t) do                                \
+{                                                                            \
+  _t _a, _b;                                                                 \
+  int _i;                                                                    \
+  BYTE* _p = Stream_Buffer(_s);                                              \
+  Stream_SetPosition(_s, 0);                                                 \
+  Stream_Peek_ ## _t(_s, _a);                                                \
+  Stream_Read_ ## _t(_s, _b);                                                \
+  if (_a != _b)                                                              \
+  {                                                                          \
+    printf("%s: test1 " #_t "_LE failed\n", __FUNCTION__);                   \
+    _r = FALSE;                                                              \
+  }                                                                          \
+  for (_i=0; _i<sizeof(_t); _i++) {                                          \
+    if (((BYTE*)&_a)[_i] != _p[_i]) {                                        \
+      printf("%s: test2 " #_t "_LE failed\n", __FUNCTION__);                 \
+      _r = FALSE;                                                            \
+      break;                                                                 \
+    }                                                                        \
+  }                                                                          \
+  /* printf("a: 0x%016llX\n", a); */                                         \
+  Stream_SetPosition(_s, 0);                                                 \
+  Stream_Peek_ ## _t ## _BE(_s, _a);                                         \
+  Stream_Read_ ## _t ## _BE(_s, _b);                                         \
+  if (_a != _b)                                                              \
+  {                                                                          \
+    printf("%s: test1 " #_t "_BE failed\n", __FUNCTION__);                   \
+    _r = FALSE;                                                              \
+  }                                                                          \
+  for (_i=0; _i<sizeof(_t); _i++) {                                          \
+    if (((BYTE*)&_a)[_i] != _p[sizeof(_t)-_i-1]) {                           \
+      printf("%s: test2 " #_t "_BE failed\n", __FUNCTION__);                 \
+      _r = FALSE;                                                            \
+      break;                                                                 \
+    }                                                                        \
+  }                                                                          \
+  /* printf("a: 0x%016llX\n", a); */                                         \
+} while (0)
+
+
+static BOOL TestStream_Reading()
+{
+	BYTE src[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+
+	wStream *s = NULL;
+	BOOL result = TRUE;
+
+	if (!(s = Stream_New(src, sizeof(src))))
+	{
+		printf("%s: Stream_New failed\n", __FUNCTION__);
+		return FALSE;
+	}
+
+	TestStream_PeekAndRead(s, result, UINT8);
+	TestStream_PeekAndRead(s, result, INT8);
+	TestStream_PeekAndRead(s, result, UINT16);
+	TestStream_PeekAndRead(s, result, INT16);
+	TestStream_PeekAndRead(s, result, UINT32);
+	TestStream_PeekAndRead(s, result, INT32);
+	TestStream_PeekAndRead(s, result, UINT64);
+	TestStream_PeekAndRead(s, result, INT64);
+
+	Stream_Free(s, FALSE);
+
+	return result;
+}
+
+
+int TestStream(int argc, char* argv[])
+{
+	if (!TestStream_Create(200, FALSE))
+		return 1;
+
+	if (!TestStream_Create(200, TRUE))
+		return 2;
+
+	if (!TestStream_Extent(4096))
+		return 3;
+
+	if (!TestStream_Reading(4096))
+		return 4;
+
+	/**
+	 * FIXME: Add tests for
+	 * Stream_Write_*
+	 * Stream_Seek_*
+	 * Stream_Rewind_*
+	 * Stream_Zero
+	 * Stream_Fill
+	 * Stream_Copy
+	 */
+
+	return 0;
+}
+


### PR DESCRIPTION
- reworked stream.h defines to avoid multiple copies of the same code
- added missing types for Stream_Peek Stream_Read
- added an initial CTest for Stream
