### PR TITLE
fix for xcode8 clock_gettime

### DIFF
--- a/winpr/libwinpr/synch/wait.c
+++ b/winpr/libwinpr/synch/wait.c
@@ -67,6 +67,7 @@
 
 #include "../pipe/pipe.h"
 
+/* clock_gettime is not implemented on OSX prior to 10.12 */
 #ifdef __MACH__
 
 #include <mach/mach_time.h>
@@ -74,7 +75,11 @@
 #define CLOCK_REALTIME 0
 #define CLOCK_MONOTONIC 0
 
-int clock_gettime(int clk_id, struct timespec *t)
+/* clock_gettime is not implemented on OSX prior to 10.12 */
+int _mach_clock_gettime(int clk_id, struct timespec *t);
+
+int 
+_mach_clock_gettime(int clk_id, struct timespec *t)
 {
 	UINT64 time;
 	double seconds;
@@ -88,6 +93,25 @@ int clock_gettime(int clk_id, struct timespec *t)
 	t->tv_nsec = nseconds;
 	return 0;
 }
+
+/* if clock_gettime is declared, then __CLOCK_AVAILABILITY will be defined */
+#ifdef __CLOCK_AVAILABILITY
+/* If we compiled with Mac OSX 10.12 or later, then clock_gettime will be declared
+ * * but it may be NULL at runtime. So we need to check before using it. */
+int _mach_safe_clock_gettime(int clk_id, struct timespec *t);
+
+int
+_mach_safe_clock_gettime(int clk_id, struct timespec *t) {
+        if( clock_gettime ) {
+                    return clock_gettime(clk_id, t);
+                        }
+            return _mach_clock_gettime(clk_id, t);
+}
+
+#define clock_gettime _mach_safe_clock_gettime
+#else
+#define clock_gettime _mach_clock_gettime
+#endif
 
 #endif
 


### PR DESCRIPTION
Credit to @ehlertjd for a relatively portable fix.

Fix comes from this: https://github.com/civetweb/civetweb/pull/358
