### PR TITLE
common: Fix handling of redirectdrives setting

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3300,15 +3300,7 @@ BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 
 		settings->DeviceRedirection = TRUE;
 	}
-
-	if (settings->RedirectDrives || settings->RedirectHomeDrive
-	    || settings->RedirectSerialPorts
-	    || settings->RedirectSmartCards || settings->RedirectPrinters)
-	{
-		settings->DeviceRedirection = TRUE; /* All of these features require rdpdr */
-	}
-
-	if (settings->RedirectDrives)
+	else if (settings->RedirectDrives)
 	{
 		if (!freerdp_device_collection_find(settings, "drive"))
 		{
@@ -3320,6 +3312,13 @@ BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 			if (!freerdp_client_add_device_channel(settings, 3, (char**) params))
 				return FALSE;
 		}
+	}
+
+	if (settings->RedirectDrives || settings->RedirectHomeDrive
+	    || settings->RedirectSerialPorts
+	    || settings->RedirectSmartCards || settings->RedirectPrinters)
+	{
+		settings->DeviceRedirection = TRUE; /* All of these features require rdpdr */
 	}
 
 	if (settings->RedirectHomeDrive)


### PR DESCRIPTION
This PR fixes handling of the redirectdrives .rdp setting that was superseded by the drivestoredirect setting. If both settings were specified we ended up redirecting drives twice. Now we first check if drivestoredirect (the newer setting) is specified and if not we check for redirectdrives (the old setting).