### PR TITLE
  Fixed SuppressOutput update.

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -289,8 +289,6 @@ static BOOL xf_desktop_resize(rdpContext* context)
 static BOOL xf_sw_begin_paint(rdpContext* context)
 {
 	rdpGdi* gdi = context->gdi;
-	gdi->primary->hdc->hwnd->invalid->null = TRUE;
-	gdi->primary->hdc->hwnd->ninvalid = 0;
 	return TRUE;
 }
 
@@ -303,6 +301,10 @@ static BOOL xf_sw_end_paint(rdpContext* context)
 	HGDI_RGN cinvalid;
 	xfContext* xfc = (xfContext*) context;
 	rdpGdi* gdi = context->gdi;
+
+	if (gdi->suppressOutput)
+		return TRUE;
+
 	x = gdi->primary->hdc->hwnd->invalid->x;
 	y = gdi->primary->hdc->hwnd->invalid->y;
 	w = gdi->primary->hdc->hwnd->invalid->w;
@@ -355,6 +357,8 @@ static BOOL xf_sw_end_paint(rdpContext* context)
 		xf_unlock_x11(xfc, FALSE);
 	}
 
+	gdi->primary->hdc->hwnd->invalid->null = TRUE;
+	gdi->primary->hdc->hwnd->ninvalid = 0;
 	return TRUE;
 }
 
@@ -392,9 +396,6 @@ out:
 
 static BOOL xf_hw_begin_paint(rdpContext* context)
 {
-	xfContext* xfc = (xfContext*) context;
-	xfc->hdc->hwnd->invalid->null = TRUE;
-	xfc->hdc->hwnd->ninvalid = 0;
 	return TRUE;
 }
 
@@ -403,6 +404,9 @@ static BOOL xf_hw_end_paint(rdpContext* context)
 	INT32 x, y;
 	UINT32 w, h;
 	xfContext* xfc = (xfContext*) context;
+
+	if (xfc->context.gdi->suppressOutput)
+		return TRUE;
 
 	if (!xfc->remote_app)
 	{
@@ -459,6 +463,8 @@ static BOOL xf_hw_end_paint(rdpContext* context)
 		xf_unlock_x11(xfc, FALSE);
 	}
 
+	xfc->hdc->hwnd->invalid->null = TRUE;
+	xfc->hdc->hwnd->ninvalid = 0;
 	return TRUE;
 }
 

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -288,7 +288,6 @@ static BOOL xf_desktop_resize(rdpContext* context)
 
 static BOOL xf_sw_begin_paint(rdpContext* context)
 {
-	rdpGdi* gdi = context->gdi;
 	return TRUE;
 }
 

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -297,7 +297,7 @@ static BOOL xf_event_Expose(xfContext* xfc, XEvent* event, BOOL app)
 		h = event->xexpose.height;
 	}
 
