### PR TITLE
Limit the time passed in transport check loop

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -157,6 +157,7 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "codec-cache", COMMAND_LINE_VALUE_REQUIRED, "<rfx|nsc|jpeg>", NULL, NULL, -1, NULL, "bitmap codec cache" },
 	{ "fast-path", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "Enable fast-path input/output" },
 	{ "max-fast-path-size", COMMAND_LINE_VALUE_OPTIONAL, "<size>", NULL, NULL, -1, NULL, "specify maximum fast-path update size" },
+	{ "max-loop-time", COMMAND_LINE_VALUE_REQUIRED, "<time>", NULL, NULL, -1, NULL, "specify maximum time in milliseconds spend treating packets"},
 	{ "async-input", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "asynchronous input" },
 	{ "async-update", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "asynchronous update" },
 	{ "async-transport", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "asynchronous transport (unstable)" },
@@ -2304,6 +2305,20 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		CommandLineSwitchCase(arg, "max-fast-path-size")
 		{
 			settings->MultifragMaxRequestSize = atoi(arg->Value);
+		}
+		CommandLineSwitchCase(arg, "max-loop-time")
+		{
+			settings->MaxTimeInCheckLoop = atoi(arg->Value);
+			if (settings->MaxTimeInCheckLoop < 0)
+			{
+				WLog_ERR(TAG, "invalid max loop time: %s", arg->Value);
+				return COMMAND_LINE_ERROR;
+			}
+
+			if (settings->MaxTimeInCheckLoop == 0)
+			{
+				settings->MaxTimeInCheckLoop = 10 * 60 * 60 * 1000; /* 10 hours can be considered as infinite */
+			}
 		}
 		CommandLineSwitchCase(arg, "async-input")
 		{

--- a/include/freerdp/peer.h
+++ b/include/freerdp/peer.h
@@ -29,32 +29,33 @@
 
 #include <winpr/sspi.h>
 
-typedef BOOL (*psPeerContextNew)(freerdp_peer* client, rdpContext* context);
-typedef void (*psPeerContextFree)(freerdp_peer* client, rdpContext* context);
+typedef BOOL (*psPeerContextNew)(freerdp_peer* peer, rdpContext* context);
+typedef void (*psPeerContextFree)(freerdp_peer* peer, rdpContext* context);
 
-typedef BOOL (*psPeerInitialize)(freerdp_peer* client);
-typedef BOOL (*psPeerGetFileDescriptor)(freerdp_peer* client, void** rfds, int* rcount);
-typedef HANDLE (*psPeerGetEventHandle)(freerdp_peer* client);
-typedef HANDLE (*psPeerGetReceiveEventHandle)(freerdp_peer* client);
-typedef BOOL (*psPeerCheckFileDescriptor)(freerdp_peer* client);
-typedef BOOL (*psPeerIsWriteBlocked)(freerdp_peer* client);
-typedef int (*psPeerDrainOutputBuffer)(freerdp_peer* client);
-typedef BOOL (*psPeerClose)(freerdp_peer* client);
-typedef void (*psPeerDisconnect)(freerdp_peer* client);
-typedef BOOL (*psPeerCapabilities)(freerdp_peer* client);
-typedef BOOL (*psPeerPostConnect)(freerdp_peer* client);
-typedef BOOL (*psPeerActivate)(freerdp_peer* client);
-typedef BOOL (*psPeerLogon)(freerdp_peer* client, SEC_WINNT_AUTH_IDENTITY* identity, BOOL automatic);
+typedef BOOL (*psPeerInitialize)(freerdp_peer* peer);
+typedef BOOL (*psPeerGetFileDescriptor)(freerdp_peer* peer, void** rfds, int* rcount);
+typedef HANDLE (*psPeerGetEventHandle)(freerdp_peer* peer);
+typedef HANDLE (*psPeerGetReceiveEventHandle)(freerdp_peer* peer);
+typedef BOOL (*psPeerCheckFileDescriptor)(freerdp_peer* peer);
+typedef BOOL (*psPeerIsWriteBlocked)(freerdp_peer* peer);
+typedef int (*psPeerDrainOutputBuffer)(freerdp_peer* peer);
+typedef BOOL (*psPeerHasMoreToRead)(freerdp_peer* peer);
+typedef BOOL (*psPeerClose)(freerdp_peer* peer);
+typedef void (*psPeerDisconnect)(freerdp_peer* peer);
+typedef BOOL (*psPeerCapabilities)(freerdp_peer* peer);
+typedef BOOL (*psPeerPostConnect)(freerdp_peer* peer);
+typedef BOOL (*psPeerActivate)(freerdp_peer* peer);
+typedef BOOL (*psPeerLogon)(freerdp_peer* peer, SEC_WINNT_AUTH_IDENTITY* identity, BOOL automatic);
 
-typedef int (*psPeerSendChannelData)(freerdp_peer* client, UINT16 channelId, BYTE* data, int size);
-typedef int (*psPeerReceiveChannelData)(freerdp_peer* client, UINT16 channelId, BYTE* data, int size, int flags, int totalSize);
+typedef int (*psPeerSendChannelData)(freerdp_peer* peer, UINT16 channelId, BYTE* data, int size);
+typedef int (*psPeerReceiveChannelData)(freerdp_peer* peer, UINT16 channelId, BYTE* data, int size, int flags, int totalSize);
 
-typedef HANDLE (*psPeerVirtualChannelOpen)(freerdp_peer* client, const char* name, UINT32 flags);
-typedef BOOL (*psPeerVirtualChannelClose)(freerdp_peer* client, HANDLE hChannel);
-typedef int (*psPeerVirtualChannelRead)(freerdp_peer* client, HANDLE hChannel, BYTE* buffer, UINT32 length);
-typedef int (*psPeerVirtualChannelWrite)(freerdp_peer* client, HANDLE hChannel, BYTE* buffer, UINT32 length);
-typedef void* (*psPeerVirtualChannelGetData)(freerdp_peer* client, HANDLE hChannel);
-typedef int (*psPeerVirtualChannelSetData)(freerdp_peer* client, HANDLE hChannel, void* data);
+typedef HANDLE (*psPeerVirtualChannelOpen)(freerdp_peer* peer, const char* name, UINT32 flags);
+typedef BOOL (*psPeerVirtualChannelClose)(freerdp_peer* peer, HANDLE hChannel);
+typedef int (*psPeerVirtualChannelRead)(freerdp_peer* peer, HANDLE hChannel, BYTE* buffer, UINT32 length);
+typedef int (*psPeerVirtualChannelWrite)(freerdp_peer* peer, HANDLE hChannel, BYTE* buffer, UINT32 length);
+typedef void* (*psPeerVirtualChannelGetData)(freerdp_peer* peer, HANDLE hChannel);
+typedef int (*psPeerVirtualChannelSetData)(freerdp_peer* peer, HANDLE hChannel, void* data);
 
 struct rdp_freerdp_peer
 {
@@ -106,6 +107,7 @@ struct rdp_freerdp_peer
 
 	psPeerIsWriteBlocked IsWriteBlocked;
 	psPeerDrainOutputBuffer DrainOutputBuffer;
+	psPeerHasMoreToRead HasMoreToRead;
 };
 
 #ifdef __cplusplus

--- a/include/freerdp/peer.h
+++ b/include/freerdp/peer.h
@@ -34,8 +34,8 @@ typedef void (*psPeerContextFree)(freerdp_peer* peer, rdpContext* context);
 
 typedef BOOL (*psPeerInitialize)(freerdp_peer* peer);
 typedef BOOL (*psPeerGetFileDescriptor)(freerdp_peer* peer, void** rfds, int* rcount);
-typedef HANDLE (*psPeerGetEventHandle)(freerdp_peer* peer);
-typedef HANDLE (*psPeerGetReceiveEventHandle)(freerdp_peer* peer);
+typedef HANDLE(*psPeerGetEventHandle)(freerdp_peer* peer);
+typedef HANDLE(*psPeerGetReceiveEventHandle)(freerdp_peer* peer);
 typedef BOOL (*psPeerCheckFileDescriptor)(freerdp_peer* peer);
 typedef BOOL (*psPeerIsWriteBlocked)(freerdp_peer* peer);
 typedef int (*psPeerDrainOutputBuffer)(freerdp_peer* peer);
@@ -48,12 +48,15 @@ typedef BOOL (*psPeerActivate)(freerdp_peer* peer);
 typedef BOOL (*psPeerLogon)(freerdp_peer* peer, SEC_WINNT_AUTH_IDENTITY* identity, BOOL automatic);
 
 typedef int (*psPeerSendChannelData)(freerdp_peer* peer, UINT16 channelId, BYTE* data, int size);
-typedef int (*psPeerReceiveChannelData)(freerdp_peer* peer, UINT16 channelId, BYTE* data, int size, int flags, int totalSize);
+typedef int (*psPeerReceiveChannelData)(freerdp_peer* peer, UINT16 channelId, BYTE* data, int size,
+                                        int flags, int totalSize);
 
-typedef HANDLE (*psPeerVirtualChannelOpen)(freerdp_peer* peer, const char* name, UINT32 flags);
+typedef HANDLE(*psPeerVirtualChannelOpen)(freerdp_peer* peer, const char* name, UINT32 flags);
 typedef BOOL (*psPeerVirtualChannelClose)(freerdp_peer* peer, HANDLE hChannel);
-typedef int (*psPeerVirtualChannelRead)(freerdp_peer* peer, HANDLE hChannel, BYTE* buffer, UINT32 length);
-typedef int (*psPeerVirtualChannelWrite)(freerdp_peer* peer, HANDLE hChannel, BYTE* buffer, UINT32 length);
+typedef int (*psPeerVirtualChannelRead)(freerdp_peer* peer, HANDLE hChannel, BYTE* buffer,
+                                        UINT32 length);
+typedef int (*psPeerVirtualChannelWrite)(freerdp_peer* peer, HANDLE hChannel, BYTE* buffer,
+        UINT32 length);
 typedef void* (*psPeerVirtualChannelGetData)(freerdp_peer* peer, HANDLE hChannel);
 typedef int (*psPeerVirtualChannelSetData)(freerdp_peer* peer, HANDLE hChannel, void* data);
 

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -829,7 +829,8 @@ struct rdp_settings
 	ALIGN64 char* Domain; /* 23 */
 	ALIGN64 char* PasswordHash; /* 24 */
 	ALIGN64 BOOL WaitForOutputBufferFlush; /* 25 */
-	UINT64 padding0064[64 - 26]; /* 26 */
+	ALIGN64 UINT32 MaxTimeInCheckLoop; /* 26 */
+	UINT64 padding0064[64 - 27]; /* 27 */
 	UINT64 padding0128[128 - 64]; /* 64 */
 
 	/**

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -1059,8 +1059,8 @@ struct rdp_settings
 	ALIGN64 rdpRsaKey* RdpServerRsaKey; /* 1413 */
 	ALIGN64 rdpCertificate* RdpServerCertificate; /* 1414 */
 	ALIGN64 BOOL ExternalCertificateManagement; /* 1415 */
-	ALIGN64 char *CertificateContent; /* 1416 */
-	ALIGN64 char *PrivateKeyContent; /* 1417 */
+	ALIGN64 char* CertificateContent; /* 1416 */
+	ALIGN64 char* PrivateKeyContent; /* 1417 */
 	ALIGN64 char* RdpKeyContent; /* 1418 */
 	ALIGN64 BOOL AutoAcceptCertificate; /* 1419 */
 	UINT64 padding1472[1472 - 1420]; /* 1420 */
@@ -1421,7 +1421,8 @@ struct rdp_settings
 	ALIGN64 int num_extensions; /*  */
 	ALIGN64 struct rdp_ext_set extensions[16]; /*  */
 
-	ALIGN64 BYTE* SettingsModified; /* byte array marking fields that have been modified from their default value */
+	ALIGN64 BYTE*
+	SettingsModified; /* byte array marking fields that have been modified from their default value */
 };
 typedef struct rdp_settings rdpSettings;
 
