### PR TITLE
Fix parsing of current keyboard locale

### DIFF
--- a/libfreerdp/locale/keyboard_x11.c
+++ b/libfreerdp/locale/keyboard_x11.c
@@ -80,6 +80,11 @@ int freerdp_detect_keyboard_layout_from_xkb(DWORD* keyboardLayoutId)
 
 			layout = beg;
 
+			/* if multiple languages are present we just take the first one */
+			pch = strchr(layout, ',');
+			if (pch)
+				*pch = '\0';
+
 			/* "variant" */
 			beg = strchr(end + 1, '"');
 			beg += 1;
@@ -123,6 +128,11 @@ int freerdp_detect_keyboard_layout_from_xkb(DWORD* keyboardLayoutId)
 			*end = '\0';
 
 			layout = beg;
+
+			/* if multiple languages are present we just take the first one */
+			pch = strchr(layout, ',');
+			if (pch)
+				*pch = '\0';
 
 			/* "variant" */
 			beg = strchr(end + 1, '"');

--- a/libfreerdp/locale/xkb_layout_ids.c
+++ b/libfreerdp/locale/xkb_layout_ids.c
@@ -776,6 +776,7 @@ static const XKB_LAYOUT xkbLayouts[] = {
 	{ "gh", 0, gh_variants },                                /* Ghana */
 	{ "gn", 0, NULL },                                       /* Guinea */
 	{ "ge", KBD_GEORGIAN, ge_variants },                     /* Georgia */
+	{ "at", KBD_GERMAN, de_variants },                       /* Austria */
 	{ "de", KBD_GERMAN, de_variants },                       /* Germany */
 	{ "gr", KBD_GREEK, gr_variants },                        /* Greece */
 	{ "hu", KBD_HUNGARIAN, hu_variants },                    /* Hungary */


### PR DESCRIPTION
The layout specifier might contain a comma separated list of keyboard layouts i.e. `"at,us"`. The current parsing code fails and `find_keyboard_layout_in_xorg_rules` returns 0. The PR fixes this issue by taking the first country code found and returning the correct layout id.
The PR also adds a missing keyboard layout for Austrian keyboards.