### PR TITLE
remove redundant assignment

### DIFF
--- a/client/Windows/wf_cliprdr.c
+++ b/client/Windows/wf_cliprdr.c
@@ -572,7 +572,7 @@ static HRESULT STDMETHODCALLTYPE CliprdrDataObject_GetData(
 	if (!pFormatEtc || !pMedium || !instance)
 		return E_INVALIDARG;
 
-	clipboard = clipboard = (wfClipboard*) instance->m_pData;
+	clipboard = (wfClipboard*) instance->m_pData;
 
 	if (!clipboard)
 		return E_INVALIDARG;


### PR DESCRIPTION
[client/Windows/wf_cliprdr.c:575]: (warning) Redundant assignment of 'clipboard' to itself.