### PR TITLE
client/mac: Run password dialog as a modal sheet and set window title to server:port

### DIFF
--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -194,7 +194,7 @@ DWORD mac_client_thread(void* param)
 		if (settings->AsyncInput)
 		{
 			if (!(inputThread = CreateThread(NULL, 0,
-			(LPTHREAD_START_ROUTINE) mac_client_input_thread, context, 0, NULL)))
+			                                 (LPTHREAD_START_ROUTINE) mac_client_input_thread, context, 0, NULL)))
 			{
 				WLog_ERR(TAG,  "failed to create async input thread");
 				goto disconnect;
@@ -203,7 +203,7 @@ DWORD mac_client_thread(void* param)
 		else
 		{
 			if (!(inputEvent = freerdp_get_message_queue_event_handle(instance,
-			FREERDP_INPUT_MESSAGE_QUEUE)))
+			                   FREERDP_INPUT_MESSAGE_QUEUE)))
 			{
 				WLog_ERR(TAG, "failed to get input event handle");
 				goto disconnect;
@@ -221,7 +221,7 @@ DWORD mac_client_thread(void* param)
 			if (!settings->AsyncTransport)
 			{
 				if (!(nCountTmp = freerdp_get_event_handles(context, &events[nCount],
-				16 - nCount)))
+				                  16 - nCount)))
 				{
 					WLog_ERR(TAG, "freerdp_get_event_handles failed");
 					break;
@@ -967,11 +967,11 @@ BOOL mac_authenticate(freerdp* instance, char** username, char** password,
 {
 	mfContext* mfc = (mfContext*) instance->context;
 	MRDPView* view = (MRDPView*) mfc->view;
-
 	PasswordDialog* dialog = [PasswordDialog new];
 	dialog.serverHostname = [NSString stringWithFormat:@"%@:%u",
-					[NSString stringWithCString:instance->settings->ServerHostname encoding:NSUTF8StringEncoding],
-					instance->settings->ServerPort];
+	                         [NSString stringWithCString:instance->settings->ServerHostname encoding:
+	                          NSUTF8StringEncoding],
+	                         instance->settings->ServerPort];
 
 	if (*username)
 		dialog.username = [NSString stringWithCString:*username encoding:
@@ -983,26 +983,24 @@ BOOL mac_authenticate(freerdp* instance, char** username, char** password,
 
 	if (*domain)
 		dialog.domain = [NSString stringWithCString:*domain encoding:
-		                   NSUTF8StringEncoding];
+		                 NSUTF8StringEncoding];
 
-	[dialog performSelectorOnMainThread:@selector(runModal:) withObject:[view window] waitUntilDone:TRUE];
-
+	[dialog performSelectorOnMainThread:@selector(runModal:) withObject:[view
+	        window] waitUntilDone:TRUE];
 	BOOL ok = dialog.modalCode;
 
-	if (ok) 
+	if (ok)
 	{
 		const char* submittedUsername = [dialog.username cStringUsingEncoding:
 		                                 NSUTF8StringEncoding];
 		*username = malloc((strlen(submittedUsername) + 1) * sizeof(char));
 		strcpy(*username, submittedUsername);
-
 		const char* submittedPassword = [dialog.password cStringUsingEncoding:
 		                                 NSUTF8StringEncoding];
 		*password = malloc((strlen(submittedPassword) + 1) * sizeof(char));
 		strcpy(*password, submittedPassword);
-
 		const char* submittedDomain = [dialog.domain cStringUsingEncoding:
-		                                 NSUTF8StringEncoding];
+		                               NSUTF8StringEncoding];
 		*domain = malloc((strlen(submittedDomain) + 1) * sizeof(char));
 		strcpy(*domain, submittedDomain);
 	}

--- a/client/Mac/PasswordDialog.h
+++ b/client/Mac/PasswordDialog.h
@@ -28,6 +28,7 @@
     NSString* serverHostname;
     NSString* username;
     NSString* password;
+    NSString* domain;
     BOOL modalCode;
 }
 @property (retain) IBOutlet NSTextField* usernameText;
@@ -40,8 +41,9 @@
 @property (retain) NSString* serverHostname;
 @property (retain) NSString* username;
 @property (retain) NSString* password;
-@property BOOL modalCode;
+@property (retain) NSString* domain;
+@property (readonly) BOOL modalCode;
 
-- (BOOL) runModal;
+- (BOOL) runModal:(NSWindow*)mainWindow;
 
 @end

--- a/client/Mac/PasswordDialog.h
+++ b/client/Mac/PasswordDialog.h
@@ -22,27 +22,27 @@
 @interface PasswordDialog : NSWindowController
 {
 @public
-    NSTextField* usernameText;
-    NSTextField* passwordText;
-    NSTextField* messageLabel;
-    NSString* serverHostname;
-    NSString* username;
-    NSString* password;
-    NSString* domain;
-    BOOL modalCode;
+	NSTextField* usernameText;
+	NSTextField* passwordText;
+	NSTextField* messageLabel;
+	NSString* serverHostname;
+	NSString* username;
+	NSString* password;
+	NSString* domain;
+	BOOL modalCode;
 }
-@property (retain) IBOutlet NSTextField* usernameText;
-@property (retain) IBOutlet NSTextField* passwordText;
-@property (retain) IBOutlet NSTextField* messageLabel;
+@property(retain) IBOutlet NSTextField* usernameText;
+@property(retain) IBOutlet NSTextField* passwordText;
+@property(retain) IBOutlet NSTextField* messageLabel;
 
 - (IBAction)onOK:(NSObject*)sender;
 - (IBAction)onCancel:(NSObject*)sender;
 
-@property (retain) NSString* serverHostname;
-@property (retain) NSString* username;
-@property (retain) NSString* password;
-@property (retain) NSString* domain;
-@property (readonly) BOOL modalCode;
+@property(retain) NSString* serverHostname;
+@property(retain) NSString* username;
+@property(retain) NSString* password;
+@property(retain) NSString* domain;
+@property(readonly) BOOL modalCode;
 
 - (BOOL) runModal:(NSWindow*)mainWindow;
 

--- a/client/Mac/PasswordDialog.m
+++ b/client/Mac/PasswordDialog.m
@@ -18,8 +18,11 @@
  */
 
 #import "PasswordDialog.h"
+#import <freerdp/client/cmdline.h>
 
 @interface PasswordDialog ()
+
+@property BOOL modalCode;
 
 @end
 
@@ -31,6 +34,7 @@
 @synthesize serverHostname;
 @synthesize username;
 @synthesize password;
+@synthesize domain;
 @synthesize modalCode;
 
 - (id)init
@@ -44,30 +48,66 @@
 	// Implement this method to handle any initialization after your window controller's window has been loaded from its nib file.
 	[self.window setTitle:self.serverHostname];
 	[messageLabel setStringValue:[NSString stringWithFormat:@"Authenticate to %@", self.serverHostname]];
+
+	NSMutableString* domainUser = [[NSMutableString alloc] initWithString:@""];
+
+	if (self.domain != nil && [[self.domain stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] length] > 0)
+	{
+		[domainUser appendFormat:@"%@\\", self.domain];
+	}
+
 	if (self.username != nil)
 	{
-		[usernameText setStringValue:self.username];
+		[domainUser appendString:self.username];
 		[self.window makeFirstResponder:passwordText];
 	}
+	[usernameText setStringValue:domainUser];
 }
 
 - (IBAction)onOK:(NSObject *)sender
 {
-	self.username = self.usernameText.stringValue;
+	char *submittedUser = NULL;
+	char *submittedDomain = NULL;
+
+	if (freerdp_parse_username([self.usernameText.stringValue cStringUsingEncoding:NSUTF8StringEncoding], &submittedUser, &submittedDomain)) {
+		self.username = [NSString stringWithCString: submittedUser encoding:NSUTF8StringEncoding];
+		self.domain = [NSString stringWithCString: submittedDomain encoding:NSUTF8StringEncoding];
+	} else {
+		self.username = self.usernameText.stringValue;
+	}
+
 	self.password = self.passwordText.stringValue;
-	[self.window orderOut:nil];
 	[NSApp stopModalWithCode:TRUE];
 }
 
 - (IBAction)onCancel:(NSObject *)sender
 {
-	[self.window orderOut:nil];
 	[NSApp stopModalWithCode:FALSE];
 }
 
