### PR TITLE
X11: don't instanciate a clipboard implementation when clipboard is disabled

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1332,7 +1332,7 @@ static BOOL xf_post_connect(freerdp* instance)
 	update->SetKeyboardIndicators = xf_keyboard_set_indicators;
 	update->SetKeyboardImeStatus = xf_keyboard_set_ime_status;
 
-	if (!(xfc->clipboard = xf_clipboard_new(xfc)))
+	if (settings->RedirectClipboard && !(xfc->clipboard = xf_clipboard_new(xfc)))
 		return FALSE;
 
 	if (!(xfc->xfDisp = xf_disp_new(xfc)))


### PR DESCRIPTION
Valgrind doesn't like the FUSE mount with the file clipboard, it makes it freeze at the end of the process, so let's instantiate the clipboard only if we need it.