### PR TITLE
Fix PCSC_SCardGetAttrib wrapper

### DIFF
--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -1866,7 +1866,7 @@ static LONG smartcard_GetAttrib_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPER
 	BOOL autoAllocate = FALSE;
 	LONG status;
 	DWORD cbAttrLen = 0;
-	LPBYTE pbAttr = NULL;
+	LPBYTE* ppbAttr = NULL;
 	GetAttrib_Return ret = { 0 };
 	IRP* irp = operation->irp;
 	const GetAttrib_Call* call = operation->call;
@@ -1874,7 +1874,7 @@ static LONG smartcard_GetAttrib_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPER
 	if (!call->fpbAttrIsNULL)
 	{
 		autoAllocate = (call->cbAttrLen == SCARD_AUTOALLOCATE) ? TRUE : FALSE;
-		pbAttr = autoAllocate ? (LPBYTE) & (ret.pbAttr) : ret.pbAttr;
+		*ppbAttr = autoAllocate ? (LPBYTE) & (ret.pbAttr) : ret.pbAttr;
 		cbAttrLen = call->cbAttrLen;
 	}
 
@@ -1886,7 +1886,8 @@ static LONG smartcard_GetAttrib_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPER
 			return SCARD_E_NO_MEMORY;
 	}
 
-	ret.ReturnCode = SCardGetAttrib(operation->hCard, call->dwAttrId, pbAttr, &cbAttrLen);
+	ret.ReturnCode = SCardGetAttrib(operation->hCard, call->dwAttrId, *ppbAttr, &cbAttrLen);
+
 	log_status_error(TAG, "SCardGetAttrib", ret.ReturnCode);
 	ret.cbAttrLen = cbAttrLen;
 

--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -1866,7 +1866,7 @@ static LONG smartcard_GetAttrib_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPER
 	BOOL autoAllocate = FALSE;
 	LONG status;
 	DWORD cbAttrLen = 0;
-	LPBYTE* ppbAttr = NULL;
+	LPBYTE pbAttr = NULL;
 	GetAttrib_Return ret = { 0 };
 	IRP* irp = operation->irp;
 	const GetAttrib_Call* call = operation->call;
@@ -1874,7 +1874,7 @@ static LONG smartcard_GetAttrib_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPER
 	if (!call->fpbAttrIsNULL)
 	{
 		autoAllocate = (call->cbAttrLen == SCARD_AUTOALLOCATE) ? TRUE : FALSE;
-		*ppbAttr = autoAllocate ? (LPBYTE) & (ret.pbAttr) : ret.pbAttr;
+		pbAttr = autoAllocate ? (LPBYTE) & (ret.pbAttr) : ret.pbAttr;
 		cbAttrLen = call->cbAttrLen;
 	}
 
@@ -1886,8 +1886,7 @@ static LONG smartcard_GetAttrib_Call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OPER
 			return SCARD_E_NO_MEMORY;
 	}
 
