### PR TITLE
Misc changes for Windows client

### DIFF
--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -567,7 +567,7 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam,
 			break;
 
 		case WM_SETCURSOR:
-			if (LOWORD(lParam) == HTCLIENT)
+			if (wfc && LOWORD(lParam) == HTCLIENT)
 				SetCursor(wfc->hDefaultCursor);
 			else
 				DefWindowProc(hWnd, Msg, wParam, lParam);

--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -566,14 +566,6 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam,
 			PostQuitMessage(WM_QUIT);
 			break;
 
-		case WM_SETCURSOR:
-			if (wfc && LOWORD(lParam) == HTCLIENT)
-				SetCursor(wfc->hDefaultCursor);
-			else
-				DefWindowProc(hWnd, Msg, wParam, lParam);
-
-			break;
-
 		case WM_SETFOCUS:
 			DEBUG_KBD("getting focus %X", hWnd);
 

--- a/client/Windows/wf_gdi.c
+++ b/client/Windows/wf_gdi.c
@@ -351,12 +351,19 @@ void wf_resize_window(wfContext* wfc)
 	else if (!wfc->context.settings->Decorations)
 	{
 		SetWindowLongPtr(wfc->hwnd, GWL_STYLE, WS_CHILD);
-		/* Now resize to get full canvas size and room for caption and borders */
-		SetWindowPos(wfc->hwnd, HWND_TOP, 0, 0, settings->DesktopWidth,
-		             settings->DesktopHeight, SWP_FRAMECHANGED);
-		wf_update_canvas_diff(wfc);
-		SetWindowPos(wfc->hwnd, HWND_TOP, -1, -1, settings->DesktopWidth + wfc->diff.x,
-		             settings->DesktopHeight + wfc->diff.y, SWP_NOMOVE | SWP_FRAMECHANGED);
+		if (settings->EmbeddedWindow)
+		{
+			wf_update_canvas_diff(wfc);
+		}
+		else
+		{
+			/* Now resize to get full canvas size and room for caption and borders */
+			SetWindowPos(wfc->hwnd, HWND_TOP, 0, 0, settings->DesktopWidth,
+				settings->DesktopHeight, SWP_FRAMECHANGED);
+			wf_update_canvas_diff(wfc);
+			SetWindowPos(wfc->hwnd, HWND_TOP, -1, -1, settings->DesktopWidth + wfc->diff.x,
+				settings->DesktopHeight + wfc->diff.y, SWP_NOMOVE | SWP_FRAMECHANGED);
+		}
 	}
 	else
 	{

--- a/client/Windows/wf_graphics.c
+++ b/client/Windows/wf_graphics.c
@@ -131,11 +131,8 @@ static void wf_Bitmap_Free(rdpContext* context, rdpBitmap* bitmap)
 		DeleteObject(wf_bitmap->bitmap);
 		DeleteDC(wf_bitmap->hdc);
 
-		if (wf_bitmap->_bitmap.data)
-		{
-			_aligned_free(wf_bitmap->_bitmap.data);
-			wf_bitmap->_bitmap.data = NULL;
-		}
+		_aligned_free(wf_bitmap->_bitmap.data);
+		wf_bitmap->_bitmap.data = NULL;
 	}
 }
 

--- a/client/Windows/wf_graphics.c
+++ b/client/Windows/wf_graphics.c
@@ -130,6 +130,12 @@ static void wf_Bitmap_Free(rdpContext* context, rdpBitmap* bitmap)
 		SelectObject(wf_bitmap->hdc, wf_bitmap->org_bitmap);
 		DeleteObject(wf_bitmap->bitmap);
 		DeleteDC(wf_bitmap->hdc);
+
+		if (wf_bitmap->_bitmap.data)
+		{
+			_aligned_free(wf_bitmap->_bitmap.data);
+			wf_bitmap->_bitmap.data = NULL;
+		}
 	}
 }
 

--- a/libfreerdp/codec/h264_mf.c
+++ b/libfreerdp/codec/h264_mf.c
@@ -431,6 +431,12 @@ static int mf_compress(H264_CONTEXT* h264, const BYTE** ppSrcYuv, const UINT32* 
 	return 1;
 }
 
