### PR TITLE
Optimization: avoid calling repeatedly GetBytesPerPixel() and GetBitsPerPixel()

### DIFF
--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -627,7 +627,7 @@ static BOOL convert_rail_icon(ICON_INFO* iconInfo, xfRailIcon* railIcon)
 
 	for (i = 2; i < nelements; i++)
 	{
-		pixels[i] = ReadColor(nextPixel, PIXEL_FORMAT_BGRA32);
+		pixels[i] = ReadColor(nextPixel, PIXEL_FORMAT_BGRA32, 32 /*GetBitsPerPixel(PIXEL_FORMAT_BGRA32)*/);
 		nextPixel += 4;
 	}
 

--- a/include/freerdp/codec/color.h
+++ b/include/freerdp/codec/color.h
@@ -711,15 +711,15 @@ extern "C"
 	 * Read a pixel from memory to internal representation
 	 *
 	 * @param src    The source buffer
-	 * @param format The PIXEL_FORMAT_* define the source buffer uses for encoding
+	 * @param bitsPerPixel The bits per pixel of PIXEL_FORMAT_* define the source buffer uses for encoding
 	 *
 	 * @return The pixel color in internal representation
 	 */
-	static INLINE UINT32 ReadColor(const BYTE* src, UINT32 format)
+	static INLINE UINT32 ReadColor(const BYTE* src, UINT32 format, UINT32 bitsPerPixel)
 	{
 		UINT32 color;
 
-		switch (GetBitsPerPixel(format))
+		switch (bitsPerPixel)
 		{
 			case 32:
 				color = ((UINT32)src[0] << 24) | ((UINT32)src[1] << 16) | ((UINT32)src[2] << 8) |
@@ -762,14 +762,14 @@ extern "C"
 	 * Write a pixel from internal representation to memory
 	 *
 	 * @param dst    The destination buffer
-	 * @param format The PIXEL_FORMAT_* define for encoding
+	 * @param bitsPerPixel The bits per pixel of PIXEL_FORMAT_* define for encoding
 	 * @param color  The pixel color in internal representation
 	 *
 	 * @return TRUE if successful, FALSE otherwise
 	 */
-	static INLINE BOOL WriteColor(BYTE* dst, UINT32 format, UINT32 color)
+	static INLINE BOOL WriteColor(BYTE* dst, UINT32 format, UINT32 bitsPerPixel, UINT32 color)
 	{
-		switch (GetBitsPerPixel(format))
+		switch (bitsPerPixel)
 		{
 			case 32:
 				dst[0] = (BYTE)(color >> 24);

--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -115,7 +115,7 @@ BOOL freerdp_image_copy_from_monochrome(BYTE* pDstData, UINT32 DstFormat, UINT32
 
 		for (x = 0; x < nWidth; x++)
 		{
-			BYTE* pDstPixel = &pDstLine[((nXDst + x) * GetBytesPerPixel(DstFormat))];
+			BYTE* pDstPixel = &pDstLine[((nXDst + x) * dstBytesPerPixel)];
 			BOOL monoPixel = (*monoBits & monoBit) ? TRUE : FALSE;
 
 			if (!(monoBit >>= 1))
@@ -337,7 +337,7 @@ static BOOL freerdp_image_copy_from_pointer_data_1bpp(BYTE* pDstData, UINT32 Dst
 		const BYTE* andBits;
 		const BYTE* xorBits;
 		BYTE* pDstPixel =
-		    &pDstData[((nYDst + y) * nDstStep) + (nXDst * GetBytesPerPixel(DstFormat))];
+		    &pDstData[((nYDst + y) * nDstStep) + (nXDst * dstBytesPerPixel)];
 		xorBit = andBit = 0x80;
 
 		if (!vFlip)
@@ -380,7 +380,7 @@ static BOOL freerdp_image_copy_from_pointer_data_1bpp(BYTE* pDstData, UINT32 Dst
 				color = freerdp_image_inverted_pointer_color(x, y, DstFormat); /* inverted */
 
 			WriteColor(pDstPixel, DstFormat, color);
-			pDstPixel += GetBytesPerPixel(DstFormat);
+			pDstPixel += dstBytesPerPixel;
 		}
 	}
 
@@ -439,7 +439,7 @@ static BOOL freerdp_image_copy_from_pointer_data_xbpp(BYTE* pDstData, UINT32 Dst
 		const BYTE* xorBits;
 		const BYTE* andBits = NULL;
 		BYTE* pDstPixel =
-		    &pDstData[((nYDst + y) * nDstStep) + (nXDst * GetBytesPerPixel(DstFormat))];
+		    &pDstData[((nYDst + y) * nDstStep) + (nXDst * dstBytesPerPixel)];
 		andBit = 0x80;
 
 		if (!vFlip)
@@ -508,7 +508,7 @@ static BOOL freerdp_image_copy_from_pointer_data_xbpp(BYTE* pDstData, UINT32 Dst
 
 			color = FreeRDPConvertColor(xorPixel, PIXEL_FORMAT_ARGB32, DstFormat, palette);
 			WriteColor(pDstPixel, DstFormat, color);
-			pDstPixel += GetBytesPerPixel(DstFormat);
+			pDstPixel += dstBytesPerPixel;
 		}
 	}
 
@@ -608,10 +608,10 @@ BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32
 		return FALSE;
 
 	if (nDstStep == 0)
-		nDstStep = nWidth * GetBytesPerPixel(DstFormat);
+		nDstStep = nWidth * dstByte;
 
 	if (nSrcStep == 0)
-		nSrcStep = nWidth * GetBytesPerPixel(SrcFormat);
+		nSrcStep = nWidth * srcByte;
 
 	if (vSrcVFlip)
 	{

--- a/libfreerdp/codec/planar.c
+++ b/libfreerdp/codec/planar.c
@@ -385,6 +385,7 @@ static INLINE BOOL writeLine(BYTE** ppRgba, UINT32 DstFormat, UINT32 width, cons
                              const BYTE** ppG, const BYTE** ppB, const BYTE** ppA)
 {
 	UINT32 x;
+	const UINT32 dstBytesPerPixel = GetBytesPerPixel(DstFormat);
 
 	if (!ppRgba || !ppR || !ppG || !ppB)
 		return FALSE;
@@ -421,7 +422,7 @@ static INLINE BOOL writeLine(BYTE** ppRgba, UINT32 DstFormat, UINT32 width, cons
 				BYTE alpha = *(*ppA)++;
 				UINT32 color = FreeRDPGetColor(DstFormat, *(*ppR)++, *(*ppG)++, *(*ppB)++, alpha);
 				WriteColor(*ppRgba, DstFormat, color);
-				*ppRgba += GetBytesPerPixel(DstFormat);
+				*ppRgba += dstBytesPerPixel;
 			}
 		}
 		else
@@ -432,7 +433,7 @@ static INLINE BOOL writeLine(BYTE** ppRgba, UINT32 DstFormat, UINT32 width, cons
 			{
 				UINT32 color = FreeRDPGetColor(DstFormat, *(*ppR)++, *(*ppG)++, *(*ppB)++, alpha);
 				WriteColor(*ppRgba, DstFormat, color);
-				*ppRgba += GetBytesPerPixel(DstFormat);
+				*ppRgba += dstBytesPerPixel;
 			}
 		}
 
@@ -451,6 +452,7 @@ static INLINE BOOL planar_decompress_planes_raw(const BYTE* pSrcData[4], BYTE* p
 	const BYTE* pG = pSrcData[1];
 	const BYTE* pB = pSrcData[2];
 	const BYTE* pA = pSrcData[3];
+	const UINT32 bpp = GetBytesPerPixel(DstFormat);
 
 	if (vFlip)
 	{
@@ -467,7 +469,7 @@ static INLINE BOOL planar_decompress_planes_raw(const BYTE* pSrcData[4], BYTE* p
 
 	for (y = beg; y != end; y += inc)
 	{
-		BYTE* pRGB = &pDstData[((nYDst + y) * nDstStep) + (nXDst * GetBytesPerPixel(DstFormat))];
+		BYTE* pRGB = &pDstData[((nYDst + y) * nDstStep) + (nXDst * bpp)];
 
 		if (!writeLine(&pRGB, DstFormat, nWidth, &pR, &pG, &pB, &pA))
 			return FALSE;
@@ -856,13 +858,14 @@ static INLINE BOOL freerdp_split_color_planes(const BYTE* data, UINT32 format, U
                                               UINT32 height, UINT32 scanline, BYTE* planes[4])
 {
 	INT32 i, j, k;
+	const UINT32 bpp = GetBytesPerPixel(format);
 	if ((width > INT32_MAX) || (height > INT32_MAX) || (scanline > INT32_MAX))
 		return FALSE;
 
 	k = 0;
 
 	if (scanline == 0)
-		scanline = width * GetBytesPerPixel(format);
+		scanline = width * bpp;
 
 	for (i = (INT32)height - 1; i >= 0; i--)
 	{
@@ -871,7 +874,7 @@ static INLINE BOOL freerdp_split_color_planes(const BYTE* data, UINT32 format, U
 		for (j = 0; j < (INT32)width; j++)
 		{
 			const UINT32 color = ReadColor(pixel, format);
-			pixel += GetBytesPerPixel(format);
+			pixel += bpp;
 			SplitColor(color, format, &planes[1][k], &planes[2][k], &planes[3][k], &planes[0][k],
 			           NULL);
 			k++;

--- a/libfreerdp/codec/planar.c
+++ b/libfreerdp/codec/planar.c
@@ -386,6 +386,7 @@ static INLINE BOOL writeLine(BYTE** ppRgba, UINT32 DstFormat, UINT32 width, cons
 {
 	UINT32 x;
 	const UINT32 dstBytesPerPixel = GetBytesPerPixel(DstFormat);
+	const UINT32 dstBitsPerPixel = GetBitsPerPixel(DstFormat);
 
 	if (!ppRgba || !ppR || !ppG || !ppB)
 		return FALSE;
@@ -421,7 +422,7 @@ static INLINE BOOL writeLine(BYTE** ppRgba, UINT32 DstFormat, UINT32 width, cons
 			{
 				BYTE alpha = *(*ppA)++;
 				UINT32 color = FreeRDPGetColor(DstFormat, *(*ppR)++, *(*ppG)++, *(*ppB)++, alpha);
-				WriteColor(*ppRgba, DstFormat, color);
+				WriteColor(*ppRgba, DstFormat, dstBitsPerPixel, color);
 				*ppRgba += dstBytesPerPixel;
 			}
 		}
@@ -432,7 +433,7 @@ static INLINE BOOL writeLine(BYTE** ppRgba, UINT32 DstFormat, UINT32 width, cons
 			for (x = 0; x < width; x++)
 			{
 				UINT32 color = FreeRDPGetColor(DstFormat, *(*ppR)++, *(*ppG)++, *(*ppB)++, alpha);
-				WriteColor(*ppRgba, DstFormat, color);
+				WriteColor(*ppRgba, DstFormat, dstBitsPerPixel, color);
 				*ppRgba += dstBytesPerPixel;
 			}
 		}
@@ -859,6 +860,7 @@ static INLINE BOOL freerdp_split_color_planes(const BYTE* data, UINT32 format, U
 {
 	INT32 i, j, k;
 	const UINT32 bpp = GetBytesPerPixel(format);
+	const UINT32 bits = GetBitsPerPixel(format);
 	if ((width > INT32_MAX) || (height > INT32_MAX) || (scanline > INT32_MAX))
 		return FALSE;
 
@@ -873,7 +875,7 @@ static INLINE BOOL freerdp_split_color_planes(const BYTE* data, UINT32 format, U
 
 		for (j = 0; j < (INT32)width; j++)
 		{
-			const UINT32 color = ReadColor(pixel, format);
+			const UINT32 color = ReadColor(pixel, format, bits);
 			pixel += bpp;
 			SplitColor(color, format, &planes[1][k], &planes[2][k], &planes[3][k], &planes[0][k],
 			           NULL);

--- a/libfreerdp/codec/test/TestFreeRDPCodecInterleaved.c
+++ b/libfreerdp/codec/test/TestFreeRDPCodecInterleaved.c
@@ -32,6 +32,7 @@ static BOOL run_encode_decode_single(UINT16 bpp, BITMAP_INTERLEAVED_CONTEXT* enc
 	const UINT32 y = 0;
 	const UINT32 format = PIXEL_FORMAT_RGBX32;
 	const UINT32 bstep = GetBytesPerPixel(format);
+	const UINT32 bits = GetBitsPerPixel(format);
 	const size_t step = (w + 13) * 4;
 	const size_t SrcSize = step * h;
 	const float maxDiff = 4.0f * ((bpp < 24) ? 2.0f : 1.0f);
@@ -72,8 +73,8 @@ static BOOL run_encode_decode_single(UINT16 bpp, BITMAP_INTERLEAVED_CONTEXT* enc
 		for (j = 0; j < w; j++)
 		{
 			BYTE r, g, b, dr, dg, db;
-			const UINT32 srcColor = ReadColor(&srcLine[j * bstep], format);
-			const UINT32 dstColor = ReadColor(&dstLine[j * bstep], format);
+			const UINT32 srcColor = ReadColor(&srcLine[j * bstep], format, bits);
+			const UINT32 dstColor = ReadColor(&dstLine[j * bstep], format, bits);
 			SplitColor(srcColor, format, &r, &g, &b, NULL, NULL);
 			SplitColor(dstColor, format, &dr, &dg, &db, NULL, NULL);
 

--- a/libfreerdp/codec/test/TestFreeRDPCodecPlanar.c
+++ b/libfreerdp/codec/test/TestFreeRDPCodecPlanar.c
@@ -5473,8 +5473,8 @@ static BOOL CompareBitmap(const BYTE* srcA, UINT32 srcAFormat, const BYTE* srcB,
 			BYTE sR, sG, sB, sA, dR, dG, dB, dA;
 			const BYTE* a = &lineA[x * srcABytes];
 			const BYTE* b = &lineB[x * srcBBytes];
-			UINT32 colorA = ReadColor(a, srcAFormat);
-			UINT32 colorB = ReadColor(b, srcBFormat);
+			UINT32 colorA = ReadColor(a, srcAFormat, srcABits);
+			UINT32 colorB = ReadColor(b, srcBFormat, srcBBits);
 			SplitColor(colorA, srcAFormat, &sR, &sG, &sB, &sA, NULL);
 			SplitColor(colorB, srcBFormat, &dR, &dG, &dB, &dA, NULL);
 
@@ -5545,6 +5545,7 @@ static BOOL RunTestPlanarSingleColor(BITMAP_PLANAR_CONTEXT* planar, const UINT32
 	UINT32 i, j, x, y;
 	BOOL rc = FALSE;
 	const UINT32 srcBpp = GetBytesPerPixel(srcFormat);
+	const UINT32 srcBits = GetBitsPerPixel(srcFormat);
 	const UINT32 dstBpp = GetBytesPerPixel(dstFormat);
 	printf("%s: [%s] --> [%s]: ", __FUNCTION__, FreeRDPGetColorFormatName(srcFormat),
 	       FreeRDPGetColorFormatName(dstFormat));
@@ -5576,7 +5577,7 @@ static BOOL RunTestPlanarSingleColor(BITMAP_PLANAR_CONTEXT* planar, const UINT32
 
 				for (x = 0; x < width; x++)
 				{
-					WriteColor(line, srcFormat, color);
+					WriteColor(line, srcFormat, bits, color);
 					line += srcBpp;
 				}
 			}

--- a/libfreerdp/codec/test/TestFreeRDPCodecPlanar.c
+++ b/libfreerdp/codec/test/TestFreeRDPCodecPlanar.c
@@ -5423,7 +5423,9 @@ static BOOL CompareBitmap(const BYTE* srcA, UINT32 srcAFormat, const BYTE* srcB,
                           UINT32 width, UINT32 height)
 {
 	double maxDiff;
+	const UINT32 srcABytes = GetBytesPerPixel(srcAFormat);
 	const UINT32 srcABits = GetBitsPerPixel(srcAFormat);
+	const UINT32 srcBBytes = GetBytesPerPixel(srcBFormat);
 	const UINT32 srcBBits = GetBitsPerPixel(srcBFormat);
 	UINT32 diff = fabs((double)srcABits - srcBBits);
 	UINT32 x, y;
@@ -5463,14 +5465,14 @@ static BOOL CompareBitmap(const BYTE* srcA, UINT32 srcAFormat, const BYTE* srcB,
 
 	for (y = 0; y < height; y++)
 	{
-		const BYTE* lineA = &srcA[width * GetBytesPerPixel(srcAFormat) * y];
-		const BYTE* lineB = &srcB[width * GetBytesPerPixel(srcBFormat) * y];
+		const BYTE* lineA = &srcA[width * srcABytes * y];
+		const BYTE* lineB = &srcB[width * srcBBytes * y];
 
 		for (x = 0; x < width; x++)
 		{
 			BYTE sR, sG, sB, sA, dR, dG, dB, dA;
-			const BYTE* a = &lineA[x * GetBytesPerPixel(srcAFormat)];
-			const BYTE* b = &lineB[x * GetBytesPerPixel(srcBFormat)];
+			const BYTE* a = &lineA[x * srcABytes];
+			const BYTE* b = &lineB[x * srcBBytes];
 			UINT32 colorA = ReadColor(a, srcAFormat);
 			UINT32 colorB = ReadColor(b, srcBFormat);
 			SplitColor(colorA, srcAFormat, &sR, &sG, &sB, &sA, NULL);
@@ -5542,6 +5544,8 @@ static BOOL RunTestPlanarSingleColor(BITMAP_PLANAR_CONTEXT* planar, const UINT32
 {
 	UINT32 i, j, x, y;
 	BOOL rc = FALSE;
+	const UINT32 srcBpp = GetBytesPerPixel(srcFormat);
+	const UINT32 dstBpp = GetBytesPerPixel(dstFormat);
 	printf("%s: [%s] --> [%s]: ", __FUNCTION__, FreeRDPGetColorFormatName(srcFormat),
 	       FreeRDPGetColorFormatName(dstFormat));
 	fflush(stdout);
@@ -5557,8 +5561,8 @@ static BOOL RunTestPlanarSingleColor(BITMAP_PLANAR_CONTEXT* planar, const UINT32
 			const UINT32 width = i;
 			const UINT32 height = i;
 			BOOL failed = TRUE;
-			const UINT32 srcSize = width * height * GetBytesPerPixel(srcFormat);
-			const UINT32 dstSize = width * height * GetBytesPerPixel(dstFormat);
+			const UINT32 srcSize = width * height * srcBpp;
+			const UINT32 dstSize = width * height * dstBpp;
 			BYTE* compressedBitmap = NULL;
 			BYTE* bmp = malloc(srcSize);
 			BYTE* decompressedBitmap = (BYTE*)malloc(dstSize);
@@ -5568,12 +5572,12 @@ static BOOL RunTestPlanarSingleColor(BITMAP_PLANAR_CONTEXT* planar, const UINT32
 
 			for (y = 0; y < height; y++)
 			{
-				BYTE* line = &bmp[width * GetBytesPerPixel(srcFormat) * y];
+				BYTE* line = &bmp[width * srcBpp * y];
 
 				for (x = 0; x < width; x++)
 				{
 					WriteColor(line, srcFormat, color);
-					line += GetBytesPerPixel(srcFormat);
+					line += srcBpp;
 				}
 			}
 

--- a/libfreerdp/gdi/bitmap.c
+++ b/libfreerdp/gdi/bitmap.c
@@ -56,7 +56,7 @@ INLINE UINT32 gdi_GetPixel(HGDI_DC hdc, UINT32 nXPos, UINT32 nYPos)
 {
 	HGDI_BITMAP hBmp = (HGDI_BITMAP)hdc->selectedObject;
 	BYTE* data = &(hBmp->data[(nYPos * hBmp->scanline) + nXPos * GetBytesPerPixel(hBmp->format)]);
-	return ReadColor(data, hBmp->format);
+	return ReadColor(data, hBmp->format, GetBitsPerPixel(hBmp->format));
 }
 
 INLINE BYTE* gdi_GetPointer(HGDI_BITMAP hBmp, UINT32 X, UINT32 Y)
@@ -78,7 +78,7 @@ INLINE BYTE* gdi_GetPointer(HGDI_BITMAP hBmp, UINT32 X, UINT32 Y)
 static INLINE UINT32 gdi_SetPixelBmp(HGDI_BITMAP hBmp, UINT32 X, UINT32 Y, UINT32 crColor)
 {
 	BYTE* p = &hBmp->data[(Y * hBmp->scanline) + X * GetBytesPerPixel(hBmp->format)];
-	WriteColor(p, hBmp->format, crColor);
+	WriteColor(p, hBmp->format, GetBitsPerPixel(hBmp->format), crColor);
 	return crColor;
 }
 
@@ -280,6 +280,7 @@ static INLINE BOOL BitBlt_write(HGDI_DC hdcDest, HGDI_DC hdcSrc, INT32 nXDest, I
 	const INT32 dstX = nXDest + x;
 	const INT32 dstY = nYDest + y;
 	BYTE* dstp = gdi_get_bitmap_pointer(hdcDest, dstX, dstY);
+	const UINT32 bits = GetBitsPerPixel(hdcDest->format);
 
 	if (!dstp)
 	{
@@ -287,7 +288,7 @@ static INLINE BOOL BitBlt_write(HGDI_DC hdcDest, HGDI_DC hdcSrc, INT32 nXDest, I
 		return FALSE;
 	}
 
-	colorA = ReadColor(dstp, hdcDest->format);
+	colorA = ReadColor(dstp, hdcDest->format, bits);
 
 	if (useSrc)
 	{
@@ -299,7 +300,7 @@ static INLINE BOOL BitBlt_write(HGDI_DC hdcDest, HGDI_DC hdcSrc, INT32 nXDest, I
 			return FALSE;
 		}
 
-		colorC = ReadColor(srcp, hdcSrc->format);
+		colorC = ReadColor(srcp, hdcSrc->format, GetBitsPerPixel(hdcSrc->format));
 		colorC = FreeRDPConvertColor(colorC, hdcSrc->format, hdcDest->format, palette);
 	}
 
@@ -322,7 +323,7 @@ static INLINE BOOL BitBlt_write(HGDI_DC hdcDest, HGDI_DC hdcSrc, INT32 nXDest, I
 					return FALSE;
 				}
 
-				colorB = ReadColor(patp, hdcDest->format);
+				colorB = ReadColor(patp, hdcDest->format, bits);
 			}
 			break;
 
@@ -332,7 +333,7 @@ static INLINE BOOL BitBlt_write(HGDI_DC hdcDest, HGDI_DC hdcSrc, INT32 nXDest, I
 	}
 
 	dstColor = process_rop(colorC, colorA, colorB, rop, hdcDest->format);
-	return WriteColor(dstp, hdcDest->format, dstColor);
+	return WriteColor(dstp, hdcDest->format, bits, dstColor);
 }
 
 static BOOL adjust_src_coordinates(HGDI_DC hdcSrc, INT32 nWidth, INT32 nHeight, INT32* px,

--- a/libfreerdp/gdi/bitmap.c
+++ b/libfreerdp/gdi/bitmap.c
@@ -61,7 +61,7 @@ INLINE UINT32 gdi_GetPixel(HGDI_DC hdc, UINT32 nXPos, UINT32 nYPos)
 
 INLINE BYTE* gdi_GetPointer(HGDI_BITMAP hBmp, UINT32 X, UINT32 Y)
 {
-	UINT32 bpp = GetBytesPerPixel(hBmp->format);
+	const UINT32 bpp = GetBytesPerPixel(hBmp->format);
 	return &hBmp->data[(Y * hBmp->width * bpp) + X * bpp];
 }
 
@@ -143,11 +143,13 @@ HGDI_BITMAP gdi_CreateCompatibleBitmap(HGDI_DC hdc, UINT32 nWidth, UINT32 nHeigh
 	if (!hBitmap)
 		return NULL;
 
+	const UINT32 bpp = GetBytesPerPixel(hdc->format);
+
 	hBitmap->objectType = GDIOBJECT_BITMAP;
 	hBitmap->format = hdc->format;
 	hBitmap->width = nWidth;
 	hBitmap->height = nHeight;
-	hBitmap->data = _aligned_malloc(nWidth * nHeight * GetBytesPerPixel(hBitmap->format), 16);
+	hBitmap->data = _aligned_malloc(nWidth * nHeight * bpp, 16);
 	hBitmap->free = _aligned_free;
 
 	if (!hBitmap->data)
@@ -156,7 +158,7 @@ HGDI_BITMAP gdi_CreateCompatibleBitmap(HGDI_DC hdc, UINT32 nWidth, UINT32 nHeigh
 		return NULL;
 	}
 
-	hBitmap->scanline = nWidth * GetBytesPerPixel(hBitmap->format);
+	hBitmap->scanline = nWidth * bpp;
 	return hBitmap;
 }
 

--- a/libfreerdp/gdi/gdi.h
+++ b/libfreerdp/gdi/gdi.h
@@ -34,10 +34,11 @@ static INLINE BYTE* gdi_get_bitmap_pointer(HGDI_DC hdcBmp, INT32 x, INT32 y)
 {
 	BYTE* p;
 	HGDI_BITMAP hBmp = (HGDI_BITMAP)hdcBmp->selectedObject;
+	const UINT32 bpp = GetBytesPerPixel(hdcBmp->format);
 
 	if ((x >= 0) && (y >= 0) && (x < hBmp->width) && (y < hBmp->height))
 	{
-		p = hBmp->data + (y * hBmp->scanline) + (x * GetBytesPerPixel(hdcBmp->format));
+		p = hBmp->data + (y * hBmp->scanline) + (x * bpp);
 		return p;
 	}
 	else

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -663,6 +663,7 @@ static UINT gdi_SurfaceCommand_Alpha(rdpGdi* gdi, RdpgfxClientContext* context,
 		return ERROR_INVALID_DATA;
 
 	surface = (gdiGfxSurface*)context->GetSurfaceData(context, cmd->surfaceId);
+	const UINT32 bpp = GetBytesPerPixel(surface->format);
 
 	if (!surface)
 	{
@@ -692,7 +693,7 @@ static UINT gdi_SurfaceCommand_Alpha(rdpGdi* gdi, RdpgfxClientContext* context,
 			{
 				UINT32 color;
 				BYTE r, g, b, a;
-				BYTE* src = &line[x * GetBytesPerPixel(surface->format)];
+				BYTE* src = &line[x * bpp];
 				Stream_Read_UINT8(&s, a);
 				color = ReadColor(src, surface->format);
 				SplitColor(color, surface->format, &r, &g, &b, NULL, NULL);

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -616,6 +616,7 @@ static BOOL gdi_apply_alpha(BYTE* data, UINT32 format, UINT32 stride, RECTANGLE_
 	UINT32 written = 0;
 	BOOL first = TRUE;
 	const UINT32 bpp = GetBytesPerPixel(format);
+	const UINT32 bits = GetBitsPerPixel(format);
 
 	for (y = rect->top; y < rect->bottom; y++)
 	{
@@ -632,10 +633,10 @@ static BOOL gdi_apply_alpha(BYTE* data, UINT32 format, UINT32 stride, RECTANGLE_
 				return TRUE;
 
 			src = &line[x * bpp];
-			color = ReadColor(src, format);
+			color = ReadColor(src, format, bits);
 			SplitColor(color, format, &r, &g, &b, NULL, NULL);
 			color = FreeRDPGetColor(format, r, g, b, a);
-			WriteColor(src, format, color);
+			WriteColor(src, format, bits, color);
 			written++;
 		}
 
@@ -664,6 +665,7 @@ static UINT gdi_SurfaceCommand_Alpha(rdpGdi* gdi, RdpgfxClientContext* context,
 
 	surface = (gdiGfxSurface*)context->GetSurfaceData(context, cmd->surfaceId);
 	const UINT32 bpp = GetBytesPerPixel(surface->format);
+	const UINT32 bits = GetBitsPerPixel(surface->format);
 
 	if (!surface)
 	{
@@ -695,10 +697,10 @@ static UINT gdi_SurfaceCommand_Alpha(rdpGdi* gdi, RdpgfxClientContext* context,
 				BYTE r, g, b, a;
 				BYTE* src = &line[x * bpp];
 				Stream_Read_UINT8(&s, a);
-				color = ReadColor(src, surface->format);
+				color = ReadColor(src, surface->format, bits);
 				SplitColor(color, surface->format, &r, &g, &b, NULL, NULL);
 				color = FreeRDPGetColor(surface->format, r, g, b, a);
-				WriteColor(src, surface->format, color);
+				WriteColor(src, surface->format, bits, color);
 			}
 		}
 	}

--- a/libfreerdp/gdi/graphics.c
+++ b/libfreerdp/gdi/graphics.c
@@ -137,13 +137,13 @@ static BOOL gdi_Bitmap_Decompress(rdpContext* context, rdpBitmap* bitmap, const 
 	UINT32 size = DstWidth * DstHeight;
 	bitmap->compressed = FALSE;
 	bitmap->format = gdi->dstFormat;
+	const UINT32 bytesPerPixel = GetBytesPerPixel(bitmap->format);
 
-	if ((GetBytesPerPixel(bitmap->format) == 0) || (DstWidth == 0) || (DstHeight == 0) ||
-	    (DstWidth > UINT32_MAX / DstHeight) ||
-	    (size > (UINT32_MAX / GetBytesPerPixel(bitmap->format))))
+	if ((bytesPerPixel == 0) || (DstWidth == 0) || (DstHeight == 0) ||
+	    (DstWidth > UINT32_MAX / DstHeight) || (size > (UINT32_MAX / bytesPerPixel)))
 		return FALSE;
 
-	size *= GetBytesPerPixel(bitmap->format);
+	size *= bytesPerPixel;
 	bitmap->length = size;
 	bitmap->data = (BYTE*)_aligned_malloc(bitmap->length, 16);
 

--- a/libfreerdp/gdi/line.c
+++ b/libfreerdp/gdi/line.c
@@ -47,7 +47,7 @@
  */
 static BOOL gdi_rop_color(UINT32 rop, BYTE* pixelPtr, UINT32 pen, UINT32 format)
 {
-	const UINT32 srcPixel = ReadColor(pixelPtr, format);
+	const UINT32 srcPixel = ReadColor(pixelPtr, format, GetBitsPerPixel(format));
 	UINT32 dstPixel;
 
 	switch (rop)
@@ -120,7 +120,7 @@ static BOOL gdi_rop_color(UINT32 rop, BYTE* pixelPtr, UINT32 pen, UINT32 format)
 			return FALSE;
 	}
 
-	return WriteColor(pixelPtr, format, dstPixel);
+	return WriteColor(pixelPtr, format, GetBitsPerPixel(format), dstPixel);
 }
 
 BOOL gdi_LineTo(HGDI_DC hdc, UINT32 nXEnd, UINT32 nYEnd)

--- a/libfreerdp/gdi/shape.c
+++ b/libfreerdp/gdi/shape.c
@@ -139,6 +139,7 @@ BOOL gdi_FillRect(HGDI_DC hdc, const HGDI_RECT rect, HGDI_BRUSH hbr)
 	if (!gdi_ClipCoords(hdc, &nXDest, &nYDest, &nWidth, &nHeight, NULL, NULL))
 		return TRUE;
 
+	const UINT32 bits = GetBitsPerPixel(hdc->format);
 	switch (hbr->style)
 	{
 		case GDI_BS_SOLID:
@@ -149,7 +150,7 @@ BOOL gdi_FillRect(HGDI_DC hdc, const HGDI_RECT rect, HGDI_BRUSH hbr)
 				BYTE* dstp = gdi_get_bitmap_pointer(hdc, nXDest + x, nYDest);
 
 				if (dstp)
-					WriteColor(dstp, hdc->format, color);
+					WriteColor(dstp, hdc->format, bits, color);
 			}
 
 			srcp = gdi_get_bitmap_pointer(hdc, nXDest, nYDest);
@@ -168,6 +169,7 @@ BOOL gdi_FillRect(HGDI_DC hdc, const HGDI_RECT rect, HGDI_BRUSH hbr)
 			monochrome = (hbr->pattern->format == PIXEL_FORMAT_MONO);
 			formatSize = GetBytesPerPixel(hbr->pattern->format);
 
+			const UINT32 patternbits = GetBitsPerPixel(hbr->pattern->format);
 			for (y = 0; y < nHeight; y++)
 			{
 				for (x = 0; x < nWidth; x++)
@@ -190,13 +192,13 @@ BOOL gdi_FillRect(HGDI_DC hdc, const HGDI_RECT rect, HGDI_BRUSH hbr)
 					}
 					else
 					{
-						dstColor = ReadColor(patp, hbr->pattern->format);
+						dstColor = ReadColor(patp, hbr->pattern->format, patternbits);
 						dstColor =
 						    FreeRDPConvertColor(dstColor, hbr->pattern->format, hdc->format, NULL);
 					}
 
 					if (dstp)
-						WriteColor(dstp, hdc->format, dstColor);
+						WriteColor(dstp, hdc->format, bits, dstColor);
 				}
 			}
 
@@ -249,6 +251,7 @@ BOOL gdi_Rectangle(HGDI_DC hdc, INT32 nXDst, INT32 nYDst, INT32 nWidth, INT32 nH
 	if (!gdi_ClipCoords(hdc, &nXDst, &nYDst, &nWidth, &nHeight, NULL, NULL))
 		return TRUE;
 
+	const UINT32 bits = GetBitsPerPixel(hdc->format);
 	color = hdc->textColor;
 
 	for (y = 0; y < nHeight; y++)
@@ -257,10 +260,10 @@ BOOL gdi_Rectangle(HGDI_DC hdc, INT32 nXDst, INT32 nYDst, INT32 nWidth, INT32 nH
 		BYTE* dstRight = gdi_get_bitmap_pointer(hdc, nXDst + nWidth - 1, nYDst + y);
 
 		if (dstLeft)
-			WriteColor(dstLeft, hdc->format, color);
+			WriteColor(dstLeft, hdc->format, bits, color);
 
 		if (dstRight)
-			WriteColor(dstRight, hdc->format, color);
+			WriteColor(dstRight, hdc->format, bits, color);
 	}
 
 	for (x = 0; x < nWidth; x++)
@@ -269,10 +272,10 @@ BOOL gdi_Rectangle(HGDI_DC hdc, INT32 nXDst, INT32 nYDst, INT32 nWidth, INT32 nH
 		BYTE* dstBottom = gdi_get_bitmap_pointer(hdc, nXDst + x, nYDst + nHeight - 1);
 
 		if (dstTop)
-			WriteColor(dstTop, hdc->format, color);
+			WriteColor(dstTop, hdc->format, bits, color);
 
 		if (dstBottom)
-			WriteColor(dstBottom, hdc->format, color);
+			WriteColor(dstBottom, hdc->format, bits, color);
 	}
 
 	return FALSE;

--- a/libfreerdp/gdi/test/TestGdiCreate.c
+++ b/libfreerdp/gdi/test/TestGdiCreate.c
@@ -357,6 +357,7 @@ static BOOL test_gdi_GetPixel(void)
 		gdi_SelectObject(hdc, (HGDIOBJECT)hBitmap);
 		bpp = GetBytesPerPixel(hBitmap->format);
 
+		const UINT32 bits = GetBitsPerPixel(hBitmap->format);
 		for (i = 0; i < height; i++)
 		{
 			for (j = 0; j < width; j++)
@@ -364,7 +365,7 @@ static BOOL test_gdi_GetPixel(void)
 				UINT32 pixel;
 				const UINT32 color =
 				    FreeRDPGetColor(hBitmap->format, rand(), rand(), rand(), rand());
-				WriteColor(&hBitmap->data[i * hBitmap->scanline + j * bpp], hBitmap->format, color);
+				WriteColor(&hBitmap->data[i * hBitmap->scanline + j * bpp], hBitmap->format, bits, color);
 				pixel = gdi_GetPixel(hdc, j, i);
 
 				if (pixel != color)
@@ -392,7 +393,7 @@ static BOOL test_gdi_SetPixel(void)
 
 	for (x = 0; x < colorFormatCount; x++)
 	{
-		UINT32 i, j, bpp;
+		UINT32 i, j, bpp, bits;
 		HGDI_DC hdc;
 		UINT32 width = 128;
 		UINT32 height = 64;
@@ -408,6 +409,7 @@ static BOOL test_gdi_SetPixel(void)
 		hBitmap = gdi_CreateCompatibleBitmap(hdc, width, height);
 		gdi_SelectObject(hdc, (HGDIOBJECT)hBitmap);
 		bpp = GetBytesPerPixel(hBitmap->format);
+		bits = GetBitsPerPixel(hBitmap->format);
 
 		for (i = 0; i < height; i++)
 		{
@@ -417,7 +419,7 @@ static BOOL test_gdi_SetPixel(void)
 				const UINT32 color =
 				    FreeRDPGetColor(hBitmap->format, rand(), rand(), rand(), rand());
 				gdi_SetPixel(hdc, j, i, color);
-				pixel = ReadColor(&hBitmap->data[i * hBitmap->scanline + j * bpp], hBitmap->format);
+				pixel = ReadColor(&hBitmap->data[i * hBitmap->scanline + j * bpp], hBitmap->format, bits);
 
 				if (pixel != color)
 				{

--- a/libfreerdp/gdi/test/helpers.c
+++ b/libfreerdp/gdi/test/helpers.c
@@ -97,14 +97,16 @@ static BOOL CompareBitmaps(HGDI_BITMAP hBmp1, HGDI_BITMAP hBmp2, const gdiPalett
 	UINT32 minw = (hBmp1->width < hBmp2->width) ? hBmp1->width : hBmp2->width;
 	UINT32 minh = (hBmp1->height < hBmp2->height) ? hBmp1->height : hBmp2->height;
 	const UINT32 colorABytes = GetBytesPerPixel(hBmp1->format);
+	const UINT32 colorABits = GetBitsPerPixel(hBmp1->format);
 	const UINT32 colorBBytes = GetBytesPerPixel(hBmp2->format);
+	const UINT32 colorBBits = GetBitsPerPixel(hBmp2->format);
 
 	for (y = 0; y < minh; y++)
 	{
 		for (x = 0; x < minw; x++)
 		{
-			colorA = ReadColor(p1, hBmp1->format);
-			colorB = ReadColor(p2, hBmp2->format);
+			colorA = ReadColor(p1, hBmp1->format, colorABits);
+			colorB = ReadColor(p2, hBmp2->format, colorBBits);
 			p1 += colorABytes;
 			p2 += colorBBytes;
 

--- a/libfreerdp/gdi/test/helpers.c
+++ b/libfreerdp/gdi/test/helpers.c
@@ -84,7 +84,7 @@ static void test_dump_data(unsigned char* p, int len, int width, const char* nam
 
 void test_dump_bitmap(HGDI_BITMAP hBmp, const char* name)
 {
-	UINT32 stride = hBmp->width * GetBytesPerPixel(hBmp->format);
+	const UINT32 stride = hBmp->width * GetBytesPerPixel(hBmp->format);
 	test_dump_data(hBmp->data, hBmp->height * stride, stride, name);
 }
 
@@ -96,6 +96,8 @@ static BOOL CompareBitmaps(HGDI_BITMAP hBmp1, HGDI_BITMAP hBmp2, const gdiPalett
 	UINT32 colorA, colorB;
 	UINT32 minw = (hBmp1->width < hBmp2->width) ? hBmp1->width : hBmp2->width;
 	UINT32 minh = (hBmp1->height < hBmp2->height) ? hBmp1->height : hBmp2->height;
+	const UINT32 colorABytes = GetBytesPerPixel(hBmp1->format);
+	const UINT32 colorBBytes = GetBytesPerPixel(hBmp2->format);
 
 	for (y = 0; y < minh; y++)
 	{
@@ -103,8 +105,8 @@ static BOOL CompareBitmaps(HGDI_BITMAP hBmp1, HGDI_BITMAP hBmp2, const gdiPalett
 		{
 			colorA = ReadColor(p1, hBmp1->format);
 			colorB = ReadColor(p2, hBmp2->format);
-			p1 += GetBytesPerPixel(hBmp1->format);
-			p2 += GetBytesPerPixel(hBmp2->format);
+			p1 += colorABytes;
+			p2 += colorBBytes;
 
 			if (hBmp1->format != hBmp2->format)
 				colorB = FreeRDPConvertColor(colorB, hBmp2->format, hBmp1->format, palette);

--- a/libfreerdp/primitives/prim_YUV.c
+++ b/libfreerdp/primitives/prim_YUV.c
@@ -613,6 +613,7 @@ static pstatus_t general_RGBToYUV444_8u_P3AC4R(const BYTE* pSrc, UINT32 SrcForma
                                                UINT32 dstStep[3], const prim_size_t* roi)
 {
 	const UINT32 bpp = GetBytesPerPixel(SrcFormat);
+	const UINT32 bits = GetBitsPerPixel(SrcFormat);
 	UINT32 x, y;
 	UINT32 nWidth, nHeight;
 	nWidth = roi->width;
@@ -628,7 +629,7 @@ static pstatus_t general_RGBToYUV444_8u_P3AC4R(const BYTE* pSrc, UINT32 SrcForma
 		for (x = 0; x < nWidth; x++)
 		{
 			BYTE B, G, R;
-			const UINT32 color = ReadColor(&pRGB[x * bpp], SrcFormat);
+			const UINT32 color = ReadColor(&pRGB[x * bpp], SrcFormat, bits);
 			SplitColor(color, SrcFormat, &R, &G, &B, NULL, NULL);
 			pY[x] = RGB2Y(R, G, B);
 			pU[x] = RGB2U(R, G, B);
@@ -776,6 +777,7 @@ static INLINE pstatus_t general_RGBToYUV420_ANY(const BYTE* pSrc, UINT32 srcForm
                                                 const prim_size_t* roi)
 {
 	const UINT32 bpp = GetBytesPerPixel(srcFormat);
+	const UINT32 bits = GetBitsPerPixel(srcFormat);
 	UINT32 x, y, i;
 	size_t x1 = 0, x2 = bpp, x3 = srcStep, x4 = srcStep + bpp;
 	size_t y1 = 0, y2 = 1, y3 = dstStep[0], y4 = dstStep[0] + 1;
@@ -795,7 +797,7 @@ static INLINE pstatus_t general_RGBToYUV420_ANY(const BYTE* pSrc, UINT32 srcForm
 			INT32 Ra, Ga, Ba;
 			UINT32 color;
 			/* row 1, pixel 1 */
-			color = ReadColor(src + x1, srcFormat);
+			color = ReadColor(src + x1, srcFormat, bits);
 			SplitColor(color, srcFormat, &R, &G, &B, NULL, NULL);
 			Ra = R;
 			Ga = G;
@@ -805,7 +807,7 @@ static INLINE pstatus_t general_RGBToYUV420_ANY(const BYTE* pSrc, UINT32 srcForm
 			if (x < max_x)
 			{
 				/* row 1, pixel 2 */
-				color = ReadColor(src + x2, srcFormat);
+				color = ReadColor(src + x2, srcFormat, bits);
 				SplitColor(color, srcFormat, &R, &G, &B, NULL, NULL);
 				Ra += R;
 				Ga += G;
@@ -816,7 +818,7 @@ static INLINE pstatus_t general_RGBToYUV420_ANY(const BYTE* pSrc, UINT32 srcForm
 			if (y < max_y)
 			{
 				/* row 2, pixel 1 */
-				color = ReadColor(src + x3, srcFormat);
+				color = ReadColor(src + x3, srcFormat, bits);
 				SplitColor(color, srcFormat, &R, &G, &B, NULL, NULL);
 				Ra += R;
 				Ga += G;
@@ -826,7 +828,7 @@ static INLINE pstatus_t general_RGBToYUV420_ANY(const BYTE* pSrc, UINT32 srcForm
 				if (x < max_x)
 				{
 					/* row 2, pixel 2 */
-					color = ReadColor(src + x4, srcFormat);
+					color = ReadColor(src + x4, srcFormat, bits);
 					SplitColor(color, srcFormat, &R, &G, &B, NULL, NULL);
 					Ra += R;
 					Ga += G;
@@ -1135,6 +1137,7 @@ static INLINE void general_RGBToAVC444YUV_ANY_DOUBLE_ROW(const BYTE* srcEven, co
                                                          BYTE* b5, BYTE* b6, BYTE* b7, UINT32 width)
 {
 	const UINT32 bpp = GetBytesPerPixel(srcFormat);
+	const UINT32 bits = GetBitsPerPixel(srcFormat);
 	UINT32 x;
 
 	for (x = 0; x < width; x += 2)
@@ -1145,7 +1148,7 @@ static INLINE void general_RGBToAVC444YUV_ANY_DOUBLE_ROW(const BYTE* srcEven, co
 		/* Read 4 pixels, 2 from even, 2 from odd lines */
 		{
 			BYTE r, g, b;
-			const UINT32 color = ReadColor(srcEven, srcFormat);
+			const UINT32 color = ReadColor(srcEven, srcFormat, bits);
 			srcEven += bpp;
 			SplitColor(color, srcFormat, &r, &g, &b, NULL, NULL);
 			Y1e = Y2e = Y1o = Y2o = RGB2Y(r, g, b);
@@ -1156,7 +1159,7 @@ static INLINE void general_RGBToAVC444YUV_ANY_DOUBLE_ROW(const BYTE* srcEven, co
 		if (!lastX)
 		{
 			BYTE r, g, b;
-			const UINT32 color = ReadColor(srcEven, srcFormat);
+			const UINT32 color = ReadColor(srcEven, srcFormat, bits);
 			srcEven += bpp;
 			SplitColor(color, srcFormat, &r, &g, &b, NULL, NULL);
 			Y2e = RGB2Y(r, g, b);
@@ -1167,7 +1170,7 @@ static INLINE void general_RGBToAVC444YUV_ANY_DOUBLE_ROW(const BYTE* srcEven, co
 		if (b1Odd)
 		{
 			BYTE r, g, b;
-			const UINT32 color = ReadColor(srcOdd, srcFormat);
+			const UINT32 color = ReadColor(srcOdd, srcFormat, bits);
 			srcOdd += bpp;
 			SplitColor(color, srcFormat, &r, &g, &b, NULL, NULL);
 			Y1o = Y2o = RGB2Y(r, g, b);
@@ -1178,7 +1181,7 @@ static INLINE void general_RGBToAVC444YUV_ANY_DOUBLE_ROW(const BYTE* srcEven, co
 		if (b1Odd && !lastX)
 		{
 			BYTE r, g, b;
-			const UINT32 color = ReadColor(srcOdd, srcFormat);
+			const UINT32 color = ReadColor(srcOdd, srcFormat, bits);
 			srcOdd += bpp;
 			SplitColor(color, srcFormat, &r, &g, &b, NULL, NULL);
 			Y2o = RGB2Y(r, g, b);
@@ -1362,6 +1365,7 @@ static INLINE void general_RGBToAVC444YUVv2_ANY_DOUBLE_ROW(
 {
 	UINT32 x;
 	const UINT32 bpp = GetBytesPerPixel(srcFormat);
+	const UINT32 bits = GetBitsPerPixel(srcFormat);
 
 	for (x = 0; x < width; x += 2)
 	{
@@ -1371,7 +1375,7 @@ static INLINE void general_RGBToAVC444YUVv2_ANY_DOUBLE_ROW(
 		BYTE Yd, Ud, Vd;
 		{
 			BYTE b, g, r;
-			const UINT32 color = ReadColor(srcEven, srcFormat);
+			const UINT32 color = ReadColor(srcEven, srcFormat, bits);
 			srcEven += bpp;
 			SplitColor(color, srcFormat, &r, &g, &b, NULL, NULL);
 			Ya = RGB2Y(r, g, b);
@@ -1382,7 +1386,7 @@ static INLINE void general_RGBToAVC444YUVv2_ANY_DOUBLE_ROW(
 		if (x < width - 1)
 		{
 			BYTE b, g, r;
-			const UINT32 color = ReadColor(srcEven, srcFormat);
+			const UINT32 color = ReadColor(srcEven, srcFormat, bits);
 			srcEven += bpp;
 			SplitColor(color, srcFormat, &r, &g, &b, NULL, NULL);
 			Yb = RGB2Y(r, g, b);
@@ -1399,7 +1403,7 @@ static INLINE void general_RGBToAVC444YUVv2_ANY_DOUBLE_ROW(
 		if (srcOdd)
 		{
 			BYTE b, g, r;
-			const UINT32 color = ReadColor(srcOdd, srcFormat);
+			const UINT32 color = ReadColor(srcOdd, srcFormat, bits);
 			srcOdd += bpp;
 			SplitColor(color, srcFormat, &r, &g, &b, NULL, NULL);
 			Yc = RGB2Y(r, g, b);
@@ -1416,7 +1420,7 @@ static INLINE void general_RGBToAVC444YUVv2_ANY_DOUBLE_ROW(
 		if (srcOdd && (x < width - 1))
 		{
 			BYTE b, g, r;
-			const UINT32 color = ReadColor(srcOdd, srcFormat);
+			const UINT32 color = ReadColor(srcOdd, srcFormat, bits);
 			srcOdd += bpp;
 			SplitColor(color, srcFormat, &r, &g, &b, NULL, NULL);
 			Yd = RGB2Y(r, g, b);

--- a/libfreerdp/primitives/prim_internal.h
+++ b/libfreerdp/primitives/prim_internal.h
@@ -99,7 +99,7 @@ static INLINE BYTE* writePixelGeneric(BYTE* dst, DWORD formatSize, UINT32 format
                                       BYTE B, BYTE A)
 {
 	UINT32 color = FreeRDPGetColor(format, R, G, B, A);
-	WriteColor(dst, format, color);
+	WriteColor(dst, format, GetBitsPerPixel(format), color);
 	return dst + formatSize;
 }
 

--- a/libfreerdp/primitives/test/TestPrimitivesColors.c
+++ b/libfreerdp/primitives/test/TestPrimitivesColors.c
@@ -34,6 +34,7 @@ static BOOL test_RGBToRGB_16s8u_P3AC4R_func(prim_size_t roi, DWORD DstFormat)
 	const INT16* ptrs[3];
 	const UINT32 rgbStride = roi.width * 2;
 	const UINT32 dstStride = roi.width * 4;
+	const UINT32 bits = GetBitsPerPixel(DstFormat);
 	PROFILER_DEFINE(genericProf)
 	PROFILER_DEFINE(optProf)
 	PROFILER_CREATE(genericProf, "RGBToRGB_16s8u_P3AC4R-GENERIC")
@@ -88,8 +89,8 @@ static BOOL test_RGBToRGB_16s8u_P3AC4R_func(prim_size_t roi, DWORD DstFormat)
 	{
 		for (i = 0; i < roi.width * roi.height; ++i)
 		{
-			const UINT32 o1 = ReadColor(out1 + 4 * i, DstFormat);
-			const UINT32 o2 = ReadColor(out2 + 4 * i, DstFormat);
+			const UINT32 o1 = ReadColor(out1 + 4 * i, DstFormat, bits);
+			const UINT32 o2 = ReadColor(out2 + 4 * i, DstFormat, bits);
 
 			if (o1 != o2)
 			{

--- a/libfreerdp/primitives/test/TestPrimitivesYCoCg.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYCoCg.c
@@ -51,6 +51,7 @@ static BOOL test_YCoCgRToRGB_8u_AC4R_func(UINT32 width, UINT32 height)
 	{
 		const UINT32 format = formats[x];
 		const UINT32 dstStride = width * GetBytesPerPixel(format);
+		const UINT32 bits = GetBitsPerPixel(format);
 		const char* formatName = FreeRDPGetColorFormatName(format);
 		PROFILER_CREATE(genericProf, "YCoCgRToRGB_8u_AC4R-GENERIC")
 		PROFILER_CREATE(optProf, "YCoCgRToRGB_8u_AC4R-OPT")
@@ -74,8 +75,8 @@ static BOOL test_YCoCgRToRGB_8u_AC4R_func(UINT32 width, UINT32 height)
 		{
 			for (i = 0; i < width * height; ++i)
 			{
-				const UINT32 c = ReadColor(out_c + 4 * i, format);
-				const UINT32 sse = ReadColor(out_sse + 4 * i, format);
+				const UINT32 c = ReadColor(out_c + 4 * i, format, bits);
+				const UINT32 sse = ReadColor(out_sse + 4 * i, format, bits);
 
 				if (c != sse)
 				{

--- a/libfreerdp/primitives/test/TestPrimitivesYUV.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYUV.c
@@ -39,6 +39,7 @@ static BOOL similarRGB(const BYTE* src, const BYTE* dst, size_t size, UINT32 for
 {
 	size_t x;
 	const UINT32 bpp = GetBytesPerPixel(format);
+	const UINT32 bits = GetBitsPerPixel(format);
 
 	for (x = 0; x < size; x++)
 	{
@@ -46,8 +47,8 @@ static BOOL similarRGB(const BYTE* src, const BYTE* dst, size_t size, UINT32 for
 		UINT32 sColor, dColor;
 		BYTE sR, sG, sB, sA;
 		BYTE dR, dG, dB, dA;
-		sColor = ReadColor(src, format);
-		dColor = ReadColor(dst, format);
+		sColor = ReadColor(src, format, bits);
+		dColor = ReadColor(dst, format, bits);
 		src += bpp;
 		dst += bpp;
 		SplitColor(sColor, format, &sR, &sG, &sB, &sA, NULL);

--- a/server/shadow/Mac/mac_shadow.c
+++ b/server/shadow/Mac/mac_shadow.c
@@ -350,7 +350,7 @@ static int freerdp_image_copy_from_retina(BYTE* pDstData, DWORD DstFormat, int n
 			R = pSrcPixel[2] + pSrcPixel[6] + pSrcPixel[nSrcStep + 2] + pSrcPixel[nSrcStep + 6];
 			pSrcPixel += 8;
 			color = FreeRDPGetColor(DstFormat, R >> 2, G >> 2, B >> 2, 0xFF);
-			WriteColor(pDstPixel, DstFormat, color);
+			WriteColor(pDstPixel, color, dstBitsPerPixel, color);
 			pDstPixel += dstBytesPerPixel;
 		}
 


### PR DESCRIPTION
This PR has 2 commits.
The first commit caches the return value of GetBytesPerPixel when used inside loops.
This is already used in code as seen in:
- libfreerdp/primitives/prim_YUV.c
- libfreerdp/primitives/prim_colors.c
- libfreerdp/primitives/prim_YCoCg.c
- libfreerdp/primitives/prim_YCoCg_opt.c
- libfreerdp/codec/rfx.c
- libfreerdp/gdi/gfx.c
- libfreerdp/gdi/shape.c
- server/shadow/Mac/mac_shadow.c

I have only added the same logic to other places.
The second commit removes the call to GetBitsPerPixel from ReadColor() and WriteColor().
These functions (ReadColor() and WriteColor()) are called several times inside loops leading to repetitive calls to GetBitsPerPixel() with always the same result.
This image show the cost of GetBitsPerPixel().
![cost_of_getbitsperpixel](https://user-images.githubusercontent.com/1659082/80138167-ca9ccf00-857a-11ea-8061-fe0679f4e216.png)
To verify the optimization, I create 4 new functions: ReadColor_orig, ReadColor_opt, WriteColor_orig and WriteColor_opt.
The patch with this code is https://github.com/rgfernandes/FreeRDP/commit/1f895172c0a776e7164dcec306beb0b9e428f6bb
The result is shown in this picture.
![read_writecolor](https://user-images.githubusercontent.com/1659082/80138313-fddf5e00-857a-11ea-98c1-c213d47759b4.png)

The 2 optimized versions don't call GetBitsPerPixel() repeatedly anymore and represents a speedup of ~20%.