### PR TITLE
cliprdr_common.c: fix memory leak in certain error condition

### DIFF
--- a/channels/cliprdr/cliprdr_common.c
+++ b/channels/cliprdr/cliprdr_common.c
@@ -191,6 +191,7 @@ wStream* cliprdr_packet_format_list_new(const CLIPRDR_FORMAT_LIST* formatList,
 	WCHAR* wszFormatName;
 	BOOL asciiNames = FALSE;
 	CLIPRDR_FORMAT* format;
+	UINT32 length;
 
 	if (formatList->msgType != CB_FORMAT_LIST)
 		WLog_WARN(TAG, "[%s] called with invalid type %08" PRIx32, __FUNCTION__,
@@ -198,7 +199,7 @@ wStream* cliprdr_packet_format_list_new(const CLIPRDR_FORMAT_LIST* formatList,
 
 	if (!useLongFormatNames)
 	{
-		UINT32 length = formatList->numFormats * 36;
+		length = formatList->numFormats * 36;
 		s = cliprdr_packet_new(CB_FORMAT_LIST, 0, length);
 
 		if (!s)
@@ -236,7 +237,10 @@ wStream* cliprdr_packet_format_list_new(const CLIPRDR_FORMAT_LIST* formatList,
 					    ConvertToUnicode(CP_UTF8, 0, szFormatName, -1, &wszFormatName, 0);
 
 				if (formatNameSize < 0)
+				{
+					Stream_Free(s, TRUE);
 					return NULL;
+				}
 
 				if (formatNameSize > 15)
 					formatNameSize = 15;
@@ -254,7 +258,7 @@ wStream* cliprdr_packet_format_list_new(const CLIPRDR_FORMAT_LIST* formatList,
 	}
 	else
 	{
-		UINT32 length = 0;
+		length = 0;
 		for (index = 0; index < formatList->numFormats; index++)
 		{
 			format = (CLIPRDR_FORMAT*)&(formatList->formats[index]);
@@ -290,7 +294,10 @@ wStream* cliprdr_packet_format_list_new(const CLIPRDR_FORMAT_LIST* formatList,
 				const size_t pos = Stream_GetPosition(s);
 				const size_t rem = cap - pos;
 				if ((cap < pos) || ((rem / 2) > INT_MAX))
+				{
+					Stream_Free(s, TRUE);
 					return NULL;
+				}
 
 				lpWideCharStr = (LPWSTR)Stream_Pointer(s);
 				cchWideChar = (int)(rem / 2);
@@ -298,7 +305,10 @@ wStream* cliprdr_packet_format_list_new(const CLIPRDR_FORMAT_LIST* formatList,
 				                                     lpWideCharStr, cchWideChar) *
 				                 2;
 				if (formatNameSize < 0)
+				{
+					Stream_Free(s, TRUE);
 					return NULL;
+				}
 				Stream_Seek(s, (size_t)formatNameSize);
 			}
 			else


### PR DESCRIPTION
Under some error condition, wStream *s is leaked in cliprdr_common.c