### PR TITLE
Update README.android in regards to CMake, NDK and ABIs

### DIFF
--- a/docs/README.android
+++ b/docs/README.android
@@ -13,8 +13,8 @@ Build requirements
 For the Android port some additional dependencies need to be fulfilled:
 
 * for JNI
-- CMake >= 3.0
-- Android NDK (>= r9)
+- CMake >= 3.0 (install CMake from Android SDK. It is part of the SDK Tools)
+- Android NDK (>= r15c)
 
 * for the Java GUI
 - Android SDK
@@ -34,13 +34,10 @@ This will fetch sources from git and build OpenSSL, OpenH264, libJPEG.
 The native FreeRDP libraries will also be build.
 
 Currently the default script builds for:
-* armeabi
 * armeabi-v7a
 * x86
-* mips
 * arm64-v8a
 * x86_64
-* mips64
 
 When the script is finished the libraries are ready for android studio to
 be picked up in client/Android/Studio/freeRDPCore/src/main/jniLibs


### PR DESCRIPTION
- CMake should be used from Android SDK. Personally I had issues using CMake from my OS (Ubuntu)
- minimum version of Android NDK must be 15c, as build target API level 26 is not supported on earlier releases
- removed ABIs that are unsupported in recent NDK and also not build by default

@akallabeth thank you for pointing out that I was using the wrong CMake version.
