### PR TITLE
[windows client] [cliprdr] Translate local to remote format IDs in cl->sv requests

### DIFF
--- a/client/Windows/wf_cliprdr.c
+++ b/client/Windows/wf_cliprdr.c
@@ -1300,12 +1300,15 @@ static UINT cliprdr_send_format_list(wfClipboard* clipboard)
 static UINT cliprdr_send_data_request(wfClipboard* clipboard, UINT32 formatId)
 {
 	UINT rc;
+	UINT32 remoteFormatId;
 	CLIPRDR_FORMAT_DATA_REQUEST formatDataRequest;
 
 	if (!clipboard || !clipboard->context || !clipboard->context->ClientFormatDataRequest)
 		return ERROR_INTERNAL_ERROR;
 
-	formatDataRequest.requestedFormatId = formatId;
+	remoteFormatId = get_remote_format_id(clipboard, formatId);
+
+	formatDataRequest.requestedFormatId = remoteFormatId;
 	clipboard->requestedFormatId = formatId;
 	rc = clipboard->context->ClientFormatDataRequest(clipboard->context, &formatDataRequest);
 


### PR DESCRIPTION
## Situation

Copying any rich text from the remote desktop and pasting it in the local desktop results in a sudden but graceful disconnection of the FreeRDP client on windows. 
(however, pasting unformatted text works fine, and pasting rich text from the local desktop into the remote desktop works fine too! Perplexing, right?)

## Background

Windows' clipboard API allows for the same data to be stored in multiple formats. It supports [several builtin clipboard formats](https://docs.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats), but also allows for [new clipboard formats to be registered](https://docs.microsoft.com/en-us/windows/win32/dataxchg/using-the-clipboard#registering-a-clipboard-format) by applications.

The FreeRDP windows client receives a list of names of clipboard formats and their respective remote clipboard format IDs whenever something is copied in the remote desktop. Subsequently, it registers those clipboard formats locally using [RegisterClipboardFormatW](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registerclipboardformatw). This function returns a local clipboard format ID.

## Assessment

The local clipboard format ID is not guaranteed to be equal to the remote clipboard format ID (unless it's a standard clipboard format, see above).

While FreeRDP sends a valid-looking request to the server for a remote->local paste, the format ID included in that request corresponds to the local format ID. When this is received by the server, the server is perplexed and lets the client know that it has requested a clipboard format that is unsupported by the server. The client sees this message from the server and gracefully shuts down without any logs to indicate why this occurred.

## Recommendations
This PR resolves the above by ensuring that we include a remote format ID (translating it in `cliprdr_send_data_request` via `get_remote_format_id`) when requesting clipboard data from the server.

