### PR TITLE
ConvertFromUnicode fixes and misc hardening

### DIFF
--- a/channels/echo/server/echo_main.c
+++ b/channels/echo/server/echo_main.c
@@ -116,12 +116,15 @@ static void* echo_server_thread_func(void* arg)
 	DWORD BytesReturned = 0;
 	echo_server* echo = (echo_server*) arg;
 	UINT error;
-    DWORD status;
+	DWORD status;
 
 	if ((error = echo_server_open_channel(echo)))
 	{
-		IFCALLRET(echo->context.OpenResult, error, &echo->context, ECHO_SERVER_OPEN_RESULT_NOTSUPPORTED);
+		UINT error2 = 0;
 		WLog_ERR(TAG, "echo_server_open_channel failed with error %lu!", error);
+		IFCALLRET(echo->context.OpenResult, error2, &echo->context, ECHO_SERVER_OPEN_RESULT_NOTSUPPORTED);
+		if (error2)
+			WLog_ERR(TAG, "echo server's OpenResult callback failed with error %lu", error2);
 		goto out;
 	}
 
@@ -145,14 +148,14 @@ static void* echo_server_thread_func(void* arg)
 
 	while (1)
 	{
-        status = WaitForMultipleObjects(nCount, events, FALSE, 100);
+		status = WaitForMultipleObjects(nCount, events, FALSE, 100);
 
-        if (status == WAIT_FAILED)
-        {
-            error = GetLastError();
-            WLog_ERR(TAG, "WaitForMultipleObjects failed with error %lu", error);
-            break;
-        }
+		if (status == WAIT_FAILED)
+		{
+			error = GetLastError();
+			WLog_ERR(TAG, "WaitForMultipleObjects failed with error %lu", error);
+			break;
+		}
 
 		if (status == WAIT_OBJECT_0)
 		{

--- a/channels/smartcard/client/smartcard_pack.c
+++ b/channels/smartcard/client/smartcard_pack.c
@@ -707,7 +707,12 @@ void smartcard_trace_list_readers_return(SMARTCARD_DEVICE* smartcard, ListReader
 	if (unicode)
 	{
 		length = ret->cBytes / 2;
-		ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) ret->msz, (int)length, &mszA, 0, NULL, NULL);
+		if (ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) ret->msz, (int)length,
+			&mszA, 0, NULL, NULL) < 1)
+		{
+			WLog_ERR(TAG, "ConvertFromUnicode failed");
+			return;
+		}
 	}
 	else
 	{
@@ -1767,7 +1772,12 @@ void smartcard_trace_status_return(SMARTCARD_DEVICE* smartcard, Status_Return* r
 	if (unicode)
 	{
 		length = ret->cBytes / 2;
-		ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) ret->mszReaderNames, (int)length, &mszReaderNamesA, 0, NULL, NULL);
+		if (ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) ret->mszReaderNames, (int)length,
+			&mszReaderNamesA, 0, NULL, NULL) < 1)
+		{
+			WLog_ERR(TAG, "ConvertFromUnicode failed");
+			return;
+		}
 	}
 	else
 	{

--- a/client/Windows/wf_rail.c
+++ b/client/Windows/wf_rail.c
@@ -456,14 +456,33 @@ static BOOL wf_rail_window_common(rdpContext* context, WINDOW_ORDER_INFO* orderI
 		{
 			char* title = NULL;
 
-			ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) windowState->titleInfo.string,
-				   windowState->titleInfo.length / 2, &title, 0, NULL, NULL);
+			if (windowState->titleInfo.length == 0)
+			{
+				if (!(title = _strdup("")))
+				{
+					WLog_ERR(TAG, "failed to duplicate empty window title string");
+					/* error handled below */
+				}
+			}
+			else if (ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) windowState->titleInfo.string,
+				   windowState->titleInfo.length / 2, &title, 0, NULL, NULL) < 1)
+			{
+				WLog_ERR(TAG, "failed to convert window title");
+				/* error handled below */
+			}
 
 			railWindow->title = title;
 		}
 		else
 		{
-			railWindow->title = _strdup("RdpRailWindow");
+			if (!(railWindow->title = _strdup("RdpRailWindow")))
+				WLog_ERR(TAG, "failed to duplicate default window title string");
+		}
+
+		if (!railWindow->title)
+		{
+			free(railWindow);
+			return FALSE;
 		}
 
 		ConvertToUnicode(CP_UTF8, 0, railWindow->title, -1, &titleW, 0);
