### PR TITLE
Windows client: refresh only updated region(s) instead of whole screen

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -119,10 +119,10 @@ static BOOL wf_begin_paint(rdpContext* context)
 {
 	HGDI_DC hdc;
 
-	if (!context || !context->gdi || !context->gdi->hdc)
+	if (!context || !context->gdi || !context->gdi->primary || !context->gdi->primary->hdc)
 		return FALSE;
 
-	hdc = context->gdi->hdc;
+	hdc = context->gdi->primary->hdc;
 
 	if (!hdc || !hdc->hwnd || !hdc->hwnd->invalid)
 		return FALSE;


### PR DESCRIPTION
Fixed hdc initialization into _wf_begin_paint_ (client/Windows/wf_client.c) so the region invalidation into _wf_end_paint_ applies to the same hdc.

The objective is that only the updated region(s) are refreshed instead of the whole screen.

It's not much a problem for normal FreeRDP usage but becomes a serious issue if the display is processed, forwarded and rendered remotely, as done by web gateways such as Guacamole, FreeRDP-WebConnect and Myrtille (I'm the author of the latter).

Thanks :)