### PR TITLE
server/shadow: Fix incorrect handle of makecert_context_process.

### DIFF
--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -554,10 +554,10 @@ static BOOL shadow_server_init_certificate(rdpShadowServer* server)
 		if (!makecert)
 			goto out_fail;
 
-		if (makecert_context_process(makecert, makecert_argc, (char**) makecert_argv) != 1)
+		if (makecert_context_process(makecert, makecert_argc, (char**) makecert_argv) < 0)
 			goto out_fail;
 
-		if (!makecert_context_set_output_file_name(makecert, "shadow") != 1)
+		if (makecert_context_set_output_file_name(makecert, "shadow") != 1)
 			goto out_fail;
 
 		if (!PathFileExistsA(server->CertificateFile))


### PR DESCRIPTION
This is introduced in PR #2708 with fault handling for makecert functions.
Other functions return '1' for OK, but makecert_context_process returns '0' for OK, so the current code is incorrect.

