### PR TITLE
winpr: fixed some misuses of S_FALSE

### DIFF
--- a/client/Windows/wf_cliprdr.c
+++ b/client/Windows/wf_cliprdr.c
@@ -104,14 +104,14 @@ HRESULT STDMETHODCALLTYPE CliprdrStream_Read(IStream* This, void *pv, ULONG cb, 
 	*pcbRead = 0;
 
 	if (instance->m_lOffset.QuadPart >= instance->m_lSize.QuadPart)
-		return S_FALSE;
+		return E_FAIL;
 
 	ret = cliprdr_send_request_filecontents(clipboard, (void*) This,
 			instance->m_lIndex, FILECONTENTS_RANGE,
 			instance->m_lOffset.HighPart, instance->m_lOffset.LowPart, cb);
 
 	if (ret < 0)
-		return S_FALSE;
+		return E_FAIL;
 
 	if (clipboard->req_fdata)
 	{
@@ -123,7 +123,7 @@ HRESULT STDMETHODCALLTYPE CliprdrStream_Read(IStream* This, void *pv, ULONG cb, 
 	instance->m_lOffset.QuadPart += clipboard->req_fsize;
 
 	if (clipboard->req_fsize < cb)
-		return S_FALSE;
+		return E_FAIL;
 
 	return S_OK;
 }
@@ -154,11 +154,11 @@ HRESULT STDMETHODCALLTYPE CliprdrStream_Seek(IStream* This, LARGE_INTEGER dlibMo
 			newoffset = instance->m_lSize.QuadPart + dlibMove.QuadPart;
 			break;
 		default:
-			return S_FALSE;
+			return E_INVALIDARG;
 	}
 
 	if (newoffset < 0 || newoffset >= instance->m_lSize.QuadPart)
-		return FALSE;
+		return E_FAIL;
 
 	instance->m_lOffset.QuadPart = newoffset;
 
@@ -736,7 +736,7 @@ HRESULT STDMETHODCALLTYPE CliprdrEnumFORMATETC_Next(IEnumFORMATETC* This, ULONG 
 	if (pceltFetched != 0)
 		*pceltFetched = copied;
 
-	return (copied == celt) ? S_OK : S_FALSE;
+	return (copied == celt) ? S_OK : E_FAIL;
 }
 
 HRESULT STDMETHODCALLTYPE CliprdrEnumFORMATETC_Skip(IEnumFORMATETC* This, ULONG celt)
@@ -744,7 +744,7 @@ HRESULT STDMETHODCALLTYPE CliprdrEnumFORMATETC_Skip(IEnumFORMATETC* This, ULONG 
 	CliprdrEnumFORMATETC* instance = (CliprdrEnumFORMATETC*) This;
 
 	if (instance->m_nIndex + (LONG) celt > instance->m_nNumFormats)
-		return S_FALSE;
+		return E_FAIL;
 
 	instance->m_nIndex += celt;
 

--- a/winpr/libwinpr/path/include/PathCchAddExtension.c
+++ b/winpr/libwinpr/path/include/PathCchAddExtension.c
@@ -17,10 +17,10 @@ HRESULT PATH_CCH_ADD_EXTENSION(PWSTR pszPath, size_t cchPath, PCWSTR pszExt)
 	size_t pszPathLength;
 
 	if (!pszPath)
-		return S_FALSE;
+		return E_INVALIDARG;
 
 	if (!pszExt)
-		return S_FALSE;
+		return E_INVALIDARG;
 
 	pszExtLength = lstrlenW(pszExt);
 	pszPathLength = lstrlenW(pszPath);
@@ -45,7 +45,7 @@ HRESULT PATH_CCH_ADD_EXTENSION(PWSTR pszPath, size_t cchPath, PCWSTR pszExt)
 		return S_OK;
 	}
 #endif
-	return S_FALSE;
+	return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
 }
 
 #else
@@ -59,10 +59,10 @@ HRESULT PATH_CCH_ADD_EXTENSION(PSTR pszPath, size_t cchPath, PCSTR pszExt)
 	size_t pszPathLength;
 
 	if (!pszPath)
-		return S_FALSE;
+		return E_INVALIDARG;
 
 	if (!pszExt)
-		return S_FALSE;
+		return E_INVALIDARG;
 
 	pszExtLength = lstrlenA(pszExt);
 	pszPathLength = lstrlenA(pszPath);
@@ -87,7 +87,7 @@ HRESULT PATH_CCH_ADD_EXTENSION(PSTR pszPath, size_t cchPath, PCSTR pszExt)
 		return S_OK;
 	}
 
