### PR TITLE
gcc: assigned string must not be freed.

### DIFF
--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -593,7 +593,6 @@ BOOL gcc_read_client_core_data(wStream* s, rdpMcs* mcs, UINT16 blockLength)
 	Stream_Seek(s, 32);
 	free(settings->ClientHostname);
 	settings->ClientHostname = str;
-	free(str);
 	str = NULL;
 
 	Stream_Read_UINT32(s, settings->KeyboardType); /* KeyboardType (4 bytes) */


### PR DESCRIPTION
This fixed a double-free memory issue. The pointer was assigned but freed, then it will be used and freed again causing memory corruption.