### PR TITLE
Assign peer to settings when a new RDP module is being initialized.

### DIFF
--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -635,6 +635,7 @@ BOOL freerdp_peer_context_new(freerdp_peer* client)
 
 	client->context = context;
 
+	context->peer = client;
 	context->ServerMode = TRUE;
 
 	if (!(context->metrics = metrics_new(context)))
@@ -649,7 +650,6 @@ BOOL freerdp_peer_context_new(freerdp_peer* client)
 	client->autodetect = rdp->autodetect;
 
 	context->rdp = rdp;
-	context->peer = client;
 	context->input = client->input;
 	context->update = client->update;
 	context->settings = client->settings;

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1406,10 +1406,16 @@ rdpRdp* rdp_new(rdpContext* context)
 	}
 
 	rdp->settings = context->settings;
-	rdp->settings->instance = context->instance;
-	
 	if (context->instance)
+	{
+		rdp->settings->instance = context->instance;
 		context->instance->settings = rdp->settings;
+	}
+	else if (context->peer)
+	{
+		rdp->settings->instance = context->peer;
+		context->peer->settings = rdp->settings;
+	}
 
 	rdp->transport = transport_new(context);
 


### PR DESCRIPTION
Otherwise instance in rdpNla is invalid when NLA is used on server-side.

Sponsored by: WHEEL Systems (http://www.wheelsystems.com)