### PR TITLE
rdpgfx/client: Add callbacks for manual caps sending and frame acking

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -265,7 +265,7 @@ static UINT rdpgfx_recv_caps_confirm_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_frame_acknowledge_pdu(RdpgfxClientContext* context,
-        RDPGFX_FRAME_ACKNOWLEDGE_PDU* pdu)
+        const RDPGFX_FRAME_ACKNOWLEDGE_PDU* pdu)
 {
 	UINT error;
 	wStream* s;

--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -52,20 +52,75 @@
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT rdpgfx_send_caps_advertise_pdu(RDPGFX_CHANNEL_CALLBACK* callback)
+static UINT rdpgfx_send_caps_advertise_pdu(RdpgfxClientContext* context,
+        const RDPGFX_CAPS_ADVERTISE_PDU* pdu)
 {
-	UINT error;
-	UINT32 x;
-	wStream* s;
+	UINT error = CHANNEL_RC_OK;
 	UINT16 index;
-	RDPGFX_PLUGIN* gfx;
 	RDPGFX_HEADER header;
+	RDPGFX_CAPSET* capsSet;
+	RDPGFX_PLUGIN* gfx;
+	RDPGFX_CHANNEL_CALLBACK* callback;
+	wStream* s;
+	gfx = (RDPGFX_PLUGIN*) context->handle;
+	callback = gfx->listener_callback->channel_callback;
+	header.flags = 0;
+	header.cmdId = RDPGFX_CMDID_CAPSADVERTISE;
+	header.pduLength = RDPGFX_HEADER_SIZE + 2;
+
+	for (index = 0; index < pdu->capsSetCount; index++)
+	{
+		capsSet = &(pdu->capsSets[index]);
+		header.pduLength += RDPGFX_CAPSET_BASE_SIZE + capsSet->length;
+	}
+
+	WLog_Print(gfx->log, WLOG_DEBUG, "SendCapsAdvertisePdu %"PRIu16"", pdu->capsSetCount);
+	s = Stream_New(NULL, header.pduLength);
+
+	if (!s)
+	{
+		WLog_ERR(TAG, "Stream_New failed!");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	if ((error = rdpgfx_write_header(s, &header)))
+		goto fail;
+
+	/* RDPGFX_CAPS_ADVERTISE_PDU */
+	Stream_Write_UINT16(s, pdu->capsSetCount); /* capsSetCount (2 bytes) */
+
+	for (index = 0; index < pdu->capsSetCount; index++)
+	{
+		capsSet = &(pdu->capsSets[index]);
+		Stream_Write_UINT32(s, capsSet->version); /* version (4 bytes) */
+		Stream_Write_UINT32(s, capsSet->length); /* capsDataLength (4 bytes) */
+		Stream_Write_UINT32(s, capsSet->flags); /* capsData (4 bytes) */
+		Stream_Zero(s, capsSet->length - 4);
+	}
+
+	Stream_SealLength(s);
+	error = callback->channel->Write(callback->channel, (UINT32) Stream_Length(s),
+	                                 Stream_Buffer(s), NULL);
+fail:
+	Stream_Free(s, TRUE);
+	return error;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT rdpgfx_send_supported_caps(RDPGFX_CHANNEL_CALLBACK* callback)
+{
+	UINT error = CHANNEL_RC_OK;
+	RDPGFX_PLUGIN* gfx;
+	RdpgfxClientContext* context;
 	RDPGFX_CAPSET* capsSet;
 	RDPGFX_CAPSET capsSets[RDPGFX_NUMBER_CAPSETS] = { 0 };
 	RDPGFX_CAPS_ADVERTISE_PDU pdu;
 	gfx = (RDPGFX_PLUGIN*) callback->plugin;
-	header.flags = 0;
-	header.cmdId = RDPGFX_CMDID_CAPSADVERTISE;
+	context = (RdpgfxClientContext*) gfx->iface.pInterface;
 	pdu.capsSetCount = 0;
 	pdu.capsSets = (RDPGFX_CAPSET*) capsSets;
 	capsSet = &capsSets[pdu.capsSetCount++];
@@ -160,40 +215,11 @@ static UINT rdpgfx_send_caps_advertise_pdu(RDPGFX_CHANNEL_CALLBACK* callback)
 #endif
 	}
 
-	header.pduLength = RDPGFX_HEADER_SIZE + 2;
-
-	for (x = 0; x < pdu.capsSetCount; x++)
-		header.pduLength += RDPGFX_CAPSET_BASE_SIZE + capsSets[x].length;
-
-	WLog_Print(gfx->log, WLOG_DEBUG, "SendCapsAdvertisePdu %"PRIu16"", pdu.capsSetCount);
-	s = Stream_New(NULL, header.pduLength);
-
-	if (!s)
+	if (context)
 	{
-		WLog_ERR(TAG, "Stream_New failed!");
-		return CHANNEL_RC_NO_MEMORY;
+		IFCALLRET(context->CapsAdvertise, error, context, &pdu);
 	}
 
-	if ((error = rdpgfx_write_header(s, &header)))
-		goto fail;
-
-	/* RDPGFX_CAPS_ADVERTISE_PDU */
-	Stream_Write_UINT16(s, pdu.capsSetCount); /* capsSetCount (2 bytes) */
-
-	for (index = 0; index < pdu.capsSetCount; index++)
-	{
-		capsSet = &(pdu.capsSets[index]);
-		Stream_Write_UINT32(s, capsSet->version); /* version (4 bytes) */
-		Stream_Write_UINT32(s, capsSet->length); /* capsDataLength (4 bytes) */
-		Stream_Write_UINT32(s, capsSet->flags); /* capsData (4 bytes) */
-		Stream_Zero(s, capsSet->length - 4);
-	}
-
-	Stream_SealLength(s);
-	error = callback->channel->Write(callback->channel, (UINT32) Stream_Length(s),
-	                                 Stream_Buffer(s), NULL);
-fail:
-	Stream_Free(s, TRUE);
 	return error;
 }
 
@@ -209,6 +235,7 @@ static UINT rdpgfx_recv_caps_confirm_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 	UINT32 capsDataLength;
 	RDPGFX_CAPS_CONFIRM_PDU pdu;
 	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*) callback->plugin;
+	RdpgfxClientContext* context = (RdpgfxClientContext*) gfx->iface.pInterface;
 	pdu.capsSet = &capsSet;
 
 	if (Stream_GetRemainingLength(s) < 12)
@@ -223,6 +250,12 @@ static UINT rdpgfx_recv_caps_confirm_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 	gfx->ConnectionCaps = capsSet;
 	WLog_Print(gfx->log, WLOG_DEBUG, "RecvCapsConfirmPdu: version: 0x%08"PRIX32" flags: 0x%08"PRIX32"",
 	           capsSet.version, capsSet.flags);
+
+	if (context)
+	{
+		IFCALL(context->CapsConfirm, context, &pdu);
+	}
+
 	return CHANNEL_RC_OK;
 }
 
