### PR TITLE
Endianness fixes

### DIFF
--- a/libfreerdp/codec/xcrush.c
+++ b/libfreerdp/codec/xcrush.c
@@ -725,7 +725,7 @@ int xcrush_decompress_l1(XCRUSH_CONTEXT* xcrush, BYTE* pSrcData, UINT32 SrcSize,
 		if ((pSrcData + 2) > pSrcEnd)
 			return -1003;
 
-		MatchCount = *((UINT16*) pSrcData);
+		Data_Read_UINT16(pSrcData, MatchCount);
 
 		MatchDetails = (RDP61_MATCH_DETAILS*) &pSrcData[2];
 		Literals = (BYTE*) &MatchDetails[MatchCount];
@@ -736,9 +736,9 @@ int xcrush_decompress_l1(XCRUSH_CONTEXT* xcrush, BYTE* pSrcData, UINT32 SrcSize,
 
 		for (MatchIndex = 0; MatchIndex < MatchCount; MatchIndex++)
 		{
-			MatchLength = MatchDetails[MatchIndex].MatchLength;
-			MatchOutputOffset = MatchDetails[MatchIndex].MatchOutputOffset;
-			MatchHistoryOffset = MatchDetails[MatchIndex].MatchHistoryOffset;
+			Data_Read_UINT16(&MatchDetails[MatchIndex].MatchLength, MatchLength);
+			Data_Read_UINT16(&MatchDetails[MatchIndex].MatchOutputOffset, MatchOutputOffset);
+			Data_Read_UINT32(&MatchDetails[MatchIndex].MatchHistoryOffset, MatchHistoryOffset);
 
 			if (MatchOutputOffset < OutputOffset)
 				return -1005;

--- a/winpr/include/winpr/endian.h
+++ b/winpr/include/winpr/endian.h
@@ -29,53 +29,53 @@ extern "C" {
 #endif
 
 #define Data_Read_UINT8_NE(_d, _v) do { _v = \
-	*_d; } while (0)
+	*((BYTE*) _d); } while (0)
 
 #define Data_Read_UINT8(_d, _v) do { _v = \
-	*_d; } while (0)
+	*((BYTE*) _d); } while (0)
 
 #define Data_Read_UINT16_NE(_d, _v) do { _v = \
 	*((UINT16*) _d); } while (0)
 
 #define Data_Read_UINT16(_d, _v) do { _v = \
-	(UINT16)(*_d) + \
-	(((UINT16)(*(_d + 1))) << 8); \
+	(UINT16)(*((BYTE*) _d)) + \
+	(((UINT16)(*((BYTE*) _d + 1))) << 8); \
 	} while (0)
 
 #define Data_Read_UINT16_BE(_d, _v) do { _v = \
-	(((UINT16)(*_d)) << 8) + \
-	(UINT16)(*(_d + 1)); \
+	(((UINT16)(*(BYTE*) _d)) << 8) + \
+	(UINT16)(*((BYTE*) _d + 1)); \
 	} while (0)
 
 #define Data_Read_UINT32_NE(_d, _v) do { _v = \
 	*((UINT32*) _d); } while (0)
 
 #define Data_Read_UINT32(_d, _v) do { _v = \
-	(UINT32)(*_d) + \
-	(((UINT32)(*(_d + 1))) << 8) + \
-	(((UINT32)(*(_d + 2))) << 16) + \
-	(((UINT32)(*(_d + 3))) << 24); \
+	(UINT32)(*((BYTE*) _d)) + \
+	(((UINT32)(*((BYTE*) _d + 1))) << 8) + \
+	(((UINT32)(*((BYTE*) _d + 2))) << 16) + \
+	(((UINT32)(*((BYTE*) _d + 3))) << 24); \
 	} while (0)
 
 #define Data_Read_UINT32_BE(_d, _v) do { _v = \
-	(((UINT32)(*(_d))) << 24) + \
-	(((UINT32)(*(_d + 1))) << 16) + \
-	(((UINT32)(*(_d + 2))) << 8) + \
-	(((UINT32)(*(_d + 3)))); \
+	(((UINT32)(*((BYTE*) _d))) << 24) + \
+	(((UINT32)(*((BYTE*) _d + 1))) << 16) + \
+	(((UINT32)(*((BYTE*) _d + 2))) << 8) + \
+	(((UINT32)(*((BYTE*) _d + 3)))); \
 	} while (0)
 
 #define Data_Read_UINT64_NE(_d, _v) do { _v = \
 	*((UINT64*) _d); } while (0)
 
 #define Data_Read_UINT64(_d, _v) do { _v = \
