### PR TITLE
Fullscreen fixes and smart sizing resuscitation

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -554,6 +554,9 @@ BOOL xf_create_window(xfContext* xfc)
 				width = settings->SmartSizingWidth;
 			if (settings->SmartSizingHeight)
 				height = settings->SmartSizingHeight;
+
+			xfc->scaledWidth = width;
+			xfc->scaledHeight = height;
 		}
 #endif
 

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -503,8 +503,6 @@ BOOL xf_create_window(xfContext* xfc)
 
 	ZeroMemory(&xevent, sizeof(xevent));
 
-	xf_detect_monitors(xfc);
-
 	width = xfc->sessionWidth;
 	height = xfc->sessionHeight;
 
@@ -539,12 +537,6 @@ BOOL xf_create_window(xfContext* xfc)
 		{
 			windowTitle = malloc(1 + sizeof("FreeRDP: ") + strlen(settings->ServerHostname) + sizeof(":00000"));
 			sprintf(windowTitle, "FreeRDP: %s:%i", settings->ServerHostname, settings->ServerPort);
-		}
-
-		if (xfc->fullscreen)
-		{
-			width = xfc->desktopWidth;
-			height = xfc->desktopHeight;
 		}
 
 #ifdef WITH_XRENDER
@@ -1016,9 +1008,7 @@ BOOL xf_pre_connect(freerdp* instance)
 
 	xf_keyboard_init(xfc);
 
-	xf_detect_monitors(xfc);
-	settings->DesktopWidth = xfc->desktopWidth;
-	settings->DesktopHeight = xfc->desktopHeight;
+	xf_detect_monitors(xfc, &settings->DesktopWidth, &settings->DesktopHeight);
 
 	xfc->fullscreen = settings->Fullscreen;
 	xfc->decorations = settings->Decorations;

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -128,14 +128,14 @@ static void xf_draw_screen_scaled(xfContext* xfc, int x, int y, int w, int h)
 		return;
 	}
 
-	if (xfc->width <= 0 || xfc->height <= 0)
+	if (xfc->sessionWidth <= 0 || xfc->sessionHeight <= 0)
 	{
 		WLog_ERR(TAG, "the window dimensions are invalid");
 		return;
 	}
 
-	xScalingFactor = xfc->width / (double)xfc->scaledWidth;
-	yScalingFactor = xfc->height / (double)xfc->scaledHeight;
+	xScalingFactor = xfc->sessionWidth / (double)xfc->scaledWidth;
+	yScalingFactor = xfc->sessionHeight / (double)xfc->scaledHeight;
 
 	XSetFillStyle(xfc->display, xfc->gc, FillSolid);
 	XSetForeground(xfc->display, xfc->gc, 0);
@@ -195,8 +195,8 @@ static void xf_draw_screen_scaled(xfContext* xfc, int x, int y, int w, int h)
 BOOL xf_picture_transform_required(xfContext* xfc)
 {
 	if (xfc->offset_x || xfc->offset_y ||
-	    xfc->scaledWidth != xfc->width ||
-	    xfc->scaledHeight != xfc->height)
+		xfc->scaledWidth != xfc->sessionWidth ||
+		xfc->scaledHeight != xfc->sessionHeight)
 	{
 		return TRUE;
 	}
@@ -232,7 +232,7 @@ static void xf_desktop_resize(rdpContext* context)
 	{
 		BOOL same = (xfc->primary == xfc->drawing) ? TRUE : FALSE;
 		XFreePixmap(xfc->display, xfc->primary);
-		xfc->primary = XCreatePixmap(xfc->display, xfc->drawable, xfc->width, xfc->height, xfc->depth);
+		xfc->primary = XCreatePixmap(xfc->display, xfc->drawable, xfc->sessionWidth, xfc->sessionHeight, xfc->depth);
 		if (same)
 			xfc->drawing = xfc->primary;
 	}
@@ -240,8 +240,8 @@ static void xf_desktop_resize(rdpContext* context)
 #ifdef WITH_XRENDER
 	if (!xfc->settings->SmartSizing)
 	{
-		xfc->scaledWidth = xfc->width;
-		xfc->scaledHeight = xfc->height;
+		xfc->scaledWidth = xfc->sessionWidth;
+		xfc->scaledHeight = xfc->sessionHeight;
 	}
 #endif
 
@@ -343,10 +343,10 @@ void xf_sw_desktop_resize(rdpContext* context)
 
 	xf_lock_x11(xfc, TRUE);
 
-	xfc->width = context->settings->DesktopWidth;
-	xfc->height = context->settings->DesktopHeight;
+	xfc->sessionWidth = context->settings->DesktopWidth;
+	xfc->sessionHeight = context->settings->DesktopHeight;
 
