### PR TITLE
uwac, wlfreerdp: corrected API for UwacOutput and added monitor listing

### DIFF
--- a/client/Wayland/wlf_disp.c
+++ b/client/Wayland/wlf_disp.c
@@ -377,3 +377,25 @@ BOOL wlf_disp_uninit(wlfDispContext* wlfDisp, DispClientContext* disp)
 	wlfDisp->disp = NULL;
 	return TRUE;
 }
+
+int wlf_list_monitors(wlfContext* wlc)
+{
+	uint32_t i, nmonitors = UwacDisplayGetNbOutputs(wlc->display);
+
+	for (i = 0; i < nmonitors; i++)
+	{
+		const UwacOutput* monitor = UwacDisplayGetOutput(wlc->display, i);
+		UwacSize resolution;
+		UwacPosition pos;
+
+		if (!monitor)
+			continue;
+		UwacOutputGetPosition(monitor, &pos);
+		UwacOutputGetResolution(monitor, &resolution);
+
+		printf("     %s [%d] %dx%d\t+%d+%d\n", (i == 0) ? "*" : " ", i, resolution.width,
+		       resolution.height, pos.x, pos.y);
+	}
+
+	return 0;
+}

--- a/client/Wayland/wlf_disp.h
+++ b/client/Wayland/wlf_disp.h
@@ -33,4 +33,6 @@ void wlf_disp_free(wlfDispContext* disp);
 BOOL wlf_disp_handle_configure(wlfDispContext* disp, int32_t width, int32_t height);
 void wlf_disp_resized(wlfDispContext* disp);
 
+int wlf_list_monitors(wlfContext* wlc);
+
 #endif /* FREERDP_CLIENT_WAYLAND_DISP_H */

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -170,7 +170,7 @@ static BOOL wl_pre_connect(freerdp* instance)
 {
 	rdpSettings* settings;
 	wlfContext* context;
-	UwacOutput* output;
+	const UwacOutput* output;
 	UwacSize resolution;
 
 	if (!instance)
@@ -602,18 +602,30 @@ int main(int argc, char* argv[])
 	int status;
 	RDP_CLIENT_ENTRY_POINTS clientEntryPoints;
 	rdpContext* context;
+	rdpSettings* settings;
+	wlfContext* wlc;
+
 	RdpClientEntry(&clientEntryPoints);
 	context = freerdp_client_context_new(&clientEntryPoints);
-
 	if (!context)
 		goto fail;
+	wlc = (wlfContext*)context;
+	settings = context->settings;
 
-	status = freerdp_client_settings_parse_command_line(context->settings, argc, argv, FALSE);
-	status =
-	    freerdp_client_settings_command_line_status_print(context->settings, status, argc, argv);
+	status = freerdp_client_settings_parse_command_line(settings, argc, argv, FALSE);
+	status = freerdp_client_settings_command_line_status_print(settings, status, argc, argv);
 
 	if (status)
-		return 0;
+	{
+		BOOL list = settings->ListMonitors;
+		if (list)
+			wlf_list_monitors(wlc);
+
+		freerdp_client_context_free(context);
+		if (list)
+			return 0;
+		return status;
+	}
 
 	if (freerdp_client_start(context) != 0)
 		goto fail;

--- a/uwac/include/uwac/uwac.h
+++ b/uwac/include/uwac/uwac.h
@@ -32,6 +32,7 @@
 #define UWAC_API
 #endif
 
+typedef struct uwac_position UwacPosition;
 typedef struct uwac_size UwacSize;
 typedef struct uwac_display UwacDisplay;
 typedef struct uwac_output UwacOutput;
@@ -61,6 +62,13 @@ enum
 	UWAC_MOD_SHIFT_MASK = 0x01,
 	UWAC_MOD_ALT_MASK = 0x02,
 	UWAC_MOD_CONTROL_MASK = 0x04,
+};
+
+/** @brief a position */
+struct uwac_position
+{
+	int x;
+	int y;
 };
 
 /** @brief a rectangle size measure */
@@ -381,7 +389,7 @@ extern "C"
 	 * @param display the display to query
 	 * @return the number of outputs
 	 */