-	(UINT64)(*_d) + \
-	(((UINT64)(*(_d + 1))) << 8) + \
-	(((UINT64)(*(_d + 2))) << 16) + \
-	(((UINT64)(*(_d + 3))) << 24) + \
-	(((UINT64)(*(_d + 4))) << 32) + \
-	(((UINT64)(*(_d + 5))) << 40) + \
-	(((UINT64)(*(_d + 6))) << 48) + \
-	(((UINT64)(*(_d + 7))) << 56); \
+	(UINT64)(*((BYTE*) _d)) + \
+	(((UINT64)(*((BYTE*) _d + 1))) << 8) + \
+	(((UINT64)(*((BYTE*) _d + 2))) << 16) + \
+	(((UINT64)(*((BYTE*) _d + 3))) << 24) + \
+	(((UINT64)(*((BYTE*) _d + 4))) << 32) + \
+	(((UINT64)(*((BYTE*) _d + 5))) << 40) + \
+	(((UINT64)(*((BYTE*) _d + 6))) << 48) + \
+	(((UINT64)(*((BYTE*) _d + 7))) << 56); \
 	} while (0)
 
 #define Data_Write_UINT8_NE(_d, _v) do { \
@@ -88,42 +88,42 @@ extern "C" {
 	*((UINT16*) _d) = _v; } while (0)
 
 #define Data_Write_UINT16(_d, _v) do { \
-	*(_d) = (_v) & 0xFF; \
-	*(_d + 1) = ((_v) >> 8) & 0xFF; \
+	*((BYTE*) _d) = (_v) & 0xFF; \
+	*((BYTE*) _d + 1) = ((_v) >> 8) & 0xFF; \
 	} while (0)
 
 #define Data_Write_UINT16_BE(_d, _v) do { \
-	*(_d) = ((_v) >> 8) & 0xFF; \
-	*(_d + 1) = (_v) & 0xFF; \
+	*((BYTE*) _d) = ((_v) >> 8) & 0xFF; \
+	*((BYTE*) _d + 1) = (_v) & 0xFF; \
 	} while (0)
 
 #define Data_Write_UINT32_NE(_d, _v) do { \
 	*((UINT32*) _d) = _v; } while (0)
 
 #define Data_Write_UINT32(_d, _v) do { \
-	*(_d) = (_v) & 0xFF; \
-	*(_d + 1) = ((_v) >> 8) & 0xFF; \
-	*(_d + 2) = ((_v) >> 16) & 0xFF; \
-	*(_d + 3) = ((_v) >> 24) & 0xFF; \
+	*((BYTE*) _d) = (_v) & 0xFF; \
+	*((BYTE*) _d + 1) = ((_v) >> 8) & 0xFF; \
+	*((BYTE*) _d + 2) = ((_v) >> 16) & 0xFF; \
+	*((BYTE*) _d + 3) = ((_v) >> 24) & 0xFF; \
 	} while (0)
 
 #define Data_Write_UINT32_BE(_d, _v) do { \
-	Data_Write_UINT16_BE(_d, ((_v) >> 16 & 0xFFFF)); \
-	Data_Write_UINT16_BE(_d + 2, ((_v) & 0xFFFF)); \
+	Data_Write_UINT16_BE((BYTE*) _d, ((_v) >> 16 & 0xFFFF)); \
+	Data_Write_UINT16_BE((BYTE*) _d + 2, ((_v) & 0xFFFF)); \
 	} while (0)
 
 #define Data_Write_UINT64_NE(_d, _v) do { \
 	*((UINT64*) _d) = _v; } while (0)
 
 #define Data_Write_UINT64(_d, _v) do { \
-	*(_d) = (UINT64)(_v) & 0xFF; \
-	*(_d + 1) = ((UINT64)(_v) >> 8) & 0xFF; \
-	*(_d + 2) = ((UINT64)(_v) >> 16) & 0xFF; \
-	*(_d + 3) = ((UINT64)(_v) >> 24) & 0xFF; \
-	*(_d + 4) = ((UINT64)(_v) >> 32) & 0xFF; \
-	*(_d + 5) = ((UINT64)(_v) >> 40) & 0xFF; \
-	*(_d + 6) = ((UINT64)(_v) >> 48) & 0xFF; \
-	*(_d + 7) = ((UINT64)(_v) >> 56) & 0xFF; \
+	*((BYTE*) _d) = (UINT64)(_v) & 0xFF; \
+	*((BYTE*) _d + 1) = ((UINT64)(_v) >> 8) & 0xFF; \
+	*((BYTE*) _d + 2) = ((UINT64)(_v) >> 16) & 0xFF; \
+	*((BYTE*) _d + 3) = ((UINT64)(_v) >> 24) & 0xFF; \
+	*((BYTE*) _d + 4) = ((UINT64)(_v) >> 32) & 0xFF; \
+	*((BYTE*) _d + 5) = ((UINT64)(_v) >> 40) & 0xFF; \
+	*((BYTE*) _d + 6) = ((UINT64)(_v) >> 48) & 0xFF; \
+	*((BYTE*) _d + 7) = ((UINT64)(_v) >> 56) & 0xFF; \
 	} while (0)
 
 #ifdef __cplusplus

--- a/winpr/include/winpr/endian.h
+++ b/winpr/include/winpr/endian.h
@@ -39,7 +39,7 @@ extern "C" {
 
 #define Data_Read_UINT16(_d, _v) do { _v = \
 	(UINT16)(*_d) + \
-	(((UINT16)(*(_d))) << 8); \
+	(((UINT16)(*(_d + 1))) << 8); \
 	} while (0)
 
 #define Data_Read_UINT16_BE(_d, _v) do { _v = \

