### PR TITLE
channels/rdpgfx: Fix for gfx client

### DIFF
--- a/client/Windows/wf_gdi.c
+++ b/client/Windows/wf_gdi.c
@@ -406,7 +406,9 @@ BOOL wf_gdi_bitmap_update(rdpContext* context, BITMAP_UPDATE* bitmapUpdate)
 
 			if (bitsPerPixel < 32)
 			{
-				if (!freerdp_client_codecs_prepare(codecs, FREERDP_CODEC_INTERLEAVED))
+				if (!freerdp_client_codecs_prepare(codecs, FREERDP_CODEC_INTERLEAVED,
+												   wfc->instance->settings->DesktopWidth,
+												   wfc->instance->settings->DesktopHeight))
 					return FALSE;
 
 				status = interleaved_decompress(codecs->interleaved, pSrcData, SrcSize, bitsPerPixel,
@@ -414,7 +416,9 @@ BOOL wf_gdi_bitmap_update(rdpContext* context, BITMAP_UPDATE* bitmapUpdate)
 			}
 			else
 			{
-				if (!freerdp_client_codecs_prepare(codecs, FREERDP_CODEC_PLANAR))
+				if (!freerdp_client_codecs_prepare(codecs, FREERDP_CODEC_PLANAR,
+												   wfc->instance->settings->DesktopWidth,
+												   wfc->instance->settings->DesktopHeight))
 					return FALSE;
 
 				status = planar_decompress(codecs->planar, pSrcData, SrcSize, &pDstData,
@@ -677,7 +681,9 @@ void wf_gdi_surface_bits(wfContext* wfc, SURFACE_BITS_COMMAND* surface_bits_comm
 
 	if (surface_bits_command->codecID == RDP_CODEC_ID_REMOTEFX)
 	{
-		if (!freerdp_client_codecs_prepare(wfc->codecs, FREERDP_CODEC_REMOTEFX))
+		if (!freerdp_client_codecs_prepare(wfc->codecs, FREERDP_CODEC_REMOTEFX,
+										   wfc->instance->settings->DesktopWidth,
+										   wfc->instance->settings->DesktopHeight))
 			return;
 
 		if (!(message = rfx_process_message(wfc->codecs->rfx, surface_bits_command->bitmapData, surface_bits_command->bitmapDataLength)))
@@ -719,7 +725,9 @@ void wf_gdi_surface_bits(wfContext* wfc, SURFACE_BITS_COMMAND* surface_bits_comm
 	}
 	else if (surface_bits_command->codecID == RDP_CODEC_ID_NSCODEC)
 	{
-		if (!freerdp_client_codecs_prepare(wfc->codecs, FREERDP_CODEC_NSCODEC))
+		if (!freerdp_client_codecs_prepare(wfc->codecs, FREERDP_CODEC_NSCODEC,
+										   wfc->instance->settings->DesktopWidth,
+										   wfc->instance->settings->DesktopHeight))
 			return;
 
 		nsc_process_message(wfc->codecs->nsc, surface_bits_command->bpp, surface_bits_command->width, surface_bits_command->height,

--- a/client/Windows/wf_graphics.c
+++ b/client/Windows/wf_graphics.c
@@ -173,7 +173,9 @@ void wf_Bitmap_Decompress(wfContext* wfc, rdpBitmap* bitmap,
 	{
 		if (bpp < 32)
 		{
-			if (!freerdp_client_codecs_prepare(wfc->codecs, FREERDP_CODEC_INTERLEAVED))
+			if (!freerdp_client_codecs_prepare(wfc->codecs, FREERDP_CODEC_INTERLEAVED,
+											   wfc->instance->settings->DesktopWidth,
+											   wfc->instance->settings->DesktopHeight))
 				return;
 
 			status = interleaved_decompress(wfc->codecs->interleaved, pSrcData, SrcSize, bpp,
@@ -181,7 +183,9 @@ void wf_Bitmap_Decompress(wfContext* wfc, rdpBitmap* bitmap,
 		}
 		else
 		{
-			if (!freerdp_client_codecs_prepare(wfc->codecs, FREERDP_CODEC_PLANAR))
+			if (!freerdp_client_codecs_prepare(wfc->codecs, FREERDP_CODEC_PLANAR,
+											   wfc->instance->settings->DesktopWidth,
+											   wfc->instance->settings->DesktopHeight))
 				return;
 
 			status = planar_decompress(wfc->codecs->planar, pSrcData, SrcSize, &pDstData,

--- a/client/X11/xf_gdi.c
+++ b/client/X11/xf_gdi.c
@@ -385,7 +385,9 @@ BOOL xf_gdi_bitmap_update(rdpContext* context, BITMAP_UPDATE* bitmapUpdate)
 
 			if (bitsPerPixel < 32)
 			{
-				if (!freerdp_client_codecs_prepare(codecs, FREERDP_CODEC_INTERLEAVED))
+				if (!freerdp_client_codecs_prepare(codecs, FREERDP_CODEC_INTERLEAVED,
+												   xfc->settings->DesktopWidth,
+												   xfc->settings->DesktopHeight))
 					return FALSE;
 
 				status = interleaved_decompress(codecs->interleaved, pSrcData, SrcSize, bitsPerPixel,
@@ -393,7 +395,9 @@ BOOL xf_gdi_bitmap_update(rdpContext* context, BITMAP_UPDATE* bitmapUpdate)
 			}
 			else
 			{
-				if (!freerdp_client_codecs_prepare(codecs, FREERDP_CODEC_PLANAR))
+				if (!freerdp_client_codecs_prepare(codecs, FREERDP_CODEC_PLANAR,
+												   xfc->settings->DesktopWidth,
+												   xfc->settings->DesktopHeight))
 					return FALSE;
 
 				status = planar_decompress(codecs->planar, pSrcData, SrcSize, &pDstData,
@@ -1170,7 +1174,9 @@ BOOL xf_gdi_surface_bits(rdpContext* context, SURFACE_BITS_COMMAND* cmd)
 
 	if (cmd->codecID == RDP_CODEC_ID_REMOTEFX)
 	{
-		if (!freerdp_client_codecs_prepare(xfc->codecs, FREERDP_CODEC_REMOTEFX))
+		if (!freerdp_client_codecs_prepare(xfc->codecs, FREERDP_CODEC_REMOTEFX,
+										   xfc->settings->DesktopWidth,
+										   xfc->settings->DesktopHeight))
 		{
 			xf_unlock_x11(xfc, FALSE);
 			return FALSE;
@@ -1245,7 +1251,9 @@ BOOL xf_gdi_surface_bits(rdpContext* context, SURFACE_BITS_COMMAND* cmd)
 	}
 	else if (cmd->codecID == RDP_CODEC_ID_NSCODEC)
 	{
-		if (!freerdp_client_codecs_prepare(xfc->codecs, FREERDP_CODEC_NSCODEC))
+		if (!freerdp_client_codecs_prepare(xfc->codecs, FREERDP_CODEC_NSCODEC,
+										   xfc->settings->DesktopWidth,
+										   xfc->settings->DesktopHeight))
 		{
 			xf_unlock_x11(xfc, FALSE);
 			return FALSE;

--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -303,7 +303,8 @@ static UINT xf_SurfaceCommand_RemoteFX(xfContext* xfc, RdpgfxClientContext* cont
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_REMOTEFX))
+	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_REMOTEFX,
+									   surface->width, surface->height))
 		return ERROR_INTERNAL_ERROR;
 
 	if (!(message = rfx_process_message(surface->codecs->rfx, cmd->data, cmd->length)))
@@ -383,7 +384,9 @@ static UINT xf_SurfaceCommand_ClearCodec(xfContext* xfc, RdpgfxClientContext* co
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!freerdp_client_codecs_prepare(xfc->codecs, FREERDP_CODEC_CLEARCODEC))
+	if (!freerdp_client_codecs_prepare(xfc->codecs, FREERDP_CODEC_CLEARCODEC,
+									   xfc->settings->DesktopWidth,
+									   xfc->settings->DesktopHeight))
 		return ERROR_INTERNAL_ERROR;
 
 	DstData = surface->data;
@@ -427,7 +430,8 @@ static UINT xf_SurfaceCommand_Planar(xfContext* xfc, RdpgfxClientContext* contex
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_PLANAR))
+	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_PLANAR,
+									   surface->width, surface->height))
 		return ERROR_INTERNAL_ERROR;
 
 	DstData = surface->data;
@@ -466,7 +470,8 @@ static UINT xf_SurfaceCommand_AVC420(xfContext* xfc, RdpgfxClientContext* contex
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_AVC420))
+	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_AVC420,
+									   surface->width, surface->height))
 		return ERROR_INTERNAL_ERROR;
 
 	bs = (RDPGFX_AVC420_BITMAP_STREAM*) cmd->extra;
@@ -523,7 +528,8 @@ static UINT xf_SurfaceCommand_AVC444(xfContext* xfc, RdpgfxClientContext* contex
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_AVC444))
+	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_AVC444,
+									   surface->width, surface->height))
 		return ERROR_INTERNAL_ERROR;
 
 	bs = (RDPGFX_AVC444_BITMAP_STREAM*) cmd->extra;
@@ -587,7 +593,8 @@ static UINT xf_SurfaceCommand_Alpha(xfContext* xfc, RdpgfxClientContext* context
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_ALPHACODEC))
+	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_ALPHACODEC,
+									   surface->width, surface->height))
 		return ERROR_INTERNAL_ERROR;
 
 	WLog_DBG(TAG, "xf_SurfaceCommand_Alpha: status: %d", status);
@@ -638,7 +645,8 @@ static UINT xf_SurfaceCommand_Progressive(xfContext* xfc, RdpgfxClientContext* c
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_PROGRESSIVE))
+	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_PROGRESSIVE,
+									   surface->width, surface->height))
 		return ERROR_INTERNAL_ERROR;
 
 	progressive_create_surface_context(surface->codecs->progressive, cmd->surfaceId, surface->width, surface->height);
@@ -800,13 +808,6 @@ static UINT xf_CreateSurface(RdpgfxClientContext* context, RDPGFX_CREATE_SURFACE
 	{
 		free (surface);
 		return CHANNEL_RC_NO_MEMORY;
-	}
-
-	if (!freerdp_client_codecs_reset(surface->codecs, FREERDP_CODEC_ALL,
-					 createSurface->width, createSurface->height))
-	{
-		free (surface);
-		return ERROR_INTERNAL_ERROR;
 	}
 
 	surface->surfaceId = createSurface->surfaceId;

--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -163,7 +163,9 @@ BOOL xf_Bitmap_Decompress(rdpContext* context, rdpBitmap* bitmap,
 	{
 		if (bpp < 32)
 		{
-			if (!freerdp_client_codecs_prepare(xfc->codecs, FREERDP_CODEC_INTERLEAVED))
+			if (!freerdp_client_codecs_prepare(xfc->codecs, FREERDP_CODEC_INTERLEAVED,
+											   xfc->settings->DesktopWidth,
+											   xfc->settings->DesktopHeight))
 				return FALSE;
 
 			status = interleaved_decompress(xfc->codecs->interleaved, pSrcData, SrcSize, bpp,
@@ -171,7 +173,9 @@ BOOL xf_Bitmap_Decompress(rdpContext* context, rdpBitmap* bitmap,
 		}
 		else
 		{
-			if (!freerdp_client_codecs_prepare(xfc->codecs, FREERDP_CODEC_PLANAR))
+			if (!freerdp_client_codecs_prepare(xfc->codecs, FREERDP_CODEC_PLANAR,
+											   xfc->settings->DesktopWidth,
+											   xfc->settings->DesktopHeight))
 				return FALSE;
 
 			status = planar_decompress(xfc->codecs->planar, pSrcData, SrcSize,

--- a/include/freerdp/codecs.h
+++ b/include/freerdp/codecs.h
@@ -60,7 +60,8 @@ struct rdp_codecs
  extern "C" {
 #endif
 
-FREERDP_API BOOL freerdp_client_codecs_prepare(rdpCodecs* codecs, UINT32 flags);
+FREERDP_API BOOL freerdp_client_codecs_prepare(rdpCodecs* codecs, UINT32 flags,
+					     UINT32 width, UINT32 height);
 FREERDP_API BOOL freerdp_client_codecs_reset(rdpCodecs* codecs, UINT32 flags,
 					     UINT32 width, UINT32 height);
 

--- a/libfreerdp/core/codecs.c
+++ b/libfreerdp/core/codecs.c
@@ -27,13 +27,20 @@
 
 #define TAG FREERDP_TAG("core.codecs")
 
-BOOL freerdp_client_codecs_prepare(rdpCodecs* codecs, UINT32 flags)
+BOOL freerdp_client_codecs_prepare(rdpCodecs* codecs, UINT32 flags, UINT32 width, UINT32 height)
 {
 	if ((flags & FREERDP_CODEC_INTERLEAVED) && !codecs->interleaved)
 	{
 		if (!(codecs->interleaved = bitmap_interleaved_context_new(FALSE)))
 		{
 			WLog_ERR(TAG, "Failed to create interleaved codec context");
+			return FALSE;
+		}
+
+		if (!bitmap_interleaved_context_reset(codecs->interleaved))
+		{
+			WLog_ERR(TAG, "Failed to reset interleaved codec context");
+			bitmap_interleaved_context_free(codecs->interleaved);
 			return FALSE;
 		}
 	}
@@ -45,6 +52,13 @@ BOOL freerdp_client_codecs_prepare(rdpCodecs* codecs, UINT32 flags)
 			WLog_ERR(TAG, "Failed to create planar bitmap codec context");
 			return FALSE;
 		}
+
+		if (!freerdp_bitmap_planar_context_reset(codecs->planar))
+		{
+			WLog_ERR(TAG, "Failed to reset plannar bitmap codec context");
+			freerdp_bitmap_planar_context_free(codecs->planar);
+			return FALSE;
+		}
 	}
 
 	if ((flags & FREERDP_CODEC_NSCODEC) && !codecs->nsc)
@@ -52,6 +66,13 @@ BOOL freerdp_client_codecs_prepare(rdpCodecs* codecs, UINT32 flags)
 		if (!(codecs->nsc = nsc_context_new()))
 		{
 			WLog_ERR(TAG, "Failed to create nsc codec context");
+			return FALSE;
+		}
+
+		if (!nsc_context_reset(codecs->nsc, width, height))
+		{
+			WLog_ERR(TAG, "Failed to reset nsc codec context");
+			nsc_context_free(codecs->nsc);
 			return FALSE;
 		}
 	}
@@ -63,6 +84,13 @@ BOOL freerdp_client_codecs_prepare(rdpCodecs* codecs, UINT32 flags)
 			WLog_ERR(TAG, "Failed to create rfx codec context");
 			return FALSE;
 		}
+
+		if (!rfx_context_reset(codecs->rfx, width, height))
+		{
+			WLog_ERR(TAG, "Failed to reset rfx codec context");
+			rfx_context_free(codecs->rfx);
+			return FALSE;
+		}
 	}
 
 	if ((flags & FREERDP_CODEC_CLEARCODEC) && !codecs->clear)
@@ -70,6 +98,13 @@ BOOL freerdp_client_codecs_prepare(rdpCodecs* codecs, UINT32 flags)
 		if (!(codecs->clear = clear_context_new(FALSE)))
 		{
 			WLog_ERR(TAG, "Failed to create clear codec context");
+			return FALSE;
+		}
+
+		if (!clear_context_reset(codecs->clear))
+		{
+			WLog_ERR(TAG, "Failed to reset clear codec context");
+			clear_context_free(codecs->clear);
 			return FALSE;
 		}
 	}
@@ -86,6 +121,13 @@ BOOL freerdp_client_codecs_prepare(rdpCodecs* codecs, UINT32 flags)
 			WLog_ERR(TAG, "Failed to create progressive codec context");
 			return FALSE;
 		}
+
+		if (!progressive_context_reset(codecs->progressive))
+		{
+			WLog_ERR(TAG, "Failed to reset progressive codec context");
+			progressive_context_free(codecs->progressive);
+			return FALSE;
+		}
 	}
 
 	if ((flags & (FREERDP_CODEC_AVC420 | FREERDP_CODEC_AVC444)) && !codecs->h264)
@@ -93,6 +135,13 @@ BOOL freerdp_client_codecs_prepare(rdpCodecs* codecs, UINT32 flags)
 		if (!(codecs->h264 = h264_context_new(FALSE)))
 		{
 			WLog_ERR(TAG, "Failed to create h264 codec context");
+			return FALSE;
+		}
+
+		if (!h264_context_reset(codecs->h264, width, height))
+		{
+			WLog_ERR(TAG, "Failed to reset h264 codec context");
+			h264_context_free(codecs->h264);
 			return FALSE;
 		}
 	}

--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -508,7 +508,8 @@ static BOOL gdi_bitmap_update(rdpContext* context, BITMAP_UPDATE* bitmapUpdate)
 
 			if (bitsPerPixel < 32)
 			{
-				if (!freerdp_client_codecs_prepare(codecs, FREERDP_CODEC_INTERLEAVED))
+				if (!freerdp_client_codecs_prepare(codecs, FREERDP_CODEC_INTERLEAVED,
+												   gdi->width, gdi->height))
 					return FALSE;
 
 				status = interleaved_decompress(codecs->interleaved, pSrcData, SrcSize, bitsPerPixel,
@@ -516,7 +517,8 @@ static BOOL gdi_bitmap_update(rdpContext* context, BITMAP_UPDATE* bitmapUpdate)
 			}
 			else
 			{
-				if (!freerdp_client_codecs_prepare(codecs, FREERDP_CODEC_PLANAR))
+				if (!freerdp_client_codecs_prepare(codecs, FREERDP_CODEC_PLANAR,
+												   gdi->width, gdi->height))
 					return FALSE;
 
 				status = planar_decompress(codecs->planar, pSrcData, SrcSize, &pDstData,
@@ -1058,7 +1060,8 @@ static BOOL gdi_surface_bits(rdpContext* context, SURFACE_BITS_COMMAND* cmd)
 
 	if (cmd->codecID == RDP_CODEC_ID_REMOTEFX)
 	{
-		if (!freerdp_client_codecs_prepare(gdi->codecs, FREERDP_CODEC_REMOTEFX))
+		if (!freerdp_client_codecs_prepare(gdi->codecs, FREERDP_CODEC_REMOTEFX,
+										   gdi->width, gdi->height))
 			return FALSE;
 
 		if (!(message = rfx_process_message(gdi->codecs->rfx, cmd->bitmapData, cmd->bitmapDataLength)))
@@ -1104,7 +1107,8 @@ static BOOL gdi_surface_bits(rdpContext* context, SURFACE_BITS_COMMAND* cmd)
 	}
 	else if (cmd->codecID == RDP_CODEC_ID_NSCODEC)
 	{
-		if (!freerdp_client_codecs_prepare(gdi->codecs, FREERDP_CODEC_NSCODEC))
+		if (!freerdp_client_codecs_prepare(gdi->codecs, FREERDP_CODEC_NSCODEC,
+										   gdi->width, gdi->height))
 			return FALSE;
 
 		nsc_process_message(gdi->codecs->nsc, cmd->bpp, cmd->width, cmd->height, cmd->bitmapData, cmd->bitmapDataLength);

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -310,7 +310,8 @@ UINT gdi_SurfaceCommand_RemoteFX(rdpGdi* gdi, RdpgfxClientContext* context, RDPG
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_REMOTEFX))
+	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_REMOTEFX,
+									   surface->width, surface->height))
 		return ERROR_INTERNAL_ERROR;
 
 	if (!(message = rfx_process_message(surface->codecs->rfx, cmd->data, cmd->length)))
@@ -390,7 +391,8 @@ UINT gdi_SurfaceCommand_ClearCodec(rdpGdi* gdi, RdpgfxClientContext* context, RD
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!freerdp_client_codecs_prepare(gdi->codecs, FREERDP_CODEC_CLEARCODEC))
+	if (!freerdp_client_codecs_prepare(gdi->codecs, FREERDP_CODEC_CLEARCODEC,
+									   gdi->width, gdi->height))
 		return ERROR_INTERNAL_ERROR;
 
 	DstData = surface->data;
@@ -434,7 +436,8 @@ UINT gdi_SurfaceCommand_Planar(rdpGdi* gdi, RdpgfxClientContext* context, RDPGFX
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_PLANAR))
+	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_PLANAR,
+									   surface->width, surface->height))
 		return ERROR_INTERNAL_ERROR;
 
 	DstData = surface->data;
