### PR TITLE
make Last error more informative

### DIFF
--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -479,7 +479,13 @@ extern "C"
 	FREERDP_API const char* freerdp_get_last_error_name(UINT32 error);
 	FREERDP_API const char* freerdp_get_last_error_string(UINT32 error);
 	FREERDP_API const char* freerdp_get_last_error_category(UINT32 error);
+
 	FREERDP_API void freerdp_set_last_error(rdpContext* context, UINT32 lastError);
+
+#define freerdp_set_last_error_log(context, lastError) \
+	freerdp_set_last_error_ex((context), (lastError), __FUNCTION__, __FILE__, __LINE__)
+	FREERDP_API void freerdp_set_last_error_ex(rdpContext* context, UINT32 lastError,
+	                                           const char* fkt, const char* file, int line);
 
 	FREERDP_API const char* freerdp_get_logon_error_info_type(UINT32 type);
 	FREERDP_API const char* freerdp_get_logon_error_info_data(UINT32 data);

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -333,7 +333,7 @@ BOOL rdp_client_connect(rdpRdp* rdp)
 	{
 		if (!freerdp_get_last_error(rdp->context))
 		{
-			freerdp_set_last_error(rdp->context, FREERDP_ERROR_SECURITY_NEGO_CONNECT_FAILED);
+			freerdp_set_last_error_log(rdp->context, FREERDP_ERROR_SECURITY_NEGO_CONNECT_FAILED);
 			WLog_ERR(TAG, "Error: protocol security negotiation or connection failure");
 		}
 
@@ -366,7 +366,7 @@ BOOL rdp_client_connect(rdpRdp* rdp)
 		if (rdp_check_fds(rdp) < 0)
 		{
 			if (!freerdp_get_last_error(rdp->context))
-				freerdp_set_last_error(rdp->context, FREERDP_ERROR_CONNECT_TRANSPORT_FAILED);
+				freerdp_set_last_error_log(rdp->context, FREERDP_ERROR_CONNECT_TRANSPORT_FAILED);
 
 			return FALSE;
 		}

--- a/libfreerdp/core/gateway/ncacn_http.c
+++ b/libfreerdp/core/gateway/ncacn_http.c
@@ -147,7 +147,7 @@ BOOL rpc_ncacn_http_ntlm_init(rdpContext* context, RpcChannel* channel)
 	{
 		if (!instance->GatewayAuthenticate)
 		{
-			freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
+			freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
 			return TRUE;
 		}
 		else
@@ -158,7 +158,8 @@ BOOL rpc_ncacn_http_ntlm_init(rdpContext* context, RpcChannel* channel)
 
 			if (!proceed)
 			{
-				freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
+				freerdp_set_last_error_log(context,
+				                           FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
 				return TRUE;
 			}
 

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -661,7 +661,7 @@ static BOOL rdg_process_handshake_response(rdpRdg* rdg, wStream* s)
 	if (FAILED(errorCode))
 	{
 		WLog_ERR(TAG, "Handshake error %s", error);
-		freerdp_set_last_error(rdg->context, errorCode);
+		freerdp_set_last_error_log(rdg->context, errorCode);
 		return FALSE;
 	}
 
@@ -698,7 +698,7 @@ static BOOL rdg_process_tunnel_response(rdpRdg* rdg, wStream* s)
 	if (FAILED(errorCode))
 	{
 		WLog_ERR(TAG, "Tunnel creation error %s", error);
-		freerdp_set_last_error(rdg->context, errorCode);
+		freerdp_set_last_error_log(rdg->context, errorCode);
 		return FALSE;
 	}
 
@@ -734,7 +734,7 @@ static BOOL rdg_process_tunnel_authorization_response(rdpRdg* rdg, wStream* s)
 	if (FAILED(errorCode))
 	{
 		WLog_ERR(TAG, "Tunnel authorization error %s", error);
-		freerdp_set_last_error(rdg->context, errorCode);
+		freerdp_set_last_error_log(rdg->context, errorCode);
 		return FALSE;
 	}
 
@@ -771,7 +771,7 @@ static BOOL rdg_process_channel_response(rdpRdg* rdg, wStream* s)
 	{
 		WLog_ERR(TAG, "channel response errorCode=%s, fieldsPresent=%s", error,
 		         channel_response_fields_present_to_string(fieldsPresent));
-		freerdp_set_last_error(rdg->context, errorCode);
+		freerdp_set_last_error_log(rdg->context, errorCode);
 		return FALSE;
 	}
 
@@ -870,7 +870,7 @@ static BOOL rdg_get_gateway_credentials(rdpContext* context)
 	{
 		if (!instance->GatewayAuthenticate)
 		{
-			freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
+			freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
 			return FALSE;
 		}
 		else
@@ -881,7 +881,8 @@ static BOOL rdg_get_gateway_credentials(rdpContext* context)
 
 			if (!proceed)
 			{
-				freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
+				freerdp_set_last_error_log(context,
+				                           FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
 				return FALSE;
 			}
 
@@ -1033,12 +1034,12 @@ static BOOL rdg_tls_connect(rdpRdg* rdg, rdpTls* tls, const char* peerAddress, i
 		if (status < 0)
 		{
 			if (!freerdp_get_last_error(context))
-				freerdp_set_last_error(context, FREERDP_ERROR_TLS_CONNECT_FAILED);
+				freerdp_set_last_error_log(context, FREERDP_ERROR_TLS_CONNECT_FAILED);
 		}
 		else
 		{
 			if (!freerdp_get_last_error(context))
-				freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_CANCELLED);
+				freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_CANCELLED);
 		}
 
 		return FALSE;
@@ -1117,7 +1118,7 @@ static BOOL rdg_establish_data_connection(rdpRdg* rdg, rdpTls* tls, const char* 
 		case HTTP_STATUS_OK:
 			break;
 		case HTTP_STATUS_DENIED:
-			freerdp_set_last_error(rdg->context, FREERDP_ERROR_CONNECT_ACCESS_DENIED);
+			freerdp_set_last_error_log(rdg->context, FREERDP_ERROR_CONNECT_ACCESS_DENIED);
 			return FALSE;
 		default:
 			return FALSE;

--- a/libfreerdp/core/gateway/rpc.c
+++ b/libfreerdp/core/gateway/rpc.c
@@ -707,12 +707,12 @@ static BOOL rpc_channel_tls_connect(RpcChannel* channel, int timeout)
 		if (tlsStatus < 0)
 		{
 			if (!freerdp_get_last_error(context))
-				freerdp_set_last_error(context, FREERDP_ERROR_TLS_CONNECT_FAILED);
+				freerdp_set_last_error_log(context, FREERDP_ERROR_TLS_CONNECT_FAILED);
 		}
 		else
 		{
 			if (!freerdp_get_last_error(context))
-				freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_CANCELLED);
+				freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_CANCELLED);
 		}
 
 		return FALSE;

--- a/libfreerdp/core/gateway/rpc_bind.c
+++ b/libfreerdp/core/gateway/rpc_bind.c
@@ -135,8 +135,8 @@ int rpc_send_bind_pdu(rdpRpc* rpc)
 	{
 		if (!instance->GatewayAuthenticate)
 		{
-			freerdp_set_last_error(instance->context,
-			                       FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
+			freerdp_set_last_error_log(instance->context,
+			                           FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
 			return 0;
 		}
 		else
@@ -147,8 +147,8 @@ int rpc_send_bind_pdu(rdpRpc* rpc)
 
 			if (!proceed)
 			{
-				freerdp_set_last_error(instance->context,
-				                       FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
+				freerdp_set_last_error_log(instance->context,
+				                           FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
 				return 0;
 			}
 

--- a/libfreerdp/core/gateway/rpc_client.c
+++ b/libfreerdp/core/gateway/rpc_client.c
@@ -550,7 +550,7 @@ static int rpc_client_default_out_channel_recv(rdpRpc* rpc)
 			if (statusCode == HTTP_STATUS_DENIED)
 			{
 				if (!freerdp_get_last_error(rpc->context))
-					freerdp_set_last_error(rpc->context, FREERDP_ERROR_AUTHENTICATION_FAILED);
+					freerdp_set_last_error_log(rpc->context, FREERDP_ERROR_AUTHENTICATION_FAILED);
 			}
 
 			http_response_free(response);

--- a/libfreerdp/core/mcs.c
+++ b/libfreerdp/core/mcs.c
@@ -1237,7 +1237,7 @@ BOOL mcs_client_begin(rdpMcs* mcs)
 	if (!mcs_send_connect_initial(mcs))
 	{
 		if (!freerdp_get_last_error(context))
-			freerdp_set_last_error(context, FREERDP_ERROR_MCS_CONNECT_INITIAL_ERROR);
+			freerdp_set_last_error_log(context, FREERDP_ERROR_MCS_CONNECT_INITIAL_ERROR);
 
 		WLog_ERR(TAG, "Error: unable to send MCS Connect Initial");
 		return FALSE;

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -276,8 +276,8 @@ static int nla_client_init(rdpNla* nla)
 	{
 		if (!instance->Authenticate)
 		{
-			freerdp_set_last_error(instance->context,
-			                       FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
+			freerdp_set_last_error_log(instance->context,
+			                           FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
 			return 0;
 		}
 		else
@@ -287,8 +287,8 @@ static int nla_client_init(rdpNla* nla)
 
 			if (!proceed)
 			{
-				freerdp_set_last_error(instance->context,
-				                       FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
+				freerdp_set_last_error_log(instance->context,
+				                           FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
 				return 0;
 			}
 		}
@@ -2178,7 +2178,7 @@ int nla_recv_pdu(rdpNla* nla, wStream* s)
 				break;
 		}
 
-		freerdp_set_last_error(nla->instance->context, code);
+		freerdp_set_last_error_log(nla->instance->context, code);
 		return -1;
 	}
 

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -308,7 +308,7 @@ BOOL rdp_set_error_info(rdpRdp* rdp, UINT32 errorInfo)
 
 		if (context)
 		{
-			context->LastError = MAKE_FREERDP_ERROR(ERRINFO, errorInfo);
+			freerdp_set_last_error_log(context, MAKE_FREERDP_ERROR(ERRINFO, errorInfo));
 
 			if (context->pubSub)
 			{
@@ -321,7 +321,7 @@ BOOL rdp_set_error_info(rdpRdp* rdp, UINT32 errorInfo)
 	}
 	else
 	{
-		rdp->context->LastError = FREERDP_ERROR_SUCCESS;
+		freerdp_set_last_error_log(rdp->context, FREERDP_ERROR_SUCCESS);
 	}
 
 	return TRUE;

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -318,6 +318,8 @@ BOOL rdp_set_error_info(rdpRdp* rdp, UINT32 errorInfo)
 				PubSub_OnErrorInfo(context->pubSub, context, &e);
 			}
 		}
+		else
+			WLog_ERR(TAG, "%s missing context=%p", __FUNCTION__, context);
 	}
 	else
 	{

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -794,12 +794,12 @@ static BOOL freerdp_tcp_is_hostname_resolvable(rdpContext* context, const char* 
 	if (!result)
 	{
 		if (!freerdp_get_last_error(context))
-			freerdp_set_last_error(context, FREERDP_ERROR_DNS_NAME_NOT_FOUND);
+			freerdp_set_last_error_log(context, FREERDP_ERROR_DNS_NAME_NOT_FOUND);
 
 		return FALSE;
 	}
 
-	freerdp_set_last_error(context, 0);
+	freerdp_set_last_error_log(context, 0);
 	freeaddrinfo(result);
 	return TRUE;
 }
@@ -850,7 +850,7 @@ static BOOL freerdp_tcp_connect_timeout(rdpContext* context, int sockfd, struct 
 	if (WAIT_OBJECT_0 != status)
 	{
 		if (status == WAIT_OBJECT_0 + 1)
-			freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_CANCELLED);
+			freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_CANCELLED);
 
 		goto fail;
 	}
@@ -981,7 +981,7 @@ static int freerdp_tcp_connect_multi(rdpContext* context, char** hostnames, UINT
 		peers[sindex].s = INVALID_SOCKET;
 	}
 	else
-		freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_CANCELLED);
+		freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_CANCELLED);
 
 	for (index = 0; index < count; index++)
 		peer_free(&peers[index]);
@@ -1075,7 +1075,7 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings, const char* 
 	if (!hostname)
 	{
 		if (freerdp_get_last_error(context) == FREERDP_ERROR_SUCCESS)
-			freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_FAILED);
+			freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_FAILED);
 
 		return -1;
 	}
@@ -1093,7 +1093,7 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings, const char* 
 		if (sockfd < 0)
 		{
 			if (freerdp_get_last_error(context) == FREERDP_ERROR_SUCCESS)
-				freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_FAILED);
+				freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_FAILED);
 
 			return -1;
 		}
@@ -1129,11 +1129,11 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings, const char* 
 			if (!result)
 			{
 				if (!freerdp_get_last_error(context))
-					freerdp_set_last_error(context, FREERDP_ERROR_DNS_NAME_NOT_FOUND);
+					freerdp_set_last_error_log(context, FREERDP_ERROR_DNS_NAME_NOT_FOUND);
 
 				return -1;
 			}
-			freerdp_set_last_error(context, 0);
+			freerdp_set_last_error_log(context, 0);
 
 			addr = result;
 
@@ -1155,7 +1155,7 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings, const char* 
 			if (sockfd < 0)
 			{
 				if (freerdp_get_last_error(context) == FREERDP_ERROR_SUCCESS)
-					freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_FAILED);
+					freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_FAILED);
 
 				freeaddrinfo(result);
 				return -1;
@@ -1175,7 +1175,7 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings, const char* 
 				close(sockfd);
 
 				if (freerdp_get_last_error(context) == FREERDP_ERROR_SUCCESS)
-					freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_FAILED);
+					freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_FAILED);
 
 				WLog_ERR(TAG, "failed to connect to %s", hostname);
 				return -1;
