### PR TITLE
Fix #4524: Initialize with cleanup handler

### DIFF
--- a/channels/rail/client/rail_main.c
+++ b/channels/rail/client/rail_main.c
@@ -849,7 +849,6 @@ BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS pEntryPoints, PVOID p
 		isFreerdp = TRUE;
 	}
 
-	WLog_Init();
 	rail->log = WLog_Get("com.freerdp.channels.rail.client");
 	WLog_Print(rail->log, WLOG_DEBUG, "VirtualChannelEntryEx");
 	CopyMemory(&(rail->channelEntryPoints), pEntryPoints,

--- a/channels/serial/client/serial_main.c
+++ b/channels/serial/client/serial_main.c
@@ -840,7 +840,6 @@ UINT DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
 	if ((name && name[0]) && (path && path[0]))
 	{
 		wLog* log;
-		WLog_Init();
 		log = WLog_Get("com.freerdp.channel.serial.client");
 		WLog_Print(log, WLOG_DEBUG, "initializing");
 #ifndef __linux__ /* to be removed */

--- a/client/DirectFB/dfreerdp.c
+++ b/client/DirectFB/dfreerdp.c
@@ -422,7 +422,7 @@ int main(int argc, char* argv[])
 	if (!(g_sem = CreateSemaphore(NULL, 0, 1, NULL)))
 	{
 		WLog_ERR(TAG, "Failed to create semaphore");
-		return winpr_exit(1);
+		return 1;
 	}
 
 	instance = freerdp_new();
@@ -437,7 +437,7 @@ int main(int argc, char* argv[])
 	if (!freerdp_context_new(instance))
 	{
 		WLog_ERR(TAG, "Failed to create FreeRDP context");
-		return winpr_exit(1);
+		return 1;
 	}
 
 	context = (dfContext*) instance->context;
@@ -449,11 +449,11 @@ int main(int argc, char* argv[])
 	         argv, FALSE);
 
 	if (status < 0)
-		return winpr_exit(0);
+		return 0;
 
 	if (!freerdp_client_load_addins(instance->context->channels,
 	                                instance->settings))
-		return winpr_exit(-1);
+		return -1;
 
 	data = (struct thread_data*) malloc(sizeof(struct thread_data));
 	ZeroMemory(data, sizeof(sizeof(struct thread_data)));
@@ -466,5 +466,5 @@ int main(int argc, char* argv[])
 		WaitForSingleObject(g_sem, INFINITE);
 	}
 
-	return winpr_exit(0);
+	return 0;
 }

--- a/client/Sample/freerdp.c
+++ b/client/Sample/freerdp.c
@@ -169,7 +169,7 @@ int main(int argc, char* argv[])
 	if (!instance)
 	{
 		WLog_ERR(TAG, "Couldn't create instance");
-		winpr_exit(1);
+		return 1;
 	}
 
 	instance->PreConnect = tf_pre_connect;
@@ -182,7 +182,7 @@ int main(int argc, char* argv[])
 	if (!freerdp_context_new(instance))
 	{
 		WLog_ERR(TAG, "Couldn't create context");
-		return winpr_exit(1);
+		return 1;
 	}
 
 	status = freerdp_client_settings_parse_command_line(instance->settings, argc,
@@ -190,12 +190,12 @@ int main(int argc, char* argv[])
 
 	if (status < 0)
 	{
-		return winpr_exit(0);
+		return 0;
 	}
 
 	if (!freerdp_client_load_addins(instance->context->channels,
 	                                instance->settings))
-		return winpr_exit(-1);
+		return -1;
 
 	if (!(thread = CreateThread(NULL, 0, tf_client_thread_proc, instance, 0, NULL)))
 	{
@@ -208,5 +208,5 @@ int main(int argc, char* argv[])
 
 	freerdp_context_free(instance);
 	freerdp_free(instance);
-	return winpr_exit(0);
+	return 0;
 }

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -474,5 +474,5 @@ int main(int argc, char* argv[])
 
 fail:
 	freerdp_client_context_free(context);
-	return winpr_exit(rc);
+	return rc;
 }

--- a/client/X11/cli/xfreerdp.c
+++ b/client/X11/cli/xfreerdp.c
@@ -50,7 +50,7 @@ int main(int argc, char* argv[])
 
 	context = freerdp_client_context_new(&clientEntryPoints);
 	if (!context)
