### PR TITLE
Added proxy input state sync

### DIFF
--- a/include/freerdp/server/proxy/proxy_context.h
+++ b/include/freerdp/server/proxy/proxy_context.h
@@ -102,6 +102,9 @@ struct p_client_context
 	wStream* remote_pem;
 	UINT16 remote_port;
 	UINT32 remote_flags;
+
+	BOOL input_state_sync_pending;
+	UINT32 input_state;
 };
 
 /**


### PR DESCRIPTION
The proxy server component might receive input related events
before the proxy client has established the connection to the
target machine.
With this change, the current keyboard state is cached and sent
to the target when it is ready. All input events received before
the target is ready are discarded.