### PR TITLE
channels: ssh-agent: cmake: turn off server side channel by default in `ChannelsOptions.cmake`

### DIFF
--- a/channels/sshagent/ChannelOptions.cmake
+++ b/channels/sshagent/ChannelOptions.cmake
@@ -1,6 +1,7 @@
 
 set(OPTION_DEFAULT OFF)
 set(OPTION_CLIENT_DEFAULT OFF)
+set(OPTION_SERVER_DEFAULT OFF)
 
 define_channel_options(NAME "sshagent" TYPE "dynamic"
 	DESCRIPTION "SSH Agent Forwarding (experimental)"


### PR DESCRIPTION
CMake v3.5.1 throws the following error if this is not set:
```
CMake Error at channels/CMakeLists.txt:48 (if):
  if given arguments:

    "OFF" "OR"

  Unknown arguments specified
Call Stack (most recent call first):
  channels/sshagent/ChannelOptions.cmake:6 (define_channel_options)
  channels/CMakeLists.txt:273 (include)
```
