### PR TITLE
server/shadow: Fix compile error on win32.

### DIFF
--- a/include/freerdp/server/shadow.h
+++ b/include/freerdp/server/shadow.h
@@ -204,7 +204,7 @@ typedef struct _SHADOW_MSG_OUT SHADOW_MSG_OUT;
 typedef void (*MSG_OUT_FREE_FN)(UINT32 id, SHADOW_MSG_OUT* msg);
 #define RDP_SHADOW_MSG_OUT_COMMON() \
 	int refCount; \
-	MSG_OUT_FREE_FN Free; /* function to free SHADOW_MSG_OUT */
+	MSG_OUT_FREE_FN Free /* function to free SHADOW_MSG_OUT */
 
 struct _SHADOW_MSG_OUT
 {

--- a/include/freerdp/server/shadow.h
+++ b/include/freerdp/server/shadow.h
@@ -201,10 +201,10 @@ struct _SHADOW_MSG_IN_SUPPRESS_OUTPUT
 typedef struct _SHADOW_MSG_IN_SUPPRESS_OUTPUT SHADOW_MSG_IN_SUPPRESS_OUTPUT;
 
 typedef struct _SHADOW_MSG_OUT SHADOW_MSG_OUT;
-typedef void (*MSG_OUT_FREE_FN)(UINT32 id, SHADOW_MSG_OUT* msg);
+typedef void (*MSG_OUT_FREE_FN)(UINT32 id, SHADOW_MSG_OUT* msg); /* function to free SHADOW_MSG_OUT */
 #define RDP_SHADOW_MSG_OUT_COMMON() \
 	int refCount; \
-	MSG_OUT_FREE_FN Free /* function to free SHADOW_MSG_OUT */
+	MSG_OUT_FREE_FN Free
 
 struct _SHADOW_MSG_OUT
 {

--- a/server/shadow/Mac/mac_shadow.c
+++ b/server/shadow/Mac/mac_shadow.c
@@ -667,7 +667,7 @@ macShadowSubsystem* mac_shadow_subsystem_new()
 	return subsystem;
 }
 
-int Mac_ShadowSubsystemEntry(RDP_SHADOW_ENTRY_POINTS* pEntryPoints)
+FREERDP_API int Mac_ShadowSubsystemEntry(RDP_SHADOW_ENTRY_POINTS* pEntryPoints)
 {
 	pEntryPoints->New = (pfnShadowSubsystemNew) mac_shadow_subsystem_new;
 	pEntryPoints->Free = (pfnShadowSubsystemFree) mac_shadow_subsystem_free;

--- a/server/shadow/Win/win_shadow.c
+++ b/server/shadow/Win/win_shadow.c
@@ -525,7 +525,7 @@ winShadowSubsystem* win_shadow_subsystem_new()
 	return subsystem;
 }
 
-int Win_ShadowSubsystemEntry(RDP_SHADOW_ENTRY_POINTS* pEntryPoints)
+FREERDP_API int Win_ShadowSubsystemEntry(RDP_SHADOW_ENTRY_POINTS* pEntryPoints)
 {
 	pEntryPoints->New = (pfnShadowSubsystemNew) win_shadow_subsystem_new;
 	pEntryPoints->Free = (pfnShadowSubsystemFree) win_shadow_subsystem_free;

--- a/server/shadow/X11/x11_shadow.c
+++ b/server/shadow/X11/x11_shadow.c
@@ -1377,7 +1377,7 @@ void x11_shadow_subsystem_free(x11ShadowSubsystem* subsystem)
 	free(subsystem);
 }
 
-int X11_ShadowSubsystemEntry(RDP_SHADOW_ENTRY_POINTS* pEntryPoints)
+FREERDP_API int X11_ShadowSubsystemEntry(RDP_SHADOW_ENTRY_POINTS* pEntryPoints)
 {
 	pEntryPoints->New = (pfnShadowSubsystemNew) x11_shadow_subsystem_new;
 	pEntryPoints->Free = (pfnShadowSubsystemFree) x11_shadow_subsystem_free;


### PR DESCRIPTION
This is introduced by previous standalone fixes. 