### PR TITLE
Fix clipboard POSIX build because of basename conflict

### DIFF
--- a/winpr/libwinpr/clipboard/posix.c
+++ b/winpr/libwinpr/clipboard/posix.c
@@ -394,7 +394,7 @@ static BOOL add_file_to_list(const char* local_name, const WCHAR* remote_name, w
 	return TRUE;
 }
 
-static const char* basename(const char* name)
+static const char* get_basename(const char* name)
 {
 	const char* c = name;
 	const char* last_name = name;
@@ -419,7 +419,7 @@ static BOOL process_file_name(const char* local_name, wArrayList* files)
 	 * exact files selected by the user, and we want the remote files
 	 * to have names relative to that selection.
 	 */
-	base_name = basename(local_name);
+	base_name = get_basename(local_name);
 
 	remote_name = convert_local_name_component_to_remote(base_name);
 	if (!remote_name)


### PR DESCRIPTION
FreeRDP/winpr/libwinpr/clipboard/posix.c:397:20: error: conflicting types for ‘basename’
 static const char* basename(const char* name)
                    ^
In file included from FreeRDP/winpr/include/winpr/collections.h:25:0,
                 from FreeRDP/winpr/libwinpr/clipboard/posix.c:37:
/usr/include/string.h:599:14: note: previous declaration of ‘basename’ was here
 extern char *basename (const char *__filename) __THROW __nonnull ((1));