### PR TITLE
core: Remove connection type manipulation in gcc_write_client_core_data

### DIFF
--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -121,7 +121,7 @@ typedef enum
 #define RNS_UD_CS_STRONG_ASYMMETRIC_KEYS 0x0008
 #define RNS_UD_CS_VALID_CONNECTION_TYPE 0x0020
 #define RNS_UD_CS_SUPPORT_MONITOR_LAYOUT_PDU 0x0040
-#define RNS_UD_CS_SUPPORT_NETWORK_AUTODETECT 0x0080
+#define RNS_UD_CS_SUPPORT_NETCHAR_AUTODETECT 0x0080
 #define RNS_UD_CS_SUPPORT_DYNVC_GFX_PROTOCOL 0x0100
 #define RNS_UD_CS_SUPPORT_DYNAMIC_TIME_ZONE 0x0200
 #define RNS_UD_CS_SUPPORT_HEARTBEAT_PDU 0x0400
@@ -190,14 +190,14 @@ typedef enum
 #define NEG_MEMBLT_INDEX 0x03
 #define NEG_MEM3BLT_INDEX 0x04
 #define NEG_ATEXTOUT_INDEX 0x05
-#define NEG_AEXTTEXTOUT_INDEX 0x06  /* Must be ignored */
+#define NEG_AEXTTEXTOUT_INDEX 0x06 /* Must be ignored */
 #define NEG_DRAWNINEGRID_INDEX 0x07 /* Must be ignored */
 #define NEG_LINETO_INDEX 0x08
 #define NEG_MULTI_DRAWNINEGRID_INDEX 0x09
 #define NEG_OPAQUE_RECT_INDEX 0x0A /* Must be ignored */
 #define NEG_SAVEBITMAP_INDEX 0x0B
-#define NEG_WTEXTOUT_INDEX 0x0C   /* Must be ignored */
-#define NEG_MEMBLT_V2_INDEX 0x0D  /* Must be ignored */
+#define NEG_WTEXTOUT_INDEX 0x0C  /* Must be ignored */
+#define NEG_MEMBLT_V2_INDEX 0x0D /* Must be ignored */
 #define NEG_MEM3BLT_V2_INDEX 0x0E /* Must be ignored */
 #define NEG_MULTIDSTBLT_INDEX 0x0F
 #define NEG_MULTIPATBLT_INDEX 0x10
@@ -1152,22 +1152,22 @@ struct rdp_settings
 	UINT64 padding1408[1408 - 1346]; /* 1346 */
 
 	/* Server Certificate */
-	ALIGN64 BOOL IgnoreCertificate;               /* 1408 */
-	ALIGN64 char* CertificateName;                /* 1409 */
-	ALIGN64 char* CertificateFile;                /* 1410 */
-	ALIGN64 char* PrivateKeyFile;                 /* 1411 */
-	ALIGN64 char* RdpKeyFile;                     /* 1412 */
-	ALIGN64 rdpRsaKey* RdpServerRsaKey;           /* 1413 */
-	ALIGN64 rdpCertificate* RdpServerCertificate; /* 1414 */
-	ALIGN64 BOOL ExternalCertificateManagement;   /* 1415 */
-	ALIGN64 char* CertificateContent;             /* 1416 */
-	ALIGN64 char* PrivateKeyContent;              /* 1417 */
-	ALIGN64 char* RdpKeyContent;                  /* 1418 */
-	ALIGN64 BOOL AutoAcceptCertificate;           /* 1419 */
-	ALIGN64 BOOL AutoDenyCertificate;             /* 1420 */
+	ALIGN64 BOOL IgnoreCertificate;                /* 1408 */
+	ALIGN64 char* CertificateName;                 /* 1409 */
+	ALIGN64 char* CertificateFile;                 /* 1410 */
+	ALIGN64 char* PrivateKeyFile;                  /* 1411 */
+	ALIGN64 char* RdpKeyFile;                      /* 1412 */
+	ALIGN64 rdpRsaKey* RdpServerRsaKey;            /* 1413 */
+	ALIGN64 rdpCertificate* RdpServerCertificate;  /* 1414 */
+	ALIGN64 BOOL ExternalCertificateManagement;    /* 1415 */
+	ALIGN64 char* CertificateContent;              /* 1416 */
+	ALIGN64 char* PrivateKeyContent;               /* 1417 */
+	ALIGN64 char* RdpKeyContent;                   /* 1418 */
+	ALIGN64 BOOL AutoAcceptCertificate;            /* 1419 */
+	ALIGN64 BOOL AutoDenyCertificate;              /* 1420 */
 	ALIGN64 char* CertificateAcceptedFingerprints; /* 1421 */
 	UINT64 padding1472[1472 - 1422];               /* 1422 */
