### PR TITLE
Increase TCP_USER_TIMEOUT to avoid disconnections.

### DIFF
--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -1027,7 +1027,7 @@ BOOL freerdp_tcp_set_keep_alive_mode(int sockfd)
 #endif
 
 #ifdef TCP_USER_TIMEOUT
-	optval = 4000;
+	optval = 60000;
 	optlen = sizeof(optval);
 
 	if (setsockopt(sockfd, SOL_TCP, TCP_USER_TIMEOUT, (void*) &optval, optlen) < 0)


### PR DESCRIPTION
TCP_USER_TIMEOUT value is too small, it is only 4 seconds. 
That causes random disconnections reported in the bug report https://github.com/FreeRDP/FreeRDP/issues/2802
This patch should fix the bug https://github.com/FreeRDP/FreeRDP/issues/2802