### PR TITLE
macosx: Bring newly launched freerdp window to front

### DIFF
--- a/client/Mac/cli/AppDelegate.m
+++ b/client/Mac/cli/AppDelegate.m
@@ -290,6 +290,8 @@ void mac_set_view_size(rdpContext* context, MRDPView* view)
 	[[view window] setContentMaxSize:innerRect.size];
 	// set window to given area
 	[[view window] setFrame:outerRect display:YES];
+	// set window to front
+	[NSApp activateIgnoringOtherApps:YES];
 
 	if (context->settings->Fullscreen)
 		[[view window] toggleFullScreen:nil];


### PR DESCRIPTION
To bring newly launched freerdp window on top of all the windows.


