### PR TITLE
Cleanups

### DIFF
--- a/channels/audin/client/audin_main.c
+++ b/channels/audin/client/audin_main.c
@@ -100,6 +100,8 @@ struct _AUDIN_PLUGIN
 
 	FREERDP_DSP_CONTEXT* dsp_context;
 	wLog* log;
+
+	IWTSListener* listener;
 };
 
 static BOOL audin_process_addin_args(AUDIN_PLUGIN* audin, ADDIN_ARGV* args);
@@ -687,7 +689,7 @@ static UINT audin_plugin_initialize(IWTSPlugin* pPlugin, IWTSVirtualChannelManag
 	audin->listener_callback->plugin = pPlugin;
 	audin->listener_callback->channel_mgr = pChannelMgr;
 	return pChannelMgr->CreateListener(pChannelMgr, "AUDIO_INPUT", 0,
-	                                   &audin->listener_callback->iface, NULL);
+	                                   &audin->listener_callback->iface, &audin->listener);
 }
 
 /**
@@ -709,7 +711,7 @@ static UINT audin_plugin_terminated(IWTSPlugin* pPlugin)
 	{
 		IWTSVirtualChannelManager* mgr = audin->listener_callback->channel_mgr;
 		if (mgr)
-			IFCALL(mgr->DestroyListener, mgr, &audin->iface);
+			IFCALL(mgr->DestroyListener, mgr, audin->listener);
 	}
 	audio_formats_free(audin->fixed_format, 1);
 

--- a/channels/disp/client/disp_main.c
+++ b/channels/disp/client/disp_main.c
@@ -326,7 +326,7 @@ static UINT disp_plugin_terminated(IWTSPlugin* pPlugin)
 	{
 		IWTSVirtualChannelManager* mgr = disp->listener_callback->channel_mgr;
 		if (mgr)
-			IFCALL(mgr->DestroyListener, mgr, &disp->iface);
+			IFCALL(mgr->DestroyListener, mgr, disp->listener);
 	}
 
 	free(disp->listener_callback);

--- a/channels/echo/client/echo_main.c
+++ b/channels/echo/client/echo_main.c
@@ -59,6 +59,7 @@ struct _ECHO_PLUGIN
 	IWTSPlugin iface;
 
 	ECHO_LISTENER_CALLBACK* listener_callback;
+	IWTSListener* listener;
 };
 
 /**
@@ -143,7 +144,7 @@ static UINT echo_plugin_initialize(IWTSPlugin* pPlugin, IWTSVirtualChannelManage
 	echo->listener_callback->channel_mgr = pChannelMgr;
 
 	return pChannelMgr->CreateListener(pChannelMgr, "ECHO", 0, &echo->listener_callback->iface,
-	                                   NULL);
+	                                   &echo->listener);
 }
 
 /**
@@ -158,7 +159,7 @@ static UINT echo_plugin_terminated(IWTSPlugin* pPlugin)
 	{
 		IWTSVirtualChannelManager* mgr = echo->listener_callback->channel_mgr;
 		if (mgr)
-			IFCALL(mgr->DestroyListener, mgr, &echo->iface);
+			IFCALL(mgr->DestroyListener, mgr, echo->listener);
 	}
 	free(echo);
 

--- a/channels/geometry/client/geometry_main.c
+++ b/channels/geometry/client/geometry_main.c
@@ -431,7 +431,7 @@ static UINT geometry_plugin_terminated(IWTSPlugin* pPlugin)
 	{
 		IWTSVirtualChannelManager* mgr = geometry->listener_callback->channel_mgr;
 		if (mgr)
-			IFCALL(mgr->DestroyListener, mgr, &geometry->iface);
+			IFCALL(mgr->DestroyListener, mgr, geometry->listener);
 	}
 
 	if (context)

--- a/channels/rdpei/client/rdpei_main.c
+++ b/channels/rdpei/client/rdpei_main.c
@@ -601,7 +601,7 @@ static UINT rdpei_plugin_terminated(IWTSPlugin* pPlugin)
 	{
 		IWTSVirtualChannelManager* mgr = rdpei->listener_callback->channel_mgr;
 		if (mgr)
-			IFCALL(mgr->DestroyListener, mgr, &rdpei->iface);
+			IFCALL(mgr->DestroyListener, mgr, rdpei->listener);
 	}
 	free(rdpei->listener_callback);
 	free(rdpei->context);

--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -1916,7 +1916,7 @@ static UINT rdpgfx_plugin_terminated(IWTSPlugin* pPlugin)
 	{
 		IWTSVirtualChannelManager* mgr = gfx->listener_callback->channel_mgr;
 		if (mgr)
-			IFCALL(mgr->DestroyListener, mgr, &gfx->iface);
+			IFCALL(mgr->DestroyListener, mgr, gfx->listener);
 	}
 	rdpgfx_client_context_free(context);
 	return CHANNEL_RC_OK;

--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -1560,7 +1560,7 @@ static UINT rdpsnd_plugin_terminated(IWTSPlugin* pPlugin)
 		{
 			IWTSVirtualChannelManager* mgr = rdpsnd->listener_callback->channel_mgr;
 			if (mgr)
-				IFCALL(mgr->DestroyListener, mgr, &rdpsnd->iface);
+				IFCALL(mgr->DestroyListener, mgr, rdpsnd->listener);
 		}
 		free(rdpsnd->listener_callback);
 		free(rdpsnd->iface.pInterface);

--- a/channels/urbdrc/client/urbdrc_main.c
+++ b/channels/urbdrc/client/urbdrc_main.c
@@ -687,7 +687,7 @@ static UINT urbdrc_plugin_initialize(IWTSPlugin* pPlugin, IWTSVirtualChannelMana
 	/* [MS-RDPEUSB] 2.1 Transport defines the channel name in uppercase letters */
 	CharUpperA(channelName);
 	status = pChannelMgr->CreateListener(pChannelMgr, channelName, 0,
-	                                     &urbdrc->listener_callback->iface, NULL);
+	                                     &urbdrc->listener_callback->iface, &urbdrc->listener);
 	if (status != CHANNEL_RC_OK)
 		return status;
 
