### PR TITLE
Updated project site link to HTTPS

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ interoperability can finally liberate your computing experience.
 Resources
 ---------
 
-Project website: http://www.freerdp.com/
+Project website: https://www.freerdp.com/
 Issue tracker: https://github.com/FreeRDP/FreeRDP/issues
 Sources: https://github.com/FreeRDP/FreeRDP/
 Downloads: https://pub.freerdp.com/releases/


### PR DESCRIPTION
A very small pull request that simply changes the project site in the README document from "http://www.freerdp.com/" to "https://www.freerdp.com/". Directing more users to the HTTPs version of the site will help improve user security a little.

There's a good explanation on the Google Developer guides why it's a good idea to provide and use HTTPS, even for static sites that don't handle credentials or sensative data: https://developers.google.com/web/fundamentals/security/encrypt-in-transit/why-https