### PR TITLE
End connection before user callbacks if aborted.

### DIFF
--- a/libfreerdp/core/gateway/ncacn_http.c
+++ b/libfreerdp/core/gateway/ncacn_http.c
@@ -145,6 +145,9 @@ BOOL rpc_ncacn_http_ntlm_init(rdpContext* context, RpcChannel* channel)
 	if (!settings->GatewayPassword || !settings->GatewayUsername ||
 	    !strlen(settings->GatewayPassword) || !strlen(settings->GatewayUsername))
 	{
+		if (freerdp_shall_disconnect(instance))
+			return FALSE;
+
 		if (!instance->GatewayAuthenticate)
 		{
 			freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -868,6 +868,9 @@ static BOOL rdg_get_gateway_credentials(rdpContext* context)
 	if (!settings->GatewayPassword || !settings->GatewayUsername ||
 	    !strlen(settings->GatewayPassword) || !strlen(settings->GatewayUsername))
 	{
+		if (freerdp_shall_disconnect(instance))
+			return FALSE;
+
 		if (!instance->GatewayAuthenticate)
 		{
 			freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);

--- a/libfreerdp/core/gateway/rpc_bind.c
+++ b/libfreerdp/core/gateway/rpc_bind.c
@@ -133,6 +133,9 @@ int rpc_send_bind_pdu(rdpRpc* rpc)
 
 	if (promptPassword)
 	{
+		if (freerdp_shall_disconnect(instance))
+			return -1;
+
 		if (!instance->GatewayAuthenticate)
 		{
 			freerdp_set_last_error_log(instance->context,

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -274,6 +274,9 @@ static int nla_client_init(rdpNla* nla)
 
 	if (PromptPassword)
 	{
+		if (freerdp_shall_disconnect(instance))
+			return 0;
+
 		if (!instance->Authenticate)
 		{
 			freerdp_set_last_error_log(instance->context,

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1338,6 +1338,9 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, const char* hostname, U
 	BYTE* pemCert = NULL;
 	DWORD flags = VERIFY_CERT_FLAG_NONE;
 
+	if (freerdp_shall_disconnect(instance))
+		return -1;
+
 	if (!tls_extract_pem(cert, &pemCert, &length))
 		goto end;
 


### PR DESCRIPTION
If somewhere in freerdp_connect freerdp_abort_connect was called
the user callbacks Authenticate, GatewayAuthenticate and
Verify[Changed|X509]Certificate[Ex] must not be called.