### PR TITLE
audin: Fixed default sys argument for audin

### DIFF
--- a/channels/audin/client/audin_main.c
+++ b/channels/audin/client/audin_main.c
@@ -721,6 +721,11 @@ BOOL audin_process_addin_args(AUDIN_PLUGIN* audin, ADDIN_ARGV* args)
 	COMMAND_LINE_ARGUMENT_A* arg;
 	UINT error;
 
+	if (args->argc == 1)
+	{
+		return TRUE;
+	}
+
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
 
 	status = CommandLineParseArgumentsA(args->argc, (const char**) args->argv,


### PR DESCRIPTION
PR #3173 fixed argument parsing. However it breaks the usage without specifying subsystem: "/microphone"
In particular, aFreerdp microphone redirect is broken as it exactly uses "/microphone"
This PR fixes the regression.
Fix: We should not call CommandLineParseArgumentsA if argc is only 1 (same case as rdpsnd_main.c)