### PR TITLE
Fix empty window title

### DIFF
--- a/libfreerdp/core/window.c
+++ b/libfreerdp/core/window.c
@@ -43,6 +43,14 @@ static BOOL rail_read_unicode_string(wStream* s, RAIL_UNICODE_STRING* unicode_st
 	if (Stream_GetRemainingLength(s) < new_len)
 		return FALSE;
 
+	if (!new_len)
+	{
+		free(unicode_string->string);
+		unicode_string->string = NULL;
+		unicode_string->length = 0;
+		return TRUE;
+	}
+
 	new_str = (BYTE*) realloc(unicode_string->string, new_len);
 	if (!new_str)
 	{


### PR DESCRIPTION
When the size of a RAIL string was 0, we were reporting an OOM error.