### PR TITLE
Limit MultifragMaxRequestSize in server mode

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -2477,7 +2477,7 @@ static BOOL rdp_write_multifragment_update_capability_set(wStream* s,
 	if (!Stream_EnsureRemainingCapacity(s, 32))
 		return FALSE;
 
-	if (settings->ServerMode)
+	if (settings->ServerMode && settings->MultifragMaxRequestSize == 0)
 	{
 		/**
 		 * In server mode we prefer to use the highest useful request size that

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -481,7 +481,8 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	settings->RemoteAppNumIconCaches = 3;
 	settings->RemoteAppNumIconCacheEntries = 12;
 	settings->VirtualChannelChunkSize = CHANNEL_CHUNK_LENGTH;
-	settings->MultifragMaxRequestSize = 0xFFFF;
+	settings->MultifragMaxRequestSize = (flags & FREERDP_SETTINGS_SERVER_MODE) ?
+	                                    0 : 0xFFFF;
 	settings->GatewayUseSameCredentials = FALSE;
 	settings->GatewayBypassLocal = FALSE;
 	settings->GatewayRpcTransport = TRUE;


### PR DESCRIPTION
With large desktop resolutions also our preferred max request size
increases, but in practice I've found that at least the client I use
(MS Lync 2013) would show only a black screen when the value is greater
than 0x3EFFFF.

Cap MultifragMaxRequestSize to its initial value, which is currently
0xFFFF or can be user-set at will.