### PR TITLE
Added app_id on wayland client

### DIFF
--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -227,6 +227,7 @@ static BOOL wl_post_connect(freerdp* instance)
 	wlfContext* context;
 	rdpSettings* settings;
 	char* title = "FreeRDP";
+	char* app_id = "wlfreerdp";
 	UINT32 w, h;
 
 	if (!instance || !instance->context)
@@ -268,6 +269,7 @@ static BOOL wl_post_connect(freerdp* instance)
 
 	UwacWindowSetFullscreenState(window, NULL, instance->context->settings->Fullscreen);
 	UwacWindowSetTitle(window, title);
+	UwacWindowSetAppId(window, app_id);
 	UwacWindowSetOpaqueRegion(context->window, 0, 0, w, h);
 	instance->update->BeginPaint = wl_begin_paint;
 	instance->update->EndPaint = wl_end_paint;

--- a/uwac/include/uwac/uwac.h
+++ b/uwac/include/uwac/uwac.h
@@ -570,6 +570,14 @@ extern "C"
 	 */
 	UWAC_API void UwacWindowSetTitle(UwacWindow* window, const char* name);
 
+	/**
+	 *	Sets the app id of the UwacWindow
+	 *
+	 * @param window the UwacWindow
+	 * @param app_id app id
+	 */
+	UWAC_API void UwacWindowSetAppId(UwacWindow* window, const char* app_id);
+
 	/** Dispatch the display
 	 *
 	 * @param display The display to dispatch

--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -816,3 +816,9 @@ void UwacWindowSetTitle(UwacWindow* window, const char* name)
 	else if (window->shell_surface)
 		wl_shell_surface_set_title(window->shell_surface, name);
 }
+
+void UwacWindowSetAppId(UwacWindow* window, const char* app_id)
+{
+	if (window->xdg_toplevel)
+		xdg_toplevel_set_app_id(window->xdg_toplevel, app_id);
+}


### PR DESCRIPTION
There is currently no app_id defined for Wayland freerdp client.
This pull request adds a method to update the app_id and, on window creation, updates the app_id.

The tests are made with swaywm command `swaymsg -t get_tree`.

On master version no app_id is shown : 

```json
{
  "id": 43,
  "name": "FreeRDP",
...
  "app_id": null,
...
}
```

In this version app_id is shown : 

```json
{
  "id": 43,
  "name": "FreeRDP",
...
  "app_id": "wlfreerdp",
...
}
```

See this issue : https://github.com/FreeRDP/FreeRDP/issues/5883

The Wayland app_id "wlfreerdp" is a mirror to the X11 class "xfreerdp".