### PR TITLE
Allow to specify the raw content of crypto materials

### DIFF
--- a/include/freerdp/crypto/tls.h
+++ b/include/freerdp/crypto/tls.h
@@ -89,7 +89,7 @@ struct rdp_tls
 #endif
 
 FREERDP_API int tls_connect(rdpTls* tls, BIO *underlying);
-FREERDP_API BOOL tls_accept(rdpTls* tls, BIO *underlying, const char* cert_file, const char* privatekey_file);
+FREERDP_API BOOL tls_accept(rdpTls* tls, BIO *underlying, rdpSettings *settings);
 FREERDP_API BOOL tls_send_alert(rdpTls* tls);
 
 FREERDP_API int tls_write_all(rdpTls* tls, const BYTE* data, int length);

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -655,6 +655,10 @@ typedef struct _RDPDR_PARALLEL RDPDR_PARALLEL;
 #define FreeRDP_RdpServerRsaKey					1413
 #define FreeRDP_RdpServerCertificate				1414
 #define FreeRDP_ExternalCertificateManagement			1415
+#define FreeRDP_CertificateContent 1416
+#define FreeRDP_PrivateKeyContent	1417
+#define FreeRDP_RdpKeyContent		1418
+
 #define FreeRDP_Workarea					1536
 #define FreeRDP_Fullscreen					1537
 #define FreeRDP_PercentScreen					1538
@@ -1071,7 +1075,10 @@ struct rdp_settings
 	ALIGN64 rdpRsaKey* RdpServerRsaKey; /* 1413 */
 	ALIGN64 rdpCertificate* RdpServerCertificate; /* 1414 */
 	ALIGN64 BOOL ExternalCertificateManagement; /* 1415 */
-	UINT64 padding1472[1472 - 1416]; /* 1416 */
+	ALIGN64 char *CertificateContent; /* 1416 */
+	ALIGN64 char *PrivateKeyContent; /* 1417 */
+	ALIGN64 char* RdpKeyContent; /* 1418 */
+	UINT64 padding1472[1472 - 1419]; /* 1419 */
 	UINT64 padding1536[1536 - 1472]; /* 1472 */
 
 	/**

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -2381,6 +2381,15 @@ char* freerdp_get_param_string(rdpSettings* settings, int id)
 		case FreeRDP_RdpKeyFile:
 			return settings->RdpKeyFile;
 
+		case FreeRDP_CertificateContent:
+			return settings->CertificateContent;
+
+		case FreeRDP_PrivateKeyContent:
+			return settings->PrivateKeyContent;
+
+		case FreeRDP_RdpKeyContent:
+			return settings->RdpKeyContent;
+
 		case FreeRDP_WindowTitle:
 			return settings->WindowTitle;
 
@@ -2549,6 +2558,18 @@ int freerdp_set_param_string(rdpSettings* settings, int id, const char* param)
 
 		case FreeRDP_PrivateKeyFile:
 			tmp = &settings->PrivateKeyFile;
+			break;
+
+		case FreeRDP_CertificateContent:
+			tmp = &settings->CertificateContent;
+			break;
+
+		case FreeRDP_PrivateKeyContent:
+			tmp = &settings->PrivateKeyContent;
+			break;
+
+		case FreeRDP_RdpKeyContent:
+			tmp = &settings->RdpKeyContent;
 			break;
 
 		case FreeRDP_RdpKeyFile:

--- a/libfreerdp/core/certificate.h
+++ b/libfreerdp/core/certificate.h
@@ -59,6 +59,7 @@ rdpCertificate* certificate_new(void);
 void certificate_free(rdpCertificate* certificate);
 
 rdpRsaKey* key_new(const char *keyfile);
+rdpRsaKey* key_new_from_content(const char *keycontent, const char *keyfile);
 void key_free(rdpRsaKey* key);
 
 #define CERTIFICATE_TAG FREERDP_TAG("core.certificate")

--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -1086,7 +1086,7 @@ BOOL nego_send_negotiation_response(rdpNego* nego)
 				settings->EncryptionLevel = ENCRYPTION_LEVEL_NONE;
 			}
 
-			if (!settings->RdpServerRsaKey && !settings->RdpKeyFile)
+			if (!settings->RdpServerRsaKey && !settings->RdpKeyFile && !settings->RdpKeyContent)
 			{
 				WLog_ERR(TAG, "Missing server certificate");
 				return FALSE;

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -219,10 +219,18 @@ static BOOL freerdp_peer_initialize(freerdp_peer* client)
 	if (settings->RdpKeyFile)
 	{
 		settings->RdpServerRsaKey = key_new(settings->RdpKeyFile);
-
 		if (!settings->RdpServerRsaKey)
 		{
 			WLog_ERR(TAG, "invalid RDP key file %s", settings->RdpKeyFile);
+			return FALSE;
+		}
+	}
+	else if (settings->RdpKeyContent)
+	{
+		settings->RdpServerRsaKey = key_new_from_content(settings->RdpKeyContent, NULL);
+		if (!settings->RdpServerRsaKey)
+		{
+			WLog_ERR(TAG, "invalid RDP key content");
 			return FALSE;
 		}
 	}

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -597,6 +597,9 @@ rdpSettings* freerdp_settings_clone(rdpSettings* settings)
 		CHECKED_STRDUP(CertificateFile); /* 1410 */
 		CHECKED_STRDUP(PrivateKeyFile); /* 1411 */
 		CHECKED_STRDUP(RdpKeyFile); /* 1412 */
+		CHECKED_STRDUP(CertificateContent); /* 1416 */
+		CHECKED_STRDUP(PrivateKeyContent); /* 1417 */
+		CHECKED_STRDUP(RdpKeyContent); /* 1418 */
 		CHECKED_STRDUP(WindowTitle); /* 1542 */
 		CHECKED_STRDUP(WmClass); /* 1549 */
 		CHECKED_STRDUP(ComputerName); /* 1664 */
@@ -924,6 +927,9 @@ void freerdp_settings_free(rdpSettings* settings)
     free(settings->ServerCertificate);
     free(settings->RdpKeyFile);
     certificate_free(settings->RdpServerCertificate);
+    free(settings->CertificateContent);
+    free(settings->PrivateKeyContent);
+    free(settings->RdpKeyContent);
     free(settings->ClientAutoReconnectCookie);
     free(settings->ServerAutoReconnectCookie);
     free(settings->ClientTimeZone);

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -322,7 +322,7 @@ BOOL transport_accept_tls(rdpTransport* transport)
 
 	transport->layer = TRANSPORT_LAYER_TLS;
 
-	if (!tls_accept(transport->tls, transport->frontBio, settings->CertificateFile, settings->PrivateKeyFile))
+	if (!tls_accept(transport->tls, transport->frontBio, settings))
 		return FALSE;
 
 	transport->frontBio = transport->tls->bio;
@@ -340,7 +340,7 @@ BOOL transport_accept_nla(rdpTransport* transport)
 
 	transport->layer = TRANSPORT_LAYER_TLS;
 
-	if (!tls_accept(transport->tls, transport->frontBio, settings->CertificateFile, settings->PrivateKeyFile))
+	if (!tls_accept(transport->tls, transport->frontBio, settings))
 		return FALSE;
 
 	transport->frontBio = transport->tls->bio;


### PR DESCRIPTION
Sometime it's possible that your server application doesn't have access to files
(when running in a very restricted environment for example). This patch allows
to ship the private key and certificate as a string.

Sponsored by: Wheel Systems (http://www.wheelsystems.com)