### PR TITLE
Fix broken color mapping

### DIFF
--- a/client/Android/Studio/aFreeRDP/src/main/assets/about_page/about.html
+++ b/client/Android/Studio/aFreeRDP/src/main/assets/about_page/about.html
@@ -116,7 +116,7 @@ of the Mozilla Public License, v. 2.0.
 
 You can obtain an online version of the License from
 
-<a href="https://mozilla.org/MPL/2.0/">https://mozilla.org/MPL/2.0/</a>. 
+<a href="http://mozilla.org/MPL/2.0/">http://mozilla.org/MPL/2.0/</a>. 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 
 without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
@@ -137,7 +137,7 @@ you may not use this file except in compliance with the License.
 
 You may obtain a copy of the License at
 
-<a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a> 
+<a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a> 
 Unless required by applicable law or agreed to in writing, software
 
 distributed under the License is distributed on an &quot;AS IS&quot; BASIS,

--- a/client/Android/Studio/aFreeRDP/src/main/assets/about_page/about_phone.html
+++ b/client/Android/Studio/aFreeRDP/src/main/assets/about_page/about_phone.html
@@ -116,7 +116,7 @@ of the Mozilla Public License, v. 2.0.
 
 You can obtain an online version of the License from
 
-<a href="https://mozilla.org/MPL/2.0/">https://mozilla.org/MPL/2.0/</a>. 
+<a href="http://mozilla.org/MPL/2.0/">http://mozilla.org/MPL/2.0/</a>. 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 
 without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
@@ -137,7 +137,7 @@ you may not use this file except in compliance with the License.
 
 You may obtain a copy of the License at
 
-<a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a> 
+<a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a> 
 Unless required by applicable law or agreed to in writing, software
 
 distributed under the License is distributed on an &quot;AS IS&quot; BASIS,

--- a/client/Android/Studio/aFreeRDP/src/main/assets/de_about_page/about.html
+++ b/client/Android/Studio/aFreeRDP/src/main/assets/de_about_page/about.html
@@ -128,7 +128,7 @@ of the Mozilla Public License, v. 2.0.
 
 You can obtain an online version of the License from
 
-<a href="https://mozilla.org/MPL/2.0/">https://mozilla.org/MPL/2.0/</a>. 
+<a href="http://mozilla.org/MPL/2.0/">http://mozilla.org/MPL/2.0/</a>. 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 
 without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
@@ -144,7 +144,7 @@ A copy of the product's source code can be obtained from the FreeRDP GitHub repo
 you may not use this file except in compliance with the License.
 
 You may obtain a copy of the License at
-<a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a> 
+<a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a> 
 Unless required by applicable law or agreed to in writing, software
 
 distributed under the License is distributed on an &quot;AS IS&quot; BASIS,

--- a/client/Android/Studio/aFreeRDP/src/main/assets/de_about_page/about_phone.html
+++ b/client/Android/Studio/aFreeRDP/src/main/assets/de_about_page/about_phone.html
@@ -128,7 +128,7 @@ of the Mozilla Public License, v. 2.0.
 
 You can obtain an online version of the License from
 
-<a href="https://mozilla.org/MPL/2.0/">https://mozilla.org/MPL/2.0/</a>. 
+<a href="http://mozilla.org/MPL/2.0/">http://mozilla.org/MPL/2.0/</a>. 
 This program is distributed in the hope
 that it will be useful, but WITHOUT ANY WARRANTY;
 
@@ -147,7 +147,7 @@ obtained from the FreeRDP GitHub repository at
 you may not use this file except in compliance with the License.
 
 You may obtain a copy of the License at
-<a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a> 
+<a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a> 
 Unless required by applicable law or agreed to in writing, software
 
 distributed under the License is distributed on an &quot;AS IS&quot; BASIS,

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-de/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-de/strings.xml
@@ -53,6 +53,8 @@
     <string name="settings_cat_screen">Bildschirm Einstellungen</string>
     <string name="settings_colors">Farben</string>
     <string-array name="colors_array">
+        <item>Palette (8 Bit)</item>
+        <item>High Color (15 Bit)</item>
         <item>High Color (16 Bit)</item>
         <item>True Color (24 Bit)</item>
         <item>Highest Quality (32 Bit)</item>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-es/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-es/strings.xml
@@ -53,6 +53,8 @@
     <string name="settings_cat_screen">Configuracion Pantalla</string>
     <string name="settings_colors">Colores</string>
     <string-array name="colors_array">
+        <item>Gama de colores (8 Bit)</item>
+        <item>Calidad Normal (15 Bit)</item>
         <item>Calidad Normal (16 Bit)</item>
         <item>Calidad Optima (24 Bit)</item>
         <item>Calidad maxima (32 Bit)</item>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-fr/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-fr/strings.xml
@@ -52,6 +52,8 @@
     <string name="settings_cat_screen">"Paramètres d'écran"</string>
     <string name="settings_colors">"Couleurs"</string>
     <string-array name="colors_array">
+        <item>"Palette (8 bits)"</item>
+        <item>"Hautes couleurs (15 bits)"</item>
         <item>"Hautes couleurs (16 bits)"</item>
         <item>"Couleurs vraies (24 bits)"</item>
         <item>"Haute qualité (32 bits)"</item>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-nl/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-nl/strings.xml
@@ -53,6 +53,8 @@
     <string name="settings_cat_screen">Scherminstellingen</string>
     <string name="settings_colors">Kleuren</string>
     <string-array name="colors_array">
+        <item>Pallet (8 Bit)</item>
+        <item>Hoge kleuren (15 Bit)</item>
         <item>Hoge kleuren (16 Bit)</item>
         <item>Ware kleuren (24 Bit)</item>
         <item>Hoogste kwaliteit (32 Bit)</item>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-zh/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-zh/strings.xml
@@ -53,6 +53,8 @@
     <string name="settings_cat_screen">显示设置</string>
     <string name="settings_colors">颜色深度</string>
     <string-array name="colors_array">
+        <item>Palette (8 Bit)</item>
+        <item>High Color (15 Bit)</item>
         <item>High Color (16 Bit)</item>
         <item>True Color (24 Bit)</item>
         <item>Highest Quality (32 Bit)</item>


### PR DESCRIPTION
* Fixes broken colour depth mapping in non english translations
* Fix license text (erroneously replaced http with https links in license text)