### PR TITLE
Fix issue with channel message queue on reconnects

### DIFF
--- a/libfreerdp/core/client.c
+++ b/libfreerdp/core/client.c
@@ -391,6 +391,8 @@ UINT freerdp_channels_post_connect(rdpChannels* channels, freerdp* instance)
 	hostname = instance->settings->ServerHostname;
 	hostnameLength = strlen(hostname);
 
+	MessageQueue_Clear(channels->queue);
+
 	for (index = 0; index < channels->clientDataCount; index++)
 	{
 		ChannelConnectedEventArgs e;

--- a/winpr/libwinpr/utils/collections/MessageQueue.c
+++ b/winpr/libwinpr/utils/collections/MessageQueue.c
@@ -268,6 +268,7 @@ int MessageQueue_Clear(wMessageQueue* queue)
 		queue->size--;
 	}
 	ResetEvent(queue->event);
+	queue->closed = FALSE;
 
 	LeaveCriticalSection(&queue->lock);
 


### PR DESCRIPTION
The message queue must be cleared on reconnects in order to reset the queue's closed state.