### PR TITLE
Advanced input channel

### DIFF
--- a/channels/ainput/CMakeLists.txt
+++ b/channels/ainput/CMakeLists.txt
@@ -1,0 +1,27 @@
+# FreeRDP: A Remote Desktop Protocol Implementation
+# FreeRDP cmake build script
+#
+# Copyright 2022 Armin Novak <anovak@thincast.com>
+# Copyright 2022 Thincast Technologies GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+define_channel("ainput")
+
+if(WITH_CLIENT_CHANNELS)
+	add_channel_client(${MODULE_PREFIX} ${CHANNEL_NAME})
+endif()
+
+if(WITH_SERVER_CHANNELS)
+	add_channel_server(${MODULE_PREFIX} ${CHANNEL_NAME})
+endif()

--- a/channels/ainput/ChannelOptions.cmake
+++ b/channels/ainput/ChannelOptions.cmake
@@ -1,0 +1,13 @@
+
+set(OPTION_DEFAULT OFF)
+set(OPTION_CLIENT_DEFAULT ON)
+set(OPTION_SERVER_DEFAULT ON)
+
+define_channel_options(NAME "ainput" TYPE "dynamic"
+	DESCRIPTION "Advanced Input Virtual Channel Extension"
+	SPECIFICATIONS "[XXXXX]"
+	DEFAULT ${OPTION_DEFAULT})
+
+define_channel_client_options(${OPTION_CLIENT_DEFAULT})
+define_channel_server_options(${OPTION_SERVER_DEFAULT})
+

--- a/channels/ainput/client/CMakeLists.txt
+++ b/channels/ainput/client/CMakeLists.txt
@@ -1,0 +1,34 @@
+# FreeRDP: A Remote Desktop Protocol Implementation
+# FreeRDP cmake build script
+#
+# Copyright 2022 Armin Novak <anovak@thincast.com>
+# Copyright 2022 Thincast Technologies GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+define_channel_client("ainput")
+
+set(${MODULE_PREFIX}_SRCS
+	ainput_main.c
+	ainput_main.h)
+
+include_directories(..)
+
+add_channel_client_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} TRUE "DVCPluginEntry")
+
+if (WITH_DEBUG_SYMBOLS AND MSVC AND NOT BUILTIN_CHANNELS AND BUILD_SHARED_LIBS)
+	install(FILES ${PROJECT_BINARY_DIR}/${MODULE_NAME}.pdb DESTINATION ${FREERDP_ADDIN_PATH} COMPONENT symbols)
+endif()
+
+target_link_libraries(${MODULE_NAME} winpr)
+set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "Channels/${CHANNEL_NAME}/Client")

--- a/channels/ainput/client/ainput_main.c
+++ b/channels/ainput/client/ainput_main.c
@@ -1,0 +1,264 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Advanced Input Virtual Channel Extension
+ *
+ * Copyright 2022 Armin Novak <anovak@thincast.com>
+ * Copyright 2022 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <winpr/crt.h>
+#include <winpr/assert.h>
+#include <winpr/stream.h>
+
+#include "ainput_main.h"
+#include <freerdp/channels/log.h>
+#include <freerdp/client/ainput.h>
+#include <freerdp/channels/ainput.h>
+
+#define TAG CHANNELS_TAG("ainput.client")
+
+typedef struct AINPUT_CHANNEL_CALLBACK_ AINPUT_CHANNEL_CALLBACK;
+struct AINPUT_CHANNEL_CALLBACK_
+{
+	IWTSVirtualChannelCallback iface;
+
+	IWTSPlugin* plugin;
+	IWTSVirtualChannelManager* channel_mgr;
+	IWTSVirtualChannel* channel;
+};
+
+typedef struct AINPUT_LISTENER_CALLBACK_ AINPUT_LISTENER_CALLBACK;
+struct AINPUT_LISTENER_CALLBACK_
+{
+	IWTSListenerCallback iface;
+
+	IWTSPlugin* plugin;
+	IWTSVirtualChannelManager* channel_mgr;
+	AINPUT_CHANNEL_CALLBACK* channel_callback;
+};
+
+typedef struct AINPUT_PLUGIN_ AINPUT_PLUGIN;
+struct AINPUT_PLUGIN_
+{
+	IWTSPlugin iface;
+
+	AINPUT_LISTENER_CALLBACK* listener_callback;
+	IWTSListener* listener;
+	BOOL initialized;
+};
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT ainput_on_data_received(IWTSVirtualChannelCallback* pChannelCallback, wStream* data)
+{
+	WINPR_UNUSED(pChannelCallback);
+	WINPR_UNUSED(data);
+
+	return CHANNEL_RC_OK;
+}
+
+static UINT ainput_send_input_event(AInputClientContext* context, UINT64 flags, INT32 x, INT32 y)
+{
+	AINPUT_PLUGIN* ainput;
+	AINPUT_CHANNEL_CALLBACK* callback;
+	BYTE buffer[32] = { 0 };
+	wStream sbuffer = { 0 };
+	wStream* s = Stream_StaticInit(&sbuffer, buffer, sizeof(buffer));
+
+	WINPR_ASSERT(s);
+	WINPR_ASSERT(context);
+
+	ainput = (AINPUT_PLUGIN*)context->handle;
+	WINPR_ASSERT(ainput);
+	WINPR_ASSERT(ainput->listener_callback);
+
+	callback = ainput->listener_callback->channel_callback;
+	WINPR_ASSERT(callback);
+
+	/* Event version header */
+	Stream_Write_UINT16(s, 1);
+	Stream_Write_UINT16(s, 0);
+
+	/* Event data */
+	Stream_Write_UINT64(s, flags);
+	Stream_Write_INT32(s, x);
+	Stream_Write_INT32(s, y);
+	Stream_SealLength(s);
+
+	/* ainput back what we have received. AINPUT does not have any message IDs. */
+	WINPR_ASSERT(callback->channel);
+	WINPR_ASSERT(callback->channel->Write);
+	return callback->channel->Write(callback->channel, (ULONG)Stream_Length(s), Stream_Buffer(s),
+	                                NULL);
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT ainput_on_close(IWTSVirtualChannelCallback* pChannelCallback)
+{
+	AINPUT_CHANNEL_CALLBACK* callback = (AINPUT_CHANNEL_CALLBACK*)pChannelCallback;
+
+	free(callback);
+
+	return CHANNEL_RC_OK;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT ainput_on_new_channel_connection(IWTSListenerCallback* pListenerCallback,
+                                             IWTSVirtualChannel* pChannel, BYTE* Data,
+                                             BOOL* pbAccept,
+                                             IWTSVirtualChannelCallback** ppCallback)
+{
+	AINPUT_CHANNEL_CALLBACK* callback;
+	AINPUT_LISTENER_CALLBACK* listener_callback = (AINPUT_LISTENER_CALLBACK*)pListenerCallback;
+
+	WINPR_ASSERT(listener_callback);
+	WINPR_UNUSED(Data);
+	WINPR_UNUSED(pbAccept);
+
+	callback = (AINPUT_CHANNEL_CALLBACK*)calloc(1, sizeof(AINPUT_CHANNEL_CALLBACK));
+
+	if (!callback)
+	{
+		WLog_ERR(TAG, "calloc failed!");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	callback->iface.OnDataReceived = ainput_on_data_received;
+	callback->iface.OnClose = ainput_on_close;
+	callback->plugin = listener_callback->plugin;
+	callback->channel_mgr = listener_callback->channel_mgr;
+	callback->channel = pChannel;
+
+	*ppCallback = &callback->iface;
+
+	return CHANNEL_RC_OK;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT ainput_plugin_initialize(IWTSPlugin* pPlugin, IWTSVirtualChannelManager* pChannelMgr)
+{
+	UINT status;
+	AINPUT_PLUGIN* ainput = (AINPUT_PLUGIN*)pPlugin;
+
+	WINPR_ASSERT(ainput);
+
+	if (ainput->initialized)
+	{
+		WLog_ERR(TAG, "[%s] channel initialized twice, aborting", AINPUT_DVC_CHANNEL_NAME);
+		return ERROR_INVALID_DATA;
+	}
+	ainput->listener_callback =
+	    (AINPUT_LISTENER_CALLBACK*)calloc(1, sizeof(AINPUT_LISTENER_CALLBACK));
+
+	if (!ainput->listener_callback)
+	{
+		WLog_ERR(TAG, "calloc failed!");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	ainput->listener_callback->iface.OnNewChannelConnection = ainput_on_new_channel_connection;
+	ainput->listener_callback->plugin = pPlugin;
+	ainput->listener_callback->channel_mgr = pChannelMgr;
+
+	status = pChannelMgr->CreateListener(pChannelMgr, AINPUT_DVC_CHANNEL_NAME, 0,
+	                                     &ainput->listener_callback->iface, &ainput->listener);
+
+	ainput->initialized = status == CHANNEL_RC_OK;
+	return status;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT ainput_plugin_terminated(IWTSPlugin* pPlugin)
+{
+	AINPUT_PLUGIN* ainput = (AINPUT_PLUGIN*)pPlugin;
+	if (ainput && ainput->listener_callback)
+	{
+		IWTSVirtualChannelManager* mgr = ainput->listener_callback->channel_mgr;
+		if (mgr)
+			IFCALL(mgr->DestroyListener, mgr, ainput->listener);
+	}
+	free(ainput);
+
+	return CHANNEL_RC_OK;
+}
+
+#ifdef BUILTIN_CHANNELS
+#define DVCPluginEntry ainput_DVCPluginEntry
+#else
+#define DVCPluginEntry FREERDP_API DVCPluginEntry
+#endif
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+UINT DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
+{
+	UINT status = CHANNEL_RC_OK;
+	AINPUT_PLUGIN* ainput = (AINPUT_PLUGIN*)pEntryPoints->GetPlugin(pEntryPoints, "ainput");
+
+	if (!ainput)
+	{
+		AInputClientContext* context = (AInputClientContext*)calloc(1, sizeof(AInputClientContext));
+		ainput = (AINPUT_PLUGIN*)calloc(1, sizeof(AINPUT_PLUGIN));
+
+		if (!ainput || !context)
+		{
+			free(context);
+			free(ainput);
+
+			WLog_ERR(TAG, "calloc failed!");
+			return CHANNEL_RC_NO_MEMORY;
+		}
+
+		ainput->iface.Initialize = ainput_plugin_initialize;
+		ainput->iface.Terminated = ainput_plugin_terminated;
+
+		context->handle = (void*)ainput;
+		context->AInputSendInputEvent = ainput_send_input_event;
+		ainput->iface.pInterface = (void*)context;
+
+		status = pEntryPoints->RegisterPlugin(pEntryPoints, "ainput", &ainput->iface);
+	}
+
+	return status;
+}

--- a/channels/ainput/client/ainput_main.c
+++ b/channels/ainput/client/ainput_main.c
@@ -124,6 +124,7 @@ static UINT ainput_send_input_event(AInputClientContext* context, UINT64 flags, 
 	{
 		WLog_WARN(TAG, "Unsupported channel version %" PRIu32 ".%" PRIu32 ", aborting.",
 		          ainput->MajorVersion, ainput->MinorVersion);
+		return CHANNEL_RC_UNSUPPORTED_VERSION;
 	}
 	callback = ainput->listener_callback->channel_callback;
 	WINPR_ASSERT(callback);

--- a/channels/ainput/client/ainput_main.c
+++ b/channels/ainput/client/ainput_main.c
@@ -257,7 +257,7 @@ UINT DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 		context->AInputSendInputEvent = ainput_send_input_event;
 		ainput->iface.pInterface = (void*)context;
 
-		status = pEntryPoints->RegisterPlugin(pEntryPoints, "ainput", &ainput->iface);
+		status = pEntryPoints->RegisterPlugin(pEntryPoints, AINPUT_CHANNEL_NAME, &ainput->iface);
 	}
 
 	return status;

--- a/channels/ainput/client/ainput_main.c
+++ b/channels/ainput/client/ainput_main.c
@@ -76,7 +76,6 @@ struct AINPUT_PLUGIN_
 static UINT ainput_on_data_received(IWTSVirtualChannelCallback* pChannelCallback, wStream* data)
 {
 	UINT16 type;
-	UINT error;
 	AINPUT_PLUGIN* ainput;
 	AINPUT_CHANNEL_CALLBACK* callback = (AINPUT_CHANNEL_CALLBACK*)pChannelCallback;
 

--- a/channels/ainput/client/ainput_main.c
+++ b/channels/ainput/client/ainput_main.c
@@ -215,6 +215,11 @@ static UINT ainput_plugin_terminated(IWTSPlugin* pPlugin)
 		if (mgr)
 			IFCALL(mgr->DestroyListener, mgr, ainput->listener);
 	}
+	if (ainput)
+	{
+		free(ainput->listener_callback);
+		free(ainput->iface.pInterface);
+	}
 	free(ainput);
 
 	return CHANNEL_RC_OK;

--- a/channels/ainput/client/ainput_main.h
+++ b/channels/ainput/client/ainput_main.h
@@ -1,0 +1,43 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Advanced Input Virtual Channel Extension
+ *
+ * Copyright 2022 Armin Novak <anovak@thincast.com>
+ * Copyright 2022 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_AINPUT_CLIENT_MAIN_H
+#define FREERDP_CHANNEL_AINPUT_CLIENT_MAIN_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <freerdp/dvc.h>
+#include <freerdp/types.h>
+#include <freerdp/addin.h>
+#include <freerdp/channels/log.h>
+
+#define DVC_TAG CHANNELS_TAG("ainput.client")
+#ifdef WITH_DEBUG_DVC
+#define DEBUG_DVC(...) WLog_DBG(DVC_TAG, __VA_ARGS__)
+#else
+#define DEBUG_DVC(...) \
+	do                 \
+	{                  \
+	} while (0)
+#endif
+
+#endif /* FREERDP_CHANNEL_AINPUT_CLIENT_MAIN_H */

--- a/channels/ainput/server/CMakeLists.txt
+++ b/channels/ainput/server/CMakeLists.txt
@@ -1,0 +1,27 @@
+# FreeRDP: A Remote Desktop Protocol Implementation
+# FreeRDP cmake build script
+#
+# Copyright 2022 Armin Novak <anovak@thincast.com>
+# Copyright 2022 Thincast Technologies GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+define_channel_server("ainput")
+
+set(${MODULE_PREFIX}_SRCS
+	ainput_main.c)
+
+add_channel_server_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} FALSE "DVCPluginEntry")
+
+target_link_libraries(${MODULE_NAME} freerdp)
+set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "Channels/${CHANNEL_NAME}/Server")

--- a/channels/audin/client/winmm/audin_winmm.c
+++ b/channels/audin/client/winmm/audin_winmm.c
@@ -452,11 +452,11 @@ static UINT audin_winmm_open(IAudinDevice* device, AudinReceive receive, void* u
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT audin_winmm_parse_addin_args(AudinWinmmDevice* device, ADDIN_ARGV* args)
+static UINT audin_winmm_parse_addin_args(AudinWinmmDevice* device, const ADDIN_ARGV* args)
 {
 	int status;
 	DWORD flags;
-	COMMAND_LINE_ARGUMENT_A* arg;
+	const COMMAND_LINE_ARGUMENT_A* arg;
 	AudinWinmmDevice* winmm = (AudinWinmmDevice*)device;
 	COMMAND_LINE_ARGUMENT_A audin_winmm_args[] = { { "dev", COMMAND_LINE_VALUE_REQUIRED, "<device>",
 		                                             NULL, NULL, -1, NULL, "audio device name" },
@@ -502,7 +502,7 @@ static UINT audin_winmm_parse_addin_args(AudinWinmmDevice* device, ADDIN_ARGV* a
  */
 UINT freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints)
 {
-	ADDIN_ARGV* args;
+	const ADDIN_ARGV* args;
 	AudinWinmmDevice* winmm;
 	UINT error;
 

--- a/channels/printer/client/win/printer_win.c
+++ b/channels/printer/client/win/printer_win.c
@@ -36,6 +36,9 @@
 
 #include <freerdp/client/printer.h>
 
+#define WIDEN_INT(x) L##x
+#define WIDEN(x) WIDEN_INT(x)
+
 #define PRINTER_TAG CHANNELS_TAG("printer.client")
 #ifdef WITH_DEBUG_WINPR
 #define DEBUG_WINPR(...) WLog_DBG(PRINTER_TAG, __VA_ARGS__)
@@ -91,9 +94,9 @@ static WCHAR* printer_win_get_printjob_name(size_t id)
 	if (!str)
 		return NULL;
 
-	rc = swprintf_s(str, len, L"FreeRDP Print %04d-%02d-%02d% 02d-%02d-%02d - Job %" PRIuz "\0",
-	                t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec,
-	                id);
+	rc = swprintf_s(
+	    str, len, WIDEN("FreeRDP Print %04d-%02d-%02d% 02d-%02d-%02d - Job %" PRIuz L"\0"),
+	    t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec, id);
 
 	return str;
 }

--- a/channels/printer/client/win/printer_win.c
+++ b/channels/printer/client/win/printer_win.c
@@ -95,7 +95,8 @@ static WCHAR* printer_win_get_printjob_name(size_t id)
 		return NULL;
 
 	rc = swprintf_s(
-	    str, len, WIDEN("FreeRDP Print %04d-%02d-%02d% 02d-%02d-%02d - Job %" PRIuz L"\0"),
+	    str, len,
+	    WIDEN("FreeRDP Print %04d-%02d-%02d% 02d-%02d-%02d - Job %") WIDEN(PRIuz) WIDEN("\0"),
 	    t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec, id);
 
 	return str;

--- a/channels/printer/client/win/printer_win.c
+++ b/channels/printer/client/win/printer_win.c
@@ -91,7 +91,7 @@ static WCHAR* printer_win_get_printjob_name(size_t id)
 	if (!str)
 		return NULL;
 
-	rc = swprintf_s(str, len, L"FreeRDP Print %04d-%02d-%02d% 02d-%02d-%02d - Job %lu\0",
+	rc = swprintf_s(str, len, L"FreeRDP Print %04d-%02d-%02d% 02d-%02d-%02d - Job %" PRIuz "\0",
 	                t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec,
 	                id);
 

--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -1740,7 +1740,4 @@ UINT rdpsnd_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 	}
 
 	return error;
-fail:
-	rdpsnd_plugin_terminated(&rdpsnd->iface);
-	return error;
 }

--- a/channels/server/channels.c
+++ b/channels/server/channels.c
@@ -54,6 +54,10 @@
 #include <freerdp/server/disp.h>
 #include <freerdp/server/gfxredir.h>
 
+#if defined(CHANNEL_AINPUT_SERVER)
+#include <freerdp/server/ainput.h>
+#endif
+
 extern void freerdp_channels_dummy(void);
 
 void freerdp_channels_dummy(void)
@@ -101,6 +105,12 @@ void freerdp_channels_dummy(void)
 	gfxredir = gfxredir_server_context_new(NULL);
 	gfxredir_server_context_free(gfxredir);
 #endif // WITH_CHANNEL_GFXREDIR
+#if defined(CHANNEL_AINPUT_SERVER)
+	{
+		ainput_server_context* ainput = ainput_server_context_new(NULL);
+		ainput_server_context_free(ainput);
+	}
+#endif
 }
 
 /**

--- a/client/Android/android_freerdp.c
+++ b/client/Android/android_freerdp.c
@@ -57,7 +57,8 @@
 /* Defines the JNI version supported by this library. */
 #define FREERDP_JNI_VERSION "3.0.0-dev"
 
-static void android_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs* e)
+static void android_OnChannelConnectedEventHandler(void* context,
+                                                   const ChannelConnectedEventArgs* e)
 {
 	rdpSettings* settings;
 	androidContext* afc;
@@ -69,28 +70,18 @@ static void android_OnChannelConnectedEventHandler(void* context, ChannelConnect
 	}
 
 	afc = (androidContext*)context;
-	settings = afc->rdpCtx.settings;
+	settings = afc->common.context.settings;
 
-	if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		if (settings->SoftwareGdi)
-		{
-			gdi_graphics_pipeline_init(afc->rdpCtx.gdi, (RdpgfxClientContext*)e->pInterface);
-		}
-		else
-		{
-			WLog_WARN(TAG, "GFX without software GDI requested. "
-			               " This is not supported, add /gdi:sw");
-		}
-	}
-	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
+	if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
 	{
 		android_cliprdr_init(afc, (CliprdrClientContext*)e->pInterface);
 	}
+	else
+		freerdp_client_OnChannelConnectedEventHandler(context, e);
 }
 
 static void android_OnChannelDisconnectedEventHandler(void* context,
-                                                      ChannelDisconnectedEventArgs* e)
+                                                      const ChannelDisconnectedEventArgs* e)
 {
 	rdpSettings* settings;
 	androidContext* afc;
@@ -102,24 +93,14 @@ static void android_OnChannelDisconnectedEventHandler(void* context,
 	}
 
 	afc = (androidContext*)context;
-	settings = afc->rdpCtx.settings;
+	settings = afc->common.context.settings;
 
-	if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		if (settings->SoftwareGdi)
-		{
-			gdi_graphics_pipeline_uninit(afc->rdpCtx.gdi, (RdpgfxClientContext*)e->pInterface);
-		}
-		else
-		{
-			WLog_WARN(TAG, "GFX without software GDI requested. "
-			               " This is not supported, add /gdi:sw");
-		}
-	}
-	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
+	if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
 	{
 		android_cliprdr_uninit(afc, (CliprdrClientContext*)e->pInterface);
 	}
+	else
+		freerdp_client_OnChannelDisconnectedEventHandler(context, e);
 }
 
 static BOOL android_begin_paint(rdpContext* context)
