### PR TITLE
Fix checking of krb in encrypt public key echo.

### DIFF
--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -1090,7 +1090,7 @@ SECURITY_STATUS nla_encrypt_public_key_echo(rdpNla* nla)
 		CopyMemory(Buffers[1].pvBuffer, nla->PublicKey.pvBuffer, Buffers[1].cbBuffer);
 	}
 
-	if (krb && nla->server)
+	if (!krb && nla->server)
 	{
 		/* server echos the public key +1 */
 		ap_integer_increment_le((BYTE*) Buffers[1].pvBuffer, Buffers[1].cbBuffer);


### PR DESCRIPTION
In commit 0e1a073384ddd1382f6a0619177cf0b601ad973c there was a mistake -
originally code said different then kerberos. Because of that NLA authentication
of server side didn't work for me.
