### PR TITLE
Map a particular disconnect situation triggered by a user logging off…

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -71,13 +71,6 @@
 #include <freerdp/codec/color.h>
 #include <freerdp/codec/bitmap.h>
 
-/*
- * X11/Xlib.h defines Status, but winpr/rpc.h, which is eventually included by
- * mcs.h, declares a few functions that have a parameter named Status.
- */
-#undef Status
-#include <libfreerdp/core/mcs.h>
-
 #include <freerdp/utils/signal.h>
 #include <freerdp/utils/passphrase.h>
 #include <freerdp/client/cliprdr.h>
@@ -1642,11 +1635,12 @@ static DWORD WINAPI xf_client_thread(LPVOID param)
 	{
 		exit_code = freerdp_error_info(instance);
 
-		if (exit_code == XF_EXIT_DISCONNECT && freerdp_get_dpu_reason(context) == MCS_Reason_user_requested)
+		if (exit_code == XF_EXIT_DISCONNECT &&
+		    freerdp_get_disconnect_ultimatum(context) == Disconnect_Ultimatum_user_requested)
 		{
 			/* This situation might be limited to Windows XP. */
 			WLog_INFO(TAG,
-			          "Error info says user did not initiate but MCS ultimatum says they did; treat this as a user logoff");
+			          "Error info says user did not initiate but disconnect ultimatum says they did; treat this as a user logoff");
 			exit_code = XF_EXIT_LOGOFF;
 		}
 	}

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -179,11 +179,25 @@ struct rdp_context
 	ALIGN64 rdpCodecs* codecs; /* 42 */
 	ALIGN64 rdpAutoDetect* autodetect; /* 43 */
 	ALIGN64 HANDLE abortEvent; /* 44 */
-	ALIGN64 int  dpuReason; /* 45 */
+	ALIGN64 int  disconnectUltimatum; /* 45 */
 	UINT64 paddingC[64 - 46]; /* 46 */
 
 	UINT64 paddingD[96 - 64]; /* 64 */
 	UINT64 paddingE[128 - 96]; /* 96 */
+};
+
+/**
+ *  Defines the possible disconnect reasons in the MCS Disconnect Provider
+ *  Ultimatum PDU
+ */
+
+enum Disconnect_Ultimatum
+{
+	Disconnect_Ultimatum_domain_disconnected = 0,
+	Disconnect_Ultimatum_provider_initiated = 1,
+	Disconnect_Ultimatum_token_purged = 2,
+	Disconnect_Ultimatum_user_requested = 3,
+	Disconnect_Ultimatum_channel_purged = 4
 };
 
 #include <freerdp/client.h>
@@ -361,8 +375,7 @@ FREERDP_API void freerdp_free(freerdp* instance);
 FREERDP_API BOOL freerdp_focus_required(freerdp* instance);
 FREERDP_API void freerdp_set_focus(freerdp* instance);
 
-FREERDP_API int freerdp_get_dpu_reason(rdpContext* context);
-FREERDP_API void freerdp_set_dpu_reason(rdpContext* context, int reason);
+FREERDP_API int freerdp_get_disconnect_ultimatum(rdpContext* context);
 
 FREERDP_API UINT32 freerdp_get_last_error(rdpContext* context);
 FREERDP_API const char* freerdp_get_last_error_name(UINT32 error);

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -179,7 +179,8 @@ struct rdp_context
 	ALIGN64 rdpCodecs* codecs; /* 42 */
 	ALIGN64 rdpAutoDetect* autodetect; /* 43 */
 	ALIGN64 HANDLE abortEvent; /* 44 */
-	UINT64 paddingC[64 - 45]; /* 45 */
+	ALIGN64 int  dpuReason; /* 45 */
+	UINT64 paddingC[64 - 46]; /* 46 */
 
 	UINT64 paddingD[96 - 64]; /* 64 */
 	UINT64 paddingE[128 - 96]; /* 96 */
@@ -359,6 +360,9 @@ FREERDP_API void freerdp_free(freerdp* instance);
 
 FREERDP_API BOOL freerdp_focus_required(freerdp* instance);
 FREERDP_API void freerdp_set_focus(freerdp* instance);