-	if (xfc->gfx)
+	if (xfc->context.gdi->gfx)
 	{
 		xf_OutputExpose(xfc, x, y, w, h);
 		return TRUE;

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -158,28 +158,6 @@ static const char* x11_event_string(int event)
 #define DEBUG_X11(...) do { } while (0)
 #endif
 
-static BOOL xf_send_suppress_output(xfContext* xfc, XEvent* event, BOOL suppress)
-{
-	RECTANGLE_16 rect;
-	rdpSettings* settings;
-	rdpUpdate* update;
-
-	if (!xfc || !xfc->context.settings || !xfc->context.update)
-		return FALSE;
-
-	if (xfc->suppress_output == suppress)
-		return TRUE;
-
-	xfc->suppress_output = suppress;
-	settings = xfc->context.settings;
-	update = xfc->context.update;
-	rect.left = 0;
-	rect.top = 0;
-	rect.right = settings->DesktopWidth;
-	rect.bottom = settings->DesktopHeight;
-	return update->SuppressOutput(&xfc->context, !suppress, &rect);
-}
-
 BOOL xf_event_action_script_init(xfContext* xfc)
 {
 	char* xevent;
@@ -791,7 +769,7 @@ static BOOL xf_event_MapNotify(xfContext* xfc, XEvent* event, BOOL app)
 	xfAppWindow* appWindow;
 
 	if (!app)
-		xf_send_suppress_output(xfc, event, FALSE);
+		gdi_send_suppress_output(xfc->context.gdi, FALSE);
 	else
 	{
 		appWindow = xf_AppWindowFromX11Window(xfc, event->xany.window);
@@ -816,7 +794,7 @@ static BOOL xf_event_UnmapNotify(xfContext* xfc, XEvent* event, BOOL app)
 	xf_keyboard_release_all_keypress(xfc);
 
 	if (!app)
-		xf_send_suppress_output(xfc, event, TRUE);
+		gdi_send_suppress_output(xfc->context.gdi, TRUE);
 	else
 	{
 		appWindow = xf_AppWindowFromX11Window(xfc, event->xany.window);
@@ -922,7 +900,7 @@ static BOOL xf_event_PropertyNotify(xfContext* xfc, XEvent* event, BOOL app)
 			}
 		}
 		else if (minimizedChanged)
-			xf_send_suppress_output(xfc, event, minimized);
+			gdi_send_suppress_output(xfc->context.gdi, minimized);
 	}
 
 	return TRUE;

--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -46,7 +46,6 @@ static UINT xf_OutputUpdate(xfContext* xfc, xfGfxSurface* surface)
 	XSetClipMask(xfc->display, xfc->gc, None);
 	XSetFunction(xfc->display, xfc->gc, GXcopy);
 	XSetFillStyle(xfc->display, xfc->gc, FillSolid);
-
 	region16_intersect_rect(&(surface->gdi.invalidRegion),
 	                        &(surface->gdi.invalidRegion), &surfaceRect);
 
@@ -215,12 +214,13 @@ static UINT xf_CreateSurface(RdpgfxClientContext* context,
 	xfGfxSurface* surface;
 	rdpGdi* gdi = (rdpGdi*)context->custom;
 	xfContext* xfc = (xfContext*) gdi->context;
+	surface = (xfGfxSurface*) calloc(1, sizeof(xfGfxSurface));
 
-	surface = (xfGfxSurface *) calloc(1, sizeof(xfGfxSurface));
 	if (!surface)
 		return CHANNEL_RC_NO_MEMORY;
 
 	surface->gdi.codecs = gdi->context->codecs;
+
 	if (!surface->gdi.codecs)
 	{
 		WLog_ERR(TAG, "%s: global GDI codecs aren't set", __FUNCTION__);
@@ -250,13 +250,14 @@ static UINT xf_CreateSurface(RdpgfxClientContext* context,
 	surface->gdi.scanline = surface->gdi.width * GetBytesPerPixel(surface->gdi.format);
 	surface->gdi.scanline = x11_pad_scanline(surface->gdi.scanline, xfc->scanline_pad);
 	size = surface->gdi.scanline * surface->gdi.height;
-
 	surface->gdi.data = (BYTE*)_aligned_malloc(size, 16);
+
 	if (!surface->gdi.data)
 	{
 		WLog_ERR(TAG, "%s: unable to allocate GDI data", __FUNCTION__);
 		goto out_free;
 	}
+
 	ZeroMemory(surface->gdi.data, size);
 
 	if (AreColorFormatsEqualNoAlpha(gdi->dstFormat, surface->gdi.format))
@@ -272,15 +273,15 @@ static UINT xf_CreateSurface(RdpgfxClientContext* context,
 		surface->stageScanline = width * bytes;
 		surface->stageScanline = x11_pad_scanline(surface->stageScanline, xfc->scanline_pad);
 		size = surface->stageScanline * surface->gdi.height;
-
 		surface->stage = (BYTE*) _aligned_malloc(size, 16);
+
 		if (!surface->stage)
 		{
 			WLog_ERR(TAG, "%s: unable to allocate stage buffer", __FUNCTION__);
 			goto out_free_gdidata;
 		}
-		ZeroMemory(surface->stage, size);
 
+		ZeroMemory(surface->stage, size);
 		surface->image = XCreateImage(xfc->display, xfc->visual, xfc->depth,
 		                              ZPixmap, 0, (char*) surface->stage,
 		                              surface->gdi.width, surface->gdi.height,
@@ -295,16 +296,16 @@ static UINT xf_CreateSurface(RdpgfxClientContext* context,
 
 	surface->image->byte_order = LSBFirst;
 	surface->image->bitmap_bit_order = LSBFirst;
-
 	surface->gdi.outputMapped = FALSE;
 	region16_init(&surface->gdi.invalidRegion);
+
 	if (context->SetSurfaceData(context, surface->gdi.surfaceId, (void*) surface) != CHANNEL_RC_OK)
 	{
 		WLog_ERR(TAG, "%s: an error occurred during SetSurfaceData", __FUNCTION__);
 		goto error_set_surface_data;
 	}
-	return CHANNEL_RC_OK;
 
+	return CHANNEL_RC_OK;
 error_set_surface_data:
 	XFree(surface->image);
 error_surface_image:

--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -147,7 +147,7 @@ UINT xf_OutputExpose(xfContext* xfc, UINT32 x, UINT32 y,
 	RECTANGLE_16 surfaceRect;
 	RECTANGLE_16 intersection;
 	UINT16* pSurfaceIds = NULL;
-	RdpgfxClientContext* context = xfc->gfx;
+	RdpgfxClientContext* context = xfc->context.gdi->gfx;
 	invalidRect.left = x;
 	invalidRect.top = y;
 	invalidRect.right = x + width;

--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -114,6 +114,9 @@ static UINT xf_UpdateSurfaces(RdpgfxClientContext* context)
 	if (!gdi->graphicsReset)
 		return status;
 
+	if (gdi->suppressOutput)
+		return CHANNEL_RC_OK;
+
 	context->GetSurfaceIds(context, &pSurfaceIds, &count);
 
 	for (index = 0; index < count; index++)

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -216,7 +216,6 @@ struct xf_context
 	xfClipboard* clipboard;
 	CliprdrClientContext* cliprdr;
 	RdpeiClientContext* rdpei;
-	RdpgfxClientContext* gfx;
 	EncomspClientContext* encomsp;
 	xfDispContext* xfDisp;
 	DispClientContext* disp;

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -158,7 +158,6 @@ struct xf_context
 	BOOL focused;
 	BOOL use_xinput;
 	BOOL mouse_active;
-	BOOL suppress_output;
 	BOOL fullscreen_toggle;
 	BOOL controlToggle;
 	UINT32 KeyboardLayout;

--- a/include/freerdp/gdi/gdi.h
+++ b/include/freerdp/gdi/gdi.h
@@ -517,6 +517,7 @@ struct rdp_gdi
 
 	BOOL inGfxFrame;
 	BOOL graphicsReset;
+	BOOL suppressOutput;
 	UINT16 outputSurfaceId;
 	RdpgfxClientContext* gfx;
 
@@ -543,6 +544,8 @@ FREERDP_API BOOL gdi_init_ex(freerdp* instance, UINT32 format,
                              UINT32 stride, BYTE* buffer,
                              void (*pfree)(void*));
 FREERDP_API void gdi_free(freerdp* instance);
+
+FREERDP_API BOOL gdi_send_suppress_output(rdpGdi* gdi, BOOL suppress);
 
 #ifdef __cplusplus
 }

--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -32,6 +32,7 @@
 #include <freerdp/log.h>
 #include <freerdp/freerdp.h>
 
+#include <freerdp/gdi/gdi.h>
 #include <freerdp/gdi/dc.h>
 #include <freerdp/gdi/pen.h>
 #include <freerdp/gdi/shape.h>
@@ -1328,5 +1329,27 @@ void gdi_free(freerdp* instance)
 	cache_free(context->cache);
 	context->cache = NULL;
 	instance->context->gdi = (rdpGdi*) NULL;
+}
+
+BOOL gdi_send_suppress_output(rdpGdi* gdi, BOOL suppress)
+{
+	RECTANGLE_16 rect;
+	rdpSettings* settings;
+	rdpUpdate* update;
+
+	if (!gdi || !gdi->context->settings || !gdi->context->update)
+		return FALSE;
+
+	if (gdi->suppressOutput == suppress)
+		return TRUE;
+
+	gdi->suppressOutput = suppress;
+	settings = gdi->context->settings;
+	update = gdi->context->update;
+	rect.left = 0;
+	rect.top = 0;
+	rect.right = settings->DesktopWidth;
+	rect.bottom = settings->DesktopHeight;
+	return update->SuppressOutput(gdi->context, !suppress, &rect);
 }
 

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -112,7 +112,7 @@ static UINT gdi_OutputUpdate(rdpGdi* gdi, gdiGfxSurface* surface)
 	                        &(surface->invalidRegion), &surfaceRect);
 
 	if (!(rects = region16_rects(&surface->invalidRegion, &nbRects)) || !nbRects)
-                return CHANNEL_RC_OK;
+		return CHANNEL_RC_OK;
 
 	update->BeginPaint(gdi->context);
 
@@ -136,7 +136,6 @@ static UINT gdi_OutputUpdate(rdpGdi* gdi, gdiGfxSurface* surface)
 	}
 
 	update->EndPaint(gdi->context);
-
 	region16_clear(&(surface->invalidRegion));
 	return CHANNEL_RC_OK;
 }
@@ -212,11 +211,12 @@ static UINT gdi_SurfaceCommand_Uncompressed(rdpGdi* gdi,
 	UINT status = CHANNEL_RC_OK;
 	gdiGfxSurface* surface;
 	RECTANGLE_16 invalidRect;
-
 	surface = (gdiGfxSurface*) context->GetSurfaceData(context, cmd->surfaceId);
+
 	if (!surface)
 	{
-		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__, cmd->surfaceId);
+		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__,
+		         cmd->surfaceId);
 		return ERROR_NOT_FOUND;
 	}
 
@@ -231,7 +231,6 @@ static UINT gdi_SurfaceCommand_Uncompressed(rdpGdi* gdi,
 	invalidRect.bottom = cmd->bottom;
 	region16_union_rect(&(surface->invalidRegion), &(surface->invalidRegion),
 	                    &invalidRect);
-
 	IFCALL(context->UpdateSurfaceArea, context, surface->surfaceId, 1, &invalidRect);
 
 	if (!gdi->inGfxFrame)
@@ -257,17 +256,18 @@ static UINT gdi_SurfaceCommand_RemoteFX(rdpGdi* gdi,
 	REGION16 invalidRegion;
 	const RECTANGLE_16* rects;
 	UINT32 nrRects, x;
-
 	surface = (gdiGfxSurface*) context->GetSurfaceData(context, cmd->surfaceId);
+
 	if (!surface)
 	{
-		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__, cmd->surfaceId);
+		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__,
+		         cmd->surfaceId);
 		return ERROR_NOT_FOUND;
 	}
 
 	rfx_context_set_pixel_format(surface->codecs->rfx, cmd->format);
-
 	region16_init(&invalidRegion);
+
 	if (!rfx_process_message(surface->codecs->rfx, cmd->data, cmd->length,
 	                         cmd->left, cmd->top,
 	                         surface->data, surface->format, surface->scanline,
@@ -281,10 +281,11 @@ static UINT gdi_SurfaceCommand_RemoteFX(rdpGdi* gdi,
 	rects = region16_rects(&invalidRegion, &nrRects);
 	IFCALL(context->UpdateSurfaceArea, context, surface->surfaceId, nrRects, rects);
 
-	for (x=0; x<nrRects; x++)
+	for (x = 0; x < nrRects; x++)
 		region16_union_rect(&surface->invalidRegion, &surface->invalidRegion, &rects[x]);
 
 	region16_uninit(&invalidRegion);
+
 	if (!gdi->inGfxFrame)
 	{
 		status = CHANNEL_RC_NOT_INITIALIZED;
@@ -307,11 +308,12 @@ static UINT gdi_SurfaceCommand_ClearCodec(rdpGdi* gdi,
 	UINT status = CHANNEL_RC_OK;
 	gdiGfxSurface* surface;
 	RECTANGLE_16 invalidRect;
-
 	surface = (gdiGfxSurface*) context->GetSurfaceData(context, cmd->surfaceId);
+
 	if (!surface)
 	{
-		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__, cmd->surfaceId);
+		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__,
+		         cmd->surfaceId);
 		return ERROR_NOT_FOUND;
 	}
 
@@ -333,7 +335,6 @@ static UINT gdi_SurfaceCommand_ClearCodec(rdpGdi* gdi,
 	invalidRect.bottom = cmd->bottom;
 	region16_union_rect(&(surface->invalidRegion), &(surface->invalidRegion),
 	                    &invalidRect);
-
 	IFCALL(context->UpdateSurfaceArea, context, surface->surfaceId, 1, &invalidRect);
 
 	if (!gdi->inGfxFrame)
@@ -357,11 +358,12 @@ static UINT gdi_SurfaceCommand_Planar(rdpGdi* gdi, RdpgfxClientContext* context,
 	BYTE* DstData = NULL;
 	gdiGfxSurface* surface;
 	RECTANGLE_16 invalidRect;
-
 	surface = (gdiGfxSurface*) context->GetSurfaceData(context, cmd->surfaceId);
+
 	if (!surface)
 	{
-		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__, cmd->surfaceId);
+		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__,
+		         cmd->surfaceId);
 		return ERROR_NOT_FOUND;
 	}
 
@@ -380,7 +382,6 @@ static UINT gdi_SurfaceCommand_Planar(rdpGdi* gdi, RdpgfxClientContext* context,
 	invalidRect.bottom = cmd->bottom;
 	region16_union_rect(&(surface->invalidRegion), &(surface->invalidRegion),
 	                    &invalidRect);
-
 	IFCALL(context->UpdateSurfaceArea, context, surface->surfaceId, 1, &invalidRect);
 
 	if (!gdi->inGfxFrame)
@@ -408,17 +409,19 @@ static UINT gdi_SurfaceCommand_AVC420(rdpGdi* gdi,
 	gdiGfxSurface* surface;
 	RDPGFX_H264_METABLOCK* meta;
 	RDPGFX_AVC420_BITMAP_STREAM* bs;
-
 	surface = (gdiGfxSurface*) context->GetSurfaceData(context, cmd->surfaceId);
+
 	if (!surface)
 	{
-		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__, cmd->surfaceId);
+		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__,
+		         cmd->surfaceId);
 		return ERROR_NOT_FOUND;
 	}
 
 	if (!surface->h264)
 	{
 		surface->h264 = h264_context_new(FALSE);
+
 		if (!surface->h264)
 		{
 			WLog_ERR(TAG, "%s: unable to create h264 context", __FUNCTION__);
@@ -430,6 +433,7 @@ static UINT gdi_SurfaceCommand_AVC420(rdpGdi* gdi,
 	}
 
 	bs = (RDPGFX_AVC420_BITMAP_STREAM*) cmd->extra;
+
 	if (!bs)
 		return ERROR_INTERNAL_ERROR;
 
@@ -450,6 +454,7 @@ static UINT gdi_SurfaceCommand_AVC420(rdpGdi* gdi,
 		region16_union_rect(&(surface->invalidRegion), &(surface->invalidRegion),
 		                    (RECTANGLE_16*) & (meta->regionRects[i]));
 	}
+
 	IFCALL(context->UpdateSurfaceArea, context, surface->surfaceId,
 	       meta->numRegionRects, meta->regionRects);
 
@@ -484,17 +489,19 @@ static UINT gdi_SurfaceCommand_AVC444(rdpGdi* gdi, RdpgfxClientContext* context,
 	RDPGFX_AVC420_BITMAP_STREAM* avc2;
 	RDPGFX_H264_METABLOCK* meta2;
 	RECTANGLE_16* regionRects = NULL;
-
 	surface = (gdiGfxSurface*) context->GetSurfaceData(context, cmd->surfaceId);
+
 	if (!surface)
 	{
-		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__, cmd->surfaceId);
+		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__,
+		         cmd->surfaceId);
 		return ERROR_NOT_FOUND;
 	}
 
 	if (!surface->h264)
 	{
 		surface->h264 = h264_context_new(FALSE);
+
 		if (!surface->h264)
 		{
 			WLog_ERR(TAG, "%s: unable to create h264 context", __FUNCTION__);
@@ -533,6 +540,7 @@ static UINT gdi_SurfaceCommand_AVC444(rdpGdi* gdi, RdpgfxClientContext* context,
 	{
 		region16_union_rect(&(surface->invalidRegion), &(surface->invalidRegion), &(meta1->regionRects[i]));
 	}
+
 	IFCALL(context->UpdateSurfaceArea, context, surface->surfaceId,
 	       meta1->numRegionRects, meta1->regionRects);
 
@@ -540,6 +548,7 @@ static UINT gdi_SurfaceCommand_AVC444(rdpGdi* gdi, RdpgfxClientContext* context,
 	{
 		region16_union_rect(&(surface->invalidRegion), &(surface->invalidRegion), &(meta2->regionRects[i]));
 	}
+
 	IFCALL(context->UpdateSurfaceArea, context, surface->surfaceId,
 	       meta2->numRegionRects, meta2->regionRects);
 
@@ -568,11 +577,12 @@ static UINT gdi_SurfaceCommand_Alpha(rdpGdi* gdi, RdpgfxClientContext* context,
 	UINT32 color;
 	gdiGfxSurface* surface;
 	RECTANGLE_16 invalidRect;
-
 	surface = (gdiGfxSurface*) context->GetSurfaceData(context, cmd->surfaceId);
+
 	if (!surface)
 	{
-		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__, cmd->surfaceId);
+		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__,
+		         cmd->surfaceId);
 		return ERROR_NOT_FOUND;
 	}
 
@@ -590,7 +600,6 @@ static UINT gdi_SurfaceCommand_Alpha(rdpGdi* gdi, RdpgfxClientContext* context,
 	invalidRect.bottom = cmd->bottom;
 	region16_union_rect(&(surface->invalidRegion), &(surface->invalidRegion),
 	                    &invalidRect);
-
 	IFCALL(context->UpdateSurfaceArea, context, surface->surfaceId, 1, &invalidRect);
 
 	if (!gdi->inGfxFrame)
@@ -617,17 +626,17 @@ static UINT gdi_SurfaceCommand_Progressive(rdpGdi* gdi,
 	REGION16 invalidRegion;
 	const RECTANGLE_16* rects;
 	UINT32 nrRects, x;
-
 	/**
 	 * Note: Since this comes via a Wire-To-Surface-2 PDU the
 	 * cmd's top/left/right/bottom/width/height members are always zero!
 	 * The update region is determined during decompression.
 	 */
-
 	surface = (gdiGfxSurface*) context->GetSurfaceData(context, cmd->surfaceId);
+
 	if (!surface)
 	{
-		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__, cmd->surfaceId);
+		WLog_ERR(TAG, "%s: unable to retrieve surfaceData for surfaceId=%"PRIu32"", __FUNCTION__,
+		         cmd->surfaceId);
 		return ERROR_NOT_FOUND;
 	}
 
@@ -657,8 +666,9 @@ static UINT gdi_SurfaceCommand_Progressive(rdpGdi* gdi,
 	rects = region16_rects(&invalidRegion, &nrRects);
 	IFCALL(context->UpdateSurfaceArea, context, surface->surfaceId, nrRects, rects);
 
-	for (x=0; x<nrRects; x++)
+	for (x = 0; x < nrRects; x++)
 		region16_union_rect(&surface->invalidRegion, &surface->invalidRegion, &rects[x]);
+
 	region16_uninit(&invalidRegion);
 
 	if (!gdi->inGfxFrame)
@@ -759,7 +769,7 @@ static UINT gdi_CreateSurface(RdpgfxClientContext* context,
                               const RDPGFX_CREATE_SURFACE_PDU* createSurface)
 {
 	gdiGfxSurface* surface;
-		rdpGdi* gdi = (rdpGdi*) context->custom;
+	rdpGdi* gdi = (rdpGdi*) context->custom;
 	surface = (gdiGfxSurface*) calloc(1, sizeof(gdiGfxSurface));
 
 	if (!surface)
@@ -886,6 +896,7 @@ static UINT gdi_SolidFill(RdpgfxClientContext* context,
 		region16_union_rect(&(surface->invalidRegion), &(surface->invalidRegion),
 		                    &invalidRect);
 	}
+
 	IFCALL(context->UpdateSurfaceArea, context, surface->surfaceId,
 	       solidFill->fillRectCount, solidFill->fillRects);
 
@@ -975,14 +986,14 @@ static UINT gdi_SurfaceToCache(RdpgfxClientContext* context,
 	const RECTANGLE_16* rect;
 	gdiGfxSurface* surface;
 	gdiGfxCacheEntry* cacheEntry;
-
 	rect = &(surfaceToCache->rectSrc);
-
 	surface = (gdiGfxSurface*) context->GetSurfaceData(context, surfaceToCache->surfaceId);
+
 	if (!surface)
 		return ERROR_INTERNAL_ERROR;
 
 	cacheEntry = (gdiGfxCacheEntry*) calloc(1, sizeof(gdiGfxCacheEntry));
+
 	if (!cacheEntry)
 		return ERROR_NOT_ENOUGH_MEMORY;
 
@@ -990,8 +1001,8 @@ static UINT gdi_SurfaceToCache(RdpgfxClientContext* context,
 	cacheEntry->height = (UINT32)(rect->bottom - rect->top);
 	cacheEntry->format = surface->format;
 	cacheEntry->scanline = gfx_align_scanline(cacheEntry->width * 4, 16);
-
 	cacheEntry->data = (BYTE*) calloc(cacheEntry->height, cacheEntry->scanline);
+
 	if (!cacheEntry->data)
 	{
 		free(cacheEntry);
@@ -1024,7 +1035,6 @@ static UINT gdi_CacheToSurface(RdpgfxClientContext* context,
 	gdiGfxCacheEntry* cacheEntry;
 	RECTANGLE_16 invalidRect;
 	rdpGdi* gdi = (rdpGdi*) context->custom;
-
 	surface = (gdiGfxSurface*) context->GetSurfaceData(context, cacheToSurface->surfaceId);
 	cacheEntry = (gdiGfxCacheEntry*) context->GetCacheSlotData(context, cacheToSurface->cacheSlot);
 

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -102,6 +102,10 @@ static UINT gdi_OutputUpdate(rdpGdi* gdi, gdiGfxSurface* surface)
 	const RECTANGLE_16* rects;
 	UINT32 i, nbRects;
 	rdpUpdate* update = gdi->context->update;
+
+	if (gdi->suppressOutput)
+		return CHANNEL_RC_OK;
+
 	surfaceX = surface->outputOriginX;
 	surfaceY = surface->outputOriginY;
 	surfaceRect.left = 0;


### PR DESCRIPTION
* Fixes #4371: Sending suppress output PDU whenever the window state changes

NOTE: As a side effect the output is suppressed when minimized and no preview is shown (e.g. cinnamon taskbar)