### PR TITLE
Cert store fix && Stream API refinements

### DIFF
--- a/channels/tsmf/client/tsmf_codec.c
+++ b/channels/tsmf/client/tsmf_codec.c
@@ -569,7 +569,7 @@ BOOL tsmf_codec_parse_media_type(TS_AM_MEDIA_TYPE* mediatype, wStream* s)
 
 BOOL tsmf_codec_check_media_type(const char* decoder_name, wStream* s)
 {
-	BYTE* m;
+	size_t pos;
 	BOOL ret = FALSE;
 	TS_AM_MEDIA_TYPE mediatype;
 
@@ -583,10 +583,10 @@ BOOL tsmf_codec_check_media_type(const char* decoder_name, wStream* s)
 			decoderAvailable = TRUE;
 	}
 
-	Stream_GetPointer(s, m);
+	pos = Stream_GetPosition(s);
 	if (decoderAvailable)
 		ret = tsmf_codec_parse_media_type(&mediatype, s);
-	Stream_SetPointer(s, m);
+	Stream_SetPosition(s, pos);
 
 	if (ret)
 	{

--- a/libfreerdp/codec/clear.c
+++ b/libfreerdp/codec/clear.c
@@ -1045,8 +1045,6 @@ INT32 clear_decompress(CLEAR_CONTEXT* clear, const BYTE* pSrcData, UINT32 SrcSiz
 	if (!s)
 		return -2005;
 
-	Stream_SetLength(s, SrcSize);
-
 	if (Stream_GetRemainingLength(s) < 2)
 	{
 		WLog_ERR(TAG, "stream short %" PRIuz " [2 expected]", Stream_GetRemainingLength(s));

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -995,7 +995,7 @@ BOOL rdp_client_connect_mcs_channel_join_confirm(rdpRdp* rdp, wStream* s)
 
 BOOL rdp_client_connect_auto_detect(rdpRdp* rdp, wStream* s)
 {
-	BYTE* mark;
+	size_t pos;
 	UINT16 length;
 	UINT16 channelId;
 
@@ -1003,7 +1003,7 @@ BOOL rdp_client_connect_auto_detect(rdpRdp* rdp, wStream* s)
 	if (rdp->mcs->messageChannelId != 0)
 	{
 		/* Process any MCS message channel PDUs. */
-		Stream_GetPointer(s, mark);
+		pos = Stream_GetPosition(s);
 
 		if (rdp_read_header(rdp, s, &length, &channelId))
 		{
@@ -1028,7 +1028,7 @@ BOOL rdp_client_connect_auto_detect(rdpRdp* rdp, wStream* s)
 			}
 		}
 
-		Stream_SetPointer(s, mark);
+		Stream_SetPosition(s, pos);
 	}
 
 	return FALSE;
@@ -1058,19 +1058,21 @@ int rdp_client_connect_license(rdpRdp* rdp, wStream* s)
 
 int rdp_client_connect_demand_active(rdpRdp* rdp, wStream* s)
 {
-	BYTE* mark;
+	size_t pos;
 	UINT16 width;
 	UINT16 height;
 	UINT16 length;
 	width = rdp->settings->DesktopWidth;
 	height = rdp->settings->DesktopHeight;
-	Stream_GetPointer(s, mark);
+
+	pos = Stream_GetPosition(s);
 
 	if (!rdp_recv_demand_active(rdp, s))
 	{
 		int rc;
 		UINT16 channelId;
-		Stream_SetPointer(s, mark);
+
+		Stream_SetPosition(s, pos);
 		if (!rdp_recv_get_active_header(rdp, s, &channelId, &length))
 			return -1;
 		/* Was Stream_Seek(s, RDP_PACKET_HEADER_MAX_LENGTH);

--- a/libfreerdp/crypto/certificate.c
+++ b/libfreerdp/crypto/certificate.c
@@ -113,8 +113,13 @@ static void certificate_store_uninit(rdpCertificateStore* certificate_store)
 	if (certificate_store)
 	{
 		free(certificate_store->certs_path);
+		certificate_store->certs_path = NULL;
+
 		free(certificate_store->file);
+		certificate_store->file = NULL;
+
 		free(certificate_store->server_path);
+		certificate_store->server_path = NULL;
 	}
 }
 
@@ -147,22 +152,30 @@ static BOOL certificate_store_init(rdpCertificateStore* certificate_store)
 {
 	const rdpSettings* settings;
 	const char* ConfigPath;
+
 	if (!certificate_store)
 		return FALSE;
-	settings = certificate_store->settings;
 
+	settings = certificate_store->settings;
 	if (!settings)
 		return FALSE;
+
 	ConfigPath = settings->ConfigPath;
 	if (!ConfigPath)
 		return FALSE;
+
+	WINPR_ASSERT(!certificate_store->certs_path);
 	if (!(certificate_store->certs_path =
 	          GetCombinedPath(ConfigPath, (const char*)certificate_store_dir)))
 		goto fail;
+
+	WINPR_ASSERT(!certificate_store->server_path);
 	certificate_store->server_path =
 	    GetCombinedPath(ConfigPath, (const char*)certificate_server_dir);
 	if (!certificate_store->server_path)
 		goto fail;
+
+	WINPR_ASSERT(!certificate_store->file);
 	if (!(certificate_store->file =
 	          GetCombinedPath(ConfigPath, (const char*)certificate_known_hosts_file)))
 		goto fail;

--- a/libfreerdp/gdi/bitmap.c
+++ b/libfreerdp/gdi/bitmap.c
@@ -52,14 +52,14 @@
  * @return pixel color
  */
 
-INLINE UINT32 gdi_GetPixel(HGDI_DC hdc, UINT32 nXPos, UINT32 nYPos)
+UINT32 gdi_GetPixel(HGDI_DC hdc, UINT32 nXPos, UINT32 nYPos)
 {
 	HGDI_BITMAP hBmp = (HGDI_BITMAP)hdc->selectedObject;
 	BYTE* data = &(hBmp->data[(nYPos * hBmp->scanline) + nXPos * GetBytesPerPixel(hBmp->format)]);
 	return ReadColor(data, hBmp->format);
 }
 
-INLINE BYTE* gdi_GetPointer(HGDI_BITMAP hBmp, UINT32 X, UINT32 Y)
+BYTE* gdi_GetPointer(HGDI_BITMAP hBmp, UINT32 X, UINT32 Y)
 {
 	UINT32 bpp = GetBytesPerPixel(hBmp->format);
 	return &hBmp->data[(Y * hBmp->width * bpp) + X * bpp];
@@ -82,7 +82,7 @@ static INLINE UINT32 gdi_SetPixelBmp(HGDI_BITMAP hBmp, UINT32 X, UINT32 Y, UINT3
 	return crColor;
 }
 
-INLINE UINT32 gdi_SetPixel(HGDI_DC hdc, UINT32 X, UINT32 Y, UINT32 crColor)
+UINT32 gdi_SetPixel(HGDI_DC hdc, UINT32 X, UINT32 Y, UINT32 crColor)
 {
 	HGDI_BITMAP hBmp = (HGDI_BITMAP)hdc->selectedObject;
 	return gdi_SetPixelBmp(hBmp, X, Y, crColor);

--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -322,7 +322,7 @@ static const BYTE GDI_BS_HATCHED_PATTERNS[] = {
 	0x7E, 0xBD, 0xDB, 0xE7, 0xE7, 0xDB, 0xBD, 0x7E  /* HS_DIACROSS */
 };
 
-INLINE BOOL gdi_decode_color(rdpGdi* gdi, const UINT32 srcColor, UINT32* color, UINT32* format)
+BOOL gdi_decode_color(rdpGdi* gdi, const UINT32 srcColor, UINT32* color, UINT32* format)
 {
 	UINT32 SrcFormat;
 	UINT32 ColorDepth;

--- a/libfreerdp/gdi/pen.c
+++ b/libfreerdp/gdi/pen.c
@@ -56,7 +56,7 @@ HGDI_PEN gdi_CreatePen(UINT32 fnPenStyle, UINT32 nWidth, UINT32 crColor, UINT32 
 	return hPen;
 }
 
-INLINE UINT32 gdi_GetPenColor(HGDI_PEN pen, UINT32 format)
+UINT32 gdi_GetPenColor(HGDI_PEN pen, UINT32 format)
 {
 	return FreeRDPConvertColor(pen->color, pen->format, format, pen->palette);
 }

--- a/libfreerdp/gdi/region.c
+++ b/libfreerdp/gdi/region.c
@@ -360,7 +360,7 @@ INLINE BOOL gdi_CRgnToRect(INT64 x, INT64 y, INT32 w, INT32 h, HGDI_RECT rect)
  * @param bottom y2
  */
 
-INLINE BOOL gdi_RgnToCRect(const HGDI_RGN rgn, INT32* left, INT32* top, INT32* right, INT32* bottom)
+BOOL gdi_RgnToCRect(const HGDI_RGN rgn, INT32* left, INT32* top, INT32* right, INT32* bottom)
 {
 	BOOL rc = TRUE;
 	if ((rgn->w < 0) || (rgn->h < 0))

--- a/server/Sample/sfreerdp.c
+++ b/server/Sample/sfreerdp.c
@@ -528,7 +528,7 @@ static BOOL tf_peer_dump_rfx(freerdp_peer* client)
 
 		record.data = Stream_Buffer(s);
 		pcap_get_next_record_content(pcap_rfx, &record);
-		Stream_SetPointer(s, Stream_Buffer(s) + Stream_Capacity(s));
+		Stream_SetPosition(s, Stream_Capacity(s));
 
 		if (info->test_dump_rfx_realtime &&
 		    test_sleep_tsdiff(&prev_seconds, &prev_useconds, record.header.ts_sec,

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -51,8 +51,8 @@ extern "C"
 	typedef struct _wStream wStream;
 
 	static INLINE size_t Stream_Capacity(wStream* _s);
-	static INLINE size_t Stream_GetRemainingCapacity(wStream* _s);
-	static INLINE size_t Stream_GetRemainingLength(wStream* _s);
+	WINPR_API size_t Stream_GetRemainingCapacity(wStream* _s);
+	WINPR_API size_t Stream_GetRemainingLength(wStream* _s);
 
 	WINPR_API BOOL Stream_EnsureCapacity(wStream* s, size_t size);
 	WINPR_API BOOL Stream_EnsureRemainingCapacity(wStream* s, size_t size);
@@ -393,58 +393,7 @@ extern "C"
 
 	WINPR_API BOOL Stream_SetPosition(wStream* _s, size_t _p);
 
-	static INLINE void Stream_SealLength(wStream* _s)
-	{
-		size_t cur;
-		WINPR_ASSERT(_s);
-		WINPR_ASSERT(_s->buffer <= _s->pointer);
-		cur = (size_t)(_s->pointer - _s->buffer);
-		WINPR_ASSERT(cur <= _s->capacity);
-		if (cur <= _s->capacity)
-			_s->length = cur;
-		else
-		{
-			const char* wTAG = "com.freerdp.winpr.wStream";
-			WLog_FATAL(wTAG, "wStream API misuse: stream was written out of bounds");
-			winpr_log_backtrace(wTAG, WLOG_FATAL, 20);
-			_s->length = 0;
-		}
-	}
-
-	static INLINE size_t Stream_GetRemainingCapacity(wStream* _s)
-	{
-		size_t cur;
-		WINPR_ASSERT(_s);
-		WINPR_ASSERT(_s->buffer <= _s->pointer);
-		cur = (size_t)(_s->pointer - _s->buffer);
-		WINPR_ASSERT(cur <= _s->capacity);
-		if (cur > _s->capacity)
-		{
-			const char* wTAG = "com.freerdp.winpr.wStream";
-			WLog_FATAL(wTAG, "wStream API misuse: stream was written out of bounds");
-			winpr_log_backtrace(wTAG, WLOG_FATAL, 20);
-			return 0;
-		}
-		return (_s->capacity - cur);
-	}
-
-	static INLINE size_t Stream_GetRemainingLength(wStream* _s)
-	{
-		size_t cur;
-		WINPR_ASSERT(_s);
-		WINPR_ASSERT(_s->buffer <= _s->pointer);
-		WINPR_ASSERT(_s->length <= _s->capacity);
-		cur = (size_t)(_s->pointer - _s->buffer);
-		WINPR_ASSERT(cur <= _s->length);
-		if (cur > _s->length)
-		{
-			const char* wTAG = "com.freerdp.winpr.wStream";
-			WLog_FATAL(wTAG, "wStream API misuse: stream was read out of bounds");
-			winpr_log_backtrace(wTAG, WLOG_FATAL, 20);
-			return 0;
-		}
-		return (_s->length - cur);
-	}
+	WINPR_API void Stream_SealLength(wStream* _s);
 
 	static INLINE void Stream_Clear(wStream* _s)
 	{
@@ -461,39 +410,8 @@ extern "C"
 		return TRUE;
 	}
 
-	static INLINE BOOL Stream_Read_UTF16_String(wStream* s, WCHAR* dst, size_t length)
-	{
-		size_t x;
-
-		WINPR_ASSERT(s);
-		WINPR_ASSERT(dst);
-
-		if (Stream_GetRemainingLength(s) / sizeof(WCHAR) < length)
-			return FALSE;
-
-		for (x = 0; x < length; x++)
-			Stream_Read_UINT16(s, dst[x]);
-
-		return TRUE;
-	}
-
-	static INLINE BOOL Stream_Write_UTF16_String(wStream* s, const WCHAR* src, size_t length)
-	{
-		size_t x;
-
-		WINPR_ASSERT(s);
-		WINPR_ASSERT(src || (length == 0));
-		if (!s || !src)
-			return FALSE;
-
-		if (Stream_GetRemainingCapacity(s) / sizeof(WCHAR) < length)
-			return FALSE;
-
-		for (x = 0; x < length; x++)
-			Stream_Write_UINT16(s, src[x]);
-
-		return TRUE;
-	}
+	WINPR_API BOOL Stream_Read_UTF16_String(wStream* s, WCHAR* dst, size_t length);
+	WINPR_API BOOL Stream_Write_UTF16_String(wStream* s, const WCHAR* src, size_t length);
 
 	/* StreamPool */
 

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -50,6 +50,10 @@ extern "C"
 	};
 	typedef struct _wStream wStream;
 
+	static INLINE size_t Stream_Capacity(wStream* _s);
+	static INLINE size_t Stream_GetRemainingCapacity(wStream* _s);
+	static INLINE size_t Stream_GetRemainingLength(wStream* _s);
+
 	WINPR_API BOOL Stream_EnsureCapacity(wStream* s, size_t size);
 	WINPR_API BOOL Stream_EnsureRemainingCapacity(wStream* s, size_t size);
 
@@ -60,26 +64,38 @@ extern "C"
 	static INLINE void Stream_Seek(wStream* s, size_t _offset)
 	{
 		WINPR_ASSERT(s);
+		WINPR_ASSERT(Stream_GetRemainingCapacity(s) >= _offset);
 		s->pointer += (_offset);
 	}
 
 	static INLINE void Stream_Rewind(wStream* s, size_t _offset)
 	{
+		size_t cur;
 		WINPR_ASSERT(s);
-		s->pointer -= (_offset);
+		WINPR_ASSERT(s->buffer <= s->pointer);
+		cur = (size_t)(s->pointer - s->buffer);
+		WINPR_ASSERT(cur >= _offset);
+		if (cur >= _offset)
+			s->pointer -= (_offset);
+		else
+			s->pointer = s->buffer;
 	}
 
-#define _stream_read_n8(_t, _s, _v, _p)  \
-	do                                   \
-	{                                    \
-		(_v) = (_t)(*(_s)->pointer);     \
-		if (_p)                          \
-			Stream_Seek(_s, sizeof(_t)); \
+#define _stream_read_n8(_t, _s, _v, _p)                   \
+	do                                                    \
+	{                                                     \
+		WINPR_ASSERT(_s);                                 \
+		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= 1); \
+		(_v) = (_t)(*(_s)->pointer);                      \
+		if (_p)                                           \
+			Stream_Seek(_s, sizeof(_t));                  \
 	} while (0)
 
 #define _stream_read_n16_le(_t, _s, _v, _p)                                      \
 	do                                                                           \
 	{                                                                            \
+		WINPR_ASSERT(_s);                                                        \
+		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= 2);                        \
 		(_v) = (_t)((*(_s)->pointer) + (((UINT16)(*((_s)->pointer + 1))) << 8)); \
 		if (_p)                                                                  \
 			Stream_Seek(_s, sizeof(_t));                                         \
@@ -88,6 +104,8 @@ extern "C"
 #define _stream_read_n16_be(_t, _s, _v, _p)                                              \
 	do                                                                                   \
 	{                                                                                    \
+		WINPR_ASSERT(_s);                                                                \
+		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= 2);                                \
 		(_v) = (_t)((((UINT16)(*(_s)->pointer)) << 8) + (UINT16)(*((_s)->pointer + 1))); \
 		if (_p)                                                                          \
 			Stream_Seek(_s, sizeof(_t));                                                 \
@@ -96,6 +114,8 @@ extern "C"
 #define _stream_read_n32_le(_t, _s, _v, _p)                                              \
 	do                                                                                   \
 	{                                                                                    \
+		WINPR_ASSERT(_s);                                                                \
+		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= 4);                                \
 		(_v) = (_t)((UINT32)(*(_s)->pointer) + (((UINT32)(*((_s)->pointer + 1))) << 8) + \
 		            (((UINT32)(*((_s)->pointer + 2))) << 16) +                           \
 		            ((((UINT32) * ((_s)->pointer + 3))) << 24));                         \
@@ -106,6 +126,8 @@ extern "C"
 #define _stream_read_n32_be(_t, _s, _v, _p)                                                        \
 	do                                                                                             \
 	{                                                                                              \
+		WINPR_ASSERT(_s);                                                                          \
+		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= 4);                                          \
 		(_v) = (_t)(((((UINT32) * ((_s)->pointer))) << 24) +                                       \
 		            (((UINT32)(*((_s)->pointer + 1))) << 16) +                                     \
 		            (((UINT32)(*((_s)->pointer + 2))) << 8) + (((UINT32)(*((_s)->pointer + 3))))); \
@@ -116,6 +138,8 @@ extern "C"
 #define _stream_read_n64_le(_t, _s, _v, _p)                                                       \
 	do                                                                                            \
 	{                                                                                             \
+		WINPR_ASSERT(_s);                                                                         \
+		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= 8);                                         \
 		(_v) = (_t)(                                                                              \
 		    (UINT64)(*(_s)->pointer) + (((UINT64)(*((_s)->pointer + 1))) << 8) +                  \
 		    (((UINT64)(*((_s)->pointer + 2))) << 16) + (((UINT64)(*((_s)->pointer + 3))) << 24) + \
@@ -128,6 +152,8 @@ extern "C"
 #define _stream_read_n64_be(_t, _s, _v, _p)                                                       \
 	do                                                                                            \
 	{                                                                                             \
+		WINPR_ASSERT(_s);                                                                         \
+		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= 8);                                         \
 		(_v) = (_t)(                                                                              \
 		    (((UINT64)(*((_s)->pointer))) << 56) + (((UINT64)(*((_s)->pointer + 1))) << 48) +     \
 		    (((UINT64)(*((_s)->pointer + 2))) << 40) + (((UINT64)(*((_s)->pointer + 3))) << 32) + \
@@ -162,6 +188,7 @@ extern "C"
 	{
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(_b || (_n == 0));
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= _n);
 		memcpy(_b, (_s->pointer), (_n));
 		Stream_Seek(_s, _n);
 	}
@@ -191,18 +218,21 @@ extern "C"
 	{
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(_b || (_n == 0));
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= _n);
 		memcpy(_b, (_s->pointer), (_n));
 	}
 
 	static INLINE void Stream_Write_UINT8(wStream* _s, UINT8 _v)
 	{
 		WINPR_ASSERT(_s);
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 1);
 		*_s->pointer++ = (UINT8)(_v);
 	}
 
 	static INLINE void Stream_Write_INT16(wStream* _s, INT16 _v)
 	{
 		WINPR_ASSERT(_s);
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 2);
 		*_s->pointer++ = (_v)&0xFF;
 		*_s->pointer++ = ((_v) >> 8) & 0xFF;
 	}
@@ -210,6 +240,7 @@ extern "C"
 	static INLINE void Stream_Write_UINT16(wStream* _s, UINT16 _v)
 	{
 		WINPR_ASSERT(_s);
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 2);
 		*_s->pointer++ = (_v)&0xFF;
 		*_s->pointer++ = ((_v) >> 8) & 0xFF;
 	}
@@ -217,6 +248,7 @@ extern "C"
 	static INLINE void Stream_Write_UINT16_BE(wStream* _s, UINT16 _v)
 	{
 		WINPR_ASSERT(_s);
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 2);
 		*_s->pointer++ = ((_v) >> 8) & 0xFF;
 		*_s->pointer++ = (_v)&0xFF;
 	}
@@ -224,6 +256,7 @@ extern "C"
 	static INLINE void Stream_Write_INT32(wStream* _s, INT32 _v)
 	{
 		WINPR_ASSERT(_s);
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 4);
 		*_s->pointer++ = (_v)&0xFF;
 		*_s->pointer++ = ((_v) >> 8) & 0xFF;
 		*_s->pointer++ = ((_v) >> 16) & 0xFF;
@@ -233,6 +266,7 @@ extern "C"
 	static INLINE void Stream_Write_UINT32(wStream* _s, UINT32 _v)
 	{
 		WINPR_ASSERT(_s);
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 4);
 		*_s->pointer++ = (_v)&0xFF;
 		*_s->pointer++ = ((_v) >> 8) & 0xFF;
 		*_s->pointer++ = ((_v) >> 16) & 0xFF;
@@ -248,6 +282,7 @@ extern "C"
 	static INLINE void Stream_Write_UINT64(wStream* _s, UINT64 _v)
 	{
 		WINPR_ASSERT(_s);
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 8);
 		*_s->pointer++ = (UINT64)(_v)&0xFF;
 		*_s->pointer++ = ((UINT64)(_v) >> 8) & 0xFF;
 		*_s->pointer++ = ((UINT64)(_v) >> 16) & 0xFF;
@@ -263,6 +298,7 @@ extern "C"
 		{
 			WINPR_ASSERT(_s);
 			WINPR_ASSERT(_b);
+			WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= _n);
 			memcpy(_s->pointer, (_b), (_n));
 			Stream_Seek(_s, _n);
 		}
@@ -281,6 +317,7 @@ extern "C"
 	static INLINE void Stream_Zero(wStream* _s, size_t _n)
 	{
 		WINPR_ASSERT(_s);
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= (_n));
 		memset(_s->pointer, '\0', (_n));
 		Stream_Seek(_s, _n);
 	}
@@ -288,6 +325,7 @@ extern "C"
 	static INLINE void Stream_Fill(wStream* _s, int _v, size_t _n)
 	{
 		WINPR_ASSERT(_s);
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= (_n));
 		memset(_s->pointer, _v, (_n));
 		Stream_Seek(_s, _n);
 	}
@@ -296,6 +334,9 @@ extern "C"
 	{
 		WINPR_ASSERT(_src);
 		WINPR_ASSERT(_dst);
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_src) >= (_n));
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_dst) >= (_n));
+
 		memcpy(_dst->pointer, _src->pointer, _n);
 		Stream_Seek(_dst, _n);
 		Stream_Seek(_src, _n);
