### PR TITLE
Implement callbacks for version 5 of wl_pointer

### DIFF
--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -602,10 +602,6 @@ static void pointer_handle_leave(void *data, struct wl_pointer *pointer, uint32_
 
 	event->seat = input;
 	event->window = window;
-
-#if 0
-	input_remove_pointer_focus(input);
-#endif
 }
 
 static void pointer_handle_motion(void *data, struct wl_pointer *pointer, uint32_t time,
@@ -677,12 +673,30 @@ static void pointer_handle_axis(void *data, struct wl_pointer *pointer, uint32_t
 	event->value = value;
 }
 
+static void pointer_frame(void *data, struct wl_pointer *wl_pointer)
+{
+	/*UwacSeat *seat = data;*/
+}
+
+static void pointer_axis_source(void *data, struct wl_pointer *wl_pointer, uint32_t axis_source)
+{
+	/*UwacSeat *seat = data;*/
+}
+
+void pointer_axis_stop(void *data, struct wl_pointer *wl_pointer, uint32_t time, uint32_t axis)
+{
+	/*UwacSeat *seat = data;*/
+}
+
 static const struct wl_pointer_listener pointer_listener = {
 	pointer_handle_enter,
 	pointer_handle_leave,
 	pointer_handle_motion,
 	pointer_handle_button,
 	pointer_handle_axis,
+	pointer_frame,
+	pointer_axis_source,
+	pointer_axis_stop,
 };
 
 


### PR DESCRIPTION
This should prevent crash with compositor that implement this version. This partially fixes https://github.com/FreeRDP/FreeRDP/issues/3415.