### PR TITLE
client: xf_channels: remove unused settings variable

### DIFF
--- a/client/X11/xf_channels.c
+++ b/client/X11/xf_channels.c
@@ -37,7 +37,6 @@
 void xf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs* e)
 {
 	xfContext* xfc = (xfContext*) context;
-	rdpSettings* settings = xfc->context.settings;
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{


### PR DESCRIPTION
Can't and don't want to see a compiler warning about this even one more time ):