### PR TITLE
fixed misc *_free functions to accept NULL

### DIFF
--- a/winpr/libwinpr/utils/collections/ArrayList.c
+++ b/winpr/libwinpr/utils/collections/ArrayList.c
@@ -470,6 +470,9 @@ out_free:
 
 void ArrayList_Free(wArrayList *arrayList)
 {
+	if (!arrayList)
+		return;
+
 	ArrayList_Clear(arrayList);
 	DeleteCriticalSection(&arrayList->lock);
 	free(arrayList->array);

--- a/winpr/libwinpr/utils/collections/BitStream.c
+++ b/winpr/libwinpr/utils/collections/BitStream.c
@@ -348,5 +348,8 @@ wBitStream* BitStream_New()
 
 void BitStream_Free(wBitStream* bs)
 {
+	if (!bs)
+		return;
+
 	free(bs);
 }

--- a/winpr/libwinpr/utils/collections/CountdownEvent.c
+++ b/winpr/libwinpr/utils/collections/CountdownEvent.c
@@ -182,6 +182,9 @@ fail_critical_section:
 
 void CountdownEvent_Free(wCountdownEvent* countdown)
 {
+	if (!countdown)
+		return;
+
 	DeleteCriticalSection(&countdown->lock);
 	CloseHandle(countdown->event);
 

--- a/winpr/libwinpr/utils/collections/Dictionary.c
+++ b/winpr/libwinpr/utils/collections/Dictionary.c
@@ -128,6 +128,9 @@ wDictionary* Dictionary_New(BOOL synchronized)
 
 void Dictionary_Free(wDictionary* dictionary)
 {
+	if (!dictionary)
+		return;
+
 	free(dictionary);
 }
 

--- a/winpr/libwinpr/utils/collections/KeyValuePair.c
+++ b/winpr/libwinpr/utils/collections/KeyValuePair.c
@@ -46,5 +46,8 @@ wKeyValuePair* KeyValuePair_New(void* key, void* value)
 
 void KeyValuePair_Free(wKeyValuePair* keyValuePair)
 {
+	if (!keyValuePair)
+		return;
+
 	free(keyValuePair);
 }

--- a/winpr/libwinpr/utils/collections/MessageQueue.c
+++ b/winpr/libwinpr/utils/collections/MessageQueue.c
@@ -223,6 +223,9 @@ error_array:
 
 void MessageQueue_Free(wMessageQueue* queue)
 {
+	if (!queue)
+		return;
+
 	CloseHandle(queue->event);
 	DeleteCriticalSection(&queue->lock);
 


### PR DESCRIPTION
Following types of collections support now
NULL in the free call:

* ArrayList
* BitStream
* ContdownEvent
* Dictionary
* KeyValuePair
* MessageQueue