### PR TITLE
Fix issue that xfreerdp failed to do remote to local clipboard file copy under KDE v5.88 

### DIFF
--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -2314,6 +2314,7 @@ static int xf_cliprdr_fuse_util_stat(xfClipboard* clipboard, fuse_ino_t ino, str
 	stbuf->st_mode = node->st_mode;
 	stbuf->st_mtime = node->st_mtim.tv_sec;
 	stbuf->st_nlink = 1;
+	stbuf->st_size = node->st_size;
 error:
 	ArrayList_Unlock(clipboard->ino_list);
 	return err;


### PR DESCRIPTION
Under KDE v5.88.0 , remote to local clipboard file copy stopped at very first chunk (512k) of file.

## Why previous it works and now not?
TL;DR I made a mistake.

Previously  KIO (KDE I/O library)  v5.80.1  gets size [only once](https://github.com/KDE/kio/blob/v5.80.1/src/ioslaves/file/file_unix.cpp#L818) and determines finish state by `read` syscall [return code](https://github.com/KDE/kio/blob/v5.80.1/src/ioslaves/file/file_unix.cpp#L880).

Now KIO  v5.88.0 gets file size [**every iteration**](https://github.com/KDE/kio/blob/v5.88.0/src/ioslaves/file/file_unix.cpp#L808) of reading chunks (Although i think this is inefficient) and uses it  to determine finish state.

First time , size info is returned by `xf_cliprdr_fuse_lookup`   , And the following calls of `size()` get size from `xf_cliprdr_fuse_getattr` where i did not fill `st_size` in response thus it returns 0 as file size and it breaks file transfer. 

So previously it's safe,  but since now it gets multiple times of file size and I screwed up.

### Why other file manager still works?
Because they (such as command line `cp` or gnome nautilus ) get size only once (from  `xf_cliprdr_fuse_lookup` ) and thus do not trigger this bug. 