### PR TITLE
Fixed #6938: Remote app mode clipboard fix

### DIFF
--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -1657,7 +1657,10 @@ static UINT xf_cliprdr_server_format_list(CliprdrClientContext* context,
 	}
 
 	ret = xf_cliprdr_send_client_format_list_response(clipboard, TRUE);
-	xf_cliprdr_prepare_to_set_selection_owner(xfc, clipboard);
+	if (xfc->remote_app)
+		xf_cliprdr_set_selection_owner(xfc, clipboard, CurrentTime);
+	else
+		xf_cliprdr_prepare_to_set_selection_owner(xfc, clipboard);
 	return ret;
 }
 


### PR DESCRIPTION
In remote app mode the _FREERDP_TIMESTAMP_PROPERTY does not work.
Therefore ignore it