### PR TITLE
Fix Android ARM64 NEON enabling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,6 +598,12 @@ if(ANDROID)
 		set (WITH_NEON OFF)
 	endif()
 
+	if(ANDROID_ABI STREQUAL arm64-v8a)
+		# https://github.com/android/ndk/issues/910
+		add_definitions(-D__ARM_NEON__)
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfloat-abi=softfp")
+	endif()
+
 	if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 		add_definitions(-DNDK_DEBUG=1)
 


### PR DESCRIPTION
Enabling Android ARM64 NEON has always been a bit tricky, unfortunately the fix I did some time ago still appears required, otherwise `__ARM_NEON__` doesn't get defined and breaks rfx_neon.c with WITH_NEON=ON.