### PR TITLE
server/shadow: Fix incorrect bitmap fragment update.

### DIFF
--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -1095,19 +1095,14 @@ static BOOL shadow_client_send_bitmap_update(rdpShadowClient* client,
 		{
 			newUpdateSize = updateSize + (bitmapData[i].bitmapLength + 16);
 
-			if ((newUpdateSize < maxUpdateSize) && ((i + 1) < k))
+			if (newUpdateSize < maxUpdateSize)
 			{
 				CopyMemory(&fragBitmapData[j++], &bitmapData[i++], sizeof(BITMAP_DATA));
 				updateSize = newUpdateSize;
 			}
-			else
-			{
-				if ((i + 1) >= k)
-				{
-					CopyMemory(&fragBitmapData[j++], &bitmapData[i++], sizeof(BITMAP_DATA));
-					updateSize = newUpdateSize;
-				}
 
+			if ((newUpdateSize >= maxUpdateSize) || (i + 1) >= k)
+			{
 				bitmapUpdate.count = bitmapUpdate.number = j;
 				IFCALLRET(update->BitmapUpdate, ret, context, &bitmapUpdate);
 


### PR DESCRIPTION
Legacy bitmap update might fail with 'fast path update size (xxxxx) exceeds the client's maximum request size (xxxxx)'
Original code might update last fragment with exceeded fragment size incorrectly. Fix the logic to prevent it.