### PR TITLE
SmartSizingWidth and SmartSizingHeight in RDP file:

### DIFF
--- a/client/common/file.c
+++ b/client/common/file.c
@@ -1340,6 +1340,25 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 		if (!freerdp_settings_set_bool(settings, FreeRDP_SmartSizing,
 		                               (file->SmartSizing == 1) ? TRUE : FALSE))
 			return FALSE;
+		/**
+		 *  SmartSizingWidth and SmartSizingHeight:
+		 *
+		 *  Adding this option to use the DesktopHeight	and DesktopWidth as
+		 *  parameters for the SmartSizingWidth and SmartSizingHeight, as there
+		 *  are no options for that in standard RDP files.
+		 *
+		 *  Equivalent of doing /smart-sizing:WxH
+		 */
+		if (((~(file->DesktopWidth) && ~(file->DesktopHeight)) || ~(file->DesktopSizeId)) &&
+		    (file->SmartSizing == 1))
+		{
+			if (!freerdp_settings_set_uint32(settings, FreeRDP_SmartSizingWidth,
+			                                 file->DesktopWidth))
+				return FALSE;
+			if (!freerdp_settings_set_uint32(settings, FreeRDP_SmartSizingHeight,
+			                                 file->DesktopHeight))
+				return FALSE;
+		}
 	}
 
 	if (~((size_t)file->LoadBalanceInfo))


### PR DESCRIPTION
Adding this option to use the DesktopHeight and DesktopWidth as
parameters for the SmartSizingWidth and SmartSizingHeight, as there
are no options for that in standard RDP files.

Equivalent of doing /smart-sizing:WxH
Fixes some issues from #5759