### PR TITLE
Store SSL fingerprints with host and port

### DIFF
--- a/include/freerdp/crypto/certificate.h
+++ b/include/freerdp/crypto/certificate.h
@@ -44,6 +44,7 @@ struct rdp_certificate_store
 	FILE* fp;
 	char* path;
 	char* file;
+	char* legacy_file;
 	rdpSettings* settings;
 	rdpCertificateData* certificate_data;
 };

--- a/include/freerdp/crypto/certificate.h
+++ b/include/freerdp/crypto/certificate.h
@@ -59,6 +59,8 @@ FREERDP_API BOOL certificate_data_replace(rdpCertificateStore* certificate_store
 FREERDP_API void certificate_store_free(rdpCertificateStore* certificate_store);
 FREERDP_API int certificate_data_match(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data);
 FREERDP_API BOOL certificate_data_print(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data);
+FREERDP_API BOOL certificate_get_fingerprint(rdpCertificateStore* certificate_store,
+        rdpCertificateData* certificate_data, char** fingerprint);
 
 #ifdef __cplusplus
  }

--- a/include/freerdp/crypto/certificate.h
+++ b/include/freerdp/crypto/certificate.h
@@ -35,6 +35,7 @@ typedef struct rdp_certificate_store rdpCertificateStore;
 struct rdp_certificate_data
 {
 	char* hostname;
+	UINT16 port;
 	char* fingerprint;
 };
 
@@ -51,13 +52,13 @@ struct rdp_certificate_store
  extern "C" {
 #endif
 
-FREERDP_API rdpCertificateData* certificate_data_new(char* hostname, char* fingerprint);
+FREERDP_API rdpCertificateData* certificate_data_new(char* hostname, UINT16 port, char* fingerprint);
 FREERDP_API void certificate_data_free(rdpCertificateData* certificate_data);
 FREERDP_API rdpCertificateStore* certificate_store_new(rdpSettings* settings);
-FREERDP_API void certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data);
+FREERDP_API BOOL certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data);
 FREERDP_API void certificate_store_free(rdpCertificateStore* certificate_store);
 FREERDP_API int certificate_data_match(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data);
-FREERDP_API void certificate_data_print(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data);
+FREERDP_API BOOL certificate_data_print(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data);
 
 #ifdef __cplusplus
  }

--- a/include/freerdp/crypto/certificate.h
+++ b/include/freerdp/crypto/certificate.h
@@ -41,7 +41,6 @@ struct rdp_certificate_data
 
 struct rdp_certificate_store
 {
-	FILE* fp;
 	char* path;
 	char* file;
 	char* legacy_file;

--- a/include/freerdp/crypto/certificate.h
+++ b/include/freerdp/crypto/certificate.h
@@ -36,6 +36,8 @@ struct rdp_certificate_data
 {
 	char* hostname;
 	UINT16 port;
+	char* subject;
+	char* issuer;
 	char* fingerprint;
 };
 
@@ -52,15 +54,29 @@ struct rdp_certificate_store
  extern "C" {
 #endif
 
-FREERDP_API rdpCertificateData* certificate_data_new(char* hostname, UINT16 port, char* fingerprint);
-FREERDP_API void certificate_data_free(rdpCertificateData* certificate_data);
-FREERDP_API rdpCertificateStore* certificate_store_new(rdpSettings* settings);
-FREERDP_API BOOL certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data);
-FREERDP_API void certificate_store_free(rdpCertificateStore* certificate_store);
-FREERDP_API int certificate_data_match(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data);
-FREERDP_API BOOL certificate_data_print(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data);
-FREERDP_API BOOL certificate_get_fingerprint(rdpCertificateStore* certificate_store,
-        rdpCertificateData* certificate_data, char** fingerprint);
+FREERDP_API rdpCertificateData* certificate_data_new(
+        char* hostname, UINT16 port, char*subject,
+        char*issuer, char* fingerprint);
+FREERDP_API void certificate_data_free(
+        rdpCertificateData* certificate_data);
+FREERDP_API rdpCertificateStore* certificate_store_new(
+        rdpSettings* settings);
+FREERDP_API BOOL certificate_data_replace(
+        rdpCertificateStore* certificate_store,
+        rdpCertificateData* certificate_data);
+FREERDP_API void certificate_store_free(
+        rdpCertificateStore* certificate_store);
+FREERDP_API int certificate_data_match(
+        rdpCertificateStore* certificate_store,
+        rdpCertificateData* certificate_data);
+FREERDP_API BOOL certificate_data_print(
+        rdpCertificateStore* certificate_store,
+        rdpCertificateData* certificate_data);
+FREERDP_API BOOL certificate_get_stored_data(
+        rdpCertificateStore* certificate_store,
+        rdpCertificateData* certificate_data,
+        char** subject, char** issuer,
+        char** fingerprint);
 
 #ifdef __cplusplus
  }

--- a/include/freerdp/crypto/crypto.h
+++ b/include/freerdp/crypto/crypto.h
@@ -133,7 +133,7 @@ FREERDP_API void crypto_cert_print_info(X509* xcert);
 FREERDP_API void crypto_cert_free(CryptoCert cert);
 
 FREERDP_API BOOL x509_verify_certificate(CryptoCert cert, char* certificate_store_path);
-FREERDP_API rdpCertificateData* crypto_get_certificate_data(X509* xcert, char* hostname);
+FREERDP_API rdpCertificateData* crypto_get_certificate_data(X509* xcert, char* hostname, UINT16 port);
 FREERDP_API BOOL crypto_cert_get_public_key(CryptoCert cert, BYTE** PublicKey, DWORD* PublicKeyLength);
 
 #define	TSSK_KEY_LENGTH	64

