### PR TITLE
Fix event created for WSAEventSelect

### DIFF
--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -360,7 +360,7 @@ static int transport_bio_simple_init(BIO* bio, SOCKET socket, int shutdown)
 	bio->init = 1;
 
 #ifdef _WIN32
-		ptr->hEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
+		ptr->hEvent = WSACreateEvent();
 
 		if (!ptr->hEvent)
 			return 0;


### PR DESCRIPTION
Fix event created for WSAEventSelect: The event we pass to WSAEventSelect should be WSAEVENT instead of normal event.

From MSDN, it looks same as CreateEvent(NULL, FALSE, FALSE, NULL):
	The WSACreateEvent function creates a manual-reset event object with an initial state of nonsignaled. The event object is unnamed.
However they are not really equivalent. When we use normal event, the WSAEventSelect still works but the event appears to be 'auto-reset'.

On my Win7 in labtop and Win7 in virtual machine, the client connection always stuck because the WSA event is 'consumed' by WaitForMultipleObjects and the later WaitForSingleObject only get a 'timeout'

I found this issue when testing shadow server on win7. 