### PR TITLE
client/X11: multimon/fullscreen fixes

### DIFF
--- a/client/X11/xf_monitor.c
+++ b/client/X11/xf_monitor.c
@@ -120,7 +120,6 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pMaxWidth, UINT32* pMaxHeight)
 	int i;
 	int nmonitors = 0;
 	int primaryMonitorFound = FALSE;
-	int vX, vY, vWidth, vHeight;
 	VIRTUAL_SCREEN* vscreen;
 	rdpSettings* settings = xfc->settings;
 
@@ -270,10 +269,10 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pMaxWidth, UINT32* pMaxHeight)
 	if (settings->MonitorCount)
 	{
 		/* Initialize bounding rectangle for all monitors */
-		vWidth = settings->MonitorDefArray[0].width;
-		vHeight = settings->MonitorDefArray[0].height;
-		vX = settings->MonitorDefArray[0].x;
-		vY = settings->MonitorDefArray[0].y;
+		int vX = settings->MonitorDefArray[0].x;
+		int vY = settings->MonitorDefArray[0].y;
+		int vR = vX + settings->MonitorDefArray[0].width;
+		int vB = vY + settings->MonitorDefArray[0].height;
 		xfc->fullscreenMonitors.top = xfc->fullscreenMonitors.bottom =
 		xfc->fullscreenMonitors.left = xfc->fullscreenMonitors.right = settings->MonitorDefArray[0].orig_screen;
 
@@ -285,36 +284,36 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pMaxWidth, UINT32* pMaxHeight)
 			/* does the same as gdk_rectangle_union */
 			int destX = MIN(vX, settings->MonitorDefArray[i].x);
 			int destY = MIN(vY, settings->MonitorDefArray[i].y);
-			int destWidth = MAX(vX + vWidth, settings->MonitorDefArray[i].x + settings->MonitorDefArray[i].width) - destX;
-			int destHeight = MAX(vY + vHeight, settings->MonitorDefArray[i].y + settings->MonitorDefArray[i].height) - destY;
+			int destR = MAX(vR, settings->MonitorDefArray[i].x + settings->MonitorDefArray[i].width);
+			int destB = MAX(vB, settings->MonitorDefArray[i].y + settings->MonitorDefArray[i].height);
 
 			if (vX != destX)
 				xfc->fullscreenMonitors.left = settings->MonitorDefArray[i].orig_screen;
 			if (vY != destY)
 				xfc->fullscreenMonitors.top = settings->MonitorDefArray[i].orig_screen;
-			if (vWidth != destWidth)
+			if (vR != destR)
 				xfc->fullscreenMonitors.right = settings->MonitorDefArray[i].orig_screen;
-			if (vHeight != destHeight)
+			if (vB != destB)
 				xfc->fullscreenMonitors.bottom = settings->MonitorDefArray[i].orig_screen;
 
 			vX = destX;
 			vY = destY;
-			vWidth = destWidth;
-			vHeight = destHeight;
+			vR = destR;
+			vB = destB;
 		}
 
 		settings->DesktopPosX = vX;
 		settings->DesktopPosY = vY;
 
 		vscreen->area.left = 0;
-		vscreen->area.right = vWidth - 1;
+		vscreen->area.right = vR - vX - 1;
 		vscreen->area.top = 0;
-		vscreen->area.bottom = vHeight - 1;
+		vscreen->area.bottom = vB - vY - 1;
 
 		if (settings->Workarea)
 		{
 			vscreen->area.top = xfc->workArea.y;
-			vscreen->area.bottom = (vHeight - (vHeight - (xfc->workArea.height + xfc->workArea.y))) - 1;
+			vscreen->area.bottom = xfc->workArea.height + xfc->workArea.y - 1;
 		}
 
 		/* If there are multiple monitors and we have not selected a primary */

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -200,12 +200,22 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 
 	xf_ResizeDesktopWindow(xfc, window, width, height);
 
-	XMoveWindow(xfc->display, window->handle, startX, startY);
+	if (fullscreen)
+	{
+		/* enter full screen: move the window before adding NET_WM_STATE_FULLSCREEN */
+		XMoveWindow(xfc->display, window->handle, startX, startY);
+	}
 
 	/* Set the fullscreen state */
 	xf_SendClientEvent(xfc, window->handle, xfc->_NET_WM_STATE, 4,
 				fullscreen ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE,
 				xfc->_NET_WM_STATE_FULLSCREEN, 0, 0);
+
+	if (!fullscreen)
+	{
+		/* leave full screen: move the window after removing NET_WM_STATE_FULLSCREEN */
+		XMoveWindow(xfc->display, window->handle, startX, startY);
+	}
 }
 
 /* http://tronche.com/gui/x/xlib/window-information/XGetWindowProperty.html */

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -185,30 +185,27 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 		 */
 		startX = startX + xfc->instance->settings->MonitorLocalShiftX;
 		startY = startY + xfc->instance->settings->MonitorLocalShiftY;
-	}
 
-	xf_ResizeDesktopWindow(xfc, window, width, height);
-
-	/* Set the fullscreen state */
-	xf_SendClientEvent(xfc, window->handle, xfc->_NET_WM_STATE, 4,
-				fullscreen ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE,
-				xfc->_NET_WM_STATE_FULLSCREEN, 0, 0);
-
-	/* Only send monitor bounds if they are valid */
-	if ((xfc->fullscreenMonitors.top >= 0) &&
-			(xfc->fullscreenMonitors.bottom >= 0) &&
-			(xfc->fullscreenMonitors.left >= 0) &&
-			(xfc->fullscreenMonitors.right >= 0))
-	{
-		xf_SendClientEvent(xfc, window->handle, xfc->_NET_WM_FULLSCREEN_MONITORS, 5,
+		/* Set monitor bounds */
+		if (settings->MonitorCount > 1)
+		{
+			xf_SendClientEvent(xfc, window->handle, xfc->_NET_WM_FULLSCREEN_MONITORS, 5,
 				xfc->fullscreenMonitors.top,
 				xfc->fullscreenMonitors.bottom,
 				xfc->fullscreenMonitors.left,
 				xfc->fullscreenMonitors.right,
 				1);
+		}
 	}
 
+	xf_ResizeDesktopWindow(xfc, window, width, height);
+
 	XMoveWindow(xfc->display, window->handle, startX, startY);
+
+	/* Set the fullscreen state */
+	xf_SendClientEvent(xfc, window->handle, xfc->_NET_WM_STATE, 4,
+				fullscreen ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE,
+				xfc->_NET_WM_STATE_FULLSCREEN, 0, 0);
 }
 
 /* http://tronche.com/gui/x/xlib/window-information/XGetWindowProperty.html */


### PR DESCRIPTION
- fixed wrong calculation of xfc->fullscreenMonitors.[right|bottom]
- only use _NET_WM_FULLSCREEN_MONITORS if at least 2 monitors are involved
- call XMoveWindow before adding the _NET_WM_STATE_FULLSCREEN property
- call XMoveWindow after removing the _NET_WM_STATE_FULLSCREEN property