### PR TITLE
Pthread cleanup fix

### DIFF
--- a/client/DirectFB/dfreerdp.c
+++ b/client/DirectFB/dfreerdp.c
@@ -422,7 +422,7 @@ int main(int argc, char* argv[])
 	if (!(g_sem = CreateSemaphore(NULL, 0, 1, NULL)))
 	{
 		WLog_ERR(TAG, "Failed to create semaphore");
-		exit(1);
+		return winpr_exit(1);
 	}
 
 	instance = freerdp_new();
@@ -437,7 +437,7 @@ int main(int argc, char* argv[])
 	if (!freerdp_context_new(instance))
 	{
 		WLog_ERR(TAG, "Failed to create FreeRDP context");
-		exit(1);
+		return winpr_exit(1);
 	}
 
 	context = (dfContext*) instance->context;
@@ -449,11 +449,11 @@ int main(int argc, char* argv[])
 	         argv, FALSE);
 
 	if (status < 0)
-		exit(0);
+		return winpr_exit(0);
 
 	if (!freerdp_client_load_addins(instance->context->channels,
 	                                instance->settings))
-		exit(-1);
+		return winpr_exit(-1);
 
 	data = (struct thread_data*) malloc(sizeof(struct thread_data));
 	ZeroMemory(data, sizeof(sizeof(struct thread_data)));
@@ -466,5 +466,5 @@ int main(int argc, char* argv[])
 		WaitForSingleObject(g_sem, INFINITE);
 	}
 
-	return 0;
+	return winpr_exit(0);
 }

--- a/client/Sample/freerdp.c
+++ b/client/Sample/freerdp.c
@@ -168,7 +168,7 @@ int main(int argc, char* argv[])
 	if (!instance)
 	{
 		WLog_ERR(TAG, "Couldn't create instance");
-		exit(1);
+		winpr_exit(1);
 	}
 
 	instance->PreConnect = tf_pre_connect;
@@ -181,7 +181,7 @@ int main(int argc, char* argv[])
 	if (!freerdp_context_new(instance))
 	{
 		WLog_ERR(TAG, "Couldn't create context");
-		exit(1);
+		return winpr_exit(1);
 	}
 
 	status = freerdp_client_settings_parse_command_line(instance->settings, argc,
@@ -189,12 +189,12 @@ int main(int argc, char* argv[])
 
 	if (status < 0)
 	{
-		exit(0);
+		return winpr_exit(0);
 	}
 
 	if (!freerdp_client_load_addins(instance->context->channels,
 	                                instance->settings))
-		exit(-1);
+		return winpr_exit(-1);
 
 	if (!(thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)
 	                            tf_client_thread_proc, instance, 0, NULL)))
@@ -208,5 +208,5 @@ int main(int argc, char* argv[])
 
 	freerdp_context_free(instance);
 	freerdp_free(instance);
-	return 0;
+	return winpr_exit(0);
 }

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -474,5 +474,5 @@ int main(int argc, char* argv[])
 
 fail:
 	freerdp_client_context_free(context);
-	return rc;
+	return winpr_exit(rc);
 }

--- a/client/X11/cli/xfreerdp.c
+++ b/client/X11/cli/xfreerdp.c
@@ -50,7 +50,7 @@ int main(int argc, char* argv[])
 
 	context = freerdp_client_context_new(&clientEntryPoints);
 	if (!context)
-		return 1;
+		return winpr_exit(1);
 
 	settings = context->settings;
 	xfc = (xfContext*) context;
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
 			xf_list_monitors(xfc);
 
 		freerdp_client_context_free(context);
-		return 0;
+		return winpr_exit(0);
 	}
 
 	freerdp_client_start(context);
@@ -79,5 +79,5 @@ int main(int argc, char* argv[])
 
 	freerdp_client_context_free(context);
 
-	return xf_exit_code_from_disconnect_reason(dwExitCode);
+	return winpr_exit(xf_exit_code_from_disconnect_reason(dwExitCode));
 }

