### PR TITLE
call xf_SetWindowTitle before XMapWindow

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -558,6 +558,7 @@ xfWindow* xf_CreateDesktopWindow(xfContext* xfc, char* name, int width,
 
 	XSelectInput(xfc->display, window->handle, input_mask);
 	XClearWindow(xfc->display, window->handle);
+	xf_SetWindowTitleText(xfc, window->handle, name);
 	XMapWindow(xfc->display, window->handle);
 	xf_input_init(xfc, window->handle);
 
@@ -587,7 +588,6 @@ xfWindow* xf_CreateDesktopWindow(xfContext* xfc, char* name, int width,
 	}
 
 	window->floatbar = xf_floatbar_new(xfc, window->handle);
-	xf_SetWindowTitleText(xfc, window->handle, name);
 	return window;
 }
 


### PR DESCRIPTION
Need to set window name before mapping, so window managers like fvwm, which allow mapping windows to a  virtual desktop/page based on the window name, can act on it.
