### PR TITLE
core: rdp: reset rdp->nla in rdp_reset

### DIFF
--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1857,11 +1857,13 @@ void rdp_reset(rdpRdp* rdp)
 	license_free(rdp->license);
 	transport_free(rdp->transport);
 	fastpath_free(rdp->fastpath);
+	nla_free(rdp->nla);
 	rdp->transport = transport_new(context);
 	rdp->license = license_new(rdp);
 	rdp->nego = nego_new(rdp->transport);
 	rdp->mcs = mcs_new(rdp->transport);
 	rdp->fastpath = fastpath_new(rdp);
+	rdp->nla = nla_new(rdp->instance, rdp->transport, rdp->settings);
 	rdp->transport->layer = TRANSPORT_LAYER_TCP;
 	rdp->errorInfo = 0;
 	rdp->deactivation_reactivation = 0;


### PR DESCRIPTION
This fixes a memory leak when freerdp_connect fails, and then called again with NlaSecurity = FALSE. Found this while testing the proxy (AllowFallbackToTls feature) compiled with address sanitizer. Output was:

Indirect leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7fba283e0ce6 in calloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dce6)
    #1 0x7fba27892d59 in sspi_CredentialsNew /home/blabla/git/kubistika/FreeRDP/winpr/libwinpr/sspi/sspi_winpr.c:217
    #2 0x7fba2788e8f1 in negotiate_AcquireCredentialsHandleA /home/blabla/git/kubistika/FreeRDP/winpr/libwinpr/sspi/Negotiate/negotiate.c:449
    #3 0x7fba27896392 in winpr_AcquireCredentialsHandleA /home/blabla/git/kubistika/FreeRDP/winpr/libwinpr/sspi/sspi_winpr.c:823
    #4 0x7fba27bac575 in nla_client_init /home/blabla/git/kubistika/FreeRDP/libfreerdp/core/nla.c:401
    #5 0x7fba27bac824 in nla_client_begin /home/blabla/git/kubistika/FreeRDP/libfreerdp/core/nla.c:431
    #6 0x7fba27c7a648 in transport_connect_nla /home/blabla/git/kubistika/FreeRDP/libfreerdp/core/transport.c:342
    #7 0x7fba27bbd46c in nego_security_connect /home/blabla/git/kubistika/FreeRDP/libfreerdp/core/nego.c:248
    #8 0x7fba27bbd15d in nego_connect /home/blabla/git/kubistika/FreeRDP/libfreerdp/core/nego.c:220
    #9 0x7fba27c45df0 in rdp_client_connect /home/blabla/git/kubistika/FreeRDP/libfreerdp/core/connection.c:332
    #10 0x7fba27c19963 in freerdp_connect /home/blabla/git/kubistika/FreeRDP/libfreerdp/core/freerdp.c:197
    #11 0x56054439f559 in pf_client_connect /home/blabla/git/kubistika/FreeRDP/server/proxy/pf_client.c:342
    #12 0x56054439f9bc in pf_client_thread_proc /home/blabla/git/kubistika/FreeRDP/server/proxy/pf_client.c:392
    #13 0x5605443a06e3 in pf_client_start /home/blabla/git/kubistika/FreeRDP/server/proxy/pf_client.c:573
    #14 0x7fba2787063d in thread_launcher /home/blabla/git/kubistika/FreeRDP/winpr/libwinpr/thread/thread.c:327
    #15 0x7fba274b4668 in start_thread /build/glibc-4WA41p/glibc-2.30/nptl/pthread_create.c:479
