### PR TITLE
Fixed SWScale cmake find script.

### DIFF
--- a/cmake/FindSWScale.cmake
+++ b/cmake/FindSWScale.cmake
@@ -2,11 +2,11 @@
 include(FindPkgConfig)
 
 if (PKG_CONFIG_FOUND)
-	pkg_check_modules(SWScale swscale)
+	pkg_check_modules(SWScale libswscale)
 endif()
 
-find_path(SWScale_INCLUDE_DIR libswscale / swscale.h PATHS $ {SWScale_INCLUDE_DIRS})
-find_library(SWScale_LIBRARY swscale PATHS $ {SWScale_LIBRARY_DIRS})
+find_path(SWScale_INCLUDE_DIR libswscale/swscale.h PATHS ${SWScale_INCLUDE_DIRS})
+find_library(SWScale_LIBRARY swscale PATHS ${SWScale_LIBRARY_DIRS})
 
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(SWScale DEFAULT_MSG SWScale_INCLUDE_DIR SWScale_LIBRARY)
 


### PR DESCRIPTION
* Wrong name for pkg-config (thanks @floppym for pointing that out)
* Formatting issues, there were spaces in path and variables that
  should not have been there.

Signed-off-by: Armin Novak <armin.novak@thincast.com>

Replaces #5794