-	return S_FALSE;
+	return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
 }
 
 #endif

--- a/winpr/libwinpr/path/include/PathCchAddSeparator.c
+++ b/winpr/libwinpr/path/include/PathCchAddSeparator.c
@@ -12,7 +12,7 @@ HRESULT PATH_CCH_ADD_SEPARATOR(PWSTR pszPath, size_t cchPath)
 	size_t pszPathLength;
 
 	if (!pszPath)
-		return S_FALSE;
+		return E_INVALIDARG;
 
 	pszPathLength = lstrlenW(pszPath);
 
@@ -27,7 +27,7 @@ HRESULT PATH_CCH_ADD_SEPARATOR(PWSTR pszPath, size_t cchPath)
 		return S_OK;
 	}
 
-	return S_FALSE;
+	return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
 }
 
 #else
@@ -37,7 +37,7 @@ HRESULT PATH_CCH_ADD_SEPARATOR(PSTR pszPath, size_t cchPath)
 	size_t pszPathLength;
 
 	if (!pszPath)
-		return S_FALSE;
+		return E_INVALIDARG;
 
 	pszPathLength = lstrlenA(pszPath);
 
@@ -52,7 +52,7 @@ HRESULT PATH_CCH_ADD_SEPARATOR(PSTR pszPath, size_t cchPath)
 		return S_OK;
 	}
 
-	return S_FALSE;
+	return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
 }
 
 #endif

--- a/winpr/libwinpr/path/include/PathCchAddSeparatorEx.c
+++ b/winpr/libwinpr/path/include/PathCchAddSeparatorEx.c
@@ -12,7 +12,7 @@ HRESULT PATH_CCH_ADD_SEPARATOR_EX(PWSTR pszPath, size_t cchPath, PWSTR* ppszEnd,
 	size_t pszPathLength;
 
 	if (!pszPath)
-		return S_FALSE;
+		return E_INVALIDARG;
 
 	pszPathLength = lstrlenW(pszPath);
 
@@ -27,7 +27,7 @@ HRESULT PATH_CCH_ADD_SEPARATOR_EX(PWSTR pszPath, size_t cchPath, PWSTR* ppszEnd,
 		return S_OK;
 	}
 
-	return S_FALSE;
+	return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
 }
 
 #else
@@ -37,7 +37,7 @@ HRESULT PATH_CCH_ADD_SEPARATOR_EX(PSTR pszPath, size_t cchPath, PSTR* ppszEnd, s
 	size_t pszPathLength;
 
 	if (!pszPath)
-		return S_FALSE;
+		return E_INVALIDARG;
 
 	pszPathLength = lstrlenA(pszPath);
 
@@ -52,7 +52,7 @@ HRESULT PATH_CCH_ADD_SEPARATOR_EX(PSTR pszPath, size_t cchPath, PSTR* ppszEnd, s
 		return S_OK;
 	}
 
-	return S_FALSE;
+	return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
 }
 
 #endif

--- a/winpr/libwinpr/path/include/PathCchAppend.c
+++ b/winpr/libwinpr/path/include/PathCchAppend.c
@@ -17,10 +17,13 @@ HRESULT PATH_CCH_APPEND(PWSTR pszPath, size_t cchPath, PCWSTR pszMore)
 	size_t pszPathLength;
 
 	if (!pszPath)
-		return S_FALSE;
+		return E_INVALIDARG;
 
 	if (!pszMore)
-		return S_FALSE;
+		return E_INVALIDARG;
+
+	if (cchPath == 0 || cchPath > PATHCCH_MAX_CCH)
+		return E_INVALIDARG;
 
 	pszMoreLength = lstrlenW(pszMore);
 	pszPathLength = lstrlenW(pszPath);
