### PR TITLE
Implement MS-RDPEVOR

### DIFF
--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -706,7 +706,9 @@ static UINT drdynvc_send(drdynvcPlugin* drdynvc, wStream* s)
 	switch (status)
 	{
 		case CHANNEL_RC_OK:
+			return CHANNEL_RC_OK;
 		case CHANNEL_RC_NOT_CONNECTED:
+			Stream_Free(s, TRUE);
 			return CHANNEL_RC_OK;
 
 		default:
@@ -839,8 +841,7 @@ static UINT drdynvc_send_capability_response(drdynvcPlugin* drdynvc)
 		return CHANNEL_RC_NO_MEMORY;
 	}
 
-	Stream_Write_UINT16(s,
-	                    0x0050); /* Cmd+Sp+cbChId+Pad. Note: MSTSC sends 0x005c */
+	Stream_Write_UINT16(s, 0x0050); /* Cmd+Sp+cbChId+Pad. Note: MSTSC sends 0x005c */
 	Stream_Write_UINT16(s, drdynvc->version);
 	status = drdynvc_send(drdynvc, s);
 
@@ -1190,6 +1191,7 @@ static void VCAPITYPE drdynvc_virtual_channel_open_event_ex(LPVOID lpUserParam, 
 	if (!drdynvc || (drdynvc->OpenHandle != openHandle))
 	{
 		WLog_ERR(TAG, "drdynvc_virtual_channel_open_event: error no match");
+		Stream_Free((wStream*) pData, TRUE);
 		return;
 	}
 

--- a/channels/geometry/ChannelOptions.cmake
+++ b/channels/geometry/ChannelOptions.cmake
@@ -9,4 +9,3 @@ define_channel_options(NAME "geometry" TYPE "dynamic"
 	DEFAULT ${OPTION_DEFAULT})
 
 define_channel_client_options(${OPTION_CLIENT_DEFAULT})
-define_channel_server_options(${OPTION_SERVER_DEFAULT})

--- a/channels/geometry/client/geometry_main.c
+++ b/channels/geometry/client/geometry_main.c
@@ -72,7 +72,29 @@ struct _GEOMETRY_PLUGIN
 typedef struct _GEOMETRY_PLUGIN GEOMETRY_PLUGIN;
 
 
-static UINT32 geometry_read_RGNDATA(wStream* s, UINT32 len, FREERDP_RGNDATA* rgndata)
+static UINT32 mappedGeometryHash(UINT64 *g)
+{
+	return (UINT32)((*g >> 32) + (*g & 0xffffffff));
+}
+
+static BOOL mappedGeometryKeyCompare(UINT64 *g1, UINT64 *g2)
+{
+	return *g1 == *g2;
+}
+
+static void mappedGeometryFree(MAPPED_GEOMETRY *g)
+{
+	free(g->geometry.rects);
+	free(g);
+}
+
+
+void freerdp_rgndata_reset(FREERDP_RGNDATA *data)
+{
+	data->nRectCount = 0;
+}
+
+static UINT32 geometry_read_RGNDATA(wStream *s, UINT32 len, FREERDP_RGNDATA *rgndata)
 {
 	UINT32 dwSize, iType;
 	INT32 right, bottom;
@@ -117,12 +139,14 @@ static UINT32 geometry_read_RGNDATA(wStream* s, UINT32 len, FREERDP_RGNDATA* rgn
 	if (rgndata->nRectCount)
 	{
 		int i;
+		RDP_RECT *tmp = realloc(rgndata->rects, rgndata->nRectCount * sizeof(RDP_RECT));
 
-		if (!(rgndata->rects = calloc(rgndata->nRectCount, sizeof(RDP_RECT))))
+		if (!tmp)
 		{
 			WLog_ERR(TAG, "unable to allocate memory for %"PRIu32" RECTs", rgndata->nRectCount);
 			return CHANNEL_RC_NO_MEMORY;
 		}
+		rgndata->rects = tmp;
 
 		for (i = 0; i < rgndata->nRectCount; i++)
 		{
@@ -146,10 +170,13 @@ static UINT32 geometry_read_RGNDATA(wStream* s, UINT32 len, FREERDP_RGNDATA* rgn
 static UINT geometry_recv_pdu(GEOMETRY_CHANNEL_CALLBACK* callback, wStream* s)
 {
 	UINT32 length, cbGeometryBuffer;
-	MAPPED_GEOMETRY_PACKET packet;
+	MAPPED_GEOMETRY *mappedGeometry;
 	GEOMETRY_PLUGIN* geometry;
-	GeometryClientContext* context;
-	UINT ret;
+	GeometryClientContext *context;
+	UINT ret = CHANNEL_RC_OK;
+	UINT32 version, updateType, geometryType;
+	UINT64 id;
+
 	geometry = (GEOMETRY_PLUGIN*) callback->plugin;
 	context = (GeometryClientContext*)geometry->iface.pInterface;
 
@@ -167,44 +194,107 @@ static UINT geometry_recv_pdu(GEOMETRY_CHANNEL_CALLBACK* callback, wStream* s)
 		return ERROR_INVALID_DATA;
 	}
 
-	Stream_Read_UINT32(s, packet.version);
-	Stream_Read_UINT64(s, packet.mappingId);
-	Stream_Read_UINT32(s, packet.updateType);
+	Stream_Read_UINT32(s, version);
+	Stream_Read_UINT64(s, id);
+	Stream_Read_UINT32(s, updateType);
 	Stream_Seek_UINT32(s); /* flags */
-	Stream_Read_UINT64(s, packet.topLevelId);
-	Stream_Read_INT32(s, packet.left);
-	Stream_Read_INT32(s, packet.top);
-	Stream_Read_INT32(s, packet.right);
-	Stream_Read_INT32(s, packet.bottom);
-	Stream_Read_INT32(s, packet.topLevelLeft);
-	Stream_Read_INT32(s, packet.topLevelTop);
-	Stream_Read_INT32(s, packet.topLevelRight);
-	Stream_Read_INT32(s, packet.topLevelBottom);
-	Stream_Read_UINT32(s, packet.geometryType);
-	Stream_Read_UINT32(s, cbGeometryBuffer);
 
-	if (Stream_GetRemainingLength(s) < cbGeometryBuffer)
+	mappedGeometry = HashTable_GetItemValue(context->geometries, &id);
+
+	if (updateType == GEOMETRY_CLEAR )
 	{
-		WLog_ERR(TAG, "invalid packet length");
-		return ERROR_INVALID_DATA;
+		if (!mappedGeometry)
+		{
+			WLog_ERR(TAG, "geometry 0x%"PRIx64" not found here, ignoring clear command", id);
+			return CHANNEL_RC_OK;
+		}
+
+		WLog_DBG(TAG, "clearing geometry 0x%"PRIx64"", id);
+
+		if (mappedGeometry->MappedGeometryClear && !mappedGeometry->MappedGeometryClear(mappedGeometry))
+			return ERROR_INTERNAL_ERROR;
+
+		HashTable_Remove(context->geometries, &id);
 	}
-
-	ZeroMemory(&packet.geometry, sizeof(packet.geometry));
-
-	if (cbGeometryBuffer)
+	else if (updateType == GEOMETRY_UPDATE)
 	{
-		ret = geometry_read_RGNDATA(s, cbGeometryBuffer, &packet.geometry);
+		BOOL newOne = FALSE;
 
-		if (ret != CHANNEL_RC_OK)
-			return ret;
+		if (!mappedGeometry)
+		{
+			newOne = TRUE;
+			WLog_DBG(TAG, "creating geometry 0x%"PRIx64"", id);
+			mappedGeometry = calloc(1, sizeof(MAPPED_GEOMETRY));
+			if (!mappedGeometry)
+				return CHANNEL_RC_NO_MEMORY;
+
+			mappedGeometry->mappingId = id;
+
+			if (HashTable_Add(context->geometries, &(mappedGeometry->mappingId), mappedGeometry) < 0)
+			{
+				WLog_ERR(TAG, "unable to register geometry 0x%"PRIx64" in the table", id);
+				free(mappedGeometry);
+				return CHANNEL_RC_NO_MEMORY;
+			}
+		}
+		else
+		{
+			WLog_DBG(TAG, "updating geometry 0x%"PRIx64"", id);
+		}
+
+		Stream_Read_UINT64(s, mappedGeometry->topLevelId);
+
+		Stream_Read_INT32(s, mappedGeometry->left);
+		Stream_Read_INT32(s, mappedGeometry->top);
+		Stream_Read_INT32(s, mappedGeometry->right);
+		Stream_Read_INT32(s, mappedGeometry->bottom);
+
+		Stream_Read_INT32(s, mappedGeometry->topLevelLeft);
+		Stream_Read_INT32(s, mappedGeometry->topLevelTop);
+		Stream_Read_INT32(s, mappedGeometry->topLevelRight);
+		Stream_Read_INT32(s, mappedGeometry->topLevelBottom);
+
+		Stream_Read_UINT32(s, geometryType);
+
+		Stream_Read_UINT32(s, cbGeometryBuffer);
+		if (Stream_GetRemainingLength(s) < cbGeometryBuffer)
+		{
+			WLog_ERR(TAG, "invalid packet length");
+			return ERROR_INVALID_DATA;
+		}
+
+		if (cbGeometryBuffer)
+		{
+			ret = geometry_read_RGNDATA(s, cbGeometryBuffer, &mappedGeometry->geometry);
+			if (ret != CHANNEL_RC_OK)
+				return ret;
+		}
+		else
+		{
+			freerdp_rgndata_reset(&mappedGeometry->geometry);
+		}
+
+		if (newOne)
+		{
+			if (context->MappedGeometryAdded && !context->MappedGeometryAdded(context, mappedGeometry))
+			{
+				WLog_ERR(TAG, "geometry added callback failed");
+				ret = ERROR_INTERNAL_ERROR;
+			}
+		}
+		else
+		{
+			if (mappedGeometry->MappedGeometryUpdate && !mappedGeometry->MappedGeometryUpdate(mappedGeometry))
+			{
+				WLog_ERR(TAG, "geometry update callback failed");
+				ret = ERROR_INTERNAL_ERROR;
+			}
+		}
 	}
 	else
 		ret = CHANNEL_RC_OK;
 
-	if (context->MappedGeometryPacket)
-		ret = context->MappedGeometryPacket(context, &packet);
 
-	free(packet.geometry.rects);
 	return ret;
 }
 
@@ -304,7 +394,6 @@ static UINT geometry_plugin_terminated(IWTSPlugin* pPlugin)
  * Channel Client Interface
  */
 
-
 #ifdef BUILTIN_CHANNELS
 #define DVCPluginEntry		geometry_DVCPluginEntry
 #else
@@ -342,9 +431,13 @@ UINT DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 		if (!context)
 		{
 			WLog_ERR(TAG, "calloc failed!");
-			free(geometry);
-			return CHANNEL_RC_NO_MEMORY;
+			goto error_context;
 		}
+
+		context->geometries = HashTable_New(FALSE);
+		context->geometries->hash = (HASH_TABLE_HASH_FN)mappedGeometryHash;
+		context->geometries->keyCompare = (HASH_TABLE_KEY_COMPARE_FN)mappedGeometryKeyCompare;
+		context->geometries->valueFree = (HASH_TABLE_VALUE_FREE_FN)mappedGeometryFree;
 
 		context->handle = (void*) geometry;
 		geometry->iface.pInterface = (void*) context;
@@ -358,4 +451,9 @@ UINT DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 	}
 
 	return error;
+
+error_context:
+	free(geometry);
+	return CHANNEL_RC_NO_MEMORY;
+
 }

--- a/channels/geometry/client/geometry_main.c
+++ b/channels/geometry/client/geometry_main.c
@@ -384,6 +384,11 @@ static UINT geometry_plugin_initialize(IWTSPlugin* pPlugin, IWTSVirtualChannelMa
 static UINT geometry_plugin_terminated(IWTSPlugin* pPlugin)
 {
 	GEOMETRY_PLUGIN* geometry = (GEOMETRY_PLUGIN*) pPlugin;
+	GeometryClientContext* context = (GeometryClientContext *)geometry->iface.pInterface;
+
+	if (context)
+		HashTable_Free(context->geometries);
+
 	free(geometry->listener_callback);
 	free(geometry->iface.pInterface);
 	free(pPlugin);

--- a/channels/video/CMakeLists.txt
+++ b/channels/video/CMakeLists.txt
@@ -1,0 +1,22 @@
+# FreeRDP: A Remote Desktop Protocol Implementation
+# FreeRDP cmake build script
+#
+# Copyright 2017 David Fort <contact@hardening-consulting.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+define_channel("video")
+
+if(WITH_CLIENT_CHANNELS)
+	add_channel_client(${MODULE_PREFIX} ${CHANNEL_NAME})
+endif()

--- a/channels/video/ChannelOptions.cmake
+++ b/channels/video/ChannelOptions.cmake
@@ -1,0 +1,12 @@
+
+set(OPTION_DEFAULT OFF)
+set(OPTION_CLIENT_DEFAULT ON)
+set(OPTION_SERVER_DEFAULT OFF)
+
+define_channel_options(NAME "video" TYPE "dynamic"
+	DESCRIPTION "Video optimized remoting Virtual Channel Extension"
+	SPECIFICATIONS "[MS-RDPEVOR]"
+	DEFAULT ${OPTION_DEFAULT})
+
+define_channel_client_options(${OPTION_CLIENT_DEFAULT})
+

--- a/channels/video/client/CMakeLists.txt
+++ b/channels/video/client/CMakeLists.txt
@@ -1,7 +1,7 @@
 # FreeRDP: A Remote Desktop Protocol Implementation
 # FreeRDP cmake build script
 #
-# Copyright 2013 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+# Copyright 2018 David Fort <contact@hardening-consulting.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/channels/video/client/CMakeLists.txt
+++ b/channels/video/client/CMakeLists.txt
@@ -1,0 +1,39 @@
+# FreeRDP: A Remote Desktop Protocol Implementation
+# FreeRDP cmake build script
+#
+# Copyright 2013 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+define_channel_client("video")
+
+set(${MODULE_PREFIX}_SRCS
+	video_main.c
+	video_main.h)
+
+include_directories(..)
+
+add_channel_client_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} TRUE "DVCPluginEntry")
+
+
+
+set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} winpr)
+
+target_link_libraries(${MODULE_NAME} ${${MODULE_PREFIX}_LIBS})
+
+
+if (WITH_DEBUG_SYMBOLS AND MSVC AND NOT BUILTIN_CHANNELS AND BUILD_SHARED_LIBS)
+	install(FILES ${CMAKE_BINARY_DIR}/${MODULE_NAME}.pdb DESTINATION ${FREERDP_ADDIN_PATH} COMPONENT symbols)
+endif()
+
+set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "Channels/${CHANNEL_NAME}/Client")

