### PR TITLE
Order data validation and correction

### DIFF
--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -1197,7 +1197,7 @@ static void rdpsnd_virtual_channel_event_terminated(rdpsndPlugin* rdpsnd)
 {
 	if (rdpsnd)
 	{
-		audio_format_free(rdpsnd->fixed_format);
+		audio_formats_free(rdpsnd->fixed_format, 1);
 		free(rdpsnd->subsystem);
 		free(rdpsnd->device_name);
 		CloseHandle(rdpsnd->stopEvent);

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1096,9 +1096,9 @@ static BOOL xf_pre_connect(freerdp* instance)
 	settings->OrderSupport[NEG_SCRBLT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_OPAQUE_RECT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_DRAWNINEGRID_INDEX] = FALSE;
-	settings->OrderSupport[NEG_MULTIDSTBLT_INDEX] = TRUE;
-	settings->OrderSupport[NEG_MULTIPATBLT_INDEX] = TRUE;
-	settings->OrderSupport[NEG_MULTISCRBLT_INDEX] = TRUE;
+	settings->OrderSupport[NEG_MULTIDSTBLT_INDEX] = FALSE;
+	settings->OrderSupport[NEG_MULTIPATBLT_INDEX] = FALSE;
+	settings->OrderSupport[NEG_MULTISCRBLT_INDEX] = FALSE;
 	settings->OrderSupport[NEG_MULTIOPAQUERECT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_MULTI_DRAWNINEGRID_INDEX] = FALSE;
 	settings->OrderSupport[NEG_LINETO_INDEX] = TRUE;

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1108,9 +1108,9 @@ static BOOL xf_pre_connect(freerdp* instance)
 	settings->OrderSupport[NEG_MEMBLT_V2_INDEX] = settings->BitmapCacheEnabled;
 	settings->OrderSupport[NEG_MEM3BLT_V2_INDEX] = settings->BitmapCacheEnabled;
 	settings->OrderSupport[NEG_SAVEBITMAP_INDEX] = FALSE;
-	settings->OrderSupport[NEG_GLYPH_INDEX_INDEX] = FALSE;
-	settings->OrderSupport[NEG_FAST_INDEX_INDEX] = FALSE;
-	settings->OrderSupport[NEG_FAST_GLYPH_INDEX] = FALSE;
+	settings->OrderSupport[NEG_GLYPH_INDEX_INDEX] = settings->GlyphSupportLevel != GLYPH_SUPPORT_NONE;
+	settings->OrderSupport[NEG_FAST_INDEX_INDEX] = settings->GlyphSupportLevel != GLYPH_SUPPORT_NONE;
+	settings->OrderSupport[NEG_FAST_GLYPH_INDEX] = settings->GlyphSupportLevel != GLYPH_SUPPORT_NONE;
 	settings->OrderSupport[NEG_POLYGON_SC_INDEX] = FALSE;
 	settings->OrderSupport[NEG_POLYGON_CB_INDEX] = FALSE;
 	settings->OrderSupport[NEG_ELLIPSE_SC_INDEX] = FALSE;

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1096,9 +1096,9 @@ static BOOL xf_pre_connect(freerdp* instance)
 	settings->OrderSupport[NEG_SCRBLT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_OPAQUE_RECT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_DRAWNINEGRID_INDEX] = FALSE;
-	settings->OrderSupport[NEG_MULTIDSTBLT_INDEX] = FALSE;
-	settings->OrderSupport[NEG_MULTIPATBLT_INDEX] = FALSE;
-	settings->OrderSupport[NEG_MULTISCRBLT_INDEX] = FALSE;
+	settings->OrderSupport[NEG_MULTIDSTBLT_INDEX] = TRUE;
+	settings->OrderSupport[NEG_MULTIPATBLT_INDEX] = TRUE;
+	settings->OrderSupport[NEG_MULTISCRBLT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_MULTIOPAQUERECT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_MULTI_DRAWNINEGRID_INDEX] = FALSE;
 	settings->OrderSupport[NEG_LINETO_INDEX] = TRUE;
@@ -1108,9 +1108,9 @@ static BOOL xf_pre_connect(freerdp* instance)
 	settings->OrderSupport[NEG_MEMBLT_V2_INDEX] = settings->BitmapCacheEnabled;
 	settings->OrderSupport[NEG_MEM3BLT_V2_INDEX] = settings->BitmapCacheEnabled;
 	settings->OrderSupport[NEG_SAVEBITMAP_INDEX] = FALSE;
-	settings->OrderSupport[NEG_GLYPH_INDEX_INDEX] = TRUE;
-	settings->OrderSupport[NEG_FAST_INDEX_INDEX] = TRUE;
-	settings->OrderSupport[NEG_FAST_GLYPH_INDEX] = TRUE;
+	settings->OrderSupport[NEG_GLYPH_INDEX_INDEX] = FALSE;
+	settings->OrderSupport[NEG_FAST_INDEX_INDEX] = FALSE;
+	settings->OrderSupport[NEG_FAST_GLYPH_INDEX] = FALSE;
 	settings->OrderSupport[NEG_POLYGON_SC_INDEX] = FALSE;
 	settings->OrderSupport[NEG_POLYGON_CB_INDEX] = FALSE;
 	settings->OrderSupport[NEG_ELLIPSE_SC_INDEX] = FALSE;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1744,6 +1744,10 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		{
 			settings->ConsoleSession = TRUE;
 		}
+		CommandLineSwitchCase(arg, "relax-order-checks")
+		{
+			settings->AllowUnanouncedOrdersFromServer = arg->Value;
+		}
 		CommandLineSwitchCase(arg, "restricted-admin")
 		{
 			settings->ConsoleSession = TRUE;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -142,6 +142,7 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "pwidth", COMMAND_LINE_VALUE_REQUIRED, "<width>", NULL, NULL, -1, NULL, "Physical width of display (in millimeters)" },
 	{ "reconnect-cookie", COMMAND_LINE_VALUE_REQUIRED, "<base64-cookie>", NULL, NULL, -1, NULL, "Pass base64 reconnect cookie to the connection" },
 	{ "redirect-prefer", COMMAND_LINE_VALUE_REQUIRED, "<FQDN|IP|NETBIOS>[,<FQDN|IP|NETBIOS>[,<FQDN|IP|NETBIOS>]]", NULL, NULL, -1, NULL, "Override the preferred redirection order" },
+	{ "relax-order-checks", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "relax-order-checks", "Do not check if a RDP order was announced during capability exchange, only use when connecting to a buggy server" },
 	{ "restricted-admin", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "restrictedAdmin", "Restricted admin mode" },
 	{ "rfx", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "RemoteFX" },
 	{ "rfx-mode", COMMAND_LINE_VALUE_REQUIRED, "image|video", NULL, NULL, -1, NULL, "RemoteFX mode" },

--- a/include/freerdp/primary.h
+++ b/include/freerdp/primary.h
@@ -212,7 +212,7 @@ struct _MULTI_DRAW_NINE_GRID_ORDER
 	UINT32 bitmapId;
 	UINT32 nDeltaEntries;
 	UINT32 cbData;
-	BYTE* codeDeltaList;
+	DELTA_RECT rectangles[45];
 };
 typedef struct _MULTI_DRAW_NINE_GRID_ORDER MULTI_DRAW_NINE_GRID_ORDER;
 

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -165,15 +165,15 @@
 #define NEG_MEMBLT_INDEX			0x03
 #define NEG_MEM3BLT_INDEX			0x04
 #define NEG_ATEXTOUT_INDEX			0x05
-#define NEG_AEXTTEXTOUT_INDEX			0x06
-#define NEG_DRAWNINEGRID_INDEX			0x07
+#define NEG_AEXTTEXTOUT_INDEX			0x06 /* Must be ignored */
+#define NEG_DRAWNINEGRID_INDEX			0x07 /* Must be ignored */
 #define NEG_LINETO_INDEX			0x08
 #define NEG_MULTI_DRAWNINEGRID_INDEX		0x09
-#define NEG_OPAQUE_RECT_INDEX			0x0A
+#define NEG_OPAQUE_RECT_INDEX			0x0A /* Must be ignored */
 #define NEG_SAVEBITMAP_INDEX			0x0B
-#define NEG_WTEXTOUT_INDEX			0x0C
-#define NEG_MEMBLT_V2_INDEX			0x0D
-#define NEG_MEM3BLT_V2_INDEX			0x0E
+#define NEG_WTEXTOUT_INDEX			0x0C /* Must be ignored */
+#define NEG_MEMBLT_V2_INDEX			0x0D /* Must be ignored */
+#define NEG_MEM3BLT_V2_INDEX			0x0E /* Must be ignored */
 #define NEG_MULTIDSTBLT_INDEX			0x0F
 #define NEG_MULTIPATBLT_INDEX			0x10
 #define NEG_MULTISCRBLT_INDEX			0x11
@@ -182,15 +182,15 @@
 #define NEG_POLYGON_SC_INDEX			0x14
 #define NEG_POLYGON_CB_INDEX			0x15
 #define NEG_POLYLINE_INDEX			0x16
-#define NEG_UNUSED23_INDEX			0x17
+#define NEG_UNUSED23_INDEX			0x17 /* Must be ignored */
 #define NEG_FAST_GLYPH_INDEX			0x18
 #define NEG_ELLIPSE_SC_INDEX			0x19
 #define NEG_ELLIPSE_CB_INDEX			0x1A
 #define NEG_GLYPH_INDEX_INDEX			0x1B
-#define NEG_GLYPH_WEXTTEXTOUT_INDEX		0x1C
-#define NEG_GLYPH_WLONGTEXTOUT_INDEX		0x1D
-#define NEG_GLYPH_WLONGEXTTEXTOUT_INDEX		0x1E
-#define NEG_UNUSED31_INDEX			0x1F
+#define NEG_GLYPH_WEXTTEXTOUT_INDEX		0x1C /* Must be ignored */
+#define NEG_GLYPH_WLONGTEXTOUT_INDEX		0x1D /* Must be ignored */
+#define NEG_GLYPH_WLONGEXTTEXTOUT_INDEX		0x1E /* Must be ignored */
+#define NEG_UNUSED31_INDEX			0x1F /* Must be ignored */
 
 /* Glyph Support Level */
 #define GLYPH_SUPPORT_NONE			0x0000
@@ -1265,7 +1265,8 @@ struct rdp_settings
 	ALIGN64 BYTE* OrderSupport;             /* 2432 */
 	ALIGN64 BOOL  BitmapCacheV3Enabled;     /* 2433 */
 	ALIGN64 BOOL  AltSecFrameMarkerSupport; /* 2434 */
-	UINT64 padding2497[2497 - 2435]; /* 2435 */
+	ALIGN64 BOOL  AllowUnanouncedOrdersFromServer; /* 2435 */
+	UINT64 padding2497[2497 - 2436]; /* 2436 */
 
 	/* Bitmap Cache Capabilities */
 	ALIGN64 BOOL                       BitmapCacheEnabled;        /* 2497 */

--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -87,6 +87,9 @@ BOOL freerdp_image_copy_from_monochrome(BYTE* pDstData, UINT32 DstFormat,
 	UINT32 monoStep;
 	const UINT32 dstBytesPerPixel = GetBytesPerPixel(DstFormat);
 
+	if (!pDstData || !pSrcData || !palette)
+		return FALSE;
+
 	if (nDstStep == 0)
 		nDstStep = dstBytesPerPixel * nWidth;
 
@@ -203,7 +206,7 @@ BOOL freerdp_image_copy_from_pointer_data(
 				const BYTE* andBits;
 				const BYTE* xorBits;
 				BYTE* pDstPixel = &pDstData[((nYDst + y) * nDstStep) +
-				                            (nXDst * GetBytesPerPixel(DstFormat))];
+				                                         (nXDst * GetBytesPerPixel(DstFormat))];
 				xorBit = andBit = 0x80;
 
 				if (!vFlip)
@@ -281,7 +284,7 @@ BOOL freerdp_image_copy_from_pointer_data(
 					const BYTE* xorBits;
 					const BYTE* andBits = NULL;
 					BYTE* pDstPixel = &pDstData[((nYDst + y) * nDstStep) +
-					                            (nXDst * GetBytesPerPixel(DstFormat))];
+					                                         (nXDst * GetBytesPerPixel(DstFormat))];
 					andBit = 0x80;
 
 					if (!vFlip)
@@ -326,9 +329,9 @@ BOOL freerdp_image_copy_from_pointer_data(
 						}
 
 						xorPixel = FreeRDPConvertColor(xorPixel,
-						                        pixelFormat,
-						                        PIXEL_FORMAT_ARGB32,
-						                        palette);
+						                               pixelFormat,
+						                               PIXEL_FORMAT_ARGB32,
+						                               palette);
 						xorBits += xorBytesPerPixel;
 						andPixel = 0;
 
@@ -352,7 +355,7 @@ BOOL freerdp_image_copy_from_pointer_data(
 						}
 
 						color = FreeRDPConvertColor(xorPixel, PIXEL_FORMAT_ARGB32,
-						                     DstFormat, palette);
+						                            DstFormat, palette);
 						WriteColor(pDstPixel, DstFormat, color);
 						pDstPixel += GetBytesPerPixel(DstFormat);
 					}
@@ -435,11 +438,11 @@ BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat,
 				for (y = 0; y < nHeight; y++)
 				{
 					const BYTE* srcLine = &pSrcData[(y + nYSrc) *
-					                                nSrcStep * srcVMultiplier +
-					                                srcVOffset];
+					                                            nSrcStep * srcVMultiplier +
+					                                            srcVOffset];
 					BYTE* dstLine = &pDstData[(y + nYDst) *
-					                          nDstStep * dstVMultiplier +
-					                          dstVOffset];
+					                                      nDstStep * dstVMultiplier +
+					                                      dstVOffset];
 					memcpy(&dstLine[xDstOffset],
 					       &srcLine[xSrcOffset], copyDstWidth);
 				}
@@ -450,11 +453,11 @@ BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat,
 				for (y = nHeight - 1; y >= 0; y--)
 				{
 					const BYTE* srcLine = &pSrcData[(y + nYSrc) *
-					                                nSrcStep * srcVMultiplier +
-					                                srcVOffset];
+					                                            nSrcStep * srcVMultiplier +
+					                                            srcVOffset];
 					BYTE* dstLine = &pDstData[(y + nYDst) *
-					                          nDstStep * dstVMultiplier +
-					                          dstVOffset];
+					                                      nDstStep * dstVMultiplier +
+					                                      dstVOffset];
 					memcpy(&dstLine[xDstOffset],
 					       &srcLine[xSrcOffset], copyDstWidth);
 				}
@@ -465,11 +468,11 @@ BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat,
 				for (y = 0; y < nHeight; y++)
 				{
 					const BYTE* srcLine = &pSrcData[(y + nYSrc) *
-					                                nSrcStep * srcVMultiplier +
-					                                srcVOffset];
+					                                            nSrcStep * srcVMultiplier +
+					                                            srcVOffset];
 					BYTE* dstLine = &pDstData[(y + nYDst) *
-					                          nDstStep * dstVMultiplier +
-					                          dstVOffset];
+					                                      nDstStep * dstVMultiplier +
+					                                      dstVOffset];
 					memmove(&dstLine[xDstOffset],
 					        &srcLine[xSrcOffset], copyDstWidth);
 				}
@@ -480,11 +483,11 @@ BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat,
 				for (y = nHeight - 1; y >= 0; y--)
 				{
 					const BYTE* srcLine = &pSrcData[(y + nYSrc) *
-					                                nSrcStep * srcVMultiplier +
-					                                srcVOffset];
+					                                            nSrcStep * srcVMultiplier +
+					                                            srcVOffset];
 					BYTE* dstLine = &pDstData[(y + nYDst) *
-					                          nDstStep * dstVMultiplier +
-					                          dstVOffset];
+					                                      nDstStep * dstVMultiplier +
+					                                      dstVOffset];
 					memmove(&dstLine[xDstOffset],
 					        &srcLine[xSrcOffset], copyDstWidth);
 				}
@@ -499,11 +502,11 @@ BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat,
 			for (y = 0; y < nHeight; y++)
 			{
 				const BYTE* srcLine = &pSrcData[(y + nYSrc) *
-				                                nSrcStep * srcVMultiplier +
-				                                srcVOffset];
+				                                            nSrcStep * srcVMultiplier +
+				                                            srcVOffset];
 				BYTE* dstLine = &pDstData[(y + nYDst) *
-				                          nDstStep * dstVMultiplier +
-				                          dstVOffset];
+				                                      nDstStep * dstVMultiplier +
+				                                      dstVOffset];
 				memcpy(&dstLine[xDstOffset],
 				       &srcLine[xSrcOffset], copyDstWidth);
 			}
