### PR TITLE
media foundation support now a compile time option.

### DIFF
--- a/cmake/ConfigOptions.cmake
+++ b/cmake/ConfigOptions.cmake
@@ -43,6 +43,8 @@ endif()
 
 if(NOT WIN32)
     option(WITH_VALGRIND_MEMCHECK "Compile with valgrind helpers." OFF)
+else()
+    option(WITH_MEDIA_FOUNDATION "Enable H264 media foundation decoder." ON)
 endif()
 
 if(MSVC)

--- a/config.h.in
+++ b/config.h.in
@@ -63,6 +63,7 @@
 #cmakedefine WITH_IOSAUDIO
 #cmakedefine WITH_OPENSLES
 #cmakedefine WITH_GSM
+#cmakedefine WITH_MEDIA_FOUNDATION
 
 /* Plugins */
 #cmakedefine STATIC_CHANNELS

--- a/libfreerdp/codec/h264.c
+++ b/libfreerdp/codec/h264.c
@@ -62,7 +62,7 @@ static H264_CONTEXT_SUBSYSTEM g_Subsystem_dummy =
  * Media Foundation subsystem
  */
 
-#ifdef _WIN32
+#if defined(_WIN32) && defined(WITH_MEDIA_FOUNDATION)
 
 #include <ks.h>
 #include <codecapi.h>
@@ -1479,7 +1479,7 @@ error_1:
 
 BOOL h264_context_init(H264_CONTEXT* h264)
 {
-#ifdef _WIN32
+#if defined(_WIN32) && defined(WITH_MEDIA_FOUNDATION)
 	if (g_Subsystem_MF.Init(h264))
 	{
 		h264->subsystem = &g_Subsystem_MF;


### PR DESCRIPTION
h264 media foundation decoder can now be disabled by compile time option on windows.