### PR TITLE
 codec: Set alpha channel to FF if not used

### DIFF
--- a/libfreerdp/codec/planar.c
+++ b/libfreerdp/codec/planar.c
@@ -20,7 +20,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#	include "config.h"
 #endif
 
 #include <winpr/crt.h>
@@ -33,14 +33,14 @@
 
 #define TAG FREERDP_TAG("codec")
 
-static INLINE BOOL freerdp_bitmap_planar_compress_plane_rle(
-    const BYTE* plane, UINT32 width, UINT32 height,
-    BYTE* outPlane, UINT32* dstSize);
-static INLINE BYTE* freerdp_bitmap_planar_delta_encode_plane(
-    const BYTE* inPlane, UINT32 width, UINT32 height, BYTE* outPlane);
+static INLINE BOOL freerdp_bitmap_planar_compress_plane_rle(const BYTE* plane, UINT32 width,
+                                                            UINT32 height, BYTE* outPlane,
+                                                            UINT32* dstSize);
+static INLINE BYTE* freerdp_bitmap_planar_delta_encode_plane(const BYTE* inPlane, UINT32 width,
+                                                             UINT32 height, BYTE* outPlane);
 
-static INLINE INT32 planar_skip_plane_rle(const BYTE* pSrcData, UINT32 SrcSize,
-        UINT32 nWidth, UINT32 nHeight)
+static INLINE INT32 planar_skip_plane_rle(const BYTE* pSrcData, UINT32 SrcSize, UINT32 nWidth,
+                                          UINT32 nHeight)
 {
 	UINT32 x, y;
 	BYTE controlByte;
@@ -88,10 +88,9 @@ static INLINE INT32 planar_skip_plane_rle(const BYTE* pSrcData, UINT32 SrcSize,
 }
 
 static INLINE INT32 planar_decompress_plane_rle(const BYTE* pSrcData, UINT32 SrcSize,
-        BYTE* pDstData, INT32 nDstStep,
-        UINT32 nXDst, UINT32 nYDst,
-        UINT32 nWidth, UINT32 nHeight,
-        UINT32 nChannel, BOOL vFlip)
+                                                BYTE* pDstData, INT32 nDstStep, UINT32 nXDst,
+                                                UINT32 nYDst, UINT32 nWidth, UINT32 nHeight,
+                                                UINT32 nChannel, BOOL vFlip)
 {
 	INT32 x, y;
 	UINT32 pixel;
@@ -135,7 +134,7 @@ static INLINE INT32 planar_decompress_plane_rle(const BYTE* pSrcData, UINT32 Src
 
 			if ((srcp - pSrcData) > SrcSize)
 			{
-				WLog_ERR(TAG,  "error reading input buffer");
+				WLog_ERR(TAG, "error reading input buffer");
 				return -1;
 			}
 
@@ -155,7 +154,7 @@ static INLINE INT32 planar_decompress_plane_rle(const BYTE* pSrcData, UINT32 Src
 
 			if (((dstp + (cRawBytes + nRunLength)) - currentScanline) > nWidth * 4)
 			{
-				WLog_ERR(TAG,  "too many pixels in scanline");
+				WLog_ERR(TAG, "too many pixels in scanline");
 				return -1;
 			}
 
@@ -234,59 +233,59 @@ static INLINE BOOL writeLine(BYTE** ppRgba, UINT32 DstFormat, UINT32 width, cons
 
 	switch (DstFormat)
 	{
-		case PIXEL_FORMAT_BGRA32:
+	case PIXEL_FORMAT_BGRA32:
+		for (x = 0; x < width; x++)
+		{
+			*(*ppRgba)++ = *(*ppB)++;
+			*(*ppRgba)++ = *(*ppG)++;
+			*(*ppRgba)++ = *(*ppR)++;
+			*(*ppRgba)++ = *(*ppA)++;
+		}
+
+		return TRUE;
+
+	case PIXEL_FORMAT_BGRX32:
+		for (x = 0; x < width; x++)
+		{
+			*(*ppRgba)++ = *(*ppB)++;
+			*(*ppRgba)++ = *(*ppG)++;
+			*(*ppRgba)++ = *(*ppR)++;
+			*(*ppRgba)++ = 0xFF;
+		}
+
+		return TRUE;
+
+	default:
+		if (ppA)
+		{
 			for (x = 0; x < width; x++)
 			{
-				*(*ppRgba)++ = *(*ppB)++;
-				*(*ppRgba)++ = *(*ppG)++;
-				*(*ppRgba)++ = *(*ppR)++;
-				*(*ppRgba)++ = *(*ppA)++;
+				BYTE alpha = *(*ppA)++;
+				UINT32 color = FreeRDPGetColor(DstFormat, *(*ppR)++, *(*ppG)++, *(*ppB)++, alpha);
+				WriteColor(*ppRgba, DstFormat, color);
+				*ppRgba += GetBytesPerPixel(DstFormat);
 			}
+		}
+		else
+		{
+			const BYTE alpha = 0xFF;
 
-			return TRUE;
-
-		case PIXEL_FORMAT_BGRX32:
 			for (x = 0; x < width; x++)
 			{
-				*(*ppRgba)++ = *(*ppB)++;
-				*(*ppRgba)++ = *(*ppG)++;
-				*(*ppRgba)++ = *(*ppR)++;
-				*(*ppRgba)++ = 0xFF;
+				UINT32 color = FreeRDPGetColor(DstFormat, *(*ppR)++, *(*ppG)++, *(*ppB)++, alpha);
+				WriteColor(*ppRgba, DstFormat, color);
+				*ppRgba += GetBytesPerPixel(DstFormat);
 			}
+		}
 
-			return TRUE;
-
-		default:
-			if (ppA)
-			{
-				for (x = 0; x < width; x++)
-				{
-					BYTE alpha = *(*ppA)++;
-					UINT32 color = FreeRDPGetColor(DstFormat, *(*ppR)++, *(*ppG)++, *(*ppB)++, alpha);
-					WriteColor(*ppRgba, DstFormat, color);
-					*ppRgba += GetBytesPerPixel(DstFormat);
-				}
-			}
-			else
-			{
-				const BYTE alpha = 0xFF;
-
-				for (x = 0; x < width; x++)
-				{
-					UINT32 color = FreeRDPGetColor(DstFormat, *(*ppR)++, *(*ppG)++, *(*ppB)++, alpha);
-					WriteColor(*ppRgba, DstFormat, color);
-					*ppRgba += GetBytesPerPixel(DstFormat);
-				}
-			}
-
-			return TRUE;
+		return TRUE;
 	}
 }
 
-static INLINE BOOL planar_decompress_planes_raw(const BYTE* pSrcData[4],
-        BYTE* pDstData, UINT32 DstFormat,
-        UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst, UINT32 nWidth, UINT32 nHeight,
-        BOOL vFlip)
+static INLINE BOOL planar_decompress_planes_raw(const BYTE* pSrcData[4], BYTE* pDstData,
+                                                UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst,
+                                                UINT32 nYDst, UINT32 nWidth, UINT32 nHeight,
+                                                BOOL vFlip)
 {
 	INT32 y;
 	INT32 beg, end, inc;
@@ -310,8 +309,7 @@ static INLINE BOOL planar_decompress_planes_raw(const BYTE* pSrcData[4],
 
 	for (y = beg; y != end; y += inc)
 	{
-		BYTE* pRGB = &pDstData[((nYDst + y) * nDstStep) + (nXDst * GetBytesPerPixel(
-		                                        DstFormat))];
+		BYTE* pRGB = &pDstData[((nYDst + y) * nDstStep) + (nXDst * GetBytesPerPixel(DstFormat))];
 
 		if (!writeLine(&pRGB, DstFormat, nWidth, &pR, &pG, &pB, &pA))
 			return FALSE;
@@ -320,12 +318,10 @@ static INLINE BOOL planar_decompress_planes_raw(const BYTE* pSrcData[4],
 	return TRUE;
 }
 
-BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar,
-                       const BYTE* pSrcData, UINT32 SrcSize,
-                       UINT32 nSrcWidth, UINT32 nSrcHeight,
-                       BYTE* pDstData, UINT32 DstFormat,
-                       UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
-                       UINT32 nDstWidth, UINT32 nDstHeight, BOOL vFlip)
+BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar, const BYTE* pSrcData, UINT32 SrcSize,
+                       UINT32 nSrcWidth, UINT32 nSrcHeight, BYTE* pDstData, UINT32 DstFormat,
+                       UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst, UINT32 nDstWidth,
+                       UINT32 nDstHeight, BOOL vFlip)
 {
 	BOOL cs;
 	BOOL rle;
@@ -368,7 +364,8 @@ BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar,
 	if (alpha)
 		useAlpha = ColorHasAlpha(DstFormat);
 
-	//WLog_INFO(TAG, "CLL: %"PRIu32" CS: %"PRIu8" RLE: %"PRIu8" ALPHA: %"PRIu8"", cll, cs, rle, alpha);
+	// WLog_INFO(TAG, "CLL: %"PRIu32" CS: %"PRIu8" RLE: %"PRIu8" ALPHA: %"PRIu8"", cll, cs, rle,
+	// alpha);
 
 	if (!cll && cs)
 		return FALSE; /* Chroma subsampling requires YCoCg */
@@ -416,7 +413,7 @@ BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar,
 			if ((SrcSize - (srcp - pSrcData)) < (planeSize * 4))
 				return FALSE;
 
-			planes[3] = srcp; /* AlphaPlane */
+			planes[3] = srcp;                    /* AlphaPlane */
 			planes[0] = planes[3] + rawSizes[3]; /* LumaOrRedPlane */
 			planes[1] = planes[0] + rawSizes[0]; /* OrangeChromaOrGreenPlane */
 			planes[2] = planes[1] + rawSizes[1]; /* GreenChromaOrBluePlane */
@@ -429,7 +426,7 @@ BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar,
 			if ((SrcSize - (srcp - pSrcData)) < (planeSize * 3))
 				return FALSE;
 
-			planes[0] = srcp; /* LumaOrRedPlane */
+			planes[0] = srcp;                    /* LumaOrRedPlane */
 			planes[1] = planes[0] + rawSizes[0]; /* OrangeChromaOrGreenPlane */
 			planes[2] = planes[1] + rawSizes[1]; /* GreenChromaOrBluePlane */
 
@@ -485,8 +482,7 @@ BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar,
 		else
 			TempFormat = PIXEL_FORMAT_BGRX32;
 
-		if ((TempFormat != DstFormat) || (nSrcWidth != nDstWidth)
-		    || (nSrcHeight != nDstHeight))
+		if ((TempFormat != DstFormat) || (nSrcWidth != nDstWidth) || (nSrcHeight != nDstHeight))
 		{
 			pTempData = planar->pTempData;
 			nTempStep = planar->nTempStep;
@@ -494,8 +490,8 @@ BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar,
 
 		if (!rle) /* RAW */
 		{
-			if (!planar_decompress_planes_raw(planes, pTempData, TempFormat, nTempStep,
-			                                  nXDst, nYDst, nSrcWidth, nSrcHeight, vFlip))
+			if (!planar_decompress_planes_raw(planes, pTempData, TempFormat, nTempStep, nXDst,
+			                                  nYDst, nSrcWidth, nSrcHeight, vFlip))
 				return FALSE;
 
 			if (alpha)
@@ -508,23 +504,23 @@ BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar,
 		}
 		else /* RLE */
 		{
-			status = planar_decompress_plane_rle(planes[0], rleSizes[0],
-			                                     pTempData, nTempStep, nXDst, nYDst, nSrcWidth, nSrcHeight, 2,
-			                                     vFlip); /* RedPlane */
+			status =
+			    planar_decompress_plane_rle(planes[0], rleSizes[0], pTempData, nTempStep, nXDst,
+			                                nYDst, nSrcWidth, nSrcHeight, 2, vFlip); /* RedPlane */
 
 			if (status < 0)
 				return FALSE;
 
-			status = planar_decompress_plane_rle(planes[1], rleSizes[1],
-			                                     pTempData, nTempStep, nXDst, nYDst, nSrcWidth, nSrcHeight, 1,
+			status = planar_decompress_plane_rle(planes[1], rleSizes[1], pTempData, nTempStep,
+			                                     nXDst, nYDst, nSrcWidth, nSrcHeight, 1,
 			                                     vFlip); /* GreenPlane */
 
 			if (status < 0)
 				return FALSE;
 
-			status = planar_decompress_plane_rle(planes[2], rleSizes[2],
-			                                     pTempData, nTempStep, nXDst, nYDst, nSrcWidth, nSrcHeight, 0,
-			                                     vFlip); /* BluePlane */
+			status =
+			    planar_decompress_plane_rle(planes[2], rleSizes[2], pTempData, nTempStep, nXDst,
+			                                nYDst, nSrcWidth, nSrcHeight, 0, vFlip); /* BluePlane */
 
 			if (status < 0)
 				return FALSE;
@@ -533,8 +529,8 @@ BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar,
 
 			if (useAlpha)
 			{
-				status = planar_decompress_plane_rle(planes[3], rleSizes[3],
-				                                     pTempData, nTempStep, nXDst, nYDst, nSrcWidth, nSrcHeight, 3,
+				status = planar_decompress_plane_rle(planes[3], rleSizes[3], pTempData, nTempStep,
+				                                     nXDst, nYDst, nSrcWidth, nSrcHeight, 3,
 				                                     vFlip); /* AlphaPlane */
 
 				if (status < 0)
@@ -547,8 +543,7 @@ BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar,
 
 		if (pTempData != pDstData)
 		{
-			if (!freerdp_image_copy(pDstData, DstFormat, nDstStep, nXDst, nYDst, w,
-			                        h, pTempData,
+			if (!freerdp_image_copy(pDstData, DstFormat, nDstStep, nXDst, nYDst, w, h, pTempData,
 			                        TempFormat, nTempStep, nXDst, nYDst, NULL, FREERDP_FLIP_NONE))
 				return FALSE;
 		}
@@ -575,8 +570,8 @@ BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar,
 
 		if (!rle) /* RAW */
 		{
-			if (!planar_decompress_planes_raw(planes, pTempData, TempFormat, nTempStep,
-			                                  nXDst, nYDst, nSrcWidth, nSrcHeight, vFlip))
+			if (!planar_decompress_planes_raw(planes, pTempData, TempFormat, nTempStep, nXDst,
+			                                  nYDst, nSrcWidth, nSrcHeight, vFlip))
 				return FALSE;
 
 			if (alpha)
@@ -591,8 +586,8 @@ BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar,
 		{
 			if (useAlpha)
 			{
-				status = planar_decompress_plane_rle(planes[3], rleSizes[3],
-				                                     pTempData, nTempStep, nXDst, nYDst, nSrcWidth, nSrcHeight, 3,
+				status = planar_decompress_plane_rle(planes[3], rleSizes[3], pTempData, nTempStep,
+				                                     nXDst, nYDst, nSrcWidth, nSrcHeight, 3,
 				                                     vFlip); /* AlphaPlane */
 
 				if (status < 0)
@@ -602,22 +597,22 @@ BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar,
 			if (alpha)
 				srcp += rleSizes[3];
 
-			status = planar_decompress_plane_rle(planes[0], rleSizes[0],
-			                                     pTempData, nTempStep, nXDst, nYDst, nSrcWidth, nSrcHeight, 2,
-			                                     vFlip); /* LumaPlane */
+			status =
+			    planar_decompress_plane_rle(planes[0], rleSizes[0], pTempData, nTempStep, nXDst,
+			                                nYDst, nSrcWidth, nSrcHeight, 2, vFlip); /* LumaPlane */
 
 			if (status < 0)
 				return FALSE;
 
-			status = planar_decompress_plane_rle(planes[1], rleSizes[1],
-			                                     pTempData, nTempStep, nXDst, nYDst, nSrcWidth, nSrcHeight, 1,
+			status = planar_decompress_plane_rle(planes[1], rleSizes[1], pTempData, nTempStep,
+			                                     nXDst, nYDst, nSrcWidth, nSrcHeight, 1,
 			                                     vFlip); /* OrangeChromaPlane */
 
 			if (status < 0)
 				return FALSE;
 
-			status = planar_decompress_plane_rle(planes[2], rleSizes[2],
-			                                     pTempData, nTempStep, nXDst, nYDst, nSrcWidth, nSrcHeight, 0,
+			status = planar_decompress_plane_rle(planes[2], rleSizes[2], pTempData, nTempStep,
+			                                     nXDst, nYDst, nSrcWidth, nSrcHeight, 0,
 			                                     vFlip); /* GreenChromaPlane */
 
 			if (status < 0)
@@ -626,18 +621,16 @@ BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar,
 			srcp += rleSizes[0] + rleSizes[1] + rleSizes[2];
 		}
 
-		if (prims->YCoCgToRGB_8u_AC4R(pTempData, nTempStep, pDstData, DstFormat,
-		                              nDstStep,
-		                              w, h, cll, useAlpha) != PRIMITIVES_SUCCESS)
+		if (prims->YCoCgToRGB_8u_AC4R(pTempData, nTempStep, pDstData, DstFormat, nDstStep, w, h,
+		                              cll, useAlpha) != PRIMITIVES_SUCCESS)
 			return FALSE;
 	}
 
 	return (SrcSize == (srcp - pSrcData)) ? TRUE : FALSE;
 }
 
-static INLINE BOOL freerdp_split_color_planes(const BYTE* data, UINT32 format,
-        UINT32 width, UINT32 height,
-        UINT32 scanline, BYTE* planes[4])
+static INLINE BOOL freerdp_split_color_planes(const BYTE* data, UINT32 format, UINT32 width,
+                                              UINT32 height, UINT32 scanline, BYTE* planes[4])
 {
 	INT32 i, j, k;
 	if ((width > INT32_MAX) || (height > INT32_MAX) || (scanline > INT32_MAX))
@@ -656,8 +649,8 @@ static INLINE BOOL freerdp_split_color_planes(const BYTE* data, UINT32 format,
 		{
 			const UINT32 color = ReadColor(pixel, format);
 			pixel += GetBytesPerPixel(format);
-			SplitColor(color, format, &planes[1][k], &planes[2][k],
-			           &planes[3][k], &planes[0][k], NULL);
+			SplitColor(color, format, &planes[1][k], &planes[2][k], &planes[3][k], &planes[0][k],
+			           NULL);
 			k++;
 		}
 	}
@@ -665,9 +658,9 @@ static INLINE BOOL freerdp_split_color_planes(const BYTE* data, UINT32 format,
 	return TRUE;
 }
 
-static INLINE UINT32 freerdp_bitmap_planar_write_rle_bytes(
-    const BYTE* pInBuffer, UINT32 cRawBytes, UINT32 nRunLength,
-    BYTE* pOutBuffer, UINT32 outBufferSize)
+static INLINE UINT32 freerdp_bitmap_planar_write_rle_bytes(const BYTE* pInBuffer, UINT32 cRawBytes,
+                                                           UINT32 nRunLength, BYTE* pOutBuffer,
+                                                           UINT32 outBufferSize)
 {
 	const BYTE* pInput;
 	BYTE* pOutput;
@@ -780,9 +773,8 @@ static INLINE UINT32 freerdp_bitmap_planar_write_rle_bytes(
 }
 
 static INLINE UINT32 freerdp_bitmap_planar_encode_rle_bytes(const BYTE* pInBuffer,
-        UINT32 inBufferSize,
-        BYTE* pOutBuffer,
-        UINT32 outBufferSize)
+                                                            UINT32 inBufferSize, BYTE* pOutBuffer,
+                                                            UINT32 outBufferSize)
 {
 	BYTE symbol;
 	const BYTE* pInput;
@@ -823,10 +815,8 @@ static INLINE UINT32 freerdp_bitmap_planar_encode_rle_bytes(const BYTE* pInBuffe
 			else
 			{
 				pBytes = pInput - (cRawBytes + nRunLength + 1);
-				nBytesWritten = freerdp_bitmap_planar_write_rle_bytes(
-				                    pBytes, cRawBytes,
-				                    nRunLength, pOutput,
-				                    outBufferSize);
+				nBytesWritten = freerdp_bitmap_planar_write_rle_bytes(pBytes, cRawBytes, nRunLength,
+				                                                      pOutput, outBufferSize);
 				nRunLength = 0;
 
 				if (!nBytesWritten || (nBytesWritten > outBufferSize))
@@ -841,14 +831,13 @@ static INLINE UINT32 freerdp_bitmap_planar_encode_rle_bytes(const BYTE* pInBuffe
 
 		nRunLength += bSymbolMatch;
 		cRawBytes += (!bSymbolMatch) ? TRUE : FALSE;
-	}
-	while (outBufferSize);
+	} while (outBufferSize);
 
 	if (cRawBytes || nRunLength)
 	{
 		pBytes = pInput - (cRawBytes + nRunLength);
-		nBytesWritten = freerdp_bitmap_planar_write_rle_bytes(pBytes,
-		                cRawBytes, nRunLength, pOutput, outBufferSize);
+		nBytesWritten = freerdp_bitmap_planar_write_rle_bytes(pBytes, cRawBytes, nRunLength,
+		                                                      pOutput, outBufferSize);
 
 		if (!nBytesWritten)
 			return 0;
@@ -862,9 +851,8 @@ static INLINE UINT32 freerdp_bitmap_planar_encode_rle_bytes(const BYTE* pInBuffe
 	return nTotalBytesWritten;
 }
 
-BOOL freerdp_bitmap_planar_compress_plane_rle(const BYTE* inPlane,
-        UINT32 width, UINT32 height,
-        BYTE* outPlane, UINT32* dstSize)
+BOOL freerdp_bitmap_planar_compress_plane_rle(const BYTE* inPlane, UINT32 width, UINT32 height,
+                                              BYTE* outPlane, UINT32* dstSize)
 {
 	UINT32 index;
 	const BYTE* pInput;
@@ -884,8 +872,8 @@ BOOL freerdp_bitmap_planar_compress_plane_rle(const BYTE* inPlane,
 
 	while (outBufferSize)
 	{
-		nBytesWritten = freerdp_bitmap_planar_encode_rle_bytes(
-		                    pInput, width, pOutput, outBufferSize);
+		nBytesWritten =
+		    freerdp_bitmap_planar_encode_rle_bytes(pInput, width, pOutput, outBufferSize);
 
 		if ((!nBytesWritten) || (nBytesWritten > outBufferSize))
 			return FALSE;
@@ -904,9 +892,9 @@ BOOL freerdp_bitmap_planar_compress_plane_rle(const BYTE* inPlane,
 	return TRUE;
 }
 
-static INLINE BOOL freerdp_bitmap_planar_compress_planes_rle(
-    BYTE* inPlanes[4], UINT32 width, UINT32 height,
-    BYTE* outPlanes, UINT32* dstSizes, BOOL skipAlpha)
+static INLINE BOOL freerdp_bitmap_planar_compress_planes_rle(BYTE* inPlanes[4], UINT32 width,
+                                                             UINT32 height, BYTE* outPlanes,
+                                                             UINT32* dstSizes, BOOL skipAlpha)
 {
 	UINT32 outPlanesSize = width * height * 4;
 
@@ -919,8 +907,8 @@ static INLINE BOOL freerdp_bitmap_planar_compress_planes_rle(
 	{
 		dstSizes[0] = outPlanesSize;
 
-		if (!freerdp_bitmap_planar_compress_plane_rle(
-		        inPlanes[0], width, height, outPlanes, &dstSizes[0]))
+		if (!freerdp_bitmap_planar_compress_plane_rle(inPlanes[0], width, height, outPlanes,
+		                                              &dstSizes[0]))
 			return FALSE;
 
 		outPlanes += dstSizes[0];
@@ -930,8 +918,8 @@ static INLINE BOOL freerdp_bitmap_planar_compress_planes_rle(
 	/* LumaOrRedPlane */
 	dstSizes[1] = outPlanesSize;
 
-	if (!freerdp_bitmap_planar_compress_plane_rle(inPlanes[1], width, height,
-	        outPlanes, &dstSizes[1]))
+	if (!freerdp_bitmap_planar_compress_plane_rle(inPlanes[1], width, height, outPlanes,
+	                                              &dstSizes[1]))
 		return FALSE;
 
 	outPlanes += dstSizes[1];
@@ -939,8 +927,8 @@ static INLINE BOOL freerdp_bitmap_planar_compress_planes_rle(
 	/* OrangeChromaOrGreenPlane */
 	dstSizes[2] = outPlanesSize;
 
-	if (!freerdp_bitmap_planar_compress_plane_rle(inPlanes[2], width, height,
-	        outPlanes, &dstSizes[2]))
+	if (!freerdp_bitmap_planar_compress_plane_rle(inPlanes[2], width, height, outPlanes,
+	                                              &dstSizes[2]))
 		return FALSE;
 
 	outPlanes += dstSizes[2];
@@ -948,29 +936,28 @@ static INLINE BOOL freerdp_bitmap_planar_compress_planes_rle(
 	/* GreenChromeOrBluePlane */
 	dstSizes[3] = outPlanesSize;
 
-	if (!freerdp_bitmap_planar_compress_plane_rle(inPlanes[3], width, height,
-	        outPlanes, &dstSizes[3]))
+	if (!freerdp_bitmap_planar_compress_plane_rle(inPlanes[3], width, height, outPlanes,
+	                                              &dstSizes[3]))
 		return FALSE;
 
 	return TRUE;
 }
 
-BYTE* freerdp_bitmap_planar_delta_encode_plane(const BYTE* inPlane,
-        UINT32 width, UINT32 height,
-        BYTE* outPlane)
+BYTE* freerdp_bitmap_planar_delta_encode_plane(const BYTE* inPlane, UINT32 width, UINT32 height,
+                                               BYTE* outPlane)
 {
 	char s2c;
 	INT32 delta;
 	UINT32 y, x;
 	BYTE* outPtr;
-	const BYTE* srcPtr, *prevLinePtr;
+	const BYTE *srcPtr, *prevLinePtr;
 
 	if (!outPlane)
 	{
 		if (width * height == 0)
 			return NULL;
 
-		if (!(outPlane = (BYTE*) calloc(height, width)))
+		if (!(outPlane = (BYTE*)calloc(height, width)))
 			return NULL;
 	}
 
@@ -985,8 +972,8 @@ BYTE* freerdp_bitmap_planar_delta_encode_plane(const BYTE* inPlane,
 		for (x = 0; x < width; x++, outPtr++, srcPtr++, prevLinePtr++)
 		{
 			delta = *srcPtr - *prevLinePtr;
-			s2c = (delta >= 0) ? (char) delta : (char)(~((BYTE)(-delta)) + 1);
-			s2c = (s2c >= 0) ? (s2c << 1) : (char)(((~((BYTE) s2c) + 1) << 1) - 1);
+			s2c = (delta >= 0) ? (char)delta : (char)(~((BYTE)(-delta)) + 1);
+			s2c = (s2c >= 0) ? (s2c << 1) : (char)(((~((BYTE)s2c) + 1) << 1) - 1);
 			*outPtr = (BYTE)s2c;
 		}
 	}
@@ -994,16 +981,15 @@ BYTE* freerdp_bitmap_planar_delta_encode_plane(const BYTE* inPlane,
 	return outPlane;
 }
 
-static INLINE BOOL freerdp_bitmap_planar_delta_encode_planes(BYTE* inPlanes[4],
-        UINT32 width, UINT32 height,
-        BYTE* outPlanes[4])
+static INLINE BOOL freerdp_bitmap_planar_delta_encode_planes(BYTE* inPlanes[4], UINT32 width,
+                                                             UINT32 height, BYTE* outPlanes[4])
 {
 	UINT32 i;
 
 	for (i = 0; i < 4; i++)
 	{
-		outPlanes[i] = freerdp_bitmap_planar_delta_encode_plane(
-		                   inPlanes[i], width, height, outPlanes[i]);
+		outPlanes[i] =
+		    freerdp_bitmap_planar_delta_encode_plane(inPlanes[i], width, height, outPlanes[i]);
 
 		if (!outPlanes[i])
 			return FALSE;
@@ -1012,9 +998,8 @@ static INLINE BOOL freerdp_bitmap_planar_delta_encode_planes(BYTE* inPlanes[4],
 	return TRUE;
 }
 
-BYTE* freerdp_bitmap_compress_planar(BITMAP_PLANAR_CONTEXT* context,
-                                     const BYTE* data, UINT32 format,
-                                     UINT32 width, UINT32 height, UINT32 scanline,
+BYTE* freerdp_bitmap_compress_planar(BITMAP_PLANAR_CONTEXT* context, const BYTE* data,
+                                     UINT32 format, UINT32 width, UINT32 height, UINT32 scanline,
                                      BYTE* dstData, UINT32* pDstSize)
 {
 	UINT32 size;
@@ -1031,21 +1016,18 @@ BYTE* freerdp_bitmap_compress_planar(BITMAP_PLANAR_CONTEXT* context,
 
 	planeSize = width * height;
 
-	if (!freerdp_split_color_planes(data, format, width, height, scanline,
-	                                context->planes))
+	if (!freerdp_split_color_planes(data, format, width, height, scanline, context->planes))
 		return NULL;
 
 	if (context->AllowRunLengthEncoding)
 	{
-		if (!freerdp_bitmap_planar_delta_encode_planes(
-		        context->planes, width, height,
-		        context->deltaPlanes))
+		if (!freerdp_bitmap_planar_delta_encode_planes(context->planes, width, height,
+		                                               context->deltaPlanes))
 			return NULL;
 
-		if (!freerdp_bitmap_planar_compress_planes_rle(
-		        context->deltaPlanes, width, height,
-		        context->rlePlanesBuffer, dstSizes,
-		        context->AllowSkipAlpha))
+		if (!freerdp_bitmap_planar_compress_planes_rle(context->deltaPlanes, width, height,
+		                                               context->rlePlanesBuffer, dstSizes,
+		                                               context->AllowSkipAlpha))
 			return NULL;
 
 		{
@@ -1058,8 +1040,9 @@ BYTE* freerdp_bitmap_compress_planar(BITMAP_PLANAR_CONTEXT* context,
 			context->rlePlanes[2] = &context->rlePlanesBuffer[offset];
 			offset += dstSizes[2];
 			context->rlePlanes[3] = &context->rlePlanesBuffer[offset];
-			//WLog_DBG(TAG, "R: [%"PRIu32"/%"PRIu32"] G: [%"PRIu32"/%"PRIu32"] B: [%"PRIu32"/%"PRIu32"]",
-			//		dstSizes[1], planeSize, dstSizes[2], planeSize, dstSizes[3], planeSize);
+			// WLog_DBG(TAG, "R: [%"PRIu32"/%"PRIu32"] G: [%"PRIu32"/%"PRIu32"] B:
+			// [%"PRIu32"/%"PRIu32"]", 		dstSizes[1], planeSize, dstSizes[2], planeSize, dstSizes[3],
+			//planeSize);
 		}
 	}
 
@@ -1181,8 +1164,8 @@ BYTE* freerdp_bitmap_compress_planar(BITMAP_PLANAR_CONTEXT* context,
 	return dstData;
 }
 
-BOOL freerdp_bitmap_planar_context_reset(
-    BITMAP_PLANAR_CONTEXT* context, UINT32 width, UINT32 height)
+BOOL freerdp_bitmap_planar_context_reset(BITMAP_PLANAR_CONTEXT* context, UINT32 width,
+                                         UINT32 height)
 {
 	if (!context)
 		return FALSE;
@@ -1200,30 +1183,26 @@ BOOL freerdp_bitmap_planar_context_reset(
 	context->deltaPlanesBuffer = calloc(context->maxPlaneSize, 4);
 	context->rlePlanesBuffer = calloc(context->maxPlaneSize, 4);
 
-	if (!context->planesBuffer || !context->pTempData ||
-	    !context->deltaPlanesBuffer || !context->rlePlanesBuffer)
+	if (!context->planesBuffer || !context->pTempData || !context->deltaPlanesBuffer ||
+	    !context->rlePlanesBuffer)
 		return FALSE;
 
 	context->planes[0] = &context->planesBuffer[context->maxPlaneSize * 0];
 	context->planes[1] = &context->planesBuffer[context->maxPlaneSize * 1];
 	context->planes[2] = &context->planesBuffer[context->maxPlaneSize * 2];
 	context->planes[3] = &context->planesBuffer[context->maxPlaneSize * 3];
-	context->deltaPlanes[0] = &context->deltaPlanesBuffer[context->maxPlaneSize *
-	                          0];
-	context->deltaPlanes[1] = &context->deltaPlanesBuffer[context->maxPlaneSize *
-	                          1];
-	context->deltaPlanes[2] = &context->deltaPlanesBuffer[context->maxPlaneSize *
-	                          2];
-	context->deltaPlanes[3] = &context->deltaPlanesBuffer[context->maxPlaneSize *
-	                          3];
+	context->deltaPlanes[0] = &context->deltaPlanesBuffer[context->maxPlaneSize * 0];
+	context->deltaPlanes[1] = &context->deltaPlanesBuffer[context->maxPlaneSize * 1];
+	context->deltaPlanes[2] = &context->deltaPlanesBuffer[context->maxPlaneSize * 2];
+	context->deltaPlanes[3] = &context->deltaPlanesBuffer[context->maxPlaneSize * 3];
 	return TRUE;
 }
 
-BITMAP_PLANAR_CONTEXT* freerdp_bitmap_planar_context_new(
-    DWORD flags, UINT32 maxWidth, UINT32 maxHeight)
+BITMAP_PLANAR_CONTEXT* freerdp_bitmap_planar_context_new(DWORD flags, UINT32 maxWidth,
+                                                         UINT32 maxHeight)
 {
 	BITMAP_PLANAR_CONTEXT* context;
-	context = (BITMAP_PLANAR_CONTEXT*) calloc(1, sizeof(BITMAP_PLANAR_CONTEXT));
+	context = (BITMAP_PLANAR_CONTEXT*)calloc(1, sizeof(BITMAP_PLANAR_CONTEXT));
 
 	if (!context)
 		return NULL;


### PR DESCRIPTION
This PR initializes the alpha channel to FF. Before the alpha channel
contained uninitialized memory potentially causing problems when the
image data was used by an alpha channel aware frontend.