### PR TITLE
redirect specific smartcard readers

### DIFF
--- a/channels/smartcard/client/smartcard_main.c
+++ b/channels/smartcard/client/smartcard_main.c
@@ -45,7 +45,6 @@ void* smartcard_context_thread(SMARTCARD_CONTEXT* pContext)
 	SMARTCARD_OPERATION* operation;
 	UINT error = CHANNEL_RC_OK;
 	smartcard = pContext->smartcard;
-
 	nCount = 0;
 	hEvents[nCount++] = MessageQueue_Event(pContext->IrpQueue);
 
@@ -516,7 +515,6 @@ static void* smartcard_thread_func(void* arg)
 	wMessage message;
 	SMARTCARD_DEVICE* smartcard = (SMARTCARD_DEVICE*) arg;
 	UINT error = CHANNEL_RC_OK;
-
 	nCount = 0;
 	hEvents[nCount++] = MessageQueue_Event(smartcard->IrpQueue);
 	hEvents[nCount++] = Queue_Event(smartcard->CompletedIrpQueue);
@@ -739,6 +737,15 @@ UINT DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
 			smartcard->path = name;
 		else
 			smartcard->name = name;
+	}
+
+	LONG status;
+	status = SCardAddReaderName(&smartcard->thread, (LPSTR) name);
+
+	if (status != SCARD_S_SUCCESS)
+	{
+		WLog_ERR(TAG, "Failed to add reader name!");
+		goto error_device_data;
 	}
 
 	smartcard->IrpQueue = MessageQueue_New(NULL);

--- a/channels/smartcard/client/smartcard_main.c
+++ b/channels/smartcard/client/smartcard_main.c
@@ -695,6 +695,7 @@ UINT DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
 	int ck;
 	RDPDR_SMARTCARD* device;
 	SMARTCARD_DEVICE* smartcard;
+	LONG status;
 	UINT error = CHANNEL_RC_NO_MEMORY;
 	device = (RDPDR_SMARTCARD*) pEntryPoints->device;
 	name = device->Name;
@@ -739,7 +740,6 @@ UINT DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
 			smartcard->name = name;
 	}
 
-	LONG status;
 	status = SCardAddReaderName(&smartcard->thread, (LPSTR) name);
 
 	if (status != SCARD_S_SUCCESS)

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -863,18 +863,18 @@ static int freerdp_client_command_line_post_filter(void* context,
 		{
 			char** p;
 			int count;
-			p = freerdp_command_line_parse_comma_separated_values_offset(arg->Value, &count);
+			p = freerdp_command_line_parse_comma_separated_values_offset(arg->Value,
+			        &count);
 			p[0] = "smartcard";
 			status = freerdp_client_add_device_channel(settings, count, p);
 			free(p);
 		}
 		else
 		{
-			char* p[2];
+			char* p[1];
 			int count;
-			count = 2;
+			count = 1;
 			p[0] = "smartcard";
-			p[1] = "";
 			status = freerdp_client_add_device_channel(settings, count, p);
 		}
 	}

--- a/winpr/include/winpr/smartcard.h
+++ b/winpr/include/winpr/smartcard.h
@@ -236,7 +236,7 @@ typedef struct _SCARD_IO_REQUEST
 	DWORD dwProtocol;
 	DWORD cbPciLength;
 } SCARD_IO_REQUEST, *PSCARD_IO_REQUEST, *LPSCARD_IO_REQUEST;
-typedef const SCARD_IO_REQUEST *LPCSCARD_IO_REQUEST;
+typedef const SCARD_IO_REQUEST* LPCSCARD_IO_REQUEST;
 
 typedef struct
 {
@@ -261,13 +261,13 @@ typedef struct
 	} DUMMYUNIONNAME;
 } SCARD_T0_REQUEST;
 
-typedef SCARD_T0_REQUEST *PSCARD_T0_REQUEST, *LPSCARD_T0_REQUEST;
+typedef SCARD_T0_REQUEST* PSCARD_T0_REQUEST, *LPSCARD_T0_REQUEST;
 
 typedef struct
 {
 	SCARD_IO_REQUEST ioRequest;
 } SCARD_T1_REQUEST;
-typedef SCARD_T1_REQUEST *PSCARD_T1_REQUEST, *LPSCARD_T1_REQUEST;
+typedef SCARD_T1_REQUEST* PSCARD_T1_REQUEST, *LPSCARD_T1_REQUEST;
 
 #define SCARD_READER_SWALLOWS		0x00000001
 #define SCARD_READER_EJECTS		0x00000002
@@ -290,10 +290,10 @@ typedef SCARD_T1_REQUEST *PSCARD_T1_REQUEST, *LPSCARD_T1_REQUEST;
 #endif
 
 typedef ULONG_PTR SCARDCONTEXT;
-typedef SCARDCONTEXT *PSCARDCONTEXT, *LPSCARDCONTEXT;
+typedef SCARDCONTEXT* PSCARDCONTEXT, *LPSCARDCONTEXT;
 
 typedef ULONG_PTR SCARDHANDLE;
-typedef SCARDHANDLE *PSCARDHANDLE, *LPSCARDHANDLE;
+typedef SCARDHANDLE* PSCARDHANDLE, *LPSCARDHANDLE;
 
 #define SCARD_AUTOALLOCATE		(DWORD)(-1)
 
@@ -330,11 +330,15 @@ typedef SCARDHANDLE *PSCARDHANDLE, *LPSCARDHANDLE;
 #define SCERR_NOCARDNAME		0x4000
 #define SCERR_NOGUIDS			0x8000
 
-typedef SCARDHANDLE (WINAPI *LPOCNCONNPROCA)(SCARDCONTEXT hSCardContext, LPSTR szReader, LPSTR mszCards, PVOID pvUserData);
-typedef SCARDHANDLE (WINAPI *LPOCNCONNPROCW)(SCARDCONTEXT hSCardContext, LPWSTR szReader, LPWSTR mszCards, PVOID pvUserData);
+typedef SCARDHANDLE(WINAPI* LPOCNCONNPROCA)(SCARDCONTEXT hSCardContext, LPSTR szReader,
+        LPSTR mszCards, PVOID pvUserData);
+typedef SCARDHANDLE(WINAPI* LPOCNCONNPROCW)(SCARDCONTEXT hSCardContext, LPWSTR szReader,
+        LPWSTR mszCards, PVOID pvUserData);
 
-typedef BOOL (WINAPI *LPOCNCHKPROC)(SCARDCONTEXT hSCardContext, SCARDHANDLE hCard, PVOID pvUserData);
-typedef void (WINAPI *LPOCNDSCPROC)(SCARDCONTEXT hSCardContext, SCARDHANDLE hCard, PVOID pvUserData);
+typedef BOOL (WINAPI* LPOCNCHKPROC)(SCARDCONTEXT hSCardContext, SCARDHANDLE hCard,
+                                    PVOID pvUserData);
+typedef void (WINAPI* LPOCNDSCPROC)(SCARDCONTEXT hSCardContext, SCARDHANDLE hCard,
+                                    PVOID pvUserData);
 
 #define SCARD_READER_SEL_AUTH_PACKAGE	((DWORD)-629)
 
@@ -463,9 +467,9 @@ typedef struct
 
 typedef enum
 {
-	RSR_MATCH_TYPE_READER_AND_CONTAINER = 1,
-	RSR_MATCH_TYPE_SERIAL_NUMBER,
-	RSR_MATCH_TYPE_ALL_CARDS
+    RSR_MATCH_TYPE_READER_AND_CONTAINER = 1,
+    RSR_MATCH_TYPE_SERIAL_NUMBER,
+    RSR_MATCH_TYPE_ALL_CARDS
 } READER_SEL_REQUEST_MATCH_TYPE;
 
 typedef struct
@@ -600,42 +604,44 @@ extern const SCARD_IO_REQUEST g_rgSCardRawPci;
 #define SCARD_PCI_RAW	(&g_rgSCardRawPci)
 
 WINSCARDAPI LONG WINAPI SCardEstablishContext(DWORD dwScope,
-		LPCVOID pvReserved1, LPCVOID pvReserved2, LPSCARDCONTEXT phContext);
+        LPCVOID pvReserved1, LPCVOID pvReserved2, LPSCARDCONTEXT phContext);
 
 WINSCARDAPI LONG WINAPI SCardReleaseContext(SCARDCONTEXT hContext);
 
 WINSCARDAPI LONG WINAPI SCardIsValidContext(SCARDCONTEXT hContext);
 
 WINSCARDAPI LONG WINAPI SCardListReaderGroupsA(SCARDCONTEXT hContext,
-		LPSTR mszGroups, LPDWORD pcchGroups);
+        LPSTR mszGroups, LPDWORD pcchGroups);
 WINSCARDAPI LONG WINAPI SCardListReaderGroupsW(SCARDCONTEXT hContext,
-		LPWSTR mszGroups, LPDWORD pcchGroups);
+        LPWSTR mszGroups, LPDWORD pcchGroups);
 
 WINSCARDAPI LONG WINAPI SCardListReadersA(SCARDCONTEXT hContext,
-		LPCSTR mszGroups, LPSTR mszReaders, LPDWORD pcchReaders);
+        LPCSTR mszGroups, LPSTR mszReaders, LPDWORD pcchReaders);
 WINSCARDAPI LONG WINAPI SCardListReadersW(SCARDCONTEXT hContext,
-		LPCWSTR mszGroups, LPWSTR mszReaders, LPDWORD pcchReaders);
+        LPCWSTR mszGroups, LPWSTR mszReaders, LPDWORD pcchReaders);
 
 WINSCARDAPI LONG WINAPI SCardListCardsA(SCARDCONTEXT hContext,
-		LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, CHAR* mszCards, LPDWORD pcchCards);
+                                        LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, CHAR* mszCards,
+                                        LPDWORD pcchCards);
 
 WINSCARDAPI LONG WINAPI SCardListCardsW(SCARDCONTEXT hContext,
-		LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, WCHAR* mszCards, LPDWORD pcchCards);
+                                        LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, WCHAR* mszCards,
+                                        LPDWORD pcchCards);
 
 WINSCARDAPI LONG WINAPI SCardListInterfacesA(SCARDCONTEXT hContext,
-		LPCSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces);
+        LPCSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces);
 WINSCARDAPI LONG WINAPI SCardListInterfacesW(SCARDCONTEXT hContext,
-		LPCWSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces);
+        LPCWSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces);
 
 WINSCARDAPI LONG WINAPI SCardGetProviderIdA(SCARDCONTEXT hContext,
-		LPCSTR szCard, LPGUID pguidProviderId);
+        LPCSTR szCard, LPGUID pguidProviderId);
 WINSCARDAPI LONG WINAPI SCardGetProviderIdW(SCARDCONTEXT hContext,
-		LPCWSTR szCard, LPGUID pguidProviderId);
+        LPCWSTR szCard, LPGUID pguidProviderId);
 
 WINSCARDAPI LONG WINAPI SCardGetCardTypeProviderNameA(SCARDCONTEXT hContext,
-		LPCSTR szCardName, DWORD dwProviderId, CHAR* szProvider, LPDWORD pcchProvider);
+        LPCSTR szCardName, DWORD dwProviderId, CHAR* szProvider, LPDWORD pcchProvider);
 WINSCARDAPI LONG WINAPI SCardGetCardTypeProviderNameW(SCARDCONTEXT hContext,
-		LPCWSTR szCardName, DWORD dwProviderId, WCHAR* szProvider, LPDWORD pcchProvider);
+        LPCWSTR szCardName, DWORD dwProviderId, WCHAR* szProvider, LPDWORD pcchProvider);
 
 WINSCARDAPI LONG WINAPI SCardIntroduceReaderGroupA(SCARDCONTEXT hContext, LPCSTR szGroupName);
 WINSCARDAPI LONG WINAPI SCardIntroduceReaderGroupW(SCARDCONTEXT hContext, LPCWSTR szGroupName);
@@ -644,34 +650,34 @@ WINSCARDAPI LONG WINAPI SCardForgetReaderGroupA(SCARDCONTEXT hContext, LPCSTR sz
 WINSCARDAPI LONG WINAPI SCardForgetReaderGroupW(SCARDCONTEXT hContext, LPCWSTR szGroupName);
 
 WINSCARDAPI LONG WINAPI SCardIntroduceReaderA(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPCSTR szDeviceName);
+        LPCSTR szReaderName, LPCSTR szDeviceName);
 WINSCARDAPI LONG WINAPI SCardIntroduceReaderW(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPCWSTR szDeviceName);
+        LPCWSTR szReaderName, LPCWSTR szDeviceName);
 
 WINSCARDAPI LONG WINAPI SCardForgetReaderA(SCARDCONTEXT hContext, LPCSTR szReaderName);
 WINSCARDAPI LONG WINAPI SCardForgetReaderW(SCARDCONTEXT hContext, LPCWSTR szReaderName);
 
 WINSCARDAPI LONG WINAPI SCardAddReaderToGroupA(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPCSTR szGroupName);
+        LPCSTR szReaderName, LPCSTR szGroupName);
 WINSCARDAPI LONG WINAPI SCardAddReaderToGroupW(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPCWSTR szGroupName);
+        LPCWSTR szReaderName, LPCWSTR szGroupName);
 
 WINSCARDAPI LONG WINAPI SCardRemoveReaderFromGroupA(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPCSTR szGroupName);
+        LPCSTR szReaderName, LPCSTR szGroupName);
 WINSCARDAPI LONG WINAPI SCardRemoveReaderFromGroupW(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPCWSTR szGroupName);
