### PR TITLE
memory grows over time in wlfreerdp with /gfx:AVC444 fixed.

### DIFF
--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -121,7 +121,8 @@ static void xdg_handle_toplevel_configure(void* data, struct xdg_toplevel* xdg_t
 	event->window = window;
 	event->states = surfaceState;
 
-	if (width && height)
+	if ((width > 0 && height > 0) &&
+		(width != window->width ||  height != window->height))
 	{
 		event->width = width;
 		event->height = height;


### PR DESCRIPTION
- When running wlfreerdp with /gfx:AVC444 parameter. Resident size of the FreeRDP process gradually grows overtime and never shrinks even if the video paused or stoped.

- Sometimes wlfreerdp crashes when there are a lot of movement on the screen (like, dragging window fast in windows).

**Compilation**
`cmake -GNinja  -DWITH_VAAPI=ON -DWITH_GFX_H264=ON -DWITH_FFMPEG=ON -DWITH_DSP_FFMPEG=ON  WITH_SSE2=ON -DWITH_CAIRO=ON -DWITH_OPENH264=OFF -DCHANNEL_URBDRC=ON -DWITH_CUPS=ON -DWITH_PULSE=ON -DWITH_FAAC=OFF -DWITH_FAAD2=OFF -DWITH_GSM=OFF -DWITH_WAYLAND=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr/ -DCMAKE_BUILD_TYPE=Release .`

**Run Command**
`/wlfreerdp /v:<ip> /u:<username> /p:<password> /relax-order-checks +glyph-cache /cert-ignore /audio-mode:0 +mic /size:1920x1080 /network:LAN /gfx:avc444 `



