### PR TITLE
 client/common: Remove incorrect prompt for creds parsing

### DIFF
--- a/client/common/file.c
+++ b/client/common/file.c
@@ -310,8 +310,7 @@ static BOOL freerdp_client_rdp_file_set_integer(rdpFile* file, const char* name,
 		file->AuthenticationLevel = (UINT32)value;
 	else if (_stricmp(name, "promptcredentialonce") == 0)
 		file->PromptCredentialOnce = (UINT32)value;
-	else if ((_stricmp(name, "prompt for credentials") == 0) ||
-	         (_stricmp(name, "prompt for credentials on client") == 0))
+	else if ((_stricmp(name, "prompt for credentials") == 0))
 		file->PromptForCredentials = (UINT32)value;
 	else if (_stricmp(name, "negotiate security layer") == 0)
 		file->NegotiateSecurityLayer = (UINT32)value;


### PR DESCRIPTION
"prompt for credentials on client" was incorrectly merged together with
"prompt for credentials" into a single setting. However the first option
determines if the client should prompt for credentials if the remote
server does not support server authentication. "prompt for credentials"
on the other hand determines if the client should use any previously
stored credentials or if it should always prompt for them.
