### PR TITLE
fixing android pointer not initialized when calling realloc

### DIFF
--- a/client/Android/android_freerdp.c
+++ b/client/Android/android_freerdp.c
@@ -287,7 +287,7 @@ static BOOL android_Pointer_SetDefault(rdpContext* context)
 
 static BOOL android_register_pointer(rdpGraphics* graphics)
 {
-	rdpPointer pointer;
+	rdpPointer pointer = { 0 };
 
 	if (!graphics)
 		return FALSE;


### PR DESCRIPTION
Replaces #7465 