### PR TITLE
core/metrics: prevent division by zero

### DIFF
--- a/libfreerdp/core/metrics.c
+++ b/libfreerdp/core/metrics.c
@@ -30,8 +30,10 @@ double metrics_write_bytes(rdpMetrics* metrics, UINT32 UncompressedBytes, UINT32
 	metrics->TotalUncompressedBytes += UncompressedBytes;
 	metrics->TotalCompressedBytes += CompressedBytes;
 
-	CompressionRatio = ((double) CompressedBytes) / ((double) UncompressedBytes);
-	metrics->TotalCompressionRatio = ((double) metrics->TotalCompressedBytes) / ((double) metrics->TotalUncompressedBytes);
+	if (UncompressedBytes != 0)
+		CompressionRatio = ((double) CompressedBytes) / ((double) UncompressedBytes);
+	if (metrics->TotalUncompressedBytes != 0)
+		metrics->TotalCompressionRatio = ((double) metrics->TotalCompressedBytes) / ((double) metrics->TotalUncompressedBytes);
 
 	return CompressionRatio;
 }


### PR DESCRIPTION
With most compilers this shouldn't happen but on some architectures a division by zero (can happen on the first call of metrics_write_bytes) could still cause a SIGFPE.