### PR TITLE
progressive: fix multiple regions in one gfx frame.

### DIFF
--- a/include/freerdp/codec/progressive.h
+++ b/include/freerdp/codec/progressive.h
@@ -46,7 +46,8 @@ extern "C"
 	FREERDP_API INT32 progressive_decompress(PROGRESSIVE_CONTEXT* progressive, const BYTE* pSrcData,
 	                                         UINT32 SrcSize, BYTE* pDstData, UINT32 DstFormat,
 	                                         UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
-	                                         REGION16* invalidRegion, UINT16 surfaceId);
+	                                         REGION16* invalidRegion, UINT16 surfaceId,
+	                                         UINT32 frameId);
 
 	FREERDP_API INT32 progressive_create_surface_context(PROGRESSIVE_CONTEXT* progressive,
 	                                                     UINT16 surfaceId, UINT32 width,

--- a/include/freerdp/gdi/gdi.h
+++ b/include/freerdp/gdi/gdi.h
@@ -520,6 +520,7 @@ struct rdp_gdi
 	BOOL graphicsReset; /* deprecated, remove with FreeRDP v3 */
 	BOOL suppressOutput;
 	UINT16 outputSurfaceId;
+	UINT32 frameId;
 	RdpgfxClientContext* gfx;
 	VideoClientContext* video;
 	GeometryClientContext* geometry;

--- a/libfreerdp/codec/progressive.h
+++ b/libfreerdp/codec/progressive.h
@@ -200,6 +200,9 @@ struct _PROGRESSIVE_SURFACE_CONTEXT
 	UINT32 gridHeight;
 	UINT32 gridSize;
 	RFX_PROGRESSIVE_TILE* tiles;
+	UINT32 frameId;
+	UINT32 numUpdatedTiles;
+	UINT32* updatedTileIndices;
 };
 typedef struct _PROGRESSIVE_SURFACE_CONTEXT PROGRESSIVE_SURFACE_CONTEXT;
 

--- a/libfreerdp/codec/test/TestFreeRDPCodecProgressive.c
+++ b/libfreerdp/codec/test/TestFreeRDPCodecProgressive.c
@@ -839,8 +839,9 @@ static int test_progressive_decode(PROGRESSIVE_CONTEXT* progressive, EGFX_SAMPLE
 
 	for (pass = 0; pass < count; pass++)
 	{
-		status = progressive_decompress(progressive, files[pass].buffer, files[pass].size,
-		                                g_DstData, PIXEL_FORMAT_XRGB32, g_DstStep, 0, 0, NULL, 0);
+		status =
+		    progressive_decompress(progressive, files[pass].buffer, files[pass].size, g_DstData,
+		                           PIXEL_FORMAT_XRGB32, g_DstStep, 0, 0, NULL, 0, 0);
 		printf("ProgressiveDecompress: status: %d pass: %d\n", status, pass + 1);
 		region = &(progressive->region);
 
@@ -1077,7 +1078,7 @@ static BOOL test_encode_decode(const char* path)
 		goto fail;
 
 	rc = progressive_decompress(progressiveDec, dstData, dstSize, resultData, ColorFormat,
-	                            image->scanline, 0, 0, &invalidRegion, 0);
+	                            image->scanline, 0, 0, &invalidRegion, 0, 0);
 	if (rc < 0)
 		goto fail;
 

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -218,6 +218,7 @@ static UINT gdi_StartFrame(RdpgfxClientContext* context, const RDPGFX_START_FRAM
 {
 	rdpGdi* gdi = (rdpGdi*)context->custom;
 	gdi->inGfxFrame = TRUE;
+	gdi->frameId = startFrame->frameId;
 	return CHANNEL_RC_OK;
 }
 
@@ -823,7 +824,7 @@ static UINT gdi_SurfaceCommand_Progressive(rdpGdi* gdi, RdpgfxClientContext* con
 	region16_init(&invalidRegion);
 	rc = progressive_decompress(surface->codecs->progressive, cmd->data, cmd->length, surface->data,
 	                            surface->format, surface->scanline, cmd->left, cmd->top,
-	                            &invalidRegion, cmd->surfaceId);
+	                            &invalidRegion, cmd->surfaceId, gdi->frameId);
 
 	if (rc < 0)
 	{


### PR DESCRIPTION
[MS-RDPEGFX] 2.2.4.2.1.5 RFX_PROGRESSIVE_REGION

**Note that RFX_PROGRESSIVE_REGION entries that are part of the same frame can share the tiles defined in the tiles field of each entry. In this scenario, tiles are not repeated in successive RFX_PROGRESSIVE_REGION entries.** Across all of the RFX_PROGRESSIVE_REGION entries of a frame, the rectangles (defined in the rects field of each entry) MUST be distinct, and the region defined by these rectangles MUST be completely covered by all of the tiles defined in the RFX_PROGRESSIVE_REGION entries of the frames. **Note that in this context, the frame is bracketed between the RDPGFX_START_FRAME_PDU and the RDPGFX_END_FRAME_PDU, and can span multiple RFX_PROGRESSIVE_FRAME_BEGIN and RFX_PROGRESSIVE_FRAME_END blocks.**