### PR TITLE
Fix polling in RDG

### DIFF
--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -1526,7 +1526,7 @@ static int rdg_bio_gets(BIO* bio, char* str, int size)
 
 static long rdg_bio_ctrl(BIO* bio, int cmd, long arg1, void* arg2)
 {
-	int status = 0;
+	int status = -1;
 	rdpRdg* rdg = (rdpRdg*) BIO_get_data(bio);
 	rdpTls* tlsOut = rdg->tlsOut;
 	rdpTls* tlsIn = rdg->tlsIn;
@@ -1536,14 +1536,6 @@ static long rdg_bio_ctrl(BIO* bio, int cmd, long arg1, void* arg2)
 		(void)BIO_flush(tlsOut->bio);
 		(void)BIO_flush(tlsIn->bio);
 		status = 1;
-	}
-	else if (cmd == BIO_C_GET_EVENT)
-	{
-		if (arg2)
-		{
-			BIO_get_event(rdg->tlsOut->bio, arg2);
-			status = 1;
-		}
 	}
 	else if (cmd == BIO_C_SET_NONBLOCK)
 	{
@@ -1583,9 +1575,10 @@ static long rdg_bio_ctrl(BIO* bio, int cmd, long arg1, void* arg2)
 		else
 			status = 1;
 	}
-	else if (cmd == BIO_C_GET_FD)
+	else if (cmd == BIO_C_GET_EVENT || cmd == BIO_C_GET_FD)
 	{
 		/*
+		 * A note about BIO_C_GET_FD:
 		 * Even if two FDs are part of RDG, only one FD can be returned here.
 		 *
 		 * In FreeRDP, BIO FDs are only used for polling, so it is safe to use the outgoing FD only

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -1583,6 +1583,17 @@ static long rdg_bio_ctrl(BIO* bio, int cmd, long arg1, void* arg2)
 		else
 			status = 1;
 	}
+	else if (cmd == BIO_C_GET_FD)
+	{
+		/*
+		 * Even if two FDs are part of RDG, only one FD can be returned here.
+		 *
+		 * In FreeRDP, BIO FDs are only used for polling, so it is safe to use the outgoing FD only
+		 *
+		 * See issue #3602
+		 */
+		return BIO_get_fd(tlsOut->bio, NULL);
+	}
 
 	return status;
 }

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -1592,7 +1592,7 @@ static long rdg_bio_ctrl(BIO* bio, int cmd, long arg1, void* arg2)
 		 *
 		 * See issue #3602
 		 */
-		return BIO_get_fd(tlsOut->bio, NULL);
+		status = BIO_ctrl(tlsOut->bio, cmd, arg1, arg2);
 	}
 
 	return status;

--- a/libfreerdp/core/gateway/tsg.c
+++ b/libfreerdp/core/gateway/tsg.c
@@ -1920,7 +1920,7 @@ static int transport_bio_tsg_gets(BIO* bio, char* str, int size)
 
 static long transport_bio_tsg_ctrl(BIO* bio, int cmd, long arg1, void* arg2)
 {
-	int status = 0;
+	int status = -1;
 	rdpTsg* tsg = (rdpTsg*) BIO_get_data(bio);
 	RpcVirtualConnection* connection = tsg->rpc->VirtualConnection;
 	RpcInChannel* inChannel = connection->DefaultInChannel;

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -737,9 +737,13 @@ static int tls_do_handshake(rdpTls* tls, BOOL clientMode)
 
 		do
 		{
-			status = poll(&pollfds, 1, 10 * 1000);
+			status = poll(&pollfds, 1, 10);
 		}
 		while ((status < 0) && (errno == EINTR));
+
+		if (status == 0) {
+			status = WAIT_TIMEOUT;
+		}
 
 #elif !defined(_WIN32)
 		FD_ZERO(&rset);

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -741,10 +741,6 @@ static int tls_do_handshake(rdpTls* tls, BOOL clientMode)
 		}
 		while ((status < 0) && (errno == EINTR));
 
-		if (status == 0) {
-			status = WAIT_TIMEOUT;
-		}
-
 #elif !defined(_WIN32)
 		FD_ZERO(&rset);
 		FD_SET(fd, &rset);


### PR DESCRIPTION
This solves the issues discussed in #3602:
- It fixes the timeout passed to `poll`
- It implements `BIO_get_fd` for RDGs in a correct way