### PR TITLE
Check hwheel capability before sending mouse event.

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -348,18 +348,12 @@ BOOL xf_generic_ButtonPress(xfContext* xfc, int x, int y, int button,
 
 		case 6:		/* wheel left */
 			wheel = TRUE;
-
-			if (xfc->context.settings->HasHorizontalWheel)
-				flags = PTR_FLAGS_HWHEEL | PTR_FLAGS_WHEEL_NEGATIVE | 0x0078;
-
+			flags = PTR_FLAGS_HWHEEL | PTR_FLAGS_WHEEL_NEGATIVE | 0x0078;
 			break;
 
 		case 7:		/* wheel right */
 			wheel = TRUE;
-
-			if (xfc->context.settings->HasHorizontalWheel)
-				flags = PTR_FLAGS_HWHEEL | 0x0078;
-
+			flags = PTR_FLAGS_HWHEEL | 0x0078;
 			break;
 
 		default:

--- a/libfreerdp/core/input.c
+++ b/libfreerdp/core/input.c
@@ -48,8 +48,10 @@ wStream* rdp_client_input_pdu_init(rdpRdp* rdp, UINT16 type)
 {
 	wStream* s;
 	s = rdp_data_pdu_init(rdp);
+
 	if (!s)
 		return NULL;
+
 	rdp_write_client_input_pdu_header(s, 1);
 	rdp_write_input_event_header(s, 0, type);
 	return s;
@@ -75,10 +77,11 @@ BOOL input_send_synchronize_event(rdpInput* input, UINT32 flags)
 		return FALSE;
 
 	rdp = input->context->rdp;
-
 	s = rdp_client_input_pdu_init(rdp, INPUT_EVENT_SYNC);
+
 	if (!s)
 		return FALSE;
+
 	input_write_synchronize_event(s, flags);
 	return rdp_send_client_input_pdu(rdp, s);
 }
@@ -99,10 +102,11 @@ BOOL input_send_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
 		return FALSE;
 
 	rdp = input->context->rdp;
-
 	s = rdp_client_input_pdu_init(rdp, INPUT_EVENT_SCANCODE);
+
 	if (!s)
 		return FALSE;
+
 	input_write_keyboard_event(s, flags, code);
 	return rdp_send_client_input_pdu(rdp, s);
 }
@@ -124,7 +128,6 @@ BOOL input_send_unicode_keyboard_event(rdpInput* input, UINT16 flags, UINT16 cod
 		return FALSE;
 
 	rdp = input->context->rdp;
-
 	/*
 	 * According to the specification, the slow path Unicode Keyboard Event
 	 * (TS_UNICODE_KEYBOARD_EVENT) contains KBD_FLAGS_RELEASE flag when key
@@ -135,10 +138,11 @@ BOOL input_send_unicode_keyboard_event(rdpInput* input, UINT16 flags, UINT16 cod
 	 * There is no KBD_FLAGS_EXTENDED flag in TS_UNICODE_KEYBOARD_EVENT.
 	 */
 	keyboardFlags |= (flags & KBD_FLAGS_RELEASE) ? KBD_FLAGS_RELEASE : 0;
-
 	s = rdp_client_input_pdu_init(rdp, INPUT_EVENT_UNICODE);
+
 	if (!s)
 		return FALSE;
+
 	input_write_unicode_keyboard_event(s, flags, code);
 	return rdp_send_client_input_pdu(rdp, s);
 }
@@ -155,14 +159,26 @@ BOOL input_send_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UINT16 y)
 	wStream* s;
 	rdpRdp* rdp;
 
-	if (!input || !input->context)
+	if (!input || !input->context || !input->context->settings)
 		return FALSE;
 
 	rdp = input->context->rdp;
 
+	if (!input->context->settings->HasHorizontalWheel)
+	{
+		if (flags & PTR_FLAGS_HWHEEL)
+		{
+			WLog_WARN(TAG, "skip mouse event %hux%hu flags=%08X, no horizontal mouse wheel supported",
+			          x, y, flags);
+			return TRUE;
+		}
+	}
+
 	s = rdp_client_input_pdu_init(rdp, INPUT_EVENT_MOUSE);
+
 	if (!s)
 		return FALSE;
+
 	input_write_mouse_event(s, flags, x, y);
 	return rdp_send_client_input_pdu(rdp, s);
 }
@@ -183,10 +199,11 @@ BOOL input_send_extended_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UI
 		return FALSE;
 
 	rdp = input->context->rdp;
-
 	s = rdp_client_input_pdu_init(rdp, INPUT_EVENT_MOUSEX);
+
 	if (!s)
 		return FALSE;
+
 	input_write_extended_mouse_event(s, flags, x, y);
 	return rdp_send_client_input_pdu(rdp, s);
 }
