### PR TITLE
wlog: fixed return values

### DIFF
--- a/winpr/include/winpr/wlog.h
+++ b/winpr/include/winpr/wlog.h
@@ -117,12 +117,12 @@ struct _wLogLayout
 #define WLOG_PACKET_INBOUND	1
 #define WLOG_PACKET_OUTBOUND	2
 
-typedef int (*WLOG_APPENDER_OPEN_FN)(wLog* log, wLogAppender* appender);
-typedef int (*WLOG_APPENDER_CLOSE_FN)(wLog* log, wLogAppender* appender);
-typedef int (*WLOG_APPENDER_WRITE_MESSAGE_FN)(wLog* log, wLogAppender* appender, wLogMessage* message);
-typedef int (*WLOG_APPENDER_WRITE_DATA_MESSAGE_FN)(wLog* log, wLogAppender* appender, wLogMessage* message);
-typedef int (*WLOG_APPENDER_WRITE_IMAGE_MESSAGE_FN)(wLog* log, wLogAppender* appender, wLogMessage* message);
-typedef int (*WLOG_APPENDER_WRITE_PACKET_MESSAGE_FN)(wLog* log, wLogAppender* appender, wLogMessage* message);
+typedef BOOL (*WLOG_APPENDER_OPEN_FN)(wLog* log, wLogAppender* appender);
+typedef BOOL (*WLOG_APPENDER_CLOSE_FN)(wLog* log, wLogAppender* appender);
+typedef BOOL (*WLOG_APPENDER_WRITE_MESSAGE_FN)(wLog* log, wLogAppender* appender, wLogMessage* message);
+typedef BOOL (*WLOG_APPENDER_WRITE_DATA_MESSAGE_FN)(wLog* log, wLogAppender* appender, wLogMessage* message);
+typedef BOOL (*WLOG_APPENDER_WRITE_IMAGE_MESSAGE_FN)(wLog* log, wLogAppender* appender, wLogMessage* message);
+typedef BOOL (*WLOG_APPENDER_WRITE_PACKET_MESSAGE_FN)(wLog* log, wLogAppender* appender, wLogMessage* message);
 
 #define WLOG_APPENDER_COMMON() \
 	DWORD Type; \
@@ -181,10 +181,10 @@ struct _wLogBinaryAppender
 };
 typedef struct _wLogBinaryAppender wLogBinaryAppender;
 
-typedef void (*CallbackAppenderMessage_t)(const wLogMessage *msg);
-typedef void (*CallbackAppenderData_t)(const wLogMessage *msg);
-typedef void (*CallbackAppenderImage_t)(const wLogMessage *msg);
-typedef void (*CallbackAppenderPackage_t)(const wLogMessage *msg);
+typedef BOOL (*CallbackAppenderMessage_t)(const wLogMessage *msg);
+typedef BOOL (*CallbackAppenderData_t)(const wLogMessage *msg);
+typedef BOOL (*CallbackAppenderImage_t)(const wLogMessage *msg);
+typedef BOOL (*CallbackAppenderPackage_t)(const wLogMessage *msg);
 
 struct _wLogCallbackAppender
 {
@@ -229,8 +229,8 @@ struct _wLog
 	DWORD ChildrenSize;
 };
 
-WINPR_API void WLog_PrintMessage(wLog* log, wLogMessage* message, ...);
-WINPR_API int WLog_PrintMessageVA(wLog* log, wLogMessage* message, va_list args);
+WINPR_API BOOL WLog_PrintMessage(wLog* log, wLogMessage* message, ...);
+WINPR_API BOOL WLog_PrintMessageVA(wLog* log, wLogMessage* message, va_list args);
 
 #define WLog_Print(_log, _log_level, _fmt, ...) \
 	do { \
@@ -314,20 +314,20 @@ WINPR_API int WLog_PrintMessageVA(wLog* log, wLogMessage* message, va_list args)
 #define WLog_FATAL(tag, fmt, ...) WLog_Print(WLog_Get(tag), WLOG_FATAL, fmt, ## __VA_ARGS__)
 
 WINPR_API DWORD WLog_GetLogLevel(wLog* log);
-WINPR_API void WLog_SetLogLevel(wLog* log, DWORD logLevel);
+WINPR_API BOOL WLog_SetLogLevel(wLog* log, DWORD logLevel);
 
 WINPR_API wLogAppender* WLog_GetLogAppender(wLog* log);
 WINPR_API BOOL WLog_SetLogAppenderType(wLog* log, DWORD logAppenderType);
 
-WINPR_API int WLog_OpenAppender(wLog* log);
-WINPR_API int WLog_CloseAppender(wLog* log);
+WINPR_API BOOL WLog_OpenAppender(wLog* log);
+WINPR_API BOOL WLog_CloseAppender(wLog* log);
 
-WINPR_API void WLog_ConsoleAppender_SetOutputStream(wLog* log, wLogConsoleAppender* appender, int outputStream);
+WINPR_API BOOL WLog_ConsoleAppender_SetOutputStream(wLog* log, wLogConsoleAppender* appender, int outputStream);
 
 WINPR_API BOOL WLog_FileAppender_SetOutputFileName(wLog* log, wLogFileAppender* appender, const char* filename);
 WINPR_API BOOL WLog_FileAppender_SetOutputFilePath(wLog* log, wLogFileAppender* appender, const char* filepath);
 
-WINPR_API void WLog_CallbackAppender_SetCallbacks(wLog* log, wLogCallbackAppender* appender,
+WINPR_API BOOL WLog_CallbackAppender_SetCallbacks(wLog* log, wLogCallbackAppender* appender,
 	CallbackAppenderMessage_t msg, CallbackAppenderImage_t img, CallbackAppenderPackage_t pkg,
 	CallbackAppenderData_t data);
 
@@ -338,7 +338,7 @@ WINPR_API wLog* WLog_GetRoot(void);
 WINPR_API wLog* WLog_Get(LPCSTR name);
 
 WINPR_API BOOL WLog_Init(void);
-WINPR_API void WLog_Uninit(void);
+WINPR_API BOOL WLog_Uninit(void);
 
 #ifdef __cplusplus
 }

--- a/winpr/libwinpr/utils/test/TestWLogCallback.c
+++ b/winpr/libwinpr/utils/test/TestWLogCallback.c
@@ -59,24 +59,28 @@ static BOOL check(const wLogMessage *msg)
 	return rc;
 }
 
