### PR TITLE
Follow OpenBSD convention when installing manpages on FreeBSD

### DIFF
--- a/cmake/InstallFreeRDPMan.cmake
+++ b/cmake/InstallFreeRDPMan.cmake
@@ -1,6 +1,6 @@
 function(install_freerdp_man manpage section)
  if(WITH_MANPAGES)
-   if(OPENBSD)
+   if(OPENBSD OR FREEBSD)
        install(FILES ${manpage} DESTINATION man/man${section})
     else()
        install(FILES ${manpage} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/man/man${section})


### PR DESCRIPTION
Both OS install third party man pages into ${PREFIX}/man/man${SECTION}, rather
than the convention established in the base system of share/man/man${SECTION}.