### PR TITLE
cliprdr/server: Fix parsing of file contents request PDU

### DIFF
--- a/channels/cliprdr/server/cliprdr_main.c
+++ b/channels/cliprdr/server/cliprdr_main.c
@@ -955,7 +955,7 @@ static UINT cliprdr_server_receive_filecontents_request(CliprdrServerContext* co
 	request.msgFlags = header->msgFlags;
 	request.dataLen = header->dataLen;
 
-	if (Stream_GetRemainingLength(s) < 28)
+	if (Stream_GetRemainingLength(s) < 24)
 	{
 		WLog_ERR(TAG, "not enought data in stream!");
 		return ERROR_INVALID_DATA;
@@ -967,7 +967,10 @@ static UINT cliprdr_server_receive_filecontents_request(CliprdrServerContext* co
 	Stream_Read_UINT32(s, request.nPositionLow); /* nPositionLow (4 bytes) */
 	Stream_Read_UINT32(s, request.nPositionHigh); /* nPositionHigh (4 bytes) */
 	Stream_Read_UINT32(s, request.cbRequested); /* cbRequested (4 bytes) */
-	Stream_Read_UINT32(s, request.clipDataId); /* clipDataId (4 bytes) */
+	if (Stream_GetRemainingLength(s) < 4) /* clipDataId (4 bytes) optional */
+		request.clipDataId = 0;
+	else
+		Stream_Read_UINT32(s, request.clipDataId);
 
 	IFCALLRET(context->ClientFileContentsRequest, error, context, &request);
 	if (error)

--- a/channels/cliprdr/server/cliprdr_main.c
+++ b/channels/cliprdr/server/cliprdr_main.c
@@ -470,7 +470,7 @@ static UINT cliprdr_server_file_contents_response(CliprdrServerContext* context,
 	if (fileContentsResponse->dwFlags & FILECONTENTS_SIZE)
 		fileContentsResponse->cbRequested = sizeof(UINT64);
 
-	s = cliprdr_server_packet_new(CB_FILECONTENTS_REQUEST, 0,
+	s = cliprdr_server_packet_new(CB_FILECONTENTS_RESPONSE, 0,
 			4 + fileContentsResponse->cbRequested);
 
 	if (!s)

--- a/channels/cliprdr/server/cliprdr_main.c
+++ b/channels/cliprdr/server/cliprdr_main.c
@@ -470,7 +470,7 @@ static UINT cliprdr_server_file_contents_response(CliprdrServerContext* context,
 	if (fileContentsResponse->dwFlags & FILECONTENTS_SIZE)
 		fileContentsResponse->cbRequested = sizeof(UINT64);
 
-	s = cliprdr_server_packet_new(CB_FILECONTENTS_RESPONSE, 0,
+	s = cliprdr_server_packet_new(CB_FILECONTENTS_RESPONSE, fileContentsResponse->msgFlags,
 			4 + fileContentsResponse->cbRequested);
 
 	if (!s)


### PR DESCRIPTION
According to https://msdn.microsoft.com/en-us/library/cc241127.aspx the clipDataId field is optional and might be missing in a File Contents Request PDU.