### PR TITLE
Compile without <sys/queue.h>

### DIFF
--- a/winpr/include/winpr/interlocked.h
+++ b/winpr/include/winpr/interlocked.h
@@ -31,10 +31,12 @@ extern "C" {
 
 #ifndef _WIN32
 
+#ifdef __IOS__
 /* workaround for SLIST_ENTRY conflict */
 
 #include <sys/queue.h>
 #undef SLIST_ENTRY
+#endif
 
 #ifndef CONTAINING_RECORD
 #define CONTAINING_RECORD(address, type, field) \


### PR DESCRIPTION
Some systems such as linux system using musl libc might not have the include <sys/queue.h>.