### PR TITLE
Fix Network Characteristics Autodetect [RDPBCGR 2.2.14]

### DIFF
--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -186,9 +186,6 @@ BOOL nego_connect(rdpNego* nego)
 		return FALSE;
 	}
 
-	if (!(nego->flags & DYNVC_GFX_PROTOCOL_SUPPORTED))
-		settings->NetworkAutoDetect = FALSE;
-
 	return TRUE;
 }
 


### PR DESCRIPTION
Removed if statement that was causing network characteristics autodetect to not work correctly.

Network characteristics autodetect does not require GFX or the GFX channel to work properly, and this if statement was preventing autodetect packets from being sent/received properly.