### PR TITLE
Disable GSS/KRB5 support

### DIFF
--- a/packaging/rpm/freerdp-nightly.spec
+++ b/packaging/rpm/freerdp-nightly.spec
@@ -123,7 +123,7 @@ cp %{_topdir}/SOURCES/source_version freerdp-nightly-%{version}/.source_version
 %if 0%{?fedora} < 21 || 0%{?rhel} < 8
         -DWITH_WAYLAND=OFF \
 %endif
-        -DWITH_GSSAPI=ON \
+        -DWITH_GSSAPI=OFF \
         -DCHANNEL_URBDRC=ON \
         -DCHANNEL_URBDRC_CLIENT=ON \
         -DWITH_SERVER=ON \


### PR DESCRIPTION
Kerberos support in FreeRDP is not working, deactivate it. Fixes #5930