### PR TITLE
new [crypto/tls]: add support to set tls security level

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2458,6 +2458,15 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 					return COMMAND_LINE_ERROR_MEMORY;
 			}
 		}
+		CommandLineSwitchCase(arg, "tls-seclevel")
+		{
+			unsigned long val = strtoul(arg->Value, NULL, 0);
+
+			if ((errno != 0) || (val > 5))
+				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
+
+			settings->TlsSecLevel = val;
+		}
 		CommandLineSwitchCase(arg, "cert-name")
 		{
 			if (!copy_value(arg->Value, &settings->CertificateName))

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2092,7 +2092,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		}
 		CommandLineSwitchCase(arg, "compression-level")
 		{
-			unsigned long val = strtol(arg->Value, NULL, 0);
+			unsigned long val = strtoul(arg->Value, NULL, 0);
 
 			if ((errno != 0) || (val > UINT32_MAX))
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -168,6 +168,7 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "t", COMMAND_LINE_VALUE_REQUIRED, "<title>", NULL, NULL, -1, "title", "Window title" },
 	{ "themes", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "themes" },
 	{ "tls-ciphers", COMMAND_LINE_VALUE_REQUIRED, "netmon|ma|ciphers", NULL, NULL, -1, NULL, "Allowed TLS ciphers" },
+	{ "tls-seclevel", COMMAND_LINE_VALUE_REQUIRED, "<level>", "1", NULL, -1, NULL, "TLS security level - defaults to 1" },
 	{ "toggle-fullscreen", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "Alt+Ctrl+Enter toggles fullscreen" },
 	{ "u", COMMAND_LINE_VALUE_REQUIRED, "[<domain>\\]<user> or <user>[@<domain>]", NULL, NULL, -1, NULL, "Username" },
 	{ "unmap-buttons", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Let server see real physical pointer button"},

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -627,6 +627,7 @@ typedef struct _RDPDR_PARALLEL RDPDR_PARALLEL;
 #define FreeRDP_VmConnectMode                                      (1102)
 #define FreeRDP_NtlmSamFile                                        (1103)
 #define FreeRDP_FIPSMode                                           (1104)
+#define FreeRDP_TlsSecLevel                                        (1105)
 #define FreeRDP_MstscCookieMode                                    (1152)
 #define FreeRDP_CookieMaxLength                                    (1153)
 #define FreeRDP_PreconnectionId                                    (1154)
@@ -756,6 +757,7 @@ typedef struct _RDPDR_PARALLEL RDPDR_PARALLEL;
 #define FreeRDP_OrderSupport                                       (2432)
 #define FreeRDP_BitmapCacheV3Enabled                               (2433)
 #define FreeRDP_AltSecFrameMarkerSupport                           (2434)
+#define FreeRDP_AllowUnanouncedOrdersFromServer                    (2435)
 #define FreeRDP_BitmapCacheEnabled                                 (2497)
 #define FreeRDP_BitmapCacheVersion                                 (2498)
 #define FreeRDP_AllowCacheWaitingList                              (2499)
@@ -1058,7 +1060,8 @@ struct rdp_settings
 	ALIGN64 BOOL   VmConnectMode;                /* 1102 */
 	ALIGN64 char*  NtlmSamFile;                  /* 1103 */
 	ALIGN64 BOOL   FIPSMode;                     /* 1104 */
-	UINT64 padding1152[1152 - 1105]; /* 1105 */
+	ALIGN64 UINT32 TlsSecLevel;                  /* 1105 */
+	UINT64 padding1152[1152 - 1106]; /* 1106 */
 
 	/* Connection Cookie */
 	ALIGN64 BOOL   MstscCookieMode;      /* 1152 */

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -1999,6 +1999,9 @@ UINT32 freerdp_get_param_uint32(rdpSettings* settings, int id)
 		case FreeRDP_SmartSizingHeight:
 			return settings->SmartSizingHeight;
 
+		case FreeRDP_TlsSecLevel:
+			return settings->TlsSecLevel;
+
 		default:
 			WLog_ERR(TAG,  "freerdp_get_param_uint32: unknown id: %d", id);
 			return 0;
@@ -2340,6 +2343,9 @@ int freerdp_set_param_uint32(rdpSettings* settings, int id, UINT32 param)
 		case FreeRDP_DynamicChannelArraySize:
 			settings->DynamicChannelArraySize = param;
 			break;
+
+		case FreeRDP_TlsSecLevel:
+			settings->TlsSecLevel = param;
 
 		default:
 			WLog_ERR(TAG, "freerdp_set_param_uint32: unknown id %d (param = %"PRIu32")", id, param);

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -615,6 +615,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 
 	settings->ActionScript = _strdup("~/.config/freerdp/action.sh");
 	settings->SmartcardLogon = FALSE;
+	settings->TlsSecLevel = 1;
 	return settings;
 out_fail:
 	free(settings->HomePath);

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -651,6 +651,10 @@ static BOOL tls_prepare(rdpTls* tls, BIO* underlying, SSL_METHOD* method,
 	SSL_CTX_set_options(tls->ctx, options);
 	SSL_CTX_set_read_ahead(tls->ctx, 1);
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+	SSL_CTX_set_security_level(tls->ctx, settings->TlsSecLevel);
+#endif
+
 	if (settings->AllowedTlsCiphers)
 	{
 		if (!SSL_CTX_set_cipher_list(tls->ctx, settings->AllowedTlsCiphers))


### PR DESCRIPTION
The newly introduced option /tls-seclevel can be used to set the tls
security level on systems with openssl >= 1.1.0 or libressl.
As default level 1 is used as higher levels might prohibit connections
to older systems.
