### PR TITLE
Incorrect extents calculation in region16_intersect_rect (libfreerdp/codec/region.c)

### DIFF
--- a/libfreerdp/codec/region.c
+++ b/libfreerdp/codec/region.c
@@ -132,10 +132,10 @@ static RECTANGLE_16 *region16_extents_noconst(REGION16 *region)
 
 BOOL rectangle_is_empty(const RECTANGLE_16 *rect)
 {
-	/* A rectangle with width <= 0 or height <= 0 should be regarded
+	/* A rectangle with width = 0 or height = 0 should be regarded
 	 * as empty.
 	 */
-	return ((rect->left >= rect->right) || (rect->top >= rect->bottom)) ? TRUE : FALSE;
+	return ((rect->left == rect->right) || (rect->top == rect->bottom)) ? TRUE : FALSE;
 }
 
 BOOL region16_is_empty(const REGION16 *region)

--- a/libfreerdp/codec/region.c
+++ b/libfreerdp/codec/region.c
@@ -132,7 +132,10 @@ static RECTANGLE_16 *region16_extents_noconst(REGION16 *region)
 
 BOOL rectangle_is_empty(const RECTANGLE_16 *rect)
 {
-	return (rect->left + rect->top + rect->right + rect->bottom) ? TRUE : FALSE;
+    /* An rectangle with width <= 0 or height <= 0 should be regarded
+     * as empty.
+     */
+	return ((rect->left >= rect->right) || (rect->top >= rect->bottom)) ? TRUE : FALSE;
 }
 
 BOOL region16_is_empty(const REGION16 *region)
@@ -770,10 +773,21 @@ BOOL region16_intersect_rect(REGION16 *dst, const REGION16 *src, const RECTANGLE
 			usedRects++;
 			dstPtr++;
 
-			newExtents.top = MIN(common.top, newExtents.top);
-			newExtents.left = MIN(common.left, newExtents.left);
-			newExtents.bottom = MAX(common.bottom, newExtents.bottom);
-			newExtents.right = MAX(common.right, newExtents.right);
+            if (rectangle_is_empty(&newExtents))
+            {
+                /* Check if the existing newExtents is empty. If it is empty, use 
+                 * new common directly. We do not need to check common rectangle 
+                 * because the rectangles_intersection() ensures that it is not empty.
+                 */
+                newExtents = common;
+            }
+            else
+            {
+                newExtents.top = MIN(common.top, newExtents.top);
+                newExtents.left = MIN(common.left, newExtents.left);
+                newExtents.bottom = MAX(common.bottom, newExtents.bottom);
+                newExtents.right = MAX(common.right, newExtents.right);
+            }
 		}
 	}
 

--- a/libfreerdp/codec/region.c
+++ b/libfreerdp/codec/region.c
@@ -132,9 +132,9 @@ static RECTANGLE_16 *region16_extents_noconst(REGION16 *region)
 
 BOOL rectangle_is_empty(const RECTANGLE_16 *rect)
 {
-    /* An rectangle with width <= 0 or height <= 0 should be regarded
-     * as empty.
-     */
+	/* A rectangle with width <= 0 or height <= 0 should be regarded
+	 * as empty.
+	 */
 	return ((rect->left >= rect->right) || (rect->top >= rect->bottom)) ? TRUE : FALSE;
 }
 
@@ -773,21 +773,21 @@ BOOL region16_intersect_rect(REGION16 *dst, const REGION16 *src, const RECTANGLE
 			usedRects++;
 			dstPtr++;
 
-            if (rectangle_is_empty(&newExtents))
-            {
-                /* Check if the existing newExtents is empty. If it is empty, use 
-                 * new common directly. We do not need to check common rectangle 
-                 * because the rectangles_intersection() ensures that it is not empty.
-                 */
-                newExtents = common;
-            }
-            else
-            {
-                newExtents.top = MIN(common.top, newExtents.top);
-                newExtents.left = MIN(common.left, newExtents.left);
-                newExtents.bottom = MAX(common.bottom, newExtents.bottom);
-                newExtents.right = MAX(common.right, newExtents.right);
-            }
+			if (rectangle_is_empty(&newExtents))
+			{
+				/* Check if the existing newExtents is empty. If it is empty, use 
+				 * new common directly. We do not need to check common rectangle 
+				 * because the rectangles_intersection() ensures that it is not empty.
+				 */
+				newExtents = common;
+			}
+			else
+			{
+				newExtents.top = MIN(common.top, newExtents.top);
+				newExtents.left = MIN(common.left, newExtents.left);
+				newExtents.bottom = MAX(common.bottom, newExtents.bottom);
+				newExtents.right = MAX(common.right, newExtents.right);
+			}
 		}
 	}
 

