### PR TITLE
X11: fixed Right-Ctrl ungrab feature (PR #3622)

### DIFF
--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -596,7 +596,7 @@ void xf_keyboard_handle_special_keys_release(xfContext* xfc, KeySym keysym)
 		{
 			xf_toggle_control(xfc);
 		}
-
+		xfc->mouse_active = FALSE;
 		XUngrabKeyboard(xfc->display, CurrentTime);
 	}
 


### PR DESCRIPTION
Since last week I have been having issues with a feature I introduced in this PR: https://github.com/FreeRDP/FreeRDP/pull/3622

Seems like XOrg update has changed the behavior somehow, and either more events got generated by mouse than before, or something similar. Adding this line fixed the issue for me.

Testing: on X11 client (not Wayland), connect to RDP server. Press Right Ctrl once. After it is released, your keyboard grab must be in your host system.
These are my most popular scenarios to use this feature, after releasing the grab:
- Alt+F4 to disconnect
- Alt+Tab or Super to switch to other window in the host
- Ctrl+Alt+Up/Down to switch workspaces (I'm using Gnome 3)

This must be working in both Fullscreen and windowed modes. Works for me.