### PR TITLE
Fix FreeRDP crashes on system in FIPS mode

### DIFF
--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -92,10 +92,10 @@ int freerdp_assistance_crypt_derive_key_sha1(BYTE* hash, int hashLength, BYTE* k
 	if (!buffer)
 		goto fail;
 
-	if (!winpr_Digest(WINPR_MD_SHA1, pad1, 64, buffer, hashLength))
+	if (!winpr_Digest(WINPR_MD_SHA1, pad1, 64, buffer, hashLength, FALSE))
 		goto fail;
 
-	if (!winpr_Digest(WINPR_MD_SHA1, pad2, 64, &buffer[hashLength], hashLength))
+	if (!winpr_Digest(WINPR_MD_SHA1, pad2, 64, &buffer[hashLength], hashLength, FALSE))
 		goto fail;
 
 	CopyMemory(key, buffer, keyLength);
@@ -558,7 +558,7 @@ BYTE* freerdp_assistance_encrypt_pass_stub(const char* password, const char* pas
 
 	cbPasswordW = (status - 1) * 2;
 
-	if (!winpr_Digest(WINPR_MD_MD5, (BYTE*)PasswordW, cbPasswordW, (BYTE*) PasswordHash, sizeof(PasswordHash)))
+	if (!winpr_Digest(WINPR_MD_MD5, (BYTE*)PasswordW, cbPasswordW, (BYTE*) PasswordHash, sizeof(PasswordHash), FALSE))
 	{
 		free (PasswordW);
 		return NULL;
@@ -604,7 +604,7 @@ BYTE* freerdp_assistance_encrypt_pass_stub(const char* password, const char* pas
 	free(PassStubW);
 
 	rc4Ctx = winpr_Cipher_New(WINPR_CIPHER_ARC4_128, WINPR_ENCRYPT,
-				  PasswordHash, NULL);
+				  PasswordHash, NULL, FALSE);
 	if (!rc4Ctx)
 	{
 		WLog_ERR(TAG,  "EVP_CipherInit_ex failure");
@@ -663,7 +663,7 @@ int freerdp_assistance_decrypt2(rdpAssistanceFile* file, const char* password)
 
 	cbPasswordW = (status - 1) * 2;
 
-	if (!winpr_Digest(WINPR_MD_SHA1, (BYTE*)PasswordW, cbPasswordW, PasswordHash, sizeof(PasswordHash)))
+	if (!winpr_Digest(WINPR_MD_SHA1, (BYTE*)PasswordW, cbPasswordW, PasswordHash, sizeof(PasswordHash), FALSE))
 	{
 		free (PasswordW);
 		return -1;
@@ -681,7 +681,7 @@ int freerdp_assistance_decrypt2(rdpAssistanceFile* file, const char* password)
 	ZeroMemory(InitializationVector, sizeof(InitializationVector));
 
 	aesDec = winpr_Cipher_New(WINPR_CIPHER_AES_128_CBC, WINPR_DECRYPT,
-				  DerivedKey, InitializationVector);
+				  DerivedKey, InitializationVector, FALSE);
 	if (!aesDec)
 	{
 		free(PasswordW);

--- a/libfreerdp/core/certificate.c
+++ b/libfreerdp/core/certificate.c
@@ -404,7 +404,7 @@ static BOOL certificate_process_server_public_signature(rdpCertificate* certific
 	BYTE encsig[TSSK_KEY_LENGTH + 8];
 	BYTE md5hash[WINPR_MD5_DIGEST_LENGTH];
 
-	if (!winpr_Digest(WINPR_MD_MD5, sigdata, sigdatalen, md5hash, sizeof(md5hash)))
+	if (!winpr_Digest(WINPR_MD_MD5, sigdata, sigdatalen, md5hash, sizeof(md5hash), FALSE))
             return FALSE;
 	Stream_Read(s, encsig, siglen);
 

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -476,7 +476,8 @@ static BOOL rdp_client_establish_keys(rdpRdp* rdp)
 		rdp->fips_encrypt = winpr_Cipher_New(WINPR_CIPHER_DES_EDE3_CBC,
 		                                     WINPR_ENCRYPT,
 		                                     rdp->fips_encrypt_key,
-		                                     fips_ivec);
+		                                     fips_ivec,
+		                                     FALSE);
 		if (!rdp->fips_encrypt)
 		{
 			WLog_ERR(TAG, "unable to allocate des3 encrypt key");
@@ -485,7 +486,8 @@ static BOOL rdp_client_establish_keys(rdpRdp* rdp)
 		rdp->fips_decrypt = winpr_Cipher_New(WINPR_CIPHER_DES_EDE3_CBC,
 		                                     WINPR_DECRYPT,
 		                                     rdp->fips_decrypt_key,
-		                                     fips_ivec);
+		                                     fips_ivec,
+		                                     FALSE);
 		if (!rdp->fips_decrypt)
 		{
 			WLog_ERR(TAG, "unable to allocate des3 decrypt key");
@@ -596,7 +598,8 @@ BOOL rdp_server_establish_keys(rdpRdp* rdp, wStream* s)
 		rdp->fips_encrypt = winpr_Cipher_New(WINPR_CIPHER_DES_EDE3_CBC,
 						     WINPR_ENCRYPT,
 						     rdp->fips_encrypt_key,
-						     fips_ivec);
+						     fips_ivec,
+						     FALSE);
 		if (!rdp->fips_encrypt)
 		{
 			WLog_ERR(TAG, "unable to allocate des3 encrypt key");
@@ -606,7 +609,8 @@ BOOL rdp_server_establish_keys(rdpRdp* rdp, wStream* s)
 		rdp->fips_decrypt = winpr_Cipher_New(WINPR_CIPHER_DES_EDE3_CBC,
 						     WINPR_DECRYPT,
 						     rdp->fips_decrypt_key,
-						     fips_ivec);
+						     fips_ivec,
+						     FALSE);
 		if (!rdp->fips_decrypt)
 		{
 			WLog_ERR(TAG, "unable to allocate des3 decrypt key");

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -1479,7 +1479,7 @@ BOOL gcc_write_server_security_data(wStream* s, rdpMcs* mcs)
 	Stream_Write_UINT16(s, sizeof(encryptedSignature) + 8); /* wSignatureBlobLen */
 	memcpy(signature, initial_signature, sizeof(initial_signature));
 
-	if (!winpr_Digest(WINPR_MD_MD5, sigData, sigDataLen, signature, sizeof(signature)))
+	if (!winpr_Digest(WINPR_MD_MD5, sigData, sigDataLen, signature, sizeof(signature), FALSE))
 		return FALSE;
 
 	crypto_rsa_private_encrypt(signature, sizeof(signature), TSSK_KEY_LENGTH,

--- a/libfreerdp/core/security.c
+++ b/libfreerdp/core/security.c
@@ -526,6 +526,8 @@ BOOL security_establish_keys(const BYTE* client_random, rdpRdp* rdp)
 			fips_expand_key_bits(client_encrypt_key_t, rdp->fips_encrypt_key);
 			fips_expand_key_bits(client_decrypt_key_t, rdp->fips_decrypt_key);
 		}
+
+		return TRUE;
 	}
 
 	memcpy(pre_master_secret, client_random, 24);

--- a/libfreerdp/core/security.c
+++ b/libfreerdp/core/security.c
@@ -125,7 +125,7 @@ fips_oddparity_table[256] =
 };
 
 static BOOL security_salted_hash(const BYTE* salt, const BYTE* input, int length,
-		const BYTE* salt1, const BYTE* salt2, BYTE* output)
+		const BYTE* salt1, const BYTE* salt2, BYTE* output, BOOL non_fips_allow)
 {
 	WINPR_DIGEST_CTX* sha1 = NULL;
 	WINPR_DIGEST_CTX* md5 = NULL;
@@ -137,7 +137,7 @@ static BOOL security_salted_hash(const BYTE* salt, const BYTE* input, int length
 	/* SHA1_Digest = SHA1(Input + Salt + Salt1 + Salt2) */
 	if (!(sha1 = winpr_Digest_New()))
 		goto out;
-	if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1))
+	if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1, non_fips_allow))
 		goto out;
 	if (!winpr_Digest_Update(sha1, input, length)) /* Input */
 		goto out;
@@ -153,7 +153,7 @@ static BOOL security_salted_hash(const BYTE* salt, const BYTE* input, int length
 	/* SaltedHash(Salt, Input, Salt1, Salt2) = MD5(S + SHA1_Digest) */
 	if (!(md5 = winpr_Digest_New()))
 		goto out;
-	if (!winpr_Digest_Init(md5, WINPR_MD_MD5))
+	if (!winpr_Digest_Init(md5, WINPR_MD_MD5, non_fips_allow))
 		goto out;
 	if (!winpr_Digest_Update(md5, salt, 48)) /* Salt (48 bytes) */
 		goto out;
@@ -170,35 +170,35 @@ out:
 }
 
 static BOOL security_premaster_hash(const char* input, int length, const BYTE* premaster_secret,
-		const BYTE* client_random, const BYTE* server_random, BYTE* output)
+		const BYTE* client_random, const BYTE* server_random, BYTE* output, BOOL non_fips_allow)
 {
 	/* PremasterHash(Input) = SaltedHash(PremasterSecret, Input, ClientRandom, ServerRandom) */
-	return security_salted_hash(premaster_secret, (BYTE*)input, length, client_random, server_random, output);
+	return security_salted_hash(premaster_secret, (BYTE*)input, length, client_random, server_random, output, non_fips_allow);
 }
 
 BOOL security_master_secret(const BYTE* premaster_secret, const BYTE* client_random,
-		const BYTE* server_random, BYTE* output)
+		const BYTE* server_random, BYTE* output, BOOL non_fips_allow)
 {
 	/* MasterSecret = PremasterHash('A') + PremasterHash('BB') + PremasterHash('CCC') */
-	return security_premaster_hash("A", 1, premaster_secret, client_random, server_random, &output[0]) &&
-		security_premaster_hash("BB", 2, premaster_secret, client_random, server_random, &output[16]) &&
-		security_premaster_hash("CCC", 3, premaster_secret, client_random, server_random, &output[32]);
+	return security_premaster_hash("A", 1, premaster_secret, client_random, server_random, &output[0], non_fips_allow) &&
+		security_premaster_hash("BB", 2, premaster_secret, client_random, server_random, &output[16], non_fips_allow) &&
+		security_premaster_hash("CCC", 3, premaster_secret, client_random, server_random, &output[32], non_fips_allow);
 }
 
 static BOOL security_master_hash(const char* input, int length, const BYTE* master_secret,
-		const BYTE* client_random, const BYTE* server_random, BYTE* output)
+		const BYTE* client_random, const BYTE* server_random, BYTE* output, BOOL non_fips_allow)
 {
 	/* MasterHash(Input) = SaltedHash(MasterSecret, Input, ServerRandom, ClientRandom) */
-	return security_salted_hash(master_secret, (const BYTE*)input, length, server_random, client_random, output);
+	return security_salted_hash(master_secret, (const BYTE*)input, length, server_random, client_random, output, non_fips_allow);
 }
 
 BOOL security_session_key_blob(const BYTE* master_secret, const BYTE* client_random,
-		const BYTE* server_random, BYTE* output)
+		const BYTE* server_random, BYTE* output, BOOL non_fips_allow)
 {
 	/* MasterHash = MasterHash('A') + MasterHash('BB') + MasterHash('CCC') */
-	return security_master_hash("A", 1, master_secret, client_random, server_random, &output[0]) &&
-		security_master_hash("BB", 2, master_secret, client_random, server_random, &output[16]) &&
-		security_master_hash("CCC", 3, master_secret, client_random, server_random, &output[32]);
+	return security_master_hash("A", 1, master_secret, client_random, server_random, &output[0], non_fips_allow) &&
+		security_master_hash("BB", 2, master_secret, client_random, server_random, &output[16], non_fips_allow) &&
+		security_master_hash("CCC", 3, master_secret, client_random, server_random, &output[32], non_fips_allow);
 }
 
 void security_mac_salt_key(const BYTE* session_key_blob, const BYTE* client_random,
@@ -208,14 +208,14 @@ void security_mac_salt_key(const BYTE* session_key_blob, const BYTE* client_rand
 	memcpy(output, session_key_blob, 16);
 }
 
-BOOL security_md5_16_32_32(const BYTE* in0, const BYTE* in1, const BYTE* in2, BYTE* output)
+BOOL security_md5_16_32_32(const BYTE* in0, const BYTE* in1, const BYTE* in2, BYTE* output, BOOL non_fips_allow)
 {
 	WINPR_DIGEST_CTX* md5 = NULL;
 	BOOL result = FALSE;
 
 	if (!(md5 = winpr_Digest_New()))
 		return FALSE;
-	if (!winpr_Digest_Init(md5, WINPR_MD_MD5))
+	if (!winpr_Digest_Init(md5, WINPR_MD_MD5, non_fips_allow))
 		goto out;
 	if (!winpr_Digest_Update(md5, in0, 16))
 		goto out;
@@ -236,7 +236,7 @@ BOOL security_licensing_encryption_key(const BYTE* session_key_blob, const BYTE*
 		const BYTE* server_random, BYTE* output)
 {
 	/* LicensingEncryptionKey = MD5(Second128Bits(SessionKeyBlob) + ClientRandom + ServerRandom)) */
-	return security_md5_16_32_32(&session_key_blob[16], client_random, server_random, output);
+	return security_md5_16_32_32(&session_key_blob[16], client_random, server_random, output, TRUE);
 }
 
 void security_UINT32_le(BYTE* output, UINT32 value)
@@ -248,7 +248,7 @@ void security_UINT32_le(BYTE* output, UINT32 value)
 }
 
 BOOL security_mac_data(const BYTE* mac_salt_key, const BYTE* data, UINT32 length,
-		BYTE* output)
+		BYTE* output, BOOL non_fips_allow)
 {
 	WINPR_DIGEST_CTX* sha1 = NULL;
 	WINPR_DIGEST_CTX* md5 = NULL;
@@ -263,7 +263,7 @@ BOOL security_mac_data(const BYTE* mac_salt_key, const BYTE* data, UINT32 length
 	/* SHA1_Digest = SHA1(MacSaltKey + pad1 + length + data) */
 	if (!(sha1 = winpr_Digest_New()))
 		goto out;
-	if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1))
+	if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1, non_fips_allow))
 		goto out;
 	if (!winpr_Digest_Update(sha1, mac_salt_key, 16)) /* MacSaltKey */
 		goto out;
