### PR TITLE
winpr: avoid calling FIPS_mode() with OpenSSL 3.0

### DIFF
--- a/winpr/libwinpr/utils/ssl.c
+++ b/winpr/libwinpr/utils/ssl.c
@@ -364,6 +364,8 @@ BOOL winpr_FIPSMode(void)
 {
 #if (OPENSSL_VERSION_NUMBER < 0x10001000L) || defined(LIBRESSL_VERSION_NUMBER)
 	return FALSE;
+#elif defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+	return (EVP_default_properties_is_fips_enabled(NULL) == 1);
 #else
 	return (FIPS_mode() == 1);
 #endif


### PR DESCRIPTION
Fixes: 26bf2816c3e0daeaf524c47cf0fcda8ae13b65ad