### PR TITLE
Fix NTLM AvPair lists

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
@@ -54,14 +54,15 @@ static const char* const AV_PAIR_STRINGS[] =
 	"MsvChannelBindings"
 };
 
-static NTLM_AV_PAIR* ntlm_av_pair_get_next_pointer(NTLM_AV_PAIR* pAvPair, size_t* pcbAvPair);
+static BOOL ntlm_av_pair_check(NTLM_AV_PAIR* pAvPair, size_t cbAvPair);
+static NTLM_AV_PAIR* ntlm_av_pair_next(NTLM_AV_PAIR* pAvPairList, size_t* pcbAvPairList);
 
-static void ntlm_av_pair_set_id(NTLM_AV_PAIR* pAvPair, UINT16 id)
+static INLINE void ntlm_av_pair_set_id(NTLM_AV_PAIR* pAvPair, UINT16 id)
 {
 	Data_Write_UINT16(&pAvPair->AvId, id);
 }
 
-static void ntlm_av_pair_set_len(NTLM_AV_PAIR* pAvPair, UINT16 len)
+static INLINE void ntlm_av_pair_set_len(NTLM_AV_PAIR* pAvPair, UINT16 len)
 {
 	Data_Write_UINT16(&pAvPair->AvLen, len);
 }
@@ -82,63 +83,53 @@ static INLINE UINT16 ntlm_av_pair_get_id(const NTLM_AV_PAIR* pAvPair)
 {
 	UINT16 AvId;
 
-	if (!pAvPair)
-		return MsvAvEOL;
-
 	Data_Read_UINT16(&pAvPair->AvId, AvId);
+
 	return AvId;
 }
 
-ULONG ntlm_av_pair_list_length(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairListMaxLength)
+ULONG ntlm_av_pair_list_length(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairList)
 {
-	ULONG length;
-	NTLM_AV_PAIR* pAvPair = pAvPairList;
+	size_t cbAvPair;
+	NTLM_AV_PAIR* pAvPair;
 
+	pAvPair = ntlm_av_pair_get(pAvPairList, cbAvPairList, MsvAvEOL, &cbAvPair);
 	if (!pAvPair)
 		return 0;
 
-	while (ntlm_av_pair_get_id(pAvPair) != MsvAvEOL)
-	{
-		pAvPair = ntlm_av_pair_get_next_pointer(pAvPair, &cbAvPairListMaxLength);
-	}
-
-	length = (pAvPair - pAvPairList) + sizeof(NTLM_AV_PAIR);
-	return length;
+	return ((PBYTE) pAvPair - (PBYTE) pAvPairList) + sizeof(NTLM_AV_PAIR);
 }
 
-static INLINE SSIZE_T ntlm_av_pair_get_len(const NTLM_AV_PAIR* pAvPair, size_t cbAvPair)
+static INLINE SSIZE_T ntlm_av_pair_get_len(const NTLM_AV_PAIR* pAvPair)
 {
 	UINT16 AvLen;
 
-	if (!pAvPair || (cbAvPair < sizeof(NTLM_AV_PAIR)))
-		return -1;
-
 	Data_Read_UINT16(&pAvPair->AvLen, AvLen);
-
-	if (cbAvPair < sizeof(NTLM_AV_PAIR) + pAvPair->AvLen)
-		return -1;
 
 	return AvLen;
 }
 
 void ntlm_print_av_pair_list(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairList)
 {
+	size_t cbAvPair = cbAvPairList;
 	NTLM_AV_PAIR* pAvPair = pAvPairList;
 
-	if (!pAvPair)
+	if (!ntlm_av_pair_check(pAvPair, cbAvPair))
 		return;
 
 	WLog_INFO(TAG, "AV_PAIRs =");
 
-	while (ntlm_av_pair_get_id(pAvPair) != MsvAvEOL)
+	while (pAvPair && ntlm_av_pair_get_id(pAvPair) != MsvAvEOL)
 	{
 		WLog_INFO(TAG, "\t%s AvId: %"PRIu16" AvLen: %"PRIu16"",
 		          AV_PAIR_STRINGS[ntlm_av_pair_get_id(pAvPair)],
 		          ntlm_av_pair_get_id(pAvPair),
-		          ntlm_av_pair_get_len(pAvPair, cbAvPairList));
-		winpr_HexDump(TAG, WLOG_INFO, ntlm_av_pair_get_value_pointer(pAvPair, cbAvPairList),
-		              ntlm_av_pair_get_len(pAvPair, cbAvPairList));
-		pAvPair = ntlm_av_pair_get_next_pointer(pAvPair, &cbAvPairList);
+		          ntlm_av_pair_get_len(pAvPair));
+		winpr_HexDump(TAG, WLOG_INFO,
+		              ntlm_av_pair_get_value_pointer(pAvPair),
+		              ntlm_av_pair_get_len(pAvPair));
+
+		pAvPair = ntlm_av_pair_next(pAvPair, &cbAvPair);
 	}
 }
 
