### PR TITLE
Transport write leak fix

### DIFF
--- a/libfreerdp/core/activation.c
+++ b/libfreerdp/core/activation.c
@@ -56,10 +56,7 @@ BOOL rdp_recv_server_synchronize_pdu(rdpRdp* rdp, wStream* s)
 
 BOOL rdp_send_server_synchronize_pdu(rdpRdp* rdp)
 {
-	wStream* s;
-
-	s = rdp_data_pdu_init(rdp);
-
+	wStream* s = rdp_data_pdu_init(rdp);
 	rdp_write_synchronize_pdu(s, rdp->settings);
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_SYNCHRONIZE, rdp->mcs->userId);
 }
@@ -67,7 +64,6 @@ BOOL rdp_send_server_synchronize_pdu(rdpRdp* rdp)
 BOOL rdp_recv_client_synchronize_pdu(rdpRdp* rdp, wStream* s)
 {
 	UINT16 messageType;
-
 	rdp->finalize_sc_pdus |= FINALIZE_SC_SYNCHRONIZE_PDU;
 
 	if (Stream_GetRemainingLength(s) < 4)
@@ -80,18 +76,13 @@ BOOL rdp_recv_client_synchronize_pdu(rdpRdp* rdp, wStream* s)
 
 	/* targetUser (2 bytes) */
 	Stream_Seek_UINT16(s);
-
 	return TRUE;
 }
 
 BOOL rdp_send_client_synchronize_pdu(rdpRdp* rdp)
 {
-	wStream* s;
-
-	s = rdp_data_pdu_init(rdp);
-
+	wStream* s = rdp_data_pdu_init(rdp);
 	rdp_write_synchronize_pdu(s, rdp->settings);
-
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_SYNCHRONIZE, rdp->mcs->userId);
 }
 
@@ -103,7 +94,6 @@ BOOL rdp_recv_control_pdu(wStream* s, UINT16* action)
 	Stream_Read_UINT16(s, *action); /* action (2 bytes) */
 	Stream_Seek_UINT16(s); /* grantId (2 bytes) */
 	Stream_Seek_UINT32(s); /* controlId (4 bytes) */
-
 	return TRUE;
 }
 
@@ -118,7 +108,7 @@ BOOL rdp_recv_server_control_pdu(rdpRdp* rdp, wStream* s)
 {
 	UINT16 action;
 
-	if(rdp_recv_control_pdu(s, &action) == FALSE)
+	if (rdp_recv_control_pdu(s, &action) == FALSE)
 		return FALSE;
 
 	switch (action)
@@ -138,37 +128,26 @@ BOOL rdp_recv_server_control_pdu(rdpRdp* rdp, wStream* s)
 
 BOOL rdp_send_server_control_cooperate_pdu(rdpRdp* rdp)
 {
-	wStream* s;
-
-	s = rdp_data_pdu_init(rdp);
-
+	wStream* s = rdp_data_pdu_init(rdp);
 	Stream_Write_UINT16(s, CTRLACTION_COOPERATE); /* action (2 bytes) */
 	Stream_Write_UINT16(s, 0); /* grantId (2 bytes) */
 	Stream_Write_UINT32(s, 0); /* controlId (4 bytes) */
-
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_CONTROL, rdp->mcs->userId);
 }
 
 BOOL rdp_send_server_control_granted_pdu(rdpRdp* rdp)
 {
-	wStream* s;
-
-	s = rdp_data_pdu_init(rdp);
-
+	wStream* s = rdp_data_pdu_init(rdp);
 	Stream_Write_UINT16(s, CTRLACTION_GRANTED_CONTROL); /* action (2 bytes) */
 	Stream_Write_UINT16(s, rdp->mcs->userId); /* grantId (2 bytes) */
 	Stream_Write_UINT32(s, 0x03EA); /* controlId (4 bytes) */
-
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_CONTROL, rdp->mcs->userId);
 }
 
 BOOL rdp_send_client_control_pdu(rdpRdp* rdp, UINT16 action)
 {
-	wStream* s;
-
-	s = rdp_data_pdu_init(rdp);
+	wStream* s = rdp_data_pdu_init(rdp);
 	rdp_write_client_control_pdu(s, action);
-
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_CONTROL, rdp->mcs->userId);
 }
 
@@ -193,17 +172,14 @@ void rdp_write_client_persistent_key_list_pdu(wStream* s, rdpSettings* settings)
 	Stream_Write_UINT8(s, PERSIST_FIRST_PDU | PERSIST_LAST_PDU); /* bBitMask (1 byte) */
 	Stream_Write_UINT8(s, 0); /* pad1 (1 byte) */
 	Stream_Write_UINT16(s, 0); /* pad3 (2 bytes) */
