### PR TITLE
Fixed #6801: Delay sending of resolution change

### DIFF
--- a/client/X11/xf_disp.c
+++ b/client/X11/xf_disp.c
@@ -46,7 +46,6 @@ struct _xfDispContext
 	UINT64 lastSentDate;
 	int targetWidth, targetHeight;
 	BOOL activated;
-	BOOL waitingResize;
 	BOOL fullscreen;
 	UINT16 lastSentDesktopOrientation;
 	UINT32 lastSentDesktopScaleFactor;
@@ -125,7 +124,6 @@ static BOOL xf_disp_sendResize(xfDispContext* xfDisp)
 	}
 	else
 	{
-		xfDisp->waitingResize = TRUE;
 		layout.Flags = DISPLAY_CONTROL_MONITOR_PRIMARY;
 		layout.Top = layout.Left = 0;
 		layout.Width = xfDisp->targetWidth;
@@ -142,6 +140,16 @@ static BOOL xf_disp_sendResize(xfDispContext* xfDisp)
 	}
 
 	return xf_update_last_sent(xfDisp);
+}
+
+static BOOL xf_disp_queueResize(xfDispContext* xfDisp, UINT32 width, UINT32 height)
+{
+	if ((xfDisp->targetWidth == width) && (xfDisp->targetHeight == height))
+		return TRUE;
+	xfDisp->targetWidth = width;
+	xfDisp->targetHeight = height;
+	xfDisp->lastSentDate = GetTickCount64();
+	return xf_disp_sendResize(xfDisp);
 }
 
 static BOOL xf_disp_set_window_resizable(xfDispContext* xfDisp)
@@ -194,8 +202,6 @@ static void xf_disp_OnActivated(void* context, ActivatedEventArgs* e)
 	if (!xf_disp_check_context(context, &xfc, &xfDisp, &settings))
 		return;
 
-	xfDisp->waitingResize = FALSE;
-
 	if (xfDisp->activated && !xfc->fullscreen)
 	{
 		xf_disp_set_window_resizable(xfDisp);
@@ -217,8 +223,6 @@ static void xf_disp_OnGraphicsReset(void* context, GraphicsResetEventArgs* e)
 
 	if (!xf_disp_check_context(context, &xfc, &xfDisp, &settings))
 		return;
-
-	xfDisp->waitingResize = FALSE;
 
 	if (xfDisp->activated && !settings->Fullscreen)
 	{
@@ -392,9 +396,7 @@ BOOL xf_disp_handle_configureNotify(xfContext* xfc, int width, int height)
 	if (!xfDisp)
 		return FALSE;
 
-	xfDisp->targetWidth = width;
-	xfDisp->targetHeight = height;
-	return xf_disp_sendResize(xfDisp);
+	return xf_disp_queueResize(xfDisp, width, height);
 }
 
 static UINT xf_DisplayControlCaps(DispClientContext* disp, UINT32 maxNumMonitors,


### PR DESCRIPTION
Changed the logic of the disp channel to wait for 800ms after a
ConfigureNotify before sending the new resolution.
The problem fixed with this patch is the following:
1.  Resize the window with the mouse
2.  ConfigureNotify triggers a resize notification
3.  The server resizes to the desired resolution
3a. More ConfigureNotify events are generated
4.  The local window resize to the new resolution triggers another
    ConfigureNotify

a. Depending on the timing (sending is already rate limited) the
   events from 3a and 4 will make the size of the window jump
b. Very fast resizing will pick a random resolution from the
   sequence of ConfigureNotify events as the final resolution