### PR TITLE
Multiply axis value by 8 in Wayland

### DIFF
--- a/client/Wayland/wlf_input.c
+++ b/client/Wayland/wlf_input.c
@@ -176,7 +176,7 @@ BOOL wlf_handle_pointer_axis(freerdp* instance, const UwacPointerAxisEvent* ev)
 	 * positive: 0 ... 0xFF  -> slow ... fast
 	 * negative: 0 ... 0xFF  -> fast ... slow
 	 */
-	step = abs(direction);
+	step = 8 * abs(direction);
 	if (step > 0xFF)
 		step = 0xFF;
 


### PR DESCRIPTION
## Description

When using wlfreerdp, the number of scrolling rows is less than either
xfreerdp or other window.

In KDE Wayland session, I get a default axis value, which is 15.

And according to the comment in issue #6087, we have a default step
value in X11, which is 120.

To make wlfreerdp and xfreerdp behave identically, we should multiply
axis value by 8.

## Test Environment

* Arch Linux
* KDE Plasma 5.20.5

## Related Issues

* Inconsistent mouse wheel scroll behavior on Wayland (#6087)
* Scrolling and keyholding behaviour (#6388)