-	UINT64 padding1536[1536 - 1472];              /* 1472 */
+	UINT64 padding1536[1536 - 1472];               /* 1472 */
 
 	/**
 	 * User Interface

--- a/libfreerdp/core/autodetect.c
+++ b/libfreerdp/core/autodetect.c
@@ -43,6 +43,10 @@
 
 #define RDP_NETCHAR_SYNC_RESPONSE_TYPE 0x0018
 
+#define RDP_NETCHAR_RESULTS_0x0840 0x0840U
+#define RDP_NETCHAR_RESULTS_0x0880 0x0880U
+#define RDP_NETCHAR_RESULTS_0x08C0 0x08C0U
+
 typedef struct
 {
 	UINT8 headerLength;
@@ -58,6 +62,45 @@ typedef struct
 	UINT16 sequenceNumber;
 	UINT16 responseType;
 } AUTODETECT_RSP_PDU;
+
+static const char* autodetect_request_type_to_string(UINT32 requestType)
+{
+	switch (requestType)
+	{
+		case RDP_RTT_RESPONSE_TYPE:
+			return "RDP_RTT_RESPONSE_TYPE";
+		case RDP_BW_RESULTS_RESPONSE_TYPE_CONNECTTIME:
+			return "RDP_BW_RESULTS_RESPONSE_TYPE_CONNECTTIME";
+		case RDP_BW_RESULTS_RESPONSE_TYPE_CONTINUOUS:
+			return "RDP_BW_RESULTS_RESPONSE_TYPE_CONTINUOUS";
+		case RDP_RTT_REQUEST_TYPE_CONTINUOUS:
+			return "RDP_RTT_REQUEST_TYPE_CONTINUOUS";
+		case RDP_RTT_REQUEST_TYPE_CONNECTTIME:
+			return "RDP_RTT_REQUEST_TYPE_CONNECTTIME";
+		case RDP_BW_START_REQUEST_TYPE_CONTINUOUS:
+			return "RDP_BW_START_REQUEST_TYPE_CONTINUOUS";
+		case RDP_BW_START_REQUEST_TYPE_TUNNEL:
+			return "RDP_BW_START_REQUEST_TYPE_TUNNEL";
+		case RDP_BW_START_REQUEST_TYPE_CONNECTTIME:
+			return "RDP_BW_START_REQUEST_TYPE_CONNECTTIME";
+		case RDP_BW_PAYLOAD_REQUEST_TYPE:
+			return "RDP_BW_PAYLOAD_REQUEST_TYPE";
+		case RDP_BW_STOP_REQUEST_TYPE_CONNECTTIME:
+			return "RDP_BW_STOP_REQUEST_TYPE_CONNECTTIME";
+		case RDP_BW_STOP_REQUEST_TYPE_CONTINUOUS:
+			return "RDP_BW_STOP_REQUEST_TYPE_CONTINUOUS";
+		case RDP_BW_STOP_REQUEST_TYPE_TUNNEL:
+			return "RDP_BW_STOP_REQUEST_TYPE_TUNNEL";
+		case RDP_NETCHAR_RESULTS_0x0840:
+			return "RDP_NETCHAR_RESULTS_0x0840";
+		case RDP_NETCHAR_RESULTS_0x0880:
+			return "RDP_NETCHAR_RESULTS_0x0880";
+		case RDP_NETCHAR_RESULTS_0x08C0:
+			return "RDP_NETCHAR_RESULTS_0x08C0";
+		default:
+			return "UNKNOWN";
+	}
+}
 
 static BOOL autodetect_send_rtt_measure_request(rdpContext* context, UINT16 sequenceNumber,
                                                 UINT16 requestType)
@@ -292,10 +335,10 @@ static BOOL autodetect_send_netchar_result(rdpContext* context, UINT16 sequenceN
 
 	if (context->rdp->autodetect->netCharBandwidth > 0)
 	{
-		Stream_Write_UINT8(s, 0x12);                       /* headerLength (1 byte) */
-		Stream_Write_UINT8(s, TYPE_ID_AUTODETECT_REQUEST); /* headerTypeId (1 byte) */
-		Stream_Write_UINT16(s, sequenceNumber);            /* sequenceNumber (2 bytes) */
-		Stream_Write_UINT16(s, 0x08C0);                    /* requestType (2 bytes) */
+		Stream_Write_UINT8(s, 0x12);                        /* headerLength (1 byte) */
+		Stream_Write_UINT8(s, TYPE_ID_AUTODETECT_REQUEST);  /* headerTypeId (1 byte) */
+		Stream_Write_UINT16(s, sequenceNumber);             /* sequenceNumber (2 bytes) */
+		Stream_Write_UINT16(s, RDP_NETCHAR_RESULTS_0x08C0); /* requestType (2 bytes) */
 		Stream_Write_UINT32(s, context->rdp->autodetect->netCharBaseRTT); /* baseRTT (4 bytes) */
 		Stream_Write_UINT32(s,
 		                    context->rdp->autodetect->netCharBandwidth); /* bandwidth (4 bytes) */
