### PR TITLE
Fix padding of encoded scan-line for XOR mask of pointer.

### DIFF
--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -421,6 +421,7 @@ BOOL freerdp_image_copy_from_pointer_data(
 			{
 				UINT32 xorBytesPerPixel = xorBpp >> 3;
 				xorStep = nWidth * xorBytesPerPixel;
+				xorStep += (xorStep % 2);
 
 				if (xorBpp == 8 && !palette)
 				{


### PR DESCRIPTION
The  [MS-RDPBCGR] said :

> **2.2.9.1.1.4.4 Color Pointer Update (TS_COLORPOINTERATTRIBUTE)**
>
> **xorMaskData (variable):** A variable-length array of bytes. Contains the 24-bpp, bottom-up XOR
mask scan-line data. **The_ XOR mask is padded to a 2-byte boundary for each encoded scan-line.** For example, if a 3x3 pixel cursor is being sent, then each scan-line will consume 10 bytes (3
pixels per scan-line multiplied by 3 bytes per pixel, rounded up to the next even number of bytes).