### PR TITLE
Getcomputername fix

### DIFF
--- a/winpr/libwinpr/sysinfo/sysinfo.c
+++ b/winpr/libwinpr/sysinfo/sysinfo.c
@@ -188,16 +188,15 @@ BOOL GetComputerNameA(LPSTR lpBuffer, LPDWORD lpnSize)
 	if (dot)
 		length = dot - hostname;
 
-	if (!lpBuffer)
-		return FALSE;
-
 	if (*lpnSize <= length)
 	{
 		SetLastError(ERROR_BUFFER_OVERFLOW);
-		*lpnSize = length;
+		*lpnSize = length + 1;
 		return FALSE;
 	}
 
+	if (!lpBuffer)
+		return FALSE;
 
 	CopyMemory(lpBuffer, hostname, length);
 	lpBuffer[length] = '\0';
@@ -227,7 +226,8 @@ BOOL GetComputerNameExA(COMPUTER_NAME_FORMAT NameType, LPSTR lpBuffer, LPDWORD l
 		case ComputerNamePhysicalDnsFullyQualified:
 			if (*lpnSize <= length)
 			{
-				*lpnSize = length;
+				*lpnSize = length + 1;
+				SetLastError(ERROR_MORE_DATA);
 				return FALSE;
 			}
 

--- a/winpr/tools/makecert/makecert.c
+++ b/winpr/tools/makecert/makecert.c
@@ -306,8 +306,24 @@ char* x509_name_parse(char* name, char* txt, int* length)
 
 char* x509_get_default_name()
 {
-	CHAR* computerName;
+	CHAR* computerName = NULL;
 	DWORD nSize = 0;
+
+    if (GetComputerNameExA(ComputerNamePhysicalDnsFullyQualified, NULL, &nSize) ||
+		GetLastError() != ERROR_MORE_DATA)
+		goto fallback;
+
+	computerName = (CHAR*)calloc(nSize, 1);
+	if (!computerName)
+		goto fallback;
+
+	if (!GetComputerNameExA(ComputerNamePhysicalDnsFullyQualified, computerName, &nSize))
+		goto fallback;
+
+    return computerName;
+
+fallback:
+    free(computerName);
 
 	if (GetComputerNameExA(ComputerNamePhysicalNetBIOS, NULL, &nSize) ||
 		GetLastError() != ERROR_MORE_DATA)


### PR DESCRIPTION
* Fixes implementation of ```GetComputerNameA``` and ```GetComputerNameExA```
* Now trying to get FQDN before hostname for ```winpr-makecert``` default CN