### PR TITLE
Fix build on older 32-bit Ubuntu releases

### DIFF
--- a/winpr/include/winpr/wtypes.h.in
+++ b/winpr/include/winpr/wtypes.h.in
@@ -285,7 +285,7 @@ typedef void *PVOID64, *LPVOID64;
 #if WINPR_HAVE_STDINT_H
 typedef intptr_t INT_PTR;
 typedef uintptr_t UINT_PTR;
-#elif __x86_64__
+#elif defined (__x86_64__)
 typedef __int64 INT_PTR;
 typedef unsigned __int64 UINT_PTR;
 #else


### PR DESCRIPTION
Some older 32-bit versions of gcc fail on '#elif __x86_64__'.
This applies at least to what Ubuntu 14.04 and 15.04 have as
the default compiler.