### PR TITLE
Add an UDP appender to wLog

### DIFF
--- a/winpr/include/winpr/wlog.h
+++ b/winpr/include/winpr/wlog.h
@@ -32,6 +32,7 @@ extern "C" {
 
 #include <winpr/synch.h>
 #include <winpr/thread.h>
+#include <winpr/winsock.h>
 
 typedef struct _wLog wLog;
 typedef struct _wLogMessage wLogMessage;
@@ -115,6 +116,7 @@ struct _wLogLayout
 #define WLOG_APPENDER_CALLBACK	3
 #define WLOG_APPENDER_SYSLOG	4
 #define WLOG_APPENDER_JOURNALD	5
+#define WLOG_APPENDER_UDP	6
 
 #define WLOG_PACKET_INBOUND	1
 #define WLOG_PACKET_OUTBOUND	2
@@ -212,6 +214,16 @@ struct _wLogJournaldAppender
 	FILE *stream;
 };
 typedef struct _wLogJournaldAppender wLogJournaldAppender;
+
+struct _wLogUdpAppender
+{
+	WLOG_APPENDER_COMMON();
+	char *host;
+	struct sockaddr targetAddr;
+	int	targetAddrLen;
+	SOCKET sock;
+};
+typedef struct _wLogUdpAppender wLogUdpAppender;
 
 
 /**

--- a/winpr/libwinpr/utils/CMakeLists.txt
+++ b/winpr/libwinpr/utils/CMakeLists.txt
@@ -94,6 +94,8 @@ set(${MODULE_PREFIX}_WLOG_SRCS
 	wlog/CallbackAppender.h
 	wlog/ConsoleAppender.c
 	wlog/ConsoleAppender.h
+	wlog/UdpAppender.c
+	wlog/UdpAppender.h
 	${SYSLOG_SRCS}
 	${JOURNALD_SRCS}
 	)

--- a/winpr/libwinpr/utils/wlog/Appender.c
+++ b/winpr/libwinpr/utils/wlog/Appender.c
@@ -58,6 +58,9 @@ wLogAppender* WLog_Appender_New(wLog* log, DWORD logAppenderType)
 		appender = (wLogAppender*) WLog_JournaldAppender_New(log);
 		break;
 #endif
+	case WLOG_APPENDER_UDP:
+		appender = (wLogAppender*) WLog_UdpAppender_New(log);
+		break;
 	default:
 		fprintf(stderr, "%s: unknown handler type %d\n", __FUNCTION__, logAppenderType);
 		appender = NULL;
@@ -118,6 +121,9 @@ void WLog_Appender_Free(wLog* log, wLogAppender* appender)
 		WLog_JournaldAppender_Free(log, (wLogJournaldAppender *) appender);
 		break;
 #endif
+	case WLOG_APPENDER_UDP:
+		WLog_UdpAppender_Free(log, (wLogUdpAppender *) appender);
+		break;
 	default:
 		fprintf(stderr, "%s: don't know how to free appender type %d\n", __FUNCTION__, appender->Type);
 		break;

--- a/winpr/libwinpr/utils/wlog/Appender.h
+++ b/winpr/libwinpr/utils/wlog/Appender.h
@@ -26,6 +26,7 @@
 #include "wlog/BinaryAppender.h"
 #include "wlog/ConsoleAppender.h"
 #include "wlog/CallbackAppender.h"
+#include "wlog/UdpAppender.h"
 
 #ifdef HAVE_SYSLOG_H
 #include "wlog/SyslogAppender.h"

--- a/winpr/libwinpr/utils/wlog/UdpAppender.c
+++ b/winpr/libwinpr/utils/wlog/UdpAppender.c
@@ -1,0 +1,209 @@
+/**
+ * WinPR: Windows Portable Runtime
+ * WinPR Logger
+ *
+ * Copyright © 2015 Thincast Technologies GmbH
+ * Copyright © 2015 David FORT <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+
+#include <winpr/crt.h>
+#include <winpr/environment.h>
+#include <winpr/thread.h>
+
+#include <winpr/wlog.h>
+
+#include "wlog/Message.h"
+#include "wlog/UdpAppender.h"
+
+#ifndef _WIN32
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#endif
+
+static BOOL WLog_UdpAppender_Open(wLog* log, wLogUdpAppender* appender)
+{
+	char addressString[256];
+	struct addrinfo hints;
+	struct addrinfo* result;
+	int status, addrLen;
+	char *colonPos;
+
+
+	if (!log || !appender)
+		return FALSE;
+
+	if (appender->targetAddrLen) /* already opened */
+		return TRUE;
+
+	colonPos = strchr(appender->host, ':');
+	if (!colonPos)
+		return FALSE;
+	addrLen = colonPos - appender->host;
+	memcpy(addressString, appender->host, addrLen);
+	addressString[addrLen] = '\0';
+
+	ZeroMemory(&hints, sizeof(hints));
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_DGRAM;
+
+	status = getaddrinfo(addressString, colonPos+1, &hints, &result);
+	if (status != 0)
+		return FALSE;
+
+	if (result->ai_addrlen > sizeof(appender->targetAddr))
+	{
+		freeaddrinfo(result);
+		return FALSE;
+	}
+
+	memcpy(&appender->targetAddr, result->ai_addr, result->ai_addrlen);
+	appender->targetAddrLen = result->ai_addrlen;
+
+
+	return TRUE;
+}
+
+BOOL Wlog_UdpAppender_SetTarget(wLogUdpAppender* appender, const char *host)
+{
+
+	appender->targetAddrLen = 0;
+	if (appender->host)
+		free(appender->host);
+
+	appender->host = _strdup(host);
+	return (appender->host != NULL) && WLog_UdpAppender_Open(NULL, appender);
+}
+
+static BOOL WLog_UdpAppender_Close(wLog* log, wLogUdpAppender* appender)
+{
+	if (!log || !appender)
+		return FALSE;
+
+	return TRUE;
+}
+
+static BOOL WLog_UdpAppender_WriteMessage(wLog* log, wLogUdpAppender* appender, wLogMessage* message)
+{
+	char prefix[WLOG_MAX_PREFIX_SIZE];
+
+	if (!log || !appender || !message)
+		return FALSE;
+
+	message->PrefixString = prefix;
+	WLog_Layout_GetMessagePrefix(log, appender->Layout, message);
+
+	_sendto(appender->sock, message->PrefixString, strlen(message->PrefixString),
+				0, &appender->targetAddr, appender->targetAddrLen);
+
+	_sendto(appender->sock, message->TextString, strlen(message->TextString),
+						0, &appender->targetAddr, appender->targetAddrLen);
+
+	_sendto(appender->sock, "\n", 1, 0, &appender->targetAddr, appender->targetAddrLen);
+
+	return TRUE;
+}
+
+static BOOL WLog_UdpAppender_WriteDataMessage(wLog* log, wLogUdpAppender* appender, wLogMessage* message)
+{
+	if (!log || !appender || !message)
+		return FALSE;
+
+	return TRUE;
+}
+
+static BOOL WLog_UdpAppender_WriteImageMessage(wLog* log, wLogUdpAppender* appender, wLogMessage* message)
+{
+	if (!log || !appender || !message)
+		return FALSE;
+
+
+	return TRUE;
+}
+
+wLogUdpAppender* WLog_UdpAppender_New(wLog* log)
+{
+	wLogUdpAppender* appender;
+	DWORD nSize;
+	LPCSTR name;
+
+	appender = (wLogUdpAppender*) calloc(1, sizeof(wLogUdpAppender));
+	if (!appender)
+		return NULL;
+
+	appender->Type = WLOG_APPENDER_UDP;
+
+	appender->Open = (WLOG_APPENDER_OPEN_FN) WLog_UdpAppender_Open;
+	appender->Close = (WLOG_APPENDER_OPEN_FN) WLog_UdpAppender_Close;
+	appender->WriteMessage =
+			(WLOG_APPENDER_WRITE_MESSAGE_FN) WLog_UdpAppender_WriteMessage;
+	appender->WriteDataMessage =
+			(WLOG_APPENDER_WRITE_DATA_MESSAGE_FN) WLog_UdpAppender_WriteDataMessage;
+	appender->WriteImageMessage =
+			(WLOG_APPENDER_WRITE_IMAGE_MESSAGE_FN) WLog_UdpAppender_WriteImageMessage;
+
+	appender->sock = _socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if (appender->sock == INVALID_SOCKET)
+		goto error_sock;
+
+	name = "WLOG_UDP_TARGET";
+	nSize = GetEnvironmentVariableA(name, NULL, 0);
+	if (nSize)
+	{
+		appender->host = (LPSTR) malloc(nSize);
+		if (!appender->host)
+			goto error_env_malloc;
+
+		GetEnvironmentVariableA(name, appender->host, nSize);
+
+		if (!WLog_UdpAppender_Open(log, appender))
+			goto error_open;
+	}
+	else
+	{
+		appender->host = _strdup("127.0.0.1:20000");
+		if (!appender->host)
+			goto error_env_malloc;
+	}
+
+	return appender;
+
+error_open:
+	free(appender->host);
+error_env_malloc:
+	closesocket(appender->sock);
+error_sock:
+	free(appender);
+	return NULL;
+}
+
+void WLog_UdpAppender_Free(wLog* log, wLogUdpAppender* appender)
+{
+	if (appender)
+	{
+		if (appender->sock != INVALID_SOCKET)
+		{
+			closesocket(appender->sock);
+			appender->sock = INVALID_SOCKET;
+		}
+		free(appender->host);
+		free(appender);
+	}
+}

