### PR TITLE
primitives: added SSSE3 rgb to yuv420 encoder

### DIFF
--- a/libfreerdp/primitives/prim_YUV.c
+++ b/libfreerdp/primitives/prim_YUV.c
@@ -1,7 +1,11 @@
 /**
  * FreeRDP: A Remote Desktop Protocol Implementation
+ * Generic YUV/RGB conversion operations
  *
  * Copyright 2014 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+ * Copyright 2015-2017 Armin Novak <armin.novak@thincast.com>
+ * Copyright 2015-2017 Vic Lee
+ * Copyright 2015-2017 Thincast Technologies GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libfreerdp/primitives/prim_internal.h
+++ b/libfreerdp/primitives/prim_internal.h
@@ -28,6 +28,15 @@
 #include <freerdp/primitives.h>
 #include <freerdp/api.h>
 
+
+#ifdef __GNUC__
+#define PRIM_ALIGN_128 __attribute__((aligned(16)))
+#else
+#ifdef _WIN32
+#define PRIM_ALIGN_128 __declspec(align(16))
+#endif
+#endif
+
 /* Use lddqu for unaligned; load for 16-byte aligned. */
 #define LOAD_SI128(_ptr_) \
 	(((ULONG_PTR) (_ptr_) & 0x0f) \

--- a/libfreerdp/primitives/test/TestPrimitivesYUV.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYUV.c
@@ -83,8 +83,8 @@ static void get_size(UINT32* width, UINT32* height)
 	winpr_RAND((BYTE*)width, sizeof(*width));
 	winpr_RAND((BYTE*)height, sizeof(*height));
 	// TODO: Algorithm only works on even resolutions...
-	*width = (*width % 64) << 1;
-	*height = (*height % 64 << 1);
+	*width = (*width % 64 + 1) << 1;
+	*height = (*height % 64 + 1) << 1;
 }
 
 static BOOL check_padding(const BYTE* psrc, size_t size, size_t padding,
@@ -567,14 +567,20 @@ int TestPrimitivesYUV(int argc, char* argv[])
 
 	for (x = 0; x < 10; x++)
 	{
-		if (!TestPrimitiveYUV(TRUE))
+		if (!TestPrimitiveYUV(TRUE)) {
+			printf("TestPrimitiveYUV (444) failed.\n");
 			goto end;
+		}
 
-		if (!TestPrimitiveYUV(FALSE))
+		if (!TestPrimitiveYUV(FALSE)) {
+			printf("TestPrimitiveYUV (420) failed.\n");
 			goto end;
+		}
 
-		if (!TestPrimitiveYUVCombine())
+		if (!TestPrimitiveYUVCombine()) {
+			printf("TestPrimitiveYUVCombine failed.\n");
 			goto end;
+		}
 	}
 
 	rc = 0;


### PR DESCRIPTION
Currently supported source pixel formats are:
- PIXEL_FORMAT_BGRA32
- PIXEL_FORMAT_BGRX32

Support for PIXEL_FORMAT_RGB[XA]32 can simply be added if required (see the comment in prim_YUV_opt.c).

On my old 3.1 GHz Core i5-2400 the new SSSE3 function can convert over 900 1080p BGRX frames per second.

The current non-optimized C version (which supports all pixel formats) can't do more than 40 yuv conversions per second on this cpu.

```
---------------------------+---------+-------------+-----------+-------
RGB TO YUV420 1080p 32bit  |   COUNT |       TOTAL |       AVG |    FPS
---------------------------+---------+-------------+-----------+-------
general_RGBToYUV420        |     500 |    13.1776s | 0.026355s |     38
ssse3_RGBToYUV420          |     500 |     0.5320s | 0.001064s |    940
```

Also fixed an error in TestPrimitivesYUV which generated resolutions with height or width set to zero.