-- (BOOL)runModal
+- (BOOL)runModal:(NSWindow*)mainWindow
 {
-	return (self.modalCode = [NSApp runModalForWindow:self.window]);
+	if ([mainWindow respondsToSelector:@selector(beginSheet:completionHandler:)]) {
+
+		[mainWindow beginSheet:self.window completionHandler:nil];
+
+		self.modalCode = [NSApp runModalForWindow: self.window];
+		[mainWindow endSheet: self.window];
+
+	} else {
+		[NSApp beginSheet: self.window
+			modalForWindow: mainWindow
+			modalDelegate: nil
+			didEndSelector: nil
+			contextInfo: nil];
+
+		self.modalCode = [NSApp runModalForWindow: self.window];
+		[NSApp endSheet: self.window];
+	}
+
+	[self.window orderOut:nil];
+
+	return self.modalCode;
 }
 
 - (void)dealloc
@@ -78,6 +118,7 @@
 	[serverHostname release];
 	[username release];
 	[password release];
+	[domain release];
 
 	[super dealloc];
 }

--- a/client/Mac/PasswordDialog.m
+++ b/client/Mac/PasswordDialog.m
@@ -20,9 +20,9 @@
 #import "PasswordDialog.h"
 #import <freerdp/client/cmdline.h>
 
-@interface PasswordDialog ()
+@interface PasswordDialog()
 
-@property BOOL modalCode;
+	@property BOOL modalCode;
 
 @end
 
@@ -47,11 +47,13 @@
 	[super windowDidLoad];
 	// Implement this method to handle any initialization after your window controller's window has been loaded from its nib file.
 	[self.window setTitle:self.serverHostname];
-	[messageLabel setStringValue:[NSString stringWithFormat:@"Authenticate to %@", self.serverHostname]];
-
+	[messageLabel setStringValue:[NSString stringWithFormat:@"Authenticate to %@",
+	                              self.serverHostname]];
 	NSMutableString* domainUser = [[NSMutableString alloc] initWithString:@""];
 
-	if (self.domain != nil && [[self.domain stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] length] > 0)
+	if (self.domain != nil
+	    && [[self.domain stringByTrimmingCharactersInSet:[NSCharacterSet
+	            whitespaceCharacterSet]] length] > 0)
 	{
 		[domainUser appendFormat:@"%@\\", self.domain];
 	}
@@ -61,18 +63,25 @@
 		[domainUser appendString:self.username];
 		[self.window makeFirstResponder:passwordText];
 	}
+
 	[usernameText setStringValue:domainUser];
 }
 
-- (IBAction)onOK:(NSObject *)sender
+- (IBAction)onOK:(NSObject*)sender
 {
-	char *submittedUser = NULL;
-	char *submittedDomain = NULL;
+	char* submittedUser = NULL;
+	char* submittedDomain = NULL;
 
-	if (freerdp_parse_username([self.usernameText.stringValue cStringUsingEncoding:NSUTF8StringEncoding], &submittedUser, &submittedDomain)) {
-		self.username = [NSString stringWithCString: submittedUser encoding:NSUTF8StringEncoding];
-		self.domain = [NSString stringWithCString: submittedDomain encoding:NSUTF8StringEncoding];
-	} else {
+	if (freerdp_parse_username([self.usernameText.stringValue cStringUsingEncoding:
+	                            NSUTF8StringEncoding], &submittedUser, &submittedDomain))
+	{
+		self.username = [NSString stringWithCString: submittedUser encoding:
+		                 NSUTF8StringEncoding];
+		self.domain = [NSString stringWithCString: submittedDomain encoding:
+		               NSUTF8StringEncoding];
+	}
+	else
+	{
 		self.username = self.usernameText.stringValue;
 	}
 
@@ -80,33 +89,31 @@
 	[NSApp stopModalWithCode:TRUE];
 }
 
-- (IBAction)onCancel:(NSObject *)sender
+- (IBAction)onCancel:(NSObject*)sender
 {
 	[NSApp stopModalWithCode:FALSE];
 }
 
 - (BOOL)runModal:(NSWindow*)mainWindow
 {
-	if ([mainWindow respondsToSelector:@selector(beginSheet:completionHandler:)]) {
-
+	if ([mainWindow respondsToSelector:@selector(beginSheet:completionHandler:)])
+	{
 		[mainWindow beginSheet:self.window completionHandler:nil];
-
 		self.modalCode = [NSApp runModalForWindow: self.window];
 		[mainWindow endSheet: self.window];
-
-	} else {
+	}
+	else
+	{
 		[NSApp beginSheet: self.window
-			modalForWindow: mainWindow
-			modalDelegate: nil
-			didEndSelector: nil
-			contextInfo: nil];
-
+		 modalForWindow: mainWindow
+		 modalDelegate: nil
+		 didEndSelector: nil
+		 contextInfo: nil];
 		self.modalCode = [NSApp runModalForWindow: self.window];
 		[NSApp endSheet: self.window];
 	}
 
 	[self.window orderOut:nil];
-
 	return self.modalCode;
 }
 
@@ -119,7 +126,6 @@
 	[username release];
 	[password release];
 	[domain release];
-
 	[super dealloc];
 }
 

