### PR TITLE
Pull in the libepoll-shim includes for libwinpr's synch/test

### DIFF
--- a/winpr/libwinpr/synch/test/CMakeLists.txt
+++ b/winpr/libwinpr/synch/test/CMakeLists.txt
@@ -21,6 +21,10 @@ create_test_sourcelist(${MODULE_PREFIX}_SRCS
 	${${MODULE_PREFIX}_DRIVER}
 	${${MODULE_PREFIX}_TESTS})
 
+if(FREEBSD)
+	include_directories(${EPOLLSHIM_INCLUDE_DIR})
+endif()
+
 add_executable(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
 
 target_link_libraries(${MODULE_NAME} winpr)


### PR DESCRIPTION
This allows FreeBSD to successfully build with BUILD_TESTING enabled. Currently,
only 3/184 tests fail:

	 13 - TestLibraryLoadLibrary (Failed)
	 14 - TestLibraryGetProcAddress (Failed)
	 15 - TestLibraryGetModuleFileName (Failed)

These failures are probably due to a lack of GetModuleFileNameA implementation
on FreeBSD.
