### PR TITLE
pkg/deb: fix nightly builds

### DIFF
--- a/packaging/deb/freerdp-nightly/rules
+++ b/packaging/deb/freerdp-nightly/rules
@@ -36,6 +36,7 @@ override_dh_strip:
 
 override_dh_install:
 	mkdir -p debian/tmp/opt/freerdp-nightly/lib/cmake/
+	rm -rf debian/tmp/opt/freerdp-nightly/lib/freerdp/*.a
 
 	dh_install --fail-missing
 


### PR DESCRIPTION
with the latest cmake changes related to static channels builds fail on
wheezy and precise this fixes the problem.