### PR TITLE
core: allow TS Gateway protocol violation

### DIFF
--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -210,9 +210,11 @@ BOOL rdp_read_extended_info_packet(rdpRdp* rdp, wStream* s)
 	/* cbClientAddress is the size in bytes of the character data in the clientAddress field.
 	 * This size includes the length of the mandatory null terminator.
 	 * The maximum allowed value is 80 bytes
+	 * Note: Although according to [MS-RDPBCGR 2.2.1.11.1.1.1] the null terminator
+	 * is mandatory, connections via Microsoft's TS Gateway set cbClientAddress to 0.
 	 */
 
-	if ((cbClientAddress % 2) || cbClientAddress < 2 || cbClientAddress > 80)
+	if ((cbClientAddress % 2) || cbClientAddress > 80)
 	{
 		WLog_ERR(TAG, "protocol error: invalid cbClientAddress value: %u", cbClientAddress);
 		return FALSE;
@@ -229,18 +231,22 @@ BOOL rdp_read_extended_info_packet(rdpRdp* rdp, wStream* s)
 		settings->ClientAddress = NULL;
 	}
 
-	wstr = (WCHAR*) Stream_Pointer(s);
-	if (wstr[cbClientAddress / 2 - 1])
+	if (cbClientAddress)
 	{
-		WLog_ERR(TAG, "protocol error: clientAddress must be null terminated");
-		return FALSE;
+		wstr = (WCHAR*) Stream_Pointer(s);
+		if (wstr[cbClientAddress / 2 - 1])
+		{
+			WLog_ERR(TAG, "protocol error: clientAddress must be null terminated");
+			return FALSE;
+		}
+		if (ConvertFromUnicode(CP_UTF8, 0, wstr, -1, &settings->ClientAddress, 0, NULL, NULL) < 1)
+		{
+			WLog_ERR(TAG, "failed to convert client address");
+			return FALSE;
+		}
+		Stream_Seek(s, cbClientAddress);
+		WLog_DBG(TAG, "rdp client address: [%s]", settings->ClientAddress);
 	}
-	if (ConvertFromUnicode(CP_UTF8, 0, wstr, -1, &settings->ClientAddress, 0, NULL, NULL) < 1)
-	{
-		WLog_ERR(TAG, "failed to convert client address");
-		return FALSE;
-	}
-	Stream_Seek(s, cbClientAddress);
 
 	if (Stream_GetRemainingLength(s) < 2)
 		return FALSE;


### PR DESCRIPTION
According to [MS-RDPBCGR 2.2.1.11.1.1.1] the TS_EXTENDED_INFO_PACKET structure's cbClientAddress field must include the _mandatory_ NULL terminator of the clientAddress field in its byte count.
However, connections proxied via Microsoft's TS Gateway set the cbClientDir value to 0.