### PR TITLE
egfx codec context reset fix, Windows Server 2012 RemoteFX empty tile set fix

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -158,7 +158,7 @@ static UINT rdpgfx_recv_caps_confirm_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStr
 
 	if (Stream_GetRemainingLength(s) < 12)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -232,7 +232,7 @@ static UINT rdpgfx_recv_reset_graphics_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wS
 
 	if (Stream_GetRemainingLength(s) < 12)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -242,7 +242,7 @@ static UINT rdpgfx_recv_reset_graphics_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wS
 
 	if (Stream_GetRemainingLength(s) < (pdu.monitorCount * 20))
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -304,7 +304,7 @@ static UINT rdpgfx_recv_evict_cache_entry_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < 2)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -337,7 +337,7 @@ UINT rdpgfx_recv_cache_import_reply_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStre
 
 	if (Stream_GetRemainingLength(s) < 2)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -345,7 +345,7 @@ UINT rdpgfx_recv_cache_import_reply_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStre
 
 	if (Stream_GetRemainingLength(s) < (size_t) (pdu.importedEntriesCount * 2))
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -391,7 +391,7 @@ static UINT rdpgfx_recv_create_surface_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wS
 
 	if (Stream_GetRemainingLength(s) < 7)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -427,7 +427,7 @@ UINT rdpgfx_recv_delete_surface_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStream* 
 
 	if (Stream_GetRemainingLength(s) < 2)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -459,7 +459,7 @@ static UINT rdpgfx_recv_start_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStre
 
 	if (Stream_GetRemainingLength(s) < 8)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -496,7 +496,7 @@ static UINT rdpgfx_recv_end_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStream
 
 	if (Stream_GetRemainingLength(s) < 4)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -552,7 +552,7 @@ static UINT rdpgfx_recv_wire_to_surface_1_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < 17)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -570,7 +570,7 @@ static UINT rdpgfx_recv_wire_to_surface_1_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (pdu.bitmapDataLength > Stream_GetRemainingLength(s))
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -617,7 +617,7 @@ static UINT rdpgfx_recv_wire_to_surface_2_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < 13)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -673,7 +673,7 @@ static UINT rdpgfx_recv_delete_encoding_context_pdu(RDPGFX_CHANNEL_CALLBACK* cal
 
 	if (Stream_GetRemainingLength(s) < 6)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -709,7 +709,7 @@ UINT rdpgfx_recv_solid_fill_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStream* s)
 
 	if (Stream_GetRemainingLength(s) < 8)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -723,7 +723,7 @@ UINT rdpgfx_recv_solid_fill_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStream* s)
 
 	if (Stream_GetRemainingLength(s) < (size_t) (pdu.fillRectCount * 8))
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -777,7 +777,7 @@ static UINT rdpgfx_recv_surface_to_surface_pdu(RDPGFX_CHANNEL_CALLBACK* callback
 
 	if (Stream_GetRemainingLength(s) < 14)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -793,7 +793,7 @@ static UINT rdpgfx_recv_surface_to_surface_pdu(RDPGFX_CHANNEL_CALLBACK* callback
 
 	if (Stream_GetRemainingLength(s) < (size_t) (pdu.destPtsCount * 4))
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -848,7 +848,7 @@ static UINT rdpgfx_recv_surface_to_cache_pdu(RDPGFX_CHANNEL_CALLBACK* callback, 
 
 	if (Stream_GetRemainingLength(s) < 20)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -893,7 +893,7 @@ UINT rdpgfx_recv_cache_to_surface_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStream
 
 	if (Stream_GetRemainingLength(s) < 6)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -903,7 +903,7 @@ UINT rdpgfx_recv_cache_to_surface_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStream
 
 	if (Stream_GetRemainingLength(s) < (size_t) (pdu.destPtsCount * 4))
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -955,7 +955,7 @@ static UINT rdpgfx_recv_map_surface_to_output_pdu(RDPGFX_CHANNEL_CALLBACK* callb
 
 	if (Stream_GetRemainingLength(s) < 12)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -991,7 +991,7 @@ UINT rdpgfx_recv_map_surface_to_window_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wS
 
 	if (Stream_GetRemainingLength(s) < 18)
 	{
-		WLog_ERR(TAG, "not enought data!");
+		WLog_ERR(TAG, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -815,8 +815,8 @@ static BOOL rfx_process_message_tileset(RFX_CONTEXT* context, RFX_MESSAGE* messa
 
 	if (message->numTiles < 1)
 	{
-		WLog_ERR(TAG, "no tiles.");
-		return FALSE;
+		/* Windows Server 2012 (not R2) can send empty tile sets */
+		return TRUE;
 	}
 
 	Stream_Read_UINT32(s, tilesDataSize); /* tilesDataSize (4 bytes) */

--- a/libfreerdp/core/codecs.c
+++ b/libfreerdp/core/codecs.c
@@ -100,13 +100,9 @@ BOOL freerdp_client_codecs_prepare(rdpCodecs* codecs, UINT32 flags)
 	return TRUE;
 }
 
-BOOL freerdp_client_codecs_reset(rdpCodecs* codecs, UINT32 flags,
-				 UINT32 width, UINT32 height)
+BOOL freerdp_client_codecs_reset(rdpCodecs* codecs, UINT32 flags, UINT32 width, UINT32 height)
 {
 	BOOL rc = TRUE;
-
-	if (!freerdp_client_codecs_prepare(codecs, flags))
-		return FALSE;
 
 	if (flags & FREERDP_CODEC_INTERLEAVED)
 	{

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -77,8 +77,7 @@ UINT gdi_ResetGraphics(RdpgfxClientContext* context, RDPGFX_RESET_GRAPHICS_PDU* 
 
 	free(pSurfaceIds);
 
-	if (!freerdp_client_codecs_reset(gdi->codecs, FREERDP_CODEC_ALL,
-					 gdi->width, gdi->height))
+	if (!freerdp_client_codecs_reset(gdi->codecs, FREERDP_CODEC_ALL, gdi->width, gdi->height))
 		return ERROR_INTERNAL_ERROR;
 
 	gdi->graphicsReset = TRUE;


### PR DESCRIPTION
Fix issue with the codec context reset in egfx that caused all codec contexts to be created, including those that aren't used. As a result, if no H.264 support was built-in, the codec context would fail, breaking egfx support entirely even if no H.264 is in use.

Fix issue with a check being too strict on RemoteFX messages containing an empty tile set. Unfortunately, such messages are sometimes sent by Windows Server 2012 (not R2), so we should not fail on them.
