### PR TITLE
transport: Don't ask for credentials if empty password is specified

### DIFF
--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -260,22 +260,14 @@ fail:
 	return FALSE;
 }
 
-static BOOL is_empty(const char* str)
-{
-	if (!str)
-		return TRUE;
-	if (strlen(str) == 0)
-		return TRUE;
-	return FALSE;
-}
-
 static BOOL transport_prompt_for_password(rdpTransport* transport)
 {
 	rdpSettings* settings = transport->settings;
 	freerdp* instance = transport->context->instance;
 
-	if (is_empty(settings->Username) ||
-	    (is_empty(settings->Password) && is_empty((const char*)settings->RedirectionPassword)))
+	/* Ask for auth data if no or an empty username was specified or no password was given */
+	if ((settings->Username == NULL || strlen(settings->Username) == 0) ||
+	    (settings->Password == NULL && settings->RedirectionPassword == NULL))
 	{
 		/* If no callback is specified still continue connection */
 		if (!instance->Authenticate)
@@ -297,6 +289,10 @@ BOOL transport_connect_rdp(rdpTransport* transport)
 {
 	if (!transport)
 		return FALSE;
+
+	if (!transport_prompt_for_password(transport))
+		return FALSE;
+
 	/* RDP encryption */
 	return TRUE;
 }


### PR DESCRIPTION
As @bmiklautz pointed out with the last merge of PR #6744 the authentication callback is also called when an empty password string was already specified (i.e. using `/p:""`). This PR fixes this issue by just asking for auth data if no or an empty username is set or if a password has not been set (is `NULL`).

The PR also adds an authentication callback when using RDP security. The Microsoft clients behave a bit different there. While on Windows an auth dialog is only shown if you select "Always ask for credentials" the Mac client seems to always show a dialog.