@@ -569,8 +588,20 @@ static BOOL wf_rail_window_common(rdpContext* context, WINDOW_ORDER_INFO* orderI
 		char* title = NULL;
 		WCHAR* titleW = NULL;
 
-		ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) windowState->titleInfo.string,
-			   windowState->titleInfo.length / 2, &title, 0, NULL, NULL);
+		if (windowState->titleInfo.length == 0)
+		{
+			if (!(title = _strdup("")))
+			{
+				WLog_ERR(TAG, "failed to duplicate empty window title string");
+				return FALSE;
+			}
+		}
+		else if (ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) windowState->titleInfo.string,
+			windowState->titleInfo.length / 2, &title, 0, NULL, NULL) < 1)
+		{
+			WLog_ERR(TAG, "failed to convert window title");
+			return FALSE;
+		}
 
 		free(railWindow->title);
 		railWindow->title = title;

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -290,15 +290,29 @@ static BOOL xf_rail_window_common(rdpContext* context, WINDOW_ORDER_INFO* orderI
 		{
 			char* title = NULL;
 
-			ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) windowState->titleInfo.string,
-				   windowState->titleInfo.length / 2, &title, 0, NULL, NULL);
+			if (windowState->titleInfo.length == 0)
+			{
+				if (!(title = _strdup("")))
+				{
+					WLog_ERR(TAG, "failed to duplicate empty window title string");
+					/* error handled below */
+				}
+			}
+			else if (ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) windowState->titleInfo.string,
+				windowState->titleInfo.length / 2, &title, 0, NULL, NULL) < 1)
+			{
+				WLog_ERR(TAG, "failed to convert window title");
+				/* error handled below */
+			}
 
 			appWindow->title = title;
 		}
 		else
 		{
-			appWindow->title = _strdup("RdpRailWindow");
+			if (!(appWindow->title = _strdup("RdpRailWindow")))
+				WLog_ERR(TAG, "failed to duplicate default window title string");
 		}
+
 		if (!appWindow->title)
 		{
 			free(appWindow);
@@ -365,9 +379,20 @@ static BOOL xf_rail_window_common(rdpContext* context, WINDOW_ORDER_INFO* orderI
 	{
 		char* title = NULL;
 
-		ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) windowState->titleInfo.string,
-			   windowState->titleInfo.length / 2, &title, 0, NULL, NULL);
-
+		if (windowState->titleInfo.length == 0)
+		{
+			if (!(title = _strdup("")))
+			{
+				WLog_ERR(TAG, "failed to duplicate empty window title string");
+				return FALSE;
+			}
+		}
+		else if (ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) windowState->titleInfo.string,
+			windowState->titleInfo.length / 2, &title, 0, NULL, NULL) < 1)
+		{
+			WLog_ERR(TAG, "failed to convert window title");
+			return FALSE;
+		}
 		free(appWindow->title);
 		appWindow->title = title;
 	}

--- a/libfreerdp/core/redirection.c
+++ b/libfreerdp/core/redirection.c
@@ -30,7 +30,7 @@
 
 #define TAG FREERDP_TAG("core.redirection")
 
-void rdp_print_redirection_flags(UINT32 flags)
+static void rdp_print_redirection_flags(UINT32 flags)
 {
 	WLog_DBG(TAG, "redirectionFlags = {");
 
@@ -76,9 +76,10 @@ void rdp_print_redirection_flags(UINT32 flags)
 	WLog_DBG(TAG, "}");
 }
 
