### PR TITLE
proper xcrush context reset fix

### DIFF
--- a/libfreerdp/codec/xcrush.c
+++ b/libfreerdp/codec/xcrush.c
@@ -816,6 +816,12 @@ int xcrush_decompress(XCRUSH_CONTEXT* xcrush, BYTE* pSrcData, UINT32 SrcSize, BY
 	pSrcData += 2;
 	SrcSize -= 2;
 
+	if (flags & PACKET_FLUSHED)
+	{
+		ZeroMemory(xcrush->HistoryBuffer, xcrush->HistoryBufferSize);
+		xcrush->HistoryOffset = 0;
+	}
+
 	if (!(Level2ComprFlags & PACKET_COMPRESSED))
 	{
 		pDstData = pSrcData;
@@ -824,11 +830,6 @@ int xcrush_decompress(XCRUSH_CONTEXT* xcrush, BYTE* pSrcData, UINT32 SrcSize, BY
 		status = xcrush_decompress_l1(xcrush, pDstData, DstSize, ppDstData, pDstSize, Level1ComprFlags);
 
 		return status;
-	}
-
-	if (Level2ComprFlags & PACKET_FLUSHED)
-	{
-		//xcrush_context_reset(xcrush, FALSE);
 	}
 
 	status = mppc_decompress(xcrush->mppc, pSrcData, SrcSize, &pDstData, &DstSize, Level2ComprFlags);


### PR DESCRIPTION
This is the true fix. I tested with RemoteFX (more data triggers more PACKET_FLUSHED) with both remote control and non remote control scenarios. The real problem was with using the PACKET_FLUSHED flags from the first compression header rather than the compression flags embedded in the xcrush compression header to trigger an xcrush context flush. Nothing was done, causing the decompression failure in remote control scenarios.