### PR TITLE
Improve urbdrc device registering via /usb:id and addr

### DIFF
--- a/channels/urbdrc/client/libusb/libusb_udevman.c
+++ b/channels/urbdrc/client/libusb/libusb_udevman.c
@@ -313,6 +313,9 @@ static BOOL udevman_unregister_all_udevices(IUDEVMAN* idevman)
 	if (!idevman)
 		return FALSE;
 
+	if (!udevman->head)
+		return TRUE;
+
 	idevman->loading_lock(idevman);
 	idevman->rewind(idevman);
 
@@ -430,11 +433,17 @@ static void udevman_free(IUDEVMAN* idevman)
 		return;
 
 	udevman->running = FALSE;
-	WaitForSingleObject(udevman->thread, INFINITE);
+	if (udevman->thread)
+	{
+		WaitForSingleObject(udevman->thread, INFINITE);
+		CloseHandle(udevman->thread);
+	}
 
 	udevman_unregister_all_udevices(idevman);
-	CloseHandle(udevman->devman_loading);
-	CloseHandle(udevman->thread);
+
+	if (udevman->devman_loading)
+		CloseHandle(udevman->devman_loading);
+
 	libusb_exit(udevman->context);
 
 	ArrayList_Free(udevman->hotplug_vid_pids);

--- a/channels/urbdrc/client/urbdrc_main.c
+++ b/channels/urbdrc/client/urbdrc_main.c
@@ -663,7 +663,9 @@ static UINT urbdrc_on_new_channel_connection(IWTSListenerCallback* pListenerCall
  */
 static UINT urbdrc_plugin_initialize(IWTSPlugin* pPlugin, IWTSVirtualChannelManager* pChannelMgr)
 {
+	UINT status;
 	URBDRC_PLUGIN* urbdrc = (URBDRC_PLUGIN*)pPlugin;
+	IUDEVMAN* udevman = urbdrc->udevman;
 	char channelName[sizeof(URBDRC_CHANNEL_NAME)] = { URBDRC_CHANNEL_NAME };
 
 	if (!urbdrc)
@@ -681,8 +683,15 @@ static UINT urbdrc_plugin_initialize(IWTSPlugin* pPlugin, IWTSVirtualChannelMana
 
 	/* [MS-RDPEUSB] 2.1 Transport defines the channel name in uppercase letters */
 	CharUpperA(channelName);
-	return pChannelMgr->CreateListener(pChannelMgr, channelName, 0,
-	                                   &urbdrc->listener_callback->iface, NULL);
+	status = pChannelMgr->CreateListener(pChannelMgr, channelName, 0,
+	                                     &urbdrc->listener_callback->iface, NULL);
+	if (status != CHANNEL_RC_OK)
+		return status;
+
+	if (udevman->listener_created_callback)
+		return udevman->listener_created_callback(udevman);
+
+	return CHANNEL_RC_OK;
 }
 
 /**

--- a/channels/urbdrc/client/urbdrc_main.h
+++ b/channels/urbdrc/client/urbdrc_main.h
@@ -216,6 +216,7 @@ struct _IUDEVMAN
 	void (*loading_lock)(IUDEVMAN* idevman);
 	void (*loading_unlock)(IUDEVMAN* idevman);
 	BOOL (*initialize)(IUDEVMAN* idevman, UINT32 channelId);
+	UINT (*listener_created_callback)(IUDEVMAN* idevman);
 
 	IWTSPlugin* plugin;
 	UINT32 controlChannelId;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -454,7 +454,7 @@ BOOL freerdp_client_print_command_line_help_ex(int argc, char** argv,
 	printf("\n");
 	printf("Multimedia Redirection: /video\n");
 #ifdef CHANNEL_URBDRC_CLIENT
-	printf("USB Device Redirection: /usb:id,dev:054c:0268\n");
+	printf("USB Device Redirection: /usb:id:054c:0268#4669:6e6b,addr:04:0c\n");
 #endif
 	printf("\n");
 	printf("For Gateways, the https_proxy environment variable is respected:\n");

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -349,8 +349,9 @@ static const COMMAND_LINE_ARGUMENT_A args[] = {
 	{ "unmap-buttons", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
 	  "Let server see real physical pointer button" },
 #ifdef CHANNEL_URBDRC_CLIENT
-	{ "usb", COMMAND_LINE_VALUE_REQUIRED, "[dbg,][dev:<dev>,][id|addr,][auto]", NULL, NULL, -1,
-	  NULL, "Redirect USB device" },
+	{ "usb", COMMAND_LINE_VALUE_REQUIRED,
+	  "[dbg,][id:<vid>:<pid>#...,][addr:<bus>:<addr>#...,][auto]", NULL, NULL, -1, NULL,
+	  "Redirect USB device" },
 #endif
 	{ "v", COMMAND_LINE_VALUE_REQUIRED, "<server>[:port]", NULL, NULL, -1, NULL,
 	  "Server hostname" },


### PR DESCRIPTION
This pr adds 3 improvements to the urbdrc /usb:id, addr  and dev  command line options:

1. It fixes them. Currently they don’t work, because the devices are attempted to be added before the urbdrc addin is initialized, which fails silently. A function is added to the `IUDEVMAN` struct, that gets called after initialization. Parsing of the device option is done there. (513cfc1)
2. It adds hotplug to the `/usb:id,dev` option. Devices, that are connected at runtime, are added when they match a specified vid+pid-pair. (5724ffc)
3. It adds the ability to specify devices via vid+pid-pairs and bus+addr-pairs simultaneously. This is done by using the id and addr option directly: `/usb:id:0123:4567#89ab:cdef,addr:01:02#03:04`. The dev option can still be used like it could before. (0155a5b)