### PR TITLE
Fixed missing NULL set of pointer after free

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -394,6 +394,7 @@ BOOL rdp_client_disconnect(rdpRdp* rdp)
 		return FALSE;
 
 	codecs_free(context->codecs);
+	context->codecs = NULL;
 	return TRUE;
 }
 


### PR DESCRIPTION
Due to this double free was possible if disconnect_and_clear was
called multiple times.