### PR TITLE
Allowing UPN syntax for user argument.

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -492,8 +492,6 @@ BOOL wf_post_connect(freerdp* instance)
 	return TRUE;
 }
 
-static const char wfTargetName[] = "TARGET";
-
 static CREDUI_INFOA wfUiInfo =
 {
 	sizeof(CREDUI_INFOA),
@@ -518,7 +516,9 @@ BOOL wf_authenticate(freerdp* instance, char** username, char** password, char**
 	ZeroMemory(Password, sizeof(Password));
 	dwFlags = CREDUI_FLAGS_DO_NOT_PERSIST | CREDUI_FLAGS_EXCLUDE_CERTIFICATES;
 
-	status = CredUIPromptForCredentialsA(&wfUiInfo, wfTargetName, NULL, 0,
+	status = CredUIPromptForCredentialsA(&wfUiInfo,
+					     instance->settings->ServerHostname,
+					     NULL, 0,
 		UserName, CREDUI_MAX_USERNAME_LENGTH + 1,
 		Password, CREDUI_MAX_PASSWORD_LENGTH + 1, &fSave, dwFlags);
 

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -537,6 +537,8 @@ BOOL wf_authenticate(freerdp* instance, char** username, char** password, char**
 
 	if (strlen(Domain) > 0)
 		*domain = _strdup(Domain);
+	else
+		*domain = _strdup("\0");
 
 	*password = _strdup(Password);
 

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2040,13 +2040,13 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 	if (!settings->Domain && user)
 	{
-		freerdp_parse_username(arg->Value, &settings->Username, &settings->Domain);
+		freerdp_parse_username(user, &settings->Username, &settings->Domain);
 		free(user);
 	}
 
 	if (!settings->GatewayDomain && gwUser)
 	{
-		freerdp_parse_username(arg->Value, &settings->GatewayUsername,
+		freerdp_parse_username(gwUser, &settings->GatewayUsername,
 				 &settings->GatewayDomain);
 		free(gwUser);
 	}

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2043,6 +2043,8 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		freerdp_parse_username(user, &settings->Username, &settings->Domain);
 		free(user);
 	}
+	else
+		settings->Username = user;
 
 	if (!settings->GatewayDomain && gwUser)
 	{
@@ -2050,6 +2052,8 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 				 &settings->GatewayDomain);
 		free(gwUser);
 	}
+	else
+		settings->GatewayUsername = gwUser;
 
 	freerdp_performance_flags_make(settings);
 

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -553,7 +553,7 @@ static char** freerdp_command_line_parse_comma_separated_values_offset(char* lis
 		return NULL;
 	p = t;
 	if (count > 0)
-        MoveMemory(&p[1], p, sizeof(char*) * *count);
+				MoveMemory(&p[1], p, sizeof(char*) * *count);
 	(*count)++;
 
 	return p;
@@ -795,17 +795,45 @@ int freerdp_client_command_line_post_filter(void* context, COMMAND_LINE_ARGUMENT
 int freerdp_parse_username(char* username, char** user, char** domain)
 {
 	char* p;
-	int length;
+	char* u;
+	int length = 0;
 
 	p = strchr(username, '\\');
+	u = strchr(username, '@');
 
 	if (p)
 	{
 		length = (int) (p - username);
+		*user = _strdup(&p[1]);
+		if (!*user)
+			return -1;
+
 		*domain = (char*) calloc(length + 1UL, sizeof(char));
+		if (!*domain)
+		{
+			free (*user);
+			*user = NULL;
+			return -1;
+		}
+
 		strncpy(*domain, username, length);
 		(*domain)[length] = '\0';
-		*user = _strdup(&p[1]);
+	}
+	else if (u)
+	{
+		length = (int) (u - username);
+		*domain = _strdup(&u[1]);
+		if (!*domain)
+			return -1;
+
+		*user = (char*) calloc(length + 1UL, sizeof(char));
+		if (!*user)
+		{
+			free(*domain);
+			*domain = NULL;
+		}
+		strncpy(*user, username, length);
+		(*user)[length] = '\0';
 	}
 	else
 	{
@@ -814,6 +842,9 @@ int freerdp_parse_username(char* username, char** user, char** domain)
 		 * as username 'user@corp.net', domain empty.
 		 */
 		*user = _strdup(username);
+		if (!*user)
+			return -1;
+
 		*domain = NULL;
 	}
 
@@ -1209,7 +1240,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 	if (compatibility)
 	{
-		WLog_WARN(TAG,  "Using deprecated command-line interface!");
+		WLog_WARN(TAG, "Using deprecated command-line interface!");
 		return freerdp_client_parse_old_command_line_arguments(argc, argv, settings);
 	}
 	else
@@ -1439,7 +1470,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 				if (!id)
 				{
-					WLog_ERR(TAG,  "Could not identify keyboard layout: %s", arg->Value);
+					WLog_ERR(TAG, "Could not identify keyboard layout: %s", arg->Value);
 				}
 			}
 
@@ -1818,7 +1849,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 			}
 			else
 			{
-				WLog_ERR(TAG,  "unknown protocol security: %s", arg->Value);
+				WLog_ERR(TAG, "unknown protocol security: %s", arg->Value);
 			}
 		}
 		CommandLineSwitchCase(arg, "encryption-methods")
@@ -1842,7 +1873,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 					else if (!strcmp(p[i], "FIPS"))
 						settings->EncryptionMethods |= ENCRYPTION_METHOD_FIPS;
 					else
-						WLog_ERR(TAG,  "unknown encryption method '%s'", p[i]);
+						WLog_ERR(TAG, "unknown encryption method '%s'", p[i]);
 				}
 
 				free(p);
@@ -1998,7 +2029,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 			}
 			else
 			{
-				WLog_ERR(TAG,  "reconnect-cookie:  invalid base64 '%s'", arg->Value);
+				WLog_ERR(TAG, "reconnect-cookie:  invalid base64 '%s'", arg->Value);
 			}
 		}
 		CommandLineSwitchCase(arg, "print-reconnect-cookie")
