### PR TITLE
winpr/sspi/ntlm: fix computer name len calculation

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -47,7 +47,7 @@ int ntlm_SetContextWorkstation(NTLM_CONTEXT* context, char* Workstation)
 	int status;
 	char* ws = Workstation;
 	CHAR computerName[MAX_COMPUTERNAME_LENGTH + 1];
-	DWORD nSize = sizeof(computerName) * sizeof(CHAR);
+	DWORD nSize = sizeof(computerName) / sizeof(CHAR);
 
 	if (!Workstation)
 	{
@@ -108,12 +108,11 @@ int ntlm_SetContextTargetName(NTLM_CONTEXT* context, char* TargetName)
 {
 	int status;
 	CHAR computerName[MAX_COMPUTERNAME_LENGTH + 1];
-	DWORD nSize = sizeof(computerName) * sizeof(CHAR);
+	DWORD nSize = sizeof(computerName) / sizeof(CHAR);
 	char* name = TargetName;
 
 	if (!name)
 	{
-
 		if (!GetComputerNameExA(ComputerNameDnsHostname, computerName, &nSize))
 			return -1;
 

--- a/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
@@ -174,7 +174,7 @@ int ntlm_get_target_computer_name(PUNICODE_STRING pName, COMPUTER_NAME_FORMAT ty
 	char* name;
 	int status;
 	CHAR computerName[MAX_COMPUTERNAME_LENGTH + 1];
-	DWORD nSize = sizeof(computerName) * sizeof(CHAR);
+	DWORD nSize = sizeof(computerName) / sizeof(CHAR);
 
 	if (!GetComputerNameExA(type, computerName, &nSize))
 		return -1;


### PR DESCRIPTION
The lpnSize parameter for GetComputerNameEx specifies the total size of the buffer (in characters).
However, the current code calculated the amount of bytes.
Since only GetComputerNameExA was used and because sizeof(CHAR) == 1 the result was correct but the math was wrong.
Credit goes to @byteboon