--- a/client/Mac/PasswordDialog.xib
+++ b/client/Mac/PasswordDialog.xib
@@ -1,1019 +1,132 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1080</int>
-		<string key="IBDocument.SystemVersion">12C60</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.34</string>
-		<string key="IBDocument.HIToolboxVersion">625.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">3084</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>IBNSLayoutConstraint</string>
-			<string>NSButton</string>
-			<string>NSButtonCell</string>
-			<string>NSCustomObject</string>
-			<string>NSSecureTextField</string>
-			<string>NSSecureTextFieldCell</string>
-			<string>NSTextField</string>
-			<string>NSTextFieldCell</string>
-			<string>NSView</string>
-			<string>NSWindowTemplate</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
-			<object class="NSCustomObject" id="1001">
-				<string key="NSClassName">PasswordDialog</string>
-			</object>
-			<object class="NSCustomObject" id="1003">
-				<string key="NSClassName">FirstResponder</string>
-			</object>
-			<object class="NSCustomObject" id="1004">
-				<string key="NSClassName">NSApplication</string>
-			</object>
-			<object class="NSWindowTemplate" id="1005">
-				<int key="NSWindowStyleMask">257</int>
-				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{196, 240}, {480, 270}}</string>
-				<int key="NSWTFlags">544735232</int>
-				<string key="NSWindowTitle">Window</string>
-				<string key="NSWindowClass">NSWindow</string>
-				<nil key="NSViewClass"/>
-				<nil key="NSUserInterfaceItemIdentifier"/>
-				<object class="NSView" key="NSWindowView" id="1006">
-					<reference key="NSNextResponder"/>
-					<int key="NSvFlags">256</int>
-					<array class="NSMutableArray" key="NSSubviews">
-						<object class="NSTextField" id="534466844">
-							<reference key="NSNextResponder" ref="1006"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{46, 127}, {108, 17}}</string>
-							<reference key="NSSuperview" ref="1006"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="605731100"/>
-							<string key="NSReuseIdentifierKey">_NS:1535</string>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="1051137816">
-								<int key="NSCellFlags">68157504</int>
-								<int key="NSCellFlags2">272630784</int>
-								<string key="NSContents">Password:</string>
-								<object class="NSFont" key="NSSupport" id="461722316">
-									<string key="NSName">LucidaGrande</string>
-									<double key="NSSize">13</double>
-									<int key="NSfFlags">1044</int>
-								</object>
-								<string key="NSCellIdentifier">_NS:1535</string>
-								<reference key="NSControlView" ref="534466844"/>
-								<object class="NSColor" key="NSBackgroundColor" id="765179253">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">controlColor</string>
-									<object class="NSColor" key="NSColor">
-										<int key="NSColorSpace">3</int>
-										<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
-									</object>
-								</object>
-								<object class="NSColor" key="NSTextColor" id="657884142">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">controlTextColor</string>
-									<object class="NSColor" key="NSColor" id="299534685">
-										<int key="NSColorSpace">3</int>
-										<bytes key="NSWhite">MAA</bytes>
-									</object>
-								</object>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSSecureTextField" id="605731100">
-							<reference key="NSNextResponder" ref="1006"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{159, 124}, {233, 22}}</string>
-							<reference key="NSSuperview" ref="1006"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="215486301"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSSecureTextFieldCell" key="NSCell" id="852260547">
-								<int key="NSCellFlags">342884416</int>
-								<int key="NSCellFlags2">272630848</int>
-								<string key="NSContents"/>
-								<reference key="NSSupport" ref="461722316"/>
-								<string key="NSPlaceholderString">Password</string>
-								<string key="NSCellIdentifier">_NS:9</string>
-								<reference key="NSControlView" ref="605731100"/>
-								<bool key="NSDrawsBackground">YES</bool>
-								<object class="NSColor" key="NSBackgroundColor" id="161469205">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">textBackgroundColor</string>
-									<object class="NSColor" key="NSColor">
-										<int key="NSColorSpace">3</int>
-										<bytes key="NSWhite">MQA</bytes>
-									</object>
-								</object>
-								<object class="NSColor" key="NSTextColor" id="193111781">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">textColor</string>
-									<reference key="NSColor" ref="299534685"/>
-								</object>
-								<array key="NSAllowedInputLocales">
-									<string>NSAllRomanInputSourcesLocaleIdentifier</string>
-								</array>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSTextField" id="677587178">
-							<reference key="NSNextResponder" ref="1006"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{46, 206}, {346, 17}}</string>
-							<reference key="NSSuperview" ref="1006"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="543773298"/>
-							<string key="NSReuseIdentifierKey">_NS:1535</string>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="13207108">
-								<int key="NSCellFlags">68157504</int>
-								<int key="NSCellFlags2">272630784</int>
-								<string key="NSContents">Connect to SERVER_NAME</string>
-								<reference key="NSSupport" ref="461722316"/>
-								<string key="NSPlaceholderString"/>
-								<string key="NSCellIdentifier">_NS:1535</string>
-								<reference key="NSControlView" ref="677587178"/>
-								<reference key="NSBackgroundColor" ref="765179253"/>
-								<reference key="NSTextColor" ref="657884142"/>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="732279407">
-							<reference key="NSNextResponder" ref="1006"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{384, 13}, {82, 32}}</string>
-							<reference key="NSSuperview" ref="1006"/>
-							<reference key="NSWindow"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="588218063">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134217728</int>
-								<string key="NSContents">Cancel</string>
-								<reference key="NSSupport" ref="461722316"/>
-								<string key="NSCellIdentifier">_NS:9</string>
-								<reference key="NSControlView" ref="732279407"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">129</int>
-								<string key="NSAlternateContents"/>
-								<string type="base64-UTF8" key="NSKeyEquivalent">Gw</string>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="215486301">
-							<reference key="NSNextResponder" ref="1006"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{302, 13}, {82, 32}}</string>
-							<reference key="NSSuperview" ref="1006"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="732279407"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="816835100">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134217728</int>
-								<string key="NSContents">OK</string>
-								<reference key="NSSupport" ref="461722316"/>
-								<string key="NSCellIdentifier">_NS:9</string>
-								<reference key="NSControlView" ref="215486301"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">129</int>
-								<reference key="NSAlternateImage" ref="461722316"/>
-								<string key="NSAlternateContents"/>
-								<string type="base64-UTF8" key="NSKeyEquivalent">DQ</string>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSTextField" id="543773298">
-							<reference key="NSNextResponder" ref="1006"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{46, 158}, {108, 17}}</string>
-							<reference key="NSSuperview" ref="1006"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="385178766"/>
-							<string key="NSReuseIdentifierKey">_NS:1535</string>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="728569686">
-								<int key="NSCellFlags">68157504</int>
-								<int key="NSCellFlags2">272630784</int>
-								<string key="NSContents">Username:</string>
-								<reference key="NSSupport" ref="461722316"/>
-								<string key="NSCellIdentifier">_NS:1535</string>
-								<reference key="NSControlView" ref="543773298"/>
-								<reference key="NSBackgroundColor" ref="765179253"/>
-								<reference key="NSTextColor" ref="657884142"/>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSTextField" id="385178766">
-							<reference key="NSNextResponder" ref="1006"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{159, 156}, {233, 22}}</string>
-							<reference key="NSSuperview" ref="1006"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="534466844"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="692566014">
-								<int key="NSCellFlags">-1804599231</int>
-								<int key="NSCellFlags2">272630784</int>
-								<string key="NSContents"/>
-								<reference key="NSSupport" ref="461722316"/>
-								<string key="NSPlaceholderString">Username</string>
-								<string key="NSCellIdentifier">_NS:9</string>
-								<reference key="NSControlView" ref="385178766"/>
-								<bool key="NSDrawsBackground">YES</bool>
-								<reference key="NSBackgroundColor" ref="161469205"/>
-								<reference key="NSTextColor" ref="193111781"/>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-					</array>
-					<string key="NSFrameSize">{480, 270}</string>
-					<reference key="NSSuperview"/>
-					<reference key="NSWindow"/>
-					<reference key="NSNextKeyView" ref="677587178"/>
-				</object>
-				<string key="NSScreenRect">{{0, 0}, {1440, 878}}</string>
-				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
-				<bool key="NSWindowIsRestorable">YES</bool>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">window</string>
-						<reference key="source" ref="1001"/>
-						<reference key="destination" ref="1005"/>
-					</object>
-					<int key="connectionID">3</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">passwordText</string>
-						<reference key="source" ref="1001"/>
-						<reference key="destination" ref="605731100"/>
-					</object>
-					<int key="connectionID">48</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">usernameText</string>
-						<reference key="source" ref="1001"/>
-						<reference key="destination" ref="385178766"/>
-					</object>
-					<int key="connectionID">49</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">messageLabel</string>
-						<reference key="source" ref="1001"/>
-						<reference key="destination" ref="677587178"/>
-					</object>
-					<int key="connectionID">50</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">onOK:</string>
-						<reference key="source" ref="1001"/>
-						<reference key="destination" ref="215486301"/>
-					</object>
-					<int key="connectionID">51</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">onCancel:</string>
-						<reference key="source" ref="1001"/>
-						<reference key="destination" ref="732279407"/>
-					</object>
-					<int key="connectionID">52</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="1005"/>
-						<reference key="destination" ref="1001"/>
-					</object>
-					<int key="connectionID">4</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="1000"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="1001"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="1003"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">First Responder</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-3</int>
-						<reference key="object" ref="1004"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Application</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1</int>
-						<reference key="object" ref="1005"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1006"/>
-						</array>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">2</int>
-						<reference key="object" ref="1006"/>
-						<array class="NSMutableArray" key="children">
-							<object class="IBNSLayoutConstraint" id="792855884">
-								<reference key="firstItem" ref="1006"/>
-								<int key="firstAttribute">6</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="732279407"/>
-								<int key="secondAttribute">6</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="361673131">
-								<reference key="firstItem" ref="1006"/>
-								<int key="firstAttribute">4</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="732279407"/>
-								<int key="secondAttribute">4</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="33598285">
-								<reference key="firstItem" ref="732279407"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="215486301"/>
-								<int key="secondAttribute">6</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">12</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="249083586">
-								<reference key="firstItem" ref="1006"/>
-								<int key="firstAttribute">4</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="215486301"/>
-								<int key="secondAttribute">4</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="376996204">
-								<reference key="firstItem" ref="605731100"/>
-								<int key="firstAttribute">3</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="385178766"/>
-								<int key="secondAttribute">4</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">10</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="749200553">
-								<reference key="firstItem" ref="605731100"/>
-								<int key="firstAttribute">6</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="385178766"/>
-								<int key="secondAttribute">6</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">2</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="645437596">
-								<reference key="firstItem" ref="605731100"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="534466844"/>
-								<int key="secondAttribute">6</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">8</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="122204147">
-								<reference key="firstItem" ref="605731100"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="385178766"/>
-								<int key="secondAttribute">5</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">2</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="601416424">
-								<reference key="firstItem" ref="385178766"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="543773298"/>
-								<int key="secondAttribute">6</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">8</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="742909147">
-								<reference key="firstItem" ref="534466844"/>
-								<int key="firstAttribute">10</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="1006"/>
-								<int key="secondAttribute">10</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">5</int>
-								<float key="scoringTypeFloat">22</float>
-								<int key="contentType">2</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="393602894">
-								<reference key="firstItem" ref="534466844"/>
-								<int key="firstAttribute">10</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="605731100"/>
-								<int key="secondAttribute">10</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">2</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="507833379">
-								<reference key="firstItem" ref="543773298"/>
-								<int key="firstAttribute">11</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="385178766"/>
-								<int key="secondAttribute">11</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">2</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="62139445">
-								<reference key="firstItem" ref="543773298"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="677587178"/>
-								<int key="secondAttribute">5</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">2</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="281189829">
-								<reference key="firstItem" ref="543773298"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="534466844"/>
-								<int key="secondAttribute">5</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">2</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="53108561">
-								<reference key="firstItem" ref="677587178"/>
-								<int key="firstAttribute">3</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="1006"/>
-								<int key="secondAttribute">3</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">47</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="346752503">
-								<reference key="firstItem" ref="677587178"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="1006"/>
-								<int key="secondAttribute">5</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">49</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="1006"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">3</int>
-							</object>
-							<reference ref="534466844"/>
-							<reference ref="605731100"/>
-							<reference ref="677587178"/>
-							<reference ref="732279407"/>
-							<reference ref="215486301"/>
-							<reference ref="543773298"/>
-							<reference ref="385178766"/>
-						</array>
-						<reference key="parent" ref="1005"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">5</int>
-						<reference key="object" ref="534466844"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1051137816"/>
-						</array>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">6</int>
-						<reference key="object" ref="605731100"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="852260547"/>
-						</array>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">7</int>
-						<reference key="object" ref="677587178"/>
-						<array class="NSMutableArray" key="children">
-							<object class="IBNSLayoutConstraint" id="218748768">
-								<reference key="firstItem" ref="677587178"/>
-								<int key="firstAttribute">7</int>
-								<int key="relation">0</int>
-								<nil key="secondItem"/>
-								<int key="secondAttribute">0</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">340</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="677587178"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">1</int>
-							</object>
-							<reference ref="13207108"/>
-						</array>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">8</int>
-						<reference key="object" ref="732279407"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="588218063"/>
-						</array>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">9</int>
-						<reference key="object" ref="215486301"/>
-						<array class="NSMutableArray" key="children">
-							<object class="IBNSLayoutConstraint" id="444683688">
-								<reference key="firstItem" ref="215486301"/>
-								<int key="firstAttribute">7</int>
-								<int key="relation">0</int>
-								<nil key="secondItem"/>
-								<int key="secondAttribute">0</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">70</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="215486301"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">1</int>
-							</object>
-							<reference ref="816835100"/>
-						</array>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">10</int>
-						<reference key="object" ref="543773298"/>
-						<array class="NSMutableArray" key="children">
-							<object class="IBNSLayoutConstraint" id="156508403">
-								<reference key="firstItem" ref="543773298"/>
-								<int key="firstAttribute">7</int>
-								<int key="relation">0</int>
-								<nil key="secondItem"/>
-								<int key="secondAttribute">0</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">102</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="543773298"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">1</int>
-							</object>
-							<reference ref="728569686"/>
-						</array>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">11</int>
-						<reference key="object" ref="385178766"/>
-						<array class="NSMutableArray" key="children">
-							<object class="IBNSLayoutConstraint" id="340450096">
-								<reference key="firstItem" ref="385178766"/>
-								<int key="firstAttribute">7</int>
-								<int key="relation">0</int>
-								<nil key="secondItem"/>
-								<int key="secondAttribute">0</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">233</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="385178766"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">1</int>
-							</object>
-							<reference ref="692566014"/>
-						</array>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">12</int>
-						<reference key="object" ref="340450096"/>
-						<reference key="parent" ref="385178766"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">13</int>
-						<reference key="object" ref="692566014"/>
-						<reference key="parent" ref="385178766"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">14</int>
-						<reference key="object" ref="156508403"/>
-						<reference key="parent" ref="543773298"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">15</int>
-						<reference key="object" ref="728569686"/>
-						<reference key="parent" ref="543773298"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">16</int>
-						<reference key="object" ref="444683688"/>
-						<reference key="parent" ref="215486301"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">17</int>
-						<reference key="object" ref="816835100"/>
-						<reference key="parent" ref="215486301"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">18</int>
-						<reference key="object" ref="588218063"/>
-						<reference key="parent" ref="732279407"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">19</int>
-						<reference key="object" ref="218748768"/>
-						<reference key="parent" ref="677587178"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">20</int>
-						<reference key="object" ref="13207108"/>
-						<reference key="parent" ref="677587178"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">21</int>
-						<reference key="object" ref="852260547"/>
-						<reference key="parent" ref="605731100"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">22</int>
-						<reference key="object" ref="1051137816"/>
-						<reference key="parent" ref="534466844"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">25</int>
-						<reference key="object" ref="122204147"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">27</int>
-						<reference key="object" ref="393602894"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">28</int>
-						<reference key="object" ref="645437596"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">30</int>
-						<reference key="object" ref="749200553"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">31</int>
-						<reference key="object" ref="601416424"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">32</int>
-						<reference key="object" ref="33598285"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">34</int>
-						<reference key="object" ref="281189829"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">37</int>
-						<reference key="object" ref="62139445"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">39</int>
-						<reference key="object" ref="249083586"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">41</int>
-						<reference key="object" ref="742909147"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">42</int>
-						<reference key="object" ref="361673131"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">43</int>
-						<reference key="object" ref="792855884"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">44</int>
-						<reference key="object" ref="346752503"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">45</int>
-						<reference key="object" ref="53108561"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">46</int>
-						<reference key="object" ref="376996204"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">47</int>
-						<reference key="object" ref="507833379"/>
-						<reference key="parent" ref="1006"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1.IBWindowTemplateEditedContentRect">{{357, 418}, {480, 270}}</string>
-				<integer value="1" key="1.NSWindowTemplate.visibleAtLaunch"/>
-				<array class="NSMutableArray" key="10.IBNSViewMetadataConstraints">
-					<reference ref="156508403"/>
-				</array>
-				<boolean value="NO" key="10.IBNSViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
-				<string key="10.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<array class="NSMutableArray" key="11.IBNSViewMetadataConstraints">
-					<reference ref="340450096"/>
-				</array>
-				<boolean value="NO" key="11.IBNSViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
-				<string key="11.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="12.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="13.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="14.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="15.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="16.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="17.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="18.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="19.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<array class="NSMutableArray" key="2.IBNSViewMetadataConstraints">
-					<reference ref="346752503"/>
-					<reference ref="53108561"/>
-					<reference ref="281189829"/>
-					<reference ref="62139445"/>
-					<reference ref="507833379"/>
-					<reference ref="393602894"/>
-					<reference ref="742909147"/>
-					<reference ref="601416424"/>
-					<reference ref="122204147"/>
-					<reference ref="645437596"/>
-					<reference ref="749200553"/>
-					<reference ref="376996204"/>
-					<reference ref="249083586"/>
-					<reference ref="33598285"/>
-					<reference ref="361673131"/>
-					<reference ref="792855884"/>
-				</array>
-				<string key="2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="20.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="21.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="22.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="25.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="27.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="28.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="30.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="31.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="32.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="34.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="37.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="39.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="41.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="42.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="43.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="44.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="45.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="46.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="47.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="NO" key="5.IBNSViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
-				<string key="5.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="NO" key="6.IBNSViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
-				<string key="6.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<array key="7.IBNSViewMetadataConstraints">
-					<reference ref="218748768"/>
-				</array>
-				<boolean value="NO" key="7.IBNSViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
-				<string key="7.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="NO" key="8.IBNSViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
-				<string key="8.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<array key="9.IBNSViewMetadataConstraints">
-					<reference ref="444683688"/>
-				</array>
-				<boolean value="NO" key="9.IBNSViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
-				<string key="9.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">54</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">PasswordDialog</string>
-					<string key="superclassName">NSWindowController</string>
-					<dictionary class="NSMutableDictionary" key="actions">
-						<string key="onCancel:">NSObject</string>
-						<string key="onOK:">NSObject</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="actionInfosByName">
-						<object class="IBActionInfo" key="onCancel:">
-							<string key="name">onCancel:</string>
-							<string key="candidateClassName">NSObject</string>
-						</object>
-						<object class="IBActionInfo" key="onOK:">
-							<string key="name">onOK:</string>
-							<string key="candidateClassName">NSObject</string>
-						</object>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="outlets">
-						<string key="messageLabel">NSTextField</string>
-						<string key="passwordText">NSTextField</string>
-						<string key="usernameText">NSTextField</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<object class="IBToOneOutletInfo" key="messageLabel">
-							<string key="name">messageLabel</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="passwordText">
-							<string key="name">passwordText</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="usernameText">
-							<string key="name">usernameText</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/PasswordDialog.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<bool key="IBDocument.UseAutolayout">YES</bool>
-	</data>
-</archive>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="PasswordDialog">
+            <connections>
+                <outlet property="messageLabel" destination="7" id="50"/>
+                <outlet property="passwordText" destination="6" id="48"/>
+                <outlet property="usernameText" destination="11" id="49"/>
+                <outlet property="window" destination="1" id="3"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application"/>
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" visibleAtLaunch="NO" animationBehavior="default" id="1">
+            <windowStyleMask key="styleMask" titled="YES" texturedBackground="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="196" y="240" width="480" height="270"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <view key="contentView" id="2">
+                <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5">
+                        <rect key="frame" x="47" y="127" width="106" height="17"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Password:" id="22">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6">
+                        <rect key="frame" x="159" y="124" width="233" height="22"/>
+                        <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Password" drawsBackground="YES" usesSingleLineMode="YES" id="21">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                            <allowedInputSourceLocales>
+                                <string>NSAllRomanInputSourcesLocaleIdentifier</string>
+                            </allowedInputSourceLocales>
+                        </secureTextFieldCell>
+                    </secureTextField>
+                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7">
+                        <rect key="frame" x="47" y="206" width="344" height="17"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="340" id="19"/>
+                        </constraints>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Connect to SERVER_NAME" placeholderString="" id="20">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8">
+                        <rect key="frame" x="384" y="13" width="82" height="32"/>
+                        <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="18">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="onCancel:" target="-2" id="52"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9">
+                        <rect key="frame" x="302" y="13" width="82" height="32"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="70" id="16"/>
+                        </constraints>
+                        <buttonCell key="cell" type="push" title="OK" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="17">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="onOK:" target="-2" id="51"/>
+                        </connections>
+                    </button>
+                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="10">
+                        <rect key="frame" x="47" y="159" width="106" height="17"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="102" id="14"/>
+                        </constraints>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Username:" id="15">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="11">
+                        <rect key="frame" x="159" y="156" width="233" height="22"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="233" id="12"/>
+                        </constraints>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="username@domain" drawsBackground="YES" id="13">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="6" firstAttribute="leading" secondItem="11" secondAttribute="leading" id="25"/>
+                    <constraint firstItem="5" firstAttribute="centerY" secondItem="6" secondAttribute="centerY" id="27"/>
+                    <constraint firstItem="6" firstAttribute="leading" secondItem="5" secondAttribute="trailing" constant="8" symbolic="YES" id="28"/>
+                    <constraint firstItem="6" firstAttribute="trailing" secondItem="11" secondAttribute="trailing" id="30"/>
+                    <constraint firstItem="11" firstAttribute="leading" secondItem="10" secondAttribute="trailing" constant="8" symbolic="YES" id="31"/>
+                    <constraint firstItem="8" firstAttribute="leading" secondItem="9" secondAttribute="trailing" constant="12" symbolic="YES" id="32"/>
+                    <constraint firstItem="10" firstAttribute="leading" secondItem="5" secondAttribute="leading" id="34"/>
+                    <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="leading" id="37"/>
+                    <constraint firstAttribute="bottom" secondItem="9" secondAttribute="bottom" constant="20" symbolic="YES" id="39"/>
+                    <constraint firstItem="5" firstAttribute="centerY" secondItem="2" secondAttribute="centerY" id="41"/>
+                    <constraint firstAttribute="bottom" secondItem="8" secondAttribute="bottom" constant="20" symbolic="YES" id="42"/>
+                    <constraint firstAttribute="trailing" secondItem="8" secondAttribute="trailing" constant="20" symbolic="YES" id="43"/>
+                    <constraint firstItem="7" firstAttribute="leading" secondItem="2" secondAttribute="leading" constant="49" id="44"/>
+                    <constraint firstItem="7" firstAttribute="top" secondItem="2" secondAttribute="top" constant="47" id="45"/>
+                    <constraint firstItem="6" firstAttribute="top" secondItem="11" secondAttribute="bottom" constant="10" symbolic="YES" id="46"/>
+                    <constraint firstItem="10" firstAttribute="baseline" secondItem="11" secondAttribute="baseline" id="47"/>
+                </constraints>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="4"/>
+            </connections>
+        </window>
+    </objects>
+</document>

