### PR TITLE
assistance v2 support

### DIFF
--- a/channels/remdesk/client/remdesk_main.c
+++ b/channels/remdesk/client/remdesk_main.c
@@ -255,7 +255,13 @@ static UINT remdesk_recv_ctl_version_info_pdu(remdeskPlugin* remdesk,
 
 	Stream_Read_UINT32(s, versionMajor); /* versionMajor (4 bytes) */
 	Stream_Read_UINT32(s, versionMinor); /* versionMinor (4 bytes) */
-	remdesk->Version = versionMajor;
+
+	if ((versionMajor != 1) || (versionMinor > 2) || (versionMinor == 0))
+	{
+		WLog_ERR(TAG, "Unsupported protocol version %"PRId32".%"PRId32, versionMajor, versionMinor);
+	}
+
+	remdesk->Version = versionMinor;
 	return CHANNEL_RC_OK;
 }
 

--- a/channels/remdesk/client/remdesk_main.h
+++ b/channels/remdesk/client/remdesk_main.h
@@ -55,7 +55,7 @@ struct remdesk_plugin
 	UINT32 Version;
 	char* ExpertBlob;
 	BYTE* EncryptedPassStub;
-	int EncryptedPassStubSize;
+	size_t EncryptedPassStubSize;
 	rdpContext* rdpcontext;
 };
 typedef struct remdesk_plugin remdeskPlugin;

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -303,24 +303,38 @@ out:
 }
 
 int freerdp_client_settings_parse_assistance_file(rdpSettings* settings,
-        const char* filename)
+        int argc, char* argv[])
 {
-	int status;
+	int status, x;
 	int ret = -1;
+	char* filename;
+	char* password = NULL;
 	rdpAssistanceFile* file;
+
+	if (!settings || !argv || (argc < 1))
+		return -1;
+
+	filename = argv[1];
+
+	for (x = 2; x < argc; x++)
+	{
+		const char* key = strstr(argv[x], "assistance:");
+
+		if (key)
+			password = strchr(key, ':') + 1;
+	}
+
 	file = freerdp_assistance_file_new();
 
 	if (!file)
 		return -1;
 
-	status = freerdp_assistance_parse_file(file, filename);
+	status = freerdp_assistance_parse_file(file, filename, password);
 
 	if (status < 0)
 		goto out;
 
-	status = freerdp_client_populate_settings_from_assistance_file(file, settings);
-
-	if (status < 0)
+	if (!freerdp_client_populate_settings_from_assistance_file(file, settings))
 		goto out;
 
 	ret = 0;

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -334,7 +334,7 @@ int freerdp_client_settings_parse_assistance_file(rdpSettings* settings,
 	if (status < 0)
 		goto out;
 
-	if (!freerdp_client_populate_settings_from_assistance_file(file, settings))
+	if (!freerdp_assistance_populate_settings_from_assistance_file(file, settings))
 		goto out;
 
 	ret = 0;

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -311,7 +311,7 @@ int freerdp_client_settings_parse_assistance_file(rdpSettings* settings,
 	char* password = NULL;
 	rdpAssistanceFile* file;
 
-	if (!settings || !argv || (argc < 1))
+	if (!settings || !argv || (argc < 2))
 		return -1;
 
 	filename = argv[1];

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1410,7 +1410,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		if (assist)
 		{
 			if (freerdp_client_settings_parse_assistance_file(settings,
-			        argv[1]) < 0)
+			        argc, argv) < 0)
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 		}
 
@@ -2672,13 +2672,6 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		CommandLineSwitchCase(arg, "print-reconnect-cookie")
 		{
 			settings->PrintReconnectCookie = enable;
-		}
-		CommandLineSwitchCase(arg, "assistance")
-		{
-			settings->RemoteAssistanceMode = TRUE;
-
-			if (!copy_value(arg->Value, &settings->RemoteAssistancePassword))
-				return COMMAND_LINE_ERROR_MEMORY;
 		}
 		CommandLineSwitchCase(arg, "pwidth")
 		{

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3050,6 +3050,7 @@ BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 	{
 		settings->EncomspVirtualChannel = TRUE;
 		settings->RemdeskVirtualChannel = TRUE;
+		settings->NlaSecurity = FALSE;
 	}
 
 	if (settings->EncomspVirtualChannel)

--- a/include/freerdp/assistance.h
+++ b/include/freerdp/assistance.h
@@ -23,62 +23,34 @@
 #include <freerdp/api.h>
 #include <freerdp/freerdp.h>
 
-struct rdp_assistance_file
-{
-	UINT32 Type;
-
-	char* Username;
-	char* LHTicket;
-	char* RCTicket;
-	char* PassStub;
-	UINT32 DtStart;
-	UINT32 DtLength;
-	BOOL LowSpeed;
-	BOOL RCTicketEncrypted;
-
-	char* ConnectionString1;
-	char* ConnectionString2;
-
-	BYTE* EncryptedPassStub;
-	int EncryptedPassStubLength;
-
-	BYTE* EncryptedLHTicket;
-	int EncryptedLHTicketLength;
-
-	char* MachineAddress;
-	UINT32 MachinePort;
-
-	UINT32 MachineCount;
-	char** MachineAddresses;
-	UINT32* MachinePorts;
-
-	char* RASessionId;
-	char* RASpecificParams;
-};
 typedef struct rdp_assistance_file rdpAssistanceFile;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-FREERDP_API BYTE* freerdp_assistance_hex_string_to_bin(const char* str, int* size);
-FREERDP_API char* freerdp_assistance_bin_to_hex_string(const BYTE* data, int size);
-
-FREERDP_API int freerdp_assistance_parse_connection_string1(rdpAssistanceFile* file);
-FREERDP_API int freerdp_assistance_parse_connection_string2(rdpAssistanceFile* file);
+FREERDP_API BYTE* freerdp_assistance_hex_string_to_bin(const char* str, size_t* size);
+FREERDP_API char* freerdp_assistance_bin_to_hex_string(const BYTE* data, size_t size);
 
 FREERDP_API char* freerdp_assistance_generate_pass_stub(DWORD flags);
 FREERDP_API char* freerdp_assistance_construct_expert_blob(const char* name, const char* pass);
-FREERDP_API BYTE* freerdp_assistance_encrypt_pass_stub(const char* password, const char* passStub, int* pEncryptedSize);
+FREERDP_API BYTE* freerdp_assistance_encrypt_pass_stub(const char* password, const char* passStub,
+        size_t* pEncryptedSize);
 
-FREERDP_API int freerdp_assistance_parse_file_buffer(rdpAssistanceFile* file, const char* buffer, size_t size);
-FREERDP_API int freerdp_assistance_parse_file(rdpAssistanceFile* file, const char* name);
-FREERDP_API int freerdp_assistance_decrypt(rdpAssistanceFile* file, const char* password);
+FREERDP_API int freerdp_assistance_parse_file_buffer(rdpAssistanceFile* file, const char* buffer,
+        size_t size, const char* password);
+FREERDP_API int freerdp_assistance_parse_file(rdpAssistanceFile* file, const char* name,
+        const char* password);
 
-FREERDP_API int freerdp_client_populate_settings_from_assistance_file(rdpAssistanceFile* file, rdpSettings* settings);
+FREERDP_API BOOL freerdp_client_populate_settings_from_assistance_file(rdpAssistanceFile* file,
+        rdpSettings* settings);
+FREERDP_API BOOL freerdp_assistance_get_encrypted_pass_stub(rdpAssistanceFile* file,
+        const char** pwd, size_t* size);
 
 FREERDP_API rdpAssistanceFile* freerdp_assistance_file_new(void);
 FREERDP_API void freerdp_assistance_file_free(rdpAssistanceFile* file);
+
+FREERDP_API void freerdp_assistance_print_file(rdpAssistanceFile* file, wLog* log, DWORD level);
 
 #ifdef __cplusplus
 }

--- a/include/freerdp/assistance.h
+++ b/include/freerdp/assistance.h
@@ -37,12 +37,15 @@ FREERDP_API char* freerdp_assistance_construct_expert_blob(const char* name, con
 FREERDP_API BYTE* freerdp_assistance_encrypt_pass_stub(const char* password, const char* passStub,
         size_t* pEncryptedSize);
 
+FREERDP_API int freerdp_assistance_set_connection_string2(rdpAssistanceFile* file,
+        const char* string, const char* password);
+
 FREERDP_API int freerdp_assistance_parse_file_buffer(rdpAssistanceFile* file, const char* buffer,
         size_t size, const char* password);
 FREERDP_API int freerdp_assistance_parse_file(rdpAssistanceFile* file, const char* name,
         const char* password);
 
-FREERDP_API BOOL freerdp_client_populate_settings_from_assistance_file(rdpAssistanceFile* file,
+FREERDP_API BOOL freerdp_assistance_populate_settings_from_assistance_file(rdpAssistanceFile* file,
         rdpSettings* settings);
 FREERDP_API BOOL freerdp_assistance_get_encrypted_pass_stub(rdpAssistanceFile* file,
         const char** pwd, size_t* size);

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -96,7 +96,7 @@ FREERDP_API int freerdp_client_settings_write_connection_file(const rdpSettings*
         const char* filename, BOOL unicode);
 
 FREERDP_API int freerdp_client_settings_parse_assistance_file(rdpSettings* settings,
-        const char* filename);
+        int argc, char* argv[]);
 
 FREERDP_API BOOL client_cli_authenticate(freerdp* instance, char** username, char** password,
         char** domain);

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -150,7 +150,11 @@ static BOOL reallocate(rdpAssistanceFile* file, const char* host, UINT32 port)
 	tmp2 = realloc(file->MachineAddresses, sizeof(char*) * file->MachineCount);
 
 	if (!tmp1 || !tmp2)
+	{
+		free(tmp1);
+		free(tmp2);
 		return FALSE;
+	}
 
 	file->MachinePorts = tmp1;
 	file->MachineAddresses = tmp2;

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -179,21 +179,15 @@ static BOOL append_address(rdpAssistanceFile* file, const char* host, const char
 	return reallocate(file, host, p);
 }
 
-static BOOL freerdp_assistance_parse_address_list(rdpAssistanceFile* file, const char* list)
+static BOOL freerdp_assistance_parse_address_list(rdpAssistanceFile* file, char* list)
 {
 	BOOL rc = FALSE;
 	char* p;
-	char* str;
 
 	if (!file || !list)
 		return FALSE;
 
-	str = _strdup(list);
-
-	if (!str)
-		return FALSE;
-
-	p =	str;
+	p =	list;
 
 	while ((p = strchr(p, ';')) != NULL)
 	{
@@ -213,8 +207,7 @@ static BOOL freerdp_assistance_parse_address_list(rdpAssistanceFile* file, const
 
 	rc = TRUE;
 out:
-	free(str);
-	return TRUE;
+	return rc;
 }
 
 static BOOL freerdp_assistance_parse_connection_string1(rdpAssistanceFile* file)

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -167,16 +167,13 @@ static BOOL append_address(rdpAssistanceFile* file, const char* host, const char
 {
 	unsigned long p;
 
-	if (!file || !host || !port)
-		return FALSE;
-
 	errno = 0;
 	p = strtoul(port, NULL, 0);
 
 	if ((errno != 0) || (p == 0) || (p > UINT16_MAX))
 		return FALSE;
 
-	return reallocate(file, host, p);
+	return reallocate(file, host, (UINT16)p);
 }
 
 static BOOL freerdp_assistance_parse_address_list(rdpAssistanceFile* file, char* list)

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -1045,7 +1045,7 @@ int freerdp_assistance_parse_file(rdpAssistanceFile* file, const char* name, con
 	return status;
 }
 
-BOOL freerdp_client_populate_settings_from_assistance_file(rdpAssistanceFile* file,
+BOOL freerdp_assistance_populate_settings_from_assistance_file(rdpAssistanceFile* file,
         rdpSettings* settings)
 {
 	UINT32 i;
@@ -1057,9 +1057,17 @@ BOOL freerdp_client_populate_settings_from_assistance_file(rdpAssistanceFile* fi
 	if (freerdp_set_param_string(settings, FreeRDP_RemoteAssistanceSessionId, file->RASessionId) != 0)
 		return FALSE;
 
-	if (file->RCTicket &&
-	    (freerdp_set_param_string(settings, FreeRDP_RemoteAssistanceRCTicket, file->RCTicket) != 0))
-		return FALSE;
+	if (file->RCTicket)
+	{
+		if (freerdp_set_param_string(settings, FreeRDP_RemoteAssistanceRCTicket, file->RCTicket) != 0)
+			return FALSE;
+	}
+	else
+	{
+		if (freerdp_set_param_string(settings, FreeRDP_RemoteAssistanceRCTicket,
+		                             file->ConnectionString2) != 0)
+			return FALSE;
+	}
 
 	if (file->PassStub)
 	{
@@ -1170,4 +1178,17 @@ BOOL freerdp_assistance_get_encrypted_pass_stub(rdpAssistanceFile* file, const c
 	*pwd = (const char*)file->EncryptedPassStub;
 	*size = file->EncryptedPassStubLength;
 	return TRUE;
+}
+
+int freerdp_assistance_set_connection_string2(rdpAssistanceFile* file, const char* string,
+        const char* password)
+{
+	if (!file || !string || !password)
+		return -1;
+
+	free(file->ConnectionString2);
+	free(file->password);
+	file->ConnectionString2 = _strdup(string);
+	file->password = _strdup(password);
+	return freerdp_assistance_parse_connection_string2(file);
 }

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -1079,6 +1079,9 @@ BOOL freerdp_client_populate_settings_from_assistance_file(rdpAssistanceFile* fi
 	if (freerdp_set_param_string(settings, FreeRDP_RemoteAssistancePassword, file->password) != 0)
 		return FALSE;
 
+	if (freerdp_set_param_string(settings, FreeRDP_Username, file->Username) != 0)
+		return FALSE;
+
 	settings->RemoteAssistanceMode = TRUE;
 	freerdp_set_param_uint32(settings, FreeRDP_ServerPort, file->MachinePorts[0]);
 	freerdp_target_net_addresses_free(settings);

--- a/libfreerdp/common/test/TestCommonAssistance.c
+++ b/libfreerdp/common/test/TestCommonAssistance.c
@@ -8,58 +8,58 @@
 const char TEST_MSRC_INCIDENT_PASSWORD_TYPE1[] = "Password1";
 
 static const char TEST_MSRC_INCIDENT_FILE_TYPE1[] =
-"<?xml version=\"1.0\" encoding=\"Unicode\" ?>"
-"<UPLOADINFO TYPE=\"Escalated\">"
-"<UPLOADDATA "
-"USERNAME=\"Administrator\" "
-"RCTICKET=\"65538,1,10.0.3.105:3389;winxpsp3.contoso3.com:3389,*,"
-"rb+v0oPmEISmi8N2zK/vuhgul/ABqlDt6wW0VxMyxK8=,*,*,IuaRySSbPDNna4+2mKcsKxsbJFI=\""
-"RCTICKETENCRYPTED=\"1\" "
-"DtStart=\"1314905741\" "
-"DtLength=\"180\" "
-"PassStub=\"RT=0PvIndan52*\" "
-"L=\"0\" />"
-"</UPLOADINFO>";
+    "<?xml version=\"1.0\" encoding=\"Unicode\" ?>"
+    "<UPLOADINFO TYPE=\"Escalated\">"
+    "<UPLOADDATA "
+    "USERNAME=\"Administrator\" "
+    "RCTICKET=\"65538,1,10.0.3.105:3389;winxpsp3.contoso3.com:3389,*,"
+    "rb+v0oPmEISmi8N2zK/vuhgul/ABqlDt6wW0VxMyxK8=,*,*,IuaRySSbPDNna4+2mKcsKxsbJFI=\""
+    "RCTICKETENCRYPTED=\"1\" "
+    "DtStart=\"1314905741\" "
+    "DtLength=\"180\" "
+    "PassStub=\"RT=0PvIndan52*\" "
+    "L=\"0\" />"
+    "</UPLOADINFO>";
 
 const BYTE TEST_MSRC_INCIDENT_EXPERT_BLOB_TYPE1[32] =
-	"\x3C\x9C\xAE\x0B\xCE\x7A\xB1\x5C\x8A\xAC\x01\xD6\x76\x04\x5E\xDF"
-	"\x3F\xFA\xF0\x92\xE2\xDE\x36\x8A\x20\x17\xE6\x8A\x0D\xED\x7C\x90";
+    "\x3C\x9C\xAE\x0B\xCE\x7A\xB1\x5C\x8A\xAC\x01\xD6\x76\x04\x5E\xDF"
+    "\x3F\xFA\xF0\x92\xE2\xDE\x36\x8A\x20\x17\xE6\x8A\x0D\xED\x7C\x90";
 
 const char TEST_MSRC_INCIDENT_PASSWORD_TYPE2[] = "48BJQ853X3B4";
 
 static const char TEST_MSRC_INCIDENT_FILE_TYPE2[] =
-"<?xml version=\"1.0\"?>"
-"<UPLOADINFO TYPE=\"Escalated\">"
-"<UPLOADDATA USERNAME=\"awake\" "
-"LHTICKET=\""
-"20FCC407AA53E95F8505AB56D485D26835064B03AF86CDA326248FD304626AD4"
-"DBDBDFFE0C473228EFFF7A1E6CEB445BBEC429294BB6616BBB600854438DDFB5"
-"82FC377CF65A2060EB3221647643C9B29BF5EC320856180B34D1BE9827A528C7"
-"E8F0DCD53C8D38F974160FEE317458FAC9DBDBA7B972D21DF3BC5B1AF0E01878"
-"65F07A3B915618C03E6EAF843FC1185770A1208C29C836DBCA5A040CB276D3C4"
-"1DDE2FA8CA9627E5E74FA750A92C0E01AD6C3D1000A5B1479DEB899BF5BCD402"
-"CE3BB3BF104CE0286C3F985AA711943C88C5EEEEE86F35B63F68883A90ADBCFD"
-"CBBAE3EAB993EFD9148E1A21D092CE9498695943946236D65D20B4A38D724C61"
-"72319E38E19C04E98EBC03F56A4A190E971F8EAEBFE6B415A3A2D8F35F7BF785"
-"26B9BFAAB48D11BDD6C905EFE503D2265678E1EAD2F2F124E570667F04103180"
-"2F63587276C14E6A5AB436CE234F722CE7C9B5D244508F14C012E84A49FE6992"
-"3F30320ABB3641F1EFA66205F3EA709E7E1C3E6874BB9642486FB96D2730CDF4"
-"514AA738167F00FC13B2978AED1D6678413FDF62008B03DD729E36173BE02742"
-"B69CAD44938512D0F56335394759338AF6ADBCF39CE829116D97435085D05BB5"
-"9320A134698050DCDBE01305A6B4712FD6BD48958BD2DC497498FF35CAECC9A8"
-"2C97FD1A5B5EC4BAF5FFB75A1471B765C465B35A7C950019066BB219B391C6E9"
-"8AE8FD2038E774F36F226D9FB9A38BCC313785612165D1EF69D19E2B9CF6E0F7"
-"FE1ECCF00AB81F9E8B626363CA82FAC719A3B7D243325C9D6042B2488EC95B80"
-"A31273FF9B72FBBB86F946E6D3DF8816BE4533F0B547C8BC028309EA9784C1E6\" "
-"RCTICKET=\"65538,1,192.168.1.200:49230;169.254.6.170:49231,*,"
-"+ULZ6ifjoCa6cGPMLQiGHRPwkg6VyJqGwxMnO6GcelwUh9a6/FBq3It5ADSndmLL,"
-"*,*,BNRjdu97DyczQSRuMRrDWoue+HA=\" "
-"PassStub=\"WB^6HsrIaFmEpi\" "
-"RCTICKETENCRYPTED=\"1\" "
-"DtStart=\"1403972263\" "
-"DtLength=\"14400\" "
-"L=\"0\"/>"
-"</UPLOADINFO>";
+    "<?xml version=\"1.0\"?>"
+    "<UPLOADINFO TYPE=\"Escalated\">"
+    "<UPLOADDATA USERNAME=\"awake\" "
+    "LHTICKET=\""
+    "20FCC407AA53E95F8505AB56D485D26835064B03AF86CDA326248FD304626AD4"
+    "DBDBDFFE0C473228EFFF7A1E6CEB445BBEC429294BB6616BBB600854438DDFB5"
+    "82FC377CF65A2060EB3221647643C9B29BF5EC320856180B34D1BE9827A528C7"
+    "E8F0DCD53C8D38F974160FEE317458FAC9DBDBA7B972D21DF3BC5B1AF0E01878"
+    "65F07A3B915618C03E6EAF843FC1185770A1208C29C836DBCA5A040CB276D3C4"
+    "1DDE2FA8CA9627E5E74FA750A92C0E01AD6C3D1000A5B1479DEB899BF5BCD402"
+    "CE3BB3BF104CE0286C3F985AA711943C88C5EEEEE86F35B63F68883A90ADBCFD"
+    "CBBAE3EAB993EFD9148E1A21D092CE9498695943946236D65D20B4A38D724C61"
+    "72319E38E19C04E98EBC03F56A4A190E971F8EAEBFE6B415A3A2D8F35F7BF785"
+    "26B9BFAAB48D11BDD6C905EFE503D2265678E1EAD2F2F124E570667F04103180"
+    "2F63587276C14E6A5AB436CE234F722CE7C9B5D244508F14C012E84A49FE6992"
+    "3F30320ABB3641F1EFA66205F3EA709E7E1C3E6874BB9642486FB96D2730CDF4"
+    "514AA738167F00FC13B2978AED1D6678413FDF62008B03DD729E36173BE02742"
+    "B69CAD44938512D0F56335394759338AF6ADBCF39CE829116D97435085D05BB5"
+    "9320A134698050DCDBE01305A6B4712FD6BD48958BD2DC497498FF35CAECC9A8"
+    "2C97FD1A5B5EC4BAF5FFB75A1471B765C465B35A7C950019066BB219B391C6E9"
+    "8AE8FD2038E774F36F226D9FB9A38BCC313785612165D1EF69D19E2B9CF6E0F7"
+    "FE1ECCF00AB81F9E8B626363CA82FAC719A3B7D243325C9D6042B2488EC95B80"
+    "A31273FF9B72FBBB86F946E6D3DF8816BE4533F0B547C8BC028309EA9784C1E6\" "
+    "RCTICKET=\"65538,1,192.168.1.200:49230;169.254.6.170:49231,*,"
+    "+ULZ6ifjoCa6cGPMLQiGHRPwkg6VyJqGwxMnO6GcelwUh9a6/FBq3It5ADSndmLL,"
+    "*,*,BNRjdu97DyczQSRuMRrDWoue+HA=\" "
+    "PassStub=\"WB^6HsrIaFmEpi\" "
+    "RCTICKETENCRYPTED=\"1\" "
+    "DtStart=\"1403972263\" "
+    "DtLength=\"14400\" "
+    "L=\"0\"/>"
+    "</UPLOADINFO>";
 
 /**
  * Decrypted Connection String 2:
@@ -77,105 +77,68 @@ static const char TEST_MSRC_INCIDENT_FILE_TYPE2[] =
  * </E>
  */
 
-int test_msrsc_incident_file_type1()
+static int test_msrsc_incident_file_type1(void)
 {
 	int status;
 	char* pass;
 	char* expertBlob;
+	const char* EncryptedPassStub;
+	size_t EncryptedPassStubLength;
 	rdpAssistanceFile* file;
-
 	file = freerdp_assistance_file_new();
 
 	if (!file)
 		return -1;
 
 	status = freerdp_assistance_parse_file_buffer(file,
-			TEST_MSRC_INCIDENT_FILE_TYPE1, sizeof(TEST_MSRC_INCIDENT_FILE_TYPE1));
-
+	         TEST_MSRC_INCIDENT_FILE_TYPE1, sizeof(TEST_MSRC_INCIDENT_FILE_TYPE1),
+	         TEST_MSRC_INCIDENT_PASSWORD_TYPE1);
 	printf("freerdp_assistance_parse_file_buffer: %d\n", status);
 
 	if (status < 0)
 		return -1;
 
-	printf("Username: %s\n", file->Username);
-	printf("LHTicket: %s\n", file->LHTicket);
-	printf("RCTicket: %s\n", file->RCTicket);
-	printf("RCTicketEncrypted: %"PRId32"\n", file->RCTicketEncrypted);
-	printf("PassStub: %s\n", file->PassStub);
-	printf("DtStart: %"PRIu32"\n", file->DtStart);
-	printf("DtLength: %"PRIu32"\n", file->DtLength);
-	printf("LowSpeed: %"PRId32"\n", file->LowSpeed);
+	freerdp_assistance_print_file(file, WLog_Get("foo"), WLOG_INFO);
 
-	printf("RASessionId: %s\n", file->RASessionId);
-	printf("RASpecificParams: %s\n", file->RASpecificParams);
-	printf("MachineAddress: %s\n", file->MachineAddress);
-	printf("MachinePort: %"PRIu32"\n", file->MachinePort);
-
-	status = freerdp_assistance_decrypt(file, TEST_MSRC_INCIDENT_PASSWORD_TYPE1);
-
-	printf("freerdp_assistance_decrypt: %d\n", status);
-
-	if (status < 0)
+	if (!freerdp_assistance_get_encrypted_pass_stub(file, &EncryptedPassStub, &EncryptedPassStubLength))
 		return -1;
 
-	pass = freerdp_assistance_bin_to_hex_string(file->EncryptedPassStub, file->EncryptedPassStubLength);
+	pass = freerdp_assistance_bin_to_hex_string(EncryptedPassStub, EncryptedPassStubLength);
 
 	if (!pass)
 		return -1;
 
 	expertBlob = freerdp_assistance_construct_expert_blob("Edgar Olougouna", pass);
-
 	freerdp_assistance_file_free(file);
-
 	free(pass);
 	free(expertBlob);
-
 	return 0;
 }
 
-int test_msrsc_incident_file_type2()
+static int test_msrsc_incident_file_type2(void)
 {
 	int status;
 	rdpAssistanceFile* file;
-
 	file = freerdp_assistance_file_new();
 
 	if (!file)
 		return -1;
 
 	status = freerdp_assistance_parse_file_buffer(file,
-			TEST_MSRC_INCIDENT_FILE_TYPE2, sizeof(TEST_MSRC_INCIDENT_FILE_TYPE2));
-
+	         TEST_MSRC_INCIDENT_FILE_TYPE2, sizeof(TEST_MSRC_INCIDENT_FILE_TYPE2), NULL);
 	printf("freerdp_assistance_parse_file_buffer: %d\n", status);
 
 	if (status < 0)
 		return -1;
 
-	printf("Username: %s\n", file->Username);
-	printf("LHTicket: %s\n", file->LHTicket);
-	printf("RCTicket: %s\n", file->RCTicket);
-	printf("RCTicketEncrypted: %"PRId32"\n", file->RCTicketEncrypted);
-	printf("PassStub: %s\n", file->PassStub);
-	printf("DtStart: %"PRIu32"\n", file->DtStart);
-	printf("DtLength: %"PRIu32"\n", file->DtLength);
-	printf("LowSpeed: %"PRId32"\n", file->LowSpeed);
-
-	printf("RASessionId: %s\n", file->RASessionId);
-	printf("RASpecificParams: %s\n", file->RASpecificParams);
-	printf("MachineAddress: %s\n", file->MachineAddress);
-	printf("MachinePort: %"PRIu32"\n", file->MachinePort);
-
+	freerdp_assistance_print_file(file, WLog_Get("foo"), WLOG_INFO);
 	status = freerdp_assistance_decrypt(file, TEST_MSRC_INCIDENT_PASSWORD_TYPE2);
-
 	printf("freerdp_assistance_decrypt: %d\n", status);
 
 	if (status < 0)
 		return -1;
 
-	printf("ConnectionString2: %s\n", file->ConnectionString2);
-
 	freerdp_assistance_file_free(file);
-
 	return 0;
 }
 

--- a/libfreerdp/common/test/TestCommonAssistance.c
+++ b/libfreerdp/common/test/TestCommonAssistance.c
@@ -79,7 +79,8 @@ static const char TEST_MSRC_INCIDENT_FILE_TYPE2[] =
 
 static BOOL test_msrsc_incident_file_type1(wLog* log)
 {
-	int status = -1;
+	BOOL rc = FALSE;
+	int status;
 	char* pass = NULL;
 	char* expertBlob = NULL;
 	const char* EncryptedPassStub;
@@ -111,11 +112,12 @@ static BOOL test_msrsc_incident_file_type1(wLog* log)
 	           EncryptedPassStubLength);
 	expertBlob = freerdp_assistance_construct_expert_blob("Edgar Olougouna", pass);
 	WLog_Print(log, WLOG_INFO, "expertBlob='%s'", expertBlob);
+	rc = TRUE;
 fail:
 	freerdp_assistance_file_free(file);
 	free(pass);
 	free(expertBlob);
-	return status >= 0 ? TRUE : FALSE;
+	return rc;
 }
 
 static BOOL test_msrsc_incident_file_type2(wLog* log)

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -881,32 +881,42 @@ fail:
 	return rc;
 }
 
+typedef struct
+{
+	SOCKET s;
+	struct addrinfo* addr;
+	struct addrinfo* result;
+} t_peer;
+
+static BOOL peer_free(t_peer* peer)
+{
+	if (peer->s != INVALID_SOCKET)
+		closesocket(peer->s);
+
+	freeaddrinfo(peer->addr);
+	memset(peer, 0, sizeof(t_peer));
+	peer->s = INVALID_SOCKET;
+}
+
 static int freerdp_tcp_connect_multi(rdpContext* context, char** hostnames,
                                      UINT32* ports, UINT32 count, int port,
                                      int timeout)
 {
 	UINT32 index;
-	int sindex;
-	int status;
-	SOCKET sockfd = (SOCKET) - 1;
-	SOCKET* sockfds;
+	UINT32 sindex = count;
+	int status = -1;
+	SOCKET sockfd = INVALID_SOCKET;
 	HANDLE* events;
-	DWORD waitStatus;
 	struct addrinfo* addr;
 	struct addrinfo* result;
-	struct addrinfo** addrs;
-	struct addrinfo** results;
-	sockfds = (SOCKET*) calloc(count, sizeof(SOCKET));
+	t_peer* peers;
 	events = (HANDLE*) calloc(count + 1, sizeof(HANDLE));
-	addrs = (struct addrinfo**) calloc(count, sizeof(struct addrinfo*));
-	results = (struct addrinfo**) calloc(count, sizeof(struct addrinfo*));
+	peers = (t_peer*)calloc(count, sizeof(t_peer));
 
-	if (!sockfds || !events || !addrs || !results)
+	if (!peers || !events || (count < 1))
 	{
-		free(sockfds);
+		free(peers);
 		free(events);
-		free(addrs);
-		free(results);
 		return -1;
 	}
 
@@ -936,104 +946,48 @@ static int freerdp_tcp_connect_multi(rdpContext* context, char** hostnames,
 				addr = result;
 		}
 
-		sockfds[index] = _socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
+		peers[index].s = _socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
 
-		if (sockfds[index] == INVALID_SOCKET)
+		if (peers[index].s == INVALID_SOCKET)
 		{
 			freeaddrinfo(result);
-			sockfds[index] = 0;
 			continue;
 		}
 
-		addrs[index] = addr;
-		results[index] = result;
+		peers[index].addr = addr;
+		peers[index].result = result;
 	}
 
 	for (index = 0; index < count; index++)
 	{
-		if (!sockfds[index])
+		if (peers[index].s == INVALID_SOCKET)
 			continue;
 
-		sockfd = sockfds[index];
-		addr = addrs[index];
-		/* set socket in non-blocking mode */
-		events[index] = WSACreateEvent();
-
-		if (!events[index])
-		{
-			WLog_ERR(TAG, "WSACreateEvent returned 0x%08X", WSAGetLastError());
-			continue;
-		}
-
-		if (WSAEventSelect(sockfd, events[index], FD_READ | FD_WRITE | FD_CONNECT | FD_CLOSE))
-		{
-			WLog_ERR(TAG, "WSAEventSelect returned 0x%08X", WSAGetLastError());
-			continue;
-		}
-
-		/* non-blocking tcp connect */
+		sockfd = peers[index].s;
+		addr = peers[index].addr;
+		/* blocking tcp connect */
 		status = _connect(sockfd, addr->ai_addr, addr->ai_addrlen);
 
 		if (status >= 0)
 		{
 			/* connection success */
+			sindex = index;
 			break;
 		}
 	}
 
-	events[count] = context->abortEvent;
-	waitStatus = WaitForMultipleObjects(count + 1, events, FALSE, timeout * 1000);
-	sindex = waitStatus - WAIT_OBJECT_0;
-
-	for (index = 0; index < count; index++)
+	if (sindex < count)
 	{
-		const char* host = hostnames[index];
-		UINT32 curPort = port;
-		u_long arg = 0;
-
-		if (ports)
-			curPort = ports[index];
-
-		if (!sockfds[index])
-			continue;
-
-		sockfd = sockfds[index];
-
-		/* set socket in blocking mode */
-		if (WSAEventSelect(sockfd, events[index], 0))
-		{
-			WLog_ERR(TAG, "[%s:%"PRId32"] WSAEventSelect returned 0x%08X", host, port, WSAGetLastError());
-			continue;
-		}
-
-		if (_ioctlsocket(sockfd, FIONBIO, &arg))
-		{
-			WLog_ERR(TAG, "[%s:%"PRId32"] _ioctlsocket failed", host, port);
-		}
+		sockfd = peers[sindex].s;
+		peers[sindex].s = INVALID_SOCKET;
 	}
-
-	if ((sindex >= 0) && (sindex < count))
-	{
-		sockfd = sockfds[sindex];
-	}
-
-	if (sindex == count)
+	else
 		freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_CANCELLED);
 
 	for (index = 0; index < count; index++)
-	{
-		if (results[index])
-			freeaddrinfo(results[index]);
+		peer_free(&peers[index]);
 
-		if (sindex != index)
-			closesocket(sockfds[index]);
-
-		CloseHandle(events[index]);
-	}
-
-	free(addrs);
-	free(results);
-	free(sockfds);
+	free(peers);
 	free(events);
 	return sockfd;
 }

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -888,7 +888,7 @@ static int freerdp_tcp_connect_multi(rdpContext* context, char** hostnames,
 	UINT32 index;
 	int sindex;
 	int status;
-	SOCKET sockfd = -1;
+	SOCKET sockfd = (SOCKET) - 1;
 	SOCKET* sockfds;
 	HANDLE* events;
 	DWORD waitStatus;
@@ -989,11 +989,10 @@ static int freerdp_tcp_connect_multi(rdpContext* context, char** hostnames,
 	{
 		const char* host = hostnames[index];
 		UINT32 curPort = port;
+		u_long arg = 0;
 
 		if (ports)
 			curPort = ports[index];
-
-		u_long arg = 0;
 
 		if (!sockfds[index])
 			continue;
@@ -1025,6 +1024,9 @@ static int freerdp_tcp_connect_multi(rdpContext* context, char** hostnames,
 	{
 		if (results[index])
 			freeaddrinfo(results[index]);
+
+		if (sindex != index)
+			closesocket(sockfds[index]);
 
 		CloseHandle(events[index]);
 	}

--- a/server/shadow/Win/win_wds.c
+++ b/server/shadow/Win/win_wds.c
@@ -47,16 +47,26 @@
 
 #include <initguid.h>
 
+#include <freerdp/assistance.h>
+
 #define TAG SERVER_TAG("shadow.win")
 
-DEFINE_GUID(CLSID_RDPSession,0x9B78F0E6,0x3E05,0x4A5B,0xB2,0xE8,0xE7,0x43,0xA8,0x95,0x6B,0x65);
-DEFINE_GUID(DIID__IRDPSessionEvents,0x98a97042,0x6698,0x40e9,0x8e,0xfd,0xb3,0x20,0x09,0x90,0x00,0x4b);
-DEFINE_GUID(IID_IRDPSRAPISharingSession,0xeeb20886,0xe470,0x4cf6,0x84,0x2b,0x27,0x39,0xc0,0xec,0x5c,0xfb);
-DEFINE_GUID(IID_IRDPSRAPIAttendee,0xec0671b3,0x1b78,0x4b80,0xa4,0x64,0x91,0x32,0x24,0x75,0x43,0xe3);
-DEFINE_GUID(IID_IRDPSRAPIAttendeeManager,0xba3a37e8,0x33da,0x4749,0x8d,0xa0,0x07,0xfa,0x34,0xda,0x79,0x44);
-DEFINE_GUID(IID_IRDPSRAPISessionProperties,0x339b24f2,0x9bc0,0x4f16,0x9a,0xac,0xf1,0x65,0x43,0x3d,0x13,0xd4);
-DEFINE_GUID(CLSID_RDPSRAPIApplicationFilter,0xe35ace89,0xc7e8,0x427e,0xa4,0xf9,0xb9,0xda,0x07,0x28,0x26,0xbd);
-DEFINE_GUID(CLSID_RDPSRAPIInvitationManager,0x53d9c9db,0x75ab,0x4271,0x94,0x8a,0x4c,0x4e,0xb3,0x6a,0x8f,0x2b);
+DEFINE_GUID(CLSID_RDPSession, 0x9B78F0E6, 0x3E05, 0x4A5B, 0xB2, 0xE8, 0xE7, 0x43, 0xA8, 0x95, 0x6B,
+            0x65);
+DEFINE_GUID(DIID__IRDPSessionEvents, 0x98a97042, 0x6698, 0x40e9, 0x8e, 0xfd, 0xb3, 0x20, 0x09, 0x90,
+            0x00, 0x4b);
+DEFINE_GUID(IID_IRDPSRAPISharingSession, 0xeeb20886, 0xe470, 0x4cf6, 0x84, 0x2b, 0x27, 0x39, 0xc0,
+            0xec, 0x5c, 0xfb);
+DEFINE_GUID(IID_IRDPSRAPIAttendee, 0xec0671b3, 0x1b78, 0x4b80, 0xa4, 0x64, 0x91, 0x32, 0x24, 0x75,
+            0x43, 0xe3);
+DEFINE_GUID(IID_IRDPSRAPIAttendeeManager, 0xba3a37e8, 0x33da, 0x4749, 0x8d, 0xa0, 0x07, 0xfa, 0x34,
+            0xda, 0x79, 0x44);
+DEFINE_GUID(IID_IRDPSRAPISessionProperties, 0x339b24f2, 0x9bc0, 0x4f16, 0x9a, 0xac, 0xf1, 0x65,
+            0x43, 0x3d, 0x13, 0xd4);
+DEFINE_GUID(CLSID_RDPSRAPIApplicationFilter, 0xe35ace89, 0xc7e8, 0x427e, 0xa4, 0xf9, 0xb9, 0xda,
+            0x07, 0x28, 0x26, 0xbd);
+DEFINE_GUID(CLSID_RDPSRAPIInvitationManager, 0x53d9c9db, 0x75ab, 0x4271, 0x94, 0x8a, 0x4c, 0x4e,
+            0xb3, 0x6a, 0x8f, 0x2b);
 
 static ULONG Shadow_IRDPSessionEvents_RefCount = 0;
 
@@ -172,16 +182,16 @@ const char* GetRDPSessionEventString(DISPID id)
 	return "OnUnknown";
 }
 
-static HRESULT STDMETHODCALLTYPE Shadow_IRDPSessionEvents_QueryInterface( 
-            __RPC__in _IRDPSessionEvents * This,
-            /* [in] */ __RPC__in REFIID riid,
-            /* [annotation][iid_is][out] */ 
-            _COM_Outptr_  void **ppvObject)
+static HRESULT STDMETHODCALLTYPE Shadow_IRDPSessionEvents_QueryInterface(
+    __RPC__in _IRDPSessionEvents* This,
+    /* [in] */ __RPC__in REFIID riid,
+    /* [annotation][iid_is][out] */
+    _COM_Outptr_  void** ppvObject)
 {
 	*ppvObject = NULL;
 
 	if (IsEqualIID(riid, &DIID__IRDPSessionEvents) ||
-		IsEqualIID(riid, &IID_IDispatch) || IsEqualIID(riid, &IID_IUnknown))
+	    IsEqualIID(riid, &IID_IDispatch) || IsEqualIID(riid, &IID_IUnknown))
 	{
 		*ppvObject = This;
 	}
@@ -190,82 +200,79 @@ static HRESULT STDMETHODCALLTYPE Shadow_IRDPSessionEvents_QueryInterface(
 		return E_NOINTERFACE;
 
 	This->lpVtbl->AddRef(This);
-
 	return S_OK;
 }
-        
-static ULONG STDMETHODCALLTYPE Shadow_IRDPSessionEvents_AddRef( 
-            __RPC__in _IRDPSessionEvents * This)
+
+static ULONG STDMETHODCALLTYPE Shadow_IRDPSessionEvents_AddRef(
+    __RPC__in _IRDPSessionEvents* This)
 {
 	Shadow_IRDPSessionEvents_RefCount++;
 	return Shadow_IRDPSessionEvents_RefCount;
 }
-        
-static ULONG STDMETHODCALLTYPE Shadow_IRDPSessionEvents_Release( 
-            __RPC__in _IRDPSessionEvents * This)
+
+static ULONG STDMETHODCALLTYPE Shadow_IRDPSessionEvents_Release(
+    __RPC__in _IRDPSessionEvents* This)
 {
 	if (!Shadow_IRDPSessionEvents_RefCount)
 		return 0;
 
 	Shadow_IRDPSessionEvents_RefCount--;
-
 	return Shadow_IRDPSessionEvents_RefCount;
 }
-        
-static HRESULT STDMETHODCALLTYPE Shadow_IRDPSessionEvents_GetTypeInfoCount( 
-            __RPC__in _IRDPSessionEvents * This,
-            /* [out] */ __RPC__out UINT *pctinfo)
+
+static HRESULT STDMETHODCALLTYPE Shadow_IRDPSessionEvents_GetTypeInfoCount(
+    __RPC__in _IRDPSessionEvents* This,
+    /* [out] */ __RPC__out UINT* pctinfo)
 {
 	WLog_INFO(TAG, "Shadow_IRDPSessionEvents_GetTypeInfoCount");
 	*pctinfo = 1;
 	return S_OK;
 }
-        
-static HRESULT STDMETHODCALLTYPE Shadow_IRDPSessionEvents_GetTypeInfo( 
-            __RPC__in _IRDPSessionEvents * This,
-            /* [in] */ UINT iTInfo,
-            /* [in] */ LCID lcid,
-            /* [out] */ __RPC__deref_out_opt ITypeInfo **ppTInfo)
+
+static HRESULT STDMETHODCALLTYPE Shadow_IRDPSessionEvents_GetTypeInfo(
+    __RPC__in _IRDPSessionEvents* This,
+    /* [in] */ UINT iTInfo,
+    /* [in] */ LCID lcid,
+    /* [out] */ __RPC__deref_out_opt ITypeInfo** ppTInfo)
 {
 	WLog_INFO(TAG, "Shadow_IRDPSessionEvents_GetTypeInfo");
 	return E_NOTIMPL;
 }
-        
-static HRESULT STDMETHODCALLTYPE Shadow_IRDPSessionEvents_GetIDsOfNames( 
-            __RPC__in _IRDPSessionEvents * This,
-            /* [in] */ __RPC__in REFIID riid,
-            /* [size_is][in] */ __RPC__in_ecount_full(cNames) LPOLESTR *rgszNames,
-            /* [range][in] */ __RPC__in_range(0,16384) UINT cNames,
-            /* [in] */ LCID lcid,
-            /* [size_is][out] */ __RPC__out_ecount_full(cNames) DISPID *rgDispId)
+
+static HRESULT STDMETHODCALLTYPE Shadow_IRDPSessionEvents_GetIDsOfNames(
+    __RPC__in _IRDPSessionEvents* This,
+    /* [in] */ __RPC__in REFIID riid,
+    /* [size_is][in] */ __RPC__in_ecount_full(cNames) LPOLESTR* rgszNames,
+    /* [range][in] */ __RPC__in_range(0, 16384) UINT cNames,
+    /* [in] */ LCID lcid,
+    /* [size_is][out] */ __RPC__out_ecount_full(cNames) DISPID* rgDispId)
 {
 	WLog_INFO(TAG, "Shadow_IRDPSessionEvents_GetIDsOfNames");
 	return E_NOTIMPL;
 }
-        
-static HRESULT STDMETHODCALLTYPE Shadow_IRDPSessionEvents_Invoke( 
-            _IRDPSessionEvents * This,
-            /* [annotation][in] */ 
-            _In_  DISPID dispIdMember,
-            /* [annotation][in] */ 
-            _In_  REFIID riid,
-            /* [annotation][in] */ 
-            _In_  LCID lcid,
-            /* [annotation][in] */ 
-            _In_  WORD wFlags,
-            /* [annotation][out][in] */ 
-            _In_  DISPPARAMS *pDispParams,
-            /* [annotation][out] */ 
-            _Out_opt_  VARIANT *pVarResult,
-            /* [annotation][out] */ 
-            _Out_opt_  EXCEPINFO *pExcepInfo,
-            /* [annotation][out] */ 
-            _Out_opt_  UINT *puArgErr)
+
+static HRESULT STDMETHODCALLTYPE Shadow_IRDPSessionEvents_Invoke(
+    _IRDPSessionEvents* This,
+    /* [annotation][in] */
+    _In_  DISPID dispIdMember,
+    /* [annotation][in] */
+    _In_  REFIID riid,
+    /* [annotation][in] */
+    _In_  LCID lcid,
+    /* [annotation][in] */
+    _In_  WORD wFlags,
+    /* [annotation][out][in] */
+    _In_  DISPPARAMS* pDispParams,
+    /* [annotation][out] */
+    _Out_opt_  VARIANT* pVarResult,
+    /* [annotation][out] */
+    _Out_opt_  EXCEPINFO* pExcepInfo,
+    /* [annotation][out] */
+    _Out_opt_  UINT* puArgErr)
 {
 	HRESULT hr;
 	VARIANT vr;
 	UINT uArgErr;
-
 	WLog_INFO(TAG, "%s (%ld)", GetRDPSessionEventString(dispIdMember), dispIdMember);
 
 	switch (dispIdMember)
@@ -275,39 +282,35 @@ static HRESULT STDMETHODCALLTYPE Shadow_IRDPSessionEvents_Invoke(
 				int level;
 				IDispatch* pDispatch;
 				IRDPSRAPIAttendee* pAttendee;
-
 				vr.vt = VT_DISPATCH;
 				vr.pdispVal = NULL;
-
 				hr = DispGetParam(pDispParams, 0, VT_DISPATCH, &vr, &uArgErr);
 
 				if (FAILED(hr))
 				{
 					WLog_ERR(TAG, "%s DispGetParam(0, VT_DISPATCH) failure: 0x%08lX",
-						GetRDPSessionEventString(dispIdMember), hr);
+					         GetRDPSessionEventString(dispIdMember), hr);
 					return hr;
 				}
-				
-				pDispatch = vr.pdispVal;
 
+				pDispatch = vr.pdispVal;
 				hr = pDispatch->lpVtbl->QueryInterface(pDispatch, &IID_IRDPSRAPIAttendee, (void**) &pAttendee);
 
 				if (FAILED(hr))
 				{
 					WLog_INFO(TAG, "%s IDispatch::QueryInterface(IRDPSRAPIAttendee) failure: 0x%08lX",
-						GetRDPSessionEventString(dispIdMember), hr);
+					          GetRDPSessionEventString(dispIdMember), hr);
 					return hr;
 				}
 
 				level = CTRL_LEVEL_VIEW;
 				//level = CTRL_LEVEL_INTERACTIVE;
-
 				hr = pAttendee->lpVtbl->put_ControlLevel(pAttendee, level);
 
 				if (FAILED(hr))
 				{
 					WLog_INFO(TAG, "%s IRDPSRAPIAttendee::put_ControlLevel() failure: 0x%08lX",
-						GetRDPSessionEventString(dispIdMember), hr);
+					          GetRDPSessionEventString(dispIdMember), hr);
 					return hr;
 				}
 
@@ -341,41 +344,36 @@ static HRESULT STDMETHODCALLTYPE Shadow_IRDPSessionEvents_Invoke(
 				int level;
 				IDispatch* pDispatch;
 				IRDPSRAPIAttendee* pAttendee;
-
 				vr.vt = VT_INT;
 				vr.pdispVal = NULL;
-
 				hr = DispGetParam(pDispParams, 1, VT_INT, &vr, &uArgErr);
 
 				if (FAILED(hr))
 				{
 					WLog_INFO(TAG, "%s DispGetParam(1, VT_INT) failure: 0x%08lX",
-						GetRDPSessionEventString(dispIdMember), hr);
+					          GetRDPSessionEventString(dispIdMember), hr);
 					return hr;
 				}
 
 				level = vr.intVal;
-
 				vr.vt = VT_DISPATCH;
 				vr.pdispVal = NULL;
-
 				hr = DispGetParam(pDispParams, 0, VT_DISPATCH, &vr, &uArgErr);
 
 				if (FAILED(hr))
 				{
 					WLog_ERR(TAG, "%s DispGetParam(0, VT_DISPATCH) failure: 0x%08lX",
-						GetRDPSessionEventString(dispIdMember), hr);
+					         GetRDPSessionEventString(dispIdMember), hr);
 					return hr;
 				}
-				
-				pDispatch = vr.pdispVal;
 
+				pDispatch = vr.pdispVal;
 				hr = pDispatch->lpVtbl->QueryInterface(pDispatch, &IID_IRDPSRAPIAttendee, (void**) &pAttendee);
 
 				if (FAILED(hr))
 				{
 					WLog_INFO(TAG, "%s IDispatch::QueryInterface(IRDPSRAPIAttendee) failure: 0x%08lX",
-						GetRDPSessionEventString(dispIdMember), hr);
+					          GetRDPSessionEventString(dispIdMember), hr);
 					return hr;
 				}
 
@@ -384,7 +382,7 @@ static HRESULT STDMETHODCALLTYPE Shadow_IRDPSessionEvents_Invoke(
 				if (FAILED(hr))
 				{
 					WLog_INFO(TAG, "%s IRDPSRAPIAttendee::put_ControlLevel() failure: 0x%08lX",
-						GetRDPSessionEventString(dispIdMember), hr);
+					          GetRDPSessionEventString(dispIdMember), hr);
 					return hr;
 				}
 
@@ -491,9 +489,7 @@ int win_shadow_wds_wnd_init(winShadowSubsystem* subsystem)
 	HMODULE hModule;
 	HINSTANCE hInstance;
 	WNDCLASSEX wndClassEx;
-
 	hModule = GetModuleHandle(NULL);
-
 	ZeroMemory(&wndClassEx, sizeof(WNDCLASSEX));
 	wndClassEx.cbSize = sizeof(WNDCLASSEX);
 	wndClassEx.style = 0;
@@ -515,9 +511,8 @@ int win_shadow_wds_wnd_init(winShadowSubsystem* subsystem)
 	}
 
 	hInstance = wndClassEx.hInstance;
-
 	subsystem->hWnd = CreateWindowEx(0, wndClassEx.lpszClassName,
-		0, 0, 0, 0, 0, 0, HWND_MESSAGE, 0, hInstance, NULL);
+	                                 0, 0, 0, 0, 0, 0, HWND_MESSAGE, 0, hInstance, NULL);
 
 	if (!subsystem->hWnd)
 	{
@@ -541,15 +536,12 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 	BSTR bstrAuthString;
 	BSTR bstrGroupName;
 	BSTR bstrPassword;
-	BSTR bstrConnectionString;
 	BSTR bstrPropertyName;
 	VARIANT varPropertyValue;
 	rdpAssistanceFile* file;
 	IConnectionPoint* pCP;
 	IConnectionPointContainer* pCPC;
-
 	win_shadow_wds_wnd_init(subsystem);
-
 	hr = OleInitialize(NULL);
 
 	if (FAILED(hr))
@@ -567,7 +559,7 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 	}
 
 	hr = CoCreateInstance(&CLSID_RDPSession, NULL, CLSCTX_ALL,
-		&IID_IRDPSRAPISharingSession, (void**) &(subsystem->pSharingSession));
+	                      &IID_IRDPSRAPISharingSession, (void**) & (subsystem->pSharingSession));
 
 	if (FAILED(hr))
 	{
@@ -588,14 +580,14 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 
 	if (FAILED(hr))
 	{
-		WLog_ERR(TAG, "IConnectionPointContainer::FindConnectionPoint(_IRDPSessionEvents) failure: 0x%08lX", hr);
+		WLog_ERR(TAG, "IConnectionPointContainer::FindConnectionPoint(_IRDPSessionEvents) failure: 0x%08lX",
+		         hr);
 		return -1;
 	}
 
 	dwCookie = 0;
 	subsystem->pSessionEvents = &Shadow_IRDPSessionEvents;
 	subsystem->pSessionEvents->lpVtbl->AddRef(subsystem->pSessionEvents);
-
 	hr = pCP->lpVtbl->Advise(pCP, (IUnknown*) subsystem->pSessionEvents, &dwCookie);
 
 	if (FAILED(hr))
@@ -613,7 +605,7 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 	}
 
 	hr = subsystem->pSharingSession->lpVtbl->GetDesktopSharedRect(subsystem->pSharingSession,
-		&left, &top, &right, &bottom);
+	        &left, &top, &right, &bottom);
 
 	if (FAILED(hr))
 	{
@@ -623,12 +615,11 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 
 	width = right - left;
 	height = bottom - top;
-
-	WLog_INFO(TAG, "GetDesktopSharedRect(): left: %ld top: %ld right: %ld bottom: %ld width: %ld height: %ld",
-		left, top, right, bottom, width, height);
-
+	WLog_INFO(TAG,
+	          "GetDesktopSharedRect(): left: %ld top: %ld right: %ld bottom: %ld width: %ld height: %ld",
+	          left, top, right, bottom, width, height);
 	hr = subsystem->pSharingSession->lpVtbl->get_VirtualChannelManager(subsystem->pSharingSession,
-		&(subsystem->pVirtualChannelMgr));
+	        &(subsystem->pVirtualChannelMgr));
 
 	if (FAILED(hr))
 	{
@@ -637,7 +628,7 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 	}
 
 	hr = subsystem->pSharingSession->lpVtbl->get_ApplicationFilter(subsystem->pSharingSession,
-		&(subsystem->pApplicationFilter));
+	        &(subsystem->pApplicationFilter));
 
 	if (FAILED(hr))
 	{
@@ -646,7 +637,7 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 	}
 
 	hr = subsystem->pSharingSession->lpVtbl->get_Attendees(subsystem->pSharingSession,
-		&(subsystem->pAttendeeMgr));
+	        &(subsystem->pAttendeeMgr));
 
 	if (FAILED(hr))
 	{
@@ -654,7 +645,8 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 		return -1;
 	}
 
