### PR TITLE
Implemented GFX mutex locking and enforce return value checks.

### DIFF
--- a/include/freerdp/client/rdpgfx.h
+++ b/include/freerdp/client/rdpgfx.h
@@ -78,13 +78,14 @@ typedef void* (*pcRdpgfxGetCacheSlotData)(RdpgfxClientContext* context,
 typedef UINT(*pcRdpgfxUpdateSurfaces)(RdpgfxClientContext* context);
 
 typedef UINT(*pcRdpgfxUpdateSurfaceArea)(RdpgfxClientContext* context, UINT16 surfaceId,
-                                         UINT32 nrRects, const RECTANGLE_16* rects);
+        UINT32 nrRects, const RECTANGLE_16* rects);
 
 struct _rdpgfx_client_context
 {
 	void* handle;
 	void* custom;
 
+	/* Implementations require locking */
 	pcRdpgfxResetGraphics ResetGraphics;
 	pcRdpgfxStartFrame StartFrame;
 	pcRdpgfxEndFrame EndFrame;
@@ -108,9 +109,11 @@ struct _rdpgfx_client_context
 	pcRdpgfxSetCacheSlotData SetCacheSlotData;
 	pcRdpgfxGetCacheSlotData GetCacheSlotData;
 
+	/* No locking required */
 	pcRdpgfxUpdateSurfaces UpdateSurfaces;
 	pcRdpgfxUpdateSurfaceArea UpdateSurfaceArea;
 
+	CRITICAL_SECTION mux;
 	PROFILER_DEFINE(SurfaceProfiler)
 };
 

--- a/include/freerdp/gdi/gfx.h
+++ b/include/freerdp/gdi/gfx.h
@@ -27,7 +27,7 @@ struct gdi_gfx_surface
 {
 	UINT16 surfaceId;
 	rdpCodecs* codecs;
-	H264_CONTEXT *h264;
+	H264_CONTEXT* h264;
 	UINT32 width;
 	UINT32 height;
 	BYTE* data;
@@ -55,7 +55,7 @@ typedef struct gdi_gfx_cache_entry gdiGfxCacheEntry;
 extern "C" {
 #endif
 
-FREERDP_API void gdi_graphics_pipeline_init(rdpGdi* gdi, RdpgfxClientContext* gfx);
+FREERDP_API BOOL gdi_graphics_pipeline_init(rdpGdi* gdi, RdpgfxClientContext* gfx);
 FREERDP_API void gdi_graphics_pipeline_uninit(rdpGdi* gdi, RdpgfxClientContext* gfx);
 
 #ifdef __cplusplus


### PR DESCRIPTION
To fix #4825 GFX functions must now aquire a lock before accessing surfaces.
This prevents simultaneous update of internal data by client and gfx threads.
Also enforce return value checks, where not already done.