### PR TITLE
channels: cliprdr: get rid of duplicated code

### DIFF
--- a/channels/cliprdr/client/CMakeLists.txt
+++ b/channels/cliprdr/client/CMakeLists.txt
@@ -21,7 +21,10 @@ set(${MODULE_PREFIX}_SRCS
 	cliprdr_format.c
 	cliprdr_format.h
 	cliprdr_main.c
-	cliprdr_main.h)
+	cliprdr_main.h
+	../cliprdr_common.h
+	../cliprdr_common.c
+	)
 
 add_channel_client_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} FALSE "VirtualChannelEntryEx")
 

--- a/channels/cliprdr/client/cliprdr_format.c
+++ b/channels/cliprdr/client/cliprdr_format.c
@@ -33,6 +33,7 @@
 
 #include "cliprdr_main.h"
 #include "cliprdr_format.h"
+#include "../cliprdr_common.h"
 
 /**
  * Function description
@@ -41,13 +42,6 @@
  */
 UINT cliprdr_process_format_list(cliprdrPlugin* cliprdr, wStream* s, UINT32 dataLen, UINT16 msgFlags)
 {
-	UINT32 index;
-	size_t position;
-	BOOL asciiNames;
-	int formatNameLength;
-	char* szFormatName;
-	WCHAR* wszFormatName;
-	CLIPRDR_FORMAT* formats = NULL;
 	CLIPRDR_FORMAT_LIST formatList;
 	CliprdrClientContext* context = cliprdr_get_client_interface(cliprdr);
 	UINT error = CHANNEL_RC_OK;
@@ -58,165 +52,12 @@ UINT cliprdr_process_format_list(cliprdrPlugin* cliprdr, wStream* s, UINT32 data
 		return ERROR_INTERNAL_ERROR;
 	}
 
-	asciiNames = (msgFlags & CB_ASCII_NAMES) ? TRUE : FALSE;
-
 	formatList.msgType = CB_FORMAT_LIST;
 	formatList.msgFlags = msgFlags;
 	formatList.dataLen = dataLen;
 
-	index = 0;
-	formatList.numFormats = 0;
-	position = Stream_GetPosition(s);
-
-	if (!formatList.dataLen)
-	{
-		/* empty format list */
-		formatList.formats = NULL;
-		formatList.numFormats = 0;
-	}
-	else if (!cliprdr->useLongFormatNames)
-	{
-		formatList.numFormats = (dataLen / 36);
-
-		if ((formatList.numFormats * 36) != dataLen)
-		{
-			WLog_ERR(TAG, "Invalid short format list length: %"PRIu32"", dataLen);
-			return ERROR_INTERNAL_ERROR;
-		}
-
-		if (formatList.numFormats)
-			formats = (CLIPRDR_FORMAT*) calloc(formatList.numFormats, sizeof(CLIPRDR_FORMAT));
-
-		if (!formats)
-		{
-			WLog_ERR(TAG, "calloc failed!");
-			return CHANNEL_RC_NO_MEMORY;
-		}
-
-		formatList.formats = formats;
-
-		while (dataLen)
-		{
-			Stream_Read_UINT32(s, formats[index].formatId); /* formatId (4 bytes) */
-			dataLen -= 4;
-
-			formats[index].formatName = NULL;
-
-			/* According to MS-RDPECLIP 2.2.3.1.1.1 formatName is "a 32-byte block containing
-			 * the *null-terminated* name assigned to the Clipboard Format: (32 ASCII 8 characters
-			 * or 16 Unicode characters)"
-			 * However, both Windows RDSH and mstsc violate this specs as seen in the following
-			 * example of a transferred short format name string: [R.i.c.h. .T.e.x.t. .F.o.r.m.a.t.]
-			 * These are 16 unicode charaters - *without* terminating null !
-			 */
-
-			if (asciiNames)
-			{
-				szFormatName = (char*) Stream_Pointer(s);
-
-				if (szFormatName[0])
-				{
-					/* ensure null termination */
-					formats[index].formatName = (char*) malloc(32 + 1);
-					if (!formats[index].formatName)
-					{
-						WLog_ERR(TAG, "malloc failed!");
-						error = CHANNEL_RC_NO_MEMORY;
-						goto error_out;
-					}
-					CopyMemory(formats[index].formatName, szFormatName, 32);
-					formats[index].formatName[32] = '\0';
-				}
-			}
-			else
-			{
-				wszFormatName = (WCHAR*) Stream_Pointer(s);
-
-				if (wszFormatName[0])
-				{
-					/* ConvertFromUnicode always returns a null-terminated
-					 * string on success, even if the source string isn't.
-					 */
-					if (ConvertFromUnicode(CP_UTF8, 0, wszFormatName, 16,
-						&(formats[index].formatName), 0, NULL, NULL) < 1)
-					{
-						WLog_ERR(TAG, "failed to convert short clipboard format name");
-						error = ERROR_INTERNAL_ERROR;
-						goto error_out;
-					}
-				}
-			}
-
-			Stream_Seek(s, 32);
-			dataLen -= 32;
-			index++;
-		}
-	}
-	else
-	{
-		while (dataLen)
-		{
-			Stream_Seek(s, 4); /* formatId (4 bytes) */
-			dataLen -= 4;
-
-			wszFormatName = (WCHAR*) Stream_Pointer(s);
-
-			if (!wszFormatName[0])
-				formatNameLength = 0;
-			else
-				formatNameLength = _wcslen(wszFormatName);
-
-			Stream_Seek(s, (formatNameLength + 1) * 2);
-			dataLen -= ((formatNameLength + 1) * 2);
-
-			formatList.numFormats++;
-		}
-
-		dataLen = formatList.dataLen;
-		Stream_SetPosition(s, position);
-
-		if (formatList.numFormats)
-			formats = (CLIPRDR_FORMAT*) calloc(formatList.numFormats, sizeof(CLIPRDR_FORMAT));
-
-		if (!formats)
-		{
-			WLog_ERR(TAG, "calloc failed!");
-			return CHANNEL_RC_NO_MEMORY;
-		}
-
-		formatList.formats = formats;
-
-		while (dataLen)
-		{
-			Stream_Read_UINT32(s, formats[index].formatId); /* formatId (4 bytes) */
-			dataLen -= 4;
-
-			formats[index].formatName = NULL;
-
-			wszFormatName = (WCHAR*) Stream_Pointer(s);
-
-			if (!wszFormatName[0])
-				formatNameLength = 0;
-			else
-				formatNameLength = _wcslen(wszFormatName);
-
-			if (formatNameLength)
-			{
-				if (ConvertFromUnicode(CP_UTF8, 0, wszFormatName, -1,
-					&(formats[index].formatName), 0, NULL, NULL) < 1)
-				{
-					WLog_ERR(TAG, "failed to convert long clipboard format name");
-					error = ERROR_INTERNAL_ERROR;
-					goto error_out;
-				}
-			}
-
-			Stream_Seek(s, (formatNameLength + 1) * 2);
-			dataLen -= ((formatNameLength + 1) * 2);
-
-			index++;
-		}
-	}
+	if ((error = cliprdr_read_format_list(s, &formatList, cliprdr->useLongFormatNames)))
+		goto error_out;
 
 	WLog_Print(cliprdr->log, WLOG_DEBUG, "ServerFormatList: numFormats: %"PRIu32"",
 			formatList.numFormats);
@@ -228,15 +69,7 @@ UINT cliprdr_process_format_list(cliprdrPlugin* cliprdr, wStream* s, UINT32 data
 	}
 
 error_out:
-	if (formats)
-	{
-		for (index = 0; index < formatList.numFormats; index++)
-		{
-			free(formats[index].formatName);
-		}
-
-		free(formats);
-	}
+	cliprdr_free_format_list(&formatList);
 	return error;
 }
 
@@ -293,7 +126,8 @@ UINT cliprdr_process_format_data_request(cliprdrPlugin* cliprdr, wStream* s, UIN
 	formatDataRequest.msgFlags = msgFlags;
 	formatDataRequest.dataLen = dataLen;
 
-	Stream_Read_UINT32(s, formatDataRequest.requestedFormatId); /* requestedFormatId (4 bytes) */
+	if ((error = cliprdr_read_format_data_request(s, &formatDataRequest)))
+		return error;
 
 	context->lastRequestedFormatId = formatDataRequest.requestedFormatId;
 	IFCALLRET(context->ServerFormatDataRequest, error, context, &formatDataRequest);
@@ -325,10 +159,9 @@ UINT cliprdr_process_format_data_response(cliprdrPlugin* cliprdr, wStream* s, UI
 	formatDataResponse.msgType = CB_FORMAT_DATA_RESPONSE;
 	formatDataResponse.msgFlags = msgFlags;
 	formatDataResponse.dataLen = dataLen;
-	formatDataResponse.requestedFormatData = NULL;
 
-	if (dataLen)
-		formatDataResponse.requestedFormatData = (BYTE*) Stream_Pointer(s);
+	if ((error = cliprdr_read_format_data_response(s, &formatDataResponse)))
+		return error;
 
 	IFCALLRET(context->ServerFormatDataResponse, error, context, &formatDataResponse);
 	if (error)

--- a/channels/cliprdr/client/cliprdr_main.c
+++ b/channels/cliprdr/client/cliprdr_main.c
@@ -96,8 +96,11 @@ static UINT cliprdr_packet_send(cliprdrPlugin* cliprdr, wStream* s)
 	}
 
 	if (status != CHANNEL_RC_OK)
+	{
+		Stream_Free(s, TRUE);
 		WLog_ERR(TAG, "VirtualChannelWrite failed with %s [%08"PRIX32"]",
 		         WTSErrorToString(status), status);
+	}
 
 	return status;
 }

