### PR TITLE
winpr/mutex: Use PTHREAD_MUTEX_RECURSIVE_NP instead of PTHREAD_MUTEX_RECURSIVE

### DIFF
--- a/winpr/libwinpr/synch/mutex.c
+++ b/winpr/libwinpr/synch/mutex.c
@@ -121,7 +121,7 @@ HANDLE CreateMutexW(LPSECURITY_ATTRIBUTES lpMutexAttributes, BOOL bInitialOwner,
 	{
 		pthread_mutexattr_t attr;
 		pthread_mutexattr_init(&attr);
-		pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+		pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE_NP);
 		pthread_mutex_init(&mutex->mutex, &attr);
 
 		WINPR_HANDLE_SET_TYPE_AND_MODE(mutex, HANDLE_TYPE_MUTEX, WINPR_FD_READ);


### PR DESCRIPTION
Some platform only defines PTHREAD_MUTEX_RECURSIVE_NP without PTHREAD_MUTEX_RECURSIVE in /usr/include/pthread.h