### PR TITLE
Resetting abort event on freerdp_connect.

### DIFF
--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -71,6 +71,7 @@ BOOL freerdp_connect(freerdp* instance)
 	connectErrorCode = 0;
 	freerdp_set_last_error(instance->context, FREERDP_ERROR_SUCCESS);
 	clearChannelError(instance->context);
+	ResetEvent(instance->context->abortEvent);
 
 	rdp = instance->context->rdp;
 	settings = instance->settings;


### PR DESCRIPTION
the ```abort``` event may be set by ```freerdp_abort_connect``` from a different thread after ```freerdp_disconnect```.
In that case the next call to ```freerdp_connect``` will not reset the event and ```freerdp_shall_disconnect``` will return true.

With this patch the event is reset on connect avoiding improper connection abort.