### PR TITLE
Ensure HTML Format clipboard synthesizer always converts number strings as if they are in base 10

### DIFF
--- a/winpr/libwinpr/clipboard/synthetic.c
+++ b/winpr/libwinpr/clipboard/synthetic.c
@@ -439,12 +439,12 @@ static void* clipboard_synthesize_text_html(wClipboard* clipboard, UINT32 format
 			return NULL;
 
 		errno = 0;
-		beg = strtol(&begStr[10], NULL, 0);
+		beg = strtol(&begStr[10], NULL, 10);
 
 		if (errno != 0)
 			return NULL;
 
-		end = strtol(&endStr[8], NULL, 0);
+		end = strtol(&endStr[8], NULL, 10);
 
 		if (beg < 0 || end < 0 || (beg > SrcSize) || (end > SrcSize) || (beg >= end) || (errno != 0))
 			return NULL;


### PR DESCRIPTION
`StartHTML` and `EndHTML` values can be left-padded with an arbitrary number of the `0` character ( per https://msdn.microsoft.com/en-us/library/windows/desktop/ms649015(v=vs.85).aspx ).

`strtol` and friends treat this as base-8 if base is specified as `0`.

Because these values are always sent in base-10 (not stated but implied in the article linked above), the fix is to always use base-10.