### PR TITLE
redirect specific smartcard readers

### DIFF
--- a/channels/smartcard/client/smartcard_main.c
+++ b/channels/smartcard/client/smartcard_main.c
@@ -725,6 +725,15 @@ UINT DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
 			smartcard->name = name;
 	}
 
+	LONG status;
+	status = SCardAddReaderName(&smartcard->thread, (LPSTR) name);
+
+	if (status != SCARD_S_SUCCESS)
+	{
+		WLog_ERR(TAG, "Failed to add reader name!");
+		goto error_device_data;
+	}
+
 	smartcard->IrpQueue = MessageQueue_New(NULL);
 	if (!smartcard->IrpQueue)
 	{

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -838,15 +838,28 @@ static int freerdp_client_command_line_post_filter(void* context, COMMAND_LINE_A
 	}
 	CommandLineSwitchCase(arg, "smartcard")
 	{
-		char** p;
-		int count;
+		if (arg->Flags & COMMAND_LINE_VALUE_PRESENT)
+		{
+			char** p;
+			int count;
 
-		p = freerdp_command_line_parse_comma_separated_values_offset(arg->Value, &count);
-		p[0] = "smartcard";
+			p = freerdp_command_line_parse_comma_separated_values_offset(arg->Value, &count);
+			p[0] = "smartcard";
 
-		status = freerdp_client_add_device_channel(settings, count, p);
+			status = freerdp_client_add_device_channel(settings, count, p);
 
-		free(p);
+			free(p);
+		}
+		else
+		{
+			char* p[2];
+			int count;
+			count = 2;
+			p[0] = "smartcard";
+			p[1] = "";
+
+			status = freerdp_client_add_device_channel(settings, count, p);
+		}
 	}
 	CommandLineSwitchCase(arg, "printer")
 	{

--- a/winpr/include/winpr/smartcard.h
+++ b/winpr/include/winpr/smartcard.h
@@ -779,6 +779,8 @@ WINSCARDAPI LONG WINAPI SCardListReadersWithDeviceInstanceIdW(SCARDCONTEXT hCont
 
 WINSCARDAPI LONG WINAPI SCardAudit(SCARDCONTEXT hContext, DWORD dwEvent);
 
+WINSCARDAPI LONG WINAPI SCardAddReaderName(HANDLE* key, LPSTR readerName);
+
 #ifdef UNICODE
 #define SCardListReaderGroups			SCardListReaderGroupsW
 #define SCardListReaders			SCardListReadersW
@@ -1027,6 +1029,8 @@ typedef LONG (WINAPI * fnSCardListReadersWithDeviceInstanceIdW)(SCARDCONTEXT hCo
 
 typedef LONG (WINAPI * fnSCardAudit)(SCARDCONTEXT hContext, DWORD dwEvent);
 
+typedef LONG (WINAPI * fnSCardAddReaderName)(HANDLE* key, LPSTR readerName);
+
 struct _SCardApiFunctionTable
 {
 	DWORD dwVersion;
@@ -1108,6 +1112,7 @@ struct _SCardApiFunctionTable
 	fnSCardListReadersWithDeviceInstanceIdA pfnSCardListReadersWithDeviceInstanceIdA;
 	fnSCardListReadersWithDeviceInstanceIdW pfnSCardListReadersWithDeviceInstanceIdW;
 	fnSCardAudit pfnSCardAudit;
+	fnSCardAddReaderName pfnSCardAddReaderName;
 };
 
 typedef struct _SCardApiFunctionTable SCardApiFunctionTable;

--- a/winpr/libwinpr/smartcard/smartcard.c
+++ b/winpr/libwinpr/smartcard/smartcard.c
@@ -497,6 +497,12 @@ WINSCARDAPI LONG WINAPI SCardAudit(SCARDCONTEXT hContext, DWORD dwEvent)
 	SCARDAPI_STUB_CALL_LONG(SCardAudit, hContext, dwEvent);
 }
 
+WINSCARDAPI LONG WINAPI SCardAddReaderName(HANDLE* key, LPSTR readerName)
+{
+	SCARDAPI_STUB_CALL_LONG(SCardAddReaderName, key, readerName);
+}
+
+
 /**
  * Extended API
  */

--- a/winpr/libwinpr/smartcard/smartcard_pcsc.c
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.c
@@ -155,6 +155,7 @@ static wArrayList* g_Readers = NULL;
 static wListDictionary* g_CardHandles = NULL;
 static wListDictionary* g_CardContexts = NULL;
 static wListDictionary* g_MemoryBlocks = NULL;
+static wListDictionary* g_ReadersNames = NULL;
 
 char SMARTCARD_PNP_NOTIFICATION_A[] = "\\\\?PnP?\\Notification";
 
@@ -646,25 +647,8 @@ error_namePSC:
 	return FALSE;
 }
 
-static int PCSC_AtoiWithLength(const char* str, int length)
-{
-	int index;
-	int value = 0;
-
-	for (index = 0; index < length; ++index)
-	{
-		if (!isdigit(str[index]))
-			return -1;
-
-		value = value * 10 + (str[index] - '0');
-	}
-
-	return value;
-}
-
 char* PCSC_ConvertReaderNameToWinSCard(const char* name)
 {
-	int slot;
 	int index;
 	int size;
 	int length;
@@ -673,7 +657,6 @@ char* PCSC_ConvertReaderNameToWinSCard(const char* name)
 	char* p, *q;
 	char* tokens[64][2];
 	char* nameWinSCard;
-	char *checkAliasName;
 	/**
 	 * pcsc-lite reader name format:
 	 * name [interface] (serial) index slot
@@ -746,45 +729,7 @@ char* PCSC_ConvertReaderNameToWinSCard(const char* name)
 	if (ntokens < 2)
 		return NULL;
 
-	slot = index = -1;
 	ctoken = ntokens - 1;
-	slot = PCSC_AtoiWithLength(tokens[ctoken][0], (int)(tokens[ctoken][1] - tokens[ctoken][0]));
-	ctoken--;
-	index = PCSC_AtoiWithLength(tokens[ctoken][0], (int)(tokens[ctoken][1] - tokens[ctoken][0]));
-	ctoken--;
-
-	if (index < 0)
-	{
-		slot = -1;
-		index = slot;
-		ctoken++;
-	}
-
-	if ((index < 0) || (slot < 0))
-		return NULL;
-
-	if (tokens[ctoken] && tokens[ctoken][1] && *(tokens[ctoken][1] - 1) == ')')
-	{
-		while ((*(tokens[ctoken][0]) != '(') && (ctoken > 0))
-			ctoken--;
-
-		ctoken--;
-	}
-
-	if (ctoken < 1)
-		return NULL;
-
-	if (*(tokens[ctoken][1] - 1) == ']')
-	{
-		while ((*(tokens[ctoken][0]) != '[') && (ctoken > 0))
-			ctoken--;
-
-		ctoken--;
-	}
-
-	if (ctoken < 1)
-		return NULL;
-
 	p = tokens[0][0];
 	q = tokens[ctoken][1];
 	length = (q - p);
@@ -801,17 +746,32 @@ char* PCSC_ConvertReaderNameToWinSCard(const char* name)
 	 * and incrementing until available index found.
 	 */
 	index = 0;
-	sprintf_s(nameWinSCard, size, "%.*s %d", length, p, index);
-
-	checkAliasName = PCSC_GetReaderNameFromAlias(nameWinSCard);
-	while ((checkAliasName != NULL) && (strcmp(checkAliasName, name) != 0))
-	{
-		index++;
-		sprintf_s(nameWinSCard, size, "%.*s %d", length, p, index);
-		checkAliasName = PCSC_GetReaderNameFromAlias(nameWinSCard);
-	}
+	sprintf_s(nameWinSCard, size, "%.*s", length, p);
 
 	return nameWinSCard;
+}
+
+int PCSC_RedirectReader(char* readerName)
+{
+	char *name;
+	ULONG_PTR *readers;
+	int i, nbReaders;
+
+	nbReaders = ListDictionary_GetKeys(g_ReadersNames, &readers);
+
+	for (i = 0; i < nbReaders; i++)
+	{
+		name = ListDictionary_GetItemValue(g_ReadersNames, (void*) readers[i]);
+		if (name)
+		{
+			if (strcmp(name, "") == 0)
+				return 0;
+			if (strncmp(readerName, name, strlen(readerName)) == 0)
+				return 0;
+		}
+	}
+
+	return -1;
 }
 
 char* PCSC_GetReaderAliasFromName(char* namePCSC)
@@ -833,6 +793,7 @@ char* PCSC_ConvertReaderNamesToWinSCard(const char* names, LPDWORD pcchReaders)
 	DWORD cchReaders;
 	char* nameWinSCard;
 	char* namesWinSCard;
+	BOOL endReaderName = FALSE;
 	p = (char*) names;
 	cchReaders = *pcchReaders;
 	namesWinSCard = (char*) malloc(cchReaders * 2);
@@ -850,7 +811,11 @@ char* PCSC_ConvertReaderNamesToWinSCard(const char* names, LPDWORD pcchReaders)
 		if (nameWinSCard)
 		{
 			length = strlen(nameWinSCard);
-			CopyMemory(q, nameWinSCard, length);
+			if (PCSC_RedirectReader(nameWinSCard) == 0)
+			{
+				CopyMemory(q, nameWinSCard, length);
+				endReaderName = TRUE;
+			}
 			free(nameWinSCard);
 		}
 		else
@@ -859,9 +824,14 @@ char* PCSC_ConvertReaderNamesToWinSCard(const char* names, LPDWORD pcchReaders)
 			CopyMemory(q, p, length);
 		}
 
-		q += length;
-		*q = '\0';
-		q++;
+		if (endReaderName)
+		{
+			q += length;
+			*q = '\0';
+			q++;
+			endReaderName = FALSE;
+		}
+
 		p += strlen(p) + 1;
 	}
 
