### PR TITLE
Fixes white border when maximizing x11 decoration

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -876,8 +876,8 @@ static BOOL xf_event_PropertyNotify(xfContext* xfc, const XPropertyEvent* event,
 			if (maxVert && maxHorz && !minimized &&
 			    (appWindow->rail_state != WINDOW_SHOW_MAXIMIZED))
 			{
-				appWindow->rail_state = WINDOW_SHOW_MAXIMIZED;
-				xf_rail_send_client_system_command(xfc, appWindow->windowId, SC_MAXIMIZE);
+				//appWindow->rail_state = WINDOW_SHOW_MAXIMIZED;
+				//xf_rail_send_client_system_command(xfc, appWindow->windowId, SC_MAXIMIZE);
 			}
 			else if (minimized && (appWindow->rail_state != WINDOW_SHOW_MINIMIZED))
 			{


### PR DESCRIPTION
Fixes https://github.com/FreeRDP/FreeRDP/issues/7192

A pseudo maximize seems to be implemented already by xfreerdp window when x11 decoration is dragged to top.

Note that this is more of a work around rather than a fix, because manually maximizing the internal app will force the white border to get displayed
