### PR TITLE
Misc patches around capabilities

### DIFF
--- a/include/freerdp/peer.h
+++ b/include/freerdp/peer.h
@@ -48,6 +48,7 @@ typedef BOOL (*psPeerPostConnect)(freerdp_peer* peer);
 typedef BOOL (*psPeerActivate)(freerdp_peer* peer);
 typedef BOOL (*psPeerLogon)(freerdp_peer* peer, SEC_WINNT_AUTH_IDENTITY* identity, BOOL automatic);
 typedef BOOL (*psPeerAdjustMonitorsLayout)(freerdp_peer* peer);
+typedef BOOL (*psPeerClientCapabilities)(freerdp_peer* peer);
 
 typedef int (*psPeerSendChannelData)(freerdp_peer* peer, UINT16 channelId, BYTE* data, int size);
 typedef int (*psPeerReceiveChannelData)(freerdp_peer* peer, UINT16 channelId, BYTE* data, int size,
@@ -116,6 +117,7 @@ struct rdp_freerdp_peer
 	psPeerHasMoreToRead HasMoreToRead;
 	psPeerGetEventHandles GetEventHandles;
 	psPeerAdjustMonitorsLayout AdjustMonitorsLayout;
+	psPeerClientCapabilities ClientCapabilities;
 };
 
 #ifdef __cplusplus

--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -74,8 +74,9 @@ static const char* get_capability_name(UINT16 type)
 	return CAPSET_TYPE_STRINGS[type];
 }
 
-static BOOL rdp_print_capability_sets(wStream* s, UINT16 numberCapabilities,
-                                      BOOL receiving);
+#ifdef WITH_DEBUG_CAPABILITIES
+static BOOL rdp_print_capability_sets(wStream* s, UINT16 numberCapabilities, BOOL receiving);
+#endif
 
 /* CODEC_GUID_REMOTEFX: 0x76772F12BD724463AFB3B73C9C6F7886 */
 
@@ -266,6 +267,7 @@ static BOOL rdp_write_general_capability_set(wStream* s, rdpSettings* settings)
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_general_capability_set(wStream* s, UINT16 length)
 {
 	UINT16 osMajorType;
@@ -288,17 +290,13 @@ static BOOL rdp_print_general_capability_set(wStream* s, UINT16 length)
 	Stream_Read_UINT16(s, osMinorType); /* osMinorType (2 bytes) */
 	Stream_Read_UINT16(s, protocolVersion); /* protocolVersion (2 bytes) */
 	Stream_Read_UINT16(s, pad2OctetsA); /* pad2OctetsA (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   generalCompressionTypes); /* generalCompressionTypes (2 bytes) */
+	Stream_Read_UINT16(s, generalCompressionTypes); /* generalCompressionTypes (2 bytes) */
 	Stream_Read_UINT16(s, extraFlags); /* extraFlags (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   updateCapabilityFlag); /* updateCapabilityFlag (2 bytes) */
+	Stream_Read_UINT16(s, updateCapabilityFlag); /* updateCapabilityFlag (2 bytes) */
 	Stream_Read_UINT16(s, remoteUnshareFlag); /* remoteUnshareFlag (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   generalCompressionLevel); /* generalCompressionLevel (2 bytes) */
+	Stream_Read_UINT16(s, generalCompressionLevel); /* generalCompressionLevel (2 bytes) */
 	Stream_Read_UINT8(s, refreshRectSupport); /* refreshRectSupport (1 byte) */
-	Stream_Read_UINT8(s,
-	                  suppressOutputSupport); /* suppressOutputSupport (1 byte) */
+	Stream_Read_UINT8(s, suppressOutputSupport); /* suppressOutputSupport (1 byte) */
 	WLog_INFO(TAG,  "\tosMajorType: 0x%04"PRIX16"", osMajorType);
 	WLog_INFO(TAG,  "\tosMinorType: 0x%04"PRIX16"", osMinorType);
 	WLog_INFO(TAG,  "\tprotocolVersion: 0x%04"PRIX16"", protocolVersion);
@@ -312,6 +310,7 @@ static BOOL rdp_print_general_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\tsuppressOutputSupport: 0x%02"PRIX8"", suppressOutputSupport);
 	return TRUE;
 }
+#endif
 
 /**
  * Read bitmap capability set.\n
@@ -333,8 +332,7 @@ static BOOL rdp_read_bitmap_capability_set(wStream* s, UINT16 length,
 	if (length < 28)
 		return FALSE;
 
-	Stream_Read_UINT16(s,
-	                   preferredBitsPerPixel); /* preferredBitsPerPixel (2 bytes) */
+	Stream_Read_UINT16(s, preferredBitsPerPixel); /* preferredBitsPerPixel (2 bytes) */
 	Stream_Seek_UINT16(s); /* receive1BitPerPixel (2 bytes) */
 	Stream_Seek_UINT16(s); /* receive4BitsPerPixel (2 bytes) */
 	Stream_Seek_UINT16(s); /* receive8BitsPerPixel (2 bytes) */
@@ -365,16 +363,13 @@ static BOOL rdp_read_bitmap_capability_set(wStream* s, UINT16 length,
 	}
 
 	if (settings->DrawAllowSkipAlpha)
-		settings->DrawAllowSkipAlpha = (drawingFlags & DRAW_ALLOW_SKIP_ALPHA) ? TRUE :
-		                               FALSE;
+		settings->DrawAllowSkipAlpha = (drawingFlags & DRAW_ALLOW_SKIP_ALPHA) ? TRUE : FALSE;
 
 	if (settings->DrawAllowDynamicColorFidelity)
-		settings->DrawAllowDynamicColorFidelity = (drawingFlags &
-		        DRAW_ALLOW_DYNAMIC_COLOR_FIDELITY) ? TRUE : FALSE;
+		settings->DrawAllowDynamicColorFidelity = (drawingFlags & DRAW_ALLOW_DYNAMIC_COLOR_FIDELITY) ? TRUE : FALSE;
 
 	if (settings->DrawAllowColorSubsampling)
-		settings->DrawAllowColorSubsampling = (drawingFlags &
-		                                       DRAW_ALLOW_COLOR_SUBSAMPLING) ? TRUE : FALSE;
+		settings->DrawAllowColorSubsampling = (drawingFlags & DRAW_ALLOW_COLOR_SUBSAMPLING) ? TRUE : FALSE;
 
 	return TRUE;
 }
@@ -420,16 +415,14 @@ static BOOL rdp_write_bitmap_capability_set(wStream* s, rdpSettings* settings)
 	else
 		preferredBitsPerPixel = 8;
 
-	Stream_Write_UINT16(s,
-	                    preferredBitsPerPixel); /* preferredBitsPerPixel (2 bytes) */
+	Stream_Write_UINT16(s, preferredBitsPerPixel); /* preferredBitsPerPixel (2 bytes) */
 	Stream_Write_UINT16(s, 1); /* receive1BitPerPixel (2 bytes) */
 	Stream_Write_UINT16(s, 1); /* receive4BitsPerPixel (2 bytes) */
 	Stream_Write_UINT16(s, 1); /* receive8BitsPerPixel (2 bytes) */
 	Stream_Write_UINT16(s, settings->DesktopWidth); /* desktopWidth (2 bytes) */
 	Stream_Write_UINT16(s, settings->DesktopHeight); /* desktopHeight (2 bytes) */
 	Stream_Write_UINT16(s, 0); /* pad2Octets (2 bytes) */
-	Stream_Write_UINT16(s,
-	                    settings->DesktopResize); /* desktopResizeFlag (2 bytes) */
+	Stream_Write_UINT16(s, settings->DesktopResize); /* desktopResizeFlag (2 bytes) */
 	Stream_Write_UINT16(s, 1); /* bitmapCompressionFlag (2 bytes) */
 	Stream_Write_UINT8(s, 0); /* highColorFlags (1 byte) */
 	Stream_Write_UINT8(s, drawingFlags); /* drawingFlags (1 byte) */
