### PR TITLE
Bugfix: when `freerdp_assistance_parse_file_buffer` was called from external code, it did not copy the access password to the `rdpAssistanceFile` struct. 

### DIFF
--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -791,6 +791,7 @@ int freerdp_assistance_parse_file_buffer(rdpAssistanceFile* file, const char* bu
 	int status;
 	size_t length;
 
+	free(file->password);
 	file->password = _strdup(password);
 
 	p = strstr(buffer, "UPLOADINFO");
@@ -1175,7 +1176,6 @@ int freerdp_assistance_parse_file(rdpAssistanceFile* file, const char* name, con
 	}
 
 	free(file->filename);
-	free(file->password);
 	file->filename = _strdup(name);
 	fp = fopen(name, "r");
 

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -790,6 +790,9 @@ int freerdp_assistance_parse_file_buffer(rdpAssistanceFile* file, const char* bu
 	char* r;
 	int status;
 	size_t length;
+
+	file->password = _strdup(password);
+
 	p = strstr(buffer, "UPLOADINFO");
 
 	if (p)
@@ -1174,7 +1177,6 @@ int freerdp_assistance_parse_file(rdpAssistanceFile* file, const char* name, con
 	free(file->filename);
 	free(file->password);
 	file->filename = _strdup(name);
-	file->password = _strdup(password);
 	fp = fopen(name, "r");
 
 	if (!fp)


### PR DESCRIPTION
`freerdp_assistance_parse_file_buffer` may be called directly, not necessarily from `freerdp_assistance_parse_file`, so password should be saved to the `rdpAssistanceFile` in `freerdp_assistance_parse_file_buffer`.
