### PR TITLE
Fixed PubSub function pointer casts.

### DIFF
--- a/client/Android/android_freerdp.c
+++ b/client/Android/android_freerdp.c
@@ -58,7 +58,7 @@
 #define FREERDP_JNI_VERSION "2.0.0"
 
 static void android_OnChannelConnectedEventHandler(
-    rdpContext* context,
+    void* context,
     ChannelConnectedEventArgs* e)
 {
 	rdpSettings* settings;
@@ -67,18 +67,18 @@ static void android_OnChannelConnectedEventHandler(
 	if (!context || !e)
 	{
 		WLog_FATAL(TAG, "%s(context=%p, EventArgs=%p",
-		           __FUNCTION__, (void*) context, (void*) e);
+		           __FUNCTION__, context, (void*) e);
 		return;
 	}
 
 	afc = (androidContext*) context;
-	settings = context->settings;
+	settings = afc->rdpCtx.settings;
 
 	if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
 		{
-			gdi_graphics_pipeline_init(context->gdi,
+			gdi_graphics_pipeline_init(afc->rdpCtx.gdi,
 			                           (RdpgfxClientContext*) e->pInterface);
 		}
 		else
@@ -94,7 +94,7 @@ static void android_OnChannelConnectedEventHandler(
 }
 
 static void android_OnChannelDisconnectedEventHandler(
-    rdpContext* context, ChannelDisconnectedEventArgs* e)
+    void* context, ChannelDisconnectedEventArgs* e)
 {
 	rdpSettings* settings;
 	androidContext* afc;
@@ -102,18 +102,18 @@ static void android_OnChannelDisconnectedEventHandler(
 	if (!context || !e)
 	{
 		WLog_FATAL(TAG, "%s(context=%p, EventArgs=%p",
-		           __FUNCTION__, (void*) context, (void*) e);
+		           __FUNCTION__, context, (void*) e);
 		return;
 	}
 
 	afc = (androidContext*) context;
-	settings = context->settings;
+	settings = afc->rdpCtx.settings;
 
 	if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
 		{
-			gdi_graphics_pipeline_uninit(context->gdi,
+			gdi_graphics_pipeline_uninit(afc->rdpCtx.gdi,
 			                             (RdpgfxClientContext*) e->pInterface);
 		}
 		else
@@ -260,7 +260,6 @@ static BOOL android_pre_connect(freerdp* instance)
 	settings->OrderSupport[NEG_ELLIPSE_CB_INDEX] = FALSE;
 	rc = PubSub_SubscribeChannelConnected(
 	         instance->context->pubSub,
-	         (pChannelConnectedEventHandler)
 	         android_OnChannelConnectedEventHandler);
 
 	if (rc != CHANNEL_RC_OK)
@@ -271,7 +270,6 @@ static BOOL android_pre_connect(freerdp* instance)
 
 	rc = PubSub_SubscribeChannelDisconnected(
 	         instance->context->pubSub,
-	         (pChannelDisconnectedEventHandler)
 	         android_OnChannelDisconnectedEventHandler);
 
 	if (rc != CHANNEL_RC_OK)

--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -823,11 +823,11 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 	mfc->client_width = width;
 }
 
-void mac_OnChannelConnectedEventHandler(rdpContext* context,
+void mac_OnChannelConnectedEventHandler(void* context,
                                         ChannelConnectedEventArgs* e)
 {
-	rdpSettings* settings = context->settings;
 	mfContext* mfc = (mfContext*) context;
+	rdpSettings* settings = mfc->context.settings;
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
@@ -835,7 +835,7 @@ void mac_OnChannelConnectedEventHandler(rdpContext* context,
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
-			gdi_graphics_pipeline_init(context->gdi, (RdpgfxClientContext*) e->pInterface);
+			gdi_graphics_pipeline_init(mfc->context.gdi, (RdpgfxClientContext*) e->pInterface);
 	}
 	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
 	{
@@ -846,11 +846,11 @@ void mac_OnChannelConnectedEventHandler(rdpContext* context,
 	}
 }
 
-void mac_OnChannelDisconnectedEventHandler(rdpContext* context,
+void mac_OnChannelDisconnectedEventHandler(void* context,
         ChannelDisconnectedEventArgs* e)
 {
-	rdpSettings* settings = context->settings;
 	mfContext* mfc = (mfContext*) context;
+	rdpSettings* settings = mfc->context.settings;
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
@@ -858,7 +858,7 @@ void mac_OnChannelDisconnectedEventHandler(rdpContext* context,
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
-			gdi_graphics_pipeline_uninit(context->gdi,
+			gdi_graphics_pipeline_uninit(mfc->context.gdi,
 			                             (RdpgfxClientContext*) e->pInterface);
 	}
 	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
@@ -916,9 +916,9 @@ BOOL mac_pre_connect(freerdp* instance)
 	settings->OrderSupport[NEG_ELLIPSE_SC_INDEX] = FALSE;
 	settings->OrderSupport[NEG_ELLIPSE_CB_INDEX] = FALSE;
 	PubSub_SubscribeChannelConnected(instance->context->pubSub,
-	                                 (pChannelConnectedEventHandler) mac_OnChannelConnectedEventHandler);
+	                                 mac_OnChannelConnectedEventHandler);
 	PubSub_SubscribeChannelDisconnected(instance->context->pubSub,
-	                                    (pChannelDisconnectedEventHandler) mac_OnChannelDisconnectedEventHandler);
+	                                    mac_OnChannelDisconnectedEventHandler);
 
 	if (!freerdp_client_load_addins(instance->context->channels,
 	                                instance->settings))
@@ -1340,7 +1340,8 @@ void windows_to_apple_cords(MRDPView* view, NSRect* r)
 	r->origin.y = [view frame].size.height - (r->origin.y + r->size.height);
 }
 
-void sync_keyboard_state(freerdp *instance) {
+void sync_keyboard_state(freerdp* instance)
+{
 	mfContext* context = (mfContext*)instance->context;
 	UINT32 flags = 0;
 	CGEventFlags currentFlags = CGEventSourceFlagsState(kCGEventSourceStateHIDSystemState);

--- a/client/Wayland/wlf_channels.c
+++ b/client/Wayland/wlf_channels.c
@@ -56,11 +56,11 @@ static void wlf_encomsp_uninit(wlfContext* wlf, EncomspClientContext* encomsp)
 }
 
 
-void wlf_OnChannelConnectedEventHandler(rdpContext* context,
+void wlf_OnChannelConnectedEventHandler(void* context,
                                         ChannelConnectedEventArgs* e)
 {
 	wlfContext* wlf = (wlfContext*) context;
-	rdpSettings* settings = context->settings;
+	rdpSettings* settings = wlf->context.settings;
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
@@ -72,7 +72,7 @@ void wlf_OnChannelConnectedEventHandler(rdpContext* context,
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
-			gdi_graphics_pipeline_init(context->gdi, (RdpgfxClientContext*) e->pInterface);
+			gdi_graphics_pipeline_init(wlf->context.gdi, (RdpgfxClientContext*) e->pInterface);
 	}
 	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
@@ -86,11 +86,11 @@ void wlf_OnChannelConnectedEventHandler(rdpContext* context,
 	}
 }
 
-void wlf_OnChannelDisconnectedEventHandler(rdpContext* context,
+void wlf_OnChannelDisconnectedEventHandler(void* context,
         ChannelDisconnectedEventArgs* e)
 {
 	wlfContext* wlf = (wlfContext*) context;
-	rdpSettings* settings = context->settings;
+	rdpSettings* settings = wlf->context.settings;
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
@@ -102,7 +102,7 @@ void wlf_OnChannelDisconnectedEventHandler(rdpContext* context,
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
-			gdi_graphics_pipeline_uninit(context->gdi,
+			gdi_graphics_pipeline_uninit(wlf->context.gdi,
 			                             (RdpgfxClientContext*) e->pInterface);
 	}
 	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)

--- a/client/Wayland/wlf_channels.h
+++ b/client/Wayland/wlf_channels.h
@@ -34,9 +34,9 @@ int wlf_on_channel_connected(freerdp* instance, const char* name,
 int wlf_on_channel_disconnected(freerdp* instance, const char* name,
                                 void* pInterface);
 
-void wlf_OnChannelConnectedEventHandler(rdpContext* context,
+void wlf_OnChannelConnectedEventHandler(void* context,
                                         ChannelConnectedEventArgs* e);
-void wlf_OnChannelDisconnectedEventHandler(rdpContext* context,
+void wlf_OnChannelDisconnectedEventHandler(void* context,
         ChannelDisconnectedEventArgs* e);
 
 #endif /* FREERDP_CLIENT_WAYLAND_CHANNELS_H */

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -144,9 +144,9 @@ static BOOL wl_pre_connect(freerdp* instance)
 	settings->OrderSupport[NEG_ELLIPSE_SC_INDEX] = FALSE;
 	settings->OrderSupport[NEG_ELLIPSE_CB_INDEX] = FALSE;
 	PubSub_SubscribeChannelConnected(instance->context->pubSub,
-	                                 (pChannelConnectedEventHandler) wlf_OnChannelConnectedEventHandler);
+	                                 wlf_OnChannelConnectedEventHandler);
 	PubSub_SubscribeChannelDisconnected(instance->context->pubSub,
-	                                    (pChannelDisconnectedEventHandler) wlf_OnChannelDisconnectedEventHandler);
+	                                    wlf_OnChannelDisconnectedEventHandler);
 
 	if (settings->Fullscreen)
 	{

--- a/client/Windows/wf_channels.c
+++ b/client/Windows/wf_channels.c
@@ -30,11 +30,11 @@
 #include <freerdp/log.h>
 #define TAG CLIENT_TAG("windows")
 
-void wf_OnChannelConnectedEventHandler(rdpContext* context,
+void wf_OnChannelConnectedEventHandler(void* context,
                                        ChannelConnectedEventArgs* e)
 {
 	wfContext* wfc = (wfContext*) context;
-	rdpSettings* settings = context->settings;
+	rdpSettings* settings = wfc->context.settings;
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
@@ -42,9 +42,10 @@ void wf_OnChannelConnectedEventHandler(rdpContext* context,
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
 		if (!settings->SoftwareGdi)
-			WLog_WARN(TAG, "Channel "RDPGFX_DVC_CHANNEL_NAME" does not support hardware acceleration, using fallback.");
+			WLog_WARN(TAG,
+			          "Channel "RDPGFX_DVC_CHANNEL_NAME" does not support hardware acceleration, using fallback.");
 
-		gdi_graphics_pipeline_init(context->gdi, (RdpgfxClientContext*) e->pInterface);
+		gdi_graphics_pipeline_init(wfc->context.gdi, (RdpgfxClientContext*) e->pInterface);
 	}
 	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
@@ -59,19 +60,19 @@ void wf_OnChannelConnectedEventHandler(rdpContext* context,
 	}
 }
 
-void wf_OnChannelDisconnectedEventHandler(rdpContext* context,
+void wf_OnChannelDisconnectedEventHandler(void* context,
         ChannelDisconnectedEventArgs* e)
 {
 	wfContext* wfc = (wfContext*) context;
-	rdpSettings* settings = context->settings;
+	rdpSettings* settings = wfc->context.settings;
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
 	}
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_graphics_pipeline_uninit(context->gdi,
-			(RdpgfxClientContext*) e->pInterface);
+		gdi_graphics_pipeline_uninit(wfc->context.gdi,
+		                             (RdpgfxClientContext*) e->pInterface);
 	}
 	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{

--- a/client/Windows/wf_channels.h
+++ b/client/Windows/wf_channels.h
@@ -28,9 +28,9 @@
 
 #include "wf_client.h"
 
-void wf_OnChannelConnectedEventHandler(rdpContext* context,
+void wf_OnChannelConnectedEventHandler(void* context,
                                        ChannelConnectedEventArgs* e);
-void wf_OnChannelDisconnectedEventHandler(rdpContext* context,
+void wf_OnChannelDisconnectedEventHandler(void* context,
         ChannelDisconnectedEventArgs* e);
 
 #endif /* FREERDP_CLIENT_WIN_CHANNELS_H */

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -274,9 +274,9 @@ static BOOL wf_pre_connect(freerdp* instance)
 	freerdp_set_param_uint32(settings, FreeRDP_KeyboardLayout,
 	                         (int) GetKeyboardLayout(0) & 0x0000FFFF);
 	PubSub_SubscribeChannelConnected(instance->context->pubSub,
-	                                 (pChannelConnectedEventHandler) wf_OnChannelConnectedEventHandler);
+	                                 wf_OnChannelConnectedEventHandler);
 	PubSub_SubscribeChannelDisconnected(instance->context->pubSub,
-	                                    (pChannelDisconnectedEventHandler) wf_OnChannelDisconnectedEventHandler);
+	                                    wf_OnChannelDisconnectedEventHandler);
 	return TRUE;
 }
 

--- a/client/X11/xf_channels.c
+++ b/client/X11/xf_channels.c
@@ -34,10 +34,10 @@
 #include "xf_disp.h"
 #include "xf_video.h"
 
-void xf_OnChannelConnectedEventHandler(rdpContext* context, ChannelConnectedEventArgs* e)
+void xf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs* e)
 {
 	xfContext* xfc = (xfContext*) context;
-	rdpSettings* settings = context->settings;
+	rdpSettings* settings = xfc->context.settings;
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
@@ -50,7 +50,7 @@ void xf_OnChannelConnectedEventHandler(rdpContext* context, ChannelConnectedEven
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
-			gdi_graphics_pipeline_init(context->gdi, (RdpgfxClientContext*) e->pInterface);
+			gdi_graphics_pipeline_init(xfc->context.gdi, (RdpgfxClientContext*) e->pInterface);
 		else
 			xf_graphics_pipeline_init(xfc, (RdpgfxClientContext*) e->pInterface);
 	}
@@ -87,10 +87,10 @@ void xf_OnChannelConnectedEventHandler(rdpContext* context, ChannelConnectedEven
 	}
 }
 
-void xf_OnChannelDisconnectedEventHandler(rdpContext* context, ChannelDisconnectedEventArgs* e)
+void xf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEventArgs* e)
 {
 	xfContext* xfc = (xfContext*) context;
-	rdpSettings* settings = context->settings;
+	rdpSettings* settings = xfc->context.settings;
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
@@ -103,7 +103,7 @@ void xf_OnChannelDisconnectedEventHandler(rdpContext* context, ChannelDisconnect
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
-			gdi_graphics_pipeline_uninit(context->gdi, (RdpgfxClientContext*) e->pInterface);
+			gdi_graphics_pipeline_uninit(xfc->context.gdi, (RdpgfxClientContext*) e->pInterface);
 		else
 			xf_graphics_pipeline_uninit(xfc, (RdpgfxClientContext*) e->pInterface);
 	}

--- a/client/X11/xf_channels.h
+++ b/client/X11/xf_channels.h
@@ -35,7 +35,7 @@
 int xf_on_channel_connected(freerdp* instance, const char* name, void* pInterface);
 int xf_on_channel_disconnected(freerdp* instance, const char* name, void* pInterface);
 
-void xf_OnChannelConnectedEventHandler(rdpContext* context, ChannelConnectedEventArgs* e);
-void xf_OnChannelDisconnectedEventHandler(rdpContext* context, ChannelDisconnectedEventArgs* e);
+void xf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs* e);
+void xf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEventArgs* e);
 
 #endif /* FREERDP_CLIENT_X11_CHANNELS_H */

--- a/client/X11/xf_disp.c
+++ b/client/X11/xf_disp.c
@@ -92,11 +92,11 @@ static BOOL xf_disp_set_window_resizable(xfDispContext *xfDisp)
 }
 
 
-static void xf_disp_OnActivated(rdpContext* context, ActivatedEventArgs* e)
+static void xf_disp_OnActivated(void* context, ActivatedEventArgs* e)
 {
 	xfContext *xfc = (xfContext *)context;
 	xfDispContext *xfDisp = xfc->xfDisp;
-	rdpSettings *settings = context->settings;
+	rdpSettings *settings = xfc->context.settings;
 
 	xfDisp->waitingResize = FALSE;
 
@@ -121,11 +121,11 @@ static void xf_disp_OnActivated(rdpContext* context, ActivatedEventArgs* e)
 }
 
 
-static void xf_disp_OnGraphicsReset(rdpContext* context, GraphicsResetEventArgs* e)
+static void xf_disp_OnGraphicsReset(void* context, GraphicsResetEventArgs* e)
 {
 	xfContext *xfc = (xfContext *)context;
 	xfDispContext *xfDisp = xfc->xfDisp;
-	rdpSettings *settings = context->settings;
+	rdpSettings *settings = xfc->context.settings;
 
 	xfDisp->waitingResize = FALSE;
 
@@ -146,12 +146,11 @@ static void xf_disp_OnGraphicsReset(rdpContext* context, GraphicsResetEventArgs*
 	}
 }
 
-static void xf_disp_OnTimer(void* voidContext, TimerEventArgs* e)
+static void xf_disp_OnTimer(void* context, TimerEventArgs* e)
 {
-	rdpContext* context = (rdpContext *)voidContext;
 	xfContext *xfc = (xfContext *)context;
 	xfDispContext *xfDisp = xfc->xfDisp;
-	rdpSettings *settings = context->settings;
+	rdpSettings *settings = xfc->context.settings;
 
 	if (!xfDisp->activated || settings->Fullscreen)
 		return;
@@ -182,16 +181,16 @@ xfDispContext *xf_disp_new(xfContext* xfc)
 	ret->lastSentWidth = ret->targetWidth = xfc->context.settings->DesktopWidth;
 	ret->lastSentHeight = ret->targetHeight = xfc->context.settings->DesktopHeight;
 
-	PubSub_SubscribeActivated(xfc->context.pubSub, (pActivatedEventHandler)xf_disp_OnActivated);
-	PubSub_SubscribeGraphicsReset(xfc->context.pubSub, (pGraphicsResetEventHandler)xf_disp_OnGraphicsReset);
-	PubSub_SubscribeTimer(xfc->context.pubSub, (pTimerEventHandler)xf_disp_OnTimer);
+	PubSub_SubscribeActivated(xfc->context.pubSub, xf_disp_OnActivated);
+	PubSub_SubscribeGraphicsReset(xfc->context.pubSub, xf_disp_OnGraphicsReset);
+	PubSub_SubscribeTimer(xfc->context.pubSub, xf_disp_OnTimer);
 	return ret;
 }
 
 void xf_disp_free(xfDispContext *disp)
 {
-	PubSub_UnsubscribeActivated(disp->xfc->context.pubSub, (pActivatedEventHandler)xf_disp_OnActivated);
-	PubSub_UnsubscribeTimer(disp->xfc->context.pubSub, (pTimerEventHandler)xf_disp_OnTimer);
+	PubSub_UnsubscribeActivated(disp->xfc->context.pubSub, xf_disp_OnActivated);
+	PubSub_UnsubscribeTimer(disp->xfc->context.pubSub, xf_disp_OnTimer);
 	free(disp);
 }
 

--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -240,6 +240,7 @@ static void xf_input_detect_pan(xfContext* xfc)
 	double py;
 	double dist_x;
 	double dist_y;
+	rdpContext* ctx = &xfc->context;
 
 	if (active_contacts != 2)
 	{
@@ -266,7 +267,7 @@ static void xf_input_detect_pan(xfContext* xfc)
 				EventArgsInit(&e, "xfreerdp");
 				e.dx = 5;
 				e.dy = 0;
-				PubSub_OnPanningChange(((rdpContext*) xfc)->pubSub, xfc, &e);
+				PubSub_OnPanningChange(ctx->pubSub, xfc, &e);
 			}
 			px_vector = 0;
 			py_vector = 0;
@@ -279,7 +280,7 @@ static void xf_input_detect_pan(xfContext* xfc)
 				EventArgsInit(&e, "xfreerdp");
 				e.dx = -5;
 				e.dy = 0;
-				PubSub_OnPanningChange(((rdpContext*) xfc)->pubSub, xfc, &e);
+				PubSub_OnPanningChange(ctx->pubSub, xfc, &e);
 			}
 			px_vector = 0;
 			py_vector = 0;
@@ -296,7 +297,7 @@ static void xf_input_detect_pan(xfContext* xfc)
 				EventArgsInit(&e, "xfreerdp");
 				e.dx = 0;
 				e.dy = 5;
-				PubSub_OnPanningChange(((rdpContext*) xfc)->pubSub, xfc, &e);
+				PubSub_OnPanningChange(ctx->pubSub, xfc, &e);
 			}
 			py_vector = 0;
 			px_vector = 0;
@@ -309,7 +310,7 @@ static void xf_input_detect_pan(xfContext* xfc)
 				EventArgsInit(&e, "xfreerdp");
 				e.dx = 0;
 				e.dy = -5;
-				PubSub_OnPanningChange(((rdpContext*) xfc)->pubSub, xfc, &e);
+				PubSub_OnPanningChange(ctx->pubSub, xfc, &e);
 			}
 			py_vector = 0;
 			px_vector = 0;
@@ -323,6 +324,7 @@ static void xf_input_detect_pinch(xfContext* xfc)
 	double dist;
 	double delta;
 	ZoomingChangeEventArgs e;
+	rdpContext* ctx = &xfc->context;
 
 	if (active_contacts != 2)
 	{
@@ -361,7 +363,7 @@ static void xf_input_detect_pinch(xfContext* xfc)
 		{
 			EventArgsInit(&e, "xfreerdp");
 			e.dx = e.dy = -10;
-			PubSub_OnZoomingChange(((rdpContext*) xfc)->pubSub, xfc, &e);
+			PubSub_OnZoomingChange(ctx->pubSub, xfc, &e);
 			z_vector = 0;
 			px_vector = 0;
 			py_vector = 0;
@@ -371,7 +373,7 @@ static void xf_input_detect_pinch(xfContext* xfc)
 		{
 			EventArgsInit(&e, "xfreerdp");
 			e.dx = e.dy = 10;
-			PubSub_OnZoomingChange(((rdpContext*) xfc)->pubSub, xfc, &e);
+			PubSub_OnZoomingChange(ctx->pubSub, xfc, &e);
 			z_vector = 0;
 			px_vector = 0;
 			py_vector = 0;

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -447,6 +447,7 @@ BOOL xf_keyboard_handle_special_keys(xfContext* xfc, KeySym keysym)
 {
 	XF_MODIFIER_KEYS mod = { 0 };
 	xk_keyboard_get_modifier_keys(xfc, &mod);
+	rdpContext* ctx = &xfc->context;
 
 	// remember state of RightCtrl to ungrab keyboard if next action is release of RightCtrl
 	// do not return anything such that the key could be used by client if ungrab is not the goal
@@ -554,7 +555,7 @@ BOOL xf_keyboard_handle_special_keys(xfContext* xfc, KeySym keysym)
 				EventArgsInit(&e, "xfreerdp");
 				e.dx = pdx;
 				e.dy = pdy;
-				PubSub_OnPanningChange(((rdpContext*) xfc)->pubSub, xfc, &e);
+				PubSub_OnPanningChange(ctx->pubSub, xfc, &e);
 				return TRUE;
 			}
 
@@ -564,7 +565,7 @@ BOOL xf_keyboard_handle_special_keys(xfContext* xfc, KeySym keysym)
 				EventArgsInit(&e, "xfreerdp");
 				e.dx = zdx;
 				e.dy = zdy;
-				PubSub_OnZoomingChange(((rdpContext*) xfc)->pubSub, xfc, &e);
+				PubSub_OnZoomingChange(ctx->pubSub, xfc, &e);
 				return TRUE;
 			}
 		}
@@ -614,13 +615,14 @@ BOOL xf_keyboard_set_indicators(rdpContext* context, UINT16 led_flags)
 	return TRUE;
 }
 
-BOOL xf_keyboard_set_ime_status(rdpContext* context, UINT16 imeId, UINT32 imeState, UINT32 imeConvMode)
+BOOL xf_keyboard_set_ime_status(rdpContext* context, UINT16 imeId, UINT32 imeState,
+                                UINT32 imeConvMode)
 {
 	if (!context)
 		return FALSE;
 
-	WLog_WARN(TAG, "KeyboardSetImeStatus(unitId=%04"PRIx16", imeState=%08"PRIx32", imeConvMode=%08"PRIx32") ignored",
+	WLog_WARN(TAG,
+	          "KeyboardSetImeStatus(unitId=%04"PRIx16", imeState=%08"PRIx32", imeConvMode=%08"PRIx32") ignored",
 	          imeId, imeState, imeConvMode);
-
 	return TRUE;
 }

--- a/client/iOS/FreeRDP/ios_freerdp.m
+++ b/client/iOS/FreeRDP/ios_freerdp.m
@@ -28,7 +28,7 @@
 #pragma mark Connection helpers
 
 static void ios_OnChannelConnectedEventHandler(
-    rdpContext* context,
+    void* context,
     ChannelConnectedEventArgs* e)
 {
 	rdpSettings* settings;
@@ -37,18 +37,18 @@ static void ios_OnChannelConnectedEventHandler(
 	if (!context || !e)
 	{
 		WLog_FATAL(TAG, "%s(context=%p, EventArgs=%p",
-		           __FUNCTION__, (void*) context, (void*) e);
+		           __FUNCTION__, context, (void*) e);
 		return;
 	}
 
 	afc = (mfContext*) context;
-	settings = context->settings;
+	settings = afc->_p.settings;
 
 	if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
 		{
-			gdi_graphics_pipeline_init(context->gdi,
+			gdi_graphics_pipeline_init(afc->_p.gdi,
 			                           (RdpgfxClientContext*) e->pInterface);
 		}
 		else
@@ -60,7 +60,7 @@ static void ios_OnChannelConnectedEventHandler(
 }
 
 static void ios_OnChannelDisconnectedEventHandler(
-    rdpContext* context, ChannelDisconnectedEventArgs* e)
+    void* context, ChannelDisconnectedEventArgs* e)
 {
 	rdpSettings* settings;
 	mfContext* afc;
@@ -68,18 +68,18 @@ static void ios_OnChannelDisconnectedEventHandler(
 	if (!context || !e)
 	{
 		WLog_FATAL(TAG, "%s(context=%p, EventArgs=%p",
-		           __FUNCTION__, (void*) context, (void*) e);
+		           __FUNCTION__, context, (void*) e);
 		return;
 	}
 
 	afc = (mfContext*) context;
-	settings = context->settings;
+	settings = afc->_p.settings;
 
 	if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
 		{
-			gdi_graphics_pipeline_uninit(context->gdi,
+			gdi_graphics_pipeline_uninit(afc->_p.gdi,
 			                             (RdpgfxClientContext*) e->pInterface);
 		}
 		else
@@ -142,7 +142,6 @@ static BOOL ios_pre_connect(freerdp* instance)
 	settings->OrderSupport[NEG_ELLIPSE_CB_INDEX] = FALSE;
 	rc = PubSub_SubscribeChannelConnected(
 	         instance->context->pubSub,
-	         (pChannelConnectedEventHandler)
 	         ios_OnChannelConnectedEventHandler);
 
 	if (rc != CHANNEL_RC_OK)
@@ -153,7 +152,6 @@ static BOOL ios_pre_connect(freerdp* instance)
 
 	rc = PubSub_SubscribeChannelDisconnected(
 	         instance->context->pubSub,
-	         (pChannelDisconnectedEventHandler)
 	         ios_OnChannelDisconnectedEventHandler);
 
 	if (rc != CHANNEL_RC_OK)
@@ -262,7 +260,7 @@ static BOOL ios_post_connect(freerdp* instance)
 	instance->update->DesktopResize = ios_ui_resize_window;
 	pointer_cache_register_callbacks(instance->update);
 	[mfi->session performSelectorOnMainThread:@selector(sessionDidConnect)
-	 withObject:nil waitUntilDone:YES];
+	              withObject:nil waitUntilDone:YES];
 	return TRUE;
 }
 
@@ -503,5 +501,5 @@ void ios_uninit_freerdp()
 /* compatibilty functions */
 size_t fwrite$UNIX2003(const void* ptr, size_t size, size_t nmemb, FILE* stream)
 {
-	return fwrite(ptr, size , nmemb, stream);
+	return fwrite(ptr, size, nmemb, stream);
 }

--- a/include/freerdp/client/geometry.h
+++ b/include/freerdp/client/geometry.h
@@ -61,7 +61,7 @@ struct _geometry_client_context
 };
 
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
 
 FREERDP_API void mappedGeometryRef(MAPPED_GEOMETRY *g);

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -637,7 +637,7 @@ BOOL freerdp_context_new(freerdp* instance)
 		goto fail;
 
 	PubSub_AddEventTypes(context->pubSub, FreeRDP_Events,
-	                     sizeof(FreeRDP_Events) / sizeof(wEventType));
+	                     ARRAYSIZE(FreeRDP_Events));
 	context->metrics = metrics_new(context);
 
 	if (!context->metrics)

--- a/libfreerdp/core/gateway/http.c
+++ b/libfreerdp/core/gateway/http.c
@@ -623,7 +623,7 @@ HttpResponse* http_response_recv(rdpTls* tls)
 {
 	size_t size;
 	size_t position;
-	size_t bodyLength;
+	size_t bodyLength = 0;
 	size_t payloadOffset;
 	HttpResponse* response;
 	size = 2048;

--- a/libfreerdp/gdi/video.c
+++ b/libfreerdp/gdi/video.c
@@ -90,7 +90,6 @@ static BOOL gdiVideoShowSurface(VideoClientContext* video, VideoSurface* surface
 	surfaceRect.top = surface->y;
 	surfaceRect.right = surface->x + surface->w;
 	surfaceRect.bottom = surface->y + surface->h;
-
 	update->BeginPaint(gdi->context);
 	{
 		const UINT32 nXSrc = surface->x;
@@ -140,9 +139,9 @@ void gdi_video_control_uninit(rdpGdi* gdi, VideoClientContext* video)
 	gdi->video = NULL;
 }
 
-static void gdi_video_timer(void *voidContext, TimerEventArgs* timer)
+static void gdi_video_timer(void* context, TimerEventArgs* timer)
 {
-	rdpContext *ctx = (rdpContext *)voidContext;
+	rdpContext* ctx = (rdpContext*)context;
 	rdpGdi* gdi = ctx->gdi;
 
 	if (gdi && gdi->video)

--- a/server/shadow/Win/win_rdp.c
+++ b/server/shadow/Win/win_rdp.c
@@ -28,21 +28,21 @@
 
 #define TAG SERVER_TAG("shadow.win")
 
-void shw_OnChannelConnectedEventHandler(rdpContext* context,
-                                        ChannelConnectedEventArgs* e)
+static void shw_OnChannelConnectedEventHandler(void* context,
+        ChannelConnectedEventArgs* e)
 {
 	shwContext* shw = (shwContext*) context;
 	WLog_INFO(TAG, "OnChannelConnected: %s", e->name);
 }
 
-void shw_OnChannelDisconnectedEventHandler(rdpContext* context,
+static void shw_OnChannelDisconnectedEventHandler(void* context,
         ChannelDisconnectedEventArgs* e)
 {
 	shwContext* shw = (shwContext*) context;
 	WLog_INFO(TAG, "OnChannelDisconnected: %s", e->name);
 }
 
-BOOL shw_begin_paint(rdpContext* context)
+static BOOL shw_begin_paint(rdpContext* context)
 {
 	shwContext* shw;
 	rdpGdi* gdi = context->gdi;
@@ -52,7 +52,7 @@ BOOL shw_begin_paint(rdpContext* context)
 	return TRUE;
 }
 
-BOOL shw_end_paint(rdpContext* context)
+static BOOL shw_end_paint(rdpContext* context)
 {
 	int index;
 	int ninvalid;
@@ -86,15 +86,15 @@ BOOL shw_desktop_resize(rdpContext* context)
 	return TRUE;
 }
 
-BOOL shw_surface_frame_marker(rdpContext* context,
-                              const SURFACE_FRAME_MARKER* surfaceFrameMarker)
+static BOOL shw_surface_frame_marker(rdpContext* context,
+                                     const SURFACE_FRAME_MARKER* surfaceFrameMarker)
 {
 	shwContext* shw = (shwContext*) context;
 	return TRUE;
 }
 
-BOOL shw_authenticate(freerdp* instance, char** username, char** password,
-                      char** domain)
+static BOOL shw_authenticate(freerdp* instance, char** username, char** password,
+                             char** domain)
 {
 	return TRUE;
 }
@@ -106,30 +106,30 @@ static DWORD shw_verify_certificate(freerdp* instance, const char* common_name,
 	return 1;
 }
 
-int shw_verify_x509_certificate(freerdp* instance, BYTE* data, int length,
-                                const char* hostname, int port, DWORD flags)
+static int shw_verify_x509_certificate(freerdp* instance, BYTE* data, int length,
+                                       const char* hostname, int port, DWORD flags)
 {
 	return 1;
 }
 
-void shw_OnConnectionResultEventHandler(rdpContext* context,
-                                        ConnectionResultEventArgs* e)
+static void shw_OnConnectionResultEventHandler(void* context,
+        ConnectionResultEventArgs* e)
 {
 	shwContext* shw = (shwContext*) context;
 	WLog_INFO(TAG, "OnConnectionResult: %d", e->result);
 }
 
-BOOL shw_pre_connect(freerdp* instance)
+static BOOL shw_pre_connect(freerdp* instance)
 {
 	shwContext* shw;
 	rdpContext* context = instance->context;
 	shw = (shwContext*) context;
 	PubSub_SubscribeConnectionResult(context->pubSub,
-	                                 (pConnectionResultEventHandler) shw_OnConnectionResultEventHandler);
+	                                 shw_OnConnectionResultEventHandler);
 	PubSub_SubscribeChannelConnected(context->pubSub,
-	                                 (pChannelConnectedEventHandler) shw_OnChannelConnectedEventHandler);
+	                                 shw_OnChannelConnectedEventHandler);
 	PubSub_SubscribeChannelDisconnected(context->pubSub,
-	                                    (pChannelDisconnectedEventHandler) shw_OnChannelDisconnectedEventHandler);
+	                                    shw_OnChannelDisconnectedEventHandler);
 
 	if (!freerdp_client_load_addins(context->channels, instance->settings))
 		return FALSE;
@@ -137,7 +137,7 @@ BOOL shw_pre_connect(freerdp* instance)
 	return TRUE;
 }
 
-BOOL shw_post_connect(freerdp* instance)
+static BOOL shw_post_connect(freerdp* instance)
 {
 	rdpGdi* gdi;
 	shwContext* shw;
@@ -156,7 +156,7 @@ BOOL shw_post_connect(freerdp* instance)
 	return TRUE;
 }
 
-void* shw_client_thread(void* arg)
+static void* shw_client_thread(void* arg)
 {
 	int index;
 	int rcount;
@@ -244,16 +244,16 @@ void* shw_client_thread(void* arg)
  * Client Interface
  */
 
-BOOL shw_freerdp_client_global_init(void)
+static BOOL shw_freerdp_client_global_init(void)
 {
 	return TRUE;
 }
 
-void shw_freerdp_client_global_uninit(void)
+static void shw_freerdp_client_global_uninit(void)
 {
 }
 
-int shw_freerdp_client_start(rdpContext* context)
+static int shw_freerdp_client_start(rdpContext* context)
 {
 	shwContext* shw;
 	freerdp* instance = context->instance;
@@ -270,14 +270,14 @@ int shw_freerdp_client_start(rdpContext* context)
 	return 0;
 }
 
-int shw_freerdp_client_stop(rdpContext* context)
+static int shw_freerdp_client_stop(rdpContext* context)
 {
 	shwContext* shw = (shwContext*) context;
 	SetEvent(shw->StopEvent);
 	return 0;
 }
 
-BOOL shw_freerdp_client_new(freerdp* instance, rdpContext* context)
+static BOOL shw_freerdp_client_new(freerdp* instance, rdpContext* context)
 {
 	shwContext* shw;
 	rdpSettings* settings;
@@ -335,7 +335,7 @@ BOOL shw_freerdp_client_new(freerdp* instance, rdpContext* context)
 	return TRUE;
 }
 
-void shw_freerdp_client_free(freerdp* instance, rdpContext* context)
+static void shw_freerdp_client_free(freerdp* instance, rdpContext* context)
 {
 	shwContext* shw = (shwContext*) instance->context;
 }


### PR DESCRIPTION
Removed all function pointer casts for the `PubSub` system to allow the compiler to warn us about argument mismatches.