### PR TITLE
Fix wlog.h includes

### DIFF
--- a/winpr/include/winpr/wlog.h
+++ b/winpr/include/winpr/wlog.h
@@ -27,6 +27,7 @@
 extern "C" {
 #endif
 
+#include <stdarg.h>
 #include <winpr/wtypes.h>
 #include <winpr/synch.h>
 #include <winpr/thread.h>


### PR DESCRIPTION
Due to missing ```stdarg.h``` ```wlog.h``` can not be included.