### PR TITLE
Do not remove transfer data on usb cancel transfer

### DIFF
--- a/channels/rdpei/rdpei_common.c
+++ b/channels/rdpei/rdpei_common.c
@@ -306,7 +306,7 @@ BOOL rdpei_write_4byte_signed(wStream* s, INT32 value)
 		value *= -1;
 	}
 
-	if (value <= 0x1FUL)
+	if (value <= 0x1FL)
 	{
 		byte = value & 0x1F;
 
@@ -315,7 +315,7 @@ BOOL rdpei_write_4byte_signed(wStream* s, INT32 value)
 
 		Stream_Write_UINT8(s, byte);
 	}
-	else if (value <= 0x1FFFUL)
+	else if (value <= 0x1FFFL)
 	{
 		byte = (value >> 8) & 0x1F;
 
@@ -326,7 +326,7 @@ BOOL rdpei_write_4byte_signed(wStream* s, INT32 value)
 		byte = (value & 0xFF);
 		Stream_Write_UINT8(s, byte);
 	}
-	else if (value <= 0x1FFFFFUL)
+	else if (value <= 0x1FFFFFL)
 	{
 		byte = (value >> 16) & 0x1F;
 
@@ -339,7 +339,7 @@ BOOL rdpei_write_4byte_signed(wStream* s, INT32 value)
 		byte = (value & 0xFF);
 		Stream_Write_UINT8(s, byte);
 	}
-	else if (value <= 0x1FFFFFFFUL)
+	else if (value <= 0x1FFFFFFFL)
 	{
 		byte = (value >> 24) & 0x1F;
 

--- a/channels/urbdrc/client/data_transfer.c
+++ b/channels/urbdrc/client/data_transfer.c
@@ -767,8 +767,6 @@ static void urb_isoch_transfer_cb(IUDEVICE* pdev, URBDRC_CHANNEL_CALLBACK* callb
 			callback->channel->Write(callback->channel, Stream_GetPosition(out), Stream_Buffer(out),
 			                         NULL);
 	}
-
-	Stream_Free(out, TRUE);
 }
 
 static UINT urb_isoch_transfer(IUDEVICE* pdev, URBDRC_CHANNEL_CALLBACK* callback, wStream* s,

--- a/channels/urbdrc/client/libusb/libusb_udevice.c
+++ b/channels/urbdrc/client/libusb/libusb_udevice.c
@@ -1177,6 +1177,7 @@ static int libusb_udev_isoch_transfer(IUDEVICE* idev, URBDRC_CHANNEL_CALLBACK* c
 	user_data->streamID = streamID;
 #endif
 	libusb_set_iso_packet_lengths(iso_transfer, iso_packet_size);
+
 	HashTable_Add(pdev->request_queue, (void*)(size_t)streamID, iso_transfer);
 	return libusb_submit_transfer(iso_transfer);
 }
@@ -1301,7 +1302,6 @@ static int func_cancel_xact_request(URBDRC_PLUGIN* urbdrc, wHashTable* queue, ui
 		return -1;
 
 	status = libusb_cancel_transfer(transfer);
-	HashTable_Remove(queue, (void*)(size_t)streamID);
 
 	if (status < 0)
 	{
@@ -1357,6 +1357,7 @@ static int libusb_udev_cancel_transfer_request(IUDEVICE* idev, UINT32 RequestId)
 
 	urbdrc = (URBDRC_PLUGIN*)pdev->urbdrc;
 	cancelID = (id1) ? cancelID1 : cancelID2;
+
 	transfer = HashTable_GetItemValue(pdev->request_queue, (void*)(size_t)cancelID);
 	return func_cancel_xact_request(urbdrc, pdev->request_queue, cancelID, transfer);
 }


### PR DESCRIPTION
Fixes a double free in case of cancelled USB transfers.
libusb will call `func_bulk_transfer_cb` which removes the data.
Same for `urb_isoch_transfer_cb`