### PR TITLE
channels/rdpei: avoid calling free() on contactPoints array

### DIFF
--- a/channels/rdpei/client/rdpei_main.c
+++ b/channels/rdpei/client/rdpei_main.c
@@ -1386,7 +1386,6 @@ UINT DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 	return CHANNEL_RC_OK;
 error_out:
 	free(context);
-	free(rdpei->contactPoints);
 	free(rdpei);
 	return error;
 }


### PR DESCRIPTION
This was fixed on master as part of
268bc2e8ef7b76887d14d50702bb8446ce15a4c1. Backporting that change seems
like too much for the stable branch.

See https://github.com/FreeRDP/FreeRDP/issues/7396.