### PR TITLE
urbdrc: fix some usb devices redirection failed

### DIFF
--- a/channels/urbdrc/client/libusb/libusb_udevice.c
+++ b/channels/urbdrc/client/libusb/libusb_udevice.c
@@ -1017,7 +1017,7 @@ static int libusb_udev_control_query_device_text(IUDEVICE* idev, UINT32 TextType
 			}
 			else
 			{
-				*BufferSize = ret;
+				*BufferSize = _wcslen((WCHAR*)Buffer) * 2;
 			}
 
 			break;


### PR DESCRIPTION
If `DeviceDescription` get by `control_query_device_text` contains
extra L'\0', the returned `bufferSize` do not match the actual value.
This will cause the USB device redirection to fail.
