### PR TITLE
X11 extended button remapping support.

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -395,22 +395,6 @@ BOOL xf_generic_ButtonEvent(xfContext* xfc, int x, int y, int button,
 
 	if (flags != 0)
 	{
-		BOOL extended = FALSE;
-
-		if (flags & (PTR_XFLAGS_BUTTON1 | PTR_XFLAGS_BUTTON1))
-		{
-			extended = TRUE;
-
-			if (down)
-				flags |= PTR_XFLAGS_DOWN;
-		}
-
-		if (flags & (PTR_FLAGS_BUTTON1 | PTR_FLAGS_BUTTON2 | PTR_FLAGS_BUTTON3))
-		{
-			if (down)
-				flags |= PTR_FLAGS_DOWN;
-		}
-
 		if (flags & (PTR_FLAGS_WHEEL | PTR_FLAGS_HWHEEL))
 		{
 			if (down)
@@ -418,6 +402,21 @@ BOOL xf_generic_ButtonEvent(xfContext* xfc, int x, int y, int button,
 		}
 		else
 		{
+			BOOL extended = FALSE;
+
+			if (flags & (PTR_XFLAGS_BUTTON1 | PTR_XFLAGS_BUTTON2))
+			{
+				extended = TRUE;
+
+				if (down)
+					flags |= PTR_XFLAGS_DOWN;
+			}
+			else if (flags & (PTR_FLAGS_BUTTON1 | PTR_FLAGS_BUTTON2 | PTR_FLAGS_BUTTON3))
+			{
+				if (down)
+					flags |= PTR_FLAGS_DOWN;
+			}
+
 			if (app)
 			{
 				/* make sure window exists */

--- a/client/X11/xf_event.h
+++ b/client/X11/xf_event.h
@@ -29,12 +29,14 @@ BOOL xf_event_action_script_init(xfContext* xfc);
 void xf_event_action_script_free(xfContext* xfc);
 
 BOOL xf_event_process(freerdp* instance, XEvent* event);
-void xf_event_SendClientEvent(xfContext* xfc, xfWindow* window, Atom atom, unsigned int numArgs, ...);
+void xf_event_SendClientEvent(xfContext* xfc, xfWindow* window, Atom atom, unsigned int numArgs,
+                              ...);
 
-void xf_event_adjust_coordinates(xfContext* xfc, int* x, int *y);
+void xf_event_adjust_coordinates(xfContext* xfc, int* x, int* y);
 
 BOOL xf_generic_MotionNotify(xfContext* xfc, int x, int y, int state, Window window, BOOL app);
 BOOL xf_generic_ButtonPress(xfContext* xfc, int x, int y, int button, Window window, BOOL app);
-BOOL xf_generic_ButtonRelease(xfContext* xfc, int x, int y, int button, Window window, BOOL app);
+BOOL xf_generic_ButtonEvent(xfContext* xfc, int x, int y, int button, Window window, BOOL app,
+                            BOOL down);
 
 #endif /* FREERDP_CLIENT_X11_EVENT_H */

--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -581,13 +581,13 @@ static int xf_input_event(xfContext* xfc, XIDeviceEvent* event, int evtype)
 	switch (evtype)
 	{
 		case XI_ButtonPress:
-			xf_generic_ButtonPress(xfc, (int) event->event_x, (int) event->event_y,
-			                       event->detail, event->event, xfc->remote_app);
+			xf_generic_ButtonEvent(xfc, (int) event->event_x, (int) event->event_y,
+			                       event->detail, event->event, xfc->remote_app, TRUE);
 			break;
 
 		case XI_ButtonRelease:
-			xf_generic_ButtonRelease(xfc, (int) event->event_x, (int) event->event_y,
-			                         event->detail, event->event, xfc->remote_app);
+			xf_generic_ButtonEvent(xfc, (int) event->event_x, (int) event->event_y,
+			                       event->detail, event->event, xfc->remote_app, FALSE);
 			break;
 
 		case XI_Motion:

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -85,13 +85,14 @@ typedef struct _xfDispContext xfDispContext;
 typedef struct _xfVideoContext xfVideoContext;
 typedef struct xf_rail_icon_cache xfRailIconCache;
 
-/* Value of the first logical button number in X11 which must be */
-/* subtracted to go from a button number in X11 to an index into */
-/* a per-button array.                                           */
-#define BUTTON_BASE Button1
-
 /* Number of buttons that are mapped from X11 to RDP button events. */
-#define NUM_BUTTONS_MAPPED 3
+#define NUM_BUTTONS_MAPPED 11
+
+typedef struct
+{
+	int button;
+	UINT16 flags;
+} button_map;
 
 struct xf_context
 {
@@ -231,7 +232,7 @@ struct xf_context
 	BOOL xrenderAvailable;
 
 	/* value to be sent over wire for each logical client mouse button */
-	int button_map[NUM_BUTTONS_MAPPED];
+	button_map button_map[NUM_BUTTONS_MAPPED];
 	BYTE savedMaximizedState;
 };
 


### PR DESCRIPTION
Up until now X11 mouse button remapping was only possible for the
default buttons 1 to 3.
With this pull any X11 mouse button can be mapped to any RDP mouse
event and all X11 remappings are respected.
Should also fix the issues with #5112