### PR TITLE
winpr: _IoCreateDeviceEx: fix mkdir error check

### DIFF
--- a/winpr/libwinpr/io/device.c
+++ b/winpr/libwinpr/io/device.c
@@ -138,7 +138,7 @@ NTSTATUS _IoCreateDeviceEx(PDRIVER_OBJECT_EX DriverObject, ULONG DeviceExtension
 
 	if (!PathFileExistsA(DeviceBasePath))
 	{
-		if (!mkdir(DeviceBasePath, S_IRUSR | S_IWUSR | S_IXUSR))
+		if (mkdir(DeviceBasePath, S_IRUSR | S_IWUSR | S_IXUSR) != 0)
 		{
 			free(DeviceBasePath);
 			return STATUS_ACCESS_DENIED;


### PR DESCRIPTION
The mkdir(2) function returns 0 on success, and -1 on error.

This resolves an error in TestIoDevice when /tmp/.device/ does not
exist.

Bug: https://bugs.gentoo.org/635838