-	gdi_resize(gdi, xfc->width, xfc->height);
+	gdi_resize(gdi, xfc->sessionWidth, xfc->sessionHeight);
 
 	if (xfc->image)
 	{
@@ -447,8 +447,8 @@ void xf_hw_desktop_resize(rdpContext* context)
 
 	xf_lock_x11(xfc, TRUE);
 
-	xfc->width = settings->DesktopWidth;
-	xfc->height = settings->DesktopHeight;
+	xfc->sessionWidth = settings->DesktopWidth;
+	xfc->sessionHeight = settings->DesktopHeight;
 
 	xf_desktop_resize(context);
 
@@ -505,8 +505,8 @@ BOOL xf_create_window(xfContext* xfc)
 
 	xf_detect_monitors(xfc);
 
-	width = xfc->width;
-	height = xfc->height;
+	width = xfc->sessionWidth;
+	height = xfc->sessionHeight;
 
 	if (!xfc->hdc)
 		xfc->hdc = gdi_CreateDC(CLRBUF_32BPP, xfc->bpp);
@@ -581,7 +581,7 @@ BOOL xf_create_window(xfContext* xfc)
 		xfc->unobscured = (xevent.xvisibility.state == VisibilityUnobscured);
 
 		/* Disallow resize now that any initial fullscreen window operation is complete */
-		xf_SetWindowSizeHints(xfc, xfc->window, FALSE, xfc->width, xfc->height);
+		xf_SetWindowSizeHints(xfc, xfc->window, FALSE, xfc->sessionWidth, xfc->sessionHeight);
 
 		XSetWMProtocols(xfc->display, xfc->window->handle, &(xfc->WM_DELETE_WINDOW), 1);
 		xfc->drawable = xfc->window->handle;
@@ -600,7 +600,7 @@ BOOL xf_create_window(xfContext* xfc)
 	assert(!xfc->gc);
 	xfc->gc = XCreateGC(xfc->display, xfc->drawable, GCGraphicsExposures, &gcv);
 	assert(!xfc->primary);
-	xfc->primary = XCreatePixmap(xfc->display, xfc->drawable, xfc->width, xfc->height, xfc->depth);
+	xfc->primary = XCreatePixmap(xfc->display, xfc->drawable, xfc->sessionWidth, xfc->sessionHeight, xfc->depth);
 	xfc->drawing = xfc->primary;
 	assert(!xfc->bitmap_mono);
 	xfc->bitmap_mono = XCreatePixmap(xfc->display, xfc->drawable, 8, 8, 1);
@@ -609,12 +609,12 @@ BOOL xf_create_window(xfContext* xfc)
 	XSetFunction(xfc->display, xfc->gc, GXcopy);
 	XSetFillStyle(xfc->display, xfc->gc, FillSolid);
 	XSetForeground(xfc->display, xfc->gc, BlackPixelOfScreen(xfc->screen));
-	XFillRectangle(xfc->display, xfc->primary, xfc->gc, 0, 0, xfc->width, xfc->height);
+	XFillRectangle(xfc->display, xfc->primary, xfc->gc, 0, 0, xfc->sessionWidth, xfc->sessionHeight);
 	XFlush(xfc->display);
 	assert(!xfc->image);
 
 	xfc->image = XCreateImage(xfc->display, xfc->visual, xfc->depth, ZPixmap, 0,
-			(char*) xfc->primary_buffer, xfc->width, xfc->height, xfc->scanline_pad, 0);
+			(char*) xfc->primary_buffer, xfc->sessionWidth, xfc->sessionHeight, xfc->scanline_pad, 0);
 
 	return TRUE;
 }
@@ -693,9 +693,9 @@ void xf_toggle_fullscreen(xfContext* xfc)
 	xfc->fullscreen = (xfc->fullscreen) ? FALSE : TRUE;
 	xfc->decorations = (xfc->fullscreen) ? FALSE : settings->Decorations;
 
-	xf_SetWindowSizeHints(xfc, xfc->window, TRUE, xfc->width, xfc->height);
+	xf_SetWindowSizeHints(xfc, xfc->window, TRUE, xfc->sessionWidth, xfc->sessionHeight);
 	xf_SetWindowFullscreen(xfc, xfc->window, xfc->fullscreen);
-	xf_SetWindowSizeHints(xfc, xfc->window, FALSE, xfc->width, xfc->height);
+	xf_SetWindowSizeHints(xfc, xfc->window, FALSE, xfc->sessionWidth, xfc->sessionHeight);
 
 	EventArgsInit(&e, "xfreerdp");
 	e.state = xfc->fullscreen ? FREERDP_WINDOW_STATE_FULLSCREEN : 0;
@@ -1074,12 +1074,12 @@ BOOL xf_post_connect(freerdp* instance)
 		xf_gdi_register_update_callbacks(update);
 	}
 
-	xfc->width = settings->DesktopWidth;
-	xfc->height = settings->DesktopHeight;
+	xfc->sessionWidth = settings->DesktopWidth;
+	xfc->sessionHeight = settings->DesktopHeight;
 
 #ifdef WITH_XRENDER
-	xfc->scaledWidth = xfc->width;
-	xfc->scaledHeight = xfc->height;
+	xfc->scaledWidth = xfc->sessionWidth;
+	xfc->scaledHeight = xfc->sessionHeight;
 	xfc->offset_x = 0;
 	xfc->offset_y = 0;
 #endif
