### PR TITLE
Fix a regression introduced with PR #4013

### DIFF
--- a/libfreerdp/core/window.c
+++ b/libfreerdp/core/window.c
@@ -295,6 +295,10 @@ BOOL update_read_window_state_order(wStream* s, WINDOW_ORDER_INFO* orderInfo, WI
 
 		Stream_Read_UINT16(s, windowState->numWindowRects); /* numWindowRects (2 bytes) */
 
+		if (windowState->numWindowRects == 0) {
+			return TRUE;
+		}
+
 		size = sizeof(RECTANGLE_16) * windowState->numWindowRects;
 		newRect = (RECTANGLE_16*)realloc(windowState->windowRects, size);
 		if (!newRect)
@@ -334,6 +338,9 @@ BOOL update_read_window_state_order(wStream* s, WINDOW_ORDER_INFO* orderInfo, WI
 
 		Stream_Read_UINT16(s, windowState->numVisibilityRects); /* numVisibilityRects (2 bytes) */
 
+		if (windowState->numVisibilityRects == 0) {
+			return TRUE;
+		}
 		size = sizeof(RECTANGLE_16) * windowState->numVisibilityRects;
 		newRect = (RECTANGLE_16*)realloc(windowState->visibilityRects, size);
 		if (!newRect)


### PR DESCRIPTION
If numWindowRects/numVisibilityRects is zero a realloc might either
return NULL or a free able memory. In the first case the introduced
regression caused a double free.
As 0 is a possible value that can be received in both cases rail was
broken.

Fixes #4022