### PR TITLE
Check smartcard_convert_string_list for NULL string

### DIFF
--- a/channels/smartcard/client/smartcard_pack.c
+++ b/channels/smartcard/client/smartcard_pack.c
@@ -349,6 +349,9 @@ static char* smartcard_convert_string_list(const void* in, size_t bytes, BOOL un
 	if (bytes < 1)
 		return NULL;
 
+	if (in == NULL)
+		return NULL;
+
 	if (unicode)
 	{
 		length = (bytes / sizeof(WCHAR)) - 1;


### PR DESCRIPTION
In #6821 it has been reported that there are buggy smartcard
drivers that report a string size but fail to allocate the string
itself. This check avoids a crash with such input parameters