### PR TITLE
winpr: fix some tests

### DIFF
--- a/winpr/libwinpr/library/test/TestLibraryA/CMakeLists.txt
+++ b/winpr/libwinpr/library/test/TestLibraryA/CMakeLists.txt
@@ -24,7 +24,7 @@ if(MSVC)
 	set(${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_SRCS})
 endif()
 
-add_library(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
+add_library(${MODULE_NAME} SHARED ${${MODULE_PREFIX}_SRCS})
 
 set_target_properties(${MODULE_NAME} PROPERTIES PREFIX "")
 

--- a/winpr/libwinpr/library/test/TestLibraryB/CMakeLists.txt
+++ b/winpr/libwinpr/library/test/TestLibraryB/CMakeLists.txt
@@ -24,7 +24,7 @@ if(MSVC)
 	set(${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_SRCS})
 endif()
 
-add_library(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
+add_library(${MODULE_NAME} SHARED ${${MODULE_PREFIX}_SRCS})
 
 set_target_properties(${MODULE_NAME} PROPERTIES PREFIX "")
 

--- a/winpr/libwinpr/nt/test/TestNtCreateFile.c
+++ b/winpr/libwinpr/nt/test/TestNtCreateFile.c
@@ -20,14 +20,7 @@ int TestNtCreateFile(int argc, char* argv[])
 	ACCESS_MASK DesiredAccess = 0;
 	OBJECT_ATTRIBUTES attributes;
 	IO_STATUS_BLOCK ioStatusBlock;
-
-	int eFailure = -1;
-	int eSuccess =  0;
-
-#ifndef _WIN32
-	printf("Note: %s result may currently only be trusted on Win32\n", __FUNCTION__);
-	eFailure = eSuccess;
-#endif
+	int result = -1;
 
 	_RtlInitAnsiString(&aString, TESTFILE);
 
@@ -35,7 +28,7 @@ int TestNtCreateFile(int argc, char* argv[])
 	if (ntstatus != STATUS_SUCCESS)
 	{
 		printf("_RtlAnsiStringToUnicodeString failure: 0x%08X\n", ntstatus);
-		return eFailure;
+		goto out;
 	}
 
 	handle = NULL;
@@ -53,7 +46,7 @@ int TestNtCreateFile(int argc, char* argv[])
 	if (ntstatus != STATUS_SUCCESS)
 	{
 		printf("_NtCreateFile failure: 0x%08X\n", ntstatus);
-		return eFailure;
+		goto out;
 	}
 
 	_RtlFreeUnicodeString(&uString);
@@ -63,8 +56,27 @@ int TestNtCreateFile(int argc, char* argv[])
 	if (ntstatus != STATUS_SUCCESS)
 	{
 		printf("_NtClose failure: 0x%08X\n", ntstatus);
-		return eFailure;
+		goto out;
 	}
 
-	return eSuccess;
+	result = 0;
+
+out:
+
+#ifndef _WIN32
+	if (result == 0)
+	{
+		printf("%s: Error, this test is currently expected not to succeed on this platform.\n",
+			__FUNCTION__);
+		result = -1;
+	}
+	else
+	{
+		printf("%s: This test is currently expected to fail on this platform.\n",
+			__FUNCTION__);
+		result = 0;
+	}
+#endif
+
+	return result;
 }

--- a/winpr/libwinpr/synch/test/TestSynchWaitableTimerAPC.c
+++ b/winpr/libwinpr/synch/test/TestSynchWaitableTimerAPC.c
@@ -108,6 +108,20 @@ cleanup:
 		CloseHandle(g_Event);
 	free(apcData);
 
+#ifdef __APPLE__
+	if (status == 0)
+	{
+		printf("%s: Error, this test is currently expected not to succeed on this platform.\n",
+			__FUNCTION__);
+		status = -1;
+	}
+	else
+	{
+		printf("%s: This test is currently expected to fail on this platform.\n",
+			__FUNCTION__);
+		status = 0;
+	}
+#endif
 	return status;
 }
 


### PR DESCRIPTION
TestNtCreateFile, TestPipeCreateNamedPipeOverlapped
- These tests are currently only expected to succeed on `_WIN32`
- Also reflect the reverse meaning of this fact in the return values

TestSynchWaitableTimer, TestSynchWaitableTimerAPC:
- These tests are currently expected to fail on `__APPLE__`
- Also reflect the reverse meaning of this fact in the return values

This logic makes sure that we don't forget to fix the tests if the corresponding WinPR implementations are fixed.

TestLibrary:
- TestLibraryA and TestLibraryB must always get built as shared libraries