### PR TITLE
Fix #4864: Register pointer cache after PostConnect is called

### DIFF
--- a/client/Android/android_freerdp.c
+++ b/client/Android/android_freerdp.c
@@ -375,7 +375,6 @@ static BOOL android_post_connect(freerdp* instance)
 	instance->update->BeginPaint = android_begin_paint;
 	instance->update->EndPaint = android_end_paint;
 	instance->update->DesktopResize = android_desktop_resize;
-	pointer_cache_register_callbacks(update);
 	freerdp_callback("OnSettingsChanged", "(JIII)V", (jlong)instance,
 	                 settings->DesktopWidth, settings->DesktopHeight,
 	                 settings->ColorDepth);

--- a/client/DirectFB/dfreerdp.c
+++ b/client/DirectFB/dfreerdp.c
@@ -204,7 +204,6 @@ BOOL df_post_connect(freerdp* instance)
 	instance->update->BeginPaint = df_begin_paint;
 	instance->update->EndPaint = df_end_paint;
 	df_keyboard_init();
-	pointer_cache_register_callbacks(instance->update);
 	df_register_graphics(instance->context->graphics);
 	return TRUE;
 }

--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -944,7 +944,6 @@ BOOL mac_post_connect(freerdp* instance)
 
 	gdi = instance->context->gdi;
 	view->bitmap_context = mac_create_bitmap_context(instance->context);
-	pointer_cache_register_callbacks(instance->update);
 	graphics_register_pointer(instance->context->graphics, &rdp_pointer);
 	/* setup pasteboard (aka clipboard) for copy operations (write only) */
 	view->pasteboard_wr = [NSPasteboard generalPasteboard];

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -372,7 +372,6 @@ static BOOL wf_post_connect(freerdp* instance)
 	instance->update->BeginPaint = wf_begin_paint;
 	instance->update->DesktopResize = wf_desktop_resize;
 	instance->update->EndPaint = wf_end_paint;
-	pointer_cache_register_callbacks(instance->update);
 	wf_register_pointer(context->graphics);
 
 	if (!settings->SoftwareGdi)

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1274,7 +1274,6 @@ static BOOL xf_post_connect(freerdp* instance)
 		update->DesktopResize = xf_hw_desktop_resize;
 	}
 
-	pointer_cache_register_callbacks(update);
 	update->PlaySound = xf_play_sound;
 	update->SetKeyboardIndicators = xf_keyboard_set_indicators;
 	update->SetKeyboardImeStatus = xf_keyboard_set_ime_status;

--- a/client/iOS/FreeRDP/ios_freerdp.m
+++ b/client/iOS/FreeRDP/ios_freerdp.m
@@ -258,7 +258,6 @@ static BOOL ios_post_connect(freerdp* instance)
 	instance->update->BeginPaint = ios_ui_begin_paint;
 	instance->update->EndPaint = ios_ui_end_paint;
 	instance->update->DesktopResize = ios_ui_resize_window;
-	pointer_cache_register_callbacks(instance->update);
 	[mfi->session performSelectorOnMainThread:@selector(sessionDidConnect)
 	              withObject:nil waitUntilDone:YES];
 	return TRUE;

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -37,6 +37,7 @@
 #include <freerdp/log.h>
 #include <freerdp/error.h>
 #include <freerdp/listener.h>
+#include <freerdp/cache/pointer.h>
 
 #define TAG FREERDP_TAG("core.connection")
 
@@ -394,6 +395,8 @@ static BOOL rdp_client_reconnect_channels(rdpRdp* rdp, BOOL redirect)
 	{
 		if (redirect)
 			return TRUE;
+
+		pointer_cache_register_callbacks(context->update);
 
 		if (!IFCALLRESULT(FALSE, context->instance->PostConnect, context->instance))
 			return FALSE;

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -48,6 +48,7 @@
 #include <freerdp/channels/channels.h>
 #include <freerdp/version.h>
 #include <freerdp/log.h>
+#include <freerdp/cache/pointer.h>
 
 #define TAG FREERDP_TAG("core")
 
@@ -208,6 +209,7 @@ BOOL freerdp_connect(freerdp* instance)
 
 	if (status)
 	{
+		pointer_cache_register_callbacks(instance->context->update);
 		IFCALLRET(instance->PostConnect, status, instance);
 		instance->ConnectionCallbackState = CLIENT_STATE_POSTCONNECT_PASSED;
 


### PR DESCRIPTION
With #4950 client side pointer implementation was made optional.
This addresses an issue that each client had to call
pointer_cache_register_callbacks on its own.