### PR TITLE
Winpr exit

### DIFF
--- a/client/Sample/freerdp.c
+++ b/client/Sample/freerdp.c
@@ -169,7 +169,7 @@ int main(int argc, char* argv[])
 	if (!instance)
 	{
 		WLog_ERR(TAG, "Couldn't create instance");
-		winpr_exit(1);
+		return winpr_exit(1);
 	}
 
 	instance->PreConnect = tf_pre_connect;

--- a/winpr/libwinpr/utils/winpr.c
+++ b/winpr/libwinpr/utils/winpr.c
@@ -78,10 +78,7 @@ const char* winpr_get_build_config(void)
 int winpr_exit(int status)
 {
 	WLog_Uninit();
-#if defined(WIN32)
+
+	_exit(status);
 	return status;
-#else
-	pthread_exit(&status);
-	return status;
-#endif
 }


### PR DESCRIPTION
Return the actual exit code instead of always 0 (side effect of `pthread_exit`)