@@ -1557,7 +1557,7 @@ static void xf_ZoomingChangeEventHandler(rdpContext* context, ZoomingChangeEvent
 	xfc->scaledWidth = w;
 	xfc->scaledHeight = h;
 
-	xf_draw_screen(xfc, 0, 0, xfc->width, xfc->height);
+	xf_draw_screen(xfc, 0, 0, xfc->sessionWidth, xfc->sessionHeight);
 }
 
 static void xf_PanningChangeEventHandler(rdpContext* context, PanningChangeEventArgs* e)
@@ -1570,7 +1570,7 @@ static void xf_PanningChangeEventHandler(rdpContext* context, PanningChangeEvent
 	xfc->offset_x += e->dx;
 	xfc->offset_y += e->dy;
 
-	xf_draw_screen(xfc, 0, 0, xfc->width, xfc->height);
+	xf_draw_screen(xfc, 0, 0, xfc->sessionWidth, xfc->sessionHeight);
 }
 #endif
 

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -572,9 +572,6 @@ BOOL xf_create_window(xfContext* xfc)
 
 		xfc->unobscured = (xevent.xvisibility.state == VisibilityUnobscured);
 
-		/* Disallow resize now that any initial fullscreen window operation is complete */
-		xf_SetWindowSizeHints(xfc, xfc->window, FALSE, xfc->sessionWidth, xfc->sessionHeight);
-
 		XSetWMProtocols(xfc->display, xfc->window->handle, &(xfc->WM_DELETE_WINDOW), 1);
 		xfc->drawable = xfc->window->handle;
 	}
@@ -685,9 +682,7 @@ void xf_toggle_fullscreen(xfContext* xfc)
 	xfc->fullscreen = (xfc->fullscreen) ? FALSE : TRUE;
 	xfc->decorations = (xfc->fullscreen) ? FALSE : settings->Decorations;
 
-	xf_SetWindowSizeHints(xfc, xfc->window, TRUE, xfc->sessionWidth, xfc->sessionHeight);
 	xf_SetWindowFullscreen(xfc, xfc->window, xfc->fullscreen);
-	xf_SetWindowSizeHints(xfc, xfc->window, FALSE, xfc->sessionWidth, xfc->sessionHeight);
 
 	EventArgsInit(&e, "xfreerdp");
 	e.state = xfc->fullscreen ? FREERDP_WINDOW_STATE_FULLSCREEN : 0;

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -642,6 +642,12 @@ static BOOL xf_event_ConfigureNotify(xfContext* xfc, XEvent* event, BOOL app)
 
 	if (!app)
 	{
+		if (xfc->window->left != event->xconfigure.x)
+			xfc->window->left = event->xconfigure.x;
+
+		if (xfc->window->top != event->xconfigure.y)
+			xfc->window->top = event->xconfigure.y;
+
 		if (xfc->window->width != event->xconfigure.width ||
 		     xfc->window->height != event->xconfigure.height)
 		{
@@ -652,11 +658,8 @@ static BOOL xf_event_ConfigureNotify(xfContext* xfc, XEvent* event, BOOL app)
 			xfc->offset_y = 0;
 			if (xfc->settings->SmartSizing || xfc->settings->MultiTouchGestures)
 			{
-				if (!xfc->fullscreen)
-				{
-					xfc->scaledWidth = xfc->window->width;
-					xfc->scaledHeight = xfc->window->height;
-				}
+				xfc->scaledWidth = xfc->window->width;
+				xfc->scaledHeight = xfc->window->height;
 				xf_draw_screen(xfc, 0, 0, xfc->sessionWidth, xfc->sessionHeight);
 			}
 			else

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -185,8 +185,8 @@ void xf_event_adjust_coordinates(xfContext* xfc, int* x, int *y)
 #ifdef WITH_XRENDER
 		if (xf_picture_transform_required(xfc))
 		{
-			double xScalingFactor = xfc->width / (double)xfc->scaledWidth;
-			double yScalingFactor = xfc->height / (double)xfc->scaledHeight;
+			double xScalingFactor = xfc->sessionWidth / (double)xfc->scaledWidth;
+			double yScalingFactor = xfc->sessionHeight / (double)xfc->scaledHeight;
 			*x = (int)((*x - xfc->offset_x) * xScalingFactor);
 			*y = (int)((*y - xfc->offset_y) * yScalingFactor);
 		}
@@ -204,8 +204,8 @@ static BOOL xf_event_Expose(xfContext* xfc, XEvent* event, BOOL app)
 	{
 		x = 0;
 		y = 0;
-		w = xfc->width;
-		h = xfc->height;
+		w = xfc->sessionWidth;
+		h = xfc->sessionHeight;
 	}
 	else
 	{
@@ -657,12 +657,12 @@ static BOOL xf_event_ConfigureNotify(xfContext* xfc, XEvent* event, BOOL app)
 					xfc->scaledWidth = xfc->window->width;
 					xfc->scaledHeight = xfc->window->height;
 				}
-				xf_draw_screen(xfc, 0, 0, xfc->width, xfc->height);
+				xf_draw_screen(xfc, 0, 0, xfc->sessionWidth, xfc->sessionHeight);
 			}
 			else
 			{
-				xfc->scaledWidth = xfc->width;
-				xfc->scaledHeight = xfc->height;
+				xfc->scaledWidth = xfc->sessionWidth;
+				xfc->scaledHeight = xfc->sessionHeight;
 			}
 #endif
 		}
