### PR TITLE
Bunch of fixes based on covscan results

### DIFF
--- a/channels/client/addin.c
+++ b/channels/client/addin.c
@@ -220,6 +220,7 @@ FREERDP_ADDIN** freerdp_channels_list_dynamic_addins(LPSTR pszName, LPSTR pszSub
 
 	if (!ppAddins)
 	{
+		FindClose(hFind);
 		WLog_ERR(TAG, "calloc failed!");
 		return NULL;
 	}
@@ -298,6 +299,7 @@ FREERDP_ADDIN** freerdp_channels_list_dynamic_addins(LPSTR pszName, LPSTR pszSub
 	ppAddins[nAddins] = NULL;
 	return ppAddins;
 error_out:
+	FindClose(hFind);
 	freerdp_channels_addin_list_free(ppAddins);
 	return NULL;
 }

--- a/channels/drive/client/drive_main.c
+++ b/channels/drive/client/drive_main.c
@@ -527,6 +527,7 @@ static UINT drive_process_irp_query_volume_information(DRIVE_DEVICE* drive,
 
 			if (!Stream_EnsureRemainingCapacity(output, 12 + length))
 			{
+				free(outStr);
 				WLog_ERR(TAG, "Stream_EnsureRemainingCapacity failed!");
 				return CHANNEL_RC_NO_MEMORY;
 			}

--- a/channels/rail/client/rail_orders.c
+++ b/channels/rail/client/rail_orders.c
@@ -910,15 +910,16 @@ UINT rail_send_client_exec_order(railPlugin* rail, RAIL_EXEC_ORDER* exec)
 	if ((error = rail_write_client_exec_order(s, exec)))
 	{
 		WLog_ERR(TAG, "rail_write_client_exec_order failed with error %"PRIu32"!", error);
-		return error;
+		goto out;
 	}
 
 	if ((error = rail_send_pdu(rail, s, RDP_RAIL_ORDER_EXEC)))
 	{
 		WLog_ERR(TAG, "rail_send_pdu failed with error %"PRIu32"!", error);
-		return error;
+		goto out;
 	}
 
+out:
 	Stream_Free(s, TRUE);
 	return error;
 }
@@ -972,15 +973,16 @@ static UINT rail_send_client_sysparam_order(railPlugin* rail, RAIL_SYSPARAM_ORDE
 	if ((error = rail_write_client_sysparam_order(s, sysparam)))
 	{
 		WLog_ERR(TAG, "rail_write_client_sysparam_order failed with error %"PRIu32"!", error);
-		return error;
+		goto out;
 	}
 
 	if ((error = rail_send_pdu(rail, s, RDP_RAIL_ORDER_SYSPARAM)))
 	{
 		WLog_ERR(TAG, "rail_send_pdu failed with error %"PRIu32"!", error);
-		return error;
+		goto out;
 	}
 
+out:
 	Stream_Free(s, TRUE);
 	return error;
 }

--- a/channels/rdpdr/server/rdpdr_main.c
+++ b/channels/rdpdr/server/rdpdr_main.c
@@ -1263,7 +1263,7 @@ static UINT rdpdr_server_start(RdpdrServerContext* context)
 	}
 
 	if (!(context->priv->Thread = CreateThread(NULL, 0,
-								  rdpdr_server_thread, (void*) context, 0, NULL)))
+	                              rdpdr_server_thread, (void*) context, 0, NULL)))
 	{
 		WLog_ERR(TAG, "CreateThread failed!");
 		CloseHandle(context->priv->StopEvent);

--- a/channels/rdpdr/server/rdpdr_main.c
+++ b/channels/rdpdr/server/rdpdr_main.c
@@ -563,7 +563,7 @@ static UINT rdpdr_server_send_core_capability_request(RdpdrServerContext*
 	{
 		WLog_ERR(TAG,
 		         "rdpdr_server_write_general_capability_set failed with error %"PRIu32"!", error);
-		return error;
+		goto out;
 	}
 
 	if (context->supportsDrives)
@@ -572,7 +572,7 @@ static UINT rdpdr_server_send_core_capability_request(RdpdrServerContext*
 		{
 			WLog_ERR(TAG, "rdpdr_server_write_drive_capability_set failed with error %"PRIu32"!",
 			         error);
-			return error;
+			goto out;
 		}
 	}
 
@@ -582,7 +582,7 @@ static UINT rdpdr_server_send_core_capability_request(RdpdrServerContext*
 		{
 			WLog_ERR(TAG, "rdpdr_server_write_port_capability_set failed with error %"PRIu32"!",
 			         error);
-			return error;
+			goto out;
 		}
 	}
 
@@ -592,7 +592,7 @@ static UINT rdpdr_server_send_core_capability_request(RdpdrServerContext*
 		{
 			WLog_ERR(TAG,
 			         "rdpdr_server_write_printer_capability_set failed with error %"PRIu32"!", error);
-			return error;
+			goto out;
 		}
 	}
 
@@ -602,7 +602,7 @@ static UINT rdpdr_server_send_core_capability_request(RdpdrServerContext*
 		{
 			WLog_ERR(TAG,
 			         "rdpdr_server_write_printer_capability_set failed with error %"PRIu32"!", error);
-			return error;
+			goto out;
 		}
 	}
 
@@ -612,6 +612,9 @@ static UINT rdpdr_server_send_core_capability_request(RdpdrServerContext*
 	                                (PCHAR) Stream_Buffer(s), Stream_Length(s), &written);
 	Stream_Free(s, TRUE);
 	return status ? CHANNEL_RC_OK : ERROR_INTERNAL_ERROR;
+out:
+	Stream_Free(s, TRUE);
+	return error;
 }
 
 /**

--- a/channels/rdpdr/server/rdpdr_main.c
+++ b/channels/rdpdr/server/rdpdr_main.c
@@ -1740,7 +1740,7 @@ static UINT rdpdr_server_drive_create_directory(RdpdrServerContext* context,
 	irp->Callback = rdpdr_server_drive_create_directory_callback1;
 	irp->CallbackData = callbackData;
 	irp->DeviceId = deviceId;
-	strncpy(irp->PathName, path, sizeof(irp->PathName));
+	strncpy(irp->PathName, path, sizeof(irp->PathName) - 1);
 	rdpdr_server_convert_slashes(irp->PathName, sizeof(irp->PathName));
 
 	if (!rdpdr_server_enqueue_irp(context, irp))
@@ -1851,7 +1851,7 @@ static UINT rdpdr_server_drive_delete_directory(RdpdrServerContext* context,
 	irp->Callback = rdpdr_server_drive_delete_directory_callback1;
 	irp->CallbackData = callbackData;
 	irp->DeviceId = deviceId;
-	strncpy(irp->PathName, path, sizeof(irp->PathName));
+	strncpy(irp->PathName, path, sizeof(irp->PathName) - 1);
 	rdpdr_server_convert_slashes(irp->PathName, sizeof(irp->PathName));
 
 	if (!rdpdr_server_enqueue_irp(context, irp))
@@ -2019,7 +2019,7 @@ static UINT rdpdr_server_drive_query_directory(RdpdrServerContext* context,
 	irp->Callback = rdpdr_server_drive_query_directory_callback1;
 	irp->CallbackData = callbackData;
 	irp->DeviceId = deviceId;
-	strncpy(irp->PathName, path, sizeof(irp->PathName));
+	strncpy(irp->PathName, path, sizeof(irp->PathName) - 1);
 	rdpdr_server_convert_slashes(irp->PathName, sizeof(irp->PathName));
 
 	if (!rdpdr_server_enqueue_irp(context, irp))
@@ -2093,7 +2093,7 @@ static UINT rdpdr_server_drive_open_file(RdpdrServerContext* context,
 	irp->Callback = rdpdr_server_drive_open_file_callback;
 	irp->CallbackData = callbackData;
 	irp->DeviceId = deviceId;
-	strncpy(irp->PathName, path, sizeof(irp->PathName));
+	strncpy(irp->PathName, path, sizeof(irp->PathName) - 1);
 	rdpdr_server_convert_slashes(irp->PathName, sizeof(irp->PathName));
 
 	if (!rdpdr_server_enqueue_irp(context, irp))
@@ -2420,7 +2420,7 @@ static UINT rdpdr_server_drive_delete_file(RdpdrServerContext* context,
 	irp->Callback = rdpdr_server_drive_delete_file_callback1;
 	irp->CallbackData = callbackData;
 	irp->DeviceId = deviceId;
-	strncpy(irp->PathName, path, sizeof(irp->PathName));
+	strncpy(irp->PathName, path, sizeof(irp->PathName) - 1);
 	rdpdr_server_convert_slashes(irp->PathName, sizeof(irp->PathName));
 
 	if (!rdpdr_server_enqueue_irp(context, irp))
@@ -2570,8 +2570,8 @@ static UINT rdpdr_server_drive_rename_file(RdpdrServerContext* context,
 	irp->Callback = rdpdr_server_drive_rename_file_callback1;
 	irp->CallbackData = callbackData;
 	irp->DeviceId = deviceId;
-	strncpy(irp->PathName, oldPath, sizeof(irp->PathName));
-	strncpy(irp->ExtraBuffer, newPath, sizeof(irp->ExtraBuffer));
+	strncpy(irp->PathName, oldPath, sizeof(irp->PathName) - 1);
+	strncpy(irp->ExtraBuffer, newPath, sizeof(irp->ExtraBuffer) - 1);
 	rdpdr_server_convert_slashes(irp->PathName, sizeof(irp->PathName));
 	rdpdr_server_convert_slashes(irp->ExtraBuffer, sizeof(irp->ExtraBuffer));
 

--- a/channels/rdpgfx/client/rdpgfx_codec.c
+++ b/channels/rdpgfx/client/rdpgfx_codec.c
@@ -149,6 +149,7 @@ static UINT rdpgfx_decode_AVC420(RDPGFX_PLUGIN* gfx, RDPGFX_SURFACE_COMMAND* cmd
 
 	if ((error = rdpgfx_read_h264_metablock(gfx, s, &(h264.meta))))
 	{
+		Stream_Free(s, FALSE);
 		WLog_ERR(TAG, "rdpgfx_read_h264_metablock failed with error %"PRIu32"!", error);
 		return error;
 	}

--- a/channels/rdpgfx/client/rdpgfx_codec.c
+++ b/channels/rdpgfx/client/rdpgfx_codec.c
@@ -139,8 +139,8 @@ static UINT rdpgfx_decode_AVC420(RDPGFX_PLUGIN* gfx, RDPGFX_SURFACE_COMMAND* cmd
 	wStream* s;
 	RDPGFX_AVC420_BITMAP_STREAM h264;
 	RdpgfxClientContext* context = (RdpgfxClientContext*) gfx->iface.pInterface;
-
 	s = Stream_New(cmd->data, cmd->length);
+
 	if (!s)
 	{
 		WLog_ERR(TAG, "Stream_New failed!");
@@ -184,8 +184,8 @@ static UINT rdpgfx_decode_AVC444(RDPGFX_PLUGIN* gfx, RDPGFX_SURFACE_COMMAND* cmd
 	wStream* s;
 	RDPGFX_AVC444_BITMAP_STREAM h264 = { 0 };
 	RdpgfxClientContext* context = (RdpgfxClientContext*) gfx->iface.pInterface;
-
 	s = Stream_New(cmd->data, cmd->length);
+
 	if (!s)
 	{
 		WLog_ERR(TAG, "Stream_New failed!");
@@ -197,6 +197,7 @@ static UINT rdpgfx_decode_AVC444(RDPGFX_PLUGIN* gfx, RDPGFX_SURFACE_COMMAND* cmd
 		error = ERROR_INVALID_DATA;
 		goto fail;
 	}
+
 	Stream_Read_UINT32(s, tmp);
 	h264.cbAvc420EncodedBitstream1 = tmp & 0x3FFFFFFFUL;
 	h264.LC = (tmp >> 30UL) & 0x03UL;

--- a/channels/remdesk/client/remdesk_main.c
+++ b/channels/remdesk/client/remdesk_main.c
@@ -109,6 +109,7 @@ static UINT remdesk_generate_expert_blob(remdeskPlugin* remdesk)
 	}
 
 	remdesk->ExpertBlob = freerdp_assistance_construct_expert_blob(name, pass);
+	free(pass);
 
 	if (!remdesk->ExpertBlob)
 	{

--- a/channels/serial/client/serial_main.c
+++ b/channels/serial/client/serial_main.c
@@ -575,6 +575,8 @@ static void create_irp_thread(SERIAL_DEVICE* serial, IRP* irp)
 			           serial->IrpThreadToBeTerminatedCount);
 			Sleep(1); /* 1 ms */
 		}
+
+		free(ids);
 	}
 
 	LeaveCriticalSection(&serial->TerminatingIrpThreadsLock);
@@ -694,6 +696,7 @@ static void terminate_pending_irp_threads(SERIAL_DEVICE* serial)
 	}
 
 	ListDictionary_Clear(serial->IrpThreads);
+	free(ids);
 }
 
 

