### PR TITLE
winpr: fixed HRESULT & SCODE types, added a ctest

### DIFF
--- a/client/Windows/wf_cliprdr.c
+++ b/client/Windows/wf_cliprdr.c
@@ -1576,7 +1576,7 @@ static int wf_cliprdr_server_format_data_request(CliprdrClientContext* context, 
 
 		result = OleGetClipboard(&dataObj);
 
-		if (!SUCCEEDED(result))
+		if (FAILED(result))
 			return -1;
 
 		ZeroMemory(&format_etc, sizeof(FORMATETC));
@@ -1615,7 +1615,7 @@ static int wf_cliprdr_server_format_data_request(CliprdrClientContext* context, 
 
 			result = IDataObject_GetData(dataObj, &format_etc, &stg_medium);
 
-			if (!SUCCEEDED(result)) {
+			if (FAILED(result)) {
 				DEBUG_CLIPRDR("dataObj->GetData failed.");
 			}
 
@@ -1782,7 +1782,7 @@ int wf_cliprdr_server_file_contents_request(CliprdrClientContext* context, CLIPR
 
 	hRet = OleGetClipboard(&pDataObj);
 
-	if (!SUCCEEDED(hRet))
+	if (FAILED(hRet))
 	{
 		WLog_ERR(TAG,  "filecontents: get ole clipboard failed.");
 		goto error;

--- a/winpr/include/winpr/wtypes.h
+++ b/winpr/include/winpr/wtypes.h
@@ -154,8 +154,9 @@ typedef unsigned int UINT32;
 typedef unsigned __int64 UINT64;
 typedef ULONG *PULONG;
 
-typedef ULONG HRESULT;
-typedef ULONG SCODE;
+typedef LONG HRESULT;
+typedef LONG SCODE;
+typedef SCODE *PSCODE;
 
 typedef ULONG_PTR DWORD_PTR, *PDWORD_PTR;
 typedef ULONG_PTR SIZE_T;

--- a/winpr/test/CMakeLists.txt
+++ b/winpr/test/CMakeLists.txt
@@ -4,7 +4,7 @@ set(MODULE_PREFIX "TEST_WINPR")
 
 set(${MODULE_PREFIX}_DRIVER ${MODULE_NAME}.c)
 
-set(${MODULE_PREFIX}_TESTS TestIntrinsics.c)
+set(${MODULE_PREFIX}_TESTS TestIntrinsics.c TestTypes.c)
 
 create_test_sourcelist(${MODULE_PREFIX}_SRCS
 	${${MODULE_PREFIX}_DRIVER}

--- a/winpr/test/TestTypes.c
+++ b/winpr/test/TestTypes.c
@@ -1,0 +1,117 @@
+/**
+ * CTest for winpr types and macros
+ *
+ * Copyright 2015 Thincast Technologies GmbH
+ * Copyright 2015 Norbert Federa <norbert.federa@thincast.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <winpr/crt.h>
+#include <winpr/error.h>
+
+BOOL TestSucceededFailedMacros(HRESULT hr, char *sym, BOOL isSuccess)
+{
+	BOOL rv = TRUE;
+
+	if (SUCCEEDED(hr) && !isSuccess)
+	{
+		printf("Error: SUCCEEDED with \"%s\" must be false\n", sym);
+		rv = FALSE;
+	}
+	if (!SUCCEEDED(hr) && isSuccess)
+	{
+		printf("Error: SUCCEEDED with \"%s\" must be true\n", sym);
+		rv = FALSE;
+	}
+	if (!FAILED(hr) && !isSuccess)
+	{
+		printf("Error: FAILED with \"%s\" must be true\n", sym);
+		rv = FALSE;
+	}
+	if (FAILED(hr) && isSuccess)
+	{
+		printf("Error: FAILED with \"%s\" must be false\n", sym);
+		rv = FALSE;
+	}
+
+	return rv;
+}
+
+int TestTypes(int argc, char* argv[])
+{
+	BOOL ok = TRUE;
+	HRESULT hr;
+
+	if (S_OK != (HRESULT)0L)
+	{
+		printf("Error: S_OK should be 0\n");
+		goto err;
+	}
+	if (S_FALSE != (HRESULT)1L)
+	{
+		printf("Error: S_FALSE should be 1\n");
+		goto err;
+	}
+
+	/* Test HRESULT success codes */
+	ok &= TestSucceededFailedMacros(S_OK, "S_OK", TRUE);
+	ok &= TestSucceededFailedMacros(S_FALSE, "S_FALSE", TRUE);
+
+	/* Test some HRESULT error codes */
+	ok &= TestSucceededFailedMacros(E_NOTIMPL, "E_NOTIMPL", FALSE);
+	ok &= TestSucceededFailedMacros(E_OUTOFMEMORY, "E_OUTOFMEMORY", FALSE);
+	ok &= TestSucceededFailedMacros(E_INVALIDARG, "E_INVALIDARG", FALSE);
+	ok &= TestSucceededFailedMacros(E_FAIL, "E_FAIL", FALSE);
+	ok &= TestSucceededFailedMacros(E_ABORT, "E_ABORT", FALSE);
+
+	/* Test some WIN32 error codes converted to HRESULT*/
+	hr = HRESULT_FROM_WIN32(ERROR_SUCCESS);
+	ok &= TestSucceededFailedMacros(hr, "HRESULT_FROM_WIN32(ERROR_SUCCESS)", TRUE);
+
+	hr = HRESULT_FROM_WIN32(ERROR_INVALID_FUNCTION);
+	ok &= TestSucceededFailedMacros(hr, "HRESULT_FROM_WIN32(ERROR_INVALID_FUNCTION)", FALSE);
+
+	hr = HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+	ok &= TestSucceededFailedMacros(hr, "HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)", FALSE);
+
+	hr = HRESULT_FROM_WIN32(ERROR_NOACCESS);
+	ok &= TestSucceededFailedMacros(hr, "HRESULT_FROM_WIN32(ERROR_NOACCESS)", FALSE);
+
+	hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
+	ok &= TestSucceededFailedMacros(hr, "HRESULT_FROM_WIN32(ERROR_NOT_FOUND)", FALSE);
+
+	hr = HRESULT_FROM_WIN32(ERROR_TIMEOUT);
+	ok &= TestSucceededFailedMacros(hr, "HRESULT_FROM_WIN32(ERROR_TIMEOUT)", FALSE);
+
+	hr = HRESULT_FROM_WIN32(RPC_S_ZERO_DIVIDE);
+	ok &= TestSucceededFailedMacros(hr, "HRESULT_FROM_WIN32(RPC_S_ZERO_DIVIDE)", FALSE);
+
+	hr = HRESULT_FROM_WIN32(ERROR_STATIC_INIT);
+	ok &= TestSucceededFailedMacros(hr, "HRESULT_FROM_WIN32(ERROR_STATIC_INIT)", FALSE);
+
+	hr = HRESULT_FROM_WIN32(ERROR_ENCRYPTION_FAILED);
+	ok &= TestSucceededFailedMacros(hr, "HRESULT_FROM_WIN32(ERROR_ENCRYPTION_FAILED)", FALSE);
+
+	hr = HRESULT_FROM_WIN32(WSAECANCELLED);
+	ok &= TestSucceededFailedMacros(hr, "HRESULT_FROM_WIN32(WSAECANCELLED)", FALSE);
+
+	if (ok) {
+		printf("Test completed successfully\n");
+		return 0;
+	}
+
+err:
+	printf("Error: Test failed\n");
+	return -1;
+}


### PR DESCRIPTION
- HRESULT was unsigned which means that until now all usages of the SUCCEDED(hr) and FAILED(hr) macros never detected any errors
- Also fixed the (unused) SCODE typedef
- Added new ctest TestTypes
