### PR TITLE
Fix #4629: Remove premature freerdp_channels_post_connect() call

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -419,9 +419,6 @@ BOOL rdp_client_redirect(rdpRdp* rdp)
 
 	status = rdp_client_connect(rdp);
 
-	if (status)
-		status = (freerdp_channels_post_connect(context->channels, context->instance) == CHANNEL_RC_OK);
-
 	return status;
 }
 


### PR DESCRIPTION
In case of RDP server redirection `freerdp_connect()` invokes `freerdp_channels_post_connect()` anyway and does so after `instance->PostConnect`, which avoids the crash.