### PR TITLE
Replace hard coded xfreerdp program name

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -337,7 +337,7 @@ static UINT rdpgfx_recv_reset_graphics_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 	}
 
 	/* some listeners may be interested (namely the display channel) */
-	EventArgsInit(&graphicsReset, "xfreerdp");
+	EventArgsInit(&graphicsReset, "libfreerdp");
 	graphicsReset.width = pdu.width;
 	graphicsReset.height = pdu.height;
 	PubSub_OnGraphicsReset(gfx->rdpcontext->pubSub, gfx->rdpcontext, &graphicsReset);

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -228,8 +228,10 @@ BOOL freerdp_client_print_command_line_help(int argc, char** argv)
 BOOL freerdp_client_print_command_line_help_ex(int argc, char** argv,
         COMMAND_LINE_ARGUMENT_A* custom)
 {
-	WINPR_UNUSED(argc);
-	WINPR_UNUSED(argv);
+	const char* name = "FreeRDP";
+
+	if (argc > 0)
+		name = argv[0];
 
 	printf("\n");
 	printf("FreeRDP - A Free Remote Desktop Protocol Implementation\n");
@@ -246,10 +248,10 @@ BOOL freerdp_client_print_command_line_help_ex(int argc, char** argv,
 	freerdp_client_print_command_line_args(args);
 	printf("\n");
 	printf("Examples:\n");
-	printf("    xfreerdp connection.rdp /p:Pwd123! /f\n");
-	printf("    xfreerdp /u:CONTOSO\\JohnDoe /p:Pwd123! /v:rdp.contoso.com\n");
-	printf("    xfreerdp /u:JohnDoe /p:Pwd123! /w:1366 /h:768 /v:192.168.1.100:4489\n");
-	printf("    xfreerdp /u:JohnDoe /p:Pwd123! /vmconnect:C824F53E-95D2-46C6-9A18-23A5BB403532 /v:192.168.1.100\n");
+	printf("    %s connection.rdp /p:Pwd123! /f\n", name);
+	printf("    %s /u:CONTOSO\\JohnDoe /p:Pwd123! /v:rdp.contoso.com\n", name);
+	printf("    %s /u:JohnDoe /p:Pwd123! /w:1366 /h:768 /v:192.168.1.100:4489\n", name);
+	printf("    %s /u:JohnDoe /p:Pwd123! /vmconnect:C824F53E-95D2-46C6-9A18-23A5BB403532 /v:192.168.1.100\n", name);
 	printf("\n");
 	printf("Clipboard Redirection: +clipboard\n");
 	printf("\n");
@@ -275,7 +277,7 @@ BOOL freerdp_client_print_command_line_help_ex(int argc, char** argv,
 #else
 	printf("    export https_proxy=http://proxy.contoso.com:3128/\n");
 #endif
-	printf("    xfreerdp /g:rdp.contoso.com ...\n");
+	printf("    %s /g:rdp.contoso.com ...\n", name);
 	printf("\n");
 	printf("More documentation is coming, in the meantime consult source files\n");
 	printf("\n");

--- a/client/common/test/TestClientCmdLine.c
+++ b/client/common/test/TestClientCmdLine.c
@@ -121,114 +121,114 @@ static test tests[] =
 {
 	{
 		COMMAND_LINE_STATUS_PRINT_HELP, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "--help", 0},
+		{"testfreerdp", "--help", 0},
 		{{0}}
 	},
 	{
 		COMMAND_LINE_STATUS_PRINT_HELP, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "/help", 0},
+		{"testfreerdp", "/help", 0},
 		{{0}}
 	},
 	{
 		COMMAND_LINE_STATUS_PRINT_HELP, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "-help", 0},
+		{"testfreerdp", "-help", 0},
 		{{0}}
 	},
 	{
 		COMMAND_LINE_STATUS_PRINT_VERSION, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "--version", 0},
+		{"testfreerdp", "--version", 0},
 		{{0}}
 	},
 	{
 		COMMAND_LINE_STATUS_PRINT_VERSION, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "/version", 0},
+		{"testfreerdp", "/version", 0},
 		{{0}}
 	},
 	{
 		COMMAND_LINE_STATUS_PRINT_VERSION, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "-version", 0},
+		{"testfreerdp", "-version", 0},
 		{{0}}
 	},
 	{
 		0, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "test.freerdp.com", 0},
+		{"testfreerdp", "test.freerdp.com", 0},
 		{{0}}
 	},
 	{
 		0, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "-v", "test.freerdp.com", 0},
+		{"testfreerdp", "-v", "test.freerdp.com", 0},
 		{{0}}
 	},
 	{
 		0, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "--v", "test.freerdp.com", 0},
+		{"testfreerdp", "--v", "test.freerdp.com", 0},
 		{{0}}
 	},
 	{
 		0, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "/v:test.freerdp.com", 0},
