### PR TITLE
rdpsnd: change plugin load order

### DIFF
--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -764,20 +764,20 @@ static void rdpsnd_process_connect(rdpsndPlugin* rdpsnd)
 	}
 #endif
 
-#if defined(WITH_OSS)
-	if (!rdpsnd->device)
-	{
-		rdpsnd_set_subsystem(rdpsnd, "oss");
-		rdpsnd_set_device_name(rdpsnd, "");
-		rdpsnd_load_device_plugin(rdpsnd, rdpsnd->subsystem, args);
-	}
-#endif
-
 #if defined(WITH_ALSA)
 	if (!rdpsnd->device)
 	{
 		rdpsnd_set_subsystem(rdpsnd, "alsa");
 		rdpsnd_set_device_name(rdpsnd, "default");
+		rdpsnd_load_device_plugin(rdpsnd, rdpsnd->subsystem, args);
+	}
+#endif
+
+#if defined(WITH_OSS)
+	if (!rdpsnd->device)
+	{
+		rdpsnd_set_subsystem(rdpsnd, "oss");
+		rdpsnd_set_device_name(rdpsnd, "");
 		rdpsnd_load_device_plugin(rdpsnd, rdpsnd->subsystem, args);
 	}
 #endif


### PR DESCRIPTION
The recently added OSS support is recommended by default and if found
loaded before ALSA. This possibly breaks old command lines if ALSA
wasn't specified (like if only /sound was used). To make sure this doesn't cause any problems the order
is changed to PULSE,ALSA,OSS.