-		return winpr_exit(1);
+		return 1;
 
 	settings = context->settings;
 	xfc = (xfContext*) context;
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
 			xf_list_monitors(xfc);
 
 		freerdp_client_context_free(context);
-		return winpr_exit(0);
+		return 0;
 	}
 
 	freerdp_client_start(context);
@@ -79,5 +79,5 @@ int main(int argc, char* argv[])
 
 	freerdp_client_context_free(context);
 
-	return winpr_exit(xf_exit_code_from_disconnect_reason(dwExitCode));
+	return xf_exit_code_from_disconnect_reason(dwExitCode);
 }

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -58,7 +58,6 @@ rdpContext* freerdp_client_context_new(RDP_CLIENT_ENTRY_POINTS* pEntryPoints)
 	if (!pEntryPoints)
 		return NULL;
 
-	WLog_Init();
 	IFCALL(pEntryPoints->GlobalInit);
 	instance = freerdp_new();
 
@@ -116,7 +115,6 @@ void freerdp_client_context_free(rdpContext* context)
 		free(instance->pClientEntryPoints);
 		freerdp_free(instance);
 	}
-	WLog_Uninit();
 }
 
 int freerdp_client_start(rdpContext* context)

--- a/libfreerdp/cache/glyph.c
+++ b/libfreerdp/cache/glyph.c
@@ -688,7 +688,6 @@ rdpGlyphCache* glyph_cache_new(rdpSettings* settings)
 	if (!glyphCache)
 		return NULL;
 
-	WLog_Init();
 	glyphCache->log = WLog_Get("com.freerdp.cache.glyph");
 	glyphCache->settings = settings;
 	glyphCache->context = ((freerdp*) settings->instance)->update->context;

--- a/libfreerdp/codec/nsc.c
+++ b/libfreerdp/codec/nsc.c
@@ -281,7 +281,6 @@ NSC_CONTEXT* nsc_context_new(void)
 	if (!context->priv)
 		goto error_priv;
 
-	WLog_Init();
 	context->priv->log = WLog_Get("com.freerdp.codec.nsc");
 	WLog_OpenAppender(context->priv->log);
 	context->BitmapData = NULL;

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -220,7 +220,6 @@ RFX_CONTEXT* rfx_context_new(BOOL encoder)
 	if (!priv)
 		goto error_priv;
 
-	WLog_Init();
 	priv->log = WLog_Get("com.freerdp.codec.rfx");
 	WLog_OpenAppender(priv->log);
 #ifdef WITH_DEBUG_RFX

--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -2057,7 +2057,6 @@ rdpUpdate* update_new(rdpRdp* rdp)
 	if (!update)
 		return NULL;
 
-	WLog_Init();
 	update->log = WLog_Get("com.freerdp.core.update");
 	update->bitmap_update.count = 64;
 	update->bitmap_update.rectangles = (BITMAP_DATA*) calloc(

--- a/libfreerdp/primitives/test/TestPrimitivesYUV.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYUV.c
@@ -879,7 +879,6 @@ int TestPrimitivesYUV(int argc, char* argv[])
 	int rc = -1;
 	prim_test_setup(FALSE);
 	primitives_t* prims = primitives_get();
-	WLog_Init();
 
 	for (x = 0; x < 10; x++)
 	{
@@ -974,7 +973,6 @@ int TestPrimitivesYUV(int argc, char* argv[])
 
 	rc = 0;
 end:
-	WLog_Uninit();
 	return rc;
 }
 

--- a/rdtk/sample/rdtk_x11.c
+++ b/rdtk/sample/rdtk_x11.c
@@ -61,7 +61,7 @@ int main(int argc, char** argv)
 	if (!display)
 	{
 		WLog_ERR(TAG, "Cannot open display");
-		return winpr_exit(1);
+		return 1;
 	}
 
 	x = 10;
@@ -97,12 +97,12 @@ int main(int argc, char** argv)
 
 	engine = rdtk_engine_new();
 	if (!engine)
-		return winpr_exit(1);
+		return 1;
 
 	scanline = width * 4;
 	buffer = (BYTE*) calloc(height, scanline);
 	if (!buffer)
-		return winpr_exit(1);
+		return 1;
 
 	surface = rdtk_surface_new(engine, buffer, width, height, scanline);
 
@@ -152,5 +152,5 @@ int main(int argc, char** argv)
 
 	rdtk_engine_free(engine);
 
-	return winpr_exit(0);
+	return 0;
 }

