### PR TITLE
Test speedup

### DIFF
--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -900,6 +900,7 @@ typedef struct _RDPDR_PARALLEL RDPDR_PARALLEL;
 #define FreeRDP_TcpAckTimeout (5194)
 #define FreeRDP_ActionScript (5195)
 #define FreeRDP_Floatbar (5196)
+#define FreeRDP_TcpConnectTimeout (5197)
 
 /**
  * FreeRDP Settings Data Structure
@@ -1559,7 +1560,8 @@ struct rdp_settings
 	ALIGN64 UINT32 TcpAckTimeout;         /* 5194 */
 	ALIGN64 char* ActionScript;           /* 5195 */
 	ALIGN64 UINT32 Floatbar;              /* 5196 */
-	UINT64 padding5312[5312 - 5197];      /* 5197 */
+	ALIGN64 UINT32 TcpConnectTimeout;     /* 5197 */
+	UINT64 padding5312[5312 - 5198];      /* 5198 */
 
 	/**
 	 * WARNING: End of ABI stable zone!

--- a/libfreerdp/codec/test/TestFreeRDPCodecInterleaved.c
+++ b/libfreerdp/codec/test/TestFreeRDPCodecInterleaved.c
@@ -133,7 +133,7 @@ static BOOL run_encode_decode(UINT16 bpp, BITMAP_INTERLEAVED_CONTEXT* encoder,
 	PROFILER_CREATE(profiler_comp, get_profiler_name(TRUE, bpp))
 	PROFILER_CREATE(profiler_decomp, get_profiler_name(FALSE, bpp))
 
-	for (x = 0; x < 500; x++)
+	for (x = 0; x < 50; x++)
 	{
 		if (!run_encode_decode_single(bpp, encoder, decoder
 #if defined(WITH_PROFILER)

--- a/libfreerdp/codec/test/TestFreeRDPCodecPlanar.c
+++ b/libfreerdp/codec/test/TestFreeRDPCodecPlanar.c
@@ -5547,9 +5547,9 @@ static BOOL RunTestPlanarSingleColor(BITMAP_PLANAR_CONTEXT* planar, const UINT32
 	       FreeRDPGetColorFormatName(dstFormat));
 	fflush(stdout);
 
-	for (j = 0; j < 100; j += 8)
+	for (j = 0; j < 32; j += 8)
 	{
-		for (i = 4; i < 64; i += 8)
+		for (i = 4; i < 32; i += 8)
 		{
 			UINT32 compressedSize;
 			const UINT32 fill = j;
@@ -5670,7 +5670,7 @@ static BOOL FuzzPlanar(void)
 	if (!planar)
 		goto fail;
 
-	for (x = 0; x < 10000; x++)
+	for (x = 0; x < 100; x++)
 	{
 		BYTE data[0x10000] = { 0 };
 		size_t dataSize = 0x10000;

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -1609,6 +1609,9 @@ UINT32 freerdp_settings_get_uint32(const rdpSettings* settings, size_t id)
 		case FreeRDP_TcpAckTimeout:
 			return settings->TcpAckTimeout;
 
+		case FreeRDP_TcpConnectTimeout:
+			return settings->TcpConnectTimeout;
+
 		case FreeRDP_TcpKeepAliveDelay:
 			return settings->TcpKeepAliveDelay;
 
@@ -2065,6 +2068,10 @@ BOOL freerdp_settings_set_uint32(rdpSettings* settings, size_t id, UINT32 val)
 
 		case FreeRDP_TcpAckTimeout:
 			settings->TcpAckTimeout = val;
+			break;
+
+		case FreeRDP_TcpConnectTimeout:
+			settings->TcpConnectTimeout = val;
 			break;
 
 		case FreeRDP_TcpKeepAliveDelay:

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -289,6 +289,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_StaticChannelCount, 3, "FreeRDP_StaticChannelCount" },
 	{ FreeRDP_TargetNetAddressCount, 3, "FreeRDP_TargetNetAddressCount" },
 	{ FreeRDP_TcpAckTimeout, 3, "FreeRDP_TcpAckTimeout" },
+	{ FreeRDP_TcpConnectTimeout, 3, "FreeRDP_TcpConnectTimeout" },
 	{ FreeRDP_TcpKeepAliveDelay, 3, "FreeRDP_TcpKeepAliveDelay" },
 	{ FreeRDP_TcpKeepAliveInterval, 3, "FreeRDP_TcpKeepAliveInterval" },
 	{ FreeRDP_TcpKeepAliveRetries, 3, "FreeRDP_TcpKeepAliveRetries" },

--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -277,6 +277,9 @@ static BOOL nego_tcp_connect(rdpNego* nego)
 {
 	if (!nego->TcpConnected)
 	{
+		const UINT32 TcpConnectTimeout = freerdp_settings_get_uint32(
+		    nego->transport->context->settings, FreeRDP_TcpConnectTimeout);
+
 		if (nego->GatewayEnabled)
 		{
 			if (nego->GatewayBypassLocal)
@@ -286,20 +289,21 @@ static BOOL nego_tcp_connect(rdpNego* nego)
 				          "Detecting if host can be reached locally. - This might take some time.");
 				WLog_INFO(TAG, "To disable auto detection use /gateway-usage-method:direct");
 				transport_set_gateway_enabled(nego->transport, FALSE);
-				nego->TcpConnected =
-				    transport_connect(nego->transport, nego->hostname, nego->port, 1);
+				nego->TcpConnected = transport_connect(nego->transport, nego->hostname, nego->port,
+				                                       TcpConnectTimeout);
 			}
 
 			if (!nego->TcpConnected)
 			{
 				transport_set_gateway_enabled(nego->transport, TRUE);
-				nego->TcpConnected =
-				    transport_connect(nego->transport, nego->hostname, nego->port, 15);
+				nego->TcpConnected = transport_connect(nego->transport, nego->hostname, nego->port,
+				                                       TcpConnectTimeout);
 			}
 		}
 		else
 		{
-			nego->TcpConnected = transport_connect(nego->transport, nego->hostname, nego->port, 15);
+			nego->TcpConnected =
+			    transport_connect(nego->transport, nego->hostname, nego->port, TcpConnectTimeout);
 		}
 	}
 

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -606,7 +606,8 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	    !freerdp_settings_set_uint32(settings, FreeRDP_TcpKeepAliveRetries, 3) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_TcpKeepAliveDelay, 5) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_TcpKeepAliveInterval, 2) ||
-	    !freerdp_settings_set_uint32(settings, FreeRDP_TcpAckTimeout, 9000))
+	    !freerdp_settings_set_uint32(settings, FreeRDP_TcpAckTimeout, 9000) ||
+	    !freerdp_settings_set_uint32(settings, FreeRDP_TcpConnectTimeout, 15000))
 		goto out_fail;
 
 	if (!freerdp_settings_get_bool(settings, FreeRDP_ServerMode))

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -803,14 +803,14 @@ static BOOL freerdp_tcp_is_hostname_resolvable(rdpContext* context, const char* 
 }
 
 static BOOL freerdp_tcp_connect_timeout(rdpContext* context, int sockfd, struct sockaddr* addr,
-                                        socklen_t addrlen, int timeout)
+                                        socklen_t addrlen, UINT32 timeout)
 {
 	BOOL rc = FALSE;
 	HANDLE handles[2];
 	int status = 0;
 	int count = 0;
 	u_long arg = 0;
-	DWORD tout = (timeout > 0) ? (DWORD)timeout * 1000U : INFINITE;
+	DWORD tout = (timeout > 0) ? timeout : INFINITE;
 
 	handles[count] = CreateEvent(NULL, TRUE, FALSE, NULL);
 
@@ -896,7 +896,7 @@ static void peer_free(t_peer* peer)
 }
 
 static int freerdp_tcp_connect_multi(rdpContext* context, char** hostnames, UINT32* ports,
-                                     UINT32 count, int port, int timeout)
+                                     UINT32 count, UINT16 port, UINT32 timeout)
 {
 	UINT32 index;
 	UINT32 sindex = count;

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -286,6 +286,7 @@ static const size_t uint32_list_indices[] = {
 	FreeRDP_StaticChannelCount,
 	FreeRDP_TargetNetAddressCount,
 	FreeRDP_TcpAckTimeout,
+	FreeRDP_TcpConnectTimeout,
 	FreeRDP_TcpKeepAliveDelay,
 	FreeRDP_TcpKeepAliveInterval,
 	FreeRDP_TcpKeepAliveRetries,

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -112,7 +112,7 @@ static UINT gdi_ResetGraphics(RdpgfxClientContext* context,
 		if (!surface)
 			continue;
 
-		memset(surface->data, 0xFF, surface->scanline * surface->height);
+		memset(surface->data, 0xFF, (size_t)surface->scanline * surface->height);
 		if (!surface->outputMapped)
 			continue;
 
@@ -1037,7 +1037,7 @@ static UINT gdi_CreateSurface(RdpgfxClientContext* context,
 		goto fail;
 	}
 
-	memset(surface->data, 0xFF, surface->scanline * surface->height);
+	memset(surface->data, 0xFF, (size_t)surface->scanline * surface->height);
 	surface->outputMapped = FALSE;
 	region16_init(&surface->invalidRegion);
 	rc = context->SetSurfaceData(context, surface->surfaceId, (void*)surface);

--- a/libfreerdp/gdi/test/helpers.c
+++ b/libfreerdp/gdi/test/helpers.c
@@ -57,6 +57,7 @@ static void test_dump_data(unsigned char* p, int len, int width, const char* nam
 {
 	unsigned char* line = p;
 	int i, thisline, offset = 0;
+	return; // TODO: Activate this manually if required. Improves test speed
 	printf("\n%s[%d][%d]:\n", name, len / width, width);
 
 	while (offset < len)

--- a/libfreerdp/primitives/test/TestPrimitivesColors.c
+++ b/libfreerdp/primitives/test/TestPrimitivesColors.c
@@ -263,7 +263,7 @@ int TestPrimitivesColors(int argc, char* argv[])
 		                      PIXEL_FORMAT_XBGR32, PIXEL_FORMAT_RGBA32, PIXEL_FORMAT_RGBX32,
 		                      PIXEL_FORMAT_BGRA32, PIXEL_FORMAT_BGRX32 };
 	DWORD x;
-	prim_size_t roi = { 1920, 1080 };
+	prim_size_t roi = { 1920 / 4, 1080 / 4 };
 	WINPR_UNUSED(argc);
 	WINPR_UNUSED(argv);
 	prim_test_setup(FALSE);

--- a/libfreerdp/primitives/test/TestPrimitivesYCbCr.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYCbCr.c
@@ -1720,6 +1720,8 @@ int TestPrimitivesYCbCr(int argc, char* argv[])
 	const primitives_t* generics = primitives_get_generic();
 	UINT32 x;
 
+	WINPR_UNUSED(argv);
+
 	if (argc < 2)
 	{
 		{
@@ -1757,13 +1759,13 @@ int TestPrimitivesYCbCr(int argc, char* argv[])
 			do
 			{
 				winpr_RAND((BYTE*)&roi.width, sizeof(roi.width));
-				roi.width %= 2048;
+				roi.width %= 2048 / 4;
 			} while (roi.width < 16);
 
 			do
 			{
 				winpr_RAND((BYTE*)&roi.height, sizeof(roi.height));
-				roi.height %= 2048;
+				roi.height %= 2048 / 4;
 			} while (roi.height < 16);
 
 			for (x = 0; x < sizeof(formats) / sizeof(formats[0]); x++)
@@ -1795,7 +1797,7 @@ int TestPrimitivesYCbCr(int argc, char* argv[])
 	/* Do a performance run with full HD */
 	else
 	{
-		prim_size_t roi = { 1928, 1080 };
+		prim_size_t roi = { 1928 / 8, 1080 / 8 };
 
 		for (x = 0; x < sizeof(formats) / sizeof(formats[0]); x++)
 		{

--- a/libfreerdp/primitives/test/TestPrimitivesYCoCg.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYCoCg.c
@@ -127,13 +127,13 @@ int TestPrimitivesYCoCg(int argc, char* argv[])
 			do
 			{
 				winpr_RAND((BYTE*)&w, sizeof(w));
-				w %= 2048;
+				w %= 2048 / 4;
 			} while (w < 16);
 
 			do
 			{
 				winpr_RAND((BYTE*)&h, sizeof(h));
-				h %= 2048;
+				h %= 2048 / 4;
 			} while (h < 16);
 
 			if (!test_YCoCgRToRGB_8u_AC4R_func(w, h))
@@ -141,8 +141,8 @@ int TestPrimitivesYCoCg(int argc, char* argv[])
 		}
 	}
 
