### PR TITLE
Added support for UPN Suffixes to FreeRDP. 

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1173,8 +1173,8 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 	COMMAND_LINE_ARGUMENT_A* arg;
        char* username = NULL;
        char* gw_username = NULL;
-       char* user;
-       char* domain;
+       char* user = NULL;
+       char* domain = NULL;
 
 	compatibility = freerdp_client_detect_command_line(argc, argv, &flags);
 
@@ -1962,22 +1962,22 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
        {
 	  freerdp_parse_username(username, &user, &domain);
          
-	  settings->Username = user;
-	  settings->Domain = domain;
+	  settings->Username = _strdup(user);
+	  settings->Domain = _strdup(domain);
        }
        else
-	  settings->Username = username;
+	  settings->Username = _strdup(username);
        
        // Same as above for Gateway Username and Domain.
        if (gw_username && !settings->GatewayDomain)
        {
 	  freerdp_parse_username(gw_username, &user, &domain);
          
-	  settings->GatewayUsername = user;
-	  settings->GatewayDomain = domain;
+	  settings->GatewayUsername = _strdup(user);
+	  settings->GatewayDomain = _strdup(domain);
        }
        else
-	  settings->GatewayUsername = gw_username;
+	  settings->GatewayUsername = _strdup(gw_username);
        
        if (user != NULL)
 	 free(user);

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1968,6 +1968,17 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
        else
 	  settings->Username = _strdup(username);
        
+	if (user != NULL)
+	{
+		free(user);
+		user = NULL;
+	}
+	if (domain != NULL)
+	{
+		free(domain);
+		domain = NULL;
+	}
+       
        // Same as above for Gateway Username and Domain.
        if (gw_username && !settings->GatewayDomain)
        {

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1978,6 +1978,15 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
        }
        else
 	  settings->GatewayUsername = gw_username;
+       
+       if (user != NULL)
+	 free(user);
+       if (domain != NULL)
+	 free(domain);
+       if (username != NULL)
+	 free(username);
+       if (gw_username != NULL)
+	 free(gw_username);
 
 	freerdp_performance_flags_make(settings);
 

--- a/winpr/libwinpr/sspi/sspi_winpr.c
+++ b/winpr/libwinpr/sspi/sspi_winpr.c
@@ -344,7 +344,9 @@ int sspi_SetAuthIdentity(SEC_WINNT_AUTH_IDENTITY* identity, const char* user, co
 	identity->Domain = (UINT16*) NULL;
 	identity->DomainLength = 0;
 
-	if (domain)
+	//      edited this line for handling UPN Suffixes. 
+	//      If Username is in UPN format we shouldn't send the Domain in NTLM authentication
+	if (domain && (strstr(user, "@")) == NULL)
 	{
 		status = ConvertToUnicode(CP_UTF8, 0, domain, -1, (LPWSTR*) &(identity->Domain), 0);
 


### PR DESCRIPTION
This includes a fix for issue: 
https://github.com/FreeRDP/FreeRDP/issues/2427

These changes are working for me. I can now logon with UPN Suffix to a win2012r2 Server and additionally to a win2012r2 Server which is behind a 2012 TS Gateway Server.
But this changes have some restrictions:
- If you want to use UPN Suffix Logon, you MUST enter a domain name with /d: even if this 
  domain name doesn't exist at all.
- If you want to use UPN Suffix Logon with TS Gateway, you MUST additionally enter a Gateway 
  domain name with /gd: even if this domain name doesn't exist at all.

This restrictions are necessary, because this is the only way we can decide if the username is for Kerberos authentication or for normal authentication with UPN suffix. I explained this in issue #2427