### PR TITLE
Use stat instead of lstat to iterate /Volumes

### DIFF
--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -405,7 +405,8 @@ static UINT handle_hotplug(rdpdrPlugin* rdpdr)
 		if (pDirent->d_name[0] != '.')
 		{
 			sprintf_s(fullpath, ARRAYSIZE(fullpath), "%s/%s", szdir, pDirent->d_name);
-			lstat(fullpath, &buf);
+			if (stat(fullpath, &buf) != 0)
+				continue;
 
 			if (S_ISDIR(buf.st_mode))
 			{


### PR DESCRIPTION
Some entries are symbolic links, so follow them and check the link
target for being a directory.