-	/* Test once with full HD */
-	if (!test_YCoCgRToRGB_8u_AC4R_func(1920, 1080))
+	/* Test once with full HD/4 */
+	if (!test_YCoCgRToRGB_8u_AC4R_func(1920 / 4, 1080 / 4))
 		return 1;
 
 	return 0;

--- a/libfreerdp/primitives/test/TestPrimitivesYUV.c
+++ b/libfreerdp/primitives/test/TestPrimitivesYUV.c
@@ -863,7 +863,7 @@ int TestPrimitivesYUV(int argc, char* argv[])
 	prim_test_setup(FALSE);
 	primitives_t* prims = primitives_get();
 
-	for (x = 0; x < 10; x++)
+	for (x = 0; x < 5; x++)
 	{
 		prim_size_t roi;
 

--- a/winpr/libwinpr/error/test/TestErrorSetLastError.c
+++ b/winpr/libwinpr/error/test/TestErrorSetLastError.c
@@ -41,7 +41,7 @@ static DWORD WINAPI test_error_thread(LPVOID arg)
 
 	do
 	{
-		dwErrorSet = (DWORD)rand();
+		dwErrorSet = (DWORD)abs(rand()) + 1;
 		SetLastError(dwErrorSet);
 		if ((dwErrorGet = GetLastError()) != dwErrorSet)
 		{
@@ -63,6 +63,9 @@ int TestErrorSetLastError(int argc, char* argv[])
 	DWORD error;
 	HANDLE threads[4];
 	int i;
+
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
 
 	/* We must initialize WLog here. It will check for settings
 	 * in the environment and if the variables are not set, the last
@@ -97,8 +100,8 @@ int TestErrorSetLastError(int argc, char* argv[])
 		}
 	}
 
-	// let the threads run for at least 2 seconds
-	Sleep(2000);
+	// let the threads run for at least 0.2 seconds
+	Sleep(200);
 	bStopTest = TRUE;
 
 	WaitForSingleObject(threads[0], INFINITE);

--- a/winpr/libwinpr/synch/test/TestSynchBarrier.c
+++ b/winpr/libwinpr/synch/test/TestSynchBarrier.c
@@ -11,7 +11,7 @@ static SYNCHRONIZATION_BARRIER gBarrier;
 static HANDLE gStartEvent = NULL;
 static LONG gErrorCount = 0;
 
-#define MAX_SLEEP_MS 32
+#define MAX_SLEEP_MS 22
 
 struct test_params
 {
@@ -181,7 +181,7 @@ int TestSynchBarrier(int argc, char* argv[])
 	SYSTEM_INFO sysinfo;
 	DWORD dwMaxThreads;
 	DWORD dwMinThreads;
-	DWORD dwNumLoops = 200;
+	DWORD dwNumLoops = 10;
 
 	WINPR_UNUSED(argc);
 	WINPR_UNUSED(argv);

--- a/winpr/libwinpr/synch/test/TestSynchCritical.c
+++ b/winpr/libwinpr/synch/test/TestSynchCritical.c
@@ -7,7 +7,7 @@
 #include <winpr/thread.h>
 #include <winpr/interlocked.h>
 
-#define TEST_SYNC_CRITICAL_TEST1_RUNTIME_MS 500
+#define TEST_SYNC_CRITICAL_TEST1_RUNTIME_MS 50
 #define TEST_SYNC_CRITICAL_TEST1_RUNS 4
 
 static CRITICAL_SECTION critical;
@@ -86,6 +86,7 @@ static DWORD WINAPI TestSynchCritical_Test1(LPVOID arg)
  */
 static DWORD WINAPI TestSynchCritical_Test2(LPVOID arg)
 {
+	WINPR_UNUSED(arg);
 	if (TryEnterCriticalSection(&critical) == TRUE)
 	{
 		LeaveCriticalSection(&critical);
@@ -155,7 +156,7 @@ static DWORD WINAPI TestSynchCritical_Main(LPVOID arg)
 
 	InitializeCriticalSection(&critical);
 
-	for (i = 0; i < 1000; i++)
+	for (i = 0; i < 10; i++)
 	{
 		if (critical.RecursionCount != i)
 		{
@@ -216,7 +217,7 @@ static DWORD WINAPI TestSynchCritical_Main(LPVOID arg)
 
 	for (j = 0; j < TEST_SYNC_CRITICAL_TEST1_RUNS; j++)
 	{
-		dwSpinCount = j * 1000;
+		dwSpinCount = j * 100;
 		InitializeCriticalSectionAndSpinCount(&critical, dwSpinCount);
 
 		gTestValueVulnerable = 0;
@@ -319,7 +320,7 @@ int TestSynchCritical(int argc, char* argv[])
 	WINPR_UNUSED(argv);
 
 	dwDeadLockDetectionTimeMs =
-	    6 * TEST_SYNC_CRITICAL_TEST1_RUNTIME_MS * TEST_SYNC_CRITICAL_TEST1_RUNS;
+	    2 * TEST_SYNC_CRITICAL_TEST1_RUNTIME_MS * TEST_SYNC_CRITICAL_TEST1_RUNS;
 
 	printf("Deadlock will be assumed after %" PRIu32 " ms.\n", dwDeadLockDetectionTimeMs);
 
@@ -337,12 +338,12 @@ int TestSynchCritical(int argc, char* argv[])
 	 * Workaround checking the value of bThreadTerminated which is passed in the thread arg
 	 */
 
-	for (i = 0; i < dwDeadLockDetectionTimeMs; i += 100)
+	for (i = 0; i < dwDeadLockDetectionTimeMs; i += 10)
 	{
 		if (bThreadTerminated)
 			break;
 
-		Sleep(100);
+		Sleep(10);
 	}
 
 	if (!bThreadTerminated)

--- a/winpr/libwinpr/synch/test/TestSynchInit.c
+++ b/winpr/libwinpr/synch/test/TestSynchInit.c
@@ -19,8 +19,12 @@ static BOOL CALLBACK TestOnceFunction(PINIT_ONCE once, PVOID param, PVOID* conte
 {
 	LONG calls = InterlockedIncrement(pTestOnceFunctionCalls) - 1;
 
+	WINPR_UNUSED(once);
+	WINPR_UNUSED(param);
+	WINPR_UNUSED(context);
+
 	/* simulate execution time */
-	Sleep(100 + rand() % 400);
+	Sleep(30 + rand() % 40);
 
 	if (calls < TEST_NUM_FAILURES)
 	{
@@ -40,6 +44,9 @@ static DWORD WINAPI TestThreadFunction(LPVOID lpParam)
 {
 	LONG calls;
 	BOOL ok;
+
+	WINPR_UNUSED(lpParam);
+
 	InterlockedIncrement(pTestThreadFunctionCalls);
 	if (WaitForSingleObject(hStartEvent, INFINITE) != WAIT_OBJECT_0)
 	{
@@ -64,6 +71,9 @@ int TestSynchInit(int argc, char* argv[])
 	DWORD dwCreatedThreads = 0;
 	DWORD i;
 	BOOL result = FALSE;
+
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
 
 	pErrors = _aligned_malloc(sizeof(LONG), sizeof(LONG));
 	pTestThreadFunctionCalls = _aligned_malloc(sizeof(LONG), sizeof(LONG));

--- a/winpr/libwinpr/synch/test/TestSynchMultipleThreads.c
+++ b/winpr/libwinpr/synch/test/TestSynchMultipleThreads.c
@@ -9,7 +9,7 @@
 
 static DWORD WINAPI test_thread(LPVOID arg)
 {
-	long timeout = 300 + (rand() % 1000);
+	long timeout = 30 + (rand() % 100);
 	WINPR_UNUSED(arg);
 	Sleep(timeout);
 	ExitThread(0);
@@ -62,7 +62,7 @@ static BOOL TestWaitForAll(void)
 		return FALSE;
 	}
 
-	ret = WaitForMultipleObjects(THREADS, threads, TRUE, 50);
+	ret = WaitForMultipleObjects(THREADS, threads, TRUE, 10);
 	if (ret != WAIT_TIMEOUT)
 	{
 		fprintf(stderr, "%s: WaitForMultipleObjects bWaitAll, timeout 50 failed, ret=%d\n",
@@ -135,7 +135,7 @@ static BOOL TestWaitOneTimeout(void)
 		return FALSE;
 	}
 
-	ret = WaitForMultipleObjects(THREADS, threads, FALSE, 50);
+	ret = WaitForMultipleObjects(THREADS, threads, FALSE, 10);
 	if (ret != WAIT_TIMEOUT)
 	{
 		fprintf(stderr, "%s: WaitForMultipleObjects timeout 50 failed, ret=%d\n", __FUNCTION__,

--- a/winpr/libwinpr/synch/test/TestSynchThread.c
+++ b/winpr/libwinpr/synch/test/TestSynchThread.c
@@ -5,7 +5,8 @@
 
 static DWORD WINAPI test_thread(LPVOID arg)
 {
-	Sleep(1000);
+	WINPR_UNUSED(arg);
+	Sleep(100);
 	ExitThread(0);
 	return 0;
 }
@@ -14,6 +15,10 @@ int TestSynchThread(int argc, char* argv[])
 {
 	DWORD rc;
 	HANDLE thread;
+
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+
 	thread = CreateThread(NULL, 0, test_thread, NULL, 0, NULL);
 
 	if (!thread)
@@ -64,7 +69,7 @@ int TestSynchThread(int argc, char* argv[])
 	}
 
 	/* TryJoin should now fail. */
-	rc = WaitForSingleObject(thread, 50);
+	rc = WaitForSingleObject(thread, 10);
 
 	if (WAIT_TIMEOUT != rc)
 	{

--- a/winpr/libwinpr/synch/test/TestSynchWaitableTimer.c
+++ b/winpr/libwinpr/synch/test/TestSynchWaitableTimer.c
@@ -19,7 +19,7 @@ int TestSynchWaitableTimer(int argc, char* argv[])
 		goto out;
 	}
 
-	due.QuadPart = -15000000LL; /* 1.5 seconds */
+	due.QuadPart = -1500000LL; /* 0.15 seconds */
 
 	if (!SetWaitableTimer(timer, &due, 0, NULL, NULL, 0))
 	{
@@ -36,18 +36,18 @@ int TestSynchWaitableTimer(int argc, char* argv[])
 	}
 
 	printf("Timer Signaled\n");
-	status = WaitForSingleObject(timer, 2000);
+	status = WaitForSingleObject(timer, 200);
 
 	if (status != WAIT_TIMEOUT)
 	{
-		printf("WaitForSingleObject(timer, 2000) failure: Actual: 0x%08" PRIX32
+		printf("WaitForSingleObject(timer, 200) failure: Actual: 0x%08" PRIX32
 		       ", Expected: 0x%08X\n",
 		       status, WAIT_TIMEOUT);
 		goto out;
 	}
 
 	due.QuadPart = 0;
-	period = 1200; /* 1.2 seconds */
+	period = 120; /* 0.12 seconds */
 
 	if (!SetWaitableTimer(timer, &due, period, NULL, NULL, 0))
 	{

--- a/winpr/libwinpr/synch/test/TestSynchWaitableTimerAPC.c
+++ b/winpr/libwinpr/synch/test/TestSynchWaitableTimerAPC.c
@@ -54,15 +54,15 @@ int TestSynchWaitableTimerAPC(int argc, char* argv[])
 	if (!hTimer)
 		goto cleanup;
 
-	due.QuadPart = -1000 * 1000LL; /* 1 seconds */
+	due.QuadPart = -1000 * 100LL; /* 0.1 seconds */
 	apcData.StartTime = GetTickCount();
-	bSuccess = SetWaitableTimer(hTimer, &due, 100, TimerAPCProc, &apcData, FALSE);
+	bSuccess = SetWaitableTimer(hTimer, &due, 10, TimerAPCProc, &apcData, FALSE);
 
 	if (!bSuccess)
 		goto cleanup;
 
-	/* nothing shall happen after 1.2 second, because thread is not in alertable state */
-	rc = WaitForSingleObject(g_Event, 1200);
+	/* nothing shall happen after 0.12 second, because thread is not in alertable state */
+	rc = WaitForSingleObject(g_Event, 120);
 	if (rc != WAIT_TIMEOUT)
 		goto cleanup;
 

--- a/winpr/libwinpr/thread/test/TestThreadExitThread.c
+++ b/winpr/libwinpr/thread/test/TestThreadExitThread.c
@@ -6,6 +6,8 @@
 
 static DWORD WINAPI thread_func(LPVOID arg)
 {
+	WINPR_UNUSED(arg);
+
 	/* exists of the thread the quickest as possible */
 	ExitThread(0);
 	return 0;
@@ -17,9 +19,12 @@ int TestThreadExitThread(int argc, char* argv[])
 	DWORD waitResult;
 	int i;
 
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+
 	/* FIXME: create some noise to better guaranty the test validity and
 	 * decrease the number of loops */
-	for (i = 0; i < 50000; i++)
+	for (i = 0; i < 5000; i++)
 	{
 		thread = CreateThread(NULL, 0, thread_func, NULL, 0, NULL);
 
@@ -29,7 +34,7 @@ int TestThreadExitThread(int argc, char* argv[])
 			return -1;
 		}
 
-		waitResult = WaitForSingleObject(thread, 1000);
+		waitResult = WaitForSingleObject(thread, 100);
 		if (waitResult != WAIT_OBJECT_0)
 		{
 			/* When the thread exits before the internal thread_list


### PR DESCRIPTION
Improves runtime speed of unit tests:

1. Set shorter timeouts
2. Reduce dataset sizes