### PR TITLE
fix: server side ntlmv2 implementation

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm.h
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.h
@@ -261,6 +261,7 @@ struct _NTLM_CONTEXT
 	SecBuffer NtChallengeResponse;
 	SecBuffer LmChallengeResponse;
 	NTLMv2_RESPONSE NTLMv2Response;
+	BYTE NtProofString[16];
 	BYTE Timestamp[8];
 	BYTE ChallengeTimestamp[8];
 	BYTE ServerChallenge[8];

--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
@@ -454,7 +454,7 @@ int ntlm_compute_ntlm_v2_response(NTLM_CONTEXT* context)
 	CopyMemory(&blob[8], ntlm_v2_temp.pvBuffer, ntlm_v2_temp.cbBuffer);
 	winpr_HMAC(WINPR_MD_MD5, (BYTE*)context->NtlmV2Hash, WINPR_MD5_DIGEST_LENGTH,
 	           (BYTE*)ntlm_v2_temp_chal.pvBuffer, ntlm_v2_temp_chal.cbBuffer,
-	           (BYTE*)context->NtProofString, WINPR_MD5_DIGEST_LENGTH);
+	           context->NtProofString, WINPR_MD5_DIGEST_LENGTH);
 
 	/* NtChallengeResponse, Concatenate NTProofStr with temp */
 
@@ -462,12 +462,12 @@ int ntlm_compute_ntlm_v2_response(NTLM_CONTEXT* context)
 		return -1;
 
 	blob = (BYTE*)context->NtChallengeResponse.pvBuffer;
-	CopyMemory(blob, context->NtProofString, 16);
+	CopyMemory(blob, context->NtProofString, WINPR_MD5_DIGEST_LENGTH);
 	CopyMemory(&blob[16], ntlm_v2_temp.pvBuffer, ntlm_v2_temp.cbBuffer);
 	/* Compute SessionBaseKey, the HMAC-MD5 hash of NTProofStr using the NTLMv2 hash as the key */
 	winpr_HMAC(WINPR_MD_MD5, (BYTE*)context->NtlmV2Hash, WINPR_MD5_DIGEST_LENGTH,
-	           (BYTE*)context->NtProofString, WINPR_MD5_DIGEST_LENGTH,
-	           (BYTE*)context->SessionBaseKey, WINPR_MD5_DIGEST_LENGTH);
+	           context->NtProofString, WINPR_MD5_DIGEST_LENGTH, context->SessionBaseKey,
+	           WINPR_MD5_DIGEST_LENGTH);
 	sspi_SecBufferFree(&ntlm_v2_temp);
 	sspi_SecBufferFree(&ntlm_v2_temp_chal);
 	return 1;

--- a/winpr/libwinpr/sspi/NTLM/ntlm_message.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_message.c
@@ -1173,9 +1173,10 @@ SECURITY_STATUS ntlm_server_AuthenticateComplete(NTLM_CONTEXT* context)
 			WLog_ERR(TAG, "Message Integrity Check (MIC) verification failed!");
 #ifdef WITH_DEBUG_NTLM
 			WLog_ERR(TAG, "Expected MIC:");
-			winpr_HexDump(TAG, WLOG_ERROR, messageIntegrityCheck, 16);
+			winpr_HexDump(TAG, WLOG_ERROR, messageIntegrityCheck, sizeof(messageIntegrityCheck));
 			WLog_ERR(TAG, "Actual MIC:");
-			winpr_HexDump(TAG, WLOG_ERROR, message->MessageIntegrityCheck, 16);
+			winpr_HexDump(TAG, WLOG_ERROR, message->MessageIntegrityCheck,
+			              sizeof(message->MessageIntegrityCheck));
 #endif
 			return SEC_E_MESSAGE_ALTERED;
 		}
@@ -1201,9 +1202,10 @@ SECURITY_STATUS ntlm_server_AuthenticateComplete(NTLM_CONTEXT* context)
 			WLog_ERR(TAG, "NtProofString verification failed!");
 #ifdef WITH_DEBUG_NTLM
 			WLog_ERR(TAG, "Expected NtProofString:");
-			winpr_HexDump(TAG, WLOG_ERROR, context->NtProofString, 16);
+			winpr_HexDump(TAG, WLOG_ERROR, context->NtProofString, sizeof(context->NtProofString));
 			WLog_ERR(TAG, "Actual NtProofString:");
-			winpr_HexDump(TAG, WLOG_ERROR, context->NTLMv2Response.Response, 16);
+			winpr_HexDump(TAG, WLOG_ERROR, context->NTLMv2Response.Response,
+			              sizeof(context->NTLMv2Response));
 #endif
 			return SEC_E_LOGON_DENIED;
 		}


### PR DESCRIPTION
 - in the case no mic was present, but the user was found,
   the enterd password was ignored and the user authenticated
