### PR TITLE
Fix SCardStatusW function

### DIFF
--- a/winpr/libwinpr/smartcard/smartcard_pcsc.c
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.c
@@ -1719,7 +1719,15 @@ WINSCARDAPI LONG WINAPI PCSC_SCardStatus_Internal(SCARDHANDLE hCard,
 
 	/* Make sure the last byte is set */
 	if (readerNames)
-		readerNames[pcsc_cchReaderLen] = '\0';
+	{
+		if (unicode)
+		{
+			readerNames[pcsc_cchReaderLen * 2] = '\0';
+			readerNames[pcsc_cchReaderLen * 2 + 1] = '\0';
+		}
+		else
+			readerNames[pcsc_cchReaderLen] = '\0';
+	}
 
 	return status;
 out_fail:


### PR DESCRIPTION
Terminating null character was inserted in the middle of readerNames instead of
last position in the unicode version of SCardStatus function.
This commit fix it.