--- a/client/Mac/cli/AppDelegate.m
+++ b/client/Mac/cli/AppDelegate.m
@@ -13,10 +13,13 @@
 #import <freerdp/client/cmdline.h>
 
 static AppDelegate* _singleDelegate = nil;
-void AppDelegate_ConnectionResultEventHandler(void* context, ConnectionResultEventArgs* e);
+void AppDelegate_ConnectionResultEventHandler(void* context,
+        ConnectionResultEventArgs* e);
 void AppDelegate_ErrorInfoEventHandler(void* ctx, ErrorInfoEventArgs* e);
-void AppDelegate_EmbedWindowEventHandler(void* context, EmbedWindowEventArgs* e);
-void AppDelegate_ResizeWindowEventHandler(void* context, ResizeWindowEventArgs* e);
+void AppDelegate_EmbedWindowEventHandler(void* context,
+        EmbedWindowEventArgs* e);
+void AppDelegate_ResizeWindowEventHandler(void* context,
+        ResizeWindowEventArgs* e);
 void mac_set_view_size(rdpContext* context, MRDPView* view);
 
 @implementation AppDelegate
@@ -35,22 +38,17 @@ void mac_set_view_size(rdpContext* context, MRDPView* view);
 {
 	int status;
 	mfContext* mfc;
-
 	_singleDelegate = self;
 	[self CreateContext];
-
 	status = [self ParseCommandLineArguments];
-
 	mfc = (mfContext*) context;
 	mfc->view = (void*) mrdpView;
 
 	if (status < 0)
 	{
-		NSString *winTitle;
+		NSString* winTitle;
 		winTitle = [[NSString alloc] initWithCString:"ERROR"];
-
 		[window setTitle:winTitle];
-
 	}
 	else
 	{
@@ -63,23 +61,27 @@ void mac_set_view_size(rdpContext* context, MRDPView* view);
 			context->instance->settings->DesktopHeight = screenFrame.size.height;
 		}
 
-		PubSub_SubscribeConnectionResult(context->pubSub, AppDelegate_ConnectionResultEventHandler);
+		PubSub_SubscribeConnectionResult(context->pubSub,
+		                                 AppDelegate_ConnectionResultEventHandler);
 		PubSub_SubscribeErrorInfo(context->pubSub, AppDelegate_ErrorInfoEventHandler);
-		PubSub_SubscribeEmbedWindow(context->pubSub, AppDelegate_EmbedWindowEventHandler);
-		PubSub_SubscribeResizeWindow(context->pubSub, AppDelegate_ResizeWindowEventHandler);
-		
+		PubSub_SubscribeEmbedWindow(context->pubSub,
+		                            AppDelegate_EmbedWindowEventHandler);
+		PubSub_SubscribeResizeWindow(context->pubSub,
+		                             AppDelegate_ResizeWindowEventHandler);
 		freerdp_client_start(context);
+		NSString* winTitle;
 
-		NSString *winTitle;
-		if ( mfc->context.settings->WindowTitle && mfc->context.settings->WindowTitle[0])
+		if (mfc->context.settings->WindowTitle && mfc->context.settings->WindowTitle[0])
 		{
-			winTitle = [[NSString alloc] initWithCString:mfc->context.settings->WindowTitle];
+			winTitle = [[NSString alloc] initWithCString:
+			            mfc->context.settings->WindowTitle];
 		}
 		else
 		{
-			winTitle = [[NSString alloc] initWithFormat:@"%@:%u", 
-					[NSString stringWithCString:mfc->context.settings->ServerHostname encoding:NSUTF8StringEncoding],
-					mfc->context.settings->ServerPort];
+			winTitle = [[NSString alloc] initWithFormat:@"%@:%u",
+			            [NSString stringWithCString:mfc->context.settings->ServerHostname encoding:
+			             NSUTF8StringEncoding],
+			            mfc->context.settings->ServerPort];
 		}
 
 		[window setTitle:winTitle];
@@ -90,14 +92,12 @@ void mac_set_view_size(rdpContext* context, MRDPView* view);
 {
 	NSLog(@"Stopping...\n");
 	freerdp_client_stop(context);
-
 	[mrdpView releaseResources];
 	_singleDelegate = nil;
-
 	NSLog(@"Stopped.\n");
 }
 
-- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender
+- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication*)sender
 {
 	return YES;
 }
