### PR TITLE
GW RPC-HTTP - 2 fixes

### DIFF
--- a/libfreerdp/core/gateway/rpc_client.c
+++ b/libfreerdp/core/gateway/rpc_client.c
@@ -425,7 +425,7 @@ int rpc_client_recv_fragment(rdpRpc* rpc, wStream* fragment)
 		pdu->Flags = 0;
 		pdu->Type = header->common.ptype;
 		pdu->CallId = header->common.call_id;
-		if (Stream_EnsureCapacity(pdu->s, Stream_Length(fragment)))
+		if (!Stream_EnsureCapacity(pdu->s, Stream_Length(fragment)))
 			return -1;
 		Stream_Write(pdu->s, buffer, Stream_Length(fragment));
 		Stream_SealLength(pdu->s);

--- a/libfreerdp/core/gateway/rpc_client.c
+++ b/libfreerdp/core/gateway/rpc_client.c
@@ -332,9 +332,9 @@ int rpc_client_recv_fragment(rdpRpc* rpc, wStream* fragment)
 
 		if (StubLength == 4)
 		{
-			/* received a disconnect request from the server? */
 			if ((header->common.call_id == rpc->PipeCallId) && (header->common.pfc_flags & PFC_LAST_FRAG))
 			{
+				/* End of TsProxySetupReceivePipe */
 				TerminateEventArgs e;
 
 				rpc->result = *((UINT32*) &buffer[StubOffset]);
@@ -344,9 +344,14 @@ int rpc_client_recv_fragment(rdpRpc* rpc, wStream* fragment)
 				EventArgsInit(&e, "freerdp");
 				e.code = 0;
 				PubSub_OnTerminate(rpc->context->pubSub, rpc->context, &e);
+				return 0;
 			}
 
-			return 0;
+			if (header->common.call_id != rpc->PipeCallId)
+			{
+				/* Ignoring non-TsProxySetupReceivePipe Response */
+				return 0;
+			}
 		}
 
 		if (rpc->StubFragCount == 0)


### PR DESCRIPTION
* The Stream_EnsureCapacity fix should get RPC-HTTP working again
* The rest should fix one of the random disconnects:
  Though not frequent, it's possible to get TsProxySetupReceivePipe
  data of stublength 4 that is actual data.  This happens when
  header->common.call_id == rpc->PipeCallId &&
  !(header->common.pfc_flags & PFC_LAST_FRAG).
  This should address GW disconnects that manifest as SSL read errors.
