### PR TITLE
Fixed #4436: double free of http response.

### DIFF
--- a/libfreerdp/core/gateway/http.c
+++ b/libfreerdp/core/gateway/http.c
@@ -517,8 +517,6 @@ static BOOL http_response_parse_header_field(HttpResponse* response, const char*
 
 			if (!authScheme || !authValue)
 				return FALSE;
-
-			*separator = ' ';
 		}
 		else
 		{

--- a/libfreerdp/core/gateway/rpc_client.c
+++ b/libfreerdp/core/gateway/rpc_client.c
@@ -531,7 +531,6 @@ static int rpc_client_default_out_channel_recv(rdpRpc* rpc)
 		{
 			WLog_ERR(TAG, "error! Status Code: %"PRIu32"", statusCode);
 			http_response_print(response);
-			http_response_free(response);
 
 			if (statusCode == HTTP_STATUS_DENIED)
 			{


### PR DESCRIPTION
Fixed #4436: reset of token split.
