### PR TITLE
Add multimon support to proxy server

### DIFF
--- a/include/freerdp/display.h
+++ b/include/freerdp/display.h
@@ -1,0 +1,36 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Display update notifications
+ *
+ * Copyright 2019 Kobi Mizrachi <kmizrachi18@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_DISPLAY_H
+#define FREERDP_DISPLAY_H
+
+#include <freerdp/freerdp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+FREERDP_API BOOL freerdp_display_send_monitor_layout(rdpContext* context, UINT32 monitorCount,
+        const MONITOR_DEF* monitorDefArray);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FREERDP_DISPLAY_UPDATE_H */

--- a/libfreerdp/core/CMakeLists.txt
+++ b/libfreerdp/core/CMakeLists.txt
@@ -129,7 +129,9 @@ set(${MODULE_PREFIX}_SRCS
 	listener.c
 	listener.h
 	peer.c
-	peer.h)
+	peer.h
+	display.c
+	display.h)
 
 set(${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_SRCS} ${${MODULE_PREFIX}_GATEWAY_SRCS})
 

--- a/libfreerdp/core/display.c
+++ b/libfreerdp/core/display.c
@@ -1,0 +1,83 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Display update notifications
+ *
+ * Copyright 2019 Kobi Mizrachi <kmizrachi18@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "display.h"
+
+BOOL display_write_monitor_layout_pdu(wStream* s, UINT32 monitorCount,
+                                      const MONITOR_DEF* monitorDefArray)
+{
+	UINT32 index;
+	const MONITOR_DEF* monitor;
+
+	if (!Stream_EnsureRemainingCapacity(s, 4 + (monitorCount * 20)))
+		return FALSE;
+
+	Stream_Write_UINT32(s, monitorCount); /* monitorCount (4 bytes) */
+
+	for (index = 0, monitor = monitorDefArray; index < monitorCount; index++, monitor++)
+	{
+		Stream_Write_UINT32(s, monitor->left); /* left (4 bytes) */
+		Stream_Write_UINT32(s, monitor->top); /* top (4 bytes) */
+		Stream_Write_UINT32(s, monitor->right); /* right (4 bytes) */
+		Stream_Write_UINT32(s, monitor->bottom); /* bottom (4 bytes) */
+		Stream_Write_UINT32(s, monitor->flags); /* flags (4 bytes) */
+	}
+
+	return TRUE;
+}
+
+BOOL display_convert_rdp_monitor_to_monitor_def(UINT32 monitorCount,
+        const rdpMonitor* monitorDefArray, MONITOR_DEF** result)
+{
+	UINT32 index;
+	const rdpMonitor* monitor;
+
+	if (!monitorDefArray || !(*result))
+		return FALSE;
+
+	for (index = 0, monitor = monitorDefArray; index < monitorCount; index++, monitor++)
+	{
+		MONITOR_DEF* current = (*result + index);
+		current->left = monitor->x; /* left (4 bytes) */
+		current->top = monitor->y; /* top (4 bytes) */
+		current->right = monitor->x + monitor->width - 1; /* right (4 bytes) */
+		current->bottom = monitor->y + monitor->height - 1; /* bottom (4 bytes) */
+		current->flags = monitor->is_primary ? MONITOR_PRIMARY : 0x0; /* flags (4 bytes) */
+	}
+
+	return TRUE;
+}
+
+BOOL freerdp_display_send_monitor_layout(rdpContext* context, UINT32 monitorCount,
+        const MONITOR_DEF* monitorDefArray)
+{
+	rdpRdp* rdp = context->rdp;
+	wStream* st = rdp_data_pdu_init(rdp);
+
+	if (!st)
+		return FALSE;
+
+	if (!display_write_monitor_layout_pdu(st, monitorCount, monitorDefArray))
+	{
+		Stream_Release(st);
+		return FALSE;
+	}
+
+	return rdp_send_data_pdu(rdp, st, DATA_PDU_TYPE_MONITOR_LAYOUT, 0);
+}

--- a/libfreerdp/core/display.h
+++ b/libfreerdp/core/display.h
@@ -1,0 +1,29 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Display update notifications
+ *
+ * Copyright 2019 Kobi Mizrachi <kmizrachi18@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_LIB_CORE_DISPLAY_H
+#define FREERDP_LIB_CORE_DISPLAY_H
+
+#include <freerdp/display.h>
+#include "rdp.h"
+
+FREERDP_LOCAL BOOL display_convert_rdp_monitor_to_monitor_def(UINT32 monitorCount,
+        const rdpMonitor* monitorDefArray, MONITOR_DEF** result);
+
+#endif /* FREERDP_LIB_CORE_DISPLAY_H */

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -807,29 +807,6 @@ static BOOL rdp_recv_monitor_layout_pdu(rdpRdp* rdp, wStream* s)
 	return ret;
 }
 
