### PR TITLE
Close file handle correctly.

### DIFF
--- a/libfreerdp/crypto/certificate.c
+++ b/libfreerdp/crypto/certificate.c
@@ -444,7 +444,7 @@ BOOL certificate_data_replace(rdpCertificateStore* certificate_store,
 
 	if (!data)
 	{
-		fclose(fp);
+		CloseHandle(fp);
 		return FALSE;
 	}
 


### PR DESCRIPTION
We have found bugs using [PVS-Studio](https://www.viva64.com/en/pvs-studio-download/) tool. It is a static code analyzer for C, C++, C#, and Java.

You can find other FreeRDP bugs in this article: [Checking FreeRDP with PVS-Studio](https://www.viva64.com/en/b/0617/).