### PR TITLE
Fixed stdbool.h and stdint.h detection.

### DIFF
--- a/winpr/include/winpr/wtypes.h.in
+++ b/winpr/include/winpr/wtypes.h.in
@@ -21,9 +21,18 @@
 #define WINPR_WTYPES_H
 
 /* Set by CMake during configuration. */
-#define WINPR_HAVE_STDINT_H @HAVE_STDINT_H@
+#if defined @HAVE_STDINT_H@
+#define WINPR_HAVE_STDINT_H 1
+#else
+#define WINPR_HAVE_STDINT_H 0
+#endif
+
 /* Set by CMake during configuration. */
-#define WINPR_HAVE_STDBOOL_H @HAVE_STDBOOL_H@
+#if defined @HAVE_STDBOOL_H@
+#define WINPR_HAVE_STDBOOL_H 1
+#else
+#define WINPR_HAVE_STDBOOL_H 0
+#endif
 
 /* MSDN: Windows Data Types - http://msdn.microsoft.com/en-us/library/aa383751/ */
 /* [MS-DTYP]: Windows Data Types - http://msdn.microsoft.com/en-us/library/cc230273/ */


### PR DESCRIPTION
When one of those headers is not detected the CMake
variable is undefined. Using it for a #define did break
things with vs2010.