### PR TITLE
Fixed Stream_* macros, bracing arguments.

### DIFF
--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -52,7 +52,7 @@ WINPR_API BOOL Stream_EnsureCapacity(wStream* s, size_t size);
 WINPR_API BOOL Stream_EnsureRemainingCapacity(wStream* s, size_t size);
 
 WINPR_API wStream* Stream_New(BYTE* buffer, size_t size);
-WINPR_API void Stream_StaticInit(wStream *s, BYTE *buffer, size_t size);
+WINPR_API void Stream_StaticInit(wStream* s, BYTE* buffer, size_t size);
 WINPR_API void Stream_Free(wStream* s, BOOL bFreeBuffer);
 
 static INLINE void Stream_Seek(wStream* s, size_t _offset)
@@ -66,60 +66,60 @@ static INLINE void Stream_Rewind(wStream* s, size_t _offset)
 }
 
 #define _stream_read_n8(_t, _s, _v, _p) do { \
-		_v = \
-		     (_t)(*_s->pointer); \
+		(_v) = \
+		       (_t)(*(_s)->pointer); \
 		if (_p) Stream_Seek(_s, sizeof(_t)); } while (0)
 
 #define _stream_read_n16_le(_t, _s, _v, _p) do { \
-		_v = \
-		     (_t)(*_s->pointer) + \
-		     (_t)(((_t)(*(_s->pointer + 1))) << 8); \
+		(_v) = \
+		       (_t)(*(_s)->pointer) + \
+		       (_t)(((_t)(*((_s)->pointer + 1))) << 8); \
 		if (_p) Stream_Seek(_s, sizeof(_t)); } while (0)
 
 #define _stream_read_n16_be(_t, _s, _v, _p) do { \
-		_v = \
-		     (_t)(((_t)(*_s->pointer)) << 8) + \
-		     (_t)(*(_s->pointer + 1)); \
+		(_v) = \
+		       (_t)(((_t)(*(_s)->pointer)) << 8) + \
+		       (_t)(*((_s)->pointer + 1)); \
 		if (_p) Stream_Seek(_s, sizeof(_t)); } while (0)
 
 #define _stream_read_n32_le(_t, _s, _v, _p) do { \
-		_v = \
-		     (_t)(*_s->pointer) + \
-		     (((_t)(*(_s->pointer + 1))) << 8) + \
-		     (((_t)(*(_s->pointer + 2))) << 16) + \
-		     (((_t)(*(_s->pointer + 3))) << 24); \
+		(_v) = \
+		       (_t)(*(_s)->pointer) + \
+		       (((_t)(*((_s)->pointer + 1))) << 8) + \
+		       (((_t)(*((_s)->pointer + 2))) << 16) + \
+		       (((_t)(*((_s)->pointer + 3))) << 24); \
 		if (_p) Stream_Seek(_s, sizeof(_t)); } while (0)
 
 #define _stream_read_n32_be(_t, _s, _v, _p) do { \
-		_v = \
-		     (((_t)(*(_s->pointer))) << 24) + \
-		     (((_t)(*(_s->pointer + 1))) << 16) + \
-		     (((_t)(*(_s->pointer + 2))) << 8) + \
-		     (((_t)(*(_s->pointer + 3)))); \
+		(_v) = \
+		       (((_t)(*((_s)->pointer))) << 24) + \
+		       (((_t)(*((_s)->pointer + 1))) << 16) + \
+		       (((_t)(*((_s)->pointer + 2))) << 8) + \
+		       (((_t)(*((_s)->pointer + 3)))); \
 		if (_p) Stream_Seek(_s, sizeof(_t)); } while (0)
 
 #define _stream_read_n64_le(_t, _s, _v, _p) do { \
-		_v = \
-		     (_t)(*_s->pointer) + \
-		     (((_t)(*(_s->pointer + 1))) << 8) + \
-		     (((_t)(*(_s->pointer + 2))) << 16) + \
-		     (((_t)(*(_s->pointer + 3))) << 24) + \
-		     (((_t)(*(_s->pointer + 4))) << 32) + \
-		     (((_t)(*(_s->pointer + 5))) << 40) + \
-		     (((_t)(*(_s->pointer + 6))) << 48) + \
-		     (((_t)(*(_s->pointer + 7))) << 56); \
+		(_v) = \
+		       (_t)(*(_s)->pointer) + \
+		       (((_t)(*((_s)->pointer + 1))) << 8) + \
+		       (((_t)(*((_s)->pointer + 2))) << 16) + \
+		       (((_t)(*((_s)->pointer + 3))) << 24) + \
+		       (((_t)(*((_s)->pointer + 4))) << 32) + \
+		       (((_t)(*((_s)->pointer + 5))) << 40) + \
+		       (((_t)(*((_s)->pointer + 6))) << 48) + \
+		       (((_t)(*((_s)->pointer + 7))) << 56); \
 		if (_p) Stream_Seek(_s, sizeof(_t)); } while (0)
 
 #define _stream_read_n64_be(_t, _s, _v, _p) do { \
-		_v = \
-		     (((_t)(*(_s->pointer))) << 56) + \
-		     (((_t)(*(_s->pointer + 1))) << 48) + \
-		     (((_t)(*(_s->pointer + 2))) << 40) + \
-		     (((_t)(*(_s->pointer + 3))) << 32) + \
-		     (((_t)(*(_s->pointer + 4))) << 24) + \
-		     (((_t)(*(_s->pointer + 5))) << 16) + \
-		     (((_t)(*(_s->pointer + 6))) << 8) + \
-		     (((_t)(*(_s->pointer + 7)))); \
+		(_v) = \
+		       (((_t)(*((_s)->pointer))) << 56) + \
+		       (((_t)(*((_s)->pointer + 1))) << 48) + \
+		       (((_t)(*((_s)->pointer + 2))) << 40) + \
+		       (((_t)(*((_s)->pointer + 3))) << 32) + \
+		       (((_t)(*((_s)->pointer + 4))) << 24) + \
+		       (((_t)(*((_s)->pointer + 5))) << 16) + \
+		       (((_t)(*((_s)->pointer + 6))) << 8) + \
+		       (((_t)(*((_s)->pointer + 7)))); \
 		if (_p) Stream_Seek(_s, sizeof(_t)); } while (0)
 
 #define Stream_Read_UINT8(_s, _v) _stream_read_n8(UINT8, _s, _v, TRUE)


### PR DESCRIPTION
Eliminates some warnings in combination with `Stream_StaticInit`:
When using `wStream s; Stream_Read_UINT32(&s, somevar);` a warning was emitted as the macro arguments were not properly contained.