### PR TITLE
Connect timeout and abort

### DIFF
--- a/channels/urbdrc/client/urbdrc_main.c
+++ b/channels/urbdrc/client/urbdrc_main.c
@@ -472,7 +472,9 @@ static void* urbdrc_search_usb_device(void* arg)
 
 	/* Get the file descriptor (fd) for the monitor.
 	   This fd will get passed to select() */
-	if (!(mon_fd = CreateFileDescriptorEvent(NULL, TRUE, FALSE, udev_monitor_get_fd(mon))))
+	mon_fd = CreateFileDescriptorEvent(NULL, TRUE, FALSE,
+				udev_monitor_get_fd(mon), FD_READ);
+	if (!mon_fd)
 		goto fail_create_monfd_event;
 
 	while (1)

--- a/client/Android/FreeRDPCore/jni/android_freerdp.c
+++ b/client/Android/FreeRDPCore/jni/android_freerdp.c
@@ -348,10 +348,12 @@ static void* jni_input_thread(void* arg)
 	if (!(queue = freerdp_get_message_queue(instance, FREERDP_INPUT_MESSAGE_QUEUE)))
 		goto fail_get_message_queue;
 
-	if (!(event[0] = CreateFileDescriptorEvent(NULL, FALSE, FALSE, aCtx->event_queue->pipe_fd[0])))
+	if (!(event[0] = CreateFileDescriptorEvent(NULL, FALSE, FALSE,
+				aCtx->event_queue->pipe_fd[0], FD_READ)))
 		goto fail_create_event_0;
 
-	if (!(event[1] = CreateFileDescriptorEvent(NULL, FALSE, FALSE, aCtx->event_queue->pipe_fd[1])))
+	if (!(event[1] = CreateFileDescriptorEvent(NULL, FALSE, FALSE,
+				aCtx->event_queue->pipe_fd[1], FD_READ)))
 		goto fail_create_event_1;
 
 	if (!(event[2] = freerdp_get_message_queue_event_handle(instance, FREERDP_INPUT_MESSAGE_QUEUE)))

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1790,7 +1790,7 @@ static BOOL xfreerdp_client_new(freerdp* instance, rdpContext* context)
 	xfc->invert = (ImageByteOrder(xfc->display) == MSBFirst) ? TRUE : FALSE;
 	xfc->complex_regions = TRUE;
 
