### PR TITLE
Synchronize NumLock, CapsLock state in Wayland

### DIFF
--- a/client/Wayland/wlf_input.c
+++ b/client/Wayland/wlf_input.c
@@ -208,13 +208,34 @@ BOOL wlf_handle_key(freerdp* instance, const UwacKeyEvent* ev)
 
 BOOL wlf_keyboard_enter(freerdp* instance, const UwacKeyboardEnterLeaveEvent* ev)
 {
+	if (!instance || !ev || !instance->input)
+		return FALSE;
+
+	((wlfContext*)instance->context)->focusing = TRUE;
+	return TRUE;
+}
+
+BOOL wlf_keyboard_modifiers(freerdp* instance, const UwacKeyboardModifiersEvent* ev)
+{
 	rdpInput* input;
+	uint32_t syncFlags;
 
 	if (!instance || !ev || !instance->input)
 		return FALSE;
 
 	input = instance->input;
-	return freerdp_input_send_focus_in_event(input, 0) &&
+	syncFlags = 0;
+
+	if (ev->modifiers & UWAC_MOD_CAPS_MASK)
+		syncFlags |= KBD_SYNC_CAPS_LOCK;
+	if (ev->modifiers & UWAC_MOD_NUM_MASK)
+		syncFlags |= KBD_SYNC_NUM_LOCK;
+
+	if (!((wlfContext*)instance->context)->focusing)
+		return TRUE;
+
+	((wlfContext*)instance->context)->focusing = FALSE;
+	return freerdp_input_send_focus_in_event(input, syncFlags) &&
 	       freerdp_input_send_mouse_event(input, PTR_FLAGS_MOVE, 0, 0);
 }
 

--- a/client/Wayland/wlf_input.h
+++ b/client/Wayland/wlf_input.h
@@ -36,5 +36,6 @@ BOOL wlf_handle_touch_motion(freerdp* instance, const UwacTouchMotion* ev);
 
 BOOL wlf_handle_key(freerdp* instance, const UwacKeyEvent* ev);
 BOOL wlf_keyboard_enter(freerdp* instance, const UwacKeyboardEnterLeaveEvent* ev);
+BOOL wlf_keyboard_modifiers(freerdp* instance, const UwacKeyboardModifiersEvent* ev);
 
 #endif /* FREERDP_CLIENT_WAYLAND_INPUT_H */

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -394,6 +394,12 @@ static BOOL handle_uwac_events(freerdp* instance, UwacDisplay* display)
 
 				break;
 
+			case UWAC_EVENT_KEYBOARD_MODIFIERS:
+				if (!wlf_keyboard_modifiers(instance, &event.keyboard_modifiers))
+					return FALSE;
+
+				break;
+
 			case UWAC_EVENT_CONFIGURE:
 				if (!wlf_disp_handle_configure(context->disp, event.configure.width,
 				                               event.configure.height))

--- a/client/Wayland/wlfreerdp.h
+++ b/client/Wayland/wlfreerdp.h
@@ -43,6 +43,7 @@ struct wlf_context
 
 	BOOL fullscreen;
 	BOOL closed;
+	BOOL focusing;
 
 	/* Channels */
 	RdpeiClientContext* rdpei;

--- a/uwac/include/uwac/uwac.h
+++ b/uwac/include/uwac/uwac.h
@@ -62,6 +62,8 @@ enum
 	UWAC_MOD_SHIFT_MASK = 0x01,
 	UWAC_MOD_ALT_MASK = 0x02,
 	UWAC_MOD_CONTROL_MASK = 0x04,
+	UWAC_MOD_CAPS_MASK = 0x08,
+	UWAC_MOD_NUM_MASK = 0x10,
 };
 
 /** @brief a position */
@@ -91,6 +93,7 @@ enum
 	UWAC_EVENT_POINTER_BUTTONS,
 	UWAC_EVENT_POINTER_AXIS,
 	UWAC_EVENT_KEYBOARD_ENTER,
+	UWAC_EVENT_KEYBOARD_MODIFIERS,
 	UWAC_EVENT_KEY,
 	UWAC_EVENT_TOUCH_FRAME_BEGIN,
 	UWAC_EVENT_TOUCH_UP,
@@ -143,6 +146,13 @@ struct uwac_keyboard_enter_event
 	UwacSeat* seat;
 };
 typedef struct uwac_keyboard_enter_event UwacKeyboardEnterLeaveEvent;
