### PR TITLE
Fixed rail unicode string conversion and const correctness.

### DIFF
--- a/channels/rail/client/rail_orders.h
+++ b/channels/rail/client/rail_orders.h
@@ -29,22 +29,27 @@
 
 #define TAG CHANNELS_TAG("rail.client")
 
-UINT rail_write_client_sysparam_order(wStream* s, RAIL_SYSPARAM_ORDER* sysparam);
+UINT rail_write_client_sysparam_order(wStream* s, const RAIL_SYSPARAM_ORDER* sysparam);
 
 UINT rail_order_recv(railPlugin* rail, wStream* s);
 UINT rail_send_pdu(railPlugin* rail, wStream* s, UINT16 orderType);
 
-UINT rail_send_handshake_order(railPlugin* rail, RAIL_HANDSHAKE_ORDER* handshake);
-UINT rail_send_handshake_ex_order(railPlugin* rail, RAIL_HANDSHAKE_EX_ORDER* handshakeEx);
-UINT rail_send_client_status_order(railPlugin* rail, RAIL_CLIENT_STATUS_ORDER* clientStatus);
-UINT rail_send_client_exec_order(railPlugin* rail, RAIL_EXEC_ORDER* exec);
-UINT rail_send_client_activate_order(railPlugin* rail, RAIL_ACTIVATE_ORDER* activate);
-UINT rail_send_client_sysmenu_order(railPlugin* rail, RAIL_SYSMENU_ORDER* sysmenu);
-UINT rail_send_client_syscommand_order(railPlugin* rail, RAIL_SYSCOMMAND_ORDER* syscommand);
+UINT rail_send_handshake_order(railPlugin* rail, const RAIL_HANDSHAKE_ORDER* handshake);
+UINT rail_send_handshake_ex_order(railPlugin* rail, const RAIL_HANDSHAKE_EX_ORDER* handshakeEx);
+UINT rail_send_client_status_order(railPlugin* rail, const RAIL_CLIENT_STATUS_ORDER* clientStatus);
+UINT rail_send_client_exec_order(railPlugin* rail, UINT16 flags,
+                                 const RAIL_UNICODE_STRING* exeOrFile, const RAIL_UNICODE_STRING* workingDir,
+                                 const RAIL_UNICODE_STRING* arguments);
+UINT rail_send_client_activate_order(railPlugin* rail, const RAIL_ACTIVATE_ORDER* activate);
+UINT rail_send_client_sysmenu_order(railPlugin* rail, const RAIL_SYSMENU_ORDER* sysmenu);
+UINT rail_send_client_syscommand_order(railPlugin* rail, const RAIL_SYSCOMMAND_ORDER* syscommand);
 
-UINT rail_send_client_notify_event_order(railPlugin* rail, RAIL_NOTIFY_EVENT_ORDER* notifyEvent);
-UINT rail_send_client_window_move_order(railPlugin* rail, RAIL_WINDOW_MOVE_ORDER* windowMove);
-UINT rail_send_client_get_appid_req_order(railPlugin* rail, RAIL_GET_APPID_REQ_ORDER* getAppIdReq);
-UINT rail_send_client_langbar_info_order(railPlugin* rail, RAIL_LANGBAR_INFO_ORDER* langBarInfo);
+UINT rail_send_client_notify_event_order(railPlugin* rail,
+        const RAIL_NOTIFY_EVENT_ORDER* notifyEvent);
+UINT rail_send_client_window_move_order(railPlugin* rail, const RAIL_WINDOW_MOVE_ORDER* windowMove);
+UINT rail_send_client_get_appid_req_order(railPlugin* rail,
+        const RAIL_GET_APPID_REQ_ORDER* getAppIdReq);
+UINT rail_send_client_langbar_info_order(railPlugin* rail,
+        const RAIL_LANGBAR_INFO_ORDER* langBarInfo);
 
 #endif /* FREERDP_CHANNEL_RAIL_CLIENT_ORDERS_H */

--- a/channels/rail/rail_common.h
+++ b/channels/rail/rail_common.h
@@ -44,11 +44,11 @@ extern const char* const RAIL_ORDER_TYPE_STRINGS[];
 #define RAIL_GET_APPID_REQ_ORDER_LENGTH		4	/* fixed */
 #define RAIL_LANGBAR_INFO_ORDER_LENGTH		4	/* fixed */
 
