### PR TITLE
Static analyser issues

### DIFF
--- a/winpr/libwinpr/comm/comm.c
+++ b/winpr/libwinpr/comm/comm.c
@@ -1473,10 +1473,7 @@ HANDLE CommCreateFileA(LPCSTR lpDeviceName, DWORD dwDesiredAccess,
 	return (HANDLE)pComm;
 error_handle:
 
-	if (pComm != NULL)
-	{
-		CloseHandle(pComm);
-	}
+	CloseHandle(pComm);
 
 	return INVALID_HANDLE_VALUE;
 }

--- a/winpr/libwinpr/synch/semaphore.c
+++ b/winpr/libwinpr/synch/semaphore.c
@@ -129,7 +129,6 @@ HANDLE CreateSemaphoreW(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lIniti
 		return NULL;
 
 	semaphore->pipe_fd[0] = -1;
-	semaphore->pipe_fd[0] = -1;
 	semaphore->sem = (winpr_sem_t*) NULL;
 	semaphore->ops = &ops;
 

--- a/winpr/libwinpr/synch/semaphore.c
+++ b/winpr/libwinpr/synch/semaphore.c
@@ -129,6 +129,7 @@ HANDLE CreateSemaphoreW(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lIniti
 		return NULL;
 
 	semaphore->pipe_fd[0] = -1;
+	semaphore->pipe_fd[1] = -1;
 	semaphore->sem = (winpr_sem_t*) NULL;
 	semaphore->ops = &ops;
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A warnings, found using PVS-Studio:
FreeRDP/winpr/libwinpr/synch/semaphore.c    132     err     V519 The 'semaphore->pipe_fd[0]' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 131, 132.
FreeRDP/winpr/libwinpr/comm/comm.c  1476    warn    V547 Expression 'pComm != NULL' is always true.