### PR TITLE
client/common: Always set gatewayprofileusagemethod to 1

### DIFF
--- a/client/common/file.c
+++ b/client/common/file.c
@@ -2021,6 +2021,7 @@ rdpFile* freerdp_client_rdp_file_new_ex(DWORD flags)
 	file->lines = NULL;
 	file->lineCount = 0;
 	file->lineSize = 32;
+	file->GatewayProfileUsageMethod = 1;
 	file->lines = (rdpFileLine*)calloc(file->lineSize, sizeof(rdpFileLine));
 
 	if (!file->lines)


### PR DESCRIPTION
mstsc will only load our gateway settings if gatewayprofileusagemethod is set to 1. Otherwise it will always set the option "Auto-detect RD Gateway server settings" and ignore the other gateway settings in the rdp file.