-	hr = subsystem->pSharingSession->lpVtbl->get_Properties(subsystem->pSharingSession, &(subsystem->pSessionProperties));
+	hr = subsystem->pSharingSession->lpVtbl->get_Properties(subsystem->pSharingSession,
+	        &(subsystem->pSessionProperties));
 
 	if (FAILED(hr))
 	{
@@ -665,10 +657,8 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 	bstrPropertyName = SysAllocString(L"PortId");
 	varPropertyValue.vt = VT_I4;
 	varPropertyValue.intVal = 40000;
-
 	hr = subsystem->pSessionProperties->lpVtbl->put_Property(subsystem->pSessionProperties,
-		bstrPropertyName, varPropertyValue);
-
+	        bstrPropertyName, varPropertyValue);
 	SysFreeString(bstrPropertyName);
 
 	if (FAILED(hr))
@@ -680,10 +670,8 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 	bstrPropertyName = SysAllocString(L"DrvConAttach");
 	varPropertyValue.vt = VT_BOOL;
 	varPropertyValue.boolVal = VARIANT_TRUE;
-
 	hr = subsystem->pSessionProperties->lpVtbl->put_Property(subsystem->pSessionProperties,
-		bstrPropertyName, varPropertyValue);
-
+	        bstrPropertyName, varPropertyValue);
 	SysFreeString(bstrPropertyName);
 
 	if (FAILED(hr))