--- a/channels/cliprdr/cliprdr_common.c
+++ b/channels/cliprdr/cliprdr_common.c
@@ -30,9 +30,9 @@
 
 static BOOL cliprdr_validate_file_contents_request(const CLIPRDR_FILE_CONTENTS_REQUEST* request)
 {
-    /*
-     * [MS-RDPECLIP] 2.2.5.3 File Contents Request PDU (CLIPRDR_FILECONTENTS_REQUEST).
-     *
+	/*
+	 * [MS-RDPECLIP] 2.2.5.3 File Contents Request PDU (CLIPRDR_FILECONTENTS_REQUEST).
+	 *
 	 * A request for the size of the file identified by the lindex field. The size MUST be
 	 * returned as a 64-bit, unsigned integer. The cbRequested field MUST be set to
 	 * 0x00000008 and both the nPositionLow and nPositionHigh fields MUST be
@@ -55,7 +55,7 @@ static BOOL cliprdr_validate_file_contents_request(const CLIPRDR_FILE_CONTENTS_R
 		}
 	}
 
-    return TRUE;
+	return TRUE;
 }
 
 UINT cliprdr_write_file_contents_request(wStream* s, const CLIPRDR_FILE_CONTENTS_REQUEST* request)
@@ -69,43 +69,45 @@ UINT cliprdr_write_file_contents_request(wStream* s, const CLIPRDR_FILE_CONTENTS
 
 	if (request->haveClipDataId)
 		Stream_Write_UINT32(s, request->clipDataId); /* clipDataId (4 bytes) */
-    
-    return CHANNEL_RC_OK;
+
+	return CHANNEL_RC_OK;
 }
 
 static INLINE UINT cliprdr_write_lock_unlock_clipdata(wStream* s, UINT32 clipDataId)
 {
-    Stream_Write_UINT32(s, clipDataId);
-    return CHANNEL_RC_OK;
+	Stream_Write_UINT32(s, clipDataId);
+	return CHANNEL_RC_OK;
 }
 
 UINT cliprdr_write_lock_clipdata(wStream* s, const CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData)
 {
-    return cliprdr_write_lock_unlock_clipdata(s, lockClipboardData->clipDataId);
+	return cliprdr_write_lock_unlock_clipdata(s, lockClipboardData->clipDataId);
 }
 
-UINT cliprdr_write_unlock_clipdata(wStream* s, const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData)
+UINT cliprdr_write_unlock_clipdata(wStream* s,
+                                   const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData)
 {
-    return cliprdr_write_lock_unlock_clipdata(s, unlockClipboardData->clipDataId);
+	return cliprdr_write_lock_unlock_clipdata(s, unlockClipboardData->clipDataId);
 }
 
-UINT cliprdr_write_file_contents_response(wStream* s, const CLIPRDR_FILE_CONTENTS_RESPONSE* response)
+UINT cliprdr_write_file_contents_response(wStream* s,
+                                          const CLIPRDR_FILE_CONTENTS_RESPONSE* response)
 {
 	Stream_Write_UINT32(s, response->streamId); /* streamId (4 bytes) */
 	Stream_Write(s, response->requestedData, response->cbRequested);
-    return CHANNEL_RC_OK;
+	return CHANNEL_RC_OK;
 }
 
 UINT cliprdr_read_unlock_clipdata(wStream* s, CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData)
 {
-    if (Stream_GetRemainingLength(s) < 4)
+	if (Stream_GetRemainingLength(s) < 4)
 	{
 		WLog_ERR(TAG, "not enough remaining data");
 		return ERROR_INVALID_DATA;
 	}
 
 	Stream_Read_UINT32(s, unlockClipboardData->clipDataId); /* clipDataId (4 bytes) */
-    return CHANNEL_RC_OK;
+	return CHANNEL_RC_OK;
 }
 
 UINT cliprdr_read_format_data_request(wStream* s, CLIPRDR_FORMAT_DATA_REQUEST* request)
@@ -117,14 +119,14 @@ UINT cliprdr_read_format_data_request(wStream* s, CLIPRDR_FORMAT_DATA_REQUEST* r
 	}
 
 	Stream_Read_UINT32(s, request->requestedFormatId); /* requestedFormatId (4 bytes) */