@@ -439,6 +432,7 @@ static BOOL rdp_write_bitmap_capability_set(wStream* s, rdpSettings* settings)
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_bitmap_capability_set(wStream* s, UINT16 length)
 {
 	UINT16 preferredBitsPerPixel;
@@ -459,23 +453,18 @@ static BOOL rdp_print_bitmap_capability_set(wStream* s, UINT16 length)
 	if (length < 28)
 		return FALSE;
 
-	Stream_Read_UINT16(s,
-	                   preferredBitsPerPixel); /* preferredBitsPerPixel (2 bytes) */
+	Stream_Read_UINT16(s, preferredBitsPerPixel); /* preferredBitsPerPixel (2 bytes) */
 	Stream_Read_UINT16(s, receive1BitPerPixel); /* receive1BitPerPixel (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   receive4BitsPerPixel); /* receive4BitsPerPixel (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   receive8BitsPerPixel); /* receive8BitsPerPixel (2 bytes) */
+	Stream_Read_UINT16(s, receive4BitsPerPixel); /* receive4BitsPerPixel (2 bytes) */
+	Stream_Read_UINT16(s, receive8BitsPerPixel); /* receive8BitsPerPixel (2 bytes) */
 	Stream_Read_UINT16(s, desktopWidth); /* desktopWidth (2 bytes) */
 	Stream_Read_UINT16(s, desktopHeight); /* desktopHeight (2 bytes) */
 	Stream_Read_UINT16(s, pad2Octets); /* pad2Octets (2 bytes) */
 	Stream_Read_UINT16(s, desktopResizeFlag); /* desktopResizeFlag (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   bitmapCompressionFlag); /* bitmapCompressionFlag (2 bytes) */
+	Stream_Read_UINT16(s, bitmapCompressionFlag); /* bitmapCompressionFlag (2 bytes) */
 	Stream_Read_UINT8(s, highColorFlags); /* highColorFlags (1 byte) */
 	Stream_Read_UINT8(s, drawingFlags); /* drawingFlags (1 byte) */
-	Stream_Read_UINT16(s,
-	                   multipleRectangleSupport); /* multipleRectangleSupport (2 bytes) */
+	Stream_Read_UINT16(s, multipleRectangleSupport); /* multipleRectangleSupport (2 bytes) */
 	Stream_Read_UINT16(s, pad2OctetsB); /* pad2OctetsB (2 bytes) */
 	WLog_INFO(TAG,  "\tpreferredBitsPerPixel: 0x%04"PRIX16"", preferredBitsPerPixel);
 	WLog_INFO(TAG,  "\treceive1BitPerPixel: 0x%04"PRIX16"", receive1BitPerPixel);
@@ -492,6 +481,7 @@ static BOOL rdp_print_bitmap_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\tpad2OctetsB: 0x%04"PRIX16"", pad2OctetsB);
 	return TRUE;
 }
+#endif
 
 /**
  * Read order capability set.\n
@@ -618,6 +608,7 @@ static BOOL rdp_write_order_capability_set(wStream* s, rdpSettings* settings)
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_order_capability_set(wStream* s, UINT16 length)
 {
 	BYTE terminalDescriptor[16];
@@ -644,10 +635,8 @@ static BOOL rdp_print_order_capability_set(wStream* s, UINT16 length)
 
 	Stream_Read(s, terminalDescriptor, 16); /* terminalDescriptor (16 bytes) */
 	Stream_Read_UINT32(s, pad4OctetsA); /* pad4OctetsA (4 bytes) */
-	Stream_Read_UINT16(s,
-	                   desktopSaveXGranularity); /* desktopSaveXGranularity (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   desktopSaveYGranularity); /* desktopSaveYGranularity (2 bytes) */
+	Stream_Read_UINT16(s, desktopSaveXGranularity); /* desktopSaveXGranularity (2 bytes) */
+	Stream_Read_UINT16(s, desktopSaveYGranularity); /* desktopSaveYGranularity (2 bytes) */
 	Stream_Read_UINT16(s, pad2OctetsA); /* pad2OctetsA (2 bytes) */
 	Stream_Read_UINT16(s, maximumOrderLevel); /* maximumOrderLevel (2 bytes) */
 	Stream_Read_UINT16(s, numberFonts); /* numberFonts (2 bytes) */
@@ -678,8 +667,7 @@ static BOOL rdp_print_order_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\t\tAEXTTEXTOUT: %"PRIu8"", orderSupport[NEG_AEXTTEXTOUT_INDEX]);
 	WLog_INFO(TAG,  "\t\tDRAWNINEGRID: %"PRIu8"", orderSupport[NEG_DRAWNINEGRID_INDEX]);
 	WLog_INFO(TAG,  "\t\tLINETO: %"PRIu8"", orderSupport[NEG_LINETO_INDEX]);
-	WLog_INFO(TAG,  "\t\tMULTI_DRAWNINEGRID: %"PRIu8"",
-	          orderSupport[NEG_MULTI_DRAWNINEGRID_INDEX]);
+	WLog_INFO(TAG,  "\t\tMULTI_DRAWNINEGRID: %"PRIu8"", orderSupport[NEG_MULTI_DRAWNINEGRID_INDEX]);
 	WLog_INFO(TAG,  "\t\tOPAQUE_RECT: %"PRIu8"", orderSupport[NEG_OPAQUE_RECT_INDEX]);
 	WLog_INFO(TAG,  "\t\tSAVEBITMAP: %"PRIu8"", orderSupport[NEG_SAVEBITMAP_INDEX]);
 	WLog_INFO(TAG,  "\t\tWTEXTOUT: %"PRIu8"", orderSupport[NEG_WTEXTOUT_INDEX]);
@@ -688,8 +676,7 @@ static BOOL rdp_print_order_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\t\tMULTIDSTBLT: %"PRIu8"", orderSupport[NEG_MULTIDSTBLT_INDEX]);
 	WLog_INFO(TAG,  "\t\tMULTIPATBLT: %"PRIu8"", orderSupport[NEG_MULTIPATBLT_INDEX]);
 	WLog_INFO(TAG,  "\t\tMULTISCRBLT: %"PRIu8"", orderSupport[NEG_MULTISCRBLT_INDEX]);
-	WLog_INFO(TAG,  "\t\tMULTIOPAQUERECT: %"PRIu8"",
-	          orderSupport[NEG_MULTIOPAQUERECT_INDEX]);
+	WLog_INFO(TAG,  "\t\tMULTIOPAQUERECT: %"PRIu8"", orderSupport[NEG_MULTIOPAQUERECT_INDEX]);
 	WLog_INFO(TAG,  "\t\tFAST_INDEX: %"PRIu8"", orderSupport[NEG_FAST_INDEX_INDEX]);
 	WLog_INFO(TAG,  "\t\tPOLYGON_SC: %"PRIu8"", orderSupport[NEG_POLYGON_SC_INDEX]);
 	WLog_INFO(TAG,  "\t\tPOLYGON_CB: %"PRIu8"", orderSupport[NEG_POLYGON_CB_INDEX]);
@@ -699,12 +686,9 @@ static BOOL rdp_print_order_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\t\tELLIPSE_SC: %"PRIu8"", orderSupport[NEG_ELLIPSE_SC_INDEX]);
 	WLog_INFO(TAG,  "\t\tELLIPSE_CB: %"PRIu8"", orderSupport[NEG_ELLIPSE_CB_INDEX]);
 	WLog_INFO(TAG,  "\t\tGLYPH_INDEX: %"PRIu8"", orderSupport[NEG_GLYPH_INDEX_INDEX]);
-	WLog_INFO(TAG,  "\t\tGLYPH_WEXTTEXTOUT: %"PRIu8"",
-	          orderSupport[NEG_GLYPH_WEXTTEXTOUT_INDEX]);
-	WLog_INFO(TAG,  "\t\tGLYPH_WLONGTEXTOUT: %"PRIu8"",
-	          orderSupport[NEG_GLYPH_WLONGTEXTOUT_INDEX]);
-	WLog_INFO(TAG,  "\t\tGLYPH_WLONGEXTTEXTOUT: %"PRIu8"",
-	          orderSupport[NEG_GLYPH_WLONGEXTTEXTOUT_INDEX]);
+	WLog_INFO(TAG,  "\t\tGLYPH_WEXTTEXTOUT: %"PRIu8"", orderSupport[NEG_GLYPH_WEXTTEXTOUT_INDEX]);
+	WLog_INFO(TAG,  "\t\tGLYPH_WLONGTEXTOUT: %"PRIu8"", orderSupport[NEG_GLYPH_WLONGTEXTOUT_INDEX]);
+	WLog_INFO(TAG,  "\t\tGLYPH_WLONGEXTTEXTOUT: %"PRIu8"", orderSupport[NEG_GLYPH_WLONGEXTTEXTOUT_INDEX]);
 	WLog_INFO(TAG,  "\t\tUNUSED31: %"PRIu8"", orderSupport[NEG_UNUSED31_INDEX]);
 	WLog_INFO(TAG,  "\ttextFlags: 0x%04"PRIX16"", textFlags);
 	WLog_INFO(TAG,  "\torderSupportExFlags: 0x%04"PRIX16"", orderSupportExFlags);
@@ -716,6 +700,7 @@ static BOOL rdp_print_order_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\tpad2OctetsE: 0x%04"PRIX16"", pad2OctetsE);
 	return TRUE;
 }
+#endif
 
 /**
  * Read bitmap cache capability set.\n
@@ -784,6 +769,7 @@ static BOOL rdp_write_bitmap_cache_capability_set(wStream* s,
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_bitmap_cache_capability_set(wStream* s, UINT16 length)
 {
 	UINT32 pad1, pad2, pad3;
@@ -806,14 +792,11 @@ static BOOL rdp_print_bitmap_cache_capability_set(wStream* s, UINT16 length)
 	Stream_Read_UINT32(s, pad5); /* pad5 (4 bytes) */
 	Stream_Read_UINT32(s, pad6); /* pad6 (4 bytes) */
 	Stream_Read_UINT16(s, Cache0Entries); /* Cache0Entries (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   Cache0MaximumCellSize); /* Cache0MaximumCellSize (2 bytes) */
