### PR TITLE
libfreerdp: core: add mem checks in gcc_write_client_data_blocks

### DIFF
--- a/libfreerdp/core/gcc.h
+++ b/libfreerdp/core/gcc.h
@@ -34,7 +34,7 @@ FREERDP_LOCAL BOOL gcc_read_conference_create_request(wStream* s, rdpMcs* mcs);
 FREERDP_LOCAL void gcc_write_conference_create_request(wStream* s, wStream* userData);
 FREERDP_LOCAL BOOL gcc_read_conference_create_response(wStream* s, rdpMcs* mcs);
 FREERDP_LOCAL void gcc_write_conference_create_response(wStream* s, wStream* userData);
-FREERDP_LOCAL void gcc_write_client_data_blocks(wStream* s, rdpMcs* mcs);
+FREERDP_LOCAL BOOL gcc_write_client_data_blocks(wStream* s, rdpMcs* mcs);
 FREERDP_LOCAL BOOL gcc_write_server_data_blocks(wStream* s, rdpMcs* mcs);
 
 #endif /* FREERDP_LIB_CORE_GCC_H */

--- a/libfreerdp/core/mcs.c
+++ b/libfreerdp/core/mcs.c
@@ -701,7 +701,9 @@ BOOL mcs_send_connect_initial(rdpMcs* mcs)
 		return FALSE;
 	}
 
-	gcc_write_client_data_blocks(client_data, mcs);
+	if (!gcc_write_client_data_blocks(client_data, mcs))
+		goto out;
+
 	gcc_CCrq = Stream_New(NULL, 1024);
 
 	if (!gcc_CCrq)


### PR DESCRIPTION
Fixes a heap overflow that may occur when connecting with 3+ screens (which makes the packet larger than the memory allocated for it). There were some missing memory checks.

There might still be more missing checks there, as that part of code usually uses void functions without checks/error handling to perform these write operations. So if someone has time to dig in and see if there are some more missing checks, it's better.