### PR TITLE
resolve compiler warning

### DIFF
--- a/channels/cliprdr/client/cliprdr_main.c
+++ b/channels/cliprdr/client/cliprdr_main.c
@@ -118,6 +118,7 @@ static UINT cliprdr_packet_send(cliprdrPlugin* cliprdr, wStream* s)
 	return status;
 }
 
+#ifdef WITH_DEBUG_CLIPRDR
 static void cliprdr_print_general_capability_flags(UINT32 flags)
 {
 	WLog_INFO(TAG,  "generalFlags (0x%08"PRIX32") {", flags);
@@ -136,6 +137,7 @@ static void cliprdr_print_general_capability_flags(UINT32 flags)
 
 	WLog_INFO(TAG,  "}");
 }
+#endif
 
 /**
  * Function description


### PR DESCRIPTION
channels/cliprdr/client/cliprdr_main.c:121:13: warning: ‘cliprdr_print_general_capability_flags’ defined but not used [-Wunused-function]

 static void cliprdr_print_general_capability_flags(UINT32 flags)

             ^