### PR TITLE
server/shadow: close the thread handle so that it is detached because…

### DIFF
--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -1747,6 +1747,12 @@ BOOL shadow_client_accepted(freerdp_listener* listener, freerdp_peer* peer)
 		freerdp_peer_context_free(peer);
 		return FALSE;
 	}
+	else
+	{
+		/* Close the thread handle to make it detached. */
+		CloseHandle(client->thread);
+		client->thread = NULL;
+	}
 
 	return TRUE;
 }


### PR DESCRIPTION
close the thread handle so that it is detached because no one is going to join it. Therefore the thread would release its resources automatically when exit