@@ -1441,7 +1442,8 @@ FREERDP_API void freerdp_settings_free(rdpSettings* settings);
 FREERDP_API int freerdp_addin_set_argument(ADDIN_ARGV* args, char* argument);
 FREERDP_API int freerdp_addin_replace_argument(ADDIN_ARGV* args, char* previous, char* argument);
 FREERDP_API int freerdp_addin_set_argument_value(ADDIN_ARGV* args, char* option, char* value);
-FREERDP_API int freerdp_addin_replace_argument_value(ADDIN_ARGV* args, char* previous, char* option, char* value);
+FREERDP_API int freerdp_addin_replace_argument_value(ADDIN_ARGV* args, char* previous, char* option,
+        char* value);
 
 FREERDP_API BOOL freerdp_device_collection_add(rdpSettings* settings, RDPDR_DEVICE* device);
 FREERDP_API RDPDR_DEVICE* freerdp_device_collection_find(rdpSettings* settings, const char* name);
@@ -1450,12 +1452,14 @@ FREERDP_API RDPDR_DEVICE* freerdp_device_clone(RDPDR_DEVICE* device);
 FREERDP_API void freerdp_device_collection_free(rdpSettings* settings);
 
 FREERDP_API BOOL freerdp_static_channel_collection_add(rdpSettings* settings, ADDIN_ARGV* channel);
-FREERDP_API ADDIN_ARGV* freerdp_static_channel_collection_find(rdpSettings* settings, const char* name);
+FREERDP_API ADDIN_ARGV* freerdp_static_channel_collection_find(rdpSettings* settings,
+        const char* name);
 FREERDP_API ADDIN_ARGV* freerdp_static_channel_clone(ADDIN_ARGV* channel);
 FREERDP_API void freerdp_static_channel_collection_free(rdpSettings* settings);
 
 FREERDP_API BOOL freerdp_dynamic_channel_collection_add(rdpSettings* settings, ADDIN_ARGV* channel);
-FREERDP_API ADDIN_ARGV* freerdp_dynamic_channel_collection_find(rdpSettings* settings, const char* name);
+FREERDP_API ADDIN_ARGV* freerdp_dynamic_channel_collection_find(rdpSettings* settings,
+        const char* name);
 FREERDP_API ADDIN_ARGV* freerdp_dynamic_channel_clone(ADDIN_ARGV* channel);
 FREERDP_API void freerdp_dynamic_channel_collection_free(rdpSettings* settings);
 
@@ -1465,7 +1469,8 @@ FREERDP_API void freerdp_performance_flags_make(rdpSettings* settings);
 FREERDP_API void freerdp_performance_flags_split(rdpSettings* settings);
 
 FREERDP_API void freerdp_set_gateway_usage_method(rdpSettings* settings, UINT32 GatewayUsageMethod);
-FREERDP_API void freerdp_update_gateway_usage_method(rdpSettings* settings, UINT32 GatewayEnabled, UINT32 GatewayBypassLocal);
+FREERDP_API void freerdp_update_gateway_usage_method(rdpSettings* settings, UINT32 GatewayEnabled,
+        UINT32 GatewayBypassLocal);
 
 FREERDP_API BOOL freerdp_get_param_bool(rdpSettings* settings, int id);
 FREERDP_API int freerdp_set_param_bool(rdpSettings* settings, int id, BOOL param);

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -674,6 +674,10 @@ static int freerdp_peer_drain_output_buffer(freerdp_peer* peer)
 	return transport_drain_output_buffer(transport);
 }
 
