### PR TITLE
Fixed #6087: Inconsistend scroll on wayland

### DIFF
--- a/client/Wayland/wlf_input.c
+++ b/client/Wayland/wlf_input.c
@@ -171,9 +171,19 @@ BOOL wlf_handle_pointer_axis(freerdp* instance, const UwacPointerAxisEvent* ev)
 			return FALSE;
 	}
 
-	step = (uint32_t)abs(direction);
-	if (step > WheelRotationMask)
-		step = WheelRotationMask;
+	/* Wheel rotation steps:
+	 *
+	 * positive: 0 ... 0xFF  -> slow ... fast
+	 * negative: 0 ... 0xFF  -> fast ... slow
+	 */
+	step = abs(direction);
+	if (step > 0xFF)
+		step = 0xFF;
+
+	/* Negative rotation, so count down steps from top */
+	if (flags & PTR_FLAGS_WHEEL_NEGATIVE)
+		step = 0xFF - step;
+
 	flags |= step;
 
 	return freerdp_input_send_mouse_event(input, flags, (UINT16)x, (UINT16)y);


### PR DESCRIPTION
Thanks to @yol and @SaschaWessel a bug in scroll step conversion
was uncovered. The RDP value ranges are inverted when scrolling
in negative direction.