### PR TITLE
client/Windows/wf_event.c: add missing "break"

### DIFF
--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -462,6 +462,7 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam,
 						// User dragged the scroll box.
 						case SB_THUMBPOSITION:
 							xNewPos = HIWORD(wParam);
+							break;
 
 						// user is dragging the scrollbar
 						case SB_THUMBTRACK :


### PR DESCRIPTION
[client/Windows/wf_event.c:464] -> [client/Windows/wf_event.c:468]: (warning) Variable 'xNewPos' is reassigned a value before the old one has been used. 'break;' missing?
