### PR TITLE
Cleanup internal channel management

### DIFF
--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -436,20 +436,6 @@ extern "C"
 	FREERDP_API BOOL freerdp_disconnect_before_reconnect(freerdp* instance);
 	FREERDP_API BOOL freerdp_reconnect(freerdp* instance);
 
-	FREERDP_API UINT freerdp_channel_add_init_handle_data(rdpChannelHandles* handles,
-	                                                      void* pInitHandle, void* pUserData);
-	FREERDP_API void* freerdp_channel_get_init_handle_data(rdpChannelHandles* handles,
-	                                                       void* pInitHandle);
-	FREERDP_API void freerdp_channel_remove_init_handle_data(rdpChannelHandles* handles,
-	                                                         void* pInitHandle);
-
-	FREERDP_API UINT freerdp_channel_add_open_handle_data(rdpChannelHandles* handles,
-	                                                      DWORD openHandle, void* pUserData);
-	FREERDP_API void* freerdp_channel_get_open_handle_data(rdpChannelHandles* handles,
-	                                                       DWORD openHandle);
-	FREERDP_API void freerdp_channel_remove_open_handle_data(rdpChannelHandles* handles,
-	                                                         DWORD openHandle);
-
 	FREERDP_API UINT freerdp_channels_attach(freerdp* instance);
 	FREERDP_API UINT freerdp_channels_detach(freerdp* instance);
 

--- a/include/freerdp/svc.h
+++ b/include/freerdp/svc.h
@@ -48,7 +48,6 @@ struct _CHANNEL_ENTRY_POINTS_FREERDP
 	UINT32 MagicNumber;  /* identifies FreeRDP */
 	void* pExtendedData; /* extended initial data */
 	void* pInterface;    /* channel callback interface, use after initialization */
-	void** ppInterface;  /* channel callback interface, use for initialization */
 	rdpContext* context;
 };
 typedef struct _CHANNEL_ENTRY_POINTS_FREERDP CHANNEL_ENTRY_POINTS_FREERDP;
@@ -67,7 +66,6 @@ struct _CHANNEL_ENTRY_POINTS_FREERDP_EX
 	UINT32 MagicNumber;  /* identifies FreeRDP */
 	void* pExtendedData; /* extended initial data */
 	void* pInterface;    /* channel callback interface, use after initialization */
-	void** ppInterface;  /* channel callback interface, use for initialization */
 	rdpContext* context;
 };
 typedef struct _CHANNEL_ENTRY_POINTS_FREERDP_EX CHANNEL_ENTRY_POINTS_FREERDP_EX;

--- a/libfreerdp/core/client.h
+++ b/libfreerdp/core/client.h
@@ -112,14 +112,13 @@ struct rdp_channels
 
 	DrdynvcClientContext* drdynvc;
 	CRITICAL_SECTION channelsLock;
-
-	wHashTable* openHandles;
 };
 
 FREERDP_LOCAL rdpChannels* freerdp_channels_new(freerdp* instance);
 FREERDP_LOCAL UINT freerdp_channels_disconnect(rdpChannels* channels, freerdp* instance);
 FREERDP_LOCAL void freerdp_channels_close(rdpChannels* channels, freerdp* instance);
 FREERDP_LOCAL void freerdp_channels_free(rdpChannels* channels);
+FREERDP_LOCAL void freerdp_channels_register_instance(rdpChannels* channels, freerdp* instance);
 FREERDP_LOCAL UINT freerdp_channels_pre_connect(rdpChannels* channels, freerdp* instance);
 FREERDP_LOCAL UINT freerdp_channels_post_connect(rdpChannels* channels, freerdp* instance);
 #endif /* FREERDP_LIB_CORE_CLIENT_H */

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -55,88 +55,6 @@
 
 #define TAG FREERDP_TAG("core")
 
-UINT freerdp_channel_add_init_handle_data(rdpChannelHandles* handles, void* pInitHandle,
-                                          void* pUserData)
-{
-	if (!handles->init)
-		handles->init = ListDictionary_New(TRUE);
-
-	if (!handles->init)
-	{
-		WLog_ERR(TAG, "ListDictionary_New failed!");
-		return ERROR_NOT_ENOUGH_MEMORY;
-	}
-
-	if (!ListDictionary_Add(handles->init, pInitHandle, pUserData))
-	{
-		WLog_ERR(TAG, "ListDictionary_Add failed!");
-		return ERROR_INTERNAL_ERROR;
-	}
-
-	return CHANNEL_RC_OK;
-}
-
-void* freerdp_channel_get_init_handle_data(rdpChannelHandles* handles, void* pInitHandle)
-{
-	void* pUserData = NULL;
-	pUserData = ListDictionary_GetItemValue(handles->init, pInitHandle);
-	return pUserData;
-}
-
-void freerdp_channel_remove_init_handle_data(rdpChannelHandles* handles, void* pInitHandle)
-{
-	ListDictionary_Remove(handles->init, pInitHandle);
-
-	if (ListDictionary_Count(handles->init) < 1)
-	{
-		ListDictionary_Free(handles->init);
-		handles->init = NULL;
-	}
-}
-
-UINT freerdp_channel_add_open_handle_data(rdpChannelHandles* handles, DWORD openHandle,
-                                          void* pUserData)
-{
-	void* pOpenHandle = (void*)(size_t)openHandle;
-
-	if (!handles->open)
-		handles->open = ListDictionary_New(TRUE);
-
-	if (!handles->open)
-	{
-		WLog_ERR(TAG, "ListDictionary_New failed!");
-		return ERROR_NOT_ENOUGH_MEMORY;
-	}
-
-	if (!ListDictionary_Add(handles->open, pOpenHandle, pUserData))
-	{
-		WLog_ERR(TAG, "ListDictionary_Add failed!");
-		return ERROR_INTERNAL_ERROR;
-	}
-
-	return CHANNEL_RC_OK;
-}
-
-void* freerdp_channel_get_open_handle_data(rdpChannelHandles* handles, DWORD openHandle)
-{
-	void* pUserData = NULL;
-	void* pOpenHandle = (void*)(size_t)openHandle;
-	pUserData = ListDictionary_GetItemValue(handles->open, pOpenHandle);
-	return pUserData;
-}
-
-void freerdp_channel_remove_open_handle_data(rdpChannelHandles* handles, DWORD openHandle)
-{
-	void* pOpenHandle = (void*)(size_t)openHandle;
-	ListDictionary_Remove(handles->open, pOpenHandle);
-
-	if (ListDictionary_Count(handles->open) < 1)
-	{
-		ListDictionary_Free(handles->open);
-		handles->open = NULL;
-	}
-}
-
 /** Creates a new connection based on the settings found in the "instance" parameter
  *  It will use the callbacks registered on the structure to process the pre/post connect operations
  *  that the caller requires.
@@ -166,6 +84,8 @@ BOOL freerdp_connect(freerdp* instance)
 	ResetEvent(instance->context->abortEvent);
 	rdp = instance->context->rdp;
 	settings = instance->settings;
+
+	freerdp_channels_register_instance(instance->context->channels, instance);
 
 	if (!freerdp_settings_set_default_order_support(settings))
 		return FALSE;


### PR DESCRIPTION
This PR gets rid of some unneeded/unused fields and functions in the channel handling code. It also makes it possible to call `VirtualChannelWrite` from any thread like the Windows API allows. The only restriction is that the channel must be initialized (`VirtualChannelInit`) from the same thread that called `freerdp_connect`.