-BOOL rdp_redirection_read_string(wStream* s, char** str)
+static BOOL rdp_redirection_read_unicode_string(wStream* s, char** str, size_t maxLength)
 {
 	UINT32 length;
+	WCHAR* wstr = NULL;
 
 	if (Stream_GetRemainingLength(s) < 4)
 	{
@@ -88,13 +89,31 @@ BOOL rdp_redirection_read_string(wStream* s, char** str)
 
 	Stream_Read_UINT32(s, length);
 
-	if (Stream_GetRemainingLength(s) < length)
+	if ((length % 2) || length < 2 || length > maxLength)
 	{
-		WLog_ERR(TAG,  "rdp_redirection_read_string failure: incorrect length %d", length);
+		WLog_ERR(TAG,  "rdp_redirection_read_string failure: invalid unicode string length: %lu", length);
 		return FALSE;
 	}
 
-	ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) Stream_Pointer(s), length / 2, str, 0, NULL, NULL);
+	if (Stream_GetRemainingLength(s) < length)
+	{
+		WLog_ERR(TAG,  "rdp_redirection_read_string failure: insufficient stream length (%lu bytes required)", length);
+		return FALSE;
+	}
+
+	wstr = (WCHAR*) Stream_Pointer(s);
+
+	if (wstr[length / 2 - 1])
+	{
+		WLog_ERR(TAG,  "rdp_redirection_read_string failure: unterminated unicode string");
+		return FALSE;
+	}
+
+	if (ConvertFromUnicode(CP_UTF8, 0, wstr, -1, str, 0, NULL, NULL) < 1)
+	{
+		WLog_ERR(TAG,  "rdp_redirection_read_string failure: string conversion failed");
+		return FALSE;
+	}
 	Stream_Seek(s, length);
 	return TRUE;
 }
@@ -173,7 +192,10 @@ int rdp_redirection_apply_settings(rdpRdp* rdp)
 		/* Password may be a cookie without a null terminator */
 		free(settings->RedirectionPassword);
 		settings->RedirectionPasswordLength = redirection->PasswordLength;
-		settings->RedirectionPassword = (BYTE*) malloc(settings->RedirectionPasswordLength);
+		/* For security reasons we'll allocate an additional zero WCHAR at the
+		 * end of the buffer that is not included in RedirectionPasswordLength
+		 */
+		settings->RedirectionPassword = (BYTE*) calloc(1, settings->RedirectionPasswordLength + sizeof(WCHAR));
 		if (!settings->RedirectionPassword)
 			return -1;
 		CopyMemory(settings->RedirectionPassword, redirection->Password, settings->RedirectionPasswordLength);
@@ -219,7 +241,7 @@ int rdp_redirection_apply_settings(rdpRdp* rdp)
 	return 0;
 }
 
