### PR TITLE
early bail from update_read_window_state_order breaks protocol

### DIFF
--- a/libfreerdp/core/window.c
+++ b/libfreerdp/core/window.c
@@ -359,33 +359,31 @@ static BOOL update_read_window_state_order(wStream* s, WINDOW_ORDER_INFO* orderI
 
 		Stream_Read_UINT16(s, windowState->numWindowRects); /* numWindowRects (2 bytes) */
 
-		if (windowState->numWindowRects == 0)
+		if (windowState->numWindowRects > 0)
 		{
-			return TRUE;
-		}
+			size = sizeof(RECTANGLE_16) * windowState->numWindowRects;
+			newRect = (RECTANGLE_16*)realloc(windowState->windowRects, size);
 
-		size = sizeof(RECTANGLE_16) * windowState->numWindowRects;
-		newRect = (RECTANGLE_16*)realloc(windowState->windowRects, size);
+			if (!newRect)
+			{
+				free(windowState->windowRects);
+				windowState->windowRects = NULL;
+				return FALSE;
+			}
 
-		if (!newRect)
-		{
-			free(windowState->windowRects);
-			windowState->windowRects = NULL;
-			return FALSE;
-		}
+			windowState->windowRects = newRect;
 
-		windowState->windowRects = newRect;
+			if (Stream_GetRemainingLength(s) < 8 * windowState->numWindowRects)
+				return FALSE;
 
-		if (Stream_GetRemainingLength(s) < 8 * windowState->numWindowRects)
-			return FALSE;
-
-		/* windowRects */
-		for (i = 0; i < windowState->numWindowRects; i++)
-		{
-			Stream_Read_UINT16(s, windowState->windowRects[i].left);   /* left (2 bytes) */
-			Stream_Read_UINT16(s, windowState->windowRects[i].top);    /* top (2 bytes) */
-			Stream_Read_UINT16(s, windowState->windowRects[i].right);  /* right (2 bytes) */
-			Stream_Read_UINT16(s, windowState->windowRects[i].bottom); /* bottom (2 bytes) */
+			/* windowRects */
+			for (i = 0; i < windowState->numWindowRects; i++)
+			{
+				Stream_Read_UINT16(s, windowState->windowRects[i].left);   /* left (2 bytes) */
+				Stream_Read_UINT16(s, windowState->windowRects[i].top);    /* top (2 bytes) */
+				Stream_Read_UINT16(s, windowState->windowRects[i].right);  /* right (2 bytes) */
+				Stream_Read_UINT16(s, windowState->windowRects[i].bottom); /* bottom (2 bytes) */
+			}
 		}
 	}
 


### PR DESCRIPTION
When handling WINDOW_ORDER_FIELD_WND_RECTS in update_read_window_state_order, the early bail breaks subsequent protocol parsing.

Log looks like this:
Alternate Secondary Drawing Order [0x0b] Windowing
WindowUpdate windowId=0x66190 [ex]style=<0x86080044, 0x10000 popup> clientOffset=(-5000,-5000) windowOffset=(-5000,-5000) windowClientDelta=(0,0) windowWidth=0 windowHeight=0 windowRects=() visibleOffset=(0,0) visibilityRects=()
pf_client_window_update
Alternate Secondary Drawing Order [0x1e] UNKNOWN
[0x1e] UNKNOWN - Alternate Secondary Drawing Order UNKNOWN
[0x1e] UNKNOWN - SERVER BUG: The support for this feature was not announced!
order flags 78 failed
Fastpath update Orders [0] failed, status 0
fastpath_recv_update() - -1
fastpath_recv_update_data() fail
pf_client_end_paint
