### PR TITLE
make cppcheck a bit happier

### DIFF
--- a/channels/printer/client/printer_cups.c
+++ b/channels/printer/client/printer_cups.c
@@ -100,6 +100,7 @@ static UINT printer_cups_write_printjob(rdpPrintJob* printjob, BYTE* data, int s
 
 		if (fwrite(data, 1, size, fp) < size)
 		{
+			fclose(fp);
 			return ERROR_INTERNAL_ERROR;
 			// FIXME once this function doesn't return void anymore!
 		}

--- a/server/Mac/mf_event.c
+++ b/server/Mac/mf_event.c
@@ -192,7 +192,10 @@ mfEventQueue* mf_event_queue_new()
 		event_queue->events = (mfEvent**) malloc(sizeof(mfEvent*) * event_queue->size);
 		
 		if (pipe(event_queue->pipe_fd) < 0)
+		{
+			free(event_queue);
 			return NULL;
+		}
 		
 		pthread_mutex_init(&(event_queue->mutex), NULL);
 	}

--- a/server/shadow/shadow_capture.c
+++ b/server/shadow/shadow_capture.c
@@ -230,7 +230,10 @@ rdpShadowCapture* shadow_capture_new(rdpShadowServer* server)
 	capture->server = server;
 
 	if (!InitializeCriticalSectionAndSpinCount(&(capture->lock), 4000))
+	{
+		free(capture);
 		return NULL;
+	}
 
 	return capture;
 }

--- a/winpr/libwinpr/sspi/test/TestSchannel.c
+++ b/winpr/libwinpr/sspi/test/TestSchannel.c
@@ -437,6 +437,7 @@ static void* schannel_test_server_thread(void* arg)
 	if (!(lpTokenOut = (BYTE*) malloc(cbMaxToken)))
 	{
 		printf("Memory allocation failed\n");
+		free(lpTokenIn);
 		return NULL;
 	}
 	fContextReq = ASC_REQ_STREAM |

--- a/winpr/libwinpr/thread/argv.c
+++ b/winpr/libwinpr/thread/argv.c
@@ -195,7 +195,10 @@ LPSTR* CommandLineToArgvA(LPCSTR lpCmdLine, int* pNumArgs)
 	buffer = (char*) HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, maxBufferSize);
 
 	if (!buffer)
+	{
+		free(lpEscapedChars);
 		return NULL;
+	}
 
 	pArgs = (LPSTR*) buffer;
 	pOutput = (char*) &buffer[maxNumArgs * (sizeof(char*))];

--- a/winpr/libwinpr/utils/sam.c
+++ b/winpr/libwinpr/utils/sam.c
@@ -309,7 +309,10 @@ WINPR_SAM_ENTRY* SamLookupUserW(WINPR_SAM* sam, LPWSTR User, UINT32 UserLength, 
 		return NULL;
 
 	if (!SamLookupStart(sam))
+	{
+		free(entry);
 		return NULL;
+	}
 
 	while (sam->line != NULL)
 	{


### PR DESCRIPTION
[channels/printer/client/printer_cups.c:103]: (error) Resource leak: fp
[server/Mac/mf_event.c:195]: (error) Memory leak: event_queue
[server/shadow/shadow_capture.c:233]: (error) Memory leak: capture
[winpr/libwinpr/sspi/test/TestSchannel.c:440]: (error) Memory leak: lpTokenIn
[winpr/libwinpr/thread/argv.c:198]: (error) Memory leak: lpEscapedChars
[winpr/libwinpr/utils/sam.c:312]: (error) Memory leak: entry