+static BOOL mf_plat_loaded(H264_CONTEXT_MF* sys)
+{
+	return sys->MFStartup && sys->MFShutdown && sys->MFCreateSample
+		&& sys->MFCreateMemoryBuffer && sys->MFCreateMediaType;
+}
+
 static void mf_uninit(H264_CONTEXT* h264)
 {
 	UINT32 x;
@@ -470,8 +476,14 @@ static void mf_uninit(H264_CONTEXT* h264)
 
 		if (sys->mfplat)
 		{
+			if (mf_plat_loaded(sys))
+				sys->MFShutdown();
+
 			FreeLibrary(sys->mfplat);
 			sys->mfplat = NULL;
+
+			if (mf_plat_loaded(sys))
+				CoUninitialize();
 		}
 
 		for (x = 0; x < sizeof(h264->pYUVData) / sizeof(h264->pYUVData[0]); x++)
@@ -479,8 +491,7 @@ static void mf_uninit(H264_CONTEXT* h264)
 
 		memset(h264->pYUVData, 0, sizeof(h264->pYUVData));
 		memset(h264->iStride, 0, sizeof(h264->iStride));
-		sys->MFShutdown();
-		CoUninitialize();
+		
 		free(sys);
 		h264->pSystemData = NULL;
 	}
@@ -494,15 +505,12 @@ static BOOL mf_init(H264_CONTEXT* h264)
 	if (!sys)
 		goto error;
 
+	h264->pSystemData = (void*) sys;
 	/* http://decklink-sdk-delphi.googlecode.com/svn/trunk/Blackmagic%20DeckLink%20SDK%209.7/Win/Samples/Streaming/StreamingPreview/DecoderMF.cpp */
 	sys->mfplat = LoadLibraryA("mfplat.dll");
-	if (!sys->mfplat)
-	{
-		free(sys);
-		goto error;
-	}
 
-	h264->pSystemData = (void*) sys;
+	if (!sys->mfplat)
+		goto error;
 
 	sys->MFStartup = (pfnMFStartup) GetProcAddress(sys->mfplat, "MFStartup");
 	sys->MFShutdown = (pfnMFShutdown) GetProcAddress(sys->mfplat, "MFShutdown");
@@ -513,8 +521,7 @@ static BOOL mf_init(H264_CONTEXT* h264)
 	sys->MFCreateMediaType = (pfnMFCreateMediaType) GetProcAddress(sys->mfplat,
 	                         "MFCreateMediaType");
 
-	if (!sys->MFStartup || !sys->MFShutdown || !sys->MFCreateSample
-	    || !sys->MFCreateMemoryBuffer || !sys->MFCreateMediaType)
+	if (!mf_plat_loaded(sys))
 		goto error;
 
 	CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);

--- a/libfreerdp/codec/h264_mf.c
+++ b/libfreerdp/codec/h264_mf.c
@@ -494,12 +494,15 @@ static BOOL mf_init(H264_CONTEXT* h264)
 	if (!sys)
 		goto error;
 
-	h264->pSystemData = (void*) sys;
 	/* http://decklink-sdk-delphi.googlecode.com/svn/trunk/Blackmagic%20DeckLink%20SDK%209.7/Win/Samples/Streaming/StreamingPreview/DecoderMF.cpp */
 	sys->mfplat = LoadLibraryA("mfplat.dll");
-
 	if (!sys->mfplat)
+	{
+		free(sys);
 		goto error;
+	}
+
+	h264->pSystemData = (void*) sys;
 
 	sys->MFStartup = (pfnMFStartup) GetProcAddress(sys->mfplat, "MFStartup");
 	sys->MFShutdown = (pfnMFShutdown) GetProcAddress(sys->mfplat, "MFShutdown");

--- a/libfreerdp/codec/planar.c
+++ b/libfreerdp/codec/planar.c
@@ -614,9 +614,14 @@ BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar,
 	}
 	else /* YCoCg */
 	{
+		UINT32 TempFormat;
 		BYTE* pTempData = planar->pTempData;
 		UINT32 nTempStep = planar->nTempStep;
-		UINT32 TempFormat = PIXEL_FORMAT_BGRA32;
+
+		if (alpha)
+			TempFormat = PIXEL_FORMAT_BGRA32;
+		else
+			TempFormat = PIXEL_FORMAT_BGRX32;
 
 		if (!pTempData)
 			return FALSE;


### PR DESCRIPTION
These are fixes from creating a client based on wfreerdp. The H.264 codec changes here handle just not trapping if the mfplat.dll load fails, which happened testing this on a Windows N system