### PR TITLE
fix segfaults casused by size_t format specifier

### DIFF
--- a/libfreerdp/primitives/test/TestPrimitivesYUV.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYUV.c
@@ -25,7 +25,7 @@ static BOOL similar(const BYTE* src, const BYTE* dst, size_t size)
 
 		if (abs(diff) > 2)
 		{
-			fprintf(stderr, "%zd %02X : %02X diff=%lf\n", x, val1, val2, diff);
+			fprintf(stderr, "%lu %02X : %02X diff=%lf\n", (unsigned long)x, val1, val2, diff);
 			return FALSE;
 		}
 	}
@@ -66,8 +66,8 @@ static BOOL check_padding(const BYTE* psrc, size_t size, size_t padding, const c
 			while((x < halfPad) && (*esrc++ != 'A'))
 				x++;
 
-			fprintf(stderr, "Buffer underflow detected %02x != %02X %s [%zd-%zd]\n",
-				d, 'A', buffer, start, x);
+			fprintf(stderr, "Buffer underflow detected %02x != %02X %s [%lu-%lu]\n",
+				d, 'A', buffer, (unsigned long)start, (unsigned long)x);
 			return FALSE;
 		}
 		if(d != 'A')
@@ -76,8 +76,8 @@ static BOOL check_padding(const BYTE* psrc, size_t size, size_t padding, const c
 			while((x < halfPad) && (*esrc++ != 'A'))
 				x++;
 
-			fprintf(stderr, "Buffer overflow detected %02x != %02X %s [%zd-%zd]\n",
-				d, 'A', buffer, start, x);
+			fprintf(stderr, "Buffer overflow detected %02x != %02X %s [%lu-%lu]\n",
+				d, 'A', buffer, (unsigned long)start, (unsigned long)x);
 			return FALSE;
 		}
 	}

--- a/winpr/libwinpr/utils/print.c
+++ b/winpr/libwinpr/utils/print.c
@@ -43,7 +43,7 @@ void winpr_HexDump(const char* tag, UINT32 level, const BYTE* data, int length)
 
 	if (!buffer)
 	{
-		WLog_ERR(tag, "malloc(%zd) failed with [%d] %s", blen, errno, strerror(errno));
+		WLog_ERR(tag, "malloc(%lu) failed with [%d] %s", (unsigned long)blen, errno, strerror(errno));
 		return;
 	}
 
@@ -84,7 +84,7 @@ void winpr_CArrayDump(const char* tag, UINT32 level, const BYTE* data, int lengt
 
 	if (!buffer)
 	{
-		WLog_ERR(tag, "malloc(%zd) failed with [%d] %s", llen, errno, strerror(errno));
+		WLog_ERR(tag, "malloc(%lu) failed with [%d] %s", (unsigned long)llen, errno, strerror(errno));
 		return;
 	}
 

--- a/winpr/libwinpr/utils/test/TestBacktrace.c
+++ b/winpr/libwinpr/utils/test/TestBacktrace.c
@@ -17,7 +17,7 @@ int TestBacktrace(int argc, char* argv[])
 	if (msg)
 	{
 		for (x=0; x<used; x++)
-			printf("%zd: %s\n", x, msg[x]);
+			printf("%lu: %s\n", (unsigned long)x, msg[x]);
 		rc = 0;
 	}
 	winpr_backtrace_symbols_fd(stack, fileno(stdout));

--- a/winpr/libwinpr/utils/test/TestImage.c
+++ b/winpr/libwinpr/utils/test/TestImage.c
@@ -14,7 +14,7 @@ static void *read_image(const char *src, size_t *size)
 	int success = 0;
 	void *a = NULL;
 	long src_size;
-	FILE *fsrc = fopen(src, "r");
+	FILE *fsrc = fopen(src, "rb");
 
 	if (!fsrc)
 	{
@@ -40,13 +40,13 @@ static void *read_image(const char *src, size_t *size)
 
 	if (!a)
 	{
-		fprintf(stderr, "Failed malloc %zd bytes\n", src_size);
+		fprintf(stderr, "Failed malloc %ld bytes\n", src_size);
 		goto cleanup;
 	}
 
 	if (fread(a, sizeof(char), src_size, fsrc) != src_size)
 	{
-		fprintf(stderr, "Failed read %zd bytes\n", src_size);
+		fprintf(stderr, "Failed read %ld bytes\n", src_size);
 		goto cleanup;
 	}
 

--- a/winpr/libwinpr/utils/wlog/wlog.c
+++ b/winpr/libwinpr/utils/wlog/wlog.c
@@ -104,7 +104,7 @@ static BOOL log_recursion(LPCSTR file, LPCSTR fkt, int line)
 		return FALSE;
 
 	for (i=0; i<used; i++)
-		if (fprintf(stderr, "%s: %zd: %s\n", fkt, i, msg[i]) < 0)
+		if (fprintf(stderr, "%s: %lu: %s\n", fkt, (unsigned long)i, msg[i]) < 0)
 			return FALSE;
 
 #endif


### PR DESCRIPTION
win32/msvc cc does not recognize the `%z` format specifier which caused invalid references and segfaults on win32.
Until FreeRDP gets format specifier macros we'll cast `size_t` to `unsigned long` and use the `%lu` specifier.

Also simplified `winpr_backtrace_symbols()` a little bit and fixed it to allocate the correct amount of bytes for the return buffer.