### PR TITLE
core: don't advertise multi layout PDUs

### DIFF
--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -295,7 +295,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	if (!settings->ChannelDefArray)
 			goto out_fail;
 
-	settings->SupportMonitorLayoutPdu = TRUE;
+	settings->SupportMonitorLayoutPdu = FALSE;
 	settings->MonitorCount = 0;
 	settings->MonitorDefArraySize = 32;
 	settings->MonitorDefArray = (rdpMonitor*) calloc(settings->MonitorDefArraySize, sizeof(rdpMonitor));


### PR DESCRIPTION
If support for multi layout PDUs is advertised there are known issues
with Windows 7 and Windows 2008R2. Until those are resolved generally
disable multi layout PDUs.

See #3114 for details.