### PR TITLE
Fix #5061: Initialize output buffer transparent.

### DIFF
--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -179,6 +179,12 @@ BOOL freerdp_image_copy_from_pointer_data(
 	if (nDstStep <= 0)
 		nDstStep = dstBytesPerPixel * nWidth;
 
+	for (y = nYDst; y < nHeight; y++)
+	{
+		BYTE* pDstLine = &pDstData[y * nDstStep + nXDst * dstBytesPerPixel];
+		memset(pDstLine, 0, dstBytesPerPixel * (nWidth - nXDst));
+	}
+
 	vFlip = (xorBpp == 1) ? FALSE : TRUE;
 	andStep = (nWidth + 7) / 8;
 	andStep += (andStep % 2);


### PR DESCRIPTION
If a destination buffer is not allocated with `calloc` but some `malloc` or other, not every pixel is initialized properly.
Fix this by setting the buffer to `0` initially.