### PR TITLE
build: fix a problem with cmake version 2.8.11

### DIFF
--- a/channels/CMakeLists.txt
+++ b/channels/CMakeLists.txt
@@ -155,9 +155,7 @@ macro(add_channel_client_subsystem _channel_prefix _channel_name _subsystem _typ
 endmacro(add_channel_client_subsystem)
 
 macro(channel_install _targets _destination _export_target)
-	if (NOT STATIC_CHANNELS OR ${CMAKE_VERSION} VERSION_LESS 2.8.12)
 		install(TARGETS ${_targets} DESTINATION ${_destination} EXPORT ${_export_target})
-	endif()
 endmacro(channel_install)
 
 macro(server_channel_install _targets _destination)
@@ -195,6 +193,9 @@ macro(add_channel_client_library _module_prefix _module_name _channel_name _dyna
 		set(${_module_prefix}_CHANNEL ${_channel_name} PARENT_SCOPE)
 		set(${_module_prefix}_ENTRY ${_entry} PARENT_SCOPE)
 		add_library(${_module_name} STATIC ${${_module_prefix}_SRCS})
+		if (${CMAKE_VERSION} VERSION_LESS 2.8.12)
+			client_channel_install(${_module_name}  ${FREERDP_ADDIN_PATH})
+		endif()
 	endif()
 endmacro(add_channel_client_library)
 
@@ -224,6 +225,9 @@ macro(add_channel_client_subsystem_library _module_prefix _module_name _channel_
 		set(${_module_prefix}_NAME ${_module_name} PARENT_SCOPE)
 		set(${_module_prefix}_TYPE ${_type} PARENT_SCOPE)
 		add_library(${_module_name} STATIC ${${_module_prefix}_SRCS})
+		if (${CMAKE_VERSION} VERSION_LESS 2.8.12)
+			client_channel_install(${_module_name}  ${FREERDP_ADDIN_PATH})
+		endif()
 	endif()
 endmacro(add_channel_client_subsystem_library)
 
@@ -253,6 +257,9 @@ macro(add_channel_server_library _module_prefix _module_name _channel_name _dyna
 		set(${_module_prefix}_CHANNEL ${_channel_name} PARENT_SCOPE)
 		set(${_module_prefix}_ENTRY ${_entry} PARENT_SCOPE)
 		add_library(${_module_name} STATIC ${${_module_prefix}_SRCS})
+		if (${CMAKE_VERSION} VERSION_LESS 2.8.12)
+			server_channel_install(${_module_name}  ${FREERDP_ADDIN_PATH})
+		endif()
 	endif()
 endmacro(add_channel_server_library)
 


### PR DESCRIPTION
Starting with cmake 2.8.10 FreeRDP exports a cmake find module. With 2.8.12
the PRIVATE/PUBLIC keywords were introduced in cmake. When building with
2.8.11 it is not possible to mark link dependencies as private and
therefore they need to be exported.