### PR TITLE
Add icons for Remote Apps on xfreerdp

### DIFF
--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -22,6 +22,7 @@
 #endif
 
 #include <X11/Xlib.h>
+#include <X11/Xatom.h>
 #include <X11/Xutil.h>
 
 #include <winpr/wlog.h>
@@ -610,15 +611,206 @@ static xfRailIcon* RailIconCache_Lookup(xfRailIconCache* cache,
 	return &cache->entries[cache->numCacheEntries * cacheId + cacheEntry];
 }
 
+static inline UINT32 read_color_quad(const BYTE* pixels)
+{
+	return (((UINT32) pixels[0]) << 24)
+	     | (((UINT32) pixels[1]) << 16)
+	     | (((UINT32) pixels[2]) << 8)
+	     | (((UINT32) pixels[3]) << 0);
+}
+
+/*
+ * DIB color palettes are arrays of RGBQUAD structs with colors in BGRX format.
+ * They are used only by 1, 2, 4, and 8-bit bitmaps.
+ */
+static void fill_gdi_palette_for_icon(ICON_INFO* iconInfo, gdiPalette *palette)
+{
+	UINT32 i;
+
+	palette->format = PIXEL_FORMAT_BGRX32;
+	ZeroMemory(palette->palette, sizeof(palette->palette));
+
+	if (!iconInfo->cbColorTable)
+		return;
+
+	if ((iconInfo->cbColorTable % 4 != 0) || (iconInfo->cbColorTable / 4 > 256))
+	{
+		WLog_WARN(TAG, "weird palette size: %u", iconInfo->cbColorTable);
+		return;
+	}
+
+	for (i = 0; i < iconInfo->cbColorTable / 4; i++)
+	{
+		palette->palette[i] = read_color_quad(&iconInfo->colorTable[4 * i]);
+	}
+}
+
+static BOOL convert_icon_color_to_argb(ICON_INFO* iconInfo, BYTE* argbPixels)
+{
+	DWORD format;
+	gdiPalette palette;
+
+	/*
+	 * Color formats used by icons are DIB bitmap formats (2-bit format
+	 * is not used by MS-RDPERP). Note that 16-bit is RGB555, not RGB565,
+	 * and that 32-bit format uses BGRA order.
+	 */
+	switch (iconInfo->bpp)
+	{
+	case 1:
+	case 4:
+		/*
+		 * These formats are not supported by freerdp_image_copy().
+		 * PIXEL_FORMAT_MONO and PIXEL_FORMAT_A4 are *not* correct
+		 * color formats for this. Please fix freerdp_image_copy()
+		 * if you came here to fix a broken icon of some weird app
+		 * that still uses 1 or 4bpp format in the 21st century.
+		 */
+		WLog_WARN(TAG, "1bpp and 4bpp icons are not supported");
+		return FALSE;
+	case 8:
+		format = PIXEL_FORMAT_RGB8;
+		break;
+	case 16:
+		format = PIXEL_FORMAT_RGB15;
+		break;
+	case 24:
+		format = PIXEL_FORMAT_RGB24;
+		break;
+	case 32:
+		format = PIXEL_FORMAT_BGRA32;
+		break;
+	default:
+		WLog_WARN(TAG, "invalid icon bpp: %d", iconInfo->bpp);
+		return FALSE;
+	}
+
+	fill_gdi_palette_for_icon(iconInfo, &palette);
+
+	return freerdp_image_copy(
+		argbPixels,
+		PIXEL_FORMAT_ARGB32,
+		0, 0, 0,
+		iconInfo->width,
+		iconInfo->height,
+		iconInfo->bitsColor,
+		format,
+		0, 0, 0,
+		&palette,
+		FREERDP_FLIP_VERTICAL
+	);
+}
+
+static inline UINT32 div_ceil(UINT32 a, UINT32 b)
+{
+	return (a + (b - 1)) / b;
+}
+
+static inline UINT32 round_up(UINT32 a, UINT32 b)
+{
+	return b * div_ceil(a, b);
+}
+
+static void apply_icon_alpha_mask(ICON_INFO* iconInfo, BYTE* argbPixels)
+{
+	BYTE nextBit;
+	BYTE* maskByte;
+	UINT32 x, y;
+	UINT32 stride;
+
+	if (!iconInfo->cbBitsMask)
+		return;
+
+	/*
+	 * Each byte encodes 8 adjacent pixels (with LSB padding as needed).
+	 * And due to hysterical raisins, stride of DIB bitmaps must be
+	 * a multiple of 4 bytes.
+	 */
+	stride = round_up(div_ceil(iconInfo->width, 8), 4);
+
+	for (y = 0; y < iconInfo->height; y++)
+	{
+		/* ɐᴉlɐɹʇsn∀ uᴉ ǝɹ,ǝʍ ʇɐɥʇ ʇǝƃɹoɟ ʇ,uop */
+		maskByte = &iconInfo->bitsMask[stride * (iconInfo->height - 1 - y)];
+		nextBit = 0x80;
+
+		for (x = 0; x < iconInfo->width; x++)
+		{
+			BYTE alpha = (*maskByte & nextBit) ? 0x00 : 0xFF;
+			argbPixels[4 * (x + y * iconInfo->width)] &= alpha;
+
+			nextBit >>= 1;
+			if (!nextBit)
+			{
+				nextBit = 0x80;
+				maskByte++;
+			}
+		}
+	}
+}
+
+/*
+ * _NET_WM_ICON format is defined as "array of CARDINAL" values which for
+ * Xlib must be represented with an array of C's "long" values. Note that
+ * "long" != "INT32" on 64-bit systems. Therefore we can't simply cast
+ * the bitmap data as (unsigned char*), we have to copy all the pixels.
+ *
+ * The first two values are width and height followed by actual color data
+ * in ARGB format (e.g., 0xFFFF0000L is opaque red), pixels are in normal,
+ * left-to-right top-down order.
+ */
 static BOOL convert_rail_icon(ICON_INFO* iconInfo, xfRailIcon *railIcon)
 {
+	BYTE* argbPixels;
+	BYTE* nextPixel;
+	long* pixels;
+	int i;
+	int nelements;
+
+	argbPixels = calloc(iconInfo->width * iconInfo->height, 4);
+	if (!argbPixels)
+		goto error;
+
+	if (!convert_icon_color_to_argb(iconInfo, argbPixels))
+		goto error;
+
+	apply_icon_alpha_mask(iconInfo, argbPixels);
+
+	nelements = 2 + iconInfo->width * iconInfo->height;
+	pixels = realloc(railIcon->data, nelements * sizeof(*pixels));
+	if (!pixels)
+		goto error;
+
+	railIcon->data = pixels;
+	railIcon->length = nelements;
+
+	pixels[0] = iconInfo->width;
+	pixels[1] = iconInfo->height;
+
+	nextPixel = argbPixels;
+	for (i = 2; i < nelements; i++)
+	{
+		pixels[i] = read_color_quad(nextPixel);
+		nextPixel += 4;
+	}
+
+	free(argbPixels);
+
 	return TRUE;
+
+error:
+	free(argbPixels);
+	return FALSE;
 }
 
 static void xf_rail_set_window_icon(xfContext* xfc,
                                     xfAppWindow* railWindow, xfRailIcon *icon,
                                     BOOL replace)
 {
+	XChangeProperty(xfc->display, railWindow->handle, xfc->_NET_WM_ICON,
+		XA_CARDINAL, 32, replace ? PropModeReplace : PropModeAppend,
+		(unsigned char*) icon->data, icon->length);
+	XFlush(xfc->display);
 }
 
 static xfAppWindow* xf_rail_get_window_by_id(xfContext* xfc, UINT32 windowId)

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -996,43 +996,6 @@ void xf_ShowWindow(xfContext* xfc, xfAppWindow* appWindow, BYTE state)
 	XFlush(xfc->display);
 }
 
