### PR TITLE
Disable comm tests per default

### DIFF
--- a/cmake/ConfigOptions.cmake
+++ b/cmake/ConfigOptions.cmake
@@ -57,6 +57,7 @@ option(WITH_SMARTCARD_INSPECT "Enable SmartCard API Inspector" OFF)
 
 option(BUILD_TESTING "Build unit tests" OFF)
 CMAKE_DEPENDENT_OPTION(TESTS_WTSAPI_EXTRA "Build extra WTSAPI tests (interactive)" OFF "BUILD_TESTING" OFF)
+CMAKE_DEPENDENT_OPTION(BUILD_COMM_TESTS "Build comm related tests (require comm port)" OFF "BUILD_TESTING" OFF)
 
 option(WITH_SAMPLE "Build sample code" OFF)
 

--- a/winpr/libwinpr/comm/CMakeLists.txt
+++ b/winpr/libwinpr/comm/CMakeLists.txt
@@ -34,7 +34,7 @@ if(UNIX AND NOT WIN32 AND NOT APPLE)
 
 	winpr_module_add(${${MODULE_PREFIX}_SRCS})
 
-	if(BUILD_TESTING)
+	if(BUILD_TESTING AND BUILD_COMM_TESTS)
 		add_subdirectory(test)
-		endif()
+	endif()
 endif()


### PR DESCRIPTION
comm tests require a serial device for testing. If the test environment
isn't available the tests will return errors therefore the tests are
now disabled per default. They can be (re-)enabled by using the cmake
option BUILD_COMM_TESTS.