### PR TITLE
client/Mac: Runs Mac password dialog on main UI thread

### DIFF
--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -977,9 +977,11 @@ BOOL mac_authenticate(freerdp* instance, char** username, char** password,
 		dialog.password = [NSString stringWithCString:*password encoding:
 		                   NSUTF8StringEncoding];
 
-	BOOL ok = [dialog runModal];
+	[dialog performSelectorOnMainThread:@selector(runModal) withObject:nil waitUntilDone:TRUE];
 
-	if (ok)
+	BOOL ok = dialog.modalCode;
+
+	if (ok) 
 	{
 		const char* submittedUsername = [dialog.username cStringUsingEncoding:
 		                                 NSUTF8StringEncoding];

--- a/client/Mac/PasswordDialog.h
+++ b/client/Mac/PasswordDialog.h
@@ -28,6 +28,7 @@
     NSString* serverHostname;
     NSString* username;
     NSString* password;
+    BOOL modalCode;
 }
 @property (retain) IBOutlet NSTextField* usernameText;
 @property (retain) IBOutlet NSTextField* passwordText;
@@ -39,6 +40,7 @@
 @property (retain) NSString* serverHostname;
 @property (retain) NSString* username;
 @property (retain) NSString* password;
+@property BOOL modalCode;
 
 - (BOOL) runModal;
 

--- a/client/Mac/PasswordDialog.m
+++ b/client/Mac/PasswordDialog.m
@@ -31,6 +31,7 @@
 @synthesize serverHostname;
 @synthesize username;
 @synthesize password;
+@synthesize modalCode;
 
 - (id)init
 {
@@ -66,7 +67,7 @@
 
 - (BOOL)runModal
 {
-	return [NSApp runModalForWindow:self.window];
+	return (self.modalCode = [NSApp runModalForWindow:self.window]);
 }
 
 - (void)dealloc


### PR DESCRIPTION
Fixes a bug in which the program terminates with the following error when supplying incomplete credentials to the Mac client:

Terminating app due to uncaught exception 'NSGenericException', reason: '-[NSApplication runModalForWindow:] may only be invoked from the main thread. Behavior on other threads is undefined.'

The submitted change ensures that the runModal dialog runs in the main UI thread and blocks the calling thread until it completes. When the user clicks OK or Cancel, the appropriate return code is saved to a property on the dialog so it can be picked up by the calling thread.