### PR TITLE
server: add WTSVirtualChannelManagerCheckFileDescriptorEx API

### DIFF
--- a/include/freerdp/channels/wtsvc.h
+++ b/include/freerdp/channels/wtsvc.h
@@ -59,6 +59,7 @@ extern "C"
 	FREERDP_API void WTSVirtualChannelManagerGetFileDescriptor(HANDLE hServer, void** fds,
 	                                                           int* fds_count);
 	FREERDP_API BOOL WTSVirtualChannelManagerCheckFileDescriptor(HANDLE hServer);
+	FREERDP_API BOOL WTSVirtualChannelManagerCheckFileDescriptorEx(HANDLE hServer, BOOL autoOpen);
 	FREERDP_API HANDLE WTSVirtualChannelManagerGetEventHandle(HANDLE hServer);
 	FREERDP_API BOOL WTSVirtualChannelManagerIsChannelJoined(HANDLE hServer, const char* name);
 	FREERDP_API BYTE WTSVirtualChannelManagerGetDrdynvcState(HANDLE hServer);

--- a/include/freerdp/client/rdpgfx.h
+++ b/include/freerdp/client/rdpgfx.h
@@ -150,7 +150,16 @@ struct _rdpgfx_client_context
 	PROFILER_DEFINE(SurfaceProfiler)
 };
 
-FREERDP_API RdpgfxClientContext* rdpgfx_client_context_new(rdpSettings* settings);
-FREERDP_API void rdpgfx_client_context_free(RdpgfxClientContext* context);
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+	FREERDP_API RdpgfxClientContext* rdpgfx_client_context_new(rdpSettings* settings);
+	FREERDP_API void rdpgfx_client_context_free(RdpgfxClientContext* context);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FREERDP_CHANNEL_RDPGFX_CLIENT_RDPGFX_H */


### PR DESCRIPTION
This PR makes it possible to turn off drdynvc on server side, but still allow static channels.
Also added missing `extern "C"` for rdpgfx public API.