### PR TITLE
Speedup for WLog_* macros, cache the log pointer

### DIFF
--- a/winpr/include/winpr/wlog.h
+++ b/winpr/include/winpr/wlog.h
@@ -110,6 +110,8 @@ WINPR_API BOOL WLog_PrintMessageVA(wLog* log, DWORD type, DWORD level,
                                    DWORD line,
                                    const char* file, const char* function, va_list args);
 
+WINPR_API wLog* WLog_GetRoot(void);
+WINPR_API wLog* WLog_Get(LPCSTR name);
 WINPR_API DWORD WLog_GetLogLevel(wLog* log);
 WINPR_API BOOL WLog_IsLevelActive(wLog* _log, DWORD _log_level);
 
@@ -120,6 +122,14 @@ WINPR_API BOOL WLog_IsLevelActive(wLog* _log, DWORD _log_level);
 			                  __LINE__, __FILE__, __FUNCTION__, __VA_ARGS__ ); \
 		} \
 	} while (0)
+
+#define WLog_Print_tag(_tag, _log_level, ...) \
+    do { \
+        static  wLog* _log_cached_ptr = NULL; \
+        if (!_log_cached_ptr) \
+            _log_cached_ptr = WLog_Get(_tag); \
+        WLog_Print(_log_cached_ptr, _log_level, __VA_ARGS__); \
+    } while (0)
 
 #define WLog_PrintVA(_log, _log_level, _args) \
 	do { \
@@ -153,13 +163,13 @@ WINPR_API BOOL WLog_IsLevelActive(wLog* _log, DWORD _log_level);
 		} \
 	} while (0)
 
-#define WLog_LVL(tag, lvl, ...) WLog_Print(WLog_Get(tag), lvl, __VA_ARGS__)
-#define WLog_VRB(tag, ...) WLog_Print(WLog_Get(tag), WLOG_TRACE, __VA_ARGS__)
-#define WLog_DBG(tag, ...) WLog_Print(WLog_Get(tag), WLOG_DEBUG, __VA_ARGS__)
-#define WLog_INFO(tag, ...) WLog_Print(WLog_Get(tag), WLOG_INFO, __VA_ARGS__)
-#define WLog_WARN(tag, ...) WLog_Print(WLog_Get(tag), WLOG_WARN, __VA_ARGS__)
-#define WLog_ERR(tag, ...) WLog_Print(WLog_Get(tag), WLOG_ERROR, __VA_ARGS__)
-#define WLog_FATAL(tag, ...) WLog_Print(WLog_Get(tag), WLOG_FATAL, __VA_ARGS__)
+#define WLog_LVL(tag, lvl, ...) WLog_Print_tag(tag, lvl, __VA_ARGS__)
+#define WLog_VRB(tag, ...) WLog_Print_tag(tag, WLOG_TRACE, __VA_ARGS__)
+#define WLog_DBG(tag, ...) WLog_Print_tag(tag, WLOG_DEBUG, __VA_ARGS__)
+#define WLog_INFO(tag, ...) WLog_Print_tag(tag, WLOG_INFO, __VA_ARGS__)
+#define WLog_WARN(tag, ...) WLog_Print_tag(tag, WLOG_WARN, __VA_ARGS__)
+#define WLog_ERR(tag, ...) WLog_Print_tag(tag, WLOG_ERROR, __VA_ARGS__)
+#define WLog_FATAL(tag, ...) WLog_Print_tag(tag, WLOG_FATAL, __VA_ARGS__)
 
 WINPR_API BOOL WLog_SetLogLevel(wLog* log, DWORD logLevel);
 WINPR_API BOOL WLog_SetStringLogLevel(wLog* log, LPCSTR level);
@@ -175,9 +185,6 @@ WINPR_API BOOL WLog_ConfigureAppender(wLogAppender* appender,
 WINPR_API wLogLayout* WLog_GetLogLayout(wLog* log);
 WINPR_API BOOL WLog_Layout_SetPrefixFormat(wLog* log, wLogLayout* layout,
         const char* format);
-
-WINPR_API wLog* WLog_GetRoot(void);
-WINPR_API wLog* WLog_Get(LPCSTR name);
 
 /** Deprecated */
 WINPR_API WINPR_DEPRECATED(BOOL WLog_Init(void));


### PR DESCRIPTION
`WLog_Get(tag)` is quite expensive if called repeatedly.
With this patch the pointer is cached on first call.