### PR TITLE
Fixed misinterpretation of SendChannelData

### DIFF
--- a/include/freerdp/channels/channels.h
+++ b/include/freerdp/channels/channels.h
@@ -50,8 +50,8 @@ extern "C"
 	FREERDP_API HANDLE freerdp_channels_get_event_handle(freerdp* instance);
 	FREERDP_API int freerdp_channels_process_pending_messages(freerdp* instance);
 
-	FREERDP_API int freerdp_channels_data(freerdp* instance, UINT16 channelId, BYTE* data,
-	                                      int dataSize, int flags, int totalSize);
+	FREERDP_API BOOL freerdp_channels_data(freerdp* instance, UINT16 channelId, const BYTE* data,
+	                                       size_t dataSize, UINT32 flags, size_t totalSize);
 
 	FREERDP_API UINT16 freerdp_channels_get_id_by_name(freerdp* instance, const char* channel_name);
 	FREERDP_API const char* freerdp_channels_get_name_by_id(freerdp* instance, UINT16 channelId);

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -178,8 +178,8 @@ extern "C"
 
 	typedef BOOL (*pSendChannelData)(freerdp* instance, UINT16 channelId, const BYTE* data,
 	                                 size_t size);
-	typedef int (*pReceiveChannelData)(freerdp* instance, UINT16 channelId, BYTE* data, int size,
-	                                   int flags, int totalSize);
+	typedef BOOL (*pReceiveChannelData)(freerdp* instance, UINT16 channelId, const BYTE* data,
+	                                    size_t size, UINT32 flags, size_t totalSize);
 
 	typedef BOOL (*pPresentGatewayMessage)(freerdp* instance, UINT32 type, BOOL isDisplayMandatory,
 	                                       BOOL isConsentMandatory, size_t length,

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -176,8 +176,8 @@ extern "C"
 
 	typedef int (*pLogonErrorInfo)(freerdp* instance, UINT32 data, UINT32 type);
 
-	typedef int (*pSendChannelData)(freerdp* instance, UINT16 channelId, const BYTE* data,
-	                                int size);
+	typedef BOOL (*pSendChannelData)(freerdp* instance, UINT16 channelId, const BYTE* data,
+	                                 size_t size);
 	typedef int (*pReceiveChannelData)(freerdp* instance, UINT16 channelId, BYTE* data, int size,
 	                                   int flags, int totalSize);
 

--- a/include/freerdp/peer.h
+++ b/include/freerdp/peer.h
@@ -51,8 +51,8 @@ typedef BOOL (*psPeerLogon)(freerdp_peer* peer, SEC_WINNT_AUTH_IDENTITY* identit
 typedef BOOL (*psPeerAdjustMonitorsLayout)(freerdp_peer* peer);
 typedef BOOL (*psPeerClientCapabilities)(freerdp_peer* peer);
 
-typedef int (*psPeerSendChannelData)(freerdp_peer* peer, UINT16 channelId, const BYTE* data,
-                                     int size);
+typedef BOOL (*psPeerSendChannelData)(freerdp_peer* peer, UINT16 channelId, const BYTE* data,
+                                      size_t size);
 typedef int (*psPeerReceiveChannelData)(freerdp_peer* peer, UINT16 channelId, const BYTE* data,
                                         size_t size, UINT32 flags, size_t totalSize);
 

--- a/include/freerdp/peer.h
+++ b/include/freerdp/peer.h
@@ -53,8 +53,8 @@ typedef BOOL (*psPeerClientCapabilities)(freerdp_peer* peer);
 
 typedef BOOL (*psPeerSendChannelData)(freerdp_peer* peer, UINT16 channelId, const BYTE* data,
                                       size_t size);
-typedef int (*psPeerReceiveChannelData)(freerdp_peer* peer, UINT16 channelId, const BYTE* data,
-                                        size_t size, UINT32 flags, size_t totalSize);
+typedef BOOL (*psPeerReceiveChannelData)(freerdp_peer* peer, UINT16 channelId, const BYTE* data,
+                                         size_t size, UINT32 flags, size_t totalSize);
 
 typedef HANDLE (*psPeerVirtualChannelOpen)(freerdp_peer* peer, const char* name, UINT32 flags);
 typedef BOOL (*psPeerVirtualChannelClose)(freerdp_peer* peer, HANDLE hChannel);

--- a/libfreerdp/core/channels.c
+++ b/libfreerdp/core/channels.c
@@ -124,7 +124,7 @@ BOOL freerdp_channel_send(rdpRdp* rdp, UINT16 channelId, const BYTE* data, size_
 
 BOOL freerdp_channel_process(freerdp* instance, wStream* s, UINT16 channelId, size_t packetLength)
 {
-	int rc = 0;
+	BOOL rc = FALSE;
 	UINT32 length;
 	UINT32 flags;
 	size_t chunkLength;
@@ -160,7 +160,7 @@ BOOL freerdp_channel_process(freerdp* instance, wStream* s, UINT16 channelId, si
 	}
 	IFCALLRET(instance->ReceiveChannelData, rc, instance, channelId, Stream_Pointer(s), chunkLength,
 	          flags, length);
-	if (rc != CHANNEL_RC_OK)
+	if (!rc)
 	{
 		WLog_WARN(TAG, "ReceiveChannelData returned %d", rc);
 		return FALSE;
@@ -213,9 +213,9 @@ BOOL freerdp_channel_peer_process(freerdp_peer* client, wStream* s, UINT16 chann
 	}
 	else if (client->ReceiveChannelData)
 	{
-		int rc = client->ReceiveChannelData(client, channelId, Stream_Pointer(s), chunkLength,
-		                                    flags, length);
-		if (rc < 0)
+		BOOL rc = client->ReceiveChannelData(client, channelId, Stream_Pointer(s), chunkLength,
+		                                     flags, length);
+		if (!rc)
 			return FALSE;
 	}
 	return Stream_SafeSeek(s, chunkLength);

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -488,18 +488,10 @@ int freerdp_message_queue_process_pending_messages(freerdp* instance, DWORD id)
 	return status;
 }
 
-static int freerdp_send_channel_data(freerdp* instance, UINT16 channelId, const BYTE* data,
-                                     int size)
+static BOOL freerdp_send_channel_data(freerdp* instance, UINT16 channelId, const BYTE* data,
+                                      size_t size)
 {
-	if (size < 0)
-	{
-		WLog_ERR(TAG, "%s: size has invalid value %d", __FUNCTION__, size);
-		return -1;
-	}
-
-	if (!rdp_send_channel_data(instance->context->rdp, channelId, data, (size_t)size))
-		return -2;
-	return 0;
+	return rdp_send_channel_data(instance->context->rdp, channelId, data, size);
 }
 
 BOOL freerdp_disconnect(freerdp* instance)
@@ -1008,7 +1000,7 @@ const char* freerdp_get_logon_error_info_data(UINT32 data)
 /** Allocator function for the rdp_freerdp structure.
  *  @return an allocated structure filled with 0s. Need to be deallocated using freerdp_free()
  */
-freerdp* freerdp_new()
+freerdp* freerdp_new(void)
 {
 	freerdp* instance;
 	instance = (freerdp*)calloc(1, sizeof(freerdp));

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -736,17 +736,10 @@ static void freerdp_peer_disconnect(freerdp_peer* client)
 	transport_disconnect(transport);
 }
 
-static int freerdp_peer_send_channel_data(freerdp_peer* client, UINT16 channelId, const BYTE* data,
-                                          int size)
+static BOOL freerdp_peer_send_channel_data(freerdp_peer* client, UINT16 channelId, const BYTE* data,
+                                           size_t size)
 {
-	if (size < 0)
-	{
-		WLog_ERR(TAG, "%s: invalid size %d", __FUNCTION__, size);
-		return -1;
-	}
-	if (!rdp_send_channel_data(client->context->rdp, channelId, data, (size_t)size))
-		return -1;
-	return 0;
+	return rdp_send_channel_data(client->context->rdp, channelId, data, size);
 }
 
 static BOOL freerdp_peer_is_write_blocked(freerdp_peer* peer)

--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -478,7 +478,6 @@ BOOL WTSVirtualChannelManagerCheckFileDescriptor(HANDLE hServer)
 
 	while (MessageQueue_Peek(vcm->queue, &message, TRUE))
 	{
-		int rc;
 		BYTE* buffer;
 		UINT32 length;
 		UINT16 channelId;
@@ -486,8 +485,7 @@ BOOL WTSVirtualChannelManagerCheckFileDescriptor(HANDLE hServer)
 		buffer = (BYTE*)message.wParam;
 		length = (UINT32)(UINT_PTR)message.lParam;
 
-		rc = vcm->client->SendChannelData(vcm->client, channelId, buffer, length);
-		if (rc < 0)
+		if (!vcm->client->SendChannelData(vcm->client, channelId, buffer, length))
 		{
 			status = FALSE;
 		}

--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -400,8 +400,8 @@ static BOOL WTSProcessChannelData(rdpPeerChannel* channel, UINT16 channelId, con
 	return ret;
 }
 
-static int WTSReceiveChannelData(freerdp_peer* client, UINT16 channelId, const BYTE* data,
-                                 size_t size, UINT32 flags, size_t totalSize)
+static BOOL WTSReceiveChannelData(freerdp_peer* client, UINT16 channelId, const BYTE* data,
+                                  size_t size, UINT32 flags, size_t totalSize)
 {
 	UINT32 i;
 	BOOL status = FALSE;
@@ -419,7 +419,7 @@ static int WTSReceiveChannelData(freerdp_peer* client, UINT16 channelId, const B
 		}
 	}
 
-	return status ? 0 : -1;
+	return status;
 }
 
 void WTSVirtualChannelManagerGetFileDescriptor(HANDLE hServer, void** fds, int* fds_count)

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -197,8 +197,8 @@ static BOOL pf_client_pre_connect(freerdp* instance)
 	return TRUE;
 }
 
-static BOOL pf_client_receive_channel_data_hook(freerdp* instance, UINT16 channelId, BYTE* data,
-                                                int size, int flags, int totalSize)
+static int pf_client_receive_channel_data_hook(freerdp* instance, UINT16 channelId, BYTE* data,
+                                               int size, int flags, int totalSize)
 {
 	pClientContext* pc = (pClientContext*)instance->context;
 	pServerContext* ps = pc->pdata->ps;
@@ -221,11 +221,13 @@ static BOOL pf_client_receive_channel_data_hook(freerdp* instance, UINT16 channe
 			ev.data_len = size;
 
 			if (!pf_modules_run_filter(FILTER_TYPE_CLIENT_PASSTHROUGH_CHANNEL_DATA, pdata, &ev))
-				return FALSE;
+				return -1;
 
 			server_channel_id = (UINT64)HashTable_GetItemValue(ps->vc_ids, (void*)channel_name);
-			return ps->context.peer->SendChannelData(ps->context.peer, (UINT16)server_channel_id,
-			                                         data, size);
+			if (!ps->context.peer->SendChannelData(ps->context.peer, (UINT16)server_channel_id,
+			                                       data, size))
+				return -1;
+			return 0;
 		}
 	}
 

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -197,8 +197,9 @@ static BOOL pf_client_pre_connect(freerdp* instance)
 	return TRUE;
 }
 
-static int pf_client_receive_channel_data_hook(freerdp* instance, UINT16 channelId, BYTE* data,
-                                               int size, int flags, int totalSize)
+static BOOL pf_client_receive_channel_data_hook(freerdp* instance, UINT16 channelId,
+                                                const BYTE* data, size_t size, UINT32 flags,
+                                                size_t totalSize)
 {
 	pClientContext* pc = (pClientContext*)instance->context;
 	pServerContext* ps = pc->pdata->ps;
@@ -221,13 +222,11 @@ static int pf_client_receive_channel_data_hook(freerdp* instance, UINT16 channel
 			ev.data_len = size;
 
 			if (!pf_modules_run_filter(FILTER_TYPE_CLIENT_PASSTHROUGH_CHANNEL_DATA, pdata, &ev))
-				return -1;
+				return FALSE;
 
 			server_channel_id = (UINT64)HashTable_GetItemValue(ps->vc_ids, (void*)channel_name);
-			if (!ps->context.peer->SendChannelData(ps->context.peer, (UINT16)server_channel_id,
-			                                       data, size))
-				return -1;
-			return 0;
+			return ps->context.peer->SendChannelData(ps->context.peer, (UINT16)server_channel_id,
+			                                         data, size);
 		}
 	}
 

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -226,8 +226,10 @@ static int pf_server_receive_channel_data_hook(freerdp_peer* peer, UINT16 channe
 
 			client_channel_id = (UINT64)HashTable_GetItemValue(pc->vc_ids, (void*)channel_name);
 
-			return pc->context.instance->SendChannelData(
-			    pc->context.instance, (UINT16)client_channel_id, (BYTE*)data, size);
+			if (!pc->context.instance->SendChannelData(
+			        pc->context.instance, (UINT16)client_channel_id, (BYTE*)data, size))
+				return -1;
+			return 0;
 		}
 	}
 

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -198,9 +198,9 @@ static BOOL pf_server_adjust_monitor_layout(freerdp_peer* peer)
 	return TRUE;
 }
 
