### PR TITLE
winpr: add some functions to use wStream in a static way

### DIFF
--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -43,6 +43,8 @@ struct _wStream
 
 	DWORD count;
 	wStreamPool* pool;
+	BOOL isAllocatedStream;
+	BOOL isOwner;
 };
 typedef struct _wStream wStream;
 
@@ -50,6 +52,7 @@ WINPR_API BOOL Stream_EnsureCapacity(wStream* s, size_t size);
 WINPR_API BOOL Stream_EnsureRemainingCapacity(wStream* s, size_t size);
 
 WINPR_API wStream* Stream_New(BYTE* buffer, size_t size);
+WINPR_API void Stream_StaticInit(wStream *s, BYTE *buffer, size_t size);
 WINPR_API void Stream_Free(wStream* s, BOOL bFreeBuffer);
 
 static INLINE void Stream_Seek(wStream* s, size_t _offset)


### PR DESCRIPTION
It's sometime useful to create a stream aliasing a buffer on the stack, and
it's nice if we don't need some extra malloc for this.

Example use:
```c
   BYTE buffer[20];
   wStream s;

   Stream_WrapBuffer(&s, buffer, sizeof(buffer));
   Stream_Write_UINT16(&s, 0xff01);
   Stream_Free(&s, FALSE);
```