### PR TITLE
Rail exec order

### DIFF
--- a/channels/rail/client/rail_orders.h
+++ b/channels/rail/client/rail_orders.h
@@ -37,9 +37,7 @@ UINT rail_send_pdu(railPlugin* rail, wStream* s, UINT16 orderType);
 UINT rail_send_handshake_order(railPlugin* rail, const RAIL_HANDSHAKE_ORDER* handshake);
 UINT rail_send_handshake_ex_order(railPlugin* rail, const RAIL_HANDSHAKE_EX_ORDER* handshakeEx);
 UINT rail_send_client_status_order(railPlugin* rail, const RAIL_CLIENT_STATUS_ORDER* clientStatus);
-UINT rail_send_client_exec_order(railPlugin* rail, UINT16 flags,
-                                 const RAIL_UNICODE_STRING* exeOrFile, const RAIL_UNICODE_STRING* workingDir,
-                                 const RAIL_UNICODE_STRING* arguments);
+UINT rail_send_client_exec_order(railPlugin* rail, const RAIL_EXEC_ORDER* exec);
 UINT rail_send_client_activate_order(railPlugin* rail, const RAIL_ACTIVATE_ORDER* activate);
 UINT rail_send_client_sysmenu_order(railPlugin* rail, const RAIL_SYSMENU_ORDER* sysmenu);
 UINT rail_send_client_syscommand_order(railPlugin* rail, const RAIL_SYSCOMMAND_ORDER* syscommand);

--- a/channels/rail/rail_common.c
+++ b/channels/rail/rail_common.c
@@ -51,30 +51,6 @@ const char* const RAIL_ORDER_TYPE_STRINGS[] =
 	""
 };
 
-BOOL rail_string_to_unicode_string(const char* string, RAIL_UNICODE_STRING* unicode_string)
-{
-	WCHAR* buffer = NULL;
-	int length = 0;
-	free(unicode_string->string);
-	unicode_string->string = NULL;
-	unicode_string->length = 0;
-
-	if (!string || strlen(string) < 1)
-		return TRUE;
-
-	length = ConvertToUnicode(CP_UTF8, 0, string, -1, &buffer, 0);
-
-	if ((length < 0) || ((size_t)length * sizeof(WCHAR) > UINT16_MAX))
-	{
-		free(buffer);
-		return FALSE;
-	}
-
-	unicode_string->string = (BYTE*) buffer;
-	unicode_string->length = (UINT16) length * sizeof(WCHAR);
-	return TRUE;
-}
-
 /**
  * Function description
  *

--- a/channels/rail/rail_common.h
+++ b/channels/rail/rail_common.h
@@ -44,7 +44,6 @@ extern const char* const RAIL_ORDER_TYPE_STRINGS[];
 #define RAIL_GET_APPID_REQ_ORDER_LENGTH		4	/* fixed */
 #define RAIL_LANGBAR_INFO_ORDER_LENGTH		4	/* fixed */
 
-BOOL rail_string_to_unicode_string(const char* string, RAIL_UNICODE_STRING* unicode_string);
 UINT rail_read_handshake_order(wStream* s, RAIL_HANDSHAKE_ORDER* handshake);
 void rail_write_handshake_order(wStream* s, const RAIL_HANDSHAKE_ORDER* handshake);
 UINT rail_read_handshake_ex_order(wStream* s, RAIL_HANDSHAKE_EX_ORDER* handshakeEx);

--- a/client/Windows/wf_rail.c
+++ b/client/Windows/wf_rail.c
@@ -910,9 +910,15 @@ static UINT wf_rail_server_handshake(RailClientContext* context,
 	sysparam.dragFullWindows = FALSE;
 	context->ClientSystemParam(context, &sysparam);
 	ZeroMemory(&exec, sizeof(RAIL_EXEC_ORDER));
-	exec.RemoteApplicationProgram = settings->RemoteApplicationProgram;
-	exec.RemoteApplicationWorkingDir = settings->ShellWorkingDirectory;
-	exec.RemoteApplicationArguments = settings->RemoteApplicationCmdLine;
+
+	if (!rail_string_to_unicode_string(settings->RemoteApplicationProgram,
+	                                   &exec.RemoteApplicationProgram) ||
+	    rail_string_to_unicode_string(settings->ShellWorkingDirectory,
+	                                  &exec.RemoteApplicationWorkingDir) ||
+	    rail_string_to_unicode_string(settings->RemoteApplicationCmdLine,
+	                                  &exec.RemoteApplicationArguments))
+		return ERROR_INTERNAL_ERROR;
+
 	context->ClientExecute(context, &exec);
 	return CHANNEL_RC_OK;
 }

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -1045,9 +1045,14 @@ static UINT xf_rail_server_handshake(RailClientContext* context,
 	if (status != CHANNEL_RC_OK)
 		return status;
 
-	exec.RemoteApplicationProgram = settings->RemoteApplicationProgram;
-	exec.RemoteApplicationWorkingDir = settings->ShellWorkingDirectory;
-	exec.RemoteApplicationArguments = settings->RemoteApplicationCmdLine;
+	if (!rail_string_to_unicode_string(settings->RemoteApplicationProgram,
+	                                   &exec.RemoteApplicationProgram) ||
+	    rail_string_to_unicode_string(settings->ShellWorkingDirectory,
+	                                  &exec.RemoteApplicationWorkingDir) ||
+	    rail_string_to_unicode_string(settings->RemoteApplicationCmdLine,
+	                                  &exec.RemoteApplicationArguments))
+		return ERROR_INTERNAL_ERROR;
+
 	return context->ClientExecute(context, &exec);
 }
 
