### PR TITLE
Add WLog locks to prevent logger initialization race conditions

### DIFF
--- a/winpr/libwinpr/utils/wlog/wlog.h
+++ b/winpr/libwinpr/utils/wlog/wlog.h
@@ -78,6 +78,7 @@ struct _wLog
 	wLog** Children;
 	DWORD ChildrenCount;
 	DWORD ChildrenSize;
+	CRITICAL_SECTION lock;
 };
 
 BOOL WLog_Layout_GetMessagePrefix(wLog* log, wLogLayout* layout, wLogMessage* message);


### PR DESCRIPTION
WLog uses a root logger singleton with a list of child loggers. While the initialization of the root logger is protected against race conditions with the usage of an init-once function, the creation and initialization of child loggers is not safe against conditions. We've seen cases where multiple loggers were created around the same time, resulting in a corrupted list of child loggers.

This pull request adds a critical section to protect operations dealing with the list of child loggers. The critical section is only used when needed to avoid a performance degradation for regular calls (basically when adding a child logger, or when finding a child logger). This fix has been used for years on our side without issues.