### PR TITLE
COMMAND_LINE_ARGUMENT structs contain parser results, use one per instance

### DIFF
--- a/channels/audin/client/alsa/audin_alsa.c
+++ b/channels/audin/client/alsa/audin_alsa.c
@@ -346,12 +346,6 @@ static UINT audin_alsa_close(IAudinDevice* device)
 	return error;
 }
 
-static COMMAND_LINE_ARGUMENT_A audin_alsa_args[] =
-{
-	{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "audio device name" },
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 /**
  * Function description
  *
@@ -364,6 +358,11 @@ static UINT audin_alsa_parse_addin_args(AudinALSADevice* device,
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
 	AudinALSADevice* alsa = (AudinALSADevice*) device;
+	COMMAND_LINE_ARGUMENT_A audin_alsa_args[] =
+		{
+			{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "audio device name" },
+			{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+		};
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON |
 	        COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
 	status = CommandLineParseArgumentsA(args->argc, args->argv,

--- a/channels/audin/client/audin_main.c
+++ b/channels/audin/client/audin_main.c
@@ -855,22 +855,21 @@ static UINT audin_set_device_name(AUDIN_PLUGIN* audin, const char* device_name)
 	return CHANNEL_RC_OK;
 }
 
-static COMMAND_LINE_ARGUMENT_A audin_args[] =
-{
-	{ "sys", COMMAND_LINE_VALUE_REQUIRED, "<subsystem>", NULL, NULL, -1, NULL, "subsystem" },
-	{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "device" },
-	{ "format", COMMAND_LINE_VALUE_REQUIRED, "<format>", NULL, NULL, -1, NULL, "format" },
-	{ "rate", COMMAND_LINE_VALUE_REQUIRED, "<rate>", NULL, NULL, -1, NULL, "rate" },
-	{ "channel", COMMAND_LINE_VALUE_REQUIRED, "<channel>", NULL, NULL, -1, NULL, "channel" },
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 BOOL audin_process_addin_args(AUDIN_PLUGIN* audin, ADDIN_ARGV* args)
 {
 	int status;
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
 	UINT error;
+	COMMAND_LINE_ARGUMENT_A audin_args[] =
+		{
+			{ "sys", COMMAND_LINE_VALUE_REQUIRED, "<subsystem>", NULL, NULL, -1, NULL, "subsystem" },
+			{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "device" },
+			{ "format", COMMAND_LINE_VALUE_REQUIRED, "<format>", NULL, NULL, -1, NULL, "format" },
+			{ "rate", COMMAND_LINE_VALUE_REQUIRED, "<rate>", NULL, NULL, -1, NULL, "rate" },
+			{ "channel", COMMAND_LINE_VALUE_REQUIRED, "<channel>", NULL, NULL, -1, NULL, "channel" },
+			{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+		};
 
 	if (!args || args->argc == 1)
 		return TRUE;

--- a/channels/audin/client/mac/audin_mac.c
+++ b/channels/audin/client/mac/audin_mac.c
@@ -304,12 +304,6 @@ static UINT audin_mac_free(IAudinDevice* device)
 	return CHANNEL_RC_OK;
 }
 
-static COMMAND_LINE_ARGUMENT_A audin_mac_args[] =
-{
-	{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "audio device name" },
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 static UINT audin_mac_parse_addin_args(AudinMacDevice* device, ADDIN_ARGV* args)
 {
 	DWORD errCode;
@@ -318,6 +312,12 @@ static UINT audin_mac_parse_addin_args(AudinMacDevice* device, ADDIN_ARGV* args)
 	char* str_num, *eptr;
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
+	COMMAND_LINE_ARGUMENT_A audin_mac_args[] =
+	{
+		{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "audio device name" },
+		{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+	};
+
 	AudinMacDevice* mac = (AudinMacDevice*)device;
 
 	if (args->argc == 1)

--- a/channels/audin/client/opensles/audin_opensl_es.c
+++ b/channels/audin/client/opensles/audin_opensl_es.c
@@ -247,15 +247,6 @@ UINT audin_opensles_close(IAudinDevice* device)
 	return CHANNEL_RC_OK;
 }
 
-static COMMAND_LINE_ARGUMENT_A audin_opensles_args[] =
-{
-	{
-		"dev", COMMAND_LINE_VALUE_REQUIRED, "<device>",
-		NULL, NULL, -1, NULL, "audio device name"
-	},
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 /**
  * Function description
  *
@@ -268,6 +259,15 @@ static UINT audin_opensles_parse_addin_args(AudinOpenSLESDevice* device,
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
 	AudinOpenSLESDevice* opensles = (AudinOpenSLESDevice*) device;
+	COMMAND_LINE_ARGUMENT_A audin_opensles_args[] =
+	{
+		{
+			"dev", COMMAND_LINE_VALUE_REQUIRED, "<device>",
+			NULL, NULL, -1, NULL, "audio device name"
+		},
+		{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+	};
+
 	WLog_Print(opensles->log, WLOG_DEBUG, "device=%p, args=%p", (void*) device, (void*) args);
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
 	status = CommandLineParseArgumentsA(args->argc, args->argv,

--- a/channels/audin/client/oss/audin_oss.c
+++ b/channels/audin/client/oss/audin_oss.c
@@ -381,12 +381,6 @@ static UINT audin_oss_free(IAudinDevice* device)
 	return CHANNEL_RC_OK;
 }
 
-static COMMAND_LINE_ARGUMENT_A audin_oss_args[] =
-{
-	{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "audio device name" },
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 /**
  * Function description
  *
@@ -399,6 +393,13 @@ static UINT audin_oss_parse_addin_args(AudinOSSDevice* device, ADDIN_ARGV* args)
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
 	AudinOSSDevice* oss = (AudinOSSDevice*)device;
+	COMMAND_LINE_ARGUMENT_A audin_oss_args[] =
+		{
+			{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "audio device name" },
+			{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+		};
+
+
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON |
 	        COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
 	status = CommandLineParseArgumentsA(args->argc, args->argv,

--- a/channels/audin/client/pulse/audin_pulse.c
+++ b/channels/audin/client/pulse/audin_pulse.c
@@ -425,12 +425,6 @@ static UINT audin_pulse_open(IAudinDevice* device, AudinReceive receive, void* u
 	return CHANNEL_RC_OK;
 }
 
-static COMMAND_LINE_ARGUMENT_A audin_pulse_args[] =
-{
-	{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "audio device name" },
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 /**
  * Function description
  *
@@ -442,6 +436,12 @@ static UINT audin_pulse_parse_addin_args(AudinPulseDevice* device, ADDIN_ARGV* a
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
 	AudinPulseDevice* pulse = (AudinPulseDevice*) device;
+	COMMAND_LINE_ARGUMENT_A audin_pulse_args[] =
+		{
+			{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "audio device name" },
+			{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+		};
+
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
 	status = CommandLineParseArgumentsA(args->argc, args->argv, audin_pulse_args, flags,
 	                                    pulse, NULL, NULL);

--- a/channels/audin/client/winmm/audin_winmm.c
+++ b/channels/audin/client/winmm/audin_winmm.c
@@ -402,12 +402,6 @@ static UINT audin_winmm_open(IAudinDevice* device, AudinReceive receive, void* u
 	return CHANNEL_RC_OK;
 }
 
-static COMMAND_LINE_ARGUMENT_A audin_winmm_args[] =
-{
-	{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "audio device name" },
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 /**
  * Function description
  *
@@ -419,6 +413,12 @@ static UINT audin_winmm_parse_addin_args(AudinWinmmDevice* device, ADDIN_ARGV* a
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
 	AudinWinmmDevice* winmm = (AudinWinmmDevice*) device;
+	COMMAND_LINE_ARGUMENT_A audin_winmm_args[] =
+	{
+		{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "audio device name" },
+		{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+	};
+
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
 	status = CommandLineParseArgumentsA(args->argc, args->argv, audin_winmm_args, flags,
 	                                    winmm, NULL, NULL);

--- a/channels/rdpsnd/client/alsa/rdpsnd_alsa.c
+++ b/channels/rdpsnd/client/alsa/rdpsnd_alsa.c
@@ -462,12 +462,6 @@ static UINT rdpsnd_alsa_play(rdpsndDevicePlugin* device, const BYTE* data, size_
 	return latency + alsa->latency;
 }
 
-static COMMAND_LINE_ARGUMENT_A rdpsnd_alsa_args[] =
-{
-	{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "device" },
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 /**
  * Function description
  *
@@ -479,6 +473,11 @@ static UINT rdpsnd_alsa_parse_addin_args(rdpsndDevicePlugin* device, ADDIN_ARGV*
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
 	rdpsndAlsaPlugin* alsa = (rdpsndAlsaPlugin*) device;
+	COMMAND_LINE_ARGUMENT_A rdpsnd_alsa_args[] =
+		{
+			{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "device" },
+			{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+		};
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
 	status = CommandLineParseArgumentsA(args->argc, args->argv, rdpsnd_alsa_args, flags,
 	                                    alsa, NULL, NULL);

--- a/channels/rdpsnd/client/fake/rdpsnd_fake.c
+++ b/channels/rdpsnd/client/fake/rdpsnd_fake.c
@@ -85,11 +85,6 @@ static void rdpsnd_fake_start(rdpsndDevicePlugin* device)
 {
 }
 
-static COMMAND_LINE_ARGUMENT_A rdpsnd_fake_args[] =
-{
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 /**
  * Function description
  *
@@ -100,6 +95,10 @@ static UINT rdpsnd_fake_parse_addin_args(rdpsndFakePlugin* fake, ADDIN_ARGV* arg
 	int status;
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
+	COMMAND_LINE_ARGUMENT_A rdpsnd_fake_args[] =
+		{
+			{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+		};
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
 	status = CommandLineParseArgumentsA(args->argc, args->argv,
 	                                    rdpsnd_fake_args, flags, fake, NULL, NULL);

--- a/channels/rdpsnd/client/opensles/rdpsnd_opensles.c
+++ b/channels/rdpsnd/client/opensles/rdpsnd_opensles.c
@@ -296,15 +296,6 @@ static void rdpsnd_opensles_start(rdpsndDevicePlugin* device)
 	DEBUG_SND("opensles=%p", (void*) opensles);
 }
 
-static COMMAND_LINE_ARGUMENT_A rdpsnd_opensles_args[] =
-{
-	{
-		"dev", COMMAND_LINE_VALUE_REQUIRED, "<device>",
-		NULL, NULL, -1, NULL, "device"
-	},
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 static int rdpsnd_opensles_parse_addin_args(rdpsndDevicePlugin* device,
         ADDIN_ARGV* args)
 {
@@ -312,6 +303,15 @@ static int rdpsnd_opensles_parse_addin_args(rdpsndDevicePlugin* device,
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
 	rdpsndopenslesPlugin* opensles = (rdpsndopenslesPlugin*) device;
+	COMMAND_LINE_ARGUMENT_A rdpsnd_opensles_args[] =
+	{
+		{
+			"dev", COMMAND_LINE_VALUE_REQUIRED, "<device>",
+			NULL, NULL, -1, NULL, "device"
+		},
+		{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+	};
+
 	assert(opensles);
 	assert(args);
 	DEBUG_SND("opensles=%p, args=%p", (void*) opensles, (void*) args);

--- a/channels/rdpsnd/client/oss/rdpsnd_oss.c
+++ b/channels/rdpsnd/client/oss/rdpsnd_oss.c
@@ -388,12 +388,6 @@ static UINT rdpsnd_oss_play(rdpsndDevicePlugin* device, const BYTE* data, size_t
 	return 10; /* TODO: Get real latency in [ms] */
 }
 