@@ -713,7 +713,7 @@ static UINT urbdrc_plugin_terminated(IWTSPlugin* pPlugin)
 	{
 		IWTSVirtualChannelManager* mgr = urbdrc->listener_callback->channel_mgr;
 		if (mgr)
-			IFCALL(mgr->DestroyListener, mgr, &urbdrc->iface);
+			IFCALL(mgr->DestroyListener, mgr, urbdrc->listener);
 	}
 	udevman = urbdrc->udevman;
 

--- a/channels/urbdrc/client/urbdrc_main.h
+++ b/channels/urbdrc/client/urbdrc_main.h
@@ -84,6 +84,7 @@ struct _URBDRC_PLUGIN
 	char* subsystem;
 
 	wLog* log;
+	IWTSListener* listener;
 };
 
 typedef BOOL (*PREGISTERURBDRCSERVICE)(IWTSPlugin* plugin, IUDEVMAN* udevman);

--- a/channels/video/client/video_main.c
+++ b/channels/video/client/video_main.c
@@ -1088,13 +1088,13 @@ static UINT video_plugin_terminated(IWTSPlugin* pPlugin)
 	{
 		IWTSVirtualChannelManager* mgr = video->control_callback->channel_mgr;
 		if (mgr)
-			IFCALL(mgr->DestroyListener, mgr, &video->control_callback->iface);
+			IFCALL(mgr->DestroyListener, mgr, video->controlListener);
 	}
 	if (video->data_callback)
 	{
 		IWTSVirtualChannelManager* mgr = video->data_callback->channel_mgr;
 		if (mgr)
-			IFCALL(mgr->DestroyListener, mgr, &video->data_callback->iface);
+			IFCALL(mgr->DestroyListener, mgr, video->dataListener);
 	}
 
 	if (video->context)

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -394,21 +394,6 @@ extern "C"
 
 	/* StreamPool */
 
-	struct _wStreamPool
-	{
-		int aSize;
-		int aCapacity;
-		wStream** aArray;
-
-		int uSize;
-		int uCapacity;
-		wStream** uArray;
-
-		CRITICAL_SECTION lock;
-		BOOL synchronized;
-		size_t defaultSize;
-	};
-
 	WINPR_API wStream* StreamPool_Take(wStreamPool* pool, size_t size);
 	WINPR_API void StreamPool_Return(wStreamPool* pool, wStream* s);
 
@@ -423,6 +408,8 @@ extern "C"
 
 	WINPR_API wStreamPool* StreamPool_New(BOOL synchronized, size_t defaultSize);
 	WINPR_API void StreamPool_Free(wStreamPool* pool);
+
+	WINPR_API char* StreamPool_GetStatistics(wStreamPool* pool, char* buffer, size_t size);
 
 #ifdef __cplusplus
 }

