### PR TITLE
egfx: the gfx reset grahics pdu is optional

### DIFF
--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -121,9 +121,6 @@ static UINT xf_UpdateSurfaces(RdpgfxClientContext* context)
 	if (!gdi)
 		return status;
 
-	if (!gdi->graphicsReset)
-		return status;
-
 	if (gdi->suppressOutput)
 		return CHANNEL_RC_OK;
 

--- a/include/freerdp/gdi/gdi.h
+++ b/include/freerdp/gdi/gdi.h
@@ -517,7 +517,7 @@ struct rdp_gdi
 	void (*free)(void*);
 
 	BOOL inGfxFrame;
-	BOOL graphicsReset;
+	BOOL graphicsReset; /* deprecated, remove with FreeRDP v3 */
 	BOOL suppressOutput;
 	UINT16 outputSurfaceId;
 	RdpgfxClientContext* gfx;

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -92,7 +92,6 @@ static UINT gdi_ResetGraphics(RdpgfxClientContext* context,
 	                                 gdi->height))
 		goto fail;
 
-	gdi->graphicsReset = TRUE;
 	rc = CHANNEL_RC_OK;
 fail:
 	LeaveCriticalSection(&context->mux);
@@ -166,9 +165,6 @@ static UINT gdi_UpdateSurfaces(RdpgfxClientContext* context)
 	gdiGfxSurface* surface;
 	UINT16* pSurfaceIds = NULL;
 	rdpGdi* gdi = (rdpGdi*)context->custom;
-
-	if (!gdi->graphicsReset)
-		return CHANNEL_RC_OK;
 
 	EnterCriticalSection(&context->mux);
 	context->GetSurfaceIds(context, &pSurfaceIds, &count);
@@ -1474,6 +1470,15 @@ BOOL gdi_graphics_pipeline_init_ex(rdpGdi* gdi, RdpgfxClientContext* gfx,
 	gfx->UpdateSurfaceArea = update;
 	InitializeCriticalSection(&gfx->mux);
 	PROFILER_CREATE(gfx->SurfaceProfiler, "GFX-PROFILER");
+
+	/**
+	 * gdi->graphicsReset will be removed in FreeRDP v3 from public headers,
+	 * since the EGFX Reset Graphics PDU seems to be optional.
+	 * There are still some clients that expect and check it and therefore
+	 * we simply initialize it with TRUE here for now.
+	 */
+	gdi->graphicsReset = TRUE;
+
 	return TRUE;
 }
 


### PR DESCRIPTION
Since the EGFX Reset Graphics PDU seems to be optional, the `graphicsReset` variable (which is updated in that PDU's handler) should be removed from the `rdp_gdi` struct with the next change in public headers (as in freerdp v3).

There are still some clients that expect and check it and therefore we keep it for now, initialized with `TRUE`.