### PR TITLE
Update reset state fix

### DIFF
--- a/libfreerdp/cache/offscreen.c
+++ b/libfreerdp/cache/offscreen.c
@@ -44,7 +44,12 @@ static BOOL update_gdi_create_offscreen_bitmap(rdpContext* context,
 	UINT32 i;
 	UINT16 index;
 	rdpBitmap* bitmap;
-	rdpCache* cache = context->cache;
+	rdpCache* cache;
+
+	if (!context || !createOffscreenBitmap || !context->cache)
+		return FALSE;
+
+	cache = context->cache;
 	bitmap = Bitmap_Alloc(context);
 
 	if (!bitmap)
@@ -77,8 +82,16 @@ static BOOL update_gdi_create_offscreen_bitmap(rdpContext* context,
 static BOOL update_gdi_switch_surface(rdpContext* context,
                                       const SWITCH_SURFACE_ORDER* switchSurface)
 {
-	rdpCache* cache = context->cache;
-	rdpBitmap* bitmap = context->graphics->Bitmap_Prototype;
+	rdpCache* cache;
+	rdpBitmap* bitmap;
+
+	if (!context || !context->cache || !switchSurface || !context->graphics)
+		return FALSE;
+
+	cache = context->cache;
+	bitmap = context->graphics->Bitmap_Prototype;
+	if (!bitmap)
+		return FALSE;
 
 	if (switchSurface->bitmapId == SCREEN_BITMAP_SURFACE)
 	{

--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -631,6 +631,8 @@ void update_post_disconnect(rdpUpdate* update)
 
 	if (update->asynchronous)
 		update_message_proxy_free(update->proxy);
+
+	update->initialState = TRUE;
 }
 
 static BOOL update_begin_paint(rdpContext* context)
@@ -1714,7 +1716,12 @@ static BOOL update_send_switch_surface_order(
 	BYTE orderType;
 	BYTE controlFlags;
 	int headerLength;
-	rdpUpdate* update = context->update;
+	rdpUpdate* update;
+
+	if (!context || !switch_surface || !context->update)
+		return FALSE;
+
+	update = context->update;
 	headerLength = 1;
 	orderType = ORDER_TYPE_SWITCH_SURFACE;
 	controlFlags = ORDER_SECONDARY | (orderType << 2);


### PR DESCRIPTION
When connecting to a server a second time after the connection dropped, reset the ```initialState``` flag.