### PR TITLE
Fixed #6162: Clipboard temporary path length limit

### DIFF
--- a/channels/cliprdr/client/cliprdr_main.c
+++ b/channels/cliprdr/client/cliprdr_main.c
@@ -572,7 +572,7 @@ static UINT cliprdr_temp_directory(CliprdrClientContext* context,
 	wStream* s;
 	WCHAR* wszTempDir = NULL;
 	cliprdrPlugin* cliprdr = (cliprdrPlugin*)context->handle;
-	s = cliprdr_packet_new(CB_TEMP_DIRECTORY, 0, 520 * 2);
+	s = cliprdr_packet_new(CB_TEMP_DIRECTORY, 0, 260 * sizeof(WCHAR));
 
 	if (!s)
 	{
@@ -585,11 +585,13 @@ static UINT cliprdr_temp_directory(CliprdrClientContext* context,
 	if (length < 0)
 		return ERROR_INTERNAL_ERROR;
 
-	if (length > 520)
-		length = 520;
+	/* Path must be 260 UTF16 characters with '\0' termination.
+	 * ensure this here */
+	if (length >= 260)
+		length = 259;
 
-	Stream_Write(s, wszTempDir, (size_t)length * 2);
-	Stream_Zero(s, (520 - (size_t)length) * 2);
+	Stream_Write_UTF16_String(s, wszTempDir, length);
+	Stream_Zero(s, 520 - (length * sizeof(WCHAR)));
 	free(wszTempDir);
 	WLog_Print(cliprdr->log, WLOG_DEBUG, "TempDirectory: %s", tempDirectory->szTempDir);
 	return cliprdr_packet_send(cliprdr, s);

--- a/channels/cliprdr/server/cliprdr_main.c
+++ b/channels/cliprdr/server/cliprdr_main.c
@@ -545,7 +545,7 @@ static UINT cliprdr_server_receive_temporary_directory(CliprdrServerContext* con
 	UINT error = CHANNEL_RC_OK;
 
 	WINPR_UNUSED(header);
-	if ((slength = Stream_GetRemainingLength(s)) < 520)
+	if ((slength = Stream_GetRemainingLength(s)) < 260 * sizeof(WCHAR))
 	{
 		WLog_ERR(TAG, "Stream_GetRemainingLength returned %" PRIuz " but should at least be 520",
 		         slength);
@@ -554,9 +554,9 @@ static UINT cliprdr_server_receive_temporary_directory(CliprdrServerContext* con
 
 	wszTempDir = (WCHAR*)Stream_Pointer(s);
 
-	if (wszTempDir[260] != 0)
+	if (wszTempDir[259] != 0)
 	{
-		WLog_ERR(TAG, "wszTempDir[260] was not 0");
+		WLog_ERR(TAG, "wszTempDir[259] was not 0");
 		return ERROR_INVALID_DATA;
 	}
 
@@ -570,10 +570,10 @@ static UINT cliprdr_server_receive_temporary_directory(CliprdrServerContext* con
 		return ERROR_INVALID_DATA;
 	}
 
-	length = strnlen(cliprdr->temporaryDirectory, 520);
+	length = strnlen(cliprdr->temporaryDirectory, 260);
 
-	if (length > 519)
-		length = 519;
+	if (length >= 260)
+		length = 259;
 
 	CopyMemory(tempDirectory.szTempDir, cliprdr->temporaryDirectory, length);
 	tempDirectory.szTempDir[length] = '\0';


### PR DESCRIPTION
The limit of clipboard temporary paths is 260 '\0' terminated
wide characters. Fix the checks to enforce that properly.