### PR TITLE
Write pixel value as little-endian in write_pixel_16

### DIFF
--- a/libfreerdp/codec/interleaved.c
+++ b/libfreerdp/codec/interleaved.c
@@ -232,7 +232,8 @@ static INLINE void write_pixel_24(BYTE* _buf, UINT32 _pix)
 
 static INLINE void write_pixel_16(BYTE* _buf, UINT16 _pix)
 {
-	*(UINT16*)_buf = _pix;
+	(_buf)[0] = (BYTE)(_pix);
+	(_buf)[1] = (BYTE)((_pix) >> 8);
 }
 
 #undef DESTWRITEPIXEL


### PR DESCRIPTION
Fixes: 722790f4cadc3f2d551bf42702a99b3a3a69e5a3
Closes: https://github.com/FreeRDP/FreeRDP/issues/6267