### PR TITLE
Force one channel input fallback for audin

### DIFF
--- a/channels/audin/client/audin_main.c
+++ b/channels/audin/client/audin_main.c
@@ -425,13 +425,16 @@ static BOOL audin_open_device(AUDIN_PLUGIN* audin, AUDIN_CHANNEL_CALLBACK* callb
 		format.cbSize = 0;
 		for (x = 0; x < ARRAYSIZE(samplerates); x++)
 		{
+			size_t y;
 			format.nSamplesPerSec = samplerates[x];
-			format.nChannels = audin->format->nChannels;
-			test = IFCALLRESULT(FALSE, audin->device->FormatSupported, audin->device, &format);
-			if (test)
-				break;
-			format.nChannels = 3 - format.nChannels;
-			test = IFCALLRESULT(FALSE, audin->device->FormatSupported, audin->device, &format);
+			for (y = audin->format->nChannels; y > 0; y--)
+			{
+				format.nChannels = y;
+				format.nBlockAlign = 2 * format.nChannels;
+				test = IFCALLRESULT(FALSE, audin->device->FormatSupported, audin->device, &format);
+				if (test)
+					break;
+			}
 			if (test)
 				break;
 		}

--- a/channels/audin/client/winmm/audin_winmm.c
+++ b/channels/audin/client/winmm/audin_winmm.c
@@ -368,6 +368,9 @@ static BOOL audin_winmm_format_supported(IAudinDevice* device, const AUDIO_FORMA
 	if (format->wFormatTag != WAVE_FORMAT_PCM)
 		return FALSE;
 
+	if (format->nChannels != 1)
+		return FALSE;
+
 	pwfx = (PWAVEFORMATEX)malloc(sizeof(WAVEFORMATEX) + format->cbSize);
 
 	if (!pwfx)


### PR DESCRIPTION
Windows winmm backend does not support stereo microphone properly.
Fall back to mono and ensure that fallback is used.
Replaces #7315 
