### PR TITLE
Fix #6730: Wait before retry in rdg_read_all

### DIFF
--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -313,6 +313,7 @@ static BOOL rdg_read_all(rdpTls* tls, BYTE* buffer, int size)
 			if (!BIO_should_retry(tls->bio))
 				return FALSE;
 
+			Sleep(10);
 			continue;
 		}
 


### PR DESCRIPTION
BIO_read might return a short read in quick succession when waiting
for network data. Add a retry delay to avoid excessive CPU use.