@@ -516,10 +519,10 @@ BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat,
 		for (y = 0; y < nHeight; y++)
 		{
 			const BYTE* srcLine = &pSrcData[(y + nYSrc) *
-			                                nSrcStep * srcVMultiplier +
-			                                srcVOffset];
+			                                            nSrcStep * srcVMultiplier +
+			                                            srcVOffset];
 			BYTE* dstLine = &pDstData[(y + nYDst) *
-			                          nDstStep * dstVMultiplier + dstVOffset];
+			                                      nDstStep * dstVMultiplier + dstVOffset];
 
 			for (x = 0; x < nWidth; x++)
 			{

--- a/libfreerdp/codec/include/bitmap.c
+++ b/libfreerdp/codec/include/bitmap.c
@@ -292,7 +292,7 @@ static INLINE BYTE* WRITEFIRSTLINEFGBGIMAGE(BYTE* pbDest, BYTE bitmask,
 /**
  * Decompress an RLE compressed bitmap.
  */
-static INLINE void RLEDECOMPRESS(const BYTE* pbSrcBuffer, UINT32 cbSrcBuffer,
+static INLINE BOOL RLEDECOMPRESS(const BYTE* pbSrcBuffer, UINT32 cbSrcBuffer,
                                  BYTE* pbDestBuffer,
                                  UINT32 rowDelta, UINT32 width, UINT32 height)
 {
@@ -309,6 +309,9 @@ static INLINE void RLEDECOMPRESS(const BYTE* pbSrcBuffer, UINT32 cbSrcBuffer,
 	UINT32 code;
 	UINT32 advance;
 	RLEEXTRA
+
+	if (!pbSrcBuffer || !pbDestBuffer)
+		return FALSE;
 
 	while (pbSrc < pbEnd)
 	{
@@ -628,6 +631,11 @@ static INLINE void RLEDECOMPRESS(const BYTE* pbSrcBuffer, UINT32 cbSrcBuffer,
 				DESTWRITEPIXEL(pbDest, BLACK_PIXEL);
 				DESTNEXTPIXEL(pbDest);
 				break;
+
+			default:
+				return FALSE;
 		}
 	}
+
+	return TRUE;
 }

--- a/libfreerdp/codec/interleaved.c
+++ b/libfreerdp/codec/interleaved.c
@@ -276,7 +276,7 @@ BOOL interleaved_decompress(BITMAP_INTERLEAVED_CONTEXT* interleaved,
 	UINT32 SrcFormat;
 	UINT32 BufferSize;
 
-	if (!interleaved)
+	if (!interleaved || !pSrcData || !pDstData)
 		return FALSE;
 
 	switch (bpp)
@@ -322,19 +322,25 @@ BOOL interleaved_decompress(BITMAP_INTERLEAVED_CONTEXT* interleaved,
 	switch (bpp)
 	{
 		case 24:
-			RleDecompress24to24(pSrcData, SrcSize, interleaved->TempBuffer,
-			                    scanline, nSrcWidth, nSrcHeight);
+			if (!RleDecompress24to24(pSrcData, SrcSize, interleaved->TempBuffer,
+			                         scanline, nSrcWidth, nSrcHeight))
+				return FALSE;
+
 			break;
 
 		case 16:
 		case 15:
-			RleDecompress16to16(pSrcData, SrcSize, interleaved->TempBuffer,
-			                    scanline, nSrcWidth, nSrcHeight);
+			if (!RleDecompress16to16(pSrcData, SrcSize, interleaved->TempBuffer,
+			                         scanline, nSrcWidth, nSrcHeight))
+				return FALSE;
+
 			break;
 
 		case 8:
-			RleDecompress8to8(pSrcData, SrcSize, interleaved->TempBuffer,
-			                  scanline, nSrcWidth, nSrcHeight);
+			if (!RleDecompress8to8(pSrcData, SrcSize, interleaved->TempBuffer,
+			                       scanline, nSrcWidth, nSrcHeight))
+				return FALSE;
+
 			break;
 
 		default:

--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -1453,7 +1453,7 @@ static BOOL rdp_write_brush_capability_set(wStream* s, rdpSettings* settings)
 		return FALSE;
 
 	header = rdp_capability_set_start(s);
-	Stream_Write_UINT32(s, BRUSH_COLOR_FULL); /* brushSupportLevel (4 bytes) */
+	Stream_Write_UINT32(s, settings->BrushSupportLevel); /* brushSupportLevel (4 bytes) */
 	rdp_capability_set_finish(s, header, CAPSET_TYPE_BRUSH);
 	return TRUE;
 }

--- a/libfreerdp/core/fastpath.c
+++ b/libfreerdp/core/fastpath.c
@@ -265,15 +265,24 @@ static BOOL fastpath_recv_orders(rdpFastPath* fastpath, wStream* s)
 	UINT16 numberOrders;
 
 	if (!fastpath || !fastpath->rdp || !s)
+	{
+		WLog_ERR(TAG, "Invalid arguments");
 		return FALSE;
+	}
 
 	update = fastpath->rdp->update;
 
 	if (!update)
+	{
+		WLog_ERR(TAG, "Invalid configuration");
 		return FALSE;
+	}
 
 	if (Stream_GetRemainingLength(s) < 2)
+	{
+		WLog_ERR(TAG, "Stream short");
 		return FALSE;
+	}
 
 	Stream_Read_UINT16(s, numberOrders); /* numberOrders (2 bytes) */
 

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -212,100 +212,89 @@ static const char* altsec_order_string(BYTE orderType)
 	return buffer;
 }
 
-static BOOL freerdp_primary_check_bound(rdpContext* context, INT32 left, INT32 top, INT32 right,
-                                        INT32 bottom)
-{
-	if (!context || !context->settings)
-		goto fail;
-
-	if (left < 0)
-		goto fail;
-
-	if (top < 0)
-		goto fail;
-
-	if (right < 0)
-		goto fail;
-
-	if (bottom < 0)
-		goto fail;
-
-	if (left > context->settings->DesktopWidth)
-		goto fail;
-
-	if (right > context->settings->DesktopWidth)
-		goto fail;
-
-	if (top > context->settings->DesktopHeight)
-		goto fail;
-
-	if (bottom > context->settings->DesktopHeight)
-		goto fail;
-
-	return TRUE;
-fail:
-	WLog_ERR(TAG, "Invalid bounds: %"PRId32", %"PRId32", %"PRId32", %"PRId32"", left, top, right,
-	         bottom);
-	return FALSE;
-}
-
-static BOOL freerdp_primary_check_bounds(rdpContext* context, const rdpBounds* bounds)
-{
-	if (!context || !context->settings || !bounds)
-		return FALSE;
-
-	return freerdp_primary_check_bound(context, bounds->left, bounds->top, bounds->right,
-	                                   bounds->bottom);
-}
-
-static BOOL freerdp_primary_check_rect(rdpContext* context, INT32* pLeft, INT32* pTop,
-                                       INT32* pWidth,
-                                       INT32* pHeight)
+static BOOL freerdp_primary_adjust_bound(wLog* log, const char* order, rdpContext* context,
+        INT32* pLeft, INT32* pTop,
+        INT32* pRight,
+        INT32* pBottom)
 {
 	UINT32 dw, dh;
 	INT32 left = *pLeft;
 	INT32 top = *pTop;
-	INT32 width = *pWidth;
-	INT32 height = *pHeight;
+	INT32 right = *pRight;
+	INT32 bottom = *pBottom;
 
 	if (!context || !context->settings)
-		goto fail;
+		return FALSE;
 
 	dw = context->settings->DesktopWidth;
 	dh = context->settings->DesktopHeight;
 
+	if (top == -32768)
+		WLog_ERR(TAG, "xxx");
+
+	if (bottom == -32768)
+		WLog_ERR(TAG, "xxx");
+
 	if (left < 0)
-		goto fail;
+		left = 0;
 
 	if (top < 0)
-		goto fail;
+		top = 0;
 
-	if (width < 0)
-		goto fail;
+	if (right < 0)
+		right = 0;
 
-	if (height < 0)
-		goto fail;
+	if (bottom < 0)
+		bottom = 0;
 
-	if (left > dw)
-		goto fail;
+	if (right > dw)
+		right = dw;
 
-	if (left + width > dw)
-		goto fail;
+	if (left > right)
+		left = right;
 
 	if (top > dh)
-		goto fail;
+		top = dh;
 
-	if (top + height > dh)
-		goto fail;
+	if (bottom > dh)
+		bottom = dh;
 
+	if (top > bottom)
+		top = bottom;
+
+	if (*pLeft != left)
+		WLog_Print(log, WLOG_WARN, "[%s] Adjusted left from %"PRId32" to %"PRId32, order, *pLeft, left);
+
+	if (*pTop != top)
+		WLog_Print(log, WLOG_WARN, "[%s] Adjusted top from %"PRId32" to %"PRId32, order, *pTop, top);
+
+	if (*pRight != right)
+		WLog_Print(log, WLOG_WARN, "[%s] Adjusted right from %"PRId32" to %"PRId32, order, *pRight, right);
+
+	if (*pBottom != bottom)
+		WLog_Print(log, WLOG_WARN, "[%s] Adjusted bottom from %"PRId32" to %"PRId32, order, *pBottom,
+		           bottom);
+
+	*pLeft = left;
+	*pTop = top;
+	*pRight = right;
+	*pBottom = bottom;
 	return TRUE;
-fail:
-	WLog_ERR(TAG, "Invalid bounds: %"PRId32", %"PRId32", %"PRId32", %"PRId32"",
-	         left, top, width, height);
-	return FALSE;
 }
 
-static BOOL freerdp_primary_adjust_rect(rdpContext* context, INT32* pLeft, INT32* pTop,
+static BOOL freerdp_primary_adjust_bounds(wLog* log, const char* order, rdpContext* context,
+        rdpBounds* bounds)
+{
+	if (!context || !context->settings || !bounds)
+		return FALSE;
+
+	return freerdp_primary_adjust_bound(log, order, context, &bounds->left, &bounds->top,
+	                                    &bounds->right,
+	                                    &bounds->bottom);
+}
+
+static BOOL freerdp_primary_adjust_rect(wLog* log, const char* order, rdpContext* context,
+                                        INT32* pLeft, INT32* pTop,
                                         INT32* pWidth,
                                         INT32* pHeight)
 {
@@ -345,6 +334,19 @@ static BOOL freerdp_primary_adjust_rect(rdpContext* context, INT32* pLeft, INT32
 	if (top + height > dh)
 		height = dh - top;
 
+	if (*pLeft != left)
+		WLog_Print(log, WLOG_WARN, "[%s] Adjusted left from %"PRId32" to %"PRId32, order, *pLeft, left);
+
+	if (*pTop != top)
+		WLog_Print(log, WLOG_WARN, "[%s] Adjusted top from %"PRId32" to %"PRId32, order, *pTop, top);
+
+	if (*pWidth != width)
+		WLog_Print(log, WLOG_WARN, "[%s] Adjusted width from %"PRId32" to %"PRId32, order, *pWidth, width);
+
+	if (*pHeight != height)
+		WLog_Print(log, WLOG_WARN, "[%s] Adjusted height from %"PRId32" to %"PRId32, order, *pHeight,
+		           height);
+
 	*pLeft = left;
 	*pTop = top;
 	*pWidth = width;
@@ -352,9 +354,12 @@ static BOOL freerdp_primary_adjust_rect(rdpContext* context, INT32* pLeft, INT32
 	return TRUE;
 }
 
-static BOOL freerdp_check_point(rdpContext* context, INT32 x, INT32 y)
+static BOOL freerdp_adjust_point(wLog* log, const char* order, rdpContext* context, INT32* pX,
+                                 INT32* pY)
 {
 	UINT32 dw, dh;
+	INT32 x = *pX;
+	INT32 y = *pY;
 
 	if (!context || !context->settings)
 		return FALSE;
@@ -362,22 +367,33 @@ static BOOL freerdp_check_point(rdpContext* context, INT32 x, INT32 y)
 	dw = context->settings->DesktopWidth;
 	dh = context->settings->DesktopHeight;
 
+	if (x == -32768)
+		WLog_ERR(TAG, "xxx");
+
+	if (y == -32768)
+		WLog_ERR(TAG, "xxx");
+
 	if (x < 0)
-		goto fail;
+		x = 0;
 
 	if (y < 0)
-		goto fail;
+		y = 0;
 
 	if (x > dw)
-		goto fail;
+		x = dw;
 
 	if (y > dh)
-		goto fail;
+		y = dh;
 
+	if (x != *pX)
+		WLog_Print(log, WLOG_WARN, "[%s] adjusted x from %"PRId32" to %"PRId32, order, *pX, x);
+
+	if (y != *pY)
+		WLog_Print(log, WLOG_WARN, "[%s] adjusted y from %"PRId32" to %"PRId32, order, *pY, y);
+
+	*pX = x;
+	*pY = y;
 	return TRUE;
-fail:
-	WLog_ERR(TAG, "Invalid point %"PRId32"x%"PRId32" [%"PRIu32"x%"PRIu32"]", x, y, dw, dh);
-	return FALSE;
 }
 
 static BOOL adjust_point(rdpContext* context, INT32* px, INT32* py)
@@ -410,31 +426,8 @@ static BOOL adjust_point(rdpContext* context, INT32* px, INT32* py)
 	return TRUE;;
 }
 
-static BOOL freerdp_check_delta_point(rdpContext* context, INT32 x, INT32 y, UINT32 count,
-                                      const DELTA_POINT* data)
-{
-	UINT32 i;
-
-	if (!context || !data)
-		return FALSE;
-
-	if (!freerdp_check_point(context, x, y))
-		return FALSE;
-
-	for (i = 0; i < count; i++)
-	{
-		const DELTA_POINT* delta = &data[i];
-		x += delta->x;
-		y += delta->y;
-
-		if (!freerdp_check_point(context, x, y))
-			return FALSE;
-	}
-
-	return TRUE;
-}
-
-static BOOL freerdp_check_delta_rect(rdpContext* context, UINT32 count, DELTA_RECT* data)
+static BOOL freerdp_adjust_delta_rect(wLog* log, const char* order, rdpContext* context,
+                                      UINT32 count, DELTA_RECT* data)
 {
 	UINT32 i;
 
@@ -448,7 +441,8 @@ static BOOL freerdp_check_delta_rect(rdpContext* context, UINT32 count, DELTA_RE
 	{
 		DELTA_RECT* delta = &data[i];
 
-		if (!freerdp_primary_adjust_rect(context, &delta->left, &delta->top, &delta->width, &delta->height))
+		if (!freerdp_primary_adjust_rect(log, order, context, &delta->left, &delta->top, &delta->width,
+		                                 &delta->height))
 			goto fail;
 	}
 
@@ -458,7 +452,8 @@ fail:
 	return FALSE;
 }
 
-static BOOL freerdp_check_glyph_op_bound(rdpContext* context, INT32 left, INT32 top, INT32 right,
+static BOOL freerdp_check_glyph_op_bound(wLog* log, const char* order, rdpContext* context,
+        INT32 left, INT32 top, INT32 right,
         INT32 bottom)
 {
 	if (right == -32768)
@@ -467,7 +462,7 @@ static BOOL freerdp_check_glyph_op_bound(rdpContext* context, INT32 left, INT32 
 	if (bottom == -32768)
 		bottom = top;
 
-	return freerdp_primary_check_bound(context, left, top, right, bottom);
+	return freerdp_primary_adjust_bound(log, order, context, left, top, right, bottom);
 }
 
 static INLINE BOOL update_read_coord(wStream* s, INT32* coord, BOOL delta)
@@ -3317,7 +3312,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			}
 		}
 
-		if (!freerdp_primary_check_bounds(context, &orderInfo->bounds))
+		if (!freerdp_primary_adjust_bounds(update->log, orderName, context, &orderInfo->bounds))
 			return FALSE;
 
 		rc = IFCALLRESULT(FALSE, update->SetBounds, context, &orderInfo->bounds);
@@ -3342,11 +3337,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			           orderName,
 			           gdi_rop3_code_string(primary->dstblt.bRop), gdi_rop3_code(primary->dstblt.bRop));
 
-			if (!freerdp_primary_check_rect(context,
-			                                &primary->dstblt.nLeftRect,
-			                                &primary->dstblt.nTopRect,
-			                                &primary->dstblt.nWidth,
-			                                &primary->dstblt.nHeight))
+			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+			                                 &primary->dstblt.nLeftRect,
+			                                 &primary->dstblt.nTopRect,
+			                                 &primary->dstblt.nWidth,
+			                                 &primary->dstblt.nHeight))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->DstBlt, context, &primary->dstblt);
@@ -3363,11 +3358,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
 			           gdi_rop3_code_string(primary->patblt.bRop), gdi_rop3_code(primary->patblt.bRop));
 
-			if (!freerdp_primary_check_rect(context,
-			                                &primary->patblt.nLeftRect,
-			                                &primary->patblt.nTopRect,
-			                                &primary->patblt.nWidth,
-			                                &primary->patblt.nHeight))
+			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+			                                 &primary->patblt.nLeftRect,
+			                                 &primary->patblt.nTopRect,
+			                                 &primary->patblt.nWidth,
+			                                 &primary->patblt.nHeight))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->PatBlt, context, &primary->patblt);
@@ -3384,11 +3379,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
 			           gdi_rop3_code_string(primary->scrblt.bRop), gdi_rop3_code(primary->scrblt.bRop));
 
-			if (!freerdp_primary_check_rect(context,
-			                                &primary->scrblt.nLeftRect,
-			                                &primary->scrblt.nTopRect,
-			                                &primary->scrblt.nWidth,
-			                                &primary->scrblt.nHeight))
+			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+			                                 &primary->scrblt.nLeftRect,
+			                                 &primary->scrblt.nTopRect,
+			                                 &primary->scrblt.nWidth,
+			                                 &primary->scrblt.nHeight))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->ScrBlt, context, &primary->scrblt);
@@ -3404,7 +3399,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_adjust_rect(context, &primary->opaque_rect.nLeftRect,
+			if (!freerdp_primary_adjust_rect(update->log, orderName, context, &primary->opaque_rect.nLeftRect,
 			                                 &primary->opaque_rect.nTopRect,
 			                                 &primary->opaque_rect.nWidth,
 			                                 &primary->opaque_rect.nHeight))
@@ -3423,9 +3418,9 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_check_bound(context, primary->draw_nine_grid.srcLeft,
-			                                 primary->draw_nine_grid.srcTop, primary->draw_nine_grid.srcRight,
-			                                 primary->draw_nine_grid.srcBottom))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->draw_nine_grid.srcLeft,
+			                                  primary->draw_nine_grid.srcTop, primary->draw_nine_grid.srcRight,
+			                                  primary->draw_nine_grid.srcBottom))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->DrawNineGrid, context, &primary->draw_nine_grid);
@@ -3443,15 +3438,15 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
 			           gdi_rop3_code_string(primary->multi_dstblt.bRop), gdi_rop3_code(primary->multi_dstblt.bRop));
 
-			if (!freerdp_primary_check_rect(context,
-			                                &primary->multi_dstblt.nLeftRect,
-			                                &primary->multi_dstblt.nTopRect,
-			                                &primary->multi_dstblt.nWidth,
-			                                &primary->multi_dstblt.nHeight))
+			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+			                                 &primary->multi_dstblt.nLeftRect,
+			                                 &primary->multi_dstblt.nTopRect,
+			                                 &primary->multi_dstblt.nWidth,
+			                                 &primary->multi_dstblt.nHeight))
 				return FALSE;
 
-			if (!freerdp_check_delta_rect(context, primary->multi_dstblt.numRectangles,
-			                              primary->multi_dstblt.rectangles))
+			if (!freerdp_adjust_delta_rect(update->log, orderName, context, primary->multi_dstblt.numRectangles,
+			                               primary->multi_dstblt.rectangles))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->MultiDstBlt, context, &primary->multi_dstblt);
@@ -3469,15 +3464,15 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
 			           gdi_rop3_code_string(primary->multi_patblt.bRop), gdi_rop3_code(primary->multi_patblt.bRop));
 
-			if (!freerdp_primary_check_rect(context,
-			                                &primary->multi_patblt.nLeftRect,
-			                                &primary->multi_patblt.nTopRect,
-			                                &primary->multi_patblt.nWidth,
-			                                &primary->multi_patblt.nHeight))
+			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+			                                 &primary->multi_patblt.nLeftRect,
+			                                 &primary->multi_patblt.nTopRect,
+			                                 &primary->multi_patblt.nWidth,
+			                                 &primary->multi_patblt.nHeight))
 				return FALSE;
 
-			if (!freerdp_check_delta_rect(context, primary->multi_patblt.numRectangles,
-			                              primary->multi_patblt.rectangles))
+			if (!freerdp_adjust_delta_rect(update->log, orderName, context, primary->multi_patblt.numRectangles,
+			                               primary->multi_patblt.rectangles))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->MultiPatBlt, context, &primary->multi_patblt);
@@ -3495,15 +3490,15 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
 			           gdi_rop3_code_string(primary->multi_scrblt.bRop), gdi_rop3_code(primary->multi_scrblt.bRop));
 
-			if (!freerdp_primary_check_rect(context,
-			                                &primary->multi_scrblt.nLeftRect,
-			                                &primary->multi_scrblt.nTopRect,
-			                                &primary->multi_scrblt.nWidth,
-			                                &primary->multi_scrblt.nHeight))
+			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+			                                 &primary->multi_scrblt.nLeftRect,
+			                                 &primary->multi_scrblt.nTopRect,
+			                                 &primary->multi_scrblt.nWidth,
+			                                 &primary->multi_scrblt.nHeight))
 				return FALSE;
 
-			if (!freerdp_check_delta_rect(context, primary->multi_scrblt.numRectangles,
-			                              primary->multi_scrblt.rectangles))
+			if (!freerdp_adjust_delta_rect(update->log, orderName, context, primary->multi_scrblt.numRectangles,
+			                               primary->multi_scrblt.rectangles))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->MultiScrBlt, context, &primary->multi_scrblt);
@@ -3520,15 +3515,16 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_adjust_rect(context,
+			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
 			                                 &primary->multi_opaque_rect.nLeftRect,
 			                                 &primary->multi_opaque_rect.nTopRect,
 			                                 &primary->multi_opaque_rect.nWidth,
 			                                 &primary->multi_opaque_rect.nHeight))
 				return FALSE;
 
-			if (!freerdp_check_delta_rect(context, primary->multi_opaque_rect.numRectangles,
-			                              primary->multi_opaque_rect.rectangles))
+			if (!freerdp_adjust_delta_rect(update->log, orderName, context,
+			                               primary->multi_opaque_rect.numRectangles,
+			                               primary->multi_opaque_rect.rectangles))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->MultiOpaqueRect, context, &primary->multi_opaque_rect);
@@ -3545,13 +3541,15 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_check_bound(context, primary->multi_draw_nine_grid.srcLeft,
-			                                 primary->multi_draw_nine_grid.srcTop, primary->multi_draw_nine_grid.srcRight,
-			                                 primary->multi_draw_nine_grid.srcBottom))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context,
+			                                  primary->multi_draw_nine_grid.srcLeft,
+			                                  primary->multi_draw_nine_grid.srcTop, primary->multi_draw_nine_grid.srcRight,
+			                                  primary->multi_draw_nine_grid.srcBottom))
 				return FALSE;
 
-			if (!freerdp_check_delta_rect(context, primary->multi_draw_nine_grid.nDeltaEntries,
-			                              primary->multi_draw_nine_grid.rectangles))
+			if (!freerdp_adjust_delta_rect(update->log, orderName, context,
+			                               primary->multi_draw_nine_grid.nDeltaEntries,
+			                               primary->multi_draw_nine_grid.rectangles))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->MultiDrawNineGrid, context, &primary->multi_draw_nine_grid);
@@ -3590,14 +3588,15 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
 			           gdi_rop3_code_string(primary->memblt.bRop), gdi_rop3_code(primary->memblt.bRop));
 
-			if (!freerdp_primary_check_rect(context,
-			                                &primary->memblt.nLeftRect,
-			                                &primary->memblt.nTopRect,
-			                                &primary->memblt.nWidth,
-			                                &primary->memblt.nHeight))
+			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+			                                 &primary->memblt.nLeftRect,
+			                                 &primary->memblt.nTopRect,
+			                                 &primary->memblt.nWidth,
+			                                 &primary->memblt.nHeight))
 				return FALSE;
 
-			if (!freerdp_check_point(context, primary->memblt.nXSrc, primary->memblt.nYSrc))
+			if (!freerdp_adjust_point(update->log, orderName, context, &primary->memblt.nXSrc,
+			                          &primary->memblt.nYSrc))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->MemBlt, context, &primary->memblt);
@@ -3614,14 +3613,15 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
 			           gdi_rop3_code_string(primary->mem3blt.bRop), gdi_rop3_code(primary->mem3blt.bRop));
 
-			if (!freerdp_primary_check_rect(context,
-			                                &primary->mem3blt.nLeftRect,
-			                                &primary->mem3blt.nTopRect,
-			                                &primary->mem3blt.nWidth,
-			                                &primary->mem3blt.nHeight))
+			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+			                                 &primary->mem3blt.nLeftRect,
+			                                 &primary->mem3blt.nTopRect,
+			                                 &primary->mem3blt.nWidth,
+			                                 &primary->mem3blt.nHeight))
 				return FALSE;
 
-			if (!freerdp_check_point(context, primary->mem3blt.nXSrc, primary->mem3blt.nYSrc))
+			if (!freerdp_adjust_point(update->log, orderName, context, &primary->mem3blt.nXSrc,
+			                          &primary->mem3blt.nYSrc))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->Mem3Blt, context, &primary->mem3blt);
@@ -3637,8 +3637,8 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_check_bound(context, primary->save_bitmap.nLeftRect,
-			                                 primary->save_bitmap.nTopRect, primary->save_bitmap.nRightRect, primary->save_bitmap.nBottomRect))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->save_bitmap.nLeftRect,
+			                                  primary->save_bitmap.nTopRect, primary->save_bitmap.nRightRect, primary->save_bitmap.nBottomRect))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->SaveBitmap, context, &primary->save_bitmap);
@@ -3654,15 +3654,18 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_check_bound(context, primary->glyph_index.bkLeft, primary->glyph_index.bkTop,
-			                                 primary->glyph_index.bkRight, primary->fast_index.bkBottom))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->glyph_index.bkLeft,
+			                                  primary->glyph_index.bkTop,
+			                                  primary->glyph_index.bkRight, primary->fast_index.bkBottom))
 				return FALSE;
 
-			if (!freerdp_primary_check_bound(context, primary->glyph_index.opLeft, primary->glyph_index.opTop,
-			                                 primary->glyph_index.opRight, primary->fast_index.opBottom))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->glyph_index.opLeft,
+			                                  primary->glyph_index.opTop,
+			                                  primary->glyph_index.opRight, primary->fast_index.opBottom))
 				return FALSE;
 
-			if (!freerdp_check_point(context, primary->glyph_index.x, primary->glyph_index.y))
+			if (!freerdp_adjust_point(update->log, orderName, context, primary->glyph_index.x,
+			                          primary->glyph_index.y))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->GlyphIndex, context, &primary->glyph_index);
@@ -3677,15 +3680,18 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_check_bound(context, primary->fast_index.bkLeft, primary->fast_index.bkTop,
-			                                 primary->fast_index.bkRight, primary->fast_index.bkBottom))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->fast_index.bkLeft,
+			                                  primary->fast_index.bkTop,
+			                                  primary->fast_index.bkRight, primary->fast_index.bkBottom))
 				return FALSE;
 
-			if (!freerdp_check_glyph_op_bound(context, primary->fast_index.opLeft, primary->fast_index.opTop,
+			if (!freerdp_check_glyph_op_bound(update->log, orderName, context, primary->fast_index.opLeft,
+			                                  primary->fast_index.opTop,
 			                                  primary->fast_index.opRight, primary->fast_index.opBottom))
 				return FALSE;
 
-			if (!freerdp_check_point(context, primary->fast_index.x, primary->fast_index.y))
+			if (!freerdp_adjust_point(update->log, orderName, context, &primary->fast_index.x,
+			                          &primary->fast_index.y))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->FastIndex, context, &primary->fast_index);
@@ -3700,11 +3706,13 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_check_bound(context, primary->fast_glyph.bkLeft, primary->fast_glyph.bkTop,
-			                                 primary->fast_glyph.bkRight, primary->fast_index.bkBottom))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->fast_glyph.bkLeft,
+			                                  primary->fast_glyph.bkTop,
+			                                  primary->fast_glyph.bkRight, primary->fast_index.bkBottom))
 				return FALSE;
 
