### PR TITLE
Fix possible endless loops on cleanup.

### DIFF
--- a/libfreerdp/core/message.c
+++ b/libfreerdp/core/message.c
@@ -107,10 +107,10 @@ static BOOL update_message_BitmapUpdate(rdpContext* context, BITMAP_UPDATE* bitm
 		wParam->rectangles[index].bitmapDataStream = (BYTE*) malloc(wParam->rectangles[index].bitmapLength);
 		if (!wParam->rectangles[index].bitmapDataStream)
 		{
-			for (index -= 1; index >= 0; --index)
-			{
-				free(wParam->rectangles[index].bitmapDataStream);
-			}
+			UINT32 i;
+			for (i = 0; i < index; ++i)
+				free(wParam->rectangles[i].bitmapDataStream);
+
 			free(wParam->rectangles);
 			free(wParam);
 			return FALSE;

--- a/libfreerdp/core/message.c
+++ b/libfreerdp/core/message.c
@@ -107,9 +107,8 @@ static BOOL update_message_BitmapUpdate(rdpContext* context, BITMAP_UPDATE* bitm
 		wParam->rectangles[index].bitmapDataStream = (BYTE*) malloc(wParam->rectangles[index].bitmapLength);
 		if (!wParam->rectangles[index].bitmapDataStream)
 		{
-			UINT32 i;
-			for (i = 0; i < index; ++i)
-				free(wParam->rectangles[i].bitmapDataStream);
+			while(index)
+				free(wParam->rectangles[--index].bitmapDataStream);
 
 			free(wParam->rectangles);
 			free(wParam);

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -755,8 +755,9 @@ rdpSettings* freerdp_settings_clone(rdpSettings* settings)
 				_settings->TargetNetAddresses[index] = _strdup(settings->TargetNetAddresses[index]);
 				if (!_settings->TargetNetAddresses[index])
 				{
-					for (--index; index >= 0; --index)
-						free(_settings->TargetNetAddresses[index]);
+					UINT32 i;
+					for (i = 0; i < index; ++i)
+						free(_settings->TargetNetAddresses[i]);
 					free(_settings->TargetNetAddresses);
 					_settings->TargetNetAddresses = NULL;
 					_settings->TargetNetAddressCount = 0;

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -755,9 +755,9 @@ rdpSettings* freerdp_settings_clone(rdpSettings* settings)
 				_settings->TargetNetAddresses[index] = _strdup(settings->TargetNetAddresses[index]);
 				if (!_settings->TargetNetAddresses[index])
 				{
-					UINT32 i;
-					for (i = 0; i < index; ++i)
-						free(_settings->TargetNetAddresses[i]);
+					while(index)
+						free(_settings->TargetNetAddresses[--index]);
+
 					free(_settings->TargetNetAddresses);
 					_settings->TargetNetAddresses = NULL;
 					_settings->TargetNetAddressCount = 0;

--- a/winpr/libwinpr/clipboard/clipboard.c
+++ b/winpr/libwinpr/clipboard/clipboard.c
@@ -374,9 +374,12 @@ BOOL ClipboardInitFormats(wClipboard* clipboard)
 
 		if (!format->formatName)
 		{
-			for (--formatId; formatId >= 0; --formatId)
+			int i;
+			for(i = formatId-1; i >= 0; --i)
+			{
+				format = &(clipboard->formats[--clipboard->numFormats]);
 				free((void *)format->formatName);
-			clipboard->numFormats = 0;
+			}
 			return FALSE;
 		}
 	}

--- a/winpr/libwinpr/clipboard/clipboard.c
+++ b/winpr/libwinpr/clipboard/clipboard.c
@@ -364,9 +364,9 @@ BOOL ClipboardInitFormats(wClipboard* clipboard)
 	if (!clipboard)
 		return FALSE;
 
-	for (formatId = 0; formatId < CF_MAX; formatId++)
+	for (formatId = 0; formatId < CF_MAX; formatId++, clipboard->numFormats++)
 	{
-		format = &(clipboard->formats[clipboard->numFormats++]);
+		format = &(clipboard->formats[clipboard->numFormats]);
 		ZeroMemory(format, sizeof(wClipboardFormat));
 
 		format->formatId = formatId;
@@ -375,7 +375,7 @@ BOOL ClipboardInitFormats(wClipboard* clipboard)
 		if (!format->formatName)
 		{
 			int i;
-			for(i = formatId-1; i >= 0; --i)
+			for (i = formatId-1; i >= 0; --i)
 			{
 				format = &(clipboard->formats[--clipboard->numFormats]);
 				free((void *)format->formatName);


### PR DESCRIPTION
Some cleanup code possibly create endless loops because an unsigned
type was used as run variable but the check was >= 0 in the for loop.