### PR TITLE
Remove thread-local storage iOS verbose warning, clarify usage restrictions

### DIFF
--- a/winpr/include/winpr/winpr.h
+++ b/winpr/include/winpr/winpr.h
@@ -55,7 +55,9 @@
 #define WINPR_DEPRECATED(obj) obj
 #endif
 
-/* Thread local storage keyword define */
+// WARNING: *do not* use thread-local storage for new code because it is not portable
+// It is only used for VirtualChannelInit, and all FreeRDP channels use VirtualChannelInitEx
+// The old virtual channel API is only realistically used on Windows where TLS is available
 #if defined _WIN32 || defined __CYGWIN__
 #ifdef __GNUC__
 #define WINPR_TLS __thread
@@ -65,8 +67,8 @@
 #elif !defined(__IOS__)
 #define WINPR_TLS __thread
 #else
-#warning "Target iOS does not support Thread Local Storage!"
-#warning "Multi Instance support is disabled!"
+// thread-local storage is not supported on iOS
+// don't warn because it isn't actually used on iOS
 #define WINPR_TLS
 #endif
 


### PR DESCRIPTION
Thread-local storage is not portable, and therefore should be avoided at all costs. We've had a nasty warning in iOS builds for years that is repeated every time the winpr.h header is included (that means a lot), which unfortunately pollutes CI build logs.

I have removed the warning but also added a comment regarding how to use thread-local storage: basically don't, except for the current code. It is only really needed for VirtualChannelInit, and we use VirtualChannelInitEx anyway for all of our virtual channels. The only platform where we have a chance of loading a plugin using the old VirtualChannelInit interface is Windows, and Windows supports thread-local storage anyway.

Maybe @akallabeth recalls that time years ago when the thread-local storage issue came up, we solved the issue by using VirtualChannelInitEx instead of VirtualChannelInit in FreeRDP, allowing us to avoid the need for thread-local storage. Aside from portability issues, we cannot assume that a particular threading strategy is used with FreeRDP, because it can be used from other languages like C# where the threading is not so easily controlled.

Last but not least: it is absolutely critical that we *never* break support for multiple connection instances in FreeRDP. We use the library in Remote Desktop Manager for Windows, macOS, Linux, Android and iOS, all we need to support concurrent RDP connections on all of those platforms. I am quite positive that FreeRDP is used in a lot of other connection managers that need to support concurrent connections as well.