### PR TITLE
core: Close channels on context free instead of disconnect

### DIFF
--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -497,7 +497,6 @@ BOOL freerdp_disconnect(freerdp* instance)
 	}
 
 	codecs_free(instance->context->codecs);
-	freerdp_channels_close(instance->context->channels, instance);
 	return rc;
 }
 
@@ -717,6 +716,7 @@ void freerdp_context_free(freerdp* instance)
 	free(instance->context->errorDescription);
 	CloseHandle(instance->context->abortEvent);
 	instance->context->abortEvent = NULL;
+	freerdp_channels_close(instance->context->channels, instance);
 	freerdp_channels_free(instance->context->channels);
 	free(instance->context);
 	instance->context = NULL;


### PR DESCRIPTION
The current implementation sent the TERMINATE event to channels on
disconnect. The result was that all channels of the freerdp instance were
destroyed. If the same instance was now used to connect again none of the
channels would work because they were already destroyed.