### PR TITLE
Fixes API misuse and logic errors

### DIFF
--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -391,7 +391,9 @@ static UINT handle_hotplug(rdpdrPlugin* rdpdr)
 	DEVICE_DRIVE_EXT *device_ext;
 	ULONG_PTR *keys;
 	UINT32 ids[1];
-	UINT error;
+	UINT error = 0;
+
+	memset(dev_array, 0, sizeof(dev_array));
 
 	f = fopen("/proc/mounts", "r");
 	if (f == NULL)

--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -410,18 +410,9 @@ static UINT handle_hotplug(rdpdrPlugin* rdpdr)
 			/* copy hotpluged device mount point to the dev_array */
 			if (strstr(word, "/mnt/") != NULL || strstr(word, "/media/") != NULL)
 			{
-				dev_array[size].path = _strdup(word);
-				if (!dev_array[size].path)
-				{
-					fclose(f);
-					free(line);
-					error = CHANNEL_RC_NO_MEMORY;
-					goto cleanup;
-				}
-
+				dev_array[size].path = word;
 				dev_array[size++].to_add = TRUE;
 			}
-			free(word);
 		}
 		free(line);
 	}

--- a/channels/smartcard/client/smartcard_main.c
+++ b/channels/smartcard/client/smartcard_main.c
@@ -36,8 +36,8 @@
 void* smartcard_context_thread(SMARTCARD_CONTEXT* pContext)
 {
 	DWORD nCount;
-	LONG status;
-    DWORD waitStatus;
+	LONG status = 0;
+	DWORD waitStatus;
 	HANDLE hEvents[2];
 	wMessage message;
 	SMARTCARD_DEVICE* smartcard;
@@ -51,23 +51,23 @@ void* smartcard_context_thread(SMARTCARD_CONTEXT* pContext)
 
 	while (1)
 	{
-        waitStatus = WaitForMultipleObjects(nCount, hEvents, FALSE, INFINITE);
+		waitStatus = WaitForMultipleObjects(nCount, hEvents, FALSE, INFINITE);
 
-        if (waitStatus == WAIT_FAILED)
-        {
-            error = GetLastError();
-            WLog_ERR(TAG, "WaitForMultipleObjects failed with error %lu!", error);
-            break;
-        }
+		if (waitStatus == WAIT_FAILED)
+		{
+			error = GetLastError();
+			WLog_ERR(TAG, "WaitForMultipleObjects failed with error %lu!", error);
+			break;
+		}
 
-        waitStatus = WaitForSingleObject(MessageQueue_Event(pContext->IrpQueue), 0);
+		waitStatus = WaitForSingleObject(MessageQueue_Event(pContext->IrpQueue), 0);
 
-        if (waitStatus == WAIT_FAILED)
-        {
-            error = GetLastError();
-            WLog_ERR(TAG, "WaitForSingleObject failed with error %lu!", error);
-            break;
-        }
+		if (waitStatus == WAIT_FAILED)
+		{
+			error = GetLastError();
+			WLog_ERR(TAG, "WaitForSingleObject failed with error %lu!", error);
+			break;
+		}
 
 		if (waitStatus == WAIT_OBJECT_0)
 		{
@@ -515,23 +515,23 @@ static void* smartcard_thread_func(void* arg)
 	{
 		status = WaitForMultipleObjects(nCount, hEvents, FALSE, INFINITE);
 
-        if (status == WAIT_FAILED)
-        {
-            error = GetLastError();
-            WLog_ERR(TAG, "WaitForMultipleObjects failed with error %lu!", error);
-            break;
-        }
+		if (status == WAIT_FAILED)
+		{
+			error = GetLastError();
+			WLog_ERR(TAG, "WaitForMultipleObjects failed with error %lu!", error);
+			break;
+		}
 
-        status = WaitForSingleObject(MessageQueue_Event(smartcard->IrpQueue), 0);
+		status = WaitForSingleObject(MessageQueue_Event(smartcard->IrpQueue), 0);
 
-        if (status == WAIT_FAILED)
-        {
-            error = GetLastError();
-            WLog_ERR(TAG, "WaitForSingleObject failed with error %lu!", error);
-            break;
-        }
+		if (status == WAIT_FAILED)
+		{
+			error = GetLastError();
+			WLog_ERR(TAG, "WaitForSingleObject failed with error %lu!", error);
+			break;
+		}
 
-        if (status == WAIT_OBJECT_0)
+		if (status == WAIT_OBJECT_0)
 		{
 			if (!MessageQueue_Peek(smartcard->IrpQueue, &message, TRUE))
 			{
@@ -545,19 +545,19 @@ static void* smartcard_thread_func(void* arg)
 			{
 				while (1)
 				{
-                    status = WaitForSingleObject(Queue_Event(smartcard->CompletedIrpQueue), 0);
+					status = WaitForSingleObject(Queue_Event(smartcard->CompletedIrpQueue), 0);
 
-                    if (status == WAIT_FAILED)
-                    {
-                        error = GetLastError();
-                        WLog_ERR(TAG, "WaitForSingleObject failed with error %lu!", error);
-                        goto out;
-                    }
+					if (status == WAIT_FAILED)
+					{
+						error = GetLastError();
+						WLog_ERR(TAG, "WaitForSingleObject failed with error %lu!", error);
+						goto out;
+					}
 
-                    if (status == WAIT_TIMEOUT)
-                        break;
+					if (status == WAIT_TIMEOUT)
+						break;
 
-                    irp = (IRP*) Queue_Dequeue(smartcard->CompletedIrpQueue);
+					irp = (IRP*) Queue_Dequeue(smartcard->CompletedIrpQueue);
 
 					if (irp)
 					{
@@ -565,12 +565,12 @@ static void* smartcard_thread_func(void* arg)
 						{
 							status = WaitForSingleObject(irp->thread, INFINITE);
 
-                            if (status == WAIT_FAILED)
-                            {
-                                error = GetLastError();
-                                WLog_ERR(TAG, "WaitForSingleObject failed with error %lu!", error);
-                                goto out;
-                            }
+							if (status == WAIT_FAILED)
+							{
+								error = GetLastError();
+								WLog_ERR(TAG, "WaitForSingleObject failed with error %lu!", error);
+								goto out;
+							}
 
 							CloseHandle(irp->thread);
 							irp->thread = NULL;
@@ -599,19 +599,19 @@ static void* smartcard_thread_func(void* arg)
 			}
 		}
 
-        status = WaitForSingleObject(Queue_Event(smartcard->CompletedIrpQueue), 0);
+		status = WaitForSingleObject(Queue_Event(smartcard->CompletedIrpQueue), 0);
 
-        if (status == WAIT_FAILED)
-        {
-            error = GetLastError();
-            WLog_ERR(TAG, "WaitForSingleObject failed with error %lu!", error);
-            break;
-        }
+		if (status == WAIT_FAILED)
+		{
+			error = GetLastError();
+			WLog_ERR(TAG, "WaitForSingleObject failed with error %lu!", error);
+			break;
+		}
 
-        if (status == WAIT_OBJECT_0)
-        {
+		if (status == WAIT_OBJECT_0)
+		{
 
-            irp = (IRP*) Queue_Dequeue(smartcard->CompletedIrpQueue);
+			irp = (IRP*) Queue_Dequeue(smartcard->CompletedIrpQueue);
 
 			if (irp)
 			{
@@ -619,12 +619,12 @@ static void* smartcard_thread_func(void* arg)
 				{
 					status = WaitForSingleObject(irp->thread, INFINITE);
 
-                    if (status == WAIT_FAILED)
-                    {
-                        error = GetLastError();
-                        WLog_ERR(TAG, "WaitForSingleObject failed with error %lu!", error);
-                        break;
-                    }
+					if (status == WAIT_FAILED)
+					{
+						error = GetLastError();
+						WLog_ERR(TAG, "WaitForSingleObject failed with error %lu!", error);
+						break;
+					}
 
 					CloseHandle(irp->thread);
 					irp->thread = NULL;

--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -474,7 +474,9 @@ static LONG smartcard_GetStatusChangeA_Call(SMARTCARD_DEVICE* smartcard, SMARTCA
 	}
 
 	ret.cReaders = call->cReaders;
-	ret.rgReaderStates = (ReaderState_Return*) calloc(ret.cReaders, sizeof(ReaderState_Return));
+	ret.rgReaderStates = NULL;
+	if (ret.cReaders > 0)
+		ret.rgReaderStates = (ReaderState_Return*) calloc(ret.cReaders, sizeof(ReaderState_Return));
 
 	if (!ret.rgReaderStates)
 		return STATUS_NO_MEMORY;
@@ -539,7 +541,9 @@ static LONG smartcard_GetStatusChangeW_Call(SMARTCARD_DEVICE* smartcard, SMARTCA
 	}
 
 	ret.cReaders = call->cReaders;
-	ret.rgReaderStates = (ReaderState_Return*) calloc(ret.cReaders, sizeof(ReaderState_Return));
+	ret.rgReaderStates = NULL;
+	if (ret.cReaders)
+		ret.rgReaderStates = (ReaderState_Return*) calloc(ret.cReaders, sizeof(ReaderState_Return));
 
 	if (!ret.rgReaderStates)
 		return STATUS_NO_MEMORY;
@@ -1231,7 +1235,9 @@ static LONG smartcard_LocateCardsByATRA_Call(SMARTCARD_DEVICE* smartcard, SMARTC
 	}
 
 	ret.cReaders = call->cReaders;
-	ret.rgReaderStates = (ReaderState_Return*) calloc(ret.cReaders, sizeof(ReaderState_Return));
+	ret.rgReaderStates = NULL;
+	if (ret.cReaders > 0)
+		ret.rgReaderStates = (ReaderState_Return*) calloc(ret.cReaders, sizeof(ReaderState_Return));
 
 	if (!ret.rgReaderStates)
 		return STATUS_NO_MEMORY;

--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -542,7 +542,7 @@ static LONG smartcard_GetStatusChangeW_Call(SMARTCARD_DEVICE* smartcard, SMARTCA
 
 	ret.cReaders = call->cReaders;
 	ret.rgReaderStates = NULL;
-	if (ret.cReaders)
+	if (ret.cReaders > 0)
 		ret.rgReaderStates = (ReaderState_Return*) calloc(ret.cReaders, sizeof(ReaderState_Return));
 
 	if (!ret.rgReaderStates)

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -1552,12 +1552,20 @@ skip_encoding_loop:
 
 	if (success && message->numTiles != maxNbTiles)
 	{
-		void* pmem = realloc((void*) message->tiles, sizeof(RFX_TILE*) * message->numTiles);
+		if (message->numTiles > 0)
+		{
+			void* pmem = realloc((void*) message->tiles, sizeof(RFX_TILE*) * message->numTiles);
 
-		if (pmem)
-			message->tiles = (RFX_TILE**) pmem;
+			if (pmem)
+				message->tiles = (RFX_TILE**) pmem;
+			else
+				success = FALSE;
+		}
 		else
+		{
+			free(message->tiles);
 			success = FALSE;
+		}
 	}
 
 	/* when using threads ensure all computations are done */

--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -713,9 +713,11 @@ int shadow_client_send_bitmap_update(rdpShadowClient* client, rdpShadowSurface* 
 		UINT32 i, j;
 		UINT32 updateSize;
 		UINT32 newUpdateSize;
-		BITMAP_DATA* fragBitmapData;
+		BITMAP_DATA* fragBitmapData = NULL;
 
-		fragBitmapData = (BITMAP_DATA*) malloc(sizeof(BITMAP_DATA) * k);
+		if (k > 0)
+			fragBitmapData = (BITMAP_DATA*) malloc(sizeof(BITMAP_DATA) * k);
+
 		if (!fragBitmapData)
 		{
 			free(bitmapData);

--- a/winpr/libwinpr/comm/comm_ioctl.c
+++ b/winpr/libwinpr/comm/comm_ioctl.c
@@ -709,7 +709,7 @@ int _comm_ioctl_tcsetattr(int fd, int optional_actions, const struct termios *te
 		return result;
 	}
 
-	if (memcmp(&currentState, &termios_p, sizeof(struct termios)) != 0)
+	if (memcmp(&currentState, termios_p, sizeof(struct termios)) != 0)
 	{
 		CommLog_Print(WLOG_DEBUG, "all termios parameters are not set yet, doing a second attempt...");
 		if ((result = tcsetattr(fd, optional_actions, termios_p)) < 0)

--- a/winpr/libwinpr/environment/test/TestEnvironmentGetSetEB.c
+++ b/winpr/libwinpr/environment/test/TestEnvironmentGetSetEB.c
@@ -98,8 +98,11 @@ int TestEnvironmentGetSetEB(int argc, char* argv[])
 		}
 	}
 	free(lpszEnvironmentBlockNew);
+	lpszEnvironmentBlockNew = NULL;
 
-	lpszEnvironmentBlockNew = (LPTCH) malloc(length);
+	if (length > 0)
+		lpszEnvironmentBlockNew = (LPTCH) malloc(length);
+
 	if (!lpszEnvironmentBlockNew)
 		return -1;
 

--- a/winpr/libwinpr/environment/test/TestEnvironmentGetSetEB.c
+++ b/winpr/libwinpr/environment/test/TestEnvironmentGetSetEB.c
@@ -99,11 +99,11 @@ int TestEnvironmentGetSetEB(int argc, char* argv[])
 	}
 	free(lpszEnvironmentBlockNew);
 
-	lpszEnvironmentBlockNew = (LPTCH) malloc(1024);
+	lpszEnvironmentBlockNew = (LPTCH) malloc(length);
 	if (!lpszEnvironmentBlockNew)
 		return -1;
 
-	memcpy(lpszEnvironmentBlockNew,lpszEnvironmentBlock,56);
+	memcpy(lpszEnvironmentBlockNew,lpszEnvironmentBlock,length);
 
 	/* Set variable in empty environment block */
 	if (SetEnvironmentVariableEBA(&lpszEnvironmentBlockNew, "test", "5"))

--- a/winpr/libwinpr/environment/test/TestEnvironmentGetSetEB.c
+++ b/winpr/libwinpr/environment/test/TestEnvironmentGetSetEB.c
@@ -98,11 +98,8 @@ int TestEnvironmentGetSetEB(int argc, char* argv[])
 		}
 	}
 	free(lpszEnvironmentBlockNew);
-	lpszEnvironmentBlockNew = NULL;
 
-	if (length > 0)
-		lpszEnvironmentBlockNew = (LPTCH) malloc(length);
-
+	lpszEnvironmentBlockNew = (LPTCH) malloc(1024);
 	if (!lpszEnvironmentBlockNew)
 		return -1;
 

--- a/winpr/libwinpr/environment/test/TestEnvironmentGetSetEB.c
+++ b/winpr/libwinpr/environment/test/TestEnvironmentGetSetEB.c
@@ -99,7 +99,7 @@ int TestEnvironmentGetSetEB(int argc, char* argv[])
 	}
 	free(lpszEnvironmentBlockNew);
 
-	lpszEnvironmentBlockNew = (LPTCH) malloc(1024);
+	lpszEnvironmentBlockNew = (LPTCH) calloc(1024, sizeof(TCHAR));
 	if (!lpszEnvironmentBlockNew)
 		return -1;
 

--- a/winpr/libwinpr/utils/lodepng/lodepng.c
+++ b/winpr/libwinpr/utils/lodepng/lodepng.c
@@ -4632,7 +4632,7 @@ unsigned lodepng_decode(unsigned char** out, unsigned* w, unsigned* h,
     }
 
     outsize = lodepng_get_raw_size(*w, *h, &state->info_raw);
-    *out = (unsigned char*)malloc(outsize);
+    *out = (unsigned char*)calloc(outsize, sizeof(unsigned char));
     if(!(*out))
     {
       state->error = 83; /*alloc fail*/

--- a/winpr/libwinpr/utils/wlog/PacketMessage.c
+++ b/winpr/libwinpr/utils/wlog/PacketMessage.c
@@ -199,7 +199,7 @@ wPcap* Pcap_Open(char* name, BOOL write)
 	pcap = (wPcap*) calloc(1, sizeof(wPcap));
 
 	if (!pcap)
-		return NULL;
+		goto out_fail;
 
 	pcap->name = name;
 	pcap->write = write;


### PR DESCRIPTION
* Fixes allocations of zero size
* Fixes uninitialized memory errors
* Fixes ```_comm_ioctl_tcsetattr```, compared ```struct termios``` against ```struct termios*```