### PR TITLE
dynvc/client: fix and improve channel closing code

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -1714,7 +1714,7 @@ static UINT rdpgfx_recv_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wStream* s)
 
 	if (error)
 	{
-		WLog_Print(gfx->log, WLOG_ERROR, "Error while parsing GFX cmdId: %s (0x%04" PRIX16 ")",
+		WLog_Print(gfx->log, WLOG_ERROR, "Error while processing GFX cmdId: %s (0x%04" PRIX16 ")",
 		           rdpgfx_get_cmd_id_string(header.cmdId), header.cmdId);
 		return error;
 	}

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -1301,7 +1301,7 @@ static UINT gdi_EvictCacheEntry(RdpgfxClientContext* context,
                                 const RDPGFX_EVICT_CACHE_ENTRY_PDU* evictCacheEntry)
 {
 	gdiGfxCacheEntry* cacheEntry;
-	UINT rc = ERROR_INTERNAL_ERROR;
+	UINT rc = ERROR_NOT_FOUND;
 	EnterCriticalSection(&context->mux);
 	cacheEntry = (gdiGfxCacheEntry*)context->GetCacheSlotData(context, evictCacheEntry->cacheSlot);
 
@@ -1309,9 +1309,9 @@ static UINT gdi_EvictCacheEntry(RdpgfxClientContext* context,
 	{
 		free(cacheEntry->data);
 		free(cacheEntry);
+		rc = context->SetCacheSlotData(context, evictCacheEntry->cacheSlot, NULL);
 	}
 
-	rc = context->SetCacheSlotData(context, evictCacheEntry->cacheSlot, NULL);
 	LeaveCriticalSection(&context->mux);
 	return rc;
 }


### PR DESCRIPTION
- fixed and consolidated the duplicated code for sending the `CLOSE_REQUEST_PDU` to the server into `dvcman_close_channel`
- call `dvcman_close_channel` if a dynamic channel plugin fails to process the received channel data
- rdpegfx: don't try to remove a non-existing cache entry, return an error instead which now will close the channel, as expected by Microsoft's windows protocols test suite
