### PR TITLE
change SetTimer elapse from 10 to USER_TIMER_MINIMUM 

### DIFF
--- a/client/Windows/wf_floatbar.c
+++ b/client/Windows/wf_floatbar.c
@@ -128,7 +128,7 @@ static BOOL floatbar_animation(wfFloatBar* const floatbar, const BOOL show)
 
 	floatbar->animating = timer;
 
-	if (SetTimer(floatbar->hwnd, timer, 10, NULL) == NULL)
+	if (SetTimer(floatbar->hwnd, timer, USER_TIMER_MINIMUM, NULL) == NULL)
 	{
 		DWORD err = GetLastError();
 		WLog_ERR(TAG, "SetTimer failed with %08"PRIx32, err);


### PR DESCRIPTION
If uElapse is less than USER_TIMER_MINIMUM (0x0000000A), the timeout is set to USER_TIMER_MINIMUM. If uElapse is greater than USER_TIMER_MAXIMUM (0x7FFFFFFF), the timeout is set to USER_TIMER_MAXIMUM.