### PR TITLE
Urbdrc export symbol fix

### DIFF
--- a/channels/urbdrc/client/urbdrc_main.h
+++ b/channels/urbdrc/client/urbdrc_main.h
@@ -229,8 +229,11 @@ struct _IUDEVMAN
 	IWTSPlugin* plugin;
 	UINT32 controlChannelId;
 };
-BOOL add_device(IUDEVMAN* idevman, BYTE busnum, BYTE devnum, UINT16 idVendor, UINT16 idProduct);
-BOOL del_device(IUDEVMAN* idevman, BYTE busnum, BYTE devnum, UINT16 idVendor, UINT16 idProduct);
+
+FREERDP_API BOOL add_device(IUDEVMAN* idevman, BYTE busnum, BYTE devnum, UINT16 idVendor,
+                            UINT16 idProduct);
+FREERDP_API BOOL del_device(IUDEVMAN* idevman, BYTE busnum, BYTE devnum, UINT16 idVendor,
+                            UINT16 idProduct);
 
 UINT stream_write_and_free(IWTSPlugin* plugin, IWTSVirtualChannel* channel, wStream* s);
 


### PR DESCRIPTION
When building the usb channel with different shared libraries some
    necessary symbols were not exported.