### PR TITLE
Extend LIBUSB_API_VERSION check

### DIFF
--- a/channels/urbdrc/client/libusb/libusb_udevman.c
+++ b/channels/urbdrc/client/libusb/libusb_udevman.c
@@ -34,7 +34,7 @@
 
 #include "libusb_udevice.h"
 
-#if LIBUSB_API_VERSION < 0x01000102
+#if !defined(LIBUSB_API_VERSION) || (LIBUSB_API_VERSION < 0x01000102)
 #define LIBUSB_HOTPLUG_NO_FLAGS 0
 #endif
 


### PR DESCRIPTION
The define exists since 1.0.13, so to compensate for older also
check if the variable is defined.
