### PR TITLE
Fix build with iOS audio redirection

### DIFF
--- a/channels/rdpsnd/client/ios/rdpsnd_ios.c
+++ b/channels/rdpsnd/client/ios/rdpsnd_ios.c
@@ -85,7 +85,7 @@ static OSStatus rdpsnd_ios_render_cb(void* inRefCon,
 	return noErr;
 }
 
-static BOOL rdpsnd_ios_format_supported(rdpsndDevicePlugin* __unused device, AUDIO_FORMAT* format)
+static BOOL rdpsnd_ios_format_supported(rdpsndDevicePlugin* __unused device, const AUDIO_FORMAT* format)
 {
 	if (format->wFormatTag == WAVE_FORMAT_PCM)
 	{
@@ -93,12 +93,6 @@ static BOOL rdpsnd_ios_format_supported(rdpsndDevicePlugin* __unused device, AUD
 	}
 
 	return 0;
-}
-
-static BOOL rdpsnd_ios_set_format(rdpsndDevicePlugin* __unused device,
-                                  AUDIO_FORMAT* __unused format, int __unused latency)
-{
-	return TRUE;
 }
 
 static BOOL rdpsnd_ios_set_volume(rdpsndDevicePlugin* __unused device, UINT32 __unused value)
@@ -140,7 +134,7 @@ static void rdpsnd_ios_stop(rdpsndDevicePlugin* __unused device)
 	}
 }
 
-static UINT rdpsnd_ios_play(rdpsndDevicePlugin* device, BYTE* data, int size)
+static UINT rdpsnd_ios_play(rdpsndDevicePlugin* device, const BYTE* data, size_t size)
 {
 	rdpsndIOSPlugin* p = THIS(device);
 	const BOOL ok = TPCircularBufferProduceBytes(&p->buffer, data, size);
@@ -152,7 +146,7 @@ static UINT rdpsnd_ios_play(rdpsndDevicePlugin* device, BYTE* data, int size)
 	return 10; /* TODO: Get real latencry in [ms] */
 }
 
-static BOOL rdpsnd_ios_open(rdpsndDevicePlugin* device, AUDIO_FORMAT* format, int __unused latency)
+static BOOL rdpsnd_ios_open(rdpsndDevicePlugin* device, const AUDIO_FORMAT* format, int __unused latency)
 {
 	rdpsndIOSPlugin* p = THIS(device);
 
@@ -285,7 +279,6 @@ UINT freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS p
 
 	p->device.Open = rdpsnd_ios_open;
 	p->device.FormatSupported = rdpsnd_ios_format_supported;
-	p->device.SetFormat = rdpsnd_ios_set_format;
 	p->device.SetVolume = rdpsnd_ios_set_volume;
 	p->device.Play = rdpsnd_ios_play;
 	p->device.Start = rdpsnd_ios_start;

--- a/docs/README.ios
+++ b/docs/README.ios
@@ -50,7 +50,7 @@ Building
 
 Run the following commands in the top level FreeRDP directory:
 
-cmake -DCMAKE_TOOLCHAIN_FILE=cmake/iOSToolchain.cmake -GXcode
+cmake -DCMAKE_TOOLCHAIN_FILE=cmake/ios.toolchain.cmake -GXcode
 
 This command will create a XCode project in the FreeRDP root folder called FreeRDP.xcodeproj.
 Open the project in XCode and modify, build or run the app. 
@@ -82,7 +82,7 @@ cmake variables
 ===============
 
 CMAKE_TOOLCHAIN_FILE
-* the toolchain file to use must be cmake/iOSToolchain.cmake
+* the toolchain file to use must be cmake/ios.toolchain.cmake
 
 IOS_PLATFORM (OS (default), SIMULATOR)
 * the platform for which to build iFreeRDP. OS compiles for iOS devices (using armv7 and armv7s ABIs) and SIMULATOR compiles for the iOS Simulator (i386)


### PR DESCRIPTION
Building with `-DWITH_IOSAUDIO="ON"` fails because:

> rdpsnd_ios.c:288:12: error: no member named 'SetFormat' in 'struct rdpsnd_device_plugin'
>        p->device.SetFormat = rdpsnd_ios_set_format;

Since `SetFormat` doesn't seem to be part of the rdpsnd subsystem device interface, this PR removes the function and fixes the build. It also corrects 3 warnings caused by incorrect method signatures.

Finally, "iOSToolchain.cmake" is corrected to "ios.toolchain.cmake" in the docs.