### PR TITLE
Reject invalid android build configuration

### DIFF
--- a/scripts/android-build-common.sh
+++ b/scripts/android-build-common.sh
@@ -83,7 +83,7 @@ function common_parse_arguments {
 		key="$1"
 		case $key in
 		    --conf)
-            source "$2"
+            source "$2" || exit 1
             shift
             ;;
 


### PR DESCRIPTION
Without this patch the default build configuration will be picked silently and continuous integration does not detect any problem in this case:

```
./scripts/android-build-freerdp.sh --config android-build-release.conf  # forgot to give the full path of the config file
```