### PR TITLE
Declare support for multimon in proxy server.

### DIFF
--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -245,6 +245,7 @@ static DWORD WINAPI pf_server_handle_client(LPVOID arg)
 	/* keep configuration in proxyData */
 	pdata->config = client->ContextExtra;
 	config = pdata->config;
+	client->settings->UseMultimon = TRUE;
 	client->settings->SupportGraphicsPipeline = config->GFX;
 	client->settings->SupportDynamicChannels = TRUE;
 	client->settings->CertificateFile = _strdup("server.crt");


### PR DESCRIPTION
Unfortunately, by mistake, in the DISP PR the multimon was broken (the `UseMultimon` was set to FALSE, then `gcc_write_client_monitor_data` wasn't called).
This PR fixes it.