### PR TITLE
client/x11: fix gfx drawing bug with /multimon

### DIFF
--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -39,10 +39,10 @@ static UINT xf_OutputUpdate(xfContext* xfc, xfGfxSurface* surface)
 	gdi = xfc->context.gdi;
 	surfaceX = surface->gdi.outputOriginX;
 	surfaceY = surface->gdi.outputOriginY;
-	surfaceRect.left = surfaceX;
-	surfaceRect.top = surfaceY;
-	surfaceRect.right = surfaceX + surface->gdi.width;
-	surfaceRect.bottom = surfaceY + surface->gdi.height;
+	surfaceRect.left = 0;
+	surfaceRect.top = 0;
+	surfaceRect.right = surface->gdi.width;
+	surfaceRect.bottom = surface->gdi.height;
 	XSetClipMask(xfc->display, xfc->gc, None);
 	XSetFunction(xfc->display, xfc->gc, GXcopy);
 	XSetFillStyle(xfc->display, xfc->gc, FillSolid);
@@ -80,7 +80,7 @@ static UINT xf_OutputUpdate(xfContext* xfc, xfGfxSurface* surface)
 		{
 			XPutImage(xfc->display, xfc->primary, xfc->gc, surface->image,
 			          nXSrc, nYSrc, nXDst, nYDst, width, height);
-			xf_draw_screen(xfc, nXSrc, nYSrc, width, height);
+			xf_draw_screen(xfc, nXDst, nYDst, width, height);
 		}
 		else
 #endif


### PR DESCRIPTION
The surface's damage region is not relative to the output but lives in its own universe starting at origin 0,0.
Also fixed the drawing coordinates used in the XRENDER code path which is used with /smart-sizing

This should fix the problem reported in issue #3910 