### PR TITLE
Fixed twice assigned values

### DIFF
--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -269,7 +269,6 @@ static void xf_input_detect_pan(xfContext* xfc)
 				PubSub_OnPanningChange(((rdpContext*) xfc)->pubSub, xfc, &e);
 			}
 			px_vector = 0;
-			px_vector = 0;
 			py_vector = 0;
 			z_vector = 0;
 		}
@@ -282,7 +281,6 @@ static void xf_input_detect_pan(xfContext* xfc)
 				e.dy = 0;
 				PubSub_OnPanningChange(((rdpContext*) xfc)->pubSub, xfc, &e);
 			}
-			px_vector = 0;
 			px_vector = 0;
 			py_vector = 0;
 			z_vector = 0;
@@ -302,7 +300,6 @@ static void xf_input_detect_pan(xfContext* xfc)
 			}
 			py_vector = 0;
 			px_vector = 0;
-			py_vector = 0;
 			z_vector = 0;
 		}
 		else if (py_vector < -PAN_THRESHOLD)
@@ -316,7 +313,6 @@ static void xf_input_detect_pan(xfContext* xfc)
 			}
 			py_vector = 0;
 			px_vector = 0;
-			py_vector = 0;
 			z_vector = 0;
 		}
 	}
@@ -346,7 +342,6 @@ static void xf_input_detect_pinch(xfContext* xfc)
 		z_vector = 0;
 		px_vector = 0;
 		py_vector = 0;
-		z_vector = 0;
 	}
 	else
 	{
@@ -370,7 +365,6 @@ static void xf_input_detect_pinch(xfContext* xfc)
 			z_vector = 0;
 			px_vector = 0;
 			py_vector = 0;
-			z_vector = 0;
 		}
 
 		if (z_vector < -ZOOM_THRESHOLD)
@@ -381,7 +375,6 @@ static void xf_input_detect_pinch(xfContext* xfc)
 			z_vector = 0;
 			px_vector = 0;
 			py_vector = 0;
-			z_vector = 0;
 		}
 	}
 }


### PR DESCRIPTION
The Pinguem.ru competition on finding errors in open source projects. Warnings, found using PVS-Studio:
FreeRDP/client/X11/xf_input.c	272	warn	V519 The 'px_vector' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 271, 272.
FreeRDP/client/X11/xf_input.c	286	warn	V519 The 'px_vector' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 285, 286.
FreeRDP/client/X11/xf_input.c	305	warn	V519 The 'py_vector' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 303, 305.
FreeRDP/client/X11/xf_input.c	319	warn	V519 The 'py_vector' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 317, 319.
FreeRDP/client/X11/xf_input.c	349	warn	V519 The 'z_vector' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 346, 349.
FreeRDP/client/X11/xf_input.c	373	warn	V519 The 'z_vector' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 370, 373.
FreeRDP/client/X11/xf_input.c	384	warn	V519 The 'z_vector' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 381, 384.