### PR TITLE
Do not delete the listener socket right after creating it.

### DIFF
--- a/libfreerdp/core/listener.c
+++ b/libfreerdp/core/listener.c
@@ -186,8 +186,8 @@ static BOOL freerdp_listener_open_local(freerdp_listener* instance, const char* 
 	addr.sun_family = AF_UNIX;
 	strncpy(addr.sun_path, path, sizeof(addr.sun_path));
 
-	status = _bind(sockfd, (struct sockaddr*) &addr, sizeof(addr));
 	unlink(path);
+	status = _bind(sockfd, (struct sockaddr*) &addr, sizeof(addr));
 
 	if (status != 0)
 	{


### PR DESCRIPTION
The listener server socket file needs to be deleted before we bind it
otherwise it's an "address already in use" error. But it was getting
deleted after the bind, causing the file to disappear, and preventing
anyone from connecting to the listener socket since the socket stops
existing.

This is caused by commit 884e87fde4ece132c3b7bdf947de044ecb3d4b14
The bug was introduced via https://github.com/FreeRDP/FreeRDP/pull/4150