### PR TITLE
winpr/path: fix PathCchFindExtensionA and more

### DIFF
--- a/winpr/libwinpr/path/include/PathAllocCombine.c
+++ b/winpr/libwinpr/path/include/PathAllocCombine.c
@@ -44,8 +44,8 @@ HRESULT PATH_ALLOC_COMBINE(PCWSTR pszPathIn, PCWSTR pszMore, unsigned long dwFla
 	if (!pszPathIn)
 		return E_FAIL;  /* valid but not implemented, see top comment */
 
-	pszPathInLength = lstrlenA(pszPathIn);
-	pszMoreLength = lstrlenA(pszMore);
+	pszPathInLength = wcslen(pszPathIn);
+	pszMoreLength = wcslen(pszMore);
 
 	/* prevent segfaults - the complete implementation below is buggy */
 	if (pszPathInLength < 3)

--- a/winpr/libwinpr/path/path.c
+++ b/winpr/libwinpr/path/path.c
@@ -517,9 +517,8 @@ HRESULT PathCchFindExtensionA(PCSTR pszPath, size_t cchPath, PCSTR* ppszExt)
 
 	/* find end of string */
 
-	while (*p && cchPath)
+	while (*p && --cchPath)
 	{
-		cchPath--;
 		p++;
 	}
 

--- a/winpr/libwinpr/path/test/TestPathCchFindExtension.c
+++ b/winpr/libwinpr/path/test/TestPathCchFindExtension.c
@@ -39,7 +39,7 @@ int TestPathCchFindExtension(int argc, char* argv[])
 
 	/* Test missing null-termination of pszPath */
 
-	hr = PathCchFindExtensionA(_T("c:\\456.789"), 9, &pszExt);
+	hr = PathCchFindExtensionA("c:\\45.789", 9, &pszExt); /* nb: correct would be 10 */
 	if (SUCCEEDED(hr))
 	{
 		printf("PathCchFindExtensionA unexpectedly succeeded with unterminated pszPath. result: 0x%08X\n", (ULONG)hr);
@@ -50,7 +50,7 @@ int TestPathCchFindExtension(int argc, char* argv[])
 	/* Test passing of an empty terminated string (must succeed) */
 
 	pszExt = NULL;
-	pszTmp = _T("");
+	pszTmp = "";
 	hr = PathCchFindExtensionA(pszTmp, 1, &pszExt);
 	if (hr != S_OK)
 	{
@@ -68,7 +68,7 @@ int TestPathCchFindExtension(int argc, char* argv[])
 	/* Test a path without file extension (must succeed) */
 
 	pszExt = NULL;
-	pszTmp = _T("c:\\4.678\\");
+	pszTmp = "c:\\4.678\\";
 	hr = PathCchFindExtensionA(pszTmp, 10, &pszExt);
 	if (hr != S_OK)
 	{
@@ -93,7 +93,7 @@ int TestPathCchFindExtension(int argc, char* argv[])
 		return -1;
 	}
 
-	if (!pszExt || _tcscmp(pszExt, _T(".exe")))
+	if (!pszExt || strcmp(pszExt, ".exe"))
 	{
 		printf("PathCchFindExtensionA failure: unexpected extension\n");
 		return -1;


### PR DESCRIPTION
- PathCchFindExtensionA had an off-by-one error when verifying the required null termination
- TestPathCchFindExtension used unicode strings when testing the *A (ASCII) functions
- The PathAllocCombineW implementation (which is still buggy as hell) used strlen to calculate the lenght of unicode strings

TestPath now succeeds on WIN32