### PR TITLE
MonitorLocalShiftX,Y should be set when 1st monitor from MonitorIds s…

### DIFF
--- a/client/X11/xf_monitor.c
+++ b/client/X11/xf_monitor.c
@@ -340,6 +340,8 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pMaxWidth, UINT32* pMaxHeight)
 		if (i == settings->MonitorIds[0])
 		{
 			settings->MonitorDefArray[nmonitors].is_primary = TRUE;
+			settings->MonitorLocalShiftX = settings->MonitorDefArray[nmonitors].x;
+			settings->MonitorLocalShiftY = settings->MonitorDefArray[nmonitors].y;
 			primaryMonitorFound = TRUE;
 		}
 


### PR DESCRIPTION
…elected as primary
The MonitorLocalShiftX,Y fields do not currently get set when the primary monitor is set to the first one from the /monitors: command line argument.  (There might be some other cases missed as well, but I do not understand all of the possibilities and objectives here well enough to deal with them all.)