### PR TITLE
winpr/crt: fix compatibility with gcc >= 4.9

### DIFF
--- a/winpr/include/winpr/crt.h
+++ b/winpr/include/winpr/crt.h
@@ -92,26 +92,35 @@ static INLINE UINT64 _rotr64(UINT64 value, int shift) {
 /**
  * __lzcnt16, __lzcnt, __lzcnt64:
  * http://msdn.microsoft.com/en-us/library/bb384809/
- */
-
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 2))
-
-/**
- * __lzcnt16, __lzcnt, __lzcnt64:
- * http://msdn.microsoft.com/en-us/library/bb384809/
  *
  * Beware: the result of __builtin_clz(0) is undefined
  */
 
-static INLINE UINT32 __lzcnt(UINT32 _val32) {
-	return _val32 ? ((UINT32) __builtin_clz(_val32)) : 32;
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 2))
+#if (__GNUC__ == 4) && (__GNUC_MINOR__ < 9)
+static INLINE UINT32 __lzcnt(UINT32 _val32)
+{
+	return (UINT32) __builtin_clz(_val32);
 }
 
-static INLINE UINT16 __lzcnt16(UINT16 _val16) {
-	return _val16 ? ((UINT16) (__builtin_clz((UINT32) _val16) - 16)) : 16;
+static INLINE UINT16 __lzcnt16(UINT16 _val16)
+{
+	return (UINT16) (__builtin_clz((UINT32) _val16) - 16);
+}
+#else /* (__GNUC__ == 4) && (__GNUC_MINOR__ < 9) */
+static INLINE UINT32 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
+       __lzcnt(UINT32 _val32)
+{
+       return ((UINT32) __builtin_clz(_val32));
 }
 
-#else
+static INLINE UINT16 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
+       __lzcnt16(UINT16 _val16)
+{
+	return (UINT16) (__builtin_clz((UINT32) _val16) - 16);
+}
+#endif /* (__GNUC__ == 4) && (__GNUC_MINOR__ < 9) */
+#else /* (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 2)) */
 
 static INLINE UINT32 __lzcnt(UINT32 x) {
 	unsigned y;


### PR DESCRIPTION
gcc 4.9 and higher don't allow function redefinition with different
attributes. In crt the functions __lzcnt16 and __lzcnt are defined and
exported. If the definitions don't match build problems might occur when
using winpr with other programs or libraries that also use __lzcnt16 or
similar.

This commit also removes the special handling of 0 for compatibility
along platforms. This situations need to be handled by the caller.

For reference the following error message is show when building a simple test program that also
includes the original definitions:

In file included from /usr/lib/gcc/x86_64-linux-gnu/4.9/include/immintrin.h:55:0,
                 from /usr/lib/gcc/x86_64-linux-gnu/4.9/include/x86intrin.h:46,
                 from test.c:2:
/usr/lib/gcc/x86_64-linux-gnu/4.9/include/lzcntintrin.h:39:1: error: redefinition of ‘__lzcnt16’
 __lzcnt16 (unsigned short __X)
 ^
In file included from test.c:1:0:
/opt/freerdp-nightly/include/winpr/crt.h:110:22: note: previous definition of ‘__lzcnt16’ was here
 static INLINE UINT16 __lzcnt16(UINT16 _val16) {