### PR TITLE
Load legacy provider when initializing OpenSSL 3.0 

### DIFF
--- a/winpr/libwinpr/crypto/cipher.c
+++ b/winpr/libwinpr/crypto/cipher.c
@@ -29,9 +29,6 @@
 #include <openssl/rc4.h>
 #include <openssl/des.h>
 #include <openssl/evp.h>
-#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
-#include <openssl/provider.h>
-#endif
 #endif
 
 #ifdef WITH_MBEDTLS
@@ -60,11 +57,6 @@ static WINPR_RC4_CTX* winpr_RC4_New_Internal(const BYTE* key, size_t keylen, BOO
 
 	if (keylen > INT_MAX)
 		return NULL;
-
-#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
-	if (OSSL_PROVIDER_load(NULL, "legacy") == NULL)
-		return NULL;
-#endif
 
 	if (!(ctx = (WINPR_RC4_CTX*)EVP_CIPHER_CTX_new()))
 		return NULL;

--- a/winpr/libwinpr/utils/ssl.c
+++ b/winpr/libwinpr/utils/ssl.c
@@ -318,7 +318,7 @@ static BOOL CALLBACK _winpr_openssl_initialize(PINIT_ONCE once, PVOID param, PVO
 #endif
 
 	g_winpr_openssl_initialized_by_winpr = TRUE;
-	return winpr_enable_fips(flags);
+	return TRUE;
 }
 
 /* exported functions */

--- a/winpr/libwinpr/utils/ssl.c
+++ b/winpr/libwinpr/utils/ssl.c
@@ -246,7 +246,7 @@ static BOOL winpr_enable_fips(DWORD flags)
 		WLog_ERR(TAG, "Openssl fips mode not available on openssl versions less than 1.0.1!");
 		return FALSE;
 #else
-		WLog_DBG(TAG, "Ensuring openssl fips mode is ENabled");
+		WLog_DBG(TAG, "Ensuring openssl fips mode is enabled");
 
 #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
 		OSSL_PROVIDER_load(NULL, "fips");
@@ -260,10 +260,10 @@ static BOOL winpr_enable_fips(DWORD flags)
 #else
 			if (FIPS_mode_set(1))
 #endif
-				WLog_INFO(TAG, "Openssl fips mode ENabled!");
+				WLog_INFO(TAG, "Openssl fips mode enabled!");
 			else
 			{
-				WLog_ERR(TAG, "Openssl fips mode ENable failed!");
+				WLog_ERR(TAG, "Openssl fips mode enable failed!");
 				return FALSE;
 			}
 		}

--- a/winpr/libwinpr/utils/ssl.c
+++ b/winpr/libwinpr/utils/ssl.c
@@ -33,6 +33,10 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+#include <openssl/provider.h>
+#endif
+
 #include "../log.h"
 #define TAG WINPR_TAG("utils.ssl")
 
@@ -245,6 +249,7 @@ static BOOL winpr_enable_fips(DWORD flags)
 		WLog_DBG(TAG, "Ensuring openssl fips mode is ENabled");
 
 #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+		OSSL_PROVIDER_load(NULL, "fips");
 		if (!EVP_default_properties_is_fips_enabled(NULL))
 #else
 		if (FIPS_mode() != 1)
@@ -305,6 +310,13 @@ static BOOL CALLBACK _winpr_openssl_initialize(PINIT_ONCE once, PVOID param, PVO
 		return FALSE;
 
 #endif
+
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+	/* The legacy provider is needed for MD4. */
+	OSSL_PROVIDER_load(NULL, "legacy");
+	OSSL_PROVIDER_load(NULL, "default");
+#endif
+
 	g_winpr_openssl_initialized_by_winpr = TRUE;
 	return winpr_enable_fips(flags);
 }


### PR DESCRIPTION
With OpenSSL 3.0, FreeRDP log contains errors like: `4036740A4C7F0000:error:0308010C:digital envelope routines: inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:346: Global default library context, Algorithm (MD4 : 85), Properties () `. This leads to connection failures in some cases, e.g. https://github.com/FreeRDP/FreeRDP/issues/7449. This is because algorithms like MD4 are now part of the legacy provider, which is not loaded by default. Let's explicitly load that provider.

This MR also contains some other semi-relevant changes, please see the commit descriptions for more details.