@@ -108,49 +108,41 @@ void mac_set_view_size(rdpContext* context, MRDPView* view);
 	int length;
 	int status;
 	char* cptr;
-
 	NSArray* args = [[NSProcessInfo processInfo] arguments];
-
 	context->argc = (int) [args count];
 	context->argv = malloc(sizeof(char*) * context->argc);
-	
 	i = 0;
-	
-	for (NSString* str in args)
+
+	for (NSString * str in args)
 	{
 		/* filter out some arguments added by XCode */
-		
 		if ([str isEqualToString:@"YES"])
 			continue;
-		
+
 		if ([str isEqualToString:@"-NSDocumentRevisionsDebugMode"])
 			continue;
-		
-		length = (int) ([str length] + 1);
+
+		length = (int)([str length] + 1);
 		cptr = (char*) malloc(length);
 		strcpy(cptr, [str UTF8String]);
 		context->argv[i++] = cptr;
 	}
-	
-	context->argc = i;
-	
-	status = freerdp_client_settings_parse_command_line(context->settings, context->argc, context->argv, FALSE);
-	
-	status = freerdp_client_settings_command_line_status_print(context->settings, status, context->argc, context->argv);
 
+	context->argc = i;
+	status = freerdp_client_settings_parse_command_line(context->settings,
+	         context->argc, context->argv, FALSE);
+	status = freerdp_client_settings_command_line_status_print(context->settings,
+	         status, context->argc, context->argv);
 	return status;
 }
 
 - (void) CreateContext
 {
 	RDP_CLIENT_ENTRY_POINTS clientEntryPoints;
-
 	ZeroMemory(&clientEntryPoints, sizeof(RDP_CLIENT_ENTRY_POINTS));
 	clientEntryPoints.Size = sizeof(RDP_CLIENT_ENTRY_POINTS);
 	clientEntryPoints.Version = RDP_CLIENT_INTERFACE_VERSION;
-
 	RdpClientEntry(&clientEntryPoints);
-
 	context = freerdp_client_context_new(&clientEntryPoints);
 }
 