@@ -718,8 +718,8 @@ static BOOL xf_event_MapNotify(xfContext* xfc, XEvent* event, BOOL app)
 	{
 		rect.left = 0;
 		rect.top = 0;
-		rect.right = xfc->width;
-		rect.bottom = xfc->height;
+		rect.right = xfc->sessionWidth;
+		rect.bottom = xfc->sessionHeight;
 
 		update->SuppressOutput((rdpContext*) xfc, 1, &rect);
 	}

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -490,16 +490,16 @@ BOOL xf_keyboard_handle_special_keys(xfContext* xfc, KeySym keysym)
 			switch(keysym)
 			{
 				case XK_0:	/* Ctrl-Alt-0: Reset scaling and panning */
-					xfc->scaledWidth = xfc->width;
-					xfc->scaledHeight = xfc->height;
+					xfc->scaledWidth = xfc->sessionWidth;
+					xfc->scaledHeight = xfc->sessionHeight;
 					xfc->offset_x = 0;
 					xfc->offset_y = 0;
-					if (!xfc->fullscreen && (xfc->width != xfc->window->width ||
-						 xfc->height != xfc->window->height))
+					if (!xfc->fullscreen && (xfc->sessionWidth != xfc->window->width ||
+						 xfc->sessionHeight != xfc->window->height))
 					{
-						xf_ResizeDesktopWindow(xfc, xfc->window, xfc->width, xfc->height);
+						xf_ResizeDesktopWindow(xfc, xfc->window, xfc->sessionWidth, xfc->sessionHeight);
 					}
-					xf_draw_screen(xfc, 0, 0, xfc->width, xfc->height);
+					xf_draw_screen(xfc, 0, 0, xfc->sessionWidth, xfc->sessionHeight);
 					return TRUE;
 
 				case XK_1:	/* Ctrl-Alt-1: Zoom in */

--- a/client/X11/xf_monitor.c
+++ b/client/X11/xf_monitor.c
@@ -115,7 +115,7 @@ BOOL xf_is_monitor_id_active(xfContext* xfc, UINT32 id)
 	return FALSE;
 }
 
