### PR TITLE
rdpsnd: Fix double frees in rdpsnd context cleanup

### DIFF
--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -1513,8 +1513,13 @@ static UINT rdpsnd_on_close(IWTSVirtualChannelCallback* pChannelCallback)
 	if (rdpsnd->device)
 		IFCALL(rdpsnd->device->Close, rdpsnd->device);
 	freerdp_dsp_context_free(rdpsnd->dsp_context);
-	StreamPool_Return(rdpsnd->pool, rdpsnd->data_in);
-	StreamPool_Free(rdpsnd->pool);
+	rdpsnd->dsp_context = NULL;
+	if (rdpsnd->pool)
+	{
+		StreamPool_Return(rdpsnd->pool, rdpsnd->data_in);
+		StreamPool_Free(rdpsnd->pool);
+		rdpsnd->pool = NULL;
+	}
 
 	audio_formats_free(rdpsnd->ClientFormats, rdpsnd->NumberOfClientFormats);
 	rdpsnd->NumberOfClientFormats = 0;


### PR DESCRIPTION
During debugging I had crashes in `freerdp_dsp_context_free` which were caused by calling it on the same context multiple times. The same also happens in the following lines with `StreamPool_Return` and `StreamPool_Free`. This PR resets the context pointers and checks for a valid pool before calling the stream pool functions.