### PR TITLE
.RDP Password Attribute

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2513,20 +2513,22 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 	}
 	while ((arg = CommandLineFindNextArgumentA(arg)) != NULL);
 
-	free(settings->Username);
-
-	if (!settings->Domain && user)
+	if (!settings->Username && user)
 	{
-		BOOL ret;
-		free(settings->Domain);
-		ret = freerdp_parse_username(user, &settings->Username, &settings->Domain);
-		free(user);
+		free(settings->Username);
+		if (!settings->Domain && user)
+		{
+			BOOL ret;
+			free(settings->Domain);
 
-		if (!ret)
-			return COMMAND_LINE_ERROR;
+			ret = freerdp_parse_username(user, &settings->Username, &settings->Domain);
+			free(user);
+			if (!ret)
+				return COMMAND_LINE_ERROR;
+		}
+		else
+			settings->Username = user;
 	}
-	else
-		settings->Username = user;
 
 	free(settings->GatewayUsername);
 

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2513,7 +2513,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 	}
 	while ((arg = CommandLineFindNextArgumentA(arg)) != NULL);
 
-	if (!settings->Username && user)
+	if (user)
 	{
 		free(settings->Username);
 		if (!settings->Domain && user)

--- a/client/common/file.c
+++ b/client/common/file.c
@@ -284,6 +284,8 @@ static int freerdp_client_rdp_file_set_string(rdpFile* file, const char* name, c
 		tmp = &file->Username;
 	else if (_stricmp(name, "domain") == 0)
 		tmp = &file->Domain;
+	else if (_stricmp(name, "password") == 0)
+		tmp = &file->Password;
 	else if (_stricmp(name, "full address") == 0)
 		tmp = &file->FullAddress;
 	else if (_stricmp(name, "alternate full address") == 0)
@@ -725,6 +727,7 @@ BOOL freerdp_client_populate_rdp_file_from_settings(rdpFile* file, const rdpSett
 {
 	SETTING_MODIFIED_SET_STRING(file->Domain, settings, Domain);
 	SETTING_MODIFIED_SET_STRING(file->Username, settings, Username);
+	SETTING_MODIFIED_SET_STRING(file->Password, settings, Password);
 	SETTING_MODIFIED_SET(file->ServerPort, settings, ServerPort);
 	SETTING_MODIFIED_SET_STRING(file->FullAddress, settings, ServerHostname);
 	SETTING_MODIFIED_SET(file->DesktopWidth, settings, DesktopWidth);
@@ -893,6 +896,12 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 
 		free(user);
 		free(domain);
+	}
+
+	if (~((size_t)file->Password))
+	{
+		if (freerdp_set_param_string(settings, FreeRDP_Password, file->Password) != 0)
+			return FALSE;
 	}
 
 	if (~((size_t) file->FullAddress))
@@ -1423,6 +1432,7 @@ void freerdp_client_rdp_file_free(rdpFile* file)
 
 		freerdp_client_file_string_check_free(file->Username);
 		freerdp_client_file_string_check_free(file->Domain);
+		freerdp_client_file_string_check_free(file->Password);
 		freerdp_client_file_string_check_free(file->FullAddress);
 		freerdp_client_file_string_check_free(file->AlternateFullAddress);
 		freerdp_client_file_string_check_free(file->UsbDevicesToRedirect);

--- a/include/freerdp/client/file.h
+++ b/include/freerdp/client/file.h
@@ -89,6 +89,7 @@ struct rdp_file
 
 	LPSTR Username; /* username */
 	LPSTR Domain; /* domain */
+	LPSTR Password; /*password*/
 	PBYTE Password51; /* password 51 */
 
 	LPSTR FullAddress; /* full address */


### PR DESCRIPTION
Allow password to be stored in .RDP file, parsed and settings
updated, this will allow for dynamic .RDP files to be created with
complete login credentials, using this method the username, server and
password will no longer be visible within process lists.

Also fixed bug with username being 
set to null by command line processor if the command line parameter not specified but the value set from the .RDP files.

Usage: create .RDP file, add line 

password:s:XXXXXX where XXXXXX is the password