+	Stream_Read_UINT16(s, Cache0MaximumCellSize); /* Cache0MaximumCellSize (2 bytes) */
 	Stream_Read_UINT16(s, Cache1Entries); /* Cache1Entries (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   Cache1MaximumCellSize); /* Cache1MaximumCellSize (2 bytes) */
+	Stream_Read_UINT16(s, Cache1MaximumCellSize); /* Cache1MaximumCellSize (2 bytes) */
 	Stream_Read_UINT16(s, Cache2Entries); /* Cache2Entries (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   Cache2MaximumCellSize); /* Cache2MaximumCellSize (2 bytes) */
+	Stream_Read_UINT16(s, Cache2MaximumCellSize); /* Cache2MaximumCellSize (2 bytes) */
 	WLog_INFO(TAG,  "\tpad1: 0x%08"PRIX32"", pad1);
 	WLog_INFO(TAG,  "\tpad2: 0x%08"PRIX32"", pad2);
 	WLog_INFO(TAG,  "\tpad3: 0x%08"PRIX32"", pad3);
@@ -828,6 +811,7 @@ static BOOL rdp_print_bitmap_cache_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\tCache2MaximumCellSize: 0x%04"PRIX16"", Cache2MaximumCellSize);
 	return TRUE;
 }
+#endif
 
 /**
  * Read control capability set.\n
@@ -873,6 +857,7 @@ static BOOL rdp_write_control_capability_set(wStream* s, rdpSettings* settings)
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_control_capability_set(wStream* s, UINT16 length)
 {
 	UINT16 controlFlags;
@@ -894,6 +879,7 @@ static BOOL rdp_print_control_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\tdetachInterest: 0x%04"PRIX16"", detachInterest);
 	return TRUE;
 }
+#endif
 
 /**
  * Read window activation capability set.\n
@@ -940,6 +926,7 @@ static BOOL rdp_write_window_activation_capability_set(wStream* s,
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_window_activation_capability_set(wStream* s,
         UINT16 length)
 {
@@ -955,14 +942,14 @@ static BOOL rdp_print_window_activation_capability_set(wStream* s,
 	Stream_Read_UINT16(s, helpKeyFlag); /* helpKeyFlag (2 bytes) */
 	Stream_Read_UINT16(s, helpKeyIndexFlag); /* helpKeyIndexFlag (2 bytes) */
 	Stream_Read_UINT16(s, helpExtendedKeyFlag); /* helpExtendedKeyFlag (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   windowManagerKeyFlag); /* windowManagerKeyFlag (2 bytes) */
+	Stream_Read_UINT16(s, windowManagerKeyFlag); /* windowManagerKeyFlag (2 bytes) */
 	WLog_INFO(TAG,  "\thelpKeyFlag: 0x%04"PRIX16"", helpKeyFlag);
 	WLog_INFO(TAG,  "\thelpKeyIndexFlag: 0x%04"PRIX16"", helpKeyIndexFlag);
 	WLog_INFO(TAG,  "\thelpExtendedKeyFlag: 0x%04"PRIX16"", helpExtendedKeyFlag);
 	WLog_INFO(TAG,  "\twindowManagerKeyFlag: 0x%04"PRIX16"", windowManagerKeyFlag);
 	return TRUE;
 }
+#endif
 
 /**
  * Read pointer capability set.\n
@@ -1021,19 +1008,18 @@ static BOOL rdp_write_pointer_capability_set(wStream* s, rdpSettings* settings)
 	header = rdp_capability_set_start(s);
 	colorPointerFlag = (settings->ColorPointerFlag) ? 1 : 0;
 	Stream_Write_UINT16(s, colorPointerFlag); /* colorPointerFlag (2 bytes) */
-	Stream_Write_UINT16(s,
-	                    settings->PointerCacheSize); /* colorPointerCacheSize (2 bytes) */
+	Stream_Write_UINT16(s, settings->PointerCacheSize); /* colorPointerCacheSize (2 bytes) */
 
 	if (settings->LargePointerFlag)
 	{
-		Stream_Write_UINT16(s,
-		                    settings->PointerCacheSize); /* pointerCacheSize (2 bytes) */
+		Stream_Write_UINT16(s, settings->PointerCacheSize); /* pointerCacheSize (2 bytes) */
 	}
 
 	rdp_capability_set_finish(s, header, CAPSET_TYPE_POINTER);
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_pointer_capability_set(wStream* s, UINT16 length)
 {
 	UINT16 colorPointerFlag;
@@ -1045,14 +1031,14 @@ static BOOL rdp_print_pointer_capability_set(wStream* s, UINT16 length)
 
 	WLog_INFO(TAG,  "PointerCapabilitySet (length %"PRIu16"):", length);
 	Stream_Read_UINT16(s, colorPointerFlag); /* colorPointerFlag (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   colorPointerCacheSize); /* colorPointerCacheSize (2 bytes) */
+	Stream_Read_UINT16(s, colorPointerCacheSize); /* colorPointerCacheSize (2 bytes) */
 	Stream_Read_UINT16(s, pointerCacheSize); /* pointerCacheSize (2 bytes) */
 	WLog_INFO(TAG,  "\tcolorPointerFlag: 0x%04"PRIX16"", colorPointerFlag);
 	WLog_INFO(TAG,  "\tcolorPointerCacheSize: 0x%04"PRIX16"", colorPointerCacheSize);
 	WLog_INFO(TAG,  "\tpointerCacheSize: 0x%04"PRIX16"", pointerCacheSize);
 	return TRUE;
 }
+#endif
 
 /**
  * Read share capability set.\n
@@ -1096,6 +1082,7 @@ static BOOL rdp_write_share_capability_set(wStream* s, rdpSettings* settings)
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_share_capability_set(wStream* s, UINT16 length)
 {
 	UINT16 nodeId;
@@ -1111,6 +1098,7 @@ static BOOL rdp_print_share_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\tpad2Octets: 0x%04"PRIX16"", pad2Octets);
 	return TRUE;
 }
+#endif
 
 /**
  * Read color cache capability set.\n
@@ -1153,6 +1141,7 @@ static BOOL rdp_write_color_cache_capability_set(wStream* s,
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_color_cache_capability_set(wStream* s, UINT16 length)
 {
 	UINT16 colorTableCacheSize;
@@ -1168,6 +1157,7 @@ static BOOL rdp_print_color_cache_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\tpad2Octets: 0x%04"PRIX16"", pad2Octets);
 	return TRUE;
 }
+#endif
 
 /**
  * Read sound capability set.\n
@@ -1214,6 +1204,7 @@ static BOOL rdp_write_sound_capability_set(wStream* s, rdpSettings* settings)
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_sound_capability_set(wStream* s, UINT16 length)
 {
 	UINT16 soundFlags;
@@ -1229,6 +1220,7 @@ static BOOL rdp_print_sound_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\tpad2OctetsA: 0x%04"PRIX16"", pad2OctetsA);
 	return TRUE;
 }
+#endif
 
 /**
  * Read input capability set.\n
@@ -1253,10 +1245,8 @@ static BOOL rdp_read_input_capability_set(wStream* s, UINT16 length,
 	{
 		Stream_Read_UINT32(s, settings->KeyboardLayout); /* keyboardLayout (4 bytes) */
 		Stream_Read_UINT32(s, settings->KeyboardType); /* keyboardType (4 bytes) */
