### PR TITLE
Wlog console output to stderr

### DIFF
--- a/winpr/include/winpr/wlog.h
+++ b/winpr/include/winpr/wlog.h
@@ -146,9 +146,10 @@ struct _wLogAppender
 	WLOG_APPENDER_COMMON();
 };
 
-#define WLOG_CONSOLE_STDOUT	1
-#define WLOG_CONSOLE_STDERR	2
-#define WLOG_CONSOLE_DEBUG	3
+#define WLOG_CONSOLE_DEFAULT	0
+#define WLOG_CONSOLE_STDOUT		1
+#define WLOG_CONSOLE_STDERR		2
+#define WLOG_CONSOLE_DEBUG		4
 
 struct _wLogConsoleAppender
 {

--- a/winpr/libwinpr/utils/wlog/ConsoleAppender.c
+++ b/winpr/libwinpr/utils/wlog/ConsoleAppender.c
@@ -139,9 +139,6 @@ int WLog_ConsoleAppender_WriteMessage(wLog* log, wLogConsoleAppender* appender, 
 				case WLOG_INFO:
 					fp = stdout;
 					break;
-				case WLOG_OFF:
-					fp = NULL;
-					break;
 				default:
 					fp = stderr;
 					break;
@@ -149,7 +146,7 @@ int WLog_ConsoleAppender_WriteMessage(wLog* log, wLogConsoleAppender* appender, 
 			break;
 	}
 
-	if (fp)
+	if (message->Level != WLOG_OFF)
 		fprintf(fp, "%s%s\n", message->PrefixString, message->TextString);
 #endif
 	return 1;

--- a/winpr/libwinpr/utils/wlog/ConsoleAppender.c
+++ b/winpr/libwinpr/utils/wlog/ConsoleAppender.c
@@ -47,14 +47,14 @@ void WLog_ConsoleAppender_SetOutputStream(wLog* log, wLogConsoleAppender* append
 		return;
 
 	if (outputStream < 0)
-		outputStream = WLOG_CONSOLE_STDOUT;
+		outputStream = WLOG_CONSOLE_DEFAULT;
 
 	if (outputStream == WLOG_CONSOLE_STDOUT)
 		appender->outputStream = WLOG_CONSOLE_STDOUT;
 	else if (outputStream == WLOG_CONSOLE_STDERR)
 		appender->outputStream = WLOG_CONSOLE_STDERR;
 	else
-		appender->outputStream = WLOG_CONSOLE_STDOUT;
+		appender->outputStream = WLOG_CONSOLE_DEFAULT;
 }
 
 int WLog_ConsoleAppender_Open(wLog* log, wLogConsoleAppender* appender)
@@ -123,9 +123,34 @@ int WLog_ConsoleAppender_WriteMessage(wLog* log, wLogConsoleAppender* appender, 
 		__android_log_print(level, log->Name, "%s%s", message->PrefixString, message->TextString);
 
 #else
-	fp = (appender->outputStream == WLOG_CONSOLE_STDERR) ? stderr : stdout;
+	switch(appender->outputStream)
+	{
+		case WLOG_CONSOLE_STDOUT:
+			fp = stdout;
+			break;
+		case WLOG_CONSOLE_STDERR:
+			fp = stderr;
+			break;
+		default:
+			switch(message->Level)
+			{
+				case WLOG_TRACE:
+				case WLOG_DEBUG:
+				case WLOG_INFO:
+					fp = stdout;
+					break;
+				case WLOG_OFF:
+					fp = NULL;
+					break;
+				default:
+					fp = stderr;
+					break;
+			}
+			break;
+	}
 
-	fprintf(fp, "%s%s\n", message->PrefixString, message->TextString);
+	if (fp)
+		fprintf(fp, "%s%s\n", message->PrefixString, message->TextString);
 #endif
 	return 1;
 }
@@ -211,11 +236,11 @@ wLogConsoleAppender* WLog_ConsoleAppender_New(wLog* log)
 	ConsoleAppender->WritePacketMessage =
 			(WLOG_APPENDER_WRITE_PACKET_MESSAGE_FN) WLog_ConsoleAppender_WritePacketMessage;
 
-	ConsoleAppender->outputStream = WLOG_CONSOLE_STDOUT;
+	ConsoleAppender->outputStream = WLOG_CONSOLE_DEFAULT;
 
 #ifdef _WIN32
-    if (IsDebuggerPresent())
-        ConsoleAppender->outputStream = WLOG_CONSOLE_DEBUG;
+		if (IsDebuggerPresent())
+				ConsoleAppender->outputStream = WLOG_CONSOLE_DEBUG;
 #endif
 
 	return ConsoleAppender;

--- a/winpr/libwinpr/utils/wlog/ConsoleAppender.c
+++ b/winpr/libwinpr/utils/wlog/ConsoleAppender.c
@@ -236,8 +236,8 @@ wLogConsoleAppender* WLog_ConsoleAppender_New(wLog* log)
 	ConsoleAppender->outputStream = WLOG_CONSOLE_DEFAULT;
 
 #ifdef _WIN32
-		if (IsDebuggerPresent())
-				ConsoleAppender->outputStream = WLOG_CONSOLE_DEBUG;
+	if (IsDebuggerPresent())
+		ConsoleAppender->outputStream = WLOG_CONSOLE_DEBUG;
 #endif
 
 	return ConsoleAppender;


### PR DESCRIPTION
Fixes the issue reported in #2595 

* Using ```stderr``` for all warning / error type messages
* Using ```stdout``` for info and debug type messages
* Skipping message printing if ```WLOG_OFF``` is set now