### PR TITLE
Implemented #3639: Add /from-fd argument

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2990,6 +2990,11 @@ static void argv_free(int argc, char** argv)
 	}
 }
 
+/* This function works like strtok except it allows for escape sequences.
+ * Take for example 'sep' as space, 'esc' as quote and 'esc2' as backslash
+ * The sequence 'a" b c \" \\ d" e f "g h"' will return
+ * 'a" b c \" \\ d"', 'e', 'f' and '"g h"'
+ */
 static const char* str_next_token(const char* start, char sep, char esc, char esc2)
 {
 	const char* cur = start;
@@ -3058,7 +3063,7 @@ static char** str_tokenize(const char* first, const char* s, char sep, char esc,
 {
 	char** list = NULL;
 	*count = str_tokens(s, sep, esc, esc2);
-	list = calloc((size_t) * count, sizeof(char*));
+	list = calloc((size_t)(*count), sizeof(char*));
 
 	if (list != NULL)
 	{

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3052,6 +3052,10 @@ static int str_tokens(const char* s, char sep, char esc, char esc2)
 	while ((next = str_next_token(cur, sep, esc, esc2)) != NULL)
 	{
 		count++;
+
+		if (*next == '\0')
+			break;
+
 		cur = next + 1;
 	}
 
@@ -3076,7 +3080,7 @@ static char** str_tokenize(const char* first, const char* s, char sep, char esc,
 		while ((next = str_next_token(cur, sep, esc, esc2)) != NULL)
 		{
 			const size_t size = (size_t)(next - cur);
-			char* arg = calloc(size, sizeof(char));
+			char* arg = calloc(size + 1, sizeof(char));
 
 			if (!arg)
 			{
@@ -3084,7 +3088,12 @@ static char** str_tokenize(const char* first, const char* s, char sep, char esc,
 				return NULL;
 			}
 
-			memcpy(arg, cur, size - 1);
+			memcpy(arg, cur, size);
+			list[i++] = arg;
+
+			if (*next == '\0')
+				break;
+
 			cur = next + 1;
 		}
 	}

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3081,6 +3081,7 @@ static char** str_tokenize(const char* first, const char* s, char sep, char esc,
 		{
 			const size_t size = (size_t)(next - cur);
 			char* arg = calloc(size + 1, sizeof(char));
+			size_t x, pos = 0;;
 
 			if (!arg)
 			{
@@ -3088,7 +3089,25 @@ static char** str_tokenize(const char* first, const char* s, char sep, char esc,
 				return NULL;
 			}
 
-			memcpy(arg, cur, size);
+			for (x = 0; x < size; x++)
+			{
+				const char c = cur[x];
+				const char n = cur[x + 1];
+
+				if ((c != esc) && (c != esc2))
+					arg[pos++] = c;
+				else
+				{
+					if ((c == esc2) && (n != esc))
+						arg[pos++] = c;
+					else if (c == esc2)
+					{
+						arg[pos++] = n;
+						x++;
+					}
+				}
+			}
+
 			list[i++] = arg;
 
 			if (*next == '\0')


### PR DESCRIPTION
* This new argument allows reading all other options from `stdin` or a custom file descriptor.
* Enables pipe support for `xfreerdp` as shown in the example
* Credentials can easily be hidden from process environment or command line