### PR TITLE
Disable unused variable warning from profiler.

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_codec.c
+++ b/channels/rdpgfx/client/rdpgfx_codec.c
@@ -274,7 +274,7 @@ UINT rdpgfx_decode(RDPGFX_PLUGIN* gfx, RDPGFX_SURFACE_COMMAND* cmd)
 {
 	UINT error = CHANNEL_RC_OK;
 	RdpgfxClientContext* context = (RdpgfxClientContext*) gfx->iface.pInterface;
-	PROFILER_ENTER(context->SurfaceProfiler);
+	PROFILER_ENTER(context->SurfaceProfiler)
 
 	switch (cmd->codecId)
 	{
@@ -303,6 +303,6 @@ UINT rdpgfx_decode(RDPGFX_PLUGIN* gfx, RDPGFX_SURFACE_COMMAND* cmd)
 			break;
 	}
 
-	PROFILER_EXIT(context->SurfaceProfiler);
+	PROFILER_EXIT(context->SurfaceProfiler)
 	return error;
 }

--- a/include/freerdp/client/rdpgfx.h
+++ b/include/freerdp/client/rdpgfx.h
@@ -111,7 +111,7 @@ struct _rdpgfx_client_context
 	pcRdpgfxUpdateSurfaces UpdateSurfaces;
 	pcRdpgfxUpdateSurfaceArea UpdateSurfaceArea;
 
-	PROFILER_DEFINE(SurfaceProfiler);
+	PROFILER_DEFINE(SurfaceProfiler)
 };
 
 #endif /* FREERDP_CHANNEL_RDPGFX_CLIENT_RDPGFX_H */

--- a/include/freerdp/utils/profiler.h
+++ b/include/freerdp/utils/profiler.h
@@ -50,24 +50,25 @@ FREERDP_API void profiler_print_footer(void);
 
 #ifdef WITH_PROFILER
 #define IF_PROFILER(then)			then
-#define PROFILER_DEFINE(prof)		PROFILER* prof
-#define PROFILER_CREATE(prof,name)	prof = profiler_create(name)
-#define PROFILER_FREE(prof)			profiler_free(prof)
-#define PROFILER_ENTER(prof)		profiler_enter(prof)
-#define PROFILER_EXIT(prof)			profiler_exit(prof)
-#define PROFILER_PRINT_HEADER		profiler_print_header()
-#define PROFILER_PRINT(prof)		profiler_print(prof)
-#define PROFILER_PRINT_FOOTER		profiler_print_footer()
+#define PROFILER_DEFINE(prof)		PROFILER* prof;
+#define PROFILER_CREATE(prof,name)	prof = profiler_create(name);
+#define PROFILER_FREE(prof)			profiler_free(prof);
+#define PROFILER_ENTER(prof)		profiler_enter(prof);
+#define PROFILER_EXIT(prof)			profiler_exit(prof);
+#define PROFILER_PRINT_HEADER		profiler_print_header();
+#define PROFILER_PRINT(prof)		profiler_print(prof);
+#define PROFILER_PRINT_FOOTER		profiler_print_footer();
 #else
 #define IF_PROFILER(then)		do { } while (0)
-#define PROFILER_DEFINE(prof)		void* prof
-#define PROFILER_CREATE(prof,name)	do { } while (0)
-#define PROFILER_FREE(prof)		do { } while (0)
-#define PROFILER_ENTER(prof)		do { } while (0)
-#define PROFILER_EXIT(prof)		do { } while (0)
-#define PROFILER_PRINT_HEADER		do { } while (0)
-#define PROFILER_PRINT(prof)		do { } while (0)
-#define PROFILER_PRINT_FOOTER		do { } while (0)
+
+#define PROFILER_DEFINE(prof)
+#define PROFILER_CREATE(prof,name)	do { } while (0);
+#define PROFILER_FREE(prof)		do { } while (0);
+#define PROFILER_ENTER(prof)		do { } while (0);
+#define PROFILER_EXIT(prof)		do { } while (0);
+#define PROFILER_PRINT_HEADER		do { } while (0);
+#define PROFILER_PRINT(prof)		do { } while (0);
+#define PROFILER_PRINT_FOOTER		do { } while (0);
 #endif
 
 #endif /* FREERDP_UTILS_PROFILER_H */

--- a/libfreerdp/codec/nsc.c
+++ b/libfreerdp/codec/nsc.c
@@ -250,12 +250,12 @@ static BOOL nsc_context_initialize(NSC_CONTEXT* context, wStream* s)
 
 static void nsc_profiler_print(NSC_CONTEXT* context)
 {
-	PROFILER_PRINT_HEADER;
-	PROFILER_PRINT(context->priv->prof_nsc_rle_decompress_data);
-	PROFILER_PRINT(context->priv->prof_nsc_decode);
-	PROFILER_PRINT(context->priv->prof_nsc_rle_compress_data);
-	PROFILER_PRINT(context->priv->prof_nsc_encode);
-	PROFILER_PRINT_FOOTER;
+	PROFILER_PRINT_HEADER
+	PROFILER_PRINT(context->priv->prof_nsc_rle_decompress_data)
+	PROFILER_PRINT(context->priv->prof_nsc_decode)
+	PROFILER_PRINT(context->priv->prof_nsc_rle_compress_data)
+	PROFILER_PRINT(context->priv->prof_nsc_encode)
+	PROFILER_PRINT_FOOTER
 }
 
 BOOL nsc_context_reset(NSC_CONTEXT* context, UINT32 width, UINT32 height)
@@ -293,11 +293,11 @@ NSC_CONTEXT* nsc_context_new(void)
 		goto error_PlanePool;
 
 	PROFILER_CREATE(context->priv->prof_nsc_rle_decompress_data,
-	                "nsc_rle_decompress_data");
-	PROFILER_CREATE(context->priv->prof_nsc_decode, "nsc_decode");
+	                "nsc_rle_decompress_data")
+	PROFILER_CREATE(context->priv->prof_nsc_decode, "nsc_decode")
 	PROFILER_CREATE(context->priv->prof_nsc_rle_compress_data,
-	                "nsc_rle_compress_data");
-	PROFILER_CREATE(context->priv->prof_nsc_encode, "nsc_encode");
+	                "nsc_rle_compress_data")
+	PROFILER_CREATE(context->priv->prof_nsc_encode, "nsc_encode")
 	/* Default encoding parameters */
 	context->ColorLossLevel = 3;
 	context->ChromaSubsamplingLevel = 1;
@@ -327,10 +327,10 @@ void nsc_context_free(NSC_CONTEXT* context)
 	free(context->BitmapData);
 	BufferPool_Free(context->priv->PlanePool);
 	nsc_profiler_print(context);
-	PROFILER_FREE(context->priv->prof_nsc_rle_decompress_data);
-	PROFILER_FREE(context->priv->prof_nsc_decode);
-	PROFILER_FREE(context->priv->prof_nsc_rle_compress_data);
-	PROFILER_FREE(context->priv->prof_nsc_encode);
+	PROFILER_FREE(context->priv->prof_nsc_rle_decompress_data)
+	PROFILER_FREE(context->priv->prof_nsc_decode)
+	PROFILER_FREE(context->priv->prof_nsc_rle_compress_data)
+	PROFILER_FREE(context->priv->prof_nsc_encode)
 	free(context->priv);
 	free(context);
 }
