### PR TITLE
Fixed copy paste error in MessagePipe.c

### DIFF
--- a/winpr/libwinpr/utils/collections/MessagePipe.c
+++ b/winpr/libwinpr/utils/collections/MessagePipe.c
@@ -58,7 +58,7 @@ wMessagePipe* MessagePipe_New()
 		goto error_in;
 
 	pipe->Out = MessageQueue_New(NULL);
-	if (!pipe->In)
+	if (!pipe->Out)
 		goto error_out;
 
 	return pipe;


### PR DESCRIPTION
`!pipe->In` was checked twice but `!pipe->Out` zero times