+
+struct uwac_keyboard_modifiers_event
+{
+	int type;
+	uint32_t modifiers;
+};
+typedef struct uwac_keyboard_modifiers_event UwacKeyboardModifiersEvent;
 
 struct uwac_pointer_enter_event
 {
@@ -276,6 +286,7 @@ union uwac_event {
 	UwacPointerButtonEvent mouse_button;
 	UwacPointerAxisEvent mouse_axis;
 	UwacKeyboardEnterLeaveEvent keyboard_enter_leave;
+	UwacKeyboardModifiersEvent keyboard_modifiers;
 	UwacClipboardEvent clipboard;
 	UwacKeyEvent key;
 	UwacTouchFrameBegin touchFrameBegin;

--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -427,7 +427,7 @@ static void keyboard_handle_modifiers(void* data, struct wl_keyboard* keyboard, 
                                       uint32_t mods_locked, uint32_t group)
 {
 	UwacSeat* input = data;
-	UwacKeyboardModifiersEvent *event;
+	UwacKeyboardModifiersEvent* event;
 	xkb_mod_mask_t mask;
 
 	/* If we're not using a keymap, then we don't handle PC-style modifiers */
@@ -435,8 +435,9 @@ static void keyboard_handle_modifiers(void* data, struct wl_keyboard* keyboard, 
 		return;
 
 	xkb_state_update_mask(input->xkb.state, mods_depressed, mods_latched, mods_locked, 0, 0, group);
-	mask = xkb_state_serialize_mods(input->xkb.state,
-	                                XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_LATCHED | XKB_STATE_MODS_LOCKED);
+	mask = xkb_state_serialize_mods(input->xkb.state, XKB_STATE_MODS_DEPRESSED |
+	                                                      XKB_STATE_MODS_LATCHED |
+	                                                      XKB_STATE_MODS_LOCKED);
 	input->modifiers = 0;
 	if (mask & input->xkb.control_mask)
 		input->modifiers |= UWAC_MOD_CONTROL_MASK;

--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -231,6 +231,8 @@ static void keyboard_handle_keymap(void* data, struct wl_keyboard* keyboard, uin
 	input->xkb.control_mask = 1 << xkb_keymap_mod_get_index(input->xkb.keymap, "Control");
 	input->xkb.alt_mask = 1 << xkb_keymap_mod_get_index(input->xkb.keymap, "Mod1");
 	input->xkb.shift_mask = 1 << xkb_keymap_mod_get_index(input->xkb.keymap, "Shift");
+	input->xkb.caps_mask = 1 << xkb_keymap_mod_get_index(input->xkb.keymap, "Lock");
+	input->xkb.num_mask = 1 << xkb_keymap_mod_get_index(input->xkb.keymap, "Mod2");
 }
 
 static void keyboard_handle_key(void* data, struct wl_keyboard* keyboard, uint32_t serial,
@@ -425,6 +427,7 @@ static void keyboard_handle_modifiers(void* data, struct wl_keyboard* keyboard, 
                                       uint32_t mods_locked, uint32_t group)
 {
 	UwacSeat* input = data;
+	UwacKeyboardModifiersEvent *event;
 	xkb_mod_mask_t mask;
 
 	/* If we're not using a keymap, then we don't handle PC-style modifiers */
@@ -433,7 +436,7 @@ static void keyboard_handle_modifiers(void* data, struct wl_keyboard* keyboard, 
 
 	xkb_state_update_mask(input->xkb.state, mods_depressed, mods_latched, mods_locked, 0, 0, group);
 	mask = xkb_state_serialize_mods(input->xkb.state,
-	                                XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_LATCHED);
+	                                XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_LATCHED | XKB_STATE_MODS_LOCKED);
 	input->modifiers = 0;
 	if (mask & input->xkb.control_mask)
 		input->modifiers |= UWAC_MOD_CONTROL_MASK;
@@ -441,6 +444,17 @@ static void keyboard_handle_modifiers(void* data, struct wl_keyboard* keyboard, 
 		input->modifiers |= UWAC_MOD_ALT_MASK;
 	if (mask & input->xkb.shift_mask)
 		input->modifiers |= UWAC_MOD_SHIFT_MASK;
+	if (mask & input->xkb.caps_mask)
+		input->modifiers |= UWAC_MOD_CAPS_MASK;
+	if (mask & input->xkb.num_mask)
+		input->modifiers |= UWAC_MOD_NUM_MASK;
+
+	event = (UwacKeyboardModifiersEvent*)UwacDisplayNewEvent(input->display,
+	                                                         UWAC_EVENT_KEYBOARD_MODIFIERS);
+	if (!event)
+		return;
+
+	event->modifiers = input->modifiers;
 }
 
 static void set_repeat_info(UwacSeat* input, int32_t rate, int32_t delay)

--- a/uwac/libuwac/uwac-priv.h
+++ b/uwac/libuwac/uwac-priv.h
@@ -180,6 +180,8 @@ struct uwac_seat
 		xkb_mod_mask_t control_mask;
 		xkb_mod_mask_t alt_mask;
 		xkb_mod_mask_t shift_mask;
+		xkb_mod_mask_t caps_mask;
+		xkb_mod_mask_t num_mask;
 	} xkb;
 	uint32_t modifiers;
 	int32_t repeat_rate_sec, repeat_rate_nsec;


### PR DESCRIPTION
According to [Wayland Procotol Spec](https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_keyboard-event-enter), `enter` event is followed by `modifiers` event.

Therefore, I make wlfreerdp send FocusIn event with toggle keys state to remote in the first `modifiers` event after `enter` event.
And the subsequent `modifiers` events will do nothing.