### PR TITLE
Handle the LogonNotify and longCredentials flag

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -193,10 +193,10 @@ static BOOL rdp_read_general_capability_set(wStream* s, UINT16 length,
 	Stream_Seek_UINT16(s); /* remoteUnshareFlag (2 bytes) */
 	Stream_Seek_UINT16(s); /* generalCompressionLevel (2 bytes) */
 	Stream_Read_UINT8(s, refreshRectSupport); /* refreshRectSupport (1 byte) */
-	Stream_Read_UINT8(s,
-	                  suppressOutputSupport); /* suppressOutputSupport (1 byte) */
-	settings->NoBitmapCompressionHeader = (extraFlags & NO_BITMAP_COMPRESSION_HDR) ?
-	                                      TRUE : FALSE;
+	Stream_Read_UINT8(s, suppressOutputSupport); /* suppressOutputSupport (1 byte) */
+
+	settings->NoBitmapCompressionHeader = (extraFlags & NO_BITMAP_COMPRESSION_HDR) ? TRUE : FALSE;
+	settings->LongCredentialsSupported = (extraFlags & LONG_CREDENTIALS_SUPPORTED) ? TRUE : FALSE;
 
 	if (!(extraFlags & FASTPATH_OUTPUT_SUPPORTED))
 		settings->FastPathOutput = FALSE;
@@ -237,7 +237,10 @@ static BOOL rdp_write_general_capability_set(wStream* s, rdpSettings* settings)
 		return FALSE;
 
 	header = rdp_capability_set_start(s);
-	extraFlags = LONG_CREDENTIALS_SUPPORTED;
+	extraFlags = 0;
+
+	if (settings->LongCredentialsSupported)
+		extraFlags |= LONG_CREDENTIALS_SUPPORTED;
 
 	if (settings->NoBitmapCompressionHeader)
 		extraFlags |= NO_BITMAP_COMPRESSION_HDR;

--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -432,6 +432,7 @@ BOOL rdp_read_info_packet(rdpRdp* rdp, wStream* s)
 	settings->RemoteApplicationMode = ((flags & INFO_RAIL) ? TRUE : FALSE);
 	settings->RemoteConsoleAudio = ((flags & INFO_REMOTECONSOLEAUDIO) ? TRUE : FALSE);
 	settings->CompressionEnabled = ((flags & INFO_COMPRESSION) ? TRUE : FALSE);
+	settings->LogonNotify = ((flags & INFO_LOGONNOTIFY) ? TRUE : FALSE);
 
 	if (flags & INFO_COMPRESSION)
 	{
@@ -628,7 +629,6 @@ void rdp_write_info_packet(rdpRdp* rdp, wStream* s)
 	flags = INFO_MOUSE |
 		INFO_UNICODE |
 		INFO_LOGONERRORS |
-		INFO_LOGONNOTIFY |
 		INFO_MAXIMIZESHELL |
 		INFO_ENABLEWINDOWSKEY |
 		INFO_DISABLECTRLALTDEL;
@@ -659,6 +659,9 @@ void rdp_write_info_packet(rdpRdp* rdp, wStream* s)
 		flags |= INFO_COMPRESSION;
 		flags |= ((settings->CompressionLevel << 9) & 0x00001E00);
 	}
+
+	if (settings->LogonNotify)
+		flags |= INFO_LOGONNOTIFY;
 
 	if (settings->Domain)
 	{

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -506,6 +506,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	settings->GatewayUdpTransport = TRUE;
 	settings->FastPathInput = TRUE;
 	settings->FastPathOutput = TRUE;
+	settings->LongCredentialsSupported = TRUE;
 	settings->FrameAcknowledge = 2;
 	settings->MouseMotion = TRUE;
 	settings->NSCodecColorLossLevel = 3;

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -334,6 +334,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	settings->EncryptionMethods = ENCRYPTION_METHOD_NONE;
 	settings->EncryptionLevel = ENCRYPTION_LEVEL_NONE;
 	settings->CompressionEnabled = TRUE;
+	settings->LogonNotify = TRUE;
 
 	if (settings->ServerMode)
 		settings->CompressionLevel = PACKET_COMPR_TYPE_RDP61;


### PR DESCRIPTION
This flag was not read in the server case and was always sent in the
case of a client.