### PR TITLE
trivial issue found by cppcheck:

### DIFF
--- a/uwac/libuwac/uwac-display.c
+++ b/uwac/libuwac/uwac-display.c
@@ -70,6 +70,7 @@ bool uwac_default_error_handler(UwacDisplay* display, UwacReturnCode code, const
 	va_list args;
 	va_start(args, msg);
 	vfprintf(stderr, "%s", args);
+	va_end(args);
 	return false;
 }
 


### PR DESCRIPTION
[uwac/libuwac/uwac-display.c:73]: (error) va_list 'args' was opened but not closed by va_end().