### PR TITLE
Refactored H264 encoding/decoding

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_codec.c
+++ b/channels/rdpgfx/client/rdpgfx_codec.c
@@ -123,10 +123,7 @@ static UINT rdpgfx_read_h264_metablock(RDPGFX_PLUGIN* gfx, wStream* s, RDPGFX_H2
 
 	return CHANNEL_RC_OK;
 error_out:
-	free(meta->regionRects);
-	meta->regionRects = NULL;
-	free(meta->quantQualityVals);
-	meta->quantQualityVals = NULL;
+	free_h264_metablock(meta);
 	return error;
 }
 
@@ -169,8 +166,7 @@ static UINT rdpgfx_decode_AVC420(RDPGFX_PLUGIN* gfx, RDPGFX_SURFACE_COMMAND* cmd
 			WLog_ERR(TAG, "context->SurfaceCommand failed with error %" PRIu32 "", error);
 	}
 
-	free(h264.meta.regionRects);
-	free(h264.meta.quantQualityVals);
+	free_h264_metablock(&h264.meta);
 	return error;
 }
 
@@ -259,10 +255,8 @@ static UINT rdpgfx_decode_AVC444(RDPGFX_PLUGIN* gfx, RDPGFX_SURFACE_COMMAND* cmd
 
 fail:
 	Stream_Free(s, FALSE);
-	free(h264.bitstream[0].meta.regionRects);
-	free(h264.bitstream[0].meta.quantQualityVals);
-	free(h264.bitstream[1].meta.regionRects);
-	free(h264.bitstream[1].meta.quantQualityVals);
+	free_h264_metablock(&h264.bitstream[0].meta);
+	free_h264_metablock(&h264.bitstream[1].meta);
 	return error;
 }
 

--- a/include/freerdp/codec/h264.h
+++ b/include/freerdp/codec/h264.h
@@ -27,23 +27,8 @@
 #include <freerdp/channels/rdpgfx.h>
 
 typedef struct _H264_CONTEXT H264_CONTEXT;
-
-typedef BOOL (*pfnH264SubsystemInit)(H264_CONTEXT* h264);
-typedef void (*pfnH264SubsystemUninit)(H264_CONTEXT* h264);
-
-typedef int (*pfnH264SubsystemDecompress)(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSize);
-typedef int (*pfnH264SubsystemCompress)(H264_CONTEXT* h264, const BYTE** pSrcYuv,
-                                        const UINT32* pStride, BYTE** ppDstData, UINT32* pDstSize);
-
-struct _H264_CONTEXT_SUBSYSTEM
-{
-	const char* name;
-	pfnH264SubsystemInit Init;
-	pfnH264SubsystemUninit Uninit;
-	pfnH264SubsystemDecompress Decompress;
-	pfnH264SubsystemCompress Compress;
-};
 typedef struct _H264_CONTEXT_SUBSYSTEM H264_CONTEXT_SUBSYSTEM;
+typedef struct _YUV_CONTEXT YUV_CONTEXT;
 
 enum _H264_RATECONTROL_MODE
 {
@@ -75,6 +60,7 @@ struct _H264_CONTEXT
 	UINT32 numSystemData;
 	void* pSystemData;
 	H264_CONTEXT_SUBSYSTEM* subsystem;
+	YUV_CONTEXT* yuv;
 
 	void* lumaData;
 	wLog* log;
@@ -91,16 +77,17 @@ extern "C"
 	FREERDP_API INT32 avc420_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSize,
 	                                    BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep,
 	                                    UINT32 nDstWidth, UINT32 nDstHeight,
-	                                    RECTANGLE_16* regionRects, UINT32 numRegionRect);
+	                                    const RECTANGLE_16* regionRects, UINT32 numRegionRect);
 
 	FREERDP_API INT32 avc444_compress(H264_CONTEXT* h264, const BYTE* pSrcData, DWORD SrcFormat,
 	                                  UINT32 nSrcStep, UINT32 nSrcWidth, UINT32 nSrcHeight,
 	                                  BYTE version, BYTE* op, BYTE** pDstData, UINT32* pDstSize,
 	                                  BYTE** pAuxDstData, UINT32* pAuxDstSize);
 
