### PR TITLE
Rail app icons

### DIFF
--- a/channels/rail/rail_common.c
+++ b/channels/rail/rail_common.c
@@ -62,7 +62,7 @@ BOOL rail_string_to_unicode_string(const char* string, RAIL_UNICODE_STRING* unic
 	if (!string || strlen(string) < 1)
 		return TRUE;
 
-	length = ConvertToUnicode(CP_UTF8, 0, string, -1, &buffer, 0) * 2;
+	length = ConvertToUnicode(CP_UTF8, 0, string, -1, &buffer, 0);
 
 	if ((length < 0) || ((size_t)length * sizeof(WCHAR) > UINT16_MAX))
 	{

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -22,6 +22,7 @@
 #endif
 
 #include <X11/Xlib.h>
+#include <X11/Xatom.h>
 #include <X11/Xutil.h>
 
 #include <winpr/wlog.h>
@@ -610,15 +611,206 @@ static xfRailIcon* RailIconCache_Lookup(xfRailIconCache* cache,
 	return &cache->entries[cache->numCacheEntries * cacheId + cacheEntry];
 }
 
+static inline UINT32 read_color_quad(const BYTE* pixels)
+{
+	return (((UINT32) pixels[0]) << 24)
+	     | (((UINT32) pixels[1]) << 16)
+	     | (((UINT32) pixels[2]) << 8)
+	     | (((UINT32) pixels[3]) << 0);
+}
+
+/*
+ * DIB color palettes are arrays of RGBQUAD structs with colors in BGRX format.
+ * They are used only by 1, 2, 4, and 8-bit bitmaps.
+ */
+static void fill_gdi_palette_for_icon(ICON_INFO* iconInfo, gdiPalette *palette)
+{
+	UINT32 i;
+
+	palette->format = PIXEL_FORMAT_BGRX32;
+	ZeroMemory(palette->palette, sizeof(palette->palette));
+
+	if (!iconInfo->cbColorTable)
+		return;
+
+	if ((iconInfo->cbColorTable % 4 != 0) || (iconInfo->cbColorTable / 4 > 256))
+	{
+		WLog_WARN(TAG, "weird palette size: %u", iconInfo->cbColorTable);
+		return;
+	}
+
+	for (i = 0; i < iconInfo->cbColorTable / 4; i++)
+	{
+		palette->palette[i] = read_color_quad(&iconInfo->colorTable[4 * i]);
+	}
+}
+
+static BOOL convert_icon_color_to_argb(ICON_INFO* iconInfo, BYTE* argbPixels)
+{
+	DWORD format;
+	gdiPalette palette;
+
+	/*
+	 * Color formats used by icons are DIB bitmap formats (2-bit format
+	 * is not used by MS-RDPERP). Note that 16-bit is RGB555, not RGB565,
+	 * and that 32-bit format uses BGRA order.
+	 */
+	switch (iconInfo->bpp)
+	{
+	case 1:
+	case 4:
+		/*
+		 * These formats are not supported by freerdp_image_copy().
+		 * PIXEL_FORMAT_MONO and PIXEL_FORMAT_A4 are *not* correct
+		 * color formats for this. Please fix freerdp_image_copy()
+		 * if you came here to fix a broken icon of some weird app
+		 * that still uses 1 or 4bpp format in the 21st century.
+		 */
+		WLog_WARN(TAG, "1bpp and 4bpp icons are not supported");
+		return FALSE;
+	case 8:
+		format = PIXEL_FORMAT_RGB8;
+		break;
+	case 16:
+		format = PIXEL_FORMAT_RGB15;
+		break;
+	case 24:
+		format = PIXEL_FORMAT_RGB24;
+		break;
+	case 32:
+		format = PIXEL_FORMAT_BGRA32;
+		break;
+	default:
+		WLog_WARN(TAG, "invalid icon bpp: %d", iconInfo->bpp);
+		return FALSE;
+	}
+
+	fill_gdi_palette_for_icon(iconInfo, &palette);
+
+	return freerdp_image_copy(
+		argbPixels,
+		PIXEL_FORMAT_ARGB32,
+		0, 0, 0,
+		iconInfo->width,
+		iconInfo->height,
+		iconInfo->bitsColor,
+		format,
+		0, 0, 0,
+		&palette,
+		FREERDP_FLIP_VERTICAL
+	);
+}
+
+static inline UINT32 div_ceil(UINT32 a, UINT32 b)
+{
+	return (a + (b - 1)) / b;
+}
+
+static inline UINT32 round_up(UINT32 a, UINT32 b)
+{
+	return b * div_ceil(a, b);
+}
+
+static void apply_icon_alpha_mask(ICON_INFO* iconInfo, BYTE* argbPixels)
+{
+	BYTE nextBit;
+	BYTE* maskByte;
+	UINT32 x, y;
+	UINT32 stride;
+
+	if (!iconInfo->cbBitsMask)
+		return;
+
+	/*
+	 * Each byte encodes 8 adjacent pixels (with LSB padding as needed).
+	 * And due to hysterical raisins, stride of DIB bitmaps must be
+	 * a multiple of 4 bytes.
+	 */
+	stride = round_up(div_ceil(iconInfo->width, 8), 4);
+
+	for (y = 0; y < iconInfo->height; y++)
+	{
+		/* ɐᴉlɐɹʇsn∀ uᴉ ǝɹ,ǝʍ ʇɐɥʇ ʇǝƃɹoɟ ʇ,uop */
+		maskByte = &iconInfo->bitsMask[stride * (iconInfo->height - 1 - y)];
+		nextBit = 0x80;
+
+		for (x = 0; x < iconInfo->width; x++)
+		{
+			BYTE alpha = (*maskByte & nextBit) ? 0x00 : 0xFF;
+			argbPixels[4 * (x + y * iconInfo->width)] &= alpha;
+
+			nextBit >>= 1;
+			if (!nextBit)
+			{
+				nextBit = 0x80;
+				maskByte++;
+			}
+		}
+	}
+}
+
+/*
+ * _NET_WM_ICON format is defined as "array of CARDINAL" values which for
+ * Xlib must be represented with an array of C's "long" values. Note that
+ * "long" != "INT32" on 64-bit systems. Therefore we can't simply cast
+ * the bitmap data as (unsigned char*), we have to copy all the pixels.
+ *
+ * The first two values are width and height followed by actual color data
+ * in ARGB format (e.g., 0xFFFF0000L is opaque red), pixels are in normal,
+ * left-to-right top-down order.
+ */
 static BOOL convert_rail_icon(ICON_INFO* iconInfo, xfRailIcon *railIcon)
 {
+	BYTE* argbPixels;
+	BYTE* nextPixel;
+	long* pixels;
+	int i;
+	int nelements;
+
+	argbPixels = calloc(iconInfo->width * iconInfo->height, 4);
+	if (!argbPixels)
+		goto error;
+
+	if (!convert_icon_color_to_argb(iconInfo, argbPixels))
+		goto error;
+
+	apply_icon_alpha_mask(iconInfo, argbPixels);
+
+	nelements = 2 + iconInfo->width * iconInfo->height;
+	pixels = realloc(railIcon->data, nelements * sizeof(*pixels));
+	if (!pixels)
+		goto error;
+
+	railIcon->data = pixels;
+	railIcon->length = nelements;
+
+	pixels[0] = iconInfo->width;
+	pixels[1] = iconInfo->height;
+
+	nextPixel = argbPixels;
+	for (i = 2; i < nelements; i++)
+	{
+		pixels[i] = read_color_quad(nextPixel);
+		nextPixel += 4;
+	}
+
+	free(argbPixels);
+
 	return TRUE;
+
+error:
+	free(argbPixels);
+	return FALSE;
 }
 
 static void xf_rail_set_window_icon(xfContext* xfc,
                                     xfAppWindow* railWindow, xfRailIcon *icon,
                                     BOOL replace)
 {
+	XChangeProperty(xfc->display, railWindow->handle, xfc->_NET_WM_ICON,
+		XA_CARDINAL, 32, replace ? PropModeReplace : PropModeAppend,
+		(unsigned char*) icon->data, icon->length);
+	XFlush(xfc->display);
 }
 
 static xfAppWindow* xf_rail_get_window_by_id(xfContext* xfc, UINT32 windowId)

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -996,43 +996,6 @@ void xf_ShowWindow(xfContext* xfc, xfAppWindow* appWindow, BYTE state)
 	XFlush(xfc->display);
 }
 
-#if 0
-void xf_SetWindowIcon(xfContext* xfc, xfAppWindow* appWindow, rdpIcon* icon)
-{
-	int x, y;
-	int pixels;
-	int propsize;
-	long* propdata;
-	long* dstp;
-	UINT32* srcp;
-
-	if (!icon->big)
-		return;
-
-	pixels = icon->entry->width * icon->entry->height;
-	propsize = 2 + pixels;
-	propdata = malloc(propsize * sizeof(long));
-	propdata[0] = icon->entry->width;
-	propdata[1] = icon->entry->height;
-	dstp = &(propdata[2]);
-	srcp = (UINT32*) icon->extra;
-
-	for (y = 0; y < icon->entry->height; y++)
-	{
-		for (x = 0; x < icon->entry->width; x++)
-		{
-			*dstp++ = *srcp++;
-		}
-	}
-
-	XChangeProperty(xfc->display, appWindow->handle, xfc->_NET_WM_ICON, XA_CARDINAL,
-	                32,
-	                PropModeReplace, (BYTE*) propdata, propsize);
-	XFlush(xfc->display);
-	free(propdata);
-}
-#endif
-
 void xf_SetWindowRects(xfContext* xfc, xfAppWindow* appWindow,
                        RECTANGLE_16* rects, int nrects)
 {

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -83,6 +83,7 @@ typedef struct xf_glyph xfGlyph;
 typedef struct xf_clipboard xfClipboard;
 typedef struct _xfDispContext xfDispContext;
 typedef struct _xfVideoContext xfVideoContext;
+typedef struct xf_rail_icon_cache xfRailIconCache;
 
 /* Value of the first logical button number in X11 which must be */
 /* subtracted to go from a button number in X11 to an index into */
@@ -225,6 +226,7 @@ struct xf_context
 
 	RailClientContext* rail;
 	wHashTable* railWindows;
+	xfRailIconCache* railIconCache;
 
 	BOOL xkbAvailable;
 	BOOL xrenderAvailable;

--- a/libfreerdp/core/window.c
+++ b/libfreerdp/core/window.c
@@ -86,8 +86,8 @@ BOOL update_read_icon_info(wStream* s, ICON_INFO* iconInfo)
 	Stream_Read_UINT16(s, iconInfo->width); /* width (2 bytes) */
 	Stream_Read_UINT16(s, iconInfo->height); /* height (2 bytes) */
 
-	/* cbColorTable is only present when bpp is 1, 2 or 4 */
-	if (iconInfo->bpp == 1 || iconInfo->bpp == 2 || iconInfo->bpp == 4)
+	/* cbColorTable is only present when bpp is 1, 4 or 8 */
+	if (iconInfo->bpp == 1 || iconInfo->bpp == 4 || iconInfo->bpp == 8)
 	{
 		if (Stream_GetRemainingLength(s) < 2)
 			return FALSE;

--- a/libfreerdp/core/window.c
+++ b/libfreerdp/core/window.c
@@ -66,6 +66,7 @@ BOOL rail_read_unicode_string(wStream* s, RAIL_UNICODE_STRING* unicode_string)
 	return TRUE;
 }
 
+/* See [MS-RDPERP] 2.2.1.2.3 Icon Info (TS_ICON_INFO) */
 static BOOL update_read_icon_info(wStream* s, ICON_INFO* iconInfo)
 {
 	BYTE* newBitMask;
@@ -87,16 +88,20 @@ static BOOL update_read_icon_info(wStream* s, ICON_INFO* iconInfo)
 	Stream_Read_UINT16(s, iconInfo->height); /* height (2 bytes) */
 
 	/* cbColorTable is only present when bpp is 1, 4 or 8 */
-	if (iconInfo->bpp == 1 || iconInfo->bpp == 4 || iconInfo->bpp == 8)
+	switch (iconInfo->bpp)
 	{
-		if (Stream_GetRemainingLength(s) < 2)
-			return FALSE;
+		case 1:
+		case 4:
+		case 8:
+			if (Stream_GetRemainingLength(s) < 2)
+				return FALSE;
 
-		Stream_Read_UINT16(s, iconInfo->cbColorTable); /* cbColorTable (2 bytes) */
-	}
-	else
-	{
-		iconInfo->cbColorTable = 0;
+			Stream_Read_UINT16(s, iconInfo->cbColorTable); /* cbColorTable (2 bytes) */
+			break;
+
+		default:
+			iconInfo->cbColorTable = 0;
+			break;
 	}
 
 	if (Stream_GetRemainingLength(s) < 4)

--- a/libfreerdp/core/window.c
+++ b/libfreerdp/core/window.c
@@ -66,7 +66,7 @@ BOOL rail_read_unicode_string(wStream* s, RAIL_UNICODE_STRING* unicode_string)
 	return TRUE;
 }
 
-BOOL update_read_icon_info(wStream* s, ICON_INFO* iconInfo)
+static BOOL update_read_icon_info(wStream* s, ICON_INFO* iconInfo)
 {
 	BYTE* newBitMask;
 
@@ -170,7 +170,7 @@ BOOL update_read_icon_info(wStream* s, ICON_INFO* iconInfo)
 	return TRUE;
 }
 
-BOOL update_read_cached_icon_info(wStream* s, CACHED_ICON_INFO* cachedIconInfo)
+static BOOL update_read_cached_icon_info(wStream* s, CACHED_ICON_INFO* cachedIconInfo)
 {
 	if (Stream_GetRemainingLength(s) < 3)
 		return FALSE;
@@ -180,7 +180,7 @@ BOOL update_read_cached_icon_info(wStream* s, CACHED_ICON_INFO* cachedIconInfo)
 	return TRUE;
 }
 
-BOOL update_read_notify_icon_infotip(wStream* s, NOTIFY_ICON_INFOTIP* notifyIconInfoTip)
+static BOOL update_read_notify_icon_infotip(wStream* s, NOTIFY_ICON_INFOTIP* notifyIconInfoTip)
 {
 	if (Stream_GetRemainingLength(s) < 8)
 		return FALSE;
@@ -191,8 +191,8 @@ BOOL update_read_notify_icon_infotip(wStream* s, NOTIFY_ICON_INFOTIP* notifyIcon
 	       rail_read_unicode_string(s, &notifyIconInfoTip->title); /* title */
 }
 
-BOOL update_read_window_state_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
-                                    WINDOW_STATE_ORDER* windowState)
+static BOOL update_read_window_state_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
+        WINDOW_STATE_ORDER* windowState)
 {
 	int i;
 	int size;
@@ -376,8 +376,8 @@ BOOL update_read_window_state_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
 	return TRUE;
 }
 
-BOOL update_read_window_icon_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
-                                   WINDOW_ICON_ORDER* window_icon)
+static BOOL update_read_window_icon_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
+        WINDOW_ICON_ORDER* window_icon)
 {
 	update_free_window_icon_info(window_icon->iconInfo);
 	window_icon->iconInfo = (ICON_INFO*) calloc(1, sizeof(ICON_INFO));
@@ -388,19 +388,20 @@ BOOL update_read_window_icon_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
 	return update_read_icon_info(s, window_icon->iconInfo); /* iconInfo (ICON_INFO) */
 }
 
