### PR TITLE
Fix drive redirection in manpage

### DIFF
--- a/client/X11/xfreerdp.1.xml
+++ b/client/X11/xfreerdp.1.xml
@@ -531,7 +531,7 @@
                   </para>
                   <variablelist>
                     <varlistentry>
-                      <term>drive:<replaceable class="parameter">name</replaceable>:<replaceable class="parameter">path</replaceable></term>
+                      <term>disk:<replaceable class="parameter">name</replaceable>:<replaceable class="parameter">path</replaceable></term>
                       <listitem>
                         <para>
                           Redirect system <replaceable class="parameter">path</replaceable> as disk with <replaceable class="parameter">name</replaceable>.


### PR DESCRIPTION
Man page has been updated according to the wiki. Unfortunately, wiki
mentioned "drive" subplugin for 1.0.2, but stable-1.0 still uses "disk".
Let's fix the man page accordingly.

Closes: https://github.com/FreeRDP/FreeRDP/issues/4593