-void CallbackAppenderMessage(const wLogMessage *msg)
+BOOL CallbackAppenderMessage(const wLogMessage *msg)
 {
 	check(msg);
+	return TRUE;
 }
 
-void CallbackAppenderData(const wLogMessage *msg)
+BOOL CallbackAppenderData(const wLogMessage *msg)
 {
 	fprintf(stdout, "%s\n", __FUNCTION__);
+	return TRUE;
 }
 
-void CallbackAppenderImage(const wLogMessage *msg)
+BOOL CallbackAppenderImage(const wLogMessage *msg)
 {
 	fprintf(stdout, "%s\n", __FUNCTION__);
+	return TRUE;
 }
 
-void CallbackAppenderPackage(const wLogMessage *msg)
+BOOL CallbackAppenderPackage(const wLogMessage *msg)
 {
 	fprintf(stdout, "%s\n", __FUNCTION__);
+	return TRUE;
 }
 
 int TestWLogCallback(int argc, char* argv[])

--- a/winpr/libwinpr/utils/wlog/Appender.c
+++ b/winpr/libwinpr/utils/wlog/Appender.c
@@ -121,7 +121,7 @@ BOOL WLog_SetLogAppenderType(wLog* log, DWORD logAppenderType)
 	return log->Appender != NULL;
 }
 
