### PR TITLE
Check for backtrace symbol and link to execinfo if needed

### DIFF
--- a/winpr/libwinpr/utils/CMakeLists.txt
+++ b/winpr/libwinpr/utils/CMakeLists.txt
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(CheckFunctionExists)
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(${MODULE_PREFIX}_COLLECTIONS_SRCS
@@ -137,10 +139,16 @@ endif()
 
 if(UNIX)
 	winpr_library_add_private(m)
-endif()
 
-if((FREEBSD) AND (NOT KFREEBSD))
-	winpr_library_add_private(execinfo)
+	set(CMAKE_REQUIRED_INCLUDES backtrace.h)
+	check_function_exists(backtrace BACKTRACE)
+	if (NOT BACKTRACE)
+		set(CMAKE_REQUIRED_LIBRARIES execinfo)
+		check_function_exists(backtrace EXECINFO)
+		if (EXECINFO)
+			winpr_library_add_private(execinfo)
+		endif()
+	endif()
 endif()
 
 if(WIN32)


### PR DESCRIPTION
I assume that backtrace symbol is needed for libwinpr (as my build failed to link without it), so cmake now errors when it cannot find `backtrace` function.

[libexecinfo](https://pkgs.alpinelinux.org/package/edge/main/x86/libexecinfo) is a library that provides backtrace header and symbol on systems that don't have it (like musl based ones). This PR should be safe to add for glibc users.