-void rail_string_to_unicode_string(char* string, RAIL_UNICODE_STRING* unicode_string);
+BOOL rail_string_to_unicode_string(const char* string, RAIL_UNICODE_STRING* unicode_string);
 UINT rail_read_handshake_order(wStream* s, RAIL_HANDSHAKE_ORDER* handshake);
-void rail_write_handshake_order(wStream* s, RAIL_HANDSHAKE_ORDER* handshake);
+void rail_write_handshake_order(wStream* s, const RAIL_HANDSHAKE_ORDER* handshake);
 UINT rail_read_handshake_ex_order(wStream* s, RAIL_HANDSHAKE_EX_ORDER* handshakeEx);
-void rail_write_handshake_ex_order(wStream* s, RAIL_HANDSHAKE_EX_ORDER* handshakeEx);
+void rail_write_handshake_ex_order(wStream* s, const RAIL_HANDSHAKE_EX_ORDER* handshakeEx);
 
 wStream* rail_pdu_init(size_t length);
 UINT rail_read_pdu_header(wStream* s, UINT16* orderType, UINT16* orderLength);

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -195,7 +195,6 @@ static void xf_rail_invalidate_region(xfContext* xfc, REGION16* invalidRegion)
 	xfAppWindow* appWindow;
 	const RECTANGLE_16* extents;
 	REGION16 windowInvalidRegion;
-
 	region16_init(&windowInvalidRegion);
 	count = HashTable_GetKeys(xfc->railWindows, &pKeys);
 
