### PR TITLE
Fix a freeze when receiving a deactivateAll PDU

### DIFF
--- a/libfreerdp/core/activation.c
+++ b/libfreerdp/core/activation.c
@@ -311,18 +311,7 @@ BOOL rdp_recv_deactivate_all(rdpRdp* rdp, wStream* s)
 		while(0);
 	}
 
-	rdp_client_transition_to_state(rdp, CONNECTION_STATE_CAPABILITIES_EXCHANGE);
-
-	while (rdp->state != CONNECTION_STATE_ACTIVE)
-	{
-		if (rdp_check_fds(rdp) < 0)
-			return FALSE;
-
-		if (freerdp_shall_disconnect(rdp->instance))
-			break;
-	}
-
-	return TRUE;
+	return rdp_client_transition_to_state(rdp, CONNECTION_STATE_CAPABILITIES_EXCHANGE) != -1;
 }
 
 BOOL rdp_send_deactivate_all(rdpRdp* rdp)


### PR DESCRIPTION
When connecting on FUDO, the xfreerdp client gets stuck when receiving a
deactivateAll PDU. It seems that rdp_recv_deactivate_all() was doing nasty
things as it is called from the receive callback, so when it was calling rdp_check_fds(),
the callback was called again, opening a potential recursive loop. The activation
state machine seems correctly implemented so just returning looks ok and fixes
connections on FUDO hosts.

Sponsored by: Wheel Systems (http://www.wheelsystems.com)