### PR TITLE
winpr/synch: fix ResetEvent & improve CTest

### DIFF
--- a/winpr/libwinpr/synch/test/TestSynchEvent.c
+++ b/winpr/libwinpr/synch/test/TestSynchEvent.c
@@ -5,6 +5,19 @@
 int TestSynchEvent(int argc, char* argv[])
 {
 	HANDLE event;
+	int i;
+
+	if (ResetEvent(NULL))
+	{
+		printf("ResetEvent(NULL) unexpectedly succeeded\n");
+		return -1;
+	}
+
+	if (SetEvent(NULL))
+	{
+		printf("SetEvent(NULL) unexpectedly succeeded\n");
+		return -1;
+	}
 
 	event = CreateEvent(NULL, TRUE, TRUE, NULL);
 
@@ -16,23 +29,62 @@ int TestSynchEvent(int argc, char* argv[])
 
 	if (WaitForSingleObject(event, INFINITE) != WAIT_OBJECT_0)
 	{
-		printf("WaitForSingleObject(event, INFINITE) failure\n");
+		printf("WaitForSingleObject failure 1\n");
 		return -1;
 	}
 
-	ResetEvent(event);
+	if (!ResetEvent(event))
+	{
+		printf("ResetEvent failure with signaled event object\n");
+		return -1;
+	}
 
 	if (WaitForSingleObject(event, 0) != WAIT_TIMEOUT)
 	{
-		printf("WaitForSingleObject(event, 0) failure\n");
+		printf("WaitForSingleObject failure 2\n");
 		return -1;
 	}
 
-	SetEvent(event);
+	if (!ResetEvent(event))
+	{
+		/* Note: ResetEvent must also succeed if event is currently nonsignaled */
+		printf("ResetEvent failure with nonsignaled event object\n");
+		return -1;
+	}
+
+	if (!SetEvent(event))
+	{
+		printf("SetEvent failure with nonsignaled event object\n");
+		return -1;
+	}
 
 	if (WaitForSingleObject(event, 0) != WAIT_OBJECT_0)
 	{
-		printf("WaitForSingleObject(event, 0) failure\n");
+		printf("WaitForSingleObject failure 3\n");
+		return -1;
+	}
+
+	for (i = 0; i < 10000; i++)
+	{
+		if (!SetEvent(event))
+		{
+			printf("SetEvent failure with signaled event object (i = %d)\n", i);
+			return -1;
+		}
+	}
+
+	if (!ResetEvent(event))
+	{
+		printf("ResetEvent failure after multiple SetEvent calls\n");
+		return -1;
+	}
+
+	/* Independent of the amount of the previous SetEvent calls, a single
+	   ResetEvent must be sufficient to get into nonsignaled state */
+
+	if (WaitForSingleObject(event, 0) != WAIT_TIMEOUT)
+	{
+		printf("WaitForSingleObject failure 4\n");
 		return -1;
 	}
 


### PR DESCRIPTION
Unless there is an invalid parameter or internal error, ResetEvent must return TRUE, even if the object is in nonsignaled state.

Also fixed and improved the CTest TestSynchEvent to test for the expected/correct SetEvent and ResetEvent return values.