### PR TITLE
Fixed disconnect handling.

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/application/GlobalApp.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/application/GlobalApp.java
@@ -167,13 +167,11 @@ public class GlobalApp extends Application implements LibFreeRDP.EventListener {
 
     public void OnDisconnecting(long instance) {
         Log.v(TAG, "OnDisconnecting");
-
-        // send disconnect notification
-        sendRDPNotification(FREERDP_EVENT_DISCONNECTED, instance);
     }
 
     public void OnDisconnected(long instance) {
         Log.v(TAG, "OnDisconnected");
+        sendRDPNotification(FREERDP_EVENT_DISCONNECTED, instance);
     }
 
     // TimerTask for disconnecting sessions after screen was turned off


### PR DESCRIPTION
```OnDisconnected``` is always called when a session ends, ```OnDisconnecting``` only when the remote host is reachable.