@@ -308,11 +349,6 @@ extern "C"
 	}
 
 #define Stream_GetBuffer(_s, _b) _b = Stream_Buffer(_s)
-	static INLINE void Stream_SetBuffer(wStream* _s, BYTE* _b)
-	{
-		WINPR_ASSERT(_s);
-		_s->buffer = _b;
-	}
 
 	static INLINE BYTE* Stream_Pointer(wStream* _s)
 	{
@@ -321,11 +357,15 @@ extern "C"
 	}
 
 #define Stream_GetPointer(_s, _p) _p = Stream_Pointer(_s)
-	static INLINE void Stream_SetPointer(wStream* _s, BYTE* _p)
-	{
-		WINPR_ASSERT(_s);
-		_s->pointer = _p;
-	}
+
+#if defined(WITH_WINPR_DEPRECATED)
+	WINPR_API WINPR_DEPRECATED_VAR("Use Stream_SetPosition instead",
+	                               BOOL Stream_SetPointer(wStream* _s, BYTE* _p));
+	WINPR_API WINPR_DEPRECATED_VAR("Use Stream_New(buffer, capacity) instead",
+	                               BOOL Stream_SetBuffer(wStream* _s, BYTE* _b));
+	WINPR_API WINPR_DEPRECATED_VAR("Use Stream_New(buffer, capacity) instead",
+	                               void Stream_SetCapacity(wStream* _s, size_t capacity));
+#endif
 
 	static INLINE size_t Stream_Length(wStream* _s)
 	{
@@ -334,11 +374,7 @@ extern "C"
 	}
 
 #define Stream_GetLength(_s, _l) _l = Stream_Length(_s)
