### PR TITLE
winpr/path: more PathCch* fixes

### DIFF
--- a/winpr/libwinpr/path/include/PathAllocCombine.c
+++ b/winpr/libwinpr/path/include/PathAllocCombine.c
@@ -6,6 +6,18 @@
 #define PATH_ALLOC_COMBINE	PathAllocCombineA
 */
 
+/**
+ * FIXME: These implementations of the PathAllocCombine functions have
+ * several issues:
+ * - pszPathIn or pszMore may be NULL (but not both)
+ * - no check if pszMore is fully qualified (if so, it must be directly
+ *   copied to the output buffer without being combined with pszPathIn.
+ * - if pszMore begins with a _single_ backslash it must be combined with
+ *   only the root of the path pointed to by pszPathIn and there's no code
+ *   to extract the root of pszPathIn.
+ * - the function will crash with some short string lengths of the parameters
+ */
+
 #if DEFINE_UNICODE
 
 HRESULT PATH_ALLOC_COMBINE(PCWSTR pszPathIn, PCWSTR pszMore, unsigned long dwFlags, PWSTR* ppszPathOut)
@@ -18,14 +30,26 @@ HRESULT PATH_ALLOC_COMBINE(PCWSTR pszPathIn, PCWSTR pszMore, unsigned long dwFla
 	int pszPathInLength;
 	int pszPathOutLength;
 
-	if (!pszPathIn)
-		return S_FALSE;
+	WLog_WARN(TAG, "%s: has known bugs and needs fixing.", __FUNCTION__);
+
+	if (!ppszPathOut)
+		return E_INVALIDARG;
+
+	if (!pszPathIn && !pszMore)
+		return E_INVALIDARG;
 
 	if (!pszMore)
-		return S_FALSE;
+		return E_FAIL; /* valid but not implemented, see top comment */
 
-	pszPathInLength = lstrlenW(pszPathIn);
-	pszMoreLength = lstrlenW(pszMore);
+	if (!pszPathIn)
+		return E_FAIL;  /* valid but not implemented, see top comment */
+
+	pszPathInLength = lstrlenA(pszPathIn);
+	pszMoreLength = lstrlenA(pszMore);
+
+	/* prevent segfaults - the complete implementation below is buggy */
+	if (pszPathInLength < 3)
+		return E_FAIL;
 
 	backslashIn = (pszPathIn[pszPathInLength - 1] == _PATH_SEPARATOR_CHR) ? TRUE : FALSE;
 	backslashMore = (pszMore[0] == _PATH_SEPARATOR_CHR) ? TRUE : FALSE;
@@ -40,6 +64,9 @@ HRESULT PATH_ALLOC_COMBINE(PCWSTR pszPathIn, PCWSTR pszMore, unsigned long dwFla
 			sizeOfBuffer = (pszPathOutLength + 1) * 2;
 
 			pszPathOut = (PWSTR) HeapAlloc(GetProcessHeap(), 0, sizeOfBuffer * 2);
+			if (!pszPathOut)
+				return E_OUTOFMEMORY;
+
 			swprintf_s(pszPathOut, sizeOfBuffer, L"%c:%s", pszPathIn[0], pszMore);
 
 			*ppszPathOut = pszPathOut;
@@ -55,6 +82,8 @@ HRESULT PATH_ALLOC_COMBINE(PCWSTR pszPathIn, PCWSTR pszMore, unsigned long dwFla
 		sizeOfBuffer = (pszPathOutLength + 1) * 2;
 
 		pszPathOut = (PWSTR) HeapAlloc(GetProcessHeap(), 0, sizeOfBuffer * 2);
+		if (!pszPathOut)
+			return E_OUTOFMEMORY;
 
 		if (backslashIn)
 			swprintf_s(pszPathOut, sizeOfBuffer, L"%s%s", pszPathIn, pszMore);
@@ -67,7 +96,7 @@ HRESULT PATH_ALLOC_COMBINE(PCWSTR pszPathIn, PCWSTR pszMore, unsigned long dwFla
 	}
 #endif
 
-	return S_OK;
+	return E_FAIL;
 }
 
 #else
@@ -81,14 +110,26 @@ HRESULT PATH_ALLOC_COMBINE(PCSTR pszPathIn, PCSTR pszMore, unsigned long dwFlags
 	int pszPathInLength;
 	int pszPathOutLength;
 
-	if (!pszPathIn)
-		return S_FALSE;
+	WLog_WARN(TAG, "%s: has known bugs and needs fixing.", __FUNCTION__);
+
+	if (!ppszPathOut)
+		return E_INVALIDARG;
+
+	if (!pszPathIn && !pszMore)
+		return E_INVALIDARG;
 
 	if (!pszMore)
-		return S_FALSE;
+		return E_FAIL; /* valid but not implemented, see top comment */
+
+	if (!pszPathIn)
+		return E_FAIL;  /* valid but not implemented, see top comment */
 
 	pszPathInLength = lstrlenA(pszPathIn);
 	pszMoreLength = lstrlenA(pszMore);
+
+	/* prevent segfaults - the complete implementation below is buggy */
+	if (pszPathInLength < 3)
+		return E_FAIL;
 
 	backslashIn = (pszPathIn[pszPathInLength - 1] == _PATH_SEPARATOR_CHR) ? TRUE : FALSE;
 	backslashMore = (pszMore[0] == _PATH_SEPARATOR_CHR) ? TRUE : FALSE;
@@ -103,6 +144,9 @@ HRESULT PATH_ALLOC_COMBINE(PCSTR pszPathIn, PCSTR pszMore, unsigned long dwFlags
 			sizeOfBuffer = (pszPathOutLength + 1) * 2;
 
 			pszPathOut = (PSTR) HeapAlloc(GetProcessHeap(), 0, sizeOfBuffer * 2);
+			if (!pszPathOut)
+				return E_OUTOFMEMORY;
+
 			sprintf_s(pszPathOut, sizeOfBuffer, "%c:%s", pszPathIn[0], pszMore);
 
 			*ppszPathOut = pszPathOut;
@@ -118,6 +162,8 @@ HRESULT PATH_ALLOC_COMBINE(PCSTR pszPathIn, PCSTR pszMore, unsigned long dwFlags
 		sizeOfBuffer = (pszPathOutLength + 1) * 2;
 
 		pszPathOut = (PSTR) HeapAlloc(GetProcessHeap(), 0, sizeOfBuffer * 2);
+		if (!pszPathOut)
+			return E_OUTOFMEMORY;
 
 		if (backslashIn)
 			sprintf_s(pszPathOut, sizeOfBuffer, "%s%s", pszPathIn, pszMore);
@@ -129,7 +175,7 @@ HRESULT PATH_ALLOC_COMBINE(PCSTR pszPathIn, PCSTR pszMore, unsigned long dwFlags
 		return S_OK;
 	}
 
-	return S_OK;
+	return E_FAIL;
 }
 
 #endif

--- a/winpr/libwinpr/path/path.c
+++ b/winpr/libwinpr/path/path.c
@@ -63,6 +63,9 @@
 #define SHARED_LIBRARY_EXT		SHARED_LIBRARY_EXT_SO
 #endif
 
+#include "../log.h"
+#define TAG WINPR_TAG("path")
+
 /*
  * PathCchAddBackslash
  */
@@ -127,12 +130,14 @@
 
 HRESULT PathCchRemoveBackslashA(PSTR pszPath, size_t cchPath)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 HRESULT PathCchRemoveBackslashW(PWSTR pszPath, size_t cchPath)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 /*
@@ -195,12 +200,14 @@ HRESULT PathCchRemoveBackslashW(PWSTR pszPath, size_t cchPath)
 
 HRESULT PathCchRemoveBackslashExA(PSTR pszPath, size_t cchPath, PSTR* ppszEnd, size_t* pcchRemaining)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 HRESULT PathCchRemoveBackslashExW(PWSTR pszPath, size_t cchPath, PWSTR* ppszEnd, size_t* pcchRemaining)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 /*
@@ -337,12 +344,14 @@ HRESULT PathCchRemoveBackslashExW(PWSTR pszPath, size_t cchPath, PWSTR* ppszEnd,
 
 HRESULT PathCchAppendExA(PSTR pszPath, size_t cchPath, PCSTR pszMore, unsigned long dwFlags)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 HRESULT PathCchAppendExW(PWSTR pszPath, size_t cchPath, PCWSTR pszMore, unsigned long dwFlags)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 /*
@@ -351,12 +360,14 @@ HRESULT PathCchAppendExW(PWSTR pszPath, size_t cchPath, PCWSTR pszMore, unsigned
 
 HRESULT PathCchCanonicalizeA(PSTR pszPathOut, size_t cchPathOut, PCSTR pszPathIn)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 HRESULT PathCchCanonicalizeW(PWSTR pszPathOut, size_t cchPathOut, PCWSTR pszPathIn)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 /*
@@ -365,12 +376,14 @@ HRESULT PathCchCanonicalizeW(PWSTR pszPathOut, size_t cchPathOut, PCWSTR pszPath
 
 HRESULT PathCchCanonicalizeExA(PSTR pszPathOut, size_t cchPathOut, PCSTR pszPathIn, unsigned long dwFlags)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 HRESULT PathCchCanonicalizeExW(PWSTR pszPathOut, size_t cchPathOut, PCWSTR pszPathIn, unsigned long dwFlags)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 /*
@@ -379,12 +392,14 @@ HRESULT PathCchCanonicalizeExW(PWSTR pszPathOut, size_t cchPathOut, PCWSTR pszPa
 
 HRESULT PathAllocCanonicalizeA(PCSTR pszPathIn, unsigned long dwFlags, PSTR* ppszPathOut)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 HRESULT PathAllocCanonicalizeW(PCWSTR pszPathIn, unsigned long dwFlags, PWSTR* ppszPathOut)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 /*
@@ -393,12 +408,14 @@ HRESULT PathAllocCanonicalizeW(PCWSTR pszPathIn, unsigned long dwFlags, PWSTR* p
 
 HRESULT PathCchCombineA(PSTR pszPathOut, size_t cchPathOut, PCSTR pszPathIn, PCSTR pszMore)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 HRESULT PathCchCombineW(PWSTR pszPathOut, size_t cchPathOut, PCWSTR pszPathIn, PCWSTR pszMore)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 /*
@@ -407,12 +424,14 @@ HRESULT PathCchCombineW(PWSTR pszPathOut, size_t cchPathOut, PCWSTR pszPathIn, P
 
 HRESULT PathCchCombineExA(PSTR pszPathOut, size_t cchPathOut, PCSTR pszPathIn, PCSTR pszMore, unsigned long dwFlags)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 HRESULT PathCchCombineExW(PWSTR pszPathOut, size_t cchPathOut, PCWSTR pszPathIn, PCWSTR pszMore, unsigned long dwFlags)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 /*
@@ -534,6 +553,7 @@ HRESULT PathCchFindExtensionA(PCSTR pszPath, size_t cchPath, PCSTR* ppszExt)
 
 HRESULT PathCchFindExtensionW(PCWSTR pszPath, size_t cchPath, PCWSTR* ppszExt)
 {
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
 	return E_NOTIMPL;
 }
 
@@ -543,12 +563,14 @@ HRESULT PathCchFindExtensionW(PCWSTR pszPath, size_t cchPath, PCWSTR* ppszExt)
 
 HRESULT PathCchRenameExtensionA(PSTR pszPath, size_t cchPath, PCSTR pszExt)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 HRESULT PathCchRenameExtensionW(PWSTR pszPath, size_t cchPath, PCWSTR pszExt)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 /**
@@ -557,12 +579,14 @@ HRESULT PathCchRenameExtensionW(PWSTR pszPath, size_t cchPath, PCWSTR pszExt)
 
 HRESULT PathCchRemoveExtensionA(PSTR pszPath, size_t cchPath)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 HRESULT PathCchRemoveExtensionW(PWSTR pszPath, size_t cchPath)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 /**
@@ -571,12 +595,14 @@ HRESULT PathCchRemoveExtensionW(PWSTR pszPath, size_t cchPath)
 
 BOOL PathCchIsRootA(PCSTR pszPath)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 BOOL PathCchIsRootW(PCWSTR pszPath)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 /**
@@ -617,12 +643,14 @@ BOOL PathIsUNCExW(PCWSTR pszPath, PCWSTR* ppszServer)
 
 HRESULT PathCchSkipRootA(PCSTR pszPath, PCSTR* ppszRootEnd)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 HRESULT PathCchSkipRootW(PCWSTR pszPath, PCWSTR* ppszRootEnd)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 /**
@@ -631,12 +659,14 @@ HRESULT PathCchSkipRootW(PCWSTR pszPath, PCWSTR* ppszRootEnd)
 
 HRESULT PathCchStripToRootA(PSTR pszPath, size_t cchPath)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 HRESULT PathCchStripToRootW(PWSTR pszPath, size_t cchPath)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 /**
@@ -718,12 +748,14 @@ HRESULT PathCchStripPrefixW(PWSTR pszPath, size_t cchPath)
 
 HRESULT PathCchRemoveFileSpecA(PSTR pszPath, size_t cchPath)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 HRESULT PathCchRemoveFileSpecW(PWSTR pszPath, size_t cchPath)
 {
-	return 0;
+	WLog_ERR(TAG, "%s: not implemented", __FUNCTION__);
+	return E_NOTIMPL;
 }
 
 /*

--- a/winpr/libwinpr/path/path.c
+++ b/winpr/libwinpr/path/path.c
@@ -811,13 +811,13 @@ HRESULT PathCchConvertStyleA(PSTR pszPath, size_t cchPath, unsigned long dwFlags
 		else
 		{
 			/* Unexpected error */
-			return S_FALSE;
+			return E_FAIL;
 		}
 	}
 	else
 	{
 		/* Gangnam style? */
-		return S_FALSE;
+		return E_FAIL;
 	}
 
 	return S_OK;
@@ -868,13 +868,13 @@ HRESULT PathCchConvertStyleW(PWSTR pszPath, size_t cchPath, unsigned long dwFlag
 		else
 		{
 			/* Unexpected error */
-			return S_FALSE;
+			return E_FAIL;
 		}
 	}
 	else
 	{
 		/* Gangnam style? */
-		return S_FALSE;
+		return E_FAIL;
 	}
 
 	return S_OK;

--- a/winpr/libwinpr/path/path.c
+++ b/winpr/libwinpr/path/path.c
@@ -493,6 +493,9 @@ HRESULT PathCchFindExtensionA(PCSTR pszPath, size_t cchPath, PCSTR* ppszExt)
 {
 	char* p = (char*) pszPath;
 
+	if (!pszPath || !cchPath || !ppszExt)
+		return E_INVALIDARG;
+
 	/* find end of string */
 
 	while (*p && cchPath)
@@ -501,6 +504,15 @@ HRESULT PathCchFindExtensionA(PCSTR pszPath, size_t cchPath, PCSTR* ppszExt)
 		p++;
 	}
 
+	if (*p)
+	{
+		/* pszPath is not null terminated within the cchPath range */
+		return E_INVALIDARG;
+	}
+
+	/* If no extension is found, ppszExt must point to the string's terminating null */
+	*ppszExt = p;
+
 	/* search backwards for '.' */
 
 	while (p > pszPath)
@@ -508,21 +520,21 @@ HRESULT PathCchFindExtensionA(PCSTR pszPath, size_t cchPath, PCSTR* ppszExt)
 		if (*p == '.')
 		{
 			*ppszExt = (PCSTR) p;
-			return S_OK;
+			break;
 		}
 
 		if ((*p == '\\') || (*p == '/') || (*p == ':'))
-			return S_FALSE;
+			break;
 
 		p--;
 	}
 
-	return S_FALSE;
+	return S_OK;
 }
 
 HRESULT PathCchFindExtensionW(PCWSTR pszPath, size_t cchPath, PCWSTR* ppszExt)
 {
-	return 0;
+	return E_NOTIMPL;
 }
 
 /**

--- a/winpr/libwinpr/path/test/TestPathAllocCanonicalize.c
+++ b/winpr/libwinpr/path/test/TestPathAllocCanonicalize.c
@@ -7,6 +7,7 @@
 
 int TestPathAllocCanonicalize(int argc, char* argv[])
 {
+	printf("Warning: %s is not implemented!\n", __FUNCTION__);
 	return 0;
 }
 

--- a/winpr/libwinpr/path/test/TestPathCchAppendEx.c
+++ b/winpr/libwinpr/path/test/TestPathCchAppendEx.c
@@ -7,6 +7,7 @@
 
 int TestPathCchAppendEx(int argc, char* argv[])
 {
+	printf("Warning: %s is not implemented!\n", __FUNCTION__);
 	return 0;
 }
 

--- a/winpr/libwinpr/path/test/TestPathCchCanonicalize.c
+++ b/winpr/libwinpr/path/test/TestPathCchCanonicalize.c
@@ -7,6 +7,7 @@
 
 int TestPathCchCanonicalize(int argc, char* argv[])
 {
+	printf("Warning: %s is not implemented!\n", __FUNCTION__);
 	return 0;
 }
 

--- a/winpr/libwinpr/path/test/TestPathCchCanonicalizeEx.c
+++ b/winpr/libwinpr/path/test/TestPathCchCanonicalizeEx.c
@@ -7,6 +7,7 @@
 
 int TestPathCchCanonicalizeEx(int argc, char* argv[])
 {
+	printf("Warning: %s is not implemented!\n", __FUNCTION__);
 	return 0;
 }
 

--- a/winpr/libwinpr/path/test/TestPathCchCombine.c
+++ b/winpr/libwinpr/path/test/TestPathCchCombine.c
@@ -7,6 +7,7 @@
 
 int TestPathCchCombine(int argc, char* argv[])
 {
+	printf("Warning: %s is not implemented!\n", __FUNCTION__);
 	return 0;
 }
 

--- a/winpr/libwinpr/path/test/TestPathCchCombineEx.c
+++ b/winpr/libwinpr/path/test/TestPathCchCombineEx.c
@@ -7,6 +7,7 @@
 
 int TestPathCchCombineEx(int argc, char* argv[])
 {
+	printf("Warning: %s is not implemented!\n", __FUNCTION__);
 	return 0;
 }
 

--- a/winpr/libwinpr/path/test/TestPathCchFindExtension.c
+++ b/winpr/libwinpr/path/test/TestPathCchFindExtension.c
@@ -10,10 +10,92 @@ static const char testPathExtension[] = "C:\\Windows\\System32\\cmd.exe";
 int TestPathCchFindExtension(int argc, char* argv[])
 {
 	PCSTR pszExt;
+	PCSTR pszTmp;
+	HRESULT hr;
 
+	/* Test invalid args */
+
+	hr = PathCchFindExtensionA(NULL, sizeof(testPathExtension), &pszExt);
+	if (SUCCEEDED(hr))
+	{
+		printf("PathCchFindExtensionA unexpectedly succeeded with pszPath = NULL. result: 0x%08X\n", (ULONG)hr);
+		return -1;
+	}
+
+	hr = PathCchFindExtensionA(testPathExtension, 0, &pszExt);
+	if (SUCCEEDED(hr))
+	{
+		printf("PathCchFindExtensionA unexpectedly succeeded with cchPath = 0. result: 0x%08X\n", (ULONG)hr);
+		return -1;
+	}
+
+	hr = PathCchFindExtensionA(testPathExtension, sizeof(testPathExtension), NULL);
+	if (SUCCEEDED(hr))
+	{
+		printf("PathCchFindExtensionA unexpectedly succeeded with ppszExt = NULL. result: 0x%08X\n", (ULONG)hr);
+		return -1;
+	}
+
+
+	/* Test missing null-termination of pszPath */
+
+	hr = PathCchFindExtensionA(_T("c:\\456.789"), 9, &pszExt);
+	if (SUCCEEDED(hr))
+	{
+		printf("PathCchFindExtensionA unexpectedly succeeded with unterminated pszPath. result: 0x%08X\n", (ULONG)hr);
+		return -1;
+	}
+
+
+	/* Test passing of an empty terminated string (must succeed) */
+
+	pszExt = NULL;
+	pszTmp = _T("");
+	hr = PathCchFindExtensionA(pszTmp, 1, &pszExt);
+	if (hr != S_OK)
+	{
+		printf("PathCchFindExtensionA failed with an empty terminated string. result: 0x%08X\n", (ULONG)hr);
+		return -1;
+	}
+	/* pszExt must point to the strings terminating 0 now */
+	if (pszExt != pszTmp)
+	{
+		printf("PathCchFindExtensionA failed with an empty terminated string:  pszExt pointer mismatch\n");
+		return -1;
+	}
+
+
+	/* Test a path without file extension (must succeed) */
+
+	pszExt = NULL;
+	pszTmp = _T("c:\\4.678\\");
+	hr = PathCchFindExtensionA(pszTmp, 10, &pszExt);
+	if (hr != S_OK)
+	{
+		printf("PathCchFindExtensionA failed with a directory path. result: 0x%08X\n", (ULONG)hr);
+		return -1;
+	}
+	/* The extension must not have been found and pszExt must point to the
+	 * strings terminating NULL now */
+	if (pszExt != &pszTmp[9])
+	{
+		printf("PathCchFindExtensionA failed with a directory path: pszExt pointer mismatch\n");
+		return -1;
+	}
+
+
+	/* Non-special tests */
+
+	pszExt = NULL;
 	if (PathCchFindExtensionA(testPathExtension, sizeof(testPathExtension), &pszExt) != S_OK)
 	{
 		printf("PathCchFindExtensionA failure: expected S_OK\n");
+		return -1;
+	}
+
+	if (!pszExt || _tcscmp(pszExt, _T(".exe")))
+	{
+		printf("PathCchFindExtensionA failure: unexpected extension\n");
 		return -1;
 	}
 

