### PR TITLE
WS_EX_NOACTIVATE treated as unmanaged

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -521,7 +521,7 @@ void xf_SetWindowStyle(xfContext* xfc, xfAppWindow* appWindow, UINT32 style,
 {
 	Atom window_type;
 
-	if (/*(ex_style & WS_EX_TOPMOST) ||*/ (ex_style & WS_EX_TOOLWINDOW))
+	if ((ex_style & WS_EX_NOACTIVATE) || (ex_style & WS_EX_TOOLWINDOW))
 	{
 		/*
 		 * Tooltips and menu items should be unmanaged windows


### PR DESCRIPTION
Hi all.

This is my first ever attempt to submit a pull request.  Please be gentle. :-)

With this patch, when using Rail with the X11 client, windows that carry the WS_EX_NOACTIVATE are treated the same as WS_EX_TOOLWINDOW in that they should not be handled as normal windows by the X window manager.  The prevents an issue with MS Outlook 2013 (and probably other applications) where attempting to resize the vertical columns causes some sort of WS_EX_NOACTIVATE window to be created which steals focus and aborts the resizing action.

Cheers.
Shaun.