### PR TITLE
Add write event support to HANDLE

### DIFF
--- a/channels/urbdrc/client/urbdrc_main.c
+++ b/channels/urbdrc/client/urbdrc_main.c
@@ -741,7 +741,9 @@ static void* urbdrc_search_usb_device(void* arg)
 
 	/* Get the file descriptor (fd) for the monitor.
 	   This fd will get passed to select() */
-	if (!(mon_fd = CreateFileDescriptorEvent(NULL, TRUE, FALSE, udev_monitor_get_fd(mon))))
+	mon_fd = CreateFileDescriptorEvent(NULL, TRUE, FALSE,
+				udev_monitor_get_fd(mon), FD_READ);
+	if (!mon_fd)
 		goto fail_create_monfd_event;
 
 	while (1)

--- a/client/Android/FreeRDPCore/jni/android_freerdp.c
+++ b/client/Android/FreeRDPCore/jni/android_freerdp.c
@@ -348,10 +348,12 @@ static void* jni_input_thread(void* arg)
 	if (!(queue = freerdp_get_message_queue(instance, FREERDP_INPUT_MESSAGE_QUEUE)))
 		goto fail_get_message_queue;
 
-	if (!(event[0] = CreateFileDescriptorEvent(NULL, FALSE, FALSE, aCtx->event_queue->pipe_fd[0])))
+	if (!(event[0] = CreateFileDescriptorEvent(NULL, FALSE, FALSE,
+				aCtx->event_queue->pipe_fd[0], FD_READ)))
 		goto fail_create_event_0;
 
-	if (!(event[1] = CreateFileDescriptorEvent(NULL, FALSE, FALSE, aCtx->event_queue->pipe_fd[1])))
+	if (!(event[1] = CreateFileDescriptorEvent(NULL, FALSE, FALSE,
+				aCtx->event_queue->pipe_fd[1], FD_READ)))
 		goto fail_create_event_1;
 
 	if (!(event[2] = freerdp_get_message_queue_event_handle(instance, FREERDP_INPUT_MESSAGE_QUEUE)))

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1790,7 +1790,7 @@ static BOOL xfreerdp_client_new(freerdp* instance, rdpContext* context)
 	xfc->invert = (ImageByteOrder(xfc->display) == MSBFirst) ? TRUE : FALSE;
 	xfc->complex_regions = TRUE;
 