--- a/channels/server/channels.c
+++ b/channels/server/channels.c
@@ -53,26 +53,36 @@
 
 void freerdp_channels_dummy()
 {
-	audin_server_context_new(NULL);
-	audin_server_context_free(NULL);
-	rdpsnd_server_context_new(NULL);
-	rdpsnd_server_context_free(NULL);
-	cliprdr_server_context_new(NULL);
-	cliprdr_server_context_free(NULL);
-	echo_server_context_new(NULL);
-	echo_server_context_free(NULL);
-	rdpdr_server_context_new(NULL);
-	rdpdr_server_context_free(NULL);
-	drdynvc_server_context_new(NULL);
-	drdynvc_server_context_free(NULL);
-	rdpei_server_context_new(NULL);
-	rdpei_server_context_free(NULL);
-	remdesk_server_context_new(NULL);
-	remdesk_server_context_free(NULL);
-	encomsp_server_context_new(NULL);
-	encomsp_server_context_free(NULL);
-	rdpgfx_server_context_new(NULL);
-	rdpgfx_server_context_free(NULL);
+	audin_server_context* audin;
+	RdpsndServerContext* rdpsnd;
+	CliprdrServerContext* cliprdr;
+	echo_server_context* echo;
+	RdpdrServerContext* rdpdr;
+	DrdynvcServerContext* drdynvc;
+	RdpeiServerContext* rdpei;
+	RemdeskServerContext* remdesk;
+	EncomspServerContext* encomsp;
+	RdpgfxServerContext* rdpgfx;
+	audin = audin_server_context_new(NULL);
+	audin_server_context_free(audin);
+	rdpsnd = rdpsnd_server_context_new(NULL);
+	rdpsnd_server_context_free(rdpsnd);
+	cliprdr = cliprdr_server_context_new(NULL);
+	cliprdr_server_context_free(cliprdr);
+	echo = echo_server_context_new(NULL);
+	echo_server_context_free(echo);
+	rdpdr = rdpdr_server_context_new(NULL);
+	rdpdr_server_context_free(rdpdr);
+	drdynvc = drdynvc_server_context_new(NULL);
+	drdynvc_server_context_free(drdynvc);
+	rdpei = rdpei_server_context_new(NULL);
+	rdpei_server_context_free(rdpei);
+	remdesk = remdesk_server_context_new(NULL);
+	remdesk_server_context_free(remdesk);
+	encomsp = encomsp_server_context_new(NULL);
+	encomsp_server_context_free(encomsp);
+	rdpgfx = rdpgfx_server_context_new(NULL);
+	rdpgfx_server_context_free(rdpgfx);
 }
 
 /**

--- a/channels/server/channels.c
+++ b/channels/server/channels.c
@@ -51,35 +51,26 @@
 #include <freerdp/server/encomsp.h>
 #include <freerdp/server/rdpgfx.h>
 
-void freerdp_channels_dummy() 
+void freerdp_channels_dummy()
 {
 	audin_server_context_new(NULL);
 	audin_server_context_free(NULL);
-
 	rdpsnd_server_context_new(NULL);
 	rdpsnd_server_context_free(NULL);
-
 	cliprdr_server_context_new(NULL);
 	cliprdr_server_context_free(NULL);
-
 	echo_server_context_new(NULL);
 	echo_server_context_free(NULL);
-
 	rdpdr_server_context_new(NULL);
 	rdpdr_server_context_free(NULL);
-
 	drdynvc_server_context_new(NULL);
 	drdynvc_server_context_free(NULL);
-
 	rdpei_server_context_new(NULL);
 	rdpei_server_context_free(NULL);
-
 	remdesk_server_context_new(NULL);
 	remdesk_server_context_free(NULL);
-
 	encomsp_server_context_new(NULL);
 	encomsp_server_context_free(NULL);
-
 	rdpgfx_server_context_new(NULL);
 	rdpgfx_server_context_free(NULL);
 }

--- a/channels/smartcard/client/smartcard_main.c
+++ b/channels/smartcard/client/smartcard_main.c
@@ -135,7 +135,7 @@ SMARTCARD_CONTEXT* smartcard_context_new(SMARTCARD_DEVICE* smartcard,
 	}
 
 	pContext->thread = CreateThread(NULL, 0,
-									smartcard_context_thread,
+	                                smartcard_context_thread,
 	                                pContext, 0, NULL);
 
 	if (!pContext->thread)
@@ -747,7 +747,7 @@ UINT DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
 	}
 
 	smartcard->thread = CreateThread(NULL, 0,
-									 smartcard_thread_func,
+	                                 smartcard_thread_func,
 	                                 smartcard, CREATE_SUSPENDED, NULL);
 
 	if (!smartcard->thread)

--- a/channels/smartcard/client/smartcard_main.c
+++ b/channels/smartcard/client/smartcard_main.c
@@ -377,10 +377,12 @@ UINT smartcard_process_irp(SMARTCARD_DEVICE* smartcard, IRP* irp)
 
 			if (!Queue_Enqueue(smartcard->CompletedIrpQueue, (void*) irp))
 			{
+				free(operation);
 				WLog_ERR(TAG, "Queue_Enqueue failed!");
 				return ERROR_INTERNAL_ERROR;
 			}
 
+			free(operation);
 			return CHANNEL_RC_OK;
 		}
 
@@ -460,6 +462,7 @@ UINT smartcard_process_irp(SMARTCARD_DEVICE* smartcard, IRP* irp)
 
 			if (!Queue_Enqueue(smartcard->CompletedIrpQueue, (void*) irp))
 			{
+				free(operation);
 				WLog_ERR(TAG, "Queue_Enqueue failed!");
 				return ERROR_INTERNAL_ERROR;
 			}

--- a/client/X11/generate_argument_docbook.c
+++ b/client/X11/generate_argument_docbook.c
@@ -11,65 +11,83 @@ LPSTR tr_esc_str(LPCSTR arg, bool format)
 	LPSTR tmp = NULL;
 	size_t cs = 0, x, ds, len;
 	size_t s;
-	if(NULL == arg)
+
+	if (NULL == arg)
 		return NULL;
+
 	s = strlen(arg);
+
 	/* Find trailing whitespaces */
-	while((s > 0) && isspace(arg[s-1]))
+	while ((s > 0) && isspace(arg[s - 1]))
 		s--;
+
 	/* Prepare a initial buffer with the size of the result string. */
 	ds = s + 1;
-	if(s)
+
+	if (s)
 		tmp = (LPSTR)realloc(tmp, ds * sizeof(CHAR));
-	if(NULL == tmp)
+
+	if (NULL == tmp)
 	{
 		fprintf(stderr,  "Could not allocate string buffer.\n");
 		exit(-2);
 	}
+
 	/* Copy character for character and check, if it is necessary to escape. */
 	memset(tmp, 0, ds * sizeof(CHAR));
-	for(x=0; x<s; x++)
+
+	for (x = 0; x < s; x++)
 	{
-		switch(arg[x])
+		switch (arg[x])
 		{
 			case '<':
 				len = format ? 13 : 4;
 				ds += len - 1;
 				tmp = (LPSTR)realloc(tmp, ds * sizeof(CHAR));
-				if(NULL == tmp)
+
+				if (NULL == tmp)
 				{
 					fprintf(stderr,  "Could not reallocate string buffer.\n");
 					exit(-3);
 				}
+
 				if (format)
-					strncpy (&tmp[cs], "<replaceable>", len);
-				else				
-					strncpy (&tmp[cs], "&lt;", len);
+					strncpy(&tmp[cs], "<replaceable>", len);
+				else
+					strncpy(&tmp[cs], "&lt;", len);
+
 				cs += len;
 				break;
+
 			case '>':
 				len = format ? 14 : 4;
 				ds += len - 1;
 				tmp = (LPSTR)realloc(tmp, ds * sizeof(CHAR));
-				if(NULL == tmp)
+
+				if (NULL == tmp)
 				{
 					fprintf(stderr,  "Could not reallocate string buffer.\n");
 					exit(-4);
 				}
+
 				if (format)
-					strncpy (&tmp[cs], "</replaceable>", len);
-				else				
-					strncpy (&tmp[cs], "&lt;", len);
+					strncpy(&tmp[cs], "</replaceable>", len);
+				else
+					strncpy(&tmp[cs], "&lt;", len);
+
 				cs += len;
 				break;
+
 			case '\'':
 				ds += 5;
 				tmp = (LPSTR)realloc(tmp, ds * sizeof(CHAR));
-				if(NULL == tmp)
+
+				if (NULL == tmp)
 				{
 					fprintf(stderr,  "Could not reallocate string buffer.\n");
 					exit(-5);
 				}
+
 				tmp[cs++] = '&';
 				tmp[cs++] = 'a';
 				tmp[cs++] = 'p';
@@ -77,14 +95,17 @@ LPSTR tr_esc_str(LPCSTR arg, bool format)
 				tmp[cs++] = 's';
 				tmp[cs++] = ';';
 				break;
+
 			case '"':
 				ds += 5;
 				tmp = (LPSTR)realloc(tmp, ds * sizeof(CHAR));
-				if(NULL == tmp)
+
+				if (NULL == tmp)
 				{
 					fprintf(stderr,  "Could not reallocate string buffer.\n");
 					exit(-6);
 				}
+
 				tmp[cs++] = '&';
 				tmp[cs++] = 'q';
 				tmp[cs++] = 'u';
@@ -92,88 +113,101 @@ LPSTR tr_esc_str(LPCSTR arg, bool format)
 				tmp[cs++] = 't';
 				tmp[cs++] = ';';
 				break;
+
 			case '&':
 				ds += 4;
 				tmp = (LPSTR)realloc(tmp, ds * sizeof(CHAR));
-				if(NULL == tmp)
+
+				if (NULL == tmp)
 				{
 					fprintf(stderr,  "Could not reallocate string buffer.\n");
 					exit(-7);
 				}
+
 				tmp[cs++] = '&';
 				tmp[cs++] = 'a';
 				tmp[cs++] = 'm';
 				tmp[cs++] = 'p';
 				tmp[cs++] = ';';
 				break;
+
 			default:
 				tmp[cs++] = arg[x];
 				break;
 		}
+
 		/* Assure, the string is '\0' terminated. */
-		tmp[ds-1] = '\0';
+		tmp[ds - 1] = '\0';
 	}
+
 	return tmp;
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-	size_t elements = sizeof(args)/sizeof(args[0]);
+	size_t elements = sizeof(args) / sizeof(args[0]);
 	size_t x;
-	const char *fname = "xfreerdp-argument.1.xml";
-	FILE *fp = NULL;
+	const char* fname = "xfreerdp-argument.1.xml";
+	FILE* fp = NULL;
 	/* Open output file for writing, truncate if existing. */
 	fp = fopen(fname, "w");
-	if(NULL == fp)
+
+	if (NULL == fp)
 	{
 		fprintf(stderr,  "Could not open '%s' for writing.\n", fname);
 		return -1;
 	}
+
 	/* The tag used as header in the manpage */
 	fprintf(fp, "<refsect1>\n");
 	fprintf(fp, "\t<title>Options</title>\n");
 	fprintf(fp, "\t\t<variablelist>\n");
+
 	/* Iterate over argument struct and write data to docbook 4.5
 	 * compatible XML */
-	if(elements < 2)
+	if (elements < 2)
 	{
 		fprintf(stderr,  "The argument array 'args' is empty, writing an empty file.\n");
 		elements = 1;
 	}
-	for(x=0; x<elements - 1; x++)
-	{
-		const COMMAND_LINE_ARGUMENT_A *arg = &args[x];
-		char *name = tr_esc_str((LPSTR) arg->Name, FALSE);
-		char *alias = tr_esc_str((LPSTR) arg->Alias, FALSE);
-		char *format = tr_esc_str(arg->Format, TRUE);
-		char *text = tr_esc_str((LPSTR) arg->Text, FALSE);
 
+	for (x = 0; x < elements - 1; x++)
+	{
+		const COMMAND_LINE_ARGUMENT_A* arg = &args[x];
+		char* name = tr_esc_str((LPSTR) arg->Name, FALSE);
+		char* alias = tr_esc_str((LPSTR) arg->Alias, FALSE);
+		char* format = tr_esc_str(arg->Format, TRUE);
+		char* text = tr_esc_str((LPSTR) arg->Text, FALSE);
 		fprintf(fp, "\t\t\t<varlistentry>\n");
 
 		do
 		{
 			fprintf(fp, "\t\t\t\t<term><option>");
+
 			if (arg->Flags == COMMAND_LINE_VALUE_BOOL)
 				fprintf(fp, "%s", arg->Default ? "-" : "+");
 			else
 				fprintf(fp, "/");
+
 			fprintf(fp, "%s</option>", name);
 
 			if (format)
 			{
 				if (arg->Flags == COMMAND_LINE_VALUE_OPTIONAL)
 					fprintf(fp, "[");
+
 				fprintf(fp, ":%s", format);
+
 				if (arg->Flags == COMMAND_LINE_VALUE_OPTIONAL)
 					fprintf(fp, "]");
 			}
 
 			fprintf(fp, "</term>\n");
-			
+
 			if (alias == name)
 				break;
 
-			free (name);
+			free(name);
 			name = alias;
 		}
 		while (alias);
@@ -190,19 +224,21 @@ int main(int argc, char *argv[])
 				fprintf(fp, " (default:%s)", arg->Default ? "on" : "off");
 			else if (arg->Default)
 			{
-				char *value = tr_esc_str((LPSTR) arg->Default, FALSE);
+				char* value = tr_esc_str((LPSTR) arg->Default, FALSE);
 				fprintf(fp, " (default:%s)", value);
-				free (value);
+				free(value);
 			}
 
 			fprintf(fp, "</para>\n");
 			fprintf(fp, "\t\t\t\t</listitem>\n");
 		}
+
 		fprintf(fp, "\t\t\t</varlistentry>\n");
 		free(name);
 		free(format);
 		free(text);
 	}
+
 	fprintf(fp, "\t\t</variablelist>\n");
 	fprintf(fp, "\t</refsect1>\n");
 	fclose(fp);

--- a/client/X11/generate_argument_docbook.c
+++ b/client/X11/generate_argument_docbook.c
@@ -52,8 +52,10 @@ LPSTR tr_esc_str(LPCSTR arg, bool format)
 				}
 
 				if (format)
+					/* coverity[buffer_size] */
 					strncpy(&tmp[cs], "<replaceable>", len);
 				else
+					/* coverity[buffer_size] */
 					strncpy(&tmp[cs], "&lt;", len);
 
 				cs += len;
@@ -71,8 +73,10 @@ LPSTR tr_esc_str(LPCSTR arg, bool format)
 				}
 
 				if (format)
+					/* coverity[buffer_size] */
 					strncpy(&tmp[cs], "</replaceable>", len);
 				else