--- a/client/X11/generate_argument_docbook.c
+++ b/client/X11/generate_argument_docbook.c
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
 	if(NULL == fp)
 	{
 		WLog_ERR(TAG,  "Could not open '%s' for writing.", fname);
-		return -1;
+		return winpr_exit(-1);
 	}
 	/* The tag used as header in the manpage */
 	fprintf(fp, "<refsect1>\n");
@@ -206,6 +206,6 @@ int main(int argc, char *argv[])
 	fprintf(fp, "\t\t</variablelist>\n");
 	fprintf(fp, "\t</refsect1>\n");
 	fclose(fp);
-	return 0;
+	return winpr_exit(0);
 }
 

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -58,6 +58,7 @@ rdpContext* freerdp_client_context_new(RDP_CLIENT_ENTRY_POINTS* pEntryPoints)
 	if (!pEntryPoints)
 		return NULL;
 
+	WLog_Init();
 	IFCALL(pEntryPoints->GlobalInit);
 	instance = freerdp_new();
 
@@ -115,6 +116,7 @@ void freerdp_client_context_free(rdpContext* context)
 		free(instance->pClientEntryPoints);
 		freerdp_free(instance);
 	}
+	WLog_Uninit();
 }
 
 int freerdp_client_start(rdpContext* context)

--- a/rdtk/sample/rdtk_x11.c
+++ b/rdtk/sample/rdtk_x11.c
@@ -60,7 +60,7 @@ int main(int argc, char** argv)
 	if (!display)
 	{
 		WLog_ERR(TAG, "Cannot open display");
-		exit(1);
+		return winpr_exit(1);
 	}
 
 	x = 10;
@@ -96,12 +96,12 @@ int main(int argc, char** argv)
 
 	engine = rdtk_engine_new();
 	if (!engine)
-		return 1;
+		return winpr_exit(1);
 
 	scanline = width * 4;
 	buffer = (BYTE*) calloc(height, scanline);
 	if (!buffer)
-		return 1;
+		return winpr_exit(1);
 
 	surface = rdtk_surface_new(engine, buffer, width, height, scanline);
 
@@ -150,5 +150,5 @@ int main(int argc, char** argv)
 
 	rdtk_engine_free(engine);
 
-	return 0;
+	return winpr_exit(0);
 }

--- a/server/Mac/mfreerdp.c
+++ b/server/Mac/mfreerdp.c
@@ -109,7 +109,7 @@ int main(int argc, char* argv[])
 	WTSRegisterWtsApiFunctionTable(FreeRDP_InitWtsApi());
 	
 	if (!(instance = freerdp_listener_new()))
-		return 1;
+		return winpr_exit(1);
 
 	instance->PeerAccepted = mf_peer_accepted;
 
@@ -120,5 +120,5 @@ int main(int argc, char* argv[])
 
 	freerdp_listener_free(instance);
 
-	return 0;
+	return winpr_exit(0);
 }

--- a/server/Sample/sfreerdp.c
+++ b/server/Sample/sfreerdp.c
@@ -924,14 +924,14 @@ int main(int argc, char* argv[])
 	instance = freerdp_listener_new();
 
 	if (!instance)
-		return -1;
+		return winpr_exit(-1);
 
 	instance->PeerAccepted = test_peer_accepted;
 
 	if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0)
 	{
 		freerdp_listener_free(instance);
-		return -1;
+		return winpr_exit(-1);
 	}
 
 	/* Open the server socket and start listening. */
@@ -942,7 +942,7 @@ int main(int argc, char* argv[])
 	{
 		freerdp_listener_free(instance);
 		WSACleanup();
-		return -1;
+		return winpr_exit(-1);
 	}
 
 	if ((localOnly || instance->Open(instance, NULL, port)) &&
@@ -955,6 +955,6 @@ int main(int argc, char* argv[])
 	free(file);
 	freerdp_listener_free(instance);
 	WSACleanup();
-	return 0;
+	return winpr_exit(0);
 }
 

