### PR TITLE
license: fix licencing against windows 2003 server

### DIFF
--- a/libfreerdp/core/license.c
+++ b/libfreerdp/core/license.c
@@ -1165,8 +1165,7 @@ static BOOL license_read_encrypted_blob(const rdpLicense *license, wStream *s, L
 	Stream_Read_UINT16(s, wBlobType);
 	if (wBlobType != BB_ENCRYPTED_DATA_BLOB)
 	{
-		WLog_ERR(TAG, "expecting BB_ENCRYPTED_DATA_BLOB blob");
-		return FALSE;
+		WLog_DBG(TAG, "expecting BB_ENCRYPTED_DATA_BLOB blob, probably a windows 2003 server, continuing...");
 	}
 
 	Stream_Read_UINT16(s, wBlobLen);


### PR DESCRIPTION
The spec says:
```
For Windows Server 2008, Windows Server 2008 R2, and Windows Server
2012, the EncryptedLicenseInfo variable (part of the Server Upgrade License PDU) sent by the server
to the client has the wBlobType parameter set to value BB_ENCRYPTED_DATA_BLOB (0x0009). For
Windows Server 2003, the value of wBlobType is not defined.
```

So don't enforce the message type.

Should fix #5101.