### PR TITLE
Wlog callback init fix

### DIFF
--- a/winpr/include/winpr/wlog.h
+++ b/winpr/include/winpr/wlog.h
@@ -111,6 +111,7 @@ WINPR_API BOOL WLog_PrintMessageVA(wLog* log, wLogMessage* message, va_list args
 	do { \
 		if (_log && _log_level >= WLog_GetLogLevel(_log)) { \
 			wLogMessage _log_message; \
+			memset(&_log_message, 0, sizeof(_log_message)); \
 			_log_message.Type = WLOG_MESSAGE_TEXT; \
 			_log_message.Level = _log_level; \
 			_log_message.FormatString = _fmt; \
@@ -125,6 +126,7 @@ WINPR_API BOOL WLog_PrintMessageVA(wLog* log, wLogMessage* message, va_list args
 	do { \
 		if (_log && _log_level >= WLog_GetLogLevel(_log)) { \
 			wLogMessage _log_message; \
+			memset(&_log_message, 0, sizeof(_log_message)); \
 			_log_message.Type = WLOG_MESSAGE_TEXT; \
 			_log_message.Level = _log_level; \
 			_log_message.FormatString = _fmt; \
@@ -139,6 +141,7 @@ WINPR_API BOOL WLog_PrintMessageVA(wLog* log, wLogMessage* message, va_list args
 	do { \
 		if (_log && _log_level >= WLog_GetLogLevel(_log)) { \
 			wLogMessage _log_message; \
+			memset(&_log_message, 0, sizeof(_log_message)); \
 			_log_message.Type = WLOG_MESSAGE_DATA; \
 			_log_message.Level = _log_level; \
 			_log_message.FormatString = NULL; \
@@ -153,6 +156,7 @@ WINPR_API BOOL WLog_PrintMessageVA(wLog* log, wLogMessage* message, va_list args
 	do { \
 		if (_log && _log_level >= WLog_GetLogLevel(_log)) { \
 			wLogMessage _log_message; \
+			memset(&_log_message, 0, sizeof(_log_message)); \
 			_log_message.Type = WLOG_MESSAGE_IMAGE; \
 			_log_message.Level = _log_level; \
 			_log_message.FormatString = NULL; \
@@ -167,6 +171,7 @@ WINPR_API BOOL WLog_PrintMessageVA(wLog* log, wLogMessage* message, va_list args
 	do { \
 		if (_log && _log_level >= WLog_GetLogLevel(_log)) { \
 			wLogMessage _log_message; \
+			memset(&_log_message, 0, sizeof(_log_message)); \
 			_log_message.Type = WLOG_MESSAGE_PACKET; \
 			_log_message.Level = _log_level; \
 			_log_message.FormatString = NULL; \

--- a/winpr/libwinpr/utils/wlog/CallbackAppender.c
+++ b/winpr/libwinpr/utils/wlog/CallbackAppender.c
@@ -49,6 +49,7 @@ static BOOL WLog_CallbackAppender_WriteMessage(wLog* log, wLogAppender* appender
 
 	if (!appender)
 		return FALSE;
+
 	message->PrefixString = prefix;
 	WLog_Layout_GetMessagePrefix(log, appender->Layout, message);
 
@@ -62,10 +63,14 @@ static BOOL WLog_CallbackAppender_WriteMessage(wLog* log, wLogAppender* appender
 
 static BOOL WLog_CallbackAppender_WriteDataMessage(wLog* log, wLogAppender* appender, wLogMessage* message)
 {
-
+	char prefix[WLOG_MAX_PREFIX_SIZE];
 	wLogCallbackAppender* callbackAppender;
+
 	if (!appender)
 		return FALSE;
+
+	message->PrefixString = prefix;
+	WLog_Layout_GetMessagePrefix(log, appender->Layout, message);
 
 	callbackAppender = (wLogCallbackAppender *)appender;
 	if (callbackAppender->callbacks && callbackAppender->callbacks->data)
@@ -76,9 +81,14 @@ static BOOL WLog_CallbackAppender_WriteDataMessage(wLog* log, wLogAppender* appe
 
 static BOOL WLog_CallbackAppender_WriteImageMessage(wLog* log, wLogAppender* appender, wLogMessage* message)
 {
+	char prefix[WLOG_MAX_PREFIX_SIZE];
 	wLogCallbackAppender* callbackAppender;
+
 	if (!appender)
 		return FALSE;
+
+	message->PrefixString = prefix;
+	WLog_Layout_GetMessagePrefix(log, appender->Layout, message);
 
 	callbackAppender = (wLogCallbackAppender *)appender;
 	if (callbackAppender->callbacks && callbackAppender->callbacks->image)
@@ -89,9 +99,14 @@ static BOOL WLog_CallbackAppender_WriteImageMessage(wLog* log, wLogAppender* app
 
 static BOOL WLog_CallbackAppender_WritePacketMessage(wLog* log, wLogAppender* appender, wLogMessage* message)
 {
+	char prefix[WLOG_MAX_PREFIX_SIZE];
 	wLogCallbackAppender* callbackAppender;
+
 	if (!appender)
 		return FALSE;
+
+	message->PrefixString = prefix;
+	WLog_Layout_GetMessagePrefix(log, appender->Layout, message);
 
 	callbackAppender = (wLogCallbackAppender *)appender;
 	if (callbackAppender->callbacks && callbackAppender->callbacks->package)


### PR DESCRIPTION
- When using the callback appender, ensure that ```PrefixString``` of the message is initialised.
- Initialise all members of ```wLogMessage``` to avoid problems with ```NULL``` checks in appenders.