-static COMMAND_LINE_ARGUMENT_A rdpsnd_oss_args[] =
-{
-	{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "device" },
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 static int rdpsnd_oss_parse_addin_args(rdpsndDevicePlugin* device, ADDIN_ARGV* args)
 {
 	int status;
@@ -401,6 +395,11 @@ static int rdpsnd_oss_parse_addin_args(rdpsndDevicePlugin* device, ADDIN_ARGV* a
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
 	rdpsndOssPlugin* oss = (rdpsndOssPlugin*)device;
+	COMMAND_LINE_ARGUMENT_A rdpsnd_oss_args[] =
+		{
+			{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "device" },
+			{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+		};
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
 	status = CommandLineParseArgumentsA(args->argc, args->argv, rdpsnd_oss_args, flags,
 	                                    oss, NULL, NULL);

--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -519,12 +519,6 @@ static void rdpsnd_pulse_start(rdpsndDevicePlugin* device)
 	pa_threaded_mainloop_unlock(pulse->mainloop);
 }
 
-static COMMAND_LINE_ARGUMENT_A rdpsnd_pulse_args[] =
-{
-	{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "device" },
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 /**
  * Function description
  *
@@ -536,6 +530,11 @@ static UINT rdpsnd_pulse_parse_addin_args(rdpsndDevicePlugin* device, ADDIN_ARGV
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*) device;
+	COMMAND_LINE_ARGUMENT_A rdpsnd_pulse_args[] =
+		{
+			{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "device" },
+			{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+		};
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
 	status = CommandLineParseArgumentsA(args->argc, args->argv,
 	                                    rdpsnd_pulse_args, flags, pulse, NULL, NULL);

--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -686,18 +686,6 @@ BOOL rdpsnd_set_device_name(rdpsndPlugin* rdpsnd, const char* device_name)
 	return (rdpsnd->device_name != NULL);
 }
 
-static COMMAND_LINE_ARGUMENT_A rdpsnd_args[] =
-{
-	{ "sys", COMMAND_LINE_VALUE_REQUIRED, "<subsystem>", NULL, NULL, -1, NULL, "subsystem" },
-	{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "device" },
-	{ "format", COMMAND_LINE_VALUE_REQUIRED, "<format>", NULL, NULL, -1, NULL, "format" },
-	{ "rate", COMMAND_LINE_VALUE_REQUIRED, "<rate>", NULL, NULL, -1, NULL, "rate" },
-	{ "channel", COMMAND_LINE_VALUE_REQUIRED, "<channel>", NULL, NULL, -1, NULL, "channel" },
-	{ "latency", COMMAND_LINE_VALUE_REQUIRED, "<latency>", NULL, NULL, -1, NULL, "latency" },
-	{ "quality", COMMAND_LINE_VALUE_REQUIRED, "<quality mode>", NULL, NULL, -1, NULL, "quality mode" },
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 /**
  * Function description
  *
@@ -708,6 +696,17 @@ static UINT rdpsnd_process_addin_args(rdpsndPlugin* rdpsnd, ADDIN_ARGV* args)
 	int status;
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
+	COMMAND_LINE_ARGUMENT_A rdpsnd_args[] =
+		{
+			{ "sys", COMMAND_LINE_VALUE_REQUIRED, "<subsystem>", NULL, NULL, -1, NULL, "subsystem" },
+			{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "device" },
+			{ "format", COMMAND_LINE_VALUE_REQUIRED, "<format>", NULL, NULL, -1, NULL, "format" },
+			{ "rate", COMMAND_LINE_VALUE_REQUIRED, "<rate>", NULL, NULL, -1, NULL, "rate" },
+			{ "channel", COMMAND_LINE_VALUE_REQUIRED, "<channel>", NULL, NULL, -1, NULL, "channel" },
+			{ "latency", COMMAND_LINE_VALUE_REQUIRED, "<latency>", NULL, NULL, -1, NULL, "latency" },
+			{ "quality", COMMAND_LINE_VALUE_REQUIRED, "<quality mode>", NULL, NULL, -1, NULL, "quality mode" },
+			{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+		};
 	rdpsnd->wQualityMode = HIGH_QUALITY; /* default quality mode */
 
 	if (args->argc > 1)

--- a/channels/tsmf/client/tsmf_main.c
+++ b/channels/tsmf/client/tsmf_main.c
@@ -489,14 +489,6 @@ static UINT tsmf_plugin_terminated(IWTSPlugin* pPlugin)
 	return CHANNEL_RC_OK;
 }
 
-COMMAND_LINE_ARGUMENT_A tsmf_args[] =
-{
-	{ "sys", COMMAND_LINE_VALUE_REQUIRED, "<subsystem>", NULL, NULL, -1, NULL, "audio subsystem" },
-	{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "audio device name" },
-	{ "decoder", COMMAND_LINE_VALUE_REQUIRED, "<subsystem>", NULL, NULL, -1, NULL, "decoder subsystem" },
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 /**
  * Function description
  *
@@ -508,6 +500,13 @@ static UINT tsmf_process_addin_args(IWTSPlugin* pPlugin, ADDIN_ARGV* args)
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
 	TSMF_PLUGIN* tsmf = (TSMF_PLUGIN*) pPlugin;
+	COMMAND_LINE_ARGUMENT_A tsmf_args[] =
+		{
+			{ "sys", COMMAND_LINE_VALUE_REQUIRED, "<subsystem>", NULL, NULL, -1, NULL, "audio subsystem" },
+			{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>", NULL, NULL, -1, NULL, "audio device name" },
+			{ "decoder", COMMAND_LINE_VALUE_REQUIRED, "<subsystem>", NULL, NULL, -1, NULL, "decoder subsystem" },
+			{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+		};
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON;
 	status = CommandLineParseArgumentsA(args->argc, args->argv,
 	                                    tsmf_args, flags, tsmf, NULL, NULL);

--- a/channels/urbdrc/client/libusb/libusb_udevman.c
+++ b/channels/urbdrc/client/libusb/libusb_udevman.c
@@ -450,16 +450,6 @@ static void udevman_load_interface(UDEVMAN* udevman)
 	udevman->iface.wait_urb = udevman_wait_urb;
 }
 
-COMMAND_LINE_ARGUMENT_A urbdrc_udevman_args[] =
-{
-	{ "dbg", COMMAND_LINE_VALUE_FLAG, "", NULL, BoolValueFalse, -1, NULL, "debug" },
-	{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<devices>", NULL, NULL, -1, NULL, "device list" },
-	{ "id", COMMAND_LINE_VALUE_FLAG, "", NULL, BoolValueFalse, -1, NULL, "FLAG_ADD_BY_VID_PID" },
-	{ "addr", COMMAND_LINE_VALUE_FLAG, "", NULL, BoolValueFalse, -1, NULL, "FLAG_ADD_BY_ADDR" },
-	{ "auto", COMMAND_LINE_VALUE_FLAG, "", NULL, BoolValueFalse, -1, NULL, "FLAG_ADD_BY_AUTO" },
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 static void urbdrc_udevman_register_devices(UDEVMAN* udevman, char* devices)
 {
 	char* token;
@@ -512,6 +502,15 @@ static void urbdrc_udevman_parse_addin_args(UDEVMAN* udevman, ADDIN_ARGV* args)
 	int status;
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
+	COMMAND_LINE_ARGUMENT_A urbdrc_udevman_args[] =
+		{
+			{ "dbg", COMMAND_LINE_VALUE_FLAG, "", NULL, BoolValueFalse, -1, NULL, "debug" },
+			{ "dev", COMMAND_LINE_VALUE_REQUIRED, "<devices>", NULL, NULL, -1, NULL, "device list" },
+			{ "id", COMMAND_LINE_VALUE_FLAG, "", NULL, BoolValueFalse, -1, NULL, "FLAG_ADD_BY_VID_PID" },
+			{ "addr", COMMAND_LINE_VALUE_FLAG, "", NULL, BoolValueFalse, -1, NULL, "FLAG_ADD_BY_ADDR" },
+			{ "auto", COMMAND_LINE_VALUE_FLAG, "", NULL, BoolValueFalse, -1, NULL, "FLAG_ADD_BY_AUTO" },
+			{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+		};
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON;
 	status = CommandLineParseArgumentsA(args->argc, args->argv,
 	                                    urbdrc_udevman_args, flags, udevman, NULL, NULL);

--- a/channels/urbdrc/client/urbdrc_main.c
+++ b/channels/urbdrc/client/urbdrc_main.c
@@ -1504,13 +1504,6 @@ BOOL urbdrc_set_subsystem(URBDRC_PLUGIN* urbdrc, char* subsystem)
 	return (urbdrc->subsystem != NULL);
 }
 
-COMMAND_LINE_ARGUMENT_A urbdrc_args[] =
-{
-	{ "dbg", COMMAND_LINE_VALUE_FLAG, "", NULL, BoolValueFalse, -1, NULL, "debug" },
-	{ "sys", COMMAND_LINE_VALUE_REQUIRED, "<subsystem>", NULL, NULL, -1, NULL, "subsystem" },
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
 /**
  * Function description
  *
@@ -1521,6 +1514,12 @@ static UINT urbdrc_process_addin_args(URBDRC_PLUGIN* urbdrc, ADDIN_ARGV* args)
 	int status;
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
+	COMMAND_LINE_ARGUMENT_A urbdrc_args[] =
+		{
+			{ "dbg", COMMAND_LINE_VALUE_FLAG, "", NULL, BoolValueFalse, -1, NULL, "debug" },
+			{ "sys", COMMAND_LINE_VALUE_REQUIRED, "<subsystem>", NULL, NULL, -1, NULL, "subsystem" },
+			{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+		};
 	flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON;
 	status = CommandLineParseArgumentsA(args->argc, args->argv,
 	                                    urbdrc_args, flags, urbdrc, NULL, NULL);

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -322,9 +322,11 @@ BOOL freerdp_client_print_command_line_help(int argc, char** argv)
 }
 
 BOOL freerdp_client_print_command_line_help_ex(int argc, char** argv,
-        COMMAND_LINE_ARGUMENT_A* custom)
+		COMMAND_LINE_ARGUMENT_A* custom)
 {
 	const char* name = "FreeRDP";
+	COMMAND_LINE_ARGUMENT_A largs[ARRAYSIZE(args)];
+	memcpy(largs, args, sizeof(args));
 
 	if (argc > 0)
 		name = argv[0];
@@ -341,7 +343,7 @@ BOOL freerdp_client_print_command_line_help_ex(int argc, char** argv,
 	printf("    +toggle -toggle (enables or disables toggle, where '/' is a synonym of '+')\n");
 	printf("\n");
 	freerdp_client_print_command_line_args(custom);
-	freerdp_client_print_command_line_args(args);
+	freerdp_client_print_command_line_args(largs);
 	printf("\n");
 	printf("Examples:\n");
 	printf("    %s connection.rdp /p:Pwd123! /f\n", name);
@@ -1273,6 +1275,9 @@ static int freerdp_detect_windows_style_command_line_syntax(int argc, char** arg
 	DWORD flags;
 	int detect_status;
 	COMMAND_LINE_ARGUMENT_A* arg;
+	COMMAND_LINE_ARGUMENT_A largs[ARRAYSIZE(args)];
+	memcpy(largs, args, sizeof(args));
+
 	flags = COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_SILENCE_PARSER;
 	flags |= COMMAND_LINE_SIGIL_SLASH | COMMAND_LINE_SIGIL_PLUS_MINUS;
 
@@ -1283,14 +1288,14 @@ static int freerdp_detect_windows_style_command_line_syntax(int argc, char** arg
 
 	*count = 0;
 	detect_status = 0;
-	CommandLineClearArgumentsA(args);
-	status = CommandLineParseArgumentsA(argc, argv, args, flags,
+	CommandLineClearArgumentsA(largs);
+	status = CommandLineParseArgumentsA(argc, argv, largs, flags,
 	                                    NULL, freerdp_detect_command_line_pre_filter, NULL);
 
 	if (status < 0)
 		return status;
 
-	arg = args;
+	arg = largs;
 
 	do
 	{
@@ -1314,6 +1319,9 @@ int freerdp_detect_posix_style_command_line_syntax(int argc, char** argv,
 	DWORD flags;
 	int detect_status;
 	COMMAND_LINE_ARGUMENT_A* arg;
+	COMMAND_LINE_ARGUMENT_A largs[ARRAYSIZE(args)];
+	memcpy(largs, args, sizeof(args));
+
 	flags = COMMAND_LINE_SEPARATOR_SPACE | COMMAND_LINE_SILENCE_PARSER;
 	flags |= COMMAND_LINE_SIGIL_DASH | COMMAND_LINE_SIGIL_DOUBLE_DASH;
 	flags |= COMMAND_LINE_SIGIL_ENABLE_DISABLE;
@@ -1325,14 +1333,14 @@ int freerdp_detect_posix_style_command_line_syntax(int argc, char** argv,
 
 	*count = 0;
 	detect_status = 0;
-	CommandLineClearArgumentsA(args);
-	status = CommandLineParseArgumentsA(argc, argv, args, flags,
+	CommandLineClearArgumentsA(largs);
+	status = CommandLineParseArgumentsA(argc, argv, largs, flags,
 	                                    NULL, freerdp_detect_command_line_pre_filter, NULL);
 
 	if (status < 0)
 		return status;
 
-	arg = args;
+	arg = largs;
 
 	do
 	{
@@ -1408,9 +1416,11 @@ int freerdp_client_settings_command_line_status_print(rdpSettings* settings,
 }
 
 int freerdp_client_settings_command_line_status_print_ex(rdpSettings* settings,
-        int status, int argc, char** argv, COMMAND_LINE_ARGUMENT_A* custom)
+		int status, int argc, char** argv, COMMAND_LINE_ARGUMENT_A* custom)
 {
 	COMMAND_LINE_ARGUMENT_A* arg;
+	COMMAND_LINE_ARGUMENT_A largs[ARRAYSIZE(args)];
+	memcpy(largs, args, sizeof(args));
 
 	if (status == COMMAND_LINE_STATUS_PRINT_VERSION)
 	{
@@ -1426,7 +1436,7 @@ int freerdp_client_settings_command_line_status_print_ex(rdpSettings* settings,
 	}
 	else if (status == COMMAND_LINE_STATUS_PRINT)
 	{
-		arg = CommandLineFindArgumentA(args, "kbd-list");
+		arg = CommandLineFindArgumentA(largs, "kbd-list");
 
 		if (arg->Flags & COMMAND_LINE_VALUE_PRESENT)
 		{
@@ -1459,7 +1469,7 @@ int freerdp_client_settings_command_line_status_print_ex(rdpSettings* settings,
 			printf("\n");
 		}
 
-		arg = CommandLineFindArgumentA(args, "monitor-list");
+		arg = CommandLineFindArgumentA(largs, "monitor-list");
 
 		if (arg->Flags & COMMAND_LINE_VALUE_PRESENT)
 		{
@@ -1551,6 +1561,8 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 	BOOL promptForPassword = FALSE;
 	BOOL compatibility = FALSE;
 	COMMAND_LINE_ARGUMENT_A* arg;
+	COMMAND_LINE_ARGUMENT_A largs[ARRAYSIZE(args)];
+	memcpy(largs, args, sizeof(args));
 
 	/* Command line detection fails if only a .rdp or .msrcIncident file
 	 * is supplied. Check this case first, only then try to detect
@@ -1593,8 +1605,8 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 		}
 
-		CommandLineClearArgumentsA(args);
-		status = CommandLineParseArgumentsA(argc, argv, args, flags,
+		CommandLineClearArgumentsA(largs);
+		status = CommandLineParseArgumentsA(argc, argv, largs, flags,
 		                                    settings,
 		                                    freerdp_client_command_line_pre_filter,
 		                                    freerdp_client_command_line_post_filter);
@@ -1603,8 +1615,8 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 			return status;
 	}
 
-	CommandLineFindArgumentA(args, "v");
-	arg = args;
+	CommandLineFindArgumentA(largs, "v");
+	arg = largs;
 	errno = 0;
 
 	do
@@ -3127,7 +3139,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		settings->ColorDepth = 32;
 	}
 
-	arg = CommandLineFindArgumentA(args, "port");
+	arg = CommandLineFindArgumentA(largs, "port");
 
 	if (arg->Flags & COMMAND_LINE_ARGUMENT_PRESENT)
 	{
@@ -3139,14 +3151,14 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings,
 		settings->ServerPort = (UINT32)val;
 	}
 
-	arg = CommandLineFindArgumentA(args, "p");
+	arg = CommandLineFindArgumentA(largs, "p");
 
 	if (arg->Flags & COMMAND_LINE_ARGUMENT_PRESENT)
 	{
 		FillMemory(arg->Value, strlen(arg->Value), '*');
 	}
 
-	arg = CommandLineFindArgumentA(args, "gp");
+	arg = CommandLineFindArgumentA(largs, "gp");
 
 	if (arg->Flags & COMMAND_LINE_ARGUMENT_PRESENT)
 	{

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -22,7 +22,8 @@
 
 #include <winpr/cmdline.h>
 
-static COMMAND_LINE_ARGUMENT_A args[] = {
+static const COMMAND_LINE_ARGUMENT_A args[] =
+{
 	{ "a", COMMAND_LINE_VALUE_REQUIRED, "<addin>[,<options>]", NULL, NULL, -1, "addin", "Addin" },
 	{ "action-script", COMMAND_LINE_VALUE_REQUIRED, "<file-name>", "~/.config/freerdp/action.sh",
 	  NULL, -1, NULL, "Action script" },
@@ -327,12 +328,9 @@ static COMMAND_LINE_ARGUMENT_A args[] = {
 	  "Hyper-V console (use port 2179, disable negotiation)" },
 	{ "w", COMMAND_LINE_VALUE_REQUIRED, "<width>", "1024", NULL, -1, NULL, "Width" },
 	{ "wallpaper", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "wallpaper" },
-	{ "window-drag", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
-	  "full window drag" },
-	{ "window-position", COMMAND_LINE_VALUE_REQUIRED, "<xpos>x<ypos>", NULL, NULL, -1, NULL,
-	  "window position" },
-	{ "wm-class", COMMAND_LINE_VALUE_REQUIRED, "<class-name>", NULL, NULL, -1, NULL,
-	  "Set the WM_CLASS hint for the window instance" },
+	{ "window-drag", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "full window drag" },
+	{ "window-position", COMMAND_LINE_VALUE_REQUIRED, "<xpos>x<ypos>", NULL, NULL, -1, NULL, "window position" },
+	{ "wm-class", COMMAND_LINE_VALUE_REQUIRED, "<class-name>", NULL, NULL, -1, NULL, "Set the WM_CLASS hint for the window instance" },
 	{ "workarea", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "Use available work area" },
 	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
 };

--- a/client/common/compatibility.c
+++ b/client/common/compatibility.c
@@ -41,7 +41,7 @@
 
 #define TAG CLIENT_TAG("common.compatibility")
 
-static COMMAND_LINE_ARGUMENT_A old_args[] =
+static const COMMAND_LINE_ARGUMENT_A old_args[] =
 {
 	{ "0", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "connect to console session" },
 	{ "a", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "set color depth in bits, default is 16" },
@@ -414,6 +414,9 @@ int freerdp_detect_old_command_line_syntax(int argc, char** argv, size_t* count)
 	int detect_status;
 	rdpSettings* settings;
 	COMMAND_LINE_ARGUMENT_A* arg;
+	COMMAND_LINE_ARGUMENT_A largs[ARRAYSIZE(old_args)];
+	memcpy(largs, old_args, sizeof(old_args));
+
 	*count = 0;
 	detect_status = 0;
 	flags = COMMAND_LINE_SEPARATOR_SPACE | COMMAND_LINE_SILENCE_PARSER;
@@ -424,8 +427,8 @@ int freerdp_detect_old_command_line_syntax(int argc, char** argv, size_t* count)
 	if (!settings)
 		return -1;
 
-	CommandLineClearArgumentsA(old_args);
-	status = CommandLineParseArgumentsA(argc, argv, old_args, flags, settings,
+	CommandLineClearArgumentsA(largs);
+	status = CommandLineParseArgumentsA(argc, argv, largs, flags, settings,
 	                                    freerdp_client_old_command_line_pre_filter, NULL);
 
 	if (status < 0)
@@ -434,7 +437,7 @@ int freerdp_detect_old_command_line_syntax(int argc, char** argv, size_t* count)
 		return status;
 	}
 
-	arg = old_args;
+	arg = largs;
 
 	do
 	{
@@ -479,12 +482,15 @@ int freerdp_client_parse_old_command_line_arguments(int argc, char** argv, rdpSe
 	int status;
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
+	COMMAND_LINE_ARGUMENT_A largs[ARRAYSIZE(old_args)];
+	memcpy(largs, old_args, sizeof(old_args));
+
 	freerdp_register_addin_provider(freerdp_channels_load_static_addin_entry, 0);
 	flags = COMMAND_LINE_SEPARATOR_SPACE;
 	flags |= COMMAND_LINE_SIGIL_DASH | COMMAND_LINE_SIGIL_DOUBLE_DASH;
 	flags |= COMMAND_LINE_SIGIL_ENABLE_DISABLE;
 	flags |= COMMAND_LINE_SIGIL_NOT_ESCAPED;
-	status = CommandLineParseArgumentsA(argc, argv, old_args, flags, settings,
+	status = CommandLineParseArgumentsA(argc, argv, largs, flags, settings,
 	                                    freerdp_client_old_command_line_pre_filter, freerdp_client_old_command_line_post_filter);
 
 	if (status == COMMAND_LINE_STATUS_PRINT_VERSION)
@@ -506,7 +512,7 @@ int freerdp_client_parse_old_command_line_arguments(int argc, char** argv, rdpSe
 		return COMMAND_LINE_STATUS_PRINT_HELP;
 	}
 
-	arg = old_args;
+	arg = largs;
 	errno = 0;
 	settings->BitmapCacheEnabled = TRUE;
 	settings->OffscreenSupportLevel = TRUE;

--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -45,7 +45,7 @@
 
 #define TAG SERVER_TAG("shadow")
 
-static COMMAND_LINE_ARGUMENT_A shadow_args[] =
+static const COMMAND_LINE_ARGUMENT_A shadow_args[] =
 {
 	{ "port", COMMAND_LINE_VALUE_REQUIRED, "<number>", NULL, NULL, -1, NULL, "Server port" },
 	{ "ipc-socket", COMMAND_LINE_VALUE_REQUIRED, "<ipc-socket>", NULL, NULL, -1, NULL, "Server IPC socket" },

--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -71,7 +71,8 @@ static int shadow_server_print_command_line_help(int argc, char** argv)
 	char* str;
 	int length;
 	COMMAND_LINE_ARGUMENT_A* arg;
-
+	COMMAND_LINE_ARGUMENT_A largs[ARRAYSIZE(shadow_args)];
+	memcpy(largs, shadow_args, sizeof(shadow_args));
 	if (argc < 1)
 		return -1;
 
@@ -82,7 +83,7 @@ static int shadow_server_print_command_line_help(int argc, char** argv)
 	WLog_INFO(TAG, "    /option:<value> (specifies option with value)");
 	WLog_INFO(TAG, "    +toggle -toggle (enables or disables toggle, where '/' is a synonym of '+')");
 	WLog_INFO(TAG, "");
-	arg = shadow_args;
+	arg = largs;
 
 	do
 	{
@@ -172,20 +173,22 @@ int shadow_server_parse_command_line(rdpShadowServer* server, int argc, char** a
 	DWORD flags;
 	COMMAND_LINE_ARGUMENT_A* arg;
 	rdpSettings* settings = server->settings;
+	COMMAND_LINE_ARGUMENT_A largs[ARRAYSIZE(shadow_args)];
+	memcpy(largs, shadow_args, sizeof(shadow_args));
 
 	if (argc < 2)
 		return 1;
 
-	CommandLineClearArgumentsA(shadow_args);
+	CommandLineClearArgumentsA(largs);
 	flags = COMMAND_LINE_SEPARATOR_COLON;
 	flags |= COMMAND_LINE_SIGIL_SLASH | COMMAND_LINE_SIGIL_PLUS_MINUS;
-	status = CommandLineParseArgumentsA(argc, argv, shadow_args, flags, server, NULL,
+	status = CommandLineParseArgumentsA(argc, argv, largs, flags, server, NULL,
 	                                    NULL);
 
 	if (status < 0)
 		return status;
 
-	arg = shadow_args;
+	arg = largs;
 	errno = 0;
 
 	do
@@ -358,7 +361,7 @@ int shadow_server_parse_command_line(rdpShadowServer* server, int argc, char** a
 	}
 	while ((arg = CommandLineFindNextArgumentA(arg)) != NULL);
 
-	arg = CommandLineFindArgumentA(shadow_args, "monitors");
+	arg = CommandLineFindArgumentA(largs, "monitors");
 
 	if (arg && (arg->Flags & COMMAND_LINE_ARGUMENT_PRESENT))
 	{

--- a/winpr/libwinpr/utils/test/TestCmdLine.c
+++ b/winpr/libwinpr/utils/test/TestCmdLine.c
@@ -19,44 +19,6 @@ static const char* testArgv[] =
 	0
 };
 
-static COMMAND_LINE_ARGUMENT_A args[] =
-{
-	{ "v", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "destination server" },
-	{ "port", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "server port" },
-	{ "w", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "width" },
-	{ "h", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "height" },
-	{ "f", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "fullscreen" },
-	{ "bpp", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "session bpp (color depth)" },
-	{ "admin", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "console", "admin (or console) session" },
-	{ "multimon", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "multi-monitor" },
-	{ "a", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, "addin", "addin" },
-	{ "u", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "username" },
-	{ "p", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "password" },
-	{ "d", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "domain" },
-	{ "z", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "compression" },
-	{ "audio", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "audio output mode" },
-	{ "mic", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "audio input (microphone)" },
-	{ "fonts", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "smooth fonts (cleartype)" },
-	{ "aero", COMMAND_LINE_VALUE_BOOL, NULL, NULL, BoolValueFalse, -1, NULL, "desktop composition" },
-	{ "window-drag", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "full window drag" },
-	{ "menu-anims", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "menu animations" },
-	{ "themes", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "themes" },
-	{ "wallpaper", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "wallpaper" },
-	{ "codec", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "codec" },
-	{ "nego", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "protocol security negotiation" },
-	{ "sec", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "force specific protocol security" },
-	{ "sec-rdp", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "rdp protocol security" },
-	{ "sec-tls", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "tls protocol security" },
-	{ "sec-nla", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "nla protocol security" },
-	{ "sec-ext", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "nla extended protocol security" },
-	{ "cert-name", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "certificate name" },
-	{ "cert-ignore", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "ignore certificate" },
-	{ "version", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT_VERSION, NULL, NULL, NULL, -1, NULL, "print version" },
-	{ "help", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT_HELP, NULL, NULL, NULL, -1, "?", "print help" },
-	{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
-};
-
-
 int TestCmdLine(int argc, char* argv[])
 {
 	int status;
@@ -67,6 +29,42 @@ int TestCmdLine(int argc, char* argv[])
 	COMMAND_LINE_ARGUMENT_A* arg;
         int testArgc;
         char** command_line;
+        COMMAND_LINE_ARGUMENT_A args[] =
+            {
+                { "v", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "destination server" },
+                { "port", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "server port" },
+                { "w", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "width" },
+                { "h", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "height" },
+                { "f", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "fullscreen" },
+                { "bpp", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "session bpp (color depth)" },
+                { "admin", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "console", "admin (or console) session" },
+                { "multimon", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "multi-monitor" },
+                { "a", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, "addin", "addin" },
+                { "u", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "username" },
+                { "p", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "password" },
+                { "d", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "domain" },
+                { "z", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "compression" },
+                { "audio", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "audio output mode" },
+                { "mic", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "audio input (microphone)" },
+                { "fonts", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "smooth fonts (cleartype)" },
+                { "aero", COMMAND_LINE_VALUE_BOOL, NULL, NULL, BoolValueFalse, -1, NULL, "desktop composition" },
+                { "window-drag", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "full window drag" },
+                { "menu-anims", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "menu animations" },
+                { "themes", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "themes" },
+                { "wallpaper", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "wallpaper" },
+                { "codec", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "codec" },
+                { "nego", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "protocol security negotiation" },
+                { "sec", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "force specific protocol security" },
+                { "sec-rdp", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "rdp protocol security" },
+                { "sec-tls", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "tls protocol security" },
+                { "sec-nla", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "nla protocol security" },
+                { "sec-ext", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "nla extended protocol security" },
+                { "cert-name", COMMAND_LINE_VALUE_REQUIRED, NULL, NULL, NULL, -1, NULL, "certificate name" },
+                { "cert-ignore", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "ignore certificate" },
+                { "version", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT_VERSION, NULL, NULL, NULL, -1, NULL, "print version" },
+                { "help", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT_HELP, NULL, NULL, NULL, -1, "?", "print help" },
+                { NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
+            };
 
 	flags = COMMAND_LINE_SIGIL_SLASH | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_SIGIL_PLUS_MINUS;
         testArgc = string_list_length(testArgv);


### PR DESCRIPTION
Remove the old global structs as the parser modifies them. When using
multiple instances in the same process space this could break parsing.