-		Stream_Read_UINT32(s,
-		                   settings->KeyboardSubType); /* keyboardSubType (4 bytes) */
-		Stream_Read_UINT32(s,
-		                   settings->KeyboardFunctionKey); /* keyboardFunctionKeys (4 bytes) */
+		Stream_Read_UINT32(s, settings->KeyboardSubType); /* keyboardSubType (4 bytes) */
+		Stream_Read_UINT32(s, settings->KeyboardFunctionKey); /* keyboardFunctionKeys (4 bytes) */
 	}
 	else
 	{
@@ -1322,15 +1312,14 @@ static BOOL rdp_write_input_capability_set(wStream* s, rdpSettings* settings)
 	Stream_Write_UINT16(s, 0); /* pad2OctetsA (2 bytes) */
 	Stream_Write_UINT32(s, settings->KeyboardLayout); /* keyboardLayout (4 bytes) */
 	Stream_Write_UINT32(s, settings->KeyboardType); /* keyboardType (4 bytes) */
-	Stream_Write_UINT32(s,
-	                    settings->KeyboardSubType); /* keyboardSubType (4 bytes) */
-	Stream_Write_UINT32(s,
-	                    settings->KeyboardFunctionKey); /* keyboardFunctionKeys (4 bytes) */
+	Stream_Write_UINT32(s, settings->KeyboardSubType); /* keyboardSubType (4 bytes) */
+	Stream_Write_UINT32(s, settings->KeyboardFunctionKey); /* keyboardFunctionKeys (4 bytes) */
 	Stream_Zero(s, 64); /* imeFileName (64 bytes) */
 	rdp_capability_set_finish(s, header, CAPSET_TYPE_INPUT);
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_input_capability_set(wStream* s, UINT16 length)
 {
 	UINT16 inputFlags;
@@ -1359,6 +1348,7 @@ static BOOL rdp_print_input_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\tkeyboardFunctionKey: 0x%08"PRIX32"", keyboardFunctionKey);
 	return TRUE;
 }
+#endif
 
 /**
  * Read font capability set.\n
@@ -1401,6 +1391,7 @@ static BOOL rdp_write_font_capability_set(wStream* s, rdpSettings* settings)
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_font_capability_set(wStream* s, UINT16 length)
 {
 	UINT16 fontSupportFlags = 0;
@@ -1417,6 +1408,7 @@ static BOOL rdp_print_font_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\tpad2Octets: 0x%04"PRIX16"", pad2Octets);
 	return TRUE;
 }
+#endif
 
 /**
  * Read brush capability set.
@@ -1456,6 +1448,7 @@ static BOOL rdp_write_brush_capability_set(wStream* s, rdpSettings* settings)
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_brush_capability_set(wStream* s, UINT16 length)
 {
 	UINT32 brushSupportLevel;
@@ -1468,6 +1461,7 @@ static BOOL rdp_print_brush_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\tbrushSupportLevel: 0x%08"PRIX32"", brushSupportLevel);
 	return TRUE;
 }
+#endif
 
 /**
  * Read cache definition (glyph).\n
@@ -1477,10 +1471,8 @@ static BOOL rdp_print_brush_capability_set(wStream* s, UINT16 length)
 static void rdp_read_cache_definition(wStream* s,
                                       GLYPH_CACHE_DEFINITION* cache_definition)
 {
-	Stream_Read_UINT16(s,
-	                   cache_definition->cacheEntries); /* cacheEntries (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   cache_definition->cacheMaximumCellSize); /* cacheMaximumCellSize (2 bytes) */
+	Stream_Read_UINT16(s, cache_definition->cacheEntries); /* cacheEntries (2 bytes) */
+	Stream_Read_UINT16(s, cache_definition->cacheMaximumCellSize); /* cacheMaximumCellSize (2 bytes) */
 }
 
 /**
@@ -1491,10 +1483,8 @@ static void rdp_read_cache_definition(wStream* s,
 static void rdp_write_cache_definition(wStream* s,
                                        GLYPH_CACHE_DEFINITION* cache_definition)
 {
-	Stream_Write_UINT16(s,
-	                    cache_definition->cacheEntries); /* cacheEntries (2 bytes) */
-	Stream_Write_UINT16(s,
-	                    cache_definition->cacheMaximumCellSize); /* cacheMaximumCellSize (2 bytes) */
+	Stream_Write_UINT16(s, cache_definition->cacheEntries); /* cacheEntries (2 bytes) */
+	Stream_Write_UINT16(s, cache_definition->cacheMaximumCellSize); /* cacheMaximumCellSize (2 bytes) */
 }
 
 /**
@@ -1512,29 +1502,18 @@ static BOOL rdp_read_glyph_cache_capability_set(wStream* s, UINT16 length,
 		return FALSE;
 
 	/* glyphCache (40 bytes) */
-	rdp_read_cache_definition(s,
-	                          &(settings->GlyphCache[0])); /* glyphCache0 (4 bytes) */
-	rdp_read_cache_definition(s,
-	                          &(settings->GlyphCache[1])); /* glyphCache1 (4 bytes) */
-	rdp_read_cache_definition(s,
-	                          &(settings->GlyphCache[2])); /* glyphCache2 (4 bytes) */
-	rdp_read_cache_definition(s,
-	                          &(settings->GlyphCache[3])); /* glyphCache3 (4 bytes) */
-	rdp_read_cache_definition(s,
-	                          &(settings->GlyphCache[4])); /* glyphCache4 (4 bytes) */
-	rdp_read_cache_definition(s,
-	                          &(settings->GlyphCache[5])); /* glyphCache5 (4 bytes) */
-	rdp_read_cache_definition(s,
-	                          &(settings->GlyphCache[6])); /* glyphCache6 (4 bytes) */
-	rdp_read_cache_definition(s,
-	                          &(settings->GlyphCache[7])); /* glyphCache7 (4 bytes) */
-	rdp_read_cache_definition(s,
-	                          &(settings->GlyphCache[8])); /* glyphCache8 (4 bytes) */
-	rdp_read_cache_definition(s,
-	                          &(settings->GlyphCache[9])); /* glyphCache9 (4 bytes) */
+	rdp_read_cache_definition(s, &(settings->GlyphCache[0])); /* glyphCache0 (4 bytes) */
+	rdp_read_cache_definition(s, &(settings->GlyphCache[1])); /* glyphCache1 (4 bytes) */
+	rdp_read_cache_definition(s, &(settings->GlyphCache[2])); /* glyphCache2 (4 bytes) */
+	rdp_read_cache_definition(s, &(settings->GlyphCache[3])); /* glyphCache3 (4 bytes) */
+	rdp_read_cache_definition(s, &(settings->GlyphCache[4])); /* glyphCache4 (4 bytes) */
+	rdp_read_cache_definition(s, &(settings->GlyphCache[5])); /* glyphCache5 (4 bytes) */
+	rdp_read_cache_definition(s, &(settings->GlyphCache[6])); /* glyphCache6 (4 bytes) */
+	rdp_read_cache_definition(s, &(settings->GlyphCache[7])); /* glyphCache7 (4 bytes) */
+	rdp_read_cache_definition(s, &(settings->GlyphCache[8])); /* glyphCache8 (4 bytes) */
+	rdp_read_cache_definition(s, &(settings->GlyphCache[9])); /* glyphCache9 (4 bytes) */
 	rdp_read_cache_definition(s, settings->FragCache);  /* fragCache (4 bytes) */
-	Stream_Read_UINT16(s,
-	                   settings->GlyphSupportLevel); /* glyphSupportLevel (2 bytes) */
+	Stream_Read_UINT16(s, settings->GlyphSupportLevel); /* glyphSupportLevel (2 bytes) */
 	Stream_Seek_UINT16(s); /* pad2Octets (2 bytes) */
 	return TRUE;
 }
