### PR TITLE
X11 /app: Fix drawing with negative window origin

### DIFF
--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -222,10 +222,10 @@ void xf_rail_invalidate_region(xfContext* xfc, REGION16* invalidRegion)
 
 		if (appWindow)
 		{
-			windowRect.left = appWindow->x;
-			windowRect.top = appWindow->y;
-			windowRect.right = appWindow->x + appWindow->width;
-			windowRect.bottom = appWindow->y + appWindow->height;
+			windowRect.left = MAX(appWindow->x, 0);
+			windowRect.top = MAX(appWindow->y, 0);
+			windowRect.right = MAX(appWindow->x + appWindow->width, 0);
+			windowRect.bottom = MAX(appWindow->y + appWindow->height, 0);
 
 			region16_clear(&windowInvalidRegion);
 			region16_intersect_rect(&windowInvalidRegion, invalidRegion, &windowRect);


### PR DESCRIPTION
Since REGION16 uses unsigned values, when `appWindow->x` or `appWindow->y`
is negative, the region will have a very large left or top value.

Avoid this problem by clamping to 0 before casting to an unsigned value.