### PR TITLE
Re-added "extern" to ntlm_export.h symbols

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm_export.h
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_export.h
@@ -28,10 +28,10 @@ extern "C"
 {
 #endif
 
-	const SecPkgInfoA NTLM_SecPkgInfoA;
-	const SecPkgInfoW NTLM_SecPkgInfoW;
-	const SecurityFunctionTableA NTLM_SecurityFunctionTableA;
-	const SecurityFunctionTableW NTLM_SecurityFunctionTableW;
+	extern const SecPkgInfoA NTLM_SecPkgInfoA;
+	extern const SecPkgInfoW NTLM_SecPkgInfoW;
+	extern const SecurityFunctionTableA NTLM_SecurityFunctionTableA;
+	extern const SecurityFunctionTableW NTLM_SecurityFunctionTableW;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This fixes a regression introduced in commit 81a4670af which broke LTO by introducing duplicate symbols.

Compiler error without this commit follows:

```: && /usr/lib/ccache/bin/clang -fPIC -march=native -O3 -pipe -Wno-unused-parameter -Wno-unused-macros -Wno-padded -Wno-c11-extensions -Wno-gnu -Wno-unused-command-line-argument -Wno-deprecated-declarations -fno-omit-frame-pointer -DWINPR_DLL -DWINPR_DLL -DWINPR_EXPORTS  -Wl,-O1 -Wl,--as-needed -rtlib=compiler-rt -unwindlib=libunwind -flto=thin -Wl,--thinlto-jobs=10 -fuse-ld=lld -march=native -O3 -pipe -stdlib=libstdc++ -shared -Wl,-soname,libwinpr3.so.3 -o winpr/libwinpr/libwinpr3.so.3.0.0 winpr/libwinpr/CMakeFiles/winpr.dir/synch/address.c.o winpr/libwinpr/CMakeFiles/winpr.dir/synch/barrier.c.o winpr/libwinpr/CMakeFiles/winpr.dir/synch/critical.c.o winpr/libwinpr/CMakeFiles/winpr.dir/synch/event.c.o winpr/libwinpr/CMakeFiles/winpr.dir/synch/init.c.o winpr/libwinpr/CMakeFiles/winpr.dir/synch/mutex.c.o winpr/libwinpr/CMakeFiles/winpr.dir/synch/pollset.c.o winpr/libwinpr/CMakeFiles/winpr.dir/synch/semaphore.c.o winpr/libwinpr/CMakeFiles/winpr.dir/synch/sleep.c.o winpr/libwinpr/CMakeFiles/winpr.dir/synch/timer.c.o winpr/libwinpr/CMakeFiles/winpr.dir/synch/wait.c.o winpr/libwinpr/CMakeFiles/winpr.dir/locale/locale.c.o winpr/libwinpr/CMakeFiles/winpr.dir/library/library.c.o winpr/libwinpr/CMakeFiles/winpr.dir/file/generic.c.o winpr/libwinpr/CMakeFiles/winpr.dir/file/namedPipeClient.c.o winpr/libwinpr/CMakeFiles/winpr.dir/file/pattern.c.o winpr/libwinpr/CMakeFiles/winpr.dir/file/file.c.o winpr/libwinpr/CMakeFiles/winpr.dir/comm/comm.c.o winpr/libwinpr/CMakeFiles/winpr.dir/comm/comm_io.c.o winpr/libwinpr/CMakeFiles/winpr.dir/comm/comm_ioctl.c.o winpr/libwinpr/CMakeFiles/winpr.dir/comm/comm_serial_sys.c.o winpr/libwinpr/CMakeFiles/winpr.dir/comm/comm_sercx_sys.c.o winpr/libwinpr/CMakeFiles/winpr.dir/comm/comm_sercx2_sys.c.o winpr/libwinpr/CMakeFiles/winpr.dir/pipe/pipe.c.o winpr/libwinpr/CMakeFiles/winpr.dir/interlocked/interlocked.c.o winpr/libwinpr/CMakeFiles/winpr.dir/security/security.c.o winpr/libwinpr/CMakeFiles/winpr.dir/environment/environment.c.o winpr/libwinpr/CMakeFiles/winpr.dir/crypto/hash.c.o winpr/libwinpr/CMakeFiles/winpr.dir/crypto/rand.c.o winpr/libwinpr/CMakeFiles/winpr.dir/crypto/cipher.c.o winpr/libwinpr/CMakeFiles/winpr.dir/crypto/cert.c.o winpr/libwinpr/CMakeFiles/winpr.dir/crypto/crypto.c.o winpr/libwinpr/CMakeFiles/winpr.dir/registry/registry_reg.c.o winpr/libwinpr/CMakeFiles/winpr.dir/registry/registry.c.o winpr/libwinpr/CMakeFiles/winpr.dir/credentials/credentials.c.o winpr/libwinpr/CMakeFiles/winpr.dir/path/path.c.o winpr/libwinpr/CMakeFiles/winpr.dir/path/shell.c.o winpr/libwinpr/CMakeFiles/winpr.dir/io/device.c.o winpr/libwinpr/CMakeFiles/winpr.dir/io/io.c.o winpr/libwinpr/CMakeFiles/winpr.dir/memory/memory.c.o winpr/libwinpr/CMakeFiles/winpr.dir/input/virtualkey.c.o winpr/libwinpr/CMakeFiles/winpr.dir/input/scancode.c.o winpr/libwinpr/CMakeFiles/winpr.dir/input/keycode.c.o winpr/libwinpr/CMakeFiles/winpr.dir/shell/shell.c.o winpr/libwinpr/CMakeFiles/winpr.dir/heap/heap.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/ini.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/sam.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/ntlm.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/image.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/print.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/stream.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/strlst.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/debug.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/winpr.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/cmdline.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/ssl.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/Queue.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/Stack.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/PubSub.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/BipBuffer.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/BitStream.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/Reference.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/ArrayList.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/LinkedList.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/HashTable.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/ListDictionary.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/CountdownEvent.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/BufferPool.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/ObjectPool.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/StreamPool.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/MessageQueue.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/collections/MessagePipe.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/lodepng/lodepng.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/trio/trio.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/trio/trionan.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/trio/triostr.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/wlog/wlog.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/wlog/Layout.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/wlog/Message.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/wlog/DataMessage.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/wlog/ImageMessage.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/wlog/PacketMessage.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/wlog/Appender.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/wlog/FileAppender.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/wlog/BinaryAppender.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/wlog/CallbackAppender.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/wlog/ConsoleAppender.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/wlog/UdpAppender.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/wlog/SyslogAppender.c.o winpr/libwinpr/CMakeFiles/winpr.dir/utils/wlog/JournaldAppender.c.o winpr/libwinpr/CMakeFiles/winpr.dir/error/error.c.o winpr/libwinpr/CMakeFiles/winpr.dir/timezone/timezone.c.o winpr/libwinpr/CMakeFiles/winpr.dir/timezone/TimeZones.c.o winpr/libwinpr/CMakeFiles/winpr.dir/timezone/WindowsZones.c.o winpr/libwinpr/CMakeFiles/winpr.dir/sysinfo/sysinfo.c.o winpr/libwinpr/CMakeFiles/winpr.dir/pool/synch.c.o winpr/libwinpr/CMakeFiles/winpr.dir/pool/work.c.o winpr/libwinpr/CMakeFiles/winpr.dir/pool/timer.c.o winpr/libwinpr/CMakeFiles/winpr.dir/pool/io.c.o winpr/libwinpr/CMakeFiles/winpr.dir/pool/cleanup_group.c.o winpr/libwinpr/CMakeFiles/winpr.dir/pool/pool.c.o winpr/libwinpr/CMakeFiles/winpr.dir/pool/callback.c.o winpr/libwinpr/CMakeFiles/winpr.dir/pool/callback_cleanup.c.o winpr/libwinpr/CMakeFiles/winpr.dir/handle/handle.c.o winpr/libwinpr/CMakeFiles/winpr.dir/handle/nonehandle.c.o winpr/libwinpr/CMakeFiles/winpr.dir/thread/apc.c.o winpr/libwinpr/CMakeFiles/winpr.dir/thread/argv.c.o winpr/libwinpr/CMakeFiles/winpr.dir/thread/process.c.o winpr/libwinpr/CMakeFiles/winpr.dir/thread/processor.c.o winpr/libwinpr/CMakeFiles/winpr.dir/thread/thread.c.o winpr/libwinpr/CMakeFiles/winpr.dir/thread/tls.c.o winpr/libwinpr/CMakeFiles/winpr.dir/winsock/winsock.c.o winpr/libwinpr/CMakeFiles/winpr.dir/sspi/CredSSP/credssp.c.o winpr/libwinpr/CMakeFiles/winpr.dir/sspi/NTLM/ntlm_av_pairs.c.o winpr/libwinpr/CMakeFiles/winpr.dir/sspi/NTLM/ntlm_compute.c.o winpr/libwinpr/CMakeFiles/winpr.dir/sspi/NTLM/ntlm_message.c.o winpr/libwinpr/CMakeFiles/winpr.dir/sspi/NTLM/ntlm.c.o winpr/libwinpr/CMakeFiles/winpr.dir/sspi/Kerberos/kerberos.c.o winpr/libwinpr/CMakeFiles/winpr.dir/sspi/Negotiate/negotiate.c.o winpr/libwinpr/CMakeFiles/winpr.dir/sspi/Schannel/schannel_openssl.c.o winpr/libwinpr/CMakeFiles/winpr.dir/sspi/Schannel/schannel.c.o winpr/libwinpr/CMakeFiles/winpr.dir/sspi/sspi_winpr.c.o winpr/libwinpr/CMakeFiles/winpr.dir/sspi/sspi_export.c.o winpr/libwinpr/CMakeFiles/winpr.dir/sspi/sspi_gss.c.o winpr/libwinpr/CMakeFiles/winpr.dir/sspi/sspi.c.o winpr/libwinpr/CMakeFiles/winpr.dir/winhttp/winhttp.c.o winpr/libwinpr/CMakeFiles/winpr.dir/asn1/asn1.c.o winpr/libwinpr/CMakeFiles/winpr.dir/sspicli/sspicli.c.o winpr/libwinpr/CMakeFiles/winpr.dir/crt/alignment.c.o winpr/libwinpr/CMakeFiles/winpr.dir/crt/conversion.c.o winpr/libwinpr/CMakeFiles/winpr.dir/crt/buffer.c.o winpr/libwinpr/CMakeFiles/winpr.dir/crt/memory.c.o winpr/libwinpr/CMakeFiles/winpr.dir/crt/unicode.c.o winpr/libwinpr/CMakeFiles/winpr.dir/crt/string.c.o winpr/libwinpr/CMakeFiles/winpr.dir/crt/utf.c.o winpr/libwinpr/CMakeFiles/winpr.dir/bcrypt/bcrypt.c.o winpr/libwinpr/CMakeFiles/winpr.dir/rpc/rpc.c.o winpr/libwinpr/CMakeFiles/winpr.dir/rpc/ndr.c.o winpr/libwinpr/CMakeFiles/winpr.dir/rpc/ndr_array.c.o winpr/libwinpr/CMakeFiles/winpr.dir/rpc/ndr_context.c.o winpr/libwinpr/CMakeFiles/winpr.dir/rpc/ndr_correlation.c.o winpr/libwinpr/CMakeFiles/winpr.dir/rpc/ndr_pointer.c.o winpr/libwinpr/CMakeFiles/winpr.dir/rpc/ndr_private.c.o winpr/libwinpr/CMakeFiles/winpr.dir/rpc/ndr_simple.c.o winpr/libwinpr/CMakeFiles/winpr.dir/rpc/ndr_string.c.o winpr/libwinpr/CMakeFiles/winpr.dir/rpc/ndr_structure.c.o winpr/libwinpr/CMakeFiles/winpr.dir/rpc/ndr_union.c.o winpr/libwinpr/CMakeFiles/winpr.dir/rpc/midl.c.o winpr/libwinpr/CMakeFiles/winpr.dir/credui/credui.c.o winpr/libwinpr/CMakeFiles/winpr.dir/wtsapi/wtsapi.c.o winpr/libwinpr/CMakeFiles/winpr.dir/dsparse/dsparse.c.o winpr/libwinpr/CMakeFiles/winpr.dir/wnd/wnd.c.o winpr/libwinpr/CMakeFiles/winpr.dir/smartcard/smartcard.c.o winpr/libwinpr/CMakeFiles/winpr.dir/smartcard/smartcard_pcsc.c.o winpr/libwinpr/CMakeFiles/winpr.dir/smartcard/smartcard_inspect.c.o winpr/libwinpr/CMakeFiles/winpr.dir/nt/nt.c.o winpr/libwinpr/CMakeFiles/winpr.dir/nt/ntstatus.c.o winpr/libwinpr/CMakeFiles/winpr.dir/clipboard/synthetic.c.o winpr/libwinpr/CMakeFiles/winpr.dir/clipboard/clipboard.c.o winpr/libwinpr/CMakeFiles/winpr.dir/clipboard/posix.c.o  -Wl,-rpath,:::::::::::::::::::::::::::  -lrt  -lssl  -lcrypto  -lsystemd  -lm  -lpthread  -ldl && :
ld.lld: error: duplicate symbol: NTLM_SecPkgInfoA
>>> defined at ntlm.c
>>>            winpr/libwinpr/CMakeFiles/winpr.dir/sspi/NTLM/ntlm.c.o:(NTLM_SecPkgInfoA)
>>> defined at sspi_winpr.c
>>>            winpr/libwinpr/CMakeFiles/winpr.dir/sspi/sspi_winpr.c.o:(.rodata+0x0)

ld.lld: error: duplicate symbol: NTLM_SecPkgInfoW
>>> defined at ntlm.c
>>>            winpr/libwinpr/CMakeFiles/winpr.dir/sspi/NTLM/ntlm.c.o:(NTLM_SecPkgInfoW)
>>> defined at sspi_winpr.c
>>>            winpr/libwinpr/CMakeFiles/winpr.dir/sspi/sspi_winpr.c.o:(.rodata+0x20)

ld.lld: error: duplicate symbol: NTLM_SecurityFunctionTableA
>>> defined at ntlm.c
>>>            winpr/libwinpr/CMakeFiles/winpr.dir/sspi/NTLM/ntlm.c.o:(NTLM_SecurityFunctionTableA)
>>> defined at sspi_winpr.c
>>>            winpr/libwinpr/CMakeFiles/winpr.dir/sspi/sspi_winpr.c.o:(.rodata+0x40)

ld.lld: error: duplicate symbol: NTLM_SecurityFunctionTableW
>>> defined at ntlm.c
>>>            winpr/libwinpr/CMakeFiles/winpr.dir/sspi/NTLM/ntlm.c.o:(NTLM_SecurityFunctionTableW)
>>> defined at sspi_winpr.c
>>>            winpr/libwinpr/CMakeFiles/winpr.dir/sspi/sspi_winpr.c.o:(.rodata+0x120)
clang-12: error: linker command failed with exit code 1 (use -v to see invocation)
```