### PR TITLE
cleanup of https://github.com/FreeRDP/FreeRDP/pull/6448

### DIFF
--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -31,7 +31,6 @@ typedef struct rdp_graphics rdpGraphics;
 typedef struct rdp_metrics rdpMetrics;
 typedef struct rdp_codecs rdpCodecs;
 typedef struct rdp_transport rdpTransport; /* Opaque */
-typedef struct rdp_transport_io rdpTransportIo;
 
 typedef struct rdp_freerdp freerdp;
 typedef struct rdp_context rdpContext;
@@ -426,36 +425,8 @@ extern "C"
 	};
 	typedef struct rdp_channel_handles rdpChannelHandles;
 
-	typedef int (*pTCPConnect)(rdpContext* context, rdpSettings* settings, const char* hostname,
-	                           int port, DWORD timeout);
-	typedef BOOL (*pTransportFkt)(rdpTransport* transport);
-	typedef BOOL (*pTransportAttach)(rdpTransport* transport, int sockfd);
-	typedef int (*pTransportRWFkt)(rdpTransport* transport, wStream* s);
-	typedef SSIZE_T (*pTransportRead)(rdpTransport* transport, BYTE* data, size_t bytes);
-
-	struct rdp_transport_io
-	{
-		pTCPConnect TCPConnect;
-		pTransportFkt RDPConnect;
-		pTransportFkt RDPAccept;
-		pTransportFkt TLSConnect;
-		pTransportFkt TLSAccept;
-		pTransportFkt NLAConnect;
-		pTransportFkt NLAAccept;
-		pTransportAttach TransportAttach;
-		pTransportFkt TransportDisconnect;
-		pTransportRWFkt ReadPdu;  /* Reads a whole PDU from the transport */
-		pTransportRWFkt WritePdu; /* Writes a whole PDU to the transport */
-		pTransportRead ReadBytes; /* Reads up to a requested amount of bytes from the transport */
-	};
-	typedef struct rdp_transport_io rdpTransportIo;
-
 	FREERDP_API BOOL freerdp_context_new(freerdp* instance);
 	FREERDP_API void freerdp_context_free(freerdp* instance);
-
-	FREERDP_API const rdpTransportIo* freerdp_get_io_callbacks(freerdp* instance);
-	FREERDP_API BOOL freerdp_set_io_callbacks(freerdp* instance,
-	                                          const rdpTransportIo* io_callbacks);
 
 	FREERDP_API BOOL freerdp_connect(freerdp* instance);
 	FREERDP_API BOOL freerdp_abort_connect(freerdp* instance);

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -30,6 +30,8 @@ typedef struct rdp_channels rdpChannels;
 typedef struct rdp_graphics rdpGraphics;
 typedef struct rdp_metrics rdpMetrics;
 typedef struct rdp_codecs rdpCodecs;
+typedef struct rdp_transport rdpTransport; /* Opaque */
+typedef struct rdp_transport_io rdpTransportIo;
 
 typedef struct rdp_freerdp freerdp;
 typedef struct rdp_context rdpContext;
@@ -424,8 +426,36 @@ extern "C"
 	};
 	typedef struct rdp_channel_handles rdpChannelHandles;
 
