### PR TITLE
Update mf_mountain_lion.c

### DIFF
--- a/server/Mac/mf_mountain_lion.c
+++ b/server/Mac/mf_mountain_lion.c
@@ -209,8 +209,6 @@ int mf_mlion_stop_getting_screen_updates()
 	}
 	
 	return 0;
-
-	return 0;
 }
 
 int mf_mlion_get_dirty_region(RFX_RECT* invalid)


### PR DESCRIPTION
Remove duplicate return statement in mf_mlion_stop_getting_screen_updates()
This change is no impact anywhere.