@@ -397,13 +397,13 @@ BOOL nsc_process_message(NSC_CONTEXT* context, UINT16 bpp,
 		return FALSE;
 
 	/* RLE decode */
-	PROFILER_ENTER(context->priv->prof_nsc_rle_decompress_data);
+	PROFILER_ENTER(context->priv->prof_nsc_rle_decompress_data)
 	nsc_rle_decompress_data(context);
-	PROFILER_EXIT(context->priv->prof_nsc_rle_decompress_data);
+	PROFILER_EXIT(context->priv->prof_nsc_rle_decompress_data)
 	/* Colorloss recover, Chroma supersample and AYCoCg to ARGB Conversion in one step */
-	PROFILER_ENTER(context->priv->prof_nsc_decode);
+	PROFILER_ENTER(context->priv->prof_nsc_decode)
 	context->decode(context);
-	PROFILER_EXIT(context->priv->prof_nsc_decode);
+	PROFILER_EXIT(context->priv->prof_nsc_decode)
 
 	if (!freerdp_image_copy(pDstData, DstFormat, nDstStride, nXDst, nYDst,
 	                        width, height, context->BitmapData,

--- a/libfreerdp/codec/nsc_encode.c
+++ b/libfreerdp/codec/nsc_encode.c
@@ -494,12 +494,12 @@ NSC_MESSAGE* nsc_encode_messages(NSC_CONTEXT* context, const BYTE* data,
 		context->priv->PlaneBuffers[4] = messages[i].PlaneBuffers[4];
 		dataOffset = (messages[i].y * messages[i].scanline) + (messages[i].x *
 		             BytesPerPixel);
-		PROFILER_ENTER(context->priv->prof_nsc_encode);
+		PROFILER_ENTER(context->priv->prof_nsc_encode)
 		context->encode(context, &data[dataOffset], scanline);
-		PROFILER_EXIT(context->priv->prof_nsc_encode);
-		PROFILER_ENTER(context->priv->prof_nsc_rle_compress_data);
+		PROFILER_EXIT(context->priv->prof_nsc_encode)
+		PROFILER_ENTER(context->priv->prof_nsc_rle_compress_data)
 		nsc_rle_compress_data(context);
-		PROFILER_EXIT(context->priv->prof_nsc_rle_compress_data);
+		PROFILER_EXIT(context->priv->prof_nsc_rle_compress_data)
 		messages[i].LumaPlaneByteCount = context->PlaneByteCount[0];
 		messages[i].OrangeChromaPlaneByteCount = context->PlaneByteCount[1];
 		messages[i].GreenChromaPlaneByteCount = context->PlaneByteCount[2];
@@ -582,13 +582,13 @@ BOOL nsc_compose_message(NSC_CONTEXT* context, wStream* s, const BYTE* data,
 		return FALSE;
 
 	/* ARGB to AYCoCg conversion, chroma subsampling and colorloss reduction */
-	PROFILER_ENTER(context->priv->prof_nsc_encode);
+	PROFILER_ENTER(context->priv->prof_nsc_encode)
 	context->encode(context, data, scanline);
-	PROFILER_EXIT(context->priv->prof_nsc_encode);
+	PROFILER_EXIT(context->priv->prof_nsc_encode)
 	/* RLE encode */
-	PROFILER_ENTER(context->priv->prof_nsc_rle_compress_data);
+	PROFILER_ENTER(context->priv->prof_nsc_rle_compress_data)
 	nsc_rle_compress_data(context);
-	PROFILER_EXIT(context->priv->prof_nsc_rle_compress_data);
+	PROFILER_EXIT(context->priv->prof_nsc_rle_compress_data)
 	message->PlaneBuffers[0] = context->priv->PlaneBuffers[0];
 	message->PlaneBuffers[1] = context->priv->PlaneBuffers[1];
 	message->PlaneBuffers[2] = context->priv->PlaneBuffers[2];

--- a/libfreerdp/codec/nsc_types.h
+++ b/libfreerdp/codec/nsc_types.h
@@ -45,10 +45,10 @@ struct _NSC_CONTEXT_PRIV
 	UINT32 PlaneBuffersLength;	/* Lengths of each plane buffer */
 
 	/* profilers */
-	PROFILER_DEFINE(prof_nsc_rle_decompress_data);
-	PROFILER_DEFINE(prof_nsc_decode);
-	PROFILER_DEFINE(prof_nsc_rle_compress_data);
-	PROFILER_DEFINE(prof_nsc_encode);
+	PROFILER_DEFINE(prof_nsc_rle_decompress_data)
+	PROFILER_DEFINE(prof_nsc_decode)
+	PROFILER_DEFINE(prof_nsc_rle_compress_data)
+	PROFILER_DEFINE(prof_nsc_encode)
 };
 
 #endif /* FREERDP_LIB_CODEC_NSC_TYPES_H */

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -81,68 +81,68 @@ static const UINT32 rfx_default_quantization_values[] =
 
 static void rfx_profiler_create(RFX_CONTEXT* context)
 {
-	PROFILER_CREATE(context->priv->prof_rfx_decode_rgb, "rfx_decode_rgb");
+	PROFILER_CREATE(context->priv->prof_rfx_decode_rgb, "rfx_decode_rgb")
 	PROFILER_CREATE(context->priv->prof_rfx_decode_component,
-	                "rfx_decode_component");
-	PROFILER_CREATE(context->priv->prof_rfx_rlgr_decode, "rfx_rlgr_decode");
+	                "rfx_decode_component")
+	PROFILER_CREATE(context->priv->prof_rfx_rlgr_decode, "rfx_rlgr_decode")
 	PROFILER_CREATE(context->priv->prof_rfx_differential_decode,
-	                "rfx_differential_decode");
+	                "rfx_differential_decode")
 	PROFILER_CREATE(context->priv->prof_rfx_quantization_decode,
-	                "rfx_quantization_decode");
-	PROFILER_CREATE(context->priv->prof_rfx_dwt_2d_decode, "rfx_dwt_2d_decode");
-	PROFILER_CREATE(context->priv->prof_rfx_ycbcr_to_rgb, "prims->yCbCrToRGB");
-	PROFILER_CREATE(context->priv->prof_rfx_encode_rgb, "rfx_encode_rgb");
+	                "rfx_quantization_decode")
+	PROFILER_CREATE(context->priv->prof_rfx_dwt_2d_decode, "rfx_dwt_2d_decode")
+	PROFILER_CREATE(context->priv->prof_rfx_ycbcr_to_rgb, "prims->yCbCrToRGB")
+	PROFILER_CREATE(context->priv->prof_rfx_encode_rgb, "rfx_encode_rgb")
 	PROFILER_CREATE(context->priv->prof_rfx_encode_component,
-	                "rfx_encode_component");
-	PROFILER_CREATE(context->priv->prof_rfx_rlgr_encode, "rfx_rlgr_encode");
+	                "rfx_encode_component")
+	PROFILER_CREATE(context->priv->prof_rfx_rlgr_encode, "rfx_rlgr_encode")
 	PROFILER_CREATE(context->priv->prof_rfx_differential_encode,
-	                "rfx_differential_encode");
+	                "rfx_differential_encode")
 	PROFILER_CREATE(context->priv->prof_rfx_quantization_encode,
-	                "rfx_quantization_encode");
-	PROFILER_CREATE(context->priv->prof_rfx_dwt_2d_encode, "rfx_dwt_2d_encode");
-	PROFILER_CREATE(context->priv->prof_rfx_rgb_to_ycbcr, "prims->RGBToYCbCr");
+	                "rfx_quantization_encode")
+	PROFILER_CREATE(context->priv->prof_rfx_dwt_2d_encode, "rfx_dwt_2d_encode")
+	PROFILER_CREATE(context->priv->prof_rfx_rgb_to_ycbcr, "prims->RGBToYCbCr")
 	PROFILER_CREATE(context->priv->prof_rfx_encode_format_rgb,
-	                "rfx_encode_format_rgb");
+	                "rfx_encode_format_rgb")
 }
 
 static void rfx_profiler_free(RFX_CONTEXT* context)
 {
-	PROFILER_FREE(context->priv->prof_rfx_decode_rgb);
-	PROFILER_FREE(context->priv->prof_rfx_decode_component);
-	PROFILER_FREE(context->priv->prof_rfx_rlgr_decode);
-	PROFILER_FREE(context->priv->prof_rfx_differential_decode);
-	PROFILER_FREE(context->priv->prof_rfx_quantization_decode);
-	PROFILER_FREE(context->priv->prof_rfx_dwt_2d_decode);
-	PROFILER_FREE(context->priv->prof_rfx_ycbcr_to_rgb);
-	PROFILER_FREE(context->priv->prof_rfx_encode_rgb);
-	PROFILER_FREE(context->priv->prof_rfx_encode_component);
-	PROFILER_FREE(context->priv->prof_rfx_rlgr_encode);
-	PROFILER_FREE(context->priv->prof_rfx_differential_encode);
-	PROFILER_FREE(context->priv->prof_rfx_quantization_encode);
-	PROFILER_FREE(context->priv->prof_rfx_dwt_2d_encode);
-	PROFILER_FREE(context->priv->prof_rfx_rgb_to_ycbcr);
-	PROFILER_FREE(context->priv->prof_rfx_encode_format_rgb);
+	PROFILER_FREE(context->priv->prof_rfx_decode_rgb)
+	PROFILER_FREE(context->priv->prof_rfx_decode_component)
+	PROFILER_FREE(context->priv->prof_rfx_rlgr_decode)
+	PROFILER_FREE(context->priv->prof_rfx_differential_decode)
+	PROFILER_FREE(context->priv->prof_rfx_quantization_decode)
+	PROFILER_FREE(context->priv->prof_rfx_dwt_2d_decode)
+	PROFILER_FREE(context->priv->prof_rfx_ycbcr_to_rgb)
+	PROFILER_FREE(context->priv->prof_rfx_encode_rgb)
+	PROFILER_FREE(context->priv->prof_rfx_encode_component)
+	PROFILER_FREE(context->priv->prof_rfx_rlgr_encode)
+	PROFILER_FREE(context->priv->prof_rfx_differential_encode)
+	PROFILER_FREE(context->priv->prof_rfx_quantization_encode)
+	PROFILER_FREE(context->priv->prof_rfx_dwt_2d_encode)
+	PROFILER_FREE(context->priv->prof_rfx_rgb_to_ycbcr)
+	PROFILER_FREE(context->priv->prof_rfx_encode_format_rgb)
 }
 
 static void rfx_profiler_print(RFX_CONTEXT* context)
 {
-	PROFILER_PRINT_HEADER;
-	PROFILER_PRINT(context->priv->prof_rfx_decode_rgb);
-	PROFILER_PRINT(context->priv->prof_rfx_decode_component);
-	PROFILER_PRINT(context->priv->prof_rfx_rlgr_decode);
-	PROFILER_PRINT(context->priv->prof_rfx_differential_decode);
-	PROFILER_PRINT(context->priv->prof_rfx_quantization_decode);
-	PROFILER_PRINT(context->priv->prof_rfx_dwt_2d_decode);
-	PROFILER_PRINT(context->priv->prof_rfx_ycbcr_to_rgb);
-	PROFILER_PRINT(context->priv->prof_rfx_encode_rgb);
-	PROFILER_PRINT(context->priv->prof_rfx_encode_component);
-	PROFILER_PRINT(context->priv->prof_rfx_rlgr_encode);
-	PROFILER_PRINT(context->priv->prof_rfx_differential_encode);
-	PROFILER_PRINT(context->priv->prof_rfx_quantization_encode);
-	PROFILER_PRINT(context->priv->prof_rfx_dwt_2d_encode);
-	PROFILER_PRINT(context->priv->prof_rfx_rgb_to_ycbcr);
-	PROFILER_PRINT(context->priv->prof_rfx_encode_format_rgb);
-	PROFILER_PRINT_FOOTER;
+	PROFILER_PRINT_HEADER
+	PROFILER_PRINT(context->priv->prof_rfx_decode_rgb)
+	PROFILER_PRINT(context->priv->prof_rfx_decode_component)
+	PROFILER_PRINT(context->priv->prof_rfx_rlgr_decode)
+	PROFILER_PRINT(context->priv->prof_rfx_differential_decode)
+	PROFILER_PRINT(context->priv->prof_rfx_quantization_decode)
+	PROFILER_PRINT(context->priv->prof_rfx_dwt_2d_decode)
+	PROFILER_PRINT(context->priv->prof_rfx_ycbcr_to_rgb)
+	PROFILER_PRINT(context->priv->prof_rfx_encode_rgb)
+	PROFILER_PRINT(context->priv->prof_rfx_encode_component)
+	PROFILER_PRINT(context->priv->prof_rfx_rlgr_encode)
+	PROFILER_PRINT(context->priv->prof_rfx_differential_encode)
+	PROFILER_PRINT(context->priv->prof_rfx_quantization_encode)
+	PROFILER_PRINT(context->priv->prof_rfx_dwt_2d_encode)
+	PROFILER_PRINT(context->priv->prof_rfx_rgb_to_ycbcr)
+	PROFILER_PRINT(context->priv->prof_rfx_encode_format_rgb)
+	PROFILER_PRINT_FOOTER
 }
 
 static void rfx_tile_init(RFX_TILE* tile)

