### PR TITLE
Make handle operations static

### DIFF
--- a/winpr/libwinpr/comm/comm.c
+++ b/winpr/libwinpr/comm/comm.c
@@ -1218,6 +1218,13 @@ void _comm_setServerSerialDriver(HANDLE hComm, SERIAL_DRIVER_ID driverId)
 	pComm->serverSerialDriverId = driverId;
 }
 
+static HANDLE_OPS ops = {
+		CommIsHandled,
+		CommCloseHandle,
+		CommGetFd,
+		NULL /* CleanupHandle */
+};
+
 
 /**
  * http://msdn.microsoft.com/en-us/library/windows/desktop/aa363198%28v=vs.85%29.aspx
@@ -1320,9 +1327,7 @@ HANDLE CommCreateFileA(LPCSTR lpDeviceName, DWORD dwDesiredAccess, DWORD dwShare
 
 	WINPR_HANDLE_SET_TYPE(pComm, HANDLE_TYPE_COMM);
 
-	pComm->cb.GetFd = CommGetFd;
-	pComm->cb.CloseHandle = CommCloseHandle;
-	pComm->cb.IsHandled = CommIsHandled;
+	pComm->ops = &ops;
 
 	/* error_handle */
 

--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -343,6 +343,13 @@ int InstallAioSignalHandler()
 
 #endif /* HAVE_AIO_H */
 
+static HANDLE_OPS ops = {
+		FileIsHandled,
+		FileCloseHandle,
+		FileGetFd,
+		NULL /* CleanupHandle */
+};
+
 HANDLE CreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes,
 				   DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile)
 {
@@ -417,9 +424,7 @@ HANDLE CreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, 
 	strcpy(s.sun_path, pNamedPipe->lpFilePath);
 	status = connect(pNamedPipe->clientfd, (struct sockaddr*) &s, sizeof(struct sockaddr_un));
 
-	pNamedPipe->cb.IsHandled = FileIsHandled;
-	pNamedPipe->cb.CloseHandle = FileCloseHandle;
-	pNamedPipe->cb.GetFd = FileGetFd;
+	pNamedPipe->ops = &ops;
 
 	if (status != 0)
 	{

--- a/winpr/libwinpr/handle/handle.c
+++ b/winpr/libwinpr/handle/handle.c
@@ -51,8 +51,14 @@ BOOL CloseHandle(HANDLE hObject)
 	if (!winpr_Handle_GetInfo(hObject, &Type, (PVOID*)&Object))
 		return FALSE;
 
-	if (Object && Object->cb.CloseHandle)
-		return Object->cb.CloseHandle(hObject);
+	if (!Object)
+		return FALSE;
+
+	if (!Object->ops)
+		return FALSE;
+
+	if(Object->ops->CloseHandle)
+		return Object->ops->CloseHandle(hObject);
 
 	return FALSE;
 }

--- a/winpr/libwinpr/handle/handle.h
+++ b/winpr/libwinpr/handle/handle.h
@@ -41,20 +41,20 @@
 
 #define WINPR_HANDLE_DEF() \
 	ULONG Type; \
-	HANDLE_CLOSE_CB cb
+	HANDLE_OPS *ops
 
 typedef BOOL (*pcIsHandled)(HANDLE handle);
 typedef BOOL (*pcCloseHandle)(HANDLE handle);
 typedef int (*pcGetFd)(HANDLE handle);
 typedef DWORD (*pcCleanupHandle)(HANDLE handle);
 
-typedef struct _HANDLE_CLOSE_CB
+typedef struct _HANDLE_OPS
 {
 	pcIsHandled IsHandled;
 	pcCloseHandle CloseHandle;
 	pcGetFd GetFd;
 	pcCleanupHandle CleanupHandle;
-} HANDLE_CLOSE_CB;
+} HANDLE_OPS;
 
 struct winpr_handle
 {
@@ -88,10 +88,10 @@ static INLINE int winpr_Handle_getFd(HANDLE handle)
 	if (!winpr_Handle_GetInfo(handle, &type, (PVOID*)&hdl))
 		return -1;
 
-	if (!hdl || !hdl->cb.GetFd)
+	if (!hdl || !hdl->ops->GetFd)
 		return -1;
 
-	return hdl->cb.GetFd(handle);
+	return hdl->ops->GetFd(handle);
 }
 
 static INLINE DWORD winpr_Handle_cleanup(HANDLE handle)
