### PR TITLE
src/libuwac/uwac-os.c: fix build with uclibc

### DIFF
--- a/uwac/libuwac/uwac-os.c
+++ b/uwac/libuwac/uwac-os.c
@@ -33,6 +33,11 @@
 #define USE_SHM
 #endif
 
+/* uClibc and uClibc-ng don't provide O_TMPFILE */
+#ifndef O_TMPFILE
+#define O_TMPFILE (020000000 | O_DIRECTORY)
+#endif
+
 #include <sys/types.h>
 #include <sys/socket.h>
 #ifdef USE_SHM


### PR DESCRIPTION
`O_TMPFILE` is used since version 2.0.0 and FreeRDP@52ef807

However, this will result in the following build failure on uclibc or uclibc-ng:

```
/home/fabrice/buildroot/output/build/freerdp-2.0.0/uwac/libuwac/uwac-os.c:228:18: error: ‘O_TMPFILE’ undeclared (first use in this function); did you mean ‘EMFILE’?
  fd = open(path, O_TMPFILE | O_RDWR | O_EXCL, 0600);
                  ^~~~~~~~~
                  EMFILE
```

To fix this build failure, define `O_TMPFILE` if needed

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>