### PR TITLE
remove unused functions (cleans up build warning)

### DIFF
--- a/libfreerdp/cache/nine_grid.c
+++ b/libfreerdp/cache/nine_grid.c
@@ -35,10 +35,6 @@
 
 #define TAG FREERDP_TAG("cache.nine_grid")
 
-static void* nine_grid_cache_get(rdpNineGridCache* nine_grid, UINT32 index);
-static void nine_grid_cache_put(rdpNineGridCache* nine_grid, UINT32 index, void* entry);
-
-
 static BOOL update_gdi_draw_nine_grid(rdpContext* context,
 					  const DRAW_NINE_GRID_ORDER* draw_nine_grid)
 {
@@ -62,39 +58,6 @@ void nine_grid_cache_register_callbacks(rdpUpdate* update)
 
 	update->primary->DrawNineGrid = update_gdi_draw_nine_grid;
 	update->primary->MultiDrawNineGrid = update_gdi_multi_draw_nine_grid;
-}
-
-void* nine_grid_cache_get(rdpNineGridCache* nine_grid, UINT32 index)
-{
-	void* entry;
-
-	if (index >= nine_grid->maxEntries)
-	{
-		WLog_ERR(TAG,  "invalid NineGrid index: 0x%08"PRIX32"", index);
-		return NULL;
-	}
-
-	entry = nine_grid->entries[index].entry;
-
-	if (entry == NULL)
-	{
-		WLog_ERR(TAG,  "invalid NineGrid at index: 0x%08"PRIX32"", index);
-		return NULL;
-	}
-
-	return entry;
-}
-
-void nine_grid_cache_put(rdpNineGridCache* nine_grid, UINT32 index, void* entry)
-{
-	if (index >= nine_grid->maxEntries)
-	{
-		WLog_ERR(TAG,  "invalid NineGrid index: 0x%08"PRIX32"", index);
-		return;
-	}
-
-	free(nine_grid->entries[index].entry);
-	nine_grid->entries[index].entry = entry;
 }
 
 rdpNineGridCache* nine_grid_cache_new(rdpSettings* settings)

--- a/libfreerdp/cache/palette.c
+++ b/libfreerdp/cache/palette.c
@@ -30,8 +30,6 @@
 
 #define TAG FREERDP_TAG("cache.palette")
 