@@ -631,7 +630,7 @@ static void xf_rail_register_update_callbacks(rdpUpdate* update)
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT xf_rail_server_execute_result(RailClientContext* context,
-        RAIL_EXEC_RESULT_ORDER* execResult)
+        const RAIL_EXEC_RESULT_ORDER* execResult)
 {
 	xfContext* xfc = (xfContext*) context->custom;
 
@@ -655,7 +654,7 @@ static UINT xf_rail_server_execute_result(RailClientContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT xf_rail_server_system_param(RailClientContext* context,
-                                        RAIL_SYSPARAM_ORDER* sysparam)
+                                        const RAIL_SYSPARAM_ORDER* sysparam)
 {
 	return CHANNEL_RC_OK;
 }
@@ -666,7 +665,7 @@ static UINT xf_rail_server_system_param(RailClientContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT xf_rail_server_handshake(RailClientContext* context,
-                                     RAIL_HANDSHAKE_ORDER* handshake)
+                                     const RAIL_HANDSHAKE_ORDER* handshake)
 {
 	RAIL_EXEC_ORDER exec;
 	RAIL_SYSPARAM_ORDER sysparam;
@@ -722,7 +721,7 @@ static UINT xf_rail_server_handshake(RailClientContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT xf_rail_server_handshake_ex(RailClientContext* context,
-                                        RAIL_HANDSHAKE_EX_ORDER* handshakeEx)
+                                        const RAIL_HANDSHAKE_EX_ORDER* handshakeEx)
 {
 	return CHANNEL_RC_OK;
 }
@@ -733,7 +732,7 @@ static UINT xf_rail_server_handshake_ex(RailClientContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT xf_rail_server_local_move_size(RailClientContext* context,
-        RAIL_LOCALMOVESIZE_ORDER* localMoveSize)
+        const RAIL_LOCALMOVESIZE_ORDER* localMoveSize)
 {
 	int x = 0, y = 0;
 	int direction = 0;
@@ -832,7 +831,7 @@ static UINT xf_rail_server_local_move_size(RailClientContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT xf_rail_server_min_max_info(RailClientContext* context,
-                                        RAIL_MINMAXINFO_ORDER* minMaxInfo)
+                                        const RAIL_MINMAXINFO_ORDER* minMaxInfo)
 {
 	xfAppWindow* appWindow = NULL;
 	xfContext* xfc = (xfContext*) context->custom;
@@ -857,7 +856,7 @@ static UINT xf_rail_server_min_max_info(RailClientContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT xf_rail_server_language_bar_info(RailClientContext* context,
-        RAIL_LANGBAR_INFO_ORDER* langBarInfo)
+        const RAIL_LANGBAR_INFO_ORDER* langBarInfo)
 {
 	return CHANNEL_RC_OK;
 }
@@ -868,7 +867,7 @@ static UINT xf_rail_server_language_bar_info(RailClientContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT xf_rail_server_get_appid_response(RailClientContext* context,
-        RAIL_GET_APPID_RESP_ORDER* getAppIdResp)
+        const RAIL_GET_APPID_RESP_ORDER* getAppIdResp)
 {
 	return CHANNEL_RC_OK;
 }

--- a/include/freerdp/client/rail.h
+++ b/include/freerdp/client/rail.h
@@ -35,26 +35,45 @@
 
 typedef struct _rail_client_context RailClientContext;
 
-typedef UINT (*pcRailClientExecute)(RailClientContext* context, RAIL_EXEC_ORDER* exec);
-typedef UINT (*pcRailClientActivate)(RailClientContext* context, RAIL_ACTIVATE_ORDER* activate);
-typedef UINT (*pcRailClientSystemParam)(RailClientContext* context, RAIL_SYSPARAM_ORDER* sysparam);
-typedef UINT (*pcRailServerSystemParam)(RailClientContext* context, RAIL_SYSPARAM_ORDER* sysparam);
-typedef UINT (*pcRailClientSystemCommand)(RailClientContext* context, RAIL_SYSCOMMAND_ORDER* syscommand);
-typedef UINT (*pcRailClientHandshake)(RailClientContext* context, RAIL_HANDSHAKE_ORDER* handshake);
-typedef UINT (*pcRailServerHandshake)(RailClientContext* context, RAIL_HANDSHAKE_ORDER* handshake);
-typedef UINT (*pcRailClientHandshakeEx)(RailClientContext* context, RAIL_HANDSHAKE_EX_ORDER* handshakeEx);
-typedef UINT (*pcRailServerHandshakeEx)(RailClientContext* context, RAIL_HANDSHAKE_EX_ORDER* handshakeEx);
-typedef UINT (*pcRailClientNotifyEvent)(RailClientContext* context, RAIL_NOTIFY_EVENT_ORDER* notifyEvent);
-typedef UINT (*pcRailClientWindowMove)(RailClientContext* context, RAIL_WINDOW_MOVE_ORDER* windowMove);
-typedef UINT (*pcRailServerLocalMoveSize)(RailClientContext* context, RAIL_LOCALMOVESIZE_ORDER* localMoveSize);
-typedef UINT (*pcRailServerMinMaxInfo)(RailClientContext* context, RAIL_MINMAXINFO_ORDER* minMaxInfo);
-typedef UINT (*pcRailClientInformation)(RailClientContext* context, RAIL_CLIENT_STATUS_ORDER* clientStatus);
-typedef UINT (*pcRailClientSystemMenu)(RailClientContext* context, RAIL_SYSMENU_ORDER* sysmenu);
-typedef UINT (*pcRailClientLanguageBarInfo)(RailClientContext* context, RAIL_LANGBAR_INFO_ORDER* langBarInfo);
-typedef UINT (*pcRailServerLanguageBarInfo)(RailClientContext* context, RAIL_LANGBAR_INFO_ORDER* langBarInfo);
-typedef UINT (*pcRailServerExecuteResult)(RailClientContext* context, RAIL_EXEC_RESULT_ORDER* execResult);
-typedef UINT (*pcRailClientGetAppIdRequest)(RailClientContext* context, RAIL_GET_APPID_REQ_ORDER* getAppIdReq);
-typedef UINT (*pcRailServerGetAppIdResponse)(RailClientContext* context, RAIL_GET_APPID_RESP_ORDER* getAppIdResp);
+typedef UINT(*pcRailClientExecute)(RailClientContext* context, const RAIL_EXEC_ORDER* exec);
+typedef UINT(*pcRailClientActivate)(RailClientContext* context,
+                                    const RAIL_ACTIVATE_ORDER* activate);
+typedef UINT(*pcRailClientSystemParam)(RailClientContext* context,
+                                       const RAIL_SYSPARAM_ORDER* sysparam);
+typedef UINT(*pcRailServerSystemParam)(RailClientContext* context,
+                                       const RAIL_SYSPARAM_ORDER* sysparam);
+typedef UINT(*pcRailClientSystemCommand)(RailClientContext* context,
+        const RAIL_SYSCOMMAND_ORDER* syscommand);
+typedef UINT(*pcRailClientHandshake)(RailClientContext* context,
+                                     const RAIL_HANDSHAKE_ORDER* handshake);
+typedef UINT(*pcRailServerHandshake)(RailClientContext* context,
+                                     const RAIL_HANDSHAKE_ORDER* handshake);
+typedef UINT(*pcRailClientHandshakeEx)(RailClientContext* context,
+                                       const RAIL_HANDSHAKE_EX_ORDER* handshakeEx);
+typedef UINT(*pcRailServerHandshakeEx)(RailClientContext* context,
+                                       const RAIL_HANDSHAKE_EX_ORDER* handshakeEx);
+typedef UINT(*pcRailClientNotifyEvent)(RailClientContext* context,
+                                       const RAIL_NOTIFY_EVENT_ORDER* notifyEvent);
+typedef UINT(*pcRailClientWindowMove)(RailClientContext* context,
+                                      const RAIL_WINDOW_MOVE_ORDER* windowMove);
+typedef UINT(*pcRailServerLocalMoveSize)(RailClientContext* context,
+        const RAIL_LOCALMOVESIZE_ORDER* localMoveSize);
+typedef UINT(*pcRailServerMinMaxInfo)(RailClientContext* context,
+                                      const RAIL_MINMAXINFO_ORDER* minMaxInfo);
+typedef UINT(*pcRailClientInformation)(RailClientContext* context,
+                                       const RAIL_CLIENT_STATUS_ORDER* clientStatus);
+typedef UINT(*pcRailClientSystemMenu)(RailClientContext* context,
+                                      const RAIL_SYSMENU_ORDER* sysmenu);
+typedef UINT(*pcRailClientLanguageBarInfo)(RailClientContext* context,
+        const RAIL_LANGBAR_INFO_ORDER* langBarInfo);
+typedef UINT(*pcRailServerLanguageBarInfo)(RailClientContext* context,
+        const RAIL_LANGBAR_INFO_ORDER* langBarInfo);
+typedef UINT(*pcRailServerExecuteResult)(RailClientContext* context,
+        const RAIL_EXEC_RESULT_ORDER* execResult);
+typedef UINT(*pcRailClientGetAppIdRequest)(RailClientContext* context,
+        const RAIL_GET_APPID_REQ_ORDER* getAppIdReq);
+typedef UINT(*pcRailServerGetAppIdResponse)(RailClientContext* context,
+        const RAIL_GET_APPID_RESP_ORDER* getAppIdResp);
 
 struct _rail_client_context
 {

--- a/include/freerdp/rail.h
+++ b/include/freerdp/rail.h
@@ -218,9 +218,6 @@ typedef struct _RAIL_CLIENT_STATUS_ORDER RAIL_CLIENT_STATUS_ORDER;
 struct _RAIL_EXEC_ORDER
 {
 	UINT16 flags;
-	RAIL_UNICODE_STRING exeOrFile;
-	RAIL_UNICODE_STRING workingDir;
-	RAIL_UNICODE_STRING arguments;
 	char* RemoteApplicationProgram;
 	char* RemoteApplicationWorkingDir;
 	char* RemoteApplicationArguments;

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -70,12 +70,12 @@ static INLINE void Stream_Rewind(wStream* s, size_t _offset)
 #define _stream_read_n16_le(_t, _s, _v, _p) do { \
 		_v = \
 		     (_t)(*_s->pointer) + \
-		     (((_t)(*(_s->pointer + 1))) << 8); \
+		     (_t)(((_t)(*(_s->pointer + 1))) << 8); \
 		if (_p) Stream_Seek(_s, sizeof(_t)); } while (0)
 
 #define _stream_read_n16_be(_t, _s, _v, _p) do { \
 		_v = \
-		     (((_t)(*_s->pointer)) << 8) + \
+		     (_t)(((_t)(*_s->pointer)) << 8) + \
 		     (_t)(*(_s->pointer + 1)); \
 		if (_p) Stream_Seek(_s, sizeof(_t)); } while (0)
 


### PR DESCRIPTION
* Fixes argument modifications for channel functions
* Fixes missing parameter checks for `TS_RAIL_ORDER_EXEC`
* Fixes `rail_string_to_unicode_string` length must be in BYTES not in CHARACTERS
* Fixed a missing cast in the `Stream_Read_UINT16` macros