@@ -231,13 +264,14 @@ static UINT rdpgfx_recv_caps_confirm_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT rdpgfx_send_frame_acknowledge_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
+static UINT rdpgfx_send_frame_acknowledge_pdu(RdpgfxClientContext* context,
         RDPGFX_FRAME_ACKNOWLEDGE_PDU* pdu)
 {
 	UINT error;
 	wStream* s;
 	RDPGFX_HEADER header;
-	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*) callback->plugin;
+	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*) context->handle;
+	RDPGFX_CHANNEL_CALLBACK* callback = gfx->listener_callback->channel_callback;
 	header.flags = 0;
 	header.cmdId = RDPGFX_CMDID_FRAMEACKNOWLEDGE;
 	header.pduLength = RDPGFX_HEADER_SIZE + 12;
@@ -599,7 +633,6 @@ static UINT rdpgfx_recv_end_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*) callback->plugin;
 	RdpgfxClientContext* context = (RdpgfxClientContext*) gfx->iface.pInterface;
 	UINT error = CHANNEL_RC_OK;
-	BOOL sendAck = TRUE;
 
 	if (Stream_GetRemainingLength(s) < RDPGFX_END_FRAME_PDU_SIZE)
 	{
@@ -625,16 +658,15 @@ static UINT rdpgfx_recv_end_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 	gfx->TotalDecodedFrames++;
 	ack.frameId = pdu.frameId;
 	ack.totalFramesDecoded = gfx->TotalDecodedFrames;
-	IFCALLRET(context->PreFrameAck, sendAck, context, &ack);
 
-	if (sendAck)
+	if (gfx->sendFrameAcks)
 	{
 		if (gfx->suspendFrameAcks)
 		{
 			ack.queueDepth = SUSPEND_FRAME_ACKNOWLEDGEMENT;
 
 			if (gfx->TotalDecodedFrames == 1)
-				if ((error = rdpgfx_send_frame_acknowledge_pdu(callback, &ack)))
+				if ((error = rdpgfx_send_frame_acknowledge_pdu(context, &ack)))
 					WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_send_frame_acknowledge_pdu failed with error %"PRIu32"",
 					           error);
 		}
@@ -642,7 +674,7 @@ static UINT rdpgfx_recv_end_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 		{
 			ack.queueDepth = QUEUE_DEPTH_UNAVAILABLE;
 
-			if ((error = rdpgfx_send_frame_acknowledge_pdu(callback, &ack)))
+			if ((error = rdpgfx_send_frame_acknowledge_pdu(context, &ack)))
 				WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_send_frame_acknowledge_pdu failed with error %"PRIu32"",
 				           error);
 		}
@@ -667,7 +699,8 @@ static UINT rdpgfx_recv_end_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 				qoe.timeDiffEDR = 1;
 
 				if ((error = rdpgfx_send_qoe_frame_acknowledge_pdu(callback, &qoe)))
-					WLog_Print(gfx->log, WLOG_ERROR, "rdpgfx_send_frame_acknowledge_pdu failed with error %"PRIu32"",
+					WLog_Print(gfx->log, WLOG_ERROR,
+					           "rdpgfx_send_qoe_frame_acknowledge_pdu failed with error %"PRIu32"",
 					           error);
 			}
 
