### PR TITLE
Flush stdout when asking about certificate

### DIFF
--- a/client/common/client.c
+++ b/client/common/client.c
@@ -441,6 +441,7 @@ static DWORD client_cli_accept_certificate(rdpSettings* settings)
 	while (1)
 	{
 		printf("Do you trust the above certificate? (Y/T/N) ");
+		fflush(stdout);
 		answer = fgetc(stdin);
 
 		if (feof(stdin))


### PR DESCRIPTION
Flush stdout when asking for certificate verification.  Without flushing before prompting for input, freerdp will not display the question when trying to automate with QProcess (or possibly something else similar) because in this case, `QProcess::readyReadStandardOutput()` will never be triggered.