@@ -214,22 +231,22 @@ BOOL input_send_keyboard_pause_event(rdpInput* input)
 
 	/* Control down (0x1D) */
 	if (!input_send_keyboard_event(input, 0,
-		RDP_SCANCODE_CODE(RDP_SCANCODE_LCONTROL)))
+	                               RDP_SCANCODE_CODE(RDP_SCANCODE_LCONTROL)))
 		return FALSE;
 
 	/* Numlock down (0x45) */
 	if (!input_send_keyboard_event(input, 0,
-		RDP_SCANCODE_CODE(RDP_SCANCODE_NUMLOCK)))
+	                               RDP_SCANCODE_CODE(RDP_SCANCODE_NUMLOCK)))
 		return FALSE;
 
 	/* Control up (0x1D) */
 	if (!input_send_keyboard_event(input, KBD_FLAGS_RELEASE,
-		RDP_SCANCODE_CODE(RDP_SCANCODE_LCONTROL)))
+	                               RDP_SCANCODE_CODE(RDP_SCANCODE_LCONTROL)))
 		return FALSE;
 
 	/* Numlock up (0x45) */
 	return input_send_keyboard_event(input, KBD_FLAGS_RELEASE,
-		RDP_SCANCODE_CODE(RDP_SCANCODE_NUMLOCK));
+	                                 RDP_SCANCODE_CODE(RDP_SCANCODE_NUMLOCK));
 }
 
 BOOL input_send_fastpath_synchronize_event(rdpInput* input, UINT32 flags)
@@ -241,11 +258,12 @@ BOOL input_send_fastpath_synchronize_event(rdpInput* input, UINT32 flags)
 		return FALSE;
 
 	rdp = input->context->rdp;
-
 	/* The FastPath Synchronization eventFlags has identical values as SlowPath */
 	s = fastpath_input_pdu_init(rdp->fastpath, (BYTE) flags, FASTPATH_INPUT_EVENT_SYNC);
+
 	if (!s)
 		return FALSE;
+
 	return fastpath_send_input_pdu(rdp->fastpath, s);
 }
 
@@ -259,12 +277,13 @@ BOOL input_send_fastpath_keyboard_event(rdpInput* input, UINT16 flags, UINT16 co
 		return FALSE;
 
 	rdp = input->context->rdp;
-
 	eventFlags |= (flags & KBD_FLAGS_RELEASE) ? FASTPATH_INPUT_KBDFLAGS_RELEASE : 0;
 	eventFlags |= (flags & KBD_FLAGS_EXTENDED) ? FASTPATH_INPUT_KBDFLAGS_EXTENDED : 0;
 	s = fastpath_input_pdu_init(rdp->fastpath, eventFlags, FASTPATH_INPUT_EVENT_SCANCODE);
+
 	if (!s)
 		return FALSE;
+
 	Stream_Write_UINT8(s, code); /* keyCode (1 byte) */
 	return fastpath_send_input_pdu(rdp->fastpath, s);
 }
@@ -279,11 +298,12 @@ BOOL input_send_fastpath_unicode_keyboard_event(rdpInput* input, UINT16 flags, U
 		return FALSE;
 
 	rdp = input->context->rdp;
-
 	eventFlags |= (flags & KBD_FLAGS_RELEASE) ? FASTPATH_INPUT_KBDFLAGS_RELEASE : 0;
 	s = fastpath_input_pdu_init(rdp->fastpath, eventFlags, FASTPATH_INPUT_EVENT_UNICODE);
+
 	if (!s)
 		return FALSE;
+
 	Stream_Write_UINT16(s, code); /* unicodeCode (2 bytes) */
 	return fastpath_send_input_pdu(rdp->fastpath, s);
 }
@@ -293,14 +313,26 @@ BOOL input_send_fastpath_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UI
 	wStream* s;
 	rdpRdp* rdp;
 
-	if (!input || !input->context)
+	if (!input || !input->context || !input->context->settings)
 		return FALSE;
 
 	rdp = input->context->rdp;
 
+	if (!input->context->settings->HasHorizontalWheel)
+	{
+		if (flags & PTR_FLAGS_HWHEEL)
+		{
+			WLog_WARN(TAG, "skip mouse event %hux%hu flags=%08X, no horizontal mouse wheel supported",
+			          x, y, flags);
+			return TRUE;
+		}
+	}
+
 	s = fastpath_input_pdu_init(rdp->fastpath, 0, FASTPATH_INPUT_EVENT_MOUSE);
+
 	if (!s)
 		return FALSE;
+
 	input_write_mouse_event(s, flags, x, y);
 	return fastpath_send_input_pdu(rdp->fastpath, s);
 }
