### PR TITLE
rdpei/server: Fix PDU length for RDPINPUT_PROTOCOL_V300

### DIFF
--- a/channels/rdpei/server/rdpei_main.c
+++ b/channels/rdpei/server/rdpei_main.c
@@ -602,6 +602,7 @@ UINT rdpei_server_send_sc_ready(RdpeiServerContext* context, UINT32 version, UIN
 {
 	ULONG written;
 	RdpeiServerPrivate* priv = context->priv;
+	UINT32 pduLen = 4;
 
 	if (priv->automataState != STATE_INITIAL)
 	{
@@ -611,14 +612,17 @@ UINT rdpei_server_send_sc_ready(RdpeiServerContext* context, UINT32 version, UIN
 
 	Stream_SetPosition(priv->outputStream, 0);
 
-	if (!Stream_EnsureCapacity(priv->outputStream, RDPINPUT_HEADER_LENGTH + 4))
+	if (version >= RDPINPUT_PROTOCOL_V300)
+		pduLen += 4;
+
+	if (!Stream_EnsureCapacity(priv->outputStream, RDPINPUT_HEADER_LENGTH + pduLen))
 	{
 		WLog_ERR(TAG, "Stream_EnsureCapacity failed!");
 		return CHANNEL_RC_NO_MEMORY;
 	}
 
 	Stream_Write_UINT16(priv->outputStream, EVENTID_SC_READY);
-	Stream_Write_UINT32(priv->outputStream, RDPINPUT_HEADER_LENGTH + 4);
+	Stream_Write_UINT32(priv->outputStream, RDPINPUT_HEADER_LENGTH + pduLen);
 	Stream_Write_UINT32(priv->outputStream, version);
 	if (version >= RDPINPUT_PROTOCOL_V300)
 		Stream_Write_UINT32(priv->outputStream, features);


### PR DESCRIPTION
Quoting the commit message here:

```
When the server supports the protocol version RDPINPUT_PROTOCOL_V300,
the additional supportedFeatures field will be present.
The pduLength in the RDPINPUT_HEADER should, however, reflect this.

So, fix this error by writing the correct PDU length when the
supportedFeatures field is present.
```

**Note:** This is compile tested only. It should however be correct. Found this, while reading through the source code.

See also `2.2.3.1 RDPINPUT_SC_READY_PDU` in `[MS-RDPEI]`