### PR TITLE
enable fonts smoothing per default, part two

### DIFF
--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -357,7 +357,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	settings->SoftwareGdi = TRUE;
 	settings->UnmapButtons = FALSE;
 	settings->PerformanceFlags = PERF_FLAG_NONE;
-	settings->AllowFontSmoothing = FALSE;
+	settings->AllowFontSmoothing = TRUE;
 	settings->AllowDesktopComposition = FALSE;
 	settings->DisableWallpaper = FALSE;
 	settings->DisableFullWindowDrag = TRUE;


### PR DESCRIPTION
This is a follow-up for #5133 and fixes #5169.
