### PR TITLE
server: proxy: improve logging

### DIFF
--- a/server/proxy/pf_channels.c
+++ b/server/proxy/pf_channels.c
@@ -52,11 +52,11 @@ static void pf_channels_wait_for_server_dynvc(pServerContext* ps)
 	WLog_DBG(TAG, "pf_channels_wait_for_server_dynvc(): server's drdynvc is ready!");
 }
 
-void pf_OnChannelConnectedEventHandler(void* data, ChannelConnectedEventArgs* e)
+void pf_channels_on_client_channel_connect(void* data, ChannelConnectedEventArgs* e)
 {
 	pClientContext* pc = (pClientContext*)data;
 	pServerContext* ps = pc->pdata->ps;
-	WLog_INFO(TAG, "Channel connected: %s", e->name);
+	LOG_INFO(TAG, pc, "Channel connected: %s", e->name);
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
@@ -139,12 +139,12 @@ void pf_OnChannelConnectedEventHandler(void* data, ChannelConnectedEventArgs* e)
 	}
 }
 
-void pf_OnChannelDisconnectedEventHandler(void* data, ChannelDisconnectedEventArgs* e)
+void pf_channels_on_client_channel_disconnect(void* data, ChannelDisconnectedEventArgs* e)
 {
 	rdpContext* context = (rdpContext*)data;
 	pClientContext* pc = (pClientContext*)context;
 	pServerContext* ps = pc->pdata->ps;
-	WLog_INFO(TAG, "Channel disconnected: %s", e->name);
+	LOG_INFO(TAG, pc, "Channel disconnected: %s", e->name);
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{

--- a/server/proxy/pf_channels.h
+++ b/server/proxy/pf_channels.h
@@ -27,8 +27,8 @@
 
 #include "pf_context.h"
 
-void pf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs* e);
-void pf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEventArgs* e);
+void pf_channels_on_client_channel_connect(void* context, ChannelConnectedEventArgs* e);
+void pf_channels_on_client_channel_disconnect(void* context, ChannelDisconnectedEventArgs* e);
 
 BOOL pf_server_channels_init(pServerContext* ps);
 void pf_server_channels_free(pServerContext* ps);

--- a/server/proxy/pf_context.h
+++ b/server/proxy/pf_context.h
@@ -108,6 +108,8 @@ struct proxy_data
 	HANDLE abort_event;
 	HANDLE client_thread;
 	HANDLE gfx_server_ready;
+
+	char* session_id;
 };
 
 BOOL pf_context_copy_settings(rdpSettings* dst, const rdpSettings* src);
@@ -115,6 +117,8 @@ BOOL pf_context_init_server_context(freerdp_peer* client);
 pClientContext* pf_context_create_client_context(rdpSettings* clientSettings);
 
 proxyData* proxy_data_new(void);
+void proxy_data_set_client_context(proxyData* pdata, pClientContext* context);
+void proxy_data_set_server_context(proxyData* pdata, pServerContext* context);
 void proxy_data_free(proxyData* pdata);
 
 BOOL proxy_data_shall_disconnect(proxyData* pdata);

--- a/server/proxy/pf_log.h
+++ b/server/proxy/pf_log.h
@@ -26,4 +26,25 @@
 
 #define PROXY_TAG(tag) "proxy." tag
 
+/*
+ * log format in proxy is:
+ * "[SessionID=%s] - [__FUNCTION__]: Log message"
+ * both SessionID and __FUNCTION__ are optional, but if they should be written to the log,
+ * that's the format.
+ */
+
+/* log macros that prepends session id and function name tp the log message */
+#define LOG_INFO(_tag, _context, _format, ...)                                                \
+	WLog_INFO(TAG, "[SessionID=%s][%s]: " _format, _context->pdata->session_id, __FUNCTION__, \
+	          ##__VA_ARGS__)
+#define LOG_ERR(_tag, _context, _format, ...)                                                \
+	WLog_ERR(TAG, "[SessionID=%s][%s]: " _format, _context->pdata->session_id, __FUNCTION__, \
+	         ##__VA_ARGS__)
+#define LOG_DBG(_tag, _context, _format, ...)                                                \
+	WLog_DBG(TAG, "[SessionID=%s][%s]: " _format, _context->pdata->session_id, __FUNCTION__, \
+	         ##__VA_ARGS__)
+#define LOG_WARN(_tag, _context, _format, ...)                                                \
+	WLog_WARN(TAG, "[SessionID=%s][%s]: " _format, _context->pdata->session_id, __FUNCTION__, \
+	          ##__VA_ARGS__)
+
 #endif /* FREERDP_SERVER_PROXY_PFLOG_H */

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -558,7 +558,7 @@ BOOL ThreadCloseHandle(HANDLE handle)
 
 		if ((thread->started) && (WaitForSingleObject(thread, 0) != WAIT_OBJECT_0))
 		{
-			WLog_ERR(TAG, "Thread running, setting to detached state!");
+			WLog_DBG(TAG, "Thread running, setting to detached state!");
 			thread->detached = TRUE;
 			pthread_detach(thread->thread);
 		}


### PR DESCRIPTION
When more than one client is connected to the proxy, it gets hard to understand which log is related to which client. This PR solves this issue by creating a unique session ID to each proxy session. Also, this PR makes sure that all proxy logs are in the same format ([session_id][func_name]: message) so it will be easy to parse the logs and forward them to splunk/elastic/whatever.