-BOOL xf_detect_monitors(xfContext* xfc)
+BOOL xf_detect_monitors(xfContext* xfc, UINT32* pWidth, UINT32* pHeight)
 {
 	int i;
 	int nmonitors = 0;
@@ -134,8 +134,8 @@ BOOL xf_detect_monitors(xfContext* xfc)
 #endif
 
 	vscreen = &xfc->vscreen;
-	xfc->desktopWidth = settings->DesktopWidth;
-	xfc->desktopHeight = settings->DesktopHeight;
+	*pWidth = settings->DesktopWidth;
+	*pHeight = settings->DesktopHeight;
 
 	/* get mouse location */
 	if (!XQueryPointer(xfc->display, DefaultRootWindow(xfc->display),
@@ -194,26 +194,26 @@ BOOL xf_detect_monitors(xfContext* xfc)
 
 	if (settings->Fullscreen)
 	{
-		xfc->desktopWidth = WidthOfScreen(xfc->screen);
-		xfc->desktopHeight = HeightOfScreen(xfc->screen);
+		*pWidth = WidthOfScreen(xfc->screen);
+		*pHeight = HeightOfScreen(xfc->screen);
 	}
 	else if (settings->Workarea)
 	{
-		xfc->desktopWidth = xfc->workArea.width;
-		xfc->desktopHeight = xfc->workArea.height;
+		*pWidth = xfc->workArea.width;
+		*pHeight = xfc->workArea.height;
 	}
 	else if (settings->PercentScreen)
 	{
-		xfc->desktopWidth = (xfc->workArea.width * settings->PercentScreen) / 100;
-		xfc->desktopHeight = (xfc->workArea.height * settings->PercentScreen) / 100;
+		*pWidth = (xfc->workArea.width * settings->PercentScreen) / 100;
+		*pHeight = (xfc->workArea.height * settings->PercentScreen) / 100;
 
 		/* If we have specific monitor information then limit the PercentScreen value
 		 * to only affect the current monitor vs. the entire desktop
 		 */
 		if (vscreen->nmonitors > 0)
 		{
-			settings->DesktopWidth = ((vscreen->monitors[current_monitor].area.right - vscreen->monitors[current_monitor].area.left + 1) * settings->PercentScreen) / 100;
-			settings->DesktopHeight = ((vscreen->monitors[current_monitor].area.bottom - vscreen->monitors[current_monitor].area.top + 1) * settings->PercentScreen) / 100;
+			*pWidth = ((vscreen->monitors[current_monitor].area.right - vscreen->monitors[current_monitor].area.left + 1) * settings->PercentScreen) / 100;
+			*pHeight = ((vscreen->monitors[current_monitor].area.bottom - vscreen->monitors[current_monitor].area.top + 1) * settings->PercentScreen) / 100;
 		}
 	}
 
@@ -245,8 +245,8 @@ BOOL xf_detect_monitors(xfContext* xfc)
 
 		settings->MonitorDefArray[nmonitors].x = vscreen->monitors[i].area.left;
 		settings->MonitorDefArray[nmonitors].y = vscreen->monitors[i].area.top;
-		settings->MonitorDefArray[nmonitors].width = MIN(vscreen->monitors[i].area.right - vscreen->monitors[i].area.left + 1, xfc->desktopWidth);
-		settings->MonitorDefArray[nmonitors].height = MIN(vscreen->monitors[i].area.bottom - vscreen->monitors[i].area.top + 1, xfc->desktopHeight);
+		settings->MonitorDefArray[nmonitors].width = MIN(vscreen->monitors[i].area.right - vscreen->monitors[i].area.left + 1, *pWidth);
+		settings->MonitorDefArray[nmonitors].height = MIN(vscreen->monitors[i].area.bottom - vscreen->monitors[i].area.top + 1, *pHeight);
 		settings->MonitorDefArray[nmonitors].orig_screen = i;
 
 		nmonitors++;
@@ -257,8 +257,8 @@ BOOL xf_detect_monitors(xfContext* xfc)
 	{
 		settings->MonitorDefArray[0].x = vscreen->monitors[current_monitor].area.left;
 		settings->MonitorDefArray[0].y = vscreen->monitors[current_monitor].area.top;
-		settings->MonitorDefArray[0].width = MIN(vscreen->monitors[current_monitor].area.right - vscreen->monitors[current_monitor].area.left + 1, xfc->desktopWidth);
-		settings->MonitorDefArray[0].height = MIN(vscreen->monitors[current_monitor].area.bottom - vscreen->monitors[current_monitor].area.top + 1, xfc->desktopHeight);
+		settings->MonitorDefArray[0].width = MIN(vscreen->monitors[current_monitor].area.right - vscreen->monitors[current_monitor].area.left + 1, *pWidth);
+		settings->MonitorDefArray[0].height = MIN(vscreen->monitors[current_monitor].area.bottom - vscreen->monitors[current_monitor].area.top + 1, *pHeight);
 		settings->MonitorDefArray[0].orig_screen = current_monitor;
 
 		nmonitors = 1;
@@ -355,8 +355,8 @@ BOOL xf_detect_monitors(xfContext* xfc)
 		}
 
 		/* Set the desktop width and height according to the bounding rectangle around the active monitors */
-		xfc->desktopWidth = vscreen->area.right - vscreen->area.left + 1;
-		xfc->desktopHeight = vscreen->area.bottom - vscreen->area.top + 1;
+		*pWidth = vscreen->area.right - vscreen->area.left + 1;
+		*pHeight = vscreen->area.bottom - vscreen->area.top + 1;
 	}
 
 	return TRUE;

--- a/client/X11/xf_monitor.c
+++ b/client/X11/xf_monitor.c
@@ -121,7 +121,6 @@ BOOL xf_detect_monitors(xfContext* xfc)
 	int nmonitors = 0;
 	int primaryMonitorFound = FALSE;
 	int vX, vY, vWidth, vHeight;
-	int maxWidth, maxHeight;
 	VIRTUAL_SCREEN* vscreen;
 	rdpSettings* settings = xfc->settings;
 
@@ -197,15 +196,11 @@ BOOL xf_detect_monitors(xfContext* xfc)
 	{
 		xfc->desktopWidth = WidthOfScreen(xfc->screen);
 		xfc->desktopHeight = HeightOfScreen(xfc->screen);
-		maxWidth = xfc->desktopWidth;
-		maxHeight = xfc->desktopHeight;
 	}
 	else if (settings->Workarea)
 	{
 		xfc->desktopWidth = xfc->workArea.width;
 		xfc->desktopHeight = xfc->workArea.height;
-		maxWidth = xfc->desktopWidth;
-		maxHeight = xfc->desktopHeight;
 	}
 	else if (settings->PercentScreen)
 	{
@@ -220,14 +215,6 @@ BOOL xf_detect_monitors(xfContext* xfc)
 			settings->DesktopWidth = ((vscreen->monitors[current_monitor].area.right - vscreen->monitors[current_monitor].area.left + 1) * settings->PercentScreen) / 100;
 			settings->DesktopHeight = ((vscreen->monitors[current_monitor].area.bottom - vscreen->monitors[current_monitor].area.top + 1) * settings->PercentScreen) / 100;
 		}
-
-		maxWidth = xfc->desktopWidth;
-		maxHeight = xfc->desktopHeight;
-	}
-	else
-	{
-		maxWidth = WidthOfScreen(xfc->screen);
-		maxHeight = HeightOfScreen(xfc->screen);
 	}
 
 	if (!settings->Fullscreen && !settings->Workarea && !settings->UseMultimon)

--- a/client/X11/xf_monitor.c
+++ b/client/X11/xf_monitor.c
@@ -115,7 +115,7 @@ BOOL xf_is_monitor_id_active(xfContext* xfc, UINT32 id)
 	return FALSE;
 }
 
