### PR TITLE
Moved global static variables to context

### DIFF
--- a/client/Wayland/wlfreerdp.h
+++ b/client/Wayland/wlfreerdp.h
@@ -32,6 +32,16 @@ typedef struct wlf_context wlfContext;
 typedef struct wlf_clipboard wfClipboard;
 typedef struct _wlfDispContext wlfDispContext;
 
+#define MAX_CONTACTS 20
+
+typedef struct touch_contact
+{
+	int id;
+	double pos_x;
+	double pos_y;
+	BOOL emulate_mouse;
+} touchContact;
+
 struct wlf_context
 {
 	rdpContext context;
@@ -54,6 +64,8 @@ struct wlf_context
 	wLog* log;
 	CRITICAL_SECTION critical;
 	wArrayList* events;
+
+	touchContact contacts[MAX_CONTACTS];
 };
 
 BOOL wlf_scale_coordinates(rdpContext* context, UINT32* px, UINT32* py, BOOL fromLocalToRDP);

--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -33,44 +33,22 @@
 #endif
 
 #include <math.h>
+#include <float.h>
+#include <limits.h>
 
 #include "xf_event.h"
 #include "xf_input.h"
 
+#include <winpr/assert.h>
 #include <freerdp/log.h>
 #define TAG CLIENT_TAG("x11")
 
 #ifdef WITH_XI
 
-#define MAX_CONTACTS 2
-
 #define PAN_THRESHOLD 50
 #define ZOOM_THRESHOLD 10
 
 #define MIN_FINGER_DIST 5
