### PR TITLE
xf_floatbar.c: fix build without Xfixes

### DIFF
--- a/client/X11/xf_floatbar.c
+++ b/client/X11/xf_floatbar.c
@@ -19,7 +19,6 @@
 #include <X11/Xutil.h>
 #include <X11/Xatom.h>
 #include <X11/extensions/shape.h>
-#include <X11/extensions/Xfixes.h>
 #include <X11/cursorfont.h>
 
 #include "xf_floatbar.h"


### PR DESCRIPTION
Remove unneeded include on Xfixes.h as it is not always available and
not used in xf_floatbar.c

Fixes:
 - http://autobuild.buildroot.org/results/69245e574787bada718c52c805ec137041dc233d

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>