### PR TITLE
codec: Remove src format parameter from rfx_process_message

### DIFF
--- a/client/X11/xf_gdi.c
+++ b/client/X11/xf_gdi.c
@@ -1018,11 +1018,8 @@ static BOOL xf_gdi_surface_bits(rdpContext* context,
 	switch (cmd->codecID)
 	{
 		case RDP_CODEC_ID_REMOTEFX:
-			format = PIXEL_FORMAT_BGRX32;
-
 			if (!rfx_process_message(context->codecs->rfx, cmd->bitmapData,
-			                         format, cmd->bitmapDataLength,
-			                         0, 0,
+			                         cmd->bitmapDataLength, 0, 0,
 			                         gdi->primary_buffer, gdi->dstFormat, stride,
 			                         gdi->height, NULL))
 				goto fail;

--- a/include/freerdp/codec/rfx.h
+++ b/include/freerdp/codec/rfx.h
@@ -171,8 +171,7 @@ struct _RFX_CONTEXT
 FREERDP_API void rfx_context_set_pixel_format(RFX_CONTEXT* context,
         UINT32 pixel_format);
 
-FREERDP_API BOOL rfx_process_message(RFX_CONTEXT* context, const BYTE* data,
-                                     UINT32 format, UINT32 length,
+FREERDP_API BOOL rfx_process_message(RFX_CONTEXT* context, const BYTE* data, UINT32 length,
                                      UINT32 left, UINT32 top,
                                      BYTE* dst, UINT32 dstFormat,
                                      UINT32 dstStride, UINT32 dstHeight,

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -996,8 +996,7 @@ static BOOL rfx_process_message_tileset(RFX_CONTEXT* context,
 	return rc;
 }
 
-BOOL rfx_process_message(RFX_CONTEXT* context, const BYTE* data,
-                         UINT32 format, UINT32 length,
+BOOL rfx_process_message(RFX_CONTEXT* context, const BYTE* data, UINT32 length,
                          UINT32 left, UINT32 top,
                          BYTE* dst, UINT32 dstFormat,
                          UINT32 dstStride, UINT32 dstHeight,
@@ -1153,7 +1152,7 @@ BOOL rfx_process_message(RFX_CONTEXT* context, const BYTE* data,
 		UINT32 nbUpdateRects;
 		REGION16 clippingRects;
 		const RECTANGLE_16* updateRects;
-		const DWORD formatSize = GetBytesPerPixel(format);
+		const DWORD formatSize = GetBytesPerPixel(context->pixel_format);
 		region16_init(&clippingRects);
 
 		for (i = 0; i < message->numRects; i++)
@@ -1191,7 +1190,7 @@ BOOL rfx_process_message(RFX_CONTEXT* context, const BYTE* data,
 
 				if (!freerdp_image_copy(dst, dstFormat, dstStride,
 				                        nXDst, nYDst, nWidth, nHeight,
-				                        tile->data, format, stride, nXSrc, nYSrc, NULL, FREERDP_FLIP_NONE))
+				                        tile->data, context->pixel_format, stride, nXSrc, nYSrc, NULL, FREERDP_FLIP_NONE))
 					goto fail;
 
 				if (invalidRegion)

--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -960,10 +960,7 @@ static BOOL gdi_surface_bits(rdpContext* context,
 	switch (cmd->codecID)
 	{
 		case RDP_CODEC_ID_REMOTEFX:
-			format = PIXEL_FORMAT_BGRX32;
-
 			if (!rfx_process_message(context->codecs->rfx, cmd->bitmapData,
-			                         format,
 			                         cmd->bitmapDataLength,
 			                         cmd->destLeft, cmd->destTop,
 			                         gdi->primary_buffer, gdi->dstFormat,

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -257,8 +257,8 @@ static UINT gdi_SurfaceCommand_RemoteFX(rdpGdi* gdi,
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!rfx_process_message(surface->codecs->rfx, cmd->data, cmd->format,
-	                         cmd->length,
+	rfx_context_set_pixel_format(surface->codecs->rfx, cmd->format);
+	if (!rfx_process_message(surface->codecs->rfx, cmd->data, cmd->length,
 	                         cmd->left, cmd->top,
 	                         surface->data, surface->format, surface->scanline,
 	                         surface->height, &surface->invalidRegion))


### PR DESCRIPTION
This parameter is not required. Default param is BGRX32 and if an other format is required rfx_context_set_pixel_format can be used.