### PR TITLE
Fixed missing check for fastpath input messages

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -1589,3 +1589,10 @@ const char* rdp_server_connection_state_string(int state)
 			return "UNKNOWN";
 	}
 }
+
+int rdp_client_get_state(rdpRdp* rdp)
+{
+	if (!rdp)
+		return -1;
+	return rdp->state;
+}

--- a/libfreerdp/core/connection.h
+++ b/libfreerdp/core/connection.h
@@ -67,6 +67,7 @@ FREERDP_LOCAL int rdp_client_connect_license(rdpRdp* rdp, wStream* s);
 FREERDP_LOCAL int rdp_client_connect_demand_active(rdpRdp* rdp, wStream* s);
 FREERDP_LOCAL int rdp_client_transition_to_state(rdpRdp* rdp, int state);
 FREERDP_LOCAL const char* rdp_client_connection_state_string(int state);
+FREERDP_LOCAL int rdp_client_get_state(rdpRdp* rdp);
 
 FREERDP_LOCAL BOOL rdp_server_accept_nego(rdpRdp* rdp, wStream* s);
 FREERDP_LOCAL BOOL rdp_server_accept_mcs_connect_initial(rdpRdp* rdp, wStream* s);

--- a/libfreerdp/core/fastpath.h
+++ b/libfreerdp/core/fastpath.h
@@ -160,7 +160,7 @@ FREERDP_LOCAL wStream* fastpath_input_pdu_init_header(rdpFastPath* fastpath);
 FREERDP_LOCAL wStream* fastpath_input_pdu_init(rdpFastPath* fastpath, BYTE eventFlags,
                                                BYTE eventCode);
 FREERDP_LOCAL BOOL fastpath_send_multiple_input_pdu(rdpFastPath* fastpath, wStream* s,
-                                                    int iEventCount);
+                                                    size_t iEventCount);
 FREERDP_LOCAL BOOL fastpath_send_input_pdu(rdpFastPath* fastpath, wStream* s);
 
 FREERDP_LOCAL wStream* fastpath_update_pdu_init(rdpFastPath* fastpath);


### PR DESCRIPTION
Input events are only allowed after a connection was established
(connection state is active)
This check aborts input sending when done before that.