### PR TITLE
fix [packaging/rpm]: build for fedora >= 33

### DIFF
--- a/packaging/rpm/freerdp-nightly.spec
+++ b/packaging/rpm/freerdp-nightly.spec
@@ -138,7 +138,11 @@ cp %{_topdir}/SOURCES/source_version freerdp-nightly-%{version}/.source_version
 %endif
         -DCMAKE_INSTALL_LIBDIR=%{_lib}
 
+%if 0%{?fedora} > 32
+%cmake_build
+%else
 make %{?_smp_mflags}
+%endif
 
 %install
 %if %{defined suse_version}
@@ -146,8 +150,12 @@ make %{?_smp_mflags}
 %endif
 
 %if %{defined fedora} || %{defined rhel}
+%if 0%{?fedora} > 32
+%cmake_install
+%else
 rm -rf $RPM_BUILD_ROOT
 make install DESTDIR=$RPM_BUILD_ROOT
+%endif
 %endif 
 
 find %{buildroot} -name "*.a" -delete


### PR DESCRIPTION
Fixes nightly mock builds for fedora >= 33.

Out of tree builds are now done. See https://fedoraproject.org/wiki/Changes/CMake_to_do_out-of-source_builds