### PR TITLE
Recognize only the cookie format anything else treat as token.

### DIFF
--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -677,18 +677,14 @@ static BOOL nego_read_request_token_or_cookie(rdpNego* nego, wStream* s)
 	if (Stream_GetRemainingLength(s) < 15)
 		return TRUE;
 
-	if (!memcmp(Stream_Pointer(s), "Cookie: msts=", 13))
+	if (memcmp(Stream_Pointer(s), "Cookie: mstshash=", 17) != 0)
 	{
 		isToken = TRUE;
-		Stream_Seek(s, 13);
 	}
 	else
 	{
 		/* not a cookie, minimum length for token is 19 */
 		if (Stream_GetRemainingLength(s) < 19)
-			return TRUE;
-
-		if (memcmp(Stream_Pointer(s), "Cookie: mstshash=", 17))
 			return TRUE;
 
 		Stream_Seek(s, 17);


### PR DESCRIPTION
If in the RDP file we will set loadbalanceinfo.
Instead of getting the cookie value we will get load balance info.

For example:
0000 03 00 00 2a 25 e0 00 00 00 00 00 74 73 76 3a 2f ...*%......tsv:/
0010 2f 56 4d 52 65 73 6f 75 72 63 65 2e 31 2e 41 48 /VMResource.1.AH
0020 0d 0a 01 00 08 00 0b 00 00 00                   ..........

The MSFT-SDLBTS document don't describe this behavior.

For this reason lets treat the token as anything ended with seqance
CR and CL. To be honest we already did that because in the core/connection.c
file where we are setting the routing_token to the LoadBalanceInfo.