### PR TITLE
Use redirection password

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -385,22 +385,6 @@ BOOL rdp_client_redirect(rdpRdp* rdp)
 			return FALSE;
 	}
 
-	if (settings->RedirectionFlags & LB_PASSWORD)
-	{
-		char *password = NULL;
-
-		/* If unicode conversion fails, this might be because the Password field
-		 * might contain a non-unicode cookie value. Simply ignore in this case. */
-		if (ConvertFromUnicode(CP_UTF8, 0,
-			 (WCHAR*) settings->RedirectionPassword, settings->RedirectionPasswordLength,
-			 &password, 0,
-			 NULL, NULL) > 0)
-		{
-			free(settings->Password);
-			settings->Password = password;
-		}
-	}
-
 	status = rdp_client_connect(rdp);
 
 	return status;

--- a/winpr/include/winpr/sspi.h
+++ b/winpr/include/winpr/sspi.h
@@ -1134,6 +1134,9 @@ WINPR_API void sspi_SecBufferFree(PSecBuffer SecBuffer);
 
 WINPR_API int sspi_SetAuthIdentity(SEC_WINNT_AUTH_IDENTITY* identity, const char* user,
                                    const char* domain, const char* password);
+WINPR_API int sspi_SetAuthIdentityWithUnicodePassword(SEC_WINNT_AUTH_IDENTITY* identity,
+                                                      const char *user, const char *domain,
+                                                      LPWSTR password, ULONG passwordLength);
 WINPR_API int sspi_CopyAuthIdentity(SEC_WINNT_AUTH_IDENTITY* identity,
                                     SEC_WINNT_AUTH_IDENTITY* srcIdentity);
 


### PR DESCRIPTION
This pull request implements using the redirection password (if present) in NLA authentication performed after a redirection.

This is required because according to MS-RDPBCGR the password field of a Redirection PDU is:

> A variable-length array of bytes containing the password used by the user in
Unicode format, including a null-terminator, or a cookie value that MUST be passed to the target
server on successful connection.

Also, with this change it's no longer meaningful to try to set settings->Password to an UTF-8 encoded representation of settings->RedirectionPassword so that change is reverted.