### PR TITLE
winpr/synch: remove the dependency on winsock.h

### DIFF
--- a/channels/urbdrc/client/urbdrc_main.c
+++ b/channels/urbdrc/client/urbdrc_main.c
@@ -742,7 +742,7 @@ static void* urbdrc_search_usb_device(void* arg)
 	/* Get the file descriptor (fd) for the monitor.
 	   This fd will get passed to select() */
 	mon_fd = CreateFileDescriptorEvent(NULL, TRUE, FALSE,
-				udev_monitor_get_fd(mon), FD_READ);
+				udev_monitor_get_fd(mon), WINPR_FD_READ);
 	if (!mon_fd)
 		goto fail_create_monfd_event;
 

--- a/client/Android/FreeRDPCore/jni/android_freerdp.c
+++ b/client/Android/FreeRDPCore/jni/android_freerdp.c
@@ -349,11 +349,11 @@ static void* jni_input_thread(void* arg)
 		goto fail_get_message_queue;
 
 	if (!(event[0] = CreateFileDescriptorEvent(NULL, FALSE, FALSE,
-				aCtx->event_queue->pipe_fd[0], FD_READ)))
+				aCtx->event_queue->pipe_fd[0], WINPR_FD_READ)))
 		goto fail_create_event_0;
 
 	if (!(event[1] = CreateFileDescriptorEvent(NULL, FALSE, FALSE,
-				aCtx->event_queue->pipe_fd[1], FD_READ)))
+				aCtx->event_queue->pipe_fd[1], WINPR_FD_READ)))
 		goto fail_create_event_1;
 
 	if (!(event[2] = freerdp_get_message_queue_event_handle(instance, FREERDP_INPUT_MESSAGE_QUEUE)))

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1790,7 +1790,7 @@ static BOOL xfreerdp_client_new(freerdp* instance, rdpContext* context)
 	xfc->invert = (ImageByteOrder(xfc->display) == MSBFirst) ? TRUE : FALSE;
 	xfc->complex_regions = TRUE;
 
-	xfc->x11event = CreateFileDescriptorEvent(NULL, FALSE, FALSE, xfc->xfds, FD_READ);
+	xfc->x11event = CreateFileDescriptorEvent(NULL, FALSE, FALSE, xfc->xfds, WINPR_FD_READ);
 	if (!xfc->x11event)
 	{
 		WLog_ERR(TAG, "Could not create xfds event");

--- a/libfreerdp/core/listener.c
+++ b/libfreerdp/core/listener.c
@@ -41,7 +41,10 @@
 #include <net/if.h>
 #endif
 
+#include <winpr/handle.h>
+
 #include "listener.h"
+
 
 #define TAG FREERDP_TAG("core.listener")
 
@@ -169,7 +172,7 @@ static BOOL freerdp_listener_open(freerdp_listener* instance, const char* bind_a
 
 		listener->sockfds[listener->num_sockfds] = sockfd;
 		listener->events[listener->num_sockfds] =
-			CreateFileDescriptorEvent(NULL, FALSE, FALSE, sockfd, FD_READ);
+			CreateFileDescriptorEvent(NULL, FALSE, FALSE, sockfd, WINPR_FD_READ);
 		listener->num_sockfds++;
 
 		WLog_INFO(TAG, "Listening on %s:%s", addr, servname);
@@ -227,7 +230,7 @@ static BOOL freerdp_listener_open_local(freerdp_listener* instance, const char* 
 		return FALSE;
 	}
 
-	hevent = CreateFileDescriptorEvent(NULL, FALSE, FALSE, sockfd, FD_READ);
+	hevent = CreateFileDescriptorEvent(NULL, FALSE, FALSE, sockfd, WINPR_FD_READ);
 	if (!hevent)
 	{
 		WLog_ERR(TAG, "failed to create sockfd event");
@@ -261,7 +264,7 @@ static BOOL freerdp_listener_open_from_socket(freerdp_listener* instance, int fd
 
 	listener->sockfds[listener->num_sockfds] = fd;
 	listener->events[listener->num_sockfds] =
-		CreateFileDescriptorEvent(NULL, FALSE, FALSE, fd, FD_READ);
+		CreateFileDescriptorEvent(NULL, FALSE, FALSE, fd, WINPR_FD_READ);
 	if (!listener->events[listener->num_sockfds])
 		return FALSE;
 

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -368,7 +368,7 @@ static int transport_bio_simple_init(BIO* bio, SOCKET socket, int shutdown)
 		/* WSAEventSelect automatically sets the socket in non-blocking mode */
 		WSAEventSelect(ptr->socket, ptr->hEvent, FD_READ | FD_WRITE | FD_CLOSE);
 #else
-		ptr->hEvent = CreateFileDescriptorEvent(NULL, FALSE, FALSE, (int) ptr->socket, FD_READ);
+		ptr->hEvent = CreateFileDescriptorEvent(NULL, FALSE, FALSE, (int) ptr->socket, WINPR_FD_READ);
 
 		if (!ptr->hEvent)
 			return 0;

--- a/server/shadow/X11/x11_shadow.c
+++ b/server/shadow/X11/x11_shadow.c
@@ -1265,7 +1265,7 @@ int x11_shadow_subsystem_init(x11ShadowSubsystem* subsystem)
 	}
 
 	if (!(subsystem->event = CreateFileDescriptorEvent(NULL, FALSE, FALSE,
-							subsystem->xfds, FD_READ)))
+							subsystem->xfds, WINPR_FD_READ)))
 		return -1;
 
 	virtualScreen = &(subsystem->virtualScreen);

