### PR TITLE
Fixed color pointer decoding.

### DIFF
--- a/client/Android/FreeRDPCore/jni/android_freerdp.c
+++ b/client/Android/FreeRDPCore/jni/android_freerdp.c
@@ -1148,7 +1148,7 @@ static void copy_pixel_buffer(UINT8* dstBuf, UINT8* srcBuf, int x, int y, int wi
 	int length;
 	int scanline;
 	UINT8 *dstp, *srcp;
-	
+
 	length = width * bpp;
 	scanline = wBuf * bpp;
 

--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -1074,11 +1074,19 @@ BOOL mf_Pointer_New(rdpContext* context, rdpPointer* pointer)
 	if (!cursor_data)
 		return FALSE;
 	mrdpCursor->cursor_data = cursor_data;
-	
-	freerdp_image_copy_from_pointer_data(cursor_data, PIXEL_FORMAT_ARGB32,
-					     pointer->width * 4, 0, 0, pointer->width, pointer->height,
-					     pointer->xorMaskData, pointer->andMaskData, pointer->xorBpp, NULL);
-	
+
+	if (freerdp_image_copy_from_pointer_data(
+		    cursor_data, PIXEL_FORMAT_ARGB32,
+		    pointer->width * 4, 0, 0, pointer->width, pointer->height,
+		    pointer->xorMaskData, pointer->lengthXorMask,
+		    pointer->andMaskData, pointer->lengthAndMask,
+		    pointer->xorBpp, NULL) < 0)
+	{
+		free(cursor_data);
+		mrdpCursor->cursor_data = NULL;
+		return FALSE;
+	}
+
 	/* store cursor bitmap image in representation - required by NSImage */
 	bmiRep = [[NSBitmapImageRep alloc] initWithBitmapDataPlanes:(unsigned char **) &cursor_data
 											pixelsWide:rect.size.width

--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -237,9 +237,12 @@ BOOL xf_Pointer_New(rdpContext* context, rdpPointer* pointer)
 		return FALSE;
 	}
 
-	if (freerdp_image_copy_from_pointer_data((BYTE*) ci.pixels, PIXEL_FORMAT_ARGB32,
-				pointer->width * 4, 0, 0, pointer->width, pointer->height,
-				pointer->xorMaskData, pointer->andMaskData, pointer->xorBpp, xfc->palette) < 0)
+	if (freerdp_image_copy_from_pointer_data(
+		    (BYTE*) ci.pixels, PIXEL_FORMAT_ARGB32,
+		    pointer->width * 4, 0, 0, pointer->width, pointer->height,
+		    pointer->xorMaskData, pointer->lengthXorMask,
+		    pointer->andMaskData, pointer->lengthAndMask,
+		    pointer->xorBpp, xfc->palette) < 0)
 	{
 		free(ci.pixels);
 		xf_unlock_x11(xfc, FALSE);

--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -237,11 +237,13 @@ BOOL xf_Pointer_New(rdpContext* context, rdpPointer* pointer)
 		return FALSE;
 	}
 
-	if ((pointer->andMaskData != 0) && (pointer->xorMaskData != 0))
-	{
-		freerdp_image_copy_from_pointer_data((BYTE*) ci.pixels, PIXEL_FORMAT_ARGB32,
+	if (freerdp_image_copy_from_pointer_data((BYTE*) ci.pixels, PIXEL_FORMAT_ARGB32,
 				pointer->width * 4, 0, 0, pointer->width, pointer->height,
-				pointer->xorMaskData, pointer->andMaskData, pointer->xorBpp, xfc->palette);
+				pointer->xorMaskData, pointer->andMaskData, pointer->xorBpp, xfc->palette) < 0)
+	{
+		free(ci.pixels);
+		xf_unlock_x11(xfc, FALSE);
+		return FALSE;
 	}
 
 	((xfPointer*) pointer)->cursor = XcursorImageLoadCursor(xfc->display, &ci);

--- a/include/freerdp/codec/color.h
+++ b/include/freerdp/codec/color.h
@@ -452,7 +452,7 @@ FREERDP_API void freerdp_clrconv_free(HCLRCONV clrconv);
 FREERDP_API int freerdp_image_copy_from_monochrome(BYTE* pDstData, UINT32 DstFormat, int nDstStep, int nXDst, int nYDst,
 		int nWidth, int nHeight, BYTE* pSrcData, UINT32 backColor, UINT32 foreColor, BYTE* palette);
 
-FREERDP_API int int freerdp_image_copy_from_pointer_data(
+FREERDP_API int freerdp_image_copy_from_pointer_data(
 		BYTE* pDstData, UINT32 DstFormat, int nDstStep,
 		int nXDst, int nYDst, int nWidth, int nHeight, BYTE* xorMask,
 		UINT32 xorMaskLength, BYTE* andMask, UINT32 andMaskLength,

--- a/include/freerdp/codec/color.h
+++ b/include/freerdp/codec/color.h
@@ -376,12 +376,12 @@ extern "C" {
 
 #define BGR16_RGB32(_r, _g, _b, _p) \
 	GetBGR16(_r, _g, _b, _p); \
- 	RGB_565_888(_r, _g, _b); \
+	RGB_565_888(_r, _g, _b); \
 	_p = RGB32(_r, _g, _b);
 
 #define RGB32_RGB16(_r, _g, _b, _p) \
 	GetRGB32(_r, _g, _b, _p); \
- 	RGB_888_565(_r, _g, _b); \
+	RGB_888_565(_r, _g, _b); \
 	_p = RGB565(_r, _g, _b);
 
 #define RGB15_RGB16(_r, _g, _b, _p) \
@@ -452,8 +452,11 @@ FREERDP_API void freerdp_clrconv_free(HCLRCONV clrconv);
 FREERDP_API int freerdp_image_copy_from_monochrome(BYTE* pDstData, UINT32 DstFormat, int nDstStep, int nXDst, int nYDst,
 		int nWidth, int nHeight, BYTE* pSrcData, UINT32 backColor, UINT32 foreColor, BYTE* palette);
 
-FREERDP_API int freerdp_image_copy_from_pointer_data(BYTE* pDstData, UINT32 DstFormat, int nDstStep, int nXDst, int nYDst,
-		int nWidth, int nHeight, BYTE* xorMask, BYTE* andMask, UINT32 xorBpp, BYTE* palette);
+FREERDP_API int int freerdp_image_copy_from_pointer_data(
+		BYTE* pDstData, UINT32 DstFormat, int nDstStep,
+		int nXDst, int nYDst, int nWidth, int nHeight, BYTE* xorMask,
+		UINT32 xorMaskLength, BYTE* andMask, UINT32 andMaskLength,
+		UINT32 xorBpp, BYTE* palette);
 
 FREERDP_API int freerdp_image8_copy(BYTE* pDstData, DWORD DstFormat, int nDstStep, int nXDst, int nYDst,
 		int nWidth, int nHeight, BYTE* pSrcData, DWORD SrcFormat, int nSrcStep, int nXSrc, int nYSrc, BYTE* palette);
@@ -472,7 +475,7 @@ FREERDP_API int freerdp_image_move(BYTE* pData, DWORD Format, int nStep, int nXD
 		int nWidth, int nHeight, int nXSrc, int nYSrc);
 FREERDP_API int freerdp_image_fill(BYTE* pDstData, DWORD DstFormat, int nDstStep, int nXDst, int nYDst,
 		int nWidth, int nHeight, UINT32 color);
-	
+
 FREERDP_API int freerdp_image_copy_from_retina(BYTE* pDstData, DWORD DstFormat, int nDstStep, int nXDst, int nYDst,
 		int nWidth, int nHeight, BYTE* pSrcData, int nSrcStep, int nXSrc, int nYSrc);
 

--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -1463,12 +1463,18 @@ int freerdp_image_copy_from_pointer_data(BYTE* pDstData, UINT32 DstFormat, int n
 	andStep = (nWidth + 7) / 8;
 	andStep += (andStep % 2);
 
+	if (!xorMask)
+		return -1;
+
 	if (dstBytesPerPixel == 4)
 	{
 		UINT32* pDstPixel;
 
 		if (xorBpp == 1)
 		{
+			if (!andMask)
+				return -1;
+
 			xorStep = (nWidth + 7) / 8;
 			xorStep += (xorStep % 2);
 
@@ -1481,14 +1487,12 @@ int freerdp_image_copy_from_pointer_data(BYTE* pDstData, UINT32 DstFormat, int n
 				if (!vFlip)
 				{
 					xorBits = &xorMask[xorStep * y];
-					if (andMask)
-						andBits = &andMask[andStep * y];
+					andBits = &andMask[andStep * y];
 				}
 				else
 				{
 					xorBits = &xorMask[xorStep * (nHeight - y - 1)];
-					if (andMask)
-						andBits = &andMask[andStep * (nHeight - y - 1)];
+					andBits = &andMask[andStep * (nHeight - y - 1)];
 				}
 
 				for (x = 0; x < nWidth; x++)

--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -1481,12 +1481,14 @@ int freerdp_image_copy_from_pointer_data(BYTE* pDstData, UINT32 DstFormat, int n
 				if (!vFlip)
 				{
 					xorBits = &xorMask[xorStep * y];
-					andBits = &andMask[andStep * y];
+					if (andMask)
+						andBits = &andMask[andStep * y];
 				}
 				else
 				{
 					xorBits = &xorMask[xorStep * (nHeight - y - 1)];
-					andBits = &andMask[andStep * (nHeight - y - 1)];
+					if (andMask)
+						andBits = &andMask[andStep * (nHeight - y - 1)];
 				}
 
 				for (x = 0; x < nWidth; x++)
@@ -1531,12 +1533,14 @@ int freerdp_image_copy_from_pointer_data(BYTE* pDstData, UINT32 DstFormat, int n
 
 				if (!vFlip)
 				{
-					andBits = &andMask[andStep * y];
+					if (andMask)
+						andBits = &andMask[andStep * y];
 					xorBits = &xorMask[xorStep * y];
 				}
 				else
 				{
-					andBits = &andMask[andStep * (nHeight - y - 1)];
+					if (andMask)
+						andBits = &andMask[andStep * (nHeight - y - 1)];
 					xorBits = &xorMask[xorStep * (nHeight - y - 1)];
 				}
 
@@ -1563,8 +1567,12 @@ int freerdp_image_copy_from_pointer_data(BYTE* pDstData, UINT32 DstFormat, int n
 
 					xorBits += xorBytesPerPixel;
 
-					andPixel = (*andBits & andBit) ? 1 : 0;
-					if (!(andBit >>= 1)) { andBits++; andBit = 0x80; }
+					andPixel = 0;
+					if (andMask)
+					{
+						andPixel = (*andBits & andBit) ? 1 : 0;
+						if (!(andBit >>= 1)) { andBits++; andBit = 0x80; }
+					}
 
 					if (andPixel)
 					{


### PR DESCRIPTION
The AND mask was wrongly applied for color pointer updates, inverting white pointers and making black ones invisible.