+
+FREERDP_API int freerdp_get_dpu_reason(rdpContext* context);
+FREERDP_API void freerdp_set_dpu_reason(rdpContext* context, int reason);
 
 FREERDP_API UINT32 freerdp_get_last_error(rdpContext* context);
 FREERDP_API const char* freerdp_get_last_error_name(UINT32 error);

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -658,6 +658,7 @@ BOOL freerdp_context_new(freerdp* instance)
 	context->instance = instance;
 	context->ServerMode = FALSE;
 	context->settings = instance->settings;
+	context->dpuReason = 0;
 	context->pubSub = PubSub_New(TRUE);
 
 	if (!context->pubSub)
@@ -758,6 +759,16 @@ void freerdp_context_free(freerdp* instance)
 	freerdp_channels_free(instance->context->channels);
 	free(instance->context);
 	instance->context = NULL;
+}
+
+void freerdp_set_dpu_reason(rdpContext* context, int reason)
+{
+	context->dpuReason = reason;
+}
+
+int freerdp_get_dpu_reason(rdpContext* context)
+{
+	return context->dpuReason;
 }
 
 UINT32 freerdp_error_info(freerdp* instance)

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -658,7 +658,7 @@ BOOL freerdp_context_new(freerdp* instance)
 	context->instance = instance;
 	context->ServerMode = FALSE;
 	context->settings = instance->settings;
-	context->dpuReason = 0;
+	context->disconnectUltimatum = 0;
 	context->pubSub = PubSub_New(TRUE);
 
 	if (!context->pubSub)
@@ -761,14 +761,9 @@ void freerdp_context_free(freerdp* instance)
 	instance->context = NULL;
 }
 
-void freerdp_set_dpu_reason(rdpContext* context, int reason)
+int freerdp_get_disconnect_ultimatum(rdpContext* context)
 {
-	context->dpuReason = reason;
-}
-
-int freerdp_get_dpu_reason(rdpContext* context)
-{
-	return context->dpuReason;
+	return context->disconnectUltimatum;
 }
 
 UINT32 freerdp_error_info(freerdp* instance)

--- a/libfreerdp/core/mcs.h
+++ b/libfreerdp/core/mcs.h
@@ -56,15 +56,6 @@ enum MCS_Result
 	MCS_Result_enum_length = 16
 };
 
-enum MCS_Reason
-{
-	MCS_Reason_domain_disconnected = 0,
-	MCS_Reason_provider_initiated = 1,
-	MCS_Reason_token_purged = 2,
-	MCS_Reason_user_requested = 3,
-	MCS_Reason_channel_purged = 4
-};
-
 enum DomainMCSPDU
 {
 	DomainMCSPDU_PlumbDomainIndication = 0,

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -373,6 +373,14 @@ BOOL rdp_read_header(rdpRdp* rdp, wStream* s, UINT16* length, UINT16* channelId)
 			else
 				rdp_set_error_info(rdp, ERRINFO_RPC_INITIATED_DISCONNECT);
 		}
+		else if ((rdp->errorInfo == ERRINFO_RPC_INITIATED_DISCONNECT) && (reason == MCS_Reason_user_requested))
+		{
+			/*
+			 * This situation might be limited to Windows XP.
+			 */
+			WLog_INFO(TAG, "Error info says user did not initiate but MCS ultimatum sa they did; treat this as a user logoff");
+			rdp_set_error_info(rdp, ERRINFO_LOGOFF_BY_USER);
+		}
 
 		WLog_DBG(TAG, "DisconnectProviderUltimatum: reason: %d", reason);
 		freerdp_abort_connect(rdp->instance);

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -358,6 +358,7 @@ BOOL rdp_read_header(rdpRdp* rdp, wStream* s, UINT16* length, UINT16* channelId)
 			return FALSE;
 
 		context = rdp->instance->context;
