### PR TITLE
resolve a typo found by cppcheck

### DIFF
--- a/server/Windows/wf_mirage.c
+++ b/server/Windows/wf_mirage.c
@@ -316,7 +316,7 @@ BOOL wf_mirror_driver_cleanup(wfInfo* wfi)
 
 		if (status == 0)
 		{
-			WLog_ERR(TAG, "Failed to release DC!"));
+			WLog_ERR(TAG, "Failed to release DC!");
 		}
 	}
 


### PR DESCRIPTION
[server/Windows/wf_mirage.c:319]: (error) Invalid number of character '(' when these macros are defined: ''.
[server/Windows/wf_mirage.c:319]: (error) Invalid number of character '(' when these macros are defined: 'DFMIRAGE_LEAN'.
[server/Windows/wf_mirage.c:319]: (error) Invalid number of character '(' when these macros are defined: '_WIN64'.