@@ -1518,8 +1551,24 @@ static UINT rdpgfx_on_data_received(IWTSVirtualChannelCallback*
 static UINT rdpgfx_on_open(IWTSVirtualChannelCallback* pChannelCallback)
 {
 	RDPGFX_CHANNEL_CALLBACK* callback = (RDPGFX_CHANNEL_CALLBACK*) pChannelCallback;
-	WLog_DBG(TAG, "OnOpen");
-	return rdpgfx_send_caps_advertise_pdu(callback);
+	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*) callback->plugin;
+	RdpgfxClientContext* context = (RdpgfxClientContext*) gfx->iface.pInterface;
+	UINT error = CHANNEL_RC_OK;
+	BOOL do_caps_advertise = TRUE;
+	gfx->sendFrameAcks = TRUE;
+
+	if (context)
+	{
+		IFCALLRET(context->OnOpen, error, context, &do_caps_advertise, &gfx->sendFrameAcks);
+
+		if (error)
+			WLog_Print(gfx->log, WLOG_ERROR, "context->OnOpen failed with error %"PRIu32"", error);
+	}
+
+	if (do_caps_advertise)
+		error = rdpgfx_send_supported_caps(callback);
+
+	return error;
 }
 
 /**
@@ -1578,6 +1627,11 @@ static UINT rdpgfx_on_close(IWTSVirtualChannelCallback* pChannelCallback)
 
 			gfx->CacheSlots[index] = NULL;
 		}
+	}
+
+	if (context)
+	{
+		IFCALL(context->OnClose, context);
 	}
 
 	return CHANNEL_RC_OK;
@@ -1911,6 +1965,8 @@ UINT DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 		context->GetSurfaceData = rdpgfx_get_surface_data;
 		context->SetCacheSlotData = rdpgfx_set_cache_slot_data;
 		context->GetCacheSlotData = rdpgfx_get_cache_slot_data;
+		context->CapsAdvertise = rdpgfx_send_caps_advertise_pdu;
+		context->FrameAcknowledge = rdpgfx_send_frame_acknowledge_pdu;
 		gfx->iface.pInterface = (void*) context;
 		gfx->zgfx = zgfx_context_new(FALSE);
 

--- a/channels/rdpgfx/client/rdpgfx_main.h
+++ b/channels/rdpgfx/client/rdpgfx_main.h
@@ -73,7 +73,7 @@ struct _RDPGFX_PLUGIN
 	UINT32 TotalDecodedFrames;
 	UINT32 StartDecodingTime;
 	BOOL suspendFrameAcks;
-    BOOL sendFrameAcks;
+	BOOL sendFrameAcks;
 
 	wHashTable* SurfaceTable;
 

--- a/channels/rdpgfx/client/rdpgfx_main.h
+++ b/channels/rdpgfx/client/rdpgfx_main.h
@@ -73,6 +73,7 @@ struct _RDPGFX_PLUGIN
 	UINT32 TotalDecodedFrames;
 	UINT32 StartDecodingTime;
 	BOOL suspendFrameAcks;
+    BOOL sendFrameAcks;
 
 	wHashTable* SurfaceTable;
 

--- a/channels/rdpgfx/rdpgfx_common.c
+++ b/channels/rdpgfx/rdpgfx_common.c
@@ -130,7 +130,7 @@ UINT rdpgfx_read_header(wStream* s, RDPGFX_HEADER* header)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT rdpgfx_write_header(wStream* s, RDPGFX_HEADER* header)
+UINT rdpgfx_write_header(wStream* s, const RDPGFX_HEADER* header)
 {
 	Stream_Write_UINT16(s, header->cmdId); /* cmdId (2 bytes) */
 	Stream_Write_UINT16(s, header->flags); /* flags (2 bytes) */