@@ -106,10 +106,10 @@ static INLINE DWORD winpr_Handle_cleanup(HANDLE handle)
 		return WAIT_FAILED;
 
 	/* If there is no cleanup function, assume all ok. */
-	if (!hdl->cb.CleanupHandle)
+	if (!hdl->ops->CleanupHandle)
 		return WAIT_OBJECT_0;
 
-	return hdl->cb.CleanupHandle(handle);
+	return hdl->ops->CleanupHandle(handle);
 }
 
 #endif /* WINPR_HANDLE_PRIVATE_H */

--- a/winpr/libwinpr/handle/nonehandle.c
+++ b/winpr/libwinpr/handle/nonehandle.c
@@ -56,6 +56,13 @@ static int NoneHandleGetFd(HANDLE handle)
 	return -1;
 }
 
+static HANDLE_OPS ops = {
+		NoneHandleIsHandle,
+		NoneHandleCloseHandle,
+		NoneHandleGetFd,
+		NULL /* CleanupHandle */
+};
+
 HANDLE CreateNoneHandle()
 {
 	WINPR_NONE_HANDLE* none;
@@ -64,9 +71,7 @@ HANDLE CreateNoneHandle()
 	if (!none)
 		return NULL;
 
-	none->cb.IsHandled = NoneHandleIsHandle;
-	none->cb.CloseHandle = NoneHandleCloseHandle;
-	none->cb.GetFd = NoneHandleGetFd;
+	none->ops = &ops;
 
 	return (HANDLE)none;
 }

--- a/winpr/libwinpr/pipe/pipe.c
+++ b/winpr/libwinpr/pipe/pipe.c
@@ -105,6 +105,7 @@ BOOL PipeCloseHandle(HANDLE handle) {
 	if (pipe->fd != -1)
 	{
 		close(pipe->fd);
+		pipe->fd = -1;
 	}
 
 	free(handle);
@@ -118,6 +119,13 @@ static void InitWinPRPipeModule()
 
 	g_NamedPipeServerSockets = ArrayList_New(FALSE);
 }
