### PR TITLE
winpr: SetWaitableTimer should not free the handle if it fails

### DIFF
--- a/winpr/libwinpr/synch/timer.c
+++ b/winpr/libwinpr/synch/timer.c
@@ -241,10 +241,7 @@ static int InitializeWaitableTimer(WINPR_TIMER* timer)
 		timer->fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK);
 
 		if (timer->fd <= 0)
-		{
-			free(timer);
 			return -1;
-		}
 
 #elif defined(__APPLE__)
 #else


### PR DESCRIPTION
I was debugging an issue in the proxy and found that if InitializeWaitableTimer() fails in the case that `HAVE_SYS_TIMERFD_H` is defined, it free()s the timer before returning an error. This should not happen. The caller SHOULD call CloseHandle() on the timer himself if SetWaitableTimer() fails, and this will cause a double-free.