### PR TITLE
winpr: add some functions to use wStream in a static way

### DIFF
--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -52,6 +52,9 @@ WINPR_API BOOL Stream_EnsureRemainingCapacity(wStream* s, size_t size);
 WINPR_API wStream* Stream_New(BYTE* buffer, size_t size);
 WINPR_API void Stream_Free(wStream* s, BOOL bFreeBuffer);
 
+WINPR_API BOOL Stream_StaticInit(wStream *s, BYTE* buffer, size_t size);
+WINPR_API void Stream_StaticFree(wStream *s, BOOL bFreeBuffer);
+
 static INLINE void Stream_Seek(wStream* s, size_t _offset)
 {
 	s->pointer += (_offset);

--- a/winpr/libwinpr/utils/stream.c
+++ b/winpr/libwinpr/utils/stream.c
@@ -66,6 +66,28 @@ BOOL Stream_EnsureRemainingCapacity(wStream* s, size_t size)
 	return TRUE;
 }
 
+BOOL Stream_StaticInit(wStream *s, BYTE* buffer, size_t size)
+{
+	if (buffer)
+		s->buffer = buffer;
+	else
+		s->buffer = (BYTE*) malloc(size);
+
+	if (!s->buffer)
+		return FALSE;
+
+	s->pointer = s->buffer;
+	s->capacity = size;
+	s->length = size;
+
+	s->pool = NULL;
+	s->count = 0;
+
+	return TRUE;
+}
+
+
+
 wStream* Stream_New(BYTE* buffer, size_t size)
 {
 	wStream* s;
@@ -78,35 +100,29 @@ wStream* Stream_New(BYTE* buffer, size_t size)
 	if (!s)
 		return NULL;
 
-
-	if (buffer)
-		s->buffer = buffer;
-	else
-		s->buffer = (BYTE*) malloc(size);
-
-	if (!s->buffer)
+	if (!Stream_StaticInit(s, buffer, size))
 	{
 		free(s);
 		return NULL;
 	}
 
-	s->pointer = s->buffer;
-	s->capacity = size;
-	s->length = size;
-
-	s->pool = NULL;
-	s->count = 0;
-
 	return s;
+}
+
+void Stream_StaticFree(wStream *s, BOOL bFreeBuffer)
+{
+	if (s)
+	{
+		if (bFreeBuffer)
+			free(s->buffer);
+	}
 }
 
 void Stream_Free(wStream* s, BOOL bFreeBuffer)
 {
 	if (s)
 	{
-		if (bFreeBuffer)
-			free(s->buffer);
-
+		Stream_StaticFree(s, bFreeBuffer);
 		free(s);
 	}
 }

--- a/winpr/libwinpr/utils/test/TestStream.c
+++ b/winpr/libwinpr/utils/test/TestStream.c
@@ -74,6 +74,27 @@ static BOOL TestStream_New()
 	return TRUE;
 }
 
+static BOOL TestStream_Static()
+{
+	BYTE buffer[20];
+	wStream staticStream, *s = &staticStream;
+	UINT16 v;
+
+	/* Test creation of a static stream */
+	if (!Stream_StaticInit(s, buffer, sizeof(buffer)))
+		return FALSE;
+
+	Stream_Write_UINT16(s, 0xcab1);
+	Stream_SetPosition(s, 0);
+	Stream_Read_UINT16(s, v);
+
+	if (v != 0xcab1)
+		return FALSE;
+
+	Stream_StaticFree(s, FALSE);
+	return TRUE;
+}
+
 
 static BOOL TestStream_Create(int count, BOOL selfAlloc)
 {
@@ -541,6 +562,9 @@ int TestStream(int argc, char* argv[])
 
 	if (!TestStream_Copy())
 		return 11;
+
+	if (!TestStream_Static())
+		return 12;
 
 	return 0;
 }


### PR DESCRIPTION
It's sometime useful to create a stream aliasing a buffer on the stack, and it's nice if we don't need some extra malloc for this.

Example use:
```C
   BYTE buffer[20];
   wStream s;

   Stream_StaticInit(&s, buffer, sizeof(buffer));
   Stream_Write_UINT16(&s, 0xff01);
   Stream_StaticFree(&s, FALSE);
```
