### PR TITLE
libfreerdp/codec/progressive.c: remove useless function call

### DIFF
--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -1984,7 +1984,6 @@ PROGRESSIVE_CONTEXT* progressive_context_new(BOOL Compressor)
 		           sizeof(RFX_PROGRESSIVE_CODEC_QUANT));
 		progressive->quantProgValFull.quality = 100;
 		progressive->SurfaceContexts = HashTable_New(TRUE);
-		progressive_context_reset(progressive);
 		progressive->log = WLog_Get(TAG);
 	}
 


### PR DESCRIPTION
function progressive_context_reset() is only useful for its return value, which is ignored