### PR TITLE
fix warnings about discarded const and comparing int with null

### DIFF
--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -170,10 +170,10 @@ static void xf_Bitmap_Free(rdpContext* context, rdpBitmap* bitmap)
 
 	xf_lock_x11(xfc, FALSE);
 
-	if (xbitmap->pixmap != NULL)
+	if (xbitmap->pixmap != 0)
 	{
 		XFreePixmap(xfc->display, xbitmap->pixmap);
-		xbitmap->pixmap = NULL;
+		xbitmap->pixmap = 0;
 	}
 
 	if (xbitmap->image)

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -589,7 +589,7 @@ static char** freerdp_command_line_parse_comma_separated_values_ex(const char* n
 
 			if (p)
 			{
-				p[0] = name;
+				p[0] = (char*)name;
 				*count = 1;
 				return p;
 			}

--- a/winpr/libwinpr/utils/cmdline.c
+++ b/winpr/libwinpr/utils/cmdline.c
@@ -289,7 +289,7 @@ int CommandLineParseArgumentsA(int argc, LPCSTR* argv, COMMAND_LINE_ARGUMENT_A* 
 
 				if (value)
 				{
-					options[j].Value = value;
+					options[j].Value = (char*)value;
 					options[j].Flags |= COMMAND_LINE_VALUE_PRESENT;
 				}
 				else


### PR DESCRIPTION
This fixes a few warnings about discarded const qualifiers and comparing an integer with null and setting it to null; including the case described in #4523.
