### PR TITLE
Autoreconnect fix

### DIFF
--- a/channels/cliprdr/client/cliprdr_main.c
+++ b/channels/cliprdr/client/cliprdr_main.c
@@ -239,7 +239,7 @@ static UINT cliprdr_process_clip_caps(cliprdrPlugin* cliprdr, wStream* s,
 		Stream_Read_UINT16(s, capabilitySetType); /* capabilitySetType (2 bytes) */
 		Stream_Read_UINT16(s, lengthCapability); /* lengthCapability (2 bytes) */
 
-		if (lengthCapability < 4 || Stream_GetRemainingLength(s) < lengthCapability-4)
+		if (lengthCapability < 4 || Stream_GetRemainingLength(s) < lengthCapability - 4)
 			return ERROR_INVALID_DATA;
 
 		switch (capabilitySetType)
@@ -337,7 +337,6 @@ static UINT cliprdr_process_filecontents_request(cliprdrPlugin* cliprdr,
 	request.msgFlags = flags;
 	request.dataLen = length;
 	request.haveClipDataId = FALSE;
-
 	Stream_Read_UINT32(s, request.streamId); /* streamId (4 bytes) */
 	Stream_Read_UINT32(s, request.listIndex); /* listIndex (4 bytes) */
 	Stream_Read_UINT32(s, request.dwFlags); /* dwFlags (4 bytes) */
@@ -633,6 +632,7 @@ static UINT cliprdr_temp_directory(CliprdrClientContext* context,
 	}
 
 	length = ConvertToUnicode(CP_UTF8, 0, tempDirectory->szTempDir, -1, &wszTempDir, 0);
+
 	if (length < 0)
 		return ERROR_INTERNAL_ERROR;
 
@@ -924,7 +924,6 @@ static UINT cliprdr_client_file_contents_request(CliprdrClientContext* context,
 	WLog_Print(cliprdr->log, WLOG_DEBUG,
 	           "ClientFileContentsRequest: streamId: 0x%08"PRIX32"",
 	           fileContentsRequest->streamId);
-
 	return cliprdr_packet_send(cliprdr, s);
 }
 
@@ -938,7 +937,6 @@ static UINT cliprdr_client_file_contents_response(CliprdrClientContext* context,
 {
 	wStream* s;
 	cliprdrPlugin* cliprdr = (cliprdrPlugin*) context->handle;
-
 	s = cliprdr_packet_new(CB_FILECONTENTS_RESPONSE, fileContentsResponse->msgFlags,
 	                       4 + fileContentsResponse->cbRequested);
 
@@ -1131,7 +1129,8 @@ static UINT cliprdr_virtual_channel_event_connected(cliprdrPlugin* cliprdr,
 		return ERROR_NOT_ENOUGH_MEMORY;
 	}
 
-	if (!(cliprdr->thread = CreateThread(NULL, 0, cliprdr_virtual_channel_client_thread, (void*) cliprdr,
+	if (!(cliprdr->thread = CreateThread(NULL, 0, cliprdr_virtual_channel_client_thread,
+	                                     (void*) cliprdr,
 	                                     0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");
@@ -1151,6 +1150,9 @@ static UINT cliprdr_virtual_channel_event_connected(cliprdrPlugin* cliprdr,
 static UINT cliprdr_virtual_channel_event_disconnected(cliprdrPlugin* cliprdr)
 {
 	UINT rc;
+
+	if (cliprdr->OpenHandle == 0)
+		return CHANNEL_RC_OK;
 
 	if (MessageQueue_PostQuit(cliprdr->queue, 0)
 	    && (WaitForSingleObject(cliprdr->thread, INFINITE) == WAIT_FAILED))

--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -713,9 +713,11 @@ static UINT drdynvc_send(drdynvcPlugin* drdynvc, wStream* s)
 	{
 		case CHANNEL_RC_OK:
 			return CHANNEL_RC_OK;
+
 		case CHANNEL_RC_NOT_CONNECTED:
 			Stream_Free(s, TRUE);
 			return CHANNEL_RC_OK;
+
 		case CHANNEL_RC_BAD_CHANNEL_HANDLE:
 			Stream_Free(s, TRUE);
 			WLog_ERR(TAG, "VirtualChannelWriteEx failed with CHANNEL_RC_BAD_CHANNEL_HANDLE");
@@ -1380,7 +1382,8 @@ static UINT drdynvc_virtual_channel_event_connected(drdynvcPlugin* drdynvc, LPVO
 
 	drdynvc->state = DRDYNVC_STATE_CAPABILITIES;
 
-	if (!(drdynvc->thread = CreateThread(NULL, 0, drdynvc_virtual_channel_client_thread, (void*) drdynvc,
+	if (!(drdynvc->thread = CreateThread(NULL, 0, drdynvc_virtual_channel_client_thread,
+	                                     (void*) drdynvc,
 	                                     0, NULL)))
 	{
 		error = ERROR_INTERNAL_ERROR;
@@ -1400,6 +1403,9 @@ error:
 static UINT drdynvc_virtual_channel_event_disconnected(drdynvcPlugin* drdynvc)
 {
 	UINT status;
+
+	if (drdynvc->OpenHandle == 0)
+		return CHANNEL_RC_OK;
 
 	if (!drdynvc)
 		return CHANNEL_RC_BAD_CHANNEL_HANDLE;

--- a/channels/encomsp/client/encomsp_main.c
+++ b/channels/encomsp/client/encomsp_main.c
@@ -1087,7 +1087,7 @@ static UINT encomsp_virtual_channel_event_connected(encomspPlugin* encomsp,
 	}
 
 	if (!(encomsp->thread = CreateThread(NULL, 0,
-										 encomsp_virtual_channel_client_thread, (void*) encomsp,
+	                                     encomsp_virtual_channel_client_thread, (void*) encomsp,
 	                                     0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");
@@ -1106,6 +1106,9 @@ static UINT encomsp_virtual_channel_event_connected(encomspPlugin* encomsp,
 static UINT encomsp_virtual_channel_event_disconnected(encomspPlugin* encomsp)
 {
 	UINT rc;
+
+	if (encomsp->OpenHandle == 0)
+		return CHANNEL_RC_OK;
 
 	if (MessageQueue_PostQuit(encomsp->queue, 0)
 	    && (WaitForSingleObject(encomsp->thread, INFINITE) == WAIT_FAILED))

--- a/channels/rail/client/rail_main.c
+++ b/channels/rail/client/rail_main.c
@@ -682,7 +682,7 @@ static UINT rail_virtual_channel_event_connected(railPlugin* rail, LPVOID pData,
 	}
 
 	if (!(rail->thread = CreateThread(NULL, 0,
-									  rail_virtual_channel_client_thread, (void*) rail, 0,
+	                                  rail_virtual_channel_client_thread, (void*) rail, 0,
 	                                  NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");
@@ -702,6 +702,9 @@ static UINT rail_virtual_channel_event_connected(railPlugin* rail, LPVOID pData,
 static UINT rail_virtual_channel_event_disconnected(railPlugin* rail)
 {
 	UINT rc;
+
+	if (rail->OpenHandle == 0)
+		return CHANNEL_RC_OK;
 
 	if (MessageQueue_PostQuit(rail->queue, 0)
 	    && (WaitForSingleObject(rail->thread, INFINITE) == WAIT_FAILED))

--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -1069,7 +1069,7 @@ static UINT rdpdr_process_connect(rdpdrPlugin* rdpdr)
 				first_hotplug(rdpdr);
 
 				if (!(rdpdr->hotplugThread = CreateThread(NULL, 0,
-								 drive_hotplug_thread_func, rdpdr, 0, NULL)))
+				                             drive_hotplug_thread_func, rdpdr, 0, NULL)))
 				{
 					WLog_ERR(TAG, "CreateThread failed!");
 					return ERROR_INTERNAL_ERROR;
@@ -1709,7 +1709,7 @@ static UINT rdpdr_virtual_channel_event_connected(rdpdrPlugin* rdpdr,
 	}
 
 	if (!(rdpdr->thread = CreateThread(NULL, 0,
-					   rdpdr_virtual_channel_client_thread, (void*) rdpdr, 0,
+	                                   rdpdr_virtual_channel_client_thread, (void*) rdpdr, 0,
 	                                   NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");
@@ -1727,6 +1727,9 @@ static UINT rdpdr_virtual_channel_event_connected(rdpdrPlugin* rdpdr,
 static UINT rdpdr_virtual_channel_event_disconnected(rdpdrPlugin* rdpdr)
 {
 	UINT error;
+
+	if (rdpdr->OpenHandle == 0)
+		return CHANNEL_RC_OK;
 
 	if (MessageQueue_PostQuit(rdpdr->queue, 0)
 	    && (WaitForSingleObject(rdpdr->thread, INFINITE) == WAIT_FAILED))

--- a/channels/remdesk/client/remdesk_main.c
+++ b/channels/remdesk/client/remdesk_main.c
@@ -882,7 +882,7 @@ static UINT remdesk_virtual_channel_event_connected(remdeskPlugin* remdesk,
 	}
 
 	remdesk->thread = CreateThread(NULL, 0,
-								   remdesk_virtual_channel_client_thread, (void*) remdesk,
+	                               remdesk_virtual_channel_client_thread, (void*) remdesk,
 	                               0, NULL);
 
 	if (!remdesk->thread)
@@ -907,6 +907,9 @@ error_out:
 static UINT remdesk_virtual_channel_event_disconnected(remdeskPlugin* remdesk)
 {
 	UINT rc;
+
+	if (remdesk->OpenHandle == 0)
+		return CHANNEL_RC_OK;
 
 	if (MessageQueue_PostQuit(remdesk->queue, 0)
 	    && (WaitForSingleObject(remdesk->thread, INFINITE) == WAIT_FAILED))

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -305,6 +305,8 @@ FREERDP_API BOOL freerdp_connect(freerdp* instance);
 FREERDP_API BOOL freerdp_abort_connect(freerdp* instance);
 FREERDP_API BOOL freerdp_shall_disconnect(freerdp* instance);
 FREERDP_API BOOL freerdp_disconnect(freerdp* instance);
+
+FREERDP_API BOOL freerdp_disconnect_before_reconnect(freerdp* instance);
 FREERDP_API BOOL freerdp_reconnect(freerdp* instance);
 
 FREERDP_API UINT freerdp_channel_add_init_handle_data(rdpChannelHandles* handles, void* pInitHandle,

--- a/libfreerdp/core/client.c
+++ b/libfreerdp/core/client.c
@@ -48,7 +48,7 @@ static CHANNEL_OPEN_DATA* freerdp_channels_find_channel_open_data_by_name(
 	{
 		pChannelOpenData = &channels->openDataList[index];
 
-		if (strcmp(name, pChannelOpenData->name) == 0)
+		if (strncmp(name, pChannelOpenData->name, CHANNEL_NAME_LEN) == 0)
 			return pChannelOpenData;
 	}
 
@@ -67,7 +67,7 @@ static rdpMcsChannel* freerdp_channels_find_channel_by_name(rdpRdp* rdp,
 	{
 		channel = &mcs->channels[index];
 
-		if (strcmp(name, channel->Name) == 0)
+		if (strncmp(name, channel->Name, CHANNEL_NAME_LEN) == 0)
 		{
 			return channel;
 		}
@@ -255,7 +255,6 @@ UINT freerdp_channels_attach(freerdp* instance)
 {
 	UINT error = CHANNEL_RC_OK;
 	int index;
-	char* name = NULL;
 	char* hostname;
 	int hostnameLength;
 	rdpChannels* channels;
@@ -285,26 +284,13 @@ UINT freerdp_channels_attach(freerdp* instance)
 			goto fail;
 
 		pChannelOpenData = &channels->openDataList[index];
-		name = (char*) malloc(9);
-
-		if (!name)
-		{
-			error = CHANNEL_RC_NO_MEMORY;
-			goto fail;
-		}
-
-		CopyMemory(name, pChannelOpenData->name, 8);
-		name[8] = '\0';
 		EventArgsInit(&e, "freerdp");
-		e.name = name;
+		e.name =  pChannelOpenData->name;
 		e.pInterface = pChannelOpenData->pInterface;
 		PubSub_OnChannelAttached(instance->context->pubSub, instance->context, &e);
-		free(name);
-		name = NULL;
 	}
 
 fail:
-	free(name);
 	return error;
 }
 
@@ -312,7 +298,6 @@ UINT freerdp_channels_detach(freerdp* instance)
 {
 	UINT error = CHANNEL_RC_OK;
 	int index;
-	char* name = NULL;
 	char* hostname;
 	int hostnameLength;
 	rdpChannels* channels;
@@ -342,26 +327,13 @@ UINT freerdp_channels_detach(freerdp* instance)
 			goto fail;
 
 		pChannelOpenData = &channels->openDataList[index];
-		name = (char*) malloc(9);
-
-		if (!name)
-		{
-			error = CHANNEL_RC_NO_MEMORY;
-			goto fail;
-		}
-
-		CopyMemory(name, pChannelOpenData->name, 8);
-		name[8] = '\0';
 		EventArgsInit(&e, "freerdp");
-		e.name = name;
+		e.name =  pChannelOpenData->name;
 		e.pInterface = pChannelOpenData->pInterface;
 		PubSub_OnChannelDetached(instance->context->pubSub, instance->context, &e);
-		free(name);
-		name = NULL;
 	}
 
 fail:
-	free(name);
 	return error;
 }
 
@@ -373,8 +345,7 @@ fail:
 UINT freerdp_channels_post_connect(rdpChannels* channels, freerdp* instance)
 {
 	UINT error = CHANNEL_RC_OK;
-	int index;
-	char* name = NULL;
+	UINT index;
 	char* hostname;
 	int hostnameLength;
 	CHANNEL_CLIENT_DATA* pChannelClientData;
@@ -403,22 +374,10 @@ UINT freerdp_channels_post_connect(rdpChannels* channels, freerdp* instance)
 			goto fail;
 
 		pChannelOpenData = &channels->openDataList[index];
-		name = (char*) malloc(9);
-
-		if (!name)
-		{
-			error = CHANNEL_RC_NO_MEMORY;
-			goto fail;
-		}
-
-		CopyMemory(name, pChannelOpenData->name, 8);
-		name[8] = '\0';
 		EventArgsInit(&e, "freerdp");
-		e.name = name;
+		e.name = pChannelOpenData->name;
 		e.pInterface = pChannelOpenData->pInterface;
 		PubSub_OnChannelConnected(instance->context->pubSub, instance->context, &e);
-		free(name);
-		name = NULL;
 	}
 
 	channels->drdynvc = (DrdynvcClientContext*)
@@ -435,7 +394,6 @@ UINT freerdp_channels_post_connect(rdpChannels* channels, freerdp* instance)
 	}
 
 fail:
-	free(name);
 	return error;
 }
 
@@ -628,7 +586,6 @@ UINT freerdp_channels_disconnect(rdpChannels* channels, freerdp* instance)
 	/* tell all libraries we are shutting down */
 	for (index = 0; index < channels->clientDataCount; index++)
 	{
-		char name[9];
 		ChannelDisconnectedEventArgs e;
 		pChannelClientData = &channels->clientDataList[index];
 
@@ -647,10 +604,8 @@ UINT freerdp_channels_disconnect(rdpChannels* channels, freerdp* instance)
 			continue;
 
 		pChannelOpenData = &channels->openDataList[index];
-		CopyMemory(name, pChannelOpenData->name, 8);
-		name[8] = '\0';
 		EventArgsInit(&e, "freerdp");
-		e.name = name;
+		e.name = pChannelOpenData->name;
 		e.pInterface = pChannelOpenData->pInterface;
 		PubSub_OnChannelDisconnected(instance->context->pubSub, instance->context, &e);
 	}

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -371,18 +371,18 @@ BOOL rdp_client_redirect(rdpRdp* rdp)
 	}
 	else
 	{
-		if (settings->RedirectionFlags & LB_TARGET_FQDN)
+        if (settings->RedirectionFlags & LB_TARGET_NET_ADDRESS)
 		{
 			free(settings->ServerHostname);
-			settings->ServerHostname = _strdup(settings->RedirectionTargetFQDN);
+			settings->ServerHostname = _strdup(settings->TargetNetAddress);
 
 			if (!settings->ServerHostname)
 				return FALSE;
 		}
-		else if (settings->RedirectionFlags & LB_TARGET_NET_ADDRESS)
+		else if (settings->RedirectionFlags & LB_TARGET_FQDN)
 		{
 			free(settings->ServerHostname);
-			settings->ServerHostname = _strdup(settings->TargetNetAddress);
+			settings->ServerHostname = _strdup(settings->RedirectionTargetFQDN);
 
 			if (!settings->ServerHostname)
 				return FALSE;

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -331,7 +331,19 @@ BOOL rdp_client_disconnect(rdpRdp* rdp)
 	if (freerdp_channels_disconnect(context->channels, context->instance) != CHANNEL_RC_OK)
 		return FALSE;
 
-	freerdp_set_last_error(context, FREERDP_ERROR_SUCCESS);
+	return TRUE;
+}
+
+BOOL rdp_client_disconnect_and_clear(rdpRdp* rdp)
+{
+	rdpContext* context;
+
+	if (!rdp_client_disconnect(rdp))
+		return FALSE;
+
+	context = rdp->context;
+
+	context->LastError = FREERDP_ERROR_SUCCESS;
 	clearChannelError(context);
 	ResetEvent(context->abortEvent);
 	return TRUE;
@@ -343,7 +355,7 @@ BOOL rdp_client_redirect(rdpRdp* rdp)
 	rdpSettings* settings;
 	rdpContext* context;
 
-	if (!rdp_client_disconnect(rdp))
+	if (!rdp_client_disconnect_and_clear(rdp))
 		return FALSE;
 
 	settings = rdp->settings;
@@ -417,7 +429,7 @@ BOOL rdp_client_reconnect(rdpRdp* rdp)
 	rdpContext* context = rdp->context;
 	rdpChannels* channels = context->channels;
 
-	if (!rdp_client_disconnect(rdp))
+	if (!rdp_client_disconnect_and_clear(rdp))
 		return FALSE;
 
 	status = rdp_client_connect(rdp);

--- a/libfreerdp/core/connection.h
+++ b/libfreerdp/core/connection.h
@@ -51,6 +51,7 @@ enum CONNECTION_STATE
 
 FREERDP_LOCAL BOOL rdp_client_connect(rdpRdp* rdp);
 FREERDP_LOCAL BOOL rdp_client_disconnect(rdpRdp* rdp);
+FREERDP_LOCAL BOOL rdp_client_disconnect_and_clear(rdpRdp* rdp);
 FREERDP_LOCAL BOOL rdp_client_reconnect(rdpRdp* rdp);
 FREERDP_LOCAL BOOL rdp_client_redirect(rdpRdp* rdp);
 FREERDP_LOCAL BOOL rdp_client_connect_mcs_channel_join_confirm(rdpRdp* rdp,

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -500,10 +500,6 @@ BOOL freerdp_disconnect(freerdp* instance)
 		MessageQueue_PostQuit(inputQueue, 0);
 	}
 
-	if (freerdp_channels_disconnect(instance->context->channels,
-	                                instance) != CHANNEL_RC_OK)
-		rc = FALSE;
-
 	IFCALL(instance->PostDisconnect, instance);
 
 	if (instance->update->pcap_rfx)
@@ -516,6 +512,12 @@ BOOL freerdp_disconnect(freerdp* instance)
 	codecs_free(instance->context->codecs);
 	freerdp_channels_close(instance->context->channels, instance);
 	return rc;
+}
+
+BOOL freerdp_disconnect_before_reconnect(freerdp* instance)
+{
+	rdpRdp* rdp = instance->context->rdp;
+	return rdp_client_disconnect(rdp);
 }
 
 BOOL freerdp_reconnect(freerdp* instance)

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -235,14 +235,15 @@ BOOL freerdp_connect(freerdp* instance)
 			pcap_record record;
 			update = instance->update;
 			update->pcap_rfx = pcap_open(settings->PlayRemoteFxFile, FALSE);
-
 			status = FALSE;
+
 			if (!update->pcap_rfx)
 				goto freerdp_connect_finally;
 			else
 				update->play_rfx = TRUE;
 
 			status = TRUE;
+
 			while (pcap_has_next_record(update->pcap_rfx) && status)
 			{
 				pcap_get_next_record_header(update->pcap_rfx, &record);
@@ -481,8 +482,15 @@ BOOL freerdp_disconnect(freerdp* instance)
 {
 	BOOL rc = TRUE;
 	rdpRdp* rdp;
+
+	if (!instance || !instance->context || !instance->context->rdp)
+		return FALSE;
+
 	rdp = instance->context->rdp;
-	rdp_client_disconnect(rdp);
+
+	if (!rdp_client_disconnect(rdp))
+		rc = FALSE;
+
 	update_post_disconnect(instance->update);
 
 	if (instance->settings->AsyncInput)

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -158,7 +158,7 @@ BOOL freerdp_connect(freerdp* instance)
 
 	/* We always set the return code to 0 before we start the connect sequence*/
 	connectErrorCode = 0;
-	freerdp_set_last_error(instance->context, FREERDP_ERROR_SUCCESS);
+	instance->context->LastError = FREERDP_ERROR_SUCCESS;
 	clearChannelError(instance->context);
 	ResetEvent(instance->context->abortEvent);
 	rdp = instance->context->rdp;
@@ -517,7 +517,7 @@ BOOL freerdp_disconnect(freerdp* instance)
 BOOL freerdp_disconnect_before_reconnect(freerdp* instance)
 {
 	rdpRdp* rdp = instance->context->rdp;
-	return rdp_client_disconnect(rdp);
+	return rdp_client_disconnect_and_clear(rdp);
 }
 
 BOOL freerdp_reconnect(freerdp* instance)

--- a/libfreerdp/core/redirection.c
+++ b/libfreerdp/core/redirection.c
@@ -156,14 +156,14 @@ int rdp_redirection_apply_settings(rdpRdp* rdp)
 		if (!settings->RedirectionTargetFQDN)
 			return -1;
 	}
-	else if (settings->RedirectionFlags & LB_TARGET_NET_ADDRESS)
+	if (settings->RedirectionFlags & LB_TARGET_NET_ADDRESS)
 	{
 		free(settings->TargetNetAddress);
 		settings->TargetNetAddress = _strdup(redirection->TargetNetAddress);
 		if (!settings->TargetNetAddress)
 			return -1;
 	}
-	else if (settings->RedirectionFlags & LB_TARGET_NETBIOS_NAME)
+	if (settings->RedirectionFlags & LB_TARGET_NETBIOS_NAME)
 	{
 		free(settings->RedirectionTargetNetBiosName);
 		settings->RedirectionTargetNetBiosName = _strdup(redirection->TargetNetBiosName);


### PR DESCRIPTION
* Channels need to be disconnected and connected again on `redirect` or `reconnect`
* Fixes #4511 : Channels did not properly handle a duplicate disconnect call
  * This could happen when the channel was not already connected
  * The channel was previously disconnected by the server
  * Fix for sound channel added in #4453 
* Remove string duplication for channel events, that is not required (the string is not changed)
* Fix clearing of previous errors (`LastError`) in case of reconnect
* Fix redirect, ensure channels were already loaded if reopening them.