### PR TITLE
Fix #5669: If cairo is detected as part of other dependencies ignore it

### DIFF
--- a/libfreerdp/CMakeLists.txt
+++ b/libfreerdp/CMakeLists.txt
@@ -89,20 +89,18 @@ if (WITH_CAIRO)
     find_package(Cairo REQUIRED)
 endif(WITH_CAIRO)
 
-if (SWScale_FOUND)
+# Prefer SWScale over Cairo, both at the same time are not possible.
+if (WITH_SWSCALE)
     add_definitions(-DSWSCALE_FOUND=1)
     include_directories(${SWScale_INCLUDE_DIR})
     freerdp_library_add(${SWScale_LIBRARY})
-else(SWScale_FOUND)
-
-    if (CAIRO_FOUND)
-        add_definitions(-DCAIRO_FOUND=1)
-        include_directories(${CAIRO_INCLUDE_DIR})
-        freerdp_library_add(${CAIRO_LIBRARY})
-    else(CAIRO_FOUND)
-        message(WARNING "neither swscale nor libcairo detected, compiling without image scaling support!")
-    endif(CAIRO_FOUND)
-endif(SWScale_FOUND)
+elseif (WITH_CAIRO)
+    add_definitions(-DCAIRO_FOUND=1)
+    include_directories(${CAIRO_INCLUDE_DIR})
+    freerdp_library_add(${CAIRO_LIBRARY})
+else()
+    message(WARNING "neither swscale nor libcairo detected, compiling without image scaling support!")
+endif()
 
 set(${MODULE_PREFIX}_SUBMODULES
 	utils


### PR DESCRIPTION
If WITH_CAIRO=OFF it was still used when the library was detected as
part of some other dependency. With this commit the dependency is
only added if WITH_CAIRO=ON