### PR TITLE
Replace backslashes with underscores in printer names

### DIFF
--- a/channels/printer/client/printer_main.c
+++ b/channels/printer/client/printer_main.c
@@ -300,6 +300,7 @@ static BOOL printer_load_from_config(const rdpSettings* settings, rdpPrinter* pr
 	void* CachedPrinterConfigData = NULL;
 	UINT32 CachedFieldsLen = 0;
 	UINT32 PrinterNameLen = 0;
+	WCHAR* wptr = NULL;
 
 	if (!settings || !printer)
 		return FALSE;
@@ -359,6 +360,8 @@ static BOOL printer_load_from_config(const rdpSettings* settings, rdpPrinter* pr
 	if (!Stream_EnsureRemainingCapacity(printer_dev->device.data, PrinterNameLen))
 		goto fail;
 
+	for (wptr = wname; (wptr = _wcschr(wptr, L'\\'));)
+		*wptr = L'_';
 	Stream_Write(printer_dev->device.data, wname, PrinterNameLen);
 
 	if (!Stream_EnsureRemainingCapacity(printer_dev->device.data, CachedFieldsLen))


### PR DESCRIPTION
On a Windows workstation, the network printers look like this: `\\DOMAIN\PRINTER` but Windows Server refuses to redirect a printer having a `\` in its name.

This fix just replaces the `\` with `_`.