### PR TITLE
Fixed #4993: Allow uninitialized bio socket in transport_bio_simple_uninit

### DIFF
--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -380,7 +380,7 @@ static int transport_bio_simple_uninit(BIO* bio)
 
 	if (BIO_get_shutdown(bio))
 	{
-		if (BIO_get_init(bio))
+		if (BIO_get_init(bio) && ptr)
 		{
 			_shutdown(ptr->socket, SD_BOTH);
 			closesocket(ptr->socket);
@@ -388,7 +388,7 @@ static int transport_bio_simple_uninit(BIO* bio)
 		}
 	}
 
-	if (ptr->hEvent)
+	if (ptr && ptr->hEvent)
 	{
 		CloseHandle(ptr->hEvent);
 		ptr->hEvent = NULL;


### PR DESCRIPTION
When the TLS connection is aborted early (certificate issues, ...)
the bio simple socket might not have been initialized.
Do not access the NULL pointer on cleanup.
