### PR TITLE
Wayland and warning fixes

### DIFF
--- a/channels/drive/client/drive_file.h
+++ b/channels/drive/client/drive_file.h
@@ -40,7 +40,7 @@ struct _DRIVE_FILE
 	HANDLE file_handle;
 	HANDLE find_handle;
 	WIN32_FIND_DATAW find_data;
-	WCHAR* basepath;
+	const WCHAR* basepath;
 	WCHAR* fullpath;
 	WCHAR* filename;
 	BOOL delete_pending;

--- a/client/Wayland/wlfreerdp.h
+++ b/client/Wayland/wlfreerdp.h
@@ -42,8 +42,6 @@ struct wlf_context
 	HANDLE displayHandle;
 	UwacWindow* window;
 
-	BOOL waitingFrameDone;
-	BOOL haveDamage;
 	BOOL fullscreen;
 
 	/* Channels */

--- a/include/freerdp/channels/cliprdr.h
+++ b/include/freerdp/channels/cliprdr.h
@@ -203,7 +203,7 @@ struct _CLIPRDR_FORMAT_DATA_RESPONSE
 {
 	DEFINE_CLIPRDR_HEADER_COMMON();
 
-	BYTE* requestedFormatData;
+	const BYTE* requestedFormatData;
 };
 typedef struct _CLIPRDR_FORMAT_DATA_RESPONSE CLIPRDR_FORMAT_DATA_RESPONSE;
 
@@ -229,7 +229,7 @@ struct _CLIPRDR_FILE_CONTENTS_RESPONSE
 	UINT32 streamId;
 	UINT32 dwFlags;
 	UINT32 cbRequested;
-	BYTE* requestedData;
+	const BYTE* requestedData;
 };
 typedef struct _CLIPRDR_FILE_CONTENTS_RESPONSE CLIPRDR_FILE_CONTENTS_RESPONSE;
 

--- a/libfreerdp/codec/dsp.c
+++ b/libfreerdp/codec/dsp.c
@@ -111,6 +111,17 @@ struct _FREERDP_DSP_CONTEXT
 #endif
 };
 
