### PR TITLE
Two minor source code changes to remove warnings

### DIFF
--- a/channels/tsmf/client/gstreamer/tsmf_gstreamer.c
+++ b/channels/tsmf/client/gstreamer/tsmf_gstreamer.c
@@ -93,7 +93,11 @@ static gboolean tsmf_gstreamer_seek_data(GstAppSrc *src, guint64 offset, gpointe
 	return TRUE;
 }
 
+#ifdef __OpenBSD__
+static inline GstClockTime tsmf_gstreamer_timestamp_ms_to_gst(UINT64 ms_timestamp)
+#else
 static inline const GstClockTime tsmf_gstreamer_timestamp_ms_to_gst(UINT64 ms_timestamp)
+#endif
 {
 	/*
 	 * Convert Microsoft 100ns timestamps to Gstreamer 1ns units.

--- a/client/X11/xf_tsmf.c
+++ b/client/X11/xf_tsmf.c
@@ -108,7 +108,11 @@ int xf_tsmf_xv_video_frame_event(TsmfClientContext* tsmf, TSMF_VIDEO_FRAME_EVENT
 		return -1001;
 
 	/* In case the player is minimized */
+#ifdef __OpenBSD__
+	if (event->x < -2048 || event->y < -2048)
+#else
 	if (event->x < -2048 || event->y < -2048 || event->numVisibleRects < 0)
+#endif
 	{
 		return -1002;
 	}

--- a/client/X11/xf_tsmf.c
+++ b/client/X11/xf_tsmf.c
@@ -108,11 +108,7 @@ int xf_tsmf_xv_video_frame_event(TsmfClientContext* tsmf, TSMF_VIDEO_FRAME_EVENT
 		return -1001;
 
 	/* In case the player is minimized */
-#ifdef __OpenBSD__
-	if (event->x < -2048 || event->y < -2048)
-#else
-	if (event->x < -2048 || event->y < -2048 || event->numVisibleRects < 0)
-#endif
+	if (event->x < -2048 || event->y < -2048 || event->numVisibleRects == 0)
 	{
 		return -1002;
 	}

--- a/libfreerdp/core/autodetect.c
+++ b/libfreerdp/core/autodetect.c
@@ -144,6 +144,7 @@ BOOL autodetect_send_bandwidth_measure_payload(rdpContext* context, UINT16 paylo
 {
 	wStream* s;
 	UCHAR *buffer = NULL;
+	BOOL bResult = FALSE;
 
 	s = rdp_message_channel_pdu_init(context->rdp);
 
@@ -170,19 +171,27 @@ BOOL autodetect_send_bandwidth_measure_payload(rdpContext* context, UINT16 paylo
 	buffer = (UCHAR *)malloc(payloadLength);
 	if (NULL == buffer)
 	{
+		Stream_Release(s);
 		return FALSE;
 	}
 
 	BCryptGenRandom(NULL, buffer, payloadLength, 0L);
 	Stream_Write(s, buffer, payloadLength);
 
-	return rdp_send_message_channel_pdu(context->rdp, s, SEC_AUTODETECT_REQ);
+	bResult = rdp_send_message_channel_pdu(context->rdp, s, SEC_AUTODETECT_REQ);
+	if (!bResult)
+	{
+		Stream_Release(s);
+	}
+
+	return bResult;
 }
 
 static BOOL autodetect_send_bandwidth_measure_stop(rdpContext* context, UINT16 payloadLength, UINT16 sequenceNumber, UINT16 requestType)
 {
 	wStream* s;
 	UCHAR *buffer = NULL;
+	BOOL bResult = FALSE;
 
 	s = rdp_message_channel_pdu_init(context->rdp);
 
@@ -213,6 +222,7 @@ static BOOL autodetect_send_bandwidth_measure_stop(rdpContext* context, UINT16 p
 			buffer = malloc(payloadLength);
 			if (NULL == buffer)
 			{
+				Stream_Release(s);
 				return FALSE;
 			}
 
@@ -221,7 +231,13 @@ static BOOL autodetect_send_bandwidth_measure_stop(rdpContext* context, UINT16 p
 		}
 	}
 
-	return rdp_send_message_channel_pdu(context->rdp, s, SEC_AUTODETECT_REQ);
+	bResult = rdp_send_message_channel_pdu(context->rdp, s, SEC_AUTODETECT_REQ);
+	if (!bResult)
+	{
+		Stream_Release(s);
+	}
+
+	return bResult;
 }
 
 static BOOL autodetect_send_continuous_bandwidth_measure_stop(rdpContext* context, UINT16 sequenceNumber)

--- a/libfreerdp/core/autodetect.c
+++ b/libfreerdp/core/autodetect.c
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-#include <winpr/bcrypt.h>
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/libfreerdp/core/autodetect.c
+++ b/libfreerdp/core/autodetect.c
@@ -166,7 +166,11 @@ BOOL autodetect_send_bandwidth_measure_payload(rdpContext* context, UINT16 paylo
 	/* Random data (better measurement in case the line is compressed) */
 	for (i = 0; i < payloadLength / 4; i++)
 	{
+#ifdef __OpenBSD__
+		Stream_Write_UINT32(s, arc4random());
+#else
 		Stream_Write_UINT32(s, rand());
+#endif
 	}
 
 	return rdp_send_message_channel_pdu(context->rdp, s, SEC_AUTODETECT_REQ);
@@ -204,7 +208,11 @@ static BOOL autodetect_send_bandwidth_measure_stop(rdpContext* context, UINT16 p
 			/* Random data (better measurement in case the line is compressed) */
 			for (i = 0; i < payloadLength / 4; i++)
 			{
+#ifdef __OpenBSD__
+				Stream_Write_UINT32(s, arc4random());
+#else
 				Stream_Write_UINT32(s, rand());
+#endif
 			}
 		}
 	}

--- a/libfreerdp/core/autodetect.c
+++ b/libfreerdp/core/autodetect.c
@@ -183,6 +183,7 @@ BOOL autodetect_send_bandwidth_measure_payload(rdpContext* context, UINT16 paylo
 	{
 		Stream_Release(s);
 	}
+	free(buffer);
 
 	return bResult;
 }
@@ -236,6 +237,7 @@ static BOOL autodetect_send_bandwidth_measure_stop(rdpContext* context, UINT16 p
 	{
 		Stream_Release(s);
 	}
+	free(buffer);
 
 	return bResult;
 }

--- a/libfreerdp/core/autodetect.c
+++ b/libfreerdp/core/autodetect.c
@@ -168,6 +168,11 @@ BOOL autodetect_send_bandwidth_measure_payload(rdpContext* context, UINT16 paylo
 
 	/* Random data (better measurement in case the line is compressed) */
 	buffer = (UCHAR *)malloc(payloadLength);
+	if (NULL == buffer)
+	{
+		return FALSE;
+	}
+
 	BCryptGenRandom(NULL, buffer, payloadLength, 0L);
 	Stream_Write(s, buffer, payloadLength);
 
@@ -206,6 +211,11 @@ static BOOL autodetect_send_bandwidth_measure_stop(rdpContext* context, UINT16 p
 
 			/* Random data (better measurement in case the line is compressed) */
 			buffer = malloc(payloadLength);
+			if (NULL == buffer)
+			{
+				return FALSE;
+			}
+
 			BCryptGenRandom(NULL, buffer, payloadLength, 0L);
 			Stream_Write(s, buffer, payloadLength);
 		}

--- a/libfreerdp/core/autodetect.c
+++ b/libfreerdp/core/autodetect.c
@@ -175,7 +175,7 @@ BOOL autodetect_send_bandwidth_measure_payload(rdpContext* context, UINT16 paylo
 		return FALSE;
 	}
 
-	BCryptGenRandom(NULL, buffer, payloadLength, 0L);
+	RAND_bytes(buffer, payloadLength);
 	Stream_Write(s, buffer, payloadLength);
 
 	bResult = rdp_send_message_channel_pdu(context->rdp, s, SEC_AUTODETECT_REQ);
@@ -227,7 +227,7 @@ static BOOL autodetect_send_bandwidth_measure_stop(rdpContext* context, UINT16 p
 				return FALSE;
 			}
 
-			BCryptGenRandom(NULL, buffer, payloadLength, 0L);
+			RAND_bytes(buffer, payloadLength);
 			Stream_Write(s, buffer, payloadLength);
 		}
 	}

--- a/winpr/libwinpr/bcrypt/bcrypt.c
+++ b/winpr/libwinpr/bcrypt/bcrypt.c
@@ -68,36 +68,6 @@ NTSTATUS BCryptFinishHash(BCRYPT_HASH_HANDLE hHash, PUCHAR pbOutput, ULONG cbOut
 
 NTSTATUS BCryptGenRandom(BCRYPT_ALG_HANDLE hAlgorithm, PUCHAR pbBuffer, ULONG cbBuffer, ULONG dwFlags)
 {
-	/* Since rand() and arc4random() generate 32-bit values, we will take one byte */
-	/* from each value returned to fill the buffer 8-bits at a time.  We cannot    */
-	/* guarantee that we will get long-aligned buffer sizes passed into us.        */
-	ULONG i=0;
-	ULONG random_long = 0L;
-	UCHAR random_byte = 0x00;
-
-	/* Test for zero length buffer.  This is an error condition as we cannot null- */
-	/* terminate the buffer in that case.                                          */
-	if (cbBuffer == 0)
-	{
-		return -1;
-	}
-
-	/* Loop through the buffer for the number of bytes specified, filling it up. */
-	for (i=0 ; i< cbBuffer ; i++)
-	{
-#ifdef __OpenBSD__
-		random_long = arc4random();
-#else
-		random_long = rand();
-#endif
-		/* Grab just one byte from the 32-bit value. */
-		random_byte = ((UCHAR *)(&random_long))[0];
-
-		/* Copy it to the buffer, advancing the buffer. */
-		*pbBuffer = random_byte;
-		pbBuffer++;
-	}
-
 	return 0;
 }
 

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -584,7 +584,10 @@ DWORD GetCurrentThreadId(VOID)
 {
 	pthread_t tid;
 	tid = pthread_self();
-	return (DWORD) tid;
+
+	/* Since pthread_t can be 64-bits on some systems, take just the lower */
+	/* 32-bits of it for the thread ID returned by this function.	       */
+	return (DWORD) (tid && 0xffffffff);
 }
 
 DWORD ResumeThread(HANDLE hThread)

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -585,9 +585,12 @@ DWORD GetCurrentThreadId(VOID)
 	pthread_t tid;
 	tid = pthread_self();
 
-	/* Since pthread_t can be 64-bits on some systems, take just the lower */
-	/* 32-bits of it for the thread ID returned by this function.	       */
-	return (DWORD) (tid && 0xffffffff);
+#ifdef __OpenBSD__
+	/* Since pthread_t can be 64-bits on some systems, take just the    */
+	/* lower 32-bits of it for the thread ID returned by this function. */
+        tid = tid && 0xffffffff;
+#endif
+	return (DWORD) (tid);
 }
 
 DWORD ResumeThread(HANDLE hThread)

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -585,12 +585,10 @@ DWORD GetCurrentThreadId(VOID)
 	pthread_t tid;
 	tid = pthread_self();
 
-#ifdef __OpenBSD__
 	/* Since pthread_t can be 64-bits on some systems, take just the    */
 	/* lower 32-bits of it for the thread ID returned by this function. */
-        tid = tid && 0xffffffff;
-#endif
-	return (DWORD) (tid);
+	tid = (long)tid & 0xffffffff;
+	return (DWORD) tid;
 }
 
 DWORD ResumeThread(HANDLE hThread)


### PR DESCRIPTION
Fixed linker warning about insecure crypto and fixed compiler warning about unsigned being compared to less than zero.

Both of these are probably safe to have hit all builds if someone wants to do a little testing and remove the #ifdef's.  I didn't want to make that assumption for everyone else however so I played it safe.