-	UWAC_API uint32_t UwacDisplayGetNbOutputs(UwacDisplay* display);
+	UWAC_API uint32_t UwacDisplayGetNbOutputs(const UwacDisplay* display);
 
 	/**
 	 *	retrieve a particular UwacOutput object
@@ -391,7 +399,7 @@ extern "C"
 	 * @return the given UwacOutput, NULL if something failed (so you should query
 	 *UwacDisplayGetLastError() to have the reason)
 	 */
-	UWAC_API UwacOutput* UwacDisplayGetOutput(UwacDisplay* display, int index);
+	UWAC_API const UwacOutput* UwacDisplayGetOutput(UwacDisplay* display, int index);
 
 	/**
 	 * retrieve the resolution of a given UwacOutput
@@ -400,7 +408,16 @@ extern "C"
 	 * @param resolution a pointer on the
 	 * @return UWAC_SUCCESS on success
 	 */
-	UWAC_API UwacReturnCode UwacOutputGetResolution(UwacOutput* output, UwacSize* resolution);
+	UWAC_API UwacReturnCode UwacOutputGetResolution(const UwacOutput* output, UwacSize* resolution);
+
+	/**
+	 * retrieve the position of a given UwacOutput
+	 *
+	 * @param output the UwacOutput
+	 * @param pos a pointer on the target position
+	 * @return UWAC_SUCCESS on success
+	 */
+	UWAC_API UwacReturnCode UwacOutputGetPosition(const UwacOutput* output, UwacPosition* pos);
 
 	/**
 	 *	creates a window using a SHM surface

--- a/uwac/libuwac/uwac-display.c
+++ b/uwac/libuwac/uwac-display.c
@@ -661,35 +661,46 @@ UwacReturnCode UwacDisplayQueryShmFormats(const UwacDisplay* display, enum wl_sh
 	return UWAC_SUCCESS;
 }
 
-uint32_t UwacDisplayGetNbOutputs(UwacDisplay* display)
+uint32_t UwacDisplayGetNbOutputs(const UwacDisplay* display)
 {
 	return wl_list_length(&display->outputs);
 }
 
-UwacOutput* UwacDisplayGetOutput(UwacDisplay* display, int index)
+const UwacOutput* UwacDisplayGetOutput(UwacDisplay* display, int index)
 {
-	struct wl_list* l;
 	int i;
+	UwacOutput* ret = NULL;
 
 	if (!display)
 		return NULL;
 
-	for (i = 0, l = &display->outputs; l && i < index; i++, l = l->next)
-		;
+	i = 0;
+	wl_list_for_each(ret, &display->outputs, link)
+	{
+		if (i == index)
+			break;
+		i++;
+	}
 
-	if (!l)
+	if (!ret)
 	{
 		display->last_error = UWAC_NOT_FOUND;
 		return NULL;
 	}
 
 	display->last_error = UWAC_SUCCESS;
-	return container_of(l, UwacOutput, link);
+	return ret;
 }
 
-UwacReturnCode UwacOutputGetResolution(UwacOutput* output, UwacSize* resolution)
+UwacReturnCode UwacOutputGetResolution(const UwacOutput* output, UwacSize* resolution)
 {
 	*resolution = output->resolution;
+	return UWAC_SUCCESS;
+}
+
+UwacReturnCode UwacOutputGetPosition(const UwacOutput* output, UwacPosition* pos)
+{
+	*pos = output->position;
 	return UWAC_SUCCESS;
 }
 

--- a/uwac/libuwac/uwac-output.c
+++ b/uwac/libuwac/uwac-output.c
@@ -35,8 +35,8 @@ static void output_handle_geometry(void* data, struct wl_output* wl_output, int 
 {
 	UwacOutput* output = data;
 
-	/*	output->allocation.x = x;
-	    output->allocation.y = y;*/
+	output->position.x = x;
+	output->position.y = y;
 	output->transform = transform;
 
 	if (output->make)

--- a/uwac/libuwac/uwac-priv.h
+++ b/uwac/libuwac/uwac-priv.h
@@ -137,6 +137,7 @@ struct uwac_output
 	bool doneNeeded;
 	bool doneReceived;
 
+	UwacPosition position;
 	UwacSize resolution;
 	int transform;
 	int scale;


### PR DESCRIPTION
`/monitor-list` was not implemented for `wlfreerdp`. This PR also fixes bugs in UWAC when retrieving a specific output.