### PR TITLE
wlfreerdp/cliprdr: Initialize pointer before use

### DIFF
--- a/client/Wayland/wlf_cliprdr.c
+++ b/client/Wayland/wlf_cliprdr.c
@@ -624,6 +624,7 @@ wlf_cliprdr_server_format_data_request(CliprdrClientContext* context,
 				rc = ERROR_INTERNAL_ERROR;
 			else
 			{
+				cdata = NULL;
 				cnv = ConvertToUnicode(CP_UTF8, 0, (LPCSTR)data, (int)size, &cdata, 0);
 				free(data);
 				data = NULL;


### PR DESCRIPTION
In `wlf_cliprdr_server_format_data_request()` `ConvertToUnicode()` may return 0
while not allocating memory for `cdata` and not setting `cdata` to a valid
address. In this case, `data` points to a random address.

Settting `cdata` to NULL before calling `ConvertToUnicode()` fixes this issues.

Asan error message:
```
==310400==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x7fffe23055c0 in thread T11
    #0 0x7ffff7697277 in __interceptor_free (/lib/x86_64-linux-gnu/libasan.so.5+0x107277)
    #1 0x55555556a224 in wlf_cliprdr_server_format_data_request ./client/Wayland/wlf_cliprdr.c:652
    #2 0x7ffff73cf64c in cliprdr_process_format_data_request ./channels/cliprdr/client/cliprdr_format.c:136
    #3 0x7ffff73c62c7 in cliprdr_order_recv ./channels/cliprdr/client/cliprdr_main.c:477
    #4 0x7ffff73c8775 in cliprdr_virtual_channel_client_thread ./channels/cliprdr/client/cliprdr_main.c:920
    #5 0x7ffff6b7540c in thread_launcher ./winpr/libwinpr/thread/thread.c:327
    #6 0x7ffff67f1f26 in start_thread /build/glibc-WZtAaN/glibc-2.30/nptl/pthread_create.c:479
    #7 0x7ffff69172ee in __clone (/lib/x86_64-linux-gnu/libc.so.6+0xfd2ee)

Address 0x7fffe23055c0 is located in stack of thread T11 at offset 48 in frame
    #0 0x7ffff73cf2b5 in cliprdr_process_format_data_request ./channels/cliprdr/client/cliprdr_format.c:115

SUMMARY: AddressSanitizer: bad-free (/lib/x86_64-linux-gnu/libasan.so.5+0x107277) in __interceptor_free
==310400==ABORTING
```