### PR TITLE
Possible fix for double attach pointer problems

### DIFF
--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -122,10 +122,13 @@ static UwacReturnCode set_cursor_image(UwacSeat* seat, uint32_t serial)
 			break;
 	}
 
+	int buffer_add_listener_success = -1;
 	if (buffer)
-		wl_buffer_add_listener(buffer, &buffer_release_listener, seat);
+	{
+		buffer_add_listener_success = wl_buffer_add_listener(buffer, &buffer_release_listener, seat);
+	}
 
-	if (surface)
+	if (surface && buffer_add_listener_success > -1)
 	{
 		wl_surface_attach(surface, buffer, -x, -y);
 		wl_surface_damage(surface, 0, 0, image->width, image->height);

--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -125,7 +125,8 @@ static UwacReturnCode set_cursor_image(UwacSeat* seat, uint32_t serial)
 
 	if (buffer)
 	{
-		buffer_add_listener_success = wl_buffer_add_listener(buffer, &buffer_release_listener, seat);
+		buffer_add_listener_success =
+		    wl_buffer_add_listener(buffer, &buffer_release_listener, seat);
 	}
 
 	if (surface && buffer_add_listener_success > -1)

--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -89,6 +89,7 @@ static UwacReturnCode set_cursor_image(UwacSeat* seat, uint32_t serial)
 	struct wl_cursor_image* image;
 	struct wl_surface* surface = NULL;
 	int32_t x = 0, y = 0;
+	int buffer_add_listener_success = -1;
 
 	if (!seat || !seat->display || !seat->default_cursor || !seat->default_cursor->images)
 		return UWAC_ERROR_INTERNAL;
@@ -122,7 +123,6 @@ static UwacReturnCode set_cursor_image(UwacSeat* seat, uint32_t serial)
 			break;
 	}
 
-	int buffer_add_listener_success = -1;
 	if (buffer)
 	{
 		buffer_add_listener_success = wl_buffer_add_listener(buffer, &buffer_release_listener, seat);


### PR DESCRIPTION
Fast touch movement on different surfaces can run into a
proxy 0x8129fc0 already has listener
wl_display@1: error 1: invalid arguments for wl_surface@10.attach

This pr checks if already a listener is registered to a buffer, to prevent a double attach. This only happens with pointer_type 0. 

I don't know exactly why this happen and where is the problem exactly, but with this patch my session don't get broken anymore.

See more in #6018 