+static BOOL freerdp_peer_has_more_to_read(freerdp_peer* peer) {
+	return peer->context->rdp->transport->haveMoreBytesToRead;
+}
+
 BOOL freerdp_peer_context_new(freerdp_peer* client)
 {
 	rdpRdp* rdp;
@@ -731,6 +735,7 @@ BOOL freerdp_peer_context_new(freerdp_peer* client)
 
 	client->IsWriteBlocked = freerdp_peer_is_write_blocked;
 	client->DrainOutputBuffer = freerdp_peer_drain_output_buffer;
+	client->HasMoreToRead = freerdp_peer_has_more_to_read;
 
 	IFCALLRET(client->ContextNew, ret, client, client->context);
 
@@ -803,6 +808,7 @@ freerdp_peer* freerdp_peer_new(int sockfd)
 		client->SendChannelData = freerdp_peer_send_channel_data;
 		client->IsWriteBlocked = freerdp_peer_is_write_blocked;
 		client->DrainOutputBuffer = freerdp_peer_drain_output_buffer;
+		client->HasMoreToRead = freerdp_peer_has_more_to_read;
 		client->VirtualChannelOpen = freerdp_peer_virtual_channel_open;
 		client->VirtualChannelClose = freerdp_peer_virtual_channel_close;
 		client->VirtualChannelWrite = freerdp_peer_virtual_channel_write;

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -38,7 +38,8 @@
 extern const char* DATA_PDU_TYPE_STRINGS[80];
 #endif
 
-static HANDLE freerdp_peer_virtual_channel_open(freerdp_peer* client, const char* name, UINT32 flags)
+static HANDLE freerdp_peer_virtual_channel_open(freerdp_peer* client, const char* name,
+        UINT32 flags)
 {
 	int length;
 	UINT32 index;
@@ -105,19 +106,19 @@ static BOOL freerdp_peer_virtual_channel_close(freerdp_peer* client, HANDLE hCha
 
 	peerChannel = (rdpPeerChannel*) hChannel;
 	mcsChannel = peerChannel->mcsChannel;
-
 	mcsChannel->handle = NULL;
 	free(peerChannel);
-
 	return TRUE;
 }
 
-int freerdp_peer_virtual_channel_read(freerdp_peer* client, HANDLE hChannel, BYTE* buffer, UINT32 length)
+int freerdp_peer_virtual_channel_read(freerdp_peer* client, HANDLE hChannel, BYTE* buffer,
+                                      UINT32 length)
 {
 	return 0; /* this needs to be implemented by the server application */
 }
 
-static int freerdp_peer_virtual_channel_write(freerdp_peer* client, HANDLE hChannel, BYTE* buffer, UINT32 length)
+static int freerdp_peer_virtual_channel_write(freerdp_peer* client, HANDLE hChannel, BYTE* buffer,
+        UINT32 length)
 {
 	wStream* s;
 	UINT32 flags;
@@ -138,13 +139,13 @@ static int freerdp_peer_virtual_channel_write(freerdp_peer* client, HANDLE hChan
 		return -1; /* not yet supported */
 
 	maxChunkSize = rdp->settings->VirtualChannelChunkSize;
-
 	totalLength = length;
 	flags = CHANNEL_FLAG_FIRST;
 
 	while (length > 0)
 	{
 		s = rdp_send_stream_init(rdp);
+
 		if (!s)
 			return -1;
 
@@ -163,11 +164,13 @@ static int freerdp_peer_virtual_channel_write(freerdp_peer* client, HANDLE hChan
 
 		Stream_Write_UINT32(s, totalLength);
 		Stream_Write_UINT32(s, flags);
+
 		if (!Stream_EnsureRemainingCapacity(s, chunkSize))
 		{
 			Stream_Release(s);
 			return -1;
 		}
+
 		Stream_Write(s, buffer, chunkSize);
 
 		if (!rdp_send(rdp, s, peerChannel->channelId))
@@ -202,7 +205,6 @@ int freerdp_peer_virtual_channel_set_data(freerdp_peer* client, HANDLE hChannel,
 		return -1;
 
 	peerChannel->extra = data;
-
 	return 1;
 }
 
@@ -210,7 +212,6 @@ static BOOL freerdp_peer_initialize(freerdp_peer* client)
 {
 	rdpRdp* rdp = client->context->rdp;
 	rdpSettings* settings = rdp->settings;
-
 	settings->ServerMode = TRUE;
 	settings->FrameAcknowledge = 0;
 	settings->LocalConnection = client->local;
@@ -219,6 +220,7 @@ static BOOL freerdp_peer_initialize(freerdp_peer* client)
 	if (settings->RdpKeyFile)
 	{
 		settings->RdpServerRsaKey = key_new(settings->RdpKeyFile);
+
 		if (!settings->RdpServerRsaKey)
 		{
 			WLog_ERR(TAG, "invalid RDP key file %s", settings->RdpKeyFile);
@@ -228,6 +230,7 @@ static BOOL freerdp_peer_initialize(freerdp_peer* client)
 	else if (settings->RdpKeyContent)
 	{
 		settings->RdpServerRsaKey = key_new_from_content(settings->RdpKeyContent, NULL);
+
 		if (!settings->RdpServerRsaKey)
 		{
 			WLog_ERR(TAG, "invalid RDP key content");
@@ -241,10 +244,8 @@ static BOOL freerdp_peer_initialize(freerdp_peer* client)
 static BOOL freerdp_peer_get_fds(freerdp_peer* client, void** rfds, int* rcount)
 {
 	rdpTransport* transport = client->context->rdp->transport;
-
 	rfds[*rcount] = (void*)(long)(BIO_get_fd(transport->frontBio, NULL));
 	(*rcount)++;
-
 	return TRUE;
 }
 
@@ -252,9 +253,7 @@ static HANDLE freerdp_peer_get_event_handle(freerdp_peer* client)
 {
 	HANDLE hEvent = NULL;
 	rdpTransport* transport = client->context->rdp->transport;
-
 	BIO_get_event(transport->frontBio, &hEvent);
-
 	return hEvent;
 }
 
@@ -262,9 +261,7 @@ static BOOL freerdp_peer_check_fds(freerdp_peer* peer)
 {
 	int status;
 	rdpRdp* rdp;
-
 	rdp = peer->context->rdp;
-
 	status = rdp_check_fds(rdp);
 
 	if (status < 0)
@@ -286,7 +283,7 @@ static BOOL peer_recv_data_pdu(freerdp_peer* client, wStream* s)
 
 #ifdef WITH_DEBUG_RDP
 	WLog_DBG(TAG, "recv %s Data PDU (0x%02X), length: %d",
-			 type < ARRAYSIZE(DATA_PDU_TYPE_STRINGS) ? DATA_PDU_TYPE_STRINGS[type] : "???", type, length);
+	         type < ARRAYSIZE(DATA_PDU_TYPE_STRINGS) ? DATA_PDU_TYPE_STRINGS[type] : "???", type, length);
 #endif
 
 	switch (type)
@@ -294,16 +291,19 @@ static BOOL peer_recv_data_pdu(freerdp_peer* client, wStream* s)
 		case DATA_PDU_TYPE_SYNCHRONIZE:
 			if (!rdp_recv_client_synchronize_pdu(client->context->rdp, s))
 				return FALSE;
+
 			break;
 
 		case DATA_PDU_TYPE_CONTROL:
 			if (!rdp_server_accept_client_control_pdu(client->context->rdp, s))
 				return FALSE;
+
 			break;
 
 		case DATA_PDU_TYPE_INPUT:
 			if (!input_recv(client->context->rdp->input, s))
 				return FALSE;
+
 			break;
 
 		case DATA_PDU_TYPE_BITMAP_CACHE_PERSISTENT_LIST:
@@ -311,7 +311,6 @@ static BOOL peer_recv_data_pdu(freerdp_peer* client, wStream* s)
 			break;
 
 		case DATA_PDU_TYPE_FONT_LIST:
-
 			if (!rdp_server_accept_client_font_list_pdu(client->context->rdp, s))
 				return FALSE;
 
@@ -324,6 +323,7 @@ static BOOL peer_recv_data_pdu(freerdp_peer* client, wStream* s)
 		case DATA_PDU_TYPE_FRAME_ACKNOWLEDGE:
 			if (Stream_GetRemainingLength(s) < 4)
 				return FALSE;
+
 			Stream_Read_UINT32(s, client->ack_frame_id);
 			IFCALL(client->update->SurfaceFrameAcknowledge, client->update->context, client->ack_frame_id);
 			break;
@@ -331,11 +331,13 @@ static BOOL peer_recv_data_pdu(freerdp_peer* client, wStream* s)
 		case DATA_PDU_TYPE_REFRESH_RECT:
 			if (!update_read_refresh_rect(client->update, s))
 				return FALSE;
+
 			break;
 
 		case DATA_PDU_TYPE_SUPPRESS_OUTPUT:
 			if (!update_read_suppress_output(client->update, s))
 				return FALSE;
+
 			break;
 
 		default:
@@ -355,7 +357,6 @@ static int peer_recv_tpkt_pdu(freerdp_peer* client, wStream* s)
 	UINT16 pduSource;
 	UINT16 channelId;
 	UINT16 securityFlags;
-
 	rdp = client->context->rdp;
 
 	if (!rdp_read_header(rdp, s, &length, &channelId))
@@ -366,7 +367,7 @@ static int peer_recv_tpkt_pdu(freerdp_peer* client, wStream* s)
 
 	if (freerdp_shall_disconnect(rdp->instance))
 		return 0;
- 
+
 	if (rdp->settings->UseRdpSecurityLayer)
 	{
 		if (!rdp_read_security_header(s, &securityFlags))
@@ -394,11 +395,13 @@ static int peer_recv_tpkt_pdu(freerdp_peer* client, wStream* s)
 			case PDU_TYPE_DATA:
 				if (!peer_recv_data_pdu(client, s))
 					return -1;
+
 				break;
 
 			case PDU_TYPE_CONFIRM_ACTIVE:
 				if (!rdp_server_accept_confirm_active(rdp, s))
 					return -1;
+
 				break;
 
 			case PDU_TYPE_FLOW_RESPONSE:
@@ -433,10 +436,8 @@ static int peer_recv_fastpath_pdu(freerdp_peer* client, wStream* s)
 	rdpRdp* rdp;
 	UINT16 length;
 	rdpFastPath* fastpath;
-
 	rdp = client->context->rdp;
 	fastpath = rdp->fastpath;
-
 	fastpath_read_header_rdp(fastpath, s, &length);
 
 	if ((length == 0) || (length > Stream_GetRemainingLength(s)))
@@ -447,7 +448,8 @@ static int peer_recv_fastpath_pdu(freerdp_peer* client, wStream* s)
 
 	if (fastpath->encryptionFlags & FASTPATH_OUTPUT_ENCRYPTED)
 	{
-		if (!rdp_decrypt(rdp, s, length, (fastpath->encryptionFlags & FASTPATH_OUTPUT_SECURE_CHECKSUM) ? SEC_SECURE_CHECKSUM : 0))
+		if (!rdp_decrypt(rdp, s, length,
+		                 (fastpath->encryptionFlags & FASTPATH_OUTPUT_SECURE_CHECKSUM) ? SEC_SECURE_CHECKSUM : 0))
 			return -1;
 	}
 
@@ -497,33 +499,41 @@ static int peer_recv_callback(rdpTransport* transport, wStream* s, void* extra)
 		case CONNECTION_STATE_NEGO:
 			if (!rdp_server_accept_mcs_connect_initial(rdp, s))
 			{
-				WLog_ERR(TAG, "peer_recv_callback: CONNECTION_STATE_NEGO - rdp_server_accept_mcs_connect_initial() fail");
+				WLog_ERR(TAG,
+				         "peer_recv_callback: CONNECTION_STATE_NEGO - rdp_server_accept_mcs_connect_initial() fail");
 				return -1;
 			}
+
 			break;
 
 		case CONNECTION_STATE_MCS_CONNECT:
 			if (!rdp_server_accept_mcs_erect_domain_request(rdp, s))
 			{
-				WLog_ERR(TAG, "peer_recv_callback: CONNECTION_STATE_MCS_CONNECT - rdp_server_accept_mcs_erect_domain_request() fail");
+				WLog_ERR(TAG,
+				         "peer_recv_callback: CONNECTION_STATE_MCS_CONNECT - rdp_server_accept_mcs_erect_domain_request() fail");
 				return -1;
 			}
+
 			break;
 
 		case CONNECTION_STATE_MCS_ERECT_DOMAIN:
 			if (!rdp_server_accept_mcs_attach_user_request(rdp, s))
 			{
-				WLog_ERR(TAG, "peer_recv_callback: CONNECTION_STATE_MCS_ERECT_DOMAIN - rdp_server_accept_mcs_attach_user_request() fail");
+				WLog_ERR(TAG,
+				         "peer_recv_callback: CONNECTION_STATE_MCS_ERECT_DOMAIN - rdp_server_accept_mcs_attach_user_request() fail");
 				return -1;
 			}
+
 			break;
 
 		case CONNECTION_STATE_MCS_ATTACH_USER:
 			if (!rdp_server_accept_mcs_channel_join_request(rdp, s))
 			{
-				WLog_ERR(TAG, "peer_recv_callback: CONNECTION_STATE_MCS_ATTACH_USER - rdp_server_accept_mcs_channel_join_request() fail");
+				WLog_ERR(TAG,
+				         "peer_recv_callback: CONNECTION_STATE_MCS_ATTACH_USER - rdp_server_accept_mcs_channel_join_request() fail");
 				return -1;
 			}
+
 			break;
 
 		case CONNECTION_STATE_RDP_SECURITY_COMMENCEMENT:
@@ -531,49 +541,52 @@ static int peer_recv_callback(rdpTransport* transport, wStream* s, void* extra)
 			{
 				if (!rdp_server_establish_keys(rdp, s))
 				{
-					WLog_ERR(TAG, "peer_recv_callback: CONNECTION_STATE_RDP_SECURITY_COMMENCEMENT - rdp_server_establish_keys() fail");
+					WLog_ERR(TAG,
+					         "peer_recv_callback: CONNECTION_STATE_RDP_SECURITY_COMMENCEMENT - rdp_server_establish_keys() fail");
 					return -1;
 				}
 			}
 
 			rdp_server_transition_to_state(rdp, CONNECTION_STATE_SECURE_SETTINGS_EXCHANGE);
+
 			if (Stream_GetRemainingLength(s) > 0)
 				return peer_recv_callback(transport, s, extra);
+
 			break;
 
 		case CONNECTION_STATE_SECURE_SETTINGS_EXCHANGE:
 			if (!rdp_recv_client_info(rdp, s))
 			{
-				WLog_ERR(TAG, "peer_recv_callback: CONNECTION_STATE_SECURE_SETTINGS_EXCHANGE - rdp_recv_client_info() fail");
+				WLog_ERR(TAG,
+				         "peer_recv_callback: CONNECTION_STATE_SECURE_SETTINGS_EXCHANGE - rdp_recv_client_info() fail");
 				return -1;
 			}
 
 			rdp_server_transition_to_state(rdp, CONNECTION_STATE_LICENSING);
 			return peer_recv_callback(transport, NULL, extra);
-
 			break;
 
 		case CONNECTION_STATE_LICENSING:
 			if (!license_send_valid_client_error_packet(rdp->license))
 			{
-				WLog_ERR(TAG, "peer_recv_callback: CONNECTION_STATE_LICENSING - license_send_valid_client_error_packet() fail");
+				WLog_ERR(TAG,
+				         "peer_recv_callback: CONNECTION_STATE_LICENSING - license_send_valid_client_error_packet() fail");
 				return FALSE;
 			}
 
 			rdp_server_transition_to_state(rdp, CONNECTION_STATE_CAPABILITIES_EXCHANGE);
 			return peer_recv_callback(transport, NULL, extra);
-
 			break;
 
 		case CONNECTION_STATE_CAPABILITIES_EXCHANGE:
-
 			if (!rdp->AwaitCapabilities)
 			{
 				IFCALL(client->Capabilities, client);
 
 				if (!rdp_send_demand_active(rdp))
 				{
-					WLog_ERR(TAG, "peer_recv_callback: CONNECTION_STATE_CAPABILITIES_EXCHANGE - rdp_send_demand_active() fail");
+					WLog_ERR(TAG,
+					         "peer_recv_callback: CONNECTION_STATE_CAPABILITIES_EXCHANGE - rdp_send_demand_active() fail");
 					return -1;
 				}
 
@@ -594,7 +607,6 @@ static int peer_recv_callback(rdpTransport* transport, wStream* s, void* extra)
 				 * During reactivation sequence the client might sent some input or channel data
 				 * before receiving the Deactivate All PDU. We need to process them as usual.
 				 */
-
 				if (peer_recv_pdu(client, s) < 0)
 				{
 					WLog_ERR(TAG, "peer_recv_callback: CONNECTION_STATE_CAPABILITIES_EXCHANGE - peer_recv_pdu() fail");
@@ -610,6 +622,7 @@ static int peer_recv_callback(rdpTransport* transport, wStream* s, void* extra)
 				WLog_ERR(TAG, "peer_recv_callback: CONNECTION_STATE_FINALIZATION - peer_recv_pdu() fail");
 				return -1;
 			}
+
 			break;
 
 		case CONNECTION_STATE_ACTIVE:
@@ -618,6 +631,7 @@ static int peer_recv_callback(rdpTransport* transport, wStream* s, void* extra)
 				WLog_ERR(TAG, "peer_recv_callback: CONNECTION_STATE_ACTIVE - peer_recv_pdu() fail");
 				return -1;
 			}
+
 			break;
 
 		default:
@@ -644,7 +658,8 @@ static BOOL freerdp_peer_close(freerdp_peer* client)
 	if (!rdp_send_deactivate_all(client->context->rdp))
 		return FALSE;
 
-	if (freerdp_get_param_bool(client->settings, FreeRDP_SupportErrorInfoPdu) ) {
+	if (freerdp_get_param_bool(client->settings, FreeRDP_SupportErrorInfoPdu))
+	{
 		rdp_send_error_info(client->context->rdp);
 	}
 
@@ -657,7 +672,8 @@ static void freerdp_peer_disconnect(freerdp_peer* client)
 	transport_disconnect(transport);
 }
 
-static int freerdp_peer_send_channel_data(freerdp_peer* client, UINT16 channelId, BYTE* data, int size)
+static int freerdp_peer_send_channel_data(freerdp_peer* client, UINT16 channelId, BYTE* data,
+        int size)
 {
 	return rdp_send_channel_data(client->context->rdp, channelId, data, size);
 }
@@ -674,7 +690,8 @@ static int freerdp_peer_drain_output_buffer(freerdp_peer* peer)
 	return transport_drain_output_buffer(transport);
 }
 
-static BOOL freerdp_peer_has_more_to_read(freerdp_peer* peer) {
+static BOOL freerdp_peer_has_more_to_read(freerdp_peer* peer)
+{
 	return peer->context->rdp->transport->haveMoreBytesToRead;
 }
 
@@ -691,7 +708,6 @@ BOOL freerdp_peer_context_new(freerdp_peer* client)
 		goto fail_context;
 
 	client->context = context;
-
 	context->peer = client;
 	context->ServerMode = TRUE;
 	context->settings = client->settings;
@@ -706,17 +722,14 @@ BOOL freerdp_peer_context_new(freerdp_peer* client)
 	client->update = rdp->update;
 	client->settings = rdp->settings;
 	client->autodetect = rdp->autodetect;
-
 	context->rdp = rdp;
 	context->input = client->input;
 	context->update = client->update;
 	context->settings = client->settings;
 	context->autodetect = client->autodetect;
-
 	client->update->context = context;
 	client->input->context = context;
 	client->autodetect->context = context;
-
 	update_register_server_callbacks(client->update);
 	autodetect_register_server_callbacks(client->autodetect);
 
@@ -732,18 +745,15 @@ BOOL freerdp_peer_context_new(freerdp_peer* client)
 	rdp->transport->ReceiveCallback = peer_recv_callback;
 	rdp->transport->ReceiveExtra = client;
 	transport_set_blocking_mode(rdp->transport, FALSE);
-
 	client->IsWriteBlocked = freerdp_peer_is_write_blocked;
 	client->DrainOutputBuffer = freerdp_peer_drain_output_buffer;
 	client->HasMoreToRead = freerdp_peer_has_more_to_read;
-
 	IFCALLRET(client->ContextNew, ret, client, client->context);
 
 	if (ret)
 		return TRUE;
 
 	WLog_ERR(TAG, "ContextNew callback failed");
-
 fail_transport_attach:
 	free(context->errorDescription);
 fail_error_description:
@@ -754,7 +764,6 @@ fail_metrics:
 	free(client->context);
 fail_context:
 	client->context = NULL;
-
 	WLog_ERR(TAG, "Failed to create new peer context");
 	return FALSE;
 }
@@ -767,13 +776,10 @@ void freerdp_peer_context_free(freerdp_peer* client)
 	{
 		free(client->context->errorDescription);
 		client->context->errorDescription = NULL;
-
 		rdp_free(client->context->rdp);
 		client->context->rdp = NULL;
-
 		metrics_free(client->context->metrics);
 		client->context->metrics = NULL;
-
 		free(client->context);
 		client->context = NULL;
 	}
@@ -784,7 +790,6 @@ freerdp_peer* freerdp_peer_new(int sockfd)
 	UINT32 option_value;
 	socklen_t option_len;
 	freerdp_peer* client;
-
 	client = (freerdp_peer*) calloc(1, sizeof(freerdp_peer));
 
 	if (!client)
@@ -792,7 +797,6 @@ freerdp_peer* freerdp_peer_new(int sockfd)
 
 	option_value = TRUE;
 	option_len = sizeof(option_value);
-
 	setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (void*) &option_value, option_len);
 
 	if (client)

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -277,6 +277,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 
 	settings->ServerMode = (flags & FREERDP_SETTINGS_SERVER_MODE) ? TRUE : FALSE;
 	settings->WaitForOutputBufferFlush = TRUE;
+	settings->MaxTimeInCheckLoop = 100;
 	settings->DesktopWidth = 1024;
 	settings->DesktopHeight = 768;
 	settings->Workarea = FALSE;

--- a/libfreerdp/core/test/TestConnect.c
+++ b/libfreerdp/core/test/TestConnect.c
@@ -8,8 +8,8 @@ static HANDLE s_sync = NULL;
 static int runInstance(int argc, char* argv[], freerdp** inst)
 {
 	int rc = -1;
-
 	freerdp* instance = freerdp_new();
+
 	if (!instance)
 		goto finish;
 
@@ -32,19 +32,19 @@ static int runInstance(int argc, char* argv[], freerdp** inst)
 	}
 
 	rc = 1;
+
 	if (!freerdp_connect(instance))
 		goto finish;
 
 	rc = 2;
+
 	if (!freerdp_disconnect(instance))
 		goto finish;
 
 	rc = 0;
-
 finish:
 	freerdp_context_free(instance);
 	freerdp_free(instance);
-
 	return rc;
 }
 
@@ -58,9 +58,7 @@ static int testTimeout(int port)
 		"/v:192.0.2.1:XXXXX",
 		NULL
 	};
-
 	int rc;
-
 	snprintf(arg1, 18, "/v:192.0.2.1:%d", port);
 	argv[1] = arg1;
 	start = GetTickCount();
@@ -71,6 +69,7 @@ static int testTimeout(int port)
 		return -1;
 
 	diff = end - start;
+
 	if (diff > 16000)
 		return -1;
 
@@ -81,7 +80,8 @@ static int testTimeout(int port)
 	return 0;
 }
 
-struct testThreadArgs {
+struct testThreadArgs
+{
 	int port;
 	freerdp** arg;
 };
@@ -95,12 +95,10 @@ static void* testThread(void* arg)
 		"/v:192.0.2.1:XXXXX",
 		NULL
 	};
-
 	int rc;
-	struct testThreadArgs *args = arg;
+	struct testThreadArgs* args = arg;
 	snprintf(arg1, 18, "/v:192.0.2.1:%d", args->port);
 	argv[1] = arg1;
-
 	rc = runInstance(2, argv, args->arg);
 
 	if (rc != 1)
@@ -117,8 +115,8 @@ static int testAbort(int port)
 	HANDLE thread;
 	struct testThreadArgs args;
 	freerdp* instance = NULL;
-
 	s_sync = CreateEvent(NULL, TRUE, FALSE, NULL);
+
 	if (!s_sync)
 		return -1;
 
@@ -126,7 +124,8 @@ static int testAbort(int port)
 	args.arg = &instance;
 	start = GetTickCount();
 	thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)testThread,
-				&args, 0, NULL);
+	                      &args, 0, NULL);
+
 	if (!thread)
 	{
 		CloseHandle(s_sync);
@@ -137,6 +136,7 @@ static int testAbort(int port)
 	WaitForSingleObject(s_sync, INFINITE);
 	freerdp_abort_connect(instance);
 	status = WaitForSingleObject(instance->context->abortEvent, 0);
+
 	if (status != WAIT_OBJECT_0)
 	{
 		CloseHandle(s_sync);
@@ -147,12 +147,11 @@ static int testAbort(int port)
 
 	status = WaitForSingleObject(thread, 20000);
 	end = GetTickCount();
-
 	CloseHandle(s_sync);
 	CloseHandle(thread);
 	s_sync = NULL;
-
 	diff = end - start;
+
 	if (diff > 1000)
 		return -1;
 
@@ -177,15 +176,13 @@ static int testSuccess(int port)
 		"/rfx",
 		NULL
 	};
-	char *commandLine;
+	char* commandLine;
 	int commandLineLen;
-
 	int argc = 4;
 	char* path = TESTING_OUTPUT_DIRECTORY;
 	char* wpath = TESTING_SRC_DIRECTORY;
 	char* exe = GetCombinedPath(path, "server");
 	char* wexe = GetCombinedPath(wpath, "server");
-
 	snprintf(arg1, 18, "/v:127.0.0.1:%d", port);
 	clientArgs[1] = arg1;
 
@@ -219,6 +216,7 @@ static int testSuccess(int port)
 
 	printf("Sample Server: %s\n", exe);
 	printf("Workspace: %s\n", wpath);
+
 	if (!PathFileExistsA(exe))
 	{
 		free(path);
@@ -230,6 +228,7 @@ static int testSuccess(int port)
 	// Start sample server locally.
 	commandLineLen = strlen(exe) + strlen(" --port=XXXXX") + 1;
 	commandLine = malloc(commandLineLen);
+
 	if (!commandLine)
 	{
 		free(path);
@@ -237,13 +236,13 @@ static int testSuccess(int port)
 		free(exe);
 		return -2;
 	}
-	snprintf(commandLine, commandLineLen, "%s --port=%d", exe, port);
 
+	snprintf(commandLine, commandLineLen, "%s --port=%d", exe, port);
 	memset(&si, 0, sizeof(si));
-    si.cb = sizeof(si);
+	si.cb = sizeof(si);
 
 	if (!CreateProcessA(exe, commandLine, NULL, NULL, FALSE, 0, NULL,
-				wpath, &si, &process))
+	                    wpath, &si, &process))
 	{
 		free(exe);
 		free(path);
@@ -255,7 +254,6 @@ static int testSuccess(int port)
 	free(path);
 	free(wpath);
 	free(commandLine);
-
 	Sleep(1 * 1000); /* let the server start */
 	rc = runInstance(argc, clientArgs, NULL);
 
@@ -265,8 +263,8 @@ static int testSuccess(int port)
 	WaitForSingleObject(process.hProcess, INFINITE);
 	CloseHandle(process.hProcess);
 	CloseHandle(process.hThread);
-
 	printf("%s: returned %d!\n", __FUNCTION__, rc);
+
 	if (rc)
 		return -1;
 
@@ -277,7 +275,6 @@ static int testSuccess(int port)
 int TestConnect(int argc, char* argv[])
 {
 	int randomPort;
-
 	randomPort = 3389 + (random() % 200);
 
 	/* Test connect to not existing server,

--- a/libfreerdp/core/test/TestConnect.c
+++ b/libfreerdp/core/test/TestConnect.c
@@ -278,7 +278,7 @@ int TestConnect(int argc, char* argv[])
 {
 	int randomPort;
 
-	randomPort = 3389 + (random() % 20);
+	randomPort = 3389 + (random() % 200);
 
 	/* Test connect to not existing server,
 	 * check if timeout is honored. */

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -917,7 +917,7 @@ int transport_check_fds(rdpTransport* transport)
 		now = GetTickCount();
 	}
 
-	if (now > dueDate)
+	if (now >= dueDate)
 	{
 		SetEvent(transport->rereadEvent);
 		transport->haveMoreBytesToRead = TRUE;

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -1153,6 +1153,7 @@ void transport_free(rdpTransport* transport)
 
 	StreamPool_Free(transport->ReceivePool);
 	CloseHandle(transport->connectedEvent);
+	CloseHandle(transport->rereadEvent);
 	DeleteCriticalSection(&(transport->ReadLock));
 	DeleteCriticalSection(&(transport->WriteLock));
 	free(transport);

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -756,38 +756,58 @@ out_cleanup:
 DWORD transport_get_event_handles(rdpTransport* transport, HANDLE* events,
                                   DWORD count)
 {
-	DWORD nCount = 0;
+	DWORD nCount = 1; /* always the reread Event */
 	DWORD tmp;
+
+	if (events)
+	{
+		if (count < 1)
+		{
+			WLog_ERR(TAG, "%s: provided handles array is too small", __FUNCTION__);
+			return 0;
+		}
+
+		events[0] = transport->rereadEvent;
+	}
 
 	if (!transport->GatewayEnabled)
 	{
-		if (events && (nCount < count))
+		nCount++;
+		if (events)
 		{
-			if (BIO_get_event(transport->frontBio, &events[nCount]) != 1)
+			if (nCount > count)
+			{
+				WLog_ERR(TAG, "%s: provided handles array is too small (count=%d nCount=%d)",
+						__FUNCTION__, count, nCount);
 				return 0;
+			}
 
-			nCount++;
+			if (BIO_get_event(transport->frontBio, &events[1]) != 1)
+			{
+				WLog_ERR(TAG, "%s: error getting the frontBio handle", __FUNCTION__);
+				return 0;
+			}
 		}
 	}
 	else
 	{
 		if (transport->rdg)
 		{
-			tmp = rdg_get_event_handles(transport->rdg, events, nCount - count);
+			tmp = rdg_get_event_handles(transport->rdg, &events[1], count - 1);
 
 			if (tmp == 0)
 				return 0;
 
-			nCount = tmp;
+			nCount += tmp;
 		}
 		else if (transport->tsg)
 		{
-			tmp = tsg_get_event_handles(transport->tsg, events, nCount - count);
+			tmp = tsg_get_event_handles(transport->tsg, &events[1], count - 1);
 
 			if (tmp == 0)
 				return 0;
 
-			nCount = tmp;
+			nCount += tmp;
 		}
 	}
 
@@ -800,12 +820,14 @@ void transport_get_fds(rdpTransport* transport, void** rfds, int* rcount)
 	DWORD nCount;
 	HANDLE events[64];
 	nCount = transport_get_event_handles(transport, events, 64);
-	*rcount = nCount;
+	*rcount = nCount + 1;
 
 	for (index = 0; index < nCount; index++)
 	{
 		rfds[index] = GetEventWaitObject(events[index]);
 	}
+
+	rfds[nCount + 1] = GetEventWaitObject(transport->rereadEvent);
 }
 
 BOOL transport_is_write_blocked(rdpTransport* transport)
@@ -833,11 +855,19 @@ int transport_check_fds(rdpTransport* transport)
 	int status;
 	int recv_status;
 	wStream* received;
+	DWORD now = GetTickCount();
+	DWORD dueDate = now + transport->settings->MaxTimeInCheckLoop;
 
 	if (!transport)
 		return -1;
 
-	while (!freerdp_shall_disconnect(transport->context->instance))
+	if (transport->haveMoreBytesToRead)
+	{
+		transport->haveMoreBytesToRead = FALSE;
+		ResetEvent(transport->rereadEvent);
+	}
+
+	while(!freerdp_shall_disconnect(transport->context->instance) && (now < dueDate))
 	{
 		/**
 		 * Note: transport_read_pdu tries to read one PDU from
@@ -883,8 +913,15 @@ int transport_check_fds(rdpTransport* transport)
 			         recv_status);
 			return -1;
 		}
+
+		now = GetTickCount();
 	}
 
+	if (now > dueDate)
+	{
+		SetEvent(transport->rereadEvent);
+		transport->haveMoreBytesToRead = TRUE;
+	}
 	return 0;
 }
 
@@ -1073,12 +1110,17 @@ rdpTransport* transport_new(rdpContext* context)
 	    || transport->connectedEvent == INVALID_HANDLE_VALUE)
 		goto out_free_receivebuffer;
 
+	transport->rereadEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+	if (!transport->rereadEvent || transport->rereadEvent == INVALID_HANDLE_VALUE)
+		goto out_free_connectedEvent;
+
+	transport->haveMoreBytesToRead = FALSE;
 	transport->blocking = TRUE;
 	transport->GatewayEnabled = FALSE;
 	transport->layer = TRANSPORT_LAYER_TCP;
 
 	if (!InitializeCriticalSectionAndSpinCount(&(transport->ReadLock), 4000))
-		goto out_free_connectedEvent;
+		goto out_free_rereadEvent;
 
 	if (!InitializeCriticalSectionAndSpinCount(&(transport->WriteLock), 4000))
 		goto out_free_readlock;
@@ -1086,6 +1128,8 @@ rdpTransport* transport_new(rdpContext* context)
 	return transport;
 out_free_readlock:
 	DeleteCriticalSection(&(transport->ReadLock));
+out_free_rereadEvent:
+	CloseHandle(transport->rereadEvent);
 out_free_connectedEvent:
 	CloseHandle(transport->connectedEvent);
 out_free_receivebuffer:

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -773,12 +773,13 @@ DWORD transport_get_event_handles(rdpTransport* transport, HANDLE* events,
 	if (!transport->GatewayEnabled)
 	{
 		nCount++;
+
 		if (events)
 		{
 			if (nCount > count)
 			{
 				WLog_ERR(TAG, "%s: provided handles array is too small (count=%d nCount=%d)",
-						__FUNCTION__, count, nCount);
+				         __FUNCTION__, count, nCount);
 				return 0;
 			}
 
@@ -867,7 +868,7 @@ int transport_check_fds(rdpTransport* transport)
 		ResetEvent(transport->rereadEvent);
 	}
 
-	while(!freerdp_shall_disconnect(transport->context->instance) && (now < dueDate))
+	while (!freerdp_shall_disconnect(transport->context->instance) && (now < dueDate))
 	{
 		/**
 		 * Note: transport_read_pdu tries to read one PDU from
@@ -922,6 +923,7 @@ int transport_check_fds(rdpTransport* transport)
 		SetEvent(transport->rereadEvent);
 		transport->haveMoreBytesToRead = TRUE;
 	}
+
 	return 0;
 }
 
@@ -1111,6 +1113,7 @@ rdpTransport* transport_new(rdpContext* context)
 		goto out_free_receivebuffer;
 
 	transport->rereadEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+
 	if (!transport->rereadEvent || transport->rereadEvent == INVALID_HANDLE_VALUE)
 		goto out_free_connectedEvent;
 

--- a/libfreerdp/core/transport.h
+++ b/libfreerdp/core/transport.h
@@ -79,6 +79,8 @@ struct rdp_transport
 	CRITICAL_SECTION ReadLock;
 	CRITICAL_SECTION WriteLock;
 	ULONG written;
+	HANDLE rereadEvent;
+	BOOL haveMoreBytesToRead;
 };
 
 FREERDP_LOCAL wStream* transport_send_stream_init(rdpTransport* transport,

--- a/scripts/format_code.sh
+++ b/scripts/format_code.sh
@@ -31,9 +31,9 @@ if [ $# -le 0 ]; then
 fi
 
 $ASTYLE --lineend=linux --mode=c --indent=tab=4 --pad-header --pad-oper --style=allman --min-conditional-indent=0 \
-							   --indent-switches --indent-cases --indent-preprocessor -k1 --max-code-length=80 \
+							   --indent-switches --indent-cases --indent-preprocessor -k1 --max-code-length=100 \
 							   --indent-col1-comments --delete-empty-lines --break-closing-brackets \
-							   --align-pointer=type --indent-labels -xe \
+							   --align-pointer=type --indent-labels -xe --break-after-logical \
 							   --unpad-paren --break-blocks $@
 
 exit $?

--- a/server/Sample/sfreerdp.c
+++ b/server/Sample/sfreerdp.c
@@ -881,6 +881,7 @@ int main(int argc, char* argv[])
 	char* file;
 	char name[MAX_PATH];
 	int port = 3389, i;
+	BOOL localOnly = FALSE;
 
 	for (i = 1; i < argc; i++)
 	{
@@ -900,6 +901,8 @@ int main(int argc, char* argv[])
 			if ((port < 1) || (port > 0xFFFF))
 				return -1;
 		}
+		else if (strcmp(arg, "--local-only"))
+			localOnly = TRUE;
 		else if (strncmp(arg, "--", 2))
 			test_pcap_file = arg;
 	}
@@ -929,8 +932,8 @@ int main(int argc, char* argv[])
 		return -1;
 	}
 
-	if (instance->Open(instance, NULL, port) &&
-	    instance->OpenLocal(instance, file))
+	if ((localOnly || instance->Open(instance, NULL, port)) &&
+		instance->OpenLocal(instance, file))
 	{
 		/* Entering the server main loop. In a real server the listener can be run in its own thread. */
 		test_server_mainloop(instance);

--- a/server/Sample/sfreerdp.c
+++ b/server/Sample/sfreerdp.c
@@ -60,7 +60,7 @@ BOOL test_peer_context_new(freerdp_peer* client, testPeerContext* context)
 		goto fail_rfx_context;
 
 	if (!rfx_context_reset(context->rfx_context, SAMPLE_SERVER_DEFAULT_WIDTH,
-			       SAMPLE_SERVER_DEFAULT_HEIGHT))
+	                       SAMPLE_SERVER_DEFAULT_HEIGHT))
 		goto fail_rfx_context;
 
 	context->rfx_context->mode = RLGR3;
@@ -197,7 +197,7 @@ static BOOL test_peer_draw_background(freerdp_peer* client)
 	if (client->settings->RemoteFxCodec)
 	{
 		if (!rfx_compose_message(context->rfx_context, s,
-					 &rect, 1, rgb_data, rect.width, rect.height, rect.width * 3))
+		                         &rect, 1, rgb_data, rect.width, rect.height, rect.width * 3))
 		{
 			goto out;
 		}
@@ -207,7 +207,7 @@ static BOOL test_peer_draw_background(freerdp_peer* client)
 	else
 	{
 		nsc_compose_message(context->nsc_context, s,
-				    rgb_data, rect.width, rect.height, rect.width * 3);
+		                    rgb_data, rect.width, rect.height, rect.width * 3);
 		cmd->codecID = client->settings->NSCodecId;
 	}
 
@@ -279,7 +279,7 @@ static BOOL test_peer_load_icon(freerdp_peer* client)
 
 	/* background with same size, which will be used to erase the icon from old position */
 	if (!(context->bg_data = malloc(context->icon_width * context->icon_height *
-					3)))
+	                                3)))
 		goto out_fail;
 
 	memset(context->bg_data, 0xA0, context->icon_width * context->icon_height * 3);
