### PR TITLE
Make "suppress output" setting available on command line

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1736,6 +1736,10 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		{
 			settings->Fullscreen = enable;
 		}
+		CommandLineSwitchCase(arg, "suppress-output")
+		{
+			settings->SuppressOutput = enable;
+		}
 		CommandLineSwitchCase(arg, "multimon")
 		{
 			settings->UseMultimon = TRUE;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -136,6 +136,7 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "pheight", COMMAND_LINE_VALUE_REQUIRED, "<height>", NULL, NULL, -1, NULL, "Physical height of display (in millimeters)" },
 	{ "play-rfx", COMMAND_LINE_VALUE_REQUIRED, "<pcap-file>", NULL, NULL, -1, NULL, "Replay rfx pcap file" },
 	{ "port", COMMAND_LINE_VALUE_REQUIRED, "<number>", NULL, NULL, -1, NULL, "Server port" },
+	{ "suppress-output", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "suppress output when minimized" },
 	{ "print-reconnect-cookie", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "Print base64 reconnect cookie after connecting" },
 	{ "printer", COMMAND_LINE_VALUE_OPTIONAL, "<name>[,<driver>]", NULL, NULL, -1, NULL, "Redirect printer device" },
 	{


### PR DESCRIPTION
Replaces #5090 
Naming of original command line option was misleading, correct that.
Thank you @praimmugen for your contribution.