### PR TITLE
X11 event lock

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -496,17 +496,16 @@ static BOOL xf_process_x_events(freerdp* instance)
 	{
 		xf_lock_x11(xfc, FALSE);
 		pending_status = XPending(xfc->display);
-		xf_unlock_x11(xfc, FALSE);
 
 		if (pending_status)
 		{
 			ZeroMemory(&xevent, sizeof(xevent));
 			XNextEvent(xfc->display, &xevent);
 			status = xf_event_process(instance, &xevent);
-
-			if (!status)
-				return status;
 		}
+		xf_unlock_x11(xfc, FALSE);
+		if (!status)
+			break;
 	}
 
 	return status;
@@ -809,10 +808,17 @@ void xf_lock_x11(xfContext* xfc, BOOL display)
 		if (display)
 			XLockDisplay(xfc->display);
 	}
+	if (xfc->locked)
+		WLog_WARN(TAG, "X11 trying to lock although already locked!");
+
+	xfc->locked = TRUE;
 }
 
 void xf_unlock_x11(xfContext* xfc, BOOL display)
 {
+	if (!xfc->locked)
+		WLog_WARN(TAG, "X11: trying to unlock although not locked!");
+
 	if (!xfc->UseXThreads)
 	{
 		ReleaseMutex(xfc->mutex);
@@ -822,6 +828,7 @@ void xf_unlock_x11(xfContext* xfc, BOOL display)
 		if (display)
 			XUnlockDisplay(xfc->display);
 	}
+	xfc->locked = FALSE;
 }
 
 static BOOL xf_get_pixmap_info(xfContext* xfc)

--- a/client/X11/xf_cliprdr.h
+++ b/client/X11/xf_cliprdr.h
@@ -31,6 +31,6 @@ void xf_clipboard_free(xfClipboard* clipboard);
 void xf_cliprdr_init(xfContext* xfc, CliprdrClientContext* cliprdr);
 void xf_cliprdr_uninit(xfContext* xfc, CliprdrClientContext* cliprdr);
 
-void xf_cliprdr_handle_xevent(xfContext* xfc, XEvent* event);
+void xf_cliprdr_handle_xevent(xfContext* xfc, const XEvent* event);
 
 #endif /* FREERDP_CLIENT_X11_CLIPRDR_H */

--- a/client/X11/xf_disp.c
+++ b/client/X11/xf_disp.c
@@ -348,7 +348,7 @@ UINT xf_disp_sendLayout(DispClientContext* disp, rdpMonitor* monitors, int nmoni
 	return ret;
 }
 
-BOOL xf_disp_handle_xevent(xfContext* xfc, XEvent* event)
+BOOL xf_disp_handle_xevent(xfContext* xfc, const XEvent* event)
 {
 	xfDispContext* xfDisp;
 	rdpSettings* settings;

--- a/client/X11/xf_disp.h
+++ b/client/X11/xf_disp.h
@@ -30,7 +30,7 @@ FREERDP_API BOOL xf_disp_uninit(xfDispContext* xfDisp, DispClientContext* disp);
 
 xfDispContext* xf_disp_new(xfContext* xfc);
 void xf_disp_free(xfDispContext* disp);
-BOOL xf_disp_handle_xevent(xfContext* xfc, XEvent* event);
+BOOL xf_disp_handle_xevent(xfContext* xfc, const XEvent* event);
 BOOL xf_disp_handle_configureNotify(xfContext* xfc, int width, int height);
 void xf_disp_resized(xfDispContext* disp);
 

--- a/client/X11/xf_event.h
+++ b/client/X11/xf_event.h
@@ -28,7 +28,7 @@
 BOOL xf_event_action_script_init(xfContext* xfc);
 void xf_event_action_script_free(xfContext* xfc);
 
-BOOL xf_event_process(freerdp* instance, XEvent* event);
+BOOL xf_event_process(freerdp* instance, const XEvent* event);
 void xf_event_SendClientEvent(xfContext* xfc, xfWindow* window, Atom atom, unsigned int numArgs,
                               ...);
 

--- a/client/X11/xf_floatbar.h
+++ b/client/X11/xf_floatbar.h
@@ -25,8 +25,8 @@ typedef struct xf_floatbar xfFloatbar;
 xfFloatbar* xf_floatbar_new(xfContext* xfc, Window window, const char* title, DWORD flags);
 void xf_floatbar_free(xfFloatbar* floatbar);
 
-BOOL xf_floatbar_event_process(xfFloatbar* floatbar, XEvent* event);
-BOOL xf_floatbar_check_event(xfFloatbar* floatbar, XEvent* event);
+BOOL xf_floatbar_event_process(xfFloatbar* floatbar, const XEvent* event);
+BOOL xf_floatbar_check_event(xfFloatbar* floatbar, const XEvent* event);
 BOOL xf_floatbar_toggle_fullscreen(xfFloatbar* floatbar, bool visible);
 BOOL xf_floatbar_hide_and_show(xfFloatbar* floatbar);
 BOOL xf_floatbar_set_root_y(xfFloatbar* floatbar, int y);

--- a/client/X11/xf_input.h
+++ b/client/X11/xf_input.h
@@ -28,6 +28,6 @@
 #endif
 
 int xf_input_init(xfContext* xfc, Window window);
-int xf_input_handle_event(xfContext* xfc, XEvent* event);
+int xf_input_handle_event(xfContext* xfc, const XEvent* event);
 
 #endif /* FREERDP_CLIENT_X11_INPUT_H */

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -247,6 +247,7 @@ struct xf_context
 	/* value to be sent over wire for each logical client mouse button */
 	button_map button_map[NUM_BUTTONS_MAPPED];
 	BYTE savedMaximizedState;
+	BOOL locked;
 };
 
 BOOL xf_create_window(xfContext* xfc);


### PR DESCRIPTION
* Fixes X11 event lock issues (see #5908 )
* Use const arguments in event handling code
* Use appropriate type in event handling code to avoid misuse