### PR TITLE
Made xf_OutputExpose non blocking.

### DIFF
--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -176,8 +176,11 @@ UINT xf_OutputExpose(xfContext* xfc, UINT32 x, UINT32 y, UINT32 width, UINT32 he
 	if (status != CHANNEL_RC_OK)
 		goto fail;
 
-	EnterCriticalSection(&context->mux);
-
+	if (!TryEnterCriticalSection(&context->mux))
+	{
+		free(pSurfaceIds);
+		return CHANNEL_RC_OK;
+	}
 	for (index = 0; index < count; index++)
 	{
 		surface = (xfGfxSurface*)context->GetSurfaceData(context, pSurfaceIds[index]);


### PR DESCRIPTION
In case xf_OutputExpose is called with GFX or async-update a race
condition occured in combination with dynamic-resolution.
To prevent the deadlock update the screen on a best effort basis.