-int WLog_OpenAppender(wLog* log)
+BOOL WLog_OpenAppender(wLog* log)
 {
 	int status = 0;
 	wLogAppender* appender;
@@ -129,10 +129,10 @@ int WLog_OpenAppender(wLog* log)
 	appender = WLog_GetLogAppender(log);
 
 	if (!appender)
-		return -1;
+		return FALSE;
 
 	if (!appender->Open)
-		return 0;
+		return TRUE;
 
 	if (!appender->State)
 	{
@@ -143,7 +143,7 @@ int WLog_OpenAppender(wLog* log)
 	return status;
 }
 
-int WLog_CloseAppender(wLog* log)
+BOOL WLog_CloseAppender(wLog* log)
 {
 	int status = 0;
 	wLogAppender* appender;
@@ -151,10 +151,10 @@ int WLog_CloseAppender(wLog* log)
 	appender = WLog_GetLogAppender(log);
 
 	if (!appender)
-		return -1;
+		return FALSE;
 
 	if (!appender->Close)
-		return 0;
+		return TRUE;
 
 	if (appender->State)
 	{

--- a/winpr/libwinpr/utils/wlog/BinaryAppender.c
+++ b/winpr/libwinpr/utils/wlog/BinaryAppender.c
@@ -69,16 +69,16 @@ BOOL WLog_BinaryAppender_SetOutputFilePath(wLog* log, wLogBinaryAppender* append
 	return TRUE;
 }
 
-int WLog_BinaryAppender_Open(wLog* log, wLogBinaryAppender* appender)
+BOOL WLog_BinaryAppender_Open(wLog* log, wLogBinaryAppender* appender)
 {
 	if (!log || !appender)
-		return -1;
+		return FALSE;
 
 	if (!appender->FileName)
 	{
 		appender->FileName = (char*) malloc(MAX_PATH);
 		if (!appender->FileName)
-			return -1;
+			return FALSE;
 		sprintf_s(appender->FileName, MAX_PATH, "%u.wlog", (unsigned int) GetCurrentProcessId());
 	}
 
@@ -86,44 +86,44 @@ int WLog_BinaryAppender_Open(wLog* log, wLogBinaryAppender* appender)
 	{
 		appender->FilePath = GetKnownSubPath(KNOWN_PATH_TEMP, "wlog");
 		if (!appender->FilePath)
-			return -1;
+			return FALSE;
 	}
 
 	if (!appender->FullFileName)
 	{
 		appender->FullFileName = GetCombinedPath(appender->FilePath, appender->FileName);
 		if (!appender->FullFileName)
-			return -1;
+			return FALSE;
 	}
 
 	if (!PathFileExistsA(appender->FilePath))
 	{
 		if (!PathMakePathA(appender->FilePath, 0))
-			return -1;
+			return FALSE;
 		UnixChangeFileMode(appender->FilePath, 0xFFFF);
 	}
 
 	appender->FileDescriptor = fopen(appender->FullFileName, "a+");
 
 	if (!appender->FileDescriptor)
-		return -1;
+		return FALSE;
 
-	return 0;
+	return TRUE;
 }
 
-int WLog_BinaryAppender_Close(wLog* log, wLogBinaryAppender* appender)
+BOOL WLog_BinaryAppender_Close(wLog* log, wLogBinaryAppender* appender)
 {
 	if (!appender->FileDescriptor)
-		return 0;
+		return TRUE;
 
 	fclose(appender->FileDescriptor);
 
 	appender->FileDescriptor = NULL;
 
-	return 0;
+	return TRUE;
 }
 
-int WLog_BinaryAppender_WriteMessage(wLog* log, wLogBinaryAppender* appender, wLogMessage* message)
+BOOL WLog_BinaryAppender_WriteMessage(wLog* log, wLogBinaryAppender* appender, wLogMessage* message)
 {
 	FILE* fp;
 	wStream* s;
@@ -131,15 +131,15 @@ int WLog_BinaryAppender_WriteMessage(wLog* log, wLogBinaryAppender* appender, wL
 	int FileNameLength;
 	int FunctionNameLength;
 	int TextStringLength;
-	int ret = 1;
+	BOOL ret = TRUE;
 
 	if (!log || !appender || !message)
-		return -1;
+		return FALSE;
 
 	fp = appender->FileDescriptor;
 
 	if (!fp)
-		return -1;
+		return FALSE;
 
 	FileNameLength = strlen(message->FileName);
 	FunctionNameLength = strlen(message->FunctionName);
@@ -152,7 +152,7 @@ int WLog_BinaryAppender_WriteMessage(wLog* log, wLogBinaryAppender* appender, wL
 
 	s = Stream_New(NULL, MessageLength);
 	if (!s)
-		return -1;
+		return FALSE;
 
 	Stream_Write_UINT32(s, MessageLength);
 
@@ -173,21 +173,21 @@ int WLog_BinaryAppender_WriteMessage(wLog* log, wLogBinaryAppender* appender, wL
 	Stream_SealLength(s);
 
 	if (fwrite(Stream_Buffer(s), MessageLength, 1, fp) != 1)
-		ret = -1;
+		ret = FALSE;
 
 	Stream_Free(s, TRUE);
 
 	return ret;
 }
 
-int WLog_BinaryAppender_WriteDataMessage(wLog* log, wLogBinaryAppender* appender, wLogMessage* message)
+BOOL WLog_BinaryAppender_WriteDataMessage(wLog* log, wLogBinaryAppender* appender, wLogMessage* message)
 {
-	return 1;
+	return TRUE;
 }
 
-int WLog_BinaryAppender_WriteImageMessage(wLog* log, wLogBinaryAppender* appender, wLogMessage* message)
+BOOL WLog_BinaryAppender_WriteImageMessage(wLog* log, wLogBinaryAppender* appender, wLogMessage* message)
 {
-	return 1;
+	return TRUE;
 }
 
 wLogBinaryAppender* WLog_BinaryAppender_New(wLog* log)

--- a/winpr/libwinpr/utils/wlog/CallbackAppender.c
+++ b/winpr/libwinpr/utils/wlog/CallbackAppender.c
@@ -34,33 +34,34 @@
  * Callback Appender
  */
 
-WINPR_API void WLog_CallbackAppender_SetCallbacks(wLog* log, wLogCallbackAppender* appender,
+WINPR_API BOOL WLog_CallbackAppender_SetCallbacks(wLog* log, wLogCallbackAppender* appender,
 	CallbackAppenderMessage_t msg, CallbackAppenderImage_t img, CallbackAppenderPackage_t pkg,
 	CallbackAppenderData_t data)
 {
 	if (!appender)
-		return;
+		return FALSE;
 
 	if (appender->Type != WLOG_APPENDER_CALLBACK)
-		return;
+		return FALSE;
 
 	appender->message = msg;
 	appender->image = img;
 	appender->package = pkg;
 	appender->data = data;
+	return TRUE;
 }
 
-int WLog_CallbackAppender_Open(wLog* log, wLogCallbackAppender* appender)
+BOOL WLog_CallbackAppender_Open(wLog* log, wLogCallbackAppender* appender)
 {
-	return 0;
+	return TRUE;
 }
 
-int WLog_CallbackAppender_Close(wLog* log, wLogCallbackAppender* appender)
+BOOL WLog_CallbackAppender_Close(wLog* log, wLogCallbackAppender* appender)
 {
-	return 0;
+	return TRUE;
 }
 
-int WLog_CallbackAppender_WriteMessage(wLog* log, wLogCallbackAppender* appender, wLogMessage* message)
+BOOL WLog_CallbackAppender_WriteMessage(wLog* log, wLogCallbackAppender* appender, wLogMessage* message)
 {
 	char prefix[WLOG_MAX_PREFIX_SIZE];
 
@@ -69,56 +70,48 @@ int WLog_CallbackAppender_WriteMessage(wLog* log, wLogCallbackAppender* appender
 
 	if (appender->message)
 	{
-		appender->message(message);
+		return appender->message(message);
 	}
 	else
 	{
-		return -1;
+		return FALSE;
 	}
-
-	return 1;
 }
 
-int WLog_CallbackAppender_WriteDataMessage(wLog* log, wLogCallbackAppender* appender, wLogMessage* message)
+BOOL WLog_CallbackAppender_WriteDataMessage(wLog* log, wLogCallbackAppender* appender, wLogMessage* message)
 {
 	if (appender->data)
 	{
-		appender->data(message);
+		return appender->data(message);
 	}
 	else
 	{
-		return -1;
+		return FALSE;
 	}
-
-	return 1;
 }
 
-int WLog_CallbackAppender_WriteImageMessage(wLog* log, wLogCallbackAppender* appender, wLogMessage* message)
+BOOL WLog_CallbackAppender_WriteImageMessage(wLog* log, wLogCallbackAppender* appender, wLogMessage* message)
 {
 	if (appender->image)
 	{
-		appender->image(message);
+		return appender->image(message);
 	}
 	else
 	{
-		return -1;
+		return FALSE;
 	}
-
-	return 1;
 }
 
-int WLog_CallbackAppender_WritePacketMessage(wLog* log, wLogCallbackAppender* appender, wLogMessage* message)
+BOOL WLog_CallbackAppender_WritePacketMessage(wLog* log, wLogCallbackAppender* appender, wLogMessage* message)
 {
 	if (appender->package)
 	{
-		appender->package(message);
+		return appender->package(message);
 	}
 	else
 	{
-		return -1;
+		return FALSE;
 	}
-
-	return 1;
 }
 
 wLogCallbackAppender* WLog_CallbackAppender_New(wLog* log)

--- a/winpr/libwinpr/utils/wlog/ConsoleAppender.c
+++ b/winpr/libwinpr/utils/wlog/ConsoleAppender.c
@@ -38,13 +38,13 @@
  * Console Appender
  */
 
-void WLog_ConsoleAppender_SetOutputStream(wLog* log, wLogConsoleAppender* appender, int outputStream)
+BOOL WLog_ConsoleAppender_SetOutputStream(wLog* log, wLogConsoleAppender* appender, int outputStream)
 {
 	if (!appender)
-		return;
+		return FALSE;
 
 	if (appender->Type != WLOG_APPENDER_CONSOLE)
-		return;
+		return FALSE;
 
 	if (outputStream < 0)
 		outputStream = WLOG_CONSOLE_DEFAULT;
@@ -55,19 +55,20 @@ void WLog_ConsoleAppender_SetOutputStream(wLog* log, wLogConsoleAppender* append
 		appender->outputStream = WLOG_CONSOLE_STDERR;
 	else
 		appender->outputStream = WLOG_CONSOLE_DEFAULT;
+	return TRUE;
 }
 
-int WLog_ConsoleAppender_Open(wLog* log, wLogConsoleAppender* appender)
+BOOL WLog_ConsoleAppender_Open(wLog* log, wLogConsoleAppender* appender)
 {
-	return 0;
+	return TRUE;
 }
 
-int WLog_ConsoleAppender_Close(wLog* log, wLogConsoleAppender* appender)
+BOOL WLog_ConsoleAppender_Close(wLog* log, wLogConsoleAppender* appender)
 {
-	return 0;
+	return TRUE;
 }
 
-int WLog_ConsoleAppender_WriteMessage(wLog* log, wLogConsoleAppender* appender, wLogMessage* message)
+BOOL WLog_ConsoleAppender_WriteMessage(wLog* log, wLogConsoleAppender* appender, wLogMessage* message)
 {
 	FILE* fp;
 	char prefix[WLOG_MAX_PREFIX_SIZE];
@@ -85,7 +86,7 @@ int WLog_ConsoleAppender_WriteMessage(wLog* log, wLogConsoleAppender* appender, 
 
 		OutputDebugStringA(MessageString);
 
-		return 1;
+		return TRUE;
 	}
 #endif
 #ifdef ANDROID
@@ -149,12 +150,12 @@ int WLog_ConsoleAppender_WriteMessage(wLog* log, wLogConsoleAppender* appender, 
 	if (message->Level != WLOG_OFF)
 		fprintf(fp, "%s%s\n", message->PrefixString, message->TextString);
 #endif
-	return 1;
+	return TRUE;
 }
 
 static int g_DataId = 0;
 
-int WLog_ConsoleAppender_WriteDataMessage(wLog* log, wLogConsoleAppender* appender, wLogMessage* message)
+BOOL WLog_ConsoleAppender_WriteDataMessage(wLog* log, wLogConsoleAppender* appender, wLogMessage* message)
 {
 	int DataId;
 	char* FullFileName;
@@ -166,12 +167,12 @@ int WLog_ConsoleAppender_WriteDataMessage(wLog* log, wLogConsoleAppender* append
 
 	free(FullFileName);
 
-	return DataId;
+	return TRUE;
 }
 
 static int g_ImageId = 0;
 
-int WLog_ConsoleAppender_WriteImageMessage(wLog* log, wLogConsoleAppender* appender, wLogMessage* message)
+BOOL WLog_ConsoleAppender_WriteImageMessage(wLog* log, wLogConsoleAppender* appender, wLogMessage* message)
 {
 	int ImageId;
 	char* FullFileName;
@@ -184,12 +185,12 @@ int WLog_ConsoleAppender_WriteImageMessage(wLog* log, wLogConsoleAppender* appen
 
 	free(FullFileName);
 
-	return ImageId;
+	return TRUE;
 }
 
 static int g_PacketId = 0;
 
-int WLog_ConsoleAppender_WritePacketMessage(wLog* log, wLogConsoleAppender* appender, wLogMessage* message)
+BOOL WLog_ConsoleAppender_WritePacketMessage(wLog* log, wLogConsoleAppender* appender, wLogMessage* message)
 {
 	int PacketId;
 	char* FullFileName;
@@ -204,10 +205,10 @@ int WLog_ConsoleAppender_WritePacketMessage(wLog* log, wLogConsoleAppender* appe
 	}
 
 	if (appender->PacketMessageContext)
-		WLog_PacketMessage_Write((wPcap*) appender->PacketMessageContext,
+		return WLog_PacketMessage_Write((wPcap*) appender->PacketMessageContext,
 				message->PacketData, message->PacketLength, message->PacketFlags);
 
-	return PacketId;
+	return TRUE;
 }
 
 wLogConsoleAppender* WLog_ConsoleAppender_New(wLog* log)

--- a/winpr/libwinpr/utils/wlog/DataMessage.c
+++ b/winpr/libwinpr/utils/wlog/DataMessage.c
@@ -28,21 +28,21 @@
 #include "../../log.h"
 #define TAG WINPR_TAG("utils.wlog")
 
-int WLog_DataMessage_Write(char* filename, void* data, int length)
+BOOL WLog_DataMessage_Write(char* filename, void* data, int length)
 {
 	FILE* fp;
-	int ret = 0;
+	BOOL ret = TRUE;
 
 	fp = fopen(filename, "w+b");
 
 	if (!fp)
 	{
-		WLog_ERR(TAG, "failed to open file %s", filename);
-		return -1;
+		//WLog_ERR(TAG, "failed to open file %s", filename);
+		return FALSE;
 	}
 
 	if (fwrite(data, length, 1, fp) != 1)
-		ret = -1;
+		ret = FALSE;
 	fclose(fp);
 	return ret;
 }

--- a/winpr/libwinpr/utils/wlog/DataMessage.h
+++ b/winpr/libwinpr/utils/wlog/DataMessage.h
@@ -24,6 +24,6 @@
 
 #include "wlog/wlog.h"
 
-int WLog_DataMessage_Write(char* filename, void* data, int length);
+BOOL WLog_DataMessage_Write(char* filename, void* data, int length);
 
 #endif /* WINPR_WLOG_DATA_MESSAGE_PRIVATE_H */

--- a/winpr/libwinpr/utils/wlog/ImageMessage.c
+++ b/winpr/libwinpr/utils/wlog/ImageMessage.c
@@ -26,14 +26,14 @@
 
 #include "wlog/ImageMessage.h"
 
-int WLog_ImageMessage_Write(char* filename, void* data, int width, int height, int bpp)
+BOOL WLog_ImageMessage_Write(char* filename, void* data, int width, int height, int bpp)
 {
 	int status;
 
 	status = winpr_bitmap_write(filename, data, width, height, bpp);
 
 	if (status < 0)
-		return -1;
+		return FALSE;
 
-	return 1;
+	return TRUE;
 }

--- a/winpr/libwinpr/utils/wlog/ImageMessage.h
+++ b/winpr/libwinpr/utils/wlog/ImageMessage.h
@@ -24,6 +24,6 @@
 
 #include "wlog/wlog.h"
 
-int WLog_ImageMessage_Write(char* filename, void* data, int width, int height, int bpp);
+BOOL WLog_ImageMessage_Write(char* filename, void* data, int width, int height, int bpp);
 
 #endif /* WINPR_WLOG_IMAGE_MESSAGE_PRIVATE_H */

--- a/winpr/libwinpr/utils/wlog/Layout.c
+++ b/winpr/libwinpr/utils/wlog/Layout.c
@@ -65,7 +65,7 @@ void WLog_PrintMessagePrefix(wLog* log, wLogMessage* message, const char* format
 	va_end(args);
 }
 
-void WLog_Layout_GetMessagePrefix(wLog* log, wLogLayout* layout, wLogMessage* message)
+BOOL WLog_Layout_GetMessagePrefix(wLog* log, wLogLayout* layout, wLogMessage* message)
 {
 	char* p;
 	int index;
@@ -327,6 +327,7 @@ void WLog_Layout_GetMessagePrefix(wLog* log, wLogLayout* layout, wLogMessage* me
 					args[11], args[12], args[13], args[14], args[15]);
 			break;
 	}
+	return TRUE;
 }
 
 wLogLayout* WLog_GetLogLayout(wLog* log)

--- a/winpr/libwinpr/utils/wlog/PacketMessage.c
+++ b/winpr/libwinpr/utils/wlog/PacketMessage.c
@@ -375,7 +375,7 @@ static BOOL WLog_PacketMessage_Write_TcpHeader(wPcap* pcap, wTcpHeader* tcp)
 static UINT32 g_InboundSequenceNumber = 0;
 static UINT32 g_OutboundSequenceNumber = 0;
 
-int WLog_PacketMessage_Write(wPcap* pcap, void* data, DWORD length, DWORD flags)
+BOOL WLog_PacketMessage_Write(wPcap* pcap, void* data, DWORD length, DWORD flags)
 {
 	wTcpHeader tcp;
 	wIPv4Header ipv4;
@@ -385,7 +385,7 @@ int WLog_PacketMessage_Write(wPcap* pcap, void* data, DWORD length, DWORD flags)
 	ethernet.Type = 0x0800;
 
 	if (!pcap || !pcap->fp)
-		return -1;
+		return FALSE;
 
 	if (flags & WLOG_PACKET_OUTBOUND)
 	{
@@ -479,7 +479,7 @@ int WLog_PacketMessage_Write(wPcap* pcap, void* data, DWORD length, DWORD flags)
 		!WLog_PacketMessage_Write_IPv4Header(pcap, &ipv4) ||
 		!WLog_PacketMessage_Write_TcpHeader(pcap, &tcp) ||
 		!Pcap_Write_RecordContent(pcap, &record))
-		return -1;
+		return FALSE;
 	fflush(pcap->fp);
-	return 0;
+	return TRUE;
 }

--- a/winpr/libwinpr/utils/wlog/PacketMessage.h
+++ b/winpr/libwinpr/utils/wlog/PacketMessage.h
@@ -116,7 +116,7 @@ struct _wTcpHeader
 };
 typedef struct _wTcpHeader wTcpHeader;
 
-int WLog_PacketMessage_Write(wPcap* pcap, void* data, DWORD length, DWORD flags);
+BOOL WLog_PacketMessage_Write(wPcap* pcap, void* data, DWORD length, DWORD flags);
 
 #endif /* WINPR_WLOG_PACKET_MESSAGE_PRIVATE_H */
 

--- a/winpr/libwinpr/utils/wlog/wlog.c
+++ b/winpr/libwinpr/utils/wlog/wlog.c
@@ -63,52 +63,64 @@ const char* WLOG_LEVELS[7] =
 static DWORD g_FilterCount = 0;
 static wLogFilter* g_Filters = NULL;
 
-static void log_recursion(const char* file, const char* fkt, int line)
+static BOOL log_recursion(const char* file, const char* fkt, int line)
 {
 	size_t used, i;
 	void* bt = winpr_backtrace(20);
+	if (!bt)
+		return FALSE;
 	char** msg = winpr_backtrace_symbols(bt, &used);
+	if (!msg)
+		return FALSE;
 #if defined(ANDROID)
 	const char* tag = WINPR_TAG("utils.wlog");
-	__android_log_print(ANDROID_LOG_FATAL, tag, "Recursion detected!!!");
-	__android_log_print(ANDROID_LOG_FATAL, tag, "Check %s [%s:%d]", fkt, file, line);
+	if (__android_log_print(ANDROID_LOG_FATAL, tag, "Recursion detected!!!") < 0)
+		return FALSE;
+	if (__android_log_print(ANDROID_LOG_FATAL, tag, "Check %s [%s:%d]", fkt, file, line) < 0)
+		return FALSE;
 
 	for (i=0; i<used; i++)
-		__android_log_print(ANDROID_LOG_FATAL, tag, "%d: %s", i, msg[i]);
+		if (__android_log_print(ANDROID_LOG_FATAL, tag, "%d: %s", i, msg[i]) < 0)
+			return FALSE;
 
 #else
-	fprintf(stderr, "[%s]: Recursion detected!\n", fkt);
-	fprintf(stderr, "[%s]: Check %s:%d\n", fkt, file, line);
+	if (fprintf(stderr, "[%s]: Recursion detected!\n", fkt) < 0)
+		return FALSE;
+	if (fprintf(stderr, "[%s]: Check %s:%d\n", fkt, file, line) < 0)
+		return FALSE;
 
 	for (i=0; i<used; i++)
-		fprintf(stderr, "%s: %zd: %s\n", fkt, i, msg[i]);
+		if (fprintf(stderr, "%s: %zd: %s\n", fkt, i, msg[i]) < 0)
+			return FALSE;
 
 #endif
 
 	free(msg);
 
 	winpr_backtrace_free(bt);
+	return TRUE;
 }
 
-int WLog_Write(wLog* log, wLogMessage* message)
+BOOL WLog_Write(wLog* log, wLogMessage* message)
 {
-	int status = -1;
+	BOOL status;
 	wLogAppender* appender;
 	appender = WLog_GetLogAppender(log);
 
 	if (!appender)
-		return -1;
+		return FALSE;
 
 	if (!appender->State)
-		WLog_OpenAppender(log);
+		if (!WLog_OpenAppender(log))
+			return FALSE;
 
 	if (!appender->WriteMessage)
-		return -1;
+		return FALSE;
 
 	EnterCriticalSection(&appender->lock);
 
 	if (appender->recursive)
-		log_recursion(message->FileName, message->FunctionName, message->LineNumber);
+		status = log_recursion(message->FileName, message->FunctionName, message->LineNumber);
 	else
 	{
 		appender->recursive = TRUE;
@@ -120,25 +132,26 @@ int WLog_Write(wLog* log, wLogMessage* message)
 	return status;
 }
 
-int WLog_WriteData(wLog* log, wLogMessage* message)
+BOOL WLog_WriteData(wLog* log, wLogMessage* message)
 {
-	int status = -1;
+	BOOL status;
 	wLogAppender* appender;
 	appender = WLog_GetLogAppender(log);
 
 	if (!appender)
-		return -1;
+		return FALSE;
 
 	if (!appender->State)
-		WLog_OpenAppender(log);
+		if (!WLog_OpenAppender(log))
+			return FALSE;
 
 	if (!appender->WriteDataMessage)
-		return -1;
+		return FALSE;
 
 	EnterCriticalSection(&appender->lock);
 
 	if (appender->recursive)
-		log_recursion(message->FileName, message->FunctionName, message->LineNumber);
+		status = log_recursion(message->FileName, message->FunctionName, message->LineNumber);
 	else
 	{
 		appender->recursive = TRUE;
@@ -150,25 +163,26 @@ int WLog_WriteData(wLog* log, wLogMessage* message)
 	return status;
 }
 
-int WLog_WriteImage(wLog* log, wLogMessage* message)
+BOOL WLog_WriteImage(wLog* log, wLogMessage* message)
 {
-	int status = -1;
+	BOOL status;
 	wLogAppender* appender;
 	appender = WLog_GetLogAppender(log);
 
 	if (!appender)
-		return -1;
+		return FALSE;
 
 	if (!appender->State)
-		WLog_OpenAppender(log);
+		if (!WLog_OpenAppender(log))
+			return FALSE;
 
 	if (!appender->WriteImageMessage)
-		return -1;
+		return FALSE;
 
 	EnterCriticalSection(&appender->lock);
 
 	if (appender->recursive)
-		log_recursion(message->FileName, message->FunctionName, message->LineNumber);
+		status = log_recursion(message->FileName, message->FunctionName, message->LineNumber);
 	else
 	{
 		appender->recursive = TRUE;
@@ -180,25 +194,26 @@ int WLog_WriteImage(wLog* log, wLogMessage* message)
 	return status;
 }
 
-int WLog_WritePacket(wLog* log, wLogMessage* message)
+BOOL WLog_WritePacket(wLog* log, wLogMessage* message)
 {
-	int status = -1;
+	BOOL status;
 	wLogAppender* appender;
 	appender = WLog_GetLogAppender(log);
 
 	if (!appender)
-		return -1;
+		return FALSE;
 
 	if (!appender->State)
-		WLog_OpenAppender(log);
+		if (!WLog_OpenAppender(log))
+			return FALSE;
 
 	if (!appender->WritePacketMessage)
-		return -1;
+		return FALSE;
 
 	EnterCriticalSection(&appender->lock);
 
 	if (appender->recursive)
-		log_recursion(message->FileName, message->FunctionName, message->LineNumber);
+		status = log_recursion(message->FileName, message->FunctionName, message->LineNumber);
 	else
 	{
 		appender->recursive = TRUE;
@@ -210,9 +225,9 @@ int WLog_WritePacket(wLog* log, wLogMessage* message)
 	return status;
 }
 
-int WLog_PrintMessageVA(wLog* log, wLogMessage* message, va_list args)
+BOOL WLog_PrintMessageVA(wLog* log, wLogMessage* message, va_list args)
 {
-	int status = -1;
+	BOOL status;
 
 	if (message->Type == WLOG_MESSAGE_TEXT)
 	{
@@ -224,7 +239,8 @@ int WLog_PrintMessageVA(wLog* log, wLogMessage* message, va_list args)
 		else
 		{
 			char formattedLogMessage[WLOG_MAX_STRING_SIZE];
-			wvsnprintfx(formattedLogMessage, WLOG_MAX_STRING_SIZE - 1, message->FormatString, args);
+			if (wvsnprintfx(formattedLogMessage, WLOG_MAX_STRING_SIZE - 1, message->FormatString, args) < 0)
+				return FALSE;
 			message->TextString = formattedLogMessage;
 			status = WLog_Write(log, message);
 		}
@@ -254,13 +270,14 @@ int WLog_PrintMessageVA(wLog* log, wLogMessage* message, va_list args)
 	return status;
 }
 
-void WLog_PrintMessage(wLog* log, wLogMessage* message, ...)
+BOOL WLog_PrintMessage(wLog* log, wLogMessage* message, ...)
 {
-	int status;
+	BOOL status;
 	va_list args;
 	va_start(args, message);
 	status = WLog_PrintMessageVA(log, message, args);
 	va_end(args);
+	return status;
 }
 
 DWORD WLog_GetLogLevel(wLog* log)
@@ -275,14 +292,18 @@ DWORD WLog_GetLogLevel(wLog* log)
 	}
 }
 
-void WLog_SetLogLevel(wLog* log, DWORD logLevel)
+BOOL WLog_SetLogLevel(wLog* log, DWORD logLevel)
 {
+	if (!log)
+		return FALSE;
+
 	if ((logLevel > WLOG_OFF) && (logLevel != WLOG_LEVEL_INHERIT))
 	{
 		logLevel = WLOG_OFF;
 	}
 
 	log->Level = logLevel;
+	return TRUE;
 }
 
 int WLog_ParseLogLevel(const char* level)
@@ -310,7 +331,7 @@ int WLog_ParseLogLevel(const char* level)
 	return iLevel;
 }
 
-int WLog_ParseFilter(wLogFilter* filter, LPCSTR name)
+BOOL WLog_ParseFilter(wLogFilter* filter, LPCSTR name)
 {
 	char* p;
 	char* q;
@@ -320,7 +341,7 @@ int WLog_ParseFilter(wLogFilter* filter, LPCSTR name)
 	count = 1;
 
 	if(!name)
-		return -1;
+		return FALSE;
 
 	p = (char*) name;
 
@@ -335,14 +356,14 @@ int WLog_ParseFilter(wLogFilter* filter, LPCSTR name)
 
 	names = _strdup(name);
 	if (!names)
-		return -1;
+		return FALSE;
 	filter->NameCount = count;
 	filter->Names = (LPSTR*) calloc((count + 1UL), sizeof(LPSTR));
 	if(!filter->Names)
 	{
 		free(names);
 		filter->NameCount = 0;
-		return -1;
+		return FALSE;
 	}
 	filter->Names[count] = NULL;
 	count = 0;
@@ -356,7 +377,7 @@ int WLog_ParseFilter(wLogFilter* filter, LPCSTR name)
 		free(filter->Names);
 		filter->Names = NULL;
 		filter->NameCount = 0;
-		return -1;
+		return FALSE;
 	}
 
 	*q = '\0';
@@ -369,7 +390,7 @@ int WLog_ParseFilter(wLogFilter* filter, LPCSTR name)
 		free(filter->Names);
 		filter->Names = NULL;
 		filter->NameCount = 0;
-		return -1;
+		return FALSE;
 	}
 
 	filter->Level = (DWORD) iLevel;
@@ -382,10 +403,10 @@ int WLog_ParseFilter(wLogFilter* filter, LPCSTR name)
 		p++;
 	}
 
-	return 0;
+	return TRUE;
 }
 
-int WLog_ParseFilters()
+BOOL WLog_ParseFilters()
 {
 	char* p;
 	char* env;
@@ -397,15 +418,15 @@ int WLog_ParseFilters()
 	nSize = GetEnvironmentVariableA("WLOG_FILTER", NULL, 0);
 
 	if (nSize < 1)
-		return 0;
+		return TRUE;
 
 	env = (LPSTR) malloc(nSize);
 
 	if (!env)
-		return -1;
+		return FALSE;
 
 	if (!GetEnvironmentVariableA("WLOG_FILTER", env, nSize))
-		return -1;
+		return FALSE;
 
 	count = 1;
 	p = env;
@@ -425,7 +446,7 @@ int WLog_ParseFilters()
 	if (!strs)
 	{
 		free(env);
-		return -1;
+		return FALSE;
 	}
 
 	strs[count++] = p;
@@ -444,7 +465,7 @@ int WLog_ParseFilters()
 	{
 		free(strs);
 		free(env);
-		return -1;
+		return FALSE;
 	}
 
 	for (count = 0; count < g_FilterCount; count++)
@@ -455,14 +476,14 @@ int WLog_ParseFilters()
 		{
 			free(strs);
 			free(env);
-			return -1;
+			return FALSE;
 		}
 	}
 
 	free(strs);
 	free(env);
 
-	return 0;
+	return TRUE;
 }
 
 int WLog_GetFilterLogLevel(wLog* log)
@@ -506,7 +527,7 @@ int WLog_GetFilterLogLevel(wLog* log)
 	return iLevel;
 }
 
-int WLog_ParseName(wLog* log, LPCSTR name)
+BOOL WLog_ParseName(wLog* log, LPCSTR name)
 {
 	char* p;
 	int count;
@@ -522,13 +543,13 @@ int WLog_ParseName(wLog* log, LPCSTR name)
 
 	names = _strdup(name);
 	if (!names)
-		return -1;
+		return FALSE;
 	log->NameCount = count;
 	log->Names = (LPSTR*) calloc((count + 1UL), sizeof(LPSTR));
 	if(!log->Names)
 	{
 		free(names);
-		return -1;
+		return FALSE;
 	}
 	log->Names[count] = NULL;
 	count = 0;
@@ -543,7 +564,7 @@ int WLog_ParseName(wLog* log, LPCSTR name)
 		p++;
 	}
 
-	return 0;
+	return TRUE;
 }
 
 wLog* WLog_New(LPCSTR name, wLog* rootLogger)
@@ -562,7 +583,7 @@ wLog* WLog_New(LPCSTR name, wLog* rootLogger)
     if (!log->Name)
 		goto out_fail;
 
-    if (WLog_ParseName(log, name) != 0)
+    if (!WLog_ParseName(log, name))
 		goto out_fail;
 
     log->Parent = rootLogger;
@@ -689,7 +710,7 @@ fail:
 	return NULL;
 }
 
-int WLog_AddChild(wLog* parent, wLog* child)
+BOOL WLog_AddChild(wLog* parent, wLog* child)
 {
 	if (parent->ChildrenCount >= parent->ChildrenSize)
 	{
@@ -710,18 +731,18 @@ int WLog_AddChild(wLog* parent, wLog* child)
 				if (parent->Children)
 					free (parent->Children);
 				parent->Children = NULL;
-				return -1;
+				return FALSE;
 			}
 			parent->Children = tmp;
 		}
 	}
 
 	if (!parent->Children)
-		return -1;
+		return FALSE;
 
 	parent->Children[parent->ChildrenCount++] = child;
 	child->Parent = parent;
-	return 0;
+	return TRUE;
 }
 
 wLog* WLog_FindChild(LPCSTR name)
@@ -731,6 +752,9 @@ wLog* WLog_FindChild(LPCSTR name)
 	wLog* child = NULL;
 	BOOL found = FALSE;
 	root = WLog_GetRoot();
+
+	if (!root)
+		return NULL;
 
 	for (index = 0; index < root->ChildrenCount; index++)
 	{
@@ -756,7 +780,11 @@ wLog* WLog_Get(LPCSTR name)
 			return NULL;
 		if (!(log = WLog_New(name, root)))
 			return NULL;
-		WLog_AddChild(root, log);
+		if (!WLog_AddChild(root, log))
+		{
+			WLog_Free(log);
+			return NULL;
+		}
 	}
 	return log;
 }
@@ -766,14 +794,14 @@ BOOL WLog_Init()
 	return WLog_GetRoot() != NULL;
 }
 
-void WLog_Uninit()
+BOOL WLog_Uninit()
 {
 	DWORD index;
 	wLog* child = NULL;
 	wLog* root = g_RootLog;
 
 	if (!root)
-		return;
+		return FALSE;
 
 	for (index = 0; index < root->ChildrenCount; index++)
 	{
@@ -783,4 +811,5 @@ void WLog_Uninit()
 
 	WLog_Free(root);
 	g_RootLog = NULL;
+	return TRUE;
 }

--- a/winpr/libwinpr/utils/wlog/wlog.h
+++ b/winpr/libwinpr/utils/wlog/wlog.h
@@ -25,7 +25,7 @@
 #define WLOG_MAX_PREFIX_SIZE	512
 #define WLOG_MAX_STRING_SIZE	8192
 
-void WLog_Layout_GetMessagePrefix(wLog* log, wLogLayout* layout, wLogMessage* message);
+BOOL WLog_Layout_GetMessagePrefix(wLog* log, wLogLayout* layout, wLogMessage* message);
 
 #include "wlog/Layout.h"
 #include "wlog/Appender.h"


### PR DESCRIPTION
Wlog used to return an int but the only meaning
of the return value was:
* negative ... error
* 0 or positive ... success

but the positve returned value was 1 or some id of some
subsystem, nothing meaningful for the caller.

For a more meaningful returnvalue we now use BOOL.

If something goes wrong FALSE is returned.