### PR TITLE
Don't ask astyle to treat long lines as it breaks code readability

### DIFF
--- a/scripts/format_code.sh
+++ b/scripts/format_code.sh
@@ -31,7 +31,7 @@ if [ $# -le 0 ]; then
 fi
 
 $ASTYLE --lineend=linux --mode=c --indent=tab=4 --pad-header --pad-oper --style=allman --min-conditional-indent=0 \
-							   --indent-switches --indent-cases --indent-preprocessor -k1 --max-code-length=100 \
+							   --indent-switches --indent-cases --indent-preprocessor -k1  \
 							   --indent-col1-comments --delete-empty-lines --break-closing-brackets \
 							   --align-pointer=type --indent-labels -xe --break-after-logical \
 							   --unpad-paren --break-blocks $@


### PR DESCRIPTION
People are smart enough to not use too long lines, and astyle is too strict
when breaking lines, so let's just remove that reformating.

That will prevent code like this:
	Stream_ReadUINT16(inStream, targetValue); /* targetValue: UINT16 comment...*/
to be changed to:
	Stream_ReadUINT16(inStream,
		targetValue); /* targetValue: UINT16 comment...*/