@@ -1194,7 +1194,7 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings, const char* 
 			close(sockfd);
 
 		if (freerdp_get_last_error(context) == FREERDP_ERROR_SUCCESS)
-			freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_FAILED);
+			freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_FAILED);
 
 		WLog_ERR(TAG, "Couldn't get socket ip address");
 		return -1;
@@ -1222,7 +1222,7 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings, const char* 
 				close(sockfd);
 
 				if (freerdp_get_last_error(context) == FREERDP_ERROR_SUCCESS)
-					freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_FAILED);
+					freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_FAILED);
 
 				WLog_ERR(TAG, "unable to set receive buffer len");
 				return -1;
@@ -1237,7 +1237,7 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings, const char* 
 			close(sockfd);
 
 			if (freerdp_get_last_error(context) == FREERDP_ERROR_SUCCESS)
-				freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_FAILED);
+				freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_FAILED);
 
 			WLog_ERR(TAG, "Couldn't set keep alive mode.");
 			return -1;
@@ -1249,7 +1249,7 @@ int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings, const char* 
 		close(sockfd);
 
 		if (freerdp_get_last_error(context) == FREERDP_ERROR_SUCCESS)
-			freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_CANCELLED);
+			freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_CANCELLED);
 
 		return -1;
 	}

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -166,7 +166,8 @@ static void transport_ssl_cb(SSL* ssl, int where, int ret)
 				if (!freerdp_get_last_error(transport->context))
 				{
 					WLog_Print(transport->log, WLOG_ERROR, "%s: ACCESS DENIED", __FUNCTION__);
-					freerdp_set_last_error(transport->context, FREERDP_ERROR_AUTHENTICATION_FAILED);
+					freerdp_set_last_error_log(transport->context,
+					                           FREERDP_ERROR_AUTHENTICATION_FAILED);
 				}
 			}
 			break;
