### PR TITLE
Fixed `update_write_surfcmd_surface_bits` to use `CMDTYPE_SET_SURFACE_BITS`

### DIFF
--- a/libfreerdp/core/surface.c
+++ b/libfreerdp/core/surface.c
@@ -226,7 +226,7 @@ BOOL update_write_surfcmd_surface_bits(wStream* s, const SURFACE_BITS_COMMAND* c
 	if (!Stream_EnsureRemainingCapacity(s, SURFCMD_SURFACE_BITS_HEADER_LENGTH))
 		return FALSE;
 
-	Stream_Write_UINT16(s, CMDTYPE_STREAM_SURFACE_BITS);
+	Stream_Write_UINT16(s, CMDTYPE_SET_SURFACE_BITS);
 	Stream_Write_UINT16(s, cmd->destLeft);
 	Stream_Write_UINT16(s, cmd->destTop);
 	Stream_Write_UINT16(s, cmd->destRight);


### PR DESCRIPTION
Although 2.2.9.2.1 Set Surface Bits Command (TS_SURFCMD_SET_SURF_BITS) and 2.2.9.2.2 Stream Surface Bits Command (TS_SURFCMD_STREAM_SURF_BITS) are almost the same and handled by the same codepath (https://github.com/FreeRDP/FreeRDP/blob/72ca88f49c1b7f6678a66c09fa5fe5506623ed35/libfreerdp/core/surface.c#L150) when mstsc connect to FreeRDP server (shadow) it doesn't update the screen using `CMDTYPE_STREAM_SURFACE_BITS` but it does using `CMDTYPE_SET_SURFACE_BITS`
