### PR TITLE
Force cmdline to ignore unknown keywords

### DIFF
--- a/client/DirectFB/dfreerdp.c
+++ b/client/DirectFB/dfreerdp.c
@@ -468,7 +468,7 @@ int main(int argc, char* argv[])
 	instance->context->argc = argc;
 	instance->context->argv = argv;
 
-	status = freerdp_client_settings_parse_command_line(instance->settings, argc, argv);
+	status = freerdp_client_settings_parse_command_line(instance->settings, argc, argv, FALSE);
 
 	if (status < 0)
 		exit(0);

--- a/client/Mac/cli/AppDelegate.m
+++ b/client/Mac/cli/AppDelegate.m
@@ -105,7 +105,7 @@ void mac_set_view_size(rdpContext* context, MRDPView* view);
 	
 	context->argc = i;
 	
-	status = freerdp_client_settings_parse_command_line(context->settings, context->argc, context->argv);
+	status = freerdp_client_settings_parse_command_line(context->settings, context->argc, context->argv, FALSE);
 	
 	status = freerdp_client_settings_command_line_status_print(context->settings, status, context->argc, context->argv);
 

--- a/client/Sample/freerdp.c
+++ b/client/Sample/freerdp.c
@@ -334,7 +334,7 @@ int main(int argc, char* argv[])
 
 	channels = instance->context->channels;
 
-	status = freerdp_client_settings_parse_command_line(instance->settings, argc, argv);
+	status = freerdp_client_settings_parse_command_line(instance->settings, argc, argv, FALSE);
 
 	if (status < 0)
 	{

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -269,7 +269,7 @@ int main(int argc, char* argv[])
 	instance->ContextFree = wl_context_free;
 	freerdp_context_new(instance);
 
-	status = freerdp_client_settings_parse_command_line_arguments(instance->settings, argc, argv);
+	status = freerdp_client_settings_parse_command_line_arguments(instance->settings, argc, argv, FALSE);
 
 	status = freerdp_client_settings_command_line_status_print(instance->settings, status, argc, argv);
 

--- a/client/Windows/cli/wfreerdp.c
+++ b/client/Windows/cli/wfreerdp.c
@@ -70,7 +70,7 @@ INT WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	for (index = 0; index < context->argc; index++)
 		context->argv[index] = _strdup(__argv[index]);
 
-	status = freerdp_client_settings_parse_command_line(settings, context->argc, context->argv);
+	status = freerdp_client_settings_parse_command_line(settings, context->argc, context->argv, FALSE);
 
 	status = freerdp_client_settings_command_line_status_print(settings, status, context->argc, context->argv);
 

--- a/client/X11/cli/xfreerdp.c
+++ b/client/X11/cli/xfreerdp.c
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
 	settings = context->settings;
 	xfc = (xfContext*) context;
 
-	status = freerdp_client_settings_parse_command_line(context->settings, argc, argv);
+	status = freerdp_client_settings_parse_command_line(context->settings, argc, argv, FALSE);
 
 	status = freerdp_client_settings_command_line_status_print(settings, status, argc, argv);
 

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -159,7 +159,8 @@ out_error:
 }
 
 
