### PR TITLE
libuwac/window: Fix memory leak / SIGBUS

### DIFF
--- a/uwac/libuwac/uwac-priv.h
+++ b/uwac/libuwac/uwac-priv.h
@@ -218,6 +218,7 @@ struct uwac_buffer
 #endif
 	struct wl_buffer* wayland_buffer;
 	void* data;
+	size_t size;
 };
 typedef struct uwac_buffer UwacBuffer;
 


### PR DESCRIPTION
`UwacWindowShmAllocBuffers()` allocates memory with `mmap` and never frees it
resulting in SIGBUS errors and running out of memory after some time.

Adding a corresponding `munmap` fixes this issue.

Note that the bus error ist usually triggered later while accessing the mmaped memory, e.g.
```
#0  __memmove_sse2_unaligned_erms () at ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:419
#1  0x00007ffff7626e46 in  () at /lib/x86_64-linux-gnu/libasan.so.5
#2  0x000055555555fa2f in wlf_copy_image (src=0x7fffd0fdb820, srcStride=15360, srcWidth=3840, srcHeight=2129, dst=0x7ffec1da9000, dstStride=15360, dstWidth=3840, dstHeight=2129, area=0x7fffffffe120, scale=0) at ./client/Wayland/wlfreerdp.c:671
#3  0x000055555555c487 in wl_update_buffer (context_w=0x619000001980, ix=0, iy=0, iw=3840, ih=2129) at ./client/Wayland/wlfreerdp.c:103
#4  0x000055555555cce5 in wl_refresh_display (context=0x619000001980) at ./client/Wayland/wlfreerdp.c:154
#5  0x000055555555e21f in handle_uwac_events (instance=0x616000000380, display=0x612000001b40) at ./client/Wayland/wlfreerdp.c:391
#6  0x000055555555e858 in wlfreerdp_run (instance=0x616000000380) at ./client/Wayland/wlfreerdp.c:468
#7  0x000055555555f6b8 in main (argc=15, argv=0x7fffffffe738) at ./client/Wayland/wlfreerdp.c:633
```
