### PR TITLE
fix size error introduced in commit 99b14815a53e556080f459a4998d94244803...

### DIFF
--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -2624,7 +2624,7 @@ BOOL update_read_create_offscreen_bitmap_order(wStream* s, CREATE_OFFSCREEN_BITM
 		{
 			UINT16 *new_indices;
 
-			new_indices = (UINT16 *)realloc(deleteList->indices, deleteList->cIndices);
+			new_indices = (UINT16 *)realloc(deleteList->indices, deleteList->sIndices * 2);
 			if (!new_indices)
 				return FALSE;
 


### PR DESCRIPTION
Commit 99b14815a53e556080f459a4998d942448031f08 introduces a bug that causes the client to crash/disconnect.
This was caused by a wrong change in the realloc size.