### PR TITLE
shadow_screen: allow sub-rectangle to span multiple monitors

### DIFF
--- a/server/shadow/shadow_screen.c
+++ b/server/shadow/shadow_screen.c
@@ -28,7 +28,6 @@ rdpShadowScreen* shadow_screen_new(rdpShadowServer* server)
 {
 	int x, y;
 	int width, height;
-	MONITOR_DEF* primary;
 	rdpShadowScreen* screen;
 	rdpShadowSubsystem* subsystem;
 
@@ -45,12 +44,21 @@ rdpShadowScreen* shadow_screen_new(rdpShadowServer* server)
 
 	region16_init(&(screen->invalidRegion));
 
-	primary = &(subsystem->monitors[subsystem->selectedMonitor]);
+	if (server->shareSubRect) {
+		x = server->subRect.left;
+		y = server->subRect.top;
+		width = server->subRect.right - server->subRect.left;
+		height = server->subRect.bottom - server->subRect.top;
+	} else {
+		MONITOR_DEF* primary;
 
-	x = primary->left;
-	y = primary->top;
-	width = primary->right - primary->left;
-	height = primary->bottom - primary->top;
+		primary = &(subsystem->monitors[subsystem->selectedMonitor]);
+
+		x = primary->left;
+		y = primary->top;
+		width = primary->right - primary->left;
+		height = primary->bottom - primary->top;
+	}
 
 	screen->width = width;
 	screen->height = height;


### PR DESCRIPTION
When we share a sub-rectangle of our desktop, allow it to span over
multiple monitors. Previously it was possible to export an area larger
than one display, however the contents were always cropped to
the boundaries of the selected monitor and the rest was visible for
the client only as a black area .