### PR TITLE
Rdp file preference fix

### DIFF
--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -317,7 +317,7 @@ int main(int argc, char* argv[])
 
 	freerdp_context_new(instance);
 
-	status = freerdp_client_settings_parse_command_line_arguments(instance->settings, argc, argv, FALSE);
+	status = freerdp_client_settings_parse_command_line(instance->settings, argc, argv, FALSE);
 
 	status = freerdp_client_settings_command_line_status_print(instance->settings, status, argc, argv);
 

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -224,19 +224,6 @@ BOOL wf_pre_connect(freerdp* instance)
 
 	settings = instance->settings;
 
-	if (settings->ConnectionFile)
-	{
-		if (wfc->connectionRdpFile)
-		{
-			freerdp_client_rdp_file_free(wfc->connectionRdpFile);
-		}
-
-		wfc->connectionRdpFile = freerdp_client_rdp_file_new();
-		WLog_INFO(TAG,  "Using connection file: %s", settings->ConnectionFile);
-		freerdp_client_parse_rdp_file(wfc->connectionRdpFile, settings->ConnectionFile);
-		freerdp_client_populate_settings_from_rdp_file(wfc->connectionRdpFile, settings);
-	}
-
 	settings->OsMajorType = OSMAJORTYPE_WINDOWS;
 	settings->OsMinorType = OSMINORTYPE_WINDOWS_NT;
 	settings->OrderSupport[NEG_DSTBLT_INDEX] = TRUE;
