### PR TITLE
New defaults for command line

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.h
+++ b/channels/rdpgfx/client/rdpgfx_main.h
@@ -61,6 +61,7 @@ struct _RDPGFX_PLUGIN
 
 	rdpSettings* settings;
 
+	BOOL CapsFlags;
 	BOOL ThinClient;
 	BOOL SmallCache;
 	BOOL Progressive;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -48,6 +48,7 @@
 #include <freerdp/log.h>
 #define TAG CLIENT_TAG("common.cmdline")
 
+
 BOOL freerdp_client_print_version(void)
 {
 	printf("This is FreeRDP version %s (%s)\n", FREERDP_VERSION_FULL,
@@ -745,27 +746,27 @@ static int freerdp_client_command_line_post_filter(void* context,
 	}
 	CommandLineSwitchCase(arg, "multitouch")
 	{
-		settings->MultiTouchInput = TRUE;
+		settings->MultiTouchInput = arg->Value ? TRUE : FALSE;
 	}
 	CommandLineSwitchCase(arg, "gestures")
 	{
-		settings->MultiTouchGestures = TRUE;
+		settings->MultiTouchGestures = arg->Value ? TRUE : FALSE;
 	}
 	CommandLineSwitchCase(arg, "echo")
 	{
-		settings->SupportEchoChannel = TRUE;
+		settings->SupportEchoChannel = arg->Value ? TRUE : FALSE;
 	}
 	CommandLineSwitchCase(arg, "ssh-agent")
 	{
-		settings->SupportSSHAgentChannel = TRUE;
+		settings->SupportSSHAgentChannel = arg->Value ? TRUE : FALSE;
 	}
 	CommandLineSwitchCase(arg, "disp")
 	{
-		settings->SupportDisplayControl = TRUE;
+		settings->SupportDisplayControl = arg->Value ? TRUE : FALSE;
 	}
 	CommandLineSwitchCase(arg, "geometry")
 	{
-		settings->SupportGeometryTracking = TRUE;
+		settings->SupportGeometryTracking = arg->Value ? TRUE : FALSE;
 	}
 	CommandLineSwitchCase(arg, "sound")
 	{
@@ -796,17 +797,17 @@ static int freerdp_client_command_line_post_filter(void* context,
 	}
 	CommandLineSwitchCase(arg, "heartbeat")
 	{
-		settings->SupportHeartbeatPdu = TRUE;
+		settings->SupportHeartbeatPdu = arg->Value ? TRUE : FALSE;
 	}
 	CommandLineSwitchCase(arg, "multitransport")
 	{
-		settings->SupportMultitransport = TRUE;
+		settings->SupportMultitransport = arg->Value ? TRUE : FALSE;
 		settings->MultitransportFlags = (TRANSPORT_TYPE_UDP_FECR |
 		                                 TRANSPORT_TYPE_UDP_FECL | TRANSPORT_TYPE_UDP_PREFERRED);
 	}
 	CommandLineSwitchCase(arg, "password-is-pin")
 	{
-		settings->PasswordIsSmartcardPin = TRUE;
+		settings->PasswordIsSmartcardPin = arg->Value ? TRUE : FALSE;
 	}
 	CommandLineSwitchEnd(arg)
 	return status ? 1 : -1;
@@ -1343,7 +1344,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 	do
 	{
-		if (!(arg->Flags & COMMAND_LINE_ARGUMENT_PRESENT))
+		if (CommandLineIgnoreArgument(arg))
 			continue;
 
 		CommandLineSwitchStart(arg)
@@ -1530,7 +1531,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "f")
 		{
-			settings->Fullscreen = TRUE;
+			settings->Fullscreen = arg->Value ? TRUE : FALSE;
 		}
 		CommandLineSwitchCase(arg, "multimon")
 		{
@@ -1546,11 +1547,11 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "span")
 		{
-			settings->SpanMonitors = TRUE;
+			settings->SpanMonitors = arg->Value ? TRUE : FALSE;
 		}
 		CommandLineSwitchCase(arg, "workarea")
 		{
-			settings->Workarea = TRUE;
+			settings->Workarea = arg->Value ? TRUE : FALSE;
 		}
 		CommandLineSwitchCase(arg, "monitors")
 		{
@@ -1584,7 +1585,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "monitor-list")
 		{
-			settings->ListMonitors = TRUE;
+			settings->ListMonitors = arg->Value ? TRUE : FALSE;
 		}
 		CommandLineSwitchCase(arg, "t")
 		{
@@ -1599,24 +1600,12 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "dynamic-resolution")
 		{
-			if (settings->SmartSizing)
-			{
-				WLog_ERR(TAG, "Smart sizing and dynamic resolution are mutually exclusive options");
-				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
-			}
-
-			settings->SupportDisplayControl = TRUE;
-			settings->DynamicResolutionUpdate = TRUE;
+			settings->SupportDisplayControl = arg->Value ? TRUE : FALSE;
+			settings->DynamicResolutionUpdate = arg->Value ? TRUE : FALSE;
 		}
 		CommandLineSwitchCase(arg, "smart-sizing")
 		{
-			if (settings->DynamicResolutionUpdate)
-			{
-				WLog_ERR(TAG, "Smart sizing and dynamic resolution are mutually exclusive options");
-				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
-			}
-
-			settings->SmartSizing = TRUE;
+			settings->SmartSizing = arg->Value ? TRUE : FALSE;
 
 			if (arg->Value)
 			{
@@ -1674,12 +1663,12 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "admin")
 		{
-			settings->ConsoleSession = TRUE;
+			settings->ConsoleSession = arg->Value ? TRUE : FALSE;
 		}
 		CommandLineSwitchCase(arg, "restricted-admin")
 		{
-			settings->ConsoleSession = TRUE;
-			settings->RestrictedAdminModeRequired = TRUE;
+			settings->ConsoleSession = arg->Value ? TRUE : FALSE;
+			settings->RestrictedAdminModeRequired = arg->Value ? TRUE : FALSE;
 		}
 		CommandLineSwitchCase(arg, "pth")
 		{
@@ -1997,7 +1986,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "ipv6")
 		{
-			settings->PreferIPv6OverIPv4 = TRUE;
+			settings->PreferIPv6OverIPv4 = arg->Value ? TRUE : FALSE;
 		}
 		CommandLineSwitchCase(arg, "clipboard")
 		{
@@ -2105,8 +2094,6 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "gfx")
 		{
-			settings->SupportGraphicsPipeline = TRUE;
-
 			if (arg->Value)
 			{
 #ifdef WITH_GFX_H264
@@ -2126,30 +2113,57 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 						return COMMAND_LINE_ERROR;
 			}
 		}
+		CommandLineSwitchCase(arg, "gfx-caps")
+		{
+			const char* cur;
+			char* delim = NULL;
+			settings->GfxCapsFlags = 0;
+			cur = arg->Value;
+
+			do
+			{
+				if (delim)
+					cur = delim + 1;
+
+				if (strncmp("8.1", cur, 3) == 0)
+					settings->GfxCapsFlags |= GFX_CAPS_81;
+				else if (strncmp("8", cur, 1) == 0)
+					settings->GfxCapsFlags |= GFX_CAPS_8;
+				else if (strncmp("10.3", cur, 4) == 0)
+					settings->GfxCapsFlags |= GFX_CAPS_103;
+				else if (strncmp("10.2", cur, 4) == 0)
+					settings->GfxCapsFlags |= GFX_CAPS_102;
+				else if (strncmp("10", cur, 2) == 0)
+					settings->GfxCapsFlags |= GFX_CAPS_10;
+				else if (strncmp("off", cur, 3) == 0)
+				{
+					settings->GfxCapsFlags = 0;
+					break;
+				}
+
+				delim = strchr(cur, ',');
+			}
+			while (delim != NULL);
+		}
 		CommandLineSwitchCase(arg, "gfx-thin-client")
 		{
 			settings->GfxThinClient = arg->Value ? TRUE : FALSE;
 
 			if (settings->GfxThinClient)
 				settings->GfxSmallCache = TRUE;
-
-			settings->SupportGraphicsPipeline = TRUE;
 		}
 		CommandLineSwitchCase(arg, "gfx-small-cache")
 		{
 			settings->GfxSmallCache = arg->Value ? TRUE : FALSE;
-			settings->SupportGraphicsPipeline = TRUE;
 		}
 		CommandLineSwitchCase(arg, "gfx-progressive")
 		{
 			settings->GfxProgressive = arg->Value ? TRUE : FALSE;
 			settings->GfxThinClient = settings->GfxProgressive ? FALSE : TRUE;
-			settings->SupportGraphicsPipeline = TRUE;
 		}
 #ifdef WITH_GFX_H264
 		CommandLineSwitchCase(arg, "gfx-h264")
 		{
-			settings->SupportGraphicsPipeline = TRUE;
 			settings->GfxH264 = TRUE;
 
 			if (arg->Value)
@@ -2165,7 +2179,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 #endif
 		CommandLineSwitchCase(arg, "rfx")
 		{
-			settings->RemoteFxCodec = TRUE;
+			settings->RemoteFxCodec = arg->Value ? TRUE : FALSE;
 		}
 		CommandLineSwitchCase(arg, "rfx-mode")
 		{
@@ -2185,12 +2199,12 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "nsc")
 		{
-			settings->NSCodec = TRUE;
+			settings->NSCodec = arg->Value ? TRUE : FALSE;
 		}
 #if defined(WITH_JPEG)
 		CommandLineSwitchCase(arg, "jpeg")
 		{
-			settings->JpegCodec = TRUE;
+			settings->JpegCodec = arg->Value ? TRUE : FALSE;
 			settings->JpegQuality = 75;
 		}
 		CommandLineSwitchCase(arg, "jpeg-quality")
@@ -2289,7 +2303,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "from-stdin")
 		{
-			settings->CredentialsFromStdin = TRUE;
+			settings->CredentialsFromStdin = arg->Value ? TRUE : FALSE;
 
 			if (arg->Flags & COMMAND_LINE_VALUE_PRESENT)
 			{
@@ -2356,11 +2370,11 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "cert-ignore")
 		{
-			settings->IgnoreCertificate = TRUE;
+			settings->IgnoreCertificate = arg->Value ? TRUE : FALSE;
 		}
 		CommandLineSwitchCase(arg, "cert-tofu")
 		{
-			settings->AutoAcceptCertificate = TRUE;
+			settings->AutoAcceptCertificate = arg->Value ? TRUE : FALSE;
 		}
 		CommandLineSwitchCase(arg, "authentication")
 		{
@@ -2629,14 +2643,17 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "action-script")
 		{
-			free(settings->ActionScript);
+			if (arg->Flags & COMMAND_LINE_ARGUMENT_PRESENT)
+			{
+				free(settings->ActionScript);
 
-			if (!(settings->ActionScript = _strdup(arg->Value)))
-				return COMMAND_LINE_ERROR_MEMORY;
+				if (!(settings->ActionScript = _strdup(arg->Value)))
+					return COMMAND_LINE_ERROR_MEMORY;
+			}
 		}
 		CommandLineSwitchCase(arg, "fipsmode")
 		{
-			settings->FIPSMode = TRUE;
+			settings->FIPSMode = arg->Value ? TRUE : FALSE;
 		}
 		CommandLineSwitchDefault(arg)
 		{
@@ -2644,6 +2661,13 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		CommandLineSwitchEnd(arg)
 	}
 	while ((arg = CommandLineFindNextArgumentA(arg)) != NULL);
+	if (settings->SmartSizing && settings->DynamicResolutionUpdate)
+	{
+		WLog_ERR(TAG, "Smart sizing and dynamic resolution are mutually exclusive options");
+		return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
+	}
+
+	settings->SupportGraphicsPipeline = (settings->GfxCapsFlags != 0);
 
 	if (user)
 	{

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -69,7 +69,7 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "f", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Fullscreen mode (<Ctrl>+<Alt>+<Enter> toggles fullscreen)" },
 	{ "fast-path", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "Enable fast-path input/output" },
 	{ "fipsmode", COMMAND_LINE_VALUE_BOOL, NULL, NULL, NULL, -1, NULL, "Enable FIPS mode" },
-	{ "fonts", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Enable smooth fonts (ClearType)" },
+	{ "fonts", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "Enable smooth fonts (ClearType)" },
 	{ "frame-ack", COMMAND_LINE_VALUE_REQUIRED, "<number>", NULL, NULL, -1, NULL, "Number of frame acknowledgement" },
 	{ "from-stdin", COMMAND_LINE_VALUE_OPTIONAL, "force", NULL, NULL, -1, NULL, "Read credentials from stdin. With <force> the prompt is done before connection, otherwise on server request." },
 	{ "g", COMMAND_LINE_VALUE_REQUIRED, "<gateway>[:<port>]", NULL, NULL, -1, NULL, "Gateway Hostname" },
@@ -79,11 +79,12 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "geometry", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Geometry tracking channel" },
 	{ "gestures", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Consume multitouch input locally" },
 #ifdef WITH_GFX_H264
-	{ "gfx", COMMAND_LINE_VALUE_OPTIONAL, "RFX|AVC420|AVC444", NULL, NULL, -1, NULL, "RDP8 graphics pipeline (experimental)" },
+	{ "gfx", COMMAND_LINE_VALUE_OPTIONAL, "RFX|AVC420|AVC444", NULL, NULL, -1, NULL, "RDP8 graphics pipeline" },
 	{ "gfx-h264", COMMAND_LINE_VALUE_OPTIONAL, "AVC420|AVC444", NULL, NULL, -1, NULL, "RDP8.1 graphics pipeline using H264 codec" },
 #else
-	{ "gfx", COMMAND_LINE_VALUE_OPTIONAL, "RFX", NULL, NULL, -1, NULL, "RDP8 graphics pipeline (experimental)" },
+	{ "gfx", COMMAND_LINE_VALUE_OPTIONAL, "RFX", NULL, NULL, -1, NULL, "RDP8 graphics pipeline" },
 #endif
+	{ "gfx-caps", COMMAND_LINE_VALUE_REQUIRED, "[<off>,<8>,<8.1>,<10>, <10.2>, <10.3>]", "10,10.2,10.3", NULL, -1, NULL, "RDP8 graphics pipeline supported versions, defaults to 10.3 only" },
 	{ "gfx-progressive", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "RDP8 graphics pipeline using progressive codec" },
 	{ "gfx-small-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "RDP8 graphics pipeline using small cache mode" },
 	{ "gfx-thin-client", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "RDP8 graphics pipeline using thin client mode" },
@@ -141,7 +142,7 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "pwidth", COMMAND_LINE_VALUE_REQUIRED, "<width>", NULL, NULL, -1, NULL, "Physical width of display (in millimeters)" },
 	{ "reconnect-cookie", COMMAND_LINE_VALUE_REQUIRED, "<base64-cookie>", NULL, NULL, -1, NULL, "Pass base64 reconnect cookie to the connection" },
 	{ "restricted-admin", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "restrictedAdmin", "Restricted admin mode" },
-	{ "rfx", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "RemoteFX" },
+	{ "rfx", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "RemoteFX (Windows 7)" },
 	{ "rfx-mode", COMMAND_LINE_VALUE_REQUIRED, "image|video", NULL, NULL, -1, NULL, "RemoteFX mode" },
 	{ "scale", COMMAND_LINE_VALUE_REQUIRED, "100|140|180", "100", NULL, -1, NULL, "Scaling factor of the display" },
 	{ "scale-desktop", COMMAND_LINE_VALUE_REQUIRED, "<percentage>", "100", NULL, -1, NULL, "Scaling factor for desktop applications (value between 100 and 500)" },

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -272,6 +272,13 @@ typedef struct _TARGET_NET_ADDRESS TARGET_NET_ADDRESS;
 #define ORIENTATION_LANDSCAPE_FLIPPED	180
 #define ORIENTATION_PORTRAIT_FLIPPED	270
 
+/* GFX capability version flags */
+#define GFX_CAPS_8	0x00000001
+#define GFX_CAPS_81	0x00000002
+#define GFX_CAPS_10	0x00000004
+#define GFX_CAPS_102	0x00000008
+#define GFX_CAPS_103	0x00000010
+
 /* ARC_CS_PRIVATE_PACKET */
 typedef struct
 {
@@ -1345,7 +1352,8 @@ struct rdp_settings
 	ALIGN64 BOOL GfxAVC444; /* 3845 */
 	ALIGN64 BOOL GfxSendQoeAck; /* 3846 */
 	ALIGN64 BOOL GfxAVC444v2; /* 3847 */
-	UINT64 padding3904[3904 - 3848]; /* 3848 */
+	ALIGN64 UINT32 GfxCapsFlags; /* 3848 */
+	UINT64 padding3904[3904 - 3849]; /* 3849 */
 
 	/**
 	 * Caches

--- a/winpr/include/winpr/cmdline.h
+++ b/winpr/include/winpr/cmdline.h
@@ -134,6 +134,22 @@ typedef int (*COMMAND_LINE_POST_FILTER_FN_W)(void* context, COMMAND_LINE_ARGUMEN
 extern "C" {
 #endif
 
+static INLINE BOOL CommandLineIgnoreArgument(const COMMAND_LINE_ARGUMENT_A* arg)
+{
+	if ((arg->Flags & COMMAND_LINE_ARGUMENT_PRESENT) == 0)
+	{
+		if ((arg->Flags & (COMMAND_LINE_VALUE_OPTIONAL | COMMAND_LINE_VALUE_REQUIRED)) &&
+		    (arg->Default != NULL))
+			return FALSE;
+
+		return arg->Flags & (COMMAND_LINE_VALUE_OPTIONAL |
+		                     COMMAND_LINE_VALUE_REQUIRED |
+		                     COMMAND_LINE_VALUE_FLAG);
+	}
+
+	return FALSE;
+}
+
 WINPR_API int CommandLineClearArgumentsA(COMMAND_LINE_ARGUMENT_A* options);
 WINPR_API int CommandLineClearArgumentsW(COMMAND_LINE_ARGUMENT_W* options);
 

--- a/winpr/libwinpr/utils/cmdline.c
+++ b/winpr/libwinpr/utils/cmdline.c
@@ -350,6 +350,25 @@ int CommandLineParseArgumentsA(int argc, LPCSTR* argv, COMMAND_LINE_ARGUMENT_A* 
 		}
 	}
 
+	/* copy defaults as value. */
+	{
+		COMMAND_LINE_ARGUMENT_A* iter = options;
+
+		while ((iter != NULL) && (iter->Name != NULL))
+		{
+			if ((iter->Flags & COMMAND_LINE_ARGUMENT_PRESENT) == 0)
+			{
+				if (iter->Flags & COMMAND_LINE_VALUE_BOOL)
+					iter->Value = (LPSTR)iter->Default;
+				else if (iter->Flags & COMMAND_LINE_VALUE_FLAG)
+					iter->Value = FALSE;
+				else if (iter->Default)
+					iter->Value = iter->Default;
+			}
+
+			iter++;
+		}
+	}
 	return status;
 }
 


### PR DESCRIPTION
* Fix a bug in the command line parser not using defaults provided
* Add a function to check, if a specific parameter has a value that needs to be evaluated.
* Added GFX capability announcement parameter
* Windows 7 RFX mode now enabled by default
* GFX mode now enabled by default (caps 10, 10.2 and 10.3, windows 10 only)
* By default enable font smoothing