-int freerdp_client_settings_parse_command_line(rdpSettings* settings, int argc, char** argv)
+int freerdp_client_settings_parse_command_line(rdpSettings* settings, int argc,
+	char** argv, BOOL allowUnknown)
 {
 	int status;
 
@@ -169,7 +170,7 @@ int freerdp_client_settings_parse_command_line(rdpSettings* settings, int argc, 
 	if (!argv)
 		return -1;
 
-	status = freerdp_client_settings_parse_command_line_arguments(settings, argc, argv);
+	status = freerdp_client_settings_parse_command_line_arguments(settings, argc, argv, allowUnknown);
 
 	if (settings->ConnectionFile)
 	{

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -988,7 +988,8 @@ int freerdp_detect_command_line_pre_filter(void* context, int index, int argc, L
 	return 0;
 }
 
-int freerdp_detect_windows_style_command_line_syntax(int argc, char** argv, int* count)
+int freerdp_detect_windows_style_command_line_syntax(int argc, char** argv,
+	int* count, BOOL ignoreUnknown)
 {
 	int status;
 	DWORD flags;
@@ -997,6 +998,10 @@ int freerdp_detect_windows_style_command_line_syntax(int argc, char** argv, int*
 
 	flags = COMMAND_LINE_SEPARATOR_COLON;
 	flags |= COMMAND_LINE_SIGIL_SLASH | COMMAND_LINE_SIGIL_PLUS_MINUS;
+	if (ignoreUnknown)
+	{
+		flags |= COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
+	}
 
 	*count = 0;
 	detect_status = 0;
@@ -1025,7 +1030,8 @@ int freerdp_detect_windows_style_command_line_syntax(int argc, char** argv, int*
 	return detect_status;
 }
 
-int freerdp_detect_posix_style_command_line_syntax(int argc, char** argv, int* count)
+int freerdp_detect_posix_style_command_line_syntax(int argc, char** argv,
+	int* count, BOOL ignoreUnknown)
 {
 	int status;
 	DWORD flags;
@@ -1035,6 +1041,10 @@ int freerdp_detect_posix_style_command_line_syntax(int argc, char** argv, int* c
 	flags = COMMAND_LINE_SEPARATOR_SPACE;
 	flags |= COMMAND_LINE_SIGIL_DASH | COMMAND_LINE_SIGIL_DOUBLE_DASH;
 	flags |= COMMAND_LINE_SIGIL_ENABLE_DISABLE;
+	if (ignoreUnknown)
+	{
+		flags |= COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
+	}
 
 	*count = 0;
 	detect_status = 0;
@@ -1063,7 +1073,8 @@ int freerdp_detect_posix_style_command_line_syntax(int argc, char** argv, int* c
 	return detect_status;
 }
 
-BOOL freerdp_client_detect_command_line(int argc, char** argv, DWORD* flags)
+static BOOL freerdp_client_detect_command_line(int argc, char** argv,
+	DWORD* flags, BOOL ignoreUnknown)
 {
 	int old_cli_status;
 	int old_cli_count;
@@ -1073,8 +1084,8 @@ BOOL freerdp_client_detect_command_line(int argc, char** argv, DWORD* flags)
 	int windows_cli_count;
 	BOOL compatibility = FALSE;
 
-	windows_cli_status = freerdp_detect_windows_style_command_line_syntax(argc, argv, &windows_cli_count);
-	posix_cli_status = freerdp_detect_posix_style_command_line_syntax(argc, argv, &posix_cli_count);
+	windows_cli_status = freerdp_detect_windows_style_command_line_syntax(argc, argv, &windows_cli_count, ignoreUnknown);
+	posix_cli_status = freerdp_detect_posix_style_command_line_syntax(argc, argv, &posix_cli_count, ignoreUnknown);
 	old_cli_status = freerdp_detect_old_command_line_syntax(argc, argv, &old_cli_count);
 
 	/* Default is POSIX syntax */
@@ -1179,7 +1190,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 	BOOL compatibility;
 	COMMAND_LINE_ARGUMENT_A* arg;
 
-	compatibility = freerdp_client_detect_command_line(argc, argv, &flags);
+	compatibility = freerdp_client_detect_command_line(argc, argv, &flags, allowUnknown);
 
 	if (compatibility)
 	{

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1168,7 +1168,8 @@ int freerdp_client_settings_command_line_status_print(rdpSettings* settings, int
 	return 0;
 }
 
-int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, int argc, char** argv)
+int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
+	int argc, char** argv, BOOL allowUnknown)
 {
 	char* p;
 	char* str;
@@ -1189,6 +1190,10 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 	{
 		CommandLineClearArgumentsA(args);
 
+		if (allowUnknown)
+		{
+			flags |= COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
+		}
 		status = CommandLineParseArgumentsA(argc, (const char**) argv, args, flags, settings,
 				freerdp_client_command_line_pre_filter, freerdp_client_command_line_post_filter);
 

--- a/client/common/file.c
+++ b/client/common/file.c
@@ -1040,7 +1040,7 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 		char* ConnectionFile = settings->ConnectionFile;
 
 		settings->ConnectionFile = NULL;
-		freerdp_client_settings_parse_command_line(settings, file->argc, file->argv);
+		freerdp_client_settings_parse_command_line(settings, file->argc, file->argv, FALSE);
 		settings->ConnectionFile = ConnectionFile;
 	}
 

--- a/client/common/test/TestClientCmdLine.c
+++ b/client/common/test/TestClientCmdLine.c
@@ -4,13 +4,13 @@
 #include <winpr/cmdline.h>
 #include <winpr/spec.h>
 
-#define TESTCASE(cmd, expected_return) status = freerdp_client_settings_parse_command_line(settings, ARRAYSIZE(cmd), cmd); \
+#define TESTCASE(cmd, expected_return) status = freerdp_client_settings_parse_command_line(settings, ARRAYSIZE(cmd), cmd, FALSE); \
    if (status != expected_return) { \
       printf("Test argument %s failed\n", #cmd); \
        return -1; \
     }
 
-#define TESTCASE_SUCCESS(cmd) status = freerdp_client_settings_parse_command_line(settings, ARRAYSIZE(cmd), cmd); \
+#define TESTCASE_SUCCESS(cmd) status = freerdp_client_settings_parse_command_line(settings, ARRAYSIZE(cmd), cmd, FALSE); \
    if (status < 0) { \
      printf("Test argument %s failed\n", #cmd); \
      return -1; \

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -85,7 +85,8 @@ FREERDP_API int freerdp_client_stop(rdpContext* context);
 FREERDP_API freerdp* freerdp_client_get_instance(rdpContext* context);
 FREERDP_API HANDLE freerdp_client_get_thread(rdpContext* context);
 
-FREERDP_API int freerdp_client_settings_parse_command_line(rdpSettings* settings, int argc, char** argv);
+FREERDP_API int freerdp_client_settings_parse_command_line(rdpSettings* settings,
+	int argc, char** argv, BOOL allowUnknown);
 
 FREERDP_API int freerdp_client_settings_parse_connection_file(rdpSettings* settings, const char* filename);
 FREERDP_API int freerdp_client_settings_parse_connection_file_buffer(rdpSettings* settings, const BYTE* buffer, size_t size);

--- a/include/freerdp/client/cmdline.h
+++ b/include/freerdp/client/cmdline.h
@@ -27,7 +27,8 @@
 extern "C" {
 #endif
 
-FREERDP_API int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, int argc, char** argv);
+FREERDP_API int freerdp_client_settings_parse_command_line_arguments(
+	rdpSettings* settings, int argc, char** argv, BOOL allowUnknown);
 FREERDP_API int freerdp_client_settings_command_line_status_print(rdpSettings* settings, int status, int argc, char** argv);
 FREERDP_API int freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings);
 


### PR DESCRIPTION
* Extended ```freerdp_client_settings_parse_command_line``` arguments to allow ignoring unknown keywords in parser