### PR TITLE
core: Move image conversion of icon data into the library

### DIFF
--- a/include/freerdp/codec/color.h
+++ b/include/freerdp/codec/color.h
@@ -820,6 +820,33 @@ FREERDP_API BOOL freerdp_image_copy_from_monochrome(BYTE* pDstData,
  * @param nYDst         destination buffer offset y
  * @param nWidth        width to copy in pixels
  * @param nHeight       height to copy in pixels
+ * @param bitsColor     icon's image data buffer
+ * @param cbBitsColor   length of the image data buffer in bytes
+ * @param bitsMask      icon's 1bpp image mask buffer
+ * @param cbBitsMask    length of the image mask buffer in bytes
+ * @param colorTable    icon's image color table
+ * @param cbBitsColor   length of the image color table buffer in bytes
+ * @param bpp           color image data bits per pixel
+ *
+ * @return              TRUE if success, FALSE otherwise
+ */
+FREERDP_API BOOL freerdp_image_copy_from_icon_data(
+	BYTE* pDstData, UINT32 DstFormat, UINT32 nDstStep,
+	UINT32 nXDst, UINT32 nYDst, UINT16 nWidth, UINT16 nHeight,
+	const BYTE* bitsColor, UINT16 cbBitsColor,
+	const BYTE* bitsMask, UINT16 cbBitsMask,
+	const BYTE* colorTable, UINT16 cbColorTable,
+	UINT32 bpp);
+
+/***
+ *
+ * @param pDstData      destination buffer
+ * @param DstFormat     destination buffer format
+ * @param nDstStep      destination buffer stride (line in bytes) 0 for default
+ * @param nXDst         destination buffer offset x
+ * @param nYDst         destination buffer offset y
+ * @param nWidth        width to copy in pixels
+ * @param nHeight       height to copy in pixels
  * @param xorMask       XOR mask buffer
  * @param xorMaskLength XOR mask length in bytes
  * @param andMask       AND mask buffer


### PR DESCRIPTION
The X11 client had its own function for converting the icon data into an 32-bit ARGB image. As other clients might need the same functionality it is better to put this function into the library itself instead of duplicating it in every client.