### PR TITLE
Ignore alpha channel in freerdp_image_copy

### DIFF
--- a/include/freerdp/codec/color.h
+++ b/include/freerdp/codec/color.h
@@ -100,6 +100,14 @@ typedef struct gdi_palette gdiPalette;
 extern "C" {
 #endif
 
+/* Compare two color formats but ignore differences in alpha channel.
+ */
+static INLINE DWORD AreColorFormatsEqualNoAlpha(DWORD first, DWORD second)
+{
+	const DWORD mask = ~(8 << 12);
+	return (first & mask) == (second & mask);
+}
+
 /* Color Space Conversions: http://msdn.microsoft.com/en-us/library/ff566496/ */
 
 /***

--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -438,7 +438,7 @@ BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat,
 		srcVMultiplier = -1;
 	}
 
-	if (SrcFormat == DstFormat)
+	if (AreColorFormatsEqualNoAlpha(SrcFormat, DstFormat))
 	{
 		INT32 y;
 

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -1151,6 +1151,7 @@ BOOL rfx_process_message(RFX_CONTEXT* context, const BYTE* data,
 		UINT32 nbUpdateRects;
 		REGION16 clippingRects;
 		const RECTANGLE_16* updateRects;
+		const DWORD formatSize = GetBytesPerPixel(format);
 		region16_init(&clippingRects);
 
 		for (i = 0; i < message->numRects; i++)
@@ -1178,7 +1179,7 @@ BOOL rfx_process_message(RFX_CONTEXT* context, const BYTE* data,
 
 			for (j = 0; j < nbUpdateRects; j++)
 			{
-				UINT32 stride = 64 * GetBytesPerPixel(format);
+				UINT32 stride = 64 * formatSize;
 				UINT32 nXDst = updateRects[j].left;
 				UINT32 nYDst = updateRects[j].top;
 				UINT32 nXSrc = nXDst - updateRect.left;

--- a/libfreerdp/gdi/shape.c
+++ b/libfreerdp/gdi/shape.c
@@ -132,6 +132,7 @@ BOOL gdi_FillRect(HGDI_DC hdc, const HGDI_RECT rect, HGDI_BRUSH hbr)
 	UINT32 nXDest, nYDest;
 	UINT32 nWidth, nHeight;
 	const BYTE* srcp;
+	DWORD formatSize;
 	gdi_RectToCRgn(rect, &nXDest, &nYDest, &nWidth, &nHeight);
 
 	if (!hdc || !hbr)
@@ -155,11 +156,12 @@ BOOL gdi_FillRect(HGDI_DC hdc, const HGDI_RECT rect, HGDI_BRUSH hbr)
 			}
 
 			srcp = gdi_get_bitmap_pointer(hdc, nXDest, nYDest);
+			formatSize = GetBytesPerPixel(hdc->format);
 
 			for (y = 1; y < nHeight; y++)
 			{
 				BYTE* dstp = gdi_get_bitmap_pointer(hdc, nXDest, nYDest + y);
-				memcpy(dstp, srcp, nWidth * GetBytesPerPixel(hdc->format));
+				memcpy(dstp, srcp, nWidth * formatSize);
 			}
 
 			break;
@@ -167,15 +169,15 @@ BOOL gdi_FillRect(HGDI_DC hdc, const HGDI_RECT rect, HGDI_BRUSH hbr)
 		case GDI_BS_HATCHED:
 		case GDI_BS_PATTERN:
 			monochrome = (hbr->pattern->format == PIXEL_FORMAT_MONO);
+			formatSize = GetBytesPerPixel(hbr->pattern->format);
 
 			for (y = 0; y < nHeight; y++)
 			{
 				for (x = 0; x < nWidth; x++)
 				{
 					const UINT32 yOffset = ((nYDest + y) * hbr->pattern->width %
-					                        hbr->pattern->height) * GetBytesPerPixel(hbr->pattern->format);
-					const UINT32 xOffset = ((nXDest + x) % hbr->pattern->width) * GetBytesPerPixel(
-					                           hbr->pattern->format);
+					                        hbr->pattern->height) * formatSize;
+					const UINT32 xOffset = ((nXDest + x) % hbr->pattern->width) * formatSize;
 					const BYTE* patp = &hbr->pattern->data[yOffset + xOffset];
 					BYTE* dstp = gdi_get_bitmap_pointer(hdc, nXDest + x,
 					                                    nYDest + y);

--- a/libfreerdp/primitives/prim_YCoCg.c
+++ b/libfreerdp/primitives/prim_YCoCg.c
@@ -32,6 +32,81 @@
 #endif /* !MINMAX */
 
 /* ------------------------------------------------------------------------- */
+static INLINE BYTE* writePixelBGRX(BYTE* dst, DWORD formatSize, UINT32 format,
+                                   BYTE R, BYTE G, BYTE B, BYTE A)
+{
+	dst[0] = B;
+	dst[1] = G;
+	dst[2] = R;
+	dst[3] = A;
+	return dst + formatSize;
+}
+
+static INLINE BYTE* writePixelRGBX(BYTE* dst, DWORD formatSize, UINT32 format,
+                                   BYTE R, BYTE G, BYTE B, BYTE A)
+{
+	dst[0] = R;
+	dst[1] = G;
+	dst[2] = B;
+	dst[3] = A;
+	return dst + formatSize;
+}
+
+static INLINE BYTE* writePixelXBGR(BYTE* dst, DWORD formatSize, UINT32 format,
+                                   BYTE R, BYTE G, BYTE B, BYTE A)
+{
+	dst[0] = A;
+	dst[1] = B;
+	dst[2] = G;
+	dst[3] = R;
+	return dst + formatSize;
+}
+
+static INLINE BYTE* writePixelXRGB(BYTE* dst, DWORD formatSize, UINT32 format,
+                                   BYTE R, BYTE G, BYTE B, BYTE A)
+{
+	dst[0] = A;
+	dst[1] = R;
+	dst[2] = G;
+	dst[3] = B;
+	return dst + formatSize;
+}
+
+static INLINE BYTE* writePixelGeneric(BYTE* dst, DWORD formatSize, UINT32 format,
+                                      BYTE R, BYTE G, BYTE B, BYTE A)
+{
+	UINT32 color = GetColor(format, R, G, B, A);
+	WriteColor(dst, format, color);
+	return dst + formatSize;
+}
+
+typedef BYTE* (*fkt_writePixel)(BYTE*, DWORD, UINT32, BYTE, BYTE, BYTE, BYTE);
+
+static INLINE fkt_writePixel getWriteFunction(DWORD format)
+{
+	switch (format)
+	{
+		case PIXEL_FORMAT_ARGB32:
+		case PIXEL_FORMAT_XRGB32:
+			return writePixelXRGB;
+
+		case PIXEL_FORMAT_ABGR32:
+		case PIXEL_FORMAT_XBGR32:
+			return writePixelXBGR;
+
+		case PIXEL_FORMAT_RGBA32:
+		case PIXEL_FORMAT_RGBX32:
+			return writePixelRGBX;
+
+		case PIXEL_FORMAT_BGRA32:
+		case PIXEL_FORMAT_BGRX32:
+			return writePixelBGRX;
+
+		default:
+			return writePixelGeneric;
+	}
+}
+
 static pstatus_t general_YCoCgToRGB_8u_AC4R(
     const BYTE* pSrc, INT32 srcStep,
     BYTE* pDst, UINT32 DstFormat, INT32 dstStep,
@@ -45,6 +120,7 @@ static pstatus_t general_YCoCgToRGB_8u_AC4R(
 	const BYTE* sptr = pSrc;
 	INT16 Cg, Co, Y, T, R, G, B;
 	const DWORD formatSize = GetBytesPerPixel(DstFormat);
+	fkt_writePixel writePixel = getWriteFunction(DstFormat);
 	int cll = shift - 1;  /* -1 builds in the /2's */
 	UINT32 srcPad = srcStep - (width * 4);
 	UINT32 dstPad = dstStep - (width * formatSize);
@@ -67,11 +143,8 @@ static pstatus_t general_YCoCgToRGB_8u_AC4R(
 			R  = T + Co;
 			G  = Y + Cg;
 			B  = T - Co;
-			color = GetColor(DstFormat,
-			                 MINMAX(R, 0, 255), MINMAX(G, 0, 255),
-			                 MINMAX(B, 0, 255), A);
-			WriteColor(dptr, DstFormat, color);
-			dptr += formatSize;
+			dptr = (*writePixel)(dptr, formatSize, DstFormat, MINMAX(R, 0, 255),
+			                     MINMAX(G, 0, 255), MINMAX(B, 0, 255), A);
 		}
 
 		sptr += srcPad;

--- a/libfreerdp/primitives/prim_YCoCg.c
+++ b/libfreerdp/primitives/prim_YCoCg.c
@@ -33,20 +33,21 @@
 
 /* ------------------------------------------------------------------------- */
 static pstatus_t general_YCoCgToRGB_8u_AC4R(
-		const BYTE* pSrc, INT32 srcStep,
-		BYTE* pDst, UINT32 DstFormat, INT32 dstStep,
-		UINT32 width, UINT32 height,
-		UINT8 shift,
-		BOOL withAlpha)
+    const BYTE* pSrc, INT32 srcStep,
+    BYTE* pDst, UINT32 DstFormat, INT32 dstStep,
+    UINT32 width, UINT32 height,
+    UINT8 shift,
+    BOOL withAlpha)
 {
 	BYTE A;
 	UINT32 x, y;
 	BYTE* dptr = pDst;
 	const BYTE* sptr = pSrc;
 	INT16 Cg, Co, Y, T, R, G, B;
+	const DWORD formatSize = GetBytesPerPixel(DstFormat);
 	int cll = shift - 1;  /* -1 builds in the /2's */
 	UINT32 srcPad = srcStep - (width * 4);
-	UINT32 dstPad = dstStep - (width * GetBytesPerPixel(DstFormat));
+	UINT32 dstPad = dstStep - (width * formatSize);
 
 	for (y = 0; y < height; y++)
 	{
@@ -66,12 +67,11 @@ static pstatus_t general_YCoCgToRGB_8u_AC4R(
 			R  = T + Co;
 			G  = Y + Cg;
 			B  = T - Co;
-
 			color = GetColor(DstFormat,
-					 MINMAX(R, 0, 255), MINMAX(G, 0, 255),
-					 MINMAX(B, 0, 255), A);
+			                 MINMAX(R, 0, 255), MINMAX(G, 0, 255),
+			                 MINMAX(B, 0, 255), A);
 			WriteColor(dptr, DstFormat, color);
-			dptr += GetBytesPerPixel(DstFormat);
+			dptr += formatSize;
 		}
 
 		sptr += srcPad;

--- a/libfreerdp/primitives/prim_YUV.c
+++ b/libfreerdp/primitives/prim_YUV.c
@@ -326,15 +326,99 @@ static INLINE BYTE YUV2B(INT32 Y, INT32 U, INT32 V)
 	return CLIP(b8);
 }
 
-static INLINE BYTE* writeYUVPixel(BYTE* dst, DWORD formatSize, UINT32 format, BYTE Y, BYTE U,
-                                  BYTE V)
+static INLINE BYTE* writeYUVPixelBGRX(BYTE* dst, DWORD formatSize, UINT32 format, BYTE Y, BYTE U,
+                                      BYTE V)
 {
 	const BYTE r = YUV2R(Y, U, V);
 	const BYTE g = YUV2G(Y, U, V);
 	const BYTE b = YUV2B(Y, U, V);
-	UINT32 color = GetColor(format, r, g, b, 0xFF);
+	const BYTE a = 0xFF;
+	dst[0] = b;
+	dst[1] = g;
+	dst[2] = r;
+	dst[3] = a;
+	return dst + formatSize;
+}
+
+static INLINE BYTE* writeYUVPixelRGBX(BYTE* dst, DWORD formatSize, UINT32 format, BYTE Y, BYTE U,
+                                      BYTE V)
+{
+	const BYTE r = YUV2R(Y, U, V);
+	const BYTE g = YUV2G(Y, U, V);
+	const BYTE b = YUV2B(Y, U, V);
+	const BYTE a = 0xFF;
+	dst[0] = r;
+	dst[1] = g;
+	dst[2] = b;
+	dst[3] = a;
+	return dst + formatSize;
+}
+
+static INLINE BYTE* writeYUVPixelXBGR(BYTE* dst, DWORD formatSize, UINT32 format, BYTE Y, BYTE U,
+                                      BYTE V)
+{
+	const BYTE r = YUV2R(Y, U, V);
+	const BYTE g = YUV2G(Y, U, V);
+	const BYTE b = YUV2B(Y, U, V);
+	const BYTE a = 0xFF;
+	dst[0] = a;
+	dst[1] = b;
+	dst[2] = g;
+	dst[3] = r;
+	return dst + formatSize;
+}
+
+static INLINE BYTE* writeYUVPixelXRGB(BYTE* dst, DWORD formatSize, UINT32 format, BYTE Y, BYTE U,
+                                      BYTE V)
+{
+	const BYTE r = YUV2R(Y, U, V);
+	const BYTE g = YUV2G(Y, U, V);
+	const BYTE b = YUV2B(Y, U, V);
+	const BYTE a = 0xFF;
+	dst[0] = a;
+	dst[1] = r;
+	dst[2] = g;
+	dst[3] = b;
+	return dst + formatSize;
+}
+
+static INLINE BYTE* writeYUVPixelGeneric(BYTE* dst, DWORD formatSize, UINT32 format, BYTE Y, BYTE U,
+        BYTE V)
+{
+	const BYTE r = YUV2R(Y, U, V);
+	const BYTE g = YUV2G(Y, U, V);
+	const BYTE b = YUV2B(Y, U, V);
+	const BYTE a = 0xFF;
+	UINT32 color = GetColor(format, r, g, b, a);
 	WriteColor(dst, format, color);
 	return dst + formatSize;
+}
+
+typedef BYTE* (*fkt_writeYUVPixel)(BYTE*, DWORD, UINT32, BYTE, BYTE, BYTE);
+
+static INLINE fkt_writeYUVPixel getWriteFunction(DWORD format)
+{
+	switch (format)
+	{
+		case PIXEL_FORMAT_ARGB32:
+		case PIXEL_FORMAT_XRGB32:
+			return writeYUVPixelXRGB;
+
+		case PIXEL_FORMAT_ABGR32:
+		case PIXEL_FORMAT_XBGR32:
+			return writeYUVPixelXBGR;
+
+		case PIXEL_FORMAT_RGBA32:
+		case PIXEL_FORMAT_RGBX32:
+			return writeYUVPixelRGBX;
+
+		case PIXEL_FORMAT_BGRA32:
+		case PIXEL_FORMAT_BGRX32:
+			return writeYUVPixelBGRX;
+
+		default:
+			return writeYUVPixelGeneric;
+	}
 }
 
 static pstatus_t general_YUV444ToRGB_8u_P3AC4R(
@@ -347,6 +431,7 @@ static pstatus_t general_YUV444ToRGB_8u_P3AC4R(
 	const DWORD formatSize = GetBytesPerPixel(DstFormat);
 	nWidth = roi->width;
 	nHeight = roi->height;
+	fkt_writeYUVPixel writeYUVPixel = getWriteFunction(DstFormat);
 
 	for (y = 0; y < nHeight; y++)
 	{
@@ -360,7 +445,7 @@ static pstatus_t general_YUV444ToRGB_8u_P3AC4R(
 			const BYTE Y = pY[x];
 			const INT32 U = pU[x];
 			const INT32 V = pV[x];
-			pRGB = writeYUVPixel(pRGB, formatSize, DstFormat, Y, U, V);
+			pRGB = (*writeYUVPixel)(pRGB, formatSize, DstFormat, Y, U, V);
 		}
 	}
 
@@ -390,6 +475,7 @@ static pstatus_t general_YUV420ToRGB_8u_P3AC4R(
 	UINT32 nWidth, nHeight;
 	UINT32 lastRow, lastCol;
 	const DWORD formatSize = GetBytesPerPixel(DstFormat);
+	fkt_writeYUVPixel writeYUVPixel = getWriteFunction(DstFormat);
 	pY = pSrc[0];
 	pU = pSrc[1];
 	pV = pSrc[2];
@@ -418,13 +504,13 @@ static pstatus_t general_YUV420ToRGB_8u_P3AC4R(
 			V = *pV++;
 			/* 1st pixel */
 			Y = *pY++;
-			pRGB = writeYUVPixel(pRGB, formatSize, DstFormat, Y, U, V);
+			pRGB = (*writeYUVPixel)(pRGB, formatSize, DstFormat, Y, U, V);
 
 			/* 2nd pixel */
 			if (!(lastCol & 0x02))
 			{
 				Y = *pY++;
-				pRGB = writeYUVPixel(pRGB, formatSize, DstFormat, Y, U, V);
+				pRGB = (*writeYUVPixel)(pRGB, formatSize, DstFormat, Y, U, V);
 			}
 			else
 			{
@@ -451,13 +537,13 @@ static pstatus_t general_YUV420ToRGB_8u_P3AC4R(
 			V = *pV++;
 			/* 3rd pixel */
 			Y = *pY++;
-			pRGB = writeYUVPixel(pRGB, formatSize, DstFormat, Y, U, V);
+			pRGB = (*writeYUVPixel)(pRGB, formatSize, DstFormat, Y, U, V);
 
 			/* 4th pixel */
 			if (!(lastCol & 0x02))
 			{
 				Y = *pY++;
-				pRGB = writeYUVPixel(pRGB, formatSize, DstFormat, Y, U, V);
+				pRGB = (*writeYUVPixel)(pRGB, formatSize, DstFormat, Y, U, V);
 			}
 			else
 			{


### PR DESCRIPTION
When copying image data consider formats that only differ on use
of alpha data equal. This allows using the optimized copy routine
instead of the slower color conversion routine. Fixes #3616