### PR TITLE
rdpUpdate: add autoBitmapDataCalculate

### DIFF
--- a/include/freerdp/update.h
+++ b/include/freerdp/update.h
@@ -253,6 +253,11 @@ struct rdp_update
 	rdpBounds currentBounds;
 	rdpBounds previousBounds;
 	CRITICAL_SECTION mux;
+
+	/* if autoCalculateBitmapData is set to TRUE, the server automatically 
+	 * fills BITMAP_DATA struct members: flags, cbCompMainBodySize and cbCompFirstRowSize.
+	*/
+	BOOL autoCalculateBitmapData;
 };
 
 #endif /* FREERDP_UPDATE_H */

--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -148,16 +148,19 @@ static BOOL update_write_bitmap_data(rdpUpdate* update, wStream* s,
 	if (!Stream_EnsureRemainingCapacity(s, 64 + bitmapData->bitmapLength))
 		return FALSE;
 
-	bitmapData->flags = 0;
-	bitmapData->cbCompFirstRowSize = 0;
-
-	if (bitmapData->compressed)
-		bitmapData->flags |= BITMAP_COMPRESSION;
-
-	if (update->context->settings->NoBitmapCompressionHeader)
+	if (update->autoCalculateBitmapData)
 	{
-		bitmapData->flags |= NO_BITMAP_COMPRESSION_HDR;
-		bitmapData->cbCompMainBodySize = bitmapData->bitmapLength;
+		bitmapData->flags = 0;
+		bitmapData->cbCompFirstRowSize = 0;
+
+		if (bitmapData->compressed)
+			bitmapData->flags |= BITMAP_COMPRESSION;
+
+		if (update->context->settings->NoBitmapCompressionHeader)
+		{
+			bitmapData->flags |= NO_BITMAP_COMPRESSION_HDR;
+			bitmapData->cbCompMainBodySize = bitmapData->bitmapLength;
+		}
 	}
 
 	Stream_Write_UINT16(s, bitmapData->destLeft);
@@ -2190,6 +2193,7 @@ rdpUpdate* update_new(rdpRdp* rdp)
 	deleteList->cIndices = 0;
 	update->SuppressOutput = update_send_suppress_output;
 	update->initialState = TRUE;
+	update->autoCalculateBitmapData = TRUE;
 	update->queue = MessageQueue_New(&cb);
 
 	if (!update->queue)

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -98,6 +98,8 @@ static BOOL pf_client_pre_connect(freerdp* instance)
 	 * Only override it if you plan to implement custom order
 	 * callbacks or deactiveate certain features.
 	 */
+	ZeroMemory(instance->settings->OrderSupport, 32);
+
 	/**
 	 * Register the channel listeners.
 	 * They are required to set up / tear down channels if they are loaded.

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -239,6 +239,9 @@ static DWORD WINAPI pf_server_handle_client(LPVOID arg)
 		goto out_free_peer;
 	}
 
+
+	ZeroMemory(client->settings->OrderSupport, 32);
+	client->update->autoCalculateBitmapData = FALSE;
 	pdata->ps = ps;
 	/* keep configuration in proxyData */
 	pdata->config = client->ContextExtra;


### PR DESCRIPTION
I found a bug in our proxy that occurs when the target server is win7:
the target sends bitmap update data with flags=0 and the server code changes it to 0x401 instead of sending it as is, then the client (mstsc) closes the connection (because it got an uncompressed bitmap with flags indicating that it is compressed, I guess)

I didn't want to break the API so I though of a way to fix it and wanted to hear what do you guys think of it
@akallabeth @hardening 

BTW, wasn't sure about the name `autoBitmapDataCalculate`, because it actually calculate only three members of the struct. I noted this in the comment, before the declaration of this struct member. So a new name for this member / a different idea for a solution will be welcomed 