-			if (!freerdp_check_glyph_op_bound(context, primary->fast_glyph.opLeft, primary->fast_glyph.opTop,
+			if (!freerdp_check_glyph_op_bound(update->log, orderName, context, primary->fast_glyph.opLeft,
+			                                  primary->fast_glyph.opTop,
 			                                  primary->fast_glyph.opRight, primary->fast_index.opBottom))
 				return FALSE;
 
@@ -3722,11 +3730,6 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			}
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-
-			if (!freerdp_check_delta_point(context, primary->polygon_sc.xStart, primary->polygon_sc.yStart,
-			                               primary->polygon_sc.numPoints, primary->polygon_sc.points))
-				return FALSE;
-
 			rc = IFCALLRESULT(FALSE, primary->PolygonSC, context, &primary->polygon_sc);
 			break;
 
@@ -3738,11 +3741,6 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			}
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-
-			if (!freerdp_check_delta_point(context, primary->polygon_cb.xStart, primary->polygon_cb.yStart,
-			                               primary->polygon_cb.numPoints, primary->polygon_cb.points))
-				return FALSE;
-
 			rc = IFCALLRESULT(FALSE, primary->PolygonCB, context, &primary->polygon_cb);
 			break;
 
@@ -3755,8 +3753,9 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_check_bound(context, primary->ellipse_sc.leftRect, primary->ellipse_sc.topRect,
-			                                 primary->ellipse_sc.rightRect,  primary->ellipse_sc.bottomRect))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->ellipse_sc.leftRect,
+			                                  primary->ellipse_sc.topRect,
+			                                  primary->ellipse_sc.rightRect,  primary->ellipse_sc.bottomRect))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->EllipseSC, context, &primary->ellipse_sc);
@@ -3771,8 +3770,9 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_check_bound(context, primary->ellipse_cb.leftRect, primary->ellipse_cb.topRect,
-			                                 primary->ellipse_cb.rightRect,  primary->ellipse_cb.bottomRect))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->ellipse_cb.leftRect,
+			                                  primary->ellipse_cb.topRect,
+			                                  primary->ellipse_cb.rightRect,  primary->ellipse_cb.bottomRect))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->EllipseCB, context, &primary->ellipse_cb);

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -379,7 +379,7 @@ static BOOL freerdp_check_glyph_op_bound(rdpContext* context, INT32 left, INT32 
 	if (right == -32768)
 		right = left;
 
-	if (bottom = -32768)
+	if (bottom == -32768)
 		bottom = top;
 
 	return freerdp_primary_check_bound(context, left, top, right, bottom);
@@ -1907,7 +1907,7 @@ static CACHE_BITMAP_ORDER* update_read_cache_bitmap_order(rdpUpdate* update, wSt
 
 	if ((cache_bitmap->bitmapBpp < 1) || (cache_bitmap->bitmapBpp > 32))
 	{
-		WLog_ERR(TAG, "invalid bitmap bpp %"PRIu32"", cache_bitmap->bitmapBpp);
+		WLog_Print(update->log, WLOG_ERROR, "invalid bitmap bpp %"PRIu32"", cache_bitmap->bitmapBpp);
 		goto fail;
 	}
 
@@ -2190,7 +2190,7 @@ static CACHE_BITMAP_V3_ORDER* update_read_cache_bitmap_v3_order(rdpUpdate* updat
 
 	if ((bitmapData->bpp < 1) || (bitmapData->bpp > 32))
 	{
-		WLog_ERR(TAG, "invalid bpp value %"PRIu32"", bitmapData->bpp);
+		WLog_Print(update->log, WLOG_ERROR, "invalid bpp value %"PRIu32"", bitmapData->bpp);
 		goto fail;
 	}
 
@@ -2595,7 +2595,8 @@ static CACHE_BRUSH_ORDER* update_read_cache_brush_order(rdpUpdate* update, wStre
 		{
 			if (cache_brush->length != 8)
 			{
-				WLog_ERR(TAG,  "incompatible 1bpp brush of length:%"PRIu32"", cache_brush->length);
+				WLog_Print(update->log, WLOG_ERROR,  "incompatible 1bpp brush of length:%"PRIu32"",
+				           cache_brush->length);
 				goto fail;
 			}
 
@@ -3204,14 +3205,14 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 	if (orderInfo->orderType >= PRIMARY_DRAWING_ORDER_COUNT)
 	{
-		WLog_ERR(TAG,  "Invalid Primary Drawing Order %s", orderName);
+		WLog_Print(update->log, WLOG_ERROR,  "Invalid Primary Drawing Order %s", orderName);
 		return FALSE;
 	}
 
 	if (!update_read_field_flags(s, &(orderInfo->fieldFlags), flags,
 	                             PRIMARY_DRAWING_ORDER_FIELD_BYTES[orderInfo->orderType]))
 	{
-		WLog_ERR(TAG, "update_read_field_flags() failed");
+		WLog_Print(update->log, WLOG_ERROR, "update_read_field_flags() failed");
 		return FALSE;
 	}
 
@@ -3221,7 +3222,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		{
 			if (!update_read_bounds(s, &orderInfo->bounds))
 			{
-				WLog_ERR(TAG, "update_read_bounds() failed");
+				WLog_Print(update->log, WLOG_ERROR, "update_read_bounds() failed");
 				return FALSE;
 			}
 		}
@@ -3242,7 +3243,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_DSTBLT:
 			if (!update_read_dstblt_order(s, orderInfo, &(primary->dstblt)))
 			{
-				WLog_ERR(TAG, "%s - update_read_dstblt_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_dstblt_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3261,7 +3262,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_PATBLT:
 			if (!update_read_patblt_order(s, orderInfo, &(primary->patblt)))
 			{
-				WLog_ERR(TAG, "%s - update_read_patblt_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_patblt_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3279,7 +3280,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_SCRBLT:
 			if (!update_read_scrblt_order(s, orderInfo, &(primary->scrblt)))
 			{
-				WLog_ERR(TAG, "%s - update_read_scrblt_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_scrblt_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3297,8 +3298,8 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_OPAQUE_RECT:
 			if (!update_read_opaque_rect_order(s, orderInfo, &(primary->opaque_rect)))
 			{
-				WLog_ERR(TAG,
-				         "%s - update_read_opaque_rect_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - update_read_opaque_rect_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3314,8 +3315,8 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_DRAW_NINE_GRID:
 			if (!update_read_draw_nine_grid_order(s, orderInfo, &(primary->draw_nine_grid)))
 			{
-				WLog_ERR(TAG,
-				         "%s - update_read_draw_nine_grid_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - update_read_draw_nine_grid_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3332,8 +3333,8 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_MULTI_DSTBLT:
 			if (!update_read_multi_dstblt_order(s, orderInfo, &(primary->multi_dstblt)))
 			{
-				WLog_ERR(TAG,
-				         "%s - update_read_multi_dstblt_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - update_read_multi_dstblt_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3355,8 +3356,8 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_MULTI_PATBLT:
 			if (!update_read_multi_patblt_order(s, orderInfo, &(primary->multi_patblt)))
 			{
-				WLog_ERR(TAG,
-				         "%s - update_read_multi_patblt_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - update_read_multi_patblt_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3378,8 +3379,8 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_MULTI_SCRBLT:
 			if (!update_read_multi_scrblt_order(s, orderInfo, &(primary->multi_scrblt)))
 			{
-				WLog_ERR(TAG,
-				         "%s - update_read_multi_scrblt_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - update_read_multi_scrblt_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3402,8 +3403,8 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			if (!update_read_multi_opaque_rect_order(s, orderInfo,
 			        &(primary->multi_opaque_rect)))
 			{
-				WLog_ERR(TAG,
-				         "%s - update_read_multi_opaque_rect_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - update_read_multi_opaque_rect_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3425,8 +3426,8 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			if (!update_read_multi_draw_nine_grid_order(s, orderInfo,
 			        &(primary->multi_draw_nine_grid)))
 			{
-				WLog_ERR(TAG,
-				         "%s - update_read_multi_draw_nine_grid_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - update_read_multi_draw_nine_grid_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3444,7 +3445,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_LINE_TO:
 			if (!update_read_line_to_order(s, orderInfo, &(primary->line_to)))
 			{
-				WLog_ERR(TAG, "%s - update_read_line_to_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_line_to_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3462,7 +3463,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_POLYLINE:
 			if (!update_read_polyline_order(s, orderInfo, &(primary->polyline)))
 			{
-				WLog_ERR(TAG, "%s - update_read_polyline_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_polyline_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3478,7 +3479,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_MEMBLT:
 			if (!update_read_memblt_order(s, orderInfo, &(primary->memblt)))
 			{
-				WLog_ERR(TAG, "%s - update_read_memblt_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_memblt_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3496,7 +3497,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_MEM3BLT:
 			if (!update_read_mem3blt_order(s, orderInfo, &(primary->mem3blt)))
 			{
-				WLog_ERR(TAG, "%s - update_read_mem3blt_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_mem3blt_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3514,8 +3515,8 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_SAVE_BITMAP:
 			if (!update_read_save_bitmap_order(s, orderInfo, &(primary->save_bitmap)))
 			{
-				WLog_ERR(TAG,
-				         "%s - update_read_save_bitmap_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - update_read_save_bitmap_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3531,8 +3532,8 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_GLYPH_INDEX:
 			if (!update_read_glyph_index_order(s, orderInfo, &(primary->glyph_index)))
 			{
-				WLog_ERR(TAG,
-				         "%s - update_read_glyph_index_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - update_read_glyph_index_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3555,7 +3556,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_FAST_INDEX:
 			if (!update_read_fast_index_order(s, orderInfo, &(primary->fast_index)))
 			{
-				WLog_ERR(TAG, "%s - update_read_fast_index_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_fast_index_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3578,7 +3579,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_FAST_GLYPH:
 			if (!update_read_fast_glyph_order(s, orderInfo, &(primary->fast_glyph)))
 			{
-				WLog_ERR(TAG, "%s - update_read_fast_glyph_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_fast_glyph_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3601,7 +3602,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_POLYGON_SC:
 			if (!update_read_polygon_sc_order(s, orderInfo, &(primary->polygon_sc)))
 			{
-				WLog_ERR(TAG, "%s - update_read_polygon_sc_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_polygon_sc_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3617,7 +3618,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_POLYGON_CB:
 			if (!update_read_polygon_cb_order(s, orderInfo, &(primary->polygon_cb)))
 			{
-				WLog_ERR(TAG, "%s - update_read_polygon_cb_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_polygon_cb_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3633,7 +3634,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_ELLIPSE_SC:
 			if (!update_read_ellipse_sc_order(s, orderInfo, &(primary->ellipse_sc)))
 			{
-				WLog_ERR(TAG, "%s - update_read_ellipse_sc_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_ellipse_sc_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3649,7 +3650,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_ELLIPSE_CB:
 			if (!update_read_ellipse_cb_order(s, orderInfo, &(primary->ellipse_cb)))
 			{
-				WLog_ERR(TAG, "%s - update_read_ellipse_cb_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_ellipse_cb_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3691,7 +3692,7 @@ static BOOL update_recv_secondary_order(rdpUpdate* update, wStream* s,
 
 	if (Stream_GetRemainingLength(s) < 5)
 	{
-		WLog_ERR(TAG, "Stream_GetRemainingLength(s) < 5");
+		WLog_Print(update->log, WLOG_ERROR, "Stream_GetRemainingLength(s) < 5");
 		return FALSE;
 	}
 
@@ -3798,7 +3799,7 @@ static BOOL update_recv_secondary_order(rdpUpdate* update, wStream* s,
 
 	if (!rc)
 	{
-		WLog_ERR(TAG, "SECONDARY ORDER %s failed", secondary_order_string(orderType));
+		WLog_Print(update->log, WLOG_ERROR, "SECONDARY ORDER %s failed", secondary_order_string(orderType));
 	}
 
 	Stream_SetPointer(s, next);
@@ -3807,12 +3808,11 @@ static BOOL update_recv_secondary_order(rdpUpdate* update, wStream* s,
 static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
                                      BYTE flags)
 {
-	BYTE orderType;
+	BYTE orderType = flags >>= 2; /* orderType is in higher 6 bits of flags field */
 	BOOL rc = FALSE;
 	rdpContext* context = update->context;
 	rdpAltSecUpdate* altsec = update->altsec;
 	const char* orderName = altsec_order_string(orderType);
-	orderType = flags >>= 2; /* orderType is in higher 6 bits of flags field */
 	WLog_Print(update->log, WLOG_DEBUG,
 	           "Alternate Secondary Drawing Order %s", orderName);
 
@@ -3976,7 +3976,7 @@ BOOL update_recv_order(rdpUpdate* update, wStream* s)
 
 	if (Stream_GetRemainingLength(s) < 1)
 	{
-		WLog_ERR(TAG, "Stream_GetRemainingLength(s) < 1");
+		WLog_Print(update->log, WLOG_ERROR, "Stream_GetRemainingLength(s) < 1");
 		return FALSE;
 	}
 

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -3281,6 +3281,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 	rdpContext* context = update->context;
 	rdpPrimaryUpdate* primary = update->primary;
 	ORDER_INFO* orderInfo = &(primary->order_info);
+	rdpSettings* settings = context->settings;
 	const char* orderName;
 
 	if (flags & ORDER_TYPE_CHANGE)
@@ -3656,6 +3657,13 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
+			if (settings->GlyphSupportLevel == GLYPH_SUPPORT_NONE)
+			{
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+				return TRUE;
+			}
+
 			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->glyph_index.bkLeft,
 			                                  &primary->glyph_index.bkTop,
 			                                  &primary->glyph_index.bkRight, &primary->fast_index.bkBottom))
@@ -3681,6 +3689,13 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			}
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+			if (settings->GlyphSupportLevel == GLYPH_SUPPORT_NONE)
+			{
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+				return TRUE;
+			}
 
 			if (!freerdp_primary_adjust_bound(update->log, orderName, context,
 			                                  &primary->fast_index.bkLeft,
@@ -3708,6 +3723,13 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			}
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+			if (settings->GlyphSupportLevel == GLYPH_SUPPORT_NONE)
+			{
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+				return TRUE;
+			}
 
 			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->fast_glyph.bkLeft,
 			                                  &primary->fast_glyph.bkTop,

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -434,13 +434,9 @@ static BOOL freerdp_check_delta_point(rdpContext* context, INT32 x, INT32 y, UIN
 	return TRUE;
 }
 
-static BOOL freerdp_check_delta_rect(rdpContext* context, UINT32 count, const DELTA_RECT* data)
+static BOOL freerdp_check_delta_rect(rdpContext* context, UINT32 count, DELTA_RECT* data)
 {
 	UINT32 i;
-	INT32 x = 0;
-	INT32 y = 0;
-	INT32 w = 0;
-	INT32 h = 0;
 
 	if (!context || !data)
 		goto fail;
@@ -450,13 +446,9 @@ static BOOL freerdp_check_delta_rect(rdpContext* context, UINT32 count, const DE
 
 	for (i = 0; i < count; i++)
 	{
-		const DELTA_RECT* delta = &data[i];
-		x = delta->left;
-		y = delta->top;
-		w = delta->width;
-		h = delta->height;
+		DELTA_RECT* delta = &data[i];
 
-		if (!freerdp_primary_check_rect(context, &x, &y, &w, &h))
+		if (!freerdp_primary_adjust_rect(context, &delta->left, &delta->top, &delta->width, &delta->height))
 			goto fail;
 	}
 
@@ -3528,11 +3520,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_check_rect(context,
-			                                &primary->multi_opaque_rect.nLeftRect,
-			                                &primary->multi_opaque_rect.nTopRect,
-			                                &primary->multi_opaque_rect.nWidth,
-			                                &primary->multi_opaque_rect.nHeight))
+			if (!freerdp_primary_adjust_rect(context,
+			                                 &primary->multi_opaque_rect.nLeftRect,
+			                                 &primary->multi_opaque_rect.nTopRect,
+			                                 &primary->multi_opaque_rect.nWidth,
+			                                 &primary->multi_opaque_rect.nHeight))
 				return FALSE;
 
 			if (!freerdp_check_delta_rect(context, primary->multi_opaque_rect.numRectangles,

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -4117,24 +4117,24 @@ static BOOL update_recv_secondary_order(rdpUpdate* update, wStream* s,
 					case GLYPH_SUPPORT_PARTIAL:
 					case GLYPH_SUPPORT_FULL:
 						{
-							CACHE_GLYPH_V2_ORDER* order = update_read_cache_glyph_v2_order(update, s, extraFlags);
-
-							if (order)
-							{
-								rc = IFCALLRESULT(FALSE, secondary->CacheGlyphV2, context, order);
-								free_cache_glyph_v2_order(context, order);
-							}
-						}
-						break;
-
-					case GLYPH_SUPPORT_ENCODE:
-						{
 							CACHE_GLYPH_ORDER* order = update_read_cache_glyph_order(update, s, extraFlags);
 
 							if (order)
 							{
 								rc = IFCALLRESULT(FALSE, secondary->CacheGlyph, context, order);
 								free_cache_glyph_order(context, order);
+							}
+						}
+						break;
+
+					case GLYPH_SUPPORT_ENCODE:
+						{
+							CACHE_GLYPH_V2_ORDER* order = update_read_cache_glyph_v2_order(update, s, extraFlags);
+
+							if (order)
+							{
+								rc = IFCALLRESULT(FALSE, secondary->CacheGlyphV2, context, order);
+								free_cache_glyph_v2_order(context, order);
 							}
 						}
 						break;

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -3327,484 +3327,665 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 	switch (orderInfo->orderType)
 	{
 		case ORDER_TYPE_DSTBLT:
-			if (!update_read_dstblt_order(s, orderInfo, &(primary->dstblt)))
 			{
-				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_dstblt_order() failed", orderName);
-				return FALSE;
+				if (!update_read_dstblt_order(s, orderInfo, &(primary->dstblt)))
+				{
+					WLog_Print(update->log, WLOG_ERROR, "%s - update_read_dstblt_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,
+				           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]",
+				           orderName,
+				           gdi_rop3_code_string(primary->dstblt.bRop), gdi_rop3_code(primary->dstblt.bRop));
+
+				if (!settings->OrderSupport[NEG_DSTBLT_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+				                                 &primary->dstblt.nLeftRect,
+				                                 &primary->dstblt.nTopRect,
+				                                 &primary->dstblt.nWidth,
+				                                 &primary->dstblt.nHeight))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->DstBlt, context, &primary->dstblt);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,
-			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]",
-			           orderName,
-			           gdi_rop3_code_string(primary->dstblt.bRop), gdi_rop3_code(primary->dstblt.bRop));
-
-			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
-			                                 &primary->dstblt.nLeftRect,
-			                                 &primary->dstblt.nTopRect,
-			                                 &primary->dstblt.nWidth,
-			                                 &primary->dstblt.nHeight))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->DstBlt, context, &primary->dstblt);
 			break;
 
 		case ORDER_TYPE_PATBLT:
-			if (!update_read_patblt_order(s, orderInfo, &(primary->patblt)))
 			{
-				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_patblt_order() failed", orderName);
-				return FALSE;
+				if (!update_read_patblt_order(s, orderInfo, &(primary->patblt)))
+				{
+					WLog_Print(update->log, WLOG_ERROR, "%s - update_read_patblt_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,
+				           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
+				           gdi_rop3_code_string(primary->patblt.bRop), gdi_rop3_code(primary->patblt.bRop));
+
+				if (!settings->OrderSupport[NEG_PATBLT_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+				                                 &primary->patblt.nLeftRect,
+				                                 &primary->patblt.nTopRect,
+				                                 &primary->patblt.nWidth,
+				                                 &primary->patblt.nHeight))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->PatBlt, context, &primary->patblt);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,
-			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
-			           gdi_rop3_code_string(primary->patblt.bRop), gdi_rop3_code(primary->patblt.bRop));
-
-			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
-			                                 &primary->patblt.nLeftRect,
-			                                 &primary->patblt.nTopRect,
-			                                 &primary->patblt.nWidth,
-			                                 &primary->patblt.nHeight))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->PatBlt, context, &primary->patblt);
 			break;
 
 		case ORDER_TYPE_SCRBLT:
-			if (!update_read_scrblt_order(s, orderInfo, &(primary->scrblt)))
 			{
-				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_scrblt_order() failed", orderName);
-				return FALSE;
+				if (!update_read_scrblt_order(s, orderInfo, &(primary->scrblt)))
+				{
+					WLog_Print(update->log, WLOG_ERROR, "%s - update_read_scrblt_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,
+				           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
+				           gdi_rop3_code_string(primary->scrblt.bRop), gdi_rop3_code(primary->scrblt.bRop));
+
+				if (!settings->OrderSupport[NEG_SCRBLT_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+				                                 &primary->scrblt.nLeftRect,
+				                                 &primary->scrblt.nTopRect,
+				                                 &primary->scrblt.nWidth,
+				                                 &primary->scrblt.nHeight))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->ScrBlt, context, &primary->scrblt);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,
-			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
-			           gdi_rop3_code_string(primary->scrblt.bRop), gdi_rop3_code(primary->scrblt.bRop));
-
-			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
-			                                 &primary->scrblt.nLeftRect,
-			                                 &primary->scrblt.nTopRect,
-			                                 &primary->scrblt.nWidth,
-			                                 &primary->scrblt.nHeight))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->ScrBlt, context, &primary->scrblt);
 			break;
 
 		case ORDER_TYPE_OPAQUE_RECT:
-			if (!update_read_opaque_rect_order(s, orderInfo, &(primary->opaque_rect)))
 			{
-				WLog_Print(update->log, WLOG_ERROR,
-				           "%s - update_read_opaque_rect_order() failed", orderName);
-				return FALSE;
+				if (!update_read_opaque_rect_order(s, orderInfo, &(primary->opaque_rect)))
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - update_read_opaque_rect_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+				if (!settings->OrderSupport[NEG_OPAQUE_RECT_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_rect(update->log, orderName, context, &primary->opaque_rect.nLeftRect,
+				                                 &primary->opaque_rect.nTopRect,
+				                                 &primary->opaque_rect.nWidth,
+				                                 &primary->opaque_rect.nHeight))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->OpaqueRect, context, &primary->opaque_rect);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-
-			if (!freerdp_primary_adjust_rect(update->log, orderName, context, &primary->opaque_rect.nLeftRect,
-			                                 &primary->opaque_rect.nTopRect,
-			                                 &primary->opaque_rect.nWidth,
-			                                 &primary->opaque_rect.nHeight))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->OpaqueRect, context, &primary->opaque_rect);
 			break;
 
 		case ORDER_TYPE_DRAW_NINE_GRID:
-			if (!update_read_draw_nine_grid_order(s, orderInfo, &(primary->draw_nine_grid)))
 			{
-				WLog_Print(update->log, WLOG_ERROR,
-				           "%s - update_read_draw_nine_grid_order() failed", orderName);
-				return FALSE;
+				if (!update_read_draw_nine_grid_order(s, orderInfo, &(primary->draw_nine_grid)))
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - update_read_draw_nine_grid_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+				if (!settings->OrderSupport[NEG_DRAWNINEGRID_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->draw_nine_grid.srcLeft,
+				                                  &primary->draw_nine_grid.srcTop, &primary->draw_nine_grid.srcRight,
+				                                  &primary->draw_nine_grid.srcBottom))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->DrawNineGrid, context, &primary->draw_nine_grid);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->draw_nine_grid.srcLeft,
-			                                  &primary->draw_nine_grid.srcTop, &primary->draw_nine_grid.srcRight,
-			                                  &primary->draw_nine_grid.srcBottom))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->DrawNineGrid, context, &primary->draw_nine_grid);
 			break;
 
 		case ORDER_TYPE_MULTI_DSTBLT:
-			if (!update_read_multi_dstblt_order(s, orderInfo, &(primary->multi_dstblt)))
 			{
-				WLog_Print(update->log, WLOG_ERROR,
-				           "%s - update_read_multi_dstblt_order() failed", orderName);
-				return FALSE;
+				if (!update_read_multi_dstblt_order(s, orderInfo, &(primary->multi_dstblt)))
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - update_read_multi_dstblt_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,
+				           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
+				           gdi_rop3_code_string(primary->multi_dstblt.bRop), gdi_rop3_code(primary->multi_dstblt.bRop));
+
+				if (!settings->OrderSupport[NEG_MULTIDSTBLT_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+				                                 &primary->multi_dstblt.nLeftRect,
+				                                 &primary->multi_dstblt.nTopRect,
+				                                 &primary->multi_dstblt.nWidth,
+				                                 &primary->multi_dstblt.nHeight))
+					return FALSE;
+
+				if (!freerdp_adjust_delta_rect(update->log, orderName, context, primary->multi_dstblt.numRectangles,
+				                               primary->multi_dstblt.rectangles))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->MultiDstBlt, context, &primary->multi_dstblt);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,
-			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
-			           gdi_rop3_code_string(primary->multi_dstblt.bRop), gdi_rop3_code(primary->multi_dstblt.bRop));
-
-			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
-			                                 &primary->multi_dstblt.nLeftRect,
-			                                 &primary->multi_dstblt.nTopRect,
-			                                 &primary->multi_dstblt.nWidth,
-			                                 &primary->multi_dstblt.nHeight))
-				return FALSE;
-
-			if (!freerdp_adjust_delta_rect(update->log, orderName, context, primary->multi_dstblt.numRectangles,
-			                               primary->multi_dstblt.rectangles))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->MultiDstBlt, context, &primary->multi_dstblt);
 			break;
 
 		case ORDER_TYPE_MULTI_PATBLT:
-			if (!update_read_multi_patblt_order(s, orderInfo, &(primary->multi_patblt)))
 			{
-				WLog_Print(update->log, WLOG_ERROR,
-				           "%s - update_read_multi_patblt_order() failed", orderName);
-				return FALSE;
+				if (!update_read_multi_patblt_order(s, orderInfo, &(primary->multi_patblt)))
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - update_read_multi_patblt_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,
+				           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
+				           gdi_rop3_code_string(primary->multi_patblt.bRop), gdi_rop3_code(primary->multi_patblt.bRop));
+
+				if (!settings->OrderSupport[NEG_MULTIPATBLT_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+				                                 &primary->multi_patblt.nLeftRect,
+				                                 &primary->multi_patblt.nTopRect,
+				                                 &primary->multi_patblt.nWidth,
+				                                 &primary->multi_patblt.nHeight))
+					return FALSE;
+
+				if (!freerdp_adjust_delta_rect(update->log, orderName, context, primary->multi_patblt.numRectangles,
+				                               primary->multi_patblt.rectangles))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->MultiPatBlt, context, &primary->multi_patblt);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,
-			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
-			           gdi_rop3_code_string(primary->multi_patblt.bRop), gdi_rop3_code(primary->multi_patblt.bRop));
-
-			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
-			                                 &primary->multi_patblt.nLeftRect,
-			                                 &primary->multi_patblt.nTopRect,
-			                                 &primary->multi_patblt.nWidth,
-			                                 &primary->multi_patblt.nHeight))
-				return FALSE;
-
-			if (!freerdp_adjust_delta_rect(update->log, orderName, context, primary->multi_patblt.numRectangles,
-			                               primary->multi_patblt.rectangles))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->MultiPatBlt, context, &primary->multi_patblt);
 			break;
 
 		case ORDER_TYPE_MULTI_SCRBLT:
-			if (!update_read_multi_scrblt_order(s, orderInfo, &(primary->multi_scrblt)))
 			{
-				WLog_Print(update->log, WLOG_ERROR,
-				           "%s - update_read_multi_scrblt_order() failed", orderName);
-				return FALSE;
+				if (!update_read_multi_scrblt_order(s, orderInfo, &(primary->multi_scrblt)))
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - update_read_multi_scrblt_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,
+				           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
+				           gdi_rop3_code_string(primary->multi_scrblt.bRop), gdi_rop3_code(primary->multi_scrblt.bRop));
+
+				if (!settings->OrderSupport[NEG_MULTISCRBLT_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+				                                 &primary->multi_scrblt.nLeftRect,
+				                                 &primary->multi_scrblt.nTopRect,
+				                                 &primary->multi_scrblt.nWidth,
+				                                 &primary->multi_scrblt.nHeight))
+					return FALSE;
+
+				if (!freerdp_adjust_delta_rect(update->log, orderName, context, primary->multi_scrblt.numRectangles,
+				                               primary->multi_scrblt.rectangles))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->MultiScrBlt, context, &primary->multi_scrblt);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,
-			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
-			           gdi_rop3_code_string(primary->multi_scrblt.bRop), gdi_rop3_code(primary->multi_scrblt.bRop));
-
-			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
-			                                 &primary->multi_scrblt.nLeftRect,
-			                                 &primary->multi_scrblt.nTopRect,
-			                                 &primary->multi_scrblt.nWidth,
-			                                 &primary->multi_scrblt.nHeight))
-				return FALSE;
-
-			if (!freerdp_adjust_delta_rect(update->log, orderName, context, primary->multi_scrblt.numRectangles,
-			                               primary->multi_scrblt.rectangles))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->MultiScrBlt, context, &primary->multi_scrblt);
 			break;
 
 		case ORDER_TYPE_MULTI_OPAQUE_RECT:
-			if (!update_read_multi_opaque_rect_order(s, orderInfo,
-			        &(primary->multi_opaque_rect)))
 			{
-				WLog_Print(update->log, WLOG_ERROR,
-				           "%s - update_read_multi_opaque_rect_order() failed", orderName);
-				return FALSE;
+				if (!update_read_multi_opaque_rect_order(s, orderInfo,
+				        &(primary->multi_opaque_rect)))
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - update_read_multi_opaque_rect_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+				if (!settings->OrderSupport[NEG_MULTIOPAQUERECT_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+				                                 &primary->multi_opaque_rect.nLeftRect,
+				                                 &primary->multi_opaque_rect.nTopRect,
+				                                 &primary->multi_opaque_rect.nWidth,
+				                                 &primary->multi_opaque_rect.nHeight))
+					return FALSE;
+
+				if (!freerdp_adjust_delta_rect(update->log, orderName, context,
+				                               primary->multi_opaque_rect.numRectangles,
+				                               primary->multi_opaque_rect.rectangles))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->MultiOpaqueRect, context, &primary->multi_opaque_rect);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-
-			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
-			                                 &primary->multi_opaque_rect.nLeftRect,
-			                                 &primary->multi_opaque_rect.nTopRect,
-			                                 &primary->multi_opaque_rect.nWidth,
-			                                 &primary->multi_opaque_rect.nHeight))
-				return FALSE;
-
-			if (!freerdp_adjust_delta_rect(update->log, orderName, context,
-			                               primary->multi_opaque_rect.numRectangles,
-			                               primary->multi_opaque_rect.rectangles))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->MultiOpaqueRect, context, &primary->multi_opaque_rect);
 			break;
 
 		case ORDER_TYPE_MULTI_DRAW_NINE_GRID:
-			if (!update_read_multi_draw_nine_grid_order(s, orderInfo,
-			        &(primary->multi_draw_nine_grid)))
 			{
-				WLog_Print(update->log, WLOG_ERROR,
-				           "%s - update_read_multi_draw_nine_grid_order() failed", orderName);
-				return FALSE;
+				if (!update_read_multi_draw_nine_grid_order(s, orderInfo,
+				        &(primary->multi_draw_nine_grid)))
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - update_read_multi_draw_nine_grid_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+				if (!settings->OrderSupport[NEG_MULTI_DRAWNINEGRID_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_bound(update->log, orderName, context,
+				                                  &primary->multi_draw_nine_grid.srcLeft,
+				                                  &primary->multi_draw_nine_grid.srcTop,
+				                                  &primary->multi_draw_nine_grid.srcRight,
+				                                  &primary->multi_draw_nine_grid.srcBottom))
+					return FALSE;
+
+				if (!freerdp_adjust_delta_rect(update->log, orderName, context,
+				                               primary->multi_draw_nine_grid.nDeltaEntries,
+				                               primary->multi_draw_nine_grid.rectangles))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->MultiDrawNineGrid, context, &primary->multi_draw_nine_grid);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context,
-			                                  &primary->multi_draw_nine_grid.srcLeft,
-			                                  &primary->multi_draw_nine_grid.srcTop,
-			                                  &primary->multi_draw_nine_grid.srcRight,
-			                                  &primary->multi_draw_nine_grid.srcBottom))
-				return FALSE;
-
-			if (!freerdp_adjust_delta_rect(update->log, orderName, context,
-			                               primary->multi_draw_nine_grid.nDeltaEntries,
-			                               primary->multi_draw_nine_grid.rectangles))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->MultiDrawNineGrid, context, &primary->multi_draw_nine_grid);
 			break;
 
 		case ORDER_TYPE_LINE_TO:
-			if (!update_read_line_to_order(s, orderInfo, &(primary->line_to)))
 			{
-				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_line_to_order() failed", orderName);
-				return FALSE;
-			}
+				if (!update_read_line_to_order(s, orderInfo, &(primary->line_to)))
+				{
+					WLog_Print(update->log, WLOG_ERROR, "%s - update_read_line_to_order() failed", orderName);
+					return FALSE;
+				}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-			rc = IFCALLRESULT(FALSE, primary->LineTo, context, &primary->line_to);
+				WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+				if (!settings->OrderSupport[NEG_LINETO_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				rc = IFCALLRESULT(FALSE, primary->LineTo, context, &primary->line_to);
+			}
 			break;
 
 		case ORDER_TYPE_POLYLINE:
-			if (!update_read_polyline_order(s, orderInfo, &(primary->polyline)))
 			{
-				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_polyline_order() failed", orderName);
-				return FALSE;
-			}
+				if (!update_read_polyline_order(s, orderInfo, &(primary->polyline)))
+				{
+					WLog_Print(update->log, WLOG_ERROR, "%s - update_read_polyline_order() failed", orderName);
+					return FALSE;
+				}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-			rc = IFCALLRESULT(FALSE, primary->Polyline, context, &primary->polyline);
+				WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+				if (!settings->OrderSupport[NEG_POLYLINE_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				rc = IFCALLRESULT(FALSE, primary->Polyline, context, &primary->polyline);
+			}
 			break;
 
 		case ORDER_TYPE_MEMBLT:
-			if (!update_read_memblt_order(s, orderInfo, &(primary->memblt)))
 			{
-				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_memblt_order() failed", orderName);
-				return FALSE;
+				if (!update_read_memblt_order(s, orderInfo, &(primary->memblt)))
+				{
+					WLog_Print(update->log, WLOG_ERROR, "%s - update_read_memblt_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,
+				           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
+				           gdi_rop3_code_string(primary->memblt.bRop), gdi_rop3_code(primary->memblt.bRop));
+
+				if (!settings->OrderSupport[NEG_MEMBLT_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+				                                 &primary->memblt.nLeftRect,
+				                                 &primary->memblt.nTopRect,
+				                                 &primary->memblt.nWidth,
+				                                 &primary->memblt.nHeight))
+					return FALSE;
+
+				if (!freerdp_adjust_point(update->log, orderName, context, &primary->memblt.nXSrc,
+				                          &primary->memblt.nYSrc))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->MemBlt, context, &primary->memblt);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,
-			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
-			           gdi_rop3_code_string(primary->memblt.bRop), gdi_rop3_code(primary->memblt.bRop));
-
-			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
-			                                 &primary->memblt.nLeftRect,
-			                                 &primary->memblt.nTopRect,
-			                                 &primary->memblt.nWidth,
-			                                 &primary->memblt.nHeight))
-				return FALSE;
-
-			if (!freerdp_adjust_point(update->log, orderName, context, &primary->memblt.nXSrc,
-			                          &primary->memblt.nYSrc))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->MemBlt, context, &primary->memblt);
 			break;
 
 		case ORDER_TYPE_MEM3BLT:
-			if (!update_read_mem3blt_order(s, orderInfo, &(primary->mem3blt)))
 			{
-				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_mem3blt_order() failed", orderName);
-				return FALSE;
+				if (!update_read_mem3blt_order(s, orderInfo, &(primary->mem3blt)))
+				{
+					WLog_Print(update->log, WLOG_ERROR, "%s - update_read_mem3blt_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,
+				           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
+				           gdi_rop3_code_string(primary->mem3blt.bRop), gdi_rop3_code(primary->mem3blt.bRop));
+
+				if (!settings->OrderSupport[NEG_MEM3BLT_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_rect(update->log, orderName, context,
+				                                 &primary->mem3blt.nLeftRect,
+				                                 &primary->mem3blt.nTopRect,
+				                                 &primary->mem3blt.nWidth,
+				                                 &primary->mem3blt.nHeight))
+					return FALSE;
+
+				if (!freerdp_adjust_point(update->log, orderName, context, &primary->mem3blt.nXSrc,
+				                          &primary->mem3blt.nYSrc))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->Mem3Blt, context, &primary->mem3blt);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,
-			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
-			           gdi_rop3_code_string(primary->mem3blt.bRop), gdi_rop3_code(primary->mem3blt.bRop));
-
-			if (!freerdp_primary_adjust_rect(update->log, orderName, context,
-			                                 &primary->mem3blt.nLeftRect,
-			                                 &primary->mem3blt.nTopRect,
-			                                 &primary->mem3blt.nWidth,
-			                                 &primary->mem3blt.nHeight))
-				return FALSE;
-
-			if (!freerdp_adjust_point(update->log, orderName, context, &primary->mem3blt.nXSrc,
-			                          &primary->mem3blt.nYSrc))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->Mem3Blt, context, &primary->mem3blt);
 			break;
 
 		case ORDER_TYPE_SAVE_BITMAP:
-			if (!update_read_save_bitmap_order(s, orderInfo, &(primary->save_bitmap)))
 			{
-				WLog_Print(update->log, WLOG_ERROR,
-				           "%s - update_read_save_bitmap_order() failed", orderName);
-				return FALSE;
+				if (!update_read_save_bitmap_order(s, orderInfo, &(primary->save_bitmap)))
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - update_read_save_bitmap_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+				if (!settings->OrderSupport[NEG_SAVEBITMAP_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->save_bitmap.nLeftRect,
+				                                  &primary->save_bitmap.nTopRect, &primary->save_bitmap.nRightRect,
+				                                  &primary->save_bitmap.nBottomRect))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->SaveBitmap, context, &primary->save_bitmap);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->save_bitmap.nLeftRect,
-			                                  &primary->save_bitmap.nTopRect, &primary->save_bitmap.nRightRect,
-			                                  &primary->save_bitmap.nBottomRect))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->SaveBitmap, context, &primary->save_bitmap);
 			break;
 
 		case ORDER_TYPE_GLYPH_INDEX:
-			if (!update_read_glyph_index_order(s, orderInfo, &(primary->glyph_index)))
 			{
-				WLog_Print(update->log, WLOG_ERROR,
-				           "%s - update_read_glyph_index_order() failed", orderName);
-				return FALSE;
+				if (!update_read_glyph_index_order(s, orderInfo, &(primary->glyph_index)))
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - update_read_glyph_index_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+				if (!settings->OrderSupport[NEG_FAST_GLYPH_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->glyph_index.bkLeft,
+				                                  &primary->glyph_index.bkTop,
+				                                  &primary->glyph_index.bkRight, &primary->fast_index.bkBottom))
+					return FALSE;
+
+				if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->glyph_index.opLeft,
+				                                  &primary->glyph_index.opTop,
+				                                  &primary->glyph_index.opRight, &primary->fast_index.opBottom))
+					return FALSE;
+
+				if (!freerdp_adjust_point(update->log, orderName, context, &primary->glyph_index.x,
+				                          &primary->glyph_index.y))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->GlyphIndex, context, &primary->glyph_index);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-
-			if (settings->GlyphSupportLevel == GLYPH_SUPPORT_NONE)
-			{
-				WLog_Print(update->log, WLOG_ERROR,
-				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
-				return TRUE;
-			}
-
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->glyph_index.bkLeft,
-			                                  &primary->glyph_index.bkTop,
-			                                  &primary->glyph_index.bkRight, &primary->fast_index.bkBottom))
-				return FALSE;
-
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->glyph_index.opLeft,
-			                                  &primary->glyph_index.opTop,
-			                                  &primary->glyph_index.opRight, &primary->fast_index.opBottom))
-				return FALSE;
-
-			if (!freerdp_adjust_point(update->log, orderName, context, &primary->glyph_index.x,
-			                          &primary->glyph_index.y))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->GlyphIndex, context, &primary->glyph_index);
 			break;
 
 		case ORDER_TYPE_FAST_INDEX:
-			if (!update_read_fast_index_order(s, orderInfo, &(primary->fast_index)))
 			{
-				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_fast_index_order() failed", orderName);
-				return FALSE;
+				if (!update_read_fast_index_order(s, orderInfo, &(primary->fast_index)))
+				{
+					WLog_Print(update->log, WLOG_ERROR, "%s - update_read_fast_index_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+				if (!settings->OrderSupport[NEG_FAST_INDEX_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_bound(update->log, orderName, context,
+				                                  &primary->fast_index.bkLeft,
+				                                  &primary->fast_index.bkTop,
+				                                  &primary->fast_index.bkRight, &primary->fast_index.bkBottom))
+					return FALSE;
+
+				if (!freerdp_check_glyph_op_bound(update->log, orderName, context, primary->fast_index.opLeft,
+				                                  primary->fast_index.opTop,
+				                                  primary->fast_index.opRight, primary->fast_index.opBottom))
+					return FALSE;
+
+				if (!freerdp_adjust_point(update->log, orderName, context, &primary->fast_index.x,
+				                          &primary->fast_index.y))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->FastIndex, context, &primary->fast_index);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-
-			if (settings->GlyphSupportLevel == GLYPH_SUPPORT_NONE)
-			{
-				WLog_Print(update->log, WLOG_ERROR,
-				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
-				return TRUE;
-			}
-
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context,
-			                                  &primary->fast_index.bkLeft,
-			                                  &primary->fast_index.bkTop,
-			                                  &primary->fast_index.bkRight, &primary->fast_index.bkBottom))
-				return FALSE;
-
-			if (!freerdp_check_glyph_op_bound(update->log, orderName, context, primary->fast_index.opLeft,
-			                                  primary->fast_index.opTop,
-			                                  primary->fast_index.opRight, primary->fast_index.opBottom))
-				return FALSE;
-
-			if (!freerdp_adjust_point(update->log, orderName, context, &primary->fast_index.x,
-			                          &primary->fast_index.y))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->FastIndex, context, &primary->fast_index);
 			break;
 
 		case ORDER_TYPE_FAST_GLYPH:
-			if (!update_read_fast_glyph_order(s, orderInfo, &(primary->fast_glyph)))
 			{
-				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_fast_glyph_order() failed", orderName);
-				return FALSE;
+				if (!update_read_fast_glyph_order(s, orderInfo, &(primary->fast_glyph)))
+				{
+					WLog_Print(update->log, WLOG_ERROR, "%s - update_read_fast_glyph_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+				if (!settings->OrderSupport[NEG_FAST_GLYPH_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->fast_glyph.bkLeft,
+				                                  &primary->fast_glyph.bkTop,
+				                                  &primary->fast_glyph.bkRight, &primary->fast_index.bkBottom))
+					return FALSE;
+
+				if (!freerdp_check_glyph_op_bound(update->log, orderName, context, primary->fast_glyph.opLeft,
+				                                  primary->fast_glyph.opTop,
+				                                  primary->fast_glyph.opRight, primary->fast_index.opBottom))
+					return FALSE;
+
+				if (!adjust_point(context, &primary->fast_glyph.x, &primary->fast_glyph.y))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->FastGlyph, context, &primary->fast_glyph);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-
-			if (settings->GlyphSupportLevel == GLYPH_SUPPORT_NONE)
-			{
-				WLog_Print(update->log, WLOG_ERROR,
-				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
-				return TRUE;
-			}
-
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->fast_glyph.bkLeft,
-			                                  &primary->fast_glyph.bkTop,
-			                                  &primary->fast_glyph.bkRight, &primary->fast_index.bkBottom))
-				return FALSE;
-
-			if (!freerdp_check_glyph_op_bound(update->log, orderName, context, primary->fast_glyph.opLeft,
-			                                  primary->fast_glyph.opTop,
-			                                  primary->fast_glyph.opRight, primary->fast_index.opBottom))
-				return FALSE;
-
-			if (!adjust_point(context, &primary->fast_glyph.x, &primary->fast_glyph.y))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->FastGlyph, context, &primary->fast_glyph);
 			break;
 
 		case ORDER_TYPE_POLYGON_SC:
-			if (!update_read_polygon_sc_order(s, orderInfo, &(primary->polygon_sc)))
 			{
-				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_polygon_sc_order() failed", orderName);
-				return FALSE;
-			}
+				if (!update_read_polygon_sc_order(s, orderInfo, &(primary->polygon_sc)))
+				{
+					WLog_Print(update->log, WLOG_ERROR, "%s - update_read_polygon_sc_order() failed", orderName);
+					return FALSE;
+				}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-			rc = IFCALLRESULT(FALSE, primary->PolygonSC, context, &primary->polygon_sc);
+				WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+				if (!settings->OrderSupport[NEG_POLYGON_SC_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				rc = IFCALLRESULT(FALSE, primary->PolygonSC, context, &primary->polygon_sc);
+			}
 			break;
 
 		case ORDER_TYPE_POLYGON_CB:
-			if (!update_read_polygon_cb_order(s, orderInfo, &(primary->polygon_cb)))
 			{
-				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_polygon_cb_order() failed", orderName);
-				return FALSE;
-			}
+				if (!update_read_polygon_cb_order(s, orderInfo, &(primary->polygon_cb)))
+				{
+					WLog_Print(update->log, WLOG_ERROR, "%s - update_read_polygon_cb_order() failed", orderName);
+					return FALSE;
+				}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-			rc = IFCALLRESULT(FALSE, primary->PolygonCB, context, &primary->polygon_cb);
+				WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+				if (!settings->OrderSupport[NEG_POLYGON_CB_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				rc = IFCALLRESULT(FALSE, primary->PolygonCB, context, &primary->polygon_cb);
+			}
 			break;
 
 		case ORDER_TYPE_ELLIPSE_SC:
-			if (!update_read_ellipse_sc_order(s, orderInfo, &(primary->ellipse_sc)))
 			{
-				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_ellipse_sc_order() failed", orderName);
-				return FALSE;
+				if (!update_read_ellipse_sc_order(s, orderInfo, &(primary->ellipse_sc)))
+				{
+					WLog_Print(update->log, WLOG_ERROR, "%s - update_read_ellipse_sc_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+				if (!settings->OrderSupport[NEG_ELLIPSE_SC_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->ellipse_sc.leftRect,
+				                                  &primary->ellipse_sc.topRect,
+				                                  &primary->ellipse_sc.rightRect,  &primary->ellipse_sc.bottomRect))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->EllipseSC, context, &primary->ellipse_sc);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->ellipse_sc.leftRect,
-			                                  &primary->ellipse_sc.topRect,
-			                                  &primary->ellipse_sc.rightRect,  &primary->ellipse_sc.bottomRect))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->EllipseSC, context, &primary->ellipse_sc);
 			break;
 
 		case ORDER_TYPE_ELLIPSE_CB:
-			if (!update_read_ellipse_cb_order(s, orderInfo, &(primary->ellipse_cb)))
 			{
-				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_ellipse_cb_order() failed", orderName);
-				return FALSE;
+				if (!update_read_ellipse_cb_order(s, orderInfo, &(primary->ellipse_cb)))
+				{
+					WLog_Print(update->log, WLOG_ERROR, "%s - update_read_ellipse_cb_order() failed", orderName);
+					return FALSE;
+				}
+
+				WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
+
+				if (!settings->OrderSupport[NEG_ELLIPSE_CB_INDEX])
+				{
+					WLog_Print(update->log, WLOG_ERROR,
+					           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+					return TRUE;
+				}
+
+				if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->ellipse_cb.leftRect,
+				                                  &primary->ellipse_cb.topRect,
+				                                  &primary->ellipse_cb.rightRect,  &primary->ellipse_cb.bottomRect))
+					return FALSE;
+
+				rc = IFCALLRESULT(FALSE, primary->EllipseCB, context, &primary->ellipse_cb);
 			}
