### PR TITLE
Small Drive fixes

### DIFF
--- a/channels/drive/client/drive_file.c
+++ b/channels/drive/client/drive_file.c
@@ -595,7 +595,7 @@ BOOL drive_file_set_information(DRIVE_FILE* file, UINT32 FsInformationClass, UIN
 				return FALSE;
 			}
 			liSize.QuadPart = size;
-			if (SetFilePointerEx(hFd, liSize, NULL, FILE_BEGIN) == 0)
+			if (SetFilePointer(hFd, liSize.LowPart, &liSize.HighPart, FILE_BEGIN) == 0)
 			{
 				WLog_ERR(TAG, "Unable to truncate %s to %d", file->fullpath, size);
 				CloseHandle(hFd);

--- a/channels/rdpdr/client/devman.c
+++ b/channels/rdpdr/client/devman.c
@@ -173,7 +173,10 @@ UINT devman_load_device_service(DEVMAN* devman, RDPDR_DEVICE* device, rdpContext
 		return ERROR_INVALID_NAME;
 	}
 
-	WLog_INFO(TAG,  "Loading device service %s (static)", ServiceName);
+	if (device->Name)
+		WLog_INFO(TAG,  "Loading device service %s [%s] (static)", ServiceName, device->Name);
+	else
+		WLog_INFO(TAG,  "Loading device service %s (static)", ServiceName);
 	entry = (PDEVICE_SERVICE_ENTRY) freerdp_load_channel_addin_entry(ServiceName, NULL, "DeviceServiceEntry", 0);
 
 	if (!entry)


### PR DESCRIPTION
* Use ```SetFilePointer``` instead of unimplemented ```SetFilePointerEx```
* Pretty print channel loading.