### PR TITLE
added missing check for remote app where no floatbar exists

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1572,7 +1572,7 @@ static DWORD WINAPI xf_client_thread(LPVOID param)
 			nCount += tmp;
 		}
 
-		if (xfc->floatbar && xfc->fullscreen)
+		if (xfc->floatbar && xfc->fullscreen && !xfc->remote_app)
 			xf_floatbar_hide_and_show(xfc);
 
 		waitStatus = WaitForMultipleObjects(nCount, handles, FALSE, INFINITE);


### PR DESCRIPTION
Found a missing check for a floatbar method which caused the method xf_floatbar_hide_and_show to be called although there was no floatbar created as the context was running in remote app mode. This happens when xfreerdp is started with a rdp file. 