### PR TITLE
Ignore NULL streams in StreamPool_Return

### DIFF
--- a/winpr/libwinpr/utils/collections/StreamPool.c
+++ b/winpr/libwinpr/utils/collections/StreamPool.c
@@ -218,6 +218,9 @@ out_fail:
 
 void StreamPool_Return(wStreamPool* pool, wStream* s)
 {
+	if (!s)
+		return;
+
 	if (pool->synchronized)
 		EnterCriticalSection(&pool->lock);
 


### PR DESCRIPTION
Prevents NULL streams to be added to streampool list