### PR TITLE
server/proxy: Bugfixes and code refactor

### DIFF
--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -183,8 +183,6 @@ static void pf_client_post_disconnect(freerdp* instance)
 {
 	pClientContext* context;
 	proxyData* pdata;
-	rdpContext* ps;
-	freerdp_peer* peer;
 
 	if (!instance)
 		return;
@@ -194,8 +192,6 @@ static void pf_client_post_disconnect(freerdp* instance)
 
 	context = (pClientContext*) instance->context;
 	pdata = context->pdata;
-	ps = (rdpContext*) pdata->ps;
-	peer = ps->peer;
 
 	PubSub_UnsubscribeChannelConnected(instance->context->pubSub,
 	                                   pf_OnChannelConnectedEventHandler);
@@ -204,13 +200,7 @@ static void pf_client_post_disconnect(freerdp* instance)
 	PubSub_UnsubscribeErrorInfo(instance->context->pubSub, pf_OnErrorInfo);
 	gdi_free(instance);
 
-	if (!pf_common_connection_aborted_by_peer(pdata))
-	{
-		SetEvent(pdata->connectionClosed);
-		WLog_INFO(TAG, "connectionClosed event is not set; closing connection with client");
-		peer->Disconnect(peer);
-	}
-
+	SetEvent(pdata->connectionClosed);
 	/* It's important to avoid calling `freerdp_peer_context_free` and `freerdp_peer_free` here,
 	 * in order to avoid double-free. Those objects will be freed by the server when needed.
 	 */

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -356,6 +356,22 @@ static BOOL pf_client_client_new(freerdp* instance, rdpContext* context)
 	return TRUE;
 }
 
+static int pf_client_client_stop(rdpContext* context)
+{
+	pClientContext* pc = (pClientContext*) context;
+	pServerContext* ps = pc->pdata->ps;
+	freerdp_abort_connect(context->instance);
+
+	if (ps->thread)
+	{
+		WaitForSingleObject(ps->thread, INFINITE);
+		CloseHandle(ps->thread);
+		ps->thread = NULL;
+	}
+
+	return 0;
+}
+
 int RdpClientEntry(RDP_CLIENT_ENTRY_POINTS* pEntryPoints)
 {
 	ZeroMemory(pEntryPoints, sizeof(RDP_CLIENT_ENTRY_POINTS));
@@ -365,6 +381,7 @@ int RdpClientEntry(RDP_CLIENT_ENTRY_POINTS* pEntryPoints)
 	pEntryPoints->ContextSize = sizeof(pClientContext);
 	/* Client init and finish */
 	pEntryPoints->ClientNew = pf_client_client_new;
+	pEntryPoints->ClientStop = pf_client_client_stop;
 	return 0;
 }
 

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -54,7 +54,7 @@
 #define TAG PROXY_TAG("client")
 
 /**
- * Re-negociate with original client after negociation between the proxy
+ * Re-negotiate with original client after negotiation between the proxy
  * and the target has finished.
  */
 static void proxy_server_reactivate(rdpContext* client, rdpContext* target)
