### PR TITLE
cliprdr/server: Don't call CloseHandle on ChannelEvent

### DIFF
--- a/channels/cliprdr/server/cliprdr_main.c
+++ b/channels/cliprdr/server/cliprdr_main.c
@@ -1409,12 +1409,6 @@ static UINT cliprdr_server_close(CliprdrServerContext* context)
 		cliprdr->ChannelHandle = NULL;
 	}
 
-	if (cliprdr->ChannelEvent)
-	{
-		CloseHandle(cliprdr->ChannelEvent);
-		cliprdr->ChannelEvent = NULL;
-	}
-
 	return CHANNEL_RC_OK;
 }
 

--- a/channels/cliprdr/server/cliprdr_main.c
+++ b/channels/cliprdr/server/cliprdr_main.c
@@ -1566,5 +1566,6 @@ void cliprdr_server_context_free(CliprdrServerContext* context)
 		free(cliprdr->temporaryDirectory);
 	}
 
+	free(context->handle);
 	free(context);
 }


### PR DESCRIPTION
ChannelEvent is queried with WTSVirtualChannelQuery and calling CloseHandle on it will result in  crashes/exceptions.