@@ -473,7 +476,8 @@ static UINT gdi_SurfaceCommand_AVC420(rdpGdi* gdi, RdpgfxClientContext* context,
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_AVC420))
+	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_AVC420,
+									   surface->width, surface->height))
 		return ERROR_INTERNAL_ERROR;
 
 	bs = (RDPGFX_AVC420_BITMAP_STREAM*) cmd->extra;
@@ -528,7 +532,8 @@ static UINT gdi_SurfaceCommand_AVC444(rdpGdi* gdi, RdpgfxClientContext* context,
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_AVC444))
+	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_AVC444,
+									   surface->width, surface->height))
 		return ERROR_INTERNAL_ERROR;
 
 	bs = (RDPGFX_AVC444_BITMAP_STREAM*) cmd->extra;
@@ -593,7 +598,8 @@ UINT gdi_SurfaceCommand_Alpha(rdpGdi* gdi, RdpgfxClientContext* context, RDPGFX_
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_ALPHACODEC))
+	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_ALPHACODEC,
+									   surface->width, surface->height))
 		return ERROR_INTERNAL_ERROR;
 
 	WLog_DBG(TAG, "gdi_SurfaceCommand_Alpha: status: %d", status);
@@ -645,7 +651,8 @@ UINT gdi_SurfaceCommand_Progressive(rdpGdi* gdi, RdpgfxClientContext* context, R
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_PROGRESSIVE))
+	if (!freerdp_client_codecs_prepare(surface->codecs, FREERDP_CODEC_PROGRESSIVE,
+									   surface->width, surface->height))
 		return ERROR_INTERNAL_ERROR;
 
 	progressive_create_surface_context(surface->codecs->progressive, cmd->surfaceId, surface->width, surface->height);