@@ -158,15 +150,12 @@ void mac_set_view_size(rdpContext* context, MRDPView* view);
 {
 	mfContext* mfc;
 	MRDPView* view;
-	
 	mfc = (mfContext*) context;
 	view = (MRDPView*) mfc->view;
-	
 	[view exitFullScreenModeWithOptions:nil];
 	[view releaseResources];
 	[view release];
-	 mfc->view = nil;
-	
+	mfc->view = nil;
 	freerdp_client_context_free(context);
 	context = nil;
 }
@@ -180,20 +169,16 @@ void mac_set_view_size(rdpContext* context, MRDPView* view);
 {
 	mfContext* mfc;
 	MRDPView* view;
-
 	mfc = (mfContext*) context;
 	view = (MRDPView*) mfc->view;
-
 	[view exitFullScreenModeWithOptions:nil];
-
 	NSString* message = withMessage ? withMessage : @"Error connecting to server";
-
-	NSAlert *alert = [[NSAlert alloc] init];
+	NSAlert* alert = [[NSAlert alloc] init];
 	[alert setMessageText:message];
 	[alert beginSheetModalForWindow:[self window]
-					  modalDelegate:self
-					 didEndSelector:@selector(alertDidEnd:returnCode:contextInfo:)
-						contextInfo:nil];
+	 modalDelegate:self
+	 didEndSelector:@selector(alertDidEnd:returnCode:contextInfo:)
+	 contextInfo:nil];
 }
 
 
