### PR TITLE
Allow /size to work with /multimon

### DIFF
--- a/client/X11/xf_monitor.c
+++ b/client/X11/xf_monitor.c
@@ -367,12 +367,22 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pMaxWidth, UINT32* pMaxHeight)
 			if (!vscreen->monitors)
 				return FALSE;
 
-			settings->MonitorDefArray[nmonitors].x = vscreen->monitors[i].area.left;
-			settings->MonitorDefArray[nmonitors].y = vscreen->monitors[i].area.top;
+			settings->MonitorDefArray[nmonitors].x =
+			    (vscreen->monitors[i].area.left *
+			     (settings->PercentScreenUseWidth ? settings->PercentScreen : 100)) /
+			    100;
+			settings->MonitorDefArray[nmonitors].y =
+			    (vscreen->monitors[i].area.top *
+			     (settings->PercentScreenUseHeight ? settings->PercentScreen : 100)) /
+			    100;
 			settings->MonitorDefArray[nmonitors].width =
-			    vscreen->monitors[i].area.right - vscreen->monitors[i].area.left + 1;
+			    ((vscreen->monitors[i].area.right - vscreen->monitors[i].area.left + 1) *
+			     (settings->PercentScreenUseWidth ? settings->PercentScreen : 100)) /
+			    100;
 			settings->MonitorDefArray[nmonitors].height =
-			    vscreen->monitors[i].area.bottom - vscreen->monitors[i].area.top + 1;
+			    ((vscreen->monitors[i].area.bottom - vscreen->monitors[i].area.top + 1) *
+			     (settings->PercentScreenUseWidth ? settings->PercentScreen : 100)) /
+			    100;
 			settings->MonitorDefArray[nmonitors].orig_screen = i;
 #ifdef USABLE_XRANDR
 
@@ -461,10 +471,12 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pMaxWidth, UINT32* pMaxHeight)
 			if (vB != destB)
 				xfc->fullscreenMonitors.bottom = settings->MonitorDefArray[i].orig_screen;
 
-			vX = destX;
-			vY = destY;
-			vR = destR;
-			vB = destB;
+			vX = destX / ((settings->PercentScreenUseWidth ? settings->PercentScreen : 100) / 100.);
+			vY =
+			    destY / ((settings->PercentScreenUseHeight ? settings->PercentScreen : 100) / 100.);
+			vR = destR / ((settings->PercentScreenUseWidth ? settings->PercentScreen : 100) / 100.);
+			vB =
+			    destB / ((settings->PercentScreenUseHeight ? settings->PercentScreen : 100) / 100.);
 		}
 
 		vscreen->area.left = 0;


### PR DESCRIPTION
Factor percent scaling from the /size parameter into the resolution that's reported to the RDP server.
Together with /smart-sizing this allows multi monitor connections at non-native resolutions.

run with /multimon /smart-sizing /size:xx%wh

Outstanding issues. (These don't bother me, and I may or may not fix them)
- Cursor is the wrong size when showing drag handles and other alternate shapes
- /multimon /size should probably imply /smart-sizing since it already implies /fullscreen