### PR TITLE
winpr: fix anonymous enum members and menbers without a size

### DIFF
--- a/channels/drive/client/drive_file.c
+++ b/channels/drive/client/drive_file.c
@@ -594,29 +594,29 @@ BOOL drive_file_set_information(DRIVE_FILE* file, UINT32 FsInformationClass, UIN
 
 			if (liCreationTime.QuadPart != 0)
 			{
-				ftCreationTime.dwHighDateTime = liCreationTime.HighPart;
-				ftCreationTime.dwLowDateTime = liCreationTime.LowPart;
+				ftCreationTime.dwHighDateTime = liCreationTime.u.HighPart;
+				ftCreationTime.dwLowDateTime = liCreationTime.u.LowPart;
 				pftCreationTime = &ftCreationTime;
 			}
 
 			if (liLastAccessTime.QuadPart != 0)
 			{
-				ftLastAccessTime.dwHighDateTime = liLastAccessTime.HighPart;
-				ftLastAccessTime.dwLowDateTime = liLastAccessTime.LowPart;
+				ftLastAccessTime.dwHighDateTime = liLastAccessTime.u.HighPart;
+				ftLastAccessTime.dwLowDateTime = liLastAccessTime.u.LowPart;
 				pftLastAccessTime = &ftLastAccessTime;
 			}
 
 			if (liLastWriteTime.QuadPart != 0)
 			{
-				ftLastWriteTime.dwHighDateTime = liLastWriteTime.HighPart;
-				ftLastWriteTime.dwLowDateTime = liLastWriteTime.LowPart;
+				ftLastWriteTime.dwHighDateTime = liLastWriteTime.u.HighPart;
+				ftLastWriteTime.dwLowDateTime = liLastWriteTime.u.LowPart;
 				pftLastWriteTime = &ftLastWriteTime;
 			}
 
 			if (liChangeTime.QuadPart != 0 && liChangeTime.QuadPart > liLastWriteTime.QuadPart)
 			{
-				ftLastWriteTime.dwHighDateTime = liChangeTime.HighPart;
-				ftLastWriteTime.dwLowDateTime = liChangeTime.LowPart;
+				ftLastWriteTime.dwHighDateTime = liChangeTime.u.HighPart;
+				ftLastWriteTime.dwLowDateTime = liChangeTime.u.LowPart;
 				pftLastWriteTime = &ftLastWriteTime;
 			}
 

--- a/winpr/include/winpr/wtypes.h.in
+++ b/winpr/include/winpr/wtypes.h.in
@@ -309,7 +309,7 @@ typedef union _ULARGE_INTEGER
 	{
 		DWORD LowPart;
 		DWORD HighPart;
-	};
+	} DUMMYSTRUCTNAME;
 
 	struct
 	{
@@ -326,7 +326,7 @@ typedef union _LARGE_INTEGER
 	{
 		DWORD LowPart;
 		LONG  HighPart;
-	};
+	} DUMMYSTRUCTNAME;
 
 	struct
 	{
@@ -367,7 +367,7 @@ typedef struct _RPC_SID
 	UCHAR Revision;
 	UCHAR SubAuthorityCount;
 	RPC_SID_IDENTIFIER_AUTHORITY IdentifierAuthority;
-	ULONG SubAuthority[];
+	ULONG SubAuthority[1];
 } RPC_SID, *PRPC_SID, *PSID;
 
 typedef struct _ACL

--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
@@ -183,8 +183,8 @@ void ntlm_current_time(BYTE* timestamp)
 	FILETIME filetime;
 	ULARGE_INTEGER time64;
 	GetSystemTimeAsFileTime(&filetime);
-	time64.LowPart = filetime.dwLowDateTime;
-	time64.HighPart = filetime.dwHighDateTime;
+	time64.u.LowPart = filetime.dwLowDateTime;
+	time64.u.HighPart = filetime.dwHighDateTime;
 	CopyMemory(timestamp, &(time64.QuadPart), 8);
 }
 

--- a/winpr/libwinpr/sysinfo/sysinfo.c
+++ b/winpr/libwinpr/sysinfo/sysinfo.c
@@ -275,8 +275,8 @@ VOID GetSystemTimeAsFileTime(LPFILETIME lpSystemTimeAsFileTime)
 	/* time represented in tenths of microseconds since midnight of January 1, 1601 */
 	time64.QuadPart = time(NULL) + 11644473600LL; /* Seconds since January 1, 1601 */
 	time64.QuadPart *= 10000000;                  /* Convert timestamp to tenths of a microsecond */
-	lpSystemTimeAsFileTime->dwLowDateTime = time64.LowPart;
-	lpSystemTimeAsFileTime->dwHighDateTime = time64.HighPart;
+	lpSystemTimeAsFileTime->dwLowDateTime = time64.u.LowPart;
+	lpSystemTimeAsFileTime->dwHighDateTime = time64.u.HighPart;
 }
 
 BOOL GetSystemTimeAdjustment(PDWORD lpTimeAdjustment, PDWORD lpTimeIncrement,


### PR DESCRIPTION
This removes C++ warnings when compiling with `-Wpedantic`.