### PR TITLE
rdpsnd/pulse: Fix crash if device isn't specified

### DIFF
--- a/channels/rdpsnd/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/pulse/rdpsnd_pulse.c
@@ -474,7 +474,7 @@ int FreeRDPRdpsndDeviceEntry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints)
 	data = pEntryPoints->plugin_data;
 	if (data && strcmp((char*)data->data[0], "pulse") == 0)
 	{
-		if(strlen((char*)data->data[1]) > 0) 
+		if(data->data[1] && strlen((char*)data->data[1]) > 0)
 			pulse->device_name = xstrdup((char*)data->data[1]);
 		else
 			pulse->device_name = NULL;


### PR DESCRIPTION
Freerdp crashes if pulseaudio device isn't specified on commandline, i.e.:
xfreerdp --plugin rdpsnd --data pulse

The crash occurs, because data[1] is NULL and it is passed into strlen
function. We have to check whether data[1] was set before calling strlen
to fix this crash.