@@ -148,98 +139,103 @@ static ULONG ntlm_av_pair_list_size(ULONG AvPairsCount, ULONG AvPairsValueLength
 	return ((AvPairsCount + 1) * 4) + AvPairsValueLength;
 }
 
-PBYTE ntlm_av_pair_get_value_pointer(NTLM_AV_PAIR* pAvPair, size_t cbAvPairListMaxLength)
+PBYTE ntlm_av_pair_get_value_pointer(NTLM_AV_PAIR* pAvPair)
 {
-	if (cbAvPairListMaxLength < 2 * sizeof(NTLM_AV_PAIR))
-		return NULL;
-
-	return &((PBYTE) pAvPair)[sizeof(NTLM_AV_PAIR)];
+	return (PBYTE) pAvPair + sizeof(NTLM_AV_PAIR);
 }
 
-static SSIZE_T ntlm_av_pair_get_next_offset(NTLM_AV_PAIR* pAvPair, size_t cbAvPairListMaxLength)
+static size_t ntlm_av_pair_get_next_offset(NTLM_AV_PAIR* pAvPair)
 {
-	return ntlm_av_pair_get_len(pAvPair, cbAvPairListMaxLength) + sizeof(NTLM_AV_PAIR);
+	return ntlm_av_pair_get_len(pAvPair) + sizeof(NTLM_AV_PAIR);
 }
 
-NTLM_AV_PAIR* ntlm_av_pair_get_next_pointer(NTLM_AV_PAIR* pAvPair, size_t* pcbAvPair)
+static BOOL ntlm_av_pair_check(NTLM_AV_PAIR* pAvPair, size_t cbAvPair)
 {
-	SSIZE_T offset;
+	if (!pAvPair || cbAvPair < sizeof(NTLM_AV_PAIR))
+		return FALSE;
+	return cbAvPair >= ntlm_av_pair_get_next_offset(pAvPair);
+}
 
-	if (!pAvPair || !pcbAvPair)
+static NTLM_AV_PAIR* ntlm_av_pair_next(NTLM_AV_PAIR* pAvPair, size_t* pcbAvPair)
+{
+	size_t offset;
+
+	if (!pcbAvPair)
+		return NULL;
+	if (!ntlm_av_pair_check(pAvPair, *pcbAvPair))
 		return NULL;
 
-	offset = ntlm_av_pair_get_next_offset(pAvPair, *pcbAvPair);
-
-	if ((offset <= 0) || (offset > *pcbAvPair))
-		return NULL;
-
+	offset = ntlm_av_pair_get_next_offset(pAvPair);
 	*pcbAvPair -= offset;
 	return (NTLM_AV_PAIR*)((PBYTE) pAvPair + offset);
 }
 
