### PR TITLE
Proxy/config loader refactor

### DIFF
--- a/server/proxy/config.ini
+++ b/server/proxy/config.ini
@@ -18,19 +18,14 @@ Port = 3389
 Mouse = 1
 Keyboard = 1
 
-[Graphics]
-GFX = 1
-BitmapUpdate = 1
-
 [Security]
 NlaSecurity = 0
 TlsSecurity = 1
 RdpSecurity = 1
 
 [Channels]
-WhitelistMode = 0
-AllowedChannels = "cliprdr,Microsoft::Windows::RDS::Video::Control"
-DeniedChannels = "Microsoft::Windows::RDS::Geometry"
+GFX = 1
+DisplayControl = 1
 
 [Filters]
 ; FilterName = FilterPath

--- a/server/proxy/filters/filter_demo.c
+++ b/server/proxy/filters/filter_demo.c
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include <stdio.h>
+
 #include "filters_api.h"
 
 static PF_FILTER_RESULT demo_filter_keyboard_event(connectionInfo* info, void* param)
@@ -33,7 +35,8 @@ static PF_FILTER_RESULT demo_filter_mouse_event(connectionInfo* info, void* para
 
 	if (event_data->x % 100 == 0)
 	{
-		return FILTER_DROP;
+		printf("filter_demo: mouse x is currently %"PRIu16"\n", event_data->x);
+		return FILTER_PASS;
 	}
 
 	return FILTER_PASS;

--- a/server/proxy/filters/filters_api.h
+++ b/server/proxy/filters/filters_api.h
@@ -22,7 +22,10 @@
 #ifndef FREERDP_SERVER_PROXY_FILTERS_API_H
 #define FREERDP_SERVER_PROXY_FILTERS_API_H
 
+#include <freerdp/freerdp.h>
 #include <winpr/winpr.h>
+
+#define PROXY_API FREERDP_API
 
 enum pf_filter_result {
     FILTER_PASS = 0,
@@ -64,6 +67,6 @@ struct proxy_mouse_event_info {
 /* implement this method and register callbacks for proxy events
  * return TRUE if initialization succeeded, otherwise FALSE.
  **/
-BOOL filter_init(proxyEvents* events);
+PROXY_API BOOL filter_init(proxyEvents* events);
 
 #endif /* FREERDP_SERVER_PROXY_FILTERS_API_H */

--- a/server/proxy/freerdp_proxy.c
+++ b/server/proxy/freerdp_proxy.c
@@ -43,6 +43,7 @@ int main(int argc, char* argv[])
 	if (!pf_server_config_load(cfg, config))
 		goto fail;
 
+	pf_server_config_print(config);
 	status = pf_server_start(config);
 fail:
 	pf_server_config_free(config);

--- a/server/proxy/freerdp_proxy.c
+++ b/server/proxy/freerdp_proxy.c
@@ -32,9 +32,6 @@ int main(int argc, char* argv[])
 {
 	const char* cfg = "config.ini";
 	int status = 0;
-	DWORD ld;
-	UINT32 i;
-	UINT32 count;
 	proxyConfig* config = calloc(1, sizeof(proxyConfig));
 
 	if (!config)
@@ -43,38 +40,8 @@ int main(int argc, char* argv[])
 	if (argc > 1)
 		cfg = argv[1];
 
-	ld = pf_server_load_config(cfg, config);
-
-	switch (ld)
-	{
-		case CONFIG_PARSE_SUCCESS:
-			WLog_DBG(TAG, "Configuration parsed successfully");
-			break;
-
-		case CONFIG_PARSE_ERROR:
-			WLog_ERR(TAG, "An error occured while parsing configuration file, exiting...");
-			goto fail;
-
-		case CONFIG_INVALID:
-			goto fail;
-	}
-
-	if (config->WhitelistMode)
-	{
-		WLog_INFO(TAG, "Channels mode: WHITELIST");
-		count = ArrayList_Count(config->AllowedChannels);
-
-		for (i = 0; i < count; i++)
-			WLog_INFO(TAG, "Allowing %s", (char*) ArrayList_GetItem(config->AllowedChannels, i));
-	}
-	else
-	{
-		WLog_INFO(TAG, "Channels mode: BLACKLIST");
-		count = ArrayList_Count(config->BlockedChannels);
-
-		for (i = 0; i < count; i++)
-			WLog_INFO(TAG, "Blocking %s", (char*) ArrayList_GetItem(config->BlockedChannels, i));
-	}
+	if (!pf_server_config_load(cfg, config))
+		goto fail;
 
 	status = pf_server_start(config);
 fail:

--- a/server/proxy/pf_config.c
+++ b/server/proxy/pf_config.c
@@ -166,6 +166,35 @@ out:
 	return ok;
 }
 
+void pf_server_config_print(proxyConfig* config)
+{
+	WLog_INFO(TAG, "Proxy configuration:");
+
+	CONFIG_PRINT_SECTION("Server");
+	CONFIG_PRINT_STR(config, Host);
+	CONFIG_PRINT_UINT16(config, Port);
+
+	if (!config->UseLoadBalanceInfo)
+	{
+		CONFIG_PRINT_SECTION("Target");
+		CONFIG_PRINT_STR(config, TargetHost);
+		CONFIG_PRINT_UINT16(config, TargetPort);
+	}
+
+	CONFIG_PRINT_SECTION("Input");
+	CONFIG_PRINT_BOOL(config, Keyboard);
+	CONFIG_PRINT_BOOL(config, Mouse);
+
+	CONFIG_PRINT_SECTION("Security");
+	CONFIG_PRINT_BOOL(config, NlaSecurity);
+	CONFIG_PRINT_BOOL(config, TlsSecurity);
+	CONFIG_PRINT_BOOL(config, RdpSecurity);
+
+	CONFIG_PRINT_SECTION("Channels");
+	CONFIG_PRINT_BOOL(config, GFX);
+	CONFIG_PRINT_BOOL(config, DisplayControl);
+}
+
 void pf_server_config_free(proxyConfig* config)
 {
 	pf_filters_unregister_all(config->Filters);

--- a/server/proxy/pf_config.h
+++ b/server/proxy/pf_config.h
@@ -22,10 +22,6 @@
 #ifndef FREERDP_SERVER_PROXY_PFCONFIG_H
 #define FREERDP_SERVER_PROXY_PFCONFIG_H
 
-#define CONFIG_PARSE_SUCCESS 0
-#define CONFIG_PARSE_ERROR 	 1
-#define CONFIG_INVALID 		 2
-
 #include <winpr/ini.h>
 
 #include "pf_filters.h"
@@ -42,10 +38,6 @@ struct proxy_config
 	char* TargetHost;
 	UINT16 TargetPort;
 
-	/* graphics */
-	BOOL GFX;
-	BOOL BitmapUpdate;
-
 	/* input */
 	BOOL Keyboard;
 	BOOL Mouse;
@@ -56,10 +48,8 @@ struct proxy_config
 	BOOL RdpSecurity;
 
 	/* channels */
-	BOOL WhitelistMode;
-
-	wArrayList* AllowedChannels;
-	wArrayList* BlockedChannels;
+	BOOL GFX;
+	BOOL DisplayControl;
 
 	/* filters */
 	filters_list* Filters;
@@ -67,7 +57,7 @@ struct proxy_config
 
 typedef struct proxy_config proxyConfig;
 
-DWORD pf_server_load_config(const char* path, proxyConfig* config);
+BOOL pf_server_config_load(const char* path, proxyConfig* config);
 void pf_server_config_free(proxyConfig* config);
 
 #endif /* FREERDP_SERVER_PROXY_PFCONFIG_H */

--- a/server/proxy/pf_config.h
+++ b/server/proxy/pf_config.h
@@ -58,6 +58,7 @@ struct proxy_config
 typedef struct proxy_config proxyConfig;
 
 BOOL pf_server_config_load(const char* path, proxyConfig* config);
+void pf_server_config_print(proxyConfig* config);
 void pf_server_config_free(proxyConfig* config);
 
 #endif /* FREERDP_SERVER_PROXY_PFCONFIG_H */

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -245,9 +245,9 @@ static DWORD WINAPI pf_server_handle_client(LPVOID arg)
 		goto out_free_peer;
 	}
 
-	client->settings->SupportDisplayControl = TRUE;
+	client->settings->SupportDisplayControl = config->DisplayControl;
+	client->settings->DynamicResolutionUpdate = config->DisplayControl;
 	client->settings->SupportMonitorLayoutPdu = TRUE;
-	client->settings->DynamicResolutionUpdate = TRUE;
 	client->settings->RdpSecurity = config->RdpSecurity;
 	client->settings->TlsSecurity = config->TlsSecurity;
 	client->settings->NlaSecurity = config->NlaSecurity;


### PR DESCRIPTION
## Regarding configuration

- Config loading code is cleaner.
- Only open allowed channels (do not allow disp if DisplayControl is not allowed in config).

## Regarding filters
- Make sure that `filter_init` is exported on filters compilation.
- Instead of dropping the connection in filter_demo, just print some info to stdout.