### PR TITLE
Let SSPI module choose which implementation to use.

### DIFF
--- a/libfreerdp/core/gateway/ntlm.c
+++ b/libfreerdp/core/gateway/ntlm.c
@@ -43,7 +43,7 @@ BOOL ntlm_client_init(rdpNtlm* ntlm, BOOL http, char* user, char* domain, char* 
 	ntlm->http = http;
 	ntlm->Bindings = Bindings;
 
-	ntlm->table = InitSecurityInterfaceEx(SSPI_INTERFACE_WINPR);
+	ntlm->table = InitSecurityInterface();
 
 	if (!ntlm->table)
 		return FALSE;
@@ -85,7 +85,7 @@ BOOL ntlm_client_init(rdpNtlm* ntlm, BOOL http, char* user, char* domain, char* 
 	}
 	else
 	{
-		/** 
+		/**
 		 * flags for RPC authentication:
 		 * RPC_C_AUTHN_LEVEL_PKT_INTEGRITY:
 		 * ISC_REQ_USE_DCE_STYLE | ISC_REQ_DELEGATE | ISC_REQ_MUTUAL_AUTH |
@@ -122,7 +122,7 @@ BOOL ntlm_client_make_spn(rdpNtlm* ntlm, LPCTSTR ServiceClass, char* hostname)
 
 		if (!ntlm->ServicePrincipalName)
 			return FALSE;
-		
+
 		return TRUE;
 	}
 

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -211,7 +211,7 @@ int nla_client_init(rdpNla* nla)
 	nla->ServicePrincipalName = spn;
 #endif
 
-	nla->table = InitSecurityInterfaceEx(SSPI_INTERFACE_WINPR);
+	nla->table = InitSecurityInterface();
 	nla->status = nla->table->QuerySecurityPackageInfo(NLA_PKG_NAME, &nla->pPackageInfo);
 
 	if (nla->status != SEC_E_OK)
@@ -498,7 +498,7 @@ int nla_server_init(rdpNla* nla)
 	}
 	else
 	{
-		nla->table = InitSecurityInterfaceEx(0);
+		nla->table = InitSecurityInterface();
 	}
 
 	nla->status = nla->table->QuerySecurityPackageInfo(NLA_PKG_NAME, &nla->pPackageInfo);


### PR DESCRIPTION
Now always using default SSPI implementation instead of mixed native and WinPR.