--- a/server/Mac/mfreerdp.c
+++ b/server/Mac/mfreerdp.c
@@ -109,7 +109,7 @@ int main(int argc, char* argv[])
 	WTSRegisterWtsApiFunctionTable(FreeRDP_InitWtsApi());
 	
 	if (!(instance = freerdp_listener_new()))
-		return winpr_exit(1);
+		return 1;
 
 	instance->PeerAccepted = mf_peer_accepted;
 
@@ -120,5 +120,5 @@ int main(int argc, char* argv[])
 
 	freerdp_listener_free(instance);
 
-	return winpr_exit(0);
+	return 0;
 }

--- a/server/Sample/sfreerdp.c
+++ b/server/Sample/sfreerdp.c
@@ -926,14 +926,14 @@ int main(int argc, char* argv[])
 	instance = freerdp_listener_new();
 
 	if (!instance)
-		return winpr_exit(-1);
+		return -1;
 
 	instance->PeerAccepted = test_peer_accepted;
 
 	if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0)
 	{
 		freerdp_listener_free(instance);
-		return winpr_exit(-1);
+		return -1;
 	}
 
 	/* Open the server socket and start listening. */
@@ -944,7 +944,7 @@ int main(int argc, char* argv[])
 	{
 		freerdp_listener_free(instance);
 		WSACleanup();
-		return winpr_exit(-1);
+		return -1;
 	}
 
 	if ((localOnly || instance->Open(instance, NULL, port)) &&
@@ -957,6 +957,6 @@ int main(int argc, char* argv[])
 	free(file);
 	freerdp_listener_free(instance);
 	WSACleanup();
-	return winpr_exit(0);
+	return 0;
 }
 

--- a/server/Windows/cli/wfreerdp.c
+++ b/server/Windows/cli/wfreerdp.c
@@ -98,7 +98,7 @@ int main(int argc, char* argv[])
 				WLog_INFO(TAG, "Virtual Screen = %dx%d", vscreen_w, vscreen_h);
 			}
 
-			return winpr_exit(0);
+			return 0;
 		}
 
 		if (strcmp("--screen", argv[index]) == 0)
@@ -110,13 +110,13 @@ int main(int argc, char* argv[])
 			if (index == argc)
 			{
 				WLog_INFO(TAG, "missing screen id parameter");
-				return winpr_exit(0);
+				return 0;
 			}
 
 			val = strtoul(argv[index], NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
-				return winpr_exit(-1);
+				return -1;
 
 			set_screen_id(val);
 			index++;
@@ -127,7 +127,7 @@ int main(int argc, char* argv[])
 			UINT32 val = strtoul(argv[index], NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
-				return winpr_exit(-1);
+				return -1;
 
 			server->port = val;
 			break;
@@ -170,5 +170,5 @@ int main(int argc, char* argv[])
 	WLog_INFO(TAG, "Stopping server");
 	wfreerdp_server_stop(server);
 	wfreerdp_server_free(server);
-	return winpr_exit(0);
+	return 0;
 }

--- a/server/shadow/shadow.c
+++ b/server/shadow/shadow.c
@@ -110,6 +110,6 @@ fail_server_init:
 fail_parse_command_line:
 	shadow_server_free(server);
 fail_server_new:
-	return winpr_exit(status);
+	return status;
 }
 

--- a/winpr/include/winpr/winpr.h
+++ b/winpr/include/winpr/winpr.h
@@ -70,7 +70,6 @@ WINPR_API const char* winpr_get_version_string(void);
 WINPR_API const char* winpr_get_build_date(void);
 WINPR_API const char* winpr_get_build_revision(void);
 WINPR_API const char* winpr_get_build_config(void);
-WINPR_API int winpr_exit(int status);
 
 #define WINPR_UNUSED(x) (void)(x)
 

