### PR TITLE
resolve several possible null pointer dereference

### DIFF
--- a/channels/drive/client/drive_main.c
+++ b/channels/drive/client/drive_main.c
@@ -440,7 +440,7 @@ static UINT drive_process_irp_query_volume_information(DRIVE_DEVICE* drive,
         IRP* irp)
 {
 	UINT32 FsInformationClass;
-	wStream* output = irp->output;
+	wStream* output = NULL;
 	char* volumeLabel = {"FREERDP"};
 	char* diskType = {"FAT32"};
 	WCHAR* outStr = NULL;
@@ -453,6 +453,8 @@ static UINT drive_process_irp_query_volume_information(DRIVE_DEVICE* drive,
 
 	if (!drive || !irp)
 		return ERROR_INVALID_PARAMETER;
+
+	output = irp->output;
 
 	if (Stream_GetRemainingLength(irp->input) < 4)
 		return ERROR_INVALID_DATA;

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -577,10 +577,12 @@ void xf_ResizeDesktopWindow(xfContext* xfc, xfWindow* window, int width,
                             int height)
 {
 	XSizeHints* size_hints;
-	rdpSettings* settings = xfc->context.settings;
+	rdpSettings* settings = NULL;
 
 	if (!xfc || !window)
 		return;
+
+	settings = xfc->context.settings;
 
 	if (!(size_hints = XAllocSizeHints()))
 		return;

--- a/winpr/libwinpr/path/test/TestPathShell.c
+++ b/winpr/libwinpr/path/test/TestPathShell.c
@@ -38,18 +38,26 @@ int TestPathShell(int argc, char* argv[])
 			char* path = GetKnownPath(id);
 
 			if (!path)
+			{
 				rc = -1;
-
-			printf("%s Path: %s\n", name, path);
+			}
+			else
+			{
+				printf("%s Path: %s\n", name, path);
+			}
 			free(path);
 		}
 		{
 			char* path = GetKnownSubPath(id, "freerdp");
 
 			if (!path)
+			{
 				rc = -1;
-
-			printf("%s SubPath: %s\n", name, path);
+			}
+			else
+			{
+				printf("%s SubPath: %s\n", name, path);
+			}
 			free(path);
 		}
 	}


### PR DESCRIPTION
issue detected by cppcheck

[channels/drive/client/drive_main.c:454] -> [channels/drive/client/drive_main.c:443]: (warning) Either the condition '!irp' is redundant or there is possible null pointer dereference: irp.
[client/X11/xf_window.c:582] -> [client/X11/xf_window.c:580]: (warning) Either the condition '!xfc' is redundant or there is possible null pointer dereference: xfc.
[winpr/libwinpr/path/test/TestPathShell.c:40] -> [winpr/libwinpr/path/test/TestPathShell.c:43]: (warning) Either the condition '!path' is redundant or there is possible null pointer dereference: path.
[winpr/libwinpr/path/test/TestPathShell.c:49] -> [winpr/libwinpr/path/test/TestPathShell.c:52]: (warning) Either the condition '!path' is redundant or there is possible null pointer dereference: path.
