### PR TITLE
MessageQueue write time to current message not the next

### DIFF
--- a/winpr/libwinpr/utils/collections/MessageQueue.c
+++ b/winpr/libwinpr/utils/collections/MessageQueue.c
@@ -100,11 +100,12 @@ BOOL MessageQueue_Dispatch(wMessageQueue* queue, wMessage* message)
 	}
 
 	CopyMemory(&(queue->array[queue->tail]), message, sizeof(wMessage));
-	queue->tail = (queue->tail + 1) % queue->capacity;
-	queue->size++;
 
 	message = &(queue->array[queue->tail]);
 	message->time = GetTickCount64();
+
+	queue->tail = (queue->tail + 1) % queue->capacity;
+	queue->size++;
 
 	if (queue->size > 0)
 		SetEvent(queue->event);


### PR DESCRIPTION
Is this a bug?
`time` is not accessed anywhere so has no effect however shouldn't the time be set for the current message rather than the next?