--- a/winpr/libwinpr/utils/wlog/UdpAppender.c
+++ b/winpr/libwinpr/utils/wlog/UdpAppender.c
@@ -47,7 +47,7 @@ static BOOL WLog_UdpAppender_Open(wLog* log, wLogUdpAppender* appender)
 	char *colonPos;
 
 
-	if (!log || !appender)
+	if (!appender)
 		return FALSE;
 
 	if (appender->targetAddrLen) /* already opened */
@@ -169,7 +169,7 @@ wLogUdpAppender* WLog_UdpAppender_New(wLog* log)
 	{
 		appender->host = (LPSTR) malloc(nSize);
 		if (!appender->host)
-			goto error_env_malloc;
+			goto error_host_alloc;
 
 		GetEnvironmentVariableA(name, appender->host, nSize);
 
@@ -180,14 +180,14 @@ wLogUdpAppender* WLog_UdpAppender_New(wLog* log)
 	{
 		appender->host = _strdup("127.0.0.1:20000");
 		if (!appender->host)
-			goto error_env_malloc;
+			goto error_host_alloc;
 	}
 
 	return appender;
 
 error_open:
 	free(appender->host);
-error_env_malloc:
+error_host_alloc:
 	closesocket(appender->sock);
 error_sock:
 	free(appender);

--- a/winpr/libwinpr/utils/wlog/UdpAppender.h
+++ b/winpr/libwinpr/utils/wlog/UdpAppender.h
@@ -1,0 +1,35 @@
+/**
+ * Copyright © 2015 Thincast Technologies GmbH
+ * Copyright © 2015 David FORT <contact@hardening-consulting.com>
+ *
+ * Permission to use, copy, modify, distribute, and sell this software and
+ * its documentation for any purpose is hereby granted without fee, provided
+ * that the above copyright notice appear in all copies and that both that
+ * copyright notice and this permission notice appear in supporting
+ * documentation, and that the name of the copyright holders not be used in
+ * advertising or publicity pertaining to distribution of the software
+ * without specific, written prior permission.  The copyright holders make
+ * no representations about the suitability of this software for any
+ * purpose.  It is provided "as is" without express or implied warranty.
+ *
+ * THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+ * SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef WINPR_LIBWINPR_UTILS_WLOG_UDPAPPENDER_H_
+#define WINPR_LIBWINPR_UTILS_WLOG_UDPAPPENDER_H_
+
+#include <winpr/wlog.h>
+
+#include "wlog/wlog.h"
+
+WINPR_API wLogUdpAppender* WLog_UdpAppender_New(wLog* log);
+WINPR_API void WLog_UdpAppender_Free(wLog* log, wLogUdpAppender* appender);
+WINPR_API BOOL Wlog_UdpAppender_SetTarget(wLogUdpAppender* appender, const char *host);
+
+#endif /* WINPR_LIBWINPR_UTILS_WLOG_UDPAPPENDER_H_ */

--- a/winpr/libwinpr/utils/wlog/wlog.c
+++ b/winpr/libwinpr/utils/wlog/wlog.c
@@ -706,6 +706,8 @@ wLog* WLog_GetRoot()
 			else if (_stricmp(env, "JOURNALD") == 0)
 				logAppenderType = WLOG_APPENDER_JOURNALD;
 #endif
+			else if (_stricmp(env, "UDP") == 0)
+				logAppenderType = WLOG_APPENDER_UDP;
 
 			free(env);
 		}


### PR DESCRIPTION
This appender allows to receive the logs over a network connection using UDP packets.
You can see the logs using a listening netcat, for example: nc -ul 127.0.0.1 20000.