### PR TITLE
Fix segfault when IniFile_Load is called with invalid input

### DIFF
--- a/winpr/libwinpr/utils/ini.c
+++ b/winpr/libwinpr/utils/ini.c
@@ -390,6 +390,10 @@ int IniFile_Load(wIniFile* ini)
 		else
 		{
 			separator = strchr(line, '=');
+
+			if (separator == NULL)
+				return -1;
+
 			end = separator;
 
 			while ((&end[-1] > line) && ((end[-1] == ' ') || (end[-1] == '\t')))

--- a/winpr/libwinpr/utils/test/TestIni.c
+++ b/winpr/libwinpr/utils/test/TestIni.c
@@ -132,11 +132,9 @@ int TestIni(int argc, char* argv[])
 	free(sectionNames);
 	IniFile_Free(ini);
 	/* Third sample - invalid input */
-	int status;
 	ini = IniFile_New();
-	status = IniFile_ReadBuffer(ini, TEST_INI_03);
 
-	if (!(status < 0))
+	if (IniFile_ReadBuffer(ini, TEST_INI_03) != -1)
 	{
 		IniFile_Free(ini);
 		return -1;

--- a/winpr/libwinpr/utils/test/TestIni.c
+++ b/winpr/libwinpr/utils/test/TestIni.c
@@ -137,7 +137,10 @@ int TestIni(int argc, char* argv[])
 	status = IniFile_ReadBuffer(ini, TEST_INI_03);
 
 	if (!(status < 0))
+	{
+		IniFile_Free(ini);
 		return -1;
+	}
 
 	IniFile_Free(ini);
 	return 0;

--- a/winpr/libwinpr/utils/test/TestIni.c
+++ b/winpr/libwinpr/utils/test/TestIni.c
@@ -1,31 +1,43 @@
 
 #include <winpr/crt.h>
-
 #include <winpr/ini.h>
 
 const char TEST_INI_01[] =
-	"; This is a sample .ini config file\n"
-	"\n"
-	"[first_section]\n"
-	"one = 1\n"
-	"five = 5\n"
-	"animal = BIRD\n"
-	"\n"
-	"[second_section]\n"
-	"path = \"/usr/local/bin\"\n"
-	"URL = \"http://www.example.com/~username\"\n"
-	"\n";
+    "; This is a sample .ini config file\n"
+    "\n"
+    "[first_section]\n"
+    "one = 1\n"
+    "five = 5\n"
+    "animal = BIRD\n"
+    "\n"
+    "[second_section]\n"
+    "path = \"/usr/local/bin\"\n"
+    "URL = \"http://www.example.com/~username\"\n"
+    "\n";
 
 const char TEST_INI_02[] =
-	"[FreeRDS]\n"
-	"prefix=\"/usr/local\"\n"
-	"bindir=\"bin\"\n"
-	"sbindir=\"sbin\"\n"
-	"libdir=\"lib\"\n"
-	"datarootdir=\"share\"\n"
-	"localstatedir=\"var\"\n"
-	"sysconfdir=\"etc\"\n"
-	"\n";
+    "[FreeRDS]\n"
+    "prefix=\"/usr/local\"\n"
+    "bindir=\"bin\"\n"
+    "sbindir=\"sbin\"\n"
+    "libdir=\"lib\"\n"
+    "datarootdir=\"share\"\n"
+    "localstatedir=\"var\"\n"
+    "sysconfdir=\"etc\"\n"
+    "\n";
+
+const char TEST_INI_03[] =
+    "[FreeRDS]\n"
+    "prefix=\"/usr/local\"\n"
+    "bindir=\"bin\"\n"
+    "# some illegal string\n"
+    "sbindir=\"sbin\"\n"
+    "libdir=\"lib\"\n"
+    "invalid key-value pair\n"
+    "datarootdir=\"share\"\n"
+    "localstatedir=\"var\"\n"
+    "sysconfdir=\"etc\"\n"
+    "\n";
 
 int TestIni(int argc, char* argv[])
 {
@@ -37,101 +49,97 @@ int TestIni(int argc, char* argv[])
 	const char* sValue;
 	char** keyNames;
 	char** sectionNames;
-
 	/* First Sample */
-	
 	ini = IniFile_New();
-
 	IniFile_ReadBuffer(ini, TEST_INI_01);
-	
 	sectionNames = IniFile_GetSectionNames(ini, &nSections);
-	
+
 	for (i = 0; i < nSections; i++)
 	{
 		keyNames = IniFile_GetSectionKeyNames(ini, sectionNames[i], &nKeys);
-		
 		printf("[%s]\n", sectionNames[i]);
-		
+
 		for (j = 0; j < nKeys; j++)
 		{
 			sValue = IniFile_GetKeyValueString(ini, sectionNames[i], keyNames[j]);
 			printf("%s = %s\n", keyNames[j], sValue);
 		}
-		
+
 		free(keyNames);
 	}
-	
-	free(sectionNames);
 
+	free(sectionNames);
 	iValue = IniFile_GetKeyValueInt(ini, "first_section", "one");
-	
+
 	if (iValue != 1)
 	{
 		printf("IniFile_GetKeyValueInt failure\n");
 		return -1;
 	}
-	
+
 	iValue = IniFile_GetKeyValueInt(ini, "first_section", "five");
-	
+
 	if (iValue != 5)
 	{
 		printf("IniFile_GetKeyValueInt failure\n");
 		return -1;
 	}
-	
+
 	sValue = IniFile_GetKeyValueString(ini, "first_section", "animal");
-	
+
 	if (strcmp(sValue, "BIRD") != 0)
 	{
 		printf("IniFile_GetKeyValueString failure\n");
-		return -1;	
+		return -1;
 	}
-	
+
 	sValue = IniFile_GetKeyValueString(ini, "second_section", "path");
-	
+
 	if (strcmp(sValue, "/usr/local/bin") != 0)
 	{
 		printf("IniFile_GetKeyValueString failure\n");
-		return -1;	
+		return -1;
 	}
-	
+
 	sValue = IniFile_GetKeyValueString(ini, "second_section", "URL");
-	
+
 	if (strcmp(sValue, "http://www.example.com/~username") != 0)
 	{
 		printf("IniFile_GetKeyValueString failure\n");
-		return -1;	
+		return -1;
 	}
-	
+
 	IniFile_Free(ini);
-	
 	/* Second Sample */
-
 	ini = IniFile_New();
-
 	IniFile_ReadBuffer(ini, TEST_INI_02);
-	
 	sectionNames = IniFile_GetSectionNames(ini, &nSections);
-	
+
 	for (i = 0; i < nSections; i++)
 	{
 		keyNames = IniFile_GetSectionKeyNames(ini, sectionNames[i], &nKeys);
-		
 		printf("[%s]\n", sectionNames[i]);
-		
+
 		for (j = 0; j < nKeys; j++)
 		{
 			sValue = IniFile_GetKeyValueString(ini, sectionNames[i], keyNames[j]);
 			printf("%s = %s\n", keyNames[j], sValue);
 		}
-		
+
 		free(keyNames);
 	}
-	
+
 	free(sectionNames);
-	
 	IniFile_Free(ini);
-	
+	/* Third sample - invalid input */
+	int status;
+	ini = IniFile_New();
+	status = IniFile_ReadBuffer(ini, TEST_INI_03);
+
+	if (!(status < 0))
+		return -1;
+
+	IniFile_Free(ini);
 	return 0;
 }
 


### PR DESCRIPTION
Just a small fix to a bug that caused a segfault to occur when `IniFile_Load` is called with an invalid input. The function's signature implies that an invalid INI input would return `-1` while the actual functionality is a segfault. For example, when calling `IniFile_Load` with this input, a segfault occurs.

```ini
[General]
Host = "0.0.0.0"
Port = 3389
LocalOnly = 0

[Input]
Mouse = 1
Keyboard = 1

[Graphics]
GFX = 1
BitmapUpdate = 1
Some Illegal Key

[Security]
NlaSupport = 0
TlsSupport = 0
RdpSupport = 0

```
That happens because the code assumes that the file is a valid INI. Therefore, there was no check for `strchr`'s result in line 392. I've added another test case to ensure the problem was fixed.

**I also ran the code formatting script.**