@@ -279,7 +279,7 @@ BOOL security_mac_data(const BYTE* mac_salt_key, const BYTE* data, UINT32 length
 	/* MacData = MD5(MacSaltKey + pad2 + SHA1_Digest) */
 	if (!(md5 = winpr_Digest_New()))
 		goto out;
-	if (!winpr_Digest_Init(md5, WINPR_MD_MD5))
+	if (!winpr_Digest_Init(md5, WINPR_MD_MD5, non_fips_allow))
 		goto out;
 	if (!winpr_Digest_Update(md5, mac_salt_key, 16)) /* MacSaltKey */
 		goto out;
@@ -311,7 +311,7 @@ BOOL security_mac_signature(rdpRdp *rdp, const BYTE* data, UINT32 length, BYTE* 
 	/* SHA1_Digest = SHA1(MACKeyN + pad1 + length + data) */
 	if (!(sha1 = winpr_Digest_New()))
 		goto out;
-	if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1))
+	if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1, FALSE))
 		goto out;
 	if (!winpr_Digest_Update(sha1, rdp->sign_key, rdp->rc4_key_len)) /* MacKeyN */
 		goto out;
@@ -327,7 +327,7 @@ BOOL security_mac_signature(rdpRdp *rdp, const BYTE* data, UINT32 length, BYTE* 
 	/* MACSignature = First64Bits(MD5(MACKeyN + pad2 + SHA1_Digest)) */
 	if (!(md5 = winpr_Digest_New()))
 		goto out;
-	if (!winpr_Digest_Init(md5, WINPR_MD_MD5))
+	if (!winpr_Digest_Init(md5, WINPR_MD_MD5, FALSE))
 		goto out;
 	if (!winpr_Digest_Update(md5, rdp->sign_key, rdp->rc4_key_len)) /* MacKeyN */
 		goto out;
@@ -375,7 +375,7 @@ BOOL security_salted_mac_signature(rdpRdp *rdp, const BYTE* data, UINT32 length,
 	/* SHA1_Digest = SHA1(MACKeyN + pad1 + length + data) */
 	if (!(sha1 = winpr_Digest_New()))
 		goto out;
-	if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1))
+	if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1, FALSE))
 		goto out;
 	if (!winpr_Digest_Update(sha1, rdp->sign_key, rdp->rc4_key_len)) /* MacKeyN */
 		goto out;
