### PR TITLE
fixing android pointer not initialized when calling realloc

### DIFF
--- a/client/Android/android_freerdp.c
+++ b/client/Android/android_freerdp.c
@@ -292,6 +292,7 @@ static BOOL android_register_pointer(rdpGraphics* graphics)
 	if (!graphics)
 		return FALSE;
 
+	memset(&pointer, 0, sizeof(rdpPointer));
 	pointer.size = sizeof(pointer);
 	pointer.New = android_Pointer_New;
 	pointer.Free = android_Pointer_Free;


### PR DESCRIPTION
fixing bug where `update_pointer_new` calls `realloc` on uninitialized pointer