### PR TITLE
Better gateway error reporting

### DIFF
--- a/client/X11/cli/xfreerdp.c
+++ b/client/X11/cli/xfreerdp.c
@@ -65,7 +65,9 @@ int main(int argc, char* argv[])
 			xf_list_monitors(xfc);
 
 		freerdp_client_context_free(context);
-		return 0;
+		if (settings->ListMonitors)
+			return 0;
+		return status;
 	}
 
 	freerdp_client_start(context);

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -861,10 +861,14 @@ const char* freerdp_get_last_error_string(UINT32 code)
 void freerdp_set_last_error(rdpContext* context, UINT32 lastError)
 {
 	if (lastError)
-		WLog_ERR(TAG, "freerdp_set_last_error %s [0x%08"PRIX32"]",
+		WLog_ERR(TAG, "%s %s [0x%08"PRIX32"]", __FUNCTION__,
 		         freerdp_get_last_error_name(lastError), lastError);
 
-	if (context->LastError != 0)
+	if (lastError == FREERDP_ERROR_SUCCESS)
+	{
+		WLog_INFO(TAG, "%s resetting error state", __FUNCTION__);
+	}
+	else if (context->LastError != 0)
 	{
 		WLog_ERR(TAG, "TODO: Trying to set error code %s, but %s already set!",
 		         freerdp_get_last_error_name(lastError),

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -664,6 +664,7 @@ static BOOL rdg_process_handshake_response(rdpRdg* rdg, wStream* s)
 	if (FAILED(errorCode))
 	{
 		WLog_ERR(TAG, "Handshake error %s", error);
+		freerdp_set_last_error(rdg->context, errorCode);
 		return FALSE;
 	}
 
@@ -700,6 +701,7 @@ static BOOL rdg_process_tunnel_response(rdpRdg* rdg, wStream* s)
 	if (FAILED(errorCode))
 	{
 		WLog_ERR(TAG, "Tunnel creation error %s", error);
+		freerdp_set_last_error(rdg->context, errorCode);
 		return FALSE;
 	}
 
@@ -735,6 +737,7 @@ static BOOL rdg_process_tunnel_authorization_response(rdpRdg* rdg, wStream* s)
 	if (FAILED(errorCode))
 	{
 		WLog_ERR(TAG, "Tunnel authorization error %s", error);
+		freerdp_set_last_error(rdg->context, errorCode);
 		return FALSE;
 	}
 
@@ -771,6 +774,7 @@ static BOOL rdg_process_channel_response(rdpRdg* rdg, wStream* s)
 	{
 		WLog_ERR(TAG, "channel response errorCode=%s, fieldsPresent=%s",
 		         error, channel_response_fields_present_to_string(fieldsPresent));
+		freerdp_set_last_error(rdg->context, errorCode);
 		return FALSE;
 	}
 

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -395,6 +395,8 @@ BOOL transport_connect(rdpTransport* transport, const char* hostname,
 			if (!transport->tsg)
 				return FALSE;
 
+			/* Reset error condition from RDG */
+			freerdp_set_last_error(context, FREERDP_ERROR_SUCCESS);
 			status = tsg_connect(transport->tsg, hostname, port, timeout);
 
 			if (status)


### PR DESCRIPTION
in RDG set the error from the server as last error.