### PR TITLE
Fixed RAIL window can't show again once hidden

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -900,7 +900,7 @@ static BOOL xf_event_PropertyNotify(xfContext* xfc, XEvent* event, BOOL app)
 				xf_rail_send_client_system_command(xfc, appWindow->windowId, SC_MINIMIZE);
 			}
 			else if (!minimized && !maxVert && !maxHorz
-			         && (appWindow->rail_state != WINDOW_SHOW))
+			         && (appWindow->rail_state != WINDOW_SHOW) && (appWindow->rail_state != WINDOW_HIDE))
 			{
 				appWindow->rail_state = WINDOW_SHOW;
 				xf_rail_send_client_system_command(xfc, appWindow->windowId, SC_RESTORE);

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -988,6 +988,8 @@ void xf_ShowWindow(xfContext* xfc, xfAppWindow* appWindow, BYTE state)
 			if (appWindow->is_transient)
 				xf_SetWindowUnlisted(xfc, appWindow->handle);
 
+			XMapWindow(xfc->display, appWindow->handle);
+
 			break;
 	}
 


### PR DESCRIPTION
The cause is very simple: we didn't map the xwindow on receiving
WINDOW_SHOW. but doing that causes another problem that you can't
hide a window anymore, and that is because whlie window hiding, the
_NET_WM_STATE and WM_STATE properies of the xwindow may change, in
the function `xf_event_PropertyNotify` we just assume that windows
not maximized, not minimized, yet not showing normally should be
corrected to be shown, we just need to consider the situation that
the window is hidden here.

fix: #5078