-	ret.ReturnCode = SCardGetAttrib(operation->hCard, call->dwAttrId, *ppbAttr, &cbAttrLen);
-
+	ret.ReturnCode = SCardGetAttrib(operation->hCard, call->dwAttrId, pbAttr, &cbAttrLen);
 	log_status_error(TAG, "SCardGetAttrib", ret.ReturnCode);
 	ret.cbAttrLen = cbAttrLen;
 

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -3686,7 +3686,7 @@ static BOOL update_recv_secondary_order(rdpUpdate* update, wStream* s, BYTE flag
 	start = Stream_GetPosition(s);
 	name = secondary_order_string(orderType);
 	WLog_Print(update->log, WLOG_DEBUG, "Secondary Drawing Order %s", name);
-	rc = IFCALLRESULT(FALSE, secondary->CacheOrderInfo, context, orderLength, extraFlags, orderType,
+	rc = IFCALLRESULT(TRUE, secondary->CacheOrderInfo, context, orderLength, extraFlags, orderType,
 	                  name);
 	if (!rc)
 		return FALSE;

--- a/winpr/libwinpr/smartcard/smartcard_pcsc.c
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.c
@@ -2237,11 +2237,15 @@ static LONG WINAPI PCSC_SCardGetAttrib_Internal(SCARDHANDLE hCard, DWORD dwAttrI
 	if (!hContext)
 		return SCARD_E_INVALID_HANDLE;
 
-	if (!pbAttr || !pcbAttrLen)
+	if (!pcbAttrLen)
 		return SCARD_E_INVALID_PARAMETER;
 
 	if (*pcbAttrLen == SCARD_AUTOALLOCATE)
+	{
+		if (!pbAttr)
+			return SCARD_E_INVALID_PARAMETER;
 		pcbAttrLenAlloc = TRUE;
+	}
 
 	pcsc_cbAttrLen = pcbAttrLenAlloc ? PCSC_SCARD_AUTOALLOCATE : (PCSC_DWORD)*pcbAttrLen;
 
@@ -2252,17 +2256,18 @@ static LONG WINAPI PCSC_SCardGetAttrib_Internal(SCARDHANDLE hCard, DWORD dwAttrI
 
 		if (status == SCARD_S_SUCCESS)
 		{
-			*conv.ppb = (BYTE*)calloc(1, pcsc_cbAttrLen);
+			BYTE* tmp = (BYTE*)calloc(1, pcsc_cbAttrLen);
 
-			if (!*conv.ppb)
+			if (!tmp)
 				return SCARD_E_NO_MEMORY;
 
-			status = g_PCSC.pfnSCardGetAttrib(hCard, pcsc_dwAttrId, *conv.ppb, &pcsc_cbAttrLen);
+			status = g_PCSC.pfnSCardGetAttrib(hCard, pcsc_dwAttrId, tmp, &pcsc_cbAttrLen);
 
 			if (status != SCARD_S_SUCCESS)
-				free(*conv.ppb);
+				free(tmp);
 			else
-				PCSC_AddMemoryBlock(hContext, *conv.ppb);
+				PCSC_AddMemoryBlock(hContext, tmp);
+			*conv.ppb = tmp;
 		}
 	}
 	else
@@ -2298,6 +2303,8 @@ static LONG WINAPI PCSC_SCardGetAttrib_FriendlyName(SCARDHANDLE hCard, DWORD dwA
 	if (!hContext)
 		return SCARD_E_INVALID_HANDLE;
 
+	if (!pcbAttrLen)
+		return SCARD_E_INVALID_PARAMETER;
 	cbAttrLen = *pcbAttrLen;
 	*pcbAttrLen = SCARD_AUTOALLOCATE;
 	status = PCSC_SCardGetAttrib_Internal(hCard, SCARD_ATTR_DEVICE_FRIENDLY_NAME_A,
@@ -2407,12 +2414,18 @@ static LONG WINAPI PCSC_SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE
 		BYTE** ppb;
 	} conv;
 
+	if (NULL == pcbAttrLen)
+		return SCARD_E_INVALID_PARAMETER;
+
 	conv.pb = pbAttr;
 
 	cbAttrLen = *pcbAttrLen;
 
 	if (*pcbAttrLen == SCARD_AUTOALLOCATE)
 	{
+		if (NULL == pbAttr)
+			return SCARD_E_INVALID_PARAMETER;
+
 		pcbAttrLenAlloc = TRUE;
 		*conv.ppb = NULL;
 	}
@@ -2852,7 +2865,9 @@ static LONG WINAPI PCSC_SCardGetDeviceTypeIdA(SCARDCONTEXT hContext, LPCSTR szRe
 	WINPR_UNUSED(hContext);
 	WINPR_UNUSED(szReaderName);
 	WINPR_UNUSED(pdwDeviceTypeId);
-	return SCARD_E_UNSUPPORTED_FEATURE;
+	if (pdwDeviceTypeId)
+		*pdwDeviceTypeId = SCARD_READER_TYPE_USB;
+	return SCARD_S_SUCCESS;
 }
 
 static LONG WINAPI PCSC_SCardGetDeviceTypeIdW(SCARDCONTEXT hContext, LPCWSTR szReaderName,
@@ -2861,8 +2876,8 @@ static LONG WINAPI PCSC_SCardGetDeviceTypeIdW(SCARDCONTEXT hContext, LPCWSTR szR
 	WINPR_UNUSED(hContext);
 	WINPR_UNUSED(szReaderName);
 	if (pdwDeviceTypeId)
-		*pdwDeviceTypeId = 0;
-	return SCARD_E_UNSUPPORTED_FEATURE;
+		*pdwDeviceTypeId = SCARD_READER_TYPE_USB;
+	return SCARD_S_SUCCESS;
 }
 
 static LONG WINAPI PCSC_SCardGetReaderDeviceInstanceIdA(SCARDCONTEXT hContext, LPCSTR szReaderName,

--- a/winpr/libwinpr/smartcard/smartcard_pcsc.c
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.c
@@ -2457,22 +2457,25 @@ static LONG WINAPI PCSC_SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE
 	{
 		if (dwAttrId == SCARD_ATTR_VENDOR_NAME)
 		{
-			const char* vendorName;
+			if (pbAttr)
+			{
+				const char* vendorName;
 
-			/**
-			 * pcsc-lite adds a null terminator to the vendor name,
-			 * while WinSCard doesn't. Strip the null terminator.
-			 */
+				/**
+				 * pcsc-lite adds a null terminator to the vendor name,
+				 * while WinSCard doesn't. Strip the null terminator.
+				 */
 
-			if (pcbAttrLenAlloc)
-				vendorName = (char*)*conv.ppb;
-			else
-				vendorName = (char*)pbAttr;
+				if (pcbAttrLenAlloc)
+					vendorName = (char*)*conv.ppb;
+				else
+					vendorName = (char*)pbAttr;
 
-			if (vendorName)
-				*pcbAttrLen = strlen(vendorName);
-			else
-				*pcbAttrLen = 0;
+				if (vendorName)
+					*pcbAttrLen = strnlen(vendorName, *pcbAttrLen);
+				else
+					*pcbAttrLen = 0;
+			}
 		}
 	}
 	else


### PR DESCRIPTION
1. The PCSC wrapper for `SCardGetAttrib` had some issues with error checks and returned data.
To test expand the following test code and compile:
1. Additionally report all attached smartcards as of type `SCARD_READER_TYPE_USB` until a better solution is found.

<details>
  <summary>Server side Test Code</summary>
```
#include <winscard.h>
#include <iostream>

#pragma comment(lib, "winscard.lib")
int main(int argc, char *argv[])
{
    SCARDCONTEXT context;
    auto rc = SCardEstablishContext(0, 0, 0, &context);
    if (rc != SCARD_S_SUCCESS)
        return -1;
    try {
        DWORD readerCount = SCARD_AUTOALLOCATE;
        LPSTR mszReaders = NULL;
        rc = SCardListReadersA(context, SCARD_ALL_READERS, (LPSTR)&mszReaders, &readerCount);
        if (rc != SCARD_S_SUCCESS)
            throw rc;
        try {
        auto cur = mszReaders;
        for (DWORD x=0; x<readerCount; x++)
        {
            DWORD dwActiveProtocol;
            SCARDHANDLE card;
            std::string reader(cur);
            cur += strlen(cur) + 1;
            std::cout <<  "[" << x << " ]: " << reader << std::endl;

            DWORD deviceType;
            rc = SCardGetDeviceTypeIdA(context, reader.c_str(), &deviceType);
            if (rc != SCARD_S_SUCCESS)
                throw rc;

            rc = SCardConnectA(context, reader.c_str(), SCARD_SHARE_SHARED, 0, &card, &dwActiveProtocol);
            if (rc != SCARD_S_SUCCESS)
                throw rc;

            DWORD length = 0;
            rc = SCardGetAttrib(card, SCARD_ATTR_ATR_STRING, nullptr, &length);
            if (rc != SCARD_S_SUCCESS)
                throw rc;
            std::cout << " got [" << length << "]" << std::endl;
            LPSTR msg = NULL;
            length = SCARD_AUTOALLOCATE;
            rc = SCardGetAttrib(card, SCARD_ATTR_ATR_STRING, (LPBYTE) &msg, &length);
            if (rc != SCARD_S_SUCCESS)
                throw rc;
            std::cout << " got " << msg << "  [" << length << "]" << std::endl;
            SCardFreeMemory(context, msg);
            rc = SCardDisconnect(card, SCARD_LEAVE_CARD);
            if (rc != SCARD_S_SUCCESS)
                throw rc;
        }
        }  catch(LONG rc) {

        }
        SCardFreeMemory(context, mszReaders);
    } catch(LONG rc) {

    }
    SCardReleaseContext(context);

    return 0;
}

```

</details>

