### PR TITLE
Added SuspendInput setting

### DIFF
--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -821,6 +821,7 @@ typedef struct _RDPDR_PARALLEL RDPDR_PARALLEL;
 #define FreeRDP_KeyboardHook (2633)
 #define FreeRDP_HasHorizontalWheel (2634)
 #define FreeRDP_HasExtendedMouseEvent (2635)
+#define FreeRDP_SuspendInput (2636)
 #define FreeRDP_BrushSupportLevel (2688)
 #define FreeRDP_GlyphSupportLevel (2752)
 #define FreeRDP_GlyphCache (2753)
@@ -1368,7 +1369,13 @@ struct rdp_settings
 	ALIGN64 UINT32 KeyboardHook;         /* 2633 */
 	ALIGN64 BOOL HasHorizontalWheel;     /* 2634 */
 	ALIGN64 BOOL HasExtendedMouseEvent;  /* 2635 */
-	UINT64 padding2688[2688 - 2636];     /* 2636 */
+
+	/** SuspendInput disables processing of keyboard/mouse/multitouch input.
+	 * If used by an implementation ensure proper state resync after reenabling
+	 * input
+	 */
+	ALIGN64 BOOL SuspendInput;           /* 2636 */
+	UINT64 padding2688[2688 - 2637];     /* 2637 */
 
 	/* Brush Capabilities */
 	ALIGN64 UINT32 BrushSupportLevel; /* 2688 */

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -492,6 +492,9 @@ BOOL freerdp_settings_get_bool(const rdpSettings* settings, size_t id)
 		case FreeRDP_SurfaceFrameMarkerEnabled:
 			return settings->SurfaceFrameMarkerEnabled;
 
+		case FreeRDP_SuspendInput:
+			return settings->SuspendInput;
+
 		case FreeRDP_TcpKeepAlive:
 			return settings->TcpKeepAlive;
 
@@ -1159,6 +1162,10 @@ BOOL freerdp_settings_set_bool(rdpSettings* settings, size_t id, BOOL val)
 
 		case FreeRDP_SurfaceFrameMarkerEnabled:
 			settings->SurfaceFrameMarkerEnabled = val;
+			break;
+
+		case FreeRDP_SuspendInput:
+			settings->SuspendInput = val;
 			break;
 
 		case FreeRDP_TcpKeepAlive:

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -169,6 +169,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_SuppressOutput, 0, "FreeRDP_SuppressOutput" },
 	{ FreeRDP_SurfaceCommandsEnabled, 0, "FreeRDP_SurfaceCommandsEnabled" },
 	{ FreeRDP_SurfaceFrameMarkerEnabled, 0, "FreeRDP_SurfaceFrameMarkerEnabled" },
+	{ FreeRDP_SuspendInput, 0, "FreeRDP_SuspendInput" },
 	{ FreeRDP_TcpKeepAlive, 0, "FreeRDP_TcpKeepAlive" },
 	{ FreeRDP_TlsSecurity, 0, "FreeRDP_TlsSecurity" },
 	{ FreeRDP_ToggleFullscreen, 0, "FreeRDP_ToggleFullscreen" },

--- a/libfreerdp/core/input.c
+++ b/libfreerdp/core/input.c
@@ -672,16 +672,22 @@ BOOL input_register_client_callbacks(rdpInput* input)
 
 BOOL freerdp_input_send_synchronize_event(rdpInput* input, UINT32 flags)
 {
-	if (!input)
+	if (!input || !input->context)
 		return FALSE;
+
+	if (freerdp_settings_get_bool(input->context->settings, FreeRDP_SuspendInput))
+		return TRUE;
 
 	return IFCALLRESULT(TRUE, input->SynchronizeEvent, input, flags);
 }
 
 BOOL freerdp_input_send_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
 {
-	if (!input)
+	if (!input || !input->context)
 		return FALSE;
+
+	if (freerdp_settings_get_bool(input->context->settings, FreeRDP_SuspendInput))
+		return TRUE;
 
 	return IFCALLRESULT(TRUE, input->KeyboardEvent, input, flags, code);
 }
@@ -697,40 +703,55 @@ BOOL freerdp_input_send_keyboard_event_ex(rdpInput* input, BOOL down, UINT32 rdp
 
 BOOL freerdp_input_send_unicode_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
 {
-	if (!input)
+	if (!input || !input->context)
 		return FALSE;
+
+	if (freerdp_settings_get_bool(input->context->settings, FreeRDP_SuspendInput))
+		return TRUE;
 
 	return IFCALLRESULT(TRUE, input->UnicodeKeyboardEvent, input, flags, code);
 }
 
 BOOL freerdp_input_send_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UINT16 y)
 {
-	if (!input)
+	if (!input || !input->context)
 		return FALSE;
+
+	if (freerdp_settings_get_bool(input->context->settings, FreeRDP_SuspendInput))
+		return TRUE;
 
 	return IFCALLRESULT(TRUE, input->MouseEvent, input, flags, x, y);
 }
 
 BOOL freerdp_input_send_extended_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UINT16 y)
 {
-	if (!input)
+	if (!input || !input->context)
 		return FALSE;
+
+	if (freerdp_settings_get_bool(input->context->settings, FreeRDP_SuspendInput))
+		return TRUE;
 
 	return IFCALLRESULT(TRUE, input->ExtendedMouseEvent, input, flags, x, y);
 }
 
 BOOL freerdp_input_send_focus_in_event(rdpInput* input, UINT16 toggleStates)
 {
-	if (!input)
+	if (!input || !input->context)
 		return FALSE;
+
+	if (freerdp_settings_get_bool(input->context->settings, FreeRDP_SuspendInput))
+		return TRUE;
 
 	return IFCALLRESULT(TRUE, input->FocusInEvent, input, toggleStates);
 }
 
 BOOL freerdp_input_send_keyboard_pause_event(rdpInput* input)
 {
-	if (!input)
+	if (!input || !input->context)
 		return FALSE;
+
+	if (freerdp_settings_get_bool(input->context->settings, FreeRDP_SuspendInput))
+		return TRUE;
 
 	return IFCALLRESULT(TRUE, input->KeyboardPauseEvent, input);
 }

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -158,6 +158,7 @@ static const size_t bool_list_indices[] = {
 	FreeRDP_SuppressOutput,
 	FreeRDP_SurfaceCommandsEnabled,
 	FreeRDP_SurfaceFrameMarkerEnabled,
+	FreeRDP_SuspendInput,
 	FreeRDP_TcpKeepAlive,
 	FreeRDP_TlsSecurity,
 	FreeRDP_ToggleFullscreen,


### PR DESCRIPTION
Allows to disable all keyboard/mouse/multitouch input from the
client side.