### PR TITLE
server/shadow: Enhancement regarding the screen and resolution - addresize support and fix subRect feature

### DIFF
--- a/include/freerdp/server/shadow.h
+++ b/include/freerdp/server/shadow.h
@@ -90,7 +90,6 @@ struct rdp_shadow_client
 	CRITICAL_SECTION lock;
 	REGION16 invalidRegion;
 	rdpShadowServer* server;
-	rdpShadowSurface* lobby;
 	rdpShadowEncoder* encoder;
 	rdpShadowSubsystem* subsystem;
 
@@ -112,6 +111,7 @@ struct rdp_shadow_server
 	wArrayList* clients;
 	rdpShadowScreen* screen;
 	rdpShadowSurface* surface;
+	rdpShadowSurface* lobby;
 	rdpShadowCapture* capture;
 	rdpShadowSubsystem* subsystem;
 
@@ -281,6 +281,8 @@ FREERDP_API int shadow_client_boardcast_quit(rdpShadowServer* server, int nExitC
 
 FREERDP_API int shadow_encoder_preferred_fps(rdpShadowEncoder* encoder);
 FREERDP_API UINT32 shadow_encoder_inflight_frames(rdpShadowEncoder* encoder);
+
+FREERDP_API BOOL shadow_screen_resize(rdpShadowScreen* screen);
 
 #ifdef __cplusplus
 }

--- a/server/shadow/shadow_encoder.c
+++ b/server/shadow/shadow_encoder.c
@@ -224,6 +224,9 @@ int shadow_encoder_init_interleaved(rdpShadowEncoder* encoder)
 
 int shadow_encoder_init(rdpShadowEncoder* encoder)
 {
+	encoder->width = encoder->server->screen->width;
+	encoder->height = encoder->server->screen->height;
+
 	encoder->maxTileWidth = 64;
 	encoder->maxTileHeight = 64;
 
@@ -400,9 +403,6 @@ rdpShadowEncoder* shadow_encoder_new(rdpShadowClient* client)
 
 	encoder->fps = 16;
 	encoder->maxFps = 32;
-
-	encoder->width = server->screen->width;
-	encoder->height = server->screen->height;
 
 	if (shadow_encoder_init(encoder) < 0)
 	{

--- a/server/shadow/shadow_input.c
+++ b/server/shadow/shadow_input.c
@@ -72,6 +72,12 @@ BOOL shadow_input_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UINT16 y)
 	rdpShadowClient* client = (rdpShadowClient*) input->context;
 	rdpShadowSubsystem* subsystem = client->server->subsystem;
 
+	if (client->server->shareSubRect)
+	{
+		x += client->server->subRect.left;
+		y += client->server->subRect.top;
+	}
+
 	if (!(flags & PTR_FLAGS_WHEEL))
 	{
 		client->pointerX = x;
@@ -101,6 +107,12 @@ BOOL shadow_input_extended_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, 
 {
 	rdpShadowClient* client = (rdpShadowClient*) input->context;
 	rdpShadowSubsystem* subsystem = client->server->subsystem;
+
+	if (client->server->shareSubRect)
+	{
+		x += client->server->subRect.left;
+		y += client->server->subRect.top;
+	}
 
 	client->pointerX = x;
 	client->pointerY = y;

--- a/server/shadow/shadow_lobby.h
+++ b/server/shadow/shadow_lobby.h
@@ -30,7 +30,7 @@
 extern "C" {
 #endif
 
-int shadow_client_init_lobby(rdpShadowClient* client);
+BOOL shadow_client_init_lobby(rdpShadowServer* server);
 
 #ifdef __cplusplus
 }

--- a/server/shadow/shadow_screen.h
+++ b/server/shadow/shadow_screen.h
@@ -35,6 +35,7 @@ struct rdp_shadow_screen
 	REGION16 invalidRegion;
 
 	rdpShadowSurface* primary;
+	rdpShadowSurface* lobby;
 };
 
 #ifdef __cplusplus

--- a/server/shadow/shadow_surface.h
+++ b/server/shadow/shadow_surface.h
@@ -45,6 +45,7 @@ extern "C" {
 
 rdpShadowSurface* shadow_surface_new(rdpShadowServer* server, int x, int y, int width, int height);
 void shadow_surface_free(rdpShadowSurface* surface);
+BOOL shadow_surface_resize(rdpShadowSurface *surface, int x, int y, int width, int height);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Detail fixes:
1. Add resize support in shadow framework layer
2. Enhance X11 implementation to detect desktop resolution change
3. Fix the subRect feature.
It seems not completely finished and it looks incompatible in different source code.
Fix it to be consistent in all source code as following:
a. The subRect is only awared in framework layer, subsystem implementation should not be aware of it. It only take effect at shadow_client and corresponding shadow_input.
b. The screen and surface should only represent a monitor screen. They don't need to consider subRect feature.
4. A lobby should be alternative image shown to client when the client is not 'mayView'.
We don't need to have seperate lobby for each client, move it into server structure as 'another surface'