### PR TITLE
windows clipboard fix: cliprdr_send_format_list format name

### DIFF
--- a/client/Windows/wf_cliprdr.c
+++ b/client/Windows/wf_cliprdr.c
@@ -1289,9 +1289,11 @@ static UINT cliprdr_send_format_list(wfClipboard* clipboard)
 
 	for (index = 0; index < numFormats; index++)
 	{
-		GetClipboardFormatNameA(formats[index].formatId, formatName,
-		                        sizeof(formatName));
-		formats[index].formatName = _strdup(formatName);
+		if(GetClipboardFormatNameA(formats[index].formatId, formatName,
+		                        sizeof(formatName)))
+		{
+			formats[index].formatName = _strdup(formatName);
+		}
 	}
 
 	formatList.numFormats = numFormats;


### PR DESCRIPTION
sometimes (depending on the formatID) wf_cliprdr_server_format_list_response is throwing errors due to the response from the server when sending cliprdr_send_format_list from the client. 

If the clipboard formatId does not have a formatName the whole empty char array is sent. Just validate that the return from GetClipboardFormatNameA, if not send it null.

This fixes the clipboard on windows as the server was not requesting wf_cliprdr_server_format_data_request fue to bad formatlist.