+static INT16 read_int16(const BYTE* src)
+{
+	return (INT16) (src[0] | (src[1] << 8));
+}
+
+static void write_int16(BYTE* dst, INT32 val)
+{
+	dst[1] = (val >> 8) & 0xFF;
+	dst[0] = val & 0xFF;
+}
+
 static BOOL freerdp_dsp_channel_mix(FREERDP_DSP_CONTEXT* context,
                                     const BYTE* src, size_t size,
                                     const AUDIO_FORMAT* srcFormat,
@@ -208,11 +219,11 @@ static BOOL freerdp_dsp_resample(FREERDP_DSP_CONTEXT* context,
 #if defined(WITH_SOXR)
 	soxr_error_t error;
 	size_t idone, odone;
-#endif
 	size_t sframes, rframes;
 	size_t rsize;
 	size_t j;
 	size_t sbytes, rbytes;
+#endif
 	size_t srcBytesPerFrame, dstBytesPerFrame;
 	size_t srcChannels, dstChannels;
 	AUDIO_FORMAT format;
@@ -256,6 +267,10 @@ static BOOL freerdp_dsp_resample(FREERDP_DSP_CONTEXT* context,
 	*length = Stream_Length(context->resample);
 	return (error == 0) ? TRUE : FALSE;
 #else
+	WINPR_UNUSED(src);
+	WINPR_UNUSED(size);
+	WINPR_UNUSED(data);
+	WINPR_UNUSED(length);
 	WLog_ERR(TAG, "Missing resample support, recompile -DWITH_SOXR=ON or -DWITH_DSP_FFMPEG=ON");
 	return FALSE;
 #endif
@@ -331,11 +346,11 @@ static BOOL freerdp_dsp_decode_ima_adpcm(FREERDP_DSP_CONTEXT* context,
 	BYTE* dst;
 	BYTE sample;
 	UINT16 decoded;
-	UINT32 out_size = size * 4;
+	size_t out_size = size * 4;
 	UINT32 channel;
 	const UINT32 block_size = context->format.nBlockAlign;
 	const UINT32 channels = context->format.nChannels;
-	int i;
+	size_t i;
 
 	if (!Stream_EnsureCapacity(out, out_size))
 		return FALSE;
@@ -410,7 +425,7 @@ static BOOL freerdp_dsp_decode_gsm610(FREERDP_DSP_CONTEXT* context,
 	{
 		int rc;
 		gsm_signal gsmBlockBuffer[160] = { 0 };
-		rc = gsm_decode(context->gsm, (gsm_byte*) &src[offset], gsmBlockBuffer);
+		rc = gsm_decode(context->gsm, (gsm_byte*) /* API does not modify */ &src[offset], gsmBlockBuffer);
 
 		if (rc < 0)
 			return FALSE;
@@ -436,12 +451,12 @@ static BOOL freerdp_dsp_encode_gsm610(FREERDP_DSP_CONTEXT* context,
 
 	while (offset < size)
 	{
-		gsm_signal* signal = (gsm_signal*)&src[offset];
+		const gsm_signal* signal = (const gsm_signal*)&src[offset];
 
 		if (!Stream_EnsureRemainingCapacity(out, sizeof(gsm_frame)))
 			return FALSE;
 
-		gsm_encode(context->gsm, signal, Stream_Pointer(out));
+		gsm_encode(context->gsm, (gsm_signal*) /* API does not modify */ signal, Stream_Pointer(out));
 
 		if ((offset % 65) == 0)
 			Stream_Seek(out, 33);
@@ -480,13 +495,13 @@ static BOOL freerdp_dsp_decode_mp3(FREERDP_DSP_CONTEXT* context,
 	if (rc <= 0)
 		return FALSE;
 
-	if (!Stream_EnsureRemainingCapacity(out, rc * context->format.nChannels * 2))
+	if (!Stream_EnsureRemainingCapacity(out, (size_t)rc * context->format.nChannels * 2))
 		return FALSE;
 
 	for (x = 0; x < rc; x++)
 	{
-		Stream_Write_UINT16(out, pcm_l[x]);
-		Stream_Write_UINT16(out, pcm_r[x]);
+		Stream_Write_UINT16(out, (UINT16)pcm_l[x]);
+		Stream_Write_UINT16(out, (UINT16)pcm_r[x]);
 	}
 
 	return TRUE;
@@ -504,7 +519,7 @@ static BOOL freerdp_dsp_encode_mp3(FREERDP_DSP_CONTEXT* context,
 	samples_per_channel = size / context->format.nChannels / context->format.wBitsPerSample / 8;
 
 	/* Ensure worst case buffer size for mp3 stream taken from LAME header */
-	if (!Stream_EnsureRemainingCapacity(out, 1.25 * samples_per_channel + 7200))
+	if (!Stream_EnsureRemainingCapacity(out, 5 / 4 * samples_per_channel + 7200))
 		return FALSE;
 
 	samples_per_channel = size / 2 /* size of a sample */ / context->format.nChannels;
@@ -514,7 +529,7 @@ static BOOL freerdp_dsp_encode_mp3(FREERDP_DSP_CONTEXT* context,
 	if (rc < 0)
 		return FALSE;
 
-	Stream_Seek(out, rc);
+	Stream_Seek(out, (size_t)rc);
 	return TRUE;
 }
 #endif
@@ -523,10 +538,10 @@ static BOOL freerdp_dsp_encode_mp3(FREERDP_DSP_CONTEXT* context,
 static BOOL freerdp_dsp_encode_faac(FREERDP_DSP_CONTEXT* context,
                                     const BYTE* src, size_t size, wStream* out)
 {
-	int16_t* inSamples = (int16_t*)src;
+	const int16_t* inSamples = (const int16_t*)src;
 	int32_t* outSamples;
 	unsigned int bpp;
-	unsigned int nrSamples, x;
+	size_t nrSamples, x;
 	int rc;
 
 	if (!context || !src || !out)
@@ -553,7 +568,7 @@ static BOOL freerdp_dsp_encode_faac(FREERDP_DSP_CONTEXT* context,
 	if (rc < 0)
 		return FALSE;
 	else if (rc > 0)
-		Stream_Seek(out, rc);
+		Stream_Seek(out, (size_t)rc);
 
 	return TRUE;
 }
@@ -574,7 +589,7 @@ static BOOL freerdp_dsp_decode_faad(FREERDP_DSP_CONTEXT* context,
 	{
 		unsigned long samplerate;
 		unsigned char channels;
-		char err = NeAACDecInit(context->faad, /* API is not modifying content */(unsigned char*)src,
+		long err = NeAACDecInit(context->faad, /* API is not modifying content */(unsigned char*)src,
 		                        size, &samplerate, &channels);
 
 		if (err != 0)
@@ -721,7 +736,7 @@ static BOOL freerdp_dsp_encode_ima_adpcm(FREERDP_DSP_CONTEXT* context,
 	BYTE* start;
 	INT16 sample;
 	BYTE encoded;
-	UINT32 out_size;
+	size_t out_size;
 	size_t align;
 	out_size = size / 2;
 
@@ -807,7 +822,7 @@ static INLINE INT16 freerdp_dsp_decode_ms_adpcm_sample(ADPCM* adpcm, BYTE sample
 {
 	INT8 nibble;
 	INT32 presample;
-	nibble = (sample & 0x08 ? (INT8) sample - 16 : sample);
+	nibble = (sample & 0x08 ? (INT8) sample - 16 : (INT8)sample);
 	presample = ((adpcm->ms.sample1[channel] * ms_adpcm_coeffs1[adpcm->ms.predictor[channel]]) +
 	             (adpcm->ms.sample2[channel] * ms_adpcm_coeffs2[adpcm->ms.predictor[channel]])) / 256;
 	presample += nibble * adpcm->ms.delta[channel];
@@ -832,7 +847,7 @@ static BOOL freerdp_dsp_decode_ms_adpcm(FREERDP_DSP_CONTEXT* context,
 {
 	BYTE* dst;
 	BYTE sample;
-	const UINT32 out_size = size * 4;
+	const size_t out_size = size * 4;
 	const UINT32 channels = context->format.nChannels;
 	const UINT32 block_size = context->format.nBlockAlign;
 
@@ -849,41 +864,41 @@ static BOOL freerdp_dsp_decode_ms_adpcm(FREERDP_DSP_CONTEXT* context,
 			{
 				context->adpcm.ms.predictor[0] = *src++;
 				context->adpcm.ms.predictor[1] = *src++;
-				context->adpcm.ms.delta[0] = *((INT16*) src);
+				context->adpcm.ms.delta[0] = read_int16(src);
 				src += 2;
-				context->adpcm.ms.delta[1] = *((INT16*) src);
+				context->adpcm.ms.delta[1] = read_int16(src);
 				src += 2;
-				context->adpcm.ms.sample1[0] = *((INT16*) src);
+				context->adpcm.ms.sample1[0] = read_int16(src);
 				src += 2;
-				context->adpcm.ms.sample1[1] = *((INT16*) src);
+				context->adpcm.ms.sample1[1] = read_int16(src);
 				src += 2;
-				context->adpcm.ms.sample2[0] = *((INT16*) src);
+				context->adpcm.ms.sample2[0] = read_int16(src);
 				src += 2;
-				context->adpcm.ms.sample2[1] = *((INT16*) src);
+				context->adpcm.ms.sample2[1] = read_int16(src);
 				src += 2;
 				size -= 14;
-				*((INT16*) dst) = context->adpcm.ms.sample2[0];
+				write_int16(dst, context->adpcm.ms.sample2[0]);
 				dst += 2;
-				*((INT16*) dst) = context->adpcm.ms.sample2[1];
+				write_int16(dst, context->adpcm.ms.sample2[1]);
 				dst += 2;
-				*((INT16*) dst) = context->adpcm.ms.sample1[0];
+				write_int16(dst, context->adpcm.ms.sample1[0]);
 				dst += 2;
-				*((INT16*) dst) = context->adpcm.ms.sample1[1];
+				write_int16(dst, context->adpcm.ms.sample1[1]);
 				dst += 2;
 			}
 			else
 			{
 				context->adpcm.ms.predictor[0] = *src++;
-				context->adpcm.ms.delta[0] = *((INT16*) src);
+				context->adpcm.ms.delta[0] = read_int16(src);
 				src += 2;
-				context->adpcm.ms.sample1[0] = *((INT16*) src);
+				context->adpcm.ms.sample1[0] = read_int16(src);
 				src += 2;
-				context->adpcm.ms.sample2[0] = *((INT16*) src);
+				context->adpcm.ms.sample2[0] = read_int16(src);
 				src += 2;
 				size -= 7;
-				*((INT16*) dst) = context->adpcm.ms.sample2[0];
+				write_int16(dst, context->adpcm.ms.sample2[0]);
 				dst += 2;
-				*((INT16*) dst) = context->adpcm.ms.sample1[0];
+				write_int16(dst, context->adpcm.ms.sample1[0]);
 				dst += 2;
 			}
 		}
@@ -892,24 +907,24 @@ static BOOL freerdp_dsp_decode_ms_adpcm(FREERDP_DSP_CONTEXT* context,
 		{
 			sample = *src++;
 			size--;
-			*((INT16*) dst) = freerdp_dsp_decode_ms_adpcm_sample(&context->adpcm, sample >> 4, 0);
+			write_int16(dst, freerdp_dsp_decode_ms_adpcm_sample(&context->adpcm, sample >> 4, 0));
 			dst += 2;
-			*((INT16*) dst) = freerdp_dsp_decode_ms_adpcm_sample(&context->adpcm, sample & 0x0F, 1);
+			write_int16(dst, freerdp_dsp_decode_ms_adpcm_sample(&context->adpcm, sample & 0x0F, 1));
 			dst += 2;
 			sample = *src++;
 			size--;
-			*((INT16*) dst) = freerdp_dsp_decode_ms_adpcm_sample(&context->adpcm, sample >> 4, 0);
+			write_int16(dst, freerdp_dsp_decode_ms_adpcm_sample(&context->adpcm, sample >> 4, 0));
 			dst += 2;
-			*((INT16*) dst) = freerdp_dsp_decode_ms_adpcm_sample(&context->adpcm, sample & 0x0F, 1);
+			write_int16(dst, freerdp_dsp_decode_ms_adpcm_sample(&context->adpcm, sample & 0x0F, 1));
 			dst += 2;
 		}
 		else
 		{
 			sample = *src++;
 			size--;
-			*((INT16*) dst) = freerdp_dsp_decode_ms_adpcm_sample(&context->adpcm, sample >> 4, 0);
+			write_int16(dst, freerdp_dsp_decode_ms_adpcm_sample(&context->adpcm, sample >> 4, 0));
 			dst += 2;
-			*((INT16*) dst) = freerdp_dsp_decode_ms_adpcm_sample(&context->adpcm, sample & 0x0F, 0);
+			write_int16(dst, freerdp_dsp_decode_ms_adpcm_sample(&context->adpcm, sample & 0x0F, 0));
 			dst += 2;
 		}
 	}
@@ -958,7 +973,7 @@ static BOOL freerdp_dsp_encode_ms_adpcm(FREERDP_DSP_CONTEXT* context, const BYTE
 	BYTE* dst;
 	BYTE* start;
 	INT32 sample;
-	UINT32 out_size;
+	size_t out_size;
 	const size_t step = 8 + ((context->format.nChannels > 1) ? 4 : 0);
 	out_size = size / 2;
 
@@ -985,14 +1000,14 @@ static BOOL freerdp_dsp_encode_ms_adpcm(FREERDP_DSP_CONTEXT* context, const BYTE
 				*dst++ = (BYTE)((context->adpcm.ms.delta[0] >> 8) & 0xFF);
 				*dst++ = (BYTE)(context->adpcm.ms.delta[1] & 0xFF);
 				*dst++ = (BYTE)((context->adpcm.ms.delta[1] >> 8) & 0xFF);
-				context->adpcm.ms.sample1[0] = *((INT16*)(src + 4));
-				context->adpcm.ms.sample1[1] = *((INT16*)(src + 6));
-				context->adpcm.ms.sample2[0] = *((INT16*)(src + 0));
-				context->adpcm.ms.sample2[1] = *((INT16*)(src + 2));
-				*((INT16*)(dst + 0)) = (INT16) context->adpcm.ms.sample1[0];
-				*((INT16*)(dst + 2)) = (INT16) context->adpcm.ms.sample1[1];
-				*((INT16*)(dst + 4)) = (INT16) context->adpcm.ms.sample2[0];
-				*((INT16*)(dst + 6)) = (INT16) context->adpcm.ms.sample2[1];
+				context->adpcm.ms.sample1[0] = read_int16(src + 4);
+				context->adpcm.ms.sample1[1] = read_int16(src + 6);
+				context->adpcm.ms.sample2[0] = read_int16(src + 0);
+				context->adpcm.ms.sample2[1] = read_int16(src + 2);
+				write_int16(dst + 0, context->adpcm.ms.sample1[0]);
+				write_int16(dst + 2, context->adpcm.ms.sample1[1]);
+				write_int16(dst + 4, context->adpcm.ms.sample2[0]);
+				write_int16(dst + 6, context->adpcm.ms.sample2[1]);
 				dst += 8;
 				src += 8;
 				size -= 8;
@@ -1002,20 +1017,20 @@ static BOOL freerdp_dsp_encode_ms_adpcm(FREERDP_DSP_CONTEXT* context, const BYTE
 				*dst++ = context->adpcm.ms.predictor[0];
 				*dst++ = (BYTE)(context->adpcm.ms.delta[0] & 0xFF);
 				*dst++ = (BYTE)((context->adpcm.ms.delta[0] >> 8) & 0xFF);
-				context->adpcm.ms.sample1[0] = *((INT16*)(src + 2));
-				context->adpcm.ms.sample2[0] = *((INT16*)(src + 0));
-				*((INT16*)(dst + 0)) = (INT16) context->adpcm.ms.sample1[0];
-				*((INT16*)(dst + 2)) = (INT16) context->adpcm.ms.sample2[0];
+				context->adpcm.ms.sample1[0] = read_int16(src + 2);
+				context->adpcm.ms.sample2[0] = read_int16(src + 0);
+				write_int16(dst + 0, context->adpcm.ms.sample1[0]);
+				write_int16(dst + 2, context->adpcm.ms.sample2[0]);
 				dst += 4;
 				src += 4;
 				size -= 4;
 			}
 		}
 
-		sample = *((INT16*) src);
+		sample = read_int16(src);
 		src += 2;
-		*dst = freerdp_dsp_encode_ms_adpcm_sample(&context->adpcm, sample, 0) << 4;
-		sample = *((INT16*) src);
+		*dst = (freerdp_dsp_encode_ms_adpcm_sample(&context->adpcm, sample, 0) << 4) & 0xFF;
+		sample = read_int16(src);
 		src += 2;
 		*dst += freerdp_dsp_encode_ms_adpcm_sample(&context->adpcm, sample,
 		        context->format.nChannels > 1 ? 1 : 0);
@@ -1258,6 +1273,9 @@ BOOL freerdp_dsp_supports_format(const AUDIO_FORMAT* format, BOOL encode)
 	return freerdp_dsp_ffmpeg_supports_format(format, encode);
 #else
 
+#if !defined(WITH_DSP_EXPERIMENTAL)
+	WINPR_UNUSED(encode);
+#endif
 	switch (format->wFormatTag)
 	{
 		case WAVE_FORMAT_PCM:

--- a/libfreerdp/codec/h264_openh264.c
+++ b/libfreerdp/codec/h264_openh264.c
@@ -375,16 +375,16 @@ static BOOL openh264_load_functionpointers(H264_CONTEXT* h264, const char* name)
 	if (!sysContexts)
 		return FALSE;
 
-	sysContexts->lib = sysContexts->lib = LoadLibraryA(name);
+	sysContexts->lib = LoadLibraryA(name);
 
 	if (!sysContexts->lib)
 		return FALSE;
 
-	sysContexts->WelsGetCodecVersionEx = GetProcAddress(sysContexts->lib, "WelsGetCodecVersionEx");
-	sysContexts->WelsCreateDecoder = GetProcAddress(sysContexts->lib, "WelsCreateDecoder");
-	sysContexts->WelsDestroyDecoder = GetProcAddress(sysContexts->lib, "WelsDestroyDecoder");
-	sysContexts->WelsCreateSVCEncoder = GetProcAddress(sysContexts->lib, "WelsCreateSVCEncoder");
-	sysContexts->WelsDestroySVCEncoder = GetProcAddress(sysContexts->lib, "WelsDestroySVCEncoder");
+	sysContexts->WelsGetCodecVersionEx = (pWelsGetCodecVersionEx) GetProcAddress(sysContexts->lib, "WelsGetCodecVersionEx");
+	sysContexts->WelsCreateDecoder = (pWelsCreateDecoder) GetProcAddress(sysContexts->lib, "WelsCreateDecoder");
+	sysContexts->WelsDestroyDecoder = (pWelsDestroyDecoder) GetProcAddress(sysContexts->lib, "WelsDestroyDecoder");
+	sysContexts->WelsCreateSVCEncoder = (pWelsCreateSVCEncoder) GetProcAddress(sysContexts->lib, "WelsCreateSVCEncoder");
+	sysContexts->WelsDestroySVCEncoder = (pWelsDestroySVCEncoder) GetProcAddress(sysContexts->lib, "WelsDestroySVCEncoder");
 
 	if (!sysContexts->WelsCreateDecoder || !sysContexts->WelsDestroyDecoder ||
 	    !sysContexts->WelsCreateSVCEncoder || !sysContexts->WelsDestroySVCEncoder ||

--- a/uwac/include/uwac/uwac.h
+++ b/uwac/include/uwac/uwac.h
@@ -454,6 +454,16 @@ UWAC_API UwacReturnCode UwacWindowAddDamage(UwacWindow* window, uint32_t x, uint
         uint32_t width, uint32_t height);
 
 /**
+ *	returns the geometry of the given UwacWindow buffer
+ *
+ * @param window   the UwacWindow
+ * @param geometry the geometry to fill
+ * @param stride   the length of a buffer line in bytes
+ * @return UWAC_SUCCESS on success, an Uwac error otherwise
+ */
+UWAC_API UwacReturnCode UwacWindowGetDrawingBufferGeometry(UwacWindow* window, UwacSize* geometry, size_t* stride);
+
+/**
  *	Sends a frame to the compositor with the content of the drawing buffer
  *
  * @param window the UwacWindow to refresh

--- a/uwac/libuwac/uwac-clipboard.c
+++ b/uwac/libuwac/uwac-clipboard.c
@@ -150,6 +150,9 @@ UwacReturnCode UwacSeatRegisterClipboard(UwacSeat* s)
 	if (!s)
 		return UWAC_ERROR_INTERNAL;
 
+	if (!s->display->data_device_manager || !s->data_device)
+		return UWAC_NOT_ENOUGH_RESOURCES;
+
 	UwacRegisterDeviceListener(s);
 
 	rc = UwacCreateDataSource(s);

--- a/uwac/libuwac/uwac-display.c
+++ b/uwac/libuwac/uwac-display.c
@@ -147,7 +147,8 @@ static void UwacSeatRegisterDDM(UwacSeat *seat)
 	if (!d->data_device_manager)
 		return;
 
-	seat->data_device = wl_data_device_manager_get_data_device(d->data_device_manager, seat->seat);
+	if (!seat->data_device)
+		seat->data_device = wl_data_device_manager_get_data_device(d->data_device_manager, seat->seat);
 }
 
 static void registry_handle_global(void* data, struct wl_registry* registry, uint32_t id,
@@ -222,6 +223,7 @@ static void registry_handle_global(void* data, struct wl_registry* registry, uin
 		wl_list_for_each(seat, &d->seats, link)
 		{
 			UwacSeatRegisterDDM(seat);
+			UwacSeatRegisterClipboard(seat);
 		}
 	}
 	else if (strcmp(interface, "wl_shell") == 0)

--- a/uwac/libuwac/uwac-priv.h
+++ b/uwac/libuwac/uwac-priv.h
@@ -223,7 +223,6 @@ struct uwac_window {
 
 	struct wl_region *opaque_region;
 	struct wl_region *input_region;
-	struct wl_callback *frame_callback;
 	UwacBuffer *drawingBuffer, *pendingBuffer;
 	struct wl_surface *surface;
 	struct wl_shell_surface *shell_surface;

--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -670,6 +670,22 @@ UwacReturnCode UwacWindowAddDamage(UwacWindow* window, uint32_t x, uint32_t y, u
 	return UWAC_SUCCESS;
 }
 
+UwacReturnCode UwacWindowGetDrawingBufferGeometry(UwacWindow* window, UwacSize* geometry, size_t* stride)
+{
+	if (!window || !window->drawingBuffer)
+		return UWAC_ERROR_INTERNAL;
+
+	if (geometry)
+	{
+		geometry->width = window->width;
+		geometry->height = window->height;
+	}
+
+	if (stride)
+		*stride = window->stride;
+
+	return UWAC_SUCCESS;
+}
 
 UwacReturnCode UwacWindowSubmitBuffer(UwacWindow* window, bool copyContentForNextFrame)
 {

--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -515,9 +515,6 @@ UwacReturnCode UwacDestroyWindow(UwacWindow** pwindow)
 	w = *pwindow;
 	UwacWindowDestroyBuffers(w);
 
-	if (w->frame_callback)
-		wl_callback_destroy(w->frame_callback);
-
 	if (w->deco)
 		zxdg_toplevel_decoration_v1_destroy(w->deco);
 
@@ -607,6 +604,7 @@ static void UwacSubmitBufferPtr(UwacWindow* window, UwacBuffer* buffer)
 	const RECTANGLE_16* box;
 #endif
 	wl_surface_attach(window->surface, buffer->wayland_buffer, 0, 0);
+#if 0
 #ifdef HAVE_PIXMAN_REGION
 	box = pixman_region32_rectangles(&buffer->damage, &nrects);
 
@@ -621,12 +619,11 @@ static void UwacSubmitBufferPtr(UwacWindow* window, UwacBuffer* buffer)
 		                  (box->bottom - box->top));
 
 #endif
-
-	if (window->frame_callback)
-		wl_callback_destroy(window->frame_callback);
-
-	window->frame_callback = wl_surface_frame(window->surface);
-	wl_callback_add_listener(window->frame_callback, &frame_listener, window);
+#else
+	wl_surface_damage(window->surface, 0, 0, window->width, window->height);
+#endif
+	struct wl_callback* frame_callback = wl_surface_frame(window->surface);
+	wl_callback_add_listener(frame_callback, &frame_listener, window);
 	wl_surface_commit(window->surface);
 #ifdef HAVE_PIXMAN_REGION
 	pixman_region32_clear(&buffer->damage);
@@ -640,6 +637,8 @@ static void frame_done_cb(void* data, struct wl_callback* callback, uint32_t tim
 {
 	UwacWindow* window = (UwacWindow*)data;
 	UwacFrameDoneEvent* event;
+
+	wl_callback_destroy(callback);
 	window->pendingBuffer = NULL;
 	event = (UwacFrameDoneEvent*)UwacDisplayNewEvent(window->display, UWAC_EVENT_FRAME_DONE);
 
@@ -692,14 +691,8 @@ UwacReturnCode UwacWindowSubmitBuffer(UwacWindow* window, bool copyContentForNex
 	UwacBuffer* drawingBuffer = window->drawingBuffer;
 
 	if (window->pendingBuffer)
-	{
-		/* we already have a pending frame. resubmit as the buffer
-		 * might have been discarded due to focus loss */
-		UwacSubmitBufferPtr(window, window->pendingBuffer);
 		return UWAC_SUCCESS;
-	}
 
-	UwacSubmitBufferPtr(window, drawingBuffer);
 	window->pendingBuffer = window->drawingBuffer;
 	window->drawingBuffer = UwacWindowFindFreeBuffer(window);
 
@@ -707,10 +700,9 @@ UwacReturnCode UwacWindowSubmitBuffer(UwacWindow* window, bool copyContentForNex
 		return UWAC_ERROR_NOMEMORY;
 
 	if (copyContentForNextFrame)
-	{
 		memcpy(window->drawingBuffer->data, window->pendingBuffer->data, window->stride * window->height);
-	}
 
+	UwacSubmitBufferPtr(window, drawingBuffer);
 	return UWAC_SUCCESS;
 }
 


### PR DESCRIPTION
* Removed frame done check in wayland client (it is unreliable and might only be used to reduce frame updates according to https://wayland.freedesktop.org/docs/html/apa.html `wl_surface::frame - request a frame throttling hint` description
* Removed buffer submit multi buffer handling in UWAC, use a single buffer for all updates (@hardening this is working on my test machines without glitches, as soon as I reenable the old behaviour I get missed screen updates on mass, could you confirm or point out any error?)
* Fixes a crash when clipboard is registered due to not all resources being initialized yet.
* Fixes some compiler and static analyzer warnings
