### PR TITLE
Expose INFO_PASSWORD_IS_SC_PIN flag

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -88,6 +88,7 @@ COMMAND_LINE_ARGUMENT_A args[] =
 	{ "serial", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, "tty", "Redirect serial device" },
 	{ "parallel", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "Redirect parallel device" },
 	{ "smartcard", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "Redirect smartcard device" },
+	{ "password-is-pin", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Use smart card authentication with password as smart card PIN"},
 	{ "printer", COMMAND_LINE_VALUE_OPTIONAL, NULL, NULL, NULL, -1, NULL, "Redirect printer device" },
 	{ "usb", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "Redirect USB device" },
 	{ "multitouch", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Redirect multitouch input" },
@@ -550,6 +551,10 @@ int freerdp_client_command_line_post_filter(void* context, COMMAND_LINE_ARGUMENT
 		freerdp_client_add_device_channel(settings, count, p);
 
 		free(p);
+	}
+	CommandLineSwitchCase(arg, "password-is-pin")
+	{
+		settings->PasswordIsSmartcardPin = TRUE;
 	}
 	CommandLineSwitchCase(arg, "printer")
 	{

--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -357,6 +357,9 @@ void rdp_write_info_packet(wStream* s, rdpSettings* settings)
 	if (settings->CompressionEnabled)
 		flags |= INFO_COMPRESSION | INFO_PACKET_COMPR_TYPE_64K;
 
+	if (settings->PasswordIsSmartcardPin)
+		flags |= INFO_PASSWORD_IS_SC_PIN;
+
 	if (settings->Domain)
 	{
 		cbDomain = ConvertToUnicode(CP_UTF8, 0, settings->Domain, -1, &domain, 0) * 2;


### PR DESCRIPTION
`TS_INFO_PACKET` has a flag enabling direct logging in with smart card authentication called `INFO_PASSWORD_IS_SC_PIN` (see[ [MS-RDPBCGR] 2.2.1.11.1.1](https://msdn.microsoft.com/en-us/library/cc240475.aspx)). These changes expose the already existing setting flag `PasswordIsSmartcardPin` via command line and passes the flag in  `TS_INFO_PACKET` message also during library use.