### PR TITLE
core/connection: handle trailing zeroes in redirection password

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -373,7 +373,7 @@ BOOL rdp_client_redirect(rdpRdp* rdp)
 		/* If unicode conversion fails, this might be because the Password field
 		 * might contain a non-unicode cookie value. Simply ignore in this case. */
 		if (ConvertFromUnicode(CP_UTF8, 0,
-			 (WCHAR*) settings->RedirectionPassword, settings->RedirectionPasswordLength,
+			 (WCHAR*) settings->RedirectionPassword, -1,
 			 &password, 0,
 			 NULL, NULL) > 0)
 		{


### PR DESCRIPTION
According to MS-RDPBCGR the Password field in the Redirection PDU
should be null-terminated. In that case the trailing zeroes are part of
settings->RedirectionPasswordLength.

Unfortunately, if that is the case, ConvertFromUnicode() fails if we use
RedirectionPasswordLength as the length of the password because the
trailing zeroes cannot be converted.

Since the redirection PDU is always copied in
rdp_redirection_apply_settings() so that the buffer contains an extra
trailing zero wchar_t, it's safe to pass -1 as the length of the string
to ConvertFromUnicode().