### PR TITLE
Android: Fix tab key mapping for hardware keyboard

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/KeyboardMapper.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/KeyboardMapper.java
@@ -271,6 +271,7 @@ public class KeyboardMapper {
         keymapAndroid[KeyEvent.KEYCODE_DEL] = VK_BACK;
         keymapAndroid[KeyEvent.KEYCODE_ENTER] = VK_RETURN;
         keymapAndroid[KeyEvent.KEYCODE_SPACE] = VK_SPACE;
+        keymapAndroid[KeyEvent.KEYCODE_TAB] = VK_TAB;
 //		keymapAndroid[KeyEvent.KEYCODE_SHIFT_LEFT] = VK_LSHIFT;
 //		keymapAndroid[KeyEvent.KEYCODE_SHIFT_RIGHT] = VK_RSHIFT;
 


### PR DESCRIPTION
Some handheld computers, such as the Motorola MC32 series, have a hardware keyboard with a Tab key. 

If the KEYCODE_TAB -> VK_TAB mapping is not present, the key is passed to the server as a Unicode key down event with no matching key up event. It appears most Windows programs (with the notable exception of Notepad) are looking for a keydown/keyup sequence before processing the Tab keypress. 

Adding the mapping to the keymapAndroid array, as done here, causes the Tab to be sent as a regular pair of keydown/keyup keyboard events.

fixes #2486
