### PR TITLE
Fix some memory leaks in freerdp_settings_free()

### DIFF
--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -963,6 +963,24 @@ void freerdp_settings_free(rdpSettings* settings)
     free(settings->GatewayUsername);
     free(settings->GatewayPassword);
     free(settings->GatewayDomain);
+    free(settings->CertificateName);
+    free(settings->DynamicDSTTimeZoneKeyName);
+    free(settings->PreconnectionBlob);
+    free(settings->KerberosKdc);
+    free(settings->KerberosRealm);
+    free(settings->DumpRemoteFxFile);
+    free(settings->PlayRemoteFxFile);
+    free(settings->RemoteApplicationName);
+    free(settings->RemoteApplicationIcon);
+    free(settings->RemoteApplicationProgram);
+    free(settings->RemoteApplicationFile);
+    free(settings->RemoteApplicationGuid);
+    free(settings->RemoteApplicationCmdLine);
+    free(settings->ImeFileName);
+    free(settings->DrivesToRedirect);
+    free(settings->WindowTitle);
+    free(settings->WmClass);
+
     freerdp_target_net_addresses_free(settings);
     freerdp_device_collection_free(settings);
     freerdp_static_channel_collection_free(settings);


### PR DESCRIPTION
**freerdp_settings_free()** in libfreerdp/core/settings.c should free almost all pointer members of "struct rdp_settings" (aka: **rdpSettings).** Currently not all members of the setting struct are freed. This PR adds free for some settings.
I did not include the following three settings, because I think they need more careful handling for the free phase
```
TargetNetAddresses
Password51
DeviceArray
```

