### PR TITLE
libfreerdp-codec: Make region16_rects() handle NULL nbRects

### DIFF
--- a/include/freerdp/codec/region.h
+++ b/include/freerdp/codec/region.h
@@ -73,10 +73,10 @@ FREERDP_API void region16_init(REGION16 *region);
 /** @return the number of rectangles of this region16 */
 FREERDP_API int region16_n_rects(const REGION16 *region);
 
-/** returns a pointer on rectangles and the number of rectangles in this region.
- * nbRect can be set to NULL if not interested by the numnber of rectangles.
+/** returns a pointer to rectangles and the number of rectangles in this region.
+ * nbRects can be set to NULL if not interested in the number of rectangles.
  * @param region the input region
- * @param nbRects a pointer that will be filled with the number of rectangles
+ * @param nbRects if non-NULL returns the number of rectangles
  * @return a pointer on the rectangles
  */
 FREERDP_API const RECTANGLE_16 *region16_rects(const REGION16 *region, int *nbRects);

--- a/libfreerdp/codec/region.c
+++ b/libfreerdp/codec/region.c
@@ -94,17 +94,17 @@ const RECTANGLE_16 *region16_rects(const REGION16 *region, int *nbRects)
 	REGION16_DATA *data;
 
 	assert(region);
-	assert(region->data);
 
 	data = region->data;
 	if (!data)
 	{
 		if (nbRects)
 			*nbRects = 0;
-		return 0;
+		return NULL;
 	}
 
-	*nbRects = data->nbRects;
+	if (nbRects)
+		*nbRects = data->nbRects;
 	return (RECTANGLE_16 *)(data + 1);
 }
 


### PR DESCRIPTION
Now matches header documentation.  Also cleans up related doc grammar.