### PR TITLE
fix: gdi stride default zero initialization

### DIFF
--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -1056,8 +1056,7 @@ static BOOL gdi_init_primary(rdpGdi* gdi, UINT32 stride, UINT32 format,
 	if (format > 0)
 		gdi->dstFormat = format;
 
-	if (stride > 0)
-		gdi->stride = stride;
+	gdi->stride = stride;
 
 	if (!gdi->primary)
 		goto fail_primary;

--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -1056,7 +1056,9 @@ static BOOL gdi_init_primary(rdpGdi* gdi, UINT32 stride, UINT32 format,
 	if (format > 0)
 		gdi->dstFormat = format;
 
-	gdi->stride = stride;
+	if (stride > 0) {
+		gdi->stride = stride;
+	}
 
 	if (!gdi->primary)
 		goto fail_primary;
@@ -1133,6 +1135,18 @@ BOOL gdi_resize_ex(rdpGdi* gdi, UINT32 width, UINT32 height,
 
 	if (gdi->drawing == gdi->primary)
 		gdi->drawing = NULL;
+
+	if (stride == 0) 
+	{
+		if (format == 0) 
+		{
+			stride = width * GetBytesPerPixel(gdi->dstFormat);
+		}
+		else 
+		{
+			stride = width * GetBytesPerPixel(format);	
+		}
+	}
 
 	gdi->width = width;
 	gdi->height = height;


### PR DESCRIPTION
when gdi_init_primary gets called with stride=0 then gdi->stride does not get initialize, this can cause problems as it can be init to a positive random value that will get used.

If set to 0 then gdi_CreateBitmapEx will correctly set it to nw*bpp 