@@ -393,7 +393,7 @@ BOOL security_salted_mac_signature(rdpRdp *rdp, const BYTE* data, UINT32 length,
 	/* MACSignature = First64Bits(MD5(MACKeyN + pad2 + SHA1_Digest)) */
 	if (!(md5 = winpr_Digest_New()))
 		goto out;
-	if (!winpr_Digest_Init(md5, WINPR_MD_MD5))
+	if (!winpr_Digest_Init(md5, WINPR_MD_MD5, FALSE))
 		goto out;
 	if (!winpr_Digest_Update(md5, rdp->sign_key, rdp->rc4_key_len)) /* MacKeyN */
 		goto out;
@@ -416,18 +416,18 @@ static BOOL security_A(BYTE* master_secret, const BYTE* client_random, BYTE* ser
 		BYTE* output)
 {
 	return
-		security_premaster_hash("A", 1, master_secret, client_random, server_random, &output[0]) &&
-		security_premaster_hash("BB", 2, master_secret, client_random, server_random, &output[16]) &&
-		security_premaster_hash("CCC", 3, master_secret, client_random, server_random, &output[32]);
+		security_premaster_hash("A", 1, master_secret, client_random, server_random, &output[0], FALSE) &&
+		security_premaster_hash("BB", 2, master_secret, client_random, server_random, &output[16], FALSE) &&
+		security_premaster_hash("CCC", 3, master_secret, client_random, server_random, &output[32], FALSE);
 }
 
 static BOOL security_X(BYTE* master_secret, const BYTE* client_random, BYTE* server_random,
 		BYTE* output)
 {
 	return
-		security_premaster_hash("X", 1, master_secret, client_random, server_random, &output[0]) &&
-		security_premaster_hash("YY", 2, master_secret, client_random, server_random, &output[16]) &&
-		security_premaster_hash("ZZZ", 3, master_secret, client_random, server_random, &output[32]);
+		security_premaster_hash("X", 1, master_secret, client_random, server_random, &output[0], FALSE) &&
+		security_premaster_hash("YY", 2, master_secret, client_random, server_random, &output[16], FALSE) &&
+		security_premaster_hash("ZZZ", 3, master_secret, client_random, server_random, &output[32], FALSE);
 }
 
 static void fips_expand_key_bits(BYTE* in, BYTE* out)
@@ -485,7 +485,7 @@ BOOL security_establish_keys(const BYTE* client_random, rdpRdp* rdp)
 		if (!(sha1 = winpr_Digest_New()))
 			return FALSE;
 
-		if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1) ||
+		if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1, FALSE) ||
 		    !winpr_Digest_Update(sha1, client_random + 16, 16) ||
 		    !winpr_Digest_Update(sha1, server_random + 16, 16) ||
 		    !winpr_Digest_Final(sha1, client_encrypt_key_t, sizeof(client_encrypt_key_t)))
