### PR TITLE
Fix #5170: Disable custom TLS alert for libressl > 2.8.3

### DIFF
--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1030,7 +1030,8 @@ BOOL tls_send_alert(rdpTls* tls)
 	 * FIXME: The following code does not work on OpenSSL > 1.1.0 because the
 	 *        SSL struct is opaqe now
 	 */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if (!defined(LIBRESSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER < 0x10100000L)) || \
+	(defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER <= 0x2080300fL))
 
 	if (tls->alertDescription != TLS_ALERT_DESCRIPTION_CLOSE_NOTIFY)
 	{
@@ -1057,7 +1058,6 @@ BOOL tls_send_alert(rdpTls* tls)
 		if (tls->ssl->s3->wbuf.left == 0)
 			tls->ssl->method->ssl_dispatch_alert(tls->ssl);
 	}
-
 #endif
 	return TRUE;
 }


### PR DESCRIPTION
Disable `tls_send_alert` for `libressl > 2.8.3` just like with `openssl 1.1`