### PR TITLE
May crash if GetCommandLineW failed

### DIFF
--- a/client/Windows/cli/wfreerdp.c
+++ b/client/Windows/cli/wfreerdp.c
@@ -54,7 +54,7 @@ INT WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	RDP_CLIENT_ENTRY_POINTS clientEntryPoints;
 	int ret = 1;
 	int argc = 0, i;
-	LPWSTR* args;
+	LPWSTR* args = NULL;
 	LPWSTR cmd;
 	char** argv;
 	ZeroMemory(&clientEntryPoints, sizeof(RDP_CLIENT_ENTRY_POINTS));


### PR DESCRIPTION
args is uninitialized， LocalFree will free rubbish if GetCommandLineW failed.
```
       	LPWSTR* args;

	cmd = GetCommandLineW();

	if (!cmd)
		goto out;

	args = CommandLineToArgvW(cmd, &argc);

	if (!args)
		goto out;
          .....

out:
         .....
        LocalFree(args);
···
