### PR TITLE
Added switch: ignore invalid Fast-Path Cached Pointer Updates from buggy server

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1949,6 +1949,10 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 		{
 			settings->AllowUnanouncedOrdersFromServer = enable;
 		}
+		CommandLineSwitchCase(arg, "relax-cachedpointer-updates")
+		{
+			settings->IgnoreInvalidCachedPointerUpdates = enable;
+		}
 		CommandLineSwitchCase(arg, "restricted-admin")
 		{
 			settings->ConsoleSession = enable;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -289,6 +289,10 @@ static const COMMAND_LINE_ARGUMENT_A args[] = {
 	{ "relax-order-checks", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "relax-order-checks",
 	  "Do not check if a RDP order was announced during capability exchange, only use when "
 	  "connecting to a buggy server" },
+	{ "relax-cachedpointer-updates", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "relax-cachedpointer-updates",
+	  "Ignore pointer cache errors which can occur when the server sends a Fast-Path Cached "
+	  "Pointer Update with an invalid (not set) cache index. Only use when connecting to a "
+	  "buggy server" },
 	{ "restricted-admin", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "restrictedAdmin",
 	  "Restricted admin mode" },
 	{ "rfx", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "RemoteFX" },

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -1559,6 +1559,8 @@ struct rdp_settings
 	                                   default value - currently UNUSED! */
 	ALIGN64 char* ActionScript;
 	ALIGN64 DWORD Floatbar;
+
+	ALIGN64 BOOL IgnoreInvalidCachedPointerUpdates;
 };
 typedef struct rdp_settings rdpSettings;
 

--- a/libfreerdp/cache/pointer.c
+++ b/libfreerdp/cache/pointer.c
@@ -240,6 +240,13 @@ static BOOL update_pointer_cached(rdpContext* context, const POINTER_CACHED_UPDA
 	if (pointer != NULL)
 		return IFCALLRESULT(TRUE, pointer->Set, context, pointer);
 
+	if (context->instance->settings->IgnoreInvalidCachedPointerUpdates)
+	{
+		WLog_DBG(TAG, "ignored invalid pointer index (pointer not in cache):%" PRIu32 "",
+					pointer_cached->cacheIndex);
+		return TRUE;
+	}
+
 	return FALSE;
 }
 


### PR DESCRIPTION
## Summary

This pull request adds a `/relax-cachedpointer-updates` CLI switch, which allows FreeRDP to ignore pointer cache errors when a buggy server sends Fast-Path Cached Pointer Update with an invalid (not set) cache index.

## The fixed issue

I experienced the issue when I tried to reach a Windows 2016 target through Wallix Redemption 1.1.76 (RDP Proxy - [link to github project](https://github.com/wallix/redemption)).

Once connected to the target, I tried to type something on any kind of text input field (file explorer, PuTTY, etc.), and FreeRDP crashed with a `Fastpath update Cached Pointer [a] failed, status 0` error message.

Same behavior for another target : xrdp 0.9.9 on Ubuntu 16.04 (same Redemption proxy).

I've been able to reproduce the issue with freerdp 2.2.0 run as standalone X11 app on Debian 10.5 and as library used in Apache Guacamole guacd service 1.2.0.

The issue does not occur when connecting the same target from Microsoft RDP clients.

## Debug

### Temporary routines

In `libfreerdp/cache/pointer.c`, function `pointer_cache_get()` :

```c
WLog_INFO(TAG, "------> Pointer GET index : %" PRIu32 " <------", index);
```

In `libfreerdp/cache/pointer.c`, function `pointer_cache_put()` :

```c
WLog_INFO(TAG, "------> Pointer PUT index : %" PRIu32 " <------", index);
```

### Debug command

```bash
./client/X11/xfreerdp /v:"$BUGGY_SERVER" /u:"$RDP_USERNAME" /p:"$RDP_PASSWORD" /cert-ignore /relax-order-checks -glyph-cache
```

### Debug output

```
[22:17:10:885] [19280:19281] [INFO][com.freerdp.core] - freerdp_connect:freerdp_set_last_error_ex resetting error state
[22:17:10:885] [19280:19281] [INFO][com.freerdp.client.common.cmdline] - loading channelEx rdpdr
[22:17:10:885] [19280:19281] [INFO][com.freerdp.client.common.cmdline] - loading channelEx rdpsnd
[22:17:10:885] [19280:19281] [INFO][com.freerdp.client.common.cmdline] - loading channelEx cliprdr
[22:17:10:316] [19280:19281] [INFO][com.freerdp.primitives] - primitives autodetect, using optimized
[22:17:10:318] [19280:19281] [INFO][com.freerdp.core] - freerdp_tcp_is_hostname_resolvable:freerdp_set_last_error_ex resetting error state
[22:17:10:318] [19280:19281] [INFO][com.freerdp.core] - freerdp_tcp_connect:freerdp_set_last_error_ex resetting error state
[22:17:11:449] [19280:19281] [WARN][com.freerdp.core.rdp] - pduType PDU_TYPE_DATA not properly parsed, 164 bytes remaining unhandled. Skipping.
[22:17:11:449] [19280:19281] [INFO][com.freerdp.gdi] - Local framebuffer format  PIXEL_FORMAT_BGRA32
[22:17:11:449] [19280:19281] [INFO][com.freerdp.gdi] - Remote framebuffer format PIXEL_FORMAT_RGB16
[22:17:11:477] [19280:19281] [INFO][com.winpr.clipboard] - initialized POSIX local file subsystem
[22:17:11:478] [19280:19281] [INFO][com.freerdp.channels.rdpsnd.client] - [static] Loaded fake backend for rdpsnd
[22:17:12:855] [19280:19281] [WARN][com.freerdp.core.update] - [0x01] Cache Color Table - SERVER BUG: The support for this feature was not announced!
[22:17:14:825] [19280:19281] [INFO][com.freerdp.cache.pointer] - ------> Pointer PUT index : 0 <------
[22:17:15:807] [19280:19281] [INFO][com.freerdp.cache.pointer] - ------> Pointer PUT index : 1 <------
[22:17:15:807] [19280:19281] [INFO][com.freerdp.cache.pointer] - ------> Pointer PUT index : 2 <------
[22:17:15:821] [19280:19281] [INFO][com.freerdp.cache.pointer] - ------> Pointer GET index : 1 <------
[22:17:15:843] [19280:19281] [INFO][com.freerdp.cache.pointer] - ------> Pointer GET index : 2 <------
[22:17:15:853] [19280:19281] [INFO][com.freerdp.cache.pointer] - ------> Pointer PUT index : 3 <------
[22:17:15:866] [19280:19281] [INFO][com.freerdp.cache.pointer] - ------> Pointer GET index : 2 <------
[22:17:15:898] [19280:19281] [INFO][com.freerdp.cache.pointer] - ------> Pointer GET index : 1 <------
[22:17:15:033] [19280:19281] [INFO][com.freerdp.cache.pointer] - ------> Pointer GET index : 4 <------
[22:17:15:033] [19280:19281] [ERROR][com.freerdp.core.fastpath] - Fastpath update Cached Pointer [a] failed, status 0
[22:17:15:033] [19280:19281] [ERROR][com.freerdp.core.fastpath] - fastpath_recv_update() - -1
[22:17:15:033] [19280:19281] [ERROR][com.freerdp.core.fastpath] - fastpath_recv_update_data() fail
[22:17:15:033] [19280:19281] [ERROR][com.freerdp.core.transport] - transport_check_fds: transport->ReceiveCallback() - -3
[22:17:15:033] [19280:19281] [ERROR][com.freerdp.core] - freerdp_check_fds() failed - 0
[22:17:15:033] [19280:19281] [INFO][com.freerdp.client.common] - Network disconnect!
[22:17:15:033] [19280:19281] [ERROR][com.freerdp.client.x11] - Failed to check FreeRDP file descriptor
```

At `22:17:15:033`, a *Fast-Path Cached Pointer Update* is received for cached index `4`. But no `pointer_cache_put()` has been called for this index. A `NULL` pointer is returned by `pointer_cache_get()` and `fastpath_recv_update()` (`fastpath.c`) returns `-1`.

## Resolution

This patch + appended `/relax-cachedpointer-updates` switch to xfreerdp command : The RDP session stay alive and I see no visual regression.