### PR TITLE
WIP: handle geometry for video control on win32

### DIFF
--- a/client/Windows/CMakeLists.txt
+++ b/client/Windows/CMakeLists.txt
@@ -35,6 +35,8 @@ set(${MODULE_PREFIX}_SRCS
 	wf_client.h
 	wf_floatbar.c
 	wf_floatbar.h
+	wf_geometry.c
+	wf_geometry.h
 	wfreerdp.rc
 	resource.h)
 

--- a/client/Windows/wf_channels.c
+++ b/client/Windows/wf_channels.c
@@ -24,6 +24,7 @@
 
 #include "wf_rail.h"
 #include "wf_cliprdr.h"
+#include "wf_geometry.h"
 
 #include <freerdp/gdi/gfx.h>
 
@@ -61,6 +62,14 @@ void wf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs*
 	{
 		wfc->disp = (DispClientContext*)e->pInterface;
 	}
+	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
+	{
+		wf_geometry_init(wfc, (GeometryClientContext*)e->pInterface);
+	}
+	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
+	{
+		wfc->video = (VideoClientContext*)e->pInterface;
+	}
 }
 
 void wf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEventArgs* e)
@@ -89,5 +98,13 @@ void wf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEven
 	else if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) == 0)
 	{
 		wfc->disp = NULL;
+	}
+	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
+	{
+		wf_geometry_uninit(wfc, (GeometryClientContext*)e->pInterface);
+	}
+	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
+	{
+		wfc->video = NULL;
 	}
 }

--- a/client/Windows/wf_client.h
+++ b/client/Windows/wf_client.h
@@ -138,6 +138,8 @@ extern "C"
 		DispClientContext* disp;
 		UINT64 lastSentDate;
 		BOOL wasMaximized;
+
+		VideoClientContext* video;
 	};
 
 	/**

--- a/client/Windows/wf_geometry.c
+++ b/client/Windows/wf_geometry.c
@@ -1,0 +1,29 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ *
+ * Copyright 2021 Alexandru Bagu <alexandru.bagu@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wf_geometry.h"
+
+BOOL wf_geometry_init(wfContext* wfc, GeometryClientContext* geometry)
+{
+	if (wfc->video)
+		wfc->video->setGeometry(wfc->video, geometry);
+}
+
+BOOL wf_geometry_uninit(wfContext* wfc, GeometryClientContext* geometry)
+{
+}

--- a/client/Windows/wf_geometry.h
+++ b/client/Windows/wf_geometry.h
@@ -1,0 +1,27 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ *
+ * Copyright 2021 Alexandru Bagu <alexandru.bagu@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CLIENT_WIN_GEOMETRY_H
+#define FREERDP_CLIENT_WIN_GEOMETRY_H
+
+#include "wf_client.h"
+
+BOOL wf_geometry_init(wfContext* wfc, GeometryClientContext* geometry);
+BOOL wf_geometry_uninit(wfContext* wfc, GeometryClientContext* geometry);
+
+#endif /* FREERDP_CLIENT_WIN_GEOMETRY_H */


### PR DESCRIPTION
fixes the issue where the video control plugin yells 'geometry channel is not ready' for win32