### PR TITLE
channels: Don't send gfx capversion 10 if AVC420 is requested

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -92,24 +92,27 @@ static UINT rdpgfx_send_caps_advertise_pdu(RDPGFX_CHANNEL_CALLBACK* callback)
 		capsSet->flags |= RDPGFX_CAPS_FLAG_AVC420_ENABLED;
 #endif
 
-	capsSet = &capsSets[pdu.capsSetCount++];
-	capsSet->version = RDPGFX_CAPVERSION_10;
-	capsSet->flags = 0;
+	if (!gfx->H264 || gfx->AVC444)
+	{
+		capsSet = &capsSets[pdu.capsSetCount++];
+		capsSet->version = RDPGFX_CAPVERSION_10;
+		capsSet->flags = 0;
 
-	if (gfx->SmallCache)
-		capsSet->flags |= RDPGFX_CAPS_FLAG_SMALL_CACHE;
+		if (gfx->SmallCache)
+			capsSet->flags |= RDPGFX_CAPS_FLAG_SMALL_CACHE;
 
 #ifdef WITH_GFX_H264
-	if (!gfx->AVC444)
-		capsSet->flags |= RDPGFX_CAPS_FLAG_AVC_DISABLED;
+		if (!gfx->AVC444)
+			capsSet->flags |= RDPGFX_CAPS_FLAG_AVC_DISABLED;
 #else
-	capsSet->flags |= RDPGFX_CAPS_FLAG_AVC_DISABLED;
+		capsSet->flags |= RDPGFX_CAPS_FLAG_AVC_DISABLED;
 #endif
 
-	capsSets[pdu.capsSetCount] = *capsSet;
-	capsSets[pdu.capsSetCount++].version = RDPGFX_CAPVERSION_102;
-	capsSets[pdu.capsSetCount] = *capsSet;
-	capsSets[pdu.capsSetCount++].version = RDPGFX_CAPVERSION_103;
+		capsSets[pdu.capsSetCount] = *capsSet;
+		capsSets[pdu.capsSetCount++].version = RDPGFX_CAPVERSION_102;
+		capsSets[pdu.capsSetCount] = *capsSet;
+		capsSets[pdu.capsSetCount++].version = RDPGFX_CAPVERSION_103;
+	}
 
 	header.pduLength = RDPGFX_HEADER_SIZE + 2 + (pdu.capsSetCount *
 	                   RDPGFX_CAPSET_SIZE);


### PR DESCRIPTION
Currently AVC420 support was broken because RDPGFX_CAPS_FLAG_AVC_DISABLED was incorrectly set.
MS terminal server only recognizes AVC420 support if the version 10 cap sets are not send - otherwise it will only recognize AVC444 support.