### PR TITLE
Remove warning: HANDLE event variable unused

### DIFF
--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -746,7 +746,6 @@ int transport_check_fds(rdpTransport* transport)
 	int status;
 	int recv_status;
 	wStream* received;
-	HANDLE event;
 
 	if (!transport)
 		return -1;


### PR DESCRIPTION
Throws a warning during compilation. And, see HANDLE event is not used inside function. So removed it.