### PR TITLE
Porting patch for CVE2018-8786 to 1.1 branch

### DIFF
--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -119,7 +119,7 @@ BOOL update_read_bitmap(rdpUpdate* update, wStream* s, BITMAP_UPDATE* bitmap_upd
 
 	if (bitmap_update->number > bitmap_update->count)
 	{
-		UINT16 count;
+		UINT32 count;
 
 		count = bitmap_update->number * 2;
 


### PR DESCRIPTION
Port the patch fix for CVE2018-8786 to  1.1
Refer Patch : https://github.com/FreeRDP/FreeRDP/commit/445a5a42c500ceb80f8fa7f2c11f3682538033f3