### PR TITLE
Use lstat instead of stat for FindFirstFile and FindNextFile win32 api

### DIFF
--- a/winpr/libwinpr/file/generic.c
+++ b/winpr/libwinpr/file/generic.c
@@ -849,7 +849,7 @@ HANDLE FindFirstFileA(LPCSTR lpFileName, LPWIN32_FIND_DATAA lpFindFileData)
 		return INVALID_HANDLE_VALUE;
 	}
 
-	if (stat(lpFileName, &fileStat) >= 0)
+	if (lstat(lpFileName, &fileStat) >= 0)
 	{
 		isDir = (S_ISDIR(fileStat.st_mode) != 0);
 	}
@@ -1082,7 +1082,7 @@ BOOL FindNextFileA(HANDLE hFindFile, LPWIN32_FIND_DATAA lpFindFileData)
 			memcpy(fullpath + pathlen, pFileSearch->pDirent->d_name, namelen);
 			fullpath[pathlen + namelen] = 0;
 
-			if (stat(fullpath, &fileStat) != 0)
+			if (lstat(fullpath, &fileStat) != 0)
 			{
 				free(fullpath);
 				SetLastError(map_posix_err(errno));


### PR DESCRIPTION
FindFirstFile and FindNextFile are using stat to get file informations.

But according to the Microsoft docs ([FindFirstFile](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilea) and [FindNextFile](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findnextfilea)):

> If the path points to a symbolic link, the WIN32_FIND_DATA buffer contains information about the symbolic link, not the target.

So this patch replaces stat by lstat to have information about the symbolic link itself.

WARNING: According to the git history, it was already lstat before but Armin Novak has changed it to stat because of #3922. So this ticket should probably be fixed another way since using stat is not the right thing to do.