@@ -495,7 +495,7 @@ BOOL security_establish_keys(const BYTE* client_random, rdpRdp* rdp)
 		}
 		client_encrypt_key_t[20] = client_encrypt_key_t[0];
 
-		if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1) ||
+		if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1, FALSE) ||
 		    !winpr_Digest_Update(sha1, client_random, 16) ||
 		    !winpr_Digest_Update(sha1, server_random, 16) ||
 		    !winpr_Digest_Final(sha1, client_decrypt_key_t, sizeof(client_decrypt_key_t)))
@@ -505,7 +505,7 @@ BOOL security_establish_keys(const BYTE* client_random, rdpRdp* rdp)
 		}
 		client_decrypt_key_t[20] = client_decrypt_key_t[0];
 
-		if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1) ||
+		if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1, FALSE) ||
 		    !winpr_Digest_Update(sha1, client_decrypt_key_t, WINPR_SHA1_DIGEST_LENGTH) ||
 		    !winpr_Digest_Update(sha1, client_encrypt_key_t, WINPR_SHA1_DIGEST_LENGTH) ||
 		    !winpr_Digest_Final(sha1, rdp->fips_sign_key, WINPR_SHA1_DIGEST_LENGTH))
@@ -543,13 +543,13 @@ BOOL security_establish_keys(const BYTE* client_random, rdpRdp* rdp)
 
 	if (rdp->settings->ServerMode)
 	{
-		status = security_md5_16_32_32(&session_key_blob[16], client_random, server_random, rdp->encrypt_key);
-		status &= security_md5_16_32_32(&session_key_blob[32], client_random, server_random, rdp->decrypt_key);
+		status = security_md5_16_32_32(&session_key_blob[16], client_random, server_random, rdp->encrypt_key, FALSE);
+		status &= security_md5_16_32_32(&session_key_blob[32], client_random, server_random, rdp->decrypt_key, FALSE);
 	}
 	else
 	{
-		status = security_md5_16_32_32(&session_key_blob[16], client_random, server_random, rdp->decrypt_key);
-		status &= security_md5_16_32_32(&session_key_blob[32], client_random, server_random, rdp->encrypt_key);
+		status = security_md5_16_32_32(&session_key_blob[16], client_random, server_random, rdp->decrypt_key, FALSE);
+		status &= security_md5_16_32_32(&session_key_blob[32], client_random, server_random, rdp->encrypt_key, FALSE);
 	}
 
 	if (!status)
