### PR TITLE
Resolve Gfx mode missing surface updates from cache.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ packaging/deb/freerdp-nightly/freerdp-nightly-dbg
 
 # VisualStudio Code
 .vscode
+cache/

--- a/client/Android/android_freerdp.c
+++ b/client/Android/android_freerdp.c
@@ -130,24 +130,6 @@ static void android_OnChannelDisconnectedEventHandler(
 
 static BOOL android_begin_paint(rdpContext* context)
 {
-	rdpGdi* gdi;
-	HGDI_WND hwnd;
-
-	if (!context)
-		return FALSE;
-
-	gdi = context->gdi;
-
-	if (!gdi || !gdi->primary || !gdi->primary->hdc)
-		return FALSE;
-
-	hwnd = gdi->primary->hdc->hwnd;
-
-	if (!hwnd || !hwnd->invalid)
-		return FALSE;
-
-	hwnd->invalid->null = TRUE;
-	hwnd->ninvalid = 0;
 	return TRUE;
 }
 
@@ -182,9 +164,9 @@ static BOOL android_end_paint(rdpContext* context)
 
 	ninvalid = hwnd->ninvalid;
 
-	if (ninvalid == 0)
+	if (ninvalid < 1)
 		return TRUE;
-
+	
 	cinvalid = hwnd->cinvalid;
 
 	if (!cinvalid)
@@ -205,6 +187,9 @@ static BOOL android_end_paint(rdpContext* context)
 
 	freerdp_callback("OnGraphicsUpdate", "(JIIII)V", (jlong)context->instance,
 	                 x1, y1, x2 - x1, y2 - y1);
+
+	hwnd->invalid->null = TRUE;
+	hwnd->ninvalid = 0;
 	return TRUE;
 }
 


### PR DESCRIPTION
In the android client library.
We found that while using Gfx mode, some screen updates (usually when not much is changing) were being missed, for example when viewing a clock running seconds.

I did some really deep digging and had to compare against the X11 version which the updates would show correctly. 
I found that some of the android_end_paint callbacks had no regions to update, and it appeared that the reason was that sometimes the android_begin_paint callback was returning false.

The windows and X11 clients don't implement the begin_paint callback, so in removing all code from the android_begin_paint and just returning TRUE, the android_end_paint would have regions to update and we would no-longer miss surface updates which were in the cache.

