### PR TITLE
Replaced hard coded registry keys with cmake defines.

### DIFF
--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -61,6 +61,9 @@
 #define RFX_INIT_SIMD(_rfx_context) do { } while (0)
 #endif
 
+#define RFX_KEY "Software\\"FREERDP_VENDOR_STRING"\\" \
+		     FREERDP_PRODUCT_STRING"\\RemoteFX"
+
 /**
  * The quantization values control the compression rate and quality. The value
  * range is between 6 and 15. The higher value, the higher compression rate
@@ -251,7 +254,7 @@ RFX_CONTEXT* rfx_context_new(BOOL encoder)
 	 * dwt_buffer: 32 * 32 * 2 * 2 * sizeof(INT16) = 8192, maximum sub-band width is 32
 	 *
 	 * Additionally we add 32 bytes (16 in front and 16 at the back of the buffer)
-	 * in order to allow optimized functions (SEE, NEON) to read from positions 
+	 * in order to allow optimized functions (SEE, NEON) to read from positions
 	 * that are actually in front/beyond the buffer. Offset calculations are
 	 * performed at the BufferPool_Take function calls in rfx_encode/decode.c.
 	 *
@@ -284,7 +287,7 @@ RFX_CONTEXT* rfx_context_new(BOOL encoder)
 	priv->MinThreadCount = sysinfo.dwNumberOfProcessors;
 	priv->MaxThreadCount = 0;
 
-	status = RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("Software\\FreeRDP\\RemoteFX"), 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+	status = RegOpenKeyExA(HKEY_LOCAL_MACHINE, RFX_KEY, 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
 
 	if (status == ERROR_SUCCESS)
 	{
@@ -328,15 +331,15 @@ RFX_CONTEXT* rfx_context_new(BOOL encoder)
 
 	/* create profilers for default decoding routines */
 	rfx_profiler_create(context);
-	
+
 	/* set up default routines */
-	context->quantization_decode = rfx_quantization_decode;	
-	context->quantization_encode = rfx_quantization_encode;	
+	context->quantization_decode = rfx_quantization_decode;
+	context->quantization_encode = rfx_quantization_encode;
 	context->dwt_2d_decode = rfx_dwt_2d_decode;
 	context->dwt_2d_encode = rfx_dwt_2d_encode;
 
 	RFX_INIT_SIMD(context);
-	
+
 	context->state = RFX_STATE_SEND_HEADERS;
 	return context;
 
@@ -514,7 +517,7 @@ static BOOL rfx_process_message_channels(RFX_CONTEXT* context, wStream* s)
 
 	Stream_Read_UINT8(s, numChannels); /* numChannels (1 byte), must bet set to 0x01 */
 
-	/* In RDVH sessions, numChannels will represent the number of virtual monitors 
+	/* In RDVH sessions, numChannels will represent the number of virtual monitors
 	 * configured and does not always be set to 0x01 as [MS-RDPRFX] said.
 	 */
 	if (numChannels < 1)

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -44,6 +44,9 @@
 
 #define TAG FREERDP_TAG("core.nla")
 
