### PR TITLE
xfreerdp: Fix window shape

### DIFF
--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -497,11 +497,12 @@ static BOOL xf_rail_window_common(rdpContext* context, WINDOW_ORDER_INFO* orderI
 				appWindow->height == appWindow->windowHeight)
 		{
 			xf_UpdateWindowArea(xfc, appWindow, 0, 0, appWindow->windowWidth, appWindow->windowHeight);
-			return TRUE;
 		}
-
-		xf_MoveWindow(xfc, appWindow, appWindow->windowOffsetX - appWindow->localWindowOffsetCorrX, appWindow->windowOffsetY - appWindow->localWindowOffsetCorrY,
+		else
+		{
+			xf_MoveWindow(xfc, appWindow, appWindow->windowOffsetX - appWindow->localWindowOffsetCorrX, appWindow->windowOffsetY - appWindow->localWindowOffsetCorrY,
 				appWindow->windowWidth, appWindow->windowHeight);
+		}
 	}
 
 	if (fieldFlags & WINDOW_ORDER_FIELD_WND_RECTS)


### PR DESCRIPTION
Don't abort the entire xf_rail_window_common function when the window is
already in the correct location.

To reproduce:
 - move an application off the edge of the screen
 - resize the window to cause a shape to be set
 - move the application window fully on the screen
 - resize the application window larger
 - note lack of drawing in newly enlarged portion of window

Bug introduced in abf6d4f71ea901e31ee2d1b4625fa805af6b0cc9 "xfreerdp:
prepare RAIL migration away from libfreerdp-rail" when
xf_rail_MoveWindow was copy-and-pasted into xf_rail_window_common
without noticing that the "return" would omit the rest of the combined
function, not just the portion that was pasted.