@@ -54,7 +57,7 @@ HRESULT PATH_CCH_APPEND(PWSTR pszPath, size_t cchPath, PCWSTR pszMore)
 	}
 #endif
 
-	return S_FALSE;
+	return HRESULT_FROM_WIN32(ERROR_FILENAME_EXCED_RANGE);
 }
 
 #else
@@ -67,10 +70,13 @@ HRESULT PATH_CCH_APPEND(PSTR pszPath, size_t cchPath, PCSTR pszMore)
 	size_t pszPathLength;
 
 	if (!pszPath)
-		return S_FALSE;
+		return E_INVALIDARG;
 
 	if (!pszMore)
-		return S_FALSE;
+		return E_INVALIDARG;
+
+	if (cchPath == 0 || cchPath > PATHCCH_MAX_CCH)
+		return E_INVALIDARG;
 
 	pszMoreLength = lstrlenA(pszMore);
 	pszPathLength = lstrlenA(pszPath);
@@ -103,7 +109,7 @@ HRESULT PATH_CCH_APPEND(PSTR pszPath, size_t cchPath, PCSTR pszMore)
 		}
 	}
 
-	return S_FALSE;
+	return HRESULT_FROM_WIN32(ERROR_FILENAME_EXCED_RANGE);
 }
 
 #endif

