### PR TITLE
wlfreerdp: Bring Wayland support into a working condition

### DIFF
--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -114,7 +114,7 @@ static BOOL wl_update_buffer(wlfContext* context_w, INT32 ix, INT32 iy, INT32 iw
 	if (UwacWindowAddDamage(context_w->window, x, y, w, h) != UWAC_SUCCESS)
 		return FALSE;
 
-	if (UwacWindowSubmitBuffer(context_w->window, true) != UWAC_SUCCESS)
+	if (UwacWindowSubmitBuffer(context_w->window, false) != UWAC_SUCCESS)
 		return FALSE;
 
 	return TRUE;
@@ -319,7 +319,7 @@ static BOOL handle_uwac_events(freerdp* instance, UwacDisplay* display)
 				break;
 
 			case UWAC_EVENT_FRAME_DONE:
-				if (UwacWindowSubmitBuffer(context->window, true) != UWAC_SUCCESS)
+				if (UwacWindowSubmitBuffer(context->window, false) != UWAC_SUCCESS)
 					return FALSE;
 
 				break;

--- a/uwac/libuwac/uwac-priv.h
+++ b/uwac/libuwac/uwac-priv.h
@@ -204,6 +204,7 @@ struct uwac_seat {
 /** @brief a buffer used for drawing a surface frame */
 struct uwac_buffer {
 	bool used;
+	bool dirty;
 #ifdef HAVE_PIXMAN_REGION
 	pixman_region32_t damage;
 #else

--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -619,16 +619,13 @@ static const struct wl_callback_listener frame_listener =
 
 static void UwacSubmitBufferPtr(UwacWindow* window, UwacBuffer* buffer)
 {
-#if 0
 	UINT32 nrects, i;
 #ifdef HAVE_PIXMAN_REGION
 	const pixman_box32_t* box;
 #else
 	const RECTANGLE_16* box;
 #endif
-#endif
 	wl_surface_attach(window->surface, buffer->wayland_buffer, 0, 0);
-#if 0
 #ifdef HAVE_PIXMAN_REGION
 	box = pixman_region32_rectangles(&buffer->damage, &nrects);
 
@@ -642,9 +639,6 @@ static void UwacSubmitBufferPtr(UwacWindow* window, UwacBuffer* buffer)
 		wl_surface_damage(window->surface, box->left, box->top, (box->right - box->left),
 		                  (box->bottom - box->top));
 
-#endif
-#else
-	wl_surface_damage(window->surface, 0, 0, window->width, window->height);
 #endif
 	struct wl_callback* frame_callback = wl_surface_frame(window->surface);
 	wl_callback_add_listener(frame_callback, &frame_listener, window);

--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -147,7 +147,9 @@ static void xdg_handle_toplevel_configure(void *data,
 			return;
 		}
 
-		window->drawingBuffer = window->pendingBuffer = &window->buffers[0];
+		window->drawingBuffer = &window->buffers[0];
+		if (window->pendingBuffer != NULL)
+			window->pendingBuffer = window->drawingBuffer;
 	}
 	else
 	{
@@ -230,7 +232,9 @@ static void ivi_handle_configure(void* data, struct ivi_surface* surface,
 			return;
 		}
 
-		window->drawingBuffer = window->pendingBuffer = &window->buffers[0];
+		window->drawingBuffer = &window->buffers[0];
+		if (window->pendingBuffer != NULL)
+			window->pendingBuffer = window->drawingBuffer;
 	}
 	else
 	{
@@ -286,7 +290,9 @@ void shell_configure(void* data, struct wl_shell_surface* surface, uint32_t edge
 			return;
 		}
 
-		window->drawingBuffer = window->pendingBuffer = &window->buffers[0];
+		window->drawingBuffer = &window->buffers[0];
+		if (window->pendingBuffer != NULL)
+			window->pendingBuffer = window->drawingBuffer;
 	}
 	else
 	{


### PR DESCRIPTION
wlfreerdp was unable to start. This was tested under sway, but would be the case for any compositor that adheres to the spec.

This PR brings wlfreerdp into a working state (i.e. can open an RDP connection, paint and interact with it), fixing the following issues:
1. Surface roles were never configured due to not ack'ing configure on our xdg_surface. This caused a window to never appear.
2. pendingBuffer was incorrectly set to a non-NULL value on configure, causing painting to bail as a non-NULL value indicated that a paint has occurred and that it should wait on a frame callback that would never arrive to clear the value. This caused the window to never be painted to.
3. Re-enable damage tracking code that was `#if 0`'d. This ensures that we're not giving the compositor unnecessary work.