### PR TITLE
Removed +async-transport options

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/domain/BookmarkBase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/domain/BookmarkBase.java
@@ -274,7 +274,6 @@ public class BookmarkBase implements Parcelable, Cloneable {
                 advancedSettings.getConsoleMode());
 
         editor.putBoolean("bookmark.async_channel", debugSettings.getAsyncChannel());
-        editor.putBoolean("bookmark.async_transport", debugSettings.getAsyncTransport());
         editor.putBoolean("bookmark.async_input", debugSettings.getAsyncInput());
         editor.putBoolean("bookmark.async_update", debugSettings.getAsyncUpdate());
         editor.putString("bookmark.debug_level",
@@ -357,7 +356,6 @@ public class BookmarkBase implements Parcelable, Cloneable {
         advancedSettings.setConsoleMode(sharedPrefs.getBoolean("bookmark.console_mode", false));
 
         debugSettings.setAsyncChannel(sharedPrefs.getBoolean("bookmark.async_channel", true));
-        debugSettings.setAsyncTransport(sharedPrefs.getBoolean("bookmark.async_transport", true));
         debugSettings.setAsyncInput(sharedPrefs.getBoolean("bookmark.async_input", true));
         debugSettings.setAsyncUpdate(sharedPrefs.getBoolean("bookmark.async_update", true));
         debugSettings.setDebugLevel(sharedPrefs.getString("bookmark.debug_level", "INFO"));
@@ -748,14 +746,6 @@ public class BookmarkBase implements Parcelable, Cloneable {
 
         public void setDebugLevel(String debug) {
             this.debug = debug;
-        }
-
-        public boolean getAsyncTransport() {
-            return asyncTransport;
-        }
-
-        public void setAsyncTransport(boolean enabled) {
-            asyncTransport = enabled;
         }
 
         public boolean getAsyncUpdate() {

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/BookmarkActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/BookmarkActivity.java
@@ -514,7 +514,6 @@ public class BookmarkActivity extends PreferenceActivity implements
     private void initDebugSettings(SharedPreferences sharedPreferences) {
         debugSettingsChanged(sharedPreferences, "bookmark.debug_level");
         debugSettingsChanged(sharedPreferences, "bookmark.async_channel");
-        debugSettingsChanged(sharedPreferences, "bookmark.async_transport");
         debugSettingsChanged(sharedPreferences, "bookmark.async_update");
         debugSettingsChanged(sharedPreferences, "bookmark.async_input");
     }
@@ -536,10 +535,6 @@ public class BookmarkActivity extends PreferenceActivity implements
         } else if (key.equals("bookmark.async_channel")) {
             boolean enabled = sharedPreferences.getBoolean(key, false);
             Preference pref = findPreference("bookmark.async_channel");
-            pref.setDefaultValue(enabled);
-        } else if (key.equals("bookmark.async_transport")) {
-            boolean enabled = sharedPreferences.getBoolean(key, false);
-            Preference pref = findPreference("bookmark.async_transport");
             pref.setDefaultValue(enabled);
         } else if (key.equals("bookmark.async_update")) {
             boolean enabled = sharedPreferences.getBoolean(key, false);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/BookmarkBaseGateway.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/BookmarkBaseGateway.java
@@ -104,7 +104,6 @@ public abstract class BookmarkBaseGateway {
         values.put(BookmarkDB.DB_KEY_BOOKMARK_WORK_DIR, bookmark.getAdvancedSettings().getWorkDir());
 
         values.put(BookmarkDB.DB_KEY_BOOKMARK_ASYNC_CHANNEL, bookmark.getDebugSettings().getAsyncChannel());
-        values.put(BookmarkDB.DB_KEY_BOOKMARK_ASYNC_TRANSPORT, bookmark.getDebugSettings().getAsyncTransport());
         values.put(BookmarkDB.DB_KEY_BOOKMARK_ASYNC_INPUT, bookmark.getDebugSettings().getAsyncInput());
         values.put(BookmarkDB.DB_KEY_BOOKMARK_ASYNC_UPDATE, bookmark.getDebugSettings().getAsyncUpdate());
         values.put(BookmarkDB.DB_KEY_BOOKMARK_DEBUG_LEVEL, bookmark.getDebugSettings().getDebugLevel());
@@ -147,7 +146,6 @@ public abstract class BookmarkBaseGateway {
         values.put(BookmarkDB.DB_KEY_BOOKMARK_WORK_DIR, bookmark.getAdvancedSettings().getWorkDir());
 
         values.put(BookmarkDB.DB_KEY_BOOKMARK_ASYNC_CHANNEL, bookmark.getDebugSettings().getAsyncChannel());
-        values.put(BookmarkDB.DB_KEY_BOOKMARK_ASYNC_TRANSPORT, bookmark.getDebugSettings().getAsyncTransport());
         values.put(BookmarkDB.DB_KEY_BOOKMARK_ASYNC_INPUT, bookmark.getDebugSettings().getAsyncInput());
         values.put(BookmarkDB.DB_KEY_BOOKMARK_ASYNC_UPDATE, bookmark.getDebugSettings().getAsyncUpdate());
         values.put(BookmarkDB.DB_KEY_BOOKMARK_DEBUG_LEVEL, bookmark.getDebugSettings().getDebugLevel());
@@ -276,7 +274,6 @@ public abstract class BookmarkBaseGateway {
         // debug settings
         columns.add(BookmarkDB.DB_KEY_BOOKMARK_DEBUG_LEVEL);
         columns.add(BookmarkDB.DB_KEY_BOOKMARK_ASYNC_CHANNEL);
-        columns.add(BookmarkDB.DB_KEY_BOOKMARK_ASYNC_TRANSPORT);
         columns.add(BookmarkDB.DB_KEY_BOOKMARK_ASYNC_UPDATE);
         columns.add(BookmarkDB.DB_KEY_BOOKMARK_ASYNC_INPUT);
 
@@ -345,8 +342,6 @@ public abstract class BookmarkBaseGateway {
 
         bookmark.getDebugSettings().setAsyncChannel(
                 cursor.getInt(cursor.getColumnIndex(BookmarkDB.DB_KEY_BOOKMARK_ASYNC_CHANNEL)) == 1);
-        bookmark.getDebugSettings().setAsyncTransport(
-                cursor.getInt(cursor.getColumnIndex(BookmarkDB.DB_KEY_BOOKMARK_ASYNC_TRANSPORT)) == 1);
         bookmark.getDebugSettings().setAsyncInput(
                 cursor.getInt(cursor.getColumnIndex(BookmarkDB.DB_KEY_BOOKMARK_ASYNC_INPUT)) == 1);
         bookmark.getDebugSettings().setAsyncUpdate(

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/BookmarkDB.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/BookmarkDB.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public class BookmarkDB extends SQLiteOpenHelper {
     public static final String ID = BaseColumns._ID;
-    private static final int DB_VERSION = 8;
+    private static final int DB_VERSION = 9;
     private static final String DB_BACKUP_PREFIX = "temp_";
     private static final String DB_NAME = "bookmarks.db";
     static final String DB_TABLE_BOOKMARK = "tbl_manual_bookmarks";
@@ -69,7 +69,6 @@ public class BookmarkDB extends SQLiteOpenHelper {
     static final String DB_KEY_BOOKMARK_REMOTE_PROGRAM = "remote_program";
     static final String DB_KEY_BOOKMARK_WORK_DIR = "work_dir";
     static final String DB_KEY_BOOKMARK_ASYNC_CHANNEL = "async_channel";
-    static final String DB_KEY_BOOKMARK_ASYNC_TRANSPORT = "async_transport";
     static final String DB_KEY_BOOKMARK_ASYNC_INPUT = "async_input";
     static final String DB_KEY_BOOKMARK_ASYNC_UPDATE = "async_update";
     static final String DB_KEY_BOOKMARK_CONSOLE_MODE = "console_mode";
@@ -265,7 +264,6 @@ public class BookmarkDB extends SQLiteOpenHelper {
         bookmarkValues.put(DB_KEY_BOOKMARK_REMOTE_PROGRAM, "");
         bookmarkValues.put(DB_KEY_BOOKMARK_WORK_DIR, "");
         bookmarkValues.put(DB_KEY_BOOKMARK_ASYNC_CHANNEL, 1);
-        bookmarkValues.put(DB_KEY_BOOKMARK_ASYNC_TRANSPORT, 0);
         bookmarkValues.put(DB_KEY_BOOKMARK_ASYNC_INPUT, 1);
         bookmarkValues.put(DB_KEY_BOOKMARK_ASYNC_UPDATE, 1);
         bookmarkValues.put(DB_KEY_BOOKMARK_CONSOLE_MODE, 0);
@@ -310,7 +308,6 @@ public class BookmarkDB extends SQLiteOpenHelper {
                         + DB_KEY_BOOKMARK_REMOTE_PROGRAM + " TEXT, "
                         + DB_KEY_BOOKMARK_WORK_DIR + " TEXT, "
                         + DB_KEY_BOOKMARK_ASYNC_CHANNEL + " INTEGER DEFAULT 0, "
-                        + DB_KEY_BOOKMARK_ASYNC_TRANSPORT + " INTEGER DEFAULT 0, "
                         + DB_KEY_BOOKMARK_ASYNC_INPUT + " INTEGER DEFAULT 0, "
                         + DB_KEY_BOOKMARK_ASYNC_UPDATE + " INTEGER DEFAULT 0, "
                         + DB_KEY_BOOKMARK_CONSOLE_MODE + " INTEGER, "
@@ -377,6 +374,7 @@ public class BookmarkDB extends SQLiteOpenHelper {
             case 6:
             case 7:
             case 8:
+            case 9:
                 upgradeDB(db);
                 break;
             default:

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -239,7 +239,6 @@ public class LibFreeRDP {
         }
 
         args.add(addFlag("async-channels", debug.getAsyncChannel()));
-        //args.add(addFlag("async-transport", debug.getAsyncTransport()));
         args.add(addFlag("async-input", debug.getAsyncInput()));
         args.add(addFlag("async-update", debug.getAsyncUpdate()));
 

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-de/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-de/strings.xml
@@ -113,7 +113,6 @@
     <string name="settings_remote_program">Remote Program</string>
     <string name="settings_work_dir">Arbeitsverzeichnis</string>
     <string name="settings_async_channel">Async channel</string>
-    <string name="settings_async_transport">Async transport</string>
     <string name="settings_async_input">Async input</string>
     <string name="settings_async_update">Async update</string>
     <string name="settings_console_mode">Konsolenmodus</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-es/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-es/strings.xml
@@ -114,7 +114,6 @@
     <string name="settings_remote_program">Programa Remoto</string>
     <string name="settings_work_dir">Directorio de trabajo</string>
     <string name="settings_async_channel">Async channel</string>
-    <string name="settings_async_transport">Async transport</string>
     <string name="settings_async_input">Async input</string>
     <string name="settings_async_update">Async update</string>
     <string name="settings_console_mode">Modo Consola</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-fr/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-fr/strings.xml
@@ -113,7 +113,6 @@
     <string name="settings_remote_program">"Lancement de programme"</string>
     <string name="settings_work_dir">"Répertoire de travail"</string>
     <string name="settings_async_channel">Async channel</string>
-    <string name="settings_async_transport">Async transport</string>
     <string name="settings_async_input">Async input</string>
     <string name="settings_async_update">Async update</string>
     <string name="settings_console_mode">"Mode console"</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-nl/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-nl/strings.xml
@@ -114,7 +114,6 @@
     <string name="settings_remote_program">Extern programma</string>
     <string name="settings_work_dir">Werkmap</string>
     <string name="settings_async_channel">Async channel</string>
-    <string name="settings_async_transport">Async transport</string>
     <string name="settings_async_input">Async input</string>
     <string name="settings_async_update">Async update</string>
     <string name="settings_console_mode">Console modus</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-zh/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-zh/strings.xml
@@ -113,7 +113,6 @@
     <string name="settings_remote_program">远程程序</string>
     <string name="settings_work_dir">工作目录</string>
     <string name="settings_async_channel">Async channel</string>
-    <string name="settings_async_transport">Async transport</string>
     <string name="settings_async_input">Async input</string>
     <string name="settings_async_update">Async update</string>
     <string name="settings_console_mode">控制台模式</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -154,7 +154,6 @@
     <string name="settings_remote_program">Remote Program</string>
     <string name="settings_work_dir">Working Directory</string>
     <string name="settings_async_channel">Async channel</string>
-    <string name="settings_async_transport">Async transport</string>
     <string name="settings_async_input">Async input</string>
     <string name="settings_async_update">Async update</string>
     <string name="settings_console_mode">Console Mode</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/debug_settings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/debug_settings.xml
@@ -29,9 +29,6 @@
             android:key="bookmark.async_channel"
             android:title="@string/settings_async_channel" />
         <CheckBoxPreference
-            android:key="bookmark.async_transport"
-            android:title="@string/settings_async_transport" />
-        <CheckBoxPreference
             android:key="bookmark.async_update"
             android:title="@string/settings_async_update" />
         <CheckBoxPreference

--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -217,8 +217,6 @@ DWORD mac_client_thread(void* param)
 		while (!freerdp_shall_disconnect(instance))
 		{
 			nCount = nCountBase;
-
-			if (!settings->AsyncTransport)
 			{
 				if (!(nCountTmp = freerdp_get_event_handles(context, &events[nCount],
 				                  16 - nCount)))
@@ -229,7 +227,6 @@ DWORD mac_client_thread(void* param)
 
 				nCount += nCountTmp;
 			}
-
 			status = WaitForMultipleObjects(nCount, events, FALSE, INFINITE);
 
 			if (status >= (WAIT_OBJECT_0 + nCount))
@@ -252,7 +249,6 @@ DWORD mac_client_thread(void* param)
 				}
 			}
 
-			if (!settings->AsyncTransport)
 			{
 				if (!freerdp_check_event_handles(context))
 				{

--- a/client/Mac/mf_client.m
+++ b/client/Mac/mf_client.m
@@ -49,7 +49,7 @@ static int mfreerdp_client_start(rdpContext* context)
 	{
 		// view not specified beforehand. Create view dynamically
 		mfc->view = [[MRDPView alloc] initWithFrame : NSMakeRect(0, 0,
-		             context->settings->DesktopWidth, context->settings->DesktopHeight)];
+		                              context->settings->DesktopWidth, context->settings->DesktopHeight)];
 		mfc->view_ownership = TRUE;
 	}
 
@@ -90,7 +90,6 @@ static BOOL mfreerdp_client_new(freerdp* instance, rdpContext* context)
 	context->instance->PostConnect = mac_post_connect;
 	context->instance->Authenticate = mac_authenticate;
 	settings = instance->settings;
-	settings->AsyncTransport = FALSE;
 	settings->AsyncUpdate = TRUE;
 	settings->AsyncInput = TRUE;
 	return TRUE;

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -628,7 +628,6 @@ static DWORD WINAPI wf_client_thread(LPVOID lpParam)
 	rdpChannels* channels;
 	rdpSettings* settings;
 	BOOL async_input;
-	BOOL async_transport;
 	HANDLE input_thread;
 	instance = (freerdp*) lpParam;
 	context = instance->context;
@@ -640,7 +639,6 @@ static DWORD WINAPI wf_client_thread(LPVOID lpParam)
 	channels = instance->context->channels;
 	settings = instance->context->settings;
 	async_input = settings->AsyncInput;
-	async_transport = settings->AsyncTransport;
 
 	if (async_input)
 	{
@@ -662,7 +660,6 @@ static DWORD WINAPI wf_client_thread(LPVOID lpParam)
 			wf_event_focus_in(wfc);
 		}
 
-		if (!async_transport)
 		{
 			DWORD tmp = freerdp_get_event_handles(context, &handles[nCount], 64 - nCount);
 
@@ -683,7 +680,6 @@ static DWORD WINAPI wf_client_thread(LPVOID lpParam)
 			break;
 		}
 
-		if (!async_transport)
 		{
 			if (!freerdp_check_event_handles(context))
 			{

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1569,7 +1569,6 @@ static DWORD WINAPI xf_client_thread(LPVOID param)
 			xf_keyboard_focus_in(xfc);
 		}
 
-		if (!settings->AsyncTransport)
 		{
 			DWORD tmp = freerdp_get_event_handles(context, &handles[nCount], ARRAYSIZE(handles) - nCount);
 
@@ -1587,7 +1586,6 @@ static DWORD WINAPI xf_client_thread(LPVOID param)
 		if (waitStatus == WAIT_FAILED)
 			break;
 
-		if (!settings->AsyncTransport)
 		{
 			if (!freerdp_check_event_handles(context))
 			{

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2554,10 +2554,6 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		{
 			settings->AsyncChannels = arg->Value ? TRUE : FALSE;
 		}
-		CommandLineSwitchCase(arg, "async-transport")
-		{
-			settings->AsyncTransport = arg->Value ? TRUE : FALSE;
-		}
 		CommandLineSwitchCase(arg, "wm-class")
 		{
 			free(settings->WmClass);

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -37,7 +37,6 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "assistance", COMMAND_LINE_VALUE_REQUIRED, "<password>", NULL, NULL, -1, NULL, "Remote assistance password" },
 	{ "async-channels", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Asynchronous channels (experimental)" },
 	{ "async-input", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Asynchronous input" },
-	{ "async-transport", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Asynchronous transport (experimental)" },
 	{ "async-update", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Asynchronous update" },
 	{ "audio-mode", COMMAND_LINE_VALUE_REQUIRED, "<mode>", NULL, NULL, -1, NULL, "Audio output mode" },
 	{ "auth-only", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Authenticate only" },

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -505,6 +505,8 @@ typedef struct _RDPDR_PARALLEL RDPDR_PARALLEL;
 #define FreeRDP_PasswordHash                                       (  24)
 #define FreeRDP_WaitForOutputBufferFlush                           (  25)
 #define FreeRDP_MaxTimeInCheckLoop                                 (  26)
+#define FreeRDP_AcceptedCert                                       (  27)
+#define FreeRDP_AcceptedCertLength                                 (  28)
 #define FreeRDP_RdpVersion                                         ( 128)
 #define FreeRDP_DesktopWidth                                       ( 129)
 #define FreeRDP_DesktopHeight                                      ( 130)
@@ -644,6 +646,8 @@ typedef struct _RDPDR_PARALLEL RDPDR_PARALLEL;
 #define FreeRDP_TargetNetAddressCount                              (1228)
 #define FreeRDP_TargetNetAddresses                                 (1229)
 #define FreeRDP_TargetNetPorts                                     (1230)
+#define FreeRDP_RedirectionAcceptedCert                            (1231)
+#define FreeRDP_RedirectionAcceptedCertLength                      (1232)
 #define FreeRDP_Password51                                         (1280)
 #define FreeRDP_Password51Length                                   (1281)
 #define FreeRDP_KerberosKdc                                        (1344)
@@ -671,7 +675,6 @@ typedef struct _RDPDR_PARALLEL RDPDR_PARALLEL;
 #define FreeRDP_AsyncInput                                         (1544)
 #define FreeRDP_AsyncUpdate                                        (1545)
 #define FreeRDP_AsyncChannels                                      (1546)
-#define FreeRDP_AsyncTransport                                     (1547)
 #define FreeRDP_ToggleFullscreen                                   (1548)
 #define FreeRDP_WmClass                                            (1549)
 #define FreeRDP_EmbeddedWindow                                     (1550)
@@ -712,6 +715,8 @@ typedef struct _RDPDR_PARALLEL RDPDR_PARALLEL;
 #define FreeRDP_GatewayHttpTransport                               (1995)
 #define FreeRDP_GatewayUdpTransport                                (1996)
 #define FreeRDP_GatewayAccessToken                                 (1997)
+#define FreeRDP_GatewayAcceptedCert                                (1998)
+#define FreeRDP_GatewayAcceptedCertLength                          (1999)
 #define FreeRDP_ProxyType                                          (2015)
 #define FreeRDP_ProxyHostname                                      (2016)
 #define FreeRDP_ProxyPort                                          (2017)
@@ -1126,7 +1131,7 @@ struct rdp_settings
 	ALIGN64 BOOL   AsyncInput;              /* 1544 */
 	ALIGN64 BOOL   AsyncUpdate;             /* 1545 */
 	ALIGN64 BOOL   AsyncChannels;           /* 1546 */
-	ALIGN64 BOOL   AsyncTransport;          /* 1547 */
+	UINT64 padding1548[1548 - 1547];        /* 1547 */
 	ALIGN64 BOOL   ToggleFullscreen;        /* 1548 */
 	ALIGN64 char*  WmClass;                 /* 1549 */
 	ALIGN64 BOOL   EmbeddedWindow;          /* 1550 */
@@ -1146,7 +1151,7 @@ struct rdp_settings
 	ALIGN64 BOOL AuthenticationOnly;   /* 1603 */
 	ALIGN64 BOOL CredentialsFromStdin; /* 1604 */
 	ALIGN64 BOOL UnmapButtons;         /* 1605 */
-	UINT64 padding1664[1664 - 1606]; /* 1606 */
+	UINT64 padding1664[1664 - 1606];   /* 1606 */
 
 	/* Names */
 	ALIGN64 char* ComputerName; /* 1664 */

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -37,7 +37,7 @@
 int freerdp_addin_set_argument(ADDIN_ARGV* args, char* argument)
 {
 	int i;
-	char **new_argv;
+	char** new_argv;
 
 	for (i = 0; i < args->argc; i++)
 	{
@@ -48,10 +48,13 @@ int freerdp_addin_set_argument(ADDIN_ARGV* args, char* argument)
 	}
 
 	new_argv = (char**) realloc(args->argv, sizeof(char*) * (args->argc + 1));
+
 	if (!new_argv)
 		return -1;
+
 	args->argv = new_argv;
 	args->argc++;
+
 	if (!(args->argv[args->argc - 1] = _strdup(argument)))
 		return -1;
 
@@ -61,13 +64,14 @@ int freerdp_addin_set_argument(ADDIN_ARGV* args, char* argument)
 int freerdp_addin_replace_argument(ADDIN_ARGV* args, char* previous, char* argument)
 {
 	int i;
-	char **new_argv;
+	char** new_argv;
 
 	for (i = 0; i < args->argc; i++)
 	{
 		if (strcmp(args->argv[i], previous) == 0)
 		{
 			free(args->argv[i]);
+
 			if (!(args->argv[i] = _strdup(argument)))
 				return -1;
 
@@ -76,10 +80,13 @@ int freerdp_addin_replace_argument(ADDIN_ARGV* args, char* previous, char* argum
 	}
 
 	new_argv = (char**) realloc(args->argv, sizeof(char*) * (args->argc + 1));
+
 	if (!new_argv)
 		return -1;
+
 	args->argv = new_argv;
 	args->argc++;
+
 	if (!(args->argv[args->argc - 1] = _strdup(argument)))
 		return -1;
 
@@ -92,12 +99,13 @@ int freerdp_addin_set_argument_value(ADDIN_ARGV* args, char* option, char* value
 	char* p;
 	char* str;
 	int length;
-	char **new_argv;
-
+	char** new_argv;
 	length = strlen(option) + strlen(value) + 1;
 	str = (char*) malloc(length + 1);
+
 	if (!str)
 		return -1;
+
 	sprintf_s(str, length + 1, "%s:%s", option, value);
 
 	for (i = 0; i < args->argc; i++)
@@ -110,13 +118,13 @@ int freerdp_addin_set_argument_value(ADDIN_ARGV* args, char* option, char* value
 			{
 				free(args->argv[i]);
 				args->argv[i] = str;
-
 				return 1;
 			}
 		}
 	}
 
 	new_argv = (char**) realloc(args->argv, sizeof(char*) * (args->argc + 1));
+
 	if (!new_argv)
 	{
 		free(str);
@@ -126,21 +134,22 @@ int freerdp_addin_set_argument_value(ADDIN_ARGV* args, char* option, char* value
 	args->argv = new_argv;
 	args->argc++;
 	args->argv[args->argc - 1] = str;
-
 	return 0;
 }
 
-int freerdp_addin_replace_argument_value(ADDIN_ARGV* args, char* previous, char* option, char* value)
+int freerdp_addin_replace_argument_value(ADDIN_ARGV* args, char* previous, char* option,
+        char* value)
 {
 	int i;
 	char* str;
 	int length;
-	char **new_argv;
-
+	char** new_argv;
 	length = strlen(option) + strlen(value) + 1;
 	str = (char*) malloc(length + 1);
+
 	if (!str)
 		return -1;
+
 	sprintf_s(str, length + 1, "%s:%s", option, value);
 
 	for (i = 0; i < args->argc; i++)
@@ -149,21 +158,21 @@ int freerdp_addin_replace_argument_value(ADDIN_ARGV* args, char* previous, char*
 		{
 			free(args->argv[i]);
 			args->argv[i] = str;
-
 			return 1;
 		}
 	}
 
 	new_argv = (char**) realloc(args->argv, sizeof(char*) * (args->argc + 1));
+
 	if (!new_argv)
 	{
 		free(str);
 		return -1;
 	}
+
 	args->argv = new_argv;
 	args->argc++;
 	args->argv[args->argc - 1] = str;
-
 	return 0;
 }
 
@@ -175,13 +184,14 @@ BOOL freerdp_device_collection_add(rdpSettings* settings, RDPDR_DEVICE* device)
 	if (settings->DeviceArraySize < (settings->DeviceCount + 1))
 	{
 		UINT32 new_size;
-		RDPDR_DEVICE **new_array;
-
+		RDPDR_DEVICE** new_array;
 		new_size = settings->DeviceArraySize * 2;
 		new_array = (RDPDR_DEVICE**)
-				realloc(settings->DeviceArray, new_size * sizeof(RDPDR_DEVICE*));
+		            realloc(settings->DeviceArray, new_size * sizeof(RDPDR_DEVICE*));
+
 		if (!new_array)
 			return FALSE;
+
 		settings->DeviceArray = new_array;
 		settings->DeviceArraySize = new_size;
 	}
@@ -237,20 +247,20 @@ RDPDR_DEVICE* freerdp_device_clone(RDPDR_DEVICE* device)
 
 		_drive->Id = drive->Id;
 		_drive->Type = drive->Type;
-
 		_drive->Name = _strdup(drive->Name);
+
 		if (!_drive->Name)
 			goto out_fs_name_error;
 
 		_drive->Path = _strdup(drive->Path);
+
 		if (!_drive->Path)
 			goto out_fs_path_error;
 
 		return (RDPDR_DEVICE*) _drive;
-
-out_fs_path_error:
+	out_fs_path_error:
 		free(_drive->Name);
-out_fs_name_error:
+	out_fs_name_error:
 		free(_drive);
 		return NULL;
 	}
@@ -269,6 +279,7 @@ out_fs_name_error:
 		if (printer->Name)
 		{
 			_printer->Name = _strdup(printer->Name);
+
 			if (!_printer->Name)
 				goto out_print_name_error;
 		}
@@ -276,15 +287,15 @@ out_fs_name_error:
 		if (printer->DriverName)
 		{
 			_printer->DriverName = _strdup(printer->DriverName);
+
 			if (!_printer->DriverName)
 				goto out_print_path_error;
 		}
 
 		return (RDPDR_DEVICE*) _printer;
-
-out_print_path_error:
+	out_print_path_error:
 		free(_printer->Name);
-out_print_name_error:
+	out_print_name_error:
 		free(_printer);
 		return NULL;
 	}
@@ -303,13 +314,13 @@ out_print_name_error:
 		if (smartcard->Name)
 		{
 			_smartcard->Name = _strdup(smartcard->Name);
+
 			if (!_smartcard->Name)
 				goto out_smartc_name_error;
 		}
 
 		return (RDPDR_DEVICE*) _smartcard;
-
-out_smartc_name_error:
+	out_smartc_name_error:
 		free(_smartcard);
 		return NULL;
 	}
@@ -328,6 +339,7 @@ out_smartc_name_error:
 		if (serial->Name)
 		{
 			_serial->Name = _strdup(serial->Name);
+
 			if (!_serial->Name)
 				goto out_serial_name_error;
 		}
@@ -335,6 +347,7 @@ out_smartc_name_error:
 		if (serial->Path)
 		{
 			_serial->Path = _strdup(serial->Path);
+
 			if (!_serial->Path)
 				goto out_serial_path_error;
 		}
@@ -342,17 +355,17 @@ out_smartc_name_error:
 		if (serial->Driver)
 		{
 			_serial->Driver = _strdup(serial->Driver);
+
 			if (!_serial->Driver)
 				goto out_serial_driver_error;
 		}
 
 		return (RDPDR_DEVICE*) _serial;
-
-out_serial_driver_error:
+	out_serial_driver_error:
 		free(_serial->Path);
-out_serial_path_error:
+	out_serial_path_error:
 		free(_serial->Name);
-out_serial_name_error:
+	out_serial_name_error:
 		free(_serial);
 		return NULL;
 	}
@@ -371,6 +384,7 @@ out_serial_name_error:
 		if (parallel->Name)
 		{
 			_parallel->Name = _strdup(parallel->Name);
+
 			if (!_parallel->Name)
 				goto out_parallel_name_error;
 		}
@@ -378,17 +392,17 @@ out_serial_name_error:
 		if (parallel->Path)
 		{
 			_parallel->Path = _strdup(parallel->Path);
+
 			if (!_parallel->Path)
 				goto out_parallel_path_error;
 		}
 
 		return (RDPDR_DEVICE*) _parallel;
-out_parallel_path_error:
+	out_parallel_path_error:
 		free(_parallel->Name);
-out_parallel_name_error:
+	out_parallel_name_error:
 		free(_parallel);
 		return NULL;
-
 	}
 
 	WLog_ERR(TAG, "unknown device type %"PRIu32"", device->Type);
@@ -415,11 +429,9 @@ void freerdp_device_collection_free(rdpSettings* settings)
 		}
 		else if (settings->DeviceArray[index]->Type == RDPDR_DTYP_PRINT)
 		{
-
 		}
 		else if (settings->DeviceArray[index]->Type == RDPDR_DTYP_SMARTCARD)
 		{
-
 		}
 		else if (settings->DeviceArray[index]->Type == RDPDR_DTYP_SERIAL)
 		{
@@ -435,7 +447,6 @@ void freerdp_device_collection_free(rdpSettings* settings)
 	}
 
 	free(settings->DeviceArray);
-
 	settings->DeviceArraySize = 0;
 	settings->DeviceArray = NULL;
 	settings->DeviceCount = 0;
@@ -449,13 +460,14 @@ BOOL freerdp_static_channel_collection_add(rdpSettings* settings, ADDIN_ARGV* ch
 	if (settings->StaticChannelArraySize < (settings->StaticChannelCount + 1))
 	{
 		UINT32 new_size;
-		ADDIN_ARGV **new_array;
-
+		ADDIN_ARGV** new_array;
 		new_size = settings->StaticChannelArraySize * 2;
 		new_array = (ADDIN_ARGV**)
-				realloc(settings->StaticChannelArray, new_size * sizeof(ADDIN_ARGV*));
+		            realloc(settings->StaticChannelArray, new_size * sizeof(ADDIN_ARGV*));
+
 		if (!new_array)
 			return FALSE;
+
 		settings->StaticChannelArray = new_array;
 		settings->StaticChannelArraySize = new_size;
 	}
@@ -484,28 +496,31 @@ ADDIN_ARGV* freerdp_static_channel_clone(ADDIN_ARGV* channel)
 {
 	int index;
 	ADDIN_ARGV* _channel = NULL;
-
 	_channel = (ADDIN_ARGV*) malloc(sizeof(ADDIN_ARGV));
+
 	if (!_channel)
 		return NULL;
 
 	_channel->argc = channel->argc;
 	_channel->argv = (char**) calloc(channel->argc, sizeof(char*));
+
 	if (!_channel->argv)
 		goto out_free;
 
 	for (index = 0; index < _channel->argc; index++)
 	{
 		_channel->argv[index] = _strdup(channel->argv[index]);
+
 		if (!_channel->argv[index])
 			goto out_release_args;
 	}
 
 	return _channel;
-
 out_release_args:
+
 	for (index = 0; _channel->argv[index]; index++)
 		free(_channel->argv[index]);
+
 out_free:
 	free(_channel);
 	return NULL;
@@ -529,7 +544,6 @@ void freerdp_static_channel_collection_free(rdpSettings* settings)
 	}
 
 	free(settings->StaticChannelArray);
-
 	settings->StaticChannelArraySize = 0;
 	settings->StaticChannelArray = NULL;
 	settings->StaticChannelCount = 0;
@@ -542,9 +556,10 @@ BOOL freerdp_dynamic_channel_collection_add(rdpSettings* settings, ADDIN_ARGV* c
 
 	if (settings->DynamicChannelArraySize < (settings->DynamicChannelCount + 1))
 	{
-		ADDIN_ARGV **new_array;
+		ADDIN_ARGV** new_array;
+		new_array = realloc(settings->DynamicChannelArray,
+		                    settings->DynamicChannelArraySize * sizeof(ADDIN_ARGV*) * 2);
 
-		new_array = realloc(settings->DynamicChannelArray, settings->DynamicChannelArraySize * sizeof(ADDIN_ARGV*) * 2);
 		if (!new_array)
 			return FALSE;
 
@@ -576,7 +591,6 @@ ADDIN_ARGV* freerdp_dynamic_channel_clone(ADDIN_ARGV* channel)
 {
 	int index;
 	ADDIN_ARGV* _channel = NULL;
-
 	_channel = (ADDIN_ARGV*) malloc(sizeof(ADDIN_ARGV));
 
 	if (!_channel)
@@ -597,10 +611,11 @@ ADDIN_ARGV* freerdp_dynamic_channel_clone(ADDIN_ARGV* channel)
 	}
 
 	return _channel;
-
 out_release_args:
+
 	for (index = 0; _channel->argv[index]; index++)
 		free(_channel->argv[index]);
+
 out_free:
 	free(_channel);
 	return NULL;
@@ -624,7 +639,6 @@ void freerdp_dynamic_channel_collection_free(rdpSettings* settings)
 	}
 
 	free(settings->DynamicChannelArray);
-
 	settings->DynamicChannelArraySize = 0;
 	settings->DynamicChannelArray = NULL;
 	settings->DynamicChannelCount = 0;
@@ -639,7 +653,6 @@ void freerdp_target_net_addresses_free(rdpSettings* settings)
 
 	free(settings->TargetNetAddresses);
 	free(settings->TargetNetPorts);
-
 	settings->TargetNetAddressCount = 0;
 	settings->TargetNetAddresses = NULL;
 	settings->TargetNetPorts = NULL;
@@ -670,16 +683,15 @@ void freerdp_performance_flags_make(rdpSettings* settings)
 
 void freerdp_performance_flags_split(rdpSettings* settings)
 {
-	settings->AllowFontSmoothing = (settings->PerformanceFlags & PERF_ENABLE_FONT_SMOOTHING) ? TRUE : FALSE;
-
-	settings->AllowDesktopComposition = (settings->PerformanceFlags & PERF_ENABLE_DESKTOP_COMPOSITION) ? TRUE : FALSE;
-
+	settings->AllowFontSmoothing = (settings->PerformanceFlags & PERF_ENABLE_FONT_SMOOTHING) ? TRUE :
+	                               FALSE;
+	settings->AllowDesktopComposition = (settings->PerformanceFlags & PERF_ENABLE_DESKTOP_COMPOSITION) ?
+	                                    TRUE : FALSE;
 	settings->DisableWallpaper = (settings->PerformanceFlags & PERF_DISABLE_WALLPAPER) ? TRUE : FALSE;
-
-	settings->DisableFullWindowDrag = (settings->PerformanceFlags & PERF_DISABLE_FULLWINDOWDRAG) ? TRUE : FALSE;
-
-	settings->DisableMenuAnims = (settings->PerformanceFlags & PERF_DISABLE_MENUANIMATIONS) ? TRUE : FALSE;
-
+	settings->DisableFullWindowDrag = (settings->PerformanceFlags & PERF_DISABLE_FULLWINDOWDRAG) ?
+	                                  TRUE : FALSE;
+	settings->DisableMenuAnims = (settings->PerformanceFlags & PERF_DISABLE_MENUANIMATIONS) ? TRUE :
+	                             FALSE;
 	settings->DisableThemes = (settings->PerformanceFlags & PERF_DISABLE_THEMING) ? TRUE : FALSE;
 }
 
@@ -719,7 +731,8 @@ void freerdp_set_gateway_usage_method(rdpSettings* settings, UINT32 GatewayUsage
 	}
 }
 
-void freerdp_update_gateway_usage_method(rdpSettings* settings, UINT32 GatewayEnabled, UINT32 GatewayBypassLocal)
+void freerdp_update_gateway_usage_method(rdpSettings* settings, UINT32 GatewayEnabled,
+        UINT32 GatewayBypassLocal)
 {
 	UINT32 GatewayUsageMethod = 0;
 
@@ -941,9 +954,6 @@ BOOL freerdp_get_param_bool(rdpSettings* settings, int id)
 
 		case FreeRDP_AsyncChannels:
 			return settings->AsyncChannels;
-
-		case FreeRDP_AsyncTransport:
-			return settings->AsyncTransport;
 
 		case FreeRDP_ToggleFullscreen:
 			return settings->ToggleFullscreen;
@@ -1415,10 +1425,6 @@ int freerdp_set_param_bool(rdpSettings* settings, int id, BOOL param)
 			settings->AsyncChannels = param;
 			break;
 
-		case FreeRDP_AsyncTransport:
-			settings->AsyncTransport = param;
-			break;
-
 		case FreeRDP_ToggleFullscreen:
 			settings->ToggleFullscreen = param;
 			break;
@@ -1686,7 +1692,6 @@ int freerdp_set_param_bool(rdpSettings* settings, int id, BOOL param)
 
 	/* Mark field as modified */
 	settings->SettingsModified[id] = 1;
-
 	return -1;
 }
 
@@ -1724,7 +1729,6 @@ int freerdp_set_param_int(rdpSettings* settings, int id, int param)
 	}
 
 	settings->SettingsModified[id] = 1;
-
 	return 0;
 }
 
@@ -2337,7 +2341,6 @@ int freerdp_set_param_uint32(rdpSettings* settings, int id, UINT32 param)
 
 	/* Mark field as modified */
 	settings->SettingsModified[id] = 1;
-
 	return 0;
 }
 
@@ -2369,7 +2372,6 @@ int freerdp_set_param_uint64(rdpSettings* settings, int id, UINT64 param)
 
 	/* Mark field as modified */
 	settings->SettingsModified[id] = 1;
-
 	return 0;
 }
 
@@ -2541,7 +2543,7 @@ char* freerdp_get_param_string(rdpSettings* settings, int id)
 
 int freerdp_set_param_string(rdpSettings* settings, int id, const char* param)
 {
-	char **tmp = NULL;
+	char** tmp = NULL;
 
 	if (!param)
 		return -1;
@@ -2762,11 +2764,11 @@ int freerdp_set_param_string(rdpSettings* settings, int id, const char* param)
 	}
 
 	free(*tmp);
+
 	if (!(*tmp = _strdup(param)))
 		return -1;
 
 	/* Mark field as modified */
 	settings->SettingsModified[id] = 1;
-
 	return 0;
 }

--- a/libfreerdp/core/transport.h
+++ b/libfreerdp/core/transport.h
@@ -70,9 +70,6 @@ struct rdp_transport
 	TransportRecv ReceiveCallback;
 	wStreamPool* ReceivePool;
 	HANDLE connectedEvent;
-	HANDLE stopEvent;
-	HANDLE thread;
-	BOOL async;
 	BOOL NlaMode;
 	BOOL blocking;
 	BOOL GatewayEnabled;
@@ -96,7 +93,7 @@ FREERDP_LOCAL BOOL transport_connect_nla(rdpTransport* transport);
 FREERDP_LOCAL BOOL transport_accept_rdp(rdpTransport* transport);
 FREERDP_LOCAL BOOL transport_accept_tls(rdpTransport* transport);
 FREERDP_LOCAL BOOL transport_accept_nla(rdpTransport* transport);
-FREERDP_LOCAL void transport_stop(rdpTransport* transport);
+
 FREERDP_LOCAL int transport_read_pdu(rdpTransport* transport, wStream* s);
 FREERDP_LOCAL int transport_write(rdpTransport* transport, wStream* s);
 

--- a/server/shadow/Win/win_rdp.c
+++ b/server/shadow/Win/win_rdp.c
@@ -292,7 +292,6 @@ static BOOL shw_freerdp_client_new(freerdp* instance, rdpContext* context)
 	instance->VerifyX509Certificate = shw_verify_x509_certificate;
 	settings = instance->settings;
 	shw->settings = instance->context->settings;
-	settings->AsyncTransport = FALSE;
 	settings->AsyncChannels = FALSE;
 	settings->AsyncUpdate = FALSE;
 	settings->AsyncInput = FALSE;


### PR DESCRIPTION
The async transport option is broken by design.
If used the main loop is called from the transport thread and the
main thread of the application.
Unless the transport layer is refactored to just work on queues
(input and output) this option will never work, therefore remove it.

Fixes #3238 and #1876
