### PR TITLE
Improve and fix extended channel handling

### DIFF
--- a/libfreerdp/common/addin.c
+++ b/libfreerdp/common/addin.c
@@ -305,7 +305,12 @@ PVIRTUALCHANNELENTRY freerdp_load_dynamic_channel_addin_entry(LPCSTR pszName,
 	/* channel add-in */
 
 	if (dwFlags & FREERDP_ADDIN_CHANNEL_STATIC)
-		entry = freerdp_load_dynamic_addin(pszFileName, NULL, "VirtualChannelEntry");
+	{
+		if (dwFlags & FREERDP_ADDIN_CHANNEL_ENTRYEX)
+			entry = freerdp_load_dynamic_addin(pszFileName, NULL, "VirtualChannelEntryEx");
+		else
+			entry = freerdp_load_dynamic_addin(pszFileName, NULL, "VirtualChannelEntry");
+	}
 	else if (dwFlags & FREERDP_ADDIN_CHANNEL_DYNAMIC)
 		entry = freerdp_load_dynamic_addin(pszFileName, NULL, "DVCPluginEntry");
 	else if (dwFlags & FREERDP_ADDIN_CHANNEL_DEVICE)
@@ -334,9 +339,6 @@ PVIRTUALCHANNELENTRY freerdp_load_channel_addin_entry(LPCSTR pszName,
 
 	if (freerdp_load_static_channel_addin_entry)
 		entry = freerdp_load_static_channel_addin_entry(pszName, pszSubsystem, pszType, dwFlags);
-
-	if (dwFlags & FREERDP_ADDIN_CHANNEL_ENTRYEX)
-		return entry; /* don't warn, don't try dynamic entries for VirtualChannelEntryEx */
 
 	if (!entry)
 		entry = freerdp_load_dynamic_channel_addin_entry(pszName, pszSubsystem, pszType, dwFlags);

--- a/libfreerdp/core/client.h
+++ b/libfreerdp/core/client.h
@@ -111,7 +111,6 @@ struct rdp_channels
 	DrdynvcClientContext* drdynvc;
 	CRITICAL_SECTION channelsLock;
 
-	int openHandleSequence;
 	wHashTable* openHandles;
 };
 


### PR DESCRIPTION
* use the same name space as for regular channels
* allow channels with extended interface to be loaded from an library

This fixes also an regression when regular and and normal channels are used together.