### PR TITLE
Fix issue #3422, ignore some dynamic virtual channel messages with invalid ids

### DIFF
--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -611,8 +611,12 @@ static UINT dvcman_receive_channel_data_first(IWTSVirtualChannelManager*
 
 	if (!channel)
 	{
+		/**
+		 * Windows Server 2012 R2 can send some messages over Microsoft::Windows::RDS::Geometry::v08.01
+		 * even if the dynamic virtual channel wasn't registered on our side. Ignoring it works.
+		 */
 		WLog_ERR(TAG, "ChannelId %d not found!", ChannelId);
-		return ERROR_INTERNAL_ERROR;
+		return CHANNEL_RC_OK;
 	}
 
 	if (channel->dvc_data)


### PR DESCRIPTION
MMR on Windows Server 2012 R2 is buggy, and can send some messages for Microsoft::Windows::RDS::Geometry::v08.01 even if the channel wasn't opened on the client. This is a violation of the protocol, but ignoring it works. This fixes https://github.com/FreeRDP/FreeRDP/issues/3422