### PR TITLE
Fix #4909: Do not initialize HOME environment variable as it is no longer used.

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -878,14 +878,6 @@ static BOOL wfreerdp_client_global_init(void)
 {
 	WSADATA wsaData;
 
-	if (!getenv("HOME"))
-	{
-		char home[MAX_PATH * 2] = "HOME=";
-		strcat(home, getenv("HOMEDRIVE"));
-		strcat(home, getenv("HOMEPATH"));
-		_putenv(home);
-	}
-
 	WSAStartup(0x101, &wsaData);
 #if defined(WITH_DEBUG) || defined(_DEBUG)
 	wf_create_console();

--- a/server/Windows/wf_peer.c
+++ b/server/Windows/wf_peer.c
@@ -247,14 +247,6 @@ DWORD WINAPI wf_peer_main_loop(LPVOID lpParam)
 	wfPeerContext* context;
 	freerdp_peer* client = (freerdp_peer*) lpParam;
 
-	if (!getenv("HOME"))
-	{
-		char home[MAX_PATH * 2] = "HOME=";
-		strcat(home, getenv("HOMEDRIVE"));
-		strcat(home, getenv("HOMEPATH"));
-		_putenv(home);
-	}
-
 	if (!wf_peer_init(client))
 		goto fail_peer_init;
 


### PR DESCRIPTION
GetKnownPath does not require this environment variable to be
available for windows builds.
