### PR TITLE
Remove library prefix override for rdpei-server

### DIFF
--- a/channels/rdpei/server/CMakeLists.txt
+++ b/channels/rdpei/server/CMakeLists.txt
@@ -27,8 +27,6 @@ set(${MODULE_PREFIX}_SRCS
 
 add_channel_server_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} FALSE "VirtualChannelEntry")
 
-set_target_properties(${MODULE_NAME} PROPERTIES PREFIX "")
-
 set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} winpr)
 
 target_link_libraries(${MODULE_NAME} ${${MODULE_PREFIX}_LIBS})


### PR DESCRIPTION
This library was missed in commit
059374457d801351d02ac81badb4aabbfa7689e7, so it was the only one that
still had a lib prefix.