### PR TITLE
Don't enable vmconnect mode based on PCB field presence

### DIFF
--- a/client/common/file.c
+++ b/client/common/file.c
@@ -1810,8 +1810,7 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 	{
 		if (!freerdp_settings_set_string(settings, FreeRDP_PreconnectionBlob,
 		                                 file->PreconnectionBlob) ||
-		    !freerdp_settings_set_bool(settings, FreeRDP_SendPreconnectionPdu, TRUE) ||
-		    !freerdp_settings_set_bool(settings, FreeRDP_VmConnectMode, TRUE))
+		    !freerdp_settings_set_bool(settings, FreeRDP_SendPreconnectionPdu, TRUE))
 			return FALSE;
 	}
 


### PR DESCRIPTION
The .RDP file parsing logic incorrectly assumes that the presence of the PCB field implies the usage of the special vmconnect mode, which breaks connectivity to anything that isn't the Hyper-V RDP server. The PCB field is indeed used for Hyper-V, but it isn't the only place where it can be used. mstsc doesn't change its behavior based on the PCB field presence anyway.

This pull request simply avoids turning on the vmconnect mode when PCB field is present inside a .RDP field. We found the issue while trying to figure out what prevented xfreerdp from connecting to our Remote Desktop Gateway called Devolutions Gateway (OSS, in Rust) that uses a JWT injected as the preconnection blob of the preconnection pdu, after which TCP-based relaying is performed. This strategy completely eliminates the need for the heavyweight RD Gateway protocol while modernizing it.

For the curious, here is the Devolutions Gateway: https://github.com/Devolutions/devolutions-gateway

This one-liner fix is enough to make xfreerdp properly consume our generated .rdp file that works with mstsc and connect through the Devolutions Gateway using the PCB.