### PR TITLE
Fix audio channel init when no audio devices are present

### DIFF
--- a/channels/audin/client/audin_main.c
+++ b/channels/audin/client/audin_main.c
@@ -1061,13 +1061,19 @@ UINT DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 	}
 
 	if (audin->device == NULL)
+	{
+		/* If we have no audin device do not register plugin but still return OK or the client will
+		 * just disconnect due to a missing microphone. */
 		WLog_Print(audin->log, WLOG_ERROR, "no sound device.");
+		error = CHANNEL_RC_OK;
+		goto out;
+	}
 
 	error = pEntryPoints->RegisterPlugin(pEntryPoints, "audin", (IWTSPlugin*)audin);
+	if (error == CHANNEL_RC_OK)
+		return error;
+
 out:
-
-	if (error != CHANNEL_RC_OK)
-		audin_plugin_terminated((IWTSPlugin*)audin);
-
+	audin_plugin_terminated((IWTSPlugin*)audin);
 	return error;
 }

--- a/channels/audin/client/winmm/audin_winmm.c
+++ b/channels/audin/client/winmm/audin_winmm.c
@@ -463,6 +463,10 @@ UINT freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEn
 	ADDIN_ARGV* args;
 	AudinWinmmDevice* winmm;
 	UINT error;
+
+	if (waveInGetNumDevs() == 0)
+		return ERROR_DEVICE_NOT_AVAILABLE;
+
 	winmm = (AudinWinmmDevice*)calloc(1, sizeof(AudinWinmmDevice));
 
 	if (!winmm)

--- a/channels/rdpsnd/client/winmm/rdpsnd_winmm.c
+++ b/channels/rdpsnd/client/winmm/rdpsnd_winmm.c
@@ -308,6 +308,9 @@ UINT freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS p
 	if (!winmm)
 		return CHANNEL_RC_NO_MEMORY;
 
+	if (waveOutGetNumDevs() == 0)
+		return ERROR_DEVICE_NOT_AVAILABLE;
+
 	winmm->device.Open = rdpsnd_winmm_open;
 	winmm->device.FormatSupported = rdpsnd_winmm_format_supported;
 	winmm->device.GetVolume = rdpsnd_winmm_get_volume;


### PR DESCRIPTION
This PR fixes the handling of using rdpsnd or audin when the system has no audio device available.
In case of a missing playback device the Windows backend now correctly reports an error and the fake rdpsnd backend is loaded.
If audin is enabled and no microphone is present the channel initialization will report an error but it won't cut the connection (as it did before).
