### PR TITLE
Fix double call to rdpgfx_server_close on RdpgfxServerContext

### DIFF
--- a/channels/rdpgfx/server/rdpgfx_main.c
+++ b/channels/rdpgfx/server/rdpgfx_main.c
@@ -1614,10 +1614,15 @@ out_free:
 
 void rdpgfx_server_context_free(RdpgfxServerContext* context)
 {
-	rdpgfx_server_close(context);
-
 	if (context->priv)
+	{
+		RdpgfxServerPrivate* priv = (RdpgfxServerPrivate*) context->priv;
+
+		if (priv->isOpened)
+			rdpgfx_server_close(context);
+
 		Stream_Free(context->priv->input_stream, TRUE);
+	}
 
 	free(context->priv);
 	free(context);


### PR DESCRIPTION
I just noticed that `rdpgfx_server_close` is both exposed as `RdpgfxServerContext`'s `Close` method and is called from `rdpgfx_server_context_free` unconditionally. Surely enough, when adding a print at the beginning of `rdpgfx_server_close`, it is printed twice consecutively in shadow. The second close doesn't do anything as it checks if everything it tries to free has already been freed, so I just added a check if the server has already been closed before calling it in `rdpgfx_server_context_free`.