### PR TITLE
codec/nsc: fix memory corruption in case of chroma subsampling

### DIFF
--- a/libfreerdp/codec/nsc_encode.c
+++ b/libfreerdp/codec/nsc_encode.c
@@ -237,9 +237,13 @@ static void nsc_encode_argb_to_aycocg(NSC_CONTEXT* context, const BYTE* data,
 
 	if (context->ChromaSubsamplingLevel && (y % 2) == 1)
 	{
-		CopyMemory(yplane + rw, yplane, rw);
-		CopyMemory(coplane + rw, coplane, rw);
-		CopyMemory(cgplane + rw, cgplane, rw);
+		yplane = context->priv->PlaneBuffers[0] + y * rw;
+		coplane = context->priv->PlaneBuffers[1] + y * rw;
+		cgplane = context->priv->PlaneBuffers[2] + y * rw;
+
+		CopyMemory(yplane, yplane - rw, rw);
+		CopyMemory(coplane, coplane - rw, rw);
+		CopyMemory(cgplane, cgplane - rw, rw);
 	}
 }
 

--- a/libfreerdp/codec/nsc_sse2.c
+++ b/libfreerdp/codec/nsc_sse2.c
@@ -326,9 +326,13 @@ static void nsc_encode_argb_to_aycocg_sse2(NSC_CONTEXT* context,
 
 	if (context->ChromaSubsamplingLevel > 0 && (y % 2) == 1)
 	{
-		CopyMemory(yplane + rw, yplane, rw);
-		CopyMemory(coplane + rw, coplane, rw);
-		CopyMemory(cgplane + rw, cgplane, rw);
+		yplane = context->priv->PlaneBuffers[0] + y * rw;
+		coplane = context->priv->PlaneBuffers[1] + y * rw;
+		cgplane = context->priv->PlaneBuffers[2] + y * rw;
+
+		CopyMemory(yplane, yplane - rw, rw);
+		CopyMemory(coplane, coplane - rw, rw);
+		CopyMemory(cgplane, cgplane - rw, rw);
 	}
 }
 


### PR DESCRIPTION
For odd number of rows, the memory copy operation was broken: after exiting
the loop, yplane points to the end of the last row data, and thus (yplane +
rw) points *after* the end of the last row.