### PR TITLE
Fix #4725: Need to copy data.

### DIFF
--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -127,8 +127,14 @@ static BOOL update_read_bitmap_data(rdpUpdate* update, wStream* s,
 	if (Stream_GetRemainingLength(s) < bitmapData->bitmapLength)
 		return FALSE;
 
-	Stream_GetPointer(s, bitmapData->bitmapDataStream);
-	Stream_Seek(s, bitmapData->bitmapLength);
+	if (bitmapData->bitmapLength > 0)
+	{
+		bitmapData->bitmapDataStream = malloc(bitmapData->bitmapLength);
+		if (!bitmapData->bitmapDataStream)
+			return FALSE;
+		memcpy(bitmapData->bitmapDataStream, Stream_Pointer(s), bitmapData->bitmapLength);
+		Stream_Seek(s, bitmapData->bitmapLength);
+	}
 	return TRUE;
 }
 


### PR DESCRIPTION
Fixed a but introduced in #4530 
We need to always copy bitmap data to the new structure.