### PR TITLE
Tell the server that smartcard is redirected

### DIFF
--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -1699,6 +1699,9 @@ void gcc_write_client_cluster_data(wStream* s, rdpMcs* mcs)
 	if (settings->ConsoleSession || settings->RedirectedSessionId)
 		flags |= REDIRECTED_SESSIONID_FIELD_VALID;
 
+	if (settings->RedirectSmartCards)
+		flags |= REDIRECTED_SMARTCARD;
+
 	Stream_Write_UINT32(s, flags);                         /* flags */
 	Stream_Write_UINT32(s, settings->RedirectedSessionId); /* redirectedSessionID */
 }

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -341,7 +341,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	settings->RestrictedAdminModeRequired = FALSE;
 	settings->MstscCookieMode = FALSE;
 	settings->CookieMaxLength = DEFAULT_COOKIE_MAX_LENGTH;
-	settings->ClientBuild = 2600;
+	settings->ClientBuild = 18363; /* Windows 10, Version 1909 */
 	settings->KeyboardType = 4;
 	settings->KeyboardSubType = 0;
 	settings->KeyboardFunctionKey = 12;


### PR DESCRIPTION
There were server-side changes on Windows 2012 and newer regarding
smartcards, namely the Smart Card Service start and stop behavior:
https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh849637(v%3Dws.11)#smart-card-service-start-and-stop-behavior

Some people see "No valid certificates were found on this smart card",
when the Smart Card Service is not running and has to use various
workarounds to start the service manually, e.g.:
http://blogs.danosaab.com/2016/12/using-smart-card-with-remote-desktop-connection-on-mac-osx/
http://www.edugeek.net/forums/windows-server-2012/161255-smart-card-service-issue-windows-server-2012r2-terminal-services-hyperv.html

I've been looking at RDP specifications and found that
REDIRECTED_SMARTCARD should be probably specified in TS_UD_CS_CLUSTER
block flags when the smartcard is redirected, but it is not currently:
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/d68c629f-36a1-4a40-afd0-8b3e56d29aac

This might be the reason, why the Smart Card Service is not
autostarted for some people. Let's try to set this flag and see what
will happens...

https://github.com/FreeRDP/FreeRDP/issues/4743