@@ -323,13 +323,13 @@ static void test_peer_draw_icon(freerdp_peer* client, int x, int y)
 		if (client->settings->RemoteFxCodec)
 		{
 			rfx_compose_message(context->rfx_context, s,
-					    &rect, 1, context->bg_data, rect.width, rect.height, rect.width * 3);
+			                    &rect, 1, context->bg_data, rect.width, rect.height, rect.width * 3);
 			cmd->codecID = client->settings->RemoteFxCodecId;
 		}
 		else
 		{
 			nsc_compose_message(context->nsc_context, s,
-					    context->bg_data, rect.width, rect.height, rect.width * 3);
+			                    context->bg_data, rect.width, rect.height, rect.width * 3);
 			cmd->codecID = client->settings->NSCodecId;
 		}
 
@@ -350,13 +350,13 @@ static void test_peer_draw_icon(freerdp_peer* client, int x, int y)
 	if (client->settings->RemoteFxCodec)
 	{
 		rfx_compose_message(context->rfx_context, s,
-				    &rect, 1, context->icon_data, rect.width, rect.height, rect.width * 3);
+		                    &rect, 1, context->icon_data, rect.width, rect.height, rect.width * 3);
 		cmd->codecID = client->settings->RemoteFxCodecId;
 	}
 	else
 	{
 		nsc_compose_message(context->nsc_context, s,
-				    context->icon_data, rect.width, rect.height, rect.width * 3);
+		                    context->icon_data, rect.width, rect.height, rect.width * 3);
 		cmd->codecID = client->settings->NSCodecId;
 	}
 
