### PR TITLE
server: Fix several memory leak found while running valgrind on freerdp-shadow

### DIFF
--- a/channels/rdpsnd/server/rdpsnd_main.c
+++ b/channels/rdpsnd/server/rdpsnd_main.c
@@ -782,6 +782,8 @@ void rdpsnd_server_context_free(RdpsndServerContext* context)
 
 	free(context->client_formats);
 
+	free(context->priv);
+
 	free(context);
 }
 

--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -983,7 +983,6 @@ HANDLE WINAPI FreeRDP_WTSVirtualChannelOpen(HANDLE hServer, DWORD SessionId, LPS
 			goto error_receiveData;
 		}
 		channel->queue = MessageQueue_New(NULL);
-		channel->queue = MessageQueue_New(NULL);
 		if (!channel->queue)
 			goto error_queue;
 

--- a/rdtk/librdtk/rdtk_font.c
+++ b/rdtk/librdtk/rdtk_font.c
@@ -710,7 +710,14 @@ rdtkFont* rdtk_embedded_font_new(rdtkEngine* engine, BYTE* imageData, int imageS
 
 void rdtk_font_free(rdtkFont* font)
 {
-	free(font);
+	if (font)
+	{
+		free(font->family);
+		free(font->style);
+		winpr_image_free(font->image, TRUE);
+		free(font->glyphs);
+		free(font);
+	}
 }
 
 int rdtk_font_engine_init(rdtkEngine* engine)


### PR DESCRIPTION
Part of the definitely lost log from valgrind:
==12776== 8 bytes in 1 blocks are definitely lost in loss record 22 of 743
==12776==    at 0x4C2B6CD: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12776==    by 0x6475AB1: strdup (strdup.c:43)
==12776==    by 0x6189C30: _strdup (string.c:45)
==12776==    by 0x6DEE329: rdtk_font_parse_descriptor_buffer (rdtk_font.c:370)
==12776==    by 0x6DEE91F: rdtk_embedded_font_new (rdtk_font.c:704)
==12776==    by 0x6DEEA3B: rdtk_font_engine_init (rdtk_font.c:731)
==12776==    by 0x6DEF8BF: rdtk_engine_new (rdtk_engine.c:39)
==12776==    by 0x5B93BCA: shadow_client_init_lobby (shadow_lobby.c:41)
==12776==    by 0x5B9402A: shadow_screen_new (shadow_screen.c:73)
==12776==    by 0x5B97C9B: shadow_server_start (shadow_server.c:380)
==12776==    by 0x40371F: main (shadow.c:94)
==12776==
==12776== 17 bytes in 1 blocks are definitely lost in loss record 46 of 743
==12776==    at 0x4C2B6CD: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12776==    by 0x6475AB1: strdup (strdup.c:43)
==12776==    by 0x6189C30: _strdup (string.c:45)
==12776==    by 0x6DEE27C: rdtk_font_parse_descriptor_buffer (rdtk_font.c:326)
==12776==    by 0x6DEE91F: rdtk_embedded_font_new (rdtk_font.c:704)
==12776==    by 0x6DEEA3B: rdtk_font_engine_init (rdtk_font.c:731)
==12776==    by 0x6DEF8BF: rdtk_engine_new (rdtk_engine.c:39)
==12776==    by 0x5B93BCA: shadow_client_init_lobby (shadow_lobby.c:41)
==12776==    by 0x5B9402A: shadow_screen_new (shadow_screen.c:73)
==12776==    by 0x5B97C9B: shadow_server_start (shadow_server.c:380)
==12776==    by 0x40371F: main (shadow.c:94)
==12776== 1,712 (112 direct, 1,600 indirect) bytes in 1 blocks are definitely lost in loss record 681 of 743
==12776==    at 0x4C29DB4: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12776==    by 0x615E595: MessageQueue_New (MessageQueue.c:194)
==12776==    by 0x5E43726: FreeRDP_WTSVirtualChannelOpen (server.c:985)
==12776==    by 0x40832B: rdpsnd_server_start (rdpsnd_main.c:611)
==12776==    by 0x5B954AC: shadow_client_rdpsnd_init (shadow_rdpsnd.c:97)
==12776==    by 0x5B94FE0: shadow_client_channels_post_connect (shadow_channels.c:41)
==12776==    by 0x5B915E4: shadow_client_post_connect (shadow_client.c:238)
==12776==    by 0x5E55CC1: rdp_server_transition_to_state (connection.c:1285)
==12776==    by 0x5E13A38: rdp_server_accept_client_font_list_pdu (activation.c:373)
==12776==    by 0x5E71DF4: peer_recv_tpkt_pdu (peer.c:307)
==12776==    by 0x5E7203A: peer_recv_pdu (peer.c:452)
==12776==    by 0x5E725FA: peer_recv_callback (peer.c:596)
==12776==
==12776== 1,712 (112 direct, 1,600 indirect) bytes in 1 blocks are definitely lost in loss record 682 of 743
==12776==    at 0x4C29DB4: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12776==    by 0x615E595: MessageQueue_New (MessageQueue.c:194)
==12776==    by 0x5E43726: FreeRDP_WTSVirtualChannelOpen (server.c:985)
==12776==    by 0x5E42F14: WTSVirtualChannelManagerCheckFileDescriptor (server.c:453)
==12776==    by 0x5B93234: shadow_client_thread (shadow_client.c:1090)
==12776==    by 0x617AB72: thread_launcher (thread.c:315)
==12776==    by 0x73D7E99: start_thread (pthread_create.c:308)
==12776==
==12776== 3,040 bytes in 1 blocks are definitely lost in loss record 689 of 743
==12776==    at 0x4C29DB4: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12776==    by 0x6DEE3B0: rdtk_font_parse_descriptor_buffer (rdtk_font.c:409)
==12776==    by 0x6DEE91F: rdtk_embedded_font_new (rdtk_font.c:704)
==12776==    by 0x6DEEA3B: rdtk_font_engine_init (rdtk_font.c:731)
==12776==    by 0x6DEF8BF: rdtk_engine_new (rdtk_engine.c:39)
==12776==    by 0x5B93BCA: shadow_client_init_lobby (shadow_lobby.c:41)
==12776==    by 0x5B9402A: shadow_screen_new (shadow_screen.c:73)
==12776==    by 0x5B97C9B: shadow_server_start (shadow_server.c:380)
==12776==    by 0x40371F: main (shadow.c:94)
==12776==
==12776== 50,564 (40 direct, 50,524 indirect) bytes in 1 blocks are definitely lost in loss record 722 of 743
==12776==    at 0x4C29DB4: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12776==    by 0x6DEE8D1: rdtk_embedded_font_new (rdtk_font.c:675)
==12776==    by 0x6DEEA3B: rdtk_font_engine_init (rdtk_font.c:731)
==12776==    by 0x6DEF8BF: rdtk_engine_new (rdtk_engine.c:39)
==12776==    by 0x5B93BCA: shadow_client_init_lobby (shadow_lobby.c:41)
==12776==    by 0x5B9402A: shadow_screen_new (shadow_screen.c:73)
==12776==    by 0x5B97C9B: shadow_server_start (shadow_server.c:380)
==12776==    by 0x40371F: main (shadow.c:94)
...
==12776== LEAK SUMMARY:
==12776==    definitely lost: 3,329 bytes in 6 blocks
==12776==    indirectly lost: 53,724 bytes in 7 blocks
