### PR TITLE
transport: check if layer was set to closed

### DIFF
--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -1005,6 +1005,12 @@ int transport_check_fds(rdpTransport* transport)
 	if (!transport)
 		return -1;
 
+	if (transport->layer == TRANSPORT_LAYER_CLOSED)
+	{
+		WLog_Print(transport->log, WLOG_DEBUG, "transport_check_fds: transport layer closed");
+		return -1;
+	}
+
 	dueDate = now + transport->settings->MaxTimeInCheckLoop;
 
 	if (transport->haveMoreBytesToRead)


### PR DESCRIPTION
There are several code paths and error conditions where `transport->layer` is correctly set to `TRANSPORT_LAYER_CLOSED` but the required code for checking that state was missing.

E.g. write errors in the rdg code resulted in marking the transport layer as closed but the transport code would indefinitely continue to read from the receiving socket.
