### PR TITLE
shadow_client: dispose encomsp and remdesk

### DIFF
--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -147,6 +147,10 @@ void shadow_client_context_free(freerdp_peer* peer, rdpShadowClient* client)
 		shadow_encoder_free(client->encoder);
 		client->encoder = NULL;
 	}
+
+	shadow_client_encomsp_uninit(client);
+
+	shadow_client_remdesk_uninit(client);
 }
 
 void shadow_client_message_free(wMessage* message)

--- a/server/shadow/shadow_encomsp.c
+++ b/server/shadow/shadow_encomsp.c
@@ -109,3 +109,10 @@ int shadow_client_encomsp_init(rdpShadowClient* client)
 	return 1;
 }
 
+void shadow_client_encomsp_uninit(rdpShadowClient* client)
+{
+	if (client->encomsp) {
+		client->encomsp->Stop(client->encomsp);
+		client->encomsp = NULL;
+	}
+}

--- a/server/shadow/shadow_encomsp.h
+++ b/server/shadow/shadow_encomsp.h
@@ -29,6 +29,7 @@ extern "C" {
 #endif
 
 int shadow_client_encomsp_init(rdpShadowClient* client);
+void shadow_client_encomsp_uninit(rdpShadowClient* client);
 
 #ifdef __cplusplus
 }

--- a/server/shadow/shadow_remdesk.c
+++ b/server/shadow/shadow_remdesk.c
@@ -37,3 +37,11 @@ int shadow_client_remdesk_init(rdpShadowClient* client)
 
 	return 1;
 }
+
+void shadow_client_remdesk_uninit(rdpShadowClient* client)
+{
+	if (client->remdesk) {
+		client->remdesk->Stop(client->remdesk);
+		client->remdesk = NULL;
+	}
+}

--- a/server/shadow/shadow_remdesk.h
+++ b/server/shadow/shadow_remdesk.h
@@ -29,6 +29,7 @@ extern "C" {
 #endif
 
 int shadow_client_remdesk_init(rdpShadowClient* client);
+void shadow_client_remdesk_uninit(rdpShadowClient* client);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Their threads were kept running after the client's exit.