### PR TITLE
Add WINPR_DLL definition to control WinPR symbol exporting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1037,6 +1037,10 @@ else()
 	set(PRIVATE_KEYWORD "PRIVATE")
 endif()
 
+if(BUILD_SHARED_LIBS)
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWINPR_DLL")
+endif()
+
 add_subdirectory(winpr)
 
 # Sub-directories

--- a/winpr/CMakeLists.txt
+++ b/winpr/CMakeLists.txt
@@ -158,6 +158,10 @@ if(NOT DEFINED BUILD_SHARED_LIBS)
 	set(BUILD_SHARED_LIBS ON)
 endif()
 
+if(BUILD_SHARED_LIBS)
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWINPR_DLL")
+endif()
+
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWINPR_EXPORTS")
 
 # Enable 64bit file support on linux and FreeBSD.

--- a/winpr/include/winpr/winpr.h
+++ b/winpr/include/winpr/winpr.h
@@ -21,6 +21,7 @@
 
 #include <winpr/platform.h>
 
+#ifdef WINPR_DLL
 #if defined _WIN32 || defined __CYGWIN__
 #ifdef WINPR_EXPORTS
 #ifdef __GNUC__
@@ -41,6 +42,9 @@
 #else
 #define WINPR_API
 #endif
+#endif
+#else /* WINPR_DLL */
+#define WINPR_API	
 #endif
 
 /* Thread local storage keyword define */


### PR DESCRIPTION
Add a WINPR_DLL definition to allow better control over dllimport/dllexport when not building a DLL. This change is necessary to make it possible to build an executable or library that will not automatically re-export the WinPR symbols (in this case, WINPR_DLL should not be defined).