@@ -2062,7 +2093,7 @@ int freerdp_client_load_static_channel_addin(rdpChannels* channels, rdpSettings*
 	{
 		if (freerdp_channels_client_load(channels, settings, entry, data) == 0)
 		{
-			WLog_INFO(TAG,  "loading channel %s", name);
+			WLog_INFO(TAG, "loading channel %s", name);
 			return 0;
 		}
 	}

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -799,7 +799,7 @@ int freerdp_parse_username(char* username, char** user, char** domain)
 	int length = 0;
 
 	p = strchr(username, '\\');
-	p = strrchr(username, '@');
+	u = strrchr(username, '@');
 
 	*user = NULL;
 	*domain = NULL;
@@ -836,10 +836,7 @@ int freerdp_parse_username(char* username, char** user, char** domain)
 		 * otherwise set the domain to an empty string.
 		 * NOTE: Domain NULL will result in undefined behavior.
 		 */
-		if (!u)
-			*domain = _strdup("TARGET");
-		else
-			*domain = _strdup("\0");
+		*domain = _strdup("\0");
 
 		if (!*domain)
 		{
@@ -2052,7 +2049,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 	if (!settings->GatewayDomain && gwUser)
 	{
 		freerdp_parse_username(gwUser, &settings->GatewayUsername,
-				 &settings->GatewayDomain);
+				       &settings->GatewayDomain);
 		free(gwUser);
 	}
 	else


### PR DESCRIPTION
* Fixed issues with authentication:
* If ```user@domain``` syntax is used, the domain is set to an empty string instead of ```NULL``` and user to the full string
* If only ```user``` is given, set domain to ```TARGET``` (similar to ```CredUIParseUserName```)
* If ```domain\user``` syntax is used, split the string.