### PR TITLE
Check if xfreerdp window != NULL

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1310,7 +1310,7 @@ static void xf_post_disconnect(freerdp* instance)
 		xfc->xfDisp = NULL;
 	}
 
-	if (xfc->drawable == xfc->window->handle)
+	if ((xfc->window != NULL) && (xfc->drawable == xfc->window->handle))
 		xfc->drawable = NULL;
 	else
 		xf_DestroyDummyWindow(xfc, xfc->drawable);


### PR DESCRIPTION
When xfreerdp aborts a connection it may be before xfc->window was allocated.
Don't access it in that case.