### PR TITLE
Possible fix for #4081 and #2707

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -145,6 +145,9 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 	UINT32 height = window->height;
 	window->decorations = xfc->decorations;
 	xf_SetWindowDecorations(xfc, window->handle, window->decorations);
+	unsigned long nitems, bytes;
+        BYTE* prop;
+        BOOL status;
 
 	if (fullscreen)
 	{
@@ -203,11 +206,14 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 		XMoveWindow(xfc->display, window->handle, startX, startY);
 	}
 
-	/* Set the fullscreen state */
-	xf_SendClientEvent(xfc, window->handle, xfc->_NET_WM_STATE, 4,
-	                   fullscreen ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE,
-	                   xfc->_NET_WM_STATE_FULLSCREEN, 0, 0);
-
+	status = xf_GetWindowProperty(xfc, DefaultRootWindow(xfc->display), xfc->_NET_WM_FULLSCREEN_MONITORS, 1, &nitems, &bytes, &prop);
+        if (status)
+        {
+		/* Set the fullscreen state */
+		xf_SendClientEvent(xfc, window->handle, xfc->_NET_WM_STATE, 4,
+	        	           fullscreen ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE,
+	                	   xfc->_NET_WM_STATE_FULLSCREEN, 0, 0);
+	}
 	if (!fullscreen)
 	{
 		/* leave full screen: move the window after removing NET_WM_STATE_FULLSCREEN */

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -6,6 +6,7 @@
  * Copyright 2012 HP Development Company, LLC
  * Copyright 2016 Thincast Technologies GmbH
  * Copyright 2016 Armin Novak <armin.novak@thincast.com>
+ * Copyright 2017 Kai Harms <kharms@rangee.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -146,8 +146,8 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 	window->decorations = xfc->decorations;
 	xf_SetWindowDecorations(xfc, window->handle, window->decorations);
 	unsigned long nitems, bytes;
-        BYTE* prop;
-        BOOL status;
+	BYTE* prop;
+	BOOL status;
 
 	if (fullscreen)
 	{
@@ -206,14 +206,17 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 		XMoveWindow(xfc->display, window->handle, startX, startY);
 	}
 
-	status = xf_GetWindowProperty(xfc, DefaultRootWindow(xfc->display), xfc->_NET_WM_FULLSCREEN_MONITORS, 1, &nitems, &bytes, &prop);
-        if (status)
-        {
+	status = xf_GetWindowProperty(xfc, DefaultRootWindow(xfc->display),
+	                              xfc->_NET_WM_FULLSCREEN_MONITORS, 1, &nitems, &bytes, &prop);
+
+	if (status)
+	{
 		/* Set the fullscreen state */
 		xf_SendClientEvent(xfc, window->handle, xfc->_NET_WM_STATE, 4,
-	        	           fullscreen ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE,
-	                	   xfc->_NET_WM_STATE_FULLSCREEN, 0, 0);
+		                   fullscreen ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE,
+		                   xfc->_NET_WM_STATE_FULLSCREEN, 0, 0);
 	}
+
 	if (!fullscreen)
 	{
 		/* leave full screen: move the window after removing NET_WM_STATE_FULLSCREEN */
@@ -342,13 +345,13 @@ static const char* get_shm_id()
 	return shm_id;
 }
 
-Window xf_CreateDummyWindow(xfContext *xfc)
+Window xf_CreateDummyWindow(xfContext* xfc)
 {
 	return XCreateSimpleWindow(xfc->display, DefaultRootWindow(xfc->display),
-			0, 0, 1, 1, 0, 0, 0);
+	                           0, 0, 1, 1, 0, 0, 0);
 }
 
-void xf_DestroyDummyWindow(xfContext *xfc, Window window)
+void xf_DestroyDummyWindow(xfContext* xfc, Window window)
 {
 	if (window)
 		XDestroyWindow(xfc->display, window);
@@ -964,7 +967,7 @@ void xf_UpdateWindowArea(xfContext* xfc, xfAppWindow* appWindow, int x, int y,
 {
 	int ax, ay;
 
-        if (appWindow == NULL)
+	if (appWindow == NULL)
 		return;
 
 	ax = x + appWindow->windowOffsetX;

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -223,6 +223,8 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 		/* leave full screen: move the window after removing NET_WM_STATE_FULLSCREEN */
 		XMoveWindow(xfc->display, window->handle, startX, startY);
 	}
+
+	free(prop);
 }
 
 /* http://tronche.com/gui/x/xlib/window-information/XGetWindowProperty.html */


### PR DESCRIPTION
I tried to create a fix for #4081 and #2707 where _NET_WM_FULLSCREEN_MONITORS gets detected automatically instead of the version before where you have to set +openbox.

I guess there are two approaches. Either search for _NET_WM_FULLSCREEN_MONITORS in _NET_WM_SUPPORTED, or read _NET_WM_FULLSCREEN_MONITORS out directly with xf_GetWindowProperty().