@@ -304,10 +347,10 @@ static BOOL autodetect_send_netchar_result(rdpContext* context, UINT16 sequenceN
 	}
 	else
 	{
-		Stream_Write_UINT8(s, 0x0E);                       /* headerLength (1 byte) */
-		Stream_Write_UINT8(s, TYPE_ID_AUTODETECT_REQUEST); /* headerTypeId (1 byte) */
-		Stream_Write_UINT16(s, sequenceNumber);            /* sequenceNumber (2 bytes) */
-		Stream_Write_UINT16(s, 0x0840);                    /* requestType (2 bytes) */
+		Stream_Write_UINT8(s, 0x0E);                        /* headerLength (1 byte) */
+		Stream_Write_UINT8(s, TYPE_ID_AUTODETECT_REQUEST);  /* headerTypeId (1 byte) */
+		Stream_Write_UINT16(s, sequenceNumber);             /* sequenceNumber (2 bytes) */
+		Stream_Write_UINT16(s, RDP_NETCHAR_RESULTS_0x0840); /* requestType (2 bytes) */
 		Stream_Write_UINT32(s, context->rdp->autodetect->netCharBaseRTT); /* baseRTT (4 bytes) */
 		Stream_Write_UINT32(s,
 		                    context->rdp->autodetect->netCharAverageRTT); /* averageRTT (4 bytes) */
@@ -488,7 +531,7 @@ static BOOL autodetect_recv_netchar_result(rdpRdp* rdp, wStream* s,
 
 	switch (autodetectReqPdu->requestType)
 	{
-		case 0x0840:
+		case RDP_NETCHAR_RESULTS_0x0840:
 
 			/* baseRTT and averageRTT fields are present (bandwidth field is not) */
 			if ((autodetectReqPdu->headerLength != 0x0E) || (Stream_GetRemainingLength(s) < 8))
@@ -498,7 +541,7 @@ static BOOL autodetect_recv_netchar_result(rdpRdp* rdp, wStream* s,
 			Stream_Read_UINT32(s, rdp->autodetect->netCharAverageRTT); /* averageRTT (4 bytes) */
 			break;
 
-		case 0x0880:
+		case RDP_NETCHAR_RESULTS_0x0880:
 
 			/* bandwidth and averageRTT fields are present (baseRTT field is not) */
 			if ((autodetectReqPdu->headerLength != 0x0E) || (Stream_GetRemainingLength(s) < 8))
@@ -508,7 +551,7 @@ static BOOL autodetect_recv_netchar_result(rdpRdp* rdp, wStream* s,
 			Stream_Read_UINT32(s, rdp->autodetect->netCharAverageRTT); /* averageRTT (4 bytes) */
 			break;
 
-		case 0x08C0:
+		case RDP_NETCHAR_RESULTS_0x08C0:
 
 			/* baseRTT, bandwidth, and averageRTT fields are present */
 			if ((autodetectReqPdu->headerLength != 0x12) || (Stream_GetRemainingLength(s) < 12))
@@ -548,8 +591,24 @@ int rdp_recv_autodetect_request_packet(rdpRdp* rdp, wStream* s)
 	         autodetectReqPdu.headerLength, autodetectReqPdu.headerTypeId,
 	         autodetectReqPdu.sequenceNumber, autodetectReqPdu.requestType);
 
-	if (autodetectReqPdu.headerTypeId != TYPE_ID_AUTODETECT_REQUEST)
+	if (!rdp->settings->NetworkAutoDetect)
+	{
+		WLog_ERR(AUTODETECT_TAG,
+		         "Received a [MS-RDPBCGR] 2.2.14.1.1 RTT Measure Request (RDP_RTT_REQUEST) [%s] "
+		         "message but support was not enabled",
+		         autodetect_request_type_to_string(autodetectReqPdu.requestType));
 		return -1;
+	}
+
+	if (autodetectReqPdu.headerTypeId != TYPE_ID_AUTODETECT_REQUEST)
+	{
+		WLog_ERR(AUTODETECT_TAG,
+		         "Received a [MS-RDPBCGR] 2.2.14.1.1 RTT Measure Request (RDP_RTT_REQUEST) [%s] "
+		         "message with invalid headerTypeId=0x%04" PRIx16,
+		         autodetect_request_type_to_string(autodetectReqPdu.requestType),
+		         autodetectReqPdu.headerTypeId);
+		return -1;
+	}
 
 	switch (autodetectReqPdu.requestType)
 	{
@@ -578,9 +637,9 @@ int rdp_recv_autodetect_request_packet(rdpRdp* rdp, wStream* s)
 			success = autodetect_recv_bandwidth_measure_stop(rdp, s, &autodetectReqPdu);
 			break;
 
-		case 0x0840:
-		case 0x0880:
-		case 0x08C0:
+		case RDP_NETCHAR_RESULTS_0x0840:
+		case RDP_NETCHAR_RESULTS_0x0880:
+		case RDP_NETCHAR_RESULTS_0x08C0:
 			/* Network Characteristics Result (RDP_NETCHAR_RESULT) - MS-RDPBCGR 2.2.14.1.5 */
 			success = autodetect_recv_netchar_result(rdp, s, &autodetectReqPdu);
 			break;
@@ -610,8 +669,24 @@ int rdp_recv_autodetect_response_packet(rdpRdp* rdp, wStream* s)
 	         autodetectRspPdu.headerLength, autodetectRspPdu.headerTypeId,
 	         autodetectRspPdu.sequenceNumber, autodetectRspPdu.responseType);
 
-	if (autodetectRspPdu.headerTypeId != TYPE_ID_AUTODETECT_RESPONSE)
+	if (!rdp->settings->NetworkAutoDetect)
+	{
+		WLog_ERR(AUTODETECT_TAG,
+		         "Received a [MS-RDPBCGR] 2.2.14.2.1 RTT Measure Response (RDP_RTT_RESPONSE) [%s] "
+		         "message but support was not enabled",
+		         autodetect_request_type_to_string(autodetectRspPdu.responseType));
 		return -1;
+	}
+
+	if (autodetectRspPdu.headerTypeId != TYPE_ID_AUTODETECT_RESPONSE)
+	{
+		WLog_ERR(AUTODETECT_TAG,
+		         "Received a [MS-RDPBCGR] 2.2.14.2.1 RTT Measure Response (RDP_RTT_RESPONSE) [%s] "
+		         "message with invalid headerTypeId=0x%04" PRIx16,
+		         autodetect_request_type_to_string(autodetectRspPdu.responseType),
+		         autodetectRspPdu.headerTypeId);
+		return -1;
+	}
 
 	switch (autodetectRspPdu.responseType)
 	{

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -879,7 +879,7 @@ BOOL gcc_read_client_core_data(wStream* s, rdpMcs* mcs, UINT16 blockLength)
 
 	if (settings->NetworkAutoDetect)
 		settings->NetworkAutoDetect =
-		    (earlyCapabilityFlags & RNS_UD_CS_SUPPORT_NETWORK_AUTODETECT) ? TRUE : FALSE;
+		    (earlyCapabilityFlags & RNS_UD_CS_SUPPORT_NETCHAR_AUTODETECT) ? TRUE : FALSE;
 
 	if (settings->SupportHeartbeatPdu)
 		settings->SupportHeartbeatPdu =
@@ -962,12 +962,6 @@ void gcc_write_client_core_data(wStream* s, rdpMcs* mcs)
 	supportedColorDepths = RNS_UD_24BPP_SUPPORT | RNS_UD_16BPP_SUPPORT | RNS_UD_15BPP_SUPPORT;
 	earlyCapabilityFlags = RNS_UD_CS_SUPPORT_ERRINFO_PDU;
 
-	if (settings->NetworkAutoDetect)
-		settings->ConnectionType = CONNECTION_TYPE_AUTODETECT;
-
-	if (settings->RemoteFxCodec && !settings->NetworkAutoDetect)
-		settings->ConnectionType = CONNECTION_TYPE_LAN;
-
 	connectionType = settings->ConnectionType;
 
 	if (connectionType)
@@ -980,7 +974,7 @@ void gcc_write_client_core_data(wStream* s, rdpMcs* mcs)
 	}
 
 	if (settings->NetworkAutoDetect)
-		earlyCapabilityFlags |= RNS_UD_CS_SUPPORT_NETWORK_AUTODETECT;
+		earlyCapabilityFlags |= RNS_UD_CS_SUPPORT_NETCHAR_AUTODETECT;
 
 	if (settings->SupportHeartbeatPdu)
 		earlyCapabilityFlags |= RNS_UD_CS_SUPPORT_HEARTBEAT_PDU;


### PR DESCRIPTION
Removes the changes to connection type in gcc_write_client_core_data and adds some checks if network detection is enabled when receiving network detection requests.

Supersedes #6767