### PR TITLE
Fix RDPEGFX bitmap cache indexing

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -75,11 +75,11 @@ static void free_surfaces(RdpgfxClientContext* context, wHashTable* SurfaceTable
 	free(pKeys);
 }
 
-static void evict_cache_slots(RdpgfxClientContext* context, UINT16 MaxCacheSlot, void** CacheSlots)
+static void evict_cache_slots(RdpgfxClientContext* context, UINT16 MaxCacheSlots, void** CacheSlots)
 {
 	UINT16 index;
 
-	for (index = 0; index < MaxCacheSlot; index++)
+	for (index = 0; index < MaxCacheSlots; index++)
 	{
 		if (CacheSlots[index])
 		{
@@ -1819,7 +1819,7 @@ static UINT rdpgfx_on_close(IWTSVirtualChannelCallback* pChannelCallback)
 
 	DEBUG_RDPGFX(gfx->log, "OnClose");
 	free_surfaces(context, gfx->SurfaceTable);
-	evict_cache_slots(context, gfx->MaxCacheSlot, gfx->CacheSlots);
+	evict_cache_slots(context, gfx->MaxCacheSlots, gfx->CacheSlots);
 
 	if (gfx->listener_callback)
 	{
@@ -1992,10 +1992,10 @@ static UINT rdpgfx_set_cache_slot_data(RdpgfxClientContext* context, UINT16 cach
 	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*)context->handle;
 
 	/* Microsoft uses 1-based indexing for the egfx bitmap cache ! */
-	if (cacheSlot == 0 || cacheSlot > gfx->MaxCacheSlot)
+	if (cacheSlot == 0 || cacheSlot > gfx->MaxCacheSlots)
 	{
-		WLog_ERR(TAG, "%s: invalid cache slot %" PRIu16 ", must be between 1 and %" PRIu16 "", __FUNCTION__,
-		         cacheSlot, gfx->MaxCacheSlot);
+		WLog_ERR(TAG, "%s: invalid cache slot %" PRIu16 ", must be between 1 and %" PRIu16 "",
+		         __FUNCTION__, cacheSlot, gfx->MaxCacheSlots);
 		return ERROR_INVALID_INDEX;
 	}
 
@@ -2009,10 +2009,10 @@ static void* rdpgfx_get_cache_slot_data(RdpgfxClientContext* context, UINT16 cac
 	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*)context->handle;
 
 	/* Microsoft uses 1-based indexing for the egfx bitmap cache ! */
-	if (cacheSlot == 0 || cacheSlot > gfx->MaxCacheSlot)
+	if (cacheSlot == 0 || cacheSlot > gfx->MaxCacheSlots)
 	{
-		WLog_ERR(TAG, "%s: invalid cache slot %" PRIu16 ", must be between 1 and %" PRIu16 "", __FUNCTION__,
-		         cacheSlot, gfx->MaxCacheSlot);
+		WLog_ERR(TAG, "%s: invalid cache slot %" PRIu16 ", must be between 1 and %" PRIu16 "",
+		         __FUNCTION__, cacheSlot, gfx->MaxCacheSlots);
 		return NULL;
 	}
 
@@ -2071,7 +2071,7 @@ RdpgfxClientContext* rdpgfx_client_context_new(rdpSettings* settings)
 	if (gfx->H264)
 		gfx->SmallCache = TRUE;
 
-	gfx->MaxCacheSlot = gfx->SmallCache ? 4096 : 25600;
+	gfx->MaxCacheSlots = gfx->SmallCache ? 4096 : 25600;
 	context = (RdpgfxClientContext*)calloc(1, sizeof(RdpgfxClientContext));
 
 	if (!context)
@@ -2117,7 +2117,7 @@ void rdpgfx_client_context_free(RdpgfxClientContext* context)
 	gfx = (RDPGFX_PLUGIN*)context->handle;
 
 	free_surfaces(context, gfx->SurfaceTable);
-	evict_cache_slots(context, gfx->MaxCacheSlot, gfx->CacheSlots);
+	evict_cache_slots(context, gfx->MaxCacheSlots, gfx->CacheSlots);
 
 	if (gfx->listener_callback)
 	{

--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -1991,14 +1991,15 @@ static UINT rdpgfx_set_cache_slot_data(RdpgfxClientContext* context, UINT16 cach
 {
 	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*)context->handle;
 
-	if (cacheSlot >= gfx->MaxCacheSlot)
+	/* Microsoft uses 1-based indexing for the egfx bitmap cache ! */
+	if (cacheSlot == 0 || cacheSlot > gfx->MaxCacheSlot)
 	{
-		WLog_ERR(TAG, "%s: invalid cache slot %" PRIu16 " maxAllowed=%" PRIu16 "", __FUNCTION__,
+		WLog_ERR(TAG, "%s: invalid cache slot %" PRIu16 ", must be between 1 and %" PRIu16 "", __FUNCTION__,
 		         cacheSlot, gfx->MaxCacheSlot);
 		return ERROR_INVALID_INDEX;
 	}
 
-	gfx->CacheSlots[cacheSlot] = pData;
+	gfx->CacheSlots[cacheSlot - 1] = pData;
 	return CHANNEL_RC_OK;
 }
 
@@ -2007,14 +2008,15 @@ static void* rdpgfx_get_cache_slot_data(RdpgfxClientContext* context, UINT16 cac
 	void* pData = NULL;
 	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*)context->handle;
 
-	if (cacheSlot >= gfx->MaxCacheSlot)
+	/* Microsoft uses 1-based indexing for the egfx bitmap cache ! */
+	if (cacheSlot == 0 || cacheSlot > gfx->MaxCacheSlot)
 	{
-		WLog_ERR(TAG, "%s: invalid cache slot %" PRIu16 " maxAllowed=%" PRIu16 "", __FUNCTION__,
+		WLog_ERR(TAG, "%s: invalid cache slot %" PRIu16 ", must be between 1 and %" PRIu16 "", __FUNCTION__,
 		         cacheSlot, gfx->MaxCacheSlot);
 		return NULL;
 	}
 
-	pData = gfx->CacheSlots[cacheSlot];
+	pData = gfx->CacheSlots[cacheSlot - 1];
 	return pData;
 }
 

--- a/channels/rdpgfx/client/rdpgfx_main.h
+++ b/channels/rdpgfx/client/rdpgfx_main.h
@@ -78,7 +78,7 @@ struct _RDPGFX_PLUGIN
 
 	wHashTable* SurfaceTable;
 
-	UINT16 MaxCacheSlot;
+	UINT16 MaxCacheSlots;
 	void* CacheSlots[25600];
 	rdpContext* rdpcontext;
 


### PR DESCRIPTION
---

Please **don't merge** until Microsoft answers https://github.com/microsoft/WindowsProtocolTestSuites/issues/227

---

Microsoft seems to use 1-based indexing in the RDPGFX bitmap cache PDU's.
This does not seem to be documented but can be deducted from the RDP client test code in Microsoft's "Windows Protocol Test Suites" [RDP client test code](https://github.com/microsoft/WindowsProtocolTestSuites/tree/staging/TestSuites/RDP/Client/src/TestSuite) and the observation that mstsc aborts with a protocol error if the cacheSlot index value 0 is used in a GFX surface to cache PDU.

I've also renamed the RDPGFX_PLUGIN struct member `MaxCacheSlot` to `MaxCacheSlots` which is less confusing, since FreeRDP of course uses 0-based numbering internally.
