### PR TITLE
rdp: count in/out bytes and packets

### DIFF
--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -454,6 +454,7 @@ FREERDP_API int freerdp_message_queue_process_pending_messages(
 FREERDP_API UINT32 freerdp_error_info(freerdp* instance);
 FREERDP_API void freerdp_set_error_info(rdpRdp* rdp, UINT32 error);
 FREERDP_API BOOL freerdp_send_error_info(rdpRdp* rdp);
+FREERDP_API BOOL freerdp_get_stats(rdpRdp* rdp, UINT64 *inBytes, UINT64 *outBytes, UINT64 *inPackets, UINT64 *outPackets);
 
 FREERDP_API void freerdp_get_version(int* major, int* minor, int* revision);
 FREERDP_API const char* freerdp_get_version_string(void);

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -175,6 +175,10 @@ struct rdp_rdp
 	BOOL resendFocus;
 	BOOL deactivation_reactivation;
 	BOOL AwaitCapabilities;
+	UINT64 inBytes;
+	UINT64 inPackets;
+	UINT64 outBytes;
+	UINT64 outPackets;
 };
 
 FREERDP_LOCAL BOOL rdp_read_security_header(wStream* s, UINT16* flags, UINT16* length);


### PR DESCRIPTION
This PR adds counters on incoming and outgoing packets, may be useful to fully return stats in the `querySessionInformation` thrift request in the ogon project.