### PR TITLE
RDPSND device API refinements

### DIFF
--- a/channels/rdpsnd/client/fake/rdpsnd_fake.c
+++ b/channels/rdpsnd/client/fake/rdpsnd_fake.c
@@ -81,10 +81,6 @@ static UINT rdpsnd_fake_play(rdpsndDevicePlugin* device, const BYTE* data, size_
 	return CHANNEL_RC_OK;
 }
 
-static void rdpsnd_fake_start(rdpsndDevicePlugin* device)
-{
-}
-
 /**
  * Function description
  *
@@ -142,7 +138,6 @@ UINT freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS p
 	fake->device.FormatSupported = rdpsnd_fake_format_supported;
 	fake->device.SetVolume = rdpsnd_fake_set_volume;
 	fake->device.Play = rdpsnd_fake_play;
-	fake->device.Start = rdpsnd_fake_start;
 	fake->device.Close = rdpsnd_fake_close;
 	fake->device.Free = rdpsnd_fake_free;
 	args = pEntryPoints->args;

--- a/channels/rdpsnd/client/proxy/rdpsnd_proxy.c
+++ b/channels/rdpsnd/client/proxy/rdpsnd_proxy.c
@@ -95,10 +95,6 @@ static UINT rdpsnd_proxy_play(rdpsndDevicePlugin* device, const BYTE* data, size
 	return GetTickCount() - start;
 }
 
-static void rdpsnd_proxy_start(rdpsndDevicePlugin* device)
-{
-	/* do nothing */
-}
 
 /**
  * Function description
@@ -131,7 +127,6 @@ UINT freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS p
 	proxy->device.FormatSupported = rdpsnd_proxy_format_supported;
 	proxy->device.SetVolume = rdpsnd_proxy_set_volume;
 	proxy->device.Play = rdpsnd_proxy_play;
-	proxy->device.Start = rdpsnd_proxy_start;
 	proxy->device.Close = rdpsnd_proxy_close;
 	proxy->device.Free = rdpsnd_proxy_free;
 	args = pEntryPoints->args;

--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -344,9 +344,13 @@ static BOOL rdpsnd_ensure_device_is_open(rdpsndPlugin* rdpsnd, UINT32 wFormatNo,
 
 		if (!supported)
 		{
-			deviceFormat.wFormatTag = WAVE_FORMAT_PCM;
-			deviceFormat.wBitsPerSample = 16;
-			deviceFormat.cbSize = 0;
+			if (!IFCALLRESULT(FALSE, rdpsnd->device->DefaultFormat, rdpsnd->device, format,
+			                  &deviceFormat))
+			{
+				deviceFormat.wFormatTag = WAVE_FORMAT_PCM;
+				deviceFormat.wBitsPerSample = 16;
+				deviceFormat.cbSize = 0;
+			}
 		}
 
 		WLog_Print(rdpsnd->log, WLOG_DEBUG, "Opening device with format %s [backend %s]",

--- a/channels/rdpsnd/client/winmm/rdpsnd_winmm.c
+++ b/channels/rdpsnd/client/winmm/rdpsnd_winmm.c
@@ -170,6 +170,10 @@ static void rdpsnd_winmm_close(rdpsndDevicePlugin* device)
 		for (x = 0; x < SEM_COUNT_MAX; x++)
 			WaitForSingleObject(winmm->semaphore, INFINITE);
 #endif
+		mmResult = waveOutReset(winmm->hWaveOut);
+		if (mmResult != MMSYSERR_NOERROR)
+			WLog_Print(winmm->log, WLOG_ERROR, "waveOutReset failure: %" PRIu32 "", mmResult);
+
 		mmResult = waveOutClose(winmm->hWaveOut);
 		if (mmResult != MMSYSERR_NOERROR)
 			WLog_Print(winmm->log, WLOG_ERROR, "waveOutClose failure: %" PRIu32 "", mmResult);

--- a/channels/rdpsnd/client/winmm/rdpsnd_winmm.c
+++ b/channels/rdpsnd/client/winmm/rdpsnd_winmm.c
@@ -41,7 +41,9 @@
 
 #include "rdpsnd_main.h"
 
-#define SEM_COUNT_MAX 4
+#if defined(WITH_WINMM_SEMAPHORE)
+#define SEM_COUNT_MAX 6
+#endif
 
 typedef struct rdpsnd_winmm_plugin rdpsndWinmmPlugin;
 
@@ -54,7 +56,9 @@ struct rdpsnd_winmm_plugin
 	UINT32 volume;
 	wLog* log;
 	UINT32 latency;
+#if defined(WITH_WINMM_SEMAPHORE)
 	HANDLE semaphore;
+#endif
 };
 
 static BOOL rdpsnd_winmm_convert_format(const AUDIO_FORMAT* in, WAVEFORMATEX* out)
@@ -107,8 +111,11 @@ static void CALLBACK waveOutProc(HWAVEOUT hwo, UINT uMsg, DWORD_PTR dwInstance, 
 			break;
 		case WOM_DONE:
 			waveOutUnprepareHeader(hwo, lpWaveHdr, sizeof(WAVEHDR));
+			free(lpWaveHdr->lpData);
 			free(lpWaveHdr);
+#if defined(WITH_WINMM_SEMAPHORE)
 			ReleaseSemaphore(winmm->semaphore, 1, NULL);
+#endif
 			break;
 		default:
 			break;
@@ -136,7 +143,9 @@ static BOOL rdpsnd_winmm_open(rdpsndDevicePlugin* device, const AUDIO_FORMAT* fo
 		return FALSE;
 	}
 
+#if defined(WITH_WINMM_SEMAPHORE)
 	ReleaseSemaphore(winmm->semaphore, SEM_COUNT_MAX, NULL);
+#endif
 
 	mmResult = waveOutSetVolume(winmm->hWaveOut, winmm->volume);
 
@@ -151,14 +160,16 @@ static BOOL rdpsnd_winmm_open(rdpsndDevicePlugin* device, const AUDIO_FORMAT* fo
 
 static void rdpsnd_winmm_close(rdpsndDevicePlugin* device)
 {
-	size_t x;
 	MMRESULT mmResult;
 	rdpsndWinmmPlugin* winmm = (rdpsndWinmmPlugin*)device;
 
 	if (winmm->hWaveOut)
 	{
+#if defined(WITH_WINMM_SEMAPHORE)
+		size_t x;
 		for (x = 0; x < SEM_COUNT_MAX; x++)
 			WaitForSingleObject(winmm->semaphore, INFINITE);
+#endif
 		mmResult = waveOutClose(winmm->hWaveOut);
 		if (mmResult != MMSYSERR_NOERROR)
 			WLog_Print(winmm->log, WLOG_ERROR, "waveOutClose failure: %" PRIu32 "", mmResult);
@@ -174,7 +185,9 @@ static void rdpsnd_winmm_free(rdpsndDevicePlugin* device)
 	if (winmm)
 	{
 		rdpsnd_winmm_close(device);
+#if defined(WITH_WINMM_SEMAPHORE)
 		CloseHandle(winmm->semaphore);
+#endif
 		free(winmm);
 	}
 }
@@ -232,12 +245,6 @@ static BOOL rdpsnd_winmm_set_volume(rdpsndDevicePlugin* device, UINT32 value)
 	return TRUE;
 }
 
-static void rdpsnd_winmm_start(rdpsndDevicePlugin* device)
-{
-	// rdpsndWinmmPlugin* winmm = (rdpsndWinmmPlugin*) device;
-	WINPR_UNUSED(device);
-}
-
 static UINT rdpsnd_winmm_play(rdpsndDevicePlugin* device, const BYTE* data, size_t size)
 {
 	MMRESULT mmResult;
@@ -256,7 +263,10 @@ static UINT rdpsnd_winmm_play(rdpsndDevicePlugin* device, const BYTE* data, size
 
 	lpWaveHdr->dwFlags = 0;
 	lpWaveHdr->dwLoops = 0;
-	lpWaveHdr->lpData = (LPSTR)data;
+	lpWaveHdr->lpData = malloc(size);
+	if (!lpWaveHdr->lpData)
+		goto fail;
+	memcpy(lpWaveHdr->lpData, data, size);
 	lpWaveHdr->dwBufferLength = (DWORD)size;
 
 	mmResult = waveOutPrepareHeader(winmm->hWaveOut, lpWaveHdr, sizeof(WAVEHDR));
@@ -264,22 +274,27 @@ static UINT rdpsnd_winmm_play(rdpsndDevicePlugin* device, const BYTE* data, size
 	if (mmResult != MMSYSERR_NOERROR)
 	{
 		WLog_Print(winmm->log, WLOG_ERROR, "waveOutPrepareHeader failure: %" PRIu32 "", mmResult);
-		free(lpWaveHdr);
-		return 0;
+		goto fail;
 	}
 
+#if defined(WITH_WINMM_SEMAPHORE)
 	WaitForSingleObject(winmm->semaphore, INFINITE);
+#endif
 	mmResult = waveOutWrite(winmm->hWaveOut, lpWaveHdr, sizeof(WAVEHDR));
 
 	if (mmResult != MMSYSERR_NOERROR)
 	{
 		WLog_Print(winmm->log, WLOG_ERROR, "waveOutWrite failure: %" PRIu32 "", mmResult);
 		waveOutUnprepareHeader(winmm->hWaveOut, lpWaveHdr, sizeof(WAVEHDR));
-		free(lpWaveHdr);
-		return 0;
+		goto fail;
 	}
 
 	return winmm->latency;
+fail:
+	if (lpWaveHdr)
+		free(lpWaveHdr->lpData);
+	free(lpWaveHdr);
+	return 0;
 }
 
 static void rdpsnd_winmm_parse_addin_args(rdpsndDevicePlugin* device, ADDIN_ARGV* args)
@@ -311,6 +326,7 @@ UINT freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS p
 	}
 
 	winmm = (rdpsndWinmmPlugin*)calloc(1, sizeof(rdpsndWinmmPlugin));
+
 	if (!winmm)
 		return CHANNEL_RC_NO_MEMORY;
 
@@ -318,14 +334,15 @@ UINT freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS p
 	winmm->device.FormatSupported = rdpsnd_winmm_format_supported;
 	winmm->device.GetVolume = rdpsnd_winmm_get_volume;
 	winmm->device.SetVolume = rdpsnd_winmm_set_volume;
-	winmm->device.Start = rdpsnd_winmm_start;
 	winmm->device.Play = rdpsnd_winmm_play;
 	winmm->device.Close = rdpsnd_winmm_close;
 	winmm->device.Free = rdpsnd_winmm_free;
 	winmm->log = WLog_Get(TAG);
+#if defined(WITH_WINMM_SEMAPHORE)
 	winmm->semaphore = CreateSemaphore(NULL, 0, SEM_COUNT_MAX, NULL);
 	if (!winmm->semaphore)
 		goto fail;
+#endif
 	args = pEntryPoints->args;
 	rdpsnd_winmm_parse_addin_args((rdpsndDevicePlugin*)winmm, args);
 	winmm->volume = 0xFFFFFFFF;

--- a/channels/urbdrc/client/libusb/libusb_udevman.c
+++ b/channels/urbdrc/client/libusb/libusb_udevman.c
@@ -34,6 +34,10 @@
 
 #include "libusb_udevice.h"
 
+#if LIBUSB_API_VERSION < 0x01000102
+#define LIBUSB_HOTPLUG_NO_FLAGS 0
+#endif
+
 #define BASIC_STATE_FUNC_DEFINED(_arg, _type)                   \
 	static _type udevman_get_##_arg(IUDEVMAN* idevman)          \
 	{                                                           \

--- a/include/freerdp/client/rdpsnd.h
+++ b/include/freerdp/client/rdpsnd.h
@@ -38,6 +38,8 @@ typedef UINT (*pcPlay)(rdpsndDevicePlugin* device, const BYTE* data, size_t size
 typedef void (*pcStart)(rdpsndDevicePlugin* device);
 typedef void (*pcClose)(rdpsndDevicePlugin* device);
 typedef void (*pcFree)(rdpsndDevicePlugin* device);
+typedef BOOL (*pcDefaultFormat)(rdpsndDevicePlugin* device, const AUDIO_FORMAT* desired,
+                                AUDIO_FORMAT* defaultFormat);
 
 struct rdpsnd_device_plugin
 {
@@ -48,9 +50,10 @@ struct rdpsnd_device_plugin
 	pcGetVolume GetVolume;
 	pcSetVolume SetVolume;
 	pcPlay Play;
-	pcStart Start;
+	pcStart Start; /* Deprecated, unused. */
 	pcClose Close;
 	pcFree Free;
+	pcDefaultFormat DefaultFormat;
 };
 
 #define RDPSND_DEVICE_EXPORT_FUNC_NAME "freerdp_rdpsnd_client_subsystem_entry"

--- a/packaging/deb/freerdp-nightly/rules
+++ b/packaging/deb/freerdp-nightly/rules
@@ -21,7 +21,7 @@ DEB_CMAKE_EXTRA_FLAGS :=  -DCMAKE_SKIP_RPATH=FALSE \
                           -DWITH_SERVER=ON \
                           -DWITH_CAIRO=ON \
                           -DBUILD_TESTING=OFF \
-                          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                          -DCMAKE_BUILD_TYPE=Debug \
                           -DCMAKE_INSTALL_PREFIX=/opt/freerdp-nightly/ \
                           -DCMAKE_INSTALL_INCLUDEDIR=include \
                           -DCMAKE_INSTALL_LIBDIR=lib \


### PR DESCRIPTION
* Added default format callback for rdpsnd backend to allow
      different default input formats (different samplerates, ...)
* Made WINMM backend in flight packet limitation a compile time
      option
* Fallback definition for LIBUSB_HOTPLUG_NO_FLAGS    
    The flag was first introduced with libusb 1.0.16, so
    define it if we are using an older version.