@@ -805,13 +812,6 @@ UINT gdi_CreateSurface(RdpgfxClientContext* context, RDPGFX_CREATE_SURFACE_PDU* 
 	{
 		free (surface);
 		return CHANNEL_RC_NO_MEMORY;
-	}
-
-	if (!freerdp_client_codecs_reset(surface->codecs, FREERDP_CODEC_ALL,
-					 createSurface->width, createSurface->height))
-	{
-		free (surface);
-		return ERROR_INTERNAL_ERROR;
 	}
 
 	surface->surfaceId = createSurface->surfaceId;

--- a/libfreerdp/gdi/graphics.c
+++ b/libfreerdp/gdi/graphics.c
@@ -173,7 +173,8 @@ BOOL gdi_Bitmap_Decompress(rdpContext* context, rdpBitmap* bitmap,
 	{
 		if (bpp < 32)
 		{
-			if (!freerdp_client_codecs_prepare(gdi->codecs, FREERDP_CODEC_INTERLEAVED))
+			if (!freerdp_client_codecs_prepare(gdi->codecs, FREERDP_CODEC_INTERLEAVED,
+											   gdi->width, gdi->height))
 				return FALSE;
 
 			status = interleaved_decompress(gdi->codecs->interleaved, pSrcData, SrcSize, bpp,
@@ -181,7 +182,8 @@ BOOL gdi_Bitmap_Decompress(rdpContext* context, rdpBitmap* bitmap,
 		}
 		else
 		{
-			if (!freerdp_client_codecs_prepare(gdi->codecs, FREERDP_CODEC_PLANAR))
+			if (!freerdp_client_codecs_prepare(gdi->codecs, FREERDP_CODEC_PLANAR,
+											   gdi->width, gdi->height))
 				return FALSE;
 
 			status = planar_decompress(gdi->codecs->planar, pSrcData, SrcSize, &pDstData,


### PR DESCRIPTION
 Make freerdp_client_codecs_prepare calls codec reset It fix broken h264 client from #3328. Also it doesn't make sense that we don't need width and height for codec initialization while we need them for codec reset