### PR TITLE
Do not discard events when updating EGFX surface mapping

### DIFF
--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -112,7 +112,7 @@ int xf_OutputUpdate(xfContext* xfc, xfGfxSurface* surface)
 	region16_clear(&surface->invalidRegion);
 
 	XSetClipMask(xfc->display, xfc->gc, None);
-	XSync(xfc->display, True);
+	XSync(xfc->display, False);
 
 	return 1;
 }


### PR DESCRIPTION
Passing True to XSync() discards any pending X11 events. Occasionally this caused ButtonRelease or KeyRelease to be lost and not forwarded to the remote computed, leading to stuck keys and buttons.

This should resolve issue #2391