### PR TITLE
fix [x11]: compiler warnings in floatbar

### DIFF
--- a/client/X11/xf_floatbar.c
+++ b/client/X11/xf_floatbar.c
@@ -527,11 +527,11 @@ static void xf_floatbar_event_motionnotify(xfContext* xfc, XEvent* event)
 	floatbar = xfc->window->floatbar;
 	cursor = XCreateFontCursor(xfc->display, XC_arrow);
 
-	if (event->xmotion.state && Button1Mask && mode > XF_FLOATBAR_MODE_DRAGGING)
+	if ((event->xmotion.state & Button1Mask) && (mode > XF_FLOATBAR_MODE_DRAGGING))
 	{
 		xf_floatbar_resize(xfc, event);
 	}
-	else if (event->xmotion.state && Button1Mask && mode == XF_FLOATBAR_MODE_DRAGGING)
+	else if ((event->xmotion.state & Button1Mask) && (mode == XF_FLOATBAR_MODE_DRAGGING))
 	{
 		xf_floatbar_dragging(xfc, event);
 	}


### PR DESCRIPTION
client/X11/xf_floatbar.c:530:27: warning: use of logical '&&' with constant
      operand [-Wconstant-logical-operand]
        if (event->xmotion.state && Button1Mask && mode > XF_FLOATBAR_MODE_DRAGGING)
                                 ^  ~~~~~~~~~~~
client/X11/xf_floatbar.c:534:32: warning: use of logical '&&' with constant
      operand [-Wconstant-logical-operand]
        else if (event->xmotion.state && Button1Mask && mode == XF_FLOATBAR_MODE_DRAGGING)
                                      ^  ~~~~~~~~~~~
clang 8.0.0-svn344413-1~exp1+0~20181012203207.819~1.gbpc91f27
