### PR TITLE
Replace fopen and path functions with wrappers

### DIFF
--- a/channels/printer/client/cups/printer_cups.c
+++ b/channels/printer/client/cups/printer_cups.c
@@ -33,6 +33,7 @@
 #include <cups/cups.h>
 
 #include <winpr/crt.h>
+#include <winpr/file.h>
 #include <winpr/string.h>
 
 #include <freerdp/channels/rdpdr.h>
@@ -92,7 +93,7 @@ static UINT printer_cups_write_printjob(rdpPrintJob* printjob, const BYTE* data,
 	{
 		FILE* fp;
 
-		fp = fopen((const char*)cups_printjob->printjob_object, "a+b");
+		fp = winpr_fopen((const char*)cups_printjob->printjob_object, "a+b");
 
 		if (!fp)
 			return ERROR_INTERNAL_ERROR;

--- a/channels/printer/client/printer_main.c
+++ b/channels/printer/client/printer_main.c
@@ -83,9 +83,9 @@ static char* get_printer_config_path(const rdpSettings* settings, const WCHAR* n
 	char* bname = crypto_base64_encode((const BYTE*)name, length);
 	char* config = GetCombinedPath(dir, bname);
 
-	if (config && !PathFileExistsA(config))
+	if (config && !winpr_PathFileExists(config))
 	{
-		if (!PathMakePathA(config, NULL))
+		if (!winpr_PathMakePath(config, NULL))
 		{
 			free(config);
 			config = NULL;
@@ -149,7 +149,7 @@ static BOOL printer_config_valid(const char* path)
 	if (!path)
 		return FALSE;
 
-	if (!PathFileExistsA(path))
+	if (!winpr_PathFileExists(path))
 		return FALSE;
 
 	return TRUE;
@@ -265,7 +265,7 @@ static BOOL printer_remove_config(const rdpSettings* settings, const WCHAR* name
 	if (!printer_config_valid(path))
 		goto fail;
 
-	rc = RemoveDirectoryA(path);
+	rc = winpr_RemoveDirectory(path);
 fail:
 	free(path);
 	return rc;
@@ -279,7 +279,7 @@ static BOOL printer_move_config(const rdpSettings* settings, const WCHAR* oldNam
 	char* newPath = get_printer_config_path(settings, newName, newLength);
 
 	if (printer_config_valid(oldPath))
-		rc = MoveFileA(oldPath, newPath);
+		rc = winpr_MoveFile(oldPath, newPath);
 
 	free(oldPath);
 	free(newPath);

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -2705,7 +2705,7 @@ static DWORD WINAPI xf_cliprdr_fuse_thread(LPVOID arg)
 	          GetCurrentProcessId());
 	free(tmpPath);
 
-	if (!PathFileExistsA(basePath) && !PathMakePathA(basePath, 0))
+	if (!winpr_PathFileExists(basePath) && !winpr_PathMakePath(basePath, 0))
 	{
 		WLog_ERR(TAG, "Failed to create directory '%s'", basePath);
 		free(basePath);
@@ -2746,7 +2746,7 @@ static DWORD WINAPI xf_cliprdr_fuse_thread(LPVOID arg)
 #endif
 	fuse_opt_free_args(&args);
 
-	RemoveDirectoryA(clipboard->delegate->basePath);
+	winpr_RemoveDirectory(clipboard->delegate->basePath);
 
 	ExitThread(0);
 	return 0;
@@ -2999,7 +2999,7 @@ void xf_clipboard_free(xfClipboard* clipboard)
 			/* 	not elegant but works for umounting FUSE
 			    fuse_chan must receieve a oper buf to unblock fuse_session_receive_buf function.
 			*/
-			PathFileExistsA(clipboard->delegate->basePath);
+			winpr_PathFileExists(clipboard->delegate->basePath);
 		}
 		WaitForSingleObject(clipboard->fuse_thread, INFINITE);
 		CloseHandle(clipboard->fuse_thread);

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -61,7 +61,7 @@ static BOOL xf_keyboard_action_script_init(xfContext* xfc)
 	char* keyCombination;
 	char buffer[1024] = { 0 };
 	char command[1024] = { 0 };
-	xfc->actionScriptExists = PathFileExistsA(xfc->context.settings->ActionScript);
+	xfc->actionScriptExists = winpr_PathFileExists(xfc->context.settings->ActionScript);
 
 	if (!xfc->actionScriptExists)
 		return FALSE;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -93,7 +93,7 @@ static BOOL freerdp_path_valid(const char* path, BOOL* special)
 	                ? TRUE
 	                : FALSE;
 	if (!isSpecial)
-		isPath = PathFileExistsA(path);
+		isPath = winpr_PathFileExists(path);
 
 	if (special)
 		*special = isSpecial;
@@ -151,9 +151,9 @@ static BOOL freerdp_client_add_drive(rdpSettings* settings, const char* path, co
 	if (name)
 	{
 		/* Path was entered as secondary argument, swap */
-		if (PathFileExistsA(name))
+		if (winpr_PathFileExists(name))
 		{
-			if (!PathFileExistsA(path) || (!PathIsRelativeA(name) && PathIsRelativeA(path)))
+			if (!winpr_PathFileExists(path) || (!PathIsRelativeA(name) && PathIsRelativeA(path)))
 			{
 				const char* tmp = path;
 				path = name;

--- a/client/common/file.c
+++ b/client/common/file.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 
 #include <winpr/string.h>
+#include <winpr/file.h>
 
 #include <freerdp/client/file.h>
 #include <freerdp/client/cmdline.h>
@@ -808,7 +809,7 @@ BOOL freerdp_client_parse_rdp_file_ex(rdpFile* file, const char* name, rdp_file_
 	if (_strnicmp(fname, "file://", 7) == 0)
 		fname = &name[7];
 
-	fp = fopen(fname, "r");
+	fp = winpr_fopen(fname, "r");
 
 	if (!fp)
 	{
@@ -1111,7 +1112,7 @@ BOOL freerdp_client_write_rdp_file(const rdpFile* file, const char* name, BOOL u
 		return FALSE;
 	}
 
-	fp = fopen(name, "w+b");
+	fp = winpr_fopen(name, "w+b");
 
 	if (fp)
 	{

--- a/client/common/test/TestClientRdpFile.c
+++ b/client/common/test/TestClientRdpFile.c
@@ -573,11 +573,11 @@ int TestClientRdpFile(int argc, char* argv[])
 	rc = 0;
 fail:
 	if (utfname)
-		DeleteFileA(utfname);
+		winpr_DeleteFile(utfname);
 	if (uniname)
-		DeleteFileA(uniname);
+		winpr_DeleteFile(uniname);
 	if (base)
-		RemoveDirectoryA(base);
+		winpr_RemoveDirectory(base);
 	free(utfname);
 	free(uniname);
 	free(base);

--- a/libfreerdp/codec/test/TestFreeRDPCodecProgressive.c
+++ b/libfreerdp/codec/test/TestFreeRDPCodecProgressive.c
@@ -6,6 +6,7 @@
 #include <winpr/wlog.h>
 #include <winpr/image.h>
 #include <winpr/sysinfo.h>
+#include <winpr/file.h>
 
 #include <freerdp/codec/region.h>
 
@@ -278,7 +279,7 @@ static BYTE* test_progressive_load_file(const char* path, const char* file, size
 	if (!filename)
 		return NULL;
 
-	fp = fopen(filename, "r");
+	fp = winpr_fopen(filename, "r");
 	free(filename);
 
 	if (!fp)
@@ -1142,7 +1143,7 @@ int TestFreeRDPCodecProgressive(int argc, char* argv[])
 		goto fail;
 	}
 
-	if (PathFileExistsA(ms_sample_path))
+	if (winpr_PathFileExists(ms_sample_path))
 	{
 		/*
 		if (test_progressive_ms_sample(ms_sample_path) < 0)

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -29,6 +29,7 @@
 #include <winpr/print.h>
 #include <winpr/windows.h>
 #include <winpr/ssl.h>
+#include <winpr/file.h>
 
 #include <freerdp/log.h>
 #include <freerdp/client/file.h>
@@ -1132,7 +1133,7 @@ int freerdp_assistance_parse_file(rdpAssistanceFile* file, const char* name, con
 
 	free(file->filename);
 	file->filename = _strdup(name);
-	fp = fopen(name, "r");
+	fp = winpr_fopen(name, "r");
 
 	if (!fp)
 	{

--- a/libfreerdp/core/certificate.c
+++ b/libfreerdp/core/certificate.c
@@ -30,6 +30,7 @@
 
 #include <winpr/wtypes.h>
 #include <winpr/crt.h>
+#include <winpr/file.h>
 #include <winpr/crypto.h>
 
 #include <openssl/pem.h>
@@ -789,7 +790,7 @@ rdpRsaKey* key_new(const char* keyfile)
 	INT64 length;
 	char* buffer = NULL;
 	rdpRsaKey* key = NULL;
-	fp = fopen(keyfile, "rb");
+	fp = winpr_fopen(keyfile, "rb");
 
 	if (!fp)
 	{

--- a/libfreerdp/core/test/TestConnect.c
+++ b/libfreerdp/core/test/TestConnect.c
@@ -194,7 +194,7 @@ static int testSuccess(int port)
 	printf("Sample Server: %s\n", exe);
 	printf("Workspace: %s\n", wpath);
 
-	if (!PathFileExistsA(exe))
+	if (!winpr_PathFileExists(exe))
 		goto fail;
 
 	// Start sample server locally.

--- a/libfreerdp/crypto/test/TestKnownHosts.c
+++ b/libfreerdp/crypto/test/TestKnownHosts.c
@@ -125,7 +125,7 @@ static int prepare(const char* currentFileV2)
 		                    "otherurl\t3389\taa:bb:cc:dd\tsubject2\tissuer2\r" };
 	FILE* fc = NULL;
 	size_t i;
-	fc = fopen(currentFileV2, "w+");
+	fc = winpr_fopen(currentFileV2, "w+");
 
 	if (!fc)
 		goto finish;
@@ -168,7 +168,7 @@ static BOOL setup_config(rdpSettings** settings)
 	path = GetKnownSubPath(KNOWN_PATH_TEMP, sname);
 	if (!path)
 		goto fail;
-	if (!PathFileExistsA(path))
+	if (!winpr_PathFileExists(path))
 	{
 		if (!CreateDirectoryA(path, NULL))
 		{
@@ -437,7 +437,7 @@ finish:
 	printf("certificate_store_free\n");
 	certificate_store_free(store);
 
-	DeleteFileA(currentFileV2);
+	winpr_DeleteFile(currentFileV2);
 	free(currentFileV2);
 
 	return rc;

--- a/libfreerdp/crypto/test/Test_x509_cert_info.c
+++ b/libfreerdp/crypto/test/Test_x509_cert_info.c
@@ -1,3 +1,4 @@
+#include <winpr/file.h>
 #include <freerdp/crypto/crypto.h>
 
 typedef char* (*get_field_pr)(X509*);
@@ -87,7 +88,7 @@ static int TestCertificateFile(const char* certificate_path,
                                const certificate_test_t* certificate_tests, int count)
 {
 	X509* certificate;
-	FILE* certificate_file = fopen(certificate_path, "r");
+	FILE* certificate_file = winpr_fopen(certificate_path, "r");
 	int success = 0;
 	int i;
 

--- a/libfreerdp/utils/pcap.c
+++ b/libfreerdp/utils/pcap.c
@@ -26,6 +26,7 @@
 #include <string.h>
 
 #include <winpr/wtypes.h>
+#include <winpr/file.h>
 #include <winpr/crt.h>
 #include <freerdp/log.h>
 
@@ -177,7 +178,7 @@ rdpPcap* pcap_open(const char* name, BOOL write)
 	pcap->name = _strdup(name);
 	pcap->write = write;
 	pcap->record_count = 0;
-	pcap->fp = fopen(name, write ? "w+b" : "rb");
+	pcap->fp = winpr_fopen(name, write ? "w+b" : "rb");
 
 	if (pcap->fp == NULL)
 		goto fail;

--- a/rdtk/librdtk/rdtk_font.c
+++ b/rdtk/librdtk/rdtk_font.c
@@ -25,6 +25,7 @@
 #include <winpr/wtypes.h>
 #include <winpr/crt.h>
 #include <winpr/path.h>
+#include <winpr/file.h>
 #include <winpr/print.h>
 
 #include "rdtk_engine.h"
@@ -154,7 +155,7 @@ static char* rdtk_font_load_descriptor_file(const char* filename, int* pSize)
 	FILE* fp = NULL;
 	size_t readSize;
 	size_t fileSize;
-	fp = fopen(filename, "r");
+	fp = winpr_fopen(filename, "r");
 
 	if (!fp)
 		return NULL;
@@ -611,10 +612,10 @@ rdtkFont* rdtk_font_new(rdtkEngine* engine, const char* path, const char* file)
 
 	sprintf_s(fontDescriptorFile, length + 8, "%s.xml", fontBaseFile);
 
-	if (!PathFileExistsA(fontImageFile))
+	if (!winpr_PathFileExists(fontImageFile))
 		goto cleanup;
 
-	if (!PathFileExistsA(fontDescriptorFile))
+	if (!winpr_PathFileExists(fontDescriptorFile))
 		goto cleanup;
 
 	font = (rdtkFont*)calloc(1, sizeof(rdtkFont));

--- a/server/Sample/sfreerdp.c
+++ b/server/Sample/sfreerdp.c
@@ -29,6 +29,7 @@
 #include <winpr/crt.h>
 #include <winpr/ssl.h>
 #include <winpr/synch.h>
+#include <winpr/file.h>
 #include <winpr/string.h>
 #include <winpr/path.h>
 #include <winpr/winsock.h>
@@ -254,7 +255,7 @@ static BOOL test_peer_load_icon(freerdp_peer* client)
 		return FALSE;
 	}
 
-	if ((fp = fopen("test_icon.ppm", "r")) == NULL)
+	if ((fp = winpr_fopen("test_icon.ppm", "r")) == NULL)
 	{
 		WLog_ERR(TAG, "Unable to open test icon");
 		return FALSE;

--- a/server/shadow/X11/x11_shadow.c
+++ b/server/shadow/X11/x11_shadow.c
@@ -140,7 +140,7 @@ static BOOL x11_shadow_pam_get_service_name(SHADOW_PAM_AUTH_INFO* info)
 		const char* hint = hints[x];
 
 		_snprintf(path, sizeof(path), "%s/%s", base, hint);
-		if (PathFileExistsA(path))
+		if (winpr_PathFileExists(path))
 		{
 
 			info->service_name = _strdup(hint);

--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -651,7 +651,7 @@ static int shadow_server_init_config_path(rdpShadowServer* server)
 
 		if (userLibraryPath)
 		{
-			if (!PathFileExistsA(userLibraryPath) && !PathMakePathA(userLibraryPath, 0))
+			if (!winpr_PathFileExists(userLibraryPath) && !winpr_PathMakePath(userLibraryPath, 0))
 			{
 				WLog_ERR(TAG, "Failed to create directory '%s'", userLibraryPath);
 				free(userLibraryPath);
@@ -662,8 +662,8 @@ static int shadow_server_init_config_path(rdpShadowServer* server)
 
 			if (userApplicationSupportPath)
 			{
-				if (!PathFileExistsA(userApplicationSupportPath) &&
-				    !PathMakePathA(userApplicationSupportPath, 0))
+				if (!winpr_PathFileExists(userApplicationSupportPath) &&
+				    !winpr_PathMakePath(userApplicationSupportPath, 0))
 				{
 					WLog_ERR(TAG, "Failed to create directory '%s'", userApplicationSupportPath);
 					free(userLibraryPath);
@@ -688,7 +688,7 @@ static int shadow_server_init_config_path(rdpShadowServer* server)
 
 		if (configHome)
 		{
-			if (!PathFileExistsA(configHome) && !PathMakePathA(configHome, 0))
+			if (!winpr_PathFileExists(configHome) && !winpr_PathMakePath(configHome, 0))
 			{
 				WLog_ERR(TAG, "Failed to create directory '%s'", configHome);
 				free(configHome);
@@ -714,7 +714,7 @@ static BOOL shadow_server_init_certificate(rdpShadowServer* server)
 	char* makecert_argv[6] = { "makecert", "-rdp", "-live", "-silent", "-y", "5" };
 	int makecert_argc = (sizeof(makecert_argv) / sizeof(char*));
 
-	if (!PathFileExistsA(server->ConfigPath) && !PathMakePathA(server->ConfigPath, 0))
+	if (!winpr_PathFileExists(server->ConfigPath) && !winpr_PathMakePath(server->ConfigPath, 0))
 	{
 		WLog_ERR(TAG, "Failed to create directory '%s'", server->ConfigPath);
 		return FALSE;
@@ -723,7 +723,7 @@ static BOOL shadow_server_init_certificate(rdpShadowServer* server)
 	if (!(filepath = GetCombinedPath(server->ConfigPath, "shadow")))
 		return FALSE;
 
-	if (!PathFileExistsA(filepath) && !PathMakePathA(filepath, 0))
+	if (!winpr_PathFileExists(filepath) && !winpr_PathMakePath(filepath, 0))
 	{
 		if (!CreateDirectoryA(filepath, 0))
 		{
@@ -738,7 +738,8 @@ static BOOL shadow_server_init_certificate(rdpShadowServer* server)
 	if (!server->CertificateFile || !server->PrivateKeyFile)
 		goto out_fail;
 
-	if ((!PathFileExistsA(server->CertificateFile)) || (!PathFileExistsA(server->PrivateKeyFile)))
+	if ((!winpr_PathFileExists(server->CertificateFile)) ||
+	    (!winpr_PathFileExists(server->PrivateKeyFile)))
 	{
 		makecert = makecert_context_new();
 
@@ -751,13 +752,13 @@ static BOOL shadow_server_init_certificate(rdpShadowServer* server)
 		if (makecert_context_set_output_file_name(makecert, "shadow") != 1)
 			goto out_fail;
 
-		if (!PathFileExistsA(server->CertificateFile))
+		if (!winpr_PathFileExists(server->CertificateFile))
 		{
 			if (makecert_context_output_certificate_file(makecert, filepath) != 1)
 				goto out_fail;
 		}
 
-		if (!PathFileExistsA(server->PrivateKeyFile))
+		if (!winpr_PathFileExists(server->PrivateKeyFile))
 		{
 			if (makecert_context_output_private_key_file(makecert, filepath) != 1)
 				goto out_fail;

--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -766,7 +766,7 @@ static HANDLE FileCreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dw
 			}
 		}
 
-		fp = fopen(pFile->lpFileName, "ab");
+		fp = winpr_fopen(pFile->lpFileName, "ab");
 		if (!fp)
 		{
 			SetLastError(map_posix_err(errno));
@@ -800,7 +800,7 @@ static HANDLE FileCreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dw
 	}
 
 	if (NULL == fp)
-		fp = fopen(pFile->lpFileName, mode);
+		fp = winpr_fopen(pFile->lpFileName, mode);
 
 	pFile->fp = fp;
 	if (!pFile->fp)

--- a/winpr/libwinpr/file/test/TestFileCreateFile.c
+++ b/winpr/libwinpr/file/test/TestFileCreateFile.c
@@ -45,7 +45,7 @@ int TestFileCreateFile(int argc, char* argv[])
 		return -1;
 	}
 
-	if (!PathFileExistsA(name))
+	if (!winpr_PathFileExists(name))
 		rc = -1;
 
 	if (!WriteFile(handle, buffer, sizeof(buffer), &written, NULL))
@@ -81,10 +81,10 @@ int TestFileCreateFile(int argc, char* argv[])
 	if (!CloseHandle(handle))
 		rc = -1;
 
-	if (!DeleteFileA(name))
+	if (!winpr_DeleteFile(name))
 		rc = -1;
 
-	if (PathFileExistsA(name))
+	if (winpr_PathFileExists(name))
 		rc = -1;
 
 	free(name);

--- a/winpr/libwinpr/io/device.c
+++ b/winpr/libwinpr/io/device.c
@@ -135,7 +135,7 @@ NTSTATUS _IoCreateDeviceEx(PDRIVER_OBJECT_EX DriverObject, ULONG DeviceExtension
 	if (!DeviceBasePath)
 		return STATUS_NO_MEMORY;
 
-	if (!PathFileExistsA(DeviceBasePath))
+	if (!winpr_PathFileExists(DeviceBasePath))
 	{
 		if (mkdir(DeviceBasePath, S_IRUSR | S_IWUSR | S_IXUSR) != 0)
 		{
@@ -169,7 +169,7 @@ NTSTATUS _IoCreateDeviceEx(PDRIVER_OBJECT_EX DriverObject, ULONG DeviceExtension
 		return STATUS_NO_MEMORY;
 	}
 
-	if (PathFileExistsA(pDeviceObjectEx->DeviceFileName))
+	if (winpr_PathFileExists(pDeviceObjectEx->DeviceFileName))
 	{
 		if (unlink(pDeviceObjectEx->DeviceFileName) == -1)
 		{

--- a/winpr/libwinpr/path/shell.c
+++ b/winpr/libwinpr/path/shell.c
@@ -221,7 +221,7 @@ static char* GetPath_XDG_CACHE_HOME(void)
 	{
 		path = GetCombinedPath(home, "cache");
 
-		if (!PathFileExistsA(path))
+		if (!winpr_PathFileExists(path))
 			if (!CreateDirectoryA(path, NULL))
 				path = NULL;
 	}
@@ -621,7 +621,7 @@ BOOL PathFileExistsW(LPCWSTR pszPath)
 	if (ConvertFromUnicode(CP_UTF8, 0, pszPath, -1, &lpFileNameA, 0, NULL, NULL) < 1)
 		return FALSE;
 
-	ret = PathFileExistsA(lpFileNameA);
+	ret = winpr_PathFileExists(lpFileNameA);
 	free(lpFileNameA);
 	return ret;
 }

--- a/winpr/libwinpr/path/test/TestPathMakePath.c
+++ b/winpr/libwinpr/path/test/TestPathMakePath.c
@@ -42,7 +42,7 @@ int TestPathMakePath(int argc, char* argv[])
 	}
 
 	printf("Creating path %s\n", path);
-	success = PathMakePathA(path, NULL);
+	success = winpr_PathMakePath(path, NULL);
 
 	if (!success)
 	{
@@ -51,7 +51,7 @@ int TestPathMakePath(int argc, char* argv[])
 		return -1;
 	}
 
-	success = PathFileExistsA(path);
+	success = winpr_PathFileExists(path);
 
 	if (!success)
 	{
@@ -62,9 +62,9 @@ int TestPathMakePath(int argc, char* argv[])
 
 	while (strlen(path) > baseLen)
 	{
-		if (!RemoveDirectoryA(path))
+		if (!winpr_RemoveDirectory(path))
 		{
-			fprintf(stderr, "RemoveDirectoryA %s failed!\n", path);
+			fprintf(stderr, "winpr_RemoveDirectory %s failed!\n", path);
 			free(path);
 			return -1;
 		}

--- a/winpr/libwinpr/pipe/pipe.c
+++ b/winpr/libwinpr/pipe/pipe.c
@@ -636,7 +636,7 @@ HANDLE CreateNamedPipeA(LPCSTR lpName, DWORD dwOpenMode, DWORD dwPipeMode, DWORD
 		if (!(lpPipePath = GetNamedPipeUnixDomainSocketBaseFilePathA()))
 			goto out;
 
-		if (!PathFileExistsA(lpPipePath))
+		if (!winpr_PathFileExists(lpPipePath))
 		{
 			if (!CreateDirectoryA(lpPipePath, 0))
 			{
@@ -649,8 +649,8 @@ HANDLE CreateNamedPipeA(LPCSTR lpName, DWORD dwOpenMode, DWORD dwPipeMode, DWORD
 
 		free(lpPipePath);
 
-		if (PathFileExistsA(pNamedPipe->lpFilePath))
-			DeleteFileA(pNamedPipe->lpFilePath);
+		if (winpr_PathFileExists(pNamedPipe->lpFilePath))
+			winpr_DeleteFile(pNamedPipe->lpFilePath);
 
 		if ((serverfd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
 		{
@@ -842,7 +842,7 @@ BOOL WaitNamedPipeA(LPCSTR lpNamedPipeName, DWORD nTimeOut)
 	status = TRUE;
 	dwSleepInterval = 10;
 
-	while (!PathFileExistsA(lpFilePath))
+	while (!winpr_PathFileExists(lpFilePath))
 	{
 		Sleep(dwSleepInterval);
 		nWaitTime += dwSleepInterval;

--- a/winpr/libwinpr/registry/registry_reg.c
+++ b/winpr/libwinpr/registry/registry_reg.c
@@ -28,6 +28,7 @@
 
 #include <winpr/wtypes.h>
 #include <winpr/crt.h>
+#include <winpr/file.h>
 
 #include "registry_reg.h"
 
@@ -414,14 +415,14 @@ Reg* reg_open(BOOL read_only)
 
 	if (reg->read_only)
 	{
-		reg->fp = fopen(reg->filename, "r");
+		reg->fp = winpr_fopen(reg->filename, "r");
 	}
 	else
 	{
-		reg->fp = fopen(reg->filename, "r+");
+		reg->fp = winpr_fopen(reg->filename, "r+");
 
 		if (!reg->fp)
-			reg->fp = fopen(reg->filename, "w+");
+			reg->fp = winpr_fopen(reg->filename, "w+");
 	}
 
 	if (!reg->fp)

--- a/winpr/libwinpr/sspi/test/TestSchannel.c
+++ b/winpr/libwinpr/sspi/test/TestSchannel.c
@@ -562,7 +562,7 @@ static int dump_test_certificate_files(void)
 	if (!fullpath)
 		return -1;
 
-	fp = fopen(fullpath, "w+");
+	fp = winpr_fopen(fullpath, "w+");
 	if (fp)
 	{
 		if (fwrite((void*)test_localhost_crt, sizeof(test_localhost_crt), 1, fp) != 1)
@@ -578,7 +578,7 @@ static int dump_test_certificate_files(void)
 	fullpath = GetCombinedPath("/tmp", "localhost.key");
 	if (!fullpath)
 		return -1;
-	fp = fopen(fullpath, "w+");
+	fp = winpr_fopen(fullpath, "w+");
 	if (fp && fwrite((void*)test_localhost_key, sizeof(test_localhost_key), 1, fp) != 1)
 		goto out_fail;
 

--- a/winpr/libwinpr/thread/process.c
+++ b/winpr/libwinpr/thread/process.c
@@ -126,7 +126,7 @@ static char* FindApplicationPath(char* application)
 	{
 		filename = GetCombinedPath(path, application);
 
-		if (PathFileExistsA(filename))
+		if (winpr_PathFileExists(filename))
 		{
 			break;
 		}

--- a/winpr/libwinpr/timezone/timezone.c
+++ b/winpr/libwinpr/timezone/timezone.c
@@ -24,6 +24,7 @@
 #include <winpr/wtypes.h>
 #include <winpr/timezone.h>
 #include <winpr/crt.h>
+#include <winpr/file.h>
 #include "../log.h"
 
 #define TAG WINPR_TAG("timezone")
@@ -230,9 +231,9 @@ static char* winpr_get_unix_timezone_identifier_from_file(void)
 	FILE* fp;
 	char* tzid = NULL;
 #if defined(__FreeBSD__) || defined(__OpenBSD__)
-	fp = fopen("/var/db/zoneinfo", "r");
+	fp = winpr_fopen("/var/db/zoneinfo", "r");
 #else
-	fp = fopen("/etc/timezone", "r");
+	fp = winpr_fopen("/etc/timezone", "r");
 #endif
 
 	if (NULL == fp)

--- a/winpr/libwinpr/utils/image.c
+++ b/winpr/libwinpr/utils/image.c
@@ -154,7 +154,7 @@ int winpr_bitmap_write(const char* filename, const BYTE* data, int width, int he
 	UINT32 img_size = width * height * (bpp / 8);
 
 	int ret = -1;
-	fp = fopen(filename, "w+b");
+	fp = winpr_fopen(filename, "w+b");
 
 	if (!fp)
 	{

--- a/winpr/libwinpr/utils/lodepng/lodepng.c
+++ b/winpr/libwinpr/utils/lodepng/lodepng.c
@@ -27,6 +27,7 @@ freely, subject to the following restrictions:
 
 #include "lodepng.h"
 #include <winpr/wtypes.h>
+#include <winpr/file.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -367,7 +368,7 @@ unsigned lodepng_load_file(unsigned char** out, size_t* outsize, const char* fil
 	*out = 0;
 	*outsize = 0;
 
-	file = fopen(filename, "rb");
+	file = winpr_fopen(filename, "rb");
 	if (!file)
 		return 78;
 
@@ -397,7 +398,7 @@ unsigned lodepng_save_file(const unsigned char* buffer, size_t buffersize, const
 {
 	FILE* file;
 	int ret = 0;
-	file = fopen(filename, "wb");
+	file = winpr_fopen(filename, "wb");
 	if (!file)
 		return 79;
 	if (fwrite((char*)buffer, 1, buffersize, file) != buffersize)

--- a/winpr/libwinpr/utils/sam.c
+++ b/winpr/libwinpr/utils/sam.c
@@ -29,6 +29,7 @@
 #include <winpr/crt.h>
 #include <winpr/sam.h>
 #include <winpr/print.h>
+#include <winpr/file.h>
 
 #include "../log.h"
 
@@ -89,13 +90,13 @@ WINPR_SAM* SamOpen(const char* filename, BOOL readOnly)
 		filename = WINPR_SAM_FILE;
 
 	if (readOnly)
-		fp = fopen(filename, "r");
+		fp = winpr_fopen(filename, "r");
 	else
 	{
-		fp = fopen(filename, "r+");
+		fp = winpr_fopen(filename, "r+");
 
 		if (!fp)
-			fp = fopen(filename, "w+");
+			fp = winpr_fopen(filename, "w+");
 	}
 
 	if (fp)

--- a/winpr/libwinpr/utils/test/TestImage.c
+++ b/winpr/libwinpr/utils/test/TestImage.c
@@ -1,6 +1,7 @@
 #include <winpr/wtypes.h>
 #include <winpr/crt.h>
 #include <winpr/path.h>
+#include <winpr/file.h>
 #include <winpr/print.h>
 #include <winpr/image.h>
 #include <winpr/environment.h>
@@ -14,7 +15,7 @@ static void* read_image(const char* src, size_t* size)
 	int success = 0;
 	void* a = NULL;
 	INT64 src_size;
-	FILE* fsrc = fopen(src, "rb");
+	FILE* fsrc = winpr_fopen(src, "rb");
 
 	if (!fsrc)
 	{
@@ -155,7 +156,7 @@ static int create_test(const char* src, const char* dst_png, const char* dst_bmp
 	void* buffer = NULL;
 	wImage *image = NULL, *image2 = NULL, *image3 = NULL, *image4 = NULL;
 
-	if (!PathFileExistsA(src))
+	if (!winpr_PathFileExists(src))
 	{
 		fprintf(stderr, "File %s does not exist!", src);
 		return -1;

--- a/winpr/libwinpr/utils/test/TestWLog.c
+++ b/winpr/libwinpr/utils/test/TestWLog.c
@@ -55,7 +55,7 @@ int TestWLog(int argc, char* argv[])
 	WLog_CloseAppender(root);
 
 	if ((wlog_file = GetCombinedPath(tmp_path, "test_w.log")))
-		DeleteFileA(wlog_file);
+		winpr_DeleteFile(wlog_file);
 
 	result = 0;
 out:

--- a/winpr/tools/makecert/makecert.c
+++ b/winpr/tools/makecert/makecert.c
@@ -25,6 +25,7 @@
 #include <winpr/cmdline.h>
 #include <winpr/sysinfo.h>
 #include <winpr/crypto.h>
+#include <winpr/file.h>
 
 #ifdef WITH_OPENSSL
 #include <openssl/crypto.h>
@@ -481,7 +482,7 @@ int makecert_context_output_certificate_file(MAKECERT_CONTEXT* context, char* pa
 	if (!fullpath)
 		goto out_fail;
 
-	fp = fopen(fullpath, "w+");
+	fp = winpr_fopen(fullpath, "w+");
 
 	if (fp)
 	{
@@ -639,7 +640,7 @@ int makecert_context_output_private_key_file(MAKECERT_CONTEXT* context, char* pa
 	if (!fullpath)
 		goto out_fail;
 
-	fp = fopen(fullpath, "w+");
+	fp = winpr_fopen(fullpath, "w+");
 
 	if (!fp)
 		goto out_fail;
@@ -1059,7 +1060,7 @@ int makecert_context_process(MAKECERT_CONTEXT* context, int argc, char** argv)
 
 	if (!context->live)
 	{
-		if (!PathFileExistsA(context->output_path))
+		if (!winpr_PathFileExists(context->output_path))
 		{
 			if (!CreateDirectoryA(context->output_path, NULL))
 				return -1;


### PR DESCRIPTION
Functions like fopen, PathFileExists, PathMakePath need to call
the wide character versions on windows for utf-8 support.
Follow up to https://github.com/FreeRDP/FreeRDP/pull/7038