### PR TITLE
Enforce Stream validity - Security Enhancement

### DIFF
--- a/winpr/include/winpr/assert.h
+++ b/winpr/include/winpr/assert.h
@@ -46,6 +46,18 @@
 	} while (0)
 #endif
 
+#define WINPR_SECURITY(cond)                                                                   \
+	do                                                                                         \
+	{                                                                                          \
+		if (!(cond))                                                                           \
+		{                                                                                      \
+			const char* tag = "com.freerdp.winpr.security";                                    \
+			WLog_FATAL(tag, "%s [%s:%s:%" PRIuz "]", #cond, __FILE__, __FUNCTION__, __LINE__); \
+			winpr_log_backtrace(tag, WLOG_FATAL, 20);                                          \
+			abort();                                                                           \
+		}                                                                                      \
+	} while (0)
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -371,16 +371,22 @@ extern "C"
 		_s->length = (size_t)(_s->pointer - _s->buffer);
 	}
 
-	static INLINE size_t Stream_GetRemainingCapacity(wStream* _s)
+	static INLINE ssize_t Stream_GetRemainingCapacity(wStream* _s)
 	{
 		WINPR_ASSERT(_s);
 		return (_s->capacity - (size_t)(_s->pointer - _s->buffer));
 	}
 
-	static INLINE size_t Stream_GetRemainingLength(wStream* _s)
+	static INLINE ssize_t Stream_GetRemainingLength(wStream* _s)
 	{
 		WINPR_ASSERT(_s);
 		return (_s->length - (size_t)(_s->pointer - _s->buffer));
+	}
+
+	static INLINE BOOL Stream_Verify(wStream* _s)
+	{
+		WINPR_ASSERT(_s);
+		return Stream_GetRemainingLength(_s) >= 0 && Stream_GetRemainingCapacity(_s) >= 0;
 	}
 
 	static INLINE void Stream_Clear(wStream* _s)

--- a/winpr/libwinpr/utils/collections/StreamPool.c
+++ b/winpr/libwinpr/utils/collections/StreamPool.c
@@ -290,7 +290,10 @@ void Stream_Release(wStream* s)
 		StreamPool_Unlock(s->pool);
 
 		if (count == 0)
+		{
+			WINPR_SECURITY(Stream_Verify(s));
 			StreamPool_Return(s->pool, s);
+		}
 	}
 }
 

--- a/winpr/libwinpr/utils/stream.c
+++ b/winpr/libwinpr/utils/stream.c
@@ -126,6 +126,7 @@ void Stream_Free(wStream* s, BOOL bFreeBuffer)
 {
 	if (s)
 	{
+		WINPR_SECURITY(Stream_Verify(s));
 		if (bFreeBuffer && s->isOwner)
 			free(s->buffer);
 


### PR DESCRIPTION
Input parsing of incoming messages is extremely fragile, and once the pointer passed the buffer's end, the sanity check macros will return a huge size_t size instead of a negative value, thus bypassing all future checks in the code.

Change the checks to use ssize_t and upon every release/free make sure that the Stream didn't reach a corrupted state. This ensures that an attacker triggering a read/write out-of-bounds will terminate the program instead of allowing the attacker to continue their exploit.

Would have blocked CVE-2020-9497 (all 3 variants), CVE-2020-13396, CVE-2020-11526, CVE-2020-11088 and more.
