### PR TITLE
Do not advertise /usb in help output if the channel is not built

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -432,7 +432,9 @@ BOOL freerdp_client_print_command_line_help_ex(int argc, char** argv,
 	printf("\n");
 	printf("Multimedia Redirection: /multimedia:sys:oss,dev:/dev/dsp1,decoder:ffmpeg\n");
 	printf("Multimedia Redirection: /multimedia:sys:alsa\n");
+#ifdef CHANNEL_URBDRC_CLIENT
 	printf("USB Device Redirection: /usb:id,dev:054c:0268\n");
+#endif
 	printf("\n");
 	printf("For Gateways, the https_proxy environment variable is respected:\n");
 #ifdef _WIN32

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -321,8 +321,10 @@ static const COMMAND_LINE_ARGUMENT_A args[] = {
 	  NULL, "Username" },
 	{ "unmap-buttons", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
 	  "Let server see real physical pointer button" },
+#ifdef CHANNEL_URBDRC_CLIENT
 	{ "usb", COMMAND_LINE_VALUE_REQUIRED, "[dbg,][dev:<dev>,][id|addr,][auto]", NULL, NULL, -1,
 	  NULL, "Redirect USB device" },
+#endif
 	{ "v", COMMAND_LINE_VALUE_REQUIRED, "<server>[:port]", NULL, NULL, -1, NULL,
 	  "Server hostname" },
 	{ "vc", COMMAND_LINE_VALUE_REQUIRED, "<channel>[,<options>]", NULL, NULL, -1, NULL,


### PR DESCRIPTION
The help output advertise an option and an example for usb redirection
regardless of the fact whether the urbdrc channel was built or not.
This is confusing for people. Let's do not show /usb in help if it is
not built.
