### PR TITLE
Improve proxy shutdown

### DIFF
--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1857,13 +1857,11 @@ void rdp_reset(rdpRdp* rdp)
 	license_free(rdp->license);
 	transport_free(rdp->transport);
 	fastpath_free(rdp->fastpath);
-	nla_free(rdp->nla);
 	rdp->transport = transport_new(context);
 	rdp->license = license_new(rdp);
 	rdp->nego = nego_new(rdp->transport);
 	rdp->mcs = mcs_new(rdp->transport);
 	rdp->fastpath = fastpath_new(rdp);
-	rdp->nla = nla_new(rdp->instance, rdp->transport, rdp->settings);
 	rdp->transport->layer = TRANSPORT_LAYER_TCP;
 	rdp->errorInfo = 0;
 	rdp->deactivation_reactivation = 0;

--- a/server/proxy/freerdp_proxy.c
+++ b/server/proxy/freerdp_proxy.c
@@ -31,18 +31,21 @@
 
 #define TAG PROXY_TAG("server")
 
-static proxyConfig config = { 0 };
+static proxyServer* server = NULL;
 
 static void cleanup_handler(int signum)
 {
 	printf("\n");
 	WLog_INFO(TAG, "[%s]: caught signal %d, starting cleanup...", __FUNCTION__, signum);
 
+	WLog_INFO(TAG, "stopping all connections.");
+	pf_server_stop(server);
+
 	WLog_INFO(TAG, "freeing loaded modules and plugins.");
 	pf_modules_free();
 
-	WLog_INFO(TAG, "freeing config.");
-	pf_server_config_free_internal(&config);
+	pf_server_config_free(server->config);
+	pf_server_free(server);
 
 	WLog_INFO(TAG, "exiting.");
 	exit(signum);
@@ -50,11 +53,12 @@ static void cleanup_handler(int signum)
 
 int main(int argc, char* argv[])
 {
-	const char* cfg = "config.ini";
-	int status = 0;
+	proxyConfig* config = NULL;
+	const char* config_path = "config.ini";
+	int status = -1;
 
 	if (argc > 1)
-		cfg = argv[1];
+		config_path = argv[1];
 
 	/* Register cleanup handler for graceful termination */
 	signal(SIGINT, cleanup_handler);
@@ -72,13 +76,26 @@ int main(int argc, char* argv[])
 
 	pf_modules_list_loaded_plugins();
 
-	if (!pf_server_config_load(cfg, &config))
+	config = pf_server_config_load(config_path);
+	if (!config)
 		goto fail;
 
-	pf_server_config_print(&config);
-	status = pf_server_start(&config);
+	pf_server_config_print(config);
+
+	server = pf_server_new(config);
+	if (!server)
+		goto fail;
+
+	if (!pf_server_start(server))
+		goto fail;
+
+	if (WaitForSingleObject(server->thread, INFINITE) != WAIT_OBJECT_0)
+		goto fail;
+
+	status = 0;
 fail:
+	pf_server_free(server);
 	pf_modules_free();
-	pf_server_config_free_internal(&config);
+	pf_server_config_free(config);
 	return status;
 }

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -23,24 +23,9 @@
 #include "config.h"
 #endif
 
-#include <errno.h>
-#include <stdio.h>
-#include <string.h>
-
 #include <freerdp/freerdp.h>
-#include <freerdp/constants.h>
 #include <freerdp/gdi/gdi.h>
-#include <freerdp/utils/signal.h>
-
-#include <freerdp/client/file.h>
 #include <freerdp/client/cmdline.h>
-#include <freerdp/client/cliprdr.h>
-#include <freerdp/client/channels.h>
-#include <freerdp/channels/channels.h>
-#include <freerdp/log.h>
-
-#include <winpr/crt.h>
-#include <winpr/synch.h>
 
 #include "pf_channels.h"
 #include "pf_gdi.h"
@@ -133,9 +118,6 @@ static BOOL pf_client_pre_connect(freerdp* instance)
 	 */
 	settings->GlyphSupportLevel = GLYPH_SUPPORT_NONE;
 	ZeroMemory(instance->settings->OrderSupport, 32);
-
-	settings->OsMajorType = OSMAJORTYPE_UNIX;
-	settings->OsMinorType = OSMINORTYPE_NATIVE_XSERVER;
 
 	settings->SupportDynamicChannels = TRUE;
 

--- a/server/proxy/pf_config.c
+++ b/server/proxy/pf_config.c
@@ -242,9 +242,9 @@ static BOOL pf_config_load_captures(wIniFile* ini, proxyConfig* config)
 	return TRUE;
 }
 
