### PR TITLE
possible memory leak when various functions return failure.

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
@@ -415,14 +415,11 @@ int ntlm_compute_lm_v2_response(NTLM_CONTEXT* context)
 int ntlm_compute_ntlm_v2_response(NTLM_CONTEXT* context)
 {
 	BYTE* blob;
-	SecBuffer ntlm_v2_temp;
-	SecBuffer ntlm_v2_temp_chal;
-	PSecBuffer TargetInfo;
-	TargetInfo = &context->ChallengeTargetInfo;
+	SecBuffer ntlm_v2_temp = {0};
+	SecBuffer ntlm_v2_temp_chal = {0};
+	PSecBuffer TargetInfo = &context->ChallengeTargetInfo;
 	int ret = -1;
 
-	ZeroMemory(&ntlm_v2_temp, sizeof(ntlm_v2_temp));
-	ZeroMemory(&ntlm_v2_temp_chal, sizeof(ntlm_v2_temp_chal));
 	if (!sspi_SecBufferAlloc(&ntlm_v2_temp, TargetInfo->cbBuffer + 28))
 		goto exit;
 

--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
@@ -415,8 +415,8 @@ int ntlm_compute_lm_v2_response(NTLM_CONTEXT* context)
 int ntlm_compute_ntlm_v2_response(NTLM_CONTEXT* context)
 {
 	BYTE* blob;
-	SecBuffer ntlm_v2_temp = {0};
-	SecBuffer ntlm_v2_temp_chal = {0};
+	SecBuffer ntlm_v2_temp = { 0 };
+	SecBuffer ntlm_v2_temp_chal = { 0 };
 	PSecBuffer TargetInfo = &context->ChallengeTargetInfo;
 	int ret = -1;
 

--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
@@ -419,16 +419,19 @@ int ntlm_compute_ntlm_v2_response(NTLM_CONTEXT* context)
 	SecBuffer ntlm_v2_temp_chal;
 	PSecBuffer TargetInfo;
 	TargetInfo = &context->ChallengeTargetInfo;
+	int ret = -1;
 
+	ZeroMemory(&ntlm_v2_temp, sizeof(ntlm_v2_temp));
+	ZeroMemory(&ntlm_v2_temp_chal, sizeof(ntlm_v2_temp_chal));
 	if (!sspi_SecBufferAlloc(&ntlm_v2_temp, TargetInfo->cbBuffer + 28))
-		return -1;
+		goto exit;
 
 	ZeroMemory(ntlm_v2_temp.pvBuffer, ntlm_v2_temp.cbBuffer);
 	blob = (BYTE*)ntlm_v2_temp.pvBuffer;
 
 	/* Compute the NTLMv2 hash */
 	if (ntlm_compute_ntlm_v2_hash(context, (BYTE*)context->NtlmV2Hash) < 0)
-		return -1;
+		goto exit;
 
 	/* Construct temp */
 	blob[0] = 1; /* RespType (1 byte) */
@@ -447,7 +450,7 @@ int ntlm_compute_ntlm_v2_response(NTLM_CONTEXT* context)
 	/* Concatenate server challenge with temp */
 
 	if (!sspi_SecBufferAlloc(&ntlm_v2_temp_chal, ntlm_v2_temp.cbBuffer + 8))
-		return -1;
+		goto exit;
 
 	blob = (BYTE*)ntlm_v2_temp_chal.pvBuffer;
 	CopyMemory(blob, context->ServerChallenge, 8);
@@ -459,7 +462,7 @@ int ntlm_compute_ntlm_v2_response(NTLM_CONTEXT* context)
 	/* NtChallengeResponse, Concatenate NTProofStr with temp */
 
 	if (!sspi_SecBufferAlloc(&context->NtChallengeResponse, ntlm_v2_temp.cbBuffer + 16))
-		return -1;
+		goto exit;
 
 	blob = (BYTE*)context->NtChallengeResponse.pvBuffer;
 	CopyMemory(blob, context->NtProofString, WINPR_MD5_DIGEST_LENGTH);
@@ -468,9 +471,11 @@ int ntlm_compute_ntlm_v2_response(NTLM_CONTEXT* context)
 	winpr_HMAC(WINPR_MD_MD5, (BYTE*)context->NtlmV2Hash, WINPR_MD5_DIGEST_LENGTH,
 	           context->NtProofString, WINPR_MD5_DIGEST_LENGTH, context->SessionBaseKey,
 	           WINPR_MD5_DIGEST_LENGTH);
+	ret = 1;
+exit:
 	sspi_SecBufferFree(&ntlm_v2_temp);
 	sspi_SecBufferFree(&ntlm_v2_temp_chal);
-	return 1;
+	return ret;
 }
 
 /**


### PR DESCRIPTION
There are possible leak  in ntlm_compute_ntlm_v2_response(), when in error, the allocated SecBuffer are not freed.