@@ -694,14 +682,11 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 
 	bstrPropertyName = SysAllocString(L"PortProtocol");
 	varPropertyValue.vt = VT_I4;
-
 	//varPropertyValue.intVal = 0; // AF_UNSPEC
 	varPropertyValue.intVal = 2; // AF_INET
 	//varPropertyValue.intVal = 23; // AF_INET6
-
 	hr = subsystem->pSessionProperties->lpVtbl->put_Property(subsystem->pSessionProperties,
-		bstrPropertyName, varPropertyValue);
-
+	        bstrPropertyName, varPropertyValue);
 	SysFreeString(bstrPropertyName);
 
 	if (FAILED(hr))
@@ -719,7 +704,7 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 	}
 
 	hr = subsystem->pSharingSession->lpVtbl->get_Invitations(subsystem->pSharingSession,
-		&(subsystem->pInvitationMgr));
+	        &(subsystem->pInvitationMgr));
 
 	if (FAILED(hr))
 	{
@@ -730,10 +715,8 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 	bstrAuthString = SysAllocString(L"Shadow");
 	bstrGroupName = SysAllocString(L"ShadowGroup");
 	bstrPassword = SysAllocString(L"Shadow123!");
-
 	hr = subsystem->pInvitationMgr->lpVtbl->CreateInvitation(subsystem->pInvitationMgr, bstrAuthString,
-		bstrGroupName, bstrPassword, 5, &(subsystem->pInvitation));
-
+	        bstrGroupName, bstrPassword, 5, &(subsystem->pInvitation));
 	SysFreeString(bstrAuthString);
 	SysFreeString(bstrGroupName);
 	SysFreeString(bstrPassword);
