### PR TITLE
Rdp sound

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3114,6 +3114,17 @@ BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 	UINT32 index;
 	ADDIN_ARGV* args;
 
+	if (settings->AudioPlayback)
+	{
+		char* p[] =
+		{
+			"rdpsnd"
+		};
+
+		if (!freerdp_client_add_static_channel(settings, ARRAYSIZE(p), p))
+			return FALSE;
+	}
+
 	if ((freerdp_static_channel_collection_find(settings, "rdpsnd")) ||
 	    (freerdp_dynamic_channel_collection_find(settings, "tsmf")))
 	{

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3125,6 +3125,17 @@ BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 			return FALSE;
 	}
 
+	if (settings->AudioCapture)
+	{
+		char* p[] =
+		{
+			"audin"
+		};
+
+		if (!freerdp_client_add_static_channel(settings, ARRAYSIZE(p), p))
+			return FALSE;
+	}
+
 	if ((freerdp_static_channel_collection_find(settings, "rdpsnd")) ||
 	    (freerdp_dynamic_channel_collection_find(settings, "tsmf")))
 	{

--- a/client/common/file.c
+++ b/client/common/file.c
@@ -1218,21 +1218,27 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 
 	if (~file->AudioMode)
 	{
-		if (file->AudioMode == AUDIO_MODE_REDIRECT)
+		switch(file->AudioMode)
 		{
-			if (!freerdp_settings_set_bool(settings, FreeRDP_AudioPlayback, TRUE))
-				return FALSE;
-		}
-		else if (file->AudioMode == AUDIO_MODE_PLAY_ON_SERVER)
-		{
-			if (!freerdp_settings_set_bool(settings, FreeRDP_RemoteConsoleAudio, TRUE))
-				return FALSE;
-		}
-		else if (file->AudioMode == AUDIO_MODE_NONE)
-		{
-			if (!freerdp_settings_set_bool(settings, FreeRDP_AudioPlayback, FALSE) ||
-			    !freerdp_settings_set_bool(settings, FreeRDP_RemoteConsoleAudio, FALSE))
-				return FALSE;
+			case AUDIO_MODE_REDIRECT:
+				if (!freerdp_settings_set_bool(settings, FreeRDP_RemoteConsoleAudio, FALSE))
+					return FALSE;
+				if (!freerdp_settings_set_bool(settings, FreeRDP_AudioPlayback, TRUE))
+					return FALSE;
+				break;
+			case AUDIO_MODE_PLAY_ON_SERVER:
+				if (!freerdp_settings_set_bool(settings, FreeRDP_RemoteConsoleAudio, TRUE))
+					return FALSE;
+				if (!freerdp_settings_set_bool(settings, FreeRDP_AudioPlayback, FALSE))
+					return FALSE;
+				break;
+			case AUDIO_MODE_NONE:
+			default:
+				if (!freerdp_settings_set_bool(settings, FreeRDP_AudioPlayback, FALSE))
+					return FALSE;
+				if (!freerdp_settings_set_bool(settings, FreeRDP_RemoteConsoleAudio, FALSE))
+					return FALSE;
+				break;
 		}
 	}
 

--- a/client/common/file.c
+++ b/client/common/file.c
@@ -789,6 +789,7 @@ BOOL freerdp_client_populate_rdp_file_from_settings(rdpFile* file, const rdpSett
 			file->AudioMode = AUDIO_MODE_NONE;
 	}
 
+	SETTING_MODIFIED_SET_BOOL(file->AudioCaptureMode, settings, AudioCapture);
 	SETTING_MODIFIED_SET_STRING(file->GatewayHostname, settings, GatewayHostname);
 	SETTING_MODIFIED_SET_STRING(file->GatewayAccessToken, settings, GatewayAccessToken);
 	SETTING_MODIFIED_SET(file->GatewayUsageMethod, settings, GatewayUsageMethod);
@@ -1240,6 +1241,12 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 					return FALSE;
 				break;
 		}
+	}
+
+	if (~file->AudioCaptureMode)
+	{
+		if (!freerdp_settings_set_bool(settings, FreeRDP_AudioCapture, file->AudioCaptureMode != 0))
+			return FALSE;
 	}
 
 	if (~file->Compression)


### PR DESCRIPTION
Ensure sound channel is loaded if settings require it in `freerdp_client_load_addins`