### PR TITLE
Refactored Certificate callbacks (but keep compatible)

### DIFF
--- a/client/Sample/tf_freerdp.c
+++ b/client/Sample/tf_freerdp.c
@@ -107,11 +107,9 @@ static BOOL tf_pre_connect(freerdp* instance)
 	/* Optional OS identifier sent to server */
 	settings->OsMajorType = OSMAJORTYPE_UNIX;
 	settings->OsMinorType = OSMINORTYPE_NATIVE_XSERVER;
-
 	/* settings->OrderSupport is initialized at this point.
 	 * Only override it if you plan to implement custom order
 	 * callbacks or deactiveate certain features. */
-
 	/* Register the channel listeners.
 	 * They are required to set up / tear down channels if they are loaded. */
 	PubSub_SubscribeChannelConnected(instance->context->pubSub,
@@ -262,8 +260,8 @@ static BOOL tf_client_new(freerdp* instance, rdpContext* context)
 	instance->PostDisconnect = tf_post_disconnect;
 	instance->Authenticate = client_cli_authenticate;
 	instance->GatewayAuthenticate = client_cli_gw_authenticate;
-	instance->VerifyCertificate = client_cli_verify_certificate;
-	instance->VerifyChangedCertificate = client_cli_verify_changed_certificate;
+	instance->VerifyCertificateEx = client_cli_verify_certificate_ex;
+	instance->VerifyChangedCertificateEx = client_cli_verify_changed_certificate_ex;
 	instance->LogonErrorInfo = tf_logon_error_info;
 	/* TODO: Client display set up */
 	return TRUE;

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -386,8 +386,8 @@ static BOOL wlf_client_new(freerdp* instance, rdpContext* context)
 	instance->PostDisconnect = wl_post_disconnect;
 	instance->Authenticate = client_cli_authenticate;
 	instance->GatewayAuthenticate = client_cli_gw_authenticate;
-	instance->VerifyCertificate = client_cli_verify_certificate;
-	instance->VerifyChangedCertificate = client_cli_verify_changed_certificate;
+	instance->VerifyCertificateEx = client_cli_verify_certificate_ex;
+	instance->VerifyChangedCertificateEx = client_cli_verify_changed_certificate_ex;
 	instance->LogonErrorInfo = wlf_logon_error_info;
 	wfl->display = UwacOpenDisplay(NULL, &status);
 

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1763,8 +1763,8 @@ static BOOL xfreerdp_client_new(freerdp* instance, rdpContext* context)
 	instance->PostDisconnect = xf_post_disconnect;
 	instance->Authenticate = client_cli_authenticate;
 	instance->GatewayAuthenticate = client_cli_gw_authenticate;
-	instance->VerifyCertificate = client_cli_verify_certificate;
-	instance->VerifyChangedCertificate = client_cli_verify_changed_certificate;
+	instance->VerifyCertificateEx = client_cli_verify_certificate_ex;
+	instance->VerifyChangedCertificateEx = client_cli_verify_changed_certificate_ex;
 	instance->LogonErrorInfo = xf_logon_error_info;
 	PubSub_SubscribeTerminate(context->pubSub,
 	                          xf_TerminateEventHandler);

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -107,11 +107,25 @@ FREERDP_API DWORD client_cli_verify_certificate(freerdp* instance, const char* c
         const char* subject, const char* issuer,
         const char* fingerprint, BOOL host_mismatch);
 
+FREERDP_API DWORD client_cli_verify_certificate_ex(freerdp* instance,
+        const char* host, UINT16 port,
+        const char* common_name,
+        const char* subject, const char* issuer,
+        const char* fingerprint, DWORD flags);
+
 FREERDP_API DWORD client_cli_verify_changed_certificate(freerdp* instance, const char* common_name,
         const char* subject, const char* issuer,
         const char* fingerprint,
         const char* old_subject, const char* old_issuer,
         const char* old_fingerprint);
+
+FREERDP_API DWORD client_cli_verify_changed_certificate_ex(freerdp* instance,
+        const char* host, UINT16 port,
+        const char* common_name,
+        const char* subject, const char* issuer,
+        const char* fingerprint,
+        const char* old_subject, const char* old_issuer,
+        const char* old_fingerprint, DWORD flags);
 FREERDP_API BOOL client_auto_reconnect(freerdp* instance);
 FREERDP_API BOOL client_auto_reconnect_ex(freerdp* instance,
         BOOL(*window_events)(freerdp* instance));

--- a/include/freerdp/crypto/certificate.h
+++ b/include/freerdp/crypto/certificate.h
@@ -51,35 +51,35 @@ struct rdp_certificate_store
 };
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 FREERDP_API rdpCertificateData* certificate_data_new(
-        char* hostname, UINT16 port, char* subject,
-        char* issuer, char* fingerprint);
+    const char* hostname, UINT16 port, const char* subject,
+    const char* issuer, const char* fingerprint);
 FREERDP_API void certificate_data_free(
-        rdpCertificateData* certificate_data);
+    rdpCertificateData* certificate_data);
 FREERDP_API rdpCertificateStore* certificate_store_new(
-        rdpSettings* settings);
+    rdpSettings* settings);
 FREERDP_API BOOL certificate_data_replace(
-        rdpCertificateStore* certificate_store,
-        rdpCertificateData* certificate_data);
+    rdpCertificateStore* certificate_store,
+    rdpCertificateData* certificate_data);
 FREERDP_API void certificate_store_free(
-        rdpCertificateStore* certificate_store);
+    rdpCertificateStore* certificate_store);
 FREERDP_API int certificate_data_match(
-        rdpCertificateStore* certificate_store,
-        rdpCertificateData* certificate_data);
+    rdpCertificateStore* certificate_store,
+    rdpCertificateData* certificate_data);
 FREERDP_API BOOL certificate_data_print(
-        rdpCertificateStore* certificate_store,
-        rdpCertificateData* certificate_data);
+    rdpCertificateStore* certificate_store,
+    rdpCertificateData* certificate_data);
 FREERDP_API BOOL certificate_get_stored_data(
-        rdpCertificateStore* certificate_store,
-        rdpCertificateData* certificate_data,
-        char** subject, char** issuer,
-        char** fingerprint);
+    rdpCertificateStore* certificate_store,
+    rdpCertificateData* certificate_data,
+    char** subject, char** issuer,
+    char** fingerprint);
 
 #ifdef __cplusplus
