### PR TITLE
Added delay for connect abort

### DIFF
--- a/libfreerdp/core/test/TestConnect.c
+++ b/libfreerdp/core/test/TestConnect.c
@@ -136,6 +136,7 @@ static int testAbort(int port)
 	}
 
 	WaitForSingleObject(s_sync, INFINITE);
+	Sleep(1000); /* Wait until freerdp_connect has been called */
 	freerdp_abort_connect(instance);
 	status = WaitForSingleObject(instance->context->abortEvent, 0);
 


### PR DESCRIPTION
```freerdp_connect``` resets the abort event. This opens a race window for ```TestConnect```. Fix it by waiting until at least freerdp_connect is called.