### PR TITLE
X11/client: call gdi resize on hw desktop resize. 

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -461,10 +461,17 @@ static BOOL xf_hw_end_paint(rdpContext* context)
 
 static BOOL xf_hw_desktop_resize(rdpContext* context)
 {
+	rdpGdi* gdi = context->gdi;
 	xfContext* xfc = (xfContext*) context;
-	BOOL ret;
+	rdpSettings* settings = context->settings;
+	BOOL ret = FALSE;
 	xf_lock_x11(xfc, TRUE);
+
+	if (!gdi_resize(gdi, settings->DesktopWidth, settings->DesktopHeight))
+		goto out;
+
 	ret = xf_desktop_resize(context);
+out:
 	xf_unlock_x11(xfc, TRUE);
 	return ret;
 }


### PR DESCRIPTION
The gdi primary buffer is used in client/X11/xf_gdi.c, it should be big enough to hold the full screen update. So we need to resize it once the session is resized