### PR TITLE
Fixed freerdp_disconnect

### DIFF
--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -471,6 +471,7 @@ BOOL freerdp_disconnect(freerdp* instance)
 	if (!instance || !instance->context)
 		return FALSE;
 
+	freerdp_abort_connect(instance);
 	rdp = instance->context->rdp;
 
 	if (!rdp_client_disconnect(rdp))


### PR DESCRIPTION
Added a missing call to freerdp_abort_connect to ensure all
threads terminate in an orderly fashion