### PR TITLE
Fixed argument checks for drive channel.

### DIFF
--- a/channels/rdpdr/client/devman.c
+++ b/channels/rdpdr/client/devman.c
@@ -6,6 +6,7 @@
  * Copyright 2010-2012 Marc-Andre Moreau <marcandre.moreau@gmail.com>
  * Copyright 2015 Thincast Technologies GmbH
  * Copyright 2015 DI (FH) Martin Haimberger <martin.haimberger@thincast.com>
+ * Copyright 2016 Armin Novak <armin.novak@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,12 +43,18 @@
 
 void devman_device_free(DEVICE* device)
 {
+	if (!device)
+		return;
+
 	IFCALL(device->Free, device);
 }
 
 DEVMAN* devman_new(rdpdrPlugin* rdpdr)
 {
 	DEVMAN* devman;
+
+	if (!rdpdr)
+		return NULL;
 
 	devman = (DEVMAN*) calloc(1, sizeof(DEVMAN));
 
@@ -84,6 +91,9 @@ void devman_unregister_device(DEVMAN* devman, void* key)
 {
 	DEVICE* device;
 
+	if (!devman || !key)
+		return;
+
 	device = (DEVICE*) ListDictionary_Remove(devman->devices, key);
 
 	if (device)
@@ -98,6 +108,12 @@ void devman_unregister_device(DEVMAN* devman, void* key)
 static UINT devman_register_device(DEVMAN* devman, DEVICE* device)
 {
 	void* key = NULL;
+
+	if (!devman || !device)
+		return ERROR_INVALID_PARAMETER;
+
+	if (device->type != RDPDR_DTYP_FILESYSTEM)
+		return CHANNEL_RC_OK;
 
 	device->id = devman->id_sequence++;
 	key = (void*) (size_t) device->id;
@@ -114,6 +130,9 @@ DEVICE* devman_get_device_by_id(DEVMAN* devman, UINT32 id)
 {
 	DEVICE* device = NULL;
 	void* key = (void*) (size_t) id;
+
+	if (!devman)
+		return NULL;
 
 	device = (DEVICE*) ListDictionary_GetItemValue(devman->devices, key);
 
@@ -136,6 +155,9 @@ UINT devman_load_device_service(DEVMAN* devman, RDPDR_DEVICE* device, rdpContext
 	char* ServiceName = NULL;
 	DEVICE_SERVICE_ENTRY_POINTS ep;
 	PDEVICE_SERVICE_ENTRY entry = NULL;
+
+	if (!devman || !device || !rdpcontext)
+		return ERROR_INVALID_PARAMETER;
 
 	if (device->Type == RDPDR_DTYP_FILESYSTEM)
 		ServiceName = DRIVE_SERVICE_NAME;

--- a/channels/rdpdr/client/irp.c
+++ b/channels/rdpdr/client/irp.c
@@ -77,18 +77,28 @@ static UINT irp_complete(IRP* irp)
 	return error;
 }
 
-IRP* irp_new(DEVMAN* devman, wStream* s)
+IRP* irp_new(DEVMAN* devman, wStream* s, UINT* error)
 {
 	IRP* irp;
 	DEVICE* device;
 	UINT32 DeviceId;
+
+	if (!Stream_EnsureRemainingCapacity(s, 20))
+	{
+		if (error)
+			*error = CHANNEL_RC_NO_BUFFER;
+		return NULL;
+	}
 
 	Stream_Read_UINT32(s, DeviceId); /* DeviceId (4 bytes) */
 	device = devman_get_device_by_id(devman, DeviceId);
 
 	if (!device)
 	{
-		WLog_ERR(TAG, "devman_get_device_by_id failed!");
+		WLog_WARN(TAG, "devman_get_device_by_id failed!");
+		if (error)
+			*error = CHANNEL_RC_OK;
+
 		return NULL;
 	};
 
@@ -97,6 +107,8 @@ IRP* irp_new(DEVMAN* devman, wStream* s)
 	if (!irp)
 	{
 		WLog_ERR(TAG, "_aligned_malloc failed!");
+		if (error)
+			*error = CHANNEL_RC_NO_MEMORY;
 		return NULL;
 	}
 
@@ -117,6 +129,8 @@ IRP* irp_new(DEVMAN* devman, wStream* s)
 	{
 		WLog_ERR(TAG, "Stream_New failed!");
 		_aligned_free(irp);
+		if (error)
+			*error = CHANNEL_RC_NO_MEMORY;
 		return NULL;
 	}
 	Stream_Write_UINT16(irp->output, RDPDR_CTYP_CORE); /* Component (2 bytes) */
@@ -130,6 +144,9 @@ IRP* irp_new(DEVMAN* devman, wStream* s)
 
 	irp->thread = NULL;
 	irp->cancelled = FALSE;
+
+	if (error)
+		*error = CHANNEL_RC_OK;
 
 	return irp;
 }

--- a/channels/rdpdr/client/irp.c
+++ b/channels/rdpdr/client/irp.c
@@ -86,7 +86,7 @@ IRP* irp_new(DEVMAN* devman, wStream* s, UINT* error)
 	if (Stream_GetRemainingLength(s) < 20)
 	{
 		if (error)
-			*error = CHANNEL_RC_NO_BUFFER;
+			*error = ERROR_INVALID_DATA;
 		return NULL;
 	}
 

--- a/channels/rdpdr/client/irp.c
+++ b/channels/rdpdr/client/irp.c
@@ -83,7 +83,7 @@ IRP* irp_new(DEVMAN* devman, wStream* s, UINT* error)
 	DEVICE* device;
 	UINT32 DeviceId;
 
-	if (!Stream_EnsureRemainingCapacity(s, 20))
+	if (Stream_GetRemainingLength(s) < 20)
 	{
 		if (error)
 			*error = CHANNEL_RC_NO_BUFFER;

--- a/channels/rdpdr/client/irp.h
+++ b/channels/rdpdr/client/irp.h
@@ -23,6 +23,6 @@
 
 #include "rdpdr_main.h"
 
-IRP* irp_new(DEVMAN* devman, wStream* s);
+IRP* irp_new(DEVMAN* devman, wStream* s, UINT* error);
 
 #endif /* FREERDP_CHANNEL_RDPDR_CLIENT_IRP_H */

--- a/channels/rdpdr/client/rdpdr_capabilities.c
+++ b/channels/rdpdr/client/rdpdr_capabilities.c
@@ -128,11 +128,14 @@ static void rdpdr_process_smartcard_capset(rdpdrPlugin* rdpdr, wStream* s)
 	Stream_Seek(s, capabilityLength - 4);
 }
 
-void rdpdr_process_capability_request(rdpdrPlugin* rdpdr, wStream* s)
+UINT rdpdr_process_capability_request(rdpdrPlugin* rdpdr, wStream* s)
 {
 	UINT16 i;
 	UINT16 numCapabilities;
 	UINT16 capabilityType;
+
+	if (!rdpdr || !s)
+		return ERROR_INVALID_PARAMETER;
 
 	Stream_Read_UINT16(s, numCapabilities);
 	Stream_Seek(s, 2); /* pad (2 bytes) */
@@ -167,6 +170,8 @@ void rdpdr_process_capability_request(rdpdrPlugin* rdpdr, wStream* s)
 				break;
 		}
 	}
+
+	return CHANNEL_RC_OK;
 }
 
 /**

--- a/channels/rdpdr/client/rdpdr_capabilities.c
+++ b/channels/rdpdr/client/rdpdr_capabilities.c
@@ -66,12 +66,12 @@ static UINT rdpdr_process_general_capset(rdpdrPlugin* rdpdr, wStream* s)
 	UINT16 capabilityLength;
 
 	if (Stream_GetRemainingLength(s) < 2)
-		return CHANNEL_RC_NO_BUFFER;
+		return ERROR_INVALID_DATA;
 
 	Stream_Read_UINT16(s, capabilityLength);
 
 	if (Stream_GetRemainingLength(s) < capabilityLength - 4)
-		return CHANNEL_RC_NO_BUFFER;
+		return ERROR_INVALID_DATA;
 
 	Stream_Seek(s, capabilityLength - 4);
 
@@ -90,12 +90,12 @@ static UINT rdpdr_process_printer_capset(rdpdrPlugin* rdpdr, wStream* s)
 	UINT16 capabilityLength;
 
 	if (Stream_GetRemainingLength(s) < 2)
-		return CHANNEL_RC_NO_BUFFER;
+		return ERROR_INVALID_DATA;
 
 	Stream_Read_UINT16(s, capabilityLength);
 
 	if (Stream_GetRemainingLength(s) < capabilityLength - 4)
-		return CHANNEL_RC_NO_BUFFER;
+		return ERROR_INVALID_DATA;
 
 	Stream_Seek(s, capabilityLength - 4);
 
@@ -114,12 +114,12 @@ static UINT rdpdr_process_port_capset(rdpdrPlugin* rdpdr, wStream* s)
 	UINT16 capabilityLength;
 
 	if (Stream_GetRemainingLength(s) < 2)
-		return CHANNEL_RC_NO_BUFFER;
+		return ERROR_INVALID_DATA;
 
 	Stream_Read_UINT16(s, capabilityLength);
 
 	if (Stream_GetRemainingLength(s) < capabilityLength - 4)
-		return CHANNEL_RC_NO_BUFFER;
+		return ERROR_INVALID_DATA;
 
 	Stream_Seek(s, capabilityLength - 4);
 
@@ -138,12 +138,12 @@ static UINT rdpdr_process_drive_capset(rdpdrPlugin* rdpdr, wStream* s)
 	UINT16 capabilityLength;
 
 	if (Stream_GetRemainingLength(s) < 2)
-		return CHANNEL_RC_NO_BUFFER;
+		return ERROR_INVALID_DATA;
 
 	Stream_Read_UINT16(s, capabilityLength);
 
 	if (Stream_GetRemainingLength(s) < capabilityLength - 4)
-		return CHANNEL_RC_NO_BUFFER;
+		return ERROR_INVALID_DATA;
 
 	Stream_Seek(s, capabilityLength - 4);
 
@@ -162,12 +162,12 @@ static UINT rdpdr_process_smartcard_capset(rdpdrPlugin* rdpdr, wStream* s)
 	UINT16 capabilityLength;
 
 	if (Stream_GetRemainingLength(s) < 2)
-		return CHANNEL_RC_NO_BUFFER;
+		return ERROR_INVALID_DATA;
 
 	Stream_Read_UINT16(s, capabilityLength);
 
 	if (Stream_GetRemainingLength(s) < capabilityLength - 4)
-		return CHANNEL_RC_NO_BUFFER;
+		return ERROR_INVALID_DATA;
 
 	Stream_Seek(s, capabilityLength - 4);
 
@@ -185,7 +185,7 @@ UINT rdpdr_process_capability_request(rdpdrPlugin* rdpdr, wStream* s)
 		return CHANNEL_RC_NULL_DATA;
 
 	if (Stream_GetRemainingLength(s) < 4)
-		return CHANNEL_RC_NO_BUFFER;
+		return ERROR_INVALID_DATA;
 
 	Stream_Read_UINT16(s, numCapabilities);
 	Stream_Seek(s, 2); /* pad (2 bytes) */
@@ -193,7 +193,7 @@ UINT rdpdr_process_capability_request(rdpdrPlugin* rdpdr, wStream* s)
 	for (i = 0; i < numCapabilities; i++)
 	{
 		if (Stream_GetRemainingLength(s) < sizeof(UINT16))
-			return CHANNEL_RC_NO_BUFFER;
+			return ERROR_INVALID_DATA;
 
 		Stream_Read_UINT16(s, capabilityType);
 

--- a/channels/rdpdr/client/rdpdr_capabilities.c
+++ b/channels/rdpdr/client/rdpdr_capabilities.c
@@ -190,11 +190,11 @@ UINT rdpdr_process_capability_request(rdpdrPlugin* rdpdr, wStream* s)
 	Stream_Read_UINT16(s, numCapabilities);
 	Stream_Seek(s, 2); /* pad (2 bytes) */
 
-	if (Stream_GetRemainingLength(s) < sizeof(UINT16) * numCapabilities)
-		return CHANNEL_RC_NO_BUFFER;
-
 	for (i = 0; i < numCapabilities; i++)
 	{
+		if (Stream_GetRemainingLength(s) < sizeof(UINT16))
+			return CHANNEL_RC_NO_BUFFER;
+
 		Stream_Read_UINT16(s, capabilityType);
 
 		switch (capabilityType)

--- a/channels/rdpdr/client/rdpdr_capabilities.c
+++ b/channels/rdpdr/client/rdpdr_capabilities.c
@@ -4,8 +4,9 @@
  *
  * Copyright 2010-2011 Vic Lee
  * Copyright 2010-2012 Marc-Andre Moreau <marcandre.moreau@gmail.com>
- * Copyright 2015 Thincast Technologies GmbH
+ * Copyright 2015-2016 Thincast Technologies GmbH
  * Copyright 2015 DI (FH) Martin Haimberger <martin.haimberger@thincast.com>
+ * Copyright 2016 Armin Novak <armin.novak@thincast.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -203,19 +204,19 @@ UINT rdpdr_process_capability_request(rdpdrPlugin* rdpdr, wStream* s)
 			break;
 
 		case CAP_PRINTER_TYPE:
-			rdpdr_process_printer_capset(rdpdr, s);
+			status = rdpdr_process_printer_capset(rdpdr, s);
 			break;
 
 		case CAP_PORT_TYPE:
-			rdpdr_process_port_capset(rdpdr, s);
+			status = rdpdr_process_port_capset(rdpdr, s);
 			break;
 
 		case CAP_DRIVE_TYPE:
-			rdpdr_process_drive_capset(rdpdr, s);
+			status = rdpdr_process_drive_capset(rdpdr, s);
 			break;
 
 		case CAP_SMARTCARD_TYPE:
-			rdpdr_process_smartcard_capset(rdpdr, s);
+			status = rdpdr_process_smartcard_capset(rdpdr, s);
 			break;
 
 		default:

--- a/channels/rdpdr/client/rdpdr_capabilities.c
+++ b/channels/rdpdr/client/rdpdr_capabilities.c
@@ -65,12 +65,12 @@ static UINT rdpdr_process_general_capset(rdpdrPlugin* rdpdr, wStream* s)
 {
 	UINT16 capabilityLength;
 
-	if (!Stream_EnsureRemainingCapacity(s, 2))
+	if (Stream_GetRemainingLength(s) < 2)
 		return CHANNEL_RC_NO_BUFFER;
 
 	Stream_Read_UINT16(s, capabilityLength);
 
-	if (!Stream_EnsureRemainingCapacity(s, capabilityLength - 4))
+	if (Stream_GetRemainingLength(s) < capabilityLength - 4)
 		return CHANNEL_RC_NO_BUFFER;
 
 	Stream_Seek(s, capabilityLength - 4);
@@ -89,12 +89,12 @@ static UINT rdpdr_process_printer_capset(rdpdrPlugin* rdpdr, wStream* s)
 {
 	UINT16 capabilityLength;
 
-	if (!Stream_EnsureRemainingCapacity(s, 2))
+	if (Stream_GetRemainingLength(s) < 2)
 		return CHANNEL_RC_NO_BUFFER;
 
 	Stream_Read_UINT16(s, capabilityLength);
 
-	if (!Stream_EnsureRemainingCapacity(s, capabilityLength - 4))
+	if (Stream_GetRemainingLength(s) < capabilityLength - 4)
 		return CHANNEL_RC_NO_BUFFER;
 
 	Stream_Seek(s, capabilityLength - 4);
@@ -113,12 +113,12 @@ static UINT rdpdr_process_port_capset(rdpdrPlugin* rdpdr, wStream* s)
 {
 	UINT16 capabilityLength;
 
-	if (!Stream_EnsureRemainingCapacity(s, 2))
+	if (Stream_GetRemainingLength(s) < 2)
 		return CHANNEL_RC_NO_BUFFER;
 
 	Stream_Read_UINT16(s, capabilityLength);
 
-	if (!Stream_EnsureRemainingCapacity(s, capabilityLength - 4))
+	if (Stream_GetRemainingLength(s) < capabilityLength - 4)
 		return CHANNEL_RC_NO_BUFFER;
 
 	Stream_Seek(s, capabilityLength - 4);
@@ -137,12 +137,12 @@ static UINT rdpdr_process_drive_capset(rdpdrPlugin* rdpdr, wStream* s)
 {
 	UINT16 capabilityLength;
 
-	if (!Stream_EnsureRemainingCapacity(s, 2))
+	if (Stream_GetRemainingLength(s) < 2)
 		return CHANNEL_RC_NO_BUFFER;
 
 	Stream_Read_UINT16(s, capabilityLength);
 
-	if (!Stream_EnsureRemainingCapacity(s, capabilityLength - 4))
+	if (Stream_GetRemainingLength(s) < capabilityLength - 4)
 		return CHANNEL_RC_NO_BUFFER;
 
 	Stream_Seek(s, capabilityLength - 4);
@@ -161,12 +161,12 @@ static UINT rdpdr_process_smartcard_capset(rdpdrPlugin* rdpdr, wStream* s)
 {
 	UINT16 capabilityLength;
 
-	if (!Stream_EnsureRemainingCapacity(s, 2))
+	if (Stream_GetRemainingLength(s) < 2)
 		return CHANNEL_RC_NO_BUFFER;
 
 	Stream_Read_UINT16(s, capabilityLength);
 
-	if (!Stream_EnsureRemainingCapacity(s, capabilityLength - 4))
+	if (Stream_GetRemainingLength(s) < capabilityLength - 4)
 		return CHANNEL_RC_NO_BUFFER;
 
 	Stream_Seek(s, capabilityLength - 4);
@@ -184,13 +184,13 @@ UINT rdpdr_process_capability_request(rdpdrPlugin* rdpdr, wStream* s)
 	if (!rdpdr || !s)
 		return CHANNEL_RC_NULL_DATA;
 
-	if (!Stream_EnsureRemainingCapacity(s, 4))
+	if (Stream_GetRemainingLength(s) < 4)
 		return CHANNEL_RC_NO_BUFFER;
 
 	Stream_Read_UINT16(s, numCapabilities);
 	Stream_Seek(s, 2); /* pad (2 bytes) */
 
-	if (!Stream_EnsureRemainingCapacity(s, sizeof(UINT16) * numCapabilities))
+	if (Stream_GetRemainingLength(s) < sizeof(UINT16) * numCapabilities)
 		return CHANNEL_RC_NO_BUFFER;
 
 	for (i = 0; i < numCapabilities; i++)

--- a/channels/rdpdr/client/rdpdr_capabilities.h
+++ b/channels/rdpdr/client/rdpdr_capabilities.h
@@ -25,7 +25,7 @@
 
 #include "rdpdr_main.h"
 
-void rdpdr_process_capability_request(rdpdrPlugin* rdpdr, wStream* s);
+UINT rdpdr_process_capability_request(rdpdrPlugin* rdpdr, wStream* s);
 UINT rdpdr_send_capability_response(rdpdrPlugin* rdpdr);
 
 #endif /* FREERDP_CHANNEL_RDPDR_CLIENT_CAPABILITIES_H */

--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -497,7 +497,6 @@ static UINT handle_hotplug(rdpdrPlugin* rdpdr)
 				free(drive->Path);
 				free(drive->Name);
 				free(drive);
-				error = CHANNEL_RC_NO_MEMORY;
 				goto cleanup;
 			}
 		}
@@ -820,7 +819,7 @@ static UINT rdpdr_send_device_list_announce_request(rdpdrPlugin* rdpdr, BOOL use
 			if (!Stream_EnsureRemainingCapacity(s, 20 + data_len))
 			{
 				WLog_ERR(TAG, "Stream_EnsureRemainingCapacity failed!");
-				return CHANNEL_RC_NO_MEMORY;
+				return CHANNEL_RC_NO_BUFFER;
 			}
 
 			Stream_Write_UINT32(s, device->type); /* deviceType */
@@ -869,12 +868,12 @@ static UINT rdpdr_process_irp(rdpdrPlugin* rdpdr, wStream* s)
 	IRP* irp;
 	UINT error = CHANNEL_RC_OK;
 
-	irp = irp_new(rdpdr->devman, s);
+	irp = irp_new(rdpdr->devman, s, &error);
 
 	if (!irp)
 	{
-		WLog_ERR(TAG, "irp_new failed!");
-		return CHANNEL_RC_NO_MEMORY;
+		WLog_ERR(TAG, "irp_new failed with %lu!", error);
+		return error;
 	}
 
 	IFCALLRET(irp->device->IRPRequest, error, irp->device, irp);
@@ -1217,7 +1216,7 @@ static UINT rdpdr_virtual_channel_event_data_received(rdpdrPlugin* rdpdr,
 	if (!Stream_EnsureRemainingCapacity(data_in, (int) dataLength))
 	{
 		WLog_ERR(TAG,  "Stream_EnsureRemainingCapacity failed!");
-		return CHANNEL_RC_NO_MEMORY;
+		return CHANNEL_RC_NO_BUFFER;
 	}
 	Stream_Write(data_in, pData, dataLength);
 

--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -664,7 +664,7 @@ static UINT rdpdr_process_connect(rdpdrPlugin* rdpdr)
 
 static UINT rdpdr_process_server_announce_request(rdpdrPlugin* rdpdr, wStream* s)
 {
-	if (!Stream_EnsureRemainingCapacity(s, 8))
+	if (Stream_GetRemainingLength(s) < 8)
 		return CHANNEL_RC_NO_BUFFER;
 
 	Stream_Read_UINT16(s, rdpdr->versionMajor);
@@ -745,7 +745,7 @@ static UINT rdpdr_process_server_clientid_confirm(rdpdrPlugin* rdpdr, wStream* s
 	UINT16 versionMinor;
 	UINT32 clientID;
 
-	if (!Stream_EnsureRemainingCapacity(s, 8))
+	if (Stream_GetRemainingLength(s) < 8)
 		return CHANNEL_RC_NO_BUFFER;
 
 	Stream_Read_UINT16(s, versionMajor);
@@ -933,7 +933,7 @@ static UINT rdpdr_process_receive(rdpdrPlugin* rdpdr, wStream* s)
 	if (!rdpdr || !s)
 		return CHANNEL_RC_NULL_DATA;
 
-	if (!Stream_EnsureRemainingCapacity(s, 4))
+	if (Stream_GetRemainingLength(s) < 4)
 		return CHANNEL_RC_NO_BUFFER;
 
 	Stream_Read_UINT16(s, component); /* Component (2 bytes) */
@@ -994,7 +994,7 @@ static UINT rdpdr_process_receive(rdpdrPlugin* rdpdr, wStream* s)
 
 		case PAKID_CORE_DEVICE_REPLY:
 			/* connect to a specific resource */
-			if (Stream_EnsureRemainingCapacity(s, 8))
+			if (Stream_GetRemainingLength(s) < 8)
 				return CHANNEL_RC_NO_BUFFER;
 
 			Stream_Read_UINT32(s, deviceId);
@@ -1024,7 +1024,7 @@ static UINT rdpdr_process_receive(rdpdrPlugin* rdpdr, wStream* s)
 		case PAKID_PRN_CACHE_DATA:
 		{
 			UINT32 eventID;
-			if (Stream_EnsureRemainingCapacity(s, 4))
+			if (Stream_GetRemainingLength(s) < 4)
 				return CHANNEL_RC_NO_BUFFER;
 
 			Stream_Read_UINT32(s, eventID);

--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -665,7 +665,7 @@ static UINT rdpdr_process_connect(rdpdrPlugin* rdpdr)
 static UINT rdpdr_process_server_announce_request(rdpdrPlugin* rdpdr, wStream* s)
 {
 	if (Stream_GetRemainingLength(s) < 8)
-		return CHANNEL_RC_NO_BUFFER;
+		return ERROR_INVALID_DATA;
 
 	Stream_Read_UINT16(s, rdpdr->versionMajor);
 	Stream_Read_UINT16(s, rdpdr->versionMinor);
@@ -746,7 +746,7 @@ static UINT rdpdr_process_server_clientid_confirm(rdpdrPlugin* rdpdr, wStream* s
 	UINT32 clientID;
 
 	if (Stream_GetRemainingLength(s) < 8)
-		return CHANNEL_RC_NO_BUFFER;
+		return ERROR_INVALID_DATA;
 
 	Stream_Read_UINT16(s, versionMajor);
 	Stream_Read_UINT16(s, versionMinor);
@@ -819,7 +819,7 @@ static UINT rdpdr_send_device_list_announce_request(rdpdrPlugin* rdpdr, BOOL use
 			if (!Stream_EnsureRemainingCapacity(s, 20 + data_len))
 			{
 				WLog_ERR(TAG, "Stream_EnsureRemainingCapacity failed!");
-				return CHANNEL_RC_NO_BUFFER;
+				return ERROR_INVALID_DATA;
 			}
 
 			Stream_Write_UINT32(s, device->type); /* deviceType */
@@ -934,7 +934,7 @@ static UINT rdpdr_process_receive(rdpdrPlugin* rdpdr, wStream* s)
 		return CHANNEL_RC_NULL_DATA;
 
 	if (Stream_GetRemainingLength(s) < 4)
-		return CHANNEL_RC_NO_BUFFER;
+		return ERROR_INVALID_DATA;
 
 	Stream_Read_UINT16(s, component); /* Component (2 bytes) */
 	Stream_Read_UINT16(s, packetId); /* PacketId (2 bytes) */
@@ -995,7 +995,7 @@ static UINT rdpdr_process_receive(rdpdrPlugin* rdpdr, wStream* s)
 		case PAKID_CORE_DEVICE_REPLY:
 			/* connect to a specific resource */
 			if (Stream_GetRemainingLength(s) < 8)
-				return CHANNEL_RC_NO_BUFFER;
+				return ERROR_INVALID_DATA;
 
 			Stream_Read_UINT32(s, deviceId);
 			Stream_Read_UINT32(s, status);
@@ -1025,7 +1025,7 @@ static UINT rdpdr_process_receive(rdpdrPlugin* rdpdr, wStream* s)
 		{
 			UINT32 eventID;
 			if (Stream_GetRemainingLength(s) < 4)
-				return CHANNEL_RC_NO_BUFFER;
+				return ERROR_INVALID_DATA;
 
 			Stream_Read_UINT32(s, eventID);
 			WLog_ERR(TAG, "Ignoring unhandled message PAKID_PRN_CACHE_DATA (EventID: 0x%04X)", eventID);
@@ -1216,7 +1216,7 @@ static UINT rdpdr_virtual_channel_event_data_received(rdpdrPlugin* rdpdr,
 	if (!Stream_EnsureRemainingCapacity(data_in, (int) dataLength))
 	{
 		WLog_ERR(TAG,  "Stream_EnsureRemainingCapacity failed!");
-		return CHANNEL_RC_NO_BUFFER;
+		return ERROR_INVALID_DATA;
 	}
 	Stream_Write(data_in, pData, dataLength);
 

--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -4,8 +4,9 @@
  *
  * Copyright 2010-2011 Vic Lee
  * Copyright 2010-2012 Marc-Andre Moreau <marcandre.moreau@gmail.com>
- * Copyright 2015 Thincast Technologies GmbH
+ * Copyright 2015-2016 Thincast Technologies GmbH
  * Copyright 2015 DI (FH) Martin Haimberger <martin.haimberger@thincast.com>
+ * Copyright 2016 Armin Novak <armin.novak@thincast.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Fixes issues from #2975, ignore hotplug events for types other than ```RDPDR_DTYP_FILESYSTEM```
* Adds argument checks for functions in drive channel.