--- a/libfreerdp/codec/rfx_decode.c
+++ b/libfreerdp/codec/rfx_decode.c
@@ -43,20 +43,20 @@ static void rfx_decode_component(RFX_CONTEXT* context,
 {
 	INT16* dwt_buffer;
 	dwt_buffer = BufferPool_Take(context->priv->BufferPool, -1); /* dwt_buffer */
-	PROFILER_ENTER(context->priv->prof_rfx_decode_component);
-	PROFILER_ENTER(context->priv->prof_rfx_rlgr_decode);
+	PROFILER_ENTER(context->priv->prof_rfx_decode_component)
+	PROFILER_ENTER(context->priv->prof_rfx_rlgr_decode)
 	context->rlgr_decode(context->mode, data, size, buffer, 4096);
-	PROFILER_EXIT(context->priv->prof_rfx_rlgr_decode);
-	PROFILER_ENTER(context->priv->prof_rfx_differential_decode);
+	PROFILER_EXIT(context->priv->prof_rfx_rlgr_decode)
+	PROFILER_ENTER(context->priv->prof_rfx_differential_decode)
 	rfx_differential_decode(buffer + 4032, 64);
-	PROFILER_EXIT(context->priv->prof_rfx_differential_decode);
-	PROFILER_ENTER(context->priv->prof_rfx_quantization_decode);
+	PROFILER_EXIT(context->priv->prof_rfx_differential_decode)
+	PROFILER_ENTER(context->priv->prof_rfx_quantization_decode)
 	context->quantization_decode(buffer, quantization_values);
-	PROFILER_EXIT(context->priv->prof_rfx_quantization_decode);
-	PROFILER_ENTER(context->priv->prof_rfx_dwt_2d_decode);
+	PROFILER_EXIT(context->priv->prof_rfx_quantization_decode)
+	PROFILER_ENTER(context->priv->prof_rfx_dwt_2d_decode)
 	context->dwt_2d_decode(buffer, dwt_buffer);
-	PROFILER_EXIT(context->priv->prof_rfx_dwt_2d_decode);
-	PROFILER_EXIT(context->priv->prof_rfx_decode_component);
+	PROFILER_EXIT(context->priv->prof_rfx_dwt_2d_decode)
+	PROFILER_EXIT(context->priv->prof_rfx_decode_component)
 	BufferPool_Return(context->priv->BufferPool, dwt_buffer);
 }
 
@@ -72,7 +72,7 @@ BOOL rfx_decode_rgb(RFX_CONTEXT* context, RFX_TILE* tile, BYTE* rgb_buffer,
 	UINT32* y_quants, *cb_quants, *cr_quants;
 	static const prim_size_t roi_64x64 = { 64, 64 };
 	const primitives_t* prims = primitives_get();
-	PROFILER_ENTER(context->priv->prof_rfx_decode_rgb);
+	PROFILER_ENTER(context->priv->prof_rfx_decode_rgb)
 	y_quants = context->quants + (tile->quantIdxY * 10);
 	cb_quants = context->quants + (tile->quantIdxCb * 10);
 	cr_quants = context->quants + (tile->quantIdxCr * 10);
@@ -89,14 +89,14 @@ BOOL rfx_decode_rgb(RFX_CONTEXT* context, RFX_TILE* tile, BYTE* rgb_buffer,
 	                     pSrcDst[1]); /* CbData */
 	rfx_decode_component(context, cr_quants, tile->CrData, tile->CrLen,
 	                     pSrcDst[2]); /* CrData */
-	PROFILER_ENTER(context->priv->prof_rfx_ycbcr_to_rgb);
+	PROFILER_ENTER(context->priv->prof_rfx_ycbcr_to_rgb)
 
 	if (prims->yCbCrToRGB_16s8u_P3AC4R((const INT16**)pSrcDst, 64 * sizeof(INT16),
 	                                   rgb_buffer, stride, context->pixel_format, &roi_64x64) != PRIMITIVES_SUCCESS)
 		rc = FALSE;
 
-	PROFILER_EXIT(context->priv->prof_rfx_ycbcr_to_rgb);
-	PROFILER_EXIT(context->priv->prof_rfx_decode_rgb);
+	PROFILER_EXIT(context->priv->prof_rfx_ycbcr_to_rgb)
+	PROFILER_EXIT(context->priv->prof_rfx_decode_rgb)
 	BufferPool_Return(context->priv->BufferPool, pBuffer);
 	return rc;
 }

--- a/libfreerdp/codec/rfx_encode.c
+++ b/libfreerdp/codec/rfx_encode.c
@@ -238,20 +238,20 @@ static void rfx_encode_component(RFX_CONTEXT* context,
 {
 	INT16* dwt_buffer;
 	dwt_buffer = BufferPool_Take(context->priv->BufferPool, -1); /* dwt_buffer */
-	PROFILER_ENTER(context->priv->prof_rfx_encode_component);
-	PROFILER_ENTER(context->priv->prof_rfx_dwt_2d_encode);
+	PROFILER_ENTER(context->priv->prof_rfx_encode_component)
+	PROFILER_ENTER(context->priv->prof_rfx_dwt_2d_encode)
 	context->dwt_2d_encode(data, dwt_buffer);
-	PROFILER_EXIT(context->priv->prof_rfx_dwt_2d_encode);
-	PROFILER_ENTER(context->priv->prof_rfx_quantization_encode);
+	PROFILER_EXIT(context->priv->prof_rfx_dwt_2d_encode)
+	PROFILER_ENTER(context->priv->prof_rfx_quantization_encode)
 	context->quantization_encode(data, quantization_values);
-	PROFILER_EXIT(context->priv->prof_rfx_quantization_encode);
-	PROFILER_ENTER(context->priv->prof_rfx_differential_encode);
+	PROFILER_EXIT(context->priv->prof_rfx_quantization_encode)
+	PROFILER_ENTER(context->priv->prof_rfx_differential_encode)
 	rfx_differential_encode(data + 4032, 64);
-	PROFILER_EXIT(context->priv->prof_rfx_differential_encode);
-	PROFILER_ENTER(context->priv->prof_rfx_rlgr_encode);
+	PROFILER_EXIT(context->priv->prof_rfx_differential_encode)
+	PROFILER_ENTER(context->priv->prof_rfx_rlgr_encode)
 	*size = context->rlgr_encode(context->mode, data, 4096, buffer, buffer_size);
-	PROFILER_EXIT(context->priv->prof_rfx_rlgr_encode);
-	PROFILER_EXIT(context->priv->prof_rfx_encode_component);
+	PROFILER_EXIT(context->priv->prof_rfx_rlgr_encode)
+	PROFILER_EXIT(context->priv->prof_rfx_encode_component)
 	BufferPool_Return(context->priv->BufferPool, dwt_buffer);
 }
 
@@ -277,15 +277,15 @@ void rfx_encode_rgb(RFX_CONTEXT* context, RFX_TILE* tile)
 	                                       16])); /* cb_g_buffer */
 	pSrcDst[2] = (INT16*)((BYTE*)(&pBuffer[((8192 + 32) * 2) +
 	                                       16])); /* cr_b_buffer */
