### PR TITLE
codec/progressive: Allow the usage of multithreading for decoding

### DIFF
--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -454,6 +454,8 @@ static PROGRESSIVE_SURFACE_CONTEXT* progressive_surface_context_new(UINT16 surfa
 
 	if (!surface->tiles || !surface->updatedTileIndices)
 	{
+		free(surface->updatedTileIndices);
+		free(surface->tiles);
 		free(surface);
 		return NULL;
 	}


### PR DESCRIPTION
Quoting the main commit here:

```
While decoding RemoteFX encoded frames is multithreaded, decoding
RemoteFX Progressive frames is not, although both codecs work
relatively similarly.
This is especially noticeable with frames, that have a resolution
larger than 1920x1080 pixels.

decompress_tile_first() and decompress_tile_upgrade() can both run in
different threads at the same time for different tiles without necessary
adjustments.

So, do exactly that using the ThreadPool that already exists in the
RFX_CONTEXT to decrease the decoding time and therefore increase the
performance.
On a 3K display (2880x1620 pixels) this makes out of a choppy
experience a fluid experience.
```

This fixes a heavy performance regression with the RemoteFX Progressive codec, which the plain RemoteFX codec (when using the graphics pipeline) does not have.
I have tested this on top of the stable-2.0 branch using gnome-remote-desktop (uses TILE_SIMPLE) and Win10 (use TILE_FIRST + TILE_UPGRADE)