### PR TITLE
Fixed parsing of FastGlyph order.

### DIFF
--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -1061,76 +1061,94 @@ static INLINE BOOL update_read_delta_points(wStream* s, DELTA_POINT* points, int
 
 	return TRUE;
 }
-#define ORDER_FIELD_BYTE(NO, TARGET)                        \
-	do                                                      \
-	{                                                       \
-		if (orderInfo->fieldFlags & (1 << (NO - 1)))        \
-		{                                                   \
-			if (Stream_GetRemainingLength(s) < 1)           \
-			{                                               \
-				WLog_ERR(TAG, "error reading %s", #TARGET); \
-				return FALSE;                               \
-			}                                               \
-			Stream_Read_UINT8(s, TARGET);                   \
-		}                                                   \
-	} while (0)
-#define ORDER_FIELD_2BYTE(NO, TARGET1, TARGET2)                              \
-	do                                                                       \
-	{                                                                        \
-		if (orderInfo->fieldFlags & (1 << (NO - 1)))                         \
-		{                                                                    \
-			if (Stream_GetRemainingLength(s) < 2)                            \
-			{                                                                \
-				WLog_ERR(TAG, "error reading %s or %s", #TARGET1, #TARGET2); \
-				return FALSE;                                                \
-			}                                                                \
-			Stream_Read_UINT8(s, TARGET1);                                   \
-			Stream_Read_UINT8(s, TARGET2);                                   \
-		}                                                                    \
-	} while (0)
-#define ORDER_FIELD_UINT16(NO, TARGET)                      \
-	do                                                      \
-	{                                                       \
-		if (orderInfo->fieldFlags & (1 << (NO - 1)))        \
-		{                                                   \
-			if (Stream_GetRemainingLength(s) < 2)           \
-			{                                               \
-				WLog_ERR(TAG, "error reading %s", #TARGET); \
-				return FALSE;                               \
-			}                                               \
-			Stream_Read_UINT16(s, TARGET);                  \
-		}                                                   \
-	} while (0)
-#define ORDER_FIELD_UINT32(NO, TARGET)                      \
-	do                                                      \
-	{                                                       \
-		if (orderInfo->fieldFlags & (1 << (NO - 1)))        \
-		{                                                   \
-			if (Stream_GetRemainingLength(s) < 4)           \
-			{                                               \
-				WLog_ERR(TAG, "error reading %s", #TARGET); \
-				return FALSE;                               \
-			}                                               \
-			Stream_Read_UINT32(s, TARGET);                  \
-		}                                                   \
-	} while (0)
-#define ORDER_FIELD_COORD(NO, TARGET)                                    \
-	do                                                                   \
-	{                                                                    \
-		if ((orderInfo->fieldFlags & (1 << (NO - 1))) &&                 \
-		    !update_read_coord(s, &TARGET, orderInfo->deltaCoordinates)) \
-		{                                                                \
-			WLog_ERR(TAG, "error reading %s", #TARGET);                  \
-			return FALSE;                                                \
-		}                                                                \
-	} while (0)
-static INLINE BOOL ORDER_FIELD_COLOR(const ORDER_INFO* orderInfo, wStream* s, UINT32 NO,
-                                     UINT32* TARGET)
+
+static INLINE BOOL read_order_field_byte(const ORDER_INFO* orderInfo, wStream* s, BYTE number,
+                                         UINT32* target, BOOL optional)
 {
-	if (!TARGET || !orderInfo)
+	const BOOL set = orderInfo->fieldFlags & (1 << (number - 1));
+	if (!set)
+		return TRUE;
+	if (Stream_GetRemainingLength(s) < 1)
+		return FALSE;
+	Stream_Read_UINT8(s, *target);
+	return TRUE;
+}
+
+static INLINE BOOL read_order_field_2bytes(const ORDER_INFO* orderInfo, wStream* s, BYTE number,
+                                           UINT32* target1, UINT32* target2, BOOL optional)
+{
+	const BOOL set = orderInfo->fieldFlags & (1 << (number - 1));
+	if (!set)
+		return TRUE;
+	if (Stream_GetRemainingLength(s) < 2)
+		return FALSE;
+	Stream_Read_UINT8(s, *target1);
+	Stream_Read_UINT8(s, *target2);
+	return TRUE;
+}
+
+static INLINE BOOL read_order_field_uint16(const ORDER_INFO* orderInfo, wStream* s, BYTE number,
+                                           UINT32* target, BOOL optional)
+{
+	const BOOL set = orderInfo->fieldFlags & (1 << (number - 1));
+	if (!set)
+		return TRUE;
+
+	if (Stream_GetRemainingLength(s) < 2)
 		return FALSE;
 
-	if ((orderInfo->fieldFlags & (1 << (NO - 1))) && !update_read_color(s, TARGET))
+	Stream_Read_UINT16(s, *target);
+	return TRUE;
+}
+
+static INLINE BOOL read_order_field_int16(const ORDER_INFO* orderInfo, wStream* s, BYTE number,
+                                          INT32* target, BOOL optional)
+{
+	const BOOL set = orderInfo->fieldFlags & (1 << (number - 1));
+	if (!set)
+		return TRUE;
+
+	if (Stream_GetRemainingLength(s) < 2)
+		return FALSE;
+
+	Stream_Read_INT16(s, *target);
+	return TRUE;
+}
+
+static INLINE BOOL read_order_field_uint32(const ORDER_INFO* orderInfo, wStream* s, BYTE number,
+                                           UINT32* target, BOOL optional)
+{
+	const BOOL set = orderInfo->fieldFlags & (1 << (number - 1));
+	if (!set)
+		return TRUE;
+	if (Stream_GetRemainingLength(s) < 4)
+		return FALSE;
+
+	Stream_Read_UINT32(s, *target);
+}
+
+static INLINE BOOL read_order_field_coord(const ORDER_INFO* orderInfo, wStream* s, UINT32 NO,
+                                          INT32* TARGET, BOOL optional)
+{
+	const BOOL set = (orderInfo->fieldFlags & (1 << (NO - 1)));
+	if (!TARGET || !orderInfo)
+		return FALSE;
+	if (!set)
+		return TRUE;
+
+	return update_read_coord(s, TARGET, orderInfo->deltaCoordinates);
+}
+
+static INLINE BOOL read_order_field_color(const ORDER_INFO* orderInfo, wStream* s, UINT32 NO,
+                                          UINT32* TARGET, BOOL optional)
+{
+	const BOOL set = (orderInfo->fieldFlags & (1 << (NO - 1)));
+	if (!TARGET || !orderInfo)
+		return FALSE;
+	if (!set)
+		return TRUE;
+
+	if (!update_read_color(s, TARGET))
 		return FALSE;
 
 	return TRUE;
@@ -1153,11 +1171,12 @@ static INLINE BOOL FIELD_SKIP_BUFFER16(wStream* s, UINT32 TARGET_LEN)
 /* Primary Drawing Orders */
 static BOOL update_read_dstblt_order(wStream* s, const ORDER_INFO* orderInfo, DSTBLT_ORDER* dstblt)
 {
-	ORDER_FIELD_COORD(1, dstblt->nLeftRect);
-	ORDER_FIELD_COORD(2, dstblt->nTopRect);
-	ORDER_FIELD_COORD(3, dstblt->nWidth);
-	ORDER_FIELD_COORD(4, dstblt->nHeight);
-	ORDER_FIELD_BYTE(5, dstblt->bRop);
+	if (!read_order_field_coord(orderInfo, s, 1, &dstblt->nLeftRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &dstblt->nTopRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &dstblt->nWidth, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &dstblt->nHeight, FALSE) ||
+	    !read_order_field_byte(orderInfo, s, 5, &dstblt->bRop, TRUE))
+		return FALSE;
 	return TRUE;
 }
 int update_approximate_dstblt_order(ORDER_INFO* orderInfo, const DSTBLT_ORDER* dstblt)
@@ -1184,13 +1203,14 @@ BOOL update_write_dstblt_order(wStream* s, ORDER_INFO* orderInfo, const DSTBLT_O
 }
 static BOOL update_read_patblt_order(wStream* s, const ORDER_INFO* orderInfo, PATBLT_ORDER* patblt)
 {
-	ORDER_FIELD_COORD(1, patblt->nLeftRect);
-	ORDER_FIELD_COORD(2, patblt->nTopRect);
-	ORDER_FIELD_COORD(3, patblt->nWidth);
-	ORDER_FIELD_COORD(4, patblt->nHeight);
-	ORDER_FIELD_BYTE(5, patblt->bRop);
-	ORDER_FIELD_COLOR(orderInfo, s, 6, &patblt->backColor);
-	ORDER_FIELD_COLOR(orderInfo, s, 7, &patblt->foreColor);
+	if (!read_order_field_coord(orderInfo, s, 1, &patblt->nLeftRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &patblt->nTopRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &patblt->nWidth, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &patblt->nHeight, FALSE) ||
+	    !read_order_field_byte(orderInfo, s, 5, &patblt->bRop, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 6, &patblt->backColor, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 7, &patblt->foreColor, TRUE))
+		return FALSE;
 	return update_read_brush(s, &patblt->brush, orderInfo->fieldFlags >> 7);
 }
 int update_approximate_patblt_order(ORDER_INFO* orderInfo, PATBLT_ORDER* patblt)
@@ -1227,13 +1247,14 @@ BOOL update_write_patblt_order(wStream* s, ORDER_INFO* orderInfo, PATBLT_ORDER* 
 }
 static BOOL update_read_scrblt_order(wStream* s, const ORDER_INFO* orderInfo, SCRBLT_ORDER* scrblt)
 {
-	ORDER_FIELD_COORD(1, scrblt->nLeftRect);
-	ORDER_FIELD_COORD(2, scrblt->nTopRect);
-	ORDER_FIELD_COORD(3, scrblt->nWidth);
-	ORDER_FIELD_COORD(4, scrblt->nHeight);
-	ORDER_FIELD_BYTE(5, scrblt->bRop);
-	ORDER_FIELD_COORD(6, scrblt->nXSrc);
-	ORDER_FIELD_COORD(7, scrblt->nYSrc);
+	if (!read_order_field_coord(orderInfo, s, 1, &scrblt->nLeftRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &scrblt->nTopRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &scrblt->nWidth, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &scrblt->nHeight, FALSE) ||
+	    !read_order_field_byte(orderInfo, s, 5, &scrblt->bRop, TRUE) ||
+	    !read_order_field_coord(orderInfo, s, 6, &scrblt->nXSrc, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 7, &scrblt->nYSrc, FALSE))
+		return FALSE;
 	return TRUE;
 }
 int update_approximate_scrblt_order(ORDER_INFO* orderInfo, const SCRBLT_ORDER* scrblt)
@@ -1266,12 +1287,13 @@ static BOOL update_read_opaque_rect_order(wStream* s, const ORDER_INFO* orderInf
                                           OPAQUE_RECT_ORDER* opaque_rect)
 {
 	BYTE byte;
-	ORDER_FIELD_COORD(1, opaque_rect->nLeftRect);
-	ORDER_FIELD_COORD(2, opaque_rect->nTopRect);
-	ORDER_FIELD_COORD(3, opaque_rect->nWidth);
-	ORDER_FIELD_COORD(4, opaque_rect->nHeight);
+	if (!read_order_field_coord(orderInfo, s, 1, &opaque_rect->nLeftRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &opaque_rect->nTopRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &opaque_rect->nWidth, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &opaque_rect->nHeight, FALSE))
+		return FALSE;
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_05)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_05) != 0)
 	{
 		if (Stream_GetRemainingLength(s) < 1)
 			return FALSE;
@@ -1280,7 +1302,7 @@ static BOOL update_read_opaque_rect_order(wStream* s, const ORDER_INFO* orderInf
 		opaque_rect->color = (opaque_rect->color & 0x00FFFF00) | ((UINT32)byte);
 	}
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_06)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_06) != 0)
 	{
 		if (Stream_GetRemainingLength(s) < 1)
 			return FALSE;
@@ -1289,7 +1311,7 @@ static BOOL update_read_opaque_rect_order(wStream* s, const ORDER_INFO* orderInf
 		opaque_rect->color = (opaque_rect->color & 0x00FF00FF) | ((UINT32)byte << 8);
 	}
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_07)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_07) != 0)
 	{
 		if (Stream_GetRemainingLength(s) < 1)
 			return FALSE;
@@ -1338,24 +1360,26 @@ BOOL update_write_opaque_rect_order(wStream* s, ORDER_INFO* orderInfo,
 static BOOL update_read_draw_nine_grid_order(wStream* s, const ORDER_INFO* orderInfo,
                                              DRAW_NINE_GRID_ORDER* draw_nine_grid)
 {
-	ORDER_FIELD_COORD(1, draw_nine_grid->srcLeft);
-	ORDER_FIELD_COORD(2, draw_nine_grid->srcTop);
-	ORDER_FIELD_COORD(3, draw_nine_grid->srcRight);
-	ORDER_FIELD_COORD(4, draw_nine_grid->srcBottom);
-	ORDER_FIELD_UINT16(5, draw_nine_grid->bitmapId);
+	if (!read_order_field_coord(orderInfo, s, 1, &draw_nine_grid->srcLeft, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &draw_nine_grid->srcTop, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &draw_nine_grid->srcRight, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &draw_nine_grid->srcBottom, FALSE) ||
+	    !read_order_field_uint16(orderInfo, s, 5, &draw_nine_grid->bitmapId, FALSE))
+		return FALSE;
 	return TRUE;
 }
 static BOOL update_read_multi_dstblt_order(wStream* s, const ORDER_INFO* orderInfo,
                                            MULTI_DSTBLT_ORDER* multi_dstblt)
 {
-	ORDER_FIELD_COORD(1, multi_dstblt->nLeftRect);
-	ORDER_FIELD_COORD(2, multi_dstblt->nTopRect);
-	ORDER_FIELD_COORD(3, multi_dstblt->nWidth);
-	ORDER_FIELD_COORD(4, multi_dstblt->nHeight);
-	ORDER_FIELD_BYTE(5, multi_dstblt->bRop);
-	ORDER_FIELD_BYTE(6, multi_dstblt->numRectangles);
+	if (!read_order_field_coord(orderInfo, s, 1, &multi_dstblt->nLeftRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &multi_dstblt->nTopRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &multi_dstblt->nWidth, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &multi_dstblt->nHeight, FALSE) ||
+	    !read_order_field_byte(orderInfo, s, 5, &multi_dstblt->bRop, TRUE) ||
+	    !read_order_field_byte(orderInfo, s, 6, &multi_dstblt->numRectangles, TRUE))
+		return FALSE;
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_07)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_07) != 0)
 	{
 		if (Stream_GetRemainingLength(s) < 2)
 			return FALSE;
@@ -1369,20 +1393,22 @@ static BOOL update_read_multi_dstblt_order(wStream* s, const ORDER_INFO* orderIn
 static BOOL update_read_multi_patblt_order(wStream* s, const ORDER_INFO* orderInfo,
                                            MULTI_PATBLT_ORDER* multi_patblt)
 {
-	ORDER_FIELD_COORD(1, multi_patblt->nLeftRect);
-	ORDER_FIELD_COORD(2, multi_patblt->nTopRect);
-	ORDER_FIELD_COORD(3, multi_patblt->nWidth);
-	ORDER_FIELD_COORD(4, multi_patblt->nHeight);
-	ORDER_FIELD_BYTE(5, multi_patblt->bRop);
-	ORDER_FIELD_COLOR(orderInfo, s, 6, &multi_patblt->backColor);
-	ORDER_FIELD_COLOR(orderInfo, s, 7, &multi_patblt->foreColor);
+	if (!read_order_field_coord(orderInfo, s, 1, &multi_patblt->nLeftRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &multi_patblt->nTopRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &multi_patblt->nWidth, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &multi_patblt->nHeight, FALSE) ||
+	    !read_order_field_byte(orderInfo, s, 5, &multi_patblt->bRop, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 6, &multi_patblt->backColor, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 7, &multi_patblt->foreColor, TRUE))
+		return FALSE;
 
 	if (!update_read_brush(s, &multi_patblt->brush, orderInfo->fieldFlags >> 7))
 		return FALSE;
 
-	ORDER_FIELD_BYTE(13, multi_patblt->numRectangles);
+	if (!read_order_field_byte(orderInfo, s, 13, &multi_patblt->numRectangles, TRUE))
+		return FALSE;
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_14)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_14) != 0)
 	{
 		if (Stream_GetRemainingLength(s) < 2)
 			return FALSE;
@@ -1398,16 +1424,17 @@ static BOOL update_read_multi_patblt_order(wStream* s, const ORDER_INFO* orderIn
 static BOOL update_read_multi_scrblt_order(wStream* s, const ORDER_INFO* orderInfo,
                                            MULTI_SCRBLT_ORDER* multi_scrblt)
 {
-	ORDER_FIELD_COORD(1, multi_scrblt->nLeftRect);
-	ORDER_FIELD_COORD(2, multi_scrblt->nTopRect);
-	ORDER_FIELD_COORD(3, multi_scrblt->nWidth);
-	ORDER_FIELD_COORD(4, multi_scrblt->nHeight);
-	ORDER_FIELD_BYTE(5, multi_scrblt->bRop);
-	ORDER_FIELD_COORD(6, multi_scrblt->nXSrc);
-	ORDER_FIELD_COORD(7, multi_scrblt->nYSrc);
-	ORDER_FIELD_BYTE(8, multi_scrblt->numRectangles);
+	if (!read_order_field_coord(orderInfo, s, 1, &multi_scrblt->nLeftRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &multi_scrblt->nTopRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &multi_scrblt->nWidth, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &multi_scrblt->nHeight, FALSE) ||
+	    !read_order_field_byte(orderInfo, s, 5, &multi_scrblt->bRop, TRUE) ||
+	    !read_order_field_coord(orderInfo, s, 6, &multi_scrblt->nXSrc, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 7, &multi_scrblt->nYSrc, FALSE) ||
+	    !read_order_field_byte(orderInfo, s, 8, &multi_scrblt->numRectangles, TRUE))
+		return FALSE;
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_09)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_09) != 0)
 	{
 		if (Stream_GetRemainingLength(s) < 2)
 			return FALSE;
@@ -1422,12 +1449,13 @@ static BOOL update_read_multi_opaque_rect_order(wStream* s, const ORDER_INFO* or
                                                 MULTI_OPAQUE_RECT_ORDER* multi_opaque_rect)
 {
 	BYTE byte;
-	ORDER_FIELD_COORD(1, multi_opaque_rect->nLeftRect);
-	ORDER_FIELD_COORD(2, multi_opaque_rect->nTopRect);
-	ORDER_FIELD_COORD(3, multi_opaque_rect->nWidth);
-	ORDER_FIELD_COORD(4, multi_opaque_rect->nHeight);
+	if (!read_order_field_coord(orderInfo, s, 1, &multi_opaque_rect->nLeftRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &multi_opaque_rect->nTopRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &multi_opaque_rect->nWidth, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &multi_opaque_rect->nHeight, FALSE))
+		return FALSE;
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_05)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_05) != 0)
 	{
 		if (Stream_GetRemainingLength(s) < 1)
 			return FALSE;
@@ -1436,7 +1464,7 @@ static BOOL update_read_multi_opaque_rect_order(wStream* s, const ORDER_INFO* or
 		multi_opaque_rect->color = (multi_opaque_rect->color & 0x00FFFF00) | ((UINT32)byte);
 	}
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_06)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_06) != 0)
 	{
 		if (Stream_GetRemainingLength(s) < 1)
 			return FALSE;
@@ -1445,7 +1473,7 @@ static BOOL update_read_multi_opaque_rect_order(wStream* s, const ORDER_INFO* or
 		multi_opaque_rect->color = (multi_opaque_rect->color & 0x00FF00FF) | ((UINT32)byte << 8);
 	}
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_07)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_07) != 0)
 	{
 		if (Stream_GetRemainingLength(s) < 1)
 			return FALSE;
@@ -1454,9 +1482,10 @@ static BOOL update_read_multi_opaque_rect_order(wStream* s, const ORDER_INFO* or
 		multi_opaque_rect->color = (multi_opaque_rect->color & 0x0000FFFF) | ((UINT32)byte << 16);
 	}
 
-	ORDER_FIELD_BYTE(8, multi_opaque_rect->numRectangles);
+	if (!read_order_field_byte(orderInfo, s, 8, &multi_opaque_rect->numRectangles, TRUE))
+		return FALSE;
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_09)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_09) != 0)
 	{
 		if (Stream_GetRemainingLength(s) < 2)
 			return FALSE;
@@ -1471,14 +1500,15 @@ static BOOL update_read_multi_opaque_rect_order(wStream* s, const ORDER_INFO* or
 static BOOL update_read_multi_draw_nine_grid_order(wStream* s, const ORDER_INFO* orderInfo,
                                                    MULTI_DRAW_NINE_GRID_ORDER* multi_draw_nine_grid)
 {
-	ORDER_FIELD_COORD(1, multi_draw_nine_grid->srcLeft);
-	ORDER_FIELD_COORD(2, multi_draw_nine_grid->srcTop);
-	ORDER_FIELD_COORD(3, multi_draw_nine_grid->srcRight);
-	ORDER_FIELD_COORD(4, multi_draw_nine_grid->srcBottom);
-	ORDER_FIELD_UINT16(5, multi_draw_nine_grid->bitmapId);
-	ORDER_FIELD_BYTE(6, multi_draw_nine_grid->nDeltaEntries);
+	if (!read_order_field_coord(orderInfo, s, 1, &multi_draw_nine_grid->srcLeft, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &multi_draw_nine_grid->srcTop, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &multi_draw_nine_grid->srcRight, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &multi_draw_nine_grid->srcBottom, FALSE) ||
+	    !read_order_field_uint16(orderInfo, s, 5, &multi_draw_nine_grid->bitmapId, TRUE) ||
+	    !read_order_field_byte(orderInfo, s, 6, &multi_draw_nine_grid->nDeltaEntries, TRUE))
+		return FALSE;
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_07)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_07) != 0)
 	{
 		if (Stream_GetRemainingLength(s) < 2)
 			return FALSE;
@@ -1493,16 +1523,17 @@ static BOOL update_read_multi_draw_nine_grid_order(wStream* s, const ORDER_INFO*
 static BOOL update_read_line_to_order(wStream* s, const ORDER_INFO* orderInfo,
                                       LINE_TO_ORDER* line_to)
 {
-	ORDER_FIELD_UINT16(1, line_to->backMode);
-	ORDER_FIELD_COORD(2, line_to->nXStart);
-	ORDER_FIELD_COORD(3, line_to->nYStart);
-	ORDER_FIELD_COORD(4, line_to->nXEnd);
-	ORDER_FIELD_COORD(5, line_to->nYEnd);
-	ORDER_FIELD_COLOR(orderInfo, s, 6, &line_to->backColor);
-	ORDER_FIELD_BYTE(7, line_to->bRop2);
-	ORDER_FIELD_BYTE(8, line_to->penStyle);
-	ORDER_FIELD_BYTE(9, line_to->penWidth);
-	ORDER_FIELD_COLOR(orderInfo, s, 10, &line_to->penColor);
+	if (!read_order_field_uint16(orderInfo, s, 1, &line_to->backMode, TRUE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &line_to->nXStart, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &line_to->nYStart, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &line_to->nXEnd, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 5, &line_to->nYEnd, FALSE) ||
+	    !read_order_field_color(orderInfo, s, 6, &line_to->backColor, TRUE) ||
+	    !read_order_field_byte(orderInfo, s, 7, &line_to->bRop2, TRUE) ||
+	    !read_order_field_byte(orderInfo, s, 8, &line_to->penStyle, TRUE) ||
+	    !read_order_field_byte(orderInfo, s, 9, &line_to->penWidth, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 10, &line_to->penColor, TRUE))
+		return FALSE;
 	return TRUE;
 }
 int update_approximate_line_to_order(ORDER_INFO* orderInfo, const LINE_TO_ORDER* line_to)
@@ -1540,16 +1571,17 @@ BOOL update_write_line_to_order(wStream* s, ORDER_INFO* orderInfo, const LINE_TO
 static BOOL update_read_polyline_order(wStream* s, const ORDER_INFO* orderInfo,
                                        POLYLINE_ORDER* polyline)
 {
-	UINT16 word;
+	UINT32 word;
 	UINT32 new_num = polyline->numDeltaEntries;
-	ORDER_FIELD_COORD(1, polyline->xStart);
-	ORDER_FIELD_COORD(2, polyline->yStart);
-	ORDER_FIELD_BYTE(3, polyline->bRop2);
-	ORDER_FIELD_UINT16(4, word);
-	ORDER_FIELD_COLOR(orderInfo, s, 5, &polyline->penColor);
-	ORDER_FIELD_BYTE(6, new_num);
+	if (!read_order_field_coord(orderInfo, s, 1, &polyline->xStart, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &polyline->yStart, FALSE) ||
+	    !read_order_field_byte(orderInfo, s, 3, &polyline->bRop2, TRUE) ||
+	    !read_order_field_uint16(orderInfo, s, 4, &word, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 5, &polyline->penColor, TRUE) ||
+	    !read_order_field_byte(orderInfo, s, 6, &new_num, TRUE))
+		return FALSE;
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_07)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_07) != 0)
 	{
 		DELTA_POINT* new_points;
 
@@ -1584,15 +1616,16 @@ static BOOL update_read_memblt_order(wStream* s, const ORDER_INFO* orderInfo, ME
 	if (!s || !orderInfo || !memblt)
 		return FALSE;
 
-	ORDER_FIELD_UINT16(1, memblt->cacheId);
-	ORDER_FIELD_COORD(2, memblt->nLeftRect);
-	ORDER_FIELD_COORD(3, memblt->nTopRect);
-	ORDER_FIELD_COORD(4, memblt->nWidth);
-	ORDER_FIELD_COORD(5, memblt->nHeight);
-	ORDER_FIELD_BYTE(6, memblt->bRop);
-	ORDER_FIELD_COORD(7, memblt->nXSrc);
-	ORDER_FIELD_COORD(8, memblt->nYSrc);
-	ORDER_FIELD_UINT16(9, memblt->cacheIndex);
+	if (!read_order_field_uint16(orderInfo, s, 1, &memblt->cacheId, TRUE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &memblt->nLeftRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &memblt->nTopRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &memblt->nWidth, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 5, &memblt->nHeight, FALSE) ||
+	    !read_order_field_byte(orderInfo, s, 6, &memblt->bRop, TRUE) ||
+	    !read_order_field_coord(orderInfo, s, 7, &memblt->nXSrc, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 8, &memblt->nYSrc, FALSE) ||
+	    !read_order_field_uint16(orderInfo, s, 9, &memblt->cacheIndex, TRUE))
+		return FALSE;
 	memblt->colorIndex = (memblt->cacheId >> 8);
 	memblt->cacheId = (memblt->cacheId & 0xFF);
 	memblt->bitmap = NULL;
@@ -1633,21 +1666,21 @@ BOOL update_write_memblt_order(wStream* s, ORDER_INFO* orderInfo, const MEMBLT_O
 static BOOL update_read_mem3blt_order(wStream* s, const ORDER_INFO* orderInfo,
                                       MEM3BLT_ORDER* mem3blt)
 {
-	ORDER_FIELD_UINT16(1, mem3blt->cacheId);
-	ORDER_FIELD_COORD(2, mem3blt->nLeftRect);
-	ORDER_FIELD_COORD(3, mem3blt->nTopRect);
-	ORDER_FIELD_COORD(4, mem3blt->nWidth);
-	ORDER_FIELD_COORD(5, mem3blt->nHeight);
-	ORDER_FIELD_BYTE(6, mem3blt->bRop);
-	ORDER_FIELD_COORD(7, mem3blt->nXSrc);
-	ORDER_FIELD_COORD(8, mem3blt->nYSrc);
-	ORDER_FIELD_COLOR(orderInfo, s, 9, &mem3blt->backColor);
-	ORDER_FIELD_COLOR(orderInfo, s, 10, &mem3blt->foreColor);
-
-	if (!update_read_brush(s, &mem3blt->brush, orderInfo->fieldFlags >> 10))
+	if (!read_order_field_uint16(orderInfo, s, 1, &mem3blt->cacheId, TRUE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &mem3blt->nLeftRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &mem3blt->nTopRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &mem3blt->nWidth, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 5, &mem3blt->nHeight, FALSE) ||
+	    !read_order_field_byte(orderInfo, s, 6, &mem3blt->bRop, TRUE) ||
+	    !read_order_field_coord(orderInfo, s, 7, &mem3blt->nXSrc, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 8, &mem3blt->nYSrc, FALSE) ||
+	    !read_order_field_color(orderInfo, s, 9, &mem3blt->backColor, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 10, &mem3blt->foreColor, TRUE))
 		return FALSE;
 
-	ORDER_FIELD_UINT16(16, mem3blt->cacheIndex);
+	if (!update_read_brush(s, &mem3blt->brush, orderInfo->fieldFlags >> 10) ||
+	    !read_order_field_uint16(orderInfo, s, 16, &mem3blt->cacheIndex, TRUE))
+		return FALSE;
 	mem3blt->colorIndex = (mem3blt->cacheId >> 8);
 	mem3blt->cacheId = (mem3blt->cacheId & 0xFF);
 	mem3blt->bitmap = NULL;
@@ -1656,39 +1689,38 @@ static BOOL update_read_mem3blt_order(wStream* s, const ORDER_INFO* orderInfo,
 static BOOL update_read_save_bitmap_order(wStream* s, const ORDER_INFO* orderInfo,
                                           SAVE_BITMAP_ORDER* save_bitmap)
 {
-	ORDER_FIELD_UINT32(1, save_bitmap->savedBitmapPosition);
-	ORDER_FIELD_COORD(2, save_bitmap->nLeftRect);
-	ORDER_FIELD_COORD(3, save_bitmap->nTopRect);
-	ORDER_FIELD_COORD(4, save_bitmap->nRightRect);
-	ORDER_FIELD_COORD(5, save_bitmap->nBottomRect);
-	ORDER_FIELD_BYTE(6, save_bitmap->operation);
+	if (!read_order_field_uint32(orderInfo, s, 1, &save_bitmap->savedBitmapPosition, TRUE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &save_bitmap->nLeftRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &save_bitmap->nTopRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &save_bitmap->nRightRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 5, &save_bitmap->nBottomRect, FALSE) ||
+	    !read_order_field_byte(orderInfo, s, 6, &save_bitmap->operation, TRUE))
+		return FALSE;
 	return TRUE;
 }
 static BOOL update_read_glyph_index_order(wStream* s, const ORDER_INFO* orderInfo,
                                           GLYPH_INDEX_ORDER* glyph_index)
 {
-	ORDER_FIELD_BYTE(1, glyph_index->cacheId);
-	ORDER_FIELD_BYTE(2, glyph_index->flAccel);
-	ORDER_FIELD_BYTE(3, glyph_index->ulCharInc);
-	ORDER_FIELD_BYTE(4, glyph_index->fOpRedundant);
-	ORDER_FIELD_COLOR(orderInfo, s, 5, &glyph_index->backColor);
-	ORDER_FIELD_COLOR(orderInfo, s, 6, &glyph_index->foreColor);
-	ORDER_FIELD_UINT16(7, glyph_index->bkLeft);
-	ORDER_FIELD_UINT16(8, glyph_index->bkTop);
-	ORDER_FIELD_UINT16(9, glyph_index->bkRight);
-	ORDER_FIELD_UINT16(10, glyph_index->bkBottom);
-	ORDER_FIELD_UINT16(11, glyph_index->opLeft);
-	ORDER_FIELD_UINT16(12, glyph_index->opTop);
-	ORDER_FIELD_UINT16(13, glyph_index->opRight);
-	ORDER_FIELD_UINT16(14, glyph_index->opBottom);
-
-	if (!update_read_brush(s, &glyph_index->brush, orderInfo->fieldFlags >> 14))
+	if (!read_order_field_byte(orderInfo, s, 1, &glyph_index->cacheId, TRUE) ||
+	    !read_order_field_byte(orderInfo, s, 2, &glyph_index->flAccel, TRUE) ||
+	    !read_order_field_byte(orderInfo, s, 3, &glyph_index->ulCharInc, TRUE) ||
+	    !read_order_field_byte(orderInfo, s, 4, &glyph_index->fOpRedundant, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 5, &glyph_index->backColor, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 6, &glyph_index->foreColor, TRUE) ||
+	    !read_order_field_int16(orderInfo, s, 7, &glyph_index->bkLeft, TRUE) ||
+	    !read_order_field_int16(orderInfo, s, 8, &glyph_index->bkTop, TRUE) ||
+	    !read_order_field_int16(orderInfo, s, 9, &glyph_index->bkRight, TRUE) ||
+	    !read_order_field_int16(orderInfo, s, 10, &glyph_index->bkBottom, TRUE) ||
+	    !read_order_field_int16(orderInfo, s, 11, &glyph_index->opLeft, TRUE) ||
+	    !read_order_field_int16(orderInfo, s, 12, &glyph_index->opTop, TRUE) ||
+	    !read_order_field_int16(orderInfo, s, 13, &glyph_index->opRight, TRUE) ||
+	    !read_order_field_int16(orderInfo, s, 14, &glyph_index->opBottom, TRUE) ||
+	    !update_read_brush(s, &glyph_index->brush, orderInfo->fieldFlags >> 14) ||
+	    !read_order_field_int16(orderInfo, s, 20, &glyph_index->x, TRUE) ||
+	    !read_order_field_int16(orderInfo, s, 21, &glyph_index->y, TRUE))
 		return FALSE;
 
-	ORDER_FIELD_UINT16(20, glyph_index->x);
-	ORDER_FIELD_UINT16(21, glyph_index->y);
-
-	if (orderInfo->fieldFlags & ORDER_FIELD_22)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_22) != 0)
 	{
 		if (Stream_GetRemainingLength(s) < 1)
 			return FALSE;
@@ -1764,22 +1796,24 @@ BOOL update_write_glyph_index_order(wStream* s, ORDER_INFO* orderInfo,
 static BOOL update_read_fast_index_order(wStream* s, const ORDER_INFO* orderInfo,
                                          FAST_INDEX_ORDER* fast_index)
 {
-	ORDER_FIELD_BYTE(1, fast_index->cacheId);
-	ORDER_FIELD_2BYTE(2, fast_index->ulCharInc, fast_index->flAccel);
-	ORDER_FIELD_COLOR(orderInfo, s, 3, &fast_index->backColor);
-	ORDER_FIELD_COLOR(orderInfo, s, 4, &fast_index->foreColor);
-	ORDER_FIELD_COORD(5, fast_index->bkLeft);
-	ORDER_FIELD_COORD(6, fast_index->bkTop);
-	ORDER_FIELD_COORD(7, fast_index->bkRight);
-	ORDER_FIELD_COORD(8, fast_index->bkBottom);
-	ORDER_FIELD_COORD(9, fast_index->opLeft);
-	ORDER_FIELD_COORD(10, fast_index->opTop);
-	ORDER_FIELD_COORD(11, fast_index->opRight);
-	ORDER_FIELD_COORD(12, fast_index->opBottom);
-	ORDER_FIELD_COORD(13, fast_index->x);
-	ORDER_FIELD_COORD(14, fast_index->y);
+	if (!read_order_field_byte(orderInfo, s, 1, &fast_index->cacheId, TRUE) ||
+	    !read_order_field_2bytes(orderInfo, s, 2, &fast_index->ulCharInc, &fast_index->flAccel,
+	                             TRUE) ||
+	    !read_order_field_color(orderInfo, s, 3, &fast_index->backColor, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 4, &fast_index->foreColor, TRUE) ||
+	    !read_order_field_coord(orderInfo, s, 5, &fast_index->bkLeft, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 6, &fast_index->bkTop, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 7, &fast_index->bkRight, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 8, &fast_index->bkBottom, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 9, &fast_index->opLeft, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 10, &fast_index->opTop, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 11, &fast_index->opRight, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 12, &fast_index->opBottom, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 13, &fast_index->x, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 14, &fast_index->y, FALSE))
+		return FALSE;
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_15)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_15) != 0)
 	{
 		if (Stream_GetRemainingLength(s) < 1)
 			return FALSE;
@@ -1799,22 +1833,27 @@ static BOOL update_read_fast_glyph_order(wStream* s, const ORDER_INFO* orderInfo
                                          FAST_GLYPH_ORDER* fastGlyph)
 {
 	GLYPH_DATA_V2* glyph = &fastGlyph->glyphData;
-	ORDER_FIELD_BYTE(1, fastGlyph->cacheId);
-	ORDER_FIELD_2BYTE(2, fastGlyph->ulCharInc, fastGlyph->flAccel);
-	ORDER_FIELD_COLOR(orderInfo, s, 3, &fastGlyph->backColor);
-	ORDER_FIELD_COLOR(orderInfo, s, 4, &fastGlyph->foreColor);
-	ORDER_FIELD_COORD(5, fastGlyph->bkLeft);
-	ORDER_FIELD_COORD(6, fastGlyph->bkTop);
-	ORDER_FIELD_COORD(7, fastGlyph->bkRight);
-	ORDER_FIELD_COORD(8, fastGlyph->bkBottom);
-	ORDER_FIELD_COORD(9, fastGlyph->opLeft);
-	ORDER_FIELD_COORD(10, fastGlyph->opTop);
-	ORDER_FIELD_COORD(11, fastGlyph->opRight);
-	ORDER_FIELD_COORD(12, fastGlyph->opBottom);
-	ORDER_FIELD_COORD(13, fastGlyph->x);
-	ORDER_FIELD_COORD(14, fastGlyph->y);
+	if (!read_order_field_byte(orderInfo, s, 1, &fastGlyph->cacheId, TRUE))
+		return FALSE;
+	if (fastGlyph->cacheId > 9)
+		return FALSE;
+	if (!read_order_field_2bytes(orderInfo, s, 2, &fastGlyph->ulCharInc, &fastGlyph->flAccel,
+	                             TRUE) ||
+	    !read_order_field_color(orderInfo, s, 3, &fastGlyph->backColor, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 4, &fastGlyph->foreColor, TRUE) ||
+	    !read_order_field_coord(orderInfo, s, 5, &fastGlyph->bkLeft, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 6, &fastGlyph->bkTop, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 7, &fastGlyph->bkRight, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 8, &fastGlyph->bkBottom, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 9, &fastGlyph->opLeft, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 10, &fastGlyph->opTop, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 11, &fastGlyph->opRight, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 12, &fastGlyph->opBottom, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 13, &fastGlyph->x, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 14, &fastGlyph->y, FALSE))
+		return FALSE;
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_15)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_15) != 0)
 	{
 		const BYTE* src;
 		wStream sub;
@@ -1865,14 +1904,15 @@ static BOOL update_read_polygon_sc_order(wStream* s, const ORDER_INFO* orderInfo
                                          POLYGON_SC_ORDER* polygon_sc)
 {
 	UINT32 num = polygon_sc->numPoints;
-	ORDER_FIELD_COORD(1, polygon_sc->xStart);
-	ORDER_FIELD_COORD(2, polygon_sc->yStart);
-	ORDER_FIELD_BYTE(3, polygon_sc->bRop2);
-	ORDER_FIELD_BYTE(4, polygon_sc->fillMode);
-	ORDER_FIELD_COLOR(orderInfo, s, 5, &polygon_sc->brushColor);
-	ORDER_FIELD_BYTE(6, num);
+	if (!read_order_field_coord(orderInfo, s, 1, &polygon_sc->xStart, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &polygon_sc->yStart, FALSE) ||
+	    !read_order_field_byte(orderInfo, s, 3, &polygon_sc->bRop2, TRUE) ||
+	    !read_order_field_byte(orderInfo, s, 4, &polygon_sc->fillMode, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 5, &polygon_sc->brushColor, TRUE) ||
+	    !read_order_field_byte(orderInfo, s, 6, &num, TRUE))
+		return FALSE;
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_07)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_07) != 0)
 	{
 		DELTA_POINT* newpoints;
 
@@ -1900,19 +1940,21 @@ static BOOL update_read_polygon_cb_order(wStream* s, const ORDER_INFO* orderInfo
                                          POLYGON_CB_ORDER* polygon_cb)
 {
 	UINT32 num = polygon_cb->numPoints;
-	ORDER_FIELD_COORD(1, polygon_cb->xStart);
-	ORDER_FIELD_COORD(2, polygon_cb->yStart);
-	ORDER_FIELD_BYTE(3, polygon_cb->bRop2);
-	ORDER_FIELD_BYTE(4, polygon_cb->fillMode);
-	ORDER_FIELD_COLOR(orderInfo, s, 5, &polygon_cb->backColor);
-	ORDER_FIELD_COLOR(orderInfo, s, 6, &polygon_cb->foreColor);
+	if (!read_order_field_coord(orderInfo, s, 1, &polygon_cb->xStart, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &polygon_cb->yStart, FALSE) ||
+	    !read_order_field_byte(orderInfo, s, 3, &polygon_cb->bRop2, TRUE) ||
+	    !read_order_field_byte(orderInfo, s, 4, &polygon_cb->fillMode, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 5, &polygon_cb->backColor, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 6, &polygon_cb->foreColor, TRUE))
+		return FALSE;
 
 	if (!update_read_brush(s, &polygon_cb->brush, orderInfo->fieldFlags >> 6))
 		return FALSE;
 
-	ORDER_FIELD_BYTE(12, num);
+	if (!read_order_field_byte(orderInfo, s, 12, &num, TRUE))
+		return FALSE;
 
-	if (orderInfo->fieldFlags & ORDER_FIELD_13)
+	if ((orderInfo->fieldFlags & ORDER_FIELD_13) != 0)
 	{
 		DELTA_POINT* newpoints;
 
@@ -1943,26 +1985,28 @@ static BOOL update_read_polygon_cb_order(wStream* s, const ORDER_INFO* orderInfo
 static BOOL update_read_ellipse_sc_order(wStream* s, const ORDER_INFO* orderInfo,
                                          ELLIPSE_SC_ORDER* ellipse_sc)
 {
-	ORDER_FIELD_COORD(1, ellipse_sc->leftRect);
-	ORDER_FIELD_COORD(2, ellipse_sc->topRect);
-	ORDER_FIELD_COORD(3, ellipse_sc->rightRect);
-	ORDER_FIELD_COORD(4, ellipse_sc->bottomRect);
-	ORDER_FIELD_BYTE(5, ellipse_sc->bRop2);
-	ORDER_FIELD_BYTE(6, ellipse_sc->fillMode);
-	ORDER_FIELD_COLOR(orderInfo, s, 7, &ellipse_sc->color);
+	if (!read_order_field_coord(orderInfo, s, 1, &ellipse_sc->leftRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &ellipse_sc->topRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &ellipse_sc->rightRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &ellipse_sc->bottomRect, FALSE) ||
+	    !read_order_field_byte(orderInfo, s, 5, &ellipse_sc->bRop2, TRUE) ||
+	    !read_order_field_byte(orderInfo, s, 6, &ellipse_sc->fillMode, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 7, &ellipse_sc->color, TRUE))
+		return FALSE;
 	return TRUE;
 }
 static BOOL update_read_ellipse_cb_order(wStream* s, const ORDER_INFO* orderInfo,
                                          ELLIPSE_CB_ORDER* ellipse_cb)
 {
-	ORDER_FIELD_COORD(1, ellipse_cb->leftRect);
-	ORDER_FIELD_COORD(2, ellipse_cb->topRect);
-	ORDER_FIELD_COORD(3, ellipse_cb->rightRect);
-	ORDER_FIELD_COORD(4, ellipse_cb->bottomRect);
-	ORDER_FIELD_BYTE(5, ellipse_cb->bRop2);
-	ORDER_FIELD_BYTE(6, ellipse_cb->fillMode);
-	ORDER_FIELD_COLOR(orderInfo, s, 7, &ellipse_cb->backColor);
-	ORDER_FIELD_COLOR(orderInfo, s, 8, &ellipse_cb->foreColor);
+	if (!read_order_field_coord(orderInfo, s, 1, &ellipse_cb->leftRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 2, &ellipse_cb->topRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 3, &ellipse_cb->rightRect, FALSE) ||
+	    !read_order_field_coord(orderInfo, s, 4, &ellipse_cb->bottomRect, FALSE) ||
+	    !read_order_field_byte(orderInfo, s, 5, &ellipse_cb->bRop2, TRUE) ||
+	    !read_order_field_byte(orderInfo, s, 6, &ellipse_cb->fillMode, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 7, &ellipse_cb->backColor, TRUE) ||
+	    !read_order_field_color(orderInfo, s, 8, &ellipse_cb->foreColor, TRUE))
+		return FALSE;
 	return update_read_brush(s, &ellipse_cb->brush, orderInfo->fieldFlags >> 8);
 }
 /* Secondary Drawing Orders */

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -1171,13 +1171,13 @@ static INLINE BOOL FIELD_SKIP_BUFFER16(wStream* s, UINT32 TARGET_LEN)
 /* Primary Drawing Orders */
 static BOOL update_read_dstblt_order(wStream* s, const ORDER_INFO* orderInfo, DSTBLT_ORDER* dstblt)
 {
-	if (!read_order_field_coord(orderInfo, s, 1, &dstblt->nLeftRect, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 2, &dstblt->nTopRect, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 3, &dstblt->nWidth, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 4, &dstblt->nHeight, FALSE) ||
-	    !read_order_field_byte(orderInfo, s, 5, &dstblt->bRop, TRUE))
-		return FALSE;
-	return TRUE;
+	if (read_order_field_coord(orderInfo, s, 1, &dstblt->nLeftRect, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 2, &dstblt->nTopRect, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 3, &dstblt->nWidth, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 4, &dstblt->nHeight, FALSE) &&
+	    read_order_field_byte(orderInfo, s, 5, &dstblt->bRop, TRUE))
+		return TRUE;
+	return FALSE;
 }
 int update_approximate_dstblt_order(ORDER_INFO* orderInfo, const DSTBLT_ORDER* dstblt)
 {
@@ -1203,15 +1203,16 @@ BOOL update_write_dstblt_order(wStream* s, ORDER_INFO* orderInfo, const DSTBLT_O
 }
 static BOOL update_read_patblt_order(wStream* s, const ORDER_INFO* orderInfo, PATBLT_ORDER* patblt)
 {
-	if (!read_order_field_coord(orderInfo, s, 1, &patblt->nLeftRect, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 2, &patblt->nTopRect, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 3, &patblt->nWidth, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 4, &patblt->nHeight, FALSE) ||
-	    !read_order_field_byte(orderInfo, s, 5, &patblt->bRop, TRUE) ||
-	    !read_order_field_color(orderInfo, s, 6, &patblt->backColor, TRUE) ||
-	    !read_order_field_color(orderInfo, s, 7, &patblt->foreColor, TRUE))
-		return FALSE;
-	return update_read_brush(s, &patblt->brush, orderInfo->fieldFlags >> 7);
+	if (read_order_field_coord(orderInfo, s, 1, &patblt->nLeftRect, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 2, &patblt->nTopRect, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 3, &patblt->nWidth, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 4, &patblt->nHeight, FALSE) &&
+	    read_order_field_byte(orderInfo, s, 5, &patblt->bRop, TRUE) &&
+	    read_order_field_color(orderInfo, s, 6, &patblt->backColor, TRUE) &&
+	    read_order_field_color(orderInfo, s, 7, &patblt->foreColor, TRUE) &&
+	    update_read_brush(s, &patblt->brush, orderInfo->fieldFlags >> 7))
+		return TRUE;
+	return FALSE;
 }
 int update_approximate_patblt_order(ORDER_INFO* orderInfo, PATBLT_ORDER* patblt)
 {
@@ -1247,15 +1248,15 @@ BOOL update_write_patblt_order(wStream* s, ORDER_INFO* orderInfo, PATBLT_ORDER* 
 }
 static BOOL update_read_scrblt_order(wStream* s, const ORDER_INFO* orderInfo, SCRBLT_ORDER* scrblt)
 {
-	if (!read_order_field_coord(orderInfo, s, 1, &scrblt->nLeftRect, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 2, &scrblt->nTopRect, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 3, &scrblt->nWidth, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 4, &scrblt->nHeight, FALSE) ||
-	    !read_order_field_byte(orderInfo, s, 5, &scrblt->bRop, TRUE) ||
-	    !read_order_field_coord(orderInfo, s, 6, &scrblt->nXSrc, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 7, &scrblt->nYSrc, FALSE))
-		return FALSE;
-	return TRUE;
+	if (read_order_field_coord(orderInfo, s, 1, &scrblt->nLeftRect, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 2, &scrblt->nTopRect, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 3, &scrblt->nWidth, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 4, &scrblt->nHeight, FALSE) &&
+	    read_order_field_byte(orderInfo, s, 5, &scrblt->bRop, TRUE) &&
+	    read_order_field_coord(orderInfo, s, 6, &scrblt->nXSrc, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 7, &scrblt->nYSrc, FALSE))
+		return TRUE;
+	return FALSE;
 }
 int update_approximate_scrblt_order(ORDER_INFO* orderInfo, const SCRBLT_ORDER* scrblt)
 {
@@ -1360,13 +1361,13 @@ BOOL update_write_opaque_rect_order(wStream* s, ORDER_INFO* orderInfo,
 static BOOL update_read_draw_nine_grid_order(wStream* s, const ORDER_INFO* orderInfo,
                                              DRAW_NINE_GRID_ORDER* draw_nine_grid)
 {
-	if (!read_order_field_coord(orderInfo, s, 1, &draw_nine_grid->srcLeft, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 2, &draw_nine_grid->srcTop, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 3, &draw_nine_grid->srcRight, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 4, &draw_nine_grid->srcBottom, FALSE) ||
-	    !read_order_field_uint16(orderInfo, s, 5, &draw_nine_grid->bitmapId, FALSE))
-		return FALSE;
-	return TRUE;
+	if (read_order_field_coord(orderInfo, s, 1, &draw_nine_grid->srcLeft, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 2, &draw_nine_grid->srcTop, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 3, &draw_nine_grid->srcRight, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 4, &draw_nine_grid->srcBottom, FALSE) &&
+	    read_order_field_uint16(orderInfo, s, 5, &draw_nine_grid->bitmapId, FALSE))
+		return TRUE;
+	return FALSE;
 }
 static BOOL update_read_multi_dstblt_order(wStream* s, const ORDER_INFO* orderInfo,
                                            MULTI_DSTBLT_ORDER* multi_dstblt)
@@ -1523,18 +1524,18 @@ static BOOL update_read_multi_draw_nine_grid_order(wStream* s, const ORDER_INFO*
 static BOOL update_read_line_to_order(wStream* s, const ORDER_INFO* orderInfo,
                                       LINE_TO_ORDER* line_to)
 {
-	if (!read_order_field_uint16(orderInfo, s, 1, &line_to->backMode, TRUE) ||
-	    !read_order_field_coord(orderInfo, s, 2, &line_to->nXStart, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 3, &line_to->nYStart, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 4, &line_to->nXEnd, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 5, &line_to->nYEnd, FALSE) ||
-	    !read_order_field_color(orderInfo, s, 6, &line_to->backColor, TRUE) ||
-	    !read_order_field_byte(orderInfo, s, 7, &line_to->bRop2, TRUE) ||
-	    !read_order_field_byte(orderInfo, s, 8, &line_to->penStyle, TRUE) ||
-	    !read_order_field_byte(orderInfo, s, 9, &line_to->penWidth, TRUE) ||
-	    !read_order_field_color(orderInfo, s, 10, &line_to->penColor, TRUE))
-		return FALSE;
-	return TRUE;
+	if (read_order_field_uint16(orderInfo, s, 1, &line_to->backMode, TRUE) &&
+	    read_order_field_coord(orderInfo, s, 2, &line_to->nXStart, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 3, &line_to->nYStart, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 4, &line_to->nXEnd, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 5, &line_to->nYEnd, FALSE) &&
+	    read_order_field_color(orderInfo, s, 6, &line_to->backColor, TRUE) &&
+	    read_order_field_byte(orderInfo, s, 7, &line_to->bRop2, TRUE) &&
+	    read_order_field_byte(orderInfo, s, 8, &line_to->penStyle, TRUE) &&
+	    read_order_field_byte(orderInfo, s, 9, &line_to->penWidth, TRUE) &&
+	    read_order_field_color(orderInfo, s, 10, &line_to->penColor, TRUE))
+		return TRUE;
+	return FALSE;
 }
 int update_approximate_line_to_order(ORDER_INFO* orderInfo, const LINE_TO_ORDER* line_to)
 {
@@ -1689,14 +1690,14 @@ static BOOL update_read_mem3blt_order(wStream* s, const ORDER_INFO* orderInfo,
 static BOOL update_read_save_bitmap_order(wStream* s, const ORDER_INFO* orderInfo,
                                           SAVE_BITMAP_ORDER* save_bitmap)
 {
-	if (!read_order_field_uint32(orderInfo, s, 1, &save_bitmap->savedBitmapPosition, TRUE) ||
-	    !read_order_field_coord(orderInfo, s, 2, &save_bitmap->nLeftRect, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 3, &save_bitmap->nTopRect, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 4, &save_bitmap->nRightRect, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 5, &save_bitmap->nBottomRect, FALSE) ||
-	    !read_order_field_byte(orderInfo, s, 6, &save_bitmap->operation, TRUE))
-		return FALSE;
-	return TRUE;
+	if (read_order_field_uint32(orderInfo, s, 1, &save_bitmap->savedBitmapPosition, TRUE) &&
+	    read_order_field_coord(orderInfo, s, 2, &save_bitmap->nLeftRect, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 3, &save_bitmap->nTopRect, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 4, &save_bitmap->nRightRect, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 5, &save_bitmap->nBottomRect, FALSE) &&
+	    read_order_field_byte(orderInfo, s, 6, &save_bitmap->operation, TRUE))
+		return TRUE;
+	return FALSE;
 }
 static BOOL update_read_glyph_index_order(wStream* s, const ORDER_INFO* orderInfo,
                                           GLYPH_INDEX_ORDER* glyph_index)
@@ -1985,29 +1986,30 @@ static BOOL update_read_polygon_cb_order(wStream* s, const ORDER_INFO* orderInfo
 static BOOL update_read_ellipse_sc_order(wStream* s, const ORDER_INFO* orderInfo,
                                          ELLIPSE_SC_ORDER* ellipse_sc)
 {
-	if (!read_order_field_coord(orderInfo, s, 1, &ellipse_sc->leftRect, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 2, &ellipse_sc->topRect, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 3, &ellipse_sc->rightRect, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 4, &ellipse_sc->bottomRect, FALSE) ||
-	    !read_order_field_byte(orderInfo, s, 5, &ellipse_sc->bRop2, TRUE) ||
-	    !read_order_field_byte(orderInfo, s, 6, &ellipse_sc->fillMode, TRUE) ||
-	    !read_order_field_color(orderInfo, s, 7, &ellipse_sc->color, TRUE))
-		return FALSE;
-	return TRUE;
+	if (read_order_field_coord(orderInfo, s, 1, &ellipse_sc->leftRect, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 2, &ellipse_sc->topRect, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 3, &ellipse_sc->rightRect, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 4, &ellipse_sc->bottomRect, FALSE) &&
+	    read_order_field_byte(orderInfo, s, 5, &ellipse_sc->bRop2, TRUE) &&
+	    read_order_field_byte(orderInfo, s, 6, &ellipse_sc->fillMode, TRUE) &&
+	    read_order_field_color(orderInfo, s, 7, &ellipse_sc->color, TRUE))
+		return TRUE;
+	return FALSE;
 }
 static BOOL update_read_ellipse_cb_order(wStream* s, const ORDER_INFO* orderInfo,
                                          ELLIPSE_CB_ORDER* ellipse_cb)
 {
-	if (!read_order_field_coord(orderInfo, s, 1, &ellipse_cb->leftRect, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 2, &ellipse_cb->topRect, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 3, &ellipse_cb->rightRect, FALSE) ||
-	    !read_order_field_coord(orderInfo, s, 4, &ellipse_cb->bottomRect, FALSE) ||
-	    !read_order_field_byte(orderInfo, s, 5, &ellipse_cb->bRop2, TRUE) ||
-	    !read_order_field_byte(orderInfo, s, 6, &ellipse_cb->fillMode, TRUE) ||
-	    !read_order_field_color(orderInfo, s, 7, &ellipse_cb->backColor, TRUE) ||
-	    !read_order_field_color(orderInfo, s, 8, &ellipse_cb->foreColor, TRUE))
-		return FALSE;
-	return update_read_brush(s, &ellipse_cb->brush, orderInfo->fieldFlags >> 8);
+	if (read_order_field_coord(orderInfo, s, 1, &ellipse_cb->leftRect, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 2, &ellipse_cb->topRect, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 3, &ellipse_cb->rightRect, FALSE) &&
+	    read_order_field_coord(orderInfo, s, 4, &ellipse_cb->bottomRect, FALSE) &&
+	    read_order_field_byte(orderInfo, s, 5, &ellipse_cb->bRop2, TRUE) &&
+	    read_order_field_byte(orderInfo, s, 6, &ellipse_cb->fillMode, TRUE) &&
+	    read_order_field_color(orderInfo, s, 7, &ellipse_cb->backColor, TRUE) &&
+	    read_order_field_color(orderInfo, s, 8, &ellipse_cb->foreColor, TRUE) &&
+	    update_read_brush(s, &ellipse_cb->brush, orderInfo->fieldFlags >> 8))
+		return TRUE;
+	return FALSE;
 }
 /* Secondary Drawing Orders */
 static CACHE_BITMAP_ORDER* update_read_cache_bitmap_order(rdpUpdate* update, wStream* s,

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -1816,54 +1816,46 @@ static BOOL update_read_fast_glyph_order(wStream* s, const ORDER_INFO* orderInfo
 
 	if (orderInfo->fieldFlags & ORDER_FIELD_15)
 	{
+		const BYTE* src;
+		wStream sub;
 		if (Stream_GetRemainingLength(s) < 1)
 			return FALSE;
 
 		Stream_Read_UINT8(s, fastGlyph->cbData);
 
-		if (Stream_GetRemainingLength(s) < fastGlyph->cbData)
+		src = Stream_Pointer(s);
+		if (!Stream_SafeSeek(s, fastGlyph->cbData) || (fastGlyph->cbData == 0))
 			return FALSE;
 
-		CopyMemory(fastGlyph->data, Stream_Pointer(s), fastGlyph->cbData);
-		if (Stream_GetRemainingLength(s) < fastGlyph->cbData)
-			return FALSE;
+		CopyMemory(fastGlyph->data, src, fastGlyph->cbData);
+		Stream_StaticInit(&sub, fastGlyph->data, fastGlyph->cbData);
 
-		if (!Stream_SafeSeek(s, 1))
-			return FALSE;
+		Stream_Read_UINT8(&sub, glyph->cacheIndex);
 
 		if (fastGlyph->cbData > 1)
 		{
-			UINT32 new_cb;
-			/* parse optional glyph data */
-			glyph->cacheIndex = fastGlyph->data[0];
-
-			if (!update_read_2byte_signed(s, &glyph->x) ||
-			    !update_read_2byte_signed(s, &glyph->y) ||
-			    !update_read_2byte_unsigned(s, &glyph->cx) ||
-			    !update_read_2byte_unsigned(s, &glyph->cy))
+			if (!update_read_2byte_signed(&sub, &glyph->x) ||
+			    !update_read_2byte_signed(&sub, &glyph->y) ||
+			    !update_read_2byte_unsigned(&sub, &glyph->cx) ||
+			    !update_read_2byte_unsigned(&sub, &glyph->cy))
 				return FALSE;
 
-			glyph->cb = ((glyph->cx + 7) / 8) * glyph->cy;
-			glyph->cb += ((glyph->cb % 4) > 0) ? 4 - (glyph->cb % 4) : 0;
-			new_cb = ((glyph->cx + 7) / 8) * glyph->cy;
-			new_cb += ((new_cb % 4) > 0) ? 4 - (new_cb % 4) : 0;
-
-			if (fastGlyph->cbData < new_cb)
-				return FALSE;
-
-			if (new_cb > 0)
+			glyph->cb = Stream_GetRemainingLength(&sub);
+			if (glyph->cb > 0)
 			{
-				BYTE* new_aj;
-				new_aj = (BYTE*)realloc(glyph->aj, new_cb);
+				BYTE* new_aj = (BYTE*)realloc(glyph->aj, glyph->cb);
 
 				if (!new_aj)
 					return FALSE;
 
 				glyph->aj = new_aj;
-				glyph->cb = new_cb;
-				Stream_Read(s, glyph->aj, glyph->cb);
+				Stream_Read(&sub, glyph->aj, glyph->cb);
 			}
-			Stream_Seek(s, fastGlyph->cbData - new_cb);
+			else
+			{
+				free(glyph->aj);
+				glyph->aj = NULL;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixed parsing of fastglyph according to
[MS-RDPEGDI] 2.2.2.2.1.2.6.1 Cache Glyph Data - Revision 2 (TS_CACHE_GLYPH_DATA_REV2)