- }
+}
 #endif
 
 #endif /* FREERDP_CRYPTO_CERTIFICATE_H */

--- a/include/freerdp/crypto/crypto.h
+++ b/include/freerdp/crypto/crypto.h
@@ -72,10 +72,10 @@ Note: email and upn amongst others are also alt_names,
 but the old crypto_cert_get_alt_names returned only the dns_names
 */
 FREERDP_API char** crypto_cert_subject_alt_name(X509* xcert, int* count, int** lengths);
-FREERDP_API void crypto_cert_subject_alt_name_free(int count, int *lengths, char** alt_names);
+FREERDP_API void crypto_cert_subject_alt_name_free(int count, int* lengths, char** alt_names);
 
-FREERDP_API BOOL x509_verify_certificate(CryptoCert cert, char* certificate_store_path);
-FREERDP_API rdpCertificateData* crypto_get_certificate_data(X509* xcert, char* hostname,
+FREERDP_API BOOL x509_verify_certificate(CryptoCert cert, const char* certificate_store_path);
+FREERDP_API rdpCertificateData* crypto_get_certificate_data(X509* xcert, const char* hostname,
         UINT16 port);
 FREERDP_API BOOL crypto_cert_get_public_key(CryptoCert cert, BYTE** PublicKey,
         DWORD* PublicKeyLength);

--- a/include/freerdp/crypto/tls.h
+++ b/include/freerdp/crypto/tls.h
@@ -96,14 +96,6 @@ FREERDP_API int tls_write_all(rdpTls* tls, const BYTE* data, int length);
 
 FREERDP_API int tls_set_alert_code(rdpTls* tls, int level, int description);
 
-FREERDP_API BOOL tls_match_hostname(char* pattern, int pattern_length, char* hostname);
-FREERDP_API int tls_verify_certificate(rdpTls* tls, CryptoCert cert, char* hostname, int port);
-FREERDP_API void tls_print_certificate_error(char* hostname, UINT16 port,
-        char* fingerprint, char* hosts_file);
-FREERDP_API void tls_print_certificate_name_mismatch_error(
-    char* hostname, UINT16 port, char* common_name, char** alt_names,
-    int alt_names_count);
-
 FREERDP_API BOOL tls_print_error(char* func, SSL* connection, int value);
 
 FREERDP_API rdpTls* tls_new(rdpSettings* settings);

--- a/include/freerdp/crypto/tls.h
+++ b/include/freerdp/crypto/tls.h
@@ -96,8 +96,6 @@ FREERDP_API int tls_write_all(rdpTls* tls, const BYTE* data, int length);
 
 FREERDP_API int tls_set_alert_code(rdpTls* tls, int level, int description);
 
-FREERDP_API BOOL tls_print_error(char* func, SSL* connection, int value);
-
 FREERDP_API rdpTls* tls_new(rdpSettings* settings);
 FREERDP_API void tls_free(rdpTls* tls);
 

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -59,6 +59,14 @@ typedef RDP_CLIENT_ENTRY_POINTS_V1 RDP_CLIENT_ENTRY_POINTS;
 extern "C" {
 #endif
 
+/* Flags used by certificate callbacks */
+#define VERIFY_CERT_FLAG_NONE     0x00
+#define VERIFY_CERT_FLAG_LEGACY   0x02
+#define VERIFY_CERT_FLAG_REDIRECT 0x10
+#define VERIFY_CERT_FLAG_GATEWAY  0x20
+#define VERIFY_CERT_FLAG_CHANGED  0x40
+#define VERIFY_CERT_FLAG_MISMATCH 0x80
+
 typedef BOOL (*pContextNew)(freerdp* instance, rdpContext* context);
 typedef void (*pContextFree)(freerdp* instance, rdpContext* context);
 
@@ -71,6 +79,7 @@ typedef BOOL (*pAuthenticate)(freerdp* instance, char** username,
 /** @brief Callback used if user interaction is required to accept
  *         an unknown certificate.
  *
+ *  @deprecated Use pVerifyCertificateEx
  *  @param common_name      The certificate registered hostname.
  *  @param subject          The common name of the certificate.
  *  @param issuer           The issuer of the certificate.
@@ -89,8 +98,32 @@ typedef DWORD (*pVerifyCertificate)(freerdp* instance,
                                     BOOL host_mismatch);
 
 /** @brief Callback used if user interaction is required to accept
+ *         an unknown certificate.
+ *
+ *  @param host             The hostname connecting to.
+ *  @param port             The port connecting to.
+ *  @param common_name      The certificate registered hostname.
+ *  @param subject          The common name of the certificate.
+ *  @param issuer           The issuer of the certificate.
+ *  @param fingerprint      The fingerprint of the certificate.
+ *  @param flags            Flags of type VERIFY_CERT_FLAG*
+ *
+ *  @return 1 to accept and store a certificate, 2 to accept
+ *          a certificate only for this session, 0 otherwise.
+ */
+typedef DWORD (*pVerifyCertificateEx)(freerdp* instance,
+                                      const char* host,
+                                      UINT16 port,
+                                      const char* common_name,
+                                      const char* subject,
+                                      const char* issuer,
+                                      const char* fingerprint,
+                                      DWORD flags);
+
+/** @brief Callback used if user interaction is required to accept
  *         a changed certificate.
  *
+ *  @deprecated Use pVerifyChangedCertificateEx
  *  @param common_name      The certificate registered hostname.
  *  @param subject          The common name of the new certificate.
  *  @param issuer           The issuer of the new certificate.
@@ -112,13 +145,35 @@ typedef DWORD (*pVerifyChangedCertificate)(freerdp* instance,
         const char* old_issuer,
         const char* old_fingerprint);
 
+/** @brief Callback used if user interaction is required to accept
+ *         a changed certificate.
+ *
+ *  @param host             The hostname connecting to.
+ *  @param port             The port connecting to.
+ *  @param common_name      The certificate registered hostname.
+ *  @param subject          The common name of the new certificate.
+ *  @param issuer           The issuer of the new certificate.
+ *  @param fingerprint      The fingerprint of the new certificate.
+ *  @param old_subject      The common name of the old certificate.
+ *  @param old_issuer       The issuer of the new certificate.
+ *  @param old_fingerprint  The fingerprint of the old certificate.
+ *  @param flags            Flags of type VERIFY_CERT_FLAG*
+ *
+ *  @return 1 to accept and store a certificate, 2 to accept
+ *          a certificate only for this session, 0 otherwise.
+ */
 
-#define VERIFY_X509_CERT_FLAG_NONE     0x00
-#define VERIFY_X509_CERT_FLAG_LEGACY   0x02
-#define VERIFY_X509_CERT_FLAG_REDIRECT 0x10
-#define VERIFY_X509_CERT_FLAG_GATEWAY  0x20
-#define VERIFY_X509_CERT_FLAG_CHANGED  0x40
-#define VERIFY_X509_CERT_FLAG_MISMATCH 0x80
+typedef DWORD (*pVerifyChangedCertificateEx)(freerdp* instance,
+        const char* host,
+        UINT16 port,
+        const char* common_name,
+        const char* subject,
+        const char* issuer,
+        const char* new_fingerprint,
+        const char* old_subject,
+        const char* old_issuer,
+        const char* old_fingerprint,
+        DWORD flags);
 
 /** @brief Callback used if user interaction is required to accept
  *         a certificate.
@@ -128,7 +183,7 @@ typedef DWORD (*pVerifyChangedCertificate)(freerdp* instance,
  *  @param length           The length of the certificate data.
  *  @param hostname         The hostname connecting to.
  *  @param port             The port connecting to.
- *  @param flags            The issuer of the new certificate.
+ *  @param flags            Flags of type VERIFY_CERT_FLAG*
  *
  *  @return 1 to accept and store a certificate, 2 to accept
  *          a certificate only for this session, 0 otherwise.
@@ -296,11 +351,12 @@ struct rdp_freerdp
 									 It is used to get the username/password when it was not provided at connection time. */
 	ALIGN64 pVerifyCertificate VerifyCertificate; /**< (offset 51)
 											   Callback for certificate validation.
-											   Used to verify that an unknown certificate is trusted. */
+											   Used to verify that an unknown certificate is trusted.
+ DEPRECATED: Use VerifyChangedCertificateEx*/
 	ALIGN64 pVerifyChangedCertificate VerifyChangedCertificate; /**< (offset 52)
 															 Callback for changed certificate validation.
 															 Used when a certificate differs from stored fingerprint.
-															 If returns TRUE, the new fingerprint will be trusted and old thrown out. */
+ DEPRECATED: Use VerifyChangedCertificateEx */
 
 	ALIGN64 pVerifyX509Certificate
 	VerifyX509Certificate;  /**< (offset 53)  Callback for X509 certificate verification (PEM format) */
@@ -327,7 +383,13 @@ struct rdp_freerdp
 											   This is called by freerdp_channel_process() (if not NULL).
 											   Clients will typically use a function that calls freerdp_channels_data() to perform the needed tasks. */
 
-	UINT64 paddingE[80 - 66]; /* 66 */
+	ALIGN64 pVerifyCertificateEx VerifyCertificateEx; /**< (offset 66)
+											   Callback for certificate validation.
+											   Used to verify that an unknown certificate is trusted. */
+	ALIGN64 pVerifyChangedCertificateEx VerifyChangedCertificateEx; /**< (offset 67)
+															 Callback for changed certificate validation.
+															 Used when a certificate differs from stored fingerprint. */
+	UINT64 paddingE[80 - 68]; /* 68 */
 };
 
 struct rdp_channel_handles

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -111,9 +111,31 @@ typedef DWORD (*pVerifyChangedCertificate)(freerdp* instance,
         const char* old_subject,
         const char* old_issuer,
         const char* old_fingerprint);
-typedef int (*pVerifyX509Certificate)(freerdp* instance, BYTE* data,
-                                      int length, const char* hostname,
-                                      int port, DWORD flags);
+
+
+#define VERIFY_X509_CERT_FLAG_NONE     0x00
+#define VERIFY_X509_CERT_FLAG_LEGACY   0x02
+#define VERIFY_X509_CERT_FLAG_REDIRECT 0x10
+#define VERIFY_X509_CERT_FLAG_GATEWAY  0x20
+#define VERIFY_X509_CERT_FLAG_CHANGED  0x40
+#define VERIFY_X509_CERT_FLAG_MISMATCH 0x80
+
+/** @brief Callback used if user interaction is required to accept
+ *         a certificate.
+ *
+ *  @param instance         Pointer to the freerdp instance.
+ *  @param data             Pointer to certificate data in PEM format.
+ *  @param length           The length of the certificate data.
+ *  @param hostname         The hostname connecting to.
+ *  @param port             The port connecting to.
+ *  @param flags            The issuer of the new certificate.
+ *
+ *  @return 1 to accept and store a certificate, 2 to accept
+ *          a certificate only for this session, 0 otherwise.
+ */
+typedef int (*pVerifyX509Certificate)(freerdp* instance, const BYTE* data,
+                                      size_t length, const char* hostname,
+                                      UINT16 port, DWORD flags);
 
 typedef int (*pLogonErrorInfo)(freerdp* instance, UINT32 data, UINT32 type);
 

--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -754,9 +754,8 @@ char* crypto_cert_issuer(X509* xcert)
 	return crypto_print_name(X509_get_issuer_name(xcert));
 }
 
-BOOL x509_verify_certificate(CryptoCert cert, char* certificate_store_path)
+BOOL x509_verify_certificate(CryptoCert cert, const char* certificate_store_path)
 {
-	X509_VERIFY_PARAM* verify_param;
 	X509_STORE_CTX* csc;
 	BOOL status = FALSE;
 	X509_STORE* cert_ctx = NULL;
@@ -812,7 +811,7 @@ end:
 	return status;
 }
 
-rdpCertificateData* crypto_get_certificate_data(X509* xcert, char* hostname, UINT16 port)
+rdpCertificateData* crypto_get_certificate_data(X509* xcert, const char* hostname, UINT16 port)
 {
 	char* issuer;
 	char* subject;

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1461,6 +1461,8 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, const char* hostname,
 				}
 				else if (instance->VerifyCertificate)
 				{
+					WLog_WARN(TAG,
+					          "The VerifyCertificate callback is deprecated, migrate your application to VerifyCertificateEx");
 					accept_certificate = instance->VerifyCertificate(
 					                         instance, common_name,
 					                         subject, issuer,
@@ -1503,6 +1505,8 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, const char* hostname,
 				}
 				else if (instance->VerifyChangedCertificate)
 				{
+					WLog_WARN(TAG,
+					          "The VerifyChangedCertificate callback is deprecated, migrate your application to VerifyChangedCertificateEx");
 					accept_certificate = instance->VerifyChangedCertificate(
 					                         instance, common_name, subject, issuer,
 					                         fingerprint, old_subject, old_issuer,

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1525,7 +1525,7 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, const char* hostname,
 			{
 				case 1:
 					/* user accepted certificate, add entry in known_hosts file */
-					verification_status = certificate_data_print(tls->certificate_store,
+					verification_status = certificate_data_replace(tls->certificate_store,
 					                      certificate_data);
 					break;
 

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1189,23 +1189,23 @@ static BOOL is_accepted(rdpTls* tls, const BYTE* pem, size_t length)
 	return FALSE;
 }
 
-static BOOL accept_cert(rdpTls* tls, BYTE* pem, UINT32 length)
+static BOOL accept_cert(rdpTls* tls, const BYTE* pem, UINT32 length)
 {
 	rdpSettings* settings = tls->settings;
 
 	if (tls->isGatewayTransport)
 	{
-		settings->GatewayAcceptedCert = (char*)pem;
+		settings->GatewayAcceptedCert = _strdup(pem);
 		settings->GatewayAcceptedCertLength = length;
 	}
 	else if (is_redirected(tls))
 	{
-		settings->RedirectionAcceptedCert = (char*)pem;
+		settings->RedirectionAcceptedCert = _strdup(pem);
 		settings->RedirectionAcceptedCertLength = length;
 	}
 	else
 	{
-		settings->AcceptedCert = (char*)pem;
+		settings->AcceptedCert = _strdup(pem);
 		settings->AcceptedCertLength = length;
 	}
 


### PR DESCRIPTION
* Allow the use of `VerifyX509Certificate` without external certificate management.
* Added `VerifyCertificateEx` and `VerifyChangedCertificateEx` to have a proper indication which certificate is being verified
* Fixed const correctness of certificate functions (mostly string arguments)
* Removed TLS internal functions from freerdp API