### PR TITLE
Fix GFX cache eviction, use 1 based indexing.

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -84,7 +84,7 @@ static void evict_cache_slots(RdpgfxClientContext* context, UINT16 MaxCacheSlots
 		if (CacheSlots[index])
 		{
 			RDPGFX_EVICT_CACHE_ENTRY_PDU pdu;
-			pdu.cacheSlot = (UINT16)index;
+			pdu.cacheSlot = (UINT16)index + 1;
 
 			if (context && context->EvictCacheEntry)
 			{


### PR DESCRIPTION
Follow up to https://github.com/FreeRDP/FreeRDP/pull/5932
Fixed eviction of caches on client close.