### PR TITLE
android: disable mips build

### DIFF
--- a/scripts/android-build.conf
+++ b/scripts/android-build.conf
@@ -19,4 +19,4 @@ BUILD_SRC=$SRC_DIR/build
 
 CMAKE_BUILD_TYPE=Debug
 
-BUILD_ARCH="armeabi armeabi-v7a x86 mips"
+BUILD_ARCH="armeabi armeabi-v7a x86"


### PR DESCRIPTION
mips build causes problems when building openssl during integration
builds. Disable it for now.