### PR TITLE
Add support for -grab-mouse, to prevent remote mouse movement

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2896,6 +2896,10 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 		{
 			settings->GrabKeyboard = enable;
 		}
+		CommandLineSwitchCase(arg, "grab-mouse")
+		{
+			settings->GrabMouse = enable;
+		}
 		CommandLineSwitchCase(arg, "unmap-buttons")
 		{
 			settings->UnmapButtons = enable;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -180,6 +180,7 @@ static const COMMAND_LINE_ARGUMENT_A args[] = {
 	{ "gp", COMMAND_LINE_VALUE_REQUIRED, "<password>", NULL, NULL, -1, NULL, "Gateway password" },
 	{ "grab-keyboard", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
 	  "Grab keyboard" },
+	{ "grab-mouse", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL, "Grab mouse" },
 	{ "gt", COMMAND_LINE_VALUE_REQUIRED, "[rpc|http|auto]", NULL, NULL, -1, NULL,
 	  "Gateway transport type" },
 	{ "gu", COMMAND_LINE_VALUE_REQUIRED, "[[<domain>\\]<user>|<user>[@<domain>]]", NULL, NULL, -1,

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -718,6 +718,7 @@ typedef struct _RDPDR_PARALLEL RDPDR_PARALLEL;
 #define FreeRDP_PercentScreenUseWidth (1556)
 #define FreeRDP_PercentScreenUseHeight (1557)
 #define FreeRDP_DynamicResolutionUpdate (1558)
+#define FreeRDP_GrabMouse (1559)
 #define FreeRDP_SoftwareGdi (1601)
 #define FreeRDP_LocalConnection (1602)
 #define FreeRDP_AuthenticationOnly (1603)
@@ -1195,7 +1196,8 @@ struct rdp_settings
 	ALIGN64 BOOL PercentScreenUseWidth;   /* 1556 */
 	ALIGN64 BOOL PercentScreenUseHeight;  /* 1557 */
 	ALIGN64 BOOL DynamicResolutionUpdate; /* 1558 */
-	UINT64 padding1601[1601 - 1559];      /* 1559 */
+	ALIGN64 BOOL GrabMouse;               /* 1559 */
+	UINT64 padding1601[1601 - 1560];      /* 1560 */
 
 	/* Miscellaneous */
 	ALIGN64 BOOL SoftwareGdi;          /* 1601 */

--- a/libfreerdp/cache/pointer.c
+++ b/libfreerdp/cache/pointer.c
@@ -68,6 +68,9 @@ static BOOL update_pointer_position(rdpContext* context,
 	    !pointer_position)
 		return FALSE;
 
+	if (!context->settings->GrabMouse)
+		return TRUE;
+
 	pointer = context->graphics->Pointer_Prototype;
 	return IFCALLRESULT(TRUE, pointer->SetPosition, context, pointer_position->xPos,
 	                    pointer_position->yPos);

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -228,6 +228,9 @@ BOOL freerdp_settings_get_bool(const rdpSettings* settings, size_t id)
 		case FreeRDP_GrabKeyboard:
 			return settings->GrabKeyboard;
 
+		case FreeRDP_GrabMouse:
+			return settings->GrabMouse;
+
 		case FreeRDP_HasExtendedMouseEvent:
 			return settings->HasExtendedMouseEvent;
 
@@ -800,6 +803,10 @@ BOOL freerdp_settings_set_bool(rdpSettings* settings, size_t id, BOOL val)
 
 		case FreeRDP_GrabKeyboard:
 			settings->GrabKeyboard = val;
+			break;
+
+		case FreeRDP_GrabMouse:
+			settings->GrabMouse = val;
 			break;
 
 		case FreeRDP_HasExtendedMouseEvent:

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -86,6 +86,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_GfxSmallCache, 0, "FreeRDP_GfxSmallCache" },
 	{ FreeRDP_GfxThinClient, 0, "FreeRDP_GfxThinClient" },
 	{ FreeRDP_GrabKeyboard, 0, "FreeRDP_GrabKeyboard" },
+	{ FreeRDP_GrabMouse, 0, "FreeRDP_GrabMouse" },
 	{ FreeRDP_HasExtendedMouseEvent, 0, "FreeRDP_HasExtendedMouseEvent" },
 	{ FreeRDP_HasHorizontalWheel, 0, "FreeRDP_HasHorizontalWheel" },
 	{ FreeRDP_HasMonitorAttributes, 0, "FreeRDP_HasMonitorAttributes" },

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -316,6 +316,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	settings->Workarea = FALSE;
 	settings->Fullscreen = FALSE;
 	settings->GrabKeyboard = TRUE;
+	settings->GrabMouse = TRUE;
 	settings->Decorations = TRUE;
 	settings->RdpVersion = RDP_VERSION_10_7;
 	settings->ColorDepth = 16;

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -75,6 +75,7 @@ static const size_t bool_list_indices[] = {
 	FreeRDP_GfxSmallCache,
 	FreeRDP_GfxThinClient,
 	FreeRDP_GrabKeyboard,
+	FreeRDP_GrabMouse,
 	FreeRDP_HasExtendedMouseEvent,
 	FreeRDP_HasHorizontalWheel,
 	FreeRDP_HasMonitorAttributes,


### PR DESCRIPTION
freerdp2 introduced some annoying behaviour for me: When switching virtual desktops to one where freerdp2 is running and focused, the pointer would be moved to the last position it had inside of the freerdp2 window. I.e. if it was moved out at the upper right corner, that's where it would go. This happens regardless of whether or not the pointer was positioned on top of the freerdp2 window at the time of switching.

The main annoyance caused by this is that when I used the scroll wheel on my dock to flip through my virtual desktops, the mouse would suddenly pop into the freerdp2 window, and continued scrolling would scroll whichever document I happened to have open on the remote Windows desktop.

This was tested on Debian 10 (Buster), with Openbox WM and a tint2 dock. It apparently happens only when logged into a Windows 10 machine (tested with 2 different ones), and not when loggied into a Windows Server 2016 (or 2019) machine (tested with 3 different ones). I also tested freerdp (1) on the same setup, which did not exhibit this behaviour.

With the included patch, -grab-mouse can be specified on the command line to prevent freerdp2 from moving the user's mouse.