### PR TITLE
Shadow server: fix channel disposal and add audio support. fix message mechanism in client

### DIFF
--- a/include/freerdp/server/shadow.h
+++ b/include/freerdp/server/shadow.h
@@ -31,6 +31,8 @@
 
 #include <freerdp/server/encomsp.h>
 #include <freerdp/server/remdesk.h>
+#include <freerdp/server/rdpsnd.h>
+#include <freerdp/server/audin.h>
 
 #include <freerdp/codec/color.h>
 #include <freerdp/codec/region.h>
@@ -71,6 +73,8 @@ typedef int (*pfnShadowUnicodeKeyboardEvent)(rdpShadowSubsystem* subsystem, UINT
 typedef int (*pfnShadowMouseEvent)(rdpShadowSubsystem* subsystem, UINT16 flags, UINT16 x, UINT16 y);
 typedef int (*pfnShadowExtendedMouseEvent)(rdpShadowSubsystem* subsystem, UINT16 flags, UINT16 x, UINT16 y);
 
+typedef void (*pfnShadowChannelAudinServerReceiveSamples)(rdpShadowSubsystem* subsystem, const void* buf, int nframes);
+
 struct rdp_shadow_client
 {
 	rdpContext context;
@@ -80,7 +84,7 @@ struct rdp_shadow_client
 	BOOL inLobby;
 	BOOL mayView;
 	BOOL mayInteract;
-	HANDLE StopEvent;
+	wMessageQueue* MsgQueue;
 	CRITICAL_SECTION lock;
 	REGION16 invalidRegion;
 	rdpShadowServer* server;
@@ -94,6 +98,8 @@ struct rdp_shadow_client
 	HANDLE vcm;
 	EncomspServerContext* encomsp;
 	RemdeskServerContext* remdesk;
+	RdpsndServerContext* rdpsnd;
+	audin_server_context* audin;
 };
 
 struct rdp_shadow_server
@@ -151,11 +157,17 @@ struct _RDP_SHADOW_ENTRY_POINTS
 	UINT32 pointerX; \
 	UINT32 pointerY; \
 	\
+	const AUDIO_FORMAT* rdpsndFormats; \
+	int nRdpsndFormats; \
+	const AUDIO_FORMAT* audinFormats; \
+	int nAudinFormats; \
+	\
 	pfnShadowSynchronizeEvent SynchronizeEvent; \
 	pfnShadowKeyboardEvent KeyboardEvent; \
 	pfnShadowUnicodeKeyboardEvent UnicodeKeyboardEvent; \
 	pfnShadowMouseEvent MouseEvent; \
 	pfnShadowExtendedMouseEvent ExtendedMouseEvent; \
+	pfnShadowChannelAudinServerReceiveSamples AudinServerReceiveSamples; \
 	\
 	pfnShadowAuthenticate Authenticate; \
 	\
@@ -165,6 +177,79 @@ struct rdp_shadow_subsystem
 {
 	RDP_SHADOW_SUBSYSTEM_COMMON();
 };
+
+/* Definition of message between subsystem and clients */
+#define SHADOW_MSG_IN_REFRESH_OUTPUT_ID			1001
+#define SHADOW_MSG_IN_SUPPRESS_OUTPUT_ID		1002
+
+struct _SHADOW_MSG_IN_REFRESH_OUTPUT
+{
+	UINT32 numRects;
+	RECTANGLE_16* rects;
+};
+typedef struct _SHADOW_MSG_IN_REFRESH_OUTPUT SHADOW_MSG_IN_REFRESH_OUTPUT;
+
+struct _SHADOW_MSG_IN_SUPPRESS_OUTPUT
+{
+	BOOL allow;
+	RECTANGLE_16 rect;
+};
+typedef struct _SHADOW_MSG_IN_SUPPRESS_OUTPUT SHADOW_MSG_IN_SUPPRESS_OUTPUT;
+
+typedef struct _SHADOW_MSG_OUT SHADOW_MSG_OUT;
+typedef void (*MSG_OUT_FREE_FN)(UINT32 id, SHADOW_MSG_OUT* msg);
+#define RDP_SHADOW_MSG_OUT_COMMON() \
+	int refCount; \
+	MSG_OUT_FREE_FN Free; /* function to free SHADOW_MSG_OUT */
+
+struct _SHADOW_MSG_OUT
+{
+	RDP_SHADOW_MSG_OUT_COMMON();
+};
+
+#define SHADOW_MSG_OUT_POINTER_POSITION_UPDATE_ID		2001
+#define SHADOW_MSG_OUT_POINTER_ALPHA_UPDATE_ID			2002
+#define SHADOW_MSG_OUT_AUDIO_OUT_SAMPLES_ID				2003
+#define SHADOW_MSG_OUT_AUDIO_OUT_VOLUME_ID				2004
+
+struct _SHADOW_MSG_OUT_POINTER_POSITION_UPDATE
+{
+	RDP_SHADOW_MSG_OUT_COMMON();
+	UINT32 xPos;
+	UINT32 yPos;
+};
+typedef struct _SHADOW_MSG_OUT_POINTER_POSITION_UPDATE SHADOW_MSG_OUT_POINTER_POSITION_UPDATE;
+
+struct _SHADOW_MSG_OUT_POINTER_ALPHA_UPDATE
+{
+	RDP_SHADOW_MSG_OUT_COMMON();
+	UINT32 xHot;
+	UINT32 yHot;
+	UINT32 width;
+	UINT32 height;
+	BYTE* pixels;
+	int scanline;
+	BOOL premultiplied;
+};
+typedef struct _SHADOW_MSG_OUT_POINTER_ALPHA_UPDATE SHADOW_MSG_OUT_POINTER_ALPHA_UPDATE;
+
+struct _SHADOW_MSG_OUT_AUDIO_OUT_SAMPLES
+{
+	RDP_SHADOW_MSG_OUT_COMMON();
+	AUDIO_FORMAT audio_format;
+	void* buf;
+	int nFrames;
+	UINT16 wTimestamp;
+};
+typedef struct _SHADOW_MSG_OUT_AUDIO_OUT_SAMPLES SHADOW_MSG_OUT_AUDIO_OUT_SAMPLES;
+
+struct _SHADOW_MSG_OUT_AUDIO_OUT_VOLUME
+{
+	RDP_SHADOW_MSG_OUT_COMMON();
+	int left;
+	int right;
+};
+typedef struct _SHADOW_MSG_OUT_AUDIO_OUT_VOLUME SHADOW_MSG_OUT_AUDIO_OUT_VOLUME;
 
 #ifdef __cplusplus
 extern "C" {
@@ -183,6 +268,10 @@ FREERDP_API int shadow_enum_monitors(MONITOR_DEF* monitors, int maxMonitors, con
 
 FREERDP_API rdpShadowServer* shadow_server_new();
 FREERDP_API void shadow_server_free(rdpShadowServer* server);
+
+FREERDP_API BOOL shadow_client_post_msg(rdpShadowClient* client, void* context, UINT32 type, SHADOW_MSG_OUT* msg, void* lParam);
+FREERDP_API int shadow_client_boardcast_msg(rdpShadowServer* server, void* context, UINT32 type, SHADOW_MSG_OUT* msg, void* lParam);
+FREERDP_API int shadow_client_boardcast_quit(rdpShadowServer* server, int nExitCode);
 
 #ifdef __cplusplus
 }

--- a/server/shadow/CMakeLists.txt
+++ b/server/shadow/CMakeLists.txt
@@ -169,6 +169,10 @@ set(${MODULE_PREFIX}_SRCS
 	shadow_encomsp.h
 	shadow_remdesk.c
 	shadow_remdesk.h
+	shadow_rdpsnd.c
+	shadow_rdpsnd.h
+	shadow_audin.c
+	shadow_audin.h
 	shadow_subsystem.c
 	shadow_subsystem.h
 	shadow_mcevent.c

--- a/server/shadow/Mac/mac_shadow.c
+++ b/server/shadow/Mac/mac_shadow.c
@@ -452,48 +452,56 @@ int mac_shadow_screen_grab(macShadowSubsystem* subsystem)
 
 int mac_shadow_subsystem_process_message(macShadowSubsystem* subsystem, wMessage* message)
 {
-	if (message->id == SHADOW_MSG_IN_REFRESH_OUTPUT_ID)
+	switch(message->id)
 	{
-		UINT32 index;
-		SHADOW_MSG_IN_REFRESH_OUTPUT* msg = (SHADOW_MSG_IN_REFRESH_OUTPUT*) message->wParam;
-		
-		if (msg->numRects)
+		case SHADOW_MSG_IN_REFRESH_OUTPUT_ID:
 		{
-			for (index = 0; index < msg->numRects; index++)
+			UINT32 index;
+			SHADOW_MSG_IN_REFRESH_OUTPUT* msg = (SHADOW_MSG_IN_REFRESH_OUTPUT*) message->wParam;
+
+			if (msg->numRects)
+			{
+				for (index = 0; index < msg->numRects; index++)
+				{
+					region16_union_rect(&(subsystem->invalidRegion),
+							&(subsystem->invalidRegion), &msg->rects[index]);
+				}
+			}
+			else
+			{
+				RECTANGLE_16 refreshRect;
+
+				refreshRect.left = 0;
+				refreshRect.top = 0;
+				refreshRect.right = subsystem->width;
+				refreshRect.bottom = subsystem->height;
+
+				region16_union_rect(&(subsystem->invalidRegion),
+							&(subsystem->invalidRegion), &refreshRect);
+			}
+			break;
+		}
+		case SHADOW_MSG_IN_SUPPRESS_OUTPUT_ID:
+		{
+			SHADOW_MSG_IN_SUPPRESS_OUTPUT* msg = (SHADOW_MSG_IN_SUPPRESS_OUTPUT*) message->wParam;
+
+			subsystem->suppressOutput = (msg->allow) ? FALSE : TRUE;
+
+			if (msg->allow)
 			{
 				region16_union_rect(&(subsystem->invalidRegion),
-						    &(subsystem->invalidRegion), &msg->rects[index]);
+							&(subsystem->invalidRegion), &(msg->rect));
 			}
+			break;
 		}
-		else
-		{
-			RECTANGLE_16 refreshRect;
-			
-			refreshRect.left = 0;
-			refreshRect.top = 0;
-			refreshRect.right = subsystem->width;
-			refreshRect.bottom = subsystem->height;
-			
-			region16_union_rect(&(subsystem->invalidRegion),
-					    &(subsystem->invalidRegion), &refreshRect);
-		}
+		default:
+			WLog_ERR(TAG, "Unknown message id: %u", message->id);
+			break;
 	}
-	else if (message->id == SHADOW_MSG_IN_SUPPRESS_OUTPUT_ID)
-	{
-		SHADOW_MSG_IN_SUPPRESS_OUTPUT* msg = (SHADOW_MSG_IN_SUPPRESS_OUTPUT*) message->wParam;
-		
-		subsystem->suppressOutput = (msg->allow) ? FALSE : TRUE;
-		
-		if (msg->allow)
-		{
-			region16_union_rect(&(subsystem->invalidRegion),
-					    &(subsystem->invalidRegion), &(msg->rect));
-		}
-	}
-	
+
 	if (message->Free)
 		message->Free(message);
-	
+
 	return 1;
 }
 

--- a/server/shadow/shadow_audin.c
+++ b/server/shadow/shadow_audin.c
@@ -1,0 +1,121 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ *
+ * Copyright 2015 Jiang Zihao <zihao.jiang@yahoo.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <freerdp/log.h>
+#include "shadow.h"
+
+#include "shadow_audin.h"
+
+#define TAG SERVER_TAG("shadow")
+
+/* Default supported audio formats */
+static const AUDIO_FORMAT default_supported_audio_formats[] =
+{
+	{ WAVE_FORMAT_PCM, 2, 44100, 176400, 4, 16, 0, NULL },
+	{ WAVE_FORMAT_ALAW, 2, 22050, 44100, 2, 8, 0, NULL }
+};
+
+static void AudinServerOpening(audin_server_context* context)
+{
+	AUDIO_FORMAT* agreed_format = NULL;
+	int i = 0, j = 0;
+	for (i = 0; i < context->num_client_formats; i++)
+	{
+		for (j = 0; j < context->num_server_formats; j++)
+		{
+			if ((context->client_formats[i].wFormatTag == context->server_formats[j].wFormatTag) &&
+					(context->client_formats[i].nChannels == context->server_formats[j].nChannels) &&
+					(context->client_formats[i].nSamplesPerSec == context->server_formats[j].nSamplesPerSec))
+			{
+				agreed_format = (AUDIO_FORMAT*) &context->server_formats[j];
+				break;
+			}
+		}
+		if (agreed_format != NULL)
+			break;
+
+	}
+
+	if (agreed_format == NULL)
+	{
+		WLog_ERR(TAG, "Could not agree on a audio format with the server\n");
+		return;
+	}
+
+	context->SelectFormat(context, i);
+}
+static void AudinServerOpenResult(audin_server_context* context, UINT32 result)
+{
+	WLog_INFO(TAG, "AUDIN open result %u.\n", result);
+}
+static void AudinServerReceiveSamples(audin_server_context* context, const void* buf, int nframes)
+{
+	rdpShadowClient* client = (rdpShadowClient* )context->data;
+	rdpShadowSubsystem* subsystem = client->server->subsystem;
+
+	if (!client->mayInteract)
+		return;
+
+	if (subsystem->AudinServerReceiveSamples)
+		subsystem->AudinServerReceiveSamples(subsystem, buf, nframes);
+}
+
+int shadow_client_audin_init(rdpShadowClient* client)
+{
+	audin_server_context* audin;
+	audin = client->audin = audin_server_context_new(client->vcm);
+	if (!audin)
+	{
+		return 0;
+	}
+
+	audin->data = client;
+
+	if (client->subsystem->audinFormats)
+	{
+		audin->server_formats = client->subsystem->audinFormats;
+		audin->num_server_formats = client->subsystem->nAudinFormats;
+	}
+	else
+	{
+		/* Set default audio formats. */
+		audin->server_formats = default_supported_audio_formats;
+		audin->num_server_formats = sizeof(default_supported_audio_formats) / sizeof(default_supported_audio_formats[0]);
+	}
+
+	audin->dst_format = audin->server_formats[0];
+
+	audin->Opening = AudinServerOpening;
+	audin->OpenResult = AudinServerOpenResult;
+	audin->ReceiveSamples = AudinServerReceiveSamples;
+
+	return 1;
+}
+
+void shadow_client_audin_uninit(rdpShadowClient* client)
+{
+	if (client->audin)
+	{
+		audin_server_context_free(client->audin);
+		client->audin = NULL;
+	}
+}

--- a/server/shadow/shadow_audin.h
+++ b/server/shadow/shadow_audin.h
@@ -1,7 +1,7 @@
 /**
  * FreeRDP: A Remote Desktop Protocol Implementation
  *
- * Copyright 2014 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+ * Copyright 2015 Jiang Zihao <zihao.jiang@yahoo.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-#ifndef FREERDP_SHADOW_SERVER_SUBSYSTEM_H
-#define FREERDP_SHADOW_SERVER_SUBSYSTEM_H
+#ifndef FREERDP_SHADOW_SERVER_AUDIN_H
+#define FREERDP_SHADOW_SERVER_AUDIN_H
 
 #include <freerdp/server/shadow.h>
 
@@ -28,18 +28,11 @@
 extern "C" {
 #endif
 
-rdpShadowSubsystem* shadow_subsystem_new(const char* name);
-void shadow_subsystem_free(rdpShadowSubsystem* subsystem);
-
-int shadow_subsystem_init(rdpShadowSubsystem* subsystem, rdpShadowServer* server);
-void shadow_subsystem_uninit(rdpShadowSubsystem* subsystem);
-
-int shadow_subsystem_start(rdpShadowSubsystem* subsystem);
-int shadow_subsystem_stop(rdpShadowSubsystem* subsystem);
+int shadow_client_audin_init(rdpShadowClient* client);
+void shadow_client_audin_uninit(rdpShadowClient* client);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* FREERDP_SHADOW_SERVER_SUBSYSTEM_H */
-
+#endif /* FREERDP_SHADOW_SERVER_AUDIN_H */

--- a/server/shadow/shadow_channels.c
+++ b/server/shadow/shadow_channels.c
@@ -36,5 +36,23 @@ int shadow_client_channels_post_connect(rdpShadowClient* client)
 		shadow_client_remdesk_init(client);
 	}
 
+	if (WTSVirtualChannelManagerIsChannelJoined(client->vcm, "rdpsnd"))
+	{
+		shadow_client_rdpsnd_init(client);
+	}
+
+	shadow_client_audin_init(client);
+
 	return 1;
+}
+
+void shadow_client_channels_free(rdpShadowClient* client)
+{
+	shadow_client_audin_uninit(client);
+
+	shadow_client_rdpsnd_uninit(client);
+
+	shadow_client_remdesk_uninit(client);
+
+	shadow_client_encomsp_uninit(client);
 }

