### PR TITLE
proxy dynamic channel passthrough support

### DIFF
--- a/include/freerdp/client/dynamic_passthrough.h
+++ b/include/freerdp/client/dynamic_passthrough.h
@@ -1,0 +1,66 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * FreeRDP Dynamic Virtual Channel Passthrough
+ *
+ * Copyright 2021 Alexandru Bagu <alexandru.bagu@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CLIENT_DYNAMIC_PASSTHROUGH_H
+#define FREERDP_CLIENT_DYNAMIC_PASSTHROUGH_H
+
+#include <freerdp/dvc.h>
+
+typedef struct _dynamic_passthrough_client_context DynamicPassthroughClientContext;
+
+typedef UINT (*pcDynamicPassthroughClientSend)(DynamicPassthroughClientContext* context,
+                                               const wStream* stream);
+
+typedef UINT (*pcDynamicPassthroughClientOnReceive)(DynamicPassthroughClientContext* context,
+                                                    const wStream* stream);
+
+typedef struct _DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL;
+typedef UINT (*pcDynamicPassthroughDisconnect)(DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL* context);
+
+struct _DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL
+{
+	void* dvcman_channel;
+	IWTSVirtualChannel* iface;
+	IWTSVirtualChannelCallback* channel_callback;
+
+	pcDynamicPassthroughDisconnect disconnect;
+};
+
+struct _dynamic_passthrough_client_context
+{
+	void* custom;
+	const char* channelname;
+	void* server;
+	DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL* dvcman_channel;
+
+	pcDynamicPassthroughClientSend Send;
+};
+
+typedef struct _DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL_CALLLBACK DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL_CALLLBACK;
+struct _DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL_CALLLBACK
+{
+	IWTSVirtualChannelCallback iface;
+
+	IWTSPlugin* plugin;
+	IWTSVirtualChannelManager* channel_mgr;
+	IWTSVirtualChannel* channel;
+
+  void* custom;
+};
+#endif /*FREERDP_CLIENT_DYNAMIC_PASSTHROUGH_H*/

--- a/include/freerdp/server/dynamic_passthrough.h
+++ b/include/freerdp/server/dynamic_passthrough.h
@@ -1,0 +1,54 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * FreeRDP Dynamic Virtual Channel Passthrough
+ *
+ * Copyright 2021 Alexandru Bagu <alexandru.bagu@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_SERVER_DYNAMIC_PASSTHROUGH_H
+#define FREERDP_SERVER_DYNAMIC_PASSTHROUGH_H
+
+typedef struct _dynamic_passthrough_server_context DynamicPassthroughServerContext;
+typedef struct _dynamic_passthrough_server_private DynamicPassthroughServerPrivate;
+
+typedef UINT (*pcDynamicPassthroughServerSend)(DynamicPassthroughServerContext* context,
+                                               const wStream* stream);
+
+typedef UINT (*pcDynamicPassthroughServerOnReceive)(DynamicPassthroughServerContext* context,
+                                                    const wStream* stream);
+
+
+struct _dynamic_passthrough_server_context
+{
+	void* custom;
+	const char* channelname;
+	void* client;
+	DynamicPassthroughServerPrivate* priv;
+
+	pcDynamicPassthroughServerSend Send;
+	pcDynamicPassthroughServerOnReceive OnReceive;
+};
+
+struct _dynamic_passthrough_server_private
+{
+	BOOL isReady;
+	HANDLE channelEvent;
+	HANDLE thread;
+	HANDLE stopEvent;
+
+	void* channel;
+};
+
+#endif /*FREERDP_SERVER_DYNAMIC_PASSTHROUGH_H*/

--- a/server/proxy/CMakeLists.txt
+++ b/server/proxy/CMakeLists.txt
@@ -54,6 +54,8 @@ set(${MODULE_PREFIX}_SRCS
   pf_rdpsnd.c
   pf_rdpsnd.h
   pf_log.h
+  pf_dynamic_passthrough.c
+  pf_dynamic_passthrough.h
   )
 
 # On windows create dll version information.

--- a/server/proxy/config.ini
+++ b/server/proxy/config.ini
@@ -31,9 +31,18 @@ DisplayControl = TRUE
 Clipboard = TRUE
 AudioOutput = TRUE
 RemoteApp = TRUE
