### PR TITLE
Reattach to cmd if wfreerdp was started from one.

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -60,7 +60,7 @@
 
 static int wf_create_console(void)
 {
-	if (!AllocConsole())
+	if (!AttachConsole(ATTACH_PARENT_PROCESS))
 		return 1;
 
 	freopen("CONOUT$", "w", stdout);
@@ -916,9 +916,8 @@ static BOOL wfreerdp_client_global_init(void)
 	WSADATA wsaData;
 
 	WSAStartup(0x101, &wsaData);
-#if defined(WITH_DEBUG) || defined(_DEBUG)
+
 	wf_create_console();
-#endif
 	freerdp_register_addin_provider(freerdp_channels_load_static_addin_entry, 0);
 	return TRUE;
 }

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -582,7 +582,7 @@ fail:
 	 * a certificate only for this session, 0 otherwise */
 	switch(what)
 	{
-	case IDOK:
+	case IDYES:
 		return 1;
 	case IDNO:
 		return 2;
@@ -641,7 +641,7 @@ fail:
 	 * a certificate only for this session, 0 otherwise */
 	switch(what)
 	{
-	case IDOK:
+	case IDYES:
 		return 1;
 	case IDNO:
 		return 2;
@@ -1030,8 +1030,7 @@ static BOOL wfreerdp_client_new(freerdp* instance, rdpContext* context)
 
 	// AttachConsole and stdin do not work well.
 	// Use GUI input dialogs instead of command line ones.
-	//wfc->isConsole = wf_create_console();
-	wf_create_console();
+	wfc->isConsole = wf_create_console();
 
 	if (!(wfreerdp_client_global_init()))
 		return FALSE;

--- a/client/Windows/wf_client.h
+++ b/client/Windows/wf_client.h
@@ -132,6 +132,7 @@ struct wf_context
 
 	RailClientContext* rail;
 	wHashTable* railWindows;
+	BOOL isConsole;
 };
 
 /**


### PR DESCRIPTION
Found a solution for the long standing no output on console issue.
With `AttachConsole(ATTACH_PARENT_PROCESS)`  we reattach `wfreerdp.exe` to the calling console.
If used as launcher for `rdp` files no new console process is created, so this should cover all use cases.