### PR TITLE
Free clipboard respond to fix bug

### DIFF
--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -1413,6 +1413,8 @@ xf_cliprdr_server_format_data_response(CliprdrClientContext* context,
 		if (SrcSize == 0)
 		{
 			WLog_INFO(TAG, "skipping, empty data detected!!!");
+			free(clipboard->respond);
+			clipboard->respond = NULL;
 			return CHANNEL_RC_OK;
 		}
 


### PR DESCRIPTION
Fixes #5997 (clipboard stops responding in the middle of a session)

If you can reproduce the bug you will be able to reproduce the fix.