### PR TITLE
fix a bug in libwinpr module

### DIFF
--- a/winpr/libwinpr/utils/collections/MessageQueue.c
+++ b/winpr/libwinpr/utils/collections/MessageQueue.c
@@ -82,8 +82,9 @@ void MessageQueue_Dispatch(wMessageQueue* queue, wMessage* message)
 		queue->capacity = new_capacity;
 		queue->array = (wMessage*) realloc(queue->array, sizeof(wMessage) * queue->capacity);
 		ZeroMemory(&(queue->array[old_capacity]), old_capacity * sizeof(wMessage));
-
-		if (queue->tail < old_capacity)
+		
+		//rearrange wrapped entries
+		if (queue->tail <= queue->head)
 		{
 			CopyMemory(&(queue->array[old_capacity]), queue->array, queue->tail * sizeof(wMessage));
 			queue->tail += old_capacity;

--- a/winpr/libwinpr/utils/collections/Queue.c
+++ b/winpr/libwinpr/utils/collections/Queue.c
@@ -148,6 +148,7 @@ void Queue_Enqueue(wQueue* queue, void* obj)
 		queue->array = (void**) realloc(queue->array, sizeof(void*) * queue->capacity);
 		ZeroMemory(&(queue->array[old_capacity]), old_capacity * sizeof(void*));
 
+		//rearrange wrapped entries
 		if (queue->tail <= queue->head)
 		{
 			CopyMemory(&(queue->array[old_capacity]), queue->array, queue->tail * sizeof(void*));

--- a/winpr/libwinpr/utils/collections/Queue.c
+++ b/winpr/libwinpr/utils/collections/Queue.c
@@ -148,7 +148,7 @@ void Queue_Enqueue(wQueue* queue, void* obj)
 		queue->array = (void**) realloc(queue->array, sizeof(void*) * queue->capacity);
 		ZeroMemory(&(queue->array[old_capacity]), old_capacity * sizeof(void*));
 
-		if (queue->tail < old_capacity)
+		if (queue->tail <= queue->head)
 		{
 			CopyMemory(&(queue->array[old_capacity]), queue->array, queue->tail * sizeof(void*));
 			queue->tail += old_capacity;


### PR DESCRIPTION
when enqueue a new entry, we should rearrange wrapped entries if we invoke realloc().
the judgment condition: queue->tail < old_capacity   is wrong, it should be: queue->tail <= queue->head