@@ -741,14 +724,6 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 	if (FAILED(hr))
 	{
 		WLog_ERR(TAG, "IRDPSRAPIInvitationManager::CreateInvitation() failure: 0x%08lX", hr);
-		return -1;
-	}
-
-	hr = subsystem->pInvitation->lpVtbl->get_ConnectionString(subsystem->pInvitation, &bstrConnectionString);
-
-	if (FAILED(hr))
-	{
-		WLog_ERR(TAG, "IRDPSRAPIInvitation::get_ConnectionString() failure: 0x%08lX", hr);
 		return -1;
 	}
 
@@ -760,43 +735,33 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 		return -1;
 	}
 
-	status = ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) bstrConnectionString,
-		((UINT32*) bstrConnectionString)[-1], &(file->ConnectionString2), 0, NULL, NULL);
-
-	SysFreeString(bstrConnectionString);
-
-	if (status < 1)
 	{
-		WLog_ERR(TAG, "failed to convert connection string");
-		return -1;
-	}
+		int status1 = -1, status2 = -1;
+		char* ConnectionString2;
+		BSTR bstrConnectionString;
+		hr = subsystem->pInvitation->lpVtbl->get_ConnectionString(subsystem->pInvitation,
+		        &bstrConnectionString);
 
-	status = freerdp_assistance_parse_connection_string2(file);
-
-	if (status < 0)
-		return -1;
-
-	WLog_INFO(TAG, "ConnectionString: %s", file->ConnectionString2);
-
-#if 0
-	FILE* fp;
-	size_t size;
-
-	fp = fopen("inv.xml", "w+b");
-
-	if (fp)
-	{
-		size = strlen(file->ConnectionString2);
-		if (fwrite(file->ConnectionString2, size, 1, fp) != 1 || fwrite("\r\n", 2, 1, fp) != 1)
+		if (FAILED(hr))
 		{
-			fclose(fp);
-			WLog_ERR(TAG, "Problem writing to inv.xml");
+			WLog_ERR(TAG, "IRDPSRAPIInvitation::get_ConnectionString() failure: 0x%08lX", hr);
 			return -1;
 		}
-		fclose(fp);
-	}
-#endif
 
