### PR TITLE
X11 selection improvements

### DIFF
--- a/client/X11/generate_argument_docbook.c
+++ b/client/X11/generate_argument_docbook.c
@@ -244,7 +244,8 @@ int main(int argc, char* argv[])
 			if (text)
 				fprintf(fp, "%s", text);
 
-			if (arg->Flags == COMMAND_LINE_VALUE_BOOL)
+			if (arg->Flags & COMMAND_LINE_VALUE_BOOL &&
+			    (!arg->Default || arg->Default == BoolValueTrue))
 				fprintf(fp, " (default:%s)", arg->Default ? "on" : "off");
 			else if (arg->Default)
 			{

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -68,6 +68,9 @@ struct xf_clipboard
 	Atom clipboard_atom;
 	Atom property_atom;
 
+	Atom timestamp_property_atom;
+	Time selection_ownership_timestamp;
+
 	Atom raw_transfer_atom;
 	Atom raw_format_list_atom;
 
@@ -111,6 +114,7 @@ struct xf_clipboard
 };
 
 static UINT xf_cliprdr_send_client_format_list(xfClipboard* clipboard);
+static void xf_cliprdr_set_selection_owner(xfContext* xfc, xfClipboard* clipboard, Time timestamp);
 
 static void xf_cliprdr_check_owner(xfClipboard* clipboard)
 {
@@ -758,6 +762,17 @@ static void xf_cliprdr_provide_targets(xfClipboard* clipboard, const XSelectionE
 	}
 }
 
