### PR TITLE
rdpsnd/pulse: Fix crashes in pulseaudio

### DIFF
--- a/channels/rdpsnd/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/pulse/rdpsnd_pulse.c
@@ -452,7 +452,9 @@ static void rdpsnd_pulse_start(rdpsndDevicePlugin* device)
 	if (!pulse->stream)
 		return;
 
+	pa_threaded_mainloop_lock(pulse->mainloop);
 	pa_stream_trigger(pulse->stream, NULL, NULL);
+	pa_threaded_mainloop_unlock(pulse->mainloop);
 }
 
 int FreeRDPRdpsndDeviceEntry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints)


### PR DESCRIPTION
Function pa_stream_trigger has to be called under lock to avoid
following crashes on asserts:

Assertion 'e->mainloop->n_enabled_defer_events > 0' failed at pulse/mainloop.c:257, function mainloop_defer_enable(). Aborting.
Assertion '!e->next' failed at pulsecore/queue.c:104, function pa_queue_pop(). Aborting.
Assertion 'q->front' failed at pulsecore/queue.c:81, function pa_queue_push(). Aborting.