### PR TITLE
Fix FIPS mode support and build with OpenSSL 3.0

### DIFF
--- a/winpr/libwinpr/utils/ssl.c
+++ b/winpr/libwinpr/utils/ssl.c
@@ -244,9 +244,17 @@ static BOOL winpr_enable_fips(DWORD flags)
 #else
 		WLog_DBG(TAG, "Ensuring openssl fips mode is ENabled");
 
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+		if (!EVP_default_properties_is_fips_enabled(NULL))
+#else
 		if (FIPS_mode() != 1)
+#endif
 		{
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+			if (EVP_set_default_properties(NULL, "fips=yes"))
+#else
 			if (FIPS_mode_set(1))
+#endif
 				WLog_INFO(TAG, "Openssl fips mode ENabled!");
 			else
 			{


### PR DESCRIPTION
FreeRDP fails to build with OpenSSL 3.0 because of usage of the `FIPS_mode`
and `FIPS_mode_set` functions, which were removed. However, `FIPS_mode_set`
seems to have done nothing since OpenSSL 1.1.1 anyway. This is tentative fix
to make FreeRDP build with OpenSSL 3.0 and to fix the FIPS mode support.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1952937