### PR TITLE
Fixed RDPSND_CHANNEL_NAME

### DIFF
--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -805,7 +805,7 @@ static UINT rdpsnd_load_device_plugin(rdpsndPlugin* rdpsnd, const char* name,
 	DWORD flags = FREERDP_ADDIN_CHANNEL_STATIC | FREERDP_ADDIN_CHANNEL_ENTRYEX;
 	if (rdpsnd->dynamic)
 		flags = FREERDP_ADDIN_CHANNEL_DYNAMIC;
-	entry = (PFREERDP_RDPSND_DEVICE_ENTRY)freerdp_load_channel_addin_entry(RDPSND_DVC_CHANNEL_NAME,
+	entry = (PFREERDP_RDPSND_DEVICE_ENTRY)freerdp_load_channel_addin_entry(RDPSND_CHANNEL_NAME,
 	                                                                       name, NULL, flags);
 
 	if (!entry)
@@ -1422,7 +1422,7 @@ BOOL VCAPITYPE rdpsnd_VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS pEntryPoints, 
 
 	rdpsnd->attached = TRUE;
 	rdpsnd->channelDef.options = CHANNEL_OPTION_INITIALIZED | CHANNEL_OPTION_ENCRYPT_RDP;
-	sprintf_s(rdpsnd->channelDef.name, ARRAYSIZE(rdpsnd->channelDef.name), RDPSND_DVC_CHANNEL_NAME);
+	sprintf_s(rdpsnd->channelDef.name, ARRAYSIZE(rdpsnd->channelDef.name), RDPSND_CHANNEL_NAME);
 	pEntryPointsEx = (CHANNEL_ENTRY_POINTS_FREERDP_EX*)pEntryPoints;
 
 	if ((pEntryPointsEx->cbSize >= sizeof(CHANNEL_ENTRY_POINTS_FREERDP_EX)) &&
@@ -1628,7 +1628,7 @@ UINT rdpsnd_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 {
 	UINT error = CHANNEL_RC_OK;
 	rdpsndPlugin* rdpsnd =
-	    (rdpsndPlugin*)pEntryPoints->GetPlugin(pEntryPoints, RDPSND_DVC_CHANNEL_NAME);
+	    (rdpsndPlugin*)pEntryPoints->GetPlugin(pEntryPoints, RDPSND_CHANNEL_NAME);
 
 	if (!rdpsnd)
 	{
@@ -1653,7 +1653,7 @@ UINT rdpsnd_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 		/* user data pointer is not const, cast to avoid warning. */
 		rdpsnd->channelEntryPoints.pExtendedData = (void*)pEntryPoints->GetPluginData(pEntryPoints);
 
-		error = pEntryPoints->RegisterPlugin(pEntryPoints, RDPSND_DVC_CHANNEL_NAME, &rdpsnd->iface);
+		error = pEntryPoints->RegisterPlugin(pEntryPoints, RDPSND_CHANNEL_NAME, &rdpsnd->iface);
 	}
 	else
 	{

--- a/channels/rdpsnd/server/rdpsnd_main.c
+++ b/channels/rdpsnd/server/rdpsnd_main.c
@@ -674,7 +674,7 @@ static UINT rdpsnd_server_start(RdpsndServerContext* context)
 	RdpsndServerPrivate* priv = context->priv;
 	UINT error = ERROR_INTERNAL_ERROR;
 	priv->ChannelHandle =
-	    WTSVirtualChannelOpen(context->vcm, WTS_CURRENT_SESSION, RDPSND_DVC_CHANNEL_NAME);
+	    WTSVirtualChannelOpen(context->vcm, WTS_CURRENT_SESSION, RDPSND_CHANNEL_NAME);
 
 	if (!priv->ChannelHandle)
 	{

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -926,7 +926,7 @@ static int freerdp_client_command_line_post_filter(void* context, COMMAND_LINE_A
 	{
 		char** p;
 		size_t count;
-		p = CommandLineParseCommaSeparatedValuesEx(RDPSND_DVC_CHANNEL_NAME, arg->Value, &count);
+		p = CommandLineParseCommaSeparatedValuesEx(RDPSND_CHANNEL_NAME, arg->Value, &count);
 		status = freerdp_client_add_static_channel(settings, count, p);
 		if (status)
 		{
@@ -3480,7 +3480,7 @@ BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 
 	if (settings->AudioPlayback)
 	{
-		char* p[] = { RDPSND_DVC_CHANNEL_NAME };
+		char* p[] = { RDPSND_CHANNEL_NAME };
 
 		if (!freerdp_client_add_static_channel(settings, ARRAYSIZE(p), p))
 			return FALSE;
@@ -3489,7 +3489,7 @@ BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 	/* for audio playback also load the dynamic sound channel */
 	if (settings->AudioPlayback)
 	{
-		char* p[] = { RDPSND_DVC_CHANNEL_NAME };
+		char* p[] = { RDPSND_CHANNEL_NAME };
 
 		if (!freerdp_client_add_dynamic_channel(settings, ARRAYSIZE(p), p))
 			return FALSE;
@@ -3503,8 +3503,8 @@ BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 			return FALSE;
 	}
 
-	if ((freerdp_static_channel_collection_find(settings, RDPSND_DVC_CHANNEL_NAME)) ||
-	    (freerdp_dynamic_channel_collection_find(settings, RDPSND_DVC_CHANNEL_NAME))
+	if ((freerdp_static_channel_collection_find(settings, RDPSND_CHANNEL_NAME)) ||
+	    (freerdp_dynamic_channel_collection_find(settings, RDPSND_CHANNEL_NAME))
 #if defined(CHANNEL_TSMF_CLIENT)
 	    || (freerdp_dynamic_channel_collection_find(settings, "tsmf"))
 #endif
@@ -3633,11 +3633,11 @@ BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 		if (!freerdp_client_load_static_channel_addin(channels, settings, "rdpdr", settings))
 			return FALSE;
 
-		if (!freerdp_static_channel_collection_find(settings, RDPSND_DVC_CHANNEL_NAME) &&
-		    !freerdp_dynamic_channel_collection_find(settings, RDPSND_DVC_CHANNEL_NAME))
+		if (!freerdp_static_channel_collection_find(settings, RDPSND_CHANNEL_NAME) &&
+		    !freerdp_dynamic_channel_collection_find(settings, RDPSND_CHANNEL_NAME))
 		{
 			char* params[2];
-			params[0] = RDPSND_DVC_CHANNEL_NAME;
+			params[0] = RDPSND_CHANNEL_NAME;
 			params[1] = "sys:fake";
 
 			if (!freerdp_client_add_static_channel(settings, 2, (char**)params))

--- a/client/common/compatibility.c
+++ b/client/common/compatibility.c
@@ -227,7 +227,7 @@ static int freerdp_client_old_process_plugin(rdpSettings* settings, ADDIN_ARGV* 
 		args_handled++;
 		freerdp_client_add_dynamic_channel(settings, args->argc - 1, &args->argv[1]);
 	}
-	else if (strcmp(args->argv[0], RDPSND_DVC_CHANNEL_NAME) == 0)
+	else if (strcmp(args->argv[0], RDPSND_CHANNEL_NAME) == 0)
 	{
 		args_handled++;
 

--- a/client/common/test/TestClientChannels.c
+++ b/client/common/test/TestClientChannels.c
@@ -31,7 +31,7 @@ int TestClientChannels(int argc, char* argv[])
 	freerdp_channels_addin_list_free(ppAddins);
 
 	printf("Enumerate rdpsnd\n");
-	ppAddins = freerdp_channels_list_addins(RDPSND_DVC_CHANNEL_NAME, NULL, NULL, dwFlags);
+	ppAddins = freerdp_channels_list_addins(RDPSND_CHANNEL_NAME, NULL, NULL, dwFlags);
 
 	for (index = 0; ppAddins[index] != NULL; index++)
 	{

--- a/include/freerdp/channels/rdpsnd.h
+++ b/include/freerdp/channels/rdpsnd.h
@@ -25,6 +25,6 @@
 
 #include <freerdp/codec/audio.h>
 
-#define RDPSND_DVC_CHANNEL_NAME "rdpsnd"
+#define RDPSND_CHANNEL_NAME "rdpsnd"
 
 #endif /* FREERDP_CHANNEL_RDPSND_H */

--- a/server/Sample/sfreerdp.c
+++ b/server/Sample/sfreerdp.c
@@ -620,7 +620,7 @@ static BOOL tf_peer_post_connect(freerdp_peer* client)
 		}
 	}
 
-	if (WTSVirtualChannelManagerIsChannelJoined(context->vcm, RDPSND_DVC_CHANNEL_NAME))
+	if (WTSVirtualChannelManagerIsChannelJoined(context->vcm, RDPSND_CHANNEL_NAME))
 	{
 		sf_peer_rdpsnd_init(context); /* Audio Output */
 	}

--- a/server/proxy/pf_channels.c
+++ b/server/proxy/pf_channels.c
@@ -124,7 +124,7 @@ void pf_channels_on_client_channel_connect(void* data, ChannelConnectedEventArgs
 		pc->cliprdr = (CliprdrClientContext*)e->pInterface;
 		pf_cliprdr_register_callbacks(pc->cliprdr, ps->cliprdr, pc->pdata);
 	}
-	else if (strcmp(e->name, RDPSND_DVC_CHANNEL_NAME) == 0)
+	else if (strcmp(e->name, RDPSND_CHANNEL_NAME) == 0)
 	{
 		/* sound is disabled */
 		if (ps->rdpsnd == NULL)
@@ -178,7 +178,7 @@ void pf_channels_on_client_channel_disconnect(void* data, ChannelDisconnectedEve
 
 		pc->cliprdr = NULL;
 	}
-	else if (strcmp(e->name, RDPSND_DVC_CHANNEL_NAME) == 0)
+	else if (strcmp(e->name, RDPSND_CHANNEL_NAME) == 0)
 	{
 		/* sound is disabled */
 		if (ps->rdpsnd == NULL)
@@ -217,7 +217,7 @@ BOOL pf_server_channels_init(pServerContext* ps)
 	}
 
 	if (config->AudioOutput &&
-	    WTSVirtualChannelManagerIsChannelJoined(ps->vcm, RDPSND_DVC_CHANNEL_NAME))
+	    WTSVirtualChannelManagerIsChannelJoined(ps->vcm, RDPSND_CHANNEL_NAME))
 	{
 		if (!pf_server_rdpsnd_init(ps))
 			return FALSE;

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -95,13 +95,13 @@ static BOOL pf_client_load_rdpsnd(pClientContext* pc)
 	 * if AudioOutput is enabled in proxy and client connected with rdpsnd, use proxy as rdpsnd
 	 * backend. Otherwise, use sys:fake.
 	 */
-	if (!freerdp_static_channel_collection_find(context->settings, RDPSND_DVC_CHANNEL_NAME))
+	if (!freerdp_static_channel_collection_find(context->settings, RDPSND_CHANNEL_NAME))
 	{
 		char* params[2];
-		params[0] = RDPSND_DVC_CHANNEL_NAME;
+		params[0] = RDPSND_CHANNEL_NAME;
 
 		if (config->AudioOutput &&
-		    WTSVirtualChannelManagerIsChannelJoined(ps->vcm, RDPSND_DVC_CHANNEL_NAME))
+		    WTSVirtualChannelManagerIsChannelJoined(ps->vcm, RDPSND_CHANNEL_NAME))
 			params[1] = "sys:proxy";
 		else
 			params[1] = "sys:fake";

--- a/server/shadow/shadow_channels.c
+++ b/server/shadow/shadow_channels.c
@@ -36,7 +36,7 @@ UINT shadow_client_channels_post_connect(rdpShadowClient* client)
 		shadow_client_remdesk_init(client);
 	}
 
-	if (WTSVirtualChannelManagerIsChannelJoined(client->vcm, RDPSND_DVC_CHANNEL_NAME))
+	if (WTSVirtualChannelManagerIsChannelJoined(client->vcm, RDPSND_CHANNEL_NAME))
 	{
 		shadow_client_rdpsnd_init(client);
 	}


### PR DESCRIPTION
RDPSND channel is special, as it has many names.
(e.g. static channel, dynamic channel and UDP one.
Use RDPSND_CHANNEL_NAME to identify the module name instad of
RDPSND_DVC_CHANNEL_NAME