--- a/winpr/include/winpr/wlog.h
+++ b/winpr/include/winpr/wlog.h
@@ -182,7 +182,9 @@ WINPR_API BOOL WLog_Layout_SetPrefixFormat(wLog* log, wLogLayout* layout,
 WINPR_API wLog* WLog_GetRoot(void);
 WINPR_API wLog* WLog_Get(LPCSTR name);
 
+/** Deprecated */
 WINPR_API BOOL WLog_Init(void);
+/** Deprecated */
 WINPR_API BOOL WLog_Uninit(void);
 
 typedef BOOL (*wLogCallbackMessage_t)(const wLogMessage* msg);

--- a/winpr/libwinpr/smartcard/test/TestSmartCardStatus.c
+++ b/winpr/libwinpr/smartcard/test/TestSmartCardStatus.c
@@ -38,7 +38,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("ScardEstablishedContext: 0x%08x\n", err);
-		return winpr_exit(-1);
+		return -1;
 	}
 
 	err = SCardListReaders(hContext, "SCard$AllReaders", NULL, &cchReaders);
@@ -46,7 +46,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != 0)
 	{
 		printf("ScardListReaders: 0x%08x\n", err);
-		return winpr_exit(-1);
+		return -1;
 	}
 
 	mszReaders = calloc(cchReaders, sizeof(char));
@@ -54,7 +54,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (!mszReaders)
 	{
 		printf("calloc\n");
-		return winpr_exit(-1);
+		return -1;
 	}
 
 	err = SCardListReaders(hContext, "SCard$AllReaders", mszReaders, &cchReaders);
@@ -62,7 +62,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("ScardListReaders: 0x%08x\n", err);
-		return winpr_exit(-1);
+		return -1;
 	}
 
 	printf("Reader: %s\n", mszReaders);
@@ -72,7 +72,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("ScardConnect: 0x%08x\n", err);
-		return winpr_exit(-1);
+		return -1;
 	}
 
 	free(mszReaders);
@@ -83,7 +83,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("SCardStatus: 0x%08x\n", err);
-		return winpr_exit(-1);
+		return -1;
 	}
 	printf("reader name length: %u\n", len);
 
@@ -93,7 +93,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("SCardStatus: 0x%08x\n", err);
-		return winpr_exit(-1);
+		return -1;
 	}
 	printf("Reader name: %s (%ld)\n", name, strlen(name));
 
@@ -103,7 +103,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("SCardStatus: 0x%08x\n", err);
-		return winpr_exit(-1);
+		return -1;
 	}
 	printf("Reader name: %s (%ld/len %u)\n", name, strlen(name), len);
 	printf("status: 0x%08X\n", status);
@@ -117,7 +117,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("SCardStatus: 0x%08x\n", err);
-		return winpr_exit(-1);
+		return -1;
 	}
 	printf("Reader name: %s (%ld/%u)\n", aname, strlen(aname), len);
 	printf("status: 0x%08X\n", status);
@@ -132,7 +132,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("SCardStatus: 0x%08x\n", err);
-		return winpr_exit(-1);
+		return -1;
 	}
 	printf("status: 0x%08X\n", status);
 	printf("proto: 0x%08X\n", protocol);
@@ -144,7 +144,7 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("SCardStatus: 0x%08x\n", err);
-		return winpr_exit(-1);
+		return -1;
 	}
 	printf("atrlen: %u\n", atrlen);
 	SCardFreeMemory(hContext, aatr);
@@ -156,11 +156,11 @@ int TestSmartCardStatus(int argc, char* argv[])
 	if (err != SCARD_S_SUCCESS)
 	{
 		printf("SCardStatus: 0x%08x\n", err);
-		return winpr_exit(-1);
+		return -1;
 	}
 	printf("atrlen: %u\n", atrlen);
 	SCardDisconnect(hCard, SCARD_LEAVE_CARD);
 	SCardReleaseContext(hContext);
 
-	return winpr_exit(0);
+	return 0;
 }

--- a/winpr/libwinpr/utils/test/TestWLog.c
+++ b/winpr/libwinpr/utils/test/TestWLog.c
@@ -21,8 +21,6 @@ int TestWLog(int argc, char* argv[])
 		goto out;
         }
 
-	WLog_Init();
-
 	root = WLog_GetRoot();
 
 	WLog_SetLogAppenderType(root, WLOG_APPENDER_BINARY);
@@ -55,8 +53,6 @@ int TestWLog(int argc, char* argv[])
 	WLog_Print(logB, WLOG_TRACE, "leaving a trace behind");
 
 	WLog_CloseAppender(root);
-
-	WLog_Uninit();
 
 	if ((wlog_file = GetCombinedPath(tmp_path, "test_w.log")))
 		DeleteFileA(wlog_file);

