### PR TITLE
Thread and Threadpool work function fix

### DIFF
--- a/channels/audin/client/alsa/audin_alsa.c
+++ b/channels/audin/client/alsa/audin_alsa.c
@@ -219,7 +219,7 @@ static UINT audin_alsa_thread_receive(AudinALSADevice* alsa, BYTE* src,
 	return ret;
 }
 
-static void* audin_alsa_thread_func(void* arg)
+static DWORD WINAPI audin_alsa_thread_func(LPVOID arg)
 {
 	long error;
 	BYTE* buffer;
@@ -300,8 +300,8 @@ out:
 		setChannelError(alsa->rdpcontext, error,
 		                "audin_alsa_thread_func reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -427,7 +427,7 @@ static UINT audin_alsa_open(IAudinDevice* device, AudinReceive receive,
 	}
 
 	if (!(alsa->thread = CreateThread(NULL, 0,
-	                                  (LPTHREAD_START_ROUTINE) audin_alsa_thread_func, alsa, 0, NULL)))
+									  audin_alsa_thread_func, alsa, 0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");
 		goto error_out;

--- a/channels/audin/client/opensles/audin_opensl_es.c
+++ b/channels/audin/client/opensles/audin_opensl_es.c
@@ -70,7 +70,7 @@ typedef struct _AudinOpenSLESDevice
 	rdpContext* rdpcontext;
 } AudinOpenSLESDevice;
 
