### PR TITLE
Fixed #6099: Add a flag for legacy hash entries

### DIFF
--- a/client/common/client.c
+++ b/client/common/client.c
@@ -549,6 +549,7 @@ DWORD client_cli_verify_certificate_ex(freerdp* instance, const char* host, UINT
 	printf("\tSubject:     %s\n", subject);
 	printf("\tIssuer:      %s\n", issuer);
 	printf("\tThumbprint:  %s\n", fingerprint);
+
 	printf("The above X.509 certificate could not be verified, possibly because you do not have\n"
 	       "the CA certificate in your certificate store, or the certificate has expired.\n"
 	       "Please look at the OpenSSL documentation on how to add a private CA to the store.\n");
@@ -644,6 +645,14 @@ DWORD client_cli_verify_changed_certificate_ex(freerdp* instance, const char* ho
 	printf("\tIssuer:      %s\n", old_issuer);
 	printf("\tThumbprint:  %s\n", old_fingerprint);
 	printf("\n");
+	if (flags & VERIFY_CERT_FLAG_MATCH_LEGACY_SHA1)
+	{
+		printf("\tA matching entry with legacy SHA1 was found in local known_hosts2 store.\n");
+		printf("\tIf you just upgraded from a FreeRDP version before 2.0 this is expected.\n");
+		printf("\tThe hashing algorithm has been upgraded from SHA1 to SHA256.\n");
+		printf("\tAll manually accepted certificates must be reconfirmed!\n");
+		printf("\n");
+	}
 	printf("The above X.509 certificate does not match the certificate used for previous "
 	       "connections.\n"
 	       "This may indicate that the certificate has been tampered with.\n"

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -67,6 +67,7 @@ extern "C"
 #define VERIFY_CERT_FLAG_GATEWAY 0x20
 #define VERIFY_CERT_FLAG_CHANGED 0x40
 #define VERIFY_CERT_FLAG_MISMATCH 0x80
+#define VERIFY_CERT_FLAG_MATCH_LEGACY_SHA1 0x100
 
 	typedef BOOL (*pContextNew)(freerdp* instance, rdpContext* context);
 	typedef void (*pContextFree)(freerdp* instance, rdpContext* context);

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1492,6 +1492,22 @@ int tls_verify_certificate(rdpTls* tls, CryptoCert cert, const char* hostname, U
 			fingerprint = crypto_cert_fingerprint(cert->px509);
 			/* search for matching entry in known_hosts file */
 			match = certificate_data_match(tls->certificate_store, certificate_data);
+			{
+				int match_old = -1;
+				char* sha1 = crypto_cert_fingerprint_by_hash(cert->px509, "sha1");
+				rdpCertificateData* certificate_data_sha1 =
+				    certificate_data_new(hostname, port, subject, issuer, sha1);
+
+				if (sha1 && certificate_data_sha1)
+					match_old =
+					    certificate_data_match(tls->certificate_store, certificate_data_sha1);
+
+				if (match_old == 0)
+					flags |= VERIFY_CERT_FLAG_MATCH_LEGACY_SHA1;
+
+				certificate_data_free(certificate_data_sha1);
+				free(sha1);
+			}
 
 			if (match == 1)
 			{


### PR DESCRIPTION
If a legacy entry is found in certificate hash store print
additional information to the user informing about the change
with FreeRDP 2.0