### PR TITLE
winpr: add a HashTable_Foreach function and associated tests

### DIFF
--- a/winpr/include/winpr/collections.h
+++ b/winpr/include/winpr/collections.h
@@ -239,6 +239,7 @@ extern "C"
 		void* value;
 
 		wKeyValuePair* next;
+		BOOL markedForRemove;
 	};
 
 	/* Reference Table */
@@ -330,8 +331,13 @@ extern "C"
 		HASH_TABLE_VALUE_CLONE_FN valueClone;
 		HASH_TABLE_KEY_FREE_FN keyFree;
 		HASH_TABLE_VALUE_FREE_FN valueFree;
+
+		DWORD foreachRecursionLevel;
+		DWORD pendingRemoves;
 	};
 	typedef struct _wHashTable wHashTable;
+
+	typedef BOOL (*HASH_TABLE_FOREACH_FN)(const void* key, void* value, void* arg);
 
 	WINPR_API int HashTable_Count(wHashTable* table);
 	WINPR_API int HashTable_Add(wHashTable* table, void* key, void* value);
@@ -343,6 +349,7 @@ extern "C"
 	WINPR_API void* HashTable_GetItemValue(wHashTable* table, void* key);
 	WINPR_API BOOL HashTable_SetItemValue(wHashTable* table, void* key, void* value);
 	WINPR_API int HashTable_GetKeys(wHashTable* table, ULONG_PTR** ppKeys);
+	WINPR_API BOOL HashTable_Foreach(wHashTable* table, HASH_TABLE_FOREACH_FN fn, VOID* arg);
 
 	WINPR_API UINT32 HashTable_PointerHash(void* pointer);
 	WINPR_API BOOL HashTable_PointerCompare(void* pointer1, void* pointer2);

--- a/winpr/libwinpr/utils/test/TestHashTable.c
+++ b/winpr/libwinpr/utils/test/TestHashTable.c
@@ -270,13 +270,160 @@ fail:
 	return rc;
 }
 
+typedef struct
+{
+	wHashTable* table;
+	int strlenCounter;
+	int foreachCalls;
+
+	BOOL test3error;
+} ForeachData;
+
+BOOL foreachFn1(const void* key, void* value, void* arg)
+{
+	ForeachData* d = (ForeachData*)arg;
+	d->strlenCounter += strlen((const char*)value);
+	return TRUE;
+}
+
+BOOL foreachFn2(const void* key, void* value, void* arg)
+{
+	ForeachData* d = (ForeachData*)arg;
+	d->foreachCalls++;
+
+	if (d->foreachCalls == 2)
+		return FALSE;
+	return TRUE;
+}
+
+BOOL foreachFn3(const void* key, void* value, void* arg)
+{
+	char* keyStr = (char*)key;
+
+	ForeachData* d = (ForeachData*)arg;
+	ForeachData d2;
+
+	if (strcmp(keyStr, "key1") == 0)
+	{
+		/* when we pass on key1, let's remove key2 and check that the value is not
+		 * visible anymore (even if has just been marked for removal)*/
+		HashTable_Remove(d->table, "key2");
+
+		if (HashTable_Contains(d->table, "key2"))
+		{
+			d->test3error = TRUE;
+			return FALSE;
+		}
+
+		if (HashTable_ContainsValue(d->table, "value2"))
+		{
+			d->test3error = TRUE;
+			return FALSE;
+		}
+
+		/* number of elements of the table shall be correct too */
+		if (HashTable_Count(d->table) != 2)
+		{
+			d->test3error = TRUE;
+			return FALSE;
+		}
+
+		/* we try recursive HashTable_Foreach */
+		d2.table = d->table;
+		d2.strlenCounter = 0;
+
+		if (!HashTable_Foreach(d->table, foreachFn1, &d2))
+		{
+			d->test3error = TRUE;
+			return FALSE;
+		}
+		if (d2.strlenCounter != 8)
+		{
+			d->test3error = TRUE;
+			return FALSE;
+		}
+	}
+	return TRUE;
+}
+
+int test_hash_foreach(void)
+{
+	ForeachData foreachData;
+	wHashTable* table;
+	int retCode = 0;
+
+	foreachData.table = table = HashTable_New(TRUE);
+	if (!table)
+		return -1;
+
+	table->hash = HashTable_StringHash;
+	table->keyCompare = HashTable_StringCompare;
+	table->valueCompare = HashTable_StringCompare;
+	table->keyClone = HashTable_StringClone;
+	table->valueClone = HashTable_StringClone;
+	table->keyFree = HashTable_StringFree;
+	table->valueFree = HashTable_StringFree;
+
+	if (HashTable_Add(table, key1, val1) < 0 || HashTable_Add(table, key2, val2) < 0 ||
+	    HashTable_Add(table, key3, val3) < 0)
+	{
+		retCode = -2;
+		goto out;
+	}
+
+	/* let's try a first trivial foreach */
+	foreachData.strlenCounter = 0;
+	if (!HashTable_Foreach(table, foreachFn1, &foreachData))
+	{
+		retCode = -10;
+		goto out;
+	}
+	if (foreachData.strlenCounter != 12)
+	{
+		retCode = -11;
+		goto out;
+	}
+
+	/* interrupted foreach */
+	foreachData.foreachCalls = 0;
+	if (HashTable_Foreach(table, foreachFn2, &foreachData))
+	{
+		retCode = -20;
+		goto out;
+	}
+	if (foreachData.foreachCalls != 2)
+	{
+		retCode = -21;
+		goto out;
+	}
+
+	/* let's try a foreach() call that will remove a value from the table in the callback */
+	foreachData.test3error = FALSE;
+	if (!HashTable_Foreach(table, foreachFn3, &foreachData))
+	{
+		retCode = -30;
+		goto out;
+	}
+	if (foreachData.test3error)
+	{
+		retCode = -31;
+		goto out;
+	}
+
+out:
+	HashTable_Free(table);
+	return retCode;
+}
+
 int TestHashTable(int argc, char* argv[])
 {
 	if (test_hash_table_pointer() < 0)
 		return 1;
 
 	if (test_hash_table_string() < 0)
-		return 1;
+		return 2;
 
+	if (test_hash_foreach() < 0)
+		return 3;
 	return 0;
 }


### PR DESCRIPTION
This useful functions allows to browse all value pairs of a hashtable without having to allocate some memory for keys and then retrieving each element.
It may also make sense with synchronized hashtables because before you were forced to `HashTable_GetKeys()` and then `HashTable_GetItemValue()` which is locking again for each element of the table.