### PR TITLE
smartcard: implement ListReaderGroups

### DIFF
--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -192,10 +192,13 @@ const char* smartcard_get_ioctl_string(UINT32 ioControlCode, BOOL funcName)
 	return funcName ? "SCardUnknown" : "SCARD_IOCTL_UNKNOWN";
 }
 
-static LONG smartcard_EstablishContext_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, EstablishContext_Call* call)
+static LONG smartcard_EstablishContext_Decode(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	EstablishContext_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(EstablishContext_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
@@ -205,16 +208,19 @@ static LONG smartcard_EstablishContext_Decode(SMARTCARD_DEVICE* smartcard, SMART
 		WLog_ERR(TAG, "smartcard_unpack_establish_context_call failed with error %"PRId32"", status);
 		return status;
 	}
+
 	smartcard_trace_establish_context_call(smartcard, call);
 	return SCARD_S_SUCCESS;
 }
 
-static LONG smartcard_EstablishContext_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, EstablishContext_Call* call)
+static LONG smartcard_EstablishContext_Call(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	SCARDCONTEXT hContext = -1;
 	EstablishContext_Return ret;
 	IRP* irp = operation->irp;
+	EstablishContext_Call* call = operation->call;
 	status = ret.ReturnCode = SCardEstablishContext(call->dwScope, NULL, NULL, &hContext);
 
 	if (ret.ReturnCode == SCARD_S_SUCCESS)
@@ -223,11 +229,13 @@ static LONG smartcard_EstablishContext_Call(SMARTCARD_DEVICE* smartcard, SMARTCA
 		void* key = (void*)(size_t) hContext;
 		// TODO: handle return values
 		pContext = smartcard_context_new(smartcard, hContext);
+
 		if (!pContext)
 		{
 			WLog_ERR(TAG, "smartcard_context_new failed!");
 			return STATUS_NO_MEMORY;
 		}
+
 		if (!ListDictionary_Add(smartcard->rgSCardContextList, key, (void*) pContext))
 		{
 			WLog_ERR(TAG, "ListDictionary_Add failed!");
@@ -242,6 +250,7 @@ static LONG smartcard_EstablishContext_Call(SMARTCARD_DEVICE* smartcard, SMARTCA
 
 	smartcard_scard_context_native_to_redir(smartcard, &(ret.hContext), hContext);
 	smartcard_trace_establish_context_return(smartcard, &ret);
+
 	if ((status = smartcard_pack_establish_context_return(smartcard, irp->output, &ret)))
 	{
 		WLog_ERR(TAG, "smartcard_pack_establish_context_return failed with error %"PRId32"", status);
@@ -251,26 +260,30 @@ static LONG smartcard_EstablishContext_Call(SMARTCARD_DEVICE* smartcard, SMARTCA
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_ReleaseContext_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Context_Call* call)
+static LONG smartcard_ReleaseContext_Decode(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	Context_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(Context_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_context_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_context_call failed with error %"PRId32"", status);
+
 	smartcard_trace_context_call(smartcard, call, "ReleaseContext");
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	return status;
 }
 
-static LONG smartcard_ReleaseContext_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Context_Call* call)
+static LONG smartcard_ReleaseContext_Call(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	Long_Return ret;
-
 	status = ret.ReturnCode = SCardReleaseContext(operation->hContext);
 
 	if (ret.ReturnCode == SCARD_S_SUCCESS)
@@ -290,61 +303,163 @@ static LONG smartcard_ReleaseContext_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_IsValidContext_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Context_Call* call)
+static LONG smartcard_IsValidContext_Decode(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	Context_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(Context_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_context_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_context_call failed with error %"PRId32"", status);
+
 	smartcard_trace_context_call(smartcard, call, "IsValidContext");
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	return status;
 }
 
-static LONG smartcard_IsValidContext_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Context_Call* call)
+static LONG smartcard_IsValidContext_Call(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	Long_Return ret;
+
 	if ((status = ret.ReturnCode = SCardIsValidContext(operation->hContext)))
 	{
 		WLog_ERR(TAG, "SCardIsValidContext failed with error %"PRId32"", status);
 		return status;
 	}
+
 	smartcard_trace_long_return(smartcard, &ret, "IsValidContext");
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_ListReadersA_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, ListReaders_Call* call)
+static LONG smartcard_ListReaderGroupsA_Decode(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	ListReaderGroups_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(ListReaderGroups_Call));
+
+	if (!call)
+		return STATUS_NO_MEMORY;
+
+	status = smartcard_unpack_list_reader_groups_call(smartcard, irp->input, call);
+	smartcard_trace_list_reader_groups_call(smartcard, call, FALSE);
+	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
+	return status;
+}
+
+static LONG smartcard_ListReaderGroupsA_Call(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
+{
+	LONG status;
+	ListReaderGroups_Return ret;
+	LPSTR mszGroups = NULL;
+	DWORD cchGroups = 0;
+	IRP* irp = operation->irp;
+	cchGroups = SCARD_AUTOALLOCATE;
+	status = ret.ReturnCode = SCardListReaderGroupsA(operation->hContext, (LPSTR) &mszGroups,
+	                          &cchGroups);
+	ret.msz = (BYTE*) mszGroups;
+	ret.cBytes = cchGroups;
+
+	if (status != SCARD_S_SUCCESS)
+		return status;
+
+	smartcard_trace_list_reader_groups_return(smartcard, &ret, FALSE);
+	status = smartcard_pack_list_reader_groups_return(smartcard, irp->output, &ret);
+
+	if (status != SCARD_S_SUCCESS)
+		return status;
+
+	if (mszGroups)
+		SCardFreeMemory(operation->hContext, mszGroups);
+
+	return ret.ReturnCode;
+}
+
+static LONG smartcard_ListReaderGroupsW_Decode(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
+{
+	LONG status;
+	ListReaderGroups_Call* call;
+	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(ListReaderGroups_Call));
+
+	if (!call)
+		return STATUS_NO_MEMORY;
+
+	status = smartcard_unpack_list_reader_groups_call(smartcard, irp->input, call);
+	smartcard_trace_list_reader_groups_call(smartcard, call, TRUE);
+	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
+	return status;
+}
+
+static LONG smartcard_ListReaderGroupsW_Call(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
+{
+	LONG status;
+	ListReaderGroups_Return ret;
+	LPWSTR mszGroups = NULL;
+	DWORD cchGroups = 0;
+	IRP* irp = operation->irp;
+	cchGroups = SCARD_AUTOALLOCATE;
+	status = ret.ReturnCode = SCardListReaderGroupsW(operation->hContext, (LPWSTR) &mszGroups,
+	                          &cchGroups);
+	ret.msz = (BYTE*) mszGroups;
+	ret.cBytes = cchGroups;
+
+	if (status != SCARD_S_SUCCESS)
+		return status;
+
+	smartcard_trace_list_reader_groups_return(smartcard, &ret, TRUE);
+	status = smartcard_pack_list_reader_groups_return(smartcard, irp->output, &ret);
+
+	if (status != SCARD_S_SUCCESS)
+		return status;
+
+	if (mszGroups)
+		SCardFreeMemory(operation->hContext, mszGroups);
+
+	return ret.ReturnCode;
+}
+
+static LONG smartcard_ListReadersA_Decode(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
+{
+	LONG status;
+	ListReaders_Call* call;
+	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(ListReaders_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_list_readers_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_list_readers_call failed with error %"PRId32"", status);
+
 	smartcard_trace_list_readers_call(smartcard, call, FALSE);
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	return status;
 }
 
-static LONG smartcard_ListReadersA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, ListReaders_Call* call)
+static LONG smartcard_ListReadersA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	ListReaders_Return ret;
 	LPSTR mszReaders = NULL;
 	DWORD cchReaders = 0;
 	IRP* irp = operation->irp;
-
+	ListReaders_Call* call = operation->call;
 	cchReaders = SCARD_AUTOALLOCATE;
-
-	status = ret.ReturnCode = SCardListReadersA(operation->hContext, (LPCSTR) call->mszGroups, (LPSTR) &mszReaders, &cchReaders);
-
+	status = ret.ReturnCode = SCardListReadersA(operation->hContext, (LPCSTR) call->mszGroups,
+	                          (LPSTR) &mszReaders, &cchReaders);
 	ret.msz = (BYTE*) mszReaders;
 	ret.cBytes = cchReaders;
 
@@ -361,6 +476,7 @@ static LONG smartcard_ListReadersA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_O
 	}
 
 	smartcard_trace_list_readers_return(smartcard, &ret, FALSE);
+
 	if ((status = smartcard_pack_list_readers_return(smartcard, irp->output, &ret)))
 	{
 		WLog_ERR(TAG, "smartcard_pack_list_readers_return failed with error %"PRId32"", status);
@@ -376,10 +492,13 @@ static LONG smartcard_ListReadersA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_O
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_ListReadersW_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, ListReaders_Call* call)
+static LONG smartcard_ListReadersW_Decode(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	ListReaders_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(ListReaders_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
@@ -389,23 +508,20 @@ static LONG smartcard_ListReadersW_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD
 
 	smartcard_trace_list_readers_call(smartcard, call, TRUE);
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
-
 	return status;
 }
 
-static LONG smartcard_ListReadersW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, ListReaders_Call* call)
+static LONG smartcard_ListReadersW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	ListReaders_Return ret;
 	LPWSTR mszReaders = NULL;
 	DWORD cchReaders = 0;
 	IRP* irp = operation->irp;
-
+	ListReaders_Call* call = operation->call;
 	cchReaders = SCARD_AUTOALLOCATE;
-
 	status = ret.ReturnCode = SCardListReadersW(operation->hContext,
-			(LPCWSTR) call->mszGroups, (LPWSTR) &mszReaders, &cchReaders);
-
+	                          (LPCWSTR) call->mszGroups, (LPWSTR) &mszReaders, &cchReaders);
 	ret.msz = (BYTE*) mszReaders;
 	ret.cBytes = cchReaders * 2;
 
@@ -415,7 +531,7 @@ static LONG smartcard_ListReadersW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_O
 		call->mszGroups = NULL;
 	}
 
-	if (status)
+	if (status != SCARD_S_SUCCESS)
 	{
 		WLog_ERR(TAG, "SCardListReadersW failed with error %"PRId32"", status);
 		return status;
@@ -438,10 +554,13 @@ static LONG smartcard_ListReadersW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_O
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_GetStatusChangeA_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, GetStatusChangeA_Call* call)
+static LONG smartcard_GetStatusChangeA_Decode(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	GetStatusChangeA_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(GetStatusChangeA_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
@@ -457,16 +576,17 @@ static LONG smartcard_GetStatusChangeA_Decode(SMARTCARD_DEVICE* smartcard, SMART
 	return status;
 }
 
-static LONG smartcard_GetStatusChangeA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, GetStatusChangeA_Call* call)
+static LONG smartcard_GetStatusChangeA_Call(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	UINT32 index;
 	GetStatusChange_Return ret;
 	LPSCARD_READERSTATEA rgReaderState = NULL;
 	IRP* irp = operation->irp;
-
+	GetStatusChangeA_Call* call = operation->call;
 	status = ret.ReturnCode = SCardGetStatusChangeA(operation->hContext,
-			call->dwTimeOut, call->rgReaderStates, call->cReaders);
+	                          call->dwTimeOut, call->rgReaderStates, call->cReaders);
 
 	if (status && (status != SCARD_E_TIMEOUT) && (status != SCARD_E_CANCELLED))
 	{
@@ -475,6 +595,7 @@ static LONG smartcard_GetStatusChangeA_Call(SMARTCARD_DEVICE* smartcard, SMARTCA
 
 	ret.cReaders = call->cReaders;
 	ret.rgReaderStates = NULL;
+
 	if (ret.cReaders > 0)
 		ret.rgReaderStates = (ReaderState_Return*) calloc(ret.cReaders, sizeof(ReaderState_Return));
 
@@ -490,6 +611,7 @@ static LONG smartcard_GetStatusChangeA_Call(SMARTCARD_DEVICE* smartcard, SMARTCA
 	}
 
 	smartcard_trace_get_status_change_return(smartcard, &ret, FALSE);
+
 	if ((status = smartcard_pack_get_status_change_return(smartcard, irp->output, &ret)))
 	{
 		WLog_ERR(TAG, "smartcard_pack_get_status_change_return failed with error %"PRId32"", status);
@@ -501,7 +623,7 @@ static LONG smartcard_GetStatusChangeA_Call(SMARTCARD_DEVICE* smartcard, SMARTCA
 		for (index = 0; index < call->cReaders; index++)
 		{
 			rgReaderState = &call->rgReaderStates[index];
-			free((void *)rgReaderState->szReader);
+			free((void*)rgReaderState->szReader);
 		}
 
 		free(call->rgReaderStates);
@@ -511,37 +633,45 @@ static LONG smartcard_GetStatusChangeA_Call(SMARTCARD_DEVICE* smartcard, SMARTCA
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_GetStatusChangeW_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, GetStatusChangeW_Call* call)
+static LONG smartcard_GetStatusChangeW_Decode(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	GetStatusChangeW_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(GetStatusChangeW_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_get_status_change_w_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_get_status_change_w_call failed with error %"PRId32"", status);
+
 	smartcard_trace_get_status_change_w_call(smartcard, call);
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	return status;
 }
 
-static LONG smartcard_GetStatusChangeW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, GetStatusChangeW_Call* call)
+static LONG smartcard_GetStatusChangeW_Call(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	UINT32 index;
 	GetStatusChange_Return ret;
 	LPSCARD_READERSTATEW rgReaderState = NULL;
 	IRP* irp = operation->irp;
-	status = ret.ReturnCode = SCardGetStatusChangeW(operation->hContext, call->dwTimeOut, call->rgReaderStates, call->cReaders);
+	GetStatusChangeW_Call* call = operation->call;
+	status = ret.ReturnCode = SCardGetStatusChangeW(operation->hContext, call->dwTimeOut,
+	                          call->rgReaderStates, call->cReaders);
 
 	if (status && (status != SCARD_E_TIMEOUT) && (status != SCARD_E_CANCELLED))
 	{
-		call->cReaders=0;
+		call->cReaders = 0;
 	}
 
 	ret.cReaders = call->cReaders;
 	ret.rgReaderStates = NULL;
+
 	if (ret.cReaders > 0)
 		ret.rgReaderStates = (ReaderState_Return*) calloc(ret.cReaders, sizeof(ReaderState_Return));
 
@@ -557,6 +687,7 @@ static LONG smartcard_GetStatusChangeW_Call(SMARTCARD_DEVICE* smartcard, SMARTCA
 	}
 
 	smartcard_trace_get_status_change_return(smartcard, &ret, TRUE);
+
 	if ((status = smartcard_pack_get_status_change_return(smartcard, irp->output, &ret)))
 	{
 		WLog_ERR(TAG, "smartcard_pack_get_status_change_return failed with error %"PRId32"", status);
@@ -568,7 +699,7 @@ static LONG smartcard_GetStatusChangeW_Call(SMARTCARD_DEVICE* smartcard, SMARTCA
 		for (index = 0; index < call->cReaders; index++)
 		{
 			rgReaderState = &call->rgReaderStates[index];
-			free((void *)rgReaderState->szReader);
+			free((void*)rgReaderState->szReader);
 		}
 
 		free(call->rgReaderStates);
@@ -578,22 +709,25 @@ static LONG smartcard_GetStatusChangeW_Call(SMARTCARD_DEVICE* smartcard, SMARTCA
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_Cancel_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Context_Call* call)
+static LONG smartcard_Cancel_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	Context_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(Context_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_context_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_context_call failed with error %"PRId32"", status);
+
 	smartcard_trace_context_call(smartcard, call, "Cancel");
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	return status;
 }
 
-static LONG smartcard_Cancel_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Context_Call* call)
+static LONG smartcard_Cancel_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	Long_Return ret;
@@ -603,41 +737,47 @@ static LONG smartcard_Cancel_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATI
 		WLog_ERR(TAG, "SCardCancel failed with error %"PRId32"", status);
 		return status;
 	}
+
 	smartcard_trace_long_return(smartcard, &ret, "Cancel");
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_ConnectA_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, ConnectA_Call* call)
+static LONG smartcard_ConnectA_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	ConnectA_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(ConnectA_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_connect_a_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_connect_a_call failed with error %"PRId32"", status);
+
 	smartcard_trace_connect_a_call(smartcard, call);
-	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->Common.hContext));
+	operation->hContext = smartcard_scard_context_native_from_redir(smartcard,
+	                      &(call->Common.hContext));
 	return status;
 }
 
-static LONG smartcard_ConnectA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, ConnectA_Call* call)
+static LONG smartcard_ConnectA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	SCARDHANDLE hCard = 0;
 	Connect_Return ret = { 0 };
 	IRP* irp = operation->irp;
+	ConnectA_Call* call = operation->call;
 
 	if ((call->Common.dwPreferredProtocols == SCARD_PROTOCOL_UNDEFINED) &&
-			(call->Common.dwShareMode != SCARD_SHARE_DIRECT))
+	    (call->Common.dwShareMode != SCARD_SHARE_DIRECT))
 	{
 		call->Common.dwPreferredProtocols = SCARD_PROTOCOL_Tx;
 	}
 
-	status = ret.ReturnCode = SCardConnectA(operation->hContext, (char*) call->szReader, call->Common.dwShareMode,
-						call->Common.dwPreferredProtocols, &hCard, &ret.dwActiveProtocol);
-
+	status = ret.ReturnCode = SCardConnectA(operation->hContext, (char*) call->szReader,
+	                                        call->Common.dwShareMode,
+	                                        call->Common.dwPreferredProtocols, &hCard, &ret.dwActiveProtocol);
 	smartcard_scard_context_native_to_redir(smartcard, &(ret.hContext), operation->hContext);
 	smartcard_scard_handle_native_to_redir(smartcard, &(ret.hCard), hCard);
 	smartcard_trace_connect_return(smartcard, &ret);
@@ -648,7 +788,6 @@ static LONG smartcard_ConnectA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERA
 		return status;
 	}
 
-
 	if ((status = smartcard_pack_connect_return(smartcard, irp->output, &ret)))
 	{
 		WLog_ERR(TAG, "smartcard_pack_connect_return failed with error %"PRId32"", status);
@@ -656,14 +795,15 @@ static LONG smartcard_ConnectA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERA
 	}
 
 	free(call->szReader);
-
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_ConnectW_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, ConnectW_Call* call)
+static LONG smartcard_ConnectW_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	ConnectW_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(ConnectW_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
@@ -672,27 +812,28 @@ static LONG smartcard_ConnectW_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPE
 		WLog_ERR(TAG, "smartcard_unpack_connect_w_call failed with error %"PRId32"", status);
 
 	smartcard_trace_connect_w_call(smartcard, call);
-	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->Common.hContext));
-
+	operation->hContext = smartcard_scard_context_native_from_redir(smartcard,
+	                      &(call->Common.hContext));
 	return status;
 }
 
-static LONG smartcard_ConnectW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, ConnectW_Call* call)
+static LONG smartcard_ConnectW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	SCARDHANDLE hCard = 0;
 	Connect_Return ret = { 0 };
 	IRP* irp = operation->irp;
+	ConnectW_Call* call = operation->call;
 
 	if ((call->Common.dwPreferredProtocols == SCARD_PROTOCOL_UNDEFINED) &&
-			(call->Common.dwShareMode != SCARD_SHARE_DIRECT))
+	    (call->Common.dwShareMode != SCARD_SHARE_DIRECT))
 	{
 		call->Common.dwPreferredProtocols = SCARD_PROTOCOL_Tx;
 	}
 
-	status = ret.ReturnCode = SCardConnectW(operation->hContext, (WCHAR*) call->szReader, call->Common.dwShareMode,
-							call->Common.dwPreferredProtocols, &hCard, &ret.dwActiveProtocol);
-
+	status = ret.ReturnCode = SCardConnectW(operation->hContext, (WCHAR*) call->szReader,
+	                                        call->Common.dwShareMode,
+	                                        call->Common.dwPreferredProtocols, &hCard, &ret.dwActiveProtocol);
 	smartcard_scard_context_native_to_redir(smartcard, &(ret.hContext), operation->hContext);
 	smartcard_scard_handle_native_to_redir(smartcard, &(ret.hCard), hCard);
 	smartcard_trace_connect_return(smartcard, &ret);
@@ -710,34 +851,38 @@ static LONG smartcard_ConnectW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERA
 	}
 
 	free(call->szReader);
-
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_Reconnect_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Reconnect_Call* call)
+static LONG smartcard_Reconnect_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	Reconnect_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(Reconnect_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_reconnect_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_reconnect_call failed with error %"PRId32"", status);
+
 	smartcard_trace_reconnect_call(smartcard, call);
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	operation->hCard = smartcard_scard_handle_native_from_redir(smartcard, &(call->hCard));
 	return status;
 }
 
-static LONG smartcard_Reconnect_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Reconnect_Call* call)
+static LONG smartcard_Reconnect_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	Reconnect_Return ret;
 	IRP* irp = operation->irp;
+	Reconnect_Call* call = operation->call;
 	status = ret.ReturnCode = SCardReconnect(operation->hCard, call->dwShareMode,
-							  call->dwPreferredProtocols, call->dwInitialization, &ret.dwActiveProtocol);
+	                          call->dwPreferredProtocols, call->dwInitialization, &ret.dwActiveProtocol);
 	smartcard_trace_reconnect_return(smartcard, &ret);
+
 	if ((status = smartcard_pack_reconnect_return(smartcard, irp->output, &ret)))
 	{
 		WLog_ERR(TAG, "smartcard_pack_reconnect_return failed with error %"PRId32"", status);
@@ -747,114 +892,143 @@ static LONG smartcard_Reconnect_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPER
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_Disconnect_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, HCardAndDisposition_Call* call)
+static LONG smartcard_Disconnect_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	HCardAndDisposition_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(HCardAndDisposition_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_hcard_and_disposition_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_hcard_and_disposition_call failed with error %"PRId32"", status);
+
 	smartcard_trace_hcard_and_disposition_call(smartcard, call, "Disconnect");
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	operation->hCard = smartcard_scard_handle_native_from_redir(smartcard, &(call->hCard));
 	return status;
 }
 
-static LONG smartcard_Disconnect_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, HCardAndDisposition_Call* call)
+static LONG smartcard_Disconnect_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	Long_Return ret;
+	HCardAndDisposition_Call* call = operation->call;
+
 	if ((status = ret.ReturnCode = SCardDisconnect(operation->hCard, call->dwDisposition)))
 	{
 		WLog_ERR(TAG, "SCardDisconnect failed with error %"PRId32"", status);
 		return status;
 	}
+
 	smartcard_trace_long_return(smartcard, &ret, "Disconnect");
+
+	if (status != SCARD_S_SUCCESS)
+		return status;
 
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_BeginTransaction_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, HCardAndDisposition_Call* call)
+static LONG smartcard_BeginTransaction_Decode(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	HCardAndDisposition_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(HCardAndDisposition_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_hcard_and_disposition_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_hcard_and_disposition_call failed with error %"PRId32"", status);
+
 	smartcard_trace_hcard_and_disposition_call(smartcard, call, "BeginTransaction");
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	operation->hCard = smartcard_scard_handle_native_from_redir(smartcard, &(call->hCard));
 	return status;
 }
 
-static LONG smartcard_BeginTransaction_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, HCardAndDisposition_Call* call)
+static LONG smartcard_BeginTransaction_Call(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret;
+
 	if ((ret.ReturnCode = SCardBeginTransaction(operation->hCard)))
 	{
 		WLog_ERR(TAG, "SCardBeginTransaction failed with error %"PRId32"", ret.ReturnCode);
 		return ret.ReturnCode;
 	}
+
 	smartcard_trace_long_return(smartcard, &ret, "BeginTransaction");
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_EndTransaction_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, HCardAndDisposition_Call* call)
+static LONG smartcard_EndTransaction_Decode(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	HCardAndDisposition_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(HCardAndDisposition_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_hcard_and_disposition_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_hcard_and_disposition_call failed with error %"PRId32"", status);
+
 	smartcard_trace_hcard_and_disposition_call(smartcard, call, "EndTransaction");
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	operation->hCard = smartcard_scard_handle_native_from_redir(smartcard, &(call->hCard));
 	return status;
 }
 
-static LONG smartcard_EndTransaction_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, HCardAndDisposition_Call* call)
+static LONG smartcard_EndTransaction_Call(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret;
+	HCardAndDisposition_Call* call = operation->call;
+
 	if ((ret.ReturnCode = SCardEndTransaction(operation->hCard, call->dwDisposition)))
 	{
 		WLog_ERR(TAG, "SCardEndTransaction failed with error %"PRId32"", ret.ReturnCode);
 		return ret.ReturnCode;
 	}
+
 	smartcard_trace_long_return(smartcard, &ret, "EndTransaction");
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_State_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, State_Call* call)
+static LONG smartcard_State_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	State_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(State_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_state_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_state_call failed with error %"PRId32"", status);
+
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	operation->hCard = smartcard_scard_handle_native_from_redir(smartcard, &(call->hCard));
 	return status;
 }
 
-static LONG smartcard_State_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, State_Call* call)
+static LONG smartcard_State_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	State_Return ret;
 	IRP* irp = operation->irp;
 	ret.cbAtrLen = SCARD_ATR_LENGTH;
-	ret.ReturnCode = SCardState(operation->hCard, &ret.dwState, &ret.dwProtocol, (BYTE*) &ret.rgAtr, &ret.cbAtrLen);
+	ret.ReturnCode = SCardState(operation->hCard, &ret.dwState, &ret.dwProtocol, (BYTE*) &ret.rgAtr,
+	                            &ret.cbAtrLen);
+
 	if ((status = smartcard_pack_state_return(smartcard, irp->output, &ret)))
 	{
 		WLog_ERR(TAG, "smartcard_pack_state_return failed with error %"PRId32"", status);
@@ -864,36 +1038,42 @@ static LONG smartcard_State_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATIO
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_StatusA_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Status_Call* call)
+static LONG smartcard_StatusA_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	Status_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(State_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_status_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_status_call failed with error %"PRId32"", status);
+
 	smartcard_trace_status_call(smartcard, call, FALSE);
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	operation->hCard = smartcard_scard_handle_native_from_redir(smartcard, &(call->hCard));
 	return status;
 }
 
-static LONG smartcard_StatusA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Status_Call* call)
+static LONG smartcard_StatusA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	Status_Return ret = { 0 };
 	DWORD cchReaderLen = 0;
 	LPSTR mszReaderNames = NULL;
 	IRP* irp = operation->irp;
+	Status_Call* call = operation->call;
 
-	ret.cbAtrLen = 32;
+	if (call->cbAtrLen > 32)
+		call->cbAtrLen = 32;
+
+	ret.cbAtrLen = call->cbAtrLen;
 	ZeroMemory(ret.pbAtr, 32);
 	cchReaderLen = SCARD_AUTOALLOCATE;
-
 	status = ret.ReturnCode = SCardStatusA(operation->hCard, (LPSTR) &mszReaderNames, &cchReaderLen,
-					&ret.dwState, &ret.dwProtocol, (BYTE*) &ret.pbAtr, &ret.cbAtrLen);
+	                                       &ret.dwState, &ret.dwProtocol, (BYTE*) &ret.pbAtr, &ret.cbAtrLen);
 
 	if (status == SCARD_S_SUCCESS)
 	{
@@ -902,6 +1082,7 @@ static LONG smartcard_StatusA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERAT
 	}
 
 	smartcard_trace_status_return(smartcard, &ret, FALSE);
+
 	if ((status = smartcard_pack_status_return(smartcard, irp->output, &ret)))
 	{
 		WLog_ERR(TAG, "smartcard_pack_status_return failed with error %"PRId32"", status);
@@ -914,40 +1095,46 @@ static LONG smartcard_StatusA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERAT
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_StatusW_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Status_Call* call)
+static LONG smartcard_StatusW_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	Status_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(State_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_status_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_status_call failed with error %"PRId32"", status);
+
 	smartcard_trace_status_call(smartcard, call, TRUE);
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	operation->hCard = smartcard_scard_handle_native_from_redir(smartcard, &(call->hCard));
 	return status;
 }
 
-static LONG smartcard_StatusW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Status_Call* call)
+static LONG smartcard_StatusW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	Status_Return ret;
 	DWORD cchReaderLen = 0;
 	LPWSTR mszReaderNames = NULL;
 	IRP* irp = operation->irp;
+	Status_Call* call = operation->call;
 
-	ret.cbAtrLen = 32;
+	if (call->cbAtrLen > 32)
+		call->cbAtrLen = 32;
+
+	ret.cbAtrLen = call->cbAtrLen;
 	ZeroMemory(ret.pbAtr, 32);
 	cchReaderLen = SCARD_AUTOALLOCATE;
-
 	status = ret.ReturnCode = SCardStatusW(operation->hCard, (LPWSTR) &mszReaderNames, &cchReaderLen,
-						&ret.dwState, &ret.dwProtocol, (BYTE*) &ret.pbAtr, &ret.cbAtrLen);
-
+	                                       &ret.dwState, &ret.dwProtocol, (BYTE*) &ret.pbAtr, &ret.cbAtrLen);
 	ret.mszReaderNames = (BYTE*) mszReaderNames;
 	ret.cBytes = cchReaderLen * 2;
 	smartcard_trace_status_return(smartcard, &ret, TRUE);
+
 	if ((status = smartcard_pack_status_return(smartcard, irp->output, &ret)))
 	{
 		WLog_ERR(TAG, "smartcard_pack_status_return failed with error %"PRId32"", status);
@@ -960,10 +1147,12 @@ static LONG smartcard_StatusW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERAT
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_Transmit_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Transmit_Call* call)
+static LONG smartcard_Transmit_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	Transmit_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(Transmit_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
@@ -972,18 +1161,17 @@ static LONG smartcard_Transmit_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPE
 		WLog_ERR(TAG, "smartcard_unpack_transmit_call failed with error %"PRId32"", status);
 
 	smartcard_trace_transmit_call(smartcard, call);
-
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	operation->hCard = smartcard_scard_handle_native_from_redir(smartcard, &(call->hCard));
-
 	return status;
 }
 
-static LONG smartcard_Transmit_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Transmit_Call* call)
+static LONG smartcard_Transmit_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	Transmit_Return ret;
 	IRP* irp = operation->irp;
+	Transmit_Call* call = operation->call;
 	ret.cbRecvLength = 0;
 	ret.pbRecvBuffer = NULL;
 
@@ -1000,11 +1188,10 @@ static LONG smartcard_Transmit_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERA
 	}
 
 	ret.pioRecvPci = call->pioRecvPci;
-
-	ret.ReturnCode = SCardTransmit(operation->hCard, call->pioSendPci, call->pbSendBuffer,
-				call->cbSendLength, ret.pioRecvPci, ret.pbRecvBuffer, &(ret.cbRecvLength));
-
+	status = ret.ReturnCode = SCardTransmit(operation->hCard, call->pioSendPci, call->pbSendBuffer,
+	                                        call->cbSendLength, ret.pioRecvPci, ret.pbRecvBuffer, &(ret.cbRecvLength));
 	smartcard_trace_transmit_return(smartcard, &ret);
+
 	if ((status = smartcard_pack_transmit_return(smartcard, irp->output, &ret)))
 	{
 		WLog_ERR(TAG, "smartcard_pack_transmit_return failed with error %"PRId32"", status);
@@ -1015,31 +1202,34 @@ static LONG smartcard_Transmit_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERA
 	free(ret.pbRecvBuffer);
 	free(call->pioSendPci);
 	free(call->pioRecvPci);
-
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_Control_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Control_Call* call)
+static LONG smartcard_Control_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	Control_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(Control_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_control_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_control_call failed with error %"PRId32"", status);
+
 	smartcard_trace_control_call(smartcard, call);
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	operation->hCard = smartcard_scard_handle_native_from_redir(smartcard, &(call->hCard));
 	return status;
 }
 