@@ -190,7 +191,7 @@ static void transport_ssl_cb(SSL* ssl, int where, int ret)
 						kret = FREERDP_ERROR_CONNECT_PASSWORD_CERTAINLY_EXPIRED;
 
 					if (!freerdp_get_last_error(transport->context))
-						freerdp_set_last_error(transport->context, kret);
+						freerdp_set_last_error_log(transport->context, kret);
 				}
 
 				break;
@@ -290,12 +291,12 @@ BOOL transport_connect_tls(rdpTransport* transport)
 		if (tlsStatus < 0)
 		{
 			if (!freerdp_get_last_error(context))
-				freerdp_set_last_error(context, FREERDP_ERROR_TLS_CONNECT_FAILED);
+				freerdp_set_last_error_log(context, FREERDP_ERROR_TLS_CONNECT_FAILED);
 		}
 		else
 		{
 			if (!freerdp_get_last_error(context))
-				freerdp_set_last_error(context, FREERDP_ERROR_CONNECT_CANCELLED);
+				freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_CANCELLED);
 		}
 
 		return FALSE;
@@ -346,7 +347,7 @@ BOOL transport_connect_nla(rdpTransport* transport)
 		WLog_Print(transport->log, WLOG_ERROR, "NLA begin failed");
 
 		if (!freerdp_get_last_error(context))
