### PR TITLE
[android] Ensure native session is disconnected before resource free.

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -99,7 +99,7 @@ public class LibFreeRDP {
             if (mInstanceState.get(inst, false)) {
                 freerdp_disconnect(inst);
             }
-            while(mInstanceState.get(inst)) {
+            while(mInstanceState.get(inst, false)) {
                 try {
                     mInstanceState.wait();
                 } catch (InterruptedException e) {
@@ -121,7 +121,7 @@ public class LibFreeRDP {
 
     public static boolean disconnect(long inst) {
         synchronized (mInstanceState) {
-            if (mInstanceState.get(inst)) {
+            if (mInstanceState.get(inst, false)) {
                 return freerdp_disconnect(inst);
             }
             return true;
@@ -130,7 +130,7 @@ public class LibFreeRDP {
 
     public static boolean cancelConnection(long inst) {
         synchronized (mInstanceState) {
-            if (mInstanceState.get(inst)) {
+            if (mInstanceState.get(inst, false)) {
                 return freerdp_disconnect(inst);
             }
             return true;

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -13,6 +13,7 @@ package com.freerdp.freerdpcore.services;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.support.v4.util.LongSparseArray;
 import android.util.Log;
 
 import com.freerdp.freerdpcore.application.GlobalApp;
@@ -27,6 +28,8 @@ public class LibFreeRDP {
     private static final String TAG = "LibFreeRDP";
     private static EventListener listener;
     private static boolean mHasH264 = true;
+
+    private static final LongSparseArray<Boolean> mInstanceState = new LongSparseArray<>();
 
     static {
         final String h264 = "openh264";
@@ -92,19 +95,46 @@ public class LibFreeRDP {
     }
 
     public static void freeInstance(long inst) {
+        synchronized (mInstanceState) {
+            if (mInstanceState.get(inst, false)) {
+                freerdp_disconnect(inst);
+            }
+            while(mInstanceState.get(inst)) {
+                try {
+                    mInstanceState.wait();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException();
+                }
+            }
+        }
         freerdp_free(inst);
     }
 
     public static boolean connect(long inst) {
+        synchronized (mInstanceState) {
+            if (mInstanceState.get(inst, false)) {
+                throw new RuntimeException("instance already connected");
+            }
+        }
         return freerdp_connect(inst);
     }
 
     public static boolean disconnect(long inst) {
-        return freerdp_disconnect(inst);
+        synchronized (mInstanceState) {
+            if (mInstanceState.get(inst)) {
+                return freerdp_disconnect(inst);
+            }
+            return true;
+        }
     }
 
     public static boolean cancelConnection(long inst) {
-        return freerdp_disconnect(inst);
+        synchronized (mInstanceState) {
+            if (mInstanceState.get(inst)) {
+                return freerdp_disconnect(inst);
+            }
+            return true;
+        }
     }
 
     private static String addFlag(String name, boolean enabled) {
@@ -337,6 +367,10 @@ public class LibFreeRDP {
     private static void OnConnectionSuccess(long inst) {
         if (listener != null)
             listener.OnConnectionSuccess(inst);
+        synchronized (mInstanceState) {
+            mInstanceState.append(inst, true);
+            mInstanceState.notifyAll();
+        }
     }
 
     private static void OnConnectionFailure(long inst) {
@@ -352,6 +386,10 @@ public class LibFreeRDP {
     private static void OnDisconnecting(long inst) {
         if (listener != null)
             listener.OnDisconnecting(inst);
+        synchronized (mInstanceState) {
+            mInstanceState.remove(inst);
+            mInstanceState.notifyAll();
+        }
     }
 
     private static void OnDisconnected(long inst) {

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -376,6 +376,10 @@ public class LibFreeRDP {
     private static void OnConnectionFailure(long inst) {
         if (listener != null)
             listener.OnConnectionFailure(inst);
+        synchronized (mInstanceState) {
+            mInstanceState.remove(inst);
+            mInstanceState.notifyAll();
+        }
     }
 
     private static void OnPreConnect(long inst) {
@@ -386,15 +390,15 @@ public class LibFreeRDP {
     private static void OnDisconnecting(long inst) {
         if (listener != null)
             listener.OnDisconnecting(inst);
-        synchronized (mInstanceState) {
-            mInstanceState.remove(inst);
-            mInstanceState.notifyAll();
-        }
     }
 
     private static void OnDisconnected(long inst) {
         if (listener != null)
             listener.OnDisconnected(inst);
+        synchronized (mInstanceState) {
+            mInstanceState.remove(inst);
+            mInstanceState.notifyAll();
+        }
     }
 
     private static void OnSettingsChanged(long inst, int width, int height, int bpp) {


### PR DESCRIPTION
```freerdp_disconnect``` native function is non blocking.
Wait for ```OnDisconnecting``` to ensure the native session was cleaned up properly.
Possible fix for #4169 and solution for issues in #4159 