### PR TITLE
[generate_argument_docbook] Fix typo in XML entity.

### DIFF
--- a/client/X11/generate_argument_docbook.c
+++ b/client/X11/generate_argument_docbook.c
@@ -89,7 +89,7 @@ LPSTR tr_esc_str(LPCSTR arg, bool format)
 					strncpy(&tmp[cs], "</replaceable>", len);
 				else
 					/* coverity[buffer_size] */
-					strncpy(&tmp[cs], "&lt;", len);
+					strncpy(&tmp[cs], "&gt;", len);
 
 				cs += len;
 				break;


### PR DESCRIPTION
The character '>' was being rendered as &lt; instead of &gt;.
