### PR TITLE
Make H.264 codec optional during runtime

### DIFF
--- a/libfreerdp/core/codecs.c
+++ b/libfreerdp/core/codecs.c
@@ -142,10 +142,7 @@ BOOL freerdp_client_codecs_prepare(rdpCodecs* codecs, UINT32 flags, UINT32 width
 	{
 		if (!(codecs->h264 = h264_context_new(FALSE)))
 		{
-			WLog_ERR(TAG, "Failed to create h264 codec context");
-#ifndef WITH_OPENH264_LOADING
-			return FALSE;
-#endif
+			WLog_WARN(TAG, "Failed to create h264 codec context");
 		}
 	}
 #endif


### PR DESCRIPTION
It's possible that FreeRDP was built against FFmpeg, but it doesn't support
H.264. In that case, just continue without H.264 support instead of failing
hard before even trying to connect.

This is especially useful for Linux distributions which can't ship H.264
support in FFmpeg out of the box (patent issues), but allow enabling H.264
later by installing a version of FFmpeg which has it enabled.

Originally found by openQA: https://bugzilla.opensuse.org/show_bug.cgi?id=1190823

Before this patch, xfreerdp would fail with

```
[06:23:15:855] [2513:2525] [ERROR][com.freerdp.codec] - Failed to find libav H.264 codec
[06:23:15:857] [2513:2525] [ERROR][com.freerdp.core.codecs] - Failed to create h264 codec context
```

With this patch, it warns that H.264 is not available but continues anyway.
If H.264 support is enabled in FFmpeg, there is no warning and it can be used.

I'm not entirely sure what the downside of running without H.264 support is, but I couldn't
find any issues while playing around a bit. IMO it's in any case better than failing hard early.