-NTLM_AV_PAIR* ntlm_av_pair_get(void* pAvPairList,
-                               size_t avPairListLength,
-                               NTLM_AV_ID AvId,
-                               size_t* pcbAvPairListRemainingLength)
+NTLM_AV_PAIR* ntlm_av_pair_get(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairList,
+                               NTLM_AV_ID AvId, size_t* pcbAvPairListRemaining)
 {
+	size_t cbAvPair = cbAvPairList;
 	NTLM_AV_PAIR* pAvPair = pAvPairList;
 
-	if (pcbAvPairListRemainingLength)
-		*pcbAvPairListRemainingLength = 0;
+	if (!ntlm_av_pair_check(pAvPair, cbAvPair))
+		pAvPair = NULL;
 
 	while (pAvPair)
 	{
-		if (ntlm_av_pair_get_id(pAvPair) == AvId)
-		{
-			if (pcbAvPairListRemainingLength)
-				*pcbAvPairListRemainingLength = avPairListLength;
+		UINT16 id = ntlm_av_pair_get_id(pAvPair);
 
-			return pAvPair;
+		if (id == AvId)
+			break;
+		if (id == MsvAvEOL)
+		{
+			pAvPair = NULL;
+			break;
 		}
 
-		if (ntlm_av_pair_get_id(pAvPair) == MsvAvEOL)
-			return NULL;
-
-		pAvPair = ntlm_av_pair_get_next_pointer(pAvPair, &avPairListLength);
+		pAvPair = ntlm_av_pair_next(pAvPair, &cbAvPair);
 	}
 
-	return NULL;
-}
-
-static NTLM_AV_PAIR* ntlm_av_pair_add(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairListLength,
-                                      NTLM_AV_ID AvId, PBYTE Value,
-                                      UINT16 AvLen)
-{
-	size_t cbAvPair;
-	NTLM_AV_PAIR* pAvPair;
-	pAvPair = ntlm_av_pair_get(pAvPairList, cbAvPairListLength, MsvAvEOL, &cbAvPair);
-
 	if (!pAvPair)
-		return NULL;
+		cbAvPair = 0;
+	if (pcbAvPairListRemaining)
+		*pcbAvPairListRemaining = cbAvPair;
 
-	assert(Value != NULL);
-	ntlm_av_pair_set_id(pAvPair, AvId);
-	ntlm_av_pair_set_len(pAvPair, AvLen);
-	CopyMemory(ntlm_av_pair_get_value_pointer(pAvPair, cbAvPair), Value, AvLen);
 	return pAvPair;
 }
 
-static NTLM_AV_PAIR* ntlm_av_pair_add_copy(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairListLength,
-        NTLM_AV_PAIR* pAvPair, size_t cbAvPair)
+static BOOL ntlm_av_pair_add(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairList,
+                             NTLM_AV_ID AvId, PBYTE Value, UINT16 AvLen)
 {
-	NTLM_AV_PAIR* pAvPairCopy;
-	size_t cbAvPairCopy;
-	pAvPairCopy = ntlm_av_pair_get(pAvPairList, cbAvPairListLength, MsvAvEOL, &cbAvPairCopy);
+	size_t cbAvPair;
+	NTLM_AV_PAIR* pAvPair;
 
-	if (!pAvPairCopy)
-		return NULL;
+	pAvPair = ntlm_av_pair_get(pAvPairList, cbAvPairList, MsvAvEOL, &cbAvPair);
 
-	CopyMemory(&pAvPairCopy->AvId, &pAvPair->AvId, 2);
-	CopyMemory(&pAvPairCopy->AvLen, &pAvPair->AvLen, 2);
-	CopyMemory(ntlm_av_pair_get_value_pointer(pAvPairCopy, cbAvPairCopy),
-	           ntlm_av_pair_get_value_pointer(pAvPair, cbAvPair),
-	           ntlm_av_pair_get_len(pAvPair, cbAvPair));
-	return pAvPairCopy;
+	/* size of header + value length + terminating MsvAvEOL AV_PAIR */
+	if (!pAvPair || cbAvPair < 2 * sizeof(NTLM_AV_PAIR) + AvLen)
+		return FALSE;
+
+	ntlm_av_pair_set_id(pAvPair, AvId);
+	ntlm_av_pair_set_len(pAvPair, AvLen);
+	if (AvLen)
+	{
+		assert(Value != NULL);
+		CopyMemory(ntlm_av_pair_get_value_pointer(pAvPair), Value, AvLen);
+	}
+
+	pAvPair = ntlm_av_pair_next(pAvPair, &cbAvPair);
+	return ntlm_av_pair_list_init(pAvPair, cbAvPair);
+}
+
+static BOOL ntlm_av_pair_add_copy(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairList,
+                                  NTLM_AV_PAIR* pAvPair, size_t cbAvPair)
+{
+	if (!ntlm_av_pair_check(pAvPair, cbAvPair))
+		return FALSE;
+
+	return ntlm_av_pair_add(pAvPairList, cbAvPairList,
+	                        ntlm_av_pair_get_id(pAvPair),
+				ntlm_av_pair_get_value_pointer(pAvPair),
+				ntlm_av_pair_get_len(pAvPair));
 }
 
 static int ntlm_get_target_computer_name(PUNICODE_STRING pName, COMPUTER_NAME_FORMAT type)
@@ -448,25 +444,25 @@ int ntlm_construct_challenge_target_info(NTLM_CONTEXT* context)
 	if (!ntlm_av_pair_list_init(pAvPairList, cbAvPairList))
 		goto fail;
 
-	if (ntlm_av_pair_add(pAvPairList, cbAvPairList, MsvAvNbDomainName, (PBYTE) NbDomainName.Buffer,
-	                     NbDomainName.Length) == NULL)
+	if (!ntlm_av_pair_add(pAvPairList, cbAvPairList, MsvAvNbDomainName, (PBYTE) NbDomainName.Buffer,
+	                      NbDomainName.Length))
 		goto fail;
 
-	if (ntlm_av_pair_add(pAvPairList, cbAvPairList, MsvAvNbComputerName, (PBYTE) NbComputerName.Buffer,
-	                     NbComputerName.Length) == NULL)
+	if (!ntlm_av_pair_add(pAvPairList, cbAvPairList, MsvAvNbComputerName, (PBYTE) NbComputerName.Buffer,
+	                      NbComputerName.Length))
 		goto fail;
 
-	if (ntlm_av_pair_add(pAvPairList, cbAvPairList, MsvAvDnsDomainName, (PBYTE) DnsDomainName.Buffer,
-	                     DnsDomainName.Length) == NULL)
+	if (!ntlm_av_pair_add(pAvPairList, cbAvPairList, MsvAvDnsDomainName, (PBYTE) DnsDomainName.Buffer,
+	                      DnsDomainName.Length))
 		goto fail;
 
-	if (ntlm_av_pair_add(pAvPairList, cbAvPairList, MsvAvDnsComputerName,
-	                     (PBYTE) DnsComputerName.Buffer,
-	                     DnsComputerName.Length) == NULL)
+	if (!ntlm_av_pair_add(pAvPairList, cbAvPairList, MsvAvDnsComputerName,
+	                      (PBYTE) DnsComputerName.Buffer,
+	                      DnsComputerName.Length))
 		goto fail;
 
-	if (ntlm_av_pair_add(pAvPairList, cbAvPairList, MsvAvTimestamp, context->Timestamp,
-	                     sizeof(context->Timestamp)) == NULL)
+	if (!ntlm_av_pair_add(pAvPairList, cbAvPairList, MsvAvTimestamp, context->Timestamp,
+	                      sizeof(context->Timestamp)))
 		goto fail;
 
 	rc = 1;
@@ -520,31 +516,31 @@ int ntlm_construct_authenticate_target_info(NTLM_CONTEXT* context)
 	if (AvNbDomainName)
 	{
 		AvPairsCount++; /* MsvAvNbDomainName */
-		AvPairsValueLength += ntlm_av_pair_get_len(AvNbDomainName, cbAvNbDomainName);
+		AvPairsValueLength += ntlm_av_pair_get_len(AvNbDomainName);
 	}
 
 	if (AvNbComputerName)
 	{
 		AvPairsCount++; /* MsvAvNbComputerName */
-		AvPairsValueLength += ntlm_av_pair_get_len(AvNbComputerName, cbAvNbComputerName);
+		AvPairsValueLength += ntlm_av_pair_get_len(AvNbComputerName);
 	}
 
 	if (AvDnsDomainName)
 	{
 		AvPairsCount++; /* MsvAvDnsDomainName */
-		AvPairsValueLength += ntlm_av_pair_get_len(AvDnsDomainName, cbAvDnsDomainName);
+		AvPairsValueLength += ntlm_av_pair_get_len(AvDnsDomainName);
 	}
 
 	if (AvDnsComputerName)
 	{
 		AvPairsCount++; /* MsvAvDnsComputerName */
-		AvPairsValueLength += ntlm_av_pair_get_len(AvDnsComputerName, cbAvDnsComputerName);
+		AvPairsValueLength += ntlm_av_pair_get_len(AvDnsComputerName);
 	}
 
 	if (AvDnsTreeName)
 	{
 		AvPairsCount++; /* MsvAvDnsTreeName */
-		AvPairsValueLength += ntlm_av_pair_get_len(AvDnsTreeName, cbAvDnsTreeName);
+		AvPairsValueLength += ntlm_av_pair_get_len(AvDnsTreeName);
 	}
 
 	AvPairsCount++; /* MsvAvTimestamp */
@@ -601,43 +597,43 @@ int ntlm_construct_authenticate_target_info(NTLM_CONTEXT* context)
 
 	if (AvNbDomainName)
 	{
-		if (ntlm_av_pair_add_copy(AuthenticateTargetInfo, cbAuthenticateTargetInfo, AvNbDomainName,
-		                          cbAvNbDomainName) == NULL)
+		if (!ntlm_av_pair_add_copy(AuthenticateTargetInfo, cbAuthenticateTargetInfo,
+		                           AvNbDomainName, cbAvNbDomainName))
 			return -1;
 	}
 
 	if (AvNbComputerName)
 	{
-		if (ntlm_av_pair_add_copy(AuthenticateTargetInfo, cbAuthenticateTargetInfo,
-		                          AvNbComputerName, cbAvNbComputerName) == NULL)
+		if (!ntlm_av_pair_add_copy(AuthenticateTargetInfo, cbAuthenticateTargetInfo,
+		                           AvNbComputerName, cbAvNbComputerName))
 			return -1;
 	}
 
 	if (AvDnsDomainName)
 	{
-		if (ntlm_av_pair_add_copy(AuthenticateTargetInfo, cbAuthenticateTargetInfo,
-		                          AvDnsDomainName, cbAvDnsDomainName) == NULL)
+		if (!ntlm_av_pair_add_copy(AuthenticateTargetInfo, cbAuthenticateTargetInfo,
+		                           AvDnsDomainName, cbAvDnsDomainName))
 			return -1;
 	}
 
 	if (AvDnsComputerName)
 	{
-		if (ntlm_av_pair_add_copy(AuthenticateTargetInfo, cbAuthenticateTargetInfo,
-		                          AvDnsComputerName, cbAvDnsComputerName) == NULL)
+		if (!ntlm_av_pair_add_copy(AuthenticateTargetInfo, cbAuthenticateTargetInfo,
+		                           AvDnsComputerName, cbAvDnsComputerName))
 			return -1;
 	}
 
 	if (AvDnsTreeName)
 	{
-		if (ntlm_av_pair_add_copy(AuthenticateTargetInfo, cbAuthenticateTargetInfo, AvDnsTreeName,
-		                          cbAvDnsTreeName) == NULL)
+		if (!ntlm_av_pair_add_copy(AuthenticateTargetInfo, cbAuthenticateTargetInfo,
+		                           AvDnsTreeName, cbAvDnsTreeName))
 			return -1;
 	}
 
 	if (AvTimestamp)
 	{
-		if (ntlm_av_pair_add_copy(AuthenticateTargetInfo, cbAuthenticateTargetInfo, AvTimestamp,
-		                          cbAvTimestamp) == NULL)
+		if (!ntlm_av_pair_add_copy(AuthenticateTargetInfo, cbAuthenticateTargetInfo,
+		                           AvTimestamp, cbAvTimestamp))
 			return -1;
 	}
 
@@ -646,31 +642,31 @@ int ntlm_construct_authenticate_target_info(NTLM_CONTEXT* context)
 		UINT32 flags;
 		Data_Write_UINT32(&flags, MSV_AV_FLAGS_MESSAGE_INTEGRITY_CHECK);
 
-		if (ntlm_av_pair_add(AuthenticateTargetInfo, cbAuthenticateTargetInfo, MsvAvFlags, (PBYTE) &flags,
-		                     4) == NULL)
+		if (!ntlm_av_pair_add(AuthenticateTargetInfo, cbAuthenticateTargetInfo, MsvAvFlags,
+		                      (PBYTE) &flags, 4))
 			return -1;
 	}
 
 	if (context->SendSingleHostData)
 	{
-		if (ntlm_av_pair_add(AuthenticateTargetInfo, cbAuthenticateTargetInfo, MsvAvSingleHost,
-		                     (PBYTE) &context->SingleHostData, context->SingleHostData.Size) == NULL)
+		if (!ntlm_av_pair_add(AuthenticateTargetInfo, cbAuthenticateTargetInfo, MsvAvSingleHost,
+		                      (PBYTE) &context->SingleHostData, context->SingleHostData.Size))
 			return -1;
 	}
 
 	if (!context->SuppressExtendedProtection)
 	{
-		if (ntlm_av_pair_add(AuthenticateTargetInfo, cbAuthenticateTargetInfo, MsvChannelBindings,
-		                     context->ChannelBindingsHash, 16) == NULL)
+		if (!ntlm_av_pair_add(AuthenticateTargetInfo, cbAuthenticateTargetInfo, MsvChannelBindings,
+		                      context->ChannelBindingsHash, 16))
 			return -1;
 
 		if (context->ServicePrincipalName.Length > 0)
 		{
-			if (ntlm_av_pair_add(AuthenticateTargetInfo,
-			                     cbAuthenticateTargetInfo,
-			                     MsvAvTargetName,
-			                     (PBYTE) context->ServicePrincipalName.Buffer,
-			                     context->ServicePrincipalName.Length) == NULL)
+			if (!ntlm_av_pair_add(AuthenticateTargetInfo,
+			                      cbAuthenticateTargetInfo,
+			                      MsvAvTargetName,
+			                      (PBYTE) context->ServicePrincipalName.Buffer,
+			                      context->ServicePrincipalName.Length))
 				return -1;
 		}
 	}

