### PR TITLE
crypto: use PEM as certificate store file format

### DIFF
--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -523,7 +523,7 @@ BOOL x509_verify_certificate(CryptoCert cert, char* certificate_store_path)
 
 	if (certificate_store_path != NULL)
 	{
-		X509_LOOKUP_add_dir(lookup, certificate_store_path, X509_FILETYPE_ASN1);
+		X509_LOOKUP_add_dir(lookup, certificate_store_path, X509_FILETYPE_PEM);
 	}
 
 	csc = X509_STORE_CTX_new();


### PR DESCRIPTION
Currently the certificate format expected in FreeRDPs certificate store
is DER (ASN1). On most linux/unix systems the system certificate store
default format is PEM. Which is also the more common format used by CAs
to distribute their certificates.

Changing the default format to PEM allows the usage of system
certificates or published CA certificates without the need to convert them.

This fixes a part of issue #2446.