### PR TITLE
libfreerdp/core/certificate: open key file for reading only

### DIFF
--- a/libfreerdp/core/certificate.c
+++ b/libfreerdp/core/certificate.c
@@ -753,7 +753,7 @@ rdpRsaKey* key_new(const char* keyfile)
 	char* buffer = NULL;
 	rdpRsaKey* key = NULL;
 
-	fp = fopen(keyfile, "r+b");
+	fp = fopen(keyfile, "rb");
 	if (!fp)
 	{
 		WLog_ERR(TAG, "unable to open RSA key file %s: %s.", keyfile, strerror(errno));


### PR DESCRIPTION
There's no point in writing the key file for read-write, and it makes it
impossible to run the shadow server with the key file being read only.