### PR TITLE
server: proxy: cliprdr support

### DIFF
--- a/channels/cliprdr/client/cliprdr_format.c
+++ b/channels/cliprdr/client/cliprdr_format.c
@@ -295,7 +295,7 @@ UINT cliprdr_process_format_data_request(cliprdrPlugin* cliprdr, wStream* s, UIN
 
 	Stream_Read_UINT32(s, formatDataRequest.requestedFormatId); /* requestedFormatId (4 bytes) */
 
-
+	context->lastRequestedFormatId = formatDataRequest.requestedFormatId;
 	IFCALLRET(context->ServerFormatDataRequest, error, context, &formatDataRequest);
 	if (error)
 		WLog_ERR(TAG, "ServerFormatDataRequest failed with error %"PRIu32"!", error);

--- a/channels/cliprdr/client/cliprdr_main.c
+++ b/channels/cliprdr/client/cliprdr_main.c
@@ -184,6 +184,7 @@ static UINT cliprdr_process_general_capability(cliprdrPlugin* cliprdr,
 		return ERROR_INTERNAL_ERROR;
 	}
 
+	capabilities.msgType = CB_CLIP_CAPS;
 	capabilities.cCapabilitiesSets = 1;
 	capabilities.capabilitySets = (CLIPRDR_CAPABILITY_SET*) &
 	                              (generalCapabilitySet);

--- a/channels/cliprdr/server/cliprdr_main.c
+++ b/channels/cliprdr/server/cliprdr_main.c
@@ -911,6 +911,7 @@ static UINT cliprdr_server_receive_format_data_request(CliprdrServerContext*
 
 	Stream_Read_UINT32(s,
 	                   formatDataRequest.requestedFormatId); /* requestedFormatId (4 bytes) */
+	context->lastRequestedFormatId = formatDataRequest.requestedFormatId;
 	IFCALLRET(context->ClientFormatDataRequest, error, context, &formatDataRequest);
 
 	if (error)

--- a/channels/cliprdr/server/cliprdr_main.c
+++ b/channels/cliprdr/server/cliprdr_main.c
@@ -91,19 +91,35 @@ wStream* cliprdr_server_packet_new(UINT16 msgType, UINT16 msgFlags,
  */
 UINT cliprdr_server_packet_send(CliprdrServerPrivate* cliprdr, wStream* s)
 {
-	size_t pos;
+	UINT rc;
+	size_t pos, size;
 	BOOL status;
 	UINT32 dataLen;
 	UINT32 written;
 	pos = Stream_GetPosition(s);
-	dataLen = pos - 8;
+	if ((pos < 8) || (pos > UINT32_MAX))
+	{
+		rc = ERROR_NO_DATA;
+		goto fail;
+	}
+
+	dataLen = (UINT32)(pos - 8);
 	Stream_SetPosition(s, 4);
 	Stream_Write_UINT32(s, dataLen);
 	Stream_SetPosition(s, pos);
+	size = Stream_Length(s);
+	if (size > UINT32_MAX)
+	{
+		rc = ERROR_INVALID_DATA;
+		goto fail;
+	}
+
 	status = WTSVirtualChannelWrite(cliprdr->ChannelHandle,
-	                                (PCHAR) Stream_Buffer(s), Stream_Length(s), &written);
+									(PCHAR) Stream_Buffer(s), (UINT32)size, &written);
+	rc = status ? CHANNEL_RC_OK : ERROR_INTERNAL_ERROR;
+	fail:
 	Stream_Free(s, TRUE);
-	return status ? CHANNEL_RC_OK : ERROR_INTERNAL_ERROR;
+	return rc;
 }
 
 /**
@@ -112,13 +128,15 @@ UINT cliprdr_server_packet_send(CliprdrServerPrivate* cliprdr, wStream* s)
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_capabilities(CliprdrServerContext* context,
-                                        CLIPRDR_CAPABILITIES* capabilities)
+                                        const CLIPRDR_CAPABILITIES* capabilities)
 {
 	wStream* s;
-	CLIPRDR_GENERAL_CAPABILITY_SET* generalCapabilitySet;
+	const CLIPRDR_GENERAL_CAPABILITY_SET* generalCapabilitySet;
 	CliprdrServerPrivate* cliprdr = (CliprdrServerPrivate*) context->handle;
-	capabilities->msgType = CB_CLIP_CAPS;
-	capabilities->msgFlags = 0;
+
+	if (capabilities->msgType != CB_CLIP_CAPS)
+		WLog_WARN(TAG, "[%s] called with invalid type %08"PRIx32, __FUNCTION__, capabilities->msgType);
+
 	s = cliprdr_server_packet_new(CB_CLIP_CAPS, 0, 4 + CB_CAPSTYPE_GENERAL_LEN);
 
 	if (!s)
@@ -129,8 +147,8 @@ static UINT cliprdr_server_capabilities(CliprdrServerContext* context,
 
 	Stream_Write_UINT16(s, 1); /* cCapabilitiesSets (2 bytes) */
 	Stream_Write_UINT16(s, 0); /* pad1 (2 bytes) */
-	generalCapabilitySet = (CLIPRDR_GENERAL_CAPABILITY_SET*)
-	                       capabilities->capabilitySets;
+	generalCapabilitySet = (const CLIPRDR_GENERAL_CAPABILITY_SET*)
+						   &capabilities->capabilitySets;
 	Stream_Write_UINT16(s,
 	                    generalCapabilitySet->capabilitySetType); /* capabilitySetType (2 bytes) */
 	Stream_Write_UINT16(s,
@@ -147,16 +165,16 @@ static UINT cliprdr_server_capabilities(CliprdrServerContext* context,
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT cliprdr_server_monitor_ready(CliprdrServerContext* context,
-        CLIPRDR_MONITOR_READY* monitorReady)
+static UINT cliprdr_server_monitor_ready(CliprdrServerContext* context, const CLIPRDR_MONITOR_READY* monitorReady)
 {
 	wStream* s;
 	CliprdrServerPrivate* cliprdr = (CliprdrServerPrivate*) context->handle;
-	monitorReady->msgType = CB_MONITOR_READY;
-	monitorReady->msgFlags = 0;
-	monitorReady->dataLen = 0;
-	s = cliprdr_server_packet_new(monitorReady->msgType,
-	                              monitorReady->msgFlags, monitorReady->dataLen);
+
+	if (monitorReady->msgType != CB_MONITOR_READY)
+		WLog_WARN(TAG, "[%s] called with invalid type %08"PRIx32, __FUNCTION__, monitorReady->msgType);
+
+	s = cliprdr_server_packet_new(CB_MONITOR_READY,
+								  monitorReady->msgFlags, monitorReady->dataLen);
 
 	if (!s)
 	{
@@ -174,24 +192,25 @@ static UINT cliprdr_server_monitor_ready(CliprdrServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_format_list(CliprdrServerContext* context,
-                                       CLIPRDR_FORMAT_LIST* formatList)
+                                       const CLIPRDR_FORMAT_LIST* formatList)
 {
 	wStream* s;
 	UINT32 index;
-	int length = 0;
 	int cchWideChar;
 	LPWSTR lpWideCharStr;
 	int formatNameSize;
-	int formatNameLength;
 	char* szFormatName;
 	WCHAR* wszFormatName;
 	BOOL asciiNames = FALSE;
 	CLIPRDR_FORMAT* format;
 	CliprdrServerPrivate* cliprdr = (CliprdrServerPrivate*) context->handle;
 
+	if (formatList->msgType != CB_FORMAT_LIST)
+		WLog_WARN(TAG, "[%s] called with invalid type %08"PRIx32, __FUNCTION__, formatList->msgType);
+
 	if (!context->useLongFormatNames)
 	{
-		length = formatList->numFormats * 36;
+		UINT32 length = formatList->numFormats * 36;
 		s = cliprdr_server_packet_new(CB_FORMAT_LIST, 0, length);
 
 		if (!s)
@@ -202,10 +221,11 @@ static UINT cliprdr_server_format_list(CliprdrServerContext* context,
 
 		for (index = 0; index < formatList->numFormats; index++)
 		{
+			size_t formatNameLength = 0;
 			format = (CLIPRDR_FORMAT*) & (formatList->formats[index]);
 			Stream_Write_UINT32(s, format->formatId); /* formatId (4 bytes) */
 			formatNameSize = 0;
-			formatNameLength = 0;
+
 			szFormatName = format->formatName;
 
 			if (asciiNames)
@@ -227,19 +247,26 @@ static UINT cliprdr_server_format_list(CliprdrServerContext* context,
 					formatNameSize = ConvertToUnicode(CP_UTF8, 0, szFormatName, -1, &wszFormatName,
 					                                  0);
 
+				if (formatNameSize < 0)
+					return ERROR_INTERNAL_ERROR;
+
 				if (formatNameSize > 15)
 					formatNameSize = 15;
 
-				if (wszFormatName)
-					Stream_Write(s, wszFormatName, formatNameSize * 2);
+				/* size in bytes  instead of wchar */
+				formatNameSize *= 2;
 
-				Stream_Zero(s, 32 - (formatNameSize * 2));
+				if (wszFormatName)
+					Stream_Write(s, wszFormatName, (size_t)formatNameSize);
+
+				Stream_Zero(s, (size_t)(32 - formatNameSize));
 				free(wszFormatName);
 			}
 		}
 	}
 	else
 	{
+		UINT32 length = 0;
 		for (index = 0; index < formatList->numFormats; index++)
 		{
 			format = (CLIPRDR_FORMAT*) & (formatList->formats[index]);
@@ -250,7 +277,10 @@ static UINT cliprdr_server_format_list(CliprdrServerContext* context,
 				formatNameSize = MultiByteToWideChar(CP_UTF8, 0, format->formatName, -1, NULL,
 				                                     0) * 2;
 
-			length += formatNameSize;
+			if (formatNameSize < 0)
+				return ERROR_INTERNAL_ERROR;
+
+			length += (UINT32)formatNameSize;
 		}
 
 		s = cliprdr_server_packet_new(CB_FORMAT_LIST, 0, length);
@@ -268,11 +298,19 @@ static UINT cliprdr_server_format_list(CliprdrServerContext* context,
 
 			if (format->formatName)
 			{
+				const size_t cap = Stream_Capacity(s);
+				const size_t pos = Stream_GetPosition(s);
+				const size_t rem = cap - pos;
+				if ((cap < pos) || ((rem / 2) > INT_MAX))
+					return ERROR_INTERNAL_ERROR;
+
 				lpWideCharStr = (LPWSTR) Stream_Pointer(s);
-				cchWideChar = (Stream_Capacity(s) - Stream_GetPosition(s)) / 2;
+				cchWideChar = (int)(rem / 2);
 				formatNameSize = MultiByteToWideChar(CP_UTF8, 0,
 				                                     format->formatName, -1, lpWideCharStr, cchWideChar) * 2;
-				Stream_Seek(s, formatNameSize);
+				if (formatNameSize < 0)
+					return ERROR_INTERNAL_ERROR;
+				Stream_Seek(s, (size_t)formatNameSize);
 			}
 			else
 			{
@@ -292,13 +330,14 @@ static UINT cliprdr_server_format_list(CliprdrServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_format_list_response(CliprdrServerContext* context,
-        CLIPRDR_FORMAT_LIST_RESPONSE* formatListResponse)
+        const CLIPRDR_FORMAT_LIST_RESPONSE* formatListResponse)
 {
 	wStream* s;
 	CliprdrServerPrivate* cliprdr = (CliprdrServerPrivate*) context->handle;
-	formatListResponse->msgType = CB_FORMAT_LIST_RESPONSE;
-	formatListResponse->dataLen = 0;
-	s = cliprdr_server_packet_new(formatListResponse->msgType,
+	if (formatListResponse->msgType != CB_FORMAT_LIST_RESPONSE)
+		WLog_WARN(TAG, "[%s] called with invalid type %08"PRIx32, __FUNCTION__, formatListResponse->msgType);
+
+	s = cliprdr_server_packet_new(CB_FORMAT_LIST_RESPONSE,
 	                              formatListResponse->msgFlags, formatListResponse->dataLen);
 
 	if (!s)
@@ -317,10 +356,12 @@ static UINT cliprdr_server_format_list_response(CliprdrServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_lock_clipboard_data(CliprdrServerContext* context,
-        CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData)
+        const CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData)
 {
 	wStream* s;
 	CliprdrServerPrivate* cliprdr = (CliprdrServerPrivate*) context->handle;
+	if (lockClipboardData->msgType != CB_LOCK_CLIPDATA)
+		WLog_WARN(TAG, "[%s] called with invalid type %08"PRIx32, __FUNCTION__, lockClipboardData->msgType);
 	s = cliprdr_server_packet_new(CB_LOCK_CLIPDATA, 0, 4);
 
 	if (!s)
@@ -342,10 +383,13 @@ static UINT cliprdr_server_lock_clipboard_data(CliprdrServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_unlock_clipboard_data(CliprdrServerContext* context,
-        CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData)
+        const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData)
 {
 	wStream* s;
 	CliprdrServerPrivate* cliprdr = (CliprdrServerPrivate*) context->handle;
+	if (unlockClipboardData->msgType != CB_UNLOCK_CLIPDATA)
+		WLog_WARN(TAG, "[%s] called with invalid type %08"PRIx32, __FUNCTION__, unlockClipboardData->msgType);
+
 	s = cliprdr_server_packet_new(CB_UNLOCK_CLIPDATA, 0, 4);
 
 	if (!s)
@@ -367,14 +411,14 @@ static UINT cliprdr_server_unlock_clipboard_data(CliprdrServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_format_data_request(CliprdrServerContext* context,
-        CLIPRDR_FORMAT_DATA_REQUEST* formatDataRequest)
+        const CLIPRDR_FORMAT_DATA_REQUEST* formatDataRequest)
 {
 	wStream* s;
 	CliprdrServerPrivate* cliprdr = (CliprdrServerPrivate*) context->handle;
-	formatDataRequest->msgType = CB_FORMAT_DATA_REQUEST;
-	formatDataRequest->msgFlags = 0;
-	formatDataRequest->dataLen = 4;
-	s = cliprdr_server_packet_new(formatDataRequest->msgType,
+	if (formatDataRequest->msgType != CB_FORMAT_DATA_REQUEST)
+		WLog_WARN(TAG, "[%s] called with invalid type %08"PRIx32, __FUNCTION__, formatDataRequest->msgType);
+
+	s = cliprdr_server_packet_new(CB_FORMAT_DATA_REQUEST,
 	                              formatDataRequest->msgFlags, formatDataRequest->dataLen);
 
 	if (!s)
@@ -395,12 +439,15 @@ static UINT cliprdr_server_format_data_request(CliprdrServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_format_data_response(CliprdrServerContext* context,
-        CLIPRDR_FORMAT_DATA_RESPONSE* formatDataResponse)
+        const CLIPRDR_FORMAT_DATA_RESPONSE* formatDataResponse)
 {
 	wStream* s;
 	CliprdrServerPrivate* cliprdr = (CliprdrServerPrivate*) context->handle;
-	formatDataResponse->msgType = CB_FORMAT_DATA_RESPONSE;
-	s = cliprdr_server_packet_new(formatDataResponse->msgType,
+
+	if (formatDataResponse->msgType != CB_FORMAT_DATA_RESPONSE)
+		WLog_WARN(TAG, "[%s] called with invalid type %08"PRIx32, __FUNCTION__, formatDataResponse->msgType);
+
+	s = cliprdr_server_packet_new(CB_FORMAT_DATA_RESPONSE,
 	                              formatDataResponse->msgFlags, formatDataResponse->dataLen);
 
 	if (!s)
@@ -421,10 +468,14 @@ static UINT cliprdr_server_format_data_response(CliprdrServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_file_contents_request(CliprdrServerContext* context,
-        CLIPRDR_FILE_CONTENTS_REQUEST* fileContentsRequest)
+        const CLIPRDR_FILE_CONTENTS_REQUEST* fileContentsRequest)
 {
 	wStream* s;
 	CliprdrServerPrivate* cliprdr = (CliprdrServerPrivate*) context->handle;
+
+	if (fileContentsRequest->msgType != CB_FILECONTENTS_REQUEST)
+		WLog_WARN(TAG, "[%s] called with invalid type %08"PRIx32, __FUNCTION__, fileContentsRequest->msgType);
+
 	s = cliprdr_server_packet_new(CB_FILECONTENTS_REQUEST, 0, 28);
 
 	if (!s)
@@ -456,17 +507,21 @@ static UINT cliprdr_server_file_contents_request(CliprdrServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_file_contents_response(CliprdrServerContext* context,
-        CLIPRDR_FILE_CONTENTS_RESPONSE* fileContentsResponse)
+        const CLIPRDR_FILE_CONTENTS_RESPONSE* fileContentsResponse)
 {
 	wStream* s;
 	CliprdrServerPrivate* cliprdr = (CliprdrServerPrivate*) context->handle;
+	UINT32 cbRequested = fileContentsResponse->cbRequested;
+
+	if (fileContentsResponse->msgType != CB_FILECONTENTS_RESPONSE)
+		WLog_WARN(TAG, "[%s] called with invalid type %08"PRIx32, __FUNCTION__, fileContentsResponse->msgType);
 
 	if (fileContentsResponse->dwFlags & FILECONTENTS_SIZE)
-		fileContentsResponse->cbRequested = sizeof(UINT64);
+		cbRequested = sizeof(UINT64);
 
 	s = cliprdr_server_packet_new(CB_FILECONTENTS_RESPONSE,
 	                              fileContentsResponse->msgFlags,
-	                              4 + fileContentsResponse->cbRequested);
+								  4 + cbRequested);
 
 	if (!s)
 	{
@@ -481,7 +536,7 @@ static UINT cliprdr_server_file_contents_response(CliprdrServerContext* context,
 	 * FILECONTENTS_RANGE: file data from requested range
 	 */
 	Stream_Write(s, fileContentsResponse->requestedData,
-	             fileContentsResponse->cbRequested);
+				 cbRequested);
 	WLog_DBG(TAG, "ServerFileContentsResponse: streamId: 0x%08"PRIX32"",
 	         fileContentsResponse->streamId);
 	return cliprdr_server_packet_send(cliprdr, s);
@@ -522,7 +577,7 @@ static UINT cliprdr_server_receive_general_capability(CliprdrServerContext*
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_receive_capabilities(CliprdrServerContext* context,
-        wStream* s, CLIPRDR_HEADER* header)
+        wStream* s, const CLIPRDR_HEADER* header)
 {
 	UINT16 index;
 	UINT16 capabilitySetType;
@@ -532,6 +587,8 @@ static UINT cliprdr_server_receive_capabilities(CliprdrServerContext* context,
 	CLIPRDR_CAPABILITIES capabilities;
 	CLIPRDR_CAPABILITY_SET* capSet;
 	void* tmp;
+
+	WINPR_UNUSED(header);
 
 	/* set `capabilitySets` to NULL so `realloc` will know to alloc the first block */
 	capabilities.capabilitySets = NULL;
@@ -592,15 +649,16 @@ out:
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_receive_temporary_directory(CliprdrServerContext*
-        context, wStream* s, CLIPRDR_HEADER* header)
+        context, wStream* s, const CLIPRDR_HEADER* header)
 {
-	int length;
+	size_t length;
 	WCHAR* wszTempDir;
 	CLIPRDR_TEMP_DIRECTORY tempDirectory;
 	CliprdrServerPrivate* cliprdr = (CliprdrServerPrivate*) context->handle;
 	size_t slength;
 	UINT error = CHANNEL_RC_OK;
 
+	WINPR_UNUSED(header);
 	if ((slength = Stream_GetRemainingLength(s)) < 520)
 	{
 		WLog_ERR(TAG,
@@ -648,13 +706,12 @@ static UINT cliprdr_server_receive_temporary_directory(CliprdrServerContext*
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_receive_format_list(CliprdrServerContext* context,
-        wStream* s, CLIPRDR_HEADER* header)
+        wStream* s, const CLIPRDR_HEADER* header)
 {
 	UINT32 index;
 	UINT32 dataLen;
 	size_t position;
 	BOOL asciiNames;
-	int formatNameLength;
 	char* szFormatName;
 	WCHAR* wszFormatName;
 	CLIPRDR_FORMAT* formats = NULL;
@@ -751,6 +808,7 @@ static UINT cliprdr_server_receive_format_list(CliprdrServerContext* context,
 	{
 		while (dataLen)
 		{
+			size_t formatNameLength;
 			Stream_Seek(s, 4); /* formatId (4 bytes) */
 			dataLen -= 4;
 			wszFormatName = (WCHAR*) Stream_Pointer(s);
@@ -782,6 +840,8 @@ static UINT cliprdr_server_receive_format_list(CliprdrServerContext* context,
 
 		while (dataLen)
 		{
+			size_t formatNameLength;
+
 			Stream_Read_UINT32(s, formats[index].formatId); /* formatId (4 bytes) */
 			dataLen -= 4;
 			formats[index].formatName = NULL;
@@ -833,10 +893,12 @@ out:
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_receive_format_list_response(
-    CliprdrServerContext* context, wStream* s, CLIPRDR_HEADER* header)
+    CliprdrServerContext* context, wStream* s, const CLIPRDR_HEADER* header)
 {
 	CLIPRDR_FORMAT_LIST_RESPONSE formatListResponse;
 	UINT error = CHANNEL_RC_OK;
+
+	WINPR_UNUSED(s);
 	WLog_DBG(TAG, "CliprdrClientFormatListResponse");
 	formatListResponse.msgType = CB_FORMAT_LIST_RESPONSE;
 	formatListResponse.msgFlags = header->msgFlags;
@@ -856,7 +918,7 @@ static UINT cliprdr_server_receive_format_list_response(
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_receive_lock_clipdata(CliprdrServerContext* context,
-        wStream* s, CLIPRDR_HEADER* header)
+        wStream* s, const CLIPRDR_HEADER* header)
 {
 	CLIPRDR_LOCK_CLIPBOARD_DATA lockClipboardData;
 	UINT error = CHANNEL_RC_OK;
@@ -886,7 +948,7 @@ static UINT cliprdr_server_receive_lock_clipdata(CliprdrServerContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_receive_unlock_clipdata(CliprdrServerContext*
-        context, wStream* s, CLIPRDR_HEADER* header)
+        context, wStream* s, const CLIPRDR_HEADER* header)
 {
 	CLIPRDR_UNLOCK_CLIPBOARD_DATA unlockClipboardData;
 	UINT error = CHANNEL_RC_OK;
@@ -918,7 +980,7 @@ static UINT cliprdr_server_receive_unlock_clipdata(CliprdrServerContext*
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_receive_format_data_request(CliprdrServerContext*
-        context, wStream* s, CLIPRDR_HEADER* header)
+        context, wStream* s, const CLIPRDR_HEADER* header)
 {
 	CLIPRDR_FORMAT_DATA_REQUEST formatDataRequest;
 	UINT error = CHANNEL_RC_OK;
@@ -950,7 +1012,7 @@ static UINT cliprdr_server_receive_format_data_request(CliprdrServerContext*
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_receive_format_data_response(
-    CliprdrServerContext* context, wStream* s, CLIPRDR_HEADER* header)
+    CliprdrServerContext* context, wStream* s, const CLIPRDR_HEADER* header)
 {
 	CLIPRDR_FORMAT_DATA_RESPONSE formatDataResponse;
 	UINT error = CHANNEL_RC_OK;
@@ -985,7 +1047,7 @@ static UINT cliprdr_server_receive_format_data_response(
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_receive_filecontents_request(
-    CliprdrServerContext* context, wStream* s, CLIPRDR_HEADER* header)
+    CliprdrServerContext* context, wStream* s, const CLIPRDR_HEADER* header)
 {
 	CLIPRDR_FILE_CONTENTS_REQUEST request;
 	UINT error = CHANNEL_RC_OK;
@@ -1026,7 +1088,7 @@ static UINT cliprdr_server_receive_filecontents_request(
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_receive_filecontents_response(
-    CliprdrServerContext* context, wStream* s, CLIPRDR_HEADER* header)
+    CliprdrServerContext* context, wStream* s, const CLIPRDR_HEADER* header)
 {
 	CLIPRDR_FILE_CONTENTS_RESPONSE response;
 	UINT error = CHANNEL_RC_OK;
@@ -1058,7 +1120,7 @@ static UINT cliprdr_server_receive_filecontents_response(
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT cliprdr_server_receive_pdu(CliprdrServerContext* context,
-                                       wStream* s, CLIPRDR_HEADER* header)
+                                       wStream* s, const CLIPRDR_HEADER* header)
 {
 	UINT error;
 	WLog_DBG(TAG,
@@ -1154,13 +1216,14 @@ static UINT cliprdr_server_receive_pdu(CliprdrServerContext* context,
 static UINT cliprdr_server_init(CliprdrServerContext* context)
 {
 	UINT32 generalFlags;
-	CLIPRDR_CAPABILITIES capabilities;
-	CLIPRDR_MONITOR_READY monitorReady;
 	CLIPRDR_GENERAL_CAPABILITY_SET generalCapabilitySet;
-	UINT error = CHANNEL_RC_OK;
-	ZeroMemory(&capabilities, sizeof(capabilities));
-	ZeroMemory(&monitorReady, sizeof(monitorReady));
+	UINT error;
+	CLIPRDR_MONITOR_READY monitorReady = { 0 };
+	CLIPRDR_CAPABILITIES capabilities = { 0 };
+
 	generalFlags = 0;
+	monitorReady.msgType = CB_MONITOR_READY;
+	capabilities.msgType = CB_CLIP_CAPS;
 
 	if (context->useLongFormatNames)
 		generalFlags |= CB_USE_LONG_FORMAT_NAMES;
@@ -1219,7 +1282,7 @@ UINT cliprdr_server_read(CliprdrServerContext* context)
 	if (Stream_GetPosition(s) < CLIPRDR_HEADER_LENGTH)
 	{
 		BytesReturned = 0;
-		BytesToRead = CLIPRDR_HEADER_LENGTH - Stream_GetPosition(s);
+		BytesToRead = (UINT32)(CLIPRDR_HEADER_LENGTH - Stream_GetPosition(s));
 		status = WaitForSingleObject(cliprdr->ChannelEvent, 0);
 
 		if (status == WAIT_FAILED)
@@ -1261,7 +1324,7 @@ UINT cliprdr_server_read(CliprdrServerContext* context)
 		if (Stream_GetPosition(s) < (header.dataLen + CLIPRDR_HEADER_LENGTH))
 		{
 			BytesReturned = 0;
-			BytesToRead = (header.dataLen + CLIPRDR_HEADER_LENGTH) - Stream_GetPosition(s);
+			BytesToRead = (UINT32)((header.dataLen + CLIPRDR_HEADER_LENGTH) - Stream_GetPosition(s));
 			status = WaitForSingleObject(cliprdr->ChannelEvent, 0);
 
 			if (status == WAIT_FAILED)

--- a/channels/cliprdr/server/cliprdr_main.c
+++ b/channels/cliprdr/server/cliprdr_main.c
@@ -1356,10 +1356,13 @@ static DWORD WINAPI cliprdr_server_thread(LPVOID arg)
 	events[nCount++] = cliprdr->StopEvent;
 	events[nCount++] = ChannelEvent;
 
-	if ((error = cliprdr_server_init(context)))
+	if (context->autoInitializationSequence)
 	{
-		WLog_ERR(TAG, "cliprdr_server_init failed with error %"PRIu32"!", error);
-		goto out;
+		if ((error = cliprdr_server_init(context)))
+		{
+			WLog_ERR(TAG, "cliprdr_server_init failed with error %"PRIu32"!", error);
+			goto out;
+		}
 	}
 
 	while (1)
@@ -1566,6 +1569,7 @@ CliprdrServerContext* cliprdr_server_context_new(HANDLE vcm)
 
 	if (context)
 	{
+		context->autoInitializationSequence = TRUE;
 		context->Open = cliprdr_server_open;
 		context->Close = cliprdr_server_close;
 		context->Start = cliprdr_server_start;

--- a/include/freerdp/client/cliprdr.h
+++ b/include/freerdp/client/cliprdr.h
@@ -81,6 +81,7 @@ struct _cliprdr_client_context
 	pcCliprdrClientFileContentsResponse ClientFileContentsResponse;
 	pcCliprdrServerFileContentsResponse ServerFileContentsResponse;
 
+	UINT32 lastRequestedFormatId;
 	rdpContext* rdpcontext;
 };
 

--- a/include/freerdp/server/cliprdr.h
+++ b/include/freerdp/server/cliprdr.h
@@ -42,26 +42,26 @@ typedef UINT (*psCliprdrStop)(CliprdrServerContext* context);
 typedef HANDLE (*psCliprdrGetEventHandle)(CliprdrServerContext* context);
 typedef UINT (*psCliprdrCheckEventHandle)(CliprdrServerContext* context);
 
-typedef UINT (*psCliprdrServerCapabilities)(CliprdrServerContext* context, CLIPRDR_CAPABILITIES* capabilities);
-typedef UINT (*psCliprdrClientCapabilities)(CliprdrServerContext* context, CLIPRDR_CAPABILITIES* capabilities);
-typedef UINT (*psCliprdrMonitorReady)(CliprdrServerContext* context, CLIPRDR_MONITOR_READY* monitorReady);
-typedef UINT (*psCliprdrTempDirectory)(CliprdrServerContext* context, CLIPRDR_TEMP_DIRECTORY* tempDirectory);
-typedef UINT (*psCliprdrClientFormatList)(CliprdrServerContext* context, CLIPRDR_FORMAT_LIST* formatList);
-typedef UINT (*psCliprdrServerFormatList)(CliprdrServerContext* context, CLIPRDR_FORMAT_LIST* formatList);
-typedef UINT (*psCliprdrClientFormatListResponse)(CliprdrServerContext* context, CLIPRDR_FORMAT_LIST_RESPONSE* formatListResponse);
-typedef UINT (*psCliprdrServerFormatListResponse)(CliprdrServerContext* context, CLIPRDR_FORMAT_LIST_RESPONSE* formatListResponse);
-typedef UINT (*psCliprdrClientLockClipboardData)(CliprdrServerContext* context, CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData);
-typedef UINT (*psCliprdrServerLockClipboardData)(CliprdrServerContext* context, CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData);
-typedef UINT (*psCliprdrClientUnlockClipboardData)(CliprdrServerContext* context, CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData);
-typedef UINT (*psCliprdrServerUnlockClipboardData)(CliprdrServerContext* context, CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData);
-typedef UINT (*psCliprdrClientFormatDataRequest)(CliprdrServerContext* context, CLIPRDR_FORMAT_DATA_REQUEST* formatDataRequest);
-typedef UINT (*psCliprdrServerFormatDataRequest)(CliprdrServerContext* context, CLIPRDR_FORMAT_DATA_REQUEST* formatDataRequest);
-typedef UINT (*psCliprdrClientFormatDataResponse)(CliprdrServerContext* context, CLIPRDR_FORMAT_DATA_RESPONSE* formatDataResponse);
-typedef UINT (*psCliprdrServerFormatDataResponse)(CliprdrServerContext* context, CLIPRDR_FORMAT_DATA_RESPONSE* formatDataResponse);
-typedef UINT (*psCliprdrClientFileContentsRequest)(CliprdrServerContext* context, CLIPRDR_FILE_CONTENTS_REQUEST* fileContentsRequest);
-typedef UINT (*psCliprdrServerFileContentsRequest)(CliprdrServerContext* context, CLIPRDR_FILE_CONTENTS_REQUEST* fileContentsRequest);
-typedef UINT (*psCliprdrClientFileContentsResponse)(CliprdrServerContext* context, CLIPRDR_FILE_CONTENTS_RESPONSE* fileContentsResponse);
-typedef UINT (*psCliprdrServerFileContentsResponse)(CliprdrServerContext* context, CLIPRDR_FILE_CONTENTS_RESPONSE* fileContentsResponse);
+typedef UINT (*psCliprdrServerCapabilities)(CliprdrServerContext* context, const CLIPRDR_CAPABILITIES* capabilities);
+typedef UINT (*psCliprdrClientCapabilities)(CliprdrServerContext* context, const CLIPRDR_CAPABILITIES* capabilities);
+typedef UINT (*psCliprdrMonitorReady)(CliprdrServerContext* context, const CLIPRDR_MONITOR_READY* monitorReady);
+typedef UINT (*psCliprdrTempDirectory)(CliprdrServerContext* context, const CLIPRDR_TEMP_DIRECTORY* tempDirectory);
+typedef UINT (*psCliprdrClientFormatList)(CliprdrServerContext* context, const CLIPRDR_FORMAT_LIST* formatList);
+typedef UINT (*psCliprdrServerFormatList)(CliprdrServerContext* context, const CLIPRDR_FORMAT_LIST* formatList);
+typedef UINT (*psCliprdrClientFormatListResponse)(CliprdrServerContext* context, const CLIPRDR_FORMAT_LIST_RESPONSE* formatListResponse);
+typedef UINT (*psCliprdrServerFormatListResponse)(CliprdrServerContext* context, const CLIPRDR_FORMAT_LIST_RESPONSE* formatListResponse);
+typedef UINT (*psCliprdrClientLockClipboardData)(CliprdrServerContext* context, const CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData);
+typedef UINT (*psCliprdrServerLockClipboardData)(CliprdrServerContext* context, const CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData);
+typedef UINT (*psCliprdrClientUnlockClipboardData)(CliprdrServerContext* context, const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData);
+typedef UINT (*psCliprdrServerUnlockClipboardData)(CliprdrServerContext* context, const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData);
+typedef UINT (*psCliprdrClientFormatDataRequest)(CliprdrServerContext* context, const CLIPRDR_FORMAT_DATA_REQUEST* formatDataRequest);
+typedef UINT (*psCliprdrServerFormatDataRequest)(CliprdrServerContext* context, const CLIPRDR_FORMAT_DATA_REQUEST* formatDataRequest);
+typedef UINT (*psCliprdrClientFormatDataResponse)(CliprdrServerContext* context, const CLIPRDR_FORMAT_DATA_RESPONSE* formatDataResponse);
+typedef UINT (*psCliprdrServerFormatDataResponse)(CliprdrServerContext* context, const CLIPRDR_FORMAT_DATA_RESPONSE* formatDataResponse);
+typedef UINT (*psCliprdrClientFileContentsRequest)(CliprdrServerContext* context, const CLIPRDR_FILE_CONTENTS_REQUEST* fileContentsRequest);
+typedef UINT (*psCliprdrServerFileContentsRequest)(CliprdrServerContext* context, const CLIPRDR_FILE_CONTENTS_REQUEST* fileContentsRequest);
+typedef UINT (*psCliprdrClientFileContentsResponse)(CliprdrServerContext* context, const CLIPRDR_FILE_CONTENTS_RESPONSE* fileContentsResponse);
+typedef UINT (*psCliprdrServerFileContentsResponse)(CliprdrServerContext* context, const CLIPRDR_FILE_CONTENTS_RESPONSE* fileContentsResponse);
 
 struct _cliprdr_server_context
 {

--- a/include/freerdp/server/cliprdr.h
+++ b/include/freerdp/server/cliprdr.h
@@ -103,6 +103,7 @@ struct _cliprdr_server_context
 	psCliprdrServerFileContentsResponse ServerFileContentsResponse;
 
 	rdpContext* rdpcontext;
+	UINT32 lastRequestedFormatId;
 };
 
 #ifdef __cplusplus

--- a/include/freerdp/server/cliprdr.h
+++ b/include/freerdp/server/cliprdr.h
@@ -103,6 +103,7 @@ struct _cliprdr_server_context
 	psCliprdrServerFileContentsResponse ServerFileContentsResponse;
 
 	rdpContext* rdpcontext;
+	BOOL autoInitializationSequence;
 	UINT32 lastRequestedFormatId;
 };
 

--- a/server/proxy/CMakeLists.txt
+++ b/server/proxy/CMakeLists.txt
@@ -45,7 +45,9 @@ set(${MODULE_PREFIX}_SRCS
   pf_graphics.h
   pf_filters.c
   pf_filters.h
-  pf_log.h)
+  pf_log.h
+  pf_cliprdr.c
+  pf_cliprdr.h)
 
 # On windows create dll version information.
 # Vendor, product and year are already set in top level CMakeLists.txt

--- a/server/proxy/config.ini
+++ b/server/proxy/config.ini
@@ -26,6 +26,11 @@ RdpSecurity = 1
 [Channels]
 GFX = 1
 DisplayControl = 1
+Clipboard = 1
+
+[Clipboard]
+TextOnly = 1
+MaxTextLength = 10 # 0 for no limit.
 
 [Filters]
 ; FilterName = FilterPath

--- a/server/proxy/pf_cliprdr.c
+++ b/server/proxy/pf_cliprdr.c
@@ -1,0 +1,428 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * FreeRDP Proxy Server
+ *
+ * Copyright 2019 Kobi Mizrachi <kmizrachi18@gmail.com>
+ * Copyright 2019 Idan Freiberg <speidy@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "pf_cliprdr.h"
+#include "pf_log.h"
+
+#define TAG PROXY_TAG("cliprdr")
+#define TEXT_FORMATS_COUNT 2
+
+/* used for createing a fake format list response, containing only text formats */
+static CLIPRDR_FORMAT g_text_formats[] = { { CF_TEXT, '\0' }, { CF_UNICODETEXT, '\0' } };
+
+BOOL pf_server_cliprdr_init(pServerContext* ps)
+{
+	CliprdrServerContext* cliprdr;
+	cliprdr = ps->cliprdr = cliprdr_server_context_new(ps->vcm);
+
+	if (!cliprdr)
+	{
+		WLog_ERR(TAG, "cliprdr_server_context_new failed.");
+		return FALSE;
+	}
+
+	cliprdr->rdpcontext = (rdpContext*)ps;
+
+	/* enable all capabilities */
+	cliprdr->useLongFormatNames = TRUE;
+	cliprdr->streamFileClipEnabled = TRUE;
+	cliprdr->fileClipNoFilePaths = TRUE;
+	cliprdr->canLockClipData = TRUE;
+
+	/* disable initialization sequence, for caps sync */
+	cliprdr->autoInitializationSequence = FALSE;
+	return TRUE;
+}
+
+static INLINE BOOL pf_cliprdr_is_text_format(UINT32 format)
+{
+	switch (format)
+	{
+		case CF_TEXT:
+		case CF_UNICODETEXT:
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
+static INLINE void pf_cliprdr_create_text_only_format_list(CLIPRDR_FORMAT_LIST* list)
+{
+	list->msgFlags = CB_RESPONSE_OK;
+	list->msgType = CB_FORMAT_LIST;
+	list->dataLen = (4 + 1) * TEXT_FORMATS_COUNT;
+	list->numFormats = TEXT_FORMATS_COUNT;
+	list->formats = g_text_formats;
+}
+
+/* format data response PDU returns the copied text as a unicode buffer.
+ * pf_cliprdr_is_copy_paste_valid returns TRUE if the length of the copied
+ * text is valid according to the configuration value of `MaxTextLength`.
+ */
+static BOOL pf_cliprdr_is_copy_paste_valid(proxyConfig* config,
+        const CLIPRDR_FORMAT_DATA_RESPONSE* pdu, UINT32 format)
+{
+	size_t copy_len;
+	if (config->MaxTextLength == 0)
+	{
+		/* no size limit */
+		return TRUE;
+	}
+
+	if (pdu->dataLen == 0)
+	{
+		/* no data */
+		return FALSE;
+	}
+
+	WLog_DBG(TAG, "pf_cliprdr_is_copy_paste_valid(): checking format %"PRIu32"", format);
+
+	switch (format)
+	{
+		case CF_UNICODETEXT:
+			copy_len = (pdu->dataLen / 2) - 1;
+			break;
+		case CF_TEXT:
+			copy_len = pdu->dataLen;
+			break;
+		default:
+			WLog_WARN(TAG, "received unknown format: %"PRIu32", format");
+			return FALSE;
+	}
+
+	if (copy_len > config->MaxTextLength)
+	{
+		WLog_WARN(TAG, "text size is too large: %"PRIu32" (max %"PRIu32")", copy_len,
+		          config->MaxTextLength);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/*
+ * if the requested text size is too long, we need a way to return a message to the other side of
+ * the connection, indicating that the copy/paste operation failed, instead of just not forwarding
+ * the response (because that destroys the state of the RDPECLIP channel). This is done by sending a
+ * `format_data_response` PDU with msgFlags = CB_RESPONSE_FAIL.
+ */
+static INLINE void pf_cliprdr_create_failed_format_data_response(CLIPRDR_FORMAT_DATA_RESPONSE* dst)
+{
+	dst->requestedFormatData = NULL;
+	dst->dataLen = 0;
+	dst->msgType = CB_FORMAT_DATA_RESPONSE;
+	dst->msgFlags = CB_RESPONSE_FAIL;
+}
+
+/* server callbacks */
+static UINT pf_cliprdr_ClientCapabilities(CliprdrServerContext* context,
+        const CLIPRDR_CAPABILITIES* capabilities)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrClientContext* client = pdata->pc->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+	return client->ClientCapabilities(client, capabilities);
+}
+
+static UINT pf_cliprdr_TempDirectory(CliprdrServerContext* context,
+                                     const CLIPRDR_TEMP_DIRECTORY* tempDirectory)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrClientContext* client = pdata->pc->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+	return client->TempDirectory(client, tempDirectory);
+}
+
+static UINT pf_cliprdr_ClientFormatList(CliprdrServerContext* context,
+                                        const CLIPRDR_FORMAT_LIST* formatList)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrClientContext* client = pdata->pc->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+
+	if (pdata->config->TextOnly)
+	{
+		CLIPRDR_FORMAT_LIST list;
+		pf_cliprdr_create_text_only_format_list(&list);
+		return client->ClientFormatList(client, &list);
+	}
+
+	/* send a format list that allows only text */
+	return client->ClientFormatList(client, formatList);
+}
+
+static UINT pf_cliprdr_ClientFormatListResponse(CliprdrServerContext* context,
+        const CLIPRDR_FORMAT_LIST_RESPONSE* formatListResponse)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrClientContext* client = pdata->pc->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+	return client->ClientFormatListResponse(client, formatListResponse);
+}
+
+static UINT pf_cliprdr_ClientLockClipboardData(CliprdrServerContext* context,
+        const CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrClientContext* client = pdata->pc->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+	return client->ClientLockClipboardData(client, lockClipboardData);
+}
+
+static UINT pf_cliprdr_ClientUnlockClipboardData(CliprdrServerContext* context,
+        const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrClientContext* client = pdata->pc->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+	return client->ClientUnlockClipboardData(client, unlockClipboardData);
+}
+
+static UINT pf_cliprdr_ClientFormatDataRequest(CliprdrServerContext* context,
+        const CLIPRDR_FORMAT_DATA_REQUEST* formatDataRequest)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrClientContext* client = pdata->pc->cliprdr;
+	CliprdrServerContext* server = pdata->ps->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+
+	if (pdata->config->TextOnly &&
+	    !pf_cliprdr_is_text_format(formatDataRequest->requestedFormatId))
+	{
+		CLIPRDR_FORMAT_DATA_RESPONSE resp;
+		pf_cliprdr_create_failed_format_data_response(&resp);
+		return server->ServerFormatDataResponse(server, &resp);
+	}
+
+	return client->ClientFormatDataRequest(client, formatDataRequest);
+}
+
+static UINT pf_cliprdr_ClientFormatDataResponse(CliprdrServerContext* context,
+        const CLIPRDR_FORMAT_DATA_RESPONSE* formatDataResponse)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrClientContext* client = pdata->pc->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+
+	if (pf_cliprdr_is_text_format(client->lastRequestedFormatId))
+	{
+		if (!pf_cliprdr_is_copy_paste_valid(pdata->config, formatDataResponse, client->lastRequestedFormatId))
+		{
+			CLIPRDR_FORMAT_DATA_RESPONSE resp;
+			pf_cliprdr_create_failed_format_data_response(&resp);
+			return client->ClientFormatDataResponse(client, &resp);
+		}
+	}
+
+	return client->ClientFormatDataResponse(client, formatDataResponse);
+}
+
+static UINT pf_cliprdr_ClientFileContentsRequest(CliprdrServerContext* context,
+        const CLIPRDR_FILE_CONTENTS_REQUEST* fileContentsRequest)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrClientContext* client = pdata->pc->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+
+	if (pdata->config->TextOnly)
+		return CHANNEL_RC_OK;
+
+	return client->ClientFileContentsRequest(client, fileContentsRequest);
+}
+
+static UINT pf_cliprdr_ClientFileContentsResponse(CliprdrServerContext* context,
+        const CLIPRDR_FILE_CONTENTS_RESPONSE* fileContentsResponse)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrClientContext* client = pdata->pc->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+
+	if (pdata->config->TextOnly)
+		return CHANNEL_RC_OK;
+
+	return client->ClientFileContentsResponse(client, fileContentsResponse);
+}
+
+/* client callbacks */
+
+static UINT pf_cliprdr_ServerCapabilities(CliprdrClientContext* context,
+        const CLIPRDR_CAPABILITIES* capabilities)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrServerContext* server = pdata->ps->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+	return server->ServerCapabilities(server, capabilities);
+}
+
+static UINT pf_cliprdr_MonitorReady(CliprdrClientContext* context,
+                                    const CLIPRDR_MONITOR_READY* monitorReady)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrServerContext* server = pdata->ps->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+	return server->MonitorReady(server, monitorReady);
+}
+
+static UINT pf_cliprdr_ServerFormatList(CliprdrClientContext* context,
+                                        const CLIPRDR_FORMAT_LIST* formatList)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrServerContext* server = pdata->ps->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+
+	if (pdata->config->TextOnly)
+	{
+		CLIPRDR_FORMAT_LIST list;
+		pf_cliprdr_create_text_only_format_list(&list);
+		return server->ServerFormatList(server, &list);
+	}
+
+	return server->ServerFormatList(server, formatList);
+}
+
+
+static UINT pf_cliprdr_ServerFormatListResponse(CliprdrClientContext* context,
+        const CLIPRDR_FORMAT_LIST_RESPONSE* formatListResponse)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrServerContext* server = pdata->ps->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+	return server->ServerFormatListResponse(server, formatListResponse);
+}
+
+
+static UINT pf_cliprdr_ServerLockClipboardData(CliprdrClientContext* context,
+        const CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrServerContext* server = pdata->ps->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+	return server->ServerLockClipboardData(server, lockClipboardData);
+}
+
+
+static UINT pf_cliprdr_ServerUnlockClipboardData(CliprdrClientContext* context,
+        const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrServerContext* server = pdata->ps->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+	return server->ServerUnlockClipboardData(server, unlockClipboardData);
+}
+
+
+static UINT pf_cliprdr_ServerFormatDataRequest(CliprdrClientContext* context,
+        const CLIPRDR_FORMAT_DATA_REQUEST* formatDataRequest)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrServerContext* server = pdata->ps->cliprdr;
+	CliprdrClientContext* client = pdata->pc->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+
+	if (pdata->config->TextOnly &&
+	    !pf_cliprdr_is_text_format(formatDataRequest->requestedFormatId))
+	{
+		/* proxy's client needs to return a failed response directly to the client */
+		CLIPRDR_FORMAT_DATA_RESPONSE resp;
+		pf_cliprdr_create_failed_format_data_response(&resp);
+		return client->ClientFormatDataResponse(client, &resp);
+	}
+
+	return server->ServerFormatDataRequest(server, formatDataRequest);
+}
+
+static UINT pf_cliprdr_ServerFormatDataResponse(CliprdrClientContext* context,
+        const CLIPRDR_FORMAT_DATA_RESPONSE* formatDataResponse)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrServerContext* server = pdata->ps->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+
+	if (pf_cliprdr_is_text_format(server->lastRequestedFormatId))
+	{
+		if (!pf_cliprdr_is_copy_paste_valid(pdata->config, formatDataResponse, server->lastRequestedFormatId))
+		{
+			CLIPRDR_FORMAT_DATA_RESPONSE resp;
+			pf_cliprdr_create_failed_format_data_response(&resp);
+			return server->ServerFormatDataResponse(server, &resp);
+		}
+	}
+
+	return server->ServerFormatDataResponse(server, formatDataResponse);
+}
+
+
+static UINT pf_cliprdr_ServerFileContentsRequest(CliprdrClientContext* context,
+        const CLIPRDR_FILE_CONTENTS_REQUEST* fileContentsRequest)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrServerContext* server = pdata->ps->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+
+	if (pdata->config->TextOnly)
+		return CHANNEL_RC_OK;
+
+	return server->ServerFileContentsRequest(server, fileContentsRequest);
+}
+
+
+static UINT pf_cliprdr_ServerFileContentsResponse(CliprdrClientContext* context,
+        const CLIPRDR_FILE_CONTENTS_RESPONSE* fileContentsResponse)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	CliprdrServerContext* server = pdata->ps->cliprdr;
+	WLog_VRB(TAG, __FUNCTION__);
+
+	if (pdata->config->TextOnly)
+		return CHANNEL_RC_OK;
+
+	return server->ServerFileContentsResponse(server, fileContentsResponse);
+}
+
+void pf_cliprdr_register_callbacks(CliprdrClientContext* cliprdr_client,
+                                 CliprdrServerContext* cliprdr_server,
+                                 proxyData* pdata)
+{
+	/* Set server and client side references to proxy data */
+	cliprdr_server->custom = (void*) pdata;
+	cliprdr_client->custom = (void*) pdata;
+	/* Set server callbacks */
+	cliprdr_server->ClientCapabilities = pf_cliprdr_ClientCapabilities;
+	cliprdr_server->TempDirectory = pf_cliprdr_TempDirectory;
+	cliprdr_server->ClientFormatList = pf_cliprdr_ClientFormatList;
+	cliprdr_server->ClientFormatListResponse = pf_cliprdr_ClientFormatListResponse;
+	cliprdr_server->ClientLockClipboardData = pf_cliprdr_ClientLockClipboardData;
+	cliprdr_server->ClientUnlockClipboardData = pf_cliprdr_ClientUnlockClipboardData;
+	cliprdr_server->ClientFormatDataRequest = pf_cliprdr_ClientFormatDataRequest;
+	cliprdr_server->ClientFormatDataResponse = pf_cliprdr_ClientFormatDataResponse;
+	cliprdr_server->ClientFileContentsRequest = pf_cliprdr_ClientFileContentsRequest;
+	cliprdr_server->ClientFileContentsResponse = pf_cliprdr_ClientFileContentsResponse;
+	/* Set client callbacks */
+	cliprdr_client->ServerCapabilities = pf_cliprdr_ServerCapabilities;
+	cliprdr_client->MonitorReady = pf_cliprdr_MonitorReady;
+	cliprdr_client->ServerFormatList = pf_cliprdr_ServerFormatList;
+	cliprdr_client->ServerFormatListResponse = pf_cliprdr_ServerFormatListResponse;
+	cliprdr_client->ServerLockClipboardData = pf_cliprdr_ServerLockClipboardData;
+	cliprdr_client->ServerUnlockClipboardData = pf_cliprdr_ServerUnlockClipboardData;
+	cliprdr_client->ServerFormatDataRequest = pf_cliprdr_ServerFormatDataRequest;
+	cliprdr_client->ServerFormatDataResponse = pf_cliprdr_ServerFormatDataResponse;
+	cliprdr_client->ServerFileContentsRequest = pf_cliprdr_ServerFileContentsRequest;
+	cliprdr_client->ServerFileContentsResponse = pf_cliprdr_ServerFileContentsResponse;
+}

--- a/server/proxy/pf_cliprdr.h
+++ b/server/proxy/pf_cliprdr.h
@@ -1,0 +1,34 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * FreeRDP Proxy Server
+ *
+ * Copyright 2019 Kobi Mizrachi <kmizrachi18@gmail.com>
+ * Copyright 2019 Idan Freiberg <speidy@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_SERVER_PROXY_PFCLIPRDR_H
+#define FREERDP_SERVER_PROXY_PFCLIPRDR_H
+
+#include <freerdp/client/cliprdr.h>
+#include <freerdp/server/cliprdr.h>
+
+#include "pf_context.h"
+
+BOOL pf_server_cliprdr_init(pServerContext* ps);
+void pf_cliprdr_register_callbacks(CliprdrClientContext* cliprdr_client,
+                                 CliprdrServerContext* cliprdr_server,
+                                 proxyData* pdata);
+
+#endif /* FREERDP_SERVER_PROXY_PFCLIPRDR_H */

--- a/server/proxy/pf_config.c
+++ b/server/proxy/pf_config.c
@@ -34,6 +34,7 @@
 #define CONFIG_PRINT_STR(config, key) WLog_INFO(TAG, "\t\t%s: %s", #key, config->key)
 #define CONFIG_PRINT_BOOL(config, key) WLog_INFO(TAG, "\t\t%s: %s", #key, config->key ? "TRUE" : "FALSE")
 #define CONFIG_PRINT_UINT16(config, key) WLog_INFO(TAG, "\t\t%s: %"PRIu16"", #key, config->key);
+#define CONFIG_PRINT_UINT32(config, key) WLog_INFO(TAG, "\t\t%s: %"PRIu32"", #key, config->key);
 
 #define CONFIG_GET_STR(ini, section, key) IniFile_GetKeyValueString(ini, section, key)
 #define CONFIG_GET_BOOL(ini, section, key) IniFile_GetKeyValueInt(ini, section, key)
@@ -79,6 +80,7 @@ static BOOL pf_config_load_channels(wIniFile* ini, proxyConfig* config)
 {
 	config->GFX = CONFIG_GET_BOOL(ini, "Channels", "GFX");
 	config->DisplayControl = CONFIG_GET_BOOL(ini, "Channels", "DisplayControl");
+	config->Clipboard = CONFIG_GET_BOOL(ini, "Channels", "Clipboard");
 	return TRUE;
 }
 
@@ -193,6 +195,12 @@ void pf_server_config_print(proxyConfig* config)
 	CONFIG_PRINT_SECTION("Channels");
 	CONFIG_PRINT_BOOL(config, GFX);
 	CONFIG_PRINT_BOOL(config, DisplayControl);
+	CONFIG_PRINT_BOOL(config, Clipboard);
+
+	CONFIG_PRINT_SECTION("Clipboard");
+	CONFIG_PRINT_BOOL(config, TextOnly);
+	if (config->MaxTextLength > 0)
+		CONFIG_PRINT_UINT32(config, MaxTextLength);
 }
 
 void pf_server_config_free(proxyConfig* config)

--- a/server/proxy/pf_config.h
+++ b/server/proxy/pf_config.h
@@ -50,9 +50,14 @@ struct proxy_config
 	/* channels */
 	BOOL GFX;
 	BOOL DisplayControl;
+	BOOL Clipboard;
 
 	/* filters */
 	filters_list* Filters;
+
+	/* clipboard specific settings*/
+	BOOL TextOnly;
+	UINT32 MaxTextLength;
 };
 
 typedef struct proxy_config proxyConfig;

--- a/server/proxy/pf_context.h
+++ b/server/proxy/pf_context.h
@@ -29,6 +29,7 @@
 #include <freerdp/server/rdpgfx.h>
 #include <freerdp/client/disp.h>
 #include <freerdp/server/disp.h>
+#include <freerdp/server/cliprdr.h>
 
 #include "pf_config.h"
 #include "pf_server.h"
@@ -50,6 +51,7 @@ struct p_server_context
 
 	RdpgfxServerContext* gfx;
 	DispServerContext* disp;
+	CliprdrServerContext* cliprdr;
 };
 typedef struct p_server_context pServerContext;
 
@@ -65,6 +67,7 @@ struct p_client_context
 	RdpeiClientContext* rdpei;
 	RdpgfxClientContext* gfx;
 	DispClientContext* disp;
+	CliprdrClientContext* cliprdr;
 
 	/*
 	 * In a case when freerdp_connect fails,

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -47,6 +47,7 @@
 #include "pf_context.h"
 #include "pf_input.h"
 #include "pf_update.h"
+#include "pf_channels.h"
 #include "pf_rdpgfx.h"
 #include "pf_disp.h"
 #include "pf_channels.h"
@@ -232,6 +233,7 @@ static DWORD WINAPI pf_server_handle_client(LPVOID arg)
 	pdata->config = client->ContextExtra;
 	config = pdata->config;
 	client->settings->UseMultimon = TRUE;
+	client->settings->RedirectClipboard = config->Clipboard;
 	client->settings->SupportGraphicsPipeline = config->GFX;
 	client->settings->SupportDynamicChannels = TRUE;
 	client->settings->CertificateFile = _strdup("server.crt");


### PR DESCRIPTION
This one adds `cliprdr` support to the proxy, allowing to decide whether to allow files copy or not, and limit text size copy.

- Added autoInitializationSequence for the proxy to be able to sync cliprdr caps between client and target (like we did in GFX).
- Changed the implementation of server_recv_capabilities to call the ClientCapabilities callback, for the proxy to be able to forward the caps.
- Added `lastRequestedFormatId` for both client & server, so the proxy will know which format is requested in every FormatDataResponse PDU (to be able to filter it). It is quite well documented in the commit message.