+		status1 = ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) bstrConnectionString,
+		                             ((UINT32*) bstrConnectionString)[-1], &(ConnectionString2), 0, NULL, NULL);
+		SysFreeString(bstrConnectionString);
+		status2 = freerdp_assistance_set_connection_string2(file, ConnectionString2, "Shadow123!");
+		free(ConnectionString2);
+
+		if ((status1 < 1) || (status < 0))
+		{
+			WLog_ERR(TAG, "failed to convert connection string");
+			return -1;
+		}
+	}
+
+	freerdp_assistance_print_file(file, WLog_Get(TAG), WLOG_INFO);
 	status = win_shadow_rdp_init(subsystem);
 
 	if (status < 0)
@@ -806,24 +771,12 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 	}
 
 	settings = subsystem->shw->settings;
-
-	freerdp_set_param_bool(settings, FreeRDP_RemoteAssistanceMode, TRUE);
-
-	freerdp_set_param_string(settings, FreeRDP_RemoteAssistanceSessionId, file->RASessionId);
-
-	freerdp_set_param_string(settings, FreeRDP_RemoteAssistanceRCTicket, file->ConnectionString2);
-
+	status = freerdp_assistance_populate_settings_from_assistance_file(file, settings);
 	freerdp_set_param_string(settings, FreeRDP_Domain, "RDP");
 	freerdp_set_param_string(settings, FreeRDP_Username, "Shadow");
