### PR TITLE
ClearCodec fix #3642

### DIFF
--- a/libfreerdp/codec/clear.c
+++ b/libfreerdp/codec/clear.c
@@ -1197,8 +1197,6 @@ BOOL clear_context_reset(CLEAR_CONTEXT* clear)
 		return FALSE;
 
 	clear->seqNumber = 0;
-	clear->VBarStorageCursor = 0;
-	clear->ShortVBarStorageCursor = 0;
 	return TRUE;
 }
 CLEAR_CONTEXT* clear_context_new(BOOL Compressor)


### PR DESCRIPTION
The V-Bar Storage must not be reset on graphics reset.
If it is, the decoding process will abort with an error, see mentioned issue #3642 for details.