-static LONG smartcard_Control_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Control_Call* call)
+static LONG smartcard_Control_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	Control_Return ret;
 	IRP* irp = operation->irp;
+	Control_Call* call = operation->call;
 	ret.cbOutBufferSize = call->cbOutBufferSize;
 	ret.pvOutBuffer = (BYTE*) malloc(call->cbOutBufferSize);
 
@@ -1047,10 +1237,10 @@ static LONG smartcard_Control_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERAT
 		return SCARD_E_NO_MEMORY;
 
 	status = ret.ReturnCode = SCardControl(operation->hCard,
-			call->dwControlCode, call->pvInBuffer, call->cbInBufferSize,
-			ret.pvOutBuffer, call->cbOutBufferSize, &ret.cbOutBufferSize);
-
+	                                       call->dwControlCode, call->pvInBuffer, call->cbInBufferSize,
+	                                       ret.pvOutBuffer, call->cbOutBufferSize, &ret.cbOutBufferSize);
 	smartcard_trace_control_return(smartcard, &ret);
+
 	if ((status = smartcard_pack_control_return(smartcard, irp->output, &ret)))
 	{
 		WLog_ERR(TAG, "smartcard_pack_control_return failed with error %"PRId32"", status);
@@ -1059,34 +1249,36 @@ static LONG smartcard_Control_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERAT
 
 	free(call->pvInBuffer);
 	free(ret.pvOutBuffer);
-
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_GetAttrib_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, GetAttrib_Call* call)
+static LONG smartcard_GetAttrib_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	GetAttrib_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(GetAttrib_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_get_attrib_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_get_attrib_call failed with error %"PRId32"", status);
+
 	smartcard_trace_get_attrib_call(smartcard, call);
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	operation->hCard = smartcard_scard_handle_native_from_redir(smartcard, &(call->hCard));
 	return status;
 }
 
-static LONG smartcard_GetAttrib_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, GetAttrib_Call* call)
+static LONG smartcard_GetAttrib_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	DWORD cbAttrLen;
 	BOOL autoAllocate;
 	GetAttrib_Return ret;
 	IRP* irp = operation->irp;
-
+	GetAttrib_Call* call = operation->call;
 	ret.pbAttr = NULL;
 
 	if (call->fpbAttrIsNULL)
@@ -1103,20 +1295,16 @@ static LONG smartcard_GetAttrib_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPER
 	}
 
 	cbAttrLen = call->cbAttrLen;
-
 	status = ret.ReturnCode = SCardGetAttrib(operation->hCard, call->dwAttrId,
-			autoAllocate ? (LPBYTE) &(ret.pbAttr) : ret.pbAttr, &cbAttrLen);
-
+	                          autoAllocate ? (LPBYTE) & (ret.pbAttr) : ret.pbAttr, &cbAttrLen);
 	ret.cbAttrLen = cbAttrLen;
-
 	smartcard_trace_get_attrib_return(smartcard, &ret, call->dwAttrId);
 
 	if (ret.ReturnCode)
 	{
 		WLog_WARN(TAG, "SCardGetAttrib: %s (0x%08"PRIX32") cbAttrLen: %"PRIu32"",
-				SCardGetAttributeString(call->dwAttrId), call->dwAttrId, call->cbAttrLen);
+		          SCardGetAttributeString(call->dwAttrId), call->dwAttrId, call->cbAttrLen);
 		Stream_Zero(irp->output, 256);
-
 		free(ret.pbAttr);
 		return ret.ReturnCode;
 	}
@@ -1131,9 +1319,12 @@ static LONG smartcard_GetAttrib_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPER
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_AccessStartedEvent_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Long_Call* call)
+static LONG smartcard_AccessStartedEvent_Decode(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
+	Long_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(Long_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
@@ -1141,7 +1332,7 @@ static LONG smartcard_AccessStartedEvent_Decode(SMARTCARD_DEVICE* smartcard, SMA
 	if (Stream_GetRemainingLength(irp->input) < 4)
 	{
 		WLog_WARN(TAG, "AccessStartedEvent is too short: %"PRIuz"",
-				   Stream_GetRemainingLength(irp->input));
+		          Stream_GetRemainingLength(irp->input));
 		return SCARD_F_INTERNAL_ERROR;
 	}
 
@@ -1149,33 +1340,43 @@ static LONG smartcard_AccessStartedEvent_Decode(SMARTCARD_DEVICE* smartcard, SMA
 	return SCARD_S_SUCCESS;
 }
 
-static LONG smartcard_AccessStartedEvent_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, Long_Call* call)
+static LONG smartcard_AccessStartedEvent_Call(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
+	LONG status;
+	Long_Return ret;
+	status = ret.ReturnCode = SCARD_S_SUCCESS;
+
 	if (!smartcard->StartedEvent)
 		smartcard->StartedEvent = SCardAccessStartedEvent();
 
 	if (!smartcard->StartedEvent)
-		return SCARD_E_NO_SERVICE;
+		status = ret.ReturnCode = SCARD_E_NO_SERVICE;
 
-	return SCARD_S_SUCCESS;
+	return status;
 }
 
-static LONG smartcard_LocateCardsByATRA_Decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, LocateCardsByATRA_Call* call)
+static LONG smartcard_LocateCardsByATRA_Decode(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
+	LocateCardsByATRA_Call* call;
 	IRP* irp = operation->irp;
+	operation->call = call = calloc(1, sizeof(LocateCardsByATRA_Call));
 
 	if (!call)
 		return STATUS_NO_MEMORY;
 
 	if ((status = smartcard_unpack_locate_cards_by_atr_a_call(smartcard, irp->input, call)))
 		WLog_ERR(TAG, "smartcard_unpack_locate_cards_by_atr_a_call failed with error %"PRId32"", status);
+
 	smartcard_trace_locate_cards_by_atr_a_call(smartcard, call);
 	operation->hContext = smartcard_scard_context_native_from_redir(smartcard, &(call->hContext));
 	return status;
 }
 