+					/* coverity[buffer_size] */
 					strncpy(&tmp[cs], "&lt;", len);
 
 				cs += len;

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -183,6 +183,7 @@ BOOL xf_event_action_script_init(xfContext* xfc)
 
 		if (!xevent || ArrayList_Add(xfc->xevents, xevent) < 0)
 		{
+			pclose(actionScript);
 			ArrayList_Free(xfc->xevents);
 			xfc->xevents = NULL;
 			return FALSE;

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -306,6 +306,7 @@ int freerdp_client_settings_parse_assistance_file(rdpSettings* settings,
         const char* filename)
 {
 	int status;
+	int ret = -1;
 	rdpAssistanceFile* file;
 	file = freerdp_assistance_file_new();
 
@@ -315,15 +316,17 @@ int freerdp_client_settings_parse_assistance_file(rdpSettings* settings,
 	status = freerdp_assistance_parse_file(file, filename);
 
 	if (status < 0)
-		return -1;
+		goto out;
 
 	status = freerdp_client_populate_settings_from_assistance_file(file, settings);
 
 	if (status < 0)
-		return -1;
+		goto out;
 
+	ret = 0;
+out:
 	freerdp_assistance_file_free(file);
-	return 0;
+	return ret;
 }
 
 /** Callback set in the rdp_freerdp structure, and used to get the user's password,

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2596,7 +2596,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "reconnect-cookie")
 		{
-			BYTE* base64;
+			BYTE* base64 = NULL;
 			int length;
 			crypto_base64_decode((const char*)(arg->Value), (int) strlen(arg->Value),
 			                     &base64, &length);
@@ -2604,12 +2604,13 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 			if ((base64 != NULL) && (length == sizeof(ARC_SC_PRIVATE_PACKET)))
 			{
 				memcpy(settings->ServerAutoReconnectCookie, base64, length);
-				free(base64);
 			}
 			else
 			{
 				WLog_ERR(TAG, "reconnect-cookie:  invalid base64 '%s'", arg->Value);
 			}
+
+			free(base64);
 		}
 		CommandLineSwitchCase(arg, "print-reconnect-cookie")
 		{

--- a/libfreerdp/cache/pointer.c
+++ b/libfreerdp/cache/pointer.c
@@ -120,7 +120,7 @@ static BOOL update_pointer_color(rdpContext* context,
 		pointer->lengthAndMask = pointer_color->lengthAndMask;
 		pointer->lengthXorMask = pointer_color->lengthXorMask;
 
-		if (pointer->lengthAndMask && pointer_color->xorMaskData)
+		if (pointer->lengthAndMask && pointer_color->andMaskData)
 		{
 			pointer->andMaskData = (BYTE*) malloc(pointer->lengthAndMask);
 

--- a/libfreerdp/codec/nsc.c
+++ b/libfreerdp/codec/nsc.c
@@ -383,6 +383,7 @@ BOOL nsc_process_message(NSC_CONTEXT* context, UINT16 bpp,
 			break;
 
 		default:
+			Stream_Free(s, TRUE);
 			return FALSE;
 	}
 

--- a/libfreerdp/codec/planar.c
+++ b/libfreerdp/codec/planar.c
@@ -33,7 +33,7 @@
 
 #define TAG FREERDP_TAG("codec")
 
-static INLINE BYTE* freerdp_bitmap_planar_compress_plane_rle(
+static INLINE BOOL freerdp_bitmap_planar_compress_plane_rle(
     const BYTE* plane, UINT32 width, UINT32 height,
     BYTE* outPlane, UINT32* dstSize);
 static INLINE BYTE* freerdp_bitmap_planar_delta_encode_plane(
@@ -948,7 +948,7 @@ static INLINE UINT32 freerdp_bitmap_planar_encode_rle_bytes(const BYTE* pInBuffe
 	return nTotalBytesWritten;
 }
 
-BYTE* freerdp_bitmap_planar_compress_plane_rle(const BYTE* inPlane,
+BOOL freerdp_bitmap_planar_compress_plane_rle(const BYTE* inPlane,
         UINT32 width, UINT32 height,
         BYTE* outPlane, UINT32* dstSize)
 {
@@ -960,25 +960,12 @@ BYTE* freerdp_bitmap_planar_compress_plane_rle(const BYTE* inPlane,
 	UINT32 nTotalBytesWritten;
 
 	if (!outPlane)
-	{
-		outBufferSize = width * height;
-
-		if (outBufferSize == 0)
-			return NULL;
-
-		outPlane = malloc(outBufferSize);
-
-		if (!outPlane)
-			return NULL;
-	}
-	else
-	{
-		outBufferSize = *dstSize;
-	}
+		return FALSE;
 
 	index = 0;
 	pInput = inPlane;
 	pOutput = outPlane;
+	outBufferSize = *dstSize;
 	nTotalBytesWritten = 0;
 
 	while (outBufferSize)
@@ -987,7 +974,7 @@ BYTE* freerdp_bitmap_planar_compress_plane_rle(const BYTE* inPlane,
 		                    pInput, width, pOutput, outBufferSize);
 
 		if ((!nBytesWritten) || (nBytesWritten > outBufferSize))
-			return NULL;
+			return FALSE;
 
 		outBufferSize -= nBytesWritten;
 		nTotalBytesWritten += nBytesWritten;
@@ -1000,7 +987,7 @@ BYTE* freerdp_bitmap_planar_compress_plane_rle(const BYTE* inPlane,
 	}
 
 	*dstSize = nTotalBytesWritten;
-	return outPlane;
+	return TRUE;
 }
 
 static INLINE BOOL freerdp_bitmap_planar_compress_planes_rle(

--- a/libfreerdp/core/gateway/rpc.c
+++ b/libfreerdp/core/gateway/rpc.c
@@ -740,7 +740,7 @@ static int rpc_channel_tls_connect(RpcChannel* channel, int timeout)
 	sockfd = freerdp_tcp_connect(context, settings, peerHostname,
 	                             peerPort, timeout);
 
-	if (sockfd < 1)
+	if (sockfd < 0)
 		return -1;
 
 	socketBio = BIO_new(BIO_s_simple_socket());

--- a/libfreerdp/core/gateway/rpc.c
+++ b/libfreerdp/core/gateway/rpc.c
@@ -734,8 +734,9 @@ static int rpc_channel_tls_connect(RpcChannel* channel, int timeout)
 	rdpSettings* settings = context->settings;
 	const char* peerHostname = settings->GatewayHostname;
 	UINT16 peerPort = settings->GatewayPort;
-	const char *proxyUsername = settings->ProxyUsername, *proxyPassword = settings->ProxyPassword;
-	BOOL isProxyConnection = proxy_prepare(settings, &peerHostname, &peerPort, &proxyUsername, &proxyPassword);
+	const char* proxyUsername = settings->ProxyUsername, *proxyPassword = settings->ProxyPassword;
+	BOOL isProxyConnection = proxy_prepare(settings, &peerHostname, &peerPort, &proxyUsername,
+	                                       &proxyPassword);
 	sockfd = freerdp_tcp_connect(context, settings, peerHostname,
 	                             peerPort, timeout);
 
@@ -760,7 +761,8 @@ static int rpc_channel_tls_connect(RpcChannel* channel, int timeout)
 
 	if (isProxyConnection)
 	{
-		if (!proxy_connect(settings, bufferedBio, proxyUsername, proxyPassword,	settings->GatewayHostname, settings->GatewayPort))
+		if (!proxy_connect(settings, bufferedBio, proxyUsername, proxyPassword,	settings->GatewayHostname,
+		                   settings->GatewayPort))
 			return -1;
 	}
 

--- a/libfreerdp/core/gateway/rpc_bind.c
+++ b/libfreerdp/core/gateway/rpc_bind.c
@@ -119,9 +119,7 @@ int rpc_send_bind_pdu(rdpRpc* rpc)
 	freerdp* instance = (freerdp*) settings->instance;
 	RpcVirtualConnection* connection = rpc->VirtualConnection;
 	RpcInChannel* inChannel = connection->DefaultInChannel;
-
 	WLog_DBG(TAG, "Sending Bind PDU");
-
 	ntlm_free(rpc->ntlm);
 	rpc->ntlm = ntlm_new();
 
@@ -129,7 +127,7 @@ int rpc_send_bind_pdu(rdpRpc* rpc)
 		return -1;
 
 	if ((!settings->GatewayPassword) || (!settings->GatewayUsername)
-			|| (!strlen(settings->GatewayPassword)) || (!strlen(settings->GatewayUsername)))
+	    || (!strlen(settings->GatewayPassword)) || (!strlen(settings->GatewayUsername)))
 	{
 		promptPassword = TRUE;
 	}
@@ -139,7 +137,7 @@ int rpc_send_bind_pdu(rdpRpc* rpc)
 		if (instance->GatewayAuthenticate)
 		{
 			BOOL proceed = instance->GatewayAuthenticate(instance,
-					&settings->GatewayUsername, &settings->GatewayPassword, &settings->GatewayDomain);
+			               &settings->GatewayUsername, &settings->GatewayPassword, &settings->GatewayDomain);
 
 			if (!proceed)
 			{
@@ -159,7 +157,8 @@ int rpc_send_bind_pdu(rdpRpc* rpc)
 		}
 	}
 
-	if (!ntlm_client_init(rpc->ntlm, FALSE, settings->GatewayUsername, settings->GatewayDomain, settings->GatewayPassword, NULL))
+	if (!ntlm_client_init(rpc->ntlm, FALSE, settings->GatewayUsername, settings->GatewayDomain,
+	                      settings->GatewayPassword, NULL))
 		return -1;
 
 	if (!ntlm_client_make_spn(rpc->ntlm, NULL, settings->GatewayHostname))
@@ -174,35 +173,29 @@ int rpc_send_bind_pdu(rdpRpc* rpc)
 		return -1;
 
 	rpc_pdu_header_init(rpc, (rpcconn_hdr_t*) bind_pdu);
-
 	bind_pdu->auth_length = (UINT16) rpc->ntlm->outputBuffer[0].cbBuffer;
 	bind_pdu->auth_verifier.auth_value = rpc->ntlm->outputBuffer[0].pvBuffer;
-
 	bind_pdu->ptype = PTYPE_BIND;
 	bind_pdu->pfc_flags = PFC_FIRST_FRAG | PFC_LAST_FRAG | PFC_SUPPORT_HEADER_SIGN | PFC_CONC_MPX;
 	bind_pdu->call_id = 2;
-
 	bind_pdu->max_xmit_frag = rpc->max_xmit_frag;
 	bind_pdu->max_recv_frag = rpc->max_recv_frag;
 	bind_pdu->assoc_group_id = 0;
-
 	bind_pdu->p_context_elem.n_context_elem = 2;
 	bind_pdu->p_context_elem.reserved = 0;
 	bind_pdu->p_context_elem.reserved2 = 0;
-
-	bind_pdu->p_context_elem.p_cont_elem = calloc(bind_pdu->p_context_elem.n_context_elem, sizeof(p_cont_elem_t));
+	bind_pdu->p_context_elem.p_cont_elem = calloc(bind_pdu->p_context_elem.n_context_elem,
+	                                       sizeof(p_cont_elem_t));
 
 	if (!bind_pdu->p_context_elem.p_cont_elem)
 		return -1;
 
 	p_cont_elem = &bind_pdu->p_context_elem.p_cont_elem[0];
-
 	p_cont_elem->p_cont_id = 0;
 	p_cont_elem->n_transfer_syn = 1;
 	p_cont_elem->reserved = 0;
 	CopyMemory(&(p_cont_elem->abstract_syntax.if_uuid), &TSGU_UUID, sizeof(p_uuid_t));
 	p_cont_elem->abstract_syntax.if_version = TSGU_SYNTAX_IF_VERSION;
-
 	p_cont_elem->transfer_syntaxes = malloc(sizeof(p_syntax_id_t));
 
 	if (!p_cont_elem->transfer_syntaxes)
@@ -210,15 +203,12 @@ int rpc_send_bind_pdu(rdpRpc* rpc)
 
 	CopyMemory(&(p_cont_elem->transfer_syntaxes[0].if_uuid), &NDR_UUID, sizeof(p_uuid_t));
 	p_cont_elem->transfer_syntaxes[0].if_version = NDR_SYNTAX_IF_VERSION;
-
 	p_cont_elem = &bind_pdu->p_context_elem.p_cont_elem[1];
-
 	p_cont_elem->p_cont_id = 1;
 	p_cont_elem->n_transfer_syn = 1;
 	p_cont_elem->reserved = 0;
 	CopyMemory(&(p_cont_elem->abstract_syntax.if_uuid), &TSGU_UUID, sizeof(p_uuid_t));
 	p_cont_elem->abstract_syntax.if_version = TSGU_SYNTAX_IF_VERSION;
-
 	p_cont_elem->transfer_syntaxes = malloc(sizeof(p_syntax_id_t));
 
 	if (!p_cont_elem->transfer_syntaxes)
@@ -226,18 +216,14 @@ int rpc_send_bind_pdu(rdpRpc* rpc)
 
 	CopyMemory(&(p_cont_elem->transfer_syntaxes[0].if_uuid), &BTFN_UUID, sizeof(p_uuid_t));
 	p_cont_elem->transfer_syntaxes[0].if_version = BTFN_SYNTAX_IF_VERSION;
-
 	offset = 116;
 	bind_pdu->auth_verifier.auth_pad_length = rpc_offset_align(&offset, 4);
-
 	bind_pdu->auth_verifier.auth_type = RPC_C_AUTHN_WINNT;
 	bind_pdu->auth_verifier.auth_level = RPC_C_AUTHN_LEVEL_PKT_INTEGRITY;
 	bind_pdu->auth_verifier.auth_reserved = 0x00;
 	bind_pdu->auth_verifier.auth_context_id = 0x00000000;
 	offset += (8 + bind_pdu->auth_length);
-
 	bind_pdu->frag_length = offset;
-
 	buffer = (BYTE*) malloc(bind_pdu->frag_length);
 
 	if (!buffer)
@@ -249,16 +235,12 @@ int rpc_send_bind_pdu(rdpRpc* rpc)
 	CopyMemory(&buffer[52], bind_pdu->p_context_elem.p_cont_elem[0].transfer_syntaxes, 20);
 	CopyMemory(&buffer[72], &bind_pdu->p_context_elem.p_cont_elem[1], 24);
 	CopyMemory(&buffer[96], bind_pdu->p_context_elem.p_cont_elem[1].transfer_syntaxes, 20);
-
 	offset = 116;
 	rpc_offset_pad(&offset, bind_pdu->auth_verifier.auth_pad_length);
-
 	CopyMemory(&buffer[offset], &bind_pdu->auth_verifier.auth_type, 8);
 	CopyMemory(&buffer[offset + 8], bind_pdu->auth_verifier.auth_value, bind_pdu->auth_length);
 	offset += (8 + bind_pdu->auth_length);
-
 	length = bind_pdu->frag_length;
-
 	clientCall = rpc_client_call_new(bind_pdu->call_id, 0);
 
 	if (!clientCall)
@@ -274,14 +256,11 @@ int rpc_send_bind_pdu(rdpRpc* rpc)
 	}
 
 	status = rpc_in_channel_send_pdu(inChannel, buffer, length);
-
 	free(bind_pdu->p_context_elem.p_cont_elem[0].transfer_syntaxes);
 	free(bind_pdu->p_context_elem.p_cont_elem[1].transfer_syntaxes);
 	free(bind_pdu->p_context_elem.p_cont_elem);
 	free(bind_pdu);
-
 	free(buffer);
-
 	return (status > 0) ? 1 : -1;
 }
 
@@ -312,14 +291,10 @@ int rpc_recv_bind_ack_pdu(rdpRpc* rpc, BYTE* buffer, UINT32 length)
 {
 	BYTE* auth_data;
 	rpcconn_hdr_t* header;
-
 	header = (rpcconn_hdr_t*) buffer;
-
 	WLog_DBG(TAG, "Receiving BindAck PDU");
-
 	rpc->max_recv_frag = header->bind_ack.max_xmit_frag;
 	rpc->max_xmit_frag = header->bind_ack.max_recv_frag;
-
 	rpc->ntlm->inputBuffer[0].cbBuffer = header->common.auth_length;
 	rpc->ntlm->inputBuffer[0].pvBuffer = malloc(header->common.auth_length);
 
@@ -328,9 +303,7 @@ int rpc_recv_bind_ack_pdu(rdpRpc* rpc, BYTE* buffer, UINT32 length)
 
 	auth_data = buffer + (header->common.frag_length - header->common.auth_length);
 	CopyMemory(rpc->ntlm->inputBuffer[0].pvBuffer, auth_data, header->common.auth_length);
-
 	ntlm_authenticate(rpc->ntlm);
-
 	return (int) length;
 }
 
@@ -351,54 +324,42 @@ int rpc_send_rpc_auth_3_pdu(rdpRpc* rpc)
 	rpcconn_rpc_auth_3_hdr_t* auth_3_pdu;
 	RpcVirtualConnection* connection = rpc->VirtualConnection;
 	RpcInChannel* inChannel = connection->DefaultInChannel;
-
 	WLog_DBG(TAG, "Sending RpcAuth3 PDU");
-
 	auth_3_pdu = (rpcconn_rpc_auth_3_hdr_t*) calloc(1, sizeof(rpcconn_rpc_auth_3_hdr_t));
 
 	if (!auth_3_pdu)
 		return -1;
 
 	rpc_pdu_header_init(rpc, (rpcconn_hdr_t*) auth_3_pdu);
-
 	auth_3_pdu->auth_length = (UINT16) rpc->ntlm->outputBuffer[0].cbBuffer;
 	auth_3_pdu->auth_verifier.auth_value = rpc->ntlm->outputBuffer[0].pvBuffer;
-
 	auth_3_pdu->ptype = PTYPE_RPC_AUTH_3;
 	auth_3_pdu->pfc_flags = PFC_FIRST_FRAG | PFC_LAST_FRAG | PFC_CONC_MPX;
 	auth_3_pdu->call_id = 2;
-
 	auth_3_pdu->max_xmit_frag = rpc->max_xmit_frag;
 	auth_3_pdu->max_recv_frag = rpc->max_recv_frag;
-
 	offset = 20;
 	auth_3_pdu->auth_verifier.auth_pad_length = rpc_offset_align(&offset, 4);
-
 	auth_3_pdu->auth_verifier.auth_type = RPC_C_AUTHN_WINNT;
 	auth_3_pdu->auth_verifier.auth_level = RPC_C_AUTHN_LEVEL_PKT_INTEGRITY;
 	auth_3_pdu->auth_verifier.auth_reserved = 0x00;
 	auth_3_pdu->auth_verifier.auth_context_id = 0x00000000;
 	offset += (8 + auth_3_pdu->auth_length);
-
 	auth_3_pdu->frag_length = offset;
-
 	buffer = (BYTE*) malloc(auth_3_pdu->frag_length);
 
 	if (!buffer)
 		return -1;
 
 	CopyMemory(buffer, auth_3_pdu, 20);
-
 	offset = 20;
 	rpc_offset_pad(&offset, auth_3_pdu->auth_verifier.auth_pad_length);
-
 	CopyMemory(&buffer[offset], &auth_3_pdu->auth_verifier.auth_type, 8);
 	CopyMemory(&buffer[offset + 8], auth_3_pdu->auth_verifier.auth_value, auth_3_pdu->auth_length);
 	offset += (8 + auth_3_pdu->auth_length);
-
 	length = auth_3_pdu->frag_length;
-
 	clientCall = rpc_client_call_new(auth_3_pdu->call_id, 0);
+
 	if (ArrayList_Add(rpc->client->ClientCallList, clientCall) >= 0)
 	{
 		status = rpc_in_channel_send_pdu(inChannel, buffer, length);
@@ -406,6 +367,5 @@ int rpc_send_rpc_auth_3_pdu(rdpRpc* rpc)
 
 	free(auth_3_pdu);
 	free(buffer);
-
 	return (status > 0) ? 1 : -1;
 }

--- a/libfreerdp/core/gateway/rpc_bind.c
+++ b/libfreerdp/core/gateway/rpc_bind.c
@@ -349,7 +349,10 @@ int rpc_send_rpc_auth_3_pdu(rdpRpc* rpc)
 	buffer = (BYTE*) malloc(auth_3_pdu->frag_length);
 
 	if (!buffer)
+	{
+		free(auth_3_pdu);
 		return -1;
+	}
 
 	CopyMemory(buffer, auth_3_pdu, 20);
 	offset = 20;

--- a/libfreerdp/core/gateway/rpc_client.c
+++ b/libfreerdp/core/gateway/rpc_client.c
@@ -476,6 +476,7 @@ static int rpc_client_default_out_channel_recv(rdpRpc* rpc)
 			/* Receive OUT Channel Response */
 			if (rpc_ncacn_http_recv_out_channel_response(rpc, outChannel, response) < 0)
 			{
+				http_response_free(response);
 				WLog_ERR(TAG, "rpc_ncacn_http_recv_out_channel_response failure");
 				return -1;
 			}
@@ -484,6 +485,7 @@ static int rpc_client_default_out_channel_recv(rdpRpc* rpc)
 
 			if (rpc_ncacn_http_send_out_channel_request(rpc, outChannel, FALSE) < 0)
 			{
+				http_response_free(response);
 				WLog_ERR(TAG, "rpc_ncacn_http_send_out_channel_request failure");
 				return -1;
 			}
@@ -496,6 +498,7 @@ static int rpc_client_default_out_channel_recv(rdpRpc* rpc)
 
 			if (rts_send_CONN_A1_pdu(rpc) < 0)
 			{
+				http_response_free(response);
 				WLog_ERR(TAG, "rpc_send_CONN_A1_pdu error!");
 				return -1;
 			}

--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -1228,6 +1228,7 @@ static BOOL rdp_write_logon_info_v1(wStream* s, logon_info* info)
 	Stream_Seek(s, 52 - len);
 	free(wString);
 	/* username */
+	wString = NULL;
 	len = ConvertToUnicode(CP_UTF8, 0, info->username, -1, &wString, 0);
 
 	if (len < 0)
@@ -1274,6 +1275,7 @@ static BOOL rdp_write_logon_info_v2(wStream* s, logon_info* info)
 
 	Stream_Write(s, wString, len * 2);
 	free(wString);
+	wString = NULL;
 	len = ConvertToUnicode(CP_UTF8, 0, info->username, -1, &wString, 0);
 
 	if (len < 0)

--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -1218,7 +1218,10 @@ static BOOL rdp_write_logon_info_v1(wStream* s, logon_info* info)
 	len *= 2;
 
 	if (len > 52)
+	{
+		free(wString);
 		return FALSE;
+	}
 
 	Stream_Write_UINT32(s, len);
 	Stream_Write(s, wString, len);
@@ -1233,7 +1236,10 @@ static BOOL rdp_write_logon_info_v1(wStream* s, logon_info* info)
 	len *= 2;
 
 	if (len > 512)
+	{
+		free(wString);
 		return FALSE;
+	}
 
 	Stream_Write_UINT32(s, len);
 	Stream_Write(s, wString, len);

--- a/libfreerdp/core/listener.c
+++ b/libfreerdp/core/listener.c
@@ -160,7 +160,7 @@ static BOOL freerdp_listener_open_local(freerdp_listener* instance, const char* 
 #ifndef _WIN32
 	int status;
 	int sockfd;
-	struct sockaddr_un addr;
+	struct sockaddr_un addr = { 0 };
 	rdpListener* listener = (rdpListener*) instance->listener;
 	HANDLE hevent;
 
@@ -180,7 +180,7 @@ static BOOL freerdp_listener_open_local(freerdp_listener* instance, const char* 
 
 	fcntl(sockfd, F_SETFL, O_NONBLOCK);
 	addr.sun_family = AF_UNIX;
-	strncpy(addr.sun_path, path, sizeof(addr.sun_path));
+	strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
 	unlink(path);
 	status = _bind(sockfd, (struct sockaddr*) &addr, sizeof(addr));
 

--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -342,6 +342,7 @@ BOOL nego_send_preconnection_pdu(rdpNego* nego)
 
 	if (!s)
 	{
+		free(wszPCB);
 		WLog_ERR(TAG, "Stream_New failed!");
 		return FALSE;
 	}

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -1886,7 +1886,10 @@ BOOL nla_send(rdpNla* nla)
 		          nla->negoToken.cbBuffer);  /* OCTET STRING */
 
 		if (length != nego_tokens_length)
+		{
+			Stream_Free(s, TRUE);
 			return FALSE;
+		}
 	}
 
 	/* [2] authInfo (OCTET STRING) */
@@ -1894,7 +1897,10 @@ BOOL nla_send(rdpNla* nla)
 	{
 		if (ber_write_sequence_octet_string(s, 2, nla->authInfo.pvBuffer,
 		                                    nla->authInfo.cbBuffer) != auth_info_length)
+		{
+			Stream_Free(s, TRUE);
 			return FALSE;
+		}
 	}
 
 	/* [3] pubKeyAuth (OCTET STRING) */
@@ -1902,7 +1908,10 @@ BOOL nla_send(rdpNla* nla)
 	{
 		if (ber_write_sequence_octet_string(s, 3, nla->pubKeyAuth.pvBuffer,
 		                                    nla->pubKeyAuth.cbBuffer) != pub_key_auth_length)
+		{
+			Stream_Free(s, TRUE);
 			return FALSE;
+		}
 	}
 
 	/* [4] errorCode (INTEGER) */
@@ -1917,7 +1926,10 @@ BOOL nla_send(rdpNla* nla)
 	{
 		if (ber_write_sequence_octet_string(s, 5, nla->ClientNonce.pvBuffer,
 		                                    nla->ClientNonce.cbBuffer) != client_nonce_length)
+		{
+			Stream_Free(s, TRUE);
 			return FALSE;
+		}
 	}
 
 	Stream_SealLength(s);

--- a/libfreerdp/core/proxy.c
+++ b/libfreerdp/core/proxy.c
@@ -234,6 +234,7 @@ static BOOL http_proxy_connect(BIO* bufferedBio, const char* hostname, UINT16 po
 
 	if (status != Stream_GetPosition(s))
 	{
+		Stream_Free(s, TRUE);
 		WLog_ERR(TAG, "HTTP proxy: failed to write CONNECT request");
 		return FALSE;
 	}

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -736,7 +736,7 @@ static int freerdp_uds_connect(const char* path)
 #ifndef _WIN32
 	int status;
 	int sockfd;
-	struct sockaddr_un addr;
+	struct sockaddr_un addr = { 0 };
 	sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
 
 	if (sockfd == -1)
@@ -746,7 +746,7 @@ static int freerdp_uds_connect(const char* path)
 	}
 
 	addr.sun_family = AF_UNIX;
-	strncpy(addr.sun_path, path, sizeof(addr.sun_path));
+	strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
 	status = connect(sockfd, (struct sockaddr*) &addr, sizeof(addr));
 
 	if (status < 0)

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -1191,7 +1191,8 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings,
 				return -1;
 			}
 
-			if ((peerAddress = freerdp_tcp_address_to_string((struct sockaddr_storage*)addr->ai_addr, NULL)) != NULL)
+			if ((peerAddress = freerdp_tcp_address_to_string((struct sockaddr_storage*)addr->ai_addr,
+			                   NULL)) != NULL)
 			{
 				WLog_DBG(TAG, "connecting to peer %s", peerAddress);
 				free(peerAddress);

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -419,7 +419,7 @@ BOOL transport_connect(rdpTransport* transport, const char* hostname,
 		else
 			sockfd = freerdp_tcp_connect(context, settings, hostname, port, timeout);
 
-		if (sockfd < 1)
+		if (sockfd < 0)
 			return FALSE;
 
 		if (!transport_attach(transport, sockfd))

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1330,15 +1330,15 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, char* hostname,
 		{
 			accept_cert(tls, pemCert, length);
 		}
-		else
-			free(pemCert);
-
-		if (status < 0)
+		else if (status < 0)
 		{
 			WLog_ERR(TAG, "VerifyX509Certificate failed: (length = %d) status: [%d] %s",
 			         length, status, pemCert);
+			free(pemCert);
 			return -1;
 		}
+		else
+			free(pemCert);
 
 		return (status == 0) ? 0 : 1;
 	}

--- a/rdtk/librdtk/rdtk_font.c
+++ b/rdtk/librdtk/rdtk_font.c
@@ -612,7 +612,6 @@ rdtkFont* rdtk_font_new(rdtkEngine* engine, const char* path, const char* file)
 
 	strcpy(fontDescriptorFile, fontBaseFile);
 	strcpy(&fontDescriptorFile[length], ".xml");
-	free(fontBaseFile);
 
 	if (!PathFileExistsA(fontImageFile))
 		goto cleanup;
@@ -641,10 +640,12 @@ rdtkFont* rdtk_font_new(rdtkEngine* engine, const char* path, const char* file)
 	if (status < 0)
 		goto cleanup;
 
+	free(fontBaseFile);
 	free(fontImageFile);
 	free(fontDescriptorFile);
 	return font;
 cleanup:
+	free(fontBaseFile);
 	free(fontImageFile);
 	free(fontDescriptorFile);
 

--- a/rdtk/librdtk/rdtk_nine_patch.c
+++ b/rdtk/librdtk/rdtk_nine_patch.c
@@ -390,6 +390,8 @@ int rdtk_nine_patch_engine_init(rdtkEngine* engine)
 
 			if (ninePatch)
 				rdtk_nine_patch_set_image(ninePatch, image);
+			else
+				winpr_image_free(image, TRUE);
 		}
 	}
 
