### PR TITLE
clients: Use the correct wheel rotation value

### DIFF
--- a/client/Mac/MRDPView.h
+++ b/client/Mac/MRDPView.h
@@ -72,16 +72,6 @@
 
 @end
 
-/* Pointer Flags */
-#define PTR_FLAGS_WHEEL 0x0200
-#define PTR_FLAGS_WHEEL_NEGATIVE 0x0100
-#define PTR_FLAGS_MOVE 0x0800
-#define PTR_FLAGS_DOWN 0x8000
-#define PTR_FLAGS_BUTTON1 0x1000
-#define PTR_FLAGS_BUTTON2 0x2000
-#define PTR_FLAGS_BUTTON3 0x4000
-#define WheelRotationMask 0x01FF
-
 BOOL mac_pre_connect(freerdp *instance);
 BOOL mac_post_connect(freerdp *instance);
 void mac_post_disconnect(freerdp *instance);

--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -442,9 +442,10 @@ DWORD WINAPI mac_client_thread(void *param)
 	if (step > 0xFF)
 		step = 0xFF;
 
-	/* Negative rotation, so count down steps from top */
+	/* Negative rotation, so count down steps from top
+	 * 9bit twos complement */
 	if (flags & PTR_FLAGS_WHEEL_NEGATIVE)
-		step = 0xFF - step;
+		step = 0x100 - step;
 
 	mf_scale_mouse_event(context, instance->input, flags | step, 0, 0);
 }

--- a/client/Wayland/wlf_input.c
+++ b/client/Wayland/wlf_input.c
@@ -178,7 +178,10 @@ BOOL wlf_handle_pointer_axis(freerdp* instance, const UwacPointerAxisEvent* ev)
 	 */
 	for (i = 0; i < abs(direction); i++)
 	{
-		const uint32_t cflags = flags | 0x78;
+		uint32_t cflags = flags | 0x78;
+		/* Convert negative values to 9bit twos complement */
+		if (flags & PTR_FLAGS_WHEEL_NEGATIVE)
+			cflags = (flags & 0xFF00) | (0x100 - (cflags & 0xFF));
 		if (!freerdp_input_send_mouse_event(input, cflags, (UINT16)x, (UINT16)y))
 			return FALSE;
 	}

--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -207,7 +207,8 @@ static BOOL wf_event_process_WM_MOUSEWHEEL(wfContext* wfc, HWND hWnd, UINT Msg, 
 	if (delta < 0)
 	{
 		flags |= PTR_FLAGS_WHEEL_NEGATIVE;
-		delta = -delta;
+		/* 9bit twos complement, delta already negative */
+		delta = 0x100 + delta;
 	}
 
 	flags |= delta;

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1076,8 +1076,9 @@ static const button_map xf_button_flags[NUM_BUTTONS_MAPPED] = {
 	{ Button2, PTR_FLAGS_BUTTON3 },
 	{ Button3, PTR_FLAGS_BUTTON2 },
 	{ Button4, PTR_FLAGS_WHEEL | 0x78 },
-	{ Button5, PTR_FLAGS_WHEEL | PTR_FLAGS_WHEEL_NEGATIVE | 0x78 },
-	{ 6, PTR_FLAGS_HWHEEL | PTR_FLAGS_WHEEL_NEGATIVE | 0x78 },
+	/* Negative value is 9bit twos complement */
+	{ Button5, PTR_FLAGS_WHEEL | PTR_FLAGS_WHEEL_NEGATIVE | (0x100 - 0x78) },
+	{ 6, PTR_FLAGS_HWHEEL | PTR_FLAGS_WHEEL_NEGATIVE | (0x100 - 0x78) },
 	{ 7, PTR_FLAGS_HWHEEL | 0x78 },
 	{ 8, PTR_XFLAGS_BUTTON1 },
 	{ 9, PTR_XFLAGS_BUTTON2 },


### PR DESCRIPTION
For the negative scrolling direction, RDP uses the two's complement,
instead of the positive wheel value with the negative flag.
xfreerdp currently uses the positive wheel value in addition to the
negative flag, which results in a wrong wheel value on the server side
(136 instead of 120).

Fix this, by using the correct wheel rotation value, which is in the
two's complement.