### PR TITLE
nsc: Fix memory leak

### DIFF
--- a/libfreerdp/codec/nsc.c
+++ b/libfreerdp/codec/nsc.c
@@ -364,7 +364,7 @@ void nsc_context_free(NSC_CONTEXT* context)
 
 	if (context->priv)
 	{
-		for (i = 0; i < 4; i++)
+		for (i = 0; i < 5; i++)
 			free(context->priv->PlaneBuffers[i]);
 
 		nsc_profiler_print(context->priv);


### PR DESCRIPTION
Fixes the following memory leak (found with valgrind):

==115716== 16,662,960 bytes in 459 blocks are definitely lost in loss record 3,504 of 3,504
==115716==    at 0x48396AF: malloc (vg_replace_malloc.c:306)
==115716==    by 0x4C6A4E2: nsc_context_initialize_encode (nsc_encode.c:77)
==115716==    by 0x4C6A4E2: nsc_compose_message (nsc_encode.c:497)

I encountered this issue with the NSCodec implementation while working on https://gitlab.gnome.org/pnowack/gnome-remote-desktop/-/blob/initial-rdp-support/src/grd-session-rdp.c#L266)