--- a/server/Windows/cli/wfreerdp.c
+++ b/server/Windows/cli/wfreerdp.c
@@ -98,7 +98,7 @@ int main(int argc, char* argv[])
 				WLog_INFO(TAG, "Virtual Screen = %dx%d", vscreen_w, vscreen_h);
 			}
 
-			return 0;
+			return winpr_exit(0);
 		}
 
 		if (strcmp("--screen", argv[index]) == 0)
@@ -110,13 +110,13 @@ int main(int argc, char* argv[])
 			if (index == argc)
 			{
 				WLog_INFO(TAG, "missing screen id parameter");
-				return 0;
+				return winpr_exit(0);
 			}
 
 			val = strtoul(argv[index], NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
-				return -1;
+				return winpr_exit(-1);
 
 			set_screen_id(val);
 			index++;
@@ -127,7 +127,7 @@ int main(int argc, char* argv[])
 			UINT32 val = strtoul(argv[index], NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
-				return -1;
+				return winpr_exit(-1);
 
 			server->port = val;
 			break;
@@ -170,5 +170,5 @@ int main(int argc, char* argv[])
 	WLog_INFO(TAG, "Stopping server");
 	wfreerdp_server_stop(server);
 	wfreerdp_server_free(server);
-	return 0;
+	return winpr_exit(0);
 }

--- a/server/shadow/shadow.c
+++ b/server/shadow/shadow.c
@@ -110,6 +110,6 @@ fail_server_init:
 fail_parse_command_line:
 	shadow_server_free(server);
 fail_server_new:
-	return status;
+	return winpr_exit(status);
 }
 

--- a/winpr/include/winpr/winpr.h
+++ b/winpr/include/winpr/winpr.h
@@ -70,6 +70,7 @@ WINPR_API const char* winpr_get_version_string(void);
 WINPR_API const char* winpr_get_build_date(void);
 WINPR_API const char* winpr_get_build_revision(void);
 WINPR_API const char* winpr_get_build_config(void);
+WINPR_API int winpr_exit(int status);
 
 #define WINPR_UNUSED(x) (void)(x)
 

--- a/winpr/libwinpr/smartcard/test/TestSmartCardStatus.c
+++ b/winpr/libwinpr/smartcard/test/TestSmartCardStatus.c
@@ -38,7 +38,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("ScardEstablishedContext: 0x%08x\n", err);
-		return -1;
+		return winpr_exit(-1);
 	}
 
 	err = SCardListReaders(hContext, "SCard$AllReaders", NULL, &cchReaders);
@@ -46,7 +46,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != 0)
 	{
 		printf("ScardListReaders: 0x%08x\n", err);
-		return -1;
+		return winpr_exit(-1);
 	}
 
 	mszReaders = calloc(cchReaders, sizeof(char));
@@ -54,7 +54,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (!mszReaders)
 	{
 		printf("calloc\n");
-		return -1;
+		return winpr_exit(-1);
 	}
 
 	err = SCardListReaders(hContext, "SCard$AllReaders", mszReaders, &cchReaders);
@@ -62,7 +62,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("ScardListReaders: 0x%08x\n", err);
-		return -1;
+		return winpr_exit(-1);
 	}
 
 	printf("Reader: %s\n", mszReaders);
@@ -72,7 +72,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("ScardConnect: 0x%08x\n", err);
-		return -1;
+		return winpr_exit(-1);
 	}
 
 	free(mszReaders);
@@ -83,7 +83,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("SCardStatus: 0x%08x\n", err);
-		return -1;
+		return winpr_exit(-1);
 	}
 	printf("reader name length: %u\n", len);
 
@@ -93,7 +93,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("SCardStatus: 0x%08x\n", err);
-		return -1;
+		return winpr_exit(-1);
 	}
 	printf("Reader name: %s (%ld)\n", name, strlen(name));
 
@@ -103,7 +103,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("SCardStatus: 0x%08x\n", err);
-		return -1;
+		return winpr_exit(-1);
 	}
 	printf("Reader name: %s (%ld/len %u)\n", name, strlen(name), len);
 	printf("status: 0x%08X\n", status);
