### PR TITLE
core: fix refreshRect/suppressOutput capabilities

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -198,11 +198,20 @@ BOOL rdp_read_general_capability_set(wStream* s, UINT16 length, rdpSettings* set
 	if (!(extraFlags & ENC_SALTED_CHECKSUM))
 		settings->SaltedChecksum = FALSE;
 
-	if (refreshRectSupport == FALSE)
-		settings->RefreshRect = FALSE;
 
-	if (suppressOutputSupport == FALSE)
-		settings->SuppressOutput = FALSE;
+	if (!settings->ServerMode)
+	{
+		/**
+		 * Note: refreshRectSupport and suppressOutputSupport are
+		 * server-only flags indicating to the client weather the
+		 * respective PDUs are supported. See MS-RDPBCGR 2.2.7.1.1
+		 */
+		if (!refreshRectSupport)
+			settings->RefreshRect = FALSE;
+
+		if (!suppressOutputSupport)
+			settings->SuppressOutput = FALSE;
+	}
 
 	return TRUE;
 }

--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -1614,7 +1614,10 @@ BOOL update_read_refresh_rect(rdpUpdate* update, wStream* s)
 		Stream_Read_UINT16(s, areas[index].bottom);
 	}
 
-	IFCALL(update->RefreshRect, update->context, numberOfAreas, areas);
+	if (update->context->settings->RefreshRect)
+		IFCALL(update->RefreshRect, update->context, numberOfAreas, areas);
+	else
+		WLog_Print(update->log, WLOG_WARN, "ignoring refresh rect request from client");
 
 	free(areas);
 
@@ -1634,8 +1637,11 @@ BOOL update_read_suppress_output(rdpUpdate* update, wStream* s)
 	if (allowDisplayUpdates > 0 && Stream_GetRemainingLength(s) < 8)
 		return FALSE;
 
-	IFCALL(update->SuppressOutput, update->context, allowDisplayUpdates,
-		allowDisplayUpdates > 0 ? (RECTANGLE_16*) Stream_Pointer(s) : NULL);
+	if (update->context->settings->SuppressOutput)
+		IFCALL(update->SuppressOutput, update->context, allowDisplayUpdates,
+			allowDisplayUpdates > 0 ? (RECTANGLE_16*) Stream_Pointer(s) : NULL);
+	else
+		WLog_Print(update->log, WLOG_WARN, "ignoring suppress output request from client");
 
 	return TRUE;
 }


### PR DESCRIPTION
refreshRectSupport and suppressOutputSupport of the General Capability Set (MS-RDPBCGR 2.2.7.1.1) are server-only flags that indicate whether the Refresh Rect or Suppress Output PDUs are supported by the server.
Therefore in rdp_read_general_capability_set() we must only change the respective settings if we are not in server mode.