### PR TITLE
Fixed audin codec negociation

### DIFF
--- a/channels/audin/client/audin_main.c
+++ b/channels/audin/client/audin_main.c
@@ -251,7 +251,7 @@ static UINT audin_process_formats(AUDIN_PLUGIN* audin, AUDIN_CHANNEL_CALLBACK* c
 			continue;
 		}
 
-		if (freerdp_dsp_supports_format(&format, TRUE) ||
+		if (freerdp_dsp_supports_format(&format, TRUE) &&
 		    audin->device->FormatSupported(audin->device, &format))
 		{
 			/* Store the agreed format in the corresponding index */


### PR DESCRIPTION
Currently, there is a bug when try to open an RDP session to a server that has multiple DSP versions, and if the first one is not supported by the client: That first one will anyway be chosen because of the bug, so the audio in won't be correctly redirected.

This patch really check that the codec is supported before to choose it.
