### PR TITLE
Set an error exit code for an unsuccessful reconnect

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1589,6 +1589,13 @@ static DWORD WINAPI xf_client_thread(LPVOID param)
 			{
 				if (xf_auto_reconnect(instance))
 					continue;
+				else
+				{
+					// Indicate an unsuccessful connection attempt if reconnect
+					// did not succeed, but did not give some other reason.
+					if (freerdp_error_info(instance) == 0)
+						exit_code = XF_EXIT_CONN_FAILED;
+				}
 
 				if (freerdp_get_last_error(context) == FREERDP_ERROR_SUCCESS)
 					WLog_ERR(TAG, "Failed to check FreeRDP file descriptor");


### PR DESCRIPTION
xfreerdp does not indicate that there was a problem via the exit code when there was a network error after connecting.  I simulated this for testing by disconnecting the network cable after establishing a connection.  The  output was
```
# xfreerdp /v:hostname
...
[09:55:35:750] [11458:11459] [ERROR][com.freerdp.core.transport] - BIO_read returned a system error 110: Connection timed out
[09:55:35:750] [11458:11459] [ERROR][com.freerdp.core] - freerdp_check_fds() failed - 0
[09:55:35:750] [11458:11459] [INFO][com.freerdp.client.x11] - Network disconnect!
[09:55:35:750] [11458:11459] [ERROR][com.freerdp.client.x11] - Failed to check FreeRDP file descriptor
# echo $?
0
```

With this commit, the exit code changes to 131.
