### PR TITLE
NEON and SSSE3 decoder optimisations

### DIFF
--- a/libfreerdp/codec/clear.c
+++ b/libfreerdp/codec/clear.c
@@ -103,35 +103,14 @@ static BOOL convert_color(BYTE* dst, UINT32 nDstStep, UINT32 DstFormat,
                           const BYTE* src, UINT32 nSrcStep, UINT32 SrcFormat,
                           UINT32 nDstWidth, UINT32 nDstHeight, const gdiPalette* palette)
 {
-	UINT32 x, y;
-
 	if (nWidth + nXDst > nDstWidth)
 		nWidth = nDstWidth - nXDst;
 
 	if (nHeight + nYDst > nDstHeight)
 		nHeight = nDstHeight - nYDst;
 
-	for (y = 0; y < nHeight; y++)
-	{
-		const BYTE* pSrcLine = &src[y * nSrcStep];
-		BYTE* pDstLine = &dst[(nYDst + y) * nDstStep];
-
-		for (x = 0; x < nWidth; x++)
-		{
-			const BYTE* pSrcPixel =
-			    &pSrcLine[x * GetBytesPerPixel(SrcFormat)];
-			BYTE* pDstPixel =
-			    &pDstLine[(nXDst + x) * GetBytesPerPixel(DstFormat)];
-			UINT32 color = ReadColor(pSrcPixel, SrcFormat);
-			color = ConvertColor(color, SrcFormat,
-			                     DstFormat, palette);
-
-			if (!WriteColor(pDstPixel, DstFormat, color))
-				return FALSE;
-		}
-	}
-
-	return TRUE;
+	return freerdp_image_copy(dst, DstFormat, nDstStep, nXDst, nYDst, nWidth, nHeight,
+	                          src, SrcFormat, nSrcStep, 0, 0, palette, 0);
 }
 
 static BOOL clear_decompress_nscodec(NSC_CONTEXT* nsc, UINT32 width,

--- a/libfreerdp/primitives/prim_YCoCg_opt.c
+++ b/libfreerdp/primitives/prim_YCoCg_opt.c
@@ -435,6 +435,134 @@ static pstatus_t ssse3_YCoCgRToRGB_8u_AC4R(
 			                                   dstStep, width, height, shift, withAlpha);
 	}
 }
+#elif defined(WITH_NEON)
+
+static pstatus_t neon_YCoCgToRGB_8u_X(
+    const BYTE* pSrc, INT32 srcStep,
+    BYTE* pDst, UINT32 DstFormat, INT32 dstStep,
+    UINT32 width, UINT32 height,
+    UINT8 shift, BYTE rPos, BYTE gPos, BYTE bPos, BYTE aPos, BOOL alpha)
+{
+	UINT32 y;
+	BYTE* dptr = pDst;
+	const BYTE* sptr = pSrc;
+	const DWORD formatSize = GetBytesPerPixel(DstFormat);
+	const int8_t cll = shift - 1;  /* -1 builds in the /2's */
+	const UINT32 srcPad = srcStep - (width * 4);
+	const UINT32 dstPad = dstStep - (width * formatSize);
+	const UINT32 pad = width % 8;
+	const uint8x8_t aVal = vdup_n_u8(0xFF);
+	const int8x8_t cllv = vdup_n_s8(cll);
+
+	for (y = 0; y < height; y++)
+	{
+		UINT32 x;
+
+		for (x = 0; x < width - pad; x += 8)
+		{
+			/* Note: shifts must be done before sign-conversion. */
+			const uint8x8x4_t raw = vld4_u8(sptr);
+			const int8x8_t CgRaw = vreinterpret_s8_u8(vshl_u8(raw.val[0], cllv));
+			const int8x8_t CoRaw = vreinterpret_s8_u8(vshl_u8(raw.val[1], cllv));
+			const int16x8_t Cg = vmovl_s8(CgRaw);
+			const int16x8_t Co = vmovl_s8(CoRaw);
+			const int16x8_t Y = vreinterpretq_s16_u16(vmovl_u8(raw.val[2]));	/* UINT8 -> INT16 */
+			const int16x8_t T  = vsubq_s16(Y, Cg);
+			const int16x8_t R  = vaddq_s16(T, Co);
+			const int16x8_t G  = vaddq_s16(Y, Cg);
+			const int16x8_t B  = vsubq_s16(T, Co);
+			uint8x8x4_t bgrx;
+			bgrx.val[bPos] = vqmovun_s16(B);
+			bgrx.val[gPos] = vqmovun_s16(G);
+			bgrx.val[rPos] = vqmovun_s16(R);
+
+			if (alpha)
+				bgrx.val[aPos] = raw.val[3];
+			else
+				bgrx.val[aPos] = aVal;
+
+			vst4_u8(dptr, bgrx);
+			sptr += sizeof(raw);
+			dptr += sizeof(bgrx);
+		}
+
+		for (x = 0; x < pad; x++)
+		{
+			/* Note: shifts must be done before sign-conversion. */
+			const INT16 Cg = (INT16)((INT8)((*sptr++) << cll));
+			const INT16 Co = (INT16)((INT8)((*sptr++) << cll));
+			const INT16 Y = (INT16)(*sptr++);	/* UINT8->INT16 */
+			const INT16 T  = Y - Cg;
+			const INT16 R  = T + Co;
+			const INT16 G  = Y + Cg;
+			const INT16 B  = T - Co;
+			BYTE bgra[4];
+			bgra[bPos] = CLIP(B);
+			bgra[gPos] = CLIP(G);
+			bgra[rPos] = CLIP(R);
+			bgra[aPos] = *sptr++;
+
+			if (!alpha)
+				bgra[aPos] = 0xFF;
+
+			*dptr++ = bgra[0];
+			*dptr++ = bgra[1];
+			*dptr++ = bgra[2];
+			*dptr++ = bgra[3];
+		}
+
+		sptr += srcPad;
+		dptr += dstPad;
+	}
+
+	return PRIMITIVES_SUCCESS;
+}
+static pstatus_t neon_YCoCgToRGB_8u_AC4R(
+    const BYTE* pSrc, INT32 srcStep,
+    BYTE* pDst, UINT32 DstFormat, INT32 dstStep,
+    UINT32 width, UINT32 height,
+    UINT8 shift,
+    BOOL withAlpha)
+{
+	switch (DstFormat)
+	{
+		case PIXEL_FORMAT_BGRA32:
+			return neon_YCoCgToRGB_8u_X(pSrc, srcStep, pDst, DstFormat, dstStep, width, height, shift, 2, 1, 0,
+			                            3, withAlpha);
+
+		case PIXEL_FORMAT_BGRX32:
+			return neon_YCoCgToRGB_8u_X(pSrc, srcStep, pDst, DstFormat, dstStep, width, height, shift, 2, 1, 0,
+			                            3, withAlpha);
+
+		case PIXEL_FORMAT_RGBA32:
+			return neon_YCoCgToRGB_8u_X(pSrc, srcStep, pDst, DstFormat, dstStep, width, height, shift, 0, 1, 2,
+			                            3, withAlpha);
+
+		case PIXEL_FORMAT_RGBX32:
+			return neon_YCoCgToRGB_8u_X(pSrc, srcStep, pDst, DstFormat, dstStep, width, height, shift, 0, 1, 2,
+			                            3, withAlpha);
+
+		case PIXEL_FORMAT_ARGB32:
+			return neon_YCoCgToRGB_8u_X(pSrc, srcStep, pDst, DstFormat, dstStep, width, height, shift, 1, 2, 3,
+			                            0, withAlpha);
+
+		case PIXEL_FORMAT_XRGB32:
+			return neon_YCoCgToRGB_8u_X(pSrc, srcStep, pDst, DstFormat, dstStep, width, height, shift, 1, 2, 3,
+			                            0, withAlpha);
+
+		case PIXEL_FORMAT_ABGR32:
+			return neon_YCoCgToRGB_8u_X(pSrc, srcStep, pDst, DstFormat, dstStep, width, height, shift, 3, 2, 1,
+			                            0, withAlpha);
+
+		case PIXEL_FORMAT_XBGR32:
+			return neon_YCoCgToRGB_8u_X(pSrc, srcStep, pDst, DstFormat, dstStep, width, height, shift, 3, 2, 1,
+			                            0, withAlpha);
+
+		default:
+			return generic->YCoCgToRGB_8u_AC4R(pSrc, srcStep, pDst, DstFormat, dstStep, width, height, shift,
+			                                   withAlpha);
+	}
+}
 #endif /* WITH_SSE2 */
 
 /* ------------------------------------------------------------------------- */
@@ -452,6 +580,13 @@ void primitives_init_YCoCg_opt(primitives_t* prims)
 	    && IsProcessorFeaturePresent(PF_SSE3_INSTRUCTIONS_AVAILABLE))
 	{
 		prims->YCoCgToRGB_8u_AC4R = ssse3_YCoCgRToRGB_8u_AC4R;
+	}
+
+#elif defined(WITH_NEON)
+
+	if (IsProcessorFeaturePresent(PF_ARM_NEON_INSTRUCTIONS_AVAILABLE))
+	{
+		prims->YCoCgToRGB_8u_AC4R = neon_YCoCgToRGB_8u_AC4R;
 	}
 
 #endif /* WITH_SSE2 */

--- a/libfreerdp/primitives/prim_YUV.c
+++ b/libfreerdp/primitives/prim_YUV.c
@@ -280,47 +280,6 @@ static pstatus_t general_YUV444SplitToYUV420(
 	return PRIMITIVES_SUCCESS;
 }
 
