### PR TITLE
fix typo

### DIFF
--- a/winpr/libwinpr/smartcard/smartcard_pcsc.c
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.c
@@ -1996,7 +1996,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardStatus_Internal(SCARDHANDLE hCard,
 		{
 			if (pcchReaderLenAlloc)
 			{
-#ifdef __MAXOSX__
+#ifdef __MACOSX__
 				/**
 				* Workaround for SCardStatus Bug in MAC OS X Yosemite
 				*/


### PR DESCRIPTION
Pretty sure that's supposed to be __MA**C**OSX__, not __MA**X**OSX__