### PR TITLE
X11 client: ignore grab related LeaveNotify events

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -618,6 +618,8 @@ static BOOL xf_event_EnterNotify(xfContext* xfc, const XEnterWindowEvent* event,
 
 static BOOL xf_event_LeaveNotify(xfContext* xfc, const XLeaveWindowEvent* event, BOOL app)
 {
+	if (event->mode == NotifyGrab || event->mode == NotifyUngrab)
+		return TRUE;
 	if (!app)
 	{
 		xfc->mouse_active = FALSE;


### PR DESCRIPTION
This fixes click and drag or more generally any press-hold-release combinations
for the primary mouse button.
Without this, click and drag, drag and drop and in, some remote applications
that presumably rely on the full press-release sequence, even button
presses don't always work.

The problem exists in 2.2.0 and master, at least in these environments:
* Gentoo Linux on amd64 with Plasma desktop (Wayland) running FreeRDP X11 client
* Alpine Linux on Raspberry Pi with Fluxbox

While both are not too common, they are also rather different, so the impact may well be broader.
Maybe it's also related to connecting to old RDP servers (Win 7 and Server 2008 R2).
Reproduction rate in the given constellation is not quite 100%, but close.

Anyway, this fixes it for me.