@@ -1267,6 +1272,7 @@ int xf_rail_init(xfContext* xfc, RailClientContext* rail)
 int xf_rail_uninit(xfContext* xfc, RailClientContext* rail)
 {
 	WINPR_UNUSED(rail);
+
 	if (xfc->rail)
 	{
 		xfc->rail->custom = NULL;

--- a/include/freerdp/client/rail.h
+++ b/include/freerdp/client/rail.h
@@ -35,7 +35,7 @@
 
 typedef struct _rail_client_context RailClientContext;
 
-typedef UINT(*pcRailClientExecute)(RailClientContext* context, const RAIL_EXEC_ORDER* exec);
+typedef UINT(*pcRailClientExecute)(RailClientContext* context, RAIL_EXEC_ORDER* exec);
 typedef UINT(*pcRailClientActivate)(RailClientContext* context,
                                     const RAIL_ACTIVATE_ORDER* activate);
 typedef UINT(*pcRailClientSystemParam)(RailClientContext* context,

--- a/include/freerdp/rail.h
+++ b/include/freerdp/rail.h
@@ -219,9 +219,9 @@ typedef struct _RAIL_CLIENT_STATUS_ORDER RAIL_CLIENT_STATUS_ORDER;
 struct _RAIL_EXEC_ORDER
 {
 	UINT16 flags;
-	char* RemoteApplicationProgram;
-	char* RemoteApplicationWorkingDir;
-	char* RemoteApplicationArguments;
+	RAIL_UNICODE_STRING RemoteApplicationProgram;
+	RAIL_UNICODE_STRING RemoteApplicationWorkingDir;
+	RAIL_UNICODE_STRING RemoteApplicationArguments;
 };
 typedef struct _RAIL_EXEC_ORDER RAIL_EXEC_ORDER;
 

--- a/include/freerdp/rail.h
+++ b/include/freerdp/rail.h
@@ -379,6 +379,8 @@ extern "C" {
 #endif
 
 FREERDP_API BOOL rail_read_unicode_string(wStream* s, RAIL_UNICODE_STRING* unicode_string);
+FREERDP_API BOOL rail_string_to_unicode_string(const char* string,
+        RAIL_UNICODE_STRING* unicode_string);
 
 #ifdef __cplusplus
 }

--- a/libfreerdp/core/window.c
+++ b/libfreerdp/core/window.c
@@ -66,6 +66,30 @@ BOOL rail_read_unicode_string(wStream* s, RAIL_UNICODE_STRING* unicode_string)
 	return TRUE;
 }
 
+BOOL rail_string_to_unicode_string(const char* string, RAIL_UNICODE_STRING* unicode_string)
+{
+	WCHAR* buffer = NULL;
+	int length = 0;
+	free(unicode_string->string);
+	unicode_string->string = NULL;
+	unicode_string->length = 0;
+
+	if (!string || strlen(string) < 1)
+		return TRUE;
+
+	length = ConvertToUnicode(CP_UTF8, 0, string, -1, &buffer, 0);
+
+	if ((length < 0) || ((size_t)length * sizeof(WCHAR) > UINT16_MAX))
+	{
+		free(buffer);
+		return FALSE;
+	}
+
+	unicode_string->string = (BYTE*) buffer;
+	unicode_string->length = (UINT16) length * sizeof(WCHAR);
+	return TRUE;
+}
+
 /* See [MS-RDPERP] 2.2.1.2.3 Icon Info (TS_ICON_INFO) */
 static BOOL update_read_icon_info(wStream* s, ICON_INFO* iconInfo)
 {


### PR DESCRIPTION
This PR might be a bit out of nowhere without context, so I'll explain shortly. In the RDP proxy we're developing (that I've mentioned in a few of my PRs already), we want to support RAIL proxy. For that to work, I am currently working on implementing RAIL server support for FreeRDP (protocol level support, not an actual implementation for a server like shadow). While implementing receiving a RAIL Exec order from the client, I noticed that the API for the Exec order is inconsistent with the rest of the orders:
- The strings in the order are unicode strings, but are instead represented as `char*` in the order struct.
- The methods that deal with the order don't even use the order struct, they just receive the struct's properties instead.

The point of this PR is to unify the handling of orders and to make it easier to work with exec order (using one struct and not multiple strings and values)