-	FREERDP_API INT32 avc444_decompress(H264_CONTEXT* h264, BYTE op, RECTANGLE_16* regionRects,
-	                                    UINT32 numRegionRect, const BYTE* pSrcData, UINT32 SrcSize,
-	                                    RECTANGLE_16* auxRegionRects, UINT32 numAuxRegionRect,
+	FREERDP_API INT32 avc444_decompress(H264_CONTEXT* h264, BYTE op,
+	                                    const RECTANGLE_16* regionRects, UINT32 numRegionRect,
+	                                    const BYTE* pSrcData, UINT32 SrcSize,
+	                                    const RECTANGLE_16* auxRegionRects, UINT32 numAuxRegionRect,
 	                                    const BYTE* pAuxSrcData, UINT32 AuxSrcSize, BYTE* pDstData,
 	                                    DWORD DstFormat, UINT32 nDstStep, UINT32 nDstWidth,
 	                                    UINT32 nDstHeight, UINT32 codecId);

--- a/include/freerdp/codec/h264.h
+++ b/include/freerdp/codec/h264.h
@@ -51,16 +51,22 @@ struct _H264_CONTEXT
 	UINT32 NumberOfThreads;
 
 	UINT32 iStride[3];
+	BYTE* pOldYUVData[3];
 	BYTE* pYUVData[3];
 
 	UINT32 iYUV444Size[3];
 	UINT32 iYUV444Stride[3];
+	BYTE* pOldYUV444Data[3];
 	BYTE* pYUV444Data[3];
 
 	UINT32 numSystemData;
 	void* pSystemData;
 	H264_CONTEXT_SUBSYSTEM* subsystem;
 	YUV_CONTEXT* yuv;
+
+	BOOL encodingBuffer;
+	BOOL firstLumaFrameDone;
+	BOOL firstChromaFrameDone;
 
 	void* lumaData;
 	wLog* log;
@@ -70,9 +76,20 @@ extern "C"
 {
 #endif
 
+	static INLINE void free_h264_metablock(RDPGFX_H264_METABLOCK* meta)
+	{
+		RDPGFX_H264_METABLOCK m = { 0 };
+		if (!meta)
+			return;
+		free(meta->quantQualityVals);
+		free(meta->regionRects);
+		*meta = m;
+	}
+
 	FREERDP_API INT32 avc420_compress(H264_CONTEXT* h264, const BYTE* pSrcData, DWORD SrcFormat,
 	                                  UINT32 nSrcStep, UINT32 nSrcWidth, UINT32 nSrcHeight,
-	                                  BYTE** ppDstData, UINT32* pDstSize);
+	                                  const RECTANGLE_16* regionRect, BYTE** ppDstData,
+	                                  UINT32* pDstSize, RDPGFX_H264_METABLOCK* meta);
 
 	FREERDP_API INT32 avc420_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSize,
 	                                    BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep,
@@ -81,8 +98,10 @@ extern "C"
 
 	FREERDP_API INT32 avc444_compress(H264_CONTEXT* h264, const BYTE* pSrcData, DWORD SrcFormat,
 	                                  UINT32 nSrcStep, UINT32 nSrcWidth, UINT32 nSrcHeight,
-	                                  BYTE version, BYTE* op, BYTE** pDstData, UINT32* pDstSize,
-	                                  BYTE** pAuxDstData, UINT32* pAuxDstSize);
+	                                  BYTE version, const RECTANGLE_16* regionRect, BYTE* op,
+	                                  BYTE** pDstData, UINT32* pDstSize, BYTE** pAuxDstData,
+	                                  UINT32* pAuxDstSize, RDPGFX_H264_METABLOCK* meta,
+	                                  RDPGFX_H264_METABLOCK* auxMeta);
 
 	FREERDP_API INT32 avc444_decompress(H264_CONTEXT* h264, BYTE op,
 	                                    const RECTANGLE_16* regionRects, UINT32 numRegionRect,

--- a/include/freerdp/codec/yuv.h
+++ b/include/freerdp/codec/yuv.h
@@ -32,9 +32,25 @@ extern "C"
 {
 #endif
 
-	FREERDP_API BOOL yuv_context_decode(YUV_CONTEXT* context, const BYTE* pYUVData[3],
-	                                    UINT32 iStride[3], DWORD DstFormat, BYTE* dest,
-	                                    UINT32 nDstStep);
+	FREERDP_API BOOL yuv420_context_decode(YUV_CONTEXT* context, const BYTE* pYUVData[3],
+	                                       const UINT32 iStride[3], DWORD DstFormat, BYTE* dest,
+	                                       UINT32 nDstStep, const RECTANGLE_16* regionRects,
+	                                       UINT32 numRegionRects);
+	FREERDP_API BOOL yuv420_context_encode(YUV_CONTEXT* context, const BYTE* rgbData,
+	                                       UINT32 srcStep, UINT32 srcFormat,
+	                                       const UINT32 iStride[3], BYTE* yuvData[3],
+	                                       const RECTANGLE_16* regionRects, UINT32 numRegionRects);
+
+	FREERDP_API BOOL yuv444_context_decode(YUV_CONTEXT* context, BYTE type, const BYTE* pYUVData[3],
+	                                       const UINT32 iStride[3], BYTE* pYUVDstData[3],
+	                                       const UINT32 iDstStride[3], DWORD DstFormat, BYTE* dest,
+	                                       UINT32 nDstStep, const RECTANGLE_16* regionRects,
+	                                       UINT32 numRegionRects);
+	FREERDP_API BOOL yuv444_context_encode(YUV_CONTEXT* context, BYTE version, const BYTE* pSrcData,
+	                                       UINT32 nSrcStep, UINT32 SrcFormat,
+	                                       const UINT32 iStride[3], BYTE* pYUVLumaData[3],
+	                                       BYTE* pYUVChromaData[3], const RECTANGLE_16* regionRects,
+	                                       UINT32 numRegionRects);
 
 	FREERDP_API void yuv_context_reset(YUV_CONTEXT* context, UINT32 width, UINT32 height);
 

--- a/include/freerdp/primitives.h
+++ b/include/freerdp/primitives.h
@@ -123,7 +123,7 @@ typedef pstatus_t (*__YUV444ToRGB_8u_P3AC4R_t)(const BYTE* const pSrc[3], const 
                                                BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
                                                const prim_size_t* roi);
 typedef pstatus_t (*__RGBToYUV420_8u_P3AC4R_t)(const BYTE* pSrc, UINT32 SrcFormat, UINT32 srcStep,
-                                               BYTE* pDst[3], UINT32 dstStep[3],
+                                               BYTE* pDst[3], const UINT32 dstStep[3],
                                                const prim_size_t* roi);
 typedef pstatus_t (*__RGBToYUV444_8u_P3AC4R_t)(const BYTE* pSrc, UINT32 SrcFormat, UINT32 srcStep,
                                                BYTE* pDst[3], UINT32 dstStep[3],

--- a/libfreerdp/codec/h264.c
+++ b/libfreerdp/codec/h264.c
@@ -41,6 +41,9 @@ static BOOL avc444_ensure_buffer(H264_CONTEXT* h264, DWORD nDstHeight);
 
 BOOL avc420_ensure_buffer(H264_CONTEXT* h264, UINT32 stride, UINT32 width, UINT32 height)
 {
+	size_t x;
+	BOOL isNull = FALSE;
+
 	if (!h264)
 		return FALSE;
 
@@ -53,23 +56,33 @@ BOOL avc420_ensure_buffer(H264_CONTEXT* h264, UINT32 stride, UINT32 width, UINT3
 	if (height % 16 != 0)
 		height += 16 - height % 16;
 
-	if (!h264->pYUVData[0] || !h264->pYUVData[1] || !h264->pYUVData[2] || (width != h264->width) ||
-	    (height != h264->height) || (stride != h264->iStride[0]))
+	for (x = 0; x < 3; x++)
 	{
+		if (!h264->pYUVData[x] || !h264->pOldYUVData[x])
+			isNull = TRUE;
+	}
+
+	if (isNull || (width != h264->width) || (height != h264->height) ||
+	    (stride != h264->iStride[0]))
+	{
+
 		h264->iStride[0] = stride;
 		h264->iStride[1] = (stride + 1) / 2;
 		h264->iStride[2] = (stride + 1) / 2;
 		h264->width = width;
 		h264->height = height;
-		_aligned_free(h264->pYUVData[0]);
-		_aligned_free(h264->pYUVData[1]);
-		_aligned_free(h264->pYUVData[2]);
-		h264->pYUVData[0] = _aligned_malloc(h264->iStride[0] * height * 1ULL, 16);
-		h264->pYUVData[1] = _aligned_malloc(h264->iStride[1] * height * 1ULL, 16);
-		h264->pYUVData[2] = _aligned_malloc(h264->iStride[2] * height * 1ULL, 16);
 
-		if (!h264->pYUVData[0] || !h264->pYUVData[1] || !h264->pYUVData[2])
-			return FALSE;
+		for (x = 0; x < 3; x++)
+		{
+			BYTE* tmp1 = _aligned_recalloc(h264->pYUVData[x], h264->iStride[x], height, 16);
+			BYTE* tmp2 = _aligned_recalloc(h264->pOldYUVData[x], h264->iStride[x], height, 16);
+			if (tmp1)
+				h264->pYUVData[x] = tmp1;
+			if (tmp2)
+				h264->pOldYUVData[x] = tmp2;
+			if (!tmp1 || !tmp2)
+				return FALSE;
+		}
 	}
 
 	return TRUE;
@@ -82,7 +95,7 @@ INT32 avc420_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSize
 	int status;
 	const BYTE* pYUVData[3];
 
-	if (!h264)
+	if (!h264 || h264->Compressor)
 		return -1001;
 
 	status = h264->subsystem->Decompress(h264, pSrcData, SrcSize);
@@ -103,13 +116,117 @@ INT32 avc420_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSize
 	return 1;
 }
 
-INT32 avc420_compress(H264_CONTEXT* h264, const BYTE* pSrcData, DWORD SrcFormat, UINT32 nSrcStep,
-                      UINT32 nSrcWidth, UINT32 nSrcHeight, BYTE** ppDstData, UINT32* pDstSize)
+static BOOL allocate_h264_metablock(UINT32 QP, RECTANGLE_16* rectangles,
+                                    RDPGFX_H264_METABLOCK* meta, size_t count)
 {
-	RECTANGLE_16 rect;
-	const BYTE* pYUVData[3];
+	size_t x;
+	if (!meta)
+		return FALSE;
 
-	if (!h264)
+	meta->regionRects = rectangles;
+	if (count == 0)
+		return TRUE;
+
+	meta->quantQualityVals = calloc(count, sizeof(RDPGFX_H264_QUANT_QUALITY));
+
+	if (!meta->quantQualityVals || !meta->regionRects)
+		return FALSE;
+	meta->numRegionRects = count;
+	for (x = 0; x < count; x++)
+	{
+		RDPGFX_H264_QUANT_QUALITY* cur = &meta->quantQualityVals[x];
+		cur->qp = QP;
+		cur->qualityVal = 100 - QP;
+	}
+	return TRUE;
+}
+
+static INLINE BOOL diff_tile(const RECTANGLE_16* regionRect, BYTE* pYUVData[3],
+                             BYTE* pOldYUVData[3], UINT32 const iStride[3])
+{
+	size_t size, y;
+	if (!regionRect || !pYUVData || !pOldYUVData || !iStride)
+		return FALSE;
+	size = regionRect->right - regionRect->left;
+	if (regionRect->right > iStride[0])
+		return FALSE;
+	if (regionRect->right / 2 > iStride[1])
+		return FALSE;
+	if (regionRect->right / 2 > iStride[2])
+		return FALSE;
+
+	for (y = regionRect->top; y < regionRect->bottom; y++)
+	{
+		const BYTE* cur0 = &pYUVData[0][y * iStride[0]];
+		const BYTE* cur1 = &pYUVData[1][y * iStride[1]];
+		const BYTE* cur2 = &pYUVData[2][y * iStride[2]];
+		const BYTE* old0 = &pOldYUVData[0][y * iStride[0]];
+		const BYTE* old1 = &pOldYUVData[1][y * iStride[1]];
+		const BYTE* old2 = &pOldYUVData[2][y * iStride[2]];
+
+		if (memcmp(&cur0[regionRect->left], &old0[regionRect->left], size) != 0)
+			return TRUE;
+		if (memcmp(&cur1[regionRect->left / 2], &old1[regionRect->left / 2], size / 2) != 0)
+			return TRUE;
+		if (memcmp(&cur2[regionRect->left / 2], &old2[regionRect->left / 2], size / 2) != 0)
+			return TRUE;
+	}
+	return FALSE;
+}
+
+static BOOL detect_changes(BOOL firstFrameDone, const UINT32 QP, const RECTANGLE_16* regionRect,
+                           BYTE* pYUVData[3], BYTE* pOldYUVData[3], UINT32 const iStride[3],
+                           RDPGFX_H264_METABLOCK* meta)
+{
+	size_t count = 0, wc, hc;
+	RECTANGLE_16* rectangles;
+
+	if (!regionRect || !pYUVData || !pOldYUVData || !iStride || !meta)
+		return FALSE;
+
+	wc = (regionRect->right - regionRect->left) / 64 + 1;
+	hc = (regionRect->bottom - regionRect->top) / 64 + 1;
+	rectangles = calloc(wc * hc, sizeof(RECTANGLE_16));
+	if (!rectangles)
+		return FALSE;
+	if (!firstFrameDone)
+	{
+		rectangles[0] = *regionRect;
+		count = 1;
+	}
+	else
+	{
+		size_t x, y;
+		for (y = regionRect->top; y < regionRect->bottom; y += 64)
+		{
+			for (x = regionRect->left; x < regionRect->right; x += 64)
+			{
+				RECTANGLE_16 rect;
+				rect.left = regionRect->left + x;
+				rect.top = regionRect->top + y;
+				rect.right = MIN(regionRect->left + x + 64, regionRect->right);
+				rect.bottom = MIN(regionRect->top + y + 64, regionRect->bottom);
+				if (diff_tile(&rect, pYUVData, pOldYUVData, iStride))
+					rectangles[count++] = rect;
+			}
+		}
+	}
+	if (!allocate_h264_metablock(QP, rectangles, meta, count))
+		return FALSE;
+	return TRUE;
+}
+
+INT32 avc420_compress(H264_CONTEXT* h264, const BYTE* pSrcData, DWORD SrcFormat, UINT32 nSrcStep,
+                      UINT32 nSrcWidth, UINT32 nSrcHeight, const RECTANGLE_16* regionRect,
+                      BYTE** ppDstData, UINT32* pDstSize, RDPGFX_H264_METABLOCK* meta)
+{
+	size_t x;
+	INT32 rc;
+	BYTE* pYUVData[3];
+	const BYTE* pcYUVData[3];
+	BYTE* pOldYUVData[3];
+
+	if (!h264 || !regionRect || !meta || !h264->Compressor)
 		return -1;
 
 	if (!h264->subsystem->Compress)
@@ -118,30 +235,58 @@ INT32 avc420_compress(H264_CONTEXT* h264, const BYTE* pSrcData, DWORD SrcFormat,
 	if (!avc420_ensure_buffer(h264, nSrcStep, nSrcWidth, nSrcHeight))
 		return -1;
 
-	rect.left = 0;
-	rect.top = 0;
-	rect.right = nSrcWidth;
-	rect.bottom = nSrcHeight;
+	if (h264->encodingBuffer)
+	{
+		for (x = 0; x < 3; x++)
+		{
+			pYUVData[x] = h264->pYUVData[x];
+			pOldYUVData[x] = h264->pOldYUVData[x];
+		}
+	}
+	else
+	{
+		for (x = 0; x < 3; x++)
+		{
+			pYUVData[x] = h264->pOldYUVData[x];
+			pOldYUVData[x] = h264->pYUVData[x];
+		}
+	}
+	h264->encodingBuffer = !h264->encodingBuffer;
 
-	if (!yuv420_context_encode(h264->yuv, pSrcData, nSrcStep, SrcFormat, h264->iStride,
-	                           h264->pYUVData, &rect, 1))
+	if (!yuv420_context_encode(h264->yuv, pSrcData, nSrcStep, SrcFormat, h264->iStride, pYUVData,
+	                           regionRect, 1))
 		return -1;
 
-	pYUVData[0] = h264->pYUVData[0];
-	pYUVData[1] = h264->pYUVData[1];
-	pYUVData[2] = h264->pYUVData[2];
-	return h264->subsystem->Compress(h264, pYUVData, h264->iStride, ppDstData, pDstSize);
+	if (!detect_changes(h264->firstLumaFrameDone, h264->QP, regionRect, pYUVData, pOldYUVData,
+	                    h264->iStride, meta))
+		return -1;
+
+	if (meta->numRegionRects == 0)
+		return 0;
+
+	for (x = 0; x < 3; x++)
+		pcYUVData[x] = pYUVData[x];
+
+	rc = h264->subsystem->Compress(h264, pcYUVData, h264->iStride, ppDstData, pDstSize);
+	if (rc >= 0)
+		h264->firstLumaFrameDone = TRUE;
+	return rc;
 }
 
 INT32 avc444_compress(H264_CONTEXT* h264, const BYTE* pSrcData, DWORD SrcFormat, UINT32 nSrcStep,
-                      UINT32 nSrcWidth, UINT32 nSrcHeight, BYTE version, BYTE* op, BYTE** ppDstData,
-                      UINT32* pDstSize, BYTE** ppAuxDstData, UINT32* pAuxDstSize)
+                      UINT32 nSrcWidth, UINT32 nSrcHeight, BYTE version, const RECTANGLE_16* region,
+                      BYTE* op, BYTE** ppDstData, UINT32* pDstSize, BYTE** ppAuxDstData,
+                      UINT32* pAuxDstSize, RDPGFX_H264_METABLOCK* meta,
+                      RDPGFX_H264_METABLOCK* auxMeta)
 {
-	RECTANGLE_16 rect = { 0 };
 	BYTE* coded;
 	UINT32 codedSize;
+	BYTE** pYUV444Data;
+	BYTE** pOldYUV444Data;
+	BYTE** pYUVData;
+	BYTE** pOldYUVData;
 
-	if (!h264)
+	if (!h264 || !h264->Compressor)
 		return -1;
 
 	if (!h264->subsystem->Compress)
@@ -153,34 +298,75 @@ INT32 avc444_compress(H264_CONTEXT* h264, const BYTE* pSrcData, DWORD SrcFormat,
 	if (!avc444_ensure_buffer(h264, nSrcHeight))
 		return -1;
 
-	rect.right = nSrcWidth;
-	rect.bottom = nSrcHeight;
+	if (h264->encodingBuffer)
+	{
+		pYUV444Data = h264->pOldYUV444Data;
+		pOldYUV444Data = h264->pYUV444Data;
+		pYUVData = h264->pOldYUVData;
+		pOldYUVData = h264->pYUVData;
+	}
+	else
+	{
+		pYUV444Data = h264->pYUV444Data;
+		pOldYUV444Data = h264->pOldYUV444Data;
+		pYUVData = h264->pYUVData;
+		pOldYUVData = h264->pOldYUVData;
+	}
+	h264->encodingBuffer = !h264->encodingBuffer;
 
 	if (!yuv444_context_encode(h264->yuv, version, pSrcData, nSrcStep, SrcFormat, h264->iStride,
-	                           h264->pYUV444Data, h264->pYUVData, &rect, 1))
+	                           pYUV444Data, pYUVData, region, 1))
 		return -1;
 
-	{
-		const BYTE* pYUV444Data[3] = { h264->pYUV444Data[0], h264->pYUV444Data[1],
-			                           h264->pYUV444Data[2] };
+	if (!detect_changes(h264->firstLumaFrameDone, h264->QP, region, pYUV444Data, pOldYUV444Data,
+	                    h264->iStride, meta))
+		return -1;
+	if (!detect_changes(h264->firstChromaFrameDone, h264->QP, region, pYUVData, pOldYUVData,
+	                    h264->iStride, auxMeta))
+		return -1;
 
-		if (h264->subsystem->Compress(h264, pYUV444Data, h264->iStride, &coded, &codedSize) < 0)
-			return -1;
+	/* [MS-RDPEGFX] 2.2.4.5 RFX_AVC444_BITMAP_STREAM
+	 * LC:
+	 * 0 ... Luma & Chroma
+	 * 1 ... Luma
+	 * 2 ... Chroma
+	 */
+	if ((meta->numRegionRects > 0) && (auxMeta->numRegionRects > 0))
+		*op = 0;
+	else if (meta->numRegionRects > 0)
+		*op = 1;
+	else if (auxMeta->numRegionRects > 0)
+		*op = 2;
+	else
+	{
+		WLog_INFO(TAG, "no changes detected for luma or chroma frame");
+		return 0;
 	}
 
-	memcpy(h264->lumaData, coded, codedSize);
-	*ppDstData = h264->lumaData;
-	*pDstSize = codedSize;
+	if ((*op == 0) || (*op == 1))
 	{
-		const BYTE* pYUVData[3] = { h264->pYUVData[0], h264->pYUVData[1], h264->pYUVData[2] };
+		const BYTE* pcYUV444Data[3] = { pYUV444Data[0], pYUV444Data[1], pYUV444Data[2] };
 
-		if (h264->subsystem->Compress(h264, pYUVData, h264->iStride, &coded, &codedSize) < 0)
+		if (h264->subsystem->Compress(h264, pcYUV444Data, h264->iStride, &coded, &codedSize) < 0)
 			return -1;
+		h264->firstLumaFrameDone = TRUE;
+		memcpy(h264->lumaData, coded, codedSize);
+		*ppDstData = h264->lumaData;
+		*pDstSize = codedSize;
 	}
-	*ppAuxDstData = coded;
-	*pAuxDstSize = codedSize;
-	*op = 0;
-	return 0;
+
+	if ((*op == 0) || (*op == 2))
+	{
+		const BYTE* pcYUVData[3] = { pYUVData[0], pYUVData[1], pYUVData[2] };
+
+		if (h264->subsystem->Compress(h264, pcYUVData, h264->iStride, &coded, &codedSize) < 0)
+			return -1;
+		h264->firstChromaFrameDone = TRUE;
+		*ppAuxDstData = coded;
+		*pAuxDstSize = codedSize;
+	}
+
+	return 1;
 }
 
 static BOOL avc444_ensure_buffer(H264_CONTEXT* h264, DWORD nDstHeight)
@@ -190,6 +376,7 @@ static BOOL avc444_ensure_buffer(H264_CONTEXT* h264, DWORD nDstHeight)
 	UINT32* piDstSize = h264->iYUV444Size;
 	UINT32* piDstStride = h264->iYUV444Stride;
 	BYTE** ppYUVDstData = h264->pYUV444Data;
+	BYTE** ppOldYUVDstData = h264->pOldYUV444Data;
 	const UINT32 pad = nDstHeight % 16;
 	UINT32 padDstHeight = nDstHeight; /* Need alignment to 16x16 blocks */
 
@@ -200,24 +387,31 @@ static BOOL avc444_ensure_buffer(H264_CONTEXT* h264, DWORD nDstHeight)
 	{
 		for (x = 0; x < 3; x++)
 		{
+			BYTE* tmp1;
+			BYTE* tmp2;
 			piDstStride[x] = piMainStride[0];
 			piDstSize[x] = piDstStride[x] * padDstHeight;
-			_aligned_free(ppYUVDstData[x]);
-			ppYUVDstData[x] = _aligned_malloc(piDstSize[x], 16);
-
-			if (!ppYUVDstData[x])
+			tmp1 = _aligned_recalloc(ppYUVDstData[x], piDstSize[x], 1, 16);
+			if (tmp1)
+				ppYUVDstData[x] = tmp1;
+			tmp2 = _aligned_recalloc(ppOldYUVDstData[x], piDstSize[x], 1, 16);
+			if (tmp2)
+				ppOldYUVDstData[x] = tmp2;
+			if (!tmp1 || !tmp2)
 				goto fail;
-
-			memset(ppYUVDstData[x], 0, piDstSize[x]);
 		}
 
-		_aligned_free(h264->lumaData);
-		h264->lumaData = _aligned_malloc(piDstSize[0] * 4, 16);
+		{
+			BYTE* tmp = _aligned_recalloc(h264->lumaData, piDstSize[0], 4, 16);
+			if (!tmp)
+				goto fail;
+			h264->lumaData = tmp;
+		}
 	}
 
 	for (x = 0; x < 3; x++)
 	{
-		if (!ppYUVDstData[x] || (piDstSize[x] == 0) || (piDstStride[x] == 0))
+		if (!ppOldYUVDstData[x] || !ppYUVDstData[x] || (piDstSize[x] == 0) || (piDstStride[x] == 0))
 		{
 			WLog_Print(h264->log, WLOG_ERROR,
 			           "YUV buffer not initialized! check your decoder settings");
@@ -230,14 +424,6 @@ static BOOL avc444_ensure_buffer(H264_CONTEXT* h264, DWORD nDstHeight)
 
 	return TRUE;
 fail:
-	_aligned_free(ppYUVDstData[0]);
-	_aligned_free(ppYUVDstData[1]);
-	_aligned_free(ppYUVDstData[2]);
-	_aligned_free(h264->lumaData);
-	ppYUVDstData[0] = NULL;
-	ppYUVDstData[1] = NULL;
-	ppYUVDstData[2] = NULL;
-	h264->lumaData = NULL;
 	return FALSE;
 }
 
@@ -297,7 +483,7 @@ INT32 avc444_decompress(H264_CONTEXT* h264, BYTE op, const RECTANGLE_16* regionR
 	avc444_frame_type chroma =
 	    (codecId == RDPGFX_CODECID_AVC444) ? AVC444_CHROMAv1 : AVC444_CHROMAv2;
 
-	if (!h264 || !regionRects || !pSrcData || !pDstData)
+	if (!h264 || !regionRects || !pSrcData || !pDstData || h264->Compressor)
 		return -1001;
 
 	switch (op)
@@ -487,11 +673,21 @@ void h264_context_free(H264_CONTEXT* h264)
 {
 	if (h264)
 	{
+		size_t x;
 		h264->subsystem->Uninit(h264);
-		_aligned_free(h264->pYUV444Data[0]);
-		_aligned_free(h264->pYUV444Data[1]);
-		_aligned_free(h264->pYUV444Data[2]);
+
+		for (x = 0; x < 3; x++)
+		{
+			if (h264->Compressor)
+			{
+				_aligned_free(h264->pYUVData[x]);
+				_aligned_free(h264->pOldYUVData[x]);
+			}
+			_aligned_free(h264->pYUV444Data[x]);
+			_aligned_free(h264->pOldYUV444Data[x]);
+		}
 		_aligned_free(h264->lumaData);
+
 		yuv_context_free(h264->yuv);
 		free(h264);
 	}

--- a/libfreerdp/codec/h264.c
+++ b/libfreerdp/codec/h264.c
@@ -30,6 +30,7 @@
 
 #include <freerdp/primitives.h>
 #include <freerdp/codec/h264.h>
+#include <freerdp/codec/yuv.h>
 #include <freerdp/log.h>
 
 #include "h264.h"
@@ -74,102 +75,12 @@ BOOL avc420_ensure_buffer(H264_CONTEXT* h264, UINT32 stride, UINT32 width, UINT3
 	return TRUE;
 }
 
-static BOOL check_rect(const H264_CONTEXT* h264, const RECTANGLE_16* rect, UINT32 nDstWidth,
-                       UINT32 nDstHeight)
-{
-	/* Check, if the output rectangle is valid in decoded h264 frame. */
-	if ((rect->right > h264->width) || (rect->left > h264->width))
-		return FALSE;
-
-	if ((rect->top > h264->height) || (rect->bottom > h264->height))
-		return FALSE;
-
-	/* Check, if the output rectangle is valid in destination buffer. */
-	if ((rect->right > nDstWidth) || (rect->left > nDstWidth))
-		return FALSE;
-
-	if ((rect->bottom > nDstHeight) || (rect->top > nDstHeight))
-		return FALSE;
-
-	return TRUE;
-}
-
-static BOOL avc_yuv_to_rgb(H264_CONTEXT* h264, const RECTANGLE_16* regionRects,
-                           UINT32 numRegionRects, UINT32 nDstWidth, UINT32 nDstHeight,
-                           UINT32 nDstStep, BYTE* pDstData, DWORD DstFormat, BOOL use444)
-{
-	UINT32 x;
-	BYTE* pDstPoint;
-	prim_size_t roi;
-	INT32 width, height;
-	const BYTE* pYUVPoint[3];
-	primitives_t* prims = primitives_get();
-
-	for (x = 0; x < numRegionRects; x++)
-	{
-		const RECTANGLE_16* rect = &(regionRects[x]);
-		const UINT32* iStride;
-		BYTE** ppYUVData;
-
-		if (use444)
-		{
-			iStride = h264->iYUV444Stride;
-			ppYUVData = h264->pYUV444Data;
-		}
-		else
-		{
-			iStride = h264->iStride;
-			ppYUVData = h264->pYUVData;
-		}
-
-		if (!check_rect(h264, rect, nDstWidth, nDstHeight))
-			return FALSE;
-
-		width = rect->right - rect->left;
-		height = rect->bottom - rect->top;
-		pDstPoint = pDstData + rect->top * nDstStep + rect->left * 4;
-		pYUVPoint[0] = ppYUVData[0] + rect->top * iStride[0] + rect->left;
-		pYUVPoint[1] = ppYUVData[1];
-		pYUVPoint[2] = ppYUVData[2];
-
-		if (use444)
-		{
-			pYUVPoint[1] += rect->top * iStride[1] + rect->left;
-			pYUVPoint[2] += rect->top * iStride[2] + rect->left;
-		}
-		else
-		{
-			pYUVPoint[1] += rect->top / 2 * iStride[1] + rect->left / 2;
-			pYUVPoint[2] += rect->top / 2 * iStride[2] + rect->left / 2;
-		}
-
-		roi.width = width;
-		roi.height = height;
-
-		if (use444)
-		{
-			if (prims->YUV444ToRGB_8u_P3AC4R(pYUVPoint, iStride, pDstPoint, nDstStep, DstFormat,
-			                                 &roi) != PRIMITIVES_SUCCESS)
-			{
-				return FALSE;
-			}
-		}
-		else
-		{
-			if (prims->YUV420ToRGB_8u_P3AC4R(pYUVPoint, iStride, pDstPoint, nDstStep, DstFormat,
-			                                 &roi) != PRIMITIVES_SUCCESS)
-				return FALSE;
-		}
-	}
-
-	return TRUE;
-}
-
 INT32 avc420_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSize, BYTE* pDstData,
                         DWORD DstFormat, UINT32 nDstStep, UINT32 nDstWidth, UINT32 nDstHeight,
-                        RECTANGLE_16* regionRects, UINT32 numRegionRects)
+                        const RECTANGLE_16* regionRects, UINT32 numRegionRects)
 {
 	int status;
+	const BYTE* pYUVData[3];
 
 	if (!h264)
 		return -1001;
@@ -182,8 +93,11 @@ INT32 avc420_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSize
 	if (status < 0)
 		return status;
 
-	if (!avc_yuv_to_rgb(h264, regionRects, numRegionRects, nDstWidth, nDstHeight, nDstStep,
-	                    pDstData, DstFormat, FALSE))
+	pYUVData[0] = h264->pYUVData[0];
+	pYUVData[1] = h264->pYUVData[1];
+	pYUVData[2] = h264->pYUVData[2];
+	if (!yuv420_context_decode(h264->yuv, pYUVData, h264->iStride, DstFormat, pDstData, nDstStep,
+	                           regionRects, numRegionRects))
 		return -1002;
 
 	return 1;
@@ -192,8 +106,8 @@ INT32 avc420_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSize
 INT32 avc420_compress(H264_CONTEXT* h264, const BYTE* pSrcData, DWORD SrcFormat, UINT32 nSrcStep,
                       UINT32 nSrcWidth, UINT32 nSrcHeight, BYTE** ppDstData, UINT32* pDstSize)
 {
-	prim_size_t roi;
-	primitives_t* prims = primitives_get();
+	RECTANGLE_16 rect;
+	const BYTE* pYUVData[3];
 
 	if (!h264)
 		return -1;
@@ -204,25 +118,26 @@ INT32 avc420_compress(H264_CONTEXT* h264, const BYTE* pSrcData, DWORD SrcFormat,
 	if (!avc420_ensure_buffer(h264, nSrcStep, nSrcWidth, nSrcHeight))
 		return -1;
 
-	roi.width = nSrcWidth;
-	roi.height = nSrcHeight;
+	rect.left = 0;
+	rect.top = 0;
+	rect.right = nSrcWidth;
+	rect.bottom = nSrcHeight;
 
-	if (prims->RGBToYUV420_8u_P3AC4R(pSrcData, SrcFormat, nSrcStep, h264->pYUVData, h264->iStride,
-	                                 &roi) != PRIMITIVES_SUCCESS)
+	if (!yuv420_context_encode(h264->yuv, pSrcData, nSrcStep, SrcFormat, h264->iStride,
+	                           h264->pYUVData, &rect, 1))
 		return -1;
 
-	{
-		const BYTE* pYUVData[3] = { h264->pYUVData[0], h264->pYUVData[1], h264->pYUVData[2] };
-		return h264->subsystem->Compress(h264, pYUVData, h264->iStride, ppDstData, pDstSize);
-	}
+	pYUVData[0] = h264->pYUVData[0];
+	pYUVData[1] = h264->pYUVData[1];
+	pYUVData[2] = h264->pYUVData[2];
+	return h264->subsystem->Compress(h264, pYUVData, h264->iStride, ppDstData, pDstSize);
 }
 
 INT32 avc444_compress(H264_CONTEXT* h264, const BYTE* pSrcData, DWORD SrcFormat, UINT32 nSrcStep,
                       UINT32 nSrcWidth, UINT32 nSrcHeight, BYTE version, BYTE* op, BYTE** ppDstData,
                       UINT32* pDstSize, BYTE** ppAuxDstData, UINT32* pAuxDstSize)
 {
-	prim_size_t roi;
-	primitives_t* prims = primitives_get();
+	RECTANGLE_16 rect = { 0 };
 	BYTE* coded;
 	UINT32 codedSize;
 
@@ -238,30 +153,12 @@ INT32 avc444_compress(H264_CONTEXT* h264, const BYTE* pSrcData, DWORD SrcFormat,
 	if (!avc444_ensure_buffer(h264, nSrcHeight))
 		return -1;
 
-	roi.width = nSrcWidth;
-	roi.height = nSrcHeight;
+	rect.right = nSrcWidth;
+	rect.bottom = nSrcHeight;
 
-	switch (version)
-	{
-		case 1:
-			if (prims->RGBToAVC444YUV(pSrcData, SrcFormat, nSrcStep, h264->pYUV444Data,
-			                          h264->iStride, h264->pYUVData, h264->iStride,
-			                          &roi) != PRIMITIVES_SUCCESS)
-				return -1;
-
-			break;
-
-		case 2:
-			if (prims->RGBToAVC444YUVv2(pSrcData, SrcFormat, nSrcStep, h264->pYUV444Data,
-			                            h264->iStride, h264->pYUVData, h264->iStride,
-			                            &roi) != PRIMITIVES_SUCCESS)
-				return -1;
-
-			break;
-
-		default:
-			return -1;
-	}
+	if (!yuv444_context_encode(h264->yuv, version, pSrcData, nSrcStep, SrcFormat, h264->iStride,
+	                           h264->pYUV444Data, h264->pYUVData, &rect, 1))
+		return -1;
 
 	{
 		const BYTE* pYUV444Data[3] = { h264->pYUV444Data[0], h264->pYUV444Data[1],
@@ -349,37 +246,26 @@ static BOOL avc444_process_rects(H264_CONTEXT* h264, const BYTE* pSrcData, UINT3
                                  UINT32 nDstWidth, UINT32 nDstHeight, const RECTANGLE_16* rects,
                                  UINT32 nrRects, avc444_frame_type type)
 {
-	const primitives_t* prims = primitives_get();
-	UINT32 x;
+	const BYTE* pYUVData[3];
+	BYTE* pYUVDstData[3];
 	UINT32* piDstStride = h264->iYUV444Stride;
 	BYTE** ppYUVDstData = h264->pYUV444Data;
 	const UINT32* piStride = h264->iStride;
-	const BYTE* const* ppYUVData = (const BYTE* const*)h264->pYUVData;
 
 	if (h264->subsystem->Decompress(h264, pSrcData, SrcSize) < 0)
 		return FALSE;
 
+	pYUVData[0] = h264->pYUVData[0];
+	pYUVData[1] = h264->pYUVData[1];
+	pYUVData[2] = h264->pYUVData[2];
 	if (!avc444_ensure_buffer(h264, nDstHeight))
 		return FALSE;
 
-	for (x = 0; x < nrRects; x++)
-	{
-		const RECTANGLE_16* rect = &rects[x];
-		const UINT32 alignedWidth =
-		    h264->width + ((h264->width % 16 != 0) ? 16 - h264->width % 16 : 0);
-		const UINT32 alignedHeight =
-		    h264->height + ((h264->height % 16 != 0) ? 16 - h264->height % 16 : 0);
-
-		if (!check_rect(h264, rect, nDstWidth, nDstHeight))
-			continue;
-
-		if (prims->YUV420CombineToYUV444(type, ppYUVData, piStride, alignedWidth, alignedHeight,
-		                                 ppYUVDstData, piDstStride, rect) != PRIMITIVES_SUCCESS)
-			return FALSE;
-	}
-
-	if (!avc_yuv_to_rgb(h264, rects, nrRects, nDstWidth, nDstHeight, nDstStep, pDstData, DstFormat,
-	                    TRUE))
+	pYUVDstData[0] = ppYUVDstData[0];
+	pYUVDstData[1] = ppYUVDstData[1];
+	pYUVDstData[2] = ppYUVDstData[2];
+	if (!yuv444_context_decode(h264->yuv, type, pYUVData, piStride, pYUVDstData, piDstStride,
+	                           DstFormat, pDstData, nDstStep, rects, nrRects))
 		return FALSE;
 
 	return TRUE;
@@ -401,9 +287,9 @@ static double avg(UINT64* count, double old, double size)
 }
 #endif
 
-INT32 avc444_decompress(H264_CONTEXT* h264, BYTE op, RECTANGLE_16* regionRects,
+INT32 avc444_decompress(H264_CONTEXT* h264, BYTE op, const RECTANGLE_16* regionRects,
                         UINT32 numRegionRects, const BYTE* pSrcData, UINT32 SrcSize,
-                        RECTANGLE_16* auxRegionRects, UINT32 numAuxRegionRect,
+                        const RECTANGLE_16* auxRegionRects, UINT32 numAuxRegionRect,
                         const BYTE* pAuxSrcData, UINT32 AuxSrcSize, BYTE* pDstData, DWORD DstFormat,
                         UINT32 nDstStep, UINT32 nDstWidth, UINT32 nDstHeight, UINT32 codecId)
 {
@@ -563,33 +449,38 @@ BOOL h264_context_reset(H264_CONTEXT* h264, UINT32 width, UINT32 height)
 
 	h264->width = width;
 	h264->height = height;
+	yuv_context_reset(h264->yuv, width, height);
+
 	return TRUE;
 }
 
 H264_CONTEXT* h264_context_new(BOOL Compressor)
 {
-	H264_CONTEXT* h264;
-	h264 = (H264_CONTEXT*)calloc(1, sizeof(H264_CONTEXT));
+	H264_CONTEXT* h264 = (H264_CONTEXT*)calloc(1, sizeof(H264_CONTEXT));
+	if (!h264)
+		return NULL;
 
-	if (h264)
+	h264->Compressor = Compressor;
+	if (Compressor)
+
 	{
-		h264->Compressor = Compressor;
-
-		if (Compressor)
-		{
-			/* Default compressor settings, may be changed by caller */
-			h264->BitRate = 1000000;
-			h264->FrameRate = 30;
-		}
-
-		if (!h264_context_init(h264))
-		{
-			free(h264);
-			return NULL;
-		}
+		/* Default compressor settings, may be changed by caller */
+		h264->BitRate = 1000000;
+		h264->FrameRate = 30;
 	}
 
+	if (!h264_context_init(h264))
+		goto fail;
+
+	h264->yuv = yuv_context_new(Compressor, 0);
+	if (!h264->yuv)
+		goto fail;
+
 	return h264;
+
+fail:
+	h264_context_free(h264);
+	return NULL;
 }
 
 void h264_context_free(H264_CONTEXT* h264)
@@ -601,6 +492,7 @@ void h264_context_free(H264_CONTEXT* h264)
 		_aligned_free(h264->pYUV444Data[1]);
 		_aligned_free(h264->pYUV444Data[2]);
 		_aligned_free(h264->lumaData);
+		yuv_context_free(h264->yuv);
 		free(h264);
 	}
 }

--- a/libfreerdp/codec/h264.h
+++ b/libfreerdp/codec/h264.h
@@ -24,6 +24,22 @@
 #include <freerdp/api.h>
 #include <freerdp/codec/h264.h>
 
+typedef BOOL (*pfnH264SubsystemInit)(H264_CONTEXT* h264);
+typedef void (*pfnH264SubsystemUninit)(H264_CONTEXT* h264);
+
+typedef int (*pfnH264SubsystemDecompress)(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSize);
+typedef int (*pfnH264SubsystemCompress)(H264_CONTEXT* h264, const BYTE** pSrcYuv,
+                                        const UINT32* pStride, BYTE** ppDstData, UINT32* pDstSize);
+
+struct _H264_CONTEXT_SUBSYSTEM
+{
+	const char* name;
+	pfnH264SubsystemInit Init;
+	pfnH264SubsystemUninit Uninit;
+	pfnH264SubsystemDecompress Decompress;
+	pfnH264SubsystemCompress Compress;
+};
+
 FREERDP_LOCAL BOOL avc420_ensure_buffer(H264_CONTEXT* h264, UINT32 stride, UINT32 width,
                                         UINT32 height);
 

--- a/libfreerdp/codec/h264_ffmpeg.c
+++ b/libfreerdp/codec/h264_ffmpeg.c
@@ -28,6 +28,8 @@
 #include <libavcodec/avcodec.h>
 #include <libavutil/opt.h>
 
+#include "h264.h"
+
 #ifdef WITH_VAAPI
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(55, 9, 0)
 #include <libavutil/hwcontext.h>

--- a/libfreerdp/codec/h264_openh264.c
+++ b/libfreerdp/codec/h264_openh264.c
@@ -30,6 +30,8 @@
 #include "wels/codec_api.h"
 #include "wels/codec_ver.h"
 
+#include "h264.h"
+
 typedef void (*pWelsGetCodecVersionEx)(OpenH264Version* pVersion);
 
 typedef long (*pWelsCreateDecoder)(ISVCDecoder** ppDecoder);

--- a/libfreerdp/codec/yuv.c
+++ b/libfreerdp/codec/yuv.c
@@ -26,21 +26,78 @@ struct _YUV_PROCESS_WORK_PARAM
 	DWORD DstFormat;
 	BYTE* dest;
 	UINT32 nDstStep;
-	UINT32 y;
-	UINT32 height;
+	RECTANGLE_16 rect;
 };
 typedef struct _YUV_PROCESS_WORK_PARAM YUV_PROCESS_WORK_PARAM;
 
-static void CALLBACK yuv_process_work_callback(PTP_CALLBACK_INSTANCE instance, void* context,
-                                               PTP_WORK work)
+struct _YUV_COMBINE_WORK_PARAM
+{
+	YUV_CONTEXT* context;
+	const BYTE* pYUVData[3];
+	UINT32 iStride[3];
+	BYTE* pYUVDstData[3];
+	UINT32 iDstStride[3];
+	RECTANGLE_16 rect;
+	BYTE type;
+};
+typedef struct _YUV_COMBINE_WORK_PARAM YUV_COMBINE_WORK_PARAM;
+
+struct _YUV_ENCODE_WORK_PARAM
+{
+	YUV_CONTEXT* context;
+	const BYTE* pSrcData;
+
+	DWORD SrcFormat;
+	UINT32 nSrcStep;
+	RECTANGLE_16 rect;
+	BYTE version;
+
+	BYTE* pYUVLumaData[3];
+	BYTE* pYUVChromaData[3];
+	UINT32 iStride[3];
+};
+typedef struct _YUV_ENCODE_WORK_PARAM YUV_ENCODE_WORK_PARAM;
+
+static void CALLBACK yuv420_process_work_callback(PTP_CALLBACK_INSTANCE instance, void* context,
+                                                  PTP_WORK work)
 {
 	prim_size_t roi;
 	YUV_PROCESS_WORK_PARAM* param = (YUV_PROCESS_WORK_PARAM*)context;
 	primitives_t* prims = primitives_get();
 
-	roi.width = param->context->width;
-	roi.height = param->height;
-	if (prims->YUV420ToRGB_8u_P3AC4R(param->pYUVData, param->iStride, param->dest, param->nDstStep,
+	const BYTE* pYUVData[3];
+	BYTE* dest = param->dest + param->rect.top * param->nDstStep +
+	             param->rect.left * GetBytesPerPixel(param->DstFormat);
+	pYUVData[0] = param->pYUVData[0] + param->iStride[0] * param->rect.top + param->rect.left;
+	pYUVData[1] =
+	    param->pYUVData[1] + param->iStride[1] * param->rect.top / 2 + param->rect.left / 2;
+	pYUVData[2] =
+	    param->pYUVData[2] + param->iStride[2] * param->rect.top / 2 + param->rect.left / 2;
+	roi.width = param->rect.right - param->rect.left;
+	roi.height = param->rect.bottom - param->rect.top;
+	if (prims->YUV420ToRGB_8u_P3AC4R(pYUVData, param->iStride, dest, param->nDstStep,
+	                                 param->DstFormat, &roi) != PRIMITIVES_SUCCESS)
+	{
+		WLog_ERR(TAG, "error when decoding lines");
+	}
+}
+
+static void CALLBACK yuv444_process_work_callback(PTP_CALLBACK_INSTANCE instance, void* context,
+                                                  PTP_WORK work)
+{
+	prim_size_t roi;
+	YUV_PROCESS_WORK_PARAM* param = (YUV_PROCESS_WORK_PARAM*)context;
+	primitives_t* prims = primitives_get();
+
+	const BYTE* pYUVData[3];
+	BYTE* dest = param->dest + param->rect.top * param->nDstStep +
+	             param->rect.left * GetBytesPerPixel(param->DstFormat);
+	pYUVData[0] = param->pYUVData[0] + param->iStride[0] * param->rect.top + param->rect.left;
+	pYUVData[1] = param->pYUVData[1] + param->iStride[1] * param->rect.top + param->rect.left;
+	pYUVData[2] = param->pYUVData[2] + param->iStride[2] * param->rect.top + param->rect.left;
+	roi.width = param->rect.right - param->rect.left;
+	roi.height = param->rect.bottom - param->rect.top;
+	if (prims->YUV444ToRGB_8u_P3AC4R(pYUVData, param->iStride, dest, param->nDstStep,
 	                                 param->DstFormat, &roi) != PRIMITIVES_SUCCESS)
 	{
 		WLog_ERR(TAG, "error when decoding lines");
@@ -94,12 +151,14 @@ YUV_CONTEXT* yuv_context_new(BOOL encoder, UINT32 ThreadingFlags)
 	return ret;
 
 error_threadpool:
-	free(ret);
+	yuv_context_free(ret);
 	return NULL;
 }
 
 void yuv_context_free(YUV_CONTEXT* context)
 {
+	if (!context)
+		return;
 	if (context->useThreads)
 	{
 		CloseThreadpool(context->threadPool);
@@ -108,70 +167,65 @@ void yuv_context_free(YUV_CONTEXT* context)
 	free(context);
 }
 
-BOOL yuv_context_decode(YUV_CONTEXT* context, const BYTE* pYUVData[3], UINT32 iStride[3],
-                        DWORD DstFormat, BYTE* dest, UINT32 nDstStep)
+static INLINE YUV_PROCESS_WORK_PARAM pool_decode_param(const RECTANGLE_16* rect,
+                                                       YUV_CONTEXT* context,
+                                                       const BYTE* pYUVData[3],
+                                                       const UINT32 iStride[3], UINT32 DstFormat,
+                                                       BYTE* dest, UINT32 nDstStep)
 {
-	UINT32 y, nobjects, i;
-	PTP_WORK* work_objects = NULL;
-	YUV_PROCESS_WORK_PARAM* params;
-	UINT32 waitCount = 0;
-	BOOL ret = TRUE;
-	primitives_t* prims = primitives_get();
+	YUV_PROCESS_WORK_PARAM current = { 0 };
 
-	if (!context->useThreads || (primitives_flags(prims) & PRIM_FLAGS_HAVE_EXTGPU))
+	current.context = context;
+	current.DstFormat = DstFormat;
+	current.pYUVData[0] = pYUVData[0];
+	current.pYUVData[1] = pYUVData[1];
+	current.pYUVData[2] = pYUVData[2];
+	current.iStride[0] = iStride[0];
+	current.iStride[1] = iStride[1];
+	current.iStride[2] = iStride[2];
+	current.nDstStep = nDstStep;
+	current.dest = dest;
+	current.rect = *rect;
+	return current;
+}
+
+static BOOL allocate_objects(PTP_WORK** work, void** params, size_t size, UINT32 count)
+{
 	{
-		prim_size_t roi;
-		roi.width = context->width;
-		roi.height = context->height;
-		return prims->YUV420ToRGB_8u_P3AC4R(pYUVData, iStride, dest, nDstStep, DstFormat, &roi) ==
-		       PRIMITIVES_SUCCESS;
+		PTP_WORK* tmp;
+		PTP_WORK* cur = *work;
+		tmp = realloc(cur, sizeof(PTP_WORK*) * count);
+		if (!tmp)
+			return FALSE;
+		*work = tmp;
 	}
-
-	/* case where we use threads */
-	nobjects = (context->height + context->heightStep - 1) / context->heightStep;
-	work_objects = (PTP_WORK*)calloc(nobjects, sizeof(PTP_WORK));
-	if (!work_objects)
 	{
+		void* cur = *params;
+		void* tmp = realloc(cur, size * count);
+		if (!tmp)
+			return FALSE;
+		*params = tmp;
+	}
+	return TRUE;
+}
+
+static BOOL submit_object(PTP_WORK* work_object, PTP_WORK_CALLBACK cb, const void* param,
+                          YUV_CONTEXT* context)
+{
+	if (!work_object || !param || !context)
 		return FALSE;
-	}
 
-	params = (YUV_PROCESS_WORK_PARAM*)calloc(nobjects, sizeof(*params));
-	if (!params)
-	{
-		free(work_objects);
+	*work_object = CreateThreadpoolWork(cb, (void*)param, &context->ThreadPoolEnv);
+	if (!*work_object)
 		return FALSE;
-	}
 
-	for (i = 0, y = 0; i < nobjects; i++, y += context->heightStep, waitCount++)
-	{
-		params[i].context = context;
-		params[i].DstFormat = DstFormat;
-		params[i].pYUVData[0] = pYUVData[0] + (y * iStride[0]);
-		params[i].pYUVData[1] = pYUVData[1] + ((y / 2) * iStride[1]);
-		params[i].pYUVData[2] = pYUVData[2] + ((y / 2) * iStride[2]);
+	SubmitThreadpoolWork(*work_object);
+	return TRUE;
+}
 
-		params[i].iStride[0] = iStride[0];
-		params[i].iStride[1] = iStride[1];
-		params[i].iStride[2] = iStride[2];
-
-		params[i].nDstStep = nDstStep;
-		params[i].dest = dest + (nDstStep * y);
-		params[i].y = y;
-		if (y + context->heightStep <= context->height)
-			params[i].height = context->heightStep;
-		else
-			params[i].height = context->height % context->heightStep;
-
-		work_objects[i] = CreateThreadpoolWork(yuv_process_work_callback, (void*)&params[i],
-		                                       &context->ThreadPoolEnv);
-		if (!work_objects[i])
-		{
-			ret = FALSE;
-			break;
-		}
-		SubmitThreadpoolWork(work_objects[i]);
-	}
-
+static void free_objects(PTP_WORK* work_objects, void* params, UINT32 waitCount)
+{
+	UINT32 i;
 	for (i = 0; i < waitCount; i++)
 	{
 		WaitForThreadpoolWorkCallbacks(work_objects[i], FALSE);
@@ -180,6 +234,426 @@ BOOL yuv_context_decode(YUV_CONTEXT* context, const BYTE* pYUVData[3], UINT32 iS
 
 	free(work_objects);
 	free(params);
+}
 
-	return ret;
+static BOOL pool_decode(YUV_CONTEXT* context, PTP_WORK_CALLBACK cb, const BYTE* pYUVData[3],
+                        const UINT32 iStride[3], UINT32 DstFormat, BYTE* dest, UINT32 nDstStep,
+                        const RECTANGLE_16* regionRects, UINT32 numRegionRects)
+{
+	BOOL rc = FALSE;
+	UINT32 x, y, nobjects;
+	PTP_WORK* work_objects = NULL;
+	YUV_PROCESS_WORK_PARAM* params = NULL;
+	UINT32 waitCount = 0;
+	primitives_t* prims = primitives_get();
+
+	if (!context->useThreads || (primitives_flags(prims) & PRIM_FLAGS_HAVE_EXTGPU))
+	{
+		for (y = 0; y < numRegionRects; y++)
+		{
+			YUV_PROCESS_WORK_PARAM current = pool_decode_param(&regionRects[y], context, pYUVData,
+			                                                   iStride, DstFormat, dest, nDstStep);
+			cb(NULL, &current, NULL);
+		}
+		return TRUE;
+	}
+
+	/* case where we use threads */
+	nobjects = (context->height + context->heightStep - 1) / context->heightStep;
+	if (!allocate_objects(&work_objects, (void**)&params, sizeof(YUV_PROCESS_WORK_PARAM), nobjects))
+		goto fail;
+
+	for (x = 0; x < numRegionRects; x++)
+	{
+		const RECTANGLE_16* rect = &regionRects[x];
+		const UINT32 height = rect->bottom - rect->top;
+		const UINT32 steps = (height + context->heightStep / 2) / context->heightStep;
+
+		if (waitCount + steps >= nobjects)
+		{
+			nobjects *= 2;
+			if (!allocate_objects(&work_objects, (void**)&params, sizeof(YUV_PROCESS_WORK_PARAM),
+			                      nobjects))
+				goto fail;
+		}
+
+		for (y = 0; y < steps; y++)
+		{
+			YUV_PROCESS_WORK_PARAM* cur = &params[waitCount];
+			RECTANGLE_16 r = *rect;
+			r.top += y * context->heightStep;
+			*cur = pool_decode_param(&r, context, pYUVData, iStride, DstFormat, dest, nDstStep);
+			if (!submit_object(&work_objects[waitCount], cb, cur, context))
+				goto fail;
+
+			waitCount++;
+		}
+	}
+
+	rc = TRUE;
+fail:
+	free_objects(work_objects, params, waitCount);
+	return rc;
+}
+
+static INLINE BOOL check_rect(const YUV_CONTEXT* yuv, const RECTANGLE_16* rect, UINT32 nDstWidth,
+                              UINT32 nDstHeight)
+{
+	/* Check, if the output rectangle is valid in decoded h264 frame. */
+	if ((rect->right > yuv->width) || (rect->left > yuv->width))
+		return FALSE;
+
+	if ((rect->top > yuv->height) || (rect->bottom > yuv->height))
+		return FALSE;
+
+	/* Check, if the output rectangle is valid in destination buffer. */
+	if ((rect->right > nDstWidth) || (rect->left > nDstWidth))
+		return FALSE;
+
+	if ((rect->bottom > nDstHeight) || (rect->top > nDstHeight))
+		return FALSE;
+
+	return TRUE;
+}
+
+static void CALLBACK yuv444_combine_work_callback(PTP_CALLBACK_INSTANCE instance, void* context,
+                                                  PTP_WORK work)
+{
+	YUV_COMBINE_WORK_PARAM* param = (YUV_COMBINE_WORK_PARAM*)context;
+	primitives_t* prims = primitives_get();
+	YUV_CONTEXT* yuv = param->context;
+	const RECTANGLE_16* rect = &param->rect;
+	const UINT32 alignedWidth = yuv->width + ((yuv->width % 16 != 0) ? 16 - yuv->width % 16 : 0);
+	const UINT32 alignedHeight =
+	    yuv->height + ((yuv->height % 16 != 0) ? 16 - yuv->height % 16 : 0);
+
+	WINPR_UNUSED(instance);
+	WINPR_UNUSED(work);
+
+	if (!check_rect(context, rect, yuv->width, yuv->height))
+		return;
+
+	if (prims->YUV420CombineToYUV444(param->type, param->pYUVData, param->iStride, alignedWidth,
+	                                 alignedHeight, param->pYUVDstData, param->iDstStride,
+	                                 rect) != PRIMITIVES_SUCCESS)
+		WLog_WARN(TAG, "YUV420CombineToYUV444 failed");
+}
+
+static INLINE YUV_COMBINE_WORK_PARAM pool_decode_rect_param(
+    const RECTANGLE_16* rect, YUV_CONTEXT* context, BYTE type, const BYTE* pYUVData[3],
+    const UINT32 iStride[3], BYTE* pYUVDstData[3], const UINT32 iDstStride[3])
+{
+	YUV_COMBINE_WORK_PARAM current = { 0 };
+	current.context = context;
+	current.pYUVData[0] = pYUVData[0];
+	current.pYUVData[1] = pYUVData[1];
+	current.pYUVData[2] = pYUVData[2];
+	current.pYUVDstData[0] = pYUVDstData[0];
+	current.pYUVDstData[1] = pYUVDstData[1];
+	current.pYUVDstData[2] = pYUVDstData[2];
+	current.iStride[0] = iStride[0];
+	current.iStride[1] = iStride[1];
+	current.iStride[2] = iStride[2];
+	current.iDstStride[0] = iDstStride[0];
+	current.iDstStride[1] = iDstStride[1];
+	current.iDstStride[2] = iDstStride[2];
+	current.type = type;
+	current.rect = *rect;
+	return current;
+}
+
+static BOOL pool_decode_rect(YUV_CONTEXT* context, BYTE type, const BYTE* pYUVData[3],
+                             const UINT32 iStride[3], BYTE* pYUVDstData[3],
+                             const UINT32 iDstStride[3], const RECTANGLE_16* regionRects,
+                             UINT32 numRegionRects)
+{
+	BOOL rc = FALSE;
+	UINT32 y;
+	PTP_WORK* work_objects = NULL;
+	YUV_COMBINE_WORK_PARAM* params = NULL;
+	UINT32 waitCount = 0;
+	PTP_WORK_CALLBACK cb = yuv444_combine_work_callback;
+	primitives_t* prims = primitives_get();
+
+	if (!context->useThreads || (primitives_flags(prims) & PRIM_FLAGS_HAVE_EXTGPU))
+	{
+		for (y = 0; y < numRegionRects; y++)
+		{
+			YUV_COMBINE_WORK_PARAM current = pool_decode_rect_param(
+			    &regionRects[y], context, type, pYUVData, iStride, pYUVDstData, iDstStride);
+			cb(NULL, &current, NULL);
+		}
+		return TRUE;
+	}
+
+	/* case where we use threads */
+	if (!allocate_objects(&work_objects, (void**)&params, sizeof(YUV_COMBINE_WORK_PARAM),
+	                      numRegionRects))
+		goto fail;
+
+	for (waitCount = 0; waitCount < numRegionRects; waitCount++)
+	{
+		YUV_COMBINE_WORK_PARAM* current = &params[waitCount];
+		*current = pool_decode_rect_param(&regionRects[waitCount], context, type, pYUVData, iStride,
+		                                  pYUVDstData, iDstStride);
+		if (!submit_object(&work_objects[waitCount], cb, current, context))
+			goto fail;
+	}
+
+	rc = TRUE;
+fail:
+	free_objects(work_objects, params, waitCount);
+	return rc;
+}
+
+BOOL yuv444_context_decode(YUV_CONTEXT* context, BYTE type, const BYTE* pYUVData[3],
+                           const UINT32 iStride[3], BYTE* pYUVDstData[3],
+                           const UINT32 iDstStride[3], DWORD DstFormat, BYTE* dest, UINT32 nDstStep,
+                           const RECTANGLE_16* regionRects, UINT32 numRegionRects)
+{
+	const BYTE* pYUVCDstData[3];
+
+	if (!pool_decode_rect(context, type, pYUVData, iStride, pYUVDstData, iDstStride, regionRects,
+	                      numRegionRects))
+		return FALSE;
+
+	pYUVCDstData[0] = pYUVDstData[0];
+	pYUVCDstData[1] = pYUVDstData[1];
+	pYUVCDstData[2] = pYUVDstData[2];
+	return pool_decode(context, yuv444_process_work_callback, pYUVCDstData, iDstStride, DstFormat,
+	                   dest, nDstStep, regionRects, numRegionRects);
+}
+
+BOOL yuv420_context_decode(YUV_CONTEXT* context, const BYTE* pYUVData[3], const UINT32 iStride[3],
+                           DWORD DstFormat, BYTE* dest, UINT32 nDstStep,
+                           const RECTANGLE_16* regionRects, UINT32 numRegionRects)
+{
+	return pool_decode(context, yuv420_process_work_callback, pYUVData, iStride, DstFormat, dest,
+	                   nDstStep, regionRects, numRegionRects);
+}
+
+static void CALLBACK yuv420_encode_work_callback(PTP_CALLBACK_INSTANCE instance, void* context,
+                                                 PTP_WORK work)
+{
+	prim_size_t roi;
+	YUV_ENCODE_WORK_PARAM* param = (YUV_ENCODE_WORK_PARAM*)context;
+	primitives_t* prims = primitives_get();
+	BYTE* pYUVData[3];
+	const BYTE* src;
+
+	WINPR_UNUSED(instance);
+	WINPR_UNUSED(work);
+
+	roi.width = param->rect.right - param->rect.left;
+	roi.height = param->rect.bottom - param->rect.top;
+	src = param->pSrcData + param->nSrcStep * param->rect.top +
+	      param->rect.left * GetBytesPerPixel(param->SrcFormat);
+	pYUVData[0] = param->pYUVLumaData[0] + param->rect.top * param->iStride[0] + param->rect.left;
+	pYUVData[1] =
+	    param->pYUVLumaData[1] + param->rect.top / 2 * param->iStride[1] + param->rect.left / 2;
+	pYUVData[2] =
+	    param->pYUVLumaData[2] + param->rect.top / 2 * param->iStride[2] + param->rect.left / 2;
+
+	if (prims->RGBToYUV420_8u_P3AC4R(src, param->SrcFormat, param->nSrcStep, pYUVData,
+	                                 param->iStride, &roi) != PRIMITIVES_SUCCESS)
+	{
+		WLog_ERR(TAG, "error when decoding lines");
+	}
+}
+
+static void CALLBACK yuv444v1_encode_work_callback(PTP_CALLBACK_INSTANCE instance, void* context,
+                                                   PTP_WORK work)
+{
+	prim_size_t roi;
+	YUV_ENCODE_WORK_PARAM* param = (YUV_ENCODE_WORK_PARAM*)context;
+	primitives_t* prims = primitives_get();
+	BYTE* pYUVLumaData[3];
+	BYTE* pYUVChromaData[3];
+	const BYTE* src;
+
+	WINPR_UNUSED(instance);
+	WINPR_UNUSED(work);
+
+	roi.width = param->rect.right - param->rect.left;
+	roi.height = param->rect.bottom - param->rect.top;
+	src = param->pSrcData + param->nSrcStep * param->rect.top +
+	      param->rect.left * GetBytesPerPixel(param->SrcFormat);
+	pYUVLumaData[0] =
+	    param->pYUVLumaData[0] + param->rect.top * param->iStride[0] + param->rect.left;
+	pYUVLumaData[1] =
+	    param->pYUVLumaData[1] + param->rect.top / 2 * param->iStride[1] + param->rect.left / 2;
+	pYUVLumaData[2] =
+	    param->pYUVLumaData[2] + param->rect.top / 2 * param->iStride[2] + param->rect.left / 2;
+	pYUVChromaData[0] =
+	    param->pYUVChromaData[0] + param->rect.top * param->iStride[0] + param->rect.left;
+	pYUVChromaData[1] =
+	    param->pYUVChromaData[1] + param->rect.top / 2 * param->iStride[1] + param->rect.left / 2;
+	pYUVChromaData[2] =
+	    param->pYUVChromaData[2] + param->rect.top / 2 * param->iStride[2] + param->rect.left / 2;
+	if (prims->RGBToAVC444YUV(src, param->SrcFormat, param->nSrcStep, pYUVLumaData, param->iStride,
+	                          pYUVChromaData, param->iStride, &roi) != PRIMITIVES_SUCCESS)
+	{
+		WLog_ERR(TAG, "error when decoding lines");
+	}
+}
+
+static void CALLBACK yuv444v2_encode_work_callback(PTP_CALLBACK_INSTANCE instance, void* context,
+                                                   PTP_WORK work)
+{
+	prim_size_t roi;
+	YUV_ENCODE_WORK_PARAM* param = (YUV_ENCODE_WORK_PARAM*)context;
+	primitives_t* prims = primitives_get();
+	BYTE* pYUVLumaData[3];
+	BYTE* pYUVChromaData[3];
+	const BYTE* src;
+
+	WINPR_UNUSED(instance);
+	WINPR_UNUSED(work);
+
+	roi.width = param->rect.right - param->rect.left;
+	roi.height = param->rect.bottom - param->rect.top;
+	src = param->pSrcData + param->nSrcStep * param->rect.top +
+	      param->rect.left * GetBytesPerPixel(param->SrcFormat);
+	pYUVLumaData[0] =
+	    param->pYUVLumaData[0] + param->rect.top * param->iStride[0] + param->rect.left;
+	pYUVLumaData[1] =
+	    param->pYUVLumaData[1] + param->rect.top / 2 * param->iStride[1] + param->rect.left / 2;
+	pYUVLumaData[2] =
+	    param->pYUVLumaData[2] + param->rect.top / 2 * param->iStride[2] + param->rect.left / 2;
+	pYUVChromaData[0] =
+	    param->pYUVChromaData[0] + param->rect.top * param->iStride[0] + param->rect.left;
+	pYUVChromaData[1] =
+	    param->pYUVChromaData[1] + param->rect.top / 2 * param->iStride[1] + param->rect.left / 2;
+	pYUVChromaData[2] =
+	    param->pYUVChromaData[2] + param->rect.top / 2 * param->iStride[2] + param->rect.left / 2;
+	if (prims->RGBToAVC444YUVv2(src, param->SrcFormat, param->nSrcStep, pYUVLumaData,
+	                            param->iStride, pYUVChromaData, param->iStride,
+	                            &roi) != PRIMITIVES_SUCCESS)
+	{
+		WLog_ERR(TAG, "error when decoding lines");
+	}
+}
+
+static INLINE YUV_ENCODE_WORK_PARAM pool_encode_fill(const RECTANGLE_16* rect, YUV_CONTEXT* context,
+                                                     const BYTE* pSrcData, UINT32 nSrcStep,
+                                                     UINT32 SrcFormat, const UINT32 iStride[],
+                                                     BYTE* pYUVLumaData[], BYTE* pYUVChromaData[])
+{
+	YUV_ENCODE_WORK_PARAM current = { 0 };
+
+	current.context = context;
+	current.pSrcData = pSrcData;
+	current.SrcFormat = SrcFormat;
+	current.nSrcStep = nSrcStep;
+	current.pYUVLumaData[0] = pYUVLumaData[0];
+	current.pYUVLumaData[1] = pYUVLumaData[1];
+	current.pYUVLumaData[2] = pYUVLumaData[2];
+	if (pYUVChromaData)
+	{
+		current.pYUVChromaData[0] = pYUVChromaData[0];
+		current.pYUVChromaData[1] = pYUVChromaData[1];
+		current.pYUVChromaData[2] = pYUVChromaData[2];
+	}
+	current.iStride[0] = iStride[0];
+	current.iStride[1] = iStride[1];
+	current.iStride[2] = iStride[2];
+
+	current.rect = *rect;
+
+	return current;
+}
+
+static BOOL pool_encode(YUV_CONTEXT* context, PTP_WORK_CALLBACK cb, const BYTE* pSrcData,
+                        UINT32 nSrcStep, UINT32 SrcFormat, const UINT32 iStride[],
+                        BYTE* pYUVLumaData[], BYTE* pYUVChromaData[],
+                        const RECTANGLE_16* regionRects, UINT32 numRegionRects)
+{
+	BOOL rc = FALSE;
+	primitives_t* prims = primitives_get();
+	UINT32 x, y, nobjects;
+	PTP_WORK* work_objects = NULL;
+	YUV_ENCODE_WORK_PARAM* params = NULL;
+	UINT32 waitCount = 0;
+
+	if (!context->useThreads || (primitives_flags(prims) & PRIM_FLAGS_HAVE_EXTGPU))
+	{
+		for (x = 0; x < numRegionRects; x++)
+		{
+			YUV_ENCODE_WORK_PARAM current =
+			    pool_encode_fill(&regionRects[x], context, pSrcData, nSrcStep, SrcFormat, iStride,
+			                     pYUVLumaData, pYUVChromaData);
+			cb(NULL, &current, NULL);
+		}
+		return TRUE;
+	}
+
+	/* case where we use threads */
+	nobjects = (context->height + context->heightStep - 1) / context->heightStep;
+	if (!allocate_objects(&work_objects, (void**)&params, sizeof(YUV_ENCODE_WORK_PARAM), nobjects))
+		goto fail;
+
+	for (x = 0; x < numRegionRects; x++)
+	{
+		const RECTANGLE_16* rect = &regionRects[x];
+		const UINT32 height = rect->bottom - rect->top;
+		const UINT32 steps = (height + context->heightStep / 2) / context->heightStep;
+
+		if (waitCount + steps >= nobjects)
+		{
+			nobjects *= 2;
+			if (!allocate_objects(&work_objects, (void**)&params, sizeof(YUV_ENCODE_WORK_PARAM),
+			                      nobjects))
+				goto fail;
+		}
+
+		for (y = 0; y < steps; y++)
+		{
+			RECTANGLE_16 r = *rect;
+			YUV_ENCODE_WORK_PARAM* current = &params[waitCount];
+			r.top += y * context->heightStep;
+			*current = pool_encode_fill(&r, context, pSrcData, nSrcStep, SrcFormat, iStride,
+			                            pYUVLumaData, pYUVChromaData);
+			if (!submit_object(&work_objects[waitCount], cb, current, context))
+				goto fail;
+			waitCount++;
+		}
+	}
+
+	rc = TRUE;
+fail:
+	free_objects(work_objects, params, waitCount);
+	return rc;
+}
+
+BOOL yuv420_context_encode(YUV_CONTEXT* context, const BYTE* pSrcData, UINT32 nSrcStep,
+                           UINT32 SrcFormat, const UINT32 iStride[], BYTE* pYUVData[],
+                           const RECTANGLE_16* regionRects, UINT32 numRegionRects)
+{
+	if (!context || !pSrcData || !iStride || !pYUVData || !regionRects)
+		return FALSE;
+
+	return pool_encode(context, yuv420_encode_work_callback, pSrcData, nSrcStep, SrcFormat, iStride,
+	                   pYUVData, NULL, regionRects, numRegionRects);
+}
+
+BOOL yuv444_context_encode(YUV_CONTEXT* context, BYTE version, const BYTE* pSrcData,
+                           UINT32 nSrcStep, UINT32 SrcFormat, const UINT32 iStride[],
+                           BYTE* pYUVLumaData[], BYTE* pYUVChromaData[],
+                           const RECTANGLE_16* regionRects, UINT32 numRegionRects)
+{
+	PTP_WORK_CALLBACK cb;
+	switch (version)
+	{
+		case 1:
+			cb = yuv444v1_encode_work_callback;
+			break;
+		case 2:
+			cb = yuv444v2_encode_work_callback;
+			break;
+		default:
+			return FALSE;
+	}
+
+	return pool_encode(context, cb, pSrcData, nSrcStep, SrcFormat, iStride, pYUVLumaData,
+	                   pYUVChromaData, regionRects, numRegionRects);
 }

--- a/libfreerdp/primitives/prim_YUV.c
+++ b/libfreerdp/primitives/prim_YUV.c
@@ -640,7 +640,7 @@ static pstatus_t general_RGBToYUV444_8u_P3AC4R(const BYTE* pSrc, UINT32 SrcForma
 }
 
 static INLINE pstatus_t general_RGBToYUV420_BGRX(const BYTE* pSrc, UINT32 srcStep, BYTE* pDst[3],
-                                                 UINT32 dstStep[3], const prim_size_t* roi)
+                                                 const UINT32 dstStep[3], const prim_size_t* roi)
 {
 	UINT32 x, y, i;
 	size_t x1 = 0, x2 = 4, x3 = srcStep, x4 = srcStep + 4;
@@ -706,7 +706,7 @@ static INLINE pstatus_t general_RGBToYUV420_BGRX(const BYTE* pSrc, UINT32 srcSte
 }
 
 static INLINE pstatus_t general_RGBToYUV420_RGBX(const BYTE* pSrc, UINT32 srcStep, BYTE* pDst[3],
-                                                 UINT32 dstStep[3], const prim_size_t* roi)
+                                                 const UINT32 dstStep[3], const prim_size_t* roi)
 {
 	UINT32 x, y, i;
 	size_t x1 = 0, x2 = 4, x3 = srcStep, x4 = srcStep + 4;
@@ -772,7 +772,7 @@ static INLINE pstatus_t general_RGBToYUV420_RGBX(const BYTE* pSrc, UINT32 srcSte
 }
 
 static INLINE pstatus_t general_RGBToYUV420_ANY(const BYTE* pSrc, UINT32 srcFormat, UINT32 srcStep,
-                                                BYTE* pDst[3], UINT32 dstStep[3],
+                                                BYTE* pDst[3], const UINT32 dstStep[3],
                                                 const prim_size_t* roi)
 {
 	const UINT32 bpp = GetBytesPerPixel(srcFormat);
@@ -849,7 +849,7 @@ static INLINE pstatus_t general_RGBToYUV420_ANY(const BYTE* pSrc, UINT32 srcForm
 }
 
 static pstatus_t general_RGBToYUV420_8u_P3AC4R(const BYTE* pSrc, UINT32 srcFormat, UINT32 srcStep,
-                                               BYTE* pDst[3], UINT32 dstStep[3],
+                                               BYTE* pDst[3], const UINT32 dstStep[3],
                                                const prim_size_t* roi)
 {
 	switch (srcFormat)

--- a/libfreerdp/primitives/prim_YUV_ssse3.c
+++ b/libfreerdp/primitives/prim_YUV_ssse3.c
@@ -436,7 +436,8 @@ static INLINE void ssse3_RGBToYUV420_BGRX_UV(const BYTE* src1, const BYTE* src2,
 }
 
 static pstatus_t ssse3_RGBToYUV420_BGRX(const BYTE* pSrc, UINT32 srcFormat, UINT32 srcStep,
-                                        BYTE* pDst[3], UINT32 dstStep[3], const prim_size_t* roi)
+                                        BYTE* pDst[3], const UINT32 dstStep[3],
+                                        const prim_size_t* roi)
 {
 	UINT32 y;
 	const BYTE* argb = pSrc;
@@ -478,7 +479,7 @@ static pstatus_t ssse3_RGBToYUV420_BGRX(const BYTE* pSrc, UINT32 srcFormat, UINT
 }
 
 static pstatus_t ssse3_RGBToYUV420(const BYTE* pSrc, UINT32 srcFormat, UINT32 srcStep,
-                                   BYTE* pDst[3], UINT32 dstStep[3], const prim_size_t* roi)
+                                   BYTE* pDst[3], const UINT32 dstStep[3], const prim_size_t* roi)
 {
 	switch (srcFormat)
 	{

--- a/server/shadow/shadow_encoder.c
+++ b/server/shadow/shadow_encoder.c
@@ -245,6 +245,7 @@ static int shadow_encoder_init_h264(rdpShadowEncoder* encoder)
 	encoder->h264->BitRate = encoder->server->h264BitRate;
 	encoder->h264->FrameRate = encoder->server->h264FrameRate;
 	encoder->h264->QP = encoder->server->h264QP;
+
 	encoder->codecs |= FREERDP_CODEC_AVC420 | FREERDP_CODEC_AVC444;
 	return 1;
 fail:

--- a/winpr/libwinpr/crt/alignment.c
+++ b/winpr/libwinpr/crt/alignment.c
@@ -160,12 +160,19 @@ void* _aligned_offset_realloc(void* memblock, size_t size, size_t alignment, siz
 	return newMemblock;
 }
 
+static INLINE size_t cMIN(size_t a, size_t b)
+{
+	if (a > b)
+		return b;
+	return a;
+}
+
 void* _aligned_offset_recalloc(void* memblock, size_t num, size_t size, size_t alignment,
                                size_t offset)
 {
-	void* newMemblock;
-	WINPR_ALIGNED_MEM* pMem;
-	WINPR_ALIGNED_MEM* pNewMem;
+	void* newMemblock = NULL;
+	WINPR_ALIGNED_MEM* pMem = NULL;
+	WINPR_ALIGNED_MEM* pNewMem = NULL;
 
 	if (!memblock)
 	{
@@ -186,22 +193,24 @@ void* _aligned_offset_recalloc(void* memblock, size_t num, size_t size, size_t a
 	{
 		WLog_ERR(TAG,
 		         "_aligned_offset_recalloc: memory block was not allocated by _aligned_malloc!");
-		return NULL;
+		goto fail;
 	}
 
 	if (size == 0)
-	{
-		_aligned_free(memblock);
-		return NULL;
-	}
+		goto fail;
 
 	newMemblock = _aligned_offset_malloc(size * num, alignment, offset);
 
 	if (!newMemblock)
-		return NULL;
+		goto fail;
 
 	pNewMem = WINPR_ALIGNED_MEM_STRUCT_FROM_PTR(newMemblock);
-	ZeroMemory(newMemblock, pNewMem->size);
+	{
+		const size_t size = cMIN(pMem->size, pNewMem->size);
+		memcpy(newMemblock, pMem->base_addr, size);
+		ZeroMemory(newMemblock + size, pNewMem->size - size);
+	}
+fail:
 	_aligned_free(memblock);
 	return newMemblock;
 }


### PR DESCRIPTION
1. Cleaned up YUV primitives, added missing ones
1. Use YUV primitives now for all H264 operations
1. Modified encoder API to return changed rectangles

TODO:
Do performance comparison tests