### PR TITLE
Fix format string is not a string literal

### DIFF
--- a/winpr/libwinpr/utils/wlog/Layout.c
+++ b/winpr/libwinpr/utils/wlog/Layout.c
@@ -48,7 +48,7 @@ extern const char* WLOG_LEVELS[7];
 static void WLog_PrintMessagePrefixVA(wLog* log, wLogMessage* message, const char* format, va_list args)
 {
 	if (!strchr(format, '%'))
-		sprintf_s(message->PrefixString, WLOG_MAX_PREFIX_SIZE - 1, format);
+		sprintf_s(message->PrefixString, WLOG_MAX_PREFIX_SIZE - 1, "%s", format);
 	else
 		wvsnprintfx(message->PrefixString, WLOG_MAX_PREFIX_SIZE - 1, format, args);
 }


### PR DESCRIPTION
Nightly builder does not like format strings from arguments (format security)