### PR TITLE
wlfreerdp: fix double-free race condition

### DIFF
--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -228,9 +228,6 @@ static BOOL handle_uwac_events(freerdp* instance, UwacDisplay* display)
 				context = (wlfContext*)instance->context;
 				context->waitingFrameDone = FALSE;
 
-				if (context->haveDamage && !wl_end_paint(instance->context))
-					return FALSE;
-
 				break;
 
 			case UWAC_EVENT_POINTER_ENTER:


### PR DESCRIPTION
This line of code was 'randomly' causing wlfreerdp to crash with a double free or corruption memory error:
https://github.com/FreeRDP/FreeRDP/blob/b2c29158be5114f3b98335baeb844824dd4ce3ab/libfreerdp/codec/region.c#L671

Removing the second call to wl_end_paint in wlfreerdp.c caused this error to go away without noticeable impact on display or memory usage.