### PR TITLE
allow ffmpeg usage on Windows without pkgconfig

### DIFF
--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -8,14 +8,15 @@
 set(REQUIRED_AVCODEC_VERSION 0.8)
 set(REQUIRED_AVCODEC_API_VERSION 53.25.0)
 
-include(FindPkgConfig)
-
-if (PKG_CONFIG_FOUND)
-	pkg_check_modules(AVCODEC libavcodec)
-	pkg_check_modules(AVUTIL libavutil)
-	pkg_check_modules(AVRESAMPLE libavresample)
-	pkg_check_modules(SWRESAMPLE libswresample)
-endif(PKG_CONFIG_FOUND)
+if (UNIX AND NOT ANDROID)
+  find_package(PkgConfig QUIET)
+  if (PKG_CONFIG_FOUND)
+    pkg_check_modules(AVCODEC libavcodec)
+    pkg_check_modules(AVUTIL libavutil)
+    pkg_check_modules(AVRESAMPLE libavresample)
+    pkg_check_modules(SWRESAMPLE libswresample)
+  endif(PKG_CONFIG_FOUND)
+endif (UNIX AND NOT ANDROID)
 
 # avcodec
 find_path(AVCODEC_INCLUDE_DIR libavcodec/avcodec.h PATHS ${AVCODEC_INCLUDE_DIRS})

--- a/libfreerdp/codec/h264.c
+++ b/libfreerdp/codec/h264.c
@@ -614,6 +614,7 @@ static BOOL h264_context_init(H264_CONTEXT* h264)
 		if (subsystem->Init(h264))
 		{
 			h264->subsystem = subsystem;
+			WLog_Print(h264->log, WLOG_INFO, "using h264 subsystem [%s]", subsystem->name);
 			return TRUE;
 		}
 	}

--- a/libfreerdp/codec/h264_ffmpeg.c
+++ b/libfreerdp/codec/h264_ffmpeg.c
@@ -521,6 +521,7 @@ static BOOL libavcodec_init(H264_CONTEXT* h264)
 			goto EXCEPTION;
 		}
 
+		WLog_Print(h264->log, WLOG_INFO, "Using libav decoder [%s]", sys->codecDecoder->name);
 		sys->codecDecoderContext = avcodec_alloc_context3(sys->codecDecoder);
 
 		if (!sys->codecDecoderContext)


### PR DESCRIPTION
Allow compiling FreeRDP with Ffmpeg h264 subsystem without pkgconfig (like openh264)