### PR TITLE
Assistance and RDP file parser fix

### DIFF
--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -1057,6 +1057,10 @@ int freerdp_assistance_parse_file(rdpAssistanceFile* file, const char* name)
 	FILE* fp = NULL;
 	size_t readSize;
 	INT64 fileSize;
+
+	if (!name)
+		return -1;
+
 	fp = fopen(name, "r");
 
 	if (!fp)


### PR DESCRIPTION
 Fixed .rdp and .msrcIncident checks.

The command line detection fails, if only one of the aforementioned
files is used as an argument. Detect those first and ignore command
line detection if found.