### PR TITLE
channels/disp/client/disp_main.c: fix possible null pointer dereference

### DIFF
--- a/channels/disp/client/disp_main.c
+++ b/channels/disp/client/disp_main.c
@@ -335,9 +335,9 @@ static UINT disp_plugin_terminated(IWTSPlugin* pPlugin)
 		IWTSVirtualChannelManager* mgr = disp->listener_callback->channel_mgr;
 		if (mgr)
 			IFCALL(mgr->DestroyListener, mgr, disp->listener);
+		free(disp->listener_callback);
 	}
 
-	free(disp->listener_callback);
 	free(disp->iface.pInterface);
 	free(pPlugin);
 	return CHANNEL_RC_OK;


### PR DESCRIPTION
found by cppcheck

channels/disp/client/disp_main.c:340:7: warning:
Either the condition 'if(disp&&disp->listener_callback)' is redundant or
there is possible null pointer dereference: disp. [nullPointerRedundantCheck]
