### PR TITLE
Fix race condition in freerdp_channels_client_load that could cause memory leak

### DIFF
--- a/libfreerdp/core/client.c
+++ b/libfreerdp/core/client.c
@@ -720,7 +720,6 @@ int freerdp_channels_client_load(rdpChannels* channels, rdpSettings* settings, P
 	EntryPoints.pVirtualChannelClose = FreeRDP_VirtualChannelClose;
 	EntryPoints.pVirtualChannelWrite = FreeRDP_VirtualChannelWrite;
 
-	g_pInterface = NULL;
 	EntryPoints.MagicNumber = FREERDP_CHANNEL_MAGIC_NUMBER;
 	EntryPoints.ppInterface = &g_pInterface;
 	EntryPoints.pExtendedData = data;
@@ -731,6 +730,7 @@ int freerdp_channels_client_load(rdpChannels* channels, rdpSettings* settings, P
 
 	EnterCriticalSection(&g_channels_lock);
 
+	g_pInterface = NULL;
 	g_ChannelInitData.channels = channels;
 	status = pChannelClientData->entry((PCHANNEL_ENTRY_POINTS) &EntryPoints);
 


### PR DESCRIPTION
If g_pInterface is set to NULL outside the critical section in one thread while another thread is in the critical section, the channel client context allocated in the VirtualChannelEntry won't end up getting freed.

The channel client context is normally loaded from g_pInterface in FreeRDP_VirtualChannelInit and stored in the pChannelInitData, then copied from there onto the pChannelOpenData structure in FreeRDP_VirtualChannelOpen and finally freed in freerdp_channels_free.