--- a/winpr/libwinpr/utils/test/TestWLogCallback.c
+++ b/winpr/libwinpr/utils/test/TestWLogCallback.c
@@ -92,7 +92,6 @@ int TestWLogCallback(int argc, char* argv[])
 	wLogCallbacks callbacks;
 
 	function = __FUNCTION__;
-	WLog_Init();
 
 	root = WLog_GetRoot();
 
@@ -129,8 +128,6 @@ int TestWLogCallback(int argc, char* argv[])
 	WLog_Print(logB, messages[7].level, messages[7].msg);
 
 	WLog_CloseAppender(root);
-
-	WLog_Uninit();
 
 	return success ? 0 : -1;
 }

--- a/winpr/libwinpr/utils/winpr.c
+++ b/winpr/libwinpr/utils/winpr.c
@@ -75,13 +75,3 @@ const char* winpr_get_build_config(void)
 	return build_config;
 }
 
-int winpr_exit(int status)
-{
-	WLog_Uninit();
-#if defined(WIN32)
-	return status;
-#else
-	pthread_exit(&status);
-	return status;
-#endif
-}

--- a/winpr/libwinpr/utils/wlog/wlog.c
+++ b/winpr/libwinpr/utils/wlog/wlog.c
@@ -78,6 +78,10 @@ static int WLog_ParseLogLevel(LPCSTR level);
 static BOOL WLog_ParseFilter(wLogFilter* filter, LPCSTR name);
 static BOOL WLog_ParseFilters(void);
 
