### PR TITLE
Proxy passthrough change

### DIFF
--- a/server/proxy/pf_config.c
+++ b/server/proxy/pf_config.c
@@ -226,21 +226,6 @@ static BOOL pf_config_load_channels(wIniFile* ini, proxyConfig* config)
 	config->Passthrough = pf_config_parse_comma_separated_list(
 	    pf_config_get_str(ini, "Channels", "Passthrough", FALSE), &config->PassthroughCount);
 
-	{
-		/* validate channel name length */
-		size_t i;
-
-		for (i = 0; i < config->PassthroughCount; i++)
-		{
-			const char* name = config->Passthrough[i];
-			if (strlen(name) > CHANNEL_NAME_LEN)
-			{
-				WLog_ERR(TAG, "passthrough channel: %s: name too long!", config->Passthrough[i]);
-				return FALSE;
-			}
-		}
-	}
-
 	return TRUE;
 }
 

--- a/server/proxy/pf_utils.c
+++ b/server/proxy/pf_utils.c
@@ -35,7 +35,7 @@ int pf_utils_channel_is_passthrough(const proxyConfig* config, const char* name)
 	for (i = 0; i < config->PassthroughCount; i++)
 	{
 		const char* channel_name = config->Passthrough[i];
-		if (strncmp(name, channel_name, CHANNEL_NAME_LEN + 1) == 0)
+		if (strcmp(name, channel_name) == 0)
 		{
 			found = TRUE;
 			break;


### PR DESCRIPTION
removes the limit imposed on the length of the names that can go in the passthrough field in the proxy config file

#7324 