### PR TITLE
server/shadow: Completely decouple subsystem implementations and shad…

### DIFF
--- a/server/shadow/CMakeLists.txt
+++ b/server/shadow/CMakeLists.txt
@@ -18,6 +18,87 @@
 set(MODULE_NAME "freerdp-shadow")
 set(MODULE_PREFIX "FREERDP_SERVER_SHADOW")
 
+include_directories(${OPENSSL_INCLUDE_DIR})
+
+set(${MODULE_PREFIX}_SRCS
+	shadow_client.c
+	shadow_client.h
+	shadow_lobby.c
+	shadow_lobby.h
+	shadow_input.c
+	shadow_input.h
+	shadow_screen.c
+	shadow_screen.h
+	shadow_surface.c
+	shadow_surface.h
+	shadow_encoder.c
+	shadow_encoder.h
+	shadow_capture.c
+	shadow_capture.h
+	shadow_channels.c
+	shadow_channels.h
+	shadow_encomsp.c
+	shadow_encomsp.h
+	shadow_remdesk.c
+	shadow_remdesk.h
+	shadow_rdpsnd.c
+	shadow_rdpsnd.h
+	shadow_audin.c
+	shadow_audin.h
+	shadow_subsystem.c
+	shadow_subsystem.h
+	shadow_mcevent.c
+	shadow_mcevent.h
+	shadow_server.c
+	shadow.h)
+
+# On windows create dll version information.
+# Vendor, product and year are already set in top level CMakeLists.txt
+if (WIN32)
+  set (RC_VERSION_MAJOR ${FREERDP_VERSION_MAJOR})
+  set (RC_VERSION_MINOR ${FREERDP_VERSION_MINOR})
+  set (RC_VERSION_BUILD ${FREERDP_VERSION_REVISION})
+  set (RC_VERSION_PATCH 0)
+  set (RC_VERSION_FILE "${CMAKE_SHARED_LIBRARY_PREFIX}${MODULE_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}" )
+
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/cmake/WindowsDLLVersion.rc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+    @ONLY)
+
+  set ( ${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_SRCS} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+endif()
+
+add_library(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
+
+list(APPEND ${MODULE_PREFIX}_LIBS freerdp)
+list(APPEND ${MODULE_PREFIX}_LIBS freerdp-server)
+list(APPEND ${MODULE_PREFIX}_LIBS freerdp-client)
+
+list(APPEND ${MODULE_PREFIX}_LIBS winpr)
+list(APPEND ${MODULE_PREFIX}_LIBS winpr-makecert-tool)
+
+list(APPEND ${MODULE_PREFIX}_LIBS rdtk)
+
+target_link_libraries(${MODULE_NAME} ${${MODULE_PREFIX}_LIBS})
+
+if (WITH_LIBRARY_VERSIONING)
+	  set_target_properties(${MODULE_NAME} PROPERTIES VERSION ${FREERDP_VERSION} SOVERSION ${FREERDP_API_VERSION})
+endif()
+
+install(TARGETS ${MODULE_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT server)
+
+if (WITH_DEBUG_SYMBOLS AND MSVC)
+	install(FILES ${CMAKE_BINARY_DIR}/${MODULE_NAME}.pdb DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT symbols)
+endif()
+
+set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "Server/shadow")
+
+# command-line executable
+
+set(MODULE_NAME "freerdp-shadow-cli")
+set(MODULE_PREFIX "FREERDP_SERVER_SHADOW_CLI")
+
 if(WIN32)
 	set(WITH_SHADOW_WIN 1)
 elseif(X11_FOUND AND NOT APPLE)
@@ -146,39 +227,8 @@ if(WITH_SHADOW_MAC)
 	list(APPEND ${MODULE_PREFIX}_MAC_LIBS ${IOKIT} ${IOSURFACE} ${CARBON})
 endif()
 
-include_directories(${OPENSSL_INCLUDE_DIR})
-
 set(${MODULE_PREFIX}_SRCS
-	shadow_client.c
-	shadow_client.h
-	shadow_lobby.c
-	shadow_lobby.h
-	shadow_input.c
-	shadow_input.h
-	shadow_screen.c
-	shadow_screen.h
-	shadow_surface.c
-	shadow_surface.h
-	shadow_encoder.c
-	shadow_encoder.h
-	shadow_capture.c
-	shadow_capture.h
-	shadow_channels.c
-	shadow_channels.h
-	shadow_encomsp.c
-	shadow_encomsp.h
-	shadow_remdesk.c
-	shadow_remdesk.h
-	shadow_rdpsnd.c
-	shadow_rdpsnd.h
-	shadow_audin.c
-	shadow_audin.h
-	shadow_subsystem.c
-	shadow_subsystem.h
-	shadow_mcevent.c
-	shadow_mcevent.h
-	shadow_server.c
-	shadow.h)
+	shadow.c)
 
 set(${MODULE_PREFIX}_WIN_SRCS
 	Win/win_rdp.c
@@ -213,56 +263,6 @@ elseif(WITH_SHADOW_MAC)
 endif()
 
 list(APPEND ${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_AUTH_LIBS})
-
-# On windows create dll version information.
-# Vendor, product and year are already set in top level CMakeLists.txt
-if (WIN32)
-  set (RC_VERSION_MAJOR ${FREERDP_VERSION_MAJOR})
-  set (RC_VERSION_MINOR ${FREERDP_VERSION_MINOR})
-  set (RC_VERSION_BUILD ${FREERDP_VERSION_REVISION})
-  set (RC_VERSION_PATCH 0)
-  set (RC_VERSION_FILE "${CMAKE_SHARED_LIBRARY_PREFIX}${MODULE_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}" )
-
-  configure_file(
-    ${CMAKE_SOURCE_DIR}/cmake/WindowsDLLVersion.rc.in
-    ${CMAKE_CURRENT_BINARY_DIR}/version.rc
-    @ONLY)
-
-  set ( ${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_SRCS} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
-endif()
-
-add_library(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
-
-list(APPEND ${MODULE_PREFIX}_LIBS freerdp)
-list(APPEND ${MODULE_PREFIX}_LIBS freerdp-server)
-list(APPEND ${MODULE_PREFIX}_LIBS freerdp-client)
-
-list(APPEND ${MODULE_PREFIX}_LIBS winpr)
-list(APPEND ${MODULE_PREFIX}_LIBS winpr-makecert-tool)
-
-list(APPEND ${MODULE_PREFIX}_LIBS rdtk)
-
-target_link_libraries(${MODULE_NAME} ${${MODULE_PREFIX}_LIBS})
-
-if (WITH_LIBRARY_VERSIONING)
-	  set_target_properties(${MODULE_NAME} PROPERTIES VERSION ${FREERDP_VERSION} SOVERSION ${FREERDP_API_VERSION})
-endif()
-
-install(TARGETS ${MODULE_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT server)
-
-if (WITH_DEBUG_SYMBOLS AND MSVC)
-	install(FILES ${CMAKE_BINARY_DIR}/${MODULE_NAME}.pdb DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT symbols)
-endif()
-
-set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "Server/shadow")
-
-# command-line executable
-
-set(MODULE_NAME "freerdp-shadow-cli")
-set(MODULE_PREFIX "FREERDP_SERVER_SHADOW_CLI")
-
-set(${MODULE_PREFIX}_SRCS
-	shadow.c)
 
 	# On windows create dll version information.
 # Vendor, product and year are already set in top level CMakeLists.txt

--- a/server/shadow/Mac/mac_shadow.c
+++ b/server/shadow/Mac/mac_shadow.c
@@ -25,13 +25,6 @@
 #include <freerdp/codec/region.h>
 #include <freerdp/log.h>
 
-#include "../shadow_screen.h"
-#include "../shadow_client.h"
-#include "../shadow_surface.h"
-#include "../shadow_capture.h"
-#include "../shadow_subsystem.h"
-#include "../shadow_mcevent.h"
-
 #include "mac_shadow.h"
 
 #define TAG SERVER_TAG("shadow.mac")
@@ -39,12 +32,12 @@
 
 static macShadowSubsystem* g_Subsystem = NULL;
 
-void mac_shadow_input_synchronize_event(macShadowSubsystem* subsystem, UINT32 flags)
+void mac_shadow_input_synchronize_event(macShadowSubsystem* subsystem, rdpShadowClient* client, UINT32 flags)
 {
 
 }
 
-void mac_shadow_input_keyboard_event(macShadowSubsystem* subsystem, UINT16 flags, UINT16 code)
+void mac_shadow_input_keyboard_event(macShadowSubsystem* subsystem, rdpShadowClient* client, UINT16 flags, UINT16 code)
 {
 	DWORD vkcode;
 	DWORD keycode;
@@ -87,12 +80,12 @@ void mac_shadow_input_keyboard_event(macShadowSubsystem* subsystem, UINT16 flags
 	CFRelease(source);
 }
 
-void mac_shadow_input_unicode_keyboard_event(macShadowSubsystem* subsystem, UINT16 flags, UINT16 code)
+void mac_shadow_input_unicode_keyboard_event(macShadowSubsystem* subsystem, rdpShadowClient* client, UINT16 flags, UINT16 code)
 {
 
 }
 
-void mac_shadow_input_mouse_event(macShadowSubsystem* subsystem, UINT16 flags, UINT16 x, UINT16 y)
+void mac_shadow_input_mouse_event(macShadowSubsystem* subsystem, rdpShadowClient* client, UINT16 flags, UINT16 x, UINT16 y)
 {
 	UINT32 scrollX = 0;
 	UINT32 scrollY = 0;
@@ -196,7 +189,7 @@ void mac_shadow_input_mouse_event(macShadowSubsystem* subsystem, UINT16 flags, U
 	}
 }
 
-void mac_shadow_input_extended_mouse_event(macShadowSubsystem* subsystem, UINT16 flags, UINT16 x, UINT16 y)
+void mac_shadow_input_extended_mouse_event(macShadowSubsystem* subsystem, rdpShadowClient* client, UINT16 flags, UINT16 x, UINT16 y)
 {
 
 }
@@ -366,7 +359,7 @@ void (^mac_capture_stream_handler)(CGDisplayStreamFrameStatus, uint64_t, IOSurfa
 			
 		count = ArrayList_Count(server->clients);
 			
-		shadow_multiclient_publish_and_wait(subsystem->updateEvent);
+		shadow_subsystem_frame_update((rdpShadowSubsystem *)subsystem);
 		
 		if (count == 1)
 		{
@@ -667,7 +660,7 @@ macShadowSubsystem* mac_shadow_subsystem_new()
 	return subsystem;
 }
 
-FREERDP_API int Mac_ShadowSubsystemEntry(RDP_SHADOW_ENTRY_POINTS* pEntryPoints)
+int Mac_ShadowSubsystemEntry(RDP_SHADOW_ENTRY_POINTS* pEntryPoints)
 {
 	pEntryPoints->New = (pfnShadowSubsystemNew) mac_shadow_subsystem_new;
 	pEntryPoints->Free = (pfnShadowSubsystemFree) mac_shadow_subsystem_free;

--- a/server/shadow/X11/x11_shadow.c
+++ b/server/shadow/X11/x11_shadow.c
@@ -40,13 +40,6 @@
 #include <freerdp/codec/color.h>
 #include <freerdp/codec/region.h>
 
-#include "../shadow_screen.h"
-#include "../shadow_client.h"
-#include "../shadow_capture.h"
-#include "../shadow_surface.h"
-#include "../shadow_subsystem.h"
-#include "../shadow_mcevent.h"
-
 #include "x11_shadow.h"
 
 #define TAG SERVER_TAG("shadow.x11")
@@ -161,7 +154,7 @@ int x11_shadow_pam_get_service_name(SHADOW_PAM_AUTH_INFO* info)
 	return 1;
 }
 
-int x11_shadow_pam_authenticate(x11ShadowSubsystem* subsystem, const char* user, const char* domain, const char* password)
+int x11_shadow_pam_authenticate(x11ShadowSubsystem* subsystem, rdpShadowClient* client, const char* user, const char* domain, const char* password)
 {
 	int pam_status;
 	SHADOW_PAM_AUTH_INFO* info;
@@ -215,12 +208,12 @@ int x11_shadow_pam_authenticate(x11ShadowSubsystem* subsystem, const char* user,
 
 #endif
 
-void x11_shadow_input_synchronize_event(x11ShadowSubsystem* subsystem, UINT32 flags)
+void x11_shadow_input_synchronize_event(x11ShadowSubsystem* subsystem, rdpShadowClient* client, UINT32 flags)
 {
 
 }
 
-void x11_shadow_input_keyboard_event(x11ShadowSubsystem* subsystem, UINT16 flags, UINT16 code)
+void x11_shadow_input_keyboard_event(x11ShadowSubsystem* subsystem, rdpShadowClient* client, UINT16 flags, UINT16 code)
 {
 #ifdef WITH_XTEST
 	DWORD vkcode;
@@ -256,12 +249,12 @@ void x11_shadow_input_keyboard_event(x11ShadowSubsystem* subsystem, UINT16 flags
 #endif
 }
 
-void x11_shadow_input_unicode_keyboard_event(x11ShadowSubsystem* subsystem, UINT16 flags, UINT16 code)
+void x11_shadow_input_unicode_keyboard_event(x11ShadowSubsystem* subsystem, rdpShadowClient* client, UINT16 flags, UINT16 code)
 {
 
 }
 
-void x11_shadow_input_mouse_event(x11ShadowSubsystem* subsystem, UINT16 flags, UINT16 x, UINT16 y)
+void x11_shadow_input_mouse_event(x11ShadowSubsystem* subsystem, rdpShadowClient* client, UINT16 flags, UINT16 x, UINT16 y)
 {
 #ifdef WITH_XTEST
 	int button = 0;
@@ -314,7 +307,7 @@ void x11_shadow_input_mouse_event(x11ShadowSubsystem* subsystem, UINT16 flags, U
 #endif
 }
 
-void x11_shadow_input_extended_mouse_event(x11ShadowSubsystem* subsystem, UINT16 flags, UINT16 x, UINT16 y)
+void x11_shadow_input_extended_mouse_event(x11ShadowSubsystem* subsystem, rdpShadowClient* client, UINT16 flags, UINT16 x, UINT16 y)
 {
 #ifdef WITH_XTEST
 	int button = 0;
@@ -793,7 +786,7 @@ int x11_shadow_screen_grab(x11ShadowSubsystem* subsystem)
 
 		count = ArrayList_Count(server->clients);
 
-		shadow_multiclient_publish_and_wait(subsystem->updateEvent);
+		shadow_subsystem_frame_update((rdpShadowSubsystem *)subsystem);
 
 		if (count == 1)
 		{
@@ -1444,7 +1437,7 @@ void x11_shadow_subsystem_free(x11ShadowSubsystem* subsystem)
 	free(subsystem);
 }
 
-FREERDP_API int X11_ShadowSubsystemEntry(RDP_SHADOW_ENTRY_POINTS* pEntryPoints)
+int X11_ShadowSubsystemEntry(RDP_SHADOW_ENTRY_POINTS* pEntryPoints)
 {
 	pEntryPoints->New = (pfnShadowSubsystemNew) x11_shadow_subsystem_new;
 	pEntryPoints->Free = (pfnShadowSubsystemFree) x11_shadow_subsystem_free;

--- a/server/shadow/shadow_audin.c
+++ b/server/shadow/shadow_audin.c
@@ -93,7 +93,7 @@ static UINT AudinServerReceiveSamples(audin_server_context* context, const void*
 		return CHANNEL_RC_OK;
 
 	if (subsystem->AudinServerReceiveSamples)
-		subsystem->AudinServerReceiveSamples(subsystem, buf, nframes);
+		subsystem->AudinServerReceiveSamples(subsystem, client, buf, nframes);
 	return CHANNEL_RC_OK;
 }
 

--- a/server/shadow/shadow_capture.h
+++ b/server/shadow/shadow_capture.h
@@ -38,9 +38,6 @@ struct rdp_shadow_capture
 extern "C" {
 #endif
 
-int shadow_capture_align_clip_rect(RECTANGLE_16* rect, RECTANGLE_16* clip);
-int shadow_capture_compare(BYTE* pData1, int nStep1, int nWidth, int nHeight, BYTE* pData2, int nStep2, RECTANGLE_16* rect);
-
 rdpShadowCapture* shadow_capture_new(rdpShadowServer* server);
 void shadow_capture_free(rdpShadowCapture* capture);
 

--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -179,6 +179,16 @@ void shadow_client_message_free(wMessage* message)
 
 BOOL shadow_client_capabilities(freerdp_peer* peer)
 {
+	rdpShadowSubsystem* subsystem;
+	rdpShadowClient* client;
+
+	client = (rdpShadowClient*) peer->context;
+	subsystem = client->server->subsystem;
+
+	if (subsystem->ClientCapabilities)
+	{
+		return subsystem->ClientCapabilities(subsystem, client);
+	}
 	return TRUE;
 }
 
@@ -243,7 +253,7 @@ BOOL shadow_client_post_connect(freerdp_peer* peer)
 	{
 		if (subsystem->Authenticate)
 		{
-			authStatus = subsystem->Authenticate(subsystem,
+			authStatus = subsystem->Authenticate(subsystem, client,
 					settings->Username, settings->Domain, settings->Password);
 		}
 	}

--- a/server/shadow/shadow_input.c
+++ b/server/shadow/shadow_input.c
@@ -32,7 +32,7 @@ BOOL shadow_input_synchronize_event(rdpInput* input, UINT32 flags)
 
 	if (subsystem->SynchronizeEvent)
 	{
-		subsystem->SynchronizeEvent(subsystem, flags);
+		subsystem->SynchronizeEvent(subsystem, client, flags);
 	}
 	return TRUE;
 }
@@ -47,7 +47,7 @@ BOOL shadow_input_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
 	
 	if (subsystem->KeyboardEvent)
 	{
-		subsystem->KeyboardEvent(subsystem, flags, code);
+		subsystem->KeyboardEvent(subsystem, client, flags, code);
 	}
 	return TRUE;
 }
@@ -62,7 +62,7 @@ BOOL shadow_input_unicode_keyboard_event(rdpInput* input, UINT16 flags, UINT16 c
 
 	if (subsystem->UnicodeKeyboardEvent)
 	{
-		subsystem->UnicodeKeyboardEvent(subsystem, flags, code);
+		subsystem->UnicodeKeyboardEvent(subsystem, client, flags, code);
 	}
 	return TRUE;
 }
@@ -98,7 +98,7 @@ BOOL shadow_input_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UINT16 y)
 
 	if (subsystem->MouseEvent)
 	{
-		subsystem->MouseEvent(subsystem, flags, x, y);
+		subsystem->MouseEvent(subsystem, client, flags, x, y);
 	}
 	return TRUE;
 }
@@ -122,7 +122,7 @@ BOOL shadow_input_extended_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, 
 
 	if (subsystem->ExtendedMouseEvent)
 	{
-		subsystem->ExtendedMouseEvent(subsystem, flags, x, y);
+		subsystem->ExtendedMouseEvent(subsystem, client, flags, x, y);
 	}
 	return TRUE;
 }

--- a/server/shadow/shadow_subsystem.c
+++ b/server/shadow/shadow_subsystem.c
@@ -271,3 +271,8 @@ int shadow_subsystem_pointer_convert_alpha_pointer_data(BYTE* pixels, BOOL premu
 
 	return 1;
 }
+
+void shadow_subsystem_frame_update(rdpShadowSubsystem* subsystem)
+{
+	shadow_multiclient_publish_and_wait(subsystem->updateEvent);
+}

--- a/server/shadow/shadow_surface.h
+++ b/server/shadow/shadow_surface.h
@@ -24,21 +24,6 @@
 #include <winpr/crt.h>
 #include <winpr/synch.h>
 
-struct rdp_shadow_surface
-{
-	rdpShadowServer* server;
-
-	int x;
-	int y;
-	int width;
-	int height;
-	int scanline;
-	BYTE* data;
-
-	CRITICAL_SECTION lock;
-	REGION16 invalidRegion;
-};
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
…ow framework internal details.

It will be completely possible to implement subsystem with only include/freerdp/server/shadow.h and libfreerdp-shadow.

Details as following:
1. Exported surface structure as subsystem implementations deeply depend on it to send image update
2. Export capture APIs. They are actually indepent APIs to help compare and calculate image difference.
3. Introduce API to trigger client frame update. Conceal details in subsystem->updateEvent
4. Pass client to client callbacks. Subsystem implementation may need to know 'which client' send the interaction event as well as the authentication request.
Add this support in callback definition before anyone really use shadow framework APIs to implement a custom subsystem.
Also added callback for client capability exchange
5. Remove X11_ShadowSubsystem Mac_ShadowSubsystem Win_ShadowSubsystem from libfreerdp-shadow.
Discard FREERDP_API mark on ShadowSubsystemEntry functions and make them be compiled together with shadow.c in CMakeLists.txt.
This is required from PR #2751.
Now subsystem implementations and shadow.c could be regarded as an example for shadow framework.