### PR TITLE
Fix strto* usage by setting errno before-hand and interpreting EINVAL properly

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1373,8 +1373,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 				if (p)
 				{
+					unsigned long val;
 					errno = 0;
-					unsigned long val = strtoul(&p[1], NULL, 0);
+					val = strtoul(&p[1], NULL, 0);
 
 					if ((errno != 0) || (val == 0) || (val > UINT16_MAX))
 						return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -1411,8 +1412,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 				if (*(p2 + 1) == ':')
 				{
+					unsigned long val;
 					errno = 0;
-					unsigned long val = strtoul(&p2[2], NULL, 0);
+					val = strtoul(&p2[2], NULL, 0);
 
 					if ((errno != 0) || (val == 0) || (val > UINT16_MAX))
 						return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -1451,8 +1453,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "w")
 		{
+			long val;
 			errno = 0;
-			long val = strtol(arg->Value, NULL, 0);
+			val = strtol(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val <= 0) || (val > UINT16_MAX))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -1461,8 +1464,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "h")
 		{
+			long val;
 			errno = 0;
-			long val = strtol(arg->Value, NULL, 0);
+			val = strtol(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val <= 0) || (val > UINT16_MAX))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -1480,8 +1484,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 			{
 				*p = '\0';
 				{
+					long val;
 					errno = 0;
-					long val = strtol(str, NULL, 0);
+					val = strtol(str, NULL, 0);
 
 					if ((errno != 0) || (val <= 0) || (val > UINT16_MAX))
 					{
@@ -1492,8 +1497,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 					settings->DesktopWidth = val;
 				}
 				{
+					long val;
 					errno = 0;
-					long val = strtol(&p[1], NULL, 0);
+					val = strtol(&p[1], NULL, 0);
 
 					if ((errno != 0) || (val <= 0) || (val > UINT16_MAX))
 					{
@@ -1532,8 +1538,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 					*p = '\0';
 					{
+						long val;
 						errno = 0;
-						long val = strtol(str, NULL, 0);
+						val = strtol(str, NULL, 0);
 
 						if ((errno != 0) || (val < 0) || (val > 100))
 						{
@@ -1591,8 +1598,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 				for (i = 0; i < settings->NumMonitorIds; i++)
 				{
+					unsigned long val;
 					errno = 0;
-					unsigned long val = strtoul(p[i], NULL, 0);
+					val = strtoul(p[i], NULL, 0);
 
 					if ((errno != 0) || (val > UINT16_MAX))
 						return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -1675,8 +1683,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "bpp")
 		{
+			unsigned long val;
 			errno = 0;
-			unsigned long val = strtoul(arg->Value, NULL, 0);
+			val = strtoul(arg->Value, NULL, 0);
 
 			if (errno != 0)
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -1723,8 +1732,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "kbd")
 		{
+			unsigned long id;
 			errno = 0;
-			unsigned long id = strtoul(arg->Value, NULL, 0);
+			id = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (id > UINT32_MAX) || (id == 0))
 			{
@@ -1746,8 +1756,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "kbd-type")
 		{
+			unsigned long val;
 			errno = 0;
-			unsigned long val = strtoul(arg->Value, NULL, 0);
+			val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -1756,8 +1767,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "kbd-subtype")
 		{
+			unsigned long val;
 			errno = 0;
-			unsigned long val = strtoul(arg->Value, NULL, 0);
+			val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -1766,8 +1778,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "kbd-fn-key")
 		{
+			unsigned long val;
 			errno = 0;
-			unsigned long val = strtoul(arg->Value, NULL, 0);
+			val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -1802,8 +1815,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 				if (p)
 				{
+					unsigned long val;
 					errno = 0;
-					unsigned long val = strtoul(&p[1], NULL, 0);
+					val = strtoul(&p[1], NULL, 0);
 
 					if ((errno != 0) || (val == 0) || (val > UINT16_MAX))
 						return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -1860,8 +1874,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 				if (p)
 				{
+					unsigned long val;
 					errno = 0;
-					unsigned long val = strtoul(&p[1], NULL, 0);
+					val = strtoul(&p[1], NULL, 0);
 
 					if ((errno != 0) || (val == 0) || (val > UINT16_MAX))
 						return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2018,8 +2033,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "compression-level")
 		{
+			unsigned long val;
 			errno = 0;
-			unsigned long val = strtol(arg->Value, NULL, 0);
+			val = strtol(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2058,8 +2074,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "audio-mode")
 		{
+			long mode;
 			errno = 0;
-			long mode = strtol(arg->Value, NULL, 0);
+			mode = strtol(arg->Value, NULL, 0);
 
 			if (errno != 0)
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2217,8 +2234,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "frame-ack")
 		{
+			unsigned long val;
 			errno = 0;
-			unsigned long val = strtoul(arg->Value, NULL, 0);
+			val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2237,8 +2255,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "jpeg-quality")
 		{
+			unsigned long val;
 			errno = 0;
-			unsigned long val = strtoul(arg->Value, NULL, 0);
+			val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > 100))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2260,8 +2279,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "pcid")
 		{
+			unsigned long val;
 			errno = 0;
-			unsigned long val = strtoul(arg->Value, NULL, 0);
+			val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2432,8 +2452,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "parent-window")
 		{
+			UINT64 val;
 			errno = 0;
-			UINT64 val = _strtoui64(arg->Value, NULL, 0);
+			val = _strtoui64(arg->Value, NULL, 0);
 
 			if (errno != 0)
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2484,8 +2505,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "max-fast-path-size")
 		{
+			unsigned long val;
 			errno = 0;
-			unsigned long val = strtoul(arg->Value, NULL, 0);
+			val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2494,8 +2516,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "max-loop-time")
 		{
+			unsigned long val;
 			errno = 0;
-			unsigned long val = strtoul(arg->Value, NULL, 0);
+			val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2555,8 +2578,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "auto-reconnect-max-retries")
 		{
+			unsigned long val;
 			errno = 0;
-			unsigned long val = strtoul(arg->Value, NULL, 0);
+			val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2597,8 +2621,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "pwidth")
 		{
+			unsigned long val;
 			errno = 0;
-			unsigned long val = strtoul(arg->Value, NULL, 0);
+			val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2607,8 +2632,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "pheight")
 		{
+			unsigned long val;
 			errno = 0;
-			unsigned long val = strtoul(arg->Value, NULL, 0);
+			val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2617,8 +2643,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "orientation")
 		{
+			unsigned long val;
 			errno = 0;
-			unsigned long val = strtoul(arg->Value, NULL, 0);
+			val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > INT16_MAX))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2627,8 +2654,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "scale")
 		{
+			unsigned long scaleFactor;
 			errno = 0;
-			unsigned long scaleFactor = strtoul(arg->Value, NULL, 0);
+			scaleFactor = strtoul(arg->Value, NULL, 0);
 
 			if (errno != 0)
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2646,8 +2674,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "scale-desktop")
 		{
+			unsigned long desktopScaleFactor;
 			errno = 0;
-			unsigned long desktopScaleFactor = strtoul(arg->Value, NULL, 0);
+			desktopScaleFactor = strtoul(arg->Value, NULL, 0);
 
 			if (errno != 0)
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2664,8 +2693,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "scale-device")
 		{
+			unsigned long deviceScaleFactor;
 			errno = 0;
-			unsigned long deviceScaleFactor = strtoul(arg->Value, NULL, 0);
+			deviceScaleFactor = strtoul(arg->Value, NULL, 0);
 
 			if (errno != 0)
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
@@ -2781,8 +2811,9 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 	if (arg->Flags & COMMAND_LINE_ARGUMENT_PRESENT)
 	{
+		unsigned long val;
 		errno = 0;
-		unsigned long val = strtoul(arg->Value, NULL, 0);
+		val = strtoul(arg->Value, NULL, 0);
 
 		if ((errno != 0) || (val == 0) || (val > UINT16_MAX))
 			return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1937,7 +1937,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 			errno = 0;
 			type = strtol(arg->Value, &pEnd, 10);
 
-			if (errno != 0)
+			if ((errno != 0) && (errno != EINVAL))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 
 			if (type == 0)
@@ -2085,7 +2085,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 			errno = 0;
 			type = strtol(arg->Value, &pEnd, 10);
 
-			if (errno != 0)
+			if ((errno != 0) && (errno != EINVAL))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 
 			if (type == 0)

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1373,6 +1373,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 				if (p)
 				{
+					errno = 0;
 					unsigned long val = strtoul(&p[1], NULL, 0);
 
 					if ((errno != 0) || (val == 0) || (val > UINT16_MAX))
@@ -1410,6 +1411,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 				if (*(p2 + 1) == ':')
 				{
+					errno = 0;
 					unsigned long val = strtoul(&p2[2], NULL, 0);
 
 					if ((errno != 0) || (val == 0) || (val > UINT16_MAX))
@@ -1449,6 +1451,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "w")
 		{
+			errno = 0;
 			long val = strtol(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val <= 0) || (val > UINT16_MAX))
@@ -1458,6 +1461,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "h")
 		{
+			errno = 0;
 			long val = strtol(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val <= 0) || (val > UINT16_MAX))
@@ -1476,6 +1480,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 			{
 				*p = '\0';
 				{
+					errno = 0;
 					long val = strtol(str, NULL, 0);
 
 					if ((errno != 0) || (val <= 0) || (val > UINT16_MAX))
@@ -1487,6 +1492,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 					settings->DesktopWidth = val;
 				}
 				{
+					errno = 0;
 					long val = strtol(&p[1], NULL, 0);
 
 					if ((errno != 0) || (val <= 0) || (val > UINT16_MAX))
@@ -1526,6 +1532,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 					*p = '\0';
 					{
+						errno = 0;
 						long val = strtol(str, NULL, 0);
 
 						if ((errno != 0) || (val < 0) || (val > 100))
@@ -1584,6 +1591,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 				for (i = 0; i < settings->NumMonitorIds; i++)
 				{
+					errno = 0;
 					unsigned long val = strtoul(p[i], NULL, 0);
 
 					if ((errno != 0) || (val > UINT16_MAX))
@@ -1640,6 +1648,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 				{
 					unsigned long w, h;
 					*p = '\0';
+					errno = 0;
 					w = strtoul(str, NULL, 0);
 
 					if ((errno != 0) || (w == 0) || (w > UINT16_MAX))
@@ -1648,6 +1657,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 						return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 					}
 
+					errno = 0;
 					h = strtoul(&p[1], NULL, 0);
 
 					if ((errno != 0) || (h == 0) || (h > UINT16_MAX))
@@ -1665,6 +1675,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "bpp")
 		{
+			errno = 0;
 			unsigned long val = strtoul(arg->Value, NULL, 0);
 
 			if (errno != 0)
@@ -1712,6 +1723,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "kbd")
 		{
+			errno = 0;
 			unsigned long id = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (id > UINT32_MAX) || (id == 0))
@@ -1734,6 +1746,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "kbd-type")
 		{
+			errno = 0;
 			unsigned long val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
@@ -1743,6 +1756,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "kbd-subtype")
 		{
+			errno = 0;
 			unsigned long val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
@@ -1752,6 +1766,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "kbd-fn-key")
 		{
+			errno = 0;
 			unsigned long val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
@@ -1787,6 +1802,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 				if (p)
 				{
+					errno = 0;
 					unsigned long val = strtoul(&p[1], NULL, 0);
 
 					if ((errno != 0) || (val == 0) || (val > UINT16_MAX))
@@ -1844,6 +1860,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 				if (p)
 				{
+					errno = 0;
 					unsigned long val = strtoul(&p[1], NULL, 0);
 
 					if ((errno != 0) || (val == 0) || (val > UINT16_MAX))
@@ -1917,6 +1934,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		{
 			long type;
 			char* pEnd;
+			errno = 0;
 			type = strtol(arg->Value, &pEnd, 10);
 
 			if (errno != 0)
@@ -2000,6 +2018,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "compression-level")
 		{
+			errno = 0;
 			unsigned long val = strtol(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
@@ -2039,6 +2058,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "audio-mode")
 		{
+			errno = 0;
 			long mode = strtol(arg->Value, NULL, 0);
 
 			if (errno != 0)
@@ -2062,6 +2082,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		{
 			long type;
 			char* pEnd;
+			errno = 0;
 			type = strtol(arg->Value, &pEnd, 10);
 
 			if (errno != 0)
@@ -2196,6 +2217,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "frame-ack")
 		{
+			errno = 0;
 			unsigned long val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
@@ -2215,6 +2237,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "jpeg-quality")
 		{
+			errno = 0;
 			unsigned long val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > 100))
@@ -2237,6 +2260,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "pcid")
 		{
+			errno = 0;
 			unsigned long val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
@@ -2408,6 +2432,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "parent-window")
 		{
+			errno = 0;
 			UINT64 val = _strtoui64(arg->Value, NULL, 0);
 
 			if (errno != 0)
@@ -2459,6 +2484,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "max-fast-path-size")
 		{
+			errno = 0;
 			unsigned long val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
@@ -2468,6 +2494,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "max-loop-time")
 		{
+			errno = 0;
 			unsigned long val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
@@ -2528,6 +2555,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "auto-reconnect-max-retries")
 		{
+			errno = 0;
 			unsigned long val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
@@ -2569,6 +2597,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "pwidth")
 		{
+			errno = 0;
 			unsigned long val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
@@ -2578,6 +2607,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "pheight")
 		{
+			errno = 0;
 			unsigned long val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
@@ -2587,6 +2617,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "orientation")
 		{
+			errno = 0;
 			unsigned long val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > INT16_MAX))
@@ -2596,6 +2627,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "scale")
 		{
+			errno = 0;
 			unsigned long scaleFactor = strtoul(arg->Value, NULL, 0);
 
 			if (errno != 0)
@@ -2614,6 +2646,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "scale-desktop")
 		{
+			errno = 0;
 			unsigned long desktopScaleFactor = strtoul(arg->Value, NULL, 0);
 
 			if (errno != 0)
@@ -2631,6 +2664,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "scale-device")
 		{
+			errno = 0;
 			unsigned long deviceScaleFactor = strtoul(arg->Value, NULL, 0);
 
 			if (errno != 0)
@@ -2747,6 +2781,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 	if (arg->Flags & COMMAND_LINE_ARGUMENT_PRESENT)
 	{
+		errno = 0;
 		unsigned long val = strtoul(arg->Value, NULL, 0);
 
 		if ((errno != 0) || (val == 0) || (val > UINT16_MAX))

--- a/libfreerdp/core/gateway/http.c
+++ b/libfreerdp/core/gateway/http.c
@@ -454,6 +454,7 @@ static BOOL http_response_parse_header_status_line(HttpResponse* response, char*
 		if ((errno != 0) || (val < 0) || (val > INT16_MAX))
 			return FALSE;
 
+		errno = 0;
 		response->StatusCode = strtol(status_code, NULL, 0);
 	}
 	response->ReasonPhrase = reason_phrase;

--- a/winpr/libwinpr/clipboard/synthetic.c
+++ b/winpr/libwinpr/clipboard/synthetic.c
@@ -444,6 +444,7 @@ static void* clipboard_synthesize_text_html(wClipboard* clipboard, UINT32 format
 		if (errno != 0)
 			return NULL;
 
+		errno = 0;
 		end = strtol(&endStr[8], NULL, 10);
 
 		if (beg < 0 || end < 0 || (beg > SrcSize) || (end > SrcSize) || (beg >= end) || (errno != 0))

--- a/winpr/libwinpr/sysinfo/cpufeatures/cpu-features.c
+++ b/winpr/libwinpr/sysinfo/cpufeatures/cpu-features.c
@@ -659,6 +659,7 @@ get_elf_hwcap_from_proc_cpuinfo(const char* cpuinfo, int cpuinfo_len)
 
 	if (cpuArch)
 	{
+		errno = 0;
 		architecture = strtol(cpuArch, NULL, 10);
 		free(cpuArch);
 
@@ -817,6 +818,7 @@ android_cpuInit(void)
 			int    hasARMv7 = 0;
 			D("found cpuArch = '%s'\n", cpuArch);
 			/* read the initial decimal number, ignore the rest */
+			errno = 0;
 			archNumber = strtol(cpuArch, &end, 10);
 
 			/* Note that ARMv8 is upwards compatible with ARMv7. */

--- a/winpr/tools/makecert/makecert.c
+++ b/winpr/tools/makecert/makecert.c
@@ -1022,6 +1022,7 @@ int makecert_context_process(MAKECERT_CONTEXT* context, int argc, char** argv)
 
 	if (arg->Flags & COMMAND_LINE_VALUE_PRESENT)
 	{
+		errno = 0;
 		key_length = strtoul(arg->Value, NULL, 0);
 
 		if (errno != 0)
@@ -1064,6 +1065,7 @@ int makecert_context_process(MAKECERT_CONTEXT* context, int argc, char** argv)
 
 	if (arg->Flags & COMMAND_LINE_VALUE_PRESENT)
 	{
+		errno = 0;
 		serial = strtol(arg->Value, NULL, 0);
 
 		if (errno != 0)


### PR DESCRIPTION
For glibc, the previous usage of these things all worked. As pointed out in #4597, these are not POSIXly correct invocations. (See the first two comments for a description of the problem and further diagnosis)

Further examination after issue #4597 revealed that not *all* invocations were incorrect; some were assumed to be on numeric strings and thus didn't check errno, while others were properly setting errno beforehand. This PR adds more errno resets and fixes the two instances of not accepting EINVAL that existed in the cmdline parsing.

I wrote a small Coccinelle patch (available here [1]) to find some of these, while others I found by hand. My Coccinelle skills suck, though, so I ended up with some false positives that I had to correct.

[1] https://people.freebsd.org/~kevans/freerdp-strto.cocci