+        LPCWSTR szReaderName, LPCWSTR szGroupName);
 
 WINSCARDAPI LONG WINAPI SCardIntroduceCardTypeA(SCARDCONTEXT hContext,
-		LPCSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
-		DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen);
+        LPCSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
+        DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen);
 WINSCARDAPI LONG WINAPI SCardIntroduceCardTypeW(SCARDCONTEXT hContext,
-		LPCWSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
-		DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen);
+        LPCWSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
+        DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen);
 
 WINSCARDAPI LONG WINAPI SCardSetCardTypeProviderNameA(SCARDCONTEXT hContext,
-		LPCSTR szCardName, DWORD dwProviderId, LPCSTR szProvider);
+        LPCSTR szCardName, DWORD dwProviderId, LPCSTR szProvider);
 WINSCARDAPI LONG WINAPI SCardSetCardTypeProviderNameW(SCARDCONTEXT hContext,
-		LPCWSTR szCardName, DWORD dwProviderId, LPCWSTR szProvider);
+        LPCWSTR szCardName, DWORD dwProviderId, LPCWSTR szProvider);
 
 WINSCARDAPI LONG WINAPI SCardForgetCardTypeA(SCARDCONTEXT hContext, LPCSTR szCardName);
 WINSCARDAPI LONG WINAPI SCardForgetCardTypeW(SCARDCONTEXT hContext, LPCWSTR szCardName);
@@ -683,31 +689,31 @@ WINSCARDAPI HANDLE WINAPI SCardAccessStartedEvent(void);
 WINSCARDAPI void WINAPI SCardReleaseStartedEvent(void);
 
 WINSCARDAPI LONG WINAPI SCardLocateCardsA(SCARDCONTEXT hContext,
-		LPCSTR mszCards, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders);
+        LPCSTR mszCards, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders);
 WINSCARDAPI LONG WINAPI SCardLocateCardsW(SCARDCONTEXT hContext,
-		LPCWSTR mszCards, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders);
+        LPCWSTR mszCards, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders);
 
 WINSCARDAPI LONG WINAPI SCardLocateCardsByATRA(SCARDCONTEXT hContext,
-		LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders);
+        LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders);
 WINSCARDAPI LONG WINAPI SCardLocateCardsByATRW(SCARDCONTEXT hContext,
-		LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders);
+        LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders);
 
 WINSCARDAPI LONG WINAPI SCardGetStatusChangeA(SCARDCONTEXT hContext,
-		DWORD dwTimeout, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders);
+        DWORD dwTimeout, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders);
 WINSCARDAPI LONG WINAPI SCardGetStatusChangeW(SCARDCONTEXT hContext,
-		DWORD dwTimeout, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders);
+        DWORD dwTimeout, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders);
 
 WINSCARDAPI LONG WINAPI SCardCancel(SCARDCONTEXT hContext);
 
 WINSCARDAPI LONG WINAPI SCardConnectA(SCARDCONTEXT hContext,
-		LPCSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
-		LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol);
+                                      LPCSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
+                                      LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol);
 WINSCARDAPI LONG WINAPI SCardConnectW(SCARDCONTEXT hContext,
-		LPCWSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
-		LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol);
+                                      LPCWSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
+                                      LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol);
 
 WINSCARDAPI LONG WINAPI SCardReconnect(SCARDHANDLE hCard,
-		DWORD dwShareMode, DWORD dwPreferredProtocols, DWORD dwInitialization, LPDWORD pdwActiveProtocol);
+                                       DWORD dwShareMode, DWORD dwPreferredProtocols, DWORD dwInitialization, LPDWORD pdwActiveProtocol);
 
 WINSCARDAPI LONG WINAPI SCardDisconnect(SCARDHANDLE hCard, DWORD dwDisposition);
 
@@ -718,28 +724,30 @@ WINSCARDAPI LONG WINAPI SCardEndTransaction(SCARDHANDLE hCard, DWORD dwDispositi
 WINSCARDAPI LONG WINAPI SCardCancelTransaction(SCARDHANDLE hCard);
 
 WINSCARDAPI LONG WINAPI SCardState(SCARDHANDLE hCard,
-		LPDWORD pdwState, LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen);
+                                   LPDWORD pdwState, LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen);
 
 WINSCARDAPI LONG WINAPI SCardStatusA(SCARDHANDLE hCard,
-		LPSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
-		LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen);
+                                     LPSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
+                                     LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen);
 WINSCARDAPI LONG WINAPI SCardStatusW(SCARDHANDLE hCard,
-		LPWSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
-		LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen);
+                                     LPWSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
+                                     LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen);
 
 WINSCARDAPI LONG WINAPI SCardTransmit(SCARDHANDLE hCard,
-		LPCSCARD_IO_REQUEST pioSendPci, LPCBYTE pbSendBuffer, DWORD cbSendLength,
-		LPSCARD_IO_REQUEST pioRecvPci, LPBYTE pbRecvBuffer, LPDWORD pcbRecvLength);
+                                      LPCSCARD_IO_REQUEST pioSendPci, LPCBYTE pbSendBuffer, DWORD cbSendLength,
+                                      LPSCARD_IO_REQUEST pioRecvPci, LPBYTE pbRecvBuffer, LPDWORD pcbRecvLength);
 
 WINSCARDAPI LONG WINAPI SCardGetTransmitCount(SCARDHANDLE hCard, LPDWORD pcTransmitCount);
 
 WINSCARDAPI LONG WINAPI SCardControl(SCARDHANDLE hCard,
-		DWORD dwControlCode, LPCVOID lpInBuffer, DWORD cbInBufferSize,
-		LPVOID lpOutBuffer, DWORD cbOutBufferSize, LPDWORD lpBytesReturned);
+                                     DWORD dwControlCode, LPCVOID lpInBuffer, DWORD cbInBufferSize,
+                                     LPVOID lpOutBuffer, DWORD cbOutBufferSize, LPDWORD lpBytesReturned);
 
-WINSCARDAPI LONG WINAPI SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr, LPDWORD pcbAttrLen);
+WINSCARDAPI LONG WINAPI SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr,
+                                       LPDWORD pcbAttrLen);
 
-WINSCARDAPI LONG WINAPI SCardSetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPCBYTE pbAttr, DWORD cbAttrLen);
+WINSCARDAPI LONG WINAPI SCardSetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPCBYTE pbAttr,
+                                       DWORD cbAttrLen);
 
 WINSCARDAPI LONG WINAPI SCardUIDlgSelectCardA(LPOPENCARDNAMEA_EX pDlgStruc);
 WINSCARDAPI LONG WINAPI SCardUIDlgSelectCardW(LPOPENCARDNAMEW_EX pDlgStruc);
@@ -750,34 +758,38 @@ WINSCARDAPI LONG WINAPI GetOpenCardNameW(LPOPENCARDNAMEW pDlgStruc);
 WINSCARDAPI LONG WINAPI SCardDlgExtendedError(void);
 
 WINSCARDAPI LONG WINAPI SCardReadCacheA(SCARDCONTEXT hContext,
-		UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD* DataLen);
+                                        UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD* DataLen);
 WINSCARDAPI LONG WINAPI SCardReadCacheW(SCARDCONTEXT hContext,
-		UUID* CardIdentifier,  DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD* DataLen);
+                                        UUID* CardIdentifier,  DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD* DataLen);
 
 WINSCARDAPI LONG WINAPI SCardWriteCacheA(SCARDCONTEXT hContext,
-		UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD DataLen);
+        UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD DataLen);
 WINSCARDAPI LONG WINAPI SCardWriteCacheW(SCARDCONTEXT hContext,
-		UUID* CardIdentifier, DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD DataLen);
+        UUID* CardIdentifier, DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD DataLen);
 
 WINSCARDAPI LONG WINAPI SCardGetReaderIconA(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon);
+        LPCSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon);
 WINSCARDAPI LONG WINAPI SCardGetReaderIconW(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon);
+        LPCWSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon);
 
-WINSCARDAPI LONG WINAPI SCardGetDeviceTypeIdA(SCARDCONTEXT hContext, LPCSTR szReaderName, LPDWORD pdwDeviceTypeId);
-WINSCARDAPI LONG WINAPI SCardGetDeviceTypeIdW(SCARDCONTEXT hContext, LPCWSTR szReaderName, LPDWORD pdwDeviceTypeId);
+WINSCARDAPI LONG WINAPI SCardGetDeviceTypeIdA(SCARDCONTEXT hContext, LPCSTR szReaderName,
+        LPDWORD pdwDeviceTypeId);
+WINSCARDAPI LONG WINAPI SCardGetDeviceTypeIdW(SCARDCONTEXT hContext, LPCWSTR szReaderName,
+        LPDWORD pdwDeviceTypeId);
 
 WINSCARDAPI LONG WINAPI SCardGetReaderDeviceInstanceIdA(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId);
+        LPCSTR szReaderName, LPSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId);
 WINSCARDAPI LONG WINAPI SCardGetReaderDeviceInstanceIdW(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPWSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId);
+        LPCWSTR szReaderName, LPWSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId);
 
 WINSCARDAPI LONG WINAPI SCardListReadersWithDeviceInstanceIdA(SCARDCONTEXT hContext,
-		LPCSTR szDeviceInstanceId, LPSTR mszReaders, LPDWORD pcchReaders);
+        LPCSTR szDeviceInstanceId, LPSTR mszReaders, LPDWORD pcchReaders);
 WINSCARDAPI LONG WINAPI SCardListReadersWithDeviceInstanceIdW(SCARDCONTEXT hContext,
-		LPCWSTR szDeviceInstanceId, LPWSTR mszReaders, LPDWORD pcchReaders);
+        LPCWSTR szDeviceInstanceId, LPWSTR mszReaders, LPDWORD pcchReaders);
 
 WINSCARDAPI LONG WINAPI SCardAudit(SCARDCONTEXT hContext, DWORD dwEvent);
+
+WINSCARDAPI LONG WINAPI SCardAddReaderName(HANDLE* key, LPSTR readerName);
 
 #ifdef UNICODE
 #define SCardListReaderGroups			SCardListReaderGroupsW
@@ -847,185 +859,193 @@ WINSCARDAPI LONG WINAPI SCardAudit(SCARDCONTEXT hContext, DWORD dwEvent);
  * Extended API
  */
 
-typedef LONG (WINAPI * fnSCardEstablishContext)(DWORD dwScope,
-		LPCVOID pvReserved1, LPCVOID pvReserved2, LPSCARDCONTEXT phContext);
+typedef LONG(WINAPI* fnSCardEstablishContext)(DWORD dwScope,
+        LPCVOID pvReserved1, LPCVOID pvReserved2, LPSCARDCONTEXT phContext);
 
-typedef LONG (WINAPI * fnSCardReleaseContext)(SCARDCONTEXT hContext);
+typedef LONG(WINAPI* fnSCardReleaseContext)(SCARDCONTEXT hContext);
 
-typedef LONG (WINAPI * fnSCardIsValidContext)(SCARDCONTEXT hContext);
+typedef LONG(WINAPI* fnSCardIsValidContext)(SCARDCONTEXT hContext);
 
-typedef LONG (WINAPI * fnSCardListReaderGroupsA)(SCARDCONTEXT hContext,
-		LPSTR mszGroups, LPDWORD pcchGroups);
-typedef LONG (WINAPI * fnSCardListReaderGroupsW)(SCARDCONTEXT hContext,
-		LPWSTR mszGroups, LPDWORD pcchGroups);
+typedef LONG(WINAPI* fnSCardListReaderGroupsA)(SCARDCONTEXT hContext,
+        LPSTR mszGroups, LPDWORD pcchGroups);
+typedef LONG(WINAPI* fnSCardListReaderGroupsW)(SCARDCONTEXT hContext,
+        LPWSTR mszGroups, LPDWORD pcchGroups);
 
-typedef LONG (WINAPI * fnSCardListReadersA)(SCARDCONTEXT hContext,
-		LPCSTR mszGroups, LPSTR mszReaders, LPDWORD pcchReaders);
-typedef LONG (WINAPI * fnSCardListReadersW)(SCARDCONTEXT hContext,
-		LPCWSTR mszGroups, LPWSTR mszReaders, LPDWORD pcchReaders);
+typedef LONG(WINAPI* fnSCardListReadersA)(SCARDCONTEXT hContext,
+        LPCSTR mszGroups, LPSTR mszReaders, LPDWORD pcchReaders);
+typedef LONG(WINAPI* fnSCardListReadersW)(SCARDCONTEXT hContext,
+        LPCWSTR mszGroups, LPWSTR mszReaders, LPDWORD pcchReaders);
 
-typedef LONG (WINAPI * fnSCardListCardsA)(SCARDCONTEXT hContext,
-		LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, CHAR* mszCards, LPDWORD pcchCards);
+typedef LONG(WINAPI* fnSCardListCardsA)(SCARDCONTEXT hContext,
+                                        LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, CHAR* mszCards,
+                                        LPDWORD pcchCards);
 
-typedef LONG (WINAPI * fnSCardListCardsW)(SCARDCONTEXT hContext,
-		LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, WCHAR* mszCards, LPDWORD pcchCards);
+typedef LONG(WINAPI* fnSCardListCardsW)(SCARDCONTEXT hContext,
+                                        LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, WCHAR* mszCards,
+                                        LPDWORD pcchCards);
 
-typedef LONG (WINAPI * fnSCardListInterfacesA)(SCARDCONTEXT hContext,
-		LPCSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces);
-typedef LONG (WINAPI * fnSCardListInterfacesW)(SCARDCONTEXT hContext,
-		LPCWSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces);
+typedef LONG(WINAPI* fnSCardListInterfacesA)(SCARDCONTEXT hContext,
+        LPCSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces);
+typedef LONG(WINAPI* fnSCardListInterfacesW)(SCARDCONTEXT hContext,
+        LPCWSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces);
 
