### PR TITLE
Send Keystrokes to Desktop 

### DIFF
--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -465,6 +465,26 @@ BOOL xf_keyboard_handle_special_keys(xfContext* xfc, KeySym keysym)
 	{
 		return TRUE;
 	}
+	// Nicholai Mitchko
+	// Add a keyboard binding to allow switching workspaces in FullScreenMode
+	// Release Keyboard: CTRL + ALT + R/r
+	// Capture Keyboard: CTRL + ALT + U/u
+	if((keysym == XK_u) || (keysym == XK_U)){
+		if(mod.Ctrl && mod.Alt){
+			if(xfc->fullscreen){
+				XGrabKeyboard(xfc->display, xfc->window->handle, TRUE, GrabModeAsync, GrabModeAsync, CurrentTime);
+			}
+		}
+	}
+
+	if((keysym == XK_r) || (keysym == XK_R)){
+		if(mod.Ctrl && mod.Alt){
+			if(xfc->fullscreen){
+				XUngrabKeyboard(xfc->display, CurrentTime);
+			}
+		}
+	}
+	// End Changes
 
 	if(!xfc->remote_app && xfc->fullscreen_toggle)
 	{


### PR DESCRIPTION
Adds keyboard hotkey that disables/enables keyboard capture on the xfreerdp client window.
Previously in X11, you were stuck in fullscreen mode and graphics would break on the normal CTRL+ALT+ENTER; This made multitasking with workspaces near impossible.

Added Keystrokes (captures both uppercase and lowercase):
Ctrl + Atl + R: Releases keystrokes until window regains focus.
Ctrl + Atl + U: Recaptures keystrokes (they get sent back to rdp), only used if the rdp window doesn't not refocus.

Example Usage:
Case (Ubuntu 16.04, multiple workspaces, RDP on workspace 1 of 4 [2x2]): 
command: xfreerdp /u:user /p:password /d:domain /f /multimon /v:rdphost.somehost.com
- First. user sends keystroke Ctrl + Alt + r
- Then user send Ctrl + Alt + →
  Outcome workspace changes to workspace 2
