### PR TITLE
Conservative keyboard state sync, refactored input API

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -503,6 +503,10 @@ static BOOL xf_event_FocusIn(xfContext* xfc, const XFocusInEvent* event, BOOL ap
 		              CurrentTime);
 	}
 
+	/* Release all keys, should already be done at FocusOut but might be missed
+	 * if the WM decided to use an alternate event order */
+	xf_keyboard_release_all_keypress(xfc);
+
 	if (app)
 	{
 		xfAppWindow* appWindow;
@@ -532,7 +536,6 @@ static BOOL xf_event_FocusOut(xfContext* xfc, const XFocusOutEvent* event, BOOL 
 		XUngrabKeyboard(xfc->display, CurrentTime);
 
 	xf_keyboard_release_all_keypress(xfc);
-	xf_keyboard_clear(xfc);
 
 	if (app)
 		xf_rail_send_activate(xfc, event->window, FALSE);

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -43,8 +43,16 @@
 #include <freerdp/log.h>
 #define TAG CLIENT_TAG("x11")
 
-static BOOL firstPressRightCtrl = TRUE;
-static BOOL ungrabKeyboardWithRightCtrl = TRUE;
+static BOOL xf_sync_kbd_state(xfContext* xfc)
+{
+	const UINT32 syncFlags = xf_keyboard_get_toggle_keys_state(xfc);
+	return freerdp_input_send_synchronize_event(xfc->context.input, syncFlags);
+}
+
+static void xf_keyboard_clear(xfContext* xfc)
+{
+	ZeroMemory(xfc->KeyboardState, 256 * sizeof(BOOL));
+}
 
 static BOOL xf_keyboard_action_script_init(xfContext* xfc)
 {
@@ -131,11 +139,6 @@ void xf_keyboard_free(xfContext* xfc)
 	xf_keyboard_action_script_free(xfc);
 }
 
-void xf_keyboard_clear(xfContext* xfc)
-{
-	ZeroMemory(xfc->KeyboardState, 256 * sizeof(BOOL));
-}
-
 void xf_keyboard_key_press(xfContext* xfc, BYTE keycode, KeySym keysym)
 {
 	if (keycode < 8)
@@ -179,6 +182,7 @@ void xf_keyboard_release_all_keypress(xfContext* xfc)
 			xfc->KeyboardState[keycode] = FALSE;
 		}
 	}
+	xf_sync_kbd_state(xfc);
 }
 
 BOOL xf_keyboard_key_pressed(xfContext* xfc, KeySym keysym)
@@ -216,9 +220,7 @@ void xf_keyboard_send_key(xfContext* xfc, BOOL down, BYTE keycode)
 
 		if ((rdp_scancode == RDP_SCANCODE_CAPSLOCK) && (down == FALSE))
 		{
-			UINT32 syncFlags;
-			syncFlags = xf_keyboard_get_toggle_keys_state(xfc);
-			input->SynchronizeEvent(input, syncFlags);
+			xf_sync_kbd_state(xfc);
 		}
 	}
 }
@@ -349,7 +351,7 @@ void xf_keyboard_focus_in(xfContext* xfc)
 
 	input = xfc->context.input;
 	syncFlags = xf_keyboard_get_toggle_keys_state(xfc);
-	input->FocusInEvent(input, syncFlags);
+	freerdp_input_send_focus_in_event(input, syncFlags);
 	xk_keyboard_update_modifier_keys(xfc);
 
 	/* finish with a mouse pointer position like mstsc.exe if required */
@@ -362,7 +364,7 @@ void xf_keyboard_focus_in(xfContext* xfc)
 		if (x >= 0 && x < xfc->window->width && y >= 0 && y < xfc->window->height)
 		{
 			xf_event_adjust_coordinates(xfc, &x, &y);
-			input->MouseEvent(input, PTR_FLAGS_MOVE, x, y);
+			freerdp_input_send_mouse_event(input, PTR_FLAGS_MOVE, x, y);
 		}
 	}
 }