@@ -414,6 +416,8 @@ int rdtk_nine_patch_engine_init(rdtkEngine* engine)
 
 			if (ninePatch)
 				rdtk_nine_patch_set_image(ninePatch, image);
+			else
+				winpr_image_free(image, TRUE);
 		}
 	}
 

--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -684,11 +684,12 @@ UwacReturnCode UwacWindowSetFullscreenState(UwacWindow* window, UwacOutput* outp
 	}
 	else if (window->shell_surface)
 	{
-		if (isFullscreen) {
+		if (isFullscreen)
+		{
 			wl_shell_surface_set_fullscreen(window->shell_surface,
-							WL_SHELL_SURFACE_FULLSCREEN_METHOD_DEFAULT,
-							0,
-							output ? output->output : NULL);
+			                                WL_SHELL_SURFACE_FULLSCREEN_METHOD_DEFAULT,
+			                                0,
+			                                output ? output->output : NULL);
 		}
 		else
 		{

--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -331,6 +331,7 @@ int UwacWindowShmAllocBuffers(UwacWindow* w, int nbuffers, int allocSize, uint32
 
 	if (!pool)
 	{
+		munmap(data, allocSize * nbuffers);
 		ret = UWAC_ERROR_NOMEMORY;
 		goto error_mmap;
 	}
@@ -500,7 +501,7 @@ UwacReturnCode UwacDestroyWindow(UwacWindow** pwindow)
 		wl_region_destroy(w->opaque_region);
 
 	if (w->input_region)
-		wl_region_destroy(w->opaque_region);
+		wl_region_destroy(w->input_region);
 
 	wl_surface_destroy(w->surface);
 	wl_list_remove(&w->link);

--- a/winpr/include/winpr/ntlm.h
+++ b/winpr/include/winpr/ntlm.h
@@ -31,22 +31,23 @@
 extern "C" {
 #endif
 
-typedef SECURITY_STATUS (*psPeerComputeNtlmHash)(void *client, const SEC_WINNT_AUTH_IDENTITY *authIdentity,
-		const SecBuffer *ntproofvalue, const BYTE *randkey, const BYTE *mic, const SecBuffer *micvalue,
-		BYTE *ntlmhash);
+typedef SECURITY_STATUS(*psPeerComputeNtlmHash)(void* client,
+        const SEC_WINNT_AUTH_IDENTITY* authIdentity,
+        const SecBuffer* ntproofvalue, const BYTE* randkey, const BYTE* mic, const SecBuffer* micvalue,
+        BYTE* ntlmhash);
 
 WINPR_API BYTE* NTOWFv1W(LPWSTR Password, UINT32 PasswordLength, BYTE* NtHash);
 WINPR_API BYTE* NTOWFv1A(LPSTR Password, UINT32 PasswordLength, BYTE* NtHash);
 
 WINPR_API BYTE* NTOWFv2W(LPWSTR Password, UINT32 PasswordLength, LPWSTR User,
-		UINT32 UserLength, LPWSTR Domain, UINT32 DomainLength, BYTE* NtHash);
+                         UINT32 UserLength, LPWSTR Domain, UINT32 DomainLength, BYTE* NtHash);
 WINPR_API BYTE* NTOWFv2A(LPSTR Password, UINT32 PasswordLength, LPSTR User,
-		UINT32 UserLength, LPSTR Domain, UINT32 DomainLength, BYTE* NtHash);
+                         UINT32 UserLength, LPSTR Domain, UINT32 DomainLength, BYTE* NtHash);
 
 WINPR_API BYTE* NTOWFv2FromHashW(BYTE* NtHashV1, LPWSTR User, UINT32 UserLength,
-		LPWSTR Domain, UINT32 DomainLength, BYTE* NtHash);
+                                 LPWSTR Domain, UINT32 DomainLength, BYTE* NtHash);
 WINPR_API BYTE* NTOWFv2FromHashA(BYTE* NtHashV1, LPSTR User, UINT32 UserLength,
-		LPSTR Domain, UINT32 DomainLength, BYTE* NtHash);
+                                 LPSTR Domain, UINT32 DomainLength, BYTE* NtHash);
 
 #ifdef __cplusplus
 }

--- a/winpr/include/winpr/ntlm.h
+++ b/winpr/include/winpr/ntlm.h
@@ -36,18 +36,18 @@ typedef SECURITY_STATUS(*psPeerComputeNtlmHash)(void* client,
         const SecBuffer* ntproofvalue, const BYTE* randkey, const BYTE* mic, const SecBuffer* micvalue,
         BYTE* ntlmhash);
 
-WINPR_API BYTE* NTOWFv1W(LPWSTR Password, UINT32 PasswordLength, BYTE* NtHash);
-WINPR_API BYTE* NTOWFv1A(LPSTR Password, UINT32 PasswordLength, BYTE* NtHash);
+WINPR_API BOOL NTOWFv1W(LPWSTR Password, UINT32 PasswordLength, BYTE* NtHash);
+WINPR_API BOOL NTOWFv1A(LPSTR Password, UINT32 PasswordLength, BYTE* NtHash);
 
-WINPR_API BYTE* NTOWFv2W(LPWSTR Password, UINT32 PasswordLength, LPWSTR User,
-                         UINT32 UserLength, LPWSTR Domain, UINT32 DomainLength, BYTE* NtHash);
-WINPR_API BYTE* NTOWFv2A(LPSTR Password, UINT32 PasswordLength, LPSTR User,
-                         UINT32 UserLength, LPSTR Domain, UINT32 DomainLength, BYTE* NtHash);
+WINPR_API BOOL NTOWFv2W(LPWSTR Password, UINT32 PasswordLength, LPWSTR User,
+                        UINT32 UserLength, LPWSTR Domain, UINT32 DomainLength, BYTE* NtHash);
+WINPR_API BOOL NTOWFv2A(LPSTR Password, UINT32 PasswordLength, LPSTR User,
+                        UINT32 UserLength, LPSTR Domain, UINT32 DomainLength, BYTE* NtHash);
 
