### PR TITLE
freerdp-utils: add the chunkstream component

### DIFF
--- a/include/freerdp/utils/chunkstream.h
+++ b/include/freerdp/utils/chunkstream.h
@@ -1,0 +1,215 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ *
+ * Copyright 2020 Hardening <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_UTILS_CHUNKSTREAM_H
+#define FREERDP_UTILS_CHUNKSTREAM_H
+
+#include <winpr/wtypes.h>
+#include <winpr/stream.h>
+#include <freerdp/api.h>
+
+typedef struct _ChunkStream ChunkStream;
+typedef struct _ChunkStreamSlot ChunkStreamSlot;
+
+#define CHUNKSTREAM_MAX_SLOTS 50
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+	/**
+	 * A ChunkStream is a component to prevent multiple memory copies when forging a packet from
+	 * headers to the payload. The idea is to create a list of chunks (slots) and to do the
+	 * assembly of the full content only when needed (usually when we want to send the content over
+	 * the network).
+	 *
+	 * The chunks can come from static blobs (chunkstream_getStaticStringSlot or
+	 * chunkstream_getStaticMemSlot), from memory allocated by the user (chunkstream_getMallocSlot)
+	 * or from a limited pool allocated by the chunkstream (chunkstream_getPoolSlot).
+	 *
+	 * chunkstream_sizeAfterSlot is useful to compute the size of chunks after a certain slot,
+	 * typically when you want to write some headers that inform of the size of the following
+	 * payload.
+	 *
+	 * A full example usage with a protocol with at least 2 layers:
+	 * 		void layer2(ChunkStream *cs)
+	 * 		{
+	 * 			... allocate and write some more chunks ...
+	 * 		}
+	 *
+	 * 		void layer1(ChunkStream *cs)
+	 * 		{
+	 * 			wStream layer1Headers;
+	 * 			// headers of layers 1 are at max 20 bytes
+	 * 			ChunkStreamSlot *headersSlot = chunkstream_getPoolStream(cs, 20, &layer1Headers);
+	 *
+	 * 			layers2(cs); // create payload, will adds chunks in the chunkstream
+	 *
+	 * 			int payloadSz = chunkstream_sizeAfterSlot(cs, headersSlot);
+	 *
+	 * 			writeLayer1Headers(layer1Headers, payloadSz);
+	 *
+	 * 			chunkstreamslot_update_fromStream(headersSlot, &layer1Headers);
+	 * 		}
+	 *
+	 * 		void writePacket()
+	 * 		{
+	 * 			ChunkStream *cs = chunkstream_new(1024);
+	 * 			layer1(cs);
+	 *
+	 * 			wStream *s = chunkstream_linearizeToStream(cs);
+	 *
+	 * 			... serialize the content of s ...
+	 * 		}
+	 */
+
+	/** Initialises a chunkstream
+	 * @param initialSize the initial capacity of the chunkstream's pool
+	 * @return if the created chunkstream
+	 */
+	FREERDP_API ChunkStream* chunkstream_new(size_t initialSize);
+
+	/** Destroys internal data used by this chunkstream
+	 * @param pchunkstream a pointer to a chunkstream
+	 */
+	FREERDP_API void chunkstream_destroy(ChunkStream** pchunkstream);
+
+	/**
+	 * Retrieves a slot containing a static string
+	 * @param chunkstream the chunkstream
+	 * @param str the string to add
+	 * @param include0 tells if we should include the leading null byte
+	 * @return the corresponding ChunkStreamSlot, NULL if it failed (no available slots)
+	 */
+	FREERDP_API ChunkStreamSlot* chunkstream_getStaticStringSlot(ChunkStream* chunkstream,
+	                                                             const char* str, BOOL include0);
+
+	/**
+	 * Retrieves a slot containing a static memory blob
+	 * @param chunkstream the chunkstream
+	 * @param data the memory blob to add
+	 * @param sz size of the memory blob
+	 * @return the corresponding ChunkStreamSlot, NULL if it failed (no available slots)
+	 */
+	FREERDP_API ChunkStreamSlot* chunkstream_getStaticMemSlot(ChunkStream* chunkstream,
+	                                                          const BYTE* data, size_t sz);
+
+	/**
+	 * Retrieves a slot containing a memory blob alloced by the user, the chunkstream takes
+	 * ownership of the provided memory, so it will be freed when the chunkstream is destroyed.
+	 * @param chunkstream the chunkstream
+	 * @param data the memory blob to add
+	 * @param sz size of the memory blob
+	 * @return the corresponding ChunkStreamSlot, NULL if it failed (no available slots)
+	 */
+	FREERDP_API ChunkStreamSlot* chunkstream_getMallocSlot(ChunkStream* chunkstream, BYTE* data,
+	                                                       size_t sz);
+
+	/**
+	 * Retrieves a slot from the chunkstream's pool. This slot is taken from the pool with an empty
+	 * used size, so it's usually a good idea to use chunkstreamslot_update_used() to set the space
+	 * used in the chunk.
+	 * @param chunkstream the chunkstream
+	 * @param sz size to retrieve from the pool
+	 * @return the corresponding ChunkStreamSlot, NULL if fails (no available slots, or memory in
+	 * 		 the pool)
+	 */
+	FREERDP_API ChunkStreamSlot* chunkstream_getPoolSlot(ChunkStream* chunkstream, size_t sz);
+
+	/**
+	 * Retrieves a slot from the chunkstream pool and initialize a static stream with it. The
+	 * stream will point on the memory associated with the pool item. It's usually a good idea
+	 * to call chunkstreamslot_update_fromStream() when stream processing is finished, to update
+	 * the used counter of the chunk.
+	 * @param chunkstream the chunkstream
+	 * @param sz size to retrieve from the pool
+	 * @param s the stream to initialize
+	 * @return the corresponding ChunkStreamSlot, NULL if fails (no available slots, or memory in
+	 * 			the pool)
+	 */
+	FREERDP_API ChunkStreamSlot* chunkstream_getPoolStream(ChunkStream* chunkstream, size_t sz,
+	                                                       wStream* s);
+
+	/**
+	 * Assembles all the chunks and put them in the returned wStream
+	 * @param chunkstream the chunkstream
+	 * @return a new wStream containing the assembled chunks
+	 */
+	FREERDP_API wStream* chunkstream_linearizeToStream(ChunkStream* chunkstream);
+
+	/**
+	 * Assemble all the chunks in a provided wStream. The function ensures that there's enough
+	 * remaining space in the target stream.
+	 * @param chunkstream the chunkstream
+	 * @param s the target stream
+	 * @return if the operation was successful
+	 */
+	FREERDP_API BOOL chunkstream_linearizeInStream(ChunkStream* chunkstream, wStream* s);
+
+	/**
+	 * Retrieves the size stored in the chunkstream after a given slot
+	 * @param chunkstream the chunkstream
+	 * @param slot the slot to start to compute
+	 * @return the stored size, -1 if the slot was not found
+	 */
+	FREERDP_API int chunkstream_sizeAfterSlot(const ChunkStream* chunkstream,
+	                                          const ChunkStreamSlot* slot);
+
+	/**
+	 * returns the size of the slot
+	 * @param slot the slot
+	 * @return the size of the slot
+	 */
+	FREERDP_API size_t chunkstreamslot_size(const ChunkStreamSlot* slot);
+
+	/**
+	 * returns the allocated size for this slot, when it's not a slot from the pool,
+	 * it's always 0.
+	 * @param slot the slot
+	 * @return the size of the slot
+	 */
+	FREERDP_API size_t chunkstreamslot_allocated(const ChunkStreamSlot* slot);
+
+	/**
+	 * returns the data associated with this slot.
+	 * @param slot the slot
+	 * @return the memory buffer associated with this slot
+	 */
+	FREERDP_API BYTE* chunkstreamslot_data(const ChunkStreamSlot* slot);
+
+	/**
+	 * updates the used counter of this slot
+	 * @param slot the slot
+	 * @param used the new used size to set
+	 * @return if the operation was successful (used can't be > to capacity)
+	 */
+	FREERDP_API BOOL chunkstreamslot_update_used(ChunkStreamSlot* slot, size_t used);
+
+	/**
+	 * updates the used counter of this slot by using the position in the stream
+	 * @param slot the slot
+	 * @param s a stream retrieved by chunkstream_getPoolStream()
+	 * @return if the operation was successful (used can't be > to capacity)
+	 */
+	FREERDP_API BOOL chunkstreamslot_update_fromStream(ChunkStreamSlot* slot, wStream* s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FREERDP_UTILS_CHUNKSTREAM_H */

--- a/libfreerdp/utils/CMakeLists.txt
+++ b/libfreerdp/utils/CMakeLists.txt
@@ -19,6 +19,7 @@ set(MODULE_NAME "freerdp-utils")
 set(MODULE_PREFIX "FREERDP_UTILS")
 
 set(${MODULE_PREFIX}_SRCS
+	chunkstream.c
 	passphrase.c
 	pcap.c
 	profiler.c

--- a/libfreerdp/utils/chunkstream.c
+++ b/libfreerdp/utils/chunkstream.c
@@ -1,0 +1,280 @@
+#include <assert.h>
+
+#include <freerdp/utils/chunkstream.h>
+
+/** @brief kind of slot **/
+typedef enum
+{
+	CHUNK_T_STATIC, /*!< some static content */
+	CHUNK_T_MALLOC, /*!< some content allocated by the caller */
+	CHUNK_T_POOL    /*!< some memory taken from our pool */
+} ChunkStreamSlotType;
+
+struct _ChunkStreamSlot
+{
+	ChunkStreamSlotType slotType;
+	BYTE* data;
+	size_t allocated;
+	size_t used;
+};
+
+struct _ChunkStream
+{
+	BYTE* pool;
+	size_t availablePoolSz;
+	BYTE* availPtr;
+	size_t poolSize;
+
+	ChunkStreamSlot slots[CHUNKSTREAM_MAX_SLOTS];
+	size_t slotCounter;
+};
+
+size_t chunkstreamslot_allocated(const ChunkStreamSlot* slot)
+{
+	assert(slot);
+	return slot->allocated;
+}
+
+size_t chunkstreamslot_size(const ChunkStreamSlot* slot)
+{
+	assert(slot);
+	return slot->used;
+}
+
+BYTE* chunkstreamslot_data(const ChunkStreamSlot* slot)
+{
+	assert(slot);
+	return slot->data;
+}
+
+BOOL chunkstreamslot_update_used(ChunkStreamSlot* slot, size_t used)
+{
+	assert(slot);
+	if (slot->allocated < used)
+		return FALSE;
+
+	slot->used = used;
+	return TRUE;
+}
+
+BOOL chunkstreamslot_update_fromStream(ChunkStreamSlot* slot, wStream* s)
+{
+	assert(s);
+	return chunkstreamslot_update_used(slot, Stream_GetPosition(s));
+}
+
+ChunkStream* chunkstream_new(size_t initialSize)
+{
+	ChunkStream* ret = (ChunkStream*)calloc(1, sizeof(*ret));
+	if (!ret)
+		return NULL;
+
+	ret->poolSize = ret->availablePoolSz = initialSize;
+	if (initialSize)
+	{
+		ret->pool = (BYTE*)calloc(initialSize, 1);
+		if (!ret->pool)
+		{
+			free(ret);
+			return NULL;
+		}
+
+		ret->availPtr = ret->pool;
+	}
+
+	return ret;
+}
+
+void chunkstream_destroy(ChunkStream** pchunkstream)
+{
+	ChunkStream* chunkstream;
+
+	assert(pchunkstream);
+	chunkstream = *pchunkstream;
+	if (chunkstream)
+	{
+		size_t i;
+		for (i = 0; i < chunkstream->slotCounter; i++)
+		{
+			ChunkStreamSlot* slot = &chunkstream->slots[i];
+			switch (slot->slotType)
+			{
+				case CHUNK_T_STATIC:
+				case CHUNK_T_POOL:
+					break;
+				case CHUNK_T_MALLOC:
+					free(slot->data);
+					break;
+			}
+		}
+
+		free(chunkstream->pool);
+		free(chunkstream);
+	}
+
+	*pchunkstream = NULL;
+}
+
+static ChunkStreamSlot* allocateSlot(ChunkStream* chunkstream, ChunkStreamSlotType t)
+{
+	size_t slotId;
+	ChunkStreamSlot* ret;
+
+	if (chunkstream->slotCounter == CHUNKSTREAM_MAX_SLOTS)
+		return NULL;
+
+	slotId = chunkstream->slotCounter++;
+	ret = &chunkstream->slots[slotId];
+	ret->slotType = t;
+	return ret;
+}
+
+ChunkStreamSlot* chunkstream_getStaticMemSlot(ChunkStream* chunkstream, const BYTE* data, size_t sz)
+{
+	ChunkStreamSlot* slot;
+	assert(chunkstream);
+
+	slot = allocateSlot(chunkstream, CHUNK_T_STATIC);
+	if (!slot)
+		return NULL;
+	slot->allocated = 0;
+	slot->used = sz;
+	slot->data = (BYTE*)data;
+	return slot;
+}
+
+ChunkStreamSlot* chunkstream_getStaticStringSlot(ChunkStream* chunkstream, const char* str,
+                                                 BOOL include0)
+{
+	size_t len;
+
+	assert(str);
+
+	len = strlen(str);
+	if (include0)
+		len++;
+	return chunkstream_getStaticMemSlot(chunkstream, (const BYTE*)str, len);
+}
+
+ChunkStreamSlot* chunkstream_getMallocSlot(ChunkStream* chunkstream, BYTE* data, size_t sz)
+{
+	ChunkStreamSlot* slot;
+
+	assert(chunkstream);
+	slot = allocateSlot(chunkstream, CHUNK_T_MALLOC);
+	if (!slot)
+		return NULL;
+
+	slot->data = data;
+	slot->allocated = 0;
+	slot->used = sz;
+	return slot;
+}
+
+static size_t computeFullSize(ChunkStream* chunkstream)
+{
+	size_t i;
+	size_t ret = 0;
+	for (i = 0; i < chunkstream->slotCounter; i++)
+		ret += chunkstream->slots[i].used;
+	return ret;
+}
+
+wStream* chunkstream_linearizeToStream(ChunkStream* chunkstream)
+{
+	wStream* ret;
+	size_t i;
+	size_t allocSz;
+
+	assert(chunkstream);
+
+	allocSz = computeFullSize(chunkstream);
+	if (!allocSz)
+		allocSz = 1;
+
+	ret = Stream_New(NULL, allocSz);
+	if (!ret)
+		return NULL;
+
+	for (i = 0; i < chunkstream->slotCounter; i++)
+	{
+		ChunkStreamSlot* slot = &chunkstream->slots[i];
+		Stream_Write(ret, slot->data, slot->used);
+	}
+
+	return ret;
+}
+
+FREERDP_API BOOL chunkstream_linearizeInStream(ChunkStream* chunkstream, wStream* s)
+{
+	size_t i;
+	size_t allocSz;
+
+	assert(chunkstream);
+	assert(s);
+
+	allocSz = computeFullSize(chunkstream);
+	if (allocSz && !Stream_EnsureRemainingCapacity(s, allocSz))
+		return FALSE;
+
+	for (i = 0; i < chunkstream->slotCounter; i++)
+	{
+		ChunkStreamSlot* slot = &chunkstream->slots[i];
+		Stream_Write(s, slot->data, slot->used);
+	}
+
+	return TRUE;
+}
+
+int chunkstream_sizeAfterSlot(const ChunkStream* chunkstream, const ChunkStreamSlot* slot)
+{
+	int ret, i;
+
+	// first pass to retrieve the slot
+	for (i = 0; i < chunkstream->slotCounter; i++)
+	{
+		if (&chunkstream->slots[i] == slot)
+			break;
+	}
+	if (i == chunkstream->slotCounter)
+		return -1;
+
+	ret = 0;
+	for (i = i + 1; i < chunkstream->slotCounter; i++)
+		ret += chunkstream->slots[i].used;
+
+	return ret;
+}
+
+ChunkStreamSlot* chunkstream_getPoolSlot(ChunkStream* chunkstream, size_t sz)
+{
+	ChunkStreamSlot* slot;
+
+	assert(chunkstream);
+
+	if (chunkstream->availablePoolSz < sz)
+		return NULL;
+
+	slot = allocateSlot(chunkstream, CHUNK_T_POOL);
+	if (!slot)
+		return NULL;
+
+	slot->data = chunkstream->availPtr;
+	slot->allocated = sz;
+	slot->used = 0;
+
+	chunkstream->availPtr += sz;
+	chunkstream->availablePoolSz -= sz;
+
+	return slot;
+}
+
+ChunkStreamSlot* chunkstream_getPoolStream(ChunkStream* chunkstream, size_t sz, wStream* s)
+{
+	ChunkStreamSlot* slot = chunkstream_getPoolSlot(chunkstream, sz);
+	if (!slot)
+		return NULL;
+
+	Stream_StaticInit(s, slot->data, sz);
+	return slot;
+}

--- a/libfreerdp/utils/test/CMakeLists.txt
+++ b/libfreerdp/utils/test/CMakeLists.txt
@@ -5,6 +5,7 @@ set(MODULE_PREFIX "TEST_FREERDP_UTILS")
 set(${MODULE_PREFIX}_DRIVER ${MODULE_NAME}.c)
 
 set(${MODULE_PREFIX}_TESTS
+	TestChunkStream.c
 	TestRingBuffer.c)
 
 create_test_sourcelist(${MODULE_PREFIX}_SRCS
@@ -13,7 +14,7 @@ create_test_sourcelist(${MODULE_PREFIX}_SRCS
 
 add_executable(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
 
-target_link_libraries(${MODULE_NAME} freerdp)
+target_link_libraries(${MODULE_NAME} freerdp winpr)
 
 set_target_properties(${MODULE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${TESTING_OUTPUT_DIRECTORY}")
 

--- a/libfreerdp/utils/test/TestChunkStream.c
+++ b/libfreerdp/utils/test/TestChunkStream.c
@@ -1,0 +1,186 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ *
+ * Copyright 2020 Hardening <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <winpr/stream.h>
+#include <freerdp/utils/chunkstream.h>
+
+int TestChunkStream(int argc, char* argv[])
+{
+	wStream* s;
+	ChunkStream* cs;
+	ChunkStreamSlot *slot, *slot3;
+	int i;
+	int errcode = 1;
+
+	/* ============== first basic tests with static chunks ======= */
+	cs = chunkstream_new(0);
+	if (!cs)
+	{
+		fprintf(stderr, "unable to allocate a chunkstream");
+		return errcode;
+	}
+	errcode++;
+
+	slot = chunkstream_getStaticStringSlot(cs, "hello", FALSE);
+	if (!slot || chunkstreamslot_size(slot) != 5)
+	{
+		fprintf(stderr, "error with first slot");
+		return errcode;
+	}
+	errcode++;
+
+	slot = chunkstream_getStaticStringSlot(cs, "hello", TRUE);
+	if (!slot || chunkstreamslot_size(slot) != 6)
+	{
+		fprintf(stderr, "error with second slot");
+		return errcode;
+	}
+	errcode++;
+
+	slot = chunkstream_getPoolSlot(cs, 10);
+	if (slot)
+	{
+		fprintf(stderr, "should not get a slot from an empty pool");
+		return errcode;
+	}
+	errcode++;
+
+	s = chunkstream_linearizeToStream(cs);
+	if (!s || Stream_GetPosition(s) != 11 || memcmp("hellohello\x00", Stream_Buffer(s), 11))
+	{
+		fprintf(stderr, "error with linearized stream");
+		return errcode;
+	}
+	Stream_Free(s, TRUE);
+	errcode++;
+
+	s = Stream_New(NULL, 3);
+	if (!s)
+	{
+		fprintf(stderr, "error allocating stream");
+		return errcode;
+	}
+
+	if (!chunkstream_linearizeInStream(cs, s) || Stream_GetPosition(s) != 11 ||
+	    memcmp("hellohello\x00", Stream_Buffer(s), 11))
+	{
+		fprintf(stderr, "error with linearized stream");
+		return errcode;
+	}
+	Stream_Free(s, TRUE);
+	errcode++;
+
+	chunkstream_destroy(&cs);
+	if (cs)
+	{
+		fprintf(stderr, "expecting chunkstream to be cleaned");
+		return errcode;
+	}
+	errcode++;
+
+	/* ==================== let's test the pool =========== */
+
+	cs = chunkstream_new(1024);
+	if (!cs)
+	{
+		fprintf(stderr, "unable to allocate a chunkstream");
+		return errcode;
+	}
+	errcode++;
+
+	// get 8 blocks of 128 bytes, that should exhaust the pool
+	for (i = 0; i < 8; i++)
+	{
+		size_t nbytes, j;
+		BYTE* slotData;
+		slot = chunkstream_getPoolSlot(cs, 128);
+		if (!slot)
+		{
+			fprintf(stderr, "failed retrieving a 128 bytes pool slot");
+			return errcode;
+		}
+		if (i == 3)
+			slot3 = slot;
+
+		slotData = chunkstreamslot_data(slot);
+		nbytes = 1 + (i / 4);
+		for (j = 0; j < nbytes; j++, slotData++)
+			*slotData = (BYTE)i;
+
+		if (!chunkstreamslot_update_used(slot, nbytes))
+		{
+			fprintf(stderr, "failed updating used size");
+			return errcode;
+		}
+	}
+	errcode++;
+
+	// we should fail to update used size of last slot with more than 128
+	if (chunkstreamslot_update_used(slot, 129))
+	{
+		fprintf(stderr, "last slot should not grow over 128");
+		return errcode;
+	}
+	errcode++;
+
+	slot = chunkstream_getPoolSlot(cs, 128);
+	if (slot)
+	{
+		fprintf(stderr, "pool should be exhausted");
+		return errcode;
+	}
+	errcode++;
+
+	// check computation of sizeAfterSlot (after slot 3 so 2 * 4)
+	if (chunkstream_sizeAfterSlot(cs, slot3) != 8)
+	{
+		fprintf(stderr, "invalid computation for chunkstream_sizeAfterSlot");
+		return errcode;
+	}
+	errcode++;
+
+	// let's check the content of the stream
+	s = Stream_New(NULL, 3);
+	if (!s)
+	{
+		fprintf(stderr, "error allocating stream");
+		return errcode;
+	}
+
+	if (!chunkstream_linearizeInStream(cs, s) ||
+	    memcmp("\x00\x01\x02\x03\x04\x04\x05\x05\x06\x06\x07\x07", Stream_Buffer(s), 12))
+	{
+		fprintf(stderr, "error with linearized stream");
+		return errcode;
+	}
+	Stream_Free(s, TRUE);
+	errcode++;
+
+	chunkstream_destroy(&cs);
+	if (cs)
+	{
+		fprintf(stderr, "expecting chunkstream to be cleaned");
+		return errcode;
+	}
+	errcode++;
+
+	return 0;
+}


### PR DESCRIPTION
The idea of a ChunkStream is to accumulate chunks of data, and to do the assembly at the last moment when emitting the packet. Doing so we avoid multiple copies of memory blocks (especially with packets that have variable length headers).

May be a good start to implement solution 1 of #6592.