### PR TITLE
Fixed #7164: android clipboard string termination

### DIFF
--- a/client/Android/android_event.c
+++ b/client/Android/android_event.c
@@ -249,7 +249,7 @@ static void android_event_disconnect_free(ANDROID_EVENT* event)
 	free(event);
 }
 
-ANDROID_EVENT_CLIPBOARD* android_event_clipboard_new(void* data, int data_length)
+ANDROID_EVENT_CLIPBOARD* android_event_clipboard_new(const void* data, size_t data_length)
 {
 	ANDROID_EVENT_CLIPBOARD* event;
 	event = (ANDROID_EVENT_CLIPBOARD*)calloc(1, sizeof(ANDROID_EVENT_CLIPBOARD));
@@ -261,7 +261,7 @@ ANDROID_EVENT_CLIPBOARD* android_event_clipboard_new(void* data, int data_length
 
 	if (data)
 	{
-		event->data = malloc(data_length);
+		event->data = calloc(data_length + 1, sizeof(char));
 
 		if (!event->data)
 		{
@@ -270,7 +270,7 @@ ANDROID_EVENT_CLIPBOARD* android_event_clipboard_new(void* data, int data_length
 		}
 
 		memcpy(event->data, data, data_length);
-		event->data_length = data_length;
+		event->data_length = data_length + 1;
 	}
 
 	return event;

--- a/client/Android/android_event.h
+++ b/client/Android/android_event.h
@@ -69,7 +69,7 @@ FREERDP_LOCAL ANDROID_EVENT_KEY* android_event_key_new(int flags, UINT16 scancod
 FREERDP_LOCAL ANDROID_EVENT_KEY* android_event_unicodekey_new(UINT16 flags, UINT16 key);
 FREERDP_LOCAL ANDROID_EVENT_CURSOR* android_event_cursor_new(UINT16 flags, UINT16 x, UINT16 y);
 FREERDP_LOCAL ANDROID_EVENT* android_event_disconnect_new(void);
-FREERDP_LOCAL ANDROID_EVENT_CLIPBOARD* android_event_clipboard_new(void* data, int data_length);
+FREERDP_LOCAL ANDROID_EVENT_CLIPBOARD* android_event_clipboard_new(const void* data, size_t data_length);
 
 FREERDP_LOCAL void android_event_free(ANDROID_EVENT* event);
 

--- a/client/Android/android_freerdp.c
+++ b/client/Android/android_freerdp.c
@@ -996,7 +996,7 @@ static jboolean JNICALL jni_freerdp_send_clipboard_data(JNIEnv* env, jclass cls,
 	ANDROID_EVENT* event;
 	freerdp* inst = (freerdp*)instance;
 	const jbyte* data = jdata != NULL ? (*env)->GetStringUTFChars(env, jdata, NULL) : NULL;
-	int data_length = data ? strlen(data) : 0;
+	const size_t data_length = data ? (*env)->GetStringUTFLength(env, data) : 0;
 	jboolean ret = JNI_FALSE;
 	event = (ANDROID_EVENT*)android_event_clipboard_new((void*)data, data_length);
 


### PR DESCRIPTION
(cherry picked from commit a6990ec188ebc6ca971700d9c445aa4c6ec11349)