--- a/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.h
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.h
@@ -24,11 +24,11 @@
 
 #include <winpr/stream.h>
 
-ULONG ntlm_av_pair_list_length(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairListMaxLength);
+ULONG ntlm_av_pair_list_length(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairList);
 void ntlm_print_av_pair_list(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairList);
-PBYTE ntlm_av_pair_get_value_pointer(NTLM_AV_PAIR* pAvPair, size_t cbAvPairListMaxLength);
-NTLM_AV_PAIR* ntlm_av_pair_get(void* pAvPairList, size_t avPairListLength, NTLM_AV_ID AvId,
-                               size_t* pcbAvPairListRemainingLength);
+PBYTE ntlm_av_pair_get_value_pointer(NTLM_AV_PAIR* pAvPair);
+NTLM_AV_PAIR* ntlm_av_pair_get(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairList,
+                               NTLM_AV_ID AvId, size_t* pcbAvPairListRemaining);
 
 int ntlm_construct_challenge_target_info(NTLM_CONTEXT* context);
 int ntlm_construct_authenticate_target_info(NTLM_CONTEXT* context);

--- a/winpr/libwinpr/sspi/NTLM/ntlm_message.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_message.c
@@ -468,7 +468,7 @@ SECURITY_STATUS ntlm_read_ChallengeMessage(NTLM_CONTEXT* context, PSecBuffer buf
 
 		if (AvTimestamp)
 		{
-			PBYTE ptr = ntlm_av_pair_get_value_pointer(AvTimestamp, cbAvTimestamp);
+			PBYTE ptr = ntlm_av_pair_get_value_pointer(AvTimestamp);
 
 			if (!ptr)
 				return SEC_E_INTERNAL_ERROR;
@@ -829,7 +829,7 @@ SECURITY_STATUS ntlm_read_AuthenticateMessage(NTLM_CONTEXT* context, PSecBuffer 
 		                           MsvAvFlags, &cbAvFlags);
 
 		if (AvFlags)
-			Data_Read_UINT32(ntlm_av_pair_get_value_pointer(AvFlags, cbAvFlags), flags);
+			Data_Read_UINT32(ntlm_av_pair_get_value_pointer(AvFlags), flags);
 	}
 
 	if (ntlm_read_message_fields_buffer(s,
@@ -1140,7 +1140,7 @@ SECURITY_STATUS ntlm_server_AuthenticateComplete(NTLM_CONTEXT* context)
 	                           MsvAvFlags, &cbAvFlags);
 
 	if (AvFlags)
-		Data_Read_UINT32(ntlm_av_pair_get_value_pointer(AvFlags, cbAvFlags), flags);
+		Data_Read_UINT32(ntlm_av_pair_get_value_pointer(AvFlags), flags);
 
 	if (ntlm_compute_lm_v2_response(context) < 0) /* LmChallengeResponse */
 		return SEC_E_INTERNAL_ERROR;


### PR DESCRIPTION
There were two main issues here: First, the `ntlm_av_pair_add` and
`ntlm_av_pair_add_copy` were not adding a new `MsvAvEOL` to the end of
the list to replace the one they overwrote. This caused the second call
to one of those functions to fail (since it couldn't find the
terminator), which was the source of the test failure. It also caused
`ntlm_av_pair_list_length` and `ntlm_print_av_pair_list` to read out of
bounds until they happened to find the right word.

Second, several bounds checks were wrong or missing. For example,
`ntlm_av_pair_add` does not ensure that the value fits inside the list.
And `ntlm_av_pair_get_len` and `ntlm_av_pair_get_value_pointer` can
return error codes or NULL, but those error returns were ignored, and
the values used anyway (such as in `ntlm_av_pair_add_copy`).

This fixes the list handling code to have the invariant that all
functions returning `NTLM_AV_PAIR*` only return non-`NULL` if the entire
returned `AvPair` is within bounds. This removes the need for the length
parameter in functions that only operate on a single `AvPair`. This
check is performed by the new `ntlm_av_pair_check` helper, which is
added in some new places and used to simplify the code in others.

Other issues fixed along the way include:
 - `ntlm_av_pair_list_length` did not cast to `PBYTE`, so it was
   returning the number of `NTLM_AV_PAIR`-sized chunks (which was
   possibly not even an integer) instead of the number of bytes
 - I removed an impossible check for `offset <= 0` in
   `ntlm_av_pair_get_next_pointer`
 - The assertion that `Value != NULL` and the call to `CopyMemory` are
   only necessary if `AvLen` is nonzero
 - `ntlm_av_pair_get_next_pointer` (renamed to `ntlm_av_pair_next`)
   could be declared `static`

With this commit, TestNTLM now passes on powerpc64.

```
$ ./Testing/TestSspi TestNTLM
NTLM_NEGOTIATE (length = 40):
NTLM_CHALLENGE (length = 168):
NTLM_AUTHENTICATE (length = 352):
$ echo $?
0
```

Fixes #5250
