### PR TITLE
RFX improvement

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -605,7 +605,7 @@ static UINT rdpgfx_recv_reset_graphics_pdu(RDPGFX_CHANNEL_CALLBACK* callback, wS
 		monitor = &(pdu.monitorDefArray[index]);
 		DEBUG_RDPGFX(gfx->log,
 		             "RecvResetGraphicsPdu: monitor left:%" PRIi32 " top:%" PRIi32 " right:%" PRIi32
-		             " left:%" PRIi32 " flags:0x%" PRIx32 "",
+		             " bottom:%" PRIi32 " flags:0x%" PRIx32 "",
 		             monitor->left, monitor->top, monitor->right, monitor->bottom, monitor->flags);
 	}
 

--- a/libfreerdp/codec/rfx_dwt.c
+++ b/libfreerdp/codec/rfx_dwt.c
@@ -87,26 +87,27 @@ void rfx_dwt_2d_decode_block(INT16* buffer, INT16* idwt, int subband_width)
 	/* Inverse DWT in vertical direction, results are stored in original buffer. */
 	for (x = 0; x < total_width; x++)
 	{
-		/* Even coefficients */
-		for (n = 0; n < subband_width; n++)
+		l = idwt + x;
+		h = idwt + x + subband_width * total_width;
+		dst = buffer + x;
+
+		*dst = *l - ((*h * 2 + 1) >> 1);
+
+		for (n = 1; n < subband_width; n++)
 		{
-			y = n << 1;
-			dst = buffer + y * total_width + x;
-			l = idwt + n * total_width + x;
-			h = l + subband_width * total_width;
-			dst[0] = *l - (((n > 0 ? *(h - total_width) : *h) + (*h) + 1) >> 1);
+			l += total_width;
+			h += total_width;
+
+			/* Even coefficients */
+			dst[2 * total_width] = *l - ((*(h - total_width) + *h + 1) >> 1);
+
+			/* Odd coefficients */
+			dst[total_width] = (*(h - total_width) << 1) + ((*dst + dst[2 * total_width]) >> 1);
+
+			dst += 2 * total_width;
 		}
 
-		/* Odd coefficients */
-		for (n = 0; n < subband_width; n++)
-		{
-			y = n << 1;
-			dst = buffer + y * total_width + x;
-			l = idwt + n * total_width + x;
-			h = l + subband_width * total_width;
-			dst[total_width] =
-			    (*h << 1) + ((dst[0] + dst[n < subband_width - 1 ? 2 * total_width : 0]) >> 1);
-		}
+		dst[total_width] = (*h << 1) + ((*dst * 2) >> 1);
 	}
 }
 


### PR DESCRIPTION
1. Fix typo in GFX logs. The log output had `left` word while the actual value was `bottom`;
2. Improved RFX DWT vertical direction inverse. I combined multiple loops into one since the calculated value of the `even` coefficients can be used in the `odd` coefficients right away without affecting `even` coefficients. I ran the client and everything works fine, moreover, the performance of the inverse was improved about 4x (by quick measurements).