### PR TITLE
Fixes #5747: Only activate sound output device

### DIFF
--- a/channels/rdpsnd/client/mac/rdpsnd_mac.m
+++ b/channels/rdpsnd/client/mac/rdpsnd_mac.m
@@ -167,22 +167,14 @@ static BOOL rdpsnd_mac_open(rdpsndDevicePlugin *device, const AUDIO_FORMAT *form
 	if (!mac->engine)
 		return FALSE;
 
-	if (@available(macOS 10.15, *))
+	err = AudioUnitSetProperty(mac->engine.outputNode.audioUnit,
+							   kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global,
+							   0, &outputDeviceID, sizeof(outputDeviceID));
+	if (err)
 	{
-		/* Setting the output audio device on 10.15 or later breaks sound playback. Do not set for
-		 * now until we find a proper fix for #5747 */
-	}
-	else
-	{
-		err = AudioUnitSetProperty(mac->engine.outputNode.audioUnit,
-		                           kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global,
-		                           0, &outputDeviceID, sizeof(outputDeviceID));
-		if (err)
-		{
-			rdpsnd_mac_release(mac);
-			WLog_ERR(TAG, "AudioUnitSetProperty: %s", FormatError(err));
-			return FALSE;
-		}
+		rdpsnd_mac_release(mac);
+		WLog_ERR(TAG, "AudioUnitSetProperty: %s", FormatError(err));
+		return FALSE;
 	}
 
 	mac->player = [[AVAudioPlayerNode alloc] init];
@@ -196,6 +188,8 @@ static BOOL rdpsnd_mac_open(rdpsndDevicePlugin *device, const AUDIO_FORMAT *form
 	[mac->engine attachNode:mac->player];
 
 	[mac->engine connect:mac->player to:mac->engine.mainMixerNode format:nil];
+	
+	[mac->engine prepare];
 
 	if (![mac->engine startAndReturnError:&error])
 	{
@@ -275,6 +269,18 @@ static void rdpsnd_mac_start(rdpsndDevicePlugin *device)
 
 	if (!mac->isPlaying)
 	{
+		if (!mac->engine.isRunning)
+		{
+			NSError* error;
+			
+			if (![mac->engine startAndReturnError:&error])
+			{
+				device->Close(device);
+				WLog_ERR(TAG, "Failed to start audio player %s", [error.localizedDescription UTF8String]);
+				return;
+			}
+		}
+		
 		[mac->player play];
 
 		mac->isPlaying = TRUE;

--- a/channels/rdpsnd/client/mac/rdpsnd_mac.m
+++ b/channels/rdpsnd/client/mac/rdpsnd_mac.m
@@ -168,8 +168,8 @@ static BOOL rdpsnd_mac_open(rdpsndDevicePlugin *device, const AUDIO_FORMAT *form
 		return FALSE;
 
 	err = AudioUnitSetProperty(mac->engine.outputNode.audioUnit,
-							   kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global,
-							   0, &outputDeviceID, sizeof(outputDeviceID));
+	                           kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 0,
+	                           &outputDeviceID, sizeof(outputDeviceID));
 	if (err)
 	{
 		rdpsnd_mac_release(mac);
@@ -188,7 +188,7 @@ static BOOL rdpsnd_mac_open(rdpsndDevicePlugin *device, const AUDIO_FORMAT *form
 	[mac->engine attachNode:mac->player];
 
 	[mac->engine connect:mac->player to:mac->engine.mainMixerNode format:nil];
-	
+
 	[mac->engine prepare];
 
 	if (![mac->engine startAndReturnError:&error])
@@ -271,16 +271,17 @@ static void rdpsnd_mac_start(rdpsndDevicePlugin *device)
 	{
 		if (!mac->engine.isRunning)
 		{
-			NSError* error;
-			
+			NSError *error;
+
 			if (![mac->engine startAndReturnError:&error])
 			{
 				device->Close(device);
-				WLog_ERR(TAG, "Failed to start audio player %s", [error.localizedDescription UTF8String]);
+				WLog_ERR(TAG, "Failed to start audio player %s",
+				         [error.localizedDescription UTF8String]);
 				return;
 			}
 		}
-		
+
 		[mac->player play];
 
 		mac->isPlaying = TRUE;


### PR DESCRIPTION
Fixes #5747 by only activating the sound output device instead of both, input and output devices.
This works around the problem that some microphone monitoring tools (like "Micro Snitch") were activated by just playing a sound inside a remote session.
This also fixes the problem that starting with macOS 10.15 sometimes the audio device wasn't ready when sound was starting to play. The fix is to check if the audio engine is running, and if it isn't, starting it inside `rdpsnd_mac_start`.