### PR TITLE
server: fix surface command types

### DIFF
--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -976,7 +976,7 @@ static BOOL shadow_client_send_surface_bits(rdpShadowClient* client, BYTE* pSrcD
 			return FALSE;
 		}
 
-		cmd.cmdType = CMDTYPE_SET_SURFACE_BITS;
+		cmd.cmdType = CMDTYPE_STREAM_SURFACE_BITS;
 		cmd.bmp.codecID = settings->RemoteFxCodecId;
 		cmd.destLeft = 0;
 		cmd.destTop = 0;

--- a/server/shadow/shadow_encoder.c
+++ b/server/shadow/shadow_encoder.c
@@ -24,6 +24,8 @@
 
 #include "shadow_encoder.h"
 
+#define TAG CLIENT_TAG("shadow")
+
 int shadow_encoder_preferred_fps(rdpShadowEncoder* encoder)
 {
 	/* Return preferred fps calculated according to the last
@@ -400,6 +402,7 @@ int shadow_encoder_prepare(rdpShadowEncoder* encoder, UINT32 codecs)
 
 	if ((codecs & FREERDP_CODEC_REMOTEFX) && !(encoder->codecs & FREERDP_CODEC_REMOTEFX))
 	{
+		WLog_DBG(TAG, "initializing RemoteFX encoder");
 		status = shadow_encoder_init_rfx(encoder);
 
 		if (status < 0)
@@ -408,6 +411,7 @@ int shadow_encoder_prepare(rdpShadowEncoder* encoder, UINT32 codecs)
 
 	if ((codecs & FREERDP_CODEC_NSCODEC) && !(encoder->codecs & FREERDP_CODEC_NSCODEC))
 	{
+		WLog_DBG(TAG, "initializing NSCodec encoder");
 		status = shadow_encoder_init_nsc(encoder);
 
 		if (status < 0)
@@ -416,6 +420,7 @@ int shadow_encoder_prepare(rdpShadowEncoder* encoder, UINT32 codecs)
 
 	if ((codecs & FREERDP_CODEC_PLANAR) && !(encoder->codecs & FREERDP_CODEC_PLANAR))
 	{
+		WLog_DBG(TAG, "initializing planar bitmap encoder");
 		status = shadow_encoder_init_planar(encoder);
 
 		if (status < 0)
@@ -424,6 +429,7 @@ int shadow_encoder_prepare(rdpShadowEncoder* encoder, UINT32 codecs)
 
 	if ((codecs & FREERDP_CODEC_INTERLEAVED) && !(encoder->codecs & FREERDP_CODEC_INTERLEAVED))
 	{
+		WLog_DBG(TAG, "initializing interleaved bitmap encoder");
 		status = shadow_encoder_init_interleaved(encoder);
 
 		if (status < 0)
@@ -433,6 +439,7 @@ int shadow_encoder_prepare(rdpShadowEncoder* encoder, UINT32 codecs)
 	if ((codecs & (FREERDP_CODEC_AVC420 | FREERDP_CODEC_AVC444)) &&
 	    !(encoder->codecs & (FREERDP_CODEC_AVC420 | FREERDP_CODEC_AVC444)))
 	{
+		WLog_DBG(TAG, "initializing H.264 encoder");
 		status = shadow_encoder_init_h264(encoder);
 
 		if (status < 0)


### PR DESCRIPTION
- Legacy RemoteFX is encapsulated in a "Stream Surface Bits Command" (CMDTYPE_STREAM_SURFACE_BITS)
- NSCodec is encapsulated in a "Set Surface Bits Command" (CMDTYPE_SET_SURFACE_BITS)

References:
- [MS-RDPRFX 3.1.8.3.1 RemoteFX Stream / Encode Message Sequencing](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdprfx/028ed301-385c-4b17-84ec-0a158a22c1b2)
- [MS-RDPNSC 2.2.2 NSCodec Compressed Bitmap Stream](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpnsc/412416a7-6721-440d-ac4b-1d1311c85cb5)