-static LONG smartcard_LocateCardsByATRA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation, LocateCardsByATRA_Call* call)
+static LONG smartcard_LocateCardsByATRA_Call(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	BOOL equal;
@@ -1184,7 +1385,7 @@ static LONG smartcard_LocateCardsByATRA_Call(SMARTCARD_DEVICE* smartcard, SMARTC
 	LPSCARD_READERSTATEA state = NULL;
 	LPSCARD_READERSTATEA states = NULL;
 	IRP* irp = operation->irp;
-
+	LocateCardsByATRA_Call* call = operation->call;
 	states = (LPSCARD_READERSTATEA) calloc(call->cReaders, sizeof(SCARD_READERSTATEA));
 
 	if (!states)
@@ -1199,7 +1400,8 @@ static LONG smartcard_LocateCardsByATRA_Call(SMARTCARD_DEVICE* smartcard, SMARTC
 		CopyMemory(&(states[i].rgbAtr), &(call->rgReaderStates[i].Common.rgbAtr), 36);
 	}
 
-	status = ret.ReturnCode = SCardGetStatusChangeA(operation->hContext, 0x000001F4, states, call->cReaders);
+	status = ret.ReturnCode = SCardGetStatusChangeA(operation->hContext, 0x000001F4, states,
+	                          call->cReaders);
 
 	if (status && (status != SCARD_E_TIMEOUT) && (status != SCARD_E_CANCELLED))
 	{
@@ -1220,6 +1422,7 @@ static LONG smartcard_LocateCardsByATRA_Call(SMARTCARD_DEVICE* smartcard, SMARTC
 					equal = FALSE;
 					break;
 				}
+
 				if (equal)
 				{
 					states[j].dwEventState |= SCARD_STATE_ATRMATCH;
@@ -1230,6 +1433,7 @@ static LONG smartcard_LocateCardsByATRA_Call(SMARTCARD_DEVICE* smartcard, SMARTC
 
 	ret.cReaders = call->cReaders;
 	ret.rgReaderStates = NULL;
+
 	if (ret.cReaders > 0)
 		ret.rgReaderStates = (ReaderState_Return*) calloc(ret.cReaders, sizeof(ReaderState_Return));
 
@@ -1244,9 +1448,10 @@ static LONG smartcard_LocateCardsByATRA_Call(SMARTCARD_DEVICE* smartcard, SMARTC
 		ret.rgReaderStates[i].cbAtr = state->cbAtr;
 		CopyMemory(&(ret.rgReaderStates[i].rgbAtr), &(state->rgbAtr), 32);
 	}
-	free(states);
 
+	free(states);
 	smartcard_trace_get_status_change_return(smartcard, &ret, FALSE);
+
 	if ((status = smartcard_pack_get_status_change_return(smartcard, irp->output, &ret)))
 	{
 		WLog_ERR(TAG, "smartcard_pack_get_status_change_return failed with error %"PRId32"", status);
@@ -1259,7 +1464,8 @@ static LONG smartcard_LocateCardsByATRA_Call(SMARTCARD_DEVICE* smartcard, SMARTC
 		{
 			state = (LPSCARD_READERSTATEA) &call->rgReaderStates[i];
 
-			if (state->szReader) {
+			if (state->szReader)
+			{
 				free((void*) state->szReader);
 				state->szReader = NULL;
 			}
@@ -1273,11 +1479,11 @@ static LONG smartcard_LocateCardsByATRA_Call(SMARTCARD_DEVICE* smartcard, SMARTC
 	return ret.ReturnCode;
 }
 
-LONG smartcard_irp_device_control_decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERATION* operation)
+LONG smartcard_irp_device_control_decode(SMARTCARD_DEVICE* smartcard,
+        SMARTCARD_OPERATION* operation)
 {
 	LONG status;
 	UINT32 offset;
-	void* call = NULL;
 	UINT32 ioControlCode;
 	UINT32 outputBufferLength;
 	UINT32 inputBufferLength;
@@ -1288,7 +1494,7 @@ LONG smartcard_irp_device_control_decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_
 	if (Stream_GetRemainingLength(irp->input) < 32)
 	{
 		WLog_WARN(TAG, "Device Control Request is too short: %"PRIuz"",
-			Stream_GetRemainingLength(irp->input));
+		          Stream_GetRemainingLength(irp->input));
 		return SCARD_F_INTERNAL_ERROR;
 	}
 
@@ -1301,17 +1507,17 @@ LONG smartcard_irp_device_control_decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_
 	if (Stream_Length(irp->input) != (Stream_GetPosition(irp->input) + inputBufferLength))
 	{
 		WLog_WARN(TAG, "InputBufferLength mismatch: Actual: %"PRIuz" Expected: %"PRIuz"",
-			Stream_Length(irp->input),
-			Stream_GetPosition(irp->input) + inputBufferLength);
+		          Stream_Length(irp->input),
+		          Stream_GetPosition(irp->input) + inputBufferLength);
 		return SCARD_F_INTERNAL_ERROR;
 	}
 
 	WLog_DBG(TAG, "%s (0x%08"PRIX32") FileId: %"PRIu32" CompletionId: %"PRIu32"",
-		smartcard_get_ioctl_string(ioControlCode, TRUE),
-		ioControlCode, irp->FileId, irp->CompletionId);
+	         smartcard_get_ioctl_string(ioControlCode, TRUE),
+	         ioControlCode, irp->FileId, irp->CompletionId);
 
 	if ((ioControlCode != SCARD_IOCTL_ACCESSSTARTEDEVENT) &&
-			(ioControlCode != SCARD_IOCTL_RELEASESTARTEDEVENT))
+	    (ioControlCode != SCARD_IOCTL_RELEASESTARTEDEVENT))
 	{
 		if ((status = smartcard_unpack_common_type_header(smartcard, irp->input)))
 		{
@@ -1327,60 +1533,36 @@ LONG smartcard_irp_device_control_decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_
 	}
 
 	/* Decode */
+	operation->call = NULL;
 
 	switch (ioControlCode)
 	{
 		case SCARD_IOCTL_ESTABLISHCONTEXT:
-			if (!(call = calloc(1, sizeof(EstablishContext_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_EstablishContext_Decode(smartcard, operation, (EstablishContext_Call*) call);
+			status = smartcard_EstablishContext_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_RELEASECONTEXT:
-			if (!(call = calloc(1, sizeof(Context_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_ReleaseContext_Decode(smartcard, operation, (Context_Call*) call);
+			status = smartcard_ReleaseContext_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_ISVALIDCONTEXT:
-			if (!(call = calloc(1, sizeof(Context_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_IsValidContext_Decode(smartcard, operation, (Context_Call*) call);
+			status = smartcard_IsValidContext_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_LISTREADERGROUPSA:
-			status = SCARD_F_INTERNAL_ERROR;
+			status = smartcard_ListReaderGroupsA_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_LISTREADERGROUPSW:
-			status = SCARD_F_INTERNAL_ERROR;
+			status = smartcard_ListReaderGroupsW_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_LISTREADERSA:
-			if (!(call = calloc(1, sizeof(ListReaders_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_ListReadersA_Decode(smartcard, operation, (ListReaders_Call*) call);
+			status = smartcard_ListReadersA_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_LISTREADERSW:
-			if (!(call = calloc(1, sizeof(ListReaders_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_ListReadersW_Decode(smartcard, operation, (ListReaders_Call*) call);
+			status = smartcard_ListReadersW_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_INTRODUCEREADERGROUPA:
@@ -1440,138 +1622,63 @@ LONG smartcard_irp_device_control_decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_
 			break;
 
 		case SCARD_IOCTL_GETSTATUSCHANGEA:
-			if (!(call = calloc(1, sizeof(GetStatusChangeA_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_GetStatusChangeA_Decode(smartcard, operation, (GetStatusChangeA_Call*) call);
+			status = smartcard_GetStatusChangeA_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_GETSTATUSCHANGEW:
-			if (!(call = calloc(1, sizeof(GetStatusChangeW_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_GetStatusChangeW_Decode(smartcard, operation, (GetStatusChangeW_Call*) call);
+			status = smartcard_GetStatusChangeW_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_CANCEL:
-			if (!(call = calloc(1, sizeof(Context_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_Cancel_Decode(smartcard, operation, (Context_Call*) call);
+			status = smartcard_Cancel_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_CONNECTA:
-			if (!(call = calloc(1, sizeof(ConnectA_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_ConnectA_Decode(smartcard, operation, (ConnectA_Call*) call);
+			status = smartcard_ConnectA_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_CONNECTW:
-			if (!(call = calloc(1, sizeof(ConnectW_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_ConnectW_Decode(smartcard, operation, (ConnectW_Call*) call);
+			status = smartcard_ConnectW_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_RECONNECT:
-			if (!(call = calloc(1, sizeof(Reconnect_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_Reconnect_Decode(smartcard, operation, (Reconnect_Call*) call);
+			status = smartcard_Reconnect_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_DISCONNECT:
-			if (!(call = calloc(1, sizeof(HCardAndDisposition_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_Disconnect_Decode(smartcard, operation, (HCardAndDisposition_Call*) call);
+			status = smartcard_Disconnect_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_BEGINTRANSACTION:
-			if (!(call = calloc(1, sizeof(HCardAndDisposition_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_BeginTransaction_Decode(smartcard, operation, (HCardAndDisposition_Call*) call);
+			status = smartcard_BeginTransaction_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_ENDTRANSACTION:
-			if (!(call = calloc(1, sizeof(HCardAndDisposition_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_EndTransaction_Decode(smartcard, operation, (HCardAndDisposition_Call*) call);
+			status = smartcard_EndTransaction_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_STATE:
-			if (!(call = calloc(1, sizeof(State_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_State_Decode(smartcard, operation, (State_Call*) call);
+			status = smartcard_State_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_STATUSA:
-			if (!(call = calloc(1, sizeof(Status_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_StatusA_Decode(smartcard, operation, (Status_Call*) call);
+			status = smartcard_StatusA_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_STATUSW:
-			if (!(call = calloc(1, sizeof(Status_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_StatusW_Decode(smartcard, operation, (Status_Call*) call);
+			status = smartcard_StatusW_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_TRANSMIT:
-			if (!(call = calloc(1, sizeof(Transmit_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_Transmit_Decode(smartcard, operation, (Transmit_Call*) call);
+			status = smartcard_Transmit_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_CONTROL:
-			if (!(call = calloc(1, sizeof(Control_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_Control_Decode(smartcard, operation, (Control_Call*) call);
+			status = smartcard_Control_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_GETATTRIB:
-			if (!(call = calloc(1, sizeof(GetAttrib_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_GetAttrib_Decode(smartcard, operation, (GetAttrib_Call*) call);
+			status = smartcard_GetAttrib_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_SETATTRIB:
@@ -1579,21 +1686,11 @@ LONG smartcard_irp_device_control_decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_
 			break;
 
 		case SCARD_IOCTL_ACCESSSTARTEDEVENT:
-			if (!(call = calloc(1, sizeof(Long_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_AccessStartedEvent_Decode(smartcard, operation, (Long_Call*) call);
+			status = smartcard_AccessStartedEvent_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_LOCATECARDSBYATRA:
-			if (!(call = calloc(1, sizeof(LocateCardsByATRA_Call))))
-			{
-				WLog_ERR(TAG, "calloc failed!");
-				return SCARD_E_NO_MEMORY;
-			}
-			status = smartcard_LocateCardsByATRA_Decode(smartcard, operation, (LocateCardsByATRA_Call*) call);
+			status = smartcard_LocateCardsByATRA_Decode(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_LOCATECARDSBYATRW:
@@ -1638,20 +1735,21 @@ LONG smartcard_irp_device_control_decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_
 	}
 
 	if ((ioControlCode != SCARD_IOCTL_ACCESSSTARTEDEVENT) &&
-			(ioControlCode != SCARD_IOCTL_RELEASESTARTEDEVENT))
+	    (ioControlCode != SCARD_IOCTL_RELEASESTARTEDEVENT))
 	{
 		offset = (RDPDR_DEVICE_IO_REQUEST_LENGTH + RDPDR_DEVICE_IO_CONTROL_REQ_HDR_LENGTH);
 		smartcard_unpack_read_size_align(smartcard, irp->input,
-					Stream_GetPosition(irp->input) - offset, 8);
+		                                 Stream_GetPosition(irp->input) - offset, 8);
 	}
 
 	if (Stream_GetPosition(irp->input) < Stream_Length(irp->input))
 	{
 		SIZE_T difference;
 		difference = Stream_Length(irp->input) - Stream_GetPosition(irp->input);
-		WLog_WARN(TAG, "IRP was not fully parsed %s (0x%08"PRIX32"): Actual: %"PRIuz", Expected: %"PRIuz", Difference: %"PRIuz"",
-				smartcard_get_ioctl_string(ioControlCode, TRUE), ioControlCode,
-				Stream_GetPosition(irp->input), Stream_Length(irp->input), difference);
+		WLog_WARN(TAG,
+		          "IRP was not fully parsed %s (0x%08"PRIX32"): Actual: %"PRIuz", Expected: %"PRIuz", Difference: %"PRIuz"",
+		          smartcard_get_ioctl_string(ioControlCode, TRUE), ioControlCode,
+		          Stream_GetPosition(irp->input), Stream_Length(irp->input), difference);
 		winpr_HexDump(TAG, WLOG_WARN, Stream_Pointer(irp->input), difference);
 	}
 
@@ -1659,18 +1757,18 @@ LONG smartcard_irp_device_control_decode(SMARTCARD_DEVICE* smartcard, SMARTCARD_
 	{
 		SIZE_T difference;
 		difference = Stream_GetPosition(irp->input) - Stream_Length(irp->input);
-		WLog_WARN(TAG, "IRP was parsed beyond its end %s (0x%08"PRIX32"): Actual: %"PRIuz", Expected: %"PRIuz", Difference: %"PRIuz"",
-				smartcard_get_ioctl_string(ioControlCode, TRUE), ioControlCode,
-				Stream_GetPosition(irp->input), Stream_Length(irp->input), difference);
+		WLog_WARN(TAG,
+		          "IRP was parsed beyond its end %s (0x%08"PRIX32"): Actual: %"PRIuz", Expected: %"PRIuz", Difference: %"PRIuz"",
+		          smartcard_get_ioctl_string(ioControlCode, TRUE), ioControlCode,
+		          Stream_GetPosition(irp->input), Stream_Length(irp->input), difference);
 	}
 
 	if (status != SCARD_S_SUCCESS)
 	{
-		free(call);
-		call = NULL;
+		free(operation->call);
+		operation->call = NULL;
 	}
 
-	operation->call = call;
 	return status;
 }
 
@@ -1679,14 +1777,11 @@ LONG smartcard_irp_device_control_call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OP
 	IRP* irp;
 	LONG result;
 	UINT32 offset;
-	ULONG_PTR* call;
 	UINT32 ioControlCode;
 	UINT32 outputBufferLength;
 	UINT32 objectBufferLength;
 	irp = operation->irp;
-	call = operation->call;
 	ioControlCode = operation->ioControlCode;
-
 	/**
 	 * [MS-RDPESC] 3.2.5.1: Sending Outgoing Messages:
 	 * the output buffer length SHOULD be set to 2048
@@ -1695,7 +1790,6 @@ LONG smartcard_irp_device_control_call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OP
 	 * about it, but we still reserve at least 2048 bytes.
 	 */
 	Stream_EnsureRemainingCapacity(irp->output, 2048);
-
 	/* Device Control Response */
 	Stream_Seek_UINT32(irp->output); /* OutputBufferLength (4 bytes) */
 	Stream_Seek(irp->output, SMARTCARD_COMMON_TYPE_HEADER_LENGTH); /* CommonTypeHeader (8 bytes) */
@@ -1707,31 +1801,31 @@ LONG smartcard_irp_device_control_call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OP
 	switch (ioControlCode)
 	{
 		case SCARD_IOCTL_ESTABLISHCONTEXT:
-			result = smartcard_EstablishContext_Call(smartcard, operation, (EstablishContext_Call*) call);
+			result = smartcard_EstablishContext_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_RELEASECONTEXT:
-			result = smartcard_ReleaseContext_Call(smartcard, operation, (Context_Call*) call);
+			result = smartcard_ReleaseContext_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_ISVALIDCONTEXT:
-			result = smartcard_IsValidContext_Call(smartcard, operation, (Context_Call*) call);
+			result = smartcard_IsValidContext_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_LISTREADERGROUPSA:
-			result = SCARD_F_INTERNAL_ERROR;
+			result = smartcard_ListReaderGroupsA_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_LISTREADERGROUPSW:
-			result = SCARD_F_INTERNAL_ERROR;
+			result = smartcard_ListReaderGroupsW_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_LISTREADERSA:
-			result = smartcard_ListReadersA_Call(smartcard, operation, (ListReaders_Call*) call);
+			result = smartcard_ListReadersA_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_LISTREADERSW:
-			result = smartcard_ListReadersW_Call(smartcard, operation, (ListReaders_Call*) call);
+			result = smartcard_ListReadersW_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_INTRODUCEREADERGROUPA:
@@ -1791,63 +1885,63 @@ LONG smartcard_irp_device_control_call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OP
 			break;
 
 		case SCARD_IOCTL_GETSTATUSCHANGEA:
-			result = smartcard_GetStatusChangeA_Call(smartcard, operation, (GetStatusChangeA_Call*) call);
+			result = smartcard_GetStatusChangeA_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_GETSTATUSCHANGEW:
-			result = smartcard_GetStatusChangeW_Call(smartcard, operation, (GetStatusChangeW_Call*) call);
+			result = smartcard_GetStatusChangeW_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_CANCEL:
-			result = smartcard_Cancel_Call(smartcard, operation, (Context_Call*) call);
+			result = smartcard_Cancel_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_CONNECTA:
-			result = smartcard_ConnectA_Call(smartcard, operation, (ConnectA_Call*) call);
+			result = smartcard_ConnectA_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_CONNECTW:
-			result = smartcard_ConnectW_Call(smartcard, operation, (ConnectW_Call*) call);
+			result = smartcard_ConnectW_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_RECONNECT:
-			result = smartcard_Reconnect_Call(smartcard, operation, (Reconnect_Call*) call);
+			result = smartcard_Reconnect_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_DISCONNECT:
-			result = smartcard_Disconnect_Call(smartcard, operation, (HCardAndDisposition_Call*) call);
+			result = smartcard_Disconnect_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_BEGINTRANSACTION:
-			result = smartcard_BeginTransaction_Call(smartcard, operation, (HCardAndDisposition_Call*) call);
+			result = smartcard_BeginTransaction_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_ENDTRANSACTION:
-			result = smartcard_EndTransaction_Call(smartcard, operation, (HCardAndDisposition_Call*) call);
+			result = smartcard_EndTransaction_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_STATE:
-			result = smartcard_State_Call(smartcard, operation, (State_Call*) call);
+			result = smartcard_State_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_STATUSA:
-			result = smartcard_StatusA_Call(smartcard, operation, (Status_Call*) call);
+			result = smartcard_StatusA_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_STATUSW:
-			result = smartcard_StatusW_Call(smartcard, operation, (Status_Call*) call);
+			result = smartcard_StatusW_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_TRANSMIT:
-			result = smartcard_Transmit_Call(smartcard, operation, (Transmit_Call*) call);
+			result = smartcard_Transmit_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_CONTROL:
-			result = smartcard_Control_Call(smartcard, operation, (Control_Call*) call);
+			result = smartcard_Control_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_GETATTRIB:
-			result = smartcard_GetAttrib_Call(smartcard, operation, (GetAttrib_Call*) call);
+			result = smartcard_GetAttrib_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_SETATTRIB:
@@ -1855,11 +1949,11 @@ LONG smartcard_irp_device_control_call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OP
 			break;
 
 		case SCARD_IOCTL_ACCESSSTARTEDEVENT:
-			result = smartcard_AccessStartedEvent_Call(smartcard, operation, (Long_Call*) call);
+			result = smartcard_AccessStartedEvent_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_LOCATECARDSBYATRA:
-			result = smartcard_LocateCardsByATRA_Call(smartcard, operation, (LocateCardsByATRA_Call*) call);
+			result = smartcard_LocateCardsByATRA_Call(smartcard, operation);
 			break;
 
 		case SCARD_IOCTL_LOCATECARDSBYATRW:
@@ -1903,7 +1997,8 @@ LONG smartcard_irp_device_control_call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OP
 			break;
 	}
 
-	free(call);
+	free(operation->call);
+	operation->call = NULL;
 
 	/**
 	 * [MS-RPCE] 2.2.6.3 Primitive Type Serialization
@@ -1912,18 +2007,19 @@ LONG smartcard_irp_device_control_call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OP
 	 */
 
 	if ((ioControlCode != SCARD_IOCTL_ACCESSSTARTEDEVENT) &&
-			(ioControlCode != SCARD_IOCTL_RELEASESTARTEDEVENT))
+	    (ioControlCode != SCARD_IOCTL_RELEASESTARTEDEVENT))
 	{
 		offset = (RDPDR_DEVICE_IO_RESPONSE_LENGTH + RDPDR_DEVICE_IO_CONTROL_RSP_HDR_LENGTH);
-		smartcard_pack_write_size_align(smartcard, irp->output, Stream_GetPosition(irp->output) - offset, 8);
+		smartcard_pack_write_size_align(smartcard, irp->output, Stream_GetPosition(irp->output) - offset,
+		                                8);
 	}
 
 	if ((result != SCARD_S_SUCCESS) && (result != SCARD_E_TIMEOUT) &&
-			(result != SCARD_E_NO_READERS_AVAILABLE) && (result != SCARD_E_NO_SERVICE))
+	    (result != SCARD_E_NO_READERS_AVAILABLE) && (result != SCARD_E_NO_SERVICE))
 	{
 		WLog_WARN(TAG, "IRP failure: %s (0x%08"PRIX32"), status: %s (0x%08"PRIX32")",
-			smartcard_get_ioctl_string(ioControlCode, TRUE), ioControlCode,
-			SCardGetErrorString(result), result);
+		          smartcard_get_ioctl_string(ioControlCode, TRUE), ioControlCode,
+		          SCardGetErrorString(result), result);
 	}
 
 	irp->IoStatus = 0;
@@ -1934,22 +2030,25 @@ LONG smartcard_irp_device_control_call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OP
 		irp->IoStatus = (UINT32)result;
 		Stream_SetPosition(irp->output, RDPDR_DEVICE_IO_RESPONSE_LENGTH);
 		WLog_WARN(TAG, "IRP failure: %s (0x%08"PRIX32"), ntstatus: 0x%08"PRIX32"",
-			smartcard_get_ioctl_string(ioControlCode, TRUE), ioControlCode, result);
+		          smartcard_get_ioctl_string(ioControlCode, TRUE), ioControlCode, result);
 	}
 
 	Stream_SealLength(irp->output);
 	outputBufferLength = Stream_Length(irp->output) - RDPDR_DEVICE_IO_RESPONSE_LENGTH - 4;
 	objectBufferLength = outputBufferLength - RDPDR_DEVICE_IO_RESPONSE_LENGTH;
 	Stream_SetPosition(irp->output, RDPDR_DEVICE_IO_RESPONSE_LENGTH);
-
 	/* Device Control Response */
 	Stream_Write_UINT32(irp->output, outputBufferLength); /* OutputBufferLength (4 bytes) */
-	if ((result = smartcard_pack_common_type_header(smartcard, irp->output))) /* CommonTypeHeader (8 bytes) */
+
+	if ((result = smartcard_pack_common_type_header(smartcard,
+	              irp->output))) /* CommonTypeHeader (8 bytes) */
 	{
 		WLog_ERR(TAG, "smartcard_pack_common_type_header failed with error %"PRId32"", result);
 		return result;
 	}
-	if ((result = smartcard_pack_private_type_header(smartcard, irp->output, objectBufferLength))) /* PrivateTypeHeader (8 bytes) */
+
+	if ((result = smartcard_pack_private_type_header(smartcard, irp->output,
+	              objectBufferLength))) /* PrivateTypeHeader (8 bytes) */
 	{
 		WLog_ERR(TAG, "smartcard_pack_private_type_header failed with error %"PRId32"", result);
 		return result;
@@ -1957,7 +2056,6 @@ LONG smartcard_irp_device_control_call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OP
 
 	Stream_Write_UINT32(irp->output, result); /* Result (4 bytes) */
 	Stream_SetPosition(irp->output, Stream_Length(irp->output));
-
 	return SCARD_S_SUCCESS;
 }
 

--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -1343,15 +1343,13 @@ static LONG smartcard_AccessStartedEvent_Decode(SMARTCARD_DEVICE* smartcard,
 static LONG smartcard_AccessStartedEvent_Call(SMARTCARD_DEVICE* smartcard,
         SMARTCARD_OPERATION* operation)
 {
-	LONG status;
-	Long_Return ret;
-	status = ret.ReturnCode = SCARD_S_SUCCESS;
+	LONG status = SCARD_S_SUCCESS;
 
 	if (!smartcard->StartedEvent)
 		smartcard->StartedEvent = SCardAccessStartedEvent();
 
 	if (!smartcard->StartedEvent)
-		status = ret.ReturnCode = SCARD_E_NO_SERVICE;
+		status = SCARD_E_NO_SERVICE;
 
 	return status;
 }

--- a/channels/smartcard/client/smartcard_pack.c
+++ b/channels/smartcard/client/smartcard_pack.c
@@ -581,16 +581,17 @@ void smartcard_trace_list_reader_groups_call(SMARTCARD_DEVICE* smartcard,
 
 	if (call->hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02X%02X%02X%02X%02X%02X%02X%02X (%d)",
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIx8"%02"PRIx8"%02"PRIx8"%02"PRIx8"%02"PRIx8"%02"PRIx8"%02"PRIx8"%02"PRIx8" (%"PRIu32")",
 		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
 	}
 	else
 	{
-		WLog_DBG(TAG, "hContext: 0x%02X%02X%02X%02X (%d)",
+		WLog_DBG(TAG, "hContext: 0x%02"PRIx8"%02"PRIx8"%02"PRIx8"%02"PRIx8" (%"PRIu32")",
 		         pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
 	}
 
-	WLog_DBG(TAG, "fmszGroupsIsNULL: %d cchGroups: 0x%08X",
+	WLog_DBG(TAG, "fmszGroupsIsNULL: %"PRId32" cchGroups: 0x%08"PRIx32,
 	         call->fmszGroupsIsNULL, call->cchGroups);
 	WLog_DBG(TAG, "}");
 }
@@ -648,9 +649,9 @@ void smartcard_trace_list_reader_groups_return(SMARTCARD_DEVICE* smartcard,
 	}
 
 	WLog_DBG(TAG, "ListReaderGroups%s_Return {", unicode ? "W" : "A");
-	WLog_DBG(TAG, "ReturnCode: %s (0x%08X)",
+	WLog_DBG(TAG, "ReturnCode: %s (0x%08"PRIx32")",
 	         SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
-	WLog_DBG(TAG, "cBytes: %d msz: %s", ret->cBytes, mszA);
+	WLog_DBG(TAG, "cBytes: %"PRIu32" msz: %s", ret->cBytes, mszA);
 	WLog_DBG(TAG, "}");
 	free(mszA);
 }

--- a/channels/smartcard/client/smartcard_pack.c
+++ b/channels/smartcard/client/smartcard_pack.c
@@ -38,12 +38,11 @@ LONG smartcard_unpack_common_type_header(SMARTCARD_DEVICE* smartcard, wStream* s
 	if (Stream_GetRemainingLength(s) < 8)
 	{
 		WLog_WARN(TAG, "CommonTypeHeader is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
 	/* Process CommonTypeHeader */
-
 	Stream_Read_UINT8(s, version); /* Version (1 byte) */
 	Stream_Read_UINT8(s, endianness); /* Endianness (1 byte) */
 	Stream_Read_UINT16(s, commonHeaderLength); /* CommonHeaderLength (2 bytes) */
@@ -82,7 +81,6 @@ LONG smartcard_pack_common_type_header(SMARTCARD_DEVICE* smartcard, wStream* s)
 	Stream_Write_UINT8(s, 0x10); /* Endianness (1 byte) */
 	Stream_Write_UINT16(s, 8); /* CommonHeaderLength (2 bytes) */
 	Stream_Write_UINT32(s, 0xCCCCCCCC); /* Filler (4 bytes), should be 0xCCCCCCCC */
-
 	return SCARD_S_SUCCESS;
 }
 
@@ -94,7 +92,7 @@ LONG smartcard_unpack_private_type_header(SMARTCARD_DEVICE* smartcard, wStream* 
 	if (Stream_GetRemainingLength(s) < 8)
 	{
 		WLog_WARN(TAG, "PrivateTypeHeader is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -109,26 +107,27 @@ LONG smartcard_unpack_private_type_header(SMARTCARD_DEVICE* smartcard, wStream* 
 
 	if (objectBufferLength != Stream_GetRemainingLength(s))
 	{
-		WLog_WARN(TAG, "PrivateTypeHeader ObjectBufferLength mismatch: Actual: %"PRIu32", Expected: %"PRIuz"",
-				objectBufferLength, Stream_GetRemainingLength(s));
+		WLog_WARN(TAG,
+		          "PrivateTypeHeader ObjectBufferLength mismatch: Actual: %"PRIu32", Expected: %"PRIuz"",
+		          objectBufferLength, Stream_GetRemainingLength(s));
 		return STATUS_INVALID_PARAMETER;
 	}
 
 	return SCARD_S_SUCCESS;
 }
 
-LONG smartcard_pack_private_type_header(SMARTCARD_DEVICE* smartcard, wStream* s, UINT32 objectBufferLength)
+LONG smartcard_pack_private_type_header(SMARTCARD_DEVICE* smartcard, wStream* s,
+                                        UINT32 objectBufferLength)
 {
 	Stream_Write_UINT32(s, objectBufferLength); /* ObjectBufferLength (4 bytes) */
 	Stream_Write_UINT32(s, 0x00000000); /* Filler (4 bytes), should be 0x00000000 */
-
 	return SCARD_S_SUCCESS;
 }
 
-LONG smartcard_unpack_read_size_align(SMARTCARD_DEVICE* smartcard, wStream* s, UINT32 size, UINT32 alignment)
+LONG smartcard_unpack_read_size_align(SMARTCARD_DEVICE* smartcard, wStream* s, UINT32 size,
+                                      UINT32 alignment)
 {
 	UINT32 pad;
-
 	pad = size;
 	size = (size + alignment - 1) & ~(alignment - 1);
 	pad = size - pad;
@@ -139,10 +138,10 @@ LONG smartcard_unpack_read_size_align(SMARTCARD_DEVICE* smartcard, wStream* s, U
 	return pad;
 }
 
-LONG smartcard_pack_write_size_align(SMARTCARD_DEVICE* smartcard, wStream* s, UINT32 size, UINT32 alignment)
+LONG smartcard_pack_write_size_align(SMARTCARD_DEVICE* smartcard, wStream* s, UINT32 size,
+                                     UINT32 alignment)
 {
 	UINT32 pad;
-
 	pad = size;
 	size = (size + alignment - 1) & ~(alignment - 1);
 	pad = size - pad;
@@ -154,20 +153,23 @@ LONG smartcard_pack_write_size_align(SMARTCARD_DEVICE* smartcard, wStream* s, UI
 			WLog_ERR(TAG, "Stream_EnsureRemainingCapacity failed!");
 			return SCARD_F_INTERNAL_ERROR;
 		}
+
 		Stream_Zero(s, pad);
 	}
 
 	return SCARD_S_SUCCESS;
 }
 
-SCARDCONTEXT smartcard_scard_context_native_from_redir(SMARTCARD_DEVICE* smartcard, REDIR_SCARDCONTEXT* context)
+SCARDCONTEXT smartcard_scard_context_native_from_redir(SMARTCARD_DEVICE* smartcard,
+        REDIR_SCARDCONTEXT* context)
 {
 	SCARDCONTEXT hContext = 0;
 
 	if ((context->cbContext != sizeof(ULONG_PTR)) && (context->cbContext != 0))
 	{
-		WLog_WARN(TAG, "REDIR_SCARDCONTEXT does not match native size: Actual: %"PRIu32", Expected: %"PRIuz"",
-			context->cbContext, sizeof(ULONG_PTR));
+		WLog_WARN(TAG,
+		          "REDIR_SCARDCONTEXT does not match native size: Actual: %"PRIu32", Expected: %"PRIuz"",
+		          context->cbContext, sizeof(ULONG_PTR));
 		return 0;
 	}
 
@@ -179,21 +181,24 @@ SCARDCONTEXT smartcard_scard_context_native_from_redir(SMARTCARD_DEVICE* smartca
 	return hContext;
 }
 
-void smartcard_scard_context_native_to_redir(SMARTCARD_DEVICE* smartcard, REDIR_SCARDCONTEXT* context, SCARDCONTEXT hContext)
+void smartcard_scard_context_native_to_redir(SMARTCARD_DEVICE* smartcard,
+        REDIR_SCARDCONTEXT* context, SCARDCONTEXT hContext)
 {
 	ZeroMemory(context, sizeof(REDIR_SCARDCONTEXT));
 	context->cbContext = sizeof(ULONG_PTR);
 	CopyMemory(&(context->pbContext), &hContext, context->cbContext);
 }
 
-SCARDHANDLE smartcard_scard_handle_native_from_redir(SMARTCARD_DEVICE* smartcard, REDIR_SCARDHANDLE* handle)
+SCARDHANDLE smartcard_scard_handle_native_from_redir(SMARTCARD_DEVICE* smartcard,
+        REDIR_SCARDHANDLE* handle)
 {
 	SCARDHANDLE hCard = 0;
 
 	if (handle->cbHandle != sizeof(ULONG_PTR))
 	{
-		WLog_WARN(TAG, "REDIR_SCARDHANDLE does not match native size: Actual: %"PRIu32", Expected: %"PRIuz"",
-			handle->cbHandle, sizeof(ULONG_PTR));
+		WLog_WARN(TAG,
+		          "REDIR_SCARDHANDLE does not match native size: Actual: %"PRIu32", Expected: %"PRIuz"",
+		          handle->cbHandle, sizeof(ULONG_PTR));
 		return 0;
 	}
 
@@ -203,23 +208,24 @@ SCARDHANDLE smartcard_scard_handle_native_from_redir(SMARTCARD_DEVICE* smartcard
 	return hCard;
 }
 
-void smartcard_scard_handle_native_to_redir(SMARTCARD_DEVICE* smartcard, REDIR_SCARDHANDLE* handle, SCARDHANDLE hCard)
+void smartcard_scard_handle_native_to_redir(SMARTCARD_DEVICE* smartcard, REDIR_SCARDHANDLE* handle,
+        SCARDHANDLE hCard)
 {
 	ZeroMemory(handle, sizeof(REDIR_SCARDHANDLE));
 	handle->cbHandle = sizeof(ULONG_PTR);
 	CopyMemory(&(handle->pbHandle), &hCard, handle->cbHandle);
 }
 
-LONG smartcard_unpack_redir_scard_context(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDCONTEXT* context)
+LONG smartcard_unpack_redir_scard_context(SMARTCARD_DEVICE* smartcard, wStream* s,
+        REDIR_SCARDCONTEXT* context)
 {
 	UINT32 pbContextNdrPtr;
-
 	ZeroMemory(context, sizeof(REDIR_SCARDCONTEXT));
 
 	if (Stream_GetRemainingLength(s) < 4)
 	{
 		WLog_WARN(TAG, "REDIR_SCARDCONTEXT is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -228,7 +234,7 @@ LONG smartcard_unpack_redir_scard_context(SMARTCARD_DEVICE* smartcard, wStream* 
 	if (Stream_GetRemainingLength(s) < context->cbContext)
 	{
 		WLog_WARN(TAG, "REDIR_SCARDCONTEXT is too short: Actual: %"PRIuz", Expected: %"PRIu32"",
-				Stream_GetRemainingLength(s), context->cbContext);
+		          Stream_GetRemainingLength(s), context->cbContext);
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -240,36 +246,36 @@ LONG smartcard_unpack_redir_scard_context(SMARTCARD_DEVICE* smartcard, wStream* 
 
 	Stream_Read_UINT32(s, pbContextNdrPtr); /* pbContextNdrPtr (4 bytes) */
 
-	if (((context->cbContext == 0) && pbContextNdrPtr) || ((context->cbContext != 0) && !pbContextNdrPtr))
+	if (((context->cbContext == 0) && pbContextNdrPtr) || ((context->cbContext != 0) &&
+	        !pbContextNdrPtr))
 	{
 		WLog_WARN(TAG, "REDIR_SCARDCONTEXT cbContext (%"PRIu32") pbContextNdrPtr (%"PRIu32") inconsistency",
-				context->cbContext, pbContextNdrPtr);
+		          context->cbContext, pbContextNdrPtr);
 		return STATUS_INVALID_PARAMETER;
 	}
 
 	if (context->cbContext > Stream_GetRemainingLength(s))
 	{
 		WLog_WARN(TAG, "REDIR_SCARDCONTEXT is too long: Actual: %"PRIuz", Expected: %"PRIu32"",
-				Stream_GetRemainingLength(s), context->cbContext);
+		          Stream_GetRemainingLength(s), context->cbContext);
 		return STATUS_INVALID_PARAMETER;
 	}
 
 	return SCARD_S_SUCCESS;
 }
 
-LONG smartcard_pack_redir_scard_context(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDCONTEXT* context)
+LONG smartcard_pack_redir_scard_context(SMARTCARD_DEVICE* smartcard, wStream* s,
+                                        REDIR_SCARDCONTEXT* context)
 {
 	UINT32 pbContextNdrPtr;
-
 	pbContextNdrPtr = (context->cbContext) ? 0x00020001 : 0;
-
 	Stream_Write_UINT32(s, context->cbContext); /* cbContext (4 bytes) */
 	Stream_Write_UINT32(s, pbContextNdrPtr); /* pbContextNdrPtr (4 bytes) */
-
 	return SCARD_S_SUCCESS;
 }
 
-LONG smartcard_unpack_redir_scard_context_ref(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDCONTEXT* context)
+LONG smartcard_unpack_redir_scard_context_ref(SMARTCARD_DEVICE* smartcard, wStream* s,
+        REDIR_SCARDCONTEXT* context)
 {
 	UINT32 length;
 
@@ -279,7 +285,7 @@ LONG smartcard_unpack_redir_scard_context_ref(SMARTCARD_DEVICE* smartcard, wStre
 	if (Stream_GetRemainingLength(s) < 4)
 	{
 		WLog_WARN(TAG, "REDIR_SCARDCONTEXT is too short: Actual: %"PRIuz", Expected: 4",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -288,7 +294,7 @@ LONG smartcard_unpack_redir_scard_context_ref(SMARTCARD_DEVICE* smartcard, wStre
 	if (length != context->cbContext)
 	{
 		WLog_WARN(TAG, "REDIR_SCARDCONTEXT length (%"PRIu32") cbContext (%"PRIu32") mismatch",
-			length, context->cbContext);
+		          length, context->cbContext);
 		return STATUS_INVALID_PARAMETER;
 	}
 
@@ -301,7 +307,7 @@ LONG smartcard_unpack_redir_scard_context_ref(SMARTCARD_DEVICE* smartcard, wStre
 	if (Stream_GetRemainingLength(s) < context->cbContext)
 	{
 		WLog_WARN(TAG, "REDIR_SCARDCONTEXT is too short: Actual: %"PRIuz", Expected: %"PRIu32"",
-				Stream_GetRemainingLength(s), context->cbContext);
+		          Stream_GetRemainingLength(s), context->cbContext);
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -313,7 +319,8 @@ LONG smartcard_unpack_redir_scard_context_ref(SMARTCARD_DEVICE* smartcard, wStre
 	return SCARD_S_SUCCESS;
 }
 
-LONG smartcard_pack_redir_scard_context_ref(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDCONTEXT* context)
+LONG smartcard_pack_redir_scard_context_ref(SMARTCARD_DEVICE* smartcard, wStream* s,
+        REDIR_SCARDCONTEXT* context)
 {
 	Stream_Write_UINT32(s, context->cbContext); /* Length (4 bytes) */
 
@@ -325,16 +332,16 @@ LONG smartcard_pack_redir_scard_context_ref(SMARTCARD_DEVICE* smartcard, wStream
 	return SCARD_S_SUCCESS;
 }
 
-LONG smartcard_unpack_redir_scard_handle(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDHANDLE* handle)
+LONG smartcard_unpack_redir_scard_handle(SMARTCARD_DEVICE* smartcard, wStream* s,
+        REDIR_SCARDHANDLE* handle)
 {
 	UINT32 pbHandleNdrPtr;
-
 	ZeroMemory(handle, sizeof(REDIR_SCARDHANDLE));
 
 	if (Stream_GetRemainingLength(s) < 4)
 	{
 		WLog_WARN(TAG, "SCARDHANDLE is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -343,35 +350,33 @@ LONG smartcard_unpack_redir_scard_handle(SMARTCARD_DEVICE* smartcard, wStream* s
 	if ((Stream_GetRemainingLength(s) < handle->cbHandle) || (!handle->cbHandle))
 	{
 		WLog_WARN(TAG, "SCARDHANDLE is too short: Actual: %"PRIuz", Expected: %"PRIu32"",
-				Stream_GetRemainingLength(s), handle->cbHandle);
+		          Stream_GetRemainingLength(s), handle->cbHandle);
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
 	Stream_Read_UINT32(s, pbHandleNdrPtr); /* NdrPtr (4 bytes) */
-
 	return SCARD_S_SUCCESS;
 }
 
-LONG smartcard_pack_redir_scard_handle(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDHANDLE* handle)
+LONG smartcard_pack_redir_scard_handle(SMARTCARD_DEVICE* smartcard, wStream* s,
+                                       REDIR_SCARDHANDLE* handle)
 {
 	UINT32 pbHandleNdrPtr;
-
 	pbHandleNdrPtr = (handle->cbHandle) ? 0x00020002 : 0;
-
 	Stream_Write_UINT32(s, handle->cbHandle); /* cbHandle (4 bytes) */
 	Stream_Write_UINT32(s, pbHandleNdrPtr); /* pbHandleNdrPtr (4 bytes) */
-
 	return SCARD_S_SUCCESS;
 }
 
-LONG smartcard_unpack_redir_scard_handle_ref(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDHANDLE* handle)
+LONG smartcard_unpack_redir_scard_handle_ref(SMARTCARD_DEVICE* smartcard, wStream* s,
+        REDIR_SCARDHANDLE* handle)
 {
 	UINT32 length;
 
 	if (Stream_GetRemainingLength(s) < 4)
 	{
 		WLog_WARN(TAG, "REDIR_SCARDHANDLE is too short: Actual: %"PRIuz", Expected: 4",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -380,7 +385,7 @@ LONG smartcard_unpack_redir_scard_handle_ref(SMARTCARD_DEVICE* smartcard, wStrea
 	if (length != handle->cbHandle)
 	{
 		WLog_WARN(TAG, "REDIR_SCARDHANDLE length (%"PRIu32") cbHandle (%"PRIu32") mismatch",
-			length, handle->cbHandle);
+		          length, handle->cbHandle);
 		return STATUS_INVALID_PARAMETER;
 	}
 
@@ -393,7 +398,7 @@ LONG smartcard_unpack_redir_scard_handle_ref(SMARTCARD_DEVICE* smartcard, wStrea
 	if ((Stream_GetRemainingLength(s) < handle->cbHandle) || (!handle->cbHandle))
 	{
 		WLog_WARN(TAG, "REDIR_SCARDHANDLE is too short: Actual: %"PRIuz", Expected: %"PRIu32"",
-				Stream_GetRemainingLength(s), handle->cbHandle);
+		          Stream_GetRemainingLength(s), handle->cbHandle);
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -403,7 +408,8 @@ LONG smartcard_unpack_redir_scard_handle_ref(SMARTCARD_DEVICE* smartcard, wStrea
 	return SCARD_S_SUCCESS;
 }
 
-LONG smartcard_pack_redir_scard_handle_ref(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDHANDLE* handle)
+LONG smartcard_pack_redir_scard_handle_ref(SMARTCARD_DEVICE* smartcard, wStream* s,
+        REDIR_SCARDHANDLE* handle)
 {
 	Stream_Write_UINT32(s, handle->cbHandle); /* Length (4 bytes) */
 
@@ -413,34 +419,34 @@ LONG smartcard_pack_redir_scard_handle_ref(SMARTCARD_DEVICE* smartcard, wStream*
 	return SCARD_S_SUCCESS;
 }
 
-LONG smartcard_unpack_establish_context_call(SMARTCARD_DEVICE* smartcard, wStream* s, EstablishContext_Call* call)
+LONG smartcard_unpack_establish_context_call(SMARTCARD_DEVICE* smartcard, wStream* s,
+        EstablishContext_Call* call)
 {
 	if (Stream_GetRemainingLength(s) < 4)
 	{
 		WLog_WARN(TAG, "EstablishContext_Call is too short: Actual: %"PRIuz", Expected: 4",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
 	Stream_Read_UINT32(s, call->dwScope); /* dwScope (4 bytes) */
-
 	return SCARD_S_SUCCESS;
 }
 
-void smartcard_trace_establish_context_call(SMARTCARD_DEVICE* smartcard, EstablishContext_Call* call)
+void smartcard_trace_establish_context_call(SMARTCARD_DEVICE* smartcard,
+        EstablishContext_Call* call)
 {
 	if (!WLog_IsLevelActive(WLog_Get(TAG), WLOG_DEBUG))
 		return;
 
 	WLog_DBG(TAG, "EstablishContext_Call {");
-
 	WLog_DBG(TAG, "dwScope: %s (0x%08"PRIX32")",
-			SCardGetScopeString(call->dwScope), call->dwScope);
-
+	         SCardGetScopeString(call->dwScope), call->dwScope);
 	WLog_DBG(TAG, "}");
 }
 
-LONG smartcard_pack_establish_context_return(SMARTCARD_DEVICE* smartcard, wStream* s, EstablishContext_Return* ret)
+LONG smartcard_pack_establish_context_return(SMARTCARD_DEVICE* smartcard, wStream* s,
+        EstablishContext_Return* ret)
 {
 	LONG status;
 
@@ -456,7 +462,8 @@ LONG smartcard_pack_establish_context_return(SMARTCARD_DEVICE* smartcard, wStrea
 	return status;
 }
 
-void smartcard_trace_establish_context_return(SMARTCARD_DEVICE* smartcard, EstablishContext_Return* ret)
+void smartcard_trace_establish_context_return(SMARTCARD_DEVICE* smartcard,
+        EstablishContext_Return* ret)
 {
 	BYTE* pb;
 
@@ -464,21 +471,20 @@ void smartcard_trace_establish_context_return(SMARTCARD_DEVICE* smartcard, Estab
 		return;
 
 	WLog_DBG(TAG, "EstablishContext_Return {");
-
 	WLog_DBG(TAG, "ReturnCode: %s (0x%08"PRIX32")",
-		SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
-
-	pb = (BYTE*) &(ret->hContext.pbContext);
+	         SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
+	pb = (BYTE*) & (ret->hContext.pbContext);
 
 	if (ret->hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], ret->hContext.cbContext);
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], ret->hContext.cbContext);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], ret->hContext.cbContext);
+		         pb[0], pb[1], pb[2], pb[3], ret->hContext.cbContext);
 	}
 
 	WLog_DBG(TAG, "}");
@@ -508,18 +514,18 @@ void smartcard_trace_context_call(SMARTCARD_DEVICE* smartcard, Context_Call* cal
 		return;
 
 	WLog_DBG(TAG, "%s_Call {", name);
-
-	pb = (BYTE*) &(call->hContext.pbContext);
+	pb = (BYTE*) & (call->hContext.pbContext);
 
 	if (call->hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
+		         pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
 	}
 
 	WLog_DBG(TAG, "}");
@@ -531,19 +537,130 @@ void smartcard_trace_long_return(SMARTCARD_DEVICE* smartcard, Long_Return* ret, 
 		return;
 
 	WLog_DBG(TAG, "%s_Return {", name);
-
 	WLog_DBG(TAG, "ReturnCode: %s (0x%08"PRIX32")",
-		SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
-
+	         SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
 	WLog_DBG(TAG, "}");
 }
 
-LONG smartcard_unpack_list_readers_call(SMARTCARD_DEVICE* smartcard, wStream* s, ListReaders_Call* call)
+LONG smartcard_unpack_list_reader_groups_call(SMARTCARD_DEVICE* smartcard, wStream* s,
+        ListReaderGroups_Call* call)
+{
+	LONG status;
+	status = smartcard_unpack_redir_scard_context(smartcard, s, &(call->hContext));
+
+	if (status)
+		return status;
+
+	if (Stream_GetRemainingLength(s) < 8)
+	{
+		WLog_WARN(TAG, "ListReaderGroups_Call is too short: %d",
+		          (int) Stream_GetRemainingLength(s));
+		return STATUS_BUFFER_TOO_SMALL;
+	}
+
+	Stream_Read_UINT32(s, call->fmszGroupsIsNULL); /* fmszGroupsIsNULL (4 bytes) */
+	Stream_Read_UINT32(s, call->cchGroups); /* cchGroups (4 bytes) */
+	status = smartcard_unpack_redir_scard_context_ref(smartcard, s, &(call->hContext));
+
+	if (status)
+		return status;
+
+	return SCARD_S_SUCCESS;
+}
+
+void smartcard_trace_list_reader_groups_call(SMARTCARD_DEVICE* smartcard,
+        ListReaderGroups_Call* call, BOOL unicode)
+{
+	BYTE* pb;
+
+	if (!WLog_IsLevelActive(WLog_Get(TAG), WLOG_DEBUG))
+		return;
+
+	WLog_DBG(TAG, "ListReaderGroups%S_Call {", unicode ? "W" : "A");
+	pb = (BYTE*) & (call->hContext.pbContext);
+
+	if (call->hContext.cbContext > 4)
+	{
+		WLog_DBG(TAG, "hContext: 0x%02X%02X%02X%02X%02X%02X%02X%02X (%d)",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
+	}
+	else
+	{
+		WLog_DBG(TAG, "hContext: 0x%02X%02X%02X%02X (%d)",
+		         pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
+	}
+
+	WLog_DBG(TAG, "fmszGroupsIsNULL: %d cchGroups: 0x%08X",
+	         call->fmszGroupsIsNULL, call->cchGroups);
+	WLog_DBG(TAG, "}");
+}
+
+LONG smartcard_pack_list_reader_groups_return(SMARTCARD_DEVICE* smartcard, wStream* s,
+        ListReaderGroups_Return* ret)
+{
+	UINT32 mszNdrPtr;
+	mszNdrPtr = (ret->cBytes) ? 0x00020008 : 0;
+	Stream_EnsureRemainingCapacity(s, ret->cBytes + 32);
+	Stream_Write_UINT32(s, ret->cBytes); /* cBytes (4 bytes) */
+	Stream_Write_UINT32(s, mszNdrPtr); /* mszNdrPtr (4 bytes) */
+
+	if (mszNdrPtr)
+	{
+		Stream_Write_UINT32(s, ret->cBytes); /* mszNdrLen (4 bytes) */
+
+		if (ret->msz)
+			Stream_Write(s, ret->msz, ret->cBytes);
+		else
+			Stream_Zero(s, ret->cBytes);
+
+		smartcard_pack_write_size_align(smartcard, s, ret->cBytes, 4);
+	}
+
+	return SCARD_S_SUCCESS;
+}
+
+void smartcard_trace_list_reader_groups_return(SMARTCARD_DEVICE* smartcard,
+        ListReaderGroups_Return* ret, BOOL unicode)
+{
+	int index;
+	int length;
+	char* mszA = NULL;
+
+	if (!WLog_IsLevelActive(WLog_Get(TAG), WLOG_DEBUG))
+		return;
+
+	if (unicode)
+	{
+		length = ret->cBytes / 2;
+		ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) ret->msz, length, &mszA, 0, NULL, NULL);
+	}
+	else
+	{
+		length = ret->cBytes;
+		mszA = (char*) malloc(length);
+		CopyMemory(mszA, ret->msz, ret->cBytes);
+	}
+
+	for (index = 0; index < length - 2; index++)
+	{
+		if (mszA[index] == '\0')
+			mszA[index] = ',';
+	}
+
+	WLog_DBG(TAG, "ListReaderGroups%s_Return {", unicode ? "W" : "A");
+	WLog_DBG(TAG, "ReturnCode: %s (0x%08X)",
+	         SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
+	WLog_DBG(TAG, "cBytes: %d msz: %s", ret->cBytes, mszA);
+	WLog_DBG(TAG, "}");
+	free(mszA);
+}
+
+LONG smartcard_unpack_list_readers_call(SMARTCARD_DEVICE* smartcard, wStream* s,
+                                        ListReaders_Call* call)
 {
 	LONG status;
 	UINT32 count;
 	UINT32 mszGroupsNdrPtr;
-
 	call->mszGroups = NULL;
 
 	if ((status = smartcard_unpack_redir_scard_context(smartcard, s, &(call->hContext))))
@@ -555,7 +672,7 @@ LONG smartcard_unpack_list_readers_call(SMARTCARD_DEVICE* smartcard, wStream* s,
 	if (Stream_GetRemainingLength(s) < 16)
 	{
 		WLog_WARN(TAG, "ListReaders_Call is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -572,46 +689,47 @@ LONG smartcard_unpack_list_readers_call(SMARTCARD_DEVICE* smartcard, wStream* s,
 
 	if ((mszGroupsNdrPtr && !call->cBytes) || (!mszGroupsNdrPtr && call->cBytes))
 	{
-		WLog_WARN(TAG, "ListReaders_Call mszGroupsNdrPtr (0x%08"PRIX32") and cBytes (0x%08"PRIX32") inconsistency",
-				mszGroupsNdrPtr, call->cBytes);
+		WLog_WARN(TAG,
+		          "ListReaders_Call mszGroupsNdrPtr (0x%08"PRIX32") and cBytes (0x%08"PRIX32") inconsistency",
+		          mszGroupsNdrPtr, call->cBytes);
 		return STATUS_INVALID_PARAMETER;
 	}
-	
+
 	if (mszGroupsNdrPtr)
 	{
 		Stream_Read_UINT32(s, count); /* NdrCount (4 bytes) */
-		
+
 		if (count != call->cBytes)
 		{
 			WLog_WARN(TAG, "ListReaders_Call NdrCount (0x%08"PRIX32") and cBytes (0x%08"PRIX32") inconsistency",
-					count, call->cBytes);
+			          count, call->cBytes);
 			return STATUS_INVALID_PARAMETER;
 		}
-		
+
 		if (Stream_GetRemainingLength(s) < call->cBytes)
 		{
 			WLog_WARN(TAG, "ListReaders_Call is too short: Actual: %"PRIuz", Expected: %"PRIu32"",
-				   Stream_GetRemainingLength(s), call->cBytes);
+			          Stream_GetRemainingLength(s), call->cBytes);
 			return STATUS_BUFFER_TOO_SMALL;
 		}
-		
+
 		call->mszGroups = (BYTE*) calloc(1, call->cBytes + 4);
-		
+
 		if (!call->mszGroups)
 		{
 			WLog_WARN(TAG, "ListReaders_Call out of memory error (mszGroups)");
 			return STATUS_NO_MEMORY;
 		}
-		
+
 		Stream_Read(s, call->mszGroups, call->cBytes);
-		
 		smartcard_unpack_read_size_align(smartcard, s, call->cBytes, 4);
 	}
 
 	return SCARD_S_SUCCESS;
 }
 
-void smartcard_trace_list_readers_call(SMARTCARD_DEVICE* smartcard, ListReaders_Call* call, BOOL unicode)
+void smartcard_trace_list_readers_call(SMARTCARD_DEVICE* smartcard, ListReaders_Call* call,
+                                       BOOL unicode)
 {
 	BYTE* pb;
 	char* mszGroupsA = NULL;
@@ -620,33 +738,35 @@ void smartcard_trace_list_readers_call(SMARTCARD_DEVICE* smartcard, ListReaders_
 		return;
 
 	if (unicode)
-		ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) call->mszGroups, call->cBytes / 2, &mszGroupsA, 0, NULL, NULL);
+		ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) call->mszGroups, call->cBytes / 2, &mszGroupsA, 0, NULL,
+		                   NULL);
 
 	WLog_DBG(TAG, "ListReaders%s_Call {", unicode ? "W" : "A");
-
-	pb = (BYTE*) &(call->hContext.pbContext);
+	pb = (BYTE*) & (call->hContext.pbContext);
 
 	if (call->hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
+		         pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
 	}
 
-	WLog_DBG(TAG, "cBytes: %"PRIu32" mszGroups: %s fmszReadersIsNULL: %"PRId32" cchReaders: 0x%08"PRIX32"",
-			call->cBytes, mszGroupsA, call->fmszReadersIsNULL, call->cchReaders);
-
+	WLog_DBG(TAG,
+	         "cBytes: %"PRIu32" mszGroups: %s fmszReadersIsNULL: %"PRId32" cchReaders: 0x%08"PRIX32"",
+	         call->cBytes, mszGroupsA, call->fmszReadersIsNULL, call->cchReaders);
 	WLog_DBG(TAG, "}");
 
 	if (unicode)
 		free(mszGroupsA);
 }
 
-LONG smartcard_pack_list_readers_return(SMARTCARD_DEVICE* smartcard, wStream* s, ListReaders_Return* ret)
+LONG smartcard_pack_list_readers_return(SMARTCARD_DEVICE* smartcard, wStream* s,
+                                        ListReaders_Return* ret)
 {
 	UINT32 mszNdrPtr;
 	LONG error;
@@ -684,7 +804,8 @@ LONG smartcard_pack_list_readers_return(SMARTCARD_DEVICE* smartcard, wStream* s,
 	return SCARD_S_SUCCESS;
 }
 
-void smartcard_trace_list_readers_return(SMARTCARD_DEVICE* smartcard, ListReaders_Return* ret, BOOL unicode)
+void smartcard_trace_list_readers_return(SMARTCARD_DEVICE* smartcard, ListReaders_Return* ret,
+        BOOL unicode)
 {
 	int index;
 	size_t length;
@@ -694,9 +815,8 @@ void smartcard_trace_list_readers_return(SMARTCARD_DEVICE* smartcard, ListReader
 		return;
 
 	WLog_DBG(TAG, "ListReaders%s_Return {", unicode ? "W" : "A");
-
 	WLog_DBG(TAG, "ReturnCode: %s (0x%08"PRIX32")",
-		SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
+	         SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
 
 	if (ret->ReturnCode != SCARD_S_SUCCESS)
 	{
@@ -707,8 +827,9 @@ void smartcard_trace_list_readers_return(SMARTCARD_DEVICE* smartcard, ListReader
 	if (unicode)
 	{
 		length = ret->cBytes / 2;
+
 		if (ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) ret->msz, (int)length,
-			&mszA, 0, NULL, NULL) < 1)
+		                       &mszA, 0, NULL, NULL) < 1)
 		{
 			WLog_ERR(TAG, "ConvertFromUnicode failed");
 			return;
@@ -718,11 +839,13 @@ void smartcard_trace_list_readers_return(SMARTCARD_DEVICE* smartcard, ListReader
 	{
 		length = ret->cBytes;
 		mszA = (char*) malloc(length);
+
 		if (!mszA)
 		{
 			WLog_ERR(TAG, "malloc failed!");
 			return;
 		}
+
 		CopyMemory(mszA, ret->msz, ret->cBytes);
 	}
 
@@ -733,20 +856,19 @@ void smartcard_trace_list_readers_return(SMARTCARD_DEVICE* smartcard, ListReader
 	}
 
 	WLog_DBG(TAG, "cBytes: %"PRIu32" msz: %s", ret->cBytes, mszA);
-
 	WLog_DBG(TAG, "}");
-
 	free(mszA);
 }
 
-LONG smartcard_unpack_connect_common(SMARTCARD_DEVICE* smartcard, wStream* s, Connect_Common* common)
+LONG smartcard_unpack_connect_common(SMARTCARD_DEVICE* smartcard, wStream* s,
+                                     Connect_Common* common)
 {
 	LONG status;
 
 	if (Stream_GetRemainingLength(s) < 8)
 	{
 		WLog_WARN(TAG, "Connect_Common is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -758,7 +880,6 @@ LONG smartcard_unpack_connect_common(SMARTCARD_DEVICE* smartcard, wStream* s, Co
 
 	Stream_Read_UINT32(s, common->dwShareMode); /* dwShareMode (4 bytes) */
 	Stream_Read_UINT32(s, common->dwPreferredProtocols); /* dwPreferredProtocols (4 bytes) */
-
 	return SCARD_S_SUCCESS;
 }
 
@@ -766,13 +887,12 @@ LONG smartcard_unpack_connect_a_call(SMARTCARD_DEVICE* smartcard, wStream* s, Co
 {
 	LONG status;
 	UINT32 count;
-
 	call->szReader = NULL;
 
 	if (Stream_GetRemainingLength(s) < 4)
 	{
 		WLog_WARN(TAG, "ConnectA_Call is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -785,11 +905,9 @@ LONG smartcard_unpack_connect_a_call(SMARTCARD_DEVICE* smartcard, wStream* s, Co
 	}
 
 	/* szReader */
-
 	Stream_Seek_UINT32(s); /* NdrMaxCount (4 bytes) */
 	Stream_Seek_UINT32(s); /* NdrOffset (4 bytes) */
 	Stream_Read_UINT32(s, count); /* NdrActualCount (4 bytes) */
-
 	call->szReader = (unsigned char*) malloc(count + 1);
 
 	if (!call->szReader)
@@ -816,24 +934,24 @@ void smartcard_trace_connect_a_call(SMARTCARD_DEVICE* smartcard, ConnectA_Call* 
 		return;
 
 	WLog_DBG(TAG, "ConnectA_Call {");
-
-	pb = (BYTE*) &(call->Common.hContext.pbContext);
+	pb = (BYTE*) & (call->Common.hContext.pbContext);
 
 	if (call->Common.hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->Common.hContext.cbContext);
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->Common.hContext.cbContext);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->Common.hContext.cbContext);
+		         pb[0], pb[1], pb[2], pb[3], call->Common.hContext.cbContext);
 	}
 
-	WLog_DBG(TAG, "szReader: %s dwShareMode: %s (0x%08"PRIX32") dwPreferredProtocols: %s (0x%08"PRIX32")",
-		call->szReader, SCardGetShareModeString(call->Common.dwShareMode), call->Common.dwShareMode,
-		SCardGetProtocolString(call->Common.dwPreferredProtocols), call->Common.dwPreferredProtocols);
-
+	WLog_DBG(TAG,
+	         "szReader: %s dwShareMode: %s (0x%08"PRIX32") dwPreferredProtocols: %s (0x%08"PRIX32")",
+	         call->szReader, SCardGetShareModeString(call->Common.dwShareMode), call->Common.dwShareMode,
+	         SCardGetProtocolString(call->Common.dwPreferredProtocols), call->Common.dwPreferredProtocols);
 	WLog_DBG(TAG, "}");
 }
 
@@ -841,13 +959,12 @@ LONG smartcard_unpack_connect_w_call(SMARTCARD_DEVICE* smartcard, wStream* s, Co
 {
 	LONG status;
 	UINT32 count;
-
 	call->szReader = NULL;
 
 	if (Stream_GetRemainingLength(s) < 4)
 	{
 		WLog_WARN(TAG, "ConnectW_Call is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -860,11 +977,9 @@ LONG smartcard_unpack_connect_w_call(SMARTCARD_DEVICE* smartcard, wStream* s, Co
 	}
 
 	/* szReader */
-
 	Stream_Seek_UINT32(s); /* NdrMaxCount (4 bytes) */
 	Stream_Seek_UINT32(s); /* NdrOffset (4 bytes) */
 	Stream_Read_UINT32(s, count); /* NdrActualCount (4 bytes) */
-
 	call->szReader = (WCHAR*) malloc((count + 1) * 2);
 
 	if (!call->szReader)
@@ -892,28 +1007,26 @@ void smartcard_trace_connect_w_call(SMARTCARD_DEVICE* smartcard, ConnectW_Call* 
 		return;
 
 	ConvertFromUnicode(CP_UTF8, 0, call->szReader, -1, &szReaderA, 0, NULL, NULL);
-
 	WLog_DBG(TAG, "ConnectW_Call {");
-
-	pb = (BYTE*) &(call->Common.hContext.pbContext);
+	pb = (BYTE*) & (call->Common.hContext.pbContext);
 
 	if (call->Common.hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->Common.hContext.cbContext);
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->Common.hContext.cbContext);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->Common.hContext.cbContext);
+		         pb[0], pb[1], pb[2], pb[3], call->Common.hContext.cbContext);
 	}
 
-	WLog_DBG(TAG, "szReader: %s dwShareMode: %s (0x%08"PRIX32") dwPreferredProtocols: %s (0x%08"PRIX32")",
-		szReaderA, SCardGetShareModeString(call->Common.dwShareMode), call->Common.dwShareMode,
-		SCardGetProtocolString(call->Common.dwPreferredProtocols), call->Common.dwPreferredProtocols);
-
+	WLog_DBG(TAG,
+	         "szReader: %s dwShareMode: %s (0x%08"PRIX32") dwPreferredProtocols: %s (0x%08"PRIX32")",
+	         szReaderA, SCardGetShareModeString(call->Common.dwShareMode), call->Common.dwShareMode,
+	         SCardGetProtocolString(call->Common.dwPreferredProtocols), call->Common.dwPreferredProtocols);
 	WLog_DBG(TAG, "}");
-
 	free(szReaderA);
 }
 
@@ -955,39 +1068,38 @@ void smartcard_trace_connect_return(SMARTCARD_DEVICE* smartcard, Connect_Return*
 		return;
 
 	WLog_DBG(TAG, "Connect_Return {");
-
 	WLog_DBG(TAG, "ReturnCode: %s (0x%08"PRIX32")",
-		SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
-
-	pb = (BYTE*) &(ret->hContext.pbContext);
+	         SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
+	pb = (BYTE*) & (ret->hContext.pbContext);
 
 	if (ret->hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], ret->hContext.cbContext);
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], ret->hContext.cbContext);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], ret->hContext.cbContext);
+		         pb[0], pb[1], pb[2], pb[3], ret->hContext.cbContext);
 	}
 
-	pb = (BYTE*) &(ret->hCard.pbHandle);
+	pb = (BYTE*) & (ret->hCard.pbHandle);
 
 	if (ret->hCard.cbHandle > 4)
 	{
-		WLog_DBG(TAG, "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], ret->hCard.cbHandle);
+		WLog_DBG(TAG,
+		         "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], ret->hCard.cbHandle);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], ret->hCard.cbHandle);
+		         pb[0], pb[1], pb[2], pb[3], ret->hCard.cbHandle);
 	}
 
 	WLog_DBG(TAG, "dwActiveProtocol: %s (0x%08"PRIX32")",
-		SCardGetProtocolString(ret->dwActiveProtocol), ret->dwActiveProtocol);
-
+	         SCardGetProtocolString(ret->dwActiveProtocol), ret->dwActiveProtocol);
 	WLog_DBG(TAG, "}");
 }
 
@@ -1007,11 +1119,10 @@ LONG smartcard_unpack_reconnect_call(SMARTCARD_DEVICE* smartcard, wStream* s, Re
 		return status;
 	}
 
-
 	if (Stream_GetRemainingLength(s) < 12)
 	{
 		WLog_WARN(TAG, "Reconnect_Call is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -1039,45 +1150,45 @@ void smartcard_trace_reconnect_call(SMARTCARD_DEVICE* smartcard, Reconnect_Call*
 		return;
 
 	WLog_DBG(TAG, "Reconnect_Call {");
-
-	pb = (BYTE*) &(call->hContext.pbContext);
+	pb = (BYTE*) & (call->hContext.pbContext);
 
 	if (call->hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
+		         pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
 	}
 
-	pb = (BYTE*) &(call->hCard.pbHandle);
+	pb = (BYTE*) & (call->hCard.pbHandle);
 
 	if (call->hCard.cbHandle > 4)
 	{
-		WLog_DBG(TAG, "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hCard.cbHandle);
+		WLog_DBG(TAG,
+		         "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hCard.cbHandle);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hCard.cbHandle);
+		         pb[0], pb[1], pb[2], pb[3], call->hCard.cbHandle);
 	}
 
-	WLog_DBG(TAG, "dwShareMode: %s (0x%08"PRIX32") dwPreferredProtocols: %s (0x%08"PRIX32") dwInitialization: %s (0x%08"PRIX32")",
-		SCardGetShareModeString(call->dwShareMode), call->dwShareMode,
-		SCardGetProtocolString(call->dwPreferredProtocols), call->dwPreferredProtocols,
-		SCardGetDispositionString(call->dwInitialization), call->dwInitialization);
-
+	WLog_DBG(TAG,
+	         "dwShareMode: %s (0x%08"PRIX32") dwPreferredProtocols: %s (0x%08"PRIX32") dwInitialization: %s (0x%08"PRIX32")",
+	         SCardGetShareModeString(call->dwShareMode), call->dwShareMode,
+	         SCardGetProtocolString(call->dwPreferredProtocols), call->dwPreferredProtocols,
+	         SCardGetDispositionString(call->dwInitialization), call->dwInitialization);
 	WLog_DBG(TAG, "}");
 }
 
 LONG smartcard_pack_reconnect_return(SMARTCARD_DEVICE* smartcard, wStream* s, Reconnect_Return* ret)
 {
 	Stream_Write_UINT32(s, ret->dwActiveProtocol); /* dwActiveProtocol (4 bytes) */
-
 	return SCARD_S_SUCCESS;
 }
 
@@ -1087,17 +1198,15 @@ void smartcard_trace_reconnect_return(SMARTCARD_DEVICE* smartcard, Reconnect_Ret
 		return;
 
 	WLog_DBG(TAG, "Reconnect_Return {");
-
 	WLog_DBG(TAG, "ReturnCode: %s (0x%08"PRIX32")",
-		SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
-
+	         SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
 	WLog_DBG(TAG, "dwActiveProtocol: %s (0x%08"PRIX32")",
-		SCardGetProtocolString(ret->dwActiveProtocol), ret->dwActiveProtocol);
-
+	         SCardGetProtocolString(ret->dwActiveProtocol), ret->dwActiveProtocol);
 	WLog_DBG(TAG, "}");
 }
 
-LONG smartcard_unpack_hcard_and_disposition_call(SMARTCARD_DEVICE* smartcard, wStream* s, HCardAndDisposition_Call* call)
+LONG smartcard_unpack_hcard_and_disposition_call(SMARTCARD_DEVICE* smartcard, wStream* s,
+        HCardAndDisposition_Call* call)
 {
 	LONG status;
 
@@ -1116,7 +1225,7 @@ LONG smartcard_unpack_hcard_and_disposition_call(SMARTCARD_DEVICE* smartcard, wS
 	if (Stream_GetRemainingLength(s) < 4)
 	{
 		WLog_WARN(TAG, "HCardAndDisposition_Call is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -1134,7 +1243,8 @@ LONG smartcard_unpack_hcard_and_disposition_call(SMARTCARD_DEVICE* smartcard, wS
 	return status;
 }
 
-void smartcard_trace_hcard_and_disposition_call(SMARTCARD_DEVICE* smartcard, HCardAndDisposition_Call* call, const char* name)
+void smartcard_trace_hcard_and_disposition_call(SMARTCARD_DEVICE* smartcard,
+        HCardAndDisposition_Call* call, const char* name)
 {
 	BYTE* pb;
 
@@ -1142,40 +1252,41 @@ void smartcard_trace_hcard_and_disposition_call(SMARTCARD_DEVICE* smartcard, HCa
 		return;
 
 	WLog_DBG(TAG, "%s_Call {", name);
-
-	pb = (BYTE*) &(call->hContext.pbContext);
+	pb = (BYTE*) & (call->hContext.pbContext);
 
 	if (call->hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
+		         pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
 	}
 
-	pb = (BYTE*) &(call->hCard.pbHandle);
+	pb = (BYTE*) & (call->hCard.pbHandle);
 
 	if (call->hCard.cbHandle > 4)
 	{
-		WLog_DBG(TAG, "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hCard.cbHandle);
+		WLog_DBG(TAG,
+		         "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hCard.cbHandle);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hCard.cbHandle);
+		         pb[0], pb[1], pb[2], pb[3], call->hCard.cbHandle);
 	}
 
 	WLog_DBG(TAG, "dwDisposition: %s (0x%08"PRIX32")",
-		SCardGetDispositionString(call->dwDisposition), call->dwDisposition);
-
+	         SCardGetDispositionString(call->dwDisposition), call->dwDisposition);
 	WLog_DBG(TAG, "}");
 }
 
-LONG smartcard_unpack_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, wStream* s, GetStatusChangeA_Call* call)
+LONG smartcard_unpack_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, wStream* s,
+        GetStatusChangeA_Call* call)
 {
 	UINT32 index;
 	UINT32 count;
@@ -1185,7 +1296,6 @@ LONG smartcard_unpack_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, wStr
 	UINT32 szReaderNdrPtr;
 	UINT32 rgReaderStatesNdrPtr;
 	LPSCARD_READERSTATEA readerState;
-
 	call->rgReaderStates = NULL;
 
 	if ((status = smartcard_unpack_redir_scard_context(smartcard, s, &(call->hContext))))
@@ -1197,7 +1307,7 @@ LONG smartcard_unpack_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, wStr
 	if (Stream_GetRemainingLength(s) < 12)
 	{
 		WLog_WARN(TAG, "GetStatusChangeA_Call is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -1214,7 +1324,7 @@ LONG smartcard_unpack_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, wStr
 	if (Stream_GetRemainingLength(s) < 4)
 	{
 		WLog_WARN(TAG, "GetStatusChangeA_Call is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -1222,8 +1332,9 @@ LONG smartcard_unpack_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, wStr
 
 	if (count != call->cReaders)
 	{
-		WLog_WARN(TAG, "GetStatusChangeA_Call unexpected reader count: Actual: %"PRIu32", Expected: %"PRIu32"",
-				count, call->cReaders);
+		WLog_WARN(TAG,
+		          "GetStatusChangeA_Call unexpected reader count: Actual: %"PRIu32", Expected: %"PRIu32"",
+		          count, call->cReaders);
 		return STATUS_INVALID_PARAMETER;
 	}
 
@@ -1244,7 +1355,7 @@ LONG smartcard_unpack_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, wStr
 			if (Stream_GetRemainingLength(s) < 52)
 			{
 				WLog_WARN(TAG, "GetStatusChangeA_Call is too short: %"PRIuz"",
-						Stream_GetRemainingLength(s));
+				          Stream_GetRemainingLength(s));
 				return STATUS_BUFFER_TOO_SMALL;
 			}
 
@@ -1263,7 +1374,7 @@ LONG smartcard_unpack_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, wStr
 			if (Stream_GetRemainingLength(s) < 12)
 			{
 				WLog_WARN(TAG, "GetStatusChangeA_Call is too short: %"PRIuz"",
-						Stream_GetRemainingLength(s));
+				          Stream_GetRemainingLength(s));
 				return STATUS_BUFFER_TOO_SMALL;
 			}
 
@@ -1274,7 +1385,7 @@ LONG smartcard_unpack_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, wStr
 			if (Stream_GetRemainingLength(s) < count)
 			{
 				WLog_WARN(TAG, "GetStatusChangeA_Call is too short: %"PRIuz"",
-						Stream_GetRemainingLength(s));
+				          Stream_GetRemainingLength(s));
 				return STATUS_BUFFER_TOO_SMALL;
 			}
 
@@ -1301,7 +1412,8 @@ LONG smartcard_unpack_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, wStr
 	return SCARD_S_SUCCESS;
 }
 
-void smartcard_trace_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, GetStatusChangeA_Call* call)
+void smartcard_trace_get_status_change_a_call(SMARTCARD_DEVICE* smartcard,
+        GetStatusChangeA_Call* call)
 {
 	BYTE* pb;
 	UINT32 index;
@@ -1313,39 +1425,34 @@ void smartcard_trace_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, GetSt
 		return;
 
 	WLog_DBG(TAG, "GetStatusChangeA_Call {");
-
-	pb = (BYTE*) &(call->hContext.pbContext);
+	pb = (BYTE*) & (call->hContext.pbContext);
 
 	if (call->hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
+		         pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
 	}
 
 	WLog_DBG(TAG, "dwTimeOut: 0x%08"PRIX32" cReaders: %"PRIu32"",
-		call->dwTimeOut, call->cReaders);
+	         call->dwTimeOut, call->cReaders);
 
 	for (index = 0; index < call->cReaders; index++)
 	{
 		readerState = &call->rgReaderStates[index];
-
 		WLog_DBG(TAG, "\t[%"PRIu32"]: szReader: %s cbAtr: %"PRIu32"",
-			index, readerState->szReader, readerState->cbAtr);
-
+		         index, readerState->szReader, readerState->cbAtr);
 		szCurrentState = SCardGetReaderStateString(readerState->dwCurrentState);
 		szEventState = SCardGetReaderStateString(readerState->dwEventState);
-
 		WLog_DBG(TAG, "\t[%"PRIu32"]: dwCurrentState: %s (0x%08"PRIX32")",
-			index, szCurrentState, readerState->dwCurrentState);
-
+		         index, szCurrentState, readerState->dwCurrentState);
 		WLog_DBG(TAG, "\t[%"PRIu32"]: dwEventState: %s (0x%08"PRIX32")",
-			index, szEventState, readerState->dwEventState);
-
+		         index, szEventState, readerState->dwEventState);
 		free(szCurrentState);
 		free(szEventState);
 	}
@@ -1353,7 +1460,8 @@ void smartcard_trace_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, GetSt
 	WLog_DBG(TAG, "}");
 }
 
-LONG smartcard_unpack_get_status_change_w_call(SMARTCARD_DEVICE* smartcard, wStream* s, GetStatusChangeW_Call* call)
+LONG smartcard_unpack_get_status_change_w_call(SMARTCARD_DEVICE* smartcard, wStream* s,
+        GetStatusChangeW_Call* call)
 {
 	UINT32 index;
 	UINT32 count;
@@ -1363,7 +1471,6 @@ LONG smartcard_unpack_get_status_change_w_call(SMARTCARD_DEVICE* smartcard, wStr
 	UINT32 szReaderNdrPtr;
 	UINT32 rgReaderStatesNdrPtr;
 	LPSCARD_READERSTATEW readerState;
-
 	call->rgReaderStates = NULL;
 
 	if ((status = smartcard_unpack_redir_scard_context(smartcard, s, &(call->hContext))))
@@ -1375,7 +1482,7 @@ LONG smartcard_unpack_get_status_change_w_call(SMARTCARD_DEVICE* smartcard, wStr
 	if (Stream_GetRemainingLength(s) < 12)
 	{
 		WLog_WARN(TAG, "GetStatusChangeW_Call is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -1392,7 +1499,7 @@ LONG smartcard_unpack_get_status_change_w_call(SMARTCARD_DEVICE* smartcard, wStr
 	if (Stream_GetRemainingLength(s) < 4)
 	{
 		WLog_WARN(TAG, "GetStatusChangeW_Call is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -1415,7 +1522,7 @@ LONG smartcard_unpack_get_status_change_w_call(SMARTCARD_DEVICE* smartcard, wStr
 			if (Stream_GetRemainingLength(s) < 52)
 			{
 				WLog_WARN(TAG, "GetStatusChangeW_Call is too short: %"PRIuz"",
-						Stream_GetRemainingLength(s));
+				          Stream_GetRemainingLength(s));
 				return STATUS_BUFFER_TOO_SMALL;
 			}
 
@@ -1434,7 +1541,7 @@ LONG smartcard_unpack_get_status_change_w_call(SMARTCARD_DEVICE* smartcard, wStr
 			if (Stream_GetRemainingLength(s) < 12)
 			{
 				WLog_WARN(TAG, "GetStatusChangeW_Call is too short: %"PRIuz"",
-						Stream_GetRemainingLength(s));
+				          Stream_GetRemainingLength(s));
 				return STATUS_BUFFER_TOO_SMALL;
 			}
 
@@ -1445,7 +1552,7 @@ LONG smartcard_unpack_get_status_change_w_call(SMARTCARD_DEVICE* smartcard, wStr
 			if (Stream_GetRemainingLength(s) < (count * 2))
 			{
 				WLog_WARN(TAG, "GetStatusChangeW_Call is too short: %"PRIuz"",
-						Stream_GetRemainingLength(s));
+				          Stream_GetRemainingLength(s));
 				return STATUS_BUFFER_TOO_SMALL;
 			}
 
@@ -1472,7 +1579,8 @@ LONG smartcard_unpack_get_status_change_w_call(SMARTCARD_DEVICE* smartcard, wStr
 	return SCARD_S_SUCCESS;
 }
 
-void smartcard_trace_get_status_change_w_call(SMARTCARD_DEVICE* smartcard, GetStatusChangeW_Call* call)
+void smartcard_trace_get_status_change_w_call(SMARTCARD_DEVICE* smartcard,
+        GetStatusChangeW_Call* call)
 {
 	BYTE* pb;
 	UINT32 index;
@@ -1484,57 +1592,49 @@ void smartcard_trace_get_status_change_w_call(SMARTCARD_DEVICE* smartcard, GetSt
 		return;
 
 	WLog_DBG(TAG, "GetStatusChangeW_Call {");
-
-	pb = (BYTE*) &(call->hContext.pbContext);
+	pb = (BYTE*) & (call->hContext.pbContext);
 
 	if (call->hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
+		         pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
 	}
 
 	WLog_DBG(TAG, "dwTimeOut: 0x%08"PRIX32" cReaders: %"PRIu32"",
-		call->dwTimeOut, call->cReaders);
+	         call->dwTimeOut, call->cReaders);
 
 	for (index = 0; index < call->cReaders; index++)
 	{
 		char* szReaderA = NULL;
-
 		readerState = &call->rgReaderStates[index];
-
 		ConvertFromUnicode(CP_UTF8, 0, readerState->szReader, -1, &szReaderA, 0, NULL, NULL);
-
 		WLog_DBG(TAG, "\t[%"PRIu32"]: szReader: %s cbAtr: %"PRIu32"",
-			index, szReaderA, readerState->cbAtr);
-
+		         index, szReaderA, readerState->cbAtr);
 		szCurrentState = SCardGetReaderStateString(readerState->dwCurrentState);
 		szEventState = SCardGetReaderStateString(readerState->dwEventState);
-
 		WLog_DBG(TAG, "\t[%"PRIu32"]: dwCurrentState: %s (0x%08"PRIX32")",
-			index, szCurrentState, readerState->dwCurrentState);
-
+		         index, szCurrentState, readerState->dwCurrentState);
 		WLog_DBG(TAG, "\t[%"PRIu32"]: dwEventState: %s (0x%08"PRIX32")",
-			index, szEventState, readerState->dwEventState);
-
+		         index, szEventState, readerState->dwEventState);
 		free(szCurrentState);
 		free(szEventState);
-
 		free(szReaderA);
 	}
 
 	WLog_DBG(TAG, "}");
 }
 
-LONG smartcard_pack_get_status_change_return(SMARTCARD_DEVICE* smartcard, wStream* s, GetStatusChange_Return* ret)
+LONG smartcard_pack_get_status_change_return(SMARTCARD_DEVICE* smartcard, wStream* s,
+        GetStatusChange_Return* ret)
 {
 	UINT32 index;
 	ReaderState_Return* rgReaderState;
-
 	Stream_Write_UINT32(s, ret->cReaders); /* cReaders (4 bytes) */
 	Stream_Write_UINT32(s, 0x00020100); /* rgReaderStatesNdrPtr (4 bytes) */
 	Stream_Write_UINT32(s, ret->cReaders); /* rgReaderStatesNdrCount (4 bytes) */
@@ -1552,7 +1652,8 @@ LONG smartcard_pack_get_status_change_return(SMARTCARD_DEVICE* smartcard, wStrea
 	return SCARD_S_SUCCESS;
 }
 
-void smartcard_trace_get_status_change_return(SMARTCARD_DEVICE* smartcard, GetStatusChange_Return* ret, BOOL unicode)
+void smartcard_trace_get_status_change_return(SMARTCARD_DEVICE* smartcard,
+        GetStatusChange_Return* ret, BOOL unicode)
 {
 	UINT32 index;
 	char* rgbAtr;
@@ -1564,29 +1665,22 @@ void smartcard_trace_get_status_change_return(SMARTCARD_DEVICE* smartcard, GetSt
 		return;
 
 	WLog_DBG(TAG, "GetStatusChange%s_Return {", unicode ? "W" : "A");
-
 	WLog_DBG(TAG, "ReturnCode: %s (0x%08"PRIX32")",
-		SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
-
+	         SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
 	WLog_DBG(TAG, "cReaders: %"PRIu32"", ret->cReaders);
 
 	for (index = 0; index < ret->cReaders; index++)
 	{
 		rgReaderState = &(ret->rgReaderStates[index]);
-
 		szCurrentState = SCardGetReaderStateString(rgReaderState->dwCurrentState);
 		szEventState = SCardGetReaderStateString(rgReaderState->dwEventState);
-		rgbAtr = winpr_BinToHexString((BYTE*) &(rgReaderState->rgbAtr), rgReaderState->cbAtr, FALSE);
-
+		rgbAtr = winpr_BinToHexString((BYTE*) & (rgReaderState->rgbAtr), rgReaderState->cbAtr, FALSE);
 		WLog_DBG(TAG, "\t[%"PRIu32"]: dwCurrentState: %s (0x%08"PRIX32")",
-			index, szCurrentState, rgReaderState->dwCurrentState);
-
+		         index, szCurrentState, rgReaderState->dwCurrentState);
 		WLog_DBG(TAG, "\t[%"PRIu32"]: dwEventState: %s (0x%08"PRIX32")",
-			index, szEventState, rgReaderState->dwEventState);
-
+		         index, szEventState, rgReaderState->dwEventState);
 		WLog_DBG(TAG, "\t[%"PRIu32"]: cbAtr: %"PRIu32" rgbAtr: %s",
-			index, rgReaderState->cbAtr, rgbAtr);
-
+		         index, rgReaderState->cbAtr, rgbAtr);
 		free(szCurrentState);
 		free(szEventState);
 		free(rgbAtr);
@@ -1614,7 +1708,7 @@ LONG smartcard_unpack_state_call(SMARTCARD_DEVICE* smartcard, wStream* s, State_
 	if (Stream_GetRemainingLength(s) < 8)
 	{
 		WLog_WARN(TAG, "State_Call is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -1636,7 +1730,6 @@ LONG smartcard_unpack_state_call(SMARTCARD_DEVICE* smartcard, wStream* s, State_
 LONG smartcard_pack_state_return(SMARTCARD_DEVICE* smartcard, wStream* s, State_Return* ret)
 {
 	LONG status;
-
 	Stream_Write_UINT32(s, ret->dwState); /* dwState (4 bytes) */
 	Stream_Write_UINT32(s, ret->dwProtocol); /* dwProtocol (4 bytes) */
 	Stream_Write_UINT32(s, ret->cbAtrLen); /* cbAtrLen (4 bytes) */
@@ -1669,7 +1762,7 @@ LONG smartcard_unpack_status_call(SMARTCARD_DEVICE* smartcard, wStream* s, Statu
 	if (Stream_GetRemainingLength(s) < 12)
 	{
 		WLog_WARN(TAG, "Status_Call is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -1697,42 +1790,43 @@ void smartcard_trace_status_call(SMARTCARD_DEVICE* smartcard, Status_Call* call,
 		return;
 
 	WLog_DBG(TAG, "Status%s_Call {", unicode ? "W" : "A");
-
-	pb = (BYTE*) &(call->hContext.pbContext);
+	pb = (BYTE*) & (call->hContext.pbContext);
 
 	if (call->hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
+		         pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
 	}
 
-	pb = (BYTE*) &(call->hCard.pbHandle);
+	pb = (BYTE*) & (call->hCard.pbHandle);
 
 	if (call->hCard.cbHandle > 4)
 	{
-		WLog_DBG(TAG, "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hCard.cbHandle);
+		WLog_DBG(TAG,
+		         "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hCard.cbHandle);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hCard.cbHandle);
+		         pb[0], pb[1], pb[2], pb[3], call->hCard.cbHandle);
 	}
 
 	WLog_DBG(TAG, "fmszReaderNamesIsNULL: %"PRId32" cchReaderLen: %"PRIu32" cbAtrLen: %"PRIu32"",
-		call->fmszReaderNamesIsNULL, call->cchReaderLen, call->cbAtrLen);
-
+	         call->fmszReaderNamesIsNULL, call->cchReaderLen, call->cbAtrLen);
 	WLog_DBG(TAG, "}");
 }
 
 LONG smartcard_pack_status_return(SMARTCARD_DEVICE* smartcard, wStream* s, Status_Return* ret)
 {
 	LONG status;
+
 	if (!Stream_EnsureRemainingCapacity(s, ret->cBytes + 64))
 	{
 		WLog_ERR(TAG, "Stream_EnsureRemainingCapacity failed!");
@@ -1745,14 +1839,13 @@ LONG smartcard_pack_status_return(SMARTCARD_DEVICE* smartcard, wStream* s, Statu
 	Stream_Write_UINT32(s, ret->dwProtocol); /* dwProtocol (4 bytes) */
 	Stream_Write(s, ret->pbAtr, 32); /* pbAtr (32 bytes) */
 	Stream_Write_UINT32(s, ret->cbAtrLen); /* cbAtrLen (4 bytes) */
-
 	Stream_Write_UINT32(s, ret->cBytes); /* mszReaderNamesNdrLen (4 bytes) */
-	
+
 	if (ret->mszReaderNames)
 		Stream_Write(s, ret->mszReaderNames, ret->cBytes);
 	else
 		Stream_Zero(s, ret->cBytes);
-	
+
 	if ((status = smartcard_pack_write_size_align(smartcard, s, ret->cBytes, 4)))
 		WLog_ERR(TAG, "smartcard_pack_write_size_align failed with error %"PRId32"", status);
 
@@ -1772,8 +1865,9 @@ void smartcard_trace_status_return(SMARTCARD_DEVICE* smartcard, Status_Return* r
 	if (unicode)
 	{
 		length = ret->cBytes / 2;
+
 		if (ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) ret->mszReaderNames, (int)length,
-			&mszReaderNamesA, 0, NULL, NULL) < 1)
+		                       &mszReaderNamesA, 0, NULL, NULL) < 1)
 		{
 			WLog_ERR(TAG, "ConvertFromUnicode failed");
 			return;
@@ -1783,11 +1877,13 @@ void smartcard_trace_status_return(SMARTCARD_DEVICE* smartcard, Status_Return* r
 	{
 		length = (int) ret->cBytes;
 		mszReaderNamesA = (char*) malloc(length);
+
 		if (!mszReaderNamesA)
 		{
 			WLog_ERR(TAG, "malloc failed!");
 			return;
 		}
+
 		CopyMemory(mszReaderNamesA, ret->mszReaderNames, ret->cBytes);
 	}
 
@@ -1804,26 +1900,21 @@ void smartcard_trace_status_return(SMARTCARD_DEVICE* smartcard, Status_Return* r
 	}
 
 	pbAtr = winpr_BinToHexString(ret->pbAtr, ret->cbAtrLen, FALSE);
-
 	WLog_DBG(TAG, "Status%s_Return {", unicode ? "W" : "A");
-
 	WLog_DBG(TAG, "ReturnCode: %s (0x%08"PRIX32")",
-		SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
-
+	         SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
 	WLog_DBG(TAG, "dwState: %s (0x%08"PRIX32") dwProtocol: %s (0x%08"PRIX32")",
-		SCardGetCardStateString(ret->dwState), ret->dwState,
-		SCardGetProtocolString(ret->dwProtocol), ret->dwProtocol);
+	         SCardGetCardStateString(ret->dwState), ret->dwState,
+	         SCardGetProtocolString(ret->dwProtocol), ret->dwProtocol);
 
 	if (mszReaderNamesA)
 	{
 		WLog_DBG(TAG, "cBytes: %"PRIu32" mszReaderNames: %s",
-			ret->cBytes, mszReaderNamesA);
+		         ret->cBytes, mszReaderNamesA);
 	}
 
 	WLog_DBG(TAG, "cbAtrLen: %"PRIu32" pbAtr: %s", ret->cbAtrLen, pbAtr);
-
 	WLog_DBG(TAG, "}");
-
 	free(mszReaderNamesA);
 	free(pbAtr);
 }
@@ -1847,7 +1938,7 @@ LONG smartcard_unpack_get_attrib_call(SMARTCARD_DEVICE* smartcard, wStream* s, G
 	if (Stream_GetRemainingLength(s) < 12)
 	{
 		WLog_WARN(TAG, "GetAttrib_Call is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -1875,42 +1966,44 @@ void smartcard_trace_get_attrib_call(SMARTCARD_DEVICE* smartcard, GetAttrib_Call
 		return;
 
 	WLog_DBG(TAG, "GetAttrib_Call {");
-
-	pb = (BYTE*) &(call->hContext.pbContext);
+	pb = (BYTE*) & (call->hContext.pbContext);
 
 	if (call->hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
+		         pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
 	}
 
-	pb = (BYTE*) &(call->hCard.pbHandle);
+	pb = (BYTE*) & (call->hCard.pbHandle);
 
 	if (call->hCard.cbHandle > 4)
 	{
-		WLog_DBG(TAG, "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hCard.cbHandle);
+		WLog_DBG(TAG,
+		         "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hCard.cbHandle);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hCard.cbHandle);
+		         pb[0], pb[1], pb[2], pb[3], call->hCard.cbHandle);
 	}
 
 	WLog_DBG(TAG, "dwAttrId: %s (0x%08"PRIX32") fpbAttrIsNULL: %"PRId32" cbAttrLen: 0x%08"PRIX32"",
-		SCardGetAttributeString(call->dwAttrId), call->dwAttrId, call->fpbAttrIsNULL, call->cbAttrLen);
-
+	         SCardGetAttributeString(call->dwAttrId), call->dwAttrId, call->fpbAttrIsNULL, call->cbAttrLen);
 	WLog_DBG(TAG, "}");
 }
 
-LONG smartcard_pack_get_attrib_return(SMARTCARD_DEVICE* smartcard, wStream* s, GetAttrib_Return* ret)
+LONG smartcard_pack_get_attrib_return(SMARTCARD_DEVICE* smartcard, wStream* s,
+                                      GetAttrib_Return* ret)
 {
 	LONG status;
+
 	if (!Stream_EnsureRemainingCapacity(s, ret->cbAttrLen + 32))
 	{
 		WLog_ERR(TAG, "Stream_EnsureRemainingCapacity failed!");
@@ -1932,18 +2025,17 @@ LONG smartcard_pack_get_attrib_return(SMARTCARD_DEVICE* smartcard, wStream* s, G
 	return status;
 }
 
-void smartcard_trace_get_attrib_return(SMARTCARD_DEVICE* smartcard, GetAttrib_Return* ret, DWORD dwAttrId)
+void smartcard_trace_get_attrib_return(SMARTCARD_DEVICE* smartcard, GetAttrib_Return* ret,
+                                       DWORD dwAttrId)
 {
 	if (!WLog_IsLevelActive(WLog_Get(TAG), WLOG_DEBUG))
 		return;
 
 	WLog_DBG(TAG, "GetAttrib_Return {");
-
 	WLog_DBG(TAG, "ReturnCode: %s (0x%08"PRIX32")",
-		SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
-
+	         SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
 	WLog_DBG(TAG, "dwAttrId: %s (0x%08"PRIX32") cbAttrLen: 0x%08"PRIX32"",
-		SCardGetAttributeString(dwAttrId), dwAttrId, ret->cbAttrLen);
+	         SCardGetAttributeString(dwAttrId), dwAttrId, ret->cbAttrLen);
 
 	if (dwAttrId == SCARD_ATTR_VENDOR_NAME)
 	{
@@ -1953,7 +2045,7 @@ void smartcard_trace_get_attrib_return(SMARTCARD_DEVICE* smartcard, GetAttrib_Re
 	{
 		UINT32 dwProtocolType = *((UINT32*) ret->pbAttr);
 		WLog_DBG(TAG, "dwProtocolType: %s (0x%08"PRIX32")",
-				SCardGetProtocolString(dwProtocolType), dwProtocolType);
+		         SCardGetProtocolString(dwProtocolType), dwProtocolType);
 	}
 
 	WLog_DBG(TAG, "}");
@@ -1963,7 +2055,6 @@ LONG smartcard_unpack_control_call(SMARTCARD_DEVICE* smartcard, wStream* s, Cont
 {
 	LONG status;
 	UINT32 length;
-
 	call->pvInBuffer = NULL;
 
 	if ((status = smartcard_unpack_redir_scard_context(smartcard, s, &(call->hContext))))
@@ -1981,7 +2072,7 @@ LONG smartcard_unpack_control_call(SMARTCARD_DEVICE* smartcard, wStream* s, Cont
 	if (Stream_GetRemainingLength(s) < 20)
 	{
 		WLog_WARN(TAG, "Control_Call is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -2008,7 +2099,7 @@ LONG smartcard_unpack_control_call(SMARTCARD_DEVICE* smartcard, wStream* s, Cont
 		if (Stream_GetRemainingLength(s) < 4)
 		{
 			WLog_WARN(TAG, "Control_Call is too short: %"PRIuz"",
-					Stream_GetRemainingLength(s));
+			          Stream_GetRemainingLength(s));
 			return STATUS_BUFFER_TOO_SMALL;
 		}
 
@@ -2017,7 +2108,7 @@ LONG smartcard_unpack_control_call(SMARTCARD_DEVICE* smartcard, wStream* s, Cont
 		if (Stream_GetRemainingLength(s) < length)
 		{
 			WLog_WARN(TAG, "Control_Call is too short: %"PRIuz"",
-					Stream_GetRemainingLength(s));
+			          Stream_GetRemainingLength(s));
 			return STATUS_BUFFER_TOO_SMALL;
 		}
 
@@ -2030,7 +2121,6 @@ LONG smartcard_unpack_control_call(SMARTCARD_DEVICE* smartcard, wStream* s, Cont
 		}
 
 		call->cbInBufferSize = length;
-
 		Stream_Read(s, call->pvInBuffer, length);
 	}
 
@@ -2045,35 +2135,37 @@ void smartcard_trace_control_call(SMARTCARD_DEVICE* smartcard, Control_Call* cal
 		return;
 
 	WLog_DBG(TAG, "Control_Call {");
-
-	pb = (BYTE*) &(call->hContext.pbContext);
+	pb = (BYTE*) & (call->hContext.pbContext);
 
 	if (call->hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
+		         pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
 	}
 
-	pb = (BYTE*) &(call->hCard.pbHandle);
+	pb = (BYTE*) & (call->hCard.pbHandle);
 
 	if (call->hCard.cbHandle > 4)
 	{
-		WLog_DBG(TAG, "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hCard.cbHandle);
+		WLog_DBG(TAG,
+		         "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hCard.cbHandle);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hCard.cbHandle);
+		         pb[0], pb[1], pb[2], pb[3], call->hCard.cbHandle);
 	}
 
-	WLog_DBG(TAG, "dwControlCode: 0x%08"PRIX32" cbInBufferSize: %"PRIu32" fpvOutBufferIsNULL: %"PRId32" cbOutBufferSize: %"PRIu32"",
-		call->dwControlCode, call->cbInBufferSize, call->fpvOutBufferIsNULL, call->cbOutBufferSize);
+	WLog_DBG(TAG,
+	         "dwControlCode: 0x%08"PRIX32" cbInBufferSize: %"PRIu32" fpvOutBufferIsNULL: %"PRId32" cbOutBufferSize: %"PRIu32"",
+	         call->dwControlCode, call->cbInBufferSize, call->fpvOutBufferIsNULL, call->cbOutBufferSize);
 
 	if (call->pvInBuffer)
 	{
@@ -2092,6 +2184,7 @@ void smartcard_trace_control_call(SMARTCARD_DEVICE* smartcard, Control_Call* cal
 LONG smartcard_pack_control_return(SMARTCARD_DEVICE* smartcard, wStream* s, Control_Return* ret)
 {
 	LONG error;
+
 	if (!Stream_EnsureRemainingCapacity(s, ret->cbOutBufferSize + 32))
 	{
 		WLog_ERR(TAG, "Stream_EnsureRemainingCapacity failed!");
@@ -2105,6 +2198,7 @@ LONG smartcard_pack_control_return(SMARTCARD_DEVICE* smartcard, wStream* s, Cont
 	if (ret->cbOutBufferSize > 0)
 	{
 		Stream_Write(s, ret->pvOutBuffer, ret->cbOutBufferSize); /* pvOutBuffer */
+
 		if ((error = smartcard_pack_write_size_align(smartcard, s, ret->cbOutBufferSize, 4)))
 		{
 			WLog_ERR(TAG, "smartcard_pack_write_size_align failed with error %"PRId32"", error);
@@ -2121,10 +2215,8 @@ void smartcard_trace_control_return(SMARTCARD_DEVICE* smartcard, Control_Return*
 		return;
 
 	WLog_DBG(TAG, "Control_Return {");
-
 	WLog_DBG(TAG, "ReturnCode: %s (0x%08"PRIX32")",
-		SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
-
+	         SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
 	WLog_DBG(TAG, "cbOutBufferSize: %"PRIu32"", ret->cbOutBufferSize);
 
 	if (ret->pvOutBuffer)
@@ -2151,7 +2243,6 @@ LONG smartcard_unpack_transmit_call(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 	UINT32 pioRecvPciNdrPtr;
 	SCardIO_Request ioSendPci;
 	SCardIO_Request ioRecvPci;
-
 	call->pioSendPci = NULL;
 	call->pioRecvPci = NULL;
 	call->pbSendBuffer = NULL;
@@ -2171,7 +2262,7 @@ LONG smartcard_unpack_transmit_call(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 	if (Stream_GetRemainingLength(s) < 32)
 	{
 		WLog_WARN(TAG, "Transmit_Call is too short: Actual: %"PRIuz", Expected: 32",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -2187,14 +2278,14 @@ LONG smartcard_unpack_transmit_call(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 	if (ioSendPci.cbExtraBytes > 1024)
 	{
 		WLog_WARN(TAG, "Transmit_Call ioSendPci.cbExtraBytes is out of bounds: %"PRIu32" (max: 1024)",
-				ioSendPci.cbExtraBytes);
+		          ioSendPci.cbExtraBytes);
 		return STATUS_INVALID_PARAMETER;
 	}
 
 	if (call->cbSendLength > 66560)
 	{
 		WLog_WARN(TAG, "Transmit_Call cbSendLength is out of bounds: %"PRIu32" (max: 66560)",
-				ioSendPci.cbExtraBytes);
+		          ioSendPci.cbExtraBytes);
 		return STATUS_INVALID_PARAMETER;
 	}
 
@@ -2221,7 +2312,7 @@ LONG smartcard_unpack_transmit_call(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 		if (Stream_GetRemainingLength(s) < 4)
 		{
 			WLog_WARN(TAG, "Transmit_Call is too short: %"PRIuz" (ioSendPci.pbExtraBytes)",
-					Stream_GetRemainingLength(s));
+			          Stream_GetRemainingLength(s));
 			return STATUS_BUFFER_TOO_SMALL;
 		}
 
@@ -2229,13 +2320,13 @@ LONG smartcard_unpack_transmit_call(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 
 		if (Stream_GetRemainingLength(s) < ioSendPci.cbExtraBytes)
 		{
-			WLog_WARN(TAG, "Transmit_Call is too short: Actual: %"PRIuz", Expected: %"PRIu32" (ioSendPci.cbExtraBytes)",
-					Stream_GetRemainingLength(s), ioSendPci.cbExtraBytes);
+			WLog_WARN(TAG,
+			          "Transmit_Call is too short: Actual: %"PRIuz", Expected: %"PRIu32" (ioSendPci.cbExtraBytes)",
+			          Stream_GetRemainingLength(s), ioSendPci.cbExtraBytes);
 			return STATUS_BUFFER_TOO_SMALL;
 		}
 
 		ioSendPci.pbExtraBytes = Stream_Pointer(s);
-
 		call->pioSendPci = (LPSCARD_IO_REQUEST) malloc(sizeof(SCARD_IO_REQUEST) + ioSendPci.cbExtraBytes);
 
 		if (!call->pioSendPci)
@@ -2246,10 +2337,8 @@ LONG smartcard_unpack_transmit_call(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 
 		call->pioSendPci->dwProtocol = ioSendPci.dwProtocol;
 		call->pioSendPci->cbPciLength = (DWORD)(ioSendPci.cbExtraBytes + sizeof(SCARD_IO_REQUEST));
-
 		pbExtraBytes = &((BYTE*) call->pioSendPci)[sizeof(SCARD_IO_REQUEST)];
 		Stream_Read(s, pbExtraBytes, ioSendPci.cbExtraBytes);
-
 		smartcard_unpack_read_size_align(smartcard, s, ioSendPci.cbExtraBytes, 4);
 	}
 	else
@@ -2271,7 +2360,7 @@ LONG smartcard_unpack_transmit_call(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 		if (Stream_GetRemainingLength(s) < 4)
 		{
 			WLog_WARN(TAG, "Transmit_Call is too short: %"PRIuz"",
-					Stream_GetRemainingLength(s));
+			          Stream_GetRemainingLength(s));
 			return STATUS_BUFFER_TOO_SMALL;
 		}
 
@@ -2279,15 +2368,16 @@ LONG smartcard_unpack_transmit_call(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 
 		if (length != call->cbSendLength)
 		{
-			WLog_WARN(TAG, "Transmit_Call unexpected length: Actual: %"PRIu32", Expected: %"PRIu32" (cbSendLength)",
-					length, call->cbSendLength);
+			WLog_WARN(TAG,
+			          "Transmit_Call unexpected length: Actual: %"PRIu32", Expected: %"PRIu32" (cbSendLength)",
+			          length, call->cbSendLength);
 			return STATUS_INVALID_PARAMETER;
 		}
 
 		if (Stream_GetRemainingLength(s) < call->cbSendLength)
 		{
 			WLog_WARN(TAG, "Transmit_Call is too short: Actual: %"PRIuz", Expected: %"PRIu32" (cbSendLength)",
-					Stream_GetRemainingLength(s), call->cbSendLength);
+			          Stream_GetRemainingLength(s), call->cbSendLength);
 			return STATUS_BUFFER_TOO_SMALL;
 		}
 
@@ -2300,7 +2390,6 @@ LONG smartcard_unpack_transmit_call(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 		}
 
 		Stream_Read(s, call->pbSendBuffer, call->cbSendLength);
-
 		smartcard_unpack_read_size_align(smartcard, s, call->cbSendLength, 4);
 	}
 
@@ -2309,7 +2398,7 @@ LONG smartcard_unpack_transmit_call(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 		if (Stream_GetRemainingLength(s) < 12)
 		{
 			WLog_WARN(TAG, "Transmit_Call is too short: Actual: %"PRIuz", Expected: 12",
-					Stream_GetRemainingLength(s));
+			          Stream_GetRemainingLength(s));
 			return STATUS_BUFFER_TOO_SMALL;
 		}
 
@@ -2328,7 +2417,7 @@ LONG smartcard_unpack_transmit_call(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 			if (Stream_GetRemainingLength(s) < 4)
 			{
 				WLog_WARN(TAG, "Transmit_Call is too short: %"PRIuz" (ioRecvPci.pbExtraBytes)",
-						Stream_GetRemainingLength(s));
+				          Stream_GetRemainingLength(s));
 				return STATUS_BUFFER_TOO_SMALL;
 			}
 
@@ -2337,26 +2426,27 @@ LONG smartcard_unpack_transmit_call(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 			if (ioRecvPci.cbExtraBytes > 1024)
 			{
 				WLog_WARN(TAG, "Transmit_Call ioRecvPci.cbExtraBytes is out of bounds: %"PRIu32" (max: 1024)",
-						ioRecvPci.cbExtraBytes);
+				          ioRecvPci.cbExtraBytes);
 				return STATUS_INVALID_PARAMETER;
 			}
 
 			if (length != ioRecvPci.cbExtraBytes)
 			{
-				WLog_WARN(TAG, "Transmit_Call unexpected length: Actual: %"PRIu32", Expected: %"PRIu32" (ioRecvPci.cbExtraBytes)",
-						length, ioRecvPci.cbExtraBytes);
+				WLog_WARN(TAG,
+				          "Transmit_Call unexpected length: Actual: %"PRIu32", Expected: %"PRIu32" (ioRecvPci.cbExtraBytes)",
+				          length, ioRecvPci.cbExtraBytes);
 				return STATUS_INVALID_PARAMETER;
 			}
 
 			if (Stream_GetRemainingLength(s) < ioRecvPci.cbExtraBytes)
 			{
-				WLog_WARN(TAG, "Transmit_Call is too short: Actual: %"PRIuz", Expected: %"PRIu32" (ioRecvPci.cbExtraBytes)",
-						Stream_GetRemainingLength(s), ioRecvPci.cbExtraBytes);
+				WLog_WARN(TAG,
+				          "Transmit_Call is too short: Actual: %"PRIuz", Expected: %"PRIu32" (ioRecvPci.cbExtraBytes)",
+				          Stream_GetRemainingLength(s), ioRecvPci.cbExtraBytes);
 				return STATUS_BUFFER_TOO_SMALL;
 			}
 
 			ioRecvPci.pbExtraBytes = Stream_Pointer(s);
-
 			call->pioRecvPci = (LPSCARD_IO_REQUEST) malloc(sizeof(SCARD_IO_REQUEST) + ioRecvPci.cbExtraBytes);
 
 			if (!call->pioRecvPci)
@@ -2367,10 +2457,8 @@ LONG smartcard_unpack_transmit_call(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 
 			call->pioRecvPci->dwProtocol = ioRecvPci.dwProtocol;
 			call->pioRecvPci->cbPciLength = (DWORD)(ioRecvPci.cbExtraBytes + sizeof(SCARD_IO_REQUEST));
-
 			pbExtraBytes = &((BYTE*) call->pioRecvPci)[sizeof(SCARD_IO_REQUEST)];
 			Stream_Read(s, pbExtraBytes, ioRecvPci.cbExtraBytes);
-
 			smartcard_unpack_read_size_align(smartcard, s, ioRecvPci.cbExtraBytes, 4);
 		}
 		else
@@ -2401,40 +2489,40 @@ void smartcard_trace_transmit_call(SMARTCARD_DEVICE* smartcard, Transmit_Call* c
 		return;
 
 	WLog_DBG(TAG, "Transmit_Call {");
-
-	pb = (BYTE*) &(call->hContext.pbContext);
+	pb = (BYTE*) & (call->hContext.pbContext);
 
 	if (call->hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
+		         pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
 	}
 
-	pb = (BYTE*) &(call->hCard.pbHandle);
+	pb = (BYTE*) & (call->hCard.pbHandle);
 
 	if (call->hCard.cbHandle > 4)
 	{
-		WLog_DBG(TAG, "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hCard.cbHandle);
+		WLog_DBG(TAG,
+		         "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hCard.cbHandle);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hCard: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hCard.cbHandle);
+		         pb[0], pb[1], pb[2], pb[3], call->hCard.cbHandle);
 	}
 
 	if (call->pioSendPci)
 	{
 		cbExtraBytes = (UINT32)(call->pioSendPci->cbPciLength - sizeof(SCARD_IO_REQUEST));
 		pbExtraBytes = &((BYTE*) call->pioSendPci)[sizeof(SCARD_IO_REQUEST)];
-
 		WLog_DBG(TAG, "pioSendPci: dwProtocol: %"PRIu32" cbExtraBytes: %"PRIu32"",
-				call->pioSendPci->dwProtocol, cbExtraBytes);
+		         call->pioSendPci->dwProtocol, cbExtraBytes);
 
 		if (cbExtraBytes)
 		{
@@ -2465,9 +2553,8 @@ void smartcard_trace_transmit_call(SMARTCARD_DEVICE* smartcard, Transmit_Call* c
 	{
 		cbExtraBytes = (UINT32)(call->pioRecvPci->cbPciLength - sizeof(SCARD_IO_REQUEST));
 		pbExtraBytes = &((BYTE*) call->pioRecvPci)[sizeof(SCARD_IO_REQUEST)];
-
 		WLog_DBG(TAG, "pioRecvPci: dwProtocol: %"PRIu32" cbExtraBytes: %"PRIu32"",
-				call->pioRecvPci->dwProtocol, cbExtraBytes);
+		         call->pioRecvPci->dwProtocol, cbExtraBytes);
 
 		if (cbExtraBytes)
 		{
@@ -2482,8 +2569,7 @@ void smartcard_trace_transmit_call(SMARTCARD_DEVICE* smartcard, Transmit_Call* c
 	}
 
 	WLog_DBG(TAG, "fpbRecvBufferIsNULL: %"PRId32" cbRecvLength: %"PRIu32"",
-			call->fpbRecvBufferIsNULL, call->cbRecvLength);
-
+	         call->fpbRecvBufferIsNULL, call->cbRecvLength);
 	WLog_DBG(TAG, "}");
 }
 
@@ -2501,7 +2587,6 @@ LONG smartcard_pack_transmit_return(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 
 	pioRecvPciNdrPtr = (ret->pioRecvPci) ? 0x00020000 : 0;
 	pbRecvBufferNdrPtr = (ret->pbRecvBuffer) ? 0x00020004 : 0;
-
 	Stream_Write_UINT32(s, pioRecvPciNdrPtr); /* pioRecvPciNdrPtr (4 bytes) */
 	Stream_Write_UINT32(s, ret->cbRecvLength); /* cbRecvLength (4 bytes) */
 	Stream_Write_UINT32(s, pbRecvBufferNdrPtr); /* pbRecvBufferNdrPtr (4 bytes) */
@@ -2526,6 +2611,7 @@ LONG smartcard_pack_transmit_return(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 		{
 			Stream_Write_UINT32(s, cbExtraBytes); /* Length (4 bytes) */
 			Stream_Write(s, pbExtraBytes, cbExtraBytes);
+
 			if ((error = smartcard_pack_write_size_align(smartcard, s, cbExtraBytes, 4)))
 			{
 				WLog_ERR(TAG, "smartcard_pack_write_size_align failed with error %"PRId32"!", error);
@@ -2544,6 +2630,7 @@ LONG smartcard_pack_transmit_return(SMARTCARD_DEVICE* smartcard, wStream* s, Tra
 
 		Stream_Write_UINT32(s, ret->cbRecvLength); /* pbRecvBufferNdrLen (4 bytes) */
 		Stream_Write(s, ret->pbRecvBuffer, ret->cbRecvLength);
+
 		if ((error = smartcard_pack_write_size_align(smartcard, s, ret->cbRecvLength, 4)))
 		{
 			WLog_ERR(TAG, "smartcard_pack_write_size_align failed with error %"PRId32"!", error);
@@ -2563,17 +2650,15 @@ void smartcard_trace_transmit_return(SMARTCARD_DEVICE* smartcard, Transmit_Retur
 		return;
 
 	WLog_DBG(TAG, "Transmit_Return {");
-
 	WLog_DBG(TAG, "ReturnCode: %s (0x%08"PRIX32")",
-		SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
+	         SCardGetErrorString(ret->ReturnCode), ret->ReturnCode);
 
 	if (ret->pioRecvPci)
 	{
 		cbExtraBytes = (UINT32)(ret->pioRecvPci->cbPciLength - sizeof(SCARD_IO_REQUEST));
 		pbExtraBytes = &((BYTE*) ret->pioRecvPci)[sizeof(SCARD_IO_REQUEST)];
-
 		WLog_DBG(TAG, "pioRecvPci: dwProtocol: %"PRIu32" cbExtraBytes: %"PRIu32"",
-				ret->pioRecvPci->dwProtocol, cbExtraBytes);
+		         ret->pioRecvPci->dwProtocol, cbExtraBytes);
 
 		if (cbExtraBytes)
 		{
@@ -2603,7 +2688,8 @@ void smartcard_trace_transmit_return(SMARTCARD_DEVICE* smartcard, Transmit_Retur
 	WLog_DBG(TAG, "}");
 }
 
-LONG smartcard_unpack_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, wStream* s, LocateCardsByATRA_Call* call)
+LONG smartcard_unpack_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, wStream* s,
+        LocateCardsByATRA_Call* call)
 {
 	UINT32 index;
 	UINT32 count;
@@ -2614,7 +2700,6 @@ LONG smartcard_unpack_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, wS
 	UINT32 rgReaderStatesNdrPtr;
 	UINT32 rgAtrMasksNdrPtr;
 	LPSCARD_READERSTATEA readerState;
-
 	call->rgReaderStates = NULL;
 
 	if ((status = smartcard_unpack_redir_scard_context(smartcard, s, &(call->hContext))))
@@ -2626,7 +2711,7 @@ LONG smartcard_unpack_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, wS
 	if (Stream_GetRemainingLength(s) < 16)
 	{
 		WLog_WARN(TAG, "LocateCardsByATRA_Call is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
@@ -2644,14 +2729,15 @@ LONG smartcard_unpack_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, wS
 	if (Stream_GetRemainingLength(s) < 4)
 	{
 		WLog_WARN(TAG, "LocateCardsByATRA_Call is too short: %"PRIuz"",
-				Stream_GetRemainingLength(s));
+		          Stream_GetRemainingLength(s));
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
 	if ((rgAtrMasksNdrPtr && !call->cAtrs) || (!rgAtrMasksNdrPtr && call->cAtrs))
 	{
-		WLog_WARN(TAG, "LocateCardsByATRA_Call rgAtrMasksNdrPtr (0x%08"PRIX32") and cAtrs (0x%08"PRIX32") inconsistency",
-				rgAtrMasksNdrPtr, call->cAtrs);
+		WLog_WARN(TAG,
+		          "LocateCardsByATRA_Call rgAtrMasksNdrPtr (0x%08"PRIX32") and cAtrs (0x%08"PRIX32") inconsistency",
+		          rgAtrMasksNdrPtr, call->cAtrs);
 		return STATUS_INVALID_PARAMETER;
 	}
 
@@ -2661,19 +2747,21 @@ LONG smartcard_unpack_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, wS
 
 		if (count != call->cAtrs)
 		{
-			WLog_WARN(TAG, "LocateCardsByATRA_Call NdrCount (0x%08"PRIX32") and cAtrs (0x%08"PRIX32") inconsistency",
-					count, call->cAtrs);
+			WLog_WARN(TAG,
+			          "LocateCardsByATRA_Call NdrCount (0x%08"PRIX32") and cAtrs (0x%08"PRIX32") inconsistency",
+			          count, call->cAtrs);
 			return STATUS_INVALID_PARAMETER;
 		}
 
 		if (Stream_GetRemainingLength(s) < call->cAtrs)
 		{
 			WLog_WARN(TAG, "LocateCardsByATRA_Call is too short: Actual: %"PRIuz", Expected: %"PRIu32"",
-					Stream_GetRemainingLength(s), call->cAtrs);
+			          Stream_GetRemainingLength(s), call->cAtrs);
 			return STATUS_BUFFER_TOO_SMALL;
 		}
 
 		call->rgAtrMasks = calloc(call->cAtrs, sizeof(SCARD_ATRMASK));
+
 		if (!call->rgAtrMasks)
 		{
 			WLog_WARN(TAG, "LocateCardsByATRA_Call out of memory error (call->rgAtrMasks)");
@@ -2692,8 +2780,9 @@ LONG smartcard_unpack_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, wS
 
 	if (count != call->cReaders)
 	{
-		WLog_WARN(TAG, "GetStatusChangeA_Call unexpected reader count: Actual: %"PRIu32", Expected: %"PRIu32"",
-				count, call->cReaders);
+		WLog_WARN(TAG,
+		          "GetStatusChangeA_Call unexpected reader count: Actual: %"PRIu32", Expected: %"PRIu32"",
+		          count, call->cReaders);
 		return STATUS_INVALID_PARAMETER;
 	}
 
@@ -2714,7 +2803,7 @@ LONG smartcard_unpack_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, wS
 			if (Stream_GetRemainingLength(s) < 52)
 			{
 				WLog_WARN(TAG, "LocateCardsByATRA_Call is too short: %"PRIuz"",
-						Stream_GetRemainingLength(s));
+				          Stream_GetRemainingLength(s));
 				return STATUS_BUFFER_TOO_SMALL;
 			}
 
@@ -2733,7 +2822,7 @@ LONG smartcard_unpack_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, wS
 			if (Stream_GetRemainingLength(s) < 12)
 			{
 				WLog_WARN(TAG, "GetStatusChangeA_Call is too short: %"PRIuz"",
-						Stream_GetRemainingLength(s));
+				          Stream_GetRemainingLength(s));
 				return STATUS_BUFFER_TOO_SMALL;
 			}
 
@@ -2744,7 +2833,7 @@ LONG smartcard_unpack_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, wS
 			if (Stream_GetRemainingLength(s) < count)
 			{
 				WLog_WARN(TAG, "GetStatusChangeA_Call is too short: %"PRIuz"",
-						Stream_GetRemainingLength(s));
+				          Stream_GetRemainingLength(s));
 				return STATUS_BUFFER_TOO_SMALL;
 			}
 
@@ -2771,7 +2860,8 @@ LONG smartcard_unpack_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, wS
 	return SCARD_S_SUCCESS;
 }
 
-void smartcard_trace_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, LocateCardsByATRA_Call* call)
+void smartcard_trace_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard,
+        LocateCardsByATRA_Call* call)
 {
 	BYTE* pb;
 	UINT32 index;
@@ -2784,51 +2874,48 @@ void smartcard_trace_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, Loc
 		return;
 
 	WLog_DBG(TAG, "LocateCardsByATRA_Call {");
-
-	pb = (BYTE*) &(call->hContext.pbContext);
+	pb = (BYTE*) & (call->hContext.pbContext);
 
 	if (call->hContext.cbContext > 4)
 	{
-		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
+		WLog_DBG(TAG,
+		         "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
+		         pb[0], pb[1], pb[2], pb[3], pb[4], pb[5], pb[6], pb[7], call->hContext.cbContext);
 	}
 	else
 	{
 		WLog_DBG(TAG, "hContext: 0x%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8" (%"PRIu32")",
-			pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
+		         pb[0], pb[1], pb[2], pb[3], call->hContext.cbContext);
 	}
 
 	for (index = 0; index < call->cReaders; index++)
 	{
 		readerState = (LPSCARD_READERSTATEA) &call->rgReaderStates[index];
-
 		WLog_DBG(TAG, "\t[%"PRIu32"]: szReader: %s cbAtr: %"PRIu32"",
-			index, readerState->szReader, readerState->cbAtr);
-
+		         index, readerState->szReader, readerState->cbAtr);
 		szCurrentState = SCardGetReaderStateString(readerState->dwCurrentState);
 		szEventState = SCardGetReaderStateString(readerState->dwEventState);
-		rgbAtr = winpr_BinToHexString((BYTE*) &(readerState->rgbAtr), readerState->cbAtr, FALSE);
-
+		rgbAtr = winpr_BinToHexString((BYTE*) & (readerState->rgbAtr), readerState->cbAtr, FALSE);
 		WLog_DBG(TAG, "\t[%"PRIu32"]: dwCurrentState: %s (0x%08"PRIX32")",
-			index, szCurrentState, readerState->dwCurrentState);
-
+		         index, szCurrentState, readerState->dwCurrentState);
 		WLog_DBG(TAG, "\t[%"PRIu32"]: dwEventState: %s (0x%08"PRIX32")",
-			index, szEventState, readerState->dwEventState);
+		         index, szEventState, readerState->dwEventState);
 
 		if (rgbAtr)
 		{
 			WLog_DBG(TAG, "\t[%"PRIu32"]: cbAtr: %"PRIu32" rgbAtr: %s",
-				index, readerState->cbAtr, rgbAtr);
+			         index, readerState->cbAtr, rgbAtr);
 		}
 		else
 		{
 			WLog_DBG(TAG, "\t[%"PRIu32"]: cbAtr: 0 rgbAtr: n/a",
-				index);
+			         index);
 		}
 
 		free(szCurrentState);
 		free(szEventState);
 		free(rgbAtr);
 	}
+
 	WLog_DBG(TAG, "}");
 }

--- a/channels/smartcard/client/smartcard_pack.h
+++ b/channels/smartcard/client/smartcard_pack.h
@@ -55,7 +55,7 @@ typedef struct _longAndMultiString_Return
 {
 	LONG ReturnCode;
 	/* [range] */ DWORD cBytes;
-	/* [size_is][unique] */ BYTE *msz;
+	/* [size_is][unique] */ BYTE* msz;
 } ListReaderGroups_Return;
 
 typedef struct _longAndMultiString_Return ListReaders_Return;
@@ -68,27 +68,27 @@ typedef struct _Context_Call
 typedef struct _ContextAndStringA_Call
 {
 	REDIR_SCARDCONTEXT hContext;
-	/* [string] */ unsigned char *sz;
+	/* [string] */ unsigned char* sz;
 } ContextAndStringA_Call;
 
 typedef struct _ContextAndStringW_Call
 {
 	REDIR_SCARDCONTEXT hContext;
-	/* [string] */ WCHAR *sz;
+	/* [string] */ WCHAR* sz;
 } ContextAndStringW_Call;
 
 typedef struct _ContextAndTwoStringA_Call
 {
 	REDIR_SCARDCONTEXT hContext;
-	/* [string] */ unsigned char *sz1;
-	/* [string] */ unsigned char *sz2;
+	/* [string] */ unsigned char* sz1;
+	/* [string] */ unsigned char* sz2;
 } ContextAndTwoStringA_Call;
 
 typedef struct _ContextAndTwoStringW_Call
 {
 	REDIR_SCARDCONTEXT hContext;
-	/* [string] */ WCHAR *sz1;
-	/* [string] */ WCHAR *sz2;
+	/* [string] */ WCHAR* sz1;
+	/* [string] */ WCHAR* sz2;
 } ContextAndTwoStringW_Call;
 
 typedef struct _EstablishContext_Call
@@ -113,7 +113,7 @@ typedef struct _ListReaders_Call
 {
 	REDIR_SCARDCONTEXT hContext;
 	/* [range] */ DWORD cBytes;
-	/* [size_is][unique] */ BYTE *mszGroups;
+	/* [size_is][unique] */ BYTE* mszGroups;
 	LONG fmszReadersIsNULL;
 	DWORD cchReaders;
 } ListReaders_Call;
@@ -128,13 +128,13 @@ typedef struct _ReaderState_Common_Call
 
 typedef struct _ReaderStateA
 {
-	/* [string] */ unsigned char *szReader;
+	/* [string] */ unsigned char* szReader;
 	ReaderState_Common_Call Common;
 } ReaderStateA;
 
 typedef struct _ReaderStateW
 {
-	/* [string] */ WCHAR *szReader;
+	/* [string] */ WCHAR* szReader;
 	ReaderState_Common_Call Common;
 } ReaderStateW;
 
@@ -158,18 +158,18 @@ typedef struct _LocateCardsA_Call
 {
 	REDIR_SCARDCONTEXT hContext;
 	/* [range] */ DWORD cBytes;
-	/* [size_is] */ BYTE *mszCards;
+	/* [size_is] */ BYTE* mszCards;
 	/* [range] */ DWORD cReaders;
-	/* [size_is] */ ReaderStateA *rgReaderStates;
+	/* [size_is] */ ReaderStateA* rgReaderStates;
 } LocateCardsA_Call;
 
 typedef struct _LocateCardsW_Call
 {
 	REDIR_SCARDCONTEXT hContext;
 	/* [range] */ DWORD cBytes;
-	/* [size_is] */ BYTE *mszCards;
+	/* [size_is] */ BYTE* mszCards;
 	/* [range] */ DWORD cReaders;
-	/* [size_is] */ ReaderStateW *rgReaderStates;
+	/* [size_is] */ ReaderStateW* rgReaderStates;
 } LocateCardsW_Call;
 
 typedef struct _LocateCards_ATRMask
@@ -183,25 +183,25 @@ typedef struct _LocateCardsByATRA_Call
 {
 	REDIR_SCARDCONTEXT hContext;
 	/* [range] */ DWORD cAtrs;
-	/* [size_is] */ LocateCards_ATRMask *rgAtrMasks;
+	/* [size_is] */ LocateCards_ATRMask* rgAtrMasks;
 	/* [range] */ DWORD cReaders;
-	/* [size_is] */ ReaderStateA *rgReaderStates;
+	/* [size_is] */ ReaderStateA* rgReaderStates;
 } LocateCardsByATRA_Call;
 
 typedef struct _LocateCardsByATRW_Call
 {
 	REDIR_SCARDCONTEXT hContext;
 	/* [range] */ DWORD cAtrs;
-	/* [size_is] */ LocateCards_ATRMask *rgAtrMasks;
+	/* [size_is] */ LocateCards_ATRMask* rgAtrMasks;
 	/* [range] */ DWORD cReaders;
-	/* [size_is] */ ReaderStateW *rgReaderStates;
+	/* [size_is] */ ReaderStateW* rgReaderStates;
 } LocateCardsByATRW_Call;
 
 typedef struct _GetStatusChange_Return
 {
 	LONG ReturnCode;
 	/* [range] */ DWORD cReaders;
-	/* [size_is] */ ReaderState_Return *rgReaderStates;
+	/* [size_is] */ ReaderState_Return* rgReaderStates;
 } LocateCards_Return;
 
 typedef struct _GetStatusChange_Return GetStatusChange_Return;
@@ -223,13 +223,13 @@ typedef struct _Connect_Common
 
 typedef struct _ConnectA_Call
 {
-	/* [string] */ unsigned char *szReader;
+	/* [string] */ unsigned char* szReader;
 	Connect_Common Common;
 } ConnectA_Call;
 
 typedef struct _ConnectW_Call
 {
-	/* [string] */ WCHAR *szReader;
+	/* [string] */ WCHAR* szReader;
 	Connect_Common Common;
 } ConnectW_Call;
 
@@ -293,7 +293,7 @@ typedef struct _Status_Return
 {
 	LONG ReturnCode;
 	/* [range] */ DWORD cBytes;
-	/* [size_is][unique] */ BYTE *mszReaderNames;
+	/* [size_is][unique] */ BYTE* mszReaderNames;
 	DWORD dwState;
 	DWORD dwProtocol;
 	BYTE pbAtr[32];
@@ -304,7 +304,7 @@ typedef struct _SCardIO_Request
 {
 	DWORD dwProtocol;
 	/* [range] */ DWORD cbExtraBytes;
-	/* [size_is][unique] */ BYTE *pbExtraBytes;
+	/* [size_is][unique] */ BYTE* pbExtraBytes;
 } SCardIO_Request;
 
 typedef struct _Transmit_Call
@@ -313,7 +313,7 @@ typedef struct _Transmit_Call
 	REDIR_SCARDHANDLE hCard;
 	LPSCARD_IO_REQUEST pioSendPci;
 	/* [range] */ DWORD cbSendLength;
-	/* [size_is] */ BYTE *pbSendBuffer;
+	/* [size_is] */ BYTE* pbSendBuffer;
 	/* [unique] */ LPSCARD_IO_REQUEST pioRecvPci;
 	LONG fpbRecvBufferIsNULL;
 	DWORD cbRecvLength;
@@ -324,7 +324,7 @@ typedef struct _Transmit_Return
 	LONG ReturnCode;
 	/* [unique] */ LPSCARD_IO_REQUEST pioRecvPci;
 	/* [range] */ DWORD cbRecvLength;
-	/* [size_is][unique] */ BYTE *pbRecvBuffer;
+	/* [size_is][unique] */ BYTE* pbRecvBuffer;
 } Transmit_Return;
 
 typedef struct _GetTransmitCount_Call
@@ -345,7 +345,7 @@ typedef struct _Control_Call
 	REDIR_SCARDHANDLE hCard;
 	DWORD dwControlCode;
 	/* [range] */ DWORD cbInBufferSize;
-	/* [size_is][unique] */ BYTE *pvInBuffer;
+	/* [size_is][unique] */ BYTE* pvInBuffer;
 	LONG fpvOutBufferIsNULL;
 	DWORD cbOutBufferSize;
 } Control_Call;
@@ -354,7 +354,7 @@ typedef struct _Control_Return
 {
 	LONG ReturnCode;
 	/* [range] */ DWORD cbOutBufferSize;
-	/* [size_is][unique] */ BYTE *pvOutBuffer;
+	/* [size_is][unique] */ BYTE* pvOutBuffer;
 } Control_Return;
 
 typedef struct _GetAttrib_Call
@@ -370,7 +370,7 @@ typedef struct _GetAttrib_Return
 {
 	LONG ReturnCode;
 	/* [range] */ DWORD cbAttrLen;
-	/* [size_is][unique] */ BYTE *pbAttr;
+	/* [size_is][unique] */ BYTE* pbAttr;
 } GetAttrib_Return;
 
 typedef struct _SetAttrib_Call
@@ -379,13 +379,13 @@ typedef struct _SetAttrib_Call
 	REDIR_SCARDHANDLE hCard;
 	DWORD dwAttrId;
 	/* [range] */ DWORD cbAttrLen;
-	/* [size_is] */ BYTE *pbAttr;
+	/* [size_is] */ BYTE* pbAttr;
 } SetAttrib_Call;
 
 typedef struct _ReadCache_Common
 {
 	REDIR_SCARDCONTEXT hContext;
-	UUID *CardIdentifier;
+	UUID* CardIdentifier;
 	DWORD FreshnessCounter;
 	LONG fPbDataIsNULL;
 	DWORD cbDataLen;
@@ -393,13 +393,13 @@ typedef struct _ReadCache_Common
 
 typedef struct _ReadCacheA_Call
 {
-	/* [string] */ unsigned char *szLookupName;
+	/* [string] */ unsigned char* szLookupName;
 	ReadCache_Common Common;
 } ReadCacheA_Call;
 
 typedef struct _ReadCacheW_Call
 {
-	/* [string] */ WCHAR *szLookupName;
+	/* [string] */ WCHAR* szLookupName;
 	ReadCache_Common Common;
 } ReadCacheW_Call;
 
@@ -407,27 +407,27 @@ typedef struct _ReadCache_Return
 {
 	LONG ReturnCode;
 	/* [range] */ DWORD cbDataLen;
-	/* [size_is][unique] */ BYTE *pbData;
+	/* [size_is][unique] */ BYTE* pbData;
 } ReadCache_Return;
 
 typedef struct _WriteCache_Common
 {
 	REDIR_SCARDCONTEXT hContext;
-	UUID *CardIdentifier;
+	UUID* CardIdentifier;
 	DWORD FreshnessCounter;
 	/* [range] */ DWORD cbDataLen;
-	/* [size_is][unique] */ BYTE *pbData;
+	/* [size_is][unique] */ BYTE* pbData;
 } WriteCache_Common;
 
 typedef struct _WriteCacheA_Call
 {
-	/* [string] */ unsigned char *szLookupName;
+	/* [string] */ unsigned char* szLookupName;
 	WriteCache_Common Common;
 } WriteCacheA_Call;
 
 typedef struct _WriteCacheW_Call
 {
-	/* [string] */ WCHAR *szLookupName;
+	/* [string] */ WCHAR* szLookupName;
 	WriteCache_Common Common;
 } WriteCacheW_Call;
 
@@ -436,49 +436,83 @@ typedef struct _WriteCacheW_Call
 
 #include "smartcard_main.h"
 
-LONG smartcard_pack_write_size_align(SMARTCARD_DEVICE* smartcard, wStream* s, UINT32 size, UINT32 alignment);
-LONG smartcard_unpack_read_size_align(SMARTCARD_DEVICE* smartcard, wStream* s, UINT32 size, UINT32 alignment);
+LONG smartcard_pack_write_size_align(SMARTCARD_DEVICE* smartcard, wStream* s, UINT32 size,
+                                     UINT32 alignment);
+LONG smartcard_unpack_read_size_align(SMARTCARD_DEVICE* smartcard, wStream* s, UINT32 size,
+                                      UINT32 alignment);
 
-SCARDCONTEXT smartcard_scard_context_native_from_redir(SMARTCARD_DEVICE* smartcard, REDIR_SCARDCONTEXT* context);
-void smartcard_scard_context_native_to_redir(SMARTCARD_DEVICE* smartcard, REDIR_SCARDCONTEXT* context, SCARDCONTEXT hContext);
+SCARDCONTEXT smartcard_scard_context_native_from_redir(SMARTCARD_DEVICE* smartcard,
+        REDIR_SCARDCONTEXT* context);
+void smartcard_scard_context_native_to_redir(SMARTCARD_DEVICE* smartcard,
+        REDIR_SCARDCONTEXT* context, SCARDCONTEXT hContext);
 
-SCARDHANDLE smartcard_scard_handle_native_from_redir(SMARTCARD_DEVICE* smartcard, REDIR_SCARDHANDLE* handle);
-void smartcard_scard_handle_native_to_redir(SMARTCARD_DEVICE* smartcard, REDIR_SCARDHANDLE* handle, SCARDHANDLE hCard);
+SCARDHANDLE smartcard_scard_handle_native_from_redir(SMARTCARD_DEVICE* smartcard,
+        REDIR_SCARDHANDLE* handle);
+void smartcard_scard_handle_native_to_redir(SMARTCARD_DEVICE* smartcard, REDIR_SCARDHANDLE* handle,
+        SCARDHANDLE hCard);
 
 LONG smartcard_unpack_common_type_header(SMARTCARD_DEVICE* smartcard, wStream* s);
 LONG smartcard_pack_common_type_header(SMARTCARD_DEVICE* smartcard, wStream* s);
 
 LONG smartcard_unpack_private_type_header(SMARTCARD_DEVICE* smartcard, wStream* s);
-LONG smartcard_pack_private_type_header(SMARTCARD_DEVICE* smartcard, wStream* s, UINT32 objectBufferLength);
+LONG smartcard_pack_private_type_header(SMARTCARD_DEVICE* smartcard, wStream* s,
+                                        UINT32 objectBufferLength);
 
-LONG smartcard_unpack_redir_scard_context(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDCONTEXT* context);
-LONG smartcard_pack_redir_scard_context(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDCONTEXT* context);
+LONG smartcard_unpack_redir_scard_context(SMARTCARD_DEVICE* smartcard, wStream* s,
+        REDIR_SCARDCONTEXT* context);
+LONG smartcard_pack_redir_scard_context(SMARTCARD_DEVICE* smartcard, wStream* s,
+                                        REDIR_SCARDCONTEXT* context);
 
-LONG smartcard_unpack_redir_scard_context_ref(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDCONTEXT* context);
-LONG smartcard_pack_redir_scard_context_ref(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDCONTEXT* context);
+LONG smartcard_unpack_redir_scard_context_ref(SMARTCARD_DEVICE* smartcard, wStream* s,
+        REDIR_SCARDCONTEXT* context);
+LONG smartcard_pack_redir_scard_context_ref(SMARTCARD_DEVICE* smartcard, wStream* s,
+        REDIR_SCARDCONTEXT* context);
 
-LONG smartcard_unpack_redir_scard_handle(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDHANDLE* handle);
-LONG smartcard_pack_redir_scard_handle(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDHANDLE* handle);
+LONG smartcard_unpack_redir_scard_handle(SMARTCARD_DEVICE* smartcard, wStream* s,
+        REDIR_SCARDHANDLE* handle);
+LONG smartcard_pack_redir_scard_handle(SMARTCARD_DEVICE* smartcard, wStream* s,
+                                       REDIR_SCARDHANDLE* handle);
 
-LONG smartcard_unpack_redir_scard_handle_ref(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDHANDLE* handle);
-LONG smartcard_pack_redir_scard_handle_ref(SMARTCARD_DEVICE* smartcard, wStream* s, REDIR_SCARDHANDLE* handle);
+LONG smartcard_unpack_redir_scard_handle_ref(SMARTCARD_DEVICE* smartcard, wStream* s,
+        REDIR_SCARDHANDLE* handle);
+LONG smartcard_pack_redir_scard_handle_ref(SMARTCARD_DEVICE* smartcard, wStream* s,
+        REDIR_SCARDHANDLE* handle);
 
-LONG smartcard_unpack_establish_context_call(SMARTCARD_DEVICE* smartcard, wStream* s, EstablishContext_Call* call);
-void smartcard_trace_establish_context_call(SMARTCARD_DEVICE* smartcard, EstablishContext_Call* call);
+LONG smartcard_unpack_establish_context_call(SMARTCARD_DEVICE* smartcard, wStream* s,
+        EstablishContext_Call* call);
+void smartcard_trace_establish_context_call(SMARTCARD_DEVICE* smartcard,
+        EstablishContext_Call* call);
 
-LONG smartcard_pack_establish_context_return(SMARTCARD_DEVICE* smartcard, wStream* s, EstablishContext_Return* ret);
-void smartcard_trace_establish_context_return(SMARTCARD_DEVICE* smartcard, EstablishContext_Return* ret);
+LONG smartcard_pack_establish_context_return(SMARTCARD_DEVICE* smartcard, wStream* s,
+        EstablishContext_Return* ret);
+void smartcard_trace_establish_context_return(SMARTCARD_DEVICE* smartcard,
+        EstablishContext_Return* ret);
 
 LONG smartcard_unpack_context_call(SMARTCARD_DEVICE* smartcard, wStream* s, Context_Call* call);
-void smartcard_trace_context_call(SMARTCARD_DEVICE* smartcard, Context_Call* call, const char* name);
+void smartcard_trace_context_call(SMARTCARD_DEVICE* smartcard, Context_Call* call,
+                                  const char* name);
 
 void smartcard_trace_long_return(SMARTCARD_DEVICE* smartcard, Long_Return* ret, const char* name);
 
-LONG smartcard_unpack_list_readers_call(SMARTCARD_DEVICE* smartcard, wStream* s, ListReaders_Call* call);
-void smartcard_trace_list_readers_call(SMARTCARD_DEVICE* smartcard, ListReaders_Call* call, BOOL unicode);
+LONG smartcard_unpack_list_reader_groups_call(SMARTCARD_DEVICE* smartcard, wStream* s,
+        ListReaderGroups_Call* call);
+void smartcard_trace_list_reader_groups_call(SMARTCARD_DEVICE* smartcard,
+        ListReaderGroups_Call* call, BOOL unicode);
 
-LONG smartcard_pack_list_readers_return(SMARTCARD_DEVICE* smartcard, wStream* s, ListReaders_Return* ret);
-void smartcard_trace_list_readers_return(SMARTCARD_DEVICE* smartcard, ListReaders_Return* ret, BOOL unicode);
+LONG smartcard_pack_list_reader_groups_return(SMARTCARD_DEVICE* smartcard, wStream* s,
+        ListReaderGroups_Return* ret);
+void smartcard_trace_list_reader_groups_return(SMARTCARD_DEVICE* smartcard,
+        ListReaderGroups_Return* ret, BOOL unicode);
+
+LONG smartcard_unpack_list_readers_call(SMARTCARD_DEVICE* smartcard, wStream* s,
+                                        ListReaders_Call* call);
+void smartcard_trace_list_readers_call(SMARTCARD_DEVICE* smartcard, ListReaders_Call* call,
+                                       BOOL unicode);
+
+LONG smartcard_pack_list_readers_return(SMARTCARD_DEVICE* smartcard, wStream* s,
+                                        ListReaders_Return* ret);
+void smartcard_trace_list_readers_return(SMARTCARD_DEVICE* smartcard, ListReaders_Return* ret,
+        BOOL unicode);
 
 LONG smartcard_unpack_connect_a_call(SMARTCARD_DEVICE* smartcard, wStream* s, ConnectA_Call* call);
 void smartcard_trace_connect_a_call(SMARTCARD_DEVICE* smartcard, ConnectA_Call* call);
@@ -492,20 +526,29 @@ void smartcard_trace_connect_return(SMARTCARD_DEVICE* smartcard, Connect_Return*
 LONG smartcard_unpack_reconnect_call(SMARTCARD_DEVICE* smartcard, wStream* s, Reconnect_Call* call);
 void smartcard_trace_reconnect_call(SMARTCARD_DEVICE* smartcard, Reconnect_Call* call);
 
-LONG smartcard_pack_reconnect_return(SMARTCARD_DEVICE* smartcard, wStream* s, Reconnect_Return* ret);
+LONG smartcard_pack_reconnect_return(SMARTCARD_DEVICE* smartcard, wStream* s,
+                                     Reconnect_Return* ret);
 void smartcard_trace_reconnect_return(SMARTCARD_DEVICE* smartcard, Reconnect_Return* ret);
 
-LONG smartcard_unpack_hcard_and_disposition_call(SMARTCARD_DEVICE* smartcard, wStream* s, HCardAndDisposition_Call* call);
-void smartcard_trace_hcard_and_disposition_call(SMARTCARD_DEVICE* smartcard, HCardAndDisposition_Call* call, const char* name);
+LONG smartcard_unpack_hcard_and_disposition_call(SMARTCARD_DEVICE* smartcard, wStream* s,
+        HCardAndDisposition_Call* call);
+void smartcard_trace_hcard_and_disposition_call(SMARTCARD_DEVICE* smartcard,
+        HCardAndDisposition_Call* call, const char* name);
 
-LONG smartcard_unpack_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, wStream* s, GetStatusChangeA_Call* call);
-void smartcard_trace_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, GetStatusChangeA_Call* call);
+LONG smartcard_unpack_get_status_change_a_call(SMARTCARD_DEVICE* smartcard, wStream* s,
+        GetStatusChangeA_Call* call);
+void smartcard_trace_get_status_change_a_call(SMARTCARD_DEVICE* smartcard,
+        GetStatusChangeA_Call* call);
 
-LONG smartcard_unpack_get_status_change_w_call(SMARTCARD_DEVICE* smartcard, wStream* s, GetStatusChangeW_Call* call);
-void smartcard_trace_get_status_change_w_call(SMARTCARD_DEVICE* smartcard, GetStatusChangeW_Call* call);
+LONG smartcard_unpack_get_status_change_w_call(SMARTCARD_DEVICE* smartcard, wStream* s,
+        GetStatusChangeW_Call* call);
+void smartcard_trace_get_status_change_w_call(SMARTCARD_DEVICE* smartcard,
+        GetStatusChangeW_Call* call);
 
-LONG smartcard_pack_get_status_change_return(SMARTCARD_DEVICE* smartcard, wStream* s, GetStatusChange_Return* ret);
-void smartcard_trace_get_status_change_return(SMARTCARD_DEVICE* smartcard, GetStatusChange_Return* ret, BOOL unicode);
+LONG smartcard_pack_get_status_change_return(SMARTCARD_DEVICE* smartcard, wStream* s,
+        GetStatusChange_Return* ret);
+void smartcard_trace_get_status_change_return(SMARTCARD_DEVICE* smartcard,
+        GetStatusChange_Return* ret, BOOL unicode);
 
 LONG smartcard_unpack_state_call(SMARTCARD_DEVICE* smartcard, wStream* s, State_Call* call);
 LONG smartcard_pack_state_return(SMARTCARD_DEVICE* smartcard, wStream* s, State_Return* ret);
@@ -516,11 +559,14 @@ void smartcard_trace_status_call(SMARTCARD_DEVICE* smartcard, Status_Call* call,
 LONG smartcard_pack_status_return(SMARTCARD_DEVICE* smartcard, wStream* s, Status_Return* ret);
 void smartcard_trace_status_return(SMARTCARD_DEVICE* smartcard, Status_Return* ret, BOOL unicode);
 
-LONG smartcard_unpack_get_attrib_call(SMARTCARD_DEVICE* smartcard, wStream* s, GetAttrib_Call* call);
+LONG smartcard_unpack_get_attrib_call(SMARTCARD_DEVICE* smartcard, wStream* s,
+                                      GetAttrib_Call* call);
 void smartcard_trace_get_attrib_call(SMARTCARD_DEVICE* smartcard, GetAttrib_Call* call);
 
-LONG smartcard_pack_get_attrib_return(SMARTCARD_DEVICE* smartcard, wStream* s, GetAttrib_Return* ret);
-void smartcard_trace_get_attrib_return(SMARTCARD_DEVICE* smartcard, GetAttrib_Return* ret, DWORD dwAttrId);
+LONG smartcard_pack_get_attrib_return(SMARTCARD_DEVICE* smartcard, wStream* s,
+                                      GetAttrib_Return* ret);
+void smartcard_trace_get_attrib_return(SMARTCARD_DEVICE* smartcard, GetAttrib_Return* ret,
+                                       DWORD dwAttrId);
 
 LONG smartcard_unpack_control_call(SMARTCARD_DEVICE* smartcard, wStream* s, Control_Call* call);
 void smartcard_trace_control_call(SMARTCARD_DEVICE* smartcard, Control_Call* call);
@@ -534,8 +580,10 @@ void smartcard_trace_transmit_call(SMARTCARD_DEVICE* smartcard, Transmit_Call* c
 LONG smartcard_pack_transmit_return(SMARTCARD_DEVICE* smartcard, wStream* s, Transmit_Return* ret);
 void smartcard_trace_transmit_return(SMARTCARD_DEVICE* smartcard, Transmit_Return* ret);
 
-LONG smartcard_unpack_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, wStream* s, LocateCardsByATRA_Call* call);
-void smartcard_trace_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, LocateCardsByATRA_Call* call);
+LONG smartcard_unpack_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard, wStream* s,
+        LocateCardsByATRA_Call* call);
+void smartcard_trace_locate_cards_by_atr_a_call(SMARTCARD_DEVICE* smartcard,
+        LocateCardsByATRA_Call* call);
 
 
 #endif /* FREERDP_CHANNEL_SMARTCARD_CLIENT_PACK_H */

--- a/winpr/libwinpr/smartcard/smartcard_pcsc.c
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.c
@@ -159,7 +159,7 @@ static wListDictionary* g_MemoryBlocks = NULL;
 char SMARTCARD_PNP_NOTIFICATION_A[] = "\\\\?PnP?\\Notification";
 
 WCHAR SMARTCARD_PNP_NOTIFICATION_W[] =
-{ '\\','\\','?','P','n','P','?','\\','N','o','t','i','f','i','c','a','t','i','o','n','\0' };
+{ '\\', '\\', '?', 'P', 'n', 'P', '?', '\\', 'N', 'o', 't', 'i', 'f', 'i', 'c', 'a', 't', 'i', 'o', 'n', '\0' };
 
 const PCSC_SCARD_IO_REQUEST g_PCSC_rgSCardT0Pci = { SCARD_PROTOCOL_T0, sizeof(PCSC_SCARD_IO_REQUEST) };
 const PCSC_SCARD_IO_REQUEST g_PCSC_rgSCardT1Pci = { SCARD_PROTOCOL_T1, sizeof(PCSC_SCARD_IO_REQUEST) };
@@ -167,7 +167,7 @@ const PCSC_SCARD_IO_REQUEST g_PCSC_rgSCardRawPci = { PCSC_SCARD_PROTOCOL_RAW, si
 
 WINSCARDAPI LONG WINAPI PCSC_SCardFreeMemory_Internal(SCARDCONTEXT hContext, LPCVOID pvMem);
 WINSCARDAPI LONG WINAPI PCSC_SCardEstablishContext_Internal(DWORD dwScope,
-		LPCVOID pvReserved1, LPCVOID pvReserved2, LPSCARDCONTEXT phContext);
+        LPCVOID pvReserved1, LPCVOID pvReserved2, LPSCARDCONTEXT phContext);
 WINSCARDAPI LONG WINAPI PCSC_SCardReleaseContext_Internal(SCARDCONTEXT hContext);
 
 LONG PCSC_MapErrorCodeToWinSCard(LONG errorCode)
@@ -312,12 +312,14 @@ PCSC_SCARDCONTEXT* PCSC_EstablishCardContext(SCARDCONTEXT hContext)
 		return NULL;
 
 	pContext->hContext = hContext;
+
 	if (!InitializeCriticalSectionAndSpinCount(&(pContext->lock), 4000))
 		goto error_spinlock;
 
 	if (!g_CardContexts)
 	{
 		g_CardContexts = ListDictionary_New(TRUE);
+
 		if (!g_CardContexts)
 			goto errors;
 	}
@@ -325,15 +327,17 @@ PCSC_SCARDCONTEXT* PCSC_EstablishCardContext(SCARDCONTEXT hContext)
 	if (!g_Readers)
 	{
 		g_Readers = ArrayList_New(TRUE);
+
 		if (!g_Readers)
 			goto errors;
+
 		ArrayList_Object(g_Readers)->fnObjectFree = (OBJECT_FREE_FN) PCSC_ReaderAliasFree;
 	}
 
 	if (!ListDictionary_Add(g_CardContexts, (void*) hContext, (void*) pContext))
 		goto errors;
-	return pContext;
 
+	return pContext;
 errors:
 	DeleteCriticalSection(&(pContext->lock));
 error_spinlock:
@@ -426,7 +430,6 @@ BOOL PCSC_WaitForCardAccess(SCARDCONTEXT hContext, SCARDHANDLE hCard, BOOL share
 	if (!hCard)
 	{
 		/* SCardConnect */
-
 		pContext = PCSC_GetCardContextData(hContext);
 
 		if (!pContext)
@@ -436,7 +439,6 @@ BOOL PCSC_WaitForCardAccess(SCARDCONTEXT hContext, SCARDHANDLE hCard, BOOL share
 			return TRUE;
 
 		/* wait for card ownership */
-
 		return TRUE;
 	}
 
@@ -447,7 +449,6 @@ BOOL PCSC_WaitForCardAccess(SCARDCONTEXT hContext, SCARDHANDLE hCard, BOOL share
 
 	shared = pCard->shared;
 	hContext = pCard->hSharedContext;
-
 	pContext = PCSC_GetCardContextData(hContext);
 
 	if (!pContext)
@@ -456,7 +457,6 @@ BOOL PCSC_WaitForCardAccess(SCARDCONTEXT hContext, SCARDHANDLE hCard, BOOL share
 	if (!pContext->owner)
 	{
 		/* card is not owned */
-
 		if (!shared)
 			pContext->owner = hCard;
 
@@ -483,7 +483,6 @@ BOOL PCSC_ReleaseCardAccess(SCARDCONTEXT hContext, SCARDHANDLE hCard)
 	if (!hCard)
 	{
 		/* release current owner */
-
 		pContext = PCSC_GetCardContextData(hContext);
 
 		if (!pContext)
@@ -500,9 +499,7 @@ BOOL PCSC_ReleaseCardAccess(SCARDCONTEXT hContext, SCARDHANDLE hCard)
 			return FALSE;
 
 		/* release card ownership */
-
 		pContext->owner = 0;
-
 		return TRUE;
 	}
 
@@ -512,7 +509,6 @@ BOOL PCSC_ReleaseCardAccess(SCARDCONTEXT hContext, SCARDHANDLE hCard)
 		return FALSE;
 
 	hContext = pCard->hSharedContext;
-
 	pContext = PCSC_GetCardContextData(hContext);
 
 	if (!pContext)
@@ -521,7 +517,6 @@ BOOL PCSC_ReleaseCardAccess(SCARDCONTEXT hContext, SCARDHANDLE hCard)
 	if (pContext->owner == hCard)
 	{
 		/* release card ownership */
-
 		pContext->owner = 0;
 	}
 
@@ -541,6 +536,7 @@ PCSC_SCARDHANDLE* PCSC_ConnectCardHandle(SCARDCONTEXT hSharedContext, SCARDHANDL
 	}
 
 	pCard = (PCSC_SCARDHANDLE*) calloc(1, sizeof(PCSC_SCARDHANDLE));
+
 	if (!pCard)
 		return NULL;
 
@@ -549,6 +545,7 @@ PCSC_SCARDHANDLE* PCSC_ConnectCardHandle(SCARDCONTEXT hSharedContext, SCARDHANDL
 	if (!g_CardHandles)
 	{
 		g_CardHandles = ListDictionary_New(TRUE);
+
 		if (!g_CardHandles)
 			goto error;
 	}
@@ -558,7 +555,6 @@ PCSC_SCARDHANDLE* PCSC_ConnectCardHandle(SCARDCONTEXT hSharedContext, SCARDHANDL
 
 	pContext->dwCardHandleCount++;
 	return pCard;
-
 error:
 	free(pCard);
 	return NULL;
@@ -568,7 +564,6 @@ void PCSC_DisconnectCardHandle(SCARDHANDLE hCard)
 {
 	PCSC_SCARDHANDLE* pCard;
 	PCSC_SCARDCONTEXT* pContext;
-
 	pCard = PCSC_GetCardHandleData(hCard);
 
 	if (!pCard)
@@ -623,20 +618,24 @@ BOOL PCSC_AddReaderNameAlias(char* namePCSC, char* nameWinSCard)
 		return TRUE;
 
 	reader = (PCSC_READER*) calloc(1, sizeof(PCSC_READER));
+
 	if (!reader)
 		return FALSE;
 
 	reader->namePCSC = _strdup(namePCSC);
+
 	if (!reader->namePCSC)
 		goto error_namePSC;
 
 	reader->nameWinSCard = _strdup(nameWinSCard);
+
 	if (!reader->nameWinSCard)
 		goto error_nameWinSCard;
+
 	if (ArrayList_Add(g_Readers, reader) < 0)
 		goto error_add;
-	return TRUE;
 
+	return TRUE;
 error_add:
 	free(reader->nameWinSCard);
 error_nameWinSCard:
@@ -673,7 +672,8 @@ char* PCSC_ConvertReaderNameToWinSCard(const char* name)
 	char* p, *q;
 	char* tokens[64][2];
 	char* nameWinSCard;
-	char *checkAliasName;
+	char* checkAliasName;
+
 	/**
 	 * pcsc-lite reader name format:
 	 * name [interface] (serial) index slot
@@ -716,8 +716,8 @@ char* PCSC_ConvertReaderNameToWinSCard(const char* name)
 	 */
 	if (!name)
 		return NULL;
-	memset(tokens, 0, sizeof(tokens));
 
+	memset(tokens, 0, sizeof(tokens));
 	length = strlen(name);
 
 	if (length < 10)
@@ -802,8 +802,8 @@ char* PCSC_ConvertReaderNameToWinSCard(const char* name)
 	 */
 	index = 0;
 	sprintf_s(nameWinSCard, size, "%.*s %d", length, p, index);
-
 	checkAliasName = PCSC_GetReaderNameFromAlias(nameWinSCard);
+
 	while ((checkAliasName != NULL) && (strcmp(checkAliasName, name) != 0))
 	{
 		index++;
@@ -817,7 +817,6 @@ char* PCSC_ConvertReaderNameToWinSCard(const char* name)
 char* PCSC_GetReaderAliasFromName(char* namePCSC)
 {
 	char* nameWinSCard = NULL;
-
 	nameWinSCard = PCSC_ConvertReaderNameToWinSCard(namePCSC);
 
 	if (nameWinSCard)
@@ -914,6 +913,7 @@ BOOL PCSC_AddMemoryBlock(SCARDCONTEXT hContext, void* pvMem)
 	if (!g_MemoryBlocks)
 	{
 		g_MemoryBlocks = ListDictionary_New(TRUE);
+
 		if (!g_MemoryBlocks)
 			return FALSE;
 	}
@@ -942,6 +942,7 @@ void* PCSC_SCardAllocMemory(SCARDCONTEXT hContext, size_t size)
 		free(pvMem);
 		return NULL;
 	}
+
 	return pvMem;
 }
 
@@ -950,7 +951,7 @@ void* PCSC_SCardAllocMemory(SCARDCONTEXT hContext, size_t size)
  */
 
 WINSCARDAPI LONG WINAPI PCSC_SCardEstablishContext_Internal(DWORD dwScope,
-		LPCVOID pvReserved1, LPCVOID pvReserved2, LPSCARDCONTEXT phContext)
+        LPCVOID pvReserved1, LPCVOID pvReserved2, LPSCARDCONTEXT phContext)
 {
 	LONG status = SCARD_S_SUCCESS;
 	PCSC_DWORD pcsc_dwScope = (PCSC_DWORD) dwScope;
@@ -965,7 +966,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardEstablishContext_Internal(DWORD dwScope,
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardEstablishContext(DWORD dwScope,
-		LPCVOID pvReserved1, LPCVOID pvReserved2, LPSCARDCONTEXT phContext)
+        LPCVOID pvReserved1, LPCVOID pvReserved2, LPSCARDCONTEXT phContext)
 {
 	LONG status = SCARD_S_SUCCESS;
 	status = PCSC_SCardEstablishContext_Internal(dwScope, pvReserved1, pvReserved2, phContext);
@@ -1017,11 +1018,73 @@ WINSCARDAPI LONG WINAPI PCSC_SCardIsValidContext(SCARDCONTEXT hContext)
 	return status;
 }
 
-WINSCARDAPI LONG WINAPI PCSC_SCardListReaderGroupsA(SCARDCONTEXT hContext,
-		LPSTR mszGroups, LPDWORD pcchGroups)
+WINSCARDAPI LONG WINAPI PCSC_SCardListReaderGroups_Internal(SCARDCONTEXT hContext,
+        LPSTR mszGroups, LPDWORD pcchGroups)
 {
 	LONG status = SCARD_S_SUCCESS;
-	PCSC_DWORD pcsc_cchGroups = (PCSC_DWORD) *pcchGroups;
+	char* mszGroupsWinSCard = NULL;
+	BOOL pcchGroupsAlloc = FALSE;
+	LPSTR* pMszGroups = (LPSTR*) mszGroups;
+	PCSC_DWORD pcsc_cchGroups = 0;
+
+	if (!pcchGroups)
+		return SCARD_E_INVALID_PARAMETER;
+
+	if (!g_PCSC.pfnSCardListReaderGroups)
+		return SCARD_E_NO_SERVICE;
+
+	if (*pcchGroups == SCARD_AUTOALLOCATE)
+		pcchGroupsAlloc = TRUE;
+
+	pcsc_cchGroups = pcchGroupsAlloc ? PCSC_SCARD_AUTOALLOCATE : (PCSC_DWORD) * pcchGroups;
+
+	if (pcchGroupsAlloc && !g_SCardAutoAllocate)
+	{
+		pcsc_cchGroups = 0;
+		status = (LONG) g_PCSC.pfnSCardListReaderGroups(hContext, NULL, &pcsc_cchGroups);
+
+		if (status == SCARD_S_SUCCESS)
+		{
+			*pMszGroups = calloc(1, pcsc_cchGroups);
+
+			if (!*pMszGroups)
+				return SCARD_E_NO_MEMORY;
+
+			status = (LONG) g_PCSC.pfnSCardListReaderGroups(hContext, *pMszGroups, &pcsc_cchGroups);
+
+			if (status != SCARD_S_SUCCESS)
+				free(*pMszGroups);
+			else
+				PCSC_AddMemoryBlock(hContext, *pMszGroups);
+		}
+	}
+	else
+	{
+		status = (LONG) g_PCSC.pfnSCardListReaderGroups(hContext, mszGroups, &pcsc_cchGroups);
+	}
+
+	status = PCSC_MapErrorCodeToWinSCard(status);
+	*pcchGroups = (DWORD) pcsc_cchGroups;
+
+	if (status == SCARD_S_SUCCESS)
+	{
+		mszGroupsWinSCard = PCSC_ConvertReaderNamesToWinSCard(*pMszGroups, pcchGroups);
+
+		if (mszGroupsWinSCard)
+		{
+			PCSC_SCardFreeMemory_Internal(hContext, *pMszGroups);
+			*pMszGroups = mszGroupsWinSCard;
+			PCSC_AddMemoryBlock(hContext, *pMszGroups);
+		}
+	}
+
+	return status;
+}
+
+WINSCARDAPI LONG WINAPI PCSC_SCardListReaderGroupsA(SCARDCONTEXT hContext,
+        LPSTR mszGroups, LPDWORD pcchGroups)
+{
+	LONG status = SCARD_S_SUCCESS;
 
 	if (!g_PCSC.pfnSCardListReaderGroups)
 		return SCARD_E_NO_SERVICE;
@@ -1029,9 +1092,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardListReaderGroupsA(SCARDCONTEXT hContext,
 	if (!PCSC_LockCardContext(hContext))
 		return SCARD_E_INVALID_HANDLE;
 
-	status = (LONG) g_PCSC.pfnSCardListReaderGroups(hContext, mszGroups, &pcsc_cchGroups);
-	status = PCSC_MapErrorCodeToWinSCard(status);
-	*pcchGroups = (DWORD) pcsc_cchGroups;
+	status = PCSC_SCardListReaderGroups_Internal(hContext, mszGroups, pcchGroups);
 
 	if (!PCSC_UnlockCardContext(hContext))
 		return SCARD_E_INVALID_HANDLE;
@@ -1040,10 +1101,11 @@ WINSCARDAPI LONG WINAPI PCSC_SCardListReaderGroupsA(SCARDCONTEXT hContext,
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardListReaderGroupsW(SCARDCONTEXT hContext,
-		LPWSTR mszGroups, LPDWORD pcchGroups)
+        LPWSTR mszGroups, LPDWORD pcchGroups)
 {
+	LPSTR mszGroupsA = NULL;
+	LPSTR* pMszGroupsA = &mszGroupsA;
 	LONG status = SCARD_S_SUCCESS;
-	PCSC_DWORD pcsc_cchGroups = (PCSC_DWORD) *pcchGroups;
 
 	if (!g_PCSC.pfnSCardListReaderGroups)
 		return SCARD_E_NO_SERVICE;
@@ -1051,13 +1113,14 @@ WINSCARDAPI LONG WINAPI PCSC_SCardListReaderGroupsW(SCARDCONTEXT hContext,
 	if (!PCSC_LockCardContext(hContext))
 		return SCARD_E_INVALID_HANDLE;
 
-	mszGroups = NULL;
-	pcchGroups = 0;
-	/* FIXME: unicode conversion */
-	status = (LONG) g_PCSC.pfnSCardListReaderGroups(hContext, (LPSTR) mszGroups, &pcsc_cchGroups);
-	status = PCSC_MapErrorCodeToWinSCard(status);
-	if (pcchGroups)
-		*pcchGroups = (DWORD) pcsc_cchGroups;
+	status = PCSC_SCardListReaderGroups_Internal(hContext, (LPSTR) &mszGroupsA, pcchGroups);
+
+	if (status == SCARD_S_SUCCESS)
+	{
+		*pcchGroups = ConvertToUnicode(CP_UTF8, 0, *pMszGroupsA, *pcchGroups, (WCHAR**) mszGroups, 0);
+		PCSC_AddMemoryBlock(hContext, mszGroups);
+		PCSC_SCardFreeMemory_Internal(hContext, *pMszGroupsA);
+	}
 
 	if (!PCSC_UnlockCardContext(hContext))
 		return SCARD_E_INVALID_HANDLE;
@@ -1066,7 +1129,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardListReaderGroupsW(SCARDCONTEXT hContext,
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardListReaders_Internal(SCARDCONTEXT hContext,
-		LPCSTR mszGroups, LPSTR mszReaders, LPDWORD pcchReaders)
+        LPCSTR mszGroups, LPSTR mszReaders, LPDWORD pcchReaders)
 {
 	LONG status = SCARD_S_SUCCESS;
 	char* mszReadersWinSCard = NULL;
@@ -1085,7 +1148,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardListReaders_Internal(SCARDCONTEXT hContext,
 	if (*pcchReaders == SCARD_AUTOALLOCATE)
 		pcchReadersAlloc = TRUE;
 
-	pcsc_cchReaders = pcchReadersAlloc ? PCSC_SCARD_AUTOALLOCATE : (PCSC_DWORD) *pcchReaders;
+	pcsc_cchReaders = pcchReadersAlloc ? PCSC_SCARD_AUTOALLOCATE : (PCSC_DWORD) * pcchReaders;
 
 	if (pcchReadersAlloc && !g_SCardAutoAllocate)
 	{
@@ -1131,7 +1194,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardListReaders_Internal(SCARDCONTEXT hContext,
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardListReadersA(SCARDCONTEXT hContext,
-		LPCSTR mszGroups, LPSTR mszReaders, LPDWORD pcchReaders)
+        LPCSTR mszGroups, LPSTR mszReaders, LPDWORD pcchReaders)
 {
 	BOOL nullCardContext = FALSE;
 	LONG status = SCARD_S_SUCCESS;
@@ -1166,7 +1229,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardListReadersA(SCARDCONTEXT hContext,
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardListReadersW(SCARDCONTEXT hContext,
-		LPCWSTR mszGroups, LPWSTR mszReaders, LPDWORD pcchReaders)
+        LPCWSTR mszGroups, LPWSTR mszReaders, LPDWORD pcchReaders)
 {
 	LPSTR mszGroupsA = NULL;
 	LPSTR mszReadersA = NULL;
@@ -1218,49 +1281,51 @@ WINSCARDAPI LONG WINAPI PCSC_SCardListReadersW(SCARDCONTEXT hContext,
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardListCardsA(SCARDCONTEXT hContext,
-		LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, CHAR* mszCards, LPDWORD pcchCards)
+        LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, CHAR* mszCards,
+        LPDWORD pcchCards)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardListCardsW(SCARDCONTEXT hContext,
-		LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, WCHAR* mszCards, LPDWORD pcchCards)
+        LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, WCHAR* mszCards,
+        LPDWORD pcchCards)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardListInterfacesA(SCARDCONTEXT hContext,
-		LPCSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces)
+        LPCSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardListInterfacesW(SCARDCONTEXT hContext,
-		LPCWSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces)
+        LPCWSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardGetProviderIdA(SCARDCONTEXT hContext,
-		LPCSTR szCard, LPGUID pguidProviderId)
+        LPCSTR szCard, LPGUID pguidProviderId)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardGetProviderIdW(SCARDCONTEXT hContext,
-		LPCWSTR szCard, LPGUID pguidProviderId)
+        LPCWSTR szCard, LPGUID pguidProviderId)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardGetCardTypeProviderNameA(SCARDCONTEXT hContext,
-		LPCSTR szCardName, DWORD dwProviderId, CHAR* szProvider, LPDWORD pcchProvider)
+        LPCSTR szCardName, DWORD dwProviderId, CHAR* szProvider, LPDWORD pcchProvider)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardGetCardTypeProviderNameW(SCARDCONTEXT hContext,
-		LPCWSTR szCardName, DWORD dwProviderId, WCHAR* szProvider, LPDWORD pcchProvider)
+        LPCWSTR szCardName, DWORD dwProviderId, WCHAR* szProvider, LPDWORD pcchProvider)
 {
 	return 0;
 }
@@ -1286,13 +1351,13 @@ WINSCARDAPI LONG WINAPI PCSC_SCardForgetReaderGroupW(SCARDCONTEXT hContext, LPCW
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardIntroduceReaderA(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPCSTR szDeviceName)
+        LPCSTR szReaderName, LPCSTR szDeviceName)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardIntroduceReaderW(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPCWSTR szDeviceName)
+        LPCWSTR szReaderName, LPCWSTR szDeviceName)
 {
 	return 0;
 }
@@ -1308,51 +1373,51 @@ WINSCARDAPI LONG WINAPI PCSC_SCardForgetReaderW(SCARDCONTEXT hContext, LPCWSTR s
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardAddReaderToGroupA(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPCSTR szGroupName)
+        LPCSTR szReaderName, LPCSTR szGroupName)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardAddReaderToGroupW(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPCWSTR szGroupName)
+        LPCWSTR szReaderName, LPCWSTR szGroupName)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardRemoveReaderFromGroupA(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPCSTR szGroupName)
+        LPCSTR szReaderName, LPCSTR szGroupName)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardRemoveReaderFromGroupW(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPCWSTR szGroupName)
+        LPCWSTR szReaderName, LPCWSTR szGroupName)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardIntroduceCardTypeA(SCARDCONTEXT hContext,
-		LPCSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
-		DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen)
+        LPCSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
+        DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardIntroduceCardTypeW(SCARDCONTEXT hContext,
-		LPCWSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
-		DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen)
+        LPCWSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
+        DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardSetCardTypeProviderNameA(SCARDCONTEXT hContext,
-		LPCSTR szCardName, DWORD dwProviderId, LPCSTR szProvider)
+        LPCSTR szCardName, DWORD dwProviderId, LPCSTR szProvider)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardSetCardTypeProviderNameW(SCARDCONTEXT hContext,
-		LPCWSTR szCardName, DWORD dwProviderId, LPCWSTR szProvider)
+        LPCWSTR szCardName, DWORD dwProviderId, LPCWSTR szProvider)
 {
 	return 0;
 }
@@ -1454,31 +1519,31 @@ WINSCARDAPI void WINAPI PCSC_SCardReleaseStartedEvent(void)
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardLocateCardsA(SCARDCONTEXT hContext,
-		LPCSTR mszCards, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders)
+        LPCSTR mszCards, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardLocateCardsW(SCARDCONTEXT hContext,
-		LPCWSTR mszCards, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders)
+        LPCWSTR mszCards, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardLocateCardsByATRA(SCARDCONTEXT hContext,
-		LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders)
+        LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardLocateCardsByATRW(SCARDCONTEXT hContext,
-		LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders)
+        LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardGetStatusChange_Internal(SCARDCONTEXT hContext,
-		DWORD dwTimeout, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders)
+        DWORD dwTimeout, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders)
 {
 	int i, j;
 	int* map;
@@ -1498,7 +1563,6 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetStatusChange_Internal(SCARDCONTEXT hContext
 
 	/* pcsc-lite interprets value 0 as INFINITE, work around the problem by using value 1 */
 	pcsc_dwTimeout = pcsc_dwTimeout ? pcsc_dwTimeout : 1;
-
 	/**
 	 * Apple's SmartCard Services (not vanilla pcsc-lite) appears to have trouble with the
 	 * "\\\\?PnP?\\Notification" reader name. I am always getting EXC_BAD_ACCESS with it.
@@ -1521,7 +1585,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetStatusChange_Internal(SCARDCONTEXT hContext
 
 	if (!states)
 	{
-		free (map);
+		free(map);
 		return SCARD_E_NO_MEMORY;
 	}
 
@@ -1555,7 +1619,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetStatusChange_Internal(SCARDCONTEXT hContext
 	if (cMappedReaders > 0)
 	{
 		status = (LONG) g_PCSC.pfnSCardGetStatusChange(hContext,
-				 pcsc_dwTimeout, states, cMappedReaders);
+		         pcsc_dwTimeout, states, cMappedReaders);
 		status = PCSC_MapErrorCodeToWinSCard(status);
 	}
 	else
@@ -1572,7 +1636,6 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetStatusChange_Internal(SCARDCONTEXT hContext
 		rgReaderStates[i].dwCurrentState = states[j].dwCurrentState;
 		rgReaderStates[i].cbAtr = states[j].cbAtr;
 		CopyMemory(&(rgReaderStates[i].rgbAtr), &(states[j].rgbAtr), PCSC_MAX_ATR_SIZE);
-
 		dwEventState = states[j].dwEventState & ~SCARD_STATE_CHANGED;
 
 		if (dwEventState != rgReaderStates[i].dwCurrentState)
@@ -1598,6 +1661,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetStatusChange_Internal(SCARDCONTEXT hContext
 
 	free(map);
 	free(states);
+
 	if ((status == SCARD_S_SUCCESS) && !stateChanged)
 		status = SCARD_E_TIMEOUT;
 	else if ((status == SCARD_E_TIMEOUT) && stateChanged)
@@ -1607,7 +1671,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetStatusChange_Internal(SCARDCONTEXT hContext
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardGetStatusChangeA(SCARDCONTEXT hContext,
-		DWORD dwTimeout, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders)
+        DWORD dwTimeout, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders)
 {
 	LONG status = SCARD_S_SUCCESS;
 
@@ -1623,7 +1687,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetStatusChangeA(SCARDCONTEXT hContext,
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardGetStatusChangeW(SCARDCONTEXT hContext,
-		DWORD dwTimeout, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders)
+        DWORD dwTimeout, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders)
 {
 	DWORD index;
 	LPSCARD_READERSTATEA states;
@@ -1647,7 +1711,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetStatusChangeW(SCARDCONTEXT hContext,
 	{
 		states[index].szReader = NULL;
 		ConvertFromUnicode(CP_UTF8, 0, rgReaderStates[index].szReader, -1,
-						   (char**) &(states[index].szReader), 0, NULL, NULL);
+		                   (char**) & (states[index].szReader), 0, NULL, NULL);
 		states[index].pvUserData = rgReaderStates[index].pvUserData;
 		states[index].dwCurrentState = rgReaderStates[index].dwCurrentState;
 		states[index].dwEventState = rgReaderStates[index].dwEventState;
@@ -1688,8 +1752,8 @@ WINSCARDAPI LONG WINAPI PCSC_SCardCancel(SCARDCONTEXT hContext)
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardConnect_Internal(SCARDCONTEXT hContext,
-		LPCSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
-		LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol)
+        LPCSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
+        LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol)
 {
 	BOOL shared;
 	BOOL access;
@@ -1704,9 +1768,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardConnect_Internal(SCARDCONTEXT hContext,
 		return SCARD_E_NO_SERVICE;
 
 	shared = (dwShareMode == SCARD_SHARE_DIRECT) ? TRUE : FALSE;
-
 	access = PCSC_WaitForCardAccess(hContext, 0, shared);
-
 	szReaderPCSC = PCSC_GetReaderNameFromAlias((char*) szReader);
 
 	if (!szReaderPCSC)
@@ -1723,15 +1785,13 @@ WINSCARDAPI LONG WINAPI PCSC_SCardConnect_Internal(SCARDCONTEXT hContext,
 		pcsc_dwPreferredProtocols = (PCSC_DWORD) PCSC_ConvertProtocolsFromWinSCard(dwPreferredProtocols);
 
 	status = (LONG) g_PCSC.pfnSCardConnect(hContext, szReaderPCSC,
-				pcsc_dwShareMode, pcsc_dwPreferredProtocols, phCard, &pcsc_dwActiveProtocol);
-
+	                                       pcsc_dwShareMode, pcsc_dwPreferredProtocols, phCard, &pcsc_dwActiveProtocol);
 	status = PCSC_MapErrorCodeToWinSCard(status);
 
 	if (status == SCARD_S_SUCCESS)
 	{
 		pCard = PCSC_ConnectCardHandle(hContext, *phCard);
 		*pdwActiveProtocol = PCSC_ConvertProtocolsToWinSCard((DWORD) pcsc_dwActiveProtocol);
-
 		pCard->shared = shared;
 		PCSC_WaitForCardAccess(hContext, pCard->hSharedContext, shared);
 	}
@@ -1740,8 +1800,8 @@ WINSCARDAPI LONG WINAPI PCSC_SCardConnect_Internal(SCARDCONTEXT hContext,
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardConnectA(SCARDCONTEXT hContext,
-		LPCSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
-		LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol)
+        LPCSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
+        LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol)
 {
 	LONG status = SCARD_S_SUCCESS;
 
@@ -1749,7 +1809,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardConnectA(SCARDCONTEXT hContext,
 		return SCARD_E_INVALID_HANDLE;
 
 	status = PCSC_SCardConnect_Internal(hContext, szReader, dwShareMode,
-					dwPreferredProtocols, phCard, pdwActiveProtocol);
+	                                    dwPreferredProtocols, phCard, pdwActiveProtocol);
 
 	if (!PCSC_UnlockCardContext(hContext))
 		return SCARD_E_INVALID_HANDLE;
@@ -1758,8 +1818,8 @@ WINSCARDAPI LONG WINAPI PCSC_SCardConnectA(SCARDCONTEXT hContext,
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardConnectW(SCARDCONTEXT hContext,
-		LPCWSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
-		LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol)
+        LPCWSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
+        LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol)
 {
 	LPSTR szReaderA = NULL;
 	LONG status = SCARD_S_SUCCESS;
@@ -1771,7 +1831,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardConnectW(SCARDCONTEXT hContext,
 		ConvertFromUnicode(CP_UTF8, 0, szReader, -1, &szReaderA, 0, NULL, NULL);
 
 	status = PCSC_SCardConnect_Internal(hContext, szReaderA, dwShareMode,
-					dwPreferredProtocols, phCard, pdwActiveProtocol);
+	                                    dwPreferredProtocols, phCard, pdwActiveProtocol);
 	free(szReaderA);
 
 	if (!PCSC_UnlockCardContext(hContext))
@@ -1781,7 +1841,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardConnectW(SCARDCONTEXT hContext,
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardReconnect(SCARDHANDLE hCard,
-		DWORD dwShareMode, DWORD dwPreferredProtocols, DWORD dwInitialization, LPDWORD pdwActiveProtocol)
+        DWORD dwShareMode, DWORD dwPreferredProtocols, DWORD dwInitialization, LPDWORD pdwActiveProtocol)
 {
 	BOOL shared;
 	BOOL access;
@@ -1795,15 +1855,12 @@ WINSCARDAPI LONG WINAPI PCSC_SCardReconnect(SCARDHANDLE hCard,
 		return SCARD_E_NO_SERVICE;
 
 	shared = (dwShareMode == SCARD_SHARE_DIRECT) ? TRUE : FALSE;
-
 	access = PCSC_WaitForCardAccess(0, hCard, shared);
-
 	pcsc_dwPreferredProtocols = (PCSC_DWORD) PCSC_ConvertProtocolsFromWinSCard(dwPreferredProtocols);
 	status = (LONG) g_PCSC.pfnSCardReconnect(hCard, pcsc_dwShareMode,
-			 pcsc_dwPreferredProtocols, pcsc_dwInitialization, &pcsc_dwActiveProtocol);
+	         pcsc_dwPreferredProtocols, pcsc_dwInitialization, &pcsc_dwActiveProtocol);
 	status = PCSC_MapErrorCodeToWinSCard(status);
 	*pdwActiveProtocol = PCSC_ConvertProtocolsToWinSCard((DWORD) pcsc_dwActiveProtocol);
-
 	return status;
 }
 
@@ -1824,7 +1881,6 @@ WINSCARDAPI LONG WINAPI PCSC_SCardDisconnect(SCARDHANDLE hCard, DWORD dwDisposit
 	}
 
 	PCSC_ReleaseCardAccess(0, hCard);
-
 	return status;
 }
 
@@ -1852,7 +1908,6 @@ WINSCARDAPI LONG WINAPI PCSC_SCardBeginTransaction(SCARDHANDLE hCard)
 
 	status = (LONG) g_PCSC.pfnSCardBeginTransaction(hCard);
 	status = PCSC_MapErrorCodeToWinSCard(status);
-
 	pContext->isTransactionLocked = TRUE;
 	return status;
 }
@@ -1884,9 +1939,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardEndTransaction(SCARDHANDLE hCard, DWORD dwDisp
 
 	status = (LONG) g_PCSC.pfnSCardEndTransaction(hCard, pcsc_dwDisposition);
 	status = PCSC_MapErrorCodeToWinSCard(status);
-
 	pContext->isTransactionLocked = FALSE;
-
 	return status;
 }
 
@@ -1896,7 +1949,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardCancelTransaction(SCARDHANDLE hCard)
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardState(SCARDHANDLE hCard,
-		LPDWORD pdwState, LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen)
+                                        LPDWORD pdwState, LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen)
 {
 	PCSC_DWORD cchReaderLen;
 	SCARDCONTEXT hContext = 0;
@@ -1905,7 +1958,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardState(SCARDHANDLE hCard,
 	PCSC_SCARDHANDLE* pCard = NULL;
 	PCSC_DWORD pcsc_dwState = 0;
 	PCSC_DWORD pcsc_dwProtocol = 0;
-	PCSC_DWORD pcsc_cbAtrLen = (PCSC_DWORD) *pcbAtrLen;
+	PCSC_DWORD pcsc_cbAtrLen = (PCSC_DWORD) * pcbAtrLen;
 
 	if (!g_PCSC.pfnSCardStatus)
 		return SCARD_E_NO_SERVICE;
@@ -1916,7 +1969,6 @@ WINSCARDAPI LONG WINAPI PCSC_SCardState(SCARDHANDLE hCard,
 		return SCARD_E_INVALID_VALUE;
 
 	PCSC_WaitForCardAccess(0, hCard, pCard->shared);
-
 	hContext = PCSC_GetCardContextFromHandle(hCard);
 
 	if (!hContext)
@@ -1924,7 +1976,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardState(SCARDHANDLE hCard,
 
 	cchReaderLen = SCARD_AUTOALLOCATE;
 	status = (LONG) g_PCSC.pfnSCardStatus(hCard, (LPSTR) &mszReaderNames, &cchReaderLen,
-						&pcsc_dwState, &pcsc_dwProtocol, pbAtr, &pcsc_cbAtrLen);
+	                                      &pcsc_dwState, &pcsc_dwProtocol, pbAtr, &pcsc_cbAtrLen);
 	status = PCSC_MapErrorCodeToWinSCard(status);
 
 	if (mszReaderNames)
@@ -1933,13 +1985,12 @@ WINSCARDAPI LONG WINAPI PCSC_SCardState(SCARDHANDLE hCard,
 	*pdwState = (DWORD) pcsc_dwState;
 	*pdwProtocol = PCSC_ConvertProtocolsToWinSCard((DWORD) pcsc_dwProtocol);
 	*pcbAtrLen = (DWORD) pcsc_cbAtrLen;
-
 	return status;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardStatus_Internal(SCARDHANDLE hCard,
-		LPSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
-		LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen)
+        LPSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
+        LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen)
 {
 	SCARDCONTEXT hContext;
 	char* mszReaderNamesWinSCard = NULL;
@@ -1963,7 +2014,6 @@ WINSCARDAPI LONG WINAPI PCSC_SCardStatus_Internal(SCARDHANDLE hCard,
 		return SCARD_E_INVALID_VALUE;
 
 	PCSC_WaitForCardAccess(0, hCard, pCard->shared);
-
 	hContext = PCSC_GetCardContextFromHandle(hCard);
 
 	if (!hContext || !pcchReaderLen || !pdwState || !pdwProtocol || !pcbAtrLen)
@@ -1972,12 +2022,12 @@ WINSCARDAPI LONG WINAPI PCSC_SCardStatus_Internal(SCARDHANDLE hCard,
 	if (*pcchReaderLen == SCARD_AUTOALLOCATE)
 		pcchReaderLenAlloc = TRUE;
 
-	pcsc_cchReaderLen = pcchReaderLenAlloc ? PCSC_SCARD_AUTOALLOCATE : (PCSC_DWORD) *pcchReaderLen;
+	pcsc_cchReaderLen = pcchReaderLenAlloc ? PCSC_SCARD_AUTOALLOCATE : (PCSC_DWORD) * pcchReaderLen;
 
 	if (*pcbAtrLen == SCARD_AUTOALLOCATE)
 		pcbAtrLenAlloc = TRUE;
 
-	pcsc_cbAtrLen = pcbAtrLenAlloc ? PCSC_SCARD_AUTOALLOCATE : (PCSC_DWORD) *pcbAtrLen;
+	pcsc_cbAtrLen = pcbAtrLenAlloc ? PCSC_SCARD_AUTOALLOCATE : (PCSC_DWORD) * pcbAtrLen;
 
 	if ((pcchReaderLenAlloc || pcbAtrLenAlloc) && !g_SCardAutoAllocate)
 	{
@@ -1988,20 +2038,22 @@ WINSCARDAPI LONG WINAPI PCSC_SCardStatus_Internal(SCARDHANDLE hCard,
 			pcsc_cbAtrLen = 0;
 
 		status = (LONG) g_PCSC.pfnSCardStatus(hCard,
-				(pcchReaderLenAlloc) ? NULL : mszReaderNames, &pcsc_cchReaderLen,
-				&pcsc_dwState, &pcsc_dwProtocol,
-				(pcbAtrLenAlloc) ? NULL : pbAtr, &pcsc_cbAtrLen);
+		                                      (pcchReaderLenAlloc) ? NULL : mszReaderNames, &pcsc_cchReaderLen,
+		                                      &pcsc_dwState, &pcsc_dwProtocol,
+		                                      (pcbAtrLenAlloc) ? NULL : pbAtr, &pcsc_cbAtrLen);
 
 		if (status == SCARD_S_SUCCESS)
 		{
 			if (pcchReaderLenAlloc)
 			{
 #ifdef __MACOSX__
+
 				/**
 				* Workaround for SCardStatus Bug in MAC OS X Yosemite
 				*/
 				if (OSXVersion == 0x10100000)
 					pcsc_cchReaderLen++;
+
 #endif
 				*pMszReaderNames = (LPSTR) calloc(1, pcsc_cchReaderLen);
 
@@ -2018,9 +2070,9 @@ WINSCARDAPI LONG WINAPI PCSC_SCardStatus_Internal(SCARDHANDLE hCard,
 			}
 
 			status = (LONG) g_PCSC.pfnSCardStatus(hCard,
-						*pMszReaderNames, &pcsc_cchReaderLen,
-						&pcsc_dwState, &pcsc_dwProtocol,
-						pbAtr, &pcsc_cbAtrLen);
+			                                      *pMszReaderNames, &pcsc_cchReaderLen,
+			                                      &pcsc_dwState, &pcsc_dwProtocol,
+			                                      pbAtr, &pcsc_cbAtrLen);
 
 			if (status != SCARD_S_SUCCESS)
 			{
@@ -2049,7 +2101,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardStatus_Internal(SCARDHANDLE hCard,
 	else
 	{
 		status = (LONG) g_PCSC.pfnSCardStatus(hCard, mszReaderNames, &pcsc_cchReaderLen,
-					&pcsc_dwState, &pcsc_dwProtocol, pbAtr, &pcsc_cbAtrLen);
+		                                      &pcsc_dwState, &pcsc_dwProtocol, pbAtr, &pcsc_cbAtrLen);
 	}
 
 	status = PCSC_MapErrorCodeToWinSCard(status);
@@ -2071,17 +2123,18 @@ WINSCARDAPI LONG WINAPI PCSC_SCardStatus_Internal(SCARDHANDLE hCard,
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardStatusA(SCARDHANDLE hCard,
-		LPSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
-		LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen)
+        LPSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
+        LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen)
 {
 	LONG status = SCARD_S_SUCCESS;
-	status = PCSC_SCardStatus_Internal(hCard, mszReaderNames, pcchReaderLen, pdwState, pdwProtocol, pbAtr, pcbAtrLen);
+	status = PCSC_SCardStatus_Internal(hCard, mszReaderNames, pcchReaderLen, pdwState, pdwProtocol,
+	                                   pbAtr, pcbAtrLen);
 	return status;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardStatusW(SCARDHANDLE hCard,
-		LPWSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
-		LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen)
+        LPWSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
+        LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen)
 {
 	SCARDCONTEXT hContext = 0;
 	LPSTR mszReaderNamesA = NULL;
@@ -2095,11 +2148,13 @@ WINSCARDAPI LONG WINAPI PCSC_SCardStatusW(SCARDHANDLE hCard,
 	if (!hContext)
 		return SCARD_E_INVALID_VALUE;
 
-	status = PCSC_SCardStatus_Internal(hCard, (LPSTR) &mszReaderNamesA, pcchReaderLen, pdwState, pdwProtocol, pbAtr, pcbAtrLen);
+	status = PCSC_SCardStatus_Internal(hCard, (LPSTR) &mszReaderNamesA, pcchReaderLen, pdwState,
+	                                   pdwProtocol, pbAtr, pcbAtrLen);
 
 	if (mszReaderNamesA)
 	{
-		*pcchReaderLen = ConvertToUnicode(CP_UTF8, 0, mszReaderNamesA, *pcchReaderLen, (WCHAR**) mszReaderNames, 0);
+		*pcchReaderLen = ConvertToUnicode(CP_UTF8, 0, mszReaderNamesA, *pcchReaderLen,
+		                                  (WCHAR**) mszReaderNames, 0);
 		PCSC_AddMemoryBlock(hContext, mszReaderNames);
 		PCSC_SCardFreeMemory_Internal(hContext, mszReaderNamesA);
 	}
@@ -2108,8 +2163,8 @@ WINSCARDAPI LONG WINAPI PCSC_SCardStatusW(SCARDHANDLE hCard,
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardTransmit(SCARDHANDLE hCard,
-		LPCSCARD_IO_REQUEST pioSendPci, LPCBYTE pbSendBuffer, DWORD cbSendLength,
-		LPSCARD_IO_REQUEST pioRecvPci, LPBYTE pbRecvBuffer, LPDWORD pcbRecvLength)
+        LPCSCARD_IO_REQUEST pioSendPci, LPCBYTE pbSendBuffer, DWORD cbSendLength,
+        LPSCARD_IO_REQUEST pioRecvPci, LPBYTE pbRecvBuffer, LPDWORD pcbRecvLength)
 {
 	LONG status = SCARD_S_SUCCESS;
 	PCSC_SCARDHANDLE* pCard = NULL;
@@ -2137,7 +2192,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardTransmit(SCARDHANDLE hCard,
 	if (*pcbRecvLength == SCARD_AUTOALLOCATE)
 		return SCARD_E_INVALID_PARAMETER;
 
-	pcsc_cbRecvLength = (PCSC_DWORD) *pcbRecvLength;
+	pcsc_cbRecvLength = (PCSC_DWORD) * pcbRecvLength;
 
 	if (!pioSendPci)
 	{
@@ -2149,7 +2204,8 @@ WINSCARDAPI LONG WINAPI PCSC_SCardTransmit(SCARDHANDLE hCard,
 		 * pcsc-lite cannot have a null pioSendPci parameter, unlike WinSCard.
 		 * Query the current protocol and use default SCARD_IO_REQUEST for it.
 		 */
-		status = (LONG) g_PCSC.pfnSCardStatus(hCard, NULL, &cchReaderLen, &dwState, &dwProtocol, NULL, &cbAtrLen);
+		status = (LONG) g_PCSC.pfnSCardStatus(hCard, NULL, &cchReaderLen, &dwState, &dwProtocol, NULL,
+		                                      &cbAtrLen);
 
 		if (status == SCARD_S_SUCCESS)
 		{
@@ -2184,7 +2240,8 @@ WINSCARDAPI LONG WINAPI PCSC_SCardTransmit(SCARDHANDLE hCard,
 		if (!pcsc_pioRecvPci)
 		{
 			if (pioSendPci)
-				free (pcsc_pioSendPci);
+				free(pcsc_pioSendPci);
+
 			return SCARD_E_NO_MEMORY;
 		}
 
@@ -2196,7 +2253,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardTransmit(SCARDHANDLE hCard,
 	}
 
 	status = (LONG) g_PCSC.pfnSCardTransmit(hCard, pcsc_pioSendPci, pbSendBuffer,
-				pcsc_cbSendLength, pcsc_pioRecvPci, pbRecvBuffer, &pcsc_cbRecvLength);
+	                                        pcsc_cbSendLength, pcsc_pioRecvPci, pbRecvBuffer, &pcsc_cbRecvLength);
 	status = PCSC_MapErrorCodeToWinSCard(status);
 	*pcbRecvLength = (DWORD) pcsc_cbRecvLength;
 
@@ -2218,20 +2275,18 @@ WINSCARDAPI LONG WINAPI PCSC_SCardTransmit(SCARDHANDLE hCard,
 WINSCARDAPI LONG WINAPI PCSC_SCardGetTransmitCount(SCARDHANDLE hCard, LPDWORD pcTransmitCount)
 {
 	PCSC_SCARDHANDLE* pCard = NULL;
-
 	pCard = PCSC_GetCardHandleData(hCard);
 
 	if (!pCard)
 		return SCARD_E_INVALID_VALUE;
 
 	PCSC_WaitForCardAccess(0, hCard, pCard->shared);
-
 	return SCARD_S_SUCCESS;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardControl(SCARDHANDLE hCard,
-		DWORD dwControlCode, LPCVOID lpInBuffer, DWORD cbInBufferSize,
-		LPVOID lpOutBuffer, DWORD cbOutBufferSize, LPDWORD lpBytesReturned)
+        DWORD dwControlCode, LPCVOID lpInBuffer, DWORD cbInBufferSize,
+        LPVOID lpOutBuffer, DWORD cbOutBufferSize, LPDWORD lpBytesReturned)
 {
 	DWORD IoCtlMethod = 0;
 	DWORD IoCtlFunction = 0;
@@ -2254,7 +2309,6 @@ WINSCARDAPI LONG WINAPI PCSC_SCardControl(SCARDHANDLE hCard,
 		return SCARD_E_INVALID_VALUE;
 
 	PCSC_WaitForCardAccess(0, hCard, pCard->shared);
-
 	/**
 	 * PCSCv2 Part 10:
 	 * http://www.pcscworkgroup.com/specifications/files/pcsc10_v2.02.09.pdf
@@ -2265,7 +2319,6 @@ WINSCARDAPI LONG WINAPI PCSC_SCardControl(SCARDHANDLE hCard,
 	 * Converting Windows Feature Request IOCTL code to the pcsc-lite control code:
 	 * http://musclecard.996296.n3.nabble.com/Converting-Windows-Feature-Request-IOCTL-code-to-the-pcsc-lite-control-code-td4906.html
 	 */
-
 	IoCtlMethod = METHOD_FROM_CTL_CODE(dwControlCode);
 	IoCtlFunction = FUNCTION_FROM_CTL_CODE(dwControlCode);
 	IoCtlAccess = ACCESS_FROM_CTL_CODE(dwControlCode);
@@ -2278,11 +2331,9 @@ WINSCARDAPI LONG WINAPI PCSC_SCardControl(SCARDHANDLE hCard,
 		dwControlCode = PCSC_SCARD_CTL_CODE(IoCtlFunction);
 
 	pcsc_dwControlCode = (PCSC_DWORD) dwControlCode;
-
 	status = (LONG) g_PCSC.pfnSCardControl(hCard,
-				pcsc_dwControlCode, lpInBuffer, pcsc_cbInBufferSize,
-				lpOutBuffer, pcsc_cbOutBufferSize, &pcsc_BytesReturned);
-
+	                                       pcsc_dwControlCode, lpInBuffer, pcsc_cbInBufferSize,
+	                                       lpOutBuffer, pcsc_cbOutBufferSize, &pcsc_BytesReturned);
 	status = PCSC_MapErrorCodeToWinSCard(status);
 	*lpBytesReturned = (DWORD) pcsc_BytesReturned;
 
@@ -2307,7 +2358,8 @@ WINSCARDAPI LONG WINAPI PCSC_SCardControl(SCARDHANDLE hCard,
 	return status;
 }
 
-WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib_Internal(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr, LPDWORD pcbAttrLen)
+WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib_Internal(SCARDHANDLE hCard, DWORD dwAttrId,
+        LPBYTE pbAttr, LPDWORD pcbAttrLen)
 {
 	SCARDCONTEXT hContext = 0;
 	BOOL pcbAttrLenAlloc = FALSE;
@@ -2326,7 +2378,6 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib_Internal(SCARDHANDLE hCard, DWORD dw
 		return SCARD_E_INVALID_VALUE;
 
 	PCSC_WaitForCardAccess(0, hCard, pCard->shared);
-
 	hContext = PCSC_GetCardContextFromHandle(hCard);
 
 	if (!hContext)
@@ -2338,7 +2389,7 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib_Internal(SCARDHANDLE hCard, DWORD dw
 	if (*pcbAttrLen == SCARD_AUTOALLOCATE)
 		pcbAttrLenAlloc = TRUE;
 
-	pcsc_cbAttrLen = pcbAttrLenAlloc ? PCSC_SCARD_AUTOALLOCATE : (PCSC_DWORD) *pcbAttrLen;
+	pcsc_cbAttrLen = pcbAttrLenAlloc ? PCSC_SCARD_AUTOALLOCATE : (PCSC_DWORD) * pcbAttrLen;
 
 	if (pcbAttrLenAlloc && !g_SCardAutoAllocate)
 	{
@@ -2373,7 +2424,8 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib_Internal(SCARDHANDLE hCard, DWORD dw
 	return status;
 }
 
-WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib_FriendlyName(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr, LPDWORD pcbAttrLen)
+WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib_FriendlyName(SCARDHANDLE hCard, DWORD dwAttrId,
+        LPBYTE pbAttr, LPDWORD pcbAttrLen)
 {
 	int length = 0;
 	char* namePCSC = NULL;
@@ -2393,18 +2445,21 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib_FriendlyName(SCARDHANDLE hCard, DWOR
 
 	cbAttrLen = *pcbAttrLen;
 	*pcbAttrLen = SCARD_AUTOALLOCATE;
-	status = PCSC_SCardGetAttrib_Internal(hCard, SCARD_ATTR_DEVICE_FRIENDLY_NAME_A, (LPBYTE) &pbAttrA, pcbAttrLen);
+	status = PCSC_SCardGetAttrib_Internal(hCard, SCARD_ATTR_DEVICE_FRIENDLY_NAME_A, (LPBYTE) &pbAttrA,
+	                                      pcbAttrLen);
 
 	if (status != SCARD_S_SUCCESS)
 	{
 		pbAttrA = NULL;
 		*pcbAttrLen = SCARD_AUTOALLOCATE;
-		status = PCSC_SCardGetAttrib_Internal(hCard, SCARD_ATTR_DEVICE_FRIENDLY_NAME_W, (LPBYTE) &pbAttrW, pcbAttrLen);
+		status = PCSC_SCardGetAttrib_Internal(hCard, SCARD_ATTR_DEVICE_FRIENDLY_NAME_W, (LPBYTE) &pbAttrW,
+		                                      pcbAttrLen);
 
 		if (status != SCARD_S_SUCCESS)
 			return status;
 
-		length = ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) pbAttrW, *pcbAttrLen, (char**) &pbAttrA, 0, NULL, NULL);
+		length = ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) pbAttrW, *pcbAttrLen, (char**) &pbAttrA, 0, NULL,
+		                            NULL);
 		namePCSC = pbAttrA;
 		PCSC_SCardFreeMemory_Internal(hContext, pbAttrW);
 	}
@@ -2499,18 +2554,17 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib_FriendlyName(SCARDHANDLE hCard, DWOR
 
 	free(namePCSC);
 	free(nameWinSCard);
-
 	return status;
 }
 
-WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr, LPDWORD pcbAttrLen)
+WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr,
+        LPDWORD pcbAttrLen)
 {
 	DWORD cbAttrLen;
 	SCARDCONTEXT hContext;
 	BOOL pcbAttrLenAlloc = FALSE;
 	LONG status = SCARD_S_SUCCESS;
 	LPBYTE* pPbAttr = (LPBYTE*) pbAttr;
-
 	cbAttrLen = *pcbAttrLen;
 
 	if (*pcbAttrLen == SCARD_AUTOALLOCATE)
@@ -2524,7 +2578,6 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, L
 		 * pcsc-lite returns SCARD_E_INSUFFICIENT_BUFFER if the given
 		 * buffer size is larger than PCSC_MAX_BUFFER_SIZE (264)
 		 */
-
 		if (*pcbAttrLen > PCSC_MAX_BUFFER_SIZE)
 			*pcbAttrLen = PCSC_MAX_BUFFER_SIZE;
 	}
@@ -2534,7 +2587,8 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, L
 	if (!hContext)
 		return SCARD_E_INVALID_HANDLE;
 
-	if ((dwAttrId == SCARD_ATTR_DEVICE_FRIENDLY_NAME_A) || (dwAttrId == SCARD_ATTR_DEVICE_FRIENDLY_NAME_W))
+	if ((dwAttrId == SCARD_ATTR_DEVICE_FRIENDLY_NAME_A) ||
+	    (dwAttrId == SCARD_ATTR_DEVICE_FRIENDLY_NAME_W))
 	{
 		status = PCSC_SCardGetAttrib_FriendlyName(hCard, dwAttrId, pbAttr, pcbAttrLen);
 		return status;
@@ -2574,8 +2628,8 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, L
 				PCSC_DWORD cbAtrLen = 0;
 				PCSC_DWORD dwProtocol = 0;
 				PCSC_DWORD cchReaderLen = 0;
-
-				status = (LONG) g_PCSC.pfnSCardStatus(hCard, NULL, &cchReaderLen, &dwState, &dwProtocol, NULL, &cbAtrLen);
+				status = (LONG) g_PCSC.pfnSCardStatus(hCard, NULL, &cchReaderLen, &dwState, &dwProtocol, NULL,
+				                                      &cbAtrLen);
 
 				if (status == SCARD_S_SUCCESS)
 				{
@@ -2600,7 +2654,6 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, L
 					return SCARD_E_INSUFFICIENT_BUFFER;
 
 				status = SCARD_S_SUCCESS;
-
 				*((DWORD*) pbAttr) = (channelType << 16) | channelNumber;
 				*pcbAttrLen = sizeof(DWORD);
 			}
@@ -2670,7 +2723,8 @@ WINSCARDAPI LONG WINAPI PCSC_SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, L
 	return status;
 }
 
-WINSCARDAPI LONG WINAPI PCSC_SCardSetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPCBYTE pbAttr, DWORD cbAttrLen)
+WINSCARDAPI LONG WINAPI PCSC_SCardSetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPCBYTE pbAttr,
+        DWORD cbAttrLen)
 {
 	LONG status = SCARD_S_SUCCESS;
 	PCSC_SCARDHANDLE* pCard = NULL;
@@ -2686,10 +2740,8 @@ WINSCARDAPI LONG WINAPI PCSC_SCardSetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, L
 		return SCARD_E_INVALID_VALUE;
 
 	PCSC_WaitForCardAccess(0, hCard, pCard->shared);
-
 	status = (LONG) g_PCSC.pfnSCardSetAttrib(hCard, pcsc_dwAttrId, pbAttr, pcsc_cbAttrLen);
 	status = PCSC_MapErrorCodeToWinSCard(status);
-
 	return status;
 }
 
@@ -2719,71 +2771,73 @@ WINSCARDAPI LONG WINAPI PCSC_SCardDlgExtendedError(void)
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardReadCacheA(SCARDCONTEXT hContext,
-		UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD* DataLen)
+        UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD* DataLen)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardReadCacheW(SCARDCONTEXT hContext,
-		UUID* CardIdentifier,  DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD* DataLen)
+        UUID* CardIdentifier,  DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD* DataLen)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardWriteCacheA(SCARDCONTEXT hContext,
-		UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD DataLen)
+        UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD DataLen)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardWriteCacheW(SCARDCONTEXT hContext,
-		UUID* CardIdentifier, DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD DataLen)
+        UUID* CardIdentifier, DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD DataLen)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardGetReaderIconA(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon)
+        LPCSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardGetReaderIconW(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon)
+        LPCWSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon)
 {
 	return 0;
 }
 
-WINSCARDAPI LONG WINAPI PCSC_SCardGetDeviceTypeIdA(SCARDCONTEXT hContext, LPCSTR szReaderName, LPDWORD pdwDeviceTypeId)
+WINSCARDAPI LONG WINAPI PCSC_SCardGetDeviceTypeIdA(SCARDCONTEXT hContext, LPCSTR szReaderName,
+        LPDWORD pdwDeviceTypeId)
 {
 	return 0;
 }
 
-WINSCARDAPI LONG WINAPI PCSC_SCardGetDeviceTypeIdW(SCARDCONTEXT hContext, LPCWSTR szReaderName, LPDWORD pdwDeviceTypeId)
+WINSCARDAPI LONG WINAPI PCSC_SCardGetDeviceTypeIdW(SCARDCONTEXT hContext, LPCWSTR szReaderName,
+        LPDWORD pdwDeviceTypeId)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardGetReaderDeviceInstanceIdA(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId)
+        LPCSTR szReaderName, LPSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardGetReaderDeviceInstanceIdW(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPWSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId)
+        LPCWSTR szReaderName, LPWSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardListReadersWithDeviceInstanceIdA(SCARDCONTEXT hContext,
-		LPCSTR szDeviceInstanceId, LPSTR mszReaders, LPDWORD pcchReaders)
+        LPCSTR szDeviceInstanceId, LPSTR mszReaders, LPDWORD pcchReaders)
 {
 	return 0;
 }
 
 WINSCARDAPI LONG WINAPI PCSC_SCardListReadersWithDeviceInstanceIdW(SCARDCONTEXT hContext,
-		LPCWSTR szDeviceInstanceId, LPWSTR mszReaders, LPDWORD pcchReaders)
+        LPCWSTR szDeviceInstanceId, LPWSTR mszReaders, LPDWORD pcchReaders)
 {
 	return 0;
 }
@@ -2796,98 +2850,115 @@ WINSCARDAPI LONG WINAPI PCSC_SCardAudit(SCARDCONTEXT hContext, DWORD dwEvent)
 #ifdef __MACOSX__
 unsigned int determineMacOSXVersion()
 {
-    int mib[2];
-    size_t len = 0;
-    char *kernelVersion = NULL;
-    char *tok = NULL;
-    unsigned int version = 0;
-    int majorVersion = 0;
-    int minorVersion = 0;
-    int patchVersion = 0;
-    int count = 0;
+	int mib[2];
+	size_t len = 0;
+	char* kernelVersion = NULL;
+	char* tok = NULL;
+	unsigned int version = 0;
+	int majorVersion = 0;
+	int minorVersion = 0;
+	int patchVersion = 0;
+	int count = 0;
+	mib[0] = CTL_KERN;
+	mib[1] = KERN_OSRELEASE;
 
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_OSRELEASE;
-    if (sysctl(mib, 2, NULL, &len, NULL, 0) != 0)
-      return 0;
-    kernelVersion = calloc(len, sizeof(char));
-    if (!kernelVersion)
-      return 0;
-    if (sysctl(mib, 2, kernelVersion, &len, NULL, 0) != 0)
-    {
-      free(kernelVersion);
-      return 0;
-    }
+	if (sysctl(mib, 2, NULL, &len, NULL, 0) != 0)
+		return 0;
 
-    tok = strtok(kernelVersion,".");
-    while (tok)
-    {
-        switch(count)
-        {
-            case 0:
-                majorVersion = atoi(tok);
-                break;
-            case 1:
-                minorVersion = atoi(tok);
-                break;
-            case 2:
-                patchVersion = atoi(tok);
-                break;
-        }
-        tok = strtok(NULL, ".");
-        count++;
-    }
+	kernelVersion = calloc(len, sizeof(char));
 
-    /**
-     * Source : http://en.wikipedia.org/wiki/Darwin_(operating_system)
-     **/
-    if (majorVersion < 5)
-    {
-        if (minorVersion < 4)
-            version = 0x10000000;
-        else
-            version = 0x10010000;
-    }
-    else
-    {
-        switch (majorVersion)
-        {
-            case 5:
-                version = 0x10010000;
-                break;
-            case 6:
-                version = 0x10020000;
-                break;
-            case 7:
-                version = 0x10030000;
-                break;
-            case 8:
-                version = 0x10040000;
-                break;
-            case 9:
-                version = 0x10050000;
-                break;
-            case 10:
-                version = 0x10060000;
-                break;
-            case 11:
-                version = 0x10070000;
-                break;
-            case 12:
-                version = 0x10080000;
-                break;
-            case 13:
-                version = 0x10090000;
-                break;
-            default:
-                version = 0x10100000;
-                break;
-        }
-        version |= (minorVersion << 8) | (patchVersion);
-    }
+	if (!kernelVersion)
+		return 0;
 
-    free(kernelVersion);
-    return version;
+	if (sysctl(mib, 2, kernelVersion, &len, NULL, 0) != 0)
+	{
+		free(kernelVersion);
+		return 0;
+	}
+
+	tok = strtok(kernelVersion, ".");
+
+	while (tok)
+	{
+		switch (count)
+		{
+			case 0:
+				majorVersion = atoi(tok);
+				break;
+
+			case 1:
+				minorVersion = atoi(tok);
+				break;
+
+			case 2:
+				patchVersion = atoi(tok);
+				break;
+		}
+
+		tok = strtok(NULL, ".");
+		count++;
+	}
+
+	/**
+	 * Source : http://en.wikipedia.org/wiki/Darwin_(operating_system)
+	 **/
+	if (majorVersion < 5)
+	{
+		if (minorVersion < 4)
+			version = 0x10000000;
+		else
+			version = 0x10010000;
+	}
+	else
+	{
+		switch (majorVersion)
+		{
+			case 5:
+				version = 0x10010000;
+				break;
+
+			case 6:
+				version = 0x10020000;
+				break;
+
+			case 7:
+				version = 0x10030000;
+				break;
+
+			case 8:
+				version = 0x10040000;
+				break;
+
+			case 9:
+				version = 0x10050000;
+				break;
+
+			case 10:
+				version = 0x10060000;
+				break;
+
+			case 11:
+				version = 0x10070000;
+				break;
+
+			case 12:
+				version = 0x10080000;
+				break;
+
+			case 13:
+				version = 0x10090000;
+				break;
+
+			default:
+				version = 0x10100000;
+				break;
+		}
+
+		version |= (minorVersion << 8) | (patchVersion);
+	}
+
+	free(kernelVersion);
+	return version;
 }
 #endif
 
@@ -2983,17 +3054,19 @@ int PCSC_InitializeSCardApi(void)
 {
 	/* Disable pcsc-lite's (poor) blocking so we can handle it ourselves */
 	SetEnvironmentVariableA("PCSCLITE_NO_BLOCKING", "1");
-
 #ifdef __MACOSX__
 	g_PCSCModule = LoadLibraryA("/System/Library/Frameworks/PCSC.framework/PCSC");
 	OSXVersion = determineMacOSXVersion();
+
 	if (OSXVersion == 0)
 		return -1;
+
 #else
 	g_PCSCModule = LoadLibraryA("libpcsclite.so.1");
 
 	if (!g_PCSCModule)
 		g_PCSCModule = LoadLibraryA("libpcsclite.so");
+
 #endif
 
 	if (!g_PCSCModule)
@@ -3009,23 +3082,22 @@ int PCSC_InitializeSCardApi(void)
 	g_PCSC.pfnSCardEndTransaction = (void*) GetProcAddress(g_PCSCModule, "SCardEndTransaction");
 	g_PCSC.pfnSCardStatus = (void*) GetProcAddress(g_PCSCModule, "SCardStatus");
 	g_PCSC.pfnSCardGetStatusChange = (void*) GetProcAddress(g_PCSCModule, "SCardGetStatusChange");
-
 #ifdef __MACOSX__
+
 	if (OSXVersion >= 0x10050600)
 		g_PCSC.pfnSCardControl = (void*) GetProcAddress(g_PCSCModule, "SCardControl132");
 	else
 		g_PCSC.pfnSCardControl = (void*) GetProcAddress(g_PCSCModule, "SCardControl");
+
 #else
 	g_PCSC.pfnSCardControl = (void*) GetProcAddress(g_PCSCModule, "SCardControl");
 #endif
-
 	g_PCSC.pfnSCardTransmit = (void*) GetProcAddress(g_PCSCModule, "SCardTransmit");
 	g_PCSC.pfnSCardListReaderGroups = (void*) GetProcAddress(g_PCSCModule, "SCardListReaderGroups");
 	g_PCSC.pfnSCardListReaders = (void*) GetProcAddress(g_PCSCModule, "SCardListReaders");
 	g_PCSC.pfnSCardCancel = (void*) GetProcAddress(g_PCSCModule, "SCardCancel");
 	g_PCSC.pfnSCardGetAttrib = (void*) GetProcAddress(g_PCSCModule, "SCardGetAttrib");
 	g_PCSC.pfnSCardSetAttrib = (void*) GetProcAddress(g_PCSCModule, "SCardSetAttrib");
-
 	g_PCSC.pfnSCardFreeMemory = NULL;
 #ifndef __APPLE__
 	g_PCSC.pfnSCardFreeMemory = (void*) GetProcAddress(g_PCSCModule, "SCardFreeMemory");
@@ -3038,11 +3110,9 @@ int PCSC_InitializeSCardApi(void)
 	g_PCSC.pfnSCardFreeMemory = NULL;
 	g_SCardAutoAllocate = FALSE;
 #endif
-
 #ifdef __APPLE__
 	g_PnP_Notification = FALSE;
 #endif
-
 	return 1;
 }
 


### PR DESCRIPTION
Rebased #2749 

Conflicts:
	channels/smartcard/client/smartcard_operations.c
	channels/smartcard/client/smartcard_pack.c
	channels/smartcard/client/smartcard_pack.h

smartcard_operations: move handling of call argument into functions

The call argument was only use by static functions and was always equal
to operation->call. Remove the argument and use operation-call directly.

Also put the memory allocation and check into the same place.

Conflicts:
	channels/smartcard/client/smartcard_operations.c

Updated formatting and API