### PR TITLE
Revert dh_missing --fail-missing

### DIFF
--- a/packaging/deb/freerdp-nightly/rules
+++ b/packaging/deb/freerdp-nightly/rules
@@ -47,8 +47,7 @@ override_dh_install:
 	mkdir -p debian/tmp/opt/freerdp-nightly/lib/cmake/
 	rm -rf debian/tmp/opt/freerdp-nightly/lib/freerdp2/*.a
 
-	dh_install
-	dh_missing --fail-missing
+	dh_install --fail-missing
 
 override_dh_clean:
 	rm -f config.h


### PR DESCRIPTION
This option is not supported on older debian/ubuntu releases.
keep the warning for the time being.