@@ -201,7 +186,7 @@ void mac_set_view_size(rdpContext* context, MRDPView* view);
  * just a terminate selector for above call
  ***********************************************************************/
 
-- (void) alertDidEnd:(NSAlert *)a returnCode:(NSInteger)rc contextInfo:(void *)ci
+- (void) alertDidEnd:(NSAlert*)a returnCode:(NSInteger)rc contextInfo:(void*)ci
 {
 	[NSApp terminate:nil];
 }
@@ -213,22 +198,26 @@ void mac_set_view_size(rdpContext* context, MRDPView* view);
  * On connection error, display message and quit application
  ***********************************************************************/
 
-void AppDelegate_ConnectionResultEventHandler(void* ctx, ConnectionResultEventArgs* e)
+void AppDelegate_ConnectionResultEventHandler(void* ctx,
+        ConnectionResultEventArgs* e)
 {
 	NSLog(@"ConnectionResult event result:%d\n", e->result);
+
 	if (_singleDelegate)
 	{
 		if (e->result != 0)
 		{
 			NSString* message = nil;
+
 			if (connectErrorCode == AUTHENTICATIONERROR)
 			{
-				message = [NSString stringWithFormat:@"%@", @"Authentication failure, check credentials."];
+				message = [NSString stringWithFormat:@"%@",
+				           @"Authentication failure, check credentials."];
 			}
-			
-			
+
 			// Making sure this should be invoked on the main UI thread.
-			[_singleDelegate performSelectorOnMainThread:@selector(rdpConnectError:) withObject:message waitUntilDone:FALSE];
+			[_singleDelegate performSelectorOnMainThread:@selector(rdpConnectError:)
+			 withObject:message waitUntilDone:FALSE];
 		}
 	}
 }
