### PR TITLE
Server/Shadow: Fix invalid ALIGN in shadow_client_send_bitmap_update

### DIFF
--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -628,14 +628,12 @@ int shadow_client_send_bitmap_update(rdpShadowClient* client, rdpShadowSurface* 
 
 	if ((nWidth % 4) != 0)
 	{
-		nXSrc -= (nWidth % 4);
-		nWidth += (nWidth % 4);
+		nWidth += (4 - (nWidth % 4));
 	}
 
 	if ((nHeight % 4) != 0)
 	{
-		nYSrc -= (nHeight % 4);
-		nHeight += (nHeight % 4);
+		nHeight += (4 - (nHeight % 4));
 	}
 
 	for (yIdx = 0; yIdx < rows; yIdx++)

--- a/server/shadow/shadow_surface.c
+++ b/server/shadow/shadow_surface.c
@@ -23,7 +23,7 @@
 #include "shadow.h"
 
 #include "shadow_surface.h"
-
+#define ALIGN_SCREEN_SIZE(size, align) ((size + align - 1) & (~(align - 1)))
 rdpShadowSurface* shadow_surface_new(rdpShadowServer* server, int x, int y, int width, int height)
 {
 	rdpShadowSurface* surface;
@@ -39,9 +39,9 @@ rdpShadowSurface* shadow_surface_new(rdpShadowServer* server, int x, int y, int 
 	surface->y = y;
 	surface->width = width;
 	surface->height = height;
-	surface->scanline = (surface->width + (surface->width % 4)) * 4;
+	surface->scanline = ALIGN_SCREEN_SIZE(surface->width, 4) * 4;
 
-	surface->data = (BYTE*) calloc(1, surface->scanline * surface->height);
+	surface->data = (BYTE*) calloc(1, surface->scanline * ALIGN_SCREEN_SIZE(surface->height, 4));
 	if (!surface->data)
 	{
 		free (surface);
@@ -77,7 +77,7 @@ void shadow_surface_free(rdpShadowSurface* surface)
 BOOL shadow_surface_resize(rdpShadowSurface *surface, int x, int y, int width, int height)
 {
 	BYTE* buffer = NULL;
-	int scanline = (width + (width % 4)) * 4;
+	int scanline =  ALIGN_SCREEN_SIZE(width, 4) * 4;
 
 	if (!surface)
 		return FALSE;
@@ -90,7 +90,7 @@ BOOL shadow_surface_resize(rdpShadowSurface *surface, int x, int y, int width, i
 		return TRUE;
 	}
 
-	buffer = (BYTE*) realloc(surface->data, scanline * height);
+	buffer = (BYTE*) realloc(surface->data, scanline * ALIGN_SCREEN_SIZE(height, 4));
 	if (buffer)
 	{
 		surface->x = x;


### PR DESCRIPTION
Some of the code in shadow looks like ‘ X + X % 4'. I think the purpose is to align variables up to multiples of 4, but it is not correct.

On the other hand, the code in shadow_client_send_bitmap_update which adjusts nXSrc/nYSrc/nWidth/nHeight. I think the purpose is to extent the left/top/right/bottom of the rect to multiples of 4. It does right thing when it adjust nXSrc and nYSrc, but it should not change nXSrc and nYSrc when adjusting nWidth and nHeight