### PR TITLE
Fix Issue #4983 : Increased size of buffer to encrypt hash with kerbe…

### DIFF
--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -1126,9 +1126,7 @@ SECURITY_STATUS nla_encrypt_public_key_hash(rdpNla* nla)
 	SECURITY_STATUS status = SEC_E_INTERNAL_ERROR;
 	WINPR_DIGEST_CTX* sha256 = NULL;
 	const BOOL krb = (_tcsncmp(nla->packageName, KERBEROS_SSP_NAME, ARRAYSIZE(KERBEROS_SSP_NAME)) == 0);
-	const ULONG auth_data_length = krb ? WINPR_SHA256_DIGEST_LENGTH :
-	                               (nla->ContextSizes.cbSecurityTrailer
-	                                + WINPR_SHA256_DIGEST_LENGTH);
+	const ULONG auth_data_length = (nla->ContextSizes.cbSecurityTrailer + WINPR_SHA256_DIGEST_LENGTH);
 	const BYTE* hashMagic = nla->server ? ServerClientHashMagic : ClientServerHashMagic;
 	const size_t hashSize = nla->server ? sizeof(ServerClientHashMagic) : sizeof(ClientServerHashMagic);
 


### PR DESCRIPTION
So, I would propose this patch which seems to work, but in general, I find it unsatisfactory that the input buffers be overwritten by gss when the output can be of different size. This SEC_BUFFER API looks dumb to me.
