### PR TITLE
Fixed format security issues.

### DIFF
--- a/libfreerdp/core/window.c
+++ b/libfreerdp/core/window.c
@@ -497,47 +497,45 @@ static BOOL window_order_supported(const rdpSettings* settings, UINT32 fieldFlag
 	}
 }
 
-
-#define DUMP_APPEND(...) do { \
-		_snprintf(tmpBuffer, sizeof(tmpBuffer), __VA_ARGS__); \
-		strncat(buffer, tmpBuffer, rem); \
-		rem -= strlen(tmpBuffer); \
-		} while(0)
-
+#define DUMP_APPEND(buffer, size, ...) \
+	do { \
+		char* b = (buffer); \
+		size_t s = (size); \
+		size_t pos = strnlen(b, s); \
+		_snprintf(&b[pos], s - pos, __VA_ARGS__); \
+	} while(0)
 
 static void dump_window_state_order(wLog *log, const char *msg, const WINDOW_ORDER_INFO* order, const WINDOW_STATE_ORDER *state)
 {
-	char buffer[3000];
-	char tmpBuffer[100];
-	size_t rem = sizeof(buffer) - 1;
+	char buffer[3000] = { 0 };
+	const size_t bufferSize = sizeof(buffer) - 1;
 
-	_snprintf(buffer, sizeof(buffer), "%s windowId=0x%"PRIu32"", msg, order->windowId);
-	rem -= strlen(msg);
+	_snprintf(buffer, bufferSize, "%s windowId=0x%"PRIu32"", msg, order->windowId);
 
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_OWNER)
-		DUMP_APPEND(" owner=0x%"PRIx32"", state->ownerWindowId);
+		DUMP_APPEND(buffer, bufferSize, " owner=0x%"PRIx32"", state->ownerWindowId);
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_STYLE)
 	{
-		DUMP_APPEND(" [ex]style=<0x%"PRIx32", 0x%"PRIx32"", state->style, state->extendedStyle);
+		DUMP_APPEND(buffer, bufferSize, " [ex]style=<0x%"PRIx32", 0x%"PRIx32"", state->style, state->extendedStyle);
 		if (state->style & WS_POPUP)
-			DUMP_APPEND(" popup");
+			DUMP_APPEND(buffer, bufferSize, " popup");
 		if (state->style & WS_VISIBLE)
-			DUMP_APPEND(" visible");
+			DUMP_APPEND(buffer, bufferSize, " visible");
 		if (state->style & WS_THICKFRAME)
-			DUMP_APPEND(" thickframe");
+			DUMP_APPEND(buffer, bufferSize, " thickframe");
 		if (state->style & WS_BORDER)
-			DUMP_APPEND(" border");
+			DUMP_APPEND(buffer, bufferSize, " border");
 		if (state->style & WS_CAPTION)
-			DUMP_APPEND(" caption");
+			DUMP_APPEND(buffer, bufferSize, " caption");
 
 		if (state->extendedStyle & WS_EX_NOACTIVATE)
-			DUMP_APPEND(" noactivate");
+			DUMP_APPEND(buffer, bufferSize, " noactivate");
 		if (state->extendedStyle & WS_EX_TOOLWINDOW)
-			DUMP_APPEND(" toolWindow");
+			DUMP_APPEND(buffer, bufferSize, " toolWindow");
 		if (state->extendedStyle & WS_EX_TOPMOST)
-			DUMP_APPEND(" topMost");
+			DUMP_APPEND(buffer, bufferSize, " topMost");
 
-		DUMP_APPEND(">");
+		DUMP_APPEND(buffer, bufferSize, ">");
 	}
 
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_SHOW)
@@ -551,77 +549,77 @@ static void dump_window_state_order(wLog *log, const char *msg, const WINDOW_ORD
 		case 5: showStr = "current"; break;
 		default: showStr = "<unknown>"; break;
 		}
