### PR TITLE
Fixes for AVC420, Warnings and tests

### DIFF
--- a/client/common/test/TestClientRdpFile.c
+++ b/client/common/test/TestClientRdpFile.c
@@ -336,6 +336,8 @@ int TestClientRdpFile(int argc, char* argv[])
 	}
 
 	iValue = freerdp_client_rdp_file_get_integer_option(file, "vendor integer");
+	if (iValue != 123)
+		return -1;
 
 	if (freerdp_client_rdp_file_set_integer_option(file, "vendor integer", 456) == -1)
 	{
@@ -344,9 +346,18 @@ int TestClientRdpFile(int argc, char* argv[])
 	}
 
 	iValue = freerdp_client_rdp_file_get_integer_option(file, "vendor integer");
+	if (iValue != 456)
+		return -1;
+
 	sValue = (char*) freerdp_client_rdp_file_get_string_option(file, "vendor string");
+	if (strncmp(sValue, "microsoft", 10) != 0)
+		return -1;
+
 	freerdp_client_rdp_file_set_string_option(file, "vendor string", "apple");
 	sValue = (char*) freerdp_client_rdp_file_get_string_option(file, "vendor string");
+	if (strncmp(sValue, "apple", 6) != 0)
+		return -1;
+
 	freerdp_client_rdp_file_set_string_option(file, "fruits", "banana,oranges");
 
 	if (freerdp_client_rdp_file_set_integer_option(file, "numbers", 123456789) == -1)

