### PR TITLE
Fix char signedness in glyph offset calculation, fixes #2137

### DIFF
--- a/libfreerdp/cache/glyph.c
+++ b/libfreerdp/cache/glyph.c
@@ -57,7 +57,7 @@ void update_process_glyph(rdpContext* context, BYTE* data, int* index,
 
 		if (offset & 0x80)
 		{
-			offset = data[*index + 1] | ((int)((char)data[*index + 2]) << 8);
+			offset = data[*index + 1] | ((int)((signed char)data[*index + 2]) << 8);
 			(*index)++;
 			(*index)++;
 		}


### PR DESCRIPTION
I have just discovered the ["Shocking truth"](http://blog.cdleary.com/2012/11/arm-chars-are-unsigned-by-default/): under ARM gcc char data type is unsigned, when `-fsigned-char` is not used :blush:.
This patch makes an [older commit](https://github.com/FreeRDP/FreeRDP/commit/85b5c5f8909a0e660d8a1b0a23a63883771fa30f) to work independently of default char signedness.
