### PR TITLE
Temporary trust certificate when helped by local cert store

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -786,7 +786,7 @@ static DWORD wf_cli_verify_certificate_ex(freerdp* instance, const char* host, U
 	{
 		if (wf_is_x509_certificate_trusted(common_name, subject, issuer, fingerprint) == S_OK)
 		{
-			return 1;
+			return 2;
 		}
 	}
 #endif
@@ -808,7 +808,7 @@ static DWORD wf_verify_certificate_ex(freerdp* instance, const char* host, UINT1
 	{
 		if (wf_is_x509_certificate_trusted(common_name, subject, issuer, fingerprint) == S_OK)
 		{
-			return 1;
+			return 2;
 		}
 	}
 #endif


### PR DESCRIPTION
Valid certificates are valid only for a specific amount of time and afterwards they must be changed. Any new certificate will have a different fingerprint and as such freerdp will reject the new certificate automatically even though it is (or may be) valid.
Since this trust (the one provided via local CA) is optional by default it should not interfere with manually accepted certificates nor should it require manual intervention to accept a new certificate.