### PR TITLE
Fix linking, if BUILTIN_CHANNELS switched off

### DIFF
--- a/channels/rdp2tcp/client/CMakeLists.txt
+++ b/channels/rdp2tcp/client/CMakeLists.txt
@@ -22,6 +22,10 @@ set(${MODULE_PREFIX}_SRCS
 
 add_channel_client_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} TRUE "VirtualChannelEntryEx")
 
-target_link_libraries(${MODULE_NAME} freerdp)
+if(BUILTIN_CHANNELS)
+  target_link_libraries(${MODULE_NAME} freerdp)
+else()
+  target_link_libraries(${MODULE_NAME} winpr freerdp)
+endif()
 
 set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "Channels/${CHANNEL_NAME}/Client")

--- a/channels/rdpsnd/client/proxy/CMakeLists.txt
+++ b/channels/rdpsnd/client/proxy/CMakeLists.txt
@@ -25,6 +25,9 @@ include_directories(..)
 
 add_channel_client_subsystem_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} "" TRUE "")
 
+if(NOT BUILTIN_CHANNELS)
+  list(APPEND ${MODULE_PREFIX}_LIBS freerdp-client)
+endif()
 list(APPEND ${MODULE_PREFIX}_LIBS freerdp)
 list(APPEND ${MODULE_PREFIX}_LIBS winpr)
 

--- a/channels/video/client/CMakeLists.txt
+++ b/channels/video/client/CMakeLists.txt
@@ -26,7 +26,10 @@ include_directories(..)
 add_channel_client_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} TRUE "DVCPluginEntry")
 
 
-
+if(NOT BUILTIN_CHANNELS)
+  set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} freerdp-client)
+  set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} rdpgfx-client)
+endif()
 set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} winpr)
 
 target_link_libraries(${MODULE_NAME} ${${MODULE_PREFIX}_LIBS})


### PR DESCRIPTION
If -DBUILTIN_CHANNELS=OFF is supplied to cmake, auxiliary channel modules
are built as plugins, that are loaded from $LIBDIR/freerdp as shared libs.

This patch fixes the linkage of these plugins by taking inter-channel dependencies
of this separation into account. If BUILTIN_CHANNELS=ON, these channel modules
are linked directly into the main modules. Therefore, the linking of the plugins
is conditioned accordingly.

This fixes #7223