+#if !defined(_WIN32)
+static void WLog_Uninit_(void) __attribute__((destructor));
+#endif
+
 static void WLog_Uninit_(void)
 {
 	DWORD index;
@@ -152,7 +156,9 @@ static BOOL CALLBACK WLog_InitializeRoot(PINIT_ONCE InitOnce, PVOID Parameter, P
 	if (!WLog_SetLogAppenderType(g_RootLog, logAppenderType))
 		goto fail;
 
+#if defined(_WIN32)
 	atexit(WLog_Uninit_);
+#endif
 	return TRUE;
 fail:
 	free(g_RootLog);

--- a/winpr/libwinpr/utils/wlog/wlog.c
+++ b/winpr/libwinpr/utils/wlog/wlog.c
@@ -28,6 +28,7 @@
 #include <winpr/print.h>
 #include <winpr/debug.h>
 #include <winpr/environment.h>
+#include <winpr/wlog.h>
 
 #if defined(ANDROID)
 #include <android/log.h>
@@ -35,7 +36,6 @@
 #endif
 
 #include "wlog.h"
-
 
 struct _wLogFilter
 {
@@ -66,12 +66,99 @@ LPCSTR WLOG_LEVELS[7] =
 	"OFF"
 };
 
+static INIT_ONCE _WLogInitialized = INIT_ONCE_STATIC_INIT;
 static DWORD g_FilterCount = 0;
 static wLogFilter* g_Filters = NULL;
+static wLog* g_RootLog = NULL;
 
+static wLog* WLog_New(LPCSTR name, wLog* rootLogger);
+static void WLog_Free(wLog* log);
 static LONG WLog_GetFilterLogLevel(wLog* log);
 static int WLog_ParseLogLevel(LPCSTR level);
 static BOOL WLog_ParseFilter(wLogFilter* filter, LPCSTR name);
+static BOOL WLog_ParseFilters(void);
+
+static void WLog_Uninit_(void)
+{
+	DWORD index;
+	wLog* child = NULL;
+	wLog* root = g_RootLog;
+
+	if (!root)
+		return;
+
+	for (index = 0; index < root->ChildrenCount; index++)
+	{
+		child = root->Children[index];
+		WLog_Free(child);
+	}
+
+	WLog_Free(root);
+	g_RootLog = NULL;
+}
+
+static BOOL CALLBACK WLog_InitializeRoot(PINIT_ONCE InitOnce, PVOID Parameter, PVOID* Context)
+{
+	char* env;
+	DWORD nSize;
+	DWORD logAppenderType;
+	LPCSTR appender = "WLOG_APPENDER";
+
+	if (!(g_RootLog = WLog_New("", NULL)))
+		return FALSE;
+
+	g_RootLog->IsRoot = TRUE;
+	WLog_ParseFilters();
+	logAppenderType = WLOG_APPENDER_CONSOLE;
+	nSize = GetEnvironmentVariableA(appender, NULL, 0);
+
+	if (nSize)
+	{
+		env = (LPSTR) malloc(nSize);
+
+		if (!env)
+			goto fail;
+
+		if (GetEnvironmentVariableA(appender, env, nSize) != nSize - 1)
+		{
+			fprintf(stderr, "%s environment variable modified in my back", appender);
+			free(env);
+			goto fail;
+		}
+
+		if (_stricmp(env, "CONSOLE") == 0)
+			logAppenderType = WLOG_APPENDER_CONSOLE;
+		else if (_stricmp(env, "FILE") == 0)
+			logAppenderType = WLOG_APPENDER_FILE;
+		else if (_stricmp(env, "BINARY") == 0)
+			logAppenderType = WLOG_APPENDER_BINARY;
+
+#ifdef HAVE_SYSLOG_H
+		else if (_stricmp(env, "SYSLOG") == 0)
+			logAppenderType = WLOG_APPENDER_SYSLOG;
+
+#endif /* HAVE_SYSLOG_H */
+#ifdef HAVE_JOURNALD_H
+		else if (_stricmp(env, "JOURNALD") == 0)
+			logAppenderType = WLOG_APPENDER_JOURNALD;
+
+#endif
+		else if (_stricmp(env, "UDP") == 0)
+			logAppenderType = WLOG_APPENDER_UDP;
+
+		free(env);
+	}
+
+	if (!WLog_SetLogAppenderType(g_RootLog, logAppenderType))
+		goto fail;
+
+	atexit(WLog_Uninit_);
+	return TRUE;
+fail:
+	free(g_RootLog);
+	g_RootLog = NULL;
+	return FALSE;
+}
 
 static BOOL log_recursion(LPCSTR file, LPCSTR fkt, int line)
 {
@@ -121,7 +208,7 @@ static BOOL log_recursion(LPCSTR file, LPCSTR fkt, int line)
 	return TRUE;
 }
 
-BOOL WLog_Write(wLog* log, wLogMessage* message)
+static BOOL WLog_Write(wLog* log, wLogMessage* message)
 {
 	BOOL status;
 	wLogAppender* appender;
@@ -153,7 +240,7 @@ BOOL WLog_Write(wLog* log, wLogMessage* message)
 	return status;
 }
 
-BOOL WLog_WriteData(wLog* log, wLogMessage* message)
+static BOOL WLog_WriteData(wLog* log, wLogMessage* message)
 {
 	BOOL status;
 	wLogAppender* appender;
@@ -185,7 +272,7 @@ BOOL WLog_WriteData(wLog* log, wLogMessage* message)
 	return status;
 }
 
-BOOL WLog_WriteImage(wLog* log, wLogMessage* message)
+static BOOL WLog_WriteImage(wLog* log, wLogMessage* message)
 {
 	BOOL status;
 	wLogAppender* appender;
@@ -217,7 +304,7 @@ BOOL WLog_WriteImage(wLog* log, wLogMessage* message)
 	return status;
 }
 
-BOOL WLog_WritePacket(wLog* log, wLogMessage* message)
+static BOOL WLog_WritePacket(wLog* log, wLogMessage* message)
 {
 	BOOL status;
 	wLogAppender* appender;
@@ -556,6 +643,7 @@ BOOL WLog_ParseFilters(void)
 
 	if (GetEnvironmentVariableA(filter, env, nSize) == nSize - 1)
 		res = WLog_AddStringLogFilters(env);
+
 	free(env);
 	return res;
 }
@@ -603,7 +691,7 @@ LONG WLog_GetFilterLogLevel(wLog* log)
 	return log->FilterLevel;
 }
 
-BOOL WLog_ParseName(wLog* log, LPCSTR name)
+static BOOL WLog_ParseName(wLog* log, LPCSTR name)
 {
 	char* p;
 	int count;
@@ -684,7 +772,6 @@ wLog* WLog_New(LPCSTR name, wLog* rootLogger)
 	else
 	{
 		LPCSTR level = "WLOG_LEVEL";
-
 		log->Level = WLOG_INFO;
 		nSize = GetEnvironmentVariableA(level, NULL, 0);
 
@@ -741,75 +828,15 @@ void WLog_Free(wLog* log)
 	}
 }
 
-static wLog* g_RootLog = NULL;
-
 wLog* WLog_GetRoot(void)
 {
-	char* env;
-	DWORD nSize;
-	DWORD logAppenderType;
-
-	if (!g_RootLog)
-	{
-		LPCSTR appender = "WLOG_APPENDER";
-
-		if (!(g_RootLog = WLog_New("", NULL)))
-			return NULL;
-
-		g_RootLog->IsRoot = TRUE;
-		WLog_ParseFilters();
-		logAppenderType = WLOG_APPENDER_CONSOLE;
-		nSize = GetEnvironmentVariableA(appender, NULL, 0);
-
-		if (nSize)
-		{
-			env = (LPSTR) malloc(nSize);
-
-			if (!env)
-				goto fail;
-
-			if (GetEnvironmentVariableA(appender, env, nSize) != nSize - 1)
-			{
-				fprintf(stderr, "%s environment variable modified in my back", appender);
-				free(env);
-				goto fail;
-			}
-
-			if (_stricmp(env, "CONSOLE") == 0)
-				logAppenderType = WLOG_APPENDER_CONSOLE;
-			else if (_stricmp(env, "FILE") == 0)
-				logAppenderType = WLOG_APPENDER_FILE;
-			else if (_stricmp(env, "BINARY") == 0)
-				logAppenderType = WLOG_APPENDER_BINARY;
-
-#ifdef HAVE_SYSLOG_H
-			else if (_stricmp(env, "SYSLOG") == 0)
-				logAppenderType = WLOG_APPENDER_SYSLOG;
-
-#endif /* HAVE_SYSLOG_H */
-#ifdef HAVE_JOURNALD_H
-			else if (_stricmp(env, "JOURNALD") == 0)
-				logAppenderType = WLOG_APPENDER_JOURNALD;
-
-#endif
-			else if (_stricmp(env, "UDP") == 0)
-				logAppenderType = WLOG_APPENDER_UDP;
-
-			free(env);
-		}
-
-		if (!WLog_SetLogAppenderType(g_RootLog, logAppenderType))
-			goto fail;
-	}
+	if (!InitOnceExecuteOnce(&_WLogInitialized, WLog_InitializeRoot, NULL, NULL))
+		return NULL;
 
 	return g_RootLog;
-fail:
-	free(g_RootLog);
-	g_RootLog = NULL;
-	return NULL;
 }
 
-BOOL WLog_AddChild(wLog* parent, wLog* child)
+static BOOL WLog_AddChild(wLog* parent, wLog* child)
 {
 	if (parent->ChildrenCount >= parent->ChildrenSize)
 	{
@@ -848,7 +875,7 @@ BOOL WLog_AddChild(wLog* parent, wLog* child)
 	return TRUE;
 }
 
-wLog* WLog_FindChild(LPCSTR name)
+static wLog* WLog_FindChild(LPCSTR name)
 {
 	DWORD index;
 	wLog* root;
@@ -904,21 +931,6 @@ BOOL WLog_Init(void)
 
 BOOL WLog_Uninit(void)
 {
-	DWORD index;
-	wLog* child = NULL;
-	wLog* root = g_RootLog;
-
-	if (!root)
-		return FALSE;
-
-	for (index = 0; index < root->ChildrenCount; index++)
-	{
-		child = root->Children[index];
-		WLog_Free(child);
-	}
-
-	WLog_Free(root);
-	g_RootLog = NULL;
-
 	return TRUE;
 }
+

--- a/winpr/tools/hash-cli/hash.c
+++ b/winpr/tools/hash-cli/hash.c
@@ -195,5 +195,5 @@ int main(int argc, char* argv[])
 		printf("\n");
 	}
 
-	return winpr_exit(0);
+	return 0;
 }

--- a/winpr/tools/makecert-cli/main.c
+++ b/winpr/tools/makecert-cli/main.c
@@ -34,12 +34,12 @@ int main(int argc, char* argv[])
 
 	context = makecert_context_new();
 	if (!context)
-		return winpr_exit(1);
+		return 1;
 
 	if (makecert_context_process(context, argc, argv) < 0)
 		ret = 1;
 
 	makecert_context_free(context);
 
-	return winpr_exit(ret);
+	return ret;
 }


### PR DESCRIPTION
Use singleton initializer and register cleanup handler for logger.

manually cleaning up WLog by calling `WLog_Uninit` is not really feasable, do it at program termination.