@@ -376,7 +376,7 @@ static void test_peer_draw_icon(freerdp_peer* client, int x, int y)
 }
 
 static BOOL test_sleep_tsdiff(UINT32* old_sec, UINT32* old_usec, UINT32 new_sec,
-			      UINT32 new_usec)
+                              UINT32 new_usec)
 {
 	INT32 sec, usec;
 
@@ -448,7 +448,7 @@ BOOL tf_peer_dump_rfx(freerdp_peer* client)
 
 		if (test_dump_rfx_realtime
 		    && test_sleep_tsdiff(&prev_seconds, &prev_useconds, record.header.ts_sec,
-					 record.header.ts_usec) == FALSE)
+		                         record.header.ts_usec) == FALSE)
 			break;
 
 		update->SurfaceCommand(update->context, s);
@@ -472,7 +472,7 @@ static void* tf_debug_channel_thread_func(void* arg)
 	testPeerContext* context = (testPeerContext*) arg;
 
 	if (WTSVirtualChannelQuery(context->debug_channel, WTSVirtualFileHandle,
-				   &buffer, &BytesReturned) == TRUE)
+	                           &buffer, &BytesReturned) == TRUE)
 	{
 		fd = *((void**) buffer);
 		WTSFreeMemory(buffer);
@@ -494,7 +494,7 @@ static void* tf_debug_channel_thread_func(void* arg)
 		Stream_SetPosition(s, 0);
 
 		if (WTSVirtualChannelRead(context->debug_channel, 0, (PCHAR) Stream_Buffer(s),
-					  Stream_Capacity(s), &BytesReturned) == FALSE)
+		                          Stream_Capacity(s), &BytesReturned) == FALSE)
 		{
 			if (BytesReturned == 0)
 				break;
@@ -502,7 +502,7 @@ static void* tf_debug_channel_thread_func(void* arg)
 			Stream_EnsureRemainingCapacity(s, BytesReturned);
 
 			if (WTSVirtualChannelRead(context->debug_channel, 0, (PCHAR) Stream_Buffer(s),
-						  Stream_Capacity(s), &BytesReturned) == FALSE)
+			                          Stream_Capacity(s), &BytesReturned) == FALSE)
 			{
 				/* should not happen */
 				break;
@@ -527,25 +527,25 @@ BOOL tf_peer_post_connect(freerdp_peer* client)
 	 * callback returns.
 	 */
 	WLog_DBG(TAG, "Client %s is activated (osMajorType %d osMinorType %d)",
-		 client->local ? "(local)" : client->hostname,
-		 client->settings->OsMajorType, client->settings->OsMinorType);
+	         client->local ? "(local)" : client->hostname,
+	         client->settings->OsMajorType, client->settings->OsMinorType);
 
 	if (client->settings->AutoLogonEnabled)
 	{
 		WLog_DBG(TAG, " and wants to login automatically as %s\\%s",
-			 client->settings->Domain ? client->settings->Domain : "",
-			 client->settings->Username);
+		         client->settings->Domain ? client->settings->Domain : "",
+		         client->settings->Username);
 		/* A real server may perform OS login here if NLA is not executed previously. */
 	}
 
 	WLog_DBG(TAG, "");
 	WLog_DBG(TAG, "Client requested desktop: %dx%dx%d",
-		 client->settings->DesktopWidth, client->settings->DesktopHeight,
-		 client->settings->ColorDepth);
+	         client->settings->DesktopWidth, client->settings->DesktopHeight,
+	         client->settings->ColorDepth);
 #if (SAMPLE_SERVER_USE_CLIENT_RESOLUTION == 1)
 
 	if (!rfx_context_reset(context->rfx_context, client->settings->DesktopWidth,
-			       client->settings->DesktopHeight))
+	                       client->settings->DesktopHeight))
 		return FALSE;
 
 	WLog_DBG(TAG, "Using resolution requested by client.");