-
 	/* entries */
 }
 
 BOOL rdp_send_client_persistent_key_list_pdu(rdpRdp* rdp)
 {
 	wStream* s;
-
 	s = rdp_data_pdu_init(rdp);
 	rdp_write_client_persistent_key_list_pdu(s, rdp->settings);
-
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_BITMAP_CACHE_PERSISTENT_LIST, rdp->mcs->userId);
 }
 
@@ -225,11 +201,8 @@ void rdp_write_client_font_list_pdu(wStream* s, UINT16 flags)
 
 BOOL rdp_send_client_font_list_pdu(rdpRdp* rdp, UINT16 flags)
 {
-	wStream* s;
-
-	s = rdp_data_pdu_init(rdp);
+	wStream* s = rdp_data_pdu_init(rdp);
 	rdp_write_client_font_list_pdu(s, flags);
-
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_FONT_LIST, rdp->mcs->userId);
 }
 
@@ -251,7 +224,7 @@ BOOL rdp_recv_client_font_map_pdu(rdpRdp* rdp, wStream* s)
 {
 	rdp->finalize_sc_pdus |= FINALIZE_SC_FONT_MAP_PDU;
 
-	if(Stream_GetRemainingLength(s) >= 8)
+	if (Stream_GetRemainingLength(s) >= 8)
 	{
 		Stream_Seek_UINT16(s); /* numberEntries (2 bytes) */
 		Stream_Seek_UINT16(s); /* totalNumEntries (2 bytes) */
@@ -265,14 +238,11 @@ BOOL rdp_recv_client_font_map_pdu(rdpRdp* rdp, wStream* s)
 BOOL rdp_send_server_font_map_pdu(rdpRdp* rdp)
 {
 	wStream* s;
-
 	s = rdp_data_pdu_init(rdp);
-
 	Stream_Write_UINT16(s, 0); /* numberEntries (2 bytes) */
 	Stream_Write_UINT16(s, 0); /* totalNumEntries (2 bytes) */
 	Stream_Write_UINT16(s, FONTLIST_FIRST | FONTLIST_LAST); /* mapFlags (2 bytes) */
 	Stream_Write_UINT16(s, 4); /* entrySize (2 bytes) */
-
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_FONT_MAP, rdp->mcs->userId);
 }
 
@@ -308,7 +278,7 @@ BOOL rdp_recv_deactivate_all(rdpRdp* rdp, wStream* s)
 
 			Stream_Seek(s, lengthSourceDescriptor); /* sourceDescriptor (should be 0x00) */
 		}
-		while(0);
+		while (0);
 	}
 
 	rdp_client_transition_to_state(rdp, CONNECTION_STATE_CAPABILITIES_EXCHANGE);
@@ -327,22 +297,17 @@ BOOL rdp_recv_deactivate_all(rdpRdp* rdp, wStream* s)
 
 BOOL rdp_send_deactivate_all(rdpRdp* rdp)
 {
-	wStream* s;
+	wStream* s = rdp_send_stream_pdu_init(rdp);
 	BOOL status;
 
-	if (!(s = Stream_New(NULL, 1024)))
+	if (!s)
 		return FALSE;
-
-	rdp_init_stream_pdu(rdp, s);
 
 	Stream_Write_UINT32(s, rdp->settings->ShareId); /* shareId (4 bytes) */
 	Stream_Write_UINT16(s, 1); /* lengthSourceDescriptor (2 bytes) */
 	Stream_Write_UINT8(s, 0); /* sourceDescriptor (should be 0x00) */
-
 	status = rdp_send_pdu(rdp, s, PDU_TYPE_DEACTIVATE_ALL, rdp->mcs->userId);
-
-	Stream_Free(s, TRUE);
-
+	Stream_Release(s);
 	return status;
 }
 
