### PR TITLE
Add OpenBSD to TRIO_PLATFORM_UNIX

### DIFF
--- a/winpr/libwinpr/utils/trio/triodef.h
+++ b/winpr/libwinpr/utils/trio/triodef.h
@@ -88,7 +88,7 @@
 # endif
 #endif
 
-#if defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#if defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__OpenBSD__)
 # define TRIO_PLATFORM_UNIX
 #endif
 


### PR DESCRIPTION
OpenBSD is family of NetBSD, FreeBSD & DragonFlyBSD so treat as the same.