-BOOL rdp_write_monitor_layout_pdu(wStream* s, UINT32 monitorCount,
-                                  const rdpMonitor* monitorDefArray)
-{
-	UINT32 index;
-	const rdpMonitor* monitor;
-
-	if (!Stream_EnsureRemainingCapacity(s, 4 + (monitorCount * 20)))
-		return FALSE;
-
-	Stream_Write_UINT32(s, monitorCount); /* monitorCount (4 bytes) */
-
-	for (index = 0, monitor = monitorDefArray; index < monitorCount; index++, monitor++)
-	{
-		Stream_Write_UINT32(s, monitor->x); /* left (4 bytes) */
-		Stream_Write_UINT32(s, monitor->y); /* top (4 bytes) */
-		Stream_Write_UINT32(s, monitor->x + monitor->width - 1); /* right (4 bytes) */
-		Stream_Write_UINT32(s, monitor->y + monitor->height - 1); /* bottom (4 bytes) */
-		Stream_Write_UINT32(s, monitor->is_primary ? 0x01 : 0x00); /* flags (4 bytes) */
-	}
-
-	return TRUE;
-}
-
 int rdp_recv_data_pdu(rdpRdp* rdp, wStream* s)
 {
 	BYTE type;

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -223,9 +223,6 @@ FREERDP_LOCAL int rdp_recv_out_of_sequence_pdu(rdpRdp* rdp, wStream* s);
 
 FREERDP_LOCAL void rdp_read_flow_control_pdu(wStream* s, UINT16* type);
 
-FREERDP_LOCAL BOOL rdp_write_monitor_layout_pdu(wStream* s, UINT32 monitorCount,
-        const rdpMonitor* monitorDefArray);
-
 FREERDP_LOCAL int rdp_recv_callback(rdpTransport* transport, wStream* s,
                                     void* extra);
 

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -29,7 +29,6 @@
 
 #include <freerdp/freerdp.h>
 #include <freerdp/constants.h>
-#include <freerdp/display.h>
 #include <freerdp/gdi/gdi.h>
 #include <freerdp/utils/signal.h>
 
@@ -38,10 +37,10 @@
 #include <freerdp/client/cliprdr.h>
 #include <freerdp/client/channels.h>
 #include <freerdp/channels/channels.h>
+#include <freerdp/log.h>
 
 #include <winpr/crt.h>
 #include <winpr/synch.h>
-#include <freerdp/log.h>
 
 #include "pf_channels.h"
 #include "pf_gdi.h"
@@ -82,7 +81,6 @@ static void pf_OnErrorInfo(void* ctx, ErrorInfoEventArgs* e)
 		freerdp_send_error_info(ps->rdp);
 	}
 }
-
 
 /**
  * Called before a connection is established.

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -29,6 +29,7 @@
 
 #include <freerdp/freerdp.h>
 #include <freerdp/constants.h>
+#include <freerdp/display.h>
 #include <freerdp/gdi/gdi.h>
 #include <freerdp/utils/signal.h>
 

--- a/server/proxy/pf_common.c
+++ b/server/proxy/pf_common.c
@@ -51,6 +51,7 @@ void pf_common_copy_settings(rdpSettings* dst, rdpSettings* src)
 	dst->DesktopOrientation = src->DesktopOrientation;
 	dst->DesktopScaleFactor = src->DesktopScaleFactor;
 	dst->DeviceScaleFactor = src->DeviceScaleFactor;
+	dst->SupportMonitorLayoutPdu = src->SupportMonitorLayoutPdu;
 	/* client info */
 	dst->AutoLogonEnabled = src->AutoLogonEnabled;
 	dst->CompressionEnabled = src->CompressionEnabled;