-	PROFILER_ENTER(context->priv->prof_rfx_encode_rgb);
-	PROFILER_ENTER(context->priv->prof_rfx_encode_format_rgb);
+	PROFILER_ENTER(context->priv->prof_rfx_encode_rgb)
+	PROFILER_ENTER(context->priv->prof_rfx_encode_format_rgb)
 	rfx_encode_format_rgb(tile->data, tile->width, tile->height, tile->scanline,
 	                      context->pixel_format, context->palette, pSrcDst[0], pSrcDst[1], pSrcDst[2]);
-	PROFILER_EXIT(context->priv->prof_rfx_encode_format_rgb);
-	PROFILER_ENTER(context->priv->prof_rfx_rgb_to_ycbcr);
+	PROFILER_EXIT(context->priv->prof_rfx_encode_format_rgb)
+	PROFILER_ENTER(context->priv->prof_rfx_rgb_to_ycbcr)
 	prims->RGBToYCbCr_16s16s_P3P3((const INT16**) pSrcDst, 64 * sizeof(INT16),
 	                              pSrcDst, 64 * sizeof(INT16), &roi_64x64);
-	PROFILER_EXIT(context->priv->prof_rfx_rgb_to_ycbcr);
+	PROFILER_EXIT(context->priv->prof_rfx_rgb_to_ycbcr)
 	/**
 	 * We need to clear the buffers as the RLGR encoder expects it to be initialized to zero.
 	 * This allows simplifying and improving the performance of the encoding process.
@@ -299,6 +299,6 @@ void rfx_encode_rgb(RFX_CONTEXT* context, RFX_TILE* tile)
 	tile->YLen = (UINT16) YLen;
 	tile->CbLen = (UINT16) CbLen;
 	tile->CrLen = (UINT16) CrLen;
-	PROFILER_EXIT(context->priv->prof_rfx_encode_rgb);
+	PROFILER_EXIT(context->priv->prof_rfx_encode_rgb)
 	BufferPool_Return(context->priv->BufferPool, pBuffer);
 }

--- a/libfreerdp/codec/rfx_types.h
+++ b/libfreerdp/codec/rfx_types.h
@@ -59,22 +59,22 @@ struct _RFX_CONTEXT_PRIV
 	wBufferPool* BufferPool;
 
 	/* profilers */
