### PR TITLE
Check arguments for Bitmap_SetSurface

### DIFF
--- a/libfreerdp/gdi/graphics.c
+++ b/libfreerdp/gdi/graphics.c
@@ -183,7 +183,14 @@ static BOOL gdi_Bitmap_Decompress(rdpContext* context, rdpBitmap* bitmap,
 static BOOL gdi_Bitmap_SetSurface(rdpContext* context, rdpBitmap* bitmap,
                                   BOOL primary)
 {
-	rdpGdi* gdi = context->gdi;
+	rdpGdi* gdi;
+
+	if (!context)
+		return FALSE;
+
+	gdi = context->gdi;
+	if (!gdi)
+		return FALSE;
 
 	if (primary)
 		gdi->drawing = gdi->primary;


### PR DESCRIPTION
The function may be called during connection phase
where there is no valid GDI available.