### PR TITLE
Client/X11: Fix h264 context leak when DeleteSurface

### DIFF
--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -328,6 +328,9 @@ static UINT xf_DeleteSurface(RdpgfxClientContext* context,
 
 	if (surface)
 	{
+#ifdef WITH_GFX_H264
+		h264_context_free(surface->gdi.h264);
+#endif
 		XFree(surface->image);
 		_aligned_free(surface->gdi.data);
 		_aligned_free(surface->stage);


### PR DESCRIPTION
Looks like it is just missed in #3937. We free h264 context in gdi/gfx.c but forgot the xf_gfx.c