@@ -553,7 +553,7 @@ BOOL tf_peer_post_connect(freerdp_peer* client)
 	client->settings->DesktopWidth = context->rfx_context->width;
 	client->settings->DesktopHeight = context->rfx_context->height;
 	WLog_DBG(TAG, "Resizing client to %dx%d", client->settings->DesktopWidth,
-		 client->settings->DesktopHeight);
+	         client->settings->DesktopHeight);
 	client->update->DesktopResize(client->update->context);
 #endif
 
@@ -567,7 +567,7 @@ BOOL tf_peer_post_connect(freerdp_peer* client)
 	if (WTSVirtualChannelManagerIsChannelJoined(context->vcm, "rdpdbg"))
 	{
 		context->debug_channel = WTSVirtualChannelOpen(context->vcm,
-					 WTS_CURRENT_SESSION, "rdpdbg");
+		                         WTS_CURRENT_SESSION, "rdpdbg");
 
 		if (context->debug_channel != NULL)
 		{
@@ -580,8 +580,8 @@ BOOL tf_peer_post_connect(freerdp_peer* client)
 			}
 
 			if (!(context->debug_channel_thread = CreateThread(NULL, 0,
-							      (LPTHREAD_START_ROUTINE) tf_debug_channel_thread_func, (void*) context, 0,
-							      NULL)))
+			                                      (LPTHREAD_START_ROUTINE) tf_debug_channel_thread_func, (void*) context, 0,
+			                                      NULL)))
 			{
 				WLog_ERR(TAG, "Failed to create debug channel thread");
 				CloseHandle(context->stopEvent);
@@ -641,7 +641,7 @@ BOOL tf_peer_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
 	rdpUpdate* update = client->update;
 	testPeerContext* context = (testPeerContext*) input->context;
 	WLog_DBG(TAG, "Client sent a keyboard event (flags:0x%X code:0x%X)", flags,
-		 code);
+	         code);
 
 	if ((flags & 0x4000) && code == 0x22) /* 'g' key */
 	{
@@ -657,7 +657,7 @@ BOOL tf_peer_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
 		}
 
 		if (!rfx_context_reset(context->rfx_context, client->settings->DesktopWidth,
-				       client->settings->DesktopHeight))
+		                       client->settings->DesktopHeight))
 			return FALSE;
 
 		update->DesktopResize(update->context);
