### PR TITLE
Memleak queue fixes

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -1595,6 +1595,7 @@ static UINT rdpgfx_get_surface_ids(RdpgfxClientContext* context,
 	if (!pSurfaceIds)
 	{
 		WLog_Print(gfx->log, WLOG_ERROR, "calloc failed!");
+		free(pKeys);
 		return CHANNEL_RC_NO_MEMORY;
 	}
 

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -645,12 +645,6 @@ BOOL xf_create_window(xfContext* xfc)
 
 static void xf_window_free(xfContext* xfc)
 {
-	if (xfc->gc_mono)
-	{
-		XFreeGC(xfc->display, xfc->gc_mono);
-		xfc->gc_mono = 0;
-	}
-
 	if (xfc->window)
 	{
 		xf_DestroyDesktopWindow(xfc, xfc->window);
@@ -680,6 +674,12 @@ static void xf_window_free(xfContext* xfc)
 	{
 		XFreePixmap(xfc->display, xfc->bitmap_mono);
 		xfc->bitmap_mono = 0;
+	}
+
+	if (xfc->gc_mono)
+	{
+		XFreeGC(xfc->display, xfc->gc_mono);
+		xfc->gc_mono = 0;
 	}
 
 	if (xfc->primary)
@@ -1311,6 +1311,11 @@ static void xf_post_disconnect(freerdp* instance)
 		xf_disp_free(xfc->xfDisp);
 		xfc->xfDisp = NULL;
 	}
+
+	if (xfc->drawable == xfc->window->handle)
+		xfc->drawable = NULL;
+	else
+		xf_DestroyDummyWindow(xfc, xfc->drawable);
 
 	xf_window_free(xfc);
 	xf_keyboard_free(xfc);

--- a/libfreerdp/codec/zgfx.c
+++ b/libfreerdp/codec/zgfx.c
@@ -332,7 +332,9 @@ int zgfx_decompress(ZGFX_CONTEXT* zgfx, const BYTE* pSrcData, UINT32 SrcSize, BY
 		if (!zgfx_decompress_segment(zgfx, stream, Stream_GetRemainingLength(stream)))
 			goto fail;
 
-		*ppDstData = (BYTE*) malloc(zgfx->OutputCount);
+		*ppDstData = NULL;
+		if (zgfx->OutputCount > 0)
+			*ppDstData = (BYTE*) malloc(zgfx->OutputCount);
 
 		if (!*ppDstData)
 			goto fail;

--- a/winpr/libwinpr/utils/collections/MessageQueue.c
+++ b/winpr/libwinpr/utils/collections/MessageQueue.c
@@ -227,6 +227,8 @@ void MessageQueue_Free(wMessageQueue* queue)
 	if (!queue)
 		return;
 
+	MessageQueue_Clear(queue);
+
 	CloseHandle(queue->event);
 	DeleteCriticalSection(&queue->lock);
 


### PR DESCRIPTION
* Fix a memory leak in gfx on error
* Now clearing message queue on free just as Hash and ArrayList
* dynamic channel message queue now frees objects still in the queue
* Clear the client channel queue and free data