### PR TITLE
rdpgfx: Fix GFX v10.6 PDUs parsing and naming according to the spec

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -1177,7 +1177,7 @@ static UINT rdpgfx_recv_map_surface_to_scaled_output_pdu(RDPGFX_CHANNEL_CALLBACK
 	RdpgfxClientContext* context = (RdpgfxClientContext*) gfx->iface.pInterface;
 	UINT error = CHANNEL_RC_OK;
 
-	if (Stream_GetRemainingLength(s) < 12)
+	if (Stream_GetRemainingLength(s) < 20)
 	{
 		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
@@ -1187,11 +1187,11 @@ static UINT rdpgfx_recv_map_surface_to_scaled_output_pdu(RDPGFX_CHANNEL_CALLBACK
 	Stream_Read_UINT16(s, pdu.reserved); /* reserved (2 bytes) */
 	Stream_Read_UINT32(s, pdu.outputOriginX); /* outputOriginX (4 bytes) */
 	Stream_Read_UINT32(s, pdu.outputOriginY); /* outputOriginY (4 bytes) */
-	Stream_Read_UINT32(s, pdu.targetX);
-	Stream_Read_UINT32(s, pdu.targetY);
+	Stream_Read_UINT32(s, pdu.targetWidth); /* targetWidth (4 bytes) */
+	Stream_Read_UINT32(s, pdu.targetHeight); /* targetHeight (4 bytes) */
 	WLog_Print(gfx->log, WLOG_DEBUG,
-	           "RecvMapSurfaceToOutputPdu: surfaceId: %"PRIu16" outputOriginX: %"PRIu32" outputOriginY: %"PRIu32" targetX: %"PRIu32" targetY: %"PRIu32,
-	           pdu.surfaceId, pdu.outputOriginX, pdu.outputOriginY, pdu.targetX, pdu.targetY);
+	           "RecvMapSurfaceToScaledOutputPdu: surfaceId: %"PRIu16" outputOriginX: %"PRIu32" outputOriginY: %"PRIu32" targetWidth: %"PRIu32" targetHeight: %"PRIu32,
+	           pdu.surfaceId, pdu.outputOriginX, pdu.outputOriginY, pdu.targetWidth, pdu.targetHeight);
 
 	if (context)
 	{
@@ -1251,7 +1251,7 @@ static UINT rdpgfx_recv_map_surface_to_scaled_window_pdu(RDPGFX_CHANNEL_CALLBACK
 	RdpgfxClientContext* context = (RdpgfxClientContext*) gfx->iface.pInterface;
 	UINT error = CHANNEL_RC_OK;
 
-	if (Stream_GetRemainingLength(s) < 18)
+	if (Stream_GetRemainingLength(s) < 26)
 	{
 		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
@@ -1261,11 +1261,11 @@ static UINT rdpgfx_recv_map_surface_to_scaled_window_pdu(RDPGFX_CHANNEL_CALLBACK
 	Stream_Read_UINT64(s, pdu.windowId); /* windowId (8 bytes) */
 	Stream_Read_UINT32(s, pdu.mappedWidth); /* mappedWidth (4 bytes) */
 	Stream_Read_UINT32(s, pdu.mappedHeight); /* mappedHeight (4 bytes) */
-	Stream_Read_UINT32(s, pdu.targetWidth);
-	Stream_Read_UINT32(s, pdu.targetHeight);
+	Stream_Read_UINT32(s, pdu.targetWidth); /* targetWidth (4 bytes) */
+	Stream_Read_UINT32(s, pdu.targetHeight); /* targetHeight (4 bytes) */
 	WLog_Print(gfx->log, WLOG_DEBUG,
-	           "RecvMapSurfaceToWindowPdu: surfaceId: %"PRIu16" windowId: 0x%016"PRIX64" mappedWidth: %"PRIu32" mappedHeight: %"PRIu32"",
-	           pdu.surfaceId, pdu.windowId, pdu.mappedWidth, pdu.mappedHeight);
+	           "RecvMapSurfaceToScaledWindowPdu: surfaceId: %"PRIu16" windowId: 0x%016"PRIX64" mappedWidth: %"PRIu32" mappedHeight: %"PRIu32" targetWidth: %"PRIu32" targetHeight: %"PRIu32"",
+	           pdu.surfaceId, pdu.windowId, pdu.mappedWidth, pdu.mappedHeight, pdu.targetWidth, pdu.targetHeight);
 
 	if (context && context->MapSurfaceToScaledWindow)
 	{
@@ -1278,7 +1278,6 @@ static UINT rdpgfx_recv_map_surface_to_scaled_window_pdu(RDPGFX_CHANNEL_CALLBACK
 
 	return error;
 }
-
 
 /**
  * Function description

--- a/channels/rdpgfx/server/rdpgfx_main.c
+++ b/channels/rdpgfx/server/rdpgfx_main.c
@@ -1065,7 +1065,7 @@ static UINT rdpgfx_send_map_surface_to_scaled_window_pdu(RdpgfxServerContext* co
         RDPGFX_MAP_SURFACE_TO_SCALED_WINDOW_PDU* pdu)
 {
 	wStream* s = rdpgfx_server_single_packet_new(
-	                 RDPGFX_CMDID_MAPSURFACETOWINDOW, 18);
+	                 RDPGFX_CMDID_MAPSURFACETOWINDOW, 26);
 
 	if (!s)
 	{
@@ -1077,8 +1077,8 @@ static UINT rdpgfx_send_map_surface_to_scaled_window_pdu(RdpgfxServerContext* co
 	Stream_Write_UINT64(s, pdu->windowId); /* windowId (8 bytes) */
 	Stream_Write_UINT32(s, pdu->mappedWidth); /* mappedWidth (4 bytes) */
 	Stream_Write_UINT32(s, pdu->mappedHeight); /* mappedHeight (4 bytes) */
-	Stream_Write_UINT32(s, pdu->targetWidth);
-	Stream_Write_UINT32(s, pdu->targetHeight);
+	Stream_Write_UINT32(s, pdu->targetWidth); /* targetWidth (4 bytes) */
+	Stream_Write_UINT32(s, pdu->targetHeight); /* targetHeight  (4 bytes) */
 	return rdpgfx_server_single_packet_send(context, s);
 }
 
@@ -1101,8 +1101,7 @@ static UINT rdpgfx_recv_frame_acknowledge_pdu(RdpgfxServerContext* context,
 
 	Stream_Read_UINT32(s, pdu.queueDepth); /* queueDepth (4 bytes) */
 	Stream_Read_UINT32(s, pdu.frameId); /* frameId (4 bytes) */
-	/* totalFramesDecoded (4 bytes) */
-	Stream_Read_UINT32(s, pdu.totalFramesDecoded);
+	Stream_Read_UINT32(s, pdu.totalFramesDecoded); /* totalFramesDecoded (4 bytes) */
 
 	if (context)
 	{
@@ -1284,7 +1283,7 @@ static UINT rdpgfx_send_map_surface_to_scaled_output_pdu(RdpgfxServerContext* co
         RDPGFX_MAP_SURFACE_TO_SCALED_OUTPUT_PDU* pdu)
 {
 	wStream* s = rdpgfx_server_single_packet_new(
-	                 RDPGFX_CMDID_MAPSURFACETOSCALEDOUTPUT, 12);
+	                 RDPGFX_CMDID_MAPSURFACETOSCALEDOUTPUT, 20);
 
 	if (!s)
 	{
@@ -1296,8 +1295,8 @@ static UINT rdpgfx_send_map_surface_to_scaled_output_pdu(RdpgfxServerContext* co
 	Stream_Write_UINT16(s, 0); /* reserved (2 bytes). Must be 0 */
 	Stream_Write_UINT32(s, pdu->outputOriginX); /* outputOriginX (4 bytes) */
 	Stream_Write_UINT32(s, pdu->outputOriginY); /* outputOriginY (4 bytes) */
-	Stream_Write_UINT32(s, pdu->targetX);
-	Stream_Write_UINT32(s, pdu->targetY);
+	Stream_Write_UINT32(s, pdu->targetWidth); /* targetWidth (4 bytes) */
+	Stream_Write_UINT32(s, pdu->targetHeight); /* targetHeight (4 bytes) */
 	return rdpgfx_server_single_packet_send(context, s);
 }
 

--- a/include/freerdp/channels/rdpgfx.h
+++ b/include/freerdp/channels/rdpgfx.h
@@ -321,8 +321,8 @@ struct _RDPGFX_MAP_SURFACE_TO_SCALED_OUTPUT_PDU
 	UINT16 reserved;
 	UINT32 outputOriginX;
 	UINT32 outputOriginY;
-	UINT32 targetX;
-	UINT32 targetY;
+	UINT32 targetWidth;
+	UINT32 targetHeight;
 };
 typedef struct _RDPGFX_MAP_SURFACE_TO_SCALED_OUTPUT_PDU
 	RDPGFX_MAP_SURFACE_TO_SCALED_OUTPUT_PDU;


### PR DESCRIPTION
This PR fixes the new GFX 10.6 client and server PDUs parsing and naming according to the spec.
This change is taken out of our proxy PR as @akallabeth asked to do. The proxy's functionality depends on this one.