-
-typedef struct touch_contact
-{
-	int id;
-	int count;
-	double pos_x;
-	double pos_y;
-	double last_x;
-	double last_y;
-
-} touchContact;
-
-static touchContact contacts[MAX_CONTACTS];
-
-static int active_contacts;
-static int lastEvType;
-static XIDeviceEvent lastEvent;
-static double firstDist = -1.0;
-static double lastDist;
-
-static double z_vector;
-static double px_vector;
-static double py_vector;
 
 static const char* xf_input_get_class_string(int class)
 {
@@ -91,21 +69,23 @@ static const char* xf_input_get_class_string(int class)
 int xf_input_init(xfContext* xfc, Window window)
 {
 	int i, j;
-	int nmasks;
-	int ndevices;
+	int nmasks = 0;
+	int ndevices = 0;
 	int major = 2;
 	int minor = 2;
 	XIDeviceInfo* info;
 	XIEventMask evmasks[64];
 	int opcode, event, error;
-	BYTE masks[8][XIMaskLen(XI_LASTEVENT)];
-	z_vector = 0;
-	px_vector = 0;
-	py_vector = 0;
-	nmasks = 0;
-	ndevices = 0;
-	active_contacts = 0;
-	ZeroMemory(contacts, sizeof(touchContact) * MAX_CONTACTS);
+	BYTE masks[8][XIMaskLen(XI_LASTEVENT)] = { 0 };
+
+	WINPR_ASSERT(xfc);
+
+	memset(xfc->contacts, 0, sizeof(xfc->contacts));
+	xfc->firstDist = -1.0;
+	xfc->z_vector = 0;
+	xfc->px_vector = 0;
+	xfc->py_vector = 0;
+	xfc->active_contacts = 0;
 
 	if (!XQueryExtension(xfc->display, "XInputExtension", &opcode, &event, &error))
 	{
@@ -204,14 +184,20 @@ int xf_input_init(xfContext* xfc, Window window)
 	return 0;
 }
 
-static BOOL xf_input_is_duplicate(const XGenericEventCookie* cookie)
+static BOOL xf_input_is_duplicate(xfContext* xfc, const XGenericEventCookie* cookie)
 {
 	const XIDeviceEvent* event;
-	event = cookie->data;
 
-	if ((lastEvent.time == event->time) && (lastEvType == cookie->evtype) &&
-	    (lastEvent.detail == event->detail) && (lastEvent.event_x == event->event_x) &&
-	    (lastEvent.event_y == event->event_y))
+	WINPR_ASSERT(xfc);
+	WINPR_ASSERT(cookie);
+
+	event = cookie->data;
+	WINPR_ASSERT(event);
+
+	if ((xfc->lastEvent.time == event->time) && (xfc->lastEvType == cookie->evtype) &&
+	    (xfc->lastEvent.detail == event->detail) &&
+	    (fabs(xfc->lastEvent.event_x - event->event_x) < DBL_EPSILON) &&
+	    (fabs(xfc->lastEvent.event_y - event->event_y) < DBL_EPSILON))
 	{
 		return TRUE;
 	}
@@ -219,15 +205,21 @@ static BOOL xf_input_is_duplicate(const XGenericEventCookie* cookie)
 	return FALSE;
 }
 
-static void xf_input_save_last_event(const XGenericEventCookie* cookie)
+static void xf_input_save_last_event(xfContext* xfc, const XGenericEventCookie* cookie)
 {
 	const XIDeviceEvent* event;
+
+	WINPR_ASSERT(xfc);
+	WINPR_ASSERT(cookie);
+
 	event = cookie->data;
-	lastEvType = cookie->evtype;
-	lastEvent.time = event->time;
-	lastEvent.detail = event->detail;
-	lastEvent.event_x = event->event_x;
-	lastEvent.event_y = event->event_y;
+	WINPR_ASSERT(event);
+
+	xfc->lastEvType = cookie->evtype;
+	xfc->lastEvent.time = event->time;
+	xfc->lastEvent.detail = event->detail;
+	xfc->lastEvent.event_x = event->event_x;
+	xfc->lastEvent.event_y = event->event_y;
 }
 
 static void xf_input_detect_pan(xfContext* xfc)
@@ -238,27 +230,31 @@ static void xf_input_detect_pan(xfContext* xfc)
 	double py;
 	double dist_x;
 	double dist_y;
-	rdpContext* ctx = &xfc->context;
+	rdpContext* ctx;
 
-	if (active_contacts != 2)
+	WINPR_ASSERT(xfc);
+	ctx = &xfc->context;
+	WINPR_ASSERT(ctx);
+
+	if (xfc->active_contacts != 2)
 	{
 		return;
 	}
 
-	dx[0] = contacts[0].pos_x - contacts[0].last_x;
-	dx[1] = contacts[1].pos_x - contacts[1].last_x;
-	dy[0] = contacts[0].pos_y - contacts[0].last_y;
-	dy[1] = contacts[1].pos_y - contacts[1].last_y;
+	dx[0] = xfc->contacts[0].pos_x - xfc->contacts[0].last_x;
+	dx[1] = xfc->contacts[1].pos_x - xfc->contacts[1].last_x;
+	dy[0] = xfc->contacts[0].pos_y - xfc->contacts[0].last_y;
+	dy[1] = xfc->contacts[1].pos_y - xfc->contacts[1].last_y;
 	px = fabs(dx[0]) < fabs(dx[1]) ? dx[0] : dx[1];
 	py = fabs(dy[0]) < fabs(dy[1]) ? dy[0] : dy[1];
-	px_vector += px;
-	py_vector += py;
-	dist_x = fabs(contacts[0].pos_x - contacts[1].pos_x);
-	dist_y = fabs(contacts[0].pos_y - contacts[1].pos_y);
+	xfc->px_vector += px;
+	xfc->py_vector += py;
+	dist_x = fabs(xfc->contacts[0].pos_x - xfc->contacts[1].pos_x);
+	dist_y = fabs(xfc->contacts[0].pos_y - xfc->contacts[1].pos_y);
 
 	if (dist_y > MIN_FINGER_DIST)
 	{
-		if (px_vector > PAN_THRESHOLD)
+		if (xfc->px_vector > PAN_THRESHOLD)
 		{
 			{
 				PanningChangeEventArgs e;
@@ -267,11 +263,11 @@ static void xf_input_detect_pan(xfContext* xfc)
 				e.dy = 0;
 				PubSub_OnPanningChange(ctx->pubSub, xfc, &e);
 			}
-			px_vector = 0;
-			py_vector = 0;
-			z_vector = 0;
+			xfc->px_vector = 0;
+			xfc->py_vector = 0;
+			xfc->z_vector = 0;
 		}
-		else if (px_vector < -PAN_THRESHOLD)
+		else if (xfc->px_vector < -PAN_THRESHOLD)
 		{
 			{
 				PanningChangeEventArgs e;
@@ -280,15 +276,15 @@ static void xf_input_detect_pan(xfContext* xfc)
 				e.dy = 0;
 				PubSub_OnPanningChange(ctx->pubSub, xfc, &e);
 			}
-			px_vector = 0;
-			py_vector = 0;
-			z_vector = 0;
+			xfc->px_vector = 0;
+			xfc->py_vector = 0;
+			xfc->z_vector = 0;
 		}
 	}
 
 	if (dist_x > MIN_FINGER_DIST)
 	{
-		if (py_vector > PAN_THRESHOLD)
+		if (xfc->py_vector > PAN_THRESHOLD)
 		{
 			{
 				PanningChangeEventArgs e;
@@ -297,11 +293,11 @@ static void xf_input_detect_pan(xfContext* xfc)
 				e.dy = 5;
 				PubSub_OnPanningChange(ctx->pubSub, xfc, &e);
 			}
-			py_vector = 0;
-			px_vector = 0;
-			z_vector = 0;
+			xfc->py_vector = 0;
+			xfc->px_vector = 0;
+			xfc->z_vector = 0;
 		}
-		else if (py_vector < -PAN_THRESHOLD)
+		else if (xfc->py_vector < -PAN_THRESHOLD)
 		{
 			{
 				PanningChangeEventArgs e;
@@ -310,9 +306,9 @@ static void xf_input_detect_pan(xfContext* xfc)
 				e.dy = -5;
 				PubSub_OnPanningChange(ctx->pubSub, xfc, &e);
 			}
-			py_vector = 0;
-			px_vector = 0;
-			z_vector = 0;
+			xfc->py_vector = 0;
+			xfc->px_vector = 0;
+			xfc->z_vector = 0;
 		}
 	}
 }
@@ -322,30 +318,34 @@ static void xf_input_detect_pinch(xfContext* xfc)
 	double dist;
 	double delta;
 	ZoomingChangeEventArgs e;
-	rdpContext* ctx = &xfc->context;
+	rdpContext* ctx;
 
-	if (active_contacts != 2)
+	WINPR_ASSERT(xfc);
+	ctx = &xfc->context;
+	WINPR_ASSERT(ctx);
+
+	if (xfc->active_contacts != 2)
 	{
-		firstDist = -1.0;
+		xfc->firstDist = -1.0;
 		return;
 	}
 
 	/* first calculate the distance */
-	dist = sqrt(pow(contacts[1].pos_x - contacts[0].last_x, 2.0) +
-	            pow(contacts[1].pos_y - contacts[0].last_y, 2.0));
+	dist = sqrt(pow(xfc->contacts[1].pos_x - xfc->contacts[0].last_x, 2.0) +
+	            pow(xfc->contacts[1].pos_y - xfc->contacts[0].last_y, 2.0));
 
 	/* if this is the first 2pt touch */
-	if (firstDist <= 0)
+	if (xfc->firstDist <= 0)
 	{
-		firstDist = dist;
-		lastDist = firstDist;
-		z_vector = 0;
-		px_vector = 0;
-		py_vector = 0;
+		xfc->firstDist = dist;
+		xfc->lastDist = xfc->firstDist;
+		xfc->z_vector = 0;
+		xfc->px_vector = 0;
+		xfc->py_vector = 0;
 	}
 	else
 	{
-		delta = lastDist - dist;
+		delta = xfc->lastDist - dist;
 
 		if (delta > 1.0)
 			delta = 1.0;
@@ -354,63 +354,66 @@ static void xf_input_detect_pinch(xfContext* xfc)
 			delta = -1.0;
 
 		/* compare the current distance to the first one */
-		z_vector += delta;
-		lastDist = dist;
+		xfc->z_vector += delta;
+		xfc->lastDist = dist;
 
-		if (z_vector > ZOOM_THRESHOLD)
+		if (xfc->z_vector > ZOOM_THRESHOLD)
 		{
 			EventArgsInit(&e, "xfreerdp");
 			e.dx = e.dy = -10;
 			PubSub_OnZoomingChange(ctx->pubSub, xfc, &e);
-			z_vector = 0;
-			px_vector = 0;
-			py_vector = 0;
+			xfc->z_vector = 0;
+			xfc->px_vector = 0;
+			xfc->py_vector = 0;
 		}
 
-		if (z_vector < -ZOOM_THRESHOLD)
+		if (xfc->z_vector < -ZOOM_THRESHOLD)
 		{
 			EventArgsInit(&e, "xfreerdp");
 			e.dx = e.dy = 10;
 			PubSub_OnZoomingChange(ctx->pubSub, xfc, &e);
-			z_vector = 0;
-			px_vector = 0;
-			py_vector = 0;
+			xfc->z_vector = 0;
+			xfc->px_vector = 0;
+			xfc->py_vector = 0;
 		}
 	}
 }
 
