### PR TITLE
Fix memory leak in lodepng_zlib_compress

### DIFF
--- a/winpr/libwinpr/utils/lodepng/lodepng.c
+++ b/winpr/libwinpr/utils/lodepng/lodepng.c
@@ -2208,6 +2208,12 @@ unsigned lodepng_zlib_compress(unsigned char** out, size_t* outsize, const unsig
     *out = outv.data;
     *outsize = outv.size;
   }
+  else
+  {
+    *out = NULL;
+    *outsize = 0;
+    ucvector_cleanup(&outv);
+  }
 
   return error;
 }


### PR DESCRIPTION
The memory in ```outv``` is reallocated and therefore the pointer in ```out``` is no longer valid.
Clean up the reallocated code and update the ```*out``` and ```*outsize``` values.