+	typedef int (*pTCPConnect)(rdpContext* context, rdpSettings* settings, const char* hostname,
+	                           int port, DWORD timeout);
+	typedef BOOL (*pTransportFkt)(rdpTransport* transport);
+	typedef BOOL (*pTransportAttach)(rdpTransport* transport, int sockfd);
+	typedef int (*pTransportRWFkt)(rdpTransport* transport, wStream* s);
+	typedef SSIZE_T (*pTransportRead)(rdpTransport* transport, BYTE* data, size_t bytes);
+
+	struct rdp_transport_io
+	{
+		pTCPConnect TCPConnect;
+		pTransportFkt RDPConnect;
+		pTransportFkt RDPAccept;
+		pTransportFkt TLSConnect;
+		pTransportFkt TLSAccept;
+		pTransportFkt NLAConnect;
+		pTransportFkt NLAAccept;
+		pTransportAttach TransportAttach;
+		pTransportFkt TransportDisconnect;
+		pTransportRWFkt ReadPdu;  /* Reads a whole PDU from the transport */
+		pTransportRWFkt WritePdu; /* Writes a whole PDU to the transport */
+		pTransportRead ReadBytes; /* Reads up to a requested amount of bytes from the transport */
+	};
+	typedef struct rdp_transport_io rdpTransportIo;
+
 	FREERDP_API BOOL freerdp_context_new(freerdp* instance);
 	FREERDP_API void freerdp_context_free(freerdp* instance);
+
+	FREERDP_API const rdpTransportIo* freerdp_get_io_callbacks(freerdp* instance);
+	FREERDP_API BOOL freerdp_set_io_callbacks(freerdp* instance,
+	                                          const rdpTransportIo* io_callbacks);
 
 	FREERDP_API BOOL freerdp_connect(freerdp* instance);
 	FREERDP_API BOOL freerdp_abort_connect(freerdp* instance);

--- a/include/freerdp/transport_io.h
+++ b/include/freerdp/transport_io.h
@@ -1,0 +1,77 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * FreeRDP Interface
+ *
+ * Copyright 2009-2011 Jay Sorg
+ * Copyright 2015 Thincast Technologies GmbH
+ * Copyright 2015 DI (FH) Martin Haimberger <martin.haimberger@thincast.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_TRANSPORT_IO_H
+#define FREERDP_TRANSPORT_IO_H
+
+typedef struct rdp_transport_io rdpTransportIo;
+
+#include <freerdp/api.h>
+#include <freerdp/types.h>
+
+#include <winpr/stream.h>
+#include <freerdp/freerdp.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+	typedef int (*pTCPConnect)(rdpContext* context, rdpSettings* settings, const char* hostname,
+	                           int port, DWORD timeout);
+	typedef BOOL (*pTransportFkt)(rdpTransport* transport);
+	typedef BOOL (*pTransportAttach)(rdpTransport* transport, int sockfd);
+	typedef int (*pTransportRWFkt)(rdpTransport* transport, wStream* s);
+	typedef SSIZE_T (*pTransportRead)(rdpTransport* transport, BYTE* data, size_t bytes);
+
+	struct rdp_transport_io
+	{
+		pTCPConnect TCPConnect;
+		pTransportFkt RDPConnect;
+		pTransportFkt RDPAccept;
+		pTransportFkt TLSConnect;
+		pTransportFkt TLSAccept;
+		pTransportFkt NLAConnect;
+		pTransportFkt NLAAccept;
+		pTransportAttach TransportAttach;
+		pTransportFkt TransportDisconnect;
+		pTransportRWFkt ReadPdu;  /* Reads a whole PDU from the transport */
+		pTransportRWFkt WritePdu; /* Writes a whole PDU to the transport */
+		pTransportRead ReadBytes; /* Reads up to a requested amount of bytes from the transport */
+	};
+	typedef struct rdp_transport_io rdpTransportIo;
+
+	FREERDP_API const rdpTransportIo* freerdp_get_io_callbacks(freerdp* instance);
+	FREERDP_API BOOL freerdp_set_io_callbacks(freerdp* instance,
+	                                          const rdpTransportIo* io_callbacks);
+	/* PDU parser.
+	 * incomplete: FALSE if the whole PDU is available, TRUE otherwise
+	 * Return: 0  -> PDU header incomplete
+	 *         >0 -> PDU header complete, length of PDU.
+	 *         <0 -> Abort, an error occured
+	 */
+	FREERDP_API SSIZE_T transport_parse_pdu(rdpTransport* transport, wStream* s, BOOL* incomplete);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FREERDP_TRANSPORT_IO_H */

