### PR TITLE
winpr/synch: fix tests

### DIFF
--- a/winpr/libwinpr/synch/test/TestSynchWaitableTimerAPC.c
+++ b/winpr/libwinpr/synch/test/TestSynchWaitableTimerAPC.c
@@ -67,9 +67,35 @@ int TestSynchWaitableTimerAPC(int argc, char* argv[])
 	if (!bSuccess)
 		goto cleanup;
 
-	if (WaitForSingleObject(g_Event, INFINITE) != WAIT_OBJECT_0)
+	/**
+	 * See Remarks at https://msdn.microsoft.com/en-us/library/windows/desktop/ms686786(v=vs.85).aspx
+	 * The SetWaitableTimer completion routine is executed by the thread that activates the timer
+	 * using SetWaitableTimer. However, the thread must be in an ALERTABLE state.
+	 */
+
+
+	/**
+	 * Note: On WIN32 we need to use WaitForSingleObjectEx with parameter bAlertable = TRUE
+	 * However, WinPR currently (May 2016) does not have a working WaitForSingleObjectEx implementation
+	 * but its non-WIN32 WaitForSingleObject implementations seem to be alertable by WinPR's
+	 * timer implementations.
+	 **/
+
+	for(;;)
 	{
-		printf("WaitForSingleObject failed (%d)\n", GetLastError());
+		DWORD rc;
+#ifdef _WIN32
+		rc = WaitForSingleObjectEx(g_Event, INFINITE, TRUE);
+#else
+		rc = WaitForSingleObject(g_Event, INFINITE);
+#endif
+		if (rc == WAIT_OBJECT_0)
+			break;
+
+		if (rc == 0x000000C0L) /* WAIT_IO_COMPLETION */
+			continue;
+
+		printf("Failed to wait for completion event (%u)\n", GetLastError());
 		goto cleanup;
 	}
 


### PR DESCRIPTION
TestSynchTimerQueue:
- fixed race condition

TestSynchWaitableTimerAPC:
- Use WaitForSingleObjectEx since the thread must be in an alterable state

TestSynch is now expected to succeed on WIN32