### PR TITLE
Allow autonegotiation of tls/ssl version for tls 1.2 compatibilty

### DIFF
--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -798,7 +798,7 @@ int tls_connect(rdpTls* tls, BIO* underlying)
 	 */
 	options |= SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
 
-	if (!tls_prepare(tls, underlying, TLSv1_client_method(), options, TRUE))
+	if (!tls_prepare(tls, underlying, SSLv23_client_method(), options, TRUE))
 		return FALSE;
 
 	return tls_do_handshake(tls, TRUE);


### PR DESCRIPTION
This is the fix referenced in the discussion of issue #2828. I have not tested it outside my own environment, but it works great for me and is reported to be working well by other users in that issue thread.