### PR TITLE
Wayland client: Disable shortcut inhibition on rctrl press

### DIFF
--- a/client/Wayland/wlf_input.c
+++ b/client/Wayland/wlf_input.c
@@ -301,6 +301,9 @@ BOOL wlf_handle_key(freerdp* instance, const UwacKeyEvent* ev)
 	if (!instance || !ev || !instance->input)
 		return FALSE;
 
+	if (instance->context->settings->GrabKeyboard && ev->raw_key == KEY_RIGHTCTRL)
+		wlf_handle_ungrab_key(instance, ev);
+
 	input = instance->input;
 	rdp_scancode = freerdp_keyboard_get_rdp_scancode_from_x11_keycode(ev->raw_key + 8);
 
@@ -308,6 +311,17 @@ BOOL wlf_handle_key(freerdp* instance, const UwacKeyEvent* ev)
 		return TRUE;
 
 	return freerdp_input_send_keyboard_event_ex(input, ev->pressed, rdp_scancode);
+}
+
+BOOL wlf_handle_ungrab_key(freerdp* instance, const UwacKeyEvent* ev)
+{
+	wlfContext* context;
+	if (!instance || !instance->context || !ev)
+		return FALSE;
+
+	context = (wlfContext*)instance->context;
+
+	return UwacSeatInhibitShortcuts(context->seat, false) == UWAC_SUCCESS;
 }
 
 BOOL wlf_keyboard_enter(freerdp* instance, const UwacKeyboardEnterLeaveEvent* ev)
@@ -339,6 +353,7 @@ BOOL wlf_keyboard_modifiers(freerdp* instance, const UwacKeyboardModifiersEvent*
 		return TRUE;
 
 	((wlfContext*)instance->context)->focusing = FALSE;
+
 	return freerdp_input_send_focus_in_event(input, syncFlags) &&
 	       freerdp_input_send_mouse_event(input, PTR_FLAGS_MOVE, 0, 0);
 }

--- a/client/Wayland/wlf_input.h
+++ b/client/Wayland/wlf_input.h
@@ -38,6 +38,7 @@ BOOL wlf_handle_touch_down(freerdp* instance, const UwacTouchDown* ev);
 BOOL wlf_handle_touch_motion(freerdp* instance, const UwacTouchMotion* ev);
 
 BOOL wlf_handle_key(freerdp* instance, const UwacKeyEvent* ev);
+BOOL wlf_handle_ungrab_key(freerdp* instance, const UwacKeyEvent* ev);
 BOOL wlf_keyboard_enter(freerdp* instance, const UwacKeyboardEnterLeaveEvent* ev);
 BOOL wlf_keyboard_modifiers(freerdp* instance, const UwacKeyboardModifiersEvent* ev);
 

--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -1135,12 +1135,15 @@ UwacReturnCode UwacSeatInhibitShortcuts(UwacSeat* s, bool inhibit)
 		return UWAC_ERROR_CLOSED;
 
 	if (s->keyboard_inhibitor)
+	{
 		zwp_keyboard_shortcuts_inhibitor_v1_destroy(s->keyboard_inhibitor);
+		s->keyboard_inhibitor = NULL;
+	}
 	if (inhibit && s->display && s->display->keyboard_inhibit_manager)
 		s->keyboard_inhibitor = zwp_keyboard_shortcuts_inhibit_manager_v1_inhibit_shortcuts(
 		    s->display->keyboard_inhibit_manager, s->keyboard_focus->surface, s->seat);
 
-	if (!s->keyboard_inhibitor)
+	if (inhibit && !s->keyboard_inhibitor)
 		return UWAC_ERROR_INTERNAL;
 	return UWAC_SUCCESS;
 }


### PR DESCRIPTION
This PR adds code to the Wayland client to disable shortcut inhibition when the right control key is pressed, which is the same behavior as the X11 client. While certain DEs provide their own key sequence for disabling the feature, to the best of my knowledge KWin does not, making it difficult to escape from a fullscreen RDP session when shortcut inhibition is enabled.

Let me know if any changes need to be made regarding the exact behavior when intercepting the key press.