### PR TITLE
Allow parallel listen to IPv4 and v6 addresses

### DIFF
--- a/libfreerdp/core/listener.c
+++ b/libfreerdp/core/listener.c
@@ -94,10 +94,11 @@ static BOOL freerdp_listener_open(freerdp_listener* instance, const char* bind_a
 
 		if (ai->ai_family == AF_INET)
 			sin_addr = &(((struct sockaddr_in*)ai->ai_addr)->sin_addr);
-		else {
+		else
+		{
 			sin_addr = &(((struct sockaddr_in6*)ai->ai_addr)->sin6_addr);
 			if (setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&option_value,
-					sizeof(option_value)) == -1)
+			               sizeof(option_value)) == -1)
 				WLog_ERR(TAG, "setsockopt");
 		}
 
@@ -106,7 +107,6 @@ static BOOL freerdp_listener_open(freerdp_listener* instance, const char* bind_a
 		if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (void*)&option_value,
 		               sizeof(option_value)) == -1)
 			WLog_ERR(TAG, "setsockopt");
-
 
 #ifndef _WIN32
 		fcntl(sockfd, F_SETFL, O_NONBLOCK);

--- a/libfreerdp/core/listener.c
+++ b/libfreerdp/core/listener.c
@@ -90,17 +90,23 @@ static BOOL freerdp_listener_open(freerdp_listener* instance, const char* bind_a
 			continue;
 		}
 
+		option_value = 1;
+
 		if (ai->ai_family == AF_INET)
 			sin_addr = &(((struct sockaddr_in*)ai->ai_addr)->sin_addr);
-		else
+		else {
 			sin_addr = &(((struct sockaddr_in6*)ai->ai_addr)->sin6_addr);
+			if (setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&option_value,
+					sizeof(option_value)) == -1)
+				WLog_ERR(TAG, "setsockopt");
+		}
 
 		inet_ntop(ai->ai_family, sin_addr, addr, sizeof(addr));
-		option_value = 1;
 
 		if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (void*)&option_value,
 		               sizeof(option_value)) == -1)
 			WLog_ERR(TAG, "setsockopt");
+
 
 #ifndef _WIN32
 		fcntl(sockfd, F_SETFL, O_NONBLOCK);


### PR DESCRIPTION
While testing freerdp based ogon RDP service I noticed, that the rdp server component does listen to IPv4 only.

Further analysis showed, that both IPv4 and IPv6 bind() calls were done, however the second one failed (resource busy).

Details s.
https://github.com/ogon-project/ogon-project/issues/16

Attached patch should fix that.
