### PR TITLE
Unified update->BeginPaint and update->EndPaint

### DIFF
--- a/include/freerdp/update.h
+++ b/include/freerdp/update.h
@@ -252,6 +252,7 @@ struct rdp_update
 	BOOL combineUpdates;
 	rdpBounds currentBounds;
 	rdpBounds previousBounds;
+	CRITICAL_SECTION mux;
 };
 
 #endif /* FREERDP_UPDATE_H */

--- a/libfreerdp/core/fastpath.c
+++ b/libfreerdp/core/fastpath.c
@@ -633,6 +633,7 @@ out_fail:
 
 int fastpath_recv_updates(rdpFastPath* fastpath, wStream* s)
 {
+	int rc = -2;
 	rdpUpdate* update;
 
 	if (!fastpath || !fastpath->rdp || !fastpath->rdp->update || !s)
@@ -640,22 +641,26 @@ int fastpath_recv_updates(rdpFastPath* fastpath, wStream* s)
 
 	update = fastpath->rdp->update;
 
-	if (!IFCALLRESULT(TRUE, update->BeginPaint, update->context))
-		return -2;
+	if (!update_begin_paint(update))
+		goto fail;
 
 	while (Stream_GetRemainingLength(s) >= 3)
 	{
 		if (fastpath_recv_update_data(fastpath, s) < 0)
 		{
 			WLog_ERR(TAG, "fastpath_recv_update_data() fail");
-			return -3;
+			rc = -3;
+			goto fail;
 		}
 	}
 
-	if (!IFCALLRESULT(FALSE, update->EndPaint, update->context))
+	rc = 0;
+fail:
+
+	if (!update_end_paint(update))
 		return -4;
 
-	return 0;
+	return rc;
 }
 
 static BOOL fastpath_read_input_event_header(wStream* s, BYTE* eventFlags, BYTE* eventCode)

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -270,12 +270,16 @@ BOOL freerdp_connect(freerdp* instance)
 			Stream_SetLength(s, record.length);
 			Stream_SetPosition(s, 0);
 
-			if (!update->BeginPaint(update->context))
+			if (!update_begin_paint(update))
 				status = FALSE;
-			else if (update_recv_surfcmds(update, s) < 0)
-				status = FALSE;
-			else if (!update->EndPaint(update->context))
-				status = FALSE;
+			else
+			{
+				if (update_recv_surfcmds(update, s) < 0)
+					status = FALSE;
+
+				if (!update_end_paint(update))
+					status = FALSE;
+			}
 
 			Stream_Release(s);
 		}

--- a/libfreerdp/core/update.h
+++ b/libfreerdp/core/update.h
@@ -64,4 +64,7 @@ FREERDP_LOCAL void update_register_server_callbacks(rdpUpdate* update);
 FREERDP_LOCAL void update_register_client_callbacks(rdpUpdate* update);
 FREERDP_LOCAL int update_process_messages(rdpUpdate* update);
 
+FREERDP_LOCAL BOOL update_begin_paint(rdpUpdate* update);
+FREERDP_LOCAL BOOL update_end_paint(rdpUpdate* update);
+
 #endif /* FREERDP_LIB_CORE_UPDATE_H */

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -23,6 +23,8 @@
 #include "config.h"
 #endif
 
+#include "../core/update.h"
+
 #include <freerdp/log.h>
 #include <freerdp/gdi/gfx.h>
 #include <freerdp/gdi/region.h>
@@ -124,7 +126,7 @@ static UINT gdi_OutputUpdate(rdpGdi* gdi, gdiGfxSurface* surface)
 	if (!(rects = region16_rects(&surface->invalidRegion, &nbRects)) || !nbRects)
 		return CHANNEL_RC_OK;
 
-	if (!IFCALLRESULT(TRUE, update->BeginPaint, gdi->context))
+	if (!update_begin_paint(update))
 		goto fail;
 
 	for (i = 0; i < nbRects; i++)
@@ -146,11 +148,12 @@ static UINT gdi_OutputUpdate(rdpGdi* gdi, gdiGfxSurface* surface)
 		gdi_InvalidateRegion(gdi->primary->hdc, nXDst, nYDst, width, height);
 	}
 
-	if (!IFCALLRESULT(FALSE, update->EndPaint, gdi->context))
-		goto fail;
-
 	rc = CHANNEL_RC_OK;
 fail:
+
+	if (!update_end_paint(update))
+		rc = ERROR_INTERNAL_ERROR;
+
 	region16_clear(&(surface->invalidRegion));
 	return rc;
 }


### PR DESCRIPTION
Since these functions were called from 2 different threads
(main thread or dynamic channel) depending on fastpath or
gfx channel use lock between these.
If not locked the invalid region may be accessed from both
threads and lead to crashes as experienced with nightly df280a7ff

Testcase:
`xfreerdp /rfx /gfx /network:auto` to a windows 10 machine sometimes sends fastpath `EndPaint` events that may crash the client. (best seen with nightly and address sanitizer)