### PR TITLE
shadow_server: allow specifying IP addresses to listen on

### DIFF
--- a/include/freerdp/server/shadow.h
+++ b/include/freerdp/server/shadow.h
@@ -144,6 +144,7 @@ struct rdp_shadow_server
 	UINT32 h264QP;
 
 	char* ipcSocket;
+	char* bindAddress;
 	char* ConfigPath;
 	char* CertificateFile;
 	char* PrivateKeyFile;

--- a/include/freerdp/server/shadow.h
+++ b/include/freerdp/server/shadow.h
@@ -144,7 +144,6 @@ struct rdp_shadow_server
 	UINT32 h264QP;
 
 	char* ipcSocket;
-	char* bindAddress;
 	char* ConfigPath;
 	char* CertificateFile;
 	char* PrivateKeyFile;

--- a/libfreerdp/core/listener.c
+++ b/libfreerdp/core/listener.c
@@ -138,7 +138,7 @@ static BOOL freerdp_listener_open(freerdp_listener* instance, const char* bind_a
 		WSAEventSelect(sockfd, listener->events[listener->num_sockfds],
 		               FD_READ | FD_ACCEPT | FD_CLOSE);
 		listener->num_sockfds++;
-		WLog_INFO(TAG, "Listening on %s:%d", addr, port);
+		WLog_INFO(TAG, "Listening on [%s]:%d", addr, port);
 	}
 
 	freeaddrinfo(res);

--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -128,6 +128,7 @@ static INLINE void shadow_client_free_queued_message(void* obj)
 
 static BOOL shadow_client_context_new(freerdp_peer* peer, rdpShadowClient* client)
 {
+	const char bind_address[] = "bind-address,";
 	rdpSettings* settings;
 	rdpShadowServer* server;
 	const wObject cb = { NULL, NULL, NULL, shadow_client_free_queued_message, NULL };
@@ -157,7 +158,8 @@ static BOOL shadow_client_context_new(freerdp_peer* peer, rdpShadowClient* clien
 	if (!(settings->RdpKeyFile = _strdup(settings->PrivateKeyFile)))
 		goto fail_rdpkey_file;
 
-	if (server->ipcSocket)
+	if (server->ipcSocket && (strncmp(bind_address, server->ipcSocket,
+	                                  strnlen(bind_address, sizeof(bind_address))) != 0))
 	{
 		settings->LyncRdpMode = TRUE;
 		settings->CompressionEnabled = FALSE;

--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -225,6 +225,10 @@ int shadow_server_parse_command_line(rdpShadowServer* server, int argc, char** a
 		}
 		CommandLineSwitchCase(arg, "ipc-socket")
 		{
+			/* /bind-address is incompatible */
+			if (server->ipcSocket)
+				return -1;
+
 			server->ipcSocket = _strdup(arg->Value);
 
 			if (!server->ipcSocket)
@@ -234,6 +238,9 @@ int shadow_server_parse_command_line(rdpShadowServer* server, int argc, char** a
 		{
 			int rc;
 			size_t len = strlen(arg->Value) + sizeof(bind_address);
+			/* /ipc-socket is incompatible */
+			if (server->ipcSocket)
+				return -1;
 			server->ipcSocket = calloc(len, sizeof(CHAR));
 
 			if (!server->ipcSocket)


### PR DESCRIPTION
To test, run one of the shadow servers:
 - With no extra arguments — behaviour should be same as before
 - With `/ipc-socket:some-socket` option — behaviour should be same as before
 - With `/listen-address:127.0.0.1` — should listen only on IPv4 localhost
 - With `/listen-address:[::]` — should listen on all IPv6 addresses
 - With `/listen-address:0.0.0.0 /ipc-socket:some-socket` — aborts for incompatible arguments
