### PR TITLE
core: Fix handling of PromptForCredentials setting

### DIFF
--- a/libfreerdp/core/gateway/ncacn_http.c
+++ b/libfreerdp/core/gateway/ncacn_http.c
@@ -146,7 +146,7 @@ BOOL rpc_ncacn_http_ntlm_init(rdpContext* context, RpcChannel* channel)
 	if (!settings->GatewayPassword || !settings->GatewayUsername ||
 	    !strlen(settings->GatewayPassword) || !strlen(settings->GatewayUsername))
 	{
-		if (!instance->settings->PromptForCredentials || !instance->GatewayAuthenticate)
+		if (!instance->GatewayAuthenticate)
 		{
 			freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
 			return TRUE;

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -867,7 +867,7 @@ static BOOL rdg_get_gateway_credentials(rdpContext* context)
 	if (!settings->GatewayPassword || !settings->GatewayUsername ||
 	    !strlen(settings->GatewayPassword) || !strlen(settings->GatewayUsername))
 	{
-		if (!instance->settings->PromptForCredentials || !instance->GatewayAuthenticate)
+		if (!instance->GatewayAuthenticate)
 		{
 			freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
 			return FALSE;

--- a/libfreerdp/core/gateway/rpc_bind.c
+++ b/libfreerdp/core/gateway/rpc_bind.c
@@ -136,7 +136,7 @@ int rpc_send_bind_pdu(rdpRpc* rpc)
 
 	if (promptPassword)
 	{
-		if (!instance->settings->PromptForCredentials || !instance->GatewayAuthenticate)
+		if (!instance->GatewayAuthenticate)
 		{
 			freerdp_set_last_error(instance->context, FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
 			return 0;

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -279,7 +279,7 @@ static int nla_client_init(rdpNla* nla)
 
 	if (PromptPassword)
 	{
-		if (!instance->settings->PromptForCredentials || !instance->Authenticate)
+		if (!instance->Authenticate)
 		{
 			freerdp_set_last_error(instance->context, FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
 			return 0;

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -623,7 +623,6 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 
 	settings->ActionScript = _strdup("~/.config/freerdp/action.sh");
 	settings->SmartcardLogon = FALSE;
-	settings->PromptForCredentials = TRUE;
 	settings->TlsSecLevel = 1;
 	settings->OrderSupport = calloc(1, 32);
 


### PR DESCRIPTION
The prompt for credentials setting was incorrectly used in FreeRDP. If this setting is set to 1 in a rdp file the client should prompt for credentials even if it has credentials stored for this connection. If the setting is set to 0 the client should either use the stored credentials (if present) or ask for username/password otherwise.
This PR changes the old handling (if PromptForCredentials was set to 0 no credential prompting was done) to the desired behavior.

This is a follow up PR to #5528