### PR TITLE
Gateway client (RDG) must connect to same IP/server for both channels

### DIFF
--- a/libfreerdp/core/tcp.h
+++ b/libfreerdp/core/tcp.h
@@ -67,4 +67,6 @@ FREERDP_LOCAL int freerdp_tcp_connect(rdpContext* context,
                                       rdpSettings* settings,
                                       const char* hostname, int port, int timeout);
 
+FREERDP_LOCAL char* freerdp_tcp_get_peer_address(int sockfd);
+
 #endif /* FREERDP_LIB_CORE_TCP_H */


### PR DESCRIPTION
## Problem description
 * Gateway connection fails when gateway name is associated to more than a single IP #4222 

Currently RDG first opens the OUT channel and the subsequently the IN channel. Each channel calls the underlying **tcp.h** available functions to resolve the peer address from its name (settings->GatewayHostname). The issue arises when the gateway name points to multiple IPs and the IN channel is opened against one IP and the OUT channel against a different one.

For example, imagine a large organization that wants to scale the number of concurrent users they can have through their gateway. It can set their gateway name have multiple [A-records](https://en.wikipedia.org/wiki/List_of_DNS_record_types) so they can have different IPs and gateway servers serving connections to a single gateway hostname.

From my observations, the RDG protocol does not support the IN and OUT channels to be handled by different gateway servers. Thus the need of guaranteeing that we pick a single server/IP to connect for both channels.

## Proposed solution

1. Added **freerdp_tcp_get_peer_address** to *tcp.c/h* that allows one to resolve the peer (remote) address from a socket
2. When opening the IN channel in *rdg.c* I first take the already connected socket for the OUT channel, get the peer address using (1) and use it to create the IN channel

## Notes

When a proxy is used between client and server, my understanding is that the proxy is the one to resolve the gateway hostname, thus no changes were made for this scenario.