### PR TITLE
client: Do not override connection type

### DIFF
--- a/client/common/file.c
+++ b/client/common/file.c
@@ -944,8 +944,8 @@ BOOL freerdp_client_populate_rdp_file_from_settings(rdpFile* file, const rdpSett
 	file->DisableFullWindowDrag = settings->DisableFullWindowDrag;
 	file->DisableMenuAnims = settings->DisableMenuAnims;
 	file->DisableThemes = settings->DisableThemes;
-	file->BandwidthAutoDetect = (settings->ConnectionType >= 7) ? TRUE : FALSE;
-	file->NetworkAutoDetect = settings->NetworkAutoDetect ? 0 : 1;
+	file->BandwidthAutoDetect = settings->NetworkAutoDetect ? 1 : 0;
+	file->NetworkAutoDetect = settings->NetworkAutoDetect ? 1 : 0;
 	file->AutoReconnectionEnabled = settings->AutoReconnectionEnabled;
 	file->RedirectSmartCards = settings->RedirectSmartCards;
 	file->RedirectClipboard = settings->RedirectClipboard;
@@ -1654,29 +1654,30 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 	{
 		if (file->BandwidthAutoDetect != 0)
 		{
-			if ((~file->NetworkAutoDetect) && (file->NetworkAutoDetect != 0))
+			if ((~file->NetworkAutoDetect) && (file->NetworkAutoDetect == 0))
 			{
 				WLog_WARN(TAG,
 				          "Got networkautodetect:i:%" PRIu32 " and bandwidthautodetect:i:%" PRIu32
-				          ". Correcting to networkautodetect:i:0",
+				          ". Correcting to networkautodetect:i:1",
 				          file->NetworkAutoDetect, file->BandwidthAutoDetect);
 				WLog_WARN(TAG,
-				          "Add networkautodetect:i:0 to your RDP file to eliminate this warning.");
+				          "Add networkautodetect:i:1 to your RDP file to eliminate this warning.");
 			}
 
 			if (!freerdp_set_connection_type(settings, CONNECTION_TYPE_AUTODETECT))
 				return FALSE;
 			setDefaultConnectionType = FALSE;
 		}
+
 		if (!freerdp_settings_set_bool(settings, FreeRDP_NetworkAutoDetect,
 		                               (file->BandwidthAutoDetect != 0) ||
-		                                   (file->NetworkAutoDetect == 0)))
+		                                   (file->NetworkAutoDetect != 0)))
 			return FALSE;
 	}
 
 	if (~file->NetworkAutoDetect)
 	{
-		if (file->NetworkAutoDetect == 0)
+		if (file->NetworkAutoDetect == 1)
 		{
 			if ((~file->BandwidthAutoDetect) && (file->BandwidthAutoDetect == 0))
 			{
@@ -1690,12 +1691,12 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 
 			if (!freerdp_set_connection_type(settings, CONNECTION_TYPE_AUTODETECT))
 				return FALSE;
-
 			setDefaultConnectionType = FALSE;
 		}
+
 		if (!freerdp_settings_set_bool(settings, FreeRDP_NetworkAutoDetect,
 		                               (file->BandwidthAutoDetect != 0) ||
-		                                   (file->NetworkAutoDetect == 0)))
+		                                   (file->NetworkAutoDetect != 0)))
 			return FALSE;
 	}
 


### PR DESCRIPTION
The RDP file parser was overriding the connection type setting if either, networkautodetect or bandwidthautodetect was enabled