### PR TITLE
Fix png image loading that needed write access

### DIFF
--- a/winpr/libwinpr/utils/image.c
+++ b/winpr/libwinpr/utils/image.c
@@ -3,6 +3,8 @@
  * Image Utils
  *
  * Copyright 2014 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+ * Copyright 2016 Inuvika Inc.
+ * Copyright 2016 David PHAM-VAN <d.phamvan@inuvika.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -308,7 +310,7 @@ int winpr_image_read(wImage* image, const char* filename)
 	BYTE sig[8];
 	int status = -1;
 
-	fp = fopen(filename, "r+b");
+	fp = fopen(filename, "rb");
 
 	if (!fp)
 	{


### PR DESCRIPTION
Opening a png file don't need the "append" flag to open a file for reading.
This is annoying if the file is in a read-only folder like /usr/share/...