-	PROFILER_DEFINE(prof_rfx_decode_rgb);
-	PROFILER_DEFINE(prof_rfx_decode_component);
-	PROFILER_DEFINE(prof_rfx_rlgr_decode);
-	PROFILER_DEFINE(prof_rfx_differential_decode);
-	PROFILER_DEFINE(prof_rfx_quantization_decode);
-	PROFILER_DEFINE(prof_rfx_dwt_2d_decode);
-	PROFILER_DEFINE(prof_rfx_ycbcr_to_rgb);
+	PROFILER_DEFINE(prof_rfx_decode_rgb)
+	PROFILER_DEFINE(prof_rfx_decode_component)
+	PROFILER_DEFINE(prof_rfx_rlgr_decode)
+	PROFILER_DEFINE(prof_rfx_differential_decode)
+	PROFILER_DEFINE(prof_rfx_quantization_decode)
+	PROFILER_DEFINE(prof_rfx_dwt_2d_decode)
+	PROFILER_DEFINE(prof_rfx_ycbcr_to_rgb)
 
-	PROFILER_DEFINE(prof_rfx_encode_rgb);
-	PROFILER_DEFINE(prof_rfx_encode_component);
-	PROFILER_DEFINE(prof_rfx_rlgr_encode);
-	PROFILER_DEFINE(prof_rfx_differential_encode);
-	PROFILER_DEFINE(prof_rfx_quantization_encode);
-	PROFILER_DEFINE(prof_rfx_dwt_2d_encode);
-	PROFILER_DEFINE(prof_rfx_rgb_to_ycbcr);
-	PROFILER_DEFINE(prof_rfx_encode_format_rgb);
+	PROFILER_DEFINE(prof_rfx_encode_rgb)
+	PROFILER_DEFINE(prof_rfx_encode_component)
+	PROFILER_DEFINE(prof_rfx_rlgr_encode)
+	PROFILER_DEFINE(prof_rfx_differential_encode)
+	PROFILER_DEFINE(prof_rfx_quantization_encode)
+	PROFILER_DEFINE(prof_rfx_dwt_2d_encode)
+	PROFILER_DEFINE(prof_rfx_rgb_to_ycbcr)
+	PROFILER_DEFINE(prof_rfx_encode_format_rgb)
 };
 
 #endif /* FREERDP_LIB_CODEC_RFX_TYPES_H */

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -1159,16 +1159,16 @@ void gdi_graphics_pipeline_init(rdpGdi* gdi, RdpgfxClientContext* gfx)
 	gfx->MapSurfaceToOutput = gdi_MapSurfaceToOutput;
 	gfx->MapSurfaceToWindow = gdi_MapSurfaceToWindow;
 	gfx->UpdateSurfaces = gdi_UpdateSurfaces;
-	PROFILER_CREATE(gfx->SurfaceProfiler, "GFX-PROFILER");
+	PROFILER_CREATE(gfx->SurfaceProfiler, "GFX-PROFILER")
 }
 
 void gdi_graphics_pipeline_uninit(rdpGdi* gdi, RdpgfxClientContext* gfx)
 {
 	gdi->gfx = NULL;
 	gfx->custom = NULL;
-	PROFILER_PRINT_HEADER;
-	PROFILER_PRINT(gfx->SurfaceProfiler);
-	PROFILER_PRINT_FOOTER;
-	PROFILER_FREE(gfx->SurfaceProfiler);
+	PROFILER_PRINT_HEADER
+	PROFILER_PRINT(gfx->SurfaceProfiler)
+	PROFILER_PRINT_FOOTER
+	PROFILER_FREE(gfx->SurfaceProfiler)
 }
 

--- a/libfreerdp/primitives/test/TestPrimitivesColors.c
+++ b/libfreerdp/primitives/test/TestPrimitivesColors.c
@@ -34,10 +34,10 @@ static BOOL test_RGBToRGB_16s8u_P3AC4R_func(prim_size_t roi, DWORD DstFormat)
 	const INT16* ptrs[3];
 	const UINT32 rgbStride = roi.width * 2;
 	const UINT32 dstStride = roi.width * 4;
-	PROFILER_DEFINE(genericProf);
-	PROFILER_DEFINE(optProf);
-	PROFILER_CREATE(genericProf, "RGBToRGB_16s8u_P3AC4R-GENERIC");
-	PROFILER_CREATE(optProf, "RGBToRGB_16s8u_P3AC4R-OPTIMIZED");
+	PROFILER_DEFINE(genericProf)
+	PROFILER_DEFINE(optProf)
+	PROFILER_CREATE(genericProf, "RGBToRGB_16s8u_P3AC4R-GENERIC")
+	PROFILER_CREATE(optProf, "RGBToRGB_16s8u_P3AC4R-OPTIMIZED")
 	r = _aligned_malloc(rgbStride * roi.height, 16);
 	g = _aligned_malloc(rgbStride * roi.height, 16);
 	b = _aligned_malloc(rgbStride * roi.height, 16);
@@ -69,22 +69,22 @@ static BOOL test_RGBToRGB_16s8u_P3AC4R_func(prim_size_t roi, DWORD DstFormat)
 	ptrs[0] = r;
 	ptrs[1] = g;
 	ptrs[2] = b;
-	PROFILER_ENTER(genericProf);
+	PROFILER_ENTER(genericProf)
 
 	if (generic->RGBToRGB_16s8u_P3AC4R(ptrs, rgbStride,
 	                                   out1, dstStride, DstFormat,
 	                                   &roi) != PRIMITIVES_SUCCESS)
 		goto fail;
 
-	PROFILER_EXIT(genericProf);
-	PROFILER_ENTER(optProf);
+	PROFILER_EXIT(genericProf)
+	PROFILER_ENTER(optProf)
 
 	if (optimized->RGBToRGB_16s8u_P3AC4R(ptrs, rgbStride,
 	                                     out2, dstStride, DstFormat,
 	                                     &roi) != PRIMITIVES_SUCCESS)
 		goto fail;
 
-	PROFILER_EXIT(optProf);
+	PROFILER_EXIT(optProf)
 
 	if (memcmp(out1, out2, dstStride * roi.height) != 0)
 	{
@@ -103,13 +103,13 @@ static BOOL test_RGBToRGB_16s8u_P3AC4R_func(prim_size_t roi, DWORD DstFormat)
 	}
 
 	printf("Results for %"PRIu32"x%"PRIu32" [%s]", roi.width, roi.height, FreeRDPGetColorFormatName(DstFormat));
-	PROFILER_PRINT_HEADER;
-	PROFILER_PRINT(genericProf);
-	PROFILER_PRINT(optProf);
-	PROFILER_PRINT_FOOTER;
+	PROFILER_PRINT_HEADER
+	PROFILER_PRINT(genericProf)
+	PROFILER_PRINT(optProf)
+	PROFILER_PRINT_FOOTER
 fail:
-	PROFILER_FREE(genericProf);
-	PROFILER_FREE(optProf);
+	PROFILER_FREE(genericProf)
+	PROFILER_FREE(optProf)
 	_aligned_free(r);
 	_aligned_free(g);
 	_aligned_free(b);