--- a/winpr/libwinpr/path/test/TestPathCchIsRoot.c
+++ b/winpr/libwinpr/path/test/TestPathCchIsRoot.c
@@ -7,6 +7,7 @@
 
 int TestPathCchIsRoot(int argc, char* argv[])
 {
+	printf("Warning: %s is not implemented!\n", __FUNCTION__);
 	return 0;
 }
 

--- a/winpr/libwinpr/path/test/TestPathCchRemoveBackslash.c
+++ b/winpr/libwinpr/path/test/TestPathCchRemoveBackslash.c
@@ -7,6 +7,7 @@
 
 int TestPathCchRemoveBackslash(int argc, char* argv[])
 {
+	printf("Warning: %s is not implemented!\n", __FUNCTION__);
 	return 0;
 }
 

--- a/winpr/libwinpr/path/test/TestPathCchRemoveBackslashEx.c
+++ b/winpr/libwinpr/path/test/TestPathCchRemoveBackslashEx.c
@@ -7,6 +7,7 @@
 
 int TestPathCchRemoveBackslashEx(int argc, char* argv[])
 {
+	printf("Warning: %s is not implemented!\n", __FUNCTION__);
 	return 0;
 }
 

--- a/winpr/libwinpr/path/test/TestPathCchRemoveExtension.c
+++ b/winpr/libwinpr/path/test/TestPathCchRemoveExtension.c
@@ -7,6 +7,7 @@
 
 int TestPathCchRemoveExtension(int argc, char* argv[])
 {
+	printf("Warning: %s is not implemented!\n", __FUNCTION__);
 	return 0;
 }
 

