### PR TITLE
Fixed http gateway body length read.

### DIFF
--- a/libfreerdp/core/gateway/http.c
+++ b/libfreerdp/core/gateway/http.c
@@ -747,7 +747,7 @@ HttpResponse* http_response_recv(rdpTls* tls)
 		size_t s;
 		char* end;
 		/* Read until we encounter \r\n\r\n */
-		int status = BIO_read(tls->bio, Stream_Pointer(response->data), 4);
+		int status = BIO_read(tls->bio, Stream_Pointer(response->data), 1);
 
 		if (status <= 0)
 		{

--- a/libfreerdp/core/gateway/http.c
+++ b/libfreerdp/core/gateway/http.c
@@ -842,15 +842,15 @@ HttpResponse* http_response_recv(rdpTls* tls)
 		}
 
 		if (response->BodyLength > 0)
-		{
 			response->BodyContent = &(Stream_Buffer(response->data))[payloadOffset];
-			response->BodyLength = bodyLength;
-		}
 
 		if (bodyLength != response->BodyLength)
 		{
 			WLog_WARN(TAG, "http_response_recv: %s unexpected body length: actual: %d, expected: %d",
-			          response->ContentType, bodyLength, response->BodyLength);
+			          response->ContentType, response->BodyLength, bodyLength);
+
+			if (bodyLength > 0)
+				response->BodyLength = MIN(bodyLength, response->BodyLength);
 		}
 	}
 


### PR DESCRIPTION
@mmattes looks like I've found it, `bodyLength` is usually `0` in the responses, then use the length actually read.