-BOOL rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
+static BOOL rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 {
 	UINT16 flags;
 	UINT16 length;
@@ -238,14 +260,33 @@ BOOL rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 
 	rdp_print_redirection_flags(redirection->flags);
 
+	/* Although MS-RDPBCGR does not mention any length constraints limits for the
+	 * variable length null-terminated unicode strings in the RDP_SERVER_REDIRECTION_PACKET
+	 * structure we will use the following limits in bytes including the null terminator:
+	 *
+	 * TargetNetAddress:     80 bytes
+	 * UserName:            512 bytes
+	 * Domain:               52 bytes
+	 * Password(Cookie):    512 bytes
+	 * TargetFQDN:          512 bytes
+	 * TargetNetBiosName:    32 bytes
+	 */
+
 	if (redirection->flags & LB_TARGET_NET_ADDRESS)
 	{
-		if (!rdp_redirection_read_string(s, &(redirection->TargetNetAddress)))
+		if (!rdp_redirection_read_unicode_string(s, &(redirection->TargetNetAddress), 80))
 			return -1;
 	}
 
 	if (redirection->flags & LB_LOAD_BALANCE_INFO)
 	{
+		/* See [MSFT-SDLBTS] (a.k.a. TS_Session_Directory.doc)
+		 * load balance info example data:
+		 * 0000  43 6f 6f 6b 69 65 3a 20 6d 73 74 73 3d 32 31 33  Cookie: msts=213
+		 * 0010  34 30 32 36 34 33 32 2e 31 35 36 32 39 2e 30 30  4026432.15629.00
+                 * 0020  30 30 0d 0a                                      00..
+		 */
+
 		if (Stream_GetRemainingLength(s) < 4)
 			return -1;
 
@@ -265,7 +306,7 @@ BOOL rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 
 	if (redirection->flags & LB_USERNAME)
 	{
-		if (!rdp_redirection_read_string(s, &(redirection->Username)))
+		if (!rdp_redirection_read_unicode_string(s, &(redirection->Username), 512))
 			return -1;
 
 		WLog_DBG(TAG, "Username: %s", redirection->Username);
@@ -273,7 +314,7 @@ BOOL rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 
 	if (redirection->flags & LB_DOMAIN)
 	{
-		if (!rdp_redirection_read_string(s, &(redirection->Domain)))
+		if (!rdp_redirection_read_unicode_string(s, &(redirection->Domain), 52))
 			return FALSE;
 
 		WLog_DBG(TAG, "Domain: %s", redirection->Domain);
@@ -281,12 +322,45 @@ BOOL rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 
 	if (redirection->flags & LB_PASSWORD)
 	{
-		/* Note: length (hopefully) includes double zero termination */
+		/* Note: Password is a variable-length array of bytes containing the
+		 * password used by the user in Unicode format, including a null-terminator
+		 * or (!) or a cookie value that MUST be passed to the target server on
+		 * successful connection.
+		 * Since the format of the password cookie (probably some salted hash) is
+		 * currently unknown we'll treat it as opaque data. All cookies seen so far
+		 * are 120 bytes including \0\0 termination.
+		 * Here is an observed example of a redirection password cookie:
+		 *
+		 * 0000  02 00 00 80 44 53 48 4c 60 ab 69 2f 07 d6 9e 2d  ....DSHL`.i/...-
+		 * 0010  f0 3a 97 3b a9 c5 ec 7e 66 bd b3 84 6c b1 ef b9  .:.;...~f...l...
+		 * 0020  b6 82 4e cc 3a df 64 b7 7b 25 04 54 c2 58 98 f8  ..N.:.d.{%.T.X..
+		 * 0030  97 87 d4 93 c7 c1 e1 5b c2 85 f8 22 49 1f 81 88  .......[..."I...
+		 * 0040  43 44 83 f6 9a 72 40 24 dc 4d 43 cb d9 92 3c 8f  CD...r@$.MC...<.
+		 * 0050  3a 37 5c 77 13 a0 72 3c 72 08 64 2a 29 fb dc eb  :7\w..r<r.d*)...
+		 * 0060  0d 2b 06 b4 c6 08 b4 73 34 16 93 62 6d 24 e9 93  .+.....s4..bm$..
+		 * 0070  97 27 7b dd 9a 72 00 00                          .'{..r..
+		 *
+		 * Notwithstanding the above, we'll allocated an additional zero WCHAR at the
+		 * end of the buffer which won't get counted in PasswordLength.
+		 */
+
 		if (Stream_GetRemainingLength(s) < 4)
 			return -1;
 
 		Stream_Read_UINT32(s, redirection->PasswordLength);
-		redirection->Password = (BYTE*) malloc(redirection->PasswordLength);
+
+		/* [MS-RDPBCGR] specifies 512 bytes as the upper limit for the password length
+		 * including the null terminatior(s). This should also be enough for the unknown
+		 * password cookie format (see previous comment).
+		 */
+
+		if (Stream_GetRemainingLength(s) < redirection->PasswordLength)
+			return -1;
+
+		if (redirection->PasswordLength > 512)
+			return -1;
+
+		redirection->Password = (BYTE*) calloc(1, redirection->PasswordLength + sizeof(WCHAR));
 		if (!redirection->Password)
 			return -1;
 		Stream_Read(s, redirection->Password, redirection->PasswordLength);
@@ -297,7 +371,7 @@ BOOL rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 
 	if (redirection->flags & LB_TARGET_FQDN)
 	{
-		if (!rdp_redirection_read_string(s, &(redirection->TargetFQDN)))
+		if (!rdp_redirection_read_unicode_string(s, &(redirection->TargetFQDN), 512))
 			return -1;
 
 		WLog_DBG(TAG, "TargetFQDN: %s", redirection->TargetFQDN);
@@ -305,7 +379,7 @@ BOOL rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 
 	if (redirection->flags & LB_TARGET_NETBIOS_NAME)
 	{
-		if (!rdp_redirection_read_string(s, &(redirection->TargetNetBiosName)))
+		if (!rdp_redirection_read_unicode_string(s, &(redirection->TargetNetBiosName), 32))
 			return -1;
 
 		WLog_DBG(TAG, "TargetNetBiosName: %s", redirection->TargetNetBiosName);
@@ -352,7 +426,7 @@ BOOL rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 
 		for (i = 0; i < (int) count; i++)
 		{
-			if (!rdp_redirection_read_string(s, &(redirection->TargetNetAddresses[i])))
+			if (!rdp_redirection_read_unicode_string(s, &(redirection->TargetNetAddresses[i]), 80))
 				return FALSE;
 
 			WLog_DBG(TAG, "TargetNetAddresses[%d]: %s", i, redirection->TargetNetAddresses[i]);
@@ -369,13 +443,6 @@ BOOL rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 		return 0;
 
 	return 1;
-}
-
-int rdp_recv_redirection_packet(rdpRdp* rdp, wStream* s)
-{
-	int status = 0;
-	status = rdp_recv_server_redirection_pdu(rdp, s);
-	return status;
 }
 
 int rdp_recv_enhanced_security_redirection_packet(rdpRdp* rdp, wStream* s)

--- a/libfreerdp/core/window.c
+++ b/libfreerdp/core/window.c
@@ -371,6 +371,7 @@ BOOL update_recv_window_info_order(rdpUpdate* update, wStream* s, WINDOW_ORDER_I
 {
 	rdpContext* context = update->context;
 	rdpWindowUpdate* window = update->window;
+	BOOL result = TRUE;
 
 	if (Stream_GetRemainingLength(s) < 4)
 		return FALSE;
@@ -382,20 +383,20 @@ BOOL update_recv_window_info_order(rdpUpdate* update, wStream* s, WINDOW_ORDER_I
 		if (!update_read_window_icon_order(s, orderInfo, &window->window_icon))
 			return FALSE;
 		WLog_Print(update->log, WLOG_DEBUG, "WindowIcon");
-		IFCALL(window->WindowIcon, context, orderInfo, &window->window_icon);
+		IFCALLRET(window->WindowIcon, result, context, orderInfo, &window->window_icon);
 	}
 	else if (orderInfo->fieldFlags & WINDOW_ORDER_CACHED_ICON)
 	{
 		if (!update_read_window_cached_icon_order(s, orderInfo, &window->window_cached_icon))
 			return FALSE;
 		WLog_Print(update->log, WLOG_DEBUG, "WindowCachedIcon");
-		IFCALL(window->WindowCachedIcon, context, orderInfo, &window->window_cached_icon);
+		IFCALLRET(window->WindowCachedIcon, result, context, orderInfo, &window->window_cached_icon);
 	}
 	else if (orderInfo->fieldFlags & WINDOW_ORDER_STATE_DELETED)
 	{
 		update_read_window_delete_order(s, orderInfo);
 		WLog_Print(update->log, WLOG_DEBUG, "WindowDelete");
-		IFCALL(window->WindowDelete, context, orderInfo);
+		IFCALLRET(window->WindowDelete, result, context, orderInfo);
 	}
 	else
 	{
@@ -405,16 +406,16 @@ BOOL update_recv_window_info_order(rdpUpdate* update, wStream* s, WINDOW_ORDER_I
 		if (orderInfo->fieldFlags & WINDOW_ORDER_STATE_NEW)
 		{
 			WLog_Print(update->log, WLOG_DEBUG, "WindowCreate");
-			IFCALL(window->WindowCreate, context, orderInfo, &window->window_state);
+			IFCALLRET(window->WindowCreate, result, context, orderInfo, &window->window_state);
 		}
 		else
 		{
 			WLog_Print(update->log, WLOG_DEBUG, "WindowUpdate");
-			IFCALL(window->WindowUpdate, context, orderInfo, &window->window_state);
+			IFCALLRET(window->WindowUpdate, result, context, orderInfo, &window->window_state);
 		}
 	}
 
-	return TRUE;
+	return result;
 }
 
 BOOL update_read_notification_icon_state_order(wStream* s, WINDOW_ORDER_INFO* orderInfo, NOTIFY_ICON_STATE_ORDER* notify_icon_state)
@@ -470,6 +471,7 @@ BOOL update_recv_notification_icon_info_order(rdpUpdate* update, wStream* s, WIN
 {
 	rdpContext* context = update->context;
 	rdpWindowUpdate* window = update->window;
+	BOOL result = TRUE;
 
 	if (Stream_GetRemainingLength(s) < 8)
 		return FALSE;
@@ -481,7 +483,7 @@ BOOL update_recv_notification_icon_info_order(rdpUpdate* update, wStream* s, WIN
 	{
 		update_read_notification_icon_delete_order(s, orderInfo);
 		WLog_Print(update->log, WLOG_DEBUG, "NotifyIconDelete");
-		IFCALL(window->NotifyIconDelete, context, orderInfo);
+		IFCALLRET(window->NotifyIconDelete, result, context, orderInfo);
 	}
 	else
 	{
@@ -491,16 +493,16 @@ BOOL update_recv_notification_icon_info_order(rdpUpdate* update, wStream* s, WIN
 		if (orderInfo->fieldFlags & WINDOW_ORDER_STATE_NEW)
 		{
 			WLog_Print(update->log, WLOG_DEBUG, "NotifyIconCreate");
-			IFCALL(window->NotifyIconCreate, context, orderInfo, &window->notify_icon_state);
+			IFCALLRET(window->NotifyIconCreate, result, context, orderInfo, &window->notify_icon_state);
 		}
 		else
 		{
 			WLog_Print(update->log, WLOG_DEBUG, "NotifyIconUpdate");
-			IFCALL(window->NotifyIconUpdate, context, orderInfo, &window->notify_icon_state);
+			IFCALLRET(window->NotifyIconUpdate, result, context, orderInfo, &window->notify_icon_state);
 		}
 	}
 
-	return TRUE;
+	return result;
 }
 
 BOOL update_read_desktop_actively_monitored_order(wStream* s, WINDOW_ORDER_INFO* orderInfo, MONITORED_DESKTOP_ORDER* monitored_desktop)
@@ -560,22 +562,23 @@ BOOL update_recv_desktop_info_order(rdpUpdate* update, wStream* s, WINDOW_ORDER_
 {
 	rdpContext* context = update->context;
 	rdpWindowUpdate* window = update->window;
+	BOOL result = TRUE;
 
 	if (orderInfo->fieldFlags & WINDOW_ORDER_FIELD_DESKTOP_NONE)
 	{
 		update_read_desktop_non_monitored_order(s, orderInfo);
 		WLog_Print(update->log, WLOG_DEBUG, "NonMonitoredDesktop");
-		IFCALL(window->NonMonitoredDesktop, context, orderInfo);
+		IFCALLRET(window->NonMonitoredDesktop, result, context, orderInfo);
 	}
 	else
 	{
 		if (!update_read_desktop_actively_monitored_order(s, orderInfo, &window->monitored_desktop))
 			return FALSE;
 		WLog_Print(update->log, WLOG_DEBUG, "ActivelyMonitoredDesktop");
-		IFCALL(window->MonitoredDesktop, context, orderInfo, &window->monitored_desktop);
+		IFCALLRET(window->MonitoredDesktop, result, context, orderInfo, &window->monitored_desktop);
 	}
 
-	return TRUE;
+	return result;
 }
 
 BOOL update_recv_altsec_window_order(rdpUpdate* update, wStream* s)

--- a/server/shadow/Win/win_wds.c
+++ b/server/shadow/Win/win_wds.c
@@ -744,7 +744,7 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 		return -1;
 	}
 
-	subsystem->pInvitation->lpVtbl->get_ConnectionString(subsystem->pInvitation, &bstrConnectionString);
+	hr = subsystem->pInvitation->lpVtbl->get_ConnectionString(subsystem->pInvitation, &bstrConnectionString);
 
 	if (FAILED(hr))
 	{
@@ -752,10 +752,24 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 		return -1;
 	}
 
+	status = ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) bstrConnectionString,
+		((UINT32*) bstrConnectionString)[-1], &(file->ConnectionString2), 0, NULL, NULL);
+
+	SysFreeString(bstrConnectionString);
+
+	if (status < 1)
+	{
+		WLog_ERR(TAG, "failed to convert connection string");
+		return -1;
+	}
+
 	file = subsystem->pAssistanceFile = freerdp_assistance_file_new();
 
-	ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) bstrConnectionString,
-		((UINT32*) bstrConnectionString)[-1], &(file->ConnectionString2), 0, NULL, NULL);
+	if (!file)
+	{
+		WLog_ERR(TAG, "freerdp_assistance_file_new() failed");
+		return -1;
+	}
 
 	status = freerdp_assistance_parse_connection_string2(file);
 

--- a/winpr/libwinpr/crt/unicode.c
+++ b/winpr/libwinpr/crt/unicode.c
@@ -276,6 +276,19 @@ int WideCharToMultiByte(UINT CodePage, DWORD dwFlags, LPCWSTR lpWideCharStr, int
 
 #endif
 
+/**
+ * ConvertToUnicode is a convenience wrapper for MultiByteToWideChar:
+ *
+ * If the lpWideCharStr prarameter for the converted string points to NULL
+ * or if the cchWideChar parameter is set to 0 this function will automatically
+ * allocate the required memory which is guaranteed to be null-terminated
+ * after the conversion, even if the source c string isn't.
+ *
+ * If the cbMultiByte parameter is set to -1 the passed lpMultiByteStr must
+ * be null-terminated and the required length for the converted string will be
+ * calculated accordingly.
+ */
+
 int ConvertToUnicode(UINT CodePage, DWORD dwFlags, LPCSTR lpMultiByteStr,
 		int cbMultiByte, LPWSTR* lpWideCharStr, int cchWideChar)
 {
@@ -305,7 +318,7 @@ int ConvertToUnicode(UINT CodePage, DWORD dwFlags, LPCSTR lpMultiByteStr,
 
 	if (allocate)
 	{
-		*lpWideCharStr = (LPWSTR) calloc(cchWideChar, sizeof(WCHAR));
+		*lpWideCharStr = (LPWSTR) calloc(cchWideChar + 1, sizeof(WCHAR));
 
 		if (!(*lpWideCharStr))
 		{
@@ -317,10 +330,30 @@ int ConvertToUnicode(UINT CodePage, DWORD dwFlags, LPCSTR lpMultiByteStr,
 	status = MultiByteToWideChar(CodePage, dwFlags, lpMultiByteStr, cbMultiByte, *lpWideCharStr, cchWideChar);
 
 	if (status != cchWideChar)
+	{
+		if (allocate)
+		{
+			free(*lpWideCharStr);
+			*lpWideCharStr = NULL;
+		}
 		status = 0;
+	}
 
 	return status;
 }
+
+/**
+ * ConvertFromUnicode is a convenience wrapper for WideCharToMultiByte:
+ *
+ * If the lpMultiByteStr parameter for the converted string points to NULL
+ * or if the cbMultiByte parameter is set to 0 this function will automatically
+ * allocate the required memory which is guaranteed to be null-terminated
+ * after the conversion, even if the source unicode string isn't.
+ *
+ * If the cchWideChar parameter is set to -1 the passed lpWideCharStr must
+ * be null-terminated and the required length for the converted string will be
+ * calculated accordingly.
+ */
 
 int ConvertFromUnicode(UINT CodePage, DWORD dwFlags, LPCWSTR lpWideCharStr, int cchWideChar,
 		LPSTR* lpMultiByteStr, int cbMultiByte, LPCSTR lpDefaultChar, LPBOOL lpUsedDefaultChar)

--- a/winpr/libwinpr/file/generic.c
+++ b/winpr/libwinpr/file/generic.c
@@ -274,7 +274,7 @@ HANDLE CreateFileW(LPCWSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode,
 	LPSTR lpFileNameA = NULL;
 	HANDLE hdl;
 
-	if (ConvertFromUnicode(CP_UTF8, 0, lpFileName, -1, &lpFileNameA, 0, NULL, NULL))
+	if (ConvertFromUnicode(CP_UTF8, 0, lpFileName, -1, &lpFileNameA, 0, NULL, NULL) < 1)
 		return NULL;
 
 	hdl= CreateFileA(lpFileNameA, dwDesiredAccess, dwShareMode, lpSecurityAttributes,
@@ -296,7 +296,7 @@ BOOL DeleteFileW(LPCWSTR lpFileName)
 	LPSTR lpFileNameA = NULL;
 	BOOL rc = FALSE;
 
-	if (ConvertFromUnicode(CP_UTF8, 0, lpFileName, -1, &lpFileNameA, 0, NULL, NULL))
+	if (ConvertFromUnicode(CP_UTF8, 0, lpFileName, -1, &lpFileNameA, 0, NULL, NULL) < 1)
 		return FALSE;
 	rc = DeleteFileA(lpFileNameA);
 	free (lpFileNameA);


### PR DESCRIPTION
- Added missing ConvertFromUnicode checks
- If ConvertToUnicode allocates memory, guarantee the null termination similar to ConvertFromUnicode's implementation
- Fixed some TestUnicodeConversion.c CTest return values
- Added some CTests for ConvertFromUnicode and ConvertToUnicode
- Misc code and protocol hardening fixes in the surrounding code regions
  that have been touched