### PR TITLE
server: proxy: sync channels close

### DIFF
--- a/server/proxy/pf_channels.h
+++ b/server/proxy/pf_channels.h
@@ -25,9 +25,14 @@
 #include <freerdp/freerdp.h>
 #include <freerdp/client/channels.h>
 
+#include "pf_context.h"
+
 void pf_OnChannelConnectedEventHandler(void* context,
                                        ChannelConnectedEventArgs* e);
 void pf_OnChannelDisconnectedEventHandler(void* context,
         ChannelDisconnectedEventArgs* e);
+
+BOOL pf_server_channels_init(pServerContext* ps);
+void pf_server_channels_free(pServerContext* ps);
 
 #endif /* FREERDP_SERVER_PROXY_PFCHANNELS_H */

--- a/server/proxy/pf_context.h
+++ b/server/proxy/pf_context.h
@@ -50,8 +50,6 @@ struct p_server_context
 
 	RdpgfxServerContext* gfx;
 	DispServerContext* disp;
-
-	BOOL dispOpened;
 };
 typedef struct p_server_context pServerContext;
 

--- a/server/proxy/pf_rdpgfx.c
+++ b/server/proxy/pf_rdpgfx.c
@@ -202,7 +202,6 @@ static UINT pf_rdpgfx_on_open(RdpgfxClientContext* context,
                               BOOL* do_caps_advertise, BOOL* send_frame_acks)
 {
 	proxyData* pdata = (proxyData*) context->custom;
-	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
 	WLog_VRB(TAG, __FUNCTION__);
 
 	if (NULL != do_caps_advertise)
@@ -215,14 +214,7 @@ static UINT pf_rdpgfx_on_open(RdpgfxClientContext* context,
 	 * the GFX DYNVC. */
 	WLog_DBG(TAG, "Waiting for proxy's server dynvc to be ready");
 	WaitForSingleObject(pdata->ps->dynvcReady, INFINITE);
-
-	/* Check for error since the server's API doesn't return WTSAPI error codes */
-	if (server->Open(server))
-	{
-		return CHANNEL_RC_OK;
-	}
-
-	return CHANNEL_RC_INITIALIZATION_ERROR;
+	return CHANNEL_RC_OK;
 }
 
 static UINT pf_rdpgfx_caps_confirm(RdpgfxClientContext* context,


### PR DESCRIPTION
fixes #5495

- Whenever a client channel is closed, the suitable server channel is closed too
    - Also fixes TS redirection that caused a crash
- Before the server free()s its channels, it waits for client termination