--- a/winpr/include/winpr/wtypes.h.in
+++ b/winpr/include/winpr/wtypes.h.in
@@ -84,7 +84,7 @@
 #endif
 
 #if WINPR_HAVE_STDINT_H
-#if defined(__x86_64__) || defined(__arm64__)
+#if __ILP64__ || __LP64__
 #define __int3264 int64_t
 #define __uint3264 uint64_t
 #else
@@ -92,7 +92,7 @@
 #define __uint3264 uint32_t
 #endif
 #else
-#if defined(__x86_64__) || defined(__arm64__)
+#if __ILP64__ || __LP64__
 #define __int3264 __int64
 #define __uint3264 __uint64
 #else
@@ -285,7 +285,7 @@ typedef void *PVOID64, *LPVOID64;
 #if WINPR_HAVE_STDINT_H
 typedef intptr_t INT_PTR;
 typedef uintptr_t UINT_PTR;
-#elif defined (__x86_64__)
+#elif __ILP64__ || __LP64__ || __LLP64__
 typedef __int64 INT_PTR;
 typedef unsigned __int64 UINT_PTR;
 #else

--- a/winpr/libwinpr/crt/string.c
+++ b/winpr/libwinpr/crt/string.c
@@ -87,13 +87,17 @@ int _strnicmp(const char* string1, const char* string2, size_t count)
 
 int _wcscmp(const WCHAR* string1, const WCHAR* string2)
 {
+	WCHAR value1, value2;
+
 	while (*string1 && (*string1 == *string2))
 	{
 		string1++;
 		string2++;
 	}
 
-	return *string1 - *string2;
+	Data_Read_UINT16(string1, value1);
+	Data_Read_UINT16(string2, value2);
+	return value1 - value2;
 }
 
 /* _wcslen -> wcslen */
@@ -116,11 +120,13 @@ size_t _wcslen(const WCHAR* str)
 WCHAR* _wcschr(const WCHAR* str, WCHAR c)
 {
 	WCHAR* p = (WCHAR*) str;
+	WCHAR value;
 
-	while (*p && (*p != c))
+	Data_Write_UINT16(&value, c);
+	while (*p && (*p != value))
 		p++;
 
-	return ((*p == c) ? p : NULL);
+	return ((*p == value) ? p : NULL);
 }
 
 char* strtok_s(char* strToken, const char* strDelimit, char** context)