-	xfc->x11event = CreateFileDescriptorEvent(NULL, FALSE, FALSE, xfc->xfds);
+	xfc->x11event = CreateFileDescriptorEvent(NULL, FALSE, FALSE, xfc->xfds, FD_READ);
 	if (!xfc->x11event)
 	{
 		WLog_ERR(TAG, "Could not create xfds event");

--- a/libfreerdp/core/listener.c
+++ b/libfreerdp/core/listener.c
@@ -168,7 +168,8 @@ static BOOL freerdp_listener_open(freerdp_listener* instance, const char* bind_a
 		/* FIXME: these file descriptors do not work on Windows */
 
 		listener->sockfds[listener->num_sockfds] = sockfd;
-		listener->events[listener->num_sockfds] = CreateFileDescriptorEvent(NULL, FALSE, FALSE, sockfd);
+		listener->events[listener->num_sockfds] =
+			CreateFileDescriptorEvent(NULL, FALSE, FALSE, sockfd, FD_READ);
 		listener->num_sockfds++;
 
 		WLog_INFO(TAG, "Listening on %s:%s", addr, servname);
@@ -226,7 +227,8 @@ static BOOL freerdp_listener_open_local(freerdp_listener* instance, const char* 
 		return FALSE;
 	}
 
-	if (!(hevent = CreateFileDescriptorEvent(NULL, FALSE, FALSE, sockfd)))
+	hevent = CreateFileDescriptorEvent(NULL, FALSE, FALSE, sockfd, FD_READ);
+	if (!hevent)
 	{
 		WLog_ERR(TAG, "failed to create sockfd event");
 		closesocket((SOCKET) sockfd);
@@ -258,7 +260,8 @@ static BOOL freerdp_listener_open_from_socket(freerdp_listener* instance, int fd
 		return FALSE;
 
 	listener->sockfds[listener->num_sockfds] = fd;
-	listener->events[listener->num_sockfds] = CreateFileDescriptorEvent(NULL, FALSE, FALSE, fd);
+	listener->events[listener->num_sockfds] =
+		CreateFileDescriptorEvent(NULL, FALSE, FALSE, fd, FD_READ);
 	if (!listener->events[listener->num_sockfds])
 		return FALSE;
 

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -368,7 +368,7 @@ static int transport_bio_simple_init(BIO* bio, SOCKET socket, int shutdown)
 		/* WSAEventSelect automatically sets the socket in non-blocking mode */
 		WSAEventSelect(ptr->socket, ptr->hEvent, FD_READ | FD_WRITE | FD_CLOSE);
 #else
-		ptr->hEvent = CreateFileDescriptorEvent(NULL, FALSE, FALSE, (int) ptr->socket);
+		ptr->hEvent = CreateFileDescriptorEvent(NULL, FALSE, FALSE, (int) ptr->socket, FD_READ);
 
 		if (!ptr->hEvent)
 			return 0;

--- a/server/shadow/X11/x11_shadow.c
+++ b/server/shadow/X11/x11_shadow.c
@@ -1264,7 +1264,8 @@ int x11_shadow_subsystem_init(x11ShadowSubsystem* subsystem)
 			subsystem->use_xdamage = FALSE;
 	}
 
-	if (!(subsystem->event = CreateFileDescriptorEvent(NULL, FALSE, FALSE, subsystem->xfds)))
+	if (!(subsystem->event = CreateFileDescriptorEvent(NULL, FALSE, FALSE,
+							subsystem->xfds, FD_READ)))
 		return -1;
 
 	virtualScreen = &(subsystem->virtualScreen);

--- a/winpr/include/winpr/debug.h
+++ b/winpr/include/winpr/debug.h
@@ -27,6 +27,7 @@ extern "C" {
 
 #include <winpr/wtypes.h>
 
+WINPR_API void winpr_log_backtrace(const char* tag, DWORD level, DWORD size);
 WINPR_API void* winpr_backtrace(DWORD size);
 WINPR_API void winpr_backtrace_free(void* buffer);
 WINPR_API char** winpr_backtrace_symbols(void* buffer, size_t* used);

--- a/winpr/include/winpr/handle.h
+++ b/winpr/include/winpr/handle.h
@@ -41,8 +41,12 @@ extern "C" {
 
 WINPR_API BOOL CloseHandle(HANDLE hObject);
 
-WINPR_API BOOL DuplicateHandle(HANDLE hSourceProcessHandle, HANDLE hSourceHandle, HANDLE hTargetProcessHandle,
-	LPHANDLE lpTargetHandle, DWORD dwDesiredAccess, BOOL bInheritHandle, DWORD dwOptions);
+WINPR_API BOOL DuplicateHandle(HANDLE hSourceProcessHandle,
+				HANDLE hSourceHandle,
+				HANDLE hTargetProcessHandle,
+				LPHANDLE lpTargetHandle,
+				DWORD dwDesiredAccess,
+				BOOL bInheritHandle, DWORD dwOptions);
 
 WINPR_API BOOL GetHandleInformation(HANDLE hObject, LPDWORD lpdwFlags);
 WINPR_API BOOL SetHandleInformation(HANDLE hObject, DWORD dwMask, DWORD dwFlags);

--- a/winpr/include/winpr/synch.h
+++ b/winpr/include/winpr/synch.h
@@ -30,6 +30,7 @@
 #include <winpr/wtypes.h>
 #include <winpr/error.h>
 #include <winpr/handle.h>
+#include <winpr/winsock.h>
 
 #include <winpr/nt.h>
 
@@ -338,9 +339,9 @@ WINPR_API BOOL WINAPI DeleteSynchronizationBarrier(LPSYNCHRONIZATION_BARRIER lpB
 WINPR_API VOID USleep(DWORD dwMicroseconds);
 
 WINPR_API HANDLE CreateFileDescriptorEventW(LPSECURITY_ATTRIBUTES lpEventAttributes,
-		BOOL bManualReset, BOOL bInitialState, int FileDescriptor);
+		BOOL bManualReset, BOOL bInitialState, int FileDescriptor, ULONG mode);
 WINPR_API HANDLE CreateFileDescriptorEventA(LPSECURITY_ATTRIBUTES lpEventAttributes,
-		BOOL bManualReset, BOOL bInitialState, int FileDescriptor);
+		BOOL bManualReset, BOOL bInitialState, int FileDescriptor, ULONG mode);
 
 WINPR_API HANDLE CreateWaitObjectEvent(LPSECURITY_ATTRIBUTES lpEventAttributes,
 		BOOL bManualReset, BOOL bInitialState, void* pObject);
@@ -352,7 +353,7 @@ WINPR_API HANDLE CreateWaitObjectEvent(LPSECURITY_ATTRIBUTES lpEventAttributes,
 #endif
 
 WINPR_API int GetEventFileDescriptor(HANDLE hEvent);
-WINPR_API int SetEventFileDescriptor(HANDLE hEvent, int FileDescriptor);
+WINPR_API int SetEventFileDescriptor(HANDLE hEvent, int FileDescriptor, ULONG mode);
 
 WINPR_API void* GetEventWaitObject(HANDLE hEvent);
 

--- a/winpr/libwinpr/comm/comm.c
+++ b/winpr/libwinpr/comm/comm.c
@@ -1221,7 +1221,7 @@ BOOL IsCommDevice(LPCTSTR lpDeviceName)
 void _comm_setServerSerialDriver(HANDLE hComm, SERIAL_DRIVER_ID driverId)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_COMM* pComm;
 
 	if (!CommInitialized())
@@ -1344,7 +1344,7 @@ HANDLE CommCreateFileA(LPCSTR lpDeviceName, DWORD dwDesiredAccess, DWORD dwShare
 		return INVALID_HANDLE_VALUE;
 	}
 
-	WINPR_HANDLE_SET_TYPE(pComm, HANDLE_TYPE_COMM);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(pComm, HANDLE_TYPE_COMM, FD_READ);
 
 	pComm->ops = &ops;
 

--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -414,7 +414,7 @@ HANDLE CreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, 
 	}
 
 	hNamedPipe = (HANDLE) pNamedPipe;
-	WINPR_HANDLE_SET_TYPE(pNamedPipe, HANDLE_TYPE_NAMED_PIPE);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(pNamedPipe, HANDLE_TYPE_NAMED_PIPE, FD_READ);
 	pNamedPipe->name = _strdup(lpFileName);
 	if (!pNamedPipe->name)
 	{
@@ -502,7 +502,6 @@ BOOL ReadFile(HANDLE hFile, LPVOID lpBuffer, DWORD nNumberOfBytesToRead,
 			  LPDWORD lpNumberOfBytesRead, LPOVERLAPPED lpOverlapped)
 {
 	ULONG Type;
-	PVOID Object;
 	WINPR_HANDLE *handle;
 
 	if (hFile == INVALID_HANDLE_VALUE)
@@ -516,12 +515,12 @@ BOOL ReadFile(HANDLE hFile, LPVOID lpBuffer, DWORD nNumberOfBytesToRead,
 	if (!lpNumberOfBytesRead && !lpOverlapped)
 		return FALSE;
 
-	if (!winpr_Handle_GetInfo(hFile, &Type, &Object))
+	if (!winpr_Handle_GetInfo(hFile, &Type, &handle))
 		return FALSE;
 
 	handle = (WINPR_HANDLE *)hFile;
 	if (handle->ops->ReadFile)
-		return handle->ops->ReadFile(Object, lpBuffer, nNumberOfBytesToRead, lpNumberOfBytesRead, lpOverlapped);
+		return handle->ops->ReadFile(handle, lpBuffer, nNumberOfBytesToRead, lpNumberOfBytesRead, lpOverlapped);
 
 	WLog_ERR(TAG, "ReadFile operation not implemented");
 	return FALSE;
@@ -543,18 +542,17 @@ BOOL WriteFile(HANDLE hFile, LPCVOID lpBuffer, DWORD nNumberOfBytesToWrite,
 			   LPDWORD lpNumberOfBytesWritten, LPOVERLAPPED lpOverlapped)
 {
 	ULONG Type;
-	PVOID Object;
 	WINPR_HANDLE *handle;
 
 	if (hFile == INVALID_HANDLE_VALUE)
 		return FALSE;
 
-	if (!winpr_Handle_GetInfo(hFile, &Type, &Object))
+	if (!winpr_Handle_GetInfo(hFile, &Type, &handle))
 		return FALSE;
 
 	handle = (WINPR_HANDLE *)hFile;
 	if (handle->ops->WriteFile)
-		return handle->ops->WriteFile(Object, lpBuffer, nNumberOfBytesToWrite, lpNumberOfBytesWritten, lpOverlapped);
+		return handle->ops->WriteFile(handle, lpBuffer, nNumberOfBytesToWrite, lpNumberOfBytesWritten, lpOverlapped);
 
 	WLog_ERR(TAG, "ReadFile operation not implemented");
 	return FALSE;

--- a/winpr/libwinpr/handle/handle.c
+++ b/winpr/libwinpr/handle/handle.c
@@ -48,7 +48,7 @@ BOOL CloseHandle(HANDLE hObject)
 	ULONG Type;
 	WINPR_HANDLE *Object;
 
-	if (!winpr_Handle_GetInfo(hObject, &Type, (PVOID*) &Object))
+	if (!winpr_Handle_GetInfo(hObject, &Type, &Object))
 		return FALSE;
 
 	if (!Object)

--- a/winpr/libwinpr/handle/handle.h
+++ b/winpr/libwinpr/handle/handle.h
@@ -23,6 +23,7 @@
 #include <winpr/handle.h>
 #include <winpr/file.h>
 #include <winpr/synch.h>
+#include <winpr/winsock.h>
 
 #define HANDLE_TYPE_NONE			0
 #define HANDLE_TYPE_PROCESS			1
@@ -41,6 +42,7 @@
 
 #define WINPR_HANDLE_DEF() \
 	ULONG Type; \
+	ULONG Mode; \
 	HANDLE_OPS *ops
 
 typedef BOOL (*pcIsHandled)(HANDLE handle);
@@ -68,10 +70,16 @@ struct winpr_handle
 };
 typedef struct winpr_handle WINPR_HANDLE;
 
-#define WINPR_HANDLE_SET_TYPE(_handle, _type) \
-	_handle->Type = _type
+static INLINE void WINPR_HANDLE_SET_TYPE_AND_MODE(void* _handle,
+						 ULONG _type, ULONG _mode)
+{
+	WINPR_HANDLE* hdl = (WINPR_HANDLE*)_handle;
 
-static INLINE BOOL winpr_Handle_GetInfo(HANDLE handle, ULONG* pType, PVOID* pObject)
+	hdl->Type = _type;
+	hdl->Mode = _mode;
+}
+
+static INLINE BOOL winpr_Handle_GetInfo(HANDLE handle, ULONG* pType, WINPR_HANDLE** pObject)
 {
 	WINPR_HANDLE* wHandle;
 
@@ -91,7 +99,7 @@ static INLINE int winpr_Handle_getFd(HANDLE handle)
 	WINPR_HANDLE *hdl;
 	ULONG type;
 
-	if (!winpr_Handle_GetInfo(handle, &type, (PVOID*)&hdl))
+	if (!winpr_Handle_GetInfo(handle, &type, &hdl))
 		return -1;
 
 	if (!hdl || !hdl->ops->GetFd)
@@ -105,7 +113,7 @@ static INLINE DWORD winpr_Handle_cleanup(HANDLE handle)
 	WINPR_HANDLE *hdl;
 	ULONG type;
 
-	if (!winpr_Handle_GetInfo(handle, &type, (PVOID*)&hdl))
+	if (!winpr_Handle_GetInfo(handle, &type, &hdl))
 		return WAIT_FAILED;
 
 	if (!hdl)

--- a/winpr/libwinpr/io/io.c
+++ b/winpr/libwinpr/io/io.c
@@ -50,7 +50,7 @@
 BOOL GetOverlappedResult(HANDLE hFile, LPOVERLAPPED lpOverlapped, LPDWORD lpNumberOfBytesTransferred, BOOL bWait)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 
 	if (!winpr_Handle_GetInfo(hFile, &Type, &Object))
 		return FALSE;

--- a/winpr/libwinpr/pipe/pipe.c
+++ b/winpr/libwinpr/pipe/pipe.c
@@ -454,11 +454,11 @@ BOOL CreatePipe(PHANDLE hReadPipe, PHANDLE hWritePipe, LPSECURITY_ATTRIBUTES lpP
 
 	pReadPipe->fd = pipe_fd[0];
 	pWritePipe->fd = pipe_fd[1];
-	WINPR_HANDLE_SET_TYPE(pReadPipe, HANDLE_TYPE_ANONYMOUS_PIPE);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(pReadPipe, HANDLE_TYPE_ANONYMOUS_PIPE, FD_READ);
 	pReadPipe->ops = &ops;
 
 	*((ULONG_PTR*) hReadPipe) = (ULONG_PTR) pReadPipe;
-	WINPR_HANDLE_SET_TYPE(pWritePipe, HANDLE_TYPE_ANONYMOUS_PIPE);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(pWritePipe, HANDLE_TYPE_ANONYMOUS_PIPE, FD_READ);
 	pWritePipe->ops = &ops;
 	*((ULONG_PTR*) hWritePipe) = (ULONG_PTR) pWritePipe;
 	return TRUE;
@@ -531,7 +531,7 @@ HANDLE CreateNamedPipeA(LPCSTR lpName, DWORD dwOpenMode, DWORD dwPipeMode, DWORD
 	if (!pNamedPipe)
 		return INVALID_HANDLE_VALUE;
 
-	WINPR_HANDLE_SET_TYPE(pNamedPipe, HANDLE_TYPE_NAMED_PIPE);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(pNamedPipe, HANDLE_TYPE_NAMED_PIPE, FD_READ);
 
 	pNamedPipe->serverfd = -1;
 	pNamedPipe->clientfd = -1;

--- a/winpr/libwinpr/sspicli/sspicli.c
+++ b/winpr/libwinpr/sspicli/sspicli.c
@@ -131,7 +131,7 @@ BOOL LogonUserA(LPCSTR lpszUsername, LPCSTR lpszDomain, LPCSTR lpszPassword,
 	if (!token)
 		return FALSE;
 
-	WINPR_HANDLE_SET_TYPE(token, HANDLE_TYPE_ACCESS_TOKEN);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(token, HANDLE_TYPE_ACCESS_TOKEN, FD_READ);
 
 	token->ops = &ops;
 

--- a/winpr/libwinpr/synch/event.c
+++ b/winpr/libwinpr/synch/event.c
@@ -376,7 +376,7 @@ int SetEventFileDescriptor(HANDLE hEvent, int FileDescriptor, ULONG mode)
 		return -1;
 
 	event = (WINPR_EVENT*) Object;
-	event->bAttached = TRUE;
+	event->bAttached = FALSE;
 	event->Mode = mode;
 	event->pipe_fd[0] = FileDescriptor;
 	return 0;

--- a/winpr/libwinpr/synch/event.c
+++ b/winpr/libwinpr/synch/event.c
@@ -78,23 +78,22 @@ BOOL EventCloseHandle(HANDLE handle) {
 	if (!EventIsHandled(handle))
 		return FALSE;
 
-    if (!event->bAttached)
-    {
-        if (event->pipe_fd[0] != -1)
-        {
-        	close(event->pipe_fd[0]);
-        	event->pipe_fd[0] = -1;
-        }
+	if (!event->bAttached)
+	{
+		if (event->pipe_fd[0] != -1)
+		{
+			close(event->pipe_fd[0]);
+			event->pipe_fd[0] = -1;
+		}
+		if (event->pipe_fd[1] != -1)
+		{
+			close(event->pipe_fd[1]);
+			event->pipe_fd[1] = -1;
+		}
+	}
 
-        if (event->pipe_fd[1] != -1)
-        {
-        	close(event->pipe_fd[1]);
-        	event->pipe_fd[1] = -1;
-        }
-    }
-
-    free(event);
-    return TRUE;
+	free(event);
+	return TRUE;
 }
 
 static HANDLE_OPS ops = {
@@ -114,7 +113,7 @@ HANDLE CreateEventW(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL bManualReset, 
 	event->bAttached = FALSE;
 	event->bManualReset = bManualReset;
 	event->ops = &ops;
-	WINPR_HANDLE_SET_TYPE(event, HANDLE_TYPE_EVENT);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(event, HANDLE_TYPE_EVENT, FD_READ);
 
 	if (!event->bManualReset)
 	{
@@ -200,7 +199,7 @@ static int eventfd_write(int fd, eventfd_t value)
 BOOL SetEvent(HANDLE hEvent)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	int length;
 	BOOL status;
 	WINPR_EVENT* event;
@@ -241,7 +240,7 @@ BOOL SetEvent(HANDLE hEvent)
 BOOL ResetEvent(HANDLE hEvent)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	int length;
 	BOOL status = TRUE;
 	WINPR_EVENT* event;
@@ -274,7 +273,9 @@ BOOL ResetEvent(HANDLE hEvent)
 #endif
 
 
-HANDLE CreateFileDescriptorEventW(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL bManualReset, BOOL bInitialState, int FileDescriptor)
+HANDLE CreateFileDescriptorEventW(LPSECURITY_ATTRIBUTES lpEventAttributes,
+					BOOL bManualReset, BOOL bInitialState,
+					int FileDescriptor, ULONG mode)
 {
 #ifndef _WIN32
 	WINPR_EVENT* event;
@@ -288,7 +289,7 @@ HANDLE CreateFileDescriptorEventW(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL 
 		event->pipe_fd[0] = FileDescriptor;
 		event->pipe_fd[1] = -1;
 		event->ops = &ops;
-		WINPR_HANDLE_SET_TYPE(event, HANDLE_TYPE_EVENT);
+		WINPR_HANDLE_SET_TYPE_AND_MODE(event, HANDLE_TYPE_EVENT, mode);
 		handle = (HANDLE) event;
 	}
 
@@ -298,9 +299,12 @@ HANDLE CreateFileDescriptorEventW(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL 
 #endif
 }
 
-HANDLE CreateFileDescriptorEventA(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL bManualReset, BOOL bInitialState, int FileDescriptor)
+HANDLE CreateFileDescriptorEventA(LPSECURITY_ATTRIBUTES lpEventAttributes,
+				BOOL bManualReset, BOOL bInitialState,
+				int FileDescriptor, ULONG mode)
 {
-	return CreateFileDescriptorEventW(lpEventAttributes, bManualReset, bInitialState, FileDescriptor);
+	return CreateFileDescriptorEventW(lpEventAttributes, bManualReset,
+					bInitialState, FileDescriptor, mode);
 }
 
 /**
@@ -310,7 +314,8 @@ HANDLE CreateWaitObjectEvent(LPSECURITY_ATTRIBUTES lpEventAttributes,
 							 BOOL bManualReset, BOOL bInitialState, void* pObject)
 {
 #ifndef _WIN32
-	return CreateFileDescriptorEventW(lpEventAttributes, bManualReset, bInitialState, (int)(ULONG_PTR) pObject);
+	return CreateFileDescriptorEventW(lpEventAttributes, bManualReset,
+					bInitialState, (int)(ULONG_PTR) pObject, FD_READ);
 #else
 	HANDLE hEvent = NULL;
 	DuplicateHandle(GetCurrentProcess(), pObject, GetCurrentProcess(), &hEvent, 0, FALSE, DUPLICATE_SAME_ACCESS);
@@ -327,7 +332,7 @@ int GetEventFileDescriptor(HANDLE hEvent)
 {
 #ifndef _WIN32
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_EVENT* event;
 
 	if (!winpr_Handle_GetInfo(hEvent, &Type, &Object))
@@ -360,17 +365,19 @@ int GetEventFileDescriptor(HANDLE hEvent)
  * This file descriptor is not usable on Windows
  */
 
-int SetEventFileDescriptor(HANDLE hEvent, int FileDescriptor)
+int SetEventFileDescriptor(HANDLE hEvent, int FileDescriptor, ULONG mode)
 {
 #ifndef _WIN32
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_EVENT* event;
 
 	if (!winpr_Handle_GetInfo(hEvent, &Type, &Object))
 		return -1;
 
 	event = (WINPR_EVENT*) Object;
+	event->bAttached = TRUE;
+	event->Mode = mode;
 	event->pipe_fd[0] = FileDescriptor;
 	return 0;
 #else

--- a/winpr/libwinpr/synch/mutex.c
+++ b/winpr/libwinpr/synch/mutex.c
@@ -140,7 +140,7 @@ HANDLE CreateMutexW(LPSECURITY_ATTRIBUTES lpMutexAttributes, BOOL bInitialOwner,
 	{
 		pthread_mutex_init(&mutex->mutex, 0);
 
-		WINPR_HANDLE_SET_TYPE(mutex, HANDLE_TYPE_MUTEX);
+		WINPR_HANDLE_SET_TYPE_AND_MODE(mutex, HANDLE_TYPE_MUTEX, FD_READ);
 		mutex->ops = &ops;
 
 		handle = (HANDLE) mutex;
@@ -180,7 +180,7 @@ HANDLE OpenMutexW(DWORD dwDesiredAccess, BOOL bInheritHandle,LPCWSTR lpName)
 BOOL ReleaseMutex(HANDLE hMutex)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_MUTEX* mutex;
 
 	if (!winpr_Handle_GetInfo(hMutex, &Type, &Object))

--- a/winpr/libwinpr/synch/semaphore.c
+++ b/winpr/libwinpr/synch/semaphore.c
@@ -179,7 +179,7 @@ HANDLE CreateSemaphoreW(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lIniti
 #endif
 	}
 
-	WINPR_HANDLE_SET_TYPE(semaphore, HANDLE_TYPE_SEMAPHORE);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(semaphore, HANDLE_TYPE_SEMAPHORE, FD_READ);
 	handle = (HANDLE) semaphore;
 	return handle;
 }
@@ -204,7 +204,7 @@ HANDLE OpenSemaphoreA(DWORD dwDesiredAccess, BOOL bInheritHandle, LPCSTR lpName)
 BOOL ReleaseSemaphore(HANDLE hSemaphore, LONG lReleaseCount, LPLONG lpPreviousCount)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_SEMAPHORE* semaphore;
 
 	if (!winpr_Handle_GetInfo(hSemaphore, &Type, &Object))

--- a/winpr/libwinpr/synch/timer.c
+++ b/winpr/libwinpr/synch/timer.c
@@ -230,7 +230,7 @@ HANDLE CreateWaitableTimerA(LPSECURITY_ATTRIBUTES lpTimerAttributes, BOOL bManua
 	timer = (WINPR_TIMER*) calloc(1, sizeof(WINPR_TIMER));
 	if (timer)
 	{
-		WINPR_HANDLE_SET_TYPE(timer, HANDLE_TYPE_TIMER);
+		WINPR_HANDLE_SET_TYPE_AND_MODE(timer, HANDLE_TYPE_TIMER, FD_READ);
 		handle = (HANDLE) timer;
 		timer->fd = -1;
 		timer->lPeriod = 0;
@@ -265,7 +265,7 @@ BOOL SetWaitableTimer(HANDLE hTimer, const LARGE_INTEGER* lpDueTime, LONG lPerio
 					  PTIMERAPCROUTINE pfnCompletionRoutine, LPVOID lpArgToCompletionRoutine, BOOL fResume)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_TIMER* timer;
 #ifdef WITH_POSIX_TIMER
 	LONGLONG seconds = 0;
@@ -365,7 +365,7 @@ BOOL SetWaitableTimerEx(HANDLE hTimer, const LARGE_INTEGER* lpDueTime, LONG lPer
 						PTIMERAPCROUTINE pfnCompletionRoutine, LPVOID lpArgToCompletionRoutine, PREASON_CONTEXT WakeContext, ULONG TolerableDelay)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_TIMER* timer;
 
 	if (!winpr_Handle_GetInfo(hTimer, &Type, &Object))
@@ -612,7 +612,7 @@ HANDLE CreateTimerQueue(void)
 
 	if (timerQueue)
 	{
-		WINPR_HANDLE_SET_TYPE(timerQueue, HANDLE_TYPE_TIMER_QUEUE);
+		WINPR_HANDLE_SET_TYPE_AND_MODE(timerQueue, HANDLE_TYPE_TIMER_QUEUE, FD_READ);
 		handle = (HANDLE) timerQueue;
 		timerQueue->activeHead = NULL;
 		timerQueue->inactiveHead = NULL;
@@ -706,7 +706,7 @@ BOOL CreateTimerQueueTimer(PHANDLE phNewTimer, HANDLE TimerQueue,
 	if (!timer)
 		return FALSE;
 
-	WINPR_HANDLE_SET_TYPE(timer, HANDLE_TYPE_TIMER_QUEUE_TIMER);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(timer, HANDLE_TYPE_TIMER_QUEUE_TIMER, FD_READ);
 	*((UINT_PTR*) phNewTimer) = (UINT_PTR)(HANDLE) timer;
 	timespec_copy(&(timer->StartTime), &CurrentTime);
 	timespec_add_ms(&(timer->StartTime), DueTime);

--- a/winpr/libwinpr/synch/wait.c
+++ b/winpr/libwinpr/synch/wait.c
@@ -217,10 +217,8 @@ DWORD WaitForSingleObject(HANDLE hHandle, DWORD dwMilliseconds)
 	{
 		WINPR_PROCESS *process;
 		process = (WINPR_PROCESS *) Object;
-		int rc;
 
-		rc = waitpid(process->pid, &(process->status), 0);
-		if (rc != process->pid)
+		if (process->pid != waitpid(process->pid, &(process->status), 0))
 		{
 			WLog_ERR(TAG, "waitpid failure [%d] %s", errno, strerror(errno));
 			return WAIT_FAILED;

--- a/winpr/libwinpr/synch/wait.c
+++ b/winpr/libwinpr/synch/wait.c
@@ -44,6 +44,7 @@
 #include "synch.h"
 #include "../thread/thread.h"
 #include <winpr/thread.h>
+#include <winpr/debug.h>
 
 #include "../log.h"
 #define TAG WINPR_TAG("sync.wait")
@@ -132,6 +133,19 @@ static int pthread_mutex_timedlock(pthread_mutex_t *mutex, const struct timespec
 }
 #endif
 
+#ifdef HAVE_POLL_H
+static DWORD handle_mode_to_pollevent(ULONG mode)
+{
+	DWORD event = 0;
+	if (mode & FD_READ)
+		event |= POLLIN;
+	if (mode & FD_WRITE)
+		event |= POLLOUT;
+
+	return event;
+}
+#endif
+
 static void ts_add_ms(struct timespec *ts, DWORD dwMilliseconds)
 {
 	ts->tv_sec += dwMilliseconds / 1000L;
@@ -140,13 +154,13 @@ static void ts_add_ms(struct timespec *ts, DWORD dwMilliseconds)
 	ts->tv_nsec = ts->tv_nsec % 1000000000L;
 }
 
-static int waitOnFd(int fd, DWORD dwMilliseconds)
+static int waitOnFd(int fd, ULONG mode, DWORD dwMilliseconds)
 {
 	int status;
 #ifdef HAVE_POLL_H
 	struct pollfd pollfds;
 	pollfds.fd = fd;
-	pollfds.events = POLLIN;
+	pollfds.events = handle_mode_to_pollevent(mode);
 	pollfds.revents = 0;
 
 	do
@@ -157,10 +171,20 @@ static int waitOnFd(int fd, DWORD dwMilliseconds)
 
 #else
 	struct timeval timeout;
-	fd_set rfds;
+	fd_set rfds, wfds;
+	fd_set* prfds = NULL;
+	fd_set* pwfds = NULL;
+	fd_set* pefds = NULL;
 	FD_ZERO(&rfds);
 	FD_SET(fd, &rfds);
+	FD_ZERO(&wfds);
+	FD_SET(fd, &wfds);
 	ZeroMemory(&timeout, sizeof(timeout));
+
+	if (mode & FD_READ)
+		prfds = &rfds;
+	if (mode & FD_WRITE)
+		pwfds = &wfds;
 
 	if ((dwMilliseconds != INFINITE) && (dwMilliseconds != 0))
 	{
@@ -170,7 +194,7 @@ static int waitOnFd(int fd, DWORD dwMilliseconds)
 
 	do
 	{
-		status = select(fd + 1, &rfds, NULL, NULL, (dwMilliseconds == INFINITE) ? NULL : &timeout);
+		status = select(fd + 1, prfds, pwfds, pefds, (dwMilliseconds == INFINITE) ? NULL : &timeout);
 	}
 	while (status < 0 && (errno == EINTR));
 
@@ -181,7 +205,7 @@ static int waitOnFd(int fd, DWORD dwMilliseconds)
 DWORD WaitForSingleObject(HANDLE hHandle, DWORD dwMilliseconds)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 
 	if (!winpr_Handle_GetInfo(hHandle, &Type, &Object))
 	{
@@ -193,8 +217,10 @@ DWORD WaitForSingleObject(HANDLE hHandle, DWORD dwMilliseconds)
 	{
 		WINPR_PROCESS *process;
 		process = (WINPR_PROCESS *) Object;
+		int rc;
 
-		if (waitpid(process->pid, &(process->status), 0) != -1)
+		rc = waitpid(process->pid, &(process->status), 0);
+		if (rc != process->pid)
 		{
 			WLog_ERR(TAG, "waitpid failure [%d] %s", errno, strerror(errno));
 			return WAIT_FAILED;
@@ -233,7 +259,7 @@ DWORD WaitForSingleObject(HANDLE hHandle, DWORD dwMilliseconds)
 		if (fd < 0)
 			return WAIT_FAILED;
 
-		status = waitOnFd(fd, dwMilliseconds);
+		status = waitOnFd(fd, Object->Mode, dwMilliseconds);
 
 		if (status < 0)
 		{
@@ -270,12 +296,14 @@ DWORD WaitForMultipleObjects(DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAl
 	int index;
 	int status;
 	ULONG Type;
-	PVOID Object;
+	BOOL signal_handled = FALSE;
+	WINPR_HANDLE* Object;
 #ifdef HAVE_POLL_H
 	struct pollfd *pollfds;
 #else
 	int maxfd;
-	fd_set fds;
+	fd_set rfds;
+	fd_set wfds;
 	struct timeval timeout;
 #endif
 
@@ -300,14 +328,18 @@ DWORD WaitForMultipleObjects(DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAl
 
 	do
 	{
+#ifndef HAVE_POLL_H
+		fd_set* prfds = NULL;
+		fd_set* pwfds = NULL;
+		maxfd = 0;
+
+		FD_ZERO(&rfds);
+		FD_ZERO(&wfds);
+		ZeroMemory(&timeout, sizeof(timeout));
+#endif
 		if (bWaitAll && (dwMilliseconds != INFINITE))
 			clock_gettime(CLOCK_MONOTONIC, &starttime);
 
-#ifndef HAVE_POLL_H
-		maxfd = 0;
-		FD_ZERO(&fds);
-		ZeroMemory(&timeout, sizeof(timeout));
-#endif
 		polled = 0;
 
 		for (index = 0; index < nCount; index++)
@@ -336,10 +368,16 @@ DWORD WaitForMultipleObjects(DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAl
 
 #ifdef HAVE_POLL_H
 			pollfds[polled].fd = fd;
-			pollfds[polled].events = POLLIN;
+			pollfds[polled].events = handle_mode_to_pollevent(Object->Mode);
 			pollfds[polled].revents = 0;
 #else
-			FD_SET(fd, &fds);
+			FD_SET(fd, &rfds);
+			FD_SET(fd, &wfds);
+
+			if (Object->Mode & FD_READ)
+				prfds = &rfds;
+			if (Object->Mode & FD_WRITE)
+				pwfds = &wfds;
 
 			if (fd > maxfd)
 				maxfd = fd;
@@ -366,8 +404,8 @@ DWORD WaitForMultipleObjects(DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAl
 
 		do
 		{
-			status = select(maxfd + 1, &fds, 0, 0,
-							(dwMilliseconds == INFINITE) ? NULL : &timeout);
+			status = select(maxfd + 1, prfds, pwfds, 0,
+					(dwMilliseconds == INFINITE) ? NULL : &timeout);
 		}
 		while (status < 0 && errno == EINTR);
 
@@ -376,12 +414,13 @@ DWORD WaitForMultipleObjects(DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAl
 		if (status < 0)
 		{
 #ifdef HAVE_POLL_H
-			WLog_ERR(TAG, "poll() failure [%d] %s", errno,
+			WLog_ERR(TAG, "poll() handle %d (%d) failure [%d] %s", index, nCount, errno,
 					 strerror(errno));
 #else
-			WLog_ERR(TAG, "select() failure [%d] %s", errno,
+			WLog_ERR(TAG, "select() handle %d (%d) failure [%d] %s", index, nCount, errno,
 					 strerror(errno));
 #endif
+			winpr_log_backtrace(TAG, WLOG_ERROR, 20);
 			return WAIT_FAILED;
 		}
 
@@ -399,9 +438,11 @@ DWORD WaitForMultipleObjects(DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAl
 				dwMilliseconds -= (diff / 1000);
 		}
 
+		signal_handled = FALSE;
 		for (index = 0; index < polled; index++)
 		{
 			DWORD idx;
+			BOOL signal_set = FALSE;
 
 			if (bWaitAll)
 				idx = poll_map[index];
@@ -423,11 +464,14 @@ DWORD WaitForMultipleObjects(DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAl
 			}
 
 #ifdef HAVE_POLL_H
-
-			if (pollfds[index].revents & POLLIN)
+			signal_set = pollfds[index].revents & pollfds[index].events;
 #else
-			if (FD_ISSET(fd, &fds))
+			if (Object->Mode & FD_READ)
+				signal_set = FD_ISSET(fd, &rfds);
+			if (Object->Mode & FD_WRITE)
+				signal_set = FD_ISSET(fd, &wfds);
 #endif
+			if (signal_set)
 			{
 				DWORD rc = winpr_Handle_cleanup(lpHandles[idx]);
 				if (rc != WAIT_OBJECT_0)
@@ -450,10 +494,12 @@ DWORD WaitForMultipleObjects(DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAl
 
 				if (bWaitAll && (signalled >= nCount))
 					return (WAIT_OBJECT_0);
+
+				signal_handled = TRUE;
 			}
 		}
 	}
-	while (bWaitAll);
+	while (bWaitAll || !signal_handled);
 
 	WLog_ERR(TAG, "failed (unknown error)");
 	return WAIT_FAILED;

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -431,7 +431,7 @@ HANDLE CreateThread(LPSECURITY_ATTRIBUTES lpThreadAttributes, SIZE_T dwStackSize
 		goto error_thread_ready;
 	}
 
-	WINPR_HANDLE_SET_TYPE(thread, HANDLE_TYPE_THREAD);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(thread, HANDLE_TYPE_THREAD, FD_READ);
 	handle = (HANDLE) thread;
 
 	if (!thread_list)
@@ -613,7 +613,7 @@ VOID ExitThread(DWORD dwExitCode)
 BOOL GetExitCodeThread(HANDLE hThread, LPDWORD lpExitCode)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_THREAD* thread;
 
 	if (!winpr_Handle_GetInfo(hThread, &Type, &Object))
@@ -665,8 +665,8 @@ DWORD GetCurrentThreadId(VOID)
 DWORD ResumeThread(HANDLE hThread)
 {
 	ULONG Type;
-	PVOID Object;
-	WINPR_THREAD *thread;
+	WINPR_HANDLE* Object;
+	WINPR_THREAD* thread;
 
 	if (!winpr_Handle_GetInfo(hThread, &Type, &Object))
 		return 0;
@@ -697,7 +697,7 @@ BOOL SwitchToThread(VOID)
 BOOL TerminateThread(HANDLE hThread, DWORD dwExitCode)
 {
 	ULONG Type;
-	PVOID Object;
+	WINPR_HANDLE* Object;
 	WINPR_THREAD* thread;
 
 	if (!winpr_Handle_GetInfo(hThread, &Type, &Object))

--- a/winpr/libwinpr/utils/debug.c
+++ b/winpr/libwinpr/utils/debug.c
@@ -434,7 +434,7 @@ void winpr_backtrace_symbols_fd(void* buffer, int fd)
 		DWORD i;
 		size_t used;
 		char** lines;
-		
+
 		lines = winpr_backtrace_symbols(buffer, &used);
 
 		if (lines)
@@ -447,3 +447,26 @@ void winpr_backtrace_symbols_fd(void* buffer, int fd)
 	LOGF(support_msg);
 #endif
 }
+
+void winpr_log_backtrace(const char* tag, DWORD level, DWORD size)
+{
+	size_t used, x;
+	char **msg;
+	void *stack = winpr_backtrace(20);
+
+	if (!stack)
+	{
+		WLog_ERR(tag, "winpr_backtrace failed!\n");
+		winpr_backtrace_free(stack);
+		return;
+	}
+
+	msg = winpr_backtrace_symbols(stack, &used);
+	if (msg)
+	{
+		for (x=0; x<used; x++)
+			WLog_LVL(tag, level, "%zd: %s\n", x, msg[x]);
+	}
+	winpr_backtrace_free(stack);
+}
+

--- a/winpr/libwinpr/winsock/winsock.c
+++ b/winpr/libwinpr/winsock/winsock.c
@@ -647,12 +647,15 @@ BOOL WSACloseEvent(HANDLE hEvent)
 
 int WSAEventSelect(SOCKET s, WSAEVENT hEventObject, LONG lNetworkEvents)
 {
-	u_long arg = 1;
+	u_long arg = lNetworkEvents ? 1 : 0;
 
 	if (_ioctlsocket(s, FIONBIO, &arg) != 0)
 		return SOCKET_ERROR;
 
-	if (SetEventFileDescriptor(hEventObject, s) < 0)
+	if (arg == 0)
+		return 0;
+
+	if (SetEventFileDescriptor(hEventObject, s, lNetworkEvents) < 0)
 		return SOCKET_ERROR;
 
 	return 0;


### PR DESCRIPTION
* Added write event support to ```WaitForSingleObject``` and ```WaitForMultipleObjects```
* Modified ```CreateFileDescriptorEvent``` to enable write event support
* Fixed ```WSAEventSelect``` with ```lNetworkEvents == 0``` as argument
* Modified ```SetEventFileDescriptor``` to enable write event support, fixed missing ```bAttached``` to allow file descriptor cleanup.
* Added ```winpr_log_backtrace```