### PR TITLE
Add jni interface for get_last_error_string

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -86,6 +86,8 @@ public class LibFreeRDP {
 
     private static native boolean freerdp_send_clipboard_data(long inst, String data);
 
+    private static native String freerdp_get_last_error_string(long inst);
+
     public static void setEventListener(EventListener l) {
         listener = l;
     }

--- a/client/Android/android_freerdp.c
+++ b/client/Android/android_freerdp.c
@@ -793,6 +793,17 @@ static void JNICALL jni_freerdp_free(JNIEnv* env, jclass cls, jlong instance)
 #endif
 }
 
+static jstring JNICALL jni_freerdp_get_last_error_string(JNIEnv* env, jclass cls, jlong instance)
+{
+	freerdp* inst = (freerdp*)instance;
+
+	if (!inst || !inst->context)
+		return (*env)->NewStringUTF(env, "");
+
+	return (*env)->NewStringUTF(env,
+	                            freerdp_get_last_error_string(freerdp_get_last_error(inst->context)));
+}
+
 static jboolean JNICALL jni_freerdp_parse_arguments(
     JNIEnv* env, jclass cls, jlong instance, jobjectArray arguments)
 {
@@ -1100,6 +1111,11 @@ static JNINativeMethod methods[] =
 		"freerdp_get_build_config",
 		"()Ljava/lang/String;",
 		&jni_freerdp_get_build_config
+	},
+	{
+		"freerdp_get_last_error_string",
+		"(J)Ljava/lang/String;",
+		&jni_freerdp_get_last_error_string
 	},
 	{
 		"freerdp_new",


### PR DESCRIPTION
An addition to the JNI interface that implements the call to freerdp_get_last_error_string.

Found I had to implement that to give the user some reason for why the rdp connection fails.