### PR TITLE
Fix window operations in Wayland

### DIFF
--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -412,6 +412,11 @@ static BOOL handle_uwac_events(freerdp* instance, UwacDisplay* display)
 
 				break;
 
+			case UWAC_EVENT_CLOSE:
+				context->closed = TRUE;
+
+				break;
+
 			default:
 				break;
 		}
@@ -479,6 +484,12 @@ static int wlfreerdp_run(freerdp* instance)
 		if (!handle_uwac_events(instance, context->display))
 		{
 			WLog_Print(context->log, WLOG_ERROR, "error handling UWAC events");
+			break;
+		}
+
+		if (context->closed)
+		{
+			WLog_Print(context->log, WLOG_INFO, "Closed from Wayland");
 			break;
 		}
 

--- a/client/Wayland/wlfreerdp.h
+++ b/client/Wayland/wlfreerdp.h
@@ -42,6 +42,7 @@ struct wlf_context
 	UwacSeat* seat;
 
 	BOOL fullscreen;
+	BOOL closed;
 
 	/* Channels */
 	RdpeiClientContext* rdpei;

--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -176,8 +176,6 @@ static void xdg_handle_surface_configure(void* data, struct xdg_surface* xdg_sur
                                          uint32_t serial)
 {
 	xdg_surface_ack_configure(xdg_surface, serial);
-	UwacWindow* window = (UwacWindow*)data;
-	wl_surface_commit(window->surface);
 }
 
 static const struct xdg_surface_listener xdg_surface_listener = {


### PR DESCRIPTION
## Description

* Process CLOSE event, which was ignored before.
* Don't commit surface in configure handler.
  This makes fullscreen, resizing and moving working on my system.

  Compared with Weston example program `simple-egl`, there is no `wl_surface_commit()` in [configure](https://github.com/wayland-project/weston/blob/master/clients/simple-egl.c#L298) handler.
  They only commit surface at needed, and wlfreerdp will commit surface in [`wl_update_buffer()`](https://github.com/FreeRDP/FreeRDP/blob/d7566f5f5af8778cf1ed647be3897e3a43213375/client/Wayland/wlfreerdp.c#L122) and [UWAC_EVENT_FRAME_DONE](https://github.com/FreeRDP/FreeRDP/blob/d7566f5f5af8778cf1ed647be3897e3a43213375/client/Wayland/wlfreerdp.c#L334) event.

## Test Environment

* Operating System
  * Arch Linux
* Compositor
  * KDE Plasma 5.20.90
  * Weston 9.0.0

## Related Issues

* Fix #6523 (Wayland fullscreen broken with Plasma 5.20)
