### PR TITLE
Fixes Auto USB Redirection

### DIFF
--- a/channels/urbdrc/client/libusb/libusb_udevice.c
+++ b/channels/urbdrc/client/libusb/libusb_udevice.c
@@ -606,12 +606,12 @@ static int udev_get_hub_handle(UDEVICE* pdev, UINT16 bus_number, UINT16 dev_numb
 			continue;
 
 		unsigned long tmp_b, tmp_d;
-		tmp_b = strtoul(udev_device_get_property_value(dev, "BUSNUM"), NULL, 0);
+		tmp_b = strtoul(udev_device_get_property_value(dev, "BUSNUM"), NULL, 10);
 
 		if (errno != 0)
 			continue;
 
-		tmp_d = strtoul(udev_device_get_property_value(dev, "DEVNUM"), NULL, 0);
+		tmp_d = strtoul(udev_device_get_property_value(dev, "DEVNUM"), NULL, 10);
 
 		if (errno != 0)
 			continue;
@@ -671,8 +671,8 @@ static int udev_get_hub_handle(UDEVICE* pdev, UINT16 bus_number, UINT16 dev_numb
 			if (dev != NULL)
 			{
 				hub_found = 1;
-				hub_bus = strtoul(udev_device_get_property_value(dev, "BUSNUM"), NULL, 0);
-				hub_dev = strtoul(udev_device_get_property_value(dev, "DEVNUM"), NULL, 0);
+				hub_bus = strtoul(udev_device_get_property_value(dev, "BUSNUM"), NULL, 10);
+				hub_dev = strtoul(udev_device_get_property_value(dev, "DEVNUM"), NULL, 10);
 				WLog_DBG(TAG, "  Hub BUS/DEV: %d %d", hub_bus, hub_dev);
 			}
 

--- a/channels/urbdrc/client/urbdrc_main.c
+++ b/channels/urbdrc/client/urbdrc_main.c
@@ -885,12 +885,12 @@ static void* urbdrc_search_usb_device(void* arg)
 						continue;
 					}
 
-					busnum = strtol(udev_device_get_property_value(dev, "BUSNUM"), NULL, 0);
+					busnum = strtol(udev_device_get_property_value(dev, "BUSNUM"), NULL, 10);
 
 					if (errno != 0)
 						continue;
 
-					devnum = strtol(udev_device_get_property_value(dev, "DEVNUM"), NULL, 0);
+					devnum = strtol(udev_device_get_property_value(dev, "DEVNUM"), NULL, 10);
 
 					if (errno != 0)
 						continue;


### PR DESCRIPTION
Base 0 does not work when converting the string to long int. This ends up not showing the correct device id and sometimes the wrong bus id. By changing it to base 10 conversion instead of base 0 this fixes the issue of auto redirect usb devices.