### PR TITLE
Add check to protect memcpy(3) from using NULL pointer.

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
@@ -21,6 +21,8 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
+
 #include "ntlm.h"
 #include "../sspi.h"
 
@@ -143,6 +145,7 @@ NTLM_AV_PAIR* ntlm_av_pair_add(NTLM_AV_PAIR* pAvPairList, NTLM_AV_ID AvId, PBYTE
 	if (!pAvPair)
 		return NULL;
 
+	assert(Value != NULL);
 	pAvPair->AvId = AvId;
 	pAvPair->AvLen = AvLen;
 	CopyMemory(ntlm_av_pair_get_value_pointer(pAvPair), Value, AvLen);


### PR DESCRIPTION
The ntlm_construct_challenge_target_info function can potentially pass NULL as
argument to the ntlm_av_pair_add function (for example DnsDomainName.Buffer).
This NULL finally lands in the CopyMemory (which is macro to the memcpy(3)
function) which can't handle NULL.

Sponsored by: WHEEL Systems (http://www.wheelsystems.com)