-typedef LONG (WINAPI * fnSCardGetProviderIdA)(SCARDCONTEXT hContext,
-		LPCSTR szCard, LPGUID pguidProviderId);
-typedef LONG (WINAPI * fnSCardGetProviderIdW)(SCARDCONTEXT hContext,
-		LPCWSTR szCard, LPGUID pguidProviderId);
+typedef LONG(WINAPI* fnSCardGetProviderIdA)(SCARDCONTEXT hContext,
+        LPCSTR szCard, LPGUID pguidProviderId);
+typedef LONG(WINAPI* fnSCardGetProviderIdW)(SCARDCONTEXT hContext,
+        LPCWSTR szCard, LPGUID pguidProviderId);
 
-typedef LONG (WINAPI * fnSCardGetCardTypeProviderNameA)(SCARDCONTEXT hContext,
-		LPCSTR szCardName, DWORD dwProviderId, CHAR* szProvider, LPDWORD pcchProvider);
-typedef LONG (WINAPI * fnSCardGetCardTypeProviderNameW)(SCARDCONTEXT hContext,
-		LPCWSTR szCardName, DWORD dwProviderId, WCHAR* szProvider, LPDWORD pcchProvider);
+typedef LONG(WINAPI* fnSCardGetCardTypeProviderNameA)(SCARDCONTEXT hContext,
+        LPCSTR szCardName, DWORD dwProviderId, CHAR* szProvider, LPDWORD pcchProvider);
+typedef LONG(WINAPI* fnSCardGetCardTypeProviderNameW)(SCARDCONTEXT hContext,
+        LPCWSTR szCardName, DWORD dwProviderId, WCHAR* szProvider, LPDWORD pcchProvider);
 
-typedef LONG (WINAPI * fnSCardIntroduceReaderGroupA)(SCARDCONTEXT hContext, LPCSTR szGroupName);
-typedef LONG (WINAPI * fnSCardIntroduceReaderGroupW)(SCARDCONTEXT hContext, LPCWSTR szGroupName);
+typedef LONG(WINAPI* fnSCardIntroduceReaderGroupA)(SCARDCONTEXT hContext, LPCSTR szGroupName);
+typedef LONG(WINAPI* fnSCardIntroduceReaderGroupW)(SCARDCONTEXT hContext, LPCWSTR szGroupName);
 
-typedef LONG (WINAPI * fnSCardForgetReaderGroupA)(SCARDCONTEXT hContext, LPCSTR szGroupName);
-typedef LONG (WINAPI * fnSCardForgetReaderGroupW)(SCARDCONTEXT hContext, LPCWSTR szGroupName);
+typedef LONG(WINAPI* fnSCardForgetReaderGroupA)(SCARDCONTEXT hContext, LPCSTR szGroupName);
+typedef LONG(WINAPI* fnSCardForgetReaderGroupW)(SCARDCONTEXT hContext, LPCWSTR szGroupName);
 
-typedef LONG (WINAPI * fnSCardIntroduceReaderA)(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPCSTR szDeviceName);
-typedef LONG (WINAPI * fnSCardIntroduceReaderW)(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPCWSTR szDeviceName);
+typedef LONG(WINAPI* fnSCardIntroduceReaderA)(SCARDCONTEXT hContext,
+        LPCSTR szReaderName, LPCSTR szDeviceName);
+typedef LONG(WINAPI* fnSCardIntroduceReaderW)(SCARDCONTEXT hContext,
+        LPCWSTR szReaderName, LPCWSTR szDeviceName);
 
-typedef LONG (WINAPI * fnSCardForgetReaderA)(SCARDCONTEXT hContext, LPCSTR szReaderName);
-typedef LONG (WINAPI * fnSCardForgetReaderW)(SCARDCONTEXT hContext, LPCWSTR szReaderName);
+typedef LONG(WINAPI* fnSCardForgetReaderA)(SCARDCONTEXT hContext, LPCSTR szReaderName);
+typedef LONG(WINAPI* fnSCardForgetReaderW)(SCARDCONTEXT hContext, LPCWSTR szReaderName);
 
-typedef LONG (WINAPI * fnSCardAddReaderToGroupA)(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPCSTR szGroupName);
-typedef LONG (WINAPI * fnSCardAddReaderToGroupW)(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPCWSTR szGroupName);
+typedef LONG(WINAPI* fnSCardAddReaderToGroupA)(SCARDCONTEXT hContext,
+        LPCSTR szReaderName, LPCSTR szGroupName);
+typedef LONG(WINAPI* fnSCardAddReaderToGroupW)(SCARDCONTEXT hContext,
+        LPCWSTR szReaderName, LPCWSTR szGroupName);
 
-typedef LONG (WINAPI * fnSCardRemoveReaderFromGroupA)(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPCSTR szGroupName);
-typedef LONG (WINAPI * fnSCardRemoveReaderFromGroupW)(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPCWSTR szGroupName);
+typedef LONG(WINAPI* fnSCardRemoveReaderFromGroupA)(SCARDCONTEXT hContext,
+        LPCSTR szReaderName, LPCSTR szGroupName);
+typedef LONG(WINAPI* fnSCardRemoveReaderFromGroupW)(SCARDCONTEXT hContext,
+        LPCWSTR szReaderName, LPCWSTR szGroupName);
 
-typedef LONG (WINAPI * fnSCardIntroduceCardTypeA)(SCARDCONTEXT hContext,
-		LPCSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
-		DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen);
-typedef LONG (WINAPI * fnSCardIntroduceCardTypeW)(SCARDCONTEXT hContext,
-		LPCWSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
-		DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen);
+typedef LONG(WINAPI* fnSCardIntroduceCardTypeA)(SCARDCONTEXT hContext,
+        LPCSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
+        DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen);
+typedef LONG(WINAPI* fnSCardIntroduceCardTypeW)(SCARDCONTEXT hContext,
+        LPCWSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
+        DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen);
 
-typedef LONG (WINAPI * fnSCardSetCardTypeProviderNameA)(SCARDCONTEXT hContext,
-		LPCSTR szCardName, DWORD dwProviderId, LPCSTR szProvider);
-typedef LONG (WINAPI * fnSCardSetCardTypeProviderNameW)(SCARDCONTEXT hContext,
-		LPCWSTR szCardName, DWORD dwProviderId, LPCWSTR szProvider);
+typedef LONG(WINAPI* fnSCardSetCardTypeProviderNameA)(SCARDCONTEXT hContext,
+        LPCSTR szCardName, DWORD dwProviderId, LPCSTR szProvider);
+typedef LONG(WINAPI* fnSCardSetCardTypeProviderNameW)(SCARDCONTEXT hContext,
+        LPCWSTR szCardName, DWORD dwProviderId, LPCWSTR szProvider);
 
-typedef LONG (WINAPI * fnSCardForgetCardTypeA)(SCARDCONTEXT hContext, LPCSTR szCardName);
-typedef LONG (WINAPI * fnSCardForgetCardTypeW)(SCARDCONTEXT hContext, LPCWSTR szCardName);
+typedef LONG(WINAPI* fnSCardForgetCardTypeA)(SCARDCONTEXT hContext, LPCSTR szCardName);
+typedef LONG(WINAPI* fnSCardForgetCardTypeW)(SCARDCONTEXT hContext, LPCWSTR szCardName);
 
-typedef LONG (WINAPI * fnSCardFreeMemory)(SCARDCONTEXT hContext, LPCVOID pvMem);
+typedef LONG(WINAPI* fnSCardFreeMemory)(SCARDCONTEXT hContext, LPCVOID pvMem);
 
-typedef HANDLE (WINAPI * fnSCardAccessStartedEvent)(void);
+typedef HANDLE(WINAPI* fnSCardAccessStartedEvent)(void);
 
-typedef void (WINAPI * fnSCardReleaseStartedEvent)(void);
+typedef void (WINAPI* fnSCardReleaseStartedEvent)(void);
 
-typedef LONG (WINAPI * fnSCardLocateCardsA)(SCARDCONTEXT hContext,
-		LPCSTR mszCards, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders);
-typedef LONG (WINAPI * fnSCardLocateCardsW)(SCARDCONTEXT hContext,
-		LPCWSTR mszCards, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders);
+typedef LONG(WINAPI* fnSCardLocateCardsA)(SCARDCONTEXT hContext,
+        LPCSTR mszCards, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders);
+typedef LONG(WINAPI* fnSCardLocateCardsW)(SCARDCONTEXT hContext,
+        LPCWSTR mszCards, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders);
 
-typedef LONG (WINAPI * fnSCardLocateCardsByATRA)(SCARDCONTEXT hContext,
-		LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders);
-typedef LONG (WINAPI * fnSCardLocateCardsByATRW)(SCARDCONTEXT hContext,
-		LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders);
+typedef LONG(WINAPI* fnSCardLocateCardsByATRA)(SCARDCONTEXT hContext,
+        LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders);
+typedef LONG(WINAPI* fnSCardLocateCardsByATRW)(SCARDCONTEXT hContext,
+        LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders);
 
-typedef LONG (WINAPI * fnSCardGetStatusChangeA)(SCARDCONTEXT hContext,
-		DWORD dwTimeout, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders);
-typedef LONG (WINAPI * fnSCardGetStatusChangeW)(SCARDCONTEXT hContext,
-		DWORD dwTimeout, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders);
+typedef LONG(WINAPI* fnSCardGetStatusChangeA)(SCARDCONTEXT hContext,
+        DWORD dwTimeout, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders);
+typedef LONG(WINAPI* fnSCardGetStatusChangeW)(SCARDCONTEXT hContext,
+        DWORD dwTimeout, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders);
 
-typedef LONG (WINAPI * fnSCardCancel)(SCARDCONTEXT hContext);
+typedef LONG(WINAPI* fnSCardCancel)(SCARDCONTEXT hContext);
 
-typedef LONG (WINAPI * fnSCardConnectA)(SCARDCONTEXT hContext,
-		LPCSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
-		LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol);
-typedef LONG (WINAPI * fnSCardConnectW)(SCARDCONTEXT hContext,
-		LPCWSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
-		LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol);
+typedef LONG(WINAPI* fnSCardConnectA)(SCARDCONTEXT hContext,
+                                      LPCSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
+                                      LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol);
+typedef LONG(WINAPI* fnSCardConnectW)(SCARDCONTEXT hContext,
+                                      LPCWSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
+                                      LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol);
 
-typedef LONG (WINAPI * fnSCardReconnect)(SCARDHANDLE hCard,
-		DWORD dwShareMode, DWORD dwPreferredProtocols, DWORD dwInitialization, LPDWORD pdwActiveProtocol);
+typedef LONG(WINAPI* fnSCardReconnect)(SCARDHANDLE hCard,
+                                       DWORD dwShareMode, DWORD dwPreferredProtocols, DWORD dwInitialization, LPDWORD pdwActiveProtocol);
 
-typedef LONG (WINAPI * fnSCardDisconnect)(SCARDHANDLE hCard, DWORD dwDisposition);
+typedef LONG(WINAPI* fnSCardDisconnect)(SCARDHANDLE hCard, DWORD dwDisposition);
 
-typedef LONG (WINAPI * fnSCardBeginTransaction)(SCARDHANDLE hCard);
+typedef LONG(WINAPI* fnSCardBeginTransaction)(SCARDHANDLE hCard);
 
-typedef LONG (WINAPI * fnSCardEndTransaction)(SCARDHANDLE hCard, DWORD dwDisposition);
+typedef LONG(WINAPI* fnSCardEndTransaction)(SCARDHANDLE hCard, DWORD dwDisposition);
 
-typedef LONG (WINAPI * fnSCardCancelTransaction)(SCARDHANDLE hCard);
+typedef LONG(WINAPI* fnSCardCancelTransaction)(SCARDHANDLE hCard);
 
-typedef LONG (WINAPI * fnSCardState)(SCARDHANDLE hCard,
-		LPDWORD pdwState, LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen);
+typedef LONG(WINAPI* fnSCardState)(SCARDHANDLE hCard,
+                                   LPDWORD pdwState, LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen);
 
-typedef LONG (WINAPI * fnSCardStatusA)(SCARDHANDLE hCard,
-		LPSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
-		LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen);
-typedef LONG (WINAPI * fnSCardStatusW)(SCARDHANDLE hCard,
-		LPWSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
-		LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen);
+typedef LONG(WINAPI* fnSCardStatusA)(SCARDHANDLE hCard,
+                                     LPSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
+                                     LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen);
+typedef LONG(WINAPI* fnSCardStatusW)(SCARDHANDLE hCard,
+                                     LPWSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
+                                     LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen);
 
-typedef LONG (WINAPI * fnSCardTransmit)(SCARDHANDLE hCard,
-		LPCSCARD_IO_REQUEST pioSendPci, LPCBYTE pbSendBuffer, DWORD cbSendLength,
-		LPSCARD_IO_REQUEST pioRecvPci, LPBYTE pbRecvBuffer, LPDWORD pcbRecvLength);
+typedef LONG(WINAPI* fnSCardTransmit)(SCARDHANDLE hCard,
+                                      LPCSCARD_IO_REQUEST pioSendPci, LPCBYTE pbSendBuffer, DWORD cbSendLength,
+                                      LPSCARD_IO_REQUEST pioRecvPci, LPBYTE pbRecvBuffer, LPDWORD pcbRecvLength);
 
