### PR TITLE
Drive find first file fix

### DIFF
--- a/winpr/libwinpr/file/generic.c
+++ b/winpr/libwinpr/file/generic.c
@@ -864,7 +864,7 @@ HANDLE FindFirstFileA(LPCSTR lpFileName, LPWIN32_FIND_DATAA lpFindFileData)
 	if (isDir)
 	{
 		pFileSearch->lpPath = _strdup(lpFileName);
-		pFileSearch->lpPattern = _strdup("*");
+		pFileSearch->lpPattern = _strdup(".");
 	}
 	else
 	{


### PR DESCRIPTION
Introduced a heisenbug with #4741 
If `FindFirstFileA` was called with an existing directory (and no pattern) set pattern to `.` to retrieve the correct entry instead of `*`