### PR TITLE
Embedded window client

### DIFF
--- a/client/Windows/wf_gdi.c
+++ b/client/Windows/wf_gdi.c
@@ -354,7 +354,17 @@ void wf_resize_window(wfContext* wfc)
 
 		if (settings->EmbeddedWindow)
 		{
+			if (!wfc->client_height)
+				wfc->client_height = settings->DesktopHeight;
+
+			if (!wfc->client_width)
+				wfc->client_width = settings->DesktopWidth;
+
 			wf_update_canvas_diff(wfc);
+			/* Now resize to get full canvas size and room for caption and borders */
+			SetWindowPos(wfc->hwnd, HWND_TOP, wfc->client_x, wfc->client_y,
+				wfc->client_width + wfc->diff.x, wfc->client_height + wfc->diff.y,
+				0 /*SWP_FRAMECHANGED*/);
 		}
 		else
 		{


### PR DESCRIPTION
Client width and height getting set as 0 when embedded using ParentWindowId setting
This is where the issue is explained in detail -> https://github.com/FreeRDP/FreeRDP/issues/5268