### PR TITLE
Fix #5852: handle CHANNEL_EVENT_WRITE_CANCELLED

### DIFF
--- a/channels/cliprdr/client/cliprdr_main.c
+++ b/channels/cliprdr/client/cliprdr_main.c
@@ -856,15 +856,14 @@ static VOID VCAPITYPE cliprdr_virtual_channel_open_event_ex(LPVOID lpUserParam, 
 	UINT error = CHANNEL_RC_OK;
 	cliprdrPlugin* cliprdr = (cliprdrPlugin*)lpUserParam;
 
-	if (!cliprdr || (cliprdr->OpenHandle != openHandle))
-	{
-		WLog_ERR(TAG, "error no match");
-		return;
-	}
-
 	switch (event)
 	{
 		case CHANNEL_EVENT_DATA_RECEIVED:
+			if (!cliprdr || (cliprdr->OpenHandle != openHandle))
+			{
+				WLog_ERR(TAG, "error no match");
+				return;
+			}
 			if ((error = cliprdr_virtual_channel_event_data_received(cliprdr, pData, dataLength,
 			                                                         totalLength, dataFlags)))
 				WLog_ERR(TAG, "failed with error %" PRIu32 "", error);
@@ -883,7 +882,7 @@ static VOID VCAPITYPE cliprdr_virtual_channel_open_event_ex(LPVOID lpUserParam, 
 			break;
 	}
 
-	if (error && cliprdr->context->rdpcontext)
+	if (error && cliprdr && cliprdr->context->rdpcontext)
 		setChannelError(cliprdr->context->rdpcontext, error,
 		                "cliprdr_virtual_channel_open_event_ex reported an error");
 }

--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -1246,15 +1246,14 @@ static void VCAPITYPE drdynvc_virtual_channel_open_event_ex(LPVOID lpUserParam, 
 	UINT error = CHANNEL_RC_OK;
 	drdynvcPlugin* drdynvc = (drdynvcPlugin*)lpUserParam;
 
-	if (!drdynvc || (drdynvc->OpenHandle != openHandle))
-	{
-		WLog_ERR(TAG, "drdynvc_virtual_channel_open_event: error no match");
-		return;
-	}
-
 	switch (event)
 	{
 		case CHANNEL_EVENT_DATA_RECEIVED:
+			if (!drdynvc || (drdynvc->OpenHandle != openHandle))
+			{
+				WLog_ERR(TAG, "drdynvc_virtual_channel_open_event: error no match");
+				return;
+			}
 			if ((error = drdynvc_virtual_channel_event_data_received(drdynvc, pData, dataLength,
 			                                                         totalLength, dataFlags)))
 				WLog_Print(drdynvc->log, WLOG_ERROR,
@@ -1276,7 +1275,7 @@ static void VCAPITYPE drdynvc_virtual_channel_open_event_ex(LPVOID lpUserParam, 
 			break;
 	}
 
-	if (error && drdynvc->rdpcontext)
+	if (error && drdynvc && drdynvc->rdpcontext)
 		setChannelError(drdynvc->rdpcontext, error,
 		                "drdynvc_virtual_channel_open_event reported an error");
 }

--- a/channels/encomsp/client/encomsp_main.c
+++ b/channels/encomsp/client/encomsp_main.c
@@ -1046,15 +1046,14 @@ static VOID VCAPITYPE encomsp_virtual_channel_open_event_ex(LPVOID lpUserParam, 
 	UINT error = CHANNEL_RC_OK;
 	encomspPlugin* encomsp = (encomspPlugin*)lpUserParam;
 
-	if (!encomsp || (encomsp->OpenHandle != openHandle))
-	{
-		WLog_ERR(TAG, "error no match");
-		return;
-	}
-
 	switch (event)
 	{
 		case CHANNEL_EVENT_DATA_RECEIVED:
+			if (!encomsp || (encomsp->OpenHandle != openHandle))
+			{
+				WLog_ERR(TAG, "error no match");
+				return;
+			}
 			if ((error = encomsp_virtual_channel_event_data_received(encomsp, pData, dataLength,
 			                                                         totalLength, dataFlags)))
 				WLog_ERR(TAG,
@@ -1076,7 +1075,7 @@ static VOID VCAPITYPE encomsp_virtual_channel_open_event_ex(LPVOID lpUserParam, 
 			break;
 	}
 
-	if (error && encomsp->rdpcontext)
+	if (error && encomsp && encomsp->rdpcontext)
 		setChannelError(encomsp->rdpcontext, error,
 		                "encomsp_virtual_channel_open_event reported an error");
 

--- a/channels/rail/client/rail_main.c
+++ b/channels/rail/client/rail_main.c
@@ -583,15 +583,14 @@ static VOID VCAPITYPE rail_virtual_channel_open_event_ex(LPVOID lpUserParam, DWO
 	UINT error = CHANNEL_RC_OK;
 	railPlugin* rail = (railPlugin*)lpUserParam;
 
-	if (!rail || (rail->OpenHandle != openHandle))
-	{
-		WLog_ERR(TAG, "error no match");
-		return;
-	}
-
 	switch (event)
 	{
 		case CHANNEL_EVENT_DATA_RECEIVED:
+			if (!rail || (rail->OpenHandle != openHandle))
+			{
+				WLog_ERR(TAG, "error no match");
+				return;
+			}
 			if ((error = rail_virtual_channel_event_data_received(rail, pData, dataLength,
 			                                                      totalLength, dataFlags)))
 				WLog_ERR(TAG,
@@ -612,7 +611,7 @@ static VOID VCAPITYPE rail_virtual_channel_open_event_ex(LPVOID lpUserParam, DWO
 			break;
 	}
 
-	if (error && rail->rdpcontext)
+	if (error && rail && rail->rdpcontext)
 		setChannelError(rail->rdpcontext, error,
 		                "rail_virtual_channel_open_event reported an error");
 

--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -1509,15 +1509,14 @@ static VOID VCAPITYPE rdpdr_virtual_channel_open_event_ex(LPVOID lpUserParam, DW
 	UINT error = CHANNEL_RC_OK;
 	rdpdrPlugin* rdpdr = (rdpdrPlugin*)lpUserParam;
 
-	if (!rdpdr || !pData || (rdpdr->OpenHandle != openHandle))
-	{
-		WLog_ERR(TAG, "error no match");
-		return;
-	}
-
 	switch (event)
 	{
 		case CHANNEL_EVENT_DATA_RECEIVED:
+			if (!rdpdr || !pData || (rdpdr->OpenHandle != openHandle))
+			{
+				WLog_ERR(TAG, "error no match");
+				return;
+			}
 			if ((error = rdpdr_virtual_channel_event_data_received(rdpdr, pData, dataLength,
 			                                                       totalLength, dataFlags)))
 				WLog_ERR(TAG,
@@ -1538,7 +1537,7 @@ static VOID VCAPITYPE rdpdr_virtual_channel_open_event_ex(LPVOID lpUserParam, DW
 			break;
 	}
 
-	if (error && rdpdr->rdpcontext)
+	if (error && rdpdr && rdpdr->rdpcontext)
 		setChannelError(rdpdr->rdpcontext, error,
 		                "rdpdr_virtual_channel_open_event_ex reported an error");
 

--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -967,15 +967,14 @@ static VOID VCAPITYPE rdpsnd_virtual_channel_open_event_ex(LPVOID lpUserParam, D
 	UINT error = CHANNEL_RC_OK;
 	rdpsndPlugin* rdpsnd = (rdpsndPlugin*)lpUserParam;
 
-	if (!rdpsnd || (rdpsnd->OpenHandle != openHandle))
-	{
-		WLog_ERR(TAG, "error no match");
-		return;
-	}
-
 	switch (event)
 	{
 		case CHANNEL_EVENT_DATA_RECEIVED:
+			if (!rdpsnd || (rdpsnd->OpenHandle != openHandle))
+			{
+				WLog_ERR(TAG, "error no match");
+				return;
+			}
 			if ((error = rdpsnd_virtual_channel_event_data_received(rdpsnd, pData, dataLength,
 			                                                        totalLength, dataFlags)))
 				WLog_ERR(TAG,
@@ -996,7 +995,7 @@ static VOID VCAPITYPE rdpsnd_virtual_channel_open_event_ex(LPVOID lpUserParam, D
 			break;
 	}
 
-	if (error && rdpsnd->rdpcontext)
+	if (error && rdpsnd && rdpsnd->rdpcontext)
 		setChannelError(rdpsnd->rdpcontext, error,
 		                "rdpsnd_virtual_channel_open_event_ex reported an error");
 }

--- a/channels/remdesk/client/remdesk_main.c
+++ b/channels/remdesk/client/remdesk_main.c
@@ -771,15 +771,14 @@ static VOID VCAPITYPE remdesk_virtual_channel_open_event_ex(LPVOID lpUserParam, 
 	UINT error = CHANNEL_RC_OK;
 	remdeskPlugin* remdesk = (remdeskPlugin*)lpUserParam;
 
-	if (!remdesk || (remdesk->OpenHandle != openHandle))
-	{
-		WLog_ERR(TAG, "error no match");
-		return;
-	}
-
 	switch (event)
 	{
 		case CHANNEL_EVENT_DATA_RECEIVED:
+			if (!remdesk || (remdesk->OpenHandle != openHandle))
+			{
+				WLog_ERR(TAG, "error no match");
+				return;
+			}
 			if ((error = remdesk_virtual_channel_event_data_received(remdesk, pData, dataLength,
 			                                                         totalLength, dataFlags)))
 				WLog_ERR(TAG,
@@ -805,7 +804,7 @@ static VOID VCAPITYPE remdesk_virtual_channel_open_event_ex(LPVOID lpUserParam, 
 			error = ERROR_INTERNAL_ERROR;
 	}
 
-	if (error && remdesk->rdpcontext)
+	if (error && remdesk && remdesk->rdpcontext)
 		setChannelError(remdesk->rdpcontext, error,
 		                "remdesk_virtual_channel_open_event_ex reported an error");
 }


### PR DESCRIPTION
When channels are cleaned up OpenHandle is most of the time
already 0. Ignore the argument checks for
CHANNEL_EVENT_WRITE_CANCELLED and CHANNEL_EVENT_WRITE_COMPLETE
only check where actually required (CHANNEL_EVENT_DATA_RECEIVED)