### PR TITLE
Correcting invocation of OnRemoteClipboardChanged to avoid java.lang.NoSuchMethodError

### DIFF
--- a/client/Android/android_cliprdr.c
+++ b/client/Android/android_cliprdr.c
@@ -436,7 +436,7 @@ static UINT android_cliprdr_server_format_data_response(
 		data = (void*) ClipboardGetData(afc->clipboard, formatId, &size);
 		attached = jni_attach_thread(&env);
 		jdata = jniNewStringUTF(env, data, size);
-		freerdp_callback("OnRemoteClipboardChanged", "(ILjava/lang/String;)V", instance,
+		freerdp_callback("OnRemoteClipboardChanged", "(JLjava/lang/String;)V", (jlong)instance,
 		                 jdata);
 		(*env)->DeleteLocalRef(env, jdata);
 


### PR DESCRIPTION
The first parameter of LibFreeRDP.OnRemoteClipboardChanged() was
changed from int to long, however, the changed method signature was not
reflected in android_cliprdr.c.

As a result, a copy in the remote session would result in the
java.lang.NoSuchMethodError below:

01-08 20:24:16.620  8234  8865 E AndroidRuntime: FATAL EXCEPTION: Thread-11495
01-08 20:24:16.620  8234  8865 E AndroidRuntime: Process: com.iiordanov.aRDP, PID: 8234
01-08 20:24:16.620  8234  8865 E AndroidRuntime: java.lang.NoSuchMethodError: no static method "Lcom/freerdp/freerdpcore/services/LibFreeRDP;.OnRemoteClipboardChanged(ILjava/lang/String;)V"
01-08 20:51:44.737 11025 11439 F libc    : Fatal signal 11 (SIGSEGV), code 1, fault addr 0xa0 in tid 11439 (Thread-6)
01-08 20:53:14.887 11717 11717 E AndroidRuntime: FATAL EXCEPTION: main

This commit fixes the bug.