-WINPR_API BYTE* NTOWFv2FromHashW(BYTE* NtHashV1, LPWSTR User, UINT32 UserLength,
-                                 LPWSTR Domain, UINT32 DomainLength, BYTE* NtHash);
-WINPR_API BYTE* NTOWFv2FromHashA(BYTE* NtHashV1, LPSTR User, UINT32 UserLength,
-                                 LPSTR Domain, UINT32 DomainLength, BYTE* NtHash);
+WINPR_API BOOL NTOWFv2FromHashW(BYTE* NtHashV1, LPWSTR User, UINT32 UserLength,
+                                LPWSTR Domain, UINT32 DomainLength, BYTE* NtHash);
+WINPR_API BOOL NTOWFv2FromHashA(BYTE* NtHashV1, LPSTR User, UINT32 UserLength,
+                                LPSTR Domain, UINT32 DomainLength, BYTE* NtHash);
 
 #ifdef __cplusplus
 }

--- a/winpr/libwinpr/file/generic.c
+++ b/winpr/libwinpr/file/generic.c
@@ -1008,6 +1008,7 @@ HANDLE FindFirstFileW(LPCWSTR lpFileName, LPWIN32_FIND_DATAW lpFindFileData)
 		if (!ConvertFindDataAToW(fd, lpFindFileData))
 		{
 			SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+			FindClose(h);
 			h = INVALID_HANDLE_VALUE;
 			goto out;
 		}

--- a/winpr/libwinpr/io/device.c
+++ b/winpr/libwinpr/io/device.c
@@ -75,7 +75,6 @@ char* GetDeviceFileNameWithoutPrefixA(LPCSTR lpName)
 		return NULL;
 
 	lpFileName = _strdup(&lpName[strlen(DEVICE_FILE_PREFIX_PATH)]);
-
 	return lpFileName;
 }
 
@@ -83,14 +82,13 @@ char* GetDeviceFileUnixDomainSocketBaseFilePathA()
 {
 	char* lpTempPath;
 	char* lpPipePath;
-
 	lpTempPath = GetKnownPath(KNOWN_PATH_TEMP);
+
 	if (!lpTempPath)
 		return NULL;
+
 	lpPipePath = GetCombinedPath(lpTempPath, ".device");
-
 	free(lpTempPath);
-
 	return lpPipePath;
 }
 
@@ -99,12 +97,13 @@ char* GetDeviceFileUnixDomainSocketFilePathA(LPCSTR lpName)
 	char* lpPipePath = NULL;
 	char* lpFileName = NULL;
 	char* lpFilePath = NULL;
-
 	lpPipePath = GetDeviceFileUnixDomainSocketBaseFilePathA();
+
 	if (!lpPipePath)
 		return NULL;
 
 	lpFileName = GetDeviceFileNameWithoutPrefixA(lpName);
+
 	if (!lpFileName)
 	{
 		free(lpFilePath);
@@ -112,10 +111,8 @@ char* GetDeviceFileUnixDomainSocketFilePathA(LPCSTR lpName)
 	}
 
 	lpFilePath = GetCombinedPath(lpPipePath, (char*) lpFileName);
-
 	free(lpPipePath);
 	free(lpFileName);
-
 	return lpFilePath;
 }
 
@@ -124,13 +121,14 @@ char* GetDeviceFileUnixDomainSocketFilePathA(LPCSTR lpName)
  * http://msdn.microsoft.com/en-us/library/windows/hardware/ff548397/
  */
 
-NTSTATUS _IoCreateDeviceEx(PDRIVER_OBJECT_EX DriverObject, ULONG DeviceExtensionSize, PUNICODE_STRING DeviceName,
-		DEVICE_TYPE DeviceType, ULONG DeviceCharacteristics, BOOLEAN Exclusive, PDEVICE_OBJECT_EX* DeviceObject)
+NTSTATUS _IoCreateDeviceEx(PDRIVER_OBJECT_EX DriverObject, ULONG DeviceExtensionSize,
+                           PUNICODE_STRING DeviceName,
+                           DEVICE_TYPE DeviceType, ULONG DeviceCharacteristics, BOOLEAN Exclusive,
+                           PDEVICE_OBJECT_EX* DeviceObject)
 {
 	int status;
 	char* DeviceBasePath;
 	DEVICE_OBJECT_EX* pDeviceObjectEx;
-
 	DeviceBasePath = GetDeviceFileUnixDomainSocketBaseFilePathA();
 
 	if (!DeviceBasePath)
@@ -144,21 +142,25 @@ NTSTATUS _IoCreateDeviceEx(PDRIVER_OBJECT_EX DriverObject, ULONG DeviceExtension
 			return STATUS_ACCESS_DENIED;
 		}
 	}
-	free(DeviceBasePath);
 
+	free(DeviceBasePath);
 	pDeviceObjectEx = (DEVICE_OBJECT_EX*) calloc(1, sizeof(DEVICE_OBJECT_EX));
 
 	if (!pDeviceObjectEx)
 		return STATUS_NO_MEMORY;
 
-	ConvertFromUnicode(CP_UTF8, 0, DeviceName->Buffer, DeviceName->Length / 2, &(pDeviceObjectEx->DeviceName), 0, NULL, NULL);
+	ConvertFromUnicode(CP_UTF8, 0, DeviceName->Buffer, DeviceName->Length / 2,
+	                   &(pDeviceObjectEx->DeviceName), 0, NULL, NULL);
+
 	if (!pDeviceObjectEx->DeviceName)
 	{
 		free(pDeviceObjectEx);
 		return STATUS_NO_MEMORY;
 	}
 
-	pDeviceObjectEx->DeviceFileName = GetDeviceFileUnixDomainSocketFilePathA(pDeviceObjectEx->DeviceName);
+	pDeviceObjectEx->DeviceFileName = GetDeviceFileUnixDomainSocketFilePathA(
+	                                      pDeviceObjectEx->DeviceName);
+
 	if (!pDeviceObjectEx->DeviceFileName)
 	{
 		free(pDeviceObjectEx->DeviceName);
@@ -175,35 +177,40 @@ NTSTATUS _IoCreateDeviceEx(PDRIVER_OBJECT_EX DriverObject, ULONG DeviceExtension
 			free(pDeviceObjectEx);
 			return STATUS_ACCESS_DENIED;
 		}
-
 	}
 
 	status = mkfifo(pDeviceObjectEx->DeviceFileName, 0666);
+
 	if (status != 0)
 	{
 		free(pDeviceObjectEx->DeviceName);
 		free(pDeviceObjectEx->DeviceFileName);
 		free(pDeviceObjectEx);
+
 		switch (errno)
 		{
 			case EACCES:
 				return STATUS_ACCESS_DENIED;
+
 			case EEXIST:
 				return STATUS_OBJECT_NAME_EXISTS;
+
 			case ENAMETOOLONG:
 				return STATUS_NAME_TOO_LONG;
+
 			case ENOENT:
 			case ENOTDIR:
 				return STATUS_NOT_A_DIRECTORY;
+
 			case ENOSPC:
 				return STATUS_DISK_FULL;
+
 			default:
 				return STATUS_INTERNAL_ERROR;
 		}
 	}
 
-	*((ULONG_PTR*) (DeviceObject)) = (ULONG_PTR) pDeviceObjectEx;
-
+	*((ULONG_PTR*)(DeviceObject)) = (ULONG_PTR) pDeviceObjectEx;
 	return STATUS_SUCCESS;
 }
 
@@ -215,17 +222,14 @@ NTSTATUS _IoCreateDeviceEx(PDRIVER_OBJECT_EX DriverObject, ULONG DeviceExtension
 VOID _IoDeleteDeviceEx(PDEVICE_OBJECT_EX DeviceObject)
 {
 	DEVICE_OBJECT_EX* pDeviceObjectEx;
-
 	pDeviceObjectEx = (DEVICE_OBJECT_EX*) DeviceObject;
 
 	if (!pDeviceObjectEx)
 		return;
 
 	unlink(pDeviceObjectEx->DeviceFileName);
-
 	free(pDeviceObjectEx->DeviceName);
 	free(pDeviceObjectEx->DeviceFileName);
-
 	free(pDeviceObjectEx);
 }
 

--- a/winpr/libwinpr/io/device.c
+++ b/winpr/libwinpr/io/device.c
@@ -106,7 +106,7 @@ char* GetDeviceFileUnixDomainSocketFilePathA(LPCSTR lpName)
 
 	if (!lpFileName)
 	{
-		free(lpFilePath);
+		free(lpPipePath);
 		return NULL;
 	}
 

--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
@@ -244,6 +244,7 @@ int ntlm_fetch_ntlm_v2_hash(NTLM_CONTEXT* context, BYTE* hash)
 	}
 	else
 	{
+		SamClose(sam);
 		WLog_ERR(TAG, "Error: Could not find user in SAM database");
 		return 0;
 	}

--- a/winpr/libwinpr/utils/ntlm.c
+++ b/winpr/libwinpr/utils/ntlm.c
@@ -32,40 +32,38 @@
  * EndDefine
  */
 
-BYTE* NTOWFv1W(LPWSTR Password, UINT32 PasswordLength, BYTE* NtHash)
+BOOL NTOWFv1W(LPWSTR Password, UINT32 PasswordLength, BYTE* NtHash)
 {
-	BOOL allocate = !NtHash;
-
-	if (!Password)
-		return NULL;
-
-	if (!NtHash && !(NtHash = malloc(WINPR_MD4_DIGEST_LENGTH)))
-		return NULL;
+	if (!Password || !NtHash)
+		return FALSE;
 
 	if (!winpr_Digest(WINPR_MD_MD4, (BYTE*) Password, (size_t) PasswordLength, NtHash,
 	                  WINPR_MD4_DIGEST_LENGTH))
-	{
-		if (allocate)
-		{
-			free(NtHash);
-			NtHash = NULL;
-		}
-	}
+		return FALSE;
 
-	return NtHash;
+	return TRUE;
 }
 
-BYTE* NTOWFv1A(LPSTR Password, UINT32 PasswordLength, BYTE* NtHash)
+BOOL NTOWFv1A(LPSTR Password, UINT32 PasswordLength, BYTE* NtHash)
 {
 	LPWSTR PasswordW = NULL;
+	BOOL result = FALSE;
+
+	if (!NtHash)
+		return FALSE;
 
 	if (!(PasswordW = (LPWSTR) calloc(PasswordLength, 2)))
-		return NULL;
+		return FALSE;
 
 	MultiByteToWideChar(CP_ACP, 0, Password, PasswordLength, PasswordW, PasswordLength);
-	NtHash = NTOWFv1W(PasswordW, PasswordLength * 2, NtHash);
+
+	if (!NTOWFv1W(PasswordW, PasswordLength * 2, NtHash))
+		goto out_fail;
+
+	result = TRUE;
+out_fail:
 	free(PasswordW);
-	return NtHash;
+	return result;
 }
 
 /**
@@ -75,30 +73,21 @@ BYTE* NTOWFv1A(LPSTR Password, UINT32 PasswordLength, BYTE* NtHash)
  * EndDefine
  */
 
