### PR TITLE
Fix #2707: Set fullscreen first

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -196,17 +196,6 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 
 	if (xfc->_NET_WM_FULLSCREEN_MONITORS != None)
 	{
-		/* Set monitor bounds */
-		if (settings->MonitorCount > 1)
-		{
-			xf_SendClientEvent(xfc, window->handle, xfc->_NET_WM_FULLSCREEN_MONITORS, 5,
-			                   xfc->fullscreenMonitors.top,
-			                   xfc->fullscreenMonitors.bottom,
-			                   xfc->fullscreenMonitors.left,
-			                   xfc->fullscreenMonitors.right,
-			                   1);
-		}
-
 		xf_ResizeDesktopWindow(xfc, window, width, height);
 
 		if (fullscreen)
@@ -224,6 +213,17 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 		{
 			/* leave full screen: move the window after removing NET_WM_STATE_FULLSCREEN */
 			XMoveWindow(xfc->display, window->handle, startX, startY);
+		}
+
+		/* Set monitor bounds */
+		if (settings->MonitorCount > 1)
+		{
+			xf_SendClientEvent(xfc, window->handle, xfc->_NET_WM_FULLSCREEN_MONITORS, 5,
+			                   xfc->fullscreenMonitors.top,
+			                   xfc->fullscreenMonitors.bottom,
+			                   xfc->fullscreenMonitors.left,
+			                   xfc->fullscreenMonitors.right,
+			                   1);
 		}
 	}
 	else


### PR DESCRIPTION
Due to kwin bug https://bugs.kde.org/show_bug.cgi?id=391960
multimonitor fullscreen is not applied correctly with the
previous approach.

Tested on Fedora27 with gnome, xfce4, openbox and plasma the behaviour is now consistent.
Thanks to the really fast response of the kwin devs (https://bugs.kde.org/show_bug.cgi?id=391778)