### PR TITLE
cmdline: add window-position argument to set initial window position

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -173,8 +173,8 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 		xfc->savedHeight = xfc->window->height;
 		xfc->savedPosX = xfc->window->left;
 		xfc->savedPosY = xfc->window->top;
-		startX = settings->DesktopPosX;
-		startY = settings->DesktopPosY;
+		startX = (settings->DesktopPosX != UINT32_MAX) ? settings->DesktopPosX : 0;
+		startY = (settings->DesktopPosY != UINT32_MAX) ? settings->DesktopPosY : 0;
 	}
 	else
 	{
@@ -580,7 +580,7 @@ xfWindow* xf_CreateDesktopWindow(xfContext* xfc, char* name, int width,
 	{
 		XMoveWindow(xfc->display, window->handle, 0, 0);
 	}
-	else if (settings->DesktopPosX || settings->DesktopPosY)
+	else if (settings->DesktopPosX != UINT32_MAX && settings->DesktopPosY != UINT32_MAX)
 	{
 		XMoveWindow(xfc->display, window->handle, settings->DesktopPosX,
 		            settings->DesktopPosY);

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -182,6 +182,7 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "w", COMMAND_LINE_VALUE_REQUIRED, "<width>", "1024", NULL, -1, NULL, "Width" },
 	{ "wallpaper", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "wallpaper" },
 	{ "window-drag", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "full window drag" },
+	{ "window-position", COMMAND_LINE_VALUE_REQUIRED, "<xpos>x<ypos>", NULL, NULL, -1, NULL, "window position" },
 	{ "wm-class", COMMAND_LINE_VALUE_REQUIRED, "<class-name>", NULL, NULL, -1, NULL, "Set the WM_CLASS hint for the window instance" },
 	{ "workarea", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Use available work area" },
 	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -320,8 +320,8 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	settings->DesktopResize = TRUE;
 	settings->ToggleFullscreen = TRUE;
 	settings->Floatbar = TRUE;
-	settings->DesktopPosX = 0;
-	settings->DesktopPosY = 0;
+	settings->DesktopPosX = UINT32_MAX;
+	settings->DesktopPosY = UINT32_MAX;
 	settings->SoftwareGdi = TRUE;
 	settings->UnmapButtons = FALSE;
 	settings->PerformanceFlags = PERF_FLAG_NONE;


### PR DESCRIPTION
This is useful if you want the window to be at a given position. The patch also mutualizes the parsing of <xpos>x<ypos> or <width>x<height> arguments.