### PR TITLE
license: support CAL license

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2679,6 +2679,10 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 
 			settings->DesktopOrientation = val;
 		}
+		CommandLineSwitchCase(arg, "old-license")
+		{
+			settings->OldLicenseBehaviour = TRUE;
+		}
 		CommandLineSwitchCase(arg, "scale")
 		{
 			unsigned long scaleFactor = strtoul(arg->Value, NULL, 0);

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -126,6 +126,7 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "nsc", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "nscodec", "NSCodec support" },
 	{ "offscreen-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "offscreen bitmap cache" },
 	{ "orientation", COMMAND_LINE_VALUE_REQUIRED, "0|90|180|270", NULL, NULL, -1, NULL, "Orientation of display in degrees" },
+	{ "old-license", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Use the old license workflow (no CAL and hwId set to 0)"},
 	{ "p", COMMAND_LINE_VALUE_REQUIRED, "<password>", NULL, NULL, -1, NULL, "Password" },
 	{ "parallel", COMMAND_LINE_VALUE_OPTIONAL, "<name>[,<path>]", NULL, NULL, -1, NULL, "Redirect parallel device" },
 	{ "parent-window", COMMAND_LINE_VALUE_REQUIRED, "<window-id>", NULL, NULL, -1, NULL, "Parent window id" },

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -1156,7 +1156,8 @@ struct rdp_settings
 	ALIGN64 BOOL AuthenticationOnly;   /* 1603 */
 	ALIGN64 BOOL CredentialsFromStdin; /* 1604 */
 	ALIGN64 BOOL UnmapButtons;         /* 1605 */
-	UINT64 padding1664[1664 - 1606];   /* 1606 */
+	ALIGN64 BOOL OldLicenseBehaviour;  /* 1606 */
+	UINT64 padding1664[1664 - 1607];   /* 1607 */
 
 	/* Names */
 	ALIGN64 char* ComputerName; /* 1664 */

--- a/libfreerdp/core/license.h
+++ b/libfreerdp/core/license.h
@@ -196,6 +196,7 @@ struct rdp_license
 	LICENSE_BLOB* PlatformChallenge;
 	LICENSE_BLOB* EncryptedPremasterSecret;
 	LICENSE_BLOB* EncryptedPlatformChallenge;
+	LICENSE_BLOB *EncryptedPlatformChallengeResponse;
 	LICENSE_BLOB* EncryptedHardwareId;
 	SCOPE_LIST* ScopeList;
 	UINT32 PacketHeaderLength;


### PR DESCRIPTION
This patch simplifies the licensing code mutualizing encryption / decryption routines. It also adds the support for client_info packet that allows to send a previously saved CAL file.
