### PR TITLE
libfreerd/color: fix typo

### DIFF
--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -1555,7 +1555,7 @@ int freerdp_image_copy_from_pointer_data(BYTE* pDstData, UINT32 DstFormat,
 
 			if (xorBpp == 8 && !palette)
 			{
-				WLog_ERR(TAG, "null palette in convertion from %d bpp to %d bpp",
+				WLog_ERR(TAG, "null palette in conversion from %d bpp to %d bpp",
 						 xorBpp, dstBitsPerPixel);
 				return -1;
 			}


### PR DESCRIPTION
Source: http://anonscm.debian.org/cgit/collab-maint/freerdp2.git/commit/?id=f3c1f25bbfe0f17a0d1317096984b73db6fa1f38