### PR TITLE
Resolve issues detected by cppcheck

### DIFF
--- a/channels/urbdrc/client/data_transfer.c
+++ b/channels/urbdrc/client/data_transfer.c
@@ -2319,12 +2319,9 @@ void* urbdrc_process_udev_data_transfer(void* arg)
 	pdev = udevman->get_udevice_by_UsbDevice(udevman, UsbDevice);
 	if (pdev == NULL || pdev->isSigToEnd(pdev))
 	{
-		if (transfer_data)
-		{
-			if (transfer_data->pBuffer)
-				zfree(transfer_data->pBuffer);
-			zfree(transfer_data);
-		}
+		if (transfer_data->pBuffer)
+			zfree(transfer_data->pBuffer);
+		zfree(transfer_data);
 		return 0;
 	}
 

--- a/channels/urbdrc/client/isoch_queue.c
+++ b/channels/urbdrc/client/isoch_queue.c
@@ -120,11 +120,13 @@ static int isoch_queue_unregister_data(ISOCH_CALLBACK_QUEUE* queue, ISOCH_CALLBA
 		}
 		queue->isoch_num--;
 
-		/* free data info */
-		isoch->out_data = NULL;
-
 		if (isoch)
+		{
+			/* free data info */
+			isoch->out_data = NULL;
+
 			zfree(isoch);
+		}
 
 		return 1; /* unregistration successful */
 	}

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -217,12 +217,9 @@ void xf_rail_invalidate_region(xfContext* xfc, REGION16* invalidRegion)
 				updateRect.right = extents->right - appWindow->x;
 				updateRect.bottom = extents->bottom - appWindow->y;
 
-				if (appWindow)
-				{
-					xf_UpdateWindowArea(xfc, appWindow, updateRect.left, updateRect.top,
-					                    updateRect.right - updateRect.left,
-					                    updateRect.bottom - updateRect.top);
-				}
+				xf_UpdateWindowArea(xfc, appWindow, updateRect.left, updateRect.top,
+				                    updateRect.right - updateRect.left,
+				                    updateRect.bottom - updateRect.top);
 			}
 		}
 	}

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -945,6 +945,10 @@ void xf_UpdateWindowArea(xfContext* xfc, xfAppWindow* appWindow, int x, int y,
                          int width, int height)
 {
 	int ax, ay;
+
+        if (appWindow == NULL)
+		return;
+
 	ax = x + appWindow->windowOffsetX;
 	ay = y + appWindow->windowOffsetY;
 


### PR DESCRIPTION
[client/X11/xf_rail.c:205] -> [client/X11/xf_rail.c:220]: (warning) Either the condition 'if(appWindow)' is redundant or there is possible null pointer dereference: appWindow.
[client/X11/xf_rail.c:206] -> [client/X11/xf_rail.c:220]: (warning) Either the condition 'if(appWindow)' is redundant or there is possible null pointer dereference: appWindow.
[client/X11/xf_rail.c:207] -> [client/X11/xf_rail.c:220]: (warning) Either the condition 'if(appWindow)' is redundant or there is possible null pointer dereference: appWindow.
[client/X11/xf_rail.c:208] -> [client/X11/xf_rail.c:220]: (warning) Either the condition 'if(appWindow)' is redundant or there is possible null pointer dereference: appWindow.
[client/X11/xf_rail.c:215] -> [client/X11/xf_rail.c:220]: (warning) Either the condition 'if(appWindow)' is redundant or there is possible null pointer dereference: appWindow.
[client/X11/xf_rail.c:216] -> [client/X11/xf_rail.c:220]: (warning) Either the condition 'if(appWindow)' is redundant or there is possible null pointer dereference: appWindow.
[client/X11/xf_rail.c:217] -> [client/X11/xf_rail.c:220]: (warning) Either the condition 'if(appWindow)' is redundant or there is possible null pointer dereference: appWindow.
[client/X11/xf_rail.c:218] -> [client/X11/xf_rail.c:220]: (warning) Either the condition 'if(appWindow)' is redundant or there is possible null pointer dereference: appWindow.