### PR TITLE
Added proper return value checks for clipboard data.

### DIFF
--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -1422,6 +1422,14 @@ static UINT xf_cliprdr_server_format_data_response(CliprdrClientContext*
 		DstSize = 0;
 		pDstData = (BYTE*) ClipboardGetData(clipboard->system, dstFormatId, &DstSize);
 
+		if (!pDstData)
+		{
+			WLog_ERR(TAG, "failed to get clipboard data in format %s [source format %s]",
+			         ClipboardGetFormatName(clipboard, dstFormatId),
+			         ClipboardGetFormatName(clipboard, srcFormatId));
+			return ERROR_INTERNAL_ERROR;
+		}
+
 		if (nullTerminated)
 		{
 			while (DstSize > 0 && pDstData[DstSize - 1] == '\0')

--- a/winpr/libwinpr/clipboard/clipboard.c
+++ b/winpr/libwinpr/clipboard/clipboard.c
@@ -436,6 +436,7 @@ void* ClipboardGetData(wClipboard* clipboard, UINT32 formatId, UINT32* pSize)
 	if (!pSize)
 		return NULL;
 
+	*pSize = 0;
 	format = ClipboardFindFormat(clipboard, clipboard->formatId, NULL);
 
 	if (!format)


### PR DESCRIPTION
Proper checks to avoid a crash like in #4595.
Might give a hint why the clipboard is empty there.