### PR TITLE
fix windows nightly

### DIFF
--- a/channels/video/client/video_main.c
+++ b/channels/video/client/video_main.c
@@ -82,7 +82,7 @@ typedef struct _VIDEO_PLUGIN VIDEO_PLUGIN;
 
 #define XF_VIDEO_UNLIMITED_RATE 31
 
-BYTE MFVideoFormat_H264[] = {'H', '2', '6', '4',
+static const BYTE MFVideoFormat_H264[] = {'H', '2', '6', '4',
 		0x00, 0x00,
 		0x10, 0x00,
 		0x80, 0x00,

--- a/libfreerdp/codec/h264_mf.c
+++ b/libfreerdp/codec/h264_mf.c
@@ -30,46 +30,42 @@
 
 #include "h264.h"
 
-#undef DEFINE_GUID
-#define INITGUID
-#include <initguid.h>
-
 #define TAG FREERDP_TAG("codec")
 
-DEFINE_GUID(CLSID_CMSH264DecoderMFT, 0x62CE7E72, 0x4C71, 0x4d20, 0xB1, 0x5D,
-            0x45, 0x28, 0x31, 0xA8, 0x7D, 0x9D);
-DEFINE_GUID(CLSID_VideoProcessorMFT, 0x88753b26, 0x5b24, 0x49bd, 0xb2, 0xe7,
-            0x0c, 0x44, 0x5c, 0x78, 0xc9, 0x82);
-DEFINE_GUID(IID_IMFTransform, 0xbf94c121, 0x5b05, 0x4e6f, 0x80, 0x00, 0xba,
-            0x59, 0x89, 0x61, 0x41, 0x4d);
-DEFINE_GUID(MF_MT_MAJOR_TYPE, 0x48eba18e, 0xf8c9, 0x4687, 0xbf, 0x11, 0x0a,
-            0x74, 0xc9, 0xf9, 0x6a, 0x8f);
-DEFINE_GUID(MF_MT_FRAME_SIZE, 0x1652c33d, 0xd6b2, 0x4012, 0xb8, 0x34, 0x72,
-            0x03, 0x08, 0x49, 0xa3, 0x7d);
-DEFINE_GUID(MF_MT_DEFAULT_STRIDE, 0x644b4e48, 0x1e02, 0x4516, 0xb0, 0xeb, 0xc0,
-            0x1c, 0xa9, 0xd4, 0x9a, 0xc6);
-DEFINE_GUID(MF_MT_SUBTYPE, 0xf7e34c9a, 0x42e8, 0x4714, 0xb7, 0x4b, 0xcb, 0x29,
-            0xd7, 0x2c, 0x35, 0xe5);
-DEFINE_GUID(MF_XVP_DISABLE_FRC, 0x2c0afa19, 0x7a97, 0x4d5a, 0x9e, 0xe8, 0x16,
-            0xd4, 0xfc, 0x51, 0x8d, 0x8c);
-DEFINE_GUID(MFMediaType_Video, 0x73646976, 0x0000, 0x0010, 0x80, 0x00, 0x00,
-            0xAA, 0x00, 0x38, 0x9B, 0x71);
-DEFINE_GUID(MFVideoFormat_RGB32, 22, 0x0000, 0x0010, 0x80, 0x00, 0x00, 0xAA,
-            0x00, 0x38, 0x9B, 0x71);
-DEFINE_GUID(MFVideoFormat_ARGB32, 21, 0x0000, 0x0010, 0x80, 0x00, 0x00, 0xAA,
-            0x00, 0x38, 0x9B, 0x71);
-DEFINE_GUID(MFVideoFormat_H264, 0x34363248, 0x0000, 0x0010, 0x80, 0x00, 0x00,
-            0xaa, 0x00, 0x38, 0x9b, 0x71);
-DEFINE_GUID(MFVideoFormat_IYUV, 0x56555949, 0x0000, 0x0010, 0x80, 0x00, 0x00,
-            0xaa, 0x00, 0x38, 0x9b, 0x71);
-DEFINE_GUID(IID_ICodecAPI, 0x901db4c7, 0x31ce, 0x41a2, 0x85, 0xdc, 0x8f, 0xa0,
-            0xbf, 0x41, 0xb8, 0xda);
-DEFINE_GUID(CODECAPI_AVLowLatencyMode, 0x9c27891a, 0xed7a, 0x40e1, 0x88, 0xe8,
-            0xb2, 0x27, 0x27, 0xa0, 0x24, 0xee);
-DEFINE_GUID(CODECAPI_AVDecVideoMaxCodedWidth, 0x5ae557b8, 0x77af, 0x41f5, 0x9f,
-            0xa6, 0x4d, 0xb2, 0xfe, 0x1d, 0x4b, 0xca);
-DEFINE_GUID(CODECAPI_AVDecVideoMaxCodedHeight, 0x7262a16a, 0xd2dc, 0x4e75, 0x9b,
-            0xa8, 0x65, 0xc0, 0xc6, 0xd3, 0x2b, 0x13);
+static const GUID sCLSID_CMSH264DecoderMFT = { 0x62CE7E72, 0x4C71, 0x4d20, { 0xB1, 0x5D,
+            0x45, 0x28, 0x31, 0xA8, 0x7D, 0x9D } };
+static const GUID sCLSID_VideoProcessorMFT = { 0x88753b26, 0x5b24, 0x49bd, { 0xb2, 0xe7,
+            0x0c, 0x44, 0x5c, 0x78, 0xc9, 0x82 } };
+static const GUID sIID_IMFTransform = { 0xbf94c121, 0x5b05, 0x4e6f, { 0x80, 0x00, 0xba,
+            0x59, 0x89, 0x61, 0x41, 0x4d } };
+static const GUID sMF_MT_MAJOR_TYPE = { 0x48eba18e, 0xf8c9, 0x4687, { 0xbf, 0x11, 0x0a,
+            0x74, 0xc9, 0xf9, 0x6a, 0x8f } };
+static const GUID sMF_MT_FRAME_SIZE = { 0x1652c33d, 0xd6b2, 0x4012, { 0xb8, 0x34, 0x72,
+            0x03, 0x08, 0x49, 0xa3, 0x7d } };
+static const GUID sMF_MT_DEFAULT_STRIDE = { 0x644b4e48, 0x1e02, 0x4516, { 0xb0, 0xeb, 0xc0,
+            0x1c, 0xa9, 0xd4, 0x9a, 0xc6 } };
+static const GUID sMF_MT_SUBTYPE = { 0xf7e34c9a, 0x42e8, 0x4714, { 0xb7, 0x4b, 0xcb, 0x29,
+            0xd7, 0x2c, 0x35, 0xe5 } };
+static const GUID sMF_XVP_DISABLE_FRC = { 0x2c0afa19, 0x7a97, 0x4d5a, { 0x9e, 0xe8, 0x16,
+            0xd4, 0xfc, 0x51, 0x8d, 0x8c } };
+static const GUID sMFMediaType_Video = { 0x73646976, 0x0000, 0x0010, { 0x80, 0x00, 0x00,
+            0xAA, 0x00, 0x38, 0x9B, 0x71 } };
+static const GUID sMFVideoFormat_RGB32 = { 22, 0x0000, 0x0010, { 0x80, 0x00, 0x00, 0xAA,
+            0x00, 0x38, 0x9B, 0x71 } };
+static const GUID sMFVideoFormat_ARGB32 = { 21, 0x0000, 0x0010, { 0x80, 0x00, 0x00, 0xAA,
+            0x00, 0x38, 0x9B, 0x71 } };
+static const GUID sMFVideoFormat_H264 = { 0x34363248, 0x0000, 0x0010, { 0x80, 0x00, 0x00,
+            0xaa, 0x00, 0x38, 0x9b, 0x71 } };
+static const GUID sMFVideoFormat_IYUV = { 0x56555949, 0x0000, 0x0010, { 0x80, 0x00, 0x00,
+            0xaa, 0x00, 0x38, 0x9b, 0x71 } };
+static const GUID sIID_ICodecAPI = { 0x901db4c7, 0x31ce, 0x41a2, { 0x85, 0xdc, 0x8f, 0xa0,
+            0xbf, 0x41, 0xb8, 0xda } };
+static const GUID sCODECAPI_AVLowLatencyMode = { 0x9c27891a, 0xed7a, 0x40e1, { 0x88, 0xe8,
+            0xb2, 0x27, 0x27, 0xa0, 0x24, 0xee } };
+static const GUID sCODECAPI_AVDecVideoMaxCodedWidth = { 0x5ae557b8, 0x77af, 0x41f5, { 0x9f,
+            0xa6, 0x4d, 0xb2, 0xfe, 0x1d, 0x4b, 0xca } };
+static const GUID sCODECAPI_AVDecVideoMaxCodedHeight = { 0x7262a16a, 0xd2dc, 0x4e75, { 0x9b,
+            0xa8, 0x65, 0xc0, 0xc6, 0xd3, 0x2b, 0x13 } };
 
 #ifndef __IMFDXGIDeviceManager_FWD_DEFINED__
 #define __IMFDXGIDeviceManager_FWD_DEFINED__
@@ -152,7 +148,7 @@ static HRESULT mf_find_output_type(H264_CONTEXT_MF* sys, const GUID* guid,
 		if (FAILED(hr))
 			break;
 
-		pMediaType->lpVtbl->GetGUID(pMediaType, &MF_MT_SUBTYPE, &mediaGuid);
+		pMediaType->lpVtbl->GetGUID(pMediaType, &sMF_MT_SUBTYPE, &mediaGuid);
 
 		if (IsEqualGUID(&mediaGuid, guid))
 		{
@@ -315,7 +311,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 			sys->outputType = NULL;
 		}
 
-		hr = mf_find_output_type(sys, &MFVideoFormat_IYUV, &sys->outputType);
+		hr = mf_find_output_type(sys, &sMFVideoFormat_IYUV, &sys->outputType);
 
 		if (FAILED(hr))
 		{
@@ -340,7 +336,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 			goto error;
 		}
 
-		hr = sys->outputType->lpVtbl->GetUINT64(sys->outputType, &MF_MT_FRAME_SIZE,
+		hr = sys->outputType->lpVtbl->GetUINT64(sys->outputType, &sMF_MT_FRAME_SIZE,
 		                                        &frameSize);
 
 		if (FAILED(hr))
@@ -351,7 +347,7 @@ static int mf_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSiz
 
 		sys->frameWidth = (UINT32)(frameSize >> 32);
 		sys->frameHeight = (UINT32) frameSize;
-		hr = sys->outputType->lpVtbl->GetUINT32(sys->outputType, &MF_MT_DEFAULT_STRIDE,
+		hr = sys->outputType->lpVtbl->GetUINT32(sys->outputType, &sMF_MT_DEFAULT_STRIDE,
 		                                        &stride);
 
 		if (FAILED(hr))
@@ -428,7 +424,8 @@ error:
 	return -1;
 }
 
-static int mf_compress(H264_CONTEXT* h264, const BYTE** ppSrcYuv, const UINT32* pStride, BYTE** ppDstData, UINT32* pDstSize)
+static int mf_compress(H264_CONTEXT* h264, const BYTE** ppSrcYuv, const UINT32* pStride,
+                       BYTE** ppDstData, UINT32* pDstSize)
 {
 	H264_CONTEXT_MF* sys = (H264_CONTEXT_MF*) h264->pSystemData;
 	return 1;
@@ -533,16 +530,17 @@ static BOOL mf_init(H264_CONTEXT* h264)
 			goto error;
 		}
 
-		hr = CoCreateInstance(&CLSID_CMSH264DecoderMFT, NULL, CLSCTX_INPROC_SERVER,
-		                      &IID_IMFTransform, (void**) &sys->transform);
+		hr = CoCreateInstance(&sCLSID_CMSH264DecoderMFT, NULL, CLSCTX_INPROC_SERVER,
+		                      &sIID_IMFTransform, (void**) &sys->transform);
 
 		if (FAILED(hr))
 		{
-			WLog_Print(h264->log, WLOG_ERROR, "CoCreateInstance(CLSID_CMSH264DecoderMFT) failure: 0x%08"PRIX32"", hr);
+			WLog_Print(h264->log, WLOG_ERROR,
+			           "CoCreateInstance(CLSID_CMSH264DecoderMFT) failure: 0x%08"PRIX32"", hr);
 			goto error;
 		}
 
-		hr = sys->transform->lpVtbl->QueryInterface(sys->transform, &IID_ICodecAPI,
+		hr = sys->transform->lpVtbl->QueryInterface(sys->transform, &sIID_ICodecAPI,
 		        (void**) &sys->codecApi);
 
 		if (FAILED(hr))
@@ -553,7 +551,7 @@ static BOOL mf_init(H264_CONTEXT* h264)
 
 		var.vt = VT_UI4;
 		var.ulVal = 1;
-		hr = sys->codecApi->lpVtbl->SetValue(sys->codecApi, &CODECAPI_AVLowLatencyMode,
+		hr = sys->codecApi->lpVtbl->SetValue(sys->codecApi, &sCODECAPI_AVLowLatencyMode,
 		                                     &var);
 
 		if (FAILED(hr))
@@ -570,8 +568,8 @@ static BOOL mf_init(H264_CONTEXT* h264)
 			goto error;
 		}
 
-		hr = sys->inputType->lpVtbl->SetGUID(sys->inputType, &MF_MT_MAJOR_TYPE,
-		                                     &MFMediaType_Video);
+		hr = sys->inputType->lpVtbl->SetGUID(sys->inputType, &sMF_MT_MAJOR_TYPE,
+		                                     &sMFMediaType_Video);
 
 		if (FAILED(hr))
 		{
@@ -579,8 +577,8 @@ static BOOL mf_init(H264_CONTEXT* h264)
 			goto error;
 		}
 
-		hr = sys->inputType->lpVtbl->SetGUID(sys->inputType, &MF_MT_SUBTYPE,
-		                                     &MFVideoFormat_H264);
+		hr = sys->inputType->lpVtbl->SetGUID(sys->inputType, &sMF_MT_SUBTYPE,
+		                                     &sMFVideoFormat_H264);
 
 		if (FAILED(hr))
 		{
@@ -596,7 +594,7 @@ static BOOL mf_init(H264_CONTEXT* h264)
 			goto error;
 		}
 
-		hr = mf_find_output_type(sys, &MFVideoFormat_IYUV, &sys->outputType);
+		hr = mf_find_output_type(sys, &sMFVideoFormat_IYUV, &sys->outputType);
 
 		if (FAILED(hr))
 		{

--- a/winpr/libwinpr/pool/cleanup_group.c
+++ b/winpr/libwinpr/pool/cleanup_group.c
@@ -61,6 +61,7 @@ PTP_CLEANUP_GROUP winpr_CreateThreadpoolCleanupGroup(void)
 	if (pCreateThreadpoolCleanupGroup)
 		return pCreateThreadpoolCleanupGroup();
 
+	return cleanupGroup;
 #else
 	cleanupGroup = (PTP_CLEANUP_GROUP) calloc(1, sizeof(TP_CLEANUP_GROUP));
 


### PR DESCRIPTION
* Declare all `UUID` values static to avoid collissions
* Fix return warning