@@ -596,7 +596,7 @@ BOOL security_key_update(BYTE* key, BYTE* update_key, int key_len, rdpRdp* rdp)
 
 	if (!(sha1 = winpr_Digest_New()))
 		goto out;
-	if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1))
+	if (!winpr_Digest_Init(sha1, WINPR_MD_SHA1, FALSE))
 		goto out;
 	if (!winpr_Digest_Update(sha1, update_key, key_len))
 		goto out;
@@ -609,7 +609,7 @@ BOOL security_key_update(BYTE* key, BYTE* update_key, int key_len, rdpRdp* rdp)
 
 	if (!(md5 = winpr_Digest_New()))
 		goto out;
-	if (!winpr_Digest_Init(md5, WINPR_MD_MD5))
+	if (!winpr_Digest_Init(md5, WINPR_MD_MD5, FALSE))
 		goto out;
 	if (!winpr_Digest_Update(md5, update_key, key_len))
 		goto out;
@@ -696,7 +696,7 @@ BOOL security_hmac_signature(const BYTE* data, int length, BYTE* output, rdpRdp*
 
 	if (!(hmac = winpr_HMAC_New()))
 		return FALSE;
-	if (!winpr_HMAC_Init(hmac, WINPR_MD_SHA1, rdp->fips_sign_key, WINPR_SHA1_DIGEST_LENGTH))
+	if (!winpr_HMAC_Init(hmac, WINPR_MD_SHA1, rdp->fips_sign_key, WINPR_SHA1_DIGEST_LENGTH, FALSE))
 		goto out;
 	if (!winpr_HMAC_Update(hmac, data, length))
 		goto out;
@@ -742,7 +742,7 @@ BOOL security_fips_check_signature(const BYTE* data, int length, const BYTE* sig
 
 	if (!(hmac = winpr_HMAC_New()))
 		return FALSE;
-	if (!winpr_HMAC_Init(hmac, WINPR_MD_SHA1, rdp->fips_sign_key, WINPR_SHA1_DIGEST_LENGTH))
+	if (!winpr_HMAC_Init(hmac, WINPR_MD_SHA1, rdp->fips_sign_key, WINPR_SHA1_DIGEST_LENGTH, FALSE))
 		goto out;
 	if (!winpr_HMAC_Update(hmac, data, length))
 		goto out;

--- a/libfreerdp/core/security.h
+++ b/libfreerdp/core/security.h
@@ -29,16 +29,16 @@
 #include <winpr/stream.h>
 
 FREERDP_LOCAL BOOL security_master_secret(const BYTE* premaster_secret,
-        const BYTE* client_random, const BYTE* server_random, BYTE* output);
+        const BYTE* client_random, const BYTE* server_random, BYTE* output, BOOL non_fips_allow);
 FREERDP_LOCAL BOOL security_session_key_blob(const BYTE* master_secret,
-        const BYTE* client_random, const BYTE* server_random, BYTE* output);
+        const BYTE* client_random, const BYTE* server_random, BYTE* output, BOOL non_fips_allow);
 FREERDP_LOCAL void security_mac_salt_key(const BYTE* session_key_blob,
         const BYTE* client_random, const BYTE* server_random, BYTE* output);
 FREERDP_LOCAL BOOL security_licensing_encryption_key(const BYTE*
         session_key_blob, const BYTE* client_random, const BYTE* server_random,
         BYTE* output);
 FREERDP_LOCAL BOOL security_mac_data(const BYTE* mac_salt_key, const BYTE* data,
-                                     UINT32 length, BYTE* output);
+                                     UINT32 length, BYTE* output, BOOL non_fips_allow);
 FREERDP_LOCAL BOOL security_mac_signature(rdpRdp* rdp, const BYTE* data,
         UINT32 length, BYTE* output);
 FREERDP_LOCAL BOOL security_salted_mac_signature(rdpRdp* rdp, const BYTE* data,

--- a/winpr/include/winpr/crypto.h
+++ b/winpr/include/winpr/crypto.h
@@ -643,7 +643,7 @@ extern "C" {
 #endif
 
 WINPR_API WINPR_HMAC_CTX* winpr_HMAC_New(void);
-WINPR_API BOOL winpr_HMAC_Init(WINPR_HMAC_CTX* ctx, WINPR_MD_TYPE md, const BYTE* key, size_t keylen);
+WINPR_API BOOL winpr_HMAC_Init(WINPR_HMAC_CTX* ctx, WINPR_MD_TYPE md, const BYTE* key, size_t keylen, BOOL non_fips_allow);
 WINPR_API BOOL winpr_HMAC_Update(WINPR_HMAC_CTX* ctx, const BYTE* input, size_t ilen);
 WINPR_API BOOL winpr_HMAC_Final(WINPR_HMAC_CTX* ctx, BYTE* output, size_t ilen);
 WINPR_API void winpr_HMAC_Free(WINPR_HMAC_CTX* ctx);
@@ -665,11 +665,11 @@ extern "C" {
 #endif
 
 WINPR_API WINPR_DIGEST_CTX* winpr_Digest_New(void);
-WINPR_API BOOL winpr_Digest_Init(WINPR_DIGEST_CTX* ctx, WINPR_MD_TYPE md);
+WINPR_API BOOL winpr_Digest_Init(WINPR_DIGEST_CTX* ctx, WINPR_MD_TYPE md, BOOL non_fips_allow);
 WINPR_API BOOL winpr_Digest_Update(WINPR_DIGEST_CTX* ctx, const BYTE* input, size_t ilen);
 WINPR_API BOOL winpr_Digest_Final(WINPR_DIGEST_CTX* ctx, BYTE* output, size_t ilen);
 WINPR_API void winpr_Digest_Free(WINPR_DIGEST_CTX* ctx);
-WINPR_API BOOL winpr_Digest(int md, const BYTE* input, size_t ilen, BYTE* output, size_t olen);
+WINPR_API BOOL winpr_Digest(int md, const BYTE* input, size_t ilen, BYTE* output, size_t olen, BOOL non_fips_allow);
 
 #ifdef __cplusplus
 }
@@ -775,7 +775,7 @@ typedef struct _winpr_cipher_ctx_private_st WINPR_CIPHER_CTX;
 extern "C" {
 #endif
 
-WINPR_API WINPR_CIPHER_CTX* winpr_Cipher_New(int cipher, int op, const BYTE* key, const BYTE* iv);
+WINPR_API WINPR_CIPHER_CTX* winpr_Cipher_New(int cipher, int op, const BYTE* key, const BYTE* iv, BOOL non_fips_allow);
 WINPR_API BOOL winpr_Cipher_Update(WINPR_CIPHER_CTX* ctx, const BYTE* input, size_t ilen, BYTE* output, size_t* olen);
 WINPR_API BOOL winpr_Cipher_Final(WINPR_CIPHER_CTX* ctx, BYTE* output, size_t* olen);
 WINPR_API void winpr_Cipher_Free(WINPR_CIPHER_CTX* ctx);

--- a/winpr/libwinpr/crypto/cipher.c
+++ b/winpr/libwinpr/crypto/cipher.c
@@ -535,10 +535,19 @@ WINPR_CIPHER_CTX* winpr_Cipher_New(int cipher, int op, const BYTE* key, const BY
 
 	operation = (op == WINPR_ENCRYPT) ? 1 : 0;
 
+	/* The additional EVP_CipherInit_ex call is needed to handle
+	 * EVP_CIPH_FLAG_NON_FIPS_ALLOW flag properly because of bug in OpenSSL.
+	 */
+	if (EVP_CipherInit_ex(octx, evp, NULL, NULL, NULL, operation) != 1)
+	{
+		EVP_CIPHER_CTX_free(octx);
+		return NULL;
+	}
+
 	if (non_fips_allow)
 		EVP_CIPHER_CTX_set_flags(octx, EVP_CIPH_FLAG_NON_FIPS_ALLOW);
 
-	if (EVP_CipherInit_ex(octx, evp, NULL, key, iv, operation) != 1)
+	if (EVP_CipherInit_ex(octx, NULL, NULL, key, iv, operation) != 1)
 	{
 		EVP_CIPHER_CTX_free(octx);
 		return NULL;

--- a/winpr/libwinpr/crypto/cipher.c
+++ b/winpr/libwinpr/crypto/cipher.c
@@ -515,7 +515,7 @@ mbedtls_cipher_type_t winpr_mbedtls_get_cipher_type(int cipher)
 }
 #endif
 
-WINPR_CIPHER_CTX* winpr_Cipher_New(int cipher, int op, const BYTE* key, const BYTE* iv)
+WINPR_CIPHER_CTX* winpr_Cipher_New(int cipher, int op, const BYTE* key, const BYTE* iv, BOOL non_fips_allow)
 {
 	WINPR_CIPHER_CTX* ctx = NULL;
 
@@ -524,6 +524,9 @@ WINPR_CIPHER_CTX* winpr_Cipher_New(int cipher, int op, const BYTE* key, const BY
 	const EVP_CIPHER* evp;
 	EVP_CIPHER_CTX* octx;
 
+	if (non_fips_allow)
+		EVP_add_cipher(EVP_rc4());
+
 	if (!(evp = winpr_openssl_get_evp_cipher(cipher)))
 		return NULL;
 
@@ -531,6 +534,9 @@ WINPR_CIPHER_CTX* winpr_Cipher_New(int cipher, int op, const BYTE* key, const BY
 		return NULL;
 
 	operation = (op == WINPR_ENCRYPT) ? 1 : 0;
+
+	if (non_fips_allow)
+		EVP_CIPHER_CTX_set_flags(octx, EVP_CIPH_FLAG_NON_FIPS_ALLOW);
 
 	if (EVP_CipherInit_ex(octx, evp, NULL, key, iv, operation) != 1)
 	{

--- a/winpr/libwinpr/crypto/crypto.c
+++ b/winpr/libwinpr/crypto/crypto.c
@@ -189,7 +189,7 @@ BOOL CryptProtectMemory(LPVOID pData, DWORD cbData, DWORD dwFlags)
 		goto out;
 
 	if ((enc = winpr_Cipher_New(WINPR_CIPHER_AES_256_CBC, WINPR_ENCRYPT,
-				    pMemBlock->key, pMemBlock->iv)) == NULL)
+				    pMemBlock->key, pMemBlock->iv, FALSE)) == NULL)
 		goto out;
 	if (!winpr_Cipher_Update(enc, pMemBlock->pData, pMemBlock->cbData, pCipherText, &cbOut))
 		goto out;
@@ -235,7 +235,7 @@ BOOL CryptUnprotectMemory(LPVOID pData, DWORD cbData, DWORD dwFlags)
 		goto out;
 
 	if ((dec = winpr_Cipher_New(WINPR_CIPHER_AES_256_CBC, WINPR_DECRYPT,
-				    pMemBlock->key, pMemBlock->iv)) == NULL)
+				    pMemBlock->key, pMemBlock->iv, FALSE)) == NULL)
 		goto out;
 	if (!winpr_Cipher_Update(dec, pMemBlock->pData, pMemBlock->cbData, pPlainText, &cbOut))
 		goto out;

--- a/winpr/libwinpr/crypto/test/TestCryptoCipher.c
+++ b/winpr/libwinpr/crypto/test/TestCryptoCipher.c
@@ -21,7 +21,7 @@ static BOOL test_crypto_cipher_aes_128_cbc()
 
 	/* encrypt */
 
-	if (!(ctx = winpr_Cipher_New(WINPR_CIPHER_AES_128_CBC, WINPR_ENCRYPT, key, iv)))
+	if (!(ctx = winpr_Cipher_New(WINPR_CIPHER_AES_128_CBC, WINPR_ENCRYPT, key, iv, TRUE)))
 	{
 		fprintf(stderr, "%s: winpr_Cipher_New (encrypt) failed\n", __FUNCTION__);
 		return FALSE;
@@ -63,7 +63,7 @@ static BOOL test_crypto_cipher_aes_128_cbc()
 
 	/* decrypt */
 
-	if (!(ctx = winpr_Cipher_New(WINPR_CIPHER_AES_128_CBC, WINPR_DECRYPT, key, iv)))
+	if (!(ctx = winpr_Cipher_New(WINPR_CIPHER_AES_128_CBC, WINPR_DECRYPT, key, iv, TRUE)))
 	{
 		fprintf(stderr, "%s: winpr_Cipher_New (decrypt) failed\n", __FUNCTION__);
 		return FALSE;

--- a/winpr/libwinpr/crypto/test/TestCryptoHash.c
+++ b/winpr/libwinpr/crypto/test/TestCryptoHash.c
@@ -18,7 +18,7 @@ static BOOL test_crypto_hash_md5(void)
 		fprintf(stderr, "%s: winpr_Digest_New failed\n", __FUNCTION__);
 		return FALSE;
 	}
-	if (!winpr_Digest_Init(ctx, WINPR_MD_MD5))
+	if (!winpr_Digest_Init(ctx, WINPR_MD_MD5, TRUE))
 	{
 		fprintf(stderr, "%s: winpr_Digest_Init failed\n", __FUNCTION__);
 		goto out;
@@ -69,7 +69,7 @@ static BOOL test_crypto_hash_md4(void)
 		fprintf(stderr, "%s: winpr_Digest_New failed\n", __FUNCTION__);
 		return FALSE;
 	}
-	if (!winpr_Digest_Init(ctx, WINPR_MD_MD4))
+	if (!winpr_Digest_Init(ctx, WINPR_MD_MD4, TRUE))
 	{
 		fprintf(stderr, "%s: winpr_Digest_Init failed\n", __FUNCTION__);
 		goto out;
@@ -120,7 +120,7 @@ static BOOL test_crypto_hash_sha1(void)
 		fprintf(stderr, "%s: winpr_Digest_New failed\n", __FUNCTION__);
 		return FALSE;
 	}
-	if (!winpr_Digest_Init(ctx, WINPR_MD_SHA1))
+	if (!winpr_Digest_Init(ctx, WINPR_MD_SHA1, TRUE))
 	{
 		fprintf(stderr, "%s: winpr_Digest_Init failed\n", __FUNCTION__);
 		goto out;
@@ -174,7 +174,7 @@ static BOOL test_crypto_hash_hmac_md5(void)
 		return FALSE;
 	}
 
-	if (!winpr_HMAC_Init(ctx, WINPR_MD_MD5, TEST_HMAC_MD5_KEY, WINPR_MD5_DIGEST_LENGTH))
+	if (!winpr_HMAC_Init(ctx, WINPR_MD_MD5, TEST_HMAC_MD5_KEY, WINPR_MD5_DIGEST_LENGTH, TRUE))
 	{
 		fprintf(stderr, "%s: winpr_HMAC_Init failed\n", __FUNCTION__);
 		goto out;
@@ -228,7 +228,7 @@ static BOOL test_crypto_hash_hmac_sha1(void)
 		return FALSE;
 	}
 
-	if (!winpr_HMAC_Init(ctx, WINPR_MD_SHA1, TEST_HMAC_SHA1_KEY, WINPR_SHA1_DIGEST_LENGTH))
+	if (!winpr_HMAC_Init(ctx, WINPR_MD_SHA1, TEST_HMAC_SHA1_KEY, WINPR_SHA1_DIGEST_LENGTH, TRUE))
 	{
 		fprintf(stderr, "%s: winpr_HMAC_Init failed\n", __FUNCTION__);
 		goto out;

--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -994,7 +994,7 @@ SECURITY_STATUS SEC_ENTRY ntlm_EncryptMessage(PCtxtHandle phContext, ULONG fQOP,
 	/* Compute the HMAC-MD5 hash of ConcatenationOf(seq_num,data) using the client signing key */
 	hmac = winpr_HMAC_New();
 
-	if (hmac && winpr_HMAC_Init(hmac, WINPR_MD_MD5, context->SendSigningKey, WINPR_MD5_DIGEST_LENGTH))
+	if (hmac && winpr_HMAC_Init(hmac, WINPR_MD_MD5, context->SendSigningKey, WINPR_MD5_DIGEST_LENGTH, FALSE))
 	{
 		Data_Write_UINT32(&value, SeqNo);
 		winpr_HMAC_Update(hmac, (void*) &value, 4);
@@ -1090,7 +1090,7 @@ SECURITY_STATUS SEC_ENTRY ntlm_DecryptMessage(PCtxtHandle phContext, PSecBufferD
 	/* Compute the HMAC-MD5 hash of ConcatenationOf(seq_num,data) using the client signing key */
 	hmac = winpr_HMAC_New();
 
-	if (hmac && winpr_HMAC_Init(hmac, WINPR_MD_MD5, context->RecvSigningKey, WINPR_MD5_DIGEST_LENGTH))
+	if (hmac && winpr_HMAC_Init(hmac, WINPR_MD_MD5, context->RecvSigningKey, WINPR_MD5_DIGEST_LENGTH, FALSE))
 	{
 		Data_Write_UINT32(&value, SeqNo);
 		winpr_HMAC_Update(hmac, (void*) &value, 4);

--- a/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
@@ -287,7 +287,7 @@ void ntlm_compute_channel_bindings(NTLM_CONTEXT* context)
 	if (!(md5 = winpr_Digest_New()))
 		return;
 
-	if (!winpr_Digest_Init(md5, WINPR_MD_MD5))
+	if (!winpr_Digest_Init(md5, WINPR_MD_MD5, TRUE))
 		goto out;
 
 	ChannelBindingTokenLength = context->Bindings.BindingsLength - sizeof(SEC_CHANNEL_BINDINGS);

--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
@@ -560,7 +560,7 @@ int ntlm_generate_signing_key(BYTE* exported_session_key, PSecBuffer sign_magic,
 	CopyMemory(value, exported_session_key, WINPR_MD5_DIGEST_LENGTH);
 	CopyMemory(&value[WINPR_MD5_DIGEST_LENGTH], sign_magic->pvBuffer, sign_magic->cbBuffer);
 
-	if (!winpr_Digest(WINPR_MD_MD5, value, length, signing_key, WINPR_MD5_DIGEST_LENGTH))
+	if (!winpr_Digest(WINPR_MD_MD5, value, length, signing_key, WINPR_MD5_DIGEST_LENGTH, FALSE))
 	{
 		free(value);
 		return -1;
@@ -618,7 +618,7 @@ int ntlm_generate_sealing_key(BYTE* exported_session_key, PSecBuffer seal_magic,
 	CopyMemory(p, exported_session_key, WINPR_MD5_DIGEST_LENGTH);
 	CopyMemory(&p[WINPR_MD5_DIGEST_LENGTH], seal_magic->pvBuffer, seal_magic->cbBuffer);
 
-	if (!winpr_Digest(WINPR_MD_MD5, buffer.pvBuffer, buffer.cbBuffer, sealing_key, WINPR_MD5_DIGEST_LENGTH))
+	if (!winpr_Digest(WINPR_MD_MD5, buffer.pvBuffer, buffer.cbBuffer, sealing_key, WINPR_MD5_DIGEST_LENGTH, FALSE))
 	{
 		sspi_SecBufferFree(&buffer);
 		return -1;
@@ -695,7 +695,7 @@ void ntlm_compute_message_integrity_check(NTLM_CONTEXT* context)
 	if (!hmac)
 		return;
 
-	if (winpr_HMAC_Init(hmac, WINPR_MD_MD5, context->ExportedSessionKey, WINPR_MD5_DIGEST_LENGTH))
+	if (winpr_HMAC_Init(hmac, WINPR_MD_MD5, context->ExportedSessionKey, WINPR_MD5_DIGEST_LENGTH, FALSE))
 	{
 		winpr_HMAC_Update(hmac, (BYTE*) context->NegotiateMessage.pvBuffer, context->NegotiateMessage.cbBuffer);
 		winpr_HMAC_Update(hmac, (BYTE*) context->ChallengeMessage.pvBuffer, context->ChallengeMessage.cbBuffer);

--- a/winpr/libwinpr/utils/ntlm.c
+++ b/winpr/libwinpr/utils/ntlm.c
@@ -42,7 +42,7 @@ BYTE* NTOWFv1W(LPWSTR Password, UINT32 PasswordLength, BYTE* NtHash)
 	if (!NtHash && !(NtHash = malloc(WINPR_MD4_DIGEST_LENGTH)))
 		return NULL;
 
-	if (!winpr_Digest(WINPR_MD_MD4, (BYTE*) Password, (size_t) PasswordLength, NtHash, WINPR_MD4_DIGEST_LENGTH))
+	if (!winpr_Digest(WINPR_MD_MD4, (BYTE*) Password, (size_t) PasswordLength, NtHash, WINPR_MD4_DIGEST_LENGTH, FALSE))
 	{
 		if (allocate)
 		{


### PR DESCRIPTION
Crypto algorithms, which aren't FIPS-compliant (i.e. MD5, RC4), can be still used for some functionality, which isn't security-relevant, on systems with enabled FIPS mode. Let's allow weak ciphers in specific cases (i.e. licensing).

Thanks to this patches, FreeRDP works properly with RDP, or TLS security on systems with enabled FIPS mode.

See https://github.com/FreeRDP/FreeRDP/issues/3412 for more details.