### PR TITLE
tls: enable tls 1+

### DIFF
--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -798,7 +798,13 @@ int tls_connect(rdpTls* tls, BIO* underlying)
 	 */
 	options |= SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
 
-	if (!tls_prepare(tls, underlying, TLSv1_client_method(), options, TRUE))
+	/**
+	 * disable SSLv2 and SSLv3
+	 */
+	options |= SSL_OP_NO_SSLv2;
+	options |= SSL_OP_NO_SSLv3;
+
+	if (!tls_prepare(tls, underlying, SSLv23_client_method(), options, TRUE))
 		return FALSE;
 
 	return tls_do_handshake(tls, TRUE);


### PR DESCRIPTION
Currently TLS version 1.0 is used implicitly by using the TLSv1_method.
To be able to also use TLS 1.1 and later use SSLv23_client_method
instead. To make sure SSLv2 or SSLv3 isn't used disable them.

Based on PR #3036