@@ -870,6 +840,27 @@ char* PCSC_ConvertReaderNamesToWinSCard(const char* names, LPDWORD pcchReaders)
 	*pcchReaders = (DWORD)(q - namesWinSCard);
 	return namesWinSCard;
 }
+
+WINSCARDAPI LONG WINAPI PCSC_SCardAddReaderName(HANDLE* key, LPSTR readerName)
+{
+	LONG status = SCARD_S_SUCCESS;
+	int count;
+
+	if (!g_ReadersNames)
+	{
+		g_ReadersNames = ListDictionary_New(TRUE);
+		if (!g_ReadersNames)
+			return SCARD_E_NO_SERVICE;
+       }
+
+	count = ListDictionary_Count(g_ReadersNames);
+
+	if(!ListDictionary_Add(g_ReadersNames, key, readerName))
+		return SCARD_E_NO_SERVICE;
+
+	return status;
+}
+
 
 char* PCSC_ConvertReaderNamesToPCSC(const char* names, LPDWORD pcchReaders)
 {
@@ -2971,7 +2962,8 @@ SCardApiFunctionTable PCSC_SCardApiFunctionTable =
 	PCSC_SCardGetReaderDeviceInstanceIdW, /* SCardGetReaderDeviceInstanceIdW */
 	PCSC_SCardListReadersWithDeviceInstanceIdA, /* SCardListReadersWithDeviceInstanceIdA */
 	PCSC_SCardListReadersWithDeviceInstanceIdW, /* SCardListReadersWithDeviceInstanceIdW */
-	PCSC_SCardAudit /* SCardAudit */
+	PCSC_SCardAudit, /* SCardAudit */
+	PCSC_SCardAddReaderName /* SCardAddReaderName */
 };
 
 PSCardApiFunctionTable PCSC_GetSCardApiFunctionTable(void)

