### PR TITLE
rdpgfx: CacheImportOffer implementation

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -363,6 +363,10 @@ static UINT rdpgfx_send_frame_acknowledge_pdu(RdpgfxClientContext* context,
 	                    pdu->totalFramesDecoded); /* totalFramesDecoded (4 bytes) */
 	error = callback->channel->Write(callback->channel, (UINT32) Stream_Length(s),
 	                                 Stream_Buffer(s), NULL);
+
+	if (error == CHANNEL_RC_OK) /* frame successfully acked */
+		gfx->UnacknowledgedFrames--;
+
 fail:
 	Stream_Free(s, TRUE);
 	return error;
@@ -804,7 +808,6 @@ static UINT rdpgfx_recv_end_frame_pdu(RDPGFX_CHANNEL_CALLBACK* callback,
 		}
 	}
 
-	gfx->UnacknowledgedFrames--;
 	gfx->TotalDecodedFrames++;
 
 	if (!gfx->sendFrameAcks)

--- a/channels/rdpgfx/server/rdpgfx_main.c
+++ b/channels/rdpgfx/server/rdpgfx_main.c
@@ -1165,8 +1165,7 @@ static UINT rdpgfx_recv_cache_import_offer_pdu(RdpgfxServerContext* context,
 	{
 		cacheEntries = &(pdu.cacheEntries[index]);
 		Stream_Read_UINT64(s, cacheEntries->cacheKey); /* cacheKey (8 bytes) */
-		/* bitmapLength (4 bytes) */
-		Stream_Read_UINT32(s, cacheEntries->bitmapLength);
+		Stream_Read_UINT32(s, cacheEntries->bitmapLength); /* bitmapLength (4 bytes) */
 	}
 
 	if (context)

--- a/include/freerdp/client/rdpgfx.h
+++ b/include/freerdp/client/rdpgfx.h
@@ -92,6 +92,8 @@ typedef UINT(*pcRdpgfxCapsConfirm)(RdpgfxClientContext* context,
                                    const RDPGFX_CAPS_CONFIRM_PDU* capsConfirm);
 typedef UINT(*pcRdpgfxFrameAcknowledge)(RdpgfxClientContext* context,
                                         const RDPGFX_FRAME_ACKNOWLEDGE_PDU* frameAcknowledge);
+typedef UINT(*pcRdpgfxQoeFrameAcknowledge)(RdpgfxClientContext* context,
+                                        const RDPGFX_QOE_FRAME_ACKNOWLEDGE_PDU* qoeFrameAcknowledge);
 
 typedef UINT(*pcRdpgfxMapWindowForSurface)(RdpgfxClientContext* context, UINT16 surfaceID,
         UINT64 windowID);
@@ -134,6 +136,7 @@ struct _rdpgfx_client_context
 	pcRdpgfxCapsAdvertise CapsAdvertise;
 	pcRdpgfxCapsConfirm CapsConfirm;
 	pcRdpgfxFrameAcknowledge FrameAcknowledge;
+	pcRdpgfxQoeFrameAcknowledge QoeFrameAcknowledge;
 
 	/* No locking required */
 	pcRdpgfxUpdateSurfaces UpdateSurfaces;

--- a/server/proxy/pf_rdpgfx.c
+++ b/server/proxy/pf_rdpgfx.c
@@ -286,6 +286,24 @@ static UINT pf_rdpgfx_frame_acknowledge(RdpgfxServerContext* context,
 	return client->FrameAcknowledge(client, frameAcknowledge);
 }
 
+static UINT pf_rdpgfx_qoe_frame_acknowledge(RdpgfxServerContext* context,
+                                        const RDPGFX_QOE_FRAME_ACKNOWLEDGE_PDU* qoeFrameAcknowledge)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	RdpgfxClientContext* client = (RdpgfxClientContext*) pdata->pc->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
+	return client->QoeFrameAcknowledge(client, qoeFrameAcknowledge);
+}
+
+static UINT pf_rdpgfx_cache_import_offer(RdpgfxServerContext* context,
+                                        const RDPGFX_CACHE_IMPORT_OFFER_PDU* cacheImportOffer)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	RdpgfxClientContext* client = (RdpgfxClientContext*) pdata->pc->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
+	return client->CacheImportOffer(client, cacheImportOffer);
+}
+
 void pf_rdpgfx_pipeline_init(RdpgfxClientContext* gfx, RdpgfxServerContext* server,
                              proxyData* pdata)
 {
@@ -310,10 +328,13 @@ void pf_rdpgfx_pipeline_init(RdpgfxClientContext* gfx, RdpgfxServerContext* serv
 	gfx->MapSurfaceToWindow = pf_rdpgfx_map_surface_to_window;
 	gfx->MapSurfaceToScaledOutput = pf_rdpgfx_map_surface_to_scaled_output;
 	gfx->MapSurfaceToScaledWindow = pf_rdpgfx_map_surface_to_scaled_window;
+
 	gfx->OnOpen = pf_rdpgfx_on_open;
 	gfx->OnClose = pf_rdpgfx_on_close;
 	gfx->CapsConfirm = pf_rdpgfx_caps_confirm;
 	/* Set server callbacks */
 	server->CapsAdvertise = pf_rdpgfx_caps_advertise;
 	server->FrameAcknowledge = pf_rdpgfx_frame_acknowledge;
+	server->CacheImportOffer = pf_rdpgfx_cache_import_offer;
+	server->QoeFrameAcknowledge = pf_rdpgfx_qoe_frame_acknowledge;
 }


### PR DESCRIPTION
This PR:

* Exposes QoeFrameAcknowledge (for proxy use). #5378 exposed FrameAck, but didn't cover the Qoe frames
    * This is needed because currently the proxy's client sends Qoe frame acks directly, instead of syncing the original client's acks correctly.
* Adds implementation for CacheImportOffer PDU
    * Currently not used by xfreerdp, but needed that for proxying the PDU, that **is** used by mstsc
* Proxy `CacheImportOffer` & `QoeFrameAck` in server/proxy