### PR TITLE
Fixed #7454: When error_info is received abort

### DIFF
--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -360,6 +360,9 @@ BOOL rdp_set_error_info(rdpRdp* rdp, UINT32 errorInfo)
 		}
 		else
 			WLog_ERR(TAG, "%s missing context=%p", __FUNCTION__, context);
+
+		/* Ensure the connection is terminated */
+		freerdp_abort_connect(context->instance);
 	}
 	else
 	{


### PR DESCRIPTION
If an error_info with a failure is received, call
freerdp_abort_connect to terminate the connection.