+		freerdp_set_dpu_reason(context, reason);
 
 		if (rdp->errorInfo == ERRINFO_SUCCESS)
 		{
@@ -372,14 +373,6 @@ BOOL rdp_read_header(rdpRdp* rdp, wStream* s, UINT16* length, UINT16* channelId)
 				rdp_set_error_info(rdp, ERRINFO_LOGOFF_BY_USER);
 			else
 				rdp_set_error_info(rdp, ERRINFO_RPC_INITIATED_DISCONNECT);
-		}
-		else if ((rdp->errorInfo == ERRINFO_RPC_INITIATED_DISCONNECT) && (reason == MCS_Reason_user_requested))
-		{
-			/*
-			 * This situation might be limited to Windows XP.
-			 */
-			WLog_INFO(TAG, "Error info says user did not initiate but MCS ultimatum sa they did; treat this as a user logoff");
-			rdp_set_error_info(rdp, ERRINFO_LOGOFF_BY_USER);
 		}
 
 		WLog_DBG(TAG, "DisconnectProviderUltimatum: reason: %d", reason);

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -358,7 +358,7 @@ BOOL rdp_read_header(rdpRdp* rdp, wStream* s, UINT16* length, UINT16* channelId)
 			return FALSE;
 
 		context = rdp->instance->context;
-		freerdp_set_dpu_reason(context, reason);
+		context->disconnectUltimatum = reason;
 
 		if (rdp->errorInfo == ERRINFO_SUCCESS)
 		{
@@ -367,9 +367,9 @@ BOOL rdp_read_header(rdpRdp* rdp, wStream* s, UINT16* length, UINT16* channelId)
 			 * when the user logs off like they should. Map DisconnectProviderUltimatum
 			 * to a ERRINFO_LOGOFF_BY_USER when the errinfo code is ERRINFO_SUCCESS.
 			 */
-			if (reason == MCS_Reason_provider_initiated)
+			if (reason == Disconnect_Ultimatum_provider_initiated)
 				rdp_set_error_info(rdp, ERRINFO_RPC_INITIATED_DISCONNECT);
-			else if (reason == MCS_Reason_user_requested)
+			else if (reason == Disconnect_Ultimatum_user_requested)
 				rdp_set_error_info(rdp, ERRINFO_LOGOFF_BY_USER);
 			else
 				rdp_set_error_info(rdp, ERRINFO_RPC_INITIATED_DISCONNECT);


### PR DESCRIPTION
This commit adds detection of a disconnect resulting from a user logging off and maps it to a user log off code.  This was found with Windows XP, so maybe there's little interest, but I'm not sure that it is limited to that.

Before the commit...
```
# freerdp /v:winxphost
...
<log off via start menu>
[09:17:53:773] [16826:16827] [INFO][com.freerdp.core] - ERRINFO_RPC_INITIATED_DISCONNECT (0x00000001):The disconnection was initiated by an administrative tool on the server in another session.
[09:17:53:776] [16826:16827] [ERROR][com.freerdp.core.rdp] - rdp_recv_tpkt_pdu: rdp_recv_deactivate_all() fail
[09:17:53:776] [16826:16827] [ERROR][com.freerdp.core.transport] - transport_check_fds: transport->ReceiveCallback() - -1
# echo $?
1
```
After the commit...
```
# freerdp /v:winxphost
...
<log off via start menu>
[09:27:14:477] [18140:18141] [INFO][com.freerdp.core] - ERRINFO_RPC_INITIATED_DISCONNECT (0x00000001):The disconnection was initiated by an administrative tool on the server in another session.
[09:27:14:478] [18140:18141] [INFO][com.freerdp.core.rdp] - Error info says user did not initiate but MCS ultimatum sa they did; treat this as a user logoff
[09:27:14:478] [18140:18141] [INFO][com.freerdp.core] - ERRINFO_LOGOFF_BY_USER (0x0000000C):The disconnection was initiated by the user logging off their session on the server.
[09:27:14:479] [18140:18141] [ERROR][com.freerdp.core.rdp] - rdp_recv_tpkt_pdu: rdp_recv_deactivate_all() fail
[09:27:14:479] [18140:18141] [ERROR][com.freerdp.core.transport] - transport_check_fds: transport->ReceiveCallback() - -1
# echo $?
12
```