### PR TITLE
Removed touch input channel thread

### DIFF
--- a/include/freerdp/client/rdpei.h
+++ b/include/freerdp/client/rdpei.h
@@ -31,7 +31,8 @@
 typedef struct _rdpei_client_context RdpeiClientContext;
 
 typedef int (*pcRdpeiGetVersion)(RdpeiClientContext* context);
-typedef UINT (*pcRdpeiAddContact)(RdpeiClientContext* context, RDPINPUT_CONTACT_DATA* contact);
+typedef UINT (*pcRdpeiAddContact)(RdpeiClientContext* context,
+                                  const RDPINPUT_CONTACT_DATA* contact);
 
 typedef UINT (*pcRdpeiTouchBegin)(RdpeiClientContext* context, int externalId, int x, int y,
                                   int* contactId);


### PR DESCRIPTION
The touch input channel only sends small events (touch points et al)
and therefore does not require a heavy processing thread.