### PR TITLE
Added cmake check for activated geometry channel.

### DIFF
--- a/channels/video/client/CMakeLists.txt
+++ b/channels/video/client/CMakeLists.txt
@@ -25,7 +25,9 @@ include_directories(..)
 
 add_channel_client_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} TRUE "DVCPluginEntry")
 
-
+if (NOT CHANNEL_GEOMETRY OR NOT CHANNEL_GEOMETRY_CLIENT)
+    message(FATAL_ERROR "Video channel requires geometry channel. Add -DCHANNEL_GEOMETRY=ON -DCHANNEL_GEOMETRY_CLIENT=ON")
+endif (NOT CHANNEL_GEOMETRY OR NOT CHANNEL_GEOMETRY_CLIENT)
 
 set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} winpr)
 


### PR DESCRIPTION
The video channel depends on geometry channel being available.
Do not allow compilation if that condition is not met.
Fixes #4562