-		DUMP_APPEND(" show=%s", showStr);
+		DUMP_APPEND(buffer, bufferSize, " show=%s", showStr);
 	}
 
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_TITLE)
-		DUMP_APPEND(" title");
+		DUMP_APPEND(buffer, bufferSize, " title");
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_CLIENT_AREA_OFFSET)
-		DUMP_APPEND(" clientOffsetX=%"PRId32" clientOffsetY=%"PRId32"",
+		DUMP_APPEND(buffer, bufferSize, " clientOffsetX=%"PRId32" clientOffsetY=%"PRId32"",
 				state->clientOffsetX, state->clientOffsetY);
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_CLIENT_AREA_SIZE)
-		DUMP_APPEND(" clientAreaWidth=%"PRIu32" clientAreaHeight=%"PRIu32"",
+		DUMP_APPEND(buffer, bufferSize, " clientAreaWidth=%"PRIu32" clientAreaHeight=%"PRIu32"",
 				state->clientAreaWidth, state->clientAreaHeight);
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_RESIZE_MARGIN_X)
-		DUMP_APPEND(" resizeMarginLeft=%"PRIu32" resizeMarginRight=%"PRIu32"",
+		DUMP_APPEND(buffer, bufferSize, " resizeMarginLeft=%"PRIu32" resizeMarginRight=%"PRIu32"",
 				state->resizeMarginLeft, state->resizeMarginRight);
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_RESIZE_MARGIN_Y)
-		DUMP_APPEND(" resizeMarginTop=%"PRIu32" resizeMarginBottom=%"PRIu32"",
+		DUMP_APPEND(buffer, bufferSize, " resizeMarginTop=%"PRIu32" resizeMarginBottom=%"PRIu32"",
 				state->resizeMarginTop, state->resizeMarginBottom);
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_RP_CONTENT)
-		DUMP_APPEND(" rpContent=0x%"PRIx8"", state->RPContent);
+		DUMP_APPEND(buffer, bufferSize, " rpContent=0x%"PRIx8"", state->RPContent);
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_ROOT_PARENT)
-		DUMP_APPEND(" rootParent=0x%"PRIx32"", state->rootParentHandle);
+		DUMP_APPEND(buffer, bufferSize, " rootParent=0x%"PRIx32"", state->rootParentHandle);
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_WND_OFFSET)
-		DUMP_APPEND(" windowOffsetX=%"PRId32" windowOffsetY=%"PRId32"", state->windowOffsetX, state->windowOffsetY);
+		DUMP_APPEND(buffer, bufferSize, " windowOffsetX=%"PRId32" windowOffsetY=%"PRId32"", state->windowOffsetX, state->windowOffsetY);
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_WND_CLIENT_DELTA)
-		DUMP_APPEND(" windowClientDeltaX=%"PRId32" windowClientDeltaY=%"PRId32"",
+		DUMP_APPEND(buffer, bufferSize, " windowClientDeltaX=%"PRId32" windowClientDeltaY=%"PRId32"",
 				state->windowClientDeltaX, state->windowClientDeltaY);
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_WND_SIZE)
-		DUMP_APPEND(" windowWidth=%"PRIu32" windowHeight=%"PRIu32"", state->windowWidth, state->windowHeight);
+		DUMP_APPEND(buffer, bufferSize, " windowWidth=%"PRIu32" windowHeight=%"PRIu32"", state->windowWidth, state->windowHeight);
 
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_WND_RECTS)
 	{
 		UINT32 i;
-		DUMP_APPEND(" windowRects=(");
+		DUMP_APPEND(buffer, bufferSize, " windowRects=(");
 		for(i = 0; i < state->numWindowRects; i++)
 		{
-			DUMP_APPEND("(%"PRIu16",%"PRIu16",%"PRIu16",%"PRIu16")",
+			DUMP_APPEND(buffer, bufferSize, "(%"PRIu16",%"PRIu16",%"PRIu16",%"PRIu16")",
 					state->windowRects[i].left, state->windowRects[i].top,
 					state->windowRects[i].right, state->windowRects[i].bottom);
 		}
-		DUMP_APPEND(")");
+		DUMP_APPEND(buffer, bufferSize, ")");
 	}
 
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_VIS_OFFSET)
-		DUMP_APPEND(" visibleOffsetX=%"PRId32" visibleOffsetY=%"PRId32"", state->visibleOffsetX, state->visibleOffsetY);
+		DUMP_APPEND(buffer, bufferSize, " visibleOffsetX=%"PRId32" visibleOffsetY=%"PRId32"", state->visibleOffsetX, state->visibleOffsetY);
 
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_VISIBILITY)
 	{
 		UINT32 i;
-		DUMP_APPEND(" visibilityRects=(");
+		DUMP_APPEND(buffer, bufferSize, " visibilityRects=(");
 		for(i = 0; i < state->numVisibilityRects; i++)
 		{
-			DUMP_APPEND("(%"PRIu16",%"PRIu16",%"PRIu16",%"PRIu16")",
+			DUMP_APPEND(buffer, bufferSize, "(%"PRIu16",%"PRIu16",%"PRIu16",%"PRIu16")",
 					state->visibilityRects[i].left, state->visibilityRects[i].top,
 					state->visibilityRects[i].right, state->visibilityRects[i].bottom);
 		}
-		DUMP_APPEND(")");
+		DUMP_APPEND(buffer, bufferSize, ")");
 	}
 
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_OVERLAY_DESCRIPTION)
-		DUMP_APPEND(" overlayDescr");
+		DUMP_APPEND(buffer, bufferSize, " overlayDescr");
 
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_ICON_OVERLAY_NULL)
-		DUMP_APPEND(" iconOverlayNull");
+		DUMP_APPEND(buffer, bufferSize, " iconOverlayNull");
 
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_TASKBAR_BUTTON)
-		DUMP_APPEND(" taskBarButton=0x%"PRIx8"", state->TaskbarButton);
+		DUMP_APPEND(buffer, bufferSize, " taskBarButton=0x%"PRIx8"", state->TaskbarButton);
 
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_ENFORCE_SERVER_ZORDER)
-		DUMP_APPEND(" enforceServerZOrder=0x%"PRIx8"", state->EnforceServerZOrder);
+		DUMP_APPEND(buffer, bufferSize, " enforceServerZOrder=0x%"PRIx8"", state->EnforceServerZOrder);
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_APPBAR_STATE)
-		DUMP_APPEND(" appBarState=0x%"PRIx8"", state->AppBarState);
+		DUMP_APPEND(buffer, bufferSize, " appBarState=0x%"PRIx8"", state->AppBarState);
 	if (order->fieldFlags & WINDOW_ORDER_FIELD_APPBAR_EDGE)
 	{
 		const char *appBarEdgeStr;
@@ -633,7 +631,7 @@ static void dump_window_state_order(wLog *log, const char *msg, const WINDOW_ORD
 		case 3: appBarEdgeStr = "bottom"; break;
 		default: appBarEdgeStr = "<unknown>"; break;
 		}
-		DUMP_APPEND(" appBarEdge=%s", appBarEdgeStr);
+		DUMP_APPEND(buffer, bufferSize, " appBarEdge=%s", appBarEdgeStr);
 	}
 
 	WLog_Print(log, WLOG_DEBUG, buffer);
