### PR TITLE
Unlink file after binding to it.

### DIFF
--- a/libfreerdp/core/listener.c
+++ b/libfreerdp/core/listener.c
@@ -185,9 +185,9 @@ static BOOL freerdp_listener_open_local(freerdp_listener* instance, const char* 
 
 	addr.sun_family = AF_UNIX;
 	strncpy(addr.sun_path, path, sizeof(addr.sun_path));
-	unlink(path);
 
 	status = _bind(sockfd, (struct sockaddr*) &addr, sizeof(addr));
+	unlink(path);
 
 	if (status != 0)
 	{


### PR DESCRIPTION
When unlinking the file before binding, a new entry is created
in the file system after binding. This is not desireable, so
unlink it after binding to remove the temporary file after the process
closes.