### PR TITLE
Fix broken channel addin.h relative include path

### DIFF
--- a/channels/cliprdr/client/cliprdr_main.c
+++ b/channels/cliprdr/client/cliprdr_main.c
@@ -32,7 +32,7 @@
 #include <freerdp/constants.h>
 #include <freerdp/client/cliprdr.h>
 
-#include "../../channels/client/addin.h"
+#include "../../../channels/client/addin.h"
 
 #include "cliprdr_main.h"
 #include "cliprdr_format.h"

--- a/channels/rail/client/rail_main.c
+++ b/channels/rail/client/rail_main.c
@@ -35,7 +35,7 @@
 #include "rail_orders.h"
 #include "rail_main.h"
 
-#include "../../channels/client/addin.h"
+#include "../../../channels/client/addin.h"
 
 RailClientContext* rail_get_client_interface(railPlugin* rail)
 {


### PR DESCRIPTION
This is one leaves me a bit perplexed: when building FreeRDP and WinPR separately, I got errors with the relative addin.h include done in two virtual channels. When I looked closely at the relative path, they were off by one parent directory (one missing ".."). I believe it may have worked by accident due to some other directory being added to the include path, but the real relative path is the one I've changed it to, and it fixes the build.