### PR TITLE
Fix use of invalid input causing SCARD_E_INSUFFICIENT_BUFFER errors

### DIFF
--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -888,10 +888,7 @@ static LONG smartcard_StatusA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERAT
 	LPSTR mszReaderNames = NULL;
 	IRP* irp = operation->irp;
 
-	if (call->cbAtrLen > 32)
-		call->cbAtrLen = 32;
-
-	ret.cbAtrLen = call->cbAtrLen;
+	ret.cbAtrLen = 32;
 	ZeroMemory(ret.pbAtr, 32);
 	cchReaderLen = SCARD_AUTOALLOCATE;
 
@@ -941,10 +938,7 @@ static LONG smartcard_StatusW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERAT
 	LPWSTR mszReaderNames = NULL;
 	IRP* irp = operation->irp;
 
-	if (call->cbAtrLen > 32)
-		call->cbAtrLen = 32;
-
-	ret.cbAtrLen = call->cbAtrLen;
+	ret.cbAtrLen = 32;
 	ZeroMemory(ret.pbAtr, 32);
 	cchReaderLen = SCARD_AUTOALLOCATE;
 


### PR DESCRIPTION
Dont use invalid/bogus input value for cbAtrLen for Smartcard Status Calls, instead just always use the max value here to indicate we have max buffer space available.

According to MS-RDPESC Section 2.2.2.18, the input value of cbAtrLen is unused and should be ignored, so we should not use it to try to calculate buffer size for actual Status calls.