### PR TITLE
Added WINPR_ASSERT

### DIFF
--- a/channels/audin/client/audin_main.c
+++ b/channels/audin/client/audin_main.c
@@ -25,7 +25,7 @@
 #endif
 
 #include <errno.h>
-#include <assert.h>
+#include <winpr/assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1001,8 +1001,8 @@ UINT DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 		{ NULL, NULL }
 	};
 	struct SubsystemEntry* entry = &entries[0];
-	assert(pEntryPoints);
-	assert(pEntryPoints->GetPlugin);
+	WINPR_ASSERT(pEntryPoints);
+	WINPR_ASSERT(pEntryPoints->GetPlugin);
 	audin = (AUDIN_PLUGIN*)pEntryPoints->GetPlugin(pEntryPoints, "audin");
 
 	if (audin != NULL)

--- a/channels/audin/client/opensles/audin_opensl_es.c
+++ b/channels/audin/client/opensles/audin_opensl_es.c
@@ -23,7 +23,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -106,7 +106,7 @@ static BOOL audin_opensles_format_supported(IAudinDevice* device, const AUDIO_FO
 		return FALSE;
 
 	WLog_Print(opensles->log, WLOG_DEBUG, "device=%p, format=%p", (void*)opensles, (void*)format);
-	assert(format);
+	WINPR_ASSERT(format);
 
 	switch (format->wFormatTag)
 	{
@@ -144,7 +144,7 @@ static UINT audin_opensles_set_format(IAudinDevice* device, const AUDIO_FORMAT* 
 
 	WLog_Print(opensles->log, WLOG_DEBUG, "device=%p, format=%p, FramesPerPacket=%" PRIu32 "",
 	           (void*)device, (void*)format, FramesPerPacket);
-	assert(format);
+	WINPR_ASSERT(format);
 
 	opensles->format = *format;
 

--- a/channels/audin/client/opensles/opensl_io.c
+++ b/channels/audin/client/opensles/opensl_io.c
@@ -27,7 +27,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include "audin_main.h"
 #include "opensl_io.h"
@@ -101,7 +101,7 @@ static SLresult openSLCreateEngine(OPENSL_STREAM* p)
 	}
 
 engine_end:
-	assert(SL_RESULT_SUCCESS == result);
+	WINPR_ASSERT(SL_RESULT_SUCCESS == result);
 	return result;
 }
 
@@ -111,7 +111,7 @@ static SLresult openSLRecOpen(OPENSL_STREAM* p)
 	SLresult result;
 	SLuint32 sr = p->sr;
 	SLuint32 channels = p->inchannels;
-	assert(!p->recorderObject);
+	WINPR_ASSERT(!p->recorderObject);
 
 	if (channels)
 	{
@@ -201,7 +201,7 @@ static SLresult openSLRecOpen(OPENSL_STREAM* p)
 			format_pcm.containerSize = 8;
 		}
 		else
-			assert(0);
+			WINPR_ASSERT(0);
 
 		SLDataSink audioSnk = { &loc_bq, &format_pcm };
 		// create audio recorder
@@ -211,14 +211,14 @@ static SLresult openSLRecOpen(OPENSL_STREAM* p)
 		result = (*p->engineEngine)
 		             ->CreateAudioRecorder(p->engineEngine, &(p->recorderObject), &audioSrc,
 		                                   &audioSnk, 1, id, req);
-		assert(!result);
+		WINPR_ASSERT(!result);
 
 		if (SL_RESULT_SUCCESS != result)
 			goto end_recopen;
 
 		// realize the audio recorder
 		result = (*p->recorderObject)->Realize(p->recorderObject, SL_BOOLEAN_FALSE);
-		assert(!result);
+		WINPR_ASSERT(!result);
 
 		if (SL_RESULT_SUCCESS != result)
 			goto end_recopen;
@@ -226,7 +226,7 @@ static SLresult openSLRecOpen(OPENSL_STREAM* p)
 		// get the record interface
 		result = (*p->recorderObject)
 		             ->GetInterface(p->recorderObject, SL_IID_RECORD, &(p->recorderRecord));
-		assert(!result);
+		WINPR_ASSERT(!result);
 
 		if (SL_RESULT_SUCCESS != result)
 			goto end_recopen;
@@ -235,7 +235,7 @@ static SLresult openSLRecOpen(OPENSL_STREAM* p)
 		result = (*p->recorderObject)
 		             ->GetInterface(p->recorderObject, SL_IID_ANDROIDSIMPLEBUFFERQUEUE,
 		                            &(p->recorderBufferQueue));
-		assert(!result);
+		WINPR_ASSERT(!result);
 
 		if (SL_RESULT_SUCCESS != result)
 			goto end_recopen;
@@ -243,7 +243,7 @@ static SLresult openSLRecOpen(OPENSL_STREAM* p)
 		// register callback on the buffer queue
 		result = (*p->recorderBufferQueue)
 		             ->RegisterCallback(p->recorderBufferQueue, bqRecorderCallback, p);
-		assert(!result);
+		WINPR_ASSERT(!result);
 
 		if (SL_RESULT_SUCCESS != result)
 			goto end_recopen;

--- a/channels/rdp2tcp/client/rdp2tcp_main.c
+++ b/channels/rdp2tcp/client/rdp2tcp_main.c
@@ -18,7 +18,7 @@
  */
 
 #include <stdio.h>
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include <winpr/file.h>
 #include <winpr/pipe.h>
@@ -321,8 +321,8 @@ BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS pEntryPoints, PVOID p
 		return FALSE;
 
 	pEntryPointsEx = (CHANNEL_ENTRY_POINTS_FREERDP_EX*)pEntryPoints;
-	assert(pEntryPointsEx->cbSize >= sizeof(CHANNEL_ENTRY_POINTS_FREERDP_EX) &&
-	       pEntryPointsEx->MagicNumber == FREERDP_CHANNEL_MAGIC_NUMBER);
+	WINPR_ASSERT(pEntryPointsEx->cbSize >= sizeof(CHANNEL_ENTRY_POINTS_FREERDP_EX) &&
+	             pEntryPointsEx->MagicNumber == FREERDP_CHANNEL_MAGIC_NUMBER);
 	plugin->initHandle = pInitHandle;
 	plugin->channelEntryPoints = *pEntryPointsEx;
 

--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -25,7 +25,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include <winpr/crt.h>
 #include <winpr/wlog.h>

--- a/channels/rdpgfx/server/rdpgfx_main.c
+++ b/channels/rdpgfx/server/rdpgfx_main.c
@@ -21,7 +21,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/channels/rdpsnd/client/ios/TPCircularBuffer.h
+++ b/channels/rdpsnd/client/ios/TPCircularBuffer.h
@@ -45,7 +45,7 @@
 
 #include <libkern/OSAtomic.h>
 #include <string.h>
-#include <assert.h>
+#include <winpr/assert.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -124,7 +124,7 @@ extern "C"
 	{
 		buffer->tail = (buffer->tail + amount) % buffer->length;
 		OSAtomicAdd32Barrier(-amount, &buffer->fillCount);
-		assert(buffer->fillCount >= 0);
+		WINPR_ASSERT(buffer->fillCount >= 0);
 	}
 
 	/*!
@@ -136,7 +136,7 @@ extern "C"
 	{
 		buffer->tail = (buffer->tail + amount) % buffer->length;
 		buffer->fillCount -= amount;
-		assert(buffer->fillCount >= 0);
+		WINPR_ASSERT(buffer->fillCount >= 0);
 	}
 
 	/*!
@@ -173,7 +173,7 @@ extern "C"
 	{
 		buffer->head = (buffer->head + amount) % buffer->length;
 		OSAtomicAdd32Barrier(amount, &buffer->fillCount);
-		assert(buffer->fillCount <= buffer->length);
+		WINPR_ASSERT(buffer->fillCount <= buffer->length);
 	}
 
 	/*!
@@ -185,7 +185,7 @@ extern "C"
 	{
 		buffer->head = (buffer->head + amount) % buffer->length;
 		buffer->fillCount += amount;
-		assert(buffer->fillCount <= buffer->length);
+		WINPR_ASSERT(buffer->fillCount <= buffer->length);
 	}
 
 	/*!

--- a/channels/rdpsnd/client/opensles/opensl_io.c
+++ b/channels/rdpsnd/client/opensles/opensl_io.c
@@ -27,7 +27,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include "rdpsnd_main.h"
 #include "opensl_io.h"
@@ -71,8 +71,8 @@ static SLresult openSLPlayOpen(OPENSL_STREAM* p)
 	SLresult result;
 	SLuint32 sr = p->sr;
 	SLuint32 channels = p->outchannels;
-	assert(p->engineObject);
-	assert(p->engineEngine);
+	WINPR_ASSERT(p->engineObject);
+	WINPR_ASSERT(p->engineEngine);
 
 	if (channels)
 	{
@@ -139,7 +139,7 @@ static SLresult openSLPlayOpen(OPENSL_STREAM* p)
 		result = (*p->engineEngine)
 		             ->CreateOutputMix(p->engineEngine, &(p->outputMixObject), 1, ids, req);
 		DEBUG_SND("engineEngine=%p", (void*)p->engineEngine);
-		assert(!result);
+		WINPR_ASSERT(!result);
 
 		if (result != SL_RESULT_SUCCESS)
 			goto end_openaudio;
@@ -147,7 +147,7 @@ static SLresult openSLPlayOpen(OPENSL_STREAM* p)
 		// realize the output mix
 		result = (*p->outputMixObject)->Realize(p->outputMixObject, SL_BOOLEAN_FALSE);
 		DEBUG_SND("Realize=%" PRIu32 "", result);
-		assert(!result);
+		WINPR_ASSERT(!result);
 
 		if (result != SL_RESULT_SUCCESS)
 			goto end_openaudio;
@@ -177,7 +177,7 @@ static SLresult openSLPlayOpen(OPENSL_STREAM* p)
 		             ->CreateAudioPlayer(p->engineEngine, &(p->bqPlayerObject), &audioSrc,
 		                                 &audioSnk, 2, ids1, req1);
 		DEBUG_SND("bqPlayerObject=%p", (void*)p->bqPlayerObject);
-		assert(!result);
+		WINPR_ASSERT(!result);
 
 		if (result != SL_RESULT_SUCCESS)
 			goto end_openaudio;
@@ -185,7 +185,7 @@ static SLresult openSLPlayOpen(OPENSL_STREAM* p)
 		// realize the player
 		result = (*p->bqPlayerObject)->Realize(p->bqPlayerObject, SL_BOOLEAN_FALSE);
 		DEBUG_SND("Realize=%" PRIu32 "", result);
-		assert(!result);
+		WINPR_ASSERT(!result);
 
 		if (result != SL_RESULT_SUCCESS)
 			goto end_openaudio;
@@ -194,7 +194,7 @@ static SLresult openSLPlayOpen(OPENSL_STREAM* p)
 		result =
 		    (*p->bqPlayerObject)->GetInterface(p->bqPlayerObject, SL_IID_PLAY, &(p->bqPlayerPlay));
 		DEBUG_SND("bqPlayerPlay=%p", (void*)p->bqPlayerPlay);
-		assert(!result);
+		WINPR_ASSERT(!result);
 
 		if (result != SL_RESULT_SUCCESS)
 			goto end_openaudio;
@@ -203,7 +203,7 @@ static SLresult openSLPlayOpen(OPENSL_STREAM* p)
 		result = (*p->bqPlayerObject)
 		             ->GetInterface(p->bqPlayerObject, SL_IID_VOLUME, &(p->bqPlayerVolume));
 		DEBUG_SND("bqPlayerVolume=%p", (void*)p->bqPlayerVolume);
-		assert(!result);
+		WINPR_ASSERT(!result);
 
 		if (result != SL_RESULT_SUCCESS)
 			goto end_openaudio;
@@ -213,7 +213,7 @@ static SLresult openSLPlayOpen(OPENSL_STREAM* p)
 		             ->GetInterface(p->bqPlayerObject, SL_IID_ANDROIDSIMPLEBUFFERQUEUE,
 		                            &(p->bqPlayerBufferQueue));
 		DEBUG_SND("bqPlayerBufferQueue=%p", (void*)p->bqPlayerBufferQueue);
-		assert(!result);
+		WINPR_ASSERT(!result);
 
 		if (result != SL_RESULT_SUCCESS)
 			goto end_openaudio;
@@ -222,7 +222,7 @@ static SLresult openSLPlayOpen(OPENSL_STREAM* p)
 		result = (*p->bqPlayerBufferQueue)
 		             ->RegisterCallback(p->bqPlayerBufferQueue, bqPlayerCallback, p);
 		DEBUG_SND("bqPlayerCallback=%p", (void*)p->bqPlayerCallback);
-		assert(!result);
+		WINPR_ASSERT(!result);
 
 		if (result != SL_RESULT_SUCCESS)
 			goto end_openaudio;
@@ -230,9 +230,9 @@ static SLresult openSLPlayOpen(OPENSL_STREAM* p)
 		// set the player's state to playing
 		result = (*p->bqPlayerPlay)->SetPlayState(p->bqPlayerPlay, SL_PLAYSTATE_PLAYING);
 		DEBUG_SND("SetPlayState=%" PRIu32 "", result);
-		assert(!result);
+		WINPR_ASSERT(!result);
 	end_openaudio:
-		assert(!result);
+		WINPR_ASSERT(!result);
 		return result;
 	}
 
@@ -323,8 +323,8 @@ void android_CloseAudioDevice(OPENSL_STREAM* p)
 static void bqPlayerCallback(SLAndroidSimpleBufferQueueItf bq, void* context)
 {
 	OPENSL_STREAM* p = (OPENSL_STREAM*)context;
-	assert(p);
-	assert(p->queue);
+	WINPR_ASSERT(p);
+	WINPR_ASSERT(p->queue);
 	void* data = Queue_Dequeue(p->queue);
 	free(data);
 }
@@ -333,9 +333,9 @@ static void bqPlayerCallback(SLAndroidSimpleBufferQueueItf bq, void* context)
 int android_AudioOut(OPENSL_STREAM* p, const short* buffer, int size)
 {
 	HANDLE ev;
-	assert(p);
-	assert(buffer);
-	assert(size > 0);
+	WINPR_ASSERT(p);
+	WINPR_ASSERT(buffer);
+	WINPR_ASSERT(size > 0);
 
 	ev = Queue_Event(p->queue);
 	/* Assure, that the queue is not full. */
@@ -362,8 +362,8 @@ int android_AudioOut(OPENSL_STREAM* p, const short* buffer, int size)
 int android_GetOutputMute(OPENSL_STREAM* p)
 {
 	SLboolean mute;
-	assert(p);
-	assert(p->bqPlayerVolume);
+	WINPR_ASSERT(p);
+	WINPR_ASSERT(p->bqPlayerVolume);
 	SLresult rc = (*p->bqPlayerVolume)->GetMute(p->bqPlayerVolume, &mute);
 
 	if (SL_RESULT_SUCCESS != rc)
@@ -375,8 +375,8 @@ int android_GetOutputMute(OPENSL_STREAM* p)
 BOOL android_SetOutputMute(OPENSL_STREAM* p, BOOL _mute)
 {
 	SLboolean mute = _mute;
-	assert(p);
-	assert(p->bqPlayerVolume);
+	WINPR_ASSERT(p);
+	WINPR_ASSERT(p->bqPlayerVolume);
 	SLresult rc = (*p->bqPlayerVolume)->SetMute(p->bqPlayerVolume, mute);
 
 	if (SL_RESULT_SUCCESS != rc)
@@ -388,8 +388,8 @@ BOOL android_SetOutputMute(OPENSL_STREAM* p, BOOL _mute)
 int android_GetOutputVolume(OPENSL_STREAM* p)
 {
 	SLmillibel level;
-	assert(p);
-	assert(p->bqPlayerVolume);
+	WINPR_ASSERT(p);
+	WINPR_ASSERT(p->bqPlayerVolume);
 	SLresult rc = (*p->bqPlayerVolume)->GetVolumeLevel(p->bqPlayerVolume, &level);
 
 	if (SL_RESULT_SUCCESS != rc)
@@ -401,8 +401,8 @@ int android_GetOutputVolume(OPENSL_STREAM* p)
 int android_GetOutputVolumeMax(OPENSL_STREAM* p)
 {
 	SLmillibel level;
-	assert(p);
-	assert(p->bqPlayerVolume);
+	WINPR_ASSERT(p);
+	WINPR_ASSERT(p->bqPlayerVolume);
 	SLresult rc = (*p->bqPlayerVolume)->GetMaxVolumeLevel(p->bqPlayerVolume, &level);
 
 	if (SL_RESULT_SUCCESS != rc)

--- a/channels/rdpsnd/client/opensles/rdpsnd_opensles.c
+++ b/channels/rdpsnd/client/opensles/rdpsnd_opensles.c
@@ -23,7 +23,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -145,7 +145,7 @@ static BOOL rdpsnd_opensles_open(rdpsndDevicePlugin* device, const AUDIO_FORMAT*
 		return TRUE;
 
 	opensles->stream = android_OpenAudioDevice(opensles->rate, opensles->channels, 20);
-	assert(opensles->stream);
+	WINPR_ASSERT(opensles->stream);
 
 	if (!opensles->stream)
 		WLog_ERR(TAG, "android_OpenAudioDevice failed");
@@ -171,8 +171,8 @@ static void rdpsnd_opensles_free(rdpsndDevicePlugin* device)
 {
 	rdpsndopenslesPlugin* opensles = (rdpsndopenslesPlugin*)device;
 	DEBUG_SND("opensles=%p", (void*)opensles);
-	assert(opensles);
-	assert(opensles->device_name);
+	WINPR_ASSERT(opensles);
+	WINPR_ASSERT(opensles->device_name);
 	free(opensles->device_name);
 	free(opensles);
 }
@@ -183,8 +183,8 @@ static BOOL rdpsnd_opensles_format_supported(rdpsndDevicePlugin* device, const A
 	          ", channels=%" PRIu16 ", align=%" PRIu16 "",
 	          format->wFormatTag, format->cbSize, format->nSamplesPerSec, format->wBitsPerSample,
 	          format->nChannels, format->nBlockAlign);
-	assert(device);
-	assert(format);
+	WINPR_ASSERT(device);
+	WINPR_ASSERT(format);
 
 	switch (format->wFormatTag)
 	{
@@ -209,7 +209,7 @@ static UINT32 rdpsnd_opensles_get_volume(rdpsndDevicePlugin* device)
 {
 	rdpsndopenslesPlugin* opensles = (rdpsndopenslesPlugin*)device;
 	DEBUG_SND("opensles=%p", (void*)opensles);
-	assert(opensles);
+	WINPR_ASSERT(opensles);
 
 	if (opensles->stream)
 	{
@@ -232,7 +232,7 @@ static BOOL rdpsnd_opensles_set_volume(rdpsndDevicePlugin* device, UINT32 value)
 {
 	rdpsndopenslesPlugin* opensles = (rdpsndopenslesPlugin*)device;
 	DEBUG_SND("opensles=%p, value=%" PRIu32 "", (void*)opensles, value);
-	assert(opensles);
+	WINPR_ASSERT(opensles);
 	opensles->volume = value;
 
 	if (opensles->stream)
@@ -270,9 +270,9 @@ static UINT rdpsnd_opensles_play(rdpsndDevicePlugin* device, const BYTE* data, s
 
 	src.b = data;
 	DEBUG_SND("size=%d, src=%p", size, (void*)src.b);
-	assert(0 == size % 2);
-	assert(size > 0);
-	assert(src.b);
+	WINPR_ASSERT(0 == size % 2);
+	WINPR_ASSERT(size > 0);
+	WINPR_ASSERT(src.b);
 	ret = android_AudioOut(opensles->stream, src.s, size / 2);
 
 	if (ret < 0)
@@ -299,8 +299,8 @@ static int rdpsnd_opensles_parse_addin_args(rdpsndDevicePlugin* device, ADDIN_AR
 		{ NULL, 0, NULL, NULL, NULL, -1, NULL, NULL }
 	};
 
-	assert(opensles);
-	assert(args);
+	WINPR_ASSERT(opensles);
+	WINPR_ASSERT(args);
 	DEBUG_SND("opensles=%p, args=%p", (void*)opensles, (void*)args);
 	flags =
 	    COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;

--- a/channels/serial/client/serial_main.c
+++ b/channels/serial/client/serial_main.c
@@ -23,7 +23,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -145,7 +145,7 @@ static UINT serial_process_irp_create(SERIAL_DEVICE* serial, IRP* irp)
 	if (!Stream_SafeSeek(irp->input, PathLength)) /* Path (variable) */
 		return ERROR_INVALID_DATA;
 
-	assert(PathLength == 0);             /* MS-RDPESP 2.2.2.2 */
+	WINPR_ASSERT(PathLength == 0); /* MS-RDPESP 2.2.2.2 */
 #ifndef _WIN32
 	/* Windows 2012 server sends on a first call :
 	 *     DesiredAccess     = 0x00100080: SYNCHRONIZE | FILE_READ_ATTRIBUTES
@@ -157,9 +157,9 @@ static UINT serial_process_irp_create(SERIAL_DEVICE* serial, IRP* irp)
 	 * FILE_READ_EA | FILE_READ_DATA SharedAccess      = 0x00000007: FILE_SHARE_DELETE |
 	 * FILE_SHARE_WRITE | FILE_SHARE_READ CreateDisposition = 0x00000001: CREATE_NEW
 	 *
-	 * assert(DesiredAccess == (GENERIC_READ | GENERIC_WRITE));
-	 * assert(SharedAccess == 0);
-	 * assert(CreateDisposition == OPEN_EXISTING);
+	 * WINPR_ASSERT(DesiredAccess == (GENERIC_READ | GENERIC_WRITE));
+	 * WINPR_ASSERT(SharedAccess == 0);
+	 * WINPR_ASSERT(CreateDisposition == OPEN_EXISTING);
 	 *
 	 */
 	WLog_Print(serial->log, WLOG_DEBUG,
@@ -194,7 +194,7 @@ static UINT serial_process_irp_create(SERIAL_DEVICE* serial, IRP* irp)
 	/* GetCommState(serial->hComm, &dcb); */
 	/* dcb.fBinary = TRUE; */
 	/* SetCommState(serial->hComm, &dcb); */
-	assert(irp->FileId == 0);
+	WINPR_ASSERT(irp->FileId == 0);
 	irp->FileId = irp->devman->id_sequence++; /* FIXME: why not ((WINPR_COMM*)hComm)->fd? */
 	irp->IoStatus = STATUS_SUCCESS;
 	WLog_Print(serial->log, WLOG_DEBUG, "%s (DeviceId: %" PRIu32 ", FileId: %" PRIu32 ") created.",
@@ -256,7 +256,7 @@ static UINT serial_process_irp_read(SERIAL_DEVICE* serial, IRP* irp)
 	}
 
 	/* MS-RDPESP 3.2.5.1.4: If the Offset field is not set to 0, the value MUST be ignored
-	 * assert(Offset == 0);
+	 * WINPR_ASSERT(Offset == 0);
 	 */
 	WLog_Print(serial->log, WLOG_DEBUG, "reading %" PRIu32 " bytes from %s", Length,
 	           serial->device.name);
@@ -311,7 +311,7 @@ static UINT serial_process_irp_write(SERIAL_DEVICE* serial, IRP* irp)
 		return ERROR_INVALID_DATA;
 
 	/* MS-RDPESP 3.2.5.1.5: The Offset field is ignored
-	 * assert(Offset == 0);
+	 * WINPR_ASSERT(Offset == 0);
 	 *
 	 * Using a serial printer, noticed though this field could be
 	 * set.
@@ -410,7 +410,7 @@ error_handle:
 	/* FIXME: find out whether it's required or not to get
 	 * BytesReturned == OutputBufferLength when
 	 * CommDeviceIoControl returns FALSE */
-	assert(OutputBufferLength == BytesReturned);
+	WINPR_ASSERT(OutputBufferLength == BytesReturned);
 	Stream_Write_UINT32(irp->output, BytesReturned); /* OutputBufferLength (4 bytes) */
 
 	if (BytesReturned > 0)
@@ -567,7 +567,7 @@ static void create_irp_thread(SERIAL_DEVICE* serial, IRP* irp)
 				WLog_Print(serial->log, WLOG_WARN,
 				           "WaitForSingleObject, got an unexpected result=0x%" PRIX32 "\n",
 				           waitResult);
-				assert(FALSE);
+				WINPR_ASSERT(FALSE);
 			}
 
 			/* pending thread (but not yet terminating thread) if waitResult == WAIT_TIMEOUT */
@@ -603,8 +603,8 @@ static void create_irp_thread(SERIAL_DEVICE* serial, IRP* irp)
 		WLog_Print(serial->log, WLOG_DEBUG,
 		           "IRP recall: IRP with the CompletionId=%" PRIu32 " not yet completed!",
 		           irp->CompletionId);
-		assert(FALSE); /* unimplemented */
-		/* TODO: asserts that previousIrpThread handles well
+		WINPR_ASSERT(FALSE); /* unimplemented */
+		/* TODO: WINPR_ASSERTs that previousIrpThread handles well
 		 * the same request by checking more details. Need an
 		 * access to the IRP object used by previousIrpThread
 		 */
@@ -626,12 +626,12 @@ static void create_irp_thread(SERIAL_DEVICE* serial, IRP* irp)
 		WLog_Print(serial->log, WLOG_WARN,
 		           "Number of IRP threads threshold reached: %d, keep on anyway",
 		           ListDictionary_Count(serial->IrpThreads));
-		assert(FALSE); /* unimplemented */
-		               /* TODO: MAX_IRP_THREADS has been thought to avoid a
-		                * flooding of pending requests. Use
-		                * WaitForMultipleObjects() when available in winpr
-		                * for threads.
-		                */
+		WINPR_ASSERT(FALSE); /* unimplemented */
+		                     /* TODO: MAX_IRP_THREADS has been thought to avoid a
+		                      * flooding of pending requests. Use
+		                      * WaitForMultipleObjects() when available in winpr
+		                      * for threads.
+		                      */
 	}
 
 	/* error_handle to be used ... */
@@ -747,7 +747,7 @@ static DWORD WINAPI serial_thread_func(LPVOID arg)
 static UINT serial_irp_request(DEVICE* device, IRP* irp)
 {
 	SERIAL_DEVICE* serial = (SERIAL_DEVICE*)device;
-	assert(irp != NULL);
+	WINPR_ASSERT(irp != NULL);
 
 	if (irp == NULL)
 		return CHANNEL_RC_OK;
@@ -889,7 +889,7 @@ UINT DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
 				serial->ServerSerialDriverId = SerialDriverSerCx2Sys;
 			else
 			{
-				assert(FALSE);
+				WINPR_ASSERT(FALSE);
 				WLog_Print(serial->log, WLOG_DEBUG,
 				           "Unknown server's serial driver: %s. SerCx2 will be used", driver);
 				serial->ServerSerialDriverId = SerialDriverSerialSys;
@@ -910,7 +910,7 @@ UINT DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
 			else
 			{
 				WLog_Print(serial->log, WLOG_DEBUG, "Unknown flag: %s", device->Permissive);
-				assert(FALSE);
+				WINPR_ASSERT(FALSE);
 			}
 		}
 

--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -27,7 +27,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include <winpr/crt.h>
 #include <winpr/print.h>

--- a/channels/tsmf/client/gstreamer/tsmf_gstreamer.c
+++ b/channels/tsmf/client/gstreamer/tsmf_gstreamer.c
@@ -23,7 +23,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include <fcntl.h>
 #include <stdio.h>

--- a/channels/urbdrc/client/urbdrc_main.c
+++ b/channels/urbdrc/client/urbdrc_main.c
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/client/Android/android_freerdp.c
+++ b/client/Android/android_freerdp.c
@@ -17,7 +17,6 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
 #include <locale.h>
 
 #include <jni.h>

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <tchar.h>
-#include <assert.h>
+#include <winpr/assert.h>
 #include <sys/types.h>
 
 #include <freerdp/log.h>
@@ -681,7 +681,7 @@ static DWORD WINAPI wf_input_thread(LPVOID arg)
 	wMessage message;
 	wMessageQueue* queue;
 	freerdp* instance = (freerdp*)arg;
-	assert(NULL != instance);
+	WINPR_ASSERT(NULL != instance);
 	status = 1;
 	queue = freerdp_get_message_queue(instance, FREERDP_INPUT_MESSAGE_QUEUE);
 
@@ -852,7 +852,7 @@ static DWORD WINAPI wf_keyboard_thread(LPVOID lpParam)
 	wfContext* wfc;
 	HHOOK hook_handle;
 	wfc = (wfContext*)lpParam;
-	assert(NULL != wfc);
+	WINPR_ASSERT(NULL != wfc);
 	hook_handle = SetWindowsHookEx(WH_KEYBOARD_LL, wf_ll_kbd_proc, wfc->hInstance, 0);
 
 	if (hook_handle)

--- a/client/Windows/wf_cliprdr.c
+++ b/client/Windows/wf_cliprdr.c
@@ -32,7 +32,7 @@
 #include <windows.h>
 #include <winuser.h>
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include <winpr/crt.h>
 #include <winpr/tchar.h>

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -26,7 +26,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <float.h>
 
 #include <X11/Xlib.h>
@@ -844,7 +844,7 @@ static BOOL xf_get_pixmap_info(xfContext* xfc)
 	XPixmapFormatValues* pf;
 	XPixmapFormatValues* pfs;
 	XWindowAttributes window_attributes;
-	assert(xfc->display);
+	WINPR_ASSERT(xfc->display);
 	pfs = XListPixmapFormats(xfc->display, &pf_count);
 
 	if (!pfs)
@@ -1806,11 +1806,11 @@ static Atom get_supported_atom(xfContext* xfc, const char* atomName)
 static BOOL xfreerdp_client_new(freerdp* instance, rdpContext* context)
 {
 	xfContext* xfc = (xfContext*)instance->context;
-	assert(context);
-	assert(xfc);
-	assert(!xfc->display);
-	assert(!xfc->mutex);
-	assert(!xfc->x11event);
+	WINPR_ASSERT(context);
+	WINPR_ASSERT(xfc);
+	WINPR_ASSERT(!xfc->display);
+	WINPR_ASSERT(!xfc->mutex);
+	WINPR_ASSERT(!xfc->x11event);
 	instance->PreConnect = xf_pre_connect;
 	instance->PostConnect = xf_post_connect;
 	instance->PostDisconnect = xf_post_disconnect;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -24,7 +24,7 @@
 #endif
 
 #include <ctype.h>
-#include <assert.h>
+#include <winpr/assert.h>
 #include <errno.h>
 
 #include <winpr/crt.h>

--- a/libfreerdp/codec/dsp.c
+++ b/libfreerdp/codec/dsp.c
@@ -21,7 +21,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/libfreerdp/codec/region.c
+++ b/libfreerdp/codec/region.c
@@ -19,7 +19,7 @@
  * limitations under the License.
  */
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <winpr/memory.h>
 #include <freerdp/log.h>
 #include <freerdp/codec/region.h>
@@ -78,15 +78,15 @@ static REGION16_DATA empty_region = { 0, 0 };
 
 void region16_init(REGION16* region)
 {
-	assert(region);
+	WINPR_ASSERT(region);
 	ZeroMemory(region, sizeof(REGION16));
 	region->data = &empty_region;
 }
 
 int region16_n_rects(const REGION16* region)
 {
-	assert(region);
-	assert(region->data);
+	WINPR_ASSERT(region);
+	WINPR_ASSERT(region->data);
 	return region->data->nbRects;
 }
 
@@ -148,8 +148,8 @@ BOOL rectangle_is_empty(const RECTANGLE_16* rect)
 
 BOOL region16_is_empty(const REGION16* region)
 {
-	assert(region);
-	assert(region->data);
+	WINPR_ASSERT(region);
+	WINPR_ASSERT(region->data);
 	return (region->data->nbRects == 0);
 }
 
@@ -178,8 +178,8 @@ BOOL rectangles_intersection(const RECTANGLE_16* r1, const RECTANGLE_16* r2, REC
 
 void region16_clear(REGION16* region)
 {
-	assert(region);
-	assert(region->data);
+	WINPR_ASSERT(region);
+	WINPR_ASSERT(region->data);
 
 	if ((region->data->size > 0) && (region->data != &empty_region))
 		free(region->data);
@@ -203,10 +203,10 @@ static INLINE REGION16_DATA* allocateRegion(long nbItems)
 
 BOOL region16_copy(REGION16* dst, const REGION16* src)
 {
-	assert(dst);
-	assert(dst->data);
-	assert(src);
-	assert(src->data);
+	WINPR_ASSERT(dst);
+	WINPR_ASSERT(dst->data);
+	WINPR_ASSERT(src);
+	WINPR_ASSERT(src->data);
 
 	if (dst == src)
 		return TRUE;
@@ -495,9 +495,9 @@ BOOL region16_union_rect(REGION16* dst, const REGION16* src, const RECTANGLE_16*
 	RECTANGLE_16* dstRect = NULL;
 	UINT32 usedRects, srcNbRects;
 	UINT16 topInterBand;
-	assert(src);
-	assert(src->data);
-	assert(dst);
+	WINPR_ASSERT(src);
+	WINPR_ASSERT(src->data);
+	WINPR_ASSERT(dst);
 	srcExtents = region16_extents(src);
 	dstExtents = region16_extents_noconst(dst);
 
@@ -719,8 +719,8 @@ BOOL region16_intersect_rect(REGION16* dst, const REGION16* src, const RECTANGLE
 	RECTANGLE_16* dstPtr;
 	UINT32 nbRects, usedRects;
 	RECTANGLE_16 common, newExtents;
-	assert(src);
-	assert(src->data);
+	WINPR_ASSERT(src);
+	WINPR_ASSERT(src->data);
 	srcPtr = region16_rects(src, &nbRects);
 
 	if (!nbRects)
@@ -800,7 +800,7 @@ BOOL region16_intersect_rect(REGION16* dst, const REGION16* src, const RECTANGLE
 
 void region16_uninit(REGION16* region)
 {
-	assert(region);
+	WINPR_ASSERT(region);
 
 	if (region->data)
 	{

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -23,7 +23,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -365,10 +365,10 @@ void rfx_context_free(RFX_CONTEXT* context)
 	if (!context)
 		return;
 
-	assert(NULL != context);
-	assert(NULL != context->priv);
-	assert(NULL != context->priv->TilePool);
-	assert(NULL != context->priv->BufferPool);
+	WINPR_ASSERT(NULL != context);
+	WINPR_ASSERT(NULL != context->priv);
+	WINPR_ASSERT(NULL != context->priv->TilePool);
+	WINPR_ASSERT(NULL != context->priv->BufferPool);
 	priv = context->priv;
 	/* coverity[address_free] */
 	rfx_message_free(context, &context->currentMessage);
@@ -1466,12 +1466,12 @@ RFX_MESSAGE* rfx_encode_message(RFX_CONTEXT* context, const RFX_RECT* rects, siz
 	RECTANGLE_16 currentTileRect;
 	const RECTANGLE_16* regionRect;
 	const RECTANGLE_16* extents;
-	assert(data);
-	assert(rects);
-	assert(numRects > 0);
-	assert(w > 0);
-	assert(h > 0);
-	assert(s > 0);
+	WINPR_ASSERT(data);
+	WINPR_ASSERT(rects);
+	WINPR_ASSERT(numRects > 0);
+	WINPR_ASSERT(w > 0);
+	WINPR_ASSERT(h > 0);
+	WINPR_ASSERT(s > 0);
 
 	if (!(message = (RFX_MESSAGE*)calloc(1, sizeof(RFX_MESSAGE))))
 		return NULL;
@@ -1505,8 +1505,8 @@ RFX_MESSAGE* rfx_encode_message(RFX_CONTEXT* context, const RFX_RECT* rects, siz
 		goto skip_encoding_loop;
 
 	extents = region16_extents(&rectsRegion);
-	assert(extents->right - extents->left > 0);
-	assert(extents->bottom - extents->top > 0);
+	WINPR_ASSERT(extents->right - extents->left > 0);
+	WINPR_ASSERT(extents->bottom - extents->top > 0);
 	maxTilesX = 1 + TILE_NO(extents->right - 1) - TILE_NO(extents->left);
 	maxTilesY = 1 + TILE_NO(extents->bottom - 1) - TILE_NO(extents->top);
 	maxNbTiles = maxTilesX * maxTilesY;

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -33,7 +33,7 @@
 #include "buildflags.h"
 #include "gateway/rpc_fault.h"
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include <winpr/crt.h>
 #include <winpr/string.h>

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -21,7 +21,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include <winpr/crt.h>
 #include <winpr/synch.h>
@@ -678,7 +678,7 @@ static int rdg_websocket_read(BIO* bio, BYTE* pBuffer, size_t size,
 {
 	int status;
 	int effectiveDataLen = 0;
-	assert(encodingContext != NULL);
+	WINPR_ASSERT(encodingContext != NULL);
 	while (TRUE)
 	{
 		switch (encodingContext->state)
@@ -771,7 +771,7 @@ static int rdg_chuncked_read(BIO* bio, BYTE* pBuffer, size_t size,
 {
 	int status;
 	int effectiveDataLen = 0;
-	assert(encodingContext != NULL);
+	WINPR_ASSERT(encodingContext != NULL);
 	while (TRUE)
 	{
 		switch (encodingContext->state)
@@ -802,8 +802,8 @@ static int rdg_chuncked_read(BIO* bio, BYTE* pBuffer, size_t size,
 			case ChunkStateFooter:
 			{
 				char _dummy[2];
-				assert(encodingContext->nextOffset == 0);
-				assert(encodingContext->headerFooterPos < 2);
+				WINPR_ASSERT(encodingContext->nextOffset == 0);
+				WINPR_ASSERT(encodingContext->headerFooterPos < 2);
 				status = BIO_read(bio, _dummy, 2 - encodingContext->headerFooterPos);
 				if (status >= 0)
 				{
@@ -823,7 +823,7 @@ static int rdg_chuncked_read(BIO* bio, BYTE* pBuffer, size_t size,
 				BOOL _haveNewLine = FALSE;
 				size_t tmp;
 				char* dst = &encodingContext->lenBuffer[encodingContext->headerFooterPos];
-				assert(encodingContext->nextOffset == 0);
+				WINPR_ASSERT(encodingContext->nextOffset == 0);
 				while (encodingContext->headerFooterPos < 10 && !_haveNewLine)
 				{
 					status = BIO_read(bio, dst, 1);
@@ -870,7 +870,7 @@ static int rdg_chuncked_read(BIO* bio, BYTE* pBuffer, size_t size,
 static int rdg_socket_read(BIO* bio, BYTE* pBuffer, size_t size,
                            rdg_http_encoding_context* encodingContext)
 {
-	assert(encodingContext != NULL);
+	WINPR_ASSERT(encodingContext != NULL);
 
 	if (encodingContext->isWebsocketTransport)
 	{
@@ -919,7 +919,7 @@ static wStream* rdg_receive_packet(rdpRdg* rdg)
 	wStream* s;
 	const size_t header = sizeof(RdgPacketHeader);
 	size_t packetLength;
-	assert(header <= INT_MAX);
+	WINPR_ASSERT(header <= INT_MAX);
 	s = Stream_New(NULL, 1024);
 
 	if (!s)
@@ -1235,7 +1235,7 @@ static BOOL rdg_skip_seed_payload(rdpTls* tls, SSIZE_T lastResponseLength,
 	BYTE seed_payload[10];
 	const size_t size = sizeof(seed_payload);
 
-	assert(size < SSIZE_MAX);
+	WINPR_ASSERT(size < SSIZE_MAX);
 
 	/* Per [MS-TSGU] 3.3.5.1 step 4, after final OK response RDG server sends
 	 * random "seed" payload of limited size. In practice it's 10 bytes.
@@ -1343,8 +1343,8 @@ static BOOL rdg_process_tunnel_response_optional(rdpRdg* rdg, wStream* s, UINT16
 		UINT16 msgLenBytes;
 		rdpContext* context = rdg->context;
 
-		assert(context);
-		assert(context->instance);
+		WINPR_ASSERT(context);
+		WINPR_ASSERT(context->instance);
 
 		/* Read message string and invoke callback */
 		if (!rdg_read_http_unicode_string(s, &msg, &msgLenBytes))
@@ -1528,7 +1528,7 @@ static BOOL rdg_process_packet(rdpRdg* rdg, wStream* s)
 DWORD rdg_get_event_handles(rdpRdg* rdg, HANDLE* events, DWORD count)
 {
 	DWORD nCount = 0;
-	assert(rdg != NULL);
+	WINPR_ASSERT(rdg != NULL);
 
 	if (rdg->tlsOut && rdg->tlsOut->bio)
 	{
@@ -1907,7 +1907,7 @@ BOOL rdg_connect(rdpRdg* rdg, DWORD timeout, BOOL* rpcFallback)
 	BOOL status;
 	SOCKET outConnSocket = 0;
 	char* peerAddress = NULL;
-	assert(rdg != NULL);
+	WINPR_ASSERT(rdg != NULL);
 	status =
 	    rdg_establish_data_connection(rdg, rdg->tlsOut, "RDG_OUT_DATA", NULL, timeout, rpcFallback);
 
@@ -2147,8 +2147,8 @@ static BOOL rdg_process_service_message(rdpRdg* rdg, wStream* s)
 	const WCHAR* msg;
 	UINT16 msgLenBytes;
 	rdpContext* context = rdg->context;
-	assert(context);
-	assert(context->instance);
+	WINPR_ASSERT(context);
+	WINPR_ASSERT(context->instance);
 
 	/* Read message string */
 	if (!rdg_read_http_unicode_string(s, &msg, &msgLenBytes))
@@ -2179,7 +2179,7 @@ static BOOL rdg_process_control_packet(rdpRdg* rdg, int type, size_t packetLengt
 	if (packetLength < sizeof(RdgPacketHeader))
 		return FALSE;
 
-	assert(sizeof(RdgPacketHeader) < INT_MAX);
+	WINPR_ASSERT(sizeof(RdgPacketHeader) < INT_MAX);
 
 	if (payloadSize)
 	{
@@ -2259,7 +2259,7 @@ static int rdg_read_data_packet(rdpRdg* rdg, BYTE* buffer, int size)
 
 	if (!rdg->packetRemainingCount)
 	{
-		assert(sizeof(RdgPacketHeader) < INT_MAX);
+		WINPR_ASSERT(sizeof(RdgPacketHeader) < INT_MAX);
 
 		while (readCount < sizeof(RdgPacketHeader))
 		{

--- a/libfreerdp/core/message.c
+++ b/libfreerdp/core/message.c
@@ -23,7 +23,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include "rdp.h"
 #include "message.h"

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -21,7 +21,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include <winpr/crt.h>
 #include <winpr/synch.h>

--- a/libfreerdp/crypto/certificate.c
+++ b/libfreerdp/crypto/certificate.c
@@ -22,7 +22,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
@@ -494,7 +494,7 @@ static int certificate_match_data_file(rdpCertificateStore* certificate_store,
 static BOOL useKnownHosts(rdpCertificateStore* certificate_store)
 {
 	BOOL use;
-	assert(certificate_store);
+	WINPR_ASSERT(certificate_store);
 
 	use = freerdp_settings_get_bool(certificate_store->settings, FreeRDP_CertificateUseKnownHosts);
 	WLog_INFO(TAG, "known_hosts=%d", use);

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -21,7 +21,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <string.h>
 #include <errno.h>
 
@@ -1584,7 +1584,7 @@ void tls_print_certificate_name_mismatch_error(const char* hostname, UINT16 port
                                                int alt_names_count)
 {
 	int index;
-	assert(NULL != hostname);
+	WINPR_ASSERT(NULL != hostname);
 	WLog_ERR(TAG, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
 	WLog_ERR(TAG, "@           WARNING: CERTIFICATE NAME MISMATCH!           @");
 	WLog_ERR(TAG, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
@@ -1596,12 +1596,12 @@ void tls_print_certificate_name_mismatch_error(const char* hostname, UINT16 port
 
 	if (alt_names_count > 0)
 	{
-		assert(NULL != alt_names);
+		WINPR_ASSERT(NULL != alt_names);
 		WLog_ERR(TAG, "Alternative names:");
 
 		for (index = 0; index < alt_names_count; index++)
 		{
-			assert(alt_names[index]);
+			WINPR_ASSERT(alt_names[index]);
 			WLog_ERR(TAG, "\t %s", alt_names[index]);
 		}
 	}

--- a/libfreerdp/utils/ringbuffer.c
+++ b/libfreerdp/utils/ringbuffer.c
@@ -25,7 +25,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include <winpr/crt.h>
 #include <freerdp/log.h>
@@ -285,7 +285,7 @@ void ringbuffer_commit_read_bytes(RingBuffer* rb, size_t sz)
 	if (sz < 1)
 		return;
 
-	assert(rb->size - rb->freeSize >= sz);
+	WINPR_ASSERT(rb->size - rb->freeSize >= sz);
 	rb->readPtr = (rb->readPtr + sz) % rb->size;
 	rb->freeSize += sz;
 

--- a/server/proxy/pf_modules.c
+++ b/server/proxy/pf_modules.c
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include <winpr/file.h>
 #include <winpr/wlog.h>
@@ -209,7 +209,7 @@ static BOOL pf_modules_set_plugin_data(const char* plugin_name, proxyData* pdata
 		char* cp;
 	} ccharconv;
 
-	assert(plugin_name);
+	WINPR_ASSERT(plugin_name);
 
 	ccharconv.ccp = plugin_name;
 	if (data == NULL) /* no need to store anything */
@@ -237,8 +237,8 @@ static void* pf_modules_get_plugin_data(const char* plugin_name, proxyData* pdat
 		const char* ccp;
 		char* cp;
 	} ccharconv;
-	assert(plugin_name);
-	assert(pdata);
+	WINPR_ASSERT(plugin_name);
+	WINPR_ASSERT(pdata);
 	ccharconv.ccp = plugin_name;
 
 	return HashTable_GetItemValue(pdata->modules_info, ccharconv.cp);
@@ -246,7 +246,7 @@ static void* pf_modules_get_plugin_data(const char* plugin_name, proxyData* pdat
 
 static void pf_modules_abort_connect(proxyData* pdata)
 {
-	assert(pdata);
+	WINPR_ASSERT(pdata);
 	WLog_DBG(TAG, "%s is called!", __FUNCTION__);
 	proxy_data_abort_connect(pdata);
 }

--- a/server/shadow/shadow_mcevent.c
+++ b/server/shadow/shadow_mcevent.c
@@ -20,7 +20,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <freerdp/log.h>
 #include "shadow.h"
 
@@ -116,7 +116,7 @@ static void _Publish(rdpShadowMultiClientEvent* event)
 
 	subscribers = event->subscribers;
 
-	assert(event->consuming == 0);
+	WINPR_ASSERT(event->consuming == 0);
 
 	/* Count subscribing clients */
 	ArrayList_Lock(subscribers);
@@ -153,7 +153,7 @@ static void _WaitForSubscribers(rdpShadowMultiClientEvent* event)
 	}
 
 	/* Last subscriber should have already reset the event */
-	assert(WaitForSingleObject(event->event, 0) != WAIT_OBJECT_0);
+	WINPR_ASSERT(WaitForSingleObject(event->event, 0) != WAIT_OBJECT_0);
 
 	return;
 }
@@ -205,7 +205,7 @@ static BOOL _Consume(struct rdp_shadow_multiclient_subscriber* subscriber, BOOL 
 		ret = TRUE;
 	}
 
-	assert(event->consuming >= 0);
+	WINPR_ASSERT(event->consuming >= 0);
 
 	if (event->consuming == 0)
 	{

--- a/winpr/CMakeLists.txt
+++ b/winpr/CMakeLists.txt
@@ -21,6 +21,12 @@ project(WinPR C)
 
 set(CMAKE_COLOR_MAKEFILE ON)
 
+option(WITH_VERBOSE_WINPR_ASSERT "Compile with verbose WINPR_ASSERT." ON)
+
+if (WITH_VERBOSE_WINPR_ASSERT)
+    add_definitions(-DWITH_VERBOSE_WINPR_ASSERT)
+endif()
+
 if(FREERDP_VERSION)
 	set(FREERDP_BUILD 1)
 endif()

--- a/winpr/include/winpr/assert.h
+++ b/winpr/include/winpr/assert.h
@@ -26,6 +26,7 @@
 #include <winpr/wtypes.h>
 #include <winpr/wlog.h>
 
+#if WITH_VERBOSE_WINPR_ASSERT
 #define WINPR_ASSERT(cond)                                                                   \
 	do                                                                                       \
 	{                                                                                        \
@@ -36,6 +37,12 @@
 			abort();                                                                         \
 		}                                                                                    \
 	} while (0)
+#else
+#define WINPR_ASSERT(cond) \
+	do                     \
+	{                      \
+	} while (0)
+#endif
 
 #ifdef __cplusplus
 extern "C"

--- a/winpr/include/winpr/assert.h
+++ b/winpr/include/winpr/assert.h
@@ -1,0 +1,49 @@
+/**
+ * WinPR: Windows Portable Runtime
+ * Runtime ASSERT macros
+ *
+ * Copyright 2021 Armin Novak <armin.novak@thincast.com>
+ * Copyright 2021 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WINPR_ASSERT_H
+#define WINPR_ASSERT_H
+
+#include <stdlib.h>
+#include <winpr/winpr.h>
+#include <winpr/wtypes.h>
+#include <winpr/wlog.h>
+
+#define WINPR_ASSERT(cond)                                                                   \
+	do                                                                                       \
+	{                                                                                        \
+		if (!(cond))                                                                         \
+		{                                                                                    \
+			WLog_FATAL("com.freerdp.winpr.assert", "%s [%s:%s:%" PRIuz "]", #cond, __FILE__, \
+			           __FUNCTION__, __LINE__);                                              \
+			abort();                                                                         \
+		}                                                                                    \
+	} while (0)
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WINPR_ERROR_H */

--- a/winpr/libwinpr/comm/comm.c
+++ b/winpr/libwinpr/comm/comm.c
@@ -26,7 +26,7 @@
 
 #if defined __linux__ && !defined ANDROID
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <pthread.h>
@@ -92,8 +92,8 @@ HANDLE_CREATOR* GetCommHandleCreator(void)
 static void _CommInit(void)
 {
 	/* NB: error management to be done outside of this function */
-	assert(_Log == NULL);
-	assert(_CommDevices == NULL);
+	WINPR_ASSERT(_Log == NULL);
+	WINPR_ASSERT(_CommDevices == NULL);
 	_CommDevices = (COMM_DEVICE**)calloc(COMM_DEVICE_MAX + 1, sizeof(COMM_DEVICE*));
 
 	if (!_CommDevices)
@@ -107,7 +107,7 @@ static void _CommInit(void)
 	}
 
 	_Log = WLog_Get("com.winpr.comm");
-	assert(_Log != NULL);
+	WINPR_ASSERT(_Log != NULL);
 }
 
 /**

--- a/winpr/libwinpr/comm/comm_io.c
+++ b/winpr/libwinpr/comm/comm_io.c
@@ -23,7 +23,7 @@
 
 #if defined __linux__ && !defined ANDROID
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <errno.h>
 #include <termios.h>
 #include <unistd.h>
@@ -253,8 +253,8 @@ BOOL CommReadFile(HANDLE hDevice, LPVOID lpBuffer, DWORD nNumberOfBytesToRead,
 		biggestFd = pComm->fd_read_event;
 
 	FD_ZERO(&read_set);
-	assert(pComm->fd_read_event < FD_SETSIZE);
-	assert(pComm->fd_read < FD_SETSIZE);
+	WINPR_ASSERT(pComm->fd_read_event < FD_SETSIZE);
+	WINPR_ASSERT(pComm->fd_read < FD_SETSIZE);
 	FD_SET(pComm->fd_read_event, &read_set);
 	FD_SET(pComm->fd_read, &read_set);
 	nbFds = select(biggestFd + 1, &read_set, NULL, NULL, pTmaxTimeout);
@@ -283,8 +283,8 @@ BOOL CommReadFile(HANDLE hDevice, LPVOID lpBuffer, DWORD nNumberOfBytesToRead,
 		{
 			if (errno == EAGAIN)
 			{
-				assert(FALSE); /* not quite sure this should ever happen */
-				               /* keep on */
+				WINPR_ASSERT(FALSE); /* not quite sure this should ever happen */
+				                     /* keep on */
 			}
 			else
 			{
@@ -294,7 +294,7 @@ BOOL CommReadFile(HANDLE hDevice, LPVOID lpBuffer, DWORD nNumberOfBytesToRead,
 				/* FIXME: goto return_false ? */
 			}
 
-			assert(errno == EAGAIN);
+			WINPR_ASSERT(errno == EAGAIN);
 		}
 
 		if (event == FREERDP_PURGE_RXABORT)
@@ -303,7 +303,7 @@ BOOL CommReadFile(HANDLE hDevice, LPVOID lpBuffer, DWORD nNumberOfBytesToRead,
 			goto return_false;
 		}
 
-		assert(event == FREERDP_PURGE_RXABORT); /* no other expected event so far */
+		WINPR_ASSERT(event == FREERDP_PURGE_RXABORT); /* no other expected event so far */
 	}
 
 	if (FD_ISSET(pComm->fd_read, &read_set))
@@ -336,7 +336,7 @@ BOOL CommReadFile(HANDLE hDevice, LPVOID lpBuffer, DWORD nNumberOfBytesToRead,
 			}
 			else
 			{
-				assert(FALSE);
+				WINPR_ASSERT(FALSE);
 				SetLastError(ERROR_IO_DEVICE);
 				goto return_false;
 			}
@@ -361,7 +361,7 @@ BOOL CommReadFile(HANDLE hDevice, LPVOID lpBuffer, DWORD nNumberOfBytesToRead,
 		goto return_true;
 	}
 
-	assert(FALSE);
+	WINPR_ASSERT(FALSE);
 	*lpNumberOfBytesRead = 0;
 return_false:
 	LeaveCriticalSection(&pComm->ReadLock);
@@ -454,8 +454,8 @@ BOOL CommWriteFile(HANDLE hDevice, LPCVOID lpBuffer, DWORD nNumberOfBytesToWrite
 
 		FD_ZERO(&event_set);
 		FD_ZERO(&write_set);
-		assert(pComm->fd_write_event < FD_SETSIZE);
-		assert(pComm->fd_write < FD_SETSIZE);
+		WINPR_ASSERT(pComm->fd_write_event < FD_SETSIZE);
+		WINPR_ASSERT(pComm->fd_write < FD_SETSIZE);
 		FD_SET(pComm->fd_write_event, &event_set);
 		FD_SET(pComm->fd_write, &write_set);
 		nbFds = select(biggestFd + 1, &event_set, &write_set, NULL, pTmaxTimeout);
@@ -484,8 +484,8 @@ BOOL CommWriteFile(HANDLE hDevice, LPCVOID lpBuffer, DWORD nNumberOfBytesToWrite
 			{
 				if (errno == EAGAIN)
 				{
-					assert(FALSE); /* not quite sure this should ever happen */
-					               /* keep on */
+					WINPR_ASSERT(FALSE); /* not quite sure this should ever happen */
+					                     /* keep on */
 				}
 				else
 				{
@@ -495,7 +495,7 @@ BOOL CommWriteFile(HANDLE hDevice, LPCVOID lpBuffer, DWORD nNumberOfBytesToWrite
 					/* FIXME: goto return_false ? */
 				}
 
-				assert(errno == EAGAIN);
+				WINPR_ASSERT(errno == EAGAIN);
 			}
 
 			if (event == FREERDP_PURGE_TXABORT)
@@ -504,7 +504,7 @@ BOOL CommWriteFile(HANDLE hDevice, LPCVOID lpBuffer, DWORD nNumberOfBytesToWrite
 				goto return_false;
 			}
 
-			assert(event == FREERDP_PURGE_TXABORT); /* no other expected event so far */
+			WINPR_ASSERT(event == FREERDP_PURGE_TXABORT); /* no other expected event so far */
 		}
 
 		/* write_set */
@@ -534,7 +534,7 @@ BOOL CommWriteFile(HANDLE hDevice, LPCVOID lpBuffer, DWORD nNumberOfBytesToWrite
 				}
 				else
 				{
-					assert(FALSE);
+					WINPR_ASSERT(FALSE);
 					SetLastError(ERROR_IO_DEVICE);
 					goto return_false;
 				}

--- a/winpr/libwinpr/comm/comm_ioctl.c
+++ b/winpr/libwinpr/comm/comm_ioctl.c
@@ -26,7 +26,7 @@
 
 #if defined __linux__ && !defined ANDROID
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <errno.h>
 
 #include <winpr/wlog.h>
@@ -132,7 +132,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			break;
 	}
 
-	assert(pServerSerialDriver != NULL);
+	WINPR_ASSERT(pServerSerialDriver != NULL);
 
 	switch (dwIoControlCode)
 	{
@@ -150,7 +150,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				SERIAL_BAUD_RATE* pBaudRate = (SERIAL_BAUD_RATE*)lpInBuffer;
 
-				assert(nInBufferSize >= sizeof(SERIAL_BAUD_RATE));
+				WINPR_ASSERT(nInBufferSize >= sizeof(SERIAL_BAUD_RATE));
 				if (nInBufferSize < sizeof(SERIAL_BAUD_RATE))
 				{
 					SetLastError(ERROR_INVALID_PARAMETER);
@@ -167,7 +167,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				SERIAL_BAUD_RATE* pBaudRate = (SERIAL_BAUD_RATE*)lpOutBuffer;
 
-				assert(nOutBufferSize >= sizeof(SERIAL_BAUD_RATE));
+				WINPR_ASSERT(nOutBufferSize >= sizeof(SERIAL_BAUD_RATE));
 				if (nOutBufferSize < sizeof(SERIAL_BAUD_RATE))
 				{
 					SetLastError(ERROR_INSUFFICIENT_BUFFER);
@@ -188,7 +188,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				COMMPROP* pProperties = (COMMPROP*)lpOutBuffer;
 
-				assert(nOutBufferSize >= sizeof(COMMPROP));
+				WINPR_ASSERT(nOutBufferSize >= sizeof(COMMPROP));
 				if (nOutBufferSize < sizeof(COMMPROP))
 				{
 					SetLastError(ERROR_INSUFFICIENT_BUFFER);
@@ -209,7 +209,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				SERIAL_CHARS* pSerialChars = (SERIAL_CHARS*)lpInBuffer;
 
-				assert(nInBufferSize >= sizeof(SERIAL_CHARS));
+				WINPR_ASSERT(nInBufferSize >= sizeof(SERIAL_CHARS));
 				if (nInBufferSize < sizeof(SERIAL_CHARS))
 				{
 					SetLastError(ERROR_INVALID_PARAMETER);
@@ -226,7 +226,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				SERIAL_CHARS* pSerialChars = (SERIAL_CHARS*)lpOutBuffer;
 
-				assert(nOutBufferSize >= sizeof(SERIAL_CHARS));
+				WINPR_ASSERT(nOutBufferSize >= sizeof(SERIAL_CHARS));
 				if (nOutBufferSize < sizeof(SERIAL_CHARS))
 				{
 					SetLastError(ERROR_INSUFFICIENT_BUFFER);
@@ -247,7 +247,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				SERIAL_LINE_CONTROL* pLineControl = (SERIAL_LINE_CONTROL*)lpInBuffer;
 
-				assert(nInBufferSize >= sizeof(SERIAL_LINE_CONTROL));
+				WINPR_ASSERT(nInBufferSize >= sizeof(SERIAL_LINE_CONTROL));
 				if (nInBufferSize < sizeof(SERIAL_LINE_CONTROL))
 				{
 					SetLastError(ERROR_INVALID_PARAMETER);
@@ -264,7 +264,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				SERIAL_LINE_CONTROL* pLineControl = (SERIAL_LINE_CONTROL*)lpOutBuffer;
 
-				assert(nOutBufferSize >= sizeof(SERIAL_LINE_CONTROL));
+				WINPR_ASSERT(nOutBufferSize >= sizeof(SERIAL_LINE_CONTROL));
 				if (nOutBufferSize < sizeof(SERIAL_LINE_CONTROL))
 				{
 					SetLastError(ERROR_INSUFFICIENT_BUFFER);
@@ -285,7 +285,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				SERIAL_HANDFLOW* pHandflow = (SERIAL_HANDFLOW*)lpInBuffer;
 
-				assert(nInBufferSize >= sizeof(SERIAL_HANDFLOW));
+				WINPR_ASSERT(nInBufferSize >= sizeof(SERIAL_HANDFLOW));
 				if (nInBufferSize < sizeof(SERIAL_HANDFLOW))
 				{
 					SetLastError(ERROR_INVALID_PARAMETER);
@@ -302,7 +302,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				SERIAL_HANDFLOW* pHandflow = (SERIAL_HANDFLOW*)lpOutBuffer;
 
-				assert(nOutBufferSize >= sizeof(SERIAL_HANDFLOW));
+				WINPR_ASSERT(nOutBufferSize >= sizeof(SERIAL_HANDFLOW));
 				if (nOutBufferSize < sizeof(SERIAL_HANDFLOW))
 				{
 					SetLastError(ERROR_INSUFFICIENT_BUFFER);
@@ -323,7 +323,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				SERIAL_TIMEOUTS* pHandflow = (SERIAL_TIMEOUTS*)lpInBuffer;
 
-				assert(nInBufferSize >= sizeof(SERIAL_TIMEOUTS));
+				WINPR_ASSERT(nInBufferSize >= sizeof(SERIAL_TIMEOUTS));
 				if (nInBufferSize < sizeof(SERIAL_TIMEOUTS))
 				{
 					SetLastError(ERROR_INVALID_PARAMETER);
@@ -340,7 +340,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				SERIAL_TIMEOUTS* pHandflow = (SERIAL_TIMEOUTS*)lpOutBuffer;
 
-				assert(nOutBufferSize >= sizeof(SERIAL_TIMEOUTS));
+				WINPR_ASSERT(nOutBufferSize >= sizeof(SERIAL_TIMEOUTS));
 				if (nOutBufferSize < sizeof(SERIAL_TIMEOUTS))
 				{
 					SetLastError(ERROR_INSUFFICIENT_BUFFER);
@@ -393,7 +393,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				ULONG* pRegister = (ULONG*)lpOutBuffer;
 
-				assert(nOutBufferSize >= sizeof(ULONG));
+				WINPR_ASSERT(nOutBufferSize >= sizeof(ULONG));
 				if (nOutBufferSize < sizeof(ULONG))
 				{
 					SetLastError(ERROR_INSUFFICIENT_BUFFER);
@@ -414,7 +414,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				ULONG* pWaitMask = (ULONG*)lpInBuffer;
 
-				assert(nInBufferSize >= sizeof(ULONG));
+				WINPR_ASSERT(nInBufferSize >= sizeof(ULONG));
 				if (nInBufferSize < sizeof(ULONG))
 				{
 					SetLastError(ERROR_INVALID_PARAMETER);
@@ -431,7 +431,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				ULONG* pWaitMask = (ULONG*)lpOutBuffer;
 
-				assert(nOutBufferSize >= sizeof(ULONG));
+				WINPR_ASSERT(nOutBufferSize >= sizeof(ULONG));
 				if (nOutBufferSize < sizeof(ULONG))
 				{
 					SetLastError(ERROR_INSUFFICIENT_BUFFER);
@@ -452,7 +452,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				ULONG* pOutputMask = (ULONG*)lpOutBuffer;
 
-				assert(nOutBufferSize >= sizeof(ULONG));
+				WINPR_ASSERT(nOutBufferSize >= sizeof(ULONG));
 				if (nOutBufferSize < sizeof(ULONG))
 				{
 					SetLastError(ERROR_INSUFFICIENT_BUFFER);
@@ -476,7 +476,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				SERIAL_QUEUE_SIZE* pQueueSize = (SERIAL_QUEUE_SIZE*)lpInBuffer;
 
-				assert(nInBufferSize >= sizeof(SERIAL_QUEUE_SIZE));
+				WINPR_ASSERT(nInBufferSize >= sizeof(SERIAL_QUEUE_SIZE));
 				if (nInBufferSize < sizeof(SERIAL_QUEUE_SIZE))
 				{
 					SetLastError(ERROR_INVALID_PARAMETER);
@@ -493,7 +493,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				ULONG* pPurgeMask = (ULONG*)lpInBuffer;
 
-				assert(nInBufferSize >= sizeof(ULONG));
+				WINPR_ASSERT(nInBufferSize >= sizeof(ULONG));
 				if (nInBufferSize < sizeof(ULONG))
 				{
 					SetLastError(ERROR_INVALID_PARAMETER);
@@ -510,7 +510,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				SERIAL_STATUS* pCommstatus = (SERIAL_STATUS*)lpOutBuffer;
 
-				assert(nOutBufferSize >= sizeof(SERIAL_STATUS));
+				WINPR_ASSERT(nOutBufferSize >= sizeof(SERIAL_STATUS));
 				if (nOutBufferSize < sizeof(SERIAL_STATUS))
 				{
 					SetLastError(ERROR_INSUFFICIENT_BUFFER);
@@ -563,7 +563,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				ULONG* pMask = (ULONG*)lpOutBuffer;
 
-				assert(nOutBufferSize >= sizeof(ULONG));
+				WINPR_ASSERT(nOutBufferSize >= sizeof(ULONG));
 				if (nOutBufferSize < sizeof(ULONG))
 				{
 					SetLastError(ERROR_INSUFFICIENT_BUFFER);
@@ -584,7 +584,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				ULONG* pSize = (ULONG*)lpOutBuffer;
 
-				assert(nOutBufferSize >= sizeof(ULONG));
+				WINPR_ASSERT(nOutBufferSize >= sizeof(ULONG));
 				if (nOutBufferSize < sizeof(ULONG))
 				{
 					SetLastError(ERROR_INSUFFICIENT_BUFFER);
@@ -605,7 +605,7 @@ static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID l
 			{
 				UCHAR* pChar = (UCHAR*)lpInBuffer;
 
-				assert(nInBufferSize >= sizeof(UCHAR));
+				WINPR_ASSERT(nInBufferSize >= sizeof(UCHAR));
 				if (nInBufferSize < sizeof(UCHAR))
 				{
 					SetLastError(ERROR_INVALID_PARAMETER);

--- a/winpr/libwinpr/comm/comm_sercx_sys.c
+++ b/winpr/libwinpr/comm/comm_sercx_sys.c
@@ -22,7 +22,7 @@
 
 #if defined __linux__ && !defined ANDROID
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <termios.h>
 
 #include <winpr/wlog.h>

--- a/winpr/libwinpr/comm/comm_serial_sys.c
+++ b/winpr/libwinpr/comm/comm_serial_sys.c
@@ -22,7 +22,7 @@
 
 #if defined __linux__ && !defined ANDROID
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
@@ -248,7 +248,7 @@ static BOOL _set_baud_rate(WINPR_COMM* pComm, const SERIAL_BAUD_RATE* pBaudRate)
 				return FALSE;
 			}
 
-			assert(cfgetispeed(&futureState) == newSpeed);
+			WINPR_ASSERT(cfgetispeed(&futureState) == newSpeed);
 
 			if (_comm_ioctl_tcsetattr(pComm->fd, TCSANOW, &futureState) < 0)
 			{
@@ -922,7 +922,7 @@ static BOOL _set_dtr(WINPR_COMM* pComm)
 		return FALSE;
 
 	/* SERIAL_DTR_HANDSHAKE not supported as of today */
-	assert((handflow.ControlHandShake & SERIAL_DTR_HANDSHAKE) == 0);
+	WINPR_ASSERT((handflow.ControlHandShake & SERIAL_DTR_HANDSHAKE) == 0);
 
 	if (handflow.ControlHandShake & SERIAL_DTR_HANDSHAKE)
 	{
@@ -940,7 +940,7 @@ static BOOL _clear_dtr(WINPR_COMM* pComm)
 		return FALSE;
 
 	/* SERIAL_DTR_HANDSHAKE not supported as of today */
-	assert((handflow.ControlHandShake & SERIAL_DTR_HANDSHAKE) == 0);
+	WINPR_ASSERT((handflow.ControlHandShake & SERIAL_DTR_HANDSHAKE) == 0);
 
 	if (handflow.ControlHandShake & SERIAL_DTR_HANDSHAKE)
 	{
@@ -1154,7 +1154,7 @@ static BOOL _purge(WINPR_COMM* pComm, const ULONG* pPurgeMask)
 				              strerror(errno));
 			}
 
-			assert(errno == EAGAIN); /* no reader <=> no pending IRP_MJ_WRITE */
+			WINPR_ASSERT(errno == EAGAIN); /* no reader <=> no pending IRP_MJ_WRITE */
 		}
 	}
 
@@ -1170,7 +1170,7 @@ static BOOL _purge(WINPR_COMM* pComm, const ULONG* pPurgeMask)
 				              strerror(errno));
 			}
 
-			assert(errno == EAGAIN); /* no reader <=> no pending IRP_MJ_READ */
+			WINPR_ASSERT(errno == EAGAIN); /* no reader <=> no pending IRP_MJ_READ */
 		}
 	}
 
@@ -1398,7 +1398,7 @@ static void _consume_event(WINPR_COMM* pComm, ULONG* pOutputMask, ULONG event)
  */
 static BOOL _wait_on_mask(WINPR_COMM* pComm, ULONG* pOutputMask)
 {
-	assert(*pOutputMask == 0);
+	WINPR_ASSERT(*pOutputMask == 0);
 
 	EnterCriticalSection(&pComm->EventsLock);
 	pComm->PendingEvents |= SERIAL_EV_FREERDP_WAITING;
@@ -1427,7 +1427,7 @@ static BOOL _wait_on_mask(WINPR_COMM* pComm, ULONG* pOutputMask)
 			 *
 			 * http://msdn.microsoft.com/en-us/library/ff546805%28v=vs.85%29.aspx
 			 */
-			assert(*pOutputMask == 0);
+			WINPR_ASSERT(*pOutputMask == 0);
 
 			pComm->PendingEvents &= ~SERIAL_EV_FREERDP_WAITING;
 			LeaveCriticalSection(&pComm->EventsLock);
@@ -1563,7 +1563,7 @@ static BOOL _immediate_char(WINPR_COMM* pComm, const UCHAR* pChar)
 
 	result = CommWriteFile(pComm, pChar, 1, &nbBytesWritten, NULL);
 
-	assert(nbBytesWritten == 1);
+	WINPR_ASSERT(nbBytesWritten == 1);
 
 	return result;
 }

--- a/winpr/libwinpr/file/generic.c
+++ b/winpr/libwinpr/file/generic.c
@@ -42,7 +42,7 @@
 #include <io.h>
 #include <sys/stat.h>
 #else
-#include <assert.h>
+#include <winpr/assert.h>
 #include <pthread.h>
 #include <dirent.h>
 #include <libgen.h>
@@ -191,7 +191,7 @@ extern HANDLE_CREATOR* GetCommHandleCreator(void);
 
 static void _HandleCreatorsInit()
 {
-	assert(_HandleCreators == NULL);
+	WINPR_ASSERT(_HandleCreators == NULL);
 	_HandleCreators = ArrayList_New(TRUE);
 
 	if (!_HandleCreators)

--- a/winpr/libwinpr/handle/handle.c
+++ b/winpr/libwinpr/handle/handle.c
@@ -26,7 +26,6 @@
 
 #ifndef _WIN32
 
-#include <assert.h>
 #include <pthread.h>
 
 #include "../synch/synch.h"
@@ -39,7 +38,7 @@
 #include <unistd.h>
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include "../handle/handle.h"
 

--- a/winpr/libwinpr/pipe/pipe.c
+++ b/winpr/libwinpr/pipe/pipe.c
@@ -42,7 +42,7 @@
 #include <errno.h>
 #include <sys/un.h>
 #include <sys/socket.h>
-#include <assert.h>
+#include <winpr/assert.h>
 #include <unistd.h>
 
 #ifdef HAVE_SYS_AIO_H
@@ -526,8 +526,8 @@ static void winpr_unref_named_pipe(WINPR_NAMED_PIPE* pNamedPipe)
 	if (!pNamedPipe)
 		return;
 
-	assert(pNamedPipe->name);
-	assert(g_NamedPipeServerSockets);
+	WINPR_ASSERT(pNamedPipe->name);
+	WINPR_ASSERT(g_NamedPipeServerSockets);
 	// WLog_VRB(TAG, "%p (%s)", (void*) pNamedPipe, pNamedPipe->name);
 	ArrayList_Lock(g_NamedPipeServerSockets);
 
@@ -535,12 +535,12 @@ static void winpr_unref_named_pipe(WINPR_NAMED_PIPE* pNamedPipe)
 	{
 		baseSocket =
 		    (NamedPipeServerSocketEntry*)ArrayList_GetItem(g_NamedPipeServerSockets, index);
-		assert(baseSocket->name);
+		WINPR_ASSERT(baseSocket->name);
 
 		if (!strcmp(baseSocket->name, pNamedPipe->name))
 		{
-			assert(baseSocket->references > 0);
-			assert(baseSocket->serverfd != -1);
+			WINPR_ASSERT(baseSocket->references > 0);
+			WINPR_ASSERT(baseSocket->serverfd != -1);
 
 			if (--baseSocket->references == 0)
 			{

--- a/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
@@ -21,7 +21,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include "ntlm.h"
 #include "../sspi.h"
@@ -263,7 +263,7 @@ static BOOL ntlm_av_pair_add(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairList, NTL
 	ntlm_av_pair_set_len(pAvPair, AvLen);
 	if (AvLen)
 	{
-		assert(Value != NULL);
+		WINPR_ASSERT(Value != NULL);
 		CopyMemory(ntlm_av_pair_get_value_pointer(pAvPair), Value, AvLen);
 	}
 

--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
@@ -21,7 +21,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include "ntlm.h"
 #include "../sspi.h"
@@ -745,7 +745,7 @@ void ntlm_compute_message_integrity_check(NTLM_CONTEXT* context, BYTE* mic, UINT
 	 * CHALLENGE_MESSAGE, AUTHENTICATE_MESSAGE) using the ExportedSessionKey
 	 */
 	WINPR_HMAC_CTX* hmac = winpr_HMAC_New();
-	assert(size >= WINPR_MD5_DIGEST_LENGTH);
+	WINPR_ASSERT(size >= WINPR_MD5_DIGEST_LENGTH);
 
 	if (!hmac)
 		return;

--- a/winpr/libwinpr/synch/barrier.c
+++ b/winpr/libwinpr/synch/barrier.c
@@ -30,7 +30,7 @@
 
 #ifdef WINPR_SYNCHRONIZATION_BARRIER
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <winpr/sysinfo.h>
 #include <winpr/library.h>
 #include <winpr/interlocked.h>
@@ -175,7 +175,7 @@ BOOL WINAPI winpr_EnterSynchronizationBarrier(LPSYNCHRONIZATION_BARRIER lpBarrie
 
 	remainingThreads = InterlockedDecrement((LONG*)&lpBarrier->Reserved1);
 
-	assert(remainingThreads >= 0);
+	WINPR_ASSERT(remainingThreads >= 0);
 
 	if (remainingThreads > 0)
 	{

--- a/winpr/libwinpr/synch/wait.c
+++ b/winpr/libwinpr/synch/wait.c
@@ -26,7 +26,7 @@
 #include <unistd.h>
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <errno.h>
 
 #include <winpr/crt.h>

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -24,7 +24,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 
 #include <winpr/handle.h>
 
@@ -312,7 +312,7 @@ static void* thread_launcher(void* arg)
 	if (pthread_mutex_unlock(&thread->threadIsReadyMutex))
 		goto exit;
 
-	assert(ListDictionary_Contains(thread_list, &thread->thread));
+	WINPR_ASSERT(ListDictionary_Contains(thread_list, &thread->thread));
 	rc = fkt(thread->lpParameter);
 exit:
 
@@ -586,7 +586,7 @@ VOID ExitThread(DWORD dwExitCode)
 		WINPR_THREAD* thread;
 		ListDictionary_Lock(thread_list);
 		thread = ListDictionary_GetItemValue(thread_list, &tid);
-		assert(thread);
+		WINPR_ASSERT(thread);
 		thread->exited = TRUE;
 		thread->dwExitCode = dwExitCode;
 #if defined(WITH_DEBUG_THREADS)

--- a/winpr/libwinpr/utils/stream.c
+++ b/winpr/libwinpr/utils/stream.c
@@ -22,7 +22,7 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
+#include <winpr/assert.h>
 #include <winpr/crt.h>
 #include <winpr/stream.h>
 
@@ -110,8 +110,8 @@ wStream* Stream_New(BYTE* buffer, size_t size)
 
 void Stream_StaticInit(wStream* s, BYTE* buffer, size_t size)
 {
-	assert(s);
-	assert(buffer);
+	WINPR_ASSERT(s);
+	WINPR_ASSERT(buffer);
 
 	s->buffer = s->pointer = buffer;
 	s->capacity = s->length = size;


### PR DESCRIPTION
Added a WinPR macro that can be used for WinPR and FreeRDP to
replace standard C assert.
It is more verbose and logs issues to WLog which makes it easier
for us to trace problems in the field.
@hardening what do you think about this?