### PR TITLE
disable test

### DIFF
--- a/winpr/libwinpr/io/test/TestIoDevice.c
+++ b/winpr/libwinpr/io/test/TestIoDevice.c
@@ -6,7 +6,7 @@
 
 int TestIoDevice(int argc, char* argv[])
 {
-#ifndef _WIN32
+#if 0
 	NTSTATUS NtStatus;
 	ANSI_STRING aString;
 	UNICODE_STRING uString;


### PR DESCRIPTION
according to @awakecoding "that test should be disabled",
actually that test fails on linux due to "#ifndef",
but it should not run on linux