### PR TITLE
Scale cursor so it matches the scale of everything else

### DIFF
--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -777,6 +777,13 @@ BOOL freerdp_image_scale(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT3
                          UINT32 nSrcWidth, UINT32 nSrcHeight)
 {
 	BOOL rc = FALSE;
+
+	if (nDstStep == 0)
+		nDstStep = nDstWidth * GetBytesPerPixel(DstFormat);
+
+	if (nSrcStep == 0)
+		nSrcStep = nSrcWidth * GetBytesPerPixel(SrcFormat);
+
 #if defined(SWSCALE_FOUND) || defined(CAIRO_FOUND)
 	const BYTE* src = &pSrcData[nXSrc * GetBytesPerPixel(SrcFormat) + nYSrc * nSrcStep];
 	BYTE* dst = &pDstData[nXDst * GetBytesPerPixel(DstFormat) + nYDst * nDstStep];


### PR DESCRIPTION
Makes use of the percent scale setting to scale the cursor in the X11 client. This ensures that the cursor scale matches the scale of the rest of the RDP session. In my particular use case, the cursor is not tiny when viewing a 1080p session on a 4k monitor.