@@ -151,7 +132,7 @@ static BOOL android_end_paint(rdpContext* context)
 	if (!gdi || !gdi->primary || !gdi->primary->hdc)
 		return FALSE;
 
-	hwnd = ctx->rdpCtx.gdi->primary->hdc->hwnd;
+	hwnd = ctx->common.context.gdi->primary->hdc->hwnd;
 
 	if (!hwnd)
 		return FALSE;

--- a/client/Android/android_freerdp.h
+++ b/client/Android/android_freerdp.h
@@ -23,7 +23,7 @@
 
 struct android_context
 {
-	rdpContext rdpCtx;
+	rdpClientContext common;
 
 	ANDROID_EVENT_QUEUE* event_queue;
 	HANDLE thread;

--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -813,48 +813,37 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 	mfc->client_width = width;
 }
 
-void mac_OnChannelConnectedEventHandler(void *context, ChannelConnectedEventArgs *e)
+static void mac_OnChannelConnectedEventHandler(void *context, const ChannelConnectedEventArgs *e)
 {
 	mfContext *mfc = (mfContext *)context;
 	rdpSettings *settings = mfc->context.settings;
 
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
-	{
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		if (settings->SoftwareGdi)
-			gdi_graphics_pipeline_init(mfc->context.gdi, (RdpgfxClientContext *)e->pInterface);
-	}
-	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
+	if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
 	{
 		mac_cliprdr_init(mfc, (CliprdrClientContext *)e->pInterface);
 	}
 	else if (strcmp(e->name, ENCOMSP_SVC_CHANNEL_NAME) == 0)
 	{
 	}
+	else
+		freerdp_client_OnChannelConnectedEventHandler(context, e);
 }
 
-void mac_OnChannelDisconnectedEventHandler(void *context, ChannelDisconnectedEventArgs *e)
+static void mac_OnChannelDisconnectedEventHandler(void *context,
+                                                  const ChannelDisconnectedEventArgs *e)
 {
 	mfContext *mfc = (mfContext *)context;
 	rdpSettings *settings = mfc->context.settings;
 
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
-	{
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		if (settings->SoftwareGdi)
-			gdi_graphics_pipeline_uninit(mfc->context.gdi, (RdpgfxClientContext *)e->pInterface);
-	}
-	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
+	if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
 	{
 		mac_cliprdr_uninit(mfc, (CliprdrClientContext *)e->pInterface);
 	}
 	else if (strcmp(e->name, ENCOMSP_SVC_CHANNEL_NAME) == 0)
 	{
 	}
+	else
+		freerdp_client_OnChannelDisconnectedEventHandler(context, e);
 }
 
 BOOL mac_pre_connect(freerdp *instance)

--- a/client/Mac/cli/AppDelegate.m
+++ b/client/Mac/cli/AppDelegate.m
@@ -13,10 +13,10 @@
 #import <freerdp/client/cmdline.h>
 
 static AppDelegate *_singleDelegate = nil;
-void AppDelegate_ConnectionResultEventHandler(void *context, ConnectionResultEventArgs *e);
-void AppDelegate_ErrorInfoEventHandler(void *ctx, ErrorInfoEventArgs *e);
-void AppDelegate_EmbedWindowEventHandler(void *context, EmbedWindowEventArgs *e);
-void AppDelegate_ResizeWindowEventHandler(void *context, ResizeWindowEventArgs *e);
+void AppDelegate_ConnectionResultEventHandler(void *context, const ConnectionResultEventArgs *e);
+void AppDelegate_ErrorInfoEventHandler(void *ctx, const ErrorInfoEventArgs *e);
+void AppDelegate_EmbedWindowEventHandler(void *context, const EmbedWindowEventArgs *e);
+void AppDelegate_ResizeWindowEventHandler(void *context, const ResizeWindowEventArgs *e);
 void mac_set_view_size(rdpContext *context, MRDPView *view);
 
 @implementation AppDelegate
@@ -58,17 +58,19 @@ void mac_set_view_size(rdpContext *context, MRDPView *view);
 		freerdp_client_start(context);
 		NSString *winTitle;
 
-		if (mfc->context.settings->WindowTitle && mfc->context.settings->WindowTitle[0])
+		if (mfc->common.context.settings->WindowTitle &&
+		    mfc->common.context.settings->WindowTitle[0])
 		{
-			winTitle = [[NSString alloc] initWithCString:mfc->context.settings->WindowTitle];
+			winTitle = [[NSString alloc] initWithCString:mfc->common.context.settings->WindowTitle];
 		}
 		else
 		{
 			winTitle = [[NSString alloc]
 			    initWithFormat:@"%@:%u",
-			                   [NSString stringWithCString:mfc->context.settings->ServerHostname
-			                                      encoding:NSUTF8StringEncoding],
-			                   mfc -> context.settings->ServerPort];
+			                   [NSString
+			                       stringWithCString:mfc->common.context.settings->ServerHostname
+			                                encoding:NSUTF8StringEncoding],
+			                   mfc -> common.context.settings->ServerPort];
 		}
 
 		[window setTitle:winTitle];
@@ -197,7 +199,7 @@ void mac_set_view_size(rdpContext *context, MRDPView *view);
  * On connection error, display message and quit application
  ***********************************************************************/
 
-void AppDelegate_ConnectionResultEventHandler(void *ctx, ConnectionResultEventArgs *e)
+void AppDelegate_ConnectionResultEventHandler(void *ctx, const ConnectionResultEventArgs *e)
 {
 	rdpContext *context = (rdpContext *)ctx;
 	NSLog(@"ConnectionResult event result:%d\n", e->result);
@@ -226,7 +228,7 @@ void AppDelegate_ConnectionResultEventHandler(void *ctx, ConnectionResultEventAr
 	}
 }
 
-void AppDelegate_ErrorInfoEventHandler(void *ctx, ErrorInfoEventArgs *e)
+void AppDelegate_ErrorInfoEventHandler(void *ctx, const ErrorInfoEventArgs *e)
 {
 	NSLog(@"ErrorInfo event code:%d\n", e->code);
 
@@ -249,7 +251,7 @@ void AppDelegate_ErrorInfoEventHandler(void *ctx, ErrorInfoEventArgs *e)
 	}
 }
 
-void AppDelegate_EmbedWindowEventHandler(void *ctx, EmbedWindowEventArgs *e)
+void AppDelegate_EmbedWindowEventHandler(void *ctx, const EmbedWindowEventArgs *e)
 {
 	rdpContext *context = (rdpContext *)ctx;
 
@@ -269,7 +271,7 @@ void AppDelegate_EmbedWindowEventHandler(void *ctx, EmbedWindowEventArgs *e)
 	}
 }
 
-void AppDelegate_ResizeWindowEventHandler(void *ctx, ResizeWindowEventArgs *e)
+void AppDelegate_ResizeWindowEventHandler(void *ctx, const ResizeWindowEventArgs *e)
 {
 	rdpContext *context = (rdpContext *)ctx;
 	fprintf(stderr, "ResizeWindowEventHandler: %d %d\n", e->width, e->height);

--- a/client/Mac/mf_client.h
+++ b/client/Mac/mf_client.h
@@ -29,12 +29,9 @@ extern "C"
 {
 #endif
 
-	FREERDP_API void mf_press_mouse_button(void* context, rdpInput* intput, int button, int x,
-	                                       int y, BOOL down);
-	FREERDP_API void mf_scale_mouse_event(void* context, rdpInput* input, UINT16 flags, UINT16 x,
-	                                      UINT16 y);
-	FREERDP_API void mf_scale_mouse_event_ex(void* context, rdpInput* input, UINT16 flags, UINT16 x,
-	                                         UINT16 y);
+	FREERDP_API void mf_press_mouse_button(void* context, int button, int x, int y, BOOL down);
+	FREERDP_API void mf_scale_mouse_event(void* context, UINT16 flags, UINT16 x, UINT16 y);
+	FREERDP_API void mf_scale_mouse_event_ex(void* context, UINT16 flags, UINT16 x, UINT16 y);
 
 	/**
 	 * Client Interface

--- a/client/Mac/mf_client.m
+++ b/client/Mac/mf_client.m
@@ -140,7 +140,7 @@ static void mf_scale_mouse_coordinates(mfContext *mfc, UINT16 *px, UINT16 *py)
 	*py = y;
 }
 
-void mf_scale_mouse_event(void *context, rdpInput *input, UINT16 flags, UINT16 x, UINT16 y)
+void mf_scale_mouse_event(void *context, UINT16 flags, UINT16 x, UINT16 y)
 {
 	mfContext *mfc = (mfContext *)context;
 	MRDPView *view = (MRDPView *)mfc->view;
@@ -149,10 +149,10 @@ void mf_scale_mouse_event(void *context, rdpInput *input, UINT16 flags, UINT16 x
 
 	if ((flags & (PTR_FLAGS_WHEEL | PTR_FLAGS_HWHEEL)) == 0)
 		mf_scale_mouse_coordinates(mfc, &x, &y);
-	freerdp_input_send_mouse_event(input, flags, x, y);
+	freerdp_client_send_button_event(&mfc->common, flags, x, y);
 }
 
-void mf_scale_mouse_event_ex(void *context, rdpInput *input, UINT16 flags, UINT16 x, UINT16 y)
+void mf_scale_mouse_event_ex(void *context, UINT16 flags, UINT16 x, UINT16 y)
 {
 	mfContext *mfc = (mfContext *)context;
 	MRDPView *view = (MRDPView *)mfc->view;
@@ -160,7 +160,7 @@ void mf_scale_mouse_event_ex(void *context, rdpInput *input, UINT16 flags, UINT1
 	y = [view frame].size.height - y;
 
 	mf_scale_mouse_coordinates(mfc, &x, &y);
-	freerdp_input_send_extended_mouse_event(input, flags, x, y);
+	freerdp_client_send_extended_button_event(&mfc->common, flags, x, y);
 }
 
 void mf_press_mouse_button(void *context, rdpInput *input, int button, int x, int y, BOOL down)

--- a/client/Mac/mf_client.m
+++ b/client/Mac/mf_client.m
@@ -150,7 +150,7 @@ void mf_scale_mouse_event(void *context, UINT16 flags, UINT16 x, UINT16 y)
 
 	if ((flags & (PTR_FLAGS_WHEEL | PTR_FLAGS_HWHEEL)) == 0)
 		mf_scale_mouse_coordinates(mfc, &x, &y);
-	freerdp_client_send_button_event(&mfc->common, flags, x, y);
+	freerdp_client_send_button_event(&mfc->common, FALSE, flags, x, y);
 }
 
 void mf_scale_mouse_event_ex(void *context, UINT16 flags, UINT16 x, UINT16 y)
@@ -161,7 +161,7 @@ void mf_scale_mouse_event_ex(void *context, UINT16 flags, UINT16 x, UINT16 y)
 	y = [view frame].size.height - y;
 
 	mf_scale_mouse_coordinates(mfc, &x, &y);
-	freerdp_client_send_extended_button_event(&mfc->common, flags, x, y);
+	freerdp_client_send_extended_button_event(&mfc->common, FALSE, flags, x, y);
 }
 
 void mf_press_mouse_button(void *context, int button, int x, int y, BOOL down)

--- a/client/Mac/mfreerdp.h
+++ b/client/Mac/mfreerdp.h
@@ -32,8 +32,7 @@ typedef struct mf_context mfContext;
 
 struct mf_context
 {
-	rdpContext context;
-	DEFINE_RDP_CLIENT_COMMON();
+	rdpClientContext common;
 
 	void* view;
 	BOOL view_ownership;

--- a/client/Sample/tf_channels.c
+++ b/client/Sample/tf_channels.c
@@ -73,22 +73,14 @@ static UINT tf_update_surfaces(RdpgfxClientContext* context)
 	return CHANNEL_RC_OK;
 }
 
-void tf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs* e)
+void tf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEventArgs* e)
 {
 	tfContext* tf = (tfContext*)context;
 
 	WINPR_ASSERT(tf);
 	WINPR_ASSERT(e);
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
-	{
-		tf->rdpei = (RdpeiClientContext*)e->pInterface;
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		RdpgfxClientContext* gfx = (RdpgfxClientContext*)e->pInterface;
-		gdi_graphics_pipeline_init(tf->context.gdi, gfx);
-	}
-	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
+
+	if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
 	}
 	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
@@ -101,23 +93,18 @@ void tf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs*
 	{
 		tf_encomsp_init(tf, (EncomspClientContext*)e->pInterface);
 	}
+	else
+		freerdp_client_OnChannelConnectedEventHandler(context, e);
 }
 
-void tf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEventArgs* e)
+void tf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnectedEventArgs* e)
 {
 	tfContext* tf = (tfContext*)context;
 
 	WINPR_ASSERT(tf);
 	WINPR_ASSERT(e);
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
-	{
-		tf->rdpei = NULL;
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_graphics_pipeline_uninit(tf->context.gdi, (RdpgfxClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
+
+	if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
 	}
 	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
@@ -130,4 +117,6 @@ void tf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEven
 	{
 		tf_encomsp_uninit(tf, (EncomspClientContext*)e->pInterface);
 	}
+	else
+		freerdp_client_OnChannelDisconnectedEventHandler(context, e);
 }

--- a/client/Sample/tf_channels.h
+++ b/client/Sample/tf_channels.h
@@ -27,7 +27,7 @@
 int tf_on_channel_connected(freerdp* instance, const char* name, void* pInterface);
 int tf_on_channel_disconnected(freerdp* instance, const char* name, void* pInterface);
 
-void tf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs* e);
-void tf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEventArgs* e);
+void tf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEventArgs* e);
+void tf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnectedEventArgs* e);
 
 #endif /* FREERDP_CLIENT_SAMPLE_CHANNELS_H */

--- a/client/Sample/tf_freerdp.h
+++ b/client/Sample/tf_freerdp.h
@@ -33,8 +33,6 @@ struct tf_context
 	rdpContext context;
 
 	/* Channels */
-	RdpeiClientContext* rdpei;
-	RdpgfxClientContext* gfx;
 	EncomspClientContext* encomsp;
 };
 typedef struct tf_context tfContext;

--- a/client/Wayland/wlf_channels.c
+++ b/client/Wayland/wlf_channels.c
@@ -25,6 +25,10 @@
 
 #include <freerdp/gdi/video.h>
 
+#if defined(CHANNEL_AINPUT_CLIENT)
+#include <freerdp/channels/ainput.h>
+#endif
+
 #include "wlf_channels.h"
 #include "wlf_cliprdr.h"
 #include "wlf_disp.h"
@@ -103,6 +107,14 @@ void wlf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs
 {
 	wlfContext* wlf = (wlfContext*)context;
 
+	WINPR_ASSERT(wlf);
+	WINPR_ASSERT(e);
+
+#if defined(CHANNEL_AINPUT_CLIENT)
+	if (strcmp(e->name, AINPUT_DVC_CHANNEL_NAME) == 0)
+		wlf->ainput = (AInputClientContext*)e->pInterface;
+#endif
+
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
 		wlf->rdpei = (RdpeiClientContext*)e->pInterface;
@@ -143,6 +155,14 @@ void wlf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs
 void wlf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEventArgs* e)
 {
 	wlfContext* wlf = (wlfContext*)context;
+
+	WINPR_ASSERT(wlf);
+	WINPR_ASSERT(e);
+
+#if defined(CHANNEL_AINPUT_CLIENT)
+	if (strcmp(e->name, AINPUT_DVC_CHANNEL_NAME) == 0)
+		wlf->ainput = NULL;
+#endif
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{

--- a/client/Wayland/wlf_channels.c
+++ b/client/Wayland/wlf_channels.c
@@ -21,14 +21,6 @@
 #include "config.h"
 #endif
 
-#include <freerdp/gdi/gfx.h>
-
-#include <freerdp/gdi/video.h>
-
-#if defined(CHANNEL_AINPUT_CLIENT)
-#include <freerdp/channels/ainput.h>
-#endif
-
 #include "wlf_channels.h"
 #include "wlf_cliprdr.h"
 #include "wlf_disp.h"
@@ -68,7 +60,7 @@ wlf_encomsp_participant_created(EncomspClientContext* context,
 		return ERROR_INVALID_PARAMETER;
 
 	wlf = (wlfContext*)context->custom;
-	settings = wlf->context.settings;
+	settings = wlf->common.context.settings;
 
 	if (!settings)
 		return ERROR_INVALID_PARAMETER;
@@ -103,27 +95,14 @@ static void wlf_encomsp_uninit(wlfContext* wlf, EncomspClientContext* encomsp)
 		wlf->encomsp = NULL;
 }
 
-void wlf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs* e)
+void wlf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEventArgs* e)
 {
 	wlfContext* wlf = (wlfContext*)context;
 
 	WINPR_ASSERT(wlf);
 	WINPR_ASSERT(e);
 
-#if defined(CHANNEL_AINPUT_CLIENT)
-	if (strcmp(e->name, AINPUT_DVC_CHANNEL_NAME) == 0)
-		wlf->ainput = (AInputClientContext*)e->pInterface;
-#endif
-
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
-	{
-		wlf->rdpei = (RdpeiClientContext*)e->pInterface;
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_graphics_pipeline_init(wlf->context.gdi, (RdpgfxClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
+	if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
 	}
 	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
@@ -138,41 +117,18 @@ void wlf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs
 	{
 		wlf_disp_init(wlf->disp, (DispClientContext*)e->pInterface);
 	}
-	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_geometry_init(wlf->context.gdi, (GeometryClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_control_init(wlf->context.gdi, (VideoClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_data_init(wlf->context.gdi, (VideoClientContext*)e->pInterface);
-	}
+	else
+		freerdp_client_OnChannelConnectedEventHandler(context, e);
 }
 
-void wlf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEventArgs* e)
+void wlf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnectedEventArgs* e)
 {
 	wlfContext* wlf = (wlfContext*)context;
 
 	WINPR_ASSERT(wlf);
 	WINPR_ASSERT(e);
 
-#if defined(CHANNEL_AINPUT_CLIENT)
-	if (strcmp(e->name, AINPUT_DVC_CHANNEL_NAME) == 0)
-		wlf->ainput = NULL;
-#endif
-
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
-	{
-		wlf->rdpei = NULL;
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_graphics_pipeline_uninit(wlf->context.gdi, (RdpgfxClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
+	if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
 	}
 	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
@@ -187,16 +143,6 @@ void wlf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEve
 	{
 		wlf_disp_uninit(wlf->disp, (DispClientContext*)e->pInterface);
 	}
-	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_geometry_uninit(wlf->context.gdi, (GeometryClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_control_uninit(wlf->context.gdi, (VideoClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_data_uninit(wlf->context.gdi, (VideoClientContext*)e->pInterface);
-	}
+	else
+		freerdp_client_OnChannelDisconnectedEventHandler(context, e);
 }

--- a/client/Wayland/wlf_channels.h
+++ b/client/Wayland/wlf_channels.h
@@ -31,7 +31,7 @@
 int wlf_on_channel_connected(freerdp* instance, const char* name, void* pInterface);
 int wlf_on_channel_disconnected(freerdp* instance, const char* name, void* pInterface);
 
-void wlf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs* e);
-void wlf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEventArgs* e);
+void wlf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEventArgs* e);
+void wlf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnectedEventArgs* e);
 
 #endif /* FREERDP_CLIENT_WAYLAND_CHANNELS_H */

--- a/client/Wayland/wlf_cliprdr.c
+++ b/client/Wayland/wlf_cliprdr.c
@@ -896,7 +896,7 @@ wfClipboard* wlf_clipboard_new(wlfContext* wfc)
 
 	InitializeCriticalSection(&clipboard->lock);
 	clipboard->wfc = wfc;
-	channels = wfc->context.channels;
+	channels = wfc->common.context.channels;
 	clipboard->log = WLog_Get(TAG);
 	clipboard->channels = channels;
 	clipboard->system = ClipboardCreate();

--- a/client/Wayland/wlf_disp.c
+++ b/client/Wayland/wlf_disp.c
@@ -20,6 +20,8 @@
 
 #include <winpr/sysinfo.h>
 
+#include <winpr/collections.h>
+
 #include "wlf_disp.h"
 
 #define TAG CLIENT_TAG("wayland.disp")
@@ -250,9 +252,10 @@ void wlf_disp_free(wlfDispContext* disp)
 
 	if (disp->wlc)
 	{
-		PubSub_UnsubscribeActivated(disp->wlc->common.context.pubSub, wlf_disp_OnActivated);
-		PubSub_UnsubscribeGraphicsReset(disp->wlc->common.context.pubSub, wlf_disp_OnGraphicsReset);
-		PubSub_UnsubscribeTimer(disp->wlc->common.context.pubSub, wlf_disp_OnTimer);
+		wPubSub* pubSub = disp->wlc->common.context.pubSub;
+		PubSub_UnsubscribeActivated(pubSub, wlf_disp_OnActivated);
+		PubSub_UnsubscribeGraphicsReset(pubSub, wlf_disp_OnGraphicsReset);
+		PubSub_UnsubscribeTimer(pubSub, wlf_disp_OnTimer);
 	}
 
 	free(disp);

--- a/client/Wayland/wlf_input.c
+++ b/client/Wayland/wlf_input.c
@@ -73,7 +73,7 @@ BOOL wlf_handle_pointer_enter(freerdp* instance, const UwacPointerEnterLeaveEven
 	WINPR_ASSERT(x <= UINT16_MAX);
 	WINPR_ASSERT(y <= UINT16_MAX);
 	cctx = (rdpClientContext*)instance->context;
-	return freerdp_client_send_button_event(cctx, PTR_FLAGS_MOVE, (UINT16)x, (UINT16)y);
+	return freerdp_client_send_button_event(cctx, FALSE, PTR_FLAGS_MOVE, x, y);
 }
 
 BOOL wlf_handle_pointer_motion(freerdp* instance, const UwacPointerMotionEvent* ev)
@@ -95,7 +95,7 @@ BOOL wlf_handle_pointer_motion(freerdp* instance, const UwacPointerMotionEvent* 
 
 	WINPR_ASSERT(x <= UINT16_MAX);
 	WINPR_ASSERT(y <= UINT16_MAX);
-	return freerdp_client_send_button_event(cctx, PTR_FLAGS_MOVE, (UINT16)x, (UINT16)y);
+	return freerdp_client_send_button_event(cctx, FALSE, PTR_FLAGS_MOVE, x, y);
 }
 
 BOOL wlf_handle_pointer_buttons(freerdp* instance, const UwacPointerButtonEvent* ev)
@@ -153,10 +153,10 @@ BOOL wlf_handle_pointer_buttons(freerdp* instance, const UwacPointerButtonEvent*
 	WINPR_ASSERT(y <= UINT16_MAX);
 
 	if ((flags & ~PTR_FLAGS_DOWN) != 0)
-		return freerdp_client_send_button_event(cctx, flags, (UINT16)x, (UINT16)y);
+		return freerdp_client_send_button_event(cctx, FALSE, flags, x, y);
 
 	if ((xflags & ~PTR_XFLAGS_DOWN) != 0)
-		return freerdp_client_send_extended_button_event(cctx, xflags, (UINT16)x, (UINT16)y);
+		return freerdp_client_send_extended_button_event(cctx, FALSE, xflags, x, y);
 
 	return FALSE;
 }
@@ -426,7 +426,7 @@ BOOL wlf_handle_touch_up(freerdp* instance, const UwacTouchUp* ev)
 
 		WINPR_ASSERT(x <= UINT16_MAX);
 		WINPR_ASSERT(y <= UINT16_MAX);
-		return freerdp_client_send_button_event(&wlf->common, flags, (UINT16)x, (UINT16)y);
+		return freerdp_client_send_button_event(&wlf->common, FALSE, flags, x, y);
 	}
 
 	if (!rdpei)
@@ -487,7 +487,7 @@ BOOL wlf_handle_touch_down(freerdp* instance, const UwacTouchDown* ev)
 
 		WINPR_ASSERT(x <= UINT16_MAX);
 		WINPR_ASSERT(y <= UINT16_MAX);
-		return freerdp_client_send_button_event(&wlf->common, flags, (UINT16)x, (UINT16)y);
+		return freerdp_client_send_button_event(&wlf->common, FALSE, flags, x, y);
 	}
 
 	WINPR_ASSERT(rdpei);
@@ -545,7 +545,7 @@ BOOL wlf_handle_touch_motion(freerdp* instance, const UwacTouchMotion* ev)
 
 		WINPR_ASSERT(x <= UINT16_MAX);
 		WINPR_ASSERT(y <= UINT16_MAX);
-		return freerdp_client_send_button_event(&wlf->common, flags, (UINT16)x, (UINT16)y);
+		return freerdp_client_send_button_event(&wlf->common, FALSE, flags, x, y);
 	}
 
 	if (!rdpei)

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -94,7 +94,7 @@ static BOOL wl_update_buffer(wlfContext* context_w, INT32 ix, INT32 iy, INT32 iw
 	if (!data || (rc != UWAC_SUCCESS))
 		goto fail;
 
-	gdi = context_w->context.gdi;
+	gdi = context_w->common.context.gdi;
 
 	if (!gdi)
 		goto fail;
@@ -113,13 +113,13 @@ static BOOL wl_update_buffer(wlfContext* context_w, INT32 ix, INT32 iy, INT32 iw
 
 	if (!wlf_copy_image(gdi->primary_buffer, gdi->stride, gdi->width, gdi->height, data, stride,
 	                    geometry.width, geometry.height, &area,
-	                    context_w->context.settings->SmartSizing))
+	                    context_w->common.context.settings->SmartSizing))
 		goto fail;
 
-	if (!wlf_scale_coordinates(&context_w->context, &x, &y, FALSE))
+	if (!wlf_scale_coordinates(&context_w->common.context, &x, &y, FALSE))
 		goto fail;
 
-	if (!wlf_scale_coordinates(&context_w->context, &w, &h, FALSE))
+	if (!wlf_scale_coordinates(&context_w->common.context, &w, &h, FALSE))
 		goto fail;
 
 	if (UwacWindowAddDamage(context_w->window, x, y, w, h) != UWAC_SUCCESS)
@@ -161,10 +161,10 @@ static BOOL wl_refresh_display(wlfContext* context)
 {
 	rdpGdi* gdi;
 
-	if (!context || !context->context.gdi)
+	if (!context || !context->common.context.gdi)
 		return FALSE;
 
-	gdi = context->context.gdi;
+	gdi = context->common.context.gdi;
 	return wl_update_buffer(context, 0, 0, gdi->width, gdi->height);
 }
 
@@ -569,7 +569,7 @@ static int wlfreerdp_run(freerdp* instance)
 		if ((status != WAIT_TIMEOUT) && (status == WAIT_OBJECT_0))
 		{
 			timerEvent.now = GetTickCount64();
-			PubSub_OnTimer(context->context.pubSub, context, &timerEvent);
+			PubSub_OnTimer(context->common.context.pubSub, context, &timerEvent);
 		}
 	}
 
@@ -684,12 +684,6 @@ static int wfl_client_start(rdpContext* context)
 	return 0;
 }
 
