### PR TITLE
proxy - allow a way to have different configs for each session

### DIFF
--- a/server/proxy/freerdp_proxy.c
+++ b/server/proxy/freerdp_proxy.c
@@ -94,7 +94,7 @@ int main(int argc, char* argv[])
 	if (argc >= 2)
 		config_path = argv[1];
 
-	config = pf_server_config_load(config_path);
+	config = pf_server_config_load_file(config_path);
 	if (!config)
 		goto fail;
 

--- a/server/proxy/pf_config.h
+++ b/server/proxy/pf_config.h
@@ -94,7 +94,8 @@ extern "C"
 };
 #endif
 
-proxyConfig* pf_server_config_load(const char* path);
+proxyConfig* pf_server_config_load_file(const char* path);
+proxyConfig* pf_server_config_load_buffer(const char* buffer);
 void pf_server_config_print(proxyConfig* config);
 void pf_server_config_free(proxyConfig* config);
 

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -470,6 +470,8 @@ fail:
 	pf_server_channels_free(ps);
 	LOG_INFO(TAG, ps, "freeing proxy data");
 	ArrayList_Remove(server->clients, pdata);
+	if (server->config != pdata->config)
+		pf_server_config_free(pdata->config);
 	proxy_data_free(pdata);
 	freerdp_client_context_free(pc);
 	client->Close(client);


### PR DESCRIPTION
this PR will allow proxy plugins to overwrite the config for the current session; split the config load function into 3 to allow either loading from a buffer or a file (a buffer might be more convenient if you don't want to keep any session information on disk). the idea is to allow each session to have their own settings (different clipboard/passthrough options etc). 
this functionality is meant to be used from by a plugin.

if a plugin does create a config and assigns it to the proxyData then on disconnect it will be freed (must be different from server->config).