-    return CHANNEL_RC_OK;
+	return CHANNEL_RC_OK;
 }
 
 UINT cliprdr_read_format_data_response(wStream* s, CLIPRDR_FORMAT_DATA_RESPONSE* response)
 {
-    response->requestedFormatData = NULL;
+	response->requestedFormatData = NULL;
 
-    if (Stream_GetRemainingLength(s) < response->dataLen)
+	if (Stream_GetRemainingLength(s) < response->dataLen)
 	{
 		WLog_ERR(TAG, "not enough data in stream!");
 		return ERROR_INVALID_DATA;
@@ -133,15 +135,15 @@ UINT cliprdr_read_format_data_response(wStream* s, CLIPRDR_FORMAT_DATA_RESPONSE*
 	if (response->dataLen)
 		response->requestedFormatData = Stream_Pointer(s);
 
-    return CHANNEL_RC_OK;
+	return CHANNEL_RC_OK;
 }
 
 UINT cliprdr_read_file_contents_request(wStream* s, CLIPRDR_FILE_CONTENTS_REQUEST* request)
 {
-    if (!cliprdr_validate_file_contents_request(request))
-        return ERROR_BAD_ARGUMENTS;
+	if (!cliprdr_validate_file_contents_request(request))
+		return ERROR_BAD_ARGUMENTS;
 
-    if (Stream_GetRemainingLength(s) < 24)
+	if (Stream_GetRemainingLength(s) < 24)
 	{
 		WLog_ERR(TAG, "not enough remaining data");
 		return ERROR_INVALID_DATA;
@@ -180,13 +182,13 @@ UINT cliprdr_read_file_contents_response(wStream* s, CLIPRDR_FILE_CONTENTS_RESPO
 
 UINT cliprdr_read_format_list(wStream* s, CLIPRDR_FORMAT_LIST* formatList, BOOL useLongFormatNames)
 {
-    UINT32 index;
+	UINT32 index;
 	size_t position;
 	BOOL asciiNames;
 	int formatNameLength;
 	char* szFormatName;
 	WCHAR* wszFormatName;
-    UINT32 dataLen = formatList->dataLen;
+	UINT32 dataLen = formatList->dataLen;
 	CLIPRDR_FORMAT* formats = NULL;
 	UINT error = CHANNEL_RC_OK;
 
@@ -208,12 +210,12 @@ UINT cliprdr_read_format_list(wStream* s, CLIPRDR_FORMAT_LIST* formatList, BOOL 
 
 		if ((formatList->numFormats * 36) != dataLen)
 		{
-			WLog_ERR(TAG, "Invalid short format list length: %"PRIu32"", dataLen);
+			WLog_ERR(TAG, "Invalid short format list length: %" PRIu32 "", dataLen);
 			return ERROR_INTERNAL_ERROR;
 		}
 
 		if (formatList->numFormats)
-			formats = (CLIPRDR_FORMAT*) calloc(formatList->numFormats, sizeof(CLIPRDR_FORMAT));
+			formats = (CLIPRDR_FORMAT*)calloc(formatList->numFormats, sizeof(CLIPRDR_FORMAT));
 
 		if (!formats)
 		{
@@ -240,12 +242,12 @@ UINT cliprdr_read_format_list(wStream* s, CLIPRDR_FORMAT_LIST* formatList, BOOL 
 
 			if (asciiNames)
 			{
-				szFormatName = (char*) Stream_Pointer(s);
+				szFormatName = (char*)Stream_Pointer(s);
 
 				if (szFormatName[0])
 				{
 					/* ensure null termination */
-					formats[index].formatName = (char*) malloc(32 + 1);
+					formats[index].formatName = (char*)malloc(32 + 1);
 					if (!formats[index].formatName)
 					{
 						WLog_ERR(TAG, "malloc failed!");
@@ -258,7 +260,7 @@ UINT cliprdr_read_format_list(wStream* s, CLIPRDR_FORMAT_LIST* formatList, BOOL 
 			}
 			else
 			{
-				wszFormatName = (WCHAR*) Stream_Pointer(s);
+				wszFormatName = (WCHAR*)Stream_Pointer(s);
 
 				if (wszFormatName[0])
 				{
@@ -266,7 +268,7 @@ UINT cliprdr_read_format_list(wStream* s, CLIPRDR_FORMAT_LIST* formatList, BOOL 
 					 * string on success, even if the source string isn't.
 					 */
 					if (ConvertFromUnicode(CP_UTF8, 0, wszFormatName, 16,
-						&(formats[index].formatName), 0, NULL, NULL) < 1)
+					                       &(formats[index].formatName), 0, NULL, NULL) < 1)
 					{
 						WLog_ERR(TAG, "failed to convert short clipboard format name");
 						error = ERROR_INTERNAL_ERROR;
@@ -287,7 +289,7 @@ UINT cliprdr_read_format_list(wStream* s, CLIPRDR_FORMAT_LIST* formatList, BOOL 
 			Stream_Seek(s, 4); /* formatId (4 bytes) */
 			dataLen -= 4;
 
-			wszFormatName = (WCHAR*) Stream_Pointer(s);
+			wszFormatName = (WCHAR*)Stream_Pointer(s);
 
 			if (!wszFormatName[0])
 				formatNameLength = 0;
@@ -304,7 +306,7 @@ UINT cliprdr_read_format_list(wStream* s, CLIPRDR_FORMAT_LIST* formatList, BOOL 
 		Stream_SetPosition(s, position);
 
 		if (formatList->numFormats)
-			formats = (CLIPRDR_FORMAT*) calloc(formatList->numFormats, sizeof(CLIPRDR_FORMAT));
+			formats = (CLIPRDR_FORMAT*)calloc(formatList->numFormats, sizeof(CLIPRDR_FORMAT));
 
 		if (!formats)
 		{
@@ -321,7 +323,7 @@ UINT cliprdr_read_format_list(wStream* s, CLIPRDR_FORMAT_LIST* formatList, BOOL 
 
 			formats[index].formatName = NULL;
 
-			wszFormatName = (WCHAR*) Stream_Pointer(s);
+			wszFormatName = (WCHAR*)Stream_Pointer(s);
 
 			if (!wszFormatName[0])
 				formatNameLength = 0;
@@ -330,8 +332,8 @@ UINT cliprdr_read_format_list(wStream* s, CLIPRDR_FORMAT_LIST* formatList, BOOL 
 
 			if (formatNameLength)
 			{
-				if (ConvertFromUnicode(CP_UTF8, 0, wszFormatName, -1,
-					&(formats[index].formatName), 0, NULL, NULL) < 1)
+				if (ConvertFromUnicode(CP_UTF8, 0, wszFormatName, -1, &(formats[index].formatName),
+				                       0, NULL, NULL) < 1)
 				{
 					WLog_ERR(TAG, "failed to convert long clipboard format name");
 					error = ERROR_INTERNAL_ERROR;
@@ -346,7 +348,7 @@ UINT cliprdr_read_format_list(wStream* s, CLIPRDR_FORMAT_LIST* formatList, BOOL 
 		}
 	}
 
-    return error;
+	return error;
 
 error_out:
 	cliprdr_free_format_list(formatList);
@@ -355,12 +357,12 @@ error_out:
 
 void cliprdr_free_format_list(CLIPRDR_FORMAT_LIST* formatList)
 {
-    UINT index = 0;
+	UINT index = 0;
 
-    if (formatList == NULL)
-        return;
+	if (formatList == NULL)
+		return;
 
-    if (formatList->formats)
+	if (formatList->formats)
 	{
 		for (index = 0; index < formatList->numFormats; index++)
 		{

--- a/channels/cliprdr/cliprdr_common.c
+++ b/channels/cliprdr/cliprdr_common.c
@@ -58,7 +58,26 @@ static BOOL cliprdr_validate_file_contents_request(const CLIPRDR_FILE_CONTENTS_R
 	return TRUE;
 }
 
-UINT cliprdr_write_file_contents_request(wStream* s, const CLIPRDR_FILE_CONTENTS_REQUEST* request)
+wStream* cliprdr_packet_new(UINT16 msgType, UINT16 msgFlags,
+                                   UINT32 dataLen)
+{
+	wStream* s;
+	s = Stream_New(NULL, dataLen + 8);
+
+	if (!s)
+	{
+		WLog_ERR(TAG, "Stream_New failed!");
+		return NULL;
+	}
+
+	Stream_Write_UINT16(s, msgType);
+	Stream_Write_UINT16(s, msgFlags);
+	/* Write actual length after the entire packet has been constructed. */
+	Stream_Seek(s, 4);
+	return s;
+}
+
+static void cliprdr_write_file_contents_request(wStream* s, const CLIPRDR_FILE_CONTENTS_REQUEST* request)
 {
 	Stream_Write_UINT32(s, request->streamId);      /* streamId (4 bytes) */
 	Stream_Write_UINT32(s, request->listIndex);     /* listIndex (4 bytes) */
@@ -69,35 +88,224 @@ UINT cliprdr_write_file_contents_request(wStream* s, const CLIPRDR_FILE_CONTENTS
 
 	if (request->haveClipDataId)
 		Stream_Write_UINT32(s, request->clipDataId); /* clipDataId (4 bytes) */
-
-	return CHANNEL_RC_OK;
 }
 
-static INLINE UINT cliprdr_write_lock_unlock_clipdata(wStream* s, UINT32 clipDataId)
+static INLINE void cliprdr_write_lock_unlock_clipdata(wStream* s, UINT32 clipDataId)
 {
 	Stream_Write_UINT32(s, clipDataId);
-	return CHANNEL_RC_OK;
 }
 
-UINT cliprdr_write_lock_clipdata(wStream* s, const CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData)
+static void cliprdr_write_lock_clipdata(wStream* s, const CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData)
 {
-	return cliprdr_write_lock_unlock_clipdata(s, lockClipboardData->clipDataId);
+	cliprdr_write_lock_unlock_clipdata(s, lockClipboardData->clipDataId);
 }
 
-UINT cliprdr_write_unlock_clipdata(wStream* s,
+static void cliprdr_write_unlock_clipdata(wStream* s,
                                    const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData)
 {
-	return cliprdr_write_lock_unlock_clipdata(s, unlockClipboardData->clipDataId);
+	cliprdr_write_lock_unlock_clipdata(s, unlockClipboardData->clipDataId);
 }
 
-UINT cliprdr_write_file_contents_response(wStream* s,
+static void cliprdr_write_file_contents_response(wStream* s,
                                           const CLIPRDR_FILE_CONTENTS_RESPONSE* response)
 {
 	Stream_Write_UINT32(s, response->streamId); /* streamId (4 bytes) */
 	Stream_Write(s, response->requestedData, response->cbRequested);
-	return CHANNEL_RC_OK;
 }
 
+wStream* cliprdr_packet_lock_clipdata_new(const CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData)
+{
+	wStream* s;
+
+	if (!lockClipboardData)
+		return NULL;
+
+	s = cliprdr_packet_new(CB_LOCK_CLIPDATA, 0, 4);
+
+	if (!s)
+		return NULL;
+
+	cliprdr_write_lock_clipdata(s, lockClipboardData);
+	return s;
+}
+
+wStream* cliprdr_packet_unlock_clipdata_new(const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData)
+{
+	wStream* s;
+
+	if (!unlockClipboardData)
+		return NULL;
+
+	s = cliprdr_packet_new(CB_LOCK_CLIPDATA, 0, 4);
+
+	if (!s)
+		return NULL;
+
+	cliprdr_write_unlock_clipdata(s, unlockClipboardData);
+	return s;
+}
+
+wStream* cliprdr_packet_file_contents_request_new(const CLIPRDR_FILE_CONTENTS_REQUEST* request)
+{
+	wStream* s;
+
+	if (!request)
+		return NULL;
+
+	s = cliprdr_packet_new(CB_FILECONTENTS_REQUEST, 0, 28);
+
+	if (!s)
+		return NULL;
+
+	cliprdr_write_file_contents_request(s, request);
+	return s;
+}
+
+wStream* cliprdr_packet_file_contents_response_new(const CLIPRDR_FILE_CONTENTS_RESPONSE* response)
+{
+	wStream* s;
+
+	if (!response)
+		return NULL;
+
+	s = cliprdr_packet_new(CB_FILECONTENTS_RESPONSE, response->msgFlags,
+	                              4 + response->cbRequested);
+
+	if (!s)
+		return NULL;
+
+	cliprdr_write_file_contents_response(s, response);
+	return s;
+}
+
+wStream* cliprdr_packet_format_list_new(const CLIPRDR_FORMAT_LIST* formatList, BOOL useLongFormatNames)
+{
+	wStream* s;
+	UINT32 index;
+	int cchWideChar;
+	LPWSTR lpWideCharStr;
+	int formatNameSize;
+	char* szFormatName;
+	WCHAR* wszFormatName;
+	BOOL asciiNames = FALSE;
+	CLIPRDR_FORMAT* format;
+
+	if (formatList->msgType != CB_FORMAT_LIST)
+		WLog_WARN(TAG, "[%s] called with invalid type %08"PRIx32, __FUNCTION__, formatList->msgType);
+
+	if (!useLongFormatNames)
+	{
+		UINT32 length = formatList->numFormats * 36;
+		s = cliprdr_packet_new(CB_FORMAT_LIST, 0, length);
+
+		if (!s)
+		{
+			WLog_ERR(TAG, "cliprdr_packet_new failed!");
+			return NULL;
+		}
+
+		for (index = 0; index < formatList->numFormats; index++)
+		{
+			size_t formatNameLength = 0;
+			format = (CLIPRDR_FORMAT*) & (formatList->formats[index]);
+			Stream_Write_UINT32(s, format->formatId); /* formatId (4 bytes) */
+			formatNameSize = 0;
+
+			szFormatName = format->formatName;
+
+			if (asciiNames)
+			{
+				if (szFormatName)
+					formatNameLength = strlen(szFormatName);
+
+				if (formatNameLength > 31)
+					formatNameLength = 31;
+
+				Stream_Write(s, szFormatName, formatNameLength);
+				Stream_Zero(s, 32 - formatNameLength);
+			}
+			else
+			{
+				wszFormatName = NULL;
+
+				if (szFormatName)
+					formatNameSize = ConvertToUnicode(CP_UTF8, 0, szFormatName, -1, &wszFormatName,
+					                                  0);
+
+				if (formatNameSize < 0)
+					return NULL;
+
+				if (formatNameSize > 15)
+					formatNameSize = 15;
+
+				/* size in bytes  instead of wchar */
+				formatNameSize *= 2;
+
+				if (wszFormatName)
+					Stream_Write(s, wszFormatName, (size_t)formatNameSize);
+
+				Stream_Zero(s, (size_t)(32 - formatNameSize));
+				free(wszFormatName);
+			}
+		}
+	}
+	else
+	{
+		UINT32 length = 0;
+		for (index = 0; index < formatList->numFormats; index++)
+		{
+			format = (CLIPRDR_FORMAT*) & (formatList->formats[index]);
+			length += 4;
+			formatNameSize = 2;
+
+			if (format->formatName)
+				formatNameSize = MultiByteToWideChar(CP_UTF8, 0, format->formatName, -1, NULL,
+				                                     0) * 2;
+
+			if (formatNameSize < 0)
+				return NULL;
+
+			length += (UINT32)formatNameSize;
+		}
+
+		s = cliprdr_packet_new(CB_FORMAT_LIST, 0, length);
+
+		if (!s)
+		{
+			WLog_ERR(TAG, "cliprdr_packet_new failed!");
+			return NULL;
+		}
+
+		for (index = 0; index < formatList->numFormats; index++)
+		{
+			format = (CLIPRDR_FORMAT*) & (formatList->formats[index]);
+			Stream_Write_UINT32(s, format->formatId); /* formatId (4 bytes) */
+
+			if (format->formatName)
+			{
+				const size_t cap = Stream_Capacity(s);
+				const size_t pos = Stream_GetPosition(s);
+				const size_t rem = cap - pos;
+				if ((cap < pos) || ((rem / 2) > INT_MAX))
+					return NULL;
+
+				lpWideCharStr = (LPWSTR) Stream_Pointer(s);
+				cchWideChar = (int)(rem / 2);
+				formatNameSize = MultiByteToWideChar(CP_UTF8, 0,
+				                                     format->formatName, -1, lpWideCharStr, cchWideChar) * 2;
+				if (formatNameSize < 0)
+					return NULL;
+				Stream_Seek(s, (size_t)formatNameSize);
+			}
+			else
+			{
+				Stream_Write_UINT16(s, 0);
+			}
+		}
+	}
+
+	return s;
+}
 UINT cliprdr_read_unlock_clipdata(wStream* s, CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData)
 {
 	if (Stream_GetRemainingLength(s) < 4)

--- a/channels/cliprdr/cliprdr_common.c
+++ b/channels/cliprdr/cliprdr_common.c
@@ -1,0 +1,372 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Cliprdr common
+ *
+ * Copyright 2013 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+ * Copyright 2015 Thincast Technologies GmbH
+ * Copyright 2015 DI (FH) Martin Haimberger <martin.haimberger@thincast.com>
+ * Copyright 2019 Kobi Mizrachi <kmizrachi18@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <winpr/crt.h>
+#include <winpr/stream.h>
+#include <freerdp/channels/log.h>
+
+#define TAG CHANNELS_TAG("cliprdr.common")
+
+#include "cliprdr_common.h"
+
+static BOOL cliprdr_validate_file_contents_request(const CLIPRDR_FILE_CONTENTS_REQUEST* request)
+{
+    /*
+     * [MS-RDPECLIP] 2.2.5.3 File Contents Request PDU (CLIPRDR_FILECONTENTS_REQUEST).
+     *
+	 * A request for the size of the file identified by the lindex field. The size MUST be
+	 * returned as a 64-bit, unsigned integer. The cbRequested field MUST be set to
+	 * 0x00000008 and both the nPositionLow and nPositionHigh fields MUST be
+	 * set to 0x00000000.
+	 */
+
+	if (request->dwFlags & FILECONTENTS_SIZE)
+	{
+		if (request->cbRequested != sizeof(UINT64))
+		{
+			WLog_ERR(TAG, "[%s]: cbRequested must be %"PRIu32", got %"PRIu32"", __FUNCTION__,
+			         sizeof(UINT64), request->cbRequested);
+			return FALSE;
+		}
+
+		if (request->nPositionHigh != 0 || request->nPositionLow != 0)
+		{
+			WLog_ERR(TAG, "[%s]: nPositionHigh and nPositionLow must be set to 0", __FUNCTION__);
+			return FALSE;
+		}
+	}
+
+    return TRUE;
+}
+
+UINT cliprdr_write_file_contents_request(wStream* s, const CLIPRDR_FILE_CONTENTS_REQUEST* request)
+{
+	Stream_Write_UINT32(s, request->streamId);      /* streamId (4 bytes) */
+	Stream_Write_UINT32(s, request->listIndex);     /* listIndex (4 bytes) */
+	Stream_Write_UINT32(s, request->dwFlags);       /* dwFlags (4 bytes) */
+	Stream_Write_UINT32(s, request->nPositionLow);  /* nPositionLow (4 bytes) */
+	Stream_Write_UINT32(s, request->nPositionHigh); /* nPositionHigh (4 bytes) */
+	Stream_Write_UINT32(s, request->cbRequested);   /* cbRequested (4 bytes) */
+
+	if (request->haveClipDataId)
+		Stream_Write_UINT32(s, request->clipDataId); /* clipDataId (4 bytes) */
+    
+    return CHANNEL_RC_OK;
+}
+
+static INLINE UINT cliprdr_write_lock_unlock_clipdata(wStream* s, UINT32 clipDataId)
+{
+    Stream_Write_UINT32(s, clipDataId);
+    return CHANNEL_RC_OK;
+}
+
+UINT cliprdr_write_lock_clipdata(wStream* s, const CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData)
+{
+    return cliprdr_write_lock_unlock_clipdata(s, lockClipboardData->clipDataId);
+}
+
+UINT cliprdr_write_unlock_clipdata(wStream* s, const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData)
+{
+    return cliprdr_write_lock_unlock_clipdata(s, unlockClipboardData->clipDataId);
+}
+
+UINT cliprdr_write_file_contents_response(wStream* s, const CLIPRDR_FILE_CONTENTS_RESPONSE* response)
+{
+	Stream_Write_UINT32(s, response->streamId); /* streamId (4 bytes) */
+	Stream_Write(s, response->requestedData, response->cbRequested);
+    return CHANNEL_RC_OK;
+}
+
+UINT cliprdr_read_unlock_clipdata(wStream* s, CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData)
+{
+    if (Stream_GetRemainingLength(s) < 4)
+	{
+		WLog_ERR(TAG, "not enough remaining data");
+		return ERROR_INVALID_DATA;
+	}
+
+	Stream_Read_UINT32(s, unlockClipboardData->clipDataId); /* clipDataId (4 bytes) */
+    return CHANNEL_RC_OK;
+}
+
+UINT cliprdr_read_format_data_request(wStream* s, CLIPRDR_FORMAT_DATA_REQUEST* request)
+{
+	if (Stream_GetRemainingLength(s) < 4)
+	{
+		WLog_ERR(TAG, "not enough data in stream!");
+		return ERROR_INVALID_DATA;
+	}
+
+	Stream_Read_UINT32(s, request->requestedFormatId); /* requestedFormatId (4 bytes) */
+    return CHANNEL_RC_OK;
+}
+
+UINT cliprdr_read_format_data_response(wStream* s, CLIPRDR_FORMAT_DATA_RESPONSE* response)
+{
+    response->requestedFormatData = NULL;
+
+    if (Stream_GetRemainingLength(s) < response->dataLen)
+	{
+		WLog_ERR(TAG, "not enough data in stream!");
+		return ERROR_INVALID_DATA;
+	}
+
+	if (response->dataLen)
+		response->requestedFormatData = Stream_Pointer(s);
+
+    return CHANNEL_RC_OK;
+}
+
+UINT cliprdr_read_file_contents_request(wStream* s, CLIPRDR_FILE_CONTENTS_REQUEST* request)
+{
+    if (!cliprdr_validate_file_contents_request(request))
+        return ERROR_BAD_ARGUMENTS;
+
+    if (Stream_GetRemainingLength(s) < 24)
+	{
+		WLog_ERR(TAG, "not enough remaining data");
+		return ERROR_INVALID_DATA;
+	}
+
+	request->haveClipDataId = FALSE;
+	Stream_Read_UINT32(s, request->streamId);      /* streamId (4 bytes) */
+	Stream_Read_UINT32(s, request->listIndex);     /* listIndex (4 bytes) */
+	Stream_Read_UINT32(s, request->dwFlags);       /* dwFlags (4 bytes) */
+	Stream_Read_UINT32(s, request->nPositionLow);  /* nPositionLow (4 bytes) */
+	Stream_Read_UINT32(s, request->nPositionHigh); /* nPositionHigh (4 bytes) */
+	Stream_Read_UINT32(s, request->cbRequested);   /* cbRequested (4 bytes) */
+
+	if (Stream_GetRemainingLength(s) >= 4)
+	{
+		Stream_Read_UINT32(s, request->clipDataId); /* clipDataId (4 bytes) */
+		request->haveClipDataId = TRUE;
+	}
+
+	return CHANNEL_RC_OK;
+}
+
+UINT cliprdr_read_file_contents_response(wStream* s, CLIPRDR_FILE_CONTENTS_RESPONSE* response)
+{
+	if (Stream_GetRemainingLength(s) < 4)
+	{
+		WLog_ERR(TAG, "not enough remaining data");
+		return ERROR_INVALID_DATA;
+	}
+
+	Stream_Read_UINT32(s, response->streamId);   /* streamId (4 bytes) */
+	response->requestedData = Stream_Pointer(s); /* requestedFileContentsData */
+	response->cbRequested = response->dataLen - 4;
+	return CHANNEL_RC_OK;
+}
+
+UINT cliprdr_read_format_list(wStream* s, CLIPRDR_FORMAT_LIST* formatList, BOOL useLongFormatNames)
+{
+    UINT32 index;
+	size_t position;
+	BOOL asciiNames;
+	int formatNameLength;
+	char* szFormatName;
+	WCHAR* wszFormatName;
+    UINT32 dataLen = formatList->dataLen;
+	CLIPRDR_FORMAT* formats = NULL;
+	UINT error = CHANNEL_RC_OK;
+
+	asciiNames = (formatList->msgFlags & CB_ASCII_NAMES) ? TRUE : FALSE;
+
+	index = 0;
+	formatList->numFormats = 0;
+	position = Stream_GetPosition(s);
+
+	if (!formatList->dataLen)
+	{
+		/* empty format list */
+		formatList->formats = NULL;
+		formatList->numFormats = 0;
+	}
+	else if (!useLongFormatNames)
+	{
+		formatList->numFormats = (dataLen / 36);
+
+		if ((formatList->numFormats * 36) != dataLen)
+		{
+			WLog_ERR(TAG, "Invalid short format list length: %"PRIu32"", dataLen);
+			return ERROR_INTERNAL_ERROR;
+		}
+
+		if (formatList->numFormats)
+			formats = (CLIPRDR_FORMAT*) calloc(formatList->numFormats, sizeof(CLIPRDR_FORMAT));
+
+		if (!formats)
+		{
+			WLog_ERR(TAG, "calloc failed!");
+			return CHANNEL_RC_NO_MEMORY;
+		}
+
+		formatList->formats = formats;
+
+		while (dataLen)
+		{
+			Stream_Read_UINT32(s, formats[index].formatId); /* formatId (4 bytes) */
+			dataLen -= 4;
+
+			formats[index].formatName = NULL;
+
+			/* According to MS-RDPECLIP 2.2.3.1.1.1 formatName is "a 32-byte block containing
+			 * the *null-terminated* name assigned to the Clipboard Format: (32 ASCII 8 characters
+			 * or 16 Unicode characters)"
+			 * However, both Windows RDSH and mstsc violate this specs as seen in the following
+			 * example of a transferred short format name string: [R.i.c.h. .T.e.x.t. .F.o.r.m.a.t.]
+			 * These are 16 unicode charaters - *without* terminating null !
+			 */
+
+			if (asciiNames)
+			{
+				szFormatName = (char*) Stream_Pointer(s);
+
+				if (szFormatName[0])
+				{
+					/* ensure null termination */
+					formats[index].formatName = (char*) malloc(32 + 1);
+					if (!formats[index].formatName)
+					{
+						WLog_ERR(TAG, "malloc failed!");
+						error = CHANNEL_RC_NO_MEMORY;
+						goto error_out;
+					}
+					CopyMemory(formats[index].formatName, szFormatName, 32);
+					formats[index].formatName[32] = '\0';
+				}
+			}
+			else
+			{
+				wszFormatName = (WCHAR*) Stream_Pointer(s);
+
+				if (wszFormatName[0])
+				{
+					/* ConvertFromUnicode always returns a null-terminated
+					 * string on success, even if the source string isn't.
+					 */
+					if (ConvertFromUnicode(CP_UTF8, 0, wszFormatName, 16,
+						&(formats[index].formatName), 0, NULL, NULL) < 1)
+					{
+						WLog_ERR(TAG, "failed to convert short clipboard format name");
+						error = ERROR_INTERNAL_ERROR;
+						goto error_out;
+					}
+				}
+			}
+
+			Stream_Seek(s, 32);
+			dataLen -= 32;
+			index++;
+		}
+	}
+	else
+	{
+		while (dataLen)
+		{
+			Stream_Seek(s, 4); /* formatId (4 bytes) */
+			dataLen -= 4;
+
+			wszFormatName = (WCHAR*) Stream_Pointer(s);
+
+			if (!wszFormatName[0])
+				formatNameLength = 0;
+			else
+				formatNameLength = _wcslen(wszFormatName);
+
+			Stream_Seek(s, (formatNameLength + 1) * 2);
+			dataLen -= ((formatNameLength + 1) * 2);
+
+			formatList->numFormats++;
+		}
+
+		dataLen = formatList->dataLen;
+		Stream_SetPosition(s, position);
+
+		if (formatList->numFormats)
+			formats = (CLIPRDR_FORMAT*) calloc(formatList->numFormats, sizeof(CLIPRDR_FORMAT));
+
+		if (!formats)
+		{
+			WLog_ERR(TAG, "calloc failed!");
+			return CHANNEL_RC_NO_MEMORY;
+		}
+
+		formatList->formats = formats;
+
+		while (dataLen)
+		{
+			Stream_Read_UINT32(s, formats[index].formatId); /* formatId (4 bytes) */
+			dataLen -= 4;
+
+			formats[index].formatName = NULL;
+
+			wszFormatName = (WCHAR*) Stream_Pointer(s);
+
+			if (!wszFormatName[0])
+				formatNameLength = 0;
+			else
+				formatNameLength = _wcslen(wszFormatName);
+
+			if (formatNameLength)
+			{
+				if (ConvertFromUnicode(CP_UTF8, 0, wszFormatName, -1,
+					&(formats[index].formatName), 0, NULL, NULL) < 1)
+				{
+					WLog_ERR(TAG, "failed to convert long clipboard format name");
+					error = ERROR_INTERNAL_ERROR;
+					goto error_out;
+				}
+			}
+
+			Stream_Seek(s, (formatNameLength + 1) * 2);
+			dataLen -= ((formatNameLength + 1) * 2);
+
+			index++;
+		}
+	}
+
+    return error;
+
+error_out:
+	cliprdr_free_format_list(formatList);
+	return error;
+}
+
+void cliprdr_free_format_list(CLIPRDR_FORMAT_LIST* formatList)
+{
+    UINT index = 0;
+
+    if (formatList == NULL)
+        return;
+
+    if (formatList->formats)
+	{
+		for (index = 0; index < formatList->numFormats; index++)
+		{
+			free(formatList->formats[index].formatName);
+		}
+
+		free(formatList->formats);
+	}
+}

--- a/channels/cliprdr/cliprdr_common.h
+++ b/channels/cliprdr/cliprdr_common.h
@@ -1,0 +1,47 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Cliprdr common
+ *
+ * Copyright 2013 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+ * Copyright 2015 Thincast Technologies GmbH
+ * Copyright 2015 DI (FH) Martin Haimberger <martin.haimberger@thincast.com>
+ * Copyright 2019 Kobi Mizrachi <kmizrachi18@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_RDPECLIP_COMMON_H
+#define FREERDP_CHANNEL_RDPECLIP_COMMON_H
+
+#include <winpr/crt.h>
+#include <winpr/stream.h>
+
+#include <freerdp/channels/cliprdr.h>
+#include <freerdp/api.h>
+
+FREERDP_LOCAL UINT cliprdr_write_lock_clipdata(wStream* s, const CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData);
+FREERDP_LOCAL UINT cliprdr_write_unlock_clipdata(wStream* s, const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData);
+FREERDP_LOCAL UINT cliprdr_write_file_contents_request(wStream* s, const CLIPRDR_FILE_CONTENTS_REQUEST* request);
+FREERDP_LOCAL UINT cliprdr_write_file_contents_response(wStream* s, const CLIPRDR_FILE_CONTENTS_RESPONSE* response);
+
+FREERDP_LOCAL UINT cliprdr_read_lock_clipdata(wStream* s, CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData);
+FREERDP_LOCAL UINT cliprdr_read_unlock_clipdata(wStream* s, CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData);
+FREERDP_LOCAL UINT cliprdr_read_format_data_request(wStream* s, CLIPRDR_FORMAT_DATA_REQUEST* formatDataRequest);
+FREERDP_LOCAL UINT cliprdr_read_format_data_response(wStream* s, CLIPRDR_FORMAT_DATA_RESPONSE* response);
+FREERDP_LOCAL UINT cliprdr_read_file_contents_request(wStream* s, CLIPRDR_FILE_CONTENTS_REQUEST* fileContentsRequest);
+FREERDP_LOCAL UINT cliprdr_read_file_contents_response(wStream* s, CLIPRDR_FILE_CONTENTS_RESPONSE* response);
+FREERDP_LOCAL UINT cliprdr_read_format_list(wStream* s, CLIPRDR_FORMAT_LIST* formatList, BOOL useLongFormatNames);
+
+FREERDP_LOCAL void cliprdr_free_format_list(CLIPRDR_FORMAT_LIST* formatList);
+
+#endif /* FREERDP_CHANNEL_RDPECLIP_COMMON_H */

--- a/channels/cliprdr/cliprdr_common.h
+++ b/channels/cliprdr/cliprdr_common.h
@@ -29,10 +29,12 @@
 #include <freerdp/channels/cliprdr.h>
 #include <freerdp/api.h>
 
-FREERDP_LOCAL UINT cliprdr_write_lock_clipdata(wStream* s, const CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData);
-FREERDP_LOCAL UINT cliprdr_write_unlock_clipdata(wStream* s, const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData);
-FREERDP_LOCAL UINT cliprdr_write_file_contents_request(wStream* s, const CLIPRDR_FILE_CONTENTS_REQUEST* request);
-FREERDP_LOCAL UINT cliprdr_write_file_contents_response(wStream* s, const CLIPRDR_FILE_CONTENTS_RESPONSE* response);
+FREERDP_LOCAL wStream* cliprdr_packet_new(UINT16 msgType, UINT16 msgFlags, UINT32 dataLen);
+FREERDP_LOCAL wStream* cliprdr_packet_lock_clipdata_new(const CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData);
+FREERDP_LOCAL wStream* cliprdr_packet_unlock_clipdata_new(const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData);
+FREERDP_LOCAL wStream* cliprdr_packet_file_contents_request_new(const CLIPRDR_FILE_CONTENTS_REQUEST* request);
+FREERDP_LOCAL wStream* cliprdr_packet_file_contents_response_new(const CLIPRDR_FILE_CONTENTS_RESPONSE* response);
+FREERDP_LOCAL wStream* cliprdr_packet_format_list_new(const CLIPRDR_FORMAT_LIST* formatList, BOOL useLongFormatNames);
 
 FREERDP_LOCAL UINT cliprdr_read_lock_clipdata(wStream* s, CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData);
 FREERDP_LOCAL UINT cliprdr_read_unlock_clipdata(wStream* s, CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData);

--- a/channels/cliprdr/server/CMakeLists.txt
+++ b/channels/cliprdr/server/CMakeLists.txt
@@ -19,7 +19,10 @@ define_channel_server("cliprdr")
 
 set(${MODULE_PREFIX}_SRCS
 	cliprdr_main.c
-	cliprdr_main.h)
+	cliprdr_main.h
+	../cliprdr_common.h
+	../cliprdr_common.c
+	)
 
 add_channel_server_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} FALSE "VirtualChannelEntry")
 

--- a/channels/cliprdr/server/cliprdr_main.c
+++ b/channels/cliprdr/server/cliprdr_main.c
@@ -29,6 +29,7 @@
 
 #include <freerdp/channels/log.h>
 #include "cliprdr_main.h"
+#include "../cliprdr_common.h"
 
 /**
  *                                    Initialization Sequence\n
@@ -384,6 +385,7 @@ static UINT cliprdr_server_format_list_response(CliprdrServerContext* context,
 static UINT cliprdr_server_lock_clipboard_data(CliprdrServerContext* context,
         const CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData)
 {
+	UINT error = CHANNEL_RC_OK;
 	wStream* s;
 	CliprdrServerPrivate* cliprdr = (CliprdrServerPrivate*) context->handle;
 	if (lockClipboardData->msgType != CB_LOCK_CLIPDATA)
@@ -396,11 +398,16 @@ static UINT cliprdr_server_lock_clipboard_data(CliprdrServerContext* context,
 		return ERROR_INTERNAL_ERROR;
 	}
 
-	Stream_Write_UINT32(s,
-	                    lockClipboardData->clipDataId); /* clipDataId (4 bytes) */
+	if ((error = cliprdr_write_lock_clipdata(s, lockClipboardData)))
+		goto fail;
+
 	WLog_DBG(TAG, "ServerLockClipboardData: clipDataId: 0x%08"PRIX32"",
 	         lockClipboardData->clipDataId);
 	return cliprdr_server_packet_send(cliprdr, s);
+
+fail:
+	Stream_Free(s, TRUE);
+	return error;
 }
 
 /**
@@ -411,6 +418,7 @@ static UINT cliprdr_server_lock_clipboard_data(CliprdrServerContext* context,
 static UINT cliprdr_server_unlock_clipboard_data(CliprdrServerContext* context,
         const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData)
 {
+	UINT error = CHANNEL_RC_OK;
 	wStream* s;
 	CliprdrServerPrivate* cliprdr = (CliprdrServerPrivate*) context->handle;
 	if (unlockClipboardData->msgType != CB_UNLOCK_CLIPDATA)
@@ -424,11 +432,16 @@ static UINT cliprdr_server_unlock_clipboard_data(CliprdrServerContext* context,
 		return ERROR_INTERNAL_ERROR;
 	}
 
-	Stream_Write_UINT32(s,
-	                    unlockClipboardData->clipDataId); /* clipDataId (4 bytes) */
+	if ((error = cliprdr_write_unlock_clipdata(s, unlockClipboardData)))
+		goto fail;
+
 	WLog_DBG(TAG, "ServerUnlockClipboardData: clipDataId: 0x%08"PRIX32"",
 	         unlockClipboardData->clipDataId);
 	return cliprdr_server_packet_send(cliprdr, s);
+
+fail:
+	Stream_Free(s, TRUE);
+	return error;
 }
 
 /**
@@ -496,6 +509,7 @@ static UINT cliprdr_server_format_data_response(CliprdrServerContext* context,
 static UINT cliprdr_server_file_contents_request(CliprdrServerContext* context,
         const CLIPRDR_FILE_CONTENTS_REQUEST* fileContentsRequest)
 {
+	UINT error = CHANNEL_RC_OK;
 	wStream* s;
 	CliprdrServerPrivate* cliprdr = (CliprdrServerPrivate*) context->handle;
 
@@ -510,21 +524,16 @@ static UINT cliprdr_server_file_contents_request(CliprdrServerContext* context,
 		return ERROR_INTERNAL_ERROR;
 	}
 
-	Stream_Write_UINT32(s, fileContentsRequest->streamId); /* streamId (4 bytes) */
-	Stream_Write_UINT32(s,
-	                    fileContentsRequest->listIndex); /* listIndex (4 bytes) */
-	Stream_Write_UINT32(s, fileContentsRequest->dwFlags); /* dwFlags (4 bytes) */
-	Stream_Write_UINT32(s,
-	                    fileContentsRequest->nPositionLow); /* nPositionLow (4 bytes) */
-	Stream_Write_UINT32(s,
-	                    fileContentsRequest->nPositionHigh); /* nPositionHigh (4 bytes) */
-	Stream_Write_UINT32(s,
-	                    fileContentsRequest->cbRequested); /* cbRequested (4 bytes) */
-	Stream_Write_UINT32(s,
-	                    fileContentsRequest->clipDataId); /* clipDataId (4 bytes) */
+	if ((error = cliprdr_write_file_contents_request(s, fileContentsRequest)))
+		goto fail;
+
 	WLog_DBG(TAG, "ServerFileContentsRequest: streamId: 0x%08"PRIX32"",
 	         fileContentsRequest->streamId);
 	return cliprdr_server_packet_send(cliprdr, s);
+
+fail:
+	Stream_Free(s, TRUE);
+	return error;
 }
 
 /**
@@ -535,19 +544,15 @@ static UINT cliprdr_server_file_contents_request(CliprdrServerContext* context,
 static UINT cliprdr_server_file_contents_response(CliprdrServerContext* context,
         const CLIPRDR_FILE_CONTENTS_RESPONSE* fileContentsResponse)
 {
+	UINT error = CHANNEL_RC_OK;
 	wStream* s;
 	CliprdrServerPrivate* cliprdr = (CliprdrServerPrivate*) context->handle;
-	UINT32 cbRequested = fileContentsResponse->cbRequested;
 
 	if (fileContentsResponse->msgType != CB_FILECONTENTS_RESPONSE)
 		WLog_WARN(TAG, "[%s] called with invalid type %08"PRIx32, __FUNCTION__, fileContentsResponse->msgType);
 
-	if (fileContentsResponse->dwFlags & FILECONTENTS_SIZE)
-		cbRequested = sizeof(UINT64);
-
-	s = cliprdr_server_packet_new(CB_FILECONTENTS_RESPONSE,
-	                              fileContentsResponse->msgFlags,
-								  4 + cbRequested);
+	s = cliprdr_server_packet_new(CB_FILECONTENTS_RESPONSE, fileContentsResponse->msgFlags,
+	                              4 + fileContentsResponse->cbRequested);
 
 	if (!s)
 	{
@@ -555,17 +560,16 @@ static UINT cliprdr_server_file_contents_response(CliprdrServerContext* context,
 		return ERROR_INTERNAL_ERROR;
 	}
 
-	Stream_Write_UINT32(s, fileContentsResponse->streamId); /* streamId (4 bytes) */
-	/**
-	 * requestedFileContentsData:
-	 * FILECONTENTS_SIZE: file size as UINT64
-	 * FILECONTENTS_RANGE: file data from requested range
-	 */
-	Stream_Write(s, fileContentsResponse->requestedData,
-				 cbRequested);
-	WLog_DBG(TAG, "ServerFileContentsResponse: streamId: 0x%08"PRIX32"",
+	if ((error = cliprdr_write_file_contents_response(s, fileContentsResponse)))
+		goto fail;
+
+	WLog_DBG(TAG, "ServerFileContentsResponse: streamId: 0x%08" PRIX32 "",
 	         fileContentsResponse->streamId);
 	return cliprdr_server_packet_send(cliprdr, s);
+
+fail:
+	Stream_Free(s, TRUE);
+	return error;
 }
 
 /**
@@ -734,166 +738,15 @@ static UINT cliprdr_server_receive_temporary_directory(CliprdrServerContext*
 static UINT cliprdr_server_receive_format_list(CliprdrServerContext* context,
         wStream* s, const CLIPRDR_HEADER* header)
 {
-	UINT32 index;
-	UINT32 dataLen;
-	size_t position;
-	BOOL asciiNames;
-	char* szFormatName;
-	WCHAR* wszFormatName;
-	CLIPRDR_FORMAT* formats = NULL;
 	CLIPRDR_FORMAT_LIST formatList;
 	UINT error = CHANNEL_RC_OK;
-	dataLen = header->dataLen;
-	asciiNames = (header->msgFlags & CB_ASCII_NAMES) ? TRUE : FALSE;
+
 	formatList.msgType = CB_FORMAT_LIST;
 	formatList.msgFlags = header->msgFlags;
 	formatList.dataLen = header->dataLen;
-	index = 0;
-	formatList.numFormats = 0;
-	position = Stream_GetPosition(s);
 
-	if (!header->dataLen)
-	{
-		/* empty format list */
-		formatList.formats = NULL;
-		formatList.numFormats = 0;
-	}
-	else if (!context->useLongFormatNames)
-	{
-		formatList.numFormats = (dataLen / 36);
-
-		if ((formatList.numFormats * 36) != dataLen)
-		{
-			WLog_ERR(TAG, "Invalid short format list length: %"PRIu32"", dataLen);
-			return ERROR_INVALID_PARAMETER;
-		}
-
-		if (formatList.numFormats)
-			formats = (CLIPRDR_FORMAT*) calloc(formatList.numFormats,
-			                                   sizeof(CLIPRDR_FORMAT));
-
-		if (!formats)
-		{
-			WLog_ERR(TAG, "calloc failed!");
-			return CHANNEL_RC_NO_MEMORY;
-		}
-
-		formatList.formats = formats;
-
-		while (dataLen)
-		{
-			Stream_Read_UINT32(s, formats[index].formatId); /* formatId (4 bytes) */
-			dataLen -= 4;
-			formats[index].formatName = NULL;
-
-			/* According to MS-RDPECLIP 2.2.3.1.1.1 formatName is "a 32-byte block containing
-			 * the *null-terminated* name assigned to the Clipboard Format: (32 ASCII 8 characters
-			 * or 16 Unicode characters)"
-			 * However, both Windows RDSH and mstsc violate this specs as seen in the following
-			 * example of a transferred short format name string: [R.i.c.h. .T.e.x.t. .F.o.r.m.a.t.]
-			 * These are 16 unicode charaters - *without* terminating null !
-			 */
-
-			if (asciiNames)
-			{
-				szFormatName = (char*) Stream_Pointer(s);
-
-				if (szFormatName[0])
-				{
-					/* ensure null termination */
-					formats[index].formatName = (char*) malloc(32 + 1);
-					CopyMemory(formats[index].formatName, szFormatName, 32);
-					formats[index].formatName[32] = '\0';
-				}
-			}
-			else
-			{
-				wszFormatName = (WCHAR*) Stream_Pointer(s);
-
-				if (wszFormatName[0])
-				{
-					/* ConvertFromUnicode always returns a null-terminated
-					 * string on success, even if the source string isn't.
-					 */
-					if (ConvertFromUnicode(CP_UTF8, 0, wszFormatName, 16,
-					                       &(formats[index].formatName), 0, NULL, NULL) < 1)
-					{
-						WLog_ERR(TAG, "failed to convert short clipboard format name");
-						error = ERROR_INVALID_DATA;
-						goto out;
-					}
-				}
-			}
-
-			Stream_Seek(s, 32);
-			dataLen -= 32;
-			index++;
-		}
-	}
-	else
-	{
-		while (dataLen)
-		{
-			size_t formatNameLength;
-			Stream_Seek(s, 4); /* formatId (4 bytes) */
-			dataLen -= 4;
-			wszFormatName = (WCHAR*) Stream_Pointer(s);
-
-			if (!wszFormatName[0])
-				formatNameLength = 0;
-			else
-				formatNameLength = _wcslen(wszFormatName);
-
-			Stream_Seek(s, (formatNameLength + 1) * 2);
-			dataLen -= ((formatNameLength + 1) * 2);
-			formatList.numFormats++;
-		}
-
-		dataLen = formatList.dataLen;
-		Stream_SetPosition(s, position);
-
-		if (formatList.numFormats)
-			formats = (CLIPRDR_FORMAT*) calloc(formatList.numFormats,
-			                                   sizeof(CLIPRDR_FORMAT));
-
-		if (!formats)
-		{
-			WLog_ERR(TAG, "calloc failed!");
-			return CHANNEL_RC_NO_MEMORY;
-		}
-
-		formatList.formats = formats;
-
-		while (dataLen)
-		{
-			size_t formatNameLength;
-
-			Stream_Read_UINT32(s, formats[index].formatId); /* formatId (4 bytes) */
-			dataLen -= 4;
-			formats[index].formatName = NULL;
-			wszFormatName = (WCHAR*) Stream_Pointer(s);
-
-			if (!wszFormatName[0])
-				formatNameLength = 0;
-			else
-				formatNameLength = _wcslen(wszFormatName);
-
-			if (formatNameLength)
-			{
-				if (ConvertFromUnicode(CP_UTF8, 0, wszFormatName, -1,
-				                       &(formats[index].formatName), 0, NULL, NULL) < 1)
-				{
-					WLog_ERR(TAG, "failed to convert long clipboard format name");
-					error = ERROR_INVALID_DATA;
-					goto out;
-				}
-			}
-
-			Stream_Seek(s, (formatNameLength + 1) * 2);
-			dataLen -= ((formatNameLength + 1) * 2);
-			index++;
-		}
-	}
+	if ((error = cliprdr_read_format_list(s, &formatList, context->useLongFormatNames)))
+		goto out;
 
 	WLog_DBG(TAG, "ClientFormatList: numFormats: %"PRIu32"",
 	         formatList.numFormats);
@@ -903,13 +756,7 @@ static UINT cliprdr_server_receive_format_list(CliprdrServerContext* context,
 		WLog_ERR(TAG, "ClientFormatList failed with error %"PRIu32"!", error);
 
 out:
-
-	for (index = 0; index < formatList.numFormats; index++)
-	{
-		free(formatList.formats[index].formatName);
-	}
-
-	free(formatList.formats);
+	cliprdr_free_format_list(&formatList);
 	return error;
 }
 
@@ -979,18 +826,14 @@ static UINT cliprdr_server_receive_unlock_clipdata(CliprdrServerContext*
 	CLIPRDR_UNLOCK_CLIPBOARD_DATA unlockClipboardData;
 	UINT error = CHANNEL_RC_OK;
 	WLog_DBG(TAG, "CliprdrClientUnlockClipData");
+
 	unlockClipboardData.msgType = CB_UNLOCK_CLIPDATA;
 	unlockClipboardData.msgFlags = header->msgFlags;
 	unlockClipboardData.dataLen = header->dataLen;
 
-	if (Stream_GetRemainingLength(s) < 4)
-	{
-		WLog_ERR(TAG, "not enough data in stream!");
-		return ERROR_INVALID_DATA;
-	}
+	if ((error = cliprdr_read_unlock_clipdata(s, &unlockClipboardData)))
+		return error;
 
-	Stream_Read_UINT32(s,
-	                   unlockClipboardData.clipDataId); /* clipDataId (4 bytes) */
 	IFCALLRET(context->ClientUnlockClipboardData, error, context,
 	          &unlockClipboardData);
 
@@ -1015,14 +858,9 @@ static UINT cliprdr_server_receive_format_data_request(CliprdrServerContext*
 	formatDataRequest.msgFlags = header->msgFlags;
 	formatDataRequest.dataLen = header->dataLen;
 
-	if (Stream_GetRemainingLength(s) < 4)
-	{
-		WLog_ERR(TAG, "not enough data in stream!");
-		return ERROR_INVALID_DATA;
-	}
+	if ((error = cliprdr_read_format_data_request(s, &formatDataRequest)))
+		return error;
 
-	Stream_Read_UINT32(s,
-	                   formatDataRequest.requestedFormatId); /* requestedFormatId (4 bytes) */
 	context->lastRequestedFormatId = formatDataRequest.requestedFormatId;
 	IFCALLRET(context->ClientFormatDataRequest, error, context, &formatDataRequest);
 
@@ -1047,16 +885,9 @@ static UINT cliprdr_server_receive_format_data_response(
 	formatDataResponse.msgType = CB_FORMAT_DATA_RESPONSE;
 	formatDataResponse.msgFlags = header->msgFlags;
 	formatDataResponse.dataLen = header->dataLen;
-	formatDataResponse.requestedFormatData = NULL;
 
-	if (header->dataLen)
-		formatDataResponse.requestedFormatData = Stream_Pointer(s);
-
-	if (!Stream_SafeSeek(s, header->dataLen))
-	{
-		WLog_ERR(TAG, "not enough data in stream!");
-		return ERROR_INVALID_DATA;
-	}
+	if ((error = cliprdr_read_format_data_response(s, &formatDataResponse)))
+		return error;
 
 	IFCALLRET(context->ClientFormatDataResponse, error, context,
 	          &formatDataResponse);
@@ -1082,23 +913,8 @@ static UINT cliprdr_server_receive_filecontents_request(
 	request.msgFlags = header->msgFlags;
 	request.dataLen = header->dataLen;
 
-	if (Stream_GetRemainingLength(s) < 24)
-	{
-		WLog_ERR(TAG, "not enough data in stream!");
-		return ERROR_INVALID_DATA;
-	}
-
-	Stream_Read_UINT32(s, request.streamId); /* streamId (4 bytes) */
-	Stream_Read_UINT32(s, request.listIndex); /* listIndex (4 bytes) */
-	Stream_Read_UINT32(s, request.dwFlags); /* dwFlags (4 bytes) */
-	Stream_Read_UINT32(s, request.nPositionLow); /* nPositionLow (4 bytes) */
-	Stream_Read_UINT32(s, request.nPositionHigh); /* nPositionHigh (4 bytes) */
-	Stream_Read_UINT32(s, request.cbRequested); /* cbRequested (4 bytes) */
-
-	if (Stream_GetRemainingLength(s) < 4) /* clipDataId (4 bytes) optional */
-		request.clipDataId = 0;
-	else
-		Stream_Read_UINT32(s, request.clipDataId);
+	if ((error = cliprdr_read_file_contents_request(s, &request)))
+		return error;
 
 	IFCALLRET(context->ClientFileContentsRequest, error, context, &request);
 
@@ -1119,19 +935,14 @@ static UINT cliprdr_server_receive_filecontents_response(
 	CLIPRDR_FILE_CONTENTS_RESPONSE response;
 	UINT error = CHANNEL_RC_OK;
 	WLog_DBG(TAG, "CliprdrClientFileContentsResponse");
+
 	response.msgType = CB_FILECONTENTS_RESPONSE;
 	response.msgFlags = header->msgFlags;
 	response.dataLen = header->dataLen;
 
-	if (Stream_GetRemainingLength(s) < 4)
-	{
-		WLog_ERR(TAG, "not enough data in stream!");
-		return ERROR_INVALID_DATA;
-	}
+	if ((error = cliprdr_read_file_contents_response(s, &response)))
+		return error;
 
-	Stream_Read_UINT32(s, response.streamId); /* streamId (4 bytes) */
-	response.cbRequested = header->dataLen - 4;
-	response.requestedData = Stream_Pointer(s); /* requestedFileContentsData */
 	IFCALLRET(context->ClientFileContentsResponse, error, context, &response);
 
 	if (error)

--- a/client/Wayland/wlf_cliprdr.c
+++ b/client/Wayland/wlf_cliprdr.c
@@ -796,7 +796,6 @@ static UINT wlf_cliprdr_clipboard_file_size_success(wClipboardDelegate* delegate
 	wfClipboard* clipboard = delegate->custom;
 	response.msgFlags = CB_RESPONSE_OK;
 	response.streamId = request->streamId;
-	response.dwFlags = FILECONTENTS_SIZE;
 	response.cbRequested = sizeof(UINT64);
 	response.requestedData = (BYTE*) &fileSize;
 	return clipboard->context->ClientFileContentsResponse(clipboard->context, &response);
@@ -810,7 +809,6 @@ static UINT wlf_cliprdr_clipboard_file_size_failure(wClipboardDelegate* delegate
 	WINPR_UNUSED(errorCode);
 	response.msgFlags = CB_RESPONSE_FAIL;
 	response.streamId = request->streamId;
-	response.dwFlags = FILECONTENTS_SIZE;
 	return clipboard->context->ClientFileContentsResponse(clipboard->context, &response);
 }
 
@@ -821,7 +819,6 @@ static UINT wlf_cliprdr_clipboard_file_range_success(wClipboardDelegate* delegat
 	wfClipboard* clipboard = delegate->custom;
 	response.msgFlags = CB_RESPONSE_OK;
 	response.streamId = request->streamId;
-	response.dwFlags = FILECONTENTS_RANGE;
 	response.cbRequested = size;
 	response.requestedData = (const BYTE*) data;
 	return clipboard->context->ClientFileContentsResponse(clipboard->context, &response);
@@ -835,7 +832,6 @@ static UINT wlf_cliprdr_clipboard_file_range_failure(wClipboardDelegate* delegat
 	WINPR_UNUSED(errorCode);
 	response.msgFlags = CB_RESPONSE_FAIL;
 	response.streamId = request->streamId;
-	response.dwFlags = FILECONTENTS_RANGE;
 	return clipboard->context->ClientFileContentsResponse(clipboard->context, &response);
 }
 

--- a/client/Wayland/wlf_cliprdr.c
+++ b/client/Wayland/wlf_cliprdr.c
@@ -752,7 +752,6 @@ static UINT wlf_cliprdr_send_file_contents_failure(CliprdrClientContext* context
 	CLIPRDR_FILE_CONTENTS_RESPONSE response = { 0 };
 	response.msgFlags = CB_RESPONSE_FAIL;
 	response.streamId = fileContentsRequest->streamId;
-	response.dwFlags = fileContentsRequest->dwFlags;
 	return context->ClientFileContentsResponse(context, &response);
 }
 

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -1517,7 +1517,6 @@ static UINT xf_cliprdr_send_file_contents_failure(CliprdrClientContext* context,
 	CLIPRDR_FILE_CONTENTS_RESPONSE response = { 0 };
 	response.msgFlags = CB_RESPONSE_FAIL;
 	response.streamId = fileContentsRequest->streamId;
-	response.dwFlags = fileContentsRequest->dwFlags;
 	return context->ClientFileContentsResponse(context, &response);
 }
 
@@ -1560,7 +1559,6 @@ static UINT xf_cliprdr_clipboard_file_size_success(wClipboardDelegate* delegate,
 	xfClipboard* clipboard = delegate->custom;
 	response.msgFlags = CB_RESPONSE_OK;
 	response.streamId = request->streamId;
-	response.dwFlags = FILECONTENTS_SIZE;
 	response.cbRequested = sizeof(UINT64);
 	response.requestedData = (BYTE*) &fileSize;
 	return clipboard->context->ClientFileContentsResponse(clipboard->context, &response);
@@ -1575,7 +1573,6 @@ static UINT xf_cliprdr_clipboard_file_size_failure(wClipboardDelegate* delegate,
 
 	response.msgFlags = CB_RESPONSE_FAIL;
 	response.streamId = request->streamId;
-	response.dwFlags = FILECONTENTS_SIZE;
 	return clipboard->context->ClientFileContentsResponse(clipboard->context, &response);
 }
 
@@ -1586,7 +1583,6 @@ static UINT xf_cliprdr_clipboard_file_range_success(wClipboardDelegate* delegate
 	xfClipboard* clipboard = delegate->custom;
 	response.msgFlags = CB_RESPONSE_OK;
 	response.streamId = request->streamId;
-	response.dwFlags = FILECONTENTS_RANGE;
 	response.cbRequested = size;
 	response.requestedData = (BYTE*) data;
 	return clipboard->context->ClientFileContentsResponse(clipboard->context, &response);
@@ -1601,7 +1597,6 @@ static UINT xf_cliprdr_clipboard_file_range_failure(wClipboardDelegate* delegate
 
 	response.msgFlags = CB_RESPONSE_FAIL;
 	response.streamId = request->streamId;
-	response.dwFlags = FILECONTENTS_RANGE;
 	return clipboard->context->ClientFileContentsResponse(clipboard->context, &response);
 }
 

--- a/include/freerdp/channels/cliprdr.h
+++ b/include/freerdp/channels/cliprdr.h
@@ -227,7 +227,6 @@ struct _CLIPRDR_FILE_CONTENTS_RESPONSE
 	DEFINE_CLIPRDR_HEADER_COMMON();
 
 	UINT32 streamId;
-	UINT32 dwFlags;
 	UINT32 cbRequested;
 	const BYTE* requestedData;
 };


### PR DESCRIPTION
This one refactors the cliprdr channel, by getting rid of a lot! code duplication. I just couldn't see so much functions duplicated (in cliprdr, many messages are bi-directional, and server's code was copy-pasted from client's code in freerdp). It also fixes a problem that occured in file copying though the proxy because a wrong check done in cliprdr server (dwFlags is only needed for request!).

By the way, it also fixes some Stream_Read that were done without making sure stream capacity is enough (in server code).