### PR TITLE
client/Wayland/wlf_cliprdr.c: resolve possible null pointer dereference

### DIFF
--- a/client/Wayland/wlf_cliprdr.c
+++ b/client/Wayland/wlf_cliprdr.c
@@ -155,7 +155,8 @@ static void wlf_cliprdr_free_server_formats(wfClipboard* clipboard)
 		clipboard->numServerFormats = 0;
 	}
 
-	UwacClipboardOfferDestroy(clipboard->seat);
+	if (clipboard)
+		UwacClipboardOfferDestroy(clipboard->seat);
 }
 
 static void wlf_cliprdr_free_client_formats(wfClipboard* clipboard)
@@ -175,7 +176,8 @@ static void wlf_cliprdr_free_client_formats(wfClipboard* clipboard)
 		clipboard->numClientFormats = 0;
 	}
 
-	UwacClipboardOfferDestroy(clipboard->seat);
+	if (clipboard)
+		UwacClipboardOfferDestroy(clipboard->seat);
 }
 
 /**


### PR DESCRIPTION
found by cppcheck

[client/Wayland/wlf_cliprdr.c:143] -> [client/Wayland/wlf_cliprdr.c:158]: (warning) Either the condition 'clipboard' is redundant or there is possible null pointer dereference: clipboard.
[client/Wayland/wlf_cliprdr.c:163] -> [client/Wayland/wlf_cliprdr.c:178]: (warning) Either the condition 'clipboard' is redundant or there is possible null pointer dereference: clipboard.