-	static INLINE void Stream_SetLength(wStream* _s, size_t _l)
-	{
-		WINPR_ASSERT(_s);
-		_s->length = _l;
-	}
+	WINPR_API BOOL Stream_SetLength(wStream* _s, size_t _l);
 
 	static INLINE size_t Stream_Capacity(wStream* _s)
 	{
@@ -347,40 +383,67 @@ extern "C"
 	}
 
 #define Stream_GetCapacity(_s, _c) _c = Stream_Capacity(_s);
-	static INLINE void Stream_SetCapacity(wStream* _s, size_t _c)
-	{
-		WINPR_ASSERT(_s);
-		_s->capacity = _c;
-	}
 
 	static INLINE size_t Stream_GetPosition(wStream* _s)
 	{
 		WINPR_ASSERT(_s);
+		WINPR_ASSERT(_s->buffer <= _s->pointer);
 		return (size_t)(_s->pointer - _s->buffer);
 	}
 
-	static INLINE void Stream_SetPosition(wStream* _s, size_t _p)
-	{
-		WINPR_ASSERT(_s);
-		_s->pointer = _s->buffer + (_p);
-	}
+	WINPR_API BOOL Stream_SetPosition(wStream* _s, size_t _p);
 
 	static INLINE void Stream_SealLength(wStream* _s)
 	{
+		size_t cur;
 		WINPR_ASSERT(_s);
-		_s->length = (size_t)(_s->pointer - _s->buffer);
+		WINPR_ASSERT(_s->buffer <= _s->pointer);
+		cur = (size_t)(_s->pointer - _s->buffer);
+		WINPR_ASSERT(cur <= _s->capacity);
+		if (cur <= _s->capacity)
+			_s->length = cur;
+		else
+		{
+			const char* wTAG = "com.freerdp.winpr.wStream";
+			WLog_FATAL(wTAG, "wStream API misuse: stream was written out of bounds");
+			winpr_log_backtrace(wTAG, WLOG_FATAL, 20);
+			_s->length = 0;
+		}
 	}
 
 	static INLINE size_t Stream_GetRemainingCapacity(wStream* _s)
 	{
+		size_t cur;
 		WINPR_ASSERT(_s);
-		return (_s->capacity - (size_t)(_s->pointer - _s->buffer));
+		WINPR_ASSERT(_s->buffer <= _s->pointer);
+		cur = (size_t)(_s->pointer - _s->buffer);
+		WINPR_ASSERT(cur <= _s->capacity);
+		if (cur > _s->capacity)
+		{
+			const char* wTAG = "com.freerdp.winpr.wStream";
+			WLog_FATAL(wTAG, "wStream API misuse: stream was written out of bounds");
+			winpr_log_backtrace(wTAG, WLOG_FATAL, 20);
+			return 0;
+		}
+		return (_s->capacity - cur);
 	}
 
 	static INLINE size_t Stream_GetRemainingLength(wStream* _s)
 	{
+		size_t cur;
 		WINPR_ASSERT(_s);
-		return (_s->length - (size_t)(_s->pointer - _s->buffer));
+		WINPR_ASSERT(_s->buffer <= _s->pointer);
+		WINPR_ASSERT(_s->length <= _s->capacity);
+		cur = (size_t)(_s->pointer - _s->buffer);
+		WINPR_ASSERT(cur <= _s->length);
+		if (cur > _s->length)
+		{
+			const char* wTAG = "com.freerdp.winpr.wStream";
+			WLog_FATAL(wTAG, "wStream API misuse: stream was read out of bounds");
+			winpr_log_backtrace(wTAG, WLOG_FATAL, 20);
+			return 0;
+		}
+		return (_s->length - cur);
 	}
 
 	static INLINE void Stream_Clear(wStream* _s)