@@ -870,25 +868,24 @@ static void update_read_desktop_non_monitored_order(wStream* s, WINDOW_ORDER_INF
 static void dump_monitored_desktop(wLog *log, const char *msg, const WINDOW_ORDER_INFO* orderInfo,
 		const MONITORED_DESKTOP_ORDER *monitored)
 {
-	char buffer[1000] = {0};
-	char tmpBuffer[1000];
-	size_t rem = sizeof(buffer) - 1;
+	char buffer[1000] = { 0 };
+	const size_t bufferSize = sizeof(buffer) - 1;
 
-	DUMP_APPEND(msg);
+	DUMP_APPEND(buffer, bufferSize, "%s", msg);
 
 	if (orderInfo->fieldFlags & WINDOW_ORDER_FIELD_DESKTOP_ACTIVE_WND)
-		DUMP_APPEND(" activeWindowId=0x%"PRIx32"", monitored->activeWindowId);
+		DUMP_APPEND(buffer, bufferSize, " activeWindowId=0x%"PRIx32"", monitored->activeWindowId);
 
 	if (orderInfo->fieldFlags & WINDOW_ORDER_FIELD_DESKTOP_ZORDER)
 	{
 		UINT32 i;
 
-		DUMP_APPEND(" windows=(");
+		DUMP_APPEND(buffer, bufferSize, " windows=(");
 		for (i = 0; i < monitored->numWindowIds; i++)
 		{
-			DUMP_APPEND("0x%"PRIx32",", monitored->windowIds[i]);
+			DUMP_APPEND(buffer, bufferSize, "0x%"PRIx32",", monitored->windowIds[i]);
 		}
-		DUMP_APPEND(")");
+		DUMP_APPEND(buffer, bufferSize, ")");
 	}
 	WLog_Print(log, WLOG_DEBUG, buffer);
 }


### PR DESCRIPTION
reported by @giox069 
* Fixes the missing format string
* Simplifies `DUMP_APPEND` macro
* Ensures the buffers are `\0` terminated by providing only `sizeof(buffer) - 1` as length to print functions.