### PR TITLE
Clipboard close fd

### DIFF
--- a/winpr/libwinpr/clipboard/posix.c
+++ b/winpr/libwinpr/clipboard/posix.c
@@ -1016,7 +1016,9 @@ UINT posix_file_read_close(struct posix_file* file, BOOL force)
 	if (file->fd < 0)
 		return NO_ERROR;
 
-	if ((file->offset >= file->size) || force)
+	/* Always force close the file. Clipboard might open hundreds of files
+	 * so avoid caching to prevent running out of available file descriptors */
+	if ((file->offset >= file->size) || force || TRUE)
 	{
 		WLog_VRB(TAG, "close file %d", file->fd);
 

--- a/winpr/libwinpr/clipboard/posix.c
+++ b/winpr/libwinpr/clipboard/posix.c
@@ -1053,7 +1053,7 @@ static UINT posix_file_get_range(struct posix_file* file, UINT64 offset, UINT32 
 
 out:
 
-	posix_file_read_close(file, FALSE);
+	posix_file_read_close(file, error != NO_ERROR);
 	return error;
 }
 

--- a/winpr/libwinpr/clipboard/posix.c
+++ b/winpr/libwinpr/clipboard/posix.c
@@ -1055,7 +1055,7 @@ static UINT posix_file_get_range(struct posix_file* file, UINT64 offset, UINT32 
 
 out:
 
-	posix_file_read_close(file, error != NO_ERROR);
+	posix_file_read_close(file, (error != NO_ERROR) && (size > 0));
 	return error;
 }
 


### PR DESCRIPTION
Do not cache open file descriptors:
1. We might run out of file descriptors available when copying many files
2. the server might not read the whole file, so we keep cached file descriptors unnecessarily