--- a/winpr/libwinpr/utils/CMakeLists.txt
+++ b/winpr/libwinpr/utils/CMakeLists.txt
@@ -105,6 +105,7 @@ set(${MODULE_PREFIX}_SRCS
 	ntlm.c
 	image.c
 	print.c
+	stream.h
 	stream.c
 	strlst.c
 	debug.c

--- a/winpr/libwinpr/utils/collections/StreamPool.c
+++ b/winpr/libwinpr/utils/collections/StreamPool.c
@@ -26,6 +26,8 @@
 
 #include <winpr/collections.h>
 
+#include "../stream.h"
+
 struct _wStreamPool
 {
 	size_t aSize;
@@ -253,8 +255,11 @@ void StreamPool_Return(wStreamPool* pool, wStream* s)
 	StreamPool_Lock(pool);
 
 	StreamPool_EnsureCapacity(pool, 1, FALSE);
-	pool->aArray[(pool->aSize)++] = s;
-	StreamPool_RemoveUsed(pool, s);
+	{
+		Stream_EnsureValidity(s);
+		pool->aArray[(pool->aSize)++] = s;
+		StreamPool_RemoveUsed(pool, s);
+	}
 
 	StreamPool_Unlock(pool);
 }

--- a/winpr/libwinpr/utils/stream.c
+++ b/winpr/libwinpr/utils/stream.c
@@ -133,3 +133,56 @@ void Stream_Free(wStream* s, BOOL bFreeBuffer)
 			free(s);
 	}
 }
