### PR TITLE
fix freerdp-nightly on suse: disable asan

### DIFF
--- a/packaging/rpm/freerdp-nightly.spec
+++ b/packaging/rpm/freerdp-nightly.spec
@@ -106,10 +106,11 @@ based on freerdp and winpr.
         -DWITH_SERVER=ON \
         -DBUILD_TESTING=OFF \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DWITH_SANITIZE_ADDRESS=ON \
         -DCMAKE_INSTALL_PREFIX=%{INSTALL_PREFIX} \
 %if %{defined suse_version}
-	-DCMAKE_NO_BUILTIN_CHRPATH=ON \
+        -DCMAKE_NO_BUILTIN_CHRPATH=ON \
+%else
+        -DWITH_SANITIZE_ADDRESS=ON \
 %endif
         -DCMAKE_INSTALL_LIBDIR=%{_lib}
 


### PR DESCRIPTION
Compilation fails on 42.3 (gcc 4.8) when address sanitizer is on.

Should fix our nightly builds for openSUSE 42.3