+#define SERVER_KEY "Software\\"FREERDP_VENDOR_STRING"\\" \
+		     FREERDP_PRODUCT_STRING"\\Server"
+
 /**
  * TSRequest ::= SEQUENCE {
  * 	version    [0] INTEGER,
@@ -1517,8 +1520,8 @@ rdpNla* nla_new(freerdp* instance, rdpTransport* transport, rdpSettings* setting
 		DWORD dwType;
 		DWORD dwSize;
 
-		status = RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("Software\\FreeRDP\\Server"),
-							  0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+		status = RegOpenKeyExA(HKEY_LOCAL_MACHINE, SERVER_KEY,
+					  0, KEY_READ | KEY_WOW64_64KEY, &hKey);
 
 		if (status != ERROR_SUCCESS)
 			return nla;

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -57,6 +57,14 @@ static const char client_dll[] = "C:\\Windows\\System32\\mstscax.dll";
 	if (RegQueryValueEx(_key, _subkey, NULL, &_type, (BYTE*) &_value, &_size) == ERROR_SUCCESS) \
 		_result = _value ? TRUE : FALSE
 
+#define SERVER_KEY "Software\\" FREERDP_VENDOR_STRING "\\" \
+		     FREERDP_PRODUCT_STRING "\\Server"
+#define CLIENT_KEY "Software\\" FREERDP_VENDOR_STRING "\\" \
+		     FREERDP_PRODUCT_STRING "\\Client"
+#define BITMAP_CACHE_KEY CLIENT_KEY "\\BitmapCacheV2"
+#define GLYPH_CACHE_KEY CLIENT_KEY "\\GlyphCache"
+#define POINTER_CACHE_KEY CLIENT_KEY "\\PointerCache"
+
 void settings_client_load_hkey_local_machine(rdpSettings* settings)
 {
 	HKEY hKey;
@@ -65,7 +73,7 @@ void settings_client_load_hkey_local_machine(rdpSettings* settings)
 	DWORD dwSize;
 	DWORD dwValue;
 
-	status = RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("Software\\FreeRDP\\Client"), 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+	status = RegOpenKeyExA(HKEY_LOCAL_MACHINE, CLIENT_KEY, 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
 
 	if (status == ERROR_SUCCESS)
 	{
@@ -97,7 +105,8 @@ void settings_client_load_hkey_local_machine(rdpSettings* settings)
 		RegCloseKey(hKey);
 	}
 
-	status = RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("Software\\FreeRDP\\Client\\BitmapCacheV2"), 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+	status = RegOpenKeyExA(HKEY_LOCAL_MACHINE, BITMAP_CACHE_KEY, 0,
+				KEY_READ | KEY_WOW64_64KEY, &hKey);
 
 	if (status == ERROR_SUCCESS)
 	{
@@ -119,7 +128,8 @@ void settings_client_load_hkey_local_machine(rdpSettings* settings)
 		RegCloseKey(hKey);
 	}
 
-	status = RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("Software\\FreeRDP\\Client\\GlyphCache"), 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+	status = RegOpenKeyExA(HKEY_LOCAL_MACHINE, GLYPH_CACHE_KEY,
+				0, KEY_READ | KEY_WOW64_64KEY, &hKey);
 
 	if (status == ERROR_SUCCESS)
 	{
@@ -152,7 +162,8 @@ void settings_client_load_hkey_local_machine(rdpSettings* settings)
 		RegCloseKey(hKey);
 	}
 
-	status = RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("Software\\FreeRDP\\Client\\PointerCache"), 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+	status = RegOpenKeyExA(HKEY_LOCAL_MACHINE, POINTER_CACHE_KEY,
+				0, KEY_READ | KEY_WOW64_64KEY, &hKey);
 
 	if (status == ERROR_SUCCESS)
 	{
@@ -172,7 +183,8 @@ void settings_server_load_hkey_local_machine(rdpSettings* settings)
 	DWORD dwSize;
 	DWORD dwValue;
 
-	status = RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("Software\\FreeRDP\\Server"), 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+	status = RegOpenKeyExA(HKEY_LOCAL_MACHINE, SERVER_KEY,
+				0, KEY_READ | KEY_WOW64_64KEY, &hKey);
 
 	if (status != ERROR_SUCCESS)
 		return;

--- a/server/Windows/wf_info.c
+++ b/server/Windows/wf_info.c
@@ -34,6 +34,9 @@
 #include <freerdp/log.h>
 #define TAG SERVER_TAG("windows")
 
+#define SERVER_KEY "Software\\"FREERDP_VENDOR_STRING"\\" \
+		FREERDP_PRODUCT_STRING"\\Server"
+
 static wfInfo* wfInfoInstance = NULL;
 static int _IDcount = 0;
 
@@ -151,7 +154,8 @@ wfInfo* wf_info_init()
 		//Set FPS
 		wfi->framesPerSecond = WF_INFO_DEFAULT_FPS;
 
-		status = RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("Software\\FreeRDP\\Server"), 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+		status = RegOpenKeyExA(HKEY_LOCAL_MACHINE, SERVER_KEY, 0,
+					KEY_READ | KEY_WOW64_64KEY, &hKey);
 		if (status == ERROR_SUCCESS)
 		{
 			if (RegQueryValueEx(hKey, _T("FramesPerSecond"), NULL, &dwType, (BYTE*) &dwValue, &dwSize) == ERROR_SUCCESS)
@@ -162,7 +166,8 @@ wfInfo* wf_info_init()
 		//Set input toggle
 		wfi->input_disabled = FALSE;
 
-		status = RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("Software\\FreeRDP\\Server"), 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+		status = RegOpenKeyExA(HKEY_LOCAL_MACHINE, SERVER_KEY,
+					0, KEY_READ | KEY_WOW64_64KEY, &hKey);
 		if (status == ERROR_SUCCESS)
 		{
 			if (RegQueryValueEx(hKey, _T("DisableInput"), NULL, &dwType, (BYTE*) &dwValue, &dwSize) == ERROR_SUCCESS)

--- a/server/Windows/wf_interface.c
+++ b/server/Windows/wf_interface.c
@@ -38,6 +38,9 @@
 
 #include "wf_interface.h"
 
+#define SERVER_KEY "Software\\"FREERDP_VENDOR_STRING"\\" \
+		FREERDP_PRODUCT_STRING"\\Server"
+
 cbCallback cbEvent;
 
 int get_screen_info(int id, _TCHAR* name, int* width, int* height, int* bpp)
@@ -130,7 +133,7 @@ DWORD WINAPI wf_server_main_loop(LPVOID lpParam)
 		if (max_fds == 0)
 			break;
 
-		
+
 		select(max_fds + 1, &rfds_set, NULL, NULL, NULL);
 
 		if (instance->CheckFileDescriptor(instance) != TRUE)
@@ -154,7 +157,8 @@ BOOL wfreerdp_server_start(wfServer* server)
 	server->instance->PeerAccepted = wf_peer_accepted;
 	instance = server->instance;
 
-	wf_settings_read_dword(HKEY_LOCAL_MACHINE, _T("Software\\FreeRDP\\Server"), _T("DefaultPort"), &server->port);
+	wf_settings_read_dword(HKEY_LOCAL_MACHINE, SERVER_KEY,
+				_T("DefaultPort"), &server->port);
 
 	if (!instance->Open(instance, NULL, (UINT16) server->port))
 		return FALSE;
@@ -289,7 +293,7 @@ FREERDP_API BOOL wfreerdp_server_peer_is_connected(int pId)
 		return FALSE;
 	peer = wfi->peers[pId];
 
-	
+
 	if (peer)
 	{
 		return peer->connected;
@@ -309,7 +313,7 @@ FREERDP_API BOOL wfreerdp_server_peer_is_activated(int pId)
 	if (!wfi)
 		return FALSE;
 	peer = wfi->peers[pId];
-	
+
 	if (peer)
 	{
 		return peer->activated;

--- a/server/Windows/wf_peer.c
+++ b/server/Windows/wf_peer.c
@@ -39,6 +39,9 @@
 #include "wf_peer.h"
 #include <freerdp/peer.h>
 
+#define SERVER_KEY "Software\\"FREERDP_VENDOR_STRING"\\" \
+	FREERDP_PRODUCT_STRING
+
 BOOL wf_peer_context_new(freerdp_peer* client, wfPeerContext* context)
 {
 	if (!(context->info = wf_info_get_instance()))
@@ -214,14 +217,16 @@ DWORD WINAPI wf_peer_socket_listener(LPVOID lpParam)
 
 BOOL wf_peer_read_settings(freerdp_peer* client)
 {
-	if (!wf_settings_read_string_ascii(HKEY_LOCAL_MACHINE, _T("Software\\FreeRDP\\Server"), _T("CertificateFile"), &(client->settings->CertificateFile)))
+	if (!wf_settings_read_string_ascii(HKEY_LOCAL_MACHINE, SERVER_KEY,
+			_T("CertificateFile"), &(client->settings->CertificateFile)))
 	{
 		client->settings->CertificateFile = _strdup("server.crt");
 		if (!client->settings->CertificateFile)
 			return FALSE;
 	}
 
-	if (!wf_settings_read_string_ascii(HKEY_LOCAL_MACHINE, _T("Software\\FreeRDP\\Server"), _T("PrivateKeyFile"), &(client->settings->PrivateKeyFile)))
+	if (!wf_settings_read_string_ascii(HKEY_LOCAL_MACHINE, SERVER_KEY,
+			_T("PrivateKeyFile"), &(client->settings->PrivateKeyFile)))
 	{
 		client->settings->PrivateKeyFile = _strdup("server.key");
 		if (!client->settings->PrivateKeyFile)

--- a/server/Windows/wf_settings.c
+++ b/server/Windows/wf_settings.c
@@ -26,7 +26,7 @@
 
 #include "wf_settings.h"
 
-BOOL wf_settings_read_dword(HKEY key, LPTSTR subkey, LPTSTR name, DWORD* value)
+BOOL wf_settings_read_dword(HKEY key, LPCSTR subkey, LPTSTR name, DWORD* value)
 {
 	HKEY hKey;
 	LONG status;
@@ -34,7 +34,7 @@ BOOL wf_settings_read_dword(HKEY key, LPTSTR subkey, LPTSTR name, DWORD* value)
 	DWORD dwSize;
 	DWORD dwValue;
 
-	status = RegOpenKeyEx(key, subkey, 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+	status = RegOpenKeyExA(key, subkey, 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
 
 	if (status == ERROR_SUCCESS)
 	{
@@ -53,7 +53,7 @@ BOOL wf_settings_read_dword(HKEY key, LPTSTR subkey, LPTSTR name, DWORD* value)
 	return FALSE;
 }
 
-BOOL wf_settings_read_string_ascii(HKEY key, LPTSTR subkey, LPTSTR name, char** value)
+BOOL wf_settings_read_string_ascii(HKEY key, LPCSTR subkey, LPTSTR name, char** value)
 {
 	HKEY hKey;
 	int length;
@@ -63,7 +63,7 @@ BOOL wf_settings_read_string_ascii(HKEY key, LPTSTR subkey, LPTSTR name, char** 
 	char* strA;
 	TCHAR* strX = NULL;
 
-	status = RegOpenKeyEx(key, subkey, 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+	status = RegOpenKeyExA(key, subkey, 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
 
 	if (status != ERROR_SUCCESS)
 		return FALSE;

--- a/server/Windows/wf_settings.h
+++ b/server/Windows/wf_settings.h
@@ -22,7 +22,7 @@
 
 #include "wf_interface.h"
 
-BOOL wf_settings_read_dword(HKEY key, LPTSTR subkey, LPTSTR name, DWORD* value);
-BOOL wf_settings_read_string_ascii(HKEY key, LPTSTR subkey, LPTSTR name, char** value);
+BOOL wf_settings_read_dword(HKEY key, LPCSTR subkey, LPTSTR name, DWORD* value);
+BOOL wf_settings_read_string_ascii(HKEY key, LPCSTR subkey, LPTSTR name, char** value);
 
 #endif /* WF_SETTINGS_H */

