### PR TITLE
server: proxy: implement NLA fallback

### DIFF
--- a/server/proxy/pf_context.h
+++ b/server/proxy/pf_context.h
@@ -68,6 +68,15 @@ struct p_client_context
 	RdpeiClientContext* rdpei;
 	RdpgfxClientContext* gfx;
 	DispClientContext* disp;
+
+	/*
+	 * Used for NLA fallback feature, to check if the server should close the connection.
+	 * When it is set to TRUE, proxy's client knows it shouldn't signal the server thread to closed
+	 * the connection when pf_client_post_disconnect is called, because it is trying to connect reconnect without NLA.
+	 * It must be set to TRUE before the first try, and to FALSE after the connection fully established,
+	 * to ensure graceful shutdown of the connection when it will be closed.
+	 */
+	BOOL during_connect_process;
 };
 typedef struct p_client_context pClientContext;
 


### PR DESCRIPTION
This PR contains a feature we called "NLA Fallback", which means that if the proxy's client fails to connect with NLA, it then tries to connect without NLA (using only TlsSecurity). We need this because there's a domain policy that disables NTLM then there are some computers that the proxy can't connect to them (because it tries NLA and fails).