### PR TITLE
SCardTransmit pioRecvPci Fix

### DIFF
--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -913,8 +913,10 @@ static UINT32 smartcard_Transmit_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPE
 	}
 
 	ret.pioRecvPci = call->pioRecvPci;
+
 	status = ret.ReturnCode = SCardTransmit(operation->hCard, call->pioSendPci, call->pbSendBuffer,
 				call->cbSendLength, ret.pioRecvPci, ret.pbRecvBuffer, &(ret.cbRecvLength));
+
 	smartcard_trace_transmit_return(smartcard, &ret);
 	status = smartcard_pack_transmit_return(smartcard, irp->output, &ret);
 


### PR DESCRIPTION
Fix NDR encoding of SCardTransmit response when pioRecvPci is non-null