-	freerdp_set_param_string(settings, FreeRDP_RemoteAssistancePassword, "Shadow123!");
 	freerdp_set_param_bool(settings, FreeRDP_AutoLogonEnabled, TRUE);
-
-	freerdp_set_param_string(settings, FreeRDP_ServerHostname, file->MachineAddress);
-	freerdp_set_param_uint32(settings, FreeRDP_ServerPort, file->MachinePort);
-
 	freerdp_set_param_uint32(settings, FreeRDP_DesktopWidth, width);
 	freerdp_set_param_uint32(settings, FreeRDP_DesktopHeight, height);
-
 	status = win_shadow_rdp_start(subsystem);
 
 	if (status < 0)


### PR DESCRIPTION
Fixes #4987 

* Adds parsing support for newer encrypted `msrcIncident` files.
* Parsing and settings initialization now unified in `assistance` file module

Testing:
1. goto `System Properties/Remote Tab`
1. Check `Allow Remote Assistance connections to this computer`
1. Click the `Advanced...` Button
1. Check `Create invitations that can only be used from computers running Windows Vista or later`

Run:
1. Start `msra`
1. Click `Invite someone you trust to help you`
1. Click `Save this invitation as a file`
1. Remember the password and copy the file to your client test machine
1. Connect using `xfreerpd <file>.msrcIncident /assistance:<password>`, add `/cert-ignore` if the certificate is not already trusted.

1. Uncheck `Create invitations that can only be used from computers running Windows Vista or later` and repeat this test