--- a/winpr/libwinpr/utils/test/TestStreamPool.c
+++ b/winpr/libwinpr/utils/test/TestStreamPool.c
@@ -9,6 +9,7 @@ int TestStreamPool(int argc, char* argv[])
 {
 	wStream* s[5];
 	wStreamPool* pool;
+	char buffer[8192];
 
 	pool = StreamPool_New(TRUE, BUFFER_SIZE);
 
@@ -16,29 +17,29 @@ int TestStreamPool(int argc, char* argv[])
 	s[1] = StreamPool_Take(pool, 0);
 	s[2] = StreamPool_Take(pool, 0);
 
-	printf("StreamPool: aSize: %d uSize: %d\n", pool->aSize, pool->uSize);
+	printf("%s\n", StreamPool_GetStatistics(pool, buffer, sizeof(buffer)));
 
 	Stream_Release(s[0]);
 	Stream_Release(s[1]);
 	Stream_Release(s[2]);
 
-	printf("StreamPool: aSize: %d uSize: %d\n", pool->aSize, pool->uSize);
+	printf("%s\n", StreamPool_GetStatistics(pool, buffer, sizeof(buffer)));
 
 	s[3] = StreamPool_Take(pool, 0);
 	s[4] = StreamPool_Take(pool, 0);
 
-	printf("StreamPool: aSize: %d uSize: %d\n", pool->aSize, pool->uSize);
+	printf("%s\n", StreamPool_GetStatistics(pool, buffer, sizeof(buffer)));
 
 	Stream_Release(s[3]);
 	Stream_Release(s[4]);
 
-	printf("StreamPool: aSize: %d uSize: %d\n", pool->aSize, pool->uSize);
+	printf("%s\n", StreamPool_GetStatistics(pool, buffer, sizeof(buffer)));
 
 	s[2] = StreamPool_Take(pool, 0);
 	s[3] = StreamPool_Take(pool, 0);
 	s[4] = StreamPool_Take(pool, 0);
 
-	printf("StreamPool: aSize: %d uSize: %d\n", pool->aSize, pool->uSize);
+	printf("%s\n", StreamPool_GetStatistics(pool, buffer, sizeof(buffer)));
 
 	Stream_AddRef(s[2]);
 
@@ -61,13 +62,13 @@ int TestStreamPool(int argc, char* argv[])
 	Stream_Release(s[4]);
 	Stream_Release(s[4]);
 
-	printf("StreamPool: aSize: %d uSize: %d\n", pool->aSize, pool->uSize);
+	printf("%s\n", StreamPool_GetStatistics(pool, buffer, sizeof(buffer)));
 
 	s[2] = StreamPool_Take(pool, 0);
 	s[3] = StreamPool_Take(pool, 0);
 	s[4] = StreamPool_Take(pool, 0);
 
-	printf("StreamPool: aSize: %d uSize: %d\n", pool->aSize, pool->uSize);
+	printf("%s\n", StreamPool_GetStatistics(pool, buffer, sizeof(buffer)));
 
 	StreamPool_AddRef(pool, s[2]->buffer + 1024);
 
@@ -78,7 +79,7 @@ int TestStreamPool(int argc, char* argv[])
 	StreamPool_AddRef(pool, s[4]->buffer + 1024 * 2);
 	StreamPool_AddRef(pool, s[4]->buffer + 1024 * 3);
 
-	printf("StreamPool: aSize: %d uSize: %d\n", pool->aSize, pool->uSize);
+	printf("%s\n", StreamPool_GetStatistics(pool, buffer, sizeof(buffer)));
 
 	StreamPool_Release(pool, s[2]->buffer + 2048);
 	StreamPool_Release(pool, s[2]->buffer + 2048 * 2);
@@ -92,7 +93,7 @@ int TestStreamPool(int argc, char* argv[])
 	StreamPool_Release(pool, s[4]->buffer + 2048 * 3);
 	StreamPool_Release(pool, s[4]->buffer + 2048 * 4);
 
-	printf("StreamPool: aSize: %d uSize: %d\n", pool->aSize, pool->uSize);
+	printf("%s\n", StreamPool_GetStatistics(pool, buffer, sizeof(buffer)));
 
 	StreamPool_Free(pool);
 


### PR DESCRIPTION
Follow up to #6173:

* `DestroyListener` was called with wrong arguments
* `dvcman_close_channel` did a bit too eager cleanup, let the listeners live until `dvcman_free` is called
* `StreamPool` refactoring due to issues with cleanup (`AddressSanitizer` did not like that)