--- a/libfreerdp/primitives/test/TestPrimitivesYCbCr.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYCbCr.c
@@ -2167,16 +2167,16 @@ static int test_PrimitivesYCbCr(const primitives_t* prims, UINT32 format, prim_s
 	const UINT32 dstStride = roi.width * GetBytesPerPixel(format);
 	const UINT32 srcSize = srcStride * roi.height;
 	const UINT32 dstSize = dstStride * roi.height;
-	PROFILER_DEFINE(prof);
-	PROFILER_DEFINE(prof1);
-	PROFILER_DEFINE(prof2);
+	PROFILER_DEFINE(prof)
+	PROFILER_DEFINE(prof1)
+	PROFILER_DEFINE(prof2)
 	//return test_YCbCr_pixels();
 	expected = (BYTE*) TEST_XRGB_IMAGE;
 	actual = _aligned_malloc(dstSize, 16);
 	actual1 = _aligned_malloc(dstSize, 16);
-	PROFILER_CREATE(prof, "yCbCrToRGB_16s8u");
-	PROFILER_CREATE(prof1, "yCbCrToRGB16s16s");
-	PROFILER_CREATE(prof2, "RGBToRGB_16s8u");
+	PROFILER_CREATE(prof, "yCbCrToRGB_16s8u")
+	PROFILER_CREATE(prof1, "yCbCrToRGB16s16s")
+	PROFILER_CREATE(prof2, "RGBToRGB_16s8u")
 
 	if (!actual || !actual1)
 		goto fail;
@@ -2202,14 +2202,14 @@ static int test_PrimitivesYCbCr(const primitives_t* prims, UINT32 format, prim_s
 	}
 
 	{
-		PROFILER_ENTER(prof);
+		PROFILER_ENTER(prof)
 		status = prims->yCbCrToRGB_16s8u_P3AC4R((const INT16**) pYCbCr, srcStride,
 		                                        actual, dstStride, format,
 		                                        &roi);
 		if (status != PRIMITIVES_SUCCESS)
 			goto fail;
 
-		PROFILER_EXIT(prof);
+		PROFILER_EXIT(prof)
 	}
 
 	{
@@ -2220,18 +2220,18 @@ static int test_PrimitivesYCbCr(const primitives_t* prims, UINT32 format, prim_s
 		CopyMemory(pSrcDst[0], pYCbCr[0], srcSize);
 		CopyMemory(pSrcDst[1], pYCbCr[1], srcSize);
 		CopyMemory(pSrcDst[2], pYCbCr[2], srcSize);
-		PROFILER_ENTER(prof1);
+		PROFILER_ENTER(prof1)
 		status = prims->yCbCrToRGB_16s16s_P3P3((const INT16**) pSrcDst, srcStride,
 		                                       pSrcDst, srcStride, &roi);
-		PROFILER_EXIT(prof1);
+		PROFILER_EXIT(prof1)
 
 		if (status != PRIMITIVES_SUCCESS)
 			goto fail2;
 
-		PROFILER_ENTER(prof2);
+		PROFILER_ENTER(prof2)
 		status = prims->RGBToRGB_16s8u_P3AC4R((const INT16**) pSrcDst, srcStride,
 		                                      actual1, dstStride, format, &roi);
-		PROFILER_EXIT(prof2);
+		PROFILER_EXIT(prof2)
 	fail2:
 		_aligned_free(pSrcDst[0]);
 		_aligned_free(pSrcDst[1]);
@@ -2286,20 +2286,20 @@ static int test_PrimitivesYCbCr(const primitives_t* prims, UINT32 format, prim_s
 		}
 	}
 
-	PROFILER_PRINT_HEADER;
-	PROFILER_PRINT(prof);
-	PROFILER_PRINT(prof1);
-	PROFILER_PRINT(prof2);
-	PROFILER_PRINT_FOOTER;
+	PROFILER_PRINT_HEADER
+	PROFILER_PRINT(prof)
+	PROFILER_PRINT(prof1)
+	PROFILER_PRINT(prof2)
+	PROFILER_PRINT_FOOTER
 fail:
 	_aligned_free((BYTE*)pYCbCr[0]);
 	_aligned_free((BYTE*)pYCbCr[1]);
 	_aligned_free((BYTE*)pYCbCr[2]);
 	_aligned_free(actual);
 	_aligned_free(actual1);
-	PROFILER_FREE(prof);
-	PROFILER_FREE(prof1);
-	PROFILER_FREE(prof2);
+	PROFILER_FREE(prof)
+	PROFILER_FREE(prof1)
+	PROFILER_FREE(prof2)
 	return status;
 }
 

--- a/libfreerdp/primitives/test/TestPrimitivesYCoCg.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYCoCg.c
@@ -43,8 +43,8 @@ static BOOL test_YCoCgRToRGB_8u_AC4R_func(UINT32 width, UINT32 height)
 		PIXEL_FORMAT_BGRA32,
 		PIXEL_FORMAT_BGRX32
 	};
-	PROFILER_DEFINE(genericProf);
-	PROFILER_DEFINE(optProf);
+	PROFILER_DEFINE(genericProf)
+	PROFILER_DEFINE(optProf)
 	in = _aligned_malloc(size, 16);
 	out_c = _aligned_malloc(size, 16);
 	out_sse = _aligned_malloc(size, 16);
@@ -59,22 +59,22 @@ static BOOL test_YCoCgRToRGB_8u_AC4R_func(UINT32 width, UINT32 height)
 		const UINT32 format = formats[x];
 		const UINT32 dstStride = width * GetBytesPerPixel(format);
 		const char* formatName = FreeRDPGetColorFormatName(format);
-		PROFILER_CREATE(genericProf, "YCoCgRToRGB_8u_AC4R-GENERIC");
-		PROFILER_CREATE(optProf, "YCoCgRToRGB_8u_AC4R-OPT");
-		PROFILER_ENTER(genericProf);
+		PROFILER_CREATE(genericProf, "YCoCgRToRGB_8u_AC4R-GENERIC")
+		PROFILER_CREATE(optProf, "YCoCgRToRGB_8u_AC4R-OPT")
+		PROFILER_ENTER(genericProf)
 		status = generic->YCoCgToRGB_8u_AC4R(
 		             in, srcStride,
 		             out_c, format, dstStride, width, height, 2, TRUE);
-		PROFILER_EXIT(genericProf);
+		PROFILER_EXIT(genericProf)
 
 		if (status != PRIMITIVES_SUCCESS)
 			goto loop_fail;
 
-		PROFILER_ENTER(optProf);
+		PROFILER_ENTER(optProf)
 		status = optimized->YCoCgToRGB_8u_AC4R(
 		             in, srcStride,
 		             out_sse, format, dstStride, width, height, 2, TRUE);
-		PROFILER_EXIT(optProf);
+		PROFILER_EXIT(optProf)
 
 		if (status != PRIMITIVES_SUCCESS)
 			goto loop_fail;
@@ -97,13 +97,13 @@ static BOOL test_YCoCgRToRGB_8u_AC4R_func(UINT32 width, UINT32 height)
 
 		printf("--------------------------- [%s] [%"PRIu32"x%"PRIu32"] ---------------------------\n",
 		       formatName, width, height);
-		PROFILER_PRINT_HEADER;
-		PROFILER_PRINT(genericProf);
-		PROFILER_PRINT(optProf);
-		PROFILER_PRINT_FOOTER;
+		PROFILER_PRINT_HEADER
+		PROFILER_PRINT(genericProf)
+		PROFILER_PRINT(optProf)
+		PROFILER_PRINT_FOOTER
 	loop_fail:
-		PROFILER_FREE(genericProf);
-		PROFILER_FREE(optProf);
+		PROFILER_FREE(genericProf)
+		PROFILER_FREE(optProf)
 
 		if (status != PRIMITIVES_SUCCESS)
 			goto fail;

