### PR TITLE
Fix disconnection when negociation has failed

### DIFF
--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -567,6 +567,12 @@ static int peer_recv_callback(rdpTransport* transport, wStream* s, void* extra)
 
 static BOOL freerdp_peer_close(freerdp_peer* client)
 {
+	/** if negotiation has failed, we're not MCS connected. So don't
+	 * 	send anything else, or some mstsc will consider that as an error
+	 */
+	if (client->context->rdp->nego->SelectedProtocol & PROTOCOL_FAILED_NEGO)
+		return TRUE;
+
 	/**
 	 * [MS-RDPBCGR] 1.3.1.4.2 User-Initiated Disconnection Sequence on Server
 	 * The server first sends the client a Deactivate All PDU followed by an


### PR DESCRIPTION
This patch fixes a bug with mstsc connecting to a RDP security only FreeRDP server.
It seems like the mstsc shipped with Windows Seven considers packets after the nego_failure
packet as an error. So after trying to do TLS, depending on the timing, mstsc can print an
error message instead of retrying to connect with RDP security. With this patch, we
don't send the MCS disconnect message if the negociation has failed.