### PR TITLE
Fix compilation on RHEL 6.x by macro-guarding two functions

### DIFF
--- a/channels/tsmf/client/gstreamer/tsmf_X11.c
+++ b/channels/tsmf/client/gstreamer/tsmf_X11.c
@@ -109,7 +109,11 @@ static GstBusSyncReply tsmf_platform_bus_sync_handler(GstBus *bus, GstMessage *m
 		gst_video_overlay_handle_events(hdl->overlay, TRUE);
 #else
 		hdl->overlay = GST_X_OVERLAY (GST_MESSAGE_SRC (message));
+#if GST_CHECK_VERSION(0,10,31) 
 		gst_x_overlay_set_window_handle(hdl->overlay, hdl->subwin);
+#else
+		gst_x_overlay_set_xwindow_id(hdl->overlay, hdl->subwin);
+#endif
 		gst_x_overlay_handle_events(hdl->overlay, TRUE);
 #endif
 

--- a/channels/tsmf/client/gstreamer/tsmf_gstreamer.c
+++ b/channels/tsmf/client/gstreamer/tsmf_gstreamer.c
@@ -1020,10 +1020,14 @@ ITSMFDecoder* freerdp_tsmf_client_subsystem_entry(void)
 {
 	TSMFGstreamerDecoder *decoder;
 
+#if GST_CHECK_VERSION(0,10,31)
 	if (!gst_is_initialized())
 	{
 		gst_init(NULL, NULL);
 	}
+#else
+	gst_init(NULL, NULL);
+#endif
 
 	decoder = calloc(1, sizeof(TSMFGstreamerDecoder));
 


### PR DESCRIPTION
Those two functions were added in gstreamer 0.10.31 (RHEL 6.x being on 0.10.29).

Compare #4019 

I was unsure about the init, though. Should I maybe add a static?