### PR TITLE
Fix inconsistent cchReaderLen value between WinScard and pcsc-lite.

### DIFF
--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -1142,7 +1142,13 @@ static LONG smartcard_StatusW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPERAT
 		if (!call->fmszReaderNamesIsNULL)
 			ret.mszReaderNames = (BYTE*) mszReaderNames;
 
+		// WinScard returns the number of CHARACTERS whereas pcsc-lite returns the
+		// number of BYTES.
+#ifdef _WIN32
+		ret.cBytes = cchReaderLen * 2;
+#else
 		ret.cBytes = cchReaderLen;
+#endif
 
 		if (call->cbAtrLen)
 			ret.cbAtrLen = cbAtrLen;


### PR DESCRIPTION
On windows we found that we were only getting half of the reader name when using the StatusW smartcard operation, the reason was that the value of cchReaderLen means the number of characters in WinScard, while in pcsc-lite it means the number of bytes.
