### PR TITLE
Fix nsc client after after color conversion huge fix

### DIFF
--- a/client/X11/xf_gdi.c
+++ b/client/X11/xf_gdi.c
@@ -1018,7 +1018,7 @@ static BOOL xf_gdi_surface_bits(rdpContext* context,
 			if (!nsc_process_message(context->codecs->nsc, cmd->bpp, cmd->width,
 			                         cmd->height,
 			                         cmd->bitmapData, cmd->bitmapDataLength,
-			                         xfc->bitmap_buffer, gdi->dstFormat, 0, 0, 0, cmd->width, cmd->height))
+			                         gdi->primary_buffer, gdi->dstFormat, 0, 0, 0, cmd->width, cmd->height))
 			{
 				xf_unlock_x11(xfc, FALSE);
 				return FALSE;
@@ -1026,8 +1026,7 @@ static BOOL xf_gdi_surface_bits(rdpContext* context,
 
 			XSetFunction(xfc->display, xfc->gc, GXcopy);
 			XSetFillStyle(xfc->display, xfc->gc, FillSolid);
-			pSrcData = context->codecs->nsc->BitmapData;
-			pDstData = xfc->bitmap_buffer;
+			pDstData = gdi->primary_buffer;
 			image = XCreateImage(xfc->display, xfc->visual, xfc->depth, ZPixmap, 0,
 			                     (char*) pDstData, cmd->width, cmd->height, xfc->scanline_pad, 0);
 			XPutImage(xfc->display, xfc->primary, xfc->gc, image, 0, 0,
@@ -1042,7 +1041,7 @@ static BOOL xf_gdi_surface_bits(rdpContext* context,
 			XSetFunction(xfc->display, xfc->gc, GXcopy);
 			XSetFillStyle(xfc->display, xfc->gc, FillSolid);
 			pSrcData = cmd->bitmapData;
-			pDstData = xfc->bitmap_buffer;
+			pDstData = gdi->primary_buffer;
 			freerdp_image_copy(pDstData, gdi->dstFormat, 0, 0, 0,
 			                   cmd->width, cmd->height, pSrcData,
 			                   PIXEL_FORMAT_BGRX32_VF, 0, 0, 0, &xfc->context.gdi->palette);

--- a/libfreerdp/codec/nsc.c
+++ b/libfreerdp/codec/nsc.c
@@ -407,7 +407,7 @@ BOOL nsc_process_message(NSC_CONTEXT* context, UINT16 bpp,
 
 	if (!freerdp_image_copy(pDstData, DstFormat, nDstStride, nXDst, nYDst,
 				width, height, context->BitmapData,
-				PIXEL_FORMAT_BGRA32, 0, 0, 0, NULL))
+				PIXEL_FORMAT_BGRX32_VF, 0, 0, 0, NULL))
 		return FALSE;
 
 	return TRUE;

--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -1060,6 +1060,12 @@ static BOOL gdi_surface_bits(rdpContext* context,
 			break;
 	}
 
+	if (!gdi_InvalidateRegion(gdi->primary->hdc, cmd->destLeft, cmd->destTop, cmd->width, cmd->height))
+	{
+		WLog_ERR(TAG, "Failed to update invalid region");
+		return FALSE;
+	}
+
 	return TRUE;
 }
 


### PR DESCRIPTION
nsc codec client doesn't work:
1. We should mark invalid region for software gdi
2. Checked the code before color conversion fix, the correct color format should be PIXEL_FORMAT_BGRX32_VF (corresponds to old PIXEL_FORMAT_XRGB32_VF)
3. For gdi:hw: xfc->bitmap_buffer is never used/initialized. However gdi->primary_buffer is always maintained. So use primary_buffer to hold the decoded bitmap data

Tested with both gdi:sw and gdi:hw