### PR TITLE
fix nla: don't use server version

### DIFF
--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -1691,14 +1691,18 @@ BOOL nla_send(rdpNla* nla)
 static int nla_decode_ts_request(rdpNla* nla, wStream* s)
 {
 	size_t length;
+	UINT32 version = 0;
 
 	/* TSRequest */
 	if (!ber_read_sequence_tag(s, &length) ||
 	    !ber_read_contextual_tag(s, 0, &length, TRUE) ||
-	    !ber_read_integer(s, &nla->version))
+	    !ber_read_integer(s, &version))
 	{
 		return -1;
 	}
+
+	if (version < nla->version)
+		nla->version = version;
 
 	/* [1] negoTokens (NegoData) */
 	if (ber_read_contextual_tag(s, 1, &length, TRUE) != FALSE)


### PR DESCRIPTION
FreeRDP currently only supports CredSSP protocol version 3. However the
current implementation always sent back the version received by the
server indicating that this version was supported.
With recent windows updates applied the protocol changed and this approach
doesn't work anymore (see
https://msdn.microsoft.com/en-us/library/mt752485.aspx for protocol changes).

With this fix FreeRDP always sends version 3 as supported version.

Credit goes to @mfleisz.

Fixes #4449