-static void* audin_opensles_thread_func(void* arg)
+static DWORD WINAPI audin_opensles_thread_func(LPVOID arg)
 {
 	union
 	{
@@ -173,8 +173,8 @@ out:
 	if (error && opensles->rdpcontext)
 		setChannelError(opensles->rdpcontext, error, "audin_opensles_thread_func reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -356,7 +356,7 @@ static UINT audin_opensles_open(IAudinDevice* device, AudinReceive receive,
 		goto error_out;
 	}
 	if (!(opensles->thread = CreateThread(NULL, 0,
-		(LPTHREAD_START_ROUTINE) audin_opensles_thread_func,
+                audin_opensles_thread_func,
 		opensles, 0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");

--- a/channels/audin/client/oss/audin_oss.c
+++ b/channels/audin/client/oss/audin_oss.c
@@ -173,7 +173,7 @@ static UINT audin_oss_set_format(IAudinDevice* device, audinFormat* format,
 	return CHANNEL_RC_OK;
 }
 
-static void* audin_oss_thread_func(void* arg)
+static DWORD WINAPI audin_oss_thread_func(LPVOID arg)
 {
 	char dev_name[PATH_MAX] = "/dev/dsp";
 	char mixer_name[PATH_MAX] = "/dev/mixer";
@@ -352,8 +352,8 @@ err_out:
 	}
 
 	free(buffer);
-	ExitThread(0);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -374,8 +374,7 @@ static UINT audin_oss_open(IAudinDevice* device, AudinReceive receive,
 		return ERROR_INTERNAL_ERROR;
 	}
 
-	if (!(oss->thread = CreateThread(NULL, 0,
-	                                 (LPTHREAD_START_ROUTINE)audin_oss_thread_func, oss, 0, NULL)))
+	if (!(oss->thread = CreateThread(NULL, 0, audin_oss_thread_func, oss, 0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");
 		CloseHandle(oss->stopEvent);

--- a/channels/audin/client/winmm/audin_winmm.c
+++ b/channels/audin/client/winmm/audin_winmm.c
@@ -94,7 +94,7 @@ static void CALLBACK waveInProc(HWAVEIN hWaveIn, UINT uMsg, DWORD_PTR dwInstance
 		setChannelError(winmm->rdpcontext, error, "waveInProc reported an error");
 }
 
-static DWORD audin_winmm_thread_func(void* arg)
+static DWORD WINAPI audin_winmm_thread_func(LPVOID arg)
 {
 	AudinWinmmDevice* winmm = (AudinWinmmDevice*) arg;
 	char *buffer;
@@ -332,8 +332,7 @@ static UINT audin_winmm_open(IAudinDevice* device, AudinReceive receive, void* u
 		return ERROR_INTERNAL_ERROR;
 	}
 
-	if (!(winmm->thread = CreateThread(NULL, 0,
-		(LPTHREAD_START_ROUTINE) audin_winmm_thread_func, winmm, 0, NULL)))
+	if (!(winmm->thread = CreateThread(NULL, 0, audin_winmm_thread_func, winmm, 0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");
 		CloseHandle(winmm->stopEvent);

--- a/channels/audin/server/audin.c
+++ b/channels/audin/server/audin.c
@@ -401,7 +401,7 @@ static UINT audin_server_recv_data(audin_server* audin, wStream* s,
 	return success;
 }
 
-static void* audin_server_thread_func(void* arg)
+static DWORD WINAPI audin_server_thread_func(LPVOID arg)
 {
 	wStream* s;
 	void* buffer;
@@ -596,8 +596,8 @@ out:
 		setChannelError(audin->context.rdpcontext, error,
 		                "audin_server_thread_func reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 static BOOL audin_server_open(audin_server_context* context)
@@ -632,8 +632,7 @@ static BOOL audin_server_open(audin_server_context* context)
 			return FALSE;
 		}
 
-		if (!(audin->thread = CreateThread(NULL, 0,
-		                                   (LPTHREAD_START_ROUTINE) audin_server_thread_func, (void*) audin, 0, NULL)))
+		if (!(audin->thread = CreateThread(NULL, 0, audin_server_thread_func, (void*) audin, 0, NULL)))
 		{
 			WLog_ERR(TAG, "CreateThread failed!");
 			CloseHandle(audin->stopEvent);

--- a/channels/cliprdr/client/cliprdr_main.c
+++ b/channels/cliprdr/client/cliprdr_main.c
@@ -1057,7 +1057,7 @@ static VOID VCAPITYPE cliprdr_virtual_channel_open_event_ex(LPVOID lpUserParam, 
 		                "cliprdr_virtual_channel_open_event_ex reported an error");
 }
 
-static void* cliprdr_virtual_channel_client_thread(void* arg)
+static DWORD WINAPI cliprdr_virtual_channel_client_thread(LPVOID arg)
 {
 	wStream* data;
 	wMessage message;
@@ -1099,8 +1099,8 @@ static void* cliprdr_virtual_channel_client_thread(void* arg)
 		setChannelError(cliprdr->context->rdpcontext, error,
 		                "cliprdr_virtual_channel_client_thread reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -1131,8 +1131,7 @@ static UINT cliprdr_virtual_channel_event_connected(cliprdrPlugin* cliprdr,
 		return ERROR_NOT_ENOUGH_MEMORY;
 	}
 
-	if (!(cliprdr->thread = CreateThread(NULL, 0,
-	                                     (LPTHREAD_START_ROUTINE) cliprdr_virtual_channel_client_thread, (void*) cliprdr,
+	if (!(cliprdr->thread = CreateThread(NULL, 0, cliprdr_virtual_channel_client_thread, (void*) cliprdr,
 	                                     0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");

--- a/channels/cliprdr/server/cliprdr_main.c
+++ b/channels/cliprdr/server/cliprdr_main.c
@@ -1319,7 +1319,7 @@ UINT cliprdr_server_read(CliprdrServerContext* context)
 	return CHANNEL_RC_OK;
 }
 
-static void* cliprdr_server_thread(void* arg)
+static DWORD WINAPI cliprdr_server_thread(LPVOID arg)
 {
 	DWORD status;
 	DWORD nCount;
@@ -1388,8 +1388,8 @@ out:
 		setChannelError(context->rdpcontext, error,
 		                "cliprdr_server_thread reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -1478,8 +1478,7 @@ static UINT cliprdr_server_start(CliprdrServerContext* context)
 		return ERROR_INTERNAL_ERROR;
 	}
 
-	if (!(cliprdr->Thread = CreateThread(NULL, 0,
-	                                     (LPTHREAD_START_ROUTINE) cliprdr_server_thread, (void*) context, 0, NULL)))
+	if (!(cliprdr->Thread = CreateThread(NULL, 0, cliprdr_server_thread, (void*) context, 0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");
 		CloseHandle(cliprdr->StopEvent);

--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -1231,7 +1231,7 @@ static void VCAPITYPE drdynvc_virtual_channel_open_event_ex(LPVOID lpUserParam, 
 		setChannelError(drdynvc->rdpcontext, error, "drdynvc_virtual_channel_open_event reported an error");
 }
 
-static void* drdynvc_virtual_channel_client_thread(void* arg)
+static DWORD WINAPI drdynvc_virtual_channel_client_thread(LPVOID arg)
 {
 	wStream* data;
 	wMessage message;
@@ -1241,7 +1241,7 @@ static void* drdynvc_virtual_channel_client_thread(void* arg)
 	if (!drdynvc)
 	{
 		ExitThread((DWORD) CHANNEL_RC_BAD_CHANNEL_HANDLE);
-		return NULL;
+		return CHANNEL_RC_BAD_CHANNEL_HANDLE;
 	}
 
 	while (1)
@@ -1298,7 +1298,7 @@ static void* drdynvc_virtual_channel_client_thread(void* arg)
 		                "drdynvc_virtual_channel_client_thread reported an error");
 
 	ExitThread((DWORD) error);
-	return NULL;
+	return error;
 }
 
 static void drdynvc_queue_object_free(void* obj)
@@ -1380,8 +1380,7 @@ static UINT drdynvc_virtual_channel_event_connected(drdynvcPlugin* drdynvc, LPVO
 
 	drdynvc->state = DRDYNVC_STATE_CAPABILITIES;
 
-	if (!(drdynvc->thread = CreateThread(NULL, 0,
-	                                     (LPTHREAD_START_ROUTINE) drdynvc_virtual_channel_client_thread, (void*) drdynvc,
+	if (!(drdynvc->thread = CreateThread(NULL, 0, drdynvc_virtual_channel_client_thread, (void*) drdynvc,
 	                                     0, NULL)))
 	{
 		error = ERROR_INTERNAL_ERROR;

--- a/channels/drdynvc/server/drdynvc_main.c
+++ b/channels/drdynvc/server/drdynvc_main.c
@@ -33,7 +33,7 @@
 #define TAG CHANNELS_TAG("drdynvc.server")
 
 
-static void* drdynvc_server_thread(void* arg)
+static DWORD WINAPI drdynvc_server_thread(LPVOID arg)
 {
 #if 0
 	wStream* s;
@@ -56,7 +56,7 @@ static void* drdynvc_server_thread(void* arg)
 	{
 		WLog_ERR(TAG, "Stream_New failed!");
 		ExitThread((DWORD) CHANNEL_RC_NO_MEMORY);
-		return NULL;
+		return CHANNEL_RC_NO_MEMORY;
 	}
 
 	if (WTSVirtualChannelQuery(context->priv->ChannelHandle, WTSVirtualEventHandle,
@@ -111,7 +111,7 @@ static void* drdynvc_server_thread(void* arg)
 #endif
 	// WTF ... this code only reads data into the stream until there is no more memory
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 /**
@@ -136,8 +136,7 @@ static UINT drdynvc_server_start(DrdynvcServerContext* context)
 		return ERROR_INTERNAL_ERROR;
 	}
 
-	if (!(context->priv->Thread = CreateThread(NULL, 0,
-	                              (LPTHREAD_START_ROUTINE) drdynvc_server_thread, (void*) context, 0, NULL)))
+	if (!(context->priv->Thread = CreateThread(NULL, 0, drdynvc_server_thread, (void*) context, 0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");
 		CloseHandle(context->priv->StopEvent);

--- a/channels/drive/client/drive_main.c
+++ b/channels/drive/client/drive_main.c
@@ -743,7 +743,7 @@ static UINT drive_process_irp(DRIVE_DEVICE* drive, IRP* irp)
 	return error;
 }
 
-static void* drive_thread_func(void* arg)
+static DWORD WINAPI drive_thread_func(LPVOID arg)
 {
 	IRP* irp;
 	wMessage message;
@@ -791,8 +791,8 @@ fail:
 	if (error && drive && drive->rdpcontext)
 		setChannelError(drive->rdpcontext, error, "drive_thread_func reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -947,7 +947,7 @@ static UINT drive_register_drive_path(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints,
 			goto out_error;
 		}
 
-		if (!(drive->thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) drive_thread_func, drive,
+		if (!(drive->thread = CreateThread(NULL, 0, drive_thread_func, drive,
 		                                   CREATE_SUSPENDED, NULL)))
 		{
 			WLog_ERR(TAG, "CreateThread failed!");

--- a/channels/echo/server/echo_main.c
+++ b/channels/echo/server/echo_main.c
@@ -105,7 +105,7 @@ static UINT echo_server_open_channel(echo_server* echo)
 	return echo->echo_channel ? CHANNEL_RC_OK : ERROR_INTERNAL_ERROR;
 }
 
-static void* echo_server_thread_func(void* arg)
+static DWORD WINAPI echo_server_thread_func(LPVOID arg)
 {
 	wStream* s;
 	void* buffer;
@@ -264,8 +264,8 @@ out:
 		setChannelError(echo->context.rdpcontext, error,
 		                "echo_server_thread_func reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -285,8 +285,7 @@ static UINT echo_server_open(echo_server_context* context)
 			return ERROR_INTERNAL_ERROR;
 		}
 
-		if (!(echo->thread = CreateThread(NULL, 0,
-		                                  (LPTHREAD_START_ROUTINE) echo_server_thread_func, (void*) echo, 0, NULL)))
+		if (!(echo->thread = CreateThread(NULL, 0, echo_server_thread_func, (void*) echo, 0, NULL)))
 		{
 			WLog_ERR(TAG, "CreateEvent failed!");
 			CloseHandle(echo->stopEvent);

--- a/channels/echo/server/echo_main.c
+++ b/channels/echo/server/echo_main.c
@@ -206,8 +206,8 @@ static DWORD WINAPI echo_server_thread_func(LPVOID arg)
 	{
 		WLog_ERR(TAG, "Stream_New failed!");
 		WTSVirtualChannelClose(echo->echo_channel);
-		ExitThread((DWORD)ERROR_NOT_ENOUGH_MEMORY);
-		return NULL;
+		ExitThread(ERROR_NOT_ENOUGH_MEMORY);
+		return ERROR_NOT_ENOUGH_MEMORY;
 	}
 
 	while (ready)

--- a/channels/encomsp/client/encomsp_main.c
+++ b/channels/encomsp/client/encomsp_main.c
@@ -1011,7 +1011,7 @@ static VOID VCAPITYPE encomsp_virtual_channel_open_event_ex(LPVOID lpUserParam, 
 	return;
 }
 
-static void* encomsp_virtual_channel_client_thread(void* arg)
+static DWORD WINAPI encomsp_virtual_channel_client_thread(LPVOID arg)
 {
 	wStream* data;
 	wMessage message;
@@ -1054,8 +1054,8 @@ static void* encomsp_virtual_channel_client_thread(void* arg)
 		setChannelError(encomsp->rdpcontext, error,
 		                "encomsp_virtual_channel_client_thread reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -1087,7 +1087,7 @@ static UINT encomsp_virtual_channel_event_connected(encomspPlugin* encomsp,
 	}
 
 	if (!(encomsp->thread = CreateThread(NULL, 0,
-	                                     (LPTHREAD_START_ROUTINE) encomsp_virtual_channel_client_thread, (void*) encomsp,
+										 encomsp_virtual_channel_client_thread, (void*) encomsp,
 	                                     0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");

--- a/channels/encomsp/server/encomsp_main.c
+++ b/channels/encomsp/server/encomsp_main.c
@@ -174,7 +174,7 @@ static UINT encomsp_server_receive_pdu(EncomspServerContext* context,
 	return error;
 }
 
-static void* encomsp_server_thread(void* arg)
+static DWORD WINAPI encomsp_server_thread(LPVOID arg)
 {
 	wStream* s;
 	DWORD nCount;
@@ -285,8 +285,8 @@ out:
 		setChannelError(context->rdpcontext, error,
 		                "encomsp_server_thread reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -309,7 +309,7 @@ static UINT encomsp_server_start(EncomspServerContext* context)
 	}
 
 	if (!(context->priv->Thread = CreateThread(NULL, 0,
-	                              (LPTHREAD_START_ROUTINE) encomsp_server_thread, (void*) context, 0, NULL)))
+								  encomsp_server_thread, (void*) context, 0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");
 		CloseHandle(context->priv->StopEvent);

--- a/channels/parallel/client/parallel_main.c
+++ b/channels/parallel/client/parallel_main.c
@@ -304,7 +304,7 @@ static UINT parallel_process_irp(PARALLEL_DEVICE* parallel, IRP* irp)
 	return CHANNEL_RC_OK;
 }
 
-static void* parallel_thread_func(void* arg)
+static DWORD WINAPI parallel_thread_func(LPVOID arg)
 {
 	IRP* irp;
 	wMessage message;
@@ -343,8 +343,8 @@ static void* parallel_thread_func(void* arg)
 		setChannelError(parallel->rdpcontext, error,
 		                "parallel_thread_func reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -466,7 +466,7 @@ UINT DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
 		}
 
 		if (!(parallel->thread = CreateThread(NULL, 0,
-		                                      (LPTHREAD_START_ROUTINE) parallel_thread_func, (void*) parallel, 0, NULL)))
+											  parallel_thread_func, (void*) parallel, 0, NULL)))
 		{
 			WLog_ERR(TAG, "CreateThread failed!");
 			error = ERROR_INTERNAL_ERROR;

--- a/channels/printer/client/printer_main.c
+++ b/channels/printer/client/printer_main.c
@@ -231,7 +231,7 @@ static UINT printer_process_irp(PRINTER_DEVICE* printer_dev, IRP* irp)
 	return CHANNEL_RC_OK;
 }
 
-static void* printer_thread_func(void* arg)
+static DWORD WINAPI printer_thread_func(LPVOID arg)
 {
 	IRP* irp;
 	PRINTER_DEVICE* printer_dev = (PRINTER_DEVICE*) arg;
@@ -275,8 +275,8 @@ static void* printer_thread_func(void* arg)
 		setChannelError(printer_dev->rdpcontext, error,
 		                "printer_thread_func reported an error");
 
-	ExitThread((DWORD) error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -445,8 +445,7 @@ UINT printer_register(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints,
 		goto error_out;
 	}
 
-	if (!(printer_dev->thread = CreateThread(NULL, 0,
-	                            (LPTHREAD_START_ROUTINE) printer_thread_func, (void*) printer_dev, 0, NULL)))
+	if (!(printer_dev->thread = CreateThread(NULL, 0, printer_thread_func, (void*) printer_dev, 0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");
 		error = ERROR_INTERNAL_ERROR;

--- a/channels/rail/client/rail_main.c
+++ b/channels/rail/client/rail_main.c
@@ -606,7 +606,7 @@ static VOID VCAPITYPE rail_virtual_channel_open_event_ex(LPVOID lpUserParam, DWO
 	return;
 }
 
-static void* rail_virtual_channel_client_thread(void* arg)
+static DWORD WINAPI rail_virtual_channel_client_thread(LPVOID arg)
 {
 	wStream* data;
 	wMessage message;
@@ -650,8 +650,8 @@ static void* rail_virtual_channel_client_thread(void* arg)
 		setChannelError(rail->rdpcontext, error,
 		                "rail_virtual_channel_client_thread reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -682,7 +682,7 @@ static UINT rail_virtual_channel_event_connected(railPlugin* rail, LPVOID pData,
 	}
 
 	if (!(rail->thread = CreateThread(NULL, 0,
-	                                  (LPTHREAD_START_ROUTINE) rail_virtual_channel_client_thread, (void*) rail, 0,
+									  rail_virtual_channel_client_thread, (void*) rail, 0,
 	                                  NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");

--- a/channels/rdpdr/server/rdpdr_main.c
+++ b/channels/rdpdr/server/rdpdr_main.c
@@ -1129,7 +1129,7 @@ static UINT rdpdr_server_receive_pdu(RdpdrServerContext* context, wStream* s,
 	return error;
 }
 
-static void* rdpdr_server_thread(void* arg)
+static DWORD WINAPI rdpdr_server_thread(LPVOID arg)
 {
 	wStream* s;
 	DWORD status;
@@ -1233,8 +1233,8 @@ out:
 		setChannelError(context->rdpcontext, error,
 		                "rdpdr_server_thread reported an error");
 
-	ExitThread((DWORD) error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -1260,7 +1260,7 @@ static UINT rdpdr_server_start(RdpdrServerContext* context)
 	}
 
 	if (!(context->priv->Thread = CreateThread(NULL, 0,
-	                              (LPTHREAD_START_ROUTINE) rdpdr_server_thread, (void*) context, 0, NULL)))
+								  rdpdr_server_thread, (void*) context, 0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");
 		CloseHandle(context->priv->StopEvent);

--- a/channels/rdpei/client/rdpei_main.c
+++ b/channels/rdpei/client/rdpei_main.c
@@ -169,7 +169,7 @@ UINT rdpei_add_frame(RdpeiClientContext* context)
 	return CHANNEL_RC_OK;
 }
 
-static void* rdpei_schedule_thread(void* arg)
+static DWORD WINAPI rdpei_schedule_thread(LPVOID arg)
 {
 	DWORD status;
 	RDPEI_PLUGIN* rdpei = (RDPEI_PLUGIN*) arg;
@@ -232,8 +232,8 @@ out:
 		setChannelError(rdpei->rdpcontext, error,
 		                "rdpei_schedule_thread reported an error");
 
-	ExitThread(0);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -653,7 +653,7 @@ static UINT rdpei_plugin_initialize(IWTSPlugin* pPlugin,
 		goto error_out;
 	}
 
-	if (!(rdpei->thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)
+	if (!(rdpei->thread = CreateThread(NULL, 0,
 	                                   rdpei_schedule_thread, (void*) rdpei, 0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");

--- a/channels/rdpgfx/server/rdpgfx_main.c
+++ b/channels/rdpgfx/server/rdpgfx_main.c
@@ -1327,7 +1327,7 @@ static UINT rdpgfx_server_receive_pdu(RdpgfxServerContext* context, wStream* s)
 	return error;
 }
 
-static void* rdpgfx_server_thread_func(void* arg)
+static DWORD WINAPI rdpgfx_server_thread_func(LPVOID arg)
 {
 	RdpgfxServerContext* context = (RdpgfxServerContext*) arg;
 	RdpgfxServerPrivate* priv = context->priv;
@@ -1369,8 +1369,8 @@ static void* rdpgfx_server_thread_func(void* arg)
 		setChannelError(context->rdpcontext, error,
 		                "rdpgfx_server_thread_func reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 static BOOL rdpgfx_server_open(RdpgfxServerContext* context)
@@ -1437,7 +1437,6 @@ static BOOL rdpgfx_server_open(RdpgfxServerContext* context)
 			}
 
 			if (!(priv->thread = CreateThread(NULL, 0,
-			                                  (LPTHREAD_START_ROUTINE)
 			                                  rdpgfx_server_thread_func,
 			                                  (void*) context, 0, NULL)))
 			{

--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -103,7 +103,7 @@ struct rdpsnd_plugin
  */
 static UINT rdpsnd_confirm_wave(rdpsndPlugin* rdpsnd, RDPSND_WAVE* wave);
 
-static void* rdpsnd_schedule_thread(void* arg)
+static DWORD WINAPI rdpsnd_schedule_thread(LPVOID arg)
 {
 	wMessage message;
 	UINT16 wTimeDiff;
@@ -183,8 +183,8 @@ static void* rdpsnd_schedule_thread(void* arg)
 		setChannelError(rdpsnd->rdpcontext, error,
 		                "rdpsnd_schedule_thread reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -1115,7 +1115,7 @@ static UINT rdpsnd_process_connect(rdpsndPlugin* rdpsnd)
 		}
 
 		rdpsnd->ScheduleThread = CreateThread(NULL, 0,
-		                                      (LPTHREAD_START_ROUTINE) rdpsnd_schedule_thread,
+											  rdpsnd_schedule_thread,
 		                                      (void*) rdpsnd, 0, NULL);
 
 		if (!rdpsnd->ScheduleThread)
@@ -1271,7 +1271,7 @@ static VOID VCAPITYPE rdpsnd_virtual_channel_open_event_ex(LPVOID lpUserParam, D
 		                "rdpsnd_virtual_channel_open_event_ex reported an error");
 }
 
-static void* rdpsnd_virtual_channel_client_thread(void* arg)
+static DWORD WINAPI rdpsnd_virtual_channel_client_thread(LPVOID arg)
 {
 	wStream* data;
 	wMessage message;
@@ -1322,8 +1322,8 @@ out:
 		                "rdpsnd_virtual_channel_client_thread reported an error");
 
 	rdpsnd_process_disconnect(rdpsnd);
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -1355,7 +1355,7 @@ static UINT rdpsnd_virtual_channel_event_connected(rdpsndPlugin* rdpsnd,
 	}
 
 	rdpsnd->thread = CreateThread(NULL, 0,
-	                              (LPTHREAD_START_ROUTINE) rdpsnd_virtual_channel_client_thread, (void*) rdpsnd,
+								  rdpsnd_virtual_channel_client_thread, (void*) rdpsnd,
 	                              0, NULL);
 
 	if (!rdpsnd->thread)

--- a/channels/rdpsnd/server/rdpsnd_main.c
+++ b/channels/rdpsnd/server/rdpsnd_main.c
@@ -239,7 +239,7 @@ out_free:
 	return error;
 }
 
-static void* rdpsnd_server_thread(void* arg)
+static DWORD WINAPI rdpsnd_server_thread(LPVOID arg)
 {
 	DWORD nCount, status;
 	HANDLE events[8];
@@ -293,8 +293,8 @@ out:
 		setChannelError(context->rdpcontext, error,
 		                "rdpsnd_server_thread reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -701,7 +701,7 @@ static UINT rdpsnd_server_start(RdpsndServerContext* context)
 		}
 
 		context->priv->Thread = CreateThread(NULL, 0,
-		                                     (LPTHREAD_START_ROUTINE) rdpsnd_server_thread, (void*) context, 0, NULL);
+											 rdpsnd_server_thread, (void*) context, 0, NULL);
 
 		if (!context->priv->Thread)
 		{

--- a/channels/remdesk/client/remdesk_main.c
+++ b/channels/remdesk/client/remdesk_main.c
@@ -804,7 +804,7 @@ static VOID VCAPITYPE remdesk_virtual_channel_open_event_ex(LPVOID lpUserParam, 
 		                "remdesk_virtual_channel_open_event_ex reported an error");
 }
 
-static void* remdesk_virtual_channel_client_thread(void* arg)
+static DWORD WINAPI remdesk_virtual_channel_client_thread(LPVOID arg)
 {
 	wStream* data;
 	wMessage message;
@@ -847,8 +847,8 @@ static void* remdesk_virtual_channel_client_thread(void* arg)
 		setChannelError(remdesk->rdpcontext, error,
 		                "remdesk_virtual_channel_client_thread reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -882,7 +882,7 @@ static UINT remdesk_virtual_channel_event_connected(remdeskPlugin* remdesk,
 	}
 
 	remdesk->thread = CreateThread(NULL, 0,
-	                               (LPTHREAD_START_ROUTINE) remdesk_virtual_channel_client_thread, (void*) remdesk,
+								   remdesk_virtual_channel_client_thread, (void*) remdesk,
 	                               0, NULL);
 
 	if (!remdesk->thread)

--- a/channels/remdesk/server/remdesk_main.c
+++ b/channels/remdesk/server/remdesk_main.c
@@ -578,7 +578,7 @@ static UINT remdesk_server_receive_pdu(RemdeskServerContext* context,
 	return error;
 }
 
-static void* remdesk_server_thread(void* arg)
+static DWORD WINAPI remdesk_server_thread(LPVOID arg)
 {
 	wStream* s;
 	DWORD status;
@@ -700,8 +700,8 @@ out:
 		setChannelError(context->rdpcontext, error,
 		                "remdesk_server_thread reported an error");
 
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 /**
@@ -727,7 +727,7 @@ static UINT remdesk_server_start(RemdeskServerContext* context)
 	}
 
 	if (!(context->priv->Thread = CreateThread(NULL, 0,
-	                              (LPTHREAD_START_ROUTINE) remdesk_server_thread, (void*) context, 0, NULL)))
+								  remdesk_server_thread, (void*) context, 0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");
 		CloseHandle(context->priv->StopEvent);

--- a/channels/serial/client/serial_main.c
+++ b/channels/serial/client/serial_main.c
@@ -483,7 +483,7 @@ static UINT serial_process_irp(SERIAL_DEVICE* serial, IRP* irp)
 }
 
 
-static void* irp_thread_func(void* arg)
+static DWORD WINAPI irp_thread_func(LPVOID arg)
 {
 	IRP_THREAD_DATA* data = (IRP_THREAD_DATA*)arg;
 	UINT error;
@@ -509,8 +509,8 @@ error_out:
 	 * the CompletionId whereas the thread is not yet
 	 * terminated */
 	free(data);
-	ExitThread((DWORD)error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 
@@ -642,7 +642,7 @@ static void create_irp_thread(SERIAL_DEVICE* serial, IRP* irp)
 	/* data freed by irp_thread_func */
 	irpThread = CreateThread(NULL,
 	                         0,
-	                         (LPTHREAD_START_ROUTINE)irp_thread_func,
+							 irp_thread_func,
 	                         (void*)data,
 	                         0,
 	                         NULL);
@@ -697,7 +697,7 @@ static void terminate_pending_irp_threads(SERIAL_DEVICE* serial)
 }
 
 
-static void* serial_thread_func(void* arg)
+static DWORD WINAPI serial_thread_func(LPVOID arg)
 {
 	IRP* irp;
 	wMessage message;
@@ -736,8 +736,8 @@ static void* serial_thread_func(void* arg)
 		setChannelError(serial->rdpcontext, error,
 		                "serial_thread_func reported an error");
 
-	ExitThread((DWORD) error);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 
@@ -952,7 +952,7 @@ UINT DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
 
 		if (!(serial->MainThread = CreateThread(NULL,
 		                                        0,
-		                                        (LPTHREAD_START_ROUTINE) serial_thread_func,
+												serial_thread_func,
 		                                        (void*) serial,
 		                                        0,
 		                                        NULL)))

--- a/channels/sshagent/client/sshagent_main.c
+++ b/channels/sshagent/client/sshagent_main.c
@@ -139,7 +139,7 @@ static int connect_to_sshagent(const char* udspath)
  *
  * @return NULL
  */
-static void* sshagent_read_thread(void* data)
+static DWORD WINAPI sshagent_read_thread(LPVOID data)
 {
 	SSHAGENT_CHANNEL_CALLBACK* callback = (SSHAGENT_CHANNEL_CALLBACK*)data;
 	BYTE buffer[4096];
@@ -189,8 +189,8 @@ static void* sshagent_read_thread(void* data)
 		setChannelError(callback->rdpcontext, status,
 		                "sshagent_read_thread reported an error");
 
-	ExitThread(0);
-	return NULL;
+        ExitThread(status);
+        return status;
 }
 
 /**
@@ -302,7 +302,7 @@ static UINT sshagent_on_new_channel_connection(IWTSListenerCallback* pListenerCa
 	callback->thread
 	    = CreateThread(NULL,
 	                   0,
-	                   (LPTHREAD_START_ROUTINE) sshagent_read_thread,
+                           sshagent_read_thread,
 	                   (void*) callback,
 	                   0,
 	                   NULL);

--- a/channels/tsmf/client/tsmf_media.c
+++ b/channels/tsmf/client/tsmf_media.c
@@ -737,7 +737,7 @@ static BOOL tsmf_sample_playback(TSMF_SAMPLE* sample)
 	return ret;
 }
 
-static void* tsmf_stream_ack_func(void* arg)
+static DWORD WINAPI tsmf_stream_ack_func(LPVOID arg)
 {
 	HANDLE hdl[2];
 	TSMF_STREAM* stream = (TSMF_STREAM*) arg;
@@ -817,11 +817,11 @@ static void* tsmf_stream_ack_func(void* arg)
 		                "tsmf_stream_ack_func reported an error");
 
 	DEBUG_TSMF("out %"PRIu32"", stream->stream_id);
-	ExitThread(0);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
-static void* tsmf_stream_playback_func(void* arg)
+static DWORD WINAPI tsmf_stream_playback_func(LPVOID arg)
 {
 	HANDLE hdl[2];
 	TSMF_SAMPLE* sample = NULL;
@@ -907,8 +907,8 @@ static void* tsmf_stream_playback_func(void* arg)
 		                "tsmf_stream_playback_func reported an error");
 
 	DEBUG_TSMF("out %"PRIu32"", stream->stream_id);
-	ExitThread(0);
-	return NULL;
+	ExitThread(error);
+	return error;
 }
 
 static BOOL tsmf_stream_start(TSMF_STREAM* stream)
@@ -1259,13 +1259,13 @@ TSMF_STREAM* tsmf_stream_new(TSMF_PRESENTATION* presentation, UINT32 stream_id,
 		goto error_sample_ack_list;
 
 	stream->sample_ack_list->object.fnObjectFree = tsmf_sample_free;
-	stream->play_thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) tsmf_stream_playback_func,
+	stream->play_thread = CreateThread(NULL, 0, tsmf_stream_playback_func,
 	                                   stream, CREATE_SUSPENDED, NULL);
 
 	if (!stream->play_thread)
 		goto error_play_thread;
 
-	stream->ack_thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)tsmf_stream_ack_func, stream,
+	stream->ack_thread = CreateThread(NULL, 0, tsmf_stream_ack_func, stream,
 	                                  CREATE_SUSPENDED, NULL);
 
 	if (!stream->ack_thread)

--- a/client/Android/android_freerdp.c
+++ b/client/Android/android_freerdp.c
@@ -494,7 +494,7 @@ static DWORD android_verify_changed_certificate(freerdp* instance,
 	return res;
 }
 
-static void* jni_input_thread(void* arg)
+static DWORD WINAPI jni_input_thread(LPVOID arg)
 {
 	HANDLE event[2];
 	wMessageQueue* queue;
@@ -536,7 +536,7 @@ static void* jni_input_thread(void* arg)
 disconnect:
 	MessageQueue_PostQuit(queue, 0);
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 static int android_freerdp_run(freerdp* instance)
@@ -553,8 +553,7 @@ static int android_freerdp_run(freerdp* instance)
 
 	if (async_input)
 	{
-		if (!(inputThread = CreateThread(NULL, 0,
-		                                 (LPTHREAD_START_ROUTINE) jni_input_thread, instance, 0, NULL)))
+		if (!(inputThread = CreateThread(NULL, 0, jni_input_thread, instance, 0, NULL)))
 		{
 			WLog_ERR(TAG, "async input: failed to create input thread");
 			goto disconnect;
@@ -627,7 +626,7 @@ disconnect:
 	return status;
 }
 
-static void* android_thread_func(void* param)
+static DWORD WINAPI android_thread_func(LPVOID param)
 {
 	DWORD status = ERROR_BAD_ARGUMENTS;
 	freerdp* instance = param;
@@ -667,7 +666,7 @@ fail:
 
 	WLog_DBG(TAG, "Quit.");
 	ExitThread(status);
-	return NULL;
+	return status;
 }
 
 static BOOL android_client_new(freerdp* instance, rdpContext* context)
@@ -869,8 +868,7 @@ static jboolean JNICALL jni_freerdp_connect(JNIEnv* env, jclass cls,
 
 	ctx = (androidContext*)inst->context;
 
-	if (!(ctx->thread = CreateThread(
-	                        NULL, 0, (LPTHREAD_START_ROUTINE)android_thread_func,
+	if (!(ctx->thread = CreateThread(NULL, 0, android_thread_func,
 	                        inst, 0, NULL)))
 	{
 		return JNI_FALSE;

--- a/client/Sample/freerdp.c
+++ b/client/Sample/freerdp.c
@@ -113,8 +113,9 @@ static BOOL tf_post_connect(freerdp* instance)
 	return TRUE;
 }
 
-static void* tf_client_thread_proc(freerdp* instance)
+static DWORD WINAPI tf_client_thread_proc(LPVOID arg)
 {
+	freerdp* instance = (freerdp*)arg;
 	DWORD nCount;
 	DWORD status;
 	HANDLE handles[64];
@@ -122,7 +123,7 @@ static void* tf_client_thread_proc(freerdp* instance)
 	if (!freerdp_connect(instance))
 	{
 		WLog_ERR(TAG, "connection failure");
-		return NULL;
+		return 0;
 	}
 
 	while (!freerdp_shall_disconnect(instance))
@@ -155,7 +156,7 @@ static void* tf_client_thread_proc(freerdp* instance)
 
 	freerdp_disconnect(instance);
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 int main(int argc, char* argv[])
@@ -196,8 +197,7 @@ int main(int argc, char* argv[])
 	                                instance->settings))
 		return winpr_exit(-1);
 
-	if (!(thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)
-	                            tf_client_thread_proc, instance, 0, NULL)))
+	if (!(thread = CreateThread(NULL, 0, tf_client_thread_proc, instance, 0, NULL)))
 	{
 		WLog_ERR(TAG, "Failed to create client thread");
 	}

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -583,7 +583,7 @@ static BOOL wf_auto_reconnect(freerdp* instance)
 	return FALSE;
 }
 
-static void* wf_input_thread(void* arg)
+static DWORD WINAPI wf_input_thread(LPVOID arg)
 {
 	int status;
 	wMessage message;
@@ -609,7 +609,7 @@ static void* wf_input_thread(void* arg)
 	}
 
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 static DWORD WINAPI wf_client_thread(LPVOID lpParam)
@@ -644,8 +644,7 @@ static DWORD WINAPI wf_client_thread(LPVOID lpParam)
 
 	if (async_input)
 	{
-		if (!(input_thread = CreateThread(NULL, 0,
-		                                  (LPTHREAD_START_ROUTINE) wf_input_thread,
+		if (!(input_thread = CreateThread(NULL, 0, wf_input_thread,
 		                                  instance, 0, NULL)))
 		{
 			WLog_ERR(TAG, "Failed to create async input thread.");

--- a/client/Windows/wf_cliprdr.c
+++ b/client/Windows/wf_cliprdr.c
@@ -1565,7 +1565,7 @@ static int create_cliprdr_window(wfClipboard* clipboard)
 	return 0;
 }
 
-static void* cliprdr_thread_func(void* arg)
+static DWORD WINAPI cliprdr_thread_func(LPVOID arg)
 {
 	int ret;
 	MSG msg;
@@ -1576,7 +1576,7 @@ static void* cliprdr_thread_func(void* arg)
 	if ((ret = create_cliprdr_window(clipboard)) != 0)
 	{
 		DEBUG_CLIPRDR("error: create clipboard window failed.");
-		return NULL;
+		return 0;
 	}
 
 	while ((mcode = GetMessage(&msg, 0, 0, 0)) != 0)
@@ -1594,7 +1594,7 @@ static void* cliprdr_thread_func(void* arg)
 	}
 
 	OleUninitialize();
-	return NULL;
+	return 0;
 }
 
 static void clear_file_array(wfClipboard* clipboard)
@@ -2520,8 +2520,7 @@ BOOL wf_cliprdr_init(wfContext* wfc, CliprdrClientContext* cliprdr)
 	                              _T("request_filecontents_event"))))
 		goto error;
 
-	if (!(clipboard->thread = CreateThread(NULL, 0,
-	                                       (LPTHREAD_START_ROUTINE) cliprdr_thread_func, clipboard, 0, NULL)))
+	if (!(clipboard->thread = CreateThread(NULL, 0, cliprdr_thread_func, clipboard, 0, NULL)))
 		goto error;
 
 	cliprdr->MonitorReady = wf_cliprdr_monitor_ready;

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1314,7 +1314,7 @@ static void xf_post_disconnect(freerdp* instance)
 	}
 
 	if ((xfc->window != NULL) && (xfc->drawable == xfc->window->handle))
-		xfc->drawable = NULL;
+		xfc->drawable = 0;
 	else
 		xf_DestroyDummyWindow(xfc, xfc->drawable);
 

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -1684,7 +1684,7 @@ INT32 progressive_decompress(PROGRESSIVE_CONTEXT* progressive,
 
 				if (region->numRects > progressive->cRects)
 				{
-					BYTE* tmpBuf = (RFX_RECT*) realloc(progressive->rects,
+					RFX_RECT* tmpBuf = (RFX_RECT*) realloc(progressive->rects,
 					               region->numRects * sizeof(RFX_RECT));
 					if (!tmpBuf)
 						return -1016;
@@ -1713,7 +1713,7 @@ INT32 progressive_decompress(PROGRESSIVE_CONTEXT* progressive,
 
 				if (region->numQuant > progressive->cQuant)
 				{
-					BYTE* tmpBuf = (RFX_COMPONENT_CODEC_QUANT*) realloc(
+					RFX_COMPONENT_CODEC_QUANT* tmpBuf = (RFX_COMPONENT_CODEC_QUANT*) realloc(
 					                             progressive->quantVals,
 					                             region->numQuant * sizeof(RFX_COMPONENT_CODEC_QUANT));
 					if (!tmpBuf)
@@ -1746,7 +1746,7 @@ INT32 progressive_decompress(PROGRESSIVE_CONTEXT* progressive,
 
 				if (region->numProgQuant > progressive->cProgQuant)
 				{
-					BYTE* tmpBuf = (RFX_PROGRESSIVE_CODEC_QUANT*) realloc(
+					RFX_PROGRESSIVE_CODEC_QUANT* tmpBuf = (RFX_PROGRESSIVE_CODEC_QUANT*) realloc(
 					                                 progressive->quantProgVals,
 					                                 region->numProgQuant * sizeof(RFX_PROGRESSIVE_CODEC_QUANT));
 					if (!tmpBuf)
@@ -1779,7 +1779,7 @@ INT32 progressive_decompress(PROGRESSIVE_CONTEXT* progressive,
 
 				if (progressive->cTiles < surface->gridSize)
 				{
-					BYTE* tmpBuf = (RFX_PROGRESSIVE_TILE**) realloc(progressive->tiles,
+					RFX_PROGRESSIVE_TILE** tmpBuf = (RFX_PROGRESSIVE_TILE**) realloc(progressive->tiles,
 					                     surface->gridSize * sizeof(RFX_PROGRESSIVE_TILE*));
 					if (!tmpBuf)
 						return -1025;

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -949,7 +949,7 @@ static BOOL rfx_process_message_tileset(RFX_CONTEXT* context,
 			params[i].context = context;
 			params[i].tile = message->tiles[i];
 
-			if (!(work_objects[i] = CreateThreadpoolWork((PTP_WORK_CALLBACK)
+			if (!(work_objects[i] = CreateThreadpoolWork(
 			                        rfx_process_message_tile_work_callback,
 			                        (void*) &params[i], &context->priv->ThreadPoolEnv)))
 			{
@@ -1367,7 +1367,7 @@ struct _RFX_TILE_COMPOSE_WORK_PARAM
 	RFX_CONTEXT* context;
 };
 
-void CALLBACK rfx_compose_message_tile_work_callback(PTP_CALLBACK_INSTANCE
+static void CALLBACK rfx_compose_message_tile_work_callback(PTP_CALLBACK_INSTANCE
         instance, void* context, PTP_WORK work)
 {
 	RFX_TILE_COMPOSE_WORK_PARAM* param = (RFX_TILE_COMPOSE_WORK_PARAM*) context;
@@ -1580,7 +1580,7 @@ RFX_MESSAGE* rfx_encode_message(RFX_CONTEXT* context, const RFX_RECT* rects,
 					workParam->tile = tile;
 
 					if (!(*workObject = CreateThreadpoolWork(
-					                        (PTP_WORK_CALLBACK)rfx_compose_message_tile_work_callback,
+					                        rfx_compose_message_tile_work_callback,
 					                        (void*) workParam,
 					                        &context->priv->ThreadPoolEnv)))
 					{

--- a/libfreerdp/codec/yuv.c
+++ b/libfreerdp/codec/yuv.c
@@ -159,7 +159,7 @@ BOOL yuv_context_decode(YUV_CONTEXT* context, const BYTE* pYUVData[3], UINT32 iS
 		else
 			params[i].height = context->height % context->heightStep;
 
-		work_objects[i] = CreateThreadpoolWork((PTP_WORK_CALLBACK)yuv_process_work_callback,
+		work_objects[i] = CreateThreadpoolWork(yuv_process_work_callback,
 					                        (void*) &params[i], &context->ThreadPoolEnv);
 		if (!work_objects[i])
 		{

--- a/libfreerdp/core/message.c
+++ b/libfreerdp/core/message.c
@@ -2851,7 +2851,7 @@ static BOOL update_message_register_interface(rdpUpdateProxy* message, rdpUpdate
 	return TRUE;
 }
 
-static void* update_message_proxy_thread(void* arg)
+static DWORD WINAPI update_message_proxy_thread(LPVOID arg)
 {
 	rdpUpdate* update = (rdpUpdate*)arg;
 	wMessage message;
@@ -2860,8 +2860,8 @@ static void* update_message_proxy_thread(void* arg)
 	{
 		WLog_ERR(TAG, "update=%p, update->queue=%p", (void*) update,
 		         (void*)(update ? update->queue : NULL));
-		ExitThread(-1);
-		return NULL;
+		ExitThread(1);
+		return 1;
 	}
 
 	while (MessageQueue_Wait(update->queue))
@@ -2876,7 +2876,7 @@ static void* update_message_proxy_thread(void* arg)
 	}
 
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 rdpUpdateProxy* update_message_proxy_new(rdpUpdate* update)
@@ -2892,7 +2892,7 @@ rdpUpdateProxy* update_message_proxy_new(rdpUpdate* update)
 	message->update = update;
 	update_message_register_interface(message, update);
 
-	if (!(message->thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) update_message_proxy_thread,
+	if (!(message->thread = CreateThread(NULL, 0, update_message_proxy_thread,
 	                                     update, 0, NULL)))
 	{
 		WLog_ERR(TAG, "Failed to create proxy thread");

--- a/libfreerdp/core/test/TestConnect.c
+++ b/libfreerdp/core/test/TestConnect.c
@@ -88,7 +88,7 @@ struct testThreadArgs
 	freerdp** arg;
 };
 
-static void* testThread(void* arg)
+static DWORD WINAPI testThread(LPVOID arg)
 {
 	char arg1[] = "/v:192.0.2.1:XXXXX";
 	char* argv[] =
@@ -107,7 +107,7 @@ static void* testThread(void* arg)
 		ExitThread(-1);
 
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 static int testAbort(int port)
@@ -125,7 +125,7 @@ static int testAbort(int port)
 	args.port = port;
 	args.arg = &instance;
 	start = GetTickCount();
-	thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)testThread,
+	thread = CreateThread(NULL, 0, testThread,
 	                      &args, 0, NULL);
 
 	if (!thread)

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -57,7 +57,7 @@
 
 #define BUFFER_SIZE 16384
 
-static void* transport_client_thread(void* arg);
+static DWORD WINAPI transport_client_thread(LPVOID arg);
 
 #ifdef WITH_GSSAPI
 
@@ -425,8 +425,7 @@ BOOL transport_connect(rdpTransport* transport, const char* hostname,
 				return FALSE;
 			}
 
-			if (!(transport->thread = CreateThread(NULL, 0,
-			                                       (LPTHREAD_START_ROUTINE) transport_client_thread, transport, 0, NULL)))
+			if (!(transport->thread = CreateThread(NULL, 0, transport_client_thread, transport, 0, NULL)))
 			{
 				WLog_Print(transport->log, WLOG_ERROR, "Failed to create transport client thread");
 				CloseHandle(transport->stopEvent);
@@ -1132,7 +1131,7 @@ BOOL transport_disconnect(rdpTransport* transport)
 	return status;
 }
 
-static void* transport_client_thread(void* arg)
+DWORD WINAPI transport_client_thread(LPVOID arg)
 {
 	DWORD dwExitCode = 0;
 	DWORD status;
@@ -1217,7 +1216,7 @@ static void* transport_client_thread(void* arg)
 out:
 	WLog_Print(transport->log, WLOG_DEBUG, "Terminating transport thread");
 	ExitThread(dwExitCode);
-	return NULL;
+	return dwExitCode;
 }
 
 rdpTransport* transport_new(rdpContext* context)

--- a/server/Windows/wf_directsound.c
+++ b/server/Windows/wf_directsound.c
@@ -88,7 +88,7 @@ int wf_directsound_activate(RdpsndServerContext* context)
 	return 0;
 }
 
-DWORD WINAPI wf_rdpsnd_directsound_thread(LPVOID lpParam)
+static DWORD WINAPI wf_rdpsnd_directsound_thread(LPVOID lpParam)
 {
 	HRESULT hr;
 	DWORD beg = 0;

--- a/server/Windows/wf_interface.c
+++ b/server/Windows/wf_interface.c
@@ -88,7 +88,7 @@ void set_screen_id(int id)
 	return;
 }
 
-DWORD WINAPI wf_server_main_loop(LPVOID lpParam)
+static DWORD WINAPI wf_server_main_loop(LPVOID lpParam)
 {
 	int i, fds;
 	int rcount;

--- a/server/Windows/wf_peer.c
+++ b/server/Windows/wf_peer.c
@@ -167,7 +167,7 @@ BOOL wf_peer_accepted(freerdp_listener* instance, freerdp_peer* client)
 	return TRUE;
 }
 
-DWORD WINAPI wf_peer_socket_listener(LPVOID lpParam)
+static DWORD WINAPI wf_peer_socket_listener(LPVOID lpParam)
 {
 	int i, fds;
 	int rcount;
@@ -239,7 +239,7 @@ BOOL wf_peer_read_settings(freerdp_peer* client)
 	return TRUE;
 }
 
-DWORD WINAPI wf_peer_main_loop(LPVOID lpParam)
+static DWORD WINAPI wf_peer_main_loop(LPVOID lpParam)
 {
 	wfInfo* wfi;
 	DWORD nCount;

--- a/server/Windows/wf_wasapi.c
+++ b/server/Windows/wf_wasapi.c
@@ -160,7 +160,7 @@ int wf_wasapi_get_device_string(LPWSTR pattern, LPWSTR * deviceStr)
 	return 0;
 }
 
-DWORD WINAPI wf_rdpsnd_wasapi_thread(LPVOID lpParam)
+static DWORD WINAPI wf_rdpsnd_wasapi_thread(LPVOID lpParam)
 {
 	IMMDeviceEnumerator *pEnumerator = NULL;
 	IMMDevice *pDevice = NULL;

--- a/server/shadow/Mac/mac_shadow.c
+++ b/server/shadow/Mac/mac_shadow.c
@@ -499,8 +499,9 @@ static int mac_shadow_subsystem_process_message(macShadowSubsystem* subsystem,
 	return 1;
 }
 
-static void* mac_shadow_subsystem_thread(macShadowSubsystem* subsystem)
+static DWORD WINAPI mac_shadow_subsystem_thread(LPVOID arg)
 {
+	macShadowSubsystem* subsystem = (macShadowSubsystem*)arg;
 	DWORD status;
 	DWORD nCount;
 	UINT64 cTime;
@@ -543,7 +544,7 @@ static void* mac_shadow_subsystem_thread(macShadowSubsystem* subsystem)
 	}
 
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 static int mac_shadow_enum_monitors(MONITOR_DEF* monitors, int maxMonitors)
@@ -600,8 +601,7 @@ static int mac_shadow_subsystem_start(macShadowSubsystem* subsystem)
 
 	mac_shadow_capture_start(subsystem);
 
-	if (!(thread = CreateThread(NULL, 0,
-	                            (LPTHREAD_START_ROUTINE) mac_shadow_subsystem_thread,
+	if (!(thread = CreateThread(NULL, 0, mac_shadow_subsystem_thread,
 	                            (void*) subsystem, 0, NULL)))
 	{
 		WLog_ERR(TAG, "Failed to create thread");

--- a/server/shadow/Win/win_rdp.c
+++ b/server/shadow/Win/win_rdp.c
@@ -156,7 +156,7 @@ static BOOL shw_post_connect(freerdp* instance)
 	return TRUE;
 }
 
-static void* shw_client_thread(void* arg)
+static DWORD WINAPI shw_client_thread(LPVOID arg)
 {
 	int index;
 	int rcount;
@@ -180,7 +180,7 @@ static void* shw_client_thread(void* arg)
 	if (!bSuccess)
 	{
 		ExitThread(0);
-		return NULL;
+		return 0;
 	}
 
 	channels = instance->context->channels;
@@ -237,7 +237,7 @@ static void* shw_client_thread(void* arg)
 
 	freerdp_free(instance);
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 /**
@@ -259,8 +259,7 @@ static int shw_freerdp_client_start(rdpContext* context)
 	freerdp* instance = context->instance;
 	shw = (shwContext*) context;
 
-	if (!(shw->thread = CreateThread(NULL, 0,
-	                                 (LPTHREAD_START_ROUTINE) shw_client_thread,
+	if (!(shw->thread = CreateThread(NULL, 0, shw_client_thread,
 	                                 instance, 0, NULL)))
 	{
 		WLog_ERR(TAG, "Failed to create thread");

--- a/server/shadow/Win/win_shadow.c
+++ b/server/shadow/Win/win_shadow.c
@@ -280,8 +280,9 @@ int win_shadow_surface_copy(winShadowSubsystem* subsystem)
 
 #if defined(WITH_WDS_API)
 
-void* win_shadow_subsystem_thread(winShadowSubsystem* subsystem)
+static DWORD WINAPI win_shadow_subsystem_thread(LPVOID arg)
 {
+	winShadowSubsystem* subsystem = (winShadowSubsystem*)arg;
 	DWORD status;
 	DWORD nCount;
 	HANDLE events[32];
@@ -309,13 +310,14 @@ void* win_shadow_subsystem_thread(winShadowSubsystem* subsystem)
 	}
 
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 #elif defined(WITH_DXGI_1_2)
 
-void* win_shadow_subsystem_thread(winShadowSubsystem* subsystem)
+static DWORD WINAPI win_shadow_subsystem_thread(LPVOID arg)
 {
+	winShadowSubsystem* subsystem = (winShadowSubsystem*)arg;
 	int fps;
 	DWORD status;
 	DWORD nCount;
@@ -361,7 +363,7 @@ void* win_shadow_subsystem_thread(winShadowSubsystem* subsystem)
 	}
 
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 #endif
@@ -438,8 +440,7 @@ int win_shadow_subsystem_start(winShadowSubsystem* subsystem)
 	if (!subsystem)
 		return -1;
 
-	if (!(thread = CreateThread(NULL, 0,
-	                            (LPTHREAD_START_ROUTINE) win_shadow_subsystem_thread,
+	if (!(thread = CreateThread(NULL, 0, win_shadow_subsystem_thread,
 	                            (void*) subsystem, 0, NULL)))
 	{
 		WLog_ERR(TAG, "Failed to create thread");

--- a/server/shadow/X11/x11_shadow.c
+++ b/server/shadow/X11/x11_shadow.c
@@ -919,7 +919,7 @@ static DWORD WINAPI x11_shadow_subsystem_thread(LPVOID arg)
 	}
 
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 static int x11_shadow_subsystem_base_init(x11ShadowSubsystem* subsystem)

--- a/server/shadow/X11/x11_shadow.c
+++ b/server/shadow/X11/x11_shadow.c
@@ -857,8 +857,9 @@ static int x11_shadow_subsystem_process_message(x11ShadowSubsystem* subsystem,
 	return 1;
 }
 
-static void* x11_shadow_subsystem_thread(x11ShadowSubsystem* subsystem)
+static DWORD WINAPI x11_shadow_subsystem_thread(LPVOID arg)
 {
+	x11ShadowSubsystem* subsystem = (x11ShadowSubsystem*)arg;
 	XEvent xevent;
 	DWORD status;
 	DWORD nCount;
@@ -1355,8 +1356,7 @@ static int x11_shadow_subsystem_start(rdpShadowSubsystem* sub)
 	if (!subsystem)
 		return -1;
 
-	if (!(subsystem->thread = CreateThread(NULL, 0,
-	                                       (LPTHREAD_START_ROUTINE) x11_shadow_subsystem_thread,
+	if (!(subsystem->thread = CreateThread(NULL, 0, x11_shadow_subsystem_thread,
 	                                       (void*) subsystem, 0, NULL)))
 	{
 		WLog_ERR(TAG, "Failed to create thread");

--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -719,7 +719,7 @@ static UINT shadow_client_rdpgfx_caps_advertise(RdpgfxServerContext* context,
 			if (settings)
 			{
 				flags = pdu.capsSet->flags;
-				settings->GfxAVC444v2 = settings->GfxAVC444 = settings->GfxAVC444 = FALSE;
+				settings->GfxAVC444v2 = settings->GfxAVC444 = FALSE;
 				settings->GfxThinClient = (flags & RDPGFX_CAPS_FLAG_THINCLIENT);
 				settings->GfxSmallCache = (flags & RDPGFX_CAPS_FLAG_SMALL_CACHE);
 #ifndef WITH_GFX_H264

--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -1595,8 +1595,9 @@ static int shadow_client_subsystem_process_message(rdpShadowClient* client,
 	return 1;
 }
 
-static void* shadow_client_thread(rdpShadowClient* client)
+static DWORD WINAPI shadow_client_thread(LPVOID arg)
 {
+	rdpShadowClient* client = (rdpShadowClient*)arg;
 	DWORD status;
 	DWORD nCount;
 	wMessage message;
@@ -1869,7 +1870,7 @@ out:
 	freerdp_peer_context_free(peer);
 	freerdp_peer_free(peer);
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 BOOL shadow_client_accepted(freerdp_listener* listener, freerdp_peer* peer)
@@ -1892,8 +1893,7 @@ BOOL shadow_client_accepted(freerdp_listener* listener, freerdp_peer* peer)
 
 	client = (rdpShadowClient*) peer->context;
 
-	if (!(client->thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)
-	                                    shadow_client_thread, client, 0, NULL)))
+	if (!(client->thread = CreateThread(NULL, 0, shadow_client_thread, client, 0, NULL)))
 	{
 		freerdp_peer_context_free(peer);
 		return FALSE;

--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -389,8 +389,9 @@ int shadow_server_parse_command_line(rdpShadowServer* server, int argc, char** a
 	return status;
 }
 
-static void* shadow_server_thread(rdpShadowServer* server)
+static DWORD WINAPI shadow_server_thread(LPVOID arg)
 {
+	rdpShadowServer* server = (rdpShadowServer*)arg;
 	BOOL running = TRUE;
 	DWORD status;
 	freerdp_listener* listener = server->listener;
@@ -450,7 +451,7 @@ static void* shadow_server_thread(rdpShadowServer* server)
 	}
 
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 int shadow_server_start(rdpShadowServer* server)
@@ -494,8 +495,7 @@ int shadow_server_start(rdpShadowServer* server)
 		return -1;
 	}
 
-	if (!(server->thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)
-	                                    shadow_server_thread, (void*) server, 0, NULL)))
+	if (!(server->thread = CreateThread(NULL, 0, shadow_server_thread, (void*) server, 0, NULL)))
 	{
 		return -1;
 	}

--- a/winpr/libwinpr/error/test/TestErrorSetLastError.c
+++ b/winpr/libwinpr/error/test/TestErrorSetLastError.c
@@ -31,7 +31,7 @@ static int status = 0;
 LONG *pLoopCount = NULL;
 BOOL bStopTest = FALSE;
 
-static void* test_error_thread(void* arg)
+static DWORD WINAPI test_error_thread(LPVOID arg)
 {
 	int id;
 	DWORD dwErrorSet;
@@ -53,7 +53,7 @@ static void* test_error_thread(void* arg)
 		InterlockedIncrement(pLoopCount);
 	} while (!status && !bStopTest);
 
-	return NULL;
+	return 0;
 }
 
 int TestErrorSetLastError(int argc, char* argv[])
@@ -88,7 +88,7 @@ int TestErrorSetLastError(int argc, char* argv[])
 
 	for (i = 0; i < 4; i++)
 	{
-		if (!(threads[i] = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) test_error_thread, (void*) (size_t) 0, 0, NULL)))
+		if (!(threads[i] = CreateThread(NULL, 0, test_error_thread, (void*) (size_t) 0, 0, NULL)))
 		{
 			printf("Failed to create thread #%d\n", i);
 			return -1;

--- a/winpr/libwinpr/pipe/test/TestPipeCreateNamedPipe.c
+++ b/winpr/libwinpr/pipe/test/TestPipeCreateNamedPipe.c
@@ -21,9 +21,9 @@ static HANDLE ReadyEvent;
 static LPTSTR lpszPipeNameMt = _T("\\\\.\\pipe\\winpr_test_pipe_mt");
 static LPTSTR lpszPipeNameSt = _T("\\\\.\\pipe\\winpr_test_pipe_st");
 
-BOOL testFailed = FALSE;
+static BOOL testFailed = FALSE;
 
-static void* named_pipe_client_thread(void* arg)
+static DWORD WINAPI named_pipe_client_thread(LPVOID arg)
 {
 	HANDLE hNamedPipe = NULL;
 	BYTE* lpReadBuffer = NULL;
@@ -87,10 +87,11 @@ out:
 	if (!fSuccess)
 		testFailed = TRUE;
 
-	return NULL;
+	ExitThread(0);
+	return 0;
 }
 
-static void* named_pipe_server_thread(void* arg)
+static DWORD WINAPI named_pipe_server_thread(LPVOID arg)
 {
 	HANDLE hNamedPipe = NULL;
 	BYTE* lpReadBuffer = NULL;
@@ -179,11 +180,12 @@ out:
 	if (!fSuccess)
 		testFailed = TRUE;
 
-	return NULL;
+	ExitThread(0);
+	return 0;
 }
 
 #define TESTNUMPIPESST 16
-static void* named_pipe_single_thread(void* arg)
+static DWORD WINAPI named_pipe_single_thread(LPVOID arg)
 {
 	HANDLE servers[TESTNUMPIPESST];
 	HANDLE clients[TESTNUMPIPESST];
@@ -431,7 +433,7 @@ out:
 	if (!bSuccess)
 		testFailed = TRUE;
 
-	return NULL;
+	return 0;
 }
 
 
@@ -459,17 +461,17 @@ int TestPipeCreateNamedPipe(int argc, char* argv[])
 		printf("CreateEvent failure: (%"PRIu32")\n", GetLastError());
 		return -1;
 	}
-	if (!(SingleThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) named_pipe_single_thread, NULL, 0, NULL)))
+	if (!(SingleThread = CreateThread(NULL, 0, named_pipe_single_thread, NULL, 0, NULL)))
 	{
 		printf("CreateThread (SingleThread) failure: (%"PRIu32")\n", GetLastError());
 		return -1;
 	}
-	if (!(ClientThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) named_pipe_client_thread, NULL, 0, NULL)))
+	if (!(ClientThread = CreateThread(NULL, 0, named_pipe_client_thread, NULL, 0, NULL)))
 	{
 		printf("CreateThread (ClientThread) failure: (%"PRIu32")\n", GetLastError());
 		return -1;
 	}
-	if (!(ServerThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) named_pipe_server_thread, NULL, 0, NULL)))
+	if (!(ServerThread = CreateThread(NULL, 0, named_pipe_server_thread, NULL, 0, NULL)))
 	{
 		printf("CreateThread (ServerThread) failure: (%"PRIu32")\n", GetLastError());
 		return -1;

--- a/winpr/libwinpr/pipe/test/TestPipeCreateNamedPipeOverlapped.c
+++ b/winpr/libwinpr/pipe/test/TestPipeCreateNamedPipeOverlapped.c
@@ -13,17 +13,17 @@
 #define PIPE_BUFFER_SIZE	32
 #define PIPE_TIMEOUT_MS		20000	// 20 seconds
 
-BYTE SERVER_MESSAGE[PIPE_BUFFER_SIZE];
-BYTE CLIENT_MESSAGE[PIPE_BUFFER_SIZE];
+static BYTE SERVER_MESSAGE[PIPE_BUFFER_SIZE];
+static BYTE CLIENT_MESSAGE[PIPE_BUFFER_SIZE];
 
-BOOL bClientSuccess = FALSE;
-BOOL bServerSuccess = FALSE;
+static BOOL bClientSuccess = FALSE;
+static BOOL bServerSuccess = FALSE;
 
 static HANDLE serverReadyEvent;
 
 static LPTSTR lpszPipeName = _T("\\\\.\\pipe\\winpr_test_pipe_overlapped");
 
-static void* named_pipe_client_thread(void* arg)
+static DWORD WINAPI named_pipe_client_thread(LPVOID arg)
 {
 	DWORD status;
 	HANDLE hEvent = NULL;
@@ -153,10 +153,10 @@ finish:
 	if (hEvent)
 		CloseHandle(hEvent);
 
-	return NULL;
+	return 0;
 }
 
-static void* named_pipe_server_thread(void* arg)
+static DWORD WINAPI named_pipe_server_thread(LPVOID arg)
 {
 	DWORD status;
 	HANDLE hEvent = NULL;
@@ -331,7 +331,7 @@ finish:
 	CloseHandle(hNamedPipe);
 	CloseHandle(hEvent);
 	free(lpReadBuffer);
-	return NULL;
+	return 0;
 }
 
 int TestPipeCreateNamedPipeOverlapped(int argc, char* argv[])
@@ -348,7 +348,7 @@ int TestPipeCreateNamedPipeOverlapped(int argc, char* argv[])
 		printf("CreateEvent failed: %"PRIu32"\n", GetLastError());
 		goto out;
 	}
-	if (!(ClientThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) named_pipe_client_thread, NULL, 0, NULL)))
+	if (!(ClientThread = CreateThread(NULL, 0, named_pipe_client_thread, NULL, 0, NULL)))
 	{
 		printf("CreateThread (client) failed: %"PRIu32"\n", GetLastError());
 		goto out;

--- a/winpr/libwinpr/pool/pool.c
+++ b/winpr/libwinpr/pool/pool.c
@@ -60,7 +60,7 @@ static TP_POOL DEFAULT_POOL =
 	NULL, /* wCountdownEvent* WorkComplete */
 };
 
-static void* thread_pool_work_func(void* arg)
+static DWORD WINAPI thread_pool_work_func(LPVOID arg)
 {
 	DWORD status;
 	PTP_POOL pool;
@@ -95,7 +95,7 @@ static void* thread_pool_work_func(void* arg)
 	}
 
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 static void threads_close(void *thread)
@@ -132,7 +132,7 @@ static BOOL InitializeThreadpool(PTP_POOL pool)
 	for (index = 0; index < 4; index++)
 	{
 		if (!(thread = CreateThread(NULL, 0,
-					(LPTHREAD_START_ROUTINE) thread_pool_work_func,
+					thread_pool_work_func,
 					(void*) pool, 0, NULL)))
 		{
 			goto fail_create_threads;
@@ -237,7 +237,7 @@ BOOL winpr_SetThreadpoolThreadMinimum(PTP_POOL ptpp, DWORD cthrdMic)
 	while (ArrayList_Count(ptpp->Threads) < ptpp->Minimum)
 	{
 		if (!(thread = CreateThread(NULL, 0,
-				(LPTHREAD_START_ROUTINE) thread_pool_work_func,
+				thread_pool_work_func,
 				(void*) ptpp, 0, NULL)))
 		{
 			return FALSE;

--- a/winpr/libwinpr/pool/test/TestPoolWork.c
+++ b/winpr/libwinpr/pool/test/TestPoolWork.c
@@ -31,7 +31,7 @@ static BOOL test1(void)
 	int index;
 	PTP_WORK work;
 	printf("Global Thread Pool\n");
-	work = CreateThreadpoolWork((PTP_WORK_CALLBACK) test_WorkCallback, "world", NULL);
+	work = CreateThreadpoolWork(test_WorkCallback, "world", NULL);
 
 	if (!work)
 	{
@@ -86,7 +86,7 @@ static BOOL test2(void)
 	}
 
 	SetThreadpoolCallbackCleanupGroup(&environment, cleanupGroup, NULL);
-	work = CreateThreadpoolWork((PTP_WORK_CALLBACK) test_WorkCallback, "world", &environment);
+	work = CreateThreadpoolWork(test_WorkCallback, "world", &environment);
 
 	if (!work)
 	{

--- a/winpr/libwinpr/synch/test/TestSynchBarrier.c
+++ b/winpr/libwinpr/synch/test/TestSynchBarrier.c
@@ -23,7 +23,7 @@ struct test_params
 };
 
 
-DWORD WINAPI test_synch_barrier_thread(LPVOID lpParam)
+static DWORD WINAPI test_synch_barrier_thread(LPVOID lpParam)
 {
 	BOOL status = FALSE;
 	struct test_params* p = (struct test_params*)lpParam;

--- a/winpr/libwinpr/synch/test/TestSynchCritical.c
+++ b/winpr/libwinpr/synch/test/TestSynchCritical.c
@@ -10,11 +10,11 @@
 #define TEST_SYNC_CRITICAL_TEST1_RUNTIME_MS 500
 #define TEST_SYNC_CRITICAL_TEST1_RUNS 4
 
-CRITICAL_SECTION critical;
-LONG gTestValueVulnerable = 0;
-LONG gTestValueSerialized = 0;
+static CRITICAL_SECTION critical;
+static LONG gTestValueVulnerable = 0;
+static LONG gTestValueSerialized = 0;
 
-BOOL TestSynchCritical_TriggerAndCheckRaceCondition(HANDLE OwningThread, LONG RecursionCount)
+static BOOL TestSynchCritical_TriggerAndCheckRaceCondition(HANDLE OwningThread, LONG RecursionCount)
 {
 	/* if called unprotected this will hopefully trigger a race condition ... */
 	gTestValueVulnerable++;
@@ -41,7 +41,7 @@ BOOL TestSynchCritical_TriggerAndCheckRaceCondition(HANDLE OwningThread, LONG Re
 }
 
 /* this thread function shall increment the global dwTestValue until the PBOOL passsed in arg is FALSE */
-static PVOID TestSynchCritical_Test1(PVOID arg)
+static DWORD WINAPI TestSynchCritical_Test1(LPVOID arg)
 {
 	int i, j, rc;
 	HANDLE hThread = (HANDLE) (ULONG_PTR) GetCurrentThreadId();
@@ -82,18 +82,17 @@ static PVOID TestSynchCritical_Test1(PVOID arg)
 }
 
 /* this thread function tries to call TryEnterCriticalSection while the main thread holds the lock */
-static PVOID TestSynchCritical_Test2(PVOID arg)
+static DWORD WINAPI TestSynchCritical_Test2(LPVOID arg)
 {
 	if (TryEnterCriticalSection(&critical)==TRUE)
 	{
 		LeaveCriticalSection(&critical);
-		return (PVOID)1;
+		return 1;
 	}
-	return (PVOID)0;
+	return 0;
 }
 
-
-static PVOID TestSynchCritical_Main(PVOID arg)
+static DWORD WINAPI TestSynchCritical_Main(LPVOID arg)
 {
 	int i, j;
 	SYSTEM_INFO sysinfo;
@@ -219,7 +218,7 @@ static PVOID TestSynchCritical_Main(PVOID arg)
 		bTest1Running = TRUE;
 		for (i = 0; i < (int) dwThreadCount; i++)
 		{
-			if (!(hThreads[i] = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) TestSynchCritical_Test1, &bTest1Running, 0, NULL)))
+			if (!(hThreads[i] = CreateThread(NULL, 0, TestSynchCritical_Test1, &bTest1Running, 0, NULL)))
 			{
 				printf("CriticalSection failure: Failed to create test_1 thread #%d\n", i);
 				goto fail;
@@ -270,7 +269,7 @@ static PVOID TestSynchCritical_Main(PVOID arg)
 		goto fail;
 	}
 	/* This thread tries to call TryEnterCriticalSection which must fail */
-	if (!(hThread = CreateThread(NULL, 0,  (LPTHREAD_START_ROUTINE) TestSynchCritical_Test2, NULL, 0, NULL)))
+	if (!(hThread = CreateThread(NULL, 0,  TestSynchCritical_Test2, NULL, 0, NULL)))
 	{
 		printf("CriticalSection failure: Failed to create test_2 thread\n");
 		goto fail;
@@ -309,7 +308,7 @@ int TestSynchCritical(int argc, char* argv[])
 
 	printf("Deadlock will be assumed after %"PRIu32" ms.\n", dwDeadLockDetectionTimeMs);
 
-	if (!(hThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) TestSynchCritical_Main, &bThreadTerminated, 0, NULL)))
+	if (!(hThread = CreateThread(NULL, 0, TestSynchCritical_Main, &bThreadTerminated, 0, NULL)))
 	{
 		printf("CriticalSection failure: Failed to create main thread\n");
 		return -1;

--- a/winpr/libwinpr/synch/test/TestSynchCritical.c
+++ b/winpr/libwinpr/synch/test/TestSynchCritical.c
@@ -55,25 +55,25 @@ static DWORD WINAPI TestSynchCritical_Test1(LPVOID arg)
 		rc = 1;
 
 		if (!TestSynchCritical_TriggerAndCheckRaceCondition(hThread, rc))
-			return (PVOID)1;
+			return 1;
 
 		/* add some random recursion level */
 		j = rand()%5;
 		for (i=0; i<j; i++)
 		{
 			if (!TestSynchCritical_TriggerAndCheckRaceCondition(hThread, rc++))
-				return (PVOID)2;
+				return 2;
 			EnterCriticalSection(&critical);
 		}
 		for (i=0; i<j; i++)
 		{
 			if (!TestSynchCritical_TriggerAndCheckRaceCondition(hThread, rc--))
-				return (PVOID)2;
+				return 2;
 			LeaveCriticalSection(&critical);
 		}
 
 		if (!TestSynchCritical_TriggerAndCheckRaceCondition(hThread, rc))
-			return (PVOID)3;
+			return 3;
 
 		LeaveCriticalSection(&critical);
 	}
@@ -288,11 +288,11 @@ static DWORD WINAPI TestSynchCritical_Main(LPVOID arg)
 	CloseHandle(hThread);
 
 	*pbThreadTerminated = TRUE; /* requ. for winpr issue, see below */
-	return (PVOID)0;
+	return 0;
 
 fail:
 	*pbThreadTerminated = TRUE; /* requ. for winpr issue, see below */
-	return (PVOID)1;
+	return 1;
 }
 
 

--- a/winpr/libwinpr/synch/test/TestSynchInit.c
+++ b/winpr/libwinpr/synch/test/TestSynchInit.c
@@ -7,16 +7,16 @@
 #define TEST_NUM_THREADS	100
 #define TEST_NUM_FAILURES	10
 
-INIT_ONCE initOnceTest = INIT_ONCE_STATIC_INIT;
+static INIT_ONCE initOnceTest = INIT_ONCE_STATIC_INIT;
 
-HANDLE hStartEvent = NULL;
-LONG *pErrors = NULL;
-LONG *pTestThreadFunctionCalls = NULL;
-LONG *pTestOnceFunctionCalls = NULL;
-LONG *pInitOnceExecuteOnceCalls = NULL;
+static HANDLE hStartEvent = NULL;
+static LONG *pErrors = NULL;
+static LONG *pTestThreadFunctionCalls = NULL;
+static LONG *pTestOnceFunctionCalls = NULL;
+static LONG *pInitOnceExecuteOnceCalls = NULL;
 
 
-BOOL CALLBACK TestOnceFunction(PINIT_ONCE once, PVOID param, PVOID *context)
+static BOOL CALLBACK TestOnceFunction(PINIT_ONCE once, PVOID param, PVOID *context)
 {
 	LONG calls = InterlockedIncrement(pTestOnceFunctionCalls) - 1;
 
@@ -37,7 +37,7 @@ BOOL CALLBACK TestOnceFunction(PINIT_ONCE once, PVOID param, PVOID *context)
 	return FALSE;
 }
 
-DWORD WINAPI TestThreadFunction(LPVOID lpParam)
+static DWORD WINAPI TestThreadFunction(LPVOID lpParam)
 {
 	LONG calls;
 	BOOL ok;

--- a/winpr/libwinpr/synch/test/TestSynchMultipleThreads.c
+++ b/winpr/libwinpr/synch/test/TestSynchMultipleThreads.c
@@ -5,14 +5,14 @@
 #include <winpr/synch.h>
 #include <winpr/thread.h>
 
-static void *test_thread(void *arg)
+static DWORD WINAPI test_thread(LPVOID arg)
 {
 	long timeout = rand();
 	timeout %= 1000;
 	timeout += 100;
 	Sleep(timeout);
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 static int start_threads(DWORD count, HANDLE *threads)
@@ -21,8 +21,7 @@ static int start_threads(DWORD count, HANDLE *threads)
 
 	for (i=0; i<count; i++)
 	{
-		threads[i] = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)test_thread,
-								  NULL, 0, NULL);
+		threads[i] = CreateThread(NULL, 0, test_thread, NULL, 0, NULL);
 
 		if (!threads[i])
 		{

--- a/winpr/libwinpr/synch/test/TestSynchMutex.c
+++ b/winpr/libwinpr/synch/test/TestSynchMutex.c
@@ -4,7 +4,7 @@
 #include <winpr/thread.h>
 
 
-BOOL test_mutex_basic()
+static BOOL test_mutex_basic(void)
 {
 	HANDLE mutex;
 	DWORD rc;
@@ -42,7 +42,7 @@ BOOL test_mutex_basic()
 	return TRUE;
 }
 
-BOOL test_mutex_recursive()
+static BOOL test_mutex_recursive(void)
 {
 	HANDLE mutex;
 	DWORD rc, i, cnt = 50;
@@ -94,11 +94,11 @@ BOOL test_mutex_recursive()
 }
 
 
-HANDLE thread1_mutex1 = NULL;
-HANDLE thread1_mutex2 = NULL;
-BOOL   thread1_failed = TRUE;
+static HANDLE thread1_mutex1 = NULL;
+static HANDLE thread1_mutex2 = NULL;
+static BOOL   thread1_failed = TRUE;
 
-DWORD WINAPI test_mutex_thread1(LPVOID lpParam)
+static DWORD WINAPI test_mutex_thread1(LPVOID lpParam)
 {
 	HANDLE hStartEvent = (HANDLE)lpParam;
 	DWORD rc = 0;
@@ -143,7 +143,7 @@ DWORD WINAPI test_mutex_thread1(LPVOID lpParam)
 	return 0;
 }
 
-BOOL test_mutex_threading()
+static BOOL test_mutex_threading(void)
 {
 	HANDLE hThread = NULL;
 	HANDLE hStartEvent = NULL;

--- a/winpr/libwinpr/synch/test/TestSynchThread.c
+++ b/winpr/libwinpr/synch/test/TestSynchThread.c
@@ -3,19 +3,18 @@
 #include <winpr/synch.h>
 #include <winpr/thread.h>
 
-static void *test_thread(void *arg)
+static DWORD WINAPI test_thread(LPVOID arg)
 {
 	Sleep(1000);
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 int TestSynchThread(int argc, char *argv[])
 {
 	DWORD rc;
 	HANDLE thread;
-	thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)test_thread,
-						  NULL, 0, NULL);
+	thread = CreateThread(NULL, 0, test_thread, NULL, 0, NULL);
 
 	if (!thread)
 	{
@@ -56,8 +55,7 @@ int TestSynchThread(int argc, char *argv[])
 		return -1;
 	}
 
-	thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)test_thread,
-						  NULL, 0, NULL);
+	thread = CreateThread(NULL, 0, test_thread, NULL, 0, NULL);
 
 	if (!thread)
 	{
@@ -99,8 +97,7 @@ int TestSynchThread(int argc, char *argv[])
 	}
 
 	/* Thread detach test */
-	thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)test_thread,
-						  NULL, 0, NULL);
+	thread = CreateThread(NULL, 0, test_thread, NULL, 0, NULL);
 
 	if (!thread)
 	{

--- a/winpr/libwinpr/thread/test/TestThreadExitThread.c
+++ b/winpr/libwinpr/thread/test/TestThreadExitThread.c
@@ -4,11 +4,11 @@
 #include <winpr/synch.h>
 #include <winpr/thread.h>
 
-static void* thread_func(void* arg)
+static DWORD WINAPI thread_func(LPVOID arg)
 {
 	/* exists of the thread the quickest as possible */
 	ExitThread(0);
-	return NULL;
+	return 0;
 }
 
 int TestThreadExitThread(int argc, char* argv[])
@@ -23,7 +23,7 @@ int TestThreadExitThread(int argc, char* argv[])
 	{
 		thread = CreateThread(NULL,
 				0,
-				(LPTHREAD_START_ROUTINE)thread_func,
+				thread_func,
 				NULL,
 				0,
 				NULL);

--- a/winpr/libwinpr/utils/test/TestMessagePipe.c
+++ b/winpr/libwinpr/utils/test/TestMessagePipe.c
@@ -3,7 +3,7 @@
 #include <winpr/thread.h>
 #include <winpr/collections.h>
 
-static void* message_echo_pipe_client_thread(void* arg)
+static DWORD WINAPI message_echo_pipe_client_thread(LPVOID arg)
 {
 	int index = 0;
 	wMessagePipe* pipe = (wMessagePipe*) arg;
@@ -35,10 +35,10 @@ static void* message_echo_pipe_client_thread(void* arg)
 
 	MessageQueue_PostQuit(pipe->In, 0);
 
-	return NULL;
+	return 0;
 }
 
-static void* message_echo_pipe_server_thread(void* arg)
+static DWORD WINAPI message_echo_pipe_server_thread(LPVOID arg)
 {
 	wMessage message;
 	wMessagePipe* pipe;
@@ -57,7 +57,7 @@ static void* message_echo_pipe_server_thread(void* arg)
 		}
 	}
 
-	return NULL;
+	return 0;
 }
 
 int TestMessagePipe(int argc, char* argv[])
@@ -73,13 +73,13 @@ int TestMessagePipe(int argc, char* argv[])
 		goto out;
 	}
 
-	if (!(ClientThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) message_echo_pipe_client_thread, (void*) EchoPipe, 0, NULL)))
+	if (!(ClientThread = CreateThread(NULL, 0, message_echo_pipe_client_thread, (void*) EchoPipe, 0, NULL)))
 	{
 		printf("failed to create client thread\n");
 		goto out;
 	}
 
-	if (!(ServerThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) message_echo_pipe_server_thread, (void*) EchoPipe, 0, NULL)))
+	if (!(ServerThread = CreateThread(NULL, 0, message_echo_pipe_server_thread, (void*) EchoPipe, 0, NULL)))
 	{
 		printf("failed to create server thread\n");
 		goto out;

--- a/winpr/libwinpr/utils/test/TestMessageQueue.c
+++ b/winpr/libwinpr/utils/test/TestMessageQueue.c
@@ -3,7 +3,7 @@
 #include <winpr/thread.h>
 #include <winpr/collections.h>
 
-static void* message_queue_consumer_thread(void* arg)
+static DWORD WINAPI message_queue_consumer_thread(LPVOID arg)
 {
 	wMessage message;
 	wMessageQueue* queue;
@@ -21,7 +21,7 @@ static void* message_queue_consumer_thread(void* arg)
 		}
 	}
 
-	return NULL;
+	return 0;
 }
 
 int TestMessageQueue(int argc, char* argv[])
@@ -35,7 +35,7 @@ int TestMessageQueue(int argc, char* argv[])
 		return 1;
 	}
 
-	if (!(thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) message_queue_consumer_thread, (void*) queue, 0, NULL)))
+	if (!(thread = CreateThread(NULL, 0, message_queue_consumer_thread, (void*) queue, 0, NULL)))
 	{
 		printf("failed to create thread\n");
 		MessageQueue_Free(queue);


### PR DESCRIPTION
* Removed unnecessary and harmful function pointer casts for `CreateThread` and `CreateThreadpoolWork`
* Fixed return, call and parameter type of thread and threadpool work functions.