+		{"testfreerdp", "/v:test.freerdp.com", 0},
 		{{0}}
 	},
 	{
 		0, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "--plugin", "rdpsnd", "--plugin", "rdpdr", "--data", "disk:media:"DRIVE_REDIRECT_PATH, "--", "test.freerdp.com", 0},
+		{"testfreerdp", "--plugin", "rdpsnd", "--plugin", "rdpdr", "--data", "disk:media:"DRIVE_REDIRECT_PATH, "--", "test.freerdp.com", 0},
 		{{0}}
 	},
 	{
 		0, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "/sound", "/drive:media,"DRIVE_REDIRECT_PATH, "/v:test.freerdp.com", 0},
+		{"testfreerdp", "/sound", "/drive:media,"DRIVE_REDIRECT_PATH, "/v:test.freerdp.com", 0},
 		{{0}}
 	},
 	{
 		0, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "-u", "test", "-p", "test", "test.freerdp.com", 0},
+		{"testfreerdp", "-u", "test", "-p", "test", "test.freerdp.com", 0},
 		{{4, "****"}, {0}}
 	},
 	{
 		0, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "-u", "test", "-p", "test", "-v", "test.freerdp.com", 0},
+		{"testfreerdp", "-u", "test", "-p", "test", "-v", "test.freerdp.com", 0},
 		{{4, "****"}, {0}}
 	},
 	{
 		0, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "/u:test", "/p:test", "/v:test.freerdp.com", 0},
+		{"testfreerdp", "/u:test", "/p:test", "/v:test.freerdp.com", 0},
 		{{2, "/p:****"}, {0}}
 	},
 	{
 		COMMAND_LINE_ERROR_NO_KEYWORD, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "-invalid", 0},
+		{"testfreerdp", "-invalid", 0},
 		{{0}}
 	},
 	{
 		COMMAND_LINE_ERROR_NO_KEYWORD, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "--invalid", 0},
+		{"testfreerdp", "--invalid", 0},
 		{{0}}
 	},
 	{
 		COMMAND_LINE_STATUS_PRINT, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "/kbd-list", 0},
+		{"testfreerdp", "/kbd-list", 0},
 		{{0}}
 	},
 	{
 		COMMAND_LINE_STATUS_PRINT, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "/monitor-list", 0},
+		{"testfreerdp", "/monitor-list", 0},
 		{{0}}
 	},
 	{
 		COMMAND_LINE_ERROR, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "/sound", "/drive:media:"DRIVE_REDIRECT_PATH, "/v:test.freerdp.com", 0},
+		{"testfreerdp", "/sound", "/drive:media:"DRIVE_REDIRECT_PATH, "/v:test.freerdp.com", 0},
 		{{0}}
 	},
 	{
 		COMMAND_LINE_ERROR, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "/sound", "/drive:media,/foo/bar/blabla", "/v:test.freerdp.com", 0},
+		{"testfreerdp", "/sound", "/drive:media,/foo/bar/blabla", "/v:test.freerdp.com", 0},
 		{{0}}
 	},
 
 #if 0
 	{
 		COMMAND_LINE_STATUS_PRINT, check_settings_smartcard_no_redirection,
-		{"xfreerdp", "-z", "--plugin", "cliprdr", "--plugin", "rdpsnd", "--data", "alsa", "latency:100", "--", "--plugin", "rdpdr", "--data", "disk:w7share:/home/w7share", "--", "--plugin", "drdynvc", "--data", "tsmf:decoder:gstreamer", "--", "-u", "test", "host.example.com", 0},
+		{"testfreerdp", "-z", "--plugin", "cliprdr", "--plugin", "rdpsnd", "--data", "alsa", "latency:100", "--", "--plugin", "rdpdr", "--data", "disk:w7share:/home/w7share", "--", "--plugin", "drdynvc", "--data", "tsmf:decoder:gstreamer", "--", "-u", "test", "host.example.com", 0},
 		{{0}}
 	},
 #endif

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1525,7 +1525,7 @@ int rdp_recv_callback(rdpTransport* transport, wStream* s, void* extra)
 				ActivatedEventArgs activatedEvent;
 				rdpContext* context = rdp->context;
 				rdp_client_transition_to_state(rdp, CONNECTION_STATE_ACTIVE);
-				EventArgsInit(&activatedEvent, "xfreerdp");
+				EventArgsInit(&activatedEvent, "libfreerdp");
 				activatedEvent.firstActivation = !rdp->deactivation_reactivation;
 				PubSub_OnActivated(context->pubSub, context, &activatedEvent);
 				return 2;


### PR DESCRIPTION
* Replaced `xfreerdp` with actual program name in help text
* Replaced `xfreerdp` with `libfreerdp` for event source name
* Replaced `xfreerdp` with `testfreerdp` for command line test case