### PR TITLE
Fix memory leaks in client/encomsp_main.c and client/remdesk_main.c

### DIFF
--- a/channels/encomsp/client/encomsp_main.c
+++ b/channels/encomsp/client/encomsp_main.c
@@ -1116,8 +1116,11 @@ static DWORD WINAPI encomsp_virtual_channel_client_thread(LPVOID arg)
 			if ((error = encomsp_process_receive(encomsp, data)))
 			{
 				WLog_ERR(TAG, "encomsp_process_receive failed with error %" PRIu32 "!", error);
+				Stream_Free(data, TRUE);
 				break;
 			}
+
+			Stream_Free(data, TRUE);
 		}
 	}
 

--- a/channels/remdesk/client/remdesk_main.c
+++ b/channels/remdesk/client/remdesk_main.c
@@ -843,8 +843,11 @@ static DWORD WINAPI remdesk_virtual_channel_client_thread(LPVOID arg)
 			if ((error = remdesk_process_receive(remdesk, data)))
 			{
 				WLog_ERR(TAG, "remdesk_process_receive failed with error %" PRIu32 "!", error);
+				Stream_Free(data, TRUE);
 				break;
 			}
+
+			Stream_Free(data, TRUE);
 		}
 	}
 


### PR DESCRIPTION
Similar fix to #2278. Not sure how to trigger encomsp PDUs with xfreerdp but the leak was seen while using freerdp library