### PR TITLE
resolve several issues found by cppcheck

### DIFF
--- a/channels/audin/client/opensles/audin_opensl_es.c
+++ b/channels/audin/client/opensles/audin_opensl_es.c
@@ -93,11 +93,6 @@ static UINT audin_opensles_free(IAudinDevice* device)
 
 	WLog_Print(opensles->log, WLOG_DEBUG, "device=%p", (void*) device);
 
-	/* The function may have been called out of order,
-	 * ignore duplicate requests. */
-	if (!opensles)
-		return CHANNEL_RC_OK;
-
 	free(opensles->device_name);
 	free(opensles);
 	return CHANNEL_RC_OK;
@@ -153,11 +148,6 @@ static UINT audin_opensles_set_format(IAudinDevice* device,
 	WLog_Print(opensles->log, WLOG_DEBUG, "device=%p, format=%p, FramesPerPacket=%"PRIu32"",
 	           (void*) device, (void*) format, FramesPerPacket);
 	assert(format);
-
-	/* The function may have been called out of order, ignore
-	 * requests before the device is available. */
-	if (!opensles)
-		return CHANNEL_RC_OK;
 
 	opensles->format = *format;
 

--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -1447,11 +1447,11 @@ static UINT drdynvc_virtual_channel_event_disconnected(drdynvcPlugin* drdynvc)
 {
 	UINT status;
 
-	if (drdynvc->OpenHandle == 0)
-		return CHANNEL_RC_OK;
-
 	if (!drdynvc)
 		return CHANNEL_RC_BAD_CHANNEL_HANDLE;
+
+	if (drdynvc->OpenHandle == 0)
+		return CHANNEL_RC_OK;
 
 	if (!MessageQueue_PostQuit(drdynvc->queue, 0))
 	{

--- a/client/X11/xf_floatbar.c
+++ b/client/X11/xf_floatbar.c
@@ -797,9 +797,6 @@ void xf_floatbar_free(xfFloatbar* floatbar)
 	xfc = floatbar->xfc;
 	size = ARRAYSIZE(floatbar->buttons);
 
-	if (!floatbar)
-		return;
-
 	for (i = 0; i < size; i++)
 	{
 		xf_floatbar_button_free(xfc, floatbar->buttons[i]);

--- a/libfreerdp/codec/dsp.c
+++ b/libfreerdp/codec/dsp.c
@@ -1151,10 +1151,12 @@ BOOL freerdp_dsp_encode(FREERDP_DSP_CONTEXT* context, const AUDIO_FORMAT* srcFor
 #else
 	const BYTE* resampleData;
 	size_t resampleLength;
-	AUDIO_FORMAT format = *srcFormat;
+	AUDIO_FORMAT format;
 
 	if (!context || !context->encoder || !srcFormat || !data || !out)
 		return FALSE;
+
+	format = *srcFormat;
 
 	if (!freerdp_dsp_channel_mix(context, data, length, srcFormat, &resampleData, &resampleLength))
 		return FALSE;


### PR DESCRIPTION
[channels/audin/client/opensles/audin_opensl_es.c:98] -> [channels/audin/client/opensles/audin_opensl_es.c:94]: (warning) Either the condition '!opensles' is redundant or there is possible null pointer dereference: opensles.
[channels/audin/client/opensles/audin_opensl_es.c:159] -> [channels/audin/client/opensles/audin_opensl_es.c:153]: (warning) Either the condition '!opensles' is redundant or there is possible null pointer dereference: opensles.