### PR TITLE
Remove unused buffer in Mac shadow subsystem

### DIFF
--- a/server/shadow/Mac/mac_shadow.c
+++ b/server/shadow/Mac/mac_shadow.c
@@ -457,11 +457,6 @@ static int mac_shadow_capture_init(macShadowSubsystem* subsystem)
 	CFDictionaryRef opts;
 	CGDirectDisplayID displayId;
 	displayId = CGMainDisplayID();
-	subsystem->updateBuffer = (BYTE*) malloc(subsystem->pixelWidth *
-	                          subsystem->pixelHeight * 4);
-
-	if (!subsystem->updateBuffer)
-		return -1;
 
 	subsystem->captureQueue = dispatch_queue_create("mac.shadow.capture", NULL);
 	keys[0] = (void*) kCGDisplayStreamShowCursor;

--- a/server/shadow/Mac/mac_shadow.h
+++ b/server/shadow/Mac/mac_shadow.h
@@ -47,7 +47,6 @@ struct mac_shadow_subsystem
 	BOOL mouseDownLeft;
 	BOOL mouseDownRight;
 	BOOL mouseDownOther;
-	BYTE* updateBuffer;
 	CGDisplayStreamRef stream;
 	dispatch_queue_t captureQueue;
 	CGDisplayStreamUpdateRef lastUpdate;


### PR DESCRIPTION
This "updateBuffer" is allocated, not used and not freed.