### PR TITLE
Removed fixed size strings.

### DIFF
--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -200,12 +200,13 @@ BOOL rdg_send_tunnel_authorization(rdpRdg* rdg)
 	BOOL status;
 	WCHAR* clientName = NULL;
 	UINT16 clientNameLen;
-	UINT32 packetSize = 12 + clientNameLen * 2;
+	UINT32 packetSize;
 
 	clientNameLen = ConvertToUnicode(CP_UTF8, 0, rdg->settings->ClientHostname, -1, &clientName, 0);
 	if (!clientName)
 		return FALSE;
 
+	packetSize = 12 + clientNameLen * 2 + sizeof(WCHAR);
 	s = Stream_New(NULL, packetSize);
 
 	if (!s)

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -198,14 +198,21 @@ BOOL rdg_send_tunnel_authorization(rdpRdg* rdg)
 	int i;
 	wStream* s;
 	BOOL status;
-	char* clientName = rdg->settings->ClientHostname;
-	UINT16 clientNameLen = strlen(clientName) + 1;
+	WCHAR* clientName = NULL;
+	UINT16 clientNameLen;
 	UINT32 packetSize = 12 + clientNameLen * 2;
+
+	clientNameLen = ConvertToUnicode(CP_UTF8, 0, rdg->settings->ClientHostname, -1, &clientName, 0);
+	if (!clientName)
+		return FALSE;
 
 	s = Stream_New(NULL, packetSize);
 
 	if (!s)
+	{
+		free(clientName);
 		return FALSE;
+	}
 
 	Stream_Write_UINT16(s, PKT_TYPE_TUNNEL_AUTH); /* Type (2 bytes) */
 	Stream_Write_UINT16(s, 0); /* Reserved (2 bytes) */
@@ -215,15 +222,16 @@ BOOL rdg_send_tunnel_authorization(rdpRdg* rdg)
 	Stream_Write_UINT16(s, clientNameLen * 2); /* Client name string length */
 
 	for (i = 0; i < clientNameLen; i++)
-	{
 		Stream_Write_UINT16(s, clientName[i]);
-	}
+
+	Stream_Write_UINT16(s, 0);
 
 	Stream_SealLength(s);
 
 	status = rdg_write_packet(rdg, s);
 
 	Stream_Free(s, TRUE);
+	free(clientName);
 
 	if (status)
 	{

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -591,8 +591,8 @@ BOOL gcc_read_client_core_data(wStream* s, rdpMcs* mcs, UINT16 blockLength)
 	/* clientName (32 bytes, null-terminated unicode, truncated to 15 characters) */
 	ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) Stream_Pointer(s), 32 / 2, &str, 0, NULL, NULL);
 	Stream_Seek(s, 32);
-	sprintf_s(settings->ClientHostname, 31, "%s", str);
-	settings->ClientHostname[31] = 0;
+	free(settings->ClientHostname);
+	settings->ClientHostname = str;
 	free(str);
 	str = NULL;
 
@@ -649,8 +649,8 @@ BOOL gcc_read_client_core_data(wStream* s, rdpMcs* mcs, UINT16 blockLength)
 
 		ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) Stream_Pointer(s), 64 / 2, &str, 0, NULL, NULL);
 		Stream_Seek(s, 64); /* clientDigProductId (64 bytes) */
-		sprintf_s(settings->ClientProductId, 32, "%s", str);
-		free(str);
+		free(settings->ClientProductId);
+		settings->ClientProductId = str;
 		blockLength -= 64;
 
 		if (blockLength < 1)

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -728,14 +728,12 @@ rdpSettings* freerdp_settings_clone(rdpSettings* settings)
 		CopyMemory(_settings->ReceivedCapabilities, settings->ReceivedCapabilities, 32);
 		CopyMemory(_settings->OrderSupport, settings->OrderSupport, 32);
 
-		_settings->ClientHostname = malloc(32);
+		_settings->ClientHostname = _strdup(settings->ClientHostname);
 		if (!_settings->ClientHostname)
 			goto out_fail;
-		_settings->ClientProductId = malloc(32);
+		_settings->ClientProductId = _strdup(settings->ClientProductId);
 		if (!_settings->ClientProductId)
 			goto out_fail;
-		CopyMemory(_settings->ClientHostname, settings->ClientHostname, 32);
-		CopyMemory(_settings->ClientProductId, settings->ClientProductId, 32);
 
 		_settings->BitmapCacheV2CellInfo = (BITMAP_CACHE_V2_CELL_INFO*) malloc(sizeof(BITMAP_CACHE_V2_CELL_INFO) * 6);
 		if (!_settings->BitmapCacheV2CellInfo)


### PR DESCRIPTION
* Removes 32 byte fixed size restriction for ```ClientHostname``` and ```ClientProductId``` in settings. (still enforced where required)
* ```ClientHostname``` now converted to proper encoding before being sent. @hardening Was there any specific reason for this ```char*``` to ```WCHAR*``` hack? Should have failed on most encodings.