### PR TITLE
Fixes #2982. The idea is to be able to create the socket externally a…

### DIFF
--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -1047,6 +1047,7 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings,
 	UINT32 optval;
 	socklen_t optlen;
 	BOOL ipcSocket = FALSE;
+	BOOL useExternalDefinedSocket = FALSE;
 
 	if (!hostname)
 		return -1;
@@ -1054,12 +1055,18 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings,
 	if (hostname[0] == '/')
 		ipcSocket = TRUE;
 
+	if (hostname[0] == '|')
+		useExternalDefinedSocket = TRUE;
+
 	if (ipcSocket)
 	{
 		sockfd = freerdp_uds_connect(hostname);
 
 		if (sockfd < 0)
 			return -1;
+	} else if (useExternalDefinedSocket)
+	{
+	  sockfd = port;
 	}
 	else
 	{

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -1150,7 +1150,8 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings,
 	settings->ClientAddress = freerdp_tcp_get_ip_address(sockfd);
 	if (!settings->ClientAddress)
 	{
-		close(sockfd);
+	        if (!useExternalDefinedSocket)
+		  close(sockfd);
 		WLog_ERR(TAG, "Couldn't get socket ip address");
 		return -1;
 	}
@@ -1158,7 +1159,7 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings,
 	optval = 1;
 	optlen = sizeof(optval);
 
-	if (!ipcSocket)
+	if (!ipcSocket && !useExternalDefinedSocket)
 	{
 		if (setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (void*) &optval, optlen) < 0)
 			WLog_ERR(TAG, "unable to set TCP_NODELAY");
@@ -1181,7 +1182,7 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings,
 		}
 	}
 
-	if (!ipcSocket)
+	if (!ipcSocket && !useExternalDefinedSocket)
 	{
 		if (!freerdp_tcp_set_keep_alive_mode(sockfd))
 		{

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -1064,10 +1064,9 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings,
 
 		if (sockfd < 0)
 			return -1;
-	} else if (useExternalDefinedSocket)
-	{
-	  sockfd = port;
 	}
+        else if (useExternalDefinedSocket)
+	  sockfd = port;
 	else
 	{
 		sockfd = -1;


### PR DESCRIPTION
…nd pass that socket FD to FreeRDP so that it can be used there.

The idea suggested is to use the following interface:

settings->ServerHostname = "|"
settings->ServerPort = SocketFD