--- a/include/freerdp/crypto/tls.h
+++ b/include/freerdp/crypto/tls.h
@@ -98,8 +98,11 @@ FREERDP_API int tls_set_alert_code(rdpTls* tls, int level, int description);
 
 FREERDP_API BOOL tls_match_hostname(char *pattern, int pattern_length, char *hostname);
 FREERDP_API int tls_verify_certificate(rdpTls* tls, CryptoCert cert, char* hostname, int port);
-FREERDP_API void tls_print_certificate_error(char* hostname, char* fingerprint, char* hosts_file);
-FREERDP_API void tls_print_certificate_name_mismatch_error(char* hostname, char* common_name, char** alt_names, int alt_names_count);
+FREERDP_API void tls_print_certificate_error(char* hostname, UINT16 port,
+                                             char* fingerprint, char* hosts_file);
+FREERDP_API void tls_print_certificate_name_mismatch_error(
+        char* hostname, UINT16 port, char* common_name, char** alt_names,
+        int alt_names_count);
 
 FREERDP_API BOOL tls_print_error(char* func, SSL* connection, int value);
 

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -67,7 +67,10 @@ typedef BOOL (*pPostConnect)(freerdp* instance);
 typedef void (*pPostDisconnect)(freerdp* instance);
 typedef BOOL (*pAuthenticate)(freerdp* instance, char** username, char** password, char** domain);
 typedef BOOL (*pVerifyCertificate)(freerdp* instance, char* subject, char* issuer, char* fingerprint);
-typedef BOOL (*pVerifyChangedCertificate)(freerdp* instance, char* subject, char* issuer, char* new_fingerprint, char* old_fingerprint);
+typedef BOOL (*pVerifyChangedCertificate)(freerdp* instance, char* subject,
+                                          char* issuer, char* new_fingerprint,
+                                          char* old_subject, char* old_issuer,
+                                          char* old_fingerprint);
 typedef int (*pVerifyX509Certificate)(freerdp* instance, BYTE* data, int length, const char* hostname, int port, DWORD flags);
 
 typedef int (*pLogonErrorInfo)(freerdp* instance, UINT32 data, UINT32 type);
@@ -207,7 +210,7 @@ struct rdp_freerdp
 											   Callback for certificate validation.
 											   Used to verify that an unknown certificate is trusted. */
 	ALIGN64 pVerifyChangedCertificate VerifyChangedCertificate; /**< (offset 52)
-															 Callback for changed certificate validation. 
+															 Callback for changed certificate validation.
 															 Used when a certificate differs from stored fingerprint.
 															 If returns TRUE, the new fingerprint will be trusted and old thrown out. */
 

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -28,6 +28,8 @@
 #include <unistd.h>
 #endif
 
+#include <ctype.h>
+
 #include <winpr/crt.h>
 #include <winpr/file.h>
 #include <winpr/path.h>

--- a/libfreerdp/crypto/certificate.c
+++ b/libfreerdp/crypto/certificate.c
@@ -36,7 +36,7 @@
 
 static const char certificate_store_dir[] = "certs";
 static const char certificate_server_dir[] = "server";
-static const char certificate_known_hosts_file[] = "known_hosts.v2";
+static const char certificate_known_hosts_file[] = "known_hosts2";
 static const char certificate_legacy_hosts_file[] = "known_hosts";
 
 #include <freerdp/log.h>

--- a/libfreerdp/crypto/certificate.c
+++ b/libfreerdp/crypto/certificate.c
@@ -208,7 +208,7 @@ int certificate_data_match(rdpCertificateStore* certificate_store, rdpCertificat
 	char* fingerprint = NULL;
 	unsigned short port = 0;
 
-	fp = fopen(certificate_store->path, "r");
+	fp = fopen(certificate_store->file, "r");
 
 	if (!fp)
 		return match;
@@ -282,7 +282,7 @@ BOOL certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertifi
 	char* pline;
 	long int size;
 
-	fp = fopen(certificate_store->path, "w+");
+	fp = fopen(certificate_store->file, "w+");
 
 	if (!fp)
 		return FALSE;

--- a/libfreerdp/crypto/certificate.c
+++ b/libfreerdp/crypto/certificate.c
@@ -195,7 +195,7 @@ static int certificate_data_match_legacy(rdpCertificateStore* certificate_store,
 }
 
 static int certificate_data_match_raw(rdpCertificateStore* certificate_store,
-        rdpCertificateData* certificate_data, char** fprint)
+	rdpCertificateData* certificate_data, char** fprint)
 {
 	BOOL found = FALSE;
 	FILE* fp;
@@ -257,9 +257,9 @@ static int certificate_data_match_raw(rdpCertificateStore* certificate_store,
 				if (port == certificate_data->port)
 				{
 					found = TRUE;
-					match = strcmp(fingerprint, certificate_data->fingerprint);
-                    if ((match == 0) && fprint)
-                        *fprint = _strdup(fingerprint);
+					match = strcmp(certificate_data->fingerprint, fingerprint);
+					if (fingerprint && fprint)
+						*fprint = _strdup(fingerprint);
 					break;
 				}
 			}
@@ -276,18 +276,18 @@ static int certificate_data_match_raw(rdpCertificateStore* certificate_store,
 }
 
 BOOL certificate_get_fingerprint(rdpCertificateStore* certificate_store,
-        rdpCertificateData* certificate_data, char** fingerprint)
+	rdpCertificateData* certificate_data, char** fingerprint)
 {
-    int rc = certificate_data_match_raw(certificate_store, certificate_data, fingerprint);
-    
-    if (rc == 0)
-        return TRUE;
-    return FALSE;
+	int rc = certificate_data_match_raw(certificate_store, certificate_data, fingerprint);
+
+	if ((rc == 0) || (rc == -1))
+		return TRUE;
+	return FALSE;
 }
 
 int certificate_data_match(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data)
 {
-    return certificate_data_match_raw(certificate_store, certificate_data, NULL);
+	return certificate_data_match_raw(certificate_store, certificate_data, NULL);
 }
 
 BOOL certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data)