@@ -314,10 +346,11 @@ BOOL input_send_fastpath_extended_mouse_event(rdpInput* input, UINT16 flags, UIN
 		return FALSE;
 
 	rdp = input->context->rdp;
-
 	s = fastpath_input_pdu_init(rdp->fastpath, 0, FASTPATH_INPUT_EVENT_MOUSEX);
+
 	if (!s)
 		return FALSE;
+
 	input_write_extended_mouse_event(s, flags, x, y);
 	return fastpath_send_input_pdu(rdp->fastpath, s);
 }
@@ -332,24 +365,22 @@ BOOL input_send_fastpath_focus_in_event(rdpInput* input, UINT16 toggleStates)
 		return FALSE;
 
 	rdp = input->context->rdp;
-
 	s = fastpath_input_pdu_init_header(rdp->fastpath);
+
 	if (!s)
 		return FALSE;
+
 	/* send a tab up like mstsc.exe */
 	eventFlags = FASTPATH_INPUT_KBDFLAGS_RELEASE | FASTPATH_INPUT_EVENT_SCANCODE << 5;
 	Stream_Write_UINT8(s, eventFlags); /* Key Release event (1 byte) */
 	Stream_Write_UINT8(s, 0x0f); /* keyCode (1 byte) */
-
 	/* send the toggle key states */
 	eventFlags = (toggleStates & 0x1F) | FASTPATH_INPUT_EVENT_SYNC << 5;
 	Stream_Write_UINT8(s, eventFlags); /* toggle state (1 byte) */
-
 	/* send another tab up like mstsc.exe */
 	eventFlags = FASTPATH_INPUT_KBDFLAGS_RELEASE | FASTPATH_INPUT_EVENT_SCANCODE << 5;
 	Stream_Write_UINT8(s, eventFlags); /* Key Release event (1 byte) */
 	Stream_Write_UINT8(s, 0x0f); /* keyCode (1 byte) */
-
 	return fastpath_send_multiple_input_pdu(rdp->fastpath, s, 3);
 }
 
@@ -362,34 +393,30 @@ BOOL input_send_fastpath_keyboard_pause_event(rdpInput* input)
 	wStream* s;
 	const BYTE keyDownEvent = FASTPATH_INPUT_EVENT_SCANCODE << 5;
 	const BYTE keyUpEvent = (FASTPATH_INPUT_EVENT_SCANCODE << 5)
-		| FASTPATH_INPUT_KBDFLAGS_RELEASE;
+	                        | FASTPATH_INPUT_KBDFLAGS_RELEASE;
 	rdpRdp* rdp;
 
 	if (!input || !input->context)
 		return FALSE;
 
 	rdp = input->context->rdp;
-
 	s = fastpath_input_pdu_init_header(rdp->fastpath);
+
 	if (!s)
 		return FALSE;
 
 	/* Control down (0x1D) */
 	Stream_Write_UINT8(s, keyDownEvent | FASTPATH_INPUT_KBDFLAGS_PREFIX_E1);
 	Stream_Write_UINT8(s, RDP_SCANCODE_CODE(RDP_SCANCODE_LCONTROL));
-
 	/* Numlock down (0x45) */
 	Stream_Write_UINT8(s, keyDownEvent);
 	Stream_Write_UINT8(s, RDP_SCANCODE_CODE(RDP_SCANCODE_NUMLOCK));
-
 	/* Control up (0x1D) */
 	Stream_Write_UINT8(s, keyUpEvent | FASTPATH_INPUT_KBDFLAGS_PREFIX_E1);
 	Stream_Write_UINT8(s, RDP_SCANCODE_CODE(RDP_SCANCODE_LCONTROL));
-
 	/* Numlock down (0x45) */
 	Stream_Write_UINT8(s, keyUpEvent);
 	Stream_Write_UINT8(s, RDP_SCANCODE_CODE(RDP_SCANCODE_NUMLOCK));
-
 	return fastpath_send_multiple_input_pdu(rdp->fastpath, s, 4);
 }
 
@@ -402,7 +429,6 @@ static BOOL input_recv_sync_event(rdpInput* input, wStream* s)
 
 	Stream_Seek(s, 2); /* pad2Octets (2 bytes) */
 	Stream_Read_UINT32(s, toggleFlags); /* toggleFlags (4 bytes) */
-
 	return IFCALLRESULT(TRUE, input->SynchronizeEvent, input, toggleFlags);
 }
 
@@ -470,7 +496,6 @@ static BOOL input_recv_mouse_event(rdpInput* input, wStream* s)
 	Stream_Read_UINT16(s, pointerFlags); /* pointerFlags (2 bytes) */
 	Stream_Read_UINT16(s, xPos); /* xPos (2 bytes) */
 	Stream_Read_UINT16(s, yPos); /* yPos (2 bytes) */