-	xfc->x11event = CreateFileDescriptorEvent(NULL, FALSE, FALSE, xfc->xfds);
+	xfc->x11event = CreateFileDescriptorEvent(NULL, FALSE, FALSE, xfc->xfds, FD_READ);
 	if (!xfc->x11event)
 	{
 		WLog_ERR(TAG, "Could not create xfds event");

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -130,7 +130,8 @@ struct rdp_context
 	ALIGN64 rdpMetrics* metrics; /* 41 */
 	ALIGN64 rdpCodecs* codecs; /* 42 */
 	ALIGN64 rdpAutoDetect* autodetect; /* 43 */
-	UINT64 paddingC[64 - 44]; /* 44 */
+	ALIGN64 HANDLE abortEvent; /* 45 */
+	UINT64 paddingC[64 - 45]; /* 45 */
 
 	UINT64 paddingD[96 - 64]; /* 64 */
 	UINT64 paddingE[128 - 96]; /* 96 */
@@ -244,6 +245,7 @@ FREERDP_API BOOL freerdp_context_new(freerdp* instance);
 FREERDP_API void freerdp_context_free(freerdp* instance);
 
 FREERDP_API BOOL freerdp_connect(freerdp* instance);
+FREERDP_API BOOL freerdp_abort_connect(freerdp* instance);
 FREERDP_API BOOL freerdp_shall_disconnect(freerdp* instance);
 FREERDP_API BOOL freerdp_disconnect(freerdp* instance);
 FREERDP_API BOOL freerdp_reconnect(freerdp* instance);

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -899,7 +899,8 @@ BOOL rdg_tls_out_connect(rdpRdg* rdg, const char* hostname, UINT16 port, int tim
 
 	assert(hostname != NULL);
 
-	sockfd = freerdp_tcp_connect(settings, settings->GatewayHostname, settings->GatewayPort, timeout);
+	sockfd = freerdp_tcp_connect(rdg->context, settings, settings->GatewayHostname,
+					settings->GatewayPort, timeout);
 
 	if (sockfd < 1)
 	{
@@ -955,7 +956,8 @@ BOOL rdg_tls_in_connect(rdpRdg* rdg, const char* hostname, UINT16 port, int time
 
 	assert(hostname != NULL);
 
-	sockfd = freerdp_tcp_connect(settings, settings->GatewayHostname, settings->GatewayPort, timeout);
+	sockfd = freerdp_tcp_connect(rdg->context, settings, settings->GatewayHostname,
+					settings->GatewayPort, timeout);
 
 	if (sockfd < 1)
 		return FALSE;

--- a/libfreerdp/core/gateway/rpc.c
+++ b/libfreerdp/core/gateway/rpc.c
@@ -760,7 +760,8 @@ int rpc_channel_tls_connect(RpcChannel* channel, int timeout)
 	rdpContext* context = rpc->context;
 	rdpSettings* settings = context->settings;
 
-	sockfd = freerdp_tcp_connect(settings, settings->GatewayHostname, settings->GatewayPort, timeout);
+	sockfd = freerdp_tcp_connect(context, settings, settings->GatewayHostname,
+					settings->GatewayPort, timeout);
 
 	if (sockfd < 1)
 		return -1;

--- a/libfreerdp/core/listener.c
+++ b/libfreerdp/core/listener.c
@@ -168,7 +168,8 @@ static BOOL freerdp_listener_open(freerdp_listener* instance, const char* bind_a
 		/* FIXME: these file descriptors do not work on Windows */
 
 		listener->sockfds[listener->num_sockfds] = sockfd;
-		listener->events[listener->num_sockfds] = CreateFileDescriptorEvent(NULL, FALSE, FALSE, sockfd);
+		listener->events[listener->num_sockfds] =
+			CreateFileDescriptorEvent(NULL, FALSE, FALSE, sockfd, FD_READ);
 		listener->num_sockfds++;
 
 		WLog_INFO(TAG, "Listening on %s:%s", addr, servname);
@@ -226,7 +227,8 @@ static BOOL freerdp_listener_open_local(freerdp_listener* instance, const char* 
 		return FALSE;
 	}
 
-	if (!(hevent = CreateFileDescriptorEvent(NULL, FALSE, FALSE, sockfd)))
+	hevent = CreateFileDescriptorEvent(NULL, FALSE, FALSE, sockfd, FD_READ);
+	if (!hevent)
 	{
 		WLog_ERR(TAG, "failed to create sockfd event");
 		closesocket((SOCKET) sockfd);
@@ -258,7 +260,8 @@ static BOOL freerdp_listener_open_from_socket(freerdp_listener* instance, int fd
 		return FALSE;
 
 	listener->sockfds[listener->num_sockfds] = fd;
-	listener->events[listener->num_sockfds] = CreateFileDescriptorEvent(NULL, FALSE, FALSE, fd);
+	listener->events[listener->num_sockfds] =
+		CreateFileDescriptorEvent(NULL, FALSE, FALSE, fd, FD_READ);
 	if (!listener->events[listener->num_sockfds])
 		return FALSE;
 

--- a/libfreerdp/core/tcp.h
+++ b/libfreerdp/core/tcp.h
@@ -25,6 +25,7 @@
 
 #include <freerdp/types.h>
 #include <freerdp/settings.h>
+#include <freerdp/freerdp.h>
 
 #include <winpr/crt.h>
 #include <winpr/synch.h>
@@ -60,6 +61,7 @@
 BIO_METHOD* BIO_s_simple_socket(void);
 BIO_METHOD* BIO_s_buffered_socket(void);
 
-int freerdp_tcp_connect(rdpSettings* settings, const char* hostname, int port, int timeout);
+int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings,
+			const char* hostname, int port, int timeout);
 
 #endif /* __TCP_H */

--- a/libfreerdp/core/test/CMakeLists.txt
+++ b/libfreerdp/core/test/CMakeLists.txt
@@ -22,6 +22,7 @@ create_test_sourcelist(${MODULE_PREFIX}_SRCS
 add_executable(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
 
 add_definitions(-DTESTING_OUTPUT_DIRECTORY="${CMAKE_BINARY_DIR}")
+add_definitions(-DTESTING_SRC_DIRECTORY="${CMAKE_SOURCE_DIR}")
 
 target_link_libraries(${MODULE_NAME} freerdp-client freerdp winpr)
 

--- a/libfreerdp/core/test/CMakeLists.txt
+++ b/libfreerdp/core/test/CMakeLists.txt
@@ -5,9 +5,15 @@ set(MODULE_PREFIX "TEST_CORE")
 set(${MODULE_PREFIX}_DRIVER ${MODULE_NAME}.c)
 
 set(${MODULE_PREFIX}_TESTS
-	TestConnect.c
 	TestVersion.c
 	TestSettings.c)
+
+if(WITH_SAMPLE AND WITH_SERVER)
+set(${MODULE_PREFIX}_TESTS
+	TestConnect.c)
+else()
+	message("Skipping connection tests, requires WITH_SAMPLE and WITH_SERVER set!")
+endif()
 
 create_test_sourcelist(${MODULE_PREFIX}_SRCS
 	${${MODULE_PREFIX}_DRIVER}

--- a/libfreerdp/core/test/CMakeLists.txt
+++ b/libfreerdp/core/test/CMakeLists.txt
@@ -5,6 +5,7 @@ set(MODULE_PREFIX "TEST_CORE")
 set(${MODULE_PREFIX}_DRIVER ${MODULE_NAME}.c)
 
 set(${MODULE_PREFIX}_TESTS
+	TestConnect.c
 	TestVersion.c
 	TestSettings.c)
 
@@ -14,7 +15,9 @@ create_test_sourcelist(${MODULE_PREFIX}_SRCS
 
 add_executable(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
 
-target_link_libraries(${MODULE_NAME} freerdp)
+add_definitions(-DTESTING_OUTPUT_DIRECTORY="${CMAKE_BINARY_DIR}")
+
+target_link_libraries(${MODULE_NAME} freerdp-client freerdp winpr)
 
 set_target_properties(${MODULE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${TESTING_OUTPUT_DIRECTORY}")
 

--- a/libfreerdp/core/test/TestConnect.c
+++ b/libfreerdp/core/test/TestConnect.c
@@ -3,200 +3,228 @@
 #include <freerdp/freerdp.h>
 #include <freerdp/client/cmdline.h>
 
+static HANDLE s_sync = NULL;
+
 static int runInstance(int argc, char* argv[], freerdp** inst)
 {
-    int rc = -1;
+	int rc = -1;
 
-    freerdp* instance = freerdp_new();
-    if (!instance)
-        goto finish;
+	freerdp* instance = freerdp_new();
+	if (!instance)
+		goto finish;
 
-    if (inst)
-        *inst = instance;
+	if (inst)
+		*inst = instance;
 
-    if (!freerdp_context_new(instance))
-        goto finish;
+	if (!freerdp_context_new(instance))
+		goto finish;
 
-    if (freerdp_client_settings_parse_command_line(instance->settings, argc, argv, FALSE) < 0)
-        goto finish;
+	if (freerdp_client_settings_parse_command_line(instance->settings, argc, argv, FALSE) < 0)
+		goto finish;
 
-    if (freerdp_client_load_addins(instance->context->channels, instance->settings) != 1)
-        goto finish;
+	if (freerdp_client_load_addins(instance->context->channels, instance->settings) != 1)
+		goto finish;
 
-    rc = 1;
-    if (!freerdp_connect(instance))
-        goto finish;
+	if (s_sync)
+	{
+		if (!SetEvent(s_sync))
+			goto finish;
+	}
 
-    rc = 2;
-    if (!freerdp_disconnect(instance))
-        goto finish;
+	rc = 1;
+	if (!freerdp_connect(instance))
+		goto finish;
 
-    rc = 0;
+	rc = 2;
+	if (!freerdp_disconnect(instance))
+		goto finish;
+
+	rc = 0;
 
 finish:
-    freerdp_context_free(instance);
-    freerdp_free(instance);
+	freerdp_context_free(instance);
+	freerdp_free(instance);
 
-    return rc;
+	return rc;
 }
 
 static int testTimeout(void)
 {
-    DWORD start, end, diff;
-    char* argv[] =
-    {
-        "test",
-        "/v:192.0.2.1",
-        NULL
-    };
+	DWORD start, end, diff;
+	char* argv[] =
+	{
+		"test",
+		"/v:192.0.2.1",
+		NULL
+	};
 
-    int rc;
-    
-    start = GetTickCount();
-    rc = runInstance(2, argv, NULL);
-    end = GetTickCount();
+	int rc;
 
-    if (rc != 1)
-        return -1;
+	start = GetTickCount();
+	rc = runInstance(2, argv, NULL);
+	end = GetTickCount();
 
-    diff = end - start;
-    if (diff > 16000)
-        return -1;
+	if (rc != 1)
+		return -1;
 
-    if (diff < 14000)
-        return -1;
+	diff = end - start;
+	if (diff > 16000)
+		return -1;
 
-    printf("%s: Success!\n", __FUNCTION__);
-    return 0;
+	if (diff < 14000)
+		return -1;
+
+	printf("%s: Success!\n", __FUNCTION__);
+	return 0;
 }
 
 static void* testThread(void* arg)
 {
-    char* argv[] =
-    {
-        "test",
-        "/v:192.0.2.1",
-        NULL
-    };
+	char* argv[] =
+	{
+		"test",
+		"/v:192.0.2.1",
+		NULL
+	};
 
-    int rc;
-    
-    rc = runInstance(2, argv, arg);
+	int rc;
 
-    if (rc != 1)
-        ExitThread(-1);
+	rc = runInstance(2, argv, arg);
 
-    ExitThread(0);
-    return NULL;
+	if (rc != 1)
+		ExitThread(-1);
+
+	ExitThread(0);
+	return NULL;
 }
 
 static int testAbort(void)
 {
-    DWORD status;
-    DWORD start, end, diff;
-    HANDLE thread;
-    freerdp* instance = NULL;
+	DWORD status;
+	DWORD start, end, diff;
+	HANDLE thread;
+	freerdp* instance = NULL;
 
-    start = GetTickCount();
-    thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)testThread,
-                &instance, 0, NULL);
-    if (!thread)
-        return -1;
+	s_sync = CreateEvent(NULL, TRUE, FALSE, NULL);
+	if (!s_sync)
+		return -1;
 
-    freerdp_abort_connect(instance);
-    status = WaitForSingleObject(thread, 20000);
-    end = GetTickCount();
+	start = GetTickCount();
+	thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)testThread,
+				&instance, 0, NULL);
+	if (!thread)
+	{
+		CloseHandle(s_sync);
+		s_sync = NULL;
+		return -1;
+	}
 
-    CloseHandle(thread);
+	WaitForSingleObject(s_sync, INFINITE);
+	freerdp_abort_connect(instance);
+	status = WaitForSingleObject(instance->context->abortEvent, 0);
+	if (status != WAIT_OBJECT_0)
+	{
+		CloseHandle(s_sync);
+		CloseHandle(thread);
+		s_sync = NULL;
+		return -1;
+	}
 
-    diff = end - start;
-    if (diff > 1000)
-        return -1;
+	status = WaitForSingleObject(thread, 20000);
+	end = GetTickCount();
 
-    if (WAIT_OBJECT_0 != status)
-        return -1;
+	CloseHandle(s_sync);
+	CloseHandle(thread);
+	s_sync = NULL;
 
-    printf("%s: Success!\n", __FUNCTION__);
-    return 0;
+	diff = end - start;
+	if (diff > 1000)
+		return -1;
+
+	if (WAIT_OBJECT_0 != status)
+		return -1;
+
+	printf("%s: Success!\n", __FUNCTION__);
+	return 0;
 }
 
 static int testSuccess(void)
 {
-    int rc;
-    STARTUPINFO si;
-    PROCESS_INFORMATION process;
-    char* argv[] =
-    {
-        "test",
-        "/v:127.0.0.1",
-        "/cert-ignore",
-        "/u:foo",
-        NULL
-    };
-    char* path = TESTING_OUTPUT_DIRECTORY;
-    char* exe = GetCombinedPath(path, "server");
+	int rc;
+	STARTUPINFO si;
+	PROCESS_INFORMATION process;
+	char* argv[] =
+	{
+		"test",
+		"/v:127.0.0.1",
+		"/cert-ignore",
+		NULL
+	};
+	char* path = TESTING_OUTPUT_DIRECTORY;
+	char* exe = GetCombinedPath(path, "server");
 
-    if (!exe)
-        return -2;
+	if (!exe)
+		return -2;
 
-    path = GetCombinedPath(exe, "Sample");
-    free(exe);
+	path = GetCombinedPath(exe, "Sample");
+	free(exe);
 
-    if (!path)
-        return -2;
+	if (!path)
+		return -2;
 
-    exe = GetCombinedPath(path, "sfreerdp-server");
+	exe = GetCombinedPath(path, "sfreerdp-server");
 
-    if (!exe)
-    {
-        free(path);
-        return -2;
-    }
+	if (!exe)
+	{
+		free(path);
+		return -2;
+	}
 
-    // Start sample server locally. 
-    if (!CreateProcessA(exe, exe, NULL, NULL, FALSE, 0, NULL,
-                path, &si, &process))
-    {
-        free(exe);
-        free(path);
-        return -2;
-    }
-   
-    free(exe);
-    free(path);
+	// Start sample server locally. 
+	if (!CreateProcessA(exe, exe, NULL, NULL, FALSE, 0, NULL,
+				path, &si, &process))
+	{
+		free(exe);
+		free(path);
+		return -2;
+	}
 
-    rc = runInstance(4, argv, NULL);
+	free(exe);
+	free(path);
 
-    if (!TerminateProcess(process.hProcess, 0))
-        return -2;
+	Sleep(500);
+	rc = runInstance(3, argv, NULL);
 
-    WaitForSingleObject(process.hProcess, INFINITE);
-    CloseHandle(process.hProcess);
-    CloseHandle(process.hThread);
+	if (!TerminateProcess(process.hProcess, 0))
+		return -2;
 
-    if (rc)
-        return -1;
+	WaitForSingleObject(process.hProcess, INFINITE);
+	CloseHandle(process.hProcess);
+	CloseHandle(process.hThread);
 
-    printf("%s: Success!\n", __FUNCTION__);
-    return 0;
+	if (rc)
+		return -1;
+
+	printf("%s: Success!\n", __FUNCTION__);
+	return 0;
 }
 
 int TestConnect(int argc, char* argv[])
 {
-    /* Test connect to not existing server,
-     * check if timeout is honored. */
-    if (testTimeout())
-        return -1;
+	/* Test connect to not existing server,
+	 * check if timeout is honored. */
+	if (testTimeout())
+		return -1;
 
-    /* Test connect to not existing server,
-     * check if connection abort is working. */
-    if (testAbort())
-        return -1;
+	/* Test connect to not existing server,
+	 * check if connection abort is working. */
+	if (testAbort())
+		return -1;
 
-    /* Test connect to existing server,
-     * check if connection is working. */
-    if (testSuccess())
-        return -1;
+	/* Test connect to existing server,
+	 * check if connection is working. */
+	if (testSuccess())
+		return -1;
 
 	return 0;
 }

--- a/libfreerdp/core/test/TestConnect.c
+++ b/libfreerdp/core/test/TestConnect.c
@@ -1,0 +1,144 @@
+#include <winpr/sysinfo.h>
+#include <freerdp/freerdp.h>
+#include <freerdp/client/cmdline.h>
+
+static int runInstance(int argc, char* argv[], freerdp** inst)
+{
+    int rc = -1;
+
+    freerdp* instance = freerdp_new();
+    if (!instance)
+        goto finish;
+
+    if (inst)
+        *inst = instance;
+
+    if (!freerdp_context_new(instance))
+        goto finish;
+
+    if (freerdp_client_settings_parse_command_line(instance->settings, argc, argv, FALSE) < 0)
+        goto finish;
+
+    if (freerdp_client_load_addins(instance->context->channels, instance->settings) != 1)
+        goto finish;
+
+    rc = 1;
+    if (!freerdp_connect(instance))
+        goto finish;
+
+    rc = 2;
+    if (!freerdp_disconnect(instance))
+        goto finish;
+
+    rc = 0;
+
+finish:
+    freerdp_context_free(instance);
+    freerdp_free(instance);
+
+    return rc;
+}
+
+static int testTimeout(void)
+{
+    DWORD start, end, diff;
+    char* argv[] =
+    {
+        "test",
+        "/v:192.0.2.1",
+        NULL
+    };
+
+    int rc;
+    
+    start = GetTickCount();
+    rc = runInstance(2, argv, NULL);
+    end = GetTickCount();
+
+    if (rc != 1)
+        return -1;
+
+    diff = end - start;
+    if (diff > 16000)
+        return -1;
+
+    if (diff < 14000)
+        return -1;
+
+    return 0;
+}
+
+static void* testThread(void* arg)
+{
+    char* argv[] =
+    {
+        "test",
+        "/v:192.0.2.1",
+        NULL
+    };
+
+    int rc;
+    
+    rc = runInstance(2, argv, arg);
+
+    if (rc != 1)
+        ExitThread(-1);
+
+    ExitThread(0);
+    return NULL;
+}
+
+static int testAbort(void)
+{
+    DWORD status;
+    DWORD start, end, diff;
+    HANDLE thread;
+    freerdp* instance = NULL;
+
+    start = GetTickCount();
+    thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)testThread,
+                &instance, 0, NULL);
+    if (!thread)
+        return -1;
+
+    freerdp_abort_connect(instance);
+    status = WaitForSingleObject(thread, 20000);
+    end = GetTickCount();
+
+    CloseHandle(thread);
+
+    diff = end - start;
+    if (diff > 1000)
+        return -1;
+
+    if (WAIT_OBJECT_0 != status)
+        return -1;
+
+    return 0;
+}
+
+static int testSuccess(void)
+{
+    return 0;
+}
+
+int TestConnect(int argc, char* argv[])
+{
+    /* Test connect to not existing server,
+     * check if timeout is honored. */
+//    if (testTimeout())
+//        return -1;
+
+    /* Test connect to not existing server,
+     * check if connection abort is working. */
+    if (testAbort())
+        return -1;
+
+    /* Test connect to existing server,
+     * check if connection is working. */
+    if (testSuccess())
+        return -1;
+
+	return 0;
+}
+

--- a/libfreerdp/core/test/TestConnect.c
+++ b/libfreerdp/core/test/TestConnect.c
@@ -180,6 +180,14 @@ static int testSuccess(void)
 		return -2;
 	}
 
+	printf("Sample Server: %s\n", exe);
+	if (!PathFileExistsA(exe))
+	{
+		free(path);
+		free(exe);
+		return -2;
+	}
+
 	// Start sample server locally. 
 	if (!CreateProcessA(exe, exe, NULL, NULL, FALSE, 0, NULL,
 				path, &si, &process))

--- a/libfreerdp/core/test/TestConnect.c
+++ b/libfreerdp/core/test/TestConnect.c
@@ -192,7 +192,7 @@ static int testSuccess(void)
 	free(exe);
 	free(path);
 
-	Sleep(500);
+	Sleep(1000);
 	rc = runInstance(3, argv, NULL);
 
 	if (!TerminateProcess(process.hProcess, 0))
@@ -202,6 +202,7 @@ static int testSuccess(void)
 	CloseHandle(process.hProcess);
 	CloseHandle(process.hThread);
 
+	printf("%s: returned %d!\n", __FUNCTION__, rc);
 	if (rc)
 		return -1;
 

--- a/libfreerdp/core/test/TestConnect.c
+++ b/libfreerdp/core/test/TestConnect.c
@@ -161,44 +161,61 @@ static int testSuccess(void)
 		NULL
 	};
 	char* path = TESTING_OUTPUT_DIRECTORY;
+	char* wpath = TESTING_SRC_DIRECTORY;
 	char* exe = GetCombinedPath(path, "server");
+	char* wexe = GetCombinedPath(wpath, "server");
 
-	if (!exe)
+	if (!exe || !wexe)
+	{
+		free(exe);
+		free(wexe);
 		return -2;
+	}
 
 	path = GetCombinedPath(exe, "Sample");
+	wpath = GetCombinedPath(wexe, "Sample");
 	free(exe);
+	free(wexe);
 
-	if (!path)
+	if (!path || !wpath)
+	{
+		free(path);
+		free(wpath);
 		return -2;
+	}
 
 	exe = GetCombinedPath(path, "sfreerdp-server");
 
 	if (!exe)
 	{
 		free(path);
+		free(wpath);
 		return -2;
 	}
 
 	printf("Sample Server: %s\n", exe);
+	printf("Workspace: %s\n", wpath);
 	if (!PathFileExistsA(exe))
 	{
 		free(path);
+		free(wpath);
 		free(exe);
 		return -2;
 	}
 
 	// Start sample server locally. 
 	if (!CreateProcessA(exe, exe, NULL, NULL, FALSE, 0, NULL,
-				path, &si, &process))
+				wpath, &si, &process))
 	{
 		free(exe);
 		free(path);
+		free(wpath);
 		return -2;
 	}
 
 	free(exe);
 	free(path);
+	free(wpath);
 
 	Sleep(1000);
 	rc = runInstance(3, argv, NULL);

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -204,6 +204,7 @@ BOOL transport_connect(rdpTransport* transport, const char* hostname, UINT16 por
 	int sockfd;
 	BOOL status = FALSE;
 	rdpSettings* settings = transport->settings;
+	rdpContext* context = transport->context;
 
 	transport->async = settings->AsyncTransport;
 
@@ -256,7 +257,7 @@ BOOL transport_connect(rdpTransport* transport, const char* hostname, UINT16 por
 	}
 	else
 	{
-		sockfd = freerdp_tcp_connect(settings, hostname, port, timeout);
+		sockfd = freerdp_tcp_connect(context, settings, hostname, port, timeout);
 
 		if (sockfd < 1)
 			return FALSE;

--- a/server/Sample/sfreerdp.c
+++ b/server/Sample/sfreerdp.c
@@ -28,6 +28,7 @@
 
 #include <winpr/crt.h>
 #include <winpr/synch.h>
+#include <winpr/path.h>
 #include <winpr/winsock.h>
 
 #include <freerdp/channels/wtsvc.h>
@@ -873,30 +874,60 @@ int main(int argc, char* argv[])
 {
 	WSADATA wsaData;
 	freerdp_listener* instance;
+	char* file;
+	int port = 3389, i;
+
+	for (i=1; i<argc; i++)
+	{
+		char* arg = argv[i];
+
+		if (strncmp(arg, "--fast", 7) == 0)
+			test_dump_rfx_realtime = FALSE;
+		else if (strncmp(arg, "--port=", 7) == 0)
+		{
+			StrSep(&arg, "=");
+			if (!arg)
+				return -1;
+
+			port = strtol(arg, NULL, 10);
+			if ((port < 1) || (port > 0xFFFF))
+				return -1;
+		}
+		else if (strncmp(arg, "--", 2))
+			test_pcap_file = arg;
+	}
 
 	WTSRegisterWtsApiFunctionTable(FreeRDP_InitWtsApi());
 	instance = freerdp_listener_new();
+	if (!instance)
+		return -1;
 
 	instance->PeerAccepted = test_peer_accepted;
 
-	if (argc > 1)
-		test_pcap_file = argv[1];
-
-	if (argc > 2 && !strcmp(argv[2], "--fast"))
-		test_dump_rfx_realtime = FALSE;
 
 	if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0)
-		return 0;
+	{
+		freerdp_listener_free(instance);
+		return -1;
+	}
 
 	/* Open the server socket and start listening. */
+	file = GetKnownSubPath(KNOWN_PATH_TEMP, "tfreerdp-server.0");
+	if (!file)
+	{
+		freerdp_listener_free(instance);
+		WSACleanup();
+		return -1;
+	}
 
-	if (instance->Open(instance, NULL, 3389) &&
-		instance->OpenLocal(instance, "/tmp/tfreerdp-server.0"))
+	if (instance->Open(instance, NULL, port) &&
+		instance->OpenLocal(instance, file))
 	{
 		/* Entering the server main loop. In a real server the listener can be run in its own thread. */
 		test_server_mainloop(instance);
 	}
 
+	free (file);
 	freerdp_listener_free(instance);
 
 	WSACleanup();

--- a/server/shadow/X11/x11_shadow.c
+++ b/server/shadow/X11/x11_shadow.c
@@ -1265,7 +1265,8 @@ int x11_shadow_subsystem_init(x11ShadowSubsystem* subsystem)
 			subsystem->use_xdamage = FALSE;
 	}
 
-	if (!(subsystem->event = CreateFileDescriptorEvent(NULL, FALSE, FALSE, subsystem->xfds)))
+	if (!(subsystem->event = CreateFileDescriptorEvent(NULL, FALSE, FALSE,
+							subsystem->xfds, FD_READ)))
 		return -1;
 
 	virtualScreen = &(subsystem->virtualScreen);

--- a/winpr/include/winpr/debug.h
+++ b/winpr/include/winpr/debug.h
@@ -27,6 +27,7 @@ extern "C" {
 
 #include <winpr/wtypes.h>
 
+WINPR_API void winpr_log_backtrace(const char* tag, DWORD level, DWORD size);
 WINPR_API void* winpr_backtrace(DWORD size);
 WINPR_API void winpr_backtrace_free(void* buffer);
 WINPR_API char** winpr_backtrace_symbols(void* buffer, size_t* used);

--- a/winpr/include/winpr/handle.h
+++ b/winpr/include/winpr/handle.h
@@ -41,8 +41,12 @@ extern "C" {
 
 WINPR_API BOOL CloseHandle(HANDLE hObject);
 
-WINPR_API BOOL DuplicateHandle(HANDLE hSourceProcessHandle, HANDLE hSourceHandle, HANDLE hTargetProcessHandle,
-	LPHANDLE lpTargetHandle, DWORD dwDesiredAccess, BOOL bInheritHandle, DWORD dwOptions);
+WINPR_API BOOL DuplicateHandle(HANDLE hSourceProcessHandle,
+				HANDLE hSourceHandle,
+				HANDLE hTargetProcessHandle,
+				LPHANDLE lpTargetHandle,
+				DWORD dwDesiredAccess,
+				BOOL bInheritHandle, DWORD dwOptions);
 
 WINPR_API BOOL GetHandleInformation(HANDLE hObject, LPDWORD lpdwFlags);
 WINPR_API BOOL SetHandleInformation(HANDLE hObject, DWORD dwMask, DWORD dwFlags);

--- a/winpr/include/winpr/synch.h
+++ b/winpr/include/winpr/synch.h
@@ -30,6 +30,7 @@
 #include <winpr/wtypes.h>
 #include <winpr/error.h>
 #include <winpr/handle.h>
+#include <winpr/winsock.h>
 
 #include <winpr/nt.h>
 
@@ -338,9 +339,9 @@ WINPR_API BOOL WINAPI DeleteSynchronizationBarrier(LPSYNCHRONIZATION_BARRIER lpB
 WINPR_API VOID USleep(DWORD dwMicroseconds);
 
 WINPR_API HANDLE CreateFileDescriptorEventW(LPSECURITY_ATTRIBUTES lpEventAttributes,
-		BOOL bManualReset, BOOL bInitialState, int FileDescriptor);
+		BOOL bManualReset, BOOL bInitialState, int FileDescriptor, ULONG mode);
 WINPR_API HANDLE CreateFileDescriptorEventA(LPSECURITY_ATTRIBUTES lpEventAttributes,
-		BOOL bManualReset, BOOL bInitialState, int FileDescriptor);
+		BOOL bManualReset, BOOL bInitialState, int FileDescriptor, ULONG mode);
 
 WINPR_API HANDLE CreateWaitObjectEvent(LPSECURITY_ATTRIBUTES lpEventAttributes,
 		BOOL bManualReset, BOOL bInitialState, void* pObject);
@@ -352,7 +353,7 @@ WINPR_API HANDLE CreateWaitObjectEvent(LPSECURITY_ATTRIBUTES lpEventAttributes,
 #endif
 
 WINPR_API int GetEventFileDescriptor(HANDLE hEvent);
-WINPR_API int SetEventFileDescriptor(HANDLE hEvent, int FileDescriptor);
+WINPR_API int SetEventFileDescriptor(HANDLE hEvent, int FileDescriptor, ULONG mode);
 
 WINPR_API void* GetEventWaitObject(HANDLE hEvent);
 

--- a/winpr/libwinpr/comm/comm.c
+++ b/winpr/libwinpr/comm/comm.c
@@ -1221,7 +1221,7 @@ BOOL IsCommDevice(LPCTSTR lpDeviceName)
 void _comm_setServerSerialDriver(HANDLE hComm, SERIAL_DRIVER_ID driverId)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_COMM* pComm;
 
 	if (!CommInitialized())
@@ -1344,7 +1344,7 @@ HANDLE CommCreateFileA(LPCSTR lpDeviceName, DWORD dwDesiredAccess, DWORD dwShare
 		return INVALID_HANDLE_VALUE;
 	}
 
-	WINPR_HANDLE_SET_TYPE(pComm, HANDLE_TYPE_COMM);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(pComm, HANDLE_TYPE_COMM, FD_READ);
 
 	pComm->ops = &ops;
 

--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -414,7 +414,7 @@ HANDLE CreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, 
 	}
 
 	hNamedPipe = (HANDLE) pNamedPipe;
-	WINPR_HANDLE_SET_TYPE(pNamedPipe, HANDLE_TYPE_NAMED_PIPE);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(pNamedPipe, HANDLE_TYPE_NAMED_PIPE, FD_READ);
 	pNamedPipe->name = _strdup(lpFileName);
 	if (!pNamedPipe->name)
 	{

--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -502,7 +502,6 @@ BOOL ReadFile(HANDLE hFile, LPVOID lpBuffer, DWORD nNumberOfBytesToRead,
 			  LPDWORD lpNumberOfBytesRead, LPOVERLAPPED lpOverlapped)
 {
 	ULONG Type;
-	PVOID Object;
 	WINPR_HANDLE *handle;
 
 	if (hFile == INVALID_HANDLE_VALUE)
@@ -516,12 +515,12 @@ BOOL ReadFile(HANDLE hFile, LPVOID lpBuffer, DWORD nNumberOfBytesToRead,
 	if (!lpNumberOfBytesRead && !lpOverlapped)
 		return FALSE;
 
-	if (!winpr_Handle_GetInfo(hFile, &Type, &Object))
+	if (!winpr_Handle_GetInfo(hFile, &Type, &handle))
 		return FALSE;
 
 	handle = (WINPR_HANDLE *)hFile;
 	if (handle->ops->ReadFile)
-		return handle->ops->ReadFile(Object, lpBuffer, nNumberOfBytesToRead, lpNumberOfBytesRead, lpOverlapped);
+		return handle->ops->ReadFile(handle, lpBuffer, nNumberOfBytesToRead, lpNumberOfBytesRead, lpOverlapped);
 
 	WLog_ERR(TAG, "ReadFile operation not implemented");
 	return FALSE;
@@ -543,18 +542,17 @@ BOOL WriteFile(HANDLE hFile, LPCVOID lpBuffer, DWORD nNumberOfBytesToWrite,
 			   LPDWORD lpNumberOfBytesWritten, LPOVERLAPPED lpOverlapped)
 {
 	ULONG Type;
-	PVOID Object;
 	WINPR_HANDLE *handle;
 
 	if (hFile == INVALID_HANDLE_VALUE)
 		return FALSE;
 
-	if (!winpr_Handle_GetInfo(hFile, &Type, &Object))
+	if (!winpr_Handle_GetInfo(hFile, &Type, &handle))
 		return FALSE;
 
 	handle = (WINPR_HANDLE *)hFile;
 	if (handle->ops->WriteFile)
-		return handle->ops->WriteFile(Object, lpBuffer, nNumberOfBytesToWrite, lpNumberOfBytesWritten, lpOverlapped);
+		return handle->ops->WriteFile(handle, lpBuffer, nNumberOfBytesToWrite, lpNumberOfBytesWritten, lpOverlapped);
 
 	WLog_ERR(TAG, "ReadFile operation not implemented");
 	return FALSE;

--- a/winpr/libwinpr/handle/handle.c
+++ b/winpr/libwinpr/handle/handle.c
@@ -48,7 +48,7 @@ BOOL CloseHandle(HANDLE hObject)
 	ULONG Type;
 	WINPR_HANDLE *Object;
 
-	if (!winpr_Handle_GetInfo(hObject, &Type, (PVOID*) &Object))
+	if (!winpr_Handle_GetInfo(hObject, &Type, &Object))
 		return FALSE;
 
 	if (!Object)

--- a/winpr/libwinpr/handle/handle.h
+++ b/winpr/libwinpr/handle/handle.h
@@ -23,6 +23,7 @@
 #include <winpr/handle.h>
 #include <winpr/file.h>
 #include <winpr/synch.h>
+#include <winpr/winsock.h>
 
 #define HANDLE_TYPE_NONE			0
 #define HANDLE_TYPE_PROCESS			1
@@ -41,6 +42,7 @@
 
 #define WINPR_HANDLE_DEF() \
 	ULONG Type; \
+	ULONG Mode; \
 	HANDLE_OPS *ops
 
 typedef BOOL (*pcIsHandled)(HANDLE handle);
@@ -68,10 +70,16 @@ struct winpr_handle
 };
 typedef struct winpr_handle WINPR_HANDLE;
 
-#define WINPR_HANDLE_SET_TYPE(_handle, _type) \
-	_handle->Type = _type
+static INLINE void WINPR_HANDLE_SET_TYPE_AND_MODE(void* _handle,
+						 ULONG _type, ULONG _mode)
+{
+	WINPR_HANDLE* hdl = (WINPR_HANDLE*)_handle;
 
-static INLINE BOOL winpr_Handle_GetInfo(HANDLE handle, ULONG* pType, PVOID* pObject)
+	hdl->Type = _type;
+	hdl->Mode = _mode;
+}
+
+static INLINE BOOL winpr_Handle_GetInfo(HANDLE handle, ULONG* pType, WINPR_HANDLE** pObject)
 {
 	WINPR_HANDLE* wHandle;
 
@@ -91,7 +99,7 @@ static INLINE int winpr_Handle_getFd(HANDLE handle)
 	WINPR_HANDLE *hdl;
 	ULONG type;
 
-	if (!winpr_Handle_GetInfo(handle, &type, (PVOID*)&hdl))
+	if (!winpr_Handle_GetInfo(handle, &type, &hdl))
 		return -1;
 
 	if (!hdl || !hdl->ops->GetFd)
@@ -105,7 +113,7 @@ static INLINE DWORD winpr_Handle_cleanup(HANDLE handle)
 	WINPR_HANDLE *hdl;
 	ULONG type;
 
-	if (!winpr_Handle_GetInfo(handle, &type, (PVOID*)&hdl))
+	if (!winpr_Handle_GetInfo(handle, &type, &hdl))
 		return WAIT_FAILED;
 
 	if (!hdl)

--- a/winpr/libwinpr/io/io.c
+++ b/winpr/libwinpr/io/io.c
@@ -50,7 +50,7 @@
 BOOL GetOverlappedResult(HANDLE hFile, LPOVERLAPPED lpOverlapped, LPDWORD lpNumberOfBytesTransferred, BOOL bWait)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 
 	if (!winpr_Handle_GetInfo(hFile, &Type, &Object))
 		return FALSE;

--- a/winpr/libwinpr/pipe/pipe.c
+++ b/winpr/libwinpr/pipe/pipe.c
@@ -454,11 +454,11 @@ BOOL CreatePipe(PHANDLE hReadPipe, PHANDLE hWritePipe, LPSECURITY_ATTRIBUTES lpP
 
 	pReadPipe->fd = pipe_fd[0];
 	pWritePipe->fd = pipe_fd[1];
-	WINPR_HANDLE_SET_TYPE(pReadPipe, HANDLE_TYPE_ANONYMOUS_PIPE);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(pReadPipe, HANDLE_TYPE_ANONYMOUS_PIPE, FD_READ);
 	pReadPipe->ops = &ops;
 
 	*((ULONG_PTR*) hReadPipe) = (ULONG_PTR) pReadPipe;
-	WINPR_HANDLE_SET_TYPE(pWritePipe, HANDLE_TYPE_ANONYMOUS_PIPE);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(pWritePipe, HANDLE_TYPE_ANONYMOUS_PIPE, FD_READ);
 	pWritePipe->ops = &ops;
 	*((ULONG_PTR*) hWritePipe) = (ULONG_PTR) pWritePipe;
 	return TRUE;
@@ -531,7 +531,7 @@ HANDLE CreateNamedPipeA(LPCSTR lpName, DWORD dwOpenMode, DWORD dwPipeMode, DWORD
 	if (!pNamedPipe)
 		return INVALID_HANDLE_VALUE;
 
-	WINPR_HANDLE_SET_TYPE(pNamedPipe, HANDLE_TYPE_NAMED_PIPE);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(pNamedPipe, HANDLE_TYPE_NAMED_PIPE, FD_READ);
 
 	pNamedPipe->serverfd = -1;
 	pNamedPipe->clientfd = -1;

--- a/winpr/libwinpr/sspicli/sspicli.c
+++ b/winpr/libwinpr/sspicli/sspicli.c
@@ -131,7 +131,7 @@ BOOL LogonUserA(LPCSTR lpszUsername, LPCSTR lpszDomain, LPCSTR lpszPassword,
 	if (!token)
 		return FALSE;
 
-	WINPR_HANDLE_SET_TYPE(token, HANDLE_TYPE_ACCESS_TOKEN);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(token, HANDLE_TYPE_ACCESS_TOKEN, FD_READ);
 
 	token->ops = &ops;
 

--- a/winpr/libwinpr/synch/event.c
+++ b/winpr/libwinpr/synch/event.c
@@ -78,23 +78,22 @@ BOOL EventCloseHandle(HANDLE handle) {
 	if (!EventIsHandled(handle))
 		return FALSE;
 
-    if (!event->bAttached)
-    {
-        if (event->pipe_fd[0] != -1)
-        {
-        	close(event->pipe_fd[0]);
-        	event->pipe_fd[0] = -1;
-        }
+	if (!event->bAttached)
+	{
+		if (event->pipe_fd[0] != -1)
+		{
+			close(event->pipe_fd[0]);
+			event->pipe_fd[0] = -1;
+		}
+		if (event->pipe_fd[1] != -1)
+		{
+			close(event->pipe_fd[1]);
+			event->pipe_fd[1] = -1;
+		}
+	}
 
-        if (event->pipe_fd[1] != -1)
-        {
-        	close(event->pipe_fd[1]);
-        	event->pipe_fd[1] = -1;
-        }
-    }
-
-    free(event);
-    return TRUE;
+	free(event);
+	return TRUE;
 }
 
 static HANDLE_OPS ops = {
@@ -114,7 +113,7 @@ HANDLE CreateEventW(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL bManualReset, 
 	event->bAttached = FALSE;
 	event->bManualReset = bManualReset;
 	event->ops = &ops;
-	WINPR_HANDLE_SET_TYPE(event, HANDLE_TYPE_EVENT);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(event, HANDLE_TYPE_EVENT, FD_READ);
 
 	if (!event->bManualReset)
 	{
@@ -200,7 +199,7 @@ static int eventfd_write(int fd, eventfd_t value)
 BOOL SetEvent(HANDLE hEvent)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	int length;
 	BOOL status;
 	WINPR_EVENT* event;
@@ -241,7 +240,7 @@ BOOL SetEvent(HANDLE hEvent)
 BOOL ResetEvent(HANDLE hEvent)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	int length;
 	BOOL status = TRUE;
 	WINPR_EVENT* event;
@@ -274,7 +273,9 @@ BOOL ResetEvent(HANDLE hEvent)
 #endif
 
 
-HANDLE CreateFileDescriptorEventW(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL bManualReset, BOOL bInitialState, int FileDescriptor)
+HANDLE CreateFileDescriptorEventW(LPSECURITY_ATTRIBUTES lpEventAttributes,
+					BOOL bManualReset, BOOL bInitialState,
+					int FileDescriptor, ULONG mode)
 {
 #ifndef _WIN32
 	WINPR_EVENT* event;
@@ -288,7 +289,8 @@ HANDLE CreateFileDescriptorEventW(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL 
 		event->pipe_fd[0] = FileDescriptor;
 		event->pipe_fd[1] = -1;
 		event->ops = &ops;
-		WINPR_HANDLE_SET_TYPE(event, HANDLE_TYPE_EVENT);
+		event->Mode = mode;
+		WINPR_HANDLE_SET_TYPE_AND_MODE(event, HANDLE_TYPE_EVENT, mode);
 		handle = (HANDLE) event;
 	}
 
@@ -298,9 +300,12 @@ HANDLE CreateFileDescriptorEventW(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL 
 #endif
 }
 
-HANDLE CreateFileDescriptorEventA(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL bManualReset, BOOL bInitialState, int FileDescriptor)
+HANDLE CreateFileDescriptorEventA(LPSECURITY_ATTRIBUTES lpEventAttributes,
+				BOOL bManualReset, BOOL bInitialState,
+				int FileDescriptor, ULONG mode)
 {
-	return CreateFileDescriptorEventW(lpEventAttributes, bManualReset, bInitialState, FileDescriptor);
+	return CreateFileDescriptorEventW(lpEventAttributes, bManualReset,
+					bInitialState, FileDescriptor, mode);
 }
 
 /**
@@ -310,7 +315,8 @@ HANDLE CreateWaitObjectEvent(LPSECURITY_ATTRIBUTES lpEventAttributes,
 							 BOOL bManualReset, BOOL bInitialState, void* pObject)
 {
 #ifndef _WIN32
-	return CreateFileDescriptorEventW(lpEventAttributes, bManualReset, bInitialState, (int)(ULONG_PTR) pObject);
+	return CreateFileDescriptorEventW(lpEventAttributes, bManualReset,
+					bInitialState, (int)(ULONG_PTR) pObject, FD_READ);
 #else
 	HANDLE hEvent = NULL;
 	DuplicateHandle(GetCurrentProcess(), pObject, GetCurrentProcess(), &hEvent, 0, FALSE, DUPLICATE_SAME_ACCESS);
@@ -327,7 +333,7 @@ int GetEventFileDescriptor(HANDLE hEvent)
 {
 #ifndef _WIN32
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_EVENT* event;
 
 	if (!winpr_Handle_GetInfo(hEvent, &Type, &Object))
@@ -360,17 +366,19 @@ int GetEventFileDescriptor(HANDLE hEvent)
  * This file descriptor is not usable on Windows
  */
 
-int SetEventFileDescriptor(HANDLE hEvent, int FileDescriptor)
+int SetEventFileDescriptor(HANDLE hEvent, int FileDescriptor, ULONG mode)
 {
 #ifndef _WIN32
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_EVENT* event;
 
 	if (!winpr_Handle_GetInfo(hEvent, &Type, &Object))
 		return -1;
 
 	event = (WINPR_EVENT*) Object;
+	event->bAttached = TRUE;
+	event->Mode = mode;
 	event->pipe_fd[0] = FileDescriptor;
 	return 0;
 #else

--- a/winpr/libwinpr/synch/mutex.c
+++ b/winpr/libwinpr/synch/mutex.c
@@ -138,7 +138,7 @@ HANDLE CreateMutexW(LPSECURITY_ATTRIBUTES lpMutexAttributes, BOOL bInitialOwner,
 	{
 		pthread_mutex_init(&mutex->mutex, 0);
 
-		WINPR_HANDLE_SET_TYPE(mutex, HANDLE_TYPE_MUTEX);
+		WINPR_HANDLE_SET_TYPE_AND_MODE(mutex, HANDLE_TYPE_MUTEX, FD_READ);
 		mutex->ops = &ops;
 
 		handle = (HANDLE) mutex;
@@ -178,7 +178,7 @@ HANDLE OpenMutexW(DWORD dwDesiredAccess, BOOL bInheritHandle,LPCWSTR lpName)
 BOOL ReleaseMutex(HANDLE hMutex)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_MUTEX* mutex;
 
 	if (!winpr_Handle_GetInfo(hMutex, &Type, &Object))

--- a/winpr/libwinpr/synch/semaphore.c
+++ b/winpr/libwinpr/synch/semaphore.c
@@ -179,7 +179,7 @@ HANDLE CreateSemaphoreW(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lIniti
 #endif
 	}
 
-	WINPR_HANDLE_SET_TYPE(semaphore, HANDLE_TYPE_SEMAPHORE);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(semaphore, HANDLE_TYPE_SEMAPHORE, FD_READ);
 	handle = (HANDLE) semaphore;
 	return handle;
 }
@@ -204,7 +204,7 @@ HANDLE OpenSemaphoreA(DWORD dwDesiredAccess, BOOL bInheritHandle, LPCSTR lpName)
 BOOL ReleaseSemaphore(HANDLE hSemaphore, LONG lReleaseCount, LPLONG lpPreviousCount)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_SEMAPHORE* semaphore;
 
 	if (!winpr_Handle_GetInfo(hSemaphore, &Type, &Object))

--- a/winpr/libwinpr/synch/timer.c
+++ b/winpr/libwinpr/synch/timer.c
@@ -230,7 +230,7 @@ HANDLE CreateWaitableTimerA(LPSECURITY_ATTRIBUTES lpTimerAttributes, BOOL bManua
 	timer = (WINPR_TIMER*) calloc(1, sizeof(WINPR_TIMER));
 	if (timer)
 	{
-		WINPR_HANDLE_SET_TYPE(timer, HANDLE_TYPE_TIMER);
+		WINPR_HANDLE_SET_TYPE_AND_MODE(timer, HANDLE_TYPE_TIMER, FD_READ);
 		handle = (HANDLE) timer;
 		timer->fd = -1;
 		timer->lPeriod = 0;
@@ -265,7 +265,7 @@ BOOL SetWaitableTimer(HANDLE hTimer, const LARGE_INTEGER* lpDueTime, LONG lPerio
 					  PTIMERAPCROUTINE pfnCompletionRoutine, LPVOID lpArgToCompletionRoutine, BOOL fResume)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_TIMER* timer;
 #ifdef WITH_POSIX_TIMER
 	LONGLONG seconds = 0;
@@ -365,7 +365,7 @@ BOOL SetWaitableTimerEx(HANDLE hTimer, const LARGE_INTEGER* lpDueTime, LONG lPer
 						PTIMERAPCROUTINE pfnCompletionRoutine, LPVOID lpArgToCompletionRoutine, PREASON_CONTEXT WakeContext, ULONG TolerableDelay)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_TIMER* timer;
 
 	if (!winpr_Handle_GetInfo(hTimer, &Type, &Object))
@@ -612,7 +612,7 @@ HANDLE CreateTimerQueue(void)
 
 	if (timerQueue)
 	{
-		WINPR_HANDLE_SET_TYPE(timerQueue, HANDLE_TYPE_TIMER_QUEUE);
+		WINPR_HANDLE_SET_TYPE_AND_MODE(timerQueue, HANDLE_TYPE_TIMER_QUEUE, FD_READ);
 		handle = (HANDLE) timerQueue;
 		timerQueue->activeHead = NULL;
 		timerQueue->inactiveHead = NULL;
@@ -706,7 +706,7 @@ BOOL CreateTimerQueueTimer(PHANDLE phNewTimer, HANDLE TimerQueue,
 	if (!timer)
 		return FALSE;
 
-	WINPR_HANDLE_SET_TYPE(timer, HANDLE_TYPE_TIMER_QUEUE_TIMER);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(timer, HANDLE_TYPE_TIMER_QUEUE_TIMER, FD_READ);
 	*((UINT_PTR*) phNewTimer) = (UINT_PTR)(HANDLE) timer;
 	timespec_copy(&(timer->StartTime), &CurrentTime);
 	timespec_add_ms(&(timer->StartTime), DueTime);

--- a/winpr/libwinpr/synch/wait.c
+++ b/winpr/libwinpr/synch/wait.c
@@ -327,13 +327,14 @@ DWORD WaitForMultipleObjects(DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAl
 	do
 	{
 #ifdef HAVE_POLL_H
-		FD_ZERO(&rfds);
-		FD_ZERO(&wfds);
 		ZeroMemory(&timeout, sizeof(timeout));
 #else
 		fd_set* prfds = NULL;
 		fd_set* pwfds = NULL;
 		maxfd = 0;
+
+		FD_ZERO(&rfds);
+		FD_ZERO(&wfds);
 #endif
 		if (bWaitAll && (dwMilliseconds != INFINITE))
 			clock_gettime(CLOCK_MONOTONIC, &starttime);

--- a/winpr/libwinpr/synch/wait.c
+++ b/winpr/libwinpr/synch/wait.c
@@ -217,8 +217,10 @@ DWORD WaitForSingleObject(HANDLE hHandle, DWORD dwMilliseconds)
 	{
 		WINPR_PROCESS *process;
 		process = (WINPR_PROCESS *) Object;
+        int rc;
 
-		if (waitpid(process->pid, &(process->status), 0) != -1)
+		rc = waitpid(process->pid, &(process->status), 0);
+		if (rc != process->pid)
 		{
 			WLog_ERR(TAG, "waitpid failure [%d] %s", errno, strerror(errno));
 			return WAIT_FAILED;

--- a/winpr/libwinpr/synch/wait.c
+++ b/winpr/libwinpr/synch/wait.c
@@ -326,15 +326,14 @@ DWORD WaitForMultipleObjects(DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAl
 
 	do
 	{
-#ifdef HAVE_POLL_H
-		ZeroMemory(&timeout, sizeof(timeout));
-#else
+#ifndef HAVE_POLL_H
 		fd_set* prfds = NULL;
 		fd_set* pwfds = NULL;
 		maxfd = 0;
 
 		FD_ZERO(&rfds);
 		FD_ZERO(&wfds);
+		ZeroMemory(&timeout, sizeof(timeout));
 #endif
 		if (bWaitAll && (dwMilliseconds != INFINITE))
 			clock_gettime(CLOCK_MONOTONIC, &starttime);

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -431,7 +431,7 @@ HANDLE CreateThread(LPSECURITY_ATTRIBUTES lpThreadAttributes, SIZE_T dwStackSize
 		goto error_thread_ready;
 	}
 
-	WINPR_HANDLE_SET_TYPE(thread, HANDLE_TYPE_THREAD);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(thread, HANDLE_TYPE_THREAD, FD_READ);
 	handle = (HANDLE) thread;
 
 	if (!thread_list)
@@ -613,7 +613,7 @@ VOID ExitThread(DWORD dwExitCode)
 BOOL GetExitCodeThread(HANDLE hThread, LPDWORD lpExitCode)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_THREAD* thread;
 
 	if (!winpr_Handle_GetInfo(hThread, &Type, &Object))
@@ -665,8 +665,8 @@ DWORD GetCurrentThreadId(VOID)
 DWORD ResumeThread(HANDLE hThread)
 {
 	ULONG Type;
-	PVOID Object;
-	WINPR_THREAD *thread;
+	WINPR_HANDLE* Object;
+	WINPR_THREAD* thread;
 
 	if (!winpr_Handle_GetInfo(hThread, &Type, &Object))
 		return 0;
@@ -697,7 +697,7 @@ BOOL SwitchToThread(VOID)
 BOOL TerminateThread(HANDLE hThread, DWORD dwExitCode)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_THREAD* thread;
 
 	if (!winpr_Handle_GetInfo(hThread, &Type, &Object))

--- a/winpr/libwinpr/utils/debug.c
+++ b/winpr/libwinpr/utils/debug.c
@@ -434,7 +434,7 @@ void winpr_backtrace_symbols_fd(void* buffer, int fd)
 		DWORD i;
 		size_t used;
 		char** lines;
-		
+
 		lines = winpr_backtrace_symbols(buffer, &used);
 
 		if (lines)
@@ -447,3 +447,26 @@ void winpr_backtrace_symbols_fd(void* buffer, int fd)
 	LOGF(support_msg);
 #endif
 }
+
+void winpr_log_backtrace(const char* tag, DWORD level, DWORD size)
+{
+	size_t used, x;
+	char **msg;
+	void *stack = winpr_backtrace(20);
+
+	if (!stack)
+	{
+		WLog_ERR(tag, "winpr_backtrace failed!\n");
+		winpr_backtrace_free(stack);
+		return;
+	}
+
+	msg = winpr_backtrace_symbols(stack, &used);
+	if (msg)
+	{
+		for (x=0; x<used; x++)
+			WLog_LVL(tag, level, "%zd: %s\n", x, msg[x]);
+	}
+	winpr_backtrace_free(stack);
+}
+

--- a/winpr/libwinpr/winsock/winsock.c
+++ b/winpr/libwinpr/winsock/winsock.c
@@ -642,12 +642,15 @@ BOOL WSACloseEvent(HANDLE hEvent)
 
 int WSAEventSelect(SOCKET s, WSAEVENT hEventObject, LONG lNetworkEvents)
 {
-	u_long arg = 1;
+	u_long arg = lNetworkEvents ? 1 : 0;
 
 	if (_ioctlsocket(s, FIONBIO, &arg) != 0)
 		return SOCKET_ERROR;
 
-	if (SetEventFileDescriptor(hEventObject, s) < 0)
+	if (arg == 0)
+		return 0;
+
+	if (SetEventFileDescriptor(hEventObject, s, lNetworkEvents) < 0)
 		return SOCKET_ERROR;
 
 	return 0;


### PR DESCRIPTION
* Implemented ```WSAEventSelect``` in a windows compatible fashion to work with async ```connect``` calls. (Only implemented ```FD_READ and FD_WRITE``` as well as reset)
* ```CreateFileDescriptorEvent``` and ```SetEventFileDescriptor``` make use of a new mode argument now.
* Added ```winpr_log_backtrace``` as convenience function writing a backtrace to ```WLog```
* Added ```abortEvent``` to ```rdpContext``` allowing abort of ```freerdp_connect``` in a multithreaded client. (exposed by ```freerdp_abort_connect```)
* Removed code duplication in ```tcp.c```, windows and unix implementations merged. (NOTE: I've tested ```freerdp_tcp_connect_timeout``` extensivly, ```freerdp_tcp_connect_multi``` should get a more rigorous look)
* Added unit test for connection success, abort and timeout