### PR TITLE
Proxy: Redirect errors back to client

### DIFF
--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -453,6 +453,7 @@ FREERDP_API int freerdp_message_queue_process_pending_messages(
 
 FREERDP_API UINT32 freerdp_error_info(freerdp* instance);
 FREERDP_API void freerdp_set_error_info(rdpRdp* rdp, UINT32 error);
+FREERDP_API BOOL freerdp_send_error_info(rdpRdp* rdp);
 
 FREERDP_API void freerdp_get_version(int* major, int* minor, int* revision);
 FREERDP_API const char* freerdp_get_version_string(void);

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -789,6 +789,14 @@ void freerdp_set_error_info(rdpRdp* rdp, UINT32 error)
 	rdp_set_error_info(rdp, error);
 }
 
+BOOL freerdp_send_error_info(rdpRdp* rdp)
+{
+	if (!rdp)
+		return FALSE;
+
+	return rdp_send_error_info(rdp);
+}
+
 UINT32 freerdp_get_last_error(rdpContext* context)
 {
 	return context->LastError;


### PR DESCRIPTION
This PR adds support for errors redirection to freerdp-proxy.