-BOOL update_read_window_cached_icon_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
+static BOOL update_read_window_cached_icon_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
         WINDOW_CACHED_ICON_ORDER* window_cached_icon)
 {
 	return update_read_cached_icon_info(s,
 	                                    &window_cached_icon->cachedIcon); /* cachedIcon (CACHED_ICON_INFO) */
 }
 
-void update_read_window_delete_order(wStream* s, WINDOW_ORDER_INFO* orderInfo)
+static void update_read_window_delete_order(wStream* s, WINDOW_ORDER_INFO* orderInfo)
 {
 	/* window deletion event */
 }
 
-BOOL update_recv_window_info_order(rdpUpdate* update, wStream* s, WINDOW_ORDER_INFO* orderInfo)
+static BOOL update_recv_window_info_order(rdpUpdate* update, wStream* s,
+        WINDOW_ORDER_INFO* orderInfo)
 {
 	rdpContext* context = update->context;
 	rdpWindowUpdate* window = update->window;
@@ -453,7 +454,7 @@ BOOL update_recv_window_info_order(rdpUpdate* update, wStream* s, WINDOW_ORDER_I
 	return result;
 }
 
-BOOL update_read_notification_icon_state_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
+static BOOL update_read_notification_icon_state_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
         NOTIFY_ICON_STATE_ORDER* notify_icon_state)
 {
 	if (orderInfo->fieldFlags & WINDOW_ORDER_FIELD_NOTIFY_VERSION)
@@ -501,12 +502,12 @@ BOOL update_read_notification_icon_state_order(wStream* s, WINDOW_ORDER_INFO* or
 	return TRUE;
 }
 
-void update_read_notification_icon_delete_order(wStream* s, WINDOW_ORDER_INFO* orderInfo)
+static void update_read_notification_icon_delete_order(wStream* s, WINDOW_ORDER_INFO* orderInfo)
 {
 	/* notification icon deletion event */
 }
 
-BOOL update_recv_notification_icon_info_order(rdpUpdate* update, wStream* s,
+static BOOL update_recv_notification_icon_info_order(rdpUpdate* update, wStream* s,
         WINDOW_ORDER_INFO* orderInfo)
 {
 	rdpContext* context = update->context;
@@ -545,7 +546,7 @@ BOOL update_recv_notification_icon_info_order(rdpUpdate* update, wStream* s,
 	return result;
 }
 
-BOOL update_read_desktop_actively_monitored_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
+static BOOL update_read_desktop_actively_monitored_order(wStream* s, WINDOW_ORDER_INFO* orderInfo,
         MONITORED_DESKTOP_ORDER* monitored_desktop)
 {
 	int i;
@@ -596,12 +597,13 @@ BOOL update_read_desktop_actively_monitored_order(wStream* s, WINDOW_ORDER_INFO*
 	return TRUE;
 }
 
-void update_read_desktop_non_monitored_order(wStream* s, WINDOW_ORDER_INFO* orderInfo)
+static void update_read_desktop_non_monitored_order(wStream* s, WINDOW_ORDER_INFO* orderInfo)
 {
 	/* non-monitored desktop notification event */
 }
 
-BOOL update_recv_desktop_info_order(rdpUpdate* update, wStream* s, WINDOW_ORDER_INFO* orderInfo)
+static BOOL update_recv_desktop_info_order(rdpUpdate* update, wStream* s,
+        WINDOW_ORDER_INFO* orderInfo)
 {
 	rdpContext* context = update->context;
 	rdpWindowUpdate* window = update->window;


### PR DESCRIPTION
Superseeds #5003, incorporates a fix for `rail_string_to_unicode` and review issues.
@hardening chaning the buffer type from `long` to `UINT32` changes behaviour with the X11 api (the icon no longer works)