### PR TITLE
fix [build]: don't export rdp2tcp as cmake target

### DIFF
--- a/channels/rdp2tcp/client/CMakeLists.txt
+++ b/channels/rdp2tcp/client/CMakeLists.txt
@@ -21,7 +21,7 @@ set(${MODULE_PREFIX}_SRCS
 	rdp2tcp_main.c)
 
 add_channel_client_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} TRUE "VirtualChannelEntryEx")
-set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} winpr freerdp)
+
 target_link_libraries(${MODULE_NAME} freerdp)
-install(TARGETS ${MODULE_NAME} DESTINATION ${FREERDP_ADDIN_PATH} EXPORT FreeRDPTargets)
+
 set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "Channels/${CHANNEL_NAME}/Client")


### PR DESCRIPTION
rdp2tcp was wrongly exposed as cmake target. This could lead to errors
like the following when the FreeRDP2 cmake file was required:

CMake Error at ../lib/cmake/FreeRDP2/FreeRDPTargets.cmake:73 (message):

  The imported target "rdp2tcp-client" references the file
     ".../lib/freerdp2/librdp2tcp-client.a"
  but this file does not exist.  Possible reasons include:
* The file was deleted, renamed, or moved to another location.
* An install or uninstall procedure did not complete successfully.
* The installation package was faulty and contained
     ".../lib/cmake/FreeRDP2/FreeRDPTargets.cmake"
  but not all the files it references.