### PR TITLE
Fixed NULL dereference.

### DIFF
--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -455,7 +455,7 @@ static BOOL rdp_security_stream_out(rdpRdp* rdp, wStream* s, int length, UINT32 
 				*pad = 8 - (length % 8);
 
 				if (*pad == 8)
-					pad = 0;
+					*pad = 0;
 				if (*pad)
 					memset(data+length, 0, *pad);
 


### PR DESCRIPTION
In```rdp_security_stream_out``` a pointer was set to ```NULL``` instead of its value being set when using FIPS encryption leading to a crash the very next line.