### PR TITLE
pkg rpm: add support for .source_version in freerdp-nightly

### DIFF
--- a/packaging/rpm/freerdp-nightly.spec
+++ b/packaging/rpm/freerdp-nightly.spec
@@ -25,6 +25,7 @@ Url:            http://www.freerdp.com
 Group:          Productivity/Networking/Other
 Source0:        %{name}-%{version}.tar.bz2
 #Source1:        %{name}-rpmlintrc
+Source1:        source_version
 BuildRequires:   gcc-c++
 BuildRequires:  cmake >= 2.8.12
 BuildRequires: libxkbfile-devel
@@ -102,8 +103,11 @@ based on freerdp and winpr.
 
 %prep
 %setup -q
+cd %{_topdir}/BUILD
+cp %{_topdir}/SOURCES/source_version freerdp-nightly-%{version}/.source_version
 
 %build
+
 %cmake  -DCMAKE_SKIP_RPATH=FALSE \
         -DCMAKE_SKIP_INSTALL_RPATH=FALSE \
         -DWITH_PULSE=ON \

--- a/packaging/scripts/prepare_rpm_freerdp-nightly.sh
+++ b/packaging/scripts/prepare_rpm_freerdp-nightly.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+git rev-parse --short HEAD > source/source_version

--- a/packaging/scripts/prepare_rpm_freerdp-nightly.sh
+++ b/packaging/scripts/prepare_rpm_freerdp-nightly.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git rev-parse --short HEAD > source/source_version
+git rev-parse --short HEAD > source_version


### PR DESCRIPTION
When the source rpm for freerdp-nightly is created the source_version file is added  and used during build to have a git commit visible when --version is run.

The build environment was already prepared to support this.