### PR TITLE
Added ConnectionStateChangeEvent for clients

### DIFF
--- a/include/freerdp/event.h
+++ b/include/freerdp/event.h
@@ -71,6 +71,11 @@ extern "C"
 	BOOL firstActivation;
 	DEFINE_EVENT_END(Activated)
 
+	DEFINE_EVENT_BEGIN(ConnectionStateChange)
+	int state;
+	BOOL active;
+	DEFINE_EVENT_END(ConnectionStateChange)
+
 	DEFINE_EVENT_BEGIN(Terminate)
 	int code;
 	DEFINE_EVENT_END(Terminate)

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -1194,11 +1194,28 @@ int rdp_client_transition_to_state(rdpRdp* rdp, int state)
 
 		case CONNECTION_STATE_ACTIVE:
 			rdp->state = CONNECTION_STATE_ACTIVE;
+			{
+				ActivatedEventArgs activatedEvent;
+				rdpContext* context = rdp->context;
+				EventArgsInit(&activatedEvent, "libfreerdp");
+				activatedEvent.firstActivation = !rdp->deactivation_reactivation;
+				PubSub_OnActivated(context->pubSub, context, &activatedEvent);
+			}
+
 			break;
 
 		default:
 			status = -1;
 			break;
+	}
+
+	{
+		ConnectionStateChangeEventArgs stateEvent;
+		rdpContext* context = rdp->context;
+		EventArgsInit(&stateEvent, "libfreerdp");
+		stateEvent.state = rdp->state;
+		stateEvent.active = rdp->state == CONNECTION_STATE_ACTIVE;
+		PubSub_OnConnectionStateChange(context->pubSub, context, &stateEvent);
 	}
 
 	return status;

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1648,12 +1648,7 @@ int rdp_recv_callback(rdpTransport* transport, wStream* s, void* extra)
 
 			if ((status >= 0) && (rdp->finalize_sc_pdus == FINALIZE_SC_COMPLETE))
 			{
-				ActivatedEventArgs activatedEvent;
-				rdpContext* context = rdp->context;
 				rdp_client_transition_to_state(rdp, CONNECTION_STATE_ACTIVE);
-				EventArgsInit(&activatedEvent, "libfreerdp");
-				activatedEvent.firstActivation = !rdp->deactivation_reactivation;
-				PubSub_OnActivated(context->pubSub, context, &activatedEvent);
 				return 2;
 			}
 


### PR DESCRIPTION
Clients can now subscribe to connection state change events to
prevend data from being transmitted on sessions being redirected.
See #6742 