### PR TITLE
libfreerdp: crypto: add certificate chain validation!

### DIFF
--- a/include/freerdp/crypto/crypto.h
+++ b/include/freerdp/crypto/crypto.h
@@ -72,6 +72,7 @@ struct crypto_hmac_struct
 struct crypto_cert_struct
 {
 	X509 * px509;
+	STACK_OF(X509) *px509chain;
 };
 
 #ifdef __cplusplus

--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -533,7 +533,7 @@ BOOL x509_verify_certificate(CryptoCert cert, char* certificate_store_path)
 
 	X509_STORE_set_flags(cert_ctx, 0);
 
-	if (!X509_STORE_CTX_init(csc, cert_ctx, xcert, 0))
+	if (!X509_STORE_CTX_init(csc, cert_ctx, xcert, cert->px509chain))
 		goto end;
 
 	if (X509_verify_cert(csc) == 1)

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -504,6 +504,7 @@ static CryptoCert tls_get_certificate(rdpTls* tls, BOOL peer)
 {
 	CryptoCert cert;
 	X509* remote_cert;
+	STACK_OF(X509) *chain;
 
 	if (peer)
 		remote_cert = SSL_get_peer_certificate(tls->ssl);
@@ -524,6 +525,11 @@ static CryptoCert tls_get_certificate(rdpTls* tls, BOOL peer)
 	}
 
 	cert->px509 = remote_cert;
+
+	/* Get the peer's chain. If it does not exist, we're setting NULL (clean data either way) */
+	chain = SSL_get_peer_cert_chain(tls->ssl);
+	cert->px509chain = chain;
+
 	return cert;
 }
 


### PR DESCRIPTION
Add a stack of X509* to the crypto_cert_struct so that we can ask openssl for the peer's cert chain if it exists, and use that in the actual validation call.

Fixes #2446