### PR TITLE
Fix 5243: Allocate buffers zero in uwac.

### DIFF
--- a/uwac/libuwac/uwac-clipboard.c
+++ b/uwac/libuwac/uwac-clipboard.c
@@ -259,7 +259,7 @@ void* UwacClipboardDataGet(UwacSeat* seat, const char* mime, size_t* size)
 	{
 		void* tmp;
 		alloc += 1024;
-		tmp = realloc(data, alloc);
+		tmp = xrealloc(data, alloc);
 		if (!tmp)
 		{
 			free(data);

--- a/uwac/libuwac/uwac-display.c
+++ b/uwac/libuwac/uwac-display.c
@@ -165,7 +165,7 @@ static void registry_handle_global(void* data, struct wl_registry* registry, uin
 {
 	UwacDisplay* d = data;
 	UwacGlobal* global;
-	global = xmalloc(sizeof * global);
+	global = xzalloc(sizeof * global);
 	global->name = id;
 	global->interface = xstrdup(interface);
 	global->version = version;
@@ -416,7 +416,7 @@ static void display_dispatch_events(UwacTask* task, uint32_t events)
 UwacDisplay* UwacOpenDisplay(const char* name, UwacReturnCode* err)
 {
 	UwacDisplay* ret;
-	ret = (UwacDisplay*)calloc(1, sizeof(*ret));
+	ret = (UwacDisplay*)xzalloc(sizeof(*ret));
 
 	if (!ret)
 	{
@@ -745,7 +745,7 @@ UwacEvent* UwacDisplayNewEvent(UwacDisplay* display, int type)
 		return 0;
 	}
 
-	ret = zalloc(sizeof(UwacEventListItem));
+	ret = xzalloc(sizeof(UwacEventListItem));
 
 	if (!ret)
 	{

--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -899,7 +899,7 @@ static const struct wl_seat_listener seat_listener = {
 UwacSeat *UwacSeatNew(UwacDisplay *d, uint32_t id, uint32_t version) {
 	UwacSeat *ret;
 
-	ret = zalloc(sizeof(UwacSeat));
+	ret = xzalloc(sizeof(UwacSeat));
 	ret->display = d;
 	ret->seat_id = id;
 	ret->seat_version = version;
@@ -1041,7 +1041,7 @@ UwacReturnCode UwacSeatSetMouseCursor(UwacSeat* seat, const void* data, size_t l
 	/* There is a cursor provided */
 	if ((data != NULL) && (length != 0))
 	{
-		seat->pointer_image = calloc(1, sizeof(struct wl_cursor_image));
+		seat->pointer_image = xzalloc(sizeof(struct wl_cursor_image));
 		if (!seat->pointer_image)
 			return UWAC_ERROR_NOMEMORY;
 		seat->pointer_image->width = width;
@@ -1050,7 +1050,7 @@ UwacReturnCode UwacSeatSetMouseCursor(UwacSeat* seat, const void* data, size_t l
 		seat->pointer_image->hotspot_y = hot_y;
 
 		free(seat->pointer_data);
-		seat->pointer_data = malloc(length);
+		seat->pointer_data = xmalloc(length);
 		memcpy(seat->pointer_data, data, length);
 		seat->pointer_size = length;
 

--- a/uwac/libuwac/uwac-os.c
+++ b/uwac/libuwac/uwac-os.c
@@ -48,6 +48,7 @@
 
 #include "../config.h"
 #include "uwac-os.h"
+#include "uwac-utils.h"
 
 static int set_cloexec_or_close(int fd)
 {
@@ -230,7 +231,7 @@ int uwac_create_anonymous_file(off_t size)
 	if (fd < 0)
 	{
 		length = strlen(path) + sizeof(template);
-		name = malloc(length);
+		name = xmalloc(length);
 
 		if (!name)
 			return -1;

--- a/uwac/libuwac/uwac-output.c
+++ b/uwac/libuwac/uwac-output.c
@@ -110,7 +110,7 @@ static const struct wl_output_listener output_listener = {
 UwacOutput *UwacCreateOutput(UwacDisplay *d, uint32_t id, uint32_t version) {
 	UwacOutput *o;
 
-	o = zalloc(sizeof *o);
+	o = xzalloc(sizeof *o);
 	if (!o)
 		return NULL;
 

--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -304,7 +304,7 @@ int UwacWindowShmAllocBuffers(UwacWindow* w, int nbuffers, int allocSize, uint32
 	int i, fd;
 	void* data;
 	struct wl_shm_pool* pool;
-	newBuffers = realloc(w->buffers, (w->nbuffers + nbuffers) * sizeof(UwacBuffer));
+	newBuffers = xrealloc(w->buffers, (w->nbuffers + nbuffers) * sizeof(UwacBuffer));
 
 	if (!newBuffers)
 		return UWAC_ERROR_NOMEMORY;
@@ -417,7 +417,7 @@ UwacWindow* UwacCreateWindowShm(UwacDisplay* display, uint32_t width, uint32_t h
 		return NULL;
 	}
 
-	w = zalloc(sizeof(*w));
+	w = xzalloc(sizeof(*w));
 
 	if (!w)
 	{


### PR DESCRIPTION
* Zero allocate global buffers
* Use `uwac` allocation wrappers in all of the library