### PR TITLE
SCardReadCache/SCardWriteCache should actually cache data

### DIFF
--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -959,7 +959,7 @@ static LONG smartcard_ReadCacheA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPE
 	if (!call->Common.fPbDataIsNULL)
 	{
 		ret.cbDataLen = call->Common.cbDataLen;
-		if (autoalloc)
+		if (!autoalloc)
 		{
 			ret.pbData = malloc(ret.cbDataLen);
 			if (!ret.pbData)
@@ -975,7 +975,11 @@ static LONG smartcard_ReadCacheA_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPE
 		ret.ReturnCode = SCardReadCacheA(operation->hContext, call->Common.CardIdentifier,
 		                                 call->Common.FreshnessCounter, call->szLookupName,
 		                                 ret.pbData, &ret.cbDataLen);
-	log_status_error(TAG, "SCardReadCacheA", ret.ReturnCode);
+	if ((ret.ReturnCode != SCARD_W_CACHE_ITEM_NOT_FOUND) &&
+	    (ret.ReturnCode != SCARD_W_CACHE_ITEM_STALE))
+	{
+		log_status_error(TAG, "SCardReadCacheA", ret.ReturnCode);
+	}
 	free(call->szLookupName);
 	free(call->Common.CardIdentifier);
 
@@ -1000,7 +1004,7 @@ static LONG smartcard_ReadCacheW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPE
 	if (!call->Common.fPbDataIsNULL)
 	{
 		ret.cbDataLen = call->Common.cbDataLen;
-		if (autoalloc)
+		if (!autoalloc)
 		{
 			ret.pbData = malloc(ret.cbDataLen);
 			if (!ret.pbData)
@@ -1016,7 +1020,11 @@ static LONG smartcard_ReadCacheW_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPE
 		ret.ReturnCode = SCardReadCacheW(operation->hContext, call->Common.CardIdentifier,
 		                                 call->Common.FreshnessCounter, call->szLookupName,
 		                                 ret.pbData, &ret.cbDataLen);
-	log_status_error(TAG, "SCardReadCacheW", ret.ReturnCode);
+	if ((ret.ReturnCode != SCARD_W_CACHE_ITEM_NOT_FOUND) &&
+	    (ret.ReturnCode != SCARD_W_CACHE_ITEM_STALE))
+	{
+		log_status_error(TAG, "SCardReadCacheA", ret.ReturnCode);
+	}
 	free(call->szLookupName);
 	free(call->Common.CardIdentifier);
 
@@ -2685,7 +2693,8 @@ LONG smartcard_irp_device_control_call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OP
 	}
 
 	if ((result != SCARD_S_SUCCESS) && (result != SCARD_E_TIMEOUT) &&
-	    (result != SCARD_E_NO_READERS_AVAILABLE) && (result != SCARD_E_NO_SERVICE))
+	    (result != SCARD_E_NO_READERS_AVAILABLE) && (result != SCARD_E_NO_SERVICE) &&
+	    (result != SCARD_W_CACHE_ITEM_NOT_FOUND) && (result != SCARD_W_CACHE_ITEM_STALE))
 	{
 		WLog_WARN(TAG, "IRP failure: %s (0x%08" PRIX32 "), status: %s (0x%08" PRIX32 ")",
 		          smartcard_get_ioctl_string(ioControlCode, TRUE), ioControlCode,

--- a/channels/smartcard/client/smartcard_pack.c
+++ b/channels/smartcard/client/smartcard_pack.c
@@ -712,7 +712,10 @@ static void smartcard_trace_read_cache_return(SMARTCARD_DEVICE* smartcard,
 
 	if (ret->ReturnCode == SCARD_S_SUCCESS)
 	{
+		char buffer[1024];
 		WLog_LVL(TAG, g_LogLevel, " cbDataLen=%" PRId32, ret->cbDataLen);
+		WLog_LVL(TAG, g_LogLevel, "  cbData: %s",
+		         smartcard_array_dump(ret->pbData, ret->cbDataLen, buffer, sizeof(buffer)));
 	}
 	WLog_LVL(TAG, g_LogLevel, "}");
 }


### PR DESCRIPTION
In the PCSC SCard code, currently since the `hash`/`keyCompare`/`keyClone` members on the `context->cache` were never being set, we were using the `HashTable_Pointer*` variants, meaning that lookup always failed (since we never ask for the same *pointer* twice, just the same *strings*).

This also revealed that the logic for autoallocate on these ops was a bit backwards, and some error codes and support for the "freshness" counter were missing.

In Win10 (at least with some card minidrivers) the freshness counter is load-bearing and smartcard login won't work without implementing at least a very basic version of it. In this patch I just return the `STALE` error if the requested freshness counter `!=` the stored value. In [MS-RDPESC] it seems to imply that this should be fine for implementors, but the MSDN docs for `SCardReadCache` seem to imply instead that we should only return `STALE` if our stored counter is *older*. Go figure. I went with `!=` for now, it's easy to change though.

I also silenced the error/warn level logs on these two new error codes (`SCARD_W_CACHE_ITEM_NOT_FOUND`, `SCARD_W_CACHE_ITEM_STALE`) since they're routine return values that don't really indicate that something has necessarily gone wrong (and every time I log in I see about half a dozen of these or more).

I'm testing this mostly against latest Win10 at the moment with the YubiKey Minidriver installed on the remote side, which after this patch seems to be working for Smartcard logon finally without changing the `/client-build-number`.