### PR TITLE
Fix #3602 by preventing to poll stdin

### DIFF
--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -735,6 +735,15 @@ int tls_do_handshake(rdpTls* tls, BOOL clientMode)
 		pollfds.events = POLLIN;
 		pollfds.revents = 0;
 
+		/*
+		 * This is a hotfix for #3602.
+		 * The condition fd == 0 should actually never hold
+		 */
+		if (fd == STDIN_FILENO)
+		{
+			continue;
+		}
+
 		do
 		{
 			status = poll(&pollfds, 1, 10 * 1000);


### PR DESCRIPTION
This pull request avoids that standard input is polled by error.

Fixes #3602

There might be another bug inside the SSL BIO handling where a FD is not initialized correctly / "on time", which is fixed by this.