### PR TITLE
fixed a synchronization issue on thread_list

### DIFF
--- a/winpr/libwinpr/thread/test/CMakeLists.txt
+++ b/winpr/libwinpr/thread/test/CMakeLists.txt
@@ -6,7 +6,8 @@ set(${MODULE_PREFIX}_DRIVER ${MODULE_NAME}.c)
 
 set(${MODULE_PREFIX}_TESTS
 	TestThreadCommandLineToArgv.c
-	TestThreadCreateProcess.c)
+	TestThreadCreateProcess.c
+	TestThreadExitThread.c)
 
 create_test_sourcelist(${MODULE_PREFIX}_SRCS
 	${${MODULE_PREFIX}_DRIVER}

--- a/winpr/libwinpr/thread/test/TestThreadExitThread.c
+++ b/winpr/libwinpr/thread/test/TestThreadExitThread.c
@@ -19,7 +19,7 @@ int TestThreadExitThread(int argc, char* argv[])
 
 	/* FIXME: create some noise to better guaranty the test validity and
          * decrease the number of loops */
-	for (i=0; i<10000; i++)
+	for (i=0; i<50000; i++)
 	{
 		thread = CreateThread(NULL,
 				0,
@@ -43,7 +43,7 @@ int TestThreadExitThread(int argc, char* argv[])
 			 * the end of the thread. Therefore WaitForSingleObject
 			 * never get the signal.
 			 */
-			fprintf(stderr, "1 second should have been enough to for the thread to be in a signaled state\n");
+			fprintf(stderr, "1 second should have been enough for the thread to be in a signaled state\n");
 			return -1;
 		}
 

--- a/winpr/libwinpr/thread/test/TestThreadExitThread.c
+++ b/winpr/libwinpr/thread/test/TestThreadExitThread.c
@@ -43,7 +43,7 @@ int TestThreadExitThread(int argc, char* argv[])
 			 * the end of the thread. Therefore WaitForSingleObject
 			 * never get the signal.
 			 */
-			fprintf(stderr, "Didn't quit the main thread correctly\n");
+			fprintf(stderr, "1 second should have been enough to for the thread to be in a signaled state\n");
 			return -1;
 		}
 

--- a/winpr/libwinpr/thread/test/TestThreadExitThread.c
+++ b/winpr/libwinpr/thread/test/TestThreadExitThread.c
@@ -1,0 +1,53 @@
+// Copyright © 2015 Hewlett-Packard Development Company, L.P.
+
+#include <winpr/file.h>
+#include <winpr/synch.h>
+#include <winpr/thread.h>
+
+static void* thread_func(void* arg)
+{
+	/* exists of the thread the quickest as possible */
+	ExitThread(0);
+	return NULL;
+}
+
+int TestThreadExitThread(int argc, char* argv[])
+{
+	HANDLE thread; 
+	QWORD waitResult;
+	int i;
+
+	/* FIXME: create some noise to better guaranty the test validity and
+         * decrease the number of loops */
+	for (i=0; i<10000; i++)
+	{
+		thread = CreateThread(NULL,
+				0,
+				(LPTHREAD_START_ROUTINE)thread_func,
+				NULL,
+				0,
+				NULL);
+
+		if (thread == INVALID_HANDLE_VALUE)
+		{
+			fprintf(stderr, "Got an invalid thread!\n");
+			return -1;
+		}
+
+		waitResult = WaitForSingleObject(thread, 1000);
+		if (waitResult != WAIT_OBJECT_0)
+		{
+			/* When the thread exits before the internal thread_list
+			 * was updated, ExitThread() is not able to retrieve the
+			 * related WINPR_THREAD object and is not able to signal
+			 * the end of the thread. Therefore WaitForSingleObject
+			 * never get the signal.
+			 */
+			fprintf(stderr, "Didn't quit the main thread correctly\n");
+			return -1;
+		}
+
+		CloseHandle(thread);
+	}
+	return 0;
+}

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -3,6 +3,7 @@
  * Process Thread Functions
  *
  * Copyright 2012 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+ * Copyright 2015 Hewlett-Packard Development Company, L.P.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -299,11 +299,9 @@ static void* thread_launcher(void* arg)
                  * actually done.*/
                 thread->thread = pthread_self(); 
 
-                /* also done by winpr_StartThread(). This ensures thread_list
-                 * was updated before the thread could exit */
                 if (!ListDictionary_Add(thread_list, &thread->thread, thread))
                 {
-                    WLog_ERR(TAG, "Thread function argument is %p", fkt);
+                    WLog_ERR(TAG, "failed to add the thread to the thread list");
                     goto exit;
                 }
 

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -349,7 +349,8 @@ static BOOL winpr_StartThread(WINPR_THREAD *thread)
 		WLog_ERR(TAG, "failed to launch the thread");
 		goto error;
 	}
-        
+	assert(ListDictionary_Contains(thread_list, &thread->thread));
+
 	pthread_attr_destroy(&attr);
 	dump_thread(thread);
 	return TRUE;

--- a/winpr/libwinpr/thread/thread.h
+++ b/winpr/libwinpr/thread/thread.h
@@ -35,7 +35,6 @@ struct winpr_thread
 	WINPR_HANDLE_DEF();
 
 	BOOL started;
-	HANDLE hLaunchedEvent;
 	int pipe_fd[2];
 	BOOL mainProcess;
 	BOOL detached;
@@ -46,6 +45,8 @@ struct winpr_thread
 	SIZE_T dwStackSize;
 	LPVOID lpParameter;
 	pthread_mutex_t mutex;
+	pthread_mutex_t threadIsReadyMutex;
+	pthread_cond_t threadIsReady;
 	LPTHREAD_START_ROUTINE lpStartAddress;
 	LPSECURITY_ATTRIBUTES lpThreadAttributes;
 #if defined(WITH_DEBUG_THREADS)

--- a/winpr/libwinpr/thread/thread.h
+++ b/winpr/libwinpr/thread/thread.h
@@ -3,6 +3,7 @@
  * Process Thread Functions
  *
  * Copyright 2012 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+ * Copyright 2015 Hewlett-Packard Development Company, L.P.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/winpr/libwinpr/thread/thread.h
+++ b/winpr/libwinpr/thread/thread.h
@@ -35,6 +35,7 @@ struct winpr_thread
 	WINPR_HANDLE_DEF();
 
 	BOOL started;
+	HANDLE hLaunchedEvent;
 	int pipe_fd[2];
 	BOOL mainProcess;
 	BOOL detached;


### PR DESCRIPTION
It was possible for a thread to call ExitThread() before it was added to thread_list. In this case a signal was never sent and was never caught by WaitForSingleObject().

Now is ensured that the thread ID is added to thread_list first by the thread itself or by the thread calling pthread_create(). Since thread_list is synchronized, it should not hurt to add two times the thread ID. This is maybe simpler than to check if the ID is already in the list.

winpr-thread:
  - added the unit test: TestThreadExitThread
  - fix: ensure thread_list to be up to date before to call ExitThread()
  - possibly resolved: Problems with serial redirection #2389