### PR TITLE
Allow fixed drive redirection (Windows) and fix macos drive duplication.

### DIFF
--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -135,7 +135,7 @@ BOOL check_path(char* path)
 {
 	UINT type = GetDriveTypeA(path);
 
-	if (!(type == DRIVE_REMOVABLE || type == DRIVE_CDROM || type == DRIVE_REMOTE))
+	if (!(type == DRIVE_FIXED ||type == DRIVE_REMOVABLE || type == DRIVE_CDROM || type == DRIVE_REMOTE))
 		return FALSE;
 
 	return GetVolumeInformationA(path, NULL, 0, NULL, NULL, NULL, NULL, 0);
@@ -439,7 +439,7 @@ static UINT handle_hotplug(rdpdrPlugin* rdpdr)
 		if (device_ext->path == NULL)
 			continue;
 
-		if (ConvertFromUnicode(CP_UTF8, 0, device_ext->path, 0, &path, 0, NULL, FALSE) <= 0)
+		if (ConvertFromUnicode(CP_UTF8, 0, device_ext->path, -1, &path, 0, NULL, FALSE) <= 0)
 			continue;
 
 		/* not plugable device */


### PR DESCRIPTION
Allow fixed drive redirection on Windows (a:, c:, ...). 
Prevent redirected drives duplication when a hot pluggable device is added or removed.