### PR TITLE
xfreerdp/clipr: fix self owned test and hardening

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1177,7 +1177,9 @@ BOOL xf_post_connect(freerdp* instance)
 	update->PlaySound = xf_play_sound;
 	update->SetKeyboardIndicators = xf_keyboard_set_indicators;
 
-	xfc->clipboard = xf_clipboard_new(xfc);
+	if (!(xfc->clipboard = xf_clipboard_new(xfc)))
+		return FALSE;
+
 	if (freerdp_channels_post_connect(channels, instance) < 0)
 		return FALSE;
 


### PR DESCRIPTION
- xf_cliprdr_is_self_owned() lied if multiple xfreerdp instances were running.
- fixed a few unchecked callocs
- added/modified and handled some return values in compliance with the new hardened channel api