### PR TITLE
Always copy null terminator when filtering smartcard list

### DIFF
--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -456,12 +456,16 @@ static DWORD filter_device_by_name_a(wLinkedList* list, LPSTR* mszReaders, DWORD
 		LPCSTR rreader = &(*mszReaders)[rpos];
 		LPSTR wreader = &(*mszReaders)[wpos];
 		size_t readerLen = strnlen(rreader, cchReaders - rpos);
+
+		if (readerLen == 0)
+			break;
+
 		rpos += readerLen + 1;
 
 		if (filter_match(list, rreader, readerLen))
 		{
 			if (rreader != wreader)
-				memmove(wreader, rreader, readerLen);
+				memmove(wreader, rreader, readerLen + 1);
 
 			wpos += readerLen + 1;
 		}


### PR DESCRIPTION
The list of smartcard readers is supposed to end up with a NUL at the end of each entry and then a final NUL (so the end bytes should be 0x00 0x00). When the current logic in `filter_device_by_name_a` filters out some of the smartcard readers, it doesn't copy the NUL byte at the end of each entry (just the extra one at the end of the whole list).

If it's eliding one device and then allowing the subsequent one, and that first device's name is longer than the second one, you can end up with a byte of the original entry's name instead of the NUL terminator. This unfortunately results in an overall msz which only ends with a single NUL, leading the server to bail out and ignore all smartcards.

Repro: run on a system with three smartcard devices with names of unequal lengths, e.g. in order "ABCD", "AB" and "XYZ". Give option `/smartcard:XY` to `xfreerdp`, and then it will send `XYZD\0` to the server as `mszReaders` in reply to a list readers request (when it should be sending `XYZ\0\0`, the `D` is coming from `ABCD`). Smartcard redir will not work as a result.