### PR TITLE
Fix #4628: CommandLineFindNextArgumentA must check the current argument

### DIFF
--- a/winpr/libwinpr/utils/cmdline.c
+++ b/winpr/libwinpr/utils/cmdline.c
@@ -427,6 +427,10 @@ COMMAND_LINE_ARGUMENT_W* CommandLineFindArgumentW(COMMAND_LINE_ARGUMENT_W* optio
 COMMAND_LINE_ARGUMENT_A* CommandLineFindNextArgumentA(COMMAND_LINE_ARGUMENT_A* argument)
 {
 	COMMAND_LINE_ARGUMENT_A* nextArgument;
+
+	if (!argument || !argument->Name)
+		return NULL;
+
 	nextArgument = &argument[1];
 
 	if (nextArgument->Name == NULL)


### PR DESCRIPTION
When determining if there is a next argument first check the current one
for abort criteria.