--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -43,6 +43,9 @@
 #include "../../log.h"
 #define TAG WINPR_TAG("sspi.NTLM")
 
+#define WINPR_KEY "Software\\"FREERDP_VENDOR_STRING \
+	"\\"FREERDP_PRODUCT_STRING"\\WinPR\\NTLM"
+
 char* NTLM_PACKAGE_NAME = "NTLM";
 
 int ntlm_SetContextWorkstation(NTLM_CONTEXT* context, char* Workstation)
@@ -165,7 +168,7 @@ NTLM_CONTEXT* ntlm_ContextNew()
 	context->SendWorkstationName = TRUE;
 	context->NegotiateKeyExchange = TRUE;
 	context->UseSamFileDatabase = TRUE;
-	status = RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("Software\\WinPR\\NTLM"), 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+	status = RegOpenKeyExA(HKEY_LOCAL_MACHINE, WINPR_KEY, 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
 
 	if (status == ERROR_SUCCESS)
 	{


### PR DESCRIPTION
* Using ```FREERDP_VENDOR_STRING``` and ```FREERDP_PRODUCT_STRING``` as base directory now.
* Updated API to allow C char strings (wide character define concatenation is tricky)

NOTE: (default build)
* This moves the registry keys from ```Software\FreeRDP``` to ```Software\FreeRDP\FreeRDP```
* This moves the registry keys from ```Software\WinPR\NTLM``` to ```Software\FreeRDP\FreeRDP\WinPR\NTLM```