### PR TITLE
Do not fixup HTML data length

### DIFF
--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -588,7 +588,6 @@ static void xf_cliprdr_process_requested_data(xfClipboard* clipboard,
 			break;
 
 		case CB_FORMAT_HTML:
-			size = strlen((char*) data) + 1;
 			srcFormatId = ClipboardGetFormatId(clipboard->system, "text/html");
 			break;
 	}


### PR DESCRIPTION
The data provided by local applications can be actually encoded in UTF-16 (e.g., Firefox does this to HTML). UTF-16 allows embedded null bytes so we should not use strlen() to fix up the data. The HTML format synthesizer can handle trailing null bytes just fine and can detect whether it deals with UTF-8 or UTF-16.

This should resolve issue #3983.