### PR TITLE
Set BIO data NULL on cleanup

### DIFF
--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -461,6 +461,7 @@ static int bio_rdp_tls_free(BIO* bio)
 	if (!tls)
 		return 0;
 
+	BIO_set_data(bio, NULL);
 	if (BIO_get_shutdown(bio))
 	{
 		if (BIO_get_init(bio) && tls->ssl)
@@ -475,6 +476,7 @@ static int bio_rdp_tls_free(BIO* bio)
 
 	DeleteCriticalSection(&tls->lock);
 	free(tls);
+
 	return 1;
 }
 


### PR DESCRIPTION
Recursive BIO free could double free, if the BIO data is not set
NULL when removed.