### PR TITLE
Reject unknown connection type values for /network command line option.

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -979,6 +979,10 @@ BOOL freerdp_set_connection_type(rdpSettings* settings, int type)
 		settings->DisableThemes = FALSE;
 		settings->NetworkAutoDetect = TRUE;
 	}
+	else
+	{
+		return FALSE;
+	}
 
 	return TRUE;
 }


### PR DESCRIPTION
Don't silently ignore unknown values for /network:.

I'm new to GitHub and fairly new to git in general, so starting with something quite simple.  Let me know if I should be doing something differently.