### PR TITLE
cssp: Separate client/server version handling (#4502)

### DIFF
--- a/libfreerdp/core/nla.h
+++ b/libfreerdp/core/nla.h
@@ -66,6 +66,7 @@ struct rdp_nla
 	SEC_CHAR* packageName;
 #endif
 	UINT32 version;
+	UINT32 peerVersion;
 	UINT32 errorCode;
 	ULONG fContextReq;
 	ULONG pfContextAttr;


### PR DESCRIPTION
This PR fixes CredSSP issues with non-version 6 servers as described in #4502. Tested with patched and unpatched Win7 Ultimate x64.