### PR TITLE
Fix update_end_paint wrong log level

### DIFF
--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -803,7 +803,7 @@ static BOOL update_end_paint(rdpContext* context)
 
 	if (update->numberOrders > 0)
 	{
-		WLog_ERR(TAG,  "sending %"PRIu16" orders", update->numberOrders);
+		WLog_DBG(TAG,  "sending %"PRIu16" orders", update->numberOrders);
 		fastpath_send_update_pdu(context->rdp->fastpath, FASTPATH_UPDATETYPE_ORDERS, s,
 		                         FALSE);
 	}


### PR DESCRIPTION
Just a small fix for a debug log that is currently an error log. On most use-cases this function isn't called, but in our scenario as a proxy, testing connection to a windows 7 target server, this log spams the proxy unnecessarily.