@@ -473,18 +475,18 @@ BOOL xf_keyboard_handle_special_keys(xfContext* xfc, KeySym keysym)
 	// do not return anything such that the key could be used by client if ungrab is not the goal
 	if (keysym == XK_Control_R)
 	{
-		if (mod.RightCtrl && firstPressRightCtrl)
+		if (mod.RightCtrl && xfc->firstPressRightCtrl)
 		{
 			// Right Ctrl is pressed, getting ready to ungrab
-			ungrabKeyboardWithRightCtrl = TRUE;
-			firstPressRightCtrl = FALSE;
+			xfc->ungrabKeyboardWithRightCtrl = TRUE;
+			xfc->firstPressRightCtrl = FALSE;
 		}
 	}
 	else
 	{
 		// some other key has been pressed, abort ungrabbing
-		if (ungrabKeyboardWithRightCtrl)
-			ungrabKeyboardWithRightCtrl = FALSE;
+		if (xfc->ungrabKeyboardWithRightCtrl)
+			xfc->ungrabKeyboardWithRightCtrl = FALSE;
 	}
 
 	if (!xf_keyboard_execute_action_script(xfc, &mod, keysym))
@@ -603,9 +605,9 @@ void xf_keyboard_handle_special_keys_release(xfContext* xfc, KeySym keysym)
 	if (keysym != XK_Control_R)
 		return;
 
-	firstPressRightCtrl = TRUE;
+	xfc->firstPressRightCtrl = TRUE;
 
-	if (!ungrabKeyboardWithRightCtrl)
+	if (!xfc->ungrabKeyboardWithRightCtrl)
 		return;
 
 	// all requirements for ungrab are fulfilled, ungrabbing now
@@ -624,7 +626,7 @@ void xf_keyboard_handle_special_keys_release(xfContext* xfc, KeySym keysym)
 	}
 
 	// ungrabbed
-	ungrabKeyboardWithRightCtrl = FALSE;
+	xfc->ungrabKeyboardWithRightCtrl = FALSE;
 }
 
 BOOL xf_keyboard_set_indicators(rdpContext* context, UINT16 led_flags)

--- a/client/X11/xf_keyboard.h
+++ b/client/X11/xf_keyboard.h
@@ -44,7 +44,7 @@ typedef struct _XF_MODIFIER_KEYS XF_MODIFIER_KEYS;
 
 BOOL xf_keyboard_init(xfContext* xfc);
 void xf_keyboard_free(xfContext* xfc);
-void xf_keyboard_clear(xfContext* xfc);
+
 void xf_keyboard_key_press(xfContext* xfc, BYTE keycode, KeySym keysym);
 void xf_keyboard_key_release(xfContext* xfc, BYTE keycode, KeySym keysym);
 void xf_keyboard_release_all_keypress(xfContext* xfc);

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -180,7 +180,7 @@ void xf_rail_end_local_move(xfContext* xfc, xfAppWindow* appWindow)
 	if ((appWindow->local_move.direction != _NET_WM_MOVERESIZE_MOVE_KEYBOARD) &&
 	    (appWindow->local_move.direction != _NET_WM_MOVERESIZE_SIZE_KEYBOARD))
 	{
-		input->MouseEvent(input, PTR_FLAGS_BUTTON1, x, y);
+		freerdp_input_send_mouse_event(input, PTR_FLAGS_BUTTON1, x, y);
 	}
 
 	/*

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -248,6 +248,8 @@ struct xf_context
 	button_map button_map[NUM_BUTTONS_MAPPED];
 	BYTE savedMaximizedState;
 	UINT32 locked;
+	BOOL firstPressRightCtrl;
+	BOOL ungrabKeyboardWithRightCtrl;
 };
 
 BOOL xf_create_window(xfContext* xfc);


### PR DESCRIPTION
* Use `input_send_*` type functions instead of directly calling function pointers
* Be really conservative with release keys (expect only `FocusIn` to be called)
* Resync keyboard state 