### PR TITLE
Fixed SRCCOPY, using memmove now.

### DIFF
--- a/libfreerdp/gdi/16bpp.c
+++ b/libfreerdp/gdi/16bpp.c
@@ -160,7 +160,7 @@ static BOOL BitBlt_SRCCOPY_16bpp(HGDI_DC hdcDest, int nXDest, int nYDest, int nW
 			dstp = gdi_get_bitmap_pointer(hdcDest, nXDest, nYDest + y);
 
 			if (srcp != 0 && dstp != 0)
-				memcpy(dstp, srcp, nWidth * hdcDest->bytesPerPixel);
+				memmove(dstp, srcp, nWidth * hdcDest->bytesPerPixel);
 		}
 
 		return TRUE;

--- a/libfreerdp/gdi/8bpp.c
+++ b/libfreerdp/gdi/8bpp.c
@@ -105,7 +105,7 @@ static BOOL BitBlt_SRCCOPY_8bpp(HGDI_DC hdcDest, int nXDest, int nYDest, int nWi
 			dstp = gdi_get_bitmap_pointer(hdcDest, nXDest, nYDest + y);
 
 			if (srcp != 0 && dstp != 0)
-				memcpy(dstp, srcp, nWidth * hdcDest->bytesPerPixel);
+				memmove(dstp, srcp, nWidth * hdcDest->bytesPerPixel);
 		}
 
 		return TRUE;

--- a/libfreerdp/gdi/region.c
+++ b/libfreerdp/gdi/region.c
@@ -234,8 +234,8 @@ INLINE BOOL gdi_CopyOverlap(int x, int y, int width, int height, int srcx, int s
 	gdi_CRgnToRect(x, y, width, height, &dst);
 	gdi_CRgnToRect(srcx, srcy, width, height, &src);
 
-	return (dst.right > src.left && dst.left < src.right &&
-		dst.bottom > src.top && dst.top < src.bottom) ? TRUE : FALSE;
+	return (dst.right >= src.left && dst.left <= src.right &&
+		dst.bottom >= src.top && dst.top <= src.bottom) ? TRUE : FALSE;
 }
 
 /**


### PR DESCRIPTION
memcpy is not defined, if source and destination overlap.

Thx @giox069 for pointing that out.