### PR TITLE
Detect command line flags in case RDP or MSINCIDENT files are used.

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1313,6 +1313,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 	if (!ext && !assist)
 		compatibility = freerdp_client_detect_command_line(argc, argv, &flags,
 		                allowUnknown);
+	else
+		compatibility = freerdp_client_detect_command_line(argc - 1, &argv[1], &flags,
+						allowUnknown);
 
 	if (compatibility)
 	{


### PR DESCRIPTION
Command line detection sets flags for the parser.
Run it when the first argument is a `.rdp` or `.msIncident` file with `argc - 1` and `&argv[1]` to avoid breaking the detector.