### PR TITLE
rdp.c : fix DATA_PDU_TYPE_STRINGS mismatch declaration

### DIFF
--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -34,7 +34,7 @@
 
 #define TAG FREERDP_TAG("core.rdp")
 
-static const char* DATA_PDU_TYPE_STRINGS[80] = {
+const char* DATA_PDU_TYPE_STRINGS[80] = {
 	"?",
 	"?",      /* 0x00 - 0x01 */
 	"Update", /* 0x02 */


### PR DESCRIPTION
fix build failed in ubuntu 1404 with following build cmd(**-DWITH_DEBUG_ALL=ON**)
```
cmake .. -DCMAKE_SKIP_RPATH=FALSE \
          -DCMAKE_SKIP_INSTALL_RPATH=FALSE \
          -DWITH_PULSE=ON \
          -DWITH_CHANNELS=ON \
          -DBUILTIN_CHANNELS=ON \
          -DWITH_CUPS=ON \
          -DWITH_PCSC=ON \
          -DWITH_GSTREAMER_0_10=ON \
          -DWITH_FFMPEG=ON \
          -DWITH_DSP_FFMPEG=ON \
          -DCHANNEL_URBDRC=ON \
          -DCHANNEL_URBDRC_CLIENT=ON \
          -DWITH_SERVER=ON \
          -DWITH_CAIRO=ON \
          -DBUILD_TESTING=OFF \
          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
          -DCMAKE_INSTALL_PREFIX=/opt/freerdp-nightly/ \
          -DCMAKE_INSTALL_INCLUDEDIR=include \
          -DCMAKE_INSTALL_LIBDIR=lib \
          -DWITH_GSTREAMER_1_0=OFF  \
          -DWITH_DEBUG_ALL=ON  \
          -DWITH_SANITIZE_ADDRESS=ON
```