### PR TITLE
Smartcard Reader Connection Handling

### DIFF
--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -320,9 +320,6 @@ static UINT32 smartcard_ListReadersA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD
 		call->mszGroups = NULL;
 	}
 
-	if (status != SCARD_S_SUCCESS)
-		return status;
-
 	smartcard_trace_list_readers_return(smartcard, &ret, FALSE);
 	status = smartcard_pack_list_readers_return(smartcard, irp->output, &ret);
 
@@ -372,9 +369,6 @@ static UINT32 smartcard_ListReadersW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD
 		free(call->mszGroups);
 		call->mszGroups = NULL;
 	}
-
-	if (status != SCARD_S_SUCCESS)
-		return status;
 
 	smartcard_trace_list_readers_return(smartcard, &ret, TRUE);
 

--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -323,11 +323,11 @@ static UINT32 smartcard_ListReadersA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD
 	smartcard_trace_list_readers_return(smartcard, &ret, FALSE);
 	status = smartcard_pack_list_readers_return(smartcard, irp->output, &ret);
 
-	if (status != SCARD_S_SUCCESS)
-		return status;
-
 	if (mszReaders)
 		SCardFreeMemory(operation->hContext, mszReaders);
+
+	if (status != SCARD_S_SUCCESS)
+		return status;
 
 	return ret.ReturnCode;
 }
@@ -371,14 +371,13 @@ static UINT32 smartcard_ListReadersW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD
 	}
 
 	smartcard_trace_list_readers_return(smartcard, &ret, TRUE);
-
 	status = smartcard_pack_list_readers_return(smartcard, irp->output, &ret);
-
-	if (status != SCARD_S_SUCCESS)
-		return status;
 
 	if (mszReaders)
 		SCardFreeMemory(operation->hContext, mszReaders);
+
+	if (status != SCARD_S_SUCCESS)
+		return status;
 
 	return ret.ReturnCode;
 }


### PR DESCRIPTION
This pull request addresses smartcard reader connection and reconnection issues (see #153)

smartcard_ListReadersA_Call & smartcard_ListReadersW_Call aborts without replying to the server when SCardListReaders return status is not SCARD_SUCCESS. As a result, SCardListReaders calls invoked by the server never get completed. This makes impossible to detect connection of a new smartcard reader when there are no other smartcard readers connected.

smartcard_ListReaders(A/W)_Call should pass the return status of SCardListReaders back to the server in all cases. This is particularly important when there are no smartcard readers in the system and SCardListReaders returns SCARD_E_NO_READERS_AVAILABLE.

Test case:
1. Start FreeRDP with no smartcard readers connected:
        ./xfreerdp -sec-nla /smartcard /v:<rdp-server-address>
2. Connect a smartcard reader;
3. The remote server detects connection of the reader;
