### PR TITLE
Fix colors on big endian

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -381,6 +381,9 @@ static BOOL xf_sw_desktop_resize(rdpContext* context)
 		goto out;
 	}
 
+	xfc->image->byte_order = LSBFirst;
+	xfc->image->bitmap_bit_order = LSBFirst;
+
 	ret = xf_desktop_resize(context);
 out:
 	xf_unlock_x11(xfc, TRUE);
@@ -628,6 +631,8 @@ BOOL xf_create_window(xfContext* xfc)
 		                          ZPixmap, 0, (char*) gdi->primary_buffer,
 		                          settings->DesktopWidth, settings->DesktopHeight,
 		                          xfc->scanline_pad, gdi->stride);
+		xfc->image->byte_order = LSBFirst;
+		xfc->image->bitmap_bit_order = LSBFirst;
 	}
 
 	return TRUE;
@@ -1813,7 +1818,7 @@ static BOOL xfreerdp_client_new(freerdp* instance, rdpContext* context)
 	xfc->screen = ScreenOfDisplay(xfc->display, xfc->screen_number);
 	xfc->depth = DefaultDepthOfScreen(xfc->screen);
 	xfc->big_endian = (ImageByteOrder(xfc->display) == MSBFirst);
-	xfc->invert = (ImageByteOrder(xfc->display) == MSBFirst) ? FALSE : TRUE;
+	xfc->invert = TRUE;
 	xfc->complex_regions = TRUE;
 	xfc->x11event = CreateFileDescriptorEvent(NULL, FALSE, FALSE, xfc->xfds,
 	                WINPR_FD_READ);

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -777,15 +777,6 @@ void xf_unlock_x11(xfContext* xfc, BOOL display)
 	}
 }
 