-BOOL xf_detect_monitors(xfContext* xfc, UINT32* pWidth, UINT32* pHeight)
+BOOL xf_detect_monitors(xfContext* xfc, UINT32* pMaxWidth, UINT32* pMaxHeight)
 {
 	int i;
 	int nmonitors = 0;
@@ -134,8 +134,8 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pWidth, UINT32* pHeight)
 #endif
 
 	vscreen = &xfc->vscreen;
-	*pWidth = settings->DesktopWidth;
-	*pHeight = settings->DesktopHeight;
+	*pMaxWidth = settings->DesktopWidth;
+	*pMaxHeight = settings->DesktopHeight;
 
 	/* get mouse location */
 	if (!XQueryPointer(xfc->display, DefaultRootWindow(xfc->display),
@@ -194,26 +194,26 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pWidth, UINT32* pHeight)
 
 	if (settings->Fullscreen)
 	{
-		*pWidth = WidthOfScreen(xfc->screen);
-		*pHeight = HeightOfScreen(xfc->screen);
+		*pMaxWidth = WidthOfScreen(xfc->screen);
+		*pMaxHeight = HeightOfScreen(xfc->screen);
 	}
 	else if (settings->Workarea)
 	{
-		*pWidth = xfc->workArea.width;
-		*pHeight = xfc->workArea.height;
+		*pMaxWidth = xfc->workArea.width;
+		*pMaxHeight = xfc->workArea.height;
 	}
 	else if (settings->PercentScreen)
 	{
-		*pWidth = (xfc->workArea.width * settings->PercentScreen) / 100;
-		*pHeight = (xfc->workArea.height * settings->PercentScreen) / 100;
+		*pMaxWidth = (xfc->workArea.width * settings->PercentScreen) / 100;
+		*pMaxHeight = (xfc->workArea.height * settings->PercentScreen) / 100;
 
 		/* If we have specific monitor information then limit the PercentScreen value
 		 * to only affect the current monitor vs. the entire desktop
 		 */
 		if (vscreen->nmonitors > 0)
 		{
-			*pWidth = ((vscreen->monitors[current_monitor].area.right - vscreen->monitors[current_monitor].area.left + 1) * settings->PercentScreen) / 100;
-			*pHeight = ((vscreen->monitors[current_monitor].area.bottom - vscreen->monitors[current_monitor].area.top + 1) * settings->PercentScreen) / 100;
+			*pMaxWidth = ((vscreen->monitors[current_monitor].area.right - vscreen->monitors[current_monitor].area.left + 1) * settings->PercentScreen) / 100;
+			*pMaxHeight = ((vscreen->monitors[current_monitor].area.bottom - vscreen->monitors[current_monitor].area.top + 1) * settings->PercentScreen) / 100;
 		}
 	}
 
@@ -245,8 +245,8 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pWidth, UINT32* pHeight)
 
 		settings->MonitorDefArray[nmonitors].x = vscreen->monitors[i].area.left;
 		settings->MonitorDefArray[nmonitors].y = vscreen->monitors[i].area.top;
-		settings->MonitorDefArray[nmonitors].width = MIN(vscreen->monitors[i].area.right - vscreen->monitors[i].area.left + 1, *pWidth);
-		settings->MonitorDefArray[nmonitors].height = MIN(vscreen->monitors[i].area.bottom - vscreen->monitors[i].area.top + 1, *pHeight);
+		settings->MonitorDefArray[nmonitors].width = MIN(vscreen->monitors[i].area.right - vscreen->monitors[i].area.left + 1, *pMaxWidth);
+		settings->MonitorDefArray[nmonitors].height = MIN(vscreen->monitors[i].area.bottom - vscreen->monitors[i].area.top + 1, *pMaxHeight);
 		settings->MonitorDefArray[nmonitors].orig_screen = i;
 
 		nmonitors++;
@@ -257,8 +257,8 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pWidth, UINT32* pHeight)
 	{
 		settings->MonitorDefArray[0].x = vscreen->monitors[current_monitor].area.left;
 		settings->MonitorDefArray[0].y = vscreen->monitors[current_monitor].area.top;
-		settings->MonitorDefArray[0].width = MIN(vscreen->monitors[current_monitor].area.right - vscreen->monitors[current_monitor].area.left + 1, *pWidth);
-		settings->MonitorDefArray[0].height = MIN(vscreen->monitors[current_monitor].area.bottom - vscreen->monitors[current_monitor].area.top + 1, *pHeight);
+		settings->MonitorDefArray[0].width = MIN(vscreen->monitors[current_monitor].area.right - vscreen->monitors[current_monitor].area.left + 1, *pMaxWidth);
+		settings->MonitorDefArray[0].height = MIN(vscreen->monitors[current_monitor].area.bottom - vscreen->monitors[current_monitor].area.top + 1, *pMaxHeight);
 		settings->MonitorDefArray[0].orig_screen = current_monitor;
 
 		nmonitors = 1;
@@ -355,8 +355,8 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pWidth, UINT32* pHeight)
 		}
 
 		/* Set the desktop width and height according to the bounding rectangle around the active monitors */
