### PR TITLE
Fixes in windows sound backends

### DIFF
--- a/channels/audin/client/winmm/audin_winmm.c
+++ b/channels/audin/client/winmm/audin_winmm.c
@@ -466,7 +466,7 @@ UINT freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEn
 
 	if (waveInGetNumDevs() == 0)
 	{
-		WLog_Print(winmm->log, WLOG_ERROR, "No microphone available!");
+		WLog_Print(WLog_Get(TAG), WLOG_ERROR, "No microphone available!");
 		return ERROR_DEVICE_NOT_AVAILABLE;
 	}
 


### PR DESCRIPTION
This PR fixes following issues:

- Possible crash in audin_winmm if no audio device is available (log instance not initialized)
- Possible crash in rdpsnd_winmm if no audio device is available (log instance not initialized)
- Fix possible deadlock in rdpsdn_winmm caused by calling waveOut* functions from within the provided callback (see remarks: https://docs.microsoft.com/en-us/previous-versions/dd743869(v=vs.85))