### PR TITLE
Sec/NLA: Support passwordless (blank password) login with NLA.

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
@@ -298,7 +298,7 @@ int ntlm_compute_ntlm_v2_hash(NTLM_CONTEXT* context, BYTE* hash)
 						 (LPWSTR) credentials->identity.Domain, credentials->identity.DomainLength * 2,
 						 (BYTE*) hash);
 	}
-	else if (credentials->identity.PasswordLength > 0)
+	else if (credentials->identity.Password)
 	{
 		NTOWFv2W((LPWSTR) credentials->identity.Password, credentials->identity.PasswordLength * 2,
 				 (LPWSTR) credentials->identity.User, credentials->identity.UserLength * 2,

--- a/winpr/libwinpr/sspi/sspi_winpr.c
+++ b/winpr/libwinpr/sspi/sspi_winpr.c
@@ -447,7 +447,7 @@ int sspi_CopyAuthIdentity(SEC_WINNT_AUTH_IDENTITY* identity, SEC_WINNT_AUTH_IDEN
 	if (identity->PasswordLength > 256)
 		identity->PasswordLength /= SSPI_CREDENTIALS_HASH_LENGTH_FACTOR;
 
-	if (identity->PasswordLength > 0)
+	if (srcIdentity->Password)
 	{
 		identity->Password = (UINT16*) malloc((identity->PasswordLength + 1) * sizeof(WCHAR));
 


### PR DESCRIPTION
It was supported in freerdp 1.0.2 but not supported in lastest master.
We should take empty password if it is explicitly specified with /p option.
If a password is not specified, we could first try SAM file. If the user entry does not exist, prompt for password.

Fixes #2783