### PR TITLE
make cppcheck even more happier

### DIFF
--- a/channels/tsmf/client/gstreamer/tsmf_X11.c
+++ b/channels/tsmf/client/gstreamer/tsmf_X11.c
@@ -314,13 +314,13 @@ int tsmf_window_resize(TSMFGstreamerDecoder* decoder, int x, int y, int width,
 {
 	struct X11Handle* hdl;
 
+	if (!decoder)
+		return -1;
+
 	if (decoder->media_type != TSMF_MAJOR_TYPE_VIDEO)
 	{
 		return -3;
 	}
-
-	if (!decoder)
-		return -1;
 
 	if (!decoder->platform)
 		return -1;
@@ -469,11 +469,11 @@ int tsmf_window_destroy(TSMFGstreamerDecoder* decoder)
 	struct X11Handle* hdl;
 	decoder->ready = FALSE;
 
-	if (decoder->media_type != TSMF_MAJOR_TYPE_VIDEO)
-		return -3;
-
 	if (!decoder)
 		return -1;
+
+	if (decoder->media_type != TSMF_MAJOR_TYPE_VIDEO)
+		return -3;
 
 	if (!decoder->platform)
 		return -1;

--- a/channels/tsmf/client/tsmf_media.c
+++ b/channels/tsmf/client/tsmf_media.c
@@ -176,10 +176,12 @@ static TSMF_SAMPLE* tsmf_stream_pop_sample(TSMF_STREAM* stream, int sync)
 	TSMF_STREAM* s;
 	TSMF_SAMPLE* sample;
 	BOOL pending = FALSE;
-	TSMF_PRESENTATION* presentation = stream->presentation;
+	TSMF_PRESENTATION* presentation = NULL;
 
 	if (!stream)
 		return NULL;
+
+	presentation = stream->presentation;
 
 	if (Queue_Count(stream->sample_list) < 1)
 		return NULL;

--- a/client/Windows/wf_cliprdr.c
+++ b/client/Windows/wf_cliprdr.c
@@ -2216,11 +2216,11 @@ static UINT wf_cliprdr_server_format_data_response(CliprdrClientContext*
 	HANDLE hMem;
 	wfClipboard* clipboard;
 
-	if (formatDataResponse->msgFlags != CB_RESPONSE_OK)
-		return E_FAIL;
-
 	if (!context || !formatDataResponse)
 		return ERROR_INTERNAL_ERROR;
+
+	if (formatDataResponse->msgFlags != CB_RESPONSE_OK)
+		return E_FAIL;
 
 	clipboard = (wfClipboard*) context->custom;
 
@@ -2442,11 +2442,11 @@ static UINT wf_cliprdr_server_file_contents_response(CliprdrClientContext*
 {
 	wfClipboard* clipboard;
 
-	if (fileContentsResponse->msgFlags != CB_RESPONSE_OK)
-		return E_FAIL;
-
 	if (!context || !fileContentsResponse)
 		return ERROR_INTERNAL_ERROR;
+
+	if (fileContentsResponse->msgFlags != CB_RESPONSE_OK)
+		return E_FAIL;
 
 	clipboard = (wfClipboard*) context->custom;
 

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -908,10 +908,12 @@ static BOOL xf_cliprdr_process_property_notify(xfClipboard* clipboard,
         XEvent* xevent)
 {
 	xfCliprdrFormat* format;
-	xfContext* xfc = clipboard->xfc;
+	xfContext* xfc = NULL;
 
 	if (!clipboard)
 		return TRUE;
+
+	xfc = clipboard->xfc;
 
 	if (xevent->xproperty.atom != clipboard->property_atom)
 		return FALSE; /* Not cliprdr-related */

--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -501,10 +501,12 @@ BOOL xf_register_graphics(rdpGraphics* graphics)
 UINT32 xf_get_local_color_format(xfContext* xfc, BOOL aligned)
 {
 	UINT32 DstFormat;
-	BOOL invert = xfc->invert;
+	BOOL invert = FALSE;
 
 	if (!xfc)
 		return 0;
+
+	invert = xfc->invert;
 
 	if (xfc->depth == 32)
 		DstFormat = (!invert) ? PIXEL_FORMAT_RGBA32 : PIXEL_FORMAT_BGRA32;

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -858,10 +858,12 @@ int transport_check_fds(rdpTransport* transport)
 	int recv_status;
 	wStream* received;
 	DWORD now = GetTickCount();
-	DWORD dueDate = now + transport->settings->MaxTimeInCheckLoop;
+	DWORD dueDate = 0;
 
 	if (!transport)
 		return -1;
+
+	dueDate = now + transport->settings->MaxTimeInCheckLoop;
 
 	if (transport->haveMoreBytesToRead)
 	{

--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -788,9 +788,6 @@ rdpShadowServer* shadow_server_new()
 
 	server->settings = freerdp_settings_new(FREERDP_SETTINGS_SERVER_MODE);
 
-	if (!server)
-		return NULL;
-
 	return server;
 }
 


### PR DESCRIPTION
[channels/tsmf/client/gstreamer/tsmf_X11.c:317] -> [channels/tsmf/client/gstreamer/tsmf_X11.c:322]: (warning) Either the condition '!decoder' is redundant or there is possible null pointer dereference: decoder.
[channels/tsmf/client/gstreamer/tsmf_X11.c:470] -> [channels/tsmf/client/gstreamer/tsmf_X11.c:475]: (warning) Either the condition '!decoder' is redundant or there is possible null pointer dereference: decoder.
[channels/tsmf/client/gstreamer/tsmf_X11.c:472] -> [channels/tsmf/client/gstreamer/tsmf_X11.c:475]: (warning) Either the condition '!decoder' is redundant or there is possible null pointer dereference: decoder.
[channels/tsmf/client/tsmf_media.c:179] -> [channels/tsmf/client/tsmf_media.c:181]: (warning) Either the condition '!stream' is redundant or there is possible null pointer dereference: stream.
[client/Windows/wf_cliprdr.c:2219] -> [client/Windows/wf_cliprdr.c:2222]: (warning) Either the condition '!formatDataResponse' is redundant or there is possible null pointer dereference: formatDataResponse
[client/Windows/wf_cliprdr.c:2445] -> [client/Windows/wf_cliprdr.c:2448]: (warning) Either the condition '!fileContentsResponse' is redundant or there is possible null pointer dereference: fileContentsResponse.
[client/X11/xf_cliprdr.c:911] -> [client/X11/xf_cliprdr.c:913]: (warning) Either the condition '!clipboard' is redundant or there is possible null pointer dereference: clipboard.
[client/X11/xf_graphics.c:504] -> [client/X11/xf_graphics.c:506]: (warning) Either the condition '!xfc' is redundant or there is possible null pointer dereference: xfc.
[libfreerdp/core/transport.c:861] -> [libfreerdp/core/transport.c:863]: (warning) Either the condition '!transport' is redundant or there is possible null pointer dereference: transport.
[server/shadow/shadow_server.c:777] -> [server/shadow/shadow_server.c:791]: (warning) Either the condition '!server' is redundant or there is possible null pointer dereference: server.
[server/shadow/shadow_server.c:778] -> [server/shadow/shadow_server.c:791]: (warning) Either the condition '!server' is redundant or there is possible null pointer dereference: server.
[server/shadow/shadow_server.c:779] -> [server/shadow/shadow_server.c:791]: (warning) Either the condition '!server' is redundant or there is possible null pointer dereference: server.
[server/shadow/shadow_server.c:781] -> [server/shadow/shadow_server.c:791]: (warning) Either the condition '!server' is redundant or there is possible null pointer dereference: server.
[server/shadow/shadow_server.c:782] -> [server/shadow/shadow_server.c:791]: (warning) Either the condition '!server' is redundant or there is possible null pointer dereference: server.
[server/shadow/shadow_server.c:783] -> [server/shadow/shadow_server.c:791]: (warning) Either the condition '!server' is redundant or there is possible null pointer dereference: server.
[server/shadow/shadow_server.c:784] -> [server/shadow/shadow_server.c:791]: (warning) Either the condition '!server' is redundant or there is possible null pointer dereference: server.
[server/shadow/shadow_server.c:785] -> [server/shadow/shadow_server.c:791]: (warning) Either the condition '!server' is redundant or there is possible null pointer dereference: server.
[server/shadow/shadow_server.c:787] -> [server/shadow/shadow_server.c:791]: (warning) Either the condition '!server' is redundant or there is possible null pointer dereference: server.
[server/shadow/shadow_server.c:789] -> [server/shadow/shadow_server.c:791]: (warning) Either the condition '!server' is redundant or there is possible null pointer dereference: server.