--- a/libfreerdp/primitives/test/TestPrimitivesYUV.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYUV.c
@@ -178,14 +178,14 @@ static BOOL TestPrimitiveYUVCombine(primitives_t* prims, prim_size_t roi)
 	UINT32 yuvStride[3];
 	const size_t padding = 10000;
 	RECTANGLE_16 rect;
-	PROFILER_DEFINE(yuvCombine);
-	PROFILER_DEFINE(yuvSplit);
+	PROFILER_DEFINE(yuvCombine)
+	PROFILER_DEFINE(yuvSplit)
 	awidth = roi.width + 16 - roi.width % 16;
 	aheight = roi.height + 16 - roi.height % 16;
 	fprintf(stderr, "Running YUVCombine on frame size %"PRIu32"x%"PRIu32" [%"PRIu32"x%"PRIu32"]\n",
 	        roi.width, roi.height, awidth, aheight);
-	PROFILER_CREATE(yuvCombine, "YUV420CombineToYUV444");
-	PROFILER_CREATE(yuvSplit, "YUV444SplitToYUV420");
+	PROFILER_CREATE(yuvCombine, "YUV420CombineToYUV444")
+	PROFILER_CREATE(yuvSplit, "YUV444SplitToYUV420")
 	rect.left = 0;
 	rect.top = 0;
 	rect.right = roi.width;
@@ -239,14 +239,14 @@ static BOOL TestPrimitiveYUVCombine(primitives_t* prims, prim_size_t roi)
 			goto fail;
 	}
 
-	PROFILER_ENTER(yuvCombine);
+	PROFILER_ENTER(yuvCombine)
 
 	if (prims->YUV420CombineToYUV444(AVC444_LUMA,
 	                                 (const BYTE**)luma, lumaStride,
 	                                 roi.width, roi.height,
 	                                 yuv, yuvStride, &rect) != PRIMITIVES_SUCCESS)
 	{
-		PROFILER_EXIT(yuvCombine);
+		PROFILER_EXIT(yuvCombine)
 		goto fail;
 	}
 
@@ -255,11 +255,11 @@ static BOOL TestPrimitiveYUVCombine(primitives_t* prims, prim_size_t roi)
 	                                 roi.width, roi.height,
 	                                 yuv, yuvStride, &rect) != PRIMITIVES_SUCCESS)
 	{
-		PROFILER_EXIT(yuvCombine);
+		PROFILER_EXIT(yuvCombine)
 		goto fail;
 	}
 
-	PROFILER_EXIT(yuvCombine);
+	PROFILER_EXIT(yuvCombine)
 
 	for (x = 0; x < 3; x++)
 	{
@@ -277,16 +277,16 @@ static BOOL TestPrimitiveYUVCombine(primitives_t* prims, prim_size_t roi)
 			goto fail;
 	}
 
-	PROFILER_ENTER(yuvSplit);
+	PROFILER_ENTER(yuvSplit)
 
 	if (prims->YUV444SplitToYUV420((const BYTE**)yuv, yuvStride, pmain, lumaStride,
 	                               paux, chromaStride, &roi) != PRIMITIVES_SUCCESS)
 	{
-		PROFILER_EXIT(yuvSplit);
+		PROFILER_EXIT(yuvSplit)
 		goto fail;
 	}
 
-	PROFILER_EXIT(yuvSplit);
+	PROFILER_EXIT(yuvSplit)
 
 	for (x = 0; x < 3; x++)
 	{
@@ -346,14 +346,14 @@ static BOOL TestPrimitiveYUVCombine(primitives_t* prims, prim_size_t roi)
 		}
 	}
 
-	PROFILER_PRINT_HEADER;
-	PROFILER_PRINT(yuvSplit);
-	PROFILER_PRINT(yuvCombine);
-	PROFILER_PRINT_FOOTER;
+	PROFILER_PRINT_HEADER
+	PROFILER_PRINT(yuvSplit)
+	PROFILER_PRINT(yuvCombine)
+	PROFILER_PRINT_FOOTER
 	rc = TRUE;
 fail:
-	PROFILER_FREE(yuvCombine);
-	PROFILER_FREE(yuvSplit);
+	PROFILER_FREE(yuvCombine)
+	PROFILER_FREE(yuvSplit)
 
 	for (x = 0; x < 3; x++)
 	{
@@ -391,10 +391,10 @@ static BOOL TestPrimitiveYUV(primitives_t* prims, prim_size_t roi, BOOL use444)
 		PIXEL_FORMAT_BGRA32,
 		PIXEL_FORMAT_BGRX32
 	};
-	PROFILER_DEFINE(rgbToYUV420);
-	PROFILER_DEFINE(rgbToYUV444);
-	PROFILER_DEFINE(yuv420ToRGB);
-	PROFILER_DEFINE(yuv444ToRGB);
+	PROFILER_DEFINE(rgbToYUV420)
+	PROFILER_DEFINE(rgbToYUV444)
+	PROFILER_DEFINE(yuv420ToRGB)
+	PROFILER_DEFINE(yuv444ToRGB)
 	/* Buffers need to be 16x16 aligned. */
 	awidth = roi.width + 16 - roi.width % 16;
 	aheight = roi.height + 16 - roi.height % 16;
@@ -459,40 +459,40 @@ static BOOL TestPrimitiveYUV(primitives_t* prims, prim_size_t roi, BOOL use444)
 		pstatus_t rc;
 		const UINT32 DstFormat = formats[x];
 		printf("Testing destination color format %s\n", FreeRDPGetColorFormatName(DstFormat));
-		PROFILER_CREATE(rgbToYUV420, "RGBToYUV420");
-		PROFILER_CREATE(rgbToYUV444, "RGBToYUV444");
-		PROFILER_CREATE(yuv420ToRGB, "YUV420ToRGB");
-		PROFILER_CREATE(yuv444ToRGB, "YUV444ToRGB");
+		PROFILER_CREATE(rgbToYUV420, "RGBToYUV420")
+		PROFILER_CREATE(rgbToYUV444, "RGBToYUV444")
+		PROFILER_CREATE(yuv420ToRGB, "YUV420ToRGB")
+		PROFILER_CREATE(yuv444ToRGB, "YUV444ToRGB")
 
 		if (use444)
 		{
-			PROFILER_ENTER(rgbToYUV444);
+			PROFILER_ENTER(rgbToYUV444)
 			rc = prims->RGBToYUV444_8u_P3AC4R(rgb, DstFormat,
 			                                  stride, yuv, yuv_step,
 			                                  &roi);
-			PROFILER_EXIT(rgbToYUV444);
+			PROFILER_EXIT(rgbToYUV444)
 
 			if (rc != PRIMITIVES_SUCCESS)
 				goto loop_fail;
 
-			PROFILER_PRINT_HEADER;
-			PROFILER_PRINT(rgbToYUV444);
-			PROFILER_PRINT_FOOTER;
+			PROFILER_PRINT_HEADER
+			PROFILER_PRINT(rgbToYUV444)
+			PROFILER_PRINT_FOOTER
 		}
 		else
 		{
-			PROFILER_ENTER(rgbToYUV420);
+			PROFILER_ENTER(rgbToYUV420)
 			rc = prims->RGBToYUV420_8u_P3AC4R(rgb, DstFormat,
 			                                  stride, yuv, yuv_step,
 			                                  &roi);
-			PROFILER_EXIT(rgbToYUV420);
+			PROFILER_EXIT(rgbToYUV420)
 
 			if (rc != PRIMITIVES_SUCCESS)
 				goto loop_fail;
 
-			PROFILER_PRINT_HEADER;
-			PROFILER_PRINT(rgbToYUV420);
-			PROFILER_PRINT_FOOTER;
+			PROFILER_PRINT_HEADER
+			PROFILER_PRINT(rgbToYUV420)
+			PROFILER_PRINT_FOOTER
 		}
 
 		if (!check_padding(rgb, size * sizeof(UINT32), padding, "rgb"))
