### PR TITLE
Fix /size: /w: /h: with /monitors: (Fix custom sizes)

### DIFF
--- a/client/X11/xf_monitor.c
+++ b/client/X11/xf_monitor.c
@@ -4,6 +4,7 @@
  *
  * Copyright 2011 Marc-Andre Moreau <marcandre.moreau@gmail.com>
  * Copyright 2017 David Fort <contact@hardening-consulting.com>
+ * Copyright 2018 Kai Harms <kharms@rangee.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -280,6 +281,11 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pMaxWidth, UINT32* pMaxHeight)
 			if (settings->PercentScreenUseHeight)
 				*pMaxHeight = (xfc->workArea.height * settings->PercentScreen) / 100;
 		}
+	}
+	else if (settings->DesktopWidth && settings->DesktopHeight)
+	{
+		*pMaxWidth = settings->DesktopWidth;
+		*pMaxHeight = settings->DesktopHeight;
 	}
 
 	if (!settings->Fullscreen && !settings->Workarea && !settings->UseMultimon)


### PR DESCRIPTION
I don't know if that was planned or part of a rework, but I noticed that you could not use /size:WxH or /w:W or /h:H with /monitors:0 or 1 or x anymore, so that a custom sized window will be rendered on a specific monitor. Instead it would be rendered where the mouse cursor is, even though this should be a fallback if /monitors:x is not used I guess.

This PR should fix that problem.