--- a/include/freerdp/transport_io.h
+++ b/include/freerdp/transport_io.h
@@ -45,12 +45,8 @@ extern "C"
 	struct rdp_transport_io
 	{
 		pTCPConnect TCPConnect;
-		pTransportFkt RDPConnect;
-		pTransportFkt RDPAccept;
 		pTransportFkt TLSConnect;
 		pTransportFkt TLSAccept;
-		pTransportFkt NLAConnect;
-		pTransportFkt NLAAccept;
 		pTransportAttach TransportAttach;
 		pTransportFkt TransportDisconnect;
 		pTransportRWFkt ReadPdu;  /* Reads a whole PDU from the transport */

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -1121,3 +1121,17 @@ const char* freerdp_nego_get_routing_token(rdpContext* context, DWORD* length)
 
 	return (const char*)nego_get_routing_token(context->rdp->nego, length);
 }
+
+const rdpTransportIo* freerdp_get_io_callbacks(freerdp* instance)
+{
+	if (!instance || !instance->context)
+		return NULL;
+	return rdp_get_io_callbacks(instance->context->rdp);
+}
+
+BOOL freerdp_set_io_callbacks(freerdp* instance, const rdpTransportIo* io_callbacks)
+{
+	if (!instance || !instance->context)
+		return FALSE;
+	return rdp_set_io_callbacks(instance->context->rdp, io_callbacks);
+}

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -180,6 +180,7 @@ struct rdp_rdp
 	UINT64 outBytes;
 	UINT64 outPackets;
 	CRITICAL_SECTION critical;
+	rdpTransportIo* io;
 };
 
 FREERDP_LOCAL BOOL rdp_read_security_header(wStream* s, UINT16* flags, UINT16* length);
@@ -223,6 +224,9 @@ FREERDP_LOCAL int rdp_check_fds(rdpRdp* rdp);
 FREERDP_LOCAL rdpRdp* rdp_new(rdpContext* context);
 FREERDP_LOCAL void rdp_reset(rdpRdp* rdp);
 FREERDP_LOCAL void rdp_free(rdpRdp* rdp);
+
+FREERDP_LOCAL const rdpTransportIo* rdp_get_io_callbacks(rdpRdp* rdp);
+FREERDP_LOCAL BOOL rdp_set_io_callbacks(rdpRdp* rdp, const rdpTransportIo* io_callbacks);
 
 #define RDP_TAG FREERDP_TAG("core.rdp")
 #ifdef WITH_DEBUG_RDP

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -30,6 +30,8 @@
 #include <winpr/platform.h>
 #include <winpr/winsock.h>
 
+#include "rdp.h"
+
 #if !defined(_WIN32)
 
 #include <netdb.h>
@@ -1061,6 +1063,18 @@ static BOOL freerdp_tcp_set_keep_alive_mode(const rdpSettings* settings, int soc
 
 int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings, const char* hostname, int port,
                         DWORD timeout)
