### PR TITLE
Fix wrong callback call on server handshake ex recv

### DIFF
--- a/channels/rail/client/rail_orders.c
+++ b/channels/rail/client/rail_orders.c
@@ -538,10 +538,10 @@ static UINT rail_recv_handshake_ex_order(railPlugin* rail, RAIL_HANDSHAKE_EX_ORD
 
 	if (context->custom)
 	{
-		IFCALLRET(context->ClientHandshakeEx, error, context, handshakeEx);
+		IFCALLRET(context->ServerHandshakeEx, error, context, handshakeEx);
 
 		if (error)
-			WLog_ERR(TAG, "context.ClientHandshakeEx failed with error %"PRIu32"", error);
+			WLog_ERR(TAG, "context.ServerHandshakeEx failed with error %"PRIu32"", error);
 	}
 
 	return error;


### PR DESCRIPTION
Just noticed that on `rail_recv_handshake_ex_order` that's called whenever the client receives a HanshakeEx message from the server, the client accidentally calls the `ClientHandshakeEx` callback instead of the `ServerHandeshakeEx`. This causes the client to send an unwanted HandshakeEx messsage, in addition to the handshake the actual client like xfreerdp will send again after that, probably causing a protocol error.

Regardless of this faulty behavior, according to the spec, the client should never send a HandshakeEx message anyway (it's documented that it should respond with a regular Handshake in response to both Handshake and HandshakeEx server messages). Wouldn't it be better to remove the `ClientHandshakeEx` callback entirely, reducing the API too? I could add a commit to the PR if found necessary.