### PR TITLE
Parse on a copy of the argument string for printer

### DIFF
--- a/channels/printer/client/printer_main.c
+++ b/channels/printer/client/printer_main.c
@@ -980,7 +980,7 @@ printer_DeviceServiceEntry
 
 	device = (RDPDR_PRINTER*)pEntryPoints->device;
 	name = device->Name;
-	driver_name = device->DriverName;
+	driver_name = _strdup(device->DriverName);
 
 	/* Secondary argument is one of the following:
 	 *
@@ -1017,7 +1017,8 @@ printer_DeviceServiceEntry
 	if (!driver)
 	{
 		WLog_ERR(TAG, "Could not get a printer driver!");
-		return CHANNEL_RC_INITIALIZATION_ERROR;
+		error = CHANNEL_RC_INITIALIZATION_ERROR;
+		goto fail;
 	}
 
 	if (name && name[0])
@@ -1065,7 +1066,9 @@ printer_DeviceServiceEntry
 	}
 
 fail:
-	driver->ReleaseRef(driver);
+	free(driver_name);
+	if (driver)
+		driver->ReleaseRef(driver);
 
 	return error;
 }


### PR DESCRIPTION
If done on original the wrong backend is loaded on autoreconnect