### PR TITLE
Fix smartcard login by ignoring Status_Call.cbAtrLen as is required by [MS-RDPESC]

### DIFF
--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -1054,9 +1054,7 @@ static LONG smartcard_StatusA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERAT
 	Status_Call* call = operation->call;
 	ZeroMemory(ret.pbAtr, 32);
 
-	if (call->cbAtrLen > 32)
-		call->cbAtrLen = 32;
-
+	call->cbAtrLen = 32;
 	cbAtrLen = call->cbAtrLen;
 
 	if (call->fmszReaderNamesIsNULL)


### PR DESCRIPTION
The [[MS-RDPESC]](https://msdn.microsoft.com/en-us/library/cc242596.aspx) clearly states in section [2.2.2.18](https://msdn.microsoft.com/en-us/library/cc242813.aspx) that Status_Call's cbAtrLen must not be used when generating Status_Return response. This is also how FreeRDP 1.1 behaves. This fixes logging in with smartcards.