### PR TITLE
gateway: Fix resolving of error codes

### DIFF
--- a/libfreerdp/core/gateway/rpc_fault.c
+++ b/libfreerdp/core/gateway/rpc_fault.c
@@ -389,7 +389,8 @@ const char* rpc_error_to_string(UINT32 code)
 
 	for (index = 0; RPC_TSG_FAULT_CODES[index].name != NULL; index++)
 	{
-		if (RPC_TSG_FAULT_CODES[index].code == code)
+		if (RPC_TSG_FAULT_CODES[index].code == code ||
+		    RPC_TSG_FAULT_CODES[index].code == HRESULT_CODE(code))
 		{
 			sprintf_s(buffer, ARRAYSIZE(buffer), "%s [0x%08" PRIX32 "]",
 			          RPC_TSG_FAULT_CODES[index].name, code);
@@ -414,7 +415,8 @@ const char* rpc_error_to_category(UINT32 code)
 
 	for (index = 0; RPC_TSG_FAULT_CODES[index].category != NULL; index++)
 	{
-		if (RPC_TSG_FAULT_CODES[index].code == code)
+		if (RPC_TSG_FAULT_CODES[index].code == code ||
+		    RPC_TSG_FAULT_CODES[index].code == HRESULT_CODE(code))
 			return RPC_TSG_FAULT_CODES[index].category;
 	}
 


### PR DESCRIPTION
Some of the TSG error codes are "cut down" using the HRESULT_CODE macro.
While the macro was correctly used in the definition of RPC_TSG_FAULT_CODES it was not used in the comparison of the error
codes.
Note: Not all codes are using HRESULT_CODE so we need to check for both the real code value and the code value using the macro to get all the errors.

By the way - the formatting in this file (see `RPC_FAULT_CODES` and `RPC_TSG_FAULT_CODES`) looks very messed up