### PR TITLE
Fixed crash when unused Japanese keys are pressed.

### DIFF
--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -381,6 +381,10 @@ int xf_keyboard_execute_action_script(xfContext* xfc, XF_MODIFIER_KEYS* mod, Key
 	}
 
 	keyStr = XKeysymToString(keysym);
+	if (keyStr == 0)
+	{
+		return 1;
+	}
 
 	if (mod->Shift)
 		strcat(combination, "Shift+");


### PR DESCRIPTION
With Japanese physical keyboard and English layout, pressing the extra keys can cause FreeRDP crash.