### PR TITLE
Activated address sanitizer for nightly builds.

### DIFF
--- a/packaging/deb/freerdp-nightly/rules
+++ b/packaging/deb/freerdp-nightly/rules
@@ -16,10 +16,11 @@ DEB_CMAKE_EXTRA_FLAGS :=  -DCMAKE_SKIP_RPATH=FALSE \
                           -DCHANNEL_URBDRC_CLIENT=ON \
                           -DWITH_SERVER=ON \
                           -DBUILD_TESTING=OFF \
-                          -DCMAKE_BUILD_TYPE=RELWITHDEBINFO \
+                          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                           -DCMAKE_INSTALL_PREFIX=/opt/freerdp-nightly/ \
                           -DCMAKE_INSTALL_INCLUDEDIR=include \
                           -DCMAKE_INSTALL_LIBDIR=lib \
+                          -DWITH_SANITIZE_ADDRESS=ON \
                           $(NULL)
 
 %:

--- a/packaging/rpm/freerdp-nightly.spec
+++ b/packaging/rpm/freerdp-nightly.spec
@@ -105,7 +105,8 @@ based on freerdp and winpr.
         -DCHANNEL_URBDRC_CLIENT=ON \
         -DWITH_SERVER=ON \
         -DBUILD_TESTING=OFF \
-        -DCMAKE_BUILD_TYPE=RELWITHDEBINFO \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DWITH_SANITIZE_ADDRESS=ON \
         -DCMAKE_INSTALL_PREFIX=%{INSTALL_PREFIX} \
 %if %{defined suse_version}
 	-DCMAKE_NO_BUILTIN_CHRPATH=ON \


### PR DESCRIPTION
Since we ship debug symbols with the nightly builds it would be nice to get proper stack traces on memory issues without users having to do anything but copy the console output.