-static void* palette_cache_get(rdpPaletteCache* palette, UINT32 index);
-
 static void palette_cache_put(rdpPaletteCache* palette, UINT32 index, void* entry);
 
 static BOOL update_gdi_cache_color_table(rdpContext* context,
@@ -47,27 +45,6 @@ static BOOL update_gdi_cache_color_table(rdpContext* context,
 
 	palette_cache_put(cache->palette, cacheColorTable->cacheIndex, (void*) colorTable);
 	return TRUE;
-}
-
-void* palette_cache_get(rdpPaletteCache* paletteCache, UINT32 index)
-{
-	void* entry;
-
-	if (index >= paletteCache->maxEntries)
-	{
-		WLog_ERR(TAG,  "invalid color table index: 0x%08"PRIX32"", index);
-		return NULL;
-	}
-
-	entry = paletteCache->entries[index].entry;
-
-	if (!entry)
-	{
-		WLog_ERR(TAG,  "invalid color table at index: 0x%08"PRIX32"", index);
-		return NULL;
-	}
-
-	return entry;
 }
 
 void palette_cache_put(rdpPaletteCache* paletteCache, UINT32 index, void* entry)

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -292,15 +292,6 @@ static INLINE BOOL progressive_rfx_quant_cmp_equal(RFX_COMPONENT_CODEC_QUANT* q1
 	return TRUE;
 }
 
-static void progressive_rfx_quant_print(RFX_COMPONENT_CODEC_QUANT* q, const char* name)
-{
-	fprintf(stderr,
-	        "%s: HL1: %"PRIu8" LH1: %"PRIu8" HH1: %"PRIu8" HL2: %"PRIu8" LH2: %"PRIu8" HH2: %"PRIu8" HL3: %"PRIu8" LH3: %"PRIu8" HH3: %"PRIu8" LL3: %"PRIu8"\n",
-	        name, q->HL1, q->LH1, q->HH1, q->HL2, q->LH2, q->HH2, q->HL3, q->LH3, q->HH3,
-	        q->LL3);
-}
-
-
 static INLINE BOOL progressive_set_surface_data(PROGRESSIVE_CONTEXT* progressive,
         UINT16 surfaceId, void* pData)
 {

--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -2104,38 +2104,6 @@ static BOOL rdp_read_draw_gdiplus_cache_capability_set(wStream* s,
 	return TRUE;
 }
 
-/**
- * Write GDI+ cache capability set.\n
- * @msdn{cc241566}
- * @param s stream
- * @param settings settings
- */
-
-static BOOL rdp_write_draw_gdiplus_cache_capability_set(wStream* s, rdpSettings* settings)
-{
-	int header;
-	UINT32 drawGDIPlusSupportLevel;
-	UINT32 drawGdiplusCacheLevel;
-
-	if (!Stream_EnsureRemainingCapacity(s, 64))
-		return FALSE;
-
-	header = rdp_capability_set_start(s);
-	drawGDIPlusSupportLevel = (settings->DrawGdiPlusEnabled) ?
-	                          DRAW_GDIPLUS_SUPPORTED : DRAW_GDIPLUS_DEFAULT;
-	drawGdiplusCacheLevel = (settings->DrawGdiPlusEnabled) ?
-	                        DRAW_GDIPLUS_CACHE_LEVEL_ONE : DRAW_GDIPLUS_CACHE_LEVEL_DEFAULT;
-	Stream_Write_UINT32(s, drawGDIPlusSupportLevel); /* drawGDIPlusSupportLevel (4 bytes) */
-	Stream_Write_UINT32(s, 0); /* GdipVersion (4 bytes) */
-	Stream_Write_UINT32(s, drawGdiplusCacheLevel); /* drawGdiplusCacheLevel (4 bytes) */
-	rdp_write_gdiplus_cache_entries(s, 10, 5, 5, 10, 2); /* GdipCacheEntries (10 bytes) */
-	rdp_write_gdiplus_cache_chunk_size(s, 512, 2048, 1024, 64); /* GdipCacheChunkSize (8 bytes) */
-	rdp_write_gdiplus_image_cache_properties(s, 4096, 256,
-	        128); /* GdipImageCacheProperties (6 bytes) */
-	rdp_capability_set_finish(s, header, CAPSET_TYPE_DRAW_GDI_PLUS);
-	return TRUE;
-}
-
 #ifdef WITH_DEBUG_CAPABILITIES
 static BOOL rdp_print_draw_gdiplus_cache_capability_set(wStream* s,
         UINT16 length)

--- a/libfreerdp/core/gateway/rts.c
+++ b/libfreerdp/core/gateway/rts.c
@@ -160,23 +160,6 @@ static int rts_connection_timeout_command_read(rdpRpc* rpc, BYTE* buffer, UINT32
 	return 4;
 }
 
-static int rts_connection_timeout_command_write(BYTE* buffer, UINT32 ConnectionTimeout)
-{
-	if (buffer)
-	{
-		*((UINT32*) &buffer[0]) = RTS_CMD_CONNECTION_TIMEOUT; /* CommandType (4 bytes) */
-		*((UINT32*) &buffer[4]) = ConnectionTimeout; /* ConnectionTimeout (4 bytes) */
-	}
-
-	return 8;
-}
-
-static int rts_cookie_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
-{
-	/* Cookie (16 bytes) */
-	return 16;
-}
-
 static int rts_cookie_command_write(BYTE* buffer, BYTE* Cookie)
 {
 	if (buffer)
@@ -188,12 +171,6 @@ static int rts_cookie_command_write(BYTE* buffer, BYTE* Cookie)
 	return 20;
 }
 
-static int rts_channel_lifetime_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
-{
-	/* ChannelLifetime (4 bytes) */
-	return 4;
-}
-
 static int rts_channel_lifetime_command_write(BYTE* buffer, UINT32 ChannelLifetime)
 {
 	if (buffer)
@@ -203,12 +180,6 @@ static int rts_channel_lifetime_command_write(BYTE* buffer, UINT32 ChannelLifeti
 	}
 
 	return 8;
-}
-
-static int rts_client_keepalive_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
-{
-	/* ClientKeepalive (4 bytes) */
-	return 4;
 }
 
 static int rts_client_keepalive_command_write(BYTE* buffer, UINT32 ClientKeepalive)
@@ -244,11 +215,6 @@ static int rts_version_command_write(BYTE* buffer)
 	return 8;
 }
 
-static int rts_empty_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
-{
-	return 0;
-}
-
 static int rts_empty_command_write(BYTE* buffer)
 {
 	if (buffer)
@@ -265,48 +231,6 @@ static int rts_padding_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
 	ConformanceCount = *((UINT32*) &buffer[0]); /* ConformanceCount (4 bytes) */
 	/* Padding (variable) */
 	return ConformanceCount + 4;
-}
-
-static int rts_padding_command_write(BYTE* buffer, UINT32 ConformanceCount)
-{
-	if (buffer)
-	{
-		*((UINT32*) &buffer[0]) = RTS_CMD_PADDING; /* CommandType (4 bytes) */
-		*((UINT32*) &buffer[4]) = ConformanceCount; /* ConformanceCount (4 bytes) */
-		ZeroMemory(&buffer[8], ConformanceCount); /* Padding (variable) */
-	}
-
-	return 8 + ConformanceCount;
-}
-
-static int rts_negative_ance_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
-{
-	return 0;
-}
-
-static int rts_negative_ance_command_write(BYTE* buffer)
-{
-	if (buffer)
-	{
-		*((UINT32*) &buffer[0]) = RTS_CMD_NEGATIVE_ANCE; /* CommandType (4 bytes) */
-	}
-
-	return 4;
-}
-
-static int rts_ance_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
-{
-	return 0;
-}
-
-static int rts_ance_command_write(BYTE* buffer)
-{
-	if (buffer)
-	{
-		*((UINT32*) &buffer[0]) = RTS_CMD_ANCE; /* CommandType (4 bytes) */
-	}
-
-	return 4;
 }
 
 static int rts_client_address_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
@@ -326,42 +250,6 @@ static int rts_client_address_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 len
 		/* padding (12 bytes) */
 		return 4 + 16 + 12;
 	}
