### PR TITLE
At least at FreeBSD - the gethostname(3) function can fail.

### DIFF
--- a/winpr/libwinpr/sysinfo/sysinfo.c
+++ b/winpr/libwinpr/sysinfo/sysinfo.c
@@ -179,7 +179,9 @@ BOOL GetComputerNameA(LPSTR lpBuffer, LPDWORD lpnSize)
 	char* dot;
 	int length;
 	char hostname[256];
-	gethostname(hostname, sizeof(hostname));
+
+	if (gethostname(hostname, sizeof(hostname)) == -1)
+		return FALSE;
 	length = strlen(hostname);
 	dot = strchr(hostname, '.');
 
@@ -208,7 +210,8 @@ BOOL GetComputerNameExA(COMPUTER_NAME_FORMAT NameType, LPSTR lpBuffer, LPDWORD l
 	if ((NameType == ComputerNameNetBIOS) || (NameType == ComputerNamePhysicalNetBIOS))
 		return GetComputerNameA(lpBuffer, lpnSize);
 
-	gethostname(hostname, sizeof(hostname));
+	if (gethostname(hostname, sizeof(hostname)) == -1)
+		return FALSE;
 	length = strlen(hostname);
 
 	switch (NameType)


### PR DESCRIPTION
At least at FreeBSD - the gethostname(3) function can fail.
Check returned value.

Sponsored by: WHEEL Systems (http://www.wheelsystems.com)