### PR TITLE
USB pass actual length of bytes transferred to callback function

### DIFF
--- a/channels/urbdrc/client/libusb/libusb_udevice.c
+++ b/channels/urbdrc/client/libusb/libusb_udevice.c
@@ -296,7 +296,7 @@ static void func_bulk_transfer_cb(struct libusb_transfer* transfer)
 		user_data->cb(user_data->idev, user_data->callback, user_data->data, InterfaceId,
 		              user_data->noack, user_data->MessageId, RequestID, transfer->num_iso_packets,
 		              transfer->status, user_data->StartFrame, user_data->ErrorCount,
-		              user_data->OutputBufferSize);
+		              transfer->actual_length);
 		user_data->data = NULL;
 		HashTable_Remove(user_data->queue, (void*)(size_t)streamID);
 	}


### PR DESCRIPTION
The libusb transfer reports the actual number of bytes written, use that to pass to the callback function instead of the size of the allocated buffer. (contributes to solving #6150)
This distinction is important, since a regular interrupt event will produce valid, usable data, but a timeout would just repeat stale data of the last interrupt or whatever happens to be in the buffer at that time.

/re @akallabeth 