-static int wfl_client_stop(rdpContext* context)
-{
-	WINPR_UNUSED(context);
-	return 0;
-}
-
 static int RdpClientEntry(RDP_CLIENT_ENTRY_POINTS* pEntryPoints)
 {
 	ZeroMemory(pEntryPoints, sizeof(RDP_CLIENT_ENTRY_POINTS));
@@ -701,7 +695,7 @@ static int RdpClientEntry(RDP_CLIENT_ENTRY_POINTS* pEntryPoints)
 	pEntryPoints->ClientNew = wlf_client_new;
 	pEntryPoints->ClientFree = wlf_client_free;
 	pEntryPoints->ClientStart = wfl_client_start;
-	pEntryPoints->ClientStop = wfl_client_stop;
+	pEntryPoints->ClientStop = freerdp_client_common_stop;
 	return 0;
 }
 

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -19,6 +19,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <stdio.h>
 #include <errno.h>
 #include <locale.h>

--- a/client/Wayland/wlfreerdp.h
+++ b/client/Wayland/wlfreerdp.h
@@ -20,6 +20,10 @@
 #ifndef FREERDP_CLIENT_WAYLAND_FREERDP_H
 #define FREERDP_CLIENT_WAYLAND_FREERDP_H
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <freerdp/client/encomsp.h>
 #include <freerdp/client/rdpei.h>
 #include <freerdp/gdi/gfx.h>
@@ -27,6 +31,9 @@
 #include <freerdp/log.h>
 #include <winpr/wtypes.h>
 #include <uwac/uwac.h>
+#if defined(CHANNEL_AINPUT_CLIENT)
+#include <freerdp/client/ainput.h>
+#endif
 
 typedef struct wlf_context wlfContext;
 typedef struct wlf_clipboard wfClipboard;
@@ -61,6 +68,10 @@ struct wlf_context
 	EncomspClientContext* encomsp;
 	wfClipboard* clipboard;
 	wlfDispContext* disp;
+#if defined(CHANNEL_AINPUT_CLIENT)
+	AInputClientContext* ainput;
+#endif
+
 	wLog* log;
 	CRITICAL_SECTION critical;
 	wArrayList* events;

