### PR TITLE
Fix /monitor-list flag being ignored on X11/Wayland

### DIFF
--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -651,9 +651,11 @@ int main(int argc, char* argv[])
 	status = freerdp_client_settings_parse_command_line(settings, argc, argv, FALSE);
 	if (status)
 	{
-		BOOL list = settings->ListMonitors;
+		BOOL list;
 
 		rc = freerdp_client_settings_command_line_status_print(settings, status, argc, argv);
+
+		list = settings->ListMonitors;
 
 		if (list)
 			wlf_list_monitors(wlc);

--- a/client/X11/cli/xfreerdp.c
+++ b/client/X11/cli/xfreerdp.c
@@ -59,9 +59,11 @@ int main(int argc, char* argv[])
 	status = freerdp_client_settings_parse_command_line(context->settings, argc, argv, FALSE);
 	if (status)
 	{
-		BOOL list = settings->ListMonitors;
+		BOOL list;
 
 		rc = freerdp_client_settings_command_line_status_print(settings, status, argc, argv);
+
+		list = settings->ListMonitors;
 
 		if (list)
 			xf_list_monitors(xfc);


### PR DESCRIPTION
This PR fixes a bug introduced by commit d7566f5f5af8778cf1ed647be3897e3a43213375 wherein the `/monitor-list` flag was being ignored due to the flag variable being grabbed _before_ the call to `freerdp_client_settings_command_line_status_print`, which is responsible for actually setting it when a status command has been issued (`freerdp_client_settings_parse_command_line` exits early in this scenario and does not see the flag).