--- a/libfreerdp/codec/test/TestFreeRDPRegion.c
+++ b/libfreerdp/codec/test/TestFreeRDPRegion.c
@@ -668,11 +668,10 @@ static int test_empty_rectangle() {
 	int retCode = -1;
 	int i;
 
-	RECTANGLE_16 emptyRectangles[4] = {
+	RECTANGLE_16 emptyRectangles[3] = {
 		{   0,    0,    0,    0},
 		{  10,   10,   10,   11},
-		{  10,   10,   11,   10},
-		{ 100,  100,    0,    0}
+		{  10,   10,   11,   10}
 	};
 
 	RECTANGLE_16 firstRect = {
@@ -689,7 +688,7 @@ static int test_empty_rectangle() {
 	region16_init(&intersection);
 
 	/* Check for empty rectangles */
-	for (i = 0; i < 4; i++)
+	for (i = 0; i < 3; i++)
 	{
 		if (!rectangle_is_empty(&emptyRectangles[i]))
 			goto out;

--- a/libfreerdp/codec/test/TestFreeRDPRegion.c
+++ b/libfreerdp/codec/test/TestFreeRDPRegion.c
@@ -669,17 +669,17 @@ static int test_empty_rectangle() {
 	int i;
 
 	RECTANGLE_16 emptyRectangles[4] = {
-			{   0,    0,    0,    0},
-			{  10,   10,   10,   11},
-			{  10,   10,   11,   10},
-			{ 100,  100,    0,    0}
+		{   0,    0,    0,    0},
+		{  10,   10,   10,   11},
+		{  10,   10,   11,   10},
+		{ 100,  100,    0,    0}
 	};
 
 	RECTANGLE_16 firstRect = {
-        0, 0, 100, 100
+		0, 0, 100, 100
 	};
 	RECTANGLE_16 anotherRect = {
-        100, 100,  200,  200
+		100, 100,  200,  200
 	};
 	RECTANGLE_16 expected_inter_extents = {
 		0, 0, 0, 0 
@@ -688,23 +688,23 @@ static int test_empty_rectangle() {
 	region16_init(&region);
 	region16_init(&intersection);
 
-    /* Check for empty rectangles */
+	/* Check for empty rectangles */
 	for (i = 0; i < 4; i++)
 	{
-        if (!rectangle_is_empty(&emptyRectangles[i]))
-            goto out;
+		if (!rectangle_is_empty(&emptyRectangles[i]))
+			goto out;
 	}
 
-    /* Check for non-empty rectangles */
-    if (rectangle_is_empty(&firstRect))
-        goto out;
+	/* Check for non-empty rectangles */
+	if (rectangle_is_empty(&firstRect))
+		goto out;
 
-    /* Intersect 2 non-intersect rectangle, result should be empty */
-    if (!region16_union_rect(&region, &region, &firstRect))
-        goto out;
+	/* Intersect 2 non-intersect rectangle, result should be empty */
+	if (!region16_union_rect(&region, &region, &firstRect))
+		goto out;
 
-    if (!region16_intersect_rect(&region, &region, &anotherRect))
-        goto out;
+	if (!region16_intersect_rect(&region, &region, &anotherRect))
+		goto out;
 
 	if (!compareRectangles(region16_extents(&region), &expected_inter_extents, 1) )
 		goto out;
@@ -712,8 +712,8 @@ static int test_empty_rectangle() {
 	if (!region16_is_empty(&region))
 		goto out;
 
-    if (!rectangle_is_empty(region16_extents(&intersection)))
-        goto out;
+	if (!rectangle_is_empty(region16_extents(&intersection)))
+		goto out;
 
 	retCode = 0;
 out:
@@ -741,7 +741,7 @@ struct UnitaryTest tests[] = {
 	{"R1 & R3",					test_r1_inter_r3},
 	{"(R1+R3)&R11 (band merge)",test_r1_r3_inter_r11},
 	{"norbert case",			test_norbert_case},
-	{"empty rectangle case",    test_empty_rectangle},
+	{"empty rectangle case",	test_empty_rectangle},
 
 	{NULL, NULL}
 };

--- a/libfreerdp/codec/test/TestFreeRDPRegion.c
+++ b/libfreerdp/codec/test/TestFreeRDPRegion.c
@@ -638,6 +638,32 @@ static int test_norbert_case() {
 	region16_init(&region);
 	region16_init(&intersection);
 
+	/*
+	 * Consider following as a screen with resolution 1920*1080
+	 *      | |    |     |           |               |      |
+	 *      | |2   |53   |294        |971            |1680  |
+	 *      | |    |     |           |               |      |
+	 *    0 +=+======================================+======+
+	 *      | |                                      |      |
+	 *      |                                        |  R[0]|
+	 *  242 |            +-----------+               +------+
+	 *      | |          |           |               |      |
+	 *      |            |           |               |      |
+	 *      |            |       R[1]|               |  R[2]|
+	 *  776 | |          +-----------+               +------+
+	 *      |                                        |      |
+	 *      |                                        |  R[3]|
+	 * 1036 | |                                      +------+
+	 * 1040 | +----+                                        
+	 *      | |R[4]|                         Union of R[0-4]|
+	 * 1078 | +----+    -    -    -    -    -    -    -    -+
+	 * 1080 |                                       
+	 *   
+	 *   
+	 * The result is union of R[0] - R[4].
+	 * After intersected with the full screen rect, the 
+	 * result should keep the same.
+	 */
 	for (i = 0; i < 5; i++)
 	{
 		if (!region16_union_rect(&region, &region, &inRectangles[i]))


### PR DESCRIPTION
There's an issue in libfreerdp/codec/region.c. When there's more than 2 rectangles in the region structure, region16_intersect_rect would calculate extents by all 'intersected' sub rectangles.
But it always extend the extents to (0,0) because it initialize the new extents as (0,0,0,0) and union later rectangles with this empty point by simple MIN/MAX calculation.

In addition, the semantics of rectangle_is_empty is also wrong.

A fix could be as following:

```diff
diff --git a/libfreerdp/codec/region.c b/libfreerdp/codec/region.c
index 95ce193..739b655 100644
--- a/libfreerdp/codec/region.c
+++ b/libfreerdp/codec/region.c
@@ -132,7 +132,7 @@ static RECTANGLE_16 *region16_extents_noconst(REGION16 *region)

 BOOL rectangle_is_empty(const RECTANGLE_16 *rect)
 {
-   return (rect->left + rect->top + rect->right + rect->bottom) ? TRUE : FALSE;
+   return ((rect->left == rect->right) || (rect->top == rect->bottom)) ? TRUE : FALSE;
 }

 BOOL region16_is_empty(const REGION16 *region)
@@ -770,10 +770,17 @@ BOOL region16_intersect_rect(REGION16 *dst, const REGION16 *src, const RECTANGLE
            usedRects++;
            dstPtr++;

-           newExtents.top = MIN(common.top, newExtents.top);
-           newExtents.left = MIN(common.left, newExtents.left);
-           newExtents.bottom = MAX(common.bottom, newExtents.bottom);
-           newExtents.right = MAX(common.right, newExtents.right);
+            if (rectangle_is_empty(&newExtents))
+            {
+                newExtents = common;
+            }
+            else
+            {
+                newExtents.top = MIN(common.top, newExtents.top);
+                newExtents.left = MIN(common.left, newExtents.left);
+                newExtents.bottom = MAX(common.bottom, newExtents.bottom);
+                newExtents.right = MAX(common.right, newExtents.right);
+            }
        }
    }
```
