### PR TITLE
channels/client: fix alsa/pulse warning and checks

### DIFF
--- a/channels/rdpsnd/client/alsa/rdpsnd_alsa.c
+++ b/channels/rdpsnd/client/alsa/rdpsnd_alsa.c
@@ -439,8 +439,8 @@ static UINT rdpsnd_alsa_play(rdpsndDevicePlugin* device, const BYTE* data, size_
 		if (status < 0)
 		{
 			WLog_ERR(TAG,  "status: %d\n", status);
-			rdpsnd_alsa_close(alsa);
-			rdpsnd_alsa_open((rdpsndDevicePlugin*) alsa, NULL, alsa->latency);
+			rdpsnd_alsa_close(device);
+			rdpsnd_alsa_open(device, NULL, alsa->latency);
 			break;
 		}
 

--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -483,7 +483,7 @@ static UINT rdpsnd_pulse_play(rdpsndDevicePlugin* device, const BYTE* data, size
 		while ((length = pa_stream_writable_size(pulse->stream)) == 0)
 			pa_threaded_mainloop_wait(pulse->mainloop);
 
-		if (length < 0)
+		if (length == (size_t) -1)
 			break;
 
 		if (length > size)

--- a/channels/tsmf/client/pulse/tsmf_pulse.c
+++ b/channels/tsmf/client/pulse/tsmf_pulse.c
@@ -317,7 +317,7 @@ static BOOL tsmf_pulse_play(ITSMFAudioDevice* audio, const BYTE* data, UINT32 da
 {
 	TSMFPulseAudioDevice* pulse = (TSMFPulseAudioDevice*) audio;
 	const BYTE* src;
-	int len;
+	size_t len;
 	int ret;
 	DEBUG_TSMF("data_size %"PRIu32"", data_size);
 
@@ -334,7 +334,7 @@ static BOOL tsmf_pulse_play(ITSMFAudioDevice* audio, const BYTE* data, UINT32 da
 				pa_threaded_mainloop_wait(pulse->mainloop);
 			}
 
-			if (len < 0)
+			if (len == (size_t) -1)
 				break;
 
 			if (len > data_size)


### PR DESCRIPTION
- `pa_stream_writable_size()` returns `(size_t) -1` on error
- fix missing cast in alsa client sound channel code
