### PR TITLE
primitives: use host pointers for openCL

### DIFF
--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -906,22 +906,22 @@ static BOOL rdp_write_info_packet(rdpRdp* rdp, wStream* s)
 	/* the mandatory null terminator */
 	Stream_Write_UINT16(s, 0);
 
-		Stream_Write(s, userNameW, cbUserName);
+	Stream_Write(s, userNameW, cbUserName);
 
 	/* the mandatory null terminator */
 	Stream_Write_UINT16(s, 0);
 
-		Stream_Write(s, passwordW, cbPassword);
+	Stream_Write(s, passwordW, cbPassword);
 
 	/* the mandatory null terminator */
 	Stream_Write_UINT16(s, 0);
 
-		Stream_Write(s, alternateShellW, cbAlternateShell);
+	Stream_Write(s, alternateShellW, cbAlternateShell);
 
 	/* the mandatory null terminator */
 	Stream_Write_UINT16(s, 0);
 
-		Stream_Write(s, workingDirW, cbWorkingDir);
+	Stream_Write(s, workingDirW, cbWorkingDir);
 
 	/* the mandatory null terminator */
 	Stream_Write_UINT16(s, 0);

--- a/libfreerdp/primitives/primitives.c
+++ b/libfreerdp/primitives/primitives.c
@@ -247,7 +247,7 @@ static BOOL primitives_autodetect_best(primitives_t* prims)
 			goto out;
 		}
 
-		WLog_DBG(TAG, " * %s\t= %" PRIu32, cur->name, cur->count);
+		WLog_DBG(TAG, " * %s= %" PRIu32, cur->name, cur->count);
 		if (!best || (best->count < cur->count))
 			best = cur;
 	}


### PR DESCRIPTION
Using host pointers may skip the need for copying buffers.