### PR TITLE
client/common/cmdline.c: remove redundant check

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -396,13 +396,10 @@ BOOL freerdp_client_add_device_channel(rdpSettings* settings, int count,
 
 			printer->Type = RDPDR_DTYP_PRINT;
 
-			if (count > 1)
+			if (!(printer->Name = _strdup(params[1])))
 			{
-				if (!(printer->Name = _strdup(params[1])))
-				{
-					free(printer);
-					return FALSE;
-				}
+				free(printer);
+				return FALSE;
 			}
 
 			if (count > 2)


### PR DESCRIPTION
[client/common/cmdline.c:390] -> [client/common/cmdline.c:399]: (warning) Identical inner 'if' condition is always true.