### PR TITLE
Fix X11 floatbar: XGetWindowAttributes returns zero on error

### DIFF
--- a/client/X11/xf_floatbar.c
+++ b/client/X11/xf_floatbar.c
@@ -185,7 +185,7 @@ static BOOL create_floatbar(xfFloatbar* floatbar)
 	status = XGetWindowAttributes(xfc->display, floatbar->root_window, &attr);
 	if (status == 0)
 	{
-		WLog_WARN(TAG, "XGetWindowAttributes returned %d", status);
+		WLog_WARN(TAG, "XGetWindowAttributes failed");
 		return FALSE;
 	}
 	floatbar->x = attr.x + attr.width / 2 - FLOATBAR_DEFAULT_WIDTH / 2;

--- a/client/X11/xf_floatbar.c
+++ b/client/X11/xf_floatbar.c
@@ -183,7 +183,7 @@ static BOOL create_floatbar(xfFloatbar* floatbar)
 
 	xfc = floatbar->xfc;
 	status = XGetWindowAttributes(xfc->display, floatbar->root_window, &attr);
-	if (status != 0)
+	if (status == 0)
 	{
 		WLog_WARN(TAG, "XGetWindowAttributes returned %d", status);
 		return FALSE;


### PR DESCRIPTION
This effectively disables the floatbar.

See https://www.x.org/releases/X11R7.7/doc/libX11/libX11/libX11.html