### PR TITLE
Fixed pthread_mutex_timedjoin detection.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,6 @@ if(OPENBSD)
 	set(WITH_ALSA  "OFF")
 	set(WITH_PULSE "ON")
 	set(WITH_WAYLAND "OFF")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_PTHREAD_GNU_EXT")
 endif()
 
 # Android
@@ -436,9 +435,7 @@ if(NOT IOS AND NOT ANDROID)
 endif()
 
 if(NOT WIN32)
-	list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
-	check_library_exists(pthread pthread_tryjoin_np "" HAVE_PTHREAD_GNU_EXT)
-	list(REMOVE_ITEM CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+	check_library_exists(pthread pthread_mutex_timedlock "" HAVE_PTHREAD_MUTEX_TIMEDLOCK)
 endif()
 
 if(WITH_VALGRIND_MEMCHECK)

--- a/config.h.in
+++ b/config.h.in
@@ -28,7 +28,7 @@
 #cmakedefine HAVE_TM_GMTOFF
 #cmakedefine HAVE_AIO_H
 #cmakedefine HAVE_POLL_H
-#cmakedefine HAVE_PTHREAD_GNU_EXT
+#cmakedefine HAVE_PTHREAD_MUTEX_TIMEDLOCK
 #cmakedefine HAVE_VALGRIND_MEMCHECK_H
 #cmakedefine HAVE_EXECINFO_H
 

--- a/winpr/libwinpr/synch/wait.c
+++ b/winpr/libwinpr/synch/wait.c
@@ -22,10 +22,6 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_PTHREAD_GNU_EXT
-#define _GNU_SOURCE
-#endif
-
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -103,18 +99,12 @@ static long long ts_difftime(const struct timespec *o,
 	return newValue - oldValue;
 }
 
-/* Drop in replacement for the linux pthread_timedjoin_np and
- * pthread_mutex_timedlock functions.
+/* Drop in replacement for pthread_mutex_timedlock
  */
-#if !defined(HAVE_PTHREAD_GNU_EXT)
+#if !defined(HAVE_PTHREAD_MUTEX_TIMEDLOCK)
 #include <pthread.h>
 
-#if defined(__FreeBSD__) || defined(sun)
-/*the only way to get it work is to remove the static*/
-int pthread_mutex_timedlock(pthread_mutex_t *mutex, const struct timespec *timeout)
-#else
 static int pthread_mutex_timedlock(pthread_mutex_t *mutex, const struct timespec *timeout)
-#endif
 {
 	struct timespec timenow;
 	struct timespec sleepytime;


### PR DESCRIPTION
According to the docs, FreeBSD and Solaris both support ```pthread_mutex_timedjoin``` , that was the reason for the static / non static declaration hack.
Now CMake checks, if the function is provided by the platform and only using the drop in replacement if not found.