### PR TITLE
Disconnect/Reconnect channels if they are already connected before a server redirect

### DIFF
--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -1652,6 +1652,13 @@ static UINT rdpdr_virtual_channel_event_disconnected(rdpdrPlugin* rdpdr)
 {
 	UINT error;
 
+	/* Remove all dependent devices before tearing down resources */
+	if (rdpdr->devman)
+	{
+		devman_free(rdpdr->devman);
+		rdpdr->devman = NULL;
+	}
+
 	if (MessageQueue_PostQuit(rdpdr->queue, 0)
 	    && (WaitForSingleObject(rdpdr->thread, INFINITE) == WAIT_FAILED))
 	{
@@ -1685,12 +1692,6 @@ static UINT rdpdr_virtual_channel_event_disconnected(rdpdrPlugin* rdpdr)
 	{
 		Stream_Free(rdpdr->data_in, TRUE);
 		rdpdr->data_in = NULL;
-	}
-
-	if (rdpdr->devman)
-	{
-		devman_free(rdpdr->devman);
-		rdpdr->devman = NULL;
 	}
 
 	return error;

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -314,7 +314,17 @@ BOOL rdp_client_disconnect(rdpRdp* rdp)
 BOOL rdp_client_redirect(rdpRdp* rdp)
 {
 	BOOL status;
+	BOOL reconnect_channels = FALSE;
 	rdpSettings* settings = rdp->settings;
+
+	/* Ensure existing channels are disconnected */
+	rdpContext* context = rdp->context;
+	rdpChannels* channels = context->channels;
+	if (channels->connected)
+	{
+		reconnect_channels = TRUE;
+		freerdp_channels_disconnect(channels, context->instance);
+	}
 
 	rdp_client_disconnect(rdp);
 	if (rdp_redirection_apply_settings(rdp) != 0)
@@ -367,6 +377,12 @@ BOOL rdp_client_redirect(rdpRdp* rdp)
 	}
 
 	status = rdp_client_connect(rdp);
+
+	/* Reconnect channels */
+	if (status && reconnect_channels)
+	{
+		status = (freerdp_channels_post_connect(channels, context->instance) == CHANNEL_RC_OK);
+	}
 
 	return status;
 }


### PR DESCRIPTION
Handle the case where a server redirection happens after channels are already set up by disconnecting the channels and running the post connect on the channels after the redirection connection is made. Also, free up dependent devices in rdpdr before freeing up their dependent resources.

This case is hit a 2012R2 Connection Broker redirects the client based on load-balance-info when NLA is not used for the connection, the symptom is that none of the channels are properly connected(no smartcard/audio/media/drive/etc. redirection). 

When NLA is enabled then the client is redirected before channels are connected, so the problem is not hit in that scenario.