### PR TITLE
known_host saving host and port.

### DIFF
--- a/include/freerdp/crypto/certificate.h
+++ b/include/freerdp/crypto/certificate.h
@@ -35,6 +35,8 @@ typedef struct rdp_certificate_store rdpCertificateStore;
 struct rdp_certificate_data
 {
 	char* hostname;
+	int port;
+	char* hostnamePort;
 	char* fingerprint;
 };
 
@@ -51,7 +53,7 @@ struct rdp_certificate_store
  extern "C" {
 #endif
 
-FREERDP_API rdpCertificateData* certificate_data_new(char* hostname, char* fingerprint);
+FREERDP_API rdpCertificateData* certificate_data_new(char* hostname, int port, char* fingerprint);
 FREERDP_API void certificate_data_free(rdpCertificateData* certificate_data);
 FREERDP_API rdpCertificateStore* certificate_store_new(rdpSettings* settings);
 FREERDP_API void certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data);

--- a/include/freerdp/crypto/crypto.h
+++ b/include/freerdp/crypto/crypto.h
@@ -133,7 +133,7 @@ FREERDP_API void crypto_cert_print_info(X509* xcert);
 FREERDP_API void crypto_cert_free(CryptoCert cert);
 
 FREERDP_API BOOL x509_verify_certificate(CryptoCert cert, char* certificate_store_path);
-FREERDP_API rdpCertificateData* crypto_get_certificate_data(X509* xcert, char* hostname);
+FREERDP_API rdpCertificateData* crypto_get_certificate_data(X509* xcert, char* hostname, int port);
 FREERDP_API BOOL crypto_cert_get_public_key(CryptoCert cert, BYTE** PublicKey, DWORD* PublicKeyLength);
 
 #define	TSSK_KEY_LENGTH	64

--- a/libfreerdp/crypto/certificate.c
+++ b/libfreerdp/crypto/certificate.c
@@ -186,7 +186,7 @@ void certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertifi
 
 	if (!fp)
 		return;
-	
+
 	/* Read the current contents of the file. */
 	fseek(fp, 0, SEEK_END);
 	size = ftell(fp);
@@ -202,7 +202,7 @@ void certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertifi
 		free(data);
 		return;
 	}
-	
+
 	/* Write the file back out, with appropriate fingerprint substitutions */
 	fp = fopen(certificate_store->file, "w+");
 	data[size] = '\n';
@@ -216,7 +216,7 @@ void certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertifi
 		if (length > 0)
 		{
 			char* hostname = pline, *fingerprint;
-			
+
 			length = strcspn(pline, " \t");
 			hostname[length] = '\0';
 
@@ -225,15 +225,15 @@ void certificate_data_replace(rdpCertificateStore* certificate_store, rdpCertifi
 				fingerprint = certificate_data->fingerprint;
 			else
 				fingerprint = &hostname[length + 1];
-			
+
 			fprintf(fp, "%s %s\n", hostname, fingerprint);
 		}
 
 		pline = strtok(NULL, "\n");
 	}
-	
+
 	fclose(fp);
-	free(data);	
+	free(data);
 }
 
 void certificate_data_print(rdpCertificateStore* certificate_store, rdpCertificateData* certificate_data)

--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -555,7 +555,7 @@ end:
 	return status;
 }
 
-rdpCertificateData* crypto_get_certificate_data(X509* xcert, char* hostname)
+rdpCertificateData* crypto_get_certificate_data(X509* xcert, char* hostname, int port)
 {
 	char* fp;
 	rdpCertificateData* certdata;
@@ -564,7 +564,7 @@ rdpCertificateData* crypto_get_certificate_data(X509* xcert, char* hostname)
 	if (!fp)
 		return NULL;
 
-	certdata = certificate_data_new(hostname, fp);
+	certdata = certificate_data_new(hostname, port, fp);
 	free(fp);
 
 	return certdata;

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1082,7 +1082,7 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, char* hostname, int por
 	certificate_status = x509_verify_certificate(cert, tls->certificate_store->path);
 
 	/* verify certificate name match */
-	certificate_data = crypto_get_certificate_data(cert->px509, hostname);
+	certificate_data = crypto_get_certificate_data(cert->px509, hostname, port);
 
 	/* extra common name and alternative names */
 	common_name = crypto_cert_subject_common_name(cert->px509, &common_name_length);


### PR DESCRIPTION
In my opinion we should save in known_host pair host and ip (like OpenSSH do this).
This allow us to connect to multiple RDP servers which have same IP but different port.