-}
-
-static int rts_client_address_command_write(BYTE* buffer, UINT32 AddressType, BYTE* ClientAddress)
-{
-	if (buffer)
-	{
-		*((UINT32*) &buffer[0]) = RTS_CMD_CLIENT_ADDRESS; /* CommandType (4 bytes) */
-		*((UINT32*) &buffer[4]) = AddressType; /* AddressType (4 bytes) */
-	}
-
-	if (AddressType == 0)
-	{
-		if (buffer)
-		{
-			CopyMemory(&buffer[8], ClientAddress, 4); /* ClientAddress (4 bytes) */
-			ZeroMemory(&buffer[12], 12); /* padding (12 bytes) */
-		}
-
-		return 24;
-	}
-	else
-	{
-		if (buffer)
-		{
-			CopyMemory(&buffer[8], ClientAddress, 16); /* ClientAddress (16 bytes) */
-			ZeroMemory(&buffer[24], 12); /* padding (12 bytes) */
-		}
-
-		return 36;
-	}
-}
-
-static int rts_association_group_id_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
-{
-	/* AssociationGroupId (16 bytes) */
-	return 16;
 }
 
 static int rts_association_group_id_command_write(BYTE* buffer, BYTE* AssociationGroupId)
@@ -390,23 +278,6 @@ static int rts_destination_command_write(BYTE* buffer, UINT32 Destination)
 	{
 		*((UINT32*) &buffer[0]) = RTS_CMD_DESTINATION; /* CommandType (4 bytes) */
 		*((UINT32*) &buffer[4]) = Destination; /* Destination (4 bytes) */
-	}
-
-	return 8;
-}
-
-static int rts_ping_traffic_sent_notify_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
-{
-	/* PingTrafficSent (4 bytes) */
-	return 4;
-}
-
-static int rts_ping_traffic_sent_notify_command_write(BYTE* buffer, UINT32 PingTrafficSent)
-{
-	if (buffer)
-	{
-		*((UINT32*) &buffer[0]) = RTS_CMD_PING_TRAFFIC_SENT_NOTIFY; /* CommandType (4 bytes) */
-		*((UINT32*) &buffer[4]) = PingTrafficSent; /* PingTrafficSent (4 bytes) */
 	}
 
 	return 8;
@@ -528,32 +399,6 @@ int rts_recv_CONN_C2_pdu(rdpRpc* rpc, BYTE* buffer, UINT32 length)
 }
 
 /* Out-of-Sequence PDUs */
