### PR TITLE
Warning fixes v2

### DIFF
--- a/libfreerdp/codec/h264_ffmpeg.c
+++ b/libfreerdp/codec/h264_ffmpeg.c
@@ -257,7 +257,8 @@ static int libavcodec_decompress(H264_CONTEXT* h264, const BYTE* pSrcData,
 
 	if (status < 0)
 	{
-		WLog_Print(h264->log, WLOG_ERROR, "Failed to transfer video frame (status=%d) (%s)", status, av_err2str(status));
+		WLog_Print(h264->log, WLOG_ERROR, "Failed to transfer video frame (status=%d) (%s)", status,
+		           av_err2str(status));
 		return -1;
 	}
 
@@ -315,12 +316,12 @@ static int libavcodec_compress(H264_CONTEXT* h264, const BYTE** pSrcYuv, const U
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(52, 92, 100)
 	sys->videoFrame->chroma_location = AVCHROMA_LOC_LEFT;
 #endif
-	sys->videoFrame->data[0] = pSrcYuv[0];
-	sys->videoFrame->data[1] = pSrcYuv[1];
-	sys->videoFrame->data[2] = pSrcYuv[2];
-	sys->videoFrame->linesize[0] = pStride[0];
-	sys->videoFrame->linesize[1] = pStride[1];
-	sys->videoFrame->linesize[2] = pStride[2];
+	sys->videoFrame->data[0] = (uint8_t*)pSrcYuv[0];
+	sys->videoFrame->data[1] = (uint8_t*)pSrcYuv[1];
+	sys->videoFrame->data[2] = (uint8_t*)pSrcYuv[2];
+	sys->videoFrame->linesize[0] = (int)pStride[0];
+	sys->videoFrame->linesize[1] = (int)pStride[1];
+	sys->videoFrame->linesize[2] = (int)pStride[2];
 	sys->videoFrame->pts++;
 	/* avcodec_encode_video2 is deprecated with libavcodec 57.48.101 */
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)
@@ -543,8 +544,9 @@ static BOOL libavcodec_init(H264_CONTEXT* h264)
 
 			if (ret < 0)
 			{
-				WLog_Print(h264->log, WLOG_ERROR, "Could not initialize hardware decoder, falling back to software: %s",
-				         av_err2str(ret));
+				WLog_Print(h264->log, WLOG_ERROR,
+				           "Could not initialize hardware decoder, falling back to software: %s",
+				           av_err2str(ret));
 				sys->hwctx = NULL;
 				goto fail_hwdevice_create;
 			}

--- a/libfreerdp/codec/h264_openh264.c
+++ b/libfreerdp/codec/h264_openh264.c
@@ -268,15 +268,15 @@ static int openh264_compress(H264_CONTEXT* h264, const BYTE** pYUVData, const UI
 
 	memset(&info, 0, sizeof(SFrameBSInfo));
 	memset(&pic, 0, sizeof(SSourcePicture));
-	pic.iPicWidth = h264->width;
-	pic.iPicHeight = h264->height;
+	pic.iPicWidth = (int)h264->width;
+	pic.iPicHeight = (int)h264->height;
 	pic.iColorFormat = videoFormatI420;
-	pic.iStride[0] = iStride[0];
-	pic.iStride[1] = iStride[1];
-	pic.iStride[2] = iStride[2];
-	pic.pData[0] = pYUVData[0];
-	pic.pData[1] = pYUVData[1];
-	pic.pData[2] = pYUVData[2];
+	pic.iStride[0] = (int)iStride[0];
+	pic.iStride[1] = (int)iStride[1];
+	pic.iStride[2] = (int)iStride[2];
+	pic.pData[0] = (unsigned char*)pYUVData[0];
+	pic.pData[1] = (unsigned char*)pYUVData[1];
+	pic.pData[2] = (unsigned char*)pYUVData[2];
 	status = (*sys->pEncoder)->EncodeFrame(sys->pEncoder, &pic, &info);
 
 	if (status < 0)

--- a/libfreerdp/core/fastpath.c
+++ b/libfreerdp/core/fastpath.c
@@ -348,7 +348,7 @@ static int fastpath_recv_update(rdpFastPath* fastpath, BYTE updateCode, wStream*
 #ifdef WITH_DEBUG_RDP
 	DEBUG_RDP("recv Fast-Path %s Update (0x%02"PRIX8"), length:%"PRIuz"",
 	          updateCode < ARRAYSIZE(FASTPATH_UPDATETYPE_STRINGS) ? FASTPATH_UPDATETYPE_STRINGS[updateCode] :
-			  "???", updateCode, Stream_GetLength(s));
+			  "???", updateCode, Stream_Length(s));
 #endif
 
 	switch (updateCode)

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -673,7 +673,7 @@ static char* freerdp_tcp_get_ip_address(int sockfd, BOOL* pIPv6)
 	struct sockaddr_in* sockaddr_ipv4 = (struct sockaddr_in*)&saddr;
 	length = sizeof(struct sockaddr_storage);
 
-	if (getsockname(sockfd, &saddr, &length) != 0)
+	if (getsockname(sockfd, (struct sockaddr*)&saddr, &length) != 0)
 		return NULL;
 
 	switch (sockaddr_ipv4->sin_family)

--- a/libfreerdp/primitives/test/TestPrimitivesYUV.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYUV.c
@@ -886,7 +886,7 @@ int TestPrimitivesYUV(int argc, char* argv[])
 
 		if (argc > 1)
 		{
-			int rc = sscanf(argv[1], "%l"PRIu32"x%"PRIu32, &roi.width, &roi.height);
+			int rc = sscanf(argv[1], "%"PRIu32"x%"PRIu32, &roi.width, &roi.height);
 
 			if (rc != 2)
 			{


### PR DESCRIPTION
* Cast warnings in H264 backends away. (The buffers / sizes are either signed or unsigned, depending on backend)
* Fix compiler format string warnings
* Fix invalid function call in log message.