### PR TITLE
shadow/rdpsnd: Fix race condition in rdpsnd channel server. 

### DIFF
--- a/channels/rdpsnd/server/rdpsnd_main.h
+++ b/channels/rdpsnd/server/rdpsnd_main.h
@@ -52,6 +52,7 @@ struct _rdpsnd_server_private
 	UINT32 src_bytes_per_sample;
 	UINT32 src_bytes_per_frame;
 	FREERDP_DSP_CONTEXT* dsp_context;
+	CRITICAL_SECTION lock; /* Protect out_buffer and related parameters */
 };
 
 #endif /* FREERDP_CHANNEL_SERVER_RDPSND_MAIN_H */

--- a/server/shadow/shadow_rdpsnd.c
+++ b/server/shadow/shadow_rdpsnd.c
@@ -62,7 +62,6 @@ static void rdpsnd_activated(RdpsndServerContext* context)
 	}
 
 	context->SelectFormat(context, i);
-	context->SetVolume(context, 0x7FFF, 0x7FFF);
 }
 
 int shadow_client_rdpsnd_init(rdpShadowClient* client)


### PR DESCRIPTION
The output buffer and format parameters are not protected. This cause some data inconsistency if rdpsnd has own thread.

A typical race scenario is:

1. Stand Alone rdpsnd server thread: In rdpsnd_server_select_format(), Run to line:

context->selected_client_format = client_format_index; // Now context->priv->out_buffer is still 0

2. Another thread: calls rdpsnd_server_send_samples().
It will pass the check of "if (context->selected_client_format < 0)", but will crash when try to copy samples to context->priv->out_buffer
 