### PR TITLE
server: proxy: show indicative log on bind failure.

### DIFF
--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -1542,5 +1542,4 @@ BOOL rdp_send_server_status_info(rdpContext* context, UINT32 status)
 
 	Stream_Write_UINT32(s, status);
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_STATUS_INFO, rdp->mcs->userId);
-	;
 }

--- a/server/proxy/freerdp_proxy.c
+++ b/server/proxy/freerdp_proxy.c
@@ -28,7 +28,6 @@
 #include <winpr/collections.h>
 #include <stdlib.h>
 #include <signal.h>
-#include <winpr/cmdline.h>
 
 #define TAG PROXY_TAG("server")
 

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -25,6 +25,7 @@
 #include <winpr/string.h>
 #include <winpr/winsock.h>
 #include <winpr/thread.h>
+#include <errno.h>
 
 #include <freerdp/freerdp.h>
 #include <freerdp/channels/wtsvc.h>
@@ -453,8 +454,19 @@ BOOL pf_server_start(proxyServer* server)
 
 	if (!server->listener->Open(server->listener, server->config->Host, server->config->Port))
 	{
-		WLog_ERR(TAG,
-		         "listener->Open failed! Port might be already used, or insufficient permissions.");
+		switch (errno)
+		{
+			case EADDRINUSE:
+				WLog_ERR(TAG, "failed to start listener: address already in use!");
+				break;
+			case EACCES:
+				WLog_ERR(TAG, "failed to start listener: insufficent permissions!");
+				break;
+			default:
+				WLog_ERR(TAG, "failed to start listener: errno=%d", errno);
+				break;
+		}
+
 		goto error;
 	}
 


### PR DESCRIPTION
Also removes a tiny unnecessary ';' in `rdp_send_server_status_info`.