-typedef LONG (WINAPI * fnSCardGetTransmitCount)(SCARDHANDLE hCard, LPDWORD pcTransmitCount);
+typedef LONG(WINAPI* fnSCardGetTransmitCount)(SCARDHANDLE hCard, LPDWORD pcTransmitCount);
 
-typedef LONG (WINAPI * fnSCardControl)(SCARDHANDLE hCard,
-		DWORD dwControlCode, LPCVOID lpInBuffer, DWORD cbInBufferSize,
-		LPVOID lpOutBuffer, DWORD cbOutBufferSize, LPDWORD lpBytesReturned);
+typedef LONG(WINAPI* fnSCardControl)(SCARDHANDLE hCard,
+                                     DWORD dwControlCode, LPCVOID lpInBuffer, DWORD cbInBufferSize,
+                                     LPVOID lpOutBuffer, DWORD cbOutBufferSize, LPDWORD lpBytesReturned);
 
-typedef LONG (WINAPI * fnSCardGetAttrib)(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr, LPDWORD pcbAttrLen);
+typedef LONG(WINAPI* fnSCardGetAttrib)(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr,
+                                       LPDWORD pcbAttrLen);
 
-typedef LONG (WINAPI * fnSCardSetAttrib)(SCARDHANDLE hCard, DWORD dwAttrId, LPCBYTE pbAttr, DWORD cbAttrLen);
+typedef LONG(WINAPI* fnSCardSetAttrib)(SCARDHANDLE hCard, DWORD dwAttrId, LPCBYTE pbAttr,
+                                       DWORD cbAttrLen);
 
-typedef LONG (WINAPI * fnSCardUIDlgSelectCardA)(LPOPENCARDNAMEA_EX pDlgStruc);
-typedef LONG (WINAPI * fnSCardUIDlgSelectCardW)(LPOPENCARDNAMEW_EX pDlgStruc);
+typedef LONG(WINAPI* fnSCardUIDlgSelectCardA)(LPOPENCARDNAMEA_EX pDlgStruc);
+typedef LONG(WINAPI* fnSCardUIDlgSelectCardW)(LPOPENCARDNAMEW_EX pDlgStruc);
 
-typedef LONG (WINAPI * fnGetOpenCardNameA)(LPOPENCARDNAMEA pDlgStruc);
-typedef LONG (WINAPI * fnGetOpenCardNameW)(LPOPENCARDNAMEW pDlgStruc);
+typedef LONG(WINAPI* fnGetOpenCardNameA)(LPOPENCARDNAMEA pDlgStruc);
+typedef LONG(WINAPI* fnGetOpenCardNameW)(LPOPENCARDNAMEW pDlgStruc);
 
-typedef LONG (WINAPI * fnSCardDlgExtendedError)(void);
+typedef LONG(WINAPI* fnSCardDlgExtendedError)(void);
 
-typedef LONG (WINAPI * fnSCardReadCacheA)(SCARDCONTEXT hContext,
-		UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD* DataLen);
-typedef LONG (WINAPI * fnSCardReadCacheW)(SCARDCONTEXT hContext,
-		UUID* CardIdentifier,  DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD* DataLen);
+typedef LONG(WINAPI* fnSCardReadCacheA)(SCARDCONTEXT hContext,
+                                        UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD* DataLen);
+typedef LONG(WINAPI* fnSCardReadCacheW)(SCARDCONTEXT hContext,
+                                        UUID* CardIdentifier,  DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD* DataLen);
 
-typedef LONG (WINAPI * fnSCardWriteCacheA)(SCARDCONTEXT hContext,
-		UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD DataLen);
-typedef LONG (WINAPI * fnSCardWriteCacheW)(SCARDCONTEXT hContext,
-		UUID* CardIdentifier, DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD DataLen);
+typedef LONG(WINAPI* fnSCardWriteCacheA)(SCARDCONTEXT hContext,
+        UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD DataLen);
+typedef LONG(WINAPI* fnSCardWriteCacheW)(SCARDCONTEXT hContext,
+        UUID* CardIdentifier, DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD DataLen);
 
-typedef LONG (WINAPI * fnSCardGetReaderIconA)(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon);
-typedef LONG (WINAPI * fnSCardGetReaderIconW)(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon);
+typedef LONG(WINAPI* fnSCardGetReaderIconA)(SCARDCONTEXT hContext,
+        LPCSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon);
+typedef LONG(WINAPI* fnSCardGetReaderIconW)(SCARDCONTEXT hContext,
+        LPCWSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon);
 
-typedef LONG (WINAPI * fnSCardGetDeviceTypeIdA)(SCARDCONTEXT hContext, LPCSTR szReaderName, LPDWORD pdwDeviceTypeId);
-typedef LONG (WINAPI * fnSCardGetDeviceTypeIdW)(SCARDCONTEXT hContext, LPCWSTR szReaderName, LPDWORD pdwDeviceTypeId);
+typedef LONG(WINAPI* fnSCardGetDeviceTypeIdA)(SCARDCONTEXT hContext, LPCSTR szReaderName,
+        LPDWORD pdwDeviceTypeId);
+typedef LONG(WINAPI* fnSCardGetDeviceTypeIdW)(SCARDCONTEXT hContext, LPCWSTR szReaderName,
+        LPDWORD pdwDeviceTypeId);
 
-typedef LONG (WINAPI * fnSCardGetReaderDeviceInstanceIdA)(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId);
-typedef LONG (WINAPI * fnSCardGetReaderDeviceInstanceIdW)(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPWSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId);
+typedef LONG(WINAPI* fnSCardGetReaderDeviceInstanceIdA)(SCARDCONTEXT hContext,
+        LPCSTR szReaderName, LPSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId);
+typedef LONG(WINAPI* fnSCardGetReaderDeviceInstanceIdW)(SCARDCONTEXT hContext,
+        LPCWSTR szReaderName, LPWSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId);
 
-typedef LONG (WINAPI * fnSCardListReadersWithDeviceInstanceIdA)(SCARDCONTEXT hContext,
-		LPCSTR szDeviceInstanceId, LPSTR mszReaders, LPDWORD pcchReaders);
-typedef LONG (WINAPI * fnSCardListReadersWithDeviceInstanceIdW)(SCARDCONTEXT hContext,
-		LPCWSTR szDeviceInstanceId, LPWSTR mszReaders, LPDWORD pcchReaders);
+typedef LONG(WINAPI* fnSCardListReadersWithDeviceInstanceIdA)(SCARDCONTEXT hContext,
+        LPCSTR szDeviceInstanceId, LPSTR mszReaders, LPDWORD pcchReaders);
+typedef LONG(WINAPI* fnSCardListReadersWithDeviceInstanceIdW)(SCARDCONTEXT hContext,
+        LPCWSTR szDeviceInstanceId, LPWSTR mszReaders, LPDWORD pcchReaders);
 
-typedef LONG (WINAPI * fnSCardAudit)(SCARDCONTEXT hContext, DWORD dwEvent);
+typedef LONG(WINAPI* fnSCardAudit)(SCARDCONTEXT hContext, DWORD dwEvent);
+
+typedef LONG(WINAPI* fnSCardAddReaderName)(HANDLE* key, LPSTR readerName);
 
 struct _SCardApiFunctionTable
 {
@@ -1108,6 +1128,7 @@ struct _SCardApiFunctionTable
 	fnSCardListReadersWithDeviceInstanceIdA pfnSCardListReadersWithDeviceInstanceIdA;
 	fnSCardListReadersWithDeviceInstanceIdW pfnSCardListReadersWithDeviceInstanceIdW;
 	fnSCardAudit pfnSCardAudit;
+	fnSCardAddReaderName pfnSCardAddReaderName;
 };
 
 typedef struct _SCardApiFunctionTable SCardApiFunctionTable;

--- a/winpr/libwinpr/smartcard/smartcard.c
+++ b/winpr/libwinpr/smartcard/smartcard.c
@@ -41,10 +41,10 @@ const SCARD_IO_REQUEST g_rgSCardT1Pci = { SCARD_PROTOCOL_T1, 8 };
 const SCARD_IO_REQUEST g_rgSCardRawPci = { SCARD_PROTOCOL_RAW, 8 };
 
 WINSCARDAPI LONG WINAPI SCardEstablishContext(DWORD dwScope,
-		LPCVOID pvReserved1, LPCVOID pvReserved2, LPSCARDCONTEXT phContext)
+        LPCVOID pvReserved1, LPCVOID pvReserved2, LPSCARDCONTEXT phContext)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardEstablishContext,
-			dwScope, pvReserved1, pvReserved2, phContext);
+	                        dwScope, pvReserved1, pvReserved2, phContext);
 }
 
 WINSCARDAPI LONG WINAPI SCardReleaseContext(SCARDCONTEXT hContext)
@@ -58,79 +58,81 @@ WINSCARDAPI LONG WINAPI SCardIsValidContext(SCARDCONTEXT hContext)
 }
 
 WINSCARDAPI LONG WINAPI SCardListReaderGroupsA(SCARDCONTEXT hContext,
-		LPSTR mszGroups, LPDWORD pcchGroups)
+        LPSTR mszGroups, LPDWORD pcchGroups)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardListReaderGroupsA, hContext, mszGroups, pcchGroups);
 }
 
 WINSCARDAPI LONG WINAPI SCardListReaderGroupsW(SCARDCONTEXT hContext,
-		LPWSTR mszGroups, LPDWORD pcchGroups)
+        LPWSTR mszGroups, LPDWORD pcchGroups)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardListReaderGroupsW, hContext, mszGroups, pcchGroups);
 }
 
 WINSCARDAPI LONG WINAPI SCardListReadersA(SCARDCONTEXT hContext,
-		LPCSTR mszGroups, LPSTR mszReaders, LPDWORD pcchReaders)
+        LPCSTR mszGroups, LPSTR mszReaders, LPDWORD pcchReaders)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardListReadersA, hContext, mszGroups, mszReaders, pcchReaders);
 }
 
 WINSCARDAPI LONG WINAPI SCardListReadersW(SCARDCONTEXT hContext,
-		LPCWSTR mszGroups, LPWSTR mszReaders, LPDWORD pcchReaders)
+        LPCWSTR mszGroups, LPWSTR mszReaders, LPDWORD pcchReaders)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardListReadersW, hContext, mszGroups, mszReaders, pcchReaders);
 }
 
 WINSCARDAPI LONG WINAPI SCardListCardsA(SCARDCONTEXT hContext,
-		LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, CHAR* mszCards, LPDWORD pcchCards)
+                                        LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, CHAR* mszCards,
+                                        LPDWORD pcchCards)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardListCardsA, hContext, pbAtr,
-			rgquidInterfaces, cguidInterfaceCount, mszCards, pcchCards);
+	                        rgquidInterfaces, cguidInterfaceCount, mszCards, pcchCards);
 }
 
 WINSCARDAPI LONG WINAPI SCardListCardsW(SCARDCONTEXT hContext,
-		LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, WCHAR* mszCards, LPDWORD pcchCards)
+                                        LPCBYTE pbAtr, LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount, WCHAR* mszCards,
+                                        LPDWORD pcchCards)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardListCardsW, hContext, pbAtr,
-			rgquidInterfaces, cguidInterfaceCount, mszCards, pcchCards);
+	                        rgquidInterfaces, cguidInterfaceCount, mszCards, pcchCards);
 }
 
 WINSCARDAPI LONG WINAPI SCardListInterfacesA(SCARDCONTEXT hContext,
-		LPCSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces)
+        LPCSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardListInterfacesA, hContext, szCard, pguidInterfaces, pcguidInterfaces);
 }
 
 WINSCARDAPI LONG WINAPI SCardListInterfacesW(SCARDCONTEXT hContext,
-		LPCWSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces)
+        LPCWSTR szCard, LPGUID pguidInterfaces, LPDWORD pcguidInterfaces)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardListInterfacesW, hContext, szCard, pguidInterfaces, pcguidInterfaces);
 }
 
 WINSCARDAPI LONG WINAPI SCardGetProviderIdA(SCARDCONTEXT hContext,
-		LPCSTR szCard, LPGUID pguidProviderId)
+        LPCSTR szCard, LPGUID pguidProviderId)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardGetProviderIdA, hContext, szCard, pguidProviderId);
 }
 
 WINSCARDAPI LONG WINAPI SCardGetProviderIdW(SCARDCONTEXT hContext,
-		LPCWSTR szCard, LPGUID pguidProviderId)
+        LPCWSTR szCard, LPGUID pguidProviderId)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardGetProviderIdW, hContext, szCard, pguidProviderId);
 }
 
 WINSCARDAPI LONG WINAPI SCardGetCardTypeProviderNameA(SCARDCONTEXT hContext,
-		LPCSTR szCardName, DWORD dwProviderId, CHAR* szProvider, LPDWORD pcchProvider)
+        LPCSTR szCardName, DWORD dwProviderId, CHAR* szProvider, LPDWORD pcchProvider)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardGetCardTypeProviderNameA, hContext, szCardName,
-			dwProviderId, szProvider, pcchProvider);
+	                        dwProviderId, szProvider, pcchProvider);
 }
 
 WINSCARDAPI LONG WINAPI SCardGetCardTypeProviderNameW(SCARDCONTEXT hContext,
-		LPCWSTR szCardName, DWORD dwProviderId, WCHAR* szProvider, LPDWORD pcchProvider)
+        LPCWSTR szCardName, DWORD dwProviderId, WCHAR* szProvider, LPDWORD pcchProvider)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardGetCardTypeProviderNameW, hContext, szCardName,
-			dwProviderId, szProvider, pcchProvider);
+	                        dwProviderId, szProvider, pcchProvider);
 }
 
 WINSCARDAPI LONG WINAPI SCardIntroduceReaderGroupA(SCARDCONTEXT hContext, LPCSTR szGroupName)
