### PR TITLE
Fix scrolling crash in wayland client

### DIFF
--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -683,7 +683,12 @@ static void pointer_axis_source(void *data, struct wl_pointer *wl_pointer, uint3
 	/*UwacSeat *seat = data;*/
 }
 
-void pointer_axis_stop(void *data, struct wl_pointer *wl_pointer, uint32_t time, uint32_t axis)
+static void pointer_axis_stop(void *data, struct wl_pointer *wl_pointer, uint32_t time, uint32_t axis)
+{
+	/*UwacSeat *seat = data;*/
+}
+
+static void pointer_axis_discrete(void *data, struct wl_pointer *wl_pointer, uint32_t axis, int32_t discrete)
 {
 	/*UwacSeat *seat = data;*/
 }
@@ -697,6 +702,7 @@ static const struct wl_pointer_listener pointer_listener = {
 	pointer_frame,
 	pointer_axis_source,
 	pointer_axis_stop,
+	pointer_axis_discrete,
 };
 
 


### PR DESCRIPTION
An "axis discrete" handler is required since protocol version 5:
https://code.woboq.org/qt5/include/wayland-client-protocol.h.html#_M/WL_POINTER_AXIS_SOURCE_SINCE_VERSION

Since this was not defined, wlfreerdp would crash with the error message "listener function for opcode 8 of wl_pointer is NULL" if the user attempted to scroll.
