### PR TITLE
android: fix a regression with remote program

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -201,7 +201,7 @@ public class LibFreeRDP {
         args.add(addFlag("glyph-cache", false));
 
         if (!advanced.getRemoteProgram().isEmpty()) {
-            args.add("/app:" + advanced.getRemoteProgram());
+            args.add("/shell:" + advanced.getRemoteProgram());
         }
 
         if (!advanced.getWorkDir().isEmpty()) {


### PR DESCRIPTION
Commit 54a7d799d1e9dc7698425b7172a8bf81a4147168 introduced a problem
where /app was used instead of /shell causing a black screen when remote
programs were used. The Android client doesn't support remote apps
therefore /app can't work. "Remote program" just sets the selected
program as shell to run.

Fixes #4048