### PR TITLE
Server/Shadow: Minor fix on authentication in shadow_client.c.

### DIFF
--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -239,7 +239,7 @@ BOOL shadow_client_post_connect(freerdp_peer* peer)
 	if (settings->Username && settings->Password)
 		settings->AutoLogonEnabled = TRUE;
 
-	if (settings->AutoLogonEnabled && server->authentication)
+	if (server->authentication)
 	{
 		if (subsystem->Authenticate)
 		{


### PR DESCRIPTION
Currently if username or password is not set, the authentication is always failed because the authentication callback is never tried.
Fix to always give a chance to try the subsystem authentication callback even if username / password is not set.