### PR TITLE
fseeko and ftello for 64bit file support.

### DIFF
--- a/client/common/file.c
+++ b/client/common/file.c
@@ -702,15 +702,15 @@ BOOL freerdp_client_parse_rdp_file(rdpFile* file, const char* name)
 	BYTE* buffer;
 	FILE* fp = NULL;
 	size_t read_size;
-	long int file_size;
+	INT64 file_size;
 	fp = fopen(name, "r");
 
 	if (!fp)
 		return FALSE;
 
-	fseek(fp, 0, SEEK_END);
-	file_size = ftell(fp);
-	fseek(fp, 0, SEEK_SET);
+	_fseeki64(fp, 0, SEEK_END);
+	file_size = _ftelli64(fp);
+	_fseeki64(fp, 0, SEEK_SET);
 
 	if (file_size < 1)
 	{

--- a/include/freerdp/utils/pcap.h
+++ b/include/freerdp/utils/pcap.h
@@ -59,7 +59,7 @@ struct rdp_pcap
 	FILE* fp;
 	char* name;
 	BOOL write;
-	int file_size;
+	INT64 file_size;
 	int record_count;
 	pcap_header header;
 	pcap_record* head;

--- a/libfreerdp/codec/test/TestFreeRDPCodecProgressive.c
+++ b/libfreerdp/codec/test/TestFreeRDPCodecProgressive.c
@@ -127,7 +127,7 @@
 struct _EGFX_SAMPLE_FILE
 {
 	BYTE* buffer;
-	UINT32 size;
+	size_t size;
 };
 typedef struct _EGFX_SAMPLE_FILE EGFX_SAMPLE_FILE;
 
@@ -265,7 +265,7 @@ static int test_image_fill_unused_quarters(BYTE* pDstData, int nDstStep, int nWi
 	return 1;
 }
 
-static BYTE* test_progressive_load_file(char* path, char* file, UINT32* size)
+static BYTE* test_progressive_load_file(char* path, char* file, size_t* size)
 {
 	FILE* fp;
 	BYTE* buffer;
@@ -281,9 +281,9 @@ static BYTE* test_progressive_load_file(char* path, char* file, UINT32* size)
 	if (!fp)
 		return NULL;
 
-	fseek(fp, 0, SEEK_END);
-	*size = ftell(fp);
-	fseek(fp, 0, SEEK_SET);
+	_fseeki64(fp, 0, SEEK_END);
+	*size = _ftelli64(fp);
+	_fseeki64(fp, 0, SEEK_SET);
 	buffer = (BYTE*) malloc(*size);
 
 	if (!buffer)

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -1065,16 +1065,16 @@ int freerdp_assistance_parse_file(rdpAssistanceFile* file, const char* name)
 	BYTE* buffer;
 	FILE* fp = NULL;
 	size_t readSize;
-	long int fileSize;
+	INT64 fileSize;
 
 	fp = fopen(name, "r");
 
 	if (!fp)
 		return -1;
 
-	fseek(fp, 0, SEEK_END);
-	fileSize = ftell(fp);
-	fseek(fp, 0, SEEK_SET);
+	_fseeki64(fp, 0, SEEK_END);
+	fileSize = _ftelli64(fp);
+	_fseeki64(fp, 0, SEEK_SET);
 
 	if (fileSize < 1)
 	{

--- a/libfreerdp/core/certificate.c
+++ b/libfreerdp/core/certificate.c
@@ -748,7 +748,7 @@ out_free:
 rdpRsaKey* key_new(const char* keyfile)
 {
 	FILE* fp = NULL;
-	int length;
+	INT64 length;
 	char* buffer = NULL;
 	rdpRsaKey* key = NULL;
 
@@ -759,11 +759,11 @@ rdpRsaKey* key_new(const char* keyfile)
 		goto out_free;
 	}
 
-	if (fseek(fp, 0, SEEK_END) < 0)
+	if (_fseeki64(fp, 0, SEEK_END) < 0)
 		goto out_free;
-	if ((length = ftell(fp)) < 0)
+	if ((length = _ftelli64(fp)) < 0)
 		goto out_free;
-	if (fseek(fp, 0, SEEK_SET) < 0)
+	if (_fseeki64(fp, 0, SEEK_SET) < 0)
 		goto out_free;
 
 	buffer = (char *)malloc(length + 1);

--- a/libfreerdp/utils/pcap.c
+++ b/libfreerdp/utils/pcap.c
@@ -138,7 +138,7 @@ BOOL pcap_add_record(rdpPcap* pcap, void* data, UINT32 length)
 
 BOOL pcap_has_next_record(rdpPcap* pcap)
 {
-	if (pcap->file_size - (ftell(pcap->fp)) <= 16)
+	if (pcap->file_size - (_ftelli64(pcap->fp)) <= 16)
 		return FALSE;
 
 	return TRUE;
@@ -201,9 +201,9 @@ rdpPcap* pcap_open(char* name, BOOL write)
 	}
 	else
 	{
-		fseek(pcap->fp, 0, SEEK_END);
-		pcap->file_size = (int) ftell(pcap->fp);
-		fseek(pcap->fp, 0, SEEK_SET);
+		_fseeki64(pcap->fp, 0, SEEK_END);
+		pcap->file_size = _ftelli64(pcap->fp);
+		_fseeki64(pcap->fp, 0, SEEK_SET);
 		if (!pcap_read_header(pcap, &pcap->header))
 			goto fail;
 	}

--- a/rdtk/librdtk/rdtk_font.c
+++ b/rdtk/librdtk/rdtk_font.c
@@ -156,9 +156,9 @@ static char* rdtk_font_load_descriptor_file(const char* filename, int* pSize)
 	if (!fp)
 		return NULL;
 
-	fseek(fp, 0, SEEK_END);
-	fileSize = ftell(fp);
-	fseek(fp, 0, SEEK_SET);
+	_fseeki64(fp, 0, SEEK_END);
+	fileSize = _ftelli64(fp);
+	_fseeki64(fp, 0, SEEK_SET);
 
 	if (fileSize < 1)
 	{

--- a/winpr/include/winpr/wtypes.h.in
+++ b/winpr/include/winpr/wtypes.h.in
@@ -525,4 +525,9 @@ typedef const BYTE *LPCBYTE;
 
 #include <winpr/user.h>
 
+#ifndef _WIN32
+#define _fseeki64(fp, offset, origin) fseeko(fp, offset, origin)
+#define _ftelli64(fp) ftello(fp)
+#endif
+
 #endif /* WINPR_WTYPES_H */

--- a/winpr/libwinpr/clipboard/posix.c
+++ b/winpr/libwinpr/clipboard/posix.c
@@ -53,8 +53,8 @@ struct posix_file
 	BOOL is_directory;
 
 	int fd;
-	off_t offset;
-	off_t size;
+	INT64 offset;
+	INT64 size;
 };
 
 static struct posix_file* make_posix_file(const char* local_name, const WCHAR* remote_name)
@@ -626,7 +626,7 @@ error:
 	return FALSE;
 }
 
-static UINT posix_file_get_size(const struct posix_file* file, off_t* size)
+static UINT posix_file_get_size(const struct posix_file* file, INT64* size)
 {
 	struct stat statbuf;
 
@@ -646,7 +646,7 @@ static UINT posix_file_request_size(wClipboardDelegate* delegate,
 		const wClipboardFileSizeRequest* request)
 {
 	UINT error = NO_ERROR;
-	off_t size = 0;
+	INT64 size = 0;
 	struct posix_file* file = NULL;
 
 	if (!delegate || !delegate->clipboard || !request)

--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -99,12 +99,12 @@ static BOOL FileCloseHandle(HANDLE handle) {
 static BOOL FileSetEndOfFile(HANDLE hFile)
 {
 	WINPR_FILE* pFile = (WINPR_FILE*) hFile;
-	off_t size;
+	INT64 size;
 
 	if (!hFile)
 		return FALSE;
 
-	size = ftell(pFile->fp);
+	size = _ftelli64(pFile->fp);
 
 	if (ftruncate(fileno(pFile->fp), size) < 0)
 	{
@@ -150,14 +150,14 @@ static DWORD FileSetFilePointer(HANDLE hFile, LONG lDistanceToMove,
 		return INVALID_SET_FILE_POINTER;
 	}
 
-	if (fseek(pFile->fp, offset, whence))
+	if (_fseeki64(pFile->fp, offset, whence))
 	{
-		WLog_ERR(TAG, "fseek(%s) failed with %s [0x%08X]", pFile->lpFileName,
+		WLog_ERR(TAG, "_fseeki64(%s) failed with %s [0x%08X]", pFile->lpFileName,
 			 strerror(errno), errno);
 		return INVALID_SET_FILE_POINTER;
 	}
 
-	return ftell(pFile->fp);
+	return _ftelli64(pFile->fp);
 }
 
 static BOOL FileSetFilePointerEx(HANDLE hFile, LARGE_INTEGER liDistanceToMove, PLARGE_INTEGER lpNewFilePointer, DWORD dwMoveMethod)
@@ -183,15 +183,15 @@ static BOOL FileSetFilePointerEx(HANDLE hFile, LARGE_INTEGER liDistanceToMove, P
 		return FALSE;
 	}
 
-	if (fseek(pFile->fp, liDistanceToMove.QuadPart, whence))
+	if (_fseeki64(pFile->fp, liDistanceToMove.QuadPart, whence))
 	{
-		WLog_ERR(TAG, "fseek(%s) failed with %s [0x%08X]", pFile->lpFileName,
+		WLog_ERR(TAG, "_fseeki64(%s) failed with %s [0x%08X]", pFile->lpFileName,
 			 strerror(errno), errno);
 		return FALSE;
 	}
 
 	if (lpNewFilePointer)
-		lpNewFilePointer->QuadPart = ftell(pFile->fp);
+		lpNewFilePointer->QuadPart = _ftelli64(pFile->fp);
 
 	return TRUE;
 }
@@ -270,41 +270,41 @@ static BOOL FileWrite(PVOID Object, LPCVOID lpBuffer, DWORD nNumberOfBytesToWrit
 static DWORD FileGetFileSize(HANDLE Object, LPDWORD lpFileSizeHigh)
 {
 	WINPR_FILE* file;
-	long cur, size;
+	INT64 cur, size;
 
 	if (!Object)
 		return 0;
 
 	file = (WINPR_FILE *)Object;
 
-	cur = ftell(file->fp);
+	cur = _ftelli64(file->fp);
 
 	if (cur < 0)
 	{
-		WLog_ERR(TAG, "ftell(%s) failed with %s [0x%08X]", file->lpFileName,
+		WLog_ERR(TAG, "_ftelli64(%s) failed with %s [0x%08X]", file->lpFileName,
 			 strerror(errno), errno);
 		return INVALID_FILE_SIZE;
 	}
 
-	if (fseek(file->fp, 0, SEEK_END) != 0)
+	if (_fseeki64(file->fp, 0, SEEK_END) != 0)
 	{
-		WLog_ERR(TAG, "fseek(%s) failed with %s [0x%08X]", file->lpFileName,
+		WLog_ERR(TAG, "_fseeki64(%s) failed with %s [0x%08X]", file->lpFileName,
 			 strerror(errno), errno);
 		return INVALID_FILE_SIZE;
 	}
 
-	size = ftell(file->fp);
+	size = _ftelli64(file->fp);
 
 	if (size < 0)
 	{
-		WLog_ERR(TAG, "ftell(%s) failed with %s [0x%08X]", file->lpFileName,
+		WLog_ERR(TAG, "_ftelli64(%s) failed with %s [0x%08X]", file->lpFileName,
 			 strerror(errno), errno);
 		return INVALID_FILE_SIZE;
 	}
 
-	if (fseek(file->fp, cur, SEEK_SET) != 0)
+	if (_fseeki64(file->fp, cur, SEEK_SET) != 0)
 	{
-		WLog_ERR(TAG, "ftell(%s) failed with %s [0x%08X]", file->lpFileName,
+		WLog_ERR(TAG, "_ftelli64(%s) failed with %s [0x%08X]", file->lpFileName,
 			 strerror(errno), errno);
 		return INVALID_FILE_SIZE;
 	}

--- a/winpr/libwinpr/registry/registry_reg.c
+++ b/winpr/libwinpr/registry/registry_reg.c
@@ -76,10 +76,10 @@ static char* REG_DATA_TYPE_STRINGS[] =
 
 static void reg_load_start(Reg* reg)
 {
-	long int file_size;
-	fseek(reg->fp, 0, SEEK_END);
-	file_size = ftell(reg->fp);
-	fseek(reg->fp, 0, SEEK_SET);
+	INT64 file_size;
+	_fseeki64(reg->fp, 0, SEEK_END);
+	file_size = _ftelli64(reg->fp);
+	_fseeki64(reg->fp, 0, SEEK_SET);
 	reg->line = NULL;
 	reg->next_line = NULL;
 	reg->buffer = NULL;

--- a/winpr/libwinpr/timezone/timezone.c
+++ b/winpr/libwinpr/timezone/timezone.c
@@ -1999,13 +1999,13 @@ static UINT64 winpr_windows_gmtime()
 
 static char* winpr_read_unix_timezone_identifier_from_file(FILE* fp)
 {
-	long length;
+	INT64 length;
 	char* tzid = NULL;
 
-	if (fseek(fp, 0, SEEK_END) != 0)
+	if (_fseeki64(fp, 0, SEEK_END) != 0)
 		return NULL;
-	length = ftell(fp);
-	if (fseek(fp, 0, SEEK_SET) != 0)
+	length = _ftelli64(fp);
+	if (_fseeki64(fp, 0, SEEK_SET) != 0)
 		return NULL;
 
 	if (length < 2)

--- a/winpr/libwinpr/utils/image.c
+++ b/winpr/libwinpr/utils/image.c
@@ -102,15 +102,15 @@ int winpr_image_write(wImage* image, const char* filename)
 
 int winpr_image_png_read_fp(wImage* image, FILE* fp)
 {
-	int size;
+	INT64 size;
 	BYTE* data;
 	UINT32 width;
 	UINT32 height;
 	int lodepng_status;
 
-	fseek(fp, 0, SEEK_END);
-	size = ftell(fp);
-	fseek(fp, 0, SEEK_SET);
+	_fseeki64(fp, 0, SEEK_END);
+	size = _ftelli64(fp);
+	_fseeki64(fp, 0, SEEK_SET);
 
 	data = (BYTE*) malloc(size);
 
@@ -180,9 +180,9 @@ int winpr_image_bitmap_read_fp(wImage* image, FILE* fp)
 	if (fread((void*) &bi, sizeof(WINPR_BITMAP_INFO_HEADER), 1, fp) != 1)
 		return -1;
 
-	if (ftell(fp) != bf.bfOffBits)
+	if (_ftelli64(fp) != bf.bfOffBits)
 	{
-		fseek(fp, bf.bfOffBits, SEEK_SET);
+		_fseeki64(fp, bf.bfOffBits, SEEK_SET);
 	}
 
 	image->width = bi.biWidth;
@@ -315,7 +315,7 @@ int winpr_image_read(wImage* image, const char* filename)
 		return -1;
 	}
 
-	if (fread((void*) &sig, sizeof(sig), 1, fp) != 1 || fseek(fp, 0, SEEK_SET) < 0)
+	if (fread((void*) &sig, sizeof(sig), 1, fp) != 1 || _fseeki64(fp, 0, SEEK_SET) < 0)
 	{
 		fclose(fp);
 		return -1;

--- a/winpr/libwinpr/utils/ini.c
+++ b/winpr/libwinpr/utils/ini.c
@@ -96,20 +96,20 @@ int IniFile_Open_File(wIniFile* ini, const char* filename)
 
 int IniFile_Load_File(wIniFile* ini, const char* filename)
 {
-	int fileSize;
+	INT64 fileSize;
 
 	if (IniFile_Open_File(ini, filename) < 0)
 		return -1;
 
-	if (fseek(ini->fp, 0, SEEK_END) < 0)
+	if (_fseeki64(ini->fp, 0, SEEK_END) < 0)
 		goto out_file;
 
-	fileSize = ftell(ini->fp);
+	fileSize = _ftelli64(ini->fp);
 	
 	if (fileSize < 0)
 		goto out_file;
 	
-	if (fseek(ini->fp, 0, SEEK_SET) < 0)
+	if (_fseeki64(ini->fp, 0, SEEK_SET) < 0)
 		goto out_file;
 
 	ini->line = NULL;

--- a/winpr/libwinpr/utils/lodepng/lodepng.c
+++ b/winpr/libwinpr/utils/lodepng/lodepng.c
@@ -26,6 +26,7 @@ freely, subject to the following restrictions:
  * Modifications fixing various errors. */
 
 #include "lodepng.h"
+#include <winpr/wtypes.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -342,7 +343,7 @@ static int lodepng_add32bitInt(ucvector* buffer, unsigned value)
 unsigned lodepng_load_file(unsigned char** out, size_t* outsize, const char* filename)
 {
   FILE* file;
-  long size;
+  INT64 size;
 
   /*provide some proper output values if error will happen*/
   *out = 0;
@@ -352,8 +353,8 @@ unsigned lodepng_load_file(unsigned char** out, size_t* outsize, const char* fil
   if(!file) return 78;
 
   /*get filesize:*/
-  fseek(file , 0 , SEEK_END);
-  size = ftell(file);
+  _fseeki64(file , 0 , SEEK_END);
+  size = _ftelli64(file);
   rewind(file);
 
   /*read contents of the file into the vector*/

--- a/winpr/libwinpr/utils/sam.c
+++ b/winpr/libwinpr/utils/sam.c
@@ -86,11 +86,11 @@ WINPR_SAM* SamOpen(const char* filename, BOOL readOnly)
 static BOOL SamLookupStart(WINPR_SAM* sam)
 {
 	size_t readSize;
-	long int fileSize;
+	INT64 fileSize;
 
-	fseek(sam->fp, 0, SEEK_END);
-	fileSize = ftell(sam->fp);
-	fseek(sam->fp, 0, SEEK_SET);
+	_fseeki64(sam->fp, 0, SEEK_END);
+	fileSize = _ftelli64(sam->fp);
+	_fseeki64(sam->fp, 0, SEEK_SET);
 
 	if (fileSize < 1)
 		return FALSE;

--- a/winpr/libwinpr/utils/test/TestImage.c
+++ b/winpr/libwinpr/utils/test/TestImage.c
@@ -12,7 +12,7 @@ static void *read_image(const char *src, size_t *size)
 {
 	int success = 0;
 	void *a = NULL;
-	long src_size;
+	INT64 src_size;
 	FILE *fsrc = fopen(src, "rb");
 
 	if (!fsrc)
@@ -21,15 +21,15 @@ static void *read_image(const char *src, size_t *size)
 		goto cleanup;
 	}
 
-	if (fseek(fsrc, 0, SEEK_END))
+	if (_fseeki64(fsrc, 0, SEEK_END))
 	{
 		fprintf(stderr, "Failed to seek to file end\n");
 		goto cleanup;
 	}
 
-	src_size = ftell(fsrc);
+	src_size = _ftelli64(fsrc);
 
-	if (fseek(fsrc, 0, SEEK_SET))
+	if (_fseeki64(fsrc, 0, SEEK_SET))
 	{
 		fprintf(stderr, "Failed to seek to SEEK_SET\n");
 		goto cleanup;

--- a/winpr/libwinpr/utils/wlog/PacketMessage.c
+++ b/winpr/libwinpr/utils/wlog/PacketMessage.c
@@ -125,7 +125,7 @@ static BOOL Pcap_Add_Record(wPcap* pcap, void* data, UINT32 length)
 
 static BOOL Pcap_HasNext_Record(wPcap* pcap)
 {
-	if (pcap->file_size - (ftell(pcap->fp)) <= 16)
+	if (pcap->file_size - (_ftelli64(pcap->fp)) <= 16)
 		return FALSE;
 
 	return TRUE;
@@ -220,12 +220,12 @@ wPcap* Pcap_Open(char* name, BOOL write)
 	}
 	else
 	{
-		if (fseek(pcap->fp, 0, SEEK_END) < 0)
+		if (_fseeki64(pcap->fp, 0, SEEK_END) < 0)
 			goto out_fail;
-		pcap->file_size = (int) ftell(pcap->fp);
+		pcap->file_size = _ftelli64(pcap->fp);
 		if (pcap->file_size < 0)
 			goto out_fail;
-		if (fseek(pcap->fp, 0, SEEK_SET) < 0)
+		if (_fseeki64(pcap->fp, 0, SEEK_SET) < 0)
 			goto out_fail;
 		if (!Pcap_Read_Header(pcap, &pcap->header))
 			goto out_fail;


### PR DESCRIPTION
Remaining issues on 32bit OS #4075:
Use the 64bit capable ```fseeko``` and ```ftello``` to allow file sizes larger than 2G