@@ -161,7 +161,7 @@ UINT rdpgfx_read_point16(wStream* s, RDPGFX_POINT16* pt16)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT rdpgfx_write_point16(wStream* s, RDPGFX_POINT16* point16)
+UINT rdpgfx_write_point16(wStream* s, const RDPGFX_POINT16* point16)
 {
 	Stream_Write_UINT16(s, point16->x); /* x (2 bytes) */
 	Stream_Write_UINT16(s, point16->y); /* y (2 bytes) */
@@ -193,7 +193,7 @@ UINT rdpgfx_read_rect16(wStream* s, RECTANGLE_16* rect16)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT rdpgfx_write_rect16(wStream* s, RECTANGLE_16* rect16)
+UINT rdpgfx_write_rect16(wStream* s, const RECTANGLE_16* rect16)
 {
 	Stream_Write_UINT16(s, rect16->left); /* left (2 bytes) */
 	Stream_Write_UINT16(s, rect16->top); /* top (2 bytes) */
@@ -227,7 +227,7 @@ UINT rdpgfx_read_color32(wStream* s, RDPGFX_COLOR32* color32)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT rdpgfx_write_color32(wStream* s, RDPGFX_COLOR32* color32)
+UINT rdpgfx_write_color32(wStream* s, const RDPGFX_COLOR32* color32)
 {
 	Stream_Write_UINT8(s, color32->B); /* B (1 byte) */
 	Stream_Write_UINT8(s, color32->G); /* G (1 byte) */

--- a/channels/rdpgfx/rdpgfx_common.h
+++ b/channels/rdpgfx/rdpgfx_common.h
@@ -32,16 +32,16 @@ FREERDP_LOCAL const char* rdpgfx_get_cmd_id_string(UINT16 cmdId);
 FREERDP_LOCAL const char* rdpgfx_get_codec_id_string(UINT16 codecId);
 
 FREERDP_LOCAL UINT rdpgfx_read_header(wStream* s, RDPGFX_HEADER* header);
-FREERDP_LOCAL UINT rdpgfx_write_header(wStream* s, RDPGFX_HEADER* header);
+FREERDP_LOCAL UINT rdpgfx_write_header(wStream* s, const RDPGFX_HEADER* header);
 
 FREERDP_LOCAL UINT rdpgfx_read_point16(wStream* s, RDPGFX_POINT16* pt16);
-FREERDP_LOCAL UINT rdpgfx_write_point16(wStream* s, RDPGFX_POINT16* point16);
+FREERDP_LOCAL UINT rdpgfx_write_point16(wStream* s, const RDPGFX_POINT16* point16);
 
 FREERDP_LOCAL UINT rdpgfx_read_rect16(wStream* s, RECTANGLE_16* rect16);
-FREERDP_LOCAL UINT rdpgfx_write_rect16(wStream* s, RECTANGLE_16* rect16);
+FREERDP_LOCAL UINT rdpgfx_write_rect16(wStream* s, const RECTANGLE_16* rect16);
 
 FREERDP_LOCAL UINT rdpgfx_read_color32(wStream* s, RDPGFX_COLOR32* color32);
-FREERDP_LOCAL UINT rdpgfx_write_color32(wStream* s, RDPGFX_COLOR32* color32);
+FREERDP_LOCAL UINT rdpgfx_write_color32(wStream* s, const RDPGFX_COLOR32* color32);
 
 #endif /* FREERDP_CHANNEL_RDPGFX_COMMON_H */
 

--- a/channels/rdpgfx/server/rdpgfx_main.c
+++ b/channels/rdpgfx/server/rdpgfx_main.c
@@ -54,6 +54,7 @@ static INLINE UINT32 rdpgfx_pdu_length(UINT32 dataLen)
 	return RDPGFX_HEADER_SIZE + dataLen;
 }
 
+
 static INLINE UINT rdpgfx_server_packet_init_header(wStream* s,
         UINT16 cmdId, UINT32 pduLength)
 {
@@ -200,7 +201,7 @@ static INLINE UINT rdpgfx_server_single_packet_send(
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_caps_confirm_pdu(RdpgfxServerContext* context,
-        RDPGFX_CAPS_CONFIRM_PDU* capsConfirm)
+        const RDPGFX_CAPS_CONFIRM_PDU* capsConfirm)
 {
 	RDPGFX_CAPSET* capsSet = capsConfirm->capsSet;
 	wStream* s = rdpgfx_server_single_packet_new(
@@ -232,7 +233,7 @@ static UINT rdpgfx_send_caps_confirm_pdu(RdpgfxServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_reset_graphics_pdu(RdpgfxServerContext* context,
-        RDPGFX_RESET_GRAPHICS_PDU* pdu)
+        const RDPGFX_RESET_GRAPHICS_PDU* pdu)
 {
 	UINT32 index;
 	MONITOR_DEF* monitor;
@@ -281,7 +282,7 @@ static UINT rdpgfx_send_reset_graphics_pdu(RdpgfxServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_evict_cache_entry_pdu(RdpgfxServerContext* context,
-        RDPGFX_EVICT_CACHE_ENTRY_PDU* pdu)
+        const RDPGFX_EVICT_CACHE_ENTRY_PDU* pdu)
 {
 	wStream* s = rdpgfx_server_single_packet_new(RDPGFX_CMDID_EVICTCACHEENTRY, 2);
 
@@ -301,7 +302,7 @@ static UINT rdpgfx_send_evict_cache_entry_pdu(RdpgfxServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_cache_import_reply_pdu(RdpgfxServerContext* context,
-        RDPGFX_CACHE_IMPORT_REPLY_PDU* pdu)
+        const RDPGFX_CACHE_IMPORT_REPLY_PDU* pdu)
 {
 	UINT16 index;
 	wStream* s = rdpgfx_server_single_packet_new(
@@ -331,7 +332,7 @@ static UINT rdpgfx_send_cache_import_reply_pdu(RdpgfxServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_create_surface_pdu(RdpgfxServerContext* context,
-        RDPGFX_CREATE_SURFACE_PDU* pdu)
+        const RDPGFX_CREATE_SURFACE_PDU* pdu)
 {
 	wStream* s = rdpgfx_server_single_packet_new(RDPGFX_CMDID_CREATESURFACE, 7);
 
@@ -354,7 +355,7 @@ static UINT rdpgfx_send_create_surface_pdu(RdpgfxServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_delete_surface_pdu(RdpgfxServerContext* context,
-        RDPGFX_DELETE_SURFACE_PDU* pdu)
+        const RDPGFX_DELETE_SURFACE_PDU* pdu)
 {
 	wStream* s = rdpgfx_server_single_packet_new(RDPGFX_CMDID_DELETESURFACE, 2);
 
@@ -369,14 +370,14 @@ static UINT rdpgfx_send_delete_surface_pdu(RdpgfxServerContext* context,
 }
 
 static INLINE void rdpgfx_write_start_frame_pdu(wStream* s,
-        RDPGFX_START_FRAME_PDU* pdu)
+        const RDPGFX_START_FRAME_PDU* pdu)
 {
 	Stream_Write_UINT32(s, pdu->timestamp); /* timestamp (4 bytes) */
 	Stream_Write_UINT32(s, pdu->frameId); /* frameId (4 bytes) */
 }
 
 static INLINE void rdpgfx_write_end_frame_pdu(wStream* s,
-        RDPGFX_END_FRAME_PDU* pdu)
+        const RDPGFX_END_FRAME_PDU* pdu)
 {
 	Stream_Write_UINT32(s, pdu->frameId); /* frameId (4 bytes) */
 }
@@ -387,7 +388,7 @@ static INLINE void rdpgfx_write_end_frame_pdu(wStream* s,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_start_frame_pdu(RdpgfxServerContext* context,
-                                        RDPGFX_START_FRAME_PDU* pdu)
+                                        const RDPGFX_START_FRAME_PDU* pdu)
 {
 	wStream* s = rdpgfx_server_single_packet_new(
 	                 RDPGFX_CMDID_STARTFRAME,
@@ -409,7 +410,7 @@ static UINT rdpgfx_send_start_frame_pdu(RdpgfxServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_end_frame_pdu(RdpgfxServerContext* context,
-                                      RDPGFX_END_FRAME_PDU* pdu)
+                                      const RDPGFX_END_FRAME_PDU* pdu)
 {
 	wStream* s = rdpgfx_server_single_packet_new(
 	                 RDPGFX_CMDID_ENDFRAME,
@@ -432,7 +433,7 @@ static UINT rdpgfx_send_end_frame_pdu(RdpgfxServerContext* context,
  * @return estimated size
  */
 static INLINE UINT32 rdpgfx_estimate_h264_avc420(
-    RDPGFX_AVC420_BITMAP_STREAM* havc420)
+    const RDPGFX_AVC420_BITMAP_STREAM* havc420)
 {
 	/* H264 metadata + H264 stream. See rdpgfx_write_h264_avc420 */
 	return sizeof(UINT32) /* numRegionRects */
@@ -447,7 +448,7 @@ static INLINE UINT32 rdpgfx_estimate_h264_avc420(
  *
  * @return estimated size
  */
-static INLINE UINT32 rdpgfx_estimate_surface_command(RDPGFX_SURFACE_COMMAND*
+static INLINE UINT32 rdpgfx_estimate_surface_command(const RDPGFX_SURFACE_COMMAND*
         cmd)
 {
 	RDPGFX_AVC420_BITMAP_STREAM* havc420 = NULL;
@@ -494,7 +495,7 @@ static INLINE UINT32 rdpgfx_estimate_surface_command(RDPGFX_SURFACE_COMMAND*
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static INLINE UINT16 rdpgfx_surface_command_cmdid(RDPGFX_SURFACE_COMMAND* cmd)
+static INLINE UINT16 rdpgfx_surface_command_cmdid(const RDPGFX_SURFACE_COMMAND* cmd)
 {
 	if (cmd->codecId == RDPGFX_CODECID_CAPROGRESSIVE ||
 	    cmd->codecId == RDPGFX_CODECID_CAPROGRESSIVE_V2)
@@ -510,7 +511,7 @@ static INLINE UINT16 rdpgfx_surface_command_cmdid(RDPGFX_SURFACE_COMMAND* cmd)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT rdpgfx_write_h264_metablock(wStream* s, RDPGFX_H264_METABLOCK* meta)
+static UINT rdpgfx_write_h264_metablock(wStream* s, const RDPGFX_H264_METABLOCK* meta)
 {
 	UINT32 index;
 	RECTANGLE_16* regionRect;
@@ -579,7 +580,7 @@ static INLINE UINT rdpgfx_write_h264_avc420(wStream* s,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_write_surface_command(wStream* s,
-        RDPGFX_SURFACE_COMMAND* cmd)
+        const RDPGFX_SURFACE_COMMAND* cmd)
 {
 	UINT error = CHANNEL_RC_OK;
 	RDPGFX_AVC420_BITMAP_STREAM* havc420 = NULL;
@@ -688,7 +689,7 @@ static UINT rdpgfx_write_surface_command(wStream* s,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_surface_command(RdpgfxServerContext* context,
-                                        RDPGFX_SURFACE_COMMAND* cmd)
+                                        const RDPGFX_SURFACE_COMMAND* cmd)
 {
 	UINT error = CHANNEL_RC_OK;
 	wStream* s;
@@ -725,8 +726,8 @@ error:
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_surface_frame_command(RdpgfxServerContext* context,
-        RDPGFX_SURFACE_COMMAND* cmd, RDPGFX_START_FRAME_PDU* startFrame,
-        RDPGFX_END_FRAME_PDU* endFrame)
+        const RDPGFX_SURFACE_COMMAND* cmd, const RDPGFX_START_FRAME_PDU* startFrame,
+        const RDPGFX_END_FRAME_PDU* endFrame)
 
 {
 	UINT error = CHANNEL_RC_OK;
@@ -821,7 +822,7 @@ error:
  */
 static UINT rdpgfx_send_delete_encoding_context_pdu(RdpgfxServerContext*
         context,
-        RDPGFX_DELETE_ENCODING_CONTEXT_PDU* pdu)
+        const RDPGFX_DELETE_ENCODING_CONTEXT_PDU* pdu)
 {
 	wStream* s = rdpgfx_server_single_packet_new(
 	                 RDPGFX_CMDID_DELETEENCODINGCONTEXT, 6);
@@ -843,7 +844,7 @@ static UINT rdpgfx_send_delete_encoding_context_pdu(RdpgfxServerContext*
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_solid_fill_pdu(RdpgfxServerContext* context,
-                                       RDPGFX_SOLID_FILL_PDU* pdu)
+                                       const RDPGFX_SOLID_FILL_PDU* pdu)
 {
 	UINT error = CHANNEL_RC_OK;
 	UINT16 index;
@@ -892,7 +893,7 @@ error:
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_surface_to_surface_pdu(RdpgfxServerContext* context,
-        RDPGFX_SURFACE_TO_SURFACE_PDU* pdu)
+        const RDPGFX_SURFACE_TO_SURFACE_PDU* pdu)
 {
 	UINT error = CHANNEL_RC_OK;
 	UINT16 index;
@@ -942,7 +943,7 @@ error:
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_surface_to_cache_pdu(RdpgfxServerContext* context,
-        RDPGFX_SURFACE_TO_CACHE_PDU* pdu)
+        const RDPGFX_SURFACE_TO_CACHE_PDU* pdu)
 {
 	UINT error = CHANNEL_RC_OK;
 	wStream* s = rdpgfx_server_single_packet_new(
@@ -977,7 +978,7 @@ error:
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_cache_to_surface_pdu(RdpgfxServerContext* context,
-        RDPGFX_CACHE_TO_SURFACE_PDU* pdu)
+        const RDPGFX_CACHE_TO_SURFACE_PDU* pdu)
 {
 	UINT error = CHANNEL_RC_OK;
 	UINT16 index;
@@ -1019,7 +1020,7 @@ error:
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_map_surface_to_output_pdu(RdpgfxServerContext* context,
-        RDPGFX_MAP_SURFACE_TO_OUTPUT_PDU* pdu)
+        const RDPGFX_MAP_SURFACE_TO_OUTPUT_PDU* pdu)
 {
 	wStream* s = rdpgfx_server_single_packet_new(
 	                 RDPGFX_CMDID_MAPSURFACETOOUTPUT, 12);
@@ -1043,7 +1044,7 @@ static UINT rdpgfx_send_map_surface_to_output_pdu(RdpgfxServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT rdpgfx_send_map_surface_to_window_pdu(RdpgfxServerContext* context,
-        RDPGFX_MAP_SURFACE_TO_WINDOW_PDU* pdu)
+        const RDPGFX_MAP_SURFACE_TO_WINDOW_PDU* pdu)
 {
 	wStream* s = rdpgfx_server_single_packet_new(
 	                 RDPGFX_CMDID_MAPSURFACETOWINDOW, 18);
@@ -1062,7 +1063,7 @@ static UINT rdpgfx_send_map_surface_to_window_pdu(RdpgfxServerContext* context,
 }
 
 static UINT rdpgfx_send_map_surface_to_scaled_window_pdu(RdpgfxServerContext* context,
-        RDPGFX_MAP_SURFACE_TO_SCALED_WINDOW_PDU* pdu)
+        const RDPGFX_MAP_SURFACE_TO_SCALED_WINDOW_PDU* pdu)
 {
 	wStream* s = rdpgfx_server_single_packet_new(
 	                 RDPGFX_CMDID_MAPSURFACETOWINDOW, 18);
@@ -1281,7 +1282,7 @@ static UINT rdpgfx_recv_qoe_frame_acknowledge_pdu(RdpgfxServerContext* context,
 }
 
 static UINT rdpgfx_send_map_surface_to_scaled_output_pdu(RdpgfxServerContext* context,
-        RDPGFX_MAP_SURFACE_TO_SCALED_OUTPUT_PDU* pdu)
+        const RDPGFX_MAP_SURFACE_TO_SCALED_OUTPUT_PDU* pdu)
 {
 	wStream* s = rdpgfx_server_single_packet_new(
 	                 RDPGFX_CMDID_MAPSURFACETOSCALEDOUTPUT, 12);

--- a/include/freerdp/client/rdpgfx.h
+++ b/include/freerdp/client/rdpgfx.h
@@ -83,8 +83,15 @@ typedef UINT(*pcRdpgfxUpdateSurfaces)(RdpgfxClientContext* context);
 typedef UINT(*pcRdpgfxUpdateSurfaceArea)(RdpgfxClientContext* context, UINT16 surfaceId,
         UINT32 nrRects, const RECTANGLE_16* rects);
 
-typedef BOOL(*pcRdpgfxPreFrameAck)(RdpgfxClientContext* context,
-                                   RDPGFX_FRAME_ACKNOWLEDGE_PDU* frameAcknowledge);
+typedef UINT(*pcRdpgfxOnOpen)(RdpgfxClientContext* context, BOOL* do_caps_advertise,
+                              BOOL* do_frame_acks);
+typedef UINT(*pcRdpgfxOnClose)(RdpgfxClientContext* context);
+typedef UINT(*pcRdpgfxCapsAdvertise)(RdpgfxClientContext* context,
+                                     const RDPGFX_CAPS_ADVERTISE_PDU* capsAdvertise);
+typedef UINT(*pcRdpgfxCapsConfirm)(RdpgfxClientContext* context,
+                                   const RDPGFX_CAPS_CONFIRM_PDU* capsConfirm);
+typedef UINT(*pcRdpgfxFrameAcknowledge)(RdpgfxClientContext* context,
+                                        const RDPGFX_FRAME_ACKNOWLEDGE_PDU* frameAcknowledge);
 
 struct _rdpgfx_client_context
 {
@@ -117,11 +124,16 @@ struct _rdpgfx_client_context
 	pcRdpgfxSetCacheSlotData SetCacheSlotData;
 	pcRdpgfxGetCacheSlotData GetCacheSlotData;
 
+	/* Proxy callbacks */
+	pcRdpgfxOnOpen OnOpen;
+	pcRdpgfxOnClose OnClose;
+	pcRdpgfxCapsAdvertise CapsAdvertise;
+	pcRdpgfxCapsConfirm CapsConfirm;
+	pcRdpgfxFrameAcknowledge FrameAcknowledge;
+
 	/* No locking required */
 	pcRdpgfxUpdateSurfaces UpdateSurfaces;
 	pcRdpgfxUpdateSurfaceArea UpdateSurfaceArea;
-
-	pcRdpgfxPreFrameAck PreFrameAck;
 
 	CRITICAL_SECTION mux;
 	PROFILER_DEFINE(SurfaceProfiler)

--- a/include/freerdp/server/rdpgfx.h
+++ b/include/freerdp/server/rdpgfx.h
@@ -29,47 +29,51 @@ typedef BOOL (*psRdpgfxServerOpen)(RdpgfxServerContext* context);
 typedef BOOL (*psRdpgfxServerClose)(RdpgfxServerContext* context);
 
 typedef UINT(*psRdpgfxResetGraphics)(RdpgfxServerContext* context,
-                                     RDPGFX_RESET_GRAPHICS_PDU* resetGraphics);
-typedef UINT(*psRdpgfxStartFrame)(RdpgfxServerContext* context, RDPGFX_START_FRAME_PDU* startFrame);
-typedef UINT(*psRdpgfxEndFrame)(RdpgfxServerContext* context, RDPGFX_END_FRAME_PDU* endFrame);
-typedef UINT(*psRdpgfxSurfaceCommand)(RdpgfxServerContext* context, RDPGFX_SURFACE_COMMAND* cmd);
+                                     const RDPGFX_RESET_GRAPHICS_PDU* resetGraphics);
+typedef UINT(*psRdpgfxStartFrame)(RdpgfxServerContext* context,
+                                  const RDPGFX_START_FRAME_PDU* startFrame);
+typedef UINT(*psRdpgfxEndFrame)(RdpgfxServerContext* context, const RDPGFX_END_FRAME_PDU* endFrame);
+typedef UINT(*psRdpgfxSurfaceCommand)(RdpgfxServerContext* context,
+                                      const  RDPGFX_SURFACE_COMMAND* cmd);
 typedef UINT(*psRdpgfxSurfaceFrameCommand)(RdpgfxServerContext* context,
-        RDPGFX_SURFACE_COMMAND* cmd, RDPGFX_START_FRAME_PDU* startFrame, RDPGFX_END_FRAME_PDU* endFrame);
+        const RDPGFX_SURFACE_COMMAND* cmd, const RDPGFX_START_FRAME_PDU* startFrame,
+        const RDPGFX_END_FRAME_PDU* endFrame);
 typedef UINT(*psRdpgfxDeleteEncodingContext)(RdpgfxServerContext* context,
-        RDPGFX_DELETE_ENCODING_CONTEXT_PDU* deleteEncodingContext);
+        const RDPGFX_DELETE_ENCODING_CONTEXT_PDU* deleteEncodingContext);
 typedef UINT(*psRdpgfxCreateSurface)(RdpgfxServerContext* context,
-                                     RDPGFX_CREATE_SURFACE_PDU* createSurface);
+                                     const RDPGFX_CREATE_SURFACE_PDU* createSurface);
 typedef UINT(*psRdpgfxDeleteSurface)(RdpgfxServerContext* context,
-                                     RDPGFX_DELETE_SURFACE_PDU* deleteSurface);
-typedef UINT(*psRdpgfxSolidFill)(RdpgfxServerContext* context, RDPGFX_SOLID_FILL_PDU* solidFill);
+                                     const RDPGFX_DELETE_SURFACE_PDU* deleteSurface);
+typedef UINT(*psRdpgfxSolidFill)(RdpgfxServerContext* context,
+                                 const RDPGFX_SOLID_FILL_PDU* solidFill);
 typedef UINT(*psRdpgfxSurfaceToSurface)(RdpgfxServerContext* context,
-                                        RDPGFX_SURFACE_TO_SURFACE_PDU* surfaceToSurface);
+                                        const RDPGFX_SURFACE_TO_SURFACE_PDU* surfaceToSurface);
 typedef UINT(*psRdpgfxSurfaceToCache)(RdpgfxServerContext* context,
-                                      RDPGFX_SURFACE_TO_CACHE_PDU* surfaceToCache);
+                                      const RDPGFX_SURFACE_TO_CACHE_PDU* surfaceToCache);
 typedef UINT(*psRdpgfxCacheToSurface)(RdpgfxServerContext* context,
-                                      RDPGFX_CACHE_TO_SURFACE_PDU* cacheToSurface);
+                                      const RDPGFX_CACHE_TO_SURFACE_PDU* cacheToSurface);
 typedef UINT(*psRdpgfxCacheImportOffer)(RdpgfxServerContext* context,
-                                        RDPGFX_CACHE_IMPORT_OFFER_PDU* cacheImportOffer);
+                                        const RDPGFX_CACHE_IMPORT_OFFER_PDU* cacheImportOffer);
 typedef UINT(*psRdpgfxCacheImportReply)(RdpgfxServerContext* context,
-                                        RDPGFX_CACHE_IMPORT_REPLY_PDU* cacheImportReply);
+                                        const RDPGFX_CACHE_IMPORT_REPLY_PDU* cacheImportReply);
 typedef UINT(*psRdpgfxEvictCacheEntry)(RdpgfxServerContext* context,
-                                       RDPGFX_EVICT_CACHE_ENTRY_PDU* evictCacheEntry);
+                                       const RDPGFX_EVICT_CACHE_ENTRY_PDU* evictCacheEntry);
 typedef UINT(*psRdpgfxMapSurfaceToOutput)(RdpgfxServerContext* context,
-        RDPGFX_MAP_SURFACE_TO_OUTPUT_PDU* surfaceToOutput);
+        const RDPGFX_MAP_SURFACE_TO_OUTPUT_PDU* surfaceToOutput);
 typedef UINT(*psRdpgfxMapSurfaceToWindow)(RdpgfxServerContext* context,
-        RDPGFX_MAP_SURFACE_TO_WINDOW_PDU* surfaceToWindow);
+        const RDPGFX_MAP_SURFACE_TO_WINDOW_PDU* surfaceToWindow);
 typedef UINT(*psRdpgfxMapSurfaceToScaledOutput)(RdpgfxServerContext* context,
-        RDPGFX_MAP_SURFACE_TO_SCALED_OUTPUT_PDU* surfaceToOutput);
+        const RDPGFX_MAP_SURFACE_TO_SCALED_OUTPUT_PDU* surfaceToOutput);
 typedef UINT(*psRdpgfxMapSurfaceToScaledWindow)(RdpgfxServerContext* context,
-        RDPGFX_MAP_SURFACE_TO_SCALED_WINDOW_PDU* surfaceToWindow);
+        const RDPGFX_MAP_SURFACE_TO_SCALED_WINDOW_PDU* surfaceToWindow);
 typedef UINT(*psRdpgfxCapsAdvertise)(RdpgfxServerContext* context,
-                                     RDPGFX_CAPS_ADVERTISE_PDU* capsAdvertise);
+                                     const RDPGFX_CAPS_ADVERTISE_PDU* capsAdvertise);
 typedef UINT(*psRdpgfxCapsConfirm)(RdpgfxServerContext* context,
-                                   RDPGFX_CAPS_CONFIRM_PDU* capsConfirm);
+                                   const RDPGFX_CAPS_CONFIRM_PDU* capsConfirm);
 typedef UINT(*psRdpgfxFrameAcknowledge)(RdpgfxServerContext* context,
-                                        RDPGFX_FRAME_ACKNOWLEDGE_PDU* frameAcknowledge);
+                                        const RDPGFX_FRAME_ACKNOWLEDGE_PDU* frameAcknowledge);
 typedef UINT(*psRdpgfxQoeFrameAcknowledge)(RdpgfxServerContext* context,
-        RDPGFX_QOE_FRAME_ACKNOWLEDGE_PDU* qoeFrameAcknowledge);
+        const RDPGFX_QOE_FRAME_ACKNOWLEDGE_PDU* qoeFrameAcknowledge);
 
 struct _rdpgfx_server_context
 {

--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -605,7 +605,7 @@ static BOOL shadow_client_surface_frame_acknowledge(rdpShadowClient* client,
 }
 
 static UINT shadow_client_rdpgfx_frame_acknowledge(RdpgfxServerContext* context,
-        RDPGFX_FRAME_ACKNOWLEDGE_PDU* frameAcknowledge)
+        const RDPGFX_FRAME_ACKNOWLEDGE_PDU* frameAcknowledge)
 {
 	rdpShadowClient* client = (rdpShadowClient*)context->custom;
 	shadow_client_common_frame_acknowledge(client, frameAcknowledge->frameId);
@@ -619,7 +619,7 @@ static UINT shadow_client_rdpgfx_frame_acknowledge(RdpgfxServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT shadow_client_rdpgfx_caps_advertise(RdpgfxServerContext* context,
-        RDPGFX_CAPS_ADVERTISE_PDU* capsAdvertise)
+        const RDPGFX_CAPS_ADVERTISE_PDU* capsAdvertise)
 {
 	UINT16 index;
 	rdpSettings* settings = context->rdpcontext->settings;


### PR DESCRIPTION
This PR contains the additions to the library for the proxy, new callbacks retaining default GFX behavior that let you manually control capability sending and frame acking. This PR also removes the `PreFrameAck` callback that I've previously added, as discussed in the proxy's PR, #5372.