### PR TITLE
transferEncoding can be NULL, correct if happens in line 348

### DIFF
--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -326,7 +326,7 @@ static wStream* rdg_build_http_request(rdpRdg* rdg, const char* method,
 	HttpRequest* request = NULL;
 	const char* uri;
 
-	if (!rdg || !method || !transferEncoding)
+	if (!rdg || !method )
 		return NULL;
 
 	uri = http_context_get_uri(rdg->http);


### PR DESCRIPTION
I am trying to use freerdp to connect to a remote app over a remote gateway which doesn't work yet. While debugging i found a false check on transferEncoding being NULL in the method rdg_build_http_request. The right IF happens a bit further in the method in line 348 and is working fine. 