### PR TITLE
some performance fixes

### DIFF
--- a/libfreerdp/codec/rfx_rlgr.c
+++ b/libfreerdp/codec/rfx_rlgr.c
@@ -76,6 +76,14 @@
 
 static BOOL g_LZCNT = FALSE;
 
+static INIT_ONCE rfx_rlgr_init_once = INIT_ONCE_STATIC_INIT;
+
+static BOOL CALLBACK rfx_rlgr_init(PINIT_ONCE once, PVOID param, PVOID *context)
+{
+	g_LZCNT = IsProcessorFeaturePresentEx(PF_EX_LZCNT);
+	return TRUE;
+}
+
 static INLINE UINT32 lzcnt_s(UINT32 x)
 {
 	if (!x)
@@ -116,7 +124,7 @@ int rfx_rlgr_decode(RLGR_MODE mode, const BYTE* pSrcData, UINT32 SrcSize, INT16*
 	wBitStream* bs;
 	wBitStream s_bs;
 
-	g_LZCNT = IsProcessorFeaturePresentEx(PF_EX_LZCNT);
+	InitOnceExecuteOnce(&rfx_rlgr_init_once, rfx_rlgr_init, NULL, NULL);
 
 	k = 1;
 	kp = k << LSGR;

--- a/libfreerdp/utils/profiler.c
+++ b/libfreerdp/utils/profiler.c
@@ -67,30 +67,21 @@ void profiler_exit(PROFILER* profiler)
 
 void profiler_print_header(void)
 {
-	WLog_INFO(TAG,
-	          "                                             |-----------------------|-----------------------|");
-	WLog_INFO(TAG,
-	          "                PROFILER                     |    elapsed seconds    |          FPS          |");
-	WLog_INFO(TAG,
-	          "|--------------------------------------------|-----------------------|-----------------------");
-	WLog_INFO(TAG,
-	          "| code section                  | iterations |     total |      avg. |     total |      avg. |");
-	WLog_INFO(TAG,
-	          "|-------------------------------|------------|-----------|-----------|-----------|-----------|");
+	WLog_INFO(TAG, "-------------------------------+------------+-------------+-----------+-------");
+	WLog_INFO(TAG, "PROFILER NAME                  |      COUNT |       TOTAL |       AVG |    IPS");
+	WLog_INFO(TAG, "-------------------------------+------------+-------------+-----------+-------");
 }
 
 void profiler_print(PROFILER* profiler)
 {
-	const double elapsed_sec = stopwatch_get_elapsed_time_in_seconds(profiler->stopwatch);
-	const double avg_sec = elapsed_sec / (double) profiler->stopwatch->count;
-	const double fps = 1.0 / elapsed_sec;
-	const double avg_fps = 1.0 / avg_sec;
-	WLog_INFO(TAG,  "| %-30.30s| %10"PRIu32" | %9f | %9f | %9f | %9f |",
-	          profiler->name, profiler->stopwatch->count, elapsed_sec, avg_sec,
-	          fps, avg_fps);
+	double s = stopwatch_get_elapsed_time_in_seconds(profiler->stopwatch);
+	double avg = profiler->stopwatch->count == 0 ? 0 : s / profiler->stopwatch->count;
+
+	WLog_INFO(TAG, "%-30s | %10u | %10.4fs | %8.6fs | %6.0f",
+		profiler->name, profiler->stopwatch->count, s, avg, profiler->stopwatch->count / s);
 }
 
 void profiler_print_footer(void)
 {
-	WLog_INFO(TAG,  "|--------------------------------------------------------------------|");
+	WLog_INFO(TAG, "-------------------------------+------------+-------------+-----------+-------");
 }


### PR DESCRIPTION
- draw only the updated region in the gdi and x11 surface bits implementation
- don't repeatedly call IsProcessorFeaturePresentEx in rfx rlgr decoder
- fix ugly and unaligned profiler print layout and remove an unnecessary value