-; a list of comma seperated static channels that will be proxied. This feature is useful,
-; for example when there's a custom static channel that isn't implemented in freerdp/proxy, and is needed to be proxied when connecting through the proxy.
-; Passthrough = ""
+
+; a list of comma seperated static channels that will be proxied
+; "rdpdr": [MS-RDPEFS] support for remote/shared file system
+StaticPassthrough = ""
+
+; a list of comma seperated dynamic channels that will be proxied
+; "PNPDR": [MS-RDPEPNP] support for plug'n'play devices 
+; "FileRedirectorChannel": [MS-RDPEPNP] passthrough file redirection for PNPDR
+; "URBDRC": [MS-RDPEUSB] support for usb redirection; requires PNPDR
+; "XPSRD": [MS-RDPEXPS] support for printers; available with rdpdr
+; "RDCamera_Device_Enumerator": [MS-RDPECAM] support for remote video capture devices
+DynamicPassthrough = ""
 
 [Clipboard]
 TextOnly = FALSE

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -119,15 +119,15 @@ static BOOL pf_client_passthrough_channels_init(pClientContext* pc)
 	proxyConfig* config = pc->pdata->config;
 	size_t i;
 
-	if (settings->ChannelCount + config->PassthroughCount >= settings->ChannelDefArraySize)
+	if (settings->ChannelCount + config->StaticPassthroughCount >= settings->ChannelDefArraySize)
 	{
 		LOG_ERR(TAG, pc, "too many channels");
 		return FALSE;
 	}
 
