### PR TITLE
Fix smartcard segfault when no devices are present

### DIFF
--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -547,9 +547,6 @@ static LONG smartcard_ListReadersA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_O
 	cchReaders = SCARD_AUTOALLOCATE;
 	status = ret.ReturnCode = SCardListReadersA(operation->hContext, (LPCSTR) call->mszGroups,
 	                          (LPSTR) &mszReaders, &cchReaders);
-	cchReaders = filter_device_by_name_a(smartcard->names, &mszReaders, cchReaders);
-	ret.msz = (BYTE*) mszReaders;
-	ret.cBytes = cchReaders;
 
 	if (call->mszGroups)
 	{
@@ -562,6 +559,10 @@ static LONG smartcard_ListReadersA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_O
 		WLog_ERR(TAG, "SCardListReadersA failed with error %"PRId32"", status);
 		return status;
 	}
+
+	cchReaders = filter_device_by_name_a(smartcard->names, &mszReaders, cchReaders);
+	ret.msz = (BYTE*) mszReaders;
+	ret.cBytes = cchReaders;
 
 	smartcard_trace_list_readers_return(smartcard, &ret, FALSE);
 
@@ -610,9 +611,6 @@ static LONG smartcard_ListReadersW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_O
 	cchReaders = SCARD_AUTOALLOCATE;
 	status = ret.ReturnCode = SCardListReadersW(operation->hContext,
 	                          (LPCWSTR) call->mszGroups, (LPWSTR) &mszReaders, &cchReaders);
-	cchReaders = filter_device_by_name_w(smartcard->names, &mszReaders, cchReaders);
-	ret.msz = (BYTE*) mszReaders;
-	ret.cBytes = cchReaders * 2;
 
 	if (call->mszGroups)
 	{
@@ -625,6 +623,10 @@ static LONG smartcard_ListReadersW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_O
 		WLog_ERR(TAG, "SCardListReadersW failed with error %"PRId32"", status);
 		return status;
 	}
+
+	cchReaders = filter_device_by_name_w(smartcard->names, &mszReaders, cchReaders);
+	ret.msz = (BYTE*) mszReaders;
+	ret.cBytes = cchReaders * 2;
 
 	smartcard_trace_list_readers_return(smartcard, &ret, TRUE);
 

--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -457,7 +457,7 @@ static DWORD filter_device_by_name_a(wLinkedList* list, LPSTR* mszReaders, DWORD
 {
 	size_t rpos = 0, wpos = 0;
 
-	if(*mszReaders == NULL || LinkedList_Count(list) < 1)
+	if (*mszReaders == NULL || LinkedList_Count(list) < 1)
 		return cchReaders;
 
 	do
@@ -563,7 +563,6 @@ static LONG smartcard_ListReadersA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_O
 	cchReaders = filter_device_by_name_a(smartcard->names, &mszReaders, cchReaders);
 	ret.msz = (BYTE*) mszReaders;
 	ret.cBytes = cchReaders;
-
 	smartcard_trace_list_readers_return(smartcard, &ret, FALSE);
 
 	if ((status = smartcard_pack_list_readers_return(smartcard, irp->output, &ret)))
@@ -627,7 +626,6 @@ static LONG smartcard_ListReadersW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_O
 	cchReaders = filter_device_by_name_w(smartcard->names, &mszReaders, cchReaders);
 	ret.msz = (BYTE*) mszReaders;
 	ret.cBytes = cchReaders * 2;
-
 	smartcard_trace_list_readers_return(smartcard, &ret, TRUE);
 
 	if ((status = smartcard_pack_list_readers_return(smartcard, irp->output, &ret)))

--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -457,7 +457,7 @@ static DWORD filter_device_by_name_a(wLinkedList* list, LPSTR* mszReaders, DWORD
 {
 	size_t rpos = 0, wpos = 0;
 
-	if (LinkedList_Count(list) < 1)
+	if(*mszReaders == NULL || LinkedList_Count(list) < 1)
 		return cchReaders;
 
 	do


### PR DESCRIPTION
Either of the two commits 324dce9 or 84382da is sufficient to fix #5360 for me though, unless there is really a reason to try to filter the smartcard device list before checking whether the status is good, both seem to be a good idea to me.
