### PR TITLE
The repair window cannot be restored normally

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -763,7 +763,7 @@ static BOOL xf_event_MapNotify(xfContext* xfc, const XMapEvent* event, BOOL app)
 	{
 		appWindow = xf_AppWindowFromX11Window(xfc, event->window);
 
-		if (appWindow)
+		if (appWindow && (appWindow->rail_state == WINDOW_SHOW))
 		{
 			/* local restore event */
 			/* This is now handled as part of the PropertyNotify


### PR DESCRIPTION
1. Use freerdp to connect to windows and use freerdp to open the Notepad window.
"xfreerdp /v:127.0.0.1:13289 /u:mecry /p:1 /app:notepad"
2. The maximized window shrinks, and then click Restore can not restore normally.
3. Read the freerdp source code and find that the function xf_event_MapNotify intercepts window magnification.
4. Add judgment to solve this problem