### PR TITLE
Error: "Unable to detect time zone" - Add support for tz package

### DIFF
--- a/libfreerdp/locale/timezone.c
+++ b/libfreerdp/locale/timezone.c
@@ -1539,7 +1539,8 @@ char* freerdp_get_unix_timezone_identifier()
 	 * America/Montreal for example.
 	 */
 	
-	if ((len = readlink("/etc/localtime", buf, sizeof(buf) - 1)) != -1)
+	if ((len = readlink("/etc/localtime", buf, sizeof(buf) - 1)) != -1 ||
+	    (len = readlink("/etc/TZ", buf, sizeof(buf) - 1)) != -1)
 	{
 		int num = 0;
 		int pos = len;


### PR DESCRIPTION
Fixes error message while freerdp connected the remote desktop:
"Unable to detect time zone"

libfreerdp always read timezone from symlink at /etc/localtime at the moment, but sometimes it also may the symlink at /etc/TZ