### PR TITLE
PCB support

### DIFF
--- a/client/common/file.c
+++ b/client/common/file.c
@@ -298,6 +298,8 @@ static int freerdp_client_rdp_file_set_string(rdpFile* file, const char* name, c
 		tmp = &file->DevicesToRedirect;
 	else if (_stricmp(name, "winposstr") == 0)
 		tmp = &file->WinPosStr;
+	else if (_stricmp(name, "pcb") == 0)
+		tmp = &file->PreconnectionBlob;
 	else
 		standard = 1;
 
@@ -612,6 +614,7 @@ BOOL freerdp_client_populate_rdp_file_from_settings(rdpFile* file, const rdpSett
 	SETTING_MODIFIED_SET_STRING(file->RemoteApplicationCmdLine, settings, RemoteApplicationCmdLine);
 	SETTING_MODIFIED_SET(file->SpanMonitors, settings, SpanMonitors);
 	SETTING_MODIFIED_SET(file->UseMultiMon, settings, UseMultimon);
+	SETTING_MODIFIED_SET_STRING(file->PreconnectionBlob, settings, PreconnectionBlob);
 	return TRUE;
 }
 
@@ -1056,6 +1059,13 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 	if (~file->KeyboardHook)
 	{
 		freerdp_set_param_uint32(settings, FreeRDP_KeyboardHook, file->KeyboardHook);
+	}
+
+	if (~((size_t) file->PreconnectionBlob))
+	{
+		freerdp_set_param_string(settings, FreeRDP_PreconnectionBlob, file->PreconnectionBlob);
+		freerdp_set_param_bool(settings, FreeRDP_SendPreconnectionPdu, TRUE);
+		freerdp_set_param_bool(settings, FreeRDP_VmConnectMode, TRUE);
 	}
 
 	if (file->argc > 1)

--- a/include/freerdp/client/file.h
+++ b/include/freerdp/client/file.h
@@ -151,6 +151,8 @@ struct rdp_file
 	LPSTR DevicesToRedirect; /* devicestoredirect */
 	LPSTR WinPosStr; /* winposstr */
 
+	LPSTR PreconnectionBlob; /* pcb */
+
 	int lineCount;
 	int lineSize;
 	rdpFileLine* lines;


### PR DESCRIPTION
This commit adds support for the "pcb" field in .RDP files generated by the VM interface in Project Honolulu. Project Honolulu is the web interface to Windows Server management that will be included with Windows Server 2019. When using the web interface to manage Hyper-V virtual machines, there is an option for Connect which generates an .RDP file to connect directly to the virtual machine console (similar in function to the freerdp /vmconnect switch). The .RDP file includes the necessary change to "server port" and "negotiate security layer". This patch simply parses the "pcb" string from the file and adds it to the settings so the connection actually works.