--- a/winpr/libwinpr/path/path.c
+++ b/winpr/libwinpr/path/path.c
@@ -634,27 +634,29 @@ HRESULT PathCchStripToRootW(PWSTR pszPath, size_t cchPath)
 HRESULT PathCchStripPrefixA(PSTR pszPath, size_t cchPath)
 {
 	BOOL hasPrefix;
-	BOOL deviceNamespace;
 
 	if (!pszPath)
-		return S_FALSE;
+		return E_INVALIDARG;
 
-	if (cchPath < 4)
-		return S_FALSE;
+	if (cchPath < 4 || cchPath > PATHCCH_MAX_CCH)
+		return E_INVALIDARG;
 
 	hasPrefix = ((pszPath[0] == '\\') && (pszPath[1] == '\\') &&
 		(pszPath[2] == '?') && (pszPath[3] == '\\')) ? TRUE : FALSE;
 
 	if (hasPrefix)
 	{
-		if (cchPath < 7)
+		if (cchPath < 6)
 			return S_FALSE;
 
-		deviceNamespace = ((pszPath[5] == ':') && (pszPath[6] == '\\')) ? TRUE : FALSE;
-
-		if (deviceNamespace)
+		if (IsCharAlpha(pszPath[4]) && (pszPath[5] == ':')) /* like C: */
 		{
 			memmove_s(pszPath, cchPath, &pszPath[4], cchPath - 4);
+			/* since the passed pszPath must not necessarily be null terminated
+			 * and we always have enough space after the strip we can always
+			 * ensure the null termination of the stripped result
+			 */
+			pszPath[cchPath - 4] = 0;
 			return S_OK;
 		}
 	}
@@ -665,27 +667,32 @@ HRESULT PathCchStripPrefixA(PSTR pszPath, size_t cchPath)
 HRESULT PathCchStripPrefixW(PWSTR pszPath, size_t cchPath)
 {
 	BOOL hasPrefix;
-	BOOL deviceNamespace;
 
 	if (!pszPath)
-		return S_FALSE;
+		return E_INVALIDARG;
 
-	if (cchPath < 4)
-		return S_FALSE;
+	if (cchPath < 4 || cchPath > PATHCCH_MAX_CCH)
+		return E_INVALIDARG;
 
 	hasPrefix = ((pszPath[0] == '\\') && (pszPath[1] == '\\') &&
 		(pszPath[2] == '?') && (pszPath[3] == '\\')) ? TRUE : FALSE;
 
 	if (hasPrefix)
 	{
-		if (cchPath < 7)
+		if (cchPath < 6)
 			return S_FALSE;
 
-		deviceNamespace = ((pszPath[5] == ':') && (pszPath[6] == '\\')) ? TRUE : FALSE;
+		if (cchPath < (lstrlenW(&pszPath[4]) + 1))
+			return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
 
-		if (deviceNamespace)
+		if (IsCharAlpha(pszPath[4]) && (pszPath[5] == ':')) /* like C: */
 		{
 			wmemmove_s(pszPath, cchPath, &pszPath[4], cchPath - 4);
+			/* since the passed pszPath must not necessarily be null terminated
+			 * and we always have enough space after the strip we can always
+			 * ensure the null termination of the stripped result
+			 */
+			pszPath[cchPath - 4] = 0;
 			return S_OK;
 		}
 	}

--- a/winpr/libwinpr/path/test/TestPathCchAddBackslash.c
+++ b/winpr/libwinpr/path/test/TestPathCchAddBackslash.c
@@ -13,6 +13,12 @@ int TestPathCchAddBackslash(int argc, char* argv[])
 	HRESULT status;
 	TCHAR Path[PATHCCH_MAX_CCH];
 
+	/**
+	 * PathCchAddBackslash returns S_OK if the function was successful,
+	 * S_FALSE if the path string already ends in a backslash,
+	 * or an error code otherwise.
+	 */
+
 	_tcscpy(Path, testPathNoBackslash);
 
 	/* Add a backslash to a path without a trailing backslash, expect S_OK */
@@ -21,7 +27,7 @@ int TestPathCchAddBackslash(int argc, char* argv[])
 
 	if (status != S_OK)
 	{
-		_tprintf(_T("PathCchAddBackslash status: 0x%08X\n"), (int) status);
+		_tprintf(_T("PathCchAddBackslash status: 0x%08X\n"), (unsigned) status);
 		return -1;
 	}
 
@@ -39,13 +45,47 @@ int TestPathCchAddBackslash(int argc, char* argv[])
 
 	if (status != S_FALSE)
 	{
-		_tprintf(_T("PathCchAddBackslash status: 0x%08X\n"), (int) status);
+		_tprintf(_T("PathCchAddBackslash status: 0x%08X\n"), (unsigned) status);
 		return -1;
 	}
 
 	if (_tcscmp(Path, testPathBackslash) != 0)
 	{
 		_tprintf(_T("Path Mismatch: Actual: %s, Expected: %s\n"), Path, testPathBackslash);
+		return -1;
+	}
+
+	/* Use NULL PSTR, expect FAILED(status) */
+
+	status = PathCchAddBackslash(NULL, PATHCCH_MAX_CCH);
+
+	if (SUCCEEDED(status))
+	{
+		_tprintf(_T("PathCchAddBackslash unexpectedly succeded with null buffer. Status: 0x%08X\n"), (unsigned) status);
+		return -1;
+	}
+
+	/* Use insufficient size value, expect FAILED(status)  */
+
+	_tcscpy(Path, _T("C:\\tmp"));
+
+	status = PathCchAddBackslash(Path, 7);
+
+	if (SUCCEEDED(status))
+	{
+		_tprintf(_T("PathCchAddBackslash unexpectedly succeded with insufficient buffer size. Status: 0x%08X\n"), (unsigned) status);
+		return -1;
+	}
+
+	/* Use minimum required size value, expect S_OK  */
+
+	_tcscpy(Path, _T("C:\\tmp"));
+
+	status = PathCchAddBackslash(Path, 8);
+
+	if (status != S_OK)
+	{
+		_tprintf(_T("PathCchAddBackslash failed with status: 0x%08X\n"), (unsigned) status);
 		return -1;
 	}
 

--- a/winpr/libwinpr/path/test/TestPathCchAddBackslashEx.c
+++ b/winpr/libwinpr/path/test/TestPathCchAddBackslashEx.c
@@ -15,6 +15,12 @@ int TestPathCchAddBackslashEx(int argc, char* argv[])
 	size_t cchRemaining;
 	TCHAR Path[PATHCCH_MAX_CCH];
 
+	/**
+	 * PathCchAddBackslashEx returns S_OK if the function was successful,
+	 * S_FALSE if the path string already ends in a backslash,
+	 * or an error code otherwise.
+	 */
+
 	_tcscpy(Path, testPathNoBackslash);
 
 	/* Add a backslash to a path without a trailing backslash, expect S_OK */
@@ -50,6 +56,41 @@ int TestPathCchAddBackslashEx(int argc, char* argv[])
 		_tprintf(_T("Path Mismatch: Actual: %s, Expected: %s\n"), Path, testPathBackslash);
 		return -1;
 	}
+
+	/* Use NULL PSTR, expect FAILED(status) */
+
+	status = PathCchAddBackslashEx(NULL, PATHCCH_MAX_CCH, NULL, NULL);
+
+	if (SUCCEEDED(status))
+	{
+		_tprintf(_T("PathCchAddBackslashEx unexpectedly succeded with null buffer. Status: 0x%08X\n"), (unsigned) status);
+		return -1;
+	}
+
+	/* Use insufficient size value, expect FAILED(status)  */
+
+	_tcscpy(Path, _T("C:\\tmp"));
+
+	status = PathCchAddBackslashEx(Path, 7, NULL, NULL);
+
+	if (SUCCEEDED(status))
+	{
+		_tprintf(_T("PathCchAddBackslashEx unexpectedly succeded with insufficient buffer size. Status: 0x%08X\n"), (unsigned) status);
+		return -1;
+	}
+
+	/* Use minimum required size value, expect S_OK  */
+
+	_tcscpy(Path, _T("C:\\tmp"));
+
+	status = PathCchAddBackslashEx(Path, 8, NULL, NULL);
+
+	if (status != S_OK)
+	{
+		_tprintf(_T("PathCchAddBackslashEx failed with status: 0x%08X\n"), (unsigned) status);
+		return -1;
+	}
+
 
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathCchAddExtension.c
+++ b/winpr/libwinpr/path/test/TestPathCchAddExtension.c
@@ -14,7 +14,7 @@ int TestPathCchAddExtension(int argc, char* argv[])
 {
 	HRESULT status;
 	TCHAR Path[PATHCCH_MAX_CCH];
-	
+
 	/* Path: no extension, Extension: dot */
 
 	_tcscpy(Path, testPathNoExtension);
@@ -86,6 +86,45 @@ int TestPathCchAddExtension(int argc, char* argv[])
 		_tprintf(_T("Path Mismatch: Actual: %s, Expected: %s\n"), Path, testPathExtension);
 		return -1;
 	}
+
+	/* Path: NULL */
+
+	status = PathCchAddExtension(NULL, PATHCCH_MAX_CCH, testExtDot);
+	if (status != E_INVALIDARG)
+	{
+		_tprintf(_T("PathCchAddExtension with null buffer returned status: 0x%08X (expected E_INVALIDARG)\n"), status);
+		return -1;
+	}
+
+	/* Extension: NULL */
+
+	status = PathCchAddExtension(Path, PATHCCH_MAX_CCH, NULL);
+	if (status != E_INVALIDARG)
+	{
+		_tprintf(_T("PathCchAddExtension with null extension returned status: 0x%08X (expected E_INVALIDARG)\n"), status);
+		return -1;
+	}
+
+	/* Insufficient Buffer size */
+
+	_tcscpy(Path, _T("C:\\456789"));
+	status = PathCchAddExtension(Path, 9 + 4, _T(".jpg"));
+	if (SUCCEEDED(status))
+	{
+		_tprintf(_T("PathCchAddExtension with insufficient buffer unexpectedly succeeded with status: 0x%08X\n"), status);
+		return -1;
+	}
+
+	/* Minimum required buffer size */
+
+	_tcscpy(Path, _T("C:\\456789"));
+	status = PathCchAddExtension(Path, 9 + 4 + 1, _T(".jpg"));
+	if (FAILED(status))
+	{
+		_tprintf(_T("PathCchAddExtension with sufficient buffer unexpectedly failed with status: 0x%08X\n"), status);
+		return -1;
+	}
+
 
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathCchAppend.c
+++ b/winpr/libwinpr/path/test/TestPathCchAppend.c
@@ -15,6 +15,7 @@ int TestPathCchAppend(int argc, char* argv[])
 {
 	HRESULT status;
 	TCHAR Path[PATHCCH_MAX_CCH];
+	size_t i;
 
 	/* Base Path: Backslash, More Path: No Backslash */
 
@@ -85,6 +86,53 @@ int TestPathCchAppend(int argc, char* argv[])
 	if (_tcscmp(Path, testPathOut) != 0)
 	{
 		_tprintf(_T("Path Mismatch: Actual: %s, Expected: %s\n"), Path, testPathOut);
+		return -1;
+	}
+
+	/* According to msdn a NULL Path is an invalid argument */
+	status = PathCchAppend(NULL, PATHCCH_MAX_CCH, testMorePathNoBackslash);
+	if (status != E_INVALIDARG)
+	{
+		_tprintf(_T("PathCchAppend with NULL path unexpectedly returned status: 0x%08X\n"), status);
+		return -1;
+	}
+
+	/* According to msdn a NULL pszMore is an invalid argument (although optional !?) */
+	_tcscpy(Path, testBasePathNoBackslash);
+	status = PathCchAppend(Path, PATHCCH_MAX_CCH, NULL);
+	if (status != E_INVALIDARG)
+	{
+		_tprintf(_T("PathCchAppend with NULL pszMore unexpectedly returned status: 0x%08X\n"), status);
+		return -1;
+	}
+
+	/* According to msdn cchPath must be > 0 and <= PATHCCH_MAX_CCH */
+	_tcscpy(Path, testBasePathNoBackslash);
+	status = PathCchAppend(Path, 0, testMorePathNoBackslash);
+	if (status != E_INVALIDARG)
+	{
+		_tprintf(_T("PathCchAppend with cchPath value 0 unexpectedly returned status: 0x%08X\n"), status);
+		return -1;
+	}
+	_tcscpy(Path, testBasePathNoBackslash);
+	status = PathCchAppend(Path, PATHCCH_MAX_CCH + 1, testMorePathNoBackslash);
+	if (status != E_INVALIDARG)
+	{
+		_tprintf(_T("PathCchAppend with cchPath value > PATHCCH_MAX_CCH unexpectedly returned status: 0x%08X\n"), status);
+		return -1;
+	}
+
+	/* Resulting file must not exceed PATHCCH_MAX_CCH */
+
+	for (i = 0; i < PATHCCH_MAX_CCH - 1; i++)
+		Path[i] = _T('X');
+
+	Path[PATHCCH_MAX_CCH - 1] = 0;
+
+	status = PathCchAppend(Path, PATHCCH_MAX_CCH, _T("\\This cannot be appended to Path"));
+	if (SUCCEEDED(status))
+	{
+		_tprintf(_T("PathCchAppend unexepectedly succeeded with status: 0x%08X\n"), status);
 		return -1;
 	}
 

--- a/winpr/libwinpr/path/test/TestPathCchStripPrefix.c
+++ b/winpr/libwinpr/path/test/TestPathCchStripPrefix.c
@@ -12,6 +12,8 @@
 
 static const TCHAR testPathPrefixFileNamespace[] = _T("\\\\?\\C:\\Program Files\\");
 static const TCHAR testPathNoPrefixFileNamespace[] = _T("C:\\Program Files\\");
+static const TCHAR testPathPrefixFileNamespaceMinimum[] = _T("\\\\?\\C:");
+static const TCHAR testPathNoPrefixFileNamespaceMinimum[] = _T("C:");
 
 static const TCHAR testPathPrefixDeviceNamespace[] = _T("\\\\?\\GLOBALROOT");
 
@@ -19,6 +21,13 @@ int TestPathCchStripPrefix(int argc, char* argv[])
 {
 	HRESULT status;
 	TCHAR Path[PATHCCH_MAX_CCH];
+	int i;
+
+	/**
+	 * PathCchStripPrefix returns S_OK if the prefix was removed, S_FALSE if
+	 * the path did not have a prefix to remove, or an HRESULT failure code.
+	 */
+
 
 	/* Path with prefix (File Namespace) */
 
@@ -53,6 +62,53 @@ int TestPathCchStripPrefix(int argc, char* argv[])
 	if (_tcscmp(Path, testPathPrefixDeviceNamespace) != 0)
 	{
 		_tprintf(_T("Path Mismatch: Actual: %s, Expected: %s\n"), Path, testPathPrefixDeviceNamespace);
+		return -1;
+	}
+
+	/* NULL Path */
+	status = PathCchStripPrefix(NULL, PATHCCH_MAX_CCH);
+	if (status != E_INVALIDARG)
+	{
+		_tprintf(_T("PathCchStripPrefix with null path unexpectedly succeeded with status 0x%08X\n"), status);
+		return -1;
+	}
+
+	/* Invalid cchPath values: 0, 1, 2, 3 and > PATHCCH_MAX_CCH */
+	for (i = 0; i < 5; i++)
+	{
+		_tcscpy(Path, testPathPrefixFileNamespace);
+		if (i == 4)
+			i = PATHCCH_MAX_CCH + 1;
+		status = PathCchStripPrefix(Path, i);
+		if (status != E_INVALIDARG)
+		{
+			_tprintf(_T("PathCchStripPrefix with invalid cchPath value %d unexpectedly succeeded with status 0x%08X\n"), i, status);
+			return -1;
+		}
+	}
+
+	/* Minimum Path that would get successfully stripped on windows */
+	_tcscpy(Path, testPathPrefixFileNamespaceMinimum);
+	i = sizeof(testPathPrefixFileNamespaceMinimum) / sizeof(TCHAR);
+	i = i - 1; /* include testing of a non-null terminated string */
+	status = PathCchStripPrefix(Path, i);
+	if (status != S_OK)
+	{
+		_tprintf(_T("PathCchStripPrefix with minimum valid strippable path length unexpectedly returned status 0x%08X\n"), status);
+		return -1;
+	}
+	if (_tcscmp(Path, testPathNoPrefixFileNamespaceMinimum))
+	{
+		_tprintf(_T("Path Mismatch: Actual: %s, Expected: %s\n"), Path, testPathNoPrefixFileNamespaceMinimum);
+		return -1;
+	}
+
+	/* Invalid drive letter symbol */
+	_tcscpy(Path, _T("\\\\?\\5:"));
+	status = PathCchStripPrefix(Path, 6);
+	if (status == S_OK)
+	{
+		_tprintf(_T("PathCchStripPrefix with invalid drive letter symbol unexpectedly succeeded\n"));
 		return -1;
 	}
 


### PR DESCRIPTION
Contrary to popular belief S_FALSE is a HRESULT success code and is not used to indicate an error. That is why they prefix with an S_ ;)

PathCchAppend:
- Make this function behave like the Windows 8 implementation and the according MSDN specification.
- return E_INVALIDARG instead of S_FALSE if pszPath is NULL
- return E_INVALIDARG instead of S_FALSE if pszMore is NULL
- return E_INVALIDARG if cchPath is zero
- return E_INVALIDARG if cchPath is greater than PATHCCH_MAX_CCH
- return HRESULT_FROM_WIN32(ERROR_FILENAME_EXCED_RANGE) if the combined  path size exceeds cchPath (this is the same HRESULT which the Windows  implementation returns in this case and which is referred to as  PATHCCH_E_FILENAME_TOO_LONG on msdn)
- extended/fixed the TestPathCchAppend ctest

PathCchStripPrefix:
- fixed to be compatible to the Windows 8 implementation of this function:
- return E_INVALIDARG instead of S_FALSE if pszPath is NULL
- return E_INVALIDARG instead of S_FALSE if cchPath < 4
- return E_INVALIDARG if cchPath > PATHCCH_MAX_CCH
- allow stripping of "\\?\c:" and don't require "\\?\c:\"
- verify that the character at the drive letter position is actually an alphabetic character
- since the passed pszPath must not necessarily be null terminated and we always have enough  space after the memmove we can always ensure the null termination of the stripped result
- extended/fixed the TestPathCchStripPrefixctest

PathCchAddExtension:
- return E_INVALIDARG instead of S_FALSE
- return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER) instead of S_FALSE
- extended/fixed the corresponding ctest

PathCchAddBackslashEx
- return E_INVALIDARG instead of S_FALSE
- return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER) instead of S_FALSE
- extended/fixed the corresponding ctest

PathCchAddBackslash
- return E_INVALIDARG instead of S_FALSE
- return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER) instead of S_FALSE
- extended/fixed the corresponding ctest


More PathCch fixes next week in a separate PR
