### PR TITLE
client/X11: Only upconvert < 24 bit RFX tiles

### DIFF
--- a/client/X11/xf_gdi.c
+++ b/client/X11/xf_gdi.c
@@ -1215,7 +1215,7 @@ BOOL xf_gdi_surface_bits(rdpContext* context, SURFACE_BITS_COMMAND* cmd)
 			pSrcData = message->tiles[i]->data;
 			pDstData = pSrcData;
 
-			if ((xfc->depth != 24) || (xfc->depth != 32))
+			if ((xfc->depth != 24) && (xfc->depth != 32))
 			{
 				pDstData = xfc->bitmap_buffer;
 


### PR DESCRIPTION
Fixing this logical typo gives a slight performance boost /
CPU usage reduction on heavy loads.