### PR TITLE
Improve clipboard format support in X11 client

### DIFF
--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -828,24 +828,6 @@ UINT xf_cliprdr_send_client_format_list_response(xfClipboard* clipboard, BOOL st
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-int xf_cliprdr_send_client_format_data_request(xfClipboard* clipboard, UINT32 formatId)
-{
-	CLIPRDR_FORMAT_DATA_REQUEST formatDataRequest;
-
-	formatDataRequest.msgType = CB_FORMAT_DATA_REQUEST;
-	formatDataRequest.msgFlags = CB_RESPONSE_OK;
-
-	formatDataRequest.requestedFormatId = formatId;
-	clipboard->requestedFormatId = formatId;
-
-	return clipboard->context->ClientFormatDataRequest(clipboard->context, &formatDataRequest);
-}
-
-/**
- * Function description
- *
- * @return 0 on success, otherwise a Win32 error code
- */
 static UINT xf_cliprdr_monitor_ready(CliprdrClientContext* context, CLIPRDR_MONITOR_READY* monitorReady)
 {
 	xfClipboard* clipboard = (xfClipboard*) context->custom;

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -222,7 +222,7 @@ static UINT xf_cliprdr_send_data_response(xfClipboard* clipboard, BYTE* data, in
 
 	ZeroMemory(&response, sizeof(CLIPRDR_FORMAT_DATA_RESPONSE));
 
-	response.msgFlags = CB_RESPONSE_OK;
+	response.msgFlags = (data) ? CB_RESPONSE_OK : CB_RESPONSE_FAIL;
 	response.dataLen = size;
 	response.requestedFormatData = data;
 

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -1102,8 +1102,11 @@ static UINT xf_cliprdr_server_format_data_response(CliprdrClientContext* context
 		DstSize = 0;
 		pDstData = (BYTE*) ClipboardGetData(clipboard->system, dstFormatId, &DstSize);
 
-		if ((DstSize > 1) && nullTerminated)
-			DstSize--;
+		if (nullTerminated)
+		{
+			while (DstSize > 0 && pDstData[DstSize - 1] == '\0')
+				DstSize--;
+		}
 	}
 
 	clipboard->data = pDstData;

--- a/winpr/include/winpr/user.h
+++ b/winpr/include/winpr/user.h
@@ -50,6 +50,7 @@
 #define IDTIMEOUT				32000
 #define IDASYNC					32001
 
+#define CF_RAW			0
 #define CF_TEXT			1
 #define CF_BITMAP		2
 #define CF_METAFILEPICT		3


### PR DESCRIPTION
Fixes in named formats (copy-paste HTML), raw format transfers (copy-paste anything between remote session), and some other things. See commit messages for more technical details.

Overview
-----------

### Named format support

As one may learn from MS-RDPECLIP spec, clipboard formats are identified either by _format ID_ (32-bit integer) or by _format name_ (arbitrary text string). Fixed-ID formats have fixed IDs assigned to them while named formats can have different IDs on different machines. The tricky part is in that cliprdr protocol is always using IDs to identify clipboard formats in protocol requests, so it is important to use _server-side_ IDs when requesting data from the server. XFreeRDP was doing it wrong, used client-side IDs instead, and expectedly was getting refusals from the server.

These commits revamp format identification and make sure that correct format IDs are used everywhere:

64d5e83 winpr/clipboard: add CF_RAW clipboard format ID
5b511a6 client/X11: improve clipboard format search functions
fed1907 client/X11: improve named clipboard format support

### Miscellaneous fixes

Some miscellaneous minor fixes:

36d3489 client/X11: correctly trim terminating null bytes from strings
f413325 client/X11: send clipboard format data errors correctly
eecd628 client/X11: remove unused function

### Raw transfer support

In the past XFreeRDP had a unique feature: ability to pass arbitrary clipboard formats between two XFreeRDP remote sessions, not limiting them to formats generally supported by X11 applications (basically, text, HTML, and some image formats). For example, this allowed to copy-paste formatted text between MS Office applications without losing any style information. Some parts of this feature still survived, but several other changes have broken it.

These commits restore the missing parts of the raw transfer mechanism:

842ea62 client/X11: refactor raw clipboard transfer indication
e4352bb client/X11: transfer raw clipboard format lists
81a584f client/X11: transfer raw clipboard format data

Generally, the idea stays the same:

  1. Session A receives a format list, assumes clipboard ownership, and advertises raw format list via a special mechanism.

  2. Session B is able to tell that an XFreeRDP session owns the clipboard, extracts raw format list and sends it to the remote side.

  3. Session B receives a format data request, and forwards the request to session A via a special mechanism.

  4. Session A passes the request to its remote side to get the actual data.

  5. The received data is passed intact from session A to session B, and then to the remote side of the session B.

The steps 1 and 5 were broken by previous changes and needed a fix.


Verification
------------

### Named formats

The only named format supported by XFreeRDP is `"HTML Format"`. It can be verified by copying anything from a remote browser into a local application supporting "text/html" (e.g, LibreOffice Writer). HTML should be kept intact: i.e., hyperlinks should be present, bold text should be pasted as bold, etc. Obviously, the same should be true in reverse.

Note that currently FreeRDP _does not remove_ `<!--StartFragment-->` and `<!--EndFragment-->` from HTML data, which results into them being shown as editorial comments by LibreOffice Writer. While additional metadata in comments is [a documented feature of `"HTML Format"`](https://msdn.microsoft.com/en-us/library/aa767917(v=vs.85).aspx), I am not sure that they should be removed by FreeRDP.

### Raw transfers

To check this case it is necessary to open two remote sessions and try transfering formats not supported by XFreeRDP. A good example would be `"Rich Text Format"`, a named format used by WordPad. The point is in that WordPad does not use `"HTML Format"` so it is not possible to confuse them. If raw transfer works correctly, rich formatting should be preserved when text is transferred between remote sessions.

To be absolutely sure that the feature works correctly one can build FreeRDP with enabled cliprdr dumps (`-DWITH_DEBUG_CLIPRDR=ON`) and observe communications over the _cliprdr_ channel.

### Affected known issues

This pull request fixes issues #1414, #2287, #2841.

It may fix #1433, but I am not able to verify it.