--- a/winpr/include/winpr/handle.h
+++ b/winpr/include/winpr/handle.h
@@ -39,6 +39,12 @@ extern "C" {
 #define HANDLE_FLAG_INHERIT			0x00000001
 #define HANDLE_FLAG_PROTECT_FROM_CLOSE		0x00000002
 
+#define WINPR_FD_READ_BIT				0
+#define WINPR_FD_READ					(1 << WINPR_FD_READ_BIT)
+
+#define WINPR_FD_WRITE_BIT				1
+#define WINPR_FD_WRITE					(1 << WINPR_FD_WRITE_BIT)
+
 WINPR_API BOOL CloseHandle(HANDLE hObject);
 
 WINPR_API BOOL DuplicateHandle(HANDLE hSourceProcessHandle,

--- a/winpr/include/winpr/handle.h
+++ b/winpr/include/winpr/handle.h
@@ -31,6 +31,12 @@
 extern "C" {
 #endif
 
+#define WINPR_FD_READ_BIT				0
+#define WINPR_FD_READ					(1 << WINPR_FD_READ_BIT)
+
+#define WINPR_FD_WRITE_BIT				1
+#define WINPR_FD_WRITE					(1 << WINPR_FD_WRITE_BIT)
+
 #ifndef _WIN32
 
 #define DUPLICATE_CLOSE_SOURCE			0x00000001
@@ -38,12 +44,6 @@ extern "C" {
 
 #define HANDLE_FLAG_INHERIT			0x00000001
 #define HANDLE_FLAG_PROTECT_FROM_CLOSE		0x00000002
-
-#define WINPR_FD_READ_BIT				0
-#define WINPR_FD_READ					(1 << WINPR_FD_READ_BIT)
-
-#define WINPR_FD_WRITE_BIT				1
-#define WINPR_FD_WRITE					(1 << WINPR_FD_WRITE_BIT)
 
 WINPR_API BOOL CloseHandle(HANDLE hObject);
 

--- a/winpr/include/winpr/synch.h
+++ b/winpr/include/winpr/synch.h
@@ -30,7 +30,6 @@
 #include <winpr/wtypes.h>
 #include <winpr/error.h>
 #include <winpr/handle.h>
-#include <winpr/winsock.h>
 
 #include <winpr/nt.h>
 
@@ -333,7 +332,6 @@ WINPR_API BOOL WINAPI EnterSynchronizationBarrier(LPSYNCHRONIZATION_BARRIER lpBa
 WINPR_API BOOL WINAPI DeleteSynchronizationBarrier(LPSYNCHRONIZATION_BARRIER lpBarrier);
 
 #endif
-
 /* Extended API */
 
 WINPR_API VOID USleep(DWORD dwMicroseconds);

--- a/winpr/libwinpr/comm/comm.c
+++ b/winpr/libwinpr/comm/comm.c
@@ -41,6 +41,7 @@
 #include <winpr/comm.h>
 #include <winpr/tchar.h>
 #include <winpr/wlog.h>
+#include <winpr/handle.h>
 
 #include "comm_ioctl.h"
 
@@ -1344,7 +1345,7 @@ HANDLE CommCreateFileA(LPCSTR lpDeviceName, DWORD dwDesiredAccess, DWORD dwShare
 		return INVALID_HANDLE_VALUE;
 	}
 
-	WINPR_HANDLE_SET_TYPE_AND_MODE(pComm, HANDLE_TYPE_COMM, FD_READ);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(pComm, HANDLE_TYPE_COMM, WINPR_FD_READ);
 
 	pComm->ops = &ops;
 

--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -42,6 +42,7 @@
 
 #include "../log.h"
 #define TAG WINPR_TAG("file")
+#include <winpr/handle.h>
 
 /**
  * api-ms-win-core-file-l1-2-0.dll:
@@ -414,7 +415,7 @@ HANDLE CreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, 
 	}
 
 	hNamedPipe = (HANDLE) pNamedPipe;
-	WINPR_HANDLE_SET_TYPE_AND_MODE(pNamedPipe, HANDLE_TYPE_NAMED_PIPE, FD_READ);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(pNamedPipe, HANDLE_TYPE_NAMED_PIPE, WINPR_FD_READ);
 	pNamedPipe->name = _strdup(lpFileName);
 	if (!pNamedPipe->name)
 	{

--- a/winpr/libwinpr/pipe/pipe.c
+++ b/winpr/libwinpr/pipe/pipe.c
@@ -454,11 +454,11 @@ BOOL CreatePipe(PHANDLE hReadPipe, PHANDLE hWritePipe, LPSECURITY_ATTRIBUTES lpP
 
 	pReadPipe->fd = pipe_fd[0];
 	pWritePipe->fd = pipe_fd[1];
-	WINPR_HANDLE_SET_TYPE_AND_MODE(pReadPipe, HANDLE_TYPE_ANONYMOUS_PIPE, FD_READ);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(pReadPipe, HANDLE_TYPE_ANONYMOUS_PIPE, WINPR_FD_READ);
 	pReadPipe->ops = &ops;
 
 	*((ULONG_PTR*) hReadPipe) = (ULONG_PTR) pReadPipe;
-	WINPR_HANDLE_SET_TYPE_AND_MODE(pWritePipe, HANDLE_TYPE_ANONYMOUS_PIPE, FD_READ);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(pWritePipe, HANDLE_TYPE_ANONYMOUS_PIPE, WINPR_FD_READ);
 	pWritePipe->ops = &ops;
 	*((ULONG_PTR*) hWritePipe) = (ULONG_PTR) pWritePipe;
 	return TRUE;
@@ -531,7 +531,7 @@ HANDLE CreateNamedPipeA(LPCSTR lpName, DWORD dwOpenMode, DWORD dwPipeMode, DWORD
 	if (!pNamedPipe)
 		return INVALID_HANDLE_VALUE;
 
-	WINPR_HANDLE_SET_TYPE_AND_MODE(pNamedPipe, HANDLE_TYPE_NAMED_PIPE, FD_READ);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(pNamedPipe, HANDLE_TYPE_NAMED_PIPE, WINPR_FD_READ);
 
 	pNamedPipe->serverfd = -1;
 	pNamedPipe->clientfd = -1;

--- a/winpr/libwinpr/sspicli/sspicli.c
+++ b/winpr/libwinpr/sspicli/sspicli.c
@@ -131,7 +131,7 @@ BOOL LogonUserA(LPCSTR lpszUsername, LPCSTR lpszDomain, LPCSTR lpszPassword,
 	if (!token)
 		return FALSE;
 
-	WINPR_HANDLE_SET_TYPE_AND_MODE(token, HANDLE_TYPE_ACCESS_TOKEN, FD_READ);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(token, HANDLE_TYPE_ACCESS_TOKEN, WINPR_FD_READ);
 
 	token->ops = &ops;
 

--- a/winpr/libwinpr/synch/event.c
+++ b/winpr/libwinpr/synch/event.c
@@ -315,7 +315,7 @@ HANDLE CreateWaitObjectEvent(LPSECURITY_ATTRIBUTES lpEventAttributes,
 {
 #ifndef _WIN32
 	return CreateFileDescriptorEventW(lpEventAttributes, bManualReset,
-					bInitialState, (int)(ULONG_PTR) pObject, FD_READ);
+					bInitialState, (int)(ULONG_PTR) pObject, WINPR_FD_READ);
 #else
 	HANDLE hEvent = NULL;
 	DuplicateHandle(GetCurrentProcess(), pObject, GetCurrentProcess(), &hEvent, 0, FALSE, DUPLICATE_SAME_ACCESS);

--- a/winpr/libwinpr/synch/mutex.c
+++ b/winpr/libwinpr/synch/mutex.c
@@ -140,7 +140,7 @@ HANDLE CreateMutexW(LPSECURITY_ATTRIBUTES lpMutexAttributes, BOOL bInitialOwner,
 	{
 		pthread_mutex_init(&mutex->mutex, 0);
 
-		WINPR_HANDLE_SET_TYPE_AND_MODE(mutex, HANDLE_TYPE_MUTEX, FD_READ);
+		WINPR_HANDLE_SET_TYPE_AND_MODE(mutex, HANDLE_TYPE_MUTEX, WINPR_FD_READ);
 		mutex->ops = &ops;
 
 		handle = (HANDLE) mutex;

--- a/winpr/libwinpr/synch/semaphore.c
+++ b/winpr/libwinpr/synch/semaphore.c
@@ -179,7 +179,7 @@ HANDLE CreateSemaphoreW(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lIniti
 #endif
 	}
 
-	WINPR_HANDLE_SET_TYPE_AND_MODE(semaphore, HANDLE_TYPE_SEMAPHORE, FD_READ);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(semaphore, HANDLE_TYPE_SEMAPHORE, WINPR_FD_READ);
 	handle = (HANDLE) semaphore;
 	return handle;
 }

--- a/winpr/libwinpr/synch/timer.c
+++ b/winpr/libwinpr/synch/timer.c
@@ -230,7 +230,7 @@ HANDLE CreateWaitableTimerA(LPSECURITY_ATTRIBUTES lpTimerAttributes, BOOL bManua
 	timer = (WINPR_TIMER*) calloc(1, sizeof(WINPR_TIMER));
 	if (timer)
 	{
-		WINPR_HANDLE_SET_TYPE_AND_MODE(timer, HANDLE_TYPE_TIMER, FD_READ);
+		WINPR_HANDLE_SET_TYPE_AND_MODE(timer, HANDLE_TYPE_TIMER, WINPR_FD_READ);
 		handle = (HANDLE) timer;
 		timer->fd = -1;
 		timer->lPeriod = 0;
@@ -612,7 +612,7 @@ HANDLE CreateTimerQueue(void)
 
 	if (timerQueue)
 	{
-		WINPR_HANDLE_SET_TYPE_AND_MODE(timerQueue, HANDLE_TYPE_TIMER_QUEUE, FD_READ);
+		WINPR_HANDLE_SET_TYPE_AND_MODE(timerQueue, HANDLE_TYPE_TIMER_QUEUE, WINPR_FD_READ);
 		handle = (HANDLE) timerQueue;
 		timerQueue->activeHead = NULL;
 		timerQueue->inactiveHead = NULL;
@@ -706,7 +706,7 @@ BOOL CreateTimerQueueTimer(PHANDLE phNewTimer, HANDLE TimerQueue,
 	if (!timer)
 		return FALSE;
 
-	WINPR_HANDLE_SET_TYPE_AND_MODE(timer, HANDLE_TYPE_TIMER_QUEUE_TIMER, FD_READ);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(timer, HANDLE_TYPE_TIMER_QUEUE_TIMER, WINPR_FD_READ);
 	*((UINT_PTR*) phNewTimer) = (UINT_PTR)(HANDLE) timer;
 	timespec_copy(&(timer->StartTime), &CurrentTime);
 	timespec_add_ms(&(timer->StartTime), DueTime);

--- a/winpr/libwinpr/synch/wait.c
+++ b/winpr/libwinpr/synch/wait.c
@@ -137,9 +137,9 @@ static int pthread_mutex_timedlock(pthread_mutex_t *mutex, const struct timespec
 static DWORD handle_mode_to_pollevent(ULONG mode)
 {
 	DWORD event = 0;
-	if (mode & FD_READ)
+	if (mode & WINPR_FD_READ)
 		event |= POLLIN;
-	if (mode & FD_WRITE)
+	if (mode & WINPR_FD_WRITE)
 		event |= POLLOUT;
 
 	return event;
@@ -181,9 +181,9 @@ static int waitOnFd(int fd, ULONG mode, DWORD dwMilliseconds)
 	FD_SET(fd, &wfds);
 	ZeroMemory(&timeout, sizeof(timeout));
 
-	if (mode & FD_READ)
+	if (mode & WINPR_FD_READ)
 		prfds = &rfds;
-	if (mode & FD_WRITE)
+	if (mode & WINPR_FD_WRITE)
 		pwfds = &wfds;
 
 	if ((dwMilliseconds != INFINITE) && (dwMilliseconds != 0))
@@ -372,9 +372,9 @@ DWORD WaitForMultipleObjects(DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAl
 			FD_SET(fd, &rfds);
 			FD_SET(fd, &wfds);
 
-			if (Object->Mode & FD_READ)
+			if (Object->Mode & WINPR_FD_READ)
 				prfds = &rfds;
-			if (Object->Mode & FD_WRITE)
+			if (Object->Mode & WINPR_FD_WRITE)
 				pwfds = &wfds;
 
 			if (fd > maxfd)
@@ -464,9 +464,9 @@ DWORD WaitForMultipleObjects(DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAl
 #ifdef HAVE_POLL_H
 			signal_set = pollfds[index].revents & pollfds[index].events;
 #else
-			if (Object->Mode & FD_READ)
+			if (Object->Mode & WINPR_FD_READ)
 				signal_set = FD_ISSET(fd, &rfds);
-			if (Object->Mode & FD_WRITE)
+			if (Object->Mode & WINPR_FD_WRITE)
 				signal_set = FD_ISSET(fd, &wfds);
 #endif
 			if (signal_set)

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -431,7 +431,7 @@ HANDLE CreateThread(LPSECURITY_ATTRIBUTES lpThreadAttributes, SIZE_T dwStackSize
 		goto error_thread_ready;
 	}
 
-	WINPR_HANDLE_SET_TYPE_AND_MODE(thread, HANDLE_TYPE_THREAD, FD_READ);
+	WINPR_HANDLE_SET_TYPE_AND_MODE(thread, HANDLE_TYPE_THREAD, WINPR_FD_READ);
 	handle = (HANDLE) thread;
 
 	if (!thread_list)

--- a/winpr/libwinpr/winsock/winsock.c
+++ b/winpr/libwinpr/winsock/winsock.c
@@ -648,6 +648,7 @@ BOOL WSACloseEvent(HANDLE hEvent)
 int WSAEventSelect(SOCKET s, WSAEVENT hEventObject, LONG lNetworkEvents)
 {
 	u_long arg = lNetworkEvents ? 1 : 0;
+	ULONG mode = 0;
 
 	if (_ioctlsocket(s, FIONBIO, &arg) != 0)
 		return SOCKET_ERROR;
@@ -655,7 +656,12 @@ int WSAEventSelect(SOCKET s, WSAEVENT hEventObject, LONG lNetworkEvents)
 	if (arg == 0)
 		return 0;
 
-	if (SetEventFileDescriptor(hEventObject, s, lNetworkEvents) < 0)
+	if (lNetworkEvents & FD_READ)
+		mode |= WINPR_FD_READ;
+	if (lNetworkEvents & FD_WRITE)
+		mode |= WINPR_FD_WRITE;
+
+	if (SetEventFileDescriptor(hEventObject, s, mode) < 0)
 		return SOCKET_ERROR;
 
 	return 0;


### PR DESCRIPTION
winsock.h pulls in a lot of defines and dependencies that are not
required and partially unwanted in winpr's core (for parts that are not
related to network). In order to get rid of this dependency and have an
independent defines for extended winpr functions the WINPR_FD_* defines
are used internally (and for exposed functions). Where required, like in
WSAEventSelect, the FD_* is mapped to WINPR_FD_*.