### PR TITLE
core: Clear message queue to reset its closed state

### DIFF
--- a/libfreerdp/core/client.c
+++ b/libfreerdp/core/client.c
@@ -266,6 +266,8 @@ UINT freerdp_channels_pre_connect(rdpChannels* channels, freerdp* instance)
 	int index;
 	CHANNEL_CLIENT_DATA* pChannelClientData;
 
+	MessageQueue_Clear(channels->queue);
+
 	for (index = 0; index < channels->clientDataCount; index++)
 	{
 		pChannelClientData = &channels->clientDataList[index];


### PR DESCRIPTION
This fixes an issue where channels are broken when you call `freerdp_connect` again on a freerdp instance that failed to connect previously.