+{
+	rdpTransport* transport;
+	if (!context || !context->rdp)
+		return -1;
+	transport = context->rdp->transport;
+	if (!transport)
+		return -1;
+	return IFCALLRESULT(-1, transport->io.TCPConnect, context, settings, hostname, port, timeout);
+}
+
+int freerdp_tcp_default_connect(rdpContext* context, rdpSettings* settings, const char* hostname,
+                                int port, DWORD timeout)
 {
 	int sockfd;
 	UINT32 optval;

--- a/libfreerdp/core/tcp.h
+++ b/libfreerdp/core/tcp.h
@@ -66,6 +66,9 @@ FREERDP_LOCAL BIO_METHOD* BIO_s_buffered_socket(void);
 FREERDP_LOCAL int freerdp_tcp_connect(rdpContext* context, rdpSettings* settings,
                                       const char* hostname, int port, DWORD timeout);
 
+FREERDP_LOCAL int freerdp_tcp_default_connect(rdpContext* context, rdpSettings* settings,
+                                              const char* hostname, int port, DWORD timeout);
+
 FREERDP_LOCAL char* freerdp_tcp_get_peer_address(SOCKET sockfd);
 
 FREERDP_LOCAL struct addrinfo* freerdp_tcp_resolve_host(const char* hostname, int port,

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -335,17 +335,17 @@ static BOOL transport_default_connect_tls(rdpTransport* transport)
 
 BOOL transport_connect_nla(rdpTransport* transport)
 {
+	rdpContext* context = NULL;
+	rdpSettings* settings = NULL;
+	freerdp* instance = NULL;
+	rdpRdp* rdp = NULL;
 	if (!transport)
 		return FALSE;
-	return IFCALLRESULT(FALSE, transport->io.NLAConnect, transport);
-}
 
-static BOOL transport_default_connect_nla(rdpTransport* transport)
-{
-	rdpContext* context = transport->context;
-	rdpSettings* settings = context->settings;
-	freerdp* instance = context->instance;
-	rdpRdp* rdp = context->rdp;
+	context = transport->context;
+	settings = context->settings;
+	instance = context->instance;
+	rdp = context->rdp;
 
 	if (!transport_connect_tls(transport))
 		return FALSE;
@@ -1250,7 +1250,6 @@ rdpTransport* transport_new(rdpContext* context)
 	transport->io.TCPConnect = freerdp_tcp_default_connect;
 	transport->io.RDPConnect = transport_default_connect_rdp;
 	transport->io.TLSConnect = transport_default_connect_tls;
-	transport->io.NLAConnect = transport_default_connect_nla;
 	transport->io.RDPAccept = transport_default_accept_rdp;
 	transport->io.TLSAccept = transport_default_accept_tls;
 	transport->io.TransportAttach = transport_default_attach;

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -508,25 +508,13 @@ static BOOL transport_default_accept_tls(rdpTransport* transport)
 
 BOOL transport_accept_nla(rdpTransport* transport)
 {
-	if (!transport)
-		return FALSE;
-	return IFCALLRESULT(FALSE, transport->io.NLAAccept, transport);
-}
 
-static BOOL transport_default_accept_nla(rdpTransport* transport)
-{
 	rdpSettings* settings = transport->settings;
 	freerdp* instance = (freerdp*)settings->instance;
-
-	if (!transport->tls)
-		transport->tls = tls_new(transport->settings);
-
-	transport->layer = TRANSPORT_LAYER_TLS;
-
-	if (!tls_accept(transport->tls, transport->frontBio, settings))
+	if (!transport)
 		return FALSE;
-
-	transport->frontBio = transport->tls->bio;
+	if (!IFCALLRESULT(FALSE, transport->io.TLSAccept, transport))
+		return FALSE;
 
 	/* Network Level Authentication */
 
@@ -1265,7 +1253,6 @@ rdpTransport* transport_new(rdpContext* context)
 	transport->io.NLAConnect = transport_default_connect_nla;
 	transport->io.RDPAccept = transport_default_accept_rdp;
 	transport->io.TLSAccept = transport_default_accept_tls;
-	transport->io.NLAAccept = transport_default_accept_nla;
 	transport->io.TransportAttach = transport_default_attach;
 	transport->io.TransportDisconnect = transport_default_disconnect;
 	transport->io.ReadPdu = transport_default_read_pdu;

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -264,11 +264,6 @@ BOOL transport_connect_rdp(rdpTransport* transport)
 {
 	if (!transport)
 		return FALSE;
-	return IFCALLRESULT(FALSE, transport->io.RDPConnect, transport);
-}
-
-static BOOL transport_default_connect_rdp(rdpTransport* transport)
-{
 	/* RDP encryption */
 	return TRUE;
 }
@@ -474,11 +469,6 @@ BOOL transport_accept_rdp(rdpTransport* transport)
 {
 	if (!transport)
 		return FALSE;
-	return IFCALLRESULT(FALSE, transport->io.RDPAccept, transport);
-}
-
-static BOOL transport_default_accept_rdp(rdpTransport* transport)
-{
 	/* RDP encryption */
 	return TRUE;
 }
@@ -1248,9 +1238,7 @@ rdpTransport* transport_new(rdpContext* context)
 
 	// transport->io.DataHandler = transport_data_handler;
 	transport->io.TCPConnect = freerdp_tcp_default_connect;
-	transport->io.RDPConnect = transport_default_connect_rdp;
 	transport->io.TLSConnect = transport_default_connect_tls;
-	transport->io.RDPAccept = transport_default_accept_rdp;
 	transport->io.TLSAccept = transport_default_accept_tls;
 	transport->io.TransportAttach = transport_default_attach;
 	transport->io.TransportDisconnect = transport_default_disconnect;

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -835,7 +835,11 @@ static int transport_default_read_pdu(rdpTransport* transport, wStream* s)
 		}
 	}
 
-	if (!Stream_EnsureCapacity(s, Stream_GetPosition(s) + pduLength))
+	if (!Stream_EnsureCapacity(s, pduLength))
+		return -1;
+
+	position = Stream_GetPosition(s);
+	if (position > pduLength)
 		return -1;
 
 	status = transport_read_layer_bytes(transport, s, pduLength - Stream_GetPosition(s));

--- a/libfreerdp/core/transport.h
+++ b/libfreerdp/core/transport.h
@@ -48,6 +48,7 @@ typedef enum
 #include <time.h>
 #include <freerdp/types.h>
 #include <freerdp/settings.h>
+#include <freerdp/transport_io.h>
 
 typedef int (*TransportRecv)(rdpTransport* transport, wStream* stream, void* extra);
 

--- a/libfreerdp/core/transport.h
+++ b/libfreerdp/core/transport.h
@@ -29,8 +29,6 @@ typedef enum
 	TRANSPORT_LAYER_CLOSED
 } TRANSPORT_LAYER;
 
-typedef struct rdp_transport rdpTransport;
-
 #include "tcp.h"
 #include "nla.h"
 
@@ -52,33 +50,6 @@ typedef struct rdp_transport rdpTransport;
 #include <freerdp/settings.h>
 
 typedef int (*TransportRecv)(rdpTransport* transport, wStream* stream, void* extra);
-
-typedef int (*pTCPConnect)(rdpContext* context, rdpSettings* settings, const char* hostname,
-                           int port, DWORD timeout);
-typedef BOOL (*pTransportFkt)(rdpTransport* transport);
-typedef BOOL (*pTransportAttach)(rdpTransport* transport, int sockfd);
-
-typedef int (*pTransportRWFkt)(rdpTransport* transport, wStream* s);
-typedef int (*pDataHandler)(rdpContext* context, const BYTE* buf, size_t buf_size);
-
-typedef SSIZE_T (*pTransportRead)(rdpTransport* transport, BYTE* data, size_t bytes);
-
-struct rdp_transport_io
-{
-	pTCPConnect TCPConnect;
-	pTransportFkt RDPConnect;
-	pTransportFkt RDPAccept;
-	pTransportFkt TLSConnect;
-	pTransportFkt TLSAccept;
-	pTransportFkt NLAConnect;
-	pTransportFkt NLAAccept;
-	pTransportAttach TransportAttach;
-	pTransportFkt TransportDisconnect;
-	pTransportRWFkt ReadPdu;  /* Reads a whole PDU from the transport */
-	pTransportRWFkt WritePdu; /* Writes a whole PDU to the transport */
-	pTransportRead ReadBytes; /* Reads up to a requested amount of bytes from the transport */
-};
-typedef struct rdp_transport_io rdpTransportIo;
 
 struct rdp_transport
 {


### PR DESCRIPTION
* eliminated code duplication, so it's not required to export rdp protocol specific api
* dropped some protocol related functions which is not needed for external io backend.