--- a/server/shadow/shadow_channels.h
+++ b/server/shadow/shadow_channels.h
@@ -26,12 +26,15 @@
 
 #include "shadow_encomsp.h"
 #include "shadow_remdesk.h"
+#include "shadow_rdpsnd.h"
+#include "shadow_audin.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 int shadow_client_channels_post_connect(rdpShadowClient* client);
+void shadow_client_channels_free(rdpShadowClient* client);
 
 #ifdef __cplusplus
 }

--- a/server/shadow/shadow_encomsp.c
+++ b/server/shadow/shadow_encomsp.c
@@ -113,6 +113,7 @@ void shadow_client_encomsp_uninit(rdpShadowClient* client)
 {
 	if (client->encomsp) {
 		client->encomsp->Stop(client->encomsp);
+		encomsp_server_context_free(client->encomsp);
 		client->encomsp = NULL;
 	}
 }

--- a/server/shadow/shadow_rdpsnd.c
+++ b/server/shadow/shadow_rdpsnd.c
@@ -1,0 +1,111 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ *
+ * Copyright 2015 Jiang Zihao <zihao.jiang@yahoo.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <freerdp/log.h>
+#include "shadow.h"
+
+#include "shadow_rdpsnd.h"
+
+#define TAG SERVER_TAG("shadow")
+
+/* Default supported audio formats */
+static const AUDIO_FORMAT default_supported_audio_formats[] =
+{
+	{ WAVE_FORMAT_PCM, 2, 44100, 176400, 4, 16, 0, NULL },
+	{ WAVE_FORMAT_ALAW, 2, 22050, 44100, 2, 8, 0, NULL }
+};
+
+static void rdpsnd_activated(RdpsndServerContext* context)
+{
+	AUDIO_FORMAT* agreed_format = NULL;
+	int i = 0, j = 0;
+	for (i = 0; i < context->num_client_formats; i++)
+	{
+		for (j = 0; j < context->num_server_formats; j++)
+		{
+			if ((context->client_formats[i].wFormatTag == context->server_formats[j].wFormatTag) &&
+					(context->client_formats[i].nChannels == context->server_formats[j].nChannels) &&
+					(context->client_formats[i].nSamplesPerSec == context->server_formats[j].nSamplesPerSec))
+			{
+				agreed_format = (AUDIO_FORMAT*) &context->server_formats[j];
+				break;
+			}
+		}
+		if (agreed_format != NULL)
+			break;
+
+	}
+
+	if (agreed_format == NULL)
+	{
+		WLog_ERR(TAG, "Could not agree on a audio format with the server\n");
+		return;
+	}
+
+	context->SelectFormat(context, i);
+	context->SetVolume(context, 0x7FFF, 0x7FFF);
+}
+
+int shadow_client_rdpsnd_init(rdpShadowClient* client)
+{
+	RdpsndServerContext* rdpsnd;
+
+	rdpsnd = client->rdpsnd = rdpsnd_server_context_new(client->vcm);
+	if (!rdpsnd)
+	{
+		return 0;
+	}
+
+	rdpsnd->data = client;
+
+	if (client->subsystem->rdpsndFormats)
+	{
+		rdpsnd->server_formats = client->subsystem->rdpsndFormats;
+		rdpsnd->num_server_formats = client->subsystem->nRdpsndFormats;
+	}
+	else
+	{
+		/* Set default audio formats. */
+		rdpsnd->server_formats = default_supported_audio_formats;
+		rdpsnd->num_server_formats =
+			sizeof(default_supported_audio_formats) / sizeof(default_supported_audio_formats[0]);
+	}
+
+	rdpsnd->src_format = rdpsnd->server_formats[0];
+
+	rdpsnd->Activated = rdpsnd_activated;
+
+	rdpsnd->Initialize(rdpsnd, TRUE);
+
+	return 1;
+
+}
+
+void shadow_client_rdpsnd_uninit(rdpShadowClient* client)
+{
+	if (client->rdpsnd)
+	{
+		client->rdpsnd->Stop(client->rdpsnd);
+		rdpsnd_server_context_free(client->rdpsnd);
+		client->rdpsnd = NULL;
+	}
+}

