### PR TITLE
Add command line option to override action script path

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -97,7 +97,7 @@ BOOL xf_event_action_script_init(xfContext* xfc)
 		return FALSE;
 
 	ArrayList_Object(xfc->xevents)->fnObjectFree = free;
-	sprintf_s(command, sizeof(command), "%s xevent", xfc->actionScript);
+	sprintf_s(command, sizeof(command), "%s xevent", xfc->context.settings->ActionScript);
 	actionScript = popen(command, "r");
 
 	if (!actionScript)
@@ -140,7 +140,7 @@ static BOOL xf_event_execute_action_script(xfContext* xfc, XEvent* event)
 	char buffer[1024] = { 0 };
 	char command[1024] = { 0 };
 
-	if (!xfc->actionScript || !xfc->xevents)
+	if (!xfc->actionScriptExists || !xfc->xevents)
 		return FALSE;
 
 	if (event->type > (sizeof(X11_EVENT_STRINGS) / sizeof(const char*)))
@@ -164,7 +164,7 @@ static BOOL xf_event_execute_action_script(xfContext* xfc, XEvent* event)
 		return FALSE;
 
 	sprintf_s(command, sizeof(command), "%s xevent %s %lu",
-	          xfc->actionScript, xeventName, (unsigned long) xfc->window->handle);
+	          xfc->context.settings->ActionScript, xeventName, (unsigned long) xfc->window->handle);
 	actionScript = popen(command, "r");
 
 	if (!actionScript)

--- a/client/X11/xf_keyboard.h
+++ b/client/X11/xf_keyboard.h
@@ -25,8 +25,6 @@
 #include "xf_client.h"
 #include "xfreerdp.h"
 
-#define XF_ACTION_SCRIPT "~/.config/freerdp/action.sh"
-
 struct _XF_MODIFIER_KEYS
 {
 	BOOL Shift;

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -171,7 +171,7 @@ struct xf_context
 	XModifierKeymap* modifierMap;
 	wArrayList* keyCombinations;
 	wArrayList* xevents;
-	char* actionScript;
+	BOOL actionScriptExists;
 
 	XSetWindowAttributes attribs;
 	BOOL complex_regions;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -187,6 +187,7 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "scale", COMMAND_LINE_VALUE_REQUIRED, "<scale amount (%%)>", "100", NULL, -1, NULL, "Scaling factor of the display (value of 100, 140, or 180)" },
 	{ "scale-desktop", COMMAND_LINE_VALUE_REQUIRED, "<scale amount (%%)>", "100", NULL, -1, NULL, "Scaling factor for desktop applications (value between 100 and 500)" },
 	{ "scale-device", COMMAND_LINE_VALUE_REQUIRED, "<scale amount (%%)>", "100", NULL, -1, NULL, "Scaling factor for app store applications (100, 140, or 180)" },
+	{ "action-script", COMMAND_LINE_VALUE_REQUIRED, "<file name>", "/usr/share/freerdp/action.sh", NULL, -1, NULL, "Action script" },
 	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
 };
 
@@ -2505,6 +2506,12 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 				WLog_ERR(TAG, "scale:  invalid device scale factor (%d)", deviceScaleFactor);
 				return COMMAND_LINE_ERROR;
 			}
+		}
+		CommandLineSwitchCase(arg, "action-script")
+		{
+			free (settings->ActionScript);
+			if (!(settings->ActionScript = _strdup(arg->Value)))
+				return COMMAND_LINE_ERROR_MEMORY;
 		}
 		CommandLineSwitchDefault(arg)
 		{

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -187,7 +187,7 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "scale", COMMAND_LINE_VALUE_REQUIRED, "<scale amount (%%)>", "100", NULL, -1, NULL, "Scaling factor of the display (value of 100, 140, or 180)" },
 	{ "scale-desktop", COMMAND_LINE_VALUE_REQUIRED, "<scale amount (%%)>", "100", NULL, -1, NULL, "Scaling factor for desktop applications (value between 100 and 500)" },
 	{ "scale-device", COMMAND_LINE_VALUE_REQUIRED, "<scale amount (%%)>", "100", NULL, -1, NULL, "Scaling factor for app store applications (100, 140, or 180)" },
-	{ "action-script", COMMAND_LINE_VALUE_REQUIRED, "<file name>", "/usr/share/freerdp/action.sh", NULL, -1, NULL, "Action script" },
+	{ "action-script", COMMAND_LINE_VALUE_REQUIRED, "<file name>", "~/.config/freerdp/action.sh", NULL, -1, NULL, "Action script" },
 	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
 };
 

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -1434,6 +1434,7 @@ struct rdp_settings
 
 	ALIGN64 BYTE*
 	SettingsModified; /* byte array marking fields that have been modified from their default value */
+	ALIGN64 char* ActionScript;
 };
 typedef struct rdp_settings rdpSettings;
 

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -591,6 +591,8 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	if (!settings->SettingsModified)
 		goto out_fail;
 
+	settings->ActionScript = _strdup("~/.config/freerdp/action.sh");
+
 	return settings;
 out_fail:
 	free(settings->HomePath);

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -680,6 +680,7 @@ rdpSettings* freerdp_settings_clone(rdpSettings* settings)
 		CHECKED_STRDUP(RemoteApplicationCmdLine); /* 2118 */
 		CHECKED_STRDUP(ImeFileName); /* 2628 */
 		CHECKED_STRDUP(DrivesToRedirect); /* 4290 */
+		CHECKED_STRDUP(ActionScript);
 		/**
 		  * Manual Code
 		  */
@@ -1080,6 +1081,7 @@ void freerdp_settings_free(rdpSettings* settings)
 	free(settings->DrivesToRedirect);
 	free(settings->WindowTitle);
 	free(settings->WmClass);
+	free(settings->ActionScript);
 	freerdp_target_net_addresses_free(settings);
 	freerdp_device_collection_free(settings);
 	freerdp_static_channel_collection_free(settings);


### PR DESCRIPTION
It makes ```"/usr/share/freerdp/action.sh"``` overridable with ```/action-script:<filename>``` command line switch
Fix for #3744 