### PR TITLE
Debug messages now use WLog_DBG instead of WLog_ERR.

### DIFF
--- a/channels/rdpsnd/client/winmm/rdpsnd_winmm.c
+++ b/channels/rdpsnd/client/winmm/rdpsnd_winmm.c
@@ -102,11 +102,11 @@ static void CALLBACK rdpsnd_winmm_callback_function(HWAVEOUT hwo, UINT uMsg, DWO
 	switch (uMsg)
 	{
 		case MM_WOM_OPEN:
-			WLog_ERR(TAG,  "MM_WOM_OPEN");
+			WLog_DBG(TAG,  "MM_WOM_OPEN");
 			break;
 		
 		case MM_WOM_CLOSE:
-			WLog_ERR(TAG,  "MM_WOM_CLOSE");
+			WLog_DBG(TAG,  "MM_WOM_CLOSE");
 			break;
 
 		case MM_WOM_DONE:
@@ -122,7 +122,7 @@ static void CALLBACK rdpsnd_winmm_callback_function(HWAVEOUT hwo, UINT uMsg, DWO
 				if (!wave)
 					return;
 
-				WLog_ERR(TAG,  "MM_WOM_DONE: dwBufferLength: %d cBlockNo: %d",
+				WLog_DBG(TAG,  "MM_WOM_DONE: dwBufferLength: %d cBlockNo: %d",
 						 lpWaveHdr->dwBufferLength, wave->cBlockNo);
 				wave->wLocalTimeB = GetTickCount();
 				wTimeDelta = wave->wLocalTimeB - wave->wLocalTimeA;


### PR DESCRIPTION
Silences log messages for ```rdpsnd``` channel for windows clients.