### PR TITLE
On Solaris use standard conforming getpwnam_r().

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,11 @@ if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
 	add_definitions("-D_FILE_OFFSET_BITS=64")
 endif()
 
+# Use Standard conforming getpwnam_r() on Solaris.
+if("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
+	add_definitions("-D_POSIX_PTHREAD_SEMANTICS")
+endif()
+
 # Compiler-specific flags
 if(CMAKE_COMPILER_IS_GNUCC)
 	if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "i686")


### PR DESCRIPTION
From Solaris getpwnam(3C) man page:

[..]
   Standard conforming
       cc [ flag...] file... -D_POSIX_PTHREAD_SEMANTICS [ library... ]

       int getpwnam_r(const char *name, struct passwd *pwd, char *buffer,
            size_t bufsize, struct passwd **result);
[..]
       Solaris 2.4 and earlier releases provided  definitions  of  the  getpw-
       nam_r()  and  getpwuid_r()  functions as specified in POSIX.1c Draft 6.
       The final POSIX.1c standard changed the interface for these  functions.
       Support  for  the  Draft 6 interface is provided for compatibility only
       and might not be supported in future  releases.  New  applications  and
       libraries should use the standard-conforming interface.
