### PR TITLE
[NLA] Password prompt is shown even if empty password is provided

### DIFF
--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -190,8 +190,7 @@ static int nla_client_init(rdpNla* nla)
 		settings->DisableCredentialsDelegation = TRUE;
 
 	if ((!settings->Username) || (!strlen(settings->Username))
-	    || (((!settings->Password) || (!strlen(settings->Password)))
-	        && (!settings->RedirectionPassword)))
+	    || ((!settings->Password) && (!settings->RedirectionPassword)))
 	{
 		PromptPassword = TRUE;
 	}


### PR DESCRIPTION
FreeRDP shows the "Enter your credentials" prompt, even if an empty password was specified on the command line. It should accept the empty password and not show the prompt.

The pull request #2919 had already fixed this issue, but it got changed again in b81f168f0e26241907035eb942204c7fbfd01a77.

For testing this change: run FreeRDP with the option `/p:""`. No prompt should be shown in that case.