### PR TITLE
Don't allow to overflow dev_array array

### DIFF
--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -670,7 +670,7 @@ static UINT handle_hotplug(rdpdrPlugin* rdpdr)
 		if (!path)
 			continue;
 		/* copy hotpluged device mount point to the dev_array */
-		if (isAutomountLocation(path) && (size <= MAX_USB_DEVICES))
+		if (isAutomountLocation(path) && (size < MAX_USB_DEVICES))
 		{
 			dev_array[size].path = _strdup(path);
 			dev_array[size++].to_add = TRUE;


### PR DESCRIPTION
dev_array have 100 elements and size may be 100 so dev_array[100] will use invalid memory