### PR TITLE
x11: reorder xf_post_disconnect

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1195,6 +1195,8 @@ static void xf_post_disconnect(freerdp* instance)
 	context = instance->context;
 	xfc = (xfContext*) context;
 
+	freerdp_channels_disconnect(context->channels, instance);
+
 	gdi_free(instance);
 
 	if (xfc->clipboard)
@@ -1212,8 +1214,6 @@ static void xf_post_disconnect(freerdp* instance)
 	}
 
 	xf_keyboard_free(xfc);
-
-	freerdp_channels_disconnect(context->channels, instance);
 }
 
 /** Callback set in the rdp_freerdp structure, and used to get the user's password,


### PR DESCRIPTION
Channels like EGFX need resources like the main window in order to
work correctly. Before the window, GDI,.. is freed it needs to be
ensured that all channels are stopped properly to prevent them to access
already freed resources. Disconnecting the channels first fixed a
possible race condition/SEGFAULT that could occur with remote initiated
disconnects.