### PR TITLE
tcp: change TCP_USER_TIMEOUT to 16000

### DIFF
--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -1027,7 +1027,7 @@ BOOL freerdp_tcp_set_keep_alive_mode(int sockfd)
 #endif
 
 #ifdef TCP_USER_TIMEOUT
-	optval = 4000;
+	optval = 60000;
 	optlen = sizeof(optval);
 
 	if (setsockopt(sockfd, SOL_TCP, TCP_USER_TIMEOUT, (void*) &optval, optlen) < 0)

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -1027,7 +1027,7 @@ BOOL freerdp_tcp_set_keep_alive_mode(int sockfd)
 #endif
 
 #ifdef TCP_USER_TIMEOUT
-	optval = 60000;
+	optval = 9000;
 	optlen = sizeof(optval);
 
 	if (setsockopt(sockfd, SOL_TCP, TCP_USER_TIMEOUT, (void*) &optval, optlen) < 0)


### PR DESCRIPTION
The initially chosen value of 4 seconds was reported to be
to low for some networks. Therefore 16 seconds was chosen. This should be
short enough to detect broken connections but still long enough to avoid
disconnect because of flaky networks.

For details see issue #2936