### PR TITLE
Windows ARM64 build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,12 +454,6 @@ if(MSVC)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Gd")
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W3")
 
-	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-		add_definitions(-D_AMD64_)
-	else()
-		add_definitions(-D_X86_)
-	endif()
-
 	set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR})
 	set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR})
 

--- a/winpr/include/winpr/collections.h
+++ b/winpr/include/winpr/collections.h
@@ -117,7 +117,7 @@ extern "C"
 
 	WINPR_API wObject* ArrayList_Object(wArrayList* arrayList);
 
-	typedef BOOL(ArrayList_ForEachFkt)(void* data, size_t index, va_list ap);
+	typedef BOOL(*ArrayList_ForEachFkt)(void* data, size_t index, va_list ap);
 
 	WINPR_API BOOL ArrayList_ForEach(wArrayList* arrayList, ArrayList_ForEachFkt fkt, ...);
 

--- a/winpr/libwinpr/utils/collections/ArrayList.c
+++ b/winpr/libwinpr/utils/collections/ArrayList.c
@@ -485,7 +485,7 @@ BOOL ArrayList_ForEach(wArrayList* arrayList, ArrayList_ForEachFkt fkt, ...)
 
 	ArrayList_Lock_Conditional(arrayList);
 	count = ArrayList_Count(arrayList);
-	va_start(ap, (void*)fkt);
+	va_start(ap, fkt);
 	for (index = 0; index < count; index++)
 	{
 		void* obj = ArrayList_GetItem(arrayList, index);


### PR DESCRIPTION
Good news: FreeRDP/WinPR builds for Windows on ARM (Surface Pro X)!

There are two tiny little things to fix:
- Avoid defining `_AMD64_` and `_X86_` based on pointer size. It's not even needed and breaks Windows ARM64.
- The va_start macro doesn't accept the type cast in parameters, but it turns out we don't need it: the ArrayList_ForEachFkt callback type definition didn't use the `(*MY_CALLBACK)` notation used everywhere else.

That's it, it builds just fine now for Windows on ARM.