-	for (i = 0; i < config->PassthroughCount; i++)
+	for (i = 0; i < config->StaticPassthroughCount; i++)
 	{
-		const char* channel_name = config->Passthrough[i];
+		const char* channel_name = config->StaticPassthrough[i];
 		CHANNEL_DEF channel = { 0 };
 
 		/* only connect connect this channel if already joined in peer connection */
@@ -250,9 +250,9 @@ static BOOL pf_client_receive_channel_data_hook(freerdp* instance, UINT16 channe
 
 	const char* channel_name = freerdp_channels_get_name_by_id(instance, channelId);
 
-	for (i = 0; i < config->PassthroughCount; i++)
+	for (i = 0; i < config->StaticPassthroughCount; i++)
 	{
-		if (strncmp(channel_name, config->Passthrough[i], CHANNEL_NAME_LEN) == 0)
+		if (strncmp(channel_name, config->StaticPassthrough[i], CHANNEL_NAME_LEN) == 0)
 		{
 			proxyChannelDataEventInfo ev;
 			UINT64 server_channel_id;
@@ -340,9 +340,9 @@ static BOOL pf_client_post_connect(freerdp* instance)
 	/* populate channel name -> channel ids map */
 	{
 		size_t i;
-		for (i = 0; i < config->PassthroughCount; i++)
+		for (i = 0; i < config->StaticPassthroughCount; i++)
 		{
-			char* channel_name = config->Passthrough[i];
+			char* channel_name = config->StaticPassthrough[i];
 			UINT64 channel_id = (UINT64)freerdp_channels_get_id_by_name(instance, channel_name);
 			HashTable_Insert(pc->vc_ids, (void*)channel_name, (void*)channel_id);
 		}
@@ -619,6 +619,7 @@ static void pf_client_context_free(freerdp* instance, rdpContext* context)
 		return;
 
 	HashTable_Free(pc->vc_ids);
+	ArrayList_Free(pc->dynamic_passthrough_channels);
 }
 
 static BOOL pf_client_client_new(freerdp* instance, rdpContext* context)

--- a/server/proxy/pf_config.h
+++ b/server/proxy/pf_config.h
@@ -58,8 +58,10 @@ struct proxy_config
 	BOOL Clipboard;
 	BOOL AudioOutput;
 	BOOL RemoteApp;
-	char** Passthrough;
-	size_t PassthroughCount;
+	char** StaticPassthrough;
+	size_t StaticPassthroughCount;
+	char** DynamicPassthrough;
+	size_t DynamicPassthroughCount;
 
 	/* clipboard specific settings */
 	BOOL TextOnly;

--- a/server/proxy/pf_context.h
+++ b/server/proxy/pf_context.h
@@ -33,11 +33,14 @@
 #include <freerdp/server/disp.h>
 #include <freerdp/server/cliprdr.h>
 #include <freerdp/server/rdpsnd.h>
+#include <freerdp/client/dynamic_passthrough.h>
+#include <freerdp/server/dynamic_passthrough.h>
 
 #include "pf_config.h"
 #include "pf_server.h"
 
 #define PROXY_SESSION_ID_LENGTH 32
+#define DYNAMIC_PASSTHROUGH_MAX_CHANNELS 32
 
 typedef struct proxy_data proxyData;
 
@@ -59,6 +62,8 @@ struct p_server_context
 	CliprdrServerContext* cliprdr;
 	RdpsndServerContext* rdpsnd;
 
+	wArrayList* dynamic_passthrough_channels;
+
 	HANDLE* vc_handles; /* static virtual channels open handles */
 	wHashTable* vc_ids; /* channel_name -> channel_id map */
 };
@@ -79,6 +84,8 @@ struct p_client_context
 	DispClientContext* disp;
 	CliprdrClientContext* cliprdr;
 	RailClientContext* rail;
+
+	wArrayList* dynamic_passthrough_channels;
 
 	/*
 	 * In a case when freerdp_connect fails,

--- a/server/proxy/pf_dynamic_passthrough.c
+++ b/server/proxy/pf_dynamic_passthrough.c
@@ -1,0 +1,486 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * FreeRDP Proxy Server
+ *
+ * Copyright 2021 Alexandru Bagu <alexandru.bagu@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "pf_dynamic_passthrough.h"
+#include "pf_log.h"
+
+#define TAG PROXY_TAG("dynamic_passthrough")
+
+void server_dynamic_passthrough_free(DynamicPassthroughServerContext* context);
+void client_dynamic_passthrough_free(DynamicPassthroughClientContext* context);
+
+DWORD get_server_session_id(pServerContext* context)
+{
+	PULONG pSessionId = NULL;
+	DWORD BytesReturned = 0;
+	DWORD SessionId = WTS_CURRENT_SESSION;
+
+	if (WTSQuerySessionInformationA(context->vcm, WTS_CURRENT_SESSION, WTSSessionId,
+	                                (LPSTR*)&pSessionId, &BytesReturned) == FALSE)
+	{
+		WLog_ERR(TAG, "WTSQuerySessionInformationA failed!");
+		return FALSE;
+	}
+
+	SessionId = (DWORD)*pSessionId;
+	WTSFreeMemory(pSessionId);
+	return SessionId;
+}
+
+BOOL get_channel_event_handle(DynamicPassthroughServerPrivate* priv)
+{
+	DWORD BytesReturned = 0;
+	PULONG pSessionId = NULL;
+	void* buffer;
+	buffer = NULL;
+
+	/* Query for channel event handle */
+	if (!WTSVirtualChannelQuery(priv->channel, WTSVirtualEventHandle, &buffer, &BytesReturned) ||
+	    (BytesReturned != sizeof(HANDLE)))
+	{
+		WLog_ERR(TAG,
+		         "WTSVirtualChannelQuery failed "
+		         "or invalid returned size(%" PRIu32 ")",
+		         BytesReturned);
+
+		if (buffer)
+			WTSFreeMemory(buffer);
+
+		return FALSE;
+	}
+
+	CopyMemory(&priv->channelEvent, buffer, sizeof(HANDLE));
+	WTSFreeMemory(buffer);
+
+	return TRUE;
+}
+
+static UINT dynamic_passthrough_server_handle_messages(DynamicPassthroughServerContext* context)
+{
+	DWORD BytesReturned;
+	void* buffer;
+	UINT ret = CHANNEL_RC_OK;
+	DynamicPassthroughServerPrivate* priv = context->priv;
+
+	/* Check whether the dynamic channel is ready */
+	if (!priv->isReady)
+	{
+		if (WTSVirtualChannelQuery(priv->channel, WTSVirtualChannelReady, &buffer,
+		                           &BytesReturned) == FALSE)
+		{
+			if (GetLastError() == ERROR_NO_DATA)
+				return ERROR_NO_DATA;
+			return ERROR_INTERNAL_ERROR;
+		}
+
+		priv->isReady = *((BOOL*)buffer);
+		WTSFreeMemory(buffer);
+	}
+
+	/* Consume channel event only after the dynamic channel is ready */
+
+	if (!WTSVirtualChannelRead(priv->channel, 0, NULL, 0, &BytesReturned))
+	{
+		if (GetLastError() == ERROR_NO_DATA)
+			return ERROR_NO_DATA;
+
+		return ERROR_INTERNAL_ERROR;
+	}
+
+	if (BytesReturned < 1)
+		return CHANNEL_RC_OK;
+
+	wStream* s = Stream_New(NULL, BytesReturned);
+
+	if (!s)
+	{
+		WLog_ERR(TAG, "Stream_EnsureRemainingCapacity failed!");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	if (WTSVirtualChannelRead(priv->channel, 0, (PCHAR)Stream_Buffer(s), Stream_Capacity(s),
+	                          &BytesReturned) == FALSE)
+	{
+		Stream_Free(s, TRUE);
+		return ERROR_INTERNAL_ERROR;
+	}
+
+	Stream_SetLength(s, BytesReturned);
+	Stream_SetPosition(s, 0);
+	if (context->OnReceive)
+		ret = context->OnReceive(context, s);
+	Stream_Free(s, TRUE);
+	return ret;
+}
+
+static DWORD WINAPI dynamic_passthrough_server_thread_func(LPVOID arg)
+{
+	DynamicPassthroughServerContext* context = (DynamicPassthroughServerContext*)arg;
+	DynamicPassthroughServerPrivate* priv = context->priv;
+	DWORD status;
+	DWORD nCount;
+	HANDLE events[8];
+	UINT error = CHANNEL_RC_OK;
+	nCount = 0;
+	events[nCount++] = priv->stopEvent;
+	events[nCount++] = priv->channelEvent;
+
+	/* Main virtual channel loop. */
+	while (TRUE)
+	{
+		status = WaitForMultipleObjects(nCount, events, FALSE, INFINITE);
+
+		if (status == WAIT_FAILED)
+		{
+			error = GetLastError();
+			WLog_ERR(TAG, "WaitForMultipleObjects failed with error %" PRIu32 "", error);
+			break;
+		}
+
+		/* Stop Event */
+		if (status == WAIT_OBJECT_0)
+			break;
+
+		if ((error = dynamic_passthrough_server_handle_messages(context)))
+		{
+			break;
+		}
+	}
+
+	DynamicPassthroughClientContext* client = (DynamicPassthroughClientContext*)context->client;
+	if (client && client->dvcman_channel)
+	{
+		client->dvcman_channel->disconnect(client->dvcman_channel);
+	}
+	else
+	{
+		pServerContext* server = context->custom;
+		server_dynamic_passthrough_free(context);
+		ArrayList_Remove(server->dynamic_passthrough_channels, context);
+	}
+
+	ExitThread(error);
+	return error;
+}
+
+UINT server_dynamic_passthrough_send(DynamicPassthroughServerContext* context,
+                                     const wStream* stream)
+{
+	UINT ret;
+	ULONG written;
+	ULONG length = Stream_Length(stream) - Stream_GetPosition(stream);
+	if (!WTSVirtualChannelWrite(context->priv->channel, (PCHAR)Stream_Pointer(stream), length,
+	                            &written))
+	{
+		WLog_ERR(TAG, "server_dynamic_passthrough_send::WTSVirtualChannelWrite failed!");
+		ret = ERROR_INTERNAL_ERROR;
+		goto out;
+	}
+
+	if (written < length)
+	{
+		WLog_WARN(TAG,
+		          "server_dynamic_passthrough_send::Unexpected bytes written: %" PRIu32 "/%" PRIuz
+		          "",
+		          written, length);
+	}
+
+	ret = CHANNEL_RC_OK;
+out:
+	return ret;
+}
+
+UINT client_dynamic_passthrough_send(DynamicPassthroughClientContext* context,
+                                     const wStream* stream)
+{
+	DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL* channel = context->dvcman_channel;
+	return channel->iface->Write(channel->iface, Stream_Length(stream),
+	                             (PCHAR)Stream_Buffer(stream), NULL);
+}
+
+UINT server_dynamic_passthrough_on_receive(DynamicPassthroughServerContext* context,
+                                           const wStream* stream)
+{
+	DynamicPassthroughClientContext* client = (DynamicPassthroughClientContext*)context->client;
+	if (client && client->Send)
+	{
+		return client->Send(client, stream);
+	}
+	return ERROR_NO_DATA;
+}
+
+UINT client_dynamic_passthrough_on_receive(DynamicPassthroughClientContext* context,
+                                           const wStream* stream)
+{
+	DynamicPassthroughServerContext* server = (DynamicPassthroughServerContext*)context->server;
+	Stream_SetPosition(stream, 2);
+	BYTE* buffer = Stream_Pointer(stream);
+	size_t len = Stream_Length(stream) - Stream_GetPosition(stream);
+	if (server && server->Send)
+	{
+		return server->Send(server, stream);
+	}
+	return ERROR_NO_DATA;
+}
+
+void server_dynamic_passthrough_free(DynamicPassthroughServerContext* context)
+{
+	if (context)
+	{
+		context->OnReceive = NULL;
+		context->Send = NULL;
+		if (context->priv)
+		{
+			if (context->priv->channel)
+				WTSVirtualChannelClose(context->priv->channel);
+			free(context->priv);
+		}
+		if (context->channelname)
+			free(context->channelname);
+		if (context->client)
+		{
+			DynamicPassthroughClientContext* client = context->client;
+			client->server = NULL;
+		}
+		free(context);
+	}
+}
+
+BOOL server_open_dynamic_passthrough(DynamicPassthroughServerContext* context)
+{
+	if (!(context->priv->thread = CreateThread(NULL, 0, dynamic_passthrough_server_thread_func,
+	                                           (void*)context, 0, NULL)))
+	{
+		WLog_ERR(TAG, "server_open_dynamic_passthrough::CreateEvent failed!");
+		CloseHandle(context->priv->stopEvent);
+		context->priv->stopEvent = NULL;
+		return FALSE;
+	}
+	return TRUE;
+}
+
+DynamicPassthroughServerContext* server_init_dynamic_passthrough(proxyData* pdata,
+                                                                 const char* channelname)
+{
+	pServerContext* server = (pServerContext*)pdata->ps;
+
+	DWORD SessionId = get_server_session_id(server);
+
+	DynamicPassthroughServerContext* dpctx =
+	    (DynamicPassthroughServerContext*)calloc(1, sizeof(DynamicPassthroughServerContext));
+
+	if (!dpctx)
+	{
+		WLog_ERR(TAG, "pf_server_init_dynamic_passthrough::dpctx calloc failed");
+		goto failed;
+	}
+
+	dpctx->custom = server;
+	dpctx->Send = server_dynamic_passthrough_send;
+	dpctx->OnReceive = server_dynamic_passthrough_on_receive;
+	dpctx->channelname = _strdup(channelname);
+
+	if (!dpctx->channelname)
+	{
+		WLog_ERR(TAG, "pf_server_init_dynamic_passthrough::channelname _strdup failed");
+		goto failed;
+	}
+
+	dpctx->priv =
+	    (DynamicPassthroughServerPrivate*)calloc(1, sizeof(DynamicPassthroughServerPrivate));
+
+	if (!dpctx->priv)
+	{
+		WLog_ERR(TAG, "pf_server_init_dynamic_passthrough::priv calloc failed");
+		goto failed;
+	}
+
+	dpctx->priv->channel =
+	    (HANDLE)WTSVirtualChannelOpenEx(SessionId, dpctx->channelname, WTS_CHANNEL_OPTION_DYNAMIC);
+
+	if (!dpctx->priv->channel)
+	{
+		WLog_ERR(TAG, "pf_server_init_dynamic_passthrough::WTSVirtualChannelOpenEx failed!");
+		goto failed;
+	}
+
+	if (!get_channel_event_handle(dpctx->priv))
+	{
+		goto failed;
+	}
+
+	if (!(dpctx->priv->stopEvent = CreateEvent(NULL, TRUE, FALSE, NULL)))
+	{
+		WLog_ERR(TAG, "pf_server_init_dynamic_passthrough::CreateEvent failed!");
+		goto failed;
+	}
+
+	ArrayList_Lock(server->dynamic_passthrough_channels);
+	ArrayList_Append(server->dynamic_passthrough_channels, dpctx);
+	ArrayList_Unlock(server->dynamic_passthrough_channels);
+	return dpctx;
+failed:
+	server_dynamic_passthrough_free(dpctx);
+	return NULL;
+}
+
+UINT client_dynamic_passthrough_on_data_received(IWTSVirtualChannelCallback* pChannelCallback,
+                                                 wStream* data)
+{
+	DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL_CALLLBACK* callback =
+	    (DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL_CALLLBACK*)pChannelCallback;
+
+	DynamicPassthroughClientContext* dpctx = (DynamicPassthroughClientContext*)callback->custom;
+	return client_dynamic_passthrough_on_receive(dpctx, data);
+}
+
+void client_dynamic_passthrough_free(DynamicPassthroughClientContext* context)
+{
+	if (context)
+	{
+		context->Send = NULL;
+		if (context->dvcman_channel && context->dvcman_channel->channel_callback)
+			context->dvcman_channel->channel_callback->OnDataReceived = NULL;
+		if (context->channelname)
+			free(context->channelname);
+		if (context->server)
+		{
+			DynamicPassthroughServerContext* server = context->server;
+			server->client = NULL;
+		}
+		if (context->dvcman_channel)
+		{
+			context->dvcman_channel->iface->Close(context->dvcman_channel->iface);
+			context->dvcman_channel = NULL;
+		}
+		free(context);
+	}
+}
+
+void client_dynamic_passthrough_on_close(IWTSVirtualChannelCallback* pChannelCallback)
+{
+	free(pChannelCallback);
+}
+
+BOOL pf_init_dynamic_passthrough(proxyData* pdata, const char* channelname,
+                                 DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL* channel)
+{
+	pServerContext* server = (pServerContext*)pdata->ps;
+	pClientContext* client = (pClientContext*)pdata->pc;
+	DynamicPassthroughServerContext* sdpctx = NULL;
+
+	DynamicPassthroughClientContext* dpctx =
+	    (DynamicPassthroughClientContext*)calloc(1, sizeof(DynamicPassthroughClientContext));
+
+	if (!dpctx)
+	{
+		WLog_ERR(TAG, "pf_init_dynamic_passthrough::dpctx calloc failed");
+		goto failed;
+	}
+	dpctx->channelname = _strdup(channelname);
+	if (!dpctx->channelname)
+	{
+		WLog_ERR(TAG, "pf_init_dynamic_passthrough::channelname _strdup failed");
+		goto failed;
+	}
+
+	dpctx->custom = client;
+	dpctx->dvcman_channel = channel;
+	dpctx->Send = client_dynamic_passthrough_send;
+
+	DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL_CALLLBACK* callback =
+	    (DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL_CALLLBACK*)channel->channel_callback;
+	callback->custom = dpctx;
+	callback->iface.OnDataReceived = client_dynamic_passthrough_on_data_received;
+	callback->iface.OnClose = client_dynamic_passthrough_on_close;
+	dpctx->channelname = _strdup(channelname);
+
+	sdpctx = server_init_dynamic_passthrough(pdata, channelname);
+	if (sdpctx)
+	{
+
+		sdpctx->client = dpctx;
+		dpctx->server = sdpctx;
+
+		if (!server_open_dynamic_passthrough(sdpctx))
+			goto failed;
+
+		ArrayList_Lock(client->dynamic_passthrough_channels);
+		ArrayList_Append(client->dynamic_passthrough_channels, dpctx);
+		ArrayList_Unlock(client->dynamic_passthrough_channels);
+		return TRUE;
+	}
+
+failed:
+	if (sdpctx)
+	{
+		server_dynamic_passthrough_free(sdpctx);
+	}
+	if (dpctx)
+	{
+		client_dynamic_passthrough_free(dpctx);
+	}
+	return FALSE;
+}
+
+void pf_free_dynamic_passthrough(proxyData* pdata, const char* channelname,
+                                 DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL* channel)
+{
+	pClientContext* client = (pClientContext*)pdata->pc;
+	ArrayList_Lock(client->dynamic_passthrough_channels);
+	int dpccount = ArrayList_Count(client->dynamic_passthrough_channels);
+	for (int i = 0; i < dpccount; i++)
+	{
+		DynamicPassthroughClientContext* dpctx =
+		    ArrayList_GetItem(client->dynamic_passthrough_channels, i);
+		if (dpctx->dvcman_channel == channel && strcmp(dpctx->channelname, channelname) == 0)
+		{
+			ArrayList_RemoveAt(client->dynamic_passthrough_channels, i);
+
+			if (dpctx->server)
+			{
+				DynamicPassthroughServerContext* sdpctx = dpctx->server;
+				pServerContext* server = sdpctx->custom;
+				if (server)
+				{
+					ArrayList_Remove(server->dynamic_passthrough_channels, sdpctx);
+					server_dynamic_passthrough_free(sdpctx);
+				}
+			}
+
+			client_dynamic_passthrough_free(dpctx);
+		}
+	}
+	ArrayList_Unlock(client->dynamic_passthrough_channels);
+}
+
+void pf_server_clear_dynamic_passthrough(proxyData* pdata)
+{
+	pServerContext* server = (pServerContext*)pdata->ps;
+	ArrayList_Lock(server->dynamic_passthrough_channels);
+	int dpccount = ArrayList_Count(server->dynamic_passthrough_channels);
+	for (int i = 0; i < dpccount; i++)
+	{
+		DynamicPassthroughServerContext* dpctx =
+		    ArrayList_GetItem(server->dynamic_passthrough_channels, i);
+		ArrayList_RemoveAt(server->dynamic_passthrough_channels, i);
+		server_dynamic_passthrough_free(dpctx);
+	}
+	ArrayList_Unlock(server->dynamic_passthrough_channels);
+}

--- a/server/proxy/pf_dynamic_passthrough.h
+++ b/server/proxy/pf_dynamic_passthrough.h
@@ -1,0 +1,33 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * FreeRDP Proxy Server
+ *
+ * Copyright 2021 Alexandru Bagu <alexandru.bagu@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_SERVER_PROXY_DYNAMIC_PASSTHROUGH_H
+#define FREERDP_SERVER_PROXY_DYNAMIC_PASSTHROUGH_H
+
+#include "pf_context.h"
+
+#define DYNAMIC_PASSTHROUGH_TEMP_TEST "PNPDR,URBDRC,RDCamera_Device_Enumerator,FileRedirectorChannel"
+
+BOOL pf_init_dynamic_passthrough(proxyData* pdata, const char* channelname,
+                                 DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL* channel);
+void pf_free_dynamic_passthrough(proxyData* pdata, const char* channelname,
+                                 DYNAMIC_PASSTHROUGH_DVCMAN_CHANNEL* channel);
+void pf_server_clear_dynamic_passthrough(proxyData* pdata);
+
+#endif /*FREERDP_SERVER_PROXY_DYNAMIC_PASSTHROUGH_H*/

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -257,9 +257,9 @@ static BOOL pf_server_receive_channel_data_hook(freerdp_peer* peer, UINT16 chann
 	if (!pc)
 		goto original_cb;
 
-	for (i = 0; i < config->PassthroughCount; i++)
+	for (i = 0; i < config->StaticPassthroughCount; i++)
 	{
-		if (strncmp(channel_name, config->Passthrough[i], CHANNEL_NAME_LEN) == 0)
+		if (strncmp(channel_name, config->StaticPassthrough[i], CHANNEL_NAME_LEN) == 0)
 		{
 			proxyChannelDataEventInfo ev;
 			UINT64 client_channel_id;


### PR DESCRIPTION
this PR adds support for dynamic channel passthrough
the proxy config now allows you to set which channels you want proxied both for static as well as dynamic and it gives some hints as to what you may want to proxy
additionally this PR adds a log to inform you whether a channel is being actively ignored or not