### PR TITLE
winpr/library: Use RTLD_GLOBAL for dlopen

### DIFF
--- a/winpr/libwinpr/library/library.c
+++ b/winpr/libwinpr/library/library.c
@@ -125,7 +125,7 @@ HMODULE LoadLibraryA(LPCSTR lpLibFileName)
 	return hModule;
 #else
 	HMODULE library;
-	library = dlopen(lpLibFileName, RTLD_LOCAL | RTLD_LAZY);
+	library = dlopen(lpLibFileName, RTLD_GLOBAL | RTLD_LAZY);
 
 	if (!library)
 	{


### PR DESCRIPTION
LoadLibraryA implementation uses the RTLD_LOCAL flag for dlopen currently.
This flag doesn't allow the symbols to be used by the subsequently loaded
libraries. This is a problem for the video channel when -DBUILTIN_CHANNELS=OFF
is used as it uses functions from the geometry channel. Let's use RTLD_GLOBAL
instead to prevent "undefined symbol" errors in such cases.

Fixes: https://github.com/FreeRDP/FreeRDP/issues/6236
