### PR TITLE
Add option to adjust the tcp ack timeout

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2434,6 +2434,13 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 		{
 			settings->DisableThemes = !enable;
 		}
+		CommandLineSwitchCase(arg, "timeout")
+		{
+			ULONGLONG val;
+			if (!value_to_uint(arg->Value, &val, 1, 600000))
+				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
+			settings->TcpAckTimeout = (UINT32)val;
+		}
 		CommandLineSwitchCase(arg, "aero")
 		{
 			settings->AllowDesktopComposition = enable;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -334,6 +334,9 @@ static const COMMAND_LINE_ARGUMENT_A args[] = {
 	  "SSH Agent forwarding channel" },
 	{ "t", COMMAND_LINE_VALUE_REQUIRED, "<title>", NULL, NULL, -1, "title", "Window title" },
 	{ "themes", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "themes" },
+	{ "timeout", COMMAND_LINE_VALUE_REQUIRED, "<time in ms>", "9000", NULL, -1, "timeout",
+	  "Advanced setting for high latency links: Adjust connection timeout, use if you encounter "
+	  "timeout failures with your connection" },
 	{ "tls-ciphers", COMMAND_LINE_VALUE_REQUIRED, "[netmon|ma|ciphers]", NULL, NULL, -1, NULL,
 	  "Allowed TLS ciphers" },
 	{ "tls-seclevel", COMMAND_LINE_VALUE_REQUIRED, "<level>", "1", NULL, -1, NULL,


### PR DESCRIPTION
On high latency links the default of 9 second timeout might be too
strict. Adjusting this for all users will result in a long time
for connections to fail, so let these with high latency links
adjust the value manually. @CeeMac-git this should address the problem you face.