### PR TITLE
New /from-stdin

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -519,7 +519,7 @@ static BOOL wf_authenticate_raw(freerdp* instance, const char* title,
 	ZeroMemory(Password, sizeof(Password));
 	dwFlags = CREDUI_FLAGS_DO_NOT_PERSIST | CREDUI_FLAGS_EXCLUDE_CERTIFICATES;
 
-	status = CredUIPromptForCredentialsA(&wfUiInfo, title, NULL, 0
+	status = CredUIPromptForCredentialsA(&wfUiInfo, title, NULL, 0,
 		UserName, CREDUI_MAX_USERNAME_LENGTH + 1,
 		Password, CREDUI_MAX_PASSWORD_LENGTH + 1, &fSave, dwFlags);
 

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -519,7 +519,7 @@ static BOOL wf_authenticate_raw(freerdp* instance, const char* title,
 	ZeroMemory(Password, sizeof(Password));
 	dwFlags = CREDUI_FLAGS_DO_NOT_PERSIST | CREDUI_FLAGS_EXCLUDE_CERTIFICATES;
 
-	status = CredUIPromptForCredentialsA(&wfUiInu, title, NULL, 0
+	status = CredUIPromptForCredentialsA(&wfUiInfo, title, NULL, 0
 		UserName, CREDUI_MAX_USERNAME_LENGTH + 1,
 		Password, CREDUI_MAX_PASSWORD_LENGTH + 1, &fSave, dwFlags);
 

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -503,7 +503,8 @@ static CREDUI_INFOA wfUiInfo =
 	NULL
 };
 
-BOOL wf_authenticate(freerdp* instance, char** username, char** password, char** domain)
+static BOOL wf_authenticate_raw(freerdp* instance, const char* title,
+		char** username, char** password, char** domain)
 {
 	BOOL fSave;
 	DWORD status;
@@ -518,9 +519,7 @@ BOOL wf_authenticate(freerdp* instance, char** username, char** password, char**
 	ZeroMemory(Password, sizeof(Password));
 	dwFlags = CREDUI_FLAGS_DO_NOT_PERSIST | CREDUI_FLAGS_EXCLUDE_CERTIFICATES;
 
-	status = CredUIPromptForCredentialsA(&wfUiInfo,
-					     instance->settings->ServerHostname,
-					     NULL, 0,
+	status = CredUIPromptForCredentialsA(&wfUiInu, title, NULL, 0
 		UserName, CREDUI_MAX_USERNAME_LENGTH + 1,
 		Password, CREDUI_MAX_PASSWORD_LENGTH + 1, &fSave, dwFlags);
 
@@ -563,6 +562,22 @@ BOOL wf_authenticate(freerdp* instance, char** username, char** password, char**
 	}
 
 	return TRUE;
+}
+
+static BOOL wf_authenticate(freerdp* instance,
+		char** username, char** password, char** domain)
+{
+	return wf_authenticate_raw(instance, instance->settings->ServerHostname,
+			username, password, domain);
+}
+
+static BOOL wf_gw_authenticate(freerdp* instance,
+		char** username, char** password, char** domain)
+{
+	char tmp[MAX_PATH];
+
+	sprintf(tmp, sizeof(tmp), "Gateway %s", instance->settings->GatewayHostname);
+	return wf_authenticate_raw(instance, tmp, username, password, domain);
 }
 
 BOOL wf_verify_certificate(freerdp* instance, char* subject, char* issuer, char* fingerprint)
@@ -1065,6 +1080,7 @@ BOOL wfreerdp_client_new(freerdp* instance, rdpContext* context)
 	instance->PreConnect = wf_pre_connect;
 	instance->PostConnect = wf_post_connect;
 	instance->Authenticate = wf_authenticate;
+	instance->GatewayAuthenticate = wf_gw_authenticate;
 	instance->VerifyCertificate = wf_verify_certificate;
 
 	wfc->instance = instance;

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -994,7 +994,7 @@ BOOL xf_pre_connect(freerdp* instance)
 	freerdp_client_load_addins(channels, instance->settings);
 	freerdp_channels_pre_connect(channels, instance);
 
-	if (!settings->Username)
+	if (!settings->Username && !settings->CredentialsFromStdin)
 	{
 		char* login_name = getlogin();
 
@@ -1228,16 +1228,72 @@ static void xf_post_disconnect(freerdp* instance)
  *  @param domain - unused
  *  @return TRUE if a password was successfully entered. See freerdp_passphrase_read() for more details.
  */
-BOOL xf_authenticate(freerdp* instance, char** username, char** password, char** domain)
+static BOOL xf_authenticate_raw(freerdp* instance, BOOL gateway, char** username,
+		char** password, char** domain)
 {
-	// FIXME: seems this callback may be called when 'username' is not known.
-	// But it doesn't do anything to fix it...
-	*password = malloc(password_size * sizeof(char));
+	const char* auth[] =
+	{
+		"Username: ",
+		"Domain:   ",
+		"Password: "
+	};
+	const char* gw[] =
+	{
+		"GatewayUsername: ",
+		"GatewayDomain:   ",
+		"GatewayPassword: "
+	};
+	const char** prompt = (gateway) ? gw : auth;
 
-	if (freerdp_passphrase_read("Password: ", *password, password_size, instance->settings->CredentialsFromStdin) == NULL)
+	if (!username || !password || !domain)
 		return FALSE;
 
+	if (!*username)
+	{
+		size_t username_size = 0;
+		printf("%s", prompt[0]);
+		getline(username, &username_size, stdin);
+		if (*username)
+		{
+			*username = StrSep(username, "\r");
+			*username = StrSep(username, "\n");
+		}
+	}
+
+	if (!*domain)
+	{
+		size_t domain_size = 0;
+		printf("%s", prompt[1]);
+		getline(domain, &domain_size, stdin);
+		if (*domain)
+		{
+			*domain = StrSep(domain, "\r");
+			*domain = StrSep(domain, "\n");
+		}
+	}
+
+	if (!*password)
+	{
+		*password = calloc(password_size, sizeof(char));
+		if (!*password)
+			return FALSE;
+
+		if (freerdp_passphrase_read(prompt[2], *password, password_size,
+			instance->settings->CredentialsFromStdin) == NULL)
+			return FALSE;
+	}
+
 	return TRUE;
+}
+
+static BOOL xf_authenticate(freerdp* instance, char** username, char** password, char** domain)
+{
+	return xf_authenticate_raw(instance, FALSE, username, password, domain);
+}
+
+static BOOL xf_gw_authenticate(freerdp* instance, char** username, char** password, char** domain)
+{
+	return xf_authenticate_raw(instance, TRUE, username, password, domain);
 }
 
 /** Callback set in the rdp_freerdp structure, and used to make a certificate validation
@@ -1720,6 +1776,7 @@ static BOOL xfreerdp_client_new(freerdp* instance, rdpContext* context)
 	instance->PostConnect = xf_post_connect;
 	instance->PostDisconnect = xf_post_disconnect;
 	instance->Authenticate = xf_authenticate;
+	instance->GatewayAuthenticate = xf_gw_authenticate;
 	instance->VerifyCertificate = xf_verify_certificate;
 	instance->LogonErrorInfo = xf_logon_error_info;
 

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -169,7 +169,7 @@ COMMAND_LINE_ARGUMENT_A args[] =
 	{ "multitransport", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Support multitransport protocol" },
 	{ "assistance", COMMAND_LINE_VALUE_REQUIRED, "<password>", NULL, NULL, -1, NULL, "Remote assistance password" },
 	{ "encryption-methods", COMMAND_LINE_VALUE_REQUIRED, "<40,56,128,FIPS>", NULL, NULL, -1, NULL, "RDP standard security encryption methods" },
-	{ "from-stdin", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "print version" },
+	{ "from-stdin", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Read credentials from stdin, do not use defaults." },
 	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
 };
 

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -169,6 +169,7 @@ COMMAND_LINE_ARGUMENT_A args[] =
 	{ "multitransport", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Support multitransport protocol" },
 	{ "assistance", COMMAND_LINE_VALUE_REQUIRED, "<password>", NULL, NULL, -1, NULL, "Remote assistance password" },
 	{ "encryption-methods", COMMAND_LINE_VALUE_REQUIRED, "<40,56,128,FIPS>", NULL, NULL, -1, NULL, "RDP standard security encryption methods" },
+	{ "from-stdin", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "print version" },
 	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
 };
 
@@ -2084,6 +2085,10 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 				free(p);
 			}
+		}
+		CommandLineSwitchCase(arg, "from-stdin")
+		{
+			settings->CredentialsFromStdin = TRUE;
 		}
 		CommandLineSwitchCase(arg, "sec-rdp")
 		{


### PR DESCRIPTION
* Adds ```/from-stdin``` to ignore missing ```user```, ```domain``` and ```password```
* Implemented ```GatewayAuthenticate``` callbacks for windows and X11 clients
* Implemented full ```Authenticate``` callback for X11