### PR TITLE
Resetting frontBio after read now.

### DIFF
--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -674,7 +674,8 @@ DWORD transport_get_event_handles(rdpTransport* transport, HANDLE* events, DWORD
 	{
 		if (events && (nCount < count))
 		{
-			BIO_get_event(transport->frontBio, &events[nCount]);
+			if (BIO_get_event(transport->frontBio, &events[nCount]) != 1)
+				return 0;
 			nCount++;
 		}
 	}
@@ -749,7 +750,8 @@ int transport_check_fds(rdpTransport* transport)
 	if (!transport)
 		return -1;
 
-	BIO_get_event(transport->frontBio, &event);
+	if (BIO_get_event(transport->frontBio, &event) != 1)
+		return -1;
 
 	/**
 	 * Loop through and read all available PDUs.  Since multiple
@@ -758,6 +760,7 @@ int transport_check_fds(rdpTransport* transport)
 	 * wait for a socket to get signaled that data is available
 	 * (which may never happen).
 	 */
+	ResetEvent(event);
 	for (;;)
 	{
 		/**
@@ -773,8 +776,6 @@ int transport_check_fds(rdpTransport* transport)
 		{
 			if (status < 0)
 				WLog_DBG(TAG, "transport_check_fds: transport_read_pdu() - %i", status);
-
-			ResetEvent(event);
 			return status;
 		}
 
@@ -803,7 +804,6 @@ int transport_check_fds(rdpTransport* transport)
 		}
 	}
 
-	ResetEvent(event);
 	return 0;
 }
 

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -744,9 +744,12 @@ int transport_check_fds(rdpTransport* transport)
 	int status;
 	int recv_status;
 	wStream* received;
+	HANDLE event;
 
 	if (!transport)
 		return -1;
+
+	BIO_get_event(transport->frontBio, &event);
 
 	/**
 	 * Loop through and read all available PDUs.  Since multiple
@@ -771,6 +774,7 @@ int transport_check_fds(rdpTransport* transport)
 			if (status < 0)
 				WLog_DBG(TAG, "transport_check_fds: transport_read_pdu() - %i", status);
 
+			ResetEvent(event);
 			return status;
 		}
 
@@ -799,6 +803,7 @@ int transport_check_fds(rdpTransport* transport)
 		}
 	}
 
+	ResetEvent(event);
 	return 0;
 }
 
@@ -966,7 +971,7 @@ out:
 rdpTransport* transport_new(rdpContext* context)
 {
 	rdpTransport* transport;
-	
+
 	transport = (rdpTransport*) calloc(1, sizeof(rdpTransport));
 
 	if (!transport)


### PR DESCRIPTION
Resetting the transport layer event after reading all data.
When the event is not manually reset, the client main loop transforms to a busy loop consuming lots of CPU
This bug was uncovered by #2750 which fixed events getting lost because of automatically reset events and the ```WaitForMultipleObjects``` followed by specific ```WaitForSingleObject``` calls on the bio event handle.