-
-static int rts_send_keep_alive_pdu(rdpRpc* rpc)
-{
-	int status;
-	BYTE* buffer;
-	UINT32 length;
-	rpcconn_rts_hdr_t header;
-	RpcInChannel* inChannel = rpc->VirtualConnection->DefaultInChannel;
-	rts_pdu_header_init(&header);
-	header.frag_length = 28;
-	header.Flags = RTS_FLAG_OTHER_CMD;
-	header.NumberOfCommands = 1;
-	WLog_DBG(TAG, "Sending Keep-Alive RTS PDU");
-	buffer = (BYTE*) malloc(header.frag_length);
-
-	if (!buffer)
-		return -1;
-
-	CopyMemory(buffer, ((BYTE*) &header), 20); /* RTS Header (20 bytes) */
-	rts_client_keepalive_command_write(&buffer[20],
-	                                   rpc->CurrentKeepAliveInterval); /* ClientKeepAlive (8 bytes) */
-	length = header.frag_length;
-	status = rpc_in_channel_write(inChannel, buffer, length);
-	free(buffer);
-	return (status > 0) ? 1 : -1;
-}
 
 int rts_send_flow_control_ack_pdu(rdpRpc* rpc)
 {

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1052,21 +1052,6 @@ BOOL tls_send_alert(rdpTls* tls)
 	return TRUE;
 }
 
