### PR TITLE
Extended certificate callbacks.

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -89,7 +89,12 @@ public class LibFreeRDP {
 
         boolean OnAuthenticate(StringBuilder username, StringBuilder domain, StringBuilder password);
 
-        boolean OnVerifiyCertificate(String subject, String issuer, String fingerprint);
+        int OnVerifiyCertificate(String commonName, String subject,
+                String issuer, String fingerprint, boolean mismatch);
+
+        int OnVerifiyChangedCertificate(String commonName, String subject,
+                String issuer, String fingerprint, String oldSubject,
+                String oldIssuer, String oldFingerprint);
 
         void OnGraphicsUpdate(int x, int y, int width, int height);
 
@@ -330,14 +335,30 @@ public class LibFreeRDP {
         return false;
     }
 
-    private static boolean OnVerifyCertificate(int inst, String subject, String issuer, String fingerprint) {
+    private static int OnVerifyCertificate(int inst, String commonName, String subject,
+                                           String issuer, String fingerprint, boolean
+                                                   hostMismatch) {
         SessionState s = GlobalApp.getSession(inst);
         if (s == null)
-            return false;
+            return 0;
         UIEventListener uiEventListener = s.getUIEventListener();
         if (uiEventListener != null)
-            return uiEventListener.OnVerifiyCertificate(subject, issuer, fingerprint);
-        return false;
+            return uiEventListener.OnVerifiyCertificate(commonName, subject, issuer, fingerprint,
+                    hostMismatch);
+        return 0;
+    }
+
+    private static int OnVerifyCertificate(int inst, String commonName, String subject,
+                                           String issuer, String fingerprint, String oldSubject,
+                                           String oldIssuer, String oldFingerprint) {
+        SessionState s = GlobalApp.getSession(inst);
+        if (s == null)
+            return 0;
+        UIEventListener uiEventListener = s.getUIEventListener();
+        if (uiEventListener != null)
+            return uiEventListener.OnVerifiyChangedCertificate(commonName, subject, issuer,
+                    fingerprint, oldSubject, oldIssuer, oldFingerprint);
+        return 0;
     }
 
     private static void OnGraphicsUpdate(int inst, int x, int y, int width, int height) {

--- a/client/Android/android_jni_callback.c
+++ b/client/Android/android_jni_callback.c
@@ -181,7 +181,7 @@ jint java_callback_int(jobject obj, const char * callback, const char* signature
 	jint res = -1;
 	JNIEnv *env;
 
-	DEBUG_ANDROID("java_callback: %s (%s)", callback, signature);
+	WLog_DBG(TAG, "java_callback: %s (%s)", callback, signature);
 
 	attached = jni_attach_thread(&env);
 

--- a/client/Android/android_jni_callback.c
+++ b/client/Android/android_jni_callback.c
@@ -172,6 +172,45 @@ finish:
 	return res;
 }
 
+/* callback with int result */
+jint java_callback_int(jobject obj, const char * callback, const char* signature, va_list args)
+{
+	jclass jObjClass;
+	jmethodID jCallback;
+	jboolean attached;
+	jint res = -1;
+	JNIEnv *env;
+
+	DEBUG_ANDROID("java_callback: %s (%s)", callback, signature);
+
+	attached = jni_attach_thread(&env);
+
+	jObjClass = (*env)->GetObjectClass(env, obj);
+
+	if (!jObjClass)
+	{
+		WLog_ERR(TAG, "android_java_callback: failed to get class reference");
+		goto finish;
+	}
+
+	jCallback = (*env)->GetStaticMethodID(env, jObjClass, callback, signature);
+
+	if (!jCallback)
+	{
+		WLog_ERR(TAG, "android_java_callback: failed to get method id");
+		goto finish;
+	}
+
+	res = (*env)->CallStaticIntMethodV(env, jObjClass, jCallback, args);
+
+finish:
+	if(attached == JNI_TRUE)
+		jni_detach_thread();
+
+	return res;
+}
+
+
 /* callback to freerdp class */
 void freerdp_callback(const char * callback, const char * signature, ...)
 {
@@ -186,6 +225,15 @@ jboolean freerdp_callback_bool_result(const char * callback, const char * signat
 	va_list vl;
 	va_start(vl, signature);
 	jboolean res = java_callback_bool(jLibFreeRDPObject, callback, signature, vl);
+	va_end(vl);
+	return res;
+}
+
+jint freerdp_callback_int_result(const char * callback, const char * signature, ...)
+{
+	va_list vl;
+ 	va_start(vl, signature);
+	jint res = java_callback_int(jLibFreeRDPObject, callback, signature, vl);
 	va_end(vl);
 	return res;
 }

--- a/client/Android/android_jni_callback.h
+++ b/client/Android/android_jni_callback.h
@@ -21,6 +21,7 @@ jboolean jni_attach_thread(JNIEnv** env);
 void jni_detach_thread(void);
 void freerdp_callback(const char * callback, const char * signature, ...);
 jboolean freerdp_callback_bool_result(const char * callback, const char * signature, ...);
+jint freerdp_callback_int_result(const char * callback, const char * signature, ...);
 
 #endif /* FREERDP_ANDROID_JNI_CALLBACK_H */
 

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -172,44 +172,82 @@ static void wl_post_disconnect(freerdp* instance)
 		wlf_DestroyWindow(context, context->window);
 }
 
-static BOOL wl_verify_certificate(freerdp* instance, char* subject, char* issuer, char* fingerprint)
+static DWORD wl_accept_certificate(rdpSettings* settings)
 {
 	char answer;
 
-	printf("Certificate details:\n");
-	printf("\tSubject: %s\n", subject);
-	printf("\tIssuer: %s\n", issuer);
-	printf("\tThumbprint: %s\n", fingerprint);
-	printf("The above X.509 certificate could not be verified, possibly because you do not have "
-		"the CA certificate in your certificate store, or the certificate has expired. "
-		"Please look at the documentation on how to create local certificate store for a private CA.\n");
-
 	while (1)
 	{
-		printf("Do you trust the above certificate? (Y/N) ");
+		printf("Do you trust the above certificate? (Y/T/N) ");
 		answer = fgetc(stdin);
 
 		if (feof(stdin))
 		{
 			printf("\nError: Could not read answer from stdin.");
-			if (instance->settings->CredentialsFromStdin)
+			if (settings->CredentialsFromStdin)
 				printf(" - Run without parameter \"--from-stdin\" to set trust.");
 			printf("\n");
-			return FALSE;
+			return 0;
 		}
 
-		if (answer == 'y' || answer == 'Y')
+		switch(answer)
 		{
-			return TRUE;
-		}
-		else if (answer == 'n' || answer == 'N')
-		{
-			break;
+			case 'y':
+			case 'Y':
+				return 1;
+			case 't':
+			case 'T':
+				return 2;
+			case 'n':
+			case 'N':
+				return 0;
+			default:
+				break;
 		}
 		printf("\n");
 	}
 
-	return FALSE;
+	return 0;
+}
+
+static DWORD wl_verify_certificate(freerdp* instance, const char* common_name,
+				   const char* subject, const char* issuer,
+				   const char* fingerprint, BOOL host_mismatch)
+{
+	printf("Certificate details:\n");
+	printf("\tSubject: %s\n", subject);
+	printf("\tIssuer: %s\n", issuer);
+	printf("\tThumbprint: %s\n", fingerprint);
+	printf("The above X.509 certificate could not be verified, possibly because you do not have\n"
+		"the CA certificate in your certificate store, or the certificate has expired.\n"
+		"Please look at the documentation on how to create local certificate store for a private CA.\n");
+
+	return wl_accept_certificate(instance->settings);
+}
+
+static DWORD wl_verify_changed_certificate(freerdp* instance, const char* common_name,
+					   const char* subject, const char* issuer,
+					   const char* fingerprint,
+					   const char* old_subject, const char* old_issuer,
+					   const char* old_fingerprint)
+{
+	printf("!!! Certificate has changed !!!\n");
+	printf("\n");
+	printf("New Certificate details:\n");
+	printf("\tSubject: %s\n", subject);
+	printf("\tIssuer: %s\n", issuer);
+	printf("\tThumbprint: %s\n", fingerprint);
+	printf("\n");
+	printf("Old Certificate details:\n");
+	printf("\tSubject: %s\n", old_subject);
+	printf("\tIssuer: %s\n", old_issuer);
+	printf("\tThumbprint: %s\n", old_fingerprint);
+	printf("\n");
+	printf("The above X.509 certificate does not match the certificate used for previous connections.\n"
+		"This may indicate that the certificate has been tampered with.\n"
+		"Please contact the administrator of the RDP server and clarify.\n");
+
+	return wl_accept_certificate(instance->settings);
 }
 
 static int wlfreerdp_run(freerdp* instance)
@@ -263,6 +301,7 @@ int main(int argc, char* argv[])
 	instance->PostConnect = wl_post_connect;
 	instance->PostDisconnect = wl_post_disconnect;
 	instance->VerifyCertificate = wl_verify_certificate;
+	instance->VerifyChangedCertificate = wl_verify_changed_certificate;
 
 	instance->ContextSize = sizeof(wlfContext);
 	instance->ContextNew = wl_context_new;

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -608,6 +608,31 @@ BOOL wf_verify_certificate(freerdp* instance, char* subject, char* issuer, char*
 	return TRUE;
 }
 
+static DWORD wf_verify_changed_certificate(freerdp* instance, const char* common_name,
+					   const char* subject, const char* issuer,
+					   const char* fingerprint,
+					   const char* old_subject, const char* old_issuer,
+					   const char* old_fingerprint)
+{
+	char answer;
+
+	WLog_ERR(TAG, "!!! Certificate has changed !!!");
+	WLog_ERR(TAG, "New Certificate details:");
+	WLog_ERR(TAG, "\tSubject: %s", subject);
+	WLog_ERR(TAG, "\tIssuer: %s", issuer);
+	WLog_ERR(TAG, "\tThumbprint: %s", fingerprint);
+	WLog_ERR(TAG, "Old Certificate details:");
+	WLog_ERR(TAG, "\tSubject: %s", old_subject);
+	WLog_ERR(TAG, "\tIssuer: %s", old_issuer);
+	WLog_ERR(TAG, "\tThumbprint: %s", old_fingerprint);
+	WLog_ERR(TAG, "The above X.509 certificate does not match the certificate used for previous connections. "
+		"This may indicate that the certificate has been tampered with."
+		"Please contact the administrator of the RDP server and clarify.");
+
+	return 0;
+}
+
+
 static BOOL wf_auto_reconnect(freerdp* instance)
 {
 	wfContext* wfc = (wfContext *)instance->context;
@@ -1081,6 +1106,7 @@ BOOL wfreerdp_client_new(freerdp* instance, rdpContext* context)
 	instance->Authenticate = wf_authenticate;
 	instance->GatewayAuthenticate = wf_gw_authenticate;
 	instance->VerifyCertificate = wf_verify_certificate;
+	instance->VerifyChangedCertificate = wf_verify_changed_certificate;
 
 	wfc->instance = instance;
 	wfc->settings = instance->settings;

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -102,8 +102,6 @@
 #include <freerdp/log.h>
 #define TAG CLIENT_TAG("x11")
 
-static const size_t password_size = 512;
-
 static int (*_def_error_handler)(Display*, XErrorEvent*);
 static int _xf_error_handler(Display* d, XErrorEvent* ev);
 static void xf_check_extensions(xfContext* context);
@@ -1357,211 +1355,6 @@ static void xf_post_disconnect(freerdp* instance)
 	xf_keyboard_free(xfc);
 }
 
-/** Callback set in the rdp_freerdp structure, and used to get the user's password,
- *  if required to establish the connection.
- *  This function is actually called in credssp_ntlmssp_client_init()
- *  @see rdp_server_accept_nego() and rdp_check_fds()
- *  @param instance - pointer to the rdp_freerdp structure that contains the connection settings
- *  @param username - unused
- *  @param password - on return: pointer to a character string that will be filled by the password entered by the user.
- *  				  Note that this character string will be allocated inside the function, and needs to be deallocated by the caller
- *  				  using free(), even in case this function fails.
- *  @param domain - unused
- *  @return TRUE if a password was successfully entered. See freerdp_passphrase_read() for more details.
- */
-static BOOL xf_authenticate_raw(freerdp* instance, BOOL gateway, char** username,
-		char** password, char** domain)
-{
-	const char* auth[] =
-	{
-		"Username: ",
-		"Domain:   ",
-		"Password: "
-	};
-	const char* gw[] =
-	{
-		"GatewayUsername: ",
-		"GatewayDomain:   ",
-		"GatewayPassword: "
-	};
-	const char** prompt = (gateway) ? gw : auth;
-
-	if (!username || !password || !domain)
-		return FALSE;
-
-	if (!*username)
-	{
-		size_t username_size = 0;
-		printf("%s", prompt[0]);
-		if (getline(username, &username_size, stdin) < 0)
-		{
-			WLog_ERR(TAG, "getline returned %s [%d]", strerror(errno), errno);
-			goto fail;
-		}
-
-		if (*username)
-		{
-			*username = StrSep(username, "\r");
-			*username = StrSep(username, "\n");
-		}
-	}
-
-	if (!*domain)
-	{
-		size_t domain_size = 0;
-		printf("%s", prompt[1]);
-		if (getline(domain, &domain_size, stdin) < 0)
-		{
-			WLog_ERR(TAG, "getline returned %s [%d]", strerror(errno), errno);
-			goto fail;
-		}
-
-		if (*domain)
-		{
-			*domain = StrSep(domain, "\r");
-			*domain = StrSep(domain, "\n");
-		}
-	}
-
-	if (!*password)
-	{
-		*password = calloc(password_size, sizeof(char));
-		if (!*password)
-			goto fail;
-
-		if (freerdp_passphrase_read(prompt[2], *password, password_size,
-			instance->settings->CredentialsFromStdin) == NULL)
-			goto fail;
-	}
-
-	return TRUE;
-
-fail:
-	free(*username);
-	free(*domain);
-	free(*password);
-
-	*username = NULL;
-	*domain = NULL;
-	*password = NULL;
-
-	return FALSE;
-}
-
-static BOOL xf_authenticate(freerdp* instance, char** username, char** password, char** domain)
-{
-	return xf_authenticate_raw(instance, FALSE, username, password, domain);
-}
-
-static BOOL xf_gw_authenticate(freerdp* instance, char** username, char** password, char** domain)
-{
-	return xf_authenticate_raw(instance, TRUE, username, password, domain);
-}
-
-static DWORD xf_accept_certificate(rdpSettings* settings)
-{
-	char answer;
-
-	while (1)
-	{
-		printf("Do you trust the above certificate? (Y/T/N) ");
-		answer = fgetc(stdin);
-
-		if (feof(stdin))
-		{
-			printf("\nError: Could not read answer from stdin.");
-			if (settings->CredentialsFromStdin)
-				printf(" - Run without parameter \"--from-stdin\" to set trust.");
-			printf("\n");
-			return 0;
-		}
-
-		switch(answer)
-		{
-			case 'y':
-			case 'Y':
-				return 1;
-			case 't':
-			case 'T':
-				return 2;
-			case 'n':
-			case 'N':
-				return 0;
-			default:
-				break;
-		}
-		printf("\n");
-	}
-
-	return 0;
-}
-
-/** Callback set in the rdp_freerdp structure, and used to make a certificate validation
- *  when the connection requires it.
- *  This function will actually be called by tls_verify_certificate().
- *  @see rdp_client_connect() and tls_connect()
- *  @param instance - pointer to the rdp_freerdp structure that contains the connection settings
- *  @param common_name
- *  @param subject
- *  @param issuer
- *  @param fingerprint
- *  @param host_mismatch Indicates the certificate host does not match.
- *  @return 1 if the certificate is trusted, 2 if temporary trusted, 0 otherwise.
- */
-static DWORD xf_verify_certificate(freerdp* instance, const char* common_name,
-				   const char* subject, const char* issuer,
-				   const char* fingerprint, BOOL host_mismatch)
-{
-	printf("Certificate details:\n");
-	printf("\tSubject: %s\n", subject);
-	printf("\tIssuer: %s\n", issuer);
-	printf("\tThumbprint: %s\n", fingerprint);
-	printf("The above X.509 certificate could not be verified, possibly because you do not have\n"
-		"the CA certificate in your certificate store, or the certificate has expired.\n"
-		"Please look at the documentation on how to create local certificate store for a private CA.\n");
-
-	return xf_accept_certificate(instance->settings);
-}
-
-/** Callback set in the rdp_freerdp structure, and used to make a certificate validation
- *  when a stored certificate does not match the remote counterpart.
- *  This function will actually be called by tls_verify_certificate().
- *  @see rdp_client_connect() and tls_connect()
- *  @param instance - pointer to the rdp_freerdp structure that contains the connection settings
- *  @param common_name
- *  @param subject
- *  @param issuer
- *  @param fingerprint
- *  @param old_subject
- *  @param old_issuer
- *  @param old_fingerprint
- *  @return 1 if the certificate is trusted, 2 if temporary trusted, 0 otherwise.
- */
-static DWORD xf_verify_changed_certificate(freerdp* instance, const char* common_name,
-					   const char* subject, const char* issuer,
-					   const char* fingerprint,
-					   const char* old_subject, const char* old_issuer,
-					   const char* old_fingerprint)
-{
-	printf("!!! Certificate has changed !!!\n");
-	printf("\n");
-	printf("New Certificate details:\n");
-	printf("\tSubject: %s\n", subject);
-	printf("\tIssuer: %s\n", issuer);
-	printf("\tThumbprint: %s\n", fingerprint);
-	printf("\n");
-	printf("Old Certificate details:\n");
-	printf("\tSubject: %s\n", old_subject);
-	printf("\tIssuer: %s\n", old_issuer);
-	printf("\tThumbprint: %s\n", old_fingerprint);
-	printf("\n");
-	printf("The above X.509 certificate does not match the certificate used for previous connections.\n"
-		"This may indicate that the certificate has been tampered with.\n"
-		"Please contact the administrator of the RDP server and clarify.\n");
-
-	return xf_accept_certificate(instance->settings);
-}
-
 int xf_logon_error_info(freerdp* instance, UINT32 data, UINT32 type)
 {
 	xfContext* xfc = (xfContext*) instance->context;
@@ -2009,10 +1802,10 @@ static BOOL xfreerdp_client_new(freerdp* instance, rdpContext* context)
 	instance->PreConnect = xf_pre_connect;
 	instance->PostConnect = xf_post_connect;
 	instance->PostDisconnect = xf_post_disconnect;
-	instance->Authenticate = xf_authenticate;
-	instance->GatewayAuthenticate = xf_gw_authenticate;
-	instance->VerifyCertificate = xf_verify_certificate;
-	instance->VerifyChangedCertificate = xf_verify_changed_certificate;
+	instance->Authenticate = client_cli_authenticate;
+	instance->GatewayAuthenticate = client_cli_gw_authenticate;
+	instance->VerifyCertificate = client_cli_verify_certificate;
+	instance->VerifyChangedCertificate = client_cli_verify_changed_certificate;
 	instance->LogonErrorInfo = xf_logon_error_info;
 
 	settings = instance->settings;

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -340,9 +340,9 @@ static BOOL client_cli_authenticate_raw(freerdp* instance, BOOL gateway, char** 
 	{
 		size_t username_size = 0;
 		printf("%s", prompt[0]);
-		if (getline(username, &username_size, stdin) < 0)
+		if (GetLine(username, &username_size, stdin) < 0)
 		{
-			WLog_ERR(TAG, "getline returned %s [%d]", strerror(errno), errno);
+			WLog_ERR(TAG, "GetLine returned %s [%d]", strerror(errno), errno);
 			goto fail;
 		}
 
@@ -357,9 +357,9 @@ static BOOL client_cli_authenticate_raw(freerdp* instance, BOOL gateway, char** 
 	{
 		size_t domain_size = 0;
 		printf("%s", prompt[1]);
-		if (getline(domain, &domain_size, stdin) < 0)
+		if (GetLine(domain, &domain_size, stdin) < 0)
 		{
-			WLog_ERR(TAG, "getline returned %s [%d]", strerror(errno), errno);
+			WLog_ERR(TAG, "GetLine returned %s [%d]", strerror(errno), errno);
 			goto fail;
 		}
 

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -21,13 +21,20 @@
 #include "config.h"
 #endif
 
+#include <string.h>
+#include <errno.h>
+
 #include <freerdp/client.h>
 
 #include <freerdp/addin.h>
 #include <freerdp/assistance.h>
 #include <freerdp/client/file.h>
+#include <freerdp/utils/passphrase.h>
 #include <freerdp/client/cmdline.h>
 #include <freerdp/client/channels.h>
+
+#include <freerdp/log.h>
+#define TAG CLIENT_TAG("common")
 
 static BOOL freerdp_client_common_new(freerdp* instance, rdpContext* context)
 {
@@ -295,4 +302,211 @@ int freerdp_client_settings_parse_assistance_file(rdpSettings* settings, const c
 
 	return 0;
 }
+
+/** Callback set in the rdp_freerdp structure, and used to get the user's password,
+ *  if required to establish the connection.
+ *  This function is actually called in credssp_ntlmssp_client_init()
+ *  @see rdp_server_accept_nego() and rdp_check_fds()
+ *  @param instance - pointer to the rdp_freerdp structure that contains the connection settings
+ *  @param username - unused
+ *  @param password - on return: pointer to a character string that will be filled by the password entered by the user.
+ *  				  Note that this character string will be allocated inside the function, and needs to be deallocated by the caller
+ *  				  using free(), even in case this function fails.
+ *  @param domain - unused
+ *  @return TRUE if a password was successfully entered. See freerdp_passphrase_read() for more details.
+ */
+static BOOL client_cli_authenticate_raw(freerdp* instance, BOOL gateway, char** username,
+		char** password, char** domain)
+{
+	static const size_t password_size = 512;
+	const char* auth[] =
+	{
+		"Username: ",
+		"Domain:   ",
+		"Password: "
+	};
+	const char* gw[] =
+	{
+		"GatewayUsername: ",
+		"GatewayDomain:   ",
+		"GatewayPassword: "
+	};
+	const char** prompt = (gateway) ? gw : auth;
+
+	if (!username || !password || !domain)
+		return FALSE;
+
+	if (!*username)
+	{
+		size_t username_size = 0;
+		printf("%s", prompt[0]);
+		if (getline(username, &username_size, stdin) < 0)
+		{
+			WLog_ERR(TAG, "getline returned %s [%d]", strerror(errno), errno);
+			goto fail;
+		}
+
+		if (*username)
+		{
+			*username = StrSep(username, "\r");
+			*username = StrSep(username, "\n");
+		}
+	}
+
+	if (!*domain)
+	{
+		size_t domain_size = 0;
+		printf("%s", prompt[1]);
+		if (getline(domain, &domain_size, stdin) < 0)
+		{
+			WLog_ERR(TAG, "getline returned %s [%d]", strerror(errno), errno);
+			goto fail;
+		}
+
+		if (*domain)
+		{
+			*domain = StrSep(domain, "\r");
+			*domain = StrSep(domain, "\n");
+		}
+	}
+
+	if (!*password)
+	{
+		*password = calloc(password_size, sizeof(char));
+		if (!*password)
+			goto fail;
+
+		if (freerdp_passphrase_read(prompt[2], *password, password_size,
+			instance->settings->CredentialsFromStdin) == NULL)
+			goto fail;
+	}
+
+	return TRUE;
+
+fail:
+	free(*username);
+	free(*domain);
+	free(*password);
+
+	*username = NULL;
+	*domain = NULL;
+	*password = NULL;
+
+	return FALSE;
+}
+
+BOOL client_cli_authenticate(freerdp* instance, char** username, char** password, char** domain)
+{
+	return client_cli_authenticate_raw(instance, FALSE, username, password, domain);
+}
+
+BOOL client_cli_gw_authenticate(freerdp* instance, char** username, char** password, char** domain)
+{
+	return client_cli_authenticate_raw(instance, TRUE, username, password, domain);
+}
+
+static DWORD client_cli_accept_certificate(rdpSettings* settings)
+{
+	char answer;
+
+	while (1)
+	{
+		printf("Do you trust the above certificate? (Y/T/N) ");
+		answer = fgetc(stdin);
+
+		if (feof(stdin))
+		{
+			printf("\nError: Could not read answer from stdin.");
+			if (settings->CredentialsFromStdin)
+				printf(" - Run without parameter \"--from-stdin\" to set trust.");
+			printf("\n");
+			return 0;
+		}
+
+		switch(answer)
+		{
+			case 'y':
+			case 'Y':
+				return 1;
+			case 't':
+			case 'T':
+				return 2;
+			case 'n':
+			case 'N':
+				return 0;
+			default:
+				break;
+		}
+		printf("\n");
+	}
+
+	return 0;
+}
+
+/** Callback set in the rdp_freerdp structure, and used to make a certificate validation
+ *  when the connection requires it.
+ *  This function will actually be called by tls_verify_certificate().
+ *  @see rdp_client_connect() and tls_connect()
+ *  @param instance - pointer to the rdp_freerdp structure that contains the connection settings
+ *  @param common_name
+ *  @param subject
+ *  @param issuer
+ *  @param fingerprint
+ *  @param host_mismatch Indicates the certificate host does not match.
+ *  @return 1 if the certificate is trusted, 2 if temporary trusted, 0 otherwise.
+ */
+DWORD client_cli_verify_certificate(freerdp* instance, const char* common_name,
+				   const char* subject, const char* issuer,
+				   const char* fingerprint, BOOL host_mismatch)
+{
+	printf("Certificate details:\n");
+	printf("\tSubject: %s\n", subject);
+	printf("\tIssuer: %s\n", issuer);
+	printf("\tThumbprint: %s\n", fingerprint);
+	printf("The above X.509 certificate could not be verified, possibly because you do not have\n"
+		"the CA certificate in your certificate store, or the certificate has expired.\n"
+		"Please look at the documentation on how to create local certificate store for a private CA.\n");
+
+	return client_cli_accept_certificate(instance->settings);
+}
+
+/** Callback set in the rdp_freerdp structure, and used to make a certificate validation
+ *  when a stored certificate does not match the remote counterpart.
+ *  This function will actually be called by tls_verify_certificate().
+ *  @see rdp_client_connect() and tls_connect()
+ *  @param instance - pointer to the rdp_freerdp structure that contains the connection settings
+ *  @param common_name
+ *  @param subject
+ *  @param issuer
+ *  @param fingerprint
+ *  @param old_subject
+ *  @param old_issuer
+ *  @param old_fingerprint
+ *  @return 1 if the certificate is trusted, 2 if temporary trusted, 0 otherwise.
+ */
+DWORD client_cli_verify_changed_certificate(freerdp* instance, const char* common_name,
+					   const char* subject, const char* issuer,
+					   const char* fingerprint,
+					   const char* old_subject, const char* old_issuer,
+					   const char* old_fingerprint)
+{
+	printf("!!! Certificate has changed !!!\n");
+	printf("\n");
+	printf("New Certificate details:\n");
+	printf("\tSubject: %s\n", subject);
+	printf("\tIssuer: %s\n", issuer);
+	printf("\tThumbprint: %s\n", fingerprint);
+	printf("\n");
+	printf("Old Certificate details:\n");
+	printf("\tSubject: %s\n", old_subject);
+	printf("\tIssuer: %s\n", old_issuer);
+	printf("\tThumbprint: %s\n", old_fingerprint);
+	printf("\n");
+	printf("The above X.509 certificate does not match the certificate used for previous connections.\n"
+		"This may indicate that the certificate has been tampered with.\n"
+		"Please contact the administrator of the RDP server and clarify.\n");
+
+	return client_cli_accept_certificate(instance->settings);
+}
+
 

--- a/client/iOS/FreeRDP/ios_freerdp_ui.h
+++ b/client/iOS/FreeRDP/ios_freerdp_ui.h
@@ -14,8 +14,15 @@ BOOL ios_ui_end_paint(rdpContext * context);
 BOOL ios_ui_resize_window(rdpContext * context);
 
 BOOL ios_ui_authenticate(freerdp * instance, char** username, char** password, char** domain);
-BOOL ios_ui_check_certificate(freerdp * instance, char * subject, char * issuer, char * fingerprint);
-BOOL ios_ui_check_changed_certificate(freerdp * instance, char * subject, char * issuer, char * new_fingerprint, char * old_fingerprint);
+DWORD ios_ui_check_certificate(freerdp * instance, const char* common_name,
+				const char * subject, const char * issuer,
+				const char * fingerprint, BOOL host_mismatch);
+DWORD ios_ui_check_changed_certificate(freerdp * instance,
+					const char* common_name,
+					const char * subject,
+					const char * issuer,
+					const char * new_fingerprint,
+					const char * old_fingerprint);
 
 void ios_allocate_display_buffer(mfInfo* mfi);
 void ios_resize_display_buffer(mfInfo* mfi);

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -94,6 +94,18 @@ FREERDP_API int freerdp_client_settings_write_connection_file(const rdpSettings*
 
 FREERDP_API int freerdp_client_settings_parse_assistance_file(rdpSettings* settings, const char* filename);
 
+FREERDP_API BOOL client_cli_authenticate(freerdp* instance, char** username, char** password, char** domain);
+FREERDP_API BOOL client_cli_gw_authenticate(freerdp* instance, char** username, char** password, char** domain);
+
+FREERDP_API DWORD client_cli_verify_certificate(freerdp* instance, const char* common_name,
+				   const char* subject, const char* issuer,
+				   const char* fingerprint, BOOL host_mismatch);
+
+FREERDP_API DWORD client_cli_verify_changed_certificate(freerdp* instance, const char* common_name,
+					   const char* subject, const char* issuer,
+					   const char* fingerprint,
+					   const char* old_subject, const char* old_issuer,
+					   const char* old_fingerprint);
 #ifdef __cplusplus
 }
 #endif

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -65,13 +65,55 @@ typedef void (*pContextFree)(freerdp* instance, rdpContext* context);
 typedef BOOL (*pPreConnect)(freerdp* instance);
 typedef BOOL (*pPostConnect)(freerdp* instance);
 typedef void (*pPostDisconnect)(freerdp* instance);
-typedef BOOL (*pAuthenticate)(freerdp* instance, char** username, char** password, char** domain);
-typedef BOOL (*pVerifyCertificate)(freerdp* instance, char* subject, char* issuer, char* fingerprint);
-typedef BOOL (*pVerifyChangedCertificate)(freerdp* instance, char* subject,
-                                          char* issuer, char* new_fingerprint,
-                                          char* old_subject, char* old_issuer,
-                                          char* old_fingerprint);
-typedef int (*pVerifyX509Certificate)(freerdp* instance, BYTE* data, int length, const char* hostname, int port, DWORD flags);
+typedef BOOL (*pAuthenticate)(freerdp* instance, char** username,
+			  char** password, char** domain);
+
+/** @brief Callback used if user interaction is required to accept
+ *         an unknown certificate.
+ *
+ *  @param common_name      The certificate registered hostname.
+ *  @param subject          The common name of the certificate.
+ *  @param issuer           The issuer of the certificate.
+ *  @param fingerprint      The fingerprint of the certificate.
+ *  @param host_mismatch    A flag indicating the certificate
+ *                          subject does not match the host connecting to.
+ *
+ *  @return 1 to accept and store a certificate, 2 to accept
+ *          a certificate only for this session, 0 otherwise.
+ */
+typedef DWORD (*pVerifyCertificate)(freerdp* instance,
+				const char* common_name,
+				const char* subject,
+				const char* issuer,
+				const char* fingerprint,
+				BOOL host_mismatch);
+
+/** @brief Callback used if user interaction is required to accept
+ *         a changed certificate.
+ *
+ *  @param common_name      The certificate registered hostname.
+ *  @param subject          The common name of the new certificate.
+ *  @param issuer           The issuer of the new certificate.
+ *  @param fingerprint      The fingerprint of the new certificate.
+ *  @param old_subject      The common name of the old certificate.
+ *  @param old_issuer       The issuer of the new certificate.
+ *  @param old_fingerprint  The fingerprint of the old certificate.
+ *
+ *  @return 1 to accept and store a certificate, 2 to accept
+ *          a certificate only for this session, 0 otherwise.
+ */
+
+typedef DWORD (*pVerifyChangedCertificate)(freerdp* instance,
+					const char* common_name,
+					const char* subject,
+					const char* issuer,
+					const char* new_fingerprint,
+					const char* old_subject,
+					const char* old_issuer,
+					const char* old_fingerprint);
+typedef int (*pVerifyX509Certificate)(freerdp* instance, BYTE* data,
+				int length, const char* hostname,
+				int port, DWORD flags);
 
 typedef int (*pLogonErrorInfo)(freerdp* instance, UINT32 data, UINT32 type);
 

--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -404,7 +404,8 @@ char* crypto_cert_subject(X509* xcert)
 char* crypto_cert_subject_common_name(X509* xcert, int* length)
 {
 	int index;
-	BYTE* common_name;
+	BYTE* common_name_raw;
+	char* common_name;
 	X509_NAME* subject_name;
 	X509_NAME_ENTRY* entry;
 	ASN1_STRING* entry_data;
@@ -429,10 +430,13 @@ char* crypto_cert_subject_common_name(X509* xcert, int* length)
 	if (entry_data == NULL)
 		return NULL;
 
-	*length = ASN1_STRING_to_UTF8(&common_name, entry_data);
+	*length = ASN1_STRING_to_UTF8(&common_name_raw, entry_data);
 
 	if (*length < 0)
 		return NULL;
+
+	common_name = _strdup(common_name_raw);
+	OPENSSL_free(common_name_raw);
 
 	return (char*) common_name;
 }

--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -435,7 +435,7 @@ char* crypto_cert_subject_common_name(X509* xcert, int* length)
 	if (*length < 0)
 		return NULL;
 
-	common_name = _strdup(common_name_raw);
+	common_name = _strdup((char*)common_name_raw);
 	OPENSSL_free(common_name_raw);
 
 	return (char*) common_name;

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1247,31 +1247,16 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, char* hostname, int por
 
 	/* if the certificate is valid and the certificate name matches, verification succeeds */
 	if (certificate_status && hostname_match)
-	{
-		if (common_name)
-		{
-			free(common_name);
-			common_name = NULL;
-		}
-
 		verification_status = TRUE; /* success! */
-	}
-
-	/* if the certificate is valid but the certificate name does not match, warn user, do not accept */
-	if (certificate_status && !hostname_match)
-		tls_print_certificate_name_mismatch_error(hostname, port,
-							  common_name, alt_names,
-							  alt_names_count);
 
 	/* verification could not succeed with OpenSSL, use known_hosts file and prompt user for manual verification */
-
-	if (!certificate_status)
+	if (!certificate_status || !hostname_match)
 	{
 		char* issuer;
 		char* subject;
 		char* fingerprint;
 		freerdp* instance = (freerdp*) tls->settings->instance;
-		BOOL accept_certificate = FALSE;
+		DWORD accept_certificate = 0;
 
 		issuer = crypto_cert_issuer(cert->px509);
 		subject = crypto_cert_subject(cert->px509);
@@ -1290,19 +1275,23 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, char* hostname, int por
 							alt_names_count);
 
 			if (instance->VerifyCertificate)
-			{
-				accept_certificate = instance->VerifyCertificate(instance, subject, issuer, fingerprint);
-			}
+				accept_certificate = instance->VerifyCertificate(instance, common_name,
+																				 subject, issuer, fingerprint, !hostname_match);
 
-			if (!accept_certificate)
+			switch(accept_certificate)
 			{
-				/* user did not accept, abort and do not add entry in known_hosts file */
-				verification_status = FALSE; /* failure! */
-			}
-			else
-			{
-				/* user accepted certificate, add entry in known_hosts file */
-				verification_status = certificate_data_print(tls->certificate_store, certificate_data);
+				case 1:
+					/* user accepted certificate, add entry in known_hosts file */
+					verification_status = certificate_data_print(tls->certificate_store, certificate_data);
+					break;
+				case 2:
+					/* user did accept temporaty, do not add to known hosts file */
+					verification_status = TRUE;
+					break;
+				default:
+					/* user did not accept, abort and do not add entry in known_hosts file */
+					verification_status = FALSE; /* failure! */
+					break;
 			}
 		}
 		else if (match == -1)
@@ -1324,28 +1313,31 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, char* hostname, int por
 			if (instance->VerifyChangedCertificate)
 			{
 				accept_certificate = instance->VerifyChangedCertificate(
-							     instance, subject, issuer,
+							     instance, common_name, subject, issuer,
 							     fingerprint, old_subject, old_issuer,
 							     old_fingerprint);
 			}
 
 			free(old_fingerprint);
 
-			if (!accept_certificate)
+			switch(accept_certificate)
 			{
-				/* user did not accept, abort and do not change known_hosts file */
-				verification_status = FALSE;  /* failure! */
-			}
-			else
-			{
-				/* user accepted new certificate, add replace fingerprint for this host in known_hosts file */
-				verification_status = certificate_data_replace(tls->certificate_store, certificate_data);
+				case 1:
+					/* user accepted certificate, add entry in known_hosts file */
+					verification_status = certificate_data_replace(tls->certificate_store, certificate_data);
+					break;
+				case 2:
+					/* user did accept temporaty, do not add to known hosts file */
+					verification_status = TRUE;
+					break;
+				default:
+					/* user did not accept, abort and do not add entry in known_hosts file */
+					verification_status = FALSE; /* failure! */
+					break;
 			}
 		}
 		else if (match == 0)
-		{
 			verification_status = TRUE; /* success! */
-		}
 
 		free(issuer);
 		free(subject);
@@ -1354,9 +1346,7 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, char* hostname, int por
 
 	certificate_data_free(certificate_data);
 
-#ifndef _WIN32
 	free(common_name);
-#endif
 
 	if (alt_names)
 		crypto_cert_subject_alt_name_free(alt_names_count, alt_names_lengths,

--- a/server/shadow/Win/win_rdp.c
+++ b/server/shadow/Win/win_rdp.c
@@ -99,9 +99,11 @@ BOOL shw_authenticate(freerdp* instance, char** username, char** password, char*
 	return TRUE;
 }
 
-BOOL shw_verify_certificate(freerdp* instance, char* subject, char* issuer, char* fingerprint)
+static DWORD shw_verify_certificate(freerdp* instance, const char* common_name,
+					const char* subject, const char* issuer,
+					const char* fingerprint, BOOL host_mismatch)
 {
-	return TRUE;
+	return 1;
 }
 
 int shw_verify_x509_certificate(freerdp* instance, BYTE* data, int length, const char* hostname, int port, DWORD flags)

--- a/winpr/include/winpr/string.h
+++ b/winpr/include/winpr/string.h
@@ -189,6 +189,8 @@ WINPR_API char* ConvertLineEndingToCRLF(const char* str, int* size);
 
 WINPR_API char* StrSep(char** stringp, const char* delim);
 
+WINPR_API INT64 GetLine(char** lineptr, size_t* size, FILE* stream);
+
 #ifdef __cplusplus
 }
 #endif

--- a/winpr/libwinpr/crt/string.c
+++ b/winpr/libwinpr/crt/string.c
@@ -515,7 +515,9 @@ INT64 GetLine(char** lineptr, size_t* size, FILE* stream)
     (*lineptr)[used] = '\0';
 
 	return used;
-#else
+#elif !defined(ANDROID) && !defined(IOS)
 	return getline(lineptr, size, stream);
+#else
+	return -1;
 #endif
 }

--- a/winpr/libwinpr/crt/string.c
+++ b/winpr/libwinpr/crt/string.c
@@ -22,6 +22,7 @@
 #endif
 
 #include <errno.h>
+#include <stdio.h>
 #include <wctype.h>
 
 #include <winpr/crt.h>
@@ -481,4 +482,40 @@ char* StrSep(char** stringp, const char* delim)
 	return start;
 }
 
+INT64 GetLine(char** lineptr, size_t* size, FILE* stream)
+{
+#if defined(_WIN32)
+	char c;
+	char *n;
+	size_t step = 32;
+	size_t used = 0;
 
+	if (!lineptr || !size)
+	{
+		errno = EINVAL;
+		return -1;
+	}
+
+	do
+	{
+		if (used + 2 >= *size)
+		{
+			*size += step;
+			n = realloc(*lineptr, *size);
+			if (!n)
+			{
+				return -1;
+			}
+			*lineptr = n;
+		}
+        c = fgetc(stream);
+        if (c != EOF)
+            (*lineptr)[used++] = c;
+    } while((c != '\n') && (c != '\r') && (c != EOF));
+    (*lineptr)[used] = '\0';
+
+	return used;
+#else
+	return getline(lineptr, size, stream);
+#endif
+}


### PR DESCRIPTION
* ```VerifyCertificate``` and ```VerifyChangedCertificate``` callbacks now have more arguments for more detailed certificate information.
* ```VerifyCertificate``` now also called, if the hostname does not match with argument set accordingly.