### PR TITLE
server/rdpgfx_main.c: Fixed caps advertise PDU recv

### DIFF
--- a/channels/rdpgfx/server/rdpgfx_main.c
+++ b/channels/rdpgfx/server/rdpgfx_main.c
@@ -1194,7 +1194,6 @@ static UINT rdpgfx_recv_caps_advertise_pdu(RdpgfxServerContext* context,
 	RDPGFX_CAPSET* capsSets;
 	RDPGFX_CAPS_ADVERTISE_PDU pdu;
 	UINT error = CHANNEL_RC_OK;
-	UINT32 capsDataLength;
 
 	if (Stream_GetRemainingLength(s) < 2)
 	{
@@ -1221,9 +1220,9 @@ static UINT rdpgfx_recv_caps_advertise_pdu(RdpgfxServerContext* context,
 	{
 		RDPGFX_CAPSET* capsSet = &(pdu.capsSets[index]);
 		Stream_Read_UINT32(s, capsSet->version); /* version (4 bytes) */
-		Stream_Read_UINT32(s, capsDataLength); /* capsDataLength (4 bytes) */
+		Stream_Read_UINT32(s, capsSet->length); /* capsDataLength (4 bytes) */
 
-		if (capsDataLength >= 4)
+		if (capsSet->length >= 4)
 			Stream_Peek_UINT32(s, capsSet->flags); /* capsData (4 bytes) */
 
 		Stream_Seek(s, capsSet->length);


### PR DESCRIPTION
Fixes #5302 . The bug was introduced in 69e9571d9edc58193d49afd4ce9f9fd0c5757075, when changing caps advertise pdu recv logic.

## The symptom
When using any FreeRDP server with GFX support (shadow), a client connecting GFX will crash. This is caused because the caps length is parsed into a local variable instead of a caps struct, and later the caps' length is tested instead of the local variable.