@@ -698,7 +698,7 @@ BOOL tf_peer_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
 BOOL tf_peer_unicode_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
 {
 	WLog_DBG(TAG, "Client sent a unicode keyboard event (flags:0x%X code:0x%X)",
-		 flags, code);
+	         flags, code);
 	return TRUE;
 }
 
@@ -710,14 +710,14 @@ BOOL tf_peer_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UINT16 y)
 }
 
 BOOL tf_peer_extended_mouse_event(rdpInput* input, UINT16 flags, UINT16 x,
-				  UINT16 y)
+                                  UINT16 y)
 {
 	//WLog_DBG(TAG, "Client sent an extended mouse event (flags:0x%X pos:%d,%d)", flags, x, y);
 	return TRUE;
 }
 
 static BOOL tf_peer_refresh_rect(rdpContext* context, BYTE count,
-				 const RECTANGLE_16* areas)
+                                 const RECTANGLE_16* areas)
 {
 	BYTE i;
 	WLog_DBG(TAG, "Client requested to refresh:");
@@ -725,19 +725,19 @@ static BOOL tf_peer_refresh_rect(rdpContext* context, BYTE count,
 	for (i = 0; i < count; i++)
 	{
 		WLog_DBG(TAG, "  (%d, %d) (%d, %d)", areas[i].left, areas[i].top,
-			 areas[i].right, areas[i].bottom);
+		         areas[i].right, areas[i].bottom);
 	}
 
 	return TRUE;
 }
 
 static BOOL tf_peer_suppress_output(rdpContext* context, BYTE allow,
-				    const RECTANGLE_16* area)
+                                    const RECTANGLE_16* area)
 {
 	if (allow > 0)
 	{
 		WLog_DBG(TAG, "Client restore output (%d, %d) (%d, %d).", area->left, area->top,
-			 area->right, area->bottom);
+		         area->right, area->bottom);
 	}
 	else
 	{
@@ -798,7 +798,7 @@ static void* test_peer_mainloop(void* arg)
 	client->Initialize(client);
 	context = (testPeerContext*) client->context;
 	WLog_INFO(TAG, "We've got a client %s",
-		  client->local ? "(local)" : client->hostname);
+	          client->local ? "(local)" : client->hostname);
 
 	while (1)
 	{
@@ -821,7 +821,7 @@ static void* test_peer_mainloop(void* arg)
 	}
 
 	WLog_INFO(TAG, "Client %s disconnected.",
-		  client->local ? "(local)" : client->hostname);
+	          client->local ? "(local)" : client->hostname);
 	client->Disconnect(client);
 	freerdp_peer_context_free(client);
 	freerdp_peer_free(client);
@@ -833,7 +833,7 @@ static BOOL test_peer_accepted(freerdp_listener* instance, freerdp_peer* client)
 	HANDLE hThread;
 
 	if (!(hThread = CreateThread(NULL, 0,
-				     (LPTHREAD_START_ROUTINE) test_peer_mainloop, (void*) client, 0, NULL)))
+	                             (LPTHREAD_START_ROUTINE) test_peer_mainloop, (void*) client, 0, NULL)))
 		return FALSE;
 
 	CloseHandle(hThread);
@@ -933,7 +933,7 @@ int main(int argc, char* argv[])
 	}
 
 	if ((localOnly || instance->Open(instance, NULL, port)) &&
-		instance->OpenLocal(instance, file))
+	    instance->OpenLocal(instance, file))
 	{
 		/* Entering the server main loop. In a real server the listener can be run in its own thread. */
 		test_server_mainloop(instance);


### PR DESCRIPTION
This patch make it possible to limit the time that is passed when we call
XXX_check_fds functions. This should smooth the treatment between handling inputs
and handling incoming bitmap updates.
The default maximum time is set to 100 ms.