-
-			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->ellipse_cb.leftRect,
-			                                  &primary->ellipse_cb.topRect,
-			                                  &primary->ellipse_cb.rightRect,  &primary->ellipse_cb.bottomRect))
-				return FALSE;
-
-			rc = IFCALLRESULT(FALSE, primary->EllipseCB, context, &primary->ellipse_cb);
 			break;
 
 		default:
-			WLog_Print(update->log, WLOG_WARN,  "Primary Drawing Order %s, ignoring", orderName);
+			WLog_Print(update->log, WLOG_WARN,  "Primary Drawing Order %s not supported, ignoring", orderName);
 			rc = TRUE;
 			break;
 	}

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -245,10 +245,6 @@ static int check_primary_order_supported(wLog* log, rdpSettings* settings, BYTE 
 			condition = settings->OrderSupport[NEG_DSTBLT_INDEX];
 			break;
 
-		case ORDER_TYPE_PATBLT:
-			condition = settings->OrderSupport[NEG_PATBLT_INDEX];
-			break;
-
 		case ORDER_TYPE_SCRBLT:
 			condition = settings->OrderSupport[NEG_SCRBLT_INDEX];
 			break;
@@ -265,8 +261,12 @@ static int check_primary_order_supported(wLog* log, rdpSettings* settings, BYTE 
 			condition = settings->OrderSupport[NEG_LINETO_INDEX];
 			break;
 
+		/* [MS-RDPEGDI] 2.2.2.2.1.1.2.5 OpaqueRect (OPAQUERECT_ORDER)
+		 * suggests that PatBlt and OpaqueRect imply each other. */
+		case ORDER_TYPE_PATBLT:
 		case ORDER_TYPE_OPAQUE_RECT:
-			condition = settings->OrderSupport[NEG_OPAQUE_RECT_INDEX];
+			condition = settings->OrderSupport[NEG_OPAQUE_RECT_INDEX] ||
+			            settings->OrderSupport[NEG_PATBLT_INDEX];
 			break;
 
 		case ORDER_TYPE_SAVE_BITMAP:

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -3808,6 +3808,7 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
                                      BYTE flags)
 {
 	BYTE orderType;
+	BOOL rc = FALSE;
 	rdpContext* context = update->context;
 	rdpAltSecUpdate* altsec = update->altsec;
 	const char* orderName = altsec_order_string(orderType);
@@ -3821,142 +3822,153 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			if (!update_read_create_offscreen_bitmap_order(s,
 			        &(altsec->create_offscreen_bitmap)))
 			{
-				WLog_ERR(TAG, "%s - update_read_create_offscreen_bitmap_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_create_offscreen_bitmap_order() failed",
+				           orderName);
 				return FALSE;
 			}
 
-			IFCALL(altsec->CreateOffscreenBitmap, context,
-			       &(altsec->create_offscreen_bitmap));
+			IFCALLRET(altsec->CreateOffscreenBitmap, rc, context,
+			          &(altsec->create_offscreen_bitmap));
 			break;
 
 		case ORDER_TYPE_SWITCH_SURFACE:
 			if (!update_read_switch_surface_order(s, &(altsec->switch_surface)))
 			{
-				WLog_ERR(TAG, "%s - update_read_switch_surface_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_switch_surface_order() failed", orderName);
 				return FALSE;
 			}
 
-			IFCALL(altsec->SwitchSurface, context, &(altsec->switch_surface));
+			IFCALLRET(altsec->SwitchSurface, rc, context, &(altsec->switch_surface));
 			break;
 
 		case ORDER_TYPE_CREATE_NINE_GRID_BITMAP:
 			if (!update_read_create_nine_grid_bitmap_order(s,
 			        &(altsec->create_nine_grid_bitmap)))
 			{
-				WLog_ERR(TAG, "%s - update_read_create_nine_grid_bitmap_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_create_nine_grid_bitmap_order() failed",
+				           orderName);
 				return FALSE;
 			}
 
-			IFCALL(altsec->CreateNineGridBitmap, context,
-			       &(altsec->create_nine_grid_bitmap));
+			IFCALLRET(altsec->CreateNineGridBitmap, rc, context,
+			          &(altsec->create_nine_grid_bitmap));
 			break;
 
 		case ORDER_TYPE_FRAME_MARKER:
 			if (!update_read_frame_marker_order(s, &(altsec->frame_marker)))
 			{
-				WLog_ERR(TAG, "%s - update_read_frame_marker_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_frame_marker_order() failed", orderName);
 				return FALSE;
 			}
 
-			IFCALL(altsec->FrameMarker, context, &(altsec->frame_marker));
+			IFCALLRET(altsec->FrameMarker, rc, context, &(altsec->frame_marker));
 			break;
 
 		case ORDER_TYPE_STREAM_BITMAP_FIRST:
 			if (!update_read_stream_bitmap_first_order(s, &(altsec->stream_bitmap_first)))
 			{
-				WLog_ERR(TAG, "%s - update_read_stream_bitmap_first_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_stream_bitmap_first_order() failed",
+				           orderName);
 				return FALSE;
 			}
 
-			IFCALL(altsec->StreamBitmapFirst, context, &(altsec->stream_bitmap_first));
+			IFCALLRET(altsec->StreamBitmapFirst, rc, context, &(altsec->stream_bitmap_first));
 			break;
 
 		case ORDER_TYPE_STREAM_BITMAP_NEXT:
 			if (!update_read_stream_bitmap_next_order(s, &(altsec->stream_bitmap_next)))
 			{
-				WLog_ERR(TAG, "%s - update_read_stream_bitmap_next_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_stream_bitmap_next_order() failed",
+				           orderName);
 				return FALSE;
 			}
 
-			IFCALL(altsec->StreamBitmapNext, context, &(altsec->stream_bitmap_next));
+			IFCALLRET(altsec->StreamBitmapNext, rc, context, &(altsec->stream_bitmap_next));
 			break;
 
 		case ORDER_TYPE_GDIPLUS_FIRST:
 			if (!update_read_draw_gdiplus_first_order(s, &(altsec->draw_gdiplus_first)))
 			{
-				WLog_ERR(TAG, "%s - update_read_draw_gdiplus_first_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_draw_gdiplus_first_order() failed",
+				           orderName);
 				return FALSE;
 			}
 
-			IFCALL(altsec->DrawGdiPlusFirst, context, &(altsec->draw_gdiplus_first));
+			IFCALLRET(altsec->DrawGdiPlusFirst, rc, context, &(altsec->draw_gdiplus_first));
 			break;
 
 		case ORDER_TYPE_GDIPLUS_NEXT:
 			if (!update_read_draw_gdiplus_next_order(s, &(altsec->draw_gdiplus_next)))
 			{
-				WLog_ERR(TAG, "%s - update_read_draw_gdiplus_next_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_draw_gdiplus_next_order() failed", orderName);
 				return FALSE;
 			}
 
-			IFCALL(altsec->DrawGdiPlusNext, context, &(altsec->draw_gdiplus_next));
+			IFCALLRET(altsec->DrawGdiPlusNext, rc, context, &(altsec->draw_gdiplus_next));
 			break;
 
 		case ORDER_TYPE_GDIPLUS_END:
 			if (!update_read_draw_gdiplus_end_order(s, &(altsec->draw_gdiplus_end)))
 			{
-				WLog_ERR(TAG, "%s - update_read_draw_gdiplus_end_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_draw_gdiplus_end_order() failed", orderName);
 				return FALSE;
 			}
 
-			IFCALL(altsec->DrawGdiPlusEnd, context, &(altsec->draw_gdiplus_end));
+			IFCALLRET(altsec->DrawGdiPlusEnd, rc, context, &(altsec->draw_gdiplus_end));
 			break;
 
 		case ORDER_TYPE_GDIPLUS_CACHE_FIRST:
 			if (!update_read_draw_gdiplus_cache_first_order(s,
 			        &(altsec->draw_gdiplus_cache_first)))
 			{
-				WLog_ERR(TAG, "%s - update_read_draw_gdiplus_cache_first_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_draw_gdiplus_cache_first_order() failed",
+				           orderName);
 				return FALSE;
 			}
 
-			IFCALL(altsec->DrawGdiPlusCacheFirst, context,
-			       &(altsec->draw_gdiplus_cache_first));
+			IFCALLRET(altsec->DrawGdiPlusCacheFirst, rc, context,
+			          &(altsec->draw_gdiplus_cache_first));
 			break;
 
 		case ORDER_TYPE_GDIPLUS_CACHE_NEXT:
 			if (!update_read_draw_gdiplus_cache_next_order(s,
 			        &(altsec->draw_gdiplus_cache_next)))
 			{
-				WLog_ERR(TAG, "%s - update_read_draw_gdiplus_cache_next_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_draw_gdiplus_cache_next_order() failed",
+				           orderName);
 				return FALSE;
 			}
 
-			IFCALL(altsec->DrawGdiPlusCacheNext, context,
-			       &(altsec->draw_gdiplus_cache_next));
+			IFCALLRET(altsec->DrawGdiPlusCacheNext, rc, context,
+			          &(altsec->draw_gdiplus_cache_next));
 			break;
 
 		case ORDER_TYPE_GDIPLUS_CACHE_END:
 			if (!update_read_draw_gdiplus_cache_end_order(s,
 			        &(altsec->draw_gdiplus_cache_end)))
 			{
-				WLog_ERR(TAG, "%s - update_read_draw_gdiplus_cache_end_order() failed", orderName);
+				WLog_Print(update->log, WLOG_ERROR, "%s - update_read_draw_gdiplus_cache_end_order() failed",
+				           orderName);
 				return FALSE;
 			}
 
-			IFCALL(altsec->DrawGdiPlusCacheEnd, context, &(altsec->draw_gdiplus_cache_end));
+			IFCALLRET(altsec->DrawGdiPlusCacheEnd, rc, context, &(altsec->draw_gdiplus_cache_end));
 			break;
 
 		case ORDER_TYPE_WINDOW:
 			return update_recv_altsec_window_order(update, s);
 
 		case ORDER_TYPE_COMPDESK_FIRST:
+			rc = TRUE;
 			break;
 
 		default:
+			WLog_Print(update->log, WLOG_WARN,
+			           "Alternate Secondary Drawing Order %s", orderName);
 			break;
 	}
 
-	return TRUE;
+	return rc;
 }
 BOOL update_recv_order(rdpUpdate* update, wStream* s)
 {

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -121,13 +121,19 @@ static int check_order_activated(wLog* log, rdpSettings* settings, const char* o
 {
 	if (!condition)
 	{
-		WLog_Print(log, WLOG_ERROR,
-		           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
-
-		if (!settings->AllowUnanouncedOrdersFromServer)
+		if (settings->AllowUnanouncedOrdersFromServer)
+		{
+			WLog_Print(log, WLOG_WARN,
+			           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+			return 0;
+		}
+		else
+		{
+			WLog_Print(log, WLOG_ERROR,
+			           "%s - SERVER BUG: The support for this feature was not announced! Use /relax-order-checks to ignore",
+			           orderName);
 			return -1;
-
-		return 0;
+		}
 	}
 
 	return 1;

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -2849,6 +2849,10 @@ static CACHE_BRUSH_ORDER* update_read_cache_brush_order(rdpUpdate* update, wStre
 
 	Stream_Read_UINT8(s, cache_brush->index); /* cacheEntry (1 byte) */
 	Stream_Read_UINT8(s, iBitmapFormat); /* iBitmapFormat (1 byte) */
+
+	if (iBitmapFormat > ARRAYSIZE(BMF_BPP))
+		goto fail;
+
 	cache_brush->bpp = BMF_BPP[iBitmapFormat];
 	Stream_Read_UINT8(s, cache_brush->cx); /* cx (1 byte) */
 	Stream_Read_UINT8(s, cache_brush->cy); /* cy (1 byte) */

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -357,6 +357,7 @@ static BOOL adjust_point(rdpContext* context, INT32* px, INT32* py)
 	*py = y;
 	return TRUE;;
 }
+
 static BOOL freerdp_check_delta_point(rdpContext* context, INT32 x, INT32 y, UINT32 count,
                                       const DELTA_POINT* data)
 {
@@ -3498,13 +3499,6 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			}
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-
-			if (!adjust_point(context, &primary->line_to.nXStart, &primary->line_to.nYStart))
-				return FALSE;
-
-			if (!adjust_point(context, &primary->line_to.nXEnd, &primary->line_to.nYEnd))
-				return FALSE;
-
 			rc = IFCALLRESULT(FALSE, primary->LineTo, context, &primary->line_to);
 			break;
 
@@ -3516,11 +3510,6 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			}
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
-
-			if (!freerdp_check_delta_point(context, primary->polyline.xStart, primary->polyline.yStart,
-			                               primary->polyline.numDeltaEntries, primary->polyline.points))
-				return FALSE;
-
 			rc = IFCALLRESULT(FALSE, primary->Polyline, context, &primary->polyline);
 			break;
 

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -4190,6 +4190,7 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 	BYTE orderType = flags >>= 2; /* orderType is in higher 6 bits of flags field */
 	BOOL rc = FALSE;
 	rdpContext* context = update->context;
+	rdpSettings* settings = context->settings;
 	rdpAltSecUpdate* altsec = update->altsec;
 	const char* orderName = altsec_order_string(orderType);
 	WLog_Print(update->log, WLOG_DEBUG,
@@ -4198,8 +4199,14 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 	switch (orderType)
 	{
 		case ORDER_TYPE_CREATE_OFFSCREEN_BITMAP:
-			if (update_read_create_offscreen_bitmap_order(s,
-			        &(altsec->create_offscreen_bitmap)))
+			if (!settings->OffscreenSupportLevel)
+			{
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+				return TRUE;
+			}
+			else if (update_read_create_offscreen_bitmap_order(s,
+			         &(altsec->create_offscreen_bitmap)))
 			{
 				IFCALLRET(altsec->CreateOffscreenBitmap, rc, context,
 				          &(altsec->create_offscreen_bitmap));
@@ -4208,7 +4215,13 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			break;
 
 		case ORDER_TYPE_SWITCH_SURFACE:
-			if (update_read_switch_surface_order(s, &(altsec->switch_surface)))
+			if (!settings->OffscreenSupportLevel)
+			{
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+				return TRUE;
+			}
+			else if (update_read_switch_surface_order(s, &(altsec->switch_surface)))
 			{
 				IFCALLRET(altsec->SwitchSurface, rc, context, &(altsec->switch_surface));
 			}
@@ -4216,8 +4229,14 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			break;
 
 		case ORDER_TYPE_CREATE_NINE_GRID_BITMAP:
-			if (update_read_create_nine_grid_bitmap_order(s,
-			        &(altsec->create_nine_grid_bitmap)))
+			if (!settings->DrawNineGridEnabled)
+			{
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+				return TRUE;
+			}
+			else if (update_read_create_nine_grid_bitmap_order(s,
+			         &(altsec->create_nine_grid_bitmap)))
 			{
 				IFCALLRET(altsec->CreateNineGridBitmap, rc, context,
 				          &(altsec->create_nine_grid_bitmap));
@@ -4226,7 +4245,13 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			break;
 
 		case ORDER_TYPE_FRAME_MARKER:
-			if (update_read_frame_marker_order(s, &(altsec->frame_marker)))
+			if (!settings->FrameMarkerCommandEnabled)
+			{
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+				return TRUE;
+			}
+			else if (update_read_frame_marker_order(s, &(altsec->frame_marker)))
 			{
 				IFCALLRET(altsec->FrameMarker, rc, context, &(altsec->frame_marker));
 			}
@@ -4250,7 +4275,13 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			break;
 
 		case ORDER_TYPE_GDIPLUS_FIRST:
-			if (update_read_draw_gdiplus_first_order(s, &(altsec->draw_gdiplus_first)))
+			if (!settings->DrawGdiPlusCacheEnabled)
+			{
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+				return TRUE;
+			}
+			else if (update_read_draw_gdiplus_first_order(s, &(altsec->draw_gdiplus_first)))
 			{
 				IFCALLRET(altsec->DrawGdiPlusFirst, rc, context, &(altsec->draw_gdiplus_first));
 			}
@@ -4258,7 +4289,13 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			break;
 
 		case ORDER_TYPE_GDIPLUS_NEXT:
-			if (update_read_draw_gdiplus_next_order(s, &(altsec->draw_gdiplus_next)))
+			if (!settings->DrawGdiPlusCacheEnabled)
+			{
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+				return TRUE;
+			}
+			else if (update_read_draw_gdiplus_next_order(s, &(altsec->draw_gdiplus_next)))
 			{
 				IFCALLRET(altsec->DrawGdiPlusNext, rc, context, &(altsec->draw_gdiplus_next));
 			}
@@ -4266,7 +4303,13 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			break;
 
 		case ORDER_TYPE_GDIPLUS_END:
-			if (update_read_draw_gdiplus_end_order(s, &(altsec->draw_gdiplus_end)))
+			if (!settings->DrawGdiPlusCacheEnabled)
+			{
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+				return TRUE;
+			}
+			else if (update_read_draw_gdiplus_end_order(s, &(altsec->draw_gdiplus_end)))
 			{
 				IFCALLRET(altsec->DrawGdiPlusEnd, rc, context, &(altsec->draw_gdiplus_end));
 			}
@@ -4274,8 +4317,14 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			break;
 
 		case ORDER_TYPE_GDIPLUS_CACHE_FIRST:
-			if (update_read_draw_gdiplus_cache_first_order(s,
-			        &(altsec->draw_gdiplus_cache_first)))
+			if (!settings->DrawGdiPlusCacheEnabled)
+			{
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+				return TRUE;
+			}
+			else if (update_read_draw_gdiplus_cache_first_order(s,
+			         &(altsec->draw_gdiplus_cache_first)))
 			{
 				IFCALLRET(altsec->DrawGdiPlusCacheFirst, rc, context,
 				          &(altsec->draw_gdiplus_cache_first));
@@ -4284,8 +4333,14 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			break;
 
 		case ORDER_TYPE_GDIPLUS_CACHE_NEXT:
-			if (update_read_draw_gdiplus_cache_next_order(s,
-			        &(altsec->draw_gdiplus_cache_next)))
+			if (!settings->DrawGdiPlusCacheEnabled)
+			{
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+				return TRUE;
+			}
+			else if (update_read_draw_gdiplus_cache_next_order(s,
+			         &(altsec->draw_gdiplus_cache_next)))
 			{
 				IFCALLRET(altsec->DrawGdiPlusCacheNext, rc, context,
 				          &(altsec->draw_gdiplus_cache_next));
@@ -4294,8 +4349,14 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			break;
 
 		case ORDER_TYPE_GDIPLUS_CACHE_END:
-			if (update_read_draw_gdiplus_cache_end_order(s,
-			        &(altsec->draw_gdiplus_cache_end)))
+			if (!settings->DrawGdiPlusCacheEnabled)
+			{
+				WLog_Print(update->log, WLOG_ERROR,
+				           "%s - SERVER BUG: The support for this feature was not announced!", orderName);
+				return TRUE;
+			}
+			else if (update_read_draw_gdiplus_cache_end_order(s,
+			         &(altsec->draw_gdiplus_cache_end)))
 			{
 				IFCALLRET(altsec->DrawGdiPlusCacheEnd, rc, context, &(altsec->draw_gdiplus_cache_end));
 			}
@@ -4311,6 +4372,8 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			break;
 
 		default:
+			WLog_Print(update->log, WLOG_WARN,
+			           "%s - Alternate Secondary Drawing Order not supported", orderName);
 			break;
 	}
 

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -462,7 +462,7 @@ static BOOL freerdp_check_glyph_op_bound(wLog* log, const char* order, rdpContex
 	if (bottom == -32768)
 		bottom = top;
 
-	return freerdp_primary_adjust_bound(log, order, context, left, top, right, bottom);
+	return freerdp_primary_adjust_bound(log, order, context, &left, &top, &right, &bottom);
 }
 
 static INLINE BOOL update_read_coord(wStream* s, INT32* coord, BOOL delta)
@@ -3418,9 +3418,9 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->draw_nine_grid.srcLeft,
-			                                  primary->draw_nine_grid.srcTop, primary->draw_nine_grid.srcRight,
-			                                  primary->draw_nine_grid.srcBottom))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->draw_nine_grid.srcLeft,
+			                                  &primary->draw_nine_grid.srcTop, &primary->draw_nine_grid.srcRight,
+			                                  &primary->draw_nine_grid.srcBottom))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->DrawNineGrid, context, &primary->draw_nine_grid);
@@ -3542,9 +3542,10 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
 			if (!freerdp_primary_adjust_bound(update->log, orderName, context,
-			                                  primary->multi_draw_nine_grid.srcLeft,
-			                                  primary->multi_draw_nine_grid.srcTop, primary->multi_draw_nine_grid.srcRight,
-			                                  primary->multi_draw_nine_grid.srcBottom))
+			                                  &primary->multi_draw_nine_grid.srcLeft,
+			                                  &primary->multi_draw_nine_grid.srcTop,
+			                                  &primary->multi_draw_nine_grid.srcRight,
+			                                  &primary->multi_draw_nine_grid.srcBottom))
 				return FALSE;
 
 			if (!freerdp_adjust_delta_rect(update->log, orderName, context,
@@ -3637,8 +3638,9 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->save_bitmap.nLeftRect,
-			                                  primary->save_bitmap.nTopRect, primary->save_bitmap.nRightRect, primary->save_bitmap.nBottomRect))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->save_bitmap.nLeftRect,
+			                                  &primary->save_bitmap.nTopRect, &primary->save_bitmap.nRightRect,
+			                                  &primary->save_bitmap.nBottomRect))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->SaveBitmap, context, &primary->save_bitmap);
@@ -3654,18 +3656,18 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->glyph_index.bkLeft,
-			                                  primary->glyph_index.bkTop,
-			                                  primary->glyph_index.bkRight, primary->fast_index.bkBottom))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->glyph_index.bkLeft,
+			                                  &primary->glyph_index.bkTop,
+			                                  &primary->glyph_index.bkRight, &primary->fast_index.bkBottom))
 				return FALSE;
 
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->glyph_index.opLeft,
-			                                  primary->glyph_index.opTop,
-			                                  primary->glyph_index.opRight, primary->fast_index.opBottom))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->glyph_index.opLeft,
+			                                  &primary->glyph_index.opTop,
+			                                  &primary->glyph_index.opRight, &primary->fast_index.opBottom))
 				return FALSE;
 
