### PR TITLE
Fixed BadValue with XCreateWindow

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -594,16 +594,6 @@ void xf_FixWindowCoordinates(xfContext* xfc, int* x, int* y, int* width,
 	vscreen_width = xfc->vscreen.area.right - xfc->vscreen.area.left + 1;
 	vscreen_height = xfc->vscreen.area.bottom - xfc->vscreen.area.top + 1;
 
-	if (*width < 1)
-	{
-		*width = 1;
-	}
-
-	if (*height < 1)
-	{
-		*height = 1;
-	}
-
 	if (*x < xfc->vscreen.area.left)
 	{
 		*width += *x;
@@ -624,6 +614,16 @@ void xf_FixWindowCoordinates(xfContext* xfc, int* x, int* y, int* width,
 	if (*height > vscreen_height)
 	{
 		*height = vscreen_height;
+	}
+	
+	if (*width < 1)
+	{
+		*width = 1;
+	}
+
+	if (*height < 1)
+	{
+		*height = 1;
 	}
 }
 


### PR DESCRIPTION
xf_FixWindowCoordinates occasionally set the dimensions of the window to invalid values (0) because the minimum value check was done at the beginning of the method rather than at the end, which caused it to crash.

Attached sample log from crash
[log.txt](https://github.com/FreeRDP/FreeRDP/files/1273319/log.txt)

