### PR TITLE
Fix #5603: Prefer absolute path for /drive: syntax.

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -103,9 +103,12 @@ static BOOL freerdp_client_add_drive(rdpSettings* settings, const char* path, co
 		/* Path was entered as secondary argument, swap */
 		if (PathFileExistsA(name))
 		{
-			const char* tmp = path;
-			path = name;
-			name = tmp;
+			if (!PathFileExistsA(path) || (!PathIsRelativeA(name) && PathIsRelativeA(path)))
+			{
+				const char* tmp = path;
+				path = name;
+				name = tmp;
+			}
 		}
 	}
 

--- a/winpr/include/winpr/path.h
+++ b/winpr/include/winpr/path.h
@@ -288,6 +288,9 @@ WINPR_API BOOL PathMakePathA(LPCSTR path, LPSECURITY_ATTRIBUTES lpAttributes);
 
 #if !defined(_WIN32) || defined(_UWP)
 
+WINPR_API BOOL PathIsRelativeA(LPCSTR pszPath);
+WINPR_API BOOL PathIsRelativeW(LPCWSTR pszPath);
+
 WINPR_API BOOL PathFileExistsA(LPCSTR pszPath);
 WINPR_API BOOL PathFileExistsW(LPCWSTR pszPath);
 

--- a/winpr/libwinpr/path/shell.c
+++ b/winpr/libwinpr/path/shell.c
@@ -521,6 +521,27 @@ BOOL PathMakePathA(LPCSTR path, LPSECURITY_ATTRIBUTES lpAttributes)
 
 #if !defined(_WIN32) || defined(_UWP)
 
+BOOL PathIsRelativeA(LPCSTR pszPath)
+{
+	if (!pszPath)
+		return FALSE;
+
+	return pszPath[0] != '/';
+}
+
+BOOL PathIsRelativeW(LPCWSTR pszPath)
+{
+	LPSTR lpFileNameA = NULL;
+	BOOL ret;
+
+	if (ConvertFromUnicode(CP_UTF8, 0, pszPath, -1, &lpFileNameA, 0, NULL, NULL) < 1)
+		return FALSE;
+
+	ret = PathIsRelativeA(lpFileNameA);
+	free(lpFileNameA);
+	return ret;
+}
+
 BOOL PathFileExistsA(LPCSTR pszPath)
 {
 	struct stat stat_info;


### PR DESCRIPTION
Preference order:
1. `<name>,<path>`
1. `<path>,<name>`