--- a/winpr/libwinpr/path/test/TestPathCchRemoveFileSpec.c
+++ b/winpr/libwinpr/path/test/TestPathCchRemoveFileSpec.c
@@ -7,6 +7,7 @@
 
 int TestPathCchRemoveFileSpec(int argc, char* argv[])
 {
+	printf("Warning: %s is not implemented!\n", __FUNCTION__);
 	return 0;
 }
 

--- a/winpr/libwinpr/path/test/TestPathCchRenameExtension.c
+++ b/winpr/libwinpr/path/test/TestPathCchRenameExtension.c
@@ -7,6 +7,7 @@
 
 int TestPathCchRenameExtension(int argc, char* argv[])
 {
+	printf("Warning: %s is not implemented!\n", __FUNCTION__);
 	return 0;
 }
 

--- a/winpr/libwinpr/path/test/TestPathCchSkipRoot.c
+++ b/winpr/libwinpr/path/test/TestPathCchSkipRoot.c
@@ -7,6 +7,7 @@
 
 int TestPathCchSkipRoot(int argc, char* argv[])
 {
+	printf("Warning: %s is not implemented!\n", __FUNCTION__);
 	return 0;
 }
 

--- a/winpr/libwinpr/path/test/TestPathCchStripToRoot.c
+++ b/winpr/libwinpr/path/test/TestPathCchStripToRoot.c
@@ -7,6 +7,7 @@
 
 int TestPathCchStripToRoot(int argc, char* argv[])
 {
+	printf("Warning: %s is not implemented!\n", __FUNCTION__);
 	return 0;
 }
 


### PR DESCRIPTION
- Fixed remaining misuses of S_FALSE which is a HRESULT success code and is not used to indicate an error.
- changed the unimplemented PathCch* functions to return E_NOTIMPL instead of the HRESULT S_OK and print an error message.
- the unimplemented PathCch ctests now also print a warning message.

Also several fixes for PathCchFindExtension:
- fixed multiple implementation errors
- return S_OK if the extension was NOT found
- if no extension was found, ppszExt must point to the string's terminating null
- return E_INVALIDARG if pszPath is not null-terminated within the cchPath range
- return E_INVALIDARG if pszPath is NULL
- return E_INVALIDARG if ppszExt is NULL
- return E_INVALIDARG if cchPath is Zero
- return E_NOTIMPL instead of S_OK in PathPathCchFindExtensionW()
- extended/fixed the TestPathCchFindExtension ctest

Denounce PathAllocCombine - This PR does not fix this function but:
- print a warning message that the function is buggy and added a code comment describing the issues
- fix misuse of the S_FALSE HRESULT in error conditions
- prevent some segfaults
- check result of HeapAlloc

(Fortunately PathAllocCombine is unused in FreeRDP)