@@ -917,40 +904,6 @@ int freerdp_client_set_window_size(wfContext* wfc, int width, int height)
 	if ((width != wfc->client_width) || (height != wfc->client_height))
 	{
 		PostThreadMessage(wfc->mainThreadId, WM_SIZE, SIZE_RESTORED, ((UINT) height << 16) | (UINT) width);
-	}
-
-	return 0;
-}
-
-// TODO: Some of that code is a duplicate of wf_pre_connect. Refactor?
-int freerdp_client_load_settings_from_rdp_file(wfContext* wfc, char* filename)
-{
-	rdpSettings* settings;
-
-	settings = wfc->instance->settings;
-
-	if (filename)
-	{
-		settings->ConnectionFile = _strdup(filename);
-		if (!settings->ConnectionFile)
-		{
-			return 3;
-		}
-
-		// free old settings file
-		freerdp_client_rdp_file_free(wfc->connectionRdpFile);
-		wfc->connectionRdpFile = freerdp_client_rdp_file_new();
-		WLog_INFO(TAG,  "Using connection file: %s", settings->ConnectionFile);
-
-		if (!freerdp_client_parse_rdp_file(wfc->connectionRdpFile, settings->ConnectionFile))
-		{
-			return 1;
-		}
-
-		if (!freerdp_client_populate_settings_from_rdp_file(wfc->connectionRdpFile, settings))
-		{
-			return 2;
-		}
 	}
 
 	return 0;

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -196,14 +196,19 @@ int freerdp_client_settings_parse_command_line(rdpSettings* settings, int argc,
 	status = freerdp_client_settings_parse_command_line_arguments(settings, argc, argv, allowUnknown);
 
 	if (settings->ConnectionFile)
-	{
 		status = freerdp_client_settings_parse_connection_file(settings, settings->ConnectionFile);
-	}
 
 	if (settings->AssistanceFile)
-	{
 		status = freerdp_client_settings_parse_assistance_file(settings, settings->AssistanceFile);
-	}
+
+	if (status < 0)
+		return status;
+
+	/* In case settings have been populated from a RDP or assistance file
+	 * reparse the command line to give priotiry to command line for concurring settings.
+	 */
+	if (settings->ConnectionFile || settings->AssistanceFile)
+		status = freerdp_client_settings_parse_command_line_arguments(settings, argc, argv, allowUnknown);
 
 	/* Only call post processing if no status/error was returned*/
 	if (status < 0)

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -195,22 +195,6 @@ int freerdp_client_settings_parse_command_line(rdpSettings* settings, int argc,
 
 	status = freerdp_client_settings_parse_command_line_arguments(settings, argc, argv, allowUnknown);
 
-	if (settings->ConnectionFile)
-		status = freerdp_client_settings_parse_connection_file(settings, settings->ConnectionFile);
-
-	if (settings->AssistanceFile)
-		status = freerdp_client_settings_parse_assistance_file(settings, settings->AssistanceFile);
-
-	if (status < 0)
-		return status;
-
-	/* In case settings have been populated from a RDP or assistance file
-	 * reparse the command line to give priotiry to command line for concurring settings.
-	 */
-	if (settings->ConnectionFile || settings->AssistanceFile)
-		status = freerdp_client_settings_parse_command_line_arguments(settings, argc, argv, allowUnknown);
-
-	/* Only call post processing if no status/error was returned*/
 	if (status < 0)
 		return status;
 

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1474,6 +1474,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 				CommandLineSwitchCase(arg, "v")
 		{
+			free (settings->ServerHostname);
 			p = strchr(arg->Value, '[');
 			/* ipv4 */
 			if (!p)
@@ -1515,6 +1516,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "spn-class")
 		{
+			free (settings->AuthenticationServiceClass);
 			if (!(settings->AuthenticationServiceClass = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 
@@ -1531,6 +1533,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 			if (arg->Flags & COMMAND_LINE_VALUE_PRESENT)
 			{
 				settings->SendPreconnectionPdu = TRUE;
+				free (settings->PreconnectionBlob);
 				if (!(settings->PreconnectionBlob = _strdup(arg->Value)))
 					return COMMAND_LINE_ERROR_MEMORY;
 			}
@@ -1622,6 +1625,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "t")
 		{
+			free (settings->WindowTitle);
 			if (!(settings->WindowTitle = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
@@ -1663,11 +1667,13 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		{
 			settings->ConsoleSession = TRUE;
 			settings->RestrictedAdminModeRequired = TRUE;
+			free (settings->PasswordHash);
 			if (!(settings->PasswordHash = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
 		CommandLineSwitchCase(arg, "client-hostname")
 		{
+			free (settings->ClientHostname);
 			if (!(settings->ClientHostname = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
@@ -1715,16 +1721,19 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "d")
 		{
+			free (settings->Domain);
 			if (!(settings->Domain = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
 		CommandLineSwitchCase(arg, "p")
 		{
+			free (settings->Password);
 			if (!(settings->Password = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
 		CommandLineSwitchCase(arg, "g")
 		{
+			free (settings->GatewayHostname);
 			if (arg->Flags & COMMAND_LINE_VALUE_PRESENT)
 			{
 				p = strchr(arg->Value, ':');
@@ -1764,12 +1773,14 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "gd")
 		{
+			free (settings->GatewayDomain);
 			if (!(settings->GatewayDomain = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 			settings->GatewayUseSameCredentials = FALSE;
 		}
 		CommandLineSwitchCase(arg, "gp")
 		{
+			free (settings->GatewayPassword);
 			if (!(settings->GatewayPassword = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 			settings->GatewayUseSameCredentials = FALSE;
@@ -1815,6 +1826,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "app")
 		{
+			free (settings->RemoteApplicationProgram);
 			if (!(settings->RemoteApplicationProgram = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 
@@ -1826,33 +1838,39 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "load-balance-info")
 		{
+			free (settings->LoadBalanceInfo);
 			if (!(settings->LoadBalanceInfo = (BYTE*) _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 			settings->LoadBalanceInfoLength = (UINT32) strlen((char*) settings->LoadBalanceInfo);
 		}
 		CommandLineSwitchCase(arg, "app-name")
 		{
+			free (settings->RemoteApplicationName);
 			if (!(settings->RemoteApplicationName = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 
 		}
 		CommandLineSwitchCase(arg, "app-icon")
 		{
+			free (settings->RemoteApplicationIcon);
 			if (!(settings->RemoteApplicationIcon = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
 		CommandLineSwitchCase(arg, "app-cmd")
 		{
+			free (settings->RemoteApplicationCmdLine);
 			if (!(settings->RemoteApplicationCmdLine = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
 		CommandLineSwitchCase(arg, "app-file")
 		{
+			free (settings->RemoteApplicationFile);
 			if (!(settings->RemoteApplicationFile = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
 		CommandLineSwitchCase(arg, "app-guid")
 		{
+			free (settings->RemoteApplicationGuid);
 			if (!(settings->RemoteApplicationGuid = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
@@ -1878,11 +1896,13 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "shell")
 		{
+			free (settings->AlternateShell);
 			if (!(settings->AlternateShell = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
 		CommandLineSwitchCase(arg, "shell-dir")
 		{
+			free (settings->ShellWorkingDirectory);
 			if (!(settings->ShellWorkingDirectory = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
@@ -2037,6 +2057,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		CommandLineSwitchCase(arg, "pcb")
 		{
 			settings->SendPreconnectionPdu = TRUE;
+			free (settings->PreconnectionBlob);
 			if (!(settings->PreconnectionBlob = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
@@ -2141,6 +2162,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "tls-ciphers")
 		{
+			free (settings->AllowedTlsCiphers);
 			if (strcmp(arg->Value, "netmon") == 0)
 			{
 				if (!(settings->AllowedTlsCiphers = _strdup("ALL:!ECDH")))
@@ -2159,6 +2181,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "cert-name")
 		{
+			free (settings->CertificateName);
 			if (!(settings->CertificateName = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
@@ -2253,11 +2276,13 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "wm-class")
 		{
+			free (settings->WmClass);
 			if (!(settings->WmClass = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
 		CommandLineSwitchCase(arg, "play-rfx")
 		{
+			free (settings->PlayRemoteFxFile);
 			if (!(settings->PlayRemoteFxFile = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 			settings->PlayRemoteFx = TRUE;
@@ -2293,6 +2318,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		CommandLineSwitchCase(arg, "assistance")
 		{
 			settings->RemoteAssistanceMode = TRUE;
+			free (settings->RemoteAssistancePassword);
 			if (!(settings->RemoteAssistancePassword = _strdup(arg->Value)))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
@@ -2353,9 +2379,12 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 	}
 	while ((arg = CommandLineFindNextArgumentA(arg)) != NULL);
 
+	free (settings->Username);
 	if (!settings->Domain && user)
 	{
 		BOOL ret;
+		free (settings->Domain);
+
 		ret = freerdp_parse_username(user, &settings->Username, &settings->Domain);
 		free(user);
 		if (!ret)
@@ -2364,9 +2393,11 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 	else
 		settings->Username = user;
 
+	free (settings->GatewayUsername);
 	if (!settings->GatewayDomain && gwUser)
 	{
 		BOOL ret;
+		free (settings->GatewayDomain);
 		ret = freerdp_parse_username(gwUser, &settings->GatewayUsername,
 					     &settings->GatewayDomain);
 		free(gwUser);

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1475,6 +1475,8 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 				CommandLineSwitchCase(arg, "v")
 		{
 			free (settings->ServerHostname);
+			settings->ServerHostname = NULL;
+
 			p = strchr(arg->Value, '[');
 			/* ipv4 */
 			if (!p)

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -321,6 +321,9 @@ static int freerdp_client_command_line_pre_filter(void* context, int index, int 
 				if (!(settings->ConnectionFile = _strdup(argv[index])))
 					return COMMAND_LINE_ERROR_MEMORY;
 
+				if (freerdp_client_settings_parse_connection_file(settings, settings->ConnectionFile))
+					return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
+
 				return 1;
 			}
 		}
@@ -332,6 +335,9 @@ static int freerdp_client_command_line_pre_filter(void* context, int index, int 
 				settings = (rdpSettings*) context;
 				if (!(settings->AssistanceFile = _strdup(argv[index])))
 					return COMMAND_LINE_ERROR_MEMORY;
+
+				if (freerdp_client_settings_parse_assistance_file(settings, settings->AssistanceFile) < 0)
+					return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 
 				return 1;
 			}


### PR DESCRIPTION
* Fixes #2810, #3199 

When using a RDP or assistance file the command line was overwritten by the values from the file.
This pull fixes that by reparsing the command line and replacing the defaults set by the file parser with the command line values.