### PR TITLE
Fix variable passsed to HashCallback with MIC.

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm.h
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.h
@@ -250,6 +250,7 @@ struct _NTLM_CONTEXT
 	NTLM_NEGOTIATE_MESSAGE NEGOTIATE_MESSAGE;
 	NTLM_CHALLENGE_MESSAGE CHALLENGE_MESSAGE;
 	NTLM_AUTHENTICATE_MESSAGE AUTHENTICATE_MESSAGE;
+	UINT32 MessageIntegrityCheckOffset;
 	SecBuffer NegotiateMessage;
 	SecBuffer ChallengeMessage;
 	SecBuffer AuthenticateMessage;
@@ -272,8 +273,6 @@ struct _NTLM_CONTEXT
 	BYTE ClientSealingKey[16];
 	BYTE ServerSigningKey[16];
 	BYTE ServerSealingKey[16];
-	BYTE MessageIntegrityCheck[16];
-	UINT32 MessageIntegrityCheckOffset;
 	psPeerComputeNtlmHash HashCallback;
 	void* HashCallbackArg;
 };

--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
@@ -21,6 +21,8 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
+
 #include "ntlm.h"
 #include "../sspi.h"
 
@@ -721,13 +723,15 @@ void ntlm_init_rc4_seal_states(NTLM_CONTEXT* context)
 	}
 }
 
-void ntlm_compute_message_integrity_check(NTLM_CONTEXT* context)
+void ntlm_compute_message_integrity_check(NTLM_CONTEXT* context, BYTE *mic, UINT32 size)
 {
 	/*
 	 * Compute the HMAC-MD5 hash of ConcatenationOf(NEGOTIATE_MESSAGE,
 	 * CHALLENGE_MESSAGE, AUTHENTICATE_MESSAGE) using the ExportedSessionKey
 	 */
 	WINPR_HMAC_CTX* hmac = winpr_HMAC_New();
+
+	assert(size >= WINPR_MD5_DIGEST_LENGTH);
 
 	if (!hmac)
 		return;
@@ -740,7 +744,7 @@ void ntlm_compute_message_integrity_check(NTLM_CONTEXT* context)
 		                  context->ChallengeMessage.cbBuffer);
 		winpr_HMAC_Update(hmac, (BYTE*) context->AuthenticateMessage.pvBuffer,
 		                  context->AuthenticateMessage.cbBuffer);
-		winpr_HMAC_Final(hmac, context->MessageIntegrityCheck, WINPR_MD5_DIGEST_LENGTH);
+		winpr_HMAC_Final(hmac, mic, WINPR_MD5_DIGEST_LENGTH);
 	}
 
 	winpr_HMAC_Free(hmac);

--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
@@ -346,8 +346,9 @@ int ntlm_compute_ntlm_v2_hash(NTLM_CONTEXT* context, BYTE* hash)
 		}
 
 		ret = context->HashCallback(context->HashCallbackArg, &credentials->identity, &proofValue,
-		                            context->EncryptedRandomSessionKey, context->MessageIntegrityCheck, &micValue,
-		                            hash);
+		                            context->EncryptedRandomSessionKey,
+					    (&context->AUTHENTICATE_MESSAGE)->MessageIntegrityCheck,
+					    &micValue, hash);
 		sspi_SecBufferFree(&proofValue);
 		sspi_SecBufferFree(&micValue);
 		return ret ? 1 : -1;

--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.h
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.h
@@ -57,6 +57,6 @@ void ntlm_generate_client_sealing_key(NTLM_CONTEXT* context);
 void ntlm_generate_server_sealing_key(NTLM_CONTEXT* context);
 void ntlm_init_rc4_seal_states(NTLM_CONTEXT* context);
 
-void ntlm_compute_message_integrity_check(NTLM_CONTEXT* context);
+void ntlm_compute_message_integrity_check(NTLM_CONTEXT* context, BYTE *mic, UINT32 size);
 
 #endif /* WINPR_AUTH_NTLM_COMPUTE_H */


### PR DESCRIPTION
Fix value where the MessageIntegrityCheck is stored.
The value in the context is not set yet and we need one from
authentication message.