### PR TITLE
winpr/include/winpr/file.h: fix build on uclibc

### DIFF
--- a/winpr/include/winpr/file.h
+++ b/winpr/include/winpr/file.h
@@ -30,6 +30,8 @@
 
 #ifndef _WIN32
 
+#include <stdio.h>
+
 #ifndef MAX_PATH
 #define MAX_PATH 260
 #endif


### PR DESCRIPTION
Include `stdio.h` to fix the following build failure with uclibc raised since version 2.4.0 and https://github.com/FreeRDP/FreeRDP/commit/eb6777ea69b022c9e43a1576a2192a1cb807b1e6:

```
In file included from /tmp/instance-0/output-1/build/freerdp-2.4.0/winpr/libwinpr/utils/lodepng/lodepng.c:30:
/tmp/instance-0/output-1/build/freerdp-2.4.0/winpr/include/winpr/file.h:524:11: error: unknown type name 'FILE'
 WINPR_API FILE* winpr_fopen(const char* path, const char* mode);
           ^~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/31e770a330158035e24b7b952bec0030138482b7

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>