### PR TITLE
resolve issues identified by cppcheck

### DIFF
--- a/channels/drive/client/drive_file.c
+++ b/channels/drive/client/drive_file.c
@@ -112,6 +112,10 @@ static BOOL drive_file_remove_dir(const WCHAR* path)
 	WCHAR* fullpath;
 	WCHAR* path_slash;
 	UINT32 base_path_length;
+
+	if (!path)
+		return FALSE;
+
 	base_path_length = _wcslen(path) * 2;
 	path_slash = (WCHAR*)calloc(1, base_path_length + sizeof(WCHAR) * 3);
 
@@ -120,9 +124,6 @@ static BOOL drive_file_remove_dir(const WCHAR* path)
 		WLog_ERR(TAG, "malloc failed!");
 		return FALSE;
 	}
-
-	if (!path)
-		return FALSE;
 
 	CopyMemory(path_slash, path, base_path_length);
 	path_slash[base_path_length / 2] = '/';

--- a/server/Windows/wf_dxgi.c
+++ b/server/Windows/wf_dxgi.c
@@ -192,7 +192,7 @@ int wf_dxgi_getDuplication(wfInfo* wfi)
 	{
 		if (status == DXGI_ERROR_NOT_CURRENTLY_AVAILABLE)
 		{
-			WLog_ERR(TAG, "There is already the maximum number of applications using the Desktop Duplication API running, please close one of those applications and then try again."));
+			WLog_ERR(TAG, "There is already the maximum number of applications using the Desktop Duplication API running, please close one of those applications and then try again.");
 			return 1;
 		}
 


### PR DESCRIPTION
[channels/drive/client/drive_file.c:125]: (error) Memory leak: path_slash
[server/Windows/wf_dxgi.c:195]: (error) Invalid number of character '(' when these macros are defined: 'WITH_DXGI_1_2'.