### PR TITLE
Fixed accidental free of XImage data.

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -612,14 +612,12 @@ BOOL xf_create_window(xfContext* xfc)
 		                             settings->DesktopHeight, xfc->depth);
 
 	xfc->drawing = xfc->primary;
-
 	if (!xfc->bitmap_mono)
 		xfc->bitmap_mono = XCreatePixmap(xfc->display, xfc->drawable, 8, 8, 1);
 
 	if (!xfc->gc_mono)
 		xfc->gc_mono = XCreateGC(xfc->display, xfc->bitmap_mono, GCGraphicsExposures,
 		                         &gcv);
-
 	XSetFunction(xfc->display, xfc->gc, GXcopy);
 	XSetFillStyle(xfc->display, xfc->gc, FillSolid);
 	XSetForeground(xfc->display, xfc->gc, BlackPixelOfScreen(xfc->screen));

--- a/client/X11/xf_gdi.c
+++ b/client/X11/xf_gdi.c
@@ -245,6 +245,8 @@ static Pixmap xf_brush_new(xfContext* xfc, UINT32 width, UINT32 height,
 		image->bitmap_bit_order = LSBFirst;
 		gc = XCreateGC(xfc->display, xfc->drawable, 0, NULL);
 		XPutImage(xfc->display, bitmap, gc, image, 0, 0, 0, 0, width, height);
+
+		image->data = NULL;
 		XDestroyImage(image);
 
 		if (cdata != data)
@@ -269,6 +271,7 @@ static Pixmap xf_mono_bitmap_new(xfContext* xfc, int width, int height,
 	image->byte_order = LSBFirst;
 	image->bitmap_bit_order = LSBFirst;
 	XPutImage(xfc->display, bitmap, xfc->gc_mono, image, 0, 0, 0, 0, width, height);
+	image->data = NULL;
 	XDestroyImage(image);
 	return bitmap;
 }
@@ -1028,6 +1031,7 @@ static BOOL xf_gdi_update_screen(xfContext* xfc, const BYTE* pSrcData,
 		image->bitmap_bit_order = LSBFirst;
 
 		XPutImage(xfc->display, xfc->primary, xfc->gc, image, 0, 0, left, top, width, height);
+		image->data = NULL;
 		XDestroyImage(image);
 		ret = xf_gdi_surface_update_frame(xfc, left, top, width, height);
 	}

--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -26,6 +26,8 @@
 #include <freerdp/log.h>
 #include "xf_gfx.h"
 
+#include <X11/Xutil.h>
+
 #define TAG CLIENT_TAG("x11")
 
 static UINT xf_OutputUpdate(xfContext* xfc, xfGfxSurface* surface)
@@ -310,6 +312,7 @@ static UINT xf_CreateSurface(RdpgfxClientContext* context,
 
 	return CHANNEL_RC_OK;
 error_set_surface_data:
+	surface->image->data = NULL;
 	XDestroyImage(surface->image);
 error_surface_image:
 	_aligned_free(surface->stage);
@@ -338,6 +341,7 @@ static UINT xf_DeleteSurface(RdpgfxClientContext* context,
 #ifdef WITH_GFX_H264
 		h264_context_free(surface->gdi.h264);
 #endif
+		surface->image->data = NULL;
 		XDestroyImage(surface->image);
 		_aligned_free(surface->gdi.data);
 		_aligned_free(surface->stage);

--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -170,11 +170,17 @@ static void xf_Bitmap_Free(rdpContext* context, rdpBitmap* bitmap)
 
 	xf_lock_x11(xfc, FALSE);
 
-	if (xbitmap->pixmap != 0)
+	if (xbitmap->pixmap != NULL)
+	{
 		XFreePixmap(xfc->display, xbitmap->pixmap);
+		xbitmap->pixmap = NULL;
+	}
 
 	if (xbitmap->image)
+	{
 		XDestroyImage(xbitmap->image);
+		xbitmap->image = NULL;
+	}
 
 	xf_unlock_x11(xfc, FALSE);
 }
@@ -397,6 +403,7 @@ static BOOL xf_Glyph_New(rdpContext* context, const rdpGlyph* glyph)
 	XInitImage(image);
 	XPutImage(xfc->display, xf_glyph->pixmap, xfc->gc_mono, image, 0, 0, 0, 0,
 	          glyph->cx, glyph->cy);
+	image->data = NULL;
 	XDestroyImage(image);
 	xf_unlock_x11(xfc, FALSE);
 	return TRUE;

--- a/rdtk/sample/rdtk_x11.c
+++ b/rdtk/sample/rdtk_x11.c
@@ -24,6 +24,7 @@
 #include <rdtk/rdtk.h>
 
 #include <X11/Xlib.h>
+#include <X11/Xutil.h>
 
 #define TAG "rdtk.sample"
 
@@ -144,7 +145,6 @@ int main(int argc, char** argv)
 	XFlush(display);
 
 	XDestroyImage(image);
-	XFreePixmap(display, pixmap);
 	XCloseDisplay(display);
 
 	rdtk_surface_free(surface);


### PR DESCRIPTION
Follow up to #4420 : `XDestroyImage` also frees the bitmap data. This is not allowed for gdi, gfx and constant buffers.