### PR TITLE
Send correct buttons when using a left-handed mouse

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1045,7 +1045,10 @@ static void xf_button_map_init (xfContext* xfc)
 	};
 
 	/* query system for actual remapping */
-	xf_get_x11_button_map (xfc, x11_map);
+	if (!xfc->settings->UnmapButtons)
+	{
+		xf_get_x11_button_map (xfc, x11_map);
+	}
 
 	/* iterate over all (mapped) physical buttons; for each of them */
 	/* find the logical button in X11, and assign to this the       */

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -312,16 +312,10 @@ BOOL xf_generic_ButtonPress(xfContext* xfc, int x, int y, int button, Window win
 
 	switch (button)
 	{
-		case 1:
-			flags = PTR_FLAGS_DOWN | PTR_FLAGS_BUTTON1;
-			break;
-
-		case 2:
-			flags = PTR_FLAGS_DOWN | PTR_FLAGS_BUTTON3;
-			break;
-
-		case 3:
-			flags = PTR_FLAGS_DOWN | PTR_FLAGS_BUTTON2;
+		case Button1:
+		case Button2:
+		case Button3:
+			flags = PTR_FLAGS_DOWN | xfc->button_map[button-BUTTON_BASE];
 			break;
 
 		case 4:
@@ -422,16 +416,10 @@ BOOL xf_generic_ButtonRelease(xfContext* xfc, int x, int y, int button, Window w
 
 	switch (button)
 	{
-		case 1:
-			flags = PTR_FLAGS_BUTTON1;
-			break;
-
-		case 2:
-			flags = PTR_FLAGS_BUTTON3;
-			break;
-
-		case 3:
-			flags = PTR_FLAGS_BUTTON2;
+		case Button1:
+		case Button2:
+		case Button3:
+			flags = xfc->button_map[button-BUTTON_BASE];
 			break;
 
 		case 6:

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -79,6 +79,14 @@ typedef struct xf_glyph xfGlyph;
 
 typedef struct xf_clipboard xfClipboard;
 
+/* Value of the first logical button number in X11 which must be */
+/* subtracted to go from a button number in X11 to an index into */
+/* a per-button array.                                           */
+#define BUTTON_BASE Button1
+
+/* Number of buttons that are mapped from X11 to RDP button events. */
+#define NUM_BUTTONS_MAPPED 3
+
 struct xf_context
 {
 	rdpContext context;
@@ -228,6 +236,9 @@ struct xf_context
 
 	BOOL xkbAvailable;
 	BOOL xrenderAvailable;
+
+	/* value to be sent over wire for each logical client mouse button */
+	int button_map[NUM_BUTTONS_MAPPED];
 };
 
 BOOL xf_create_window(xfContext* xfc);

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -107,6 +107,7 @@ COMMAND_LINE_ARGUMENT_A args[] =
 	{ "usb", COMMAND_LINE_VALUE_REQUIRED, "[dbg][dev][id|addr][auto]", NULL, NULL, -1, NULL, "Redirect USB device" },
 	{ "multitouch", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Redirect multitouch input" },
 	{ "gestures", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Consume multitouch input locally" },
+	{ "unmap-buttons", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Let server see real physical pointer button"},
 	{ "echo", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "echo", "Echo channel" },
 	{ "disp", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Display control" },
 	{ "fonts", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Smooth fonts (ClearType)" },
@@ -2141,6 +2142,10 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		CommandLineSwitchCase(arg, "grab-keyboard")
 		{
 			settings->GrabKeyboard = arg->Value ? TRUE : FALSE;
+		}
+		CommandLineSwitchCase(arg, "unmap-buttons")
+		{
+			settings->UnmapButtons = arg->Value ? TRUE : FALSE;
 		}
 		CommandLineSwitchCase(arg, "toggle-fullscreen")
 		{

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -1422,6 +1422,7 @@ struct rdp_settings
 	/*
 	 * Extensions
 	 */
+	ALIGN64 BOOL UnmapButtons;
 
 	/* Extensions */
 	ALIGN64 int num_extensions; /*  */

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -1106,7 +1106,8 @@ struct rdp_settings
 	ALIGN64 BOOL LocalConnection; /* 1602 */
 	ALIGN64 BOOL AuthenticationOnly; /* 1603 */
 	ALIGN64 BOOL CredentialsFromStdin; /* 1604 */
-	UINT64 padding1664[1664 - 1605]; /* 1605 */
+	ALIGN64 BOOL UnmapButtons; /* 1605 */
+	UINT64 padding1664[1664 - 1606]; /* 1606 */
 
 	/* Names */
 	ALIGN64 char* ComputerName; /* 1664 */
@@ -1422,7 +1423,6 @@ struct rdp_settings
 	/*
 	 * Extensions
 	 */
-	ALIGN64 BOOL UnmapButtons;
 
 	/* Extensions */
 	ALIGN64 int num_extensions; /*  */

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -262,6 +262,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	settings->ToggleFullscreen = TRUE;
 	settings->DesktopPosX = 0;
 	settings->DesktopPosY = 0;
+	settings->UnmapButtons = FALSE;
 
 	settings->PerformanceFlags = PERF_FLAG_NONE;
 	settings->AllowFontSmoothing = FALSE;


### PR DESCRIPTION
If you connect to a Windows server which is set up to use the left button as primary, from an X.org client which is also configured this way, the mouse buttons will appear switched in the RDP session!

This is because RDP expects physical button values to be sent whereas the client currently sends the X.org button event argument which are logical buttons values. The buttons are thus mapped twice.

This changeset implements an indirection where the logical buttons are first unmapped/reverse mapped back to the physical buttons, which are then sent over the wire and can then be mapped by the server. This enables a user to keep the same configuration at both the console and in a remote session.

I have enabled this mapping by default since a remote session should ideally behave like a console session. Left-handed server administrators that only configured their workstation but didn't bother to set the option at the server can use an option to get the back the old behaviour.

For those using a right-handed mouse (at both client and server), there should be no changes.

Tested with Ubuntu Precise 12.04 connecting to Windows 7 SP1.