### PR TITLE
Dynamic resolution improvements

### DIFF
--- a/client/X11/xf_disp.h
+++ b/client/X11/xf_disp.h
@@ -32,7 +32,7 @@ FREERDP_API BOOL xf_disp_init(xfContext* xfc, DispClientContext *disp);
 xfDispContext *xf_disp_new(xfContext* xfc);
 void xf_disp_free(xfDispContext *disp);
 BOOL xf_disp_handle_xevent(xfContext *xfc, XEvent *event);
-BOOL xf_disp_handle_resize(xfContext *xfc, int width, int height);
+BOOL xf_disp_handle_configureNotify(xfContext *xfc, int width, int height);
 void xf_disp_resized(xfDispContext *disp);
 
 #endif /* FREERDP_CLIENT_X11_DISP_H */

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -673,7 +673,7 @@ static BOOL xf_event_ConfigureNotify(xfContext* xfc, XEvent* event, BOOL app)
 			alignedHeight = (xfc->window->height / 2) * 2;
 
 			/* ask the server to resize using the display channel */
-			xf_disp_handle_resize(xfc, alignedWidth, alignedHeight);
+			xf_disp_handle_configureNotify(xfc, alignedWidth, alignedHeight);
 		}
 
 		return TRUE;

--- a/include/freerdp/event.h
+++ b/include/freerdp/event.h
@@ -66,6 +66,10 @@ DEFINE_EVENT_BEGIN(ErrorInfo)
 UINT32 code;
 DEFINE_EVENT_END(ErrorInfo)
 
+DEFINE_EVENT_BEGIN(Activated)
+BOOL firstActivation;
+DEFINE_EVENT_END(Activated)
+
 DEFINE_EVENT_BEGIN(Terminate)
 int code;
 DEFINE_EVENT_END(Terminate)
@@ -99,6 +103,10 @@ UINT16 flags;
 UINT16 x;
 UINT16 y;
 DEFINE_EVENT_END(MouseEvent)
+
+DEFINE_EVENT_BEGIN(Timer)
+UINT64 now;
+DEFINE_EVENT_END(Timer)
 
 #ifdef	__cplusplus
 }

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -600,6 +600,8 @@ static wEventType FreeRDP_Events[] =
 	DEFINE_EVENT_ENTRY(ChannelConnected)
 	DEFINE_EVENT_ENTRY(ChannelDisconnected)
 	DEFINE_EVENT_ENTRY(MouseEvent)
+	DEFINE_EVENT_ENTRY(Activated)
+	DEFINE_EVENT_ENTRY(Timer)
 };
 
 /** Allocator function for a rdp context.

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1438,7 +1438,15 @@ int rdp_recv_callback(rdpTransport* transport, wStream* s, void* extra)
 
 			if ((status >= 0) && (rdp->finalize_sc_pdus == FINALIZE_SC_COMPLETE))
 			{
+				ActivatedEventArgs activatedEvent;
+				rdpContext *context = rdp->context;
+
 				rdp_client_transition_to_state(rdp, CONNECTION_STATE_ACTIVE);
+
+				EventArgsInit(&activatedEvent, "xfreerdp");
+				activatedEvent.firstActivation = !rdp->deactivation_reactivation;
+				PubSub_OnActivated(context->pubSub, context, &activatedEvent);
+
 				return 2;
 			}
 			if (status < 0)


### PR DESCRIPTION
This PR introduces a new Activated event that is triggered when a (re)activation sequence has completed. This is needed as the DesktopResize callback is called just after capabilities, that means that the activation sequence is not completed (and so we theoretically can't send any packet).
As the goal was to limit the number of resize requests, we also introduced a Timer event that is triggered every 100ms, it is used by the display implementation for X11 to send resizes not more than every 200 ms. But the timer event could be used by any other channel.