### PR TITLE
wlfreerdp: improve performance by making the window opaque

### DIFF
--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -176,6 +176,7 @@ static BOOL wl_post_connect(freerdp* instance)
 
 	UwacWindowSetFullscreenState(window, NULL, instance->context->settings->Fullscreen);
 	UwacWindowSetTitle(window, "FreeRDP");
+	UwacWindowSetOpaqueRegion(context->window, 0, 0, gdi->width, gdi->height);
 	instance->update->BeginPaint = wl_begin_paint;
 	instance->update->EndPaint = wl_end_paint;
 	memcpy(UwacWindowGetDrawingBuffer(context->window), gdi->primary_buffer,


### PR DESCRIPTION
I don't have any numbers.. but this seems to have improved wlfreerdp's performance on both of my test machines.
A similar improvement was made to glmark2-wayland, for example: https://bugs.launchpad.net/glmark2/+bug/1219764