### PR TITLE
core: message channel pdu broken with rdp security

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -755,7 +755,12 @@ BOOL rdp_client_connect_auto_detect(rdpRdp* rdp, wStream* s)
 		{
 			if (channelId == rdp->mcs->messageChannelId)
 			{
-				if (rdp_recv_message_channel_pdu(rdp, s) == 0)
+				UINT16 securityFlags;
+
+				if (!rdp_read_security_header(s, &securityFlags))
+					return FALSE;
+
+				if (rdp_recv_message_channel_pdu(rdp, s, securityFlags) == 0)
 					return TRUE;
 			}
 		}

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -405,7 +405,11 @@ static int peer_recv_tpkt_pdu(freerdp_peer* client, wStream* s)
 	}
 	else if (rdp->mcs->messageChannelId && channelId == rdp->mcs->messageChannelId)
 	{
-		return rdp_recv_message_channel_pdu(rdp, s);
+		if (!rdp->settings->UseRdpSecurityLayer)
+			if (!rdp_read_security_header(s, &securityFlags))
+				return -1;
+
+		return rdp_recv_message_channel_pdu(rdp, s, securityFlags);
 	}
 	else
 	{

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -898,13 +898,8 @@ out_fail:
     return -1;
 }
 
-int rdp_recv_message_channel_pdu(rdpRdp* rdp, wStream* s)
+int rdp_recv_message_channel_pdu(rdpRdp* rdp, wStream* s, UINT16 securityFlags)
 {
-	UINT16 securityFlags;
-
-	if (!rdp_read_security_header(s, &securityFlags))
-		return -1;
-
 	if (securityFlags & SEC_AUTODETECT_REQ)
 	{
 		/* Server Auto-Detect Request PDU */
@@ -1162,7 +1157,11 @@ static int rdp_recv_tpkt_pdu(rdpRdp* rdp, wStream* s)
 	}
 	else if (rdp->mcs->messageChannelId && channelId == rdp->mcs->messageChannelId)
 	{
-		return rdp_recv_message_channel_pdu(rdp, s);
+		if (!rdp->settings->UseRdpSecurityLayer)
+			if (!rdp_read_security_header(s, &securityFlags))
+				return -1;
+
+		return rdp_recv_message_channel_pdu(rdp, s, securityFlags);
 	}
 	else
 	{

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -209,7 +209,7 @@ int rdp_send_channel_data(rdpRdp* rdp, UINT16 channelId, BYTE* data, int size);
 
 wStream* rdp_message_channel_pdu_init(rdpRdp* rdp);
 BOOL rdp_send_message_channel_pdu(rdpRdp* rdp, wStream* s, UINT16 sec_flags);
-int rdp_recv_message_channel_pdu(rdpRdp* rdp, wStream* s);
+int rdp_recv_message_channel_pdu(rdpRdp* rdp, wStream* s, UINT16 securityFlags);
 
 int rdp_recv_out_of_sequence_pdu(rdpRdp* rdp, wStream* s);
 


### PR DESCRIPTION
rdp_recv_message_channel_pdu always read the rdp security header even if it was already previously read (which is the case if rdp security is active)

This caused malfunctions and disconnects when heartbeat or bandwidth autodetect packets were sent/received in rdp security mode.

Credit goes to @MartinHaimberger for identifying the broken code part.
