### PR TITLE
If Android, get timezone from system command.

### DIFF
--- a/libfreerdp/locale/timezone.c
+++ b/libfreerdp/locale/timezone.c
@@ -1584,7 +1584,7 @@ char* freerdp_get_unix_timezone_identifier()
 		return tzid;
 	}
 
-	tzid = freerdp_get_unix_timezone_identifier_from_file(FILE* fp);
+	tzid = freerdp_get_unix_timezone_identifier_from_file();
 	if (tzid != NULL)
 	{
 		return tzid;

--- a/libfreerdp/locale/timezone.c
+++ b/libfreerdp/locale/timezone.c
@@ -1536,6 +1536,7 @@ char* freerdp_read_unix_timezone_identifier_from_file(FILE* fp)
 		tzid[length - 1] = '\0';
 	}
 
+	return tzid;
 }
 
 char* freerdp_get_unix_timezone_identifier_from_file()

--- a/libfreerdp/locale/timezone.c
+++ b/libfreerdp/locale/timezone.c
@@ -1523,7 +1523,9 @@ char* freerdp_get_unix_timezone_identifier()
 		return tzid;
 	}
 
-#if defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(ANDROID)
+	fp = popen("getprop persist.sys.timezone", "r");
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 	fp = fopen("/var/db/zoneinfo", "r");
 #else
 	fp = fopen("/etc/timezone", "r");

--- a/libfreerdp/locale/timezone.c
+++ b/libfreerdp/locale/timezone.c
@@ -1538,21 +1538,33 @@ char* freerdp_get_unix_timezone_identifier()
 
 		if (length < 2)
 		{
+#if defined(ANDROID)
+			pclose(fp) ;
+#else
 			fclose(fp) ;
+#endif
 			return NULL;
 		}
 
 		tzid = (char*) malloc(length + 1);
 		if (!tzid)
 		{
-			fclose(fp);
+#if defined(ANDROID)
+			pclose(fp) ;
+#else
+			fclose(fp) ;
+#endif
 			return NULL;
 		}
 
 		if (fread(tzid, length, 1, fp) != 1)
 		{
 			free(tzid);
-			fclose(fp);
+#if defined(ANDROID)
+			pclose(fp) ;
+#else
+			fclose(fp) ;
+#endif
 			return NULL;
 		}
 		tzid[length] = '\0';
@@ -1560,7 +1572,11 @@ char* freerdp_get_unix_timezone_identifier()
 		if (tzid[length - 1] == '\n')
 			tzid[length - 1] = '\0';
 
-		fclose(fp);
+#if defined(ANDROID)
+			pclose(fp) ;
+#else
+			fclose(fp) ;
+#endif
 
 		return tzid;
 	}


### PR DESCRIPTION
In the case of Android, I changed to get timezone from Android's system command 'getprop persist.sys.timezone' if TZ environmental variable not set. It is because Android doesn't seem to have both "/var/db/zoneinfo" and "/etc/timezone" unlike BSD or Linux.