### PR TITLE
[Clipboard] Fixed out of bound array access.

### DIFF
--- a/channels/cliprdr/client/cliprdr_main.c
+++ b/channels/cliprdr/client/cliprdr_main.c
@@ -458,7 +458,7 @@ int cliprdr_temp_directory(CliprdrClientContext* context, CLIPRDR_TEMP_DIRECTORY
 	if (length > 520)
 		length = 520;
 
-	Stream_Write(s, tempDirectory->szTempDir, length * 2);
+	Stream_Write(s, wszTempDir, length * 2);
 	Stream_Zero(s, (520 - length) * 2);
 
 	free(wszTempDir);


### PR DESCRIPTION
Found this nasty little bug in clipboard, sending UTF8 string instead of wide character string in ```cliprdr_temp_directory```.
Could anyone with knowledge check if this breaks/fixes anything?