### PR TITLE
Clamp ultra-wide glyph opRight vals to desktop width

### DIFF
--- a/libfreerdp/cache/glyph.c
+++ b/libfreerdp/cache/glyph.c
@@ -260,6 +260,12 @@ BOOL update_gdi_fast_index(rdpContext* context, FAST_INDEX_ORDER* fastIndex)
 	if (opRight == 0)
 		opRight = fastIndex->bkRight;
 
+	/* Server can send a massive number (32766) which appears to be
+	 * undocumented special behavior for "Erase all the way right".
+	 * X11 has nondeterministic results asking for a draw that wide. */
+	if (opRight > context->instance->settings->DesktopWidth)
+		opRight = context->instance->settings->DesktopWidth;
+
 	if (x == -32768)
 		x = fastIndex->bkLeft;
 
@@ -312,6 +318,10 @@ BOOL update_gdi_fast_glyph(rdpContext* context, FAST_GLYPH_ORDER* fastGlyph)
 
 	if (opRight == 0)
 		opRight = fastGlyph->bkRight;
+
+	/* See update_gdi_fast_index opRight comment. */
+	if (opRight > context->instance->settings->DesktopWidth)
+		opRight = context->instance->settings->DesktopWidth;
 
 	if (x == -32768)
 		x = fastGlyph->bkLeft;


### PR DESCRIPTION
On 2003r2, notepad (and presumably other applications) can trigger fast_index and fast_glyph operations where opRight == 0x7FFE (32766).  X11 handles the resulting request poorly.  Downstream operations seem to clamp the big request anyhow, so limiting the opRight effective width reduces glitches.

To see the issues, probably the easiest way is a windowed desktop connection to 2003r2 running notepad where one simply types.  You may observe the characters not being drawn, or having delete/backspace operations not update the screen as expected.