### PR TITLE
New option to disable user certificate dialog

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2606,6 +2606,10 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		{
 			settings->AutoAcceptCertificate = enable;
 		}
+		CommandLineSwitchCase(arg, "cert-deny")
+		{
+			settings->AutoDenyCertificate = enable;
+		}
 		CommandLineSwitchCase(arg, "authentication")
 		{
 			settings->Authentication = enable;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -46,6 +46,7 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "bitmap-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "bitmap cache" },
 	{ "bpp", COMMAND_LINE_VALUE_REQUIRED, "<depth>", "16", NULL, -1, NULL, "Session bpp (color depth)" },
 	{ "buildconfig", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT_BUILDCONFIG, NULL, NULL, NULL, -1, NULL, "Print the build configuration" },
+	{ "cert-deny", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Automatically abort connection for any certificate that can not be validated." },
 	{ "cert-ignore", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Ignore certificate" },
 	{ "cert-name", COMMAND_LINE_VALUE_REQUIRED, "<name>", NULL, NULL, -1, NULL, "Certificate name" },
 	{ "cert-tofu", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Automatically accept certificate on first connect" },

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -682,6 +682,7 @@ typedef struct _RDPDR_PARALLEL RDPDR_PARALLEL;
 #define FreeRDP_PrivateKeyContent                                  (1417)
 #define FreeRDP_RdpKeyContent                                      (1418)
 #define FreeRDP_AutoAcceptCertificate                              (1419)
+#define FreeRDP_AutoDenyCertificate                                (1420)
 #define FreeRDP_Workarea                                           (1536)
 #define FreeRDP_Fullscreen                                         (1537)
 #define FreeRDP_PercentScreen                                      (1538)
@@ -1136,7 +1137,8 @@ struct rdp_settings
 	ALIGN64 char*           PrivateKeyContent;             /* 1417 */
 	ALIGN64 char*           RdpKeyContent;                 /* 1418 */
 	ALIGN64 BOOL            AutoAcceptCertificate;         /* 1419 */
-	UINT64 padding1472[1472 - 1420]; /* 1420 */
+	ALIGN64 BOOL            AutoDenyCertificate;           /* 1420 */
+	UINT64 padding1472[1472 - 1421]; /* 1421 */
 	UINT64 padding1536[1536 - 1472]; /* 1472 */
 
 	/**

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -919,6 +919,9 @@ BOOL freerdp_get_param_bool(rdpSettings* settings, int id)
 		case FreeRDP_IgnoreCertificate:
 			return settings->IgnoreCertificate;
 
+		case FreeRDP_AutoDenyCertificate:
+			return settings->AutoDenyCertificate;
+
 		case FreeRDP_AutoAcceptCertificate:
 			return settings->AutoAcceptCertificate;
 
@@ -1378,6 +1381,10 @@ int freerdp_set_param_bool(rdpSettings* settings, int id, BOOL param)
 
 		case FreeRDP_IgnoreCertificate:
 			settings->IgnoreCertificate = param;
+			break;
+
+		case FreeRDP_AutoDenyCertificate:
+			settings->AutoDenyCertificate = param;
 			break;
 
 		case FreeRDP_AutoAcceptCertificate:

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1444,6 +1444,11 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, const char* hostname,
 					WLog_INFO(TAG, "No certificate stored, automatically accepting.");
 					accept_certificate = 1;
 				}
+				else if (tls->settings->AutoDenyCertificate)
+				{
+					WLog_INFO(TAG, "No certificate stored, automatically denying.");
+					accept_certificate = 0;
+				}
 				else if (instance->VerifyX509Certificate)
 				{
 					int rc = instance->VerifyX509Certificate(instance, pemCert, length, hostname,
@@ -1488,7 +1493,12 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, const char* hostname,
 					WLog_WARN(TAG, "Failed to get certificate entry for %s:%d",
 					          hostname, port);
 
-				if (instance->VerifyX509Certificate)
+				if (tls->settings->AutoDenyCertificate)
+				{
+					WLog_INFO(TAG, "No certificate stored, automatically denying.");
+					accept_certificate = 0;
+				}
+				else if (instance->VerifyX509Certificate)
 				{
 					const int rc = instance->VerifyX509Certificate(instance, pemCert, length, hostname,
 					               port, flags | VERIFY_CERT_FLAG_CHANGED);


### PR DESCRIPTION
The new option +cert-deny aborts a connection automatically if
the certificate can not be validated by OpenSSL or via known hosts.