@@ -154,13 +156,13 @@ WINSCARDAPI LONG WINAPI SCardForgetReaderGroupW(SCARDCONTEXT hContext, LPCWSTR s
 }
 
 WINSCARDAPI LONG WINAPI SCardIntroduceReaderA(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPCSTR szDeviceName)
+        LPCSTR szReaderName, LPCSTR szDeviceName)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardIntroduceReaderA, hContext, szReaderName, szDeviceName);
 }
 
 WINSCARDAPI LONG WINAPI SCardIntroduceReaderW(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPCWSTR szDeviceName)
+        LPCWSTR szReaderName, LPCWSTR szDeviceName)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardIntroduceReaderW, hContext, szReaderName, szDeviceName);
 }
@@ -176,55 +178,57 @@ WINSCARDAPI LONG WINAPI SCardForgetReaderW(SCARDCONTEXT hContext, LPCWSTR szRead
 }
 
 WINSCARDAPI LONG WINAPI SCardAddReaderToGroupA(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPCSTR szGroupName)
+        LPCSTR szReaderName, LPCSTR szGroupName)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardAddReaderToGroupA, hContext, szReaderName, szGroupName);
 }
 
 WINSCARDAPI LONG WINAPI SCardAddReaderToGroupW(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPCWSTR szGroupName)
+        LPCWSTR szReaderName, LPCWSTR szGroupName)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardAddReaderToGroupW, hContext, szReaderName, szGroupName);
 }
 
 WINSCARDAPI LONG WINAPI SCardRemoveReaderFromGroupA(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPCSTR szGroupName)
+        LPCSTR szReaderName, LPCSTR szGroupName)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardRemoveReaderFromGroupA, hContext, szReaderName, szGroupName);
 }
 
 WINSCARDAPI LONG WINAPI SCardRemoveReaderFromGroupW(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPCWSTR szGroupName)
+        LPCWSTR szReaderName, LPCWSTR szGroupName)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardRemoveReaderFromGroupW, hContext, szReaderName, szGroupName);
 }
 
 WINSCARDAPI LONG WINAPI SCardIntroduceCardTypeA(SCARDCONTEXT hContext,
-		LPCSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
-		DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen)
+        LPCSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
+        DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardIntroduceCardTypeA, hContext, szCardName, pguidPrimaryProvider,
-			rgguidInterfaces, dwInterfaceCount, pbAtr, pbAtrMask, cbAtrLen);
+	                        rgguidInterfaces, dwInterfaceCount, pbAtr, pbAtrMask, cbAtrLen);
 }
 
 WINSCARDAPI LONG WINAPI SCardIntroduceCardTypeW(SCARDCONTEXT hContext,
-		LPCWSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
-		DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen)
+        LPCWSTR szCardName, LPCGUID pguidPrimaryProvider, LPCGUID rgguidInterfaces,
+        DWORD dwInterfaceCount, LPCBYTE pbAtr, LPCBYTE pbAtrMask, DWORD cbAtrLen)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardIntroduceCardTypeW, hContext, szCardName, pguidPrimaryProvider,
-			rgguidInterfaces, dwInterfaceCount, pbAtr, pbAtrMask, cbAtrLen);
+	                        rgguidInterfaces, dwInterfaceCount, pbAtr, pbAtrMask, cbAtrLen);
 }
 
 WINSCARDAPI LONG WINAPI SCardSetCardTypeProviderNameA(SCARDCONTEXT hContext,
-		LPCSTR szCardName, DWORD dwProviderId, LPCSTR szProvider)
+        LPCSTR szCardName, DWORD dwProviderId, LPCSTR szProvider)
 {
-	SCARDAPI_STUB_CALL_LONG(SCardSetCardTypeProviderNameA, hContext, szCardName, dwProviderId, szProvider);
+	SCARDAPI_STUB_CALL_LONG(SCardSetCardTypeProviderNameA, hContext, szCardName, dwProviderId,
+	                        szProvider);
 }
 
 WINSCARDAPI LONG WINAPI SCardSetCardTypeProviderNameW(SCARDCONTEXT hContext,
-		LPCWSTR szCardName, DWORD dwProviderId, LPCWSTR szProvider)
+        LPCWSTR szCardName, DWORD dwProviderId, LPCWSTR szProvider)
 {
-	SCARDAPI_STUB_CALL_LONG(SCardSetCardTypeProviderNameW, hContext, szCardName, dwProviderId, szProvider);
+	SCARDAPI_STUB_CALL_LONG(SCardSetCardTypeProviderNameW, hContext, szCardName, dwProviderId,
+	                        szProvider);
 }
 
 WINSCARDAPI LONG WINAPI SCardForgetCardTypeA(SCARDCONTEXT hContext, LPCSTR szCardName)
@@ -253,37 +257,39 @@ WINSCARDAPI void WINAPI SCardReleaseStartedEvent(void)
 }
 
 WINSCARDAPI LONG WINAPI SCardLocateCardsA(SCARDCONTEXT hContext,
-		LPCSTR mszCards, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders)
+        LPCSTR mszCards, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardLocateCardsA, hContext, mszCards, rgReaderStates, cReaders);
 }
 
 WINSCARDAPI LONG WINAPI SCardLocateCardsW(SCARDCONTEXT hContext,
-		LPCWSTR mszCards, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders)
+        LPCWSTR mszCards, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardLocateCardsW, hContext, mszCards, rgReaderStates, cReaders);
 }
 
 WINSCARDAPI LONG WINAPI SCardLocateCardsByATRA(SCARDCONTEXT hContext,
-		LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders)
+        LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders)
 {
-	SCARDAPI_STUB_CALL_LONG(SCardLocateCardsByATRA, hContext, rgAtrMasks, cAtrs, rgReaderStates, cReaders);
+	SCARDAPI_STUB_CALL_LONG(SCardLocateCardsByATRA, hContext, rgAtrMasks, cAtrs, rgReaderStates,
+	                        cReaders);
 }
 
 WINSCARDAPI LONG WINAPI SCardLocateCardsByATRW(SCARDCONTEXT hContext,
-		LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders)
+        LPSCARD_ATRMASK rgAtrMasks, DWORD cAtrs, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders)
 {
-	SCARDAPI_STUB_CALL_LONG(SCardLocateCardsByATRW, hContext, rgAtrMasks, cAtrs, rgReaderStates, cReaders);
+	SCARDAPI_STUB_CALL_LONG(SCardLocateCardsByATRW, hContext, rgAtrMasks, cAtrs, rgReaderStates,
+	                        cReaders);
 }
 
 WINSCARDAPI LONG WINAPI SCardGetStatusChangeA(SCARDCONTEXT hContext,
-		DWORD dwTimeout, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders)
+        DWORD dwTimeout, LPSCARD_READERSTATEA rgReaderStates, DWORD cReaders)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardGetStatusChangeA, hContext, dwTimeout, rgReaderStates, cReaders);
 }
 
 WINSCARDAPI LONG WINAPI SCardGetStatusChangeW(SCARDCONTEXT hContext,
-		DWORD dwTimeout, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders)
+        DWORD dwTimeout, LPSCARD_READERSTATEW rgReaderStates, DWORD cReaders)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardGetStatusChangeW, hContext, dwTimeout, rgReaderStates, cReaders);
 }
@@ -294,26 +300,26 @@ WINSCARDAPI LONG WINAPI SCardCancel(SCARDCONTEXT hContext)
 }
 
 WINSCARDAPI LONG WINAPI SCardConnectA(SCARDCONTEXT hContext,
-		LPCSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
-		LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol)
+                                      LPCSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
+                                      LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardConnectA, hContext, szReader, dwShareMode,
-			dwPreferredProtocols, phCard, pdwActiveProtocol);
+	                        dwPreferredProtocols, phCard, pdwActiveProtocol);
 }
 
 WINSCARDAPI LONG WINAPI SCardConnectW(SCARDCONTEXT hContext,
-		LPCWSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
-		LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol)
+                                      LPCWSTR szReader, DWORD dwShareMode, DWORD dwPreferredProtocols,
+                                      LPSCARDHANDLE phCard, LPDWORD pdwActiveProtocol)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardConnectW, hContext, szReader, dwShareMode,
-			dwPreferredProtocols, phCard, pdwActiveProtocol);
+	                        dwPreferredProtocols, phCard, pdwActiveProtocol);
 }
 
 WINSCARDAPI LONG WINAPI SCardReconnect(SCARDHANDLE hCard,
-		DWORD dwShareMode, DWORD dwPreferredProtocols, DWORD dwInitialization, LPDWORD pdwActiveProtocol)
+                                       DWORD dwShareMode, DWORD dwPreferredProtocols, DWORD dwInitialization, LPDWORD pdwActiveProtocol)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardReconnect, hCard, dwShareMode,
-			dwPreferredProtocols, dwInitialization, pdwActiveProtocol);
+	                        dwPreferredProtocols, dwInitialization, pdwActiveProtocol);
 }
 
 WINSCARDAPI LONG WINAPI SCardDisconnect(SCARDHANDLE hCard, DWORD dwDisposition)
@@ -337,33 +343,33 @@ WINSCARDAPI LONG WINAPI SCardCancelTransaction(SCARDHANDLE hCard)
 }
 
 WINSCARDAPI LONG WINAPI SCardState(SCARDHANDLE hCard,
-		LPDWORD pdwState, LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen)
+                                   LPDWORD pdwState, LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardState, hCard, pdwState, pdwProtocol, pbAtr, pcbAtrLen);
 }
 
 WINSCARDAPI LONG WINAPI SCardStatusA(SCARDHANDLE hCard,
-		LPSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
-		LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen)
+                                     LPSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
+                                     LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardStatusA, hCard, mszReaderNames, pcchReaderLen,
-			pdwState, pdwProtocol, pbAtr, pcbAtrLen);
+	                        pdwState, pdwProtocol, pbAtr, pcbAtrLen);
 }
 
 WINSCARDAPI LONG WINAPI SCardStatusW(SCARDHANDLE hCard,
-		LPWSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
-		LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen)
+                                     LPWSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState,
+                                     LPDWORD pdwProtocol, LPBYTE pbAtr, LPDWORD pcbAtrLen)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardStatusW, hCard, mszReaderNames, pcchReaderLen,
-			pdwState, pdwProtocol, pbAtr, pcbAtrLen);
+	                        pdwState, pdwProtocol, pbAtr, pcbAtrLen);
 }
 
 WINSCARDAPI LONG WINAPI SCardTransmit(SCARDHANDLE hCard,
-		LPCSCARD_IO_REQUEST pioSendPci, LPCBYTE pbSendBuffer, DWORD cbSendLength,
-		LPSCARD_IO_REQUEST pioRecvPci, LPBYTE pbRecvBuffer, LPDWORD pcbRecvLength)
+                                      LPCSCARD_IO_REQUEST pioSendPci, LPCBYTE pbSendBuffer, DWORD cbSendLength,
+                                      LPSCARD_IO_REQUEST pioRecvPci, LPBYTE pbRecvBuffer, LPDWORD pcbRecvLength)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardTransmit, hCard, pioSendPci, pbSendBuffer, cbSendLength,
-			pioRecvPci, pbRecvBuffer, pcbRecvLength);
+	                        pioRecvPci, pbRecvBuffer, pcbRecvLength);
 }
 
 WINSCARDAPI LONG WINAPI SCardGetTransmitCount(SCARDHANDLE hCard, LPDWORD pcTransmitCount)
@@ -372,19 +378,21 @@ WINSCARDAPI LONG WINAPI SCardGetTransmitCount(SCARDHANDLE hCard, LPDWORD pcTrans
 }
 
 WINSCARDAPI LONG WINAPI SCardControl(SCARDHANDLE hCard,
-		DWORD dwControlCode, LPCVOID lpInBuffer, DWORD cbInBufferSize,
-		LPVOID lpOutBuffer, DWORD cbOutBufferSize, LPDWORD lpBytesReturned)
+                                     DWORD dwControlCode, LPCVOID lpInBuffer, DWORD cbInBufferSize,
+                                     LPVOID lpOutBuffer, DWORD cbOutBufferSize, LPDWORD lpBytesReturned)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardControl, hCard, dwControlCode, lpInBuffer, cbInBufferSize,
-			lpOutBuffer, cbOutBufferSize, lpBytesReturned);
+	                        lpOutBuffer, cbOutBufferSize, lpBytesReturned);
 }
 
-WINSCARDAPI LONG WINAPI SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr, LPDWORD pcbAttrLen)
+WINSCARDAPI LONG WINAPI SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr,
+                                       LPDWORD pcbAttrLen)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardGetAttrib, hCard, dwAttrId, pbAttr, pcbAttrLen);
 }
 
-WINSCARDAPI LONG WINAPI SCardSetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPCBYTE pbAttr, DWORD cbAttrLen)
+WINSCARDAPI LONG WINAPI SCardSetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPCBYTE pbAttr,
+                                       DWORD cbAttrLen)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardSetAttrib, hCard, dwAttrId, pbAttr, cbAttrLen);
 }
