### PR TITLE
Cleaned up const char** -> char** for argv, since we definitely do modify the argv!

### DIFF
--- a/channels/audin/client/alsa/audin_alsa.c
+++ b/channels/audin/client/alsa/audin_alsa.c
@@ -341,7 +341,7 @@ static UINT audin_alsa_parse_addin_args(AudinALSADevice* device,
 	AudinALSADevice* alsa = (AudinALSADevice*) device;
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON |
 	        COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
-	status = CommandLineParseArgumentsA(args->argc, (const char**) args->argv,
+	status = CommandLineParseArgumentsA(args->argc, args->argv,
 	                                    audin_alsa_args, flags, alsa, NULL, NULL);
 
 	if (status < 0)

--- a/channels/audin/client/audin_main.c
+++ b/channels/audin/client/audin_main.c
@@ -826,7 +826,7 @@ BOOL audin_process_addin_args(AUDIN_PLUGIN* audin, ADDIN_ARGV* args)
 		return TRUE;
 
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
-	status = CommandLineParseArgumentsA(args->argc, (const char**) args->argv,
+	status = CommandLineParseArgumentsA(args->argc, args->argv,
 	                                    audin_args, flags, audin, NULL, NULL);
 
 	if (status != 0)

--- a/channels/audin/client/mac/audin_mac.c
+++ b/channels/audin/client/mac/audin_mac.c
@@ -341,7 +341,7 @@ static UINT audin_mac_parse_addin_args(AudinMacDevice* device, ADDIN_ARGV* args)
 		return CHANNEL_RC_OK;
 
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
-	status = CommandLineParseArgumentsA(args->argc, (const char**)args->argv, audin_mac_args, flags,
+	status = CommandLineParseArgumentsA(args->argc, args->argv, audin_mac_args, flags,
 	                                    mac, NULL, NULL);
 
 	if (status < 0)

--- a/channels/audin/client/opensles/audin_opensl_es.c
+++ b/channels/audin/client/opensles/audin_opensl_es.c
@@ -367,7 +367,7 @@ static UINT audin_opensles_parse_addin_args(AudinOpenSLESDevice* device,
 	AudinOpenSLESDevice* opensles = (AudinOpenSLESDevice*) device;
 	DEBUG_DVC("device=%p, args=%p", (void*) device, (void*) args);
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
-	status = CommandLineParseArgumentsA(args->argc, (const char**) args->argv,
+	status = CommandLineParseArgumentsA(args->argc, args->argv,
 	                                    audin_opensles_args, flags, opensles, NULL, NULL);
 
 	if (status < 0)

--- a/channels/audin/client/oss/audin_oss.c
+++ b/channels/audin/client/oss/audin_oss.c
@@ -400,7 +400,7 @@ static UINT audin_oss_parse_addin_args(AudinOSSDevice* device, ADDIN_ARGV* args)
 	AudinOSSDevice* oss = (AudinOSSDevice*)device;
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON |
 	        COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
-	status = CommandLineParseArgumentsA(args->argc, (const char**)args->argv,
+	status = CommandLineParseArgumentsA(args->argc, args->argv,
 	                                    audin_oss_args, flags, oss, NULL, NULL);
 
 	if (status < 0)

--- a/channels/audin/client/pulse/audin_pulse.c
+++ b/channels/audin/client/pulse/audin_pulse.c
@@ -425,7 +425,7 @@ static UINT audin_pulse_parse_addin_args(AudinPulseDevice* device, ADDIN_ARGV* a
 	COMMAND_LINE_ARGUMENT_A* arg;
 	AudinPulseDevice* pulse = (AudinPulseDevice*) device;
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
-	status = CommandLineParseArgumentsA(args->argc, (const char**) args->argv, audin_pulse_args, flags,
+	status = CommandLineParseArgumentsA(args->argc, args->argv, audin_pulse_args, flags,
 	                                    pulse, NULL, NULL);
 
 	if (status < 0)

--- a/channels/audin/client/winmm/audin_winmm.c
+++ b/channels/audin/client/winmm/audin_winmm.c
@@ -400,7 +400,7 @@ static UINT audin_winmm_parse_addin_args(AudinWinmmDevice* device, ADDIN_ARGV* a
 	COMMAND_LINE_ARGUMENT_A* arg;
 	AudinWinmmDevice* winmm = (AudinWinmmDevice*) device;
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
-	status = CommandLineParseArgumentsA(args->argc, (const char**) args->argv, audin_winmm_args, flags,
+	status = CommandLineParseArgumentsA(args->argc, args->argv, audin_winmm_args, flags,
 	                                    winmm, NULL, NULL);
 	arg = audin_winmm_args;
 

--- a/channels/rdpsnd/client/alsa/rdpsnd_alsa.c
+++ b/channels/rdpsnd/client/alsa/rdpsnd_alsa.c
@@ -480,7 +480,7 @@ static UINT rdpsnd_alsa_parse_addin_args(rdpsndDevicePlugin* device, ADDIN_ARGV*
 	COMMAND_LINE_ARGUMENT_A* arg;
 	rdpsndAlsaPlugin* alsa = (rdpsndAlsaPlugin*) device;
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
-	status = CommandLineParseArgumentsA(args->argc, (const char**) args->argv, rdpsnd_alsa_args, flags,
+	status = CommandLineParseArgumentsA(args->argc, args->argv, rdpsnd_alsa_args, flags,
 	                                    alsa, NULL, NULL);
 
 	if (status < 0)

--- a/channels/rdpsnd/client/fake/rdpsnd_fake.c
+++ b/channels/rdpsnd/client/fake/rdpsnd_fake.c
@@ -48,7 +48,6 @@ static BOOL rdpsnd_fake_open(rdpsndDevicePlugin* device, const AUDIO_FORMAT* for
 
 static void rdpsnd_fake_close(rdpsndDevicePlugin* device)
 {
-
 }
 
 static BOOL rdpsnd_fake_set_volume(rdpsndDevicePlugin* device, UINT32 value)
@@ -71,7 +70,8 @@ static BOOL rdpsnd_fake_format_supported(rdpsndDevicePlugin* device, const AUDIO
 	return TRUE;
 }
 
-static BOOL rdpsnd_fake_set_format(rdpsndDevicePlugin* device, const AUDIO_FORMAT* format, int latency)
+static BOOL rdpsnd_fake_set_format(rdpsndDevicePlugin* device, const AUDIO_FORMAT* format,
+                                   int latency)
 {
 	return TRUE;
 }
@@ -83,7 +83,6 @@ static UINT rdpsnd_fake_play(rdpsndDevicePlugin* device, const BYTE* data, size_
 
 static void rdpsnd_fake_start(rdpsndDevicePlugin* device)
 {
-
 }
 
 static COMMAND_LINE_ARGUMENT_A rdpsnd_fake_args[] =
@@ -101,22 +100,21 @@ static UINT rdpsnd_fake_parse_addin_args(rdpsndFakePlugin* fake, ADDIN_ARGV* arg
 	int status;
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
-
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
+	status = CommandLineParseArgumentsA(args->argc, args->argv,
+	                                    rdpsnd_fake_args, flags, fake, NULL, NULL);
 
-	status = CommandLineParseArgumentsA(args->argc, (const char**) args->argv,
-			rdpsnd_fake_args, flags, fake, NULL, NULL);
 	if (status < 0)
 		return ERROR_INVALID_DATA;
 
 	arg = rdpsnd_fake_args;
+
 	do
 	{
 		if (!(arg->Flags & COMMAND_LINE_VALUE_PRESENT))
 			continue;
 
 		CommandLineSwitchStart(arg)
-
 		CommandLineSwitchEnd(arg)
 	}
 	while ((arg = CommandLineFindNextArgumentA(arg)) != NULL);
@@ -140,8 +138,8 @@ UINT freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS p
 	ADDIN_ARGV* args;
 	rdpsndFakePlugin* fake;
 	UINT ret;
-
 	fake = (rdpsndFakePlugin*) calloc(1, sizeof(rdpsndFakePlugin));
+
 	if (!fake)
 		return CHANNEL_RC_NO_MEMORY;
 
@@ -152,11 +150,12 @@ UINT freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS p
 	fake->device.Start = rdpsnd_fake_start;
 	fake->device.Close = rdpsnd_fake_close;
 	fake->device.Free = rdpsnd_fake_free;
-
 	args = pEntryPoints->args;
+
 	if (args->argc > 1)
 	{
 		ret = rdpsnd_fake_parse_addin_args(fake, args);
+
 		if (ret != CHANNEL_RC_OK)
 		{
 			WLog_ERR(TAG, "error parsing arguments");
@@ -165,10 +164,8 @@ UINT freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS p
 	}
 
 	ret = CHANNEL_RC_NO_MEMORY;
-
 	pEntryPoints->pRegisterRdpsndDevice(pEntryPoints->rdpsnd, &fake->device);
 	return CHANNEL_RC_OK;
-
 error:
 	rdpsnd_fake_free(&fake->device);
 	return ret;

--- a/channels/rdpsnd/client/opensles/rdpsnd_opensles.c
+++ b/channels/rdpsnd/client/opensles/rdpsnd_opensles.c
@@ -317,7 +317,7 @@ static int rdpsnd_opensles_parse_addin_args(rdpsndDevicePlugin* device,
 	DEBUG_SND("opensles=%p, args=%p", (void*) opensles, (void*) args);
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON |
 	        COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
-	status = CommandLineParseArgumentsA(args->argc, (const char**) args->argv,
+	status = CommandLineParseArgumentsA(args->argc, args->argv,
 	                                    rdpsnd_opensles_args, flags, opensles, NULL, NULL);
 
 	if (status < 0)

--- a/channels/rdpsnd/client/oss/rdpsnd_oss.c
+++ b/channels/rdpsnd/client/oss/rdpsnd_oss.c
@@ -402,7 +402,7 @@ static int rdpsnd_oss_parse_addin_args(rdpsndDevicePlugin* device, ADDIN_ARGV* a
 	COMMAND_LINE_ARGUMENT_A* arg;
 	rdpsndOssPlugin* oss = (rdpsndOssPlugin*)device;
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
-	status = CommandLineParseArgumentsA(args->argc, (const char**)args->argv, rdpsnd_oss_args, flags,
+	status = CommandLineParseArgumentsA(args->argc, args->argv, rdpsnd_oss_args, flags,
 	                                    oss, NULL, NULL);
 
 	if (status < 0)

--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -481,7 +481,7 @@ static UINT rdpsnd_pulse_parse_addin_args(rdpsndDevicePlugin* device, ADDIN_ARGV
 	COMMAND_LINE_ARGUMENT_A* arg;
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*) device;
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
-	status = CommandLineParseArgumentsA(args->argc, (const char**) args->argv,
+	status = CommandLineParseArgumentsA(args->argc, args->argv,
 	                                    rdpsnd_pulse_args, flags, pulse, NULL, NULL);
 
 	if (status < 0)

--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -766,7 +766,7 @@ static UINT rdpsnd_process_addin_args(rdpsndPlugin* rdpsnd, ADDIN_ARGV* args)
 	if (args->argc > 1)
 	{
 		flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON;
-		status = CommandLineParseArgumentsA(args->argc, (const char**) args->argv,
+		status = CommandLineParseArgumentsA(args->argc, args->argv,
 		                                    rdpsnd_args, flags, rdpsnd, NULL, NULL);
 
 		if (status < 0)

--- a/channels/urbdrc/client/libusb/libusb_udevman.c
+++ b/channels/urbdrc/client/libusb/libusb_udevman.c
@@ -513,7 +513,7 @@ static void urbdrc_udevman_parse_addin_args(UDEVMAN* udevman, ADDIN_ARGV* args)
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON;
-	status = CommandLineParseArgumentsA(args->argc, (const char**) args->argv,
+	status = CommandLineParseArgumentsA(args->argc, args->argv,
 	                                    urbdrc_udevman_args, flags, udevman, NULL, NULL);
 	arg = urbdrc_udevman_args;
 

--- a/channels/urbdrc/client/urbdrc_main.c
+++ b/channels/urbdrc/client/urbdrc_main.c
@@ -66,7 +66,7 @@ static int func_hardware_id_format(IUDEVICE* pdev, char(*HardwareIds)[DEVICE_HAR
 }
 
 static int func_compat_id_format(IUDEVICE* pdev,
-                                 char (*CompatibilityIds)[DEVICE_COMPATIBILITY_ID_SIZE])
+                                 char(*CompatibilityIds)[DEVICE_COMPATIBILITY_ID_SIZE])
 {
 	char str[DEVICE_COMPATIBILITY_ID_SIZE];
 	UINT8 bDeviceClass, bDeviceSubClass, bDeviceProtocol;
@@ -1522,7 +1522,7 @@ static UINT urbdrc_process_addin_args(URBDRC_PLUGIN* urbdrc, ADDIN_ARGV* args)
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON;
-	status = CommandLineParseArgumentsA(args->argc, (const char**) args->argv,
+	status = CommandLineParseArgumentsA(args->argc, args->argv,
 	                                    urbdrc_args, flags, urbdrc, NULL, NULL);
 
 	if (status < 0)

--- a/client/common/compatibility.c
+++ b/client/common/compatibility.c
@@ -232,7 +232,7 @@ static int freerdp_client_old_process_plugin(rdpSettings* settings, ADDIN_ARGV* 
 	return args_handled;
 }
 static int freerdp_client_old_command_line_pre_filter(void* context, int index, int argc,
-        LPCSTR* argv)
+        LPSTR* argv)
 {
 	rdpSettings* settings = (rdpSettings*) context;
 
@@ -251,7 +251,7 @@ static int freerdp_client_old_command_line_pre_filter(void* context, int index, 
 				return -1;
 			}
 
-			if (!freerdp_client_old_parse_hostname((char*) argv[index],
+			if (!freerdp_client_old_parse_hostname(argv[index],
 			                                       &settings->ServerHostname, &settings->ServerPort))
 				return -1;
 
@@ -310,7 +310,7 @@ static int freerdp_client_old_command_line_pre_filter(void* context, int index, 
 					return -1;
 				}
 
-				for (j = 0, p = (char*) argv[index]; (j < 4) && (p != NULL); j++)
+				for (j = 0, p = argv[index]; (j < 4) && (p != NULL); j++)
 				{
 					if (*p == '\'')
 					{
@@ -422,7 +422,7 @@ int freerdp_detect_old_command_line_syntax(int argc, char** argv, int* count)
 		return -1;
 
 	CommandLineClearArgumentsA(old_args);
-	status = CommandLineParseArgumentsA(argc, (const char**) argv, old_args, flags, settings,
+	status = CommandLineParseArgumentsA(argc, argv, old_args, flags, settings,
 	                                    freerdp_client_old_command_line_pre_filter, NULL);
 
 	if (status < 0)
@@ -481,7 +481,7 @@ int freerdp_client_parse_old_command_line_arguments(int argc, char** argv, rdpSe
 	flags |= COMMAND_LINE_SIGIL_DASH | COMMAND_LINE_SIGIL_DOUBLE_DASH;
 	flags |= COMMAND_LINE_SIGIL_ENABLE_DISABLE;
 	flags |= COMMAND_LINE_SIGIL_NOT_ESCAPED;
-	status = CommandLineParseArgumentsA(argc, (const char**) argv, old_args, flags, settings,
+	status = CommandLineParseArgumentsA(argc, argv, old_args, flags, settings,
 	                                    freerdp_client_old_command_line_pre_filter, freerdp_client_old_command_line_post_filter);
 
 	if (status == COMMAND_LINE_STATUS_PRINT_VERSION)

--- a/client/common/test/TestClientCmdLine.c
+++ b/client/common/test/TestClientCmdLine.c
@@ -3,28 +3,77 @@
 #include <freerdp/settings.h>
 #include <winpr/cmdline.h>
 #include <winpr/spec.h>
+#include <winpr/strlst.h>
+#include <winpr/collections.h>
 
-#define TESTCASE(argv, ret_val) TESTCASE_impl(#argv, argv, ARRAYSIZE(argv), ret_val)
-#define TESTCASE_SUCCESS(argv) TESTCASE_impl(#argv, argv, ARRAYSIZE(argv), 0)
-static INLINE BOOL TESTCASE_impl(const char* name, char** argv, size_t argc,
-                                 int expected_return)
+
+typedef BOOL (*validate_settings_pr)(rdpSettings* settings);
+
+#define printref() printf("%s:%d: in function %-40s:", __FILE__, __LINE__, __FUNCTION__)
+
+#define ERROR(format, ...)                                              \
+	do{                                                             \
+		fprintf(stderr, format, ##__VA_ARGS__);                 \
+		printref();                                             \
+		printf(format, ##__VA_ARGS__);                          \
+		fflush(stdout);                                         \
+	}while(0)
+
+#define FAILURE(format, ...)                                            \
+	do{                                                             \
+		printref();                                             \
+		printf(" FAILURE ");                                    \
+		printf(format, ##__VA_ARGS__);                          \
+		fflush(stdout);                                         \
+	}while(0)
+
+
+static void print_test_title(int argc, char** argv)
+{
+	int i;
+	printf("Running test:");
+
+	for (i = 0; i < argc; i ++)
+	{
+		printf(" %s", argv[i]);
+	}
+
+	printf("\n");
+}
+
+static INLINE BOOL testcase(const char* name, char** argv, size_t argc,
+                            int expected_return, validate_settings_pr validate_settings)
 {
 	int status;
+	BOOL valid_settings = TRUE;
 	rdpSettings* settings = freerdp_settings_new(0);
-	printf("Running test %s\n", name);
+	print_test_title(argc, argv);
 
 	if (!settings)
 	{
-		fprintf(stderr, "Test %s could not allocate settings!\n", name);
+		ERROR("Test %s could not allocate settings!\n", name);
 		return FALSE;
 	}
 
 	status = freerdp_client_settings_parse_command_line(settings, argc, argv, FALSE);
+
+	if (validate_settings)
+	{
+		valid_settings = validate_settings(settings);
+	}
+
 	freerdp_settings_free(settings);
 
-	if (status != expected_return)
+	if (status == expected_return)
 	{
-		fprintf(stderr, "Test %s failed!\n", name);
+		if (!valid_settings)
+		{
+			return FALSE;
+		}
+	}
+	else
+	{
+		FAILURE("Expected status %d,  got status %d\n", expected_return, status);
 		return FALSE;
 	}
 
@@ -36,121 +85,205 @@ static INLINE BOOL TESTCASE_impl(const char* name, char** argv, size_t argc,
 #else
 #define DRIVE_REDIRECT_PATH "/tmp"
 #endif
-int TestClientCmdLine(int argc, char* argv[])
+
+static BOOL check_settings_smartcard_no_redirection(rdpSettings* settings)
 {
-	int rc = -1;
-	char* cmd1[] = {"xfreerdp", "--help"};
-	char* cmd2[] = {"xfreerdp", "/help"};
-	char* cmd3[] = {"xfreerdp", "-help"};
-	char* cmd4[] = {"xfreerdp", "--version"};
-	char* cmd5[] = {"xfreerdp", "/version"};
-	char* cmd6[] = {"xfreerdp", "-version"};
-	char* cmd7[] = {"xfreerdp", "test.freerdp.com"};
-	char* cmd8[] = {"xfreerdp", "-v", "test.freerdp.com"};
-	char* cmd9[] = {"xfreerdp", "--v", "test.freerdp.com"};
-	char* cmd10[] = {"xfreerdp", "/v:test.freerdp.com"};
-	char* cmd11[] = {"xfreerdp", "--plugin", "rdpsnd", "--plugin", "rdpdr", "--data", "disk:media:"DRIVE_REDIRECT_PATH, "--", "test.freerdp.com" };
-	char* cmd12[] = {"xfreerdp", "/sound", "/drive:media,"DRIVE_REDIRECT_PATH, "/v:test.freerdp.com" };
-	char* cmd13[] = {"xfreerdp", "-u", "test", "-p", "test", "test.freerdp.com"};
-	char* cmd14[] = {"xfreerdp", "-u", "test", "-p", "test", "-v", "test.freerdp.com"};
-	char* cmd15[] = {"xfreerdp", "/u:test", "/p:test", "/v:test.freerdp.com"};
-	char* cmd16[] = {"xfreerdp", "-invalid"};
-	char* cmd17[] = {"xfreerdp", "--invalid"};
-	char* cmd18[] = {"xfreerdp", "/kbd-list"};
-	char* cmd19[] = {"xfreerdp", "/monitor-list"};
-	char* cmd20[] = {"xfreerdp", "/sound", "/drive:media:"DRIVE_REDIRECT_PATH, "/v:test.freerdp.com" };
-	char* cmd21[] = {"xfreerdp", "/sound", "/drive:media,/foo/bar/blabla", "/v:test.freerdp.com" };
+	BOOL result = TRUE;
 
-	if (!TESTCASE(cmd1, COMMAND_LINE_STATUS_PRINT_HELP))
-		goto fail;
+	if (settings->RedirectSmartCards)
+	{
+		FAILURE("Expected RedirectSmartCards = FALSE,  but RedirectSmartCards = TRUE!\n");
+		result = FALSE;
+	}
 
-	if (!TESTCASE(cmd2, COMMAND_LINE_STATUS_PRINT_HELP))
-		goto fail;
+	if (freerdp_device_collection_find_type(settings, RDPDR_DTYP_SMARTCARD))
+	{
+		FAILURE("Expected no SMARTCARD device, but found at least one!\n");
+		result = FALSE;
+	}
 
-	if (!TESTCASE(cmd3, COMMAND_LINE_STATUS_PRINT_HELP))
-		goto fail;
-
-	if (!TESTCASE(cmd4, COMMAND_LINE_STATUS_PRINT_VERSION))
-		goto fail;
-
-	if (!TESTCASE(cmd5, COMMAND_LINE_STATUS_PRINT_VERSION))
-		goto fail;
-
-	if (!TESTCASE(cmd6, COMMAND_LINE_STATUS_PRINT_VERSION))
-		goto fail;
-
-	if (!TESTCASE_SUCCESS(cmd7))
-		goto fail;
-
-	if (!TESTCASE_SUCCESS(cmd8))
-		goto fail;
-
-	if (!TESTCASE_SUCCESS(cmd9))
-		goto fail;
-
-	if (!TESTCASE_SUCCESS(cmd10))
-		goto fail;
-
-	if (!TESTCASE_SUCCESS(cmd11))
-		goto fail;
-
-	if (!TESTCASE_SUCCESS(cmd12))
-		goto fail;
-
-	// password gets overwritten therefore it need to be writeable
-	cmd13[4] = _strdup("test");
-	cmd14[4] = _strdup("test");
-	cmd15[2] = _strdup("/p:test");
-
-	if (!cmd13[4] || !cmd14[4] || !cmd15[2])
-		goto free_arg;
-
-	if (!TESTCASE_SUCCESS(cmd13))
-		goto free_arg;
-
-	if (memcmp(cmd13[4], "****", 4) != 0)
-		goto free_arg;
-
-	if (!TESTCASE_SUCCESS(cmd14))
-		goto free_arg;
-
-	if (memcmp(cmd14[4], "****", 4) != 0)
-		goto free_arg;
-
-	if (!TESTCASE_SUCCESS(cmd15))
-		goto free_arg;
-
-	if (memcmp(cmd15[2], "/p:****", 7) != 0)
-		goto free_arg;
-
-	if (!TESTCASE(cmd16, COMMAND_LINE_ERROR_NO_KEYWORD))
-		goto free_arg;
-
-	if (!TESTCASE(cmd17, COMMAND_LINE_ERROR_NO_KEYWORD))
-		goto free_arg;
-
-	if (!TESTCASE(cmd18, COMMAND_LINE_STATUS_PRINT))
-		goto free_arg;
-
-	if (!TESTCASE(cmd19, COMMAND_LINE_STATUS_PRINT))
-		goto free_arg;
-
-	if (!TESTCASE(cmd20, COMMAND_LINE_ERROR))
-		goto free_arg;
-
-	if (!TESTCASE(cmd21, COMMAND_LINE_ERROR))
-		goto free_arg;
-
-	rc = 0;
-free_arg:
-	free(cmd13[4]);
-	free(cmd14[4]);
-	free(cmd15[2]);
-#if 0
-	char* cmd20[] = {"-z --plugin cliprdr --plugin rdpsnd --data alsa latency:100 -- --plugin rdpdr --data disk:w7share:/home/w7share -- --plugin drdynvc --data tsmf:decoder:gstreamer -- -u test host.example.com"};
-	TESTCASE(cmd20, COMMAND_LINE_STATUS_PRINT);
-#endif
-fail:
-	return rc;
+	return result;
 }
 
+typedef struct
+{
+	int expected_status;
+	validate_settings_pr validate_settings;
+	const char* command_line[128];
+	struct
+	{
+		int index;
+		const char*   expected_value;
+	} modified_arguments[8];
+} test;
+
+static test tests[] =
+{
+	{
+		COMMAND_LINE_STATUS_PRINT_HELP, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "--help", 0},
+		{{0}}
+	},
+	{
+		COMMAND_LINE_STATUS_PRINT_HELP, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "/help", 0},
+		{{0}}
+	},
+	{
+		COMMAND_LINE_STATUS_PRINT_HELP, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "-help", 0},
+		{{0}}
+	},
+	{
+		COMMAND_LINE_STATUS_PRINT_VERSION, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "--version", 0},
+		{{0}}
+	},
+	{
+		COMMAND_LINE_STATUS_PRINT_VERSION, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "/version", 0},
+		{{0}}
+	},
+	{
+		COMMAND_LINE_STATUS_PRINT_VERSION, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "-version", 0},
+		{{0}}
+	},
+	{
+		0, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "test.freerdp.com", 0},
+		{{0}}
+	},
+	{
+		0, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "-v", "test.freerdp.com", 0},
+		{{0}}
+	},
+	{
+		0, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "--v", "test.freerdp.com", 0},
+		{{0}}
+	},
+	{
+		0, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "/v:test.freerdp.com", 0},
+		{{0}}
+	},
+	{
+		0, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "--plugin", "rdpsnd", "--plugin", "rdpdr", "--data", "disk:media:"DRIVE_REDIRECT_PATH, "--", "test.freerdp.com", 0},
+		{{0}}
+	},
+	{
+		0, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "/sound", "/drive:media,"DRIVE_REDIRECT_PATH, "/v:test.freerdp.com", 0},
+		{{0}}
+	},
+	{
+		0, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "-u", "test", "-p", "test", "test.freerdp.com", 0},
+		{{4, "****"}, {0}}
+	},
+	{
+		0, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "-u", "test", "-p", "test", "-v", "test.freerdp.com", 0},
+		{{4, "****"}, {0}}
+	},
+	{
+		0, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "/u:test", "/p:test", "/v:test.freerdp.com", 0},
+		{{2, "/p:****"}, {0}}
+	},
+	{
+		COMMAND_LINE_ERROR_NO_KEYWORD, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "-invalid", 0},
+		{{0}}
+	},
+	{
+		COMMAND_LINE_ERROR_NO_KEYWORD, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "--invalid", 0},
+		{{0}}
+	},
+	{
+		COMMAND_LINE_STATUS_PRINT, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "/kbd-list", 0},
+		{{0}}
+	},
+	{
+		COMMAND_LINE_STATUS_PRINT, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "/monitor-list", 0},
+		{{0}}
+	},
+	{
+		COMMAND_LINE_ERROR, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "/sound", "/drive:media:"DRIVE_REDIRECT_PATH, "/v:test.freerdp.com", 0},
+		{{0}}
+	},
+	{
+		COMMAND_LINE_ERROR, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "/sound", "/drive:media,/foo/bar/blabla", "/v:test.freerdp.com", 0},
+		{{0}}
+	},
+
+#if 0
+	{
+		COMMAND_LINE_STATUS_PRINT, check_settings_smartcard_no_redirection,
+		{"xfreerdp", "-z", "--plugin", "cliprdr", "--plugin", "rdpsnd", "--data", "alsa", "latency:100", "--", "--plugin", "rdpdr", "--data", "disk:w7share:/home/w7share", "--", "--plugin", "drdynvc", "--data", "tsmf:decoder:gstreamer", "--", "-u", "test", "host.example.com", 0},
+		{{0}}
+	},
+#endif
+};
+
+
+void check_modified_arguments(test* test, char** command_line, int* rc)
+{
+	int k;
+	const char*   expected_argument;
+
+	for (k = 0; (expected_argument = test->modified_arguments[k].expected_value); k ++)
+	{
+		int index = test->modified_arguments[k].index;
+		char* actual_argument = command_line[index];
+
+		if (0 != strcmp(actual_argument, expected_argument))
+		{
+			printref();
+			printf("Failure: overridden argument %d is %s but it should be %s\n",
+			       index, actual_argument, expected_argument);
+			fflush(stdout);
+			* rc = -1;
+		}
+	}
+}
+
+int TestClientCmdLine(int argc, char* argv[])
+{
+	int rc = 0;
+	int i;
+
+	for (i = 0; i < sizeof(tests) / sizeof(tests[0]); i ++)
+	{
+		int failure = 0;
+		char** command_line = string_list_copy(tests[i].command_line);
+
+		if (!testcase(__FUNCTION__,
+		              command_line, string_list_length((const char * const*)command_line),
+		              tests[i].expected_status, tests[i].validate_settings))
+		{
+			FAILURE("parsing arguments.\n");
+			failure = 1;
+		}
+
+		check_modified_arguments(& tests[i], command_line, & failure);
+
+		if (failure)
+		{
+			string_list_print(stdout, (const char * const*)command_line);
+			rc = -1;
+		}
+
+		string_list_free(command_line);
+	}
+
+	return rc;
+}

--- a/libfreerdp/core/gateway/http.c
+++ b/libfreerdp/core/gateway/http.c
@@ -660,7 +660,7 @@ HttpResponse* http_response_recv(rdpTls* tls)
 
 		if (position >= 4)
 		{
-			char* buffer = Stream_Buffer(response->data);
+			char* buffer = (char*)Stream_Buffer(response->data);
 			const char* line = string_strnstr(buffer, "\r\n\r\n", position);
 
 			if (line)
@@ -671,8 +671,8 @@ HttpResponse* http_response_recv(rdpTls* tls)
 	if (payloadOffset)
 	{
 		size_t count = 0;
-		char* buffer = Stream_Buffer(response->data);
-		char* line = Stream_Buffer(response->data);
+		char* buffer = (char*)Stream_Buffer(response->data);
+		char* line = (char*) Stream_Buffer(response->data);
 
 		while ((line = string_strnstr(line, "\r\n", payloadOffset - (line - buffer) - 2)))
 		{

--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -167,7 +167,7 @@ int shadow_server_parse_command_line(rdpShadowServer* server, int argc, char** a
 	CommandLineClearArgumentsA(shadow_args);
 	flags = COMMAND_LINE_SEPARATOR_COLON;
 	flags |= COMMAND_LINE_SIGIL_SLASH | COMMAND_LINE_SIGIL_PLUS_MINUS;
-	status = CommandLineParseArgumentsA(argc, (const char**) argv, shadow_args, flags, server, NULL,
+	status = CommandLineParseArgumentsA(argc, argv, shadow_args, flags, server, NULL,
 	                                    NULL);
 
 	if (status < 0)

--- a/winpr/include/winpr/cmdline.h
+++ b/winpr/include/winpr/cmdline.h
@@ -124,8 +124,8 @@ struct _COMMAND_LINE_ARGUMENT_W
 #define COMMAND_LINE_ARGUMENT	COMMAND_LINE_ARGUMENT_A
 #endif
 
-typedef int (*COMMAND_LINE_PRE_FILTER_FN_A)(void* context, int index, int argc, LPCSTR* argv);
-typedef int (*COMMAND_LINE_PRE_FILTER_FN_W)(void* context, int index, int argc, LPCWSTR* argv);
+typedef int (*COMMAND_LINE_PRE_FILTER_FN_A)(void* context, int index, int argc, LPSTR* argv);
+typedef int (*COMMAND_LINE_PRE_FILTER_FN_W)(void* context, int index, int argc, LPWSTR* argv);
 
 typedef int (*COMMAND_LINE_POST_FILTER_FN_A)(void* context, COMMAND_LINE_ARGUMENT_A* arg);
 typedef int (*COMMAND_LINE_POST_FILTER_FN_W)(void* context, COMMAND_LINE_ARGUMENT_W* arg);
@@ -137,10 +137,10 @@ extern "C" {
 WINPR_API int CommandLineClearArgumentsA(COMMAND_LINE_ARGUMENT_A* options);
 WINPR_API int CommandLineClearArgumentsW(COMMAND_LINE_ARGUMENT_W* options);
 
-WINPR_API int CommandLineParseArgumentsA(int argc, LPCSTR* argv, COMMAND_LINE_ARGUMENT_A* options,
+WINPR_API int CommandLineParseArgumentsA(int argc, LPSTR* argv, COMMAND_LINE_ARGUMENT_A* options,
         DWORD flags,
         void* context, COMMAND_LINE_PRE_FILTER_FN_A preFilter, COMMAND_LINE_POST_FILTER_FN_A postFilter);
-WINPR_API int CommandLineParseArgumentsW(int argc, LPCWSTR* argv, COMMAND_LINE_ARGUMENT_W* options,
+WINPR_API int CommandLineParseArgumentsW(int argc, LPWSTR* argv, COMMAND_LINE_ARGUMENT_W* options,
         DWORD flags,
         void* context, COMMAND_LINE_PRE_FILTER_FN_W preFilter, COMMAND_LINE_POST_FILTER_FN_W postFilter);
 

--- a/winpr/include/winpr/strlst.h
+++ b/winpr/include/winpr/strlst.h
@@ -1,0 +1,41 @@
+/**
+ * String list Manipulation (UTILS)
+ *
+ * Copyright 2018 Pascal Bourguignon <pjb@informatimago.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WINPR_UTILS_STRLST_H
+#define WINPR_UTILS_STRLST_H
+
+#include <stdio.h>
+
+#include <winpr/winpr.h>
+#include <winpr/wtypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+WINPR_API void string_list_free(char** string_list);
+WINPR_API int string_list_length(const char* const* string_list);
+WINPR_API char** string_list_copy(const char* const* string_list);
+WINPR_API void string_list_print(FILE* out, const char* const* string_list);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WINPR_UTILS_STRLST_H */

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -71,9 +71,9 @@ const SecPkgInfoA KERBEROS_SecPkgInfoA =
 	"Kerberos Security Package" /* Comment */
 };
 
-static const WCHAR KERBEROS_SecPkgInfoW_Name[] = { 'K', 'e', 'r', 'b', 'e', 'r', 'o', 's', '\0' };
+static WCHAR KERBEROS_SecPkgInfoW_Name[] = { 'K', 'e', 'r', 'b', 'e', 'r', 'o', 's', '\0' };
 
-static const WCHAR KERBEROS_SecPkgInfoW_Comment[] =
+static WCHAR KERBEROS_SecPkgInfoW_Comment[] =
 {
 	'K', 'e', 'r', 'b', 'e', 'r', 'o', 's', ' ',
 	'S', 'e', 'c', 'u', 'r', 'i', 't', 'y', ' ',

--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -1243,9 +1243,9 @@ const SecPkgInfoA NTLM_SecPkgInfoA =
 	"NTLM Security Package" /* Comment */
 };
 
-static const WCHAR NTLM_SecPkgInfoW_Name[] = { 'N', 'T', 'L', 'M', '\0' };
+static WCHAR NTLM_SecPkgInfoW_Name[] = { 'N', 'T', 'L', 'M', '\0' };
 
-static const WCHAR NTLM_SecPkgInfoW_Comment[] =
+static WCHAR NTLM_SecPkgInfoW_Comment[] =
 {
 	'N', 'T', 'L', 'M', ' ',
 	'S', 'e', 'c', 'u', 'r', 'i', 't', 'y', ' ',

--- a/winpr/libwinpr/sspi/Negotiate/negotiate.c
+++ b/winpr/libwinpr/sspi/Negotiate/negotiate.c
@@ -54,9 +54,9 @@ const SecPkgInfoA NEGOTIATE_SecPkgInfoA =
 	"Microsoft Package Negotiator" /* Comment */
 };
 
-static const WCHAR NEGOTIATE_SecPkgInfoW_Name[] = { 'N', 'e', 'g', 'o', 't', 'i', 'a', 't', 'e', '\0' };
+static WCHAR NEGOTIATE_SecPkgInfoW_Name[] = { 'N', 'e', 'g', 'o', 't', 'i', 'a', 't', 'e', '\0' };
 
-static const WCHAR NEGOTIATE_SecPkgInfoW_Comment[] =
+static WCHAR NEGOTIATE_SecPkgInfoW_Comment[] =
 {
 	'M', 'i', 'c', 'r', 'o', 's', 'o', 'f', 't', ' ',
 	'P', 'a', 'c', 'k', 'a', 'g', 'e', ' ',

--- a/winpr/libwinpr/utils/CMakeLists.txt
+++ b/winpr/libwinpr/utils/CMakeLists.txt
@@ -36,7 +36,7 @@ set(${MODULE_PREFIX}_COLLECTIONS_SRCS
 	collections/StreamPool.c
 	collections/MessageQueue.c
 	collections/MessagePipe.c)
-	
+
 set(${MODULE_PREFIX}_LODEPNG_SRCS
 	lodepng/lodepng.c
 	lodepng/lodepng.h)
@@ -68,7 +68,7 @@ if (LIBSYSTEMD_FOUND)
 	winpr_include_directory_add(${LIBSYSTEMD_INCLUDE_DIR})
 	winpr_library_add(${LIBSYSTEMD_LIBRARY})
 endif()
-	
+
 set(${MODULE_PREFIX}_WLOG_SRCS
 	wlog/wlog.c
 	wlog/wlog.h
@@ -107,6 +107,7 @@ set(${MODULE_PREFIX}_SRCS
 	image.c
 	print.c
 	stream.c
+	strlst.c
 	debug.c
 	winpr.c
 	cmdline.c
@@ -126,7 +127,7 @@ winpr_include_directory_add(
 	"lodepng"
 	"trio"
 	".")
-	
+
 if(OPENSSL_FOUND)
 	winpr_include_directory_add(${OPENSSL_INCLUDE_DIR})
 	winpr_library_add(${OPENSSL_LIBRARIES})
@@ -152,4 +153,3 @@ endif()
 if(BUILD_TESTING)
 	add_subdirectory(test)
 endif()
-

--- a/winpr/libwinpr/utils/cmdline.c
+++ b/winpr/libwinpr/utils/cmdline.c
@@ -45,7 +45,7 @@
  *
  */
 
-int CommandLineParseArgumentsA(int argc, LPCSTR* argv, COMMAND_LINE_ARGUMENT_A* options,
+int CommandLineParseArgumentsA(int argc, LPSTR* argv, COMMAND_LINE_ARGUMENT_A* options,
                                DWORD flags,
                                void* context, COMMAND_LINE_PRE_FILTER_FN_A preFilter, COMMAND_LINE_POST_FILTER_FN_A postFilter)
 {
@@ -56,11 +56,11 @@ int CommandLineParseArgumentsA(int argc, LPCSTR* argv, COMMAND_LINE_ARGUMENT_A* 
 	BOOL notescaped;
 	const char* sigil;
 	size_t sigil_length;
-	const char* keyword;
+	char* keyword;
 	SSIZE_T keyword_length;
 	SSIZE_T keyword_index;
 	char* separator;
-	const char* value;
+	char* value;
 	int toggle;
 	status = 0;
 	notescaped = FALSE;
@@ -353,7 +353,7 @@ int CommandLineParseArgumentsA(int argc, LPCSTR* argv, COMMAND_LINE_ARGUMENT_A* 
 	return status;
 }
 
-int CommandLineParseArgumentsW(int argc, LPCWSTR* argv, COMMAND_LINE_ARGUMENT_W* options,
+int CommandLineParseArgumentsW(int argc, LPWSTR* argv, COMMAND_LINE_ARGUMENT_W* options,
                                DWORD flags,
                                void* context, COMMAND_LINE_PRE_FILTER_FN_W preFilter, COMMAND_LINE_POST_FILTER_FN_W postFilter)
 {

--- a/winpr/libwinpr/utils/strlst.c
+++ b/winpr/libwinpr/utils/strlst.c
@@ -1,0 +1,83 @@
+/*
+ * String List Utils
+ *
+ * Copyright 2018 Pascal Bourguignon <pjb@informatimago.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <winpr/strlst.h>
+
+
+
+void string_list_free(char** string_list)
+{
+	int i;
+
+	for (i = 0; string_list[i]; i ++)
+	{
+		free(string_list[i]);
+	}
+
+	free(string_list);
+}
+
+int string_list_length(const char* const* string_list)
+{
+	int i;
+
+	for (i = 0; string_list[i]; i ++);
+
+	return i;
+}
+
+char**  string_list_copy(const char* const* string_list)
+{
+	int i;
+	int length = string_list_length(string_list);
+	char**   copy = calloc(length + 1, sizeof(char*));
+
+	if (!copy)
+	{
+		return 0;
+	}
+
+	for (i = 0; i < length; i ++)
+	{
+		copy[i] = strdup(string_list[i]);
+	}
+
+	copy[length] = 0;
+	return copy;
+}
+
+void string_list_print(FILE* out, const char* const* string_list)
+{
+	int j;
+
+	for (j = 0; string_list[j]; j ++)
+	{
+		fprintf(out, "[%2d]: %s\n", j, string_list[j]);
+	}
+
+	fflush(out);
+}
+

--- a/winpr/libwinpr/utils/test/TestCmdLine.c
+++ b/winpr/libwinpr/utils/test/TestCmdLine.c
@@ -64,9 +64,12 @@ int TestCmdLine(int argc, char* argv[])
 	long width = 0;
 	long height = 0;
 	COMMAND_LINE_ARGUMENT_A* arg;
+        int testArgc;
+        char** command_line;
+
 	flags = COMMAND_LINE_SIGIL_SLASH | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_SIGIL_PLUS_MINUS;
-	int testArgc = string_list_length(testArgv);
-	char** command_line = string_list_copy(testArgv);
+        testArgc = string_list_length(testArgv);
+	command_line = string_list_copy(testArgv);
 	status = CommandLineParseArgumentsA(testArgc, command_line, args, flags, NULL, NULL, NULL);
 
 	if (status != 0)

--- a/winpr/libwinpr/utils/test/TestCmdLine.c
+++ b/winpr/libwinpr/utils/test/TestCmdLine.c
@@ -1,8 +1,8 @@
-
 #include <errno.h>
 #include <winpr/crt.h>
 #include <winpr/tchar.h>
 #include <winpr/cmdline.h>
+#include <winpr/strlst.h>
 
 static const char* testArgv[] =
 {
@@ -15,7 +15,8 @@ static const char* testArgv[] =
 	"/multimon",
 	"+fonts",
 	"-wallpaper",
-	"/v:localhost:3389"
+	"/v:localhost:3389",
+	0
 };
 
 static COMMAND_LINE_ARGUMENT_A args[] =
@@ -55,7 +56,6 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
 };
 
-#define testArgc (sizeof(testArgv) / sizeof(testArgv[0]))
 
 int TestCmdLine(int argc, char* argv[])
 {
@@ -65,7 +65,9 @@ int TestCmdLine(int argc, char* argv[])
 	long height = 0;
 	COMMAND_LINE_ARGUMENT_A* arg;
 	flags = COMMAND_LINE_SIGIL_SLASH | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_SIGIL_PLUS_MINUS;
-	status = CommandLineParseArgumentsA(testArgc, testArgv, args, flags, NULL, NULL, NULL);
+	int testArgc = string_list_length(testArgv);
+	char** command_line = string_list_copy(testArgv);
+	status = CommandLineParseArgumentsA(testArgc, command_line, args, flags, NULL, NULL, NULL);
 
 	if (status != 0)
 	{

--- a/winpr/tools/makecert/makecert.c
+++ b/winpr/tools/makecert/makecert.c
@@ -433,7 +433,7 @@ static int makecert_context_parse_arguments(MAKECERT_CONTEXT* context, int argc,
 	 */
 	CommandLineClearArgumentsA(args);
 	flags = COMMAND_LINE_SEPARATOR_SPACE | COMMAND_LINE_SIGIL_DASH;
-	status = CommandLineParseArgumentsA(argc, (const char**) argv, args, flags, context,
+	status = CommandLineParseArgumentsA(argc, argv, args, flags, context,
 	                                    (COMMAND_LINE_PRE_FILTER_FN_A) command_line_pre_filter, NULL);
 
 	if (status & COMMAND_LINE_STATUS_PRINT_HELP)


### PR DESCRIPTION
We overwrite the password and pin arguments.
This implies changes in the argument parsing tests that now must pass a mutable argv
(copied from the statically declared test argvs).
Some other const inconsistency have been dealt with too.

Note there remains a const problem with structure literals declared in ntlm.c; I'll post an issue about it.