-static BIO* findBufferedBio(BIO* front)
-{
-	BIO* ret = front;
-
-	while (ret)
-	{
-		if (BIO_method_type(ret) == BIO_TYPE_BUFFERED)
-			return ret;
-
-		ret = BIO_next(ret);
-	}
-
-	return ret;
-}
-
 int tls_write_all(rdpTls* tls, const BYTE* data, int length)
 {
 	int status;

--- a/server/shadow/X11/x11_shadow.c
+++ b/server/shadow/X11/x11_shadow.c
@@ -553,28 +553,6 @@ static int x11_shadow_handle_xevent(x11ShadowSubsystem* subsystem,
 	return 1;
 }
 
-static void x11_shadow_validate_region(x11ShadowSubsystem* subsystem, int x,
-                                       int y,
-                                       int width, int height)
-{
-	XRectangle region;
-
-	if (!subsystem->use_xfixes || !subsystem->use_xdamage)
-		return;
-
-	region.x = x;
-	region.y = y;
-	region.width = width;
-	region.height = height;
-#ifdef WITH_XFIXES
-	XLockDisplay(subsystem->display);
-	XFixesSetRegion(subsystem->display, subsystem->xdamage_region, &region, 1);
-	XDamageSubtract(subsystem->display, subsystem->xdamage,
-	                subsystem->xdamage_region, None);
-	XUnlockDisplay(subsystem->display);
-#endif
-}
-
 static int x11_shadow_blend_cursor(x11ShadowSubsystem* subsystem)
 {
 	int x, y;

--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -230,21 +230,6 @@ static void shadow_client_context_free(freerdp_peer* peer,
 	DeleteCriticalSection(&(client->lock));
 }
 
-static void shadow_client_message_free(wMessage* message)
-{
-	switch (message->id)
-	{
-		case SHADOW_MSG_IN_REFRESH_REQUEST_ID:
-			/* Refresh request do not have message to free */
-			break;
-
-		default:
-			WLog_ERR(TAG, "Unknown message id: %"PRIu32"", message->id);
-			free(message->wParam);
-			break;
-	}
-}
-
 static INLINE void shadow_client_mark_invalid(rdpShadowClient* client,
         int numRects, const RECTANGLE_16* rects)
 {

--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -110,20 +110,6 @@ static int ntlm_SetContextServicePrincipalNameW(NTLM_CONTEXT* context, LPWSTR Se
 	return 1;
 }
 
-static int ntlm_SetContextServicePrincipalNameA(NTLM_CONTEXT* context, char* ServicePrincipalName)
-{
-	int status;
-	context->ServicePrincipalName.Buffer = NULL;
-	status = ConvertToUnicode(CP_UTF8, 0, ServicePrincipalName, -1,
-	                          &context->ServicePrincipalName.Buffer, 0);
-
-	if (status <= 0)
-		return -1;
-
-	context->ServicePrincipalName.Length = (USHORT)((status - 1) * 2);
-	return 1;
-}
-
 static int ntlm_SetContextTargetName(NTLM_CONTEXT* context, char* TargetName)
 {
 	int status;

--- a/winpr/libwinpr/synch/timer.c
+++ b/winpr/libwinpr/synch/timer.c
@@ -577,14 +577,6 @@ static void timespec_add_ms(struct timespec* tspec, UINT32 ms)
 	tspec->tv_nsec = (ns % 1000000000);
 }
 
-static UINT64 timespec_to_ms(struct timespec* tspec)
-{
-	UINT64 ms;
-	ms = tspec->tv_sec * 1000;
-	ms += tspec->tv_nsec / 1000000;
-	return ms;
-}
-
 static void timespec_gettimeofday(struct timespec* tspec)
 {
 	struct timeval tval;


### PR DESCRIPTION
winpr/libwinpr/synch/timer.c:
	timespec_to_ms

winpr/libwinpr/sspi/NTLM/ntlm.c:
	ntlm_SetContextServicePrincipalNameA

libfreerdp/cache/nine_grid.c:
	nine_grid_cache_get
	nine_grid_cache_put

libfreerdp/cache/palette.c:
	palette_cache_get

libfreerdp/crypto/tls.c:
	findBufferedBio

libfreerdp/core/capabilities.c:
	rdp_write_draw_gdiplus_cache_capability_set

libfreerdp/core/gateway/rts.c:
	rts_connection_timeout_command_write
	rts_cookie_command_read
	rts_channel_lifetime_command_read
	rts_client_keepalive_command_read
	rts_empty_command_read
	rts_padding_command_write
	rts_negative_ance_command_read
	rts_ance_command_read
	rts_ance_command_write
	rts_client_address_command_write
	rts_association_group_id_command_read
	rts_ping_traffic_sent_notify_command_read
	rts_ping_traffic_sent_notify_command_write

libfreerdp/codec/progressive.c:
	progressive_rfx_quant_print

server/shadow/shadow_client.c:
	shadow_client_message_free

server/shadow/X11/x11_shadow.c:
	x11_shadow_validate_region