### PR TITLE
Configure USB interface only when necessary

### DIFF
--- a/channels/urbdrc/client/libusb/libusb_udevice.c
+++ b/channels/urbdrc/client/libusb/libusb_udevice.c
@@ -465,7 +465,7 @@ static LIBUSB_DEVICE_DESCRIPTOR* udev_new_descript(URBDRC_PLUGIN* urbdrc, LIBUSB
 
 static int libusb_udev_select_interface(IUDEVICE* idev, BYTE InterfaceNumber, BYTE AlternateSetting)
 {
-	int error = 0, diff = 1;
+	int error = 0, diff = 0;
 	UDEVICE* pdev = (UDEVICE*)idev;
 	URBDRC_PLUGIN* urbdrc;
 	MSUSB_CONFIG_DESCRIPTOR* MsConfig;
@@ -480,21 +480,30 @@ static int libusb_udev_select_interface(IUDEVICE* idev, BYTE InterfaceNumber, BY
 	if (MsConfig)
 	{
 		MsInterfaces = MsConfig->MsInterfaces;
-
-		if ((MsInterfaces) && (MsInterfaces[InterfaceNumber]->AlternateSetting == AlternateSetting))
+		if (MsInterfaces)
 		{
-			diff = 0;
+			WLog_Print(urbdrc->log, WLOG_INFO,
+			           "select Interface(%" PRIu8 ") curr AlternateSetting(%" PRIu8
+			           ") new AlternateSetting(" PRIu8 ")",
+			           InterfaceNumber, MsInterfaces[InterfaceNumber]->AlternateSetting,
+			           AlternateSetting);
+
+			if (MsInterfaces[InterfaceNumber]->AlternateSetting != AlternateSetting)
+			{
+				diff = 1;
+			}
 		}
-	}
 
-	if (diff)
-	{
-		error = libusb_set_interface_alt_setting(pdev->libusb_handle, InterfaceNumber,
-		                                         AlternateSetting);
-
-		if (error < 0)
+		if (diff)
 		{
-			WLog_Print(urbdrc->log, WLOG_ERROR, "Set interface altsetting get error num %d", error);
+			error = libusb_set_interface_alt_setting(pdev->libusb_handle, InterfaceNumber,
+			                                         AlternateSetting);
+
+			if (error < 0)
+			{
+				WLog_Print(urbdrc->log, WLOG_ERROR, "Set interface altsetting get error num %d",
+				           error);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR contributes to solving #6150 - USB interrupt events were not triggered, since the device was apparently set to an invalid config/state, when initialized. The code around the libusb function was adapted to only run when actually called with a changed value. It appears that was already the intended behaviour, I just inverted the logic around it.

I tested with the HID device Olympus Optical Co., Ltd Foot Switch RS-28 (ID 07b4:0218) - without this change, none of the button presses trigger interrupts. With the patch applied, buttons are triggering as expected and forwarded in the RDP session.

Let me know, if this needs more work before it can be merged.

/re @akallabeth 