@@ -364,30 +329,30 @@ BOOL rdp_server_accept_client_control_pdu(rdpRdp* rdp, wStream* s)
 
 BOOL rdp_server_accept_client_font_list_pdu(rdpRdp* rdp, wStream* s)
 {
-	rdpSettings *settings = rdp->settings;
-	freerdp_peer *peer = rdp->context->peer;
+	rdpSettings* settings = rdp->settings;
+	freerdp_peer* peer = rdp->context->peer;
 
 	if (!rdp_recv_client_font_list_pdu(s))
 		return FALSE;
 
 	if (settings->SupportMonitorLayoutPdu && settings->MonitorCount && peer->AdjustMonitorsLayout &&
-			peer->AdjustMonitorsLayout(peer))
+	    peer->AdjustMonitorsLayout(peer))
 	{
 		/* client supports the monitorLayout PDU, let's send him the monitors if any */
-		wStream *st;
+		wStream* st = rdp_data_pdu_init(rdp);
 		BOOL r;
 
-		st = rdp_data_pdu_init(rdp);
 		if (!st)
 			return FALSE;
 
 		if (!rdp_write_monitor_layout_pdu(st, settings->MonitorCount, settings->MonitorDefArray))
 		{
-			Stream_Free(st, TRUE);
+			Stream_Release(st);
 			return FALSE;
 		}
 
 		r = rdp_send_data_pdu(rdp, st, DATA_PDU_TYPE_MONITOR_LAYOUT, 0);
+
 		if (!r)
 			return FALSE;
 	}

--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -3966,17 +3966,16 @@ BOOL rdp_write_demand_active(wStream* s, rdpSettings* settings)
 
 BOOL rdp_send_demand_active(rdpRdp* rdp)
 {
-	wStream* s;
+	wStream* s = rdp_send_stream_pdu_init(rdp);
 	BOOL status;
 
-	if (!(s = Stream_New(NULL, 4096)))
+	if (!s)
 		return FALSE;
 
-	rdp_init_stream_pdu(rdp, s);
 	rdp->settings->ShareId = 0x10000 + rdp->mcs->userId;
 	status = rdp_write_demand_active(s, rdp->settings) &&
 	         rdp_send_pdu(rdp, s, PDU_TYPE_DEMAND_ACTIVE, rdp->mcs->userId);
-	Stream_Free(s, TRUE);
+	Stream_Release(s);
 	return status;
 }
 
@@ -4196,15 +4195,14 @@ BOOL rdp_write_confirm_active(wStream* s, rdpSettings* settings)
 
 BOOL rdp_send_confirm_active(rdpRdp* rdp)
 {
-	wStream* s;
+	wStream* s = rdp_send_stream_pdu_init(rdp);
 	BOOL status;
 
-	if (!(s = Stream_New(NULL, 4096)))
+	if (!s)
 		return FALSE;
 
-	rdp_init_stream_pdu(rdp, s);
 	status = rdp_write_confirm_active(s, rdp->settings) &&
 	         rdp_send_pdu(rdp, s, PDU_TYPE_CONFIRM_ACTIVE, rdp->mcs->userId);
-	Stream_Free(s, TRUE);
+	Stream_Release(s);
 	return status;
 }

