### PR TITLE
fix [rpm/freerdp-nightly]: build dependencies

### DIFF
--- a/packaging/rpm/freerdp-nightly.spec
+++ b/packaging/rpm/freerdp-nightly.spec
@@ -63,7 +63,7 @@ BuildRequires: wayland-devel
 BuildRequires: libjpeg-devel
 BuildRequires: libavutil-devel
 BuildRequires: libavcodec-devel
-BuildRequires: libswresample-devel || libavresample-devel
+BuildRequires: libswresample-devel
 %endif
 # fedora 21+
 %if 0%{?fedora} >= 21 || 0%{?rhel} >= 7


### PR DESCRIPTION
Depend on libswresample-devel not libavresample-dev.
This reverts the behavior introduced in fbe95209e72265af07dd426e0def7e3a9082fb4e.