### PR TITLE
Fixed #2021: Removed *get_fds functions and use.

### DIFF
--- a/client/common/client.c
+++ b/client/common/client.c
@@ -346,7 +346,7 @@ out:
 /** Callback set in the rdp_freerdp structure, and used to get the user's password,
  *  if required to establish the connection.
  *  This function is actually called in credssp_ntlmssp_client_init()
- *  @see rdp_server_accept_nego() and rdp_check_fds()
+ *  @see rdp_server_accept_nego() and rdp_check_event_handles()
  *  @param instance - pointer to the rdp_freerdp structure that contains the connection settings
  *  @param username - unused
  *  @param password - on return: pointer to a character string that will be filled by the password entered by the user.

--- a/client/iOS/FreeRDP/ios_freerdp.h
+++ b/client/iOS/FreeRDP/ios_freerdp.h
@@ -1,8 +1,8 @@
 /*
  RDP run-loop
- 
+
  Copyright 2013 Thincast Technologies GmbH, Authors: Martin Fleisz, Dorian Johnson
- 
+
  This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
  If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
@@ -22,7 +22,7 @@ typedef struct mf_info mfInfo;
 typedef struct mf_context
 {
 	rdpContext _p;
-	
+
 	mfInfo* mfi;
 	rdpSettings* settings;
 } mfContext;
@@ -34,19 +34,20 @@ struct mf_info
 	freerdp* instance;
 	mfContext* context;
 	rdpContext* _context;
-	
+
 	// UI
 	RDPSession* session;
-	
+
 	// Graphics
 	CGContextRef bitmap_context;
-	
+
 	// Events
 	int event_pipe_producer, event_pipe_consumer;
 
 	// Tracking connection state
 	volatile TSXConnectionState connection_state;
 	volatile BOOL unwanted; // set when controlling Session no longer wants the connection to continue
+	HANDLE handle;
 };
 
 
@@ -59,8 +60,8 @@ enum MF_EXIT_CODE
 
 	MF_EXIT_CONN_FAILED = 128,
 	MF_EXIT_CONN_CANCELED = 129,
-    MF_EXIT_LOGON_TIMEOUT = 130,
-	
+	MF_EXIT_LOGON_TIMEOUT = 130,
+
 	MF_EXIT_UNKNOWN = 255
 };
 

--- a/client/iOS/FreeRDP/ios_freerdp_events.h
+++ b/client/iOS/FreeRDP/ios_freerdp_events.h
@@ -1,9 +1,9 @@
 /*
- RDP event queuing 
- 
+ RDP event queuing
+
  Copyright 2013 Thincast Technologies GmbH, Author: Dorian Johnson
- 
- This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. 
+
+ This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
  If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
@@ -14,11 +14,11 @@
 #import "ios_freerdp.h"
 
 // For UI: use to send events
-BOOL ios_events_send(mfInfo* mfi, NSDictionary * event_description);
+BOOL ios_events_send(mfInfo* mfi, NSDictionary* event_description);
 
 // For connection runloop: use to poll for queued input events
-BOOL ios_events_get_fds(mfInfo* mfi, void ** read_fds, int * read_count, void ** write_fds, int * write_count);
-BOOL ios_events_check_fds(mfInfo* mfi, fd_set* rfds);
+HANDLE ios_events_get_event_handle(mfInfo* mfi);
+BOOL ios_events_check_event_handles(mfInfo* mfi);
 BOOL ios_events_create_pipe(mfInfo* mfi);
 void ios_events_free_pipe(mfInfo* mfi);
 

--- a/client/iOS/FreeRDP/ios_freerdp_events.m
+++ b/client/iOS/FreeRDP/ios_freerdp_events.m
@@ -1,9 +1,9 @@
 /*
- RDP event queuing 
- 
+ RDP event queuing
+
  Copyright 2013 Thincast Technologies GmbH, Author: Dorian Johnson
- 
- This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. 
+
+ This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
  If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
@@ -13,133 +13,136 @@
 #pragma mark Sending compacted input events (from main thread)
 
 // While this function may be called from any thread that has an autorelease pool allocated, it is not threadsafe: caller is responsible for synchronization
-BOOL ios_events_send(mfInfo* mfi, NSDictionary * event_description)
-{		
-	NSData * encoded_description = [NSKeyedArchiver archivedDataWithRootObject:event_description];
-	
-	if ([encoded_description length] > 32000 || (mfi->event_pipe_producer == -1) )
+BOOL ios_events_send(mfInfo* mfi, NSDictionary* event_description)
+{
+	NSData* encoded_description = [NSKeyedArchiver archivedDataWithRootObject:event_description];
+
+	if ([encoded_description length] > 32000 || (mfi->event_pipe_producer == -1))
 		return FALSE;
-	
+
 	uint32_t archived_data_len = (uint32_t)[encoded_description length];
-	
+
 	//NSLog(@"writing %d bytes to input event pipe", archived_data_len);
-	
+
 	if (write(mfi->event_pipe_producer, &archived_data_len, 4) == -1)
 	{
 		NSLog(@"%s: Failed to write length descriptor to pipe.", __func__);
 		return FALSE;
 	}
-	
+
 	if (write(mfi->event_pipe_producer, [encoded_description bytes], archived_data_len) == -1)
 	{
-		NSLog(@"%s: Failed to write %d bytes into the event queue (event type: %@).", __func__, (int)[encoded_description length], [event_description objectForKey:@"type"]);
+		NSLog(@"%s: Failed to write %d bytes into the event queue (event type: %@).", __func__,
+		      (int)[encoded_description length], [event_description objectForKey:@"type"]);
 		return FALSE;
 	}
-	
-	return TRUE;	
+
+	return TRUE;
 }
 
 
 #pragma mark -
 #pragma mark Processing compacted input events (from connection thread runloop)
 
-static BOOL ios_events_handle_event(mfInfo* mfi, NSDictionary * event_description)
+static BOOL ios_events_handle_event(mfInfo* mfi, NSDictionary* event_description)
 {
-	NSString * event_type = [event_description objectForKey:@"type"];
+	NSString* event_type = [event_description objectForKey:@"type"];
 	BOOL should_continue = TRUE;
 	freerdp* instance = mfi->instance;
-	
+
 	if ([event_type isEqualToString:@"mouse"])
-	{        
-		instance->input->MouseEvent(instance->input, 
-                                    [[event_description objectForKey:@"flags"] unsignedShortValue],
-                                    [[event_description objectForKey:@"coord_x"] unsignedShortValue],
-                                    [[event_description objectForKey:@"coord_y"] unsignedShortValue]);
+	{
+		instance->input->MouseEvent(instance->input,
+		                            [[event_description objectForKey:@"flags"] unsignedShortValue],
+		                            [[event_description objectForKey:@"coord_x"] unsignedShortValue],
+		                            [[event_description objectForKey:@"coord_y"] unsignedShortValue]);
 	}
 	else if ([event_type isEqualToString:@"keyboard"])
 	{
 		if ([[event_description objectForKey:@"subtype"] isEqualToString:@"scancode"])
-			instance->input->KeyboardEvent(instance->input, 
-                                           [[event_description objectForKey:@"flags"] unsignedShortValue],
-                                           [[event_description objectForKey:@"scancode"] unsignedShortValue]);
+			instance->input->KeyboardEvent(instance->input,
+			                               [[event_description objectForKey:@"flags"] unsignedShortValue],
+			                               [[event_description objectForKey:@"scancode"] unsignedShortValue]);
 		else if ([[event_description objectForKey:@"subtype"] isEqualToString:@"unicode"])
 			instance->input->UnicodeKeyboardEvent(instance->input,
-                                                  [[event_description objectForKey:@"flags"] unsignedShortValue],
-                                                  [[event_description objectForKey:@"unicode_char"] unsignedShortValue]);
+			                                      [[event_description objectForKey:@"flags"] unsignedShortValue],
+			                                      [[event_description objectForKey:@"unicode_char"] unsignedShortValue]);
 		else
-			NSLog(@"%s: doesn't know how to send keyboard input with subtype %@", __func__, [event_description objectForKey:@"subtype"]);
+			NSLog(@"%s: doesn't know how to send keyboard input with subtype %@",
+			      __func__, [event_description objectForKey:@"subtype"]);
 	}
 	else if ([event_type isEqualToString:@"disconnect"])
 		should_continue = FALSE;
 	else
 		NSLog(@"%s: unrecognized event type: %@", __func__, event_type);
-	
+
 	return should_continue;
 }
 
-BOOL ios_events_check_fds(mfInfo* mfi, fd_set* rfds)
-{	
-	if ( (mfi->event_pipe_consumer == -1) || !FD_ISSET(mfi->event_pipe_consumer, rfds))
-		return TRUE;
-	
+BOOL ios_events_check_event_handles(mfInfo* mfi)
+{
 	uint32_t archived_data_length = 0;
 	ssize_t bytes_read;
-	
 	// First, read the length of the blob
 	bytes_read = read(mfi->event_pipe_consumer, &archived_data_length, 4);
-	
+
 	if (bytes_read == -1 || archived_data_length < 1 || archived_data_length > 32000)
 	{
-		NSLog(@"%s: just read length descriptor. bytes_read=%ld, archived_data_length=%u", __func__, bytes_read, archived_data_length);
+		NSLog(@"%s: just read length descriptor. bytes_read=%ld, archived_data_length=%u", __func__,
+		      bytes_read, archived_data_length);
 		return FALSE;
 	}
-	
+
 	//NSLog(@"reading %d bytes from input event pipe", archived_data_length);
-	
-	NSMutableData * archived_object_data = [[NSMutableData alloc] initWithLength:archived_data_length];
-	bytes_read = read(mfi->event_pipe_consumer, [archived_object_data mutableBytes], archived_data_length);
-	
+	NSMutableData* archived_object_data = [[NSMutableData alloc] initWithLength:archived_data_length];
+	bytes_read = read(mfi->event_pipe_consumer, [archived_object_data mutableBytes],
+	                  archived_data_length);
+
 	if (bytes_read != archived_data_length)
 	{
-		NSLog(@"%s: attempted to read data; read %ld bytes but wanted %d bytes.", __func__, bytes_read, archived_data_length);
+		NSLog(@"%s: attempted to read data; read %ld bytes but wanted %d bytes.", __func__, bytes_read,
+		      archived_data_length);
 		[archived_object_data release];
 		return FALSE;
 	}
-	
+
 	id unarchived_object_data = [NSKeyedUnarchiver unarchiveObjectWithData:archived_object_data];
 	[archived_object_data release];
-	
 	return ios_events_handle_event(mfi, unarchived_object_data);
 }
 
-BOOL ios_events_get_fds(mfInfo* mfi, void ** read_fds, int * read_count, void ** write_fds, int * write_count)
+HANDLE ios_events_get_event_handle(mfInfo* mfi)
 {
-	read_fds[*read_count] = (void *)(long)(mfi->event_pipe_consumer);
-	(*read_count)++;
-	return TRUE;
+	if (!mfi)
+		return INVALID_HANDLE_VALUE;
+
+	return mfi->handle;
 }
 
 // Sets up the event pipe
 BOOL ios_events_create_pipe(mfInfo* mfi)
 {
 	int pipe_fds[2];
-	
+
 	if (pipe(pipe_fds) == -1)
 	{
 		NSLog(@"%s: pipe failed.", __func__);
 		return FALSE;
 	}
-	
+
 	mfi->event_pipe_consumer = pipe_fds[0];
 	mfi->event_pipe_producer = pipe_fds[1];
+	mfi->handle = CreateFileDescriptorEvent(NULL, TRUE, FALSE, mfi->event_pipe_consumer, WINPR_FD_READ);
 	return TRUE;
 }
 
 void ios_events_free_pipe(mfInfo* mfi)
 {
 	int consumer_fd = mfi->event_pipe_consumer, producer_fd = mfi->event_pipe_producer;
-	
 	mfi->event_pipe_consumer = mfi->event_pipe_producer = -1;
 	close(producer_fd);
-	close(consumer_fd);	
+	close(consumer_fd);
+
+	if (mfi->handle)
+		CloseHandle(mfi->handle);
 }

--- a/include/freerdp/channels/channels.h
+++ b/include/freerdp/channels/channels.h
@@ -32,6 +32,9 @@
 extern "C" {
 #endif
 
+/* Compatibility define */
+#define freerdp_channels_check_fds freerdp_channels_check_event_handles
+
 FREERDP_API int freerdp_channels_client_load(rdpChannels* channels,
         rdpSettings* settings, PVIRTUALCHANNELENTRY entry, void* data);
 FREERDP_API int freerdp_channels_client_load_ex(rdpChannels* channels,
@@ -39,15 +42,14 @@ FREERDP_API int freerdp_channels_client_load_ex(rdpChannels* channels,
 FREERDP_API int freerdp_channels_load_plugin(rdpChannels* channels,
         rdpSettings* settings,
         const char* name, void* data);
+/* Prefer freerdp_channels_get_event_handle whereever possible */
 FREERDP_API BOOL freerdp_channels_get_fds(rdpChannels* channels,
         freerdp* instance, void** read_fds,
         int* read_count, void** write_fds, int* write_count);
-FREERDP_API BOOL freerdp_channels_check_fds(rdpChannels* channels,
+FREERDP_API BOOL freerdp_channels_check_event_handles(rdpChannels* channels,
         freerdp* instance);
-
 FREERDP_API void* freerdp_channels_get_static_channel_interface(
     rdpChannels* channels, const char* name);
-
 FREERDP_API HANDLE freerdp_channels_get_event_handle(freerdp* instance);
 FREERDP_API int freerdp_channels_process_pending_messages(freerdp* instance);
 

--- a/include/freerdp/channels/wtsvc.h
+++ b/include/freerdp/channels/wtsvc.h
@@ -64,13 +64,15 @@ FREERDP_API BYTE WTSVirtualChannelManagerGetDrdynvcState(HANDLE hServer);
 /**
  * Extended FreeRDP WTS functions for channel handling
  */
-FREERDP_API UINT16 WTSChannelGetId(freerdp_peer *client, const char *channel_name);
-FREERDP_API BOOL WTSIsChannelJoinedByName(freerdp_peer *client, const char *channel_name);
-FREERDP_API BOOL WTSIsChannelJoinedById(freerdp_peer *client, const UINT16 channel_id);
-FREERDP_API BOOL WTSChannelSetHandleByName(freerdp_peer *client, const char *channel_name, void *handle);
-FREERDP_API BOOL WTSChannelSetHandleById(freerdp_peer *client, const UINT16 channel_id, void *handle);
-FREERDP_API void *WTSChannelGetHandleByName(freerdp_peer *client, const char *channel_name);
-FREERDP_API void *WTSChannelGetHandleById(freerdp_peer *client, const UINT16 channel_id);
+FREERDP_API UINT16 WTSChannelGetId(freerdp_peer* client, const char* channel_name);
+FREERDP_API BOOL WTSIsChannelJoinedByName(freerdp_peer* client, const char* channel_name);
+FREERDP_API BOOL WTSIsChannelJoinedById(freerdp_peer* client, const UINT16 channel_id);
+FREERDP_API BOOL WTSChannelSetHandleByName(freerdp_peer* client, const char* channel_name,
+        void* handle);
+FREERDP_API BOOL WTSChannelSetHandleById(freerdp_peer* client, const UINT16 channel_id,
+        void* handle);
+FREERDP_API void* WTSChannelGetHandleByName(freerdp_peer* client, const char* channel_name);
+FREERDP_API void* WTSChannelGetHandleById(freerdp_peer* client, const UINT16 channel_id);
 
 #ifdef __cplusplus
 }

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -434,12 +434,15 @@ FREERDP_API void freerdp_channel_remove_open_handle_data(rdpChannelHandles* hand
 FREERDP_API UINT freerdp_channels_attach(freerdp* instance);
 FREERDP_API UINT freerdp_channels_detach(freerdp* instance);
 
+/* LEGACY: Prefer freerdp_get_event_handles whenever possible */
 FREERDP_API BOOL freerdp_get_fds(freerdp* instance, void** rfds, int* rcount,
                                  void** wfds, int* wcount);
-FREERDP_API BOOL freerdp_check_fds(freerdp* instance);
 
 FREERDP_API DWORD freerdp_get_event_handles(rdpContext* context, HANDLE* events,
         DWORD count);
+
+/* Compatibility define */
+#define freerdp_check_fds freerdp_check_event_handles
 FREERDP_API BOOL freerdp_check_event_handles(rdpContext* context);
 
 FREERDP_API wMessageQueue* freerdp_get_message_queue(freerdp* instance,

--- a/libfreerdp/core/activation.c
+++ b/libfreerdp/core/activation.c
@@ -285,7 +285,7 @@ BOOL rdp_recv_deactivate_all(rdpRdp* rdp, wStream* s)
 
 	while (rdp->state != CONNECTION_STATE_ACTIVE)
 	{
-		if (rdp_check_fds(rdp) < 0)
+		if (rdp_check_event_handles(rdp) < 0)
 			return FALSE;
 
 		if (freerdp_shall_disconnect(rdp->instance))

--- a/libfreerdp/core/client.c
+++ b/libfreerdp/core/client.c
@@ -565,7 +565,7 @@ int freerdp_channels_process_pending_messages(freerdp* instance)
 /**
  * called only from main thread
  */
-BOOL freerdp_channels_check_fds(rdpChannels* channels, freerdp* instance)
+BOOL freerdp_channels_check_event_handles(rdpChannels* channels, freerdp* instance)
 {
 	if (WaitForSingleObject(MessageQueue_Event(channels->queue),
 	                        0) == WAIT_OBJECT_0)
@@ -586,7 +586,7 @@ UINT freerdp_channels_disconnect(rdpChannels* channels, freerdp* instance)
 	if (!channels->connected)
 		return 0;
 
-	freerdp_channels_check_fds(channels, instance);
+	freerdp_channels_check_event_handles(channels, instance);
 
 	/* tell all libraries we are shutting down */
 	for (index = 0; index < channels->clientDataCount; index++)
@@ -624,7 +624,7 @@ void freerdp_channels_close(rdpChannels* channels, freerdp* instance)
 	int index;
 	CHANNEL_OPEN_DATA* pChannelOpenData;
 	CHANNEL_CLIENT_DATA* pChannelClientData;
-	freerdp_channels_check_fds(channels, instance);
+	freerdp_channels_check_event_handles(channels, instance);
 
 	/* tell all libraries we are shutting down */
 	for (index = 0; index < channels->clientDataCount; index++)

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -329,7 +329,7 @@ BOOL rdp_client_connect(rdpRdp* rdp)
 
 	while (rdp->state != CONNECTION_STATE_ACTIVE)
 	{
-		if (rdp_check_fds(rdp) < 0)
+		if (rdp_check_event_handles(rdp) < 0)
 		{
 			if (!freerdp_get_last_error(rdp->context))
 				freerdp_set_last_error(rdp->context, FREERDP_ERROR_CONNECT_TRANSPORT_FAILED);

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -54,6 +54,8 @@
 
 #define TAG FREERDP_TAG("core")
 
+static BOOL freerdp_check_for_events(freerdp* instance);
+
 /* connectErrorCode is 'extern' in error.h. See comment there.*/
 
 UINT freerdp_channel_add_init_handle_data(rdpChannelHandles* handles, void* pInitHandle,
@@ -317,7 +319,7 @@ BOOL freerdp_get_fds(freerdp* instance, void** rfds, int* rcount, void** wfds,
 	return TRUE;
 }
 
-BOOL freerdp_check_fds(freerdp* instance)
+BOOL freerdp_check_for_events(freerdp* instance)
 {
 	int status;
 	rdpRdp* rdp;
@@ -332,13 +334,13 @@ BOOL freerdp_check_fds(freerdp* instance)
 		return FALSE;
 
 	rdp = instance->context->rdp;
-	status = rdp_check_fds(rdp);
+	status = rdp_check_event_handles(rdp);
 
 	if (status < 0)
 	{
 		TerminateEventArgs e;
 		rdpContext* context = instance->context;
-		WLog_DBG(TAG, "rdp_check_fds() - %i", status);
+		WLog_DBG(TAG, "freerdp_check_for_events() - %i", status);
 		EventArgsInit(&e, "freerdp");
 		e.code = 0;
 		PubSub_OnTerminate(context->pubSub, context, &e);
@@ -381,22 +383,22 @@ DWORD freerdp_get_event_handles(rdpContext* context, HANDLE* events,
 BOOL freerdp_check_event_handles(rdpContext* context)
 {
 	BOOL status;
-	status = freerdp_check_fds(context->instance);
+	status = freerdp_check_for_events(context->instance);
 
 	if (!status)
 	{
 		if (freerdp_get_last_error(context) == FREERDP_ERROR_SUCCESS)
-			WLog_ERR(TAG, "freerdp_check_fds() failed - %"PRIi32"", status);
+			WLog_ERR(TAG, "freerdp_check_for_events() failed - %"PRIi32"", status);
 
 		return FALSE;
 	}
 
-	status = freerdp_channels_check_fds(context->channels, context->instance);
+	status = freerdp_channels_check_event_handles(context->channels, context->instance);
 
 	if (!status)
 	{
 		if (freerdp_get_last_error(context) == FREERDP_ERROR_SUCCESS)
-			WLog_ERR(TAG, "freerdp_channels_check_fds() failed - %"PRIi32"", status);
+			WLog_ERR(TAG, "freerdp_channels_check_event_handles() failed - %"PRIi32"", status);
 
 		return FALSE;
 	}

--- a/libfreerdp/core/listener.c
+++ b/libfreerdp/core/listener.c
@@ -287,7 +287,7 @@ DWORD freerdp_listener_get_event_handles(freerdp_listener* instance, HANDLE* eve
 	return listener->num_sockfds;
 }
 
-static BOOL freerdp_listener_check_fds(freerdp_listener* instance)
+static BOOL freerdp_listener_check_event_handles(freerdp_listener* instance)
 {
 	int i;
 	void* sin_addr;
@@ -388,9 +388,8 @@ freerdp_listener* freerdp_listener_new(void)
 	instance->Open = freerdp_listener_open;
 	instance->OpenLocal = freerdp_listener_open_local;
 	instance->OpenFromSocket = freerdp_listener_open_from_socket;
-	instance->GetFileDescriptor = freerdp_listener_get_fds;
 	instance->GetEventHandles = freerdp_listener_get_event_handles;
-	instance->CheckFileDescriptor = freerdp_listener_check_fds;
+	instance->CheckFileDescriptor = freerdp_listener_check_event_handles;
 	instance->Close = freerdp_listener_close;
 	listener = (rdpListener*) calloc(1, sizeof(rdpListener));
 

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -235,13 +235,6 @@ static BOOL freerdp_peer_initialize(freerdp_peer* client)
 	return TRUE;
 }
 
-static BOOL freerdp_peer_get_fds(freerdp_peer* client, void** rfds, int* rcount)
-{
-	rdpTransport* transport = client->context->rdp->transport;
-	transport_get_fds(transport, rfds, rcount);
-	return TRUE;
-}
-
 static HANDLE freerdp_peer_get_event_handle(freerdp_peer* client)
 {
 	HANDLE hEvent = NULL;
@@ -255,12 +248,12 @@ static DWORD freerdp_peer_get_event_handles(freerdp_peer* client, HANDLE* events
 	return transport_get_event_handles(client->context->rdp->transport, events, count);
 }
 
-static BOOL freerdp_peer_check_fds(freerdp_peer* peer)
+static BOOL freerdp_peer_check_event_handles(freerdp_peer* peer)
 {
 	int status;
 	rdpRdp* rdp;
 	rdp = peer->context->rdp;
-	status = rdp_check_fds(rdp);
+	status = rdp_check_event_handles(rdp);
 
 	if (status < 0)
 		return FALSE;
@@ -840,10 +833,9 @@ freerdp_peer* freerdp_peer_new(int sockfd)
 		client->sockfd = sockfd;
 		client->ContextSize = sizeof(rdpContext);
 		client->Initialize = freerdp_peer_initialize;
-		client->GetFileDescriptor = freerdp_peer_get_fds;
 		client->GetEventHandle = freerdp_peer_get_event_handle;
 		client->GetEventHandles = freerdp_peer_get_event_handles;
-		client->CheckFileDescriptor = freerdp_peer_check_fds;
+		client->CheckFileDescriptor = freerdp_peer_check_event_handles;
 		client->Close = freerdp_peer_close;
 		client->Disconnect = freerdp_peer_disconnect;
 		client->SendChannelData = freerdp_peer_send_channel_data;

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1576,7 +1576,7 @@ BOOL rdp_send_error_info(rdpRdp* rdp)
 	return status;
 }
 
-int rdp_check_fds(rdpRdp* rdp)
+int rdp_check_event_handles(rdpRdp* rdp)
 {
 	int status;
 	rdpTransport* transport = rdp->transport;
@@ -1587,7 +1587,7 @@ int rdp_check_fds(rdpRdp* rdp)
 
 		if (!tsg_check_event_handles(tsg))
 		{
-			WLog_ERR(TAG, "rdp_check_fds: tsg_check_event_handles()");
+			WLog_ERR(TAG, "rdp_check_event_handles: tsg_check_event_handles()");
 			return -1;
 		}
 
@@ -1595,7 +1595,7 @@ int rdp_check_fds(rdpRdp* rdp)
 			return 1;
 	}
 
-	status = transport_check_fds(transport);
+	status = transport_check_event_handles(transport);
 
 	if (status == 1)
 	{
@@ -1603,7 +1603,7 @@ int rdp_check_fds(rdpRdp* rdp)
 	}
 
 	if (status < 0)
-		WLog_DBG(TAG, "transport_check_fds() - %i", status);
+		WLog_DBG(TAG, "transport_check_event_handles() - %i", status);
 
 	return status;
 }

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -229,7 +229,7 @@ FREERDP_LOCAL BOOL rdp_write_monitor_layout_pdu(wStream* s, UINT32 monitorCount,
 FREERDP_LOCAL int rdp_recv_callback(rdpTransport* transport, wStream* s,
                                     void* extra);
 
-FREERDP_LOCAL int rdp_check_fds(rdpRdp* rdp);
+FREERDP_LOCAL int rdp_check_event_handles(rdpRdp* rdp);
 
 FREERDP_LOCAL rdpRdp* rdp_new(rdpContext* context);
 FREERDP_LOCAL void rdp_reset(rdpRdp* rdp);

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -982,7 +982,7 @@ int transport_drain_output_buffer(rdpTransport* transport)
 	return status;
 }
 
-int transport_check_fds(rdpTransport* transport)
+int transport_check_event_handles(rdpTransport* transport)
 {
 	int status;
 	int recv_status;
@@ -1020,7 +1020,8 @@ int transport_check_fds(rdpTransport* transport)
 		if ((status = transport_read_pdu(transport, transport->ReceiveBuffer)) <= 0)
 		{
 			if (status < 0)
-				WLog_Print(transport->log, WLOG_DEBUG, "transport_check_fds: transport_read_pdu() - %i", status);
+				WLog_Print(transport->log, WLOG_DEBUG, "transport_check_event_handles: transport_read_pdu() - %i",
+				           status);
 
 			return status;
 		}
@@ -1047,7 +1048,8 @@ int transport_check_fds(rdpTransport* transport)
 
 		if (recv_status < 0)
 		{
-			WLog_Print(transport->log, WLOG_ERROR, "transport_check_fds: transport->ReceiveCallback() - %i",
+			WLog_Print(transport->log, WLOG_ERROR,
+			           "transport_check_event_handles: transport->ReceiveCallback() - %i",
 			           recv_status);
 			return -1;
 		}

--- a/libfreerdp/core/transport.h
+++ b/libfreerdp/core/transport.h
@@ -99,7 +99,8 @@ FREERDP_LOCAL int transport_write(rdpTransport* transport, wStream* s);
 
 FREERDP_LOCAL void transport_get_fds(rdpTransport* transport, void** rfds,
                                      int* rcount);
-FREERDP_LOCAL int transport_check_fds(rdpTransport* transport);
+
+FREERDP_LOCAL int transport_check_event_handles(rdpTransport* transport);
 
 FREERDP_LOCAL DWORD transport_get_event_handles(rdpTransport* transport,
         HANDLE* events, DWORD nCount);

--- a/server/Mac/mf_audin.c
+++ b/server/Mac/mf_audin.c
@@ -57,8 +57,9 @@ static UINT mf_peer_audin_open_result(audin_server_context* context, UINT32 resu
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT mf_peer_audin_receive_samples(audin_server_context* context, const void* buf,
-        int nframes)
+static UINT mf_peer_audin_receive_samples(audin_server_context* context,
+        const AUDIO_FORMAT* format, wStream* buf,
+        size_t nframes)
 {
 	return CHANNEL_RC_OK;
 }
@@ -69,8 +70,10 @@ void mf_peer_audin_init(mfPeerContext* context)
 	context->audin->rdpcontext = &context->_p;
 	context->audin->data = context;
 	context->audin->num_server_formats = server_audin_get_formats(&context->audin->server_formats);
+
 	if (context->audin->num_server_formats > 0)
 		context->audin->dst_format = &context->audin->server_formats[0];
+
 	context->audin->Opening = mf_peer_audin_opening;
 	context->audin->OpenResult = mf_peer_audin_open_result;
 	context->audin->ReceiveSamples = mf_peer_audin_receive_samples;

--- a/server/Mac/mf_interface.h
+++ b/server/Mac/mf_interface.h
@@ -49,7 +49,7 @@ typedef struct mf_peer_context mfPeerContext;
 struct mf_peer_context
 {
 	rdpContext _p;
-	
+
 	mfInfo* info;
 	wStream* s;
 	BOOL activated;
@@ -57,24 +57,25 @@ struct mf_peer_context
 	BOOL audin_open;
 	RFX_CONTEXT* rfx_context;
 	NSC_CONTEXT* nsc_context;
-	
+
 	//#ifdef WITH_SERVER_CHANNELS
 	HANDLE vcm;
 	//#endif
 	//#ifdef CHANNEL_AUDIN_SERVER
 	audin_server_context* audin;
 	//#endif
-	
+
 	//#ifdef CHANNEL_RDPSND_SERVER
 	RdpsndServerContext* rdpsnd;
 	//#endif
+	HANDLE handle;
 };
 
 
 struct mf_info
 {
 	//STREAM* s;
-	
+
 	//screen and monitor info
 	UINT32 screenID;
 	UINT32 virtscreen_width;
@@ -83,7 +84,7 @@ struct mf_info
 	UINT32 servscreen_height;
 	UINT32 servscreen_xoffset;
 	UINT32 servscreen_yoffset;
-	
+
 	int bitsPerPixel;
 	int peerCount;
 	int activePeerCount;
@@ -91,10 +92,10 @@ struct mf_info
 	freerdp_peer** peers;
 	unsigned int framesWaiting;
 	UINT32 scale;
-	
+
 	RFX_RECT invalid;
 	pthread_mutex_t mutex;
-	
+
 	BOOL mouse_down_left;
 	BOOL mouse_down_right;
 	BOOL mouse_down_other;

--- a/server/Windows/wf_peer.c
+++ b/server/Windows/wf_peer.c
@@ -167,43 +167,37 @@ BOOL wf_peer_accepted(freerdp_listener* instance, freerdp_peer* client)
 
 static DWORD WINAPI wf_peer_socket_listener(LPVOID lpParam)
 {
-	int i, fds;
-	int rcount;
-	int max_fds;
-	void* rfds[32];
-	fd_set rfds_set;
 	wfPeerContext* context;
 	freerdp_peer* client = (freerdp_peer*) lpParam;
-	ZeroMemory(rfds, sizeof(rfds));
+
+	if (!client || !client->context)
+	{
+		ExitThread(1);
+		return 1;
+	}
+
 	context = (wfPeerContext*) client->context;
 
 	while (1)
 	{
-		rcount = 0;
+		DWORD status;
+		HANDLE handles[64];
+		DWORD usedHandles = client->GetEventHandles(client, handles, ARRAYSIZE(handles));
 
-		if (client->GetFileDescriptor(client, rfds, &rcount) != TRUE)
+		if (usedHandles == 0)
 		{
 			WLog_ERR(TAG, "Failed to get peer file descriptor");
 			break;
 		}
 
-		max_fds = 0;
-		FD_ZERO(&rfds_set);
+		status = WaitForMultipleObjects(usedHandles, handles, FALSE, INFINITE);
 
-		for (i = 0; i < rcount; i++)
+		if (status == WAIT_FAILED)
 		{
-			fds = (int)(long)(rfds[i]);
-
-			if (fds > max_fds)
-				max_fds = fds;
-
-			FD_SET(fds, &rfds_set);
+			WLog_ERR(TAG, "WaitForMultipleObjects failed");
+			break;
 		}
 
-		if (max_fds == 0)
-			break;
-
-		select(max_fds + 1, &rfds_set, NULL, NULL, NULL);
 		SetEvent(context->socketEvent);
 		WaitForSingleObject(context->socketSemaphore, INFINITE);
 
@@ -211,6 +205,7 @@ static DWORD WINAPI wf_peer_socket_listener(LPVOID lpParam)
 			break;
 	}
 
+	ExitThread(0);
 	return 0;
 }
 


### PR DESCRIPTION
* Removed all useages of `*_get_fds` functions
* Renamed `*check_fds` functions to `*check_event_handles`
* Added compatibility defines for `*check_fds`
* Still keeping the funtions around for compatibility