### PR TITLE
Fixed shadow server with mstsc as client.

### DIFF
--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -223,6 +223,8 @@ static BOOL wts_read_drdynvc_data(rdpPeerChannel* channel, wStream* s, UINT32 le
 			                             channel->dvc_total_length);
 			channel->dvc_total_length = 0;
 		}
+		else
+			ret = TRUE;
 	}
 	else
 	{

--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -2139,6 +2139,8 @@ BOOL update_read_refresh_rect(rdpUpdate* update, wStream* s)
 
 BOOL update_read_suppress_output(rdpUpdate* update, wStream* s)
 {
+	RECTANGLE_16* prect = NULL;
+	RECTANGLE_16 rect = { 0 };
 	BYTE allowDisplayUpdates;
 
 	if (Stream_GetRemainingLength(s) < 4)
@@ -2147,12 +2149,20 @@ BOOL update_read_suppress_output(rdpUpdate* update, wStream* s)
 	Stream_Read_UINT8(s, allowDisplayUpdates);
 	Stream_Seek(s, 3); /* pad3Octects */
 
-	if (allowDisplayUpdates > 0 && Stream_GetRemainingLength(s) < 8)
-		return FALSE;
+	if (allowDisplayUpdates > 0)
+	{
+		if (Stream_GetRemainingLength(s) < sizeof(RECTANGLE_16))
+			return FALSE;
+		Stream_Read_UINT16(s, rect.left);
+		Stream_Read_UINT16(s, rect.top);
+		Stream_Read_UINT16(s, rect.right);
+		Stream_Read_UINT16(s, rect.bottom);
+
+		prect = &rect;
+	}
 
 	if (update->context->settings->SuppressOutput)
-		IFCALL(update->SuppressOutput, update->context, allowDisplayUpdates,
-		       allowDisplayUpdates > 0 ? (RECTANGLE_16*)Stream_Pointer(s) : NULL);
+		IFCALL(update->SuppressOutput, update->context, allowDisplayUpdates, prect);
 	else
 		WLog_Print(update->log, WLOG_WARN, "ignoring suppress output request from client");
 


### PR DESCRIPTION
* Remove casts for `shadow` function pointers and fix their arguments.
* Fix reading of `suppress output PDU` to prevent `tpkt` lenght check issues. 