### PR TITLE
Fixed a regression on the #2333 resolution

### DIFF
--- a/winpr/libwinpr/comm/comm_serial_sys.c
+++ b/winpr/libwinpr/comm/comm_serial_sys.c
@@ -849,6 +849,12 @@ static BOOL _set_timeouts(WINPR_COMM *pComm, const SERIAL_TIMEOUTS *pTimeouts)
 	pComm->timeouts.WriteTotalTimeoutMultiplier = pTimeouts->WriteTotalTimeoutMultiplier;
 	pComm->timeouts.WriteTotalTimeoutConstant   = pTimeouts->WriteTotalTimeoutConstant;
 
+	CommLog_Print(WLOG_DEBUG, "ReadIntervalTimeout %d", pComm->timeouts.ReadIntervalTimeout);
+	CommLog_Print(WLOG_DEBUG, "ReadTotalTimeoutMultiplier %d", pComm->timeouts.ReadTotalTimeoutMultiplier);
+	CommLog_Print(WLOG_DEBUG, "ReadTotalTimeoutConstant %d", pComm->timeouts.ReadTotalTimeoutConstant);
+	CommLog_Print(WLOG_DEBUG, "WriteTotalTimeoutMultiplier %d", pComm->timeouts.WriteTotalTimeoutMultiplier);
+	CommLog_Print(WLOG_DEBUG, "WriteTotalTimeoutConstant %d", pComm->timeouts.WriteTotalTimeoutConstant);
+
 	return TRUE;
 }
 


### PR DESCRIPTION
Revisited the resolution of #2333 I did a few days ago. It appears I was still confused about the definition of the select() timeout. During the issue's resolution, I understood in the select()'s manual "Indefinitely" more as "undefined" whereas we well need a NULL timeout or a zero-ed timeout according the timeouts values.

The resolution of #2333 is preserved.