### PR TITLE
Mark unused functions to avoid compiler warnings

### DIFF
--- a/channels/rdpei/client/rdpei_main.c
+++ b/channels/rdpei/client/rdpei_main.c
@@ -233,7 +233,7 @@ static UINT rdpei_send_cs_ready_pdu(RDPEI_CHANNEL_CALLBACK* callback)
 	return status;
 }
 
-static void rdpei_print_contact_flags(UINT32 contactFlags)
+__attribute__((unused)) static void rdpei_print_contact_flags(UINT32 contactFlags)
 {
 	if (contactFlags & CONTACT_FLAG_DOWN)
 		WLog_DBG(TAG, " CONTACT_FLAG_DOWN");

--- a/client/Wayland/wlf_disp.c
+++ b/client/Wayland/wlf_disp.c
@@ -258,7 +258,7 @@ void wlf_disp_free(wlfDispContext* disp)
 	free(disp);
 }
 
-UINT wlf_disp_sendLayout(DispClientContext* disp, rdpMonitor* monitors, size_t nmonitors)
+__attribute__((unused)) UINT wlf_disp_sendLayout(DispClientContext* disp, rdpMonitor* monitors, size_t nmonitors)
 {
 	UINT ret = CHANNEL_RC_OK;
 	DISPLAY_CONTROL_MONITOR_LAYOUT* layouts;

--- a/libfreerdp/cache/nine_grid.c
+++ b/libfreerdp/cache/nine_grid.c
@@ -84,7 +84,7 @@ void nine_grid_cache_register_callbacks(rdpUpdate* update)
 	update->primary->MultiDrawNineGrid = update_gdi_multi_draw_nine_grid;
 }
 
-void* nine_grid_cache_get(rdpNineGridCache* nine_grid, UINT32 index)
+__attribute__((unused)) void* nine_grid_cache_get(rdpNineGridCache* nine_grid, UINT32 index)
 {
 	void* entry;
 
@@ -105,7 +105,7 @@ void* nine_grid_cache_get(rdpNineGridCache* nine_grid, UINT32 index)
 	return entry;
 }
 
