### PR TITLE
Make "suppress output" setting available as command line option

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1736,6 +1736,10 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		{
 			settings->Fullscreen = enable;
 		}
+		CommandLineSwitchCase(arg, "prevent-suppress-output")
+		{
+			settings->SuppressOutput = !enable;
+		}
 		CommandLineSwitchCase(arg, "multimon")
 		{
 			settings->UseMultimon = TRUE;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -136,6 +136,7 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "pheight", COMMAND_LINE_VALUE_REQUIRED, "<height>", NULL, NULL, -1, NULL, "Physical height of display (in millimeters)" },
 	{ "play-rfx", COMMAND_LINE_VALUE_REQUIRED, "<pcap-file>", NULL, NULL, -1, NULL, "Replay rfx pcap file" },
 	{ "port", COMMAND_LINE_VALUE_REQUIRED, "<number>", NULL, NULL, -1, NULL, "Server port" },
+	{ "prevent-suppress-output", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Do not suppress output" },
 	{ "print-reconnect-cookie", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Print base64 reconnect cookie after connecting" },
 	{ "printer", COMMAND_LINE_VALUE_OPTIONAL, "<name>[,<driver>]", NULL, NULL, -1, NULL, "Redirect printer device" },
 	{


### PR DESCRIPTION
There's a common issue with using automation tools on Windows hosts that are mainly accessed through RDP. The issue consists in the remote OS switching to a "GUI-less" mode when a RDP client window is minimized. This causes automation tools to fail to receive data from the remote system. In our case, this caused our tech support VNC connection to a VM to stop working whenever our main FreeRDP client was minimized.

The issue is described in several places online and for Windows clients the solution is to use a setting called `RemoteDesktop_SuppressWhenMinimized` in the system registry ([see here for an example](https://www.inflectra.com/support/knowledgebase/kb131.aspx)), that tells the RDP client to keep the graphic session on the server active when the window is minimized. This was also the case in our environment, when testing with a Windows RDP client rather than with FreeRDP.

This setting seems to be already supported in FreeRDP via the `SuppressOutput` member of the `rdp_settings` structure. This merge request exposes this setting as a command line flag called `prevent-suppress-output`. Enabling this flag prevents the client from signaling the server to stop sending data when the client window is minimized and is, in our case, a solution for the issue described above.

The default behaviour is unmodified.

I am not sure whether there is a reason why the setting wasn't available as a command line option yet. If using this option might affect unexpectedly other areas of FreeRDP, an alternative and more limited way (and probably only for X11 clients?) would be to use a new settings which would be only read in `xf_event.c` to determine the value of the `suppress` parameter when calling `gdi_send_suppress_output` from `xf_event_PropertyNotify`.

A possible way to test this is the following:
* run a Windows VM (tested with windows server 2012 r2 - unsure this test would work on non-server versions) that is only accessed through RDP
* install TightVNC on the VM; stop the TightVNC service from running and run the server "standalone"
* configure the server to accept shared connections
* with the RDP connection active, VNC to the VM - session should be shared between RDP and VNC
* if the `+prevent-suppress-output` flag is used, when minimizing the RDP window the VNC connection should stay active and functional
* if the `+prevent-suppress-output` flag is not used, minimizind the RDP window will result in the VNC connection to be closed/non-functional