### PR TITLE
shadow/subsystem: fix pkgconfig file

### DIFF
--- a/server/shadow/freerdp-shadow.pc.in
+++ b/server/shadow/freerdp-shadow.pc.in
@@ -2,14 +2,14 @@ prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
 libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=${prefix}/@FREERDP_INCLUDE_DIR@
-libs=-lfreerdp-shadow
+libs=-lfreerdp-shadow -lfreerdp-shadow-subsystem
 
 Name: FreeRDP shadow
 Description: FreeRDP: A Remote Desktop Protocol Implementation
 URL: http://www.freerdp.com/
 Version: @FREERDP_VERSION@
 Requires: 
-Requires.private: @WINPR_PKG_CONFIG_FILENAME@ freerdp@FREERDP_VERSION_MAJOR@ freerdp-shadow@FREERDP_VERSION_MAJOR@
+Requires.private: @WINPR_PKG_CONFIG_FILENAME@ freerdp@FREERDP_VERSION_MAJOR@
 Libs: -L${libdir} ${libs}
 Libs.private: -ldl -lpthread
 Cflags: -I${includedir}


### PR DESCRIPTION
Add freerdp-shadow-subsystem to 'libs' in order to avoid undefined
reference to shadow_subsystem_set_entry_builtin at runtime.

Remove cyclic dependency on itself.