### PR TITLE
Bugfix/blank screen

### DIFF
--- a/server/proxy/pf_channels.c
+++ b/server/proxy/pf_channels.c
@@ -43,6 +43,13 @@
 
 #define TAG PROXY_TAG("channels")
 
+static void pf_channels_wait_for_server_dynvc(pServerContext* ps)
+{
+	WLog_DBG(TAG, "pf_channels_wait_for_server_dynvc(): waiting for server's drdynvc to be ready");
+	WaitForSingleObject(ps->dynvcReady, INFINITE);
+	WLog_DBG(TAG, "pf_channels_wait_for_server_dynvc(): server's drdynvc is ready!");
+}
+
 void pf_OnChannelConnectedEventHandler(void* data,
                                        ChannelConnectedEventArgs* e)
 {
@@ -57,6 +64,8 @@ void pf_OnChannelConnectedEventHandler(void* data,
 	}
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
+		pf_channels_wait_for_server_dynvc(ps);
+
 		if (!ps->gfx->Open(ps->gfx))
 		{
 			WLog_ERR(TAG, "failed to open GFX server");
@@ -68,13 +77,28 @@ void pf_OnChannelConnectedEventHandler(void* data,
 	}
 	else if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) == 0)
 	{
-		if (ps->disp->Open(ps->disp) != CHANNEL_RC_OK)
+		UINT ret;
+
+		ret = ps->disp->Open(ps->disp);
+		if (ret != CHANNEL_RC_OK)
 		{
-			WLog_ERR(TAG, "failed to open disp channel");
-			return;
+			if (ret == ERROR_NOT_FOUND)
+			{
+				/* client did not connect with disp */
+				return;
+			}
+		}
+		else
+		{
+			pf_channels_wait_for_server_dynvc(ps);
+			if (ps->disp->Open(ps->disp) != CHANNEL_RC_OK)
+			{
+				WLog_ERR(TAG, "failed to open disp channel");
+				return;
+			}
 		}
 
-		pc->disp = (DispClientContext*) e->pInterface;
+		pc->disp = (DispClientContext*)e->pInterface;
 		pf_disp_register_callbacks(pc->disp, ps->disp, pc->pdata);
 	}
 	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -129,10 +129,6 @@ static BOOL pf_client_pre_connect(freerdp* instance)
 	                                    pf_OnChannelDisconnectedEventHandler);
 	PubSub_SubscribeErrorInfo(instance->context->pubSub, pf_OnErrorInfo);
 
-	/* before loading client's channels, make sure proxy's dynvc is ready */
-	WLog_DBG(TAG, "pf_client_pre_connect(): Waiting for proxy's server dynvc to be ready");
-	WaitForSingleObject(ps->dynvcReady, INFINITE);
-
 	/**
 	 * Load all required plugins / channels / libraries specified by current
 	 * settings.


### PR DESCRIPTION
Fixes #5530.

Problem was that proxy's client was waiting for server's drynvc to be in ready state no matter if original client connected with any dynamic channel.

Fixed by: only waiting when needed. For disp, which doesn't have an early capability flag (like GFX) indicating that it will be opened, we first call Open and check if ERROR_NOT_FOUND was returned. If it wasn't the error, then we wait and call it again.