### PR TITLE
  Fix issue #3229 Barcode Scanner USB - missing double characters 

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -492,18 +492,6 @@ static BOOL xf_event_KeyRelease(xfContext* xfc, XEvent* event, BOOL app)
 	KeySym keysym;
 	char str[256];
 
-	if (XPending(xfc->display))
-	{
-		ZeroMemory(&nextEvent, sizeof(nextEvent));
-		XPeekEvent(xfc->display, &nextEvent);
-
-		if (nextEvent.type == KeyPress)
-		{
-			if (nextEvent.xkey.keycode == event->xkey.keycode)
-				return TRUE;
-		}
-	}
-
 	XLookupString((XKeyEvent*) event, str, sizeof(str), &keysym, NULL);
 	xf_keyboard_key_release(xfc, event->xkey.keycode, keysym);
 	return TRUE;


### PR DESCRIPTION
With some USB barcode scanners, repeated characters do not appear in the FreeRDP session.
It looks like this is because the KeyRelease signal is not sent for the first character.

This fixes the problem, but I'm not sure if there is a reason these KeyRelease events need to be ignored