### PR TITLE
settings: handle collection_add in detection case

### DIFF
--- a/client/common/test/TestClientCmdLine.c
+++ b/client/common/test/TestClientCmdLine.c
@@ -88,6 +88,11 @@ int TestClientCmdLine(int argc, char* argv[])
 	char* cmd19[] = {"xfreerdp", "/monitor-list"};
 	TESTCASE(cmd19, COMMAND_LINE_STATUS_PRINT);
 
+#if 0
+	char* cmd20[] = {"-z --plugin cliprdr --plugin rdpsnd --data alsa latency:100 -- --plugin rdpdr --data disk:w7share:/home/w7share -- --plugin drdynvc --data tsmf:decoder:gstreamer -- -u test host.example.com"};
+	TESTCASE(cmd20, COMMAND_LINE_STATUS_PRINT);
+#endif
+
 	return 0;
 }
 

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -138,6 +138,9 @@ int freerdp_addin_replace_argument_value(ADDIN_ARGV* args, char* previous, char*
 
 void freerdp_device_collection_add(rdpSettings* settings, RDPDR_DEVICE* device)
 {
+	if (!settings->DeviceArray)
+		return;
+
 	if (settings->DeviceArraySize < (settings->DeviceCount + 1))
 	{
 		settings->DeviceArraySize *= 2;
@@ -391,6 +394,9 @@ void freerdp_device_collection_free(rdpSettings* settings)
 
 void freerdp_static_channel_collection_add(rdpSettings* settings, ADDIN_ARGV* channel)
 {
+	if (!settings->StaticChannelArray)
+		return;
+
 	if (settings->StaticChannelArraySize < (settings->StaticChannelCount + 1))
 	{
 		settings->StaticChannelArraySize *= 2;
@@ -471,6 +477,9 @@ void freerdp_static_channel_collection_free(rdpSettings* settings)
 
 void freerdp_dynamic_channel_collection_add(rdpSettings* settings, ADDIN_ARGV* channel)
 {
+	if (!settings->DynamicChannelArray)
+		return;
+
 	if (settings->DynamicChannelArraySize < (settings->DynamicChannelCount + 1))
 	{
 		settings->DynamicChannelArraySize *= 2;


### PR DESCRIPTION
Command line detection is run with dummy settings where not everything
is allocated. Collections (device, dynamic channel and static
channel) didn't handle this case properly.
