### PR TITLE
Don't dispose shadow server before all clients have disconnected

### DIFF
--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -344,6 +344,14 @@ void* shadow_server_thread(rdpShadowServer* server)
 
 	shadow_subsystem_stop(server->subsystem);
 
+	/* Signal to the clients that server is being stopped and wait for them
+	 * to disconnect. */
+	MessageQueue_PostQuit(subsystem->MsgPipe->Out, 0);
+	while(ArrayList_Count(server->clients) > 0)
+	{
+		Sleep(100);
+	}
+
 	ExitThread(0);
 
 	return NULL;


### PR DESCRIPTION
Ensure all client threads are disconnected before we stop the server
thread and thus make it available for deletion. We do this because
shadow_client_context_free() accesses rdpShadowServer structure, which
we have to keep alive as long as it is needed.

Calling shadow_client_context_free() after shadow_server_stop() and
shadow_server_free() were called may have caused an application crash.