### PR TITLE
Fixed #3423: Process xevents when in reconnect mode.

### DIFF
--- a/client/X11/xf_channels.c
+++ b/client/X11/xf_channels.c
@@ -68,7 +68,7 @@ void xf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs*
 	}
 	else if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) == 0)
 	{
-		xf_disp_init(xfc, (DispClientContext*)e->pInterface);
+		xf_disp_init(xfc->xfDisp, (DispClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
 	{
@@ -95,6 +95,10 @@ void xf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEven
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
 		xfc->rdpei = NULL;
+	}
+	else if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) == 0)
+	{
+		xf_disp_uninit(xfc->xfDisp, (DispClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, TSMF_DVC_CHANNEL_NAME) == 0)
 	{

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1413,6 +1413,27 @@ static DWORD WINAPI xf_input_thread(LPVOID arg)
 	return 0;
 }
 
+static BOOL handle_window_events(freerdp* instance)
+{
+	rdpSettings* settings;
+
+	if (!instance || !instance->settings)
+		return FALSE;
+
+	settings = instance->settings;
+
+	if (!settings->AsyncInput)
+	{
+		if (!xf_process_x_events(instance))
+		{
+			WLog_INFO(TAG, "Closed from X11");
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}
+
 /** Main loop for the rdp connection.
 *  It will be run from the thread's entry point (thread_func()).
 *  It initiates the connection, and will continue to run until the session ends,
@@ -1548,7 +1569,7 @@ static DWORD WINAPI xf_client_thread(LPVOID param)
 		{
 			if (!freerdp_check_event_handles(context))
 			{
-				if (client_auto_reconnect(instance))
+				if (client_auto_reconnect_ex(instance, handle_window_events))
 					continue;
 				else
 				{
@@ -1567,14 +1588,8 @@ static DWORD WINAPI xf_client_thread(LPVOID param)
 			}
 		}
 
-		if (!settings->AsyncInput)
-		{
-			if (!xf_process_x_events(instance))
-			{
-				WLog_INFO(TAG, "Closed from X11");
-				break;
-			}
-		}
+		if (!handle_window_events(instance))
+			break;
 
 		if ((status != WAIT_TIMEOUT) && (waitStatus == WAIT_OBJECT_0))
 		{

--- a/client/X11/xf_disp.h
+++ b/client/X11/xf_disp.h
@@ -25,12 +25,13 @@
 #include "xf_client.h"
 #include "xfreerdp.h"
 
-FREERDP_API BOOL xf_disp_init(xfContext* xfc, DispClientContext *disp);
+FREERDP_API BOOL xf_disp_init(xfDispContext* xfDisp, DispClientContext* disp);
+FREERDP_API BOOL xf_disp_uninit(xfDispContext* xfDisp, DispClientContext* disp);
 
-xfDispContext *xf_disp_new(xfContext* xfc);
-void xf_disp_free(xfDispContext *disp);
-BOOL xf_disp_handle_xevent(xfContext *xfc, XEvent *event);
-BOOL xf_disp_handle_configureNotify(xfContext *xfc, int width, int height);
-void xf_disp_resized(xfDispContext *disp);
+xfDispContext* xf_disp_new(xfContext* xfc);
+void xf_disp_free(xfDispContext* disp);
+BOOL xf_disp_handle_xevent(xfContext* xfc, XEvent* event);
+BOOL xf_disp_handle_configureNotify(xfContext* xfc, int width, int height);
+void xf_disp_resized(xfDispContext* disp);
 
 #endif /* FREERDP_CLIENT_X11_DISP_H */

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -1103,7 +1103,7 @@ BOOL xf_event_process(freerdp* instance, XEvent* event)
 			break;
 
 		default:
-			if (settings->SupportDisplayControl && xfc->xfDisp)
+			if (settings->SupportDisplayControl)
 				xf_disp_handle_xevent(xfc, event);
 
 			break;

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -220,7 +220,6 @@ struct xf_context
 	RdpeiClientContext* rdpei;
 	EncomspClientContext* encomsp;
 	xfDispContext* xfDisp;
-	DispClientContext* disp;
 
 	RailClientContext* rail;
 	wHashTable* railWindows;

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -113,6 +113,8 @@ FREERDP_API DWORD client_cli_verify_changed_certificate(freerdp* instance, const
         const char* old_subject, const char* old_issuer,
         const char* old_fingerprint);
 FREERDP_API BOOL client_auto_reconnect(freerdp* instance);
+FREERDP_API BOOL client_auto_reconnect_ex(freerdp* instance,
+        BOOL(*window_events)(freerdp* instance));
 
 #ifdef __cplusplus
 }

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -782,13 +782,16 @@ int transport_write(rdpTransport* transport, wStream* s)
 	int status = -1;
 	int writtenlength = 0;
 
-	if (!transport)
+	if (!s)
 		return -1;
+
+	if (!transport)
+		goto fail;
 
 	if (!transport->frontBio)
 	{
 		transport->layer = TRANSPORT_LAYER_CLOSED;
-		return -1;
+		goto fail;
 	}
 
 	EnterCriticalSection(&(transport->WriteLock));
@@ -868,8 +871,9 @@ out_cleanup:
 		transport->layer = TRANSPORT_LAYER_CLOSED;
 	}
 
-	Stream_Release(s);
 	LeaveCriticalSection(&(transport->WriteLock));
+fail:
+	Stream_Release(s);
 	return status;
 }
 


### PR DESCRIPTION
* Adds a callback function to process local window events to reconnect function.
* Fixed crashes due to unloaded disp channel in reconnect mode.

To test:
1. Connect with `+auto-reconnect`
1. Disable network connection
1. Wait 15 seconds until reconnect triggers
1. Try to resize/fullscreen/close the local window

Old behaviour:
The window does not process any events and is frozen