--- a/server/shadow/shadow_rdpsnd.h
+++ b/server/shadow/shadow_rdpsnd.h
@@ -1,7 +1,7 @@
 /**
  * FreeRDP: A Remote Desktop Protocol Implementation
  *
- * Copyright 2014 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+ * Copyright 2015 Jiang Zihao <zihao.jiang@yahoo.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-#ifndef FREERDP_SHADOW_SERVER_SUBSYSTEM_H
-#define FREERDP_SHADOW_SERVER_SUBSYSTEM_H
+#ifndef FREERDP_SHADOW_SERVER_RDPSND_H
+#define FREERDP_SHADOW_SERVER_RDPSND_H
 
 #include <freerdp/server/shadow.h>
 
@@ -28,18 +28,11 @@
 extern "C" {
 #endif
 
-rdpShadowSubsystem* shadow_subsystem_new(const char* name);
-void shadow_subsystem_free(rdpShadowSubsystem* subsystem);
-
-int shadow_subsystem_init(rdpShadowSubsystem* subsystem, rdpShadowServer* server);
-void shadow_subsystem_uninit(rdpShadowSubsystem* subsystem);
-
-int shadow_subsystem_start(rdpShadowSubsystem* subsystem);
-int shadow_subsystem_stop(rdpShadowSubsystem* subsystem);
+int shadow_client_rdpsnd_init(rdpShadowClient* client);
+void shadow_client_rdpsnd_uninit(rdpShadowClient* client);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* FREERDP_SHADOW_SERVER_SUBSYSTEM_H */
-
+#endif /* FREERDP_SHADOW_SERVER_RDPSND_H */

