### PR TITLE
server: proxy: declare GlyphSupportLevel

### DIFF
--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -91,6 +91,14 @@ static void pf_OnErrorInfo(void* ctx, ErrorInfoEventArgs* e)
 static BOOL pf_client_pre_connect(freerdp* instance)
 {
 	rdpSettings* settings = instance->settings;
+
+	/*
+	 * as the client's settings are copied from the server's, GlyphSupportLevel might not be
+	 * GLYPH_SUPPORT_NONE. the proxy currently do not support GDI & GLYPH_SUPPORT_CACHE, so
+	 * GlyphCacheSupport must be explicitly set to GLYPH_SUPPORT_NONE.
+	 */
+	settings->GlyphSupportLevel = GLYPH_SUPPORT_NONE;
+
 	settings->OsMajorType = OSMAJORTYPE_UNIX;
 	settings->OsMinorType = OSMINORTYPE_NATIVE_XSERVER;
 	/**

--- a/server/proxy/pf_rdpgfx.c
+++ b/server/proxy/pf_rdpgfx.c
@@ -201,7 +201,6 @@ static UINT pf_rdpgfx_map_surface_to_scaled_output(RdpgfxClientContext* context,
 static UINT pf_rdpgfx_on_open(RdpgfxClientContext* context,
                               BOOL* do_caps_advertise, BOOL* send_frame_acks)
 {
-	proxyData* pdata = (proxyData*) context->custom;
 	WLog_VRB(TAG, __FUNCTION__);
 
 	if (NULL != do_caps_advertise)
@@ -210,10 +209,6 @@ static UINT pf_rdpgfx_on_open(RdpgfxClientContext* context,
 	if (NULL != send_frame_acks)
 		*send_frame_acks = FALSE;
 
-	/* Wait for the proxy's server's DYNVC to be in a ready state to safely open
-	 * the GFX DYNVC. */
-	WLog_DBG(TAG, "Waiting for proxy's server dynvc to be ready");
-	WaitForSingleObject(pdata->ps->dynvcReady, INFINITE);
 	return CHANNEL_RC_OK;
 }
 


### PR DESCRIPTION
- Fixes a bug that causes the connection to be closed (after client <> proxy server negotiation, GlyphSupportLevel was updated to be 0x3, then the client, who's settings are copied from the server's settings, connected with GlyphSupportLevel = 0x3, instead of 0x0 (GLYPH_SUPPORT_NONE - we currently do not support GDI orders [`OrderSupport` is zeroed], so the library checks caused the connection to be closed).
- Fixes a bug introduced in #5509: server dynamic channel (for eg. GFX) may be opened before server's dynvc is in ready state.