### PR TITLE
potential fix for ENTER (modifiers) stuck after CTRL-ALT-ENTER (toggle fullscreen), clearing the buffer in xk_keyboard_update_modifier_keys.

### DIFF
--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -326,7 +326,6 @@ static void xk_keyboard_update_modifier_keys(xfContext* xfc)
 	                 XK_Control_L, XK_Control_R, XK_Super_L, XK_Super_R
 	                };
 
-	// CTRL-ALT-ENTER FIX: we need to clear the buffer here beforehand
 	xf_keyboard_clear(xfc);
 
 	state = xf_keyboard_read_keyboard_state(xfc);

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -325,6 +325,10 @@ static void xk_keyboard_update_modifier_keys(xfContext* xfc)
 	int keysyms[] = {XK_Shift_L, XK_Shift_R, XK_Alt_L, XK_Alt_R,
 	                 XK_Control_L, XK_Control_R, XK_Super_L, XK_Super_R
 	                };
+
+	// CTRL-ALT-ENTER FIX: we need to clear the buffer here beforehand
+	xf_keyboard_clear(xfc);
+
 	state = xf_keyboard_read_keyboard_state(xfc);
 
 	for (i = 0; i < ARRAYSIZE(keysyms); i++)


### PR DESCRIPTION
A possible fix for issues FreeRDP/FreeRDP#4966 FreeRDP/FreeRDP#5092 .

Tested heavily on the Linux/Ubuntu side (mostly LinuxMint) as a HOST and Win10 as remote. 
This fix works on my end and is solving the issue I was having.

Issue: 
On fullscreen toggle (CTRL-ALT-ENTER) any subsequent ENTER (w/o any modifiers pressed) toggles the screen - i.e. user is unable to edit anything remotely.

Solution:
Problem seems to be the modifiers buffer that for some reason doesn't refresh, while xk_keyboard_update_modifier_keys() is called on focus successfully it doesn't seem to do anything (in some cases at least). Forcing the xk_keyboard_update_modifier_keys doesn't help either, but clearing the buffer does the trick. That solution is adapted from a long history of this issue.
My first solution was to put the modifiers refresh on every press call (which should be ok enough), but that alone didn't fix it - forcing the 'xf_keyboard_clear(xfc)' on refresh is what actually solves it.

Fix is a one-liner and it should be quite safe to introduce into the code w/o major testing - as it 'just' adds extra initialization step (w/o any hit on the performance or similar).