### PR TITLE
winpr/sspi/ntlm: fix GetComputerNameExA parameters

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -45,9 +45,9 @@ char* NTLM_PACKAGE_NAME = "NTLM";
 int ntlm_SetContextWorkstation(NTLM_CONTEXT* context, char* Workstation)
 {
 	int status;
-	DWORD nSize = MAX_COMPUTERNAME_LENGTH;
 	char* ws = Workstation;
 	CHAR computerName[MAX_COMPUTERNAME_LENGTH + 1];
+	DWORD nSize = sizeof(computerName) * sizeof(CHAR);
 
 	if (!Workstation)
 	{
@@ -108,7 +108,7 @@ int ntlm_SetContextTargetName(NTLM_CONTEXT* context, char* TargetName)
 {
 	int status;
 	CHAR computerName[MAX_COMPUTERNAME_LENGTH + 1];
-	DWORD nSize = MAX_COMPUTERNAME_LENGTH;
+	DWORD nSize = sizeof(computerName) * sizeof(CHAR);
 	char* name = TargetName;
 
 	if (!name)

--- a/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
@@ -174,7 +174,7 @@ int ntlm_get_target_computer_name(PUNICODE_STRING pName, COMPUTER_NAME_FORMAT ty
 	char* name;
 	int status;
 	CHAR computerName[MAX_COMPUTERNAME_LENGTH + 1];
-	DWORD nSize = MAX_COMPUTERNAME_LENGTH;
+	DWORD nSize = sizeof(computerName) * sizeof(CHAR);
 
 	if (!GetComputerNameExA(type, computerName, &nSize))
 		return -1;


### PR DESCRIPTION
On input, the lpnSize [in, out] parameter for GetComputerNameEx() specifies the total size of the buffer (in characters).
Several functions in ntlm.c were off by one which caused ntlm to fail if the netbios hostname's strlen was exactly MAX_COMPUTERNAME_LENGTH.