-
 	return IFCALLRESULT(TRUE, input->MouseEvent, input, pointerFlags, xPos, yPos);
 }
 
@@ -484,7 +509,6 @@ static BOOL input_recv_extended_mouse_event(rdpInput* input, wStream* s)
 	Stream_Read_UINT16(s, pointerFlags); /* pointerFlags (2 bytes) */
 	Stream_Read_UINT16(s, xPos); /* xPos (2 bytes) */
 	Stream_Read_UINT16(s, yPos); /* yPos (2 bytes) */
-
 	return IFCALLRESULT(TRUE, input->ExtendedMouseEvent, input, pointerFlags, xPos, yPos);
 }
 
@@ -503,26 +527,31 @@ static BOOL input_recv_event(rdpInput* input, wStream* s)
 		case INPUT_EVENT_SYNC:
 			if (!input_recv_sync_event(input, s))
 				return FALSE;
+
 			break;
 
 		case INPUT_EVENT_SCANCODE:
 			if (!input_recv_keyboard_event(input, s))
 				return FALSE;
+
 			break;
 
 		case INPUT_EVENT_UNICODE:
 			if (!input_recv_unicode_keyboard_event(input, s))
 				return FALSE;
+
 			break;
 
 		case INPUT_EVENT_MOUSE:
 			if (!input_recv_mouse_event(input, s))
 				return FALSE;
+
 			break;
 
 		case INPUT_EVENT_MOUSEX:
 			if (!input_recv_extended_mouse_event(input, s))
 				return FALSE;
+
 			break;
 
 		default:
@@ -549,7 +578,7 @@ BOOL input_recv(rdpInput* input, wStream* s)
 	Stream_Seek(s, 2); /* pad2Octets (2 bytes) */
 
 	/* Each input event uses 6 exactly bytes. */
-	if (Stream_GetRemainingLength(s) < (size_t) (6 * numberEvents))
+	if (Stream_GetRemainingLength(s) < (size_t)(6 * numberEvents))
 		return FALSE;
 
 	for (i = 0; i < numberEvents; i++)
@@ -599,9 +628,11 @@ BOOL input_register_client_callbacks(rdpInput* input)
 	if (input->asynchronous)
 	{
 		input->proxy = input_message_proxy_new(input);
+
 		if (!input->proxy)
 			return FALSE;
 	}
+
 	return TRUE;
 }
 
@@ -624,9 +655,9 @@ BOOL freerdp_input_send_keyboard_event(rdpInput* input, UINT16 flags, UINT16 cod
 BOOL freerdp_input_send_keyboard_event_ex(rdpInput* input, BOOL down, UINT32 rdp_scancode)
 {
 	return freerdp_input_send_keyboard_event(input,
-			(RDP_SCANCODE_EXTENDED(rdp_scancode) ? KBD_FLAGS_EXTENDED : 0) |
-			((down) ? KBD_FLAGS_DOWN : KBD_FLAGS_RELEASE),
-			RDP_SCANCODE_CODE(rdp_scancode));
+	        (RDP_SCANCODE_EXTENDED(rdp_scancode) ? KBD_FLAGS_EXTENDED : 0) |
+	        ((down) ? KBD_FLAGS_DOWN : KBD_FLAGS_RELEASE),
+	        RDP_SCANCODE_CODE(rdp_scancode));
 }
 
 BOOL freerdp_input_send_unicode_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
@@ -677,9 +708,9 @@ int input_process_events(rdpInput* input)
 	return input_message_queue_process_pending_messages(input);
 }
 
-static void input_free_queued_message(void *obj)
+static void input_free_queued_message(void* obj)
 {
-	wMessage *msg = (wMessage*)obj;
+	wMessage* msg = (wMessage*)obj;
 	input_message_queue_free_message(msg);
 }
 
@@ -687,12 +718,13 @@ rdpInput* input_new(rdpRdp* rdp)
 {
 	const wObject cb = { NULL, NULL, NULL, input_free_queued_message, NULL };
 	rdpInput* input;
-
 	input = (rdpInput*) calloc(1, sizeof(rdpInput));
+
 	if (!input)
 		return NULL;
 
 	input->queue = MessageQueue_New(&cb);
+
 	if (!input->queue)
 	{
 		free(input);
@@ -710,7 +742,6 @@ void input_free(rdpInput* input)
 			input_message_proxy_free(input->proxy);
 
 		MessageQueue_Free(input->queue);
-
 		free(input);
 	}
 }


### PR DESCRIPTION
The horizontal mouse wheel event must not be sent if the server does not announce that capability.
Move the check from client code to core library to avoid duplicate checks and accidental server disconnects.