### PR TITLE
fix issue with fnObjectFree and related casts

### DIFF
--- a/channels/drive/client/drive_main.c
+++ b/channels/drive/client/drive_main.c
@@ -865,6 +865,14 @@ static UINT drive_free(DEVICE* device)
 }
 
 /**
+ * Helper function used for freeing list dictionary value object
+ */
+static void drive_file_objfree(void* obj)
+{
+	drive_file_free((DRIVE_FILE*) obj);
+}
+
+/**
  * Function description
  *
  * @return 0 on success, otherwise a Win32 error code
@@ -925,7 +933,7 @@ static UINT drive_register_drive_path(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints,
 			goto out_error;
 		}
 
-		ListDictionary_ValueObject(drive->files)->fnObjectFree = (OBJECT_FREE_FN) drive_file_free;
+		ListDictionary_ValueObject(drive->files)->fnObjectFree = drive_file_objfree;
 		drive->IrpQueue = MessageQueue_New(NULL);
 
 		if (!drive->IrpQueue)

--- a/channels/rdpdr/client/devman.c
+++ b/channels/rdpdr/client/devman.c
@@ -41,8 +41,10 @@
 
 #include "devman.h"
 
-void devman_device_free(DEVICE* device)
+static void devman_device_free(void* obj)
 {
+	DEVICE* device = (DEVICE*) obj;
+
 	if (!device)
 		return;
 
@@ -75,8 +77,7 @@ DEVMAN* devman_new(rdpdrPlugin* rdpdr)
 		return NULL;
 	}
 
-	ListDictionary_ValueObject(devman->devices)->fnObjectFree =
-			(OBJECT_FREE_FN) devman_device_free;
+	ListDictionary_ValueObject(devman->devices)->fnObjectFree = devman_device_free;
 
 	return devman;
 }

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -145,8 +145,9 @@ static void rfx_profiler_print(RFX_CONTEXT* context)
 	PROFILER_PRINT_FOOTER
 }
 
-static void rfx_tile_init(RFX_TILE* tile)
+static void rfx_tile_init(void* obj)
 {
+	RFX_TILE* tile = (RFX_TILE*)obj;
 	if (tile)
 	{
 		tile->x = 0;
@@ -160,9 +161,10 @@ static void rfx_tile_init(RFX_TILE* tile)
 	}
 }
 
-static RFX_TILE* rfx_decoder_tile_new(void)
+static void* rfx_decoder_tile_new(void* val)
 {
 	RFX_TILE* tile = NULL;
+	WINPR_UNUSED(val);
 
 	if (!(tile = (RFX_TILE*) calloc(1, sizeof(RFX_TILE))))
 		return NULL;
@@ -177,8 +179,10 @@ static RFX_TILE* rfx_decoder_tile_new(void)
 	return tile;
 }
 
-static void rfx_decoder_tile_free(RFX_TILE* tile)
+static void rfx_decoder_tile_free(void* obj)
 {
+	RFX_TILE* tile = (RFX_TILE*)obj;
+
 	if (tile)
 	{
 		if (tile->allocated)
@@ -188,14 +192,15 @@ static void rfx_decoder_tile_free(RFX_TILE* tile)
 	}
 }
 
-static RFX_TILE* rfx_encoder_tile_new(void)
+static void* rfx_encoder_tile_new(void* val)
 {
-	return (RFX_TILE*)calloc(1, sizeof(RFX_TILE));
+	WINPR_UNUSED(val);
+	return calloc(1, sizeof(RFX_TILE));
 }
 
-static void rfx_encoder_tile_free(RFX_TILE* tile)
+static void rfx_encoder_tile_free(void* obj)
 {
-	free(tile);
+	free(obj);
 }
 
 RFX_CONTEXT* rfx_context_new(BOOL encoder)
@@ -231,17 +236,17 @@ RFX_CONTEXT* rfx_context_new(BOOL encoder)
 		goto error_tilePool;
 
 	pool = ObjectPool_Object(priv->TilePool);
-	pool->fnObjectInit = (OBJECT_INIT_FN) rfx_tile_init;
+	pool->fnObjectInit = rfx_tile_init;
 
 	if (context->encoder)
 	{
-		pool->fnObjectNew = (OBJECT_NEW_FN) rfx_encoder_tile_new;
-		pool->fnObjectFree = (OBJECT_FREE_FN) rfx_encoder_tile_free;
+		pool->fnObjectNew = rfx_encoder_tile_new;
+		pool->fnObjectFree = rfx_encoder_tile_free;
 	}
 	else
 	{
-		pool->fnObjectNew = (OBJECT_NEW_FN) rfx_decoder_tile_new;
-		pool->fnObjectFree = (OBJECT_FREE_FN) rfx_decoder_tile_free;
+		pool->fnObjectNew = rfx_decoder_tile_new;
+		pool->fnObjectFree = rfx_decoder_tile_free;
 	}
 
 	/*

--- a/winpr/include/winpr/collections.h
+++ b/winpr/include/winpr/collections.h
@@ -35,9 +35,7 @@
 extern "C" {
 #endif
 
-/* We don't know if the new function will require an argument.
- * Leave the braces empty, C defines that as variable arguments. */
-typedef void* (*OBJECT_NEW_FN)();
+typedef void* (*OBJECT_NEW_FN)(void* val);
 typedef void (*OBJECT_INIT_FN)(void* obj);
 typedef void (*OBJECT_UNINIT_FN)(void* obj);
 typedef void (*OBJECT_FREE_FN)(void* obj);

--- a/winpr/libwinpr/utils/collections/ObjectPool.c
+++ b/winpr/libwinpr/utils/collections/ObjectPool.c
@@ -51,7 +51,7 @@ void* ObjectPool_Take(wObjectPool* pool)
 	if (!obj)
 	{
 		if (pool->object.fnObjectNew)
-			obj = pool->object.fnObjectNew();
+			obj = pool->object.fnObjectNew(NULL);
 	}
 
 	if (pool->object.fnObjectInit)


### PR DESCRIPTION
- remove unnecessary/dangerous OBJECT_xxx_FN function-style casts
- fix `-Wstrict-prototypes` issue with `OBJECT_NEW_FN` definition