--- a/winpr/libwinpr/smartcard/smartcard_pcsc.h
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.h
@@ -152,6 +152,7 @@ struct _PCSCFunctionTable
 	PCSC_LONG (* pfnSCardCancel)(SCARDCONTEXT hContext);
 	PCSC_LONG (* pfnSCardGetAttrib)(SCARDHANDLE hCard, PCSC_DWORD dwAttrId, LPBYTE pbAttr, PCSC_LPDWORD pcbAttrLen);
 	PCSC_LONG (* pfnSCardSetAttrib)(SCARDHANDLE hCard, PCSC_DWORD dwAttrId, LPCBYTE pbAttr, PCSC_DWORD cbAttrLen);
+	PCSC_LONG (* pfnSCardAddReaderName)(HANDLE* key, LPSTR readerName);
 };
 typedef struct _PCSCFunctionTable PCSCFunctionTable;
 

--- a/winpr/libwinpr/smartcard/smartcard_winscard.c
+++ b/winpr/libwinpr/smartcard/smartcard_winscard.c
@@ -111,7 +111,8 @@ SCardApiFunctionTable WinSCard_SCardApiFunctionTable =
 	NULL, /* SCardGetReaderDeviceInstanceIdW */
 	NULL, /* SCardListReadersWithDeviceInstanceIdA */
 	NULL, /* SCardListReadersWithDeviceInstanceIdW */
-	NULL /* SCardAudit */
+	NULL, /* SCardAudit */
+	NULL /* SCardAddReaderName */
 };
 
 PSCardApiFunctionTable WinSCard_GetSCardApiFunctionTable(void)


### PR DESCRIPTION
Until now, /smartcard: had the behaviour to redirect every connected readers. It didn't matter what you used after the parameter /smartcard:xxxx:yyyy.

With this patch you can:
-    use /smartcard: "as is" (without argument) to continue to redirect every readers
-    use /smartcard:"Reader name" (you have to repeat that for every reader you want to redirect)

The reader name is exactly the one returned by libpcsclite, e.g.

> root@host:# opensc-tool -l
> Detected readers (pcsc)
> 
> Nr. Card Features Name
> 0 Yes Xiring Leo V2 (12547854125036) 00 00
> 1 Yes Xiring Leo V2 (52412506854712) 01 00

(Thanks to A. Aing for this PR)
