### PR TITLE
codec/color: fix segfault in freerdp_image32_copy

### DIFF
--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -3444,8 +3444,8 @@ int freerdp_image32_copy(BYTE* pDstData, DWORD DstFormat, int nDstStep, int nXDs
 					pSrcPixel++;
 				}
 
-				pSrcPixel = (UINT32*) &((BYTE*) pSrcPixel)[nSrcStep];
-				pDstPixel = (BYTE*) &((BYTE*) pDstPixel)[nDstStep];
+				pSrcPixel = (UINT32*) &((BYTE*) pSrcPixel)[nSrcPad];
+				pDstPixel = (BYTE*) &((BYTE*) pDstPixel)[nDstPad];
 			}
 
 			return 1;


### PR DESCRIPTION
Code path for dstBytesPerPixel == 3 moved src and dst pointers beyond their respective buffers.