### PR TITLE
Enable FIPS mode automatically

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2827,17 +2827,6 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		settings->ColorDepth = 32;
 	}
 
-	/* FIPS Mode forces the following and overrides the following(by happening later */
-	/* in the command line processing): */
-	/* 1. Disables NLA Security since NLA in freerdp uses NTLM(no Kerberos support yet) which uses algorithms */
-	/*      not allowed in FIPS for sensitive data. So, we disallow NLA when FIPS is required. */
-	/* 2. Forces the only supported RDP encryption method to be FIPS. */
-	if (settings->FIPSMode)
-	{
-		settings->NlaSecurity = FALSE;
-		settings->EncryptionMethods = ENCRYPTION_METHOD_FIPS;
-	}
-
 	arg = CommandLineFindArgumentA(args, "port");
 
 	if (arg->Flags & COMMAND_LINE_ARGUMENT_PRESENT)

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -186,6 +186,17 @@ BOOL rdp_client_connect(rdpRdp* rdp)
 		flags |= WINPR_SSL_INIT_ENABLE_FIPS;
 	winpr_InitializeSSL(flags);
 
+	/* FIPS Mode forces the following and overrides the following(by happening later */
+	/* in the command line processing): */
+	/* 1. Disables NLA Security since NLA in freerdp uses NTLM(no Kerberos support yet) which uses algorithms */
+	/*      not allowed in FIPS for sensitive data. So, we disallow NLA when FIPS is required. */
+	/* 2. Forces the only supported RDP encryption method to be FIPS. */
+	if (settings->FIPSMode || winpr_FIPSMode())
+	{
+		settings->NlaSecurity = FALSE;
+		settings->EncryptionMethods = ENCRYPTION_METHOD_FIPS;
+	}
+
 	nego_init(rdp->nego);
 	nego_set_target(rdp->nego, settings->ServerHostname, settings->ServerPort);
 

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -615,7 +615,6 @@ BOOL freerdp_context_new(freerdp* instance)
 	rdpRdp* rdp;
 	rdpContext* context;
 	BOOL ret = TRUE;
-	DWORD flags = WINPR_SSL_INIT_DEFAULT;
 	instance->context = (rdpContext*) calloc(1, instance->ContextSize);
 
 	if (!instance->context)

--- a/winpr/include/winpr/ssl.h
+++ b/winpr/include/winpr/ssl.h
@@ -38,6 +38,8 @@ extern "C" {
 WINPR_API BOOL winpr_InitializeSSL(DWORD flags);
 WINPR_API BOOL winpr_CleanupSSL(DWORD flags);
 
+WINPR_API BOOL winpr_FIPSMode(void);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/winpr/libwinpr/utils/ssl.c
+++ b/winpr/libwinpr/utils/ssl.c
@@ -346,6 +346,15 @@ BOOL winpr_CleanupSSL(DWORD flags)
 	return TRUE;
 }
 
+BOOL winpr_FIPSMode(void)
+{
+#if (OPENSSL_VERSION_NUMBER < 0x10001000L)
+	return FALSE;
+#else
+	return (FIPS_mode() == 1);
+#endif
+}
+
 #else
 
 BOOL winpr_InitializeSSL(DWORD flags)
@@ -356,6 +365,11 @@ BOOL winpr_InitializeSSL(DWORD flags)
 BOOL winpr_CleanupSSL(DWORD flags)
 {
 	return TRUE;
+}
+
+BOOL winpr_FIPSMode(void)
+{
+	return FALSE;
 }
 
 #endif


### PR DESCRIPTION
FreeRDP aborts if OpenSSL operates in FIPS mode and +fipsmode is not manually specified. Let's prevent the abortion and enable the necessary options in that case automatically.