-BOOL pf_server_config_load(const char* path, proxyConfig* config)
+proxyConfig* pf_server_config_load(const char* path)
 {
-	BOOL ok = FALSE;
+	proxyConfig* config = NULL;
 	wIniFile* ini = IniFile_New();
 
 	if (!ini)
@@ -258,6 +258,8 @@ BOOL pf_server_config_load(const char* path, proxyConfig* config)
 		WLog_ERR(TAG, "pf_server_load_config(): IniFile_ReadFile() failed!");
 		goto out;
 	}
+
+	config = calloc(1, sizeof(proxyConfig));
 
 	if (!pf_config_load_server(ini, config))
 		goto out;
@@ -283,10 +285,13 @@ BOOL pf_server_config_load(const char* path, proxyConfig* config)
 	if (!pf_config_load_captures(ini, config))
 		goto out;
 
-	ok = TRUE;
+	IniFile_Free(ini);
+	return config;
+
 out:
 	IniFile_Free(ini);
-	return ok;
+	pf_server_config_free(config);
+	return NULL;
 }
 
 void pf_server_config_print(proxyConfig* config)
@@ -336,7 +341,7 @@ void pf_server_config_print(proxyConfig* config)
 	CONFIG_PRINT_STR(config, CapturesDirectory);
 }
 
-void pf_server_config_free_internal(proxyConfig* config)
+void pf_server_config_free(proxyConfig* config)
 {
 	if (config == NULL)
 		return;
@@ -344,4 +349,5 @@ void pf_server_config_free_internal(proxyConfig* config)
 	free(config->CapturesDirectory);
 	free(config->TargetHost);
 	free(config->Host);
+	free(config);
 }

--- a/server/proxy/pf_config.h
+++ b/server/proxy/pf_config.h
@@ -77,8 +77,8 @@ FREERDP_API BOOL pf_config_get_uint32(wIniFile* ini, const char* section, const 
 FREERDP_API BOOL pf_config_get_bool(wIniFile* ini, const char* section, const char* key);
 FREERDP_API const char* pf_config_get_str(wIniFile* ini, const char* section, const char* key);
 
-BOOL pf_server_config_load(const char* path, proxyConfig* config);
+proxyConfig* pf_server_config_load(const char* path);
 void pf_server_config_print(proxyConfig* config);
-void pf_server_config_free_internal(proxyConfig* config);
+void pf_server_config_free(proxyConfig* config);
 
 #endif /* FREERDP_SERVER_PROXY_PFCONFIG_H */

--- a/server/proxy/pf_context.c
+++ b/server/proxy/pf_context.c
@@ -56,10 +56,12 @@ error:
 /* Proxy context free callback */
 static void client_to_proxy_context_free(freerdp_peer* client, pServerContext* context)
 {
-	WINPR_UNUSED(client);
+	proxyServer* server;
 
-	if (!context)
+	if (!client || !context)
 		return;
+
+	server = (proxyServer*)client->ContextExtra;
 
 	WTSCloseServer((HANDLE)context->vcm);
 

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -452,7 +452,11 @@ BOOL pf_server_start(proxyServer* server)
 		goto error;
 
 	if (!server->listener->Open(server->listener, server->config->Host, server->config->Port))
+	{
+		WLog_ERR(TAG,
+		         "listener->Open failed! Port might be already used, or insufficient permissions.");
 		goto error;
+	}
 
 	server->thread = CreateThread(NULL, 0, pf_server_mainloop, (void*)server, 0, NULL);
 	if (!server->thread)

--- a/server/proxy/pf_server.h
+++ b/server/proxy/pf_server.h
@@ -22,8 +22,26 @@
 #ifndef FREERDP_SERVER_PROXY_SERVER_H
 #define FREERDP_SERVER_PROXY_SERVER_H
 
+#include <winpr/collections.h>
+#include <freerdp/listener.h>
+
 #include "pf_config.h"
 
-int pf_server_start(proxyConfig* config);
+typedef struct proxy_server
+{
+	proxyConfig* config;
+
+	freerdp_listener* listener;
+	wArrayList* clients;        /* maintain a list of active sessions, for stats */
+	wCountdownEvent* waitGroup; /* wait group used for gracefull shutdown */
+	HANDLE thread;              /* main server thread - freerdp listener thread */
+	HANDLE stopEvent;           /* an event used to signal the main thread to stop */
+} proxyServer;
+
+proxyServer* pf_server_new(proxyConfig* config);
+void pf_server_free(proxyServer* server);
+
+BOOL pf_server_start(proxyServer* server);
+void pf_server_stop(proxyServer* server);
 
 #endif /* FREERDP_SERVER_PROXY_SERVER_H */


### PR DESCRIPTION
Reverted #5838, simply because it was a mistake in understanding how rdpNla*, rdpTls* instances are managed. After digging, I found that it is allocated in transport_connect_nla and freed by freerdp_disconnect. Furthermore, I found that the output from ASAN, that pointed to this leak, was actually caused because the proxy **itself** didn't close all active connections gracefully.