-			freerdp_set_last_error(context, FREERDP_ERROR_AUTHENTICATION_FAILED);
+			freerdp_set_last_error_log(context, FREERDP_ERROR_AUTHENTICATION_FAILED);
 
 		transport_set_nla_mode(transport, FALSE);
 		return FALSE;
@@ -397,7 +398,7 @@ BOOL transport_connect(rdpTransport* transport, const char* hostname, UINT16 por
 				return FALSE;
 
 			/* Reset error condition from RDG */
-			freerdp_set_last_error(context, FREERDP_ERROR_SUCCESS);
+			freerdp_set_last_error_log(context, FREERDP_ERROR_SUCCESS);
 			status = tsg_connect(transport->tsg, hostname, port, timeout);
 
 			if (status)

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -1009,6 +1009,8 @@ int transport_check_fds(rdpTransport* transport)
 	if (transport->layer == TRANSPORT_LAYER_CLOSED)
 	{
 		WLog_Print(transport->log, WLOG_DEBUG, "transport_check_fds: transport layer closed");
+		if (freerdp_get_last_error(transport->context) == FREERDP_ERROR_SUCCESS)
+			freerdp_set_last_error_log(transport->context, FREERDP_ERROR_CONNECT_TRANSPORT_FAILED);
 		return -1;
 	}
 


### PR DESCRIPTION
* Adds a new function `freerdp_set_last_error_ex` and a accompanying macro `freerdp_set_last_error_log` to allow more verbose logging of where an error was set.
* Set a error in `transport_check_fds` for proper error handling later on.