### PR TITLE
Do not set CMAKE_OSX_ARCHITECTURES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,10 +478,6 @@ if(APPLE)
 		endif()
 		set(CMAKE_FIND_ROOT_PATH ${CMAKE_FIND_ROOT_PATH} ${FREERDP_IOS_EXTERNAL_SSL_PATH})
 		set_property(GLOBAL PROPERTY XCODE_ATTRIBUTE_SKIP_INSTALL YES)
-	else(IOS)
-		if(NOT DEFINED CMAKE_OSX_ARCHITECTURES)
-			set(CMAKE_OSX_ARCHITECTURES i386 x86_64)
-		endif()
 	endif(IOS)
 
 # Temporarily disabled, causes the cmake script to be reexecuted, causing the compilation to fail.

--- a/channels/audin/client/mac/audin_mac.m
+++ b/channels/audin/client/mac/audin_mac.m
@@ -329,7 +329,7 @@ static UINT audin_mac_parse_addin_args(AudinMacDevice *device, const ADDIN_ARGV 
 	int status;
 	char *str_num, *eptr;
 	DWORD flags;
-	COMMAND_LINE_ARGUMENT_A *arg;
+	const COMMAND_LINE_ARGUMENT_A *arg;
 	COMMAND_LINE_ARGUMENT_A audin_mac_args[] = { { "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>",
 		                                           NULL, NULL, -1, NULL, "audio device name" },
 		                                         { NULL, 0, NULL, NULL, NULL, -1, NULL, NULL } };

--- a/winpr/include/winpr/wtypes.h.in
+++ b/winpr/include/winpr/wtypes.h.in
@@ -167,7 +167,7 @@ typedef void* PVOID, *LPVOID, *PVOID64, *LPVOID64;
 typedef __int32 BOOL;
 #else /* __APPLE__ */
 /* ensure compatibility with objc libraries */
-#if (TARGET_OS_IPHONE && __LP64__)  ||  TARGET_OS_WATCH
+#if (defined(TARGET_OS_IPHONE) && defined(__LP64__))  || defined(TARGET_OS_WATCH)
 typedef bool BOOL;
 #else
 typedef signed char BOOL;

--- a/winpr/libwinpr/utils/debug.c
+++ b/winpr/libwinpr/utils/debug.c
@@ -45,7 +45,10 @@
 #include <winpr/wlog.h>
 #include <winpr/debug.h>
 
+#ifndef MIN
 #define MIN(a, b) (a) < (b) ? (a) : (b)
+#endif
+
 #define TAG "com.winpr.utils.debug"
 #define LOGT(...)                                           \
 	do                                                      \

--- a/winpr/libwinpr/utils/print.c
+++ b/winpr/libwinpr/utils/print.c
@@ -33,7 +33,9 @@
 
 #include "../log.h"
 
+#ifndef MIN
 #define MIN(a, b) (a) < (b) ? (a) : (b)
+#endif
 
 void winpr_HexDump(const char* tag, UINT32 level, const BYTE* data, size_t length)
 {


### PR DESCRIPTION
We do not know which architecture we are going to build on, so
skip this if not explicitly set externally