-BYTE* NTOWFv2W(LPWSTR Password, UINT32 PasswordLength, LPWSTR User,
-               UINT32 UserLength, LPWSTR Domain, UINT32 DomainLength, BYTE* NtHash)
+BOOL NTOWFv2W(LPWSTR Password, UINT32 PasswordLength, LPWSTR User,
+              UINT32 UserLength, LPWSTR Domain, UINT32 DomainLength, BYTE* NtHash)
 {
 	BYTE* buffer;
 	BYTE NtHashV1[16];
-	BYTE* result = NtHash;
+	BOOL result = FALSE;
 
-	if ((!User) || (!Password))
-		return NULL;
-
-	if (!NtHash && !(NtHash = (BYTE*) malloc(WINPR_MD4_DIGEST_LENGTH)))
-		return NULL;
+	if ((!User) || (!Password) || (!NtHash))
+		return FALSE;
 
 	if (!NTOWFv1W(Password, PasswordLength, NtHashV1))
-	{
-		free(NtHash);
-		return NULL;
-	}
+		return FALSE;
 
 	if (!(buffer = (BYTE*) malloc(UserLength + DomainLength)))
-	{
-		free(NtHash);
-		return NULL;
-	}
+		return FALSE;
 
 	/* Concatenate(UpperCase(User), Domain) */
 	CopyMemory(buffer, User, UserLength);
@@ -108,18 +97,25 @@ BYTE* NTOWFv2W(LPWSTR Password, UINT32 PasswordLength, LPWSTR User,
 	/* Compute the HMAC-MD5 hash of the above value using the NTLMv1 hash as the key, the result is the NTLMv2 hash */
 	if (!winpr_HMAC(WINPR_MD_MD5, NtHashV1, 16, buffer, UserLength + DomainLength, NtHash,
 	                WINPR_MD4_DIGEST_LENGTH))
-		result = NULL;
+		goto out_fail;
 
+	result = TRUE;
+out_fail:
 	free(buffer);
 	return result;
 }
 
-BYTE* NTOWFv2A(LPSTR Password, UINT32 PasswordLength, LPSTR User,
-               UINT32 UserLength, LPSTR Domain, UINT32 DomainLength, BYTE* NtHash)
+BOOL NTOWFv2A(LPSTR Password, UINT32 PasswordLength, LPSTR User,
+              UINT32 UserLength, LPSTR Domain, UINT32 DomainLength, BYTE* NtHash)
 {
 	LPWSTR UserW = NULL;
 	LPWSTR DomainW = NULL;
 	LPWSTR PasswordW = NULL;
+	BOOL result = FALSE;
+
+	if (!NtHash)
+		return FALSE;
+
 	UserW = (LPWSTR) calloc(UserLength, 2);
 	DomainW = (LPWSTR) calloc(DomainLength, 2);
 	PasswordW = (LPWSTR) calloc(PasswordLength, 2);
@@ -130,32 +126,30 @@ BYTE* NTOWFv2A(LPSTR Password, UINT32 PasswordLength, LPSTR User,
 	MultiByteToWideChar(CP_ACP, 0, User, UserLength, UserW, UserLength);
 	MultiByteToWideChar(CP_ACP, 0, Domain, DomainLength, DomainW, DomainLength);
 	MultiByteToWideChar(CP_ACP, 0, Password, PasswordLength, PasswordW, PasswordLength);
-	NtHash = NTOWFv2W(PasswordW, PasswordLength * 2, UserW, UserLength * 2, DomainW, DomainLength * 2,
-	                  NtHash);
+
+	if (!NTOWFv2W(PasswordW, PasswordLength * 2, UserW, UserLength * 2, DomainW, DomainLength * 2,
+	              NtHash))
+		goto out_fail;
+
+	result = TRUE;
 out_fail:
 	free(UserW);
 	free(DomainW);
 	free(PasswordW);
-	return NtHash;
+	return result;
 }
 
-BYTE* NTOWFv2FromHashW(BYTE* NtHashV1, LPWSTR User, UINT32 UserLength, LPWSTR Domain,
-                       UINT32 DomainLength, BYTE* NtHash)
+BOOL NTOWFv2FromHashW(BYTE* NtHashV1, LPWSTR User, UINT32 UserLength, LPWSTR Domain,
+                      UINT32 DomainLength, BYTE* NtHash)
 {
 	BYTE* buffer;
-	BYTE* result = NtHash;
+	BYTE result = FALSE;
 
-	if (!User)
-		return NULL;
-
-	if (!NtHash && !(NtHash = (BYTE*) malloc(WINPR_MD4_DIGEST_LENGTH)))
-		return NULL;
+	if (!User || !NtHash)
+		return FALSE;
 
 	if (!(buffer = (BYTE*) malloc(UserLength + DomainLength)))
-	{
-		free(NtHash);
-		return NULL;
-	}
+		return FALSE;
 
 	/* Concatenate(UpperCase(User), Domain) */
 	CopyMemory(buffer, User, UserLength);
@@ -169,17 +163,24 @@ BYTE* NTOWFv2FromHashW(BYTE* NtHashV1, LPWSTR User, UINT32 UserLength, LPWSTR Do
 	/* Compute the HMAC-MD5 hash of the above value using the NTLMv1 hash as the key, the result is the NTLMv2 hash */
 	if (!winpr_HMAC(WINPR_MD_MD5, NtHashV1, 16, buffer, UserLength + DomainLength, NtHash,
 	                WINPR_MD4_DIGEST_LENGTH))
-		result = NULL;
+		goto out_fail;
 
+	result = TRUE;
+out_fail:
 	free(buffer);
 	return result;
 }
 
-BYTE* NTOWFv2FromHashA(BYTE* NtHashV1, LPSTR User, UINT32 UserLength, LPSTR Domain,
-                       UINT32 DomainLength, BYTE* NtHash)
+BOOL NTOWFv2FromHashA(BYTE* NtHashV1, LPSTR User, UINT32 UserLength, LPSTR Domain,
+                      UINT32 DomainLength, BYTE* NtHash)
 {
 	LPWSTR UserW = NULL;
 	LPWSTR DomainW = NULL;
+	BOOL result = FALSE;
+
+	if (!NtHash)
+		return FALSE;
+
 	UserW = (LPWSTR) calloc(UserLength, 2);
 	DomainW = (LPWSTR) calloc(DomainLength, 2);
 
@@ -188,9 +189,13 @@ BYTE* NTOWFv2FromHashA(BYTE* NtHashV1, LPSTR User, UINT32 UserLength, LPSTR Doma
 
 	MultiByteToWideChar(CP_ACP, 0, User, UserLength, UserW, UserLength);
 	MultiByteToWideChar(CP_ACP, 0, Domain, DomainLength, DomainW, DomainLength);
-	NtHash = NTOWFv2FromHashW(NtHashV1, UserW, UserLength * 2, DomainW, DomainLength * 2, NtHash);
+
+	if (!NTOWFv2FromHashW(NtHashV1, UserW, UserLength * 2, DomainW, DomainLength * 2, NtHash))
+		goto out_fail;
+
+	result = TRUE;
 out_fail:
 	free(UserW);
 	free(DomainW);
-	return NtHash;
+	return result;
 }

--- a/winpr/libwinpr/utils/ntlm.c
+++ b/winpr/libwinpr/utils/ntlm.c
@@ -42,7 +42,8 @@ BYTE* NTOWFv1W(LPWSTR Password, UINT32 PasswordLength, BYTE* NtHash)
 	if (!NtHash && !(NtHash = malloc(WINPR_MD4_DIGEST_LENGTH)))
 		return NULL;
 
-	if (!winpr_Digest(WINPR_MD_MD4, (BYTE*) Password, (size_t) PasswordLength, NtHash, WINPR_MD4_DIGEST_LENGTH))
+	if (!winpr_Digest(WINPR_MD_MD4, (BYTE*) Password, (size_t) PasswordLength, NtHash,
+	                  WINPR_MD4_DIGEST_LENGTH))
 	{
 		if (allocate)
 		{
@@ -62,11 +63,8 @@ BYTE* NTOWFv1A(LPSTR Password, UINT32 PasswordLength, BYTE* NtHash)
 		return NULL;
 
 	MultiByteToWideChar(CP_ACP, 0, Password, PasswordLength, PasswordW, PasswordLength);
-
 	NtHash = NTOWFv1W(PasswordW, PasswordLength * 2, NtHash);
-
 	free(PasswordW);
-
 	return NtHash;
 }
 
@@ -78,7 +76,7 @@ BYTE* NTOWFv1A(LPSTR Password, UINT32 PasswordLength, BYTE* NtHash)
  */
 
 BYTE* NTOWFv2W(LPWSTR Password, UINT32 PasswordLength, LPWSTR User,
-		UINT32 UserLength, LPWSTR Domain, UINT32 DomainLength, BYTE* NtHash)
+               UINT32 UserLength, LPWSTR Domain, UINT32 DomainLength, BYTE* NtHash)
 {
 	BYTE* buffer;
 	BYTE NtHashV1[16];
@@ -103,27 +101,25 @@ BYTE* NTOWFv2W(LPWSTR Password, UINT32 PasswordLength, LPWSTR User,
 	}
 
 	/* Concatenate(UpperCase(User), Domain) */
-
 	CopyMemory(buffer, User, UserLength);
 	CharUpperBuffW((LPWSTR) buffer, UserLength / 2);
 	CopyMemory(&buffer[UserLength], Domain, DomainLength);
 
 	/* Compute the HMAC-MD5 hash of the above value using the NTLMv1 hash as the key, the result is the NTLMv2 hash */
-	if (!winpr_HMAC(WINPR_MD_MD5, NtHashV1, 16, buffer, UserLength + DomainLength, NtHash, WINPR_MD4_DIGEST_LENGTH))
+	if (!winpr_HMAC(WINPR_MD_MD5, NtHashV1, 16, buffer, UserLength + DomainLength, NtHash,
+	                WINPR_MD4_DIGEST_LENGTH))
 		result = NULL;
 
 	free(buffer);
-
 	return result;
 }
 
 BYTE* NTOWFv2A(LPSTR Password, UINT32 PasswordLength, LPSTR User,
-		UINT32 UserLength, LPSTR Domain, UINT32 DomainLength, BYTE* NtHash)
+               UINT32 UserLength, LPSTR Domain, UINT32 DomainLength, BYTE* NtHash)
 {
 	LPWSTR UserW = NULL;
 	LPWSTR DomainW = NULL;
 	LPWSTR PasswordW = NULL;
-
 	UserW = (LPWSTR) calloc(UserLength, 2);
 	DomainW = (LPWSTR) calloc(DomainLength, 2);
 	PasswordW = (LPWSTR) calloc(PasswordLength, 2);
@@ -134,18 +130,17 @@ BYTE* NTOWFv2A(LPSTR Password, UINT32 PasswordLength, LPSTR User,
 	MultiByteToWideChar(CP_ACP, 0, User, UserLength, UserW, UserLength);
 	MultiByteToWideChar(CP_ACP, 0, Domain, DomainLength, DomainW, DomainLength);
 	MultiByteToWideChar(CP_ACP, 0, Password, PasswordLength, PasswordW, PasswordLength);
-
-	NtHash = NTOWFv2W(PasswordW, PasswordLength * 2, UserW, UserLength * 2, DomainW, DomainLength * 2, NtHash);
-
+	NtHash = NTOWFv2W(PasswordW, PasswordLength * 2, UserW, UserLength * 2, DomainW, DomainLength * 2,
+	                  NtHash);
 out_fail:
 	free(UserW);
 	free(DomainW);
 	free(PasswordW);
-
 	return NtHash;
 }
 
-BYTE* NTOWFv2FromHashW(BYTE* NtHashV1, LPWSTR User, UINT32 UserLength, LPWSTR Domain, UINT32 DomainLength, BYTE* NtHash)
+BYTE* NTOWFv2FromHashW(BYTE* NtHashV1, LPWSTR User, UINT32 UserLength, LPWSTR Domain,
+                       UINT32 DomainLength, BYTE* NtHash)
 {
 	BYTE* buffer;
 	BYTE* result = NtHash;
@@ -163,7 +158,6 @@ BYTE* NTOWFv2FromHashW(BYTE* NtHashV1, LPWSTR User, UINT32 UserLength, LPWSTR Do
 	}
 
 	/* Concatenate(UpperCase(User), Domain) */
-
 	CopyMemory(buffer, User, UserLength);
 	CharUpperBuffW((LPWSTR) buffer, UserLength / 2);
 
@@ -173,19 +167,19 @@ BYTE* NTOWFv2FromHashW(BYTE* NtHashV1, LPWSTR User, UINT32 UserLength, LPWSTR Do
 	}
 
 	/* Compute the HMAC-MD5 hash of the above value using the NTLMv1 hash as the key, the result is the NTLMv2 hash */
-	if (!winpr_HMAC(WINPR_MD_MD5, NtHashV1, 16, buffer, UserLength + DomainLength, NtHash, WINPR_MD4_DIGEST_LENGTH))
+	if (!winpr_HMAC(WINPR_MD_MD5, NtHashV1, 16, buffer, UserLength + DomainLength, NtHash,
+	                WINPR_MD4_DIGEST_LENGTH))
 		result = NULL;
 
 	free(buffer);
-
 	return result;
 }
 
-BYTE* NTOWFv2FromHashA(BYTE* NtHashV1, LPSTR User, UINT32 UserLength, LPSTR Domain, UINT32 DomainLength, BYTE* NtHash)
+BYTE* NTOWFv2FromHashA(BYTE* NtHashV1, LPSTR User, UINT32 UserLength, LPSTR Domain,
+                       UINT32 DomainLength, BYTE* NtHash)
 {
 	LPWSTR UserW = NULL;
 	LPWSTR DomainW = NULL;
-
 	UserW = (LPWSTR) calloc(UserLength, 2);
 	DomainW = (LPWSTR) calloc(DomainLength, 2);
 
@@ -194,12 +188,9 @@ BYTE* NTOWFv2FromHashA(BYTE* NtHashV1, LPSTR User, UINT32 UserLength, LPSTR Doma
 
 	MultiByteToWideChar(CP_ACP, 0, User, UserLength, UserW, UserLength);
 	MultiByteToWideChar(CP_ACP, 0, Domain, DomainLength, DomainW, DomainLength);
-
 	NtHash = NTOWFv2FromHashW(NtHashV1, UserW, UserLength * 2, DomainW, DomainLength * 2, NtHash);
-
 out_fail:
 	free(UserW);
 	free(DomainW);
-
 	return NtHash;
 }

--- a/winpr/libwinpr/utils/wlog/UdpAppender.c
+++ b/winpr/libwinpr/utils/wlog/UdpAppender.c
@@ -81,6 +81,7 @@ static BOOL WLog_UdpAppender_Open(wLog* log, wLogAppender* appender)
 
 	memcpy(&udpAppender->targetAddr, result->ai_addr, result->ai_addrlen);
 	udpAppender->targetAddrLen = (int) result->ai_addrlen;
+	freeaddrinfo(result);
 	return TRUE;
 }
 

--- a/winpr/libwinpr/utils/wlog/UdpAppender.c
+++ b/winpr/libwinpr/utils/wlog/UdpAppender.c
@@ -33,7 +33,7 @@
 struct _wLogUdpAppender
 {
 	WLOG_APPENDER_COMMON();
-	char *host;
+	char* host;
 	struct sockaddr targetAddr;
 	int	targetAddrLen;
 	SOCKET sock;
@@ -42,12 +42,12 @@ typedef struct _wLogUdpAppender wLogUdpAppender;
 
 static BOOL WLog_UdpAppender_Open(wLog* log, wLogAppender* appender)
 {
-	wLogUdpAppender *udpAppender;
+	wLogUdpAppender* udpAppender;
 	char addressString[256];
 	struct addrinfo hints;
 	struct addrinfo* result;
 	int status, addrLen;
-	char *colonPos;
+	char* colonPos;
 
 	if (!appender)
 		return FALSE;
@@ -58,17 +58,18 @@ static BOOL WLog_UdpAppender_Open(wLog* log, wLogAppender* appender)
 		return TRUE;
 
 	colonPos = strchr(udpAppender->host, ':');
+
 	if (!colonPos)
 		return FALSE;
-	addrLen = (int) (colonPos - udpAppender->host);
+
+	addrLen = (int)(colonPos - udpAppender->host);
 	memcpy(addressString, udpAppender->host, addrLen);
 	addressString[addrLen] = '\0';
-
 	ZeroMemory(&hints, sizeof(hints));
 	hints.ai_family = AF_INET;
 	hints.ai_socktype = SOCK_DGRAM;
+	status = getaddrinfo(addressString, colonPos + 1, &hints, &result);
 
-	status = getaddrinfo(addressString, colonPos+1, &hints, &result);
 	if (status != 0)
 		return FALSE;
 
@@ -80,7 +81,6 @@ static BOOL WLog_UdpAppender_Open(wLog* log, wLogAppender* appender)
 
 	memcpy(&udpAppender->targetAddr, result->ai_addr, result->ai_addrlen);
 	udpAppender->targetAddrLen = (int) result->ai_addrlen;
-
 	return TRUE;
 }
 
@@ -95,29 +95,24 @@ static BOOL WLog_UdpAppender_Close(wLog* log, wLogAppender* appender)
 static BOOL WLog_UdpAppender_WriteMessage(wLog* log, wLogAppender* appender, wLogMessage* message)
 {
 	char prefix[WLOG_MAX_PREFIX_SIZE];
-	wLogUdpAppender *udpAppender;
-
+	wLogUdpAppender* udpAppender;
 
 	if (!log || !appender || !message)
 		return FALSE;
 
-	udpAppender = (wLogUdpAppender *)appender;
-
+	udpAppender = (wLogUdpAppender*)appender;
 	message->PrefixString = prefix;
 	WLog_Layout_GetMessagePrefix(log, appender->Layout, message);
-
 	_sendto(udpAppender->sock, message->PrefixString, strlen(message->PrefixString),
-				0, &udpAppender->targetAddr, udpAppender->targetAddrLen);
-
+	        0, &udpAppender->targetAddr, udpAppender->targetAddrLen);
 	_sendto(udpAppender->sock, message->TextString, strlen(message->TextString),
-						0, &udpAppender->targetAddr, udpAppender->targetAddrLen);
-
+	        0, &udpAppender->targetAddr, udpAppender->targetAddrLen);
 	_sendto(udpAppender->sock, "\n", 1, 0, &udpAppender->targetAddr, udpAppender->targetAddrLen);
-
 	return TRUE;
 }
 
-static BOOL WLog_UdpAppender_WriteDataMessage(wLog* log, wLogAppender* appender, wLogMessage* message)
+static BOOL WLog_UdpAppender_WriteDataMessage(wLog* log, wLogAppender* appender,
+        wLogMessage* message)
 {
 	if (!log || !appender || !message)
 		return FALSE;
@@ -125,18 +120,18 @@ static BOOL WLog_UdpAppender_WriteDataMessage(wLog* log, wLogAppender* appender,
 	return TRUE;
 }
 
-static BOOL WLog_UdpAppender_WriteImageMessage(wLog* log, wLogAppender* appender, wLogMessage* message)
+static BOOL WLog_UdpAppender_WriteImageMessage(wLog* log, wLogAppender* appender,
+        wLogMessage* message)
 {
 	if (!log || !appender || !message)
 		return FALSE;
 
-
 	return TRUE;
 }
 
-static BOOL WLog_UdpAppender_Set(wLogAppender* appender, const char *setting, void *value)
+static BOOL WLog_UdpAppender_Set(wLogAppender* appender, const char* setting, void* value)
 {
-	wLogUdpAppender *udpAppender = (wLogUdpAppender *)appender;
+	wLogUdpAppender* udpAppender = (wLogUdpAppender*)appender;
 
 	if (!value || !strlen(value))
 		return FALSE;
@@ -145,24 +140,28 @@ static BOOL WLog_UdpAppender_Set(wLogAppender* appender, const char *setting, vo
 		return FALSE;
 
 	udpAppender->targetAddrLen = 0;
+
 	if (udpAppender->host)
 		free(udpAppender->host);
 
-	udpAppender->host = _strdup((const char *)value);
+	udpAppender->host = _strdup((const char*)value);
 	return (udpAppender->host != NULL) && WLog_UdpAppender_Open(NULL, appender);
 }
 
 static void WLog_UdpAppender_Free(wLogAppender* appender)
 {
 	wLogUdpAppender* udpAppender;
+
 	if (appender)
 	{
-		udpAppender = (wLogUdpAppender *)appender;
+		udpAppender = (wLogUdpAppender*)appender;
+
 		if (udpAppender->sock != INVALID_SOCKET)
 		{
 			closesocket(udpAppender->sock);
 			udpAppender->sock = INVALID_SOCKET;
 		}
+
 		free(udpAppender->host);
 		free(udpAppender);
 	}
@@ -173,13 +172,12 @@ wLogAppender* WLog_UdpAppender_New(wLog* log)
 	wLogUdpAppender* appender;
 	DWORD nSize;
 	LPCSTR name;
-
 	appender = (wLogUdpAppender*) calloc(1, sizeof(wLogUdpAppender));
+
 	if (!appender)
 		return NULL;
 
 	appender->Type = WLOG_APPENDER_UDP;
-
 	appender->Open = WLog_UdpAppender_Open;
 	appender->Close = WLog_UdpAppender_Close;
 	appender->WriteMessage = WLog_UdpAppender_WriteMessage;
@@ -187,34 +185,36 @@ wLogAppender* WLog_UdpAppender_New(wLog* log)
 	appender->WriteImageMessage = WLog_UdpAppender_WriteImageMessage;
 	appender->Free = WLog_UdpAppender_Free;
 	appender->Set = WLog_UdpAppender_Set;
-
 	appender->sock = _socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+
 	if (appender->sock == INVALID_SOCKET)
 		goto error_sock;
 
 	name = "WLOG_UDP_TARGET";
 	nSize = GetEnvironmentVariableA(name, NULL, 0);
+
 	if (nSize)
 	{
 		appender->host = (LPSTR) malloc(nSize);
+
 		if (!appender->host)
 			goto error_open;
 
 		if (GetEnvironmentVariableA(name, appender->host, nSize) != nSize - 1)
 			goto error_open;
 
-		if (!WLog_UdpAppender_Open(log, (wLogAppender *)appender))
+		if (!WLog_UdpAppender_Open(log, (wLogAppender*)appender))
 			goto error_open;
 	}
 	else
 	{
 		appender->host = _strdup("127.0.0.1:20000");
+
 		if (!appender->host)
 			goto error_open;
 	}
 
 	return (wLogAppender*)appender;
-
 error_open:
 	free(appender->host);
 	closesocket(appender->sock);

--- a/winpr/libwinpr/winsock/winsock.c
+++ b/winpr/libwinpr/winsock/winsock.c
@@ -1225,7 +1225,7 @@ SOCKET _socket(int af, int type, int protocol)
 	SOCKET s;
 	fd = socket(af, type, protocol);
 
-	if (fd < 1)
+	if (fd < 0)
 		return INVALID_SOCKET;
 
 	s = (SOCKET) fd;

--- a/winpr/libwinpr/winsock/winsock.c
+++ b/winpr/libwinpr/winsock/winsock.c
@@ -47,7 +47,7 @@
 
 /**
  * ws2_32.dll:
- * 
+ *
  * __WSAFDIsSet
  * accept
  * bind
@@ -239,23 +239,21 @@ PCSTR winpr_inet_ntop(INT Family, PVOID pAddr, PSTR pStringBuf, size_t StringBuf
 	if (Family == AF_INET)
 	{
 		struct sockaddr_in in;
-
 		memset(&in, 0, sizeof(in));
 		in.sin_family = AF_INET;
 		memcpy(&in.sin_addr, pAddr, sizeof(struct in_addr));
-		getnameinfo((struct sockaddr*) &in, sizeof(struct sockaddr_in), pStringBuf, StringBufSize, NULL, 0, NI_NUMERICHOST);
-
+		getnameinfo((struct sockaddr*) &in, sizeof(struct sockaddr_in), pStringBuf, StringBufSize, NULL, 0,
+		            NI_NUMERICHOST);
 		return pStringBuf;
 	}
 	else if (Family == AF_INET6)
 	{
 		struct sockaddr_in6 in;
-
 		memset(&in, 0, sizeof(in));
 		in.sin6_family = AF_INET6;
 		memcpy(&in.sin6_addr, pAddr, sizeof(struct in_addr6));
-		getnameinfo((struct sockaddr*) &in, sizeof(struct sockaddr_in6), pStringBuf, StringBufSize, NULL, 0, NI_NUMERICHOST);
-
+		getnameinfo((struct sockaddr*) &in, sizeof(struct sockaddr_in6), pStringBuf, StringBufSize, NULL, 0,
+		            NI_NUMERICHOST);
 		return pStringBuf;
 	}
 
@@ -270,7 +268,8 @@ INT winpr_inet_pton(INT Family, PCSTR pszAddrString, PVOID pAddrBuf)
 	if ((Family != AF_INET) && (Family != AF_INET6))
 		return -1;
 
-	if (WSAStringToAddressA((char*) pszAddrString, Family, NULL, (struct sockaddr*) &addr, &addr_len) != 0)
+	if (WSAStringToAddressA((char*) pszAddrString, Family, NULL, (struct sockaddr*) &addr,
+	                        &addr_len) != 0)
 		return 0;
 
 	if (Family == AF_INET)
@@ -305,10 +304,8 @@ INT winpr_inet_pton(INT Family, PCSTR pszAddrString, PVOID pAddrBuf)
 int WSAStartup(WORD wVersionRequired, LPWSADATA lpWSAData)
 {
 	ZeroMemory(lpWSAData, sizeof(WSADATA));
-
 	lpWSAData->wVersion = wVersionRequired;
 	lpWSAData->wHighVersion = MAKEWORD(2, 2);
-
 	return 0; /* success */
 }
 
@@ -322,22 +319,26 @@ void WSASetLastError(int iError)
 	switch (iError)
 	{
 		/* Base error codes */
-
 		case WSAEINTR:
 			errno = EINTR;
 			break;
+
 		case WSAEBADF:
 			errno = EBADF;
 			break;
+
 		case WSAEACCES:
 			errno = EACCES;
 			break;
+
 		case WSAEFAULT:
 			errno = EFAULT;
 			break;
+
 		case WSAEINVAL:
 			errno = EINVAL;
 			break;
+
 		case WSAEMFILE:
 			errno = EMFILE;
 			break;
@@ -347,113 +348,149 @@ void WSASetLastError(int iError)
 		case WSAEWOULDBLOCK:
 			errno = EWOULDBLOCK;
 			break;
+
 		case WSAEINPROGRESS:
 			errno = EINPROGRESS;
 			break;
+
 		case WSAEALREADY:
 			errno = EALREADY;
 			break;
+
 		case WSAENOTSOCK:
 			errno = ENOTSOCK;
 			break;
+
 		case WSAEDESTADDRREQ:
 			errno = EDESTADDRREQ;
 			break;
+
 		case WSAEMSGSIZE:
 			errno = EMSGSIZE;
 			break;
+
 		case WSAEPROTOTYPE:
 			errno = EPROTOTYPE;
 			break;
+
 		case WSAENOPROTOOPT:
 			errno = ENOPROTOOPT;
 			break;
+
 		case WSAEPROTONOSUPPORT:
 			errno = EPROTONOSUPPORT;
 			break;
+
 		case WSAESOCKTNOSUPPORT:
 			errno = ESOCKTNOSUPPORT;
 			break;
+
 		case WSAEOPNOTSUPP:
 			errno = EOPNOTSUPP;
 			break;
+
 		case WSAEPFNOSUPPORT:
 			errno = EPFNOSUPPORT;
 			break;
+
 		case WSAEAFNOSUPPORT:
 			errno = EAFNOSUPPORT;
 			break;
+
 		case WSAEADDRINUSE:
 			errno = EADDRINUSE;
 			break;
+
 		case WSAEADDRNOTAVAIL:
 			errno = EADDRNOTAVAIL;
 			break;
+
 		case WSAENETDOWN:
 			errno = ENETDOWN;
 			break;
+
 		case WSAENETUNREACH:
 			errno = ENETUNREACH;
 			break;
+
 		case WSAENETRESET:
 			errno = ENETRESET;
 			break;
+
 		case WSAECONNABORTED:
 			errno = ECONNABORTED;
 			break;
+
 		case WSAECONNRESET:
 			errno = ECONNRESET;
 			break;
+
 		case WSAENOBUFS:
 			errno = ENOBUFS;
 			break;
+
 		case WSAEISCONN:
 			errno = EISCONN;
 			break;
+
 		case WSAENOTCONN:
 			errno = ENOTCONN;
 			break;
+
 		case WSAESHUTDOWN:
 			errno = ESHUTDOWN;
 			break;
+
 		case WSAETOOMANYREFS:
 			errno = ETOOMANYREFS;
 			break;
+
 		case WSAETIMEDOUT:
 			errno = ETIMEDOUT;
 			break;
+
 		case WSAECONNREFUSED:
 			errno = ECONNREFUSED;
 			break;
+
 		case WSAELOOP:
 			errno = ELOOP;
 			break;
+
 		case WSAENAMETOOLONG:
 			errno = ENAMETOOLONG;
 			break;
+
 		case WSAEHOSTDOWN:
 			errno = EHOSTDOWN;
 			break;
+
 		case WSAEHOSTUNREACH:
 			errno = EHOSTUNREACH;
 			break;
+
 		case WSAENOTEMPTY:
 			errno = ENOTEMPTY;
 			break;
 #ifdef EPROCLIM
+
 		case WSAEPROCLIM:
 			errno = EPROCLIM;
 			break;
 #endif
+
 		case WSAEUSERS:
 			errno = EUSERS;
 			break;
+
 		case WSAEDQUOT:
 			errno = EDQUOT;
 			break;
+
 		case WSAESTALE:
 			errno = ESTALE;
 			break;
+
 		case WSAEREMOTE:
 			errno = EREMOTE;
 			break;
@@ -467,22 +504,26 @@ int WSAGetLastError(void)
 	switch (errno)
 	{
 		/* Base error codes */
-
 		case EINTR:
 			iError = WSAEINTR;
 			break;
+
 		case EBADF:
 			iError = WSAEBADF;
 			break;
+
 		case EACCES:
 			iError = WSAEACCES;
 			break;
+
 		case EFAULT:
 			iError = WSAEFAULT;
 			break;
+
 		case EINVAL:
 			iError = WSAEINVAL;
 			break;
+
 		case EMFILE:
 			iError = WSAEMFILE;
 			break;
@@ -492,126 +533,161 @@ int WSAGetLastError(void)
 		case EWOULDBLOCK:
 			iError = WSAEWOULDBLOCK;
 			break;
+
 		case EINPROGRESS:
 			iError = WSAEINPROGRESS;
 			break;
+
 		case EALREADY:
 			iError = WSAEALREADY;
 			break;
+
 		case ENOTSOCK:
 			iError = WSAENOTSOCK;
 			break;
+
 		case EDESTADDRREQ:
 			iError = WSAEDESTADDRREQ;
 			break;
+
 		case EMSGSIZE:
 			iError = WSAEMSGSIZE;
 			break;
+
 		case EPROTOTYPE:
 			iError = WSAEPROTOTYPE;
 			break;
+
 		case ENOPROTOOPT:
 			iError = WSAENOPROTOOPT;
 			break;
+
 		case EPROTONOSUPPORT:
 			iError = WSAEPROTONOSUPPORT;
 			break;
+
 		case ESOCKTNOSUPPORT:
 			iError = WSAESOCKTNOSUPPORT;
 			break;
+
 		case EOPNOTSUPP:
 			iError = WSAEOPNOTSUPP;
 			break;
+
 		case EPFNOSUPPORT:
 			iError = WSAEPFNOSUPPORT;
 			break;
+
 		case EAFNOSUPPORT:
 			iError = WSAEAFNOSUPPORT;
 			break;
+
 		case EADDRINUSE:
 			iError = WSAEADDRINUSE;
 			break;
+
 		case EADDRNOTAVAIL:
 			iError = WSAEADDRNOTAVAIL;
 			break;
+
 		case ENETDOWN:
 			iError = WSAENETDOWN;
 			break;
+
 		case ENETUNREACH:
 			iError = WSAENETUNREACH;
 			break;
+
 		case ENETRESET:
 			iError = WSAENETRESET;
 			break;
+
 		case ECONNABORTED:
 			iError = WSAECONNABORTED;
 			break;
+
 		case ECONNRESET:
 			iError = WSAECONNRESET;
 			break;
+
 		case ENOBUFS:
 			iError = WSAENOBUFS;
 			break;
+
 		case EISCONN:
 			iError = WSAEISCONN;
 			break;
+
 		case ENOTCONN:
 			iError = WSAENOTCONN;
 			break;
+
 		case ESHUTDOWN:
 			iError = WSAESHUTDOWN;
 			break;
+
 		case ETOOMANYREFS:
 			iError = WSAETOOMANYREFS;
 			break;
+
 		case ETIMEDOUT:
 			iError = WSAETIMEDOUT;
 			break;
+
 		case ECONNREFUSED:
 			iError = WSAECONNREFUSED;
 			break;
+
 		case ELOOP:
 			iError = WSAELOOP;
 			break;
+
 		case ENAMETOOLONG:
 			iError = WSAENAMETOOLONG;
 			break;
+
 		case EHOSTDOWN:
 			iError = WSAEHOSTDOWN;
 			break;
+
 		case EHOSTUNREACH:
 			iError = WSAEHOSTUNREACH;
 			break;
+
 		case ENOTEMPTY:
 			iError = WSAENOTEMPTY;
 			break;
 #ifdef EPROCLIM
+
 		case EPROCLIM:
 			iError = WSAEPROCLIM;
 			break;
 #endif
+
 		case EUSERS:
 			iError = WSAEUSERS;
 			break;
+
 		case EDQUOT:
 			iError = WSAEDQUOT;
 			break;
+
 		case ESTALE:
 			iError = WSAESTALE;
 			break;
+
 		case EREMOTE:
 			iError = WSAEREMOTE;
 			break;
-
-		/* Special cases */
-
+			/* Special cases */
 #if (EAGAIN != EWOULDBLOCK)
+
 		case EAGAIN:
 			iError = WSAEWOULDBLOCK;
 			break;
 #endif
-
 #if defined(EPROTO)
+
 		case EPROTO:
 			iError = WSAECONNRESET;
 			break;
@@ -637,7 +713,6 @@ int WSAGetLastError(void)
 	 * WSA_E_CANCELLED
 	 * WSAEREFUSED
 	 */
-
 	return iError;
 }
 
@@ -661,7 +736,6 @@ BOOL WSAResetEvent(HANDLE hEvent)
 BOOL WSACloseEvent(HANDLE hEvent)
 {
 	BOOL status;
-
 	status = CloseHandle(hEvent);
 
 	if (!status)
@@ -683,6 +757,7 @@ int WSAEventSelect(SOCKET s, WSAEVENT hEventObject, LONG lNetworkEvents)
 
 	if (lNetworkEvents & FD_READ)
 		mode |= WINPR_FD_READ;
+
 	if (lNetworkEvents & FD_WRITE)
 		mode |= WINPR_FD_WRITE;
 
@@ -692,29 +767,30 @@ int WSAEventSelect(SOCKET s, WSAEVENT hEventObject, LONG lNetworkEvents)
 	return 0;
 }
 
-DWORD WSAWaitForMultipleEvents(DWORD cEvents, const HANDLE* lphEvents, BOOL fWaitAll, DWORD dwTimeout, BOOL fAlertable)
+DWORD WSAWaitForMultipleEvents(DWORD cEvents, const HANDLE* lphEvents, BOOL fWaitAll,
+                               DWORD dwTimeout, BOOL fAlertable)
 {
 	return WaitForMultipleObjectsEx(cEvents, lphEvents, fWaitAll, dwTimeout, fAlertable);
 }
 
-SOCKET WSASocketA(int af, int type, int protocol, LPWSAPROTOCOL_INFOA lpProtocolInfo, GROUP g, DWORD dwFlags)
+SOCKET WSASocketA(int af, int type, int protocol, LPWSAPROTOCOL_INFOA lpProtocolInfo, GROUP g,
+                  DWORD dwFlags)
 {
 	SOCKET s;
-
 	s = _socket(af, type, protocol);
-
 	return s;
 }
 
-SOCKET WSASocketW(int af, int type, int protocol, LPWSAPROTOCOL_INFOW lpProtocolInfo, GROUP g, DWORD dwFlags)
+SOCKET WSASocketW(int af, int type, int protocol, LPWSAPROTOCOL_INFOW lpProtocolInfo, GROUP g,
+                  DWORD dwFlags)
 {
 	return WSASocketA(af, type, protocol, (LPWSAPROTOCOL_INFOA) lpProtocolInfo, g, dwFlags);
 }
 
 int WSAIoctl(SOCKET s, DWORD dwIoControlCode, LPVOID lpvInBuffer,
-		DWORD cbInBuffer, LPVOID lpvOutBuffer, DWORD cbOutBuffer,
-		LPDWORD lpcbBytesReturned, LPWSAOVERLAPPED lpOverlapped,
-		LPWSAOVERLAPPED_COMPLETION_ROUTINE lpCompletionRoutine)
+             DWORD cbInBuffer, LPVOID lpvOutBuffer, DWORD cbOutBuffer,
+             LPDWORD lpcbBytesReturned, LPWSAOVERLAPPED lpOverlapped,
+             LPWSAOVERLAPPED_COMPLETION_ROUTINE lpCompletionRoutine)
 {
 	int fd;
 	int index;
@@ -736,7 +812,7 @@ int WSAIoctl(SOCKET s, DWORD dwIoControlCode, LPVOID lpvInBuffer,
 	struct sockaddr_in* pNetmask;
 
 	if ((dwIoControlCode != SIO_GET_INTERFACE_LIST) ||
-		(!lpvOutBuffer || !cbOutBuffer || !lpcbBytesReturned))
+	    (!lpvOutBuffer || !cbOutBuffer || !lpcbBytesReturned))
 	{
 		WSASetLastError(WSAEINVAL);
 		return SOCKET_ERROR;
@@ -745,7 +821,6 @@ int WSAIoctl(SOCKET s, DWORD dwIoControlCode, LPVOID lpvInBuffer,
 	fd = (int) s;
 	pInterfaces = (INTERFACE_INFO*) lpvOutBuffer;
 	maxNumInterfaces = cbOutBuffer / sizeof(INTERFACE_INFO);
-
 #ifdef WSAIOCTL_IFADDRS
 	{
 		struct ifaddrs* ifa = NULL;
@@ -766,7 +841,6 @@ int WSAIoctl(SOCKET s, DWORD dwIoControlCode, LPVOID lpvInBuffer,
 			pAddress = (struct sockaddr_in*) &pInterface->iiAddress;
 			pBroadcast = (struct sockaddr_in*) &pInterface->iiBroadcastAddress;
 			pNetmask = (struct sockaddr_in*) &pInterface->iiNetmask;
-
 			nFlags = 0;
 
 			if (ifa->ifa_flags & IFF_UP)
@@ -792,8 +866,7 @@ int WSAIoctl(SOCKET s, DWORD dwIoControlCode, LPVOID lpvInBuffer,
 					continue;
 
 				getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr),
-						address, sizeof(address), 0, 0, NI_NUMERICHOST);
-
+				            address, sizeof(address), 0, 0, NI_NUMERICHOST);
 				inet_pton(ifa->ifa_addr->sa_family, address, (void*) &pAddress->sin_addr);
 			}
 			else
@@ -807,8 +880,7 @@ int WSAIoctl(SOCKET s, DWORD dwIoControlCode, LPVOID lpvInBuffer,
 					continue;
 
 				getnameinfo(ifa->ifa_dstaddr, sizeof(struct sockaddr),
-						broadcast, sizeof(broadcast), 0, 0, NI_NUMERICHOST);
-
+				            broadcast, sizeof(broadcast), 0, 0, NI_NUMERICHOST);
 				inet_pton(ifa->ifa_dstaddr->sa_family, broadcast, (void*) &pBroadcast->sin_addr);
 			}
 			else
@@ -822,8 +894,7 @@ int WSAIoctl(SOCKET s, DWORD dwIoControlCode, LPVOID lpvInBuffer,
 					continue;
 
 				getnameinfo(ifa->ifa_netmask, sizeof(struct sockaddr),
-						netmask, sizeof(netmask), 0, 0, NI_NUMERICHOST);
-
+				            netmask, sizeof(netmask), 0, 0, NI_NUMERICHOST);
 				inet_pton(ifa->ifa_netmask->sa_family, netmask, (void*) &pNetmask->sin_addr);
 			}
 			else
@@ -835,14 +906,11 @@ int WSAIoctl(SOCKET s, DWORD dwIoControlCode, LPVOID lpvInBuffer,
 			index++;
 		}
 
-		*lpcbBytesReturned = (DWORD) (numInterfaces * sizeof(INTERFACE_INFO));
-
+		*lpcbBytesReturned = (DWORD)(numInterfaces * sizeof(INTERFACE_INFO));
 		freeifaddrs(ifap);
-
 		return 0;
 	}
 #endif
-
 	ifconf.ifc_len = sizeof(buffer);
 	ifconf.ifc_buf = buffer;
 
@@ -893,8 +961,7 @@ int WSAIoctl(SOCKET s, DWORD dwIoControlCode, LPVOID lpvInBuffer,
 			goto next_ifreq;
 
 		getnameinfo(&ifreq->ifr_addr, sizeof(ifreq->ifr_addr),
-				address, sizeof(address), 0, 0, NI_NUMERICHOST);
-
+		            address, sizeof(address), 0, 0, NI_NUMERICHOST);
 		inet_pton(ifreq->ifr_addr.sa_family, address, (void*) &pAddress->sin_addr);
 
 		if (ioctl(fd, SIOCGIFBRDADDR, ifreq) != 0)
@@ -904,8 +971,7 @@ int WSAIoctl(SOCKET s, DWORD dwIoControlCode, LPVOID lpvInBuffer,
 			goto next_ifreq;
 
 		getnameinfo(&ifreq->ifr_addr, sizeof(ifreq->ifr_addr),
-				broadcast, sizeof(broadcast), 0, 0, NI_NUMERICHOST);
-
+		            broadcast, sizeof(broadcast), 0, 0, NI_NUMERICHOST);
 		inet_pton(ifreq->ifr_addr.sa_family, broadcast, (void*) &pBroadcast->sin_addr);
 
 		if (ioctl(fd, SIOCGIFNETMASK, ifreq) != 0)
@@ -915,27 +981,21 @@ int WSAIoctl(SOCKET s, DWORD dwIoControlCode, LPVOID lpvInBuffer,
 			goto next_ifreq;
 
 		getnameinfo(&ifreq->ifr_addr, sizeof(ifreq->ifr_addr),
-				netmask, sizeof(netmask), 0, 0, NI_NUMERICHOST);
-
+		            netmask, sizeof(netmask), 0, 0, NI_NUMERICHOST);
 		inet_pton(ifreq->ifr_addr.sa_family, netmask, (void*) &pNetmask->sin_addr);
-
 		numInterfaces++;
-
-next_ifreq:
-
+	next_ifreq:
 #if !defined(__linux__) && !defined(__sun__) && !defined(__CYGWIN__)
 		ifreq_len = IFNAMSIZ + ifreq->ifr_addr.sa_len;
 #else
 		ifreq_len = sizeof(*ifreq);
 #endif
-
-		ifreq = (struct ifreq*) &((BYTE*) ifreq)[ifreq_len];
+		ifreq = (struct ifreq*) & ((BYTE*) ifreq)[ifreq_len];
 		offset += ifreq_len;
 		index++;
 	}
 
-	*lpcbBytesReturned = (DWORD) (numInterfaces * sizeof(INTERFACE_INFO));
-
+	*lpcbBytesReturned = (DWORD)(numInterfaces * sizeof(INTERFACE_INFO));
 	return 0;
 }
 
@@ -943,11 +1003,9 @@ SOCKET _accept(SOCKET s, struct sockaddr* addr, int* addrlen)
 {
 	int status;
 	int fd = (int) s;
-	socklen_t s_addrlen = (socklen_t) *addrlen;
-
+	socklen_t s_addrlen = (socklen_t) * addrlen;
 	status = accept(fd, addr, &s_addrlen);
 	*addrlen = (socklen_t) s_addrlen;
-
 	return status;
 }
 
@@ -955,7 +1013,6 @@ int _bind(SOCKET s, const struct sockaddr* addr, int namelen)
 {
 	int status;
 	int fd = (int) s;
-
 	status = bind(fd, addr, (socklen_t) namelen);
 
 	if (status < 0)
@@ -968,9 +1025,7 @@ int closesocket(SOCKET s)
 {
 	int status;
 	int fd = (int) s;
-
 	status = close(fd);
-
 	return status;
 }
 
@@ -978,7 +1033,6 @@ int _connect(SOCKET s, const struct sockaddr* name, int namelen)
 {
 	int status;
 	int fd = (int) s;
-
 	status = connect(fd, name, (socklen_t) namelen);
 
 	if (status < 0)
@@ -1016,11 +1070,9 @@ int _getpeername(SOCKET s, struct sockaddr* name, int* namelen)
 {
 	int status;
 	int fd = (int) s;
-	socklen_t s_namelen = (socklen_t) *namelen;
-
+	socklen_t s_namelen = (socklen_t) * namelen;
 	status = getpeername(fd, name, &s_namelen);
 	*namelen = (int) s_namelen;
-
 	return status;
 }
 
@@ -1028,11 +1080,9 @@ int _getsockname(SOCKET s, struct sockaddr* name, int* namelen)
 {
 	int status;
 	int fd = (int) s;
-	socklen_t s_namelen = (socklen_t) *namelen;
-
+	socklen_t s_namelen = (socklen_t) * namelen;
 	status = getsockname(fd, name, &s_namelen);
 	*namelen = (int) s_namelen;
-
 	return status;
 }
 
@@ -1040,11 +1090,9 @@ int _getsockopt(SOCKET s, int level, int optname, char* optval, int* optlen)
 {
 	int status;
 	int fd = (int) s;
-	socklen_t s_optlen = (socklen_t) *optlen;
-
+	socklen_t s_optlen = (socklen_t) * optlen;
 	status = getsockopt(fd, level, optname, (void*) optval, &s_optlen);
 	*optlen = (socklen_t) s_optlen;
-
 	return status;
 }
 
@@ -1072,9 +1120,7 @@ int _listen(SOCKET s, int backlog)
 {
 	int status;
 	int fd = (int) s;
-
 	status = listen(fd, backlog);
-
 	return status;
 }
 
@@ -1092,9 +1138,7 @@ int _recv(SOCKET s, char* buf, int len, int flags)
 {
 	int status;
 	int fd = (int) s;
-
 	status = (int) recv(fd, (void*) buf, (size_t) len, flags);
-
 	return status;
 }
 
@@ -1102,15 +1146,14 @@ int _recvfrom(SOCKET s, char* buf, int len, int flags, struct sockaddr* from, in
 {
 	int status;
 	int fd = (int) s;
-	socklen_t s_fromlen = (socklen_t) *fromlen;
-
+	socklen_t s_fromlen = (socklen_t) * fromlen;
 	status = (int) recvfrom(fd, (void*) buf, (size_t) len, flags, from, &s_fromlen);
 	*fromlen = (int) s_fromlen;
-
 	return status;
 }
 
-int _select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, const struct timeval* timeout)
+int _select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds,
+            const struct timeval* timeout)
 {
 	int status;
 
@@ -1127,11 +1170,8 @@ int _send(SOCKET s, const char* buf, int len, int flags)
 {
 	int status;
 	int fd = (int) s;
-
 	flags |= MSG_NOSIGNAL;
-
 	status = (int) send(fd, (void*) buf, (size_t) len, flags);
-
 	return status;
 }
 
@@ -1139,9 +1179,7 @@ int _sendto(SOCKET s, const char* buf, int len, int flags, const struct sockaddr
 {
 	int status;
 	int fd = (int) s;
-
 	status = (int) sendto(fd, (void*) buf, (size_t) len, flags, to, (socklen_t) tolen);
-
 	return status;
 }
 
@@ -1149,9 +1187,7 @@ int _setsockopt(SOCKET s, int level, int optname, const char* optval, int optlen
 {
 	int status;
 	int fd = (int) s;
-
 	status = setsockopt(fd, level, optname, (void*) optval, (socklen_t) optlen);
-
 	return status;
 }
 
@@ -1180,7 +1216,6 @@ int _shutdown(SOCKET s, int how)
 		return SOCKET_ERROR;
 
 	status = shutdown(fd, s_how);
-
 	return status;
 }
 
@@ -1188,77 +1223,61 @@ SOCKET _socket(int af, int type, int protocol)
 {
 	int fd;
 	SOCKET s;
-
 	fd = socket(af, type, protocol);
 
 	if (fd < 1)
 		return INVALID_SOCKET;
 
 	s = (SOCKET) fd;
-
 	return s;
 }
 
 struct hostent* _gethostbyaddr(const char* addr, int len, int type)
 {
 	struct hostent* host;
-
 	host = gethostbyaddr((void*) addr, (socklen_t) len, type);
-
 	return host;
 }
 
 struct hostent* _gethostbyname(const char* name)
 {
 	struct hostent* host;
-
 	host = gethostbyname(name);
-
 	return host;
 }
 
 int _gethostname(char* name, int namelen)
 {
 	int status;
-
 	status = gethostname(name, (size_t) namelen);
-
 	return status;
 }
 
 struct servent* _getservbyport(int port, const char* proto)
 {
 	struct servent* serv;
-
 	serv = getservbyport(port, proto);
-
 	return serv;
 }
 
 struct servent* _getservbyname(const char* name, const char* proto)
 {
 	struct servent* serv;
-
 	serv = getservbyname(name, proto);
-
 	return serv;
 }
 
 struct protoent* _getprotobynumber(int number)
 {
 	struct protoent* proto;
-
 	proto = getprotobynumber(number);
-
 	return proto;
 }
 
 struct protoent* _getprotobyname(const char* name)
 {
 	struct protoent* proto;
-
 	proto = getprotobyname(name);
-
 	return proto;
 }
 


### PR DESCRIPTION
Here is a bunch of fixes based on covscan results. The most of them fix leaks in various corner-cases, but there are also some fixes for potential buffer overflow, usage of released memory...

The set of patches in this branch eliminates 131 defects marked as important from the [scan-results-imp.err](https://github.com/FreeRDP/FreeRDP/files/2306685/scan-results-imp.err.before.txt) generated for commit 735ab2e8b22840c33d5cab368ac168243e96f33e.

However, there are still some remaining issues, which I think are mostly false positives, see [scan-results-imp.err](https://github.com/FreeRDP/FreeRDP/files/2306753/scan-results-imp.err.after.txt) for this branch, but there are some which are worth to be investigated (i.e. the one with `USE_AFTER_FREE`) where I am not sure how to fix it...


