### PR TITLE
Use a preallocated logger instance for GFX

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -110,7 +110,7 @@ static UINT rdpgfx_send_caps_advertise_pdu(RDPGFX_CHANNEL_CALLBACK* callback)
 
 	header.pduLength = RDPGFX_HEADER_SIZE + 2 + (pdu.capsSetCount *
 	                   RDPGFX_CAPSET_SIZE);
-	WLog_DBG(TAG, "SendCapsAdvertisePdu %"PRIu16"", pdu.capsSetCount);
+	WLog_Print(gfx->log, WLOG_DEBUG, "SendCapsAdvertisePdu %"PRIu16"", pdu.capsSetCount);
 	s = Stream_New(NULL, header.pduLength);
 
 	if (!s)
@@ -121,7 +121,7 @@ static UINT rdpgfx_send_caps_advertise_pdu(RDPGFX_CHANNEL_CALLBACK* callback)
 
 	if ((error = rdpgfx_write_header(s, &header)))
 	{
-		WLog_ERR(TAG, "rdpgfx_write_header failed with error %"PRIu32"!", error);
+		WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_write_header failed with error %"PRIu32"!", error);
 		return error;
 	}
 
@@ -154,6 +154,8 @@ static UINT rdpgfx_recv_caps_confirm_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 	RDPGFX_CAPSET capsSet;
 	UINT32 capsDataLength;
 	RDPGFX_CAPS_CONFIRM_PDU pdu;
+	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*) callback->plugin;
+
 	pdu.capsSet = &capsSet;
 
 	if (Stream_GetRemainingLength(s) < 12)
@@ -165,7 +167,7 @@ static UINT rdpgfx_recv_caps_confirm_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 	Stream_Read_UINT32(s, capsSet.version); /* version (4 bytes) */
 	Stream_Read_UINT32(s, capsDataLength); /* capsDataLength (4 bytes) */
 	Stream_Read_UINT32(s, capsSet.flags); /* capsData (4 bytes) */
-	WLog_DBG(TAG, "RecvCapsConfirmPdu: version: 0x%08"PRIX32" flags: 0x%08"PRIX32"",
+	WLog_Print(gfx->log, WLOG_DEBUG, "RecvCapsConfirmPdu: version: 0x%08"PRIX32" flags: 0x%08"PRIX32"",
 	         capsSet.version, capsSet.flags);
 	return CHANNEL_RC_OK;
 }
@@ -181,10 +183,12 @@ static UINT rdpgfx_send_frame_acknowledge_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 	UINT error;
 	wStream* s;
 	RDPGFX_HEADER header;
+	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*) callback->plugin;
+
 	header.flags = 0;
 	header.cmdId = RDPGFX_CMDID_FRAMEACKNOWLEDGE;
 	header.pduLength = RDPGFX_HEADER_SIZE + 12;
-	WLog_DBG(TAG, "SendFrameAcknowledgePdu: %"PRIu32"", pdu->frameId);
+	WLog_Print(gfx->log, WLOG_DEBUG, "SendFrameAcknowledgePdu: %"PRIu32"", pdu->frameId);
 	s = Stream_New(NULL, header.pduLength);
 
 	if (!s)
@@ -228,7 +232,7 @@ static UINT rdpgfx_recv_reset_graphics_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < 12)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -238,7 +242,7 @@ static UINT rdpgfx_recv_reset_graphics_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < (pdu.monitorCount * 20))
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -247,7 +251,7 @@ static UINT rdpgfx_recv_reset_graphics_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (!pdu.monitorDefArray)
 	{
-		WLog_ERR(TAG, "calloc failed!");
+		WLog_Print(gfx->log, WLOG_ERROR, "calloc failed!");
 		return CHANNEL_RC_NO_MEMORY;
 	}
 
@@ -265,19 +269,19 @@ static UINT rdpgfx_recv_reset_graphics_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < (size_t) pad)
 	{
-		WLog_ERR(TAG, "Stream_GetRemainingLength failed!");
+		WLog_Print(gfx->log, WLOG_ERROR, "Stream_GetRemainingLength failed!");
 		free(pdu.monitorDefArray);
 		return CHANNEL_RC_NO_MEMORY;
 	}
 
 	Stream_Seek(s, pad); /* pad (total size is 340 bytes) */