@@ -75,7 +75,7 @@ static void pf_OnErrorInfo(void* ctx, ErrorInfoEventArgs* e)
 	if (e->code != ERRINFO_NONE)
 	{
 		const char* errorMessage = freerdp_get_error_info_string(e->code);
-		WLog_DBG(TAG, "Client received error info (0x%08"PRIu32"): %s", e->code, errorMessage);
+		WLog_WARN(TAG, "Proxy's client received error info pdu from server: (0x%08"PRIu32"): %s", e->code, errorMessage);
 		/* forward error back to client */
 		freerdp_set_error_info(ps->rdp, e->code);
 		freerdp_send_error_info(ps->rdp);
@@ -98,6 +98,8 @@ static BOOL pf_client_pre_connect(freerdp* instance)
 	 * Only override it if you plan to implement custom order
 	 * callbacks or deactiveate certain features.
 	 */
+
+	/* currently not supporting GDI orders */
 	ZeroMemory(instance->settings->OrderSupport, 32);
 
 	/**
@@ -127,7 +129,7 @@ static BOOL pf_client_pre_connect(freerdp* instance)
 
 /**
  * Called after a RDP connection was successfully established.
- * Settings might have changed during negociation of client / server feature
+ * Settings might have changed during negotiation of client / server feature
  * support.
  *
  * Set up local framebuffers and painting callbacks.

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -142,13 +142,20 @@ static BOOL pf_client_post_connect(freerdp* instance)
 	pClientContext* pc;
 	rdpContext* ps;
 
-	if (!gdi_init(instance, PIXEL_FORMAT_XRGB32))
-		return FALSE;
-
 	context = instance->context;
 	settings = instance->settings;
 	update = instance->update;
 	pc = (pClientContext*) context;
+	ps = (rdpContext*) pc->pdata->ps;
+
+	if (!proxy_data_set_connection_info(pc->pdata, ps->settings, settings))
+	{
+		WLog_ERR(TAG, "proxy_data_set_connection_info failed!");
+		return FALSE;
+	}
+
+	if (!gdi_init(instance, PIXEL_FORMAT_XRGB32))
+		return FALSE;
 
 	if (!pf_register_pointer(context->graphics))
 		return FALSE;
@@ -170,7 +177,6 @@ static BOOL pf_client_post_connect(freerdp* instance)
 	}
 	
 	pf_client_register_update_callbacks(update);
-	ps = (rdpContext*) pc->pdata->ps;
 	proxy_server_reactivate(ps, context);
 	return TRUE;
 }

--- a/server/proxy/pf_context.c
+++ b/server/proxy/pf_context.c
@@ -159,16 +159,16 @@ proxyData* proxy_data_new()
 	return pdata;
 }
 
-BOOL proxy_data_set_connection_info(proxyData* pdata, rdpSettings* clientSettings,
-                                    const char* target)
+/* sets connection info values using the settings of both server & client */
+BOOL proxy_data_set_connection_info(proxyData* pdata, rdpSettings* ps, rdpSettings* pc)
 {
-	if (!(pdata->info->TargetHostname = _strdup(target)))
+	if (!(pdata->info->TargetHostname = _strdup(pc->ServerHostname)))
 		goto out_fail;
 
-	if (!(pdata->info->ClientHostname = _strdup(clientSettings->ClientHostname)))
+	if (!(pdata->info->Username = _strdup(pc->Username)))
 		goto out_fail;
 
-	if (!(pdata->info->Username = _strdup(clientSettings->Username)))
+	if (!(pdata->info->ClientHostname = _strdup(ps->ClientHostname)))
 		goto out_fail;
 
 	return TRUE;

--- a/server/proxy/pf_context.c
+++ b/server/proxy/pf_context.c
@@ -44,8 +44,16 @@ static void client_to_proxy_context_free(freerdp_peer* client,
 {
 	WINPR_UNUSED(client);
 
-	if (context)
-		WTSCloseServer((HANDLE) context->vcm);
+	if (!context)
+		return;
+
+	WTSCloseServer((HANDLE) context->vcm);
+
+	if (context->dynvcReady)
+	{
+		CloseHandle(context->dynvcReady);
+		context->dynvcReady = NULL;
+	}
 }
 
 BOOL init_p_server_context(freerdp_peer* client)
@@ -172,5 +180,11 @@ out_fail:
 void proxy_data_free(proxyData* pdata)
 {
 	connection_info_free(pdata->info);
+	if (pdata->connectionClosed)
+	{
+		CloseHandle(pdata->connectionClosed);
+		pdata->connectionClosed = NULL;
+	}
+
 	free(pdata);
 }

--- a/server/proxy/pf_context.h
+++ b/server/proxy/pf_context.h
@@ -90,8 +90,7 @@ struct proxy_data
 BOOL init_p_server_context(freerdp_peer* client);
 rdpContext* p_client_context_create(rdpSettings* clientSettings);
 proxyData* proxy_data_new();
-BOOL proxy_data_set_connection_info(proxyData* pdata, rdpSettings* clientSettings,
-                                    const char* target);
+BOOL proxy_data_set_connection_info(proxyData* pdata, rdpSettings* ps, rdpSettings* pc);
 void proxy_data_free(proxyData* pdata);
 
 #endif /* FREERDP_SERVER_PROXY_PFCONTEXT_H */

--- a/server/proxy/pf_disp.c
+++ b/server/proxy/pf_disp.c
@@ -24,7 +24,7 @@ static UINT pf_disp_monitor_layout(DispServerContext* context,
 {
 	proxyData* pdata = (proxyData*) context->custom;
 	DispClientContext* client = (DispClientContext*) pdata->pc->disp;
-	WLog_INFO(TAG, __FUNCTION__);
+	WLog_DBG(TAG, __FUNCTION__);
 	return client->SendMonitorLayout(client, pdu->NumMonitors, pdu->Monitors);
 }
 
@@ -34,7 +34,7 @@ static UINT pf_disp_on_caps_control(DispClientContext* context, UINT32 MaxNumMon
 {
 	proxyData* pdata = (proxyData*) context->custom;
 	DispServerContext* server = (DispServerContext*) pdata->ps->disp;
-	WLog_INFO(TAG, __FUNCTION__);
+	WLog_DBG(TAG, __FUNCTION__);
 	/* Update caps of proxy's disp server */
 	server->MaxMonitorAreaFactorA = MaxMonitorAreaFactorA;
 	server->MaxMonitorAreaFactorB = MaxMonitorAreaFactorB;

--- a/server/proxy/pf_filters.c
+++ b/server/proxy/pf_filters.c
@@ -121,7 +121,9 @@ PF_FILTER_RESULT pf_filters_run_by_type(filters_list* list, PF_FILTER_TYPE type,
 
 static void pf_filters_filter_free(proxyFilter* filter)
 {
-	assert(filter != NULL);
+	if (!filter)
+		return;
+
 	if (filter->handle)
 		FreeLibrary(filter->handle);
 

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -176,12 +176,6 @@ static BOOL pf_server_post_connect(freerdp_peer* client)
 		return FALSE;
 	}
 
-	if (!proxy_data_set_connection_info(pdata, client->settings, pc->settings->ServerHostname))
-	{
-		WLog_ERR(TAG, "proxy_data_set_connection_info failed!");
-		return FALSE;
-	}
-
 	pf_server_rdpgfx_init(ps);
 	pf_server_disp_init(ps);
 

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -366,12 +366,15 @@ fail:
 		disp_server_context_free(ps->disp);
 	}
 
+	if (ps->gfx)
+		rdpgfx_server_context_free(ps->gfx);
+		
 	if (client->connected && !pf_common_connection_aborted_by_peer(pdata))
 	{
 		pf_server_handle_client_disconnection(client);
 	}
 
-	pc = (rdpContext*)pdata->pc;
+	pc = (rdpContext*) pdata->pc;
 	freerdp_client_stop(pc);
 	proxy_data_free(pdata);
 	freerdp_client_context_free(pc);

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -156,11 +156,15 @@ static BOOL pf_server_post_connect(freerdp_peer* client)
 	pServerContext* ps;
 	rdpContext* pc;
 	proxyData* pdata;
-
 	ps = (pServerContext*)client->context;
 	pdata = ps->pdata;
 
 	pc = p_client_context_create(client->settings);
+	if (pc == NULL)
+	{
+		WLog_ERR(TAG, "pf_server_post_connect(): p_client_context_create failed!");
+		return FALSE;
+	}
 
 	/* keep both sides of the connection in pdata */
 	((pClientContext*)pc)->pdata = ps->pdata;

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -55,13 +55,10 @@
 
 static void pf_server_handle_client_disconnection(freerdp_peer* client)
 {
-	pServerContext* ps;
-	proxyData* pdata;
-	rdpContext* pc;
-	ps = (pServerContext*)client->context;
-	pc = (rdpContext*) ps->pdata->pc;
-	pdata = ps->pdata;
-	WLog_INFO(TAG, "Client %s disconnected; closing proxy's client <> target server connection %s",
+	pServerContext* ps = (pServerContext*)client->context;
+	rdpContext* pc = (rdpContext*) ps->pdata->pc;
+	proxyData* pdata = ps->pdata;
+	WLog_INFO(TAG, "Connection with %s was closed; closing proxy's client <> target server connection %s",
 	          client->hostname, pc->settings->ServerHostname);
 	/* Mark connection closed for sContext */
 	SetEvent(pdata->connectionClosed);
@@ -70,6 +67,7 @@ static void pf_server_handle_client_disconnection(freerdp_peer* client)
 	WLog_DBG(TAG, "Waiting for proxy's client thread to finish");
 	WaitForSingleObject(ps->thread, INFINITE);
 	CloseHandle(ps->thread);
+	ps->thread = NULL;
 }
 
 static BOOL pf_server_parse_target_from_routing_token(rdpContext* context,

--- a/server/proxy/pf_update.c
+++ b/server/proxy/pf_update.c
@@ -82,6 +82,8 @@ static BOOL pf_client_desktop_resize(rdpContext* context)
 	pClientContext* pc = (pClientContext*) context;
 	proxyData* pdata = pc->pdata;
 	rdpContext* ps = (rdpContext*)pdata->ps;
+	ps->settings->DesktopWidth = context->settings->DesktopWidth;
+	ps->settings->DesktopHeight = context->settings->DesktopHeight;
 	return ps->update->DesktopResize(ps);
 }
 


### PR DESCRIPTION
This PR fixes some bugs & memory leaks, and refactors some of the code:

* Race conditions that caused a segfault
* Memory leaks
* `RdpgfxServerContext` was never free()'ed by the server
* Some handles that were never closed by the server
* Logs improvements
* Some mistakes in comments fixed

@speidy feel free to review
@akallabeth @hardening when this PR will be merged, please consider not squashing the commits, they have meaning