### PR TITLE
wfreerdp: fix name build without client interface

### DIFF
--- a/client/Windows/CMakeLists.txt
+++ b/client/Windows/CMakeLists.txt
@@ -73,6 +73,7 @@ else()
 	set(${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_SRCS} cli/wfreerdp.c cli/wfreerdp.h)
 	add_executable(${MODULE_NAME} WIN32 ${${MODULE_PREFIX}_SRCS})
 	include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+	set_target_properties(${MODULE_NAME} PROPERTIES OUTPUT_NAME "wfreerdp")
 endif()
 
 set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} freerdp-client)


### PR DESCRIPTION
When built without client-interface the binary should be called wfreerdp
as well (currently it is wfreerdp-client)