-static void xf_input_touch_begin(xfContext* xfc, XIDeviceEvent* event)
+static void xf_input_touch_begin(xfContext* xfc, const XIDeviceEvent* event)
 {
 	int i;
 
 	WINPR_UNUSED(xfc);
 	for (i = 0; i < MAX_CONTACTS; i++)
 	{
-		if (contacts[i].id == 0)
+		if (xfc->contacts[i].id == 0)
 		{
-			contacts[i].id = event->detail;
-			contacts[i].count = 1;
-			contacts[i].pos_x = event->event_x;
-			contacts[i].pos_y = event->event_y;
-			active_contacts++;
+			xfc->contacts[i].id = event->detail;
+			xfc->contacts[i].count = 1;
+			xfc->contacts[i].pos_x = event->event_x;
+			xfc->contacts[i].pos_y = event->event_y;
+			xfc->active_contacts++;
 			break;
 		}
 	}
 }
 
-static void xf_input_touch_update(xfContext* xfc, XIDeviceEvent* event)
+static void xf_input_touch_update(xfContext* xfc, const XIDeviceEvent* event)
 {
 	int i;
 
+	WINPR_ASSERT(xfc);
+	WINPR_ASSERT(event);
+
 	for (i = 0; i < MAX_CONTACTS; i++)
 	{
-		if (contacts[i].id == event->detail)
+		if (xfc->contacts[i].id == event->detail)
 		{
-			contacts[i].count++;
-			contacts[i].last_x = contacts[i].pos_x;
-			contacts[i].last_y = contacts[i].pos_y;
-			contacts[i].pos_x = event->event_x;
-			contacts[i].pos_y = event->event_y;
+			xfc->contacts[i].count++;
+			xfc->contacts[i].last_x = xfc->contacts[i].pos_x;
+			xfc->contacts[i].last_y = xfc->contacts[i].pos_y;
+			xfc->contacts[i].pos_x = event->event_x;
+			xfc->contacts[i].pos_y = event->event_y;
 			xf_input_detect_pinch(xfc);
 			xf_input_detect_pan(xfc);
 			break;
@@ -418,18 +421,18 @@ static void xf_input_touch_update(xfContext* xfc, XIDeviceEvent* event)
 	}
 }
 
-static void xf_input_touch_end(xfContext* xfc, XIDeviceEvent* event)
+static void xf_input_touch_end(xfContext* xfc, const XIDeviceEvent* event)
 {
 	int i;
 
 	WINPR_UNUSED(xfc);
 	for (i = 0; i < MAX_CONTACTS; i++)
 	{
-		if (contacts[i].id == event->detail)
+		if (xfc->contacts[i].id == event->detail)
 		{
-			contacts[i].id = 0;
-			contacts[i].count = 0;
-			active_contacts--;
+			xfc->contacts[i].id = 0;
+			xfc->contacts[i].count = 0;
+			xfc->active_contacts--;
 			break;
 		}
 	}
@@ -449,24 +452,24 @@ static int xf_input_handle_event_local(xfContext* xfc, const XEvent* event)
 		switch (cookie.cc->evtype)
 		{
 			case XI_TouchBegin:
-				if (xf_input_is_duplicate(cookie.cc) == FALSE)
+				if (xf_input_is_duplicate(xfc, cookie.cc) == FALSE)
 					xf_input_touch_begin(xfc, cookie.cc->data);
 
-				xf_input_save_last_event(cookie.cc);
+				xf_input_save_last_event(xfc, cookie.cc);
 				break;
 
 			case XI_TouchUpdate:
-				if (xf_input_is_duplicate(cookie.cc) == FALSE)
+				if (xf_input_is_duplicate(xfc, cookie.cc) == FALSE)
 					xf_input_touch_update(xfc, cookie.cc->data);
 
-				xf_input_save_last_event(cookie.cc);
+				xf_input_save_last_event(xfc, cookie.cc);
 				break;
 
 			case XI_TouchEnd:
-				if (xf_input_is_duplicate(cookie.cc) == FALSE)
+				if (xf_input_is_duplicate(xfc, cookie.cc) == FALSE)
 					xf_input_touch_end(xfc, cookie.cc->data);
 
-				xf_input_save_last_event(cookie.cc);
+				xf_input_save_last_event(xfc, cookie.cc);
 				break;
 
 			default:

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -32,6 +32,10 @@ typedef struct xf_context xfContext;
 #include <X11/Xcursor/Xcursor.h>
 #endif
 
+#ifdef WITH_XI
+#include <X11/extensions/XInput2.h>
+#endif
+
 #include <freerdp/api.h>
 
 #include "xf_window.h"
@@ -119,6 +123,21 @@ typedef struct
 	int button;
 	UINT16 flags;
 } button_map;
+
+#if defined(WITH_XI)
+#define MAX_CONTACTS 20
+
+typedef struct touch_contact
+{
+	int id;
+	int count;
+	double pos_x;
+	double pos_y;
+	double last_x;
+	double last_y;
+
+} touchContact;
+#endif
 
 struct xf_context
 {
@@ -270,6 +289,18 @@ struct xf_context
 	UINT32 locked;
 	BOOL firstPressRightCtrl;
 	BOOL ungrabKeyboardWithRightCtrl;
+
+#if defined(WITH_XI)
+	touchContact contacts[MAX_CONTACTS];
+	int active_contacts;
+	int lastEvType;
+	XIDeviceEvent lastEvent;
+	double firstDist;
+	double lastDist;
+	double z_vector;
+	double px_vector;
+	double py_vector;
+#endif
 };
 
 BOOL xf_create_window(xfContext* xfc);


### PR DESCRIPTION
xfreerdp and wlfreerdp used global static variables for multitouch
input. Use fields in client context instead.