### PR TITLE
client: disable the client interface per default

### DIFF
--- a/client/Windows/CMakeLists.txt
+++ b/client/Windows/CMakeLists.txt
@@ -72,6 +72,7 @@ if(WITH_CLIENT_INTERFACE)
 else()
 	set(${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_SRCS} cli/wfreerdp.c cli/wfreerdp.h)
 	add_executable(${MODULE_NAME} WIN32 ${${MODULE_PREFIX}_SRCS})
+	include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
 set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} freerdp-client)

--- a/cmake/ConfigOptions.cmake
+++ b/cmake/ConfigOptions.cmake
@@ -81,7 +81,7 @@ endif()
 
 option(WITH_THIRD_PARTY "Build third-party components" OFF)
 
-option(WITH_CLIENT_INTERFACE "Build clients as a library with an interface" ON)
+option(WITH_CLIENT_INTERFACE "Build clients as a library with an interface" OFF)
 option(WITH_SERVER_INTERFACE "Build servers as a library with an interface" ON)
 
 option(WITH_DEBUG_ALL "Print all debug messages." OFF)


### PR DESCRIPTION
libxfreerdp-client doesn't necessarily provide a stable interface
therefore it isn't built and installed anymore per default.

To archive the same behavior as before this change -
libxfreerdp-client.so built and a library version set - use
-DWITH_CLIENT_INTERFACE=ON -DCLIENT_INTERFACE_SHARED=ON
when running cmake.