--- a/client/Wayland/wlfreerdp.h
+++ b/client/Wayland/wlfreerdp.h
@@ -51,7 +51,7 @@ typedef struct touch_contact
 
 struct wlf_context
 {
-	rdpContext context;
+	rdpClientContext common;
 
 	UwacDisplay* display;
 	HANDLE displayHandle;
@@ -63,14 +63,10 @@ struct wlf_context
 	BOOL focusing;
 
 	/* Channels */
-	RdpeiClientContext* rdpei;
 	RdpgfxClientContext* gfx;
 	EncomspClientContext* encomsp;
 	wfClipboard* clipboard;
 	wlfDispContext* disp;
-#if defined(CHANNEL_AINPUT_CLIENT)
-	AInputClientContext* ainput;
-#endif
 
 	wLog* log;
 	CRITICAL_SECTION critical;

--- a/client/Windows/wf_channels.c
+++ b/client/Windows/wf_channels.c
@@ -20,6 +20,8 @@
 #include "config.h"
 #endif
 
+#include <winpr/assert.h>
+
 #include "wf_channels.h"
 
 #include "wf_rail.h"
@@ -31,23 +33,17 @@
 #include <freerdp/log.h>
 #define TAG CLIENT_TAG("windows")
 
-void wf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs* e)
+void wf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEventArgs* e)
 {
 	wfContext* wfc = (wfContext*)context;
-	rdpSettings* settings = wfc->context.settings;
+	rdpSettings* settings;
 
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
-	{
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		if (!settings->SoftwareGdi)
-			WLog_WARN(TAG, "Channel " RDPGFX_DVC_CHANNEL_NAME
-			               " does not support hardware acceleration, using fallback.");
+	WINPR_ASSERT(wfc);
 
-		gdi_graphics_pipeline_init(wfc->context.gdi, (RdpgfxClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
+	settings = wfc->common.context.settings;
+	WINPR_ASSERT(settings);
+
+	if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
 		wf_rail_init(wfc, (RailClientContext*)e->pInterface);
 	}
@@ -62,33 +58,21 @@ void wf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs*
 	{
 		wfc->disp = (DispClientContext*)e->pInterface;
 	}
-	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_geometry_init(wfc->context.gdi, (GeometryClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_control_init(wfc->context.gdi, (VideoClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_data_init(wfc->context.gdi, (VideoClientContext*)e->pInterface);
-	}
+	else
+		freerdp_client_OnChannelConnectedEventHandler(context, e);
 }
 
-void wf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEventArgs* e)
+void wf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnectedEventArgs* e)
 {
 	wfContext* wfc = (wfContext*)context;
-	rdpSettings* settings = wfc->context.settings;
+	rdpSettings* settings;
 
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
-	{
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_graphics_pipeline_uninit(wfc->context.gdi, (RdpgfxClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
+	WINPR_ASSERT(wfc);
+
+	settings = wfc->common.context.settings;
+	WINPR_ASSERT(settings);
+
+	if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
 		wf_rail_uninit(wfc, (RailClientContext*)e->pInterface);
 	}
@@ -103,16 +87,6 @@ void wf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEven
 	{
 		wfc->disp = NULL;
 	}
-	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_geometry_uninit(wfc->context.gdi, (GeometryClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_control_uninit(wfc->context.gdi, (VideoClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_data_uninit(wfc->context.gdi, (VideoClientContext*)e->pInterface);
-	}
+	else
+		freerdp_client_OnChannelDisconnectedEventHandler(context, e);
 }

--- a/client/Windows/wf_channels.h
+++ b/client/Windows/wf_channels.h
@@ -20,6 +20,7 @@
 #define FREERDP_CLIENT_WIN_CHANNELS_H
 
 #include <freerdp/freerdp.h>
+#include <freerdp/client.h>
 #include <freerdp/client/channels.h>
 #include <freerdp/client/rdpei.h>
 #include <freerdp/client/rdpgfx.h>

--- a/client/Windows/wf_channels.h
+++ b/client/Windows/wf_channels.h
@@ -29,7 +29,7 @@
 
 #include "wf_client.h"
 
-void wf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs* e);
-void wf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEventArgs* e);
+void wf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEventArgs* e);
+void wf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnectedEventArgs* e);
 
 #endif /* FREERDP_CLIENT_WIN_CHANNELS_H */

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -46,7 +46,6 @@
 #endif
 
 #include <freerdp/log.h>
-#include <freerdp/event.h>
 #include <freerdp/freerdp.h>
 #include <freerdp/constants.h>
 

--- a/client/Windows/wf_client.h
+++ b/client/Windows/wf_client.h
@@ -78,8 +78,7 @@ extern "C"
 
 	struct wf_context
 	{
-		rdpContext context;
-		DEFINE_RDP_CLIENT_COMMON();
+		rdpClientContext common;
 
 		int offset_x;
 		int offset_y;

--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -726,7 +726,11 @@ BOOL wf_scale_blt(wfContext* wfc, HDC hdc, int x, int y, int w, int h, HDC hdcSr
 {
 	rdpSettings* settings;
 	UINT32 ww, wh, dw, dh;
+
+	WINPR_ASSERT(wfc);
+
 	settings = wfc->common.context.settings;
+	WINPR_ASSERT(settings);
 
 	if (!wfc->client_width)
 		wfc->client_width = settings->DesktopWidth;
@@ -745,7 +749,7 @@ BOOL wf_scale_blt(wfContext* wfc, HDC hdc, int x, int y, int w, int h, HDC hdcSr
 	if (!wh)
 		wh = dh;
 
-	if (wfc->fullscreen || !wfc->common.context.settings->SmartSizing || (ww == dw && wh == dh))
+	if (wfc->fullscreen || !settings->SmartSizing || (ww == dw && wh == dh))
 	{
 		return BitBlt(hdc, x, y, w, h, wfc->primary->hdc, x1, y1, SRCCOPY);
 	}

--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -44,10 +44,10 @@ static HWND g_focus_hWnd;
 
 static BOOL wf_scale_blt(wfContext* wfc, HDC hdc, int x, int y, int w, int h, HDC hdcSrc, int x1,
                          int y1, DWORD rop);
-static BOOL wf_scale_mouse_event(wfContext* wfc, rdpInput* input, UINT16 flags, UINT16 x, UINT16 y);
+static BOOL wf_scale_mouse_event(wfContext* wfc, UINT16 flags, UINT16 x, UINT16 y);
 #if (_WIN32_WINNT >= 0x0500)
-static BOOL wf_scale_mouse_event_ex(wfContext* wfc, rdpInput* input, UINT16 flags,
-                                    UINT16 buttonMask, UINT16 x, UINT16 y);
+static BOOL wf_scale_mouse_event_ex(wfContext* wfc, UINT16 flags, UINT16 buttonMask, UINT16 x,
+                                    UINT16 y);
 #endif
 
 static BOOL g_flipping_in;
@@ -88,7 +88,7 @@ LRESULT CALLBACK wf_ll_kbd_proc(int nCode, WPARAM wParam, LPARAM lParam)
 				if (!wfc || !p)
 					return 1;
 
-				input = wfc->context.input;
+				input = wfc->common.context.input;
 				rdp_scancode = MAKE_RDP_SCANCODE((BYTE)p->scanCode, p->flags & LLKHF_EXTENDED);
 				DEBUG_KBD("keydown %d scanCode 0x%08lX flags 0x%08lX vkCode 0x%08lX",
 				          (wParam == WM_KEYDOWN), p->scanCode, p->flags, p->vkCode);
@@ -167,7 +167,7 @@ void wf_event_focus_in(wfContext* wfc)
 	rdpInput* input;
 	POINT pt;
 	RECT rc;
-	input = wfc->context.input;
+	input = wfc->common.context.input;
 	syncFlags = 0;
 
 	if (GetKeyState(VK_NUMLOCK))
@@ -197,9 +197,8 @@ static BOOL wf_event_process_WM_MOUSEWHEEL(wfContext* wfc, HWND hWnd, UINT Msg, 
 {
 	int delta;
 	UINT16 flags = 0;
-	rdpInput* input;
+
 	DefWindowProc(hWnd, Msg, wParam, lParam);
-	input = wfc->context.input;
 	delta = ((signed short)HIWORD(wParam)); /* GET_WHEEL_DELTA_WPARAM(wParam); */
 
 	if (horizontal)
@@ -215,12 +214,12 @@ static BOOL wf_event_process_WM_MOUSEWHEEL(wfContext* wfc, HWND hWnd, UINT Msg, 
 	}
 
 	flags |= delta;
-	return wf_scale_mouse_event(wfc, input, flags, x, y);
+	return wf_scale_mouse_event(wfc, flags, x, y);
 }
 
 static void wf_sizing(wfContext* wfc, WPARAM wParam, LPARAM lParam)
 {
-	rdpSettings* settings = wfc->context.settings;
+	rdpSettings* settings = wfc->common.context.settings;
 	// Holding the CTRL key down while resizing the window will force the desktop aspect ratio.
 	LPRECT rect;
 
@@ -262,7 +261,7 @@ static void wf_send_resize(wfContext* wfc)
 	RECT windowRect;
 	int targetWidth = wfc->client_width;
 	int targetHeight = wfc->client_height;
-	rdpSettings* settings = wfc->context.settings;
+	rdpSettings* settings = wfc->common.context.settings;
 
 	if (settings->DynamicResolutionUpdate && wfc->disp != NULL)
 	{
@@ -319,8 +318,7 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 
 	if (wfc != NULL)
 	{
-		rdpInput* input = wfc->context.input;
-		rdpSettings* settings = wfc->context.settings;
+		rdpSettings* settings = wfc->common.context.settings;
 
 		switch (Msg)
 		{
@@ -336,8 +334,8 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 				break;
 
 			case WM_GETMINMAXINFO:
-				if (wfc->context.settings->SmartSizing ||
-				    wfc->context.settings->DynamicResolutionUpdate)
+				if (wfc->common.context.settings->SmartSizing ||
+				    wfc->common.context.settings->DynamicResolutionUpdate)
 				{
 					processed = FALSE;
 				}
@@ -426,50 +424,50 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 #if (_WIN32_WINNT >= 0x0500)
 
 			case WM_XBUTTONDOWN:
-				wf_scale_mouse_event_ex(wfc, input, PTR_XFLAGS_DOWN, GET_XBUTTON_WPARAM(wParam),
+				wf_scale_mouse_event_ex(wfc, PTR_XFLAGS_DOWN, GET_XBUTTON_WPARAM(wParam),
 				                        X_POS(lParam) - wfc->offset_x,
 				                        Y_POS(lParam) - wfc->offset_y);
 				break;
 
 			case WM_XBUTTONUP:
-				wf_scale_mouse_event_ex(wfc, input, 0, GET_XBUTTON_WPARAM(wParam),
+				wf_scale_mouse_event_ex(wfc, 0, GET_XBUTTON_WPARAM(wParam),
 				                        X_POS(lParam) - wfc->offset_x,
 				                        Y_POS(lParam) - wfc->offset_y);
 				break;
 #endif
 
 			case WM_MBUTTONDOWN:
-				wf_scale_mouse_event(wfc, input, PTR_FLAGS_DOWN | PTR_FLAGS_BUTTON3,
+				wf_scale_mouse_event(wfc, PTR_FLAGS_DOWN | PTR_FLAGS_BUTTON3,
 				                     X_POS(lParam) - wfc->offset_x, Y_POS(lParam) - wfc->offset_y);
 				break;
 
 			case WM_MBUTTONUP:
-				wf_scale_mouse_event(wfc, input, PTR_FLAGS_BUTTON3, X_POS(lParam) - wfc->offset_x,
+				wf_scale_mouse_event(wfc, PTR_FLAGS_BUTTON3, X_POS(lParam) - wfc->offset_x,
 				                     Y_POS(lParam) - wfc->offset_y);
 				break;
 
 			case WM_LBUTTONDOWN:
-				wf_scale_mouse_event(wfc, input, PTR_FLAGS_DOWN | PTR_FLAGS_BUTTON1,
+				wf_scale_mouse_event(wfc, PTR_FLAGS_DOWN | PTR_FLAGS_BUTTON1,
 				                     X_POS(lParam) - wfc->offset_x, Y_POS(lParam) - wfc->offset_y);
 				break;
 
 			case WM_LBUTTONUP:
-				wf_scale_mouse_event(wfc, input, PTR_FLAGS_BUTTON1, X_POS(lParam) - wfc->offset_x,
+				wf_scale_mouse_event(wfc, PTR_FLAGS_BUTTON1, X_POS(lParam) - wfc->offset_x,
 				                     Y_POS(lParam) - wfc->offset_y);
 				break;
 
 			case WM_RBUTTONDOWN:
-				wf_scale_mouse_event(wfc, input, PTR_FLAGS_DOWN | PTR_FLAGS_BUTTON2,
+				wf_scale_mouse_event(wfc, PTR_FLAGS_DOWN | PTR_FLAGS_BUTTON2,
 				                     X_POS(lParam) - wfc->offset_x, Y_POS(lParam) - wfc->offset_y);
 				break;
 
 			case WM_RBUTTONUP:
-				wf_scale_mouse_event(wfc, input, PTR_FLAGS_BUTTON2, X_POS(lParam) - wfc->offset_x,
+				wf_scale_mouse_event(wfc, PTR_FLAGS_BUTTON2, X_POS(lParam) - wfc->offset_x,
 				                     Y_POS(lParam) - wfc->offset_y);
 				break;
 
 			case WM_MOUSEMOVE:
-				wf_scale_mouse_event(wfc, input, PTR_FLAGS_MOVE, X_POS(lParam) - wfc->offset_x,
+				wf_scale_mouse_event(wfc, PTR_FLAGS_MOVE, X_POS(lParam) - wfc->offset_x,
 				                     Y_POS(lParam) - wfc->offset_y);
 				break;
 #if (_WIN32_WINNT >= 0x0400) || (_WIN32_WINDOWS > 0x0400)
@@ -640,10 +638,11 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 				if (wParam == SYSCOMMAND_ID_SMARTSIZING)
 				{
 					HMENU hMenu = GetSystemMenu(wfc->hwnd, FALSE);
-					freerdp_settings_set_bool(wfc->context.settings, FreeRDP_SmartSizing,
-					                          !wfc->context.settings->SmartSizing);
+					freerdp_settings_set_bool(wfc->common.context.settings, FreeRDP_SmartSizing,
+					                          !wfc->common.context.settings->SmartSizing);
 					CheckMenuItem(hMenu, SYSCOMMAND_ID_SMARTSIZING,
-					              wfc->context.settings->SmartSizing ? MF_CHECKED : MF_UNCHECKED);
+					              wfc->common.context.settings->SmartSizing ? MF_CHECKED
+					                                                        : MF_UNCHECKED);
 				}
 				else
 				{
@@ -678,7 +677,7 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 				g_flipping_in = TRUE;
 
 			g_focus_hWnd = hWnd;
-			freerdp_set_focus(wfc->context.instance);
+			freerdp_set_focus(wfc->common.context.instance);
 			break;
 
 		case WM_KILLFOCUS:
@@ -727,7 +726,7 @@ BOOL wf_scale_blt(wfContext* wfc, HDC hdc, int x, int y, int w, int h, HDC hdcSr
 {
 	rdpSettings* settings;
 	UINT32 ww, wh, dw, dh;
-	settings = wfc->context.settings;
+	settings = wfc->common.context.settings;
 
 	if (!wfc->client_width)
 		wfc->client_width = settings->DesktopWidth;
@@ -746,7 +745,7 @@ BOOL wf_scale_blt(wfContext* wfc, HDC hdc, int x, int y, int w, int h, HDC hdcSr
 	if (!wh)
 		wh = dh;
 
-	if (wfc->fullscreen || !wfc->context.settings->SmartSizing || (ww == dw && wh == dh))
+	if (wfc->fullscreen || !wfc->common.context.settings->SmartSizing || (ww == dw && wh == dh))
 	{
 		return BitBlt(hdc, x, y, w, h, wfc->primary->hdc, x1, y1, SRCCOPY);
 	}
@@ -763,13 +762,12 @@ BOOL wf_scale_blt(wfContext* wfc, HDC hdc, int x, int y, int w, int h, HDC hdcSr
 static BOOL wf_scale_mouse_pos(wfContext* wfc, UINT16* x, UINT16* y)
 {
 	int ww, wh, dw, dh;
-	rdpContext* context;
 	rdpSettings* settings;
 
 	if (!wfc || !x || !y)
 		return FALSE;
 
-	settings = wfc->context.settings;
+	settings = wfc->common.context.settings;
 
 	if (!settings)
 		return FALSE;
@@ -799,28 +797,32 @@ static BOOL wf_scale_mouse_pos(wfContext* wfc, UINT16* x, UINT16* y)
 	return TRUE;
 }
 
-static BOOL wf_scale_mouse_event(wfContext* wfc, rdpInput* input, UINT16 flags, UINT16 x, UINT16 y)
+static BOOL wf_scale_mouse_event(wfContext* wfc, UINT16 flags, UINT16 x, UINT16 y)
 {
 	MouseEventEventArgs eventArgs;
+
+	WINPR_ASSERT(wfc);
 
 	if (!wf_scale_mouse_pos(wfc, &x, &y))
 		return FALSE;
 
-	if (freerdp_input_send_mouse_event(input, flags, x, y))
+	if (freerdp_client_send_button_event(&wfc->common, flags, x, y))
 		return FALSE;
 
 	eventArgs.flags = flags;
 	eventArgs.x = x;
 	eventArgs.y = y;
-	PubSub_OnMouseEvent(wfc->context.pubSub, &wfc->context, &eventArgs);
+	PubSub_OnMouseEvent(wfc->common.context.pubSub, &wfc->common.context, &eventArgs);
 	return TRUE;
 }
 
 #if (_WIN32_WINNT >= 0x0500)
-static BOOL wf_scale_mouse_event_ex(wfContext* wfc, rdpInput* input, UINT16 flags,
-                                    UINT16 buttonMask, UINT16 x, UINT16 y)
+static BOOL wf_scale_mouse_event_ex(wfContext* wfc, UINT16 flags, UINT16 buttonMask, UINT16 x,
+                                    UINT16 y)
 {
 	MouseEventExEventArgs eventArgs;
+
+	WINPR_ASSERT(wfc);
 
 	if (buttonMask & XBUTTON1)
 		flags |= PTR_XFLAGS_BUTTON1;
@@ -831,13 +833,13 @@ static BOOL wf_scale_mouse_event_ex(wfContext* wfc, rdpInput* input, UINT16 flag
 	if (!wf_scale_mouse_pos(wfc, &x, &y))
 		return FALSE;
 
-	if (freerdp_input_send_extended_mouse_event(input, flags, x, y))
+	if (freerdp_client_send_extended_button_event(&wfc->common, flags, x, y))
 		return FALSE;
 
 	eventArgs.flags = flags;
 	eventArgs.x = x;
 	eventArgs.y = y;
-	PubSub_OnMouseEventEx(wfc->context.pubSub, &wfc->context, &eventArgs);
+	PubSub_OnMouseEventEx(wfc->common.context.pubSub, &wfc->common.context, &eventArgs);
 	return TRUE;
 }
 #endif

--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -810,7 +810,7 @@ static BOOL wf_scale_mouse_event(wfContext* wfc, UINT16 flags, UINT16 x, UINT16 
 	if (!wf_scale_mouse_pos(wfc, &x, &y))
 		return FALSE;
 
-	if (freerdp_client_send_button_event(&wfc->common, flags, x, y))
+	if (freerdp_client_send_button_event(&wfc->common, FALSE, flags, x, y))
 		return FALSE;
 
 	eventArgs.flags = flags;
@@ -837,7 +837,7 @@ static BOOL wf_scale_mouse_event_ex(wfContext* wfc, UINT16 flags, UINT16 buttonM
 	if (!wf_scale_mouse_pos(wfc, &x, &y))
 		return FALSE;
 
-	if (freerdp_client_send_extended_button_event(&wfc->common, flags, x, y))
+	if (freerdp_client_send_extended_button_event(&wfc->common, FALSE, flags, x, y))
 		return FALSE;
 
 	eventArgs.flags = flags;

--- a/client/Windows/wf_floatbar.c
+++ b/client/Windows/wf_floatbar.c
@@ -701,7 +701,7 @@ wfFloatBar* wf_floatbar_new(wfContext* wfc, HINSTANCE window, DWORD flags)
 	if (!update_locked_state(floatbar))
 		goto fail;
 
-	if (!wf_floatbar_toggle_fullscreen(floatbar, wfc->context.settings->Fullscreen))
+	if (!wf_floatbar_toggle_fullscreen(floatbar, wfc->common.context.settings->Fullscreen))
 		goto fail;
 
 	return floatbar;

--- a/client/Windows/wf_gdi.c
+++ b/client/Windows/wf_gdi.c
@@ -71,8 +71,8 @@ static BOOL wf_decode_color(wfContext* wfc, const UINT32 srcColor, COLORREF* col
 	if (!wfc)
 		return FALSE;
 
-	gdi = wfc->context.gdi;
-	settings = wfc->context.settings;
+	gdi = wfc->common.context.gdi;
+	settings = wfc->common.context.settings;
 
 	if (!gdi || !settings)
 		return FALSE;
@@ -216,10 +216,10 @@ static BOOL wf_scale_rect(wfContext* wfc, RECT* source)
 	UINT32 ww, wh, dw, dh;
 	rdpSettings* settings;
 
-	if (!wfc || !source || !wfc->context.settings)
+	if (!wfc || !source || !wfc->common.context.settings)
 		return FALSE;
 
-	settings = wfc->context.settings;
+	settings = wfc->common.context.settings;
 
 	if (!settings)
 		return FALSE;
@@ -242,7 +242,7 @@ static BOOL wf_scale_rect(wfContext* wfc, RECT* source)
 	if (!wh)
 		wh = dh;
 
-	if (wfc->context.settings->SmartSizing && (ww != dw || wh != dh))
+	if (wfc->common.context.settings->SmartSizing && (ww != dw || wh != dh))
 	{
 		source->bottom = source->bottom * wh / dh + 20;
 		source->top = source->top * wh / dh - 20;
@@ -260,7 +260,7 @@ static BOOL wf_scale_rect(wfContext* wfc, RECT* source)
 void wf_invalidate_region(wfContext* wfc, UINT32 x, UINT32 y, UINT32 width, UINT32 height)
 {
 	RECT rect;
-	rdpGdi* gdi = wfc->context.gdi;
+	rdpGdi* gdi = wfc->common.context.gdi;
 	wfc->update_rect.left = x + wfc->offset_x;
 	wfc->update_rect.top = y + wfc->offset_y;
 	wfc->update_rect.right = wfc->update_rect.left + width;
@@ -278,11 +278,11 @@ void wf_invalidate_region(wfContext* wfc, UINT32 x, UINT32 y, UINT32 width, UINT
 void wf_update_offset(wfContext* wfc)
 {
 	rdpSettings* settings;
-	settings = wfc->context.settings;
+	settings = wfc->common.context.settings;
 
 	if (wfc->fullscreen)
 	{
-		if (wfc->context.settings->UseMultimon)
+		if (wfc->common.context.settings->UseMultimon)
 		{
 			int x = GetSystemMetrics(SM_XVIRTUALSCREEN);
 			int y = GetSystemMetrics(SM_YVIRTUALSCREEN);
@@ -321,11 +321,11 @@ void wf_update_offset(wfContext* wfc)
 void wf_resize_window(wfContext* wfc)
 {
 	rdpSettings* settings;
-	settings = wfc->context.settings;
+	settings = wfc->common.context.settings;
 
 	if (wfc->fullscreen)
 	{
-		if (wfc->context.settings->UseMultimon)
+		if (wfc->common.context.settings->UseMultimon)
 		{
 			int x = GetSystemMetrics(SM_XVIRTUALSCREEN);
 			int y = GetSystemMetrics(SM_YVIRTUALSCREEN);
@@ -341,7 +341,7 @@ void wf_resize_window(wfContext* wfc)
 			             GetSystemMetrics(SM_CYSCREEN), SWP_FRAMECHANGED);
 		}
 	}
-	else if (!wfc->context.settings->Decorations)
+	else if (!wfc->common.context.settings->Decorations)
 	{
 		SetWindowLongPtr(wfc->hwnd, GWL_STYLE, WS_CHILD);
 

--- a/client/Windows/wf_graphics.c
+++ b/client/Windows/wf_graphics.c
@@ -58,7 +58,7 @@ HBITMAP wf_create_dib(wfContext* wfc, UINT32 width, UINT32 height, UINT32 srcFor
 
 	if (data)
 		freerdp_image_copy(cdata, dstFormat, 0, 0, 0, width, height, data, srcFormat, 0, 0, 0,
-		                   &wfc->context.gdi->palette, FREERDP_FLIP_NONE);
+		                   &wfc->common.context.gdi->palette, FREERDP_FLIP_NONE);
 
 	if (pdata)
 		*pdata = cdata;

--- a/client/Windows/wf_rail.c
+++ b/client/Windows/wf_rail.c
@@ -879,7 +879,7 @@ static UINT wf_rail_server_start_cmd(RailClientContext* context)
 	RAIL_SYSPARAM_ORDER sysparam = { 0 };
 	RAIL_CLIENT_STATUS_ORDER clientStatus = { 0 };
 	wfContext* wfc = (wfContext*)context->custom;
-	rdpSettings* settings = wfc->context.settings;
+	rdpSettings* settings = wfc->common.context.settings;
 	clientStatus.flags = TS_RAIL_CLIENTSTATUS_ALLOWLOCALMOVESIZE;
 
 	if (settings->AutoReconnectionEnabled)

--- a/client/X11/xf_channels.c
+++ b/client/X11/xf_channels.c
@@ -31,15 +31,12 @@
 #if defined(CHANNEL_TSMF_CLIENT)
 #include "xf_tsmf.h"
 #endif
-#if defined(CHANNEL_AINPUT_CLIENT)
-#include <freerdp/channels/ainput.h>
-#endif
 #include "xf_rail.h"
 #include "xf_cliprdr.h"
 #include "xf_disp.h"
 #include "xf_video.h"
 
-void xf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs* e)
+void xf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEventArgs* e)
 {
 	xfContext* xfc = (xfContext*)context;
 	rdpSettings* settings;
@@ -48,17 +45,11 @@ void xf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs*
 	WINPR_ASSERT(e);
 	WINPR_ASSERT(e->name);
 
-	settings = xfc->context.settings;
+	settings = xfc->common.context.settings;
 	WINPR_ASSERT(settings);
 
-#if defined(CHANNEL_AINPUT_CLIENT)
-	if (strcmp(e->name, AINPUT_DVC_CHANNEL_NAME) == 0)
-		xfc->ainput = (AInputClientContext*)e->pInterface;
-#endif
-
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
+	if (0)
 	{
-		xfc->rdpei = (RdpeiClientContext*)e->pInterface;
 	}
 #if defined(CHANNEL_TSMF_CLIENT)
 	else if (strcmp(e->name, TSMF_DVC_CHANNEL_NAME) == 0)
@@ -86,24 +77,18 @@ void xf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs*
 	{
 		xf_disp_init(xfc->xfDisp, (DispClientContext*)e->pInterface);
 	}
-	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_geometry_init(xfc->context.gdi, (GeometryClientContext*)e->pInterface);
-	}
 	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
-			gdi_video_control_init(xfc->context.gdi, (VideoClientContext*)e->pInterface);
+			gdi_video_control_init(xfc->common.context.gdi, (VideoClientContext*)e->pInterface);
 		else
 			xf_video_control_init(xfc, (VideoClientContext*)e->pInterface);
 	}
-	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_data_init(xfc->context.gdi, (VideoClientContext*)e->pInterface);
-	}
+	else
+		freerdp_client_OnChannelConnectedEventHandler(context, e);
 }
 
-void xf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEventArgs* e)
+void xf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnectedEventArgs* e)
 {
 	xfContext* xfc = (xfContext*)context;
 	rdpSettings* settings;
@@ -112,17 +97,11 @@ void xf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEven
 	WINPR_ASSERT(e);
 	WINPR_ASSERT(e->name);
 
-	settings = xfc->context.settings;
+	settings = xfc->common.context.settings;
 	WINPR_ASSERT(settings);
 
-#if defined(CHANNEL_AINPUT_CLIENT)
-	if (strcmp(e->name, AINPUT_DVC_CHANNEL_NAME) == 0)
-		xfc->ainput = NULL;
-#endif
-
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
+	if (0)
 	{
-		xfc->rdpei = NULL;
 	}
 	else if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) == 0)
 	{
@@ -150,19 +129,13 @@ void xf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEven
 	{
 		xf_encomsp_uninit(xfc, (EncomspClientContext*)e->pInterface);
 	}
-	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_geometry_uninit(xfc->context.gdi, (GeometryClientContext*)e->pInterface);
-	}
 	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
-			gdi_video_control_uninit(xfc->context.gdi, (VideoClientContext*)e->pInterface);
+			gdi_video_control_uninit(xfc->common.context.gdi, (VideoClientContext*)e->pInterface);
 		else
 			xf_video_control_uninit(xfc, (VideoClientContext*)e->pInterface);
 	}
-	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_data_uninit(xfc->context.gdi, (VideoClientContext*)e->pInterface);
-	}
+	else
+		freerdp_client_OnChannelDisconnectedEventHandler(context, e);
 }

--- a/client/X11/xf_channels.c
+++ b/client/X11/xf_channels.c
@@ -31,6 +31,9 @@
 #if defined(CHANNEL_TSMF_CLIENT)
 #include "xf_tsmf.h"
 #endif
+#if defined(CHANNEL_AINPUT_CLIENT)
+#include <freerdp/channels/ainput.h>
+#endif
 #include "xf_rail.h"
 #include "xf_cliprdr.h"
 #include "xf_disp.h"
@@ -47,6 +50,11 @@ void xf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs*
 
 	settings = xfc->context.settings;
 	WINPR_ASSERT(settings);
+
+#if defined(CHANNEL_AINPUT_CLIENT)
+	if (strcmp(e->name, AINPUT_DVC_CHANNEL_NAME) == 0)
+		xfc->ainput = (AInputClientContext*)e->pInterface;
+#endif
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
@@ -106,6 +114,11 @@ void xf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEven
 
 	settings = xfc->context.settings;
 	WINPR_ASSERT(settings);
+
+#if defined(CHANNEL_AINPUT_CLIENT)
+	if (strcmp(e->name, AINPUT_DVC_CHANNEL_NAME) == 0)
+		xfc->ainput = NULL;
+#endif
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{

--- a/client/X11/xf_channels.h
+++ b/client/X11/xf_channels.h
@@ -31,7 +31,7 @@
 #include <freerdp/client/geometry.h>
 #include <freerdp/client/video.h>
 
-void xf_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs* e);
-void xf_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEventArgs* e);
+void xf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEventArgs* e);
+void xf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnectedEventArgs* e);
 
 #endif /* FREERDP_CLIENT_X11_CHANNELS_H */

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -733,6 +733,7 @@ void xf_toggle_fullscreen(xfContext* xfc)
 	if (xfc->debug)
 	{
 		XUngrabKeyboard(xfc->display, CurrentTime);
+		XUngrabPointer(xfc->display, CurrentTime);
 	}
 
 	xfc->fullscreen = (xfc->fullscreen) ? FALSE : TRUE;
@@ -939,6 +940,7 @@ static int _xf_error_handler(Display* d, XErrorEvent* ev)
 	 */
 
 	XUngrabKeyboard(d, CurrentTime);
+	XUngrabPointer(d, CurrentTime);
 	return xf_error_handler(d, ev);
 }
 

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -2839,8 +2839,8 @@ xfClipboard* xf_clipboard_new(xfContext* xfc)
 	clipboard->requestedFormatId = -1;
 	clipboard->root_window = DefaultRootWindow(xfc->display);
 	selectionAtom = "CLIPBOARD";
-	if (xfc->context.settings->XSelectionAtom)
-		selectionAtom = xfc->context.settings->XSelectionAtom;
+	if (xfc->common.context.settings->XSelectionAtom)
+		selectionAtom = xfc->common.context.settings->XSelectionAtom;
 	clipboard->clipboard_atom = XInternAtom(xfc->display, selectionAtom, FALSE);
 
 	if (clipboard->clipboard_atom == None)

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -395,7 +395,7 @@ BOOL xf_generic_MotionNotify(xfContext* xfc, int x, int y, int state, Window win
 	}
 
 	xf_event_adjust_coordinates(xfc, &x, &y);
-	freerdp_client_send_button_event(&xfc->common, PTR_FLAGS_MOVE, (UINT16)x, (UINT16)y);
+	freerdp_client_send_button_event(&xfc->common, FALSE, PTR_FLAGS_MOVE, x, y);
 
 	if (xfc->fullscreen && !app)
 	{
@@ -404,6 +404,21 @@ BOOL xf_generic_MotionNotify(xfContext* xfc, int x, int y, int state, Window win
 
 	return TRUE;
 }
+
+BOOL xf_generic_RawMotionNotify(xfContext* xfc, int x, int y, Window window, BOOL app)
+{
+	WINPR_ASSERT(xfc);
+
+	if (app)
+	{
+		WLog_ERR(TAG, "Relative mouse input is not supported with remoate app mode!");
+		return FALSE;
+	}
+
+	freerdp_client_send_button_event(&xfc->common, TRUE, PTR_FLAGS_MOVE, x, y);
+	return TRUE;
+}
+
 static BOOL xf_event_MotionNotify(xfContext* xfc, const XMotionEvent* event, BOOL app)
 {
 	if (xfc->window)
@@ -471,10 +486,9 @@ BOOL xf_generic_ButtonEvent(xfContext* xfc, int x, int y, int button, Window win
 			xf_event_adjust_coordinates(xfc, &x, &y);
 
 			if (extended)
-				freerdp_client_send_extended_button_event(&xfc->common, flags, (UINT16)x,
-				                                          (UINT16)y);
+				freerdp_client_send_extended_button_event(&xfc->common, FALSE, flags, x, y);
 			else
-				freerdp_client_send_button_event(&xfc->common, flags, (UINT16)x, (UINT16)y);
+				freerdp_client_send_button_event(&xfc->common, FALSE, flags, x, y);
 		}
 	}
 
@@ -1143,4 +1157,57 @@ BOOL xf_event_process(freerdp* instance, const XEvent* event)
 	xf_input_handle_event(xfc, event);
 	XSync(xfc->display, FALSE);
 	return status;
+}
+
+BOOL xf_generic_RawButtonEvent(xfContext* xfc, int button, BOOL app, BOOL down)
+{
+	UINT16 flags = 0;
+	size_t i;
+
+	if (app)
+		return FALSE;
+
+	for (i = 0; i < ARRAYSIZE(xfc->button_map); i++)
+	{
+		const button_map* cur = &xfc->button_map[i];
+
+		if (cur->button == button)
+		{
+			flags = cur->flags;
+			break;
+		}
+	}
+
+	if (flags != 0)
+	{
+		if (flags & (PTR_FLAGS_WHEEL | PTR_FLAGS_HWHEEL))
+		{
+			if (down)
+				freerdp_client_send_wheel_event(&xfc->common, flags);
+		}
+		else
+		{
+			BOOL extended = FALSE;
+
+			if (flags & (PTR_XFLAGS_BUTTON1 | PTR_XFLAGS_BUTTON2))
+			{
+				extended = TRUE;
+
+				if (down)
+					flags |= PTR_XFLAGS_DOWN;
+			}
+			else if (flags & (PTR_FLAGS_BUTTON1 | PTR_FLAGS_BUTTON2 | PTR_FLAGS_BUTTON3))
+			{
+				if (down)
+					flags |= PTR_FLAGS_DOWN;
+			}
+
+			if (extended)
+				freerdp_client_send_extended_button_event(&xfc->common, TRUE, flags, 0, 0);
+			else
+				freerdp_client_send_button_event(&xfc->common, TRUE, flags, 0, 0);
+		}
+	}
+
+	return TRUE;
 }

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -375,9 +375,7 @@ static BOOL xf_event_VisibilityNotify(xfContext* xfc, const XVisibilityEvent* ev
 
 BOOL xf_generic_MotionNotify(xfContext* xfc, int x, int y, int state, Window window, BOOL app)
 {
-	rdpInput* input;
 	Window childWindow;
-	input = xfc->common.context.input;
 
 	if (!xfc->common.context.settings->MouseMotion)
 	{

--- a/client/X11/xf_event.h
+++ b/client/X11/xf_event.h
@@ -36,8 +36,9 @@ void xf_event_adjust_coordinates(xfContext* xfc, int* x, int* y);
 void xf_adjust_coordinates_to_screen(xfContext* xfc, UINT32* x, UINT32* y);
 
 BOOL xf_generic_MotionNotify(xfContext* xfc, int x, int y, int state, Window window, BOOL app);
-BOOL xf_generic_ButtonPress(xfContext* xfc, int x, int y, int button, Window window, BOOL app);
+BOOL xf_generic_RawMotionNotify(xfContext* xfc, int x, int y, Window window, BOOL app);
 BOOL xf_generic_ButtonEvent(xfContext* xfc, int x, int y, int button, Window window, BOOL app,
                             BOOL down);
+BOOL xf_generic_RawButtonEvent(xfContext* xfc, int button, BOOL app, BOOL down);
 
 #endif /* FREERDP_CLIENT_X11_EVENT_H */

--- a/client/X11/xf_floatbar.c
+++ b/client/X11/xf_floatbar.c
@@ -100,7 +100,7 @@ static BOOL xf_floatbar_button_onclick_close(xfFloatbar* floatbar)
 	if (!floatbar)
 		return FALSE;
 
-	return freerdp_abort_connect(floatbar->xfc->context.instance);
+	return freerdp_abort_connect(floatbar->xfc->common.context.instance);
 }
 
 static BOOL xf_floatbar_button_onclick_minimize(xfFloatbar* floatbar)

--- a/client/X11/xf_gdi.c
+++ b/client/X11/xf_gdi.c
@@ -225,7 +225,7 @@ static Pixmap xf_brush_new(xfContext* xfc, UINT32 width, UINT32 height, UINT32 b
 	XImage* image;
 	rdpGdi* gdi;
 	UINT32 brushFormat;
-	gdi = xfc->context.gdi;
+	gdi = xfc->common.context.gdi;
 	bitmap = XCreatePixmap(xfc->display, xfc->drawable, width, height, xfc->depth);
 
 	if (data)
@@ -233,7 +233,7 @@ static Pixmap xf_brush_new(xfContext* xfc, UINT32 width, UINT32 height, UINT32 b
 		brushFormat = gdi_get_pixel_format(bpp);
 		cdata = (BYTE*)_aligned_malloc(width * height * 4ULL, 16);
 		freerdp_image_copy(cdata, gdi->dstFormat, 0, 0, 0, width, height, data, brushFormat, 0, 0,
-		                   0, &xfc->context.gdi->palette, FREERDP_FLIP_NONE);
+		                   0, &xfc->common.context.gdi->palette, FREERDP_FLIP_NONE);
 		image = XCreateImage(xfc->display, xfc->visual, xfc->depth, ZPixmap, 0, (char*)cdata, width,
 		                     height, xfc->scanline_pad, 0);
 		image->byte_order = LSBFirst;
@@ -898,7 +898,7 @@ static BOOL xf_gdi_surface_frame_marker(rdpContext* context,
 	rdpSettings* settings;
 	xfContext* xfc = (xfContext*)context;
 	BOOL ret = TRUE;
-	settings = xfc->context.settings;
+	settings = xfc->common.context.settings;
 	xf_lock_x11(xfc);
 
 	switch (surface_frame_marker->frameAction)
@@ -921,7 +921,7 @@ static BOOL xf_gdi_surface_frame_marker(rdpContext* context,
 
 			if (settings->FrameAcknowledge > 0)
 			{
-				IFCALL(xfc->context.update->SurfaceFrameAcknowledge, context,
+				IFCALL(xfc->common.context.update->SurfaceFrameAcknowledge, context,
 				       surface_frame_marker->frameId);
 			}
 
@@ -1077,7 +1077,8 @@ static BOOL xf_gdi_surface_bits(rdpContext* context, const SURFACE_BITS_COMMAND*
 
 			if (!freerdp_image_copy(gdi->primary_buffer, gdi->dstFormat, gdi->stride, cmd->destLeft,
 			                        cmd->destTop, cmd->bmp.width, cmd->bmp.height, pSrcData, format,
-			                        0, 0, 0, &xfc->context.gdi->palette, FREERDP_FLIP_VERTICAL))
+			                        0, 0, 0, &xfc->common.context.gdi->palette,
+			                        FREERDP_FLIP_VERTICAL))
 				goto fail;
 
 			region16_union_rect(&region, &region, &cmdRect);

--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -40,7 +40,7 @@ static UINT xf_OutputUpdate(xfContext* xfc, xfGfxSurface* surface)
 	UINT32 nbRects, x;
 	double sx, sy;
 	const RECTANGLE_16* rects;
-	gdi = xfc->context.gdi;
+	gdi = xfc->common.context.gdi;
 	surfaceX = surface->gdi.outputOriginX;
 	surfaceY = surface->gdi.outputOriginY;
 	surfaceRect.left = 0;
@@ -87,7 +87,8 @@ static UINT xf_OutputUpdate(xfContext* xfc, xfGfxSurface* surface)
 		}
 		else
 #ifdef WITH_XRENDER
-		    if (xfc->context.settings->SmartSizing || xfc->context.settings->MultiTouchGestures)
+		    if (xfc->common.context.settings->SmartSizing ||
+		        xfc->common.context.settings->MultiTouchGestures)
 		{
 			XPutImage(xfc->display, xfc->primary, xfc->gc, surface->image, nXSrc, nYSrc, nXDst,
 			          nYDst, dwidth, dheight);
@@ -166,7 +167,7 @@ UINT xf_OutputExpose(xfContext* xfc, UINT32 x, UINT32 y, UINT32 width, UINT32 he
 	RECTANGLE_16 surfaceRect;
 	RECTANGLE_16 intersection;
 	UINT16* pSurfaceIds = NULL;
-	RdpgfxClientContext* context = xfc->context.gdi->gfx;
+	RdpgfxClientContext* context = xfc->common.context.gdi->gfx;
 	invalidRect.left = x;
 	invalidRect.top = y;
 	invalidRect.right = x + width;
@@ -400,10 +401,10 @@ static UINT xf_DeleteSurface(RdpgfxClientContext* context,
 
 void xf_graphics_pipeline_init(xfContext* xfc, RdpgfxClientContext* gfx)
 {
-	rdpGdi* gdi = xfc->context.gdi;
+	rdpGdi* gdi = xfc->common.context.gdi;
 	gdi_graphics_pipeline_init(gdi, gfx);
 
-	if (!xfc->context.settings->SoftwareGdi)
+	if (!xfc->common.context.settings->SoftwareGdi)
 	{
 		gfx->UpdateSurfaces = xf_UpdateSurfaces;
 		gfx->CreateSurface = xf_CreateSurface;
@@ -413,6 +414,6 @@ void xf_graphics_pipeline_init(xfContext* xfc, RdpgfxClientContext* gfx)
 
 void xf_graphics_pipeline_uninit(xfContext* xfc, RdpgfxClientContext* gfx)
 {
-	rdpGdi* gdi = xfc->context.gdi;
+	rdpGdi* gdi = xfc->common.context.gdi;
 	gdi_graphics_pipeline_uninit(gdi, gfx);
 }

--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -52,12 +52,12 @@ BOOL xf_decode_color(xfContext* xfc, const UINT32 srcColor, XColor* color)
 	if (!xfc || !color)
 		return FALSE;
 
-	gdi = xfc->context.gdi;
+	gdi = xfc->common.context.gdi;
 
 	if (!gdi)
 		return FALSE;
 
-	settings = xfc->context.settings;
+	settings = xfc->common.context.settings;
 
 	if (!settings)
 		return FALSE;
@@ -248,7 +248,7 @@ static BOOL _xf_Pointer_GetCursorForCurrentScale(rdpContext* context, const rdpP
 	if (!context || !pointer || !context->gdi)
 		return FALSE;
 
-	settings = xfc->context.settings;
+	settings = xfc->common.context.settings;
 
 	if (!settings)
 		return FALSE;

--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -102,7 +102,7 @@ int xf_input_init(xfContext* xfc, Window window)
 		return -1;
 	}
 
-	if (xfc->context.settings->MultiTouchInput)
+	if (xfc->common.context.settings->MultiTouchInput)
 		xfc->use_xinput = TRUE;
 
 	info = XIQueryDevice(xfc->display, XIAllDevices, &ndevices);
@@ -129,7 +129,7 @@ int xf_input_init(xfContext* xfc, Window window)
 			XIAnyClassInfo* class = dev->classes[j];
 			XITouchClassInfo* t = (XITouchClassInfo*)class;
 
-			if (xfc->context.settings->MultiTouchInput)
+			if (xfc->common.context.settings->MultiTouchInput)
 			{
 				WLog_INFO(TAG, "%s (%d) \"%s\" id: %d", xf_input_get_class_string(class->type),
 				          class->type, dev->name, dev->deviceid);
@@ -143,7 +143,7 @@ int xf_input_init(xfContext* xfc, Window window)
 			if ((class->type == XITouchClass) && (t->mode == XIDirectTouch) &&
 			    (strcmp(dev->name, "Virtual core pointer") != 0))
 			{
-				if (xfc->context.settings->MultiTouchInput)
+				if (xfc->common.context.settings->MultiTouchInput)
 				{
 					WLog_INFO(TAG, "%s %s touch device (id: %d, mode: %d), supporting %d touches.",
 					          dev->name, (t->mode == XIDirectTouch) ? "direct" : "dependent",
@@ -233,7 +233,7 @@ static void xf_input_detect_pan(xfContext* xfc)
 	rdpContext* ctx;
 
 	WINPR_ASSERT(xfc);
-	ctx = &xfc->context;
+	ctx = &xfc->common.context;
 	WINPR_ASSERT(ctx);
 
 	if (xfc->active_contacts != 2)
@@ -321,7 +321,7 @@ static void xf_input_detect_pinch(xfContext* xfc)
 	rdpContext* ctx;
 
 	WINPR_ASSERT(xfc);
-	ctx = &xfc->context;
+	ctx = &xfc->common.context;
 	WINPR_ASSERT(ctx);
 
 	if (xfc->active_contacts != 2)
@@ -557,7 +557,7 @@ static int xf_input_touch_remote(xfContext* xfc, XIDeviceEvent* event, int evtyp
 	int x, y;
 	int touchId;
 	int contactId;
-	RdpeiClientContext* rdpei = xfc->rdpei;
+	RdpeiClientContext* rdpei = xfc->common.rdpei;
 
 	if (!rdpei)
 		return 0;
@@ -660,12 +660,12 @@ int xf_input_handle_event(xfContext* xfc, const XEvent* event)
 {
 #ifdef WITH_XI
 
-	if (xfc->context.settings->MultiTouchInput)
+	if (xfc->common.context.settings->MultiTouchInput)
 	{
 		return xf_input_handle_event_remote(xfc, event);
 	}
 
-	if (xfc->context.settings->MultiTouchGestures)
+	if (xfc->common.context.settings->MultiTouchGestures)
 	{
 		return xf_input_handle_event_local(xfc, event);
 	}

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -48,7 +48,7 @@ static void xf_keyboard_send_key(xfContext* xfc, BOOL down, const XKeyEvent* ev)
 static BOOL xf_sync_kbd_state(xfContext* xfc)
 {
 	const UINT32 syncFlags = xf_keyboard_get_toggle_keys_state(xfc);
-	return freerdp_input_send_synchronize_event(xfc->context.input, syncFlags);
+	return freerdp_input_send_synchronize_event(xfc->common.context.input, syncFlags);
 }
 
 static void xf_keyboard_clear(xfContext* xfc)
@@ -63,7 +63,7 @@ static BOOL xf_keyboard_action_script_init(xfContext* xfc)
 	char* keyCombination;
 	char buffer[1024] = { 0 };
 	char command[1024] = { 0 };
-	xfc->actionScriptExists = winpr_PathFileExists(xfc->context.settings->ActionScript);
+	xfc->actionScriptExists = winpr_PathFileExists(xfc->common.context.settings->ActionScript);
 
 	if (!xfc->actionScriptExists)
 		return FALSE;
@@ -75,7 +75,7 @@ static BOOL xf_keyboard_action_script_init(xfContext* xfc)
 
 	obj = ArrayList_Object(xfc->keyCombinations);
 	obj->fnObjectFree = free;
-	sprintf_s(command, sizeof(command), "%s key", xfc->context.settings->ActionScript);
+	sprintf_s(command, sizeof(command), "%s key", xfc->common.context.settings->ActionScript);
 	keyScript = popen(command, "r");
 
 	if (!keyScript)
@@ -118,10 +118,10 @@ static void xf_keyboard_action_script_free(xfContext* xfc)
 BOOL xf_keyboard_init(xfContext* xfc)
 {
 	xf_keyboard_clear(xfc);
-	xfc->KeyboardLayout = xfc->context.settings->KeyboardLayout;
-	xfc->KeyboardLayout =
-	    freerdp_keyboard_init_ex(xfc->KeyboardLayout, xfc->context.settings->KeyboardRemappingList);
-	xfc->context.settings->KeyboardLayout = xfc->KeyboardLayout;
+	xfc->KeyboardLayout = xfc->common.context.settings->KeyboardLayout;
+	xfc->KeyboardLayout = freerdp_keyboard_init_ex(
+	    xfc->KeyboardLayout, xfc->common.context.settings->KeyboardRemappingList);
+	xfc->common.context.settings->KeyboardLayout = xfc->KeyboardLayout;
 
 	if (xfc->modifierMap)
 		XFreeModifiermap(xfc->modifierMap);
@@ -187,9 +187,10 @@ void xf_keyboard_release_all_keypress(xfContext* xfc)
 			// release tab before releasing the windows key.
 			// this stops the start menu from opening on unfocus event.
 			if (rdp_scancode == RDP_SCANCODE_LWIN)
-				freerdp_input_send_keyboard_event_ex(xfc->context.input, FALSE, RDP_SCANCODE_TAB);
+				freerdp_input_send_keyboard_event_ex(xfc->common.context.input, FALSE,
+				                                     RDP_SCANCODE_TAB);
 
-			freerdp_input_send_keyboard_event_ex(xfc->context.input, FALSE, rdp_scancode);
+			freerdp_input_send_keyboard_event_ex(xfc->common.context.input, FALSE, rdp_scancode);
 			xfc->KeyboardState[keycode] = FALSE;
 		}
 	}
@@ -210,7 +211,7 @@ void xf_keyboard_send_key(xfContext* xfc, BOOL down, const XKeyEvent* event)
 	WINPR_ASSERT(xfc);
 	WINPR_ASSERT(event);
 
-	input = xfc->context.input;
+	input = xfc->common.context.input;
 	WINPR_ASSERT(input);
 
 	rdp_scancode = freerdp_keyboard_get_rdp_scancode_from_x11_keycode(event->keycode);
@@ -229,7 +230,7 @@ void xf_keyboard_send_key(xfContext* xfc, BOOL down, const XKeyEvent* event)
 	else
 	{
 		BOOL rc;
-		if (freerdp_settings_get_bool(xfc->context.settings, FreeRDP_UnicodeInput))
+		if (freerdp_settings_get_bool(xfc->common.context.settings, FreeRDP_UnicodeInput))
 		{
 			wchar_t buffer[32] = { 0 };
 			int rc = 0;
@@ -402,7 +403,7 @@ void xf_keyboard_focus_in(xfContext* xfc)
 	if (!xfc->display || !xfc->window)
 		return;
 
-	input = xfc->context.input;
+	input = xfc->common.context.input;
 	syncFlags = xf_keyboard_get_toggle_keys_state(xfc);
 	freerdp_input_send_focus_in_event(input, syncFlags);
 	xk_keyboard_update_modifier_keys(xfc);
@@ -479,7 +480,7 @@ static int xf_keyboard_execute_action_script(xfContext* xfc, XF_MODIFIER_KEYS* m
 	if (!match)
 		return 1;
 
-	sprintf_s(command, sizeof(command), "%s key %s", xfc->context.settings->ActionScript,
+	sprintf_s(command, sizeof(command), "%s key %s", xfc->common.context.settings->ActionScript,
 	          combination);
 	keyScript = popen(command, "r");
 
@@ -574,7 +575,7 @@ BOOL xf_keyboard_handle_special_keys(xfContext* xfc, KeySym keysym)
 
 	if (!xfc->remote_app && xfc->settings->MultiTouchGestures)
 	{
-		rdpContext* ctx = &xfc->context;
+		rdpContext* ctx = &xfc->common.context;
 
 		if (mod.Ctrl && mod.Alt)
 		{

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -417,7 +417,6 @@ void xf_keyboard_focus_in(xfContext* xfc)
 		if (x >= 0 && x < xfc->window->width && y >= 0 && y < xfc->window->height)
 		{
 			xf_event_adjust_coordinates(xfc, &x, &y);
-			freerdp_input_send_mouse_event(input, PTR_FLAGS_MOVE, x, y);
 		}
 	}
 }

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -676,6 +676,7 @@ void xf_keyboard_handle_special_keys_release(xfContext* xfc, KeySym keysym)
 
 		xfc->mouse_active = FALSE;
 		XUngrabKeyboard(xfc->display, CurrentTime);
+		XUngrabPointer(xfc->display, CurrentTime);
 	}
 
 	// ungrabbed

--- a/client/X11/xf_monitor.c
+++ b/client/X11/xf_monitor.c
@@ -116,7 +116,7 @@ int xf_list_monitors(xfContext* xfc)
 static BOOL xf_is_monitor_id_active(xfContext* xfc, UINT32 id)
 {
 	UINT32 index;
-	rdpSettings* settings = xfc->context.settings;
+	rdpSettings* settings = xfc->common.context.settings;
 
 	if (!settings->NumMonitorIds)
 		return TRUE;
@@ -150,10 +150,10 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pMaxWidth, UINT32* pMaxHeight)
 	BOOL useXRandr = FALSE;
 #endif
 
-	if (!xfc || !pMaxWidth || !pMaxHeight || !xfc->context.settings)
+	if (!xfc || !pMaxWidth || !pMaxHeight || !xfc->common.context.settings)
 		return FALSE;
 
-	settings = xfc->context.settings;
+	settings = xfc->common.context.settings;
 	vscreen = &xfc->vscreen;
 	*pMaxWidth = settings->DesktopWidth;
 	*pMaxHeight = settings->DesktopHeight;

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -153,7 +153,7 @@ void xf_rail_end_local_move(xfContext* xfc, xfAppWindow* appWindow)
 	Window root_window;
 	Window child_window;
 	RAIL_WINDOW_MOVE_ORDER windowMove;
-	rdpInput* input = xfc->context.input;
+	rdpInput* input = xfc->common.context.input;
 	/*
 	 * For keyboard moves send and explicit update to RDP server
 	 */
@@ -798,7 +798,7 @@ static UINT xf_rail_server_execute_result(RailClientContext* context,
 	{
 		WLog_ERR(TAG, "RAIL exec error: execResult=%s NtError=0x%X\n",
 		         error_code_names[execResult->execResult], execResult->rawResult);
-		freerdp_abort_connect(xfc->context.instance);
+		freerdp_abort_connect(xfc->common.context.instance);
 	}
 	else
 	{
@@ -827,7 +827,7 @@ static UINT xf_rail_server_start_cmd(RailClientContext* context)
 	RAIL_SYSPARAM_ORDER sysparam = { 0 };
 	RAIL_CLIENT_STATUS_ORDER clientStatus = { 0 };
 	xfContext* xfc = (xfContext*)context->custom;
-	rdpSettings* settings = xfc->context.settings;
+	rdpSettings* settings = xfc->common.context.settings;
 	clientStatus.flags = TS_RAIL_CLIENTSTATUS_ALLOWLOCALMOVESIZE;
 
 	if (settings->AutoReconnectionEnabled)
@@ -1111,7 +1111,7 @@ int xf_rail_init(xfContext* xfc, RailClientContext* rail)
 		wObject* obj = HashTable_ValueObject(xfc->railWindows);
 		obj->fnObjectFree = rail_window_free;
 	}
-	xfc->railIconCache = RailIconCache_New(xfc->context.settings);
+	xfc->railIconCache = RailIconCache_New(xfc->common.context.settings);
 
 	if (!xfc->railIconCache)
 	{

--- a/client/X11/xf_video.c
+++ b/client/X11/xf_video.c
@@ -72,7 +72,8 @@ static BOOL xfVideoShowSurface(VideoClientContext* video, const VideoSurface* su
 
 #ifdef WITH_XRENDER
 
-	if (xfc->context.settings->SmartSizing || xfc->context.settings->MultiTouchGestures)
+	if (xfc->common.context.settings->SmartSizing ||
+	    xfc->common.context.settings->MultiTouchGestures)
 	{
 		XPutImage(xfc->display, xfc->primary, xfc->gc, xfSurface->image, 0, 0, surface->x,
 		          surface->y, surface->w, surface->h);
@@ -106,7 +107,7 @@ void xf_video_control_init(xfContext* xfc, VideoClientContext* video)
 	WINPR_ASSERT(xfc);
 	WINPR_ASSERT(video);
 
-	gdi_video_control_init(xfc->context.gdi, video);
+	gdi_video_control_init(xfc->common.context.gdi, video);
 
 	/* X11 needs to be able to handle 32bpp colors directly. */
 	if (xfc->depth >= 24)
@@ -120,5 +121,5 @@ void xf_video_control_init(xfContext* xfc, VideoClientContext* video)
 
 void xf_video_control_uninit(xfContext* xfc, VideoClientContext* video)
 {
-	gdi_video_control_uninit(xfc->context.gdi, video);
+	gdi_video_control_uninit(xfc->common.context.gdi, video);
 }

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -156,7 +156,7 @@ void xf_SetWindowMinimized(xfContext* xfc, xfWindow* window)
 void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 {
 	UINT32 i;
-	rdpSettings* settings = xfc->context.settings;
+	rdpSettings* settings = xfc->common.context.settings;
 	int startX, startY;
 	UINT32 width = window->width;
 	UINT32 height = window->height;
@@ -190,21 +190,21 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 	if (fullscreen)
 	{
 		/* Initialize startX and startY with reasonable values */
-		startX = xfc->context.settings->MonitorDefArray[0].x;
-		startY = xfc->context.settings->MonitorDefArray[0].y;
+		startX = xfc->common.context.settings->MonitorDefArray[0].x;
+		startY = xfc->common.context.settings->MonitorDefArray[0].y;
 
 		/* Search all monitors to find the lowest startX and startY values */
-		for (i = 0; i < xfc->context.settings->MonitorCount; i++)
+		for (i = 0; i < xfc->common.context.settings->MonitorCount; i++)
 		{
-			startX = MIN(startX, xfc->context.settings->MonitorDefArray[i].x);
-			startY = MIN(startY, xfc->context.settings->MonitorDefArray[i].y);
+			startX = MIN(startX, xfc->common.context.settings->MonitorDefArray[i].x);
+			startY = MIN(startY, xfc->common.context.settings->MonitorDefArray[i].y);
 		}
 
 		/* Lastly apply any monitor shift(translation from remote to local coordinate system)
 		 *  to startX and startY values
 		 */
-		startX += xfc->context.settings->MonitorLocalShiftX;
-		startY += xfc->context.settings->MonitorLocalShiftY;
+		startX += xfc->common.context.settings->MonitorLocalShiftX;
+		startY += xfc->common.context.settings->MonitorLocalShiftY;
 	}
 
 	/*
@@ -481,8 +481,8 @@ xfWindow* xf_CreateDesktopWindow(xfContext* xfc, char* name, int width, int heig
 	if (!window)
 		return NULL;
 
-	settings = xfc->context.settings;
-	parentWindow = (Window)xfc->context.settings->ParentWindowId;
+	settings = xfc->common.context.settings;
+	parentWindow = (Window)xfc->common.context.settings->ParentWindowId;
 	window->width = width;
 	window->height = height;
 	window->decorations = xfc->decorations;
@@ -532,8 +532,8 @@ xfWindow* xf_CreateDesktopWindow(xfContext* xfc, char* name, int width, int heig
 	{
 		classHints->res_name = "xfreerdp";
 
-		if (xfc->context.settings->WmClass)
-			classHints->res_class = xfc->context.settings->WmClass;
+		if (xfc->common.context.settings->WmClass)
+			classHints->res_class = xfc->common.context.settings->WmClass;
 		else
 			classHints->res_class = "xfreerdp";
 
@@ -577,7 +577,7 @@ xfWindow* xf_CreateDesktopWindow(xfContext* xfc, char* name, int width, int heig
 	 * monitor instead of the upper-left monitor for remote app mode (which uses all monitors).
 	 * This extra call after the window is mapped will position the login window correctly
 	 */
-	if (xfc->context.settings->RemoteApplicationMode)
+	if (xfc->common.context.settings->RemoteApplicationMode)
 	{
 		XMoveWindow(xfc->display, window->handle, 0, 0);
 	}
@@ -602,7 +602,7 @@ void xf_ResizeDesktopWindow(xfContext* xfc, xfWindow* window, int width, int hei
 	if (!xfc || !window)
 		return;
 
-	settings = xfc->context.settings;
+	settings = xfc->common.context.settings;
 
 	if (!(size_hints = XAllocSizeHints()))
 		return;
@@ -804,9 +804,9 @@ int xf_AppWindowCreate(xfContext* xfc, xfAppWindow* appWindow)
 	{
 		char* class = NULL;
 
-		if (xfc->context.settings->WmClass)
+		if (xfc->common.context.settings->WmClass)
 		{
-			class_hints->res_class = xfc->context.settings->WmClass;
+			class_hints->res_class = xfc->common.context.settings->WmClass;
 		}
 		else
 		{
@@ -1075,7 +1075,7 @@ void xf_UpdateWindowArea(xfContext* xfc, xfAppWindow* appWindow, int x, int y, i
 
 	xf_lock_x11(xfc);
 
-	if (xfc->context.settings->SoftwareGdi)
+	if (xfc->common.context.settings->SoftwareGdi)
 	{
 		XPutImage(xfc->display, xfc->primary, appWindow->gc, xfc->image, ax, ay, ax, ay, width,
 		          height);

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -46,10 +46,6 @@ typedef struct xf_context xfContext;
 #include <freerdp/client/tsmf.h>
 #endif
 
-#if defined(CHANNEL_AINPUT_CLIENT)
-#include <freerdp/client/ainput.h>
-#endif
-
 #include <freerdp/gdi/gdi.h>
 #include <freerdp/codec/rfx.h>
 #include <freerdp/codec/nsc.h>
@@ -145,8 +141,7 @@ typedef struct touch_contact
 
 struct xf_context
 {
-	rdpContext context;
-	DEFINE_RDP_CLIENT_COMMON();
+	rdpClientContext common;
 
 	GC gc;
 	int xfds;
@@ -273,14 +268,9 @@ struct xf_context
 	TsmfClientContext* tsmf;
 #endif
 
-#if defined(CHANNEL_AINPUT_CLIENT)
-	AInputClientContext* ainput;
-#endif
-
 	xfClipboard* clipboard;
 	CliprdrClientContext* cliprdr;
 	xfVideoContext* xfVideo;
-	RdpeiClientContext* rdpei;
 	EncomspClientContext* encomsp;
 	xfDispContext* xfDisp;
 

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -46,6 +46,10 @@ typedef struct xf_context xfContext;
 #include <freerdp/client/tsmf.h>
 #endif
 
+#if defined(CHANNEL_AINPUT_CLIENT)
+#include <freerdp/client/ainput.h>
+#endif
+
 #include <freerdp/gdi/gdi.h>
 #include <freerdp/codec/rfx.h>
 #include <freerdp/codec/nsc.h>
@@ -267,6 +271,10 @@ struct xf_context
 	/* Channels */
 #if defined(CHANNEL_TSMF_CLIENT)
 	TsmfClientContext* tsmf;
+#endif
+
+#if defined(CHANNEL_AINPUT_CLIENT)
+	AInputClientContext* ainput;
 #endif
 
 	xfClipboard* clipboard;

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -1055,8 +1055,18 @@ static INLINE BOOL ainput_send_diff_event(rdpClientContext* cctx, UINT64 flags, 
 	WINPR_ASSERT(cctx->ainput);
 	WINPR_ASSERT(cctx->ainput->AInputSendInputEvent);
 
-	curX = x - cctx->lastX;
-	curY = y - cctx->lastY;
+	if (freerdp_settings_get_bool(cctx->context.settings, FreeRDP_MouseUseRelativeMove))
+	{
+		flags |= AINPUT_FLAGS_REL;
+
+		curX = x - cctx->lastX;
+		curY = y - cctx->lastY;
+	}
+	else
+	{
+		curX = x;
+		curY = y;
+	}
 	rc = cctx->ainput->AInputSendInputEvent(cctx->ainput, flags, curX, curY);
 
 	cctx->lastX = curX;
@@ -1079,8 +1089,6 @@ BOOL freerdp_client_send_button_event(rdpClientContext* cctx, UINT16 mflags, UIN
 	{
 		UINT64 flags = 0;
 
-		if (freerdp_settings_get_bool(cctx->context.settings, FreeRDP_MouseUseRelativeMove))
-			flags |= AINPUT_FLAGS_REL;
 		if (mflags & PTR_FLAGS_DOWN)
 			flags |= AINPUT_FLAGS_DOWN;
 		if (mflags & PTR_FLAGS_BUTTON1)
@@ -1113,8 +1121,6 @@ BOOL freerdp_client_send_extended_button_event(rdpClientContext* cctx, UINT16 mf
 	{
 		UINT64 flags = 0;
 
-		if (freerdp_settings_get_bool(cctx->context.settings, FreeRDP_MouseUseRelativeMove))
-			flags |= AINPUT_FLAGS_REL;
 		if (mflags & PTR_XFLAGS_DOWN)
 			flags |= AINPUT_FLAGS_DOWN;
 		if (mflags & PTR_XFLAGS_BUTTON1)

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -917,9 +917,9 @@ BOOL client_auto_reconnect_ex(freerdp* instance, BOOL (*window_events)(freerdp* 
 	return FALSE;
 }
 
-void freerdp_client_OnChannelConnectedEventHandler(void* context, const wEventArgs* ge)
+void freerdp_client_OnChannelConnectedEventHandler(void* context,
+                                                   const ChannelConnectedEventArgs* e)
 {
-	const ChannelConnectedEventArgs* e = (const ChannelConnectedEventArgs*)ge;
 	rdpClientContext* cctx = (rdpClientContext*)context;
 
 	WINPR_ASSERT(cctx);
@@ -962,9 +962,9 @@ void freerdp_client_OnChannelConnectedEventHandler(void* context, const wEventAr
 #endif
 }
 
-void freerdp_client_OnChannelDisconnectedEventHandler(void* context, const wEventArgs* ge)
+void freerdp_client_OnChannelDisconnectedEventHandler(void* context,
+                                                      const ChannelDisconnectedEventArgs* e)
 {
-	const ChannelDisconnectedEventArgs* e = (const ChannelDisconnectedEventArgs*)ge;
 	rdpClientContext* cctx = (rdpClientContext*)context;
 
 	WINPR_ASSERT(cctx);

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -46,6 +46,10 @@
 #include <freerdp/channels/urbdrc.h>
 #include <freerdp/channels/rdpdr.h>
 
+#if defined(CHANNEL_AINPUT_CLIENT)
+#include <freerdp/channels/ainput.h>
+#endif
+
 #include <freerdp/client/cmdline.h>
 #include <freerdp/version.h>
 
@@ -3527,6 +3531,16 @@ static BOOL freerdp_client_load_static_channel_addin(rdpChannels* channels, rdpS
 BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 {
 	UINT32 index;
+
+	/* Always load FreeRDP advanced input dynamic channel */
+#if defined(CHANNEL_AINPUT_CLIENT)
+	{
+		const char* p[] = { AINPUT_DVC_CHANNEL_NAME };
+
+		if (!freerdp_client_add_dynamic_channel(settings, ARRAYSIZE(p), p))
+			return FALSE;
+	}
+#endif
 
 	if (settings->AudioPlayback)
 	{

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3535,7 +3535,7 @@ BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 	/* Always load FreeRDP advanced input dynamic channel */
 #if defined(CHANNEL_AINPUT_CLIENT)
 	{
-		const char* p[] = { AINPUT_DVC_CHANNEL_NAME };
+		const char* p[] = { AINPUT_CHANNEL_NAME };
 
 		if (!freerdp_client_add_dynamic_channel(settings, ARRAYSIZE(p), p))
 			return FALSE;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2923,6 +2923,10 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 		{
 			settings->GrabMouse = enable;
 		}
+		CommandLineSwitchCase(arg, "mouse-relative")
+		{
+			settings->MouseUseRelativeMove = enable;
+		}
 		CommandLineSwitchCase(arg, "unmap-buttons")
 		{
 			settings->UnmapButtons = enable;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -245,6 +245,8 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "Select monitors to use" },
 	{ "mouse-motion", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
 	  "Send mouse motion" },
+	{ "mouse-relative", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
+	  "Send mouse motion with relative addressing" },
 #if defined(CHANNEL_TSMF_CLIENT)
 	{ "multimedia", COMMAND_LINE_VALUE_OPTIONAL, "[sys:<sys>,][dev:<dev>,][decoder:<decoder>]",
 	  NULL, NULL, -1, "mmr", "[DEPRECATED] Redirect multimedia (video) use /video instead" },

--- a/client/iOS/FreeRDP/ios_freerdp.m
+++ b/client/iOS/FreeRDP/ios_freerdp.m
@@ -28,7 +28,7 @@
 
 #pragma mark Connection helpers
 
-static void ios_OnChannelConnectedEventHandler(void *context, ChannelConnectedEventArgs *e)
+static void ios_OnChannelConnectedEventHandler(void *context, const ChannelConnectedEventArgs *e)
 {
 	rdpSettings *settings;
 	mfContext *afc;
@@ -56,7 +56,7 @@ static void ios_OnChannelConnectedEventHandler(void *context, ChannelConnectedEv
 	}
 }
 
-static void ios_OnChannelDisconnectedEventHandler(void *context, ChannelDisconnectedEventArgs *e)
+static void ios_OnChannelDisconnectedEventHandler(void *context, const ChannelDisconnectedEventArgs *e)
 {
 	rdpSettings *settings;
 	mfContext *afc;

--- a/config.h.in
+++ b/config.h.in
@@ -67,6 +67,9 @@
 #cmakedefine WITH_RDPDR
 
 /* Channels */
+#cmakedefine CHANNEL_AINPUT
+#cmakedefine CHANNEL_AINPUT_CLIENT
+#cmakedefine CHANNEL_AINPUT_SERVER
 #cmakedefine CHANNEL_AUDIN
 #cmakedefine CHANNEL_AUDIN_CLIENT
 #cmakedefine CHANNEL_AUDIN_SERVER
@@ -88,6 +91,9 @@
 #cmakedefine CHANNEL_ENCOMSP
 #cmakedefine CHANNEL_ENCOMSP_CLIENT
 #cmakedefine CHANNEL_ENCOMSP_SERVER
+#cmakedefine CHANNEL_GEOMETRY
+#cmakedefine CHANNEL_GEOMETRY_CLIENT
+#cmakedefine CHANNEL_GEOMETRY_SERVER
 #cmakedefine CHANNEL_GFXREDIR
 #cmakedefine CHANNEL_GFXREDIR_CLIENT
 #cmakedefine CHANNEL_GFXREDIR_SERVER
@@ -97,6 +103,9 @@
 #cmakedefine CHANNEL_PRINTER
 #cmakedefine CHANNEL_PRINTER_CLIENT
 #cmakedefine CHANNEL_PRINTER_SERVER
+#cmakedefine CHANNEL_RDPEI
+#cmakedefine CHANNEL_RDPEI_CLIENT
+#cmakedefine CHANNEL_RDPEI_SERVER
 #cmakedefine CHANNEL_RAIL
 #cmakedefine CHANNEL_RAIL_CLIENT
 #cmakedefine CHANNEL_RAIL_SERVER
@@ -133,9 +142,9 @@
 #cmakedefine CHANNEL_URBDRC
 #cmakedefine CHANNEL_URBDRC_CLIENT
 #cmakedefine CHANNEL_URBDRC_SERVER
-#cmakedefine CHANNEL_AINPUT
-#cmakedefine CHANNEL_AINPUT_CLIENT
-#cmakedefine CHANNEL_AINPUT_SERVER
+#cmakedefine CHANNEL_VIDEO
+#cmakedefine CHANNEL_VIDEO_CLIENT
+#cmakedefine CHANNEL_VIDEO_SERVER
 
 /* Debug */
 #cmakedefine WITH_DEBUG_CERTIFICATE

--- a/config.h.in
+++ b/config.h.in
@@ -133,6 +133,9 @@
 #cmakedefine CHANNEL_URBDRC
 #cmakedefine CHANNEL_URBDRC_CLIENT
 #cmakedefine CHANNEL_URBDRC_SERVER
+#cmakedefine CHANNEL_AINPUT
+#cmakedefine CHANNEL_AINPUT_CLIENT
+#cmakedefine CHANNEL_AINPUT_SERVER
 
 /* Debug */
 #cmakedefine WITH_DEBUG_CERTIFICATE

--- a/include/freerdp/channels/ainput.h
+++ b/include/freerdp/channels/ainput.h
@@ -1,0 +1,30 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Audio Input Redirection Virtual Channel
+ *
+ * Copyright 2022 Armin Novak <anovak@thincast.com>
+ * Copyright 2022 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_AINPUT_H
+#define FREERDP_CHANNEL_AINPUT_H
+
+#include <freerdp/api.h>
+#include <freerdp/dvc.h>
+#include <freerdp/types.h>
+
+#define AINPUT_DVC_CHANNEL_NAME "FreeRDP::Advanced::Input"
+
+#endif /* FREERDP_CHANNEL_AINPUT_H */

--- a/include/freerdp/channels/ainput.h
+++ b/include/freerdp/channels/ainput.h
@@ -25,6 +25,7 @@
 #include <freerdp/dvc.h>
 #include <freerdp/types.h>
 
+#define AINPUT_CHANNEL_NAME "ainput"
 #define AINPUT_DVC_CHANNEL_NAME "FreeRDP::Advanced::Input"
 
 #endif /* FREERDP_CHANNEL_AINPUT_H */

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -24,11 +24,9 @@
 #include "config.h"
 #endif
 
-#include <winpr/windows.h>
-#include <freerdp/event.h>
-
 #include <freerdp/api.h>
 #include <freerdp/freerdp.h>
+#include <freerdp/event.h>
 
 #if defined(CHANNEL_AINPUT_CLIENT)
 #include <freerdp/client/ainput.h>
@@ -123,10 +121,12 @@ extern "C"
 	FREERDP_API BOOL client_cli_authenticate_ex(freerdp* instance, char** username, char** password,
 	                                            char** domain, rdp_auth_reason reason);
 
-	FREERDP_API void freerdp_client_OnChannelConnectedEventHandler(void* context,
-	                                                               const wEventArgs* e);
-	FREERDP_API void freerdp_client_OnChannelDisconnectedEventHandler(void* context,
-	                                                                  const wEventArgs* e);
+	FREERDP_API void
+	freerdp_client_OnChannelConnectedEventHandler(void* context,
+	                                              const struct _ChannelConnectedEventArgs* e);
+	FREERDP_API void
+	freerdp_client_OnChannelDisconnectedEventHandler(void* context,
+	                                                 const struct _ChannelDisconnectedEventArgs* e);
 
 #if defined(WITH_FREERDP_DEPRECATED)
 	FREERDP_API WINPR_DEPRECATED_VAR("Use client_cli_authenticate_ex",

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -123,10 +123,10 @@ extern "C"
 
 	FREERDP_API void
 	freerdp_client_OnChannelConnectedEventHandler(void* context,
-	                                              const struct _ChannelConnectedEventArgs* e);
+	                                              const ChannelConnectedEventArgs* e);
 	FREERDP_API void
 	freerdp_client_OnChannelDisconnectedEventHandler(void* context,
-	                                                 const struct _ChannelDisconnectedEventArgs* e);
+	                                                 const ChannelDisconnectedEventArgs* e);
 
 #if defined(WITH_FREERDP_DEPRECATED)
 	FREERDP_API WINPR_DEPRECATED_VAR("Use client_cli_authenticate_ex",

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -20,8 +20,23 @@
 #ifndef FREERDP_CLIENT_H
 #define FREERDP_CLIENT_H
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <winpr/windows.h>
+#include <freerdp/event.h>
+
 #include <freerdp/api.h>
 #include <freerdp/freerdp.h>
+
+#if defined(CHANNEL_AINPUT_CLIENT)
+#include <freerdp/client/ainput.h>
+#endif
+
+#if defined(CHANNEL_RDPEI_CLIENT)
+#include <freerdp/client/rdpei.h>
+#endif
 
 #ifdef __cplusplus
 extern "C"
@@ -65,13 +80,18 @@ extern "C"
 	typedef int (*pRdpClientEntry)(RDP_CLIENT_ENTRY_POINTS* pEntryPoints);
 
 	/* Common Client Interface */
-
-#define DEFINE_RDP_CLIENT_COMMON() HANDLE thread
-
 	struct rdp_client_context
 	{
 		rdpContext context;
-		DEFINE_RDP_CLIENT_COMMON();
+		HANDLE thread;
+#if defined(CHANNEL_AINPUT_CLIENT)
+		INT32 lastX, lastY;
+		AInputClientContext* ainput;
+#endif
+
+#if defined(CHANNEL_RDPEI_CLIENT)
+		RdpeiClientContext* rdpei;
+#endif
 	};
 
 	/* Common client functions */
@@ -103,15 +123,20 @@ extern "C"
 	FREERDP_API BOOL client_cli_authenticate_ex(freerdp* instance, char** username, char** password,
 	                                            char** domain, rdp_auth_reason reason);
 
+	FREERDP_API void freerdp_client_OnChannelConnectedEventHandler(void* context,
+	                                                               const wEventArgs* e);
+	FREERDP_API void freerdp_client_OnChannelDisconnectedEventHandler(void* context,
+	                                                                  const wEventArgs* e);
+
 #if defined(WITH_FREERDP_DEPRECATED)
 	FREERDP_API WINPR_DEPRECATED_VAR("Use client_cli_authenticate_ex",
 	                                 BOOL client_cli_authenticate(freerdp* instance,
 	                                                              char** username, char** password,
 	                                                              char** domain));
 	FREERDP_API
-	    WINPR_DEPRECATED_VAR("Use client_cli_authenticate_ex",
-	                         BOOL client_cli_gw_authenticate(freerdp* instance, char** username,
-	                                                         char** password, char** domain));
+	WINPR_DEPRECATED_VAR("Use client_cli_authenticate_ex",
+	                     BOOL client_cli_gw_authenticate(freerdp* instance, char** username,
+	                                                     char** password, char** domain));
 
 	FREERDP_API WINPR_DEPRECATED_VAR(
 	    "Use client_cli_verify_certificate_ex",
@@ -147,6 +172,16 @@ extern "C"
 	FREERDP_API BOOL client_auto_reconnect(freerdp* instance);
 	FREERDP_API BOOL client_auto_reconnect_ex(freerdp* instance,
 	                                          BOOL (*window_events)(freerdp* instance));
+
+	FREERDP_API BOOL freerdp_client_send_wheel_event(rdpClientContext* cctx, UINT16 mflags);
+
+	FREERDP_API BOOL freerdp_client_send_button_event(rdpClientContext* cctx, UINT16 mflags,
+	                                                  UINT16 x, UINT16 y);
+
+	FREERDP_API BOOL freerdp_client_send_extended_button_event(rdpClientContext* cctx,
+	                                                           UINT16 mflags, UINT16 x, UINT16 y);
+
+	FREERDP_API int freerdp_client_common_stop(rdpContext* context);
 
 #ifdef __cplusplus
 }

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -83,7 +83,6 @@ extern "C"
 		rdpContext context;
 		HANDLE thread;
 #if defined(CHANNEL_AINPUT_CLIENT)
-		INT32 lastX, lastY;
 		AInputClientContext* ainput;
 #endif
 
@@ -175,11 +174,12 @@ extern "C"
 
 	FREERDP_API BOOL freerdp_client_send_wheel_event(rdpClientContext* cctx, UINT16 mflags);
 
-	FREERDP_API BOOL freerdp_client_send_button_event(rdpClientContext* cctx, UINT16 mflags,
-	                                                  UINT16 x, UINT16 y);
+	FREERDP_API BOOL freerdp_client_send_button_event(rdpClientContext* cctx, BOOL relative,
+	                                                  UINT16 mflags, INT32 x, INT32 y);
 
 	FREERDP_API BOOL freerdp_client_send_extended_button_event(rdpClientContext* cctx,
-	                                                           UINT16 mflags, UINT16 x, UINT16 y);
+	                                                           BOOL relative, UINT16 mflags,
+	                                                           INT32 x, INT32 y);
 
 	FREERDP_API int freerdp_client_common_stop(rdpContext* context);
 

--- a/include/freerdp/client/ainput.h
+++ b/include/freerdp/client/ainput.h
@@ -1,0 +1,82 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Display Update Virtual Channel Extension
+ *
+ * Copyright 2013 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+ * Copyright 2015 Thincast Technologies GmbH
+ * Copyright 2015 DI (FH) Martin Haimberger <martin.haimberger@thincast.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_AINPUT_CLIENT_AINPUT_H
+#define FREERDP_CHANNEL_AINPUT_CLIENT_AINPUT_H
+
+#include <winpr/assert.h>
+#include <freerdp/channels/disp.h>
+
+typedef enum
+{
+	AINPUT_FLAGS_WHEEL = 0x0001,
+	AINPUT_FLAGS_HWHEEL = 0x0002,
+	AINPUT_FLAGS_MOVE = 0x0004,
+	AINPUT_FLAGS_DOWN = 0x0008,
+
+	AINPUT_FLAGS_REL = 0x0010,
+
+	/* Pointer Flags */
+	AINPUT_FLAGS_BUTTON1 = 0x1000, /* left */
+	AINPUT_FLAGS_BUTTON2 = 0x2000, /* right */
+	AINPUT_FLAGS_BUTTON3 = 0x4000, /* middle */
+
+	/* Extended Pointer Flags */
+	AINPUT_XFLAGS_BUTTON1 = 0x0100,
+	AINPUT_XFLAGS_BUTTON2 = 0x0200
+} AInputEventFlags;
+
+typedef struct ainput_client_context AInputClientContext;
+
+typedef UINT (*pcAInputSendInputEvent)(AInputClientContext* context, UINT64 flags, INT32 x,
+                                       INT32 y);
+
+struct ainput_client_context
+{
+	void* handle;
+	void* custom;
+
+	INT32 lastX;
+	INT32 lastY;
+
+	pcAInputSendInputEvent AInputSendInputEvent;
+};
+
+static INLINE BOOL ainput_send_diff_event(AInputClientContext* ainput, UINT64 flags, INT32 x,
+                                          INT32 y)
+{
+	UINT rc;
+	INT32 curX, curY;
+
+	WINPR_ASSERT(ainput);
+	WINPR_ASSERT(ainput->AInputSendInputEvent);
+
+	curX = x - ainput->lastX;
+	curY = y - ainput->lastY;
+	rc = ainput->AInputSendInputEvent(ainput, flags, curX, curY);
+
+	ainput->lastX = curX;
+	ainput->lastY = curY;
+
+	return rc == CHANNEL_RC_OK;
+}
+
+#endif /* FREERDP_CHANNEL_AINPUT_CLIENT_AINPUT_H */

--- a/include/freerdp/client/ainput.h
+++ b/include/freerdp/client/ainput.h
@@ -54,29 +54,7 @@ struct ainput_client_context
 	void* handle;
 	void* custom;
 
-	INT32 lastX;
-	INT32 lastY;
-
 	pcAInputSendInputEvent AInputSendInputEvent;
 };
-
-static INLINE BOOL ainput_send_diff_event(AInputClientContext* ainput, UINT64 flags, INT32 x,
-                                          INT32 y)
-{
-	UINT rc;
-	INT32 curX, curY;
-
-	WINPR_ASSERT(ainput);
-	WINPR_ASSERT(ainput->AInputSendInputEvent);
-
-	curX = x - ainput->lastX;
-	curY = y - ainput->lastY;
-	rc = ainput->AInputSendInputEvent(ainput, flags, curX, curY);
-
-	ainput->lastX = curX;
-	ainput->lastY = curY;
-
-	return rc == CHANNEL_RC_OK;
-}
 
 #endif /* FREERDP_CHANNEL_AINPUT_CLIENT_AINPUT_H */

--- a/include/freerdp/event.h
+++ b/include/freerdp/event.h
@@ -23,6 +23,8 @@
 #include <freerdp/api.h>
 #include <freerdp/freerdp.h>
 
+#include <winpr/collections.h>
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/include/freerdp/server/ainput.h
+++ b/include/freerdp/server/ainput.h
@@ -35,11 +35,12 @@ typedef struct _ainput_server_context ainput_server_context;
 
 typedef UINT (*psAInputServerOpen)(ainput_server_context* context);
 typedef UINT (*psAInputServerClose)(ainput_server_context* context);
+typedef BOOL (*psAInputServerIsOpen)(ainput_server_context* context);
 
 typedef UINT (*psAInputServerOpenResult)(ainput_server_context* context,
                                          AINPUT_SERVER_OPEN_RESULT result);
-typedef UINT (*psAInputServerReceive)(ainput_server_context* context, const BYTE* buffer,
-                                      UINT32 length);
+typedef UINT (*psAInputServerMouseEvent)(ainput_server_context* context, UINT64 flags, INT32 x,
+                                         INT32 y);
 
 struct _ainput_server_context
 {
@@ -57,16 +58,17 @@ struct _ainput_server_context
 	 * Close the ainput channel.
 	 */
 	psAInputServerClose Close;
+	/**
+	 * Status of the ainput channel.
+	 */
+	psAInputServerIsOpen IsOpen;
 
 	/*** Callbacks registered by the server. ***/
+
 	/**
-	 * Indicate whether the channel is opened successfully.
+	 * Receive ainput mouse event PDU.
 	 */
-	psAInputServerOpenResult OpenResult;
-	/**
-	 * Receive ainput response PDU.
-	 */
-	psAInputServerReceive Receive;
+	psAInputServerMouseEvent MouseEvent;
 
 	rdpContext* rdpcontext;
 };

--- a/include/freerdp/server/ainput.h
+++ b/include/freerdp/server/ainput.h
@@ -1,0 +1,86 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * AInput Virtual Channel Extension
+ *
+ * Copyright 2022 Armin Novak <anovak@thincast.com>
+ * Copyright 2022 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_AINPUT_SERVER_H
+#define FREERDP_CHANNEL_AINPUT_SERVER_H
+
+#include <freerdp/channels/wtsvc.h>
+
+typedef enum AINPUT_SERVER_OPEN_RESULT
+{
+	AINPUT_SERVER_OPEN_RESULT_OK = 0,
+	AINPUT_SERVER_OPEN_RESULT_CLOSED = 1,
+	AINPUT_SERVER_OPEN_RESULT_NOTSUPPORTED = 2,
+	AINPUT_SERVER_OPEN_RESULT_ERROR = 3
+} AINPUT_SERVER_OPEN_RESULT;
+
+typedef struct _ainput_server_context ainput_server_context;
+
+typedef UINT (*psAInputServerOpen)(ainput_server_context* context);
+typedef UINT (*psAInputServerClose)(ainput_server_context* context);
+
+typedef UINT (*psAInputServerOpenResult)(ainput_server_context* context,
+                                         AINPUT_SERVER_OPEN_RESULT result);
+typedef UINT (*psAInputServerReceive)(ainput_server_context* context, const BYTE* buffer,
+                                      UINT32 length);
+
+struct _ainput_server_context
+{
+	HANDLE vcm;
+
+	/* Server self-defined pointer. */
+	void* data;
+
+	/*** APIs called by the server. ***/
+	/**
+	 * Open the ainput channel.
+	 */
+	psAInputServerOpen Open;
+	/**
+	 * Close the ainput channel.
+	 */
+	psAInputServerClose Close;
+
+	/*** Callbacks registered by the server. ***/
+	/**
+	 * Indicate whether the channel is opened successfully.
+	 */
+	psAInputServerOpenResult OpenResult;
+	/**
+	 * Receive ainput response PDU.
+	 */
+	psAInputServerReceive Receive;
+
+	rdpContext* rdpcontext;
+};
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+	FREERDP_API ainput_server_context* ainput_server_context_new(HANDLE vcm);
+	FREERDP_API void ainput_server_context_free(ainput_server_context* context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FREERDP_CHANNEL_AINPUT_SERVER_H */

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -723,6 +723,7 @@ typedef struct _RDPDR_PARALLEL RDPDR_PARALLEL;
 #define FreeRDP_CredentialsFromStdin (1604)
 #define FreeRDP_UnmapButtons (1605)
 #define FreeRDP_OldLicenseBehaviour (1606)
+#define FreeRDP_MouseUseRelativeMove (1607)
 #define FreeRDP_ComputerName (1664)
 #define FreeRDP_ConnectionFile (1728)
 #define FreeRDP_AssistanceFile (1729)
@@ -1157,10 +1158,10 @@ struct rdp_settings
 	ALIGN64 BOOL PromptForCredentials; /* 1283 */
 
 	/* Settings used for smartcard emulation */
-	UINT64 padding1284[1285 - 1284];     /* 1284 */
-	ALIGN64 char* SmartcardCertificate;  /* 1285 */
-	ALIGN64 char* SmartcardPrivateKey;   /* 1286 */
-	UINT64 padding1344[1344 - 1287];     /* 1287 */
+	UINT64 padding1284[1285 - 1284];    /* 1284 */
+	ALIGN64 char* SmartcardCertificate; /* 1285 */
+	ALIGN64 char* SmartcardPrivateKey;  /* 1286 */
+	UINT64 padding1344[1344 - 1287];    /* 1287 */
 
 	/* Kerberos Authentication */
 	ALIGN64 char* KerberosKdc;       /* 1344 */
@@ -1225,7 +1226,8 @@ struct rdp_settings
 	ALIGN64 BOOL CredentialsFromStdin; /* 1604 */
 	ALIGN64 BOOL UnmapButtons;         /* 1605 */
 	ALIGN64 BOOL OldLicenseBehaviour;  /* 1606 */
-	UINT64 padding1664[1664 - 1607];   /* 1607 */
+	ALIGN64 BOOL MouseUseRelativeMove; /* 1607 */
+	UINT64 padding1664[1664 - 1608];   /* 1608 */
 
 	/* Names */
 	ALIGN64 char* ComputerName;      /* 1664 */

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -318,6 +318,9 @@ BOOL freerdp_settings_get_bool(const rdpSettings* settings, size_t id)
 		case FreeRDP_MouseMotion:
 			return settings->MouseMotion;
 
+		case FreeRDP_MouseUseRelativeMove:
+			return settings->MouseUseRelativeMove;
+
 		case FreeRDP_MstscCookieMode:
 			return settings->MstscCookieMode;
 
@@ -948,6 +951,10 @@ BOOL freerdp_settings_set_bool(rdpSettings* settings, size_t id, BOOL val)
 
 		case FreeRDP_MouseMotion:
 			settings->MouseMotion = cnv.c;
+			break;
+
+		case FreeRDP_MouseUseRelativeMove:
+			settings->MouseUseRelativeMove = cnv.c;
 			break;
 
 		case FreeRDP_MstscCookieMode:

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -109,6 +109,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_MouseAttached, 0, "FreeRDP_MouseAttached" },
 	{ FreeRDP_MouseHasWheel, 0, "FreeRDP_MouseHasWheel" },
 	{ FreeRDP_MouseMotion, 0, "FreeRDP_MouseMotion" },
+	{ FreeRDP_MouseUseRelativeMove, 0, "FreeRDP_MouseUseRelativeMove" },
 	{ FreeRDP_MstscCookieMode, 0, "FreeRDP_MstscCookieMode" },
 	{ FreeRDP_MultiTouchGestures, 0, "FreeRDP_MultiTouchGestures" },
 	{ FreeRDP_MultiTouchInput, 0, "FreeRDP_MultiTouchInput" },

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -591,14 +591,14 @@ const char* freerdp_get_build_revision(void)
 }
 
 static wEventType FreeRDP_Events[] = {
-	DEFINE_EVENT_ENTRY(WindowStateChange) DEFINE_EVENT_ENTRY(ResizeWindow)
-	    DEFINE_EVENT_ENTRY(LocalResizeWindow) DEFINE_EVENT_ENTRY(EmbedWindow)
-	        DEFINE_EVENT_ENTRY(PanningChange) DEFINE_EVENT_ENTRY(ZoomingChange)
-	            DEFINE_EVENT_ENTRY(ErrorInfo) DEFINE_EVENT_ENTRY(Terminate)
-	                DEFINE_EVENT_ENTRY(ConnectionResult) DEFINE_EVENT_ENTRY(ChannelConnected)
-	                    DEFINE_EVENT_ENTRY(ChannelDisconnected) DEFINE_EVENT_ENTRY(MouseEvent)
-	                        DEFINE_EVENT_ENTRY(Activated) DEFINE_EVENT_ENTRY(Timer)
-	                            DEFINE_EVENT_ENTRY(GraphicsReset)
+	DEFINE_EVENT_ENTRY(WindowStateChange),   DEFINE_EVENT_ENTRY(ResizeWindow),
+	DEFINE_EVENT_ENTRY(LocalResizeWindow),   DEFINE_EVENT_ENTRY(EmbedWindow),
+	DEFINE_EVENT_ENTRY(PanningChange),       DEFINE_EVENT_ENTRY(ZoomingChange),
+	DEFINE_EVENT_ENTRY(ErrorInfo),           DEFINE_EVENT_ENTRY(Terminate),
+	DEFINE_EVENT_ENTRY(ConnectionResult),    DEFINE_EVENT_ENTRY(ChannelConnected),
+	DEFINE_EVENT_ENTRY(ChannelDisconnected), DEFINE_EVENT_ENTRY(MouseEvent),
+	DEFINE_EVENT_ENTRY(Activated),           DEFINE_EVENT_ENTRY(Timer),
+	DEFINE_EVENT_ENTRY(GraphicsReset)
 };
 
 /** Allocator function for a rdp context.

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -98,6 +98,7 @@ static const size_t bool_list_indices[] = {
 	FreeRDP_MouseAttached,
 	FreeRDP_MouseHasWheel,
 	FreeRDP_MouseMotion,
+	FreeRDP_MouseUseRelativeMove,
 	FreeRDP_MstscCookieMode,
 	FreeRDP_MultiTouchGestures,
 	FreeRDP_MultiTouchInput,

--- a/libfreerdp/gdi/video.c
+++ b/libfreerdp/gdi/video.c
@@ -147,7 +147,7 @@ void gdi_video_control_uninit(rdpGdi* gdi, VideoClientContext* video)
 	gdi->video = NULL;
 }
 
-static void gdi_video_timer(void* context, TimerEventArgs* timer)
+static void gdi_video_timer(void* context, const TimerEventArgs* timer)
 {
 	rdpContext* ctx = (rdpContext*)context;
 	rdpGdi* gdi;

--- a/server/Sample/CMakeLists.txt
+++ b/server/Sample/CMakeLists.txt
@@ -18,15 +18,19 @@
 set(MODULE_NAME "sfreerdp-server")
 set(MODULE_PREFIX "FREERDP_SERVER_SAMPLE")
 
-set(${MODULE_PREFIX}_SRCS
+set(SRCS
 	sfreerdp.c
-	sfreerdp.h
+        sfreerdp.h
 	sf_audin.c
 	sf_audin.h
 	sf_rdpsnd.c
 	sf_rdpsnd.h
 	sf_encomsp.c
 	sf_encomsp.h)
+
+if (CHANNEL_AINPUT_SERVER)
+    list(APPEND SRCS sf_ainput.c sf_ainput.h)
+endif()
 
 	# On windows create dll version information.
 # Vendor, product and year are already set in top level CMakeLists.txt
@@ -41,15 +45,15 @@ if (WIN32)
     ${CMAKE_CURRENT_BINARY_DIR}/version.rc
     @ONLY)
 
-  set ( ${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_SRCS} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+  set ( SRCS ${SRCS} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
 endif()
 
-add_executable(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
+add_executable(${MODULE_NAME} ${SRCS})
 
-set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} freerdp-server)
-set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} winpr freerdp)
+list(APPEND LIBS freerdp-server)
+list(APPEND LIBS winpr freerdp)
 
-target_link_libraries(${MODULE_NAME} ${${MODULE_PREFIX}_LIBS})
+target_link_libraries(${MODULE_NAME} ${LIBS})
 install(TARGETS ${MODULE_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT server)
 if (WITH_DEBUG_SYMBOLS AND MSVC)
     install(FILES ${CMAKE_PDB_BINARY_DIR}/${MODULE_NAME}.pdb DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT symbols)

--- a/server/Sample/sf_ainput.c
+++ b/server/Sample/sf_ainput.c
@@ -1,0 +1,108 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * FreeRDP Sample Server (Advanced Input)
+ *
+ * Copyright 2022 Armin Novak <armin.novak@thincast.com>
+ * Copyright 2022 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <winpr/assert.h>
+
+#include "sfreerdp.h"
+
+#include "sf_ainput.h"
+
+#include <freerdp/server/server-common.h>
+#include <freerdp/server/ainput.h>
+
+#include <freerdp/log.h>
+#define TAG SERVER_TAG("sample.ainput")
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT sf_peer_ainput_opening(ainput_server_context* context)
+{
+	WINPR_ASSERT(context);
+
+	WLog_DBG(TAG, "ainput opening.");
+
+	return CHANNEL_RC_OK;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT sf_peer_ainput_mouse_event(ainput_server_context* context, UINT64 flags, INT32 x,
+                                       INT32 y)
+{
+	/* TODO: Implement */
+	WINPR_ASSERT(context);
+
+	WLog_WARN(TAG, "%s not implemented: 0x%08" PRIx64 ", %" PRId32 "x%" PRId32, __FUNCTION__, flags,
+	          x, y);
+	return CHANNEL_RC_OK;
+}
+
+void sf_peer_ainput_init(testPeerContext* context)
+{
+	WINPR_ASSERT(context);
+
+	context->ainput = ainput_server_context_new(context->vcm);
+	WINPR_ASSERT(context->ainput);
+
+	context->ainput->rdpcontext = &context->_p;
+	context->ainput->data = context;
+
+	context->ainput->MouseEvent = sf_peer_ainput_mouse_event;
+}
+
+BOOL sf_peer_ainput_start(testPeerContext* context)
+{
+	if (!context || !context->ainput || !context->ainput->Open)
+		return FALSE;
+
+	return context->ainput->Open(context->ainput) == CHANNEL_RC_OK;
+}
+
+BOOL sf_peer_ainput_stop(testPeerContext* context)
+{
+	if (!context || !context->ainput || !context->ainput->Close)
+		return FALSE;
+
+	return context->ainput->Close(context->ainput) == CHANNEL_RC_OK;
+}
+
+BOOL sf_peer_ainput_running(testPeerContext* context)
+{
+	if (!context || !context->ainput || !context->ainput->IsOpen)
+		return FALSE;
+
+	return context->ainput->IsOpen(context->ainput);
+}
+
+void sf_peer_ainput_uninit(testPeerContext* context)
+{
+	ainput_server_context_free(context->ainput);
+}

--- a/server/Sample/sf_ainput.h
+++ b/server/Sample/sf_ainput.h
@@ -1,8 +1,8 @@
 /**
  * FreeRDP: A Remote Desktop Protocol Implementation
- * Audio Input Redirection Virtual Channel
+ * FreeRDP Sample Server (Advanced Input)
  *
- * Copyright 2022 Armin Novak <anovak@thincast.com>
+ * Copyright 2022 Armin Novak <armin.novak@thincast.com>
  * Copyright 2022 Thincast Technologies GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,23 +18,20 @@
  * limitations under the License.
  */
 
-#ifndef FREERDP_CHANNEL_AINPUT_H
-#define FREERDP_CHANNEL_AINPUT_H
+#ifndef FREERDP_SERVER_SAMPLE_SF_AINPUT_H
+#define FREERDP_SERVER_SAMPLE_SF_AINPUT_H
 
-#include <freerdp/api.h>
-#include <freerdp/dvc.h>
-#include <freerdp/types.h>
+#include <freerdp/freerdp.h>
+#include <freerdp/listener.h>
+#include <freerdp/server/ainput.h>
 
-#define AINPUT_CHANNEL_NAME "ainput"
-#define AINPUT_DVC_CHANNEL_NAME "FreeRDP::Advanced::Input"
+#include "sfreerdp.h"
 
-typedef enum
-{
-	MSG_AINPUT_VERSION = 0x01,
-	MSG_AINPUT_MOUSE = 0x02
-} eAInputMsgType;
+void sf_peer_ainput_init(testPeerContext* context);
+void sf_peer_ainput_uninit(testPeerContext* context);
 
-#define AINPUT_VERSION_MAJOR 1
-#define AINPUT_VERSION_MINOR 0
+BOOL sf_peer_ainput_running(testPeerContext* context);
+BOOL sf_peer_ainput_start(testPeerContext* context);
+BOOL sf_peer_ainput_stop(testPeerContext* context);
 
-#endif /* FREERDP_CHANNEL_AINPUT_H */
+#endif /* FREERDP_SERVER_SAMPLE_SF_AINPUT_H */

--- a/server/Sample/sfreerdp.h
+++ b/server/Sample/sfreerdp.h
@@ -25,6 +25,9 @@
 #include <freerdp/codec/rfx.h>
 #include <freerdp/codec/nsc.h>
 #include <freerdp/channels/wtsvc.h>
+#if defined(CHANNEL_AINPUT_SERVER)
+#include <freerdp/server/ainput.h>
+#endif
 #include <freerdp/server/audin.h>
 #include <freerdp/server/rdpsnd.h>
 #include <freerdp/server/encomsp.h>
@@ -55,6 +58,10 @@ struct test_peer_context
 	HANDLE debug_channel_thread;
 	audin_server_context* audin;
 	BOOL audin_open;
+#if defined(CHANNEL_AINPUT_SERVER)
+	ainput_server_context* ainput;
+	BOOL ainput_open;
+#endif
 	UINT32 frame_id;
 	RdpsndServerContext* rdpsnd;
 	EncomspServerContext* encomsp;

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -69,7 +69,7 @@ static BOOL proxy_server_reactivate(rdpContext* ps, const rdpContext* pc)
 	return TRUE;
 }
 
-static void pf_client_on_error_info(void* ctx, ErrorInfoEventArgs* e)
+static void pf_client_on_error_info(void* ctx, const ErrorInfoEventArgs* e)
 {
 	pClientContext* pc = (pClientContext*)ctx;
 	pServerContext* ps;
@@ -91,7 +91,7 @@ static void pf_client_on_error_info(void* ctx, ErrorInfoEventArgs* e)
 	freerdp_send_error_info(ps->context.rdp);
 }
 
-static void pf_client_on_activated(void* ctx, ActivatedEventArgs* e)
+static void pf_client_on_activated(void* ctx, const ActivatedEventArgs* e)
 {
 	pClientContext* pc = (pClientContext*)ctx;
 	pServerContext* ps;

--- a/server/shadow/Win/win_rdp.c
+++ b/server/shadow/Win/win_rdp.c
@@ -28,22 +28,29 @@
 
 #define TAG SERVER_TAG("shadow.win")
 
-static void shw_OnChannelConnectedEventHandler(void* context, ChannelConnectedEventArgs* e)
+static void shw_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEventArgs* e)
 {
 	shwContext* shw = (shwContext*)context;
+	WINPR_ASSERT(e);
 	WLog_INFO(TAG, "OnChannelConnected: %s", e->name);
 }
 
-static void shw_OnChannelDisconnectedEventHandler(void* context, ChannelDisconnectedEventArgs* e)
+static void shw_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnectedEventArgs* e)
 {
 	shwContext* shw = (shwContext*)context;
+	WINPR_ASSERT(e);
 	WLog_INFO(TAG, "OnChannelDisconnected: %s", e->name);
 }
 
 static BOOL shw_begin_paint(rdpContext* context)
 {
 	shwContext* shw;
-	rdpGdi* gdi = context->gdi;
+	rdpGdi* gdi;
+
+	WINPR_ASSERT(context);
+	gdi = context->gdi;
+	WINPR_ASSERT(gdi);
+
 	shw = (shwContext*)context;
 	gdi->primary->hdc->hwnd->invalid->null = TRUE;
 	gdi->primary->hdc->hwnd->ninvalid = 0;
@@ -104,9 +111,10 @@ static int shw_verify_x509_certificate(freerdp* instance, const BYTE* data, size
 	return 1;
 }
 
-static void shw_OnConnectionResultEventHandler(void* context, ConnectionResultEventArgs* e)
+static void shw_OnConnectionResultEventHandler(void* context, const ConnectionResultEventArgs* e)
 {
 	shwContext* shw = (shwContext*)context;
+	WINPR_ASSERT(e);
 	WLog_INFO(TAG, "OnConnectionResult: %d", e->result);
 }
 
@@ -246,7 +254,7 @@ static int shw_freerdp_client_start(rdpContext* context)
 	freerdp* instance = context->instance;
 	shw = (shwContext*)context;
 
-	if (!(shw->thread = CreateThread(NULL, 0, shw_client_thread, instance, 0, NULL)))
+	if (!(shw->common.thread = CreateThread(NULL, 0, shw_client_thread, instance, 0, NULL)))
 	{
 		WLog_ERR(TAG, "Failed to create thread");
 		return -1;

--- a/server/shadow/Win/win_rdp.h
+++ b/server/shadow/Win/win_rdp.h
@@ -30,8 +30,7 @@ typedef struct shw_context shwContext;
 
 struct shw_context
 {
-	rdpContext context;
-	DEFINE_RDP_CLIENT_COMMON();
+	rdpClientContext common;
 
 	HANDLE StopEvent;
 	freerdp* instance;

--- a/server/shadow/Win/win_shadow.c
+++ b/server/shadow/Win/win_shadow.c
@@ -291,9 +291,17 @@ static int win_shadow_surface_copy(winShadowSubsystem* subsystem)
 		rdpGdi* gdi;
 		shwContext* shw;
 		rdpContext* context;
+
+		WINPR_ASSERT(subsystem);
 		shw = subsystem->shw;
-		context = &shw->context;
+		WINPR_ASSERT(shw);
+
+		context = &shw->common.context;
+		WINPR_ASSERT(context);
+
 		gdi = context->gdi;
+		WINPR_ASSERT(gdi);
+
 		pDstData = gdi->primary_buffer;
 		nDstStep = gdi->width * 4;
 		DstFormat = gdi->dstFormat;

--- a/winpr/include/winpr/collections.h
+++ b/winpr/include/winpr/collections.h
@@ -511,44 +511,49 @@ extern "C"
 	(_event_args)->e.Size = sizeof(*_event_args); \
 	(_event_args)->e.Sender = _sender
 
-#define DEFINE_EVENT_HANDLER(_name) \
-	typedef void (*p##_name##EventHandler)(void* context, const _name##EventArgs* e)
+#define DEFINE_EVENT_HANDLER(name) \
+	typedef void (*p##name##EventHandler)(void* context, const name##EventArgs* e)
 
-#define DEFINE_EVENT_RAISE(_name)                                                                 \
-	static INLINE int PubSub_On##_name(wPubSub* pubSub, void* context, const _name##EventArgs* e) \
+#define DEFINE_EVENT_RAISE(name)                                                                \
+	static INLINE int PubSub_On##name(wPubSub* pubSub, void* context, const name##EventArgs* e) \
+	{                                                                                           \
+		WINPR_ASSERT(e);                                                                        \
+		return PubSub_OnEvent(pubSub, #name, context, &e->e);                                   \
+	}
+
+#define DEFINE_EVENT_SUBSCRIBE(name)                                                              \
+	static INLINE int PubSub_Subscribe##name(wPubSub* pubSub, p##name##EventHandler EventHandler) \
 	{                                                                                             \
-		WINPR_ASSERT(e);                                                                          \
-		return PubSub_OnEvent(pubSub, #_name, context, &e->e);                                    \
+		return PubSub_Subscribe(pubSub, #name, (pEventHandler)EventHandler);                      \
 	}
 
-#define DEFINE_EVENT_SUBSCRIBE(_name)                                              \
-	static INLINE int PubSub_Subscribe##_name(wPubSub* pubSub,                     \
-	                                          p##_name##EventHandler EventHandler) \
+#define DEFINE_EVENT_UNSUBSCRIBE(name)                                             \
+	static INLINE int PubSub_Unsubscribe##name(wPubSub* pubSub,                    \
+	                                           p##name##EventHandler EventHandler) \
 	{                                                                              \
-		return PubSub_Subscribe(pubSub, #_name, (pEventHandler)EventHandler);      \
+		return PubSub_Unsubscribe(pubSub, #name, (pEventHandler)EventHandler);     \
 	}
 
-#define DEFINE_EVENT_UNSUBSCRIBE(_name)                                              \
-	static INLINE int PubSub_Unsubscribe##_name(wPubSub* pubSub,                     \
-	                                            p##_name##EventHandler EventHandler) \
-	{                                                                                \
-		return PubSub_Unsubscribe(pubSub, #_name, (pEventHandler)EventHandler);      \
-	}
-
-#define DEFINE_EVENT_BEGIN(_name) \
-	typedef struct                \
-	{                             \
+#define DEFINE_EVENT_BEGIN(name)      \
+	typedef struct _##name##EventArgs \
+	{                                 \
 		wEventArgs e;
 
-#define DEFINE_EVENT_END(_name)   \
-	}                             \
-	_name##EventArgs;             \
-	DEFINE_EVENT_HANDLER(_name);  \
-	DEFINE_EVENT_RAISE(_name)     \
-	DEFINE_EVENT_SUBSCRIBE(_name) \
-	DEFINE_EVENT_UNSUBSCRIBE(_name)
+#define DEFINE_EVENT_END(name)   \
+	}                            \
+	name##EventArgs;             \
+	DEFINE_EVENT_HANDLER(name);  \
+	DEFINE_EVENT_RAISE(name)     \
+	DEFINE_EVENT_SUBSCRIBE(name) \
+	DEFINE_EVENT_UNSUBSCRIBE(name)
 
-#define DEFINE_EVENT_ENTRY(_name) { #_name, { sizeof(_name##EventArgs), NULL }, 0, { NULL } },
+#define DEFINE_EVENT_ENTRY(name)                     \
+	{                                                \
+#name, { sizeof(name##EventArgs), NULL }, 0, \
+		{                                            \
+			NULL                                     \
+		}                                            \
+	}
 
 	typedef struct _wPubSub wPubSub;
 

--- a/winpr/libwinpr/utils/collections/BufferPool.c
+++ b/winpr/libwinpr/utils/collections/BufferPool.c
@@ -85,7 +85,7 @@ static BOOL BufferPool_Unlock(wBufferPool* pool)
  * Methods
  */
 
-static BOOL BufferPool_ShiftAvailable(wBufferPool* pool, int index, int count)
+static BOOL BufferPool_ShiftAvailable(wBufferPool* pool, size_t index, int count)
 {
 	if (count > 0)
 	{
@@ -119,7 +119,7 @@ static BOOL BufferPool_ShiftAvailable(wBufferPool* pool, int index, int count)
 	return TRUE;
 }
 
-static BOOL BufferPool_ShiftUsed(wBufferPool* pool, int index, int count)
+static BOOL BufferPool_ShiftUsed(wBufferPool* pool, SSIZE_T index, SSIZE_T count)
 {
 	if (count > 0)
 	{
@@ -323,7 +323,7 @@ void* BufferPool_Take(wBufferPool* pool, SSIZE_T size)
 
 		if (pool->uSize + 1 > pool->uCapacity)
 		{
-			int newUCapacity = pool->uCapacity * 2;
+			size_t newUCapacity = pool->uCapacity * 2;
 			wBufferPoolItem* newUArray =
 			    (wBufferPoolItem*)realloc(pool->uArray, sizeof(wBufferPoolItem) * newUCapacity);
 			if (!newUArray)
@@ -359,8 +359,8 @@ out_error_no_free:
 BOOL BufferPool_Return(wBufferPool* pool, void* buffer)
 {
 	BOOL rc = FALSE;
-	int size = 0;
-	int index = 0;
+	SSIZE_T size = 0;
+	SSIZE_T index = 0;
 	BOOL found = FALSE;
 
 	BufferPool_Lock(pool);
@@ -371,7 +371,7 @@ BOOL BufferPool_Return(wBufferPool* pool, void* buffer)
 
 		if ((pool->size + 1) >= pool->capacity)
 		{
-			int newCapacity = pool->capacity * 2;
+			SSIZE_T newCapacity = pool->capacity * 2;
 			void** newArray = (void**)realloc(pool->array, sizeof(void*) * newCapacity);
 			if (!newArray)
 				goto out_error;
@@ -406,7 +406,7 @@ BOOL BufferPool_Return(wBufferPool* pool, void* buffer)
 		{
 			if ((pool->aSize + 1) >= pool->aCapacity)
 			{
-				int newCapacity = pool->aCapacity * 2;
+				SSIZE_T newCapacity = pool->aCapacity * 2;
 				wBufferPoolItem* newArray =
 				    (wBufferPoolItem*)realloc(pool->aArray, sizeof(wBufferPoolItem) * newCapacity);
 				if (!newArray)

--- a/winpr/libwinpr/utils/collections/PubSub.c
+++ b/winpr/libwinpr/utils/collections/PubSub.c
@@ -46,6 +46,8 @@ struct _wPubSub
 
 wEventType* PubSub_GetEventTypes(wPubSub* pubSub, size_t* count)
 {
+	WINPR_ASSERT(pubSub);
+
 	if (count)
 		*count = pubSub->count;
 
@@ -58,12 +60,14 @@ wEventType* PubSub_GetEventTypes(wPubSub* pubSub, size_t* count)
 
 void PubSub_Lock(wPubSub* pubSub)
 {
+	WINPR_ASSERT(pubSub);
 	if (pubSub->synchronized)
 		EnterCriticalSection(&pubSub->lock);
 }
 
 void PubSub_Unlock(wPubSub* pubSub)
 {
+	WINPR_ASSERT(pubSub);
 	if (pubSub->synchronized)
 		LeaveCriticalSection(&pubSub->lock);
 }
@@ -72,6 +76,9 @@ wEventType* PubSub_FindEventType(wPubSub* pubSub, const char* EventName)
 {
 	size_t index;
 	wEventType* event = NULL;
+
+	WINPR_ASSERT(pubSub);
+	WINPR_ASSERT(EventName);
 
 	for (index = 0; index < pubSub->count; index++)
 	{
@@ -87,6 +94,9 @@ wEventType* PubSub_FindEventType(wPubSub* pubSub, const char* EventName)
 
 void PubSub_AddEventTypes(wPubSub* pubSub, wEventType* events, size_t count)
 {
+	WINPR_ASSERT(pubSub);
+	WINPR_ASSERT(events || (count == 0));
+
 	if (pubSub->synchronized)
 		PubSub_Lock(pubSub);
 
@@ -115,6 +125,9 @@ int PubSub_Subscribe(wPubSub* pubSub, const char* EventName, pEventHandler Event
 	wEventType* event;
 	int status = -1;
 
+	WINPR_ASSERT(pubSub);
+	WINPR_ASSERT(EventHandler);
+
 	if (pubSub->synchronized)
 		PubSub_Lock(pubSub);
 
@@ -141,6 +154,10 @@ int PubSub_Unsubscribe(wPubSub* pubSub, const char* EventName, pEventHandler Eve
 	size_t index;
 	wEventType* event;
 	int status = -1;
+
+	WINPR_ASSERT(pubSub);
+	WINPR_ASSERT(EventName);
+	WINPR_ASSERT(EventHandler);
 
 	if (pubSub->synchronized)
 		PubSub_Lock(pubSub);
@@ -170,11 +187,14 @@ int PubSub_Unsubscribe(wPubSub* pubSub, const char* EventName, pEventHandler Eve
 	return status;
 }
 
-int PubSub_OnEvent(wPubSub* pubSub, const char* EventName, void* context, wEventArgs* e)
+int PubSub_OnEvent(wPubSub* pubSub, const char* EventName, void* context, const wEventArgs* e)
 {
 	size_t index;
 	wEventType* event;
 	int status = -1;
+
+	WINPR_ASSERT(pubSub);
+	WINPR_ASSERT(e);
 
 	if (pubSub->synchronized)
 		PubSub_Lock(pubSub);

--- a/winpr/libwinpr/utils/test/TestPubSub.c
+++ b/winpr/libwinpr/utils/test/TestPubSub.c
@@ -15,12 +15,12 @@ int flags;
 int button;
 DEFINE_EVENT_END(MouseButton)
 
-static void MouseMotionEventHandler(void* context, MouseMotionEventArgs* e)
+static void MouseMotionEventHandler(void* context, const MouseMotionEventArgs* e)
 {
 	printf("MouseMotionEvent: x: %d y: %d\n", e->x, e->y);
 }
 
-static void MouseButtonEventHandler(void* context, MouseButtonEventArgs* e)
+static void MouseButtonEventHandler(void* context, const MouseButtonEventArgs* e)
 {
 	printf("MouseButtonEvent: x: %d y: %d flags: %d button: %d\n", e->x, e->y, e->flags, e->button);
 }

--- a/winpr/libwinpr/utils/test/TestPubSub.c
+++ b/winpr/libwinpr/utils/test/TestPubSub.c
@@ -25,8 +25,8 @@ static void MouseButtonEventHandler(void* context, const MouseButtonEventArgs* e
 	printf("MouseButtonEvent: x: %d y: %d flags: %d button: %d\n", e->x, e->y, e->flags, e->button);
 }
 
-static wEventType Node_Events[] = { DEFINE_EVENT_ENTRY(MouseMotion)
-	                                    DEFINE_EVENT_ENTRY(MouseButton) };
+static wEventType Node_Events[] = { DEFINE_EVENT_ENTRY(MouseMotion),
+	                                DEFINE_EVENT_ENTRY(MouseButton) };
 
 #define NODE_EVENT_COUNT (sizeof(Node_Events) / sizeof(wEventType))
 


### PR DESCRIPTION
A first draft for implementing #7560 

How to test:
1. start `sfreerdp-server --cert=<path> --key=<path>` from `server/Sample` source directory (path required to find mouse image)
2. start `xfreerdp /v:host /u:foo /p:bar`
3. When connected type `i`, this will toggle the channel.
4. Move the mouse

When the channel is active, the mouse icon will not move, but the server will print warning log messages.
If the channel is disabled, the mouse icon will follow the mouse.

Protocol messages (after dynamic channel is established):
A `MSG_AINPUT_VERSION` from server to client to announce which channel version the server supports.
`MSG_AINPUT_MOUSE` messages from client to server when a mouse event happens.