+
+BOOL Stream_SetLength(wStream* _s, size_t _l)
+{
+	if ((_l) > Stream_Capacity(_s))
+	{
+		_s->length = 0;
+		return FALSE;
+	}
+	_s->length = _l;
+	return TRUE;
+}
+
+BOOL Stream_SetPosition(wStream* _s, size_t _p)
+{
+	if ((_p) > Stream_Capacity(_s))
+	{
+		_s->pointer = _s->buffer;
+		return FALSE;
+	}
+	_s->pointer = _s->buffer + (_p);
+	return TRUE;
+}
+
+#if defined(WITH_WINPR_DEPRECATED)
+BOOL Stream_SetPointer(wStream* _s, BYTE* _p)
+{
+	WINPR_ASSERT(_s);
+	if (!_p || (_s->buffer > _p) || (_s->buffer + _s->capacity < _p))
+	{
+		_s->pointer = _s->buffer;
+		return FALSE;
+	}
+	_s->pointer = _p;
+	return TRUE;
+}
+
+BOOL Stream_SetBuffer(wStream* _s, BYTE* _b)
+{
+	WINPR_ASSERT(_s);
+	WINPR_ASSERT(_b);
+
+	_s->buffer = _b;
+	_s->pointer = _b;
+	return _s->buffer != NULL;
+}
+
+void Stream_SetCapacity(wStream* _s, size_t _c)
+{
+	WINPR_ASSERT(_s);
+	_s->capacity = _c;
+}
+
+#endif

--- a/winpr/libwinpr/utils/stream.h
+++ b/winpr/libwinpr/utils/stream.h
@@ -1,0 +1,28 @@
+/*
+ * WinPR: Windows Portable Runtime
+ * Stream Utils
+ *
+ * Copyright 2021 Armin Novak <anovak@thincast.com>
+ * Copyright 2021 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LIBWINPR_UTILS_STREAM_H
+#define LIBWINPR_UTILS_STREAM_H
+
+#include <winpr/stream.h>
+
+void Stream_EnsureValidity(wStream* s);
+
+#endif /* LIBWINPR_UTILS_STREAM_H */


### PR DESCRIPTION
Replaces #7320 and #7321 

* Fix a missing `NULL` reset after free in certificate store
* Adds validity checks for `wStream API`
* Removes problematic `wStream` setter functions that are not strictly necessary.