### PR TITLE
Fixed bitmap context for 15bit color depth

### DIFF
--- a/client/iOS/FreeRDP/ios_freerdp_ui.m
+++ b/client/iOS/FreeRDP/ios_freerdp_ui.m
@@ -126,7 +126,7 @@ static void ios_create_bitmap_context(mfInfo* mfi)
 	    
     rdpGdi* gdi = mfi->instance->context->gdi;
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-	if(gdi->dstBpp == 16)
+	if (gdi->bytesPerPixel == 2)
 		mfi->bitmap_context = CGBitmapContextCreate(gdi->primary_buffer, gdi->width, gdi->height, 5, gdi->width * 2, colorSpace, kCGBitmapByteOrder16Little | kCGImageAlphaNoneSkipFirst);
 	else
 		mfi->bitmap_context = CGBitmapContextCreate(gdi->primary_buffer, gdi->width, gdi->height, 8, gdi->width * 4, colorSpace, kCGBitmapByteOrder32Little | kCGImageAlphaNoneSkipFirst);


### PR DESCRIPTION
Implements the fix for #2152, now using same comparison as mac client for bitmap context creation.
@DonMag thx for the hint.