### PR TITLE
rdpsnd/pulse: Fix crashes in pulseaudio

### DIFF
--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -584,7 +584,9 @@ static void rdpsnd_pulse_start(rdpsndDevicePlugin* device)
 	if (!pulse->stream)
 		return;
 
+	pa_threaded_mainloop_lock(pulse->mainloop);
 	pa_stream_trigger(pulse->stream, NULL, NULL);
+	pa_threaded_mainloop_unlock(pulse->mainloop);
 }
 
 COMMAND_LINE_ARGUMENT_A rdpsnd_pulse_args[] =


### PR DESCRIPTION
This fix is already part of `stable-1.0` branch and it should be merged into `master` branch also, see https://github.com/FreeRDP/FreeRDP/pull/2694.

The `pa_stream_trigger` function has to be called under the lock in order to avoid the following crashes on asserts:

```
Assertion 'e->mainloop->n_enabled_defer_events > 0' failed at pulse/mainloop.c:257, function mainloop_defer_enable(). Aborting.
Assertion '!e->next' failed at pulsecore/queue.c:104, function pa_queue_pop(). Aborting.
Assertion 'q->front' failed at pulsecore/queue.c:81, function pa_queue_push(). Aborting.
```