### PR TITLE
Ignore redirection password in case of smartcard auth

### DIFF
--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -711,7 +711,9 @@ static BOOL rdp_write_info_packet(rdpRdp* rdp, wStream* s)
 
 	if (!settings->RemoteAssistanceMode)
 	{
-		if (settings->RedirectionPassword && settings->RedirectionPasswordLength > 0)
+		/* Ignore redirection password if we´re using smartcard and have the pin as password */
+		if (((flags & INFO_PASSWORD_IS_SC_PIN) == 0) && settings->RedirectionPassword &&
+		    (settings->RedirectionPasswordLength > 0))
 		{
 			union {
 				BYTE* bp;


### PR DESCRIPTION
When a redirection occurs, we must not use the redirection password if smartcard authentication is used.
The password contains the PIN for the smartcard and the redirection password is not required as we already have the smartcard to authenticate.