### PR TITLE
Fix smartcard usage in manpage

### DIFF
--- a/client/X11/xfreerdp.1.xml
+++ b/client/X11/xfreerdp.1.xml
@@ -539,7 +539,7 @@
                       </listitem>
                     </varlistentry>
                     <varlistentry>
-                      <term>smartcard[:<replaceable class="parameter">name</replaceable>]</term>
+                      <term>scard[:<replaceable class="parameter">name</replaceable>]</term>
                       <listitem>
                         <para>
                           Redirect smartcard with <replaceable class="parameter">name</replaceable>.


### PR DESCRIPTION
Man page has been updated according to the wiki by https://github.com/FreeRDP/FreeRDP/pull/4129. Unfortunately, wiki mentions "smartcard" subplugin, which was introduced later, but stable-1.0 uses just scard. Let's fix the man page accordingly.