-void nine_grid_cache_put(rdpNineGridCache* nine_grid, UINT32 index, void* entry)
+__attribute__((unused)) void nine_grid_cache_put(rdpNineGridCache* nine_grid, UINT32 index, void* entry)
 {
 	if (index >= nine_grid->maxEntries)
 	{

--- a/libfreerdp/cache/palette.c
+++ b/libfreerdp/cache/palette.c
@@ -51,7 +51,7 @@ static BOOL update_gdi_cache_color_table(rdpContext* context,
 	return TRUE;
 }
 
-void* palette_cache_get(rdpPaletteCache* paletteCache, UINT32 index)
+__attribute__((unused)) void* palette_cache_get(rdpPaletteCache* paletteCache, UINT32 index)
 {
 	void* entry;
 

--- a/libfreerdp/codec/audio.c
+++ b/libfreerdp/codec/audio.c
@@ -254,7 +254,7 @@ BOOL audio_format_compatible(const AUDIO_FORMAT* with, const AUDIO_FORMAT* what)
 	return TRUE;
 }
 
-static BOOL audio_format_valid(const AUDIO_FORMAT* format)
+__attribute__((unused)) static BOOL audio_format_valid(const AUDIO_FORMAT* format)
 {
 	if (!format)
 		return FALSE;

--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -716,8 +716,8 @@ BOOL freerdp_image_scale(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT3
                          UINT32 nSrcWidth, UINT32 nSrcHeight)
 {
 	BOOL rc = FALSE;
-	const BYTE* src = &pSrcData[nXSrc * GetBytesPerPixel(SrcFormat) + nYSrc * nSrcStep];
-	BYTE* dst = &pDstData[nXDst * GetBytesPerPixel(DstFormat) + nYDst * nDstStep];
+	__attribute__((unused)) const BYTE* src = &pSrcData[nXSrc * GetBytesPerPixel(SrcFormat) + nYSrc * nSrcStep];
+	__attribute__((unused)) BYTE* dst = &pDstData[nXDst * GetBytesPerPixel(DstFormat) + nYDst * nDstStep];
 
 	/* direct copy is much faster than scaling, so check if we can simply copy... */
 	if ((nDstWidth == nSrcWidth) && (nDstHeight == nSrcHeight))

--- a/libfreerdp/codec/nsc_encode.c
+++ b/libfreerdp/codec/nsc_encode.c
@@ -418,7 +418,7 @@ static void nsc_rle_compress_data(NSC_CONTEXT* context)
 	}
 }
 
-static UINT32 nsc_compute_byte_count(NSC_CONTEXT* context, UINT32* ByteCount, UINT32 width,
+__attribute__((unused)) static UINT32 nsc_compute_byte_count(NSC_CONTEXT* context, UINT32* ByteCount, UINT32 width,
                                      UINT32 height)
 {
 	UINT32 tempWidth;

--- a/libfreerdp/core/activation.c
+++ b/libfreerdp/core/activation.c
@@ -159,7 +159,7 @@ BOOL rdp_send_client_control_pdu(rdpRdp* rdp, UINT16 action)
 	return rdp_send_data_pdu(rdp, s, DATA_PDU_TYPE_CONTROL, rdp->mcs->userId);
 }
 
-static void rdp_write_persistent_list_entry(wStream* s, UINT32 key1, UINT32 key2)
+__attribute__((unused)) static void rdp_write_persistent_list_entry(wStream* s, UINT32 key1, UINT32 key2)
 {
 	Stream_Write_UINT32(s, key1); /* key1 (4 bytes) */
 	Stream_Write_UINT32(s, key2); /* key2 (4 bytes) */

--- a/libfreerdp/core/autodetect.c
+++ b/libfreerdp/core/autodetect.c
@@ -316,7 +316,7 @@ static BOOL autodetect_send_netchar_result(rdpContext* context, UINT16 sequenceN
 	return rdp_send_message_channel_pdu(context->rdp, s, SEC_AUTODETECT_REQ);
 }
 
-static BOOL autodetect_send_netchar_sync(rdpRdp* rdp, UINT16 sequenceNumber)
+__attribute__((unused)) static BOOL autodetect_send_netchar_sync(rdpRdp* rdp, UINT16 sequenceNumber)
 {
 	wStream* s;
 	/* Send the response PDU to the server */

--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -2148,7 +2148,7 @@ static BOOL rdp_read_draw_gdiplus_cache_capability_set(wStream* s, rdpSettings* 
  * @param settings settings
  */
 
-static BOOL rdp_write_draw_gdiplus_cache_capability_set(wStream* s, const rdpSettings* settings)
+__attribute__((unused)) static BOOL rdp_write_draw_gdiplus_cache_capability_set(wStream* s, const rdpSettings* settings)
 {
 	size_t header;
 	UINT32 drawGDIPlusSupportLevel;
@@ -3056,7 +3056,7 @@ static BOOL rdp_write_rfx_server_capability_container(wStream* s, const rdpSetti
 	return TRUE;
 }
 
-static BOOL rdp_write_jpeg_server_capability_container(wStream* s, const rdpSettings* settings)
+__attribute__((unused)) static BOOL rdp_write_jpeg_server_capability_container(wStream* s, const rdpSettings* settings)
 {
 	WINPR_UNUSED(settings);
 	if (!Stream_EnsureRemainingCapacity(s, 8))

--- a/libfreerdp/core/gateway/rts.c
+++ b/libfreerdp/core/gateway/rts.c
@@ -143,7 +143,7 @@ static int rts_connection_timeout_command_read(rdpRpc* rpc, BYTE* buffer, UINT32
 	return 4;
 }
 
-static int rts_connection_timeout_command_write(BYTE* buffer, UINT32 ConnectionTimeout)
+__attribute__((unused)) static int rts_connection_timeout_command_write(BYTE* buffer, UINT32 ConnectionTimeout)
 {
 	if (buffer)
 	{
@@ -154,7 +154,7 @@ static int rts_connection_timeout_command_write(BYTE* buffer, UINT32 ConnectionT
 	return 8;
 }
 
-static int rts_cookie_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
+__attribute__((unused)) static int rts_cookie_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
 {
 	/* Cookie (16 bytes) */
 	return 16;
@@ -171,7 +171,7 @@ static int rts_cookie_command_write(BYTE* buffer, BYTE* Cookie)
 	return 20;
 }
 
-static int rts_channel_lifetime_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
+__attribute__((unused)) static int rts_channel_lifetime_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
 {
 	/* ChannelLifetime (4 bytes) */
 	return 4;
@@ -188,7 +188,7 @@ static int rts_channel_lifetime_command_write(BYTE* buffer, UINT32 ChannelLifeti
 	return 8;
 }
 
-static int rts_client_keepalive_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
+__attribute__((unused)) static int rts_client_keepalive_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
 {
 	/* ClientKeepalive (4 bytes) */
 	return 4;
@@ -227,7 +227,7 @@ static int rts_version_command_write(BYTE* buffer)
 	return 8;
 }
 
-static int rts_empty_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
+__attribute__((unused)) static int rts_empty_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
 {
 	return 0;
 }
@@ -250,7 +250,7 @@ static SSIZE_T rts_padding_command_read(const BYTE* buffer, size_t length)
 	return ConformanceCount + 4;
 }
 
-static int rts_padding_command_write(BYTE* buffer, UINT32 ConformanceCount)
+__attribute__((unused)) static int rts_padding_command_write(BYTE* buffer, UINT32 ConformanceCount)
 {
 	if (buffer)
 	{
@@ -262,12 +262,12 @@ static int rts_padding_command_write(BYTE* buffer, UINT32 ConformanceCount)
 	return 8 + ConformanceCount;
 }
 
-static int rts_negative_ance_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
+__attribute__((unused)) static int rts_negative_ance_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
 {
 	return 0;
 }
 
-static int rts_negative_ance_command_write(BYTE* buffer)
+__attribute__((unused)) static int rts_negative_ance_command_write(BYTE* buffer)
 {
 	if (buffer)
 	{
@@ -277,12 +277,12 @@ static int rts_negative_ance_command_write(BYTE* buffer)
 	return 4;
 }
 
-static int rts_ance_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
+__attribute__((unused)) static int rts_ance_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
 {
 	return 0;
 }
 
-static int rts_ance_command_write(BYTE* buffer)
+__attribute__((unused)) static int rts_ance_command_write(BYTE* buffer)
 {
 	if (buffer)
 	{
@@ -311,7 +311,7 @@ static SSIZE_T rts_client_address_command_read(const BYTE* buffer, size_t length
 	}
 }
 
-static int rts_client_address_command_write(BYTE* buffer, UINT32 AddressType, BYTE* ClientAddress)
+__attribute__((unused)) static int rts_client_address_command_write(BYTE* buffer, UINT32 AddressType, BYTE* ClientAddress)
 {
 	if (buffer)
 	{
@@ -341,7 +341,7 @@ static int rts_client_address_command_write(BYTE* buffer, UINT32 AddressType, BY
 	}
 }
 
-static int rts_association_group_id_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
+__attribute__((unused)) static int rts_association_group_id_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
 {
 	/* AssociationGroupId (16 bytes) */
 	return 16;
@@ -378,13 +378,13 @@ static int rts_destination_command_write(BYTE* buffer, UINT32 Destination)
 	return 8;
 }
 
-static int rts_ping_traffic_sent_notify_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
+__attribute__((unused)) static int rts_ping_traffic_sent_notify_command_read(rdpRpc* rpc, BYTE* buffer, UINT32 length)
 {
 	/* PingTrafficSent (4 bytes) */
 	return 4;
 }
 
-static int rts_ping_traffic_sent_notify_command_write(BYTE* buffer, UINT32 PingTrafficSent)
+__attribute__((unused)) static int rts_ping_traffic_sent_notify_command_write(BYTE* buffer, UINT32 PingTrafficSent)
 {
 	if (buffer)
 	{
@@ -515,7 +515,7 @@ int rts_recv_CONN_C2_pdu(rdpRpc* rpc, BYTE* buffer, UINT32 length)
 
 /* Out-of-Sequence PDUs */
 
-static int rts_send_keep_alive_pdu(rdpRpc* rpc)
+__attribute__((unused)) static int rts_send_keep_alive_pdu(rdpRpc* rpc)
 {
 	int status;
 	BYTE* buffer;

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -2014,7 +2014,7 @@ BOOL gcc_read_server_multitransport_channel_data(wStream* s, rdpMcs* mcs)
 	return TRUE;
 }
 
-void gcc_write_server_multitransport_channel_data(wStream* s, rdpMcs* mcs)
+__attribute__((unused)) void gcc_write_server_multitransport_channel_data(wStream* s, rdpMcs* mcs)
 {
 	UINT32 flags = 0;
 	gcc_write_user_data_header(s, SC_MULTITRANSPORT, 8);

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -216,7 +216,7 @@ void nla_identity_free(SEC_WINNT_AUTH_IDENTITY* identity)
  * @param credssp
  */
 
-static BOOL is_empty(const char* str)
+__attribute__((unused)) static BOOL is_empty(const char* str)
 {
 	if (!str)
 		return TRUE;

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -100,7 +100,7 @@ typedef struct _WINPR_BIO_SIMPLE_SOCKET WINPR_BIO_SIMPLE_SOCKET;
 static int transport_bio_simple_init(BIO* bio, SOCKET socket, int shutdown);
 static int transport_bio_simple_uninit(BIO* bio);
 
-static long transport_bio_simple_callback(BIO* bio, int mode, const char* argp, int argi, long argl,
+__attribute__((unused)) static long transport_bio_simple_callback(BIO* bio, int mode, const char* argp, int argi, long argl,
                                           long ret)
 {
 	return 1;
@@ -459,7 +459,7 @@ struct _WINPR_BIO_BUFFERED_SOCKET
 };
 typedef struct _WINPR_BIO_BUFFERED_SOCKET WINPR_BIO_BUFFERED_SOCKET;
 
-static long transport_bio_buffered_callback(BIO* bio, int mode, const char* argp, int argi,
+__attribute__((unused)) static long transport_bio_buffered_callback(BIO* bio, int mode, const char* argp, int argi,
                                             long argl, long ret)
 {
 	return 1;

--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -193,7 +193,7 @@ int crypto_rsa_private_decrypt(const BYTE* input, int length, UINT32 key_length,
 	return crypto_rsa_private(input, length, key_length, modulus, private_exponent, output);
 }
 
-static int crypto_rsa_decrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus,
+__attribute__((unused)) static int crypto_rsa_decrypt(const BYTE* input, int length, UINT32 key_length, const BYTE* modulus,
                               const BYTE* private_exponent, BYTE* output)
 {
 	return crypto_rsa_common(input, length, key_length, modulus, private_exponent, key_length,

--- a/libfreerdp/crypto/per.c
+++ b/libfreerdp/crypto/per.c
@@ -373,7 +373,7 @@ void per_write_object_identifier(wStream* s, BYTE oid[6])
  * @param length string length
  */
 
-static void per_write_string(wStream* s, BYTE* str, int length)
+__attribute__((unused)) static void per_write_string(wStream* s, BYTE* str, int length)
 {
 	int i;
 

--- a/libfreerdp/locale/keyboard.c
+++ b/libfreerdp/locale/keyboard.c
@@ -61,7 +61,7 @@ int freerdp_detect_keyboard(DWORD* keyboardLayoutId)
 	return 0;
 }
 
-static int freerdp_keyboard_init_apple(DWORD* keyboardLayoutId,
+__attribute__((unused)) static int freerdp_keyboard_init_apple(DWORD* keyboardLayoutId,
                                        DWORD x11_keycode_to_rdp_scancode[256])
 {
 	DWORD vkcode;

--- a/libfreerdp/locale/keyboard_x11.c
+++ b/libfreerdp/locale/keyboard_x11.c
@@ -146,7 +146,7 @@ int freerdp_detect_keyboard_layout_from_xkb(DWORD* keyboardLayoutId)
 	return 0;
 }
 
-static char* freerdp_detect_keymap_from_xkb(void)
+__attribute__((unused)) static char* freerdp_detect_keymap_from_xkb(void)
 {
 	char* pch;
 	char* beg;

--- a/uwac/libuwac/uwac-display.c
+++ b/uwac/libuwac/uwac-display.c
@@ -308,7 +308,7 @@ static void UwacDestroyGlobal(UwacGlobal* global)
 	free(global);
 }
 
-static void* display_bind(UwacDisplay* display, uint32_t name, const struct wl_interface* interface,
+__attribute__((unused)) static void* display_bind(UwacDisplay* display, uint32_t name, const struct wl_interface* interface,
                           uint32_t version)
 {
 	return wl_registry_bind(display->registry, name, interface, version);
@@ -325,7 +325,7 @@ int UwacDisplayWatchFd(UwacDisplay* display, int fd, uint32_t events, UwacTask* 
 	return epoll_ctl(display->epoll_fd, EPOLL_CTL_ADD, fd, &ep);
 }
 
-static void UwacDisplayUnwatchFd(UwacDisplay* display, int fd)
+__attribute__((unused)) static void UwacDisplayUnwatchFd(UwacDisplay* display, int fd)
 {
 	epoll_ctl(display->epoll_fd, EPOLL_CTL_DEL, fd, NULL);
 }

--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
@@ -652,7 +652,7 @@ void ntlm_generate_server_signing_key(NTLM_CONTEXT* context)
  * @param sealing_key Destination sealing key
  */
 
-static int ntlm_generate_sealing_key(BYTE* exported_session_key, PSecBuffer seal_magic,
+__attribute__((unused)) static int ntlm_generate_sealing_key(BYTE* exported_session_key, PSecBuffer seal_magic,
                                      BYTE* sealing_key)
 {
 	BYTE* p;


### PR DESCRIPTION
Only adds ``__attribute__((unused))`` to unused functions to avoid compiler warnings.