### PR TITLE
android: Fix sound redirection.

### DIFF
--- a/channels/audin/client/opensles/audin_opensl_es.c
+++ b/channels/audin/client/opensles/audin_opensl_es.c
@@ -218,8 +218,6 @@ static BOOL audin_opensles_format_supported(IAudinDevice* device, audinFormat* f
 
 	switch (format->wFormatTag)
 	{
-		/* TODO: Deactivated, untested */
-#if 0
 		case WAVE_FORMAT_PCM: /* PCM */
 			if (format->cbSize == 0 &&
 				(format->nSamplesPerSec <= 48000) &&
@@ -229,7 +227,6 @@ static BOOL audin_opensles_format_supported(IAudinDevice* device, audinFormat* f
 				return TRUE;
 			}
 			break;
-#endif
 			/* TODO: Deactivated format, does not work, find out why */
 //		case WAVE_FORMAT_ADPCM: /* IMA ADPCM */
 		case WAVE_FORMAT_DVI_ADPCM: 

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -257,10 +257,13 @@ public class LibFreeRDP {
             }
         }
 
-        /* 0 ... disable
-           1 ... local
-           2 ... remote */
+        /* 0 ... local
+           1 ... remote 
+           2 ... disable */
         args.add("/audio-mode:" + String.valueOf(advanced.getRedirectSound()));
+        if (advanced.getRedirectSound() == 0) {
+            args.add("/sound");
+        }
 
         if (advanced.getRedirectMicrophone()) {
             args.add("/microphone");

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-de/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-de/strings.xml
@@ -119,9 +119,9 @@
         <item>Auf Client abspielen</item>
     </string-array>
     <string-array name="redirect_sound_values_array">
-        <item>0</item>
-        <item>1</item>
         <item>2</item>
+        <item>1</item>
+        <item>0</item>
     </string-array>
     <string name="settings_redirect_microphone">Mikrophon umleiten</string>
     <string name="settings_security">Sicherheit</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-es/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-es/strings.xml
@@ -122,9 +122,9 @@
         <item>Play on Device</item>
     </string-array>
     <string-array name="redirect_sound_values_array">
-        <item>0</item>
-        <item>1</item>
         <item>2</item>
+        <item>1</item>
+        <item>0</item>
     </string-array>
     <string name="settings_redirect_microphone">Redirect Microphone</string>
     <string name="settings_security">Seguridad</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-fr/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-fr/strings.xml
@@ -121,9 +121,9 @@
         <item>Play on Device</item>
     </string-array>
     <string-array name="redirect_sound_values_array">
-        <item>0</item>
-        <item>1</item>
         <item>2</item>
+        <item>1</item>
+        <item>0</item>
     </string-array>
     <string name="settings_redirect_microphone">Redirect Microphone</string>
     <string name="settings_security">"Securité"</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-nl/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-nl/strings.xml
@@ -122,9 +122,9 @@
         <item>Play on Device</item>
     </string-array>
     <string-array name="redirect_sound_values_array">
-        <item>0</item>
-        <item>1</item>
         <item>2</item>
+        <item>1</item>
+        <item>0</item>
     </string-array>
     <string name="settings_redirect_microphone">Redirect Microphone</string>
     <string name="settings_security">Beveiliging</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-zh/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-zh/strings.xml
@@ -119,9 +119,9 @@
         <item>在此设备上播放</item>
     </string-array>
     <string-array name="redirect_sound_values_array">
-        <item>0</item>
-        <item>1</item>
         <item>2</item>
+        <item>1</item>
+        <item>0</item>
     </string-array>
     <string name="settings_redirect_microphone">麦克风重定向</string>
     <string name="settings_security">连接协议</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -122,9 +122,9 @@
         <item>Play on Device</item>
     </string-array>
     <string-array name="redirect_sound_values_array">
-        <item>0</item>
-        <item>1</item>
         <item>2</item>
+        <item>1</item>
+        <item>0</item>
     </string-array>
     <string name="settings_redirect_microphone">Redirect Microphone</string>
     <string name="settings_security">Security</string>


### PR DESCRIPTION
After #3097, the java side pass command line argument to JNI for freerdp settings. However there's several issues need to be fixed:
1. The argument /sound should be appended if freerdp is required to play sound at local device
2. The option value for "audio-mode" is not correct.
It should match the definition in client/common/cmdline.c
/* Audio Mode */
define AUDIO_MODE_REDIRECT     0 /* Bring to this computer */
define AUDIO_MODE_PLAY_ON_SERVER   1 /* Leave at remote computer */
define AUDIO_MODE_NONE         2 /* Do not play */
3. Uncomment support for WAVE_FORMAT_PCM in audin. I tested on my android phone and Nokia N1 tablet. It works on both device