@@ -131,20 +137,29 @@ char* strtok_s(char* strToken, const char* strDelimit, char** context)
 WCHAR* wcstok_s(WCHAR* strToken, const WCHAR* strDelimit, WCHAR** context)
 {
 	WCHAR* nextToken;
+	WCHAR value;
 
 	if (!strToken)
 		strToken = *context;
 
-	while (*strToken && _wcschr(strDelimit, *strToken))
+	Data_Read_UINT16(strToken, value);
+	while (*strToken && _wcschr(strDelimit, value))
+	{
 		strToken++;
+		Data_Read_UINT16(strToken, value);
+	}
 
 	if (!*strToken)
 		return NULL;
 
 	nextToken = strToken++;
 
-	while (*strToken && !(_wcschr(strDelimit, *strToken)))
+	Data_Read_UINT16(strToken, value);
+	while (*strToken && !(_wcschr(strDelimit, value)))
+	{
 		strToken++;
+		Data_Read_UINT16(strToken, value);
+	}
 
 	if (*strToken)
 		*strToken++ = 0;
@@ -387,13 +402,17 @@ int lstrcmpA(LPCSTR lpString1, LPCSTR lpString2)
 
 int lstrcmpW(LPCWSTR lpString1, LPCWSTR lpString2)
 {
+	WCHAR value1, value2;
+
 	while (*lpString1 && (*lpString1 == *lpString2))
 	{
 		lpString1++;
 		lpString2++;
 	}
 
-	return *lpString1 - *lpString2;
+	Data_Read_UINT16(lpString1, value1);
+	Data_Read_UINT16(lpString2, value2);
+	return value1 - value2;
 }
 
 #endif

--- a/winpr/libwinpr/crt/string.c
+++ b/winpr/libwinpr/crt/string.c
@@ -26,6 +26,7 @@
 #include <wctype.h>
 
 #include <winpr/crt.h>
+#include <winpr/endian.h>
 
 /* String Manipulation (CRT): http://msdn.microsoft.com/en-us/library/f0151s4x.aspx */
 
@@ -220,10 +221,13 @@ DWORD CharUpperBuffA(LPSTR lpsz, DWORD cchLength)
 DWORD CharUpperBuffW(LPWSTR lpsz, DWORD cchLength)
 {
 	DWORD i;
+	WCHAR value;
 
 	for (i = 0; i < cchLength; i++)
 	{
-		lpsz[i] = WINPR_TOUPPERW(lpsz[i]);
+		Data_Read_UINT16(&lpsz[i], value);
+		value = WINPR_TOUPPERW(value);
+		Data_Write_UINT16(&lpsz[i], value);
 	}
 
 	return cchLength;
@@ -287,10 +291,13 @@ DWORD CharLowerBuffA(LPSTR lpsz, DWORD cchLength)
 DWORD CharLowerBuffW(LPWSTR lpsz, DWORD cchLength)
 {
 	DWORD i;
+	WCHAR value;
 
 	for (i = 0; i < cchLength; i++)
 	{
-		lpsz[i] = WINPR_TOLOWERW(lpsz[i]);
+		Data_Read_UINT16(&lpsz[i], value);
+		value = WINPR_TOLOWERW(value);
+		Data_Write_UINT16(&lpsz[i], value);
 	}
 
 	return cchLength;

--- a/winpr/libwinpr/crt/test/TestString.c
+++ b/winpr/libwinpr/crt/test/TestString.c
@@ -16,6 +16,10 @@ static WCHAR testToken1W[] = { 	'q', 'u', 'i', 'c', 'k', '\0' };
 static WCHAR testToken2W[] = { 	'b', 'r', 'o', 'w', 'n', '\0' };
 static WCHAR testToken3W[] = { 'f', 'o', 'x', '\0' };
 
+#define testToken1W_Length	((sizeof(testToken1W) / sizeof(WCHAR)) - 1)
+#define testToken2W_Length	((sizeof(testToken2W) / sizeof(WCHAR)) - 1)
+#define testToken3W_Length	((sizeof(testToken3W) / sizeof(WCHAR)) - 1)
+
 static WCHAR testTokensW[] =
 {
 	'q', 'u', 'i', 'c', 'k', '\r', '\n',
@@ -23,7 +27,11 @@ static WCHAR testTokensW[] =
 	'f', 'o', 'x', '\r', '\n', '\0'
 };
 
+#define testTokensW_Length	((sizeof(testTokensW) / sizeof(WCHAR)) - 1)
+
 static WCHAR testDelimiter[] = { '\r', '\n', '\0' };
+
+#define testDelimiter_Length	((sizeof(testDelimiter) / sizeof(WCHAR)) - 1)
 
 int TestString(int argc, char* argv[])
 {
@@ -31,6 +39,16 @@ int TestString(int argc, char* argv[])
 	size_t pos;
 	size_t length;
 	WCHAR* context;
+
+#ifdef __BIG_ENDIAN__
+	/* Be sure that we always use LE encoded string */
+	ByteSwapUnicode(testStringW, testStringW_Length);
+	ByteSwapUnicode(testToken1W, testToken1W_Length);
+	ByteSwapUnicode(testToken2W, testToken2W_Length);
+	ByteSwapUnicode(testToken3W, testToken3W_Length);
+	ByteSwapUnicode(testTokensW, testTokensW_Length);
+	ByteSwapUnicode(testDelimiter, testDelimiter_Length);
+#endif
 
 	/* _wcslen */
 

--- a/winpr/libwinpr/crt/test/TestUnicodeConversion.c
+++ b/winpr/libwinpr/crt/test/TestUnicodeConversion.c
@@ -292,9 +292,9 @@ BOOL test_unicode_uppercasing(BYTE* lower, BYTE* upper)
 
 BOOL test_ConvertFromUnicode_wrapper()
 {
+	BYTE src1[] = "\x52\x00\x49\x00\x43\x00\x48\x00\x20\x00\x54\x00\x45\x00\x58\x00\x54\x00\x20\x00\x46\x00\x4f\x00\x52\x00\x4d\x00\x41\x00\x54\x00\x40\x00\x40\x00\x40\x00";
+	BYTE src2[] = "\x52\x00\x49\x00\x43\x00\x48\x00\x20\x00\x54\x00\x45\x00\x58\x00\x54\x00\x20\x00\x46\x00\x4f\x00\x52\x00\x4d\x00\x41\x00\x54\x00\x00\x00";
 	/*               00  01  02  03  04  05  06  07  08  09  10  11  12  13  14  15  16  17  18 */
-	WCHAR src1[] = { 'R','I','C','H',' ','T','E','X','T',' ','F','O','R','M','A','T','@','@','@' };
-	WCHAR src2[] = { 'R','I','C','H',' ','T','E','X','T',' ','F','O','R','M','A','T', 0 };
 	CHAR  cmp0[] = { 'R','I','C','H',' ','T','E','X','T',' ','F','O','R','M','A','T', 0 };
 	CHAR* dst = NULL;
 	int i;
@@ -306,7 +306,7 @@ BOOL test_ConvertFromUnicode_wrapper()
 	printf("Input UTF16 String:\n");
 	string_hexdump((BYTE*) src1, 19 * sizeof(WCHAR));
 
-	i = ConvertFromUnicode(CP_UTF8, 0, src1, 16, &dst, 0, NULL, NULL);
+	i = ConvertFromUnicode(CP_UTF8, 0, (WCHAR*)src1, 16, &dst, 0, NULL, NULL);
 	if (i != 16)
 	{
 		fprintf(stderr, "ConvertFromUnicode failure A1: unexpectedly returned %d instead of 16\n", i);
@@ -336,9 +336,9 @@ BOOL test_ConvertFromUnicode_wrapper()
 	/* Test null-terminated string */
 
 	printf("Input UTF16 String:\n");
-	string_hexdump((BYTE*) src2, (_wcslen(src2) + 1 ) * sizeof(WCHAR));
+	string_hexdump((BYTE*) src2, (_wcslen((WCHAR*)src2) + 1 ) * sizeof(WCHAR));
 
-	i = ConvertFromUnicode(CP_UTF8, 0, src2, -1, &dst, 0, NULL, NULL);
+	i = ConvertFromUnicode(CP_UTF8, 0, (WCHAR*)src2, -1, &dst, 0, NULL, NULL);
 	if (i != 17)
 	{
 		fprintf(stderr, "ConvertFromUnicode failure B1: unexpectedly returned %d instead of 17\n", i);
@@ -379,7 +379,7 @@ BOOL test_ConvertToUnicode_wrapper()
 	/*               00  01  02  03  04  05  06  07  08  09  10  11  12  13  14  15  16  17  18 */
 	CHAR  src1[] = { 'R','I','C','H',' ','T','E','X','T',' ','F','O','R','M','A','T','@','@','@' };
 	CHAR  src2[] = { 'R','I','C','H',' ','T','E','X','T',' ','F','O','R','M','A','T', 0 };
-	WCHAR cmp0[] = { 'R','I','C','H',' ','T','E','X','T',' ','F','O','R','M','A','T', 0 };
+	BYTE cmp0[] = "\x52\x00\x49\x00\x43\x00\x48\x00\x20\x00\x54\x00\x45\x00\x58\x00\x54\x00\x20\x00\x46\x00\x4f\x00\x52\x00\x4d\x00\x41\x00\x54\x00\x00\x00";
 	WCHAR* dst = NULL;
 	int i;
 
@@ -406,7 +406,7 @@ BOOL test_ConvertToUnicode_wrapper()
 		fprintf(stderr, "ConvertToUnicode failure A3: dst length is %d instead of 16\n", i);
 		goto fail;
 	}
-	if (_wcscmp(dst, cmp0))
+	if (_wcscmp(dst, (WCHAR*)cmp0))
 	{
 		fprintf(stderr, "ConvertToUnicode failure A4: data mismatch\n");
 		goto fail;
@@ -438,7 +438,7 @@ BOOL test_ConvertToUnicode_wrapper()
 		fprintf(stderr, "ConvertToUnicode failure B3: dst length is %d instead of 16\n", i);
 		goto fail;
 	}
-	if (_wcscmp(dst, cmp0))
+	if (_wcscmp(dst, (WCHAR*)cmp0))
 	{
 		fprintf(stderr, "ConvertToUnicode failure B: data mismatch\n");
 		goto fail;

--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -27,6 +27,7 @@
 #include <winpr/tchar.h>
 #include <winpr/sysinfo.h>
 #include <winpr/registry.h>
+#include <winpr/endian.h>
 #include <freerdp/build-config.h>
 
 #include "ntlm.h"
@@ -891,6 +892,7 @@ SECURITY_STATUS SEC_ENTRY ntlm_EncryptMessage(PCtxtHandle phContext, ULONG fQOP,
 	int length;
 	void* data;
 	UINT32 SeqNo;
+	UINT32 value;
 	BYTE digest[WINPR_MD5_DIGEST_LENGTH];
 	BYTE checksum[8];
 	BYTE* signature;
@@ -926,7 +928,8 @@ SECURITY_STATUS SEC_ENTRY ntlm_EncryptMessage(PCtxtHandle phContext, ULONG fQOP,
 	CopyMemory(data, data_buffer->pvBuffer, length);
 	/* Compute the HMAC-MD5 hash of ConcatenationOf(seq_num,data) using the client signing key */
 	winpr_HMAC_Init(&hmac, WINPR_MD_MD5, context->SendSigningKey, WINPR_MD5_DIGEST_LENGTH);
-	winpr_HMAC_Update(&hmac, (void*) &(SeqNo), 4);
+	Data_Write_UINT32(&value, SeqNo);
+	winpr_HMAC_Update(&hmac, (void*) &value, 4);
 	winpr_HMAC_Update(&hmac, (void*) data, length);
 	winpr_HMAC_Final(&hmac, digest, WINPR_MD5_DIGEST_LENGTH);
 
@@ -948,9 +951,9 @@ SECURITY_STATUS SEC_ENTRY ntlm_EncryptMessage(PCtxtHandle phContext, ULONG fQOP,
 	winpr_RC4_Update(context->SendRc4Seal, 8, digest, checksum);
 	signature = (BYTE*) signature_buffer->pvBuffer;
 	/* Concatenate version, ciphertext and sequence number to build signature */
-	CopyMemory(signature, (void*) &version, 4);
+	Data_Write_UINT32(signature, version);
 	CopyMemory(&signature[4], (void*) checksum, 8);
-	CopyMemory(&signature[12], (void*) &(SeqNo), 4);
+	Data_Write_UINT32(&signature[12], SeqNo);
 	context->SendSeqNum++;
 #ifdef WITH_DEBUG_NTLM
 	WLog_DBG(TAG, "Signature (length = %d)", (int) signature_buffer->cbBuffer);
@@ -965,6 +968,7 @@ SECURITY_STATUS SEC_ENTRY ntlm_DecryptMessage(PCtxtHandle phContext, PSecBufferD
 	int length;
 	void* data;
 	UINT32 SeqNo;
+	UINT32 value;
 	BYTE digest[WINPR_MD5_DIGEST_LENGTH];
 	BYTE checksum[8];
 	UINT32 version = 1;
@@ -1008,7 +1012,8 @@ SECURITY_STATUS SEC_ENTRY ntlm_DecryptMessage(PCtxtHandle phContext, PSecBufferD
 
 	/* Compute the HMAC-MD5 hash of ConcatenationOf(seq_num,data) using the client signing key */
 	winpr_HMAC_Init(&hmac, WINPR_MD_MD5, context->RecvSigningKey, WINPR_MD5_DIGEST_LENGTH);
-	winpr_HMAC_Update(&hmac, (void*) &(SeqNo), 4);
+	Data_Write_UINT32(&value, SeqNo);
+	winpr_HMAC_Update(&hmac, (void*) &value, 4);
 	winpr_HMAC_Update(&hmac, (void*) data_buffer->pvBuffer, data_buffer->cbBuffer);
 	winpr_HMAC_Final(&hmac, digest, WINPR_MD5_DIGEST_LENGTH);
 #ifdef WITH_DEBUG_NTLM
@@ -1021,9 +1026,9 @@ SECURITY_STATUS SEC_ENTRY ntlm_DecryptMessage(PCtxtHandle phContext, PSecBufferD
 	/* RC4-encrypt first 8 bytes of digest */
 	winpr_RC4_Update(context->RecvRc4Seal, 8, digest, checksum);
 	/* Concatenate version, ciphertext and sequence number to build signature */
-	CopyMemory(expected_signature, (void*) &version, 4);
+	Data_Write_UINT32(expected_signature, version);
 	CopyMemory(&expected_signature[4], (void*) checksum, 8);
-	CopyMemory(&expected_signature[12], (void*) &(SeqNo), 4);
+	Data_Write_UINT32(&expected_signature[12], SeqNo);
 	context->RecvSeqNum++;
 
 	if (memcmp(signature_buffer->pvBuffer, expected_signature, 16) != 0)

--- a/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
@@ -57,8 +57,8 @@ const char* const AV_PAIR_STRINGS[] =
 void ntlm_av_pair_list_init(NTLM_AV_PAIR* pAvPairList)
 {
 	NTLM_AV_PAIR* pAvPair = pAvPairList;
-	pAvPair->AvId = MsvAvEOL;
-	pAvPair->AvLen = 0;
+	ntlm_av_pair_set_id(pAvPair, MsvAvEOL);
+	ntlm_av_pair_set_len(pAvPair, 0);
 }
 
 ULONG ntlm_av_pair_list_length(NTLM_AV_PAIR* pAvPairList)
@@ -69,7 +69,7 @@ ULONG ntlm_av_pair_list_length(NTLM_AV_PAIR* pAvPairList)
 	if (!pAvPair)
 		return 0;
 
-	while (pAvPair->AvId != MsvAvEOL)
+	while (ntlm_av_pair_get_id(pAvPair) != MsvAvEOL)
 	{
 		pAvPair = ntlm_av_pair_get_next_pointer(pAvPair);
 	}
@@ -87,12 +87,14 @@ void ntlm_print_av_pair_list(NTLM_AV_PAIR* pAvPairList)
 
 	WLog_INFO(TAG, "AV_PAIRs =");
 
-	while (pAvPair->AvId != MsvAvEOL)
+	while (ntlm_av_pair_get_id(pAvPair) != MsvAvEOL)
 	{
 		WLog_INFO(TAG, "\t%s AvId: %d AvLen: %d",
-				  AV_PAIR_STRINGS[pAvPair->AvId],
-				  pAvPair->AvId, pAvPair->AvLen);
-		winpr_HexDump(TAG, WLOG_INFO, ntlm_av_pair_get_value_pointer(pAvPair), pAvPair->AvLen);
+				  AV_PAIR_STRINGS[ntlm_av_pair_get_id(pAvPair)],
+				  ntlm_av_pair_get_id(pAvPair),
+				  ntlm_av_pair_get_len(pAvPair));
+		winpr_HexDump(TAG, WLOG_INFO, ntlm_av_pair_get_value_pointer(pAvPair),
+				      ntlm_av_pair_get_len(pAvPair));
 		pAvPair = ntlm_av_pair_get_next_pointer(pAvPair);
 	}
 }
@@ -110,7 +112,7 @@ PBYTE ntlm_av_pair_get_value_pointer(NTLM_AV_PAIR* pAvPair)
 
 int ntlm_av_pair_get_next_offset(NTLM_AV_PAIR* pAvPair)
 {
-	return pAvPair->AvLen + sizeof(NTLM_AV_PAIR);
+	return ntlm_av_pair_get_len(pAvPair) + sizeof(NTLM_AV_PAIR);
 }
 
 NTLM_AV_PAIR* ntlm_av_pair_get_next_pointer(NTLM_AV_PAIR* pAvPair)
@@ -127,10 +129,10 @@ NTLM_AV_PAIR* ntlm_av_pair_get(NTLM_AV_PAIR* pAvPairList, NTLM_AV_ID AvId)
 
 	while (1)
 	{
-		if (pAvPair->AvId == AvId)
+		if (ntlm_av_pair_get_id(pAvPair) == AvId)
 			return pAvPair;
 
-		if (pAvPair->AvId == MsvAvEOL)
+		if (ntlm_av_pair_get_id(pAvPair) == MsvAvEOL)
 			return NULL;
 
 		pAvPair = ntlm_av_pair_get_next_pointer(pAvPair);
@@ -148,8 +150,8 @@ NTLM_AV_PAIR* ntlm_av_pair_add(NTLM_AV_PAIR* pAvPairList, NTLM_AV_ID AvId, PBYTE
 		return NULL;
 
 	assert(Value != NULL);
-	pAvPair->AvId = AvId;
-	pAvPair->AvLen = AvLen;
+	ntlm_av_pair_set_id(pAvPair, AvId);
+	ntlm_av_pair_set_len(pAvPair, AvLen);
 	CopyMemory(ntlm_av_pair_get_value_pointer(pAvPair), Value, AvLen);
 	return pAvPair;
 }
@@ -162,10 +164,11 @@ NTLM_AV_PAIR* ntlm_av_pair_add_copy(NTLM_AV_PAIR* pAvPairList, NTLM_AV_PAIR* pAv
 	if (!pAvPairCopy)
 		return NULL;
 
-	pAvPairCopy->AvId = pAvPair->AvId;
-	pAvPairCopy->AvLen = pAvPair->AvLen;
+	CopyMemory(&pAvPairCopy->AvId, &pAvPair->AvId, 2);
+	CopyMemory(&pAvPairCopy->AvLen, &pAvPair->AvLen, 2);
 	CopyMemory(ntlm_av_pair_get_value_pointer(pAvPairCopy),
-			   ntlm_av_pair_get_value_pointer(pAvPair), pAvPair->AvLen);
+			   ntlm_av_pair_get_value_pointer(pAvPair),
+			   ntlm_av_pair_get_len (pAvPair));
 	return pAvPairCopy;
 }
 
@@ -288,10 +291,10 @@ void ntlm_compute_single_host_data(NTLM_CONTEXT* context)
 	 * different or if they are on different hosts, then the information MUST be ignored.
 	 * Any fields after the MachineID field MUST be ignored on receipt.
 	 */
-	context->SingleHostData.Size = 48;
-	context->SingleHostData.Z4 = 0;
-	context->SingleHostData.DataPresent = 1;
-	context->SingleHostData.CustomData = SECURITY_MANDATORY_MEDIUM_RID;
+	Data_Write_UINT32(&context->SingleHostData.Size, 48);
+	Data_Write_UINT32(&context->SingleHostData.Z4, 0);
+	Data_Write_UINT32(&context->SingleHostData.DataPresent, 1);
+	Data_Write_UINT32(&context->SingleHostData.CustomData, SECURITY_MANDATORY_MEDIUM_RID);
 	FillMemory(context->SingleHostData.MachineID, 32, 0xAA);
 }
 
@@ -375,31 +378,31 @@ int ntlm_construct_authenticate_target_info(NTLM_CONTEXT* context)
 	if (AvNbDomainName)
 	{
 		AvPairsCount++; /* MsvAvNbDomainName */
-		AvPairsValueLength += AvNbDomainName->AvLen;
+		AvPairsValueLength += ntlm_av_pair_get_len(AvNbDomainName);
 	}
 
 	if (AvNbComputerName)
 	{
 		AvPairsCount++; /* MsvAvNbComputerName */
-		AvPairsValueLength += AvNbComputerName->AvLen;
+		AvPairsValueLength += ntlm_av_pair_get_len(AvNbComputerName);
 	}
 
 	if (AvDnsDomainName)
 	{
 		AvPairsCount++; /* MsvAvDnsDomainName */
-		AvPairsValueLength += AvDnsDomainName->AvLen;
+		AvPairsValueLength += ntlm_av_pair_get_len(AvDnsDomainName);
 	}
 
 	if (AvDnsComputerName)
 	{
 		AvPairsCount++; /* MsvAvDnsComputerName */
-		AvPairsValueLength += AvDnsComputerName->AvLen;
+		AvPairsValueLength += ntlm_av_pair_get_len(AvDnsComputerName);
 	}
 
 	if (AvDnsTreeName)
 	{
 		AvPairsCount++; /* MsvAvDnsTreeName */
-		AvPairsValueLength += AvDnsTreeName->AvLen;
+		AvPairsValueLength += ntlm_av_pair_get_len(AvDnsTreeName);
 	}
 
 	AvPairsCount++; /* MsvAvTimestamp */
@@ -470,7 +473,8 @@ int ntlm_construct_authenticate_target_info(NTLM_CONTEXT* context)
 
 	if (context->UseMIC)
 	{
-		UINT32 flags = MSV_AV_FLAGS_MESSAGE_INTEGRITY_CHECK;
+		UINT32 flags;
+		Data_Write_UINT32(&flags, MSV_AV_FLAGS_MESSAGE_INTEGRITY_CHECK);
 		ntlm_av_pair_add(AuthenticateTargetInfo, MsvAvFlags, (PBYTE) &flags, 4);
 	}
 

--- a/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.h
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.h
@@ -35,6 +35,23 @@ NTLM_AV_PAIR* ntlm_av_pair_get(NTLM_AV_PAIR* pAvPairList, NTLM_AV_ID AvId);
 NTLM_AV_PAIR* ntlm_av_pair_add(NTLM_AV_PAIR* pAvPairList, NTLM_AV_ID AvId, PBYTE Value, UINT16 AvLen);
 NTLM_AV_PAIR* ntlm_av_pair_add_copy(NTLM_AV_PAIR* pAvPairList, NTLM_AV_PAIR* pAvPair);
 
+static INLINE UINT16 ntlm_av_pair_get_id(NTLM_AV_PAIR* pAvPair)
+{
+	UINT16 AvId;
+	Data_Read_UINT16(&pAvPair->AvId, AvId);
+	return AvId;
+}
+
+static INLINE UINT16 ntlm_av_pair_get_len(NTLM_AV_PAIR* pAvPair)
+{
+	UINT16 AvLen;
+	Data_Read_UINT16(&pAvPair->AvLen, AvLen);
+	return AvLen;
+}
+
+#define ntlm_av_pair_set_id(pAvPair, id) Data_Write_UINT16(&pAvPair->AvId, id)
+#define ntlm_av_pair_set_len(pAvPair, len) Data_Write_UINT16(&pAvPair->AvLen, len)
+
 int ntlm_construct_challenge_target_info(NTLM_CONTEXT* context);
 int ntlm_construct_authenticate_target_info(NTLM_CONTEXT* context);
 

--- a/winpr/libwinpr/sspi/NTLM/ntlm_message.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_message.c
@@ -679,7 +679,7 @@ SECURITY_STATUS ntlm_read_AuthenticateMessage(NTLM_CONTEXT* context, PSecBuffer 
 		AvFlags = ntlm_av_pair_get(context->NTLMv2Response.Challenge.AvPairs, MsvAvFlags);
 
 		if (AvFlags)
-			flags = *((UINT32*) ntlm_av_pair_get_value_pointer(AvFlags));
+			Data_Read_UINT32(ntlm_av_pair_get_value_pointer(AvFlags), flags);
 	}
 
 	if (ntlm_read_message_fields_buffer(s, &(message->EncryptedRandomSessionKey)) < 0) /* EncryptedRandomSessionKey */
@@ -952,7 +952,7 @@ SECURITY_STATUS ntlm_server_AuthenticateComplete(NTLM_CONTEXT* context)
 	AvFlags = ntlm_av_pair_get(context->NTLMv2Response.Challenge.AvPairs, MsvAvFlags);
 
 	if (AvFlags)
-		flags = *((UINT32*) ntlm_av_pair_get_value_pointer(AvFlags));
+		Data_Read_UINT32(ntlm_av_pair_get_value_pointer(AvFlags), flags);
 
 	if (ntlm_compute_lm_v2_response(context) < 0) /* LmChallengeResponse */
 		return SEC_E_INTERNAL_ERROR;

--- a/winpr/libwinpr/utils/test/TestStream.c
+++ b/winpr/libwinpr/utils/test/TestStream.c
@@ -208,7 +208,7 @@ fail:
     _r = FALSE;                                                              \
   }                                                                          \
   for (_i=0; _i<sizeof(_t); _i++) {                                          \
-    if (((BYTE*)&_a)[_i] != _p[_i]) {                                        \
+    if (((_a >> (_i * 8)) & 0xFF) != _p[_i]) {                               \
       printf("%s: test2 " #_t "_LE failed\n", __FUNCTION__);                 \
       _r = FALSE;                                                            \
       break;                                                                 \
@@ -224,7 +224,7 @@ fail:
     _r = FALSE;                                                              \
   }                                                                          \
   for (_i=0; _i<sizeof(_t); _i++) {                                          \
-    if (((BYTE*)&_a)[_i] != _p[sizeof(_t)-_i-1]) {                           \
+    if (((_a >> (_i * 8)) & 0xFF) != _p[sizeof(_t)-_i-1]) {                  \
       printf("%s: test2 " #_t "_BE failed\n", __FUNCTION__);                 \
       _r = FALSE;                                                            \
       break;                                                                 \


### PR DESCRIPTION
Hello, I am trying to fix freerdp to work on big endian architectures (s390, ppc64). See issue #2520 for some additional info. I made some patches, but not sure this is right way to fix it. So I would like to ask for some feedback before I will continue...

The following patch for libwinpr is needed to fix build problems:
http://anonscm.debian.org/cgit/collab-maint/freerdp.git/tree/debian/patches/1004_64-bit-architectures.patch

It seems that bunch of functionality doesn't work (e.g. nfs, compression, colors, string) on big endian machines. I am proposing fixes for some of those problems currently, I will update the branch subsequently. E.g. I modified utf.c to fix strings, so I do not expect that you like this solution, but I am not sure how to do it better to avoid additional memory copies...

Can you give me some feedback? 