-			if (!freerdp_adjust_point(update->log, orderName, context, primary->glyph_index.x,
-			                          primary->glyph_index.y))
+			if (!freerdp_adjust_point(update->log, orderName, context, &primary->glyph_index.x,
+			                          &primary->glyph_index.y))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->GlyphIndex, context, &primary->glyph_index);
@@ -3680,9 +3682,10 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->fast_index.bkLeft,
-			                                  primary->fast_index.bkTop,
-			                                  primary->fast_index.bkRight, primary->fast_index.bkBottom))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context,
+			                                  &primary->fast_index.bkLeft,
+			                                  &primary->fast_index.bkTop,
+			                                  &primary->fast_index.bkRight, &primary->fast_index.bkBottom))
 				return FALSE;
 
 			if (!freerdp_check_glyph_op_bound(update->log, orderName, context, primary->fast_index.opLeft,
@@ -3706,9 +3709,9 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->fast_glyph.bkLeft,
-			                                  primary->fast_glyph.bkTop,
-			                                  primary->fast_glyph.bkRight, primary->fast_index.bkBottom))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->fast_glyph.bkLeft,
+			                                  &primary->fast_glyph.bkTop,
+			                                  &primary->fast_glyph.bkRight, &primary->fast_index.bkBottom))
 				return FALSE;
 
 			if (!freerdp_check_glyph_op_bound(update->log, orderName, context, primary->fast_glyph.opLeft,
@@ -3753,9 +3756,9 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->ellipse_sc.leftRect,
-			                                  primary->ellipse_sc.topRect,
-			                                  primary->ellipse_sc.rightRect,  primary->ellipse_sc.bottomRect))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->ellipse_sc.leftRect,
+			                                  &primary->ellipse_sc.topRect,
+			                                  &primary->ellipse_sc.rightRect,  &primary->ellipse_sc.bottomRect))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->EllipseSC, context, &primary->ellipse_sc);
@@ -3770,9 +3773,9 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 
 			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
