### PR TITLE
winpr: Fix parsing of comma separated values if list is an empty string

### DIFF
--- a/winpr/libwinpr/utils/cmdline.c
+++ b/winpr/libwinpr/utils/cmdline.c
@@ -490,7 +490,7 @@ char** CommandLineParseCommaSeparatedValuesEx(const char* name, const char* list
 
 	*count = 0;
 
-	if (!list)
+	if (!list || strlen(list) == 0)
 	{
 		if (name)
 		{

--- a/winpr/libwinpr/utils/test/TestCmdLine.c
+++ b/winpr/libwinpr/utils/test/TestCmdLine.c
@@ -4,10 +4,19 @@
 #include <winpr/cmdline.h>
 #include <winpr/strlst.h>
 
-static const char* testArgv[] = {
-	"mstsc.exe", "+z",         "/w:1024",           "/h:768", "/bpp:32", "/admin", "/multimon",
-	"+fonts",    "-wallpaper", "/v:localhost:3389", 0
-};
+static const char* testArgv[] = { "mstsc.exe",
+	                              "+z",
+	                              "/w:1024",
+	                              "/h:768",
+	                              "/bpp:32",
+	                              "/admin",
+	                              "/multimon",
+	                              "+fonts",
+	                              "-wallpaper",
+	                              "/v:localhost:3389",
+	                              "/valuelist:value1,value2",
+	                              "/valuelist-empty:",
+	                              0 };
 
 int TestCmdLine(int argc, char* argv[])
 {
@@ -64,6 +73,11 @@ int TestCmdLine(int argc, char* argv[])
 		  "certificate name" },
 		{ "cert-ignore", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL,
 		  "ignore certificate" },
+		{ "valuelist", COMMAND_LINE_VALUE_REQUIRED, "<val1>,<val2>", NULL, NULL, -1, NULL,
+		  "List of comma separated values." },
+		{ "valuelist-empty", COMMAND_LINE_VALUE_REQUIRED, "<val1>,<val2>", NULL, NULL, -1, NULL,
+		  "List of comma separated values. Used to test correct behavior if an empty list was "
+		  "passed." },
 		{ "version", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT_VERSION, NULL, NULL, NULL, -1,
 		  NULL, "print version" },
 		{ "help", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT_HELP, NULL, NULL, NULL, -1, "?",
@@ -186,6 +200,36 @@ int TestCmdLine(int argc, char* argv[])
 
 			if (errno != 0)
 				goto out;
+		}
+		CommandLineSwitchCase(arg, "valuelist")
+		{
+			char** p;
+			size_t count;
+			p = CommandLineParseCommaSeparatedValuesEx(arg->Name, arg->Value, &count);
+			free(p);
+
+			if (!p || count != 3)
+			{
+				printf("CommandLineParseCommaSeparatedValuesEx: invalid p or count (%" PRIuz
+				       "!=3)\n",
+				       count);
+				goto out;
+			}
+		}
+		CommandLineSwitchCase(arg, "valuelist-empty")
+		{
+			char** p;
+			size_t count;
+			p = CommandLineParseCommaSeparatedValuesEx(arg->Name, arg->Value, &count);
+			free(p);
+
+			if (!p || count != 1)
+			{
+				printf("CommandLineParseCommaSeparatedValuesEx: invalid p or count (%" PRIuz
+				       "!=1)\n",
+				       count);
+				goto out;
+			}
 		}
 		CommandLineSwitchDefault(arg)
 		{


### PR DESCRIPTION
This PR fixes `CommandLineParseCommaSeparatedValuesEx` that incorrectly returned a count of 1 when an empty string `""` was passed in the list parameter.