### PR TITLE
event: Fix reset of non eventfd winpr event

### DIFF
--- a/winpr/libwinpr/synch/event.c
+++ b/winpr/libwinpr/synch/event.c
@@ -129,7 +129,7 @@ BOOL winpr_event_reset(WINPR_EVENT_IMPL* event)
 			ret = eventfd_read(event->fds[0], &value);
 #else
 			char value;
-			ret = read(event->fds[1], &value, 1);
+			ret = read(event->fds[0], &value, 1);
 #endif
 		} while (ret < 0 && errno == EINTR);
 	} while (ret >= 0);


### PR DESCRIPTION
After aeba30a505e9872a57e0fec00fc84cf52dc43d93 the MacOS client is not able to connect anymore.
Every connection attempt is aborted with the following error messages in the log:

```
....
[error] [com.freerdp.channels.drdynvc.client] - MessageQueue_Peek failed!
[error] [com.freerdp.core] - drdynvc_virtual_channel_client_thread reported an error. Error was 1359
[error] [com.freerdp.core] - checkChannelErrorEvent() failed - 0
...
```

The problem is that winpr_event_reset tries to read from the write pipe (`fds[1]`) which keeps returning `EBADF` on MacOS. Threfore the event is never reset and `MessageQueue_Wait` always returns true even though the queue is actually empty.