### PR TITLE
Do not try to free a colormap that FreeRDP did not create.

### DIFF
--- a/client/X11/xf_floatbar.c
+++ b/client/X11/xf_floatbar.c
@@ -340,7 +340,6 @@ static unsigned long xf_floatbar_get_color(xfFloatbar* floatbar, char* rgb_value
 	cmap = DefaultColormap(display, XDefaultScreen(display));
 	XParseColor(display, cmap, rgb_value, &color);
 	XAllocColor(display, cmap, &color);
-	XFreeColormap(display, cmap);
 	return color.pixel;
 }
 


### PR DESCRIPTION
I think the call to XFreeColormap() should not be here since it tries to free the default colormap that FreeRDP did not create.