### PR TITLE
Added missing pointer.SetPosition to corrected crash

### DIFF
--- a/client/Windows/wf_graphics.c
+++ b/client/Windows/wf_graphics.c
@@ -318,6 +318,14 @@ static BOOL wf_Pointer_SetDefault(rdpContext* context)
 	return TRUE;
 }
 
+static BOOL wf_Pointer_SetPosition(rdpContext* context, UINT32 x, UINT32 y)
+{
+	if (!context)
+		return FALSE;
+
+	return TRUE;
+}
+
 BOOL wf_register_pointer(rdpGraphics* graphics)
 {
 	wfContext* wfc;
@@ -334,6 +342,7 @@ BOOL wf_register_pointer(rdpGraphics* graphics)
 	pointer.Set = wf_Pointer_Set;
 	pointer.SetNull = wf_Pointer_SetNull;
 	pointer.SetDefault = wf_Pointer_SetDefault;
+	pointer.SetPosition = wf_Pointer_SetPosition;
 	graphics_register_pointer(graphics, &pointer);
 	return TRUE;
 }


### PR DESCRIPTION
Crash happens if mouse pointer position changed programmatically.