-/**
- * | R |   ( | 256     0    403 | |    Y    | )
- * | G | = ( | 256   -48   -120 | | U - 128 | ) >> 8
- * | B |   ( | 256   475      0 | | V - 128 | )
- */
-static INLINE INT32 C(INT32 Y)
-{
-	return (Y) -   0L;
-}
-
-static INLINE INT32 D(INT32 U)
-{
-	return (U) - 128L;
-}
-
-static INLINE INT32 E(INT32 V)
-{
-	return (V) - 128L;
-}
-
-static INLINE BYTE YUV2R(INT32 Y, INT32 U, INT32 V)
-{
-	const INT32 r = (256L * C(Y) +   0L * D(U) + 403L * E(V));
-	const INT32 r8 = r >> 8L;
-	return CLIP(r8);
-}
-
-static INLINE BYTE YUV2G(INT32 Y, INT32 U, INT32 V)
-{
-	const INT32 g = (256L * C(Y) -  48L * D(U) - 120L * E(V));
-	const INT32 g8 = g >> 8L;
-	return CLIP(g8);
-}
-
-static INLINE BYTE YUV2B(INT32 Y, INT32 U, INT32 V)
-{
-	const INT32 b = (256L * C(Y) + 475L * D(U) +   0L * E(V));
-	const INT32 b8 = b >> 8L;
-	return CLIP(b8);
-}
-
 static pstatus_t general_YUV444ToRGB_8u_P3AC4R_general(
     const BYTE* pSrc[3], const UINT32 srcStep[3],
     BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
@@ -343,8 +302,8 @@ static pstatus_t general_YUV444ToRGB_8u_P3AC4R_general(
 		for (x = 0; x < nWidth; x++)
 		{
 			const BYTE Y = pY[x];
-			const INT32 U = pU[x];
-			const INT32 V = pV[x];
+			const BYTE U = pU[x];
+			const BYTE V = pV[x];
 			const BYTE r = YUV2R(Y, U, V);
 			const BYTE g = YUV2G(Y, U, V);
 			const BYTE b = YUV2B(Y, U, V);
@@ -376,8 +335,8 @@ static pstatus_t general_YUV444ToRGB_8u_P3AC4R_BGRX(
 		for (x = 0; x < nWidth; x++)
 		{
 			const BYTE Y = pY[x];
-			const INT32 U = pU[x];
-			const INT32 V = pV[x];
+			const BYTE U = pU[x];
+			const BYTE V = pV[x];
 			const BYTE r = YUV2R(Y, U, V);
 			const BYTE g = YUV2G(Y, U, V);
 			const BYTE b = YUV2B(Y, U, V);
@@ -589,7 +548,7 @@ static INLINE pstatus_t general_RGBToYUV420_BGRX(
     const BYTE* pSrc, UINT32 srcStep,
     BYTE* pDst[3], UINT32 dstStep[3], const prim_size_t* roi)
 {
-	UINT32 x, y, i, j;
+	UINT32 x, y, i;
 	size_t x1 = 0, x2 = 4, x3 = srcStep, x4 = srcStep + 4;
 	size_t y1 = 0, y2 = 1, y3 = dstStep[0], y4 = dstStep[0] + 1;
 	UINT32 max_x = roi->width - 1;
@@ -606,7 +565,6 @@ static INLINE pstatus_t general_RGBToYUV420_BGRX(
 		{
 			BYTE R, G, B;
 			INT32 Ra, Ga, Ba;
-			UINT32 color;
 			/* row 1, pixel 1 */
 			Ba = B = *(src + x1 + 0);
 			Ga = G = *(src + x1 + 1);
@@ -658,7 +616,7 @@ static INLINE pstatus_t general_RGBToYUV420_ANY(
     BYTE* pDst[3], UINT32 dstStep[3], const prim_size_t* roi)
 {
 	const UINT32 bpp = GetBytesPerPixel(srcFormat);
-	UINT32 x, y, i, j;
+	UINT32 x, y, i;
 	size_t x1 = 0, x2 = bpp, x3 = srcStep, x4 = srcStep + bpp;
 	size_t y1 = 0, y2 = 1, y3 = dstStep[0], y4 = dstStep[0] + 1;
 	UINT32 max_x = roi->width - 1;

--- a/libfreerdp/primitives/prim_YUV_opt.c
+++ b/libfreerdp/primitives/prim_YUV_opt.c
@@ -31,22 +31,25 @@
 
 #include "prim_internal.h"
 
-static primitives_t* generic = NULL;
-
 #ifdef WITH_SSE2
 
 #include <emmintrin.h>
 #include <tmmintrin.h>
+#elif defined(WITH_NEON)
+#include <arm_neon.h>
+#endif /* WITH_SSE2 else WITH_NEON */
 
+static primitives_t* generic = NULL;
 
+#ifdef WITH_SSE2
 /****************************************************************************/
 /* SSSE3 YUV420 -> RGB conversion                                           */
 /****************************************************************************/
 
 static pstatus_t ssse3_YUV420ToRGB_BGRX(
-	const BYTE** pSrc, const UINT32* srcStep,
-	BYTE* pDst, UINT32 dstStep, UINT32 dstFormat,
-	const prim_size_t* roi)
+    const BYTE** pSrc, const UINT32* srcStep,
+    BYTE* pDst, UINT32 dstStep, UINT32 dstFormat,
+    const prim_size_t* roi)
 {
 	UINT32 lastRow, lastCol;
 	BYTE* UData, *VData, *YData;
@@ -341,9 +344,9 @@ static pstatus_t ssse3_YUV420ToRGB_BGRX(
 }
 
 static pstatus_t ssse3_YUV420ToRGB(
-	const BYTE** pSrc, const UINT32* srcStep,
-	BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
-	const prim_size_t* roi)
+    const BYTE** pSrc, const UINT32* srcStep,
+    BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
+    const prim_size_t* roi)
 {
 	switch (DstFormat)
 	{
@@ -356,8 +359,115 @@ static pstatus_t ssse3_YUV420ToRGB(
 	}
 }
 
+static pstatus_t ssse3_YUV444ToRGB_8u_P3AC4R_BGRX(
+    const BYTE** pSrc, const UINT32* srcStep,
+    BYTE* pDst, UINT32 dstStep,
+    const prim_size_t* roi)
+{
+	const UINT32 nWidth = roi->width;
+	const UINT32 nHeight = roi->height;
+	const __m128i c128 = _mm_set1_epi16(128);
+	const __m128i mapY = _mm_set_epi32(0x80800380, 0x80800280, 0x80800180, 0x80800080);
+	const __m128i map = _mm_set_epi32(0x80038002, 0x80018000, 0x80808080, 0x80808080);
+	UINT32 y;
 
+	for (y = 0; y < nHeight; y++)
+	{
+		UINT32 x;
+		__m128i* dst = (__m128i*)(pDst + dstStep * y);
+		const BYTE* YData = pSrc[0] + y * srcStep[0];
+		const BYTE* UData = pSrc[1] + y * srcStep[1];
+		const BYTE* VData = pSrc[2] + y * srcStep[2];
 
+		for (x = 0; x < nWidth; x += 4)
+		{
+			__m128i BGRX = _mm_set_epi32(0xFF000000, 0xFF000000, 0xFF000000, 0xFF000000);
+			{
+				__m128i C, D, E;
+				/* Load Y values and expand to 32 bit */
+				{
+					const __m128i Yraw = _mm_loadu_si128((__m128i*)YData);
+					C = _mm_shuffle_epi8(Yraw, mapY); /* Reorder and multiply by 256 */
+				}
+				/* Load U values and expand to 32 bit */
+				{
+					const __m128i Uraw = _mm_loadu_si128((__m128i*)UData);
+					const __m128i U = _mm_shuffle_epi8(Uraw, map); /* Reorder dcba */
+					D = _mm_sub_epi16(U, c128); /* D = U - 128 */
+				}
+				/* Load V values and expand to 32 bit */
+				{
+					const __m128i Vraw = _mm_loadu_si128((__m128i*)VData);
+					const __m128i V = _mm_shuffle_epi8(Vraw, map); /* Reorder dcba */
+					E = _mm_sub_epi16(V, c128); /* E = V - 128 */
+				}
+				/* Get the R value */
+				{
+					const __m128i c403 = _mm_set1_epi16(403);
+					const __m128i e403 = _mm_unpackhi_epi16(_mm_mullo_epi16(E, c403), _mm_mulhi_epi16(E, c403));
+					const __m128i Rs = _mm_add_epi32(C, e403);
+					const __m128i R32 = _mm_srai_epi32(Rs, 8);
+					const __m128i R16 = _mm_packs_epi32(R32, _mm_setzero_si128());
+					const __m128i R = _mm_packus_epi16(R16, _mm_setzero_si128());
+					const __m128i mask = _mm_set_epi32(0x80038080, 0x80028080, 0x80018080, 0x80008080);
+					const __m128i packed = _mm_shuffle_epi8(R, mask);
+					BGRX = _mm_or_si128(BGRX, packed);
+				}
+				/* Get the G value */
+				{
+					const __m128i c48 = _mm_set1_epi16(48);
+					const __m128i d48 = _mm_unpackhi_epi16(_mm_mullo_epi16(D, c48), _mm_mulhi_epi16(D, c48));
+					const __m128i c120 = _mm_set1_epi16(120);
+					const __m128i e120 = _mm_unpackhi_epi16(_mm_mullo_epi16(E, c120), _mm_mulhi_epi16(E, c120));
+					const __m128i de = _mm_add_epi32(d48, e120);
+					const __m128i Gs = _mm_sub_epi32(C, de);
+					const __m128i G32 = _mm_srai_epi32(Gs, 8);
+					const __m128i G16 = _mm_packs_epi32(G32, _mm_setzero_si128());
+					const __m128i G = _mm_packus_epi16(G16, _mm_setzero_si128());
+					const __m128i mask = _mm_set_epi32(0x80800380, 0x80800280, 0x80800180, 0x80800080);
+					const __m128i packed = _mm_shuffle_epi8(G, mask);
+					BGRX = _mm_or_si128(BGRX, packed);
+				}
+				/* Get the B value */
+				{
+					const __m128i c475 = _mm_set1_epi16(475);
+					const __m128i d475 = _mm_unpackhi_epi16(_mm_mullo_epi16(D, c475), _mm_mulhi_epi16(D, c475));
+					const __m128i Bs = _mm_add_epi32(C, d475);
+					const __m128i B32 = _mm_srai_epi32(Bs, 8);
+					const __m128i B16 = _mm_packs_epi32(B32, _mm_setzero_si128());
+					const __m128i B = _mm_packus_epi16(B16, _mm_setzero_si128());
+					const __m128i mask = _mm_set_epi32(0x80808003, 0x80808002, 0x80808001, 0x80808000);
+					const __m128i packed = _mm_shuffle_epi8(B, mask);
+					BGRX = _mm_or_si128(BGRX, packed);
+				}
+			}
+			_mm_storeu_si128(dst++, BGRX);
+			YData += 4;
+			UData += 4;
+			VData += 4;
+		}
+	}
+
+	return PRIMITIVES_SUCCESS;
+}
+
+static pstatus_t ssse3_YUV444ToRGB_8u_P3AC4R(const BYTE** pSrc, const UINT32* srcStep,
+        BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
+        const prim_size_t* roi)
+{
+	if (roi->width % 4 != 0)
+		return generic->YUV444ToRGB_8u_P3AC4R(pSrc, srcStep, pDst, dstStep, DstFormat, roi);
+
+	switch (DstFormat)
+	{
+		case PIXEL_FORMAT_BGRX32:
+		case PIXEL_FORMAT_BGRA32:
+			return ssse3_YUV444ToRGB_8u_P3AC4R_BGRX(pSrc, srcStep, pDst, dstStep, roi);
+
+		default:
+			return generic->YUV444ToRGB_8u_P3AC4R(pSrc, srcStep, pDst, dstStep, DstFormat, roi);
+	}
+}
 
 /****************************************************************************/
 /* SSSE3 RGB -> YUV420 conversion                                          **/
@@ -383,18 +493,22 @@ static pstatus_t ssse3_YUV420ToRGB(
  *
  */
 
-PRIM_ALIGN_128 static const BYTE bgrx_y_factors[] = {
-	   9,  92,  27,   0,   9,  92,  27,   0,   9,  92,  27,   0,   9,  92,  27,   0
+PRIM_ALIGN_128 static const BYTE bgrx_y_factors[] =
+{
+	9,  92,  27,   0,   9,  92,  27,   0,   9,  92,  27,   0,   9,  92,  27,   0
 };
-PRIM_ALIGN_128 static const BYTE bgrx_u_factors[] = {
-	  64, -49, -15,   0,  64, -49, -15,   0,  64, -49, -15,   0,  64, -49, -15,   0
+PRIM_ALIGN_128 static const BYTE bgrx_u_factors[] =
+{
+	64, -49, -15,   0,  64, -49, -15,   0,  64, -49, -15,   0,  64, -49, -15,   0
 };
-PRIM_ALIGN_128 static const BYTE bgrx_v_factors[] = {
-	  -6, -58,  64,   0,  -6, -58,  64,   0,  -6, -58,  64,   0,  -6, -58,  64,   0
+PRIM_ALIGN_128 static const BYTE bgrx_v_factors[] =
+{
+	-6, -58,  64,   0,  -6, -58,  64,   0,  -6, -58,  64,   0,  -6, -58,  64,   0
 };
 
-PRIM_ALIGN_128 static const BYTE const_buf_128b[] = {
-	 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128
+PRIM_ALIGN_128 static const BYTE const_buf_128b[] =
+{
+	128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128
 };
 
 /*
@@ -418,13 +532,12 @@ PRIM_ALIGN_128 static const BYTE rgbx_v_factors[] = {
 /* compute the luma (Y) component from a single rgb source line */
 
 static INLINE void ssse3_RGBToYUV420_BGRX_Y(
-	const BYTE* src, BYTE* dst, UINT32 width)
+    const BYTE* src, BYTE* dst, UINT32 width)
 {
 	UINT32 x;
 	__m128i y_factors, x0, x1, x2, x3;
 	const __m128i* argb = (const __m128i*) src;
 	__m128i* ydst = (__m128i*) dst;
-
 	y_factors = _mm_load_si128((__m128i*)bgrx_y_factors);
 
 	for (x = 0; x < width; x += 16)
@@ -434,24 +547,19 @@ static INLINE void ssse3_RGBToYUV420_BGRX_Y(
 		x1 = _mm_load_si128(argb++); // 2nd 4 pixels
 		x2 = _mm_load_si128(argb++); // 3rd 4 pixels
 		x3 = _mm_load_si128(argb++); // 4th 4 pixels
-
 		/* multiplications and subtotals */
 		x0 = _mm_maddubs_epi16(x0, y_factors);
 		x1 = _mm_maddubs_epi16(x1, y_factors);
 		x2 = _mm_maddubs_epi16(x2, y_factors);
 		x3 = _mm_maddubs_epi16(x3, y_factors);
-
 		/* the total sums */
 		x0 = _mm_hadd_epi16(x0, x1);
 		x2 = _mm_hadd_epi16(x2, x3);
-
 		/* shift the results */
 		x0 = _mm_srli_epi16(x0, 7);
 		x2 = _mm_srli_epi16(x2, 7);
-
 		/* pack the 16 words into bytes */
 		x0 = _mm_packus_epi16(x0, x2);
-
 		/* save to y plane */
 		_mm_storeu_si128(ydst++, x0);
 	}
@@ -460,18 +568,15 @@ static INLINE void ssse3_RGBToYUV420_BGRX_Y(
 /* compute the chrominance (UV) components from two rgb source lines */
 
 static INLINE void ssse3_RGBToYUV420_BGRX_UV(
-	const BYTE* src1, const BYTE* src2,
-	BYTE* dst1, BYTE* dst2, UINT32 width)
+    const BYTE* src1, const BYTE* src2,
+    BYTE* dst1, BYTE* dst2, UINT32 width)
 {
 	UINT32 x;
 	__m128i vector128, u_factors, v_factors, x0, x1, x2, x3, x4, x5;
-
 	const __m128i* rgb1 = (const __m128i*)src1;
 	const __m128i* rgb2 = (const __m128i*)src2;
-
 	__m64* udst = (__m64*)dst1;
 	__m64* vdst = (__m64*)dst2;
-
 	vector128 = _mm_load_si128((__m128i*)const_buf_128b);
 	u_factors = _mm_load_si128((__m128i*)bgrx_u_factors);
 	v_factors = _mm_load_si128((__m128i*)bgrx_v_factors);
@@ -482,68 +587,53 @@ static INLINE void ssse3_RGBToYUV420_BGRX_UV(
 		x0 = _mm_load_si128(rgb1++);
 		x4 = _mm_load_si128(rgb2++);
 		x0 = _mm_avg_epu8(x0, x4);
-
 		x1 = _mm_load_si128(rgb1++);
 		x4 = _mm_load_si128(rgb2++);
 		x1 = _mm_avg_epu8(x1, x4);
-
 		x2 = _mm_load_si128(rgb1++);
 		x4 = _mm_load_si128(rgb2++);
 		x2 = _mm_avg_epu8(x2, x4);
-
 		x3 = _mm_load_si128(rgb1++);
 		x4 = _mm_load_si128(rgb2++);
 		x3 = _mm_avg_epu8(x3, x4);
-
 		// subsample these 16x1 pixels into 8x1 pixels */
-
 		/**
 		 * shuffle controls
 		 * c = a[0],a[2],b[0],b[2] == 10 00 10 00 = 0x88
 		 * c = a[1],a[3],b[1],b[3] == 11 01 11 01 = 0xdd
 		 */
-
-		x4 = _mm_castps_si128( _mm_shuffle_ps(_mm_castsi128_ps(x0), _mm_castsi128_ps(x1), 0x88) );
-		x0 = _mm_castps_si128( _mm_shuffle_ps(_mm_castsi128_ps(x0), _mm_castsi128_ps(x1), 0xdd) );
+		x4 = _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(x0), _mm_castsi128_ps(x1), 0x88));
+		x0 = _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(x0), _mm_castsi128_ps(x1), 0xdd));
 		x0 = _mm_avg_epu8(x0, x4);
-
-		x4 = _mm_castps_si128( _mm_shuffle_ps(_mm_castsi128_ps(x2), _mm_castsi128_ps(x3), 0x88) );
-		x1 = _mm_castps_si128( _mm_shuffle_ps(_mm_castsi128_ps(x2), _mm_castsi128_ps(x3), 0xdd) );
+		x4 = _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(x2), _mm_castsi128_ps(x3), 0x88));
+		x1 = _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(x2), _mm_castsi128_ps(x3), 0xdd));
 		x1 = _mm_avg_epu8(x1, x4);
-
 		/* multiplications and subtotals */
 		x2 = _mm_maddubs_epi16(x0, u_factors);
 		x3 = _mm_maddubs_epi16(x1, u_factors);
-
 		x4 = _mm_maddubs_epi16(x0, v_factors);
 		x5 = _mm_maddubs_epi16(x1, v_factors);
-
 		/* the total sums */
 		x0 = _mm_hadd_epi16(x2, x3);
 		x1 = _mm_hadd_epi16(x4, x5);
-
 		/* shift the results */
 		x0 = _mm_srai_epi16(x0, 7);
 		x1 = _mm_srai_epi16(x1, 7);
-
 		/* pack the 16 words into bytes */
 		x0 = _mm_packs_epi16(x0, x1);
-
 		/* add 128 */
 		x0 = _mm_add_epi8(x0, vector128);
-
 		/* the lower 8 bytes go to the u plane */
 		_mm_storel_pi(udst++, _mm_castsi128_ps(x0));
-
 		/* the upper 8 bytes go to the v plane */
 		_mm_storeh_pi(vdst++, _mm_castsi128_ps(x0));
 	}
 }
 
 static pstatus_t ssse3_RGBToYUV420_BGRX(
-	const BYTE* pSrc, UINT32 srcFormat, UINT32 srcStep,
-	BYTE* pDst[3], UINT32 dstStep[3],
-	const prim_size_t* roi)
+    const BYTE* pSrc, UINT32 srcFormat, UINT32 srcStep,
+    BYTE* pDst[3], UINT32 dstStep[3],
+    const prim_size_t* roi)
 {
 	UINT32 y;
 	const BYTE* argb = pSrc;
@@ -561,15 +651,13 @@ static pstatus_t ssse3_RGBToYUV420_BGRX(
 		return generic->RGBToYUV420_8u_P3AC4R(pSrc, srcFormat, srcStep, pDst, dstStep, roi);
 	}
 
-	for (y = 0; y < roi->height-1; y+=2)
+	for (y = 0; y < roi->height - 1; y += 2)
 	{
 		const BYTE* line1 = argb;
 		const BYTE* line2 = argb + srcStep;
-
 		ssse3_RGBToYUV420_BGRX_UV(line1, line2, udst, vdst, roi->width);
 		ssse3_RGBToYUV420_BGRX_Y(line1, ydst, roi->width);
 		ssse3_RGBToYUV420_BGRX_Y(line2, ydst + dstStep[0], roi->width);
-
 		argb += 2 * srcStep;
 		ydst += 2 * dstStep[0];
 		udst += 1 * dstStep[1];
@@ -587,21 +675,569 @@ static pstatus_t ssse3_RGBToYUV420_BGRX(
 }
 
 static pstatus_t ssse3_RGBToYUV420(
-	const BYTE* pSrc, UINT32 srcFormat, UINT32 srcStep,
-	BYTE* pDst[3], UINT32 dstStep[3],
-	const prim_size_t* roi)
+    const BYTE* pSrc, UINT32 srcFormat, UINT32 srcStep,
+    BYTE* pDst[3], UINT32 dstStep[3],
+    const prim_size_t* roi)
 {
 	switch (srcFormat)
 	{
 		case PIXEL_FORMAT_BGRX32:
 		case PIXEL_FORMAT_BGRA32:
 			return ssse3_RGBToYUV420_BGRX(pSrc, srcFormat, srcStep, pDst, dstStep, roi);
+
 		default:
 			return generic->RGBToYUV420_8u_P3AC4R(pSrc, srcFormat, srcStep, pDst, dstStep, roi);
 	}
 }
 
+#elif defined(WITH_NEON)
 
+static INLINE uint8x8_t neon_YUV2R(int32x4_t Ch, int32x4_t Cl,
+                                   int16x4_t Dh, int16x4_t Dl,
+                                   int16x4_t Eh, int16x4_t El)
+{
+	/* R = (256 * Y + 403 * (V - 128)) >> 8 */
+	const int16x4_t c403 = vdup_n_s16(403);
+	const int32x4_t CEh = vmlal_s16(Ch, Eh, c403);
+	const int32x4_t CEl = vmlal_s16(Cl, El, c403);
+	const int32x4_t Rh = vrshrq_n_s32(CEh, 8);
+	const int32x4_t Rl = vrshrq_n_s32(CEl, 8);
+	const int16x8_t R = vcombine_s16(vqmovn_s32(Rl), vqmovn_s32(Rh));
+	return vqmovun_s16(R);
+}
+
+static INLINE uint8x8_t neon_YUV2G(int32x4_t Ch, int32x4_t Cl,
+                                   int16x4_t Dh, int16x4_t Dl,
+                                   int16x4_t Eh, int16x4_t El)
+{
+	/* G = (256L * Y -  48 * (U - 128) - 120 * (V - 128)) >> 8 */
+	const int16x4_t c48 = vdup_n_s16(48);
+	const int16x4_t c120 = vdup_n_s16(120);
+	const int32x4_t CDh = vmlsl_s16(Ch, Dh, c48);
+	const int32x4_t CDl = vmlsl_s16(Cl, Dl, c48);
+	const int32x4_t CDEh = vmlsl_s16(CDh, Eh, c120);
+	const int32x4_t CDEl = vmlsl_s16(CDl, El, c120);
+	const int32x4_t Gh = vrshrq_n_s32(CDEh, 8);
+	const int32x4_t Gl = vrshrq_n_s32(CDEl, 8);
+	const int16x8_t G = vcombine_s16(vqmovn_s32(Gl), vqmovn_s32(Gh));
+	return vqmovun_s16(G);
+}
+
+static INLINE uint8x8_t neon_YUV2B(int32x4_t Ch, int32x4_t Cl,
+                                   int16x4_t Dh, int16x4_t Dl,
+                                   int16x4_t Eh, int16x4_t El)
+{
+	/* B = (256L * Y + 475 * (U - 128)) >> 8*/
+	const int16x4_t c475 = vdup_n_s16(475);
+	const int32x4_t CDh = vmlal_s16(Ch, Dh, c475);
+	const int32x4_t CDl = vmlal_s16(Ch, Dl, c475);
+	const int32x4_t Bh = vrshrq_n_s32(CDh, 8);
+	const int32x4_t Bl = vrshrq_n_s32(CDl, 8);
+	const int16x8_t B = vcombine_s16(vqmovn_s32(Bl), vqmovn_s32(Bh));
+	return vqmovun_s16(B);
+}
+
+static INLINE pstatus_t neon_YUV420ToX(
+    const BYTE* pSrc[3], const UINT32 srcStep[3],
+    BYTE* pDst, UINT32 dstStep,
+    const prim_size_t* roi, const uint8_t rPos,  const uint8_t gPos,
+    const uint8_t bPos, const uint8_t aPos)
+{
+	UINT32 y;
+	const UINT32 nWidth = roi->width;
+	const UINT32 nHeight = roi->height;
+	const int16x8_t c128 = vdupq_n_s16(128);
+
+	for (y = 0; y < nHeight; y += 2)
+	{
+		const uint8_t* pY1 = pSrc[0] + y * srcStep[0];
+		const uint8_t* pY2 = pY1 + srcStep[0];
+		const uint8_t* pU = pSrc[1] + (y / 2) * srcStep[1];
+		const uint8_t* pV = pSrc[2] + (y / 2) * srcStep[2];
+		uint8_t* pRGB1 = pDst + y * dstStep;
+		uint8_t* pRGB2 = pRGB1 + dstStep;
+		UINT32 x;
+		const BOOL lastY = y >= nHeight - 1;
+
+		for (x = 0; x < nWidth;)
+		{
+			const BOOL lastX = (nWidth - x) < 16;
+			const uint8x8_t Uraw = vld1_u8(pU);
+			const uint8x8x2_t Uu = vzip_u8(Uraw, Uraw);
+			const int16x8_t U1 = vreinterpretq_s16_u16(vmovl_u8(Uu.val[0]));
+			const int16x8_t U2 = vreinterpretq_s16_u16(vmovl_u8(Uu.val[1]));
+			const uint8x8_t Vraw = vld1_u8(pV);
+			const uint8x8x2_t Vu = vzip_u8(Vraw, Vraw);
+			const int16x8_t V1 = vreinterpretq_s16_u16(vmovl_u8(Vu.val[0]));
+			const int16x8_t V2 = vreinterpretq_s16_u16(vmovl_u8(Vu.val[1]));
+			const int16x8_t D1 = vsubq_s16(U1, c128);
+			const int16x4_t D1h = vget_high_s16(D1);
+			const int16x4_t D1l = vget_low_s16(D1);
+			const int16x8_t E1 = vsubq_s16(V1, c128);
+			const int16x4_t E1h = vget_high_s16(E1);
+			const int16x4_t E1l = vget_low_s16(E1);
+			const int16x8_t D2 = vsubq_s16(U2, c128);
+			const int16x4_t D2h = vget_high_s16(D2);
+			const int16x4_t D2l = vget_low_s16(D2);
+			const int16x8_t E2 = vsubq_s16(V2, c128);
+			const int16x4_t E2h = vget_high_s16(E2);
+			const int16x4_t E2l = vget_low_s16(E2);
+			uint8x8x4_t bgrx;
+			bgrx.val[aPos] = vdup_n_u8(0xFF);
+			{
+				const uint8x8_t Y1u = vld1_u8(pY1);
+				const int16x8_t Y1 = vreinterpretq_s16_u16(vmovl_u8(Y1u));
+				const int32x4_t Ch = vmulq_n_s32(vmovl_s16(vget_high_s16(Y1)), 256);  /* Y * 256 */
+				const int32x4_t Cl = vmulq_n_s32(vmovl_s16(vget_low_s16(Y1)), 256);  /* Y * 256 */
+				bgrx.val[rPos] = neon_YUV2R(Ch, Cl, D1h, D1l, E1h, E1l);
+				bgrx.val[gPos] = neon_YUV2G(Ch, Cl, D1h, D1l, E1h, E1l);
+				bgrx.val[bPos] = neon_YUV2B(Ch, Cl, D1h, D1l, E1h, E1l);
+				vst4_u8(pRGB1, bgrx);
+				pRGB1 += 32;
+				pY1 += 8;
+				x += 8;
+			}
+
+			if (!lastX)
+			{
+				const uint8x8_t Y1u = vld1_u8(pY1);
+				const int16x8_t Y1 = vreinterpretq_s16_u16(vmovl_u8(Y1u));
+				const int32x4_t Ch = vmulq_n_s32(vmovl_s16(vget_high_s16(Y1)), 256);  /* Y * 256 */
+				const int32x4_t Cl = vmulq_n_s32(vmovl_s16(vget_low_s16(Y1)), 256);  /* Y * 256 */
+				bgrx.val[rPos] = neon_YUV2R(Ch, Cl, D2h, D2l, E2h, E2l);
+				bgrx.val[gPos] = neon_YUV2G(Ch, Cl, D2h, D2l, E2h, E2l);
+				bgrx.val[bPos] = neon_YUV2B(Ch, Cl, D2h, D2l, E2h, E2l);
+				vst4_u8(pRGB1, bgrx);
+				pRGB1 += 32;
+				pY1 += 8;
+				x += 8;
+			}
+
+			if (!lastY)
+			{
+				const uint8x8_t Y2u = vld1_u8(pY2);
+				const int16x8_t Y2 = vreinterpretq_s16_u16(vmovl_u8(Y2u));
+				const int32x4_t Ch = vmulq_n_s32(vmovl_s16(vget_high_s16(Y2)), 256);  /* Y * 256 */
+				const int32x4_t Cl = vmulq_n_s32(vmovl_s16(vget_low_s16(Y2)), 256);  /* Y * 256 */
+				bgrx.val[rPos] = neon_YUV2R(Ch, Cl, D1h, D1l, E1h, E1l);
+				bgrx.val[gPos] = neon_YUV2G(Ch, Cl, D1h, D1l, E1h, E1l);
+				bgrx.val[bPos] = neon_YUV2B(Ch, Cl, D1h, D1l, E1h, E1l);
+				vst4_u8(pRGB2, bgrx);
+				pRGB2 += 32;
+				pY2 += 8;
+
+				if (!lastX)
+				{
+					const uint8x8_t Y2u = vld1_u8(pY2);
+					const int16x8_t Y2 = vreinterpretq_s16_u16(vmovl_u8(Y2u));
+					const int32x4_t Ch = vmulq_n_s32(vmovl_s16(vget_high_s16(Y2)), 256);  /* Y * 256 */
+					const int32x4_t Cl = vmulq_n_s32(vmovl_s16(vget_low_s16(Y2)), 256);  /* Y * 256 */
+					bgrx.val[rPos] = neon_YUV2R(Ch, Cl, D2h, D2l, E2h, E2l);
+					bgrx.val[gPos] = neon_YUV2G(Ch, Cl, D2h, D2l, E2h, E2l);
+					bgrx.val[bPos] = neon_YUV2B(Ch, Cl, D2h, D2l, E2h, E2l);
+					vst4_u8(pRGB2, bgrx);
+					pRGB2 += 32;
+					pY2 += 8;
+				}
+			}
+
+			pU += 8;
+			pV += 8;
+		}
+	}
+
+	return PRIMITIVES_SUCCESS;
+}
+
+static pstatus_t neon_YUV420ToRGB_8u_P3AC4R(
+    const BYTE* pSrc[3], const UINT32 srcStep[3],
+    BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
+    const prim_size_t* roi)
+{
+	switch (DstFormat)
+	{
+		case PIXEL_FORMAT_BGRA32:
+		case PIXEL_FORMAT_BGRX32:
+			return neon_YUV420ToX(pSrc, srcStep, pDst, dstStep, roi, 2, 1, 0, 3);
+
+		case PIXEL_FORMAT_RGBA32:
+		case PIXEL_FORMAT_RGBX32:
+			return neon_YUV420ToX(pSrc, srcStep, pDst, dstStep, roi, 0, 1, 2, 3);
+
+		case PIXEL_FORMAT_ARGB32:
+		case PIXEL_FORMAT_XRGB32:
+			return neon_YUV420ToX(pSrc, srcStep, pDst, dstStep, roi, 1, 2, 3, 0);
+
+		case PIXEL_FORMAT_ABGR32:
+		case PIXEL_FORMAT_XBGR32:
+			return neon_YUV420ToX(pSrc, srcStep, pDst, dstStep, roi, 3, 2, 1, 0);
+
+		default:
+			return generic->YUV420ToRGB_8u_P3AC4R(pSrc, srcStep, pDst, dstStep, DstFormat, roi);
+	}
+}
+
+static INLINE pstatus_t neon_YUV444ToX(
+    const BYTE* pSrc[3], const UINT32 srcStep[3],
+    BYTE* pDst, UINT32 dstStep,
+    const prim_size_t* roi, const uint8_t rPos,  const uint8_t gPos,
+    const uint8_t bPos, const uint8_t aPos)
+{
+	UINT32 y;
+	const UINT32 nWidth = roi->width;
+	const UINT32 nHeight = roi->height;
+	const UINT32 yPad = srcStep[0] - roi->width;
+	const UINT32 uPad = srcStep[1] - roi->width;
+	const UINT32 vPad = srcStep[2] - roi->width;
+	const UINT32 dPad = dstStep - roi->width * 4;
+	const uint8_t* pY = pSrc[0];
+	const uint8_t* pU = pSrc[1];
+	const uint8_t* pV = pSrc[2];
+	uint8_t* pRGB = pDst;
+	const int16x8_t c128 = vdupq_n_s16(128);
+	const int16x4_t c48 = vdup_n_s16(48);
+	const int16x4_t c120 = vdup_n_s16(120);
+	const int16x4_t c403 = vdup_n_s16(403);
+	const int16x4_t c475 = vdup_n_s16(475);
+	const DWORD pad = nWidth % 8;
+
+	for (y = 0; y < nHeight; y++)
+	{
+		UINT32 x;
+
+		for (x = 0; x < nWidth - pad; x += 8)
+		{
+			const uint8x8_t Yu = vld1_u8(pY);
+			const int16x8_t Y = vreinterpretq_s16_u16(vmovl_u8(Yu));
+			const uint8x8_t Uu = vld1_u8(pU);
+			const int16x8_t U = vreinterpretq_s16_u16(vmovl_u8(Uu));
+			const uint8x8_t Vu = vld1_u8(pV);
+			const int16x8_t V = vreinterpretq_s16_u16(vmovl_u8(Vu));
+			/* Do the calculations on Y in 32bit width, the result of 255 * 256 does not fit
+			 * a signed 16 bit value. */
+			const int32x4_t Ch = vmulq_n_s32(vmovl_s16(vget_high_s16(Y)), 256);  /* Y * 256 */
+			const int32x4_t Cl = vmulq_n_s32(vmovl_s16(vget_low_s16(Y)), 256);  /* Y * 256 */
+			const int16x8_t D = vsubq_s16(U, c128);
+			const int16x4_t Dh = vget_high_s16(D);
+			const int16x4_t Dl = vget_low_s16(D);
+			const int16x8_t E = vsubq_s16(V, c128);
+			const int16x4_t Eh = vget_high_s16(E);
+			const int16x4_t El = vget_low_s16(E);
+			uint8x8x4_t bgrx;
+			{
+				/* B = (256L * Y + 475 * (U - 128)) >> 8*/
+				const int32x4_t CDh = vmlal_s16(Ch, Dh, c475);
+				const int32x4_t CDl = vmlal_s16(Cl, Dl, c475);
+				const int32x4_t Bh = vrshrq_n_s32(CDh, 8);
+				const int32x4_t Bl = vrshrq_n_s32(CDl, 8);
+				const int16x8_t B = vcombine_s16(vqmovn_s32(Bl), vqmovn_s32(Bh));
+				bgrx.val[bPos] = vqmovun_s16(B);
+			}
+			{
+				/* G = (256L * Y -  48 * (U - 128) - 120 * (V - 128)) >> 8 */
+				const int32x4_t CDh = vmlsl_s16(Ch, Dh, c48);
+				const int32x4_t CDl = vmlsl_s16(Cl, Dl, c48);
+				const int32x4_t CDEh = vmlsl_s16(CDh, Eh, c120);
+				const int32x4_t CDEl = vmlsl_s16(CDl, El, c120);
+				const int32x4_t Gh = vrshrq_n_s32(CDEh, 8);
+				const int32x4_t Gl = vrshrq_n_s32(CDEl, 8);
+				const int16x8_t G = vcombine_s16(vqmovn_s32(Gl), vqmovn_s32(Gh));
+				bgrx.val[gPos] = vqmovun_s16(G);
+			}
+			{
+				/* R = (256 * Y + 403 * (V - 128)) >> 8 */
+				const int32x4_t CEh = vmlal_s16(Ch, Eh, c403);
+				const int32x4_t CEl = vmlal_s16(Cl, El, c403);
+				const int32x4_t Rh = vrshrq_n_s32(CEh, 8);
+				const int32x4_t Rl = vrshrq_n_s32(CEl, 8);
+				const int16x8_t R = vcombine_s16(vqmovn_s32(Rl), vqmovn_s32(Rh));
+				bgrx.val[rPos] = vqmovun_s16(R);
+			}
+			{
+				/* A */
+				bgrx.val[aPos] = vdup_n_u8(0xFF);
+			}
+			vst4_u8(pRGB, bgrx);
+			pRGB += 32;
+			pY += 8;
+			pU += 8;
+			pV += 8;
+		}
+
+		for (x = 0; x < pad; x++)
+		{
+			const BYTE Y = *pY++;
+			const BYTE U = *pU++;
+			const BYTE V = *pV++;
+			const BYTE r = YUV2R(Y, U, V);
+			const BYTE g = YUV2G(Y, U, V);
+			const BYTE b = YUV2B(Y, U, V);
+			pRGB[aPos] = 0xFF;
+			pRGB[rPos] = r;
+			pRGB[gPos] = g;
+			pRGB[bPos] = b;
+			pRGB += 4;
+		}
+
+		pRGB += dPad;
+		pY += yPad;
+		pU += uPad;
+		pV += vPad;
+	}
+
+	return PRIMITIVES_SUCCESS;
+}
+
+static pstatus_t neon_YUV444ToRGB_8u_P3AC4R(
+    const BYTE* pSrc[3], const UINT32 srcStep[3],
+    BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
+    const prim_size_t* roi)
+{
+	switch (DstFormat)
+	{
+		case PIXEL_FORMAT_BGRA32:
+		case PIXEL_FORMAT_BGRX32:
+			return neon_YUV444ToX(pSrc, srcStep, pDst, dstStep, roi, 2, 1, 0, 3);
+
+		case PIXEL_FORMAT_RGBA32:
+		case PIXEL_FORMAT_RGBX32:
+			return neon_YUV444ToX(pSrc, srcStep, pDst, dstStep, roi, 0, 1, 2, 3);
+
+		case PIXEL_FORMAT_ARGB32:
+		case PIXEL_FORMAT_XRGB32:
+			return neon_YUV444ToX(pSrc, srcStep, pDst, dstStep, roi, 1, 2, 3, 0);
+
+		case PIXEL_FORMAT_ABGR32:
+		case PIXEL_FORMAT_XBGR32:
+			return neon_YUV444ToX(pSrc, srcStep, pDst, dstStep, roi, 3, 2, 1, 0);
+
+		default:
+			return generic->YUV444ToRGB_8u_P3AC4R(pSrc, srcStep, pDst, dstStep, DstFormat, roi);
+	}
+}
+
+static pstatus_t neon_YUV420CombineToYUV444(
+    const BYTE* pMainSrc[3], const UINT32 srcMainStep[3],
+    const BYTE* pAuxSrc[3], const UINT32 srcAuxStep[3],
+    BYTE* pDst[3], const UINT32 dstStep[3],
+    const prim_size_t* roi)
+{
+	UINT32 x, y;
+	const UINT32 nWidth = roi->width;
+	const UINT32 nHeight = roi->height;
+	const UINT32 halfWidth = nWidth / 2, halfHeight = nHeight / 2;
+	const UINT32 oddY = 1;
+	const UINT32 evenY = 0;
+	/* The auxilary frame is aligned to multiples of 16x16.
+	 * We need the padded height for B4 and B5 conversion. */
+	const UINT32 padHeigth = roi->height + 16 - roi->height % 16;
+
+	if (pMainSrc && pMainSrc[0] && pMainSrc[1] && pMainSrc[2])
+	{
+		/* Y data is already here... */
+		/* B1 */
+		for (y = 0; y < nHeight; y++)
+		{
+			const BYTE* Ym = pMainSrc[0] + srcMainStep[0] * y;
+			BYTE* pY = pDst[0] + dstStep[0] * y;
+			memcpy(pY, Ym, nWidth);
+		}
+
+		/* The first half of U, V are already here part of this frame. */
+		/* B2 and B3 */
+		for (y = 0; y < halfHeight; y++)
+		{
+			const UINT32 val2y = (2 * y + evenY);
+			const BYTE* Um = pMainSrc[1] + srcMainStep[1] * y;
+			const BYTE* Vm = pMainSrc[2] + srcMainStep[2] * y;
+			BYTE* pU = pDst[1] + dstStep[1] * val2y;
+			BYTE* pV = pDst[2] + dstStep[2] * val2y;
+			BYTE* pU1 = pU + dstStep[1];
+			BYTE* pV1 = pV + dstStep[2];
+
+			for (x = 0; x + 16 < halfWidth; x += 16)
+			{
+				{
+					const uint8x16_t u = vld1q_u8(Um);
+					uint8x16x2_t u2x;
+					u2x.val[0] = u;
+					u2x.val[1] = u;
+					vst2q_u8(pU, u2x);
+					vst2q_u8(pU1, u2x);
+					Um += 16;
+					pU += 32;
+					pU1 += 32;
+				}
+				{
+					const uint8x16_t v = vld1q_u8(Vm);
+					uint8x16x2_t v2x;
+					v2x.val[0] = v;
+					v2x.val[1] = v;
+					vst2q_u8(pV, v2x);
+					vst2q_u8(pV1, v2x);
+					Vm += 16;
+					pV += 32;
+					pV1 += 32;
+				}
+			}
+
+			for (; x < halfWidth; x++)
+			{
+				const BYTE u = *Um++;
+				const BYTE v = *Vm++;
+				*pU++ = u;
+				*pU++ = u;
+				*pU1++ = u;
+				*pU1++ = u;
+				*pV++ = v;
+				*pV++ = v;
+				*pV1++ = v;
+				*pV1++ = v;
+			}
+		}
+	}
+
+	if (!pAuxSrc || !pAuxSrc[0] || !pAuxSrc[1] || !pAuxSrc[2])
+		return PRIMITIVES_SUCCESS;
+
+	/* The second half of U and V is a bit more tricky... */
+	/* B4 and B5 */
+	for (y = 0; y < padHeigth; y += 16)
+	{
+		const BYTE* Ya = pAuxSrc[0] + srcAuxStep[0] * y;
+		UINT32 x;
+		BYTE* pU = pDst[1] + dstStep[1] * (y + 1);
+		BYTE* pV = pDst[2] + dstStep[2] * (y + 1);
+
+		for (x = 0; x < 8; x++)
+		{
+			if (y + x >= nHeight)
+				continue;
+
+			memcpy(pU, Ya, nWidth);
+			pU += dstStep[1] * 2;
+			Ya += srcAuxStep[0];
+		}
+
+		for (x = 0; x < 8; x++)
+		{
+			if (y + x >= nHeight)
+				continue;
+
+			memcpy(pV, Ya, nWidth);
+			pV += dstStep[1] * 2;
+			Ya += srcAuxStep[0];
+		}
+	}
+
+	/* B6 and B7 */
+	for (y = 0; y < halfHeight; y++)
+	{
+		const UINT32 val2y = (y * 2 + evenY);
+		const BYTE* Ua = pAuxSrc[1] + srcAuxStep[1] * y;
+		const BYTE* Va = pAuxSrc[2] + srcAuxStep[2] * y;
+		BYTE* pU = pDst[1] + dstStep[1] * val2y;
+		BYTE* pV = pDst[2] + dstStep[2] * val2y;
+
+		for (x = 0; x + 16 < halfWidth; x += 16)
+		{
+			{
+				const uint8x16_t u = vld1q_u8(Ua);
+				uint8x16x2_t uu = vld2q_u8(pU);
+				uu.val[1] = u;
+				vst2q_u8(pU, uu);
+				Ua += 16;
+				pU += 32;
+			}
+			{
+				const uint8x16_t v = vld1q_u8(Va);
+				uint8x16x2_t vv = vld2q_u8(pV);
+				vv.val[1] = v;
+				vst2q_u8(pV, vv);
+				Va += 16;
+				pV += 32;
+			}
+		}
+
+		for (; x < halfWidth; x++)
+		{
+			pU++;
+			*pU++ = *Ua++;
+			pV++;
+			*pV++ = *Va++;
+		}
+	}
+
+	/* Filter */
+	for (y = 0; y < halfHeight; y++)
+	{
+		const UINT32 val2y = (y * 2 + evenY);
+		const UINT32 val2y1 = val2y + oddY;
+		BYTE* pU = pDst[1] + dstStep[1] * val2y;
+		BYTE* pV = pDst[2] + dstStep[2] * val2y;
+		BYTE* pU1 = pU + dstStep[1];
+		BYTE* pV1 = pV + dstStep[2];
+
+		if (val2y1 > nHeight)
+			continue;
+
+		for (x = 0; x + 16 < halfWidth; x += 16)
+		{
+			{
+				/* U = (U2x,2y << 2) - U2x1,2y - U2x,2y1 - U2x1,2y1 */
+				uint8x8x2_t u = vld2_u8(pU);
+				const int16x8_t up = vreinterpretq_s16_u16(vshll_n_u8(u.val[0], 2)); /* Ux2,2y << 2 */
+				const uint8x8x2_t u1 = vld2_u8(pU1);
+				const uint16x8_t usub = vaddl_u8(u1.val[1], u1.val[0]); /* U2x,2y1 + U2x1,2y1 */
+				const int16x8_t us = vreinterpretq_s16_u16(vaddw_u8(usub,
+				                     u.val[1])); /* U2x1,2y + U2x,2y1 + U2x1,2y1 */
+				const int16x8_t un = vsubq_s16(up, us);
+				const uint8x8_t u8 = vqmovun_s16(un); /* CLIP(un) */
+				u.val[0] = u8;
+				vst2_u8(pU, u);
+				pU += 16;
+				pU1 += 16;
+			}
+			{
+				/* V = (V2x,2y << 2) - V2x1,2y - V2x,2y1 - V2x1,2y1 */
+				uint8x8x2_t v = vld2_u8(pV);
+				const int16x8_t vp = vreinterpretq_s16_u16(vshll_n_u8(v.val[0], 2)); /* Vx2,2y << 2 */
+				const uint8x8x2_t v1 = vld2_u8(pV1);
+				const uint16x8_t vsub = vaddl_u8(v1.val[1], v1.val[0]); /* V2x,2y1 + V2x1,2y1 */
+				const int16x8_t vs = vreinterpretq_s16_u16(vaddw_u8(vsub,
+				                     v.val[1])); /* V2x1,2y + V2x,2y1 + V2x1,2y1 */
+				const int16x8_t vn = vsubq_s16(vp, vs);
+				const uint8x8_t v8 = vqmovun_s16(vn); /* CLIP(vn) */
+				v.val[0] = v8;
+				vst2_u8(pV, v);
+				pV += 16;
+				pV1 += 16;
+			}
+		}
+
+		for (; x < halfWidth; x++)
+		{
+			const UINT32 val2x = (x * 2);
+			const UINT32 val2x1 = val2x + 1;
+			const INT32 up = pU[val2x] * 4;
+			const INT32 vp = pV[val2x] * 4;
+			INT32 u2020;
+			INT32 v2020;
+
+			if (val2x1 > nWidth)
+				continue;
+
+			u2020 = up - pU[val2x1] - pU1[val2x] - pU1[val2x1];
+			v2020 = vp - pV[val2x1] - pV1[val2x] - pV1[val2x1];
+			*pU = CLIP(u2020);
+			*pV = CLIP(v2020);
+			pU += 2;
+			pV += 2;
+		}
+	}
+
+	return PRIMITIVES_SUCCESS;
+}
 #endif
 
 void primitives_init_YUV_opt(primitives_t* prims)
@@ -615,6 +1251,16 @@ void primitives_init_YUV_opt(primitives_t* prims)
 	{
 		prims->RGBToYUV420_8u_P3AC4R = ssse3_RGBToYUV420;
 		prims->YUV420ToRGB_8u_P3AC4R = ssse3_YUV420ToRGB;
+		prims->YUV444ToRGB_8u_P3AC4R = ssse3_YUV444ToRGB_8u_P3AC4R;
+	}
+
+#elif defined(WITH_NEON)
+
+	if (IsProcessorFeaturePresent(PF_ARM_NEON_INSTRUCTIONS_AVAILABLE))
+	{
+		prims->YUV420ToRGB_8u_P3AC4R = neon_YUV420ToRGB_8u_P3AC4R;
+		prims->YUV444ToRGB_8u_P3AC4R = neon_YUV444ToRGB_8u_P3AC4R;
+		prims->YUV420CombineToYUV444 = neon_YUV420CombineToYUV444;
 	}
 
 #endif

--- a/libfreerdp/primitives/prim_colors.c
+++ b/libfreerdp/primitives/prim_colors.c
@@ -302,9 +302,9 @@ static INLINE void writeScanlineRGB(BYTE* dst, DWORD formatSize, UINT32 DstForma
 
 	for (x = 0; x < width; x++)
 	{
-		const BYTE R = *r++;
-		const BYTE G = *g++;
-		const BYTE B = *b++;
+		const BYTE R = CLIP(*r++);
+		const BYTE G = CLIP(*g++);
+		const BYTE B = CLIP(*b++);
 		*dst++ = R;
 		*dst++ = G;
 		*dst++ = B;
@@ -318,9 +318,9 @@ static INLINE void writeScanlineBGR(BYTE* dst, DWORD formatSize, UINT32 DstForma
 
 	for (x = 0; x < width; x++)
 	{
-		const BYTE R = *r++;
-		const BYTE G = *g++;
-		const BYTE B = *b++;
+		const BYTE R = CLIP(*r++);
+		const BYTE G = CLIP(*g++);
+		const BYTE B = CLIP(*b++);
 		*dst++ = B;
 		*dst++ = G;
 		*dst++ = R;
@@ -334,9 +334,9 @@ static INLINE void writeScanlineBGRX(BYTE* dst, DWORD formatSize, UINT32 DstForm
 
 	for (x = 0; x < width; x++)
 	{
-		const BYTE R = *r++;
-		const BYTE G = *g++;
-		const BYTE B = *b++;
+		const BYTE R = CLIP(*r++);
+		const BYTE G = CLIP(*g++);
+		const BYTE B = CLIP(*b++);
 		*dst++ = B;
 		*dst++ = G;
 		*dst++ = R;
@@ -351,9 +351,9 @@ static INLINE void writeScanlineRGBX(BYTE* dst, DWORD formatSize, UINT32 DstForm
 
 	for (x = 0; x < width; x++)
 	{
-		const BYTE R = *r++;
-		const BYTE G = *g++;
-		const BYTE B = *b++;
+		const BYTE R = CLIP(*r++);
+		const BYTE G = CLIP(*g++);
+		const BYTE B = CLIP(*b++);
 		*dst++ = R;
 		*dst++ = G;
 		*dst++ = B;
@@ -368,9 +368,9 @@ static INLINE void writeScanlineXBGR(BYTE* dst, DWORD formatSize, UINT32 DstForm
 
 	for (x = 0; x < width; x++)
 	{
-		const BYTE R = *r++;
-		const BYTE G = *g++;
-		const BYTE B = *b++;
+		const BYTE R = CLIP(*r++);
+		const BYTE G = CLIP(*g++);
+		const BYTE B = CLIP(*b++);
 		*dst++ = 0xFF;
 		*dst++ = B;
 		*dst++ = G;
@@ -385,9 +385,9 @@ static INLINE void writeScanlineXRGB(BYTE* dst, DWORD formatSize, UINT32 DstForm
 
 	for (x = 0; x < width; x++)
 	{
-		const BYTE R = *r++;
-		const BYTE G = *g++;
-		const BYTE B = *b++;
+		const BYTE R = CLIP(*r++);
+		const BYTE G = CLIP(*g++);
+		const BYTE B = CLIP(*b++);
 		*dst++ = 0xFF;
 		*dst++ = R;
 		*dst++ = G;

--- a/libfreerdp/primitives/prim_colors_opt.c
+++ b/libfreerdp/primitives/prim_colors_opt.c
@@ -202,6 +202,396 @@ static pstatus_t sse2_yCbCrToRGB_16s16s_P3P3(
 }
 
 /*---------------------------------------------------------------------------*/
+static pstatus_t sse2_yCbCrToRGB_16s8u_P3AC4R_BGRX(
+    const INT16* pSrc[3], UINT32 srcStep,
+    BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
+    const prim_size_t* roi)	/* region of interest */
+{
+	__m128i zero, max, r_cr, g_cb, g_cr, b_cb, c4096;
+	const __m128i* y_buf, *cb_buf, *cr_buf;
+	__m128i* d_buf;
+	int srcbump, dstbump, yp, imax;
+	size_t dstPad, yPad, cbPad, crPad;
+
+	if (((ULONG_PTR)(pSrc[0]) & 0x0f)
+	    || ((ULONG_PTR)(pSrc[1]) & 0x0f)
+	    || ((ULONG_PTR)(pSrc[2]) & 0x0f)
+	    || ((ULONG_PTR)(pDst[0]) & 0x0f)
+	    || ((ULONG_PTR)(pDst[1]) & 0x0f)
+	    || ((ULONG_PTR)(pDst[2]) & 0x0f)
+	    || (roi->width & 0x07)
+	    || (srcStep & 127)
+	    || (dstStep & 127))
+	{
+		/* We can't maintain 16-byte alignment. */
+		return generic->yCbCrToRGB_16s8u_P3AC4R(pSrc, srcStep,
+		                                        pDst, dstStep, DstFormat, roi);
+	}
+
+	zero = _mm_setzero_si128();
+	max = _mm_set1_epi16(255);
+	y_buf  = (const __m128i*)(pSrc[0]);
+	cb_buf = (const __m128i*)(pSrc[1]);
+	cr_buf = (const __m128i*)(pSrc[2]);
+	d_buf = (__m128i*)pDst;
+	r_cr = _mm_set1_epi16(22986);	/*  1.403 << 14 */
+	g_cb = _mm_set1_epi16(-5636);	/* -0.344 << 14 */
+	g_cr = _mm_set1_epi16(-11698);	/* -0.714 << 14 */
+	b_cb = _mm_set1_epi16(28999);	/*  1.770 << 14 */
+	c4096 = _mm_set1_epi16(4096);
+	srcbump = srcStep / sizeof(__m128i);
+	dstbump = dstStep / sizeof(__m128i);
+	dstPad = (dstStep - roi->width * 4) / sizeof(__m128i);
+	yPad = 0;
+	cbPad = 0;
+	crPad = 0;
+#ifdef DO_PREFETCH
+
+	/* Prefetch Y's, Cb's, and Cr's. */
+	for (yp = 0; yp < roi->height; yp++)
+	{
+		int i;
+
+		for (i = 0; i < roi->width * sizeof(INT16) / sizeof(__m128i);
+		     i += (CACHE_LINE_BYTES / sizeof(__m128i)))
+		{
+			_mm_prefetch((char*)(&y_buf[i]),  _MM_HINT_NTA);
+			_mm_prefetch((char*)(&cb_buf[i]), _MM_HINT_NTA);
+			_mm_prefetch((char*)(&cr_buf[i]), _MM_HINT_NTA);
+		}
+
+		y_buf  += srcbump;
+		cb_buf += srcbump;
+		cr_buf += srcbump;
+	}
+
+	y_buf  = (__m128i*)(pSrc[0]);
+	cb_buf = (__m128i*)(pSrc[1]);
+	cr_buf = (__m128i*)(pSrc[2]);
+#endif /* DO_PREFETCH */
+	imax = roi->width * sizeof(INT16) / sizeof(__m128i);
+
+	for (yp = 0; yp < roi->height; ++yp)
+	{
+		int i;
+
+		for (i = 0; i < imax; i += 2)
+		{
+			/* In order to use SSE2 signed 16-bit integer multiplication
+			 * we need to convert the floating point factors to signed int
+			 * without losing information.
+			 * The result of this multiplication is 32 bit and we have two
+			 * SSE instructions that return either the hi or lo word.
+			 * Thus we will multiply the factors by the highest possible 2^n,
+			 * take the upper 16 bits of the signed 32-bit result
+			 * (_mm_mulhi_epi16) and correct this result by multiplying
+			 * it by 2^(16-n).
+			 *
+			 * For the given factors in the conversion matrix the best
+			 * possible n is 14.
+			 *
+			 * Example for calculating r:
+			 * r = (y>>5) + 128 + (cr*1.403)>>5             // our base formula
+			 * r = (y>>5) + 128 + (HIWORD(cr*(1.403<<14)<<2))>>5   // see above
+			 * r = (y+4096)>>5 + (HIWORD(cr*22986)<<2)>>5     // simplification
+			 * r = ((y+4096)>>2 + HIWORD(cr*22986)) >> 3
+			 */
+			/* y = (y_r_buf[i] + 4096) >> 2 */
+			__m128i y1, y2, cb1, cb2, cr1, cr2, r1, r2, g1, g2, b1, b2;
+			y1 = _mm_load_si128(y_buf++);
+			y1 = _mm_add_epi16(y1, c4096);
+			y1 = _mm_srai_epi16(y1, 2);
+			/* cb = cb_g_buf[i]; */
+			cb1 = _mm_load_si128(cb_buf++);
+			/* cr = cr_b_buf[i]; */
+			cr1 = _mm_load_si128(cr_buf++);
+			/* (y + HIWORD(cr*22986)) >> 3 */
+			r1 = _mm_add_epi16(y1, _mm_mulhi_epi16(cr1, r_cr));
+			r1 = _mm_srai_epi16(r1, 3);
+			/* r_buf[i] = CLIP(r); */
+			_mm_between_epi16(r1, zero, max);
+			/* (y + HIWORD(cb*-5636) + HIWORD(cr*-11698)) >> 3 */
+			g1 = _mm_add_epi16(y1, _mm_mulhi_epi16(cb1, g_cb));
+			g1 = _mm_add_epi16(g1, _mm_mulhi_epi16(cr1, g_cr));
+			g1 = _mm_srai_epi16(g1, 3);
+			/* g_buf[i] = CLIP(g); */
+			_mm_between_epi16(g1, zero, max);
+			/* (y + HIWORD(cb*28999)) >> 3 */
+			b1 = _mm_add_epi16(y1, _mm_mulhi_epi16(cb1, b_cb));
+			b1 = _mm_srai_epi16(b1, 3);
+			/* b_buf[i] = CLIP(b); */
+			_mm_between_epi16(b1, zero, max);
+			y2 = _mm_load_si128(y_buf++);
+			y2 = _mm_add_epi16(y2, c4096);
+			y2 = _mm_srai_epi16(y2, 2);
+			/* cb = cb_g_buf[i]; */
+			cb2 = _mm_load_si128(cb_buf++);
+			/* cr = cr_b_buf[i]; */
+			cr2 = _mm_load_si128(cr_buf++);
+			/* (y + HIWORD(cr*22986)) >> 3 */
+			r2 = _mm_add_epi16(y2, _mm_mulhi_epi16(cr2, r_cr));
+			r2 = _mm_srai_epi16(r2, 3);
+			/* r_buf[i] = CLIP(r); */
+			_mm_between_epi16(r2, zero, max);
+			/* (y + HIWORD(cb*-5636) + HIWORD(cr*-11698)) >> 3 */
+			g2 = _mm_add_epi16(y2, _mm_mulhi_epi16(cb2, g_cb));
+			g2 = _mm_add_epi16(g2, _mm_mulhi_epi16(cr2, g_cr));
+			g2 = _mm_srai_epi16(g2, 3);
+			/* g_buf[i] = CLIP(g); */
+			_mm_between_epi16(g2, zero, max);
+			/* (y + HIWORD(cb*28999)) >> 3 */
+			b2 = _mm_add_epi16(y2, _mm_mulhi_epi16(cb2, b_cb));
+			b2 = _mm_srai_epi16(b2, 3);
+			/* b_buf[i] = CLIP(b); */
+			_mm_between_epi16(b2, zero, max);
+			{
+				__m128i R0, R1, R2, R3, R4;
+				/* The comments below pretend these are 8-byte registers
+				 * rather than 16-byte, for readability.
+				 */
+				R0 = b1; /* R0 = 00B300B200B100B0 */
+				R1 = b2; /* R1 = 00B700B600B500B4 */
+				R0 = _mm_packus_epi16(R0, R1);	/* R0 = B7B6B5B4B3B2B1B0 */
+				R1 = g1;		/* R1 = 00G300G200G100G0 */
+				R2 = g2;		/* R2 = 00G700G600G500G4 */
+				R1 = _mm_packus_epi16(R1, R2);				/* R1 = G7G6G5G4G3G2G1G0 */
+				R2 = R1;						/* R2 = G7G6G5G4G3G2G1G0 */
+				R2 = _mm_unpacklo_epi8(R0, R2);				/* R2 = B3G3B2G2B1G1B0G0 */
+				R1 = _mm_unpackhi_epi8(R0, R1);				/* R1 = B7G7B6G6B5G5B4G4 */
+				R0 = r1;		/* R0 = 00R300R200R100R0 */
+				R3 = r2;		/* R3 = 00R700R600R500R4 */
+				R0 = _mm_packus_epi16(R0, R3);				/* R0 = R7R6R5R4R3R2R1R0 */
+				R3 = _mm_set1_epi32(0xFFFFFFFFU);				/* R3 = FFFFFFFFFFFFFFFF */
+				R4 = R3;						/* R4 = FFFFFFFFFFFFFFFF */
+				R4 = _mm_unpacklo_epi8(R0, R4);				/* R4 = R3FFR2FFR1FFR0FF */
+				R3 = _mm_unpackhi_epi8(R0, R3);				/* R3 = R7FFR6FFR5FFR4FF */
+				R0 = R4;						/* R0 = R4               */
+				R0 = _mm_unpacklo_epi16(R2, R0);				/* R0 = B1G1R1FFB0G0R0FF */
+				R4 = _mm_unpackhi_epi16(R2, R4);				/* R4 = B3G3R3FFB2G2R2FF */
+				R2 = R3;						/* R2 = R3               */
+				R2 = _mm_unpacklo_epi16(R1, R2);				/* R2 = B5G5R5FFB4G4R4FF */
+				R3 = _mm_unpackhi_epi16(R1, R3);				/* R3 = B7G7R7FFB6G6R6FF */
+				_mm_store_si128(d_buf++, R0); /* B1G1R1FFB0G0R0FF      */
+				_mm_store_si128(d_buf++, R4); /* B3G3R3FFB2G2R2FF      */
+				_mm_store_si128(d_buf++, R2); /* B5G5R5FFB4G4R4FF      */
+				_mm_store_si128(d_buf++, R3); /* B7G7R7FFB6G6R6FF      */
+			}
+		}
+
+		y_buf  += yPad;
+		cb_buf += cbPad;
+		cr_buf += crPad;
+		d_buf += dstPad;
+	}
+
+	return PRIMITIVES_SUCCESS;
+}
+
+/*---------------------------------------------------------------------------*/
+static pstatus_t sse2_yCbCrToRGB_16s8u_P3AC4R_RGBX(
+    const INT16* pSrc[3], UINT32 srcStep,
+    BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
+    const prim_size_t* roi)	/* region of interest */
+{
+	__m128i zero, max, r_cr, g_cb, g_cr, b_cb, c4096;
+	const __m128i* y_buf, *cb_buf, *cr_buf;
+	__m128i* d_buf;
+	int srcbump, dstbump, yp, imax;
+	size_t dstPad, yPad, cbPad, crPad;
+
+	if (((ULONG_PTR)(pSrc[0]) & 0x0f)
+	    || ((ULONG_PTR)(pSrc[1]) & 0x0f)
+	    || ((ULONG_PTR)(pSrc[2]) & 0x0f)
+	    || ((ULONG_PTR)(pDst[0]) & 0x0f)
+	    || ((ULONG_PTR)(pDst[1]) & 0x0f)
+	    || ((ULONG_PTR)(pDst[2]) & 0x0f)
+	    || (roi->width & 0x07)
+	    || (srcStep & 127)
+	    || (dstStep & 127))
+	{
+		/* We can't maintain 16-byte alignment. */
+		return generic->yCbCrToRGB_16s8u_P3AC4R(pSrc, srcStep,
+		                                        pDst, dstStep, DstFormat, roi);
+	}
+
+	zero = _mm_setzero_si128();
+	max = _mm_set1_epi16(255);
+	y_buf  = (const __m128i*)(pSrc[0]);
+	cb_buf = (const __m128i*)(pSrc[1]);
+	cr_buf = (const __m128i*)(pSrc[2]);
+	d_buf = (__m128i*)pDst;
+	r_cr = _mm_set1_epi16(22986);	/*  1.403 << 14 */
+	g_cb = _mm_set1_epi16(-5636);	/* -0.344 << 14 */
+	g_cr = _mm_set1_epi16(-11698);	/* -0.714 << 14 */
+	b_cb = _mm_set1_epi16(28999);	/*  1.770 << 14 */
+	c4096 = _mm_set1_epi16(4096);
+	srcbump = srcStep / sizeof(__m128i);
+	dstbump = dstStep / sizeof(__m128i);
+	dstPad = (dstStep - roi->width * 4) / sizeof(__m128i);
+	yPad = 0;
+	cbPad = 0;
+	crPad = 0;
+#ifdef DO_PREFETCH
+
+	/* Prefetch Y's, Cb's, and Cr's. */
+	for (yp = 0; yp < roi->height; yp++)
+	{
+		int i;
+
+		for (i = 0; i < roi->width * sizeof(INT16) / sizeof(__m128i);
+		     i += (CACHE_LINE_BYTES / sizeof(__m128i)))
+		{
+			_mm_prefetch((char*)(&y_buf[i]),  _MM_HINT_NTA);
+			_mm_prefetch((char*)(&cb_buf[i]), _MM_HINT_NTA);
+			_mm_prefetch((char*)(&cr_buf[i]), _MM_HINT_NTA);
+		}
+
+		y_buf  += srcbump;
+		cb_buf += srcbump;
+		cr_buf += srcbump;
+	}
+
+	y_buf  = (__m128i*)(pSrc[0]);
+	cb_buf = (__m128i*)(pSrc[1]);
+	cr_buf = (__m128i*)(pSrc[2]);
+#endif /* DO_PREFETCH */
+	imax = roi->width * sizeof(INT16) / sizeof(__m128i);
+
+	for (yp = 0; yp < roi->height; ++yp)
+	{
+		int i;
+
+		for (i = 0; i < imax; i += 2)
+		{
+			/* In order to use SSE2 signed 16-bit integer multiplication
+			 * we need to convert the floating point factors to signed int
+			 * without losing information.
+			 * The result of this multiplication is 32 bit and we have two
+			 * SSE instructions that return either the hi or lo word.
+			 * Thus we will multiply the factors by the highest possible 2^n,
+			 * take the upper 16 bits of the signed 32-bit result
+			 * (_mm_mulhi_epi16) and correct this result by multiplying
+			 * it by 2^(16-n).
+			 *
+			 * For the given factors in the conversion matrix the best
+			 * possible n is 14.
+			 *
+			 * Example for calculating r:
+			 * r = (y>>5) + 128 + (cr*1.403)>>5             // our base formula
+			 * r = (y>>5) + 128 + (HIWORD(cr*(1.403<<14)<<2))>>5   // see above
+			 * r = (y+4096)>>5 + (HIWORD(cr*22986)<<2)>>5     // simplification
+			 * r = ((y+4096)>>2 + HIWORD(cr*22986)) >> 3
+			 */
+			/* y = (y_r_buf[i] + 4096) >> 2 */
+			__m128i y1, y2, cb1, cb2, cr1, cr2, r1, r2, g1, g2, b1, b2;
+			y1 = _mm_load_si128(y_buf++);
+			y1 = _mm_add_epi16(y1, c4096);
+			y1 = _mm_srai_epi16(y1, 2);
+			/* cb = cb_g_buf[i]; */
+			cb1 = _mm_load_si128(cb_buf++);
+			/* cr = cr_b_buf[i]; */
+			cr1 = _mm_load_si128(cr_buf++);
+			/* (y + HIWORD(cr*22986)) >> 3 */
+			r1 = _mm_add_epi16(y1, _mm_mulhi_epi16(cr1, r_cr));
+			r1 = _mm_srai_epi16(r1, 3);
+			/* r_buf[i] = CLIP(r); */
+			_mm_between_epi16(r1, zero, max);
+			/* (y + HIWORD(cb*-5636) + HIWORD(cr*-11698)) >> 3 */
+			g1 = _mm_add_epi16(y1, _mm_mulhi_epi16(cb1, g_cb));
+			g1 = _mm_add_epi16(g1, _mm_mulhi_epi16(cr1, g_cr));
+			g1 = _mm_srai_epi16(g1, 3);
+			/* g_buf[i] = CLIP(g); */
+			_mm_between_epi16(g1, zero, max);
+			/* (y + HIWORD(cb*28999)) >> 3 */
+			b1 = _mm_add_epi16(y1, _mm_mulhi_epi16(cb1, b_cb));
+			b1 = _mm_srai_epi16(b1, 3);
+			/* b_buf[i] = CLIP(b); */
+			_mm_between_epi16(b1, zero, max);
+			y2 = _mm_load_si128(y_buf++);
+			y2 = _mm_add_epi16(y2, c4096);
+			y2 = _mm_srai_epi16(y2, 2);
+			/* cb = cb_g_buf[i]; */
+			cb2 = _mm_load_si128(cb_buf++);
+			/* cr = cr_b_buf[i]; */
+			cr2 = _mm_load_si128(cr_buf++);
+			/* (y + HIWORD(cr*22986)) >> 3 */
+			r2 = _mm_add_epi16(y2, _mm_mulhi_epi16(cr2, r_cr));
+			r2 = _mm_srai_epi16(r2, 3);
+			/* r_buf[i] = CLIP(r); */
+			_mm_between_epi16(r2, zero, max);
+			/* (y + HIWORD(cb*-5636) + HIWORD(cr*-11698)) >> 3 */
+			g2 = _mm_add_epi16(y2, _mm_mulhi_epi16(cb2, g_cb));
+			g2 = _mm_add_epi16(g2, _mm_mulhi_epi16(cr2, g_cr));
+			g2 = _mm_srai_epi16(g2, 3);
+			/* g_buf[i] = CLIP(g); */
+			_mm_between_epi16(g2, zero, max);
+			/* (y + HIWORD(cb*28999)) >> 3 */
+			b2 = _mm_add_epi16(y2, _mm_mulhi_epi16(cb2, b_cb));
+			b2 = _mm_srai_epi16(b2, 3);
+			/* b_buf[i] = CLIP(b); */
+			_mm_between_epi16(b2, zero, max);
+			{
+				__m128i R0, R1, R2, R3, R4;
+				/* The comments below pretend these are 8-byte registers
+				 * rather than 16-byte, for readability.
+				 */
+				R0 = r1; /* R0 = 00R300R200R100R0 */
+				R1 = r2; /* R1 = 00R700R600R500R4 */
+				R0 = _mm_packus_epi16(R0, R1);	/* R0 = R7R6R5R4R3R2R1R0 */
+				R1 = g1;		/* R1 = 00G300G200G100G0 */
+				R2 = g2;		/* R2 = 00G700G600G500G4 */
+				R1 = _mm_packus_epi16(R1, R2);				/* R1 = G7G6G5G4G3G2G1G0 */
+				R2 = R1;						/* R2 = G7G6G5G4G3G2G1G0 */
+				R2 = _mm_unpacklo_epi8(R0, R2);				/* R2 = R3G3R2G2R1G1R0G0 */
+				R1 = _mm_unpackhi_epi8(R0, R1);				/* R1 = R7G7R6G6R5G5R4G4 */
+				R0 = b1;		/* R0 = 00B300B200B100B0 */
+				R3 = b2;		/* R3 = 00B700B600B500B4 */
+				R0 = _mm_packus_epi16(R0, R3);				/* R0 = B7B6B5B4B3B2B1B0 */
+				R3 = _mm_set1_epi32(0xFFFFFFFFU);				/* R3 = FFFFFFFFFFFFFFFF */
+				R4 = R3;						/* R4 = FFFFFFFFFFFFFFFF */
+				R4 = _mm_unpacklo_epi8(R0, R4);				/* R4 = B3FFB2FFB1FFB0FF */
+				R3 = _mm_unpackhi_epi8(R0, R3);				/* R3 = B7FFB6FFB5FFB4FF */
+				R0 = R4;						/* R0 = R4               */
+				R0 = _mm_unpacklo_epi16(R2, R0);				/* R0 = R1G1B1FFR0G0B0FF */
+				R4 = _mm_unpackhi_epi16(R2, R4);				/* R4 = R3G3B3FFR2G2B2FF */
+				R2 = R3;						/* R2 = R3               */
+				R2 = _mm_unpacklo_epi16(R1, R2);				/* R2 = R5G5B5FFR4G4B4FF */
+				R3 = _mm_unpackhi_epi16(R1, R3);				/* R3 = R7G7B7FFR6G6B6FF */
+				_mm_store_si128(d_buf++, R0); /* R1G1B1FFR0G0B0FF      */
+				_mm_store_si128(d_buf++, R4); /* R3G3B3FFR2G2B2FF      */
+				_mm_store_si128(d_buf++, R2); /* R5G5B5FFR4G4B4FF      */
+				_mm_store_si128(d_buf++, R3); /* R7G7B7FFR6G6B6FF      */
+			}
+		}
+
+		y_buf  += yPad;
+		cb_buf += cbPad;
+		cr_buf += crPad;
+		d_buf += dstPad;
+	}
+
+	return PRIMITIVES_SUCCESS;
+}
+
+static pstatus_t sse2_yCbCrToRGB_16s8u_P3AC4R(
+    const INT16* pSrc[3], UINT32 srcStep,
+    BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
+    const prim_size_t* roi)	/* region of interest */
+{
+	switch (DstFormat)
+	{
+		case PIXEL_FORMAT_BGRA32:
+		case PIXEL_FORMAT_BGRX32:
+			return sse2_yCbCrToRGB_16s8u_P3AC4R_BGRX(pSrc, srcStep, pDst, dstStep, DstFormat, roi);
+
+		case PIXEL_FORMAT_RGBA32:
+		case PIXEL_FORMAT_RGBX32:
+			return sse2_yCbCrToRGB_16s8u_P3AC4R_RGBX(pSrc, srcStep, pDst, dstStep, DstFormat, roi);
+
+		default:
+			return generic->yCbCrToRGB_16s8u_P3AC4R(pSrc, srcStep, pDst, dstStep, DstFormat, roi);
+	}
+}
 /* The encodec YCbCr coeffectients are represented as 11.5 fixed-point
  * numbers. See the general code above.
  */
@@ -337,119 +727,374 @@ static pstatus_t sse2_RGBToYCbCr_16s16s_P3P3(
 }
 
 /*---------------------------------------------------------------------------*/
-#define LOAD128(_src_) \
-	_mm_load_si128((__m128i *) _src_)
-#define STORE128(_dst_, _src_) \
-	_mm_store_si128((__m128i *) _dst_, _src_)
-#define PUNPCKLBW(_dst_, _src_) \
-	_dst_ = _mm_unpacklo_epi8(_src_, _dst_)
-#define PUNPCKHBW(_dst_, _src_) \
-	_dst_ = _mm_unpackhi_epi8(_src_, _dst_)
-#define PUNPCKLWD(_dst_, _src_) \
-	_dst_ = _mm_unpacklo_epi16(_src_, _dst_)
-#define PUNPCKHWD(_dst_, _src_) \
-	_dst_ = _mm_unpackhi_epi16(_src_, _dst_)
-#define PACKUSWB(_dst_, _src_) \
-	_dst_ = _mm_packus_epi16(_dst_, _src_)
-#define PREFETCH(_ptr_) \
-	_mm_prefetch((const void *) _ptr_, _MM_HINT_T0)
-#define XMM_ALL_ONES \
-	_mm_set1_epi32(0xFFFFFFFFU)
-
 static pstatus_t sse2_RGBToRGB_16s8u_P3AC4R_BGRX(
     const INT16* const pSrc[3],	/* 16-bit R,G, and B arrays */
     UINT32 srcStep,			/* bytes between rows in source data */
     BYTE* pDst,				/* 32-bit interleaved ARGB (ABGR?) data */
     UINT32 dstStep,			/* bytes between rows in dest data */
-    UINT32 DstFormat,
     const prim_size_t* roi)	/* region of interest */
 {
-	const UINT16* r = (const UINT16*)(pSrc[0]);
-	const UINT16* g = (const UINT16*)(pSrc[1]);
-	const UINT16* b = (const UINT16*)(pSrc[2]);
+	const UINT16* pr = (const UINT16*)(pSrc[0]);
+	const UINT16* pg = (const UINT16*)(pSrc[1]);
+	const UINT16* pb = (const UINT16*)(pSrc[2]);
+	const __m128i a = _mm_set1_epi32(0xFFFFFFFFU);
 	BYTE* out;
-	int srcbump, dstbump, y;
-
-	/* Ensure 16-byte alignment on all pointers,
-	 * that width is a multiple of 8,
-	 * and that the next row will also remain aligned.
-	 * Since this is usually used for 64x64 aligned arrays,
-	 * these checks should presumably pass.
-	 */
-	if ((((ULONG_PTR)(pSrc[0]) & 0x0f) != 0)
-	    || (((ULONG_PTR)(pSrc[1]) & 0x0f) != 0)
-	    || (((ULONG_PTR)(pSrc[2]) & 0x0f) != 0)
-	    || (((ULONG_PTR) pDst & 0x0f) != 0)
-	    || (roi->width & 0x0f)
-	    || (srcStep & 0x0f)
-	    || (dstStep & 0x0f))
-	{
-		return generic->RGBToRGB_16s8u_P3AC4R(pSrc, srcStep, pDst,
-		                                      dstStep, DstFormat, roi);
-	}
-
+	UINT32 srcbump, dstbump, y;
 	out = (BYTE*) pDst;
 	srcbump = (srcStep - (roi->width * sizeof(UINT16))) / sizeof(UINT16);
 	dstbump = (dstStep - (roi->width * sizeof(UINT32)));
 
 	for (y = 0; y < roi->height; ++y)
 	{
-		int width = roi->width;
+		UINT32 x;
 
-		do
+		for (x = 0; x < roi->width; x += 16)
 		{
-			__m128i R0, R1, R2, R3, R4;
+			__m128i r, g, b;
 			/* The comments below pretend these are 8-byte registers
 			 * rather than 16-byte, for readability.
 			 */
-			R0 = LOAD128(b);
-			b += 8;		/* R0 = 00B300B200B100B0 */
-			R1 = LOAD128(b);
-			b += 8;		/* R1 = 00B700B600B500B4 */
-			PACKUSWB(R0, R1);				/* R0 = B7B6B5B4B3B2B1B0 */
-			R1 = LOAD128(g);
-			g += 8;		/* R1 = 00G300G200G100G0 */
-			R2 = LOAD128(g);
-			g += 8;		/* R2 = 00G700G600G500G4 */
-			PACKUSWB(R1, R2);				/* R1 = G7G6G5G4G3G2G1G0 */
-			R2 = R1;						/* R2 = G7G6G5G4G3G2G1G0 */
-			PUNPCKLBW(R2, R0);				/* R2 = G3B3G2B2G1B1G0B0 */
-			PUNPCKHBW(R1, R0);				/* R1 = G7B7G6B7G5B5G4B4 */
-			R0 = LOAD128(r);
-			r += 8;		/* R0 = 00R300R200R100R0 */
-			R3 = LOAD128(r);
-			r += 8;		/* R3 = 00R700R600R500R4 */
-			PACKUSWB(R0, R3);				/* R0 = R7R6R5R4R3R2R1R0 */
-			R3 = XMM_ALL_ONES;				/* R3 = FFFFFFFFFFFFFFFF */
-			R4 = R3;						/* R4 = FFFFFFFFFFFFFFFF */
-			PUNPCKLBW(R4, R0);				/* R4 = FFR3FFR2FFR1FFR0 */
-			PUNPCKHBW(R3, R0);				/* R3 = FFR7FFR6FFR5FFR4 */
-			R0 = R4;						/* R0 = R4               */
-			PUNPCKLWD(R0, R2);				/* R0 = FFR1G1B1FFR0G0B0 */
-			PUNPCKHWD(R4, R2);				/* R4 = FFR3G3B3FFR2G2B2 */
-			R2 = R3;						/* R2 = R3               */
-			PUNPCKLWD(R2, R1);				/* R2 = FFR5G5B5FFR4G4B4 */
-			PUNPCKHWD(R3, R1);				/* R3 = FFR7G7B7FFR6G6B6 */
-			STORE128(out, R0);
-			out += 16;	/* FFR1G1B1FFR0G0B0      */
-			STORE128(out, R4);
-			out += 16;	/* FFR3G3B3FFR2G2B2      */
-			STORE128(out, R2);
-			out += 16;	/* FFR5G5B5FFR4G4B4      */
-			STORE128(out, R3);
-			out += 16;	/* FFR7G7B7FFR6G6B6      */
+			{
+				__m128i R0, R1;
+				R0 = _mm_loadu_si128((__m128i*)pb);
+				pb += 8;		/* R0 = 00B300B200B100B0 */
+				R1 = _mm_loadu_si128((__m128i*)pb);
+				pb += 8;		/* R1 = 00B700B600B500B4 */
+				b = _mm_packus_epi16(R0, R1);				/* b = B7B6B5B4B3B2B1B0 */
+			}
+			{
+				__m128i R0, R1;
+				R0 = _mm_loadu_si128((__m128i*)pg);
+				pg += 8;		/* R1 = 00G300G200G100G0 */
+				R1 = _mm_loadu_si128((__m128i*)pg);
+				pg += 8;		/* R2 = 00G700G600G500G4 */
+				g = _mm_packus_epi16(R0, R1);				/* g = G7G6G5G4G3G2G1G0 */
+			}
+			{
+				__m128i R0, R1;
+				R0 = _mm_loadu_si128((__m128i*)pr);
+				pr += 8;		/* R0 = 00R300R200R100R0 */
+				R1 = _mm_loadu_si128((__m128i*)pr);
+				pr += 8;		/* R3 = 00R700R600R500R4 */
+				r = _mm_packus_epi16(R0, R1);				/* r = R7R6R5R4R3R2R1R0 */
+			}
+			{
+				__m128i gbHi, gbLo, arHi, arLo;
+				{
+					gbLo = _mm_unpacklo_epi8(b, g);	/* R0 = G7G6G5G4G3G2G1G0 */
+					gbHi = _mm_unpackhi_epi8(b, g);	/* R1 = G7B7G6B7G5B5G4B4 */
+					arLo = _mm_unpacklo_epi8(r, a);	/* R4 = FFR3FFR2FFR1FFR0 */
+					arHi = _mm_unpackhi_epi8(r, a);	/* R3 = FFR7FFR6FFR5FFR4 */
+				}
+				{
+					const __m128i bgrx = _mm_unpacklo_epi16(gbLo, arLo);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR1G1B1FFR0G0B0      */
+				}
+				{
+					const __m128i bgrx = _mm_unpackhi_epi16(gbLo, arLo);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR3G3B3FFR2G2B2      */
+				}
+				{
+					const __m128i bgrx = _mm_unpacklo_epi16(gbHi, arHi);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR5G5B5FFR4G4B4      */
+				}
+				{
+					const __m128i bgrx = _mm_unpackhi_epi16(gbHi, arHi);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR7G7B7FFR6G6B6      */
+				}
+			}
 		}
-		while (width -= 16);
 
 		/* Jump to next row. */
-		r += srcbump;
-		g += srcbump;
-		b += srcbump;
+		pr += srcbump;
+		pg += srcbump;
+		pb += srcbump;
 		out += dstbump;
 	}
 
 	return PRIMITIVES_SUCCESS;
 }
+
+static pstatus_t sse2_RGBToRGB_16s8u_P3AC4R_RGBX(
+    const INT16* const pSrc[3],	/* 16-bit R,G, and B arrays */
+    UINT32 srcStep,			/* bytes between rows in source data */
+    BYTE* pDst,				/* 32-bit interleaved ARGB (ABGR?) data */
+    UINT32 dstStep,			/* bytes between rows in dest data */
+    const prim_size_t* roi)	/* region of interest */
+{
+	const UINT16* pr = (const UINT16*)(pSrc[0]);
+	const UINT16* pg = (const UINT16*)(pSrc[1]);
+	const UINT16* pb = (const UINT16*)(pSrc[2]);
+	const __m128i a = _mm_set1_epi32(0xFFFFFFFFU);
+	BYTE* out;
+	UINT32 srcbump, dstbump, y;
+	out = (BYTE*) pDst;
+	srcbump = (srcStep - (roi->width * sizeof(UINT16))) / sizeof(UINT16);
+	dstbump = (dstStep - (roi->width * sizeof(UINT32)));
+
+	for (y = 0; y < roi->height; ++y)
+	{
+		UINT32 x;
+
+		for (x = 0; x < roi->width; x += 16)
+		{
+			__m128i r, g, b;
+			/* The comments below pretend these are 8-byte registers
+			 * rather than 16-byte, for readability.
+			 */
+			{
+				__m128i R0, R1;
+				R0 = _mm_loadu_si128((__m128i*)pb);
+				pb += 8;		/* R0 = 00B300B200B100B0 */
+				R1 = _mm_loadu_si128((__m128i*)pb);
+				pb += 8;		/* R1 = 00B700B600B500B4 */
+				b = _mm_packus_epi16(R0, R1);				/* b = B7B6B5B4B3B2B1B0 */
+			}
+			{
+				__m128i R0, R1;
+				R0 = _mm_loadu_si128((__m128i*)pg);
+				pg += 8;		/* R1 = 00G300G200G100G0 */
+				R1 = _mm_loadu_si128((__m128i*)pg);
+				pg += 8;		/* R2 = 00G700G600G500G4 */
+				g = _mm_packus_epi16(R0, R1);				/* g = G7G6G5G4G3G2G1G0 */
+			}
+			{
+				__m128i R0, R1;
+				R0 = _mm_loadu_si128((__m128i*)pr);
+				pr += 8;		/* R0 = 00R300R200R100R0 */
+				R1 = _mm_loadu_si128((__m128i*)pr);
+				pr += 8;		/* R3 = 00R700R600R500R4 */
+				r = _mm_packus_epi16(R0, R1);				/* r = R7R6R5R4R3R2R1R0 */
+			}
+			{
+				__m128i gbHi, gbLo, arHi, arLo;
+				{
+					gbLo = _mm_unpacklo_epi8(r, g);	/* R0 = G7G6G5G4G3G2G1G0 */
+					gbHi = _mm_unpackhi_epi8(r, g);	/* R1 = G7B7G6B7G5B5G4B4 */
+					arLo = _mm_unpacklo_epi8(b, a);	/* R4 = FFR3FFR2FFR1FFR0 */
+					arHi = _mm_unpackhi_epi8(b, a);	/* R3 = FFR7FFR6FFR5FFR4 */
+				}
+				{
+					const __m128i bgrx = _mm_unpacklo_epi16(gbLo, arLo);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR1G1B1FFR0G0B0      */
+				}
+				{
+					const __m128i bgrx = _mm_unpackhi_epi16(gbLo, arLo);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR3G3B3FFR2G2B2      */
+				}
+				{
+					const __m128i bgrx = _mm_unpacklo_epi16(gbHi, arHi);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR5G5B5FFR4G4B4      */
+				}
+				{
+					const __m128i bgrx = _mm_unpackhi_epi16(gbHi, arHi);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR7G7B7FFR6G6B6      */
+				}
+			}
+		}
+
+		/* Jump to next row. */
+		pr += srcbump;
+		pg += srcbump;
+		pb += srcbump;
+		out += dstbump;
+	}
+
+	return PRIMITIVES_SUCCESS;
+}
+
+static pstatus_t sse2_RGBToRGB_16s8u_P3AC4R_XBGR(
+    const INT16* const pSrc[3],	/* 16-bit R,G, and B arrays */
+    UINT32 srcStep,			/* bytes between rows in source data */
+    BYTE* pDst,				/* 32-bit interleaved ARGB (ABGR?) data */
+    UINT32 dstStep,			/* bytes between rows in dest data */
+    const prim_size_t* roi)	/* region of interest */
+{
+	const UINT16* pr = (const UINT16*)(pSrc[0]);
+	const UINT16* pg = (const UINT16*)(pSrc[1]);
+	const UINT16* pb = (const UINT16*)(pSrc[2]);
+	const __m128i a = _mm_set1_epi32(0xFFFFFFFFU);
+	BYTE* out;
+	UINT32 srcbump, dstbump, y;
+	out = (BYTE*) pDst;
+	srcbump = (srcStep - (roi->width * sizeof(UINT16))) / sizeof(UINT16);
+	dstbump = (dstStep - (roi->width * sizeof(UINT32)));
+
+	for (y = 0; y < roi->height; ++y)
+	{
+		UINT32 x;
+
+		for (x = 0; x < roi->width; x += 16)
+		{
+			__m128i r, g, b;
+			/* The comments below pretend these are 8-byte registers
+			 * rather than 16-byte, for readability.
+			 */
+			{
+				__m128i R0, R1;
+				R0 = _mm_loadu_si128((__m128i*)pb);
+				pb += 8;		/* R0 = 00B300B200B100B0 */
+				R1 = _mm_loadu_si128((__m128i*)pb);
+				pb += 8;		/* R1 = 00B700B600B500B4 */
+				b = _mm_packus_epi16(R0, R1);				/* b = B7B6B5B4B3B2B1B0 */
+			}
+			{
+				__m128i R0, R1;
+				R0 = _mm_loadu_si128((__m128i*)pg);
+				pg += 8;		/* R1 = 00G300G200G100G0 */
+				R1 = _mm_loadu_si128((__m128i*)pg);
+				pg += 8;		/* R2 = 00G700G600G500G4 */
+				g = _mm_packus_epi16(R0, R1);				/* g = G7G6G5G4G3G2G1G0 */
+			}
+			{
+				__m128i R0, R1;
+				R0 = _mm_loadu_si128((__m128i*)pr);
+				pr += 8;		/* R0 = 00R300R200R100R0 */
+				R1 = _mm_loadu_si128((__m128i*)pr);
+				pr += 8;		/* R3 = 00R700R600R500R4 */
+				r = _mm_packus_epi16(R0, R1);				/* r = R7R6R5R4R3R2R1R0 */
+			}
+			{
+				__m128i gbHi, gbLo, arHi, arLo;
+				{
+					gbLo = _mm_unpacklo_epi8(a, b);	/* R0 = G7G6G5G4G3G2G1G0 */
+					gbHi = _mm_unpackhi_epi8(a, b);	/* R1 = G7B7G6B7G5B5G4B4 */
+					arLo = _mm_unpacklo_epi8(g, r);	/* R4 = FFR3FFR2FFR1FFR0 */
+					arHi = _mm_unpackhi_epi8(g, r);	/* R3 = FFR7FFR6FFR5FFR4 */
+				}
+				{
+					const __m128i bgrx = _mm_unpacklo_epi16(gbLo, arLo);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR1G1B1FFR0G0B0      */
+				}
+				{
+					const __m128i bgrx = _mm_unpackhi_epi16(gbLo, arLo);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR3G3B3FFR2G2B2      */
+				}
+				{
+					const __m128i bgrx = _mm_unpacklo_epi16(gbHi, arHi);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR5G5B5FFR4G4B4      */
+				}
+				{
+					const __m128i bgrx = _mm_unpackhi_epi16(gbHi, arHi);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR7G7B7FFR6G6B6      */
+				}
+			}
+		}
+
+		/* Jump to next row. */
+		pr += srcbump;
+		pg += srcbump;
+		pb += srcbump;
+		out += dstbump;
+	}
+
+	return PRIMITIVES_SUCCESS;
+}
+
+static pstatus_t sse2_RGBToRGB_16s8u_P3AC4R_XRGB(
+    const INT16* const pSrc[3],	/* 16-bit R,G, and B arrays */
+    UINT32 srcStep,			/* bytes between rows in source data */
+    BYTE* pDst,				/* 32-bit interleaved ARGB (ABGR?) data */
+    UINT32 dstStep,			/* bytes between rows in dest data */
+    const prim_size_t* roi)	/* region of interest */
+{
+	const UINT16* pr = (const UINT16*)(pSrc[0]);
+	const UINT16* pg = (const UINT16*)(pSrc[1]);
+	const UINT16* pb = (const UINT16*)(pSrc[2]);
+	const __m128i a = _mm_set1_epi32(0xFFFFFFFFU);
+	BYTE* out;
+	UINT32 srcbump, dstbump, y;
+	out = (BYTE*) pDst;
+	srcbump = (srcStep - (roi->width * sizeof(UINT16))) / sizeof(UINT16);
+	dstbump = (dstStep - (roi->width * sizeof(UINT32)));
+
+	for (y = 0; y < roi->height; ++y)
+	{
+		UINT32 x;
+
+		for (x = 0; x < roi->width; x += 16)
+		{
+			__m128i r, g, b;
+			/* The comments below pretend these are 8-byte registers
+			 * rather than 16-byte, for readability.
+			 */
+			{
+				__m128i R0, R1;
+				R0 = _mm_loadu_si128((__m128i*)pb);
+				pb += 8;		/* R0 = 00B300B200B100B0 */
+				R1 = _mm_loadu_si128((__m128i*)pb);
+				pb += 8;		/* R1 = 00B700B600B500B4 */
+				b = _mm_packus_epi16(R0, R1);				/* b = B7B6B5B4B3B2B1B0 */
+			}
+			{
+				__m128i R0, R1;
+				R0 = _mm_loadu_si128((__m128i*)pg);
+				pg += 8;		/* R1 = 00G300G200G100G0 */
+				R1 = _mm_loadu_si128((__m128i*)pg);
+				pg += 8;		/* R2 = 00G700G600G500G4 */
+				g = _mm_packus_epi16(R0, R1);				/* g = G7G6G5G4G3G2G1G0 */
+			}
+			{
+				__m128i R0, R1;
+				R0 = _mm_loadu_si128((__m128i*)pr);
+				pr += 8;		/* R0 = 00R300R200R100R0 */
+				R1 = _mm_loadu_si128((__m128i*)pr);
+				pr += 8;		/* R3 = 00R700R600R500R4 */
+				r = _mm_packus_epi16(R0, R1);				/* r = R7R6R5R4R3R2R1R0 */
+			}
+			{
+				__m128i gbHi, gbLo, arHi, arLo;
+				{
+					gbLo = _mm_unpacklo_epi8(a, r);	/* R0 = G7G6G5G4G3G2G1G0 */
+					gbHi = _mm_unpackhi_epi8(a, r);	/* R1 = G7B7G6B7G5B5G4B4 */
+					arLo = _mm_unpacklo_epi8(g, b);	/* R4 = FFR3FFR2FFR1FFR0 */
+					arHi = _mm_unpackhi_epi8(g, b);	/* R3 = FFR7FFR6FFR5FFR4 */
+				}
+				{
+					const __m128i bgrx = _mm_unpacklo_epi16(gbLo, arLo);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR1G1B1FFR0G0B0      */
+				}
+				{
+					const __m128i bgrx = _mm_unpackhi_epi16(gbLo, arLo);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR3G3B3FFR2G2B2      */
+				}
+				{
+					const __m128i bgrx = _mm_unpacklo_epi16(gbHi, arHi);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR5G5B5FFR4G4B4      */
+				}
+				{
+					const __m128i bgrx = _mm_unpackhi_epi16(gbHi, arHi);
+					_mm_store_si128((__m128i*)out, bgrx);
+					out += 16;	/* FFR7G7B7FFR6G6B6      */
+				}
+			}
+		}
+
+		/* Jump to next row. */
+		pr += srcbump;
+		pg += srcbump;
+		pb += srcbump;
+		out += dstbump;
+	}
+
+	return PRIMITIVES_SUCCESS;
+}
+
 static pstatus_t sse2_RGBToRGB_16s8u_P3AC4R(
     const INT16* const pSrc[3],	/* 16-bit R,G, and B arrays */
     UINT32 srcStep,			/* bytes between rows in source data */
@@ -462,7 +1107,19 @@ static pstatus_t sse2_RGBToRGB_16s8u_P3AC4R(
 	{
 		case PIXEL_FORMAT_BGRA32:
 		case PIXEL_FORMAT_BGRX32:
-			return sse2_RGBToRGB_16s8u_P3AC4R_BGRX(pSrc, srcStep, pDst, dstStep, DstFormat, roi);
+			return sse2_RGBToRGB_16s8u_P3AC4R_BGRX(pSrc, srcStep, pDst, dstStep, roi);
+
+		case PIXEL_FORMAT_RGBA32:
+		case PIXEL_FORMAT_RGBX32:
+			return sse2_RGBToRGB_16s8u_P3AC4R_RGBX(pSrc, srcStep, pDst, dstStep, roi);
+
+		case PIXEL_FORMAT_ABGR32:
+		case PIXEL_FORMAT_XBGR32:
+			return sse2_RGBToRGB_16s8u_P3AC4R_XBGR(pSrc, srcStep, pDst, dstStep, roi);
+
+		case PIXEL_FORMAT_ARGB32:
+		case PIXEL_FORMAT_XRGB32:
+			return sse2_RGBToRGB_16s8u_P3AC4R_XRGB(pSrc, srcStep, pDst, dstStep, roi);
 
 		default:
 			return generic->RGBToRGB_16s8u_P3AC4R(pSrc, srcStep, pDst, dstStep, DstFormat, roi);
@@ -559,9 +1216,240 @@ static pstatus_t neon_yCbCrToRGB_16s16s_P3P3(
 	return PRIMITIVES_SUCCESS;
 }
 
+static pstatus_t neon_yCbCrToRGB_16s8u_P3AC4R_X(
+    const INT16* pSrc[3], UINT32 srcStep,
+    BYTE* pDst, UINT32 dstStep,
+    const prim_size_t* roi,
+    uint8_t rPos,
+    uint8_t gPos,
+    uint8_t bPos,
+    uint8_t aPos)
+{
+	UINT32 x, y;
+	BYTE* pRGB = pDst;
+	const INT16* pY  = pSrc[0];
+	const INT16* pCb = pSrc[1];
+	const INT16* pCr = pSrc[2];
+	const size_t srcPad = (srcStep - (roi->width * sizeof(INT16))) / sizeof(INT16);
+	const size_t dstPad = (dstStep - (roi->width * 4)) / 4;
+	const size_t pad = roi->width % 8;
+	const int16x4_t c4096 = vdup_n_s16(4096);
+
+	for (y = 0; y < roi->height; y++)
+	{
+		for (x = 0; x < roi->width - pad; x += 8)
+		{
+			const int16x8_t Y = vld1q_s16(pY);
+			const int16x4_t Yh = vget_high_s16(Y);
+			const int16x4_t Yl = vget_low_s16(Y);
+			const int32x4_t YhAdd = vaddl_s16(Yh, c4096); /* Y + 4096 */
+			const int32x4_t YlAdd = vaddl_s16(Yl, c4096); /* Y + 4096 */
+			const int32x4_t YhW = vshlq_n_s32(YhAdd, 16);
+			const int32x4_t YlW = vshlq_n_s32(YlAdd, 16);
+			const int16x8_t Cr = vld1q_s16(pCr);
+			const int16x4_t Crh = vget_high_s16(Cr);
+			const int16x4_t Crl = vget_low_s16(Cr);
+			const int16x8_t Cb = vld1q_s16(pCb);
+			const int16x4_t Cbh = vget_high_s16(Cb);
+			const int16x4_t Cbl = vget_low_s16(Cb);
+			uint8x8x4_t bgrx;
+			{
+				/* R */
+				const int32x4_t CrhR = vmulq_n_s32(vmovl_s16(Crh), 91916); /* 1.402525 * 2^16 */
+				const int32x4_t CrlR = vmulq_n_s32(vmovl_s16(Crl), 91916); /* 1.402525 * 2^16 */
+				const int32x4_t CrhRa = vaddq_s32(CrhR, YhW);
+				const int32x4_t CrlRa = vaddq_s32(CrlR, YlW);
+				const int16x4_t Rsh = vmovn_s32(vshrq_n_s32(CrhRa, 21));
+				const int16x4_t Rsl = vmovn_s32(vshrq_n_s32(CrlRa, 21));
+				const int16x8_t Rs = vcombine_s16(Rsl, Rsh);
+				bgrx.val[rPos] = vqmovun_s16(Rs);
+			}
+			{
+				/* G */
+				const int32x4_t CbGh = vmull_n_s16(Cbh, 22527); /* 0.343730 * 2^16 */
+				const int32x4_t CbGl = vmull_n_s16(Cbl, 22527); /* 0.343730 * 2^16 */
+				const int32x4_t CrGh = vmulq_n_s32(vmovl_s16(Crh), 46819); /* 0.714401 * 2^16 */
+				const int32x4_t CrGl = vmulq_n_s32(vmovl_s16(Crl), 46819); /* 0.714401 * 2^16 */
+				const int32x4_t CbCrGh = vaddq_s32(CbGh, CrGh);
+				const int32x4_t CbCrGl = vaddq_s32(CbGl, CrGl);
+				const int32x4_t YCbCrGh = vsubq_s32(YhW, CbCrGh);
+				const int32x4_t YCbCrGl = vsubq_s32(YlW, CbCrGl);
+				const int16x4_t Gsh = vmovn_s32(vshrq_n_s32(YCbCrGh, 21));
+				const int16x4_t Gsl = vmovn_s32(vshrq_n_s32(YCbCrGl, 21));
+				const int16x8_t Gs = vcombine_s16(Gsl, Gsh);
+				const uint8x8_t G = vqmovun_s16(Gs);
+				bgrx.val[gPos] = G;
+			}
+			{
+				/* B */
+				const int32x4_t CbBh = vmulq_n_s32(vmovl_s16(Cbh), 115992); /* 1.769905 * 2^16 */
+				const int32x4_t CbBl = vmulq_n_s32(vmovl_s16(Cbl), 115992); /* 1.769905 * 2^16 */
+				const int32x4_t YCbBh = vaddq_s32(CbBh, YhW);
+				const int32x4_t YCbBl = vaddq_s32(CbBl, YlW);
+				const int16x4_t Bsh = vmovn_s32(vshrq_n_s32(YCbBh, 21));
+				const int16x4_t Bsl = vmovn_s32(vshrq_n_s32(YCbBl, 21));
+				const int16x8_t Bs = vcombine_s16(Bsl, Bsh);
+				const uint8x8_t B = vqmovun_s16(Bs);
+				bgrx.val[bPos] = B;
+			}
+			/* A */
+			{
+				bgrx.val[aPos] = vdup_n_u8(0xFF);
+			}
+			vst4_u8(pRGB, bgrx);
+			pY += 8;
+			pCb += 8;
+			pCr += 8;
+			pRGB += 32;
+		}
+
+		for (x = 0; x < pad; x++)
+		{
+			const INT32 divisor = 16;
+			const INT32 Y = ((*pY++) + 4096) << divisor;
+			const INT32 Cb = (*pCb++);
+			const INT32 Cr = (*pCr++);
+			const INT32 CrR = Cr * (INT32)(1.402525f * (1 << divisor));
+			const INT32 CrG = Cr * (INT32)(0.714401f * (1 << divisor));
+			const INT32 CbG = Cb * (INT32)(0.343730f * (1 << divisor));
+			const INT32 CbB = Cb * (INT32)(1.769905f * (1 << divisor));
+			INT16 R = ((INT16)((CrR + Y) >> divisor) >> 5);
+			INT16 G = ((INT16)((Y - CbG - CrG) >> divisor) >> 5);
+			INT16 B = ((INT16)((CbB + Y) >> divisor) >> 5);
+			BYTE bgrx[4];
+			bgrx[bPos] = CLIP(B);
+			bgrx[gPos] = CLIP(G);
+			bgrx[rPos] = CLIP(R);
+			bgrx[aPos] = 0xFF;
+			*pRGB++ = bgrx[0];
+			*pRGB++ = bgrx[1];
+			*pRGB++ = bgrx[2];
+			*pRGB++ = bgrx[3];
+		}
+
+		pY += srcPad;
+		pCb += srcPad;
+		pCr += srcPad;
+		pRGB += dstPad;
+	}
+
+	return PRIMITIVES_SUCCESS;
+}
+
+static pstatus_t neon_yCbCrToRGB_16s8u_P3AC4R(
+    const INT16* pSrc[3], UINT32 srcStep,
+    BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
+    const prim_size_t* roi)
+{
+	switch (DstFormat)
+	{
+		case PIXEL_FORMAT_BGRA32:
+		case PIXEL_FORMAT_BGRX32:
+			return neon_yCbCrToRGB_16s8u_P3AC4R_X(pSrc, srcStep, pDst, dstStep, roi, 2, 1, 0, 3);
+
+		case PIXEL_FORMAT_RGBA32:
+		case PIXEL_FORMAT_RGBX32:
+			return neon_yCbCrToRGB_16s8u_P3AC4R_X(pSrc, srcStep, pDst, dstStep, roi, 0, 1, 2, 3);
+
+		case PIXEL_FORMAT_ARGB32:
+		case PIXEL_FORMAT_XRGB32:
+			return neon_yCbCrToRGB_16s8u_P3AC4R_X(pSrc, srcStep, pDst, dstStep, roi, 1, 2, 3, 0);
+
+		case PIXEL_FORMAT_ABGR32:
+		case PIXEL_FORMAT_XBGR32:
+			return neon_yCbCrToRGB_16s8u_P3AC4R_X(pSrc, srcStep, pDst, dstStep, roi, 3, 2, 1, 0);
+
+		default:
+			return generic->yCbCrToRGB_16s8u_P3AC4R(pSrc, srcStep, pDst, dstStep, DstFormat, roi);
+	}
+}
+
+static pstatus_t neon_RGBToRGB_16s8u_P3AC4R_X(
+    const INT16* const pSrc[3],	/* 16-bit R,G, and B arrays */
+    UINT32 srcStep,			/* bytes between rows in source data */
+    BYTE* pDst,			/* 32-bit interleaved ARGB (ABGR?) data */
+    UINT32 dstStep,			/* bytes between rows in dest data */
+    const prim_size_t* roi,	/* region of interest */
+    uint8_t rPos,
+    uint8_t gPos,
+    uint8_t bPos,
+    uint8_t aPos)
+{
+	UINT32 x, y;
+	UINT32 pad = roi->width % 8;
+
+	for (y = 0; y < roi->height; y++)
+	{
+		const INT16* pr = (INT16*)(((BYTE*)pSrc[0]) + y * srcStep);
+		const INT16* pg = (INT16*)(((BYTE*)pSrc[1]) + y * srcStep);
+		const INT16* pb = (INT16*)(((BYTE*)pSrc[2]) + y * srcStep);
+		BYTE* dst = pDst + y * dstStep;
+
+		for (x = 0; x < roi->width - pad; x += 8)
+		{
+			int16x8_t r = vld1q_s16(pr);
+			int16x8_t g = vld1q_s16(pg);
+			int16x8_t b = vld1q_s16(pb);
+			uint8x8x4_t bgrx;
+			bgrx.val[aPos] = vdup_n_u8(0xFF);
+			bgrx.val[rPos] = vqmovun_s16(r);
+			bgrx.val[gPos] = vqmovun_s16(g);
+			bgrx.val[bPos] = vqmovun_s16(b);
+			vst4_u8(dst, bgrx);
+			pr += 8;
+			pg += 8;
+			pb += 8;
+			dst += 32;
+		}
+
+		for (x = 0; x < pad; x ++)
+		{
+			BYTE bgrx[4];
+			bgrx[bPos] = *pb++;
+			bgrx[gPos] = *pg++;
+			bgrx[rPos] = *pr++;
+			bgrx[aPos] = 0xFF;
+			*dst++ = bgrx[0];
+			*dst++ = bgrx[1];
+			*dst++ = bgrx[2];
+			*dst++ = bgrx[3];
+		}
+	}
+
+	return PRIMITIVES_SUCCESS;
+}
+
+static pstatus_t neon_RGBToRGB_16s8u_P3AC4R(
+    const INT16* const pSrc[3],	/* 16-bit R,G, and B arrays */
+    UINT32 srcStep,			/* bytes between rows in source data */
+    BYTE* pDst,			/* 32-bit interleaved ARGB (ABGR?) data */
+    UINT32 dstStep,			/* bytes between rows in dest data */
+    UINT32 DstFormat,
+    const prim_size_t* roi)	/* region of interest */
+{
+	switch (DstFormat)
+	{
+		case PIXEL_FORMAT_BGRA32:
+		case PIXEL_FORMAT_BGRX32:
+			return neon_RGBToRGB_16s8u_P3AC4R_X(pSrc, srcStep, pDst, dstStep, roi, 2, 1, 0, 3);
+
+		case PIXEL_FORMAT_RGBA32:
+		case PIXEL_FORMAT_RGBX32:
+			return neon_RGBToRGB_16s8u_P3AC4R_X(pSrc, srcStep, pDst, dstStep, roi, 0, 1, 2, 3);
+
+		case PIXEL_FORMAT_ARGB32:
+		case PIXEL_FORMAT_XRGB32:
+			return neon_RGBToRGB_16s8u_P3AC4R_X(pSrc, srcStep, pDst, dstStep, roi, 1, 2, 3, 0);
+
+		case PIXEL_FORMAT_ABGR32:
+		case PIXEL_FORMAT_XBGR32:
+			return neon_RGBToRGB_16s8u_P3AC4R_X(pSrc, srcStep, pDst, dstStep, roi, 3, 2, 1, 0);
+
+		default:
+			return generic->yCbCrToRGB_16s8u_P3AC4R(pSrc, srcStep, pDst, dstStep, DstFormat, roi);
+	}
+}
 #endif /* WITH_NEON */
-
-
 /* I don't see a direct IPP version of this, since the input is INT16
  * YCbCr.  It may be possible via  Deinterleave and then YCbCrToRGB_<mod>.
  * But that would likely be slower.
@@ -578,6 +1466,7 @@ void primitives_init_colors_opt(primitives_t* prims)
 	{
 		prims->RGBToRGB_16s8u_P3AC4R  = sse2_RGBToRGB_16s8u_P3AC4R;
 		prims->yCbCrToRGB_16s16s_P3P3 = sse2_yCbCrToRGB_16s16s_P3P3;
+		prims->yCbCrToRGB_16s8u_P3AC4R = sse2_yCbCrToRGB_16s8u_P3AC4R;
 		prims->RGBToYCbCr_16s16s_P3P3 = sse2_RGBToYCbCr_16s16s_P3P3;
 	}
 
@@ -585,6 +1474,8 @@ void primitives_init_colors_opt(primitives_t* prims)
 
 	if (IsProcessorFeaturePresent(PF_ARM_NEON_INSTRUCTIONS_AVAILABLE))
 	{
+		prims->RGBToRGB_16s8u_P3AC4R  = neon_RGBToRGB_16s8u_P3AC4R;
+		prims->yCbCrToRGB_16s8u_P3AC4R = neon_yCbCrToRGB_16s8u_P3AC4R;
 		prims->yCbCrToRGB_16s16s_P3P3 = neon_yCbCrToRGB_16s16s_P3P3;
 	}
 

--- a/libfreerdp/primitives/prim_internal.h
+++ b/libfreerdp/primitives/prim_internal.h
@@ -129,6 +129,47 @@ static INLINE BYTE CLIP(INT32 X)
 	return X;
 }
 
+/**
+ * | R |   ( | 256     0    403 | |    Y    | )
+ * | G | = ( | 256   -48   -120 | | U - 128 | ) >> 8
+ * | B |   ( | 256   475      0 | | V - 128 | )
+ */
+static INLINE INT32 C(INT32 Y)
+{
+	return (Y) -   0L;
+}
+
+static INLINE INT32 D(INT32 U)
+{
+	return (U) - 128L;
+}
+
+static INLINE INT32 E(INT32 V)
+{
+	return (V) - 128L;
+}
+
+static INLINE BYTE YUV2R(INT32 Y, INT32 U, INT32 V)
+{
+	const INT32 r = (256L * C(Y) +   0L * D(U) + 403L * E(V));
+	const INT32 r8 = r >> 8L;
+	return CLIP(r8);
+}
+
+static INLINE BYTE YUV2G(INT32 Y, INT32 U, INT32 V)
+{
+	const INT32 g = (256L * C(Y) -  48L * D(U) - 120L * E(V));
+	const INT32 g8 = g >> 8L;
+	return CLIP(g8);
+}
+
+static INLINE BYTE YUV2B(INT32 Y, INT32 U, INT32 V)
+{
+	const INT32 b = (256L * C(Y) + 475L * D(U) +   0L * E(V));
+	const INT32 b8 = b >> 8L;
+	return CLIP(b8);
+}
+
 /* Function prototypes for all the init/deinit routines. */
 FREERDP_LOCAL void primitives_init_copy(primitives_t* prims);
 FREERDP_LOCAL void primitives_init_set(primitives_t* prims);

--- a/libfreerdp/primitives/test/TestPrimitivesSign.c
+++ b/libfreerdp/primitives/test/TestPrimitivesSign.c
@@ -25,16 +25,19 @@
 static BOOL test_sign16s_func(void)
 {
 	pstatus_t status;
-	INT16 ALIGN(src[TEST_BUFFER_SIZE]);
-	INT16 ALIGN(d1[TEST_BUFFER_SIZE]);
-	INT16 ALIGN(d2[TEST_BUFFER_SIZE]);
-
+	INT16 ALIGN(src[TEST_BUFFER_SIZE + 16]);
+	INT16 ALIGN(d1[TEST_BUFFER_SIZE + 16]);
+	INT16 ALIGN(d2[TEST_BUFFER_SIZE + 16]);
 	winpr_RAND((BYTE*)src, sizeof(src));
-
+	memset(d1, 0, sizeof(d1));
+	memset(d2, 0, sizeof(d2));
 	status = generic->sign_16s(src + 1, d1 + 1, TEST_BUFFER_SIZE);
+
 	if (status != PRIMITIVES_SUCCESS)
 		return FALSE;
+
 	status = optimized->sign_16s(src + 1, d2 + 1, TEST_BUFFER_SIZE);
+
 	if (status != PRIMITIVES_SUCCESS)
 		return FALSE;
 
@@ -42,9 +45,12 @@ static BOOL test_sign16s_func(void)
 		return FALSE;
 
 	status = generic->sign_16s(src + 1, d1 + 2, TEST_BUFFER_SIZE);
+
 	if (status != PRIMITIVES_SUCCESS)
 		return FALSE;
+
 	status = optimized->sign_16s(src + 1, d2 + 2, TEST_BUFFER_SIZE);
+
 	if (status != PRIMITIVES_SUCCESS)
 		return FALSE;
 
@@ -60,15 +66,15 @@ static int test_sign16s_speed(void)
 	winpr_RAND((BYTE*)src, sizeof(src));
 
 	if (!speed_test("sign16s", "aligned", g_Iterations,
-			(speed_test_fkt)generic->sign_16s,
-			(speed_test_fkt)optimized->sign_16s, src + 1, dst + 1,
-			MAX_TEST_SIZE))
+	                (speed_test_fkt)generic->sign_16s,
+	                (speed_test_fkt)optimized->sign_16s, src + 1, dst + 1,
+	                MAX_TEST_SIZE))
 		return FALSE;
 
 	if (!speed_test("sign16s", "unaligned", g_Iterations,
-			(speed_test_fkt)generic->sign_16s,
-			(speed_test_fkt)optimized->sign_16s, src + 1, dst + 2,
-			MAX_TEST_SIZE))
+	                (speed_test_fkt)generic->sign_16s,
+	                (speed_test_fkt)optimized->sign_16s, src + 1, dst + 2,
+	                MAX_TEST_SIZE))
 		return FALSE;
 
 	return TRUE;

--- a/libfreerdp/primitives/test/TestPrimitivesYCbCr.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYCbCr.c
@@ -4,6 +4,7 @@
 #include <winpr/print.h>
 #include <freerdp/codec/color.h>
 #include <winpr/wlog.h>
+#include <freerdp/utils/profiler.h>
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -11,7 +12,7 @@
 
 #define TAG __FILE__
 
-static INT16 TEST_Y_COMPONENT[4096] =
+static const INT16 TEST_Y_COMPONENT[4096] =
 {
 	-32,	+16,	+64,	+272,	-32,	-16,	+0,	-16,
 	-32,	-24,	-16,	-8,	+0,	-24,	-48,	-72,
@@ -527,7 +528,7 @@ static INT16 TEST_Y_COMPONENT[4096] =
 	+8,	-24,	-56,	-88,	-120,	-120,	-120,	-120
 };
 
-static INT16 TEST_CB_COMPONENT[4096] =
+static const INT16 TEST_CB_COMPONENT[4096] =
 {
 	+1728,	+1730,	+1732,	+1734,	+1736,	+1738,	+1740,	+1742,
 	+1744,	+1740,	+1736,	+1732,	+1728,	+1796,	+1864,	+1804,
@@ -1043,7 +1044,7 @@ static INT16 TEST_CB_COMPONENT[4096] =
 	+2160,	+2168,	+2176,	+2184,	+2192,	+2192,	+2192,	+2192
 };
 
-static INT16 TEST_CR_COMPONENT[4096] =
+static const INT16 TEST_CR_COMPONENT[4096] =
 {
 	-2112,	-2114,	-2116,	-2118,	-2120,	-2122,	-2124,	-2126,
 	-2128,	-2118,	-2108,	-2098,	-2088,	-2150,	-2212,	-2146,
@@ -1563,7 +1564,7 @@ static INT16 TEST_CR_COMPONENT[4096] =
  * 64x64 XRGB Image
  */
 
-static UINT32 TEST_XRGB_IMAGE[4096] =
+static const UINT32 TEST_XRGB_IMAGE[4096] =
 {
 	0xFF229cdf, 0xFF249de0, 0xFF259fe2, 0xFF2ca5e8, 0xFF229cdf, 0xFF229ce0, 0xFF239de0, 0xFF229ce0,
 	0xFF229cdf, 0xFF229cdf, 0xFF239ce0, 0xFF249ce0, 0xFF249ce0, 0xFF219ce3, 0xFF1e9ce6, 0xFF209ae2,
@@ -2154,211 +2155,136 @@ static int test_bmp_cmp_dump(const BYTE* actual, const BYTE* expected, int size,
 	return count;
 }
 
-static void test_fill_bitmap_channel(BYTE* data, int width, int height,
-                                     BYTE value, int nChannel)
+static int test_PrimitivesYCbCr(const primitives_t* prims, UINT32 format, prim_size_t roi)
 {
-	int x, y;
-	BYTE* pChannel;
-	pChannel = data + nChannel;
-
-	for (y = 0; y < height; y++)
-	{
-		for (x = 0; x < width; x++)
-		{
-			*pChannel = value;
-			pChannel += 4;
-		}
-	}
-}
-
-#define TEST_FP_TYPE	float
-
-static TEST_FP_TYPE TEST_YCbCrToRGB_01[4] = { 1.403f,             0.344f,              0.714f,              1.770f    };
-static TEST_FP_TYPE TEST_YCbCrToRGB_02[4] = { 1.402525f,          0.343730f,           0.714401f,           1.769905f };
-static TEST_FP_TYPE TEST_YCbCrToRGB_03[4] = { 1.402524948120117L, 0.3437300026416779L, 0.7144010066986084L, 1.769904971122742L };
-
-static INT16 TEST_YCbCr_01[3] = { +3443, -1863, +272 };
-static BYTE TEST_RGB_01[3] = { 247, 249, 132 };
-
-static INT16 TEST_YCbCr_02[3] = { +1086, +1584, -2268 };
-static BYTE TEST_RGB_02[3] = { 62, 195, 249 };
-
-static INT16 TEST_YCbCr_03[3] = { -576, +2002, -2179 };
-static BYTE TEST_RGB_03[3] = { 15, 137, 221 };
-
-int test_YCbCr_fp(TEST_FP_TYPE coeffs[4], INT16 YCbCr[3], BYTE RGB[3])
-{
-	INT16 R, G, B;
-	TEST_FP_TYPE Y, Cb, Cr;
-	TEST_FP_TYPE fR, fG, fB;
-	TEST_FP_TYPE fR1, fR2;
-	Y = (TEST_FP_TYPE)(YCbCr[0] + 4096);
-	Cb = (TEST_FP_TYPE)(YCbCr[1]);
-	Cr = (TEST_FP_TYPE)(YCbCr[2]);
-#if 1
-	fR1 = Cr * coeffs[0];
-	fR2 = fR1 + Y + 16.0f;
-	fR = ((Cr * coeffs[0]) + Y + 16.0f);
-	fG = (Y - (Cb * coeffs[1]) - (Cr * coeffs[2]) + 16.0f);
-	fB = ((Cb * coeffs[3]) + Y + 16.0f);
-	printf("fR: %f fG: %f fB: %f fY: %f\n", fR, fG, fB, Y);
-	R = (INT16) fR;
-	G = (INT16) fG;
-	B = (INT16) fB;
-	printf("mR: %d mG: %d mB: %d\n", (R - 16) % 32, (G - 16) % 32, (B - 16) % 32);
-	printf("iR: %"PRId16" iG: %"PRId16" iB: %"PRId16"\n", R, G, B);
-	R >>= 5;
-	G >>= 5;
-	B >>= 5;
-	printf("R5: %"PRId16" G5: %"PRId16" B5: %"PRId16"\n", R, G, B);
-#else
-	R = ((INT16)(((Cr * coeffs[0]) + Y + 16.0f)) >> 5);
-	G = ((INT16)((Y - (Cb * coeffs[1]) - (Cr * coeffs[2]) + 16.0f)) >> 5);
-	B = ((INT16)(((Cb * coeffs[3]) + Y + 16.0f)) >> 5);
-#endif
-
-	if (R < 0)
-		R = 0;
-	else if (R > 255)
-		R = 255;
-
-	if (G < 0)
-		G = 0;
-	else if (G > 255)
-		G = 255;
-
-	if (B < 0)
-		B = 0;
-	else if (B > 255)
-		B = 255;
-
-	printf("--------------------------------\n");
-	printf("R: A: %3"PRId16" E: %3"PRIu8" %s\n", R, RGB[0], (R == RGB[0]) ? "" : "***");
-	printf("G: A: %3"PRId16" E: %3"PRIu8" %s\n", G, RGB[1], (G == RGB[1]) ? "" : "***");
-	printf("B: A: %3"PRId16" E: %3"PRIu8" %s\n", B, RGB[2], (B == RGB[2]) ? "" : "***");
-	printf("Y: %+5"PRId16" Cb: %+5"PRId16" Cr: %+5"PRId16"\n", YCbCr[0], YCbCr[1], YCbCr[2]);
-	//printf("[0]: %20.20lf\n", coeffs[0]);
-	//printf("[1]: %20.20lf\n", coeffs[1]);
-	//printf("[2]: %20.20lf\n", coeffs[2]);
-	//printf("[3]: %20.20lf\n", coeffs[3]);
-	printf("--------------------------------\n\n");
-	return 0;
-}
-
-int test_YCbCr_pixels()
-{
-	if (0)
-	{
-		test_YCbCr_fp(TEST_YCbCrToRGB_01, TEST_YCbCr_01, TEST_RGB_01);
-		test_YCbCr_fp(TEST_YCbCrToRGB_01, TEST_YCbCr_02, TEST_RGB_02);
-		test_YCbCr_fp(TEST_YCbCrToRGB_01, TEST_YCbCr_03, TEST_RGB_03);
-	}
-
-	if (1)
-	{
-		test_YCbCr_fp(TEST_YCbCrToRGB_02, TEST_YCbCr_01, TEST_RGB_01);
-		test_YCbCr_fp(TEST_YCbCrToRGB_02, TEST_YCbCr_02, TEST_RGB_02);
-		test_YCbCr_fp(TEST_YCbCrToRGB_02, TEST_YCbCr_03, TEST_RGB_03);
-	}
-
-	if (0)
-	{
-		test_YCbCr_fp(TEST_YCbCrToRGB_03, TEST_YCbCr_01, TEST_RGB_01);
-		test_YCbCr_fp(TEST_YCbCrToRGB_03, TEST_YCbCr_02, TEST_RGB_02);
-		test_YCbCr_fp(TEST_YCbCrToRGB_03, TEST_YCbCr_03, TEST_RGB_03);
-	}
-
-	return 0;
-}
-
-int TestPrimitivesYCbCr(int argc, char* argv[])
-{
-	pstatus_t status = PRIMITIVES_SUCCESS;
-	int size;
+	pstatus_t status = -1;
 	int cnt[3];
 	float err[3];
 	BYTE* actual;
 	BYTE* expected;
 	int margin = 1;
-	INT16* pYCbCr[3];
-	const primitives_t* prims = primitives_get();
-	static const prim_size_t roi_64x64 = { 64, 64 };
+	const INT16* pYCbCr[3];
+	const UINT32 srcStride = roi.width * 2;
+	const UINT32 dstStride = roi.width * GetBytesPerPixel(format);
+	const UINT32 srcSize = srcStride * roi.height;
+	const UINT32 dstSize = dstStride * roi.height;
+	PROFILER_DEFINE(prof);
 	//return test_YCbCr_pixels();
 	expected = (BYTE*) TEST_XRGB_IMAGE;
-	size = 64 * 64 * 4;
-	actual = _aligned_malloc(size, 16);
+	actual = _aligned_malloc(dstSize, 16);
+	PROFILER_CREATE(prof, "YCbCr");
 
 	if (!actual)
-		return 1;
+		goto fail;
 
-	ZeroMemory(actual, size);
+	ZeroMemory(actual, dstSize);
 	pYCbCr[0] = TEST_Y_COMPONENT;
 	pYCbCr[1] = TEST_CB_COMPONENT;
 	pYCbCr[2] = TEST_CR_COMPONENT;
 
 	if (1)
 	{
-		status = prims->yCbCrToRGB_16s8u_P3AC4R((const INT16**) pYCbCr, 64 * 2,
-		                                        actual, 64 * 4, PIXEL_FORMAT_BGRA32,
-		                                        &roi_64x64);
+		PROFILER_ENTER(prof);
+		status = prims->yCbCrToRGB_16s8u_P3AC4R((const INT16**) pYCbCr, srcStride,
+		                                        actual, dstStride, format,
+		                                        &roi);
+		PROFILER_EXIT(prof);
 	}
 	else
 	{
 		INT16* pSrcDst[3];
-		pSrcDst[0] = _aligned_malloc(4096 * 2, 16);
-		pSrcDst[1] = _aligned_malloc(4096 * 2, 16);
-		pSrcDst[2] = _aligned_malloc(4096 * 2, 16);
-		CopyMemory(pSrcDst[0], pYCbCr[0], 4096 * 2);
-		CopyMemory(pSrcDst[1], pYCbCr[1], 4096 * 2);
-		CopyMemory(pSrcDst[2], pYCbCr[2], 4096 * 2);
-		prims->yCbCrToRGB_16s16s_P3P3((const INT16**) pSrcDst, 64 * 2,
-		                              pSrcDst, 64 * 2, &roi_64x64);
-		prims->RGBToRGB_16s8u_P3AC4R((const INT16**) pSrcDst, 64 * 2,
-		                             actual, 64 * 4, PIXEL_FORMAT_BGRA32, &roi_64x64);
+		pSrcDst[0] = _aligned_malloc(srcSize, 16);
+		pSrcDst[1] = _aligned_malloc(srcSize, 16);
+		pSrcDst[2] = _aligned_malloc(srcSize, 16);
+		CopyMemory(pSrcDst[0], pYCbCr[0], srcSize);
+		CopyMemory(pSrcDst[1], pYCbCr[1], srcSize);
+		CopyMemory(pSrcDst[2], pYCbCr[2], srcSize);
+		PROFILER_ENTER(prof);
+		status = prims->yCbCrToRGB_16s16s_P3P3((const INT16**) pSrcDst, srcStride,
+		                                       pSrcDst, srcStride, &roi);
+
+		if (status != PRIMITIVES_SUCCESS)
+			goto fail2;
+
+		status = prims->RGBToRGB_16s8u_P3AC4R((const INT16**) pSrcDst, srcStride,
+		                                      actual, dstStride, format, &roi);
+		PROFILER_EXIT(prof);
+	fail2:
 		_aligned_free(pSrcDst[0]);
 		_aligned_free(pSrcDst[1]);
 		_aligned_free(pSrcDst[2]);
+
+		if (status != PRIMITIVES_SUCCESS)
+			goto fail;
 	}
 
-	if (0)
-	{
-		test_fill_bitmap_channel(actual, 64, 64, 0, 2); /* red */
-		test_fill_bitmap_channel(expected, 64, 64, 0, 2); /* red */
-	}
-
-	if (0)
-	{
-		test_fill_bitmap_channel(actual, 64, 64, 0, 1); /* green */
-		test_fill_bitmap_channel(expected, 64, 64, 0, 1); /* green */
-	}
-
-	if (0)
-	{
-		test_fill_bitmap_channel(actual, 64, 64, 0, 0); /* blue */
-		test_fill_bitmap_channel(expected, 64, 64, 0, 0); /* blue */
-	}
-
-	cnt[2] = test_bmp_cmp_count(actual, expected, size, 2, margin); /* red */
-	err[2] = ((float) cnt[2]) / ((float) size / 4) * 100.0f;
-	cnt[1] = test_bmp_cmp_count(actual, expected, size, 1, margin); /* green */
-	err[1] = ((float) cnt[1]) / ((float) size / 4) * 100.0f;
-	cnt[0] = test_bmp_cmp_count(actual, expected, size, 0, margin); /* blue */
-	err[0] = ((float) cnt[0]) / ((float) size / 4) * 100.0f;
+	cnt[2] = test_bmp_cmp_count(actual, expected, dstSize, 2, margin); /* red */
+	err[2] = ((float) cnt[2]) / ((float) dstSize / 4) * 100.0f;
+	cnt[1] = test_bmp_cmp_count(actual, expected, dstSize, 1, margin); /* green */
+	err[1] = ((float) cnt[1]) / ((float) dstSize / 4) * 100.0f;
+	cnt[0] = test_bmp_cmp_count(actual, expected, dstSize, 0, margin); /* blue */
+	err[0] = ((float) cnt[0]) / ((float) dstSize / 4) * 100.0f;
 
 	if (cnt[0] || cnt[1] || cnt[2])
 	{
 		printf("Red Error Dump:\n");
-		test_bmp_cmp_dump(actual, expected, size, 2, margin); /* red */
+		test_bmp_cmp_dump(actual, expected, dstSize, 2, margin); /* red */
 		printf("Green Error Dump:\n");
-		test_bmp_cmp_dump(actual, expected, size, 1, margin); /* green */
+		test_bmp_cmp_dump(actual, expected, dstSize, 1, margin); /* green */
 		printf("Blue Error Dump:\n");
-		test_bmp_cmp_dump(actual, expected, size, 0, margin); /* blue */
+		test_bmp_cmp_dump(actual, expected, dstSize, 0, margin); /* blue */
 		printf("R: diff: %d (%f%%)\n", cnt[2], err[2]);
 		printf("G: diff: %d (%f%%)\n", cnt[1], err[1]);
 		printf("B: diff: %d (%f%%)\n", cnt[0], err[0]);
 	}
 
+	PROFILER_PRINT(prof);
+fail:
 	_aligned_free(actual);
-	return (status == PRIMITIVES_SUCCESS) ? 0 : 1;
+	PROFILER_FREE(prof);
+	return status;
 }
 
+int TestPrimitivesYCbCr(int argc, char* argv[])
+{
+	const UINT32 formats[] =
+	{
+		PIXEL_FORMAT_XRGB32,
+		PIXEL_FORMAT_XBGR32,
+		PIXEL_FORMAT_ARGB32,
+		PIXEL_FORMAT_ABGR32,
+		PIXEL_FORMAT_RGBA32,
+		PIXEL_FORMAT_RGBX32,
+		PIXEL_FORMAT_BGRA32,
+		PIXEL_FORMAT_BGRX32
+	};
+	const primitives_t* prims = primitives_get();
+	const primitives_t* generics = primitives_get_generic();
+	prim_size_t roi = { 64, 64 };
+	UINT32 x;
+
+	for (x = 0; x < sizeof(formats) / sizeof(formats[0]); x++)
+	{
+		int rc;
+		printf("----------------------- GENERIC %s -------------------\n",
+		       GetColorFormatName(formats[x]));
+		rc = test_PrimitivesYCbCr(generics, formats[x], roi);
+
+		if (rc != PRIMITIVES_SUCCESS)
+			return rc;
+
+		printf("------------------------- END %s ----------------------\n",
+		       GetColorFormatName(formats[x]));
+		printf("---------------------- OPTIMIZED %s -------------------\n",
+		       GetColorFormatName(formats[x]));
+		rc = test_PrimitivesYCbCr(prims, formats[x], roi);
+
+		if (rc != PRIMITIVES_SUCCESS)
+			return rc;
+
+		printf("------------------------- END %s ----------------------\n",
+		       GetColorFormatName(formats[x]));
+	}
+
+	return 0;
+}

--- a/scripts/android-build-openssl.sh
+++ b/scripts/android-build-openssl.sh
@@ -110,5 +110,5 @@ if [ ! -d $BUILD_DST/include ];
 then
 	common_run mkdir -p $BUILD_DST/include
 fi
-common_run cp -L -r $BUILD_SRC/include/openssl $BUILD_DST/include/
+common_run cp -L -R $BUILD_SRC/include/openssl $BUILD_DST/include/
 


### PR DESCRIPTION
* Optimized NEON primitives for decoding RFX, AVC420, AVC444 and progressive
* Optimized SSSE3 RFX ```yCbCrToRGB_16s8u_P3AC4R```
* Added profiler to tests