### PR TITLE
Abort on first possible certificate validation error

### DIFF
--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -837,7 +837,7 @@ BOOL x509_verify_certificate(CryptoCert cert, const char* certificate_store_path
 
 	for (i = 0; i < ARRAYSIZE(purposes); i++)
 	{
-		int rc = -1;
+		int err = -1, rc = -1;
 		int purpose = purposes[i];
 		csc = X509_STORE_CTX_new();
 
@@ -850,6 +850,7 @@ BOOL x509_verify_certificate(CryptoCert cert, const char* certificate_store_path
 		X509_STORE_CTX_set_verify_cb(csc, verify_cb);
 
 		rc = X509_verify_cert(csc);
+		err = X509_STORE_CTX_get_error(csc);
 	skip:
 		X509_STORE_CTX_free(csc);
 		if (rc == 1)
@@ -857,6 +858,8 @@ BOOL x509_verify_certificate(CryptoCert cert, const char* certificate_store_path
 			status = TRUE;
 			break;
 		}
+		else if (err != X509_V_ERR_INVALID_PURPOSE)
+			break;
 	}
 
 	X509_STORE_free(cert_ctx);


### PR DESCRIPTION
Only retry certificate validation if the purpose was wrong.