### PR TITLE
Client random

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -583,7 +583,14 @@ BOOL rdp_server_establish_keys(rdpRdp* rdp, wStream* s)
 
 	mod = rdp->settings->RdpServerRsaKey->Modulus;
 	priv_exp = rdp->settings->RdpServerRsaKey->PrivateExponent;
-	crypto_rsa_private_decrypt(crypt_client_random, rand_len - 8, key_len, mod, priv_exp, client_random);
+	if (crypto_rsa_private_decrypt(crypt_client_random, rand_len - 8, key_len, mod, priv_exp, client_random) <= 0)
+	{
+		free(client_random);
+		goto end;
+	}
+
+	rdp->settings->ClientRandom = client_random;
+	rdp->settings->ClientRandomLength = 32;
 
 	/* now calculate encrypt / decrypt and update keys */
 	if (!security_establish_keys(client_random, rdp))
@@ -625,7 +632,6 @@ BOOL rdp_server_establish_keys(rdpRdp* rdp, wStream* s)
 	ret = TRUE;
 end:
 	free(crypt_client_random);
-	free(client_random);
 
 	if (!ret)
 	{

--- a/winpr/libwinpr/crt/unicode.c
+++ b/winpr/libwinpr/crt/unicode.c
@@ -269,7 +269,7 @@ int WideCharToMultiByte(UINT CodePage, DWORD dwFlags, LPCWSTR lpWideCharStr, int
 /**
  * ConvertToUnicode is a convenience wrapper for MultiByteToWideChar:
  *
- * If the lpWideCharStr prarameter for the converted string points to NULL
+ * If the lpWideCharStr parameter for the converted string points to NULL
  * or if the cchWideChar parameter is set to 0 this function will automatically
  * allocate the required memory which is guaranteed to be null-terminated
  * after the conversion, even if the source c string isn't.


### PR DESCRIPTION
We need the client_random to enable client reconnection when the client uses RDP security.