### PR TITLE
Use separate codec context for GDI/SurfaceBits and GFX channel

### DIFF
--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -253,7 +253,7 @@ static UINT xf_CreateSurface(RdpgfxClientContext* context,
 	if (!surface)
 		return CHANNEL_RC_NO_MEMORY;
 
-	surface->gdi.codecs = gdi->context->codecs;
+	surface->gdi.codecs = context->codecs;
 
 	if (!surface->gdi.codecs)
 	{

--- a/include/freerdp/client/rdpgfx.h
+++ b/include/freerdp/client/rdpgfx.h
@@ -22,6 +22,7 @@
 #ifndef FREERDP_CHANNEL_RDPGFX_CLIENT_RDPGFX_H
 #define FREERDP_CHANNEL_RDPGFX_CLIENT_RDPGFX_H
 
+#include <freerdp/freerdp.h>
 #include <freerdp/channels/rdpgfx.h>
 #include <freerdp/utils/profiler.h>
 
@@ -147,6 +148,7 @@ struct _rdpgfx_client_context
 	pcRdpgfxUnmapWindowForSurface UnmapWindowForSurface;
 
 	CRITICAL_SECTION mux;
+	rdpCodecs* codecs;
 	PROFILER_DEFINE(SurfaceProfiler)
 };
 


### PR DESCRIPTION
GFX and SurfaceBits commands share a common codec backend.
Recreating all codec context on GFX initialization will break
clients that are decoding SurfaceBits codec while having the GFX
channel initialized.

#6620 was the cause of this, probably a fix for the proxy is required.