@@ -1556,34 +1535,24 @@ static BOOL rdp_write_glyph_cache_capability_set(wStream* s,
 
 	header = rdp_capability_set_start(s);
 	/* glyphCache (40 bytes) */
-	rdp_write_cache_definition(s,
-	                           &(settings->GlyphCache[0])); /* glyphCache0 (4 bytes) */
-	rdp_write_cache_definition(s,
-	                           &(settings->GlyphCache[1])); /* glyphCache1 (4 bytes) */
-	rdp_write_cache_definition(s,
-	                           &(settings->GlyphCache[2])); /* glyphCache2 (4 bytes) */
-	rdp_write_cache_definition(s,
-	                           &(settings->GlyphCache[3])); /* glyphCache3 (4 bytes) */
-	rdp_write_cache_definition(s,
-	                           &(settings->GlyphCache[4])); /* glyphCache4 (4 bytes) */
-	rdp_write_cache_definition(s,
-	                           &(settings->GlyphCache[5])); /* glyphCache5 (4 bytes) */
-	rdp_write_cache_definition(s,
-	                           &(settings->GlyphCache[6])); /* glyphCache6 (4 bytes) */
-	rdp_write_cache_definition(s,
-	                           &(settings->GlyphCache[7])); /* glyphCache7 (4 bytes) */
-	rdp_write_cache_definition(s,
-	                           &(settings->GlyphCache[8])); /* glyphCache8 (4 bytes) */
-	rdp_write_cache_definition(s,
-	                           &(settings->GlyphCache[9])); /* glyphCache9 (4 bytes) */
+	rdp_write_cache_definition(s, &(settings->GlyphCache[0])); /* glyphCache0 (4 bytes) */
+	rdp_write_cache_definition(s, &(settings->GlyphCache[1])); /* glyphCache1 (4 bytes) */
+	rdp_write_cache_definition(s, &(settings->GlyphCache[2])); /* glyphCache2 (4 bytes) */
+	rdp_write_cache_definition(s, &(settings->GlyphCache[3])); /* glyphCache3 (4 bytes) */
+	rdp_write_cache_definition(s, &(settings->GlyphCache[4])); /* glyphCache4 (4 bytes) */
+	rdp_write_cache_definition(s, &(settings->GlyphCache[5])); /* glyphCache5 (4 bytes) */
+	rdp_write_cache_definition(s, &(settings->GlyphCache[6])); /* glyphCache6 (4 bytes) */
+	rdp_write_cache_definition(s, &(settings->GlyphCache[7])); /* glyphCache7 (4 bytes) */
+	rdp_write_cache_definition(s, &(settings->GlyphCache[8])); /* glyphCache8 (4 bytes) */
+	rdp_write_cache_definition(s, &(settings->GlyphCache[9])); /* glyphCache9 (4 bytes) */
 	rdp_write_cache_definition(s, settings->FragCache);  /* fragCache (4 bytes) */
-	Stream_Write_UINT16(s,
-	                    settings->GlyphSupportLevel); /* glyphSupportLevel (2 bytes) */
+	Stream_Write_UINT16(s, settings->GlyphSupportLevel); /* glyphSupportLevel (2 bytes) */
 	Stream_Write_UINT16(s, 0); /* pad2Octets (2 bytes) */
 	rdp_capability_set_finish(s, header, CAPSET_TYPE_GLYPH_CACHE);
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_glyph_cache_capability_set(wStream* s, UINT16 length)
 {
 	GLYPH_CACHE_DEFINITION glyphCache[10];
@@ -1635,6 +1604,7 @@ static BOOL rdp_print_glyph_cache_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\tpad2Octets: 0x%04"PRIX16"", pad2Octets);
 	return TRUE;
 }
+#endif
 
 /**
  * Read offscreen bitmap cache capability set.\n
@@ -1652,12 +1622,9 @@ static BOOL rdp_read_offscreen_bitmap_cache_capability_set(wStream* s,
 	if (length < 12)
 		return FALSE;
 
-	Stream_Read_UINT32(s,
-	                   offscreenSupportLevel); /* offscreenSupportLevel (4 bytes) */
-	Stream_Read_UINT16(s,
-	                   settings->OffscreenCacheSize); /* offscreenCacheSize (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   settings->OffscreenCacheEntries); /* offscreenCacheEntries (2 bytes) */
+	Stream_Read_UINT32(s, offscreenSupportLevel); /* offscreenSupportLevel (4 bytes) */
+	Stream_Read_UINT16(s, settings->OffscreenCacheSize); /* offscreenCacheSize (2 bytes) */
+	Stream_Read_UINT16(s, settings->OffscreenCacheEntries); /* offscreenCacheEntries (2 bytes) */
 
 	if (offscreenSupportLevel & TRUE)
 		settings->OffscreenSupportLevel = TRUE;
@@ -1686,16 +1653,14 @@ static BOOL rdp_write_offscreen_bitmap_cache_capability_set(wStream* s,
 	if (settings->OffscreenSupportLevel)
 		offscreenSupportLevel = TRUE;
 
-	Stream_Write_UINT32(s,
-	                    offscreenSupportLevel); /* offscreenSupportLevel (4 bytes) */
-	Stream_Write_UINT16(s,
-	                    settings->OffscreenCacheSize); /* offscreenCacheSize (2 bytes) */
-	Stream_Write_UINT16(s,
-	                    settings->OffscreenCacheEntries); /* offscreenCacheEntries (2 bytes) */
+	Stream_Write_UINT32(s, offscreenSupportLevel); /* offscreenSupportLevel (4 bytes) */
+	Stream_Write_UINT16(s, settings->OffscreenCacheSize); /* offscreenCacheSize (2 bytes) */
+	Stream_Write_UINT16(s, settings->OffscreenCacheEntries); /* offscreenCacheEntries (2 bytes) */
 	rdp_capability_set_finish(s, header, CAPSET_TYPE_OFFSCREEN_CACHE);
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_offscreen_bitmap_cache_capability_set(wStream* s,
         UINT16 length)
 {
@@ -1707,16 +1672,15 @@ static BOOL rdp_print_offscreen_bitmap_cache_capability_set(wStream* s,
 	if (length < 12)
 		return FALSE;
 
-	Stream_Read_UINT32(s,
-	                   offscreenSupportLevel); /* offscreenSupportLevel (4 bytes) */
+	Stream_Read_UINT32(s, offscreenSupportLevel); /* offscreenSupportLevel (4 bytes) */
 	Stream_Read_UINT16(s, offscreenCacheSize); /* offscreenCacheSize (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   offscreenCacheEntries); /* offscreenCacheEntries (2 bytes) */
+	Stream_Read_UINT16(s, offscreenCacheEntries); /* offscreenCacheEntries (2 bytes) */
 	WLog_INFO(TAG,  "\toffscreenSupportLevel: 0x%08"PRIX32"", offscreenSupportLevel);
 	WLog_INFO(TAG,  "\toffscreenCacheSize: 0x%04"PRIX16"", offscreenCacheSize);
 	WLog_INFO(TAG,  "\toffscreenCacheEntries: 0x%04"PRIX16"", offscreenCacheEntries);
 	return TRUE;
 }
+#endif
 
 /**
  * Read bitmap cache host support capability set.\n
@@ -1767,6 +1731,7 @@ static BOOL rdp_write_bitmap_cache_host_support_capability_set(wStream* s,
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_bitmap_cache_host_support_capability_set(wStream* s,
         UINT16 length)
 {
@@ -1787,8 +1752,7 @@ static BOOL rdp_print_bitmap_cache_host_support_capability_set(wStream* s,
 	return TRUE;
 }
 
-static void rdp_read_bitmap_cache_cell_info(wStream* s,
-        BITMAP_CACHE_V2_CELL_INFO* cellInfo)
+static void rdp_read_bitmap_cache_cell_info(wStream* s, BITMAP_CACHE_V2_CELL_INFO* cellInfo)
 {
 	UINT32 info;
 	/**
@@ -1799,6 +1763,7 @@ static void rdp_read_bitmap_cache_cell_info(wStream* s,
 	cellInfo->numEntries = (info & 0x7FFFFFFF);
 	cellInfo->persistent = (info & 0x80000000) ? 1 : 0;
 }
+#endif
 
 static void rdp_write_bitmap_cache_cell_info(wStream* s,
         BITMAP_CACHE_V2_CELL_INFO* cellInfo)
@@ -1864,21 +1829,17 @@ static BOOL rdp_write_bitmap_cache_v2_capability_set(wStream* s,
 	Stream_Write_UINT8(s, 0); /* pad2 (1 byte) */
 	Stream_Write_UINT8(s,
 	                   settings->BitmapCacheV2NumCells); /* numCellCaches (1 byte) */
-	rdp_write_bitmap_cache_cell_info(s,
-	                                 &settings->BitmapCacheV2CellInfo[0]); /* bitmapCache0CellInfo (4 bytes) */
-	rdp_write_bitmap_cache_cell_info(s,
-	                                 &settings->BitmapCacheV2CellInfo[1]); /* bitmapCache1CellInfo (4 bytes) */
-	rdp_write_bitmap_cache_cell_info(s,
-	                                 &settings->BitmapCacheV2CellInfo[2]); /* bitmapCache2CellInfo (4 bytes) */
-	rdp_write_bitmap_cache_cell_info(s,
-	                                 &settings->BitmapCacheV2CellInfo[3]); /* bitmapCache3CellInfo (4 bytes) */
-	rdp_write_bitmap_cache_cell_info(s,
-	                                 &settings->BitmapCacheV2CellInfo[4]); /* bitmapCache4CellInfo (4 bytes) */
+	rdp_write_bitmap_cache_cell_info(s, &settings->BitmapCacheV2CellInfo[0]); /* bitmapCache0CellInfo (4 bytes) */
+	rdp_write_bitmap_cache_cell_info(s, &settings->BitmapCacheV2CellInfo[1]); /* bitmapCache1CellInfo (4 bytes) */
+	rdp_write_bitmap_cache_cell_info(s, &settings->BitmapCacheV2CellInfo[2]); /* bitmapCache2CellInfo (4 bytes) */
+	rdp_write_bitmap_cache_cell_info(s, &settings->BitmapCacheV2CellInfo[3]); /* bitmapCache3CellInfo (4 bytes) */
+	rdp_write_bitmap_cache_cell_info(s, &settings->BitmapCacheV2CellInfo[4]); /* bitmapCache4CellInfo (4 bytes) */
 	Stream_Zero(s, 12); /* pad3 (12 bytes) */
 	rdp_capability_set_finish(s, header, CAPSET_TYPE_BITMAP_CACHE_V2);
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_bitmap_cache_v2_capability_set(wStream* s, UINT16 length)
 {
 	UINT16 cacheFlags;
@@ -1893,16 +1854,11 @@ static BOOL rdp_print_bitmap_cache_v2_capability_set(wStream* s, UINT16 length)
 	Stream_Read_UINT16(s, cacheFlags); /* cacheFlags (2 bytes) */
 	Stream_Read_UINT8(s, pad2); /* pad2 (1 byte) */
 	Stream_Read_UINT8(s, numCellCaches); /* numCellCaches (1 byte) */
-	rdp_read_bitmap_cache_cell_info(s,
-	                                &bitmapCacheV2CellInfo[0]); /* bitmapCache0CellInfo (4 bytes) */
-	rdp_read_bitmap_cache_cell_info(s,
-	                                &bitmapCacheV2CellInfo[1]); /* bitmapCache1CellInfo (4 bytes) */
-	rdp_read_bitmap_cache_cell_info(s,
-	                                &bitmapCacheV2CellInfo[2]); /* bitmapCache2CellInfo (4 bytes) */
-	rdp_read_bitmap_cache_cell_info(s,
-	                                &bitmapCacheV2CellInfo[3]); /* bitmapCache3CellInfo (4 bytes) */
-	rdp_read_bitmap_cache_cell_info(s,
-	                                &bitmapCacheV2CellInfo[4]); /* bitmapCache4CellInfo (4 bytes) */
+	rdp_read_bitmap_cache_cell_info(s, &bitmapCacheV2CellInfo[0]); /* bitmapCache0CellInfo (4 bytes) */
+	rdp_read_bitmap_cache_cell_info(s, &bitmapCacheV2CellInfo[1]); /* bitmapCache1CellInfo (4 bytes) */
+	rdp_read_bitmap_cache_cell_info(s, &bitmapCacheV2CellInfo[2]); /* bitmapCache2CellInfo (4 bytes) */
+	rdp_read_bitmap_cache_cell_info(s, &bitmapCacheV2CellInfo[3]); /* bitmapCache3CellInfo (4 bytes) */
+	rdp_read_bitmap_cache_cell_info(s, &bitmapCacheV2CellInfo[4]); /* bitmapCache4CellInfo (4 bytes) */
 	Stream_Seek(s, 12); /* pad3 (12 bytes) */
 	WLog_INFO(TAG,  "\tcacheFlags: 0x%04"PRIX16"", cacheFlags);
 	WLog_INFO(TAG,  "\tpad2: 0x%02"PRIX8"", pad2);
@@ -1919,6 +1875,7 @@ static BOOL rdp_print_bitmap_cache_v2_capability_set(wStream* s, UINT16 length)
 	          bitmapCacheV2CellInfo[4].numEntries, bitmapCacheV2CellInfo[4].persistent);
 	return TRUE;
 }
+#endif
 
 /**
  * Read virtual channel capability set.\n
@@ -1975,6 +1932,7 @@ static BOOL rdp_write_virtual_channel_capability_set(wStream* s,
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_virtual_channel_capability_set(wStream* s, UINT16 length)
 {
 	UINT32 flags;
@@ -1995,6 +1953,7 @@ static BOOL rdp_print_virtual_channel_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\tVCChunkSize: 0x%08"PRIX32"", VCChunkSize);
 	return TRUE;
 }
+#endif
 
 /**
  * Read drawn nine grid cache capability set.\n
@@ -2012,12 +1971,9 @@ static BOOL rdp_read_draw_nine_grid_cache_capability_set(wStream* s,
 	if (length < 12)
 		return FALSE;
 
-	Stream_Read_UINT32(s,
-	                   drawNineGridSupportLevel); /* drawNineGridSupportLevel (4 bytes) */
-	Stream_Read_UINT16(s,
-	                   settings->DrawNineGridCacheSize); /* drawNineGridCacheSize (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   settings->DrawNineGridCacheEntries); /* drawNineGridCacheEntries (2 bytes) */
+	Stream_Read_UINT32(s, drawNineGridSupportLevel); /* drawNineGridSupportLevel (4 bytes) */
+	Stream_Read_UINT16(s, settings->DrawNineGridCacheSize); /* drawNineGridCacheSize (2 bytes) */
+	Stream_Read_UINT16(s, settings->DrawNineGridCacheEntries); /* drawNineGridCacheEntries (2 bytes) */
 
 	if ((drawNineGridSupportLevel & DRAW_NINEGRID_SUPPORTED) ||
 	    (drawNineGridSupportLevel & DRAW_NINEGRID_SUPPORTED_V2))
@@ -2045,12 +2001,9 @@ static BOOL rdp_write_draw_nine_grid_cache_capability_set(wStream* s,
 	header = rdp_capability_set_start(s);
 	drawNineGridSupportLevel = (settings->DrawNineGridEnabled) ?
 	                           DRAW_NINEGRID_SUPPORTED_V2 : DRAW_NINEGRID_NO_SUPPORT;
-	Stream_Write_UINT32(s,
-	                    drawNineGridSupportLevel); /* drawNineGridSupportLevel (4 bytes) */
-	Stream_Write_UINT16(s,
-	                    settings->DrawNineGridCacheSize); /* drawNineGridCacheSize (2 bytes) */
-	Stream_Write_UINT16(s,
-	                    settings->DrawNineGridCacheEntries); /* drawNineGridCacheEntries (2 bytes) */
+	Stream_Write_UINT32(s, drawNineGridSupportLevel); /* drawNineGridSupportLevel (4 bytes) */
+	Stream_Write_UINT16(s, settings->DrawNineGridCacheSize); /* drawNineGridCacheSize (2 bytes) */
+	Stream_Write_UINT16(s, settings->DrawNineGridCacheEntries); /* drawNineGridCacheEntries (2 bytes) */
 	rdp_capability_set_finish(s, header, CAPSET_TYPE_DRAW_NINE_GRID_CACHE);
 	return TRUE;
 }
@@ -2083,6 +2036,7 @@ static void rdp_write_gdiplus_image_cache_properties(wStream* s, UINT16 oiccs,
 	Stream_Write_UINT16(s, oicms); /* gdipObjectImageCacheMaxSize (2 bytes) */
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_draw_nine_grid_cache_capability_set(wStream* s,
         UINT16 length)
 {
@@ -2094,14 +2048,12 @@ static BOOL rdp_print_draw_nine_grid_cache_capability_set(wStream* s,
 	if (length < 12)
 		return FALSE;
 
-	Stream_Read_UINT32(s,
-	                   drawNineGridSupportLevel); /* drawNineGridSupportLevel (4 bytes) */
-	Stream_Read_UINT16(s,
-	                   DrawNineGridCacheSize); /* drawNineGridCacheSize (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   DrawNineGridCacheEntries); /* drawNineGridCacheEntries (2 bytes) */
+	Stream_Read_UINT32(s, drawNineGridSupportLevel); /* drawNineGridSupportLevel (4 bytes) */
+	Stream_Read_UINT16(s, DrawNineGridCacheSize); /* drawNineGridCacheSize (2 bytes) */
+	Stream_Read_UINT16(s, DrawNineGridCacheEntries); /* drawNineGridCacheEntries (2 bytes) */
 	return TRUE;
 }
+#endif
 
 /**
  * Read GDI+ cache capability set.\n
@@ -2120,11 +2072,9 @@ static BOOL rdp_read_draw_gdiplus_cache_capability_set(wStream* s,
 	if (length < 40)
 		return FALSE;
 
-	Stream_Read_UINT32(s,
-	                   drawGDIPlusSupportLevel); /* drawGDIPlusSupportLevel (4 bytes) */
+	Stream_Read_UINT32(s, drawGDIPlusSupportLevel); /* drawGDIPlusSupportLevel (4 bytes) */
 	Stream_Seek_UINT32(s); /* GdipVersion (4 bytes) */
-	Stream_Read_UINT32(s,
-	                   drawGdiplusCacheLevel); /* drawGdiplusCacheLevel (4 bytes) */
+	Stream_Read_UINT32(s, drawGdiplusCacheLevel); /* drawGdiplusCacheLevel (4 bytes) */
 	Stream_Seek(s, 10); /* GdipCacheEntries (10 bytes) */
 	Stream_Seek(s, 8); /* GdipCacheChunkSize (8 bytes) */
 	Stream_Seek(s, 6); /* GdipImageCacheProperties (6 bytes) */
@@ -2160,21 +2110,17 @@ static BOOL rdp_write_draw_gdiplus_cache_capability_set(wStream* s,
 	                          DRAW_GDIPLUS_SUPPORTED : DRAW_GDIPLUS_DEFAULT;
 	drawGdiplusCacheLevel = (settings->DrawGdiPlusEnabled) ?
 	                        DRAW_GDIPLUS_CACHE_LEVEL_ONE : DRAW_GDIPLUS_CACHE_LEVEL_DEFAULT;
-	Stream_Write_UINT32(s,
-	                    drawGDIPlusSupportLevel); /* drawGDIPlusSupportLevel (4 bytes) */
+	Stream_Write_UINT32(s, drawGDIPlusSupportLevel); /* drawGDIPlusSupportLevel (4 bytes) */
 	Stream_Write_UINT32(s, 0); /* GdipVersion (4 bytes) */
-	Stream_Write_UINT32(s,
-	                    drawGdiplusCacheLevel); /* drawGdiplusCacheLevel (4 bytes) */
-	rdp_write_gdiplus_cache_entries(s, 10, 5, 5, 10,
-	                                2); /* GdipCacheEntries (10 bytes) */
-	rdp_write_gdiplus_cache_chunk_size(s, 512, 2048, 1024,
-	                                   64); /* GdipCacheChunkSize (8 bytes) */
-	rdp_write_gdiplus_image_cache_properties(s, 4096, 256,
-	        128); /* GdipImageCacheProperties (6 bytes) */
+	Stream_Write_UINT32(s, drawGdiplusCacheLevel); /* drawGdiplusCacheLevel (4 bytes) */
+	rdp_write_gdiplus_cache_entries(s, 10, 5, 5, 10, 2); /* GdipCacheEntries (10 bytes) */
+	rdp_write_gdiplus_cache_chunk_size(s, 512, 2048, 1024, 64); /* GdipCacheChunkSize (8 bytes) */
+	rdp_write_gdiplus_image_cache_properties(s, 4096, 256, 128); /* GdipImageCacheProperties (6 bytes) */
 	rdp_capability_set_finish(s, header, CAPSET_TYPE_DRAW_GDI_PLUS);
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_draw_gdiplus_cache_capability_set(wStream* s,
         UINT16 length)
 {
@@ -2186,16 +2132,15 @@ static BOOL rdp_print_draw_gdiplus_cache_capability_set(wStream* s,
 	if (length < 40)
 		return FALSE;
 
-	Stream_Read_UINT32(s,
-	                   drawGdiPlusSupportLevel); /* drawGdiPlusSupportLevel (4 bytes) */
+	Stream_Read_UINT32(s, drawGdiPlusSupportLevel); /* drawGdiPlusSupportLevel (4 bytes) */
 	Stream_Read_UINT32(s, GdipVersion); /* GdipVersion (4 bytes) */
-	Stream_Read_UINT32(s,
-	                   drawGdiplusCacheLevel); /* drawGdiPlusCacheLevel (4 bytes) */
+	Stream_Read_UINT32(s, drawGdiplusCacheLevel); /* drawGdiPlusCacheLevel (4 bytes) */
 	Stream_Seek(s, 10); /* GdipCacheEntries (10 bytes) */
 	Stream_Seek(s, 8); /* GdipCacheChunkSize (8 bytes) */
 	Stream_Seek(s, 6); /* GdipImageCacheProperties (6 bytes) */
 	return TRUE;
 }
+#endif
 
 /**
  * Read remote programs capability set.\n
@@ -2254,6 +2199,7 @@ static BOOL rdp_write_remote_programs_capability_set(wStream* s,
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_remote_programs_capability_set(wStream* s, UINT16 length)
 {
 	UINT32 railSupportLevel;
@@ -2266,6 +2212,7 @@ static BOOL rdp_print_remote_programs_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\trailSupportLevel: 0x%08"PRIX32"", railSupportLevel);
 	return TRUE;
 }
+#endif
 
 /**
  * Read window list capability set.\n
@@ -2306,14 +2253,13 @@ static BOOL rdp_write_window_list_capability_set(wStream* s,
 	header = rdp_capability_set_start(s);
 	wndSupportLevel = WINDOW_LEVEL_SUPPORTED_EX;
 	Stream_Write_UINT32(s, wndSupportLevel); /* wndSupportLevel (4 bytes) */
-	Stream_Write_UINT8(s,
-	                   settings->RemoteAppNumIconCaches); /* numIconCaches (1 byte) */
-	Stream_Write_UINT16(s,
-	                    settings->RemoteAppNumIconCacheEntries); /* numIconCacheEntries (2 bytes) */
+	Stream_Write_UINT8(s, settings->RemoteAppNumIconCaches); /* numIconCaches (1 byte) */
+	Stream_Write_UINT16(s, settings->RemoteAppNumIconCacheEntries); /* numIconCacheEntries (2 bytes) */
 	rdp_capability_set_finish(s, header, CAPSET_TYPE_WINDOW);
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_window_list_capability_set(wStream* s, UINT16 length)
 {
 	UINT32 wndSupportLevel;
@@ -2332,6 +2278,7 @@ static BOOL rdp_print_window_list_capability_set(wStream* s, UINT16 length)
 	WLog_INFO(TAG,  "\tnumIconCacheEntries: 0x%04"PRIX16"", numIconCacheEntries);
 	return TRUE;
 }
+#endif
 
 /**
  * Read desktop composition capability set.\n
@@ -2370,12 +2317,12 @@ static BOOL rdp_write_desktop_composition_capability_set(wStream* s,
 	header = rdp_capability_set_start(s);
 	compDeskSupportLevel = (settings->AllowDesktopComposition) ?
 	                       COMPDESK_SUPPORTED : COMPDESK_NOT_SUPPORTED;
-	Stream_Write_UINT16(s,
-	                    compDeskSupportLevel); /* compDeskSupportLevel (2 bytes) */
+	Stream_Write_UINT16(s, compDeskSupportLevel); /* compDeskSupportLevel (2 bytes) */
 	rdp_capability_set_finish(s, header, CAPSET_TYPE_COMP_DESK);
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_desktop_composition_capability_set(wStream* s,
         UINT16 length)
 {
@@ -2385,11 +2332,11 @@ static BOOL rdp_print_desktop_composition_capability_set(wStream* s,
 	if (length < 6)
 		return FALSE;
 
-	Stream_Read_UINT16(s,
-	                   compDeskSupportLevel); /* compDeskSupportLevel (2 bytes) */
+	Stream_Read_UINT16(s, compDeskSupportLevel); /* compDeskSupportLevel (2 bytes) */
 	WLog_INFO(TAG,  "\tcompDeskSupportLevel: 0x%04"PRIX16"", compDeskSupportLevel);
 	return TRUE;
 }
+#endif
 
 /**
  * Read multifragment update capability set.\n
@@ -2498,12 +2445,12 @@ static BOOL rdp_write_multifragment_update_capability_set(wStream* s,
 	}
 
 	header = rdp_capability_set_start(s);
-	Stream_Write_UINT32(s,
-	                    settings->MultifragMaxRequestSize); /* MaxRequestSize (4 bytes) */
+	Stream_Write_UINT32(s, settings->MultifragMaxRequestSize); /* MaxRequestSize (4 bytes) */
 	rdp_capability_set_finish(s, header, CAPSET_TYPE_MULTI_FRAGMENT_UPDATE);
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_multifragment_update_capability_set(wStream* s,
         UINT16 length)
 {
@@ -2517,6 +2464,7 @@ static BOOL rdp_print_multifragment_update_capability_set(wStream* s,
 	WLog_INFO(TAG,  "\tmaxRequestSize: 0x%08"PRIX32"", maxRequestSize);
 	return TRUE;
 }
+#endif
 
 /**
  * Read large pointer capability set.\n
@@ -2534,8 +2482,7 @@ static BOOL rdp_read_large_pointer_capability_set(wStream* s, UINT16 length,
 	if (length < 6)
 		return FALSE;
 
-	Stream_Read_UINT16(s,
-	                   largePointerSupportFlags); /* largePointerSupportFlags (2 bytes) */
+	Stream_Read_UINT16(s, largePointerSupportFlags); /* largePointerSupportFlags (2 bytes) */
 	settings->LargePointerFlag = (largePointerSupportFlags &
 	                              LARGE_POINTER_FLAG_96x96) ? 1 : 0;
 	return TRUE;
@@ -2548,8 +2495,7 @@ static BOOL rdp_read_large_pointer_capability_set(wStream* s, UINT16 length,
  * @param settings settings
  */
 
-static BOOL rdp_write_large_pointer_capability_set(wStream* s,
-        rdpSettings* settings)
+static BOOL rdp_write_large_pointer_capability_set(wStream* s, rdpSettings* settings)
 {
 	int header;
 	UINT16 largePointerSupportFlags;
@@ -2558,14 +2504,13 @@ static BOOL rdp_write_large_pointer_capability_set(wStream* s,
 		return FALSE;
 
 	header = rdp_capability_set_start(s);
-	largePointerSupportFlags = (settings->LargePointerFlag) ?
-	                           LARGE_POINTER_FLAG_96x96 : 0;
-	Stream_Write_UINT16(s,
-	                    largePointerSupportFlags); /* largePointerSupportFlags (2 bytes) */
+	largePointerSupportFlags = (settings->LargePointerFlag) ? LARGE_POINTER_FLAG_96x96 : 0;
+	Stream_Write_UINT16(s, largePointerSupportFlags); /* largePointerSupportFlags (2 bytes) */
 	rdp_capability_set_finish(s, header, CAPSET_TYPE_LARGE_POINTER);
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_large_pointer_capability_set(wStream* s, UINT16 length)
 {
 	UINT16 largePointerSupportFlags;
@@ -2574,11 +2519,11 @@ static BOOL rdp_print_large_pointer_capability_set(wStream* s, UINT16 length)
 	if (length < 6)
 		return FALSE;
 
-	Stream_Read_UINT16(s,
-	                   largePointerSupportFlags); /* largePointerSupportFlags (2 bytes) */
+	Stream_Read_UINT16(s, largePointerSupportFlags); /* largePointerSupportFlags (2 bytes) */
 	WLog_INFO(TAG,  "\tlargePointerSupportFlags: 0x%04"PRIX16"", largePointerSupportFlags);
 	return TRUE;
 }
+#endif
 
 /**
  * Read surface commands capability set.\n
@@ -2632,6 +2577,7 @@ static BOOL rdp_write_surface_commands_capability_set(wStream* s,
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_surface_commands_capability_set(wStream* s, UINT16 length)
 {
 	UINT32 cmdFlags;
@@ -2648,6 +2594,7 @@ static BOOL rdp_print_surface_commands_capability_set(wStream* s, UINT16 length)
 	return TRUE;
 }
 
+
 static void rdp_print_bitmap_codec_guid(const GUID* guid)
 {
 	WLog_INFO(TAG,  "%08"PRIX32"%04"PRIX16"%04"PRIX16"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"%02"PRIX8"",
@@ -2655,6 +2602,7 @@ static void rdp_print_bitmap_codec_guid(const GUID* guid)
 	          guid->Data4[0], guid->Data4[1], guid->Data4[2], guid->Data4[3],
 	          guid->Data4[4], guid->Data4[5], guid->Data4[6], guid->Data4[7]);
 }
+
 
 static char* rdp_get_bitmap_codec_guid_name(const GUID* guid)
 {
@@ -2673,7 +2621,7 @@ static char* rdp_get_bitmap_codec_guid_name(const GUID* guid)
 
 	return "CODEC_GUID_UNKNOWN";
 }
-
+#endif
 
 static void rdp_read_bitmap_codec_guid(wStream* s, GUID* guid)
 {
@@ -2748,8 +2696,7 @@ static BOOL rdp_read_bitmap_codecs_capability_set(wStream* s, UINT16 length,
 
 		rdp_read_bitmap_codec_guid(s, &codecGuid); /* codecGuid (16 bytes) */
 		Stream_Read_UINT8(s, codecId); /* codecId (1 byte) */
-		Stream_Read_UINT16(s,
-		                   codecPropertiesLength); /* codecPropertiesLength (2 bytes) */
+		Stream_Read_UINT16(s, codecPropertiesLength); /* codecPropertiesLength (2 bytes) */
 		remainingLength -= 19;
 
 		if (remainingLength < codecPropertiesLength)
@@ -2868,8 +2815,7 @@ static BOOL rdp_read_bitmap_codecs_capability_set(wStream* s, UINT16 length,
 				BYTE fAllowDynamicFidelity;
 				guidNSCodec = TRUE;
 				settings->NSCodecId = codecId;
-				Stream_Read_UINT8(s,
-				                  fAllowDynamicFidelity); /* fAllowDynamicFidelity (1 byte) */
+				Stream_Read_UINT8(s, fAllowDynamicFidelity); /* fAllowDynamicFidelity (1 byte) */
 				Stream_Read_UINT8(s, fAllowSubsampling); /* fAllowSubsampling (1 byte) */
 				Stream_Read_UINT8(s, colorLossLevel); /* colorLossLevel (1 byte) */
 
@@ -2915,8 +2861,7 @@ static BOOL rdp_read_bitmap_codecs_capability_set(wStream* s, UINT16 length,
 	{
 		/* only enable a codec if we've announced/enabled it before */
 		settings->RemoteFxCodec = settings->RemoteFxCodec && guidRemoteFx;
-		settings->RemoteFxImageCodec = settings->RemoteFxImageCodec
-		                               && guidRemoteFxImage;
+		settings->RemoteFxImageCodec = settings->RemoteFxImageCodec && guidRemoteFxImage;
 		settings->NSCodec = settings->NSCodec && guidNSCodec;
 		settings->JpegCodec = FALSE;
 	}
@@ -3177,6 +3122,7 @@ static BOOL rdp_write_bitmap_codecs_capability_set(wStream* s,
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_bitmap_codecs_capability_set(wStream* s, UINT16 length)
 {
 	GUID codecGuid;
@@ -3219,6 +3165,7 @@ static BOOL rdp_print_bitmap_codecs_capability_set(wStream* s, UINT16 length)
 
 	return TRUE;
 }
+#endif
 
 /**
  * Read frame acknowledge capability set.\n
@@ -3265,6 +3212,7 @@ static BOOL rdp_write_frame_acknowledge_capability_set(wStream* s,
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_frame_acknowledge_capability_set(wStream* s,
         UINT16 length)
 {
@@ -3278,6 +3226,7 @@ static BOOL rdp_print_frame_acknowledge_capability_set(wStream* s,
 	WLog_INFO(TAG,  "\tframeAcknowledge: 0x%08"PRIX32"", frameAcknowledge);
 	return TRUE;
 }
+#endif
 
 static BOOL rdp_read_bitmap_cache_v3_codec_id_capability_set(wStream* s,
         UINT16 length, rdpSettings* settings)
@@ -3305,6 +3254,7 @@ static BOOL rdp_write_bitmap_cache_v3_codec_id_capability_set(wStream* s,
 	return TRUE;
 }
 
+#ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_bitmap_cache_v3_codec_id_capability_set(wStream* s,
         UINT16 length)
 {
@@ -3532,6 +3482,7 @@ static BOOL rdp_print_capability_sets(wStream* s, UINT16 numberCapabilities,
 
 	return TRUE;
 }
+#endif
 
 static BOOL rdp_read_capability_sets(wStream* s, rdpSettings* settings,
                                      UINT16 numberCapabilities)
@@ -3835,7 +3786,7 @@ BOOL rdp_recv_get_active_header(rdpRdp* rdp, wStream* s, UINT16* pChannelId)
 
 		if ((mcsMessageChannelId == 0) || (*pChannelId != mcsMessageChannelId))
 		{
-			WLog_ERR(TAG,  "unexpected MCS channel id %04"PRIx16" received", *pChannelId);
+			WLog_ERR(TAG, "unexpected MCS channel id %04"PRIx16" received", *pChannelId);
 			return FALSE;
 		}
 	}
@@ -3892,10 +3843,8 @@ BOOL rdp_recv_demand_active(rdpRdp* rdp, wStream* s)
 		return FALSE;
 
 	Stream_Read_UINT32(s, rdp->settings->ShareId); /* shareId (4 bytes) */
-	Stream_Read_UINT16(s,
-	                   lengthSourceDescriptor); /* lengthSourceDescriptor (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   lengthCombinedCapabilities); /* lengthCombinedCapabilities (2 bytes) */
+	Stream_Read_UINT16(s, lengthSourceDescriptor); /* lengthSourceDescriptor (2 bytes) */
+	Stream_Read_UINT16(s, lengthCombinedCapabilities); /* lengthCombinedCapabilities (2 bytes) */
 
 	if (!Stream_SafeSeek(s, lengthSourceDescriptor)
 	    || Stream_GetRemainingLength(s) < 4) /* sourceDescriptor */
@@ -4009,10 +3958,8 @@ BOOL rdp_recv_confirm_active(rdpRdp* rdp, wStream* s)
 
 	Stream_Seek_UINT32(s); /* shareId (4 bytes) */
 	Stream_Seek_UINT16(s); /* originatorId (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   lengthSourceDescriptor); /* lengthSourceDescriptor (2 bytes) */
-	Stream_Read_UINT16(s,
-	                   lengthCombinedCapabilities); /* lengthCombinedCapabilities (2 bytes) */
+	Stream_Read_UINT16(s, lengthSourceDescriptor); /* lengthSourceDescriptor (2 bytes) */
+	Stream_Read_UINT16(s, lengthCombinedCapabilities); /* lengthCombinedCapabilities (2 bytes) */
 
 	if (((int) Stream_GetRemainingLength(s)) < lengthSourceDescriptor + 4)
 		return FALSE;
@@ -4078,8 +4025,7 @@ BOOL rdp_write_confirm_active(wStream* s, rdpSettings* settings)
 	                    lengthSourceDescriptor);/* lengthSourceDescriptor (2 bytes) */
 	lm = Stream_GetPosition(s);
 	Stream_Seek_UINT16(s); /* lengthCombinedCapabilities (2 bytes) */
-	Stream_Write(s, SOURCE_DESCRIPTOR,
-	             lengthSourceDescriptor); /* sourceDescriptor */
+	Stream_Write(s, SOURCE_DESCRIPTOR, lengthSourceDescriptor); /* sourceDescriptor */
 	bm = Stream_GetPosition(s);
 	Stream_Seek_UINT16(s); /* numberCapabilities (2 bytes) */
 	Stream_Write_UINT16(s, 0); /* pad2Octets (2 bytes) */
@@ -4199,8 +4145,7 @@ BOOL rdp_write_confirm_active(wStream* s, rdpSettings* settings)
 	em = Stream_GetPosition(s);
 	Stream_SetPosition(s, lm); /* go back to lengthCombinedCapabilities */
 	lengthCombinedCapabilities = (em - bm);
-	Stream_Write_UINT16(s,
-	                    lengthCombinedCapabilities); /* lengthCombinedCapabilities (2 bytes) */
+	Stream_Write_UINT16(s, lengthCombinedCapabilities); /* lengthCombinedCapabilities (2 bytes) */
 	Stream_SetPosition(s, bm); /* go back to numberCapabilities */
 	Stream_Write_UINT16(s, numberCapabilities); /* numberCapabilities (2 bytes) */
 #ifdef WITH_DEBUG_CAPABILITIES

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -1145,10 +1145,15 @@ BOOL rdp_server_accept_mcs_channel_join_request(rdpRdp* rdp, wStream* s)
 
 BOOL rdp_server_accept_confirm_active(rdpRdp* rdp, wStream* s)
 {
+	freerdp_peer *peer = rdp->context->peer;
+
 	if (rdp->state != CONNECTION_STATE_CAPABILITIES_EXCHANGE)
 		return FALSE;
 
 	if (!rdp_recv_confirm_active(rdp, s))
+		return FALSE;
+
+	if (peer->ClientCapabilities && !peer->ClientCapabilities(peer))
 		return FALSE;
 
 	if (rdp->settings->SaltedChecksum)


### PR DESCRIPTION
This PR : 

* removes some warning;
* tries to reformat some parts of the code that have become ugly with the usage of --max-code-length in astyle;
* it adds the very useful ClientCapabilities callback;