### PR TITLE
log failure to load dynamic channel without returning error

### DIFF
--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -1520,7 +1520,9 @@ static UINT drdynvc_virtual_channel_event_connected(drdynvcPlugin* drdynvc, LPVO
 		error = dvcman_load_addin(drdynvc, drdynvc->channel_mgr, args, settings);
 
 		if (CHANNEL_RC_OK != error)
-			goto error;
+		{
+			WLog_ERR(TAG, "Failed to load channel %s", args->argv[0]);
+		}
 	}
 
 	if ((error = dvcman_init(drdynvc, drdynvc->channel_mgr)))


### PR DESCRIPTION
Instead of returning error when we don't manage to load a dynamic channel we should log it as an error and let it continue, which works fine.
I propose this change because if you start FreeRDP with a rdp file with "Video capture devices" enabled, freerdp will be stuck in reconnect loop (connect, get dynamic channel list, try to open `rdpecam`, fail to load channel, reconnect, etc).
Obviously one fix would be to disable the dynamic channel but I believe having an error instead will be just as effective, especially since new dynamic channels might continue to be added by Microsoft.