-static int pf_server_receive_channel_data_hook(freerdp_peer* peer, UINT16 channelId,
-                                               const BYTE* data, size_t size, UINT32 flags,
-                                               size_t totalSize)
+static BOOL pf_server_receive_channel_data_hook(freerdp_peer* peer, UINT16 channelId,
+                                                const BYTE* data, size_t size, UINT32 flags,
+                                                size_t totalSize)
 {
 	pServerContext* ps = (pServerContext*)peer->context;
 	pClientContext* pc = ps->pdata->pc;
@@ -222,14 +222,12 @@ static int pf_server_receive_channel_data_hook(freerdp_peer* peer, UINT16 channe
 			ev.data_len = size;
 
 			if (!pf_modules_run_filter(FILTER_TYPE_SERVER_PASSTHROUGH_CHANNEL_DATA, pdata, &ev))
-				return -1;
+				return FALSE;
 
 			client_channel_id = (UINT64)HashTable_GetItemValue(pc->vc_ids, (void*)channel_name);
 
-			if (!pc->context.instance->SendChannelData(
-			        pc->context.instance, (UINT16)client_channel_id, (BYTE*)data, size))
-				return -1;
-			return 0;
+			return pc->context.instance->SendChannelData(pc->context.instance,
+			                                             (UINT16)client_channel_id, data, size);
 		}
 	}
 


### PR DESCRIPTION
* SendChannelData was defined with a return value of type int, but used as BOOL everywhere. Fix the definition to match use.
* Same for ReceiveChannelData
* Will create warnings in external projects, maybe break something.