### PR TITLE
resolve issue found by cppcheck

### DIFF
--- a/channels/tsmf/client/tsmf_main.c
+++ b/channels/tsmf/client/tsmf_main.c
@@ -79,6 +79,9 @@ BOOL tsmf_playback_ack(IWTSVirtualChannelCallback *pChannelCallback,
 	int status = -1;
 	TSMF_CHANNEL_CALLBACK *callback = (TSMF_CHANNEL_CALLBACK *) pChannelCallback;
 
+	if (!callback) 
+		return FALSE;
+
 	s = Stream_New(NULL, 32);
 	if (!s)
 		return FALSE;
@@ -92,7 +95,7 @@ BOOL tsmf_playback_ack(IWTSVirtualChannelCallback *pChannelCallback,
 
 	DEBUG_TSMF("ACK response size %"PRIuz"", Stream_GetPosition(s));
 
-	if (!callback || !callback->channel || !callback->channel->Write)
+	if (!callback->channel || !callback->channel->Write)
 	{
 		WLog_ERR(TAG, "callback=%p, channel=%p, write=%p", callback,
 		         (callback ? callback->channel : NULL),


### PR DESCRIPTION
[channels/tsmf/client/tsmf_main.c:89] -> [channels/tsmf/client/tsmf_main.c:95]: (warning) Either the condition '!callback' is redundant or there is possible null pointer dereference: callback.