-			if (!freerdp_primary_adjust_bound(update->log, orderName, context, primary->ellipse_cb.leftRect,
-			                                  primary->ellipse_cb.topRect,
-			                                  primary->ellipse_cb.rightRect,  primary->ellipse_cb.bottomRect))
+			if (!freerdp_primary_adjust_bound(update->log, orderName, context, &primary->ellipse_cb.leftRect,
+			                                  &primary->ellipse_cb.topRect,
+			                                  &primary->ellipse_cb.rightRect,  &primary->ellipse_cb.bottomRect))
 				return FALSE;
 
 			rc = IFCALLRESULT(FALSE, primary->EllipseCB, context, &primary->ellipse_cb);

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -43,70 +43,6 @@
 
 #define TAG FREERDP_TAG("core.orders")
 
-static const char* const PRIMARY_DRAWING_ORDER_STRINGS[] =
-{
-	"DstBlt",
-	"PatBlt",
-	"ScrBlt",
-	"", "", "", "",
-	"DrawNineGrid",
-	"MultiDrawNineGrid",
-	"LineTo",
-	"OpaqueRect",
-	"SaveBitmap",
-	"",
-	"MemBlt",
-	"Mem3Blt",
-	"MultiDstBlt",
-	"MultiPatBlt",
-	"MultiScrBlt",
-	"MultiOpaqueRect",
-	"FastIndex",
-	"PolygonSC",
-	"PolygonCB",
-	"Polyline",
-	"",
-	"FastGlyph",
-	"EllipseSC",
-	"EllipseCB",
-	"GlyphIndex"
-};
-
-static const char* const SECONDARY_DRAWING_ORDER_STRINGS[] =
-{
-	"Cache Bitmap",
-	"Cache Color Table",
-	"Cache Bitmap (Compressed)",
-	"Cache Glyph",
-	"Cache Bitmap V2",
-	"Cache Bitmap V2 (Compressed)",
-	"",
-	"Cache Brush",
-	"Cache Bitmap V3"
-};
-
-#define SECONDARY_DRAWING_ORDER_COUNT	(ARRAYSIZE(SECONDARY_DRAWING_ORDER_STRINGS))
-
-static const char* const ALTSEC_DRAWING_ORDER_STRINGS[] =
-{
-	"Switch Surface",
-	"Create Offscreen Bitmap",
-	"Stream Bitmap First",
-	"Stream Bitmap Next",
-	"Create NineGrid Bitmap",
-	"Draw GDI+ First",
-	"Draw GDI+ Next",
-	"Draw GDI+ End",
-	"Draw GDI+ Cache First",
-	"Draw GDI+ Cache Next",
-	"Draw GDI+ Cache End",
-	"Windowing",
-	"Desktop Composition",
-	"Frame Marker"
-};
-
-#define ALTSEC_DRAWING_ORDER_COUNT	(ARRAYSIZE(ALTSEC_DRAWING_ORDER_STRINGS))
-
 const BYTE PRIMARY_DRAWING_ORDER_FIELD_BYTES[] =
 {
 	DSTBLT_ORDER_FIELD_BYTES,
@@ -179,6 +115,102 @@ static const BYTE BPP_BMF[] =
 	5, 0, 0, 0, 0, 0, 0, 0,
 	6, 0, 0, 0, 0, 0, 0, 0
 };
+
+static const char* primary_order_string(UINT32 orderType)
+{
+	const char* orders[] =
+	{
+		"[0x%02"PRIu8"] DstBlt",
+		"[0x%02"PRIu8"] PatBlt",
+		"[0x%02"PRIu8"] ScrBlt",
+		"[0x%02"PRIu8"] UNUSED",
+		"[0x%02"PRIu8"] UNUSED",
+		"[0x%02"PRIu8"] UNUSED",
+		"[0x%02"PRIu8"] UNUSED",
+		"[0x%02"PRIu8"] DrawNineGrid",
+		"[0x%02"PRIu8"] MultiDrawNineGrid",
+		"[0x%02"PRIu8"] LineTo",
+		"[0x%02"PRIu8"] OpaqueRect",
+		"[0x%02"PRIu8"] SaveBitmap",
+		"[0x%02"PRIu8"] UNUSED",
+		"[0x%02"PRIu8"] MemBlt",
+		"[0x%02"PRIu8"] Mem3Blt",
+		"[0x%02"PRIu8"] MultiDstBlt",
+		"[0x%02"PRIu8"] MultiPatBlt",
+		"[0x%02"PRIu8"] MultiScrBlt",
+		"[0x%02"PRIu8"] MultiOpaqueRect",
+		"[0x%02"PRIu8"] FastIndex",
+		"[0x%02"PRIu8"] PolygonSC",
+		"[0x%02"PRIu8"] PolygonCB",
+		"[0x%02"PRIu8"] Polyline",
+		"[0x%02"PRIu8"] UNUSED",
+		"[0x%02"PRIu8"] FastGlyph",
+		"[0x%02"PRIu8"] EllipseSC",
+		"[0x%02"PRIu8"] EllipseCB",
+		"[0x%02"PRIu8"] GlyphIndex"
+	};
+	const char* fmt = "[0x%02"PRIu8"] UNKNOWN";
+	static char buffer[64] = {0};
+
+	if (orderType < ARRAYSIZE(orders))
+		fmt = orders[orderType];
+
+	sprintf_s(buffer, ARRAYSIZE(buffer), fmt, orderType);
+	return buffer;
+}
+
+static const char* secondary_order_string(UINT32 orderType)
+{
+	const char* orders[] =
+	{
+		"[0x%02"PRIu8"] Cache Bitmap",
+		"[0x%02"PRIu8"] Cache Color Table",
+		"[0x%02"PRIu8"] Cache Bitmap (Compressed)",
+		"[0x%02"PRIu8"] Cache Glyph",
+		"[0x%02"PRIu8"] Cache Bitmap V2",
+		"[0x%02"PRIu8"] Cache Bitmap V2 (Compressed)",
+		"[0x%02"PRIu8"] UNUSED",
+		"[0x%02"PRIu8"] Cache Brush",
+		"[0x%02"PRIu8"] Cache Bitmap V3"
+	};
+	const char* fmt = "[0x%02"PRIu8"] UNKNOWN";
+	static char buffer[64] = {0};
+
+	if (orderType < ARRAYSIZE(orders))
+		fmt = orders[orderType];
+
+	sprintf_s(buffer, ARRAYSIZE(buffer), fmt, orderType);
+	return buffer;
+}
+
+static const char* altsec_order_string(BYTE orderType)
+{
+	const char* orders[] =
+	{
+		"[0x%02"PRIu8"] Switch Surface",
+		"[0x%02"PRIu8"] Create Offscreen Bitmap",
+		"[0x%02"PRIu8"] Stream Bitmap First",
+		"[0x%02"PRIu8"] Stream Bitmap Next",
+		"[0x%02"PRIu8"] Create NineGrid Bitmap",
+		"[0x%02"PRIu8"] Draw GDI+ First",
+		"[0x%02"PRIu8"] Draw GDI+ Next",
+		"[0x%02"PRIu8"] Draw GDI+ End",
+		"[0x%02"PRIu8"] Draw GDI+ Cache First",
+		"[0x%02"PRIu8"] Draw GDI+ Cache Next",
+		"[0x%02"PRIu8"] Draw GDI+ Cache End",
+		"[0x%02"PRIu8"] Windowing",
+		"[0x%02"PRIu8"] Desktop Composition",
+		"[0x%02"PRIu8"] Frame Marker"
+	};
+	const char* fmt = "[0x%02"PRIu8"] UNKNOWN";
+	static char buffer[64] = {0};
+
+	if (orderType < ARRAYSIZE(orders))
+		fmt = orders[orderType];
+
+	sprintf_s(buffer, ARRAYSIZE(buffer), fmt, orderType);
+	return buffer;
+}
 
 static BOOL freerdp_primary_check_bound(rdpContext* context, INT32 left, INT32 top, INT32 right,
                                         INT32 bottom)
@@ -351,13 +383,6 @@ static BOOL freerdp_check_glyph_op_bound(rdpContext* context, INT32 left, INT32 
 		bottom = top;
 
 	return freerdp_primary_check_bound(context, left, top, right, bottom);
-}
-static const char* update_secondary_order_to_string(BYTE order)
-{
-	if (order >= ARRAYSIZE(SECONDARY_DRAWING_ORDER_STRINGS))
-		return "UNKNOWN";
-
-	return SECONDARY_DRAWING_ORDER_STRINGS[order];
 }
 
 static INLINE BOOL update_read_coord(wStream* s, INT32* coord, BOOL delta)
@@ -3167,17 +3192,19 @@ BOOL update_write_bounds(wStream* s, ORDER_INFO* orderInfo)
 static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 {
 	BOOL rc = FALSE;
-	ORDER_INFO* orderInfo;
 	rdpContext* context = update->context;
 	rdpPrimaryUpdate* primary = update->primary;
-	orderInfo = &(primary->order_info);
+	ORDER_INFO* orderInfo = &(primary->order_info);
+	const char* orderName;
 
 	if (flags & ORDER_TYPE_CHANGE)
 		Stream_Read_UINT8(s, orderInfo->orderType); /* orderType (1 byte) */
 
+	orderName = primary_order_string(orderInfo->orderType);
+
 	if (orderInfo->orderType >= PRIMARY_DRAWING_ORDER_COUNT)
 	{
-		WLog_ERR(TAG,  "Invalid Primary Drawing Order (0x%08"PRIX32")", orderInfo->orderType);
+		WLog_ERR(TAG,  "Invalid Primary Drawing Order %s", orderName);
 		return FALSE;
 	}
 
@@ -3215,13 +3242,13 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_DSTBLT:
 			if (!update_read_dstblt_order(s, orderInfo, &(primary->dstblt)))
 			{
-				WLog_ERR(TAG, "ORDER_TYPE_DSTBLT - update_read_dstblt_order() failed");
+				WLog_ERR(TAG, "%s - update_read_dstblt_order() failed", orderName);
 				return FALSE;
 			}
 
 			WLog_Print(update->log, WLOG_DEBUG,
-			           "%s Primary Drawing Order (0x%08"PRIX32") rop=%s [0x%08"PRIx32"]",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType,
+			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]",
+			           orderName,
 			           gdi_rop3_code_string(primary->dstblt.bRop), gdi_rop3_code(primary->dstblt.bRop));
 
 			if (!freerdp_primary_check_rect(context, primary->dstblt.nLeftRect, primary->dstblt.nTopRect,
@@ -3234,13 +3261,12 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_PATBLT:
 			if (!update_read_patblt_order(s, orderInfo, &(primary->patblt)))
 			{
-				WLog_ERR(TAG, "ORDER_TYPE_PATBLT - update_read_patblt_order() failed");
+				WLog_ERR(TAG, "%s - update_read_patblt_order() failed", orderName);
 				return FALSE;
 			}
 
 			WLog_Print(update->log, WLOG_DEBUG,
-			           "%s Primary Drawing Order (0x%08"PRIX32") rop=%s [0x%08"PRIx32"]",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType,
+			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
 			           gdi_rop3_code_string(primary->patblt.bRop), gdi_rop3_code(primary->patblt.bRop));
 
 			if (!freerdp_primary_check_rect(context, primary->patblt.nLeftRect, primary->patblt.nTopRect,
@@ -3253,13 +3279,12 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_SCRBLT:
 			if (!update_read_scrblt_order(s, orderInfo, &(primary->scrblt)))
 			{
-				WLog_ERR(TAG, "ORDER_TYPE_SCRBLT - update_read_scrblt_order() failed");
+				WLog_ERR(TAG, "%s - update_read_scrblt_order() failed", orderName);
 				return FALSE;
 			}
 
 			WLog_Print(update->log, WLOG_DEBUG,
-			           "%s Primary Drawing Order (0x%08"PRIX32") rop=%s [0x%08"PRIx32"]",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType,
+			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
 			           gdi_rop3_code_string(primary->scrblt.bRop), gdi_rop3_code(primary->scrblt.bRop));
 
 			if (!freerdp_primary_check_rect(context, primary->scrblt.nLeftRect, primary->scrblt.nTopRect,
@@ -3273,12 +3298,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			if (!update_read_opaque_rect_order(s, orderInfo, &(primary->opaque_rect)))
 			{
 				WLog_ERR(TAG,
-				         "ORDER_TYPE_OPAQUE_RECT - update_read_opaque_rect_order() failed");
+				         "%s - update_read_opaque_rect_order() failed", orderName);
 				return FALSE;
 			}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "%s Primary Drawing Order (0x%08"PRIX32")",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType);
+			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
 			if (!freerdp_primary_check_rect(context, primary->opaque_rect.nLeftRect,
 			                                primary->opaque_rect.nTopRect, primary->opaque_rect.nWidth, primary->opaque_rect.nHeight))
@@ -3291,12 +3315,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			if (!update_read_draw_nine_grid_order(s, orderInfo, &(primary->draw_nine_grid)))
 			{
 				WLog_ERR(TAG,
-				         "ORDER_TYPE_DRAW_NINE_GRID - update_read_draw_nine_grid_order() failed");
+				         "%s - update_read_draw_nine_grid_order() failed", orderName);
 				return FALSE;
 			}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "%s Primary Drawing Order (0x%08"PRIX32")",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType);
+			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
 			if (!freerdp_primary_check_bound(context, primary->draw_nine_grid.srcLeft,
 			                                 primary->draw_nine_grid.srcTop, primary->draw_nine_grid.srcRight,
@@ -3310,13 +3333,12 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			if (!update_read_multi_dstblt_order(s, orderInfo, &(primary->multi_dstblt)))
 			{
 				WLog_ERR(TAG,
-				         "ORDER_TYPE_MULTI_DSTBLT - update_read_multi_dstblt_order() failed");
+				         "%s - update_read_multi_dstblt_order() failed", orderName);
 				return FALSE;
 			}
 
 			WLog_Print(update->log, WLOG_DEBUG,
-			           "%s Primary Drawing Order (0x%08"PRIX32") rop=%s [0x%08"PRIx32"]",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType,
+			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
 			           gdi_rop3_code_string(primary->multi_dstblt.bRop), gdi_rop3_code(primary->multi_dstblt.bRop));
 
 			if (!freerdp_primary_check_rect(context, primary->multi_dstblt.nLeftRect,
@@ -3334,13 +3356,12 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			if (!update_read_multi_patblt_order(s, orderInfo, &(primary->multi_patblt)))
 			{
 				WLog_ERR(TAG,
-				         "ORDER_TYPE_MULTI_PATBLT - update_read_multi_patblt_order() failed");
+				         "%s - update_read_multi_patblt_order() failed", orderName);
 				return FALSE;
 			}
 
 			WLog_Print(update->log, WLOG_DEBUG,
-			           "%s Primary Drawing Order (0x%08"PRIX32") rop=%s [0x%08"PRIx32"]",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType,
+			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
 			           gdi_rop3_code_string(primary->multi_patblt.bRop), gdi_rop3_code(primary->multi_patblt.bRop));
 
 			if (!freerdp_primary_check_rect(context, primary->multi_patblt.nLeftRect,
@@ -3358,13 +3379,12 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			if (!update_read_multi_scrblt_order(s, orderInfo, &(primary->multi_scrblt)))
 			{
 				WLog_ERR(TAG,
-				         "ORDER_TYPE_MULTI_SCRBLT - update_read_multi_scrblt_order() failed");
+				         "%s - update_read_multi_scrblt_order() failed", orderName);
 				return FALSE;
 			}
 
 			WLog_Print(update->log, WLOG_DEBUG,
-			           "%s Primary Drawing Order (0x%08"PRIX32") rop=%s [0x%08"PRIx32"]",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType,
+			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
 			           gdi_rop3_code_string(primary->multi_scrblt.bRop), gdi_rop3_code(primary->multi_scrblt.bRop));
 
 			if (!freerdp_primary_check_rect(context, primary->multi_scrblt.nLeftRect,
@@ -3383,12 +3403,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			        &(primary->multi_opaque_rect)))
 			{
 				WLog_ERR(TAG,
-				         "ORDER_TYPE_MULTI_OPAQUE_RECT - update_read_multi_opaque_rect_order() failed");
+				         "%s - update_read_multi_opaque_rect_order() failed", orderName);
 				return FALSE;
 			}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "%s Primary Drawing Order (0x%08"PRIX32")",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType);
+			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
 			if (!freerdp_primary_check_rect(context, primary->multi_opaque_rect.nLeftRect,
 			                                primary->multi_opaque_rect.nTopRect, primary->multi_opaque_rect.nWidth,
@@ -3407,12 +3426,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			        &(primary->multi_draw_nine_grid)))
 			{
 				WLog_ERR(TAG,
-				         "ORDER_TYPE_MULTI_DRAW_NINE_GRID - update_read_multi_draw_nine_grid_order() failed");
+				         "%s - update_read_multi_draw_nine_grid_order() failed", orderName);
 				return FALSE;
 			}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "%s Primary Drawing Order (0x%08"PRIX32")",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType);
+			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
 			if (!freerdp_primary_check_bound(context, primary->multi_draw_nine_grid.srcLeft,
 			                                 primary->multi_draw_nine_grid.srcTop, primary->multi_draw_nine_grid.srcRight,
@@ -3426,12 +3444,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_LINE_TO:
 			if (!update_read_line_to_order(s, orderInfo, &(primary->line_to)))
 			{
-				WLog_ERR(TAG, "ORDER_TYPE_LINE_TO - update_read_line_to_order() failed");
+				WLog_ERR(TAG, "%s - update_read_line_to_order() failed", orderName);
 				return FALSE;
 			}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "%s Primary Drawing Order (0x%08"PRIX32")",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType);
+			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
 			if (!freerdp_check_point(context, primary->line_to.nXStart, primary->line_to.nYStart))
 				return FALSE;
@@ -3445,12 +3462,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_POLYLINE:
 			if (!update_read_polyline_order(s, orderInfo, &(primary->polyline)))
 			{
-				WLog_ERR(TAG, "ORDER_TYPE_POLYLINE - update_read_polyline_order() failed");
+				WLog_ERR(TAG, "%s - update_read_polyline_order() failed", orderName);
 				return FALSE;
 			}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "%s Primary Drawing Order (0x%08"PRIX32")",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType);
+			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
 			if (!freerdp_check_delta_point(context, primary->polyline.xStart, primary->polyline.yStart,
 			                               primary->polyline.numDeltaEntries, primary->polyline.points))
@@ -3462,13 +3478,12 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_MEMBLT:
 			if (!update_read_memblt_order(s, orderInfo, &(primary->memblt)))
 			{
-				WLog_ERR(TAG, "ORDER_TYPE_MEMBLT - update_read_memblt_order() failed");
+				WLog_ERR(TAG, "%s - update_read_memblt_order() failed", orderName);
 				return FALSE;
 			}
 
 			WLog_Print(update->log, WLOG_DEBUG,
-			           "%s Primary Drawing Order (0x%08"PRIX32") rop=%s [0x%08"PRIx32"]",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType,
+			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
 			           gdi_rop3_code_string(primary->memblt.bRop), gdi_rop3_code(primary->memblt.bRop));
 
 			if (!freerdp_primary_check_rect(context, primary->memblt.nLeftRect, primary->memblt.nTopRect,
@@ -3481,13 +3496,12 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_MEM3BLT:
 			if (!update_read_mem3blt_order(s, orderInfo, &(primary->mem3blt)))
 			{
-				WLog_ERR(TAG, "ORDER_TYPE_MEM3BLT - update_read_mem3blt_order() failed");
+				WLog_ERR(TAG, "%s - update_read_mem3blt_order() failed", orderName);
 				return FALSE;
 			}
 
 			WLog_Print(update->log, WLOG_DEBUG,
-			           "%s Primary Drawing Order (0x%08"PRIX32") rop=%s [0x%08"PRIx32"]",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType,
+			           "Primary Drawing Order %s rop=%s [0x%08"PRIx32"]", orderName,
 			           gdi_rop3_code_string(primary->mem3blt.bRop), gdi_rop3_code(primary->mem3blt.bRop));
 
 			if (!freerdp_primary_check_rect(context, primary->mem3blt.nLeftRect, primary->mem3blt.nTopRect,
@@ -3501,12 +3515,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			if (!update_read_save_bitmap_order(s, orderInfo, &(primary->save_bitmap)))
 			{
 				WLog_ERR(TAG,
-				         "ORDER_TYPE_SAVE_BITMAP - update_read_save_bitmap_order() failed");
+				         "%s - update_read_save_bitmap_order() failed", orderName);
 				return FALSE;
 			}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "%s Primary Drawing Order (0x%08"PRIX32")",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType);
+			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
 			if (!freerdp_primary_check_bound(context, primary->save_bitmap.nLeftRect,
 			                                 primary->save_bitmap.nTopRect, primary->save_bitmap.nRightRect, primary->save_bitmap.nBottomRect))
@@ -3519,12 +3532,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			if (!update_read_glyph_index_order(s, orderInfo, &(primary->glyph_index)))
 			{
 				WLog_ERR(TAG,
-				         "ORDER_TYPE_GLYPH_INDEX - update_read_glyph_index_order() failed");
+				         "%s - update_read_glyph_index_order() failed", orderName);
 				return FALSE;
 			}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "%s Primary Drawing Order (0x%08"PRIX32")",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType);
+			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
 			if (!freerdp_primary_check_bound(context, primary->glyph_index.bkLeft, primary->glyph_index.bkTop,
 			                                 primary->glyph_index.bkRight, primary->fast_index.bkBottom))
@@ -3543,12 +3555,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_FAST_INDEX:
 			if (!update_read_fast_index_order(s, orderInfo, &(primary->fast_index)))
 			{
-				WLog_ERR(TAG, "ORDER_TYPE_FAST_INDEX - update_read_fast_index_order() failed");
+				WLog_ERR(TAG, "%s - update_read_fast_index_order() failed", orderName);
 				return FALSE;
 			}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "%s Primary Drawing Order (0x%08"PRIX32")",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType);
