### PR TITLE
server: proxy: support server heartbeats

### DIFF
--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -54,6 +54,7 @@ typedef RDP_CLIENT_ENTRY_POINTS_V1 RDP_CLIENT_ENTRY_POINTS;
 #include <freerdp/update.h>
 #include <freerdp/message.h>
 #include <freerdp/autodetect.h>
+#include <freerdp/heartbeat.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -309,7 +310,9 @@ extern "C"
 		ALIGN64 rdpAutoDetect* autodetect; /* (offset 19)
 		                                Auto-Detect handle for the connection.
 		                                Will be initialized by a call to freerdp_context_new() */
-		UINT64 paddingB[32 - 20];          /* 20 */
+		ALIGN64 rdpHeartbeat* heartbeat;   /* (offset 21) */
+
+		UINT64 paddingB[32 - 21]; /* 21 */
 
 		ALIGN64 size_t
 		    ContextSize; /* (offset 32)

--- a/include/freerdp/heartbeat.h
+++ b/include/freerdp/heartbeat.h
@@ -17,23 +17,30 @@
  * limitations under the License.
  */
 
-#ifndef FREERDP_LIB_CORE_HEARTBEET_H
-#define FREERDP_LIB_CORE_HEARTBEET_H
+#ifndef FREERDP_HEARTBEAT_H
+#define FREERDP_HEARTBEAT_H
 
-#include "rdp.h"
+#include <freerdp/types.h>
 
-#include <freerdp/heartbeat.h>
-#include <freerdp/freerdp.h>
-#include <freerdp/log.h>
-#include <freerdp/api.h>
+typedef struct rdp_heartbeat rdpHeartbeat;
 
-#include <winpr/stream.h>
+typedef BOOL (*pServerHeartbeat)(freerdp* instance, BYTE period, BYTE count1, BYTE count2);
 
-int rdp_recv_heartbeat_packet(rdpRdp* rdp, wStream* s);
+struct rdp_heartbeat
+{
+	pServerHeartbeat ServerHeartbeat;
+};
 
-FREERDP_LOCAL rdpHeartbeat* heartbeat_new(void);
-FREERDP_LOCAL void heartbeat_free(rdpHeartbeat* heartbeat);
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
-#define HEARTBEAT_TAG FREERDP_TAG("core.heartbeat")
+	FREERDP_API BOOL freerdp_heartbeat_send_heartbeat_pdu(freerdp_peer* peer, BYTE period,
+	                                                      BYTE count1, BYTE count2);
 
-#endif /* FREERDP_LIB_CORE_HEARTBEET_H */
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FREERDP_HEARTBEAT_H */

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -672,6 +672,7 @@ BOOL freerdp_context_new(freerdp* instance)
 	instance->update = rdp->update;
 	instance->settings = rdp->settings;
 	instance->autodetect = rdp->autodetect;
+	instance->heartbeat = rdp->heartbeat;
 	context->graphics = graphics_new(context);
 
 	if (!context->graphics)

--- a/libfreerdp/core/heartbeat.c
+++ b/libfreerdp/core/heartbeat.c
@@ -31,6 +31,7 @@ int rdp_recv_heartbeat_packet(rdpRdp* rdp, wStream* s)
 	BYTE period;
 	BYTE count1;
 	BYTE count2;
+	BOOL rc;
 
 	if (Stream_GetRemainingLength(s) < 4)
 		return -1;
@@ -44,7 +45,37 @@ int rdp_recv_heartbeat_packet(rdpRdp* rdp, wStream* s)
 	         "received Heartbeat PDU -> period=%" PRIu8 ", count1=%" PRIu8 ", count2=%" PRIu8 "",
 	         period, count1, count2);
 
+	rc = IFCALLRESULT(TRUE, rdp->heartbeat->ServerHeartbeat, rdp->instance, period, count1, count2);
+	if (!rc)
+	{
+		WLog_ERR(HEARTBEAT_TAG, "heartbeat->ServerHeartbeat callback failed!");
+		return -1;
+	}
+
 	return 0;
+}
+
+BOOL freerdp_heartbeat_send_heartbeat_pdu(freerdp_peer* peer, BYTE period, BYTE count1, BYTE count2)
+{
+	rdpRdp* rdp = peer->context->rdp;
+	wStream* s = rdp_message_channel_pdu_init(rdp);
+
+	if (!s)
+		return FALSE;
+
+	Stream_Seek_UINT8(s);          /* reserved (1 byte) */
+	Stream_Write_UINT8(s, period); /* period (1 byte) */
+	Stream_Write_UINT8(s, count1); /* count1 (1 byte) */
+	Stream_Write_UINT8(s, count2); /* count2 (1 byte) */
+
+	WLog_DBG(HEARTBEAT_TAG,
+	         "sending Heartbeat PDU -> period=%" PRIu8 ", count1=%" PRIu8 ", count2=%" PRIu8 "",
+	         period, count1, count2);
+
+	if (!rdp_send_message_channel_pdu(rdp, s, SEC_HEARTBEAT))
+		return FALSE;
+
+	return TRUE;
 }
 
 rdpHeartbeat* heartbeat_new(void)

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -155,12 +155,6 @@ static BOOL pf_client_use_peer_load_balance_info(pClientContext* pc)
 	return TRUE;
 }
 
-/**
- * Called before a connection is established.
- *
- * TODO: Take client to proxy settings and use channel whitelist to filter out
- * unwanted channels.
- */
 static BOOL pf_client_pre_connect(freerdp* instance)
 {
 	pClientContext* pc = (pClientContext*)instance->context;
@@ -272,6 +266,13 @@ static BOOL pf_client_receive_channel_data_hook(freerdp* instance, UINT16 channe
 	return client_receive_channel_data_original(instance, channelId, data, size, flags, totalSize);
 }
 
+static BOOL pf_client_on_server_heartbeat(freerdp* instance, BYTE period, BYTE count1, BYTE count2)
+{
+	pClientContext* pc = (pClientContext*)instance->context;
+	pServerContext* ps = pc->pdata->ps;
+	return freerdp_heartbeat_send_heartbeat_pdu(ps->context.peer, period, count1, count2);
+}
+
 /**
  * Called after a RDP connection was successfully established.
  * Settings might have changed during negotiation of client / server feature
@@ -338,6 +339,8 @@ static BOOL pf_client_post_connect(freerdp* instance)
 			HashTable_Add(pc->vc_ids, (void*)channel_name, (void*)channel_id);
 		}
 	}
+
+	instance->heartbeat->ServerHeartbeat = pf_client_on_server_heartbeat;
 
 	/*
 	 * after the connection fully established and settings were negotiated with target server,


### PR DESCRIPTION
I noticed that `rdpRdp` struct contains a pointer to another *empty* struct called `rdpHeartbeat`. So, I just added a callback called `ServerHeartbeat` and called it whenever the client receives a server heartbeat. I also added server functionality to send an heartbeat. I'm not sure I like the way the `rdpHeartbeat` struct is currently used, because I don't think it's place is under `rdpRdp`, as only clients (freerdp* structs) really receive heartbeats (from servers). I'd maybe remove this struct from `rdpRdp` and maintain it only in `freerdp` struct. What do you guys think?