### PR TITLE
Fix stable-1.1 build on Windows

### DIFF
--- a/winpr/include/winpr/nt.h
+++ b/winpr/include/winpr/nt.h
@@ -38,6 +38,9 @@
 #define STATUS_ACCOUNT_LOCKED_OUT					((NTSTATUS)0xC0000234L)
 #define STATUS_ACCOUNT_EXPIRED						((NTSTATUS)0xC0000193L)
 #define STATUS_LOGON_TYPE_NOT_GRANTED					((NTSTATUS)0xC000015BL)
+
+#else
+#include <wincred.h>
 #endif
 
 #endif /* WINPR_NT_H */

--- a/winpr/libwinpr/sspi/sspi.c
+++ b/winpr/libwinpr/sspi/sspi.c
@@ -1171,6 +1171,8 @@ SecurityFunctionTableW SSPI_SecurityFunctionTableW =
 	SetContextAttributes, /* SetContextAttributes */
 };
 
+#endif
+
 const char* GetSecurityStatusString(SECURITY_STATUS status)
 {
 	switch (status)
@@ -1430,5 +1432,3 @@ const char* GetSecurityStatusString(SECURITY_STATUS status)
 
 	return "SEC_E_UNKNOWN";
 }
-
-#endif


### PR DESCRIPTION
Two commits broke the build on Windows for stable-1.1:

https://github.com/freerdp/FreeRDP/commit/a99ec8cb6526ce6b3dd3caf723bbfc66b93e2108
https://github.com/freerdp/FreeRDP/commit/6b66f199e624b7203818fc55298e4695ed82ba84

The fixes are trivial.

Thanks!