@@ -117,7 +117,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("SCardStatus: 0x%08x\n", err);
-		return -1;
+		return winpr_exit(-1);
 	}
 	printf("Reader name: %s (%ld/%u)\n", aname, strlen(aname), len);
 	printf("status: 0x%08X\n", status);
@@ -132,7 +132,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("SCardStatus: 0x%08x\n", err);
-		return -1;
+		return winpr_exit(-1);
 	}
 	printf("status: 0x%08X\n", status);
 	printf("proto: 0x%08X\n", protocol);
@@ -144,7 +144,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("SCardStatus: 0x%08x\n", err);
-		return -1;
+		return winpr_exit(-1);
 	}
 	printf("atrlen: %u\n", atrlen);
 	SCardFreeMemory(hContext, aatr);
@@ -156,11 +156,11 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("SCardStatus: 0x%08x\n", err);
-		return -1;
+		return winpr_exit(-1);
 	}
 	printf("atrlen: %u\n", atrlen);
 	SCardDisconnect(hCard, SCARD_LEAVE_CARD);
 	SCardReleaseContext(hContext);
 
-	return 0;
+	return winpr_exit(0);
 }

--- a/winpr/libwinpr/utils/winpr.c
+++ b/winpr/libwinpr/utils/winpr.c
@@ -30,6 +30,11 @@
 #include <winpr/string.h>
 #include <winpr/winpr.h>
 #include <winpr/version.h>
+#include <winpr/wlog.h>
+
+#if !defined(WIN32)
+#include <pthread.h>
+#endif
 
 void winpr_get_version(int* major, int* minor, int* revision)
 {
@@ -68,4 +73,15 @@ const char* winpr_get_build_config(void)
 		"Target architecture: " TARGET_ARCH "\n";
 
 	return build_config;
+}
+
+int winpr_exit(int status)
+{
+	WLog_Uninit();
+#if defined(WIN32)
+	return status;
+#else
+	pthread_exit(&status);
+	return status;
+#endif
 }

--- a/winpr/libwinpr/utils/wlog/wlog.c
+++ b/winpr/libwinpr/utils/wlog/wlog.c
@@ -919,5 +919,6 @@ BOOL WLog_Uninit(void)
 
 	WLog_Free(root);
 	g_RootLog = NULL;
+
 	return TRUE;
 }

--- a/winpr/tools/hash-cli/hash.c
+++ b/winpr/tools/hash-cli/hash.c
@@ -195,5 +195,5 @@ int main(int argc, char* argv[])
 		printf("\n");
 	}
 
-	return 0;
+	return winpr_exit(0);
 }

--- a/winpr/tools/makecert-cli/CMakeLists.txt
+++ b/winpr/tools/makecert-cli/CMakeLists.txt
@@ -42,7 +42,7 @@ add_executable(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
 
 set(${MODULE_PREFIX}_LIBS winpr-tools)
 
-target_link_libraries(${MODULE_NAME} ${${MODULE_PREFIX}_LIBS})
+target_link_libraries(${MODULE_NAME} ${${MODULE_PREFIX}_LIBS} winpr)
 
 set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "WinPR/Tools")
 

--- a/winpr/tools/makecert-cli/main.c
+++ b/winpr/tools/makecert-cli/main.c
@@ -34,12 +34,12 @@ int main(int argc, char* argv[])
 
 	context = makecert_context_new();
 	if (!context)
-		return 1;
+		return winpr_exit(1);
 
 	if (makecert_context_process(context, argc, argv) < 0)
 		ret = 1;
 
 	makecert_context_free(context);
 
-	return ret;
+	return winpr_exit(ret);
 }


### PR DESCRIPTION
`pthread_once` destructor functions are only called when a thread exits with `pthread_exit`.
This was not true for the main application thread leading to noise in valigrind and address sanitizer

To resolve this issue, a new function `winpr_exit` is introduced that must be called on main thread exit.
* It deletes the memory allocated by WLog
* It triggers the pthread destructors

While not strictly necessary for production use, it greatly improves the usefullness of valgrind/address sanitizer by reducing false positives.