### PR TITLE
rail: Fixes incorrect setting of TS_RAIL_EXEC_FLAG_FILE

### DIFF
--- a/channels/rail/client/rail_main.c
+++ b/channels/rail/client/rail_main.c
@@ -127,12 +127,6 @@ static UINT rail_client_execute(RailClientContext* context,
 	if (!exeOrFile)
 		return ERROR_INVALID_PARAMETER;
 
-	if (strnlen(exeOrFile, MAX_PATH) >= 2)
-	{
-		if (strncmp(exeOrFile, "||", 2) != 0)
-			flags |= TS_RAIL_EXEC_FLAG_FILE;
-	}
-
 	if (!rail_string_to_unicode_string(exec->RemoteApplicationProgram,
 	                                   &ruExeOrFile) || /* RemoteApplicationProgram */
 	    !rail_string_to_unicode_string(exec->RemoteApplicationWorkingDir,


### PR DESCRIPTION
The TS_RAIL_EXEC_FLAG should only be set if ExeOrFile refers to a file
path. If we don't supply a published app name (using ||) but the name of
an application (i.e. notepad.exe) this flag was incorrectly set causing
an remote app execution error (error 5 - file not found).