--- a/channels/video/client/video_main.c
+++ b/channels/video/client/video_main.c
@@ -1,0 +1,510 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Video Optimized Remoting Virtual Channel Extension
+ *
+ * Copyright 2017 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <winpr/crt.h>
+#include <winpr/synch.h>
+#include <winpr/print.h>
+#include <winpr/stream.h>
+#include <winpr/cmdline.h>
+#include <winpr/collections.h>
+
+#include <freerdp/addin.h>
+#include <freerdp/client/video.h>
+#include <freerdp/channels/log.h>
+
+#define TAG CHANNELS_TAG("video.client")
+
+#include "video_main.h"
+
+struct _VIDEO_CHANNEL_CALLBACK
+{
+	IWTSVirtualChannelCallback iface;
+
+	IWTSPlugin* plugin;
+	IWTSVirtualChannelManager* channel_mgr;
+	IWTSVirtualChannel* channel;
+};
+typedef struct _VIDEO_CHANNEL_CALLBACK VIDEO_CHANNEL_CALLBACK;
+
+struct _VIDEO_LISTENER_CALLBACK
+{
+	IWTSListenerCallback iface;
+
+	IWTSPlugin* plugin;
+	IWTSVirtualChannelManager* channel_mgr;
+	VIDEO_CHANNEL_CALLBACK* channel_callback;
+};
+typedef struct _VIDEO_LISTENER_CALLBACK VIDEO_LISTENER_CALLBACK;
+
+struct _VIDEO_PLUGIN
+{
+	IWTSPlugin wtsPlugin;
+
+	IWTSListener* controlListener;
+	IWTSListener* dataListener;
+	VIDEO_LISTENER_CALLBACK* control_callback;
+	VIDEO_LISTENER_CALLBACK* data_callback;
+
+	VideoClientContext *context;
+};
+typedef struct _VIDEO_PLUGIN VIDEO_PLUGIN;
+
+static const char *video_command_name(BYTE cmd)
+{
+	switch(cmd)
+	{
+	case TSMM_START_PRESENTATION:
+		return "start";
+	case TSMM_STOP_PRESENTATION:
+		return "stop";
+	default:
+		return "<unknown>";
+	}
+}
+
+static UINT video_read_tsmm_presentation_req(VideoClientContext *context, wStream *s)
+{
+	TSMM_PRESENTATION_REQUEST req;
+	UINT ret = CHANNEL_RC_OK;
+
+	if (Stream_GetRemainingLength(s) < 60)
+	{
+		WLog_ERR(TAG, "not enough bytes for a TSMM_PRESENTATION_REQUEST");
+		return ERROR_INVALID_DATA;
+	}
+
+	Stream_Read_UINT8(s, req.PresentationId);
+	Stream_Read_UINT8(s, req.Version);
+	Stream_Read_UINT8(s, req.Command);
+	Stream_Seek_UINT8(s); /* FrameRate - reserved and ignored */
+
+	Stream_Seek_UINT16(s); /* AverageBitrateKbps reserved and ignored */
+	Stream_Seek_UINT16(s); /* reserved */
+
+	Stream_Read_UINT32(s, req.SourceWidth);
+	Stream_Read_UINT32(s, req.SourceHeight);
+	Stream_Read_UINT32(s, req.ScaledWidth);
+	Stream_Read_UINT32(s, req.ScaledHeight);
+	Stream_Read_UINT64(s, req.hnsTimestampOffset);
+	Stream_Read_UINT64(s, req.GeometryMappingId);
+	Stream_Read(s, req.VideoSubtypeId, 16);
+
+	Stream_Read_UINT32(s, req.cbExtra);
+
+	if (Stream_GetRemainingLength(s) < req.cbExtra)
+	{
+		WLog_ERR(TAG, "not enough bytes for cbExtra of TSMM_PRESENTATION_REQUEST");
+		return ERROR_INVALID_DATA;
+	}
+
+	req.pExtraData = Stream_Pointer(s);
+
+	WLog_DBG(TAG, "presentationReq: id:%"PRIu8" version:%"PRIu8" command:%s srcWidth/srcHeight=%"PRIu32"x%"PRIu32
+			" scaled Width/Height=%"PRIu32"x%"PRIu32" timestamp=%"PRIu64" mappingId=%"PRIx64"",
+			req.PresentationId, req.Version, video_command_name(req.Command),
+			req.SourceWidth, req.SourceHeight, req.ScaledWidth, req.ScaledHeight,
+			req.hnsTimestampOffset, req.GeometryMappingId);
+
+	if (context->PresentationRequest)
+		ret = context->PresentationRequest(context, &req);
+
+	return ret;
+}
+
+static UINT video_control_send_presentation_response(VideoClientContext *context, TSMM_PRESENTATION_RESPONSE *resp)
+{
+	BYTE buf[12];
+	wStream *s;
+	VIDEO_PLUGIN* video = (VIDEO_PLUGIN *)context->handle;
+	IWTSVirtualChannel* channel;
+	UINT ret;
+
+	s = Stream_New(buf, 12);
+	if (!s)
+		return CHANNEL_RC_NO_MEMORY;
+
+	Stream_Write_UINT32(s, 12); /* cbSize */
+	Stream_Write_UINT32(s, TSMM_PACKET_TYPE_PRESENTATION_RESPONSE); /* PacketType */
+	Stream_Write_UINT8(s, resp->PresentationId);
+	Stream_Zero(s, 3);
+	Stream_SealLength(s);
+
+	channel = video->control_callback->channel_callback->channel;
+	ret = channel->Write(channel, 12, buf, NULL);
+	Stream_Free(s, FALSE);
+
+	return ret;
+}
+
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT video_control_on_data_received(IWTSVirtualChannelCallback* pChannelCallback, wStream *s)
+{
+	VIDEO_CHANNEL_CALLBACK* callback = (VIDEO_CHANNEL_CALLBACK*) pChannelCallback;
+	VIDEO_PLUGIN* video;
+	VideoClientContext *context;
+	UINT ret = CHANNEL_RC_OK;
+	UINT32 cbSize, packetType;
+
+	video = (VIDEO_PLUGIN*) callback->plugin;
+	context = (VideoClientContext *)video->wtsPlugin.pInterface;
+
+	if (Stream_GetRemainingLength(s) < 4)
+		return ERROR_INVALID_DATA;
+
+	Stream_Read_UINT32(s, cbSize);
+	if (cbSize < 8 || Stream_GetRemainingLength(s) < (cbSize-4))
+	{
+		WLog_ERR(TAG, "invalid cbSize");
+		return ERROR_INVALID_DATA;
+	}
+
+	Stream_Read_UINT32(s, packetType);
+	switch (packetType)
+	{
+	case TSMM_PACKET_TYPE_PRESENTATION_REQUEST:
+		ret = video_read_tsmm_presentation_req(context, s);
+		break;
+	default:
+		WLog_ERR(TAG, "not expecting packet type %"PRIu32"", packetType);
+		ret = ERROR_UNSUPPORTED_TYPE;
+		break;
+	}
+
+	return ret;
+}
+
+static UINT video_control_send_client_notification(VideoClientContext *context, TSMM_CLIENT_NOTIFICATION *notif)
+{
+	BYTE buf[30];
+	wStream *s;
+	VIDEO_PLUGIN* video = (VIDEO_PLUGIN *)context->handle;
+	IWTSVirtualChannel* channel;
+	UINT ret;
+	UINT32 cbSize;
+
+	s = Stream_New(buf, 30);
+	if (!s)
+		return CHANNEL_RC_NO_MEMORY;
+
+	cbSize = 16;
+	Stream_Seek_UINT32(s); /* cbSize */
+	Stream_Write_UINT32(s, TSMM_PACKET_TYPE_CLIENT_NOTIFICATION); /* PacketType */
+	Stream_Write_UINT8(s, notif->PresentationId);
+	Stream_Write_UINT8(s, notif->NotificationType);
+	Stream_Zero(s, 2);
+	if (notif->NotificationType == TSMM_CLIENT_NOTIFICATION_TYPE_FRAMERATE_OVERRIDE)
+	{
+		Stream_Write_UINT32(s, 16); /* cbData */
+
+		/* TSMM_CLIENT_NOTIFICATION_FRAMERATE_OVERRIDE */
+		Stream_Write_UINT32(s, notif->FramerateOverride.Flags);
+		Stream_Write_UINT32(s, notif->FramerateOverride.DesiredFrameRate);
+		Stream_Zero(s, 4 * 2);
+
+		cbSize += 4 * 4;
+	}
+	else
+	{
+		Stream_Write_UINT32(s, 0); /* cbData */
+	}
+
+	Stream_SealLength(s);
+	Stream_SetPosition(s, 0);
+	Stream_Write_UINT32(s, cbSize);
+
+	channel = video->control_callback->channel_callback->channel;
+	ret = channel->Write(channel, cbSize, buf, NULL);
+	Stream_Free(s, FALSE);
+
+	return ret;
+}
+
+
+static UINT video_data_on_data_received(IWTSVirtualChannelCallback* pChannelCallback, wStream *s)
+{
+	VIDEO_CHANNEL_CALLBACK* callback = (VIDEO_CHANNEL_CALLBACK*) pChannelCallback;
+	VIDEO_PLUGIN* video;
+	VideoClientContext *context;
+	UINT32 cbSize, packetType;
+	TSMM_VIDEO_DATA data;
+
+	video = (VIDEO_PLUGIN*) callback->plugin;
+	context = (VideoClientContext *)video->wtsPlugin.pInterface;
+
+	if (Stream_GetRemainingLength(s) < 4)
+		return ERROR_INVALID_DATA;
+
+	Stream_Read_UINT32(s, cbSize);
+	if (cbSize < 8 || Stream_GetRemainingLength(s) < (cbSize-4))
+	{
+		WLog_ERR(TAG, "invalid cbSize");
+		return ERROR_INVALID_DATA;
+	}
+
+	Stream_Read_UINT32(s, packetType);
+	if (packetType != TSMM_PACKET_TYPE_VIDEO_DATA)
+	{
+		WLog_ERR(TAG, "only expecting VIDEO_DATA on the data channel");
+		return ERROR_INVALID_DATA;
+	}
+
+	if (Stream_GetRemainingLength(s) < 32)
+	{
+		WLog_ERR(TAG, "not enough bytes for a TSMM_VIDEO_DATA");
+		return ERROR_INVALID_DATA;
+	}
+
+	Stream_Read_UINT8(s, data.PresentationId);
+	Stream_Read_UINT8(s, data.Version);
+	Stream_Read_UINT8(s, data.Flags);
+	Stream_Seek_UINT8(s); /* reserved */
+	Stream_Read_UINT64(s, data.hnsTimestamp);
+	Stream_Read_UINT64(s, data.hnsDuration);
+	Stream_Read_UINT16(s, data.CurrentPacketIndex);
+	Stream_Read_UINT16(s, data.PacketsInSample);
+	Stream_Read_UINT32(s, data.SampleNumber);
+	Stream_Read_UINT32(s, data.cbSample);
+	data.pSample = Stream_Pointer(s);
+
+	WLog_DBG(TAG, "videoData: id:%"PRIu8" version:%"PRIu8" flags:0x%"PRIx8" timestamp=%"PRIu64" duration=%"PRIu64
+			" curPacketIndex:%"PRIu16" packetInSample:%"PRIu16" sampleNumber:%"PRIu32" cbSample:%"PRIu32"",
+			data.PresentationId, data.Version, data.Flags, data.hnsTimestamp, data.hnsDuration,
+			data.CurrentPacketIndex, data.PacketsInSample, data.SampleNumber, data.cbSample);
+
+	if (context->VideoData)
+		return context->VideoData(context, &data);
+
+	return CHANNEL_RC_OK;
+}
+
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT video_control_on_close(IWTSVirtualChannelCallback* pChannelCallback)
+{
+	free(pChannelCallback);
+	return CHANNEL_RC_OK;
+}
+
+static UINT video_data_on_close(IWTSVirtualChannelCallback* pChannelCallback)
+{
+	free(pChannelCallback);
+	return CHANNEL_RC_OK;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT video_control_on_new_channel_connection(IWTSListenerCallback* listenerCallback,
+	IWTSVirtualChannel* channel, BYTE* Data, BOOL* pbAccept,
+	IWTSVirtualChannelCallback** ppCallback)
+{
+	VIDEO_CHANNEL_CALLBACK* callback;
+	VIDEO_LISTENER_CALLBACK* listener_callback = (VIDEO_LISTENER_CALLBACK*) listenerCallback;
+
+	callback = (VIDEO_CHANNEL_CALLBACK*) calloc(1, sizeof(VIDEO_CHANNEL_CALLBACK));
+	if (!callback)
+	{
+		WLog_ERR(TAG, "calloc failed!");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	callback->iface.OnDataReceived = video_control_on_data_received;
+	callback->iface.OnClose = video_control_on_close;
+	callback->plugin = listener_callback->plugin;
+	callback->channel_mgr = listener_callback->channel_mgr;
+	callback->channel = channel;
+	listener_callback->channel_callback = callback;
+
+	*ppCallback = (IWTSVirtualChannelCallback*) callback;
+
+	return CHANNEL_RC_OK;
+}
+
+static UINT video_data_on_new_channel_connection(IWTSListenerCallback* pListenerCallback,
+	IWTSVirtualChannel* pChannel, BYTE* Data, BOOL* pbAccept,
+	IWTSVirtualChannelCallback** ppCallback)
+{
+	VIDEO_CHANNEL_CALLBACK* callback;
+	VIDEO_LISTENER_CALLBACK* listener_callback = (VIDEO_LISTENER_CALLBACK*) pListenerCallback;
+
+	callback = (VIDEO_CHANNEL_CALLBACK*) calloc(1, sizeof(VIDEO_CHANNEL_CALLBACK));
+	if (!callback)
+	{
+		WLog_ERR(TAG, "calloc failed!");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	callback->iface.OnDataReceived = video_data_on_data_received;
+	callback->iface.OnClose = video_data_on_close;
+	callback->plugin = listener_callback->plugin;
+	callback->channel_mgr = listener_callback->channel_mgr;
+	callback->channel = pChannel;
+	listener_callback->channel_callback = callback;
+
+	*ppCallback = (IWTSVirtualChannelCallback*) callback;
+
+	return CHANNEL_RC_OK;
+}
+
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT video_plugin_initialize(IWTSPlugin* plugin, IWTSVirtualChannelManager* channelMgr)
+{
+	UINT status;
+	VIDEO_PLUGIN* video = (VIDEO_PLUGIN *)plugin;
+	VIDEO_LISTENER_CALLBACK *callback;
+
+	video->control_callback = callback = (VIDEO_LISTENER_CALLBACK*) calloc(1, sizeof(VIDEO_LISTENER_CALLBACK));
+	if (!callback)
+	{
+		WLog_ERR(TAG, "calloc for control callback failed!");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	callback->iface.OnNewChannelConnection = video_control_on_new_channel_connection;
+	callback->plugin = plugin;
+	callback->channel_mgr = channelMgr;
+
+	status = channelMgr->CreateListener(channelMgr, VIDEO_CONTROL_DVC_CHANNEL_NAME, 0,
+		(IWTSListenerCallback*)callback, &(video->controlListener));
+
+	if (status != CHANNEL_RC_OK)
+		return status;
+	video->controlListener->pInterface = video->wtsPlugin.pInterface;
+
+
+	video->data_callback = callback = (VIDEO_LISTENER_CALLBACK*) calloc(1, sizeof(VIDEO_LISTENER_CALLBACK));
+	if (!callback)
+	{
+		WLog_ERR(TAG, "calloc for data callback failed!");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	callback->iface.OnNewChannelConnection = video_data_on_new_channel_connection;
+	callback->plugin = plugin;
+	callback->channel_mgr = channelMgr;
+
+	status = channelMgr->CreateListener(channelMgr, VIDEO_DATA_DVC_CHANNEL_NAME, 0,
+		(IWTSListenerCallback*)callback, &(video->dataListener));
+
+	if (status == CHANNEL_RC_OK)
+		video->dataListener->pInterface = video->wtsPlugin.pInterface;
+
+	return status;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT video_plugin_terminated(IWTSPlugin* pPlugin)
+{
+	VIDEO_PLUGIN* video = (VIDEO_PLUGIN*) pPlugin;
+	free(video->control_callback);
+	free(video->wtsPlugin.pInterface);
+	free(pPlugin);
+	return CHANNEL_RC_OK;
+}
+
+/**
+ * Channel Client Interface
+ */
+
+
+#ifdef BUILTIN_CHANNELS
+#define DVCPluginEntry		video_DVCPluginEntry
+#else
+#define DVCPluginEntry		FREERDP_API DVCPluginEntry
+#endif
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+UINT DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
+{
+	UINT error = CHANNEL_RC_OK;
+	VIDEO_PLUGIN* videoPlugin;
+	VideoClientContext* context;
+
+	videoPlugin = (VIDEO_PLUGIN*) pEntryPoints->GetPlugin(pEntryPoints, "video");
+	if (!videoPlugin)
+	{
+		videoPlugin = (VIDEO_PLUGIN*) calloc(1, sizeof(VIDEO_PLUGIN));
+		if (!videoPlugin)
+		{
+			WLog_ERR(TAG, "calloc failed!");
+			return CHANNEL_RC_NO_MEMORY;
+		}
+
+		videoPlugin->wtsPlugin.Initialize = video_plugin_initialize;
+		videoPlugin->wtsPlugin.Connected = NULL;
+		videoPlugin->wtsPlugin.Disconnected = NULL;
+		videoPlugin->wtsPlugin.Terminated = video_plugin_terminated;
+
+		context = (VideoClientContext*) calloc(1, sizeof(VideoClientContext));
+		if (!context)
+		{
+			WLog_ERR(TAG, "calloc failed!");
+			free(videoPlugin);
+			return CHANNEL_RC_NO_MEMORY;
+		}
+
+		context->handle = (void*) videoPlugin;
+		context->PresentationResponse = video_control_send_presentation_response;
+		context->ClientNotification = video_control_send_client_notification;
+
+		videoPlugin->wtsPlugin.pInterface = (void*) context;
+		videoPlugin->context = context;
+
+		error = pEntryPoints->RegisterPlugin(pEntryPoints, "video", (IWTSPlugin*) videoPlugin);
+	}
+	else
+	{
+		WLog_ERR(TAG, "could not get video Plugin.");
+		return CHANNEL_RC_BAD_CHANNEL;
+	}
+
+	return error;
+}

--- a/channels/video/client/video_main.c
+++ b/channels/video/client/video_main.c
@@ -204,7 +204,7 @@ static UINT video_control_on_data_received(IWTSVirtualChannelCallback* pChannelC
 
 static UINT video_control_send_client_notification(VideoClientContext *context, TSMM_CLIENT_NOTIFICATION *notif)
 {
-	BYTE buf[30];
+	BYTE buf[100];
 	wStream *s;
 	VIDEO_PLUGIN* video = (VIDEO_PLUGIN *)context->handle;
 	IWTSVirtualChannel* channel;
@@ -240,10 +240,10 @@ static UINT video_control_send_client_notification(VideoClientContext *context, 
 	Stream_SealLength(s);
 	Stream_SetPosition(s, 0);
 	Stream_Write_UINT32(s, cbSize);
+	Stream_Free(s, FALSE);
 
 	channel = video->control_callback->channel_callback->channel;
 	ret = channel->Write(channel, cbSize, buf, NULL);
-	Stream_Free(s, FALSE);
 
 	return ret;
 }
@@ -440,7 +440,9 @@ static UINT video_plugin_initialize(IWTSPlugin* plugin, IWTSVirtualChannelManage
 static UINT video_plugin_terminated(IWTSPlugin* pPlugin)
 {
 	VIDEO_PLUGIN* video = (VIDEO_PLUGIN*) pPlugin;
+
 	free(video->control_callback);
+	free(video->data_callback);
 	free(video->wtsPlugin.pInterface);
 	free(pPlugin);
 	return CHANNEL_RC_OK;

--- a/channels/video/client/video_main.c
+++ b/channels/video/client/video_main.c
@@ -393,8 +393,8 @@ static BOOL video_onMappedGeometryUpdate(MAPPED_GEOMETRY *geometry)
 			r->x, r->y, r->width, r->height
 	);
 
-	presentation->surface->x = geometry->topLevelLeft + geometry->left + r->x;
-	presentation->surface->y = geometry->topLevelTop + geometry->top + r->y;
+	presentation->surface->x = geometry->left + r->x;
+	presentation->surface->y = geometry->top + r->y;
 
 	return TRUE;
 }
@@ -455,8 +455,8 @@ static UINT video_PresentationRequest(VideoClientContext* video, TSMM_PRESENTATI
 
 		WLog_DBG(TAG, "creating presentation 0x%x", req->PresentationId);
 		presentation = PresentationContext_new(video, req->PresentationId,
-				geom->topLevelLeft + geom->left + geom->geometry.boundingRect.x,
-				geom->topLevelTop + geom->top + geom->geometry.boundingRect.y,
+				geom->left + geom->geometry.boundingRect.x,
+				geom->top + geom->geometry.boundingRect.y,
 				req->SourceWidth, req->SourceHeight);
 		if (!presentation)
 		{

--- a/channels/video/client/video_main.c
+++ b/channels/video/client/video_main.c
@@ -31,12 +31,18 @@
 #include <winpr/stream.h>
 #include <winpr/cmdline.h>
 #include <winpr/collections.h>
+#include <winpr/interlocked.h>
+#include <winpr/sysinfo.h>
 
 #include <freerdp/addin.h>
+#include <freerdp/primitives.h>
 #include <freerdp/client/video.h>
 #include <freerdp/channels/log.h>
+#include <freerdp/codec/h264.h>
+#include <freerdp/codec/yuv.h>
 
-#define TAG CHANNELS_TAG("video.client")
+
+#define TAG CHANNELS_TAG("video")
 
 #include "video_main.h"
 
@@ -73,6 +79,64 @@ struct _VIDEO_PLUGIN
 };
 typedef struct _VIDEO_PLUGIN VIDEO_PLUGIN;
 
+
+#define XF_VIDEO_UNLIMITED_RATE 31
+
+BYTE MFVideoFormat_H264[] = {'H', '2', '6', '4',
+		0x00, 0x00,
+		0x10, 0x00,
+		0x80, 0x00,
+		0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71};
+
+typedef struct _PresentationContext PresentationContext;
+typedef struct _VideoFrame VideoFrame;
+
+
+/** @brief private data for the channel */
+struct _VideoClientContextPriv
+{
+	VideoClientContext *video;
+	GeometryClientContext *geometry;
+	wQueue *frames;
+	CRITICAL_SECTION framesLock;
+	wBufferPool *surfacePool;
+	UINT32 publishedFrames;
+	UINT32 droppedFrames;
+	UINT32 lastSentRate;
+	UINT64 nextFeedbackTime;
+	PresentationContext *currentPresentation;
+};
+
+/** @brief */
+struct _VideoFrame
+{
+	UINT64 publishTime;
+	UINT64 hnsDuration;
+	UINT32 x, y, w, h;
+	BYTE *surfaceData;
+	PresentationContext *presentation;
+};
+
+struct _PresentationContext
+{
+	VideoClientContext *video;
+	BYTE PresentationId;
+	UINT32 SourceWidth, SourceHeight;
+	UINT32 ScaledWidth, ScaledHeight;
+	MAPPED_GEOMETRY *geometry;
+
+	UINT64 startTimeStamp;
+	UINT64 publishOffset;
+	H264_CONTEXT *h264;
+	YUV_CONTEXT *yuv;
+	wStream *currentSample;
+	UINT64 lastPublishTime, nextPublishTime;
+	volatile LONG refCounter;
+	BYTE *surfaceData;
+	VideoSurface *surface;
+};
+
+
 static const char *video_command_name(BYTE cmd)
 {
 	switch(cmd)
@@ -86,10 +150,336 @@ static const char *video_command_name(BYTE cmd)
 	}
 }
 
+static BOOL yuv_to_rgb(PresentationContext *presentation, BYTE *dest)
+{
+	const BYTE* pYUVPoint[3];
+	H264_CONTEXT *h264 = presentation->h264;
+
+	BYTE** ppYUVData;
+	ppYUVData = h264->pYUVData;
+
+	pYUVPoint[0] = ppYUVData[0];
+	pYUVPoint[1] = ppYUVData[1];
+	pYUVPoint[2] = ppYUVData[2];
+
+	if (!yuv_context_decode(presentation->yuv, pYUVPoint, h264->iStride, PIXEL_FORMAT_BGRX32, dest, h264->width * 4))
+	{
+		WLog_ERR(TAG, "error in yuv_to_rgb conversion");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+
+static void video_client_context_set_geometry(VideoClientContext *video, GeometryClientContext *geometry)
+{
+	video->priv->geometry = geometry;
+}
+
+VideoClientContextPriv *VideoClientContextPriv_new(VideoClientContext *video)
+{
+	VideoClientContextPriv *ret = calloc(1, sizeof(*ret));
+	if (!ret)
+		return NULL;
+
+	ret->frames = Queue_New(TRUE, 10, 2);
+	if (!ret->frames)
+	{
+		WLog_ERR(TAG, "unable to allocate frames queue");
+		goto error_frames;
+	}
+
+	ret->surfacePool = BufferPool_New(FALSE, 0, 16);
+	if (!ret->surfacePool)
+	{
+		WLog_ERR(TAG, "unable to create surface pool");
+		goto error_surfacePool;
+	}
+
+	if (!InitializeCriticalSectionAndSpinCount(&ret->framesLock, 4000))
+	{
+		WLog_ERR(TAG, "unable to initialize frames lock");
+		goto error_spinlock;
+	}
+
+	ret->video = video;
+
+	 /* don't set to unlimited so that we have the chance to send a feedback in
+	  * the first second (for servers that want feedback directly)
+	  */
+	ret->lastSentRate = 30;
+	return ret;
+
+error_spinlock:
+	BufferPool_Free(ret->surfacePool);
+error_surfacePool:
+	Queue_Free(ret->frames);
+error_frames:
+	free(ret);
+	return NULL;
+}
+
+
+static PresentationContext *PresentationContext_new(VideoClientContext *video, BYTE PresentationId,
+		UINT32 x, UINT32 y, UINT32 width, UINT32 height)
+{
+	VideoClientContextPriv *priv = video->priv;
+	PresentationContext *ret = calloc(1, sizeof(*ret));
+	if (!ret)
+		return NULL;
+
+	ret->video = video;
+	ret->PresentationId = PresentationId;
+
+	ret->h264 = h264_context_new(FALSE);
+	if (!ret->h264)
+	{
+		WLog_ERR(TAG, "unable to create a h264 context");
+		goto error_h264;
+	}
+	h264_context_reset(ret->h264, width, height);
+
+	ret->currentSample = Stream_New(NULL, 4096);
+	if (!ret->currentSample)
+	{
+		WLog_ERR(TAG, "unable to create current packet stream");
+		goto error_currentSample;
+	}
+
+	ret->surfaceData = BufferPool_Take(priv->surfacePool, width * height * 4);
+	if (!ret->surfaceData)
+	{
+		WLog_ERR(TAG, "unable to allocate surfaceData");
+		goto error_surfaceData;
+	}
+
+	ret->surface = video->createSurface(video, ret->surfaceData, x, y, width, height);
+	if (!ret->surface)
+	{
+		WLog_ERR(TAG, "unable to create surface");
+		goto error_surface;
+	}
+
+	ret->yuv = yuv_context_new(FALSE);
+	if (!ret->yuv)
+	{
+		WLog_ERR(TAG, "unable to create YUV decoder");
+		goto error_yuv;
+	}
+
+	yuv_context_reset(ret->yuv, width, height);
+	ret->refCounter = 1;
+	return ret;
+
+error_yuv:
+	video->deleteSurface(video, ret->surface);
+error_surface:
+	BufferPool_Return(priv->surfacePool, ret->surfaceData);
+error_surfaceData:
+	Stream_Free(ret->currentSample, TRUE);
+error_currentSample:
+	h264_context_free(ret->h264);
+error_h264:
+	free(ret);
+	return NULL;
+}
+
+
+static void PresentationContext_unref(PresentationContext *c)
+{
+	VideoClientContextPriv *priv;
+
+	if (!c)
+		return;
+
+	if (InterlockedDecrement(&c->refCounter) != 0)
+		return;
+
+	priv = c->video->priv;
+	if (c->geometry)
+	{
+		c->geometry->MappedGeometryUpdate = NULL;
+		c->geometry->MappedGeometryClear = NULL;
+		c->geometry->custom = NULL;
+	}
+
+	h264_context_free(c->h264);
+	Stream_Free(c->currentSample, TRUE);
+	c->video->deleteSurface(c->video, c->surface);
+	BufferPool_Return(priv->surfacePool, c->surfaceData);
+	yuv_context_free(c->yuv);
+	free(c);
+}
+
+
+static void VideoFrame_free(VideoFrame **pframe)
+{
+	VideoFrame *frame = *pframe;
+
+	PresentationContext_unref(frame->presentation);
+	BufferPool_Return(frame->presentation->video->priv->surfacePool, frame->surfaceData);
+	free(frame);
+	*pframe = NULL;
+}
+
+
+static void VideoClientContextPriv_free(VideoClientContextPriv *priv)
+{
+	EnterCriticalSection(&priv->framesLock);
+	while (Queue_Count(priv->frames))
+	{
+		VideoFrame *frame = Queue_Dequeue(priv->frames);
+		if (frame)
+			VideoFrame_free(&frame);
+	}
+
+	Queue_Free(priv->frames);
+	LeaveCriticalSection(&priv->framesLock);
+
+	DeleteCriticalSection(&priv->framesLock);
+
+	if (priv->currentPresentation)
+		PresentationContext_unref(priv->currentPresentation);
+
+	BufferPool_Free(priv->surfacePool);
+	free(priv);
+}
+
+
+static UINT video_control_send_presentation_response(VideoClientContext *context, TSMM_PRESENTATION_RESPONSE *resp)
+{
+	BYTE buf[12];
+	wStream *s;
+	VIDEO_PLUGIN* video = (VIDEO_PLUGIN *)context->handle;
+	IWTSVirtualChannel* channel;
+	UINT ret;
+
+	s = Stream_New(buf, 12);
+	if (!s)
+		return CHANNEL_RC_NO_MEMORY;
+
+	Stream_Write_UINT32(s, 12); /* cbSize */
+	Stream_Write_UINT32(s, TSMM_PACKET_TYPE_PRESENTATION_RESPONSE); /* PacketType */
+	Stream_Write_UINT8(s, resp->PresentationId);
+	Stream_Zero(s, 3);
+	Stream_SealLength(s);
+
+	channel = video->control_callback->channel_callback->channel;
+	ret = channel->Write(channel, 12, buf, NULL);
+	Stream_Free(s, FALSE);
+
+	return ret;
+}
+
+static BOOL video_onMappedGeometryUpdate(MAPPED_GEOMETRY *geometry)
+{
+	WLog_DBG(TAG, "geometry updated");
+	return TRUE;
+}
+
+static BOOL video_onMappedGeometryClear(MAPPED_GEOMETRY *geometry)
+{
+	PresentationContext *presentation = (PresentationContext *)geometry->custom;
+
+	presentation->geometry = NULL;
+	return TRUE;
+}
+
+static UINT video_PresentationRequest(VideoClientContext* video, TSMM_PRESENTATION_REQUEST *req)
+{
+	VideoClientContextPriv *priv = video->priv;
+	PresentationContext *presentation;
+	UINT ret = CHANNEL_RC_OK;
+
+	presentation = priv->currentPresentation;
+
+	if (req->Command == TSMM_START_PRESENTATION)
+	{
+		MAPPED_GEOMETRY *geom;
+		TSMM_PRESENTATION_RESPONSE resp;
+
+		if (memcmp(req->VideoSubtypeId, MFVideoFormat_H264, 16) != 0)
+		{
+			WLog_ERR(TAG, "not a H264 video, ignoring request");
+			return CHANNEL_RC_OK;
+		}
+
+		if (presentation)
+		{
+			if (presentation->PresentationId == req->PresentationId)
+			{
+				WLog_ERR(TAG, "ignoring start request for existing presentation %d", req->PresentationId);
+				return CHANNEL_RC_OK;
+			}
+
+			WLog_ERR(TAG, "releasing current presentation %d", req->PresentationId);
+			PresentationContext_unref(presentation);
+			presentation = priv->currentPresentation = NULL;
+		}
+
+		if (!priv->geometry)
+		{
+			WLog_ERR(TAG, "geometry channel not ready, ignoring request");
+			return CHANNEL_RC_OK;
+		}
+
+		geom = HashTable_GetItemValue(priv->geometry->geometries, &(req->GeometryMappingId));
+		if (!geom)
+		{
+			WLog_ERR(TAG, "geometry mapping 0x%"PRIx64" not registered", req->GeometryMappingId);
+			return CHANNEL_RC_OK;
+		}
+
+		WLog_DBG(TAG, "creating presentation 0x%x", req->PresentationId);
+		presentation = PresentationContext_new(video, req->PresentationId,
+				geom->topLevelLeft + geom->left + geom->geometry.boundingRect.x,
+				geom->topLevelTop + geom->top + geom->geometry.boundingRect.y,
+				req->SourceWidth, req->SourceHeight);
+		if (!presentation)
+		{
+			WLog_ERR(TAG, "unable to create presentation video");
+			return CHANNEL_RC_NO_MEMORY;
+		}
+
+		priv->currentPresentation = presentation;
+		presentation->video = video;
+		presentation->geometry = geom;
+		presentation->SourceWidth = req->SourceWidth;
+		presentation->SourceHeight = req->SourceHeight;
+		presentation->ScaledWidth = req->ScaledWidth;
+		presentation->ScaledHeight = req->ScaledHeight;
+
+		geom->custom = presentation;
+		geom->MappedGeometryUpdate = video_onMappedGeometryUpdate;
+		geom->MappedGeometryClear = video_onMappedGeometryClear;
+
+		/* send back response */
+		resp.PresentationId = req->PresentationId;
+		ret = video_control_send_presentation_response(video, &resp);
+	}
+	else if (req->Command == TSMM_STOP_PRESENTATION)
+	{
+		WLog_DBG(TAG, "stopping presentation 0x%x", req->PresentationId);
+		if (!presentation)
+		{
+			WLog_ERR(TAG, "unknown presentation to stop %d", req->PresentationId);
+			return CHANNEL_RC_OK;
+		}
+
+		priv->currentPresentation = NULL;
+		priv->droppedFrames = 0;
+		priv->publishedFrames = 0;
+		PresentationContext_unref(presentation);
+	}
+
+	return CHANNEL_RC_OK;
+}
+
+
 static UINT video_read_tsmm_presentation_req(VideoClientContext *context, wStream *s)
 {
 	TSMM_PRESENTATION_REQUEST req;
-	UINT ret = CHANNEL_RC_OK;
 
 	if (Stream_GetRemainingLength(s) < 60)
 	{
@@ -129,36 +519,9 @@ static UINT video_read_tsmm_presentation_req(VideoClientContext *context, wStrea
 			req.SourceWidth, req.SourceHeight, req.ScaledWidth, req.ScaledHeight,
 			req.hnsTimestampOffset, req.GeometryMappingId);
 
-	if (context->PresentationRequest)
-		ret = context->PresentationRequest(context, &req);
-
-	return ret;
+	return video_PresentationRequest(context, &req);
 }
 
-static UINT video_control_send_presentation_response(VideoClientContext *context, TSMM_PRESENTATION_RESPONSE *resp)
-{
-	BYTE buf[12];
-	wStream *s;
-	VIDEO_PLUGIN* video = (VIDEO_PLUGIN *)context->handle;
-	IWTSVirtualChannel* channel;
-	UINT ret;
-
-	s = Stream_New(buf, 12);
-	if (!s)
-		return CHANNEL_RC_NO_MEMORY;
-
-	Stream_Write_UINT32(s, 12); /* cbSize */
-	Stream_Write_UINT32(s, TSMM_PACKET_TYPE_PRESENTATION_RESPONSE); /* PacketType */
-	Stream_Write_UINT8(s, resp->PresentationId);
-	Stream_Zero(s, 3);
-	Stream_SealLength(s);
-
-	channel = video->control_callback->channel_callback->channel;
-	ret = channel->Write(channel, 12, buf, NULL);
-	Stream_Free(s, FALSE);
-
-	return ret;
-}
 
 
 /**
@@ -248,6 +611,263 @@ static UINT video_control_send_client_notification(VideoClientContext *context, 
 	return ret;
 }
 
+static void video_timer(VideoClientContext *video, UINT64 now)
+{
+	PresentationContext *presentation;
+	VideoClientContextPriv *priv = video->priv;
+	VideoFrame *peekFrame, *frame = NULL;
+
+	EnterCriticalSection(&priv->framesLock);
+	do
+	{
+		peekFrame = (VideoFrame *)Queue_Peek(priv->frames);
+		if (!peekFrame)
+			break;
+
+		if (peekFrame->publishTime > now)
+			break;
+
+		if (frame)
+		{
+			/* free skipped frame */
+			WLog_DBG(TAG, "dropping frame @%"PRIu64, frame->publishTime);
+			priv->droppedFrames++;
+			VideoFrame_free(&frame);
+		}
+		frame = peekFrame;
+		Queue_Dequeue(priv->frames);
+	}
+	while (1);
+	LeaveCriticalSection(&priv->framesLock);
+
+	if (!frame)
+		goto treat_feedback;
+
+	presentation = frame->presentation;
+
+	priv->publishedFrames++;
+	memcpy(presentation->surfaceData, frame->surfaceData, frame->w * frame->h * 4);
+
+	video->showSurface(video, presentation->surface);
+
+	PresentationContext_unref(presentation);
+	BufferPool_Return(priv->surfacePool, frame->surfaceData);
+	free(frame);
+
+treat_feedback:
+	if (priv->nextFeedbackTime < now)
+	{
+		/* we can compute some feedback only if we have some published frames and
+		 * a current presentation
+		 */
+		if (priv->publishedFrames && priv->currentPresentation)
+		{
+			UINT32 computedRate;
+
+			InterlockedIncrement(&priv->currentPresentation->refCounter);
+
+			if (priv->droppedFrames)
+			{
+				/**
+				 * some dropped frames, looks like we're asking too many frames per seconds,
+				 * try lowering rate. We go directly from unlimited rate to 24 frames/seconds
+				 * otherwise we lower rate by 2 frames by seconds
+				 */
+				if (priv->lastSentRate == XF_VIDEO_UNLIMITED_RATE)
+					computedRate = 24;
+				else
+				{
+					computedRate = priv->lastSentRate - 2;
+					if (!computedRate)
+						computedRate = 2;
+				}
+			}
+			else
+			{
+				/**
+				 * we treat all frames ok, so either ask the server to send more,
+				 * or stay unlimited
+			 */
+				if (priv->lastSentRate == XF_VIDEO_UNLIMITED_RATE)
+					computedRate = XF_VIDEO_UNLIMITED_RATE; /* stay unlimited */
+				else
+				{
+					computedRate = priv->lastSentRate + 2;
+					if (computedRate > XF_VIDEO_UNLIMITED_RATE)
+						computedRate = XF_VIDEO_UNLIMITED_RATE;
+				}
+			}
+
+			if (computedRate != priv->lastSentRate)
+			{
+				TSMM_CLIENT_NOTIFICATION notif;
+				notif.PresentationId = priv->currentPresentation->PresentationId;
+				notif.NotificationType = TSMM_CLIENT_NOTIFICATION_TYPE_FRAMERATE_OVERRIDE;
+				if (computedRate == XF_VIDEO_UNLIMITED_RATE)
+				{
+					notif.FramerateOverride.Flags = 0x01;
+					notif.FramerateOverride.DesiredFrameRate = 0x00;
+				}
+				else
+				{
+					notif.FramerateOverride.Flags = 0x02;
+					notif.FramerateOverride.DesiredFrameRate = computedRate;
+				}
+
+				video_control_send_client_notification(video, &notif);
+				priv->lastSentRate = computedRate;
+
+				WLog_DBG(TAG, "server notified with rate %d published=%d dropped=%d", priv->lastSentRate,
+						priv->publishedFrames, priv->droppedFrames);
+			}
+
+			PresentationContext_unref(priv->currentPresentation);
+		}
+
+		WLog_DBG(TAG, "currentRate=%d published=%d dropped=%d", priv->lastSentRate,
+				priv->publishedFrames, priv->droppedFrames);
+
+		priv->droppedFrames = 0;
+		priv->publishedFrames = 0;
+		priv->nextFeedbackTime = now + 1000;
+	}
+}
+
+
+static UINT video_VideoData(VideoClientContext* context, TSMM_VIDEO_DATA *data)
+{
+	VideoClientContextPriv *priv = context->priv;
+	PresentationContext *presentation;
+	int status;
+
+	presentation = priv->currentPresentation;
+	if (!presentation)
+	{
+		WLog_ERR(TAG, "no current presentation");
+		return CHANNEL_RC_OK;
+	}
+
+	if (presentation->PresentationId != data->PresentationId)
+	{
+		WLog_ERR(TAG, "current presentation id=%d doesn't match data id=%d", presentation->PresentationId,
+				data->PresentationId);
+		return CHANNEL_RC_OK;
+	}
+
+	if (!Stream_EnsureRemainingCapacity(presentation->currentSample, data->cbSample))
+	{
+		WLog_ERR(TAG, "unable to expand the current packet");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	Stream_Write(presentation->currentSample, data->pSample, data->cbSample);
+
+	if (data->CurrentPacketIndex == data->PacketsInSample)
+	{
+		H264_CONTEXT *h264 = presentation->h264;
+		UINT64 startTime = GetTickCount64(), timeAfterH264;
+		MAPPED_GEOMETRY *geom = presentation->geometry;
+
+		Stream_SealLength(presentation->currentSample);
+		Stream_SetPosition(presentation->currentSample, 0);
+
+		status = h264->subsystem->Decompress(h264, Stream_Pointer(presentation->currentSample),
+				Stream_Length(presentation->currentSample));
+		if (status == 0)
+			return CHANNEL_RC_OK;
+
+		if (status < 0)
+			return CHANNEL_RC_OK;
+
+		timeAfterH264 = GetTickCount64();
+		if (data->SampleNumber == 1)
+		{
+			presentation->lastPublishTime = startTime;
+		}
+
+		presentation->lastPublishTime += (data->hnsDuration / 10000);
+		if (presentation->lastPublishTime <= timeAfterH264 + 10)
+		{
+			int dropped = 0;
+
+			/* if the frame is to be published in less than 10 ms, let's consider it's now */
+			yuv_to_rgb(presentation, presentation->surfaceData);
+
+			context->showSurface(context, presentation->surface);
+
+			priv->publishedFrames++;
+
+			/* cleanup previously scheduled frames */
+			EnterCriticalSection(&priv->framesLock);
+			while (Queue_Count(priv->frames) > 0)
+			{
+				VideoFrame *frame = Queue_Dequeue(priv->frames);
+				if (frame)
+				{
+					priv->droppedFrames++;
+					VideoFrame_free(&frame);
+					dropped++;
+				}
+			}
+			LeaveCriticalSection(&priv->framesLock);
+
+			if (dropped)
+				WLog_DBG(TAG, "showing frame (%d dropped)", dropped);
+		}
+		else
+		{
+			BOOL enqueueResult;
+			VideoFrame *frame = calloc(1, sizeof(*frame));
+			if (!frame)
+			{
+				WLog_ERR(TAG, "unable to create frame");
+				return CHANNEL_RC_NO_MEMORY;
+			}
+
+			frame->presentation = presentation;
+			frame->publishTime = presentation->lastPublishTime;
+			frame->x = geom->topLevelLeft + geom->left + geom->geometry.boundingRect.x;
+			frame->y = geom->topLevelTop + geom->top + geom->geometry.boundingRect.y;
+			frame->w = presentation->SourceWidth;
+			frame->h = presentation->SourceHeight;
+
+			frame->surfaceData = BufferPool_Take(priv->surfacePool, frame->w * frame->h * 4);
+			if (!frame->surfaceData)
+			{
+				WLog_ERR(TAG, "unable to allocate frame data");
+				free(frame);
+				return CHANNEL_RC_NO_MEMORY;
+			}
+
+			if (!yuv_to_rgb(presentation, frame->surfaceData))
+			{
+				WLog_ERR(TAG, "error during YUV->RGB conversion");
+				BufferPool_Return(priv->surfacePool, frame->surfaceData);
+				free(frame);
+				return CHANNEL_RC_NO_MEMORY;
+			}
+
+			InterlockedIncrement(&presentation->refCounter);
+
+			EnterCriticalSection(&priv->framesLock);
+			enqueueResult = Queue_Enqueue(priv->frames, frame);
+			LeaveCriticalSection(&priv->framesLock);
+
+			if (!enqueueResult)
+			{
+				WLog_ERR(TAG, "unable to enqueue frame");
+				VideoFrame_free(&frame);
+				return CHANNEL_RC_NO_MEMORY;
+			}
+
+			WLog_DBG(TAG, "scheduling frame in %"PRIu32" ms", (frame->publishTime-startTime));
+		}
+	}
+
+	return CHANNEL_RC_OK;
+}
+
+
 
 static UINT video_data_on_data_received(IWTSVirtualChannelCallback* pChannelCallback, wStream *s)
 {
@@ -295,15 +915,14 @@ static UINT video_data_on_data_received(IWTSVirtualChannelCallback* pChannelCall
 	Stream_Read_UINT32(s, data.cbSample);
 	data.pSample = Stream_Pointer(s);
 
+/*
 	WLog_DBG(TAG, "videoData: id:%"PRIu8" version:%"PRIu8" flags:0x%"PRIx8" timestamp=%"PRIu64" duration=%"PRIu64
 			" curPacketIndex:%"PRIu16" packetInSample:%"PRIu16" sampleNumber:%"PRIu32" cbSample:%"PRIu32"",
 			data.PresentationId, data.Version, data.Flags, data.hnsTimestamp, data.hnsDuration,
 			data.CurrentPacketIndex, data.PacketsInSample, data.SampleNumber, data.cbSample);
+*/
 
-	if (context->VideoData)
-		return context->VideoData(context, &data);
-
-	return CHANNEL_RC_OK;
+	return video_VideoData(context, &data);
 }
 
 
@@ -441,6 +1060,9 @@ static UINT video_plugin_terminated(IWTSPlugin* pPlugin)
 {
 	VIDEO_PLUGIN* video = (VIDEO_PLUGIN*) pPlugin;
 
+	if (video->context)
+		VideoClientContextPriv_free(video->context->priv);
+
 	free(video->control_callback);
 	free(video->data_callback);
 	free(video->wtsPlugin.pInterface);
@@ -468,7 +1090,8 @@ UINT DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 {
 	UINT error = CHANNEL_RC_OK;
 	VIDEO_PLUGIN* videoPlugin;
-	VideoClientContext* context;
+	VideoClientContext* videoContext;
+	VideoClientContextPriv *priv;
 
 	videoPlugin = (VIDEO_PLUGIN*) pEntryPoints->GetPlugin(pEntryPoints, "video");
 	if (!videoPlugin)
@@ -485,20 +1108,30 @@ UINT DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 		videoPlugin->wtsPlugin.Disconnected = NULL;
 		videoPlugin->wtsPlugin.Terminated = video_plugin_terminated;
 
-		context = (VideoClientContext*) calloc(1, sizeof(VideoClientContext));
-		if (!context)
+		videoContext = (VideoClientContext*) calloc(1, sizeof(VideoClientContext));
+		if (!videoContext)
 		{
 			WLog_ERR(TAG, "calloc failed!");
 			free(videoPlugin);
 			return CHANNEL_RC_NO_MEMORY;
 		}
 
-		context->handle = (void*) videoPlugin;
-		context->PresentationResponse = video_control_send_presentation_response;
-		context->ClientNotification = video_control_send_client_notification;
+		priv = VideoClientContextPriv_new(videoContext);
+		if (!priv)
+		{
+			WLog_ERR(TAG, "VideoClientContextPriv_new failed!");
+			free(videoContext);
+			free(videoPlugin);
+			return CHANNEL_RC_NO_MEMORY;
+		}
 
-		videoPlugin->wtsPlugin.pInterface = (void*) context;
-		videoPlugin->context = context;
+		videoContext->handle = (void*) videoPlugin;
+		videoContext->priv = priv;
+		videoContext->timer = video_timer;
+		videoContext->setGeometry = video_client_context_set_geometry;
+
+		videoPlugin->wtsPlugin.pInterface = (void*) videoContext;
+		videoPlugin->context = videoContext;
 
 		error = pEntryPoints->RegisterPlugin(pEntryPoints, "video", (IWTSPlugin*) videoPlugin);
 	}

--- a/channels/video/client/video_main.c
+++ b/channels/video/client/video_main.c
@@ -100,7 +100,7 @@ static UINT video_read_tsmm_presentation_req(VideoClientContext *context, wStrea
 	Stream_Read_UINT8(s, req.PresentationId);
 	Stream_Read_UINT8(s, req.Version);
 	Stream_Read_UINT8(s, req.Command);
-	Stream_Seek_UINT8(s); /* FrameRate - reserved and ignored */
+	Stream_Read_UINT8(s, req.FrameRate); /* FrameRate - reserved and ignored */
 
 	Stream_Seek_UINT16(s); /* AverageBitrateKbps reserved and ignored */
 	Stream_Seek_UINT16(s); /* reserved */

--- a/channels/video/client/video_main.h
+++ b/channels/video/client/video_main.h
@@ -1,0 +1,35 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Video Optimized Remoting Virtual Channel Extension
+ *
+ * Copyright 2017 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_VIDEO_CLIENT_MAIN_H
+#define FREERDP_CHANNEL_VIDEO_CLIENT_MAIN_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <freerdp/dvc.h>
+#include <freerdp/types.h>
+#include <freerdp/addin.h>
+
+#include <freerdp/channels/video.h>
+
+
+#endif /* FREERDP_CHANNEL_GEOMETRY_CLIENT_MAIN_H */
+

--- a/client/X11/CMakeLists.txt
+++ b/client/X11/CMakeLists.txt
@@ -50,6 +50,8 @@ set(${MODULE_PREFIX}_SRCS
 	xf_graphics.h
 	xf_keyboard.c
 	xf_keyboard.h
+	xf_video.c
+	xf_video.h
 	xf_window.c
 	xf_window.h
 	xf_client.c

--- a/client/X11/xf_channels.c
+++ b/client/X11/xf_channels.c
@@ -31,7 +31,7 @@
 #include "xf_rail.h"
 #include "xf_cliprdr.h"
 #include "xf_disp.h"
-
+#include "xf_video.h"
 
 void xf_OnChannelConnectedEventHandler(rdpContext* context, ChannelConnectedEventArgs* e)
 {
@@ -68,6 +68,18 @@ void xf_OnChannelConnectedEventHandler(rdpContext* context, ChannelConnectedEven
 	else if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) == 0)
 	{
 		xf_disp_init(xfc, (DispClientContext*)e->pInterface);
+	}
+	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
+	{
+		xf_video_geometry_init(xfc, (GeometryClientContext*)e->pInterface);
+	}
+	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
+	{
+		xf_video_control_init(xfc, (VideoClientContext*)e->pInterface);
+	}
+	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
+	{
+		xf_video_data_init(xfc, (VideoClientContext*)e->pInterface);
 	}
 }
 

--- a/client/X11/xf_channels.c
+++ b/client/X11/xf_channels.c
@@ -115,4 +115,13 @@ void xf_OnChannelDisconnectedEventHandler(rdpContext* context, ChannelDisconnect
 	{
 		xf_encomsp_uninit(xfc, (EncomspClientContext*) e->pInterface);
 	}
+	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
+	{
+		xf_video_control_uninit(xfc, (VideoClientContext*)e->pInterface);
+	}
+	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
+	{
+		xf_video_data_uninit(xfc, (VideoClientContext*)e->pInterface);
+	}
+
 }

--- a/client/X11/xf_channels.c
+++ b/client/X11/xf_channels.c
@@ -72,10 +72,7 @@ void xf_OnChannelConnectedEventHandler(rdpContext* context, ChannelConnectedEven
 	}
 	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
 	{
-		if (settings->SoftwareGdi)
-			gdi_video_geometry_init(xfc->context.gdi, (GeometryClientContext*)e->pInterface);
-		else
-			xf_video_geometry_init(xfc, (GeometryClientContext*)e->pInterface);
+		gdi_video_geometry_init(xfc->context.gdi, (GeometryClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
 	{
@@ -86,10 +83,7 @@ void xf_OnChannelConnectedEventHandler(rdpContext* context, ChannelConnectedEven
 	}
 	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
 	{
-		if (settings->SoftwareGdi)
-			gdi_video_data_init(xfc->context.gdi, (VideoClientContext*)e->pInterface);
-		else
-			xf_video_data_init(xfc, (VideoClientContext*)e->pInterface);
+		gdi_video_data_init(xfc->context.gdi, (VideoClientContext*)e->pInterface);
 	}
 }
 
@@ -127,10 +121,7 @@ void xf_OnChannelDisconnectedEventHandler(rdpContext* context, ChannelDisconnect
 	}
 	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
 	{
-		if (settings->SoftwareGdi)
-			gdi_video_geometry_uninit(xfc->context.gdi, (GeometryClientContext*)e->pInterface);
-		else
-			xf_video_geometry_uninit(xfc, (GeometryClientContext*)e->pInterface);
+		gdi_video_geometry_uninit(xfc->context.gdi, (GeometryClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
 	{
@@ -141,9 +132,6 @@ void xf_OnChannelDisconnectedEventHandler(rdpContext* context, ChannelDisconnect
 	}
 	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
 	{
-		if (settings->SoftwareGdi)
-			gdi_video_data_uninit(xfc->context.gdi, (VideoClientContext*)e->pInterface);
-		else
-			xf_video_data_uninit(xfc, (VideoClientContext*)e->pInterface);
+		gdi_video_data_uninit(xfc->context.gdi, (VideoClientContext*)e->pInterface);
 	}
 }

--- a/client/X11/xf_channels.c
+++ b/client/X11/xf_channels.c
@@ -21,6 +21,7 @@
 #include "config.h"
 #endif
 
+#include <freerdp/gdi/video.h>
 #include "xf_channels.h"
 
 #include "xf_client.h"
@@ -71,15 +72,24 @@ void xf_OnChannelConnectedEventHandler(rdpContext* context, ChannelConnectedEven
 	}
 	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
 	{
-		xf_video_geometry_init(xfc, (GeometryClientContext*)e->pInterface);
+		if (settings->SoftwareGdi)
+			gdi_video_geometry_init(xfc->context.gdi, (GeometryClientContext*)e->pInterface);
+		else
+			xf_video_geometry_init(xfc, (GeometryClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
 	{
-		xf_video_control_init(xfc, (VideoClientContext*)e->pInterface);
+		if (settings->SoftwareGdi)
+			gdi_video_control_init(xfc->context.gdi, (VideoClientContext*)e->pInterface);
+		else
+			xf_video_control_init(xfc, (VideoClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
 	{
-		xf_video_data_init(xfc, (VideoClientContext*)e->pInterface);
+		if (settings->SoftwareGdi)
+			gdi_video_data_init(xfc->context.gdi, (VideoClientContext*)e->pInterface);
+		else
+			xf_video_data_init(xfc, (VideoClientContext*)e->pInterface);
 	}
 }
 
@@ -115,13 +125,25 @@ void xf_OnChannelDisconnectedEventHandler(rdpContext* context, ChannelDisconnect
 	{
 		xf_encomsp_uninit(xfc, (EncomspClientContext*) e->pInterface);
 	}
+	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
+	{
+		if (settings->SoftwareGdi)
+			gdi_video_geometry_uninit(xfc->context.gdi, (GeometryClientContext*)e->pInterface);
+		else
+			xf_video_geometry_uninit(xfc, (GeometryClientContext*)e->pInterface);
+	}
 	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
 	{
-		xf_video_control_uninit(xfc, (VideoClientContext*)e->pInterface);
+		if (settings->SoftwareGdi)
+			gdi_video_control_uninit(xfc->context.gdi, (VideoClientContext*)e->pInterface);
+		else
+			xf_video_control_uninit(xfc, (VideoClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
 	{
-		xf_video_data_uninit(xfc, (VideoClientContext*)e->pInterface);
+		if (settings->SoftwareGdi)
+			gdi_video_data_uninit(xfc->context.gdi, (VideoClientContext*)e->pInterface);
+		else
+			xf_video_data_uninit(xfc, (VideoClientContext*)e->pInterface);
 	}
-
 }

--- a/client/X11/xf_channels.h
+++ b/client/X11/xf_channels.h
@@ -29,6 +29,8 @@
 #include <freerdp/client/rdpgfx.h>
 #include <freerdp/client/encomsp.h>
 #include <freerdp/client/disp.h>
+#include <freerdp/client/geometry.h>
+#include <freerdp/client/video.h>
 
 int xf_on_channel_connected(freerdp* instance, const char* name, void* pInterface);
 int xf_on_channel_disconnected(freerdp* instance, const char* name, void* pInterface);

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1322,6 +1322,12 @@ static void xf_post_disconnect(freerdp* instance)
 		xfc->drawable = NULL;
 	else
 		xf_DestroyDummyWindow(xfc, xfc->drawable);
+	
+	if (xfc->xfVideo)
+	{
+		xf_video_free(xfc->xfVideo);
+		xfc->xfVideo = NULL;
+	}
 
 	xf_window_free(xfc);
 	xf_keyboard_free(xfc);

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -97,6 +97,7 @@
 #include "xf_input.h"
 #include "xf_cliprdr.h"
 #include "xf_disp.h"
+#include "xf_video.h"
 #include "xf_monitor.h"
 #include "xf_graphics.h"
 #include "xf_keyboard.h"
@@ -1279,6 +1280,13 @@ static BOOL xf_post_connect(freerdp* instance)
 		return FALSE;
 	}
 
+	if (!(xfc->xfVideo = xf_video_new(xfc)))
+	{
+		xf_clipboard_free(xfc->clipboard);
+		xf_disp_free(xfc->xfDisp);
+		return FALSE;
+	}
+
 	EventArgsInit(&e, "xfreerdp");
 	e.width = settings->DesktopWidth;
 	e.height = settings->DesktopHeight;
@@ -1529,7 +1537,7 @@ static void* xf_client_thread(void* param)
 
 	due.QuadPart = 0;
 
-	if (!SetWaitableTimer(timer, &due, 100, NULL, NULL, FALSE))
+	if (!SetWaitableTimer(timer, &due, 20, NULL, NULL, FALSE))
 	{
 		goto disconnect;
 	}

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1280,12 +1280,12 @@ static BOOL xf_post_connect(freerdp* instance)
 		return FALSE;
 	}
 
-	if (!(xfc->xfVideo = xf_video_new(xfc)))
+/*	if (!(xfc->xfVideo = xf_video_new(xfc)))
 	{
 		xf_clipboard_free(xfc->clipboard);
 		xf_disp_free(xfc->xfDisp);
 		return FALSE;
-	}
+	}*/
 
 	EventArgsInit(&e, "xfreerdp");
 	e.width = settings->DesktopWidth;
@@ -1323,12 +1323,6 @@ static void xf_post_disconnect(freerdp* instance)
 	else
 		xf_DestroyDummyWindow(xfc, xfc->drawable);
 	
-	if (xfc->xfVideo)
-	{
-		xf_video_free(xfc->xfVideo);
-		xfc->xfVideo = NULL;
-	}
-
 	xf_window_free(xfc);
 	xf_keyboard_free(xfc);
 }

--- a/client/X11/xf_video.c
+++ b/client/X11/xf_video.c
@@ -1,0 +1,631 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Video Optimized Remoting Virtual Channel Extension for X11
+ *
+ * Copyright 2017 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <winpr/sysinfo.h>
+#include <winpr/interlocked.h>
+
+#include <freerdp/client/geometry.h>
+#include <freerdp/client/video.h>
+#include <freerdp/primitives.h>
+#include <freerdp/codec/h264.h>
+#include <freerdp/codec/yuv.h>
+
+#include "xf_video.h"
+
+#define TAG CLIENT_TAG("video")
+#define XF_VIDEO_UNLIMITED_RATE 31
+
+
+BYTE MFVideoFormat_H264[] = {'H', '2', '6', '4',
+		0x00, 0x00,
+		0x10, 0x00,
+		0x80, 0x00,
+		0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71};
+
+typedef struct _xfPresentationContext xfPresentationContext;
+
+struct _xfVideoContext
+{
+	xfContext *xfc;
+	wQueue *frames;
+	CRITICAL_SECTION framesLock;
+	wBufferPool *surfacePool;
+	UINT32 publishedFrames;
+	UINT32 droppedFrames;
+	UINT32 lastSentRate;
+	UINT64 nextFeedbackTime;
+	xfPresentationContext *currentPresentation;
+};
+
+struct _xfVideoFrame
+{
+	UINT64 publishTime;
+	UINT64 hnsDuration;
+	UINT32 x, y, w, h;
+	BYTE *surfaceData;
+	xfPresentationContext *presentation;
+};
+typedef struct _xfVideoFrame xfVideoFrame;
+
+struct _xfPresentationContext
+{
+	xfContext *xfc;
+	xfVideoContext *xfVideo;
+	BYTE PresentationId;
+	UINT32 SourceWidth, SourceHeight;
+	UINT32 ScaledWidth, ScaledHeight;
+	MAPPED_GEOMETRY *geometry;
+
+	UINT64 startTimeStamp;
+	UINT64 publishOffset;
+	H264_CONTEXT *h264;
+	YUV_CONTEXT *yuv;
+	wStream *currentSample;
+	BYTE *surfaceData;
+	XImage *surface;
+	UINT64 lastPublishTime, nextPublishTime;
+	volatile LONG refCounter;
+};
+
+
+
+static void xfPresentationContext_unref(xfPresentationContext *c)
+{
+	xfVideoContext *xfVideo;
+
+	if (!c)
+		return;
+
+	if (InterlockedDecrement(&c->refCounter) != 0)
+		return;
+
+	xfVideo = c->xfVideo;
+	if (c->geometry)
+	{
+		c->geometry->MappedGeometryUpdate = NULL;
+		c->geometry->MappedGeometryClear = NULL;
+		c->geometry->custom = NULL;
+	}
+
+	h264_context_free(c->h264);
+	Stream_Free(c->currentSample, TRUE);
+	XFree(c->surface);
+	BufferPool_Return(xfVideo->surfacePool, c->surfaceData);
+	yuv_context_free(c->yuv);
+	free(c);
+}
+
+
+static xfPresentationContext *xfPresentationContext_new(xfContext *xfc, BYTE PresentationId, UINT32 width, UINT32 height)
+{
+	xfVideoContext *xfVideo = xfc->xfVideo;
+	xfPresentationContext *ret = calloc(1, sizeof(*ret));
+	if (!ret)
+		return NULL;
+
+	ret->xfc = xfc;
+	ret->PresentationId = PresentationId;
+
+	ret->h264 = h264_context_new(FALSE);
+	if (!ret->h264)
+	{
+		WLog_ERR(TAG, "unable to create a h264 context");
+		goto error_h264;
+	}
+	h264_context_reset(ret->h264, width, height);
+
+	ret->currentSample = Stream_New(NULL, 4096);
+	if (!ret->currentSample)
+	{
+		WLog_ERR(TAG, "unable to create current packet stream");
+		goto error_currentSample;
+	}
+
+	ret->surfaceData = BufferPool_Take(xfVideo->surfacePool, width * height * 4);
+	if (!ret->surfaceData)
+	{
+		WLog_ERR(TAG, "unable to allocate surfaceData");
+		goto error_surfaceData;
+	}
+
+	ret->surface = XCreateImage(xfc->display, xfc->visual, xfc->depth, ZPixmap, 0,
+			(char *)ret->surfaceData, width, height, 8, width * 4);
+	if (!ret->surface)
+	{
+		WLog_ERR(TAG, "unable to create surface");
+		goto error_surface;
+	}
+
+	ret->yuv = yuv_context_new(FALSE);
+	if (!ret->yuv)
+	{
+		WLog_ERR(TAG, "unable to create YUV decoder");
+		goto error_yuv;
+	}
+
+	yuv_context_reset(ret->yuv, width, height);
+	ret->refCounter = 1;
+	return ret;
+
+error_yuv:
+	XFree(ret->surface);
+error_surface:
+	BufferPool_Return(xfVideo->surfacePool, ret->surfaceData);
+error_surfaceData:
+	Stream_Free(ret->currentSample, TRUE);
+error_currentSample:
+	h264_context_free(ret->h264);
+error_h264:
+	free(ret);
+	return NULL;
+}
+
+xfVideoContext *xf_video_new(xfContext *xfc)
+{
+	xfVideoContext *ret = calloc(1, sizeof(xfVideoContext));
+	if (!ret)
+		return NULL;
+
+	ret->frames = Queue_New(TRUE, 10, 2);
+	if (!ret->frames)
+	{
+		WLog_ERR(TAG, "unable to allocate frames queue");
+		goto error_frames;
+	}
+
+	ret->surfacePool = BufferPool_New(FALSE, 0, 16);
+	if (!ret->surfacePool)
+	{
+		WLog_ERR(TAG, "unable to create surface pool");
+		goto error_surfacePool;
+	}
+
+	if (!InitializeCriticalSectionAndSpinCount(&ret->framesLock, 4000))
+	{
+		WLog_ERR(TAG, "unable to initialize frames lock");
+		goto error_spinlock;
+	}
+
+	ret->xfc = xfc;
+	ret->lastSentRate = XF_VIDEO_UNLIMITED_RATE;
+	return ret;
+
+error_spinlock:
+	BufferPool_Free(ret->surfacePool);
+error_surfacePool:
+	Queue_Free(ret->frames);
+error_frames:
+	free(ret);
+	return NULL;
+}
+
+
+void xf_video_geometry_init(xfContext *xfc, GeometryClientContext *geom)
+{
+	xfc->geometry = geom;
+}
+
+static BOOL xf_video_onMappedGeometryUpdate(MAPPED_GEOMETRY *geometry)
+{
+	return TRUE;
+}
+
+static BOOL xf_video_onMappedGeometryClear(MAPPED_GEOMETRY *geometry)
+{
+	xfPresentationContext *presentation = (xfPresentationContext *)geometry->custom;
+
+	presentation->geometry = NULL;
+	return TRUE;
+}
+
+
+static UINT xf_video_PresentationRequest(VideoClientContext* context, TSMM_PRESENTATION_REQUEST *req)
+{
+	xfContext *xfc = context->custom;
+	xfVideoContext *xfVideo = xfc->xfVideo;
+	xfPresentationContext *presentation;
+	UINT ret = CHANNEL_RC_OK;
+
+	presentation = xfVideo->currentPresentation;
+
+	if (req->Command == TSMM_START_PRESENTATION)
+	{
+		MAPPED_GEOMETRY *geom;
+		TSMM_PRESENTATION_RESPONSE resp;
+
+		if (memcmp(req->VideoSubtypeId, MFVideoFormat_H264, 16) != 0)
+		{
+			WLog_ERR(TAG, "not a H264 video, ignoring request");
+			return CHANNEL_RC_OK;
+		}
+
+		if (presentation)
+		{
+			if (presentation->PresentationId == req->PresentationId)
+			{
+				WLog_ERR(TAG, "ignoring start request for existing presentation %d", req->PresentationId);
+				return CHANNEL_RC_OK;
+			}
+
+			WLog_ERR(TAG, "releasing current presentation %d", req->PresentationId);
+			xfPresentationContext_unref(presentation);
+			presentation = xfVideo->currentPresentation = NULL;
+		}
+
+		if (!xfc->geometry)
+		{
+			WLog_ERR(TAG, "geometry channel not ready, ignoring request");
+			return CHANNEL_RC_OK;
+		}
+
+		geom = HashTable_GetItemValue(xfc->geometry->geometries, &(req->GeometryMappingId));
+		if (!geom)
+		{
+			WLog_ERR(TAG, "geometry mapping 0x%"PRIx64" not registered", req->GeometryMappingId);
+			return CHANNEL_RC_OK;
+		}
+
+		WLog_DBG(TAG, "creating presentation 0x%x", req->PresentationId);
+		presentation = xfPresentationContext_new(xfc, req->PresentationId, req->SourceWidth, req->SourceHeight);
+		if (!presentation)
+		{
+			WLog_ERR(TAG, "unable to create presentation context");
+			return CHANNEL_RC_NO_MEMORY;
+		}
+
+		xfVideo->currentPresentation = presentation;
+		presentation->xfVideo = xfVideo;
+		presentation->geometry = geom;
+		presentation->SourceWidth = req->SourceWidth;
+		presentation->SourceHeight = req->SourceHeight;
+		presentation->ScaledWidth = req->ScaledWidth;
+		presentation->ScaledHeight = req->ScaledHeight;
+
+		geom->custom = presentation;
+		geom->MappedGeometryUpdate = xf_video_onMappedGeometryUpdate;
+		geom->MappedGeometryClear = xf_video_onMappedGeometryClear;
+
+		/* send back response */
+		resp.PresentationId = req->PresentationId;
+		ret = context->PresentationResponse(context, &resp);
+	}
+	else if (req->Command == TSMM_STOP_PRESENTATION)
+	{
+		WLog_DBG(TAG, "stopping presentation 0x%x", req->PresentationId);
+		if (!presentation)
+		{
+			WLog_ERR(TAG, "unknown presentation to stop %d", req->PresentationId);
+			return CHANNEL_RC_OK;
+		}
+
+		xfVideo->currentPresentation = NULL;
+		xfPresentationContext_unref(presentation);
+	}
+
+	return CHANNEL_RC_OK;
+}
+
+
+static BOOL yuv_to_rgb(xfPresentationContext *presentation, BYTE *dest)
+{
+	const BYTE* pYUVPoint[3];
+	H264_CONTEXT *h264 = presentation->h264;
+
+	BYTE** ppYUVData;
+	ppYUVData = h264->pYUVData;
+
+	pYUVPoint[0] = ppYUVData[0];
+	pYUVPoint[1] = ppYUVData[1];
+	pYUVPoint[2] = ppYUVData[2];
+
+	if (!yuv_context_decode(presentation->yuv, pYUVPoint, h264->iStride, PIXEL_FORMAT_BGRX32, dest, h264->width * 4))
+	{
+		WLog_ERR(TAG, "error in yuv_to_rgb conversion");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static void xf_video_frame_free(xfVideoFrame **pframe)
+{
+	xfVideoFrame *frame = *pframe;
+
+	xfPresentationContext_unref(frame->presentation);
+	BufferPool_Return(frame->presentation->xfVideo->surfacePool, frame->surfaceData);
+	free(frame);
+	*pframe = NULL;
+}
+
+static void xf_video_timer(xfContext *xfc, TimerEventArgs *timer)
+{
+	xfVideoContext *xfVideo = xfc->xfVideo;
+	xfPresentationContext *presentation;
+	xfVideoFrame *peekFrame, *frame = NULL;
+
+	if (!xfVideo->currentPresentation)
+		return;
+
+	EnterCriticalSection(&xfVideo->framesLock);
+	do
+	{
+		peekFrame = (xfVideoFrame *)Queue_Peek(xfVideo->frames);
+		if (!peekFrame)
+			break;
+
+		if (peekFrame->publishTime > timer->now)
+			break;
+
+		if (frame)
+		{
+			/* free skipped frame */
+			WLog_DBG(TAG, "dropping frame @%"PRIu64, frame->publishTime);
+			xfVideo->droppedFrames++;
+			xf_video_frame_free(&frame);
+		}
+		frame = peekFrame;
+		Queue_Dequeue(xfVideo->frames);
+	}
+	while (1);
+	LeaveCriticalSection(&xfVideo->framesLock);
+
+	if (!frame)
+		goto treat_feedback;
+
+	presentation = frame->presentation;
+
+	xfVideo->publishedFrames++;
+	memcpy(presentation->surfaceData, frame->surfaceData, frame->w * frame->h * 4);
+
+	XPutImage(xfc->display, xfc->drawable, xfc->gc, presentation->surface,
+		0, 0,
+		frame->x, frame->y, frame->w, frame->h);
+
+	xfPresentationContext_unref(presentation);
+	BufferPool_Return(xfVideo->surfacePool, frame->surfaceData);
+	free(frame);
+
+treat_feedback:
+	if (xfVideo->nextFeedbackTime < timer->now)
+	{
+		/* we can compute some feedback only if we have some published frames */
+		if (xfVideo->publishedFrames)
+		{
+			UINT32 computedRate;
+
+			if (xfVideo->droppedFrames)
+			{
+				/**
+				 * some dropped frames, looks like we're asking too many frames per seconds,
+				 * try lowering rate. We go directly from unlimited rate to 24 frames/seconds
+				 * otherwise we lower rate by 2 frames by seconds
+				 */
+				if (xfVideo->lastSentRate == XF_VIDEO_UNLIMITED_RATE)
+					computedRate = 24;
+				else
+				{
+					computedRate = xfVideo->lastSentRate - 2;
+					if (!computedRate)
+						computedRate = 2;
+				}
+			}
+			else
+			{
+				/**
+				 * we treat all frames ok, so either ask the server to send more,
+				 * or stay unlimited
+				 */
+				if (xfVideo->lastSentRate == XF_VIDEO_UNLIMITED_RATE)
+					computedRate = XF_VIDEO_UNLIMITED_RATE; /* stay unlimited */
+				else
+				{
+					computedRate = xfVideo->lastSentRate + 2;
+					if (computedRate > XF_VIDEO_UNLIMITED_RATE)
+						computedRate = XF_VIDEO_UNLIMITED_RATE;
+				}
+			}
+
+			if (computedRate != xfVideo->lastSentRate)
+			{
+				TSMM_CLIENT_NOTIFICATION notif;
+				notif.PresentationId = presentation->PresentationId;
+				notif.NotificationType = TSMM_CLIENT_NOTIFICATION_TYPE_FRAMERATE_OVERRIDE;
+				if (computedRate == XF_VIDEO_UNLIMITED_RATE)
+				{
+					notif.FramerateOverride.Flags = 0x01;
+					notif.FramerateOverride.DesiredFrameRate = 0x00;
+				}
+				else
+				{
+					notif.FramerateOverride.Flags = 0x02;
+					notif.FramerateOverride.DesiredFrameRate = computedRate;
+				}
+
+				xfVideo->xfc->video->ClientNotification(xfVideo->xfc->video, &notif);
+				xfVideo->lastSentRate = computedRate;
+
+				WLog_DBG(TAG, "server notified with rate %d published=%d dropped=%d", xfVideo->lastSentRate,
+						xfVideo->publishedFrames, xfVideo->droppedFrames);
+			}
+		}
+
+		WLog_DBG(TAG, "currentRate=%d published=%d dropped=%d", xfVideo->lastSentRate,
+				xfVideo->publishedFrames, xfVideo->droppedFrames);
+
+		xfVideo->droppedFrames = 0;
+		xfVideo->publishedFrames = 0;
+		xfVideo->nextFeedbackTime = timer->now + 1000;
+	}
+}
+
+static UINT xf_video_VideoData(VideoClientContext* context, TSMM_VIDEO_DATA *data)
+{
+	xfContext *xfc = context->custom;
+	xfVideoContext *xfVideo = xfc->xfVideo;
+	xfPresentationContext *presentation;
+	int status;
+
+	presentation = xfVideo->currentPresentation;
+	if (!presentation)
+	{
+		WLog_ERR(TAG, "no current presentation");
+		return CHANNEL_RC_OK;
+	}
+
+	if (presentation->PresentationId != data->PresentationId)
+	{
+		WLog_ERR(TAG, "current presentation id=%d doesn't match data id=%d", presentation->PresentationId,
+				data->PresentationId);
+		return CHANNEL_RC_OK;
+	}
+
+	if (!Stream_EnsureRemainingCapacity(presentation->currentSample, data->cbSample))
+	{
+		WLog_ERR(TAG, "unable to expand the current packet");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	Stream_Write(presentation->currentSample, data->pSample, data->cbSample);
+
+	if (data->CurrentPacketIndex == data->PacketsInSample)
+	{
+		H264_CONTEXT *h264 = presentation->h264;
+		UINT64 startTime = GetTickCount64(), timeAfterH264;
+		MAPPED_GEOMETRY *geom = presentation->geometry;
+
+		Stream_SealLength(presentation->currentSample);
+		Stream_SetPosition(presentation->currentSample, 0);
+
+		status = h264->subsystem->Decompress(h264, Stream_Pointer(presentation->currentSample),
+				Stream_Length(presentation->currentSample));
+		if (status == 0)
+			return CHANNEL_RC_OK;
+
+		if (status < 0)
+			return CHANNEL_RC_OK;
+
+		timeAfterH264 = GetTickCount64();
+		if (data->SampleNumber == 1)
+		{
+			presentation->lastPublishTime = startTime;
+		}
+
+		presentation->lastPublishTime += (data->hnsDuration / 10000);
+		if (presentation->lastPublishTime <= timeAfterH264 + 10)
+		{
+			int dropped = 0;
+
+			/* if the frame is to be published in less than 10 ms, let's consider it's now */
+			yuv_to_rgb(presentation, presentation->surfaceData);
+
+			XPutImage(xfc->display, xfc->drawable, xfc->gc, presentation->surface,
+				0, 0,
+				geom->topLevelLeft + geom->left + geom->geometry.boundingRect.x,
+				geom->topLevelTop + geom->top + geom->geometry.boundingRect.y,
+				presentation->SourceWidth, presentation->SourceHeight);
+
+			xfVideo->publishedFrames++;
+
+			/* cleanup previously scheduled frames */
+			EnterCriticalSection(&xfVideo->framesLock);
+			while (Queue_Count(xfVideo->frames) > 0)
+			{
+				xfVideoFrame *frame = Queue_Dequeue(xfVideo->frames);
+				if (frame)
+				{
+					xfVideo->droppedFrames++;
+					xf_video_frame_free(&frame);
+					dropped++;
+				}
+			}
+			LeaveCriticalSection(&xfVideo->framesLock);
+
+			if (dropped)
+				WLog_DBG(TAG, "showing frame (%d dropped)", dropped);
+		}
+		else
+		{
+			BOOL enqueueResult;
+			xfVideoFrame *frame = calloc(1, sizeof(*frame));
+			if (!frame)
+			{
+				WLog_ERR(TAG, "unable to create frame");
+				return CHANNEL_RC_NO_MEMORY;
+			}
+
+			frame->presentation = presentation;
+			frame->publishTime = presentation->lastPublishTime;
+			frame->x = geom->topLevelLeft + geom->left + geom->geometry.boundingRect.x;
+			frame->y = geom->topLevelTop + geom->top + geom->geometry.boundingRect.y;
+			frame->w = presentation->SourceWidth;
+			frame->h = presentation->SourceHeight;
+
+			frame->surfaceData = BufferPool_Take(xfVideo->surfacePool, frame->w * frame->h * 4);
+			if (!frame->surfaceData)
+			{
+				WLog_ERR(TAG, "unable to allocate frame data");
+				free(frame);
+				return CHANNEL_RC_NO_MEMORY;
+			}
+
+			if (!yuv_to_rgb(presentation, frame->surfaceData))
+			{
+				WLog_ERR(TAG, "error during YUV->RGB conversion");
+				BufferPool_Return(xfVideo->surfacePool, frame->surfaceData);
+				free(frame);
+				return CHANNEL_RC_NO_MEMORY;
+			}
+
+			InterlockedIncrement(&presentation->refCounter);
+
+			EnterCriticalSection(&xfVideo->framesLock);
+			enqueueResult = Queue_Enqueue(xfVideo->frames, frame);
+			LeaveCriticalSection(&xfVideo->framesLock);
+
+			if (!enqueueResult)
+			{
+				WLog_ERR(TAG, "unable to enqueue frame");
+				xf_video_frame_free(&frame);
+				return CHANNEL_RC_NO_MEMORY;
+			}
+
+			WLog_DBG(TAG, "scheduling frame in %"PRIu32" ms", (frame->publishTime-startTime));
+		}
+	}
+
+	return CHANNEL_RC_OK;
+}
+
+
+void xf_video_control_init(xfContext *xfc, VideoClientContext *video)
+{
+	xfc->video = video;
+	video->custom = xfc;
+	video->PresentationRequest = xf_video_PresentationRequest;
+}
+
+void xf_video_data_init(xfContext *xfc, VideoClientContext *video)
+{
+	video->VideoData = xf_video_VideoData;
+	PubSub_SubscribeTimer(xfc->context.pubSub, (pTimerEventHandler)xf_video_timer);
+}
+
+void xf_video_data_uninit(xfVideoContext *xfVideo)
+{
+	PubSub_UnsubscribeTimer(xfVideo->xfc->context.pubSub, (pTimerEventHandler)xf_video_timer);
+}

--- a/client/X11/xf_video.c
+++ b/client/X11/xf_video.c
@@ -621,9 +621,6 @@ static UINT xf_video_VideoData(VideoClientContext* context, TSMM_VIDEO_DATA *dat
 
 void xf_video_free(xfVideoContext *xfVideo)
 {
-	if (xfVideo->xfc->video)
-		xfVideo->xfc->video->VideoData = NULL;
-
 	EnterCriticalSection(&xfVideo->framesLock);
 	while (Queue_Count(xfVideo->frames))
 	{
@@ -654,8 +651,7 @@ void xf_video_control_init(xfContext *xfc, VideoClientContext *video)
 
 void xf_video_control_uninit(xfContext *xfc, VideoClientContext *video)
 {
-	xf_video_free(xfc->xfVideo);
-	xfc->xfVideo = NULL;
+	video->VideoData = NULL;
 }
 
 

--- a/client/X11/xf_video.c
+++ b/client/X11/xf_video.c
@@ -28,25 +28,27 @@
 typedef struct
 {
 	VideoSurface base;
-	XImage *image;
+	XImage* image;
 } xfVideoSurface;
 
 
-void xf_video_geometry_init(xfContext *xfc, GeometryClientContext *geom)
+void xf_video_geometry_init(xfContext* xfc, GeometryClientContext* geom)
 {
 	xfc->geometry = geom;
+
 	if (xfc->video)
 	{
-		VideoClientContext *video = xfc->video;
+		VideoClientContext* video = xfc->video;
 		video->setGeometry(video, xfc->geometry);
 	}
 }
 
-static VideoSurface *xfVideoCreateSurface(VideoClientContext *video, BYTE *data, UINT32 x, UINT32 y,
-			UINT32 width, UINT32 height)
+static VideoSurface* xfVideoCreateSurface(VideoClientContext* video, BYTE* data, UINT32 x, UINT32 y,
+        UINT32 width, UINT32 height)
 {
-	xfContext *xfc = (xfContext *)video->custom;
-	xfVideoSurface *ret = calloc(1, sizeof(*ret));
+	xfContext* xfc = (xfContext*)video->custom;
+	xfVideoSurface* ret = calloc(1, sizeof(*ret));
+
 	if (!ret)
 		return NULL;
 
@@ -55,41 +57,53 @@ static VideoSurface *xfVideoCreateSurface(VideoClientContext *video, BYTE *data,
 	ret->base.y = y;
 	ret->base.w = width;
 	ret->base.h = height;
-
 	ret->image = XCreateImage(xfc->display, xfc->visual, xfc->depth, ZPixmap, 0,
-			(char *)data, width, height, 8, width * 4);
+	                          (char*)data, width, height, 8, width * 4);
+
 	if (!ret->image)
 	{
 		WLog_ERR(TAG, "unable to create surface image");
 		free(ret);
 		return NULL;
 	}
+
 	return &ret->base;
 }
 
 
-static BOOL xfVideoShowSurface(VideoClientContext *video, xfVideoSurface *surface)
+static BOOL xfVideoShowSurface(VideoClientContext* video, xfVideoSurface* surface)
 {
-	xfContext *xfc = video->custom;
+	xfContext* xfc = video->custom;
+#ifdef WITH_XRENDER
 
-	XPutImage(xfc->display, xfc->drawable, xfc->gc, surface->image,
-		0, 0,
-		surface->base.x, surface->base.y, surface->base.w, surface->base.h);
+	if (xfc->context.settings->SmartSizing
+	    || xfc->context.settings->MultiTouchGestures)
+	{
+		XPutImage(xfc->display, xfc->primary, xfc->gc, surface->image,
+		          0, 0, surface->base.x, surface->base.y, surface->base.w, surface->base.h);
+		xf_draw_screen(xfc, surface->base.x, surface->base.y, surface->base.w, surface->base.h);
+	}
+	else
+#endif
+	{
+		XPutImage(xfc->display, xfc->drawable, xfc->gc, surface->image,
+		          0, 0,
+		          surface->base.x, surface->base.y, surface->base.w, surface->base.h);
+	}
+
 	return TRUE;
 }
 
-static BOOL xfVideoDeleteSurface(VideoClientContext *video, xfVideoSurface *surface)
+static BOOL xfVideoDeleteSurface(VideoClientContext* video, xfVideoSurface* surface)
 {
 	XFree(surface->image);
 	free(surface);
-
 	return TRUE;
 }
-void xf_video_control_init(xfContext *xfc, VideoClientContext *video)
+void xf_video_control_init(xfContext* xfc, VideoClientContext* video)
 {
 	xfc->video = video;
 	video->custom = xfc;
-
 	video->createSurface = xfVideoCreateSurface;
 	video->showSurface = (pcVideoShowSurface)xfVideoShowSurface;
 	video->deleteSurface = (pcVideoDeleteSurface)xfVideoDeleteSurface;
@@ -97,21 +111,21 @@ void xf_video_control_init(xfContext *xfc, VideoClientContext *video)
 }
 
 
-void xf_video_control_uninit(xfContext *xfc, VideoClientContext *video)
+void xf_video_control_uninit(xfContext* xfc, VideoClientContext* video)
 {
 }
 
-static void xf_video_timer(xfContext *xfc, TimerEventArgs *timer)
+static void xf_video_timer(xfContext* xfc, TimerEventArgs* timer)
 {
 	xfc->video->timer(xfc->video, timer->now);
 }
 
-void xf_video_data_init(xfContext *xfc, VideoClientContext *video)
+void xf_video_data_init(xfContext* xfc, VideoClientContext* video)
 {
 	PubSub_SubscribeTimer(xfc->context.pubSub, (pTimerEventHandler)xf_video_timer);
 }
 
-void xf_video_data_uninit(xfContext *xfc, VideoClientContext *context)
+void xf_video_data_uninit(xfContext* xfc, VideoClientContext* context)
 {
 	PubSub_UnsubscribeTimer(xfc->context.pubSub, (pTimerEventHandler)xf_video_timer);
 }

--- a/client/X11/xf_video.c
+++ b/client/X11/xf_video.c
@@ -16,648 +16,98 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <winpr/sysinfo.h>
-#include <winpr/interlocked.h>
+
 
 #include <freerdp/client/geometry.h>
 #include <freerdp/client/video.h>
-#include <freerdp/primitives.h>
-#include <freerdp/codec/h264.h>
-#include <freerdp/codec/yuv.h>
 
 #include "xf_video.h"
 
 #define TAG CLIENT_TAG("video")
-#define XF_VIDEO_UNLIMITED_RATE 31
 
-
-BYTE MFVideoFormat_H264[] = {'H', '2', '6', '4',
-		0x00, 0x00,
-		0x10, 0x00,
-		0x80, 0x00,
-		0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71};
-
-typedef struct _xfPresentationContext xfPresentationContext;
-
-struct _xfVideoContext
+typedef struct
 {
-	xfContext *xfc;
-	wQueue *frames;
-	CRITICAL_SECTION framesLock;
-	wBufferPool *surfacePool;
-	UINT32 publishedFrames;
-	UINT32 droppedFrames;
-	UINT32 lastSentRate;
-	UINT64 nextFeedbackTime;
-	xfPresentationContext *currentPresentation;
-};
+	VideoSurface base;
+	XImage *image;
+} xfVideoSurface;
 
-struct _xfVideoFrame
-{
-	UINT64 publishTime;
-	UINT64 hnsDuration;
-	UINT32 x, y, w, h;
-	BYTE *surfaceData;
-	xfPresentationContext *presentation;
-};
-typedef struct _xfVideoFrame xfVideoFrame;
-
-struct _xfPresentationContext
-{
-	xfContext *xfc;
-	xfVideoContext *xfVideo;
-	BYTE PresentationId;
-	UINT32 SourceWidth, SourceHeight;
-	UINT32 ScaledWidth, ScaledHeight;
-	MAPPED_GEOMETRY *geometry;
-
-	UINT64 startTimeStamp;
-	UINT64 publishOffset;
-	H264_CONTEXT *h264;
-	YUV_CONTEXT *yuv;
-	wStream *currentSample;
-	BYTE *surfaceData;
-	XImage *surface;
-	UINT64 lastPublishTime, nextPublishTime;
-	volatile LONG refCounter;
-};
-
-
-
-static void xfPresentationContext_unref(xfPresentationContext *c)
-{
-	xfVideoContext *xfVideo;
-
-	if (!c)
-		return;
-
-	if (InterlockedDecrement(&c->refCounter) != 0)
-		return;
-
-	xfVideo = c->xfVideo;
-	if (c->geometry)
-	{
-		c->geometry->MappedGeometryUpdate = NULL;
-		c->geometry->MappedGeometryClear = NULL;
-		c->geometry->custom = NULL;
-	}
-
-	h264_context_free(c->h264);
-	Stream_Free(c->currentSample, TRUE);
-	XFree(c->surface);
-	BufferPool_Return(xfVideo->surfacePool, c->surfaceData);
-	yuv_context_free(c->yuv);
-	free(c);
-}
-
-
-static xfPresentationContext *xfPresentationContext_new(xfContext *xfc, BYTE PresentationId, UINT32 width, UINT32 height)
-{
-	xfVideoContext *xfVideo = xfc->xfVideo;
-	xfPresentationContext *ret = calloc(1, sizeof(*ret));
-	if (!ret)
-		return NULL;
-
-	ret->xfc = xfc;
-	ret->PresentationId = PresentationId;
-
-	ret->h264 = h264_context_new(FALSE);
-	if (!ret->h264)
-	{
-		WLog_ERR(TAG, "unable to create a h264 context");
-		goto error_h264;
-	}
-	h264_context_reset(ret->h264, width, height);
-
-	ret->currentSample = Stream_New(NULL, 4096);
-	if (!ret->currentSample)
-	{
-		WLog_ERR(TAG, "unable to create current packet stream");
-		goto error_currentSample;
-	}
-
-	ret->surfaceData = BufferPool_Take(xfVideo->surfacePool, width * height * 4);
-	if (!ret->surfaceData)
-	{
-		WLog_ERR(TAG, "unable to allocate surfaceData");
-		goto error_surfaceData;
-	}
-
-	ret->surface = XCreateImage(xfc->display, xfc->visual, xfc->depth, ZPixmap, 0,
-			(char *)ret->surfaceData, width, height, 8, width * 4);
-	if (!ret->surface)
-	{
-		WLog_ERR(TAG, "unable to create surface");
-		goto error_surface;
-	}
-
-	ret->yuv = yuv_context_new(FALSE);
-	if (!ret->yuv)
-	{
-		WLog_ERR(TAG, "unable to create YUV decoder");
-		goto error_yuv;
-	}
-
-	yuv_context_reset(ret->yuv, width, height);
-	ret->refCounter = 1;
-	return ret;
-
-error_yuv:
-	XFree(ret->surface);
-error_surface:
-	BufferPool_Return(xfVideo->surfacePool, ret->surfaceData);
-error_surfaceData:
-	Stream_Free(ret->currentSample, TRUE);
-error_currentSample:
-	h264_context_free(ret->h264);
-error_h264:
-	free(ret);
-	return NULL;
-}
-
-xfVideoContext *xf_video_new(xfContext *xfc)
-{
-	xfVideoContext *ret = calloc(1, sizeof(xfVideoContext));
-	if (!ret)
-		return NULL;
-
-	ret->frames = Queue_New(TRUE, 10, 2);
-	if (!ret->frames)
-	{
-		WLog_ERR(TAG, "unable to allocate frames queue");
-		goto error_frames;
-	}
-
-	ret->surfacePool = BufferPool_New(FALSE, 0, 16);
-	if (!ret->surfacePool)
-	{
-		WLog_ERR(TAG, "unable to create surface pool");
-		goto error_surfacePool;
-	}
-
-	if (!InitializeCriticalSectionAndSpinCount(&ret->framesLock, 4000))
-	{
-		WLog_ERR(TAG, "unable to initialize frames lock");
-		goto error_spinlock;
-	}
-
-	ret->xfc = xfc;
-
-	 /* don't set to unlimited so that we have the chance to send a feedback in
-	  * the first second (for servers that want feedback directly)
-	  */
-	ret->lastSentRate = 30;
-	return ret;
-
-error_spinlock:
-	BufferPool_Free(ret->surfacePool);
-error_surfacePool:
-	Queue_Free(ret->frames);
-error_frames:
-	free(ret);
-	return NULL;
-}
 
 void xf_video_geometry_init(xfContext *xfc, GeometryClientContext *geom)
 {
 	xfc->geometry = geom;
-}
-
-static BOOL xf_video_onMappedGeometryUpdate(MAPPED_GEOMETRY *geometry)
-{
-	return TRUE;
-}
-
-static BOOL xf_video_onMappedGeometryClear(MAPPED_GEOMETRY *geometry)
-{
-	xfPresentationContext *presentation = (xfPresentationContext *)geometry->custom;
-
-	presentation->geometry = NULL;
-	return TRUE;
-}
-
-
-static UINT xf_video_PresentationRequest(VideoClientContext* context, TSMM_PRESENTATION_REQUEST *req)
-{
-	xfContext *xfc = context->custom;
-	xfVideoContext *xfVideo = xfc->xfVideo;
-	xfPresentationContext *presentation;
-	UINT ret = CHANNEL_RC_OK;
-
-	presentation = xfVideo->currentPresentation;
-
-	if (req->Command == TSMM_START_PRESENTATION)
+	if (xfc->video)
 	{
-		MAPPED_GEOMETRY *geom;
-		TSMM_PRESENTATION_RESPONSE resp;
-
-		if (memcmp(req->VideoSubtypeId, MFVideoFormat_H264, 16) != 0)
-		{
-			WLog_ERR(TAG, "not a H264 video, ignoring request");
-			return CHANNEL_RC_OK;
-		}
-
-		if (presentation)
-		{
-			if (presentation->PresentationId == req->PresentationId)
-			{
-				WLog_ERR(TAG, "ignoring start request for existing presentation %d", req->PresentationId);
-				return CHANNEL_RC_OK;
-			}
-
-			WLog_ERR(TAG, "releasing current presentation %d", req->PresentationId);
-			xfPresentationContext_unref(presentation);
-			presentation = xfVideo->currentPresentation = NULL;
-		}
-
-		if (!xfc->geometry)
-		{
-			WLog_ERR(TAG, "geometry channel not ready, ignoring request");
-			return CHANNEL_RC_OK;
-		}
-
-		geom = HashTable_GetItemValue(xfc->geometry->geometries, &(req->GeometryMappingId));
-		if (!geom)
-		{
-			WLog_ERR(TAG, "geometry mapping 0x%"PRIx64" not registered", req->GeometryMappingId);
-			return CHANNEL_RC_OK;
-		}
-
-		WLog_DBG(TAG, "creating presentation 0x%x", req->PresentationId);
-		presentation = xfPresentationContext_new(xfc, req->PresentationId, req->SourceWidth, req->SourceHeight);
-		if (!presentation)
-		{
-			WLog_ERR(TAG, "unable to create presentation context");
-			return CHANNEL_RC_NO_MEMORY;
-		}
-
-		xfVideo->currentPresentation = presentation;
-		presentation->xfVideo = xfVideo;
-		presentation->geometry = geom;
-		presentation->SourceWidth = req->SourceWidth;
-		presentation->SourceHeight = req->SourceHeight;
-		presentation->ScaledWidth = req->ScaledWidth;
-		presentation->ScaledHeight = req->ScaledHeight;
-
-		geom->custom = presentation;
-		geom->MappedGeometryUpdate = xf_video_onMappedGeometryUpdate;
-		geom->MappedGeometryClear = xf_video_onMappedGeometryClear;
-
-		/* send back response */
-		resp.PresentationId = req->PresentationId;
-		ret = context->PresentationResponse(context, &resp);
+		VideoClientContext *video = xfc->video;
+		video->setGeometry(video, xfc->geometry);
 	}
-	else if (req->Command == TSMM_STOP_PRESENTATION)
+}
+
+static VideoSurface *xfVideoCreateSurface(VideoClientContext *video, BYTE *data, UINT32 x, UINT32 y,
+			UINT32 width, UINT32 height)
+{
+	xfContext *xfc = (xfContext *)video->custom;
+	xfVideoSurface *ret = calloc(1, sizeof(*ret));
+	if (!ret)
+		return NULL;
+
+	ret->base.data = data;
+	ret->base.x = x;
+	ret->base.y = y;
+	ret->base.w = width;
+	ret->base.h = height;
+
+	ret->image = XCreateImage(xfc->display, xfc->visual, xfc->depth, ZPixmap, 0,
+			(char *)data, width, height, 8, width * 4);
+	if (!ret->image)
 	{
-		WLog_DBG(TAG, "stopping presentation 0x%x", req->PresentationId);
-		if (!presentation)
-		{
-			WLog_ERR(TAG, "unknown presentation to stop %d", req->PresentationId);
-			return CHANNEL_RC_OK;
-		}
-
-		xfVideo->currentPresentation = NULL;
-		xfVideo->droppedFrames = 0;
-		xfVideo->publishedFrames = 0;
-		xfPresentationContext_unref(presentation);
+		WLog_ERR(TAG, "unable to create surface image");
+		free(ret);
+		return NULL;
 	}
-
-	return CHANNEL_RC_OK;
+	return &ret->base;
 }
 
 
-static BOOL yuv_to_rgb(xfPresentationContext *presentation, BYTE *dest)
+static BOOL xfVideoShowSurface(VideoClientContext *video, xfVideoSurface *surface)
 {
-	const BYTE* pYUVPoint[3];
-	H264_CONTEXT *h264 = presentation->h264;
+	xfContext *xfc = video->custom;
 
-	BYTE** ppYUVData;
-	ppYUVData = h264->pYUVData;
-
-	pYUVPoint[0] = ppYUVData[0];
-	pYUVPoint[1] = ppYUVData[1];
-	pYUVPoint[2] = ppYUVData[2];
-
-	if (!yuv_context_decode(presentation->yuv, pYUVPoint, h264->iStride, PIXEL_FORMAT_BGRX32, dest, h264->width * 4))
-	{
-		WLog_ERR(TAG, "error in yuv_to_rgb conversion");
-		return FALSE;
-	}
-
-	return TRUE;
-}
-
-static void xf_video_frame_free(xfVideoFrame **pframe)
-{
-	xfVideoFrame *frame = *pframe;
-
-	xfPresentationContext_unref(frame->presentation);
-	BufferPool_Return(frame->presentation->xfVideo->surfacePool, frame->surfaceData);
-	free(frame);
-	*pframe = NULL;
-}
-
-static void xf_video_timer(xfContext *xfc, TimerEventArgs *timer)
-{
-	xfVideoContext *xfVideo = xfc->xfVideo;
-	xfPresentationContext *presentation;
-	xfVideoFrame *peekFrame, *frame = NULL;
-
-	EnterCriticalSection(&xfVideo->framesLock);
-	do
-	{
-		peekFrame = (xfVideoFrame *)Queue_Peek(xfVideo->frames);
-		if (!peekFrame)
-			break;
-
-		if (peekFrame->publishTime > timer->now)
-			break;
-
-		if (frame)
-		{
-			/* free skipped frame */
-			WLog_DBG(TAG, "dropping frame @%"PRIu64, frame->publishTime);
-			xfVideo->droppedFrames++;
-			xf_video_frame_free(&frame);
-		}
-		frame = peekFrame;
-		Queue_Dequeue(xfVideo->frames);
-	}
-	while (1);
-	LeaveCriticalSection(&xfVideo->framesLock);
-
-	if (!frame)
-		goto treat_feedback;
-
-	presentation = frame->presentation;
-
-	xfVideo->publishedFrames++;
-	memcpy(presentation->surfaceData, frame->surfaceData, frame->w * frame->h * 4);
-
-	XPutImage(xfc->display, xfc->drawable, xfc->gc, presentation->surface,
+	XPutImage(xfc->display, xfc->drawable, xfc->gc, surface->image,
 		0, 0,
-		frame->x, frame->y, frame->w, frame->h);
-
-	xfPresentationContext_unref(presentation);
-	BufferPool_Return(xfVideo->surfacePool, frame->surfaceData);
-	free(frame);
-
-treat_feedback:
-	if (xfVideo->nextFeedbackTime < timer->now)
-	{
-		/* we can compute some feedback only if we have some published frames and
-		 * a current presentation
-		 */
-		if (xfVideo->publishedFrames && xfVideo->currentPresentation)
-		{
-			UINT32 computedRate;
-
-			InterlockedIncrement(&xfVideo->currentPresentation->refCounter);
-
-			if (xfVideo->droppedFrames)
-			{
-				/**
-				 * some dropped frames, looks like we're asking too many frames per seconds,
-				 * try lowering rate. We go directly from unlimited rate to 24 frames/seconds
-				 * otherwise we lower rate by 2 frames by seconds
-				 */
-				if (xfVideo->lastSentRate == XF_VIDEO_UNLIMITED_RATE)
-					computedRate = 24;
-				else
-				{
-					computedRate = xfVideo->lastSentRate - 2;
-					if (!computedRate)
-						computedRate = 2;
-				}
-			}
-			else
-			{
-				/**
-				 * we treat all frames ok, so either ask the server to send more,
-				 * or stay unlimited
-				 */
-				if (xfVideo->lastSentRate == XF_VIDEO_UNLIMITED_RATE)
-					computedRate = XF_VIDEO_UNLIMITED_RATE; /* stay unlimited */
-				else
-				{
-					computedRate = xfVideo->lastSentRate + 2;
-					if (computedRate > XF_VIDEO_UNLIMITED_RATE)
-						computedRate = XF_VIDEO_UNLIMITED_RATE;
-				}
-			}
-
-			if (computedRate != xfVideo->lastSentRate)
-			{
-				TSMM_CLIENT_NOTIFICATION notif;
-				notif.PresentationId = xfVideo->currentPresentation->PresentationId;
-				notif.NotificationType = TSMM_CLIENT_NOTIFICATION_TYPE_FRAMERATE_OVERRIDE;
-				if (computedRate == XF_VIDEO_UNLIMITED_RATE)
-				{
-					notif.FramerateOverride.Flags = 0x01;
-					notif.FramerateOverride.DesiredFrameRate = 0x00;
-				}
-				else
-				{
-					notif.FramerateOverride.Flags = 0x02;
-					notif.FramerateOverride.DesiredFrameRate = computedRate;
-				}
-
-				xfVideo->xfc->video->ClientNotification(xfVideo->xfc->video, &notif);
-				xfVideo->lastSentRate = computedRate;
-
-				WLog_DBG(TAG, "server notified with rate %d published=%d dropped=%d", xfVideo->lastSentRate,
-						xfVideo->publishedFrames, xfVideo->droppedFrames);
-			}
-
-			xfPresentationContext_unref(xfVideo->currentPresentation);
-		}
-
-		WLog_DBG(TAG, "currentRate=%d published=%d dropped=%d", xfVideo->lastSentRate,
-				xfVideo->publishedFrames, xfVideo->droppedFrames);
-
-		xfVideo->droppedFrames = 0;
-		xfVideo->publishedFrames = 0;
-		xfVideo->nextFeedbackTime = timer->now + 1000;
-	}
+		surface->base.x, surface->base.y, surface->base.w, surface->base.h);
+	return TRUE;
 }
 
-static UINT xf_video_VideoData(VideoClientContext* context, TSMM_VIDEO_DATA *data)
+static BOOL xfVideoDeleteSurface(VideoClientContext *video, xfVideoSurface *surface)
 {
-	xfContext *xfc = context->custom;
-	xfVideoContext *xfVideo = xfc->xfVideo;
-	xfPresentationContext *presentation;
-	int status;
+	XFree(surface->image);
+	free(surface);
 
-	presentation = xfVideo->currentPresentation;
-	if (!presentation)
-	{
-		WLog_ERR(TAG, "no current presentation");
-		return CHANNEL_RC_OK;
-	}
-
-	if (presentation->PresentationId != data->PresentationId)
-	{
-		WLog_ERR(TAG, "current presentation id=%d doesn't match data id=%d", presentation->PresentationId,
-				data->PresentationId);
-		return CHANNEL_RC_OK;
-	}
-
-	if (!Stream_EnsureRemainingCapacity(presentation->currentSample, data->cbSample))
-	{
-		WLog_ERR(TAG, "unable to expand the current packet");
-		return CHANNEL_RC_NO_MEMORY;
-	}
-
-	Stream_Write(presentation->currentSample, data->pSample, data->cbSample);
-
-	if (data->CurrentPacketIndex == data->PacketsInSample)
-	{
-		H264_CONTEXT *h264 = presentation->h264;
-		UINT64 startTime = GetTickCount64(), timeAfterH264;
-		MAPPED_GEOMETRY *geom = presentation->geometry;
-
-		Stream_SealLength(presentation->currentSample);
-		Stream_SetPosition(presentation->currentSample, 0);
-
-		status = h264->subsystem->Decompress(h264, Stream_Pointer(presentation->currentSample),
-				Stream_Length(presentation->currentSample));
-		if (status == 0)
-			return CHANNEL_RC_OK;
-
-		if (status < 0)
-			return CHANNEL_RC_OK;
-
-		timeAfterH264 = GetTickCount64();
-		if (data->SampleNumber == 1)
-		{
-			presentation->lastPublishTime = startTime;
-		}
-
-		presentation->lastPublishTime += (data->hnsDuration / 10000);
-		if (presentation->lastPublishTime <= timeAfterH264 + 10)
-		{
-			int dropped = 0;
-
-			/* if the frame is to be published in less than 10 ms, let's consider it's now */
-			yuv_to_rgb(presentation, presentation->surfaceData);
-
-			XPutImage(xfc->display, xfc->drawable, xfc->gc, presentation->surface,
-				0, 0,
-				geom->topLevelLeft + geom->left + geom->geometry.boundingRect.x,
-				geom->topLevelTop + geom->top + geom->geometry.boundingRect.y,
-				presentation->SourceWidth, presentation->SourceHeight);
-
-			xfVideo->publishedFrames++;
-
-			/* cleanup previously scheduled frames */
-			EnterCriticalSection(&xfVideo->framesLock);
-			while (Queue_Count(xfVideo->frames) > 0)
-			{
-				xfVideoFrame *frame = Queue_Dequeue(xfVideo->frames);
-				if (frame)
-				{
-					xfVideo->droppedFrames++;
-					xf_video_frame_free(&frame);
-					dropped++;
-				}
-			}
-			LeaveCriticalSection(&xfVideo->framesLock);
-
-			if (dropped)
-				WLog_DBG(TAG, "showing frame (%d dropped)", dropped);
-		}
-		else
-		{
-			BOOL enqueueResult;
-			xfVideoFrame *frame = calloc(1, sizeof(*frame));
-			if (!frame)
-			{
-				WLog_ERR(TAG, "unable to create frame");
-				return CHANNEL_RC_NO_MEMORY;
-			}
-
-			frame->presentation = presentation;
-			frame->publishTime = presentation->lastPublishTime;
-			frame->x = geom->topLevelLeft + geom->left + geom->geometry.boundingRect.x;
-			frame->y = geom->topLevelTop + geom->top + geom->geometry.boundingRect.y;
-			frame->w = presentation->SourceWidth;
-			frame->h = presentation->SourceHeight;
-
-			frame->surfaceData = BufferPool_Take(xfVideo->surfacePool, frame->w * frame->h * 4);
-			if (!frame->surfaceData)
-			{
-				WLog_ERR(TAG, "unable to allocate frame data");
-				free(frame);
-				return CHANNEL_RC_NO_MEMORY;
-			}
-
-			if (!yuv_to_rgb(presentation, frame->surfaceData))
-			{
-				WLog_ERR(TAG, "error during YUV->RGB conversion");
-				BufferPool_Return(xfVideo->surfacePool, frame->surfaceData);
-				free(frame);
-				return CHANNEL_RC_NO_MEMORY;
-			}
-
-			InterlockedIncrement(&presentation->refCounter);
-
-			EnterCriticalSection(&xfVideo->framesLock);
-			enqueueResult = Queue_Enqueue(xfVideo->frames, frame);
-			LeaveCriticalSection(&xfVideo->framesLock);
-
-			if (!enqueueResult)
-			{
-				WLog_ERR(TAG, "unable to enqueue frame");
-				xf_video_frame_free(&frame);
-				return CHANNEL_RC_NO_MEMORY;
-			}
-
-			WLog_DBG(TAG, "scheduling frame in %"PRIu32" ms", (frame->publishTime-startTime));
-		}
-	}
-
-	return CHANNEL_RC_OK;
+	return TRUE;
 }
-
-void xf_video_free(xfVideoContext *xfVideo)
-{
-	EnterCriticalSection(&xfVideo->framesLock);
-	while (Queue_Count(xfVideo->frames))
-	{
-		xfVideoFrame *frame = Queue_Dequeue(xfVideo->frames);
-		if (frame)
-			xf_video_frame_free(&frame);
-	}
-
-	Queue_Free(xfVideo->frames);
-	LeaveCriticalSection(&xfVideo->framesLock);
-
-	DeleteCriticalSection(&xfVideo->framesLock);
-
-	if (xfVideo->currentPresentation)
-		xfPresentationContext_unref(xfVideo->currentPresentation);
-
-	BufferPool_Free(xfVideo->surfacePool);
-	free(xfVideo);
-}
-
-
 void xf_video_control_init(xfContext *xfc, VideoClientContext *video)
 {
 	xfc->video = video;
 	video->custom = xfc;
-	video->PresentationRequest = xf_video_PresentationRequest;
+
+	video->createSurface = xfVideoCreateSurface;
+	video->showSurface = (pcVideoShowSurface)xfVideoShowSurface;
+	video->deleteSurface = (pcVideoDeleteSurface)xfVideoDeleteSurface;
+	video->setGeometry(video, xfc->geometry);
 }
+
 
 void xf_video_control_uninit(xfContext *xfc, VideoClientContext *video)
 {
-	video->VideoData = NULL;
 }
 
+static void xf_video_timer(xfContext *xfc, TimerEventArgs *timer)
+{
+	xfc->video->timer(xfc->video, timer->now);
+}
 
 void xf_video_data_init(xfContext *xfc, VideoClientContext *video)
 {
-	video->VideoData = xf_video_VideoData;
 	PubSub_SubscribeTimer(xfc->context.pubSub, (pTimerEventHandler)xf_video_timer);
 }
 

--- a/client/X11/xf_video.c
+++ b/client/X11/xf_video.c
@@ -43,6 +43,10 @@ void xf_video_geometry_init(xfContext* xfc, GeometryClientContext* geom)
 	}
 }
 
+void xf_video_geometry_uninit(xfContext* xfc, GeometryClientContext* geom)
+{
+}
+
 static VideoSurface* xfVideoCreateSurface(VideoClientContext* video, BYTE* data, UINT32 x, UINT32 y,
         UINT32 width, UINT32 height)
 {

--- a/client/X11/xf_video.h
+++ b/client/X11/xf_video.h
@@ -35,6 +35,7 @@ void xf_video_data_init(xfContext *xfc, VideoClientContext *video);
 void xf_video_data_uninit(xfContext *xfc, VideoClientContext *context);
 
 xfVideoContext *xf_video_new(xfContext *xfc);
+void xf_video_free(xfVideoContext *context);
 
 
 #endif /* CLIENT_X11_XF_VIDEO_H_ */

--- a/client/X11/xf_video.h
+++ b/client/X11/xf_video.h
@@ -1,0 +1,39 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Video Optimized Remoting Virtual Channel Extension for X11
+ *
+ * Copyright 2017 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef CLIENT_X11_XF_VIDEO_H_
+#define CLIENT_X11_XF_VIDEO_H_
+
+#include "xfreerdp.h"
+
+#include <freerdp/channels/geometry.h>
+#include <freerdp/channels/video.h>
+
+struct _xfVideoContext;
+typedef struct _xfVideoContext xfVideoContext;
+
+void xf_video_geometry_init(xfContext *xfc, GeometryClientContext *geom);
+void xf_video_control_init(xfContext *xfc, VideoClientContext *video);
+
+void xf_video_data_init(xfContext *xfc, VideoClientContext *video);
+void xf_video_data_uninit(xfVideoContext *xfVideo);
+
+xfVideoContext *xf_video_new();
+
+
+#endif /* CLIENT_X11_XF_VIDEO_H_ */

--- a/client/X11/xf_video.h
+++ b/client/X11/xf_video.h
@@ -27,14 +27,8 @@
 struct _xfVideoContext;
 typedef struct _xfVideoContext xfVideoContext;
 
-void xf_video_geometry_init(xfContext* xfc, GeometryClientContext* geom);
-void xf_video_geometry_uninit(xfContext* xfc, GeometryClientContext* geom);
-
 void xf_video_control_init(xfContext* xfc, VideoClientContext* video);
 void xf_video_control_uninit(xfContext* xfc, VideoClientContext* video);
-
-void xf_video_data_init(xfContext* xfc, VideoClientContext* video);
-void xf_video_data_uninit(xfContext* xfc, VideoClientContext* context);
 
 xfVideoContext* xf_video_new(xfContext* xfc);
 void xf_video_free(xfVideoContext* context);

--- a/client/X11/xf_video.h
+++ b/client/X11/xf_video.h
@@ -27,15 +27,17 @@
 struct _xfVideoContext;
 typedef struct _xfVideoContext xfVideoContext;
 
-void xf_video_geometry_init(xfContext *xfc, GeometryClientContext *geom);
-void xf_video_control_init(xfContext *xfc, VideoClientContext *video);
-void xf_video_control_uninit(xfContext *xfc, VideoClientContext *video);
+void xf_video_geometry_init(xfContext* xfc, GeometryClientContext* geom);
+void xf_video_geometry_uninit(xfContext* xfc, GeometryClientContext* geom);
 
-void xf_video_data_init(xfContext *xfc, VideoClientContext *video);
-void xf_video_data_uninit(xfContext *xfc, VideoClientContext *context);
+void xf_video_control_init(xfContext* xfc, VideoClientContext* video);
+void xf_video_control_uninit(xfContext* xfc, VideoClientContext* video);
 
-xfVideoContext *xf_video_new(xfContext *xfc);
-void xf_video_free(xfVideoContext *context);
+void xf_video_data_init(xfContext* xfc, VideoClientContext* video);
+void xf_video_data_uninit(xfContext* xfc, VideoClientContext* context);
+
+xfVideoContext* xf_video_new(xfContext* xfc);
+void xf_video_free(xfVideoContext* context);
 
 
 #endif /* CLIENT_X11_XF_VIDEO_H_ */

--- a/client/X11/xf_video.h
+++ b/client/X11/xf_video.h
@@ -29,11 +29,12 @@ typedef struct _xfVideoContext xfVideoContext;
 
 void xf_video_geometry_init(xfContext *xfc, GeometryClientContext *geom);
 void xf_video_control_init(xfContext *xfc, VideoClientContext *video);
+void xf_video_control_uninit(xfContext *xfc, VideoClientContext *video);
 
 void xf_video_data_init(xfContext *xfc, VideoClientContext *video);
-void xf_video_data_uninit(xfVideoContext *xfVideo);
+void xf_video_data_uninit(xfContext *xfc, VideoClientContext *context);
 
-xfVideoContext *xf_video_new();
+xfVideoContext *xf_video_new(xfContext *xfc);
 
 
 #endif /* CLIENT_X11_XF_VIDEO_H_ */

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -82,6 +82,7 @@ typedef struct xf_glyph xfGlyph;
 
 typedef struct xf_clipboard xfClipboard;
 typedef struct _xfDispContext xfDispContext;
+typedef struct _xfVideoContext xfVideoContext;
 
 /* Value of the first logical button number in X11 which must be */
 /* subtracted to go from a button number in X11 to an index into */
@@ -215,6 +216,9 @@ struct xf_context
 	TsmfClientContext* tsmf;
 	xfClipboard* clipboard;
 	CliprdrClientContext* cliprdr;
+	xfVideoContext *xfVideo;
+	GeometryClientContext *geometry;
+	VideoClientContext *video;
 	RdpeiClientContext* rdpei;
 	EncomspClientContext* encomsp;
 	xfDispContext* xfDisp;

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -216,9 +216,7 @@ struct xf_context
 	TsmfClientContext* tsmf;
 	xfClipboard* clipboard;
 	CliprdrClientContext* cliprdr;
-	xfVideoContext *xfVideo;
-	GeometryClientContext *geometry;
-	VideoClientContext *video;
+	xfVideoContext* xfVideo;
 	RdpeiClientContext* rdpei;
 	EncomspClientContext* encomsp;
 	xfDispContext* xfDisp;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -767,6 +767,11 @@ static int freerdp_client_command_line_post_filter(void* context,
 	{
 		settings->SupportGeometryTracking = TRUE;
 	}
+	CommandLineSwitchCase(arg, "video")
+	{
+		settings->SupportGeometryTracking = TRUE; /* this requires geometry tracking */
+		settings->SupportVideoOptimized = TRUE;
+	}
 	CommandLineSwitchCase(arg, "sound")
 	{
 		char** p;
@@ -3010,6 +3015,17 @@ BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 		int count;
 		count = 1;
 		p[0] = "geometry";
+
+		if (!freerdp_client_add_dynamic_channel(settings, count, p))
+			return FALSE;
+	}
+
+	if (settings->SupportVideoOptimized)
+	{
+		char* p[1];
+		int count;
+		count = 1;
+		p[0] = "video";
 
 		if (!freerdp_client_add_dynamic_channel(settings, count, p))
 			return FALSE;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -171,6 +171,7 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "v", COMMAND_LINE_VALUE_REQUIRED, "<server>[:port]", NULL, NULL, -1, NULL, "Server hostname" },
 	{ "vc", COMMAND_LINE_VALUE_REQUIRED, "<channel>[,<options>]", NULL, NULL, -1, NULL, "Static virtual channel" },
 	{ "version", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT_VERSION, NULL, NULL, NULL, -1, NULL, "Print version" },
+    { "video", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Video optimized remoting channel" },
 	{ "vmconnect", COMMAND_LINE_VALUE_OPTIONAL, "<vmid>", NULL, NULL, -1, NULL, "Hyper-V console (use port 2179, disable negotiation)" },
 	{ "w", COMMAND_LINE_VALUE_REQUIRED, "<width>", "1024", NULL, -1, NULL, "Width" },
 	{ "wallpaper", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "Enable wallpaper" },

--- a/include/freerdp/channels/geometry.h
+++ b/include/freerdp/channels/geometry.h
@@ -45,6 +45,7 @@ struct _FREERDP_RGNDATA
 
 typedef struct _FREERDP_RGNDATA FREERDP_RGNDATA;
 
+
 struct _MAPPED_GEOMETRY_PACKET
 {
 	UINT32 version;

--- a/include/freerdp/channels/video.h
+++ b/include/freerdp/channels/video.h
@@ -48,6 +48,7 @@ struct _TSMM_PRESENTATION_REQUEST
 	BYTE PresentationId;
 	BYTE Version;
 	BYTE Command;
+	BYTE FrameRate;
 	UINT32 SourceWidth, SourceHeight;
 	UINT32 ScaledWidth, ScaledHeight;
 	UINT64 hnsTimestampOffset;
@@ -89,12 +90,14 @@ struct _TSMM_VIDEO_DATA
 };
 typedef struct _TSMM_VIDEO_DATA TSMM_VIDEO_DATA;
 
+/** @brief values for NotificationType in TSMM_CLIENT_NOTIFICATION */
 enum
 {
 	TSMM_CLIENT_NOTIFICATION_TYPE_NETWORK_ERROR = 1,
 	TSMM_CLIENT_NOTIFICATION_TYPE_FRAMERATE_OVERRIDE = 2
 };
 
+/** @brief struct used when NotificationType is FRAMERATE_OVERRIDE */
 struct _TSMM_CLIENT_NOTIFICATION_FRAMERATE_OVERRIDE
 {
 	UINT32 Flags;
@@ -102,6 +105,7 @@ struct _TSMM_CLIENT_NOTIFICATION_FRAMERATE_OVERRIDE
 };
 typedef struct _TSMM_CLIENT_NOTIFICATION_FRAMERATE_OVERRIDE TSMM_CLIENT_NOTIFICATION_FRAMERATE_OVERRIDE;
 
+/** @brief a client to server notification struct */
 struct _TSMM_CLIENT_NOTIFICATION
 {
 	BYTE PresentationId;

--- a/include/freerdp/channels/video.h
+++ b/include/freerdp/channels/video.h
@@ -2,7 +2,7 @@
  * FreeRDP: A Remote Desktop Protocol Implementation
  * Video Optimized Remoting Virtual Channel Extension
  *
- * Copyright 2017 David Fort <contact@hardening-consulting.com>
+ * Copyright 2018 David Fort <contact@hardening-consulting.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/freerdp/channels/video.h
+++ b/include/freerdp/channels/video.h
@@ -1,0 +1,114 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Video Optimized Remoting Virtual Channel Extension
+ *
+ * Copyright 2017 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_VIDEO_H
+#define FREERDP_CHANNEL_VIDEO_H
+
+#include <winpr/wtypes.h>
+#include <freerdp/types.h>
+
+#define VIDEO_CONTROL_DVC_CHANNEL_NAME "Microsoft::Windows::RDS::Video::Control::v08.01"
+#define VIDEO_DATA_DVC_CHANNEL_NAME "Microsoft::Windows::RDS::Video::Data::v08.01"
+
+/** @brief TSNM packet type */
+enum
+{
+	TSMM_PACKET_TYPE_PRESENTATION_REQUEST	= 1,
+	TSMM_PACKET_TYPE_PRESENTATION_RESPONSE	= 2,
+	TSMM_PACKET_TYPE_CLIENT_NOTIFICATION	= 3,
+	TSMM_PACKET_TYPE_VIDEO_DATA				= 4
+};
+
+/** @brief TSMM_PRESENTATION_REQUEST commands */
+enum
+{
+	TSMM_START_PRESENTATION = 1,
+	TSMM_STOP_PRESENTATION	= 2
+};
+
+/** @brief presentation request struct */
+struct _TSMM_PRESENTATION_REQUEST
+{
+	BYTE PresentationId;
+	BYTE Version;
+	BYTE Command;
+	UINT32 SourceWidth, SourceHeight;
+	UINT32 ScaledWidth, ScaledHeight;
+	UINT64 hnsTimestampOffset;
+	UINT64 GeometryMappingId;
+	BYTE VideoSubtypeId[16];
+	UINT32 cbExtra;
+	BYTE *pExtraData;
+};
+typedef struct _TSMM_PRESENTATION_REQUEST TSMM_PRESENTATION_REQUEST;
+
+/** @brief response to a TSMM_PRESENTATION_REQUEST */
+struct _TSMM_PRESENTATION_RESPONSE
+{
+	BYTE PresentationId;
+};
+typedef struct _TSMM_PRESENTATION_RESPONSE TSMM_PRESENTATION_RESPONSE;
+
+/** @brief TSMM_VIDEO_DATA flags */
+enum
+{
+	TSMM_VIDEO_DATA_FLAG_HAS_TIMESTAMPS	= 0x01,
+	TSMM_VIDEO_DATA_FLAG_KEYFRAME		= 0x02,
+	TSMM_VIDEO_DATA_FLAG_NEW_FRAMERATE	= 0x04
+};
+
+/** @brief a video data packet */
+struct _TSMM_VIDEO_DATA
+{
+	BYTE PresentationId;
+	BYTE Version;
+	BYTE Flags;
+	UINT64 hnsTimestamp;
+	UINT64 hnsDuration;
+	UINT16 CurrentPacketIndex;
+	UINT16 PacketsInSample;
+	UINT32 SampleNumber;
+	UINT32 cbSample;
+	BYTE *pSample;
+};
+typedef struct _TSMM_VIDEO_DATA TSMM_VIDEO_DATA;
+
+enum
+{
+	TSMM_CLIENT_NOTIFICATION_TYPE_NETWORK_ERROR = 1,
+	TSMM_CLIENT_NOTIFICATION_TYPE_FRAMERATE_OVERRIDE = 2
+};
+
+struct _TSMM_CLIENT_NOTIFICATION_FRAMERATE_OVERRIDE
+{
+	UINT32 Flags;
+	UINT32 DesiredFrameRate;
+};
+typedef struct _TSMM_CLIENT_NOTIFICATION_FRAMERATE_OVERRIDE TSMM_CLIENT_NOTIFICATION_FRAMERATE_OVERRIDE;
+
+struct _TSMM_CLIENT_NOTIFICATION
+{
+	BYTE PresentationId;
+	BYTE NotificationType;
+	TSMM_CLIENT_NOTIFICATION_FRAMERATE_OVERRIDE FramerateOverride;
+};
+typedef struct _TSMM_CLIENT_NOTIFICATION TSMM_CLIENT_NOTIFICATION;
+
+
+#endif /* FREERDP_CHANNEL_VIDEO_H */

--- a/include/freerdp/client/geometry.h
+++ b/include/freerdp/client/geometry.h
@@ -21,6 +21,7 @@
 #define FREERDP_CHANNELS_CLIENT_GEOMETRY_H
 
 #include <winpr/collections.h>
+#include <freerdp/api.h>
 #include <freerdp/channels/geometry.h>
 
 /**
@@ -63,8 +64,8 @@ struct _geometry_client_context
 extern "C"
 #endif
 
-void mappedGeometryRef(MAPPED_GEOMETRY *g);
-void mappedGeometryUnref(MAPPED_GEOMETRY *g);
+FREERDP_API void mappedGeometryRef(MAPPED_GEOMETRY *g);
+FREERDP_API void mappedGeometryUnref(MAPPED_GEOMETRY *g);
 
 #ifdef __cplusplus
 }

--- a/include/freerdp/client/geometry.h
+++ b/include/freerdp/client/geometry.h
@@ -20,6 +20,7 @@
 #ifndef FREERDP_CHANNELS_CLIENT_GEOMETRY_H
 #define FREERDP_CHANNELS_CLIENT_GEOMETRY_H
 
+#include <winpr/collections.h>
 #include <freerdp/channels/geometry.h>
 
 /**
@@ -28,14 +29,31 @@
 typedef struct _geometry_client_context GeometryClientContext;
 
 
-typedef UINT (*pcMappedGeometryPacket)(GeometryClientContext* context, MAPPED_GEOMETRY_PACKET *packet);
+typedef struct _MAPPED_GEOMETRY MAPPED_GEOMETRY;
+typedef BOOL (*pcMappedGeometryAdded)(GeometryClientContext* context, MAPPED_GEOMETRY *geometry);
+typedef BOOL (*pcMappedGeometryUpdate)(MAPPED_GEOMETRY *geometry);
+typedef BOOL (*pcMappedGeometryClear)(MAPPED_GEOMETRY *geometry);
+
+struct _MAPPED_GEOMETRY
+{
+	UINT64 mappingId;
+	UINT64 topLevelId;
+	INT32 left, top, right, bottom;
+	INT32 topLevelLeft, topLevelTop, topLevelRight, topLevelBottom;
+	FREERDP_RGNDATA geometry;
+
+	void *custom;
+	pcMappedGeometryUpdate MappedGeometryUpdate;
+	pcMappedGeometryClear MappedGeometryClear;
+};
 
 struct _geometry_client_context
 {
+	wHashTable *geometries;
 	void* handle;
 	void* custom;
 
-	pcMappedGeometryPacket MappedGeometryPacket;
+	pcMappedGeometryAdded MappedGeometryAdded;
 };
 
 #endif /* FREERDP_CHANNELS_CLIENT_GEOMETRY_H */

--- a/include/freerdp/client/geometry.h
+++ b/include/freerdp/client/geometry.h
@@ -28,12 +28,12 @@
  */
 typedef struct _geometry_client_context GeometryClientContext;
 
-
 typedef struct _MAPPED_GEOMETRY MAPPED_GEOMETRY;
 typedef BOOL (*pcMappedGeometryAdded)(GeometryClientContext* context, MAPPED_GEOMETRY *geometry);
 typedef BOOL (*pcMappedGeometryUpdate)(MAPPED_GEOMETRY *geometry);
 typedef BOOL (*pcMappedGeometryClear)(MAPPED_GEOMETRY *geometry);
 
+/** @brief a geometry record tracked by the geometry channel */
 struct _MAPPED_GEOMETRY
 {
 	UINT64 mappingId;
@@ -47,6 +47,7 @@ struct _MAPPED_GEOMETRY
 	pcMappedGeometryClear MappedGeometryClear;
 };
 
+/** @brief the geometry context for client channel */
 struct _geometry_client_context
 {
 	wHashTable *geometries;

--- a/include/freerdp/client/geometry.h
+++ b/include/freerdp/client/geometry.h
@@ -36,6 +36,7 @@ typedef BOOL (*pcMappedGeometryClear)(MAPPED_GEOMETRY *geometry);
 /** @brief a geometry record tracked by the geometry channel */
 struct _MAPPED_GEOMETRY
 {
+	volatile LONG refCounter;
 	UINT64 mappingId;
 	UINT64 topLevelId;
 	INT32 left, top, right, bottom;
@@ -47,6 +48,7 @@ struct _MAPPED_GEOMETRY
 	pcMappedGeometryClear MappedGeometryClear;
 };
 
+
 /** @brief the geometry context for client channel */
 struct _geometry_client_context
 {
@@ -56,6 +58,18 @@ struct _geometry_client_context
 
 	pcMappedGeometryAdded MappedGeometryAdded;
 };
+
+#ifdef __cplusplus
+extern "C"
+#endif
+
+void mappedGeometryRef(MAPPED_GEOMETRY *g);
+void mappedGeometryUnref(MAPPED_GEOMETRY *g);
+
+#ifdef __cplusplus
+}
+#endif
+
 
 #endif /* FREERDP_CHANNELS_CLIENT_GEOMETRY_H */
 

--- a/include/freerdp/client/video.h
+++ b/include/freerdp/client/video.h
@@ -1,0 +1,45 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Video Optimized Remoting Virtual Channel Extension
+ *
+ * Copyright 2017 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNELS_CLIENT_VIDEO_H
+#define FREERDP_CHANNELS_CLIENT_VIDEO_H
+
+#include <freerdp/channels/video.h>
+
+typedef struct _video_client_context VideoClientContext;
+
+typedef UINT (*pcPresentationRequest)(VideoClientContext* context, TSMM_PRESENTATION_REQUEST *req);
+typedef UINT (*pcPresentationResponse)(VideoClientContext* context, TSMM_PRESENTATION_RESPONSE *resp);
+typedef UINT (*pcVideoClientNotification)(VideoClientContext *context, TSMM_CLIENT_NOTIFICATION *notif);
+typedef UINT (*pcVideoData)(VideoClientContext* context, TSMM_VIDEO_DATA *data);
+
+/** @brief context for the video (MS-RDPEVOR) channel */
+struct _video_client_context
+{
+	void* handle;
+	void* custom;
+
+	pcPresentationRequest PresentationRequest;
+	pcPresentationResponse PresentationResponse;
+	pcVideoClientNotification ClientNotification;
+	pcVideoData VideoData;
+};
+
+#endif /* FREERDP_CHANNELS_CLIENT_VIDEO_H */
+

--- a/include/freerdp/client/video.h
+++ b/include/freerdp/client/video.h
@@ -20,26 +20,42 @@
 #ifndef FREERDP_CHANNELS_CLIENT_VIDEO_H
 #define FREERDP_CHANNELS_CLIENT_VIDEO_H
 
+#include <freerdp/client/geometry.h>
 #include <freerdp/channels/video.h>
 
-typedef struct _video_client_context VideoClientContext;
+typedef struct _VideoClientContext VideoClientContext;
+typedef struct _VideoClientContextPriv VideoClientContextPriv;
+typedef struct _VideoSurface VideoSurface;
 
-typedef UINT (*pcPresentationRequest)(VideoClientContext* context, TSMM_PRESENTATION_REQUEST *req);
-typedef UINT (*pcPresentationResponse)(VideoClientContext* context, TSMM_PRESENTATION_RESPONSE *resp);
-typedef UINT (*pcVideoClientNotification)(VideoClientContext *context, TSMM_CLIENT_NOTIFICATION *notif);
-typedef UINT (*pcVideoData)(VideoClientContext* context, TSMM_VIDEO_DATA *data);
+
+/** @brief an implementation of surface used by the video channel */
+struct _VideoSurface
+{
+	UINT32 x, y, w, h;
+	BYTE *data;
+};
+
+typedef void (*pcVideoTimer)(VideoClientContext *video, UINT64 now);
+typedef void (*pcVideoSetGeometry)(VideoClientContext *video, GeometryClientContext *geometry);
+typedef VideoSurface *(*pcVideoCreateSurface)(VideoClientContext *video, BYTE *data, UINT32 x, UINT32 y,
+			UINT32 width, UINT32 height);
+typedef BOOL (*pcVideoShowSurface)(VideoClientContext *video, VideoSurface *surface);
+typedef BOOL (*pcVideoDeleteSurface)(VideoClientContext *video, VideoSurface *surface);
 
 /** @brief context for the video (MS-RDPEVOR) channel */
-struct _video_client_context
+struct _VideoClientContext
 {
 	void* handle;
 	void* custom;
+	VideoClientContextPriv *priv;
 
-	pcPresentationRequest PresentationRequest;
-	pcPresentationResponse PresentationResponse;
-	pcVideoClientNotification ClientNotification;
-	pcVideoData VideoData;
+	pcVideoSetGeometry setGeometry;
+	pcVideoTimer timer;
+	pcVideoCreateSurface createSurface;
+	pcVideoShowSurface showSurface;
+	pcVideoDeleteSurface deleteSurface;
 };
+
 
 #endif /* FREERDP_CHANNELS_CLIENT_VIDEO_H */
 

--- a/include/freerdp/codec/yuv.h
+++ b/include/freerdp/codec/yuv.h
@@ -1,0 +1,48 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * YUV decoder
+ *
+ * Copyright 2017 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CODEC_YUV_H
+#define FREERDP_CODEC_YUV_H
+
+typedef struct _YUV_CONTEXT YUV_CONTEXT;
+
+#include <freerdp/api.h>
+#include <freerdp/types.h>
+#include <freerdp/freerdp.h>
+#include <freerdp/constants.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+FREERDP_API BOOL yuv_context_decode(YUV_CONTEXT* context, const BYTE* pYUVData[3], UINT32 iStride[3],
+		DWORD DstFormat, BYTE *dest, UINT32 nDstStep);
+
+FREERDP_API void yuv_context_reset(YUV_CONTEXT* context, UINT32 width, UINT32 height);
+
+FREERDP_API YUV_CONTEXT* yuv_context_new(BOOL encoder);
+FREERDP_API void yuv_context_free(YUV_CONTEXT* context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FREERDP_CODEC_YUV_H */

--- a/include/freerdp/gdi/gdi.h
+++ b/include/freerdp/gdi/gdi.h
@@ -32,6 +32,8 @@
 #include <freerdp/codec/region.h>
 
 #include <freerdp/client/rdpgfx.h>
+#include <freerdp/client/geometry.h>
+#include <freerdp/client/video.h>
 
 /* For more information, see [MS-RDPEGDI] */
 
@@ -520,6 +522,8 @@ struct rdp_gdi
 	BOOL suppressOutput;
 	UINT16 outputSurfaceId;
 	RdpgfxClientContext* gfx;
+	VideoClientContext* video;
+	GeometryClientContext* geometry;
 
 	wLog* log;
 };

--- a/include/freerdp/gdi/video.h
+++ b/include/freerdp/gdi/video.h
@@ -1,0 +1,42 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Video Optimized Remoting Virtual Channel Extension for X11
+ *
+ * Copyright 2017 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FREERDP_GDI_VIDEO_H_
+#define FREERDP_GDI_VIDEO_H_
+
+#include <freerdp/freerdp.h>
+#include <freerdp/client/geometry.h>
+#include <freerdp/client/video.h>
+
+struct _gdiVideoContext;
+typedef struct _gdiVideoContext gdiVideoContext;
+
+void gdi_video_geometry_init(rdpGdi* gdi, GeometryClientContext* geom);
+void gdi_video_geometry_uninit(rdpGdi* gdi, GeometryClientContext* geom);
+
+void gdi_video_control_init(rdpGdi* gdi, VideoClientContext* video);
+void gdi_video_control_uninit(rdpGdi* gdi, VideoClientContext* video);
+
+void gdi_video_data_init(rdpGdi* gdi, VideoClientContext* video);
+void gdi_video_data_uninit(rdpGdi* gdi, VideoClientContext* context);
+
+gdiVideoContext* gdi_video_new(rdpGdi* gdi);
+void gdi_video_free(gdiVideoContext* context);
+
+
+#endif /* FREERDP_GDI_VIDEO_H_ */

--- a/include/freerdp/gdi/video.h
+++ b/include/freerdp/gdi/video.h
@@ -19,6 +19,7 @@
 #ifndef FREERDP_GDI_VIDEO_H_
 #define FREERDP_GDI_VIDEO_H_
 
+#include <freerdp/api.h>
 #include <freerdp/freerdp.h>
 #include <freerdp/client/geometry.h>
 #include <freerdp/client/video.h>
@@ -26,17 +27,17 @@
 struct _gdiVideoContext;
 typedef struct _gdiVideoContext gdiVideoContext;
 
-void gdi_video_geometry_init(rdpGdi* gdi, GeometryClientContext* geom);
-void gdi_video_geometry_uninit(rdpGdi* gdi, GeometryClientContext* geom);
+FREERDP_API void gdi_video_geometry_init(rdpGdi* gdi, GeometryClientContext* geom);
+FREERDP_API void gdi_video_geometry_uninit(rdpGdi* gdi, GeometryClientContext* geom);
 
-void gdi_video_control_init(rdpGdi* gdi, VideoClientContext* video);
-void gdi_video_control_uninit(rdpGdi* gdi, VideoClientContext* video);
+FREERDP_API void gdi_video_control_init(rdpGdi* gdi, VideoClientContext* video);
+FREERDP_API void gdi_video_control_uninit(rdpGdi* gdi, VideoClientContext* video);
 
-void gdi_video_data_init(rdpGdi* gdi, VideoClientContext* video);
-void gdi_video_data_uninit(rdpGdi* gdi, VideoClientContext* context);
+FREERDP_API void gdi_video_data_init(rdpGdi* gdi, VideoClientContext* video);
+FREERDP_API void gdi_video_data_uninit(rdpGdi* gdi, VideoClientContext* context);
 
-gdiVideoContext* gdi_video_new(rdpGdi* gdi);
-void gdi_video_free(gdiVideoContext* context);
+FREERDP_API gdiVideoContext* gdi_video_new(rdpGdi* gdi);
+FREERDP_API void gdi_video_free(gdiVideoContext* context);
 
 
 #endif /* FREERDP_GDI_VIDEO_H_ */

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -1428,7 +1428,8 @@ struct rdp_settings
 	ALIGN64 BOOL SupportDisplayControl; /* 5185 */
 	ALIGN64 BOOL SupportGeometryTracking; /* 5186 */
 	ALIGN64 BOOL SupportSSHAgentChannel; /* 5187 */
-	UINT64 padding5312[5312 - 5188]; /* 5188 */
+	ALIGN64 BOOL SupportVideoOptimized; /* 5188 */
+	UINT64 padding5312[5312 - 5189]; /* 5189 */
 
 	/**
 	 * WARNING: End of ABI stable zone!

--- a/libfreerdp/CMakeLists.txt
+++ b/libfreerdp/CMakeLists.txt
@@ -130,7 +130,8 @@ set(CODEC_SRCS
 	codec/zgfx.c
 	codec/clear.c
 	codec/jpeg.c
-	codec/h264.c)
+	codec/h264.c
+	codec/yuv.c)
 
 set(CODEC_SSE2_SRCS
 	codec/rfx_sse2.c

--- a/libfreerdp/codec/h264.c
+++ b/libfreerdp/codec/h264.c
@@ -180,7 +180,6 @@ INT32 avc420_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSize
 		return -1001;
 
 	status = h264->subsystem->Decompress(h264, pSrcData, SrcSize);
-
 	if (status == 0)
 		return 1;
 

--- a/libfreerdp/codec/yuv.c
+++ b/libfreerdp/codec/yuv.c
@@ -1,0 +1,182 @@
+#include <winpr/sysinfo.h>
+#include <winpr/pool.h>
+
+#include <freerdp/primitives.h>
+#include <freerdp/log.h>
+#include <freerdp/codec/yuv.h>
+
+#define TAG FREERDP_TAG("codec")
+
+struct _YUV_CONTEXT
+{
+	UINT32 width, height;
+	BOOL useThreads;
+	UINT32 nthreads;
+	UINT32 heightStep;
+
+	PTP_POOL threadPool;
+	TP_CALLBACK_ENVIRON ThreadPoolEnv;
+};
+
+
+struct _YUV_PROCESS_WORK_PARAM
+{
+	YUV_CONTEXT* context;
+	const BYTE* pYUVData[3];
+	UINT32 iStride[3];
+	DWORD DstFormat;
+	BYTE *dest;
+	UINT32 nDstStep;
+	UINT32 y;
+	UINT32 height;
+};
+typedef struct _YUV_PROCESS_WORK_PARAM YUV_PROCESS_WORK_PARAM;
+
+static void CALLBACK yuv_process_work_callback(PTP_CALLBACK_INSTANCE instance, void* context,
+		PTP_WORK work)
+{
+	prim_size_t roi;
+	YUV_PROCESS_WORK_PARAM* param = (YUV_PROCESS_WORK_PARAM*)context;
+	primitives_t* prims = primitives_get();
+
+	roi.width = param->context->width;
+	roi.height = param->height;
+	if( prims->YUV420ToRGB_8u_P3AC4R(param->pYUVData, param->iStride, param->dest, param->nDstStep,
+				        param->DstFormat, &roi) != PRIMITIVES_SUCCESS)
+	{
+		WLog_ERR(TAG, "error when decoding lines");
+	}
+}
+
+
+void yuv_context_reset(YUV_CONTEXT* context, UINT32 width, UINT32 height)
+{
+	context->width = width;
+	context->height = height;
+	context->heightStep = (height / context->nthreads);
+}
+
+
+YUV_CONTEXT* yuv_context_new(BOOL encoder)
+{
+	SYSTEM_INFO sysInfos;
+	YUV_CONTEXT* ret = calloc(1, sizeof(*ret));
+	if (!ret)
+		return NULL;
+
+	/** do it here to avoid a race condition between threads */
+	primitives_get();
+
+	GetNativeSystemInfo(&sysInfos);
+	ret->useThreads = (sysInfos.dwNumberOfProcessors > 1);
+	if (ret->useThreads)
+	{
+		ret->nthreads = sysInfos.dwNumberOfProcessors;
+		ret->threadPool = CreateThreadpool(NULL);
+		if (!ret->threadPool)
+		{
+			goto error_threadpool;
+		}
+
+		InitializeThreadpoolEnvironment(&ret->ThreadPoolEnv);
+		SetThreadpoolCallbackPool(&ret->ThreadPoolEnv, ret->threadPool);
+	}
+	else
+	{
+		ret->nthreads = 1;
+	}
+
+	return ret;
+
+error_threadpool:
+	free(ret);
+	return NULL;
+}
+
+
+void yuv_context_free(YUV_CONTEXT* context)
+{
+	if (context->useThreads)
+	{
+		CloseThreadpool(context->threadPool);
+		DestroyThreadpoolEnvironment(&context->ThreadPoolEnv);
+	}
+	free(context);
+}
+
+
+BOOL yuv_context_decode(YUV_CONTEXT* context, const BYTE* pYUVData[3], UINT32 iStride[3],
+						DWORD DstFormat, BYTE *dest, UINT32 nDstStep)
+{
+	UINT32 y, nobjects, i;
+	PTP_WORK *work_objects = NULL;
+	YUV_PROCESS_WORK_PARAM *params;
+	int waitCount = 0;
+	BOOL ret = TRUE;
+
+	if (!context->useThreads)
+	{
+		primitives_t* prims = primitives_get();
+		prim_size_t roi;
+		roi.width = context->width;
+		roi.height = context->height;
+		return prims->YUV420ToRGB_8u_P3AC4R(pYUVData, iStride, dest, nDstStep,
+					        DstFormat, &roi) == PRIMITIVES_SUCCESS;
+	}
+
+	/* case where we use threads */
+	nobjects = (context->height + context->heightStep - 1) / context->heightStep;
+	work_objects = (PTP_WORK *)calloc(nobjects, sizeof(PTP_WORK));
+	if (!work_objects)
+	{
+		return FALSE;
+	}
+
+	params = (YUV_PROCESS_WORK_PARAM *)calloc(nobjects, sizeof(*params));
+	if (!params)
+	{
+		free(work_objects);
+		return FALSE;
+	}
+
+	for (i = 0, y = 0; i < nobjects; i++, y += context->heightStep, waitCount++)
+	{
+		params[i].context = context;
+		params[i].DstFormat = DstFormat;
+		params[i].pYUVData[0] = pYUVData[0] + (y * iStride[0]);
+		params[i].pYUVData[1] = pYUVData[1] + ((y / 2) * iStride[1]);
+		params[i].pYUVData[2] = pYUVData[2] + ((y / 2) * iStride[2]);
+
+		params[i].iStride[0] = iStride[0];
+		params[i].iStride[1] = iStride[1];
+		params[i].iStride[2] = iStride[2];
+
+		params[i].nDstStep = nDstStep;
+		params[i].dest = dest + (nDstStep * y);
+		params[i].y = y;
+		if (y + context->heightStep <= context->height)
+			params[i].height = context->heightStep;
+		else
+			params[i].height = context->height % context->heightStep;
+
+		work_objects[i] = CreateThreadpoolWork((PTP_WORK_CALLBACK)yuv_process_work_callback,
+					                        (void*) &params[i], &context->ThreadPoolEnv);
+		if (!work_objects[i])
+		{
+			ret = FALSE;
+			break;
+		}
+		SubmitThreadpoolWork(work_objects[i]);
+	}
+
+	for (i = 0; i < waitCount; i++)
+	{
+		WaitForThreadpoolWorkCallbacks(work_objects[i], FALSE);
+		CloseThreadpoolWork(work_objects[i]);
+	}
+
+	free(work_objects);
+	free(params);
+
+	return ret;
+}

--- a/libfreerdp/gdi/CMakeLists.txt
+++ b/libfreerdp/gdi/CMakeLists.txt
@@ -33,6 +33,7 @@ set(${MODULE_PREFIX}_SRCS
 	graphics.c
 	graphics.h
 	gfx.c
+	video.c
 	gdi.c
 	gdi.h)
 

--- a/libfreerdp/gdi/video.c
+++ b/libfreerdp/gdi/video.c
@@ -1,0 +1,163 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Video Optimized Remoting Virtual Channel Extension for X11
+ *
+ * Copyright 2017 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include <freerdp/client/geometry.h>
+#include <freerdp/client/video.h>
+#include <freerdp/gdi/gdi.h>
+#include <freerdp/gdi/video.h>
+
+#define TAG FREERDP_TAG("video")
+
+typedef struct
+{
+	VideoSurface base;
+	UINT32 scanline;
+	BYTE* image;
+} gdiVideoSurface;
+
+
+void gdi_video_geometry_init(rdpGdi* gdi, GeometryClientContext* geom)
+{
+	gdi->geometry = geom;
+
+	if (gdi->video)
+	{
+		VideoClientContext* video = gdi->video;
+		video->setGeometry(video, gdi->geometry);
+	}
+}
+
+void gdi_video_geometry_uninit(rdpGdi* gdi, GeometryClientContext* geom)
+{
+}
+
+static VideoSurface* gdiVideoCreateSurface(VideoClientContext* video, BYTE* data, UINT32 x,
+        UINT32 y,
+        UINT32 width, UINT32 height)
+{
+	rdpGdi* gdi = (rdpGdi*)video->custom;
+	gdiVideoSurface* ret = calloc(1, sizeof(*ret));
+	UINT32 bpp;
+
+	if (!ret)
+		return NULL;
+
+	bpp = GetBytesPerPixel(gdi->dstFormat);
+	ret->base.data = data;
+	ret->base.x = x;
+	ret->base.y = y;
+	ret->base.w = width;
+	ret->base.h = height;
+	ret->scanline = width * bpp;
+
+	if (ret->scanline % 16 != 0)
+		ret->scanline += 16 - ret->scanline % 16;
+
+	ret->image = _aligned_malloc(ret->scanline * height, 16);
+
+	if (!ret->image)
+	{
+		WLog_ERR(TAG, "unable to create surface image");
+		free(ret);
+		return NULL;
+	}
+
+	return &ret->base;
+}
+
+
+static BOOL gdiVideoShowSurface(VideoClientContext* video, VideoSurface* surface)
+{
+	rdpGdi* gdi = (rdpGdi*)video->custom;
+	gdiVideoSurface* gdiSurface = (gdiVideoSurface*)surface;
+	UINT32 nXDst, nYDst;
+	UINT32 nXSrc, nYSrc;
+	UINT16 width, height;
+	RECTANGLE_16 surfaceRect;
+	rdpUpdate* update = gdi->context->update;
+	surfaceRect.left = surface->x;
+	surfaceRect.top = surface->y;
+	surfaceRect.right = surface->x + surface->w;
+	surfaceRect.bottom = surface->y + surface->h;
+	update->BeginPaint(gdi->context);
+	{
+		nXSrc = surface->x;
+		nYSrc = surface->y;
+		nXDst = nXSrc;
+		nYDst = nYSrc;
+		width = (surface->w + surface->x < gdi->width) ? surface->w : gdi->width - surface->x;
+		height = (surface->h + surface->y < gdi->height) ? surface->h : gdi->height - surface->y;
+
+		if (!freerdp_image_copy(gdi->primary_buffer, gdi->primary->hdc->format,
+		                        gdi->stride,
+		                        nXDst, nYDst, width, height,
+		                        surface->data, gdi->primary->hdc->format,
+		                        gdiSurface->scanline, nXSrc, nYSrc, NULL, FREERDP_FLIP_NONE))
+			return CHANNEL_RC_NULL_DATA;
+
+		gdi_InvalidateRegion(gdi->primary->hdc, nXDst, nYDst, width, height);
+	}
+	update->EndPaint(gdi->context);
+	return TRUE;
+}
+
+static BOOL gdiVideoDeleteSurface(VideoClientContext* video, VideoSurface* surface)
+{
+	gdiVideoSurface* gdiSurface = (gdiVideoSurface*)surface;
+
+	if (gdiSurface)
+		_aligned_free(gdiSurface->image);
+
+	free(gdiSurface);
+	return TRUE;
+}
+void gdi_video_control_init(rdpGdi* gdi, VideoClientContext* video)
+{
+	gdi->video = video;
+	video->custom = gdi;
+	video->createSurface = gdiVideoCreateSurface;
+	video->showSurface = gdiVideoShowSurface;
+	video->deleteSurface = gdiVideoDeleteSurface;
+	video->setGeometry(video, gdi->geometry);
+}
+
+
+void gdi_video_control_uninit(rdpGdi* gdi, VideoClientContext* video)
+{
+	gdi->video = NULL;
+}
+
+static void gdi_video_timer(void* ctx, TimerEventArgs* timer)
+{
+	rdpGdi* gdi = (rdpGdi*)ctx;
+
+	if (gdi && gdi->video)
+		gdi->video->timer(gdi->video, timer->now);
+}
+
+void gdi_video_data_init(rdpGdi* gdi, VideoClientContext* video)
+{
+	PubSub_SubscribeTimer(gdi->context->pubSub, gdi_video_timer);
+}
+
+void gdi_video_data_uninit(rdpGdi* gdi, VideoClientContext* context)
+{
+	PubSub_UnsubscribeTimer(gdi->context->pubSub, gdi_video_timer);
+}


### PR DESCRIPTION
This PR proposes an implementation of MS-RDPEVOR. It changes the API of the geometry plugin to make it more convenient for other plugin to interact with it.
The video packets are reassembled and decoded (only H264). Then rendering is done using a new YUV renderer, that may use multiple threads to do the work (each thread doing the YUV420->RGB conversion on a small part of the picture).
A very trivial feedback algorithm is implemented to inform the server about the decoding capabilities.
To test: use WMP (don't know minimal version) with at least a 2012 server, download your favourite trailer and enjoy.
TODO: the spec suggests that we should be able to synchronize audio and video using the provided timestamps but I've not dig the subject.