### PR TITLE
Avoid seeking when reading Android timezone identifier 'file'

### DIFF
--- a/winpr/libwinpr/timezone/timezone.c
+++ b/winpr/libwinpr/timezone/timezone.c
@@ -53,35 +53,42 @@ static UINT64 winpr_windows_gmtime(void)
 
 static char* winpr_read_unix_timezone_identifier_from_file(FILE* fp)
 {
-	INT64 length;
-	char* tzid = NULL;
+	const INT CHUNK_SIZE = 32;
+	INT64 rc, read = 0, length = CHUNK_SIZE;
+	char *tmp, *tzid = NULL;
 
-	if (_fseeki64(fp, 0, SEEK_END) != 0)
-		return NULL;
-
-	length = _ftelli64(fp);
-
-	if (_fseeki64(fp, 0, SEEK_SET) != 0)
-		return NULL;
-
-	if (length < 2)
-		return NULL;
-
-	tzid = (char*)malloc((size_t)length + 1);
-
+	tzid = (char*)malloc(length);
 	if (!tzid)
 		return NULL;
 
-	if (fread(tzid, (size_t)length, 1, fp) != 1)
+	do
+	{
+		rc = fread(tzid + read, 1, length - read - 1, fp);
+		read += rc;
+
+		if (read < (length - 1))
+			break;
+
+		length += CHUNK_SIZE;
+		tmp = (char*)realloc(tzid, length);
+		if (!tmp)
+		{
+			free(tzid);
+			return NULL;
+		}
+
+		tzid = tmp;
+	} while (rc > 0);
+
+	if (ferror(fp))
 	{
 		free(tzid);
 		return NULL;
 	}
 
-	tzid[length] = '\0';
-
-	if (tzid[length - 1] == '\n')
-		tzid[length - 1] = '\0';
+	tzid[read] = '\0';
+	if (tzid[read - 1] == '\n')
+		tzid[read - 1] = '\0';
 
 	return tzid;
 }


### PR DESCRIPTION
winpr_read_unix_timezone_identifier_from_file takes a file pointer to read a "file" by seeking to the end and allocating a buffer that fits. The only problem is that not all code paths return a file handle that you can seek, resulting in deadlocks on some Android devices. The Android timezone detection code on Android tries using JNI and fallbacks to calling `popen("getprop persist.sys.timezone", "r");` to obtain a file pointer, but that file pointer cannot be seeked, leading to the issue. A long time ago I think the original code was doing a loop + realloc to read the buffer by chunks and it was changed to use seek calls, this pull request basically restores that old code to read by chunks and avoid seeking.