### PR TITLE
Fix Wire to Surface 2 pixel format decode on client

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -792,7 +792,21 @@ static UINT rdpgfx_recv_wire_to_surface_2_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 	cmd.surfaceId = pdu.surfaceId;
 	cmd.codecId = pdu.codecId;
 	cmd.contextId = pdu.codecContextId;
-	cmd.format = pdu.pixelFormat;
+
+	switch (pdu.pixelFormat)
+	{
+		case GFX_PIXEL_FORMAT_XRGB_8888:
+			cmd.format = PIXEL_FORMAT_BGRX32;
+			break;
+
+		case GFX_PIXEL_FORMAT_ARGB_8888:
+			cmd.format = PIXEL_FORMAT_BGRA32;
+			break;
+
+		default:
+			return ERROR_INVALID_DATA;
+	}
+
 	cmd.left = 0;
 	cmd.top = 0;
 	cmd.right = 0;


### PR DESCRIPTION
Came across this when tunneling GFX messages from `RdpgfxClientContext` to `RdpgfxServerContext` in the proxy we're implementing. The client just copies the `pixelFormat` field instead of parsing properly, while the server implementation does this correctly, which threw an error when tunneling the message.

This parsing of the same pixel format field is already implemented correctly in `recv_w2s1_pdu`, I just took the parse code from there. Should I maybe implement a conversion method that could be reused instead of having this big switch statement multiple times? If so, where would be the correct place for it, color.h where the pixel formats are defined?