### PR TITLE
add VAAPI options and pass them to ffmpeg

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2371,6 +2371,16 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 					return rc;
 			}
 		}
+		CommandLineSwitchCase(arg, "vaapi-connection-type")
+		{
+			if (!copy_value(arg->Value, &settings->VAAPIConnectionType))
+				return COMMAND_LINE_ERROR_MEMORY;
+		}
+		CommandLineSwitchCase(arg, "vaapi-device")
+		{
+			if (!copy_value(arg->Value, &settings->VAAPIDevice))
+				return COMMAND_LINE_ERROR_MEMORY;
+		}
 		CommandLineSwitchCase(arg, "shell")
 		{
 			if (!copy_value(arg->Value, &settings->AlternateShell))

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -364,6 +364,11 @@ static const COMMAND_LINE_ARGUMENT_A args[] = {
 #endif
 	{ "v", COMMAND_LINE_VALUE_REQUIRED, "<server>[:port]", NULL, NULL, -1, NULL,
 	  "Server hostname" },
+#ifdef WITH_VAAPI
+	{ "vaapi-connection-type", COMMAND_LINE_VALUE_OPTIONAL, "drm|x11|...", NULL, NULL, -1, NULL,
+	  "Connection type of the VAAPI device" },
+	{ "vaapi-device", COMMAND_LINE_VALUE_OPTIONAL, NULL, NULL, NULL, -1, NULL, "VAAPI device" },
+#endif
 	{ "vc", COMMAND_LINE_VALUE_REQUIRED, "<channel>[,<options>]", NULL, NULL, -1, NULL,
 	  "Static virtual channel" },
 	{ "version", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT_VERSION, NULL, NULL, NULL, -1, NULL,

--- a/include/freerdp/codec/h264.h
+++ b/include/freerdp/codec/h264.h
@@ -78,6 +78,8 @@ struct _H264_CONTEXT
 
 	void* lumaData;
 	wLog* log;
+
+	const rdpSettings* settings;
 };
 #ifdef __cplusplus
 extern "C"
@@ -108,6 +110,8 @@ extern "C"
 	FREERDP_API BOOL h264_context_reset(H264_CONTEXT* h264, UINT32 width, UINT32 height);
 
 	FREERDP_API H264_CONTEXT* h264_context_new(BOOL Compressor);
+	FREERDP_API H264_CONTEXT* h264_context_new_settings(BOOL Compressor,
+	                                                    const rdpSettings* settings);
 	FREERDP_API void h264_context_free(H264_CONTEXT* h264);
 
 #ifdef __cplusplus

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -1151,22 +1151,22 @@ struct rdp_settings
 	UINT64 padding1408[1408 - 1346]; /* 1346 */
 
 	/* Server Certificate */
-	ALIGN64 BOOL IgnoreCertificate;               /* 1408 */
-	ALIGN64 char* CertificateName;                /* 1409 */
-	ALIGN64 char* CertificateFile;                /* 1410 */
-	ALIGN64 char* PrivateKeyFile;                 /* 1411 */
-	ALIGN64 char* RdpKeyFile;                     /* 1412 */
-	ALIGN64 rdpRsaKey* RdpServerRsaKey;           /* 1413 */
-	ALIGN64 rdpCertificate* RdpServerCertificate; /* 1414 */
-	ALIGN64 BOOL ExternalCertificateManagement;   /* 1415 */
-	ALIGN64 char* CertificateContent;             /* 1416 */
-	ALIGN64 char* PrivateKeyContent;              /* 1417 */
-	ALIGN64 char* RdpKeyContent;                  /* 1418 */
-	ALIGN64 BOOL AutoAcceptCertificate;           /* 1419 */
-	ALIGN64 BOOL AutoDenyCertificate;             /* 1420 */
+	ALIGN64 BOOL IgnoreCertificate;                /* 1408 */
+	ALIGN64 char* CertificateName;                 /* 1409 */
+	ALIGN64 char* CertificateFile;                 /* 1410 */
+	ALIGN64 char* PrivateKeyFile;                  /* 1411 */
+	ALIGN64 char* RdpKeyFile;                      /* 1412 */
+	ALIGN64 rdpRsaKey* RdpServerRsaKey;            /* 1413 */
+	ALIGN64 rdpCertificate* RdpServerCertificate;  /* 1414 */
+	ALIGN64 BOOL ExternalCertificateManagement;    /* 1415 */
+	ALIGN64 char* CertificateContent;              /* 1416 */
+	ALIGN64 char* PrivateKeyContent;               /* 1417 */
+	ALIGN64 char* RdpKeyContent;                   /* 1418 */
+	ALIGN64 BOOL AutoAcceptCertificate;            /* 1419 */
+	ALIGN64 BOOL AutoDenyCertificate;              /* 1420 */
 	ALIGN64 char* CertificateAcceptedFingerprints; /* 1421 */
 	UINT64 padding1472[1472 - 1422];               /* 1422 */
-	UINT64 padding1536[1536 - 1472];              /* 1472 */
+	UINT64 padding1536[1536 - 1472];               /* 1472 */
 
 	/**
 	 * User Interface
@@ -1562,6 +1562,9 @@ struct rdp_settings
 	ALIGN64 char* ActionScript;
 	ALIGN64 DWORD Floatbar;
 	ALIGN64 char* XSelectionAtom;
+
+	ALIGN64 char* VAAPIConnectionType;
+	ALIGN64 char* VAAPIDevice;
 };
 typedef struct rdp_settings rdpSettings;
 

--- a/libfreerdp/codec/h264.c
+++ b/libfreerdp/codec/h264.c
@@ -568,6 +568,11 @@ BOOL h264_context_reset(H264_CONTEXT* h264, UINT32 width, UINT32 height)
 
 H264_CONTEXT* h264_context_new(BOOL Compressor)
 {
+	return h264_context_new_settings(Compressor, NULL);
+}
+
+H264_CONTEXT* h264_context_new_settings(BOOL Compressor, const rdpSettings* settings)
+{
 	H264_CONTEXT* h264;
 	h264 = (H264_CONTEXT*)calloc(1, sizeof(H264_CONTEXT));
 
@@ -581,6 +586,8 @@ H264_CONTEXT* h264_context_new(BOOL Compressor)
 			h264->BitRate = 1000000;
 			h264->FrameRate = 30;
 		}
+
+		h264->settings = settings;
 
 		if (!h264_context_init(h264))
 		{

--- a/libfreerdp/codec/h264_ffmpeg.c
+++ b/libfreerdp/codec/h264_ffmpeg.c
@@ -535,8 +535,30 @@ static BOOL libavcodec_init(H264_CONTEXT* h264)
 
 		if (!sys->hwctx)
 		{
-			int ret =
-			    av_hwdevice_ctx_create(&sys->hwctx, AV_HWDEVICE_TYPE_VAAPI, VAAPI_DEVICE, NULL, 0);
+			AVDictionary* av_opts = NULL;
+			char* vaapi_device = VAAPI_DEVICE;
+
+			if (h264->settings)
+			{
+				if (h264->settings->VAAPIDevice)
+				{
+					vaapi_device = h264->settings->VAAPIDevice;
+				}
+				if (h264->settings->VAAPIConnectionType &&
+				    av_dict_set(&av_opts, "connection_type", h264->settings->VAAPIConnectionType,
+				                0) < 0)
+				{
+					WLog_Print(h264->log, WLOG_WARN, "Could not specify VAAPI connection type");
+				}
+			}
+
+			int ret = av_hwdevice_ctx_create(&sys->hwctx, AV_HWDEVICE_TYPE_VAAPI, vaapi_device,
+			                                 av_opts, 0);
+
+			if (av_opts)
+			{
+				av_dict_free(&av_opts);
+			}
 
 			if (ret < 0)
 			{

--- a/libfreerdp/core/codecs.c
+++ b/libfreerdp/core/codecs.c
@@ -104,7 +104,7 @@ BOOL freerdp_client_codecs_prepare(rdpCodecs* codecs, UINT32 flags, UINT32 width
 	{
 		h264_context_free(codecs->h264);
 
-		if (!(codecs->h264 = h264_context_new(FALSE)))
+		if (!(codecs->h264 = h264_context_new_settings(FALSE, codecs->context->settings)))
 		{
 			WLog_ERR(TAG, "Failed to create h264 codec context");
 #ifndef WITH_OPENH264_LOADING

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -973,6 +973,12 @@ static BOOL freerdp_settings_int_buffer_copy(rdpSettings* _settings, const rdpSe
 		_settings->ActionScript = _strdup(settings->ActionScript);
 	if (settings->XSelectionAtom)
 		_settings->XSelectionAtom = _strdup(settings->XSelectionAtom);
+
+	if (settings->VAAPIConnectionType)
+		_settings->VAAPIConnectionType = _strdup(settings->VAAPIConnectionType);
+	if (settings->VAAPIDevice)
+		_settings->VAAPIDevice = _strdup(settings->VAAPIDevice);
+
 	rc = TRUE;
 out_fail:
 	return rc;


### PR DESCRIPTION
**TLDR:** Simple way of getting hardware acceleration working (again) with NVIDIA graphics cards.

FreeRDP uses FFmpeg for VAAPI hardware acceleration. If not specified, the FFmpeg API internally prefers the DRM connection type over the X11 one. Unfortunately, the VAAPI driver for NVIDIA users (libva-vdpau-driver), which seems to be unmaintained since 2012, only supports the X11 connection type.

Two new options are added:

/vaapi-connection-type
/vaapi-device

both of which are passed to ffmpeg, where parameter validation is handled
