### PR TITLE
NLA decrypt credentials fixed.

### DIFF
--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -945,7 +945,7 @@ BOOL nla_read_ts_password_creds(rdpNla* nla, wStream* s)
 		return FALSE;
 	}
 	nla->identity->UserLength = (UINT32) length;
-	if (nla->identity->PasswordLength > 0)
+	if (nla->identity->UserLength > 0)
 	{
 		nla->identity->User = (UINT16 *) malloc(length);
 		if (!nla->identity->User)


### PR DESCRIPTION
Fixes a bug in server side credential decryption.
The username was skipped during decryption caused by the password length being checked instead of username length.