--- a/libfreerdp/codec/nsc_encode.c
+++ b/libfreerdp/codec/nsc_encode.c
@@ -95,10 +95,10 @@ static void nsc_encode_argb_to_aycocg(NSC_CONTEXT* context, const BYTE* data,
 	UINT16 rw;
 	BYTE ccl;
 	const BYTE* src;
-	BYTE* yplane;
-	BYTE* coplane;
-	BYTE* cgplane;
-	BYTE* aplane;
+	BYTE* yplane = NULL;
+	BYTE* coplane = NULL;
+	BYTE* cgplane = NULL;
+	BYTE* aplane = NULL;
 	INT16 r_val;
 	INT16 g_val;
 	INT16 b_val;
@@ -109,10 +109,6 @@ static void nsc_encode_argb_to_aycocg(NSC_CONTEXT* context, const BYTE* data,
 	tempHeight = ROUND_UP_TO(context->height, 2);
 	rw = (context->ChromaSubsamplingLevel ? tempWidth : context->width);
 	ccl = context->ColorLossLevel;
-	yplane = context->priv->PlaneBuffers[0];
-	coplane = context->priv->PlaneBuffers[1];
-	cgplane = context->priv->PlaneBuffers[2];
-	aplane = context->priv->PlaneBuffers[3];
 
 	for (y = 0; y < context->height; y++)
 	{

--- a/libfreerdp/codec/nsc_sse2.c
+++ b/libfreerdp/codec/nsc_sse2.c
@@ -42,10 +42,10 @@ static void nsc_encode_argb_to_aycocg_sse2(NSC_CONTEXT* context,
 	UINT16 rw;
 	BYTE ccl;
 	const BYTE* src;
-	BYTE* yplane;
-	BYTE* coplane;
-	BYTE* cgplane;
-	BYTE* aplane;
+	BYTE* yplane = NULL;
+	BYTE* coplane = NULL;
+	BYTE* cgplane = NULL;
+	BYTE* aplane = NULL;
 	__m128i r_val;
 	__m128i g_val;
 	__m128i b_val;
@@ -59,10 +59,6 @@ static void nsc_encode_argb_to_aycocg_sse2(NSC_CONTEXT* context,
 	tempHeight = ROUND_UP_TO(context->height, 2);
 	rw = (context->ChromaSubsamplingLevel > 0 ? tempWidth : context->width);
 	ccl = context->ColorLossLevel;
-	yplane = context->priv->PlaneBuffers[0];
-	coplane = context->priv->PlaneBuffers[1];
-	cgplane = context->priv->PlaneBuffers[2];
-	aplane = context->priv->PlaneBuffers[3];
 
 	for (y = 0; y < context->height; y++)
 	{

--- a/libfreerdp/codec/test/TestFreeRDPCodecMppc.c
+++ b/libfreerdp/codec/test/TestFreeRDPCodecMppc.c
@@ -6,7 +6,7 @@
 #include <freerdp/codec/mppc.h>
 #include <freerdp/log.h>
 
-static BYTE TEST_RDP5_COMPRESSED_DATA[] =
+static const BYTE TEST_RDP5_COMPRESSED_DATA[] =
 {
 	0x24, 0x02, 0x03, 0x09, 0x00, 0x20, 0x0c, 0x05, 0x10, 0x01, 0x40, 0x0a, 0xbf, 0xdf, 0xc3, 0x20,
 	0x80, 0x00, 0x1f, 0x0a, 0x00, 0x00, 0x07, 0x43, 0x4e, 0x00, 0x68, 0x02, 0x00, 0x22, 0x00, 0x34,
@@ -188,7 +188,7 @@ static BYTE TEST_RDP5_COMPRESSED_DATA[] =
 	0x7f, 0x52, 0x00
 };
 
-static BYTE TEST_RDP5_UNCOMPRESSED_DATA[] =
+static const BYTE TEST_RDP5_UNCOMPRESSED_DATA[] =
 {
 	0x24, 0x02, 0x03, 0x09, 0x00, 0x20, 0x0c, 0x05, 0x10, 0x01, 0x40, 0x0a, 0xff, 0xff, 0x0c, 0x84,
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1d, 0x0d, 0x38, 0x01, 0xc0, 0x10, 0x01, 0x10,
@@ -737,8 +737,9 @@ static const BYTE TEST_ISLAND_DATA_RDP5[] =
 	"\x43\x7b\x6f\xa8\xe5\x8b\xd0\xf0\xe8\xde\xd8\xd8\xe7\xec\xf3\xa7"
 	"\xe4\x7c\xa7\xe2\x9f\x01\x99\x4b\x80";
 
-int test_MppcCompressBellsRdp5()
+static int test_MppcCompressBellsRdp5(void)
 {
+	int rc = -1;
 	int status;
 	UINT32 Flags;
 	UINT32 SrcSize;
@@ -749,18 +750,23 @@ int test_MppcCompressBellsRdp5()
 	UINT32 expectedSize;
 	BYTE OutputBuffer[65536];
 	mppc = mppc_context_new(1, TRUE);
+	if (!mppc)
+		return -1;
+
 	SrcSize = sizeof(TEST_MPPC_BELLS) - 1;
 	pSrcData = (BYTE*) TEST_MPPC_BELLS;
 	expectedSize = sizeof(TEST_MPPC_BELLS_RDP5) - 1;
 	DstSize = sizeof(OutputBuffer);
 	pDstData = OutputBuffer;
 	status = mppc_compress(mppc, pSrcData, SrcSize, &pDstData, &DstSize, &Flags);
+	if (status < 0)
+		goto fail;
 	printf("Flags: 0x%08"PRIX32" DstSize: %"PRIu32"\n", Flags, DstSize);
 
 	if (DstSize != expectedSize)
 	{
 		printf("MppcCompressBellsRdp5: output size mismatch: Actual: %"PRIu32", Expected: %"PRIu32"\n", DstSize, expectedSize);
-		return -1;
+		goto fail;
 	}
 
 	if (memcmp(pDstData, TEST_MPPC_BELLS_RDP5, DstSize) != 0)
@@ -770,15 +776,19 @@ int test_MppcCompressBellsRdp5()
 		BitDump(__FUNCTION__, WLOG_INFO, pDstData, DstSize * 8, 0);
 		printf("Expected\n");
 		BitDump(__FUNCTION__, WLOG_INFO, TEST_MPPC_BELLS_RDP5, DstSize * 8, 0);
-		return -1;
+		goto fail;
 	}
 
+	rc = 0;
+
+fail:
 	mppc_context_free(mppc);
-	return 0;
+	return rc;
 }
 
-int test_MppcCompressBellsRdp4()
+static int test_MppcCompressBellsRdp4(void)
 {
+	int rc = -1;
 	int status;
 	UINT32 Flags;
 	BYTE* pSrcData;
@@ -788,19 +798,26 @@ int test_MppcCompressBellsRdp4()
 	MPPC_CONTEXT* mppc;
 	UINT32 expectedSize;
 	BYTE OutputBuffer[65536];
+
 	mppc = mppc_context_new(0, TRUE);
+	if (!mppc)
+		return -1;
+
 	SrcSize = sizeof(TEST_MPPC_BELLS) - 1;
 	pSrcData = (BYTE*) TEST_MPPC_BELLS;
 	expectedSize = sizeof(TEST_MPPC_BELLS_RDP4) - 1;
 	DstSize = sizeof(OutputBuffer);
 	pDstData = OutputBuffer;
 	status = mppc_compress(mppc, pSrcData, SrcSize, &pDstData, &DstSize, &Flags);
+	if (status < 0)
+		goto fail;
+
 	printf("flags: 0x%08"PRIX32" size: %"PRIu32"\n", Flags, DstSize);
 
 	if (DstSize != expectedSize)
 	{
 		printf("MppcCompressBellsRdp4: output size mismatch: Actual: %"PRIu32", Expected: %"PRIu32"\n", DstSize, expectedSize);
-		return -1;
+		goto fail;
 	}
 
 	if (memcmp(pDstData, TEST_MPPC_BELLS_RDP4, DstSize) != 0)
@@ -810,15 +827,19 @@ int test_MppcCompressBellsRdp4()
 		BitDump(__FUNCTION__, WLOG_INFO, pDstData, DstSize * 8, 0);
 		printf("Expected\n");
 		BitDump(__FUNCTION__, WLOG_INFO, TEST_MPPC_BELLS_RDP4, DstSize * 8, 0);
-		return -1;
+		goto fail;
 	}
 
+	rc = 0;
+
+fail:
 	mppc_context_free(mppc);
-	return 0;
+	return rc;
 }
 
-int test_MppcDecompressBellsRdp5()
+static int test_MppcDecompressBellsRdp5(void)
 {
+	int rc = -1;
 	int status;
 	UINT32 Flags;
 	BYTE* pSrcData;
@@ -827,32 +848,43 @@ int test_MppcDecompressBellsRdp5()
 	MPPC_CONTEXT* mppc;
 	UINT32 expectedSize;
 	BYTE* pDstData = NULL;
+
 	mppc = mppc_context_new(1, FALSE);
+	if (!mppc)
+		return -1;
+
 	SrcSize = sizeof(TEST_MPPC_BELLS_RDP5) - 1;
 	pSrcData = (BYTE*) TEST_MPPC_BELLS_RDP5;
 	Flags = PACKET_AT_FRONT | PACKET_COMPRESSED | 1;
 	expectedSize = sizeof(TEST_MPPC_BELLS) - 1;
 	status = mppc_decompress(mppc, pSrcData, SrcSize, &pDstData, &DstSize, Flags);
+	if (status < 0)
+		goto fail;
+
 	printf("flags: 0x%08"PRIX32" size: %"PRIu32"\n", Flags, DstSize);
 
 	if (DstSize != expectedSize)
 	{
 		printf("MppcDecompressBellsRdp5: output size mismatch: Actual: %"PRIu32", Expected: %"PRIu32"\n", DstSize, expectedSize);
-		return -1;
+		goto fail;
 	}
 
 	if (memcmp(pDstData, TEST_MPPC_BELLS, DstSize) != 0)
 	{
 		printf("MppcDecompressBellsRdp5: output mismatch\n");
-		return -1;
+		goto fail;
 	}
 
+	rc = 0;
+
+fail:
 	mppc_context_free(mppc);
-	return 0;
+	return rc;
 }
 
-int test_MppcDecompressBellsRdp4()
+static int test_MppcDecompressBellsRdp4(void)
 {
+	int rc = -1;
 	int status;
 	UINT32 Flags;
 	BYTE* pSrcData;
@@ -862,31 +894,41 @@ int test_MppcDecompressBellsRdp4()
 	UINT32 expectedSize;
 	BYTE* pDstData = NULL;
 	mppc = mppc_context_new(0, FALSE);
+	if (!mppc)
+		return -1;
+
 	SrcSize = sizeof(TEST_MPPC_BELLS_RDP4) - 1;
 	pSrcData = (BYTE*) TEST_MPPC_BELLS_RDP4;
 	Flags = PACKET_AT_FRONT | PACKET_COMPRESSED | 0;
 	expectedSize = sizeof(TEST_MPPC_BELLS) - 1;
 	status = mppc_decompress(mppc, pSrcData, SrcSize, &pDstData, &DstSize, Flags);
+	if (status < 0)
+		goto fail;
+
 	printf("flags: 0x%08"PRIX32" size: %"PRIu32"\n", Flags, DstSize);
 
 	if (DstSize != expectedSize)
 	{
 		printf("MppcDecompressBellsRdp4: output size mismatch: Actual: %"PRIu32", Expected: %"PRIu32"\n", DstSize, expectedSize);
-		return -1;
+		goto fail;
 	}
 
 	if (memcmp(pDstData, TEST_MPPC_BELLS, DstSize) != 0)
 	{
 		printf("MppcDecompressBellsRdp4: output mismatch\n");
-		return -1;
+		goto fail;
 	}
 
+	rc = 0;
+
+fail:
 	mppc_context_free(mppc);
-	return 0;
+	return rc;
 }
 
-int test_MppcCompressIslandRdp5()
+static int test_MppcCompressIslandRdp5(void)
 {
+	int rc = -1;
 	int status;
 	UINT32 Flags;
 	UINT32 SrcSize;
@@ -896,19 +938,26 @@ int test_MppcCompressIslandRdp5()
 	MPPC_CONTEXT* mppc;
 	UINT32 expectedSize;
 	BYTE OutputBuffer[65536];
+
 	mppc = mppc_context_new(1, TRUE);
+	if (!mppc)
+		return -1;
+
 	SrcSize = sizeof(TEST_ISLAND_DATA) - 1;
 	pSrcData = (BYTE*) TEST_ISLAND_DATA;
 	expectedSize = sizeof(TEST_ISLAND_DATA_RDP5) - 1;
 	DstSize = sizeof(OutputBuffer);
 	pDstData = OutputBuffer;
 	status = mppc_compress(mppc, pSrcData, SrcSize, &pDstData, &DstSize, &Flags);
+	if (status < 0)
+		goto fail;
+
 	printf("Flags: 0x%08"PRIX32" DstSize: %"PRIu32"\n", Flags, DstSize);
 
 	if (DstSize != expectedSize)
 	{
 		printf("MppcCompressIslandRdp5: output size mismatch: Actual: %"PRIu32", Expected: %"PRIu32"\n", DstSize, expectedSize);
-		return -1;
+		goto fail;
 	}
 
 	if (memcmp(pDstData, TEST_ISLAND_DATA_RDP5, DstSize) != 0)
@@ -918,15 +967,19 @@ int test_MppcCompressIslandRdp5()
 		BitDump(__FUNCTION__, WLOG_INFO, pDstData, DstSize * 8, 0);
 		printf("Expected\n");
 		BitDump(__FUNCTION__, WLOG_INFO, TEST_ISLAND_DATA_RDP5, DstSize * 8, 0);
-		return -1;
+		goto fail;
 	}
 
+	rc = 0;
+
+fail:
 	mppc_context_free(mppc);
-	return 0;
+	return rc;
 }
 
-int test_MppcCompressBufferRdp5()
+static int test_MppcCompressBufferRdp5(void)
 {
+	int rc = -1;
 	int status;
 	UINT32 Flags;
 	BYTE* pSrcData;
@@ -936,33 +989,44 @@ int test_MppcCompressBufferRdp5()
 	MPPC_CONTEXT* mppc;
 	UINT32 expectedSize;
 	BYTE OutputBuffer[65536];
+
 	mppc = mppc_context_new(1, TRUE);
+	if (!mppc)
+		return -1;
+
 	SrcSize = sizeof(TEST_RDP5_UNCOMPRESSED_DATA);
 	pSrcData = (BYTE*) TEST_RDP5_UNCOMPRESSED_DATA;
 	expectedSize = sizeof(TEST_RDP5_COMPRESSED_DATA);
 	DstSize = sizeof(OutputBuffer);
 	pDstData = OutputBuffer;
 	status = mppc_compress(mppc, pSrcData, SrcSize, &pDstData, &DstSize, &Flags);
+	if (status < 0)
+		goto fail;
+
 	printf("flags: 0x%08"PRIX32" size: %"PRIu32"\n", Flags, DstSize);
 
 	if (DstSize != expectedSize)
 	{
 		printf("MppcCompressBufferRdp5: output size mismatch: Actual: %"PRIu32", Expected: %"PRIu32"\n", DstSize, expectedSize);
-		return -1;
+		goto fail;
 	}
 
 	if (memcmp(pDstData, TEST_RDP5_COMPRESSED_DATA, DstSize) != 0)
 	{
 		printf("MppcCompressBufferRdp5: output mismatch: compressed output does not match Microsoft implementation\n");
-		return -1;
+		goto fail;
 	}
 
+	rc = 0;
+
+fail:
 	mppc_context_free(mppc);
-	return 0;
+	return rc;
 }
 
-int test_MppcDecompressBufferRdp5()
+static int test_MppcDecompressBufferRdp5(void)
 {
+	int rc = -1;
 	int status;
 	UINT32 Flags;
 	BYTE* pSrcData;
@@ -971,28 +1035,38 @@ int test_MppcDecompressBufferRdp5()
 	MPPC_CONTEXT* mppc;
 	UINT32 expectedSize;
 	BYTE* pDstData = NULL;
+
 	mppc = mppc_context_new(1, FALSE);
+	if (!mppc)
+		return -1;
+
 	SrcSize = sizeof(TEST_RDP5_COMPRESSED_DATA);
 	pSrcData = (BYTE*) TEST_RDP5_COMPRESSED_DATA;
 	Flags = PACKET_AT_FRONT | PACKET_COMPRESSED | 1;
 	expectedSize = sizeof(TEST_RDP5_UNCOMPRESSED_DATA);
 	status = mppc_decompress(mppc, pSrcData, SrcSize, &pDstData, &DstSize, Flags);
+	if (status < 0)
+		goto fail;
+
 	printf("flags: 0x%08"PRIX32" size: %"PRIu32"\n", Flags, DstSize);
 
 	if (DstSize != expectedSize)
 	{
 		printf("MppcDecompressBufferRdp5: output size mismatch: Actual: %"PRIu32", Expected: %"PRIu32"\n", DstSize, expectedSize);
-		return -1;
+		goto fail;
 	}
 
 	if (memcmp(pDstData, TEST_RDP5_UNCOMPRESSED_DATA, DstSize) != 0)
 	{
 		printf("MppcDecompressBufferRdp5: output mismatch\n");
-		return -1;
+		goto fail;
 	}
 
+	rc = 0;
+
+fail:
 	mppc_context_free(mppc);
-	return 0;
+	return rc;
 }
 
 int TestFreeRDPCodecMppc(int argc, char* argv[])

--- a/libfreerdp/codec/test/TestFreeRDPCodecProgressive.c
+++ b/libfreerdp/codec/test/TestFreeRDPCodecProgressive.c
@@ -265,7 +265,7 @@ static int test_image_fill_unused_quarters(BYTE* pDstData, int nDstStep, int nWi
 	return 1;
 }
 
-BYTE* test_progressive_load_file(char* path, char* file, UINT32* size)
+static BYTE* test_progressive_load_file(char* path, char* file, UINT32* size)
 {
 	FILE* fp;
 	BYTE* buffer;
@@ -303,7 +303,7 @@ BYTE* test_progressive_load_file(char* path, char* file, UINT32* size)
 	return buffer;
 }
 
-int test_progressive_load_files(char* ms_sample_path, EGFX_SAMPLE_FILE files[3][4][4])
+static int test_progressive_load_files(char* ms_sample_path, EGFX_SAMPLE_FILE files[3][4][4])
 {
 	int imageNo = 0;
 	int quarterNo = 0;
@@ -465,7 +465,6 @@ int test_progressive_load_files(char* ms_sample_path, EGFX_SAMPLE_FILE files[3][
 	passNo = (passNo + 1) % 4;
 	files[imageNo][quarterNo][passNo].buffer = test_progressive_load_file(ms_sample_path,
 	        "compress/enc_2_3_100_sampleimage3.bin", &(files[imageNo][quarterNo][passNo].size));
-	passNo = (passNo + 1) % 4;
 
 	/* check if all test data has been loaded */
 
@@ -484,7 +483,7 @@ int test_progressive_load_files(char* ms_sample_path, EGFX_SAMPLE_FILE files[3][
 	return 1;
 }
 
-BYTE* test_progressive_load_bitmap(char* path, char* file, UINT32* size, int quarter)
+static BYTE* test_progressive_load_bitmap(char* path, char* file, UINT32* size, int quarter)
 {
 	int status;
 	BYTE* buffer;
@@ -515,7 +514,7 @@ BYTE* test_progressive_load_bitmap(char* path, char* file, UINT32* size, int qua
 	return buffer;
 }
 
-int test_progressive_load_bitmaps(char* ms_sample_path, EGFX_SAMPLE_FILE bitmaps[3][4][4])
+static int test_progressive_load_bitmaps(char* ms_sample_path, EGFX_SAMPLE_FILE bitmaps[3][4][4])
 {
 	int imageNo = 0;
 	int quarterNo = 0;
@@ -677,7 +676,6 @@ int test_progressive_load_bitmaps(char* ms_sample_path, EGFX_SAMPLE_FILE bitmaps
 	passNo = (passNo + 1) % 4;
 	bitmaps[imageNo][quarterNo][passNo].buffer = test_progressive_load_bitmap(ms_sample_path,
 	        "decompress/dec_2_3_100_sampleimage3.bmp", &(bitmaps[imageNo][quarterNo][passNo].size), quarterNo);
-	passNo = (passNo + 1) % 4;
 
 	/* check if all test data has been loaded */
 

--- a/libfreerdp/codec/test/TestFreeRDPCodecZGfx.c
+++ b/libfreerdp/codec/test/TestFreeRDPCodecZGfx.c
@@ -24,8 +24,9 @@ static const BYTE TEST_FOX_DATA_MULTIPART[] =
 	"\x00\x00\x24\x39\x08\x0E\x91\xF8\xD8\x61\x3D\x1E\x44\x06\x43\x79"
 	"\x9C\x02";
 
-int test_ZGfxCompressFox()
+static int test_ZGfxCompressFox(void)
 {
+	int rc = -1;
 	int status;
 	UINT32 Flags;
 	BYTE* pSrcData;
@@ -36,17 +37,23 @@ int test_ZGfxCompressFox()
 	UINT32 expectedSize;
 
 	zgfx = zgfx_context_new(TRUE);
+	if (!zgfx)
+		return -1;
+
 	SrcSize = sizeof(TEST_FOX_DATA) - 1;
 	pSrcData = (BYTE*) TEST_FOX_DATA;
 	Flags = 0;
 	expectedSize = sizeof(TEST_FOX_DATA_SINGLE) - 1;
 	status = zgfx_compress(zgfx, pSrcData, SrcSize, &pDstData, &DstSize, &Flags);
+	if (status < 0)
+		goto fail;
+
 	printf("flags: 0x%08"PRIX32" size: %"PRIu32"\n", Flags, DstSize);
 
 	if (DstSize != expectedSize)
 	{
 		printf("test_ZGfxCompressFox: output size mismatch: Actual: %"PRIu32", Expected: %"PRIu32"\n", DstSize, expectedSize);
-		return -1;
+		goto fail;
 	}
 
 	if (memcmp(pDstData, TEST_FOX_DATA_SINGLE, DstSize) != 0)
@@ -56,15 +63,19 @@ int test_ZGfxCompressFox()
 		BitDump(__FUNCTION__, WLOG_INFO, pDstData, DstSize * 8, 0);
 		printf("Expected\n");
 		BitDump(__FUNCTION__, WLOG_INFO, TEST_FOX_DATA_SINGLE, DstSize * 8, 0);
-		return -1;
+		goto fail;
 	}
 
+	rc = 0;
+
+fail:
 	zgfx_context_free(zgfx);
-	return 0;
+	return rc;
 }
 
-int test_ZGfxDecompressFoxSingle()
+static int test_ZGfxDecompressFoxSingle(void)
 {
+	int rc = -1;
 	int status;
 	UINT32 Flags;
 	BYTE* pSrcData;
@@ -75,17 +86,23 @@ int test_ZGfxDecompressFoxSingle()
 	UINT32 expectedSize;
 
 	zgfx = zgfx_context_new(TRUE);
+	if (!zgfx)
+		return -1;
+
 	SrcSize = sizeof(TEST_FOX_DATA_SINGLE) - 1;
 	pSrcData = (BYTE*) TEST_FOX_DATA_SINGLE;
 	Flags = 0;
 	expectedSize = sizeof(TEST_FOX_DATA) - 1;
 	status = zgfx_decompress(zgfx, pSrcData, SrcSize, &pDstData, &DstSize, Flags);
+	if (status < 0)
+		goto fail;
+
 	printf("flags: 0x%08"PRIX32" size: %"PRIu32"\n", Flags, DstSize);
 
 	if (DstSize != expectedSize)
 	{
 		printf("test_ZGfxDecompressFoxSingle: output size mismatch: Actual: %"PRIu32", Expected: %"PRIu32"\n", DstSize, expectedSize);
-		return -1;
+		goto fail;
 	}
 
 	if (memcmp(pDstData, TEST_FOX_DATA, DstSize) != 0)
@@ -95,15 +112,19 @@ int test_ZGfxDecompressFoxSingle()
 		BitDump(__FUNCTION__, WLOG_INFO, pDstData, DstSize * 8, 0);
 		printf("Expected\n");
 		BitDump(__FUNCTION__, WLOG_INFO, TEST_FOX_DATA, DstSize * 8, 0);
-		return -1;
+		goto fail;
 	}
 
+	rc = 0;
+
+fail:
 	zgfx_context_free(zgfx);
-	return 0;
+	return rc;
 }
 
-int test_ZGfxDecompressFoxMultipart()
+static int test_ZGfxDecompressFoxMultipart(void)
 {
+	int rc = -1;
 	int status;
 	UINT32 Flags;
 	BYTE* pSrcData;
@@ -114,17 +135,23 @@ int test_ZGfxDecompressFoxMultipart()
 	UINT32 expectedSize;
 
 	zgfx = zgfx_context_new(TRUE);
+	if (!zgfx)
+		return -1;
+
 	SrcSize = sizeof(TEST_FOX_DATA_MULTIPART) - 1;
 	pSrcData = (BYTE*) TEST_FOX_DATA_MULTIPART;
 	Flags = 0;
 	expectedSize = sizeof(TEST_FOX_DATA) - 1;
 	status = zgfx_decompress(zgfx, pSrcData, SrcSize, &pDstData, &DstSize, Flags);
+	if (status < 0)
+		goto fail;
+
 	printf("flags: 0x%08"PRIX32" size: %"PRIu32"\n", Flags, DstSize);
 
 	if (DstSize != expectedSize)
 	{
 		printf("test_ZGfxDecompressFoxSingle: output size mismatch: Actual: %"PRIu32", Expected: %"PRIu32"\n", DstSize, expectedSize);
-		return -1;
+		goto fail;
 	}
 
 	if (memcmp(pDstData, TEST_FOX_DATA, DstSize) != 0)
@@ -134,15 +161,19 @@ int test_ZGfxDecompressFoxMultipart()
 		BitDump(__FUNCTION__, WLOG_INFO, pDstData, DstSize * 8, 0);
 		printf("Expected\n");
 		BitDump(__FUNCTION__, WLOG_INFO, TEST_FOX_DATA, DstSize * 8, 0);
-		return -1;
+		goto fail;
 	}
 
+	rc = 0;
+
+fail:
 	zgfx_context_free(zgfx);
 	return 0;
 }
 
-int test_ZGfxCompressConsistent()
+static int test_ZGfxCompressConsistent(void)
 {
+	int rc = -1;
 	int status;
 	UINT32 Flags;
 	BYTE* pSrcData;
@@ -158,22 +189,30 @@ int test_ZGfxCompressConsistent()
 	memset(BigBuffer, 0xaa, sizeof(BigBuffer));
 	memcpy(BigBuffer, TEST_FOX_DATA, sizeof(TEST_FOX_DATA) - 1);
 	zgfx = zgfx_context_new(TRUE);
-	
+	if (!zgfx)
+		return -1;
+
 	/* Compress */
 	expectedSize = SrcSize = sizeof(BigBuffer);
 	pSrcData = (BYTE*) BigBuffer;
 	Flags = 0;
 	status = zgfx_compress(zgfx, pSrcData, SrcSize, &pDstData2, &DstSize2, &Flags);
+	if (status < 0)
+		goto fail;
+
 	printf("Compress: flags: 0x%08"PRIX32" size: %"PRIu32"\n", Flags, DstSize2);
 
 	/* Decompress */
 	status = zgfx_decompress(zgfx, pDstData2, DstSize2, &pDstData, &DstSize, Flags);
+	if (status < 0)
+		goto fail;
+
 	printf("Decompress: flags: 0x%08"PRIX32" size: %"PRIu32"\n", Flags, DstSize);
 
 	if (DstSize != expectedSize)
 	{
 		printf("test_ZGfxDecompressFoxSingle: output size mismatch: Actual: %"PRIu32", Expected: %"PRIu32"\n", DstSize, expectedSize);
-		return -1;
+		goto fail;
 	}
 
 	if (memcmp(pDstData, BigBuffer, DstSize) != 0)
@@ -191,11 +230,13 @@ int test_ZGfxCompressConsistent()
 		BitDump(__FUNCTION__, WLOG_INFO, pDstData2, 64 * 8, 0);
 		printf("...\n");
 		BitDump(__FUNCTION__, WLOG_INFO, pDstData2 + DstSize2 - 64, 64 * 8, 0);
-		return -1;
+		goto fail;
 	}
 
+	rc = 0;
+fail:
 	zgfx_context_free(zgfx);
-	return 0;
+	return rc;
 }
 
 int TestFreeRDPCodecZGfx(int argc, char* argv[])

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -159,8 +159,6 @@ int freerdp_assistance_parse_address_list(rdpAssistanceFile* file, char* list)
 
 	for (i = 0; i < count; i++)
 	{
-		length = strlen(tokens[i]);
-
 		p = tokens[i];
 
 		q = strchr(p, ':');

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -750,7 +750,6 @@ BOOL gcc_read_client_core_data(wStream* s, rdpMcs* mcs, UINT16 blockLength)
 
 		Stream_Read_UINT32(s,
 		                   settings->DeviceScaleFactor); /* deviceScaleFactor (4 bytes) */
-		blockLength -= 4;
 
 		if (settings->SelectedProtocol != serverSelectedProtocol)
 			return FALSE;

--- a/libfreerdp/gdi/test/TestGdiRop3.c
+++ b/libfreerdp/gdi/test/TestGdiRop3.c
@@ -105,7 +105,7 @@ static char* gdi_convert_postfix_to_infix(const char* postfix)
 	wStack* stack;
 	int al, bl, cl, dl;
 	char* a, *b, *c, *d;
-	al = bl = cl = dl = 0;
+	bl = cl = dl = 0;
 	stack = Stack_New(FALSE);
 	length = strlen(postfix);
 

--- a/libfreerdp/primitives/test/TestPrimitivesYCbCr.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYCbCr.c
@@ -2110,15 +2110,9 @@ static int test_bmp_cmp_count(const BYTE* mem1, const BYTE* mem2, int size,
 static int test_bmp_cmp_dump(const BYTE* actual, const BYTE* expected, int size,
                              int channel, int margin)
 {
-	int x, y;
 	int error[3];
-	UINT32 pixel = 0;
 	int count = 0;
 	int index = 0;
-	BYTE R, G, B;
-	BYTE eR, eG, eB;
-	INT16 Y, Cb, Cr;
-	R = G = B = eR = eG = eB = 0;
 	size /= 4;
 	actual += channel;
 	expected += channel;
@@ -2127,15 +2121,18 @@ static int test_bmp_cmp_dump(const BYTE* actual, const BYTE* expected, int size,
 	{
 		if (*actual != *expected)
 		{
-			pixel = *((UINT32*) &actual[-channel]);
-			pixel = GetColor(PIXEL_FORMAT_XRGB32, R, G, B, 0xff);
-			pixel = *((UINT32*) &expected[-channel]);
-			pixel = GetColor(PIXEL_FORMAT_XRGB32, eR, eG, eB, 0xFF);
-			Y = TEST_Y_COMPONENT[index];
-			Cb = TEST_CB_COMPONENT[index];
-			Cr = TEST_CR_COMPONENT[index];
-			x = index % 64;
-			y = (index - x) / 64;
+			const UINT32 pixel = *((UINT32*) &actual[-channel]);
+			const UINT32 ePixel = *((UINT32*) &expected[-channel]);
+			const INT16 Y = TEST_Y_COMPONENT[index];
+			const INT16 Cb = TEST_CB_COMPONENT[index];
+			const INT16 Cr = TEST_CR_COMPONENT[index];
+			const int x = index % 64;
+			const int y = (index - x) / 64;
+			BYTE R, G, B;
+			BYTE eR, eG, eB;
+
+			SplitColor(pixel, PIXEL_FORMAT_XRGB32, &R, &G, &B, NULL, NULL);
+			SplitColor(ePixel, PIXEL_FORMAT_XRGB32, &eR, &eG, &eB, NULL, NULL);
 			error[0] = (R > eR) ? R - eR : eR - R;
 			error[1] = (G > eG) ? G - eG : eG - G;
 			error[2] = (B > eB) ? B - eB : eB - B;
@@ -2209,6 +2206,9 @@ static int test_PrimitivesYCbCr(const primitives_t* prims, UINT32 format, prim_s
 		status = prims->yCbCrToRGB_16s8u_P3AC4R((const INT16**) pYCbCr, srcStride,
 		                                        actual, dstStride, format,
 		                                        &roi);
+		if (status != PRIMITIVES_SUCCESS)
+			goto fail;
+
 		PROFILER_EXIT(prof);
 	}
 

--- a/libfreerdp/primitives/test/TestPrimitivesYUV.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYUV.c
@@ -36,10 +36,10 @@ static BOOL similarRGB(const BYTE* src, const BYTE* dst, size_t size, UINT32 for
 {
 	size_t x;
 	const UINT32 bpp = GetBytesPerPixel(format);
-	const BOOL alpha = ColorHasAlpha(format);
 
 	for (x = 0; x < size; x++)
 	{
+		const double maxDiff = 3.0;
 		UINT32 sColor, dColor;
 		BYTE sR, sG, sB, sA;
 		BYTE dR, dG, dB, dA;
@@ -48,30 +48,19 @@ static BOOL similarRGB(const BYTE* src, const BYTE* dst, size_t size, UINT32 for
 		src += bpp;
 		dst += bpp;
 		SplitColor(sColor, format, &sR, &sG, &sB, &sA, NULL);
-		SplitColor(sColor, format, &dR, &dG, &dB, &dA, NULL);
+		SplitColor(dColor, format, &dR, &dG, &dB, &dA, NULL);
 
-		if ((abs(sR - dR) > 2) || (abs(sG - dG) > 2) || (abs(sB - dB) > 2))
+		if ((abs(sR - dR) > maxDiff) || (abs(sG - dG) > maxDiff) || (abs(sB - dB) > maxDiff))
 		{
 			fprintf(stderr, "Color value  mismatch R[%02X %02X], G[%02X %02X], B[%02X %02X] at position %lu",
 			        sR, dR, sG, dG, sA, dA, x);
 			return FALSE;
 		}
 
-		if (alpha)
+		if (dA != 0xFF)
 		{
-			if (abs(sA - dA) > 2)
-			{
-				fprintf(stderr, "Alpha value  mismatch %02X %02X at position %lu", sA, dA, x);
-				return FALSE;
-			}
-		}
-		else
-		{
-			if (dA != 0xFF)
-			{
-				fprintf(stderr, "Invalid destination alpha value %02X at position %lu", dA, x);
-				return FALSE;
-			}
+			fprintf(stderr, "Invalid destination alpha value %02X at position %lu", dA, x);
+			return FALSE;
 		}
 	}
 

--- a/libfreerdp/primitives/test/TestPrimitivesYUV.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYUV.c
@@ -39,7 +39,7 @@ static BOOL similarRGB(const BYTE* src, const BYTE* dst, size_t size, UINT32 for
 
 	for (x = 0; x < size; x++)
 	{
-		const double maxDiff = 3.0;
+		const double maxDiff = 4.0;
 		UINT32 sColor, dColor;
 		BYTE sR, sG, sB, sA;
 		BYTE dR, dG, dB, dA;

--- a/libfreerdp/utils/test/TestRingBuffer.c
+++ b/libfreerdp/utils/test/TestRingBuffer.c
@@ -22,7 +22,7 @@
 
 #include <freerdp/utils/ringbuffer.h>
 
-BOOL test_overlaps(void)
+static BOOL test_overlaps(void)
 {
 	RingBuffer rb;
 	DataChunk chunks[2];
@@ -61,7 +61,6 @@ BOOL test_overlaps(void)
 
 	if (!ringbuffer_write(&rb, &bytes[counter], 6)) /* [56789ab....] */
 		goto error;
-	counter += 6;
 
 	ringbuffer_commit_read_bytes(&rb, 6); /* [......b....] */
 	nchunks = ringbuffer_peek(&rb, chunks, 10);
@@ -222,7 +221,4 @@ int TestRingBuffer(int argc, char* argv[])
 	free(tmpBuf);
 	return 0;
 }
-
-
-
 

--- a/winpr/libwinpr/clipboard/test/TestClipboardFormats.c
+++ b/winpr/libwinpr/clipboard/test/TestClipboardFormats.c
@@ -7,22 +7,26 @@ int TestClipboardFormats(int argc, char* argv[])
 {
 	UINT32 index;
 	UINT32 count;
-	UINT32 formatId;
 	UINT32* pFormatIds;
 	const char* formatName;
 	wClipboard* clipboard;
 	UINT32 utf8StringFormatId;
+
 	clipboard = ClipboardCreate();
-	formatId = ClipboardRegisterFormat(clipboard, "text/html");
-	formatId = ClipboardRegisterFormat(clipboard, "image/bmp");
-	formatId = ClipboardRegisterFormat(clipboard, "image/png");
+	if (!clipboard)
+		return -1;
+
+	ClipboardRegisterFormat(clipboard, "text/html");
+	ClipboardRegisterFormat(clipboard, "image/bmp");
+	ClipboardRegisterFormat(clipboard, "image/png");
+
 	utf8StringFormatId = ClipboardRegisterFormat(clipboard, "UTF8_STRING");
 	pFormatIds = NULL;
 	count = ClipboardGetRegisteredFormatIds(clipboard, &pFormatIds);
 
 	for (index = 0; index < count; index++)
 	{
-		formatId = pFormatIds[index];
+		UINT32 formatId = pFormatIds[index];
 		formatName = ClipboardGetFormatName(clipboard, formatId);
 		fprintf(stderr, "Format: 0x%08"PRIX32" %s\n", formatId, formatName);
 	}
@@ -72,7 +76,7 @@ int TestClipboardFormats(int argc, char* argv[])
 
 	for (index = 0; index < count; index++)
 	{
-		formatId = pFormatIds[index];
+		UINT32 formatId = pFormatIds[index];
 		formatName = ClipboardGetFormatName(clipboard, formatId);
 		fprintf(stderr, "Format: 0x%08"PRIX32" %s\n", formatId, formatName);
 	}

--- a/winpr/libwinpr/crypto/test/TestCryptoCertEnumCertificatesInStore.c
+++ b/winpr/libwinpr/crypto/test/TestCryptoCertEnumCertificatesInStore.c
@@ -44,7 +44,7 @@ int TestCryptoCertEnumCertificatesInStore(int argc, char* argv[])
 	while ((pCertContext = CertEnumCertificatesInStore(hCertStore, pCertContext)))
 	{
 		status = CertGetNameString(pCertContext, CERT_NAME_SIMPLE_DISPLAY_TYPE, 0, NULL, NULL, 0);
-		if (status)
+		if (status == 0)
 			return -1;
 
 		pszNameString = (LPTSTR) malloc(status * sizeof(TCHAR));
@@ -55,10 +55,15 @@ int TestCryptoCertEnumCertificatesInStore(int argc, char* argv[])
 		}
 
 		status = CertGetNameString(pCertContext, CERT_NAME_SIMPLE_DISPLAY_TYPE, 0, NULL, pszNameString, status);
-		if (status)
+		if (status == 0)
+		{
+			free (pszNameString);
 			return -1;
+		}
 
 		_tprintf(_T("Certificate #%d: %s\n"), index++, pszNameString);
+
+		free(pszNameString);
 
 #ifdef WITH_CRYPTUI
 		CryptUIDlgViewContext(CERT_STORE_CERTIFICATE_CONTEXT, pCertContext, NULL, NULL, 0, NULL);

--- a/winpr/libwinpr/crypto/test/TestCryptoCertEnumCertificatesInStore.c
+++ b/winpr/libwinpr/crypto/test/TestCryptoCertEnumCertificatesInStore.c
@@ -44,6 +44,8 @@ int TestCryptoCertEnumCertificatesInStore(int argc, char* argv[])
 	while ((pCertContext = CertEnumCertificatesInStore(hCertStore, pCertContext)))
 	{
 		status = CertGetNameString(pCertContext, CERT_NAME_SIMPLE_DISPLAY_TYPE, 0, NULL, NULL, 0);
+		if (status)
+			return -1;
 
 		pszNameString = (LPTSTR) malloc(status * sizeof(TCHAR));
 		if (!pszNameString)
@@ -53,6 +55,8 @@ int TestCryptoCertEnumCertificatesInStore(int argc, char* argv[])
 		}
 
 		status = CertGetNameString(pCertContext, CERT_NAME_SIMPLE_DISPLAY_TYPE, 0, NULL, pszNameString, status);
+		if (status)
+			return -1;
 
 		_tprintf(_T("Certificate #%d: %s\n"), index++, pszNameString);
 

--- a/winpr/libwinpr/environment/test/TestEnvironmentGetSetEB.c
+++ b/winpr/libwinpr/environment/test/TestEnvironmentGetSetEB.c
@@ -23,7 +23,8 @@ int TestEnvironmentGetSetEB(int argc, char* argv[])
 	if (!p)
 		return -1;
 
-	length = GetEnvironmentVariableEBA(lpszEnvironmentBlock,"DISPLAY", p, length);
+	if (GetEnvironmentVariableEBA(lpszEnvironmentBlock,"DISPLAY", p, length) != length - 1)
+		return -1;
 
 	printf("GetEnvironmentVariableA(WINPR_TEST_VARIABLE) = %s\n" , p);
 

--- a/winpr/libwinpr/interlocked/test/TestInterlockedDList.c
+++ b/winpr/libwinpr/interlocked/test/TestInterlockedDList.c
@@ -48,7 +48,7 @@ int TestInterlockedDList(int argc, char* argv[])
 	{
 		pListEntry = RemoveHeadList(pListHead);
 		pListItem = (PLIST_ITEM) pListEntry;
-		_aligned_free(pListEntry);
+		_aligned_free(pListItem);
 	}
 
 	/* InsertTailList / RemoveTailList */
@@ -66,7 +66,7 @@ int TestInterlockedDList(int argc, char* argv[])
 	{
 		pListEntry = RemoveTailList(pListHead);
 		pListItem = (PLIST_ITEM) pListEntry;
-		_aligned_free(pListEntry);
+		_aligned_free(pListItem);
 	}
 
 	_aligned_free(pListHead);

--- a/winpr/libwinpr/interlocked/test/TestInterlockedSList.c
+++ b/winpr/libwinpr/interlocked/test/TestInterlockedSList.c
@@ -14,9 +14,7 @@ int TestInterlockedSList(int argc, char* argv[])
 {
 	ULONG Count;
 	WINPR_PSLIST_ENTRY pFirstEntry;
-	WINPR_PSLIST_ENTRY pListEntry;
 	WINPR_PSLIST_HEADER pListHead;
-	PPROGRAM_ITEM pProgramItem;
 
 	/* Initialize the list header to a MEMORY_ALLOCATION_ALIGNMENT boundary. */
 	pListHead = (WINPR_PSLIST_HEADER) _aligned_malloc(sizeof(WINPR_SLIST_HEADER), MEMORY_ALLOCATION_ALIGNMENT);
@@ -32,7 +30,7 @@ int TestInterlockedSList(int argc, char* argv[])
 	/* Insert 10 items into the list. */
 	for (Count = 1; Count <= 10; Count += 1)
 	{
-		pProgramItem = (PPROGRAM_ITEM) _aligned_malloc(sizeof(PROGRAM_ITEM), MEMORY_ALLOCATION_ALIGNMENT);
+		PPROGRAM_ITEM pProgramItem = (PPROGRAM_ITEM) _aligned_malloc(sizeof(PROGRAM_ITEM), MEMORY_ALLOCATION_ALIGNMENT);
 
 		if (!pProgramItem)
 		{
@@ -47,21 +45,22 @@ int TestInterlockedSList(int argc, char* argv[])
 	/* Remove 10 items from the list and display the signature. */
 	for (Count = 10; Count >= 1; Count -= 1)
 	{
-		pListEntry = InterlockedPopEntrySList(pListHead);
+		PPROGRAM_ITEM pProgramItem;
+		WINPR_PSLIST_ENTRY pListEntry = InterlockedPopEntrySList(pListHead);
 
 		if (!pListEntry)
 		{
 			printf("List is empty.\n");
 			return -1;
 		}
-  
+
 		pProgramItem = (PPROGRAM_ITEM) pListEntry;
 		printf("Signature is %"PRIu32"\n", pProgramItem->Signature);
 
-		/* 
-		 * This example assumes that the SLIST_ENTRY structure is the 
-		 * first member of the structure. If your structure does not 
-		 * follow this convention, you must compute the starting address 
+		/*
+		 * This example assumes that the SLIST_ENTRY structure is the
+		 * first member of the structure. If your structure does not
+		 * follow this convention, you must compute the starting address
 		 * of the structure before calling the free function.
 		 */
 
@@ -69,7 +68,6 @@ int TestInterlockedSList(int argc, char* argv[])
 	}
 
 	/* Flush the list and verify that the items are gone. */
-	pListEntry = InterlockedFlushSList(pListHead);
 	pFirstEntry = InterlockedPopEntrySList(pListHead);
 
 	if (pFirstEntry)

--- a/winpr/libwinpr/pipe/pipe.c
+++ b/winpr/libwinpr/pipe/pipe.c
@@ -378,8 +378,6 @@ BOOL NamedPipeWrite(PVOID Object, LPCVOID lpBuffer, DWORD nNumberOfBytesToWrite,
 
 	if (!(pipe->dwFlagsAndAttributes & FILE_FLAG_OVERLAPPED))
 	{
-		io_status = nNumberOfBytesToWrite;
-
 		if (pipe->clientfd == -1)
 			return FALSE;
 

--- a/winpr/libwinpr/pipe/test/TestPipeCreateNamedPipe.c
+++ b/winpr/libwinpr/pipe/test/TestPipeCreateNamedPipe.c
@@ -194,9 +194,6 @@ static void* named_pipe_single_thread(void* arg)
 	int i;
 	int numPipes;
 	BOOL bSuccess = FALSE;
-#ifndef _WIN32
-	WINPR_NAMED_PIPE* p;
-#endif
 	numPipes = TESTNUMPIPESST;
 	memset(servers, 0, sizeof(servers));
 	memset(clients, 0, sizeof(clients));
@@ -217,7 +214,7 @@ static void* named_pipe_single_thread(void* arg)
 
 	for (i = 0; i < numPipes; i++)
 	{
-		p = (WINPR_NAMED_PIPE*)servers[i];
+		WINPR_NAMED_PIPE* p = (WINPR_NAMED_PIPE*)servers[i];
 
 		if (strcmp(lpszPipeNameSt, p->name))
 		{
@@ -281,7 +278,7 @@ static void* named_pipe_single_thread(void* arg)
 
 	for (i = 0; i < numPipes; i++)
 	{
-		p = servers[i];
+		WINPR_NAMED_PIPE* p = servers[i];
 
 		if (p->clientfd < 1)
 		{
@@ -304,7 +301,6 @@ static void* named_pipe_single_thread(void* arg)
 		ZeroMemory(sndbuf, sizeof(sndbuf));
 		ZeroMemory(rcvbuf, sizeof(rcvbuf));
 		sprintf_s(sndbuf, sizeof(sndbuf), "CLIENT->SERVER ON PIPE #%05d", i);
-		p = servers[i];
 
 		if (!WriteFile(clients[i], sndbuf, sizeof(sndbuf), &dwWritten, NULL) ||
 				dwWritten != sizeof(sndbuf))
@@ -331,7 +327,6 @@ static void* named_pipe_single_thread(void* arg)
 		ZeroMemory(sndbuf, sizeof(sndbuf));
 		ZeroMemory(rcvbuf, sizeof(rcvbuf));
 		sprintf_s(sndbuf, sizeof(sndbuf), "SERVER->CLIENT ON PIPE #%05d", i);
-		p = servers[i];
 
 		if (!WriteFile(servers[i], sndbuf, sizeof(sndbuf), &dwWritten, NULL) ||
 				dwWritten != sizeof(sndbuf))
@@ -430,7 +425,6 @@ static void* named_pipe_single_thread(void* arg)
 		CloseHandle(clients[i]);
 	}
 
-	numPipes = 0;
 	bSuccess = TRUE;
 out:
 

--- a/winpr/libwinpr/synch/test/TestSynchMultipleThreads.c
+++ b/winpr/libwinpr/synch/test/TestSynchMultipleThreads.c
@@ -121,6 +121,9 @@ int TestSynchMultipleThreads(int argc, char *argv[])
 	if (close_threads(THREADS, threads))
 		return -1;
 
+	if (rc < 0)
+		return rc;
+
 	/* WaitOne, timeout, multiple joins */
 	if (start_threads(THREADS, threads))
 		return -1;
@@ -142,6 +145,9 @@ int TestSynchMultipleThreads(int argc, char *argv[])
 
 	if (close_threads(THREADS, threads))
 		return -1;
+
+	if (rc < 0)
+		return rc;
 
 	/* Thread detach test */
 	if (start_threads(THREADS, threads))

--- a/winpr/libwinpr/thread/process.c
+++ b/winpr/libwinpr/thread/process.c
@@ -162,7 +162,6 @@ BOOL _CreateProcessExA(HANDLE hToken, DWORD dwLogonFlags,
 	sigset_t newSigMask;
 	BOOL restoreSigMask = FALSE;
 
-	pid = 0;
 	numArgs = 0;
 	lpszEnvironmentBlock = NULL;
 

--- a/winpr/libwinpr/utils/test/TestMessagePipe.c
+++ b/winpr/libwinpr/utils/test/TestMessagePipe.c
@@ -5,16 +5,14 @@
 
 static void* message_echo_pipe_client_thread(void* arg)
 {
-	int index;
-	int count;
-	wMessage message;
-	wMessagePipe* pipe;
-
-	count = index = 0;
-	pipe = (wMessagePipe*) arg;
+	int index = 0;
+	wMessagePipe* pipe = (wMessagePipe*) arg;
 
 	while (index < 100)
 	{
+		wMessage message;
+		int count;
+
 		if (!MessageQueue_Post(pipe->In, NULL, 0, (void*) (size_t) index, NULL))
 			break;
 
@@ -42,7 +40,6 @@ static void* message_echo_pipe_client_thread(void* arg)
 
 static void* message_echo_pipe_server_thread(void* arg)
 {
-	int count;
 	wMessage message;
 	wMessagePipe* pipe;
 
@@ -54,8 +51,6 @@ static void* message_echo_pipe_server_thread(void* arg)
 		{
 			if (message.id == WMQ_QUIT)
 				break;
-
-			count = (int) (size_t) message.wParam;
 
 			if (!MessageQueue_Dispatch(pipe->Out, &message))
 				break;

--- a/winpr/libwinpr/utils/wlog/ConsoleAppender.c
+++ b/winpr/libwinpr/utils/wlog/ConsoleAppender.c
@@ -192,10 +192,9 @@ static BOOL WLog_ConsoleAppender_WritePacketMessage(wLog* log, wLogAppender* app
 #if defined(ANDROID)
 	return FALSE;
 #else
-	int PacketId;
 	char* FullFileName;
 
-	PacketId = g_PacketId++;
+	g_PacketId++;
 
 	if (!appender->PacketMessageContext)
 	{

--- a/winpr/libwinpr/wtsapi/test/TestWtsApiExtraLogoffSession.c
+++ b/winpr/libwinpr/wtsapi/test/TestWtsApiExtraLogoffSession.c
@@ -7,9 +7,7 @@ int TestWtsApiExtraLogoffSession(int argc, char* argv[])
 {
 	BOOL bSuccess;
 	HANDLE hServer;
-	DWORD sessionId;
 
-	sessionId = 123;
 	hServer = WTS_CURRENT_SERVER_HANDLE;
 
 	bSuccess = WTSLogoffSession(hServer, WTS_CURRENT_SESSION, FALSE);

--- a/winpr/tools/makecert/makecert.c
+++ b/winpr/tools/makecert/makecert.c
@@ -682,6 +682,8 @@ int makecert_context_output_certificate_file(MAKECERT_CONTEXT* context, char* pa
 					goto out_fail;
 
 				status = PEM_write_bio_PrivateKey(bio, context->pkey, NULL, NULL, 0, NULL, NULL);
+				if (status < 0)
+					goto out_fail;
 
 				offset = 0;
 				length = 2048;
@@ -1040,6 +1042,12 @@ int makecert_context_process(MAKECERT_CONTEXT* context, int argc, char** argv)
 			return -1;
 
 		status = X509_print(bio, context->x509);
+		if (status < 0)
+		{
+			BIO_free(bio);
+			return -1;
+		}
+
 
 		offset = 0;
 		length = 2048;


### PR DESCRIPTION
* Fixed a lot of tests which did not check return values
* Fixed SSE AVC420 decoder, reusing AVC444 pixel decoder
* Fixed dead store and missing return value checks in library.