+
+static HANDLE_OPS ops = {
+		PipeIsHandled,
+		PipeCloseHandle,
+		PipeGetFd,
+		NULL /* CleanupHandle */
+};
 
 
 /*
@@ -155,15 +163,11 @@ BOOL CreatePipe(PHANDLE hReadPipe, PHANDLE hWritePipe, LPSECURITY_ATTRIBUTES lpP
 	pReadPipe->fd = pipe_fd[0];
 	pWritePipe->fd = pipe_fd[1];
 	WINPR_HANDLE_SET_TYPE(pReadPipe, HANDLE_TYPE_ANONYMOUS_PIPE);
-	pReadPipe->cb.GetFd = PipeGetFd;
-	pReadPipe->cb.CloseHandle = PipeCloseHandle;
-	pReadPipe->cb.IsHandled = PipeIsHandled;
+	pReadPipe->ops = &ops;
 
 	*((ULONG_PTR*) hReadPipe) = (ULONG_PTR) pReadPipe;
 	WINPR_HANDLE_SET_TYPE(pWritePipe, HANDLE_TYPE_ANONYMOUS_PIPE);
-	pWritePipe->cb.GetFd = PipeGetFd;
-	pWritePipe->cb.CloseHandle = PipeCloseHandle;
-	pWritePipe->cb.IsHandled = PipeIsHandled;
+	pWritePipe->ops = &ops;
 	*((ULONG_PTR*) hWritePipe) = (ULONG_PTR) pWritePipe;
 	return TRUE;
 }

--- a/winpr/libwinpr/sspicli/sspicli.c
+++ b/winpr/libwinpr/sspicli/sspicli.c
@@ -114,6 +114,13 @@ BOOL LogonUserCloseHandle(HANDLE handle) {
 	return TRUE;
 }
 
+static HANDLE_OPS ops = {
+		LogonUserIsHandled,
+		LogonUserCloseHandle,
+		LogonUserGetFd,
+		NULL /* CleanupHandle */
+};
+
 BOOL LogonUserA(LPCSTR lpszUsername, LPCSTR lpszDomain, LPCSTR lpszPassword,
 		DWORD dwLogonType, DWORD dwLogonProvider, PHANDLE phToken)
 {
@@ -130,9 +137,7 @@ BOOL LogonUserA(LPCSTR lpszUsername, LPCSTR lpszDomain, LPCSTR lpszPassword,
 
 	WINPR_HANDLE_SET_TYPE(token, HANDLE_TYPE_ACCESS_TOKEN);
 
-	token->cb.GetFd = LogonUserGetFd;
-	token->cb.CloseHandle = LogonUserCloseHandle;
-	token->cb.IsHandled = LogonUserIsHandled;
+	token->ops = &ops;
 
 	token->Username = _strdup(lpszUsername);
 

--- a/winpr/libwinpr/synch/event.c
+++ b/winpr/libwinpr/synch/event.c
@@ -96,6 +96,13 @@ BOOL EventCloseHandle(HANDLE handle) {
     return TRUE;
 }
 
+static HANDLE_OPS ops = {
+		EventIsHandled,
+		EventCloseHandle,
+		EventGetFd,
+		NULL /* CleanupHandle */
+};
+
 HANDLE CreateEventW(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL bManualReset, BOOL bInitialState, LPCWSTR lpName)
 {
 	WINPR_EVENT* event;
@@ -105,9 +112,7 @@ HANDLE CreateEventW(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL bManualReset, 
 	{
 		event->bAttached = FALSE;
 		event->bManualReset = bManualReset;
-		event->cb.IsHandled = EventIsHandled;
-		event->cb.CloseHandle = EventCloseHandle;
-		event->cb.GetFd = EventGetFd;
+		event->ops = &ops;
 
 		if (!event->bManualReset)
 		{
@@ -271,6 +276,7 @@ BOOL ResetEvent(HANDLE hEvent)
 
 #endif
 
+
 HANDLE CreateFileDescriptorEventW(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL bManualReset, BOOL bInitialState, int FileDescriptor)
 {
 #ifndef _WIN32
@@ -284,9 +290,7 @@ HANDLE CreateFileDescriptorEventW(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL 
 		event->bManualReset = bManualReset;
 		event->pipe_fd[0] = FileDescriptor;
 		event->pipe_fd[1] = -1;
-		event->cb.CloseHandle = EventCloseHandle;
-		event->cb.GetFd = EventGetFd;
-		event->cb.IsHandled = EventIsHandled;
+		event->ops = &ops;
 		WINPR_HANDLE_SET_TYPE(event, HANDLE_TYPE_EVENT);
 		handle = (HANDLE) event;
 	}

--- a/winpr/libwinpr/synch/mutex.c
+++ b/winpr/libwinpr/synch/mutex.c
@@ -68,6 +68,13 @@ BOOL MutexCloseHandle(HANDLE handle) {
 	return TRUE;
 }
 
+static HANDLE_OPS ops = {
+		MutexIsHandled,
+		MutexCloseHandle,
+		MutexGetFd,
+		NULL /* CleanupHandle */
+};
+
 HANDLE CreateMutexW(LPSECURITY_ATTRIBUTES lpMutexAttributes, BOOL bInitialOwner, LPCWSTR lpName)
 {
 	HANDLE handle = NULL;
@@ -80,9 +87,7 @@ HANDLE CreateMutexW(LPSECURITY_ATTRIBUTES lpMutexAttributes, BOOL bInitialOwner,
 		pthread_mutex_init(&mutex->mutex, 0);
 
 		WINPR_HANDLE_SET_TYPE(mutex, HANDLE_TYPE_MUTEX);
-		mutex->cb.GetFd = MutexGetFd;
-		mutex->cb.CloseHandle = MutexCloseHandle;
-		mutex->cb.IsHandled = MutexIsHandled;
+		mutex->ops = &ops;
 
 		handle = (HANDLE) mutex;
 

--- a/winpr/libwinpr/synch/semaphore.c
+++ b/winpr/libwinpr/synch/semaphore.c
@@ -111,6 +111,13 @@ BOOL SemaphoreCloseHandle(HANDLE handle) {
 	return TRUE;
 }
 
+static HANDLE_OPS ops = {
+		SemaphoreIsHandled,
+		SemaphoreCloseHandle,
+		SemaphoreGetFd,
+		SemaphoreCleanupHandle
+};
+
 HANDLE CreateSemaphoreW(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lInitialCount, LONG lMaximumCount, LPCWSTR lpName)
 {
 	HANDLE handle;
@@ -124,10 +131,7 @@ HANDLE CreateSemaphoreW(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lIniti
 	semaphore->pipe_fd[0] = -1;
 	semaphore->pipe_fd[0] = -1;
 	semaphore->sem = (winpr_sem_t*) NULL;
-	semaphore->cb.IsHandled = SemaphoreIsHandled;
-	semaphore->cb.CloseHandle = SemaphoreCloseHandle;
-	semaphore->cb.GetFd = SemaphoreGetFd;
-	semaphore->cb.CleanupHandle = SemaphoreCleanupHandle;
+	semaphore->ops = &ops;
 
 	if (semaphore)
 	{
@@ -220,6 +224,7 @@ BOOL ReleaseSemaphore(HANDLE hSemaphore, LONG lReleaseCount, LPLONG lpPreviousCo
 		return TRUE;
 	}
 
+	WLog_ERR(TAG, "calling %s on a handle that is not a semaphore");
 	return FALSE;
 }
 

--- a/winpr/libwinpr/synch/timer.c
+++ b/winpr/libwinpr/synch/timer.c
@@ -210,6 +210,14 @@ int InitializeWaitableTimer(WINPR_TIMER* timer)
 	return 0;
 }
 
+
+static HANDLE_OPS ops = {
+		TimerIsHandled,
+		TimerCloseHandle,
+		TimerGetFd,
+		TimerCleanupHandle
+};
+
 /**
  * Waitable Timer
  */
@@ -230,10 +238,7 @@ HANDLE CreateWaitableTimerA(LPSECURITY_ATTRIBUTES lpTimerAttributes, BOOL bManua
 		timer->pfnCompletionRoutine = NULL;
 		timer->lpArgToCompletionRoutine = NULL;
 		timer->bInit = FALSE;
-		timer->cb.GetFd = TimerGetFd;
-		timer->cb.CloseHandle = TimerCloseHandle;
-		timer->cb.IsHandled = TimerIsHandled;
-		timer->cb.CleanupHandle = TimerCleanupHandle;
+		timer->ops = &ops;
 	}
 
 	return handle;

--- a/winpr/libwinpr/thread/process.c
+++ b/winpr/libwinpr/thread/process.c
@@ -487,6 +487,13 @@ static int ProcessGetFd(HANDLE handle)
 	return -1;
 }
 
+static HANDLE_OPS ops = {
+		ProcessHandleIsHandle,
+		ProcessHandleCloseHandle,
+		ProcessGetFd,
+		NULL /* CleanupHandle */
+};
+
 HANDLE CreateProcessHandle(pid_t pid)
 {
 	WINPR_PROCESS* process;
@@ -497,9 +504,7 @@ HANDLE CreateProcessHandle(pid_t pid)
 
 	process->pid = pid;
 	process->Type = HANDLE_TYPE_PROCESS;
-	process->cb.GetFd = ProcessGetFd;
-	process->cb.CloseHandle = ProcessHandleCloseHandle;
-	process->cb.IsHandled = ProcessHandleIsHandle;
+	process->ops = &ops;
 
 	return (HANDLE)process;
 }

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -151,6 +151,14 @@ static DWORD ThreadCleanupHandle(HANDLE handle)
 	return WAIT_OBJECT_0;
 }
 
+static HANDLE_OPS ops = {
+		ThreadIsHandled,
+		ThreadCloseHandle,
+		ThreadGetFd,
+		ThreadCleanupHandle
+};
+
+
 static void dump_thread(WINPR_THREAD* thread)
 {
 #if defined(WITH_DEBUG_THREADS)
@@ -339,10 +347,7 @@ HANDLE CreateThread(LPSECURITY_ATTRIBUTES lpThreadAttributes, SIZE_T dwStackSize
 	thread->lpParameter = lpParameter;
 	thread->lpStartAddress = lpStartAddress;
 	thread->lpThreadAttributes = lpThreadAttributes;
-	thread->cb.IsHandled = ThreadIsHandled;
-	thread->cb.CloseHandle = ThreadCloseHandle;
-	thread->cb.GetFd = ThreadGetFd;
-	thread->cb.CleanupHandle = ThreadCleanupHandle;
+	thread->ops = &ops;
 
 #if defined(WITH_DEBUG_THREADS)
 	thread->create_stack = winpr_backtrace(20);


### PR DESCRIPTION
This patch moves the handle operations in a static struct.

Note that the test with named pipes fails after the patch, but it was already triggering errors in valgrind before. So I guess there's a problem either with pipes or with the test itself.