### PR TITLE
Fix #4768: Set SSL verify purpose to ANY

### DIFF
--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -756,6 +756,8 @@ char* crypto_cert_issuer(X509* xcert)
 
 BOOL x509_verify_certificate(CryptoCert cert, char* certificate_store_path)
 {
+	int purpose;
+	X509_VERIFY_PARAM* verify_param;
 	X509_STORE_CTX* csc;
 	BOOL status = FALSE;
 	X509_STORE* cert_ctx = NULL;
@@ -799,6 +801,14 @@ BOOL x509_verify_certificate(CryptoCert cert, char* certificate_store_path)
 
 	if (!X509_STORE_CTX_init(csc, cert_ctx, xcert, cert->px509chain))
 		goto end;
+
+	purpose = X509_PURPOSE_ANY;
+	verify_param = X509_STORE_CTX_get0_param(csc);
+
+	if (!verify_param)
+		goto end;
+
+	X509_VERIFY_PARAM_set_purpose(verify_param, purpose);
 
 	if (X509_verify_cert(csc) == 1)
 		status = TRUE;


### PR DESCRIPTION
Found https://stackoverflow.com/questions/40685111/why-openssls-pkcs7-verify-requires-smimesign-certificate-purpose which explains the references behaviour.

Set to server since we verify the certificate of the server and not the client in that case only.