-#if 0
-void xf_SetWindowIcon(xfContext* xfc, xfAppWindow* appWindow, rdpIcon* icon)
-{
-	int x, y;
-	int pixels;
-	int propsize;
-	long* propdata;
-	long* dstp;
-	UINT32* srcp;
-
-	if (!icon->big)
-		return;
-
-	pixels = icon->entry->width * icon->entry->height;
-	propsize = 2 + pixels;
-	propdata = malloc(propsize * sizeof(long));
-	propdata[0] = icon->entry->width;
-	propdata[1] = icon->entry->height;
-	dstp = &(propdata[2]);
-	srcp = (UINT32*) icon->extra;
-
-	for (y = 0; y < icon->entry->height; y++)
-	{
-		for (x = 0; x < icon->entry->width; x++)
-		{
-			*dstp++ = *srcp++;
-		}
-	}
-
-	XChangeProperty(xfc->display, appWindow->handle, xfc->_NET_WM_ICON, XA_CARDINAL,
-	                32,
-	                PropModeReplace, (BYTE*) propdata, propsize);
-	XFlush(xfc->display);
-	free(propdata);
-}
-#endif
-
 void xf_SetWindowRects(xfContext* xfc, xfAppWindow* appWindow,
                        RECTANGLE_16* rects, int nrects)
 {

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -83,6 +83,7 @@ typedef struct xf_glyph xfGlyph;
 typedef struct xf_clipboard xfClipboard;
 typedef struct _xfDispContext xfDispContext;
 typedef struct _xfVideoContext xfVideoContext;
+typedef struct xf_rail_icon_cache xfRailIconCache;
 
 /* Value of the first logical button number in X11 which must be */
 /* subtracted to go from a button number in X11 to an index into */
@@ -225,6 +226,7 @@ struct xf_context
 
 	RailClientContext* rail;
 	wHashTable* railWindows;
+	xfRailIconCache* railIconCache;
 
 	BOOL xkbAvailable;
 	BOOL xrenderAvailable;

--- a/libfreerdp/core/window.c
+++ b/libfreerdp/core/window.c
@@ -86,8 +86,8 @@ BOOL update_read_icon_info(wStream* s, ICON_INFO* iconInfo)
 	Stream_Read_UINT16(s, iconInfo->width); /* width (2 bytes) */
 	Stream_Read_UINT16(s, iconInfo->height); /* height (2 bytes) */
 
-	/* cbColorTable is only present when bpp is 1, 2 or 4 */
-	if (iconInfo->bpp == 1 || iconInfo->bpp == 2 || iconInfo->bpp == 4)
+	/* cbColorTable is only present when bpp is 1, 4 or 8 */
+	if (iconInfo->bpp == 1 || iconInfo->bpp == 4 || iconInfo->bpp == 8)
 	{
 		if (Stream_GetRemainingLength(s) < 2)
 			return FALSE;


### PR DESCRIPTION
Now remote applications can actually have icons! :tada: 

![rail-icons](https://user-images.githubusercontent.com/1256587/48378652-07a03900-e6da-11e8-865d-58921d2cd55a.png)

I've implemented the stubs for icon cache callbacks, added some color conversion code, and fixed a couple of bugs. More technical details and rants are in commit messages and comments.

This works at least on my Ubuntu 14.04 and Ubuntu 18.04 with the only RAIL-capable VM that I have (Windows 7 Ultimate). More testing would be appreciated.

Issue #4984 should be partially resolved by this. (There seems to be an issue with app names on GNOME 3, but that may be a separate issue because GNOME 2 is fine.)