--- a/libfreerdp/core/channels.c
+++ b/libfreerdp/core/channels.c
@@ -112,10 +112,7 @@ BOOL freerdp_channel_send(rdpRdp* rdp, UINT16 channelId, const BYTE* data, int s
 
 		/* WLog_DBG(TAG, "%s: sending data (flags=0x%x size=%d)", __FUNCTION__, flags, size); */
 		if (!rdp_send(rdp, s, channelId))
-		{
-			Stream_Release(s);
 			return FALSE;
-		}
 
 		data += chunkSize;
 		left -= chunkSize;

--- a/libfreerdp/core/fastpath.c
+++ b/libfreerdp/core/fastpath.c
@@ -909,7 +909,7 @@ wStream* fastpath_input_pdu_init(rdpFastPath* fastpath, BYTE eventFlags, BYTE ev
 
 BOOL fastpath_send_multiple_input_pdu(rdpFastPath* fastpath, wStream* s, int iNumEvents)
 {
-	BOOL rc;
+	BOOL rc = FALSE;
 	rdpRdp* rdp;
 	UINT16 length;
 	BYTE eventHeader;

--- a/libfreerdp/core/fastpath.c
+++ b/libfreerdp/core/fastpath.c
@@ -909,12 +909,16 @@ wStream* fastpath_input_pdu_init(rdpFastPath* fastpath, BYTE eventFlags, BYTE ev
 
 BOOL fastpath_send_multiple_input_pdu(rdpFastPath* fastpath, wStream* s, int iNumEvents)
 {
+	BOOL rc;
 	rdpRdp* rdp;
 	UINT16 length;
 	BYTE eventHeader;
 
-	if (!fastpath || !fastpath->rdp || !s)
+	if (!s)
 		return FALSE;
+
+	if (!fastpath || !fastpath->rdp)
+		goto fail;
 
 	/*
 	 *  A maximum of 15 events are allowed per request
@@ -922,7 +926,7 @@ BOOL fastpath_send_multiple_input_pdu(rdpFastPath* fastpath, wStream* s, int iNu
 	 *  see MS-RDPBCGR 2.2.8.1.2 for details
 	 */
 	if (iNumEvents > 15)
-		return FALSE;
+		goto fail;
 
 	rdp = fastpath->rdp;
 	length = Stream_GetPosition(s);
@@ -930,7 +934,7 @@ BOOL fastpath_send_multiple_input_pdu(rdpFastPath* fastpath, wStream* s, int iNu
 	if (length >= (2 << 14))
 	{
 		WLog_ERR(TAG, "Maximum FastPath PDU length is 32767");
-		return FALSE;
+		goto fail;
 	}
 
 	eventHeader = FASTPATH_INPUT_ACTION_FASTPATH;
@@ -965,13 +969,13 @@ BOOL fastpath_send_multiple_input_pdu(rdpFastPath* fastpath, wStream* s, int iNu
 			Stream_Write_UINT8(s, pad); /* padding */
 
 			if (!security_hmac_signature(fpInputEvents, fpInputEvents_length, Stream_Pointer(s), rdp))
-				return FALSE;
+				goto fail;
 
 			if (pad)
 				memset(fpInputEvents + fpInputEvents_length, 0, pad);
 
 			if (!security_fips_encrypt(fpInputEvents, fpInputEvents_length + pad, rdp))
-				return FALSE;
+				goto fail;
 
 			length += pad;
 		}
@@ -986,7 +990,7 @@ BOOL fastpath_send_multiple_input_pdu(rdpFastPath* fastpath, wStream* s, int iNu
 				status = security_mac_signature(rdp, fpInputEvents, fpInputEvents_length, Stream_Pointer(s));
 
 			if (!status || !security_encrypt(fpInputEvents, fpInputEvents_length, rdp))
-				return FALSE;
+				goto fail;
 		}
 	}
 
@@ -1003,9 +1007,12 @@ BOOL fastpath_send_multiple_input_pdu(rdpFastPath* fastpath, wStream* s, int iNu
 	Stream_SealLength(s);
 
 	if (transport_write(fastpath->rdp->transport, s) < 0)
-		return FALSE;
+		goto fail;
 
-	return TRUE;
+	rc = TRUE;
+fail:
+	Stream_Release(s);
+	return rc;
 }
 
 BOOL fastpath_send_input_pdu(rdpFastPath* fastpath, wStream* s)

--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -929,9 +929,8 @@ BOOL rdp_recv_client_info(rdpRdp* rdp, wStream* s)
 BOOL rdp_send_client_info(rdpRdp* rdp)
 {
 	wStream* s;
-	BOOL status;
 	rdp->sec_flags |= SEC_INFO_PKT;
-	s = Stream_New(NULL, 2048);
+	s = rdp_send_stream_init(rdp);
 
 	if (!s)
 	{
@@ -939,11 +938,8 @@ BOOL rdp_send_client_info(rdpRdp* rdp)
 		return FALSE;
 	}
 
-	rdp_init_stream(rdp, s);
 	rdp_write_info_packet(rdp, s);
-	status = rdp_send(rdp, s, MCS_GLOBAL_CHANNEL_ID);
-	Stream_Free(s, TRUE);
-	return status;
+	return rdp_send(rdp, s, MCS_GLOBAL_CHANNEL_ID);
 }
 
 static BOOL rdp_recv_logon_info_v1(rdpRdp* rdp, wStream* s, logon_info* info)
@@ -1461,7 +1457,7 @@ BOOL rdp_send_save_session_info(rdpContext* context, UINT32 type, void* data)
 	if (status)
 		status = rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_SAVE_SESSION_INFO, rdp->mcs->userId);
 	else
-		Stream_Free(s, TRUE);
+		Stream_Release(s);
 
 	return status;
 }

--- a/libfreerdp/core/license.h
+++ b/libfreerdp/core/license.h
@@ -202,7 +202,6 @@ struct rdp_license
 };
 
 FREERDP_LOCAL int license_recv(rdpLicense* license, wStream* s);
-FREERDP_LOCAL BOOL license_send(rdpLicense* license, wStream* s, BYTE type);
 
 FREERDP_LOCAL BOOL license_send_valid_client_error_packet(rdpLicense* license);
 

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -1831,6 +1831,7 @@ static size_t nla_sizeof_ts_request(size_t length)
 
 BOOL nla_send(rdpNla* nla)
 {
+	BOOL rc = TRUE;
 	wStream* s;
 	size_t length;
 	size_t ts_request_length;
@@ -1933,9 +1934,12 @@ BOOL nla_send(rdpNla* nla)
 	}
 
 	Stream_SealLength(s);
-	transport_write(nla->transport, s);
+
+	if (transport_write(nla->transport, s) < 0)
+		rc = FALSE;
+
 	Stream_Free(s, TRUE);
-	return TRUE;
+	return rc;
 }
 
 static int nla_decode_ts_request(rdpNla* nla, wStream* s)

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -171,10 +171,7 @@ static int freerdp_peer_virtual_channel_write(freerdp_peer* client, HANDLE hChan
 		Stream_Write(s, buffer, chunkSize);
 
 		if (!rdp_send(rdp, s, peerChannel->channelId))
-		{
-			Stream_Release(s);
 			return -1;
-		}
 
 		buffer += chunkSize;
 		length -= chunkSize;

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -181,14 +181,21 @@ void rdp_write_share_data_header(wStream* s, UINT16 length, BYTE type, UINT32 sh
 	Stream_Write_UINT16(s, 0); /* compressedLength (2 bytes) */
 }
 
-static int rdp_security_stream_init(rdpRdp* rdp, wStream* s, BOOL sec_header)
+static BOOL rdp_security_stream_init(rdpRdp* rdp, wStream* s, BOOL sec_header)
 {
+	if (!rdp || !s)
+		return FALSE;
+
 	if (rdp->do_crypt)
 	{
-		Stream_Seek(s, 12);
+		if (!Stream_SafeSeek(s, 12))
+			return FALSE;
 
 		if (rdp->settings->EncryptionMethods == ENCRYPTION_METHOD_FIPS)
-			Stream_Seek(s, 4);
+		{
+			if (!Stream_SafeSeek(s, 4))
+				return FALSE;
+		}
 
 		rdp->sec_flags |= SEC_ENCRYPT;
 
@@ -197,53 +204,62 @@ static int rdp_security_stream_init(rdpRdp* rdp, wStream* s, BOOL sec_header)
 	}
 	else if (rdp->sec_flags != 0 || sec_header)
 	{
-		Stream_Seek(s, 4);
+		if (!Stream_SafeSeek(s, 4))
+			return FALSE;
 	}
 
-	return 0;
-}
-
-int rdp_init_stream(rdpRdp* rdp, wStream* s)
-{
-	Stream_Seek(s, RDP_PACKET_HEADER_MAX_LENGTH);
-	return rdp_security_stream_init(rdp, s, FALSE);
+	return TRUE;
 }
 
 wStream* rdp_send_stream_init(rdpRdp* rdp)
 {
-	wStream* s;
-	s = transport_send_stream_init(rdp->transport, 2048);
-	rdp_init_stream(rdp, s);
-	return s;
-}
-
-int rdp_init_stream_pdu(rdpRdp* rdp, wStream* s)
-{
-	Stream_Seek(s, RDP_PACKET_HEADER_MAX_LENGTH);
-	rdp_security_stream_init(rdp, s, FALSE);
-	Stream_Seek(s, RDP_SHARE_CONTROL_HEADER_LENGTH);
-	return 0;
-}
-
-int rdp_init_stream_data_pdu(rdpRdp* rdp, wStream* s)
-{
-	Stream_Seek(s, RDP_PACKET_HEADER_MAX_LENGTH);
-	rdp_security_stream_init(rdp, s, FALSE);
-	Stream_Seek(s, RDP_SHARE_CONTROL_HEADER_LENGTH);
-	Stream_Seek(s, RDP_SHARE_DATA_HEADER_LENGTH);
-	return 0;
-}
-
-wStream* rdp_data_pdu_init(rdpRdp* rdp)
-{
-	wStream* s;
-	s = transport_send_stream_init(rdp->transport, 2048);
+	wStream* s = transport_send_stream_init(rdp->transport, 4096);
 
 	if (!s)
 		return NULL;
 
-	rdp_init_stream_data_pdu(rdp, s);
+	if (!Stream_SafeSeek(s, RDP_PACKET_HEADER_MAX_LENGTH))
+		goto fail;
+
+	if (!rdp_security_stream_init(rdp, s, FALSE))
+		goto fail;
+
 	return s;
+fail:
+	Stream_Release(s);
+	return NULL;
+}
+
+wStream* rdp_send_stream_pdu_init(rdpRdp* rdp)
+{
+	wStream* s = rdp_send_stream_init(rdp);
+
+	if (!s)
+		return NULL;
+
+	if (!Stream_SafeSeek(s, RDP_SHARE_CONTROL_HEADER_LENGTH))
+		goto fail;
+
+	return s;
+fail:
+	Stream_Release(s);
+	return NULL;
+}
+
+wStream* rdp_data_pdu_init(rdpRdp* rdp)
+{
+	wStream* s = rdp_send_stream_pdu_init(rdp);
+
+	if (!s)
+		return NULL;
+
+	if (!Stream_SafeSeek(s, RDP_SHARE_DATA_HEADER_LENGTH))
+		goto fail;
+
+	return s;
+fail:
+	Stream_Release(s);
+	return NULL;
 }
 
 BOOL rdp_set_error_info(rdpRdp* rdp, UINT32 errorInfo)
@@ -278,15 +294,21 @@ BOOL rdp_set_error_info(rdpRdp* rdp, UINT32 errorInfo)
 
 wStream* rdp_message_channel_pdu_init(rdpRdp* rdp)
 {
-	wStream* s;
-	s = transport_send_stream_init(rdp->transport, 2048);
+	wStream* s = transport_send_stream_init(rdp->transport, 4096);
 
 	if (!s)
 		return NULL;
 
-	Stream_Seek(s, RDP_PACKET_HEADER_MAX_LENGTH);
-	rdp_security_stream_init(rdp, s, TRUE);
+	if (!Stream_SafeSeek(s, RDP_PACKET_HEADER_MAX_LENGTH))
+		goto fail;
+
+	if (!rdp_security_stream_init(rdp, s, TRUE))
+		goto fail;
+
 	return s;
+fail:
+	Stream_Release(s);
+	return NULL;
 }
 
 /**
@@ -537,23 +559,34 @@ static UINT32 rdp_get_sec_bytes(rdpRdp* rdp, UINT16 sec_flags)
 
 BOOL rdp_send(rdpRdp* rdp, wStream* s, UINT16 channel_id)
 {
+	BOOL rc = FALSE;
 	UINT32 pad;
 	UINT16 length;
+
+	if (!s)
+		return FALSE;
+
+	if (!rdp)
+		goto fail;
+
 	length = Stream_GetPosition(s);
 	Stream_SetPosition(s, 0);
 	rdp_write_header(rdp, s, length, channel_id);
 
 	if (!rdp_security_stream_out(rdp, s, length, 0, &pad))
-		return FALSE;
+		goto fail;
 
 	length += pad;
 	Stream_SetPosition(s, length);
 	Stream_SealLength(s);
 
 	if (transport_write(rdp->transport, s) < 0)
-		return FALSE;
+		goto fail;
 
-	return TRUE;
+	rc = TRUE;
+fail:
+	Stream_Release(s);
+	return rc;
 }
 
 BOOL rdp_send_pdu(rdpRdp* rdp, wStream* s, UINT16 type, UINT16 channel_id)
@@ -562,6 +595,10 @@ BOOL rdp_send_pdu(rdpRdp* rdp, wStream* s, UINT16 type, UINT16 channel_id)
 	UINT32 sec_bytes;
 	size_t sec_hold;
 	UINT32 pad;
+
+	if (!rdp || !s)
+		return FALSE;
+
 	length = Stream_GetPosition(s);
 	Stream_SetPosition(s, 0);
 	rdp_write_header(rdp, s, length, MCS_GLOBAL_CHANNEL_ID);
@@ -586,10 +623,18 @@ BOOL rdp_send_pdu(rdpRdp* rdp, wStream* s, UINT16 type, UINT16 channel_id)
 
 BOOL rdp_send_data_pdu(rdpRdp* rdp, wStream* s, BYTE type, UINT16 channel_id)
 {
+	BOOL rc = FALSE;
 	size_t length;
 	UINT32 sec_bytes;
 	size_t sec_hold;
 	UINT32 pad;
+
+	if (!s)
+		return FALSE;
+
+	if (!rdp)
+		goto fail;
+
 	length = Stream_GetPosition(s);
 	Stream_SetPosition(s, 0);
 	rdp_write_header(rdp, s, length, MCS_GLOBAL_CHANNEL_ID);
@@ -601,7 +646,7 @@ BOOL rdp_send_data_pdu(rdpRdp* rdp, wStream* s, BYTE type, UINT16 channel_id)
 	Stream_SetPosition(s, sec_hold);
 
 	if (!rdp_security_stream_out(rdp, s, length, 0, &pad))
-		return FALSE;
+		goto fail;
 
 	length += pad;
 	Stream_SetPosition(s, length);
@@ -610,30 +655,44 @@ BOOL rdp_send_data_pdu(rdpRdp* rdp, wStream* s, BYTE type, UINT16 channel_id)
 	         type, Stream_Length(s), channel_id);
 
 	if (transport_write(rdp->transport, s) < 0)
-		return FALSE;
+		goto fail;
 
-	return TRUE;
+	rc = TRUE;
+fail:
+	Stream_Release(s);
+	return rc;
 }
 
 BOOL rdp_send_message_channel_pdu(rdpRdp* rdp, wStream* s, UINT16 sec_flags)
 {
+	BOOL rc = FALSE;
 	UINT16 length;
 	UINT32 pad;
+
+	if (!s)
+		return FALSE;
+
+	if (!rdp)
+		goto fail;
+
 	length = Stream_GetPosition(s);
 	Stream_SetPosition(s, 0);
 	rdp_write_header(rdp, s, length, rdp->mcs->messageChannelId);
 
 	if (!rdp_security_stream_out(rdp, s, length, sec_flags, &pad))
-		return FALSE;
+		goto fail;
 
 	length += pad;
 	Stream_SetPosition(s, length);
 	Stream_SealLength(s);
 
 	if (transport_write(rdp->transport, s) < 0)
-		return FALSE;
+		goto fail;
 
-	return TRUE;
+	rc = TRUE;
+fail:
+	Stream_Release(s);
+	return rc;
 }
 
 static BOOL rdp_recv_server_shutdown_denied_pdu(rdpRdp* rdp, wStream* s)

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -192,20 +192,18 @@ FREERDP_LOCAL BOOL rdp_read_share_data_header(wStream* s, UINT16* length,
 FREERDP_LOCAL void rdp_write_share_data_header(wStream* s, UINT16 length,
         BYTE type, UINT32 share_id);
 
-FREERDP_LOCAL int rdp_init_stream(rdpRdp* rdp, wStream* s);
 FREERDP_LOCAL wStream* rdp_send_stream_init(rdpRdp* rdp);
+FREERDP_LOCAL wStream* rdp_send_stream_pdu_init(rdpRdp* rdp);
 
 FREERDP_LOCAL BOOL rdp_read_header(rdpRdp* rdp, wStream* s, UINT16* length,
                                    UINT16* channel_id);
 FREERDP_LOCAL void rdp_write_header(rdpRdp* rdp, wStream* s, UINT16 length,
                                     UINT16 channel_id);
 
-FREERDP_LOCAL int rdp_init_stream_pdu(rdpRdp* rdp, wStream* s);
 FREERDP_LOCAL BOOL rdp_send_pdu(rdpRdp* rdp, wStream* s, UINT16 type,
                                 UINT16 channel_id);
 
 FREERDP_LOCAL wStream* rdp_data_pdu_init(rdpRdp* rdp);
-FREERDP_LOCAL int rdp_init_stream_data_pdu(rdpRdp* rdp, wStream* s);
 FREERDP_LOCAL BOOL rdp_send_data_pdu(rdpRdp* rdp, wStream* s, BYTE type,
                                      UINT16 channel_id);
 FREERDP_LOCAL int rdp_recv_data_pdu(rdpRdp* rdp, wStream* s);

--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -995,21 +995,17 @@ static void update_write_refresh_rect(wStream* s, BYTE count,
 static BOOL update_send_refresh_rect(rdpContext* context, BYTE count,
                                      const RECTANGLE_16* areas)
 {
-	wStream* s;
 	rdpRdp* rdp = context->rdp;
 
 	if (rdp->settings->RefreshRect)
 	{
-		BOOL ret;
-		s = rdp_data_pdu_init(rdp);
+		wStream* s = rdp_data_pdu_init(rdp);
 
 		if (!s)
 			return FALSE;
 
 		update_write_refresh_rect(s, count, areas);
-		ret = rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_REFRESH_RECT, rdp->mcs->userId);
-		Stream_Release(s);
-		return ret;
+		return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_REFRESH_RECT, rdp->mcs->userId);
 	}
 
 	return TRUE;
@@ -1034,22 +1030,18 @@ static void update_write_suppress_output(wStream* s, BYTE allow,
 static BOOL update_send_suppress_output(rdpContext* context, BYTE allow,
                                         const RECTANGLE_16* area)
 {
-	wStream* s;
 	rdpRdp* rdp = context->rdp;
 
 	if (rdp->settings->SuppressOutput)
 	{
-		BOOL ret;
-		s = rdp_data_pdu_init(rdp);
+		wStream* s = rdp_data_pdu_init(rdp);
 
 		if (!s)
 			return FALSE;
 
 		update_write_suppress_output(s, allow, area);
-		ret = rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_SUPPRESS_OUTPUT,
-		                        rdp->mcs->userId);
-		Stream_Release(s);
-		return ret;
+		return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_SUPPRESS_OUTPUT,
+		                         rdp->mcs->userId);
 	}
 
 	return TRUE;
@@ -1169,22 +1161,18 @@ out_fail:
 
 static BOOL update_send_frame_acknowledge(rdpContext* context, UINT32 frameId)
 {
-	wStream* s;
 	rdpRdp* rdp = context->rdp;
 
 	if (rdp->settings->ReceivedCapabilities[CAPSET_TYPE_FRAME_ACKNOWLEDGE])
 	{
-		BOOL ret;
-		s = rdp_data_pdu_init(rdp);
+		wStream* s = rdp_data_pdu_init(rdp);
 
 		if (!s)
 			return FALSE;
 
 		Stream_Write_UINT32(s, frameId);
-		ret = rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_FRAME_ACKNOWLEDGE,
-		                        rdp->mcs->userId);
-		Stream_Release(s);
-		return ret;
+		return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_FRAME_ACKNOWLEDGE,
+		                         rdp->mcs->userId);
 	}
 
 	return TRUE;
@@ -1244,7 +1232,6 @@ static BOOL update_send_play_sound(rdpContext* context,
 {
 	wStream* s;
 	rdpRdp* rdp = context->rdp;
-	BOOL ret;
 
 	if (!rdp->settings->ReceivedCapabilities[CAPSET_TYPE_SOUND])
 	{
@@ -1258,9 +1245,7 @@ static BOOL update_send_play_sound(rdpContext* context,
 
 	Stream_Write_UINT32(s, play_sound->duration);
 	Stream_Write_UINT32(s, play_sound->frequency);
-	ret = rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_PLAY_SOUND, rdp->mcs->userId);
-	Stream_Release(s);
-	return ret;
+	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_PLAY_SOUND, rdp->mcs->userId);
 }
 /**
  * Primary Drawing Orders
@@ -2065,7 +2050,6 @@ static BOOL update_send_set_keyboard_indicators(rdpContext* context,
 {
 	wStream* s;
 	rdpRdp* rdp = context->rdp;
-	BOOL ret;
 	s = rdp_data_pdu_init(rdp);
 
 	if (!s)
@@ -2074,10 +2058,8 @@ static BOOL update_send_set_keyboard_indicators(rdpContext* context,
 	Stream_Write_UINT16(s,
 	                    0); /* unitId should be 0 according to MS-RDPBCGR 2.2.8.2.1.1 */
 	Stream_Write_UINT16(s, led_flags); /* ledFlags (2 bytes) */
-	ret = rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_SET_KEYBOARD_INDICATORS,
-	                        rdp->mcs->userId);
-	Stream_Release(s);
-	return ret;
+	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_SET_KEYBOARD_INDICATORS,
+	                         rdp->mcs->userId);
 }
 
 static BOOL update_send_set_keyboard_ime_status(rdpContext* context,
@@ -2085,7 +2067,6 @@ static BOOL update_send_set_keyboard_ime_status(rdpContext* context,
 {
 	wStream* s;
 	rdpRdp* rdp = context->rdp;
-	BOOL ret;
 	s = rdp_data_pdu_init(rdp);
 
 	if (!s)
@@ -2095,10 +2076,8 @@ static BOOL update_send_set_keyboard_ime_status(rdpContext* context,
 	Stream_Write_UINT16(s, imeId);
 	Stream_Write_UINT32(s, imeState);
 	Stream_Write_UINT32(s, imeConvMode);
-	ret = rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_SET_KEYBOARD_IME_STATUS,
-	                        rdp->mcs->userId);
-	Stream_Release(s);
-	return ret;
+	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_SET_KEYBOARD_IME_STATUS,
+	                         rdp->mcs->userId);
 }
 
 void update_register_server_callbacks(rdpUpdate* update)

--- a/winpr/libwinpr/utils/collections/StreamPool.c
+++ b/winpr/libwinpr/utils/collections/StreamPool.c
@@ -175,6 +175,7 @@ wStream* StreamPool_Take(wStreamPool* pool, size_t size)
 	else
 	{
 		Stream_SetPosition(s, 0);
+		Stream_SetLength(s, Stream_Capacity(s));
 		StreamPool_ShiftAvailable(pool, foundIndex, -1);
 	}
 


### PR DESCRIPTION
* Handling stream allocation and free for buffers used for `transport_write` was quite error prone, this pull tries to address this.
* `StreamPool_Take` did not reset used stream length to current capacity letting `Stream_SafeSeek` and other operations dependent on length fail.