### PR TITLE
Fix for #3666

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -209,12 +209,6 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 		                   fullscreen ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE,
 		                   xfc->_NET_WM_STATE_FULLSCREEN, 0, 0);
 
-		if (!fullscreen)
-		{
-			/* leave full screen: move the window after removing NET_WM_STATE_FULLSCREEN */
-			XMoveWindow(xfc->display, window->handle, startX, startY);
-		}
-
 		/* Set monitor bounds */
 		if (settings->MonitorCount > 1)
 		{

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -209,6 +209,16 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 		                   fullscreen ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE,
 		                   xfc->_NET_WM_STATE_FULLSCREEN, 0, 0);
 
+		if (!fullscreen)
+		{
+			/* Fix for Cinnamon WM see ISSUE 3666 */
+			if (startX == 0)
+				startX = 1;
+
+			/* leave full screen: move the window after removing NET_WM_STATE_FULLSCREEN */
+			XMoveWindow(xfc->display, window->handle, startX, startY);
+		}
+
 		/* Set monitor bounds */
 		if (settings->MonitorCount > 1)
 		{


### PR DESCRIPTION
According to https://specifications.freedesktop.org/wm-spec/wm-spec-latest.html#idm140200472531472 

> _NET_WM_STATE_FULLSCREEN indicates that the window should fill the entire screen and have no window decorations. **Additionally the Window Manager is responsible for restoring the original geometry after a switch from fullscreen back to normal window.**

I think that the cinnamon desktop handles this and that the additional move to position 0, 0 causes issues here. Not moving the window after the event is send fixes this issue in cinnamon. I additionally tested the change in XFCE and Mate and it seems to work without any problems. 

