### PR TITLE
Fixed error on exit about pthread_mutex_destroy with waiters

### DIFF
--- a/client/X11/xf_tsmf.c
+++ b/client/X11/xf_tsmf.c
@@ -108,7 +108,12 @@ int xf_tsmf_xv_video_frame_event(TsmfClientContext* tsmf, TSMF_VIDEO_FRAME_EVENT
 		return -1001;
 
 	/* In case the player is minimized */
+#ifdef __OpenBSD__
+	/* numVisibleRects is unsigned */
+	if (event->x < -2048 || event->y < -2048)
+#else
 	if (event->x < -2048 || event->y < -2048 || event->numVisibleRects < 0)
+#endif
 	{
 		return -1002;
 	}

--- a/libfreerdp/core/autodetect.c
+++ b/libfreerdp/core/autodetect.c
@@ -166,7 +166,11 @@ BOOL autodetect_send_bandwidth_measure_payload(rdpContext* context, UINT16 paylo
 	/* Random data (better measurement in case the line is compressed) */
 	for (i = 0; i < payloadLength / 4; i++)
 	{
+#ifdef __OpenBSD__
+		Stream_Write_UINT32(s, arc4random());
+#else
 		Stream_Write_UINT32(s, rand());
+#endif
 	}
 
 	return rdp_send_message_channel_pdu(context->rdp, s, SEC_AUTODETECT_REQ);
@@ -204,7 +208,11 @@ static BOOL autodetect_send_bandwidth_measure_stop(rdpContext* context, UINT16 p
 			/* Random data (better measurement in case the line is compressed) */
 			for (i = 0; i < payloadLength / 4; i++)
 			{
+#ifdef __OpenBSD__
+				Stream_Write_UINT32(s, arc4random());
+#else
 				Stream_Write_UINT32(s, rand());
+#endif
 			}
 		}
 	}

--- a/winpr/libwinpr/synch/mutex.c
+++ b/winpr/libwinpr/synch/mutex.c
@@ -61,6 +61,9 @@ BOOL MutexCloseHandle(HANDLE handle)
 	if (!MutexIsHandled(handle))
 		return FALSE;
 
+#ifdef __OpenBSD__
+	pthread_mutex_unlock(&mutex->mutex);
+#endif
 	if (!pthread_mutex_destroy(&mutex->mutex))
 		return FALSE;
 


### PR DESCRIPTION
There was a lingering error message on OpenBSD about destroying a mutex with waiters.  I have made a one-line change (ifdef'ed to just OpenBSD) to correct this.  It might be legit on other platforms but I didn't want to make that call b/c of risk.