### PR TITLE
Fixed read/write of surface bits command.

### DIFF
--- a/client/X11/xf_gdi.c
+++ b/client/X11/xf_gdi.c
@@ -1057,19 +1057,19 @@ static BOOL xf_gdi_surface_bits(rdpContext* context,
 	region16_init(&region);
 	cmdRect.left = cmd->destLeft;
 	cmdRect.top = cmd->destTop;
-	cmdRect.right = cmdRect.left + cmd->width;
-	cmdRect.bottom = cmdRect.top + cmd->height;
+	cmdRect.right = cmdRect.left + cmd->bmp.width;
+	cmdRect.bottom = cmdRect.top + cmd->bmp.height;
 
 
 	gdi = context->gdi;
 
 	xf_lock_x11(xfc, FALSE);
 
-	switch (cmd->codecID)
+	switch (cmd->bmp.codecID)
 	{
 		case RDP_CODEC_ID_REMOTEFX:
-			if (!rfx_process_message(context->codecs->rfx, cmd->bitmapData,
-			                         cmd->bitmapDataLength, cmd->destLeft, cmd->destTop,
+			if (!rfx_process_message(context->codecs->rfx, cmd->bmp.bitmapData,
+									 cmd->bmp.bitmapDataLength, cmd->destLeft, cmd->destTop,
 			                         gdi->primary_buffer, gdi->dstFormat, gdi->stride,
 			                         gdi->height, &region))
 				goto fail;
@@ -1077,21 +1077,21 @@ static BOOL xf_gdi_surface_bits(rdpContext* context,
 			break;
 
 		case RDP_CODEC_ID_NSCODEC:
-			if (!nsc_process_message(context->codecs->nsc, cmd->bpp, cmd->width,
-			                         cmd->height, cmd->bitmapData, cmd->bitmapDataLength,
+			if (!nsc_process_message(context->codecs->nsc, cmd->bmp.bpp, cmd->bmp.width,
+									 cmd->bmp.height, cmd->bmp.bitmapData, cmd->bmp.bitmapDataLength,
 			                         gdi->primary_buffer, gdi->dstFormat, gdi->stride,
-			                         0, 0, cmd->width, cmd->height, FREERDP_FLIP_VERTICAL))
+									 0, 0, cmd->bmp.width, cmd->bmp.height, FREERDP_FLIP_VERTICAL))
 				goto fail;
 
 			region16_union_rect(&region, &region, &cmdRect);
 			break;
 
 		case RDP_CODEC_ID_NONE:
-			pSrcData = cmd->bitmapData;
-			format = gdi_get_pixel_format(cmd->bpp);
+			pSrcData = cmd->bmp.bitmapData;
+			format = gdi_get_pixel_format(cmd->bmp.bpp);
 
 			if (!freerdp_image_copy(gdi->primary_buffer, gdi->dstFormat, gdi->stride,
-			                        cmd->destLeft, cmd->destTop, cmd->width, cmd->height,
+									cmd->destLeft, cmd->destTop, cmd->bmp.width, cmd->bmp.height,
 			                        pSrcData, format, 0, 0, 0,
 			                        &xfc->context.gdi->palette, FREERDP_FLIP_VERTICAL))
 				goto fail;
@@ -1100,7 +1100,7 @@ static BOOL xf_gdi_surface_bits(rdpContext* context,
 			break;
 
 		default:
-			WLog_ERR(TAG, "Unsupported codecID %"PRIu32"", cmd->codecID);
+			WLog_ERR(TAG, "Unsupported codecID %"PRIu16"", cmd->bmp.codecID);
 			ret = TRUE;
 			goto fail;
 	}

--- a/include/freerdp/update.h
+++ b/include/freerdp/update.h
@@ -42,6 +42,7 @@ typedef struct rdp_update rdpUpdate;
 #include <freerdp/pointer.h>
 
 /* Bitmap Updates */
+#define EX_COMPRESSED_BITMAP_HEADER_PRESENT 0x01
 
 struct _BITMAP_DATA
 {
@@ -91,6 +92,27 @@ struct _PLAY_SOUND_UPDATE
 typedef struct _PLAY_SOUND_UPDATE PLAY_SOUND_UPDATE;
 
 /* Surface Command Updates */
+struct _TS_COMPRESSED_BITMAP_HEADER_EX
+{
+	UINT32 highUniqueId;
+	UINT32 lowUniqueId;
+	UINT64 tmMilliseconds;
+	UINT64 tmSeconds;
+};
+typedef struct _TS_COMPRESSED_BITMAP_HEADER_EX TS_COMPRESSED_BITMAP_HEADER_EX;
+
+struct _TS_BITMAP_DATA_EX
+{
+	BYTE bpp;
+	BYTE flags;
+	UINT16 codecID;
+	UINT16 width;
+	UINT16 height;
+	UINT32 bitmapDataLength;
+	TS_COMPRESSED_BITMAP_HEADER_EX exBitmapDataHeader;
+	BYTE* bitmapData;
+};
+typedef struct _TS_BITMAP_DATA_EX TS_BITMAP_DATA_EX;
 
 struct _SURFACE_BITS_COMMAND
 {
@@ -99,12 +121,7 @@ struct _SURFACE_BITS_COMMAND
 	UINT32 destTop;
 	UINT32 destRight;
 	UINT32 destBottom;
-	UINT32 bpp;
-	UINT32 codecID;
-	UINT32 width;
-	UINT32 height;
-	UINT32 bitmapDataLength;
-	BYTE* bitmapData;
+	TS_BITMAP_DATA_EX bmp;
 	BOOL skipCompression;
 };
 typedef struct _SURFACE_BITS_COMMAND SURFACE_BITS_COMMAND;
@@ -148,20 +165,21 @@ typedef BOOL (*pSetKeyboardIndicators)(rdpContext* context, UINT16 led_flags);
 
 typedef BOOL (*pRefreshRect)(rdpContext* context, BYTE count, const RECTANGLE_16* areas);
 typedef BOOL (*pSuppressOutput)(rdpContext* context, BYTE allow, const RECTANGLE_16* area);
-typedef BOOL (*pRemoteMonitors)(rdpContext* context, UINT32 count, const MONITOR_DEF *monitors);
+typedef BOOL (*pRemoteMonitors)(rdpContext* context, UINT32 count, const MONITOR_DEF* monitors);
 
 typedef BOOL (*pSurfaceCommand)(rdpContext* context, wStream* s);
 typedef BOOL (*pSurfaceBits)(rdpContext* context,
-			     const SURFACE_BITS_COMMAND* surfaceBitsCommand);
+                             const SURFACE_BITS_COMMAND* surfaceBitsCommand);
 typedef BOOL (*pSurfaceFrameMarker)(rdpContext* context,
-				    const SURFACE_FRAME_MARKER* surfaceFrameMarker);
+                                    const SURFACE_FRAME_MARKER* surfaceFrameMarker);
 typedef BOOL (*pSurfaceFrameBits)(rdpContext* context,
-				  const SURFACE_BITS_COMMAND* cmd, BOOL first,
-				  BOOL last, UINT32 frameId);
+                                  const SURFACE_BITS_COMMAND* cmd, BOOL first,
+                                  BOOL last, UINT32 frameId);
 typedef BOOL (*pSurfaceFrameAcknowledge)(rdpContext* context, UINT32 frameId);
 
-typedef BOOL (*pSaveSessionInfo)(rdpContext *context, UINT32 type, void *data);
-typedef BOOL (*pSetKeyboardImeStatus)(rdpContext* context, UINT16 imeId, UINT32 imeState, UINT32 imeConvMode);
+typedef BOOL (*pSaveSessionInfo)(rdpContext* context, UINT32 type, void* data);
+typedef BOOL (*pSetKeyboardImeStatus)(rdpContext* context, UINT16 imeId, UINT32 imeState,
+                                      UINT32 imeConvMode);
 
 struct rdp_update
 {

--- a/libfreerdp/core/fastpath.c
+++ b/libfreerdp/core/fastpath.c
@@ -381,7 +381,7 @@ static int fastpath_recv_update(rdpFastPath* fastpath, BYTE updateCode, UINT32 s
 			break;
 
 		case FASTPATH_UPDATETYPE_SURFCMDS:
-			status = update_recv_surfcmds(update, size, s);
+			status = update_recv_surfcmds(update, s);
 
 			if (status < 0)
 				WLog_ERR(TAG, "FASTPATH_UPDATETYPE_SURFCMDS - update_recv_surfcmds() - %i", status);

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -258,7 +258,7 @@ BOOL freerdp_connect(freerdp* instance)
 				Stream_SetLength(s, record.length);
 				Stream_SetPosition(s, 0);
 				update->BeginPaint(update->context);
-				update_recv_surfcmds(update, Stream_Length(s), s);
+				update_recv_surfcmds(update, s);
 				update->EndPaint(update->context);
 				Stream_Release(s);
 			}

--- a/libfreerdp/core/message.c
+++ b/libfreerdp/core/message.c
@@ -280,17 +280,17 @@ static BOOL update_message_SurfaceBits(rdpContext* context,
 
 	CopyMemory(wParam, surfaceBitsCommand, sizeof(SURFACE_BITS_COMMAND));
 #ifdef WITH_STREAM_POOL
-	StreamPool_AddRef(context->rdp->transport->ReceivePool, surfaceBitsCommand->bitmapData);
+	StreamPool_AddRef(context->rdp->transport->ReceivePool, surfaceBitsCommand->bmp.bitmapData);
 #else
-	wParam->bitmapData = (BYTE*) malloc(wParam->bitmapDataLength);
+	wParam->bmp.bitmapData = (BYTE*) malloc(wParam->bmp.bitmapDataLength);
 
-	if (!wParam->bitmapData)
+	if (!wParam->bmp.bitmapData)
 	{
 		free(wParam);
 		return FALSE;
 	}
 
-	CopyMemory(wParam->bitmapData, surfaceBitsCommand->bitmapData, wParam->bitmapDataLength);
+	CopyMemory(wParam->bmp.bitmapData, surfaceBitsCommand->bmp.bitmapData, wParam->bmp.bitmapDataLength);
 #endif
 	return MessageQueue_Post(context->update->queue, (void*) context,
 	                         MakeMessageId(Update, SurfaceBits), (void*) wParam, NULL);
@@ -1702,10 +1702,10 @@ static int update_message_free_update_class(wMessage* msg, int type)
 #ifdef WITH_STREAM_POOL
 				rdpContext* context = (rdpContext*) msg->context;
 				SURFACE_BITS_COMMAND* wParam = (SURFACE_BITS_COMMAND*) msg->wParam;
-				StreamPool_Release(context->rdp->transport->ReceivePool, wParam->bitmapData);
+				StreamPool_Release(context->rdp->transport->ReceivePool, wParam->bmp.bitmapData);
 #else
 				SURFACE_BITS_COMMAND* wParam = (SURFACE_BITS_COMMAND*) msg->wParam;
-				free(wParam->bitmapData);
+				free(wParam->bmp.bitmapData);
 				free(wParam);
 #endif
 			}

--- a/libfreerdp/core/surface.h
+++ b/libfreerdp/core/surface.h
@@ -35,10 +35,9 @@ enum SURFCMD_CMDTYPE
 	CMDTYPE_STREAM_SURFACE_BITS = 0x0006
 };
 
-FREERDP_LOCAL int update_recv_surfcmds(rdpUpdate* update, UINT32 size,
-                                       wStream* s);
+FREERDP_LOCAL int update_recv_surfcmds(rdpUpdate* update, wStream* s);
 
-FREERDP_LOCAL BOOL update_write_surfcmd_surface_bits_header(wStream* s,
+FREERDP_LOCAL BOOL update_write_surfcmd_surface_bits(wStream* s,
         const SURFACE_BITS_COMMAND* cmd);
 FREERDP_LOCAL BOOL update_write_surfcmd_frame_marker(wStream* s,
         UINT16 frameAction, UINT32 frameId);

--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -1022,20 +1022,20 @@ static BOOL gdi_surface_bits(rdpContext* context,
 	gdi = context->gdi;
 	WLog_Print(gdi->log, WLOG_DEBUG,
 	           "destLeft %"PRIu32" destTop %"PRIu32" destRight %"PRIu32" destBottom %"PRIu32" "
-	           "bpp %"PRIu32" codecID %"PRIu32" width %"PRIu32" height %"PRIu32" length %"PRIu32"",
+	           "bpp %"PRIu8" flags %"PRIx8" codecID %"PRIu16" width %"PRIu16" height %"PRIu16" length %"PRIu32"",
 	           cmd->destLeft, cmd->destTop, cmd->destRight, cmd->destBottom,
-	           cmd->bpp, cmd->codecID, cmd->width, cmd->height, cmd->bitmapDataLength);
+			   cmd->bmp.bpp, cmd->bmp.flags, cmd->bmp.codecID, cmd->bmp.width, cmd->bmp.height, cmd->bmp.bitmapDataLength);
 	region16_init(&region);
 	cmdRect.left = cmd->destLeft;
 	cmdRect.top = cmd->destTop;
-	cmdRect.right = cmdRect.left + cmd->width;
-	cmdRect.bottom = cmdRect.top + cmd->height;
+	cmdRect.right = cmdRect.left + cmd->bmp.width;
+	cmdRect.bottom = cmdRect.top + cmd->bmp.height;
 
-	switch (cmd->codecID)
+	switch (cmd->bmp.codecID)
 	{
 		case RDP_CODEC_ID_REMOTEFX:
-			if (!rfx_process_message(context->codecs->rfx, cmd->bitmapData,
-			                         cmd->bitmapDataLength,
+			if (!rfx_process_message(context->codecs->rfx, cmd->bmp.bitmapData,
+									 cmd->bmp.bitmapDataLength,
 			                         cmd->destLeft, cmd->destTop,
 			                         gdi->primary_buffer, gdi->dstFormat,
 			                         gdi->stride, gdi->height, &region))
@@ -1049,11 +1049,11 @@ static BOOL gdi_surface_bits(rdpContext* context,
 		case RDP_CODEC_ID_NSCODEC:
 			format = gdi->dstFormat;
 
-			if (!nsc_process_message(context->codecs->nsc, cmd->bpp, cmd->width,
-			                         cmd->height, cmd->bitmapData,
-			                         cmd->bitmapDataLength, gdi->primary_buffer,
+			if (!nsc_process_message(context->codecs->nsc, cmd->bmp.bpp, cmd->bmp.width,
+									 cmd->bmp.height, cmd->bmp.bitmapData,
+									 cmd->bmp.bitmapDataLength, gdi->primary_buffer,
 			                         format, gdi->stride, cmd->destLeft, cmd->destTop,
-			                         cmd->width, cmd->height, FREERDP_FLIP_VERTICAL))
+									 cmd->bmp.width, cmd->bmp.height, FREERDP_FLIP_VERTICAL))
 			{
 				WLog_ERR(TAG, "Failed to process NSCodec message");
 				goto out;
@@ -1063,11 +1063,11 @@ static BOOL gdi_surface_bits(rdpContext* context,
 			break;
 
 		case RDP_CODEC_ID_NONE:
-			format = gdi_get_pixel_format(cmd->bpp);
+			format = gdi_get_pixel_format(cmd->bmp.bpp);
 
 			if (!freerdp_image_copy(gdi->primary_buffer, gdi->dstFormat, gdi->stride,
-			                        cmd->destLeft, cmd->destTop, cmd->width, cmd->height,
-			                        cmd->bitmapData, format, 0, 0, 0,
+									cmd->destLeft, cmd->destTop, cmd->bmp.width, cmd->bmp.height,
+									cmd->bmp.bitmapData, format, 0, 0, 0,
 			                        &gdi->palette, FREERDP_FLIP_VERTICAL))
 			{
 				WLog_ERR(TAG, "Failed to process nocodec message");
@@ -1078,7 +1078,7 @@ static BOOL gdi_surface_bits(rdpContext* context,
 			break;
 
 		default:
-			WLog_ERR(TAG, "Unsupported codecID %"PRIu32"", cmd->codecID);
+			WLog_ERR(TAG, "Unsupported codecID %"PRIu32"", cmd->bmp.codecID);
 			break;
 	}
 

--- a/server/Mac/mf_peer.c
+++ b/server/Mac/mf_peer.c
@@ -113,16 +113,17 @@ static void mf_peer_rfx_update(freerdp_peer* client)
 		return;
 	}
 
+	memset(cmd, 0, sizeof(SURFACE_BITS_COMMAND));
 	cmd->destLeft = x;
 	cmd->destTop = y;
 	cmd->destRight = x + rect.width;
 	cmd->destBottom = y + rect.height;
-	cmd->bpp = 32;
-	cmd->codecID = 3;
-	cmd->width = rect.width;
-	cmd->height = rect.height;
-	cmd->bitmapDataLength = Stream_GetPosition(s);
-	cmd->bitmapData = Stream_Buffer(s);
+	cmd->bmp.bpp = 32;
+	cmd->bmp.codecID = 3;
+	cmd->bmp.width = rect.width;
+	cmd->bmp.height = rect.height;
+	cmd->bmp.bitmapDataLength = Stream_GetPosition(s);
+	cmd->bmp.bitmapData = Stream_Buffer(s);
 	//send
 	update->SurfaceBits(update->context, cmd);
 	//clean up... maybe?

--- a/server/Sample/sfreerdp.c
+++ b/server/Sample/sfreerdp.c
@@ -194,6 +194,7 @@ static BOOL test_peer_draw_background(freerdp_peer* client)
 	}
 
 	memset(rgb_data, 0xA0, size);
+	memset(cmd, 0, sizeof(SURFACE_BITS_COMMAND));
 
 	if (client->settings->RemoteFxCodec)
 	{
@@ -203,24 +204,25 @@ static BOOL test_peer_draw_background(freerdp_peer* client)
 			goto out;
 		}
 
-		cmd->codecID = client->settings->RemoteFxCodecId;
+		cmd->bmp.codecID = client->settings->RemoteFxCodecId;
 	}
 	else
 	{
 		nsc_compose_message(context->nsc_context, s,
 		                    rgb_data, rect.width, rect.height, rect.width * 3);
-		cmd->codecID = client->settings->NSCodecId;
+		cmd->bmp.codecID = client->settings->NSCodecId;
 	}
 
 	cmd->destLeft = 0;
 	cmd->destTop = 0;
 	cmd->destRight = rect.width;
 	cmd->destBottom = rect.height;
-	cmd->bpp = 32;
-	cmd->width = rect.width;
-	cmd->height = rect.height;
-	cmd->bitmapDataLength = Stream_GetPosition(s);
-	cmd->bitmapData = Stream_Buffer(s);
+	cmd->bmp.bpp = 32;
+	cmd->bmp.flags = 0;
+	cmd->bmp.width = rect.width;
+	cmd->bmp.height = rect.height;
+	cmd->bmp.bitmapDataLength = Stream_GetPosition(s);
+	cmd->bmp.bitmapData = Stream_Buffer(s);
 	test_peer_begin_frame(client);
 	update->SurfaceBits(update->context, cmd);
 	test_peer_end_frame(client);
@@ -315,6 +317,7 @@ static void test_peer_draw_icon(freerdp_peer* client, int x, int y)
 	rect.y = 0;
 	rect.width = context->icon_width;
 	rect.height = context->icon_height;
+	memset(cmd, 0, sizeof(SURFACE_BITS_COMMAND));
 
 	if (context->icon_x >= 0)
 	{
@@ -324,24 +327,25 @@ static void test_peer_draw_icon(freerdp_peer* client, int x, int y)
 		{
 			rfx_compose_message(context->rfx_context, s,
 			                    &rect, 1, context->bg_data, rect.width, rect.height, rect.width * 3);
-			cmd->codecID = client->settings->RemoteFxCodecId;
+			cmd->bmp.codecID = client->settings->RemoteFxCodecId;
 		}
 		else
 		{
 			nsc_compose_message(context->nsc_context, s,
 			                    context->bg_data, rect.width, rect.height, rect.width * 3);
-			cmd->codecID = client->settings->NSCodecId;
+			cmd->bmp.codecID = client->settings->NSCodecId;
 		}
 
 		cmd->destLeft = context->icon_x;
 		cmd->destTop = context->icon_y;
 		cmd->destRight = context->icon_x + context->icon_width;
 		cmd->destBottom = context->icon_y + context->icon_height;
-		cmd->bpp = 32;
-		cmd->width = context->icon_width;
-		cmd->height = context->icon_height;
-		cmd->bitmapDataLength = Stream_GetPosition(s);
-		cmd->bitmapData = Stream_Buffer(s);
+		cmd->bmp.bpp = 32;
+		cmd->bmp.flags = 0;
+		cmd->bmp.width = context->icon_width;
+		cmd->bmp.height = context->icon_height;
+		cmd->bmp.bitmapDataLength = Stream_GetPosition(s);
+		cmd->bmp.bitmapData = Stream_Buffer(s);
 		update->SurfaceBits(update->context, cmd);
 	}
 
@@ -351,24 +355,24 @@ static void test_peer_draw_icon(freerdp_peer* client, int x, int y)
 	{
 		rfx_compose_message(context->rfx_context, s,
 		                    &rect, 1, context->icon_data, rect.width, rect.height, rect.width * 3);
-		cmd->codecID = client->settings->RemoteFxCodecId;
+		cmd->bmp.codecID = client->settings->RemoteFxCodecId;
 	}
 	else
 	{
 		nsc_compose_message(context->nsc_context, s,
 		                    context->icon_data, rect.width, rect.height, rect.width * 3);
-		cmd->codecID = client->settings->NSCodecId;
+		cmd->bmp.codecID = client->settings->NSCodecId;
 	}
 
 	cmd->destLeft = x;
 	cmd->destTop = y;
 	cmd->destRight = x + context->icon_width;
 	cmd->destBottom = y + context->icon_height;
-	cmd->bpp = 32;
-	cmd->width = context->icon_width;
-	cmd->height = context->icon_height;
-	cmd->bitmapDataLength = Stream_GetPosition(s);
-	cmd->bitmapData = Stream_Buffer(s);
+	cmd->bmp.bpp = 32;
+	cmd->bmp.width = context->icon_width;
+	cmd->bmp.height = context->icon_height;
+	cmd->bmp.bitmapDataLength = Stream_GetPosition(s);
+	cmd->bmp.bitmapData = Stream_Buffer(s);
 	update->SurfaceBits(update->context, cmd);
 	context->icon_x = x;
 	context->icon_y = y;

--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -925,7 +925,7 @@ static BOOL shadow_client_send_surface_bits(rdpShadowClient* client,
 	rdpContext* context = (rdpContext*) client;
 	rdpSettings* settings;
 	rdpShadowEncoder* encoder;
-	SURFACE_BITS_COMMAND cmd;
+	SURFACE_BITS_COMMAND cmd = { 0 };
 
 	if (!context || !pSrcData)
 		return FALSE;
@@ -966,14 +966,15 @@ static BOOL shadow_client_send_surface_bits(rdpShadowClient* client,
 			return FALSE;
 		}
 
-		cmd.codecID = settings->RemoteFxCodecId;
+		cmd.bmp.codecID = settings->RemoteFxCodecId;
 		cmd.destLeft = 0;
 		cmd.destTop = 0;
 		cmd.destRight = settings->DesktopWidth;
 		cmd.destBottom = settings->DesktopHeight;
-		cmd.bpp = 32;
-		cmd.width = settings->DesktopWidth;
-		cmd.height = settings->DesktopHeight;
+		cmd.bmp.bpp = 32;
+		cmd.bmp.flags = 0;
+		cmd.bmp.width = settings->DesktopWidth;
+		cmd.bmp.height = settings->DesktopHeight;
 		cmd.skipCompression = TRUE;
 
 		if (numMessages > 0)
@@ -996,8 +997,8 @@ static BOOL shadow_client_send_surface_bits(rdpShadowClient* client,
 			}
 
 			rfx_message_free(encoder->rfx, &messages[i]);
-			cmd.bitmapDataLength = Stream_GetPosition(s);
-			cmd.bitmapData = Stream_Buffer(s);
+			cmd.bmp.bitmapDataLength = Stream_GetPosition(s);
+			cmd.bmp.bitmapData = Stream_Buffer(s);
 			first = (i == 0) ? TRUE : FALSE;
 			last = ((i + 1) == numMessages) ? TRUE : FALSE;
 
@@ -1029,16 +1030,16 @@ static BOOL shadow_client_send_surface_bits(rdpShadowClient* client,
 		Stream_SetPosition(s, 0);
 		pSrcData = &pSrcData[(nYSrc * nSrcStep) + (nXSrc * 4)];
 		nsc_compose_message(encoder->nsc, s, pSrcData, nWidth, nHeight, nSrcStep);
-		cmd.bpp = 32;
-		cmd.codecID = settings->NSCodecId;
+		cmd.bmp.bpp = 32;
+		cmd.bmp.codecID = settings->NSCodecId;
 		cmd.destLeft = nXSrc;
 		cmd.destTop = nYSrc;
 		cmd.destRight = cmd.destLeft + nWidth;
 		cmd.destBottom = cmd.destTop + nHeight;
-		cmd.width = nWidth;
-		cmd.height = nHeight;
-		cmd.bitmapDataLength = Stream_GetPosition(s);
-		cmd.bitmapData = Stream_Buffer(s);
+		cmd.bmp.width = nWidth;
+		cmd.bmp.height = nHeight;
+		cmd.bmp.bitmapDataLength = Stream_GetPosition(s);
+		cmd.bmp.bitmapData = Stream_Buffer(s);
 		first = TRUE;
 		last = TRUE;
 


### PR DESCRIPTION
The optional field exBitmapDataHeader of TS_ BITMAP_DATA_EX was ignored.
Read and expose the data (currently unused)

May be related to #3518