### PR TITLE
Fix tpkt header length checks for encrypted packets

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -3862,7 +3862,7 @@ BOOL rdp_recv_get_active_header(rdpRdp* rdp, wStream* s, UINT16* pChannelId, UIN
 
 		if (securityFlags & SEC_ENCRYPT)
 		{
-			if (!rdp_decrypt(rdp, s, *length, securityFlags))
+			if (!rdp_decrypt(rdp, s, length, securityFlags))
 			{
 				WLog_ERR(TAG, "rdp_decrypt failed");
 				return FALSE;

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -991,7 +991,7 @@ BOOL rdp_client_connect_auto_detect(rdpRdp* rdp, wStream* s)
 
 				if (securityFlags & SEC_ENCRYPT)
 				{
-					if (!rdp_decrypt(rdp, s, length, securityFlags))
+					if (!rdp_decrypt(rdp, s, &length, securityFlags))
 					{
 						WLog_ERR(TAG, "rdp_decrypt failed");
 						return FALSE;

--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -991,7 +991,7 @@ BOOL rdp_recv_client_info(rdpRdp* rdp, wStream* s)
 
 		if (securityFlags & SEC_ENCRYPT)
 		{
-			if (!rdp_decrypt(rdp, s, length, securityFlags))
+			if (!rdp_decrypt(rdp, s, &length, securityFlags))
 			{
 				WLog_ERR(TAG, "rdp_decrypt failed");
 				return FALSE;

--- a/libfreerdp/core/license.c
+++ b/libfreerdp/core/license.c
@@ -467,7 +467,7 @@ int license_recv(rdpLicense* license, wStream* s)
 
 	if (securityFlags & SEC_ENCRYPT)
 	{
-		if (!rdp_decrypt(license->rdp, s, length, securityFlags))
+		if (!rdp_decrypt(license->rdp, s, &length, securityFlags))
 		{
 			WLog_ERR(TAG, "rdp_decrypt failed");
 			return -1;

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -371,7 +371,7 @@ static int peer_recv_tpkt_pdu(freerdp_peer* client, wStream* s)
 
 		if (securityFlags & SEC_ENCRYPT)
 		{
-			if (!rdp_decrypt(rdp, s, length, securityFlags))
+			if (!rdp_decrypt(rdp, s, &length, securityFlags))
 			{
 				WLog_ERR(TAG, "rdp_decrypt failed");
 				return -1;
@@ -446,7 +446,7 @@ static int peer_recv_fastpath_pdu(freerdp_peer* client, wStream* s)
 
 	if (fastpath->encryptionFlags & FASTPATH_OUTPUT_ENCRYPTED)
 	{
-		if (!rdp_decrypt(rdp, s, length,
+		if (!rdp_decrypt(rdp, s, &length,
 		                 (fastpath->encryptionFlags & FASTPATH_OUTPUT_SECURE_CHECKSUM)
 		                     ? SEC_SECURE_CHECKSUM
 		                     : 0))

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -233,7 +233,7 @@ extern const char* DATA_PDU_TYPE_STRINGS[80];
 	} while (0)
 #endif
 
-BOOL rdp_decrypt(rdpRdp* rdp, wStream* s, INT32 length, UINT16 securityFlags);
+BOOL rdp_decrypt(rdpRdp* rdp, wStream* s, UINT16* pLength, UINT16 securityFlags);
 
 BOOL rdp_set_error_info(rdpRdp* rdp, UINT32 errorInfo);
 BOOL rdp_send_error_info(rdpRdp* rdp);


### PR DESCRIPTION
If securityFlag SEC_ENCRYPT is set, remove the encryption headers from
the TPKT header length on comparison.