### PR TITLE
Added optional PreFrameAck callback to RdpgfxClientContext 

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -643,7 +643,7 @@ static UINT rdpgfx_recv_end_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 			ack.queueDepth = QUEUE_DEPTH_UNAVAILABLE;
 
 			if ((error = rdpgfx_send_frame_acknowledge_pdu(callback, &ack)))
-				WLog_Print(gfx->log, WLOG_DEBUG, "rdpgfx_send_frame_acknowledge_pdu failed with error %"PRIu32"",
+				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_send_frame_acknowledge_pdu failed with error %"PRIu32"",
 				           error);
 		}
 	}
@@ -667,7 +667,7 @@ static UINT rdpgfx_recv_end_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 				qoe.timeDiffEDR = 1;
 
 				if ((error = rdpgfx_send_qoe_frame_acknowledge_pdu(callback, &qoe)))
-					WLog_Print(gfx->log, WLOG_DEBUG, "rdpgfx_send_frame_acknowledge_pdu failed with error %"PRIu32"",
+					WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_send_frame_acknowledge_pdu failed with error %"PRIu32"",
 					           error);
 			}
 

--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -599,6 +599,7 @@ static UINT rdpgfx_recv_end_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*) callback->plugin;
 	RdpgfxClientContext* context = (RdpgfxClientContext*) gfx->iface.pInterface;
 	UINT error = CHANNEL_RC_OK;
+	BOOL sendAck = TRUE;
 
 	if (Stream_GetRemainingLength(s) < RDPGFX_END_FRAME_PDU_SIZE)
 	{
@@ -624,7 +625,6 @@ static UINT rdpgfx_recv_end_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 	gfx->TotalDecodedFrames++;
 	ack.frameId = pdu.frameId;
 	ack.totalFramesDecoded = gfx->TotalDecodedFrames;
-	BOOL sendAck = TRUE;
 	IFCALLRET(context->PreFrameAck, sendAck, context, &ack);
 
 	if (sendAck)

--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -148,7 +148,6 @@ static UINT rdpgfx_send_caps_advertise_pdu(RDPGFX_CHANNEL_CALLBACK* callback)
 		capsSet->version = RDPGFX_CAPVERSION_105;
 		capsSet->length = 0x4;
 		capsSet->flags = caps10Flags;
-
 		/* TODO: Until  RDPGFX_MAP_SURFACE_TO_SCALED_OUTPUT_PDU and
 		 * RDPGFX_MAP_SURFACE_TO_SCALED_WINDOW_PDU are not implemented do not
 		 * announce the following version */
@@ -625,23 +624,28 @@ static UINT rdpgfx_recv_end_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 	gfx->TotalDecodedFrames++;
 	ack.frameId = pdu.frameId;
 	ack.totalFramesDecoded = gfx->TotalDecodedFrames;
+	BOOL sendAck = TRUE;
+	IFCALLRET(context->PreFrameAck, sendAck, context, &ack);
 
-	if (gfx->suspendFrameAcks)
+	if (sendAck)
 	{
-		ack.queueDepth = SUSPEND_FRAME_ACKNOWLEDGEMENT;
+		if (gfx->suspendFrameAcks)
+		{
+			ack.queueDepth = SUSPEND_FRAME_ACKNOWLEDGEMENT;
 
-		if (gfx->TotalDecodedFrames == 1)
+			if (gfx->TotalDecodedFrames == 1)
+				if ((error = rdpgfx_send_frame_acknowledge_pdu(callback, &ack)))
+					WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_send_frame_acknowledge_pdu failed with error %"PRIu32"",
+					           error);
+		}
+		else
+		{
+			ack.queueDepth = QUEUE_DEPTH_UNAVAILABLE;
+
 			if ((error = rdpgfx_send_frame_acknowledge_pdu(callback, &ack)))
-				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_send_frame_acknowledge_pdu failed with error %"PRIu32"",
+				WLog_Print(gfx->log, WLOG_DEBUG, "rdpgfx_send_frame_acknowledge_pdu failed with error %"PRIu32"",
 				           error);
-	}
-	else
-	{
-		ack.queueDepth = QUEUE_DEPTH_UNAVAILABLE;
-
-		if ((error = rdpgfx_send_frame_acknowledge_pdu(callback, &ack)))
-			WLog_Print(gfx->log, WLOG_DEBUG, "rdpgfx_send_frame_acknowledge_pdu failed with error %"PRIu32"",
-			           error);
+		}
 	}
 
 	switch (gfx->ConnectionCaps.version)

--- a/include/freerdp/client/rdpgfx.h
+++ b/include/freerdp/client/rdpgfx.h
@@ -83,6 +83,9 @@ typedef UINT(*pcRdpgfxUpdateSurfaces)(RdpgfxClientContext* context);
 typedef UINT(*pcRdpgfxUpdateSurfaceArea)(RdpgfxClientContext* context, UINT16 surfaceId,
         UINT32 nrRects, const RECTANGLE_16* rects);
 
+typedef BOOL(*pcRdpgfxPreFrameAck)(RdpgfxClientContext* context,
+                                   RDPGFX_FRAME_ACKNOWLEDGE_PDU* frameAcknowledge);
+
 struct _rdpgfx_client_context
 {
 	void* handle;
@@ -117,6 +120,8 @@ struct _rdpgfx_client_context
 	/* No locking required */
 	pcRdpgfxUpdateSurfaces UpdateSurfaces;
 	pcRdpgfxUpdateSurfaceArea UpdateSurfaceArea;
+
+	pcRdpgfxPreFrameAck PreFrameAck;
 
 	CRITICAL_SECTION mux;
 	PROFILER_DEFINE(SurfaceProfiler)


### PR DESCRIPTION
## Motivation
When implementing an RDP proxy I came by a potential sync issue between the proxy's client and target server. My implementation of the GFX proxy registers all `RdpgfxClientContext` callbacks from the target server and sends the PDUs using an `RdpgfxServerContext` serving the proxy's client. Ideally, I could register the same `RdpgfxServerContext`'s FrameAck callback and send it back using the `RdpgfxClientContext`, but `RdpgfxClientContext` doesn't expose a method for sending the ack. Instead, `RdpgfxClientContext`'s implementation sends the ack automatically when an EndFrame PDU is received.

This behaviour could prove to be an issue in the context of a proxy, where there can be small latency between the proxy and target server, maybe being together in the same LAN, and big latency towards the client, perhaps connecting via the internet.

## My solution
After discussion on the IRC, I added an optional callback called just before the FrameAck is sent. This lets you to optionally register the callback and block for however long you need, in my case waiting for an ack from the proxy's client, while maintaining the default behavior where you don't need to concern yourself with acking.

## Testing
Testing the implementation is pretty simple, you could register a method in one of the RDP clients that sleeps for a second, connect with GFX and watch the frame updating once a second. 

Example test callback:
```c
#include <unistd.h>

BOOL test_PreClientAck(RdpgfxClientContext* context, RDPGFX_FRAME_ACKNOWLEDGE_PDU* ack)
{
	sleep(1);
	return TRUE;
}
```