### PR TITLE
Optimize function xcrush_copy_bytes()

### DIFF
--- a/libfreerdp/codec/xcrush.c
+++ b/libfreerdp/codec/xcrush.c
@@ -732,13 +732,27 @@ static int xcrush_generate_output(XCRUSH_CONTEXT* xcrush, BYTE* OutputBuffer, UI
 	return 1;
 }
 
-static size_t xcrush_copy_bytes(BYTE* dst, const BYTE* src, size_t num)
+static INLINE size_t xcrush_copy_bytes(BYTE* dst, const BYTE* src, size_t num)
 {
-	size_t index;
-
-	for (index = 0; index < num; index++)
+	size_t diff, rest, end, a;
+	if (src + num < dst || src > dst + num)
 	{
-		dst[index] = src[index];
+		memcpy(dst, src, num);
+	}
+	else
+	{
+		// src and dst overlaps
+		// we should copy the area that doesn't overlap repeatly
+		diff = (dst > src) ? dst - src : src - dst;
+		rest = num % diff;
+		end = num - rest;
+		for (a = 0; a < end; a += diff)
+		{
+			memcpy(&dst[a], &src[a], diff);
+		}
+
+		if (rest != 0)
+			memcpy(&dst[end], &src[end], rest);
 	}
 
 	return num;


### PR DESCRIPTION
Use memcpy to copy the bytes when we can assure that the memory areas does not overlap.
With this change, the copy is ~30x faster.