### PR TITLE
codec: Revamp of rfx rlgr API

### DIFF
--- a/include/freerdp/codec/rfx.h
+++ b/include/freerdp/codec/rfx.h
@@ -161,6 +161,8 @@ struct _RFX_CONTEXT
 	void (*quantization_encode)(INT16* buffer, const UINT32* quantization_values);
 	void (*dwt_2d_decode)(INT16* buffer, INT16* dwt_buffer);
 	void (*dwt_2d_encode)(INT16* buffer, INT16* dwt_buffer);
+	int (*rlgr_decode)(RLGR_MODE mode, const BYTE* data, UINT32 data_size, INT16* buffer, UINT32 buffer_size);
+	int (*rlgr_encode)(RLGR_MODE mode, const INT16* data, UINT32 data_size, BYTE* buffer, UINT32 buffer_size);
 
 	/* private definitions */
 	RFX_CONTEXT_PRIV* priv;
@@ -168,9 +170,6 @@ struct _RFX_CONTEXT
 
 FREERDP_API void rfx_context_set_pixel_format(RFX_CONTEXT* context,
         UINT32 pixel_format);
-
-FREERDP_API int rfx_rlgr_decode(const BYTE* pSrcData, UINT32 SrcSize,
-                                INT16* pDstData, UINT32 DstSize, int mode);
 
 FREERDP_API BOOL rfx_process_message(RFX_CONTEXT* context, const BYTE* data,
                                      UINT32 format, UINT32 length,

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -33,6 +33,7 @@
 
 #include "rfx_differential.h"
 #include "rfx_quantization.h"
+#include "rfx_rlgr.h"
 
 #define TAG FREERDP_TAG("codec.progressive")
 
@@ -707,7 +708,7 @@ static int progressive_rfx_decode_component(PROGRESSIVE_CONTEXT* progressive,
 	int status;
 	INT16* temp;
 	const primitives_t* prims = primitives_get();
-	status = rfx_rlgr_decode(data, length, buffer, 4096, 1);
+	status = rfx_rlgr_decode(RLGR1, data, length, buffer, 4096);
 
 	if (status < 0)
 		return status;

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -337,6 +337,8 @@ RFX_CONTEXT* rfx_context_new(BOOL encoder)
 	context->quantization_encode = rfx_quantization_encode;
 	context->dwt_2d_decode = rfx_dwt_2d_decode;
 	context->dwt_2d_encode = rfx_dwt_2d_encode;
+	context->rlgr_decode = rfx_rlgr_decode;
+	context->rlgr_encode = rfx_rlgr_encode;
 	RFX_INIT_SIMD(context);
 	context->state = RFX_STATE_SEND_HEADERS;
 	return context;

--- a/libfreerdp/codec/rfx_decode.c
+++ b/libfreerdp/codec/rfx_decode.c
@@ -65,7 +65,7 @@ static void rfx_decode_component(RFX_CONTEXT* context,
 	dwt_buffer = BufferPool_Take(context->priv->BufferPool, -1); /* dwt_buffer */
 	PROFILER_ENTER(context->priv->prof_rfx_decode_component);
 	PROFILER_ENTER(context->priv->prof_rfx_rlgr_decode);
-	rfx_rlgr_decode(context->mode, data, size, buffer, 4096);
+	context->rlgr_decode(context->mode, data, size, buffer, 4096);
 	PROFILER_EXIT(context->priv->prof_rfx_rlgr_decode);
 	PROFILER_ENTER(context->priv->prof_rfx_differential_decode);
 	rfx_differential_decode(buffer + 4032, 64);

--- a/libfreerdp/codec/rfx_decode.c
+++ b/libfreerdp/codec/rfx_decode.c
@@ -65,7 +65,7 @@ static void rfx_decode_component(RFX_CONTEXT* context,
 	dwt_buffer = BufferPool_Take(context->priv->BufferPool, -1); /* dwt_buffer */
 	PROFILER_ENTER(context->priv->prof_rfx_decode_component);
 	PROFILER_ENTER(context->priv->prof_rfx_rlgr_decode);
-	rfx_rlgr_decode(data, size, buffer, 4096, (context->mode == RLGR1) ? 1 : 3);
+	rfx_rlgr_decode(context->mode, data, size, buffer, 4096);
 	PROFILER_EXIT(context->priv->prof_rfx_rlgr_decode);
 	PROFILER_ENTER(context->priv->prof_rfx_differential_decode);
 	rfx_differential_decode(buffer + 4032, 64);

--- a/libfreerdp/codec/rfx_encode.c
+++ b/libfreerdp/codec/rfx_encode.c
@@ -249,7 +249,7 @@ static void rfx_encode_component(RFX_CONTEXT* context,
 	rfx_differential_encode(data + 4032, 64);
 	PROFILER_EXIT(context->priv->prof_rfx_differential_encode);
 	PROFILER_ENTER(context->priv->prof_rfx_rlgr_encode);
-	*size = rfx_rlgr_encode(context->mode, data, 4096, buffer, buffer_size);
+	*size = context->rlgr_encode(context->mode, data, 4096, buffer, buffer_size);
 	PROFILER_EXIT(context->priv->prof_rfx_rlgr_encode);
 	PROFILER_EXIT(context->priv->prof_rfx_encode_component);
 	BufferPool_Return(context->priv->BufferPool, dwt_buffer);

--- a/libfreerdp/codec/rfx_rlgr.c
+++ b/libfreerdp/codec/rfx_rlgr.c
@@ -96,7 +96,7 @@ static INLINE UINT32 lzcnt_s(UINT32 x)
 	return __lzcnt(x);
 }
 
-int rfx_rlgr_decode(const BYTE* pSrcData, UINT32 SrcSize, INT16* pDstData, UINT32 DstSize, int mode)
+int rfx_rlgr_decode(RLGR_MODE mode, const BYTE* pSrcData, UINT32 SrcSize, INT16* pDstData, UINT32 DstSize)
 {
 	int vk;
 	int run;
@@ -124,8 +124,8 @@ int rfx_rlgr_decode(const BYTE* pSrcData, UINT32 SrcSize, INT16* pDstData, UINT3
 	kr = 1;
 	krp = kr << LSGR;
 
-	if ((mode != 1) && (mode != 3))
-		mode = 1;
+	if ((mode != RLGR1) && (mode != RLGR3))
+		mode = RLGR1;
 
 	if (!pSrcData || !SrcSize)
 		return -1;
@@ -387,7 +387,7 @@ int rfx_rlgr_decode(const BYTE* pSrcData, UINT32 SrcSize, INT16* pDstData, UINT3
 				kr = krp >> LSGR;
 			}
 
-			if (mode == 1) /* RLGR1 */
+			if (mode == RLGR1) /* RLGR1 */
 			{
 				if (!code)
 				{
@@ -430,7 +430,7 @@ int rfx_rlgr_decode(const BYTE* pSrcData, UINT32 SrcSize, INT16* pDstData, UINT3
 					pOutput++;
 				}
 			}
-			else if (mode == 3) /* RLGR3 */
+			else if (mode == RLGR3) /* RLGR3 */
 			{
 				nIdx = 0;
 
@@ -573,7 +573,7 @@ static void rfx_rlgr_code_gr(RFX_BITSTREAM* bs, int* krp, UINT32 val)
 	}
 }
 
-int rfx_rlgr_encode(RLGR_MODE mode, const INT16* data, int data_size, BYTE* buffer, int buffer_size)
+int rfx_rlgr_encode(RLGR_MODE mode, const INT16* data, UINT32 data_size, BYTE* buffer, UINT32 buffer_size)
 {
 	int k;
 	int kp;

--- a/libfreerdp/codec/rfx_rlgr.h
+++ b/libfreerdp/codec/rfx_rlgr.h
@@ -24,6 +24,9 @@
 #include <freerdp/api.h>
 
 FREERDP_LOCAL int rfx_rlgr_encode(RLGR_MODE mode, const INT16* data,
-                                  int data_size, BYTE* buffer, int buffer_size);
+                                  UINT32 data_size, BYTE* buffer, UINT32 buffer_size);
+
+FREERDP_LOCAL int rfx_rlgr_decode(RLGR_MODE mode, const BYTE* pSrcData, UINT32 SrcSize,
+                                  INT16* pDstData, UINT32 DstSize);
 
 #endif /* __RFX_RLGR_H */


### PR DESCRIPTION
This PR contains following changes:
- Give rlgr encode/decode APIs a similar interface
- Make rlgr encode API accessible again
- Make it possible to exchange rlgr functions
- Make use of RLGR1/3 defines instead of 0/1 in decoding