+static void xf_cliprdr_provide_timestamp(xfClipboard* clipboard, const XSelectionEvent* respond)
+{
+	xfContext* xfc = clipboard->xfc;
+
+	if (respond->property != None)
+	{
+		XChangeProperty(xfc->display, respond->requestor, respond->property, XA_INTEGER, 32,
+		                PropModeReplace, (BYTE*)&clipboard->selection_ownership_timestamp, 1);
+	}
+}
+
 static void xf_cliprdr_provide_data(xfClipboard* clipboard, const XSelectionEvent* respond,
                                     const BYTE* data, UINT32 size)
 {
@@ -849,7 +864,9 @@ static BOOL xf_cliprdr_process_selection_request(xfClipboard* clipboard,
 
 	if (xevent->target == clipboard->targets[0]) /* TIMESTAMP */
 	{
-		/* TODO */
+		/* Someone else requests the selection's timestamp */
+		respond->property = xevent->property;
+		xf_cliprdr_provide_timestamp(clipboard, respond);
 	}
 	else if (xevent->target == clipboard->targets[1]) /* TARGETS */
 	{
@@ -963,6 +980,16 @@ static BOOL xf_cliprdr_process_property_notify(xfClipboard* clipboard, const XPr
 		return TRUE;
 
 	xfc = clipboard->xfc;
+
+	if (xevent->atom == clipboard->timestamp_property_atom)
+	{
+		/* This is the response to the property change we did
+		 * in xf_cliprdr_prepare_to_set_selection_owner. Now
+		 * we can set ourselves as the selection owner. (See
+		 * comments in those functions below.) */
+		xf_cliprdr_set_selection_owner(xfc, clipboard, xevent->time);
+		return TRUE;
+	}
 
 	if (xevent->atom != clipboard->property_atom)
 		return FALSE; /* Not cliprdr-related */
@@ -1187,6 +1214,43 @@ static UINT xf_cliprdr_server_capabilities(CliprdrClientContext* context,
 	return CHANNEL_RC_OK;
 }
 
+static void xf_cliprdr_prepare_to_set_selection_owner(xfContext* xfc, xfClipboard* clipboard)
+{
+	/*
+	 * When you're writing to the selection in response to a
+	 * normal X event like a mouse click or keyboard action, you
+	 * get the selection timestamp by copying the time field out
+	 * of that X event. Here, we're doing it on our own
+	 * initiative, so we have to _request_ the X server time.
+	 *
+	 * There isn't a GetServerTime request in the X protocol, so I
+	 * work around it by setting a property on our own window, and
+	 * waiting for a PropertyNotify event to come back telling me
+	 * it's been done - which will have a timestamp we can use.
+	 */
+
+	/* We have to set the property to some value, but it doesn't
+	 * matter what. Set it to its own name, which we have here
+	 * anyway! */
+	Atom value = clipboard->timestamp_property_atom;
+
+	XChangeProperty(xfc->display, xfc->drawable, clipboard->timestamp_property_atom, XA_ATOM, 32,
+	                PropModeReplace, (BYTE*)&value, 1);
+	XFlush(xfc->display);
+}
+
+static void xf_cliprdr_set_selection_owner(xfContext* xfc, xfClipboard* clipboard, Time timestamp)
+{
+	/*
+	 * Actually set ourselves up as the selection owner, now that
+	 * we have a timestamp to use.
+	 */
+
+	clipboard->selection_ownership_timestamp = timestamp;
+	XSetSelectionOwner(xfc->display, clipboard->clipboard_atom, xfc->drawable, timestamp);
+	XFlush(xfc->display);
+}
+
 /**
  * Function description
  *
@@ -1270,8 +1334,7 @@ static UINT xf_cliprdr_server_format_list(CliprdrClientContext* context,
 	}
 
 	ret = xf_cliprdr_send_client_format_list_response(clipboard, TRUE);
-	XSetSelectionOwner(xfc->display, clipboard->clipboard_atom, xfc->drawable, CurrentTime);
-	XFlush(xfc->display);
+	xf_cliprdr_prepare_to_set_selection_owner(xfc, clipboard);
 	return ret;
 }
 
@@ -1626,6 +1689,8 @@ xfClipboard* xf_clipboard_new(xfContext* xfc)
 		goto error;
 	}
 
+	clipboard->timestamp_property_atom =
+	    XInternAtom(xfc->display, "_FREERDP_TIMESTAMP_PROPERTY", FALSE);
 	clipboard->property_atom = XInternAtom(xfc->display, "_FREERDP_CLIPRDR", FALSE);
 	clipboard->raw_transfer_atom = XInternAtom(xfc->display, "_FREERDP_CLIPRDR_RAW", FALSE);
 	clipboard->raw_format_list_atom = XInternAtom(xfc->display, "_FREERDP_CLIPRDR_FORMATS", FALSE);

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -1667,6 +1667,7 @@ xfClipboard* xf_clipboard_new(xfContext* xfc)
 	int i, n = 0;
 	rdpChannels* channels;
 	xfClipboard* clipboard;
+	const char* selectionAtom;
 
 	if (!(clipboard = (xfClipboard*)calloc(1, sizeof(xfClipboard))))
 	{
@@ -1681,11 +1682,14 @@ xfClipboard* xf_clipboard_new(xfContext* xfc)
 	clipboard->system = ClipboardCreate();
 	clipboard->requestedFormatId = -1;
 	clipboard->root_window = DefaultRootWindow(xfc->display);
-	clipboard->clipboard_atom = XInternAtom(xfc->display, "CLIPBOARD", FALSE);
+	selectionAtom = "CLIPBOARD";
+	if (xfc->context.settings->XSelectionAtom)
+		selectionAtom = xfc->context.settings->XSelectionAtom;
+	clipboard->clipboard_atom = XInternAtom(xfc->display, selectionAtom, FALSE);
 
 	if (clipboard->clipboard_atom == None)
 	{
-		WLog_ERR(TAG, "unable to get CLIPBOARD atom");
+		WLog_ERR(TAG, "unable to get %s atom", selectionAtom);
 		goto error;
 	}
 

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2326,7 +2326,36 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 		}
 		CommandLineSwitchCase(arg, "clipboard")
 		{
-			settings->RedirectClipboard = enable;
+			if (arg->Value == BoolValueTrue || arg->Value == BoolValueFalse)
+			{
+				settings->RedirectClipboard = (arg->Value == BoolValueTrue);
+			}
+			else
+			{
+				int rc = 0;
+				char** p;
+				size_t count, x;
+				p = CommandLineParseCommaSeparatedValues(arg->Value, &count);
+				for (x = 0; (x < count) && (rc == 0); x++)
+				{
+					const char usesel[14] = "use-selection:";
+
+					const char* cur = p[x];
+					if (_strnicmp(usesel, cur, sizeof(usesel)) == 0)
+					{
+						const char* val = &cur[sizeof(usesel)];
+						if (!copy_value(val, &settings->XSelectionAtom))
+							rc = COMMAND_LINE_ERROR_MEMORY;
+						settings->RedirectClipboard = TRUE;
+					}
+					else
+						rc = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
+				}
+				free(p);
+
+				if (rc)
+					return rc;
+			}
 		}
 		CommandLineSwitchCase(arg, "shell")
 		{

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -102,8 +102,12 @@ static const COMMAND_LINE_ARGUMENT_A args[] = {
 	  "Client Build Number sent to server (influences smartcard behaviour, see [MS-RDPESC])" },
 	{ "client-hostname", COMMAND_LINE_VALUE_REQUIRED, "<name>", NULL, NULL, -1, NULL,
 	  "Client Hostname to send to server" },
-	{ "clipboard", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
-	  "Redirect clipboard" },
+	{ "clipboard", COMMAND_LINE_VALUE_BOOL | COMMAND_LINE_VALUE_OPTIONAL, "[use-selection:<atom>]",
+	  BoolValueTrue, NULL, -1, NULL,
+	  "Redirect clipboard.                       "
+	  " * use-selection:<atom>  ... (X11) Specify which X selection to access. Default is "
+	  "CLIPBOARD."
+	  " PRIMARY is the X-style middle-click selection." },
 	{ "codec-cache", COMMAND_LINE_VALUE_REQUIRED, "[rfx|nsc|jpeg]", NULL, NULL, -1, NULL,
 	  "Bitmap codec cache" },
 	{ "compression", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, "z", "compression" },

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -1559,6 +1559,7 @@ struct rdp_settings
 	                                   default value - currently UNUSED! */
 	ALIGN64 char* ActionScript;
 	ALIGN64 DWORD Floatbar;
+	ALIGN64 char* XSelectionAtom;
 };
 typedef struct rdp_settings rdpSettings;
 

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -610,6 +610,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	settings_load_hkey_local_machine(settings);
 
 	settings->ActionScript = _strdup("~/.config/freerdp/action.sh");
+	settings->XSelectionAtom = NULL;
 	settings->SmartcardLogon = FALSE;
 	settings->TlsSecLevel = 1;
 	settings->OrderSupport = calloc(1, 32);
@@ -656,6 +657,8 @@ static void freerdp_settings_free_internal(rdpSettings* settings)
 	/* Extensions */
 	free(settings->ActionScript);
 	settings->ActionScript = NULL;
+	free(settings->XSelectionAtom);
+	settings->XSelectionAtom = NULL;
 
 	/* Free all strings, set other pointers NULL */
 	freerdp_settings_free_keys(settings, TRUE);
@@ -983,6 +986,8 @@ static BOOL freerdp_settings_int_buffer_copy(rdpSettings* _settings, const rdpSe
 
 	if (settings->ActionScript)
 		_settings->ActionScript = _strdup(settings->ActionScript);
+	if (settings->XSelectionAtom)
+		_settings->XSelectionAtom = _strdup(settings->XSelectionAtom);
 	rc = TRUE;
 out_fail:
 	return rc;
@@ -1024,6 +1029,7 @@ BOOL freerdp_settings_copy(rdpSettings* _settings, const rdpSettings* settings)
 	_settings->StaticChannelArray = NULL;
 	_settings->DynamicChannelArray = NULL;
 	_settings->ActionScript = NULL;
+	_settings->XSelectionAtom = NULL;
 	if (!rc)
 		goto out_fail;
 

--- a/winpr/libwinpr/utils/cmdline.c
+++ b/winpr/libwinpr/utils/cmdline.c
@@ -312,7 +312,8 @@ int CommandLineParseArgumentsA(int argc, LPSTR* argv, COMMAND_LINE_ARGUMENT_A* o
 
 				if (value)
 				{
-					if (options[j].Flags & (COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_VALUE_BOOL))
+					if (!(options[j].Flags &
+					      (COMMAND_LINE_VALUE_OPTIONAL | COMMAND_LINE_VALUE_REQUIRED)))
 					{
 						log_error(flags, "Failed at index %d [%s]: Unexpected value", i, argv[i]);
 						return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;


### PR DESCRIPTION
Here's a collection of changes that all improve handling of X11 selections. They're more or less independent as patches, but they all contribute to the same overall goal, which is that if I run an `xfreerdp` side by side with an `xtightvncviewer` on the same X display, then I can transfer clipboard data from the FreeRDP to the VNC viewer quickly and easily without anything going wrong.