### PR TITLE
Add null terminator to RoutingToken in nego_set_routing_token

### DIFF
--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -1294,12 +1294,13 @@ BOOL nego_set_routing_token(rdpNego* nego, BYTE* RoutingToken, DWORD RoutingToke
 
 	free(nego->RoutingToken);
 	nego->RoutingTokenLength = RoutingTokenLength;
-	nego->RoutingToken = (BYTE*) malloc(nego->RoutingTokenLength);
+	nego->RoutingToken = (BYTE*) malloc(nego->RoutingTokenLength + 1);
 
 	if (!nego->RoutingToken)
 		return FALSE;
 
 	CopyMemory(nego->RoutingToken, RoutingToken, nego->RoutingTokenLength);
+	nego->RoutingToken[nego->RoutingTokenLength] = 0;
 	return TRUE;
 }
 


### PR DESCRIPTION
While working on the proxy we're implementing, We used the routing token as a temporary solution for passing the target server from the client. After running some manual tests, I noticed that `nego->RoutingToken` isn't null terminated correctly in `nego_set_routing_token`. While it is being parsed, the function `nego_read_request_token_or_cookie` replaces the CRLF with zeros:

```c
if (crlf == 0x0A0D)
{
	Stream_Rewind(s, 2);
	len = Stream_GetPosition(s) - pos;
	Stream_Write_UINT16(s, 0); /* Here the CRLF bytes are being replaced with zeros */
	if (strlen((char*)str) == len)
	{
		if (isToken)
			result = nego_set_routing_token(nego, str, len);
		else
			result = nego_set_cookie(nego, (char*)str);
	}
}
```
The problem is that `nego_set_routing_token` calls CopyMemory with Length = `nego->RoutingTokenLength` which is the length of the routing token without the null terminator byte.

I chose to fix it by adding the null terminator "manually" instead of calling CopyMemory with `RoutingTokenLength + 1` because I found it more readable and understandable.