### PR TITLE
gdi: fix problem with gdi_SelectObject check(s)

### DIFF
--- a/include/freerdp/gdi/gdi.h
+++ b/include/freerdp/gdi/gdi.h
@@ -121,12 +121,17 @@
 #define GDI_FILL_WINDING		0x02
 
 /* GDI Object Types */
-#define GDIOBJECT_BITMAP		0x00
-#define GDIOBJECT_PEN			0x01
-#define GDIOBJECT_PALETTE		0x02
-#define GDIOBJECT_BRUSH			0x03
-#define GDIOBJECT_RECT			0x04
-#define GDIOBJECT_REGION		0x04
+#define GDIOBJECT_BITMAP   0x00
+#define GDIOBJECT_PEN      0x01
+#define GDIOBJECT_PALETTE  0x02
+#define GDIOBJECT_BRUSH    0x03
+#define GDIOBJECT_RECT     0x04
+#define GDIOBJECT_REGION   0x05
+
+/* Region return values */
+#define NULLREGION         0x01
+#define SIMPLEREGION       0x02
+#define COMPLEXREGION      0x03
 
 struct _GDIOBJECT
 {

--- a/libfreerdp/gdi/dc.c
+++ b/libfreerdp/gdi/dc.c
@@ -152,10 +152,12 @@ HGDIOBJECT gdi_SelectObject(HGDI_DC hdc, HGDIOBJECT hgdiobject)
 	else if (hgdiobject->objectType == GDIOBJECT_REGION)
 	{
 		hdc->selectedObject = hgdiobject;
+		previousSelectedObject = (HGDIOBJECT) COMPLEXREGION;
 	}
 	else if (hgdiobject->objectType == GDIOBJECT_RECT)
 	{
 		hdc->selectedObject = hgdiobject;
+		previousSelectedObject = (HGDIOBJECT) SIMPLEREGION;
 	}
 	else
 	{
@@ -231,13 +233,11 @@ int gdi_DeleteObject(HGDIOBJECT hgdiobject)
 
 int gdi_DeleteDC(HGDI_DC hdc)
 {
-	if (hdc->hwnd)
+	if (hdc && hdc->hwnd)
 	{
-		if (hdc->hwnd->cinvalid != NULL)
-			free(hdc->hwnd->cinvalid);
+		free(hdc->hwnd->cinvalid);
 
-		if (hdc->hwnd->invalid != NULL)
-			free(hdc->hwnd->invalid);
+		free(hdc->hwnd->invalid);
 
 		free(hdc->hwnd);
 	}

--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -797,11 +797,7 @@ static BOOL gdi_line_to(rdpContext* context, LINE_TO_ORDER* lineTo)
 	hPen = gdi_CreatePen(lineTo->penStyle, lineTo->penWidth, (GDI_COLOR) color);
 	if (!hPen)
 		return FALSE;
-	if (!gdi_SelectObject(gdi->drawing->hdc, (HGDIOBJECT) hPen))
-	{
-		gdi_DeleteObject((HGDIOBJECT) hPen);
-		return FALSE;
-	}
+	gdi_SelectObject(gdi->drawing->hdc, (HGDIOBJECT) hPen);
 	gdi_SetROP2(gdi->drawing->hdc, lineTo->bRop2);
 
 	gdi_MoveToEx(gdi->drawing->hdc, lineTo->nXStart, lineTo->nYStart, NULL);

--- a/libfreerdp/gdi/graphics.c
+++ b/libfreerdp/gdi/graphics.c
@@ -104,7 +104,7 @@ BOOL gdi_Bitmap_New(rdpContext* context, rdpBitmap* bitmap)
 
 	gdi_bitmap = (gdiBitmap*) bitmap;
 	gdi_bitmap->hdc = gdi_CreateCompatibleDC(gdi->hdc);
-	if (!gdi->hdc)
+	if (!gdi_bitmap->hdc)
 		return FALSE;
 
 	if (!bitmap->data)
@@ -118,12 +118,7 @@ BOOL gdi_Bitmap_New(rdpContext* context, rdpBitmap* bitmap)
 		return FALSE;
 	}
 
-	if (!gdi_SelectObject(gdi_bitmap->hdc, (HGDIOBJECT) gdi_bitmap->bitmap))
-	{
-		gdi_DeleteObject((HGDIOBJECT) gdi_bitmap->bitmap);
-		gdi_DeleteDC(gdi->hdc);
-		return FALSE;
-	}
+	gdi_SelectObject(gdi_bitmap->hdc, (HGDIOBJECT) gdi_bitmap->bitmap);
 	gdi_bitmap->org_bitmap = NULL;
 	return TRUE;
 }
@@ -256,12 +251,7 @@ BOOL gdi_Glyph_New(rdpContext* context, rdpGlyph* glyph)
 	gdi_glyph->bitmap->bytesPerPixel = 1;
 	gdi_glyph->bitmap->bitsPerPixel = 1;
 
-	if (!gdi_SelectObject(gdi_glyph->hdc, (HGDIOBJECT) gdi_glyph->bitmap))
-	{
-		gdi_DeleteDC(gdi_glyph->hdc);
-		_aligned_free(data);
-		return FALSE;
-	}
+	gdi_SelectObject(gdi_glyph->hdc, (HGDIOBJECT) gdi_glyph->bitmap);
 	gdi_glyph->org_bitmap = NULL;
 	return TRUE;
 }


### PR DESCRIPTION
When a hdc is created no initial or default objects are created
therefore can the first call of gdi_SelectObject return NULL.
Because of this checking the return value of  gdi_SelectObject failed
for newly create hdc causing errors (disconnects).

Since all types of HGDIOBJECT are handled and the return value of
gdi_SelectObject isn't used the recently added checks were removed
again.