### PR TITLE
makecert: Remove key usage attribute

### DIFF
--- a/winpr/tools/makecert/makecert.c
+++ b/winpr/tools/makecert/makecert.c
@@ -989,7 +989,6 @@ int makecert_context_process(MAKECERT_CONTEXT* context, int argc, char** argv)
 	X509_set_issuer_name(context->x509, name);
 
 	x509_add_ext(context->x509, NID_ext_key_usage, "serverAuth");
-	x509_add_ext(context->x509, NID_key_usage, "keyEncipherment,dataEncipherment");
 
 	arg = CommandLineFindArgumentA(args, "a");
 


### PR DESCRIPTION
The original makecert tool won't add this tribute to a generated
certificate. Adding this attribute might cause problems when using the
certificate with other apps (i.e. Qt SSL).