### PR TITLE
rdpegfx: fix RemoteFX Progressive Codec decoding

### DIFF
--- a/include/freerdp/codec/progressive.h
+++ b/include/freerdp/codec/progressive.h
@@ -30,6 +30,7 @@ typedef struct _PROGRESSIVE_CONTEXT PROGRESSIVE_CONTEXT;
 
 #include <freerdp/codec/rfx.h>
 #include <freerdp/codec/color.h>
+#include <freerdp/codec/region.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,7 +43,7 @@ FREERDP_API INT32 progressive_decompress(PROGRESSIVE_CONTEXT* progressive,
         const BYTE* pSrcData, UINT32 SrcSize,
         BYTE* pDstData, UINT32 DstFormat,
         UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
-        UINT32 nWidth, UINT32 nHeight, UINT16 surfaceId);
+        REGION16* invalidRegion, UINT16 surfaceId);
 
 FREERDP_API INT32 progressive_create_surface_context(PROGRESSIVE_CONTEXT*
         progressive, UINT16 surfaceId, UINT32 width, UINT32 height);

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -1530,7 +1530,7 @@ INT32 progressive_decompress(PROGRESSIVE_CONTEXT* progressive,
                              const BYTE* pSrcData, UINT32 SrcSize,
                              BYTE* pDstData, UINT32 DstFormat,
                              UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
-                             UINT32 nWidth, UINT32 nHeight, UINT16 surfaceId)
+                             REGION16* invalidRegion, UINT16 surfaceId)
 {
 	INT32 rc = 1;
 	INT32 status;
@@ -1910,6 +1910,9 @@ INT32 progressive_decompress(PROGRESSIVE_CONTEXT* progressive,
 				rc = -42;
 				break;
 			}
+
+			if (invalidRegion)
+				region16_union_rect(invalidRegion, invalidRegion, rect);
 		}
 
 		region16_uninit(&updateRegion);

--- a/libfreerdp/codec/test/TestFreeRDPCodecProgressive.c
+++ b/libfreerdp/codec/test/TestFreeRDPCodecProgressive.c
@@ -741,7 +741,7 @@ static int test_progressive_decode(PROGRESSIVE_CONTEXT* progressive, EGFX_SAMPLE
 	for (pass = 0; pass < count; pass++)
 	{
 		status = progressive_decompress(progressive, files[pass].buffer, files[pass].size,
-		                                g_DstData, PIXEL_FORMAT_XRGB32, g_DstStep, 0, 0, g_Width, g_Height, 0);
+		                                g_DstData, PIXEL_FORMAT_XRGB32, g_DstStep, 0, 0, NULL, 0);
 		printf("ProgressiveDecompress: status: %d pass: %d\n", status, pass + 1);
 		region = &(progressive->region);
 


### PR DESCRIPTION
Since this comes via a Wire-To-Surface-2 PDU we don't have any left/top/right/bottom destination values.
The current code has always dealt with zeros when updating the invalid region which resulted in black rectangles.
The correct update region is determined during decompression.