### PR TITLE
transport: fix regression introduced with PR #2770

### DIFF
--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -760,7 +760,9 @@ int transport_check_fds(rdpTransport* transport)
 	 * wait for a socket to get signaled that data is available
 	 * (which may never happen).
 	 */
+#ifdef _WIN32
 	ResetEvent(event);
+#endif
 	for (;;)
 	{
 		/**


### PR DESCRIPTION
When the event is reset in transport_check_fds xfreerdp doesn't work and
consumes 100% CPU (see #2790). On windows this is require otherwise the
CPU consumption is 100% there.
This quick fix only resets the event on windows. It's a working approach
but definitely not the final solution.