### PR TITLE
Determine posix timer use by function availability

### DIFF
--- a/winpr/libwinpr/CMakeLists.txt
+++ b/winpr/libwinpr/CMakeLists.txt
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(CheckFunctionExists)
+
 set(WINPR_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(WINPR_SRCS "")
 set(WINPR_LIBS "")
@@ -66,6 +68,16 @@ macro (winpr_definition_add)
     endforeach()
      set (WINPR_DEFINITIONS ${WINPR_DEFINITIONS} PARENT_SCOPE)
 endmacro()
+
+set(CMAKE_REQUIRED_LIBRARIES rt)
+check_function_exists(timer_create TIMER_CREATE)
+check_function_exists(timer_delete TIMER_DELETE)
+check_function_exists(timer_settime TIMER_SETTIME)
+check_function_exists(timer_gettime TIMER_GETTIME)
+if (TIMER_CREATE AND TIMER_DELETE AND TIMER_SETTIME AND TIMER_GETTIME)
+    add_definitions(-DWITH_POSIX_TIMER)
+	winpr_library_add(rt)
+endif()
 
 if (ANDROID)
     winpr_library_add(log)

--- a/winpr/libwinpr/synch/CMakeLists.txt
+++ b/winpr/libwinpr/synch/CMakeLists.txt
@@ -35,10 +35,6 @@ if(FREEBSD)
 	winpr_library_add(${EPOLLSHIM_LIBS})
 endif()
 
-if((NOT WIN32) AND (NOT APPLE) AND (NOT ANDROID) AND (NOT OPENBSD))
-	winpr_library_add(rt)
-endif()
-
 if(BUILD_TESTING)
 	add_subdirectory(test)
 endif()

--- a/winpr/libwinpr/synch/synch.h
+++ b/winpr/libwinpr/synch/synch.h
@@ -28,10 +28,6 @@
 
 #include <winpr/synch.h>
 
-#ifdef __linux__
-#define WITH_POSIX_TIMER	1
-#endif
-
 #include "../handle/handle.h"
 
 #ifndef _WIN32


### PR DESCRIPTION
To avoid having to whitelist every os starting to implement posix
timer API just detect if the functions are available.

Should fix #4605 #4592 and every other OS that has posix timers available.