### PR TITLE
xfreerdp: Fix +unmap-buttons option having the opposite effect

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1120,7 +1120,7 @@ static void xf_button_map_init(xfContext* xfc)
 	x11_map[111] = 112;
 
 	/* query system for actual remapping */
-	if (!xfc->context.settings->UnmapButtons)
+	if (xfc->context.settings->UnmapButtons)
 	{
 		xf_get_x11_button_map(xfc, x11_map);
 	}
@@ -1142,8 +1142,8 @@ static void xf_button_map_init(xfContext* xfc)
 			else
 			{
 				button_map* map = &xfc->button_map[pos++];
-				map->button = physical + Button1;
-				map->flags = get_flags_for_button(logical);
+				map->button = logical;
+				map->flags = get_flags_for_button(physical + Button1);
 			}
 		}
 	}


### PR DESCRIPTION
## Overview
The xfreerdp's help text says:
> +unmap-buttons   Enable Let server see real physical pointer button

Without this option, X11 button mappings are cancelled and real physical button events are sent to the server.
On the other hand, logical button events are sent to the server with this option.

This PR makes it opposite (to fit the help text).

## X11 button mappings 
I use this conf file on Ubuntu focal. (see `"ButtonMapping"` option)

/usr/share/X11/xorg.conf.d/90-kensington-em5.conf
```
Section "InputClass"
        Identifier "Kensington Expert Mouse"
        MatchUSBID "047d:1015"
        Option "ButtonMapping" "3 2 1 4 5 6 7 8 9"
        Option "MiddleEmulation" "false"
        Option "ScrollMethod" "button"
        Option "ScrollButton" "1"
        Option "YAxisMapping" "4 5"
        Option "XAxisMapping" "6 7"
EndSection
```

## Description of changes

The X11's button mapping is used to unmap buttons.
So `xf_get_x11_button_map()` is called only when UnmapButtons setting is true.

The `button` field on `xfc->button_map[n]` is compared to `button` param in the `xf_generic_ButtonEvent()` ([xf_event.c](https://github.com/FreeRDP/FreeRDP/blob/4607a2766afd2875696b7b7febd9dc63f778b8d7/client/X11/xf_event.c#L398)).
This param is logical button number, so this field should be logical.

The `get_flags_for_button()` is a function to convert physical mouse buttons to wire flags.
It described on the comment of `xf_button_flags` ([xf_client.c](https://github.com/FreeRDP/FreeRDP/blob/4607a2766afd2875696b7b7febd9dc63f778b8d7/client/X11/xf_client.c#L1071)).
So the param of this function should be physical.