### PR TITLE
extend /size to allow width or height percentages

### DIFF
--- a/client/X11/xf_monitor.c
+++ b/client/X11/xf_monitor.c
@@ -198,20 +198,34 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pMaxWidth, UINT32* pMaxHeight)
 	}
 	else if (settings->PercentScreen)
 	{
-		*pMaxWidth = (xfc->workArea.width * settings->PercentScreen) / 100;
-		*pMaxHeight = (xfc->workArea.height * settings->PercentScreen) / 100;
-
 		/* If we have specific monitor information then limit the PercentScreen value
 		 * to only affect the current monitor vs. the entire desktop
 		 */
 		if (vscreen->nmonitors > 0)
 		{
-			*pMaxWidth = ((vscreen->monitors[current_monitor].area.right -
+			*pMaxWidth = vscreen->monitors[current_monitor].area.right -
+				           vscreen->monitors[current_monitor].area.left + 1;
+			*pMaxHeight = vscreen->monitors[current_monitor].area.bottom -
+			              vscreen->monitors[current_monitor].area.top + 1;
+			if(settings->PercentScreenUseWidth)
+				*pMaxWidth = ((vscreen->monitors[current_monitor].area.right -
 			               vscreen->monitors[current_monitor].area.left + 1) * settings->PercentScreen) /
 			             100;
-			*pMaxHeight = ((vscreen->monitors[current_monitor].area.bottom -
+
+			if(settings->PercentScreenUseHeight)
+				*pMaxHeight = ((vscreen->monitors[current_monitor].area.bottom -
 			                vscreen->monitors[current_monitor].area.top + 1) * settings->PercentScreen) /
 			              100;
+		}
+		else
+		{
+			*pMaxWidth = xfc->workArea.width;
+			*pMaxHeight = xfc->workArea.height;
+
+			if(settings->PercentScreenUseWidth)
+				*pMaxWidth = (xfc->workArea.width * settings->PercentScreen) / 100;
+			if(settings->PercentScreenUseHeight)
+				*pMaxHeight = (xfc->workArea.height * settings->PercentScreen) / 100;
 		}
 	}
 

--- a/client/X11/xfreerdp-examples.1.xml
+++ b/client/X11/xfreerdp-examples.1.xml
@@ -8,6 +8,12 @@
 			</listitem>
 		</varlistentry>
 		<varlistentry>
+			<term><command>xfreerdp /u:USER /size:50%h /v:rdp.contoso.com</command></term>
+			<listitem>
+				<para>Connect to host <replaceable>rdp.contoso.com</replaceable> with user <replaceable>USER</replaceable> and a size of <replaceable>50 percent of the height</replaceable>. If width (w) is set instead of height (h) like /size:50%w. 50 percent of the width is used.</para>
+			</listitem>
+		</varlistentry>
+		<varlistentry>
 			<term><command>xfreerdp /u:CONTOSO\\JohnDoe /p:Pwd123! /v:rdp.contoso.com</command></term>
 			<listitem>
 				<para>Connect to host <replaceable>rdp.contoso.com</replaceable> with user <replaceable>CONTOSO\\JohnDoe</replaceable> and password <replaceable>Pwd123!</replaceable></para>

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -51,7 +51,7 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "port", COMMAND_LINE_VALUE_REQUIRED, "<number>", NULL, NULL, -1, NULL, "Server port" },
 	{ "w", COMMAND_LINE_VALUE_REQUIRED, "<width>", "1024", NULL, -1, NULL, "Width" },
 	{ "h", COMMAND_LINE_VALUE_REQUIRED, "<height>", "768", NULL, -1, NULL, "Height" },
-	{ "size", COMMAND_LINE_VALUE_REQUIRED, "<width>x<height> or <percent>%", "1024x768", NULL, -1, NULL, "Screen size" },
+	{ "size", COMMAND_LINE_VALUE_REQUIRED, "<width>x<height> or <percent>%[wh]", "1024x768", NULL, -1, NULL, "Screen size" },
 	{ "f", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Fullscreen mode" },
 	{ "bpp", COMMAND_LINE_VALUE_REQUIRED, "<depth>", "16", NULL, -1, NULL, "Session bpp (color depth)" },
 	{ "kbd", COMMAND_LINE_VALUE_REQUIRED, "0x<layout id> or <layout name>", NULL, NULL, -1, NULL, "Keyboard layout" },
@@ -1600,6 +1600,26 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 				if (p)
 				{
+					BOOL partial = FALSE;
+
+					if (strchr(p, 'w'))
+					{
+						settings->PercentScreenUseWidth = 1;
+						partial = TRUE;
+					}
+					if (strchr(p, 'h'))
+					{
+						settings->PercentScreenUseHeight = 1;
+						partial = TRUE;
+					}
+
+					if (!partial)
+					{
+						settings->PercentScreenUseWidth = 1;
+						settings->PercentScreenUseHeight = 1;
+					}
+
+					*p = '\0';
 					settings->PercentScreen = atoi(str);
 				}
 			}

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -662,6 +662,8 @@ typedef struct _RDPDR_PARALLEL RDPDR_PARALLEL;
 #define FreeRDP_YPan						1553
 #define FreeRDP_SmartSizingWidth				1554
 #define FreeRDP_SmartSizingHeight				1555
+#define FreeRDP_PercentScreenUseWidth				1556
+#define FreeRDP_PercentScreenUseHeight				1557
 #define FreeRDP_SoftwareGdi					1601
 #define FreeRDP_LocalConnection					1602
 #define FreeRDP_AuthenticationOnly				1603
@@ -1098,7 +1100,9 @@ struct rdp_settings
 	ALIGN64 int YPan; /* 1553 */
 	ALIGN64 UINT32 SmartSizingWidth; /* 1554 */
 	ALIGN64 UINT32 SmartSizingHeight; /* 1555 */
-	UINT64 padding1601[1601 - 1556]; /* 1556 */
+	ALIGN64 BOOL PercentScreenUseWidth; /* 1556 */
+	ALIGN64 BOOL PercentScreenUseHeight; /* 1557 */
+	UINT64 padding1601[1601 - 1558]; /* 1558 */
 
 	/* Miscellaneous */
 	ALIGN64 BOOL SoftwareGdi; /* 1601 */

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -1845,6 +1845,12 @@ UINT32 freerdp_get_param_uint32(rdpSettings* settings, int id)
 		case FreeRDP_PercentScreen:
 			return settings->PercentScreen;
 
+		case FreeRDP_PercentScreenUseWidth:
+			return settings->PercentScreenUseWidth;
+
+		case FreeRDP_PercentScreenUseHeight:
+			return settings->PercentScreenUseHeight;
+
 		case FreeRDP_GatewayUsageMethod:
 			return settings->GatewayUsageMethod;
 
@@ -2140,6 +2146,14 @@ int freerdp_set_param_uint32(rdpSettings* settings, int id, UINT32 param)
 
 		case FreeRDP_PercentScreen:
 			settings->PercentScreen = param;
+			break;
+
+		case FreeRDP_PercentScreenUseWidth:
+			settings->PercentScreenUseWidth = param;
+			break;
+
+		case FreeRDP_PercentScreenUseHeight:
+			settings->PercentScreenUseHeight = param;
 			break;
 
 		case FreeRDP_GatewayUsageMethod:


### PR DESCRIPTION
If the size parameter is used with a percentages like /size:50% now
an additional 'w' or 'h' can be appended (like /size:50%w) to specify
where the percentage should be applied. If both or none are set the
behavior is like it was before and the percentage is applied to width
and height.