### PR TITLE
android_freerdp.c: fixed wrong registered signature

### DIFF
--- a/client/Android/android_freerdp.c
+++ b/client/Android/android_freerdp.c
@@ -1145,7 +1145,7 @@ static JNINativeMethod methods[] =
 	},
 	{
 		"freerdp_send_unicodekey_event",
-		"(JI)Z",
+		"(JIZ)Z",
 		&jni_freerdp_send_unicodekey_event
 	},
 	{


### PR DESCRIPTION
android_freerdp.c: Line 1148, changed wrong registered signature from (JI)Z to (JIZ)Z