### PR TITLE
client: proxy: allow passing SOCKS5 proxies as env. vars

### DIFF
--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -143,7 +143,7 @@ static COMMAND_LINE_ARGUMENT_A args[] =
 	{ "printer", COMMAND_LINE_VALUE_OPTIONAL, "<name>[,<driver>]", NULL, NULL, -1, NULL, "Redirect printer device" },
 	{
 		"proxy", COMMAND_LINE_VALUE_REQUIRED, "[<proto>://][<user>:<password>@]<host>:<port>", NULL, NULL, -1, NULL,
-		"Proxy settings: override env.var (see also environment variable below). Protocol \"socks5\" should be given explicitly where \"http\" is default.  Note: socks proxy is not supported by env. variable"
+		"Proxy settings: override env. var (see also environment variable below). Protocol \"socks5\" should be given explicitly where \"http\" is default."
 	},
 	{ "pth", COMMAND_LINE_VALUE_REQUIRED, "<password-hash>", NULL, NULL, -1, "pass-the-hash", "Pass the hash (restricted admin mode)" },
 	{ "pwidth", COMMAND_LINE_VALUE_REQUIRED, "<width>", NULL, NULL, -1, NULL, "Physical width of display (in millimeters)" },

--- a/libfreerdp/core/proxy.c
+++ b/libfreerdp/core/proxy.c
@@ -305,9 +305,14 @@ BOOL proxy_parse_uri(rdpSettings* settings, const char* uri)
 			settings->ProxyType = PROXY_TYPE_HTTP;
 			protocol = "http";
 		}
+		else if (p == uri + 6 && !strncmp("socks5", uri, 6))
+		{
+			settings->ProxyType = PROXY_TYPE_SOCKS;
+			protocol = "socks5";
+		}
 		else
 		{
-			WLog_ERR(TAG, "Only HTTP proxys supported by now");
+			WLog_ERR(TAG, "Only HTTP and SOCKS5 proxies supported by now");
 			return FALSE;
 		}
 


### PR DESCRIPTION
Hi,
For some reason, when SOCKS5 support was added, SOCKS5 proxies could not be passed via environment variables. This PR fixes that shortcoming.