### PR TITLE
Fix key repeat in Wayland

### DIFF
--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -168,6 +168,7 @@ static void keyboard_repeat_func(UwacTask* task, uint32_t events)
 
 		key->window = window;
 		key->sym = input->repeat_sym;
+		key->raw_key = input->repeat_key;
 		key->pressed = true;
 	}
 }


### PR DESCRIPTION
## Description

Without this commit, key repeat doesn't work.
When I press space key and hold it, there is only one space character in editor.

After applying this patch, it will repeat the characters as the expected.

## Test Environment

* Arch Linux
* KDE Plasma 5.20.5

## Related Issues

* Scrolling and keyholding behaviour (#6388)