### PR TITLE
gateway HTTP transport - fixed partial reads

### DIFF
--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -79,10 +79,11 @@ static BOOL rdg_read_all(rdpTls* tls, BYTE* buffer, int size)
 {
 	int status;
 	int readCount = 0;
+	BYTE* pBuffer = buffer;
 
 	while (readCount < size)
 	{
-		status = BIO_read(tls->bio, buffer, size - readCount);
+		status = BIO_read(tls->bio, pBuffer, size - readCount);
 
 		if (status <= 0)
 		{
@@ -93,6 +94,7 @@ static BOOL rdg_read_all(rdpTls* tls, BYTE* buffer, int size)
 		}
 
 		readCount += status;
+		pBuffer += status;
 	}
 
 	return TRUE;


### PR DESCRIPTION
This at least fixed the read of the PKT_TYPE_HANDSHAKE_RESPONSE message in a specific environment of mine.