--- a/server/proxy/pf_context.c
+++ b/server/proxy/pf_context.c
@@ -77,5 +77,45 @@ rdpContext* p_client_context_create(rdpSettings* clientSettings,
 	settings->ServerPort = port;
 	settings->SoftwareGdi = FALSE;
 	settings->RedirectClipboard = FALSE;
+	/* Client Monitor Data */
+	settings->MonitorCount = clientSettings->MonitorCount;
+	settings->SpanMonitors = clientSettings->SpanMonitors;
+	settings->UseMultimon = clientSettings->UseMultimon;
+	settings->ForceMultimon = clientSettings->ForceMultimon;
+	settings->DesktopPosX = clientSettings->DesktopPosX;
+	settings->DesktopPosY = clientSettings->DesktopPosY;
+	settings->ListMonitors = clientSettings->ListMonitors;
+	settings->NumMonitorIds = clientSettings->NumMonitorIds;
+	settings->MonitorLocalShiftX = clientSettings->MonitorLocalShiftX;
+	settings->MonitorLocalShiftY = clientSettings->MonitorLocalShiftY;
+	settings->HasMonitorAttributes = clientSettings->HasMonitorAttributes;
+	settings->MonitorCount = clientSettings->MonitorCount;
+	settings->MonitorDefArraySize = clientSettings->MonitorDefArraySize;
+
+	if (clientSettings->MonitorDefArraySize > 0)
+	{
+		settings->MonitorDefArray = (rdpMonitor*) calloc(clientSettings->MonitorDefArraySize,
+		                            sizeof(rdpMonitor));
+
+		if (!settings->MonitorDefArray)
+		{
+			goto error;
+		}
+
+		CopyMemory(settings->MonitorDefArray, clientSettings->MonitorDefArray,
+		           sizeof(rdpMonitor) * clientSettings->MonitorDefArraySize);
+	}
+	else
+		settings->MonitorDefArray = NULL;
+
+	settings->MonitorIds = (UINT32*) calloc(16, sizeof(UINT32));
+
+	if (!settings->MonitorIds)
+		goto error;
+
+	CopyMemory(settings->MonitorIds, clientSettings->MonitorIds, 16 * sizeof(UINT32));
 	return context;
+error:
+	freerdp_client_context_free(context);
+	return NULL;
 }

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -180,6 +180,12 @@ static BOOL pf_server_activate(freerdp_peer* client)
 	return TRUE;
 }
 
+static BOOL pf_server_adjust_monitor_layout(freerdp_peer* peer)
+{
+	/* proxy as is, there's no need to do anything here */
+	return TRUE;
+}
+
 /**
  * Handles an incoming client connection, to be run in it's own thread.
  *
@@ -232,8 +238,11 @@ static DWORD WINAPI pf_server_handle_client(LPVOID arg)
 	client->settings->ColorDepth = 32;
 	client->settings->SuppressOutput = TRUE;
 	client->settings->RefreshRect = TRUE;
+	client->settings->UseMultimon = TRUE;
+	client->settings->SupportMonitorLayoutPdu = TRUE;
 	client->PostConnect = pf_server_post_connect;
 	client->Activate = pf_server_activate;
+	client->AdjustMonitorsLayout = pf_server_adjust_monitor_layout;
 	pf_server_register_input_callbacks(client->input);
 	pf_server_register_update_callbacks(client->update);
 	client->settings->MultifragMaxRequestSize = 0xFFFFFF; /* FIXME */

--- a/server/proxy/pf_update.c
+++ b/server/proxy/pf_update.c
@@ -19,6 +19,8 @@
  * limitations under the License.
  */
 
+#include <freerdp/update.h>
+
 #include "pf_update.h"
 #include "pf_context.h"
 
@@ -83,6 +85,15 @@ static BOOL pf_client_desktop_resize(rdpContext* context)
 	return ps->update->DesktopResize(ps);
 }
 
+static BOOL pf_client_remote_monitors(rdpContext* context, UINT32 count,
+                                      const MONITOR_DEF* monitors)
+{
+	pClientContext* pc = (pClientContext*) context;
+	proxyData* pdata = pc->pdata;
+	rdpContext* ps = (rdpContext*)pdata->ps;
+	return freerdp_display_send_monitor_layout(ps, count, monitors);
+}
+
 static BOOL pf_client_send_pointer_system(rdpContext* context,
                                        const POINTER_SYSTEM_UPDATE* pointer_system)
 {
@@ -134,6 +145,7 @@ void pf_client_register_update_callbacks(rdpUpdate* update)
 	update->EndPaint = pf_client_end_paint;
 	update->BitmapUpdate = pf_client_bitmap_update;
 	update->DesktopResize = pf_client_desktop_resize;
+	update->RemoteMonitors = pf_client_remote_monitors;
 
 	update->pointer->PointerSystem = pf_client_send_pointer_system;
 	update->pointer->PointerPosition = pf_client_send_pointer_position;


### PR DESCRIPTION
This PR adds multimon support to the proxy.

* In order to send MonitorLayoutPdu, we had to export it. It was located in acitvation.c (which is not the location for this message, so we moved it to a new file display.c as the it appears in the docs under "Display update notifications"). Please refer to #5400.