### PR TITLE
server: proxy: sync cliprdr opening

### DIFF
--- a/server/proxy/pf_channels.c
+++ b/server/proxy/pf_channels.c
@@ -128,6 +128,7 @@ void pf_OnChannelDisconnectedEventHandler(void* data,
 BOOL pf_server_channels_init(pServerContext* ps)
 {
 	rdpContext* context = (rdpContext*) ps;
+	rdpContext* client = (rdpContext*) ps->pdata->pc;
 	proxyConfig* config = ps->pdata->config;
 
 	if (context->settings->SupportGraphicsPipeline && config->GFX)
@@ -144,6 +145,8 @@ BOOL pf_server_channels_init(pServerContext* ps)
 
 	if (config->Clipboard && WTSVirtualChannelManagerIsChannelJoined(ps->vcm, CLIPRDR_SVC_CHANNEL_NAME))
 	{
+		client->settings->RedirectClipboard = TRUE;
+
 		if (!pf_server_cliprdr_init(ps))
 			return FALSE;
 	}

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -233,7 +233,6 @@ static DWORD WINAPI pf_server_handle_client(LPVOID arg)
 	pdata->config = client->ContextExtra;
 	config = pdata->config;
 	client->settings->UseMultimon = TRUE;
-	client->settings->RedirectClipboard = config->Clipboard;
 	client->settings->SupportGraphicsPipeline = config->GFX;
 	client->settings->SupportDynamicChannels = TRUE;
 	client->settings->CertificateFile = _strdup("server.crt");


### PR DESCRIPTION
Only open cliprdr for client if it is allowed in configuration and original client (client <> proxy's server) connected with cliprdr. Fixes a crash when connecting with xfreerdp without `/clipboard` flag.