--- a/server/shadow/shadow_remdesk.c
+++ b/server/shadow/shadow_remdesk.c
@@ -42,6 +42,7 @@ void shadow_client_remdesk_uninit(rdpShadowClient* client)
 {
 	if (client->remdesk) {
 		client->remdesk->Stop(client->remdesk);
+		remdesk_server_context_free(client->remdesk);
 		client->remdesk = NULL;
 	}
 }

--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -346,7 +346,7 @@ void* shadow_server_thread(rdpShadowServer* server)
 
 	/* Signal to the clients that server is being stopped and wait for them
 	 * to disconnect. */
-	if (MessageQueue_PostQuit(subsystem->MsgPipe->Out, 0))
+	if (shadow_client_boardcast_quit(server, 0))
 	{
 		while(ArrayList_Count(server->clients) > 0)
 		{


### PR DESCRIPTION
This PR originally is used to add audio support, however some fix in shadow_client is related to it.
So also include several fixes:
1. Introduce message queue in shadow client. No longer use subsytem->MsgPipe->out to deliver message to clients.
We used to use subsytem->MsgPipe->out for messages which need to be sent to client. But it's not correct. Only one client would get the message if multiple client exists
This problem make the fix in PR #2643 incomplete.
Introduced reference count based solution to release resource taken by the message.
Also added APIs for client message delivery.
Also fixed msg pipe in subsystem to clean resource when destroyed.
2. Discard unused StopEvent in client. We actually use quit message instead.
3. Enhance disposal of channels.
Free context for remdesk and encomsp channels. The original fix only stop the threads, but doesn't release resource.
Dispose channels earlier. The channels are built on client->vcm. Disposing channels after client->vcm is closed cause unknown behavior.
Original fix is #2644
4. Start to add audio support.