### PR TITLE
Gracefully handle edge case where clipboard format name is NULL

### DIFF
--- a/winpr/libwinpr/clipboard/clipboard.c
+++ b/winpr/libwinpr/clipboard/clipboard.c
@@ -89,6 +89,9 @@ static wClipboardFormat* ClipboardFindFormat(wClipboard* clipboard, UINT32 forma
 	{
 		for (index = 0; index < clipboard->numFormats; index++)
 		{
+			if (!clipboard->formats[index].formatName)
+				continue;
+
 			if (strcmp(name, clipboard->formats[index].formatName) == 0)
 			{
 				format = &clipboard->formats[index];


### PR DESCRIPTION
The ClipboardFindFormat function does not gracefully handle a null format name in the format list - this is an edge case we've managed to hit on our side. This pull request simply skips over format entries that have a null format name when searching by name, instead of crashing in the strcmp call that follows.