-		*pWidth = vscreen->area.right - vscreen->area.left + 1;
-		*pHeight = vscreen->area.bottom - vscreen->area.top + 1;
+		*pMaxWidth = vscreen->area.right - vscreen->area.left + 1;
+		*pMaxHeight = vscreen->area.bottom - vscreen->area.top + 1;
 	}
 
 	return TRUE;

--- a/client/X11/xf_monitor.h
+++ b/client/X11/xf_monitor.h
@@ -44,7 +44,7 @@ typedef struct _VIRTUAL_SCREEN VIRTUAL_SCREEN;
 #include "xfreerdp.h"
 
 FREERDP_API int xf_list_monitors(xfContext* xfc);
-FREERDP_API BOOL xf_detect_monitors(xfContext* xfc);
+FREERDP_API BOOL xf_detect_monitors(xfContext* xfc, UINT32* pWidth, UINT32* pHeight);
 FREERDP_API void xf_monitors_free(xfContext* xfc);
 
 #endif /* __XF_MONITOR_H */

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -168,7 +168,6 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 	}
 
 	XMoveResizeWindow(xfc->display, window->handle, startX, startY, window->width, window->height);
-	XMapRaised(xfc->display, window->handle);
 
 	/* Set the fullscreen state */
 	xf_SendClientEvent(xfc, window->handle, xfc->_NET_WM_STATE, 4,
@@ -188,8 +187,6 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 				xfc->fullscreenMonitors.right,
 				1);
 	}
-
-	window->fullscreen = fullscreen;
 }
 
 /* http://tronche.com/gui/x/xlib/window-information/XGetWindowProperty.html */
