### PR TITLE
core/tcp: set TCP_USER_TIMEOUT if available

### DIFF
--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -1065,6 +1065,17 @@ BOOL freerdp_tcp_set_keep_alive_mode(int sockfd)
 		WLog_WARN(TAG, "setsockopt() SOL_SOCKET, SO_NOSIGPIPE");
 	}
 #endif
+
+#ifdef TCP_USER_TIMEOUT
+	optval = 4000;
+	optlen = sizeof(optval);
+
+	if (setsockopt(sockfd, SOL_TCP, TCP_USER_TIMEOUT, (void*) &optval, optlen) < 0)
+	{
+		WLog_WARN(TAG, "setsockopt() SOL_TCP, TCP_USER_TIMEOUT");
+	}
+#endif
+
 	return TRUE;
 }
 


### PR DESCRIPTION
Keepalive settings are usually (depending on the implementation) only
used if the TCP connection is idle.
If the network is interrupted/disconnected/... click or keyboard input
generates outgoing traffic therefore the connection isn't idle
anymore and keepalives might not be used causing the connection to
stay open and the client to stall.

Linux 2.6.36 added a TCP_USER_TIMEOUT TCP socket option that lets a
program specify the maximum time transmitted data may remain
unacknowledged before TCP will close the corresponding connection with
ETIMEDOUT.

Setting TCP_USER_TIMEOUT allows us to detect a network problem (like
cable disconnect) even if the connection isn't idle.