### PR TITLE
Fixed certificate accept

### DIFF
--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1528,9 +1528,15 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, const char* hostname,
 			switch (accept_certificate)
 			{
 				case 1:
+
 					/* user accepted certificate, add entry in known_hosts file */
-					verification_status = certificate_data_replace(tls->certificate_store,
-					                      certificate_data);
+					if (match < 0)
+						verification_status = certificate_data_replace(tls->certificate_store,
+						                      certificate_data);
+					else
+						verification_status = certificate_data_print(tls->certificate_store,
+						                      certificate_data);
+
 					break;
 
 				case 2:


### PR DESCRIPTION
certificate_data_replace can only replace an existing entry,
use certificate_data_print for new ones.
