### PR TITLE
Fix double-free of rdpCertificateStore members

### DIFF
--- a/libfreerdp/crypto/certificate.c
+++ b/libfreerdp/crypto/certificate.c
@@ -175,7 +175,6 @@ static BOOL certificate_store_init(rdpCertificateStore* certificate_store)
 	return TRUE;
 fail:
 	WLog_ERR(TAG, "certificate store initialization failed");
-	certificate_store_uninit(certificate_store);
 	return FALSE;
 }
 


### PR DESCRIPTION
certificate_store_uninit is always called from certificate_store_free
before freeing the certificate store. Since the certificate store is
freed if certificate_store_init fails, calling certificate_store_uninit
from certificate_store_init means it gets called twice, and all of the
struct members get double-freed.