### PR TITLE
Quickfix to make "smart sizing" work in RDP files

### DIFF
--- a/client/common/file.c
+++ b/client/common/file.c
@@ -1301,6 +1301,22 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 		if (!freerdp_settings_set_bool(settings, FreeRDP_SmartSizing,
 		                               (file->SmartSizing == 1) ? TRUE : FALSE))
 			return FALSE;
+		/**
+		 *  SmartSizingWidth and SmartSizingHeight:
+		 *
+		 *  Adding this option to use the DesktopHeight	and DesktopWidth as
+		 *  parameters for the SmartSizingWidth and SmartSizingHeight, as there
+		 *  are no options for that in standard RDP files.
+		 *
+		 *  Equivalent of doing /smart-sizing:WxH
+		 */
+		if (~(file->DesktopWidth) && ~(file->DesktopHeight))
+		{
+			if (!freerdp_settings_set_uint32(settings, FreeRDP_SmartSizingWidth, file->DesktopWidth))
+				return FALSE;
+			if (!freerdp_settings_set_uint32(settings, FreeRDP_SmartSizingHeight, file->DesktopHeight))
+				return FALSE;
+		}
 	}
 
 	if (~((size_t)file->LoadBalanceInfo))

--- a/client/common/file.c
+++ b/client/common/file.c
@@ -1312,9 +1312,11 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 		 */
 		if (~(file->DesktopWidth) && ~(file->DesktopHeight))
 		{
-			if (!freerdp_settings_set_uint32(settings, FreeRDP_SmartSizingWidth, file->DesktopWidth))
+			if (!freerdp_settings_set_uint32(settings, FreeRDP_SmartSizingWidth,
+			                                 file->DesktopWidth))
 				return FALSE;
-			if (!freerdp_settings_set_uint32(settings, FreeRDP_SmartSizingHeight, file->DesktopHeight))
+			if (!freerdp_settings_set_uint32(settings, FreeRDP_SmartSizingHeight,
+			                                 file->DesktopHeight))
 				return FALSE;
 		}
 	}

--- a/client/common/file.c
+++ b/client/common/file.c
@@ -1310,7 +1310,7 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 		 *
 		 *  Equivalent of doing /smart-sizing:WxH
 		 */
-		if (~(file->DesktopWidth) && ~(file->DesktopHeight))
+		if (~(file->DesktopWidth) && ~(file->DesktopHeight) && file->SmartSizing == 1)
 		{
 			if (!freerdp_settings_set_uint32(settings, FreeRDP_SmartSizingWidth,
 			                                 file->DesktopWidth))


### PR DESCRIPTION
When using smart sizing in an RDP file it does not set the settings: SmartSizingWidth and SmartSizingHeight.

This pull request tries to add a fix where if the displaywidth and displayheight is set in the RDP file, as well as the "smart sizing" then it uses those values for the SmartSizingWidth and SmartSizingHeight as there are no options in the specification for that in RDP files.

Equivalent of doing /smart-sizing:WxH