### PR TITLE
Fixed issues with planar codec buffer alignment

### DIFF
--- a/libfreerdp/codec/planar.c
+++ b/libfreerdp/codec/planar.c
@@ -33,6 +33,8 @@
 
 #define TAG FREERDP_TAG("codec")
 
+#define ALIGN(val, align) ((val) % (align) == 0) ? (val) : ((val) + (align) - (val) % (align))
+
 static INLINE UINT32 planar_invert_format(BITMAP_PLANAR_CONTEXT* planar, BOOL alpha,
                                           UINT32 DstFormat)
 {
@@ -1483,8 +1485,8 @@ BOOL freerdp_bitmap_planar_context_reset(BITMAP_PLANAR_CONTEXT* context, UINT32 
 		return FALSE;
 
 	context->bgr = FALSE;
-	context->maxWidth = width;
-	context->maxHeight = height;
+	context->maxWidth = ALIGN(width, 4);
+	context->maxHeight = ALIGN(height, 4);
 	context->maxPlaneSize = context->maxWidth * context->maxHeight;
 	context->nTempStep = context->maxWidth * 4;
 	free(context->planesBuffer);


### PR DESCRIPTION
Align width and height to next multiple of 4 to avoid issues with
internal buffer sizes.
@antenore @pnowack please confirm I understood https://gitlab.com/Remmina/Remmina/-/issues/2507 correctly.