-static void xf_calculate_color_shifts(UINT32 mask, UINT8* rsh, UINT8* lsh)
-{
-	for (*lsh = 0; !(mask & 1); mask >>= 1)
-		(*lsh)++;
-
-	for (*rsh = 8; mask; mask >>= 1)
-		(*rsh)--;
-}
-
 static BOOL xf_get_pixmap_info(xfContext* xfc)
 {
 	int i;
@@ -861,13 +852,6 @@ static BOOL xf_get_pixmap_info(xfContext* xfc)
 		{
 			xfc->invert = FALSE;
 		}
-
-		/* calculate color shifts required for rdp order color conversion */
-		xf_calculate_color_shifts(vi->red_mask, &xfc->red_shift_r, &xfc->red_shift_l);
-		xf_calculate_color_shifts(vi->green_mask, &xfc->green_shift_r,
-		                          &xfc->green_shift_l);
-		xf_calculate_color_shifts(vi->blue_mask, &xfc->blue_shift_r,
-		                          &xfc->blue_shift_l);
 	}
 
 	XFree(vis);

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -859,7 +859,7 @@ static BOOL xf_get_pixmap_info(xfContext* xfc)
 			 */
 		if (vi->red_mask & 0xFF)
 		{
-			xfc->invert = TRUE;
+			xfc->invert = FALSE;
 		}
 
 		/* calculate color shifts required for rdp order color conversion */

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -854,9 +854,9 @@ static BOOL xf_get_pixmap_info(xfContext* xfc)
 	if (xfc->visual)
 	{
 		/*
-			 * Detect if the server visual has an inverted colormap
-			 * (BGR vs RGB, or red being the least significant byte)
-			 */
+		 * Detect if the server visual has an inverted colormap
+		 * (BGR vs RGB, or red being the least significant byte)
+		 */
 		if (vi->red_mask & 0xFF)
 		{
 			xfc->invert = FALSE;

--- a/client/X11/xf_gdi.c
+++ b/client/X11/xf_gdi.c
@@ -241,6 +241,8 @@ static Pixmap xf_brush_new(xfContext* xfc, UINT32 width, UINT32 height,
 		                   &xfc->context.gdi->palette, FREERDP_FLIP_NONE);
 		image = XCreateImage(xfc->display, xfc->visual, xfc->depth,
 		                     ZPixmap, 0, (char*) cdata, width, height, xfc->scanline_pad, 0);
+		image->byte_order = LSBFirst;
+		image->bitmap_bit_order = LSBFirst;
 		gc = XCreateGC(xfc->display, xfc->drawable, 0, NULL);
 		XPutImage(xfc->display, bitmap, gc, image, 0, 0, 0, 0, width, height);
 		XFree(image);
@@ -264,6 +266,8 @@ static Pixmap xf_mono_bitmap_new(xfContext* xfc, int width, int height,
 	bitmap = XCreatePixmap(xfc->display, xfc->drawable, width, height, 1);
 	image = XCreateImage(xfc->display, xfc->visual, 1,
 	                     ZPixmap, 0, (char*) data, width, height, 8, scanline);
+	image->byte_order = LSBFirst;
+	image->bitmap_bit_order = LSBFirst;
 	XPutImage(xfc->display, bitmap, xfc->gc_mono, image, 0, 0, 0, 0, width, height);
 	XFree(image);
 	return bitmap;
@@ -997,6 +1001,9 @@ static BOOL xf_gdi_update_screen(xfContext* xfc, const BYTE* pSrcData,
 		                     (char*) src, width, height, xfc->scanline_pad, scanline);
 		if (!image)
 			break;
+
+		image->byte_order = LSBFirst;
+		image->bitmap_bit_order = LSBFirst;
 
 		XPutImage(xfc->display, xfc->primary, xfc->gc, image, 0, 0, left, top, width, height);
 		XFree(image);

--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -293,6 +293,9 @@ static UINT xf_CreateSurface(RdpgfxClientContext* context,
 		goto error_surface_image;
 	}
 
+	surface->image->byte_order = LSBFirst;
+	surface->image->bitmap_bit_order = LSBFirst;
+
 	surface->gdi.outputMapped = FALSE;
 	region16_init(&surface->gdi.invalidRegion);
 	if (context->SetSurfaceData(context, surface->gdi.surfaceId, (void*) surface) != CHANNEL_RC_OK)

--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -229,9 +229,9 @@ static BOOL xf_Pointer_New(rdpContext* context, rdpPointer* pointer)
 		return FALSE;
 
 	if (!xfc->invert)
-		CursorFormat = PIXEL_FORMAT_RGBA32;
+		CursorFormat = (!xfc->big_endian) ? PIXEL_FORMAT_RGBA32 : PIXEL_FORMAT_ABGR32;
 	else
-		CursorFormat = PIXEL_FORMAT_BGRA32;
+		CursorFormat = (!xfc->big_endian) ? PIXEL_FORMAT_BGRA32 : PIXEL_FORMAT_ARGB32;
 
 	xf_lock_x11(xfc, FALSE);
 	ZeroMemory(&ci, sizeof(ci));

--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -144,9 +144,11 @@ static BOOL xf_Bitmap_New(rdpContext* context, rdpBitmap* bitmap)
 		xbitmap->image = XCreateImage(xfc->display, xfc->visual, xfc->depth,
 		                              ZPixmap, 0, (char*) bitmap->data, bitmap->width, bitmap->height,
 		                              xfc->scanline_pad, 0);
-
 		if (!xbitmap->image)
 			goto unlock;
+
+		xbitmap->image->byte_order = LSBFirst;
+		xbitmap->image->bitmap_bit_order = LSBFirst;
 
 		XPutImage(xfc->display, xbitmap->pixmap, xfc->gc, xbitmap->image, 0, 0, 0, 0, bitmap->width,
 		          bitmap->height);

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -140,13 +140,6 @@ struct xf_context
 	UINT16 frame_x2;
 	UINT16 frame_y2;
 
-	UINT8 red_shift_l;
-	UINT8 red_shift_r;
-	UINT8 green_shift_l;
-	UINT8 green_shift_r;
-	UINT8 blue_shift_l;
-	UINT8 blue_shift_r;
-
 	int XInputOpcode;
 
 	int savedWidth;


### PR DESCRIPTION
Let's fix the colors on big endian finally https://github.com/FreeRDP/FreeRDP/issues/2520. See commit descriptions...

Tested all combinations of 16/24/32 depth of X11 and /bpp:16/24/32 on systems with little/big endian. It seems it is working correctly, just /bpp:32 doesn't work correctly on X11 with 32 depth, but this is a problem even with master, see https://github.com/FreeRDP/FreeRDP/issues/4134. I did not test with /bpp:8 and lower systematically, but it seems that there are still some minor issues...