@@ -511,39 +511,39 @@ static BOOL TestPrimitiveYUV(primitives_t* prims, prim_size_t roi, BOOL use444)
 
 		if (use444)
 		{
-			PROFILER_ENTER(yuv444ToRGB);
+			PROFILER_ENTER(yuv444ToRGB)
 			rc = prims->YUV444ToRGB_8u_P3AC4R((const BYTE**)yuv, yuv_step, rgb_dst, stride,
 			                                  DstFormat,
 			                                  &roi);
-			PROFILER_EXIT(yuv444ToRGB);
+			PROFILER_EXIT(yuv444ToRGB)
 
 			if (rc != PRIMITIVES_SUCCESS)
 				goto loop_fail;
 
 		loop_fail:
-			PROFILER_EXIT(yuv444ToRGB);
-			PROFILER_PRINT_HEADER;
-			PROFILER_PRINT(yuv444ToRGB);
-			PROFILER_PRINT_FOOTER;
+			PROFILER_EXIT(yuv444ToRGB)
+			PROFILER_PRINT_HEADER
+			PROFILER_PRINT(yuv444ToRGB)
+			PROFILER_PRINT_FOOTER
 
 			if (rc != PRIMITIVES_SUCCESS)
 				goto fail;
 		}
 		else
 		{
-			PROFILER_ENTER(yuv420ToRGB);
+			PROFILER_ENTER(yuv420ToRGB)
 
 			if (prims->YUV420ToRGB_8u_P3AC4R((const BYTE**)yuv, yuv_step, rgb_dst,
 			                                 stride, DstFormat, &roi) != PRIMITIVES_SUCCESS)
 			{
-				PROFILER_EXIT(yuv420ToRGB);
+				PROFILER_EXIT(yuv420ToRGB)
 				goto fail;
 			}
 
-			PROFILER_EXIT(yuv420ToRGB);
-			PROFILER_PRINT_HEADER;
-			PROFILER_PRINT(yuv420ToRGB);
-			PROFILER_PRINT_FOOTER;
+			PROFILER_EXIT(yuv420ToRGB)
+			PROFILER_PRINT_HEADER
+			PROFILER_PRINT(yuv420ToRGB)
+			PROFILER_PRINT_FOOTER
 		}
 
 		if (!check_padding(rgb_dst, size * sizeof(UINT32), padding, "rgb dst"))
@@ -563,10 +563,10 @@ static BOOL TestPrimitiveYUV(primitives_t* prims, prim_size_t roi, BOOL use444)
 				goto fail;
 		}
 
-		PROFILER_FREE(rgbToYUV420);
-		PROFILER_FREE(rgbToYUV444);
-		PROFILER_FREE(yuv420ToRGB);
-		PROFILER_FREE(yuv444ToRGB);
+		PROFILER_FREE(rgbToYUV420)
+		PROFILER_FREE(rgbToYUV444)
+		PROFILER_FREE(yuv420ToRGB)
+		PROFILER_FREE(yuv444ToRGB)
 	}
 
 	rc = TRUE;
@@ -702,8 +702,8 @@ static BOOL TestPrimitiveRgbToLumaChroma(primitives_t* prims, prim_size_t roi, U
 		PIXEL_FORMAT_BGRA32,
 		PIXEL_FORMAT_BGRX32
 	};
-	PROFILER_DEFINE(rgbToYUV444);
-	PROFILER_DEFINE(rgbToYUV444opt);
+	PROFILER_DEFINE(rgbToYUV444)
+	PROFILER_DEFINE(rgbToYUV444opt)
 	/* Buffers need to be 16x16 aligned. */
 	awidth = roi.width;
 
@@ -790,22 +790,22 @@ static BOOL TestPrimitiveRgbToLumaChroma(primitives_t* prims, prim_size_t roi, U
 		pstatus_t rc;
 		const UINT32 DstFormat = formats[x];
 		printf("Testing destination color format %s\n", FreeRDPGetColorFormatName(DstFormat));
-		PROFILER_CREATE(rgbToYUV444, "RGBToYUV444-generic");
-		PROFILER_CREATE(rgbToYUV444opt, "RGBToYUV444-optimized");
+		PROFILER_CREATE(rgbToYUV444, "RGBToYUV444-generic")
+		PROFILER_CREATE(rgbToYUV444opt, "RGBToYUV444-optimized")
 
 		for (cnt = 0; cnt < 10; cnt++)
 		{
-			PROFILER_ENTER(rgbToYUV444opt);
+			PROFILER_ENTER(rgbToYUV444opt)
 			rc = fkt(rgb, DstFormat, stride, luma, yuv_step, chroma, yuv_step, &roi);
-			PROFILER_EXIT(rgbToYUV444opt);
+			PROFILER_EXIT(rgbToYUV444opt)
 
 			if (rc != PRIMITIVES_SUCCESS)
 				goto loop_fail;
 		}
 
-		PROFILER_PRINT_HEADER;
-		PROFILER_PRINT(rgbToYUV444opt);
-		PROFILER_PRINT_FOOTER;
+		PROFILER_PRINT_HEADER
+		PROFILER_PRINT(rgbToYUV444opt)
+		PROFILER_PRINT_FOOTER
 
 		if (!check_padding(rgb, size * sizeof(UINT32), padding, "rgb"))
 		{
@@ -822,17 +822,17 @@ static BOOL TestPrimitiveRgbToLumaChroma(primitives_t* prims, prim_size_t roi, U
 
 		for (cnt = 0; cnt < 10; cnt++)
 		{
-			PROFILER_ENTER(rgbToYUV444);
+			PROFILER_ENTER(rgbToYUV444)
 			rc = gen(rgb, DstFormat, stride, lumaGeneric, yuv_step, chromaGeneric, yuv_step, &roi);
-			PROFILER_EXIT(rgbToYUV444);
+			PROFILER_EXIT(rgbToYUV444)
 
 			if (rc != PRIMITIVES_SUCCESS)
 				goto loop_fail;
 		}
 
-		PROFILER_PRINT_HEADER;
-		PROFILER_PRINT(rgbToYUV444);
-		PROFILER_PRINT_FOOTER;
+		PROFILER_PRINT_HEADER
+		PROFILER_PRINT(rgbToYUV444)
+		PROFILER_PRINT_FOOTER
 
 		if (!check_padding(rgb, size * sizeof(UINT32), padding, "rgb"))
 		{
@@ -855,8 +855,8 @@ static BOOL TestPrimitiveRgbToLumaChroma(primitives_t* prims, prim_size_t roi, U
 		}
 
 	loop_fail:
-		PROFILER_FREE(rgbToYUV444);
-		PROFILER_FREE(rgbToYUV444opt);
+		PROFILER_FREE(rgbToYUV444)
+		PROFILER_FREE(rgbToYUV444opt)
 
 		if (rc != PRIMITIVES_SUCCESS)
 			goto fail;


### PR DESCRIPTION
Get rid of these annoying unused variable warnings and not break VS2010