### PR TITLE
Limit the number of client announced monitors

### DIFF
--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -1705,6 +1705,10 @@ BOOL gcc_read_client_monitor_data(wStream* s, rdpMcs* mcs, UINT16 blockLength)
 	Stream_Read_UINT32(s, flags); /* flags */
 	Stream_Read_UINT32(s, monitorCount); /* monitorCount */
 
+	/* 2.2.1.3.6 Client Monitor Data -
+	 * monitorCount (4 bytes): A 32-bit, unsigned integer. The number of display
+	 * monitor definitions in the monitorDefArray field (the maximum allowed is 16).
+	 */
 	if (monitorCount > 16)
 	{
 		WLog_ERR(TAG, "announced monitors(%"PRIu32") exceed the 16 limit", monitorCount);

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -1705,6 +1705,12 @@ BOOL gcc_read_client_monitor_data(wStream* s, rdpMcs* mcs, UINT16 blockLength)
 	Stream_Read_UINT32(s, flags); /* flags */
 	Stream_Read_UINT32(s, monitorCount); /* monitorCount */
 
+	if (monitorCount > 16)
+	{
+		WLog_ERR(TAG, "announced monitors(%"PRIu32") exceed the 16 limit", monitorCount);
+		return FALSE;
+	}
+
 	if (monitorCount > settings->MonitorDefArraySize)
 	{
 		WLog_ERR(TAG, "too many announced monitors(%"PRIu32"), clamping to %"PRIu32"", monitorCount,


### PR DESCRIPTION
The specs says that only 16 are allowed, so let's make that limitation a reality.