### PR TITLE
Implement APC and cleanup polling

### DIFF
--- a/winpr/include/winpr/synch.h
+++ b/winpr/include/winpr/synch.h
@@ -174,6 +174,7 @@ extern "C"
 
 #define WAIT_OBJECT_0 0x00000000L
 #define WAIT_ABANDONED 0x00000080L
+#define WAIT_IO_COMPLETION 0x000000C0L
 
 #ifndef WAIT_TIMEOUT
 #define WAIT_TIMEOUT 0x00000102L
@@ -202,7 +203,8 @@ extern "C"
 		ULONG Version;
 		DWORD Flags;
 
-		union {
+		union
+		{
 			struct
 			{
 				HMODULE LocalizedReasonModule;

--- a/winpr/include/winpr/thread.h
+++ b/winpr/include/winpr/thread.h
@@ -213,6 +213,9 @@ extern "C"
 	WINPR_API HANDLE _GetCurrentThread(void);
 	WINPR_API DWORD GetCurrentThreadId(void);
 
+	typedef void (*PAPCFUNC)(ULONG_PTR Parameter);
+	WINPR_API DWORD QueueUserAPC(PAPCFUNC pfnAPC, HANDLE hThread, ULONG_PTR dwData);
+
 	WINPR_API DWORD ResumeThread(HANDLE hThread);
 	WINPR_API DWORD SuspendThread(HANDLE hThread);
 	WINPR_API BOOL SwitchToThread(void);

--- a/winpr/libwinpr/synch/CMakeLists.txt
+++ b/winpr/libwinpr/synch/CMakeLists.txt
@@ -22,6 +22,8 @@ winpr_module_add(
 	event.c
 	init.c
 	mutex.c
+	pollset.c
+	pollset.h
 	semaphore.c
 	sleep.c
 	synch.h

--- a/winpr/libwinpr/synch/event.h
+++ b/winpr/libwinpr/synch/event.h
@@ -1,0 +1,56 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * event implementation
+ *
+ * Copyright 2021 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef WINPR_LIBWINPR_SYNCH_EVENT_H_
+#define WINPR_LIBWINPR_SYNCH_EVENT_H_
+
+#include "../handle/handle.h"
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef HAVE_SYS_EVENTFD_H
+#include <sys/eventfd.h>
+#endif
+
+struct winpr_event_impl
+{
+	int fds[2];
+};
+
+typedef struct winpr_event_impl WINPR_EVENT_IMPL;
+
+struct winpr_event
+{
+	WINPR_HANDLE_DEF();
+
+	WINPR_EVENT_IMPL impl;
+	BOOL bAttached;
+	BOOL bManualReset;
+	char* name;
+};
+typedef struct winpr_event WINPR_EVENT;
+
+BOOL winpr_event_init(WINPR_EVENT_IMPL* event);
+void winpr_event_init_from_fd(WINPR_EVENT_IMPL* event, int fd);
+BOOL winpr_event_set(WINPR_EVENT_IMPL* event);
+BOOL winpr_event_reset(WINPR_EVENT_IMPL* event);
+void winpr_event_uninit(WINPR_EVENT_IMPL* event);
+
+#endif /* WINPR_LIBWINPR_SYNCH_EVENT_H_ */

--- a/winpr/libwinpr/synch/pollset.c
+++ b/winpr/libwinpr/synch/pollset.c
@@ -1,0 +1,168 @@
+#include <errno.h>
+
+#include "pollset.h"
+#include <winpr/handle.h>
+#include "../log.h"
+
+#define TAG WINPR_TAG("sync.pollset")
+
+#ifdef HAVE_POLL_H
+static DWORD handle_mode_to_pollevent(ULONG mode)
+{
+	DWORD event = 0;
+
+	if (mode & WINPR_FD_READ)
+		event |= POLLIN;
+
+	if (mode & WINPR_FD_WRITE)
+		event |= POLLOUT;
+
+	return event;
+}
+#endif
+
+BOOL pollset_init(WINPR_POLL_SET* set, size_t nhandles)
+{
+#ifdef HAVE_POLL_H
+	if (nhandles > MAXIMUM_WAIT_OBJECTS)
+	{
+		set->isStatic = FALSE;
+		set->pollset = calloc(nhandles, sizeof(*set->pollset));
+		if (!set->pollset)
+			return FALSE;
+	}
+	else
+	{
+		set->pollset = set->staticSet;
+		set->isStatic = TRUE;
+	}
+#else
+	set->fdIndex = calloc(nhandles, sizeof(*set->fdIndex));
+	if (!set->fdIndex)
+		return FALSE;
+
+	FD_ZERO(&set->rset);
+	FD_ZERO(&set->wset);
+	set->maxFd = 0;
+	set->nread = set->nwrite = 0;
+#endif
+
+	set->size = nhandles;
+	set->fillIndex = 0;
+	return TRUE;
+}
+
+void pollset_uninit(WINPR_POLL_SET* set)
+{
+#ifdef HAVE_POLL_H
+	if (!set->isStatic)
+		free(set->pollset);
+#else
+	free(set->fdIndex);
+#endif
+}
+
+void pollset_reset(WINPR_POLL_SET* set)
+{
+#ifndef HAVE_POLL_H
+	FD_ZERO(&set->rset);
+	FD_ZERO(&set->wset);
+	set->maxFd = 0;
+	set->nread = set->nwrite = 0;
+#endif
+	set->fillIndex = 0;
+}
+
+BOOL pollset_add(WINPR_POLL_SET* set, int fd, ULONG mode)
+{
+#ifdef HAVE_POLL_H
+	struct pollfd* item;
+	if (set->fillIndex == set->size)
+		return FALSE;
+
+	item = &set->pollset[set->fillIndex];
+	item->fd = fd;
+	item->revents = 0;
+	item->events = handle_mode_to_pollevent(mode);
+#else
+	FdIndex* fdIndex = &set->fdIndex[set->fillIndex];
+	if (mode & WINPR_FD_READ)
+	{
+		FD_SET(fd, &set->rset);
+		set->nread++;
+	}
+
+	if (mode & WINPR_FD_WRITE)
+	{
+		FD_SET(fd, &set->wset);
+		set->nwrite++;
+	}
+
+	if (fd > set->maxFd)
+		set->maxFd = fd;
+
+	fdIndex->fd = fd;
+	fdIndex->mode = mode;
+#endif
+	set->fillIndex++;
+	return TRUE;
+}
+
+int pollset_poll(WINPR_POLL_SET* set, DWORD dwMilliseconds)
+{
+	int ret;
+#ifdef HAVE_POLL_H
+	do
+	{
+		ret = poll(set->pollset, set->fillIndex, dwMilliseconds);
+	} while (ret < 0 && errno == EINTR);
+#else
+	struct timeval staticTimeout;
+	struct timeval* timeout;
+
+	if (dwMilliseconds == INFINITE || dwMilliseconds == 0)
+	{
+		timeout = NULL;
+	}
+	else
+	{
+		timeout = &staticTimeout;
+		timeout->tv_sec = dwMilliseconds / 1000;
+		timeout->tv_usec = (dwMilliseconds % 1000) * 1000;
+	}
+
+	do
+	{
+		ret = select(set->maxFd + 1, set->nread ? &set->rset : NULL,
+		             set->nwrite ? &set->wset : NULL, NULL, timeout);
+	} while (ret < 0 && errno == EINTR);
+#endif
+
+	return ret;
+}
+
+BOOL pollset_isSignaled(WINPR_POLL_SET* set, size_t idx)
+{
+	if (idx > set->fillIndex)
+	{
+		WLog_ERR(TAG, "%s: index=%d out of pollset(fillIndex=%d)", __FUNCTION__, idx,
+		         set->fillIndex);
+		return FALSE;
+	}
+
+#ifdef HAVE_POLL_H
+	return !!(set->pollset[idx].revents & set->pollset[idx].events);
+#else
+	FdIndex* fdIndex = &set->fdIndex[idx];
+	if (fdIndex->fd < 0)
+		return FALSE;
+
+	if ((fdIndex->mode & WINPR_FD_READ) && FD_ISSET(fdIndex->fd, &set->rset))
+		return TRUE;
+
+	if ((fdIndex->mode & WINPR_FD_WRITE) && FD_ISSET(fdIndex->fd, &set->wset))
+		return TRUE;
+
+	return FALSE;
+#endif
+}

--- a/winpr/libwinpr/synch/pollset.h
+++ b/winpr/libwinpr/synch/pollset.h
@@ -1,0 +1,67 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * pollset
+ *
+ * Copyright 2021 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef WINPR_LIBWINPR_SYNCH_POLLSET_H_
+#define WINPR_LIBWINPR_SYNCH_POLLSET_H_
+
+#include <winpr/wtypes.h>
+#include <winpr/synch.h>
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef HAVE_POLL_H
+#include <poll.h>
+#else
+#include <sys/select.h>
+
+typedef struct
+{
+	int fd;
+	ULONG mode;
+} FdIndex;
+#endif
+
+struct winpr_poll_set
+{
+#ifdef HAVE_POLL_H
+	struct pollfd* pollset;
+	struct pollfd staticSet[MAXIMUM_WAIT_OBJECTS];
+	BOOL isStatic;
+#else
+	FdIndex* fdIndex;
+	fd_set rset;
+	fd_set wset;
+	int nread, nwrite;
+	int maxFd;
+#endif
+	size_t fillIndex;
+	size_t size;
+};
+
+typedef struct winpr_poll_set WINPR_POLL_SET;
+
+BOOL pollset_init(WINPR_POLL_SET* set, size_t nhandles);
+void pollset_uninit(WINPR_POLL_SET* set);
+void pollset_reset(WINPR_POLL_SET* set);
+BOOL pollset_add(WINPR_POLL_SET* set, int fd, ULONG mode);
+int pollset_poll(WINPR_POLL_SET* set, DWORD dwMilliseconds);
+BOOL pollset_isSignaled(WINPR_POLL_SET* set, size_t idx);
+
+#endif /* WINPR_LIBWINPR_SYNCH_POLLSET_H_ */

--- a/winpr/libwinpr/synch/pollset.h
+++ b/winpr/libwinpr/synch/pollset.h
@@ -26,6 +26,8 @@
 #include "config.h"
 #endif
 
+#ifndef _WIN32
+
 #ifdef HAVE_POLL_H
 #include <poll.h>
 #else
@@ -46,7 +48,9 @@ struct winpr_poll_set
 	BOOL isStatic;
 #else
 	FdIndex* fdIndex;
+	fd_set rset_base;
 	fd_set rset;
+	fd_set wset_base;
 	fd_set wset;
 	int nread, nwrite;
 	int maxFd;
@@ -63,5 +67,7 @@ void pollset_reset(WINPR_POLL_SET* set);
 BOOL pollset_add(WINPR_POLL_SET* set, int fd, ULONG mode);
 int pollset_poll(WINPR_POLL_SET* set, DWORD dwMilliseconds);
 BOOL pollset_isSignaled(WINPR_POLL_SET* set, size_t idx);
+
+#endif
 
 #endif /* WINPR_LIBWINPR_SYNCH_POLLSET_H_ */

--- a/winpr/libwinpr/synch/sleep.c
+++ b/winpr/libwinpr/synch/sleep.c
@@ -26,6 +26,9 @@
 #include <winpr/synch.h>
 
 #include "../log.h"
+#include "../thread/apc.h"
+#include "../thread/thread.h"
+#include "../synch/pollset.h"
 
 #define TAG WINPR_TAG("synch.sleep")
 
@@ -47,11 +50,64 @@ VOID Sleep(DWORD dwMilliseconds)
 
 DWORD SleepEx(DWORD dwMilliseconds, BOOL bAlertable)
 {
-	/* TODO: Implement bAlertable support */
-	if (bAlertable)
-		WLog_WARN(TAG, "%s does not support bAlertable", __FUNCTION__);
-	Sleep(dwMilliseconds);
-	return 0;
+	WINPR_THREAD* thread = winpr_GetCurrentThread();
+	WINPR_POLL_SET pollset;
+	int status;
+	DWORD ret = WAIT_FAILED;
+	BOOL autoSignalled;
+
+	if (!thread)
+	{
+		WLog_ERR(TAG, "unable to retrieve currentThread");
+		return WAIT_FAILED;
+	}
+
+	/* treat re-entrancy if a completion is calling us */
+	if (thread->apc.treatingCompletions)
+		bAlertable = FALSE;
+
+	if (!bAlertable || !thread->apc.length)
+	{
+		usleep(dwMilliseconds * 1000);
+		return 0;
+	}
+
+	if (!pollset_init(&pollset, thread->apc.length))
+	{
+		WLog_ERR(TAG, "unable to initialize pollset");
+		return WAIT_FAILED;
+	}
+
+	if (!apc_collectFds(thread, &pollset, &autoSignalled))
+	{
+		WLog_ERR(TAG, "unable to APC file descriptors");
+		goto out;
+	}
+
+	if (!autoSignalled)
+	{
+		/* we poll and wait only if no APC member is ready */
+		status = pollset_poll(&pollset, dwMilliseconds);
+		if (status < 0)
+		{
+			WLog_ERR(TAG, "polling of apc fds failed");
+			goto out;
+		}
+	}
+
+	if (apc_executeCompletions(thread, &pollset, 0))
+	{
+		ret = WAIT_IO_COMPLETION;
+	}
+	else
+	{
+		/* according to the spec return value is 0 see
+		 * https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleepex*/
+		ret = 0;
+	}
+out:
+	pollset_uninit(&pollset);
+	return ret;
 }
 
 #endif

--- a/winpr/libwinpr/synch/test/CMakeLists.txt
+++ b/winpr/libwinpr/synch/test/CMakeLists.txt
@@ -15,7 +15,8 @@ set(${MODULE_PREFIX}_TESTS
 	TestSynchMultipleThreads.c
 	TestSynchTimerQueue.c
 	TestSynchWaitableTimer.c
-	TestSynchWaitableTimerAPC.c)
+	TestSynchWaitableTimerAPC.c
+	TestSynchAPC.c)
 
 create_test_sourcelist(${MODULE_PREFIX}_SRCS
 	${${MODULE_PREFIX}_DRIVER}

--- a/winpr/libwinpr/synch/test/TestSynchAPC.c
+++ b/winpr/libwinpr/synch/test/TestSynchAPC.c
@@ -1,0 +1,174 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * TestSyncAPC
+ *
+ * Copyright 2021 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <winpr/wtypes.h>
+#include <winpr/thread.h>
+#include <winpr/synch.h>
+
+typedef struct
+{
+	BOOL error;
+	BOOL called;
+} UserApcArg;
+
+void CALLBACK userApc(ULONG_PTR arg)
+{
+	UserApcArg* userArg = (UserApcArg*)arg;
+	userArg->called = TRUE;
+}
+
+static DWORD WINAPI uncleanThread(LPVOID lpThreadParameter)
+{
+	/* this thread post an APC that will never get executed */
+	UserApcArg* userArg = (UserApcArg*)lpThreadParameter;
+	if (!QueueUserAPC((PAPCFUNC)userApc, _GetCurrentThread(), (ULONG_PTR)lpThreadParameter))
+	{
+		userArg->error = TRUE;
+		return 1;
+	}
+
+	return 0;
+}
+
+static DWORD WINAPI cleanThread(LPVOID lpThreadParameter)
+{
+	Sleep(500);
+
+	SleepEx(500, TRUE);
+	return 0;
+}
+
+typedef struct
+{
+	HANDLE timer1;
+	DWORD timer1Calls;
+	HANDLE timer2;
+	DWORD timer2Calls;
+	BOOL endTest;
+} UncleanCloseData;
+
+static VOID CALLBACK Timer1APCProc(LPVOID lpArg, DWORD dwTimerLowValue, DWORD dwTimerHighValue)
+{
+	UncleanCloseData* data = (UncleanCloseData*)lpArg;
+	data->timer1Calls++;
+	CloseHandle(data->timer2);
+	data->endTest = TRUE;
+}
+
+static VOID CALLBACK Timer2APCProc(LPVOID lpArg, DWORD dwTimerLowValue, DWORD dwTimerHighValue)
+{
+	UncleanCloseData* data = (UncleanCloseData*)lpArg;
+	data->timer2Calls++;
+}
+
+static DWORD /*WINAPI*/ closeHandleTest(LPVOID lpThreadParameter)
+{
+	LARGE_INTEGER dueTime;
+	UncleanCloseData* data = (UncleanCloseData*)lpThreadParameter;
+	data->endTest = FALSE;
+
+	dueTime.QuadPart = -500;
+	if (!SetWaitableTimer(data->timer1, &dueTime, 0, Timer1APCProc, lpThreadParameter, FALSE))
+		return 1;
+
+	dueTime.QuadPart = -900;
+	if (!SetWaitableTimer(data->timer2, &dueTime, 0, Timer2APCProc, lpThreadParameter, FALSE))
+		return 1;
+
+	while (!data->endTest)
+	{
+		SleepEx(100, TRUE);
+	}
+	return 0;
+}
+
+int TestSynchAPC(int argc, char* argv[])
+{
+	HANDLE thread = NULL;
+	UserApcArg userApcArg;
+	UncleanCloseData uncleanCloseData;
+
+	userApcArg.error = FALSE;
+	userApcArg.called = FALSE;
+
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+
+	/* first post an APC and check it is executed during a SleepEx */
+	if (!QueueUserAPC((PAPCFUNC)userApc, _GetCurrentThread(), (ULONG_PTR)&userApcArg))
+		return 1;
+
+	if (SleepEx(100, FALSE) != 0)
+		return 2;
+
+	if (SleepEx(100, TRUE) != WAIT_IO_COMPLETION)
+		return 3;
+
+	if (!userApcArg.called)
+		return 4;
+
+	userApcArg.called = FALSE;
+
+	/* test that the APC is cleaned up even when not called */
+	thread = CreateThread(NULL, 0, uncleanThread, &userApcArg, 0, NULL);
+	if (!thread)
+		return 10;
+	WaitForSingleObject(thread, INFINITE);
+	CloseHandle(thread);
+
+	if (userApcArg.called || userApcArg.error)
+		return 11;
+
+	/* test a remote APC queuing */
+	thread = CreateThread(NULL, 0, cleanThread, &userApcArg, 0, NULL);
+	if (!thread)
+		return 20;
+
+	if (!QueueUserAPC((PAPCFUNC)userApc, thread, (ULONG_PTR)&userApcArg))
+		return 21;
+
+	WaitForSingleObject(thread, INFINITE);
+	CloseHandle(thread);
+
+	if (!userApcArg.called)
+		return 22;
+
+#if 0
+	/* test cleanup of timer completions */
+	memset(&uncleanCloseData, 0, sizeof(uncleanCloseData));
+	uncleanCloseData.timer1 = CreateWaitableTimerA(NULL, FALSE, NULL);
+	if (!uncleanCloseData.timer1)
+		return 31;
+
+	uncleanCloseData.timer2 = CreateWaitableTimerA(NULL, FALSE, NULL);
+	if (!uncleanCloseData.timer2)
+		return 32;
+
+	thread = CreateThread(NULL, 0, closeHandleTest, &uncleanCloseData, 0, NULL);
+	if (!thread)
+		return 33;
+
+	WaitForSingleObject(thread, INFINITE);
+	CloseHandle(thread);
+
+	if (uncleanCloseData.timer1Calls != 1 || uncleanCloseData.timer2Calls != 0)
+		return 34;
+	CloseHandle(uncleanCloseData.timer1);
+#endif
+	return 0;
+}

--- a/winpr/libwinpr/synch/test/TestSynchMultipleThreads.c
+++ b/winpr/libwinpr/synch/test/TestSynchMultipleThreads.c
@@ -7,9 +7,7 @@
 
 static DWORD WINAPI test_thread(LPVOID arg)
 {
-	long timeout = rand();
-	timeout %= 1000;
-	timeout += 100;
+	long timeout = 100 + (rand() % 1000);
 	Sleep(timeout);
 	ExitThread(0);
 	return 0;
@@ -54,14 +52,16 @@ int TestSynchMultipleThreads(int argc, char* argv[])
 #define THREADS 24
 	DWORD rc = 0, ev, i;
 	HANDLE threads[THREADS];
+	DWORD ret;
 
 	/* WaitForAll, timeout */
 	if (start_threads(THREADS, threads))
 		return 1;
 
-	if (WaitForMultipleObjects(THREADS, threads, TRUE, 50) != WAIT_TIMEOUT)
+	ret = WaitForMultipleObjects(THREADS, threads, TRUE, 50);
+	if (ret != WAIT_TIMEOUT)
 	{
-		printf("WaitForMultipleObjects bWaitAll, timeout 50 failed\n");
+		printf("WaitForMultipleObjects bWaitAll, timeout 50 failed, ret=%d\n", ret);
 		rc = 2;
 	}
 
@@ -82,7 +82,6 @@ int TestSynchMultipleThreads(int argc, char* argv[])
 		return 5;
 
 	ev = WaitForMultipleObjects(THREADS, threads, FALSE, INFINITE);
-
 	if (ev > (WAIT_OBJECT_0 + THREADS))
 	{
 		printf("WaitForMultipleObjects INFINITE failed\n");
@@ -105,9 +104,10 @@ int TestSynchMultipleThreads(int argc, char* argv[])
 	if (start_threads(THREADS, threads))
 		return 9;
 
-	if (WaitForMultipleObjects(THREADS, threads, FALSE, 50) != WAIT_TIMEOUT)
+	ret = WaitForMultipleObjects(THREADS, threads, FALSE, 50);
+	if (ret != WAIT_TIMEOUT)
 	{
-		printf("WaitForMultipleObjects timeout 50 failed\n");
+		printf("WaitForMultipleObjects timeout 50 failed, ret=%d\n", ret);
 		rc = 10;
 	}
 
@@ -129,9 +129,10 @@ int TestSynchMultipleThreads(int argc, char* argv[])
 
 	for (i = 0; i < THREADS; i++)
 	{
-		if (WaitForMultipleObjects(THREADS, threads, FALSE, 0) != WAIT_TIMEOUT)
+		ret = WaitForMultipleObjects(THREADS, threads, FALSE, 0);
+		if (ret != WAIT_TIMEOUT)
 		{
-			printf("WaitForMultipleObjects timeout 50 failed\n");
+			printf("WaitForMultipleObjects timeout 50 failed, ret=%d\n", ret);
 			rc = 15;
 		}
 	}

--- a/winpr/libwinpr/synch/test/TestSynchWaitableTimerAPC.c
+++ b/winpr/libwinpr/synch/test/TestSynchWaitableTimerAPC.c
@@ -87,7 +87,7 @@ int TestSynchWaitableTimerAPC(int argc, char* argv[])
 		if (rc == WAIT_OBJECT_0)
 			break;
 
-		if (rc == 0x000000C0L) /* WAIT_IO_COMPLETION */
+		if (rc == WAIT_IO_COMPLETION)
 			continue;
 
 		printf("Failed to wait for completion event (%" PRIu32 ")\n", GetLastError());

--- a/winpr/libwinpr/thread/CMakeLists.txt
+++ b/winpr/libwinpr/thread/CMakeLists.txt
@@ -16,6 +16,8 @@
 # limitations under the License.
 
 winpr_module_add(
+	apc.h
+	apc.c
 	argv.c
 	process.c
 	processor.c

--- a/winpr/libwinpr/thread/apc.c
+++ b/winpr/libwinpr/thread/apc.c
@@ -1,0 +1,244 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * APC implementation
+ *
+ * Copyright 2021 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _WIN32
+
+#include "apc.h"
+#include "thread.h"
+#include "../log.h"
+#include "../synch/pollset.h"
+
+#define TAG WINPR_TAG("apc")
+
+BOOL apc_init(APC_QUEUE* apc)
+{
+	pthread_mutexattr_t attr;
+	BOOL ret = FALSE;
+
+	pthread_mutexattr_init(&attr);
+	if (pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE) != 0)
+	{
+		WLog_ERR(TAG, "failed to initialize mutex attributes to recursive");
+		return FALSE;
+	}
+
+	memset(apc, 0, sizeof(*apc));
+
+	if (pthread_mutex_init(&apc->mutex, &attr) != 0)
+	{
+		WLog_ERR(TAG, "failed to initialize main thread APC mutex");
+		goto out;
+	}
+
+	ret = TRUE;
+out:
+	pthread_mutexattr_destroy(&attr);
+	return ret;
+}
+
+BOOL apc_uninit(APC_QUEUE* apc)
+{
+	return pthread_mutex_destroy(&apc->mutex) == 0;
+}
+
+void apc_register(WINPR_THREAD* thread, WINPR_APC_ITEM* addItem)
+{
+	WINPR_APC_ITEM** nextp;
+	APC_QUEUE* apc = &thread->apc;
+
+	pthread_mutex_lock(&apc->mutex);
+	if (apc->tail)
+	{
+		nextp = &apc->tail->next;
+		addItem->last = apc->tail;
+	}
+	else
+	{
+		nextp = &apc->head;
+	}
+
+	*nextp = addItem;
+	apc->tail = addItem;
+	apc->length++;
+
+	addItem->markedForRemove = FALSE;
+	addItem->boundThread = GetCurrentThreadId();
+	addItem->linked = TRUE;
+	pthread_mutex_unlock(&apc->mutex);
+}
+
+static INLINE void apc_item_remove(APC_QUEUE* apc, WINPR_APC_ITEM* item)
+{
+	if (!item->last)
+		apc->head = item->next;
+	else
+		item->last->next = item->next;
+
+	if (!item->next)
+		apc->tail = item->last;
+	else
+		item->next->last = item->last;
+
+	apc->length--;
+}
+
+APC_REMOVE_RESULT apc_remove(WINPR_APC_ITEM* item)
+{
+	WINPR_THREAD* thread = winpr_GetCurrentThread();
+	APC_QUEUE* apc;
+	APC_REMOVE_RESULT ret = APC_REMOVE_OK;
+
+	if (!item->linked)
+		return APC_REMOVE_OK;
+
+	if (item->boundThread != GetCurrentThreadId())
+	{
+		WLog_ERR(TAG, "removing an APC entry should be done in the creating thread");
+		return APC_REMOVE_ERROR;
+	}
+
+	if (!thread)
+	{
+		WLog_ERR(TAG, "unable to retrieve current thread");
+		return APC_REMOVE_ERROR;
+	}
+
+	apc = &thread->apc;
+	pthread_mutex_lock(&apc->mutex);
+	if (apc->treatingCompletions)
+	{
+		item->markedForRemove = TRUE;
+		ret = APC_REMOVE_DELAY_FREE;
+		goto out;
+	}
+
+	apc_item_remove(apc, item);
+
+out:
+	pthread_mutex_unlock(&apc->mutex);
+	item->boundThread = 0xFFFFFFFF;
+	item->linked = FALSE;
+	return ret;
+}
+
+BOOL apc_collectFds(WINPR_THREAD* thread, WINPR_POLL_SET* set, BOOL* haveAutoSignaled)
+{
+	WINPR_APC_ITEM* item;
+	BOOL ret = FALSE;
+	APC_QUEUE* apc = &thread->apc;
+
+	*haveAutoSignaled = FALSE;
+	pthread_mutex_lock(&apc->mutex);
+	item = apc->head;
+	for (; item; item = item->next)
+	{
+		if (item->alwaysSignaled)
+			*haveAutoSignaled = TRUE;
+		else if (!pollset_add(set, item->pollFd, item->pollMode))
+			goto out;
+	}
+
+	ret = TRUE;
+out:
+	pthread_mutex_unlock(&apc->mutex);
+	return ret;
+}
+
+int apc_executeCompletions(WINPR_THREAD* thread, WINPR_POLL_SET* set, size_t idx)
+{
+	APC_QUEUE* apc = &thread->apc;
+	WINPR_APC_ITEM *item, *nextItem;
+	int ret = 0;
+
+	pthread_mutex_lock(&apc->mutex);
+	apc->treatingCompletions = TRUE;
+
+	/* first pass to compute signaled items */
+	for (item = apc->head; item; item = item->next)
+	{
+		item->isSignaled = item->alwaysSignaled || pollset_isSignaled(set, idx);
+		if (!item->alwaysSignaled)
+			idx++;
+	}
+
+	/* second pass: run completions */
+	for (item = apc->head; item; item = nextItem)
+	{
+		if (item->isSignaled)
+		{
+			if (item->completion && !item->markedForRemove)
+				item->completion(item->completionArgs);
+			ret++;
+		}
+
+		nextItem = item->next;
+
+		if (item->markedForRemove)
+		{
+			apc_item_remove(apc, item);
+
+			if (item->markedForFree)
+				free(item);
+		}
+	}
+
+	/* third pass: to do final cleanup */
+	for (item = apc->head; item; item = nextItem)
+	{
+		nextItem = item->next;
+
+		if (item->markedForRemove)
+		{
+			apc_item_remove(apc, item);
+			if (item->markedForFree)
+				free(item);
+		}
+	}
+
+	apc->treatingCompletions = FALSE;
+	pthread_mutex_unlock(&apc->mutex);
+
+	return ret;
+}
+
+void apc_cleanupThread(WINPR_THREAD* thread)
+{
+	WINPR_APC_ITEM* item;
+	WINPR_APC_ITEM* nextItem;
+	APC_QUEUE* apc = &thread->apc;
+
+	pthread_mutex_lock(&apc->mutex);
+	item = apc->head;
+	for (; item; item = nextItem)
+	{
+		nextItem = item->next;
+
+		if (item->type == APC_TYPE_HANDLE_FREE)
+			item->completion(item->completionArgs);
+
+		item->last = item->next = NULL;
+		item->linked = FALSE;
+		if (item->markedForFree)
+			free(item);
+	}
+
+	apc->head = apc->tail = NULL;
+	pthread_mutex_unlock(&apc->mutex);
+}
+
+#endif

--- a/winpr/libwinpr/thread/apc.h
+++ b/winpr/libwinpr/thread/apc.h
@@ -1,0 +1,85 @@
+/**
+ * WinPR: Windows Portable Runtime
+ * APC implementation
+ *
+ * Copyright 2021 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WINPR_APC_H
+#define WINPR_APC_H
+
+#include <winpr/winpr.h>
+#include <winpr/wtypes.h>
+
+#ifndef _WIN32
+
+#include <pthread.h>
+
+typedef struct winpr_thread WINPR_THREAD;
+typedef struct winpr_APC_item WINPR_APC_ITEM;
+typedef struct winpr_poll_set WINPR_POLL_SET;
+
+typedef void (*apc_treatment)(LPVOID arg);
+
+typedef enum
+{
+	APC_TYPE_USER,
+	APC_TYPE_TIMER,
+	APC_TYPE_HANDLE_FREE
+} ApcType;
+
+struct winpr_APC_item
+{
+	ApcType type;
+	int pollFd;
+	DWORD pollMode;
+	apc_treatment completion;
+	LPVOID completionArgs;
+	BOOL markedForFree;
+
+	/* private fields used by the APC */
+	BOOL alwaysSignaled;
+	BOOL isSignaled;
+	DWORD boundThread;
+	BOOL linked;
+	BOOL markedForRemove;
+	WINPR_APC_ITEM *last, *next;
+};
+
+typedef enum
+{
+	APC_REMOVE_OK,
+	APC_REMOVE_ERROR,
+	APC_REMOVE_DELAY_FREE
+} APC_REMOVE_RESULT;
+
+typedef struct
+{
+	pthread_mutex_t mutex;
+	DWORD length;
+	WINPR_APC_ITEM *head, *tail;
+	BOOL treatingCompletions;
+} APC_QUEUE;
+
+BOOL apc_init(APC_QUEUE* apc);
+BOOL apc_uninit(APC_QUEUE* apc);
+void apc_register(WINPR_THREAD* thread, WINPR_APC_ITEM* addItem);
+APC_REMOVE_RESULT apc_remove(WINPR_APC_ITEM* item);
+BOOL apc_collectFds(WINPR_THREAD* thread, WINPR_POLL_SET* set, BOOL* haveAutoSignaled);
+int apc_executeCompletions(WINPR_THREAD* thread, WINPR_POLL_SET* set, size_t startIndex);
+void apc_cleanupThread(WINPR_THREAD* thread);
+#endif
+
+#endif /* WINPR_APC_H */

--- a/winpr/libwinpr/thread/thread.h
+++ b/winpr/libwinpr/thread/thread.h
@@ -4,6 +4,7 @@
  *
  * Copyright 2012 Marc-Andre Moreau <marcandre.moreau@gmail.com>
  * Copyright 2015 Hewlett-Packard Development Company, L.P.
+ * Copyright 2021 David Fort <contact@hardening-consulting.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,15 +29,18 @@
 #include <winpr/thread.h>
 
 #include "../handle/handle.h"
+#include "../synch/event.h"
+#include "apc.h"
 
 typedef void* (*pthread_start_routine)(void*);
+typedef struct winpr_APC_item WINPR_APC_ITEM;
 
 struct winpr_thread
 {
 	WINPR_HANDLE_DEF();
 
 	BOOL started;
-	int pipe_fd[2];
+	WINPR_EVENT_IMPL event;
 	BOOL mainProcess;
 	BOOL detached;
 	BOOL joined;
@@ -50,12 +54,15 @@ struct winpr_thread
 	pthread_cond_t threadIsReady;
 	LPTHREAD_START_ROUTINE lpStartAddress;
 	LPSECURITY_ATTRIBUTES lpThreadAttributes;
+	APC_QUEUE apc;
 #if defined(WITH_DEBUG_THREADS)
 	void* create_stack;
 	void* exit_stack;
 #endif
 };
 typedef struct winpr_thread WINPR_THREAD;
+
+WINPR_THREAD* winpr_GetCurrentThread(VOID);
 
 struct winpr_process
 {


### PR DESCRIPTION
This big PR implements APC calls so that they are executed in the correct thread. The main target is having a correct behaviour with WaitableTimers with completions: executed in the correct thread and when the thread is in alertable state.

I took this opportunity to cleanup the polling API and have it in its own `PollSet` component.
I've also mutualized the `Event` implementation so that threads and timers don't have to deal with `eventfd` or `pipes`.