@@ -236,18 +225,21 @@ void AppDelegate_ConnectionResultEventHandler(void* ctx, ConnectionResultEventAr
 void AppDelegate_ErrorInfoEventHandler(void* ctx, ErrorInfoEventArgs* e)
 {
 	NSLog(@"ErrorInfo event code:%d\n", e->code);
+
 	if (_singleDelegate)
 	{
 		// Retrieve error message associated with error code
 		NSString* message = nil;
+
 		if (e->code != ERRINFO_NONE)
 		{
 			const char* errorMessage = freerdp_get_error_info_string(e->code);
 			message = [[NSString alloc] initWithUTF8String:errorMessage];
 		}
-		
+
 		// Making sure this should be invoked on the main UI thread.
-		[_singleDelegate performSelectorOnMainThread:@selector(rdpConnectError:) withObject:message waitUntilDone:TRUE];
+		[_singleDelegate performSelectorOnMainThread:@selector(rdpConnectError:)
+		 withObject:message waitUntilDone:TRUE];
 		[message release];
 	}
 }
@@ -255,17 +247,17 @@ void AppDelegate_ErrorInfoEventHandler(void* ctx, ErrorInfoEventArgs* e)
 void AppDelegate_EmbedWindowEventHandler(void* ctx, EmbedWindowEventArgs* e)
 {
 	rdpContext* context = (rdpContext*) ctx;
-	
+
 	if (_singleDelegate)
 	{
 		mfContext* mfc = (mfContext*) context;
 		_singleDelegate->mrdpView = mfc->view;
-		
+
 		if (_singleDelegate->window)
 		{
 			[[_singleDelegate->window contentView] addSubview:mfc->view];
 		}
-		
+
 		mac_set_view_size(context, mfc->view);
 	}
 }
@@ -273,9 +265,8 @@ void AppDelegate_EmbedWindowEventHandler(void* ctx, EmbedWindowEventArgs* e)
 void AppDelegate_ResizeWindowEventHandler(void* ctx, ResizeWindowEventArgs* e)
 {
 	rdpContext* context = (rdpContext*) ctx;
-	
 	fprintf(stderr, "ResizeWindowEventHandler: %d %d\n", e->width, e->height);
-	
+
 	if (_singleDelegate)
 	{
 		mfContext* mfc = (mfContext*) context;
@@ -292,17 +283,14 @@ void mac_set_view_size(rdpContext* context, MRDPView* view)
 	innerRect.size.width = context->settings->DesktopWidth;
 	innerRect.size.height = context->settings->DesktopHeight;
 	[view setFrame:innerRect];
-	
 	// calculate window of same size, but keep position
 	NSRect outerRect = [[view window] frame];
 	outerRect.size = [[view window] frameRectForContentRect:innerRect].size;
-	
 	// we are not in RemoteApp mode, disable larger than resolution
 	[[view window] setContentMaxSize:innerRect.size];
-	
 	// set window to given area
 	[[view window] setFrame:outerRect display:YES];
-	
+
 	if (context->settings->Fullscreen)
 		[[view window] toggleFullScreen:nil];
 }

--- a/client/Mac/cli/AppDelegate.m
+++ b/client/Mac/cli/AppDelegate.m
@@ -77,7 +77,9 @@ void mac_set_view_size(rdpContext* context, MRDPView* view);
 		}
 		else
 		{
-			winTitle = [[NSString alloc] initWithCString:"FreeRDP"];
+			winTitle = [[NSString alloc] initWithFormat:@"%@:%u", 
+					[NSString stringWithCString:mfc->context.settings->ServerHostname encoding:NSUTF8StringEncoding],
+					mfc->context.settings->ServerPort];
 		}
 
 		[window setTitle:winTitle];


### PR DESCRIPTION
Refinement of PR #3562 

The dialog runs as an application modal sheet attached to the main window in accordance with Apple user interface standards.
The window title, if not set by /t , is set to ServerHostname:ServerPort to give some indication of where we are connected to. Example: server.contoso.com:3389 . This is also used in the "Authenticate to" label on the password dialog.

New with this PR:
Password dialog placeholder for user name is username@domain .

The initially displayed text in the user name field is d1\u1 where:
d1 is the domain provided by the /d command line parameter or parsed out of a user name given as /u:domain\user by the command line argument parser and;
u1 is the user string given as /u parsed out by the command line argument parser. This will either be in format "username" or "username@domain" .
If no domain was provided, the user name field is simply u1 .

The user can supply the login credential as either domain\username or username@domain. The resulting login is parsed to break out the domain and user name into separate strings for consumption by the caller.

Should a user supply the domain with both the /d and /u parameters, the user name field will look like d1\d1\u1 or d1\u1@d1 . This is ugly, but maintains consistency with the behavior of the command line argument parser and is indicative of what would actually be passed to the server given those arguments. Seeing the domain name duplicated should lead the user to correct the login name before submitting.
