### PR TITLE
TCP/Transport: Fix tcp handling on win32.

### DIFF
--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -745,12 +745,8 @@ int transport_check_fds(rdpTransport* transport)
 	int status;
 	int recv_status;
 	wStream* received;
-	HANDLE event;
 
 	if (!transport)
-		return -1;
-
-	if (BIO_get_event(transport->frontBio, &event) != 1)
 		return -1;
 
 	/**
@@ -760,9 +756,6 @@ int transport_check_fds(rdpTransport* transport)
 	 * wait for a socket to get signaled that data is available
 	 * (which may never happen).
 	 */
-#ifdef _WIN32
-	ResetEvent(event);
-#endif
 	for (;;)
 	{
 		/**


### PR DESCRIPTION
1. Fix socket event (created by WSAEventCreate) handling for win32. This is to fix the issue which uncovered by #2750.
We used to fall in loop after 2750. The reason is event created by WSAEventSelect on windows need manually reset, it is always in 'set' state even when we run out of the read buffer.
It was first fixed in PR 2770. However the solution introduced another issue on Linux. This PR discards the fix in 2770
Later A quick fix for 2770 was introduced in 2790/2791. It is also discarded together.
This fix try to keep usage same on Windows and Posix.
2. Fix argument for WSAEventSelect on win32 to be consistent with Linux.
3. Fix tcp event for listener.