### PR TITLE
core/connection: use redirection password when reconnecting

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -366,6 +366,22 @@ BOOL rdp_client_redirect(rdpRdp* rdp)
 			return FALSE;
 	}
 
+	if (settings->RedirectionFlags & LB_PASSWORD)
+	{
+		char *password = NULL;
+
+		/* If unicode conversion fails, this might be because the Password field
+		 * might contain a non-unicode cookie value. Simply ignore in this case. */
+		if (ConvertFromUnicode(CP_UTF8, 0,
+			 (WCHAR*) settings->RedirectionPassword, settings->RedirectionPasswordLength,
+			 &password, 0,
+			 NULL, NULL) > 0)
+		{
+			free(settings->Password);
+			settings->Password = password;
+		}
+	}
+
 	status = rdp_client_connect(rdp);
 
 	return status;


### PR DESCRIPTION
According to MS-RDPBCGR the server might send a password in the Redirection PDU
that then must be sent by the client to the server as password.

Since the field either contains a password string (unicode) or a binary cookie,
we try to convert the password from unicode and use it only if conversion
succeeds.