### PR TITLE
winpr/event: fix file descriptor leak

### DIFF
--- a/winpr/libwinpr/synch/event.c
+++ b/winpr/libwinpr/synch/event.c
@@ -364,6 +364,8 @@ int SetEventFileDescriptor(HANDLE hEvent, int FileDescriptor, ULONG mode)
 		return -1;
 
 	event = (WINPR_EVENT*) Object;
+	if (!event->bAttached && event->pipe_fd[0] >= 0)
+		close(event->pipe_fd[0]);
 	event->bAttached = TRUE;
 	event->Mode = mode;
 	event->pipe_fd[0] = FileDescriptor;


### PR DESCRIPTION
SetEventFileDescriptor overrides the internal file descriptor of the
event but didn't close it. Now if the descriptor is closed if it isn't
marked as attached.

Fixes #3355