-	WLog_DBG(TAG, "RecvResetGraphicsPdu: width: %"PRIu32" height: %"PRIu32" count: %"PRIu32"",
+	WLog_Print(gfx->log, WLOG_DEBUG, "RecvResetGraphicsPdu: width: %"PRIu32" height: %"PRIu32" count: %"PRIu32"",
 	         pdu.width, pdu.height, pdu.monitorCount);
 
 	for (index = 0; index < pdu.monitorCount; index++)
 	{
 		monitor = &(pdu.monitorDefArray[index]);
-		WLog_DBG(TAG,
+		WLog_Print(gfx->log, WLOG_DEBUG,
 		         "RecvResetGraphicsPdu: monitor left:%"PRIi32" top:%"PRIi32" right:%"PRIi32" left:%"PRIi32" flags:0x%"PRIx32"",
 		         monitor->left, monitor->top, monitor->right, monitor->bottom, monitor->flags);
 	}
@@ -287,7 +291,7 @@ static UINT rdpgfx_recv_reset_graphics_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 		IFCALLRET(context->ResetGraphics, error, context, &pdu);
 
 		if (error)
-			WLog_ERR(TAG, "context->ResetGraphics failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "context->ResetGraphics failed with error %"PRIu32"", error);
 	}
 
 	free(pdu.monitorDefArray);
@@ -309,19 +313,19 @@ static UINT rdpgfx_recv_evict_cache_entry_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < 2)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
 	Stream_Read_UINT16(s, pdu.cacheSlot); /* cacheSlot (2 bytes) */
-	WLog_DBG(TAG, "RecvEvictCacheEntryPdu: cacheSlot: %"PRIu16"", pdu.cacheSlot);
+	WLog_Print(gfx->log, WLOG_DEBUG, "RecvEvictCacheEntryPdu: cacheSlot: %"PRIu16"", pdu.cacheSlot);
 
 	if (context)
 	{
 		IFCALLRET(context->EvictCacheEntry, error, context, &pdu);
 
 		if (error)
-			WLog_ERR(TAG, "context->EvictCacheEntry failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "context->EvictCacheEntry failed with error %"PRIu32"", error);
 	}
 
 	return error;
@@ -343,7 +347,7 @@ static UINT rdpgfx_recv_cache_import_reply_pdu(RDPGFX_CHANNEL_CALLBACK* callback
 
 	if (Stream_GetRemainingLength(s) < 2)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -351,7 +355,7 @@ static UINT rdpgfx_recv_cache_import_reply_pdu(RDPGFX_CHANNEL_CALLBACK* callback
 
 	if (Stream_GetRemainingLength(s) < (size_t)(pdu.importedEntriesCount * 2))
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -359,7 +363,7 @@ static UINT rdpgfx_recv_cache_import_reply_pdu(RDPGFX_CHANNEL_CALLBACK* callback
 
 	if (!pdu.cacheSlots)
 	{
-		WLog_ERR(TAG, "calloc failed!");
+		WLog_Print(gfx->log, WLOG_ERROR, "calloc failed!");
 		return CHANNEL_RC_NO_MEMORY;
 	}
 
@@ -368,7 +372,7 @@ static UINT rdpgfx_recv_cache_import_reply_pdu(RDPGFX_CHANNEL_CALLBACK* callback
 		Stream_Read_UINT16(s, pdu.cacheSlots[index]); /* cacheSlot (2 bytes) */
 	}
 
-	WLog_DBG(TAG, "RecvCacheImportReplyPdu: importedEntriesCount: %"PRIu16"",
+	WLog_Print(gfx->log, WLOG_DEBUG, "RecvCacheImportReplyPdu: importedEntriesCount: %"PRIu16"",
 	         pdu.importedEntriesCount);
 
 	if (context)
@@ -376,7 +380,7 @@ static UINT rdpgfx_recv_cache_import_reply_pdu(RDPGFX_CHANNEL_CALLBACK* callback
 		IFCALLRET(context->CacheImportReply, error, context, &pdu);
 
 		if (error)
-			WLog_ERR(TAG, "context->CacheImportReply failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "context->CacheImportReply failed with error %"PRIu32"", error);
 	}
 
 	free(pdu.cacheSlots);
@@ -398,7 +402,7 @@ static UINT rdpgfx_recv_create_surface_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < 7)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -406,7 +410,7 @@ static UINT rdpgfx_recv_create_surface_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 	Stream_Read_UINT16(s, pdu.width); /* width (2 bytes) */
 	Stream_Read_UINT16(s, pdu.height); /* height (2 bytes) */
 	Stream_Read_UINT8(s, pdu.pixelFormat); /* RDPGFX_PIXELFORMAT (1 byte) */
-	WLog_DBG(TAG,
+	WLog_Print(gfx->log, WLOG_DEBUG,
 	         "RecvCreateSurfacePdu: surfaceId: %"PRIu16" width: %"PRIu16" height: %"PRIu16" pixelFormat: 0x%02"PRIX8"",
 	         pdu.surfaceId, pdu.width, pdu.height, pdu.pixelFormat);
 
@@ -415,7 +419,7 @@ static UINT rdpgfx_recv_create_surface_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 		IFCALLRET(context->CreateSurface, error, context, &pdu);
 
 		if (error)
-			WLog_ERR(TAG, "context->CreateSurface failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "context->CreateSurface failed with error %"PRIu32"", error);
 	}
 
 	return error;
@@ -436,19 +440,19 @@ static UINT rdpgfx_recv_delete_surface_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < 2)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
 	Stream_Read_UINT16(s, pdu.surfaceId); /* surfaceId (2 bytes) */
-	WLog_DBG(TAG, "RecvDeleteSurfacePdu: surfaceId: %"PRIu16"", pdu.surfaceId);
+	WLog_Print(gfx->log, WLOG_DEBUG, "RecvDeleteSurfacePdu: surfaceId: %"PRIu16"", pdu.surfaceId);
 
 	if (context)
 	{
 		IFCALLRET(context->DeleteSurface, error, context, &pdu);
 
 		if (error)
-			WLog_ERR(TAG, "context->DeleteSurface failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "context->DeleteSurface failed with error %"PRIu32"", error);
 	}
 
 	return error;
@@ -469,13 +473,13 @@ static UINT rdpgfx_recv_start_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < RDPGFX_START_FRAME_PDU_SIZE)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
 	Stream_Read_UINT32(s, pdu.timestamp); /* timestamp (4 bytes) */
 	Stream_Read_UINT32(s, pdu.frameId); /* frameId (4 bytes) */
-	WLog_DBG(TAG, "RecvStartFramePdu: frameId: %"PRIu32" timestamp: 0x%08"PRIX32"",
+	WLog_Print(gfx->log, WLOG_DEBUG, "RecvStartFramePdu: frameId: %"PRIu32" timestamp: 0x%08"PRIX32"",
 	         pdu.frameId, pdu.timestamp);
 
 	if (context)
@@ -483,7 +487,7 @@ static UINT rdpgfx_recv_start_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 		IFCALLRET(context->StartFrame, error, context, &pdu);
 
 		if (error)
-			WLog_ERR(TAG, "context->StartFrame failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "context->StartFrame failed with error %"PRIu32"", error);
 	}
 
 	gfx->UnacknowledgedFrames++;
@@ -506,12 +510,12 @@ static UINT rdpgfx_recv_end_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < RDPGFX_END_FRAME_PDU_SIZE)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
 	Stream_Read_UINT32(s, pdu.frameId); /* frameId (4 bytes) */
-	WLog_DBG(TAG, "RecvEndFramePdu: frameId: %"PRIu32"", pdu.frameId);
+	WLog_Print(gfx->log, WLOG_DEBUG, "RecvEndFramePdu: frameId: %"PRIu32"", pdu.frameId);
 
 	if (context)
 	{
@@ -519,7 +523,7 @@ static UINT rdpgfx_recv_end_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 		if (error)
 		{
-			WLog_ERR(TAG, "context->EndFrame failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "context->EndFrame failed with error %"PRIu32"", error);
 			return error;
 		}
 	}
@@ -535,14 +539,14 @@ static UINT rdpgfx_recv_end_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 		if (gfx->TotalDecodedFrames == 1)
 			if ((error = rdpgfx_send_frame_acknowledge_pdu(callback, &ack)))
-				WLog_ERR(TAG, "rdpgfx_send_frame_acknowledge_pdu failed with error %"PRIu32"", error);
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_send_frame_acknowledge_pdu failed with error %"PRIu32"", error);
 	}
 	else
 	{
 		ack.queueDepth = QUEUE_DEPTH_UNAVAILABLE;
 
 		if ((error = rdpgfx_send_frame_acknowledge_pdu(callback, &ack)))
-			WLog_DBG(TAG, "rdpgfx_send_frame_acknowledge_pdu failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_DEBUG, "rdpgfx_send_frame_acknowledge_pdu failed with error %"PRIu32"", error);
 	}
 
 	return error;
@@ -563,7 +567,7 @@ static UINT rdpgfx_recv_wire_to_surface_1_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < RDPGFX_WIRE_TO_SURFACE_PDU_1_SIZE)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -573,7 +577,7 @@ static UINT rdpgfx_recv_wire_to_surface_1_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if ((error = rdpgfx_read_rect16(s, &(pdu.destRect)))) /* destRect (8 bytes) */
 	{
-		WLog_ERR(TAG, "rdpgfx_read_rect16 failed with error %"PRIu32"", error);
+		WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_read_rect16 failed with error %"PRIu32"", error);
 		return error;
 	}
 
@@ -581,13 +585,13 @@ static UINT rdpgfx_recv_wire_to_surface_1_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (pdu.bitmapDataLength > Stream_GetRemainingLength(s))
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
 	pdu.bitmapData = Stream_Pointer(s);
 	Stream_Seek(s, pdu.bitmapDataLength);
-	WLog_DBG(TAG,
+	WLog_Print(gfx->log, WLOG_DEBUG,
 	         "RecvWireToSurface1Pdu: surfaceId: %"PRIu16" codecId: %s (0x%04"PRIX16") pixelFormat: 0x%02"PRIX8" "
 	         "destRect: left: %"PRIu16" top: %"PRIu16" right: %"PRIu16" bottom: %"PRIu16" bitmapDataLength: %"PRIu32"",
 	         pdu.surfaceId, rdpgfx_get_codec_id_string(pdu.codecId),
@@ -624,7 +628,7 @@ static UINT rdpgfx_recv_wire_to_surface_1_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 	cmd.extra = NULL;
 
 	if ((error = rdpgfx_decode(gfx, &cmd)))
-		WLog_ERR(TAG, "rdpgfx_decode failed with error %"PRIu32"!", error);
+		WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_decode failed with error %"PRIu32"!", error);
 
 	return error;
 }
@@ -645,7 +649,7 @@ static UINT rdpgfx_recv_wire_to_surface_2_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < RDPGFX_WIRE_TO_SURFACE_PDU_2_SIZE)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -656,7 +660,7 @@ static UINT rdpgfx_recv_wire_to_surface_2_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 	Stream_Read_UINT32(s, pdu.bitmapDataLength); /* bitmapDataLength (4 bytes) */
 	pdu.bitmapData = Stream_Pointer(s);
 	Stream_Seek(s, pdu.bitmapDataLength);
-	WLog_DBG(TAG, "RecvWireToSurface2Pdu: surfaceId: %"PRIu16" codecId: %s (0x%04"PRIX16") "
+	WLog_Print(gfx->log, WLOG_DEBUG, "RecvWireToSurface2Pdu: surfaceId: %"PRIu16" codecId: %s (0x%04"PRIX16") "
 	         "codecContextId: %"PRIu32" pixelFormat: 0x%02"PRIX8" bitmapDataLength: %"PRIu32"",
 	         pdu.surfaceId, rdpgfx_get_codec_id_string(pdu.codecId), pdu.codecId,
 	         pdu.codecContextId, pdu.pixelFormat, pdu.bitmapDataLength);
@@ -679,7 +683,7 @@ static UINT rdpgfx_recv_wire_to_surface_2_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 		IFCALLRET(context->SurfaceCommand, error, context, &cmd);
 
 		if (error)
-			WLog_ERR(TAG, "context->SurfaceCommand failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "context->SurfaceCommand failed with error %"PRIu32"", error);
 	}
 
 	return error;
@@ -700,13 +704,13 @@ static UINT rdpgfx_recv_delete_encoding_context_pdu(RDPGFX_CHANNEL_CALLBACK*
 
 	if (Stream_GetRemainingLength(s) < 6)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
 	Stream_Read_UINT16(s, pdu.surfaceId); /* surfaceId (2 bytes) */
 	Stream_Read_UINT32(s, pdu.codecContextId); /* codecContextId (4 bytes) */
-	WLog_DBG(TAG, "RecvDeleteEncodingContextPdu: surfaceId: %"PRIu16" codecContextId: %"PRIu32"",
+	WLog_Print(gfx->log, WLOG_DEBUG, "RecvDeleteEncodingContextPdu: surfaceId: %"PRIu16" codecContextId: %"PRIu32"",
 	         pdu.surfaceId, pdu.codecContextId);
 
 	if (context)
@@ -714,7 +718,7 @@ static UINT rdpgfx_recv_delete_encoding_context_pdu(RDPGFX_CHANNEL_CALLBACK*
 		IFCALLRET(context->DeleteEncodingContext, error, context, &pdu);
 
 		if (error)
-			WLog_ERR(TAG, "context->DeleteEncodingContext failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "context->DeleteEncodingContext failed with error %"PRIu32"", error);
 	}
 
 	return error;
@@ -736,7 +740,7 @@ static UINT rdpgfx_recv_solid_fill_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStrea
 
 	if (Stream_GetRemainingLength(s) < 8)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -745,7 +749,7 @@ static UINT rdpgfx_recv_solid_fill_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStrea
 	if ((error = rdpgfx_read_color32(s,
 	                                 &(pdu.fillPixel)))) /* fillPixel (4 bytes) */
 	{
-		WLog_ERR(TAG, "rdpgfx_read_color32 failed with error %"PRIu32"!", error);
+		WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_read_color32 failed with error %"PRIu32"!", error);
 		return error;
 	}
 
@@ -753,7 +757,7 @@ static UINT rdpgfx_recv_solid_fill_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStrea
 
 	if (Stream_GetRemainingLength(s) < (size_t)(pdu.fillRectCount * 8))
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -761,7 +765,7 @@ static UINT rdpgfx_recv_solid_fill_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStrea
 
 	if (!pdu.fillRects)
 	{
-		WLog_ERR(TAG, "calloc failed!");
+		WLog_Print(gfx->log, WLOG_ERROR, "calloc failed!");
 		return CHANNEL_RC_NO_MEMORY;
 	}
 
@@ -771,13 +775,13 @@ static UINT rdpgfx_recv_solid_fill_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStrea
 
 		if ((error = rdpgfx_read_rect16(s, fillRect)))
 		{
-			WLog_ERR(TAG, "rdpgfx_read_rect16 failed with error %"PRIu32"!", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_read_rect16 failed with error %"PRIu32"!", error);
 			free(pdu.fillRects);
 			return error;
 		}
 	}
 
-	WLog_DBG(TAG, "RecvSolidFillPdu: surfaceId: %"PRIu16" fillRectCount: %"PRIu16"",
+	WLog_Print(gfx->log, WLOG_DEBUG, "RecvSolidFillPdu: surfaceId: %"PRIu16" fillRectCount: %"PRIu16"",
 	         pdu.surfaceId, pdu.fillRectCount);
 
 	if (context)
@@ -785,7 +789,7 @@ static UINT rdpgfx_recv_solid_fill_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStrea
 		IFCALLRET(context->SolidFill, error, context, &pdu);
 
 		if (error)
-			WLog_ERR(TAG, "context->SolidFill failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "context->SolidFill failed with error %"PRIu32"", error);
 	}
 
 	free(pdu.fillRects);
@@ -809,7 +813,7 @@ static UINT rdpgfx_recv_surface_to_surface_pdu(RDPGFX_CHANNEL_CALLBACK*
 
 	if (Stream_GetRemainingLength(s) < 14)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -818,7 +822,7 @@ static UINT rdpgfx_recv_surface_to_surface_pdu(RDPGFX_CHANNEL_CALLBACK*
 
 	if ((error = rdpgfx_read_rect16(s, &(pdu.rectSrc)))) /* rectSrc (8 bytes ) */
 	{
-		WLog_ERR(TAG, "rdpgfx_read_rect16 failed with error %"PRIu32"!", error);
+		WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_read_rect16 failed with error %"PRIu32"!", error);
 		return error;
 	}
 
@@ -826,7 +830,7 @@ static UINT rdpgfx_recv_surface_to_surface_pdu(RDPGFX_CHANNEL_CALLBACK*
 
 	if (Stream_GetRemainingLength(s) < (size_t)(pdu.destPtsCount * 4))
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -835,7 +839,7 @@ static UINT rdpgfx_recv_surface_to_surface_pdu(RDPGFX_CHANNEL_CALLBACK*
 
 	if (!pdu.destPts)
 	{
-		WLog_ERR(TAG, "calloc failed!");
+		WLog_Print(gfx->log, WLOG_ERROR, "calloc failed!");
 		return CHANNEL_RC_NO_MEMORY;
 	}
 
@@ -845,13 +849,13 @@ static UINT rdpgfx_recv_surface_to_surface_pdu(RDPGFX_CHANNEL_CALLBACK*
 
 		if ((error = rdpgfx_read_point16(s, destPt)))
 		{
-			WLog_ERR(TAG, "rdpgfx_read_point16 failed with error %"PRIu32"!", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_read_point16 failed with error %"PRIu32"!", error);
 			free(pdu.destPts);
 			return error;
 		}
 	}
 
-	WLog_DBG(TAG, "RecvSurfaceToSurfacePdu: surfaceIdSrc: %"PRIu16" surfaceIdDest: %"PRIu16" "
+	WLog_Print(gfx->log, WLOG_DEBUG, "RecvSurfaceToSurfacePdu: surfaceIdSrc: %"PRIu16" surfaceIdDest: %"PRIu16" "
 	         "left: %"PRIu16" top: %"PRIu16" right: %"PRIu16" bottom: %"PRIu16" destPtsCount: %"PRIu16"",
 	         pdu.surfaceIdSrc, pdu.surfaceIdDest,
 	         pdu.rectSrc.left, pdu.rectSrc.top, pdu.rectSrc.right, pdu.rectSrc.bottom,
@@ -862,7 +866,7 @@ static UINT rdpgfx_recv_surface_to_surface_pdu(RDPGFX_CHANNEL_CALLBACK*
 		IFCALLRET(context->SurfaceToSurface, error, context, &pdu);
 
 		if (error)
-			WLog_ERR(TAG, "context->SurfaceToSurface failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "context->SurfaceToSurface failed with error %"PRIu32"", error);
 	}
 
 	free(pdu.destPts);
@@ -884,7 +888,7 @@ static UINT rdpgfx_recv_surface_to_cache_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < 20)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -894,11 +898,11 @@ static UINT rdpgfx_recv_surface_to_cache_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if ((error = rdpgfx_read_rect16(s, &(pdu.rectSrc)))) /* rectSrc (8 bytes ) */
 	{
-		WLog_ERR(TAG, "rdpgfx_read_rect16 failed with error %"PRIu32"!", error);
+		WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_read_rect16 failed with error %"PRIu32"!", error);
 		return error;
 	}
 
-	WLog_DBG(TAG,
+	WLog_Print(gfx->log, WLOG_DEBUG,
 	         "RecvSurfaceToCachePdu: surfaceId: %"PRIu16" cacheKey: 0x%016"PRIX64" cacheSlot: %"PRIu16" "
 	         "left: %"PRIu16" top: %"PRIu16" right: %"PRIu16" bottom: %"PRIu16"",
 	         pdu.surfaceId, pdu.cacheKey, pdu.cacheSlot,
@@ -910,7 +914,7 @@ static UINT rdpgfx_recv_surface_to_cache_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 		IFCALLRET(context->SurfaceToCache, error, context, &pdu);
 
 		if (error)
-			WLog_ERR(TAG, "context->SurfaceToCache failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "context->SurfaceToCache failed with error %"PRIu32"", error);
 	}
 
 	return error;
@@ -933,7 +937,7 @@ static UINT rdpgfx_recv_cache_to_surface_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < 6)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -943,7 +947,7 @@ static UINT rdpgfx_recv_cache_to_surface_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (Stream_GetRemainingLength(s) < (size_t)(pdu.destPtsCount * 4))
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -952,7 +956,7 @@ static UINT rdpgfx_recv_cache_to_surface_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 	if (!pdu.destPts)
 	{
-		WLog_ERR(TAG, "calloc failed!");
+		WLog_Print(gfx->log, WLOG_ERROR, "calloc failed!");
 		return CHANNEL_RC_NO_MEMORY;
 	}
 
@@ -962,13 +966,13 @@ static UINT rdpgfx_recv_cache_to_surface_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 
 		if ((error = rdpgfx_read_point16(s, destPt)))
 		{
-			WLog_ERR(TAG, "rdpgfx_read_point16 failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_read_point16 failed with error %"PRIu32"", error);
 			free(pdu.destPts);
 			return error;
 		}
 	}
 
-	WLog_DBG(TAG,
+	WLog_Print(gfx->log, WLOG_DEBUG,
 	         "RdpGfxRecvCacheToSurfacePdu: cacheSlot: %"PRIu16" surfaceId: %"PRIu16" destPtsCount: %"PRIu16"",
 	         pdu.cacheSlot, pdu.surfaceId, pdu.destPtsCount);
 
@@ -977,7 +981,7 @@ static UINT rdpgfx_recv_cache_to_surface_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 		IFCALLRET(context->CacheToSurface, error, context, &pdu);
 
 		if (error)
-			WLog_ERR(TAG, "context->CacheToSurface failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "context->CacheToSurface failed with error %"PRIu32"", error);
 	}
 
 	free(pdu.destPts);
@@ -999,7 +1003,7 @@ static UINT rdpgfx_recv_map_surface_to_output_pdu(RDPGFX_CHANNEL_CALLBACK*
 
 	if (Stream_GetRemainingLength(s) < 12)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -1007,7 +1011,7 @@ static UINT rdpgfx_recv_map_surface_to_output_pdu(RDPGFX_CHANNEL_CALLBACK*
 	Stream_Read_UINT16(s, pdu.reserved); /* reserved (2 bytes) */
 	Stream_Read_UINT32(s, pdu.outputOriginX); /* outputOriginX (4 bytes) */
 	Stream_Read_UINT32(s, pdu.outputOriginY); /* outputOriginY (4 bytes) */
-	WLog_DBG(TAG,
+	WLog_Print(gfx->log, WLOG_DEBUG,
 	         "RecvMapSurfaceToOutputPdu: surfaceId: %"PRIu16" outputOriginX: %"PRIu32" outputOriginY: %"PRIu32"",
 	         pdu.surfaceId, pdu.outputOriginX, pdu.outputOriginY);
 
@@ -1016,7 +1020,7 @@ static UINT rdpgfx_recv_map_surface_to_output_pdu(RDPGFX_CHANNEL_CALLBACK*
 		IFCALLRET(context->MapSurfaceToOutput, error, context, &pdu);
 
 		if (error)
-			WLog_ERR(TAG, "context->MapSurfaceToOutput failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "context->MapSurfaceToOutput failed with error %"PRIu32"", error);
 	}
 
 	return error;
@@ -1037,7 +1041,7 @@ static UINT rdpgfx_recv_map_surface_to_window_pdu(RDPGFX_CHANNEL_CALLBACK* callb
 
 	if (Stream_GetRemainingLength(s) < 18)
 	{
-		WLog_ERR(TAG, "not enough data!");
+		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -1045,7 +1049,7 @@ static UINT rdpgfx_recv_map_surface_to_window_pdu(RDPGFX_CHANNEL_CALLBACK* callb
 	Stream_Read_UINT64(s, pdu.windowId); /* windowId (8 bytes) */
 	Stream_Read_UINT32(s, pdu.mappedWidth); /* mappedWidth (4 bytes) */
 	Stream_Read_UINT32(s, pdu.mappedHeight); /* mappedHeight (4 bytes) */
-	WLog_DBG(TAG,
+	WLog_Print(gfx->log, WLOG_DEBUG,
 	         "RecvMapSurfaceToWindowPdu: surfaceId: %"PRIu16" windowId: 0x%016"PRIX64" mappedWidth: %"PRIu32" mappedHeight: %"PRIu32"",
 	         pdu.surfaceId, pdu.windowId, pdu.mappedWidth, pdu.mappedHeight);
 
@@ -1054,7 +1058,7 @@ static UINT rdpgfx_recv_map_surface_to_window_pdu(RDPGFX_CHANNEL_CALLBACK* callb
 		IFCALLRET(context->MapSurfaceToWindow, error, context, &pdu);
 
 		if (error)
-			WLog_ERR(TAG, "context->MapSurfaceToWindow failed with error %"PRIu32"", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "context->MapSurfaceToWindow failed with error %"PRIu32"", error);
 	}
 
 	return error;
@@ -1070,16 +1074,18 @@ static UINT rdpgfx_recv_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStream* s)
 	int beg, end;
 	RDPGFX_HEADER header;
 	UINT error;
+	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*) callback->plugin;
+
 	beg = Stream_GetPosition(s);
 
 	if ((error = rdpgfx_read_header(s, &header)))
 	{
-		WLog_ERR(TAG, "rdpgfx_read_header failed with error %"PRIu32"!", error);
+		WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_read_header failed with error %"PRIu32"!", error);
 		return error;
 	}
 
 #if 1
-	WLog_DBG(TAG, "cmdId: %s (0x%04"PRIX16") flags: 0x%04"PRIX16" pduLength: %"PRIu32"",
+	WLog_Print(gfx->log, WLOG_DEBUG, "cmdId: %s (0x%04"PRIX16") flags: 0x%04"PRIX16" pduLength: %"PRIu32"",
 	         rdpgfx_get_cmd_id_string(header.cmdId), header.cmdId, header.flags,
 	         header.pduLength);
 #endif
@@ -1088,110 +1094,110 @@ static UINT rdpgfx_recv_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStream* s)
 	{
 		case RDPGFX_CMDID_WIRETOSURFACE_1:
 			if ((error = rdpgfx_recv_wire_to_surface_1_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_wire_to_surface_1_pdu failed with error %"PRIu32"!",
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_wire_to_surface_1_pdu failed with error %"PRIu32"!",
 				         error);
 
 			break;
 
 		case RDPGFX_CMDID_WIRETOSURFACE_2:
 			if ((error = rdpgfx_recv_wire_to_surface_2_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_wire_to_surface_2_pdu failed with error %"PRIu32"!",
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_wire_to_surface_2_pdu failed with error %"PRIu32"!",
 				         error);
 
 			break;
 
 		case RDPGFX_CMDID_DELETEENCODINGCONTEXT:
 			if ((error = rdpgfx_recv_delete_encoding_context_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_delete_encoding_context_pdu failed with error %"PRIu32"!",
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_delete_encoding_context_pdu failed with error %"PRIu32"!",
 				         error);
 
 			break;
 
 		case RDPGFX_CMDID_SOLIDFILL:
 			if ((error = rdpgfx_recv_solid_fill_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_solid_fill_pdu failed with error %"PRIu32"!", error);
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_solid_fill_pdu failed with error %"PRIu32"!", error);
 
 			break;
 
 		case RDPGFX_CMDID_SURFACETOSURFACE:
 			if ((error = rdpgfx_recv_surface_to_surface_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_surface_to_surface_pdu failed with error %"PRIu32"!",
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_surface_to_surface_pdu failed with error %"PRIu32"!",
 				         error);
 
 			break;
 
 		case RDPGFX_CMDID_SURFACETOCACHE:
 			if ((error = rdpgfx_recv_surface_to_cache_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_surface_to_cache_pdu failed with error %"PRIu32"!", error);
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_surface_to_cache_pdu failed with error %"PRIu32"!", error);
 
 			break;
 
 		case RDPGFX_CMDID_CACHETOSURFACE:
 			if ((error = rdpgfx_recv_cache_to_surface_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_cache_to_surface_pdu failed with error %"PRIu32"!", error);
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_cache_to_surface_pdu failed with error %"PRIu32"!", error);
 
 			break;
 
 		case RDPGFX_CMDID_EVICTCACHEENTRY:
 			if ((error = rdpgfx_recv_evict_cache_entry_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_evict_cache_entry_pdu failed with error %"PRIu32"!",
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_evict_cache_entry_pdu failed with error %"PRIu32"!",
 				         error);
 
 			break;
 
 		case RDPGFX_CMDID_CREATESURFACE:
 			if ((error = rdpgfx_recv_create_surface_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_create_surface_pdu failed with error %"PRIu32"!", error);
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_create_surface_pdu failed with error %"PRIu32"!", error);
 
 			break;
 
 		case RDPGFX_CMDID_DELETESURFACE:
 			if ((error = rdpgfx_recv_delete_surface_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_delete_surface_pdu failed with error %"PRIu32"!", error);
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_delete_surface_pdu failed with error %"PRIu32"!", error);
 
 			break;
 
 		case RDPGFX_CMDID_STARTFRAME:
 			if ((error = rdpgfx_recv_start_frame_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_start_frame_pdu failed with error %"PRIu32"!", error);
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_start_frame_pdu failed with error %"PRIu32"!", error);
 
 			break;
 
 		case RDPGFX_CMDID_ENDFRAME:
 			if ((error = rdpgfx_recv_end_frame_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_end_frame_pdu failed with error %"PRIu32"!", error);
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_end_frame_pdu failed with error %"PRIu32"!", error);
 
 			break;
 
 		case RDPGFX_CMDID_RESETGRAPHICS:
 			if ((error = rdpgfx_recv_reset_graphics_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_reset_graphics_pdu failed with error %"PRIu32"!", error);
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_reset_graphics_pdu failed with error %"PRIu32"!", error);
 
 			break;
 
 		case RDPGFX_CMDID_MAPSURFACETOOUTPUT:
 			if ((error = rdpgfx_recv_map_surface_to_output_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_map_surface_to_output_pdu failed with error %"PRIu32"!",
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_map_surface_to_output_pdu failed with error %"PRIu32"!",
 				         error);
 
 			break;
 
 		case RDPGFX_CMDID_CACHEIMPORTREPLY:
 			if ((error = rdpgfx_recv_cache_import_reply_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_cache_import_reply_pdu failed with error %"PRIu32"!",
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_cache_import_reply_pdu failed with error %"PRIu32"!",
 				         error);
 
 			break;
 
 		case RDPGFX_CMDID_CAPSCONFIRM:
 			if ((error = rdpgfx_recv_caps_confirm_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_caps_confirm_pdu failed with error %"PRIu32"!", error);
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_caps_confirm_pdu failed with error %"PRIu32"!", error);
 
 			break;
 
 		case RDPGFX_CMDID_MAPSURFACETOWINDOW:
 			if ((error = rdpgfx_recv_map_surface_to_window_pdu(callback, s)))
-				WLog_ERR(TAG, "rdpgfx_recv_map_surface_to_window_pdu failed with error %"PRIu32"!",
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_map_surface_to_window_pdu failed with error %"PRIu32"!",
 				         error);
 
 			break;
@@ -1203,7 +1209,7 @@ static UINT rdpgfx_recv_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStream* s)
 
 	if (error)
 	{
-		WLog_ERR(TAG,  "Error while parsing GFX cmdId: %s (0x%04"PRIX16")",
+		WLog_Print(gfx->log, WLOG_ERROR,  "Error while parsing GFX cmdId: %s (0x%04"PRIX16")",
 		         rdpgfx_get_cmd_id_string(header.cmdId), header.cmdId);
 		return error;
 	}
@@ -1212,7 +1218,7 @@ static UINT rdpgfx_recv_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStream* s)
 
 	if (end != (beg + header.pduLength))
 	{
-		WLog_ERR(TAG,  "Unexpected gfx pdu end: Actual: %d, Expected: %"PRIu32"",
+		WLog_Print(gfx->log, WLOG_ERROR,  "Unexpected gfx pdu end: Actual: %d, Expected: %"PRIu32"",
 		         end, (beg + header.pduLength));
 		Stream_SetPosition(s, (beg + header.pduLength));
 	}
@@ -1240,7 +1246,7 @@ static UINT rdpgfx_on_data_received(IWTSVirtualChannelCallback*
 
 	if (status < 0)
 	{
-		WLog_ERR(TAG, "zgfx_decompress failure! status: %d", status);
+		WLog_Print(gfx->log, WLOG_ERROR, "zgfx_decompress failure! status: %d", status);
 		return ERROR_INTERNAL_ERROR;
 	}
 
@@ -1248,7 +1254,7 @@ static UINT rdpgfx_on_data_received(IWTSVirtualChannelCallback*
 
 	if (!s)
 	{
-		WLog_ERR(TAG, "calloc failed!");
+		WLog_Print(gfx->log, WLOG_ERROR, "calloc failed!");
 		return CHANNEL_RC_NO_MEMORY;
 	}
 
@@ -1256,7 +1262,7 @@ static UINT rdpgfx_on_data_received(IWTSVirtualChannelCallback*
 	{
 		if ((error = rdpgfx_recv_pdu(callback, s)))
 		{
-			WLog_ERR(TAG, "rdpgfx_recv_pdu failed with error %"PRIu32"!", error);
+			WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_recv_pdu failed with error %"PRIu32"!", error);
 			break;
 		}
 	}
@@ -1290,7 +1296,7 @@ static UINT rdpgfx_on_close(IWTSVirtualChannelCallback* pChannelCallback)
 	RDPGFX_CHANNEL_CALLBACK* callback = (RDPGFX_CHANNEL_CALLBACK*) pChannelCallback;
 	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*) callback->plugin;
 	RdpgfxClientContext* context = (RdpgfxClientContext*) gfx->iface.pInterface;
-	WLog_DBG(TAG, "OnClose");
+	WLog_Print(gfx->log, WLOG_DEBUG, "OnClose");
 	free(callback);
 	gfx->UnacknowledgedFrames = 0;
 	gfx->TotalDecodedFrames = 0;
@@ -1386,7 +1392,7 @@ static UINT rdpgfx_plugin_initialize(IWTSPlugin* pPlugin,
 
 	if (!gfx->listener_callback)
 	{
-		WLog_ERR(TAG, "calloc failed!");
+		WLog_Print(gfx->log, WLOG_ERROR, "calloc failed!");
 		return CHANNEL_RC_NO_MEMORY;
 	}
 
@@ -1397,7 +1403,7 @@ static UINT rdpgfx_plugin_initialize(IWTSPlugin* pPlugin,
 	error = pChannelMgr->CreateListener(pChannelMgr, RDPGFX_DVC_CHANNEL_NAME, 0,
 	                                    (IWTSListenerCallback*) gfx->listener_callback, &(gfx->listener));
 	gfx->listener->pInterface = gfx->iface.pInterface;
-	WLog_DBG(TAG, "Initialize");
+	WLog_Print(gfx->log, WLOG_DEBUG, "Initialize");
 	return error;
 }
 
@@ -1414,7 +1420,7 @@ static UINT rdpgfx_plugin_terminated(IWTSPlugin* pPlugin)
 	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*) pPlugin;
 	RdpgfxClientContext* context = (RdpgfxClientContext*) gfx->iface.pInterface;
 	UINT error = CHANNEL_RC_OK;
-	WLog_DBG(TAG, "Terminated");
+	WLog_Print(gfx->log, WLOG_DEBUG, "Terminated");
 
 	if (gfx->listener_callback)
 	{
@@ -1441,7 +1447,7 @@ static UINT rdpgfx_plugin_terminated(IWTSPlugin* pPlugin)
 
 			if (error)
 			{
-				WLog_ERR(TAG, "context->DeleteSurface failed with error %"PRIu32"", error);
+				WLog_Print(gfx->log, WLOG_ERROR, "context->DeleteSurface failed with error %"PRIu32"", error);
 				free(pKeys);
 				free(context);
 				free(gfx);
@@ -1466,7 +1472,7 @@ static UINT rdpgfx_plugin_terminated(IWTSPlugin* pPlugin)
 
 				if (error)
 				{
-					WLog_ERR(TAG, "context->EvictCacheEntry failed with error %"PRIu32"", error);
+					WLog_Print(gfx->log, WLOG_ERROR, "context->EvictCacheEntry failed with error %"PRIu32"", error);
 					free(context);
 					free(gfx);
 					return error;
@@ -1527,7 +1533,7 @@ static UINT rdpgfx_get_surface_ids(RdpgfxClientContext* context,
 
 	if (!pSurfaceIds)
 	{
-		WLog_ERR(TAG, "calloc failed!");
+		WLog_Print(gfx->log, WLOG_ERROR, "calloc failed!");
 		return CHANNEL_RC_NO_MEMORY;
 	}
 
@@ -1608,6 +1614,14 @@ UINT DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 		{
 			WLog_ERR(TAG, "calloc failed!");
 			return CHANNEL_RC_NO_MEMORY;
+		}
+
+		gfx->log = WLog_Get(TAG);
+		if (!gfx->log)
+		{
+			free(gfx);
+			WLog_ERR(TAG, "Failed to aquire reference to WLog %s", TAG);
+			return ERROR_INTERNAL_ERROR;
 		}
 
 		gfx->settings = (rdpSettings*) pEntryPoints->GetRdpSettings(pEntryPoints);

--- a/channels/rdpgfx/client/rdpgfx_main.h
+++ b/channels/rdpgfx/client/rdpgfx_main.h
@@ -78,6 +78,8 @@ struct _RDPGFX_PLUGIN
 	UINT16 MaxCacheSlot;
 	void* CacheSlots[25600];
 	rdpContext* rdpcontext;
+
+	wLog* log;
 };
 typedef struct _RDPGFX_PLUGIN RDPGFX_PLUGIN;
 


### PR DESCRIPTION
The static logger functions of WLog have quite a heavy performance
penalty. Use a pointer to an allocated logger to speed things up.