### PR TITLE
remove unwanted log level set to debug in rfx

### DIFF
--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -220,9 +220,6 @@ RFX_CONTEXT* rfx_context_new(BOOL encoder)
 
 	priv->log = WLog_Get("com.freerdp.codec.rfx");
 	WLog_OpenAppender(priv->log);
-#ifdef WITH_DEBUG_RFX
-	WLog_SetLogLevel(priv->log, WLOG_DEBUG);
-#endif
 	priv->TilePool = ObjectPool_New(TRUE);
 
 	if (!priv->TilePool)


### PR DESCRIPTION
I saw on debian packages (that have -DWITH_DEBUG_ALL=ON) remotefx logs always to
debug without respect log-level and log-filters settings making difficult
debugging of issue on other parts.
After a search I found this that set loglevel to debug that akallabeth confirmed
is unwanted, this patch remove it.

Closes #6606

I tested it and now respect log-level and log-filters.
Can this backported to next 2.2 stable please? Already tested: http://debomatic-armhf.debian.net/distribution#buster-backports/freerdp2/2.2.0+dfsg1-1~bpo10+1.1
