### PR TITLE
Wave 2 pdu fix

### DIFF
--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -347,11 +347,6 @@ static void rdpsnd_pulse_free(rdpsndDevicePlugin* device)
 
 BOOL rdpsnd_pulse_format_supported(rdpsndDevicePlugin* device, const AUDIO_FORMAT* format)
 {
-	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)device;
-
-	if (!pulse->context)
-		return FALSE;
-
 	switch (format->wFormatTag)
 	{
 		case WAVE_FORMAT_PCM:

--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -50,9 +50,46 @@ struct rdpsnd_pulse_plugin
 	pa_sample_spec sample_spec;
 	pa_stream* stream;
 	UINT32 latency;
+	UINT32 volume;
 };
 
 static BOOL rdpsnd_pulse_format_supported(rdpsndDevicePlugin* device, const AUDIO_FORMAT* format);
+
+static void rdpsnd_pulse_get_sink_info(pa_context* c, const pa_sink_info* i, int eol,
+                                       void* userdata)
+{
+	uint8_t x;
+	UINT16 dwVolumeLeft = ((50 * 0xFFFF) / 100); /* 50% */;
+	UINT16 dwVolumeRight = ((50 * 0xFFFF) / 100); /* 50% */;
+	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*) userdata;
+
+	if (!pulse || !c || !i)
+		return;
+
+	for (x = 0; x < i->volume.channels; x++)
+	{
+		pa_volume_t volume = i->volume.values[x];
+
+		if (volume >= PA_VOLUME_NORM)
+			volume = PA_VOLUME_NORM - 1;
+
+		switch (x)
+		{
+			case 0:
+				dwVolumeLeft = (UINT16)volume;
+				break;
+
+			case 1:
+				dwVolumeRight = (UINT16)volume;
+				break;
+
+			default:
+				break;
+		}
+	}
+
+	pulse->volume = ((UINT32)dwVolumeLeft << 16U) | dwVolumeRight;
+}
 
 static void rdpsnd_pulse_context_state_callback(pa_context* context, void* userdata)
 {
@@ -78,6 +115,7 @@ static void rdpsnd_pulse_context_state_callback(pa_context* context, void* userd
 
 static BOOL rdpsnd_pulse_connect(rdpsndDevicePlugin* device)
 {
+	pa_operation* o;
 	pa_context_state_t state;
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*) device;
 
@@ -111,6 +149,11 @@ static BOOL rdpsnd_pulse_connect(rdpsndDevicePlugin* device)
 
 		pa_threaded_mainloop_wait(pulse->mainloop);
 	}
+
+	o = pa_context_get_sink_info_by_index(pulse->context, 0, rdpsnd_pulse_get_sink_info, pulse);
+
+	if (o)
+		pa_operation_unref(o);
 
 	pa_threaded_mainloop_unlock(pulse->mainloop);
 
@@ -376,6 +419,24 @@ BOOL rdpsnd_pulse_format_supported(rdpsndDevicePlugin* device, const AUDIO_FORMA
 	return FALSE;
 }
 
+static UINT32 rdpsnd_pulse_get_volume(rdpsndDevicePlugin* device)
+{
+	pa_operation* o;
+	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*) device;
+
+	if (!pulse)
+		return 0;
+
+	if (!pulse->context || !pulse->mainloop)
+		return 0;
+
+	pa_threaded_mainloop_lock(pulse->mainloop);
+	o = pa_context_get_sink_info_by_index(pulse->context, 0, rdpsnd_pulse_get_sink_info, pulse);
+	pa_operation_unref(o);
+	pa_threaded_mainloop_unlock(pulse->mainloop);
+	return pulse->volume;
+}
+
 static BOOL rdpsnd_pulse_set_volume(rdpsndDevicePlugin* device, UINT32 value)
 {
 	pa_cvolume cv;
@@ -527,6 +588,7 @@ UINT freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS p
 
 	pulse->device.Open = rdpsnd_pulse_open;
 	pulse->device.FormatSupported = rdpsnd_pulse_format_supported;
+	pulse->device.GetVolume = rdpsnd_pulse_get_volume;
 	pulse->device.SetVolume = rdpsnd_pulse_set_volume;
 	pulse->device.Play = rdpsnd_pulse_play;
 	pulse->device.Start = rdpsnd_pulse_start;

--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -547,7 +547,7 @@ static void rdpsnd_recv_close_pdu(rdpsndPlugin* rdpsnd)
  */
 static UINT rdpsnd_recv_volume_pdu(rdpsndPlugin* rdpsnd, wStream* s)
 {
-	BOOL error;
+	BOOL rc;
 	UINT32 dwVolume;
 
 	if (Stream_GetRemainingLength(s) < 4)
@@ -555,9 +555,9 @@ static UINT rdpsnd_recv_volume_pdu(rdpsndPlugin* rdpsnd, wStream* s)
 
 	Stream_Read_UINT32(s, dwVolume);
 	WLog_Print(rdpsnd->log, WLOG_DEBUG, "Volume: 0x%08"PRIX32"", dwVolume);
-	error = IFCALLRESULT(FALSE, rdpsnd->device->SetVolume, rdpsnd->device, dwVolume);
+	rc = IFCALLRESULT(FALSE, rdpsnd->device->SetVolume, rdpsnd->device, dwVolume);
 
-	if (error)
+	if (!rc)
 	{
 		WLog_ERR(TAG, "error setting volume");
 		return CHANNEL_RC_INITIALIZATION_ERROR;

--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -353,6 +353,9 @@ static BOOL rdpsnd_ensure_device_is_open(rdpsndPlugin* rdpsnd, UINT32 wFormatNo,
 			deviceFormat.cbSize = 0;
 		}
 
+		WLog_Print(rdpsnd->log, WLOG_DEBUG, "Opening device with format %s [backend %s]",
+		           audio_format_get_tag_string(format->wFormatTag),
+		           audio_format_get_tag_string(deviceFormat.wFormatTag));
 		rc = IFCALLRESULT(FALSE, rdpsnd->device->Open, rdpsnd->device, &deviceFormat, rdpsnd->latency);
 
 		if (!rc)
@@ -523,12 +526,14 @@ static UINT rdpsnd_recv_wave2_pdu(rdpsndPlugin* rdpsnd, wStream* s, UINT16 BodyS
 
 static void rdpsnd_recv_close_pdu(rdpsndPlugin* rdpsnd)
 {
-	WLog_Print(rdpsnd->log, WLOG_DEBUG, "Close");
-
 	if (rdpsnd->isOpen)
+	{
+		WLog_Print(rdpsnd->log, WLOG_DEBUG, "Closing device");
 		IFCALL(rdpsnd->device->Close, rdpsnd->device);
-
-	rdpsnd->isOpen = FALSE;
+		rdpsnd->isOpen = FALSE;
+	}
+	else
+		WLog_Print(rdpsnd->log, WLOG_DEBUG, "Device already closed");
 }
 
 /**

--- a/libfreerdp/core/surface.c
+++ b/libfreerdp/core/surface.c
@@ -87,20 +87,17 @@ static BOOL update_recv_surfcmd_bitmap_ex(wStream* s, TS_BITMAP_DATA_EX* bmp)
 
 static BOOL update_recv_surfcmd_surface_bits(rdpUpdate* update, wStream* s)
 {
-	SURFACE_BITS_COMMAND* cmd = calloc(1, sizeof(SURFACE_BITS_COMMAND));
-
-	if (!cmd)
-		return FALSE;
+	SURFACE_BITS_COMMAND cmd = {0};
 
 	if (Stream_GetRemainingLength(s) < 8)
 		goto fail;
 
-	Stream_Read_UINT16(s, cmd->destLeft);
-	Stream_Read_UINT16(s, cmd->destTop);
-	Stream_Read_UINT16(s, cmd->destRight);
-	Stream_Read_UINT16(s, cmd->destBottom);
+	Stream_Read_UINT16(s, cmd.destLeft);
+	Stream_Read_UINT16(s, cmd.destTop);
+	Stream_Read_UINT16(s, cmd.destRight);
+	Stream_Read_UINT16(s, cmd.destBottom);
 
-	if (!update_recv_surfcmd_bitmap_ex(s, &cmd->bmp))
+	if (!update_recv_surfcmd_bitmap_ex(s, &cmd.bmp))
 		goto fail;
 
 	if (!update->SurfaceBits)
@@ -109,9 +106,8 @@ static BOOL update_recv_surfcmd_surface_bits(rdpUpdate* update, wStream* s)
 		goto fail;
 	}
 
-	return update->SurfaceBits(update->context, cmd);
+	return update->SurfaceBits(update->context, &cmd);
 fail:
-	free_surface_bits_command(update->context, cmd);
 	return FALSE;
 }
 


### PR DESCRIPTION
Changes/Fixes:
* Server side stream alignment with `WAV2_PDU`
* Fixes `rdpsnd_recv_volume_pdu` (return value check was broken)
* Client pulse backend now has a `GetVolume` callback
* Unified backend (re)open function