### PR TITLE
wlog: Fix uninitialized type in wLogMessage

### DIFF
--- a/winpr/libwinpr/utils/wlog/wlog.c
+++ b/winpr/libwinpr/utils/wlog/wlog.c
@@ -352,6 +352,7 @@ BOOL WLog_PrintMessageVA(wLog* log, DWORD type, DWORD level, DWORD line,
 {
 	BOOL status = FALSE;
 	wLogMessage message = { 0 };
+	message.Type = type;
 	message.Level = level;
 	message.LineNumber = line;
 	message.FileName = file;


### PR DESCRIPTION
This PR correctly sets the type of the wLogMessage structs forwarded to user-defined wlog callbacks.