### PR TITLE
rename and update tls_disconnect

### DIFF
--- a/include/freerdp/crypto/tls.h
+++ b/include/freerdp/crypto/tls.h
@@ -90,7 +90,7 @@ struct rdp_tls
 
 FREERDP_API int tls_connect(rdpTls* tls, BIO *underlying);
 FREERDP_API BOOL tls_accept(rdpTls* tls, BIO *underlying, const char* cert_file, const char* privatekey_file);
-FREERDP_API BOOL tls_disconnect(rdpTls* tls);
+FREERDP_API BOOL tls_send_alert(rdpTls* tls);
 
 FREERDP_API int tls_write_all(rdpTls* tls, const BYTE* data, int length);
 

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -709,7 +709,7 @@ int tls_do_handshake(rdpTls* tls, BOOL clientMode)
 		if (verify_status < 1)
 		{
 			WLog_ERR(TAG, "certificate not trusted, aborting.");
-			tls_disconnect(tls);
+			tls_send_alert(tls);
 			verify_status = 0;
 		}
 	}
@@ -819,7 +819,7 @@ BOOL tls_accept(rdpTls* tls, BIO* underlying, const char* cert_file, const char*
 	return tls_do_handshake(tls, FALSE) > 0;
 }
 
-BOOL tls_disconnect(rdpTls* tls)
+BOOL tls_send_alert(rdpTls* tls)
 {
 	if (!tls)
 		return FALSE;
@@ -850,14 +850,7 @@ BOOL tls_disconnect(rdpTls* tls)
 
 		if (tls->ssl->s3->wbuf.left == 0)
 			tls->ssl->method->ssl_dispatch_alert(tls->ssl);
-
-		SSL_shutdown(tls->ssl);
 	}
-	else
-	{
-		SSL_shutdown(tls->ssl);
-	}
-
 	return TRUE;
 }
 


### PR DESCRIPTION
tls_disconnect shut down the ssl stream but didn't inform
the BIO(s) about this therefore could happen that a second shut down
was initiated (e.g. in bio_rdp_tls_free) causing rather long delays.

After removing the shut down from tls_disconnect the only thing the
function does is to prepare/set an alert therefore it was renamed to
tls_set_alert.