+			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
 			if (!freerdp_primary_check_bound(context, primary->fast_index.bkLeft, primary->fast_index.bkTop,
 			                                 primary->fast_index.bkRight, primary->fast_index.bkBottom))
@@ -3567,12 +3578,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_FAST_GLYPH:
 			if (!update_read_fast_glyph_order(s, orderInfo, &(primary->fast_glyph)))
 			{
-				WLog_ERR(TAG, "ORDER_TYPE_FAST_GLYPH - update_read_fast_glyph_order() failed");
+				WLog_ERR(TAG, "%s - update_read_fast_glyph_order() failed", orderName);
 				return FALSE;
 			}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "%s Primary Drawing Order (0x%08"PRIX32")",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType);
+			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
 			if (!freerdp_primary_check_bound(context, primary->fast_glyph.bkLeft, primary->fast_glyph.bkTop,
 			                                 primary->fast_glyph.bkRight, primary->fast_index.bkBottom))
@@ -3591,12 +3601,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_POLYGON_SC:
 			if (!update_read_polygon_sc_order(s, orderInfo, &(primary->polygon_sc)))
 			{
-				WLog_ERR(TAG, "ORDER_TYPE_POLYGON_SC - update_read_polygon_sc_order() failed");
+				WLog_ERR(TAG, "%s - update_read_polygon_sc_order() failed", orderName);
 				return FALSE;
 			}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "%s Primary Drawing Order (0x%08"PRIX32")",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType);
+			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
 			if (!freerdp_check_delta_point(context, primary->polygon_sc.xStart, primary->polygon_sc.yStart,
 			                               primary->polygon_sc.numPoints, primary->polygon_sc.points))
@@ -3608,12 +3617,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_POLYGON_CB:
 			if (!update_read_polygon_cb_order(s, orderInfo, &(primary->polygon_cb)))
 			{
-				WLog_ERR(TAG, "ORDER_TYPE_POLYGON_CB - update_read_polygon_cb_order() failed");
+				WLog_ERR(TAG, "%s - update_read_polygon_cb_order() failed", orderName);
 				return FALSE;
 			}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "%s Primary Drawing Order (0x%08"PRIX32")",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType);
+			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
 			if (!freerdp_check_delta_point(context, primary->polygon_cb.xStart, primary->polygon_cb.yStart,
 			                               primary->polygon_cb.numPoints, primary->polygon_cb.points))
@@ -3625,12 +3633,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_ELLIPSE_SC:
 			if (!update_read_ellipse_sc_order(s, orderInfo, &(primary->ellipse_sc)))
 			{
-				WLog_ERR(TAG, "ORDER_TYPE_ELLIPSE_SC - update_read_ellipse_sc_order() failed");
+				WLog_ERR(TAG, "%s - update_read_ellipse_sc_order() failed", orderName);
 				return FALSE;
 			}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "%s Primary Drawing Order (0x%08"PRIX32")",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType);
+			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
 			if (!freerdp_primary_check_bound(context, primary->ellipse_sc.leftRect, primary->ellipse_sc.topRect,
 			                                 primary->ellipse_sc.rightRect,  primary->ellipse_sc.bottomRect))
@@ -3642,12 +3649,11 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 		case ORDER_TYPE_ELLIPSE_CB:
 			if (!update_read_ellipse_cb_order(s, orderInfo, &(primary->ellipse_cb)))
 			{
-				WLog_ERR(TAG, "ORDER_TYPE_ELLIPSE_CB - update_read_ellipse_cb_order() failed");
+				WLog_ERR(TAG, "%s - update_read_ellipse_cb_order() failed", orderName);
 				return FALSE;
 			}
 
-			WLog_Print(update->log, WLOG_DEBUG,  "%s Primary Drawing Order (0x%08"PRIX32")",
-			           PRIMARY_DRAWING_ORDER_STRINGS[orderInfo->orderType], orderInfo->orderType);
+			WLog_Print(update->log, WLOG_DEBUG,  "Primary Drawing Order %s", orderName);
 
 			if (!freerdp_primary_check_bound(context, primary->ellipse_cb.leftRect, primary->ellipse_cb.topRect,
 			                                 primary->ellipse_cb.rightRect,  primary->ellipse_cb.bottomRect))
@@ -3657,8 +3663,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 			break;
 
 		default:
-			WLog_Print(update->log, WLOG_WARN,  "[UNKNOWN] Primary Drawing Order (0x%08"PRIX32"), ignoring",
-			           orderInfo->orderType);
+			WLog_Print(update->log, WLOG_WARN,  "Primary Drawing Order %s, ignoring", orderName);
 			rc = TRUE;
 			break;
 	}
