### PR TITLE
libfreerdp/core: transport_write unchecked parameters

### DIFF
--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -657,6 +657,15 @@ int transport_write(rdpTransport* transport, wStream* s)
 	int status = -1;
 	int writtenlength = 0;
 
+	if (!transport)
+		return -1;
+
+	if (!transport->frontBio)
+	{
+		transport->layer = TRANSPORT_LAYER_CLOSED;
+		return -1;
+	}
+
 	EnterCriticalSection(&(transport->WriteLock));
 
 	length = Stream_GetPosition(s);


### PR DESCRIPTION
transport_write did not check if transport or bio are
set. The transport read checks it. In using fastpath
and for example a mouse input is sent, the transport
is never checked and can cause a segfault.