@@ -332,7 +332,7 @@ BOOL certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertifi
 
 	fclose(fp);
 
-	fp = fopen(certificate_store->file, "wb+");
+	fp = fopen(certificate_store->file, "wb");
 
 	if (!fp)
 	{
@@ -356,11 +356,13 @@ BOOL certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertifi
 			char* hostname = NULL, *fingerprint;
 
 			if (!certificate_split_line(pline, &hostname, &port, &fingerprint))
-				WLog_WARN(TAG, "Skipping invalid %s entry %s!", certificate_known_hosts_file, pline);
+				WLog_WARN(TAG, "Skipping invalid %s entry %s!",
+					  certificate_known_hosts_file, pline);
 			else
 			{
 				/* If this is the replaced hostname, use the updated fingerprint. */
-				if ((strcmp(hostname, certificate_data->hostname) == 0) && (port == certificate_data->port))
+				if ((strcmp(hostname, certificate_data->hostname) == 0) &&
+						(port == certificate_data->port))
 				{
 					fingerprint = certificate_data->fingerprint;
 					rc = TRUE;

--- a/libfreerdp/crypto/certificate.c
+++ b/libfreerdp/crypto/certificate.c
@@ -194,7 +194,8 @@ static int certificate_data_match_legacy(rdpCertificateStore* certificate_store,
 
 }
 
-int certificate_data_match(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data)
+static int certificate_data_match_raw(rdpCertificateStore* certificate_store,
+        rdpCertificateData* certificate_data, char** fprint)
 {
 	BOOL found = FALSE;
 	FILE* fp;
@@ -257,6 +258,8 @@ int certificate_data_match(rdpCertificateStore* certificate_store, rdpCertificat
 				{
 					found = TRUE;
 					match = strcmp(fingerprint, certificate_data->fingerprint);
+                    if ((match == 0) && fprint)
+                        *fprint = _strdup(fingerprint);
 					break;
 				}
 			}
@@ -270,6 +273,21 @@ int certificate_data_match(rdpCertificateStore* certificate_store, rdpCertificat
 		match = certificate_data_match_legacy(certificate_store, certificate_data);
 
 	return match;
+}
+
+BOOL certificate_get_fingerprint(rdpCertificateStore* certificate_store,
+        rdpCertificateData* certificate_data, char** fingerprint)
+{
+    int rc = certificate_data_match_raw(certificate_store, certificate_data, fingerprint);
+    
+    if (rc == 0)
+        return TRUE;
+    return FALSE;
+}
+
+int certificate_data_match(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data)
+{
+    return certificate_data_match_raw(certificate_store, certificate_data, NULL);
 }
 
 BOOL certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data)

--- a/libfreerdp/crypto/certificate.c
+++ b/libfreerdp/crypto/certificate.c
@@ -122,7 +122,7 @@ static int certificate_data_match_legacy(rdpCertificateStore* certificate_store,
 	long size;
 	size_t length;
 
-	fp = fopen(certificate_store->legacy_file, "r");
+	fp = fopen(certificate_store->legacy_file, "rb");
 	if (!fp)
 		return match;
 
@@ -208,7 +208,7 @@ int certificate_data_match(rdpCertificateStore* certificate_store, rdpCertificat
 	char* fingerprint = NULL;
 	unsigned short port = 0;
 
-	fp = fopen(certificate_store->file, "r");
+	fp = fopen(certificate_store->file, "rb");
 
 	if (!fp)
 		return match;
@@ -282,7 +282,7 @@ BOOL certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertifi
 	char* pline;
 	long int size;
 
-	fp = fopen(certificate_store->file, "w+");
+	fp = fopen(certificate_store->file, "wb+");
 
 	if (!fp)
 		return FALSE;
@@ -384,7 +384,7 @@ BOOL certificate_data_print(rdpCertificateStore* certificate_store, rdpCertifica
 	FILE* fp;
 
 	/* reopen in append mode */
-	fp = fopen(certificate_store->file, "a");
+	fp = fopen(certificate_store->file, "ab");
 
 	if (!fp)
 		return FALSE;

--- a/libfreerdp/crypto/certificate.c
+++ b/libfreerdp/crypto/certificate.c
@@ -93,7 +93,7 @@ BOOL certificate_store_init(rdpCertificateStore* certificate_store)
 		goto fail;
 
 	if (!(certificate_store->legacy_file = GetCombinedPath(settings->ConfigPath,
-								(char*) certificate_known_hosts_file)))
+								(char*) certificate_legacy_hosts_file)))
 		goto fail;
 
 	if (!PathFileExistsA(certificate_store->file))
@@ -278,6 +278,7 @@ int certificate_data_match(rdpCertificateStore* certificate_store, rdpCertificat
 BOOL certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data)
 {
 	FILE* fp;
+	BOOL rc = FALSE;
 	int length;
 	char* data;
 	char* sdata;
@@ -335,9 +336,10 @@ BOOL certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertifi
 			{
 				/* If this is the replaced hostname, use the updated fingerprint. */
 				if ((strcmp(hostname, certificate_data->hostname) == 0) && (port == certificate_data->port))
+				{
 					fingerprint = certificate_data->fingerprint;
-				else
-					fingerprint = &hostname[length + 1];
+					rc = TRUE;
+				}
 				fprintf(fp, "%s %hu %s\n", hostname, port, fingerprint);
 			}
 		}
@@ -348,7 +350,7 @@ BOOL certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertifi
 	fclose(fp);
 	free(data);
 
-	return TRUE;
+	return rc;
 }
 
 BOOL certificate_split_line(char* line, char** host, UINT16* port, char** fingerprint)

--- a/libfreerdp/crypto/certificate.c
+++ b/libfreerdp/crypto/certificate.c
@@ -300,7 +300,7 @@ BOOL certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertifi
 	char* pline;
 	long int size;
 
-	fp = fopen(certificate_store->file, "wb+");
+	fp = fopen(certificate_store->file, "rb");
 
 	if (!fp)
 		return FALSE;
@@ -326,6 +326,16 @@ BOOL certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertifi
 	if (fread(data, size, 1, fp) != 1)
 	{
 		fclose(fp);
+		free(data);
+		return FALSE;
+	}
+
+	fclose(fp);
+
+	fp = fopen(certificate_store->file, "wb+");
+
+	if (!fp)
+	{
 		free(data);
 		return FALSE;
 	}

--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -555,7 +555,7 @@ end:
 	return status;
 }
 
-rdpCertificateData* crypto_get_certificate_data(X509* xcert, char* hostname)
+rdpCertificateData* crypto_get_certificate_data(X509* xcert, char* hostname, UINT16 port)
 {
 	char* fp;
 	rdpCertificateData* certdata;
@@ -564,7 +564,7 @@ rdpCertificateData* crypto_get_certificate_data(X509* xcert, char* hostname)
 	if (!fp)
 		return NULL;
 
-	certdata = certificate_data_new(hostname, fp);
+	certdata = certificate_data_new(hostname, port, fp);
 	free(fp);
 
 	return certdata;

--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -288,7 +288,7 @@ static int crypto_rsa_common(const BYTE* input, int length, UINT32 key_length, c
 	BN_free(&mod);
 	BN_CTX_free(ctx);
 
-out_free_input_reverse: 
+out_free_input_reverse:
 	free(input_reverse);
 
 	return output_length;
@@ -376,7 +376,7 @@ char* crypto_print_name(X509_NAME* name)
 {
 	char* buffer = NULL;
 	BIO* outBIO = BIO_new(BIO_s_mem());
-	
+
 	if (X509_NAME_print_ex(outBIO, name, 0, XN_FLAG_ONELINE) > 0)
 	{
 		unsigned long size = BIO_number_written(outBIO);
@@ -433,7 +433,7 @@ char* crypto_cert_subject_common_name(X509* xcert, int* length)
 }
 
 FREERDP_API void crypto_cert_subject_alt_name_free(int count, int *lengths,
-		char** alt_name)
+						   char** alt_name)
 {
 	int i;
 
@@ -557,6 +557,8 @@ end:
 
 rdpCertificateData* crypto_get_certificate_data(X509* xcert, char* hostname, UINT16 port)
 {
+	char* issuer;
+	char* subject;
 	char* fp;
 	rdpCertificateData* certdata;
 
@@ -564,7 +566,13 @@ rdpCertificateData* crypto_get_certificate_data(X509* xcert, char* hostname, UIN
 	if (!fp)
 		return NULL;
 
-	certdata = certificate_data_new(hostname, port, fp);
+	issuer = crypto_cert_issuer(xcert);
+	subject = crypto_cert_subject(xcert);
+
+	certdata = certificate_data_new(hostname, port, issuer, subject, fp);
+
+	free(subject);
+	free(issuer);
 	free(fp);
 
 	return certdata;
@@ -590,8 +598,8 @@ void crypto_cert_print_info(X509* xcert)
 	WLog_INFO(TAG,  "\tIssuer: %s", issuer);
 	WLog_INFO(TAG,  "\tThumbprint: %s", fp);
 	WLog_INFO(TAG,  "The above X.509 certificate could not be verified, possibly because you do not have "
-			  "the CA certificate in your certificate store, or the certificate has expired. "
-			  "Please look at the documentation on how to create local certificate store for a private CA.");
+			"the CA certificate in your certificate store, or the certificate has expired. "
+			"Please look at the documentation on how to create local certificate store for a private CA.");
 	free(fp);
 out_free_issuer:
 	free(issuer);

--- a/libfreerdp/crypto/test/CMakeLists.txt
+++ b/libfreerdp/crypto/test/CMakeLists.txt
@@ -5,6 +5,7 @@ set(MODULE_PREFIX "TEST_FREERDP_CRYPTO")
 set(${MODULE_PREFIX}_DRIVER ${MODULE_NAME}.c)
 
 set(${MODULE_PREFIX}_TESTS
+	TestKnownHosts.c
 	TestBase64.c)
 
 create_test_sourcelist(${MODULE_PREFIX}_SRCS

--- a/libfreerdp/crypto/test/TestKnownHosts.c
+++ b/libfreerdp/crypto/test/TestKnownHosts.c
@@ -83,6 +83,7 @@ int TestKnownHosts(int argc, char* argv[])
 	char* currentFileV2 = NULL;
 	char* legacyFileV2 = NULL;
 	char* legacyFile = NULL;
+	char* fp = NULL;
 
 	current.ConfigPath = GetKnownSubPath(KNOWN_PATH_TEMP, "TestKnownHostsCurrent");
 	legacy.ConfigPath = GetKnownSubPath(KNOWN_PATH_TEMP, "TestKnownHostsLegacy");
@@ -150,6 +151,15 @@ int TestKnownHosts(int argc, char* argv[])
 		goto finish;
 	}
 
+	/* Test if we can read out the old fingerprint. */
+	if (!certificate_get_fingerprint(store, data, &fp))
+	{
+		fprintf(stderr, "Could not read old fingerprint!\n");
+		goto finish;
+	}
+	printf("Got '%s'\n", fp);
+	free(fp);
+	fp = NULL;
 	certificate_data_free(data);
 
 	/* Test if host not found in current file. */
@@ -163,6 +173,13 @@ int TestKnownHosts(int argc, char* argv[])
 	if (0 == certificate_data_match(store, data))
 	{
 		fprintf(stderr, "Invalid host found in v2 file!\n");
+		goto finish;
+	}
+
+	/* Test if we read out the old fingerprint fails. */
+	if (certificate_get_fingerprint(store, data, &fp))
+	{
+		fprintf(stderr, "Read out not existing old fingerprint succeeded?!\n");
 		goto finish;
 	}
 
@@ -291,6 +308,7 @@ finish:
 	free (currentFileV2);
 	free (legacyFileV2);
 	free (legacyFile);
+	free(fp);
 
 	return rc;
 }

--- a/libfreerdp/crypto/test/TestKnownHosts.c
+++ b/libfreerdp/crypto/test/TestKnownHosts.c
@@ -108,14 +108,14 @@ int TestKnownHosts(int argc, char* argv[])
 		}
 	}
 
-	currentFileV2 = GetCombinedPath(current.ConfigPath, "known_hosts.v2");
+	currentFileV2 = GetCombinedPath(current.ConfigPath, "known_hosts2");
 	if (!currentFileV2)
 	{
 		fprintf(stderr, "Could not get file path!\n");
 		goto finish;
 	}
 
-	legacyFileV2 = GetCombinedPath(legacy.ConfigPath, "known_hosts.v2");
+	legacyFileV2 = GetCombinedPath(legacy.ConfigPath, "known_hosts2");
 	if (!legacyFileV2)
 	{
 		fprintf(stderr, "Could not get file path!\n");

--- a/libfreerdp/crypto/test/TestKnownHosts.c
+++ b/libfreerdp/crypto/test/TestKnownHosts.c
@@ -1,0 +1,285 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ *
+ * Copyright 2015 Thincast Technologies GmbH
+ * Copyright 2015 Armin Novak <armin.novak@thincast.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <winpr/path.h>
+#include <winpr/file.h>
+#include <freerdp/crypto/certificate.h>
+
+static int prepare(const char* currentFileV2, const char* legacyFileV2, const char* legacyFile)
+{
+	char buffer[1024];
+	HANDLE fp = NULL;
+	HANDLE fl = NULL;
+	HANDLE fc = NULL;
+	DWORD read = 0;
+	char* srcV2 = _strdup("known_hosts/known_hosts.v2");
+	char* src = _strdup("known_hosts/known_hosts");
+
+	if (!src || !srcV2)
+		goto finish;
+
+	PathCchConvertStyleA(srcV2, strlen(srcV2), PATH_STYLE_NATIVE);
+	PathCchConvertStyleA(src, strlen(src), PATH_STYLE_NATIVE);
+
+	fp = CreateFileA(srcV2, GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (!fp)
+		goto finish;
+
+	fl = CreateFileA(currentFileV2, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (!fc)
+		goto finish;
+
+	fl = CreateFileA(legacyFileV2, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (!fl)
+		goto finish;
+
+	while(ReadFile(fp, buffer, sizeof(buffer), &read, NULL))
+	{
+		WriteFile(fc, buffer, read, NULL, NULL);
+		WriteFile(fl, buffer, read, NULL, NULL);
+	}
+
+	CloseHandle(fp);
+	fp = NULL;
+
+	CloseHandle(fc);
+	fc = NULL;
+
+	CloseHandle(fl);
+	fl = NULL;
+
+	fp = CreateFileA(src, GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (!fp)
+		goto finish;
+
+	fl = CreateFileA(legacyFile, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (!fl)
+		goto finish;
+
+	while(ReadFile(fp, buffer, sizeof(buffer), &read, NULL))
+		WriteFile(fl, buffer, read, NULL, NULL);
+
+	CloseHandle(fp);
+	CloseHandle(fl);
+	free(src);
+	free(srcV2);
+	return 0;
+
+finish:
+	free(src);
+	free(srcV2);
+	CloseHandle(fp);
+	CloseHandle(fl);
+	CloseHandle(fc);
+
+	return -1;
+}
+
+int TestKnownHosts(int argc, char* argv[])
+{
+	int rc = -1;
+	rdpSettings current;
+	rdpSettings legacy;
+	rdpCertificateData* data = NULL;
+	rdpCertificateStore* store = NULL;
+	char* currentFileV2 = NULL;
+	char* legacyFileV2 = NULL;
+	char* legacyFile = NULL;
+
+	current.ConfigPath = GetKnownSubPath(KNOWN_PATH_TEMP, "TestKnownHostsCurrent");
+	legacy.ConfigPath = GetKnownSubPath(KNOWN_PATH_TEMP, "TestKnownHostsLegacy");
+
+	if (!CreateDirectoryA(current.ConfigPath, NULL))
+	{
+		fprintf(stderr, "Could not create %s!\n", current.ConfigPath);
+	//	goto finish;
+	}
+
+	if (!CreateDirectoryA(legacy.ConfigPath, NULL))
+	{
+		fprintf(stderr, "Could not create %s!\n", legacy.ConfigPath);
+	//	goto finish;
+	}
+
+	currentFileV2 = GetCombinedPath(current.ConfigPath, "known_hosts.v2");
+	if (!currentFileV2)
+	{
+		fprintf(stderr, "Could not get file path!\n");
+		goto finish;
+	}
+
+	legacyFileV2 = GetCombinedPath(legacy.ConfigPath, "known_hosts.v2");
+	if (!legacyFileV2)
+	{
+		fprintf(stderr, "Could not get file path!\n");
+		goto finish;
+	}
+
+	legacyFile = GetCombinedPath(legacy.ConfigPath, "known_hosts");
+	if (!legacyFile)
+	{
+		fprintf(stderr, "Could not get file path!\n");
+		goto finish;
+	}
+
+ 	store = certificate_store_new(&current);
+	if (!store)
+	{
+		fprintf(stderr, "Could not create certificate store!\n");
+		goto finish;
+	}
+
+	if (prepare(currentFileV2, legacyFileV2, legacyFile))
+		goto finish;
+
+	/* Test if host is found in current file. */
+	data = certificate_data_new("someurl", 3389, "ff:11:22:dd");
+	if (!data)
+	{
+		fprintf(stderr, "Could not create certificate data!\n");
+		goto finish;
+	}
+
+	if (0 != certificate_data_match(store, data))
+	{
+		fprintf(stderr, "Could not find data in v2 file!\n");
+		goto finish;
+	}
+
+	certificate_data_free(data);
+
+	/* Test if host not found in current file. */
+	data = certificate_data_new("somehost", 1234, "ff:aa:bb:cc");
+	if (!data)
+	{
+		fprintf(stderr, "Could not create certificate data!\n");
+		goto finish;
+	}
+
+	if (0 == certificate_data_match(store, data))
+	{
+		fprintf(stderr, "Invalid host found in v2 file!\n");
+		goto finish;
+	}
+
+	certificate_data_free(data);
+
+	/* Test host add current file. */
+	data = certificate_data_new("somehost", 1234, "ff:aa:bb:cc");
+	if (!data)
+	{
+		fprintf(stderr, "Could not create certificate data!\n");
+		goto finish;
+	}
+
+	if (!certificate_data_print(store, data))
+	{
+		fprintf(stderr, "Could not add host to file!\n");
+		goto finish;
+	}
+
+	if (0 == certificate_data_match(store, data))
+	{
+		fprintf(stderr, "Invalid host found in v2 file!\n");
+		goto finish;
+	}
+
+	certificate_data_free(data);
+
+	/* Test host replace current file. */
+	data = certificate_data_new("somehost", 1234, "ff:aa:bb:dd:ee");
+	if (!data)
+	{
+		fprintf(stderr, "Could not create certificate data!\n");
+		goto finish;
+	}
+
+	if (!certificate_data_replace(store, data))
+	{
+		fprintf(stderr, "Could not replace data!\n");
+		goto finish;
+	}
+
+	if (0 == certificate_data_match(store, data))
+	{
+		fprintf(stderr, "Invalid host found in v2 file!\n");
+		goto finish;
+	}
+
+	certificate_data_free(data);
+
+	certificate_store_free(store);
+
+	store = certificate_store_new(&legacy);
+	if (!store)
+	{
+		fprintf(stderr, "could not create certificate store!\n");
+		goto finish;
+	}
+
+	/* test if host found in legacy file. */
+	data = certificate_data_new("someurl", 1234, "ff:11:22:dd");
+	if (!data)
+	{
+		fprintf(stderr, "Could not create certificate data!\n");
+		goto finish;
+	}
+
+	if (0 != certificate_data_match(store, data))
+	{
+		fprintf(stderr, "Could not find host in file!\n");
+		goto finish;
+	}
+
+	certificate_data_free(data);
+
+	/* test if host not found. */
+	data = certificate_data_new("somehost-not-in-file", 1234, "ff:aa:bb:cc");
+	if (!data)
+	{
+		fprintf(stderr, "Could not create certificate data!\n");
+		goto finish;
+	}
+
+	if (0 == certificate_data_match(store, data))
+	{
+		fprintf(stderr, "Invalid host found in file!\n");
+		goto finish;
+	}
+
+	rc = 0;
+
+finish:
+	if (store)
+		certificate_store_free(store);
+	if (data)
+		certificate_data_free(data);
+	DeleteFileA(currentFileV2);
+	//RemoveDirectoryA(current.ConfigPath);
+
+	DeleteFileA(legacyFileV2);
+	DeleteFileA(legacyFile);
+	//RemoveDirectoryA(legacy.ConfigPath);
+
+	free (currentFileV2);
+	free (legacyFileV2);
+	free (legacyFile);
+
+	return rc;
+}

--- a/libfreerdp/crypto/test/TestKnownHosts.c
+++ b/libfreerdp/crypto/test/TestKnownHosts.c
@@ -29,8 +29,8 @@ static int prepare(const char* currentFileV2, const char* legacyFileV2, const ch
 		"legacyurl aa:bb:cc:dd\n"
 	};
 	char* hosts[] = {
-		"someurl 3389 ff:11:22:dd\r\n",
-		"otherurl\t3389\taa:bb:cc:dd\r",
+		"someurl 3389 ff:11:22:dd subject issuer\r\n",
+		"otherurl\t3389\taa:bb:cc:dd\tsubject2\tissuer2\r",
 	};
 	FILE* fl = NULL;
 	FILE* fc = NULL;
@@ -140,7 +140,7 @@ int TestKnownHosts(int argc, char* argv[])
 		goto finish;
 
 	/* Test if host is found in current file. */
-	data = certificate_data_new("someurl", 3389, "ff:11:22:dd");
+	data = certificate_data_new("someurl", 3389, "subject", "issuer", "ff:11:22:dd");
 	if (!data)
 	{
 		fprintf(stderr, "Could not create certificate data!\n");
@@ -169,7 +169,7 @@ int TestKnownHosts(int argc, char* argv[])
 	certificate_data_free(data);
 
 	/* Test if host not found in current file. */
-	data = certificate_data_new("somehost", 1234, "ff:aa:bb:cc");
+	data = certificate_data_new("somehost", 1234, "", "", "ff:aa:bb:cc");
 	if (!data)
 	{
 		fprintf(stderr, "Could not create certificate data!\n");
@@ -192,7 +192,7 @@ int TestKnownHosts(int argc, char* argv[])
 	certificate_data_free(data);
 
 	/* Test host add current file. */
-	data = certificate_data_new("somehost", 1234, "ff:aa:bb:cc");
+	data = certificate_data_new("somehost", 1234, "", "", "ff:aa:bb:cc");
 	if (!data)
 	{
 		fprintf(stderr, "Could not create certificate data!\n");
@@ -214,7 +214,7 @@ int TestKnownHosts(int argc, char* argv[])
 	certificate_data_free(data);
 
 	/* Test host replace current file. */
-	data = certificate_data_new("somehost", 1234, "ff:aa:bb:dd:ee");
+	data = certificate_data_new("somehost", 1234, "", "", "ff:aa:bb:dd:ee");
 	if (!data)
 	{
 		fprintf(stderr, "Could not create certificate data!\n");
@@ -236,7 +236,7 @@ int TestKnownHosts(int argc, char* argv[])
 	certificate_data_free(data);
 
 	/* Test host replace invalid entry in current file. */
-	data = certificate_data_new("somehostXXXX", 1234, "ff:aa:bb:dd:ee");
+	data = certificate_data_new("somehostXXXX", 1234, "", "", "ff:aa:bb:dd:ee");
 	if (!data)
 	{
 		fprintf(stderr, "Could not create certificate data!\n");
@@ -268,7 +268,7 @@ int TestKnownHosts(int argc, char* argv[])
 	}
 
 	/* test if host found in legacy file. */
-	data = certificate_data_new("legacyurl", 1234, "aa:bb:cc:dd");
+	data = certificate_data_new("legacyurl", 1234, "", "", "aa:bb:cc:dd");
 	if (!data)
 	{
 		fprintf(stderr, "Could not create certificate data!\n");
@@ -284,7 +284,7 @@ int TestKnownHosts(int argc, char* argv[])
 	certificate_data_free(data);
 
 	/* test if host not found. */
-	data = certificate_data_new("somehost-not-in-file", 1234, "ff:aa:bb:cc");
+	data = certificate_data_new("somehost-not-in-file", 1234, "", "", "ff:aa:bb:cc");
 	if (!data)
 	{
 		fprintf(stderr, "Could not create certificate data!\n");

--- a/libfreerdp/crypto/test/TestKnownHosts.c
+++ b/libfreerdp/crypto/test/TestKnownHosts.c
@@ -83,6 +83,8 @@ int TestKnownHosts(int argc, char* argv[])
 	char* currentFileV2 = NULL;
 	char* legacyFileV2 = NULL;
 	char* legacyFile = NULL;
+	char* subject = NULL;
+	char* issuer = NULL;
 	char* fp = NULL;
 
 	current.ConfigPath = GetKnownSubPath(KNOWN_PATH_TEMP, "TestKnownHostsCurrent");
@@ -152,13 +154,17 @@ int TestKnownHosts(int argc, char* argv[])
 	}
 
 	/* Test if we can read out the old fingerprint. */
-	if (!certificate_get_fingerprint(store, data, &fp))
+	if (!certificate_get_stored_data(store, data, &subject, &issuer, &fp))
 	{
 		fprintf(stderr, "Could not read old fingerprint!\n");
 		goto finish;
 	}
-	printf("Got '%s'\n", fp);
+	printf("Got %s, %s '%s'\n", subject, issuer, fp);
+	free(subject);
+	free(issuer);
 	free(fp);
+	subject = NULL;
+	issuer = NULL;
 	fp = NULL;
 	certificate_data_free(data);
 
@@ -177,7 +183,7 @@ int TestKnownHosts(int argc, char* argv[])
 	}
 
 	/* Test if we read out the old fingerprint fails. */
-	if (certificate_get_fingerprint(store, data, &fp))
+	if (certificate_get_stored_data(store, data, &subject, &issuer, &fp))
 	{
 		fprintf(stderr, "Read out not existing old fingerprint succeeded?!\n");
 		goto finish;
@@ -308,6 +314,8 @@ finish:
 	free (currentFileV2);
 	free (legacyFileV2);
 	free (legacyFile);
+	free(subject);
+	free(issuer);
 	free(fp);
 
 	return rc;

--- a/libfreerdp/crypto/test/known_hosts/known_hosts
+++ b/libfreerdp/crypto/test/known_hosts/known_hosts
@@ -1,0 +1,2 @@
+someurl ff:11:22:dd
+otherurl aa:bb:cc:dd

--- a/libfreerdp/crypto/test/known_hosts/known_hosts.v2
+++ b/libfreerdp/crypto/test/known_hosts/known_hosts.v2
@@ -1,0 +1,2 @@
+someurl 3389 ff:11:22:dd
+otherurl 3389 aa:bb:cc:dd

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1082,7 +1082,7 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, char* hostname, int por
 	certificate_status = x509_verify_certificate(cert, tls->certificate_store->path);
 
 	/* verify certificate name match */
-	certificate_data = crypto_get_certificate_data(cert->px509, hostname);
+	certificate_data = crypto_get_certificate_data(cert->px509, hostname, port);
 
 	/* extra common name and alternative names */
 	common_name = crypto_cert_subject_common_name(cert->px509, &common_name_length);
@@ -1162,15 +1162,14 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, char* hostname, int por
 			else
 			{
 				/* user accepted certificate, add entry in known_hosts file */
-				certificate_data_print(tls->certificate_store, certificate_data);
-				verification_status = TRUE; /* success! */
+				verification_status = certificate_data_print(tls->certificate_store, certificate_data);
 			}
 		}
 		else if (match == -1)
 		{
 			/* entry was found in known_hosts file, but fingerprint does not match. ask user to use it */
 			tls_print_certificate_error(hostname, fingerprint, tls->certificate_store->file);
-			
+
 			if (instance->VerifyChangedCertificate)
 			{
 				accept_certificate = instance->VerifyChangedCertificate(instance, subject, issuer, fingerprint, "");
@@ -1184,8 +1183,7 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, char* hostname, int por
 			else
 			{
 				/* user accepted new certificate, add replace fingerprint for this host in known_hosts file */
-				certificate_data_replace(tls->certificate_store, certificate_data);
-				verification_status = TRUE; /* success! */
+				verification_status = certificate_data_replace(tls->certificate_store, certificate_data);
 			}
 		}
 		else if (match == 0)

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1172,14 +1172,22 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, char* hostname, int por
 		}
 		else if (match == -1)
 		{
+            char* old_fingerprint = NULL;
+
 			/* entry was found in known_hosts file, but fingerprint does not match. ask user to use it */
 			tls_print_certificate_error(hostname, port, fingerprint,
 						    tls->certificate_store->file);
 
+            if (!certificate_get_fingerprint(tls->certificate_store, certificate_data, &old_fingerprint))
+                WLog_WARN(TAG, "Failed to get certificate entry for %s:hu", hostname, port);
+
 			if (instance->VerifyChangedCertificate)
 			{
-				accept_certificate = instance->VerifyChangedCertificate(instance, subject, issuer, fingerprint, "");
+				accept_certificate = instance->VerifyChangedCertificate(instance, subject, issuer,
+                        fingerprint, old_fingerprint);
 			}
+
+            free(old_fingerprint);
 
 			if (!accept_certificate)
 			{

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1172,22 +1172,25 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, char* hostname, int por
 		}
 		else if (match == -1)
 		{
-            char* old_fingerprint = NULL;
+			char* old_fingerprint = NULL;
 
 			/* entry was found in known_hosts file, but fingerprint does not match. ask user to use it */
 			tls_print_certificate_error(hostname, port, fingerprint,
 						    tls->certificate_store->file);
 
-            if (!certificate_get_fingerprint(tls->certificate_store, certificate_data, &old_fingerprint))
-                WLog_WARN(TAG, "Failed to get certificate entry for %s:hu", hostname, port);
+			if (!certificate_get_fingerprint(tls->certificate_store,
+							 certificate_data, &old_fingerprint))
+				WLog_WARN(TAG, "Failed to get certificate entry for %s:hu",
+					  hostname, port);
 
 			if (instance->VerifyChangedCertificate)
 			{
-				accept_certificate = instance->VerifyChangedCertificate(instance, subject, issuer,
-                        fingerprint, old_fingerprint);
+				accept_certificate = instance->VerifyChangedCertificate(
+							     instance, subject, issuer,
+							     fingerprint, old_fingerprint);
 			}
 
-            free(old_fingerprint);
+			free(old_fingerprint);
 
 			if (!accept_certificate)
 			{

--- a/winpr/include/winpr/string.h
+++ b/winpr/include/winpr/string.h
@@ -186,6 +186,8 @@ WINPR_API void ByteSwapUnicode(WCHAR* wstr, int length);
 WINPR_API int ConvertLineEndingToLF(char* str, int size);
 WINPR_API char* ConvertLineEndingToCRLF(const char* str, int* size);
 
+WINPR_API char* StrSep(char** stringp, const char* delim);
+
 #ifdef __cplusplus
 }
 #endif

--- a/winpr/libwinpr/crt/string.c
+++ b/winpr/libwinpr/crt/string.c
@@ -463,3 +463,22 @@ char* ConvertLineEndingToCRLF(const char* str, int* size)
 	return newStr;
 }
 
+char* StrSep(char** stringp, const char* delim)
+{
+	char* start = *stringp;
+	char* p;
+
+	p = (start != NULL) ? strpbrk(start, delim) : NULL;
+
+	if (!p)
+		*stringp = NULL;
+	else
+	{
+		*p = '\0';
+		*stringp = p + 1;
+	}
+
+	return start;
+}
+
+


### PR DESCRIPTION
* Can now store SSL fingerprints for each <host> <port> combination.
* Using new ```known_host.v2``` file to store.
* Already existing ```known_host``` entries are added on first use to ```known_host.v2``` if the fingerprint matches.
* Added unit test to ensure functionality
* Storing subject and issuer now to display on ```VerifyChangedCertificate``` callback.
* Adjusted arguments of ```VerifyChangedCertificate```