@@ -3694,8 +3699,8 @@ static BOOL update_recv_secondary_order(rdpUpdate* update, wStream* s,
 	Stream_Read_UINT16(s, extraFlags); /* extraFlags (2 bytes) */
 	Stream_Read_UINT8(s, orderType); /* orderType (1 byte) */
 	next = Stream_Pointer(s) + ((INT16) orderLength) + 7;
-	WLog_Print(update->log, WLOG_DEBUG,  "%s Secondary Drawing Order (0x%02"PRIX8")",
-	           update_secondary_order_to_string(orderType), orderType);
+	WLog_Print(update->log, WLOG_DEBUG,  "Secondary Drawing Order %s",
+	           secondary_order_string(orderType));
 
 	switch (orderType)
 	{
@@ -3793,8 +3798,7 @@ static BOOL update_recv_secondary_order(rdpUpdate* update, wStream* s,
 
 	if (!rc)
 	{
-		WLog_ERR(TAG, "SECONDARY ORDER %s [%"PRIx16"] failed", update_secondary_order_to_string(orderType),
-		         orderType);
+		WLog_ERR(TAG, "SECONDARY ORDER %s failed", secondary_order_string(orderType));
 	}
 
 	Stream_SetPointer(s, next);
@@ -3806,15 +3810,10 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 	BYTE orderType;
 	rdpContext* context = update->context;
 	rdpAltSecUpdate* altsec = update->altsec;
+	const char* orderName = altsec_order_string(orderType);
 	orderType = flags >>= 2; /* orderType is in higher 6 bits of flags field */
-
-	if (orderType < ALTSEC_DRAWING_ORDER_COUNT)
-		WLog_Print(update->log, WLOG_DEBUG,
-		           "%s Alternate Secondary Drawing Order (0x%02"PRIX8")",
-		           ALTSEC_DRAWING_ORDER_STRINGS[orderType], orderType);
-	else
-		WLog_Print(update->log, WLOG_DEBUG,
-		           "Unknown Alternate Secondary Drawing Order: 0x%02"PRIX8"", orderType);
+	WLog_Print(update->log, WLOG_DEBUG,
+	           "Alternate Secondary Drawing Order %s", orderName);
 
 	switch (orderType)
 	{
@@ -3822,8 +3821,7 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			if (!update_read_create_offscreen_bitmap_order(s,
 			        &(altsec->create_offscreen_bitmap)))
 			{
-				WLog_ERR(TAG,
-				         "ORDER_TYPE_CREATE_OFFSCREEN_BITMAP - update_read_create_offscreen_bitmap_order() failed");
+				WLog_ERR(TAG, "%s - update_read_create_offscreen_bitmap_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3834,8 +3832,7 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 		case ORDER_TYPE_SWITCH_SURFACE:
 			if (!update_read_switch_surface_order(s, &(altsec->switch_surface)))
 			{
-				WLog_ERR(TAG,
-				         "ORDER_TYPE_SWITCH_SURFACE - update_read_switch_surface_order() failed");
+				WLog_ERR(TAG, "%s - update_read_switch_surface_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3846,8 +3843,7 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			if (!update_read_create_nine_grid_bitmap_order(s,
 			        &(altsec->create_nine_grid_bitmap)))
 			{
-				WLog_ERR(TAG,
-				         "ORDER_TYPE_CREATE_NINE_GRID_BITMAP - update_read_create_nine_grid_bitmap_order() failed");
+				WLog_ERR(TAG, "%s - update_read_create_nine_grid_bitmap_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3858,8 +3854,7 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 		case ORDER_TYPE_FRAME_MARKER:
 			if (!update_read_frame_marker_order(s, &(altsec->frame_marker)))
 			{
-				WLog_ERR(TAG,
-				         "ORDER_TYPE_FRAME_MARKER - update_read_frame_marker_order() failed");
+				WLog_ERR(TAG, "%s - update_read_frame_marker_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3869,8 +3864,7 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 		case ORDER_TYPE_STREAM_BITMAP_FIRST:
 			if (!update_read_stream_bitmap_first_order(s, &(altsec->stream_bitmap_first)))
 			{
-				WLog_ERR(TAG,
-				         "ORDER_TYPE_STREAM_BITMAP_FIRST - update_read_stream_bitmap_first_order() failed");
+				WLog_ERR(TAG, "%s - update_read_stream_bitmap_first_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3880,8 +3874,7 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 		case ORDER_TYPE_STREAM_BITMAP_NEXT:
 			if (!update_read_stream_bitmap_next_order(s, &(altsec->stream_bitmap_next)))
 			{
-				WLog_ERR(TAG,
-				         "ORDER_TYPE_STREAM_BITMAP_NEXT - update_read_stream_bitmap_next_order() failed");
+				WLog_ERR(TAG, "%s - update_read_stream_bitmap_next_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3891,8 +3884,7 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 		case ORDER_TYPE_GDIPLUS_FIRST:
 			if (!update_read_draw_gdiplus_first_order(s, &(altsec->draw_gdiplus_first)))
 			{
-				WLog_ERR(TAG,
-				         "ORDER_TYPE_GDIPLUS_FIRST - update_read_draw_gdiplus_first_order() failed");
+				WLog_ERR(TAG, "%s - update_read_draw_gdiplus_first_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3902,8 +3894,7 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 		case ORDER_TYPE_GDIPLUS_NEXT:
 			if (!update_read_draw_gdiplus_next_order(s, &(altsec->draw_gdiplus_next)))
 			{
-				WLog_ERR(TAG,
-				         "ORDER_TYPE_GDIPLUS_NEXT - update_read_draw_gdiplus_next_order() failed");
+				WLog_ERR(TAG, "%s - update_read_draw_gdiplus_next_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3913,8 +3904,7 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 		case ORDER_TYPE_GDIPLUS_END:
 			if (!update_read_draw_gdiplus_end_order(s, &(altsec->draw_gdiplus_end)))
 			{
-				WLog_ERR(TAG,
-				         "ORDER_TYPE_GDIPLUS_END - update_read_draw_gdiplus_end_order() failed");
+				WLog_ERR(TAG, "%s - update_read_draw_gdiplus_end_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3925,8 +3915,7 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			if (!update_read_draw_gdiplus_cache_first_order(s,
 			        &(altsec->draw_gdiplus_cache_first)))
 			{
-				WLog_ERR(TAG,
-				         "ORDER_TYPE_GDIPLUS_CACHE_FIRST - update_read_draw_gdiplus_cache_first_order() failed");
+				WLog_ERR(TAG, "%s - update_read_draw_gdiplus_cache_first_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3938,8 +3927,7 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			if (!update_read_draw_gdiplus_cache_next_order(s,
 			        &(altsec->draw_gdiplus_cache_next)))
 			{
-				WLog_ERR(TAG,
-				         "ORDER_TYPE_GDIPLUS_CACHE_NEXT - update_read_draw_gdiplus_cache_next_order() failed");
+				WLog_ERR(TAG, "%s - update_read_draw_gdiplus_cache_next_order() failed", orderName);
 				return FALSE;
 			}
 
@@ -3951,8 +3939,7 @@ static BOOL update_recv_altsec_order(rdpUpdate* update, wStream* s,
 			if (!update_read_draw_gdiplus_cache_end_order(s,
 			        &(altsec->draw_gdiplus_cache_end)))
 			{
-				WLog_ERR(TAG,
-				         "ORDER_TYPE_GDIPLUS_CACHE_END - update_read_draw_gdiplus_cache_end_order() failed");
+				WLog_ERR(TAG, "%s - update_read_draw_gdiplus_cache_end_order() failed", orderName);
 				return FALSE;
 			}
 

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -337,6 +337,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	settings->FIPSMode = FALSE;
 	settings->CompressionEnabled = TRUE;
 	settings->LogonNotify = TRUE;
+	settings->BrushSupportLevel = BRUSH_COLOR_FULL;
 
 	if (settings->ServerMode)
 		settings->CompressionLevel = PACKET_COMPR_TYPE_RDP61;

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -390,9 +390,9 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	settings->OrderSupport[NEG_SCRBLT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_OPAQUE_RECT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_DRAWNINEGRID_INDEX] = TRUE;
-	settings->OrderSupport[NEG_MULTIDSTBLT_INDEX] = TRUE;
-	settings->OrderSupport[NEG_MULTIPATBLT_INDEX] = TRUE;
-	settings->OrderSupport[NEG_MULTISCRBLT_INDEX] = TRUE;
+	settings->OrderSupport[NEG_MULTIDSTBLT_INDEX] = FALSE;
+	settings->OrderSupport[NEG_MULTIPATBLT_INDEX] = FALSE;
+	settings->OrderSupport[NEG_MULTISCRBLT_INDEX] = FALSE;
 	settings->OrderSupport[NEG_MULTIOPAQUERECT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_MULTI_DRAWNINEGRID_INDEX] = FALSE;
 	settings->OrderSupport[NEG_LINETO_INDEX] = TRUE;

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -394,19 +394,19 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	settings->OrderSupport[NEG_MULTIPATBLT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_MULTISCRBLT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_MULTIOPAQUERECT_INDEX] = TRUE;
-	settings->OrderSupport[NEG_MULTI_DRAWNINEGRID_INDEX] = TRUE;
+	settings->OrderSupport[NEG_MULTI_DRAWNINEGRID_INDEX] = FALSE;
 	settings->OrderSupport[NEG_LINETO_INDEX] = TRUE;
 	settings->OrderSupport[NEG_POLYLINE_INDEX] = TRUE;
 	settings->OrderSupport[NEG_MEMBLT_INDEX] = TRUE;
 	settings->OrderSupport[NEG_MEM3BLT_INDEX] = TRUE;
-	settings->OrderSupport[NEG_SAVEBITMAP_INDEX] = TRUE;
-	settings->OrderSupport[NEG_GLYPH_INDEX_INDEX] = TRUE;
-	settings->OrderSupport[NEG_FAST_INDEX_INDEX] = TRUE;
-	settings->OrderSupport[NEG_FAST_GLYPH_INDEX] = TRUE;
-	settings->OrderSupport[NEG_POLYGON_SC_INDEX] = TRUE;
-	settings->OrderSupport[NEG_POLYGON_CB_INDEX] = TRUE;
-	settings->OrderSupport[NEG_ELLIPSE_SC_INDEX] = TRUE;
-	settings->OrderSupport[NEG_ELLIPSE_CB_INDEX] = TRUE;
+	settings->OrderSupport[NEG_SAVEBITMAP_INDEX] = FALSE;
+	settings->OrderSupport[NEG_GLYPH_INDEX_INDEX] = FALSE;
+	settings->OrderSupport[NEG_FAST_INDEX_INDEX] = FALSE;
+	settings->OrderSupport[NEG_FAST_GLYPH_INDEX] = FALSE;
+	settings->OrderSupport[NEG_POLYGON_SC_INDEX] = FALSE;
+	settings->OrderSupport[NEG_POLYGON_CB_INDEX] = FALSE;
+	settings->OrderSupport[NEG_ELLIPSE_SC_INDEX] = FALSE;
+	settings->OrderSupport[NEG_ELLIPSE_CB_INDEX] = FALSE;
 	settings->ClientProductId = calloc(1, 32);
 
 	if (!settings->ClientProductId)

--- a/libfreerdp/core/window.c
+++ b/libfreerdp/core/window.c
@@ -33,7 +33,7 @@
 BOOL rail_read_unicode_string(wStream* s, RAIL_UNICODE_STRING* unicode_string)
 {
 	UINT16 new_len;
-	BYTE *new_str;
+	BYTE* new_str;
 
 	if (Stream_GetRemainingLength(s) < 2)
 		return FALSE;
@@ -52,9 +52,10 @@ BOOL rail_read_unicode_string(wStream* s, RAIL_UNICODE_STRING* unicode_string)
 	}
 
 	new_str = (BYTE*) realloc(unicode_string->string, new_len);
+
 	if (!new_str)
 	{
-		free (unicode_string->string);
+		free(unicode_string->string);
 		unicode_string->string = NULL;
 		return FALSE;
 	}
@@ -62,7 +63,6 @@ BOOL rail_read_unicode_string(wStream* s, RAIL_UNICODE_STRING* unicode_string)
 	unicode_string->string = new_str;
 	unicode_string->length = new_len;
 	Stream_Read(s, unicode_string->string, unicode_string->length);
-
 	return TRUE;
 }
 
@@ -110,14 +110,15 @@ BOOL update_read_icon_info(wStream* s, ICON_INFO* iconInfo)
 
 	/* bitsMask */
 	newBitMask = (BYTE*) realloc(iconInfo->bitsMask, iconInfo->cbBitsMask);
+
 	if (!newBitMask)
 	{
-		free (iconInfo->bitsMask);
+		free(iconInfo->bitsMask);
 		iconInfo->bitsMask = NULL;
 		return FALSE;
 	}
-	iconInfo->bitsMask = newBitMask;
 
+	iconInfo->bitsMask = newBitMask;
 	Stream_Read(s, iconInfo->bitsMask, iconInfo->cbBitsMask);
 
 	/* colorTable */
@@ -126,21 +127,23 @@ BOOL update_read_icon_info(wStream* s, ICON_INFO* iconInfo)
 		if (iconInfo->cbColorTable)
 		{
 			iconInfo->colorTable = (BYTE*) malloc(iconInfo->cbColorTable);
+
 			if (!iconInfo->colorTable)
 				return FALSE;
 		}
 	}
 	else if (iconInfo->cbColorTable)
 	{
-		BYTE *new_tab;
-
+		BYTE* new_tab;
 		new_tab = (BYTE*) realloc(iconInfo->colorTable, iconInfo->cbColorTable);
+
 		if (!new_tab)
 		{
-			free (iconInfo->colorTable);
+			free(iconInfo->colorTable);
 			iconInfo->colorTable = NULL;
 			return FALSE;
 		}
+
 		iconInfo->colorTable = new_tab;
 	}
 	else
@@ -153,17 +156,17 @@ BOOL update_read_icon_info(wStream* s, ICON_INFO* iconInfo)
 		Stream_Read(s, iconInfo->colorTable, iconInfo->cbColorTable);
 
 	/* bitsColor */
-	newBitMask = (BYTE *)realloc(iconInfo->bitsColor, iconInfo->cbBitsColor);
+	newBitMask = (BYTE*)realloc(iconInfo->bitsColor, iconInfo->cbBitsColor);
+
 	if (!newBitMask)
 	{
-		free (iconInfo->bitsColor);
+		free(iconInfo->bitsColor);
 		iconInfo->bitsColor = NULL;
 		return FALSE;
 	}
+
 	iconInfo->bitsColor = newBitMask;
-
 	Stream_Read(s, iconInfo->bitsColor, iconInfo->cbBitsColor);
-
 	return TRUE;
 }
 
@@ -174,7 +177,6 @@ BOOL update_read_cached_icon_info(wStream* s, CACHED_ICON_INFO* cachedIconInfo)
 
 	Stream_Read_UINT16(s, cachedIconInfo->cacheEntry); /* cacheEntry (2 bytes) */
 	Stream_Read_UINT8(s, cachedIconInfo->cacheId); /* cacheId (1 byte) */
-
 	return TRUE;
 }
 
@@ -185,12 +187,12 @@ BOOL update_read_notify_icon_infotip(wStream* s, NOTIFY_ICON_INFOTIP* notifyIcon
 
 	Stream_Read_UINT32(s, notifyIconInfoTip->timeout); /* timeout (4 bytes) */
 	Stream_Read_UINT32(s, notifyIconInfoTip->flags); /* infoFlags (4 bytes) */
-
 	return rail_read_unicode_string(s, &notifyIconInfoTip->text) && /* infoTipText */
-			rail_read_unicode_string(s, &notifyIconInfoTip->title); /* title */
+	       rail_read_unicode_string(s, &notifyIconInfoTip->title); /* title */
 }
 
-BOOL update_read_window_state_order(wStream* s, WINDOW_ORDER_INFO* orderInfo, WINDOW_STATE_ORDER* windowState)
+BOOL update_read_window_state_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
+                                    WINDOW_STATE_ORDER* windowState)
 {
 	int i;
 	int size;
@@ -295,18 +297,21 @@ BOOL update_read_window_state_order(wStream* s, WINDOW_ORDER_INFO* orderInfo, WI
 
 		Stream_Read_UINT16(s, windowState->numWindowRects); /* numWindowRects (2 bytes) */
 
-		if (windowState->numWindowRects == 0) {
+		if (windowState->numWindowRects == 0)
+		{
 			return TRUE;
 		}
 
 		size = sizeof(RECTANGLE_16) * windowState->numWindowRects;
 		newRect = (RECTANGLE_16*)realloc(windowState->windowRects, size);
+
 		if (!newRect)
 		{
 			free(windowState->windowRects);
 			windowState->windowRects = NULL;
 			return FALSE;
 		}
+
 		windowState->windowRects = newRect;
 
 		if (Stream_GetRemainingLength(s) < 8 * windowState->numWindowRects)
@@ -338,17 +343,21 @@ BOOL update_read_window_state_order(wStream* s, WINDOW_ORDER_INFO* orderInfo, WI
 
 		Stream_Read_UINT16(s, windowState->numVisibilityRects); /* numVisibilityRects (2 bytes) */
 
-		if (windowState->numVisibilityRects == 0) {
+		if (windowState->numVisibilityRects == 0)
+		{
 			return TRUE;
 		}
+
 		size = sizeof(RECTANGLE_16) * windowState->numVisibilityRects;
 		newRect = (RECTANGLE_16*)realloc(windowState->visibilityRects, size);
+
 		if (!newRect)
 		{
 			free(windowState->visibilityRects);
 			windowState->visibilityRects = NULL;
 			return FALSE;
 		}
+
 		windowState->visibilityRects = newRect;
 
 		if (Stream_GetRemainingLength(s) < windowState->numVisibilityRects * 8)
@@ -363,22 +372,27 @@ BOOL update_read_window_state_order(wStream* s, WINDOW_ORDER_INFO* orderInfo, WI
 			Stream_Read_UINT16(s, windowState->visibilityRects[i].bottom); /* bottom (2 bytes) */
 		}
 	}
+
 	return TRUE;
 }
 
-BOOL update_read_window_icon_order(wStream* s, WINDOW_ORDER_INFO* orderInfo, WINDOW_ICON_ORDER* window_icon)
+BOOL update_read_window_icon_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
+                                   WINDOW_ICON_ORDER* window_icon)
 {
 	update_free_window_icon_info(window_icon->iconInfo);
 	window_icon->iconInfo = (ICON_INFO*) calloc(1, sizeof(ICON_INFO));
+
 	if (!window_icon->iconInfo)
 		return FALSE;
 
 	return update_read_icon_info(s, window_icon->iconInfo); /* iconInfo (ICON_INFO) */
 }
 
-BOOL update_read_window_cached_icon_order(wStream* s, WINDOW_ORDER_INFO* orderInfo, WINDOW_CACHED_ICON_ORDER* window_cached_icon)
+BOOL update_read_window_cached_icon_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
+        WINDOW_CACHED_ICON_ORDER* window_cached_icon)
 {
-	return update_read_cached_icon_info(s, &window_cached_icon->cachedIcon); /* cachedIcon (CACHED_ICON_INFO) */
+	return update_read_cached_icon_info(s,
+	                                    &window_cached_icon->cachedIcon); /* cachedIcon (CACHED_ICON_INFO) */
 }
 
 void update_read_window_delete_order(wStream* s, WINDOW_ORDER_INFO* orderInfo)
@@ -401,6 +415,7 @@ BOOL update_recv_window_info_order(rdpUpdate* update, wStream* s, WINDOW_ORDER_I
 	{
 		if (!update_read_window_icon_order(s, orderInfo, &window->window_icon))
 			return FALSE;
+
 		WLog_Print(update->log, WLOG_DEBUG, "WindowIcon");
 		IFCALLRET(window->WindowIcon, result, context, orderInfo, &window->window_icon);
 	}
@@ -408,6 +423,7 @@ BOOL update_recv_window_info_order(rdpUpdate* update, wStream* s, WINDOW_ORDER_I
 	{
 		if (!update_read_window_cached_icon_order(s, orderInfo, &window->window_cached_icon))
 			return FALSE;
+
 		WLog_Print(update->log, WLOG_DEBUG, "WindowCachedIcon");
 		IFCALLRET(window->WindowCachedIcon, result, context, orderInfo, &window->window_cached_icon);
 	}
@@ -437,12 +453,14 @@ BOOL update_recv_window_info_order(rdpUpdate* update, wStream* s, WINDOW_ORDER_I
 	return result;
 }
 
-BOOL update_read_notification_icon_state_order(wStream* s, WINDOW_ORDER_INFO* orderInfo, NOTIFY_ICON_STATE_ORDER* notify_icon_state)
+BOOL update_read_notification_icon_state_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
+        NOTIFY_ICON_STATE_ORDER* notify_icon_state)
 {
 	if (orderInfo->fieldFlags & WINDOW_ORDER_FIELD_NOTIFY_VERSION)
 	{
 		if (Stream_GetRemainingLength(s) < 4)
 			return FALSE;
+
 		Stream_Read_UINT32(s, notify_icon_state->version); /* version (4 bytes) */
 	}
 
@@ -454,7 +472,8 @@ BOOL update_read_notification_icon_state_order(wStream* s, WINDOW_ORDER_INFO* or
 
 	if (orderInfo->fieldFlags & WINDOW_ORDER_FIELD_NOTIFY_INFO_TIP)
 	{
-		if (!update_read_notify_icon_infotip(s, &notify_icon_state->infoTip)) /* infoTip (NOTIFY_ICON_INFOTIP) */
+		if (!update_read_notify_icon_infotip(s,
+		                                     &notify_icon_state->infoTip)) /* infoTip (NOTIFY_ICON_INFOTIP) */
 			return FALSE;
 	}
 
@@ -474,7 +493,8 @@ BOOL update_read_notification_icon_state_order(wStream* s, WINDOW_ORDER_INFO* or
 
 	if (orderInfo->fieldFlags & WINDOW_ORDER_CACHED_ICON)
 	{
-		if (!update_read_cached_icon_info(s, &notify_icon_state->cachedIcon)) /* cachedIcon (CACHED_ICON_INFO) */
+		if (!update_read_cached_icon_info(s,
+		                                  &notify_icon_state->cachedIcon)) /* cachedIcon (CACHED_ICON_INFO) */
 			return FALSE;
 	}
 
@@ -486,7 +506,8 @@ void update_read_notification_icon_delete_order(wStream* s, WINDOW_ORDER_INFO* o
 	/* notification icon deletion event */
 }
 
-BOOL update_recv_notification_icon_info_order(rdpUpdate* update, wStream* s, WINDOW_ORDER_INFO* orderInfo)
+BOOL update_recv_notification_icon_info_order(rdpUpdate* update, wStream* s,
+        WINDOW_ORDER_INFO* orderInfo)
 {
 	rdpContext* context = update->context;
 	rdpWindowUpdate* window = update->window;
@@ -524,7 +545,8 @@ BOOL update_recv_notification_icon_info_order(rdpUpdate* update, wStream* s, WIN
 	return result;
 }
 
-BOOL update_read_desktop_actively_monitored_order(wStream* s, WINDOW_ORDER_INFO* orderInfo, MONITORED_DESKTOP_ORDER* monitored_desktop)
+BOOL update_read_desktop_actively_monitored_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
+        MONITORED_DESKTOP_ORDER* monitored_desktop)
 {
 	int i;
 	int size;
@@ -539,7 +561,7 @@ BOOL update_read_desktop_actively_monitored_order(wStream* s, WINDOW_ORDER_INFO*
 
 	if (orderInfo->fieldFlags & WINDOW_ORDER_FIELD_DESKTOP_ZORDER)
 	{
-		UINT32 *newid;
+		UINT32* newid;
 
 		if (Stream_GetRemainingLength(s) < 1)
 			return FALSE;
@@ -549,16 +571,18 @@ BOOL update_read_desktop_actively_monitored_order(wStream* s, WINDOW_ORDER_INFO*
 		if (Stream_GetRemainingLength(s) < 4 * monitored_desktop->numWindowIds)
 			return FALSE;
 
-		if (monitored_desktop->numWindowIds > 0) {
+		if (monitored_desktop->numWindowIds > 0)
+		{
 			size = sizeof(UINT32) * monitored_desktop->numWindowIds;
-
 			newid = (UINT32*)realloc(monitored_desktop->windowIds, size);
+
 			if (!newid)
 			{
 				free(monitored_desktop->windowIds);
 				monitored_desktop->windowIds = NULL;
 				return FALSE;
 			}
+
 			monitored_desktop->windowIds = newid;
 
 			/* windowIds */
@@ -593,6 +617,7 @@ BOOL update_recv_desktop_info_order(rdpUpdate* update, wStream* s, WINDOW_ORDER_
 	{
 		if (!update_read_desktop_actively_monitored_order(s, orderInfo, &window->monitored_desktop))
 			return FALSE;
+
 		WLog_Print(update->log, WLOG_DEBUG, "ActivelyMonitoredDesktop");
 		IFCALLRET(window->MonitoredDesktop, result, context, orderInfo, &window->monitored_desktop);
 	}
@@ -602,39 +627,44 @@ BOOL update_recv_desktop_info_order(rdpUpdate* update, wStream* s, WINDOW_ORDER_
 
 void update_free_window_icon_info(ICON_INFO* iconInfo)
 {
-    if (!iconInfo)
-        return;
+	if (!iconInfo)
+		return;
 
-    free(iconInfo->bitsColor);
-    iconInfo->bitsColor = NULL;
-
-    free(iconInfo->bitsMask);
-    iconInfo->bitsMask = NULL;
-
-    free(iconInfo->colorTable);
-    iconInfo->colorTable = NULL;
-
+	free(iconInfo->bitsColor);
+	iconInfo->bitsColor = NULL;
+	free(iconInfo->bitsMask);
+	iconInfo->bitsMask = NULL;
+	free(iconInfo->colorTable);
+	iconInfo->colorTable = NULL;
 	free(iconInfo);
 }
 
 BOOL update_recv_altsec_window_order(rdpUpdate* update, wStream* s)
 {
+	BOOL rc = TRUE;
 	UINT16 orderSize;
 	rdpWindowUpdate* window = update->window;
 
 	if (Stream_GetRemainingLength(s) < 6)
+	{
+		WLog_Print(update->log, WLOG_ERROR, "Stream short");
 		return FALSE;
+	}
 
 	Stream_Read_UINT16(s, orderSize); /* orderSize (2 bytes) */
 	Stream_Read_UINT32(s, window->orderInfo.fieldFlags); /* FieldsPresentFlags (4 bytes) */
 
 	if (window->orderInfo.fieldFlags & WINDOW_ORDER_TYPE_WINDOW)
-		return update_recv_window_info_order(update, s, &window->orderInfo);
+		rc = update_recv_window_info_order(update, s, &window->orderInfo);
 	else if (window->orderInfo.fieldFlags & WINDOW_ORDER_TYPE_NOTIFY)
-		return update_recv_notification_icon_info_order(update, s, &window->orderInfo);
+		rc = update_recv_notification_icon_info_order(update, s, &window->orderInfo);
 	else if (window->orderInfo.fieldFlags & WINDOW_ORDER_TYPE_DESKTOP)
-		return update_recv_desktop_info_order(update, s, &window->orderInfo);
+		rc = update_recv_desktop_info_order(update, s, &window->orderInfo);
 
-	return TRUE;
+	if (!rc)
+		WLog_Print(update->log, WLOG_ERROR, "windoworder flags %08"PRIx32" failed",
+		           window->orderInfo.fieldFlags);
+
+	return rc;
 }
 

--- a/libfreerdp/gdi/bitmap.c
+++ b/libfreerdp/gdi/bitmap.c
@@ -56,7 +56,7 @@ INLINE UINT32 gdi_GetPixel(HGDI_DC hdc, UINT32 nXPos, UINT32 nYPos)
 {
 	HGDI_BITMAP hBmp = (HGDI_BITMAP) hdc->selectedObject;
 	BYTE* data = &(hBmp->data[(nYPos * hBmp->scanline) + nXPos * GetBytesPerPixel(
-	                              hBmp->format)]);
+	                                                       hBmp->format)]);
 	return ReadColor(data, hBmp->format);
 }
 
@@ -80,7 +80,7 @@ static INLINE UINT32 gdi_SetPixelBmp(HGDI_BITMAP hBmp, UINT32 X, UINT32 Y,
                                      UINT32 crColor)
 {
 	BYTE* p = &hBmp->data[(Y * hBmp->scanline) + X * GetBytesPerPixel(
-	                          hBmp->format)];
+	                                               hBmp->format)];
 	WriteColor(p, hBmp->format, crColor);
 	return crColor;
 }
@@ -480,8 +480,14 @@ BOOL gdi_BitBlt(HGDI_DC hdcDest, UINT32 nXDest, UINT32 nYDest,
 	switch (rop)
 	{
 		case GDI_SRCCOPY:
+			if (!hdcSrc)
+				return FALSE;
+
 			hSrcBmp = (HGDI_BITMAP) hdcSrc->selectedObject;
 			hDstBmp = (HGDI_BITMAP) hdcDest->selectedObject;
+
+			if (!hSrcBmp || !hDstBmp)
+				return FALSE;
 
 			if (!freerdp_image_copy(hDstBmp->data, hDstBmp->format, hDstBmp->scanline,
 			                        nXDest, nYDest, nWidth, nHeight,
@@ -493,6 +499,9 @@ BOOL gdi_BitBlt(HGDI_DC hdcDest, UINT32 nXDest, UINT32 nYDest,
 		case GDI_DSTCOPY:
 			hSrcBmp = (HGDI_BITMAP) hdcDest->selectedObject;
 			hDstBmp = (HGDI_BITMAP) hdcDest->selectedObject;
+
+			if (!hSrcBmp || !hDstBmp)
+				return FALSE;
 
 			if (!freerdp_image_copy(hDstBmp->data, hDstBmp->format, hDstBmp->scanline,
 			                        nXDest, nYDest, nWidth, nHeight,

--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -574,7 +574,7 @@ static BOOL gdi_dstblt(rdpContext* context, const DSTBLT_ORDER* dstblt)
 	                  gdi_rop3_code(dstblt->bRop), &gdi->palette);
 }
 
-static BOOL gdi_patblt(rdpContext* context, PATBLT_ORDER* patblt)
+static BOOL gdi_patblt(rdpContext* context, const PATBLT_ORDER* patblt)
 {
 	const rdpBrush* brush = &patblt->brush;
 	UINT32 foreColor;

--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -663,9 +663,7 @@ static BOOL gdi_patblt(rdpContext* context, PATBLT_ORDER* patblt)
 			break;
 	}
 
-	if (!hbrush)
-		gdi_DeleteObject((HGDIOBJECT) hBmp);
-	else
+	if (hbrush)
 	{
 		hbrush->nXOrg = brush->x;
 		hbrush->nYOrg = brush->y;
@@ -676,6 +674,7 @@ static BOOL gdi_patblt(rdpContext* context, PATBLT_ORDER* patblt)
 	}
 
 out_error:
+	gdi_DeleteObject((HGDIOBJECT) hBmp);
 	gdi_DeleteObject((HGDIOBJECT) hbrush);
 	gdi->drawing->hdc->brush = originalBrush;
 	gdi_SetTextColor(gdi->drawing->hdc, originalColor);
@@ -933,6 +932,7 @@ static BOOL gdi_mem3blt(rdpContext* context, MEM3BLT_ORDER* mem3blt)
 				                 mem3blt->nXSrc, mem3blt->nYSrc, gdi_rop3_code(mem3blt->bRop),
 				                 &gdi->palette);
 				gdi_DeleteObject((HGDIOBJECT) gdi->drawing->hdc->brush);
+				gdi_DeleteObject((HGDIOBJECT) hBmp);
 				gdi->drawing->hdc->brush = originalBrush;
 			}
 			break;

--- a/libfreerdp/gdi/graphics.c
+++ b/libfreerdp/gdi/graphics.c
@@ -112,10 +112,11 @@ static void gdi_Bitmap_Free(rdpContext* context, rdpBitmap* bitmap)
 
 	if (gdi_bitmap)
 	{
-		gdi_SelectObject(gdi_bitmap->hdc, (HGDIOBJECT) gdi_bitmap->org_bitmap);
+		if (gdi_bitmap->hdc)
+			gdi_SelectObject(gdi_bitmap->hdc, (HGDIOBJECT) gdi_bitmap->org_bitmap);
+
 		gdi_DeleteObject((HGDIOBJECT) gdi_bitmap->bitmap);
 		gdi_DeleteDC(gdi_bitmap->hdc);
-
 		_aligned_free(bitmap->data);
 	}
 
@@ -193,6 +194,7 @@ static BOOL gdi_Bitmap_SetSurface(rdpContext* context, rdpBitmap* bitmap,
 		return FALSE;
 
 	gdi = context->gdi;
+
 	if (!gdi)
 		return FALSE;
 

--- a/libfreerdp/gdi/graphics.c
+++ b/libfreerdp/gdi/graphics.c
@@ -176,6 +176,9 @@ static BOOL gdi_Bitmap_Decompress(rdpContext* context, rdpBitmap* bitmap,
 	{
 		SrcFormat = gdi_get_pixel_format(bpp);
 
+		if (SrcSize < bitmap->length)
+			return FALSE;
+
 		if (!freerdp_image_copy(bitmap->data, bitmap->format, 0, 0, 0,
 		                        DstWidth, DstHeight, pSrcData, SrcFormat,
 		                        0, 0, 0, &gdi->palette, FREERDP_FLIP_VERTICAL))

--- a/libfreerdp/gdi/graphics.c
+++ b/libfreerdp/gdi/graphics.c
@@ -140,7 +140,6 @@ static BOOL gdi_Bitmap_Decompress(rdpContext* context, rdpBitmap* bitmap,
                                   UINT32 codecId)
 {
 	UINT32 SrcSize = length;
-	UINT32 SrcFormat;
 	rdpGdi* gdi = context->gdi;
 	bitmap->compressed = FALSE;
 	bitmap->format = gdi->dstFormat;
@@ -174,9 +173,12 @@ static BOOL gdi_Bitmap_Decompress(rdpContext* context, rdpBitmap* bitmap,
 	}
 	else
 	{
-		SrcFormat = gdi_get_pixel_format(bpp);
+		const UINT32 SrcFormat = gdi_get_pixel_format(bpp);
+		const size_t sbpp = GetBytesPerPixel(SrcFormat);
+		const size_t dbpp = GetBytesPerPixel(bitmap->format);
+		const size_t dstSize = SrcSize * dbpp / sbpp;
 
-		if (SrcSize < bitmap->length)
+		if (dstSize  < bitmap->length)
 			return FALSE;
 
 		if (!freerdp_image_copy(bitmap->data, bitmap->format, 0, 0, 0,

--- a/libfreerdp/gdi/graphics.c
+++ b/libfreerdp/gdi/graphics.c
@@ -176,10 +176,16 @@ static BOOL gdi_Bitmap_Decompress(rdpContext* context, rdpBitmap* bitmap,
 		const UINT32 SrcFormat = gdi_get_pixel_format(bpp);
 		const size_t sbpp = GetBytesPerPixel(SrcFormat);
 		const size_t dbpp = GetBytesPerPixel(bitmap->format);
-		const size_t dstSize = SrcSize * dbpp / sbpp;
 
-		if (dstSize  < bitmap->length)
+		if ((sbpp == 0) || (dbpp == 0))
 			return FALSE;
+		else
+		{
+			const size_t dstSize = SrcSize * dbpp / sbpp;
+
+			if (dstSize  < bitmap->length)
+				return FALSE;
+		}
 
 		if (!freerdp_image_copy(bitmap->data, bitmap->format, 0, 0, 0,
 		                        DstWidth, DstHeight, pSrcData, SrcFormat,


### PR DESCRIPTION
Related to fixing #4925 

* Adds checks to only allow orders that have been activated by client and server during capability exchange
* Various crash fixes found during fuzzing run
* Coordinate adjustments for orders, cut invalid ones before passing them on
* Split order handling in `support check`, `decoding` and `processing`

