### PR TITLE
Fix compilation error under Visual Studio 2010

### DIFF
--- a/winpr/libwinpr/utils/wlog/ConsoleAppender.c
+++ b/winpr/libwinpr/utils/wlog/ConsoleAppender.c
@@ -55,10 +55,11 @@ static BOOL WLog_ConsoleAppender_WriteMessage(wLog* log, wLogAppender* appender,
 {
 	FILE* fp;
 	char prefix[WLOG_MAX_PREFIX_SIZE];
+	wLogConsoleAppender *consoleAppender;
 	if (!appender)
 		return FALSE;
 
-	wLogConsoleAppender *consoleAppender = (wLogConsoleAppender *)appender;
+	consoleAppender = (wLogConsoleAppender *)appender;
 
 
 	message->PrefixString = prefix;


### PR DESCRIPTION
Visual Studio 2010 use a compiler that supports only C89, which
only supports declaring variable at top of a local scope. Moving
scope variable to the top of function should solve this problem.