@@ -415,86 +423,93 @@ WINSCARDAPI LONG WINAPI SCardDlgExtendedError(void)
 }
 
 WINSCARDAPI LONG WINAPI SCardReadCacheA(SCARDCONTEXT hContext,
-		UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD* DataLen)
+                                        UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD* DataLen)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardReadCacheA, hContext, CardIdentifier,
-			FreshnessCounter, LookupName, Data, DataLen);
+	                        FreshnessCounter, LookupName, Data, DataLen);
 }
 
 WINSCARDAPI LONG WINAPI SCardReadCacheW(SCARDCONTEXT hContext,
-		UUID* CardIdentifier,  DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD* DataLen)
+                                        UUID* CardIdentifier,  DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD* DataLen)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardReadCacheW, hContext, CardIdentifier,
-			FreshnessCounter, LookupName, Data, DataLen);
+	                        FreshnessCounter, LookupName, Data, DataLen);
 }
 
 WINSCARDAPI LONG WINAPI SCardWriteCacheA(SCARDCONTEXT hContext,
-		UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD DataLen)
+        UUID* CardIdentifier, DWORD FreshnessCounter, LPSTR LookupName, PBYTE Data, DWORD DataLen)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardWriteCacheA, hContext, CardIdentifier,
-			FreshnessCounter, LookupName, Data, DataLen);
+	                        FreshnessCounter, LookupName, Data, DataLen);
 }
 
 WINSCARDAPI LONG WINAPI SCardWriteCacheW(SCARDCONTEXT hContext,
-		UUID* CardIdentifier, DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD DataLen)
+        UUID* CardIdentifier, DWORD FreshnessCounter, LPWSTR LookupName, PBYTE Data, DWORD DataLen)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardWriteCacheW, hContext, CardIdentifier,
-			FreshnessCounter, LookupName, Data, DataLen);
+	                        FreshnessCounter, LookupName, Data, DataLen);
 }
 
 WINSCARDAPI LONG WINAPI SCardGetReaderIconA(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon)
+        LPCSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardGetReaderIconA, hContext, szReaderName, pbIcon, pcbIcon);
 }
 
 WINSCARDAPI LONG WINAPI SCardGetReaderIconW(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon)
+        LPCWSTR szReaderName, LPBYTE pbIcon, LPDWORD pcbIcon)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardGetReaderIconW, hContext, szReaderName, pbIcon, pcbIcon);
 }
 
-WINSCARDAPI LONG WINAPI SCardGetDeviceTypeIdA(SCARDCONTEXT hContext, LPCSTR szReaderName, LPDWORD pdwDeviceTypeId)
+WINSCARDAPI LONG WINAPI SCardGetDeviceTypeIdA(SCARDCONTEXT hContext, LPCSTR szReaderName,
+        LPDWORD pdwDeviceTypeId)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardGetDeviceTypeIdA, hContext, szReaderName, pdwDeviceTypeId);
 }
 
-WINSCARDAPI LONG WINAPI SCardGetDeviceTypeIdW(SCARDCONTEXT hContext, LPCWSTR szReaderName, LPDWORD pdwDeviceTypeId)
+WINSCARDAPI LONG WINAPI SCardGetDeviceTypeIdW(SCARDCONTEXT hContext, LPCWSTR szReaderName,
+        LPDWORD pdwDeviceTypeId)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardGetDeviceTypeIdW, hContext, szReaderName, pdwDeviceTypeId);
 }
 
 WINSCARDAPI LONG WINAPI SCardGetReaderDeviceInstanceIdA(SCARDCONTEXT hContext,
-		LPCSTR szReaderName, LPSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId)
+        LPCSTR szReaderName, LPSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardGetReaderDeviceInstanceIdA, hContext, szReaderName,
-			szDeviceInstanceId, pcchDeviceInstanceId);
+	                        szDeviceInstanceId, pcchDeviceInstanceId);
 }
 
 WINSCARDAPI LONG WINAPI SCardGetReaderDeviceInstanceIdW(SCARDCONTEXT hContext,
-		LPCWSTR szReaderName, LPWSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId)
+        LPCWSTR szReaderName, LPWSTR szDeviceInstanceId, LPDWORD pcchDeviceInstanceId)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardGetReaderDeviceInstanceIdW, hContext, szReaderName,
-			szDeviceInstanceId, pcchDeviceInstanceId);
+	                        szDeviceInstanceId, pcchDeviceInstanceId);
 }
 
 WINSCARDAPI LONG WINAPI SCardListReadersWithDeviceInstanceIdA(SCARDCONTEXT hContext,
-		LPCSTR szDeviceInstanceId, LPSTR mszReaders, LPDWORD pcchReaders)
+        LPCSTR szDeviceInstanceId, LPSTR mszReaders, LPDWORD pcchReaders)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardListReadersWithDeviceInstanceIdA,
-			hContext, szDeviceInstanceId, mszReaders, pcchReaders);
+	                        hContext, szDeviceInstanceId, mszReaders, pcchReaders);
 }
 
 WINSCARDAPI LONG WINAPI SCardListReadersWithDeviceInstanceIdW(SCARDCONTEXT hContext,
-		LPCWSTR szDeviceInstanceId, LPWSTR mszReaders, LPDWORD pcchReaders)
+        LPCWSTR szDeviceInstanceId, LPWSTR mszReaders, LPDWORD pcchReaders)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardListReadersWithDeviceInstanceIdW,
-			hContext, szDeviceInstanceId, mszReaders, pcchReaders);
+	                        hContext, szDeviceInstanceId, mszReaders, pcchReaders);
 }
 
 WINSCARDAPI LONG WINAPI SCardAudit(SCARDCONTEXT hContext, DWORD dwEvent)
 {
 	SCARDAPI_STUB_CALL_LONG(SCardAudit, hContext, dwEvent);
+}
+
+WINSCARDAPI LONG WINAPI SCardAddReaderName(HANDLE* key, LPSTR readerName)
+{
+	SCARDAPI_STUB_CALL_LONG(SCardAddReaderName, key, readerName);
 }
 
 /**
@@ -507,138 +522,205 @@ WINSCARDAPI const char* WINAPI SCardGetErrorString(LONG errorCode)
 	{
 		case SCARD_S_SUCCESS:
 			return "SCARD_S_SUCCESS";
+
 		case SCARD_F_INTERNAL_ERROR:
 			return "SCARD_F_INTERNAL_ERROR";
+
 		case SCARD_E_CANCELLED:
 			return "SCARD_E_CANCELLED";
+
 		case SCARD_E_INVALID_HANDLE:
 			return "SCARD_E_INVALID_HANDLE";
+
 		case SCARD_E_INVALID_PARAMETER:
 			return "SCARD_E_INVALID_PARAMETER";
+
 		case SCARD_E_INVALID_TARGET:
 			return "SCARD_E_INVALID_TARGET";
+
 		case SCARD_E_NO_MEMORY:
 			return "SCARD_E_NO_MEMORY";
+
 		case SCARD_F_WAITED_TOO_LONG:
 			return "SCARD_F_WAITED_TOO_LONG";
+
 		case SCARD_E_INSUFFICIENT_BUFFER:
 			return "SCARD_E_INSUFFICIENT_BUFFER";
+
 		case SCARD_E_UNKNOWN_READER:
 			return "SCARD_E_UNKNOWN_READER";
+
 		case SCARD_E_TIMEOUT:
 			return "SCARD_E_TIMEOUT";
+
 		case SCARD_E_SHARING_VIOLATION:
 			return "SCARD_E_SHARING_VIOLATION";
+
 		case SCARD_E_NO_SMARTCARD:
 			return "SCARD_E_NO_SMARTCARD";
+
 		case SCARD_E_UNKNOWN_CARD:
 			return "SCARD_E_UNKNOWN_CARD";
+
 		case SCARD_E_CANT_DISPOSE:
 			return "SCARD_E_CANT_DISPOSE";
+
 		case SCARD_E_PROTO_MISMATCH:
 			return "SCARD_E_PROTO_MISMATCH";
+
 		case SCARD_E_NOT_READY:
 			return "SCARD_E_NOT_READY";
+
 		case SCARD_E_INVALID_VALUE:
 			return "SCARD_E_INVALID_VALUE";
+
 		case SCARD_E_SYSTEM_CANCELLED:
 			return "SCARD_E_SYSTEM_CANCELLED";
+
 		case SCARD_F_COMM_ERROR:
 			return "SCARD_F_COMM_ERROR";
+
 		case SCARD_F_UNKNOWN_ERROR:
 			return "SCARD_F_UNKNOWN_ERROR";
+
 		case SCARD_E_INVALID_ATR:
 			return "SCARD_E_INVALID_ATR";
+
 		case SCARD_E_NOT_TRANSACTED:
 			return "SCARD_E_NOT_TRANSACTED";
+
 		case SCARD_E_READER_UNAVAILABLE:
 			return "SCARD_E_READER_UNAVAILABLE";
+
 		case SCARD_P_SHUTDOWN:
 			return "SCARD_P_SHUTDOWN";
+
 		case SCARD_E_PCI_TOO_SMALL:
 			return "SCARD_E_PCI_TOO_SMALL";
+
 		case SCARD_E_READER_UNSUPPORTED:
 			return "SCARD_E_READER_UNSUPPORTED";
+
 		case SCARD_E_DUPLICATE_READER:
 			return "SCARD_E_DUPLICATE_READER";
+
 		case SCARD_E_CARD_UNSUPPORTED:
 			return "SCARD_E_CARD_UNSUPPORTED";
+
 		case SCARD_E_NO_SERVICE:
 			return "SCARD_E_NO_SERVICE";
+
 		case SCARD_E_SERVICE_STOPPED:
 			return "SCARD_E_SERVICE_STOPPED";
+
 		case SCARD_E_UNEXPECTED:
 			return "SCARD_E_UNEXPECTED";
+
 		case SCARD_E_ICC_INSTALLATION:
 			return "SCARD_E_ICC_INSTALLATION";
+
 		case SCARD_E_ICC_CREATEORDER:
 			return "SCARD_E_ICC_CREATEORDER";
+
 		case SCARD_E_UNSUPPORTED_FEATURE:
 			return "SCARD_E_UNSUPPORTED_FEATURE";
+
 		case SCARD_E_DIR_NOT_FOUND:
 			return "SCARD_E_DIR_NOT_FOUND";
+
 		case SCARD_E_FILE_NOT_FOUND:
 			return "SCARD_E_FILE_NOT_FOUND";
+
 		case SCARD_E_NO_DIR:
 			return "SCARD_E_NO_DIR";
+
 		case SCARD_E_NO_FILE:
 			return "SCARD_E_NO_FILE";
+
 		case SCARD_E_NO_ACCESS:
 			return "SCARD_E_NO_ACCESS";
+
 		case SCARD_E_WRITE_TOO_MANY:
 			return "SCARD_E_WRITE_TOO_MANY";
+
 		case SCARD_E_BAD_SEEK:
 			return "SCARD_E_BAD_SEEK";
+
 		case SCARD_E_INVALID_CHV:
 			return "SCARD_E_INVALID_CHV";
+
 		case SCARD_E_UNKNOWN_RES_MNG:
 			return "SCARD_E_UNKNOWN_RES_MNG";
+
 		case SCARD_E_NO_SUCH_CERTIFICATE:
 			return "SCARD_E_NO_SUCH_CERTIFICATE";
+
 		case SCARD_E_CERTIFICATE_UNAVAILABLE:
 			return "SCARD_E_CERTIFICATE_UNAVAILABLE";
+
 		case SCARD_E_NO_READERS_AVAILABLE:
 			return "SCARD_E_NO_READERS_AVAILABLE";
+
 		case SCARD_E_COMM_DATA_LOST:
 			return "SCARD_E_COMM_DATA_LOST";
+
 		case SCARD_E_NO_KEY_CONTAINER:
 			return "SCARD_E_NO_KEY_CONTAINER";
+
 		case SCARD_E_SERVER_TOO_BUSY:
 			return "SCARD_E_SERVER_TOO_BUSY";
+
 		case SCARD_E_PIN_CACHE_EXPIRED:
 			return "SCARD_E_PIN_CACHE_EXPIRED";
+
 		case SCARD_E_NO_PIN_CACHE:
 			return "SCARD_E_NO_PIN_CACHE";
+
 		case SCARD_E_READ_ONLY_CARD:
 			return "SCARD_E_READ_ONLY_CARD";
+
 		case SCARD_W_UNSUPPORTED_CARD:
 			return "SCARD_W_UNSUPPORTED_CARD";
+
 		case SCARD_W_UNRESPONSIVE_CARD:
 			return "SCARD_W_UNRESPONSIVE_CARD";
+
 		case SCARD_W_UNPOWERED_CARD:
 			return "SCARD_W_UNPOWERED_CARD";
+
 		case SCARD_W_RESET_CARD:
 			return "SCARD_W_RESET_CARD";
+
 		case SCARD_W_REMOVED_CARD:
 			return "SCARD_W_REMOVED_CARD";
+
 		case SCARD_W_SECURITY_VIOLATION:
 			return "SCARD_W_SECURITY_VIOLATION";
+
 		case SCARD_W_WRONG_CHV:
 			return "SCARD_W_WRONG_CHV";
+
 		case SCARD_W_CHV_BLOCKED:
 			return "SCARD_W_CHV_BLOCKED";
+
 		case SCARD_W_EOF:
 			return "SCARD_W_EOF";
+
 		case SCARD_W_CANCELLED_BY_USER:
 			return "SCARD_W_CANCELLED_BY_USER";
+
 		case SCARD_W_CARD_NOT_AUTHENTICATED:
 			return "SCARD_W_CARD_NOT_AUTHENTICATED";
+
 		case SCARD_W_CACHE_ITEM_NOT_FOUND:
 			return "SCARD_W_CACHE_ITEM_NOT_FOUND";
+
 		case SCARD_W_CACHE_ITEM_STALE:
 			return "SCARD_W_CACHE_ITEM_STALE";
+
 		case SCARD_W_CACHE_ITEM_TOO_BIG:
 			return "SCARD_W_CACHE_ITEM_TOO_BIG";
+
 		default:
 			return "SCARD_E_UNKNOWN";
 	}
@@ -653,132 +735,175 @@ WINSCARDAPI const char* WINAPI SCardGetAttributeString(DWORD dwAttrId)
 		case SCARD_ATTR_VENDOR_NAME:
 			return "SCARD_ATTR_VENDOR_NAME";
 			break;
+
 		case SCARD_ATTR_VENDOR_IFD_TYPE:
 			return "SCARD_ATTR_VENDOR_IFD_TYPE";
 			break;
+
 		case SCARD_ATTR_VENDOR_IFD_VERSION:
 			return "SCARD_ATTR_VENDOR_IFD_VERSION";
 			break;
+
 		case SCARD_ATTR_VENDOR_IFD_SERIAL_NO:
 			return "SCARD_ATTR_VENDOR_IFD_SERIAL_NO";
 			break;
+
 		case SCARD_ATTR_CHANNEL_ID:
 			return "SCARD_ATTR_CHANNEL_ID";
 			break;
+
 		case SCARD_ATTR_PROTOCOL_TYPES:
 			return "SCARD_ATTR_PROTOCOL_TYPES";
 			break;
+
 		case SCARD_ATTR_DEFAULT_CLK:
 			return "SCARD_ATTR_DEFAULT_CLK";
 			break;
+
 		case SCARD_ATTR_MAX_CLK:
 			return "SCARD_ATTR_MAX_CLK";
 			break;
+
 		case SCARD_ATTR_DEFAULT_DATA_RATE:
 			return "SCARD_ATTR_DEFAULT_DATA_RATE";
 			break;
+
 		case SCARD_ATTR_MAX_DATA_RATE:
 			return "SCARD_ATTR_MAX_DATA_RATE";
 			break;
+
 		case SCARD_ATTR_MAX_IFSD:
 			return "SCARD_ATTR_MAX_IFSD";
 			break;
+
 		case SCARD_ATTR_POWER_MGMT_SUPPORT:
 			return "SCARD_ATTR_POWER_MGMT_SUPPORT";
 			break;
+
 		case SCARD_ATTR_USER_TO_CARD_AUTH_DEVICE:
 			return "SCARD_ATTR_USER_TO_CARD_AUTH_DEVICE";
 			break;
+
 		case SCARD_ATTR_USER_AUTH_INPUT_DEVICE:
 			return "SCARD_ATTR_USER_AUTH_INPUT_DEVICE";
 			break;
+
 		case SCARD_ATTR_CHARACTERISTICS:
 			return "SCARD_ATTR_CHARACTERISTICS";
 			break;
+
 		case SCARD_ATTR_CURRENT_PROTOCOL_TYPE:
 			return "SCARD_ATTR_CURRENT_PROTOCOL_TYPE";
 			break;
+
 		case SCARD_ATTR_CURRENT_CLK:
 			return "SCARD_ATTR_CURRENT_CLK";
 			break;
+
 		case SCARD_ATTR_CURRENT_F:
 			return "SCARD_ATTR_CURRENT_F";
 			break;
+
 		case SCARD_ATTR_CURRENT_D:
 			return "SCARD_ATTR_CURRENT_D";
 			break;
+
 		case SCARD_ATTR_CURRENT_N:
 			return "SCARD_ATTR_CURRENT_N";
 			break;
+
 		case SCARD_ATTR_CURRENT_W:
 			return "SCARD_ATTR_CURRENT_W";
 			break;
+
 		case SCARD_ATTR_CURRENT_IFSC:
 			return "SCARD_ATTR_CURRENT_IFSC";
 			break;
+
 		case SCARD_ATTR_CURRENT_IFSD:
 			return "SCARD_ATTR_CURRENT_IFSD";
 			break;
+
 		case SCARD_ATTR_CURRENT_BWT:
 			return "SCARD_ATTR_CURRENT_BWT";
 			break;
+
 		case SCARD_ATTR_CURRENT_CWT:
 			return "SCARD_ATTR_CURRENT_CWT";
 			break;
+
 		case SCARD_ATTR_CURRENT_EBC_ENCODING:
 			return "SCARD_ATTR_CURRENT_EBC_ENCODING";
 			break;
+
 		case SCARD_ATTR_EXTENDED_BWT:
 			return "SCARD_ATTR_EXTENDED_BWT";
 			break;
+
 		case SCARD_ATTR_ICC_PRESENCE:
 			return "SCARD_ATTR_ICC_PRESENCE";
 			break;
+
 		case SCARD_ATTR_ICC_INTERFACE_STATUS:
 			return "SCARD_ATTR_ICC_INTERFACE_STATUS";
 			break;
+
 		case SCARD_ATTR_CURRENT_IO_STATE:
 			return "SCARD_ATTR_CURRENT_IO_STATE";
 			break;
+
 		case SCARD_ATTR_ATR_STRING:
 			return "SCARD_ATTR_ATR_STRING";
 			break;
+
 		case SCARD_ATTR_ICC_TYPE_PER_ATR:
 			return "SCARD_ATTR_ICC_TYPE_PER_ATR";
 			break;
+
 		case SCARD_ATTR_ESC_RESET:
 			return "SCARD_ATTR_ESC_RESET";
 			break;
+
 		case SCARD_ATTR_ESC_CANCEL:
 			return "SCARD_ATTR_ESC_CANCEL";
 			break;
+
 		case SCARD_ATTR_ESC_AUTHREQUEST:
 			return "SCARD_ATTR_ESC_AUTHREQUEST";
 			break;
+
 		case SCARD_ATTR_MAXINPUT:
 			return "SCARD_ATTR_MAXINPUT";
 			break;
+
 		case SCARD_ATTR_DEVICE_UNIT:
 			return "SCARD_ATTR_DEVICE_UNIT";
 			break;
+
 		case SCARD_ATTR_DEVICE_IN_USE:
 			return "SCARD_ATTR_DEVICE_IN_USE";
 			break;
+
 		case SCARD_ATTR_DEVICE_FRIENDLY_NAME_A:
 			return "SCARD_ATTR_DEVICE_FRIENDLY_NAME_A";
 			break;
+
 		case SCARD_ATTR_DEVICE_SYSTEM_NAME_A:
 			return "SCARD_ATTR_DEVICE_SYSTEM_NAME_A";
 			break;
+
 		case SCARD_ATTR_DEVICE_FRIENDLY_NAME_W:
 			return "SCARD_ATTR_DEVICE_FRIENDLY_NAME_W";
 			break;
+
 		case SCARD_ATTR_DEVICE_SYSTEM_NAME_W:
 			return "SCARD_ATTR_DEVICE_SYSTEM_NAME_W";
 			break;
+
 		case SCARD_ATTR_SUPRESS_T1_IFS_REQUEST:
 			return "SCARD_ATTR_SUPRESS_T1_IFS_REQUEST";
 			break;
+
 		default:
 			return "SCARD_ATTR_UNKNOWN";
 			break;
@@ -826,12 +951,15 @@ WINSCARDAPI const char* WINAPI SCardGetShareModeString(DWORD dwShareMode)
 		case SCARD_SHARE_EXCLUSIVE:
 			return "SCARD_SHARE_EXCLUSIVE";
 			break;
+
 		case SCARD_SHARE_SHARED:
 			return "SCARD_SHARE_SHARED";
 			break;
+
 		case SCARD_SHARE_DIRECT:
 			return "SCARD_SHARE_DIRECT";
 			break;
+
 		default:
 			return "SCARD_SHARE_UNKNOWN";
 			break;
@@ -847,12 +975,15 @@ WINSCARDAPI const char* WINAPI SCardGetDispositionString(DWORD dwDisposition)
 		case SCARD_LEAVE_CARD:
 			return "SCARD_LEAVE_CARD";
 			break;
+
 		case SCARD_RESET_CARD:
 			return "SCARD_RESET_CARD";
 			break;
+
 		case SCARD_UNPOWER_CARD:
 			return "SCARD_UNPOWER_CARD";
 			break;
+
 		default:
 			return "SCARD_UNKNOWN_CARD";
 			break;
@@ -868,12 +999,15 @@ WINSCARDAPI const char* WINAPI SCardGetScopeString(DWORD dwScope)
 		case SCARD_SCOPE_USER:
 			return "SCARD_SCOPE_USER";
 			break;
+
 		case SCARD_SCOPE_TERMINAL:
 			return "SCARD_SCOPE_TERMINAL";
 			break;
+
 		case SCARD_SCOPE_SYSTEM:
 			return "SCARD_SCOPE_SYSTEM";
 			break;
+
 		default:
 			return "SCARD_SCOPE_UNKNOWN";
 			break;
@@ -889,24 +1023,31 @@ WINSCARDAPI const char* WINAPI SCardGetCardStateString(DWORD dwCardState)
 		case SCARD_UNKNOWN:
 			return "SCARD_UNKNOWN";
 			break;
+
 		case SCARD_ABSENT:
 			return "SCARD_ABSENT";
 			break;
+
 		case SCARD_PRESENT:
 			return "SCARD_PRESENT";
 			break;
+
 		case SCARD_SWALLOWED:
 			return "SCARD_SWALLOWED";
 			break;
+
 		case SCARD_POWERED:
 			return "SCARD_POWERED";
 			break;
+
 		case SCARD_NEGOTIABLE:
 			return "SCARD_NEGOTIABLE";
 			break;
+
 		case SCARD_SPECIFIC:
 			return "SCARD_SPECIFIC";
 			break;
+
 		default:
 			return "SCARD_UNKNOWN";
 			break;
@@ -928,66 +1069,87 @@ WINSCARDAPI char* WINAPI SCardGetReaderStateString(DWORD dwReaderState)
 	{
 		if (szReaderState[0])
 			strcat(szReaderState, " | ");
+
 		strcat(szReaderState, "SCARD_STATE_IGNORE");
 	}
+
 	if (dwReaderState & SCARD_STATE_CHANGED)
 	{
 		if (szReaderState[0])
 			strcat(szReaderState, " | ");
+
 		strcat(szReaderState, "SCARD_STATE_CHANGED");
 	}
+
 	if (dwReaderState & SCARD_STATE_UNKNOWN)
 	{
 		if (szReaderState[0])
 			strcat(szReaderState, " | ");
+
 		strcat(szReaderState, "SCARD_STATE_UNKNOWN");
 	}
+
 	if (dwReaderState & SCARD_STATE_UNAVAILABLE)
 	{
 		if (szReaderState[0])
 			strcat(szReaderState, " | ");
+
 		strcat(szReaderState, "SCARD_STATE_UNAVAILABLE");
 	}
+
 	if (dwReaderState & SCARD_STATE_EMPTY)
 	{
 		if (szReaderState[0])
 			strcat(szReaderState, " | ");
+
 		strcat(szReaderState, "SCARD_STATE_EMPTY");
 	}
+
 	if (dwReaderState & SCARD_STATE_PRESENT)
 	{
 		if (szReaderState[0])
 			strcat(szReaderState, " | ");
+
 		strcat(szReaderState, "SCARD_STATE_PRESENT");
 	}
+
 	if (dwReaderState & SCARD_STATE_ATRMATCH)
 	{
 		if (szReaderState[0])
 			strcat(szReaderState, " | ");
+
 		strcat(szReaderState, "SCARD_STATE_ATRMATCH");
 	}
+
 	if (dwReaderState & SCARD_STATE_EXCLUSIVE)
 	{
 		if (szReaderState[0])
 			strcat(szReaderState, " | ");
+
 		strcat(szReaderState, "SCARD_STATE_EXCLUSIVE");
 	}
+
 	if (dwReaderState & SCARD_STATE_INUSE)
 	{
 		if (szReaderState[0])
 			strcat(szReaderState, " | ");
+
 		strcat(szReaderState, "SCARD_STATE_INUSE");
 	}
+
 	if (dwReaderState & SCARD_STATE_MUTE)
 	{
 		if (szReaderState[0])
 			strcat(szReaderState, " | ");
+
 		strcat(szReaderState, "SCARD_STATE_MUTE");
 	}
+
 	if (dwReaderState & SCARD_STATE_UNPOWERED)
 	{
 		if (szReaderState[0])
 			strcat(szReaderState, " | ");
+
 		strcat(szReaderState, "SCARD_STATE_UNPOWERED");
 	}
 
@@ -1000,19 +1162,21 @@ WINSCARDAPI char* WINAPI SCardGetReaderStateString(DWORD dwReaderState)
 void InitializeSCardApiStubs(void)
 {
 	g_Initialized = TRUE;
-
 #ifndef _WIN32
+
 	if (PCSC_InitializeSCardApi() >= 0)
 	{
 		g_SCardApi = PCSC_GetSCardApiFunctionTable();
 	}
+
 #else
+
 	if (WinSCard_InitializeSCardApi() >= 0)
 	{
 		g_SCardApi = WinSCard_GetSCardApiFunctionTable();
 	}
-#endif
 
+#endif
 #ifdef WITH_SMARTCARD_INSPECT
 	g_SCardApi = Inspect_RegisterSCardApi(g_SCardApi);
 #endif

--- a/winpr/libwinpr/smartcard/smartcard_pcsc.c
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.c
@@ -768,27 +768,33 @@ int PCSC_RedirectReader(char* readerName)
 		{
 			if (strcmp(name, "") == 0)
 			{
-				return 0;
+				return 1;
 			}
 
 			if (strncmp(readerName, name, strlen(readerName)) == 0)
 			{
-				return 0;
+				return 1;
 			}
+		}
+		else
+		{
+			return 2;
 		}
 	}
 
-	return -1;
+	return 0;
 }
 
 char* PCSC_ConvertReaderNamesToWinSCard(const char* names, LPDWORD pcchReaders)
 {
+	int ret=0;
 	int length;
 	char* p, *q;
 	DWORD cchReaders;
 	char* nameWinSCard;
 	char* namesWinSCard;
 	BOOL endReaderName = FALSE;
+	BOOL allReaders=FALSE;
 	p = (char*) names;
 	cchReaders = *pcchReaders;
 	namesWinSCard = (char*) malloc(cchReaders * 2);
@@ -807,10 +813,16 @@ char* PCSC_ConvertReaderNamesToWinSCard(const char* names, LPDWORD pcchReaders)
 		{
 			length = strlen(nameWinSCard);
 
-			if (PCSC_RedirectReader(nameWinSCard) == 0)
+			ret = PCSC_RedirectReader(nameWinSCard);
+			if ( ret == 1 )
 			{
 				CopyMemory(q, nameWinSCard, length);
 				endReaderName = TRUE;
+			}
+			else if( ret == 2 )
+			{
+				CopyMemory(q, nameWinSCard, length);
+				allReaders = TRUE;
 			}
 
 			free(nameWinSCard);
@@ -827,6 +839,12 @@ char* PCSC_ConvertReaderNamesToWinSCard(const char* names, LPDWORD pcchReaders)
 			*q = '\0';
 			q++;
 			endReaderName = FALSE;
+		}
+		else if (allReaders)
+		{
+			q += length;
+			*q = '\0';
+			q++;
 		}
 
 		p += strlen(p) + 1;

--- a/winpr/libwinpr/smartcard/smartcard_pcsc.c
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.c
@@ -787,14 +787,14 @@ int PCSC_RedirectReader(char* readerName)
 
 char* PCSC_ConvertReaderNamesToWinSCard(const char* names, LPDWORD pcchReaders)
 {
-	int ret=0;
+	int ret = 0;
 	int length;
 	char* p, *q;
 	DWORD cchReaders;
 	char* nameWinSCard;
 	char* namesWinSCard;
 	BOOL endReaderName = FALSE;
-	BOOL allReaders=FALSE;
+	BOOL allReaders = FALSE;
 	p = (char*) names;
 	cchReaders = *pcchReaders;
 	namesWinSCard = (char*) malloc(cchReaders * 2);
@@ -812,14 +812,14 @@ char* PCSC_ConvertReaderNamesToWinSCard(const char* names, LPDWORD pcchReaders)
 		if (nameWinSCard)
 		{
 			length = strlen(nameWinSCard);
-
 			ret = PCSC_RedirectReader(nameWinSCard);
-			if ( ret == 1 )
+
+			if (ret == 1)
 			{
 				CopyMemory(q, nameWinSCard, length);
 				endReaderName = TRUE;
 			}
-			else if( ret == 2 )
+			else if (ret == 2)
 			{
 				CopyMemory(q, nameWinSCard, length);
 				allReaders = TRUE;

--- a/winpr/libwinpr/smartcard/smartcard_pcsc.h
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.h
@@ -41,15 +41,15 @@
 
 #ifdef __APPLE__
 typedef unsigned int PCSC_DWORD;
-typedef PCSC_DWORD *PCSC_PDWORD, *PCSC_LPDWORD;
+typedef PCSC_DWORD* PCSC_PDWORD, *PCSC_LPDWORD;
 typedef unsigned int PCSC_ULONG;
-typedef PCSC_ULONG *PCSC_PULONG;
+typedef PCSC_ULONG* PCSC_PULONG;
 typedef int PCSC_LONG;
 #else
 typedef unsigned long PCSC_DWORD;
-typedef PCSC_DWORD *PCSC_PDWORD, *PCSC_LPDWORD;
+typedef PCSC_DWORD* PCSC_PDWORD, *PCSC_LPDWORD;
 typedef unsigned long PCSC_ULONG;
-typedef PCSC_ULONG *PCSC_PULONG;
+typedef PCSC_ULONG* PCSC_PULONG;
 typedef long PCSC_LONG;
 #endif
 
@@ -121,37 +121,41 @@ typedef struct
 
 struct _PCSCFunctionTable
 {
-	PCSC_LONG (* pfnSCardEstablishContext)(PCSC_DWORD dwScope,
-			LPCVOID pvReserved1, LPCVOID pvReserved2, LPSCARDCONTEXT phContext);
-	PCSC_LONG (* pfnSCardReleaseContext)(SCARDCONTEXT hContext);
-	PCSC_LONG (* pfnSCardIsValidContext)(SCARDCONTEXT hContext);
-	PCSC_LONG (* pfnSCardConnect)(SCARDCONTEXT hContext,
-			LPCSTR szReader, PCSC_DWORD dwShareMode, PCSC_DWORD dwPreferredProtocols,
-			LPSCARDHANDLE phCard, PCSC_LPDWORD pdwActiveProtocol);
-	PCSC_LONG (* pfnSCardReconnect)(SCARDHANDLE hCard,
-			PCSC_DWORD dwShareMode, PCSC_DWORD dwPreferredProtocols,
-			PCSC_DWORD dwInitialization, PCSC_LPDWORD pdwActiveProtocol);
-	PCSC_LONG (* pfnSCardDisconnect)(SCARDHANDLE hCard, PCSC_DWORD dwDisposition);
-	PCSC_LONG (* pfnSCardBeginTransaction)(SCARDHANDLE hCard);
-	PCSC_LONG (* pfnSCardEndTransaction)(SCARDHANDLE hCard, PCSC_DWORD dwDisposition);
-	PCSC_LONG (* pfnSCardStatus)(SCARDHANDLE hCard,
-			LPSTR mszReaderName, PCSC_LPDWORD pcchReaderLen, PCSC_LPDWORD pdwState,
-			PCSC_LPDWORD pdwProtocol, LPBYTE pbAtr, PCSC_LPDWORD pcbAtrLen);
-	PCSC_LONG (* pfnSCardGetStatusChange)(SCARDCONTEXT hContext,
-			PCSC_DWORD dwTimeout, PCSC_SCARD_READERSTATE* rgReaderStates, PCSC_DWORD cReaders);
-	PCSC_LONG (* pfnSCardControl)(SCARDHANDLE hCard,
-			PCSC_DWORD dwControlCode, LPCVOID pbSendBuffer, PCSC_DWORD cbSendLength,
-			LPVOID pbRecvBuffer, PCSC_DWORD cbRecvLength, PCSC_LPDWORD lpBytesReturned);
-	PCSC_LONG (* pfnSCardTransmit)(SCARDHANDLE hCard,
-			const PCSC_SCARD_IO_REQUEST* pioSendPci, LPCBYTE pbSendBuffer, PCSC_DWORD cbSendLength,
-			PCSC_SCARD_IO_REQUEST* pioRecvPci, LPBYTE pbRecvBuffer, PCSC_LPDWORD pcbRecvLength);
-	PCSC_LONG (* pfnSCardListReaderGroups)(SCARDCONTEXT hContext, LPSTR mszGroups, PCSC_LPDWORD pcchGroups);
-	PCSC_LONG (* pfnSCardListReaders)(SCARDCONTEXT hContext,
-			LPCSTR mszGroups, LPSTR mszReaders, PCSC_LPDWORD pcchReaders);
-	PCSC_LONG (* pfnSCardFreeMemory)(SCARDCONTEXT hContext, LPCVOID pvMem);
-	PCSC_LONG (* pfnSCardCancel)(SCARDCONTEXT hContext);
-	PCSC_LONG (* pfnSCardGetAttrib)(SCARDHANDLE hCard, PCSC_DWORD dwAttrId, LPBYTE pbAttr, PCSC_LPDWORD pcbAttrLen);
-	PCSC_LONG (* pfnSCardSetAttrib)(SCARDHANDLE hCard, PCSC_DWORD dwAttrId, LPCBYTE pbAttr, PCSC_DWORD cbAttrLen);
+	PCSC_LONG(* pfnSCardEstablishContext)(PCSC_DWORD dwScope,
+	                                      LPCVOID pvReserved1, LPCVOID pvReserved2, LPSCARDCONTEXT phContext);
+	PCSC_LONG(* pfnSCardReleaseContext)(SCARDCONTEXT hContext);
+	PCSC_LONG(* pfnSCardIsValidContext)(SCARDCONTEXT hContext);
+	PCSC_LONG(* pfnSCardConnect)(SCARDCONTEXT hContext,
+	                             LPCSTR szReader, PCSC_DWORD dwShareMode, PCSC_DWORD dwPreferredProtocols,
+	                             LPSCARDHANDLE phCard, PCSC_LPDWORD pdwActiveProtocol);
+	PCSC_LONG(* pfnSCardReconnect)(SCARDHANDLE hCard,
+	                               PCSC_DWORD dwShareMode, PCSC_DWORD dwPreferredProtocols,
+	                               PCSC_DWORD dwInitialization, PCSC_LPDWORD pdwActiveProtocol);
+	PCSC_LONG(* pfnSCardDisconnect)(SCARDHANDLE hCard, PCSC_DWORD dwDisposition);
+	PCSC_LONG(* pfnSCardBeginTransaction)(SCARDHANDLE hCard);
+	PCSC_LONG(* pfnSCardEndTransaction)(SCARDHANDLE hCard, PCSC_DWORD dwDisposition);
+	PCSC_LONG(* pfnSCardStatus)(SCARDHANDLE hCard,
+	                            LPSTR mszReaderName, PCSC_LPDWORD pcchReaderLen, PCSC_LPDWORD pdwState,
+	                            PCSC_LPDWORD pdwProtocol, LPBYTE pbAtr, PCSC_LPDWORD pcbAtrLen);
+	PCSC_LONG(* pfnSCardGetStatusChange)(SCARDCONTEXT hContext,
+	                                     PCSC_DWORD dwTimeout, PCSC_SCARD_READERSTATE* rgReaderStates, PCSC_DWORD cReaders);
+	PCSC_LONG(* pfnSCardControl)(SCARDHANDLE hCard,
+	                             PCSC_DWORD dwControlCode, LPCVOID pbSendBuffer, PCSC_DWORD cbSendLength,
+	                             LPVOID pbRecvBuffer, PCSC_DWORD cbRecvLength, PCSC_LPDWORD lpBytesReturned);
+	PCSC_LONG(* pfnSCardTransmit)(SCARDHANDLE hCard,
+	                              const PCSC_SCARD_IO_REQUEST* pioSendPci, LPCBYTE pbSendBuffer, PCSC_DWORD cbSendLength,
+	                              PCSC_SCARD_IO_REQUEST* pioRecvPci, LPBYTE pbRecvBuffer, PCSC_LPDWORD pcbRecvLength);
+	PCSC_LONG(* pfnSCardListReaderGroups)(SCARDCONTEXT hContext, LPSTR mszGroups,
+	                                      PCSC_LPDWORD pcchGroups);
+	PCSC_LONG(* pfnSCardListReaders)(SCARDCONTEXT hContext,
+	                                 LPCSTR mszGroups, LPSTR mszReaders, PCSC_LPDWORD pcchReaders);
+	PCSC_LONG(* pfnSCardFreeMemory)(SCARDCONTEXT hContext, LPCVOID pvMem);
+	PCSC_LONG(* pfnSCardCancel)(SCARDCONTEXT hContext);
+	PCSC_LONG(* pfnSCardGetAttrib)(SCARDHANDLE hCard, PCSC_DWORD dwAttrId, LPBYTE pbAttr,
+	                               PCSC_LPDWORD pcbAttrLen);
+	PCSC_LONG(* pfnSCardSetAttrib)(SCARDHANDLE hCard, PCSC_DWORD dwAttrId, LPCBYTE pbAttr,
+	                               PCSC_DWORD cbAttrLen);
+	PCSC_LONG(* pfnSCardAddReaderName)(HANDLE* key, LPSTR readerName);
 };
 typedef struct _PCSCFunctionTable PCSCFunctionTable;
 

--- a/winpr/libwinpr/smartcard/smartcard_winscard.c
+++ b/winpr/libwinpr/smartcard/smartcard_winscard.c
@@ -111,7 +111,8 @@ SCardApiFunctionTable WinSCard_SCardApiFunctionTable =
 	NULL, /* SCardGetReaderDeviceInstanceIdW */
 	NULL, /* SCardListReadersWithDeviceInstanceIdA */
 	NULL, /* SCardListReadersWithDeviceInstanceIdW */
-	NULL /* SCardAudit */
+	NULL, /* SCardAudit */
+	NULL /* SCardAddReaderName */
 };
 
 PSCardApiFunctionTable WinSCard_GetSCardApiFunctionTable(void)
@@ -202,7 +203,6 @@ int WinSCard_InitializeSCardApi(void)
 	WINSCARD_LOAD_PROC(SCardListReadersWithDeviceInstanceIdA);
 	WINSCARD_LOAD_PROC(SCardListReadersWithDeviceInstanceIdW);
 	WINSCARD_LOAD_PROC(SCardAudit);
-
 	return 1;
 }
 


### PR DESCRIPTION
Rebased pull-request #3416 : redirect specific smartcard readers.

Until now, /smartcard: had the behaviour to redirect every connected readers. It didn't matter what you used after the parameter /smartcard:xxxx:yyyy.

With this patch you can:

use `/smartcard:` "as is" (without argument) to continue to redirect every readers
use `/smartcard:"Reader name"` (you have to repeat that for every reader you want to redirect)

The reader name is exactly the one returned by libpcsclite, e.g.

    root@host:# opensc-tool -l
    Detected readers (pcsc)

    Nr. Card Features Name
    0 Yes Xiring Leo V2 (12547854125036) 00 00
    1 Yes Xiring Leo V2 (52412506854712) 01 00