@@ -340,7 +337,6 @@ xfWindow* xf_CreateDesktopWindow(xfContext* xfc, char* name, int width, int heig
 
 	window->width = width;
 	window->height = height;
-	window->fullscreen = FALSE;
 	window->decorations = xfc->decorations;
 	window->is_mapped = FALSE;
 	window->is_transient = FALSE;
@@ -395,12 +391,6 @@ xfWindow* xf_CreateDesktopWindow(xfContext* xfc, char* name, int width, int heig
 	xf_SetWindowDecorations(xfc, window->handle, window->decorations);
 	xf_SetWindowPID(xfc, window->handle, 0);
 
-	/* Set the window hints to allow minimal resize, so fullscreen
-	 * changes can work in window managers that might disallow otherwise. 
-	 * We will set back afterwards.
-	 */
-	xf_SetWindowSizeHints(xfc, window, TRUE, xfc->sessionWidth, xfc->sessionHeight);
-
 	input_mask =
 		KeyPressMask | KeyReleaseMask | ButtonPressMask | ButtonReleaseMask |
 		VisibilityChangeMask | FocusChangeMask | StructureNotifyMask |
@@ -451,45 +441,34 @@ xfWindow* xf_CreateDesktopWindow(xfContext* xfc, char* name, int width, int heig
 
 void xf_ResizeDesktopWindow(xfContext* xfc, xfWindow* window, int width, int height)
 {
-	xf_SetWindowSizeHints(xfc, window, FALSE, width, height);
-}
-
-void xf_SetWindowSizeHints(xfContext* xfc, xfWindow *window, BOOL can_resize, int width, int height)
-{
 	XSizeHints* size_hints;
-	size_hints = XAllocSizeHints();
 
-	if (size_hints)
-	{
-		size_hints->flags = PMinSize | PMaxSize | PWinGravity;
+	if (!xfc || !window)
+			return;
 
-		size_hints->win_gravity = NorthWestGravity;
-		size_hints->min_width = size_hints->max_width = width;
-		size_hints->min_height = size_hints->max_height = height;
+	if (!(size_hints = XAllocSizeHints()))
+			return;
+
+	size_hints->flags = PMinSize | PMaxSize | PWinGravity;
+
+	size_hints->win_gravity = NorthWestGravity;
+	size_hints->min_width = size_hints->min_height = 1;
+	size_hints->max_width = size_hints->max_height = 16384;
+
+	XSetWMNormalHints(xfc->display, window->handle, size_hints);
+
+	XResizeWindow(xfc->display, window->handle, width, height);
 
 #ifdef WITH_XRENDER
-		if (xfc->settings->SmartSizing)
-		{
-			size_hints->min_width = size_hints->min_height = 1;
-			size_hints->max_width = size_hints->max_height = 16384;
-		}
+	if (!xfc->settings->SmartSizing)
 #endif
-
-		/* Allows the window to resize larger by 1 pixel - so we can
-		 * fullscreen the window with no worries about window manager disallowing based
-		 * on size parameters
-		 */
-		if (can_resize)
-		{
-			size_hints->width_inc = size_hints->height_inc = 1;
-			size_hints->max_width = xfc->sessionWidth + 1;
-			size_hints->max_height = xfc->sessionHeight + 1;
-		}
-
-		XSetWMNormalHints(xfc->display, window->handle, size_hints);
-		XResizeWindow(xfc->display, window->handle, width, height);
-		XFree(size_hints);
+	{
+		size_hints->min_width = size_hints->max_width = width;
+		size_hints->min_height = size_hints->max_height = height;
 	}
+
+	XSetWMNormalHints(xfc->display, window->handle, size_hints);
+	XFree(size_hints);
 }
 
 void xf_DestroyDesktopWindow(xfContext* xfc, xfWindow* window)

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -189,7 +189,7 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 				1);
 	}
 
-	window->fullscreen = TRUE;
+	window->fullscreen = fullscreen;
 }
 
 /* http://tronche.com/gui/x/xlib/window-information/XGetWindowProperty.html */
@@ -399,7 +399,7 @@ xfWindow* xf_CreateDesktopWindow(xfContext* xfc, char* name, int width, int heig
 	 * changes can work in window managers that might disallow otherwise. 
 	 * We will set back afterwards.
 	 */
-	xf_SetWindowSizeHints(xfc, window, TRUE, xfc->width, xfc->height);
+	xf_SetWindowSizeHints(xfc, window, TRUE, xfc->sessionWidth, xfc->sessionHeight);
 
 	input_mask =
 		KeyPressMask | KeyReleaseMask | ButtonPressMask | ButtonReleaseMask |
@@ -482,8 +482,8 @@ void xf_SetWindowSizeHints(xfContext* xfc, xfWindow *window, BOOL can_resize, in
 		if (can_resize)
 		{
 			size_hints->width_inc = size_hints->height_inc = 1;
-			size_hints->max_width = xfc->width + 1;
-			size_hints->max_height = xfc->height + 1;
+			size_hints->max_width = xfc->sessionWidth + 1;
+			size_hints->max_height = xfc->sessionHeight + 1;
 		}
 
 		XSetWMNormalHints(xfc->display, window->handle, size_hints);

--- a/client/X11/xf_window.h
+++ b/client/X11/xf_window.h
@@ -80,7 +80,6 @@ struct xf_window
 	int shmid;
 	Window handle;
 	Window* xfwin;
-	BOOL fullscreen;
 	BOOL decorations;
 	BOOL is_mapped;
 	BOOL is_transient;
@@ -149,7 +148,6 @@ void xf_SetWindowUnlisted(xfContext* xfc, Window window);
 
 xfWindow* xf_CreateDesktopWindow(xfContext* xfc, char* name, int width, int height);
 void xf_ResizeDesktopWindow(xfContext* xfc, xfWindow* window, int width, int height);
-void xf_SetWindowSizeHints(xfContext* xfc, xfWindow* window, BOOL can_resize, int width, int height);
 void xf_DestroyDesktopWindow(xfContext* xfc, xfWindow* window);
 
 BOOL xf_GetWindowProperty(xfContext* xfc, Window window, Atom property, int length,

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -92,8 +92,8 @@ struct xf_context
 	int bpp;
 	int xfds;
 	int depth;
-	int width;
-	int height;
+	int sessionWidth;
+	int sessionHeight;
 	int srcBpp;
 	GC gc_mono;
 	BOOL invert;

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -151,6 +151,11 @@ struct xf_context
 
 	int XInputOpcode;
 
+	int savedWidth;
+	int savedHeight;
+	int savedPosX;
+	int savedPosY;
+
 #ifdef WITH_XRENDER
 	int scaledWidth;
 	int scaledHeight;

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -171,8 +171,6 @@ struct xf_context
 	wArrayList* xevents;
 	char* actionScript;
 
-	UINT32 desktopWidth;
-	UINT32 desktopHeight;
 	XSetWindowAttributes attribs;
 	BOOL complex_regions;
 	VIRTUAL_SCREEN vscreen;


### PR DESCRIPTION
- make smart-sizing work again which was killed in previous commits
- renamed xfc->width and xfc->height to sessionWidth / sessionHeight since several contributers in the past repeatedly made the error to treat these as equal with the x11 window width and heigth
- removed unused variables from xf_detect_monitors()
- removed xfc->desktopWidth and xfc->desktopHeight context variables since they were basically unused (from the contexts's point of view) and only served as temporary storage
- removed some weird/unnecessary/ugly code and workarounds
- miscellaneous small fixes
- new feature: restore previous window position when toggling out of  fullscreen mode
- new feature: if /f is specified in combination with /smart-sizing:WxH we run the session in the /smart-sizing dimensions scaled to full screen