### PR TITLE
Using dynamic logger for GFX-H264 backend.

### DIFF
--- a/include/freerdp/codec/h264.h
+++ b/include/freerdp/codec/h264.h
@@ -77,6 +77,7 @@ struct _H264_CONTEXT
 	H264_CONTEXT_SUBSYSTEM* subsystem;
 
 	void* lumaData;
+	wLog* log;
 };
 #ifdef __cplusplus
 extern "C" {

--- a/include/freerdp/codec/h264.h
+++ b/include/freerdp/codec/h264.h
@@ -20,6 +20,8 @@
 #ifndef FREERDP_CODEC_H264_H
 #define FREERDP_CODEC_H264_H
 
+#include <winpr/wlog.h>
+
 #include <freerdp/api.h>
 #include <freerdp/types.h>
 #include <freerdp/channels/rdpgfx.h>

--- a/libfreerdp/codec/h264.c
+++ b/libfreerdp/codec/h264.c
@@ -315,7 +315,7 @@ static BOOL avc444_ensure_buffer(H264_CONTEXT* h264,
 	{
 		if (!ppYUVDstData[x] || (piDstSize[x] == 0) || (piDstStride[x] == 0))
 		{
-			WLog_ERR(TAG, "YUV buffer not initialized! check your decoder settings");
+			WLog_Print(h264->log, WLOG_ERROR, "YUV buffer not initialized! check your decoder settings");
 			goto fail;
 		}
 	}
@@ -471,9 +471,9 @@ INT32 avc444_decompress(H264_CONTEXT* h264, BYTE op,
 			break;
 	}
 
-	WLog_INFO(TAG,
-	          "luma=%"PRIu64" [avg=%lf] chroma=%"PRIu64" [avg=%lf] combined=%"PRIu64" [avg=%lf]",
-	          op1, op1sum, op2, op2sum, op3, op3sum);
+	WLog_Print(h264->log, WLOG_INFO,
+	           "luma=%"PRIu64" [avg=%lf] chroma=%"PRIu64" [avg=%lf] combined=%"PRIu64" [avg=%lf]",
+	           op1, op1sum, op2, op2sum, op3, op3sum);
 #endif
 	return status;
 }
@@ -526,6 +526,11 @@ BOOL h264_context_init(H264_CONTEXT* h264)
 	int i;
 
 	if (!h264)
+		return FALSE;
+
+	h264->log = WLog_Get(TAG);
+
+	if (!h264->log)
 		return FALSE;
 
 	h264->subsystem = NULL;

--- a/libfreerdp/codec/h264_ffmpeg.c
+++ b/libfreerdp/codec/h264_ffmpeg.c
@@ -453,7 +453,8 @@ static void libavcodec_uninit(H264_CONTEXT* h264)
 static enum AVPixelFormat libavcodec_get_format(struct AVCodecContext* ctx,
         const enum AVPixelFormat* fmts)
 {
-	H264_CONTEXT_LIBAVCODEC* sys = (H264_CONTEXT_LIBAVCODEC*) ctx->opaque;
+	H264_CONTEXT* h264 = (H264_CONTEXT*) ctx->opaque;
+	H264_CONTEXT_LIBAVCODEC* sys = (H264_CONTEXT_LIBAVCODEC*) h264->subsystem;
 	const enum AVPixelFormat* p;
 
 	for (p = fmts; *p != AV_PIX_FMT_NONE; p++)
@@ -554,7 +555,7 @@ static BOOL libavcodec_init(H264_CONTEXT* h264)
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 80, 100)
 		sys->codecDecoderContext->hw_device_ctx = av_buffer_ref(sys->hwctx);
 #endif
-		sys->codecDecoderContext->opaque = (void*) sys;
+		sys->codecDecoderContext->opaque = (void*) h264;
 	fail_hwdevice_create:
 #endif
 

--- a/libfreerdp/codec/h264_ffmpeg.c
+++ b/libfreerdp/codec/h264_ffmpeg.c
@@ -204,7 +204,7 @@ static int libavcodec_decompress(H264_CONTEXT* h264, const BYTE* pSrcData,
 
 	if (status < 0)
 	{
-		WLog_ERR(TAG, "Failed to decode video frame (%s)", av_err2str(status));
+		WLog_Print(h264->log, WLOG_ERROR, "Failed to decode video frame (status=%d)", status);
 		return -1;
 	}
 
@@ -235,7 +235,7 @@ static int libavcodec_decompress(H264_CONTEXT* h264, const BYTE* pSrcData,
 
 	if (status < 0)
 	{
-		WLog_ERR(TAG, "Failed to decode video frame (status=%d)", status);
+		WLog_Print(h264->log, WLOG_ERROR, "Failed to decode video frame (status=%d)", status);
 		return -1;
 	}
 
@@ -259,18 +259,18 @@ static int libavcodec_decompress(H264_CONTEXT* h264, const BYTE* pSrcData,
 
 	if (status < 0)
 	{
-		WLog_ERR(TAG, "Failed to transfer video frame (status=%d) (%s)", status, av_err2str(status));
+		WLog_Print(h264->log, WLOG_ERROR, "Failed to transfer video frame (status=%d) (%s)", status, av_err2str(status));
 		return -1;
 	}
 
 #endif
 #if 0
-	WLog_INFO(TAG,
-	          "libavcodec_decompress: frame decoded (status=%d, gotFrame=%d, width=%d, height=%d, Y=[%p,%d], U=[%p,%d], V=[%p,%d])",
-	          status, gotFrame, sys->videoFrame->width, sys->videoFrame->height,
-	          (void*) sys->videoFrame->data[0], sys->videoFrame->linesize[0],
-	          (void*) sys->videoFrame->data[1], sys->videoFrame->linesize[1],
-	          (void*) sys->videoFrame->data[2], sys->videoFrame->linesize[2]);
+	WLog_Print(h264->log, WLOG_INFO, (TAG,
+	                                  "libavcodec_decompress: frame decoded (status=%d, gotFrame=%d, width=%d, height=%d, Y=[%p,%d], U=[%p,%d], V=[%p,%d])",
+	                                  status, gotFrame, sys->videoFrame->width, sys->videoFrame->height,
+	                                  (void*) sys->videoFrame->data[0], sys->videoFrame->linesize[0],
+	                                  (void*) sys->videoFrame->data[1], sys->videoFrame->linesize[1],
+	                                  (void*) sys->videoFrame->data[2], sys->videoFrame->linesize[2]);
 #endif
 
 	if (gotFrame)
@@ -330,8 +330,8 @@ static int libavcodec_compress(H264_CONTEXT* h264, const BYTE** pSrcYuv, const U
 
 	if (status < 0)
 	{
-		WLog_ERR(TAG, "Failed to encode video frame (%s [%d])",
-		         av_err2str(status), status);
+		WLog_Print(h264->log, WLOG_ERROR, "Failed to encode video frame (%s [%d])",
+		           av_err2str(status), status);
 		return -1;
 	}
 
@@ -340,8 +340,8 @@ static int libavcodec_compress(H264_CONTEXT* h264, const BYTE** pSrcYuv, const U
 
 	if (status < 0)
 	{
-		WLog_ERR(TAG, "Failed to encode video frame (%s [%d])",
-		         av_err2str(status), status);
+		WLog_Print(h264->log, WLOG_ERROR, "Failed to encode video frame (%s [%d])",
+		           av_err2str(status), status);
 		return -1;
 	}
 
@@ -374,8 +374,8 @@ static int libavcodec_compress(H264_CONTEXT* h264, const BYTE** pSrcYuv, const U
 
 	if (status < 0)
 	{
-		WLog_ERR(TAG, "Failed to encode video frame (%s [%d])",
-		         av_err2str(status), status);
+		WLog_Print(h264->log, WLOG_ERROR, "Failed to encode video frame (%s [%d])",
+		           av_err2str(status), status);
 		return -1;
 	}
 
@@ -384,7 +384,7 @@ static int libavcodec_compress(H264_CONTEXT* h264, const BYTE** pSrcYuv, const U
 
 	if (!gotFrame)
 	{
-		WLog_ERR(TAG, "Did not get frame! (%s [%d])", av_err2str(status), status);
+		WLog_Print(h264->log, WLOG_ERROR, "Did not get frame! (%s [%d])", av_err2str(status), status);
 		return -2;
 	}
 
@@ -486,7 +486,7 @@ static enum AVPixelFormat libavcodec_get_format(struct AVCodecContext* ctx,
 
 			if (err < 0)
 			{
-				WLog_ERR(TAG, "Could not init hwframes context: %s", av_err2str(err));
+				WLog_Print(h264->log, WLOG_ERROR, "Could not init hwframes context: %s", av_err2str(err));
 				return AV_PIX_FMT_NONE;
 			}
 
@@ -519,7 +519,7 @@ static BOOL libavcodec_init(H264_CONTEXT* h264)
 
 		if (!sys->codecDecoder)
 		{
-			WLog_ERR(TAG, "Failed to find libav H.264 codec");
+			WLog_Print(h264->log, WLOG_ERROR, "Failed to find libav H.264 codec");
 			goto EXCEPTION;
 		}
 
@@ -527,7 +527,7 @@ static BOOL libavcodec_init(H264_CONTEXT* h264)
 
 		if (!sys->codecDecoderContext)
 		{
-			WLog_ERR(TAG, "Failed to allocate libav codec context");
+			WLog_Print(h264->log, WLOG_ERROR, "Failed to allocate libav codec context");
 			goto EXCEPTION;
 		}
 
@@ -544,7 +544,7 @@ static BOOL libavcodec_init(H264_CONTEXT* h264)
 
 			if (ret < 0)
 			{
-				WLog_ERR(TAG, "Could not initialize hardware decoder, falling back to software: %s",
+				WLog_Print(h264->log, WLOG_ERROR, "Could not initialize hardware decoder, falling back to software: %s",
 				         av_err2str(ret));
 				sys->hwctx = NULL;
 				goto fail_hwdevice_create;
@@ -562,7 +562,7 @@ static BOOL libavcodec_init(H264_CONTEXT* h264)
 
 		if (avcodec_open2(sys->codecDecoderContext, sys->codecDecoder, NULL) < 0)
 		{
-			WLog_ERR(TAG, "Failed to open libav codec");
+			WLog_Print(h264->log, WLOG_ERROR, "Failed to open libav codec");
 			goto EXCEPTION;
 		}
 
@@ -570,7 +570,7 @@ static BOOL libavcodec_init(H264_CONTEXT* h264)
 
 		if (!sys->codecParser)
 		{
-			WLog_ERR(TAG, "Failed to initialize libav parser");
+			WLog_Print(h264->log, WLOG_ERROR, "Failed to initialize libav parser");
 			goto EXCEPTION;
 		}
 	}
@@ -586,7 +586,7 @@ static BOOL libavcodec_init(H264_CONTEXT* h264)
 
 	if (!sys->videoFrame)
 	{
-		WLog_ERR(TAG, "Failed to allocate libav frame");
+		WLog_Print(h264->log, WLOG_ERROR, "Failed to allocate libav frame");
 		goto EXCEPTION;
 	}
 
@@ -594,7 +594,7 @@ static BOOL libavcodec_init(H264_CONTEXT* h264)
 
 	if (!sys->hwVideoFrame)
 	{
-		WLog_ERR(TAG, "Failed to allocate libav hw frame");
+		WLog_Print(h264->log, WLOG_ERROR, "Failed to allocate libav hw frame");
 		goto EXCEPTION;
 	}
 

--- a/libfreerdp/codec/h264_ffmpeg.c
+++ b/libfreerdp/codec/h264_ffmpeg.c
@@ -37,8 +37,6 @@
 #endif
 #endif
 
-#define TAG FREERDP_TAG("codec")
-
 /* Fallback support for older libavcodec versions */
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(54, 59, 100)
 #define AV_CODEC_ID_H264 CODEC_ID_H264
@@ -265,12 +263,12 @@ static int libavcodec_decompress(H264_CONTEXT* h264, const BYTE* pSrcData,
 
 #endif
 #if 0
-	WLog_Print(h264->log, WLOG_INFO, (TAG,
-	                                  "libavcodec_decompress: frame decoded (status=%d, gotFrame=%d, width=%d, height=%d, Y=[%p,%d], U=[%p,%d], V=[%p,%d])",
-	                                  status, gotFrame, sys->videoFrame->width, sys->videoFrame->height,
-	                                  (void*) sys->videoFrame->data[0], sys->videoFrame->linesize[0],
-	                                  (void*) sys->videoFrame->data[1], sys->videoFrame->linesize[1],
-	                                  (void*) sys->videoFrame->data[2], sys->videoFrame->linesize[2]);
+	WLog_Print(h264->log, WLOG_INFO,
+	           "libavcodec_decompress: frame decoded (status=%d, gotFrame=%d, width=%d, height=%d, Y=[%p,%d], U=[%p,%d], V=[%p,%d])",
+	           status, gotFrame, sys->videoFrame->width, sys->videoFrame->height,
+	           (void*) sys->videoFrame->data[0], sys->videoFrame->linesize[0],
+	           (void*) sys->videoFrame->data[1], sys->videoFrame->linesize[1],
+	           (void*) sys->videoFrame->data[2], sys->videoFrame->linesize[2]);
 #endif
 
 	if (gotFrame)

--- a/libfreerdp/codec/h264_mf.c
+++ b/libfreerdp/codec/h264_mf.c
@@ -167,7 +167,7 @@ static HRESULT mf_find_output_type(H264_CONTEXT_MF* sys, const GUID* guid,
 	return hr;
 }
 
-static HRESULT mf_create_output_sample(H264_CONTEXT_MF* sys)
+static HRESULT mf_create_output_sample(H264_CONTEXT* h264, H264_CONTEXT_MF* sys)
 {
 	HRESULT hr = S_OK;
 	MFT_OUTPUT_STREAM_INFO streamInfo;
@@ -182,7 +182,7 @@ static HRESULT mf_create_output_sample(H264_CONTEXT_MF* sys)
 
 	if (FAILED(hr))
 	{
-		WLog_ERR(TAG, "MFCreateSample failure: 0x%08"PRIX32"", hr);
+		WLog_Print(h264->log, WLOG_ERROR, "MFCreateSample failure: 0x%08"PRIX32"", hr);
 		goto error;
 	}
 
@@ -191,7 +191,7 @@ static HRESULT mf_create_output_sample(H264_CONTEXT_MF* sys)
 
 	if (FAILED(hr))
 	{
-		WLog_ERR(TAG, "GetOutputStreamInfo failure: 0x%08"PRIX32"", hr);
+		WLog_Print(h264->log, WLOG_ERROR, "GetOutputStreamInfo failure: 0x%08"PRIX32"", hr);
 		goto error;
 	}
 
@@ -199,7 +199,7 @@ static HRESULT mf_create_output_sample(H264_CONTEXT_MF* sys)
 
 	if (FAILED(hr))
 	{
-		WLog_ERR(TAG, "MFCreateMemoryBuffer failure: 0x%08"PRIX32"", hr);
+		WLog_Print(h264->log, WLOG_ERROR, "MFCreateMemoryBuffer failure: 0x%08"PRIX32"", hr);
 		goto error;
 	}
 
@@ -207,7 +207,7 @@ static HRESULT mf_create_output_sample(H264_CONTEXT_MF* sys)
 
 	if (FAILED(hr))
 	{
-		WLog_ERR(TAG, "AddBuffer failure: 0x%08"PRIX32"", hr);
+		WLog_Print(h264->log, WLOG_ERROR, "AddBuffer failure: 0x%08"PRIX32"", hr);
 		goto error;
 	}
 
@@ -234,7 +234,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 	if (FAILED(hr))
 	{
-		WLog_ERR(TAG, "MFCreateMemoryBuffer failure: 0x%08"PRIX32"", hr);
+		WLog_Print(h264->log, WLOG_ERROR, "MFCreateMemoryBuffer failure: 0x%08"PRIX32"", hr);
 		goto error;
 	}
 
@@ -243,7 +243,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 	if (FAILED(hr))
 	{
-		WLog_ERR(TAG, "Lock failure: 0x%08"PRIX32"", hr);
+		WLog_Print(h264->log, WLOG_ERROR, "Lock failure: 0x%08"PRIX32"", hr);
 		goto error;
 	}
 
@@ -252,7 +252,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 	if (FAILED(hr))
 	{
-		WLog_ERR(TAG, "SetCurrentLength failure: 0x%08"PRIX32"", hr);
+		WLog_Print(h264->log, WLOG_ERROR, "SetCurrentLength failure: 0x%08"PRIX32"", hr);
 		goto error;
 	}
 
@@ -260,7 +260,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 	if (FAILED(hr))
 	{
-		WLog_ERR(TAG, "Unlock failure: 0x%08"PRIX32"", hr);
+		WLog_Print(h264->log, WLOG_ERROR, "Unlock failure: 0x%08"PRIX32"", hr);
 		goto error;
 	}
 
@@ -268,7 +268,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 	if (FAILED(hr))
 	{
-		WLog_ERR(TAG, "MFCreateSample failure: 0x%08"PRIX32"", hr);
+		WLog_Print(h264->log, WLOG_ERROR, "MFCreateSample failure: 0x%08"PRIX32"", hr);
 		goto error;
 	}
 
@@ -276,7 +276,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 	if (FAILED(hr))
 	{
-		WLog_ERR(TAG, "AddBuffer failure: 0x%08"PRIX32"", hr);
+		WLog_Print(h264->log, WLOG_ERROR, "AddBuffer failure: 0x%08"PRIX32"", hr);
 		goto error;
 	}
 
@@ -285,15 +285,15 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 	if (FAILED(hr))
 	{
-		WLog_ERR(TAG, "ProcessInput failure: 0x%08"PRIX32"", hr);
+		WLog_Print(h264->log, WLOG_ERROR, "ProcessInput failure: 0x%08"PRIX32"", hr);
 		goto error;
 	}
 
-	hr = mf_create_output_sample(sys);
+	hr = mf_create_output_sample(h264, sys);
 
 	if (FAILED(hr))
 	{
-		WLog_ERR(TAG, "mf_create_output_sample failure: 0x%08"PRIX32"", hr);
+		WLog_Print(h264->log, WLOG_ERROR, "mf_create_output_sample failure: 0x%08"PRIX32"", hr);
 		goto error;
 	}
 
@@ -319,7 +319,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "mf_find_output_type failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "mf_find_output_type failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -328,15 +328,15 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "SetOutputType failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "SetOutputType failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
-		hr = mf_create_output_sample(sys);
+		hr = mf_create_output_sample(h264, sys);
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "mf_create_output_sample failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "mf_create_output_sample failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -345,7 +345,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "GetUINT64(MF_MT_FRAME_SIZE) failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "GetUINT64(MF_MT_FRAME_SIZE) failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -356,7 +356,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "GetUINT32(MF_MT_DEFAULT_STRIDE) failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "GetUINT32(MF_MT_DEFAULT_STRIDE) failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -368,7 +368,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 	}
 	else if (FAILED(hr))
 	{
-		WLog_ERR(TAG, "ProcessOutput failure: 0x%08"PRIX32"", hr);
+		WLog_Print(h264->log, WLOG_ERROR, "ProcessOutput failure: 0x%08"PRIX32"", hr);
 		goto error;
 	}
 	else
@@ -382,7 +382,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "GetBufferCount failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "GetBufferCount failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -391,7 +391,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "GetBufferByIndex failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "GetBufferByIndex failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -400,7 +400,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "Lock failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "Lock failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -414,7 +414,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "Unlock failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "Unlock failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -529,7 +529,7 @@ static BOOL mf_init(H264_CONTEXT* h264)
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "MFStartup failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "MFStartup failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -538,7 +538,7 @@ static BOOL mf_init(H264_CONTEXT* h264)
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "CoCreateInstance(CLSID_CMSH264DecoderMFT) failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "CoCreateInstance(CLSID_CMSH264DecoderMFT) failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -547,7 +547,7 @@ static BOOL mf_init(H264_CONTEXT* h264)
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "QueryInterface(IID_ICodecAPI) failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "QueryInterface(IID_ICodecAPI) failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -558,7 +558,7 @@ static BOOL mf_init(H264_CONTEXT* h264)
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "SetValue(CODECAPI_AVLowLatencyMode) failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "SetValue(CODECAPI_AVLowLatencyMode) failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -566,7 +566,7 @@ static BOOL mf_init(H264_CONTEXT* h264)
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "MFCreateMediaType failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "MFCreateMediaType failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -575,7 +575,7 @@ static BOOL mf_init(H264_CONTEXT* h264)
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "SetGUID(MF_MT_MAJOR_TYPE) failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "SetGUID(MF_MT_MAJOR_TYPE) failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -584,7 +584,7 @@ static BOOL mf_init(H264_CONTEXT* h264)
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "SetGUID(MF_MT_SUBTYPE) failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "SetGUID(MF_MT_SUBTYPE) failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -592,7 +592,7 @@ static BOOL mf_init(H264_CONTEXT* h264)
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "SetInputType failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "SetInputType failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -600,7 +600,7 @@ static BOOL mf_init(H264_CONTEXT* h264)
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "mf_find_output_type failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "mf_find_output_type failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
@@ -609,22 +609,22 @@ static BOOL mf_init(H264_CONTEXT* h264)
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "SetOutputType failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "SetOutputType failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
-		hr = mf_create_output_sample(sys);
+		hr = mf_create_output_sample(h264, sys);
 
 		if (FAILED(hr))
 		{
-			WLog_ERR(TAG, "mf_create_output_sample failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR, "mf_create_output_sample failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 	}
 
 	return TRUE;
 error:
-	WLog_ERR(TAG, "mf_init failure");
+	WLog_Print(h264->log, WLOG_ERROR, "mf_init failure");
 	mf_uninit(h264);
 	return FALSE;
 }

--- a/libfreerdp/codec/h264_openh264.c
+++ b/libfreerdp/codec/h264_openh264.c
@@ -25,8 +25,6 @@
 #include "wels/codec_api.h"
 #include "wels/codec_ver.h"
 
-#define TAG FREERDP_TAG("codec")
-
 #if (OPENH264_MAJOR == 1) && (OPENH264_MINOR < 3) || (OPENH264_MAJOR < 1)
 #error "Unsupported OpenH264 version "OPENH264_MAJOR"."OPENH264_MINOR"."OPENH264_REVISION" detected!"
 #elif (OPENH264_MAJOR > 1) || (OPENH264_MINOR > 7)

--- a/libfreerdp/codec/h264_openh264.c
+++ b/libfreerdp/codec/h264_openh264.c
@@ -29,7 +29,7 @@
 
 #if (OPENH264_MAJOR == 1) && (OPENH264_MINOR < 3) || (OPENH264_MAJOR < 1)
 #error "Unsupported OpenH264 version "OPENH264_MAJOR"."OPENH264_MINOR"."OPENH264_REVISION" detected!"
-#elif (OPENH264_MAJOR > 1) || (OPENH264_MINOR > 6)
+#elif (OPENH264_MAJOR > 1) || (OPENH264_MINOR > 7)
 #warning "Untested OpenH264 version "OPENH264_MAJOR"."OPENH264_MINOR"."OPENH264_REVISION" detected!"
 #endif
 
@@ -41,12 +41,10 @@ struct _H264_CONTEXT_OPENH264
 };
 typedef struct _H264_CONTEXT_OPENH264 H264_CONTEXT_OPENH264;
 
-static BOOL g_openh264_trace_enabled = FALSE;
-
 static void openh264_trace_callback(H264_CONTEXT* h264, int level,
                                     const char* message)
 {
-	WLog_INFO(TAG, "%d - %s", level, message);
+	WLog_Print(h264->log, WLOG_TRACE, "%d - %s", level, message);
 }
 
 static int openh264_decompress(H264_CONTEXT* h264, const BYTE* pSrcData,
@@ -88,8 +86,8 @@ static int openh264_decompress(H264_CONTEXT* h264, const BYTE* pSrcData,
 		}
 		else
 		{
-			WLog_WARN(TAG, "DecodeFrame2 state: 0x%04X iBufferStatus: %d", state,
-			          sBufferInfo.iBufferStatus);
+			WLog_Print(h264->log, WLOG_WARN, "DecodeFrame2 state: 0x%04X iBufferStatus: %d", state,
+			           sBufferInfo.iBufferStatus);
 			return -2002;
 		}
 	}
@@ -101,22 +99,22 @@ static int openh264_decompress(H264_CONTEXT* h264, const BYTE* pSrcData,
 
 	if (sBufferInfo.iBufferStatus != 1)
 	{
-		WLog_WARN(TAG, "DecodeFrame2 iBufferStatus: %d", sBufferInfo.iBufferStatus);
+		WLog_Print(h264->log, WLOG_WARN, "DecodeFrame2 iBufferStatus: %d", sBufferInfo.iBufferStatus);
 		return 0;
 	}
 
 	if (state != dsErrorFree)
 	{
-		WLog_WARN(TAG, "DecodeFrame2 state: 0x%02X", state);
+		WLog_Print(h264->log, WLOG_WARN, "DecodeFrame2 state: 0x%02X", state);
 		return -2003;
 	}
 
 #if 0
-	WLog_INFO(TAG,
-	          "h264_decompress: state=%u, pYUVData=[%p,%p,%p], bufferStatus=%d, width=%d, height=%d, format=%d, stride=[%d,%d]",
-	          state, (void*) pYUVData[0], (void*) pYUVData[1], (void*) pYUVData[2], sBufferInfo.iBufferStatus,
-	          pSystemBuffer->iWidth, pSystemBuffer->iHeight, pSystemBuffer->iFormat,
-	          pSystemBuffer->iStride[0], pSystemBuffer->iStride[1]);
+	WLog_Print(h264->log, WLOG_INFO,
+	           "h264_decompress: state=%u, pYUVData=[%p,%p,%p], bufferStatus=%d, width=%d, height=%d, format=%d, stride=[%d,%d]",
+	           state, (void*) pYUVData[0], (void*) pYUVData[1], (void*) pYUVData[2], sBufferInfo.iBufferStatus,
+	           pSystemBuffer->iWidth, pSystemBuffer->iHeight, pSystemBuffer->iFormat,
+	           pSystemBuffer->iStride[0], pSystemBuffer->iStride[1]);
 #endif
 
 	if (pSystemBuffer->iFormat != videoFormatI420)
@@ -152,7 +150,7 @@ static int openh264_compress(H264_CONTEXT* h264, const BYTE** pYUVData, const UI
 
 		if (status < 0)
 		{
-			WLog_ERR(TAG, "Failed to get OpenH264 default parameters (status=%d)", status);
+			WLog_Print(h264->log, WLOG_ERROR, "Failed to get OpenH264 default parameters (status=%d)", status);
 			return status;
 		}
 
@@ -200,7 +198,7 @@ static int openh264_compress(H264_CONTEXT* h264, const BYTE** pYUVData, const UI
 
 		if (status < 0)
 		{
-			WLog_ERR(TAG, "Failed to initialize OpenH264 encoder (status=%d)", status);
+			WLog_Print(h264->log, WLOG_ERROR, "Failed to initialize OpenH264 encoder (status=%d)", status);
 			return status;
 		}
 
@@ -210,8 +208,8 @@ static int openh264_compress(H264_CONTEXT* h264, const BYTE** pYUVData, const UI
 
 		if (status < 0)
 		{
-			WLog_ERR(TAG, "Failed to get initial OpenH264 encoder parameters (status=%d)",
-			         status);
+			WLog_Print(h264->log, WLOG_ERROR, "Failed to get initial OpenH264 encoder parameters (status=%d)",
+			           status);
 			return status;
 		}
 	}
@@ -230,7 +228,7 @@ static int openh264_compress(H264_CONTEXT* h264, const BYTE** pYUVData, const UI
 
 					if (status < 0)
 					{
-						WLog_ERR(TAG, "Failed to set encoder bitrate (status=%d)", status);
+						WLog_Print(h264->log, WLOG_ERROR, "Failed to set encoder bitrate (status=%d)", status);
 						return status;
 					}
 				}
@@ -243,7 +241,7 @@ static int openh264_compress(H264_CONTEXT* h264, const BYTE** pYUVData, const UI
 
 					if (status < 0)
 					{
-						WLog_ERR(TAG, "Failed to set encoder framerate (status=%d)", status);
+						WLog_Print(h264->log, WLOG_ERROR, "Failed to set encoder framerate (status=%d)", status);
 						return status;
 					}
 				}
@@ -260,7 +258,7 @@ static int openh264_compress(H264_CONTEXT* h264, const BYTE** pYUVData, const UI
 
 					if (status < 0)
 					{
-						WLog_ERR(TAG, "Failed to set encoder parameters (status=%d)", status);
+						WLog_Print(h264->log, WLOG_ERROR, "Failed to set encoder parameters (status=%d)", status);
 						return status;
 					}
 				}
@@ -284,7 +282,7 @@ static int openh264_compress(H264_CONTEXT* h264, const BYTE** pYUVData, const UI
 
 	if (status < 0)
 	{
-		WLog_ERR(TAG, "Failed to encode frame (status=%d)", status);
+		WLog_Print(h264->log, WLOG_ERROR, "Failed to encode frame (status=%d)", status);
 		return status;
 	}
 
@@ -364,7 +362,7 @@ static BOOL openh264_init(H264_CONTEXT* h264)
 
 			if (!sys->pEncoder)
 			{
-				WLog_ERR(TAG, "Failed to create OpenH264 encoder");
+				WLog_Print(h264->log, WLOG_ERROR, "Failed to create OpenH264 encoder");
 				goto EXCEPTION;
 			}
 		}
@@ -374,7 +372,7 @@ static BOOL openh264_init(H264_CONTEXT* h264)
 
 			if (!sys->pDecoder)
 			{
-				WLog_ERR(TAG, "Failed to create OpenH264 decoder");
+				WLog_Print(h264->log, WLOG_ERROR, "Failed to create OpenH264 decoder");
 				goto EXCEPTION;
 			}
 
@@ -388,8 +386,8 @@ static BOOL openh264_init(H264_CONTEXT* h264)
 
 			if (status != 0)
 			{
-				WLog_ERR(TAG, "Failed to initialize OpenH264 decoder (status=%ld)",
-				         status);
+				WLog_Print(h264->log, WLOG_ERROR, "Failed to initialize OpenH264 decoder (status=%ld)",
+				           status);
 				goto EXCEPTION;
 			}
 
@@ -401,13 +399,13 @@ static BOOL openh264_init(H264_CONTEXT* h264)
 
 			if (status != 0)
 			{
-				WLog_ERR(TAG,
-				         "Failed to set data format option on OpenH264 decoder (status=%ld)",
-				         status);
+				WLog_Print(h264->log, WLOG_ERROR,
+				           "Failed to set data format option on OpenH264 decoder (status=%ld)",
+				           status);
 				goto EXCEPTION;
 			}
 
-			if (g_openh264_trace_enabled)
+			if (WLog_GetLogLevel(h264->log) == WLOG_TRACE)
 			{
 				status = (*sys->pDecoder)->SetOption(
 				             sys->pDecoder, DECODER_OPTION_TRACE_LEVEL,
@@ -415,9 +413,9 @@ static BOOL openh264_init(H264_CONTEXT* h264)
 
 				if (status != 0)
 				{
-					WLog_ERR(TAG,
-					         "Failed to set trace level option on OpenH264 decoder (status=%ld)",
-					         status);
+					WLog_Print(h264->log, WLOG_ERROR,
+					           "Failed to set trace level option on OpenH264 decoder (status=%ld)",
+					           status);
 					goto EXCEPTION;
 				}
 
@@ -427,9 +425,9 @@ static BOOL openh264_init(H264_CONTEXT* h264)
 
 				if (status != 0)
 				{
-					WLog_ERR(TAG,
-					         "Failed to set trace callback option on OpenH264 decoder (status=%ld)",
-					         status);
+					WLog_Print(h264->log, WLOG_ERROR,
+					           "Failed to set trace callback option on OpenH264 decoder (status=%ld)",
+					           status);
 					goto EXCEPTION;
 				}
 
@@ -440,9 +438,9 @@ static BOOL openh264_init(H264_CONTEXT* h264)
 
 				if (status != 0)
 				{
-					WLog_ERR(TAG,
-					         "Failed to set trace callback context option on OpenH264 decoder (status=%ld)",
-					         status);
+					WLog_Print(h264->log, WLOG_ERROR,
+					           "Failed to set trace callback context option on OpenH264 decoder (status=%ld)",
+					           status);
 					goto EXCEPTION;
 				}
 			}

--- a/libfreerdp/codec/h264_openh264.c
+++ b/libfreerdp/codec/h264_openh264.c
@@ -44,7 +44,8 @@ typedef struct _H264_CONTEXT_OPENH264 H264_CONTEXT_OPENH264;
 static void openh264_trace_callback(H264_CONTEXT* h264, int level,
                                     const char* message)
 {
-	WLog_Print(h264->log, WLOG_TRACE, "%d - %s", level, message);
+	if (h264)
+		WLog_Print(h264->log, WLOG_TRACE, "%d - %s", level, message);
 }
 
 static int openh264_decompress(H264_CONTEXT* h264, const BYTE* pSrcData,
@@ -420,18 +421,6 @@ static BOOL openh264_init(H264_CONTEXT* h264)
 				}
 
 				status = (*sys->pDecoder)->SetOption(
-				             sys->pDecoder, DECODER_OPTION_TRACE_CALLBACK,
-				             &traceCallback);
-
-				if (status != 0)
-				{
-					WLog_Print(h264->log, WLOG_ERROR,
-					           "Failed to set trace callback option on OpenH264 decoder (status=%ld)",
-					           status);
-					goto EXCEPTION;
-				}
-
-				status = (*sys->pDecoder)->SetOption(
 				             sys->pDecoder,
 				             DECODER_OPTION_TRACE_CALLBACK_CONTEXT,
 				             &h264);
@@ -440,6 +429,18 @@ static BOOL openh264_init(H264_CONTEXT* h264)
 				{
 					WLog_Print(h264->log, WLOG_ERROR,
 					           "Failed to set trace callback context option on OpenH264 decoder (status=%ld)",
+					           status);
+					goto EXCEPTION;
+				}
+
+				status = (*sys->pDecoder)->SetOption(
+				             sys->pDecoder, DECODER_OPTION_TRACE_CALLBACK,
+				             &traceCallback);
+
+				if (status != 0)
+				{
+					WLog_Print(h264->log, WLOG_ERROR,
+					           "Failed to set trace callback option on OpenH264 decoder (status=%ld)",
 					           status);
 					goto EXCEPTION;
 				}


### PR DESCRIPTION
* Use preallocated logger for GFX-H264 backend.
* Enabled OpenH264 traces on log level TRACE