### PR TITLE
Advanced Input Channel

### DIFF
--- a/channels/ainput/CMakeLists.txt
+++ b/channels/ainput/CMakeLists.txt
@@ -1,0 +1,27 @@
+# FreeRDP: A Remote Desktop Protocol Implementation
+# FreeRDP cmake build script
+#
+# Copyright 2022 Armin Novak <anovak@thincast.com>
+# Copyright 2022 Thincast Technologies GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+define_channel("ainput")
+
+if(WITH_CLIENT_CHANNELS)
+	add_channel_client(${MODULE_PREFIX} ${CHANNEL_NAME})
+endif()
+
+if(WITH_SERVER_CHANNELS)
+	add_channel_server(${MODULE_PREFIX} ${CHANNEL_NAME})
+endif()

--- a/channels/ainput/ChannelOptions.cmake
+++ b/channels/ainput/ChannelOptions.cmake
@@ -1,0 +1,13 @@
+
+set(OPTION_DEFAULT OFF)
+set(OPTION_CLIENT_DEFAULT ON)
+set(OPTION_SERVER_DEFAULT ON)
+
+define_channel_options(NAME "ainput" TYPE "dynamic"
+	DESCRIPTION "Advanced Input Virtual Channel Extension"
+	SPECIFICATIONS "[XXXXX]"
+	DEFAULT ${OPTION_DEFAULT})
+
+define_channel_client_options(${OPTION_CLIENT_DEFAULT})
+define_channel_server_options(${OPTION_SERVER_DEFAULT})
+

--- a/channels/ainput/client/CMakeLists.txt
+++ b/channels/ainput/client/CMakeLists.txt
@@ -1,0 +1,34 @@
+# FreeRDP: A Remote Desktop Protocol Implementation
+# FreeRDP cmake build script
+#
+# Copyright 2022 Armin Novak <anovak@thincast.com>
+# Copyright 2022 Thincast Technologies GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+define_channel_client("ainput")
+
+set(${MODULE_PREFIX}_SRCS
+	ainput_main.c
+	ainput_main.h)
+
+include_directories(..)
+
+add_channel_client_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} TRUE "DVCPluginEntry")
+
+if (WITH_DEBUG_SYMBOLS AND MSVC AND NOT BUILTIN_CHANNELS AND BUILD_SHARED_LIBS)
+	install(FILES ${PROJECT_BINARY_DIR}/${MODULE_NAME}.pdb DESTINATION ${FREERDP_ADDIN_PATH} COMPONENT symbols)
+endif()
+
+target_link_libraries(${MODULE_NAME} winpr)
+set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "Channels/${CHANNEL_NAME}/Client")

--- a/channels/ainput/client/ainput_main.c
+++ b/channels/ainput/client/ainput_main.c
@@ -34,6 +34,8 @@
 #include <freerdp/client/ainput.h>
 #include <freerdp/channels/ainput.h>
 
+#include "../common/ainput_common.h"
+
 #define TAG CHANNELS_TAG("ainput.client")
 
 typedef struct AINPUT_CHANNEL_CALLBACK_ AINPUT_CHANNEL_CALLBACK;
@@ -127,6 +129,12 @@ static UINT ainput_send_input_event(AInputClientContext* context, UINT64 flags, 
 	}
 	callback = ainput->listener_callback->channel_callback;
 	WINPR_ASSERT(callback);
+
+	{
+		char buffer[128] = { 0 };
+		WLog_VRB(TAG, "[%s] sending flags=%s, %" PRId32 "x%" PRId32, __FUNCTION__,
+		         ainput_flags_to_string(flags, buffer, sizeof(buffer)), x, y);
+	}
 
 	/* Message type */
 	Stream_Write_UINT16(s, MSG_AINPUT_MOUSE);

--- a/channels/ainput/client/ainput_main.c
+++ b/channels/ainput/client/ainput_main.c
@@ -1,0 +1,301 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Advanced Input Virtual Channel Extension
+ *
+ * Copyright 2022 Armin Novak <anovak@thincast.com>
+ * Copyright 2022 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <winpr/crt.h>
+#include <winpr/assert.h>
+#include <winpr/stream.h>
+
+#include "ainput_main.h"
+#include <freerdp/channels/log.h>
+#include <freerdp/client/ainput.h>
+#include <freerdp/channels/ainput.h>
+
+#define TAG CHANNELS_TAG("ainput.client")
+
+typedef struct AINPUT_CHANNEL_CALLBACK_ AINPUT_CHANNEL_CALLBACK;
+struct AINPUT_CHANNEL_CALLBACK_
+{
+	IWTSVirtualChannelCallback iface;
+
+	IWTSPlugin* plugin;
+	IWTSVirtualChannelManager* channel_mgr;
+	IWTSVirtualChannel* channel;
+};
+
+typedef struct AINPUT_LISTENER_CALLBACK_ AINPUT_LISTENER_CALLBACK;
+struct AINPUT_LISTENER_CALLBACK_
+{
+	IWTSListenerCallback iface;
+
+	IWTSPlugin* plugin;
+	IWTSVirtualChannelManager* channel_mgr;
+	AINPUT_CHANNEL_CALLBACK* channel_callback;
+};
+
+typedef struct AINPUT_PLUGIN_ AINPUT_PLUGIN;
+struct AINPUT_PLUGIN_
+{
+	IWTSPlugin iface;
+
+	AINPUT_LISTENER_CALLBACK* listener_callback;
+	IWTSListener* listener;
+	UINT32 MajorVersion;
+	UINT32 MinorVersion;
+	BOOL initialized;
+};
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT ainput_on_data_received(IWTSVirtualChannelCallback* pChannelCallback, wStream* data)
+{
+	UINT16 type;
+	AINPUT_PLUGIN* ainput;
+	AINPUT_CHANNEL_CALLBACK* callback = (AINPUT_CHANNEL_CALLBACK*)pChannelCallback;
+
+	WINPR_ASSERT(callback);
+	WINPR_ASSERT(data);
+
+	ainput = (AINPUT_PLUGIN*)callback->plugin;
+	WINPR_ASSERT(ainput);
+
+	if (Stream_GetRemainingLength(data) < 2)
+		return ERROR_NO_DATA;
+	Stream_Read_UINT16(data, type);
+	switch (type)
+	{
+		case MSG_AINPUT_VERSION:
+			if (Stream_GetRemainingLength(data) < 8)
+				return ERROR_NO_DATA;
+			Stream_Read_UINT32(data, ainput->MajorVersion);
+			Stream_Read_UINT32(data, ainput->MinorVersion);
+			break;
+		default:
+			WLog_WARN(TAG, "Received unsupported message type 0x%04" PRIx16, type);
+			break;
+	}
+
+	return CHANNEL_RC_OK;
+}
+
+static UINT ainput_send_input_event(AInputClientContext* context, UINT64 flags, INT32 x, INT32 y)
+{
+	AINPUT_PLUGIN* ainput;
+	AINPUT_CHANNEL_CALLBACK* callback;
+	BYTE buffer[32] = { 0 };
+	wStream sbuffer = { 0 };
+	wStream* s = Stream_StaticInit(&sbuffer, buffer, sizeof(buffer));
+
+	WINPR_ASSERT(s);
+	WINPR_ASSERT(context);
+
+	ainput = (AINPUT_PLUGIN*)context->handle;
+	WINPR_ASSERT(ainput);
+	WINPR_ASSERT(ainput->listener_callback);
+
+	if (ainput->MajorVersion != AINPUT_VERSION_MAJOR)
+	{
+		WLog_WARN(TAG, "Unsupported channel version %" PRIu32 ".%" PRIu32 ", aborting.",
+		          ainput->MajorVersion, ainput->MinorVersion);
+		return CHANNEL_RC_UNSUPPORTED_VERSION;
+	}
+	callback = ainput->listener_callback->channel_callback;
+	WINPR_ASSERT(callback);
+
+	/* Message type */
+	Stream_Write_UINT16(s, MSG_AINPUT_MOUSE);
+
+	/* Event data */
+	Stream_Write_UINT64(s, flags);
+	Stream_Write_INT32(s, x);
+	Stream_Write_INT32(s, y);
+	Stream_SealLength(s);
+
+	/* ainput back what we have received. AINPUT does not have any message IDs. */
+	WINPR_ASSERT(callback->channel);
+	WINPR_ASSERT(callback->channel->Write);
+	return callback->channel->Write(callback->channel, (ULONG)Stream_Length(s), Stream_Buffer(s),
+	                                NULL);
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT ainput_on_close(IWTSVirtualChannelCallback* pChannelCallback)
+{
+	AINPUT_CHANNEL_CALLBACK* callback = (AINPUT_CHANNEL_CALLBACK*)pChannelCallback;
+
+	free(callback);
+
+	return CHANNEL_RC_OK;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT ainput_on_new_channel_connection(IWTSListenerCallback* pListenerCallback,
+                                             IWTSVirtualChannel* pChannel, BYTE* Data,
+                                             BOOL* pbAccept,
+                                             IWTSVirtualChannelCallback** ppCallback)
+{
+	AINPUT_CHANNEL_CALLBACK* callback;
+	AINPUT_LISTENER_CALLBACK* listener_callback = (AINPUT_LISTENER_CALLBACK*)pListenerCallback;
+
+	WINPR_ASSERT(listener_callback);
+	WINPR_UNUSED(Data);
+	WINPR_UNUSED(pbAccept);
+
+	callback = (AINPUT_CHANNEL_CALLBACK*)calloc(1, sizeof(AINPUT_CHANNEL_CALLBACK));
+
+	if (!callback)
+	{
+		WLog_ERR(TAG, "calloc failed!");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	callback->iface.OnDataReceived = ainput_on_data_received;
+	callback->iface.OnClose = ainput_on_close;
+	callback->plugin = listener_callback->plugin;
+	callback->channel_mgr = listener_callback->channel_mgr;
+	callback->channel = pChannel;
+	listener_callback->channel_callback = callback;
+
+	*ppCallback = &callback->iface;
+
+	return CHANNEL_RC_OK;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT ainput_plugin_initialize(IWTSPlugin* pPlugin, IWTSVirtualChannelManager* pChannelMgr)
+{
+	UINT status;
+	AINPUT_PLUGIN* ainput = (AINPUT_PLUGIN*)pPlugin;
+
+	WINPR_ASSERT(ainput);
+
+	if (ainput->initialized)
+	{
+		WLog_ERR(TAG, "[%s] channel initialized twice, aborting", AINPUT_DVC_CHANNEL_NAME);
+		return ERROR_INVALID_DATA;
+	}
+	ainput->listener_callback =
+	    (AINPUT_LISTENER_CALLBACK*)calloc(1, sizeof(AINPUT_LISTENER_CALLBACK));
+
+	if (!ainput->listener_callback)
+	{
+		WLog_ERR(TAG, "calloc failed!");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	ainput->listener_callback->iface.OnNewChannelConnection = ainput_on_new_channel_connection;
+	ainput->listener_callback->plugin = pPlugin;
+	ainput->listener_callback->channel_mgr = pChannelMgr;
+
+	status = pChannelMgr->CreateListener(pChannelMgr, AINPUT_DVC_CHANNEL_NAME, 0,
+	                                     &ainput->listener_callback->iface, &ainput->listener);
+
+	ainput->listener->pInterface = ainput->iface.pInterface;
+	ainput->initialized = status == CHANNEL_RC_OK;
+	return status;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT ainput_plugin_terminated(IWTSPlugin* pPlugin)
+{
+	AINPUT_PLUGIN* ainput = (AINPUT_PLUGIN*)pPlugin;
+	if (ainput && ainput->listener_callback)
+	{
+		IWTSVirtualChannelManager* mgr = ainput->listener_callback->channel_mgr;
+		if (mgr)
+			IFCALL(mgr->DestroyListener, mgr, ainput->listener);
+	}
+	if (ainput)
+	{
+		free(ainput->listener_callback);
+		free(ainput->iface.pInterface);
+	}
+	free(ainput);
+
+	return CHANNEL_RC_OK;
+}
+
+#ifdef BUILTIN_CHANNELS
+#define DVCPluginEntry ainput_DVCPluginEntry
+#else
+#define DVCPluginEntry FREERDP_API DVCPluginEntry
+#endif
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+UINT DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
+{
+	UINT status = CHANNEL_RC_OK;
+	AINPUT_PLUGIN* ainput = (AINPUT_PLUGIN*)pEntryPoints->GetPlugin(pEntryPoints, "ainput");
+
+	if (!ainput)
+	{
+		AInputClientContext* context = (AInputClientContext*)calloc(1, sizeof(AInputClientContext));
+		ainput = (AINPUT_PLUGIN*)calloc(1, sizeof(AINPUT_PLUGIN));
+
+		if (!ainput || !context)
+		{
+			free(context);
+			free(ainput);
+
+			WLog_ERR(TAG, "calloc failed!");
+			return CHANNEL_RC_NO_MEMORY;
+		}
+
+		ainput->iface.Initialize = ainput_plugin_initialize;
+		ainput->iface.Terminated = ainput_plugin_terminated;
+
+		context->handle = (void*)ainput;
+		context->AInputSendInputEvent = ainput_send_input_event;
+		ainput->iface.pInterface = (void*)context;
+
+		status = pEntryPoints->RegisterPlugin(pEntryPoints, AINPUT_CHANNEL_NAME, &ainput->iface);
+	}
+
+	return status;
+}

--- a/channels/ainput/client/ainput_main.h
+++ b/channels/ainput/client/ainput_main.h
@@ -1,0 +1,43 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Advanced Input Virtual Channel Extension
+ *
+ * Copyright 2022 Armin Novak <anovak@thincast.com>
+ * Copyright 2022 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_AINPUT_CLIENT_MAIN_H
+#define FREERDP_CHANNEL_AINPUT_CLIENT_MAIN_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <freerdp/dvc.h>
+#include <freerdp/types.h>
+#include <freerdp/addin.h>
+#include <freerdp/channels/log.h>
+
+#define DVC_TAG CHANNELS_TAG("ainput.client")
+#ifdef WITH_DEBUG_DVC
+#define DEBUG_DVC(...) WLog_DBG(DVC_TAG, __VA_ARGS__)
+#else
+#define DEBUG_DVC(...) \
+	do                 \
+	{                  \
+	} while (0)
+#endif
+
+#endif /* FREERDP_CHANNEL_AINPUT_CLIENT_MAIN_H */

--- a/channels/ainput/common/ainput_common.h
+++ b/channels/ainput/common/ainput_common.h
@@ -1,0 +1,78 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Audio Input Redirection Virtual Channel
+ *
+ * Copyright 2022 Armin Novak <anovak@thincast.com>
+ * Copyright 2022 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_INT_AINPUT_COMMON_H
+#define FREERDP_INT_AINPUT_COMMON_H
+
+#include <winpr/string.h>
+
+#include <freerdp/channels/ainput.h>
+
+static INLINE void ainput_append(char* buffer, size_t size, const char* what, BOOL separator)
+{
+	size_t have;
+	size_t toadd;
+
+	WINPR_ASSERT(buffer || (size == 0));
+	WINPR_ASSERT(what);
+
+	have = strnlen(buffer, size);
+	toadd = strlen(what);
+	if (have > 0)
+		toadd += 1;
+
+	if (size - have < toadd + 1)
+		return;
+
+	if (have > 0)
+		strcat(buffer, separator ? "|" : " ");
+	strcat(buffer, what);
+}
+
+static INLINE const char* ainput_flags_to_string(UINT64 flags, char* buffer, size_t size)
+{
+	char number[32] = { 0 };
+
+	if (flags & AINPUT_FLAGS_WHEEL)
+		ainput_append(buffer, size, "AINPUT_FLAGS_WHEEL", TRUE);
+	if (flags & AINPUT_FLAGS_MOVE)
+		ainput_append(buffer, size, "AINPUT_FLAGS_MOVE", TRUE);
+	if (flags & AINPUT_FLAGS_DOWN)
+		ainput_append(buffer, size, "AINPUT_FLAGS_DOWN", TRUE);
+	if (flags & AINPUT_FLAGS_REL)
+		ainput_append(buffer, size, "AINPUT_FLAGS_REL", TRUE);
+	if (flags & AINPUT_FLAGS_BUTTON1)
+		ainput_append(buffer, size, "AINPUT_FLAGS_BUTTON1", TRUE);
+	if (flags & AINPUT_FLAGS_BUTTON2)
+		ainput_append(buffer, size, "AINPUT_FLAGS_BUTTON2", TRUE);
+	if (flags & AINPUT_FLAGS_BUTTON3)
+		ainput_append(buffer, size, "AINPUT_FLAGS_BUTTON3", TRUE);
+	if (flags & AINPUT_XFLAGS_BUTTON1)
+		ainput_append(buffer, size, "AINPUT_XFLAGS_BUTTON1", TRUE);
+	if (flags & AINPUT_XFLAGS_BUTTON2)
+		ainput_append(buffer, size, "AINPUT_XFLAGS_BUTTON2", TRUE);
+
+	_snprintf(number, sizeof(number), "[0x%08" PRIx64 "]", flags);
+	ainput_append(buffer, size, number, FALSE);
+
+	return buffer;
+}
+
+#endif /* FREERDP_INT_AINPUT_COMMON_H */

--- a/channels/ainput/common/ainput_common.h
+++ b/channels/ainput/common/ainput_common.h
@@ -50,6 +50,8 @@ static INLINE const char* ainput_flags_to_string(UINT64 flags, char* buffer, siz
 {
 	char number[32] = { 0 };
 
+	if (flags & AINPUT_FLAGS_HAVE_REL)
+		ainput_append(buffer, size, "AINPUT_FLAGS_HAVE_REL", TRUE);
 	if (flags & AINPUT_FLAGS_WHEEL)
 		ainput_append(buffer, size, "AINPUT_FLAGS_WHEEL", TRUE);
 	if (flags & AINPUT_FLAGS_MOVE)

--- a/channels/ainput/server/CMakeLists.txt
+++ b/channels/ainput/server/CMakeLists.txt
@@ -1,0 +1,27 @@
+# FreeRDP: A Remote Desktop Protocol Implementation
+# FreeRDP cmake build script
+#
+# Copyright 2022 Armin Novak <anovak@thincast.com>
+# Copyright 2022 Thincast Technologies GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+define_channel_server("ainput")
+
+set(${MODULE_PREFIX}_SRCS
+	ainput_main.c)
+
+add_channel_server_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} FALSE "DVCPluginEntry")
+
+target_link_libraries(${MODULE_NAME} freerdp)
+set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "Channels/${CHANNEL_NAME}/Server")

--- a/channels/ainput/server/ainput_main.c
+++ b/channels/ainput/server/ainput_main.c
@@ -1,0 +1,418 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Advanced Input Virtual Channel Extension
+ *
+ * Copyright 2022 Armin Novak <anovak@thincast.com>
+ * Copyright 2022 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <winpr/crt.h>
+#include <winpr/assert.h>
+#include <winpr/synch.h>
+#include <winpr/thread.h>
+#include <winpr/stream.h>
+#include <winpr/sysinfo.h>
+
+#include <freerdp/server/ainput.h>
+#include <freerdp/channels/ainput.h>
+#include <freerdp/channels/log.h>
+
+#define TAG CHANNELS_TAG("ainput.server")
+
+typedef struct ainput_server_
+{
+	ainput_server_context context;
+
+	BOOL opened;
+
+	HANDLE stopEvent;
+
+	HANDLE thread;
+	void* ainput_channel;
+
+	DWORD SessionId;
+
+} ainput_server;
+
+static BOOL ainput_server_is_open(ainput_server_context* context)
+{
+	ainput_server* ainput = (ainput_server*)context;
+
+	WINPR_ASSERT(ainput);
+	return ainput->thread != NULL;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT ainput_server_open_channel(ainput_server* ainput)
+{
+	DWORD Error;
+	HANDLE hEvent;
+	DWORD StartTick;
+	DWORD BytesReturned = 0;
+	PULONG pSessionId = NULL;
+
+	WINPR_ASSERT(ainput);
+
+	if (WTSQuerySessionInformationA(ainput->context.vcm, WTS_CURRENT_SESSION, WTSSessionId,
+	                                (LPSTR*)&pSessionId, &BytesReturned) == FALSE)
+	{
+		WLog_ERR(TAG, "WTSQuerySessionInformationA failed!");
+		return ERROR_INTERNAL_ERROR;
+	}
+
+	ainput->SessionId = (DWORD)*pSessionId;
+	WTSFreeMemory(pSessionId);
+	hEvent = WTSVirtualChannelManagerGetEventHandle(ainput->context.vcm);
+	StartTick = GetTickCount();
+
+	while (ainput->ainput_channel == NULL)
+	{
+		if (WaitForSingleObject(hEvent, 1000) == WAIT_FAILED)
+		{
+			Error = GetLastError();
+			WLog_ERR(TAG, "WaitForSingleObject failed with error %" PRIu32 "!", Error);
+			return Error;
+		}
+
+		ainput->ainput_channel = WTSVirtualChannelOpenEx(ainput->SessionId, AINPUT_DVC_CHANNEL_NAME,
+		                                                 WTS_CHANNEL_OPTION_DYNAMIC);
+
+		if (ainput->ainput_channel)
+			break;
+
+		Error = GetLastError();
+
+		if (Error == ERROR_NOT_FOUND)
+			break;
+
+		if (GetTickCount() - StartTick > 5000)
+			break;
+	}
+
+	return ainput->ainput_channel ? CHANNEL_RC_OK : ERROR_INTERNAL_ERROR;
+}
+
+static UINT ainput_server_send_version(ainput_server* ainput, wStream* s)
+{
+	ULONG written;
+	WINPR_ASSERT(ainput);
+	WINPR_ASSERT(s);
+
+	Stream_SetPosition(s, 0);
+	if (!Stream_EnsureCapacity(s, 10))
+		return ERROR_OUTOFMEMORY;
+
+	Stream_Write_UINT16(s, MSG_AINPUT_VERSION);
+	Stream_Write_UINT32(s, AINPUT_VERSION_MAJOR); /* Version (4 bytes) */
+	Stream_Write_UINT32(s, AINPUT_VERSION_MINOR); /* Version (4 bytes) */
+
+	WINPR_ASSERT(Stream_GetPosition(s) <= ULONG_MAX);
+	if (!WTSVirtualChannelWrite(ainput->ainput_channel, (PCHAR)Stream_Buffer(s),
+	                            (ULONG)Stream_GetPosition(s), &written))
+	{
+		WLog_ERR(TAG, "WTSVirtualChannelWrite failed!");
+		return ERROR_INTERNAL_ERROR;
+	}
+
+	return CHANNEL_RC_OK;
+}
+
+static UINT ainput_server_recv_mouse_event(ainput_server* ainput, wStream* s)
+{
+	UINT error = CHANNEL_RC_OK;
+	UINT64 flags;
+	INT32 x, y;
+
+	WINPR_ASSERT(ainput);
+	WINPR_ASSERT(s);
+
+	if (Stream_GetRemainingLength(s) < 16)
+		return ERROR_NO_DATA;
+
+	Stream_Read_UINT64(s, flags);
+	Stream_Read_INT32(s, x);
+	Stream_Read_INT32(s, y);
+	IFCALLRET(ainput->context.MouseEvent, error, &ainput->context, flags, x, y);
+
+	return error;
+}
+static DWORD WINAPI ainput_server_thread_func(LPVOID arg)
+{
+	wStream* s;
+	void* buffer;
+	DWORD nCount;
+	HANDLE events[8] = { 0 };
+	BOOL ready = FALSE;
+	HANDLE ChannelEvent;
+	DWORD BytesReturned = 0;
+	ainput_server* ainput = (ainput_server*)arg;
+	UINT error;
+	DWORD status;
+
+	WINPR_ASSERT(ainput);
+
+	if ((error = ainput_server_open_channel(ainput)))
+	{
+		WLog_ERR(TAG, "ainput_server_open_channel failed with error %" PRIu32 "!", error);
+		goto out;
+	}
+
+	buffer = NULL;
+	BytesReturned = 0;
+	ChannelEvent = NULL;
+
+	if (WTSVirtualChannelQuery(ainput->ainput_channel, WTSVirtualEventHandle, &buffer,
+	                           &BytesReturned) == TRUE)
+	{
+		if (BytesReturned == sizeof(HANDLE))
+			CopyMemory(&ChannelEvent, buffer, sizeof(HANDLE));
+
+		WTSFreeMemory(buffer);
+	}
+
+	nCount = 0;
+	events[nCount++] = ainput->stopEvent;
+	events[nCount++] = ChannelEvent;
+
+	while (1)
+	{
+		status = WaitForMultipleObjects(nCount, events, FALSE, 100);
+
+		if (status == WAIT_FAILED)
+		{
+			error = GetLastError();
+			WLog_ERR(TAG, "WaitForMultipleObjects failed with error %" PRIu32 "", error);
+			break;
+		}
+
+		if (status == WAIT_OBJECT_0)
+		{
+			if (error)
+				WLog_ERR(TAG, "OpenResult failed with error %" PRIu32 "!", error);
+
+			break;
+		}
+
+		if (WTSVirtualChannelQuery(ainput->ainput_channel, WTSVirtualChannelReady, &buffer,
+		                           &BytesReturned) == FALSE)
+		{
+			if (error)
+				WLog_ERR(TAG, "OpenResult failed with error %" PRIu32 "!", error);
+
+			break;
+		}
+
+		ready = *((BOOL*)buffer);
+		WTSFreeMemory(buffer);
+
+		if (ready)
+		{
+			if (error)
+				WLog_ERR(TAG, "OpenResult failed with error %" PRIu32 "!", error);
+
+			break;
+		}
+	}
+
+	s = Stream_New(NULL, 4096);
+
+	if (!s)
+	{
+		WLog_ERR(TAG, "Stream_New failed!");
+		WTSVirtualChannelClose(ainput->ainput_channel);
+		ExitThread(ERROR_NOT_ENOUGH_MEMORY);
+		return ERROR_NOT_ENOUGH_MEMORY;
+	}
+
+	if (ready)
+	{
+		if ((error = ainput_server_send_version(ainput, s)))
+		{
+			WLog_ERR(TAG, "audin_server_send_version failed with error %" PRIu32 "!", error);
+			goto out_capacity;
+		}
+	}
+
+	while (ready)
+	{
+		UINT16 MessageId;
+		status = WaitForMultipleObjects(nCount, events, FALSE, INFINITE);
+
+		if (status == WAIT_FAILED)
+		{
+			error = GetLastError();
+			WLog_ERR(TAG, "WaitForMultipleObjects failed with error %" PRIu32 "", error);
+			break;
+		}
+
+		if (status == WAIT_OBJECT_0)
+			break;
+
+		Stream_SetPosition(s, 0);
+		WTSVirtualChannelRead(ainput->ainput_channel, 0, NULL, 0, &BytesReturned);
+
+		if (BytesReturned < 2)
+			continue;
+
+		if (!Stream_EnsureRemainingCapacity(s, BytesReturned))
+		{
+			WLog_ERR(TAG, "Stream_EnsureRemainingCapacity failed!");
+			error = CHANNEL_RC_NO_MEMORY;
+			break;
+		}
+
+		if (WTSVirtualChannelRead(ainput->ainput_channel, 0, (PCHAR)Stream_Buffer(s),
+		                          (ULONG)Stream_Capacity(s), &BytesReturned) == FALSE)
+		{
+			WLog_ERR(TAG, "WTSVirtualChannelRead failed!");
+			error = ERROR_INTERNAL_ERROR;
+			break;
+		}
+
+		Stream_SetLength(s, BytesReturned);
+		Stream_Read_UINT16(s, MessageId);
+
+		switch (MessageId)
+		{
+			case MSG_AINPUT_MOUSE:
+				error = ainput_server_recv_mouse_event(ainput, s);
+				break;
+
+			default:
+				WLog_ERR(TAG, "audin_server_thread_func: unknown MessageId %" PRIu8 "", MessageId);
+				break;
+		}
+
+		if (error)
+		{
+			WLog_ERR(TAG, "Response failed with error %" PRIu32 "!", error);
+			break;
+		}
+	}
+
+out_capacity:
+	Stream_Free(s, TRUE);
+
+out:
+	WTSVirtualChannelClose(ainput->ainput_channel);
+	ainput->ainput_channel = NULL;
+
+	if (error && ainput->context.rdpcontext)
+		setChannelError(ainput->context.rdpcontext, error,
+		                "ainput_server_thread_func reported an error");
+
+	ExitThread(error);
+	return error;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT ainput_server_open(ainput_server_context* context)
+{
+	ainput_server* ainput = (ainput_server*)context;
+
+	WINPR_ASSERT(ainput);
+
+	if (ainput->thread == NULL)
+	{
+		ainput->stopEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+		if (!ainput->stopEvent)
+		{
+			WLog_ERR(TAG, "CreateEvent failed!");
+			return ERROR_INTERNAL_ERROR;
+		}
+
+		ainput->thread = CreateThread(NULL, 0, ainput_server_thread_func, ainput, 0, NULL);
+		if (!ainput->thread)
+		{
+			WLog_ERR(TAG, "CreateEvent failed!");
+			CloseHandle(ainput->stopEvent);
+			ainput->stopEvent = NULL;
+			return ERROR_INTERNAL_ERROR;
+		}
+	}
+
+	return CHANNEL_RC_OK;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT ainput_server_close(ainput_server_context* context)
+{
+	UINT error = CHANNEL_RC_OK;
+	ainput_server* ainput = (ainput_server*)context;
+
+	WINPR_ASSERT(ainput);
+
+	if (ainput->thread)
+	{
+		SetEvent(ainput->stopEvent);
+
+		if (WaitForSingleObject(ainput->thread, INFINITE) == WAIT_FAILED)
+		{
+			error = GetLastError();
+			WLog_ERR(TAG, "WaitForSingleObject failed with error %" PRIu32 "", error);
+			return error;
+		}
+
+		CloseHandle(ainput->thread);
+		CloseHandle(ainput->stopEvent);
+		ainput->thread = NULL;
+		ainput->stopEvent = NULL;
+	}
+
+	return error;
+}
+
+ainput_server_context* ainput_server_context_new(HANDLE vcm)
+{
+	ainput_server* ainput = (ainput_server*)calloc(1, sizeof(ainput_server));
+
+	if (!ainput)
+		return NULL;
+
+	ainput->context.vcm = vcm;
+	ainput->context.Open = ainput_server_open;
+	ainput->context.IsOpen = ainput_server_is_open;
+	ainput->context.Close = ainput_server_close;
+
+	return &ainput->context;
+}
+
+void ainput_server_context_free(ainput_server_context* context)
+{
+	ainput_server* ainput = (ainput_server*)context;
+	if (ainput)
+		ainput_server_close(context);
+	free(ainput);
+}

--- a/channels/ainput/server/ainput_main.c
+++ b/channels/ainput/server/ainput_main.c
@@ -37,6 +37,8 @@
 #include <freerdp/channels/ainput.h>
 #include <freerdp/channels/log.h>
 
+#include "../common/ainput_common.h"
+
 #define TAG CHANNELS_TAG("ainput.server")
 
 typedef struct ainput_server_
@@ -146,6 +148,7 @@ static UINT ainput_server_recv_mouse_event(ainput_server* ainput, wStream* s)
 	UINT error = CHANNEL_RC_OK;
 	UINT64 flags;
 	INT32 x, y;
+	char buffer[128] = { 0 };
 
 	WINPR_ASSERT(ainput);
 	WINPR_ASSERT(s);
@@ -156,6 +159,9 @@ static UINT ainput_server_recv_mouse_event(ainput_server* ainput, wStream* s)
 	Stream_Read_UINT64(s, flags);
 	Stream_Read_INT32(s, x);
 	Stream_Read_INT32(s, y);
+
+	WLog_VRB(TAG, "[%s] received: flags=%s, %" PRId32 "x%" PRId32, __FUNCTION__,
+	         ainput_flags_to_string(flags, buffer, sizeof(buffer)), x, y);
 	IFCALLRET(ainput->context.MouseEvent, error, &ainput->context, flags, x, y);
 
 	return error;

--- a/channels/ainput/server/ainput_main.c
+++ b/channels/ainput/server/ainput_main.c
@@ -146,23 +146,24 @@ static UINT ainput_server_send_version(ainput_server* ainput, wStream* s)
 static UINT ainput_server_recv_mouse_event(ainput_server* ainput, wStream* s)
 {
 	UINT error = CHANNEL_RC_OK;
-	UINT64 flags;
+	UINT64 flags, time;
 	INT32 x, y;
 	char buffer[128] = { 0 };
 
 	WINPR_ASSERT(ainput);
 	WINPR_ASSERT(s);
 
-	if (Stream_GetRemainingLength(s) < 16)
+	if (Stream_GetRemainingLength(s) < 24)
 		return ERROR_NO_DATA;
 
+	Stream_Read_UINT64(s, time);
 	Stream_Read_UINT64(s, flags);
 	Stream_Read_INT32(s, x);
 	Stream_Read_INT32(s, y);
 
-	WLog_VRB(TAG, "[%s] received: flags=%s, %" PRId32 "x%" PRId32, __FUNCTION__,
-	         ainput_flags_to_string(flags, buffer, sizeof(buffer)), x, y);
-	IFCALLRET(ainput->context.MouseEvent, error, &ainput->context, flags, x, y);
+	WLog_VRB(TAG, "[%s] received: time=0x%08" PRIx64 ", flags=%s, %" PRId32 "x%" PRId32,
+	         __FUNCTION__, time, ainput_flags_to_string(flags, buffer, sizeof(buffer)), x, y);
+	IFCALLRET(ainput->context.MouseEvent, error, &ainput->context, time, flags, x, y);
 
 	return error;
 }

--- a/channels/ainput/server/ainput_main.c
+++ b/channels/ainput/server/ainput_main.c
@@ -41,7 +41,14 @@
 
 #define TAG CHANNELS_TAG("ainput.server")
 
-typedef struct ainput_server_
+typedef enum
+{
+	AINPUT_INITIAL,
+	AINPUT_OPENED,
+	AINPUT_VERSION_SENT,
+} eAInputChannelState;
+
+typedef struct
 {
 	ainput_server_context context;
 
@@ -54,14 +61,25 @@ typedef struct ainput_server_
 
 	DWORD SessionId;
 
+	BOOL isOpened;
+	BOOL externalThread;
+
+	/* Channel state */
+	eAInputChannelState state;
+
+	wStream* buffer;
 } ainput_server;
+
+static UINT ainput_server_context_poll(ainput_server_context* context);
+static BOOL ainput_server_context_handle(ainput_server_context* context, HANDLE* handle);
+static UINT ainput_server_context_poll_int(ainput_server_context* context);
 
 static BOOL ainput_server_is_open(ainput_server_context* context)
 {
 	ainput_server* ainput = (ainput_server*)context;
 
 	WINPR_ASSERT(ainput);
-	return ainput->thread != NULL;
+	return ainput->isOpened;
 }
 
 /**
@@ -118,10 +136,14 @@ static UINT ainput_server_open_channel(ainput_server* ainput)
 	return ainput->ainput_channel ? CHANNEL_RC_OK : ERROR_INTERNAL_ERROR;
 }
 
-static UINT ainput_server_send_version(ainput_server* ainput, wStream* s)
+static UINT ainput_server_send_version(ainput_server* ainput)
 {
 	ULONG written;
+	wStream* s;
+
 	WINPR_ASSERT(ainput);
+
+	s = ainput->buffer;
 	WINPR_ASSERT(s);
 
 	Stream_SetPosition(s, 0);
@@ -167,30 +189,14 @@ static UINT ainput_server_recv_mouse_event(ainput_server* ainput, wStream* s)
 
 	return error;
 }
-static DWORD WINAPI ainput_server_thread_func(LPVOID arg)
+
+static HANDLE ainput_server_get_channel_handle(ainput_server* ainput)
 {
-	wStream* s;
-	void* buffer;
-	DWORD nCount;
-	HANDLE events[8] = { 0 };
-	BOOL ready = FALSE;
-	HANDLE ChannelEvent;
+	BYTE* buffer = NULL;
 	DWORD BytesReturned = 0;
-	ainput_server* ainput = (ainput_server*)arg;
-	UINT error;
-	DWORD status;
+	HANDLE ChannelEvent = NULL;
 
 	WINPR_ASSERT(ainput);
-
-	if ((error = ainput_server_open_channel(ainput)))
-	{
-		WLog_ERR(TAG, "ainput_server_open_channel failed with error %" PRIu32 "!", error);
-		goto out;
-	}
-
-	buffer = NULL;
-	BytesReturned = 0;
-	ChannelEvent = NULL;
 
 	if (WTSVirtualChannelQuery(ainput->ainput_channel, WTSVirtualEventHandle, &buffer,
 	                           &BytesReturned) == TRUE)
@@ -201,130 +207,64 @@ static DWORD WINAPI ainput_server_thread_func(LPVOID arg)
 		WTSFreeMemory(buffer);
 	}
 
+	return ChannelEvent;
+}
+
+static DWORD WINAPI ainput_server_thread_func(LPVOID arg)
+{
+	DWORD nCount;
+	HANDLE events[2] = { 0 };
+	ainput_server* ainput = (ainput_server*)arg;
+	UINT error = CHANNEL_RC_OK;
+	DWORD status;
+
+	WINPR_ASSERT(ainput);
+
 	nCount = 0;
 	events[nCount++] = ainput->stopEvent;
-	events[nCount++] = ChannelEvent;
 
-	while (1)
+	while ((error == CHANNEL_RC_OK) && (WaitForSingleObject(events[0], 0) != WAIT_OBJECT_0))
 	{
-		status = WaitForMultipleObjects(nCount, events, FALSE, 100);
-
-		if (status == WAIT_FAILED)
+		switch (ainput->state)
 		{
-			error = GetLastError();
-			WLog_ERR(TAG, "WaitForMultipleObjects failed with error %" PRIu32 "", error);
-			break;
-		}
+			case AINPUT_OPENED:
+				events[1] = ainput_server_get_channel_handle(ainput);
+				nCount = 2;
+				status = WaitForMultipleObjects(nCount, events, FALSE, 100);
+				switch (status)
+				{
+					case WAIT_TIMEOUT:
+					case WAIT_OBJECT_0 + 1:
+					case WAIT_OBJECT_0:
+						error = ainput_server_context_poll_int(&ainput->context);
 
-		if (status == WAIT_OBJECT_0)
-		{
-			if (error)
-				WLog_ERR(TAG, "OpenResult failed with error %" PRIu32 "!", error);
-
-			break;
-		}
-
-		if (WTSVirtualChannelQuery(ainput->ainput_channel, WTSVirtualChannelReady, &buffer,
-		                           &BytesReturned) == FALSE)
-		{
-			if (error)
-				WLog_ERR(TAG, "OpenResult failed with error %" PRIu32 "!", error);
-
-			break;
-		}
-
-		ready = *((BOOL*)buffer);
-		WTSFreeMemory(buffer);
-
-		if (ready)
-		{
-			if (error)
-				WLog_ERR(TAG, "OpenResult failed with error %" PRIu32 "!", error);
-
-			break;
-		}
-	}
-
-	s = Stream_New(NULL, 4096);
-
-	if (!s)
-	{
-		WLog_ERR(TAG, "Stream_New failed!");
-		WTSVirtualChannelClose(ainput->ainput_channel);
-		ExitThread(ERROR_NOT_ENOUGH_MEMORY);
-		return ERROR_NOT_ENOUGH_MEMORY;
-	}
-
-	if (ready)
-	{
-		if ((error = ainput_server_send_version(ainput, s)))
-		{
-			WLog_ERR(TAG, "audin_server_send_version failed with error %" PRIu32 "!", error);
-			goto out_capacity;
-		}
-	}
-
-	while (ready)
-	{
-		UINT16 MessageId;
-		status = WaitForMultipleObjects(nCount, events, FALSE, INFINITE);
-
-		if (status == WAIT_FAILED)
-		{
-			error = GetLastError();
-			WLog_ERR(TAG, "WaitForMultipleObjects failed with error %" PRIu32 "", error);
-			break;
-		}
-
-		if (status == WAIT_OBJECT_0)
-			break;
-
-		Stream_SetPosition(s, 0);
-		WTSVirtualChannelRead(ainput->ainput_channel, 0, NULL, 0, &BytesReturned);
-
-		if (BytesReturned < 2)
-			continue;
-
-		if (!Stream_EnsureRemainingCapacity(s, BytesReturned))
-		{
-			WLog_ERR(TAG, "Stream_EnsureRemainingCapacity failed!");
-			error = CHANNEL_RC_NO_MEMORY;
-			break;
-		}
-
-		if (WTSVirtualChannelRead(ainput->ainput_channel, 0, (PCHAR)Stream_Buffer(s),
-		                          (ULONG)Stream_Capacity(s), &BytesReturned) == FALSE)
-		{
-			WLog_ERR(TAG, "WTSVirtualChannelRead failed!");
-			error = ERROR_INTERNAL_ERROR;
-			break;
-		}
-
-		Stream_SetLength(s, BytesReturned);
-		Stream_Read_UINT16(s, MessageId);
-
-		switch (MessageId)
-		{
-			case MSG_AINPUT_MOUSE:
-				error = ainput_server_recv_mouse_event(ainput, s);
+					case WAIT_FAILED:
+					default:
+						error = ERROR_INTERNAL_ERROR;
+						break;
+				}
 				break;
+			case AINPUT_VERSION_SENT:
+				status = WaitForMultipleObjects(nCount, events, FALSE, INFINITE);
+				switch (status)
+				{
+					case WAIT_TIMEOUT:
+					case WAIT_OBJECT_0 + 1:
+					case WAIT_OBJECT_0:
+						error = ainput_server_context_poll_int(&ainput->context);
 
+					case WAIT_FAILED:
+					default:
+						error = ERROR_INTERNAL_ERROR;
+						break;
+				}
+				break;
 			default:
-				WLog_ERR(TAG, "audin_server_thread_func: unknown MessageId %" PRIu8 "", MessageId);
+				error = ainput_server_context_poll_int(&ainput->context);
 				break;
-		}
-
-		if (error)
-		{
-			WLog_ERR(TAG, "Response failed with error %" PRIu32 "!", error);
-			break;
 		}
 	}
 
-out_capacity:
-	Stream_Free(s, TRUE);
-
-out:
 	WTSVirtualChannelClose(ainput->ainput_channel);
 	ainput->ainput_channel = NULL;
 
@@ -347,7 +287,7 @@ static UINT ainput_server_open(ainput_server_context* context)
 
 	WINPR_ASSERT(ainput);
 
-	if (ainput->thread == NULL)
+	if (!ainput->externalThread && (ainput->thread == NULL))
 	{
 		ainput->stopEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
 		if (!ainput->stopEvent)
@@ -365,6 +305,7 @@ static UINT ainput_server_open(ainput_server_context* context)
 			return ERROR_INTERNAL_ERROR;
 		}
 	}
+	ainput->isOpened = TRUE;
 
 	return CHANNEL_RC_OK;
 }
@@ -381,7 +322,7 @@ static UINT ainput_server_close(ainput_server_context* context)
 
 	WINPR_ASSERT(ainput);
 
-	if (ainput->thread)
+	if (!ainput->externalThread && ainput->thread)
 	{
 		SetEvent(ainput->stopEvent);
 
@@ -397,7 +338,34 @@ static UINT ainput_server_close(ainput_server_context* context)
 		ainput->thread = NULL;
 		ainput->stopEvent = NULL;
 	}
+	if (ainput->externalThread)
+	{
+		if (ainput->state != AINPUT_INITIAL)
+		{
+			WTSVirtualChannelClose(ainput->ainput_channel);
+			ainput->ainput_channel = NULL;
+			ainput->state = AINPUT_INITIAL;
+		}
+	}
+	ainput->isOpened = FALSE;
 
+	return error;
+}
+
+static UINT ainput_server_initialize(ainput_server_context* context, BOOL externalThread)
+{
+	UINT error = CHANNEL_RC_OK;
+	ainput_server* ainput = (ainput_server*)context;
+
+	WINPR_ASSERT(ainput);
+
+	if (ainput->isOpened)
+	{
+		WLog_WARN(TAG, "Application error: AINPUT channel already initialized, calling in this "
+		               "state is not possible!");
+		return ERROR_INVALID_STATE;
+	}
+	ainput->externalThread = externalThread;
 	return error;
 }
 
@@ -412,14 +380,165 @@ ainput_server_context* ainput_server_context_new(HANDLE vcm)
 	ainput->context.Open = ainput_server_open;
 	ainput->context.IsOpen = ainput_server_is_open;
 	ainput->context.Close = ainput_server_close;
+	ainput->context.Initialize = ainput_server_initialize;
+	ainput->context.Poll = ainput_server_context_poll;
+	ainput->context.ChannelHandle = ainput_server_context_handle;
 
+	ainput->buffer = Stream_New(NULL, 4096);
+	if (!ainput->buffer)
+		goto fail;
 	return &ainput->context;
+fail:
+	ainput_server_context_free(ainput);
+	return NULL;
 }
 
 void ainput_server_context_free(ainput_server_context* context)
 {
 	ainput_server* ainput = (ainput_server*)context;
 	if (ainput)
+	{
 		ainput_server_close(context);
+		Stream_Free(ainput->buffer, TRUE);
+	}
 	free(ainput);
+}
+
+static UINT ainput_process_message(ainput_server* ainput)
+{
+	BOOL rc;
+	UINT error = ERROR_INTERNAL_ERROR;
+	ULONG BytesReturned;
+	UINT16 MessageId;
+	wStream* s;
+
+	WINPR_ASSERT(ainput);
+	WINPR_ASSERT(ainput->ainput_channel);
+
+	s = ainput->buffer;
+	WINPR_ASSERT(s);
+
+	Stream_SetPosition(s, 0);
+	rc = WTSVirtualChannelRead(ainput->ainput_channel, 0, NULL, 0, &BytesReturned);
+	if (!rc)
+		goto out;
+
+	if (BytesReturned < 2)
+	{
+		error = CHANNEL_RC_OK;
+		goto out;
+	}
+
+	if (!Stream_EnsureRemainingCapacity(s, BytesReturned))
+	{
+		WLog_ERR(TAG, "Stream_EnsureRemainingCapacity failed!");
+		error = CHANNEL_RC_NO_MEMORY;
+		goto out;
+	}
+
+	if (WTSVirtualChannelRead(ainput->ainput_channel, 0, (PCHAR)Stream_Buffer(s),
+	                          (ULONG)Stream_Capacity(s), &BytesReturned) == FALSE)
+	{
+		WLog_ERR(TAG, "WTSVirtualChannelRead failed!");
+		goto out;
+	}
+
+	Stream_SetLength(s, BytesReturned);
+	Stream_Read_UINT16(s, MessageId);
+
+	switch (MessageId)
+	{
+		case MSG_AINPUT_MOUSE:
+			error = ainput_server_recv_mouse_event(ainput, s);
+			break;
+
+		default:
+			WLog_ERR(TAG, "audin_server_thread_func: unknown MessageId %" PRIu8 "", MessageId);
+			break;
+	}
+
+out:
+	if (error)
+		WLog_ERR(TAG, "Response failed with error %" PRIu32 "!", error);
+
+	return error;
+}
+
+BOOL ainput_server_context_handle(ainput_server_context* context, HANDLE* handle)
+{
+	ainput_server* ainput = (ainput_server*)context;
+	WINPR_ASSERT(ainput);
+	WINPR_ASSERT(handle);
+
+	if (!ainput->externalThread)
+		return FALSE;
+	if (ainput->state == AINPUT_INITIAL)
+		return FALSE;
+	*handle = ainput_server_get_channel_handle(ainput);
+	return TRUE;
+}
+
+UINT ainput_server_context_poll_int(ainput_server_context* context)
+{
+	ainput_server* ainput = (ainput_server*)context;
+	UINT error = ERROR_INTERNAL_ERROR;
+
+	WINPR_ASSERT(ainput);
+
+	switch (ainput->state)
+	{
+		case AINPUT_INITIAL:
+			error = ainput_server_open_channel(ainput);
+			if (error)
+				WLog_ERR(TAG, "ainput_server_open_channel failed with error %" PRIu32 "!", error);
+			else
+				ainput->state = AINPUT_OPENED;
+			break;
+		case AINPUT_OPENED:
+		{
+			BYTE* buffer = NULL;
+			DWORD BytesReturned = 0;
+
+			if (WTSVirtualChannelQuery(ainput->ainput_channel, WTSVirtualChannelReady, &buffer,
+			                           &BytesReturned) != TRUE)
+			{
+				WLog_ERR(TAG, "WTSVirtualChannelReady failed,");
+			}
+			else
+			{
+				if (*buffer != 0)
+				{
+					error = ainput_server_send_version(ainput);
+					if (error)
+						WLog_ERR(TAG, "audin_server_send_version failed with error %" PRIu32 "!",
+						         error);
+					else
+						ainput->state = AINPUT_VERSION_SENT;
+				}
+				else
+					error = CHANNEL_RC_OK;
+			}
+			WTSFreeMemory(buffer);
+		}
+		break;
+		case AINPUT_VERSION_SENT:
+			error = ainput_process_message(ainput);
+			break;
+
+		default:
+			WLog_ERR(TAG, "AINPUT chanel is in invalid state %d", ainput->state);
+			break;
+	}
+
+	return error;
+}
+
+UINT ainput_server_context_poll(ainput_server_context* context)
+{
+	ainput_server* ainput = (ainput_server*)context;
+
+	WINPR_ASSERT(ainput);
+	if (!ainput->externalThread)
+		return ERROR_INTERNAL_ERROR;
+	return ainput_server_context_poll_int(context);
 }

--- a/channels/rdpsnd/server/rdpsnd_main.c
+++ b/channels/rdpsnd/server/rdpsnd_main.c
@@ -695,10 +695,11 @@ static UINT rdpsnd_server_start(RdpsndServerContext* context)
 			priv->SessionId = (DWORD)*pSessionId;
 			WTSFreeMemory(pSessionId);
 			priv->ChannelHandle = (HANDLE)WTSVirtualChannelOpenEx(
-			    priv->SessionId, "AUDIO_PLAYBACK_DVC", WTS_CHANNEL_OPTION_DYNAMIC);
+			    priv->SessionId, RDPSND_DVC_CHANNEL_NAME, WTS_CHANNEL_OPTION_DYNAMIC);
 			if (!priv->ChannelHandle)
 			{
-				WLog_ERR(TAG, "Open audio dynamic virtual channel (AUDIO_PLAYBACK_DVC) failed!");
+				WLog_ERR(TAG, "Open audio dynamic virtual channel (%s) failed!",
+				         RDPSND_DVC_CHANNEL_NAME);
 				return ERROR_INTERNAL_ERROR;
 			}
 		}

--- a/channels/server/channels.c
+++ b/channels/server/channels.c
@@ -54,6 +54,10 @@
 #include <freerdp/server/disp.h>
 #include <freerdp/server/gfxredir.h>
 
+#if defined(CHANNEL_AINPUT_SERVER)
+#include <freerdp/server/ainput.h>
+#endif
+
 extern void freerdp_channels_dummy(void);
 
 void freerdp_channels_dummy(void)
@@ -101,6 +105,12 @@ void freerdp_channels_dummy(void)
 	gfxredir = gfxredir_server_context_new(NULL);
 	gfxredir_server_context_free(gfxredir);
 #endif // WITH_CHANNEL_GFXREDIR
+#if defined(CHANNEL_AINPUT_SERVER)
+	{
+		ainput_server_context* ainput = ainput_server_context_new(NULL);
+		ainput_server_context_free(ainput);
+	}
+#endif
 }
 
 /**

--- a/client/Android/android_freerdp.c
+++ b/client/Android/android_freerdp.c
@@ -71,19 +71,20 @@ static void android_OnChannelConnectedEventHandler(void* context,
 	}
 
 	afc = (androidContext*)context;
-	settings = afc->rdpCtx.settings;
+	settings = afc->common.context.settings;
 
 	if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
 		{
-			gdi_graphics_pipeline_init(afc->rdpCtx.gdi, (RdpgfxClientContext*)e->pInterface);
+			gdi_graphics_pipeline_init(afc->common.context.gdi,
+			                           (RdpgfxClientContext*)e->pInterface);
 		}
-		else
-		{
-			WLog_WARN(TAG, "GFX without software GDI requested. "
-			               " This is not supported, add /gdi:sw");
-		}
+	else
+	{
+		WLog_WARN(TAG, "GFX without software GDI requested. "
+			           " This is not supported, add /gdi:sw");
+	}
 	}
 	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
 	{
@@ -104,19 +105,20 @@ static void android_OnChannelDisconnectedEventHandler(void* context,
 	}
 
 	afc = (androidContext*)context;
-	settings = afc->rdpCtx.settings;
+	settings = afc->common.context.settings;
 
 	if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
 		{
-			gdi_graphics_pipeline_uninit(afc->rdpCtx.gdi, (RdpgfxClientContext*)e->pInterface);
+			gdi_graphics_pipeline_uninit(afc->common.context.gdi,
+			                             (RdpgfxClientContext*)e->pInterface);
 		}
-		else
-		{
-			WLog_WARN(TAG, "GFX without software GDI requested. "
-			               " This is not supported, add /gdi:sw");
-		}
+	else
+	{
+		WLog_WARN(TAG, "GFX without software GDI requested. "
+			           " This is not supported, add /gdi:sw");
+	}
 	}
 	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
 	{
@@ -153,7 +155,7 @@ static BOOL android_end_paint(rdpContext* context)
 	if (!gdi || !gdi->primary || !gdi->primary->hdc)
 		return FALSE;
 
-	hwnd = ctx->rdpCtx.gdi->primary->hdc->hwnd;
+	hwnd = ctx->common.context.gdi->primary->hdc->hwnd;
 
 	if (!hwnd)
 		return FALSE;
@@ -528,7 +530,7 @@ static int android_freerdp_run(freerdp* instance)
 		count += tmp;
 		status = WaitForMultipleObjects(count, handles, FALSE, INFINITE);
 
-		if ((status == WAIT_FAILED))
+		if (status == WAIT_FAILED)
 		{
 			WLog_ERR(TAG, "WaitForMultipleObjects failed with %" PRIu32 " [%08lX]", status,
 			         GetLastError());

--- a/client/Android/android_freerdp.c
+++ b/client/Android/android_freerdp.c
@@ -76,7 +76,7 @@ static void android_OnChannelConnectedEventHandler(void* context,
 	if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
 	{
 		android_cliprdr_init(afc, (CliprdrClientContext*)e->pInterface);
-	    }
+	}
 	else
 		freerdp_client_OnChannelConnectedEventHandler(context, e);
 }
@@ -99,7 +99,7 @@ static void android_OnChannelDisconnectedEventHandler(void* context,
 	if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
 	{
 		android_cliprdr_uninit(afc, (CliprdrClientContext*)e->pInterface);
-	    }
+	}
 	else
 		freerdp_client_OnChannelDisconnectedEventHandler(context, e);
 }

--- a/client/Android/android_freerdp.c
+++ b/client/Android/android_freerdp.c
@@ -73,23 +73,12 @@ static void android_OnChannelConnectedEventHandler(void* context,
 	afc = (androidContext*)context;
 	settings = afc->common.context.settings;
 
-	if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		if (settings->SoftwareGdi)
-		{
-			gdi_graphics_pipeline_init(afc->common.context.gdi,
-			                           (RdpgfxClientContext*)e->pInterface);
-		}
-	else
-	{
-		WLog_WARN(TAG, "GFX without software GDI requested. "
-			           " This is not supported, add /gdi:sw");
-	}
-	}
-	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
+	if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
 	{
 		android_cliprdr_init(afc, (CliprdrClientContext*)e->pInterface);
-	}
+	    }
+	else
+		freerdp_client_OnChannelConnectedEventHandler(context, e);
 }
 
 static void android_OnChannelDisconnectedEventHandler(void* context,
@@ -107,23 +96,12 @@ static void android_OnChannelDisconnectedEventHandler(void* context,
 	afc = (androidContext*)context;
 	settings = afc->common.context.settings;
 
-	if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		if (settings->SoftwareGdi)
-		{
-			gdi_graphics_pipeline_uninit(afc->common.context.gdi,
-			                             (RdpgfxClientContext*)e->pInterface);
-		}
-	else
-	{
-		WLog_WARN(TAG, "GFX without software GDI requested. "
-			           " This is not supported, add /gdi:sw");
-	}
-	}
-	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
+	if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
 	{
 		android_cliprdr_uninit(afc, (CliprdrClientContext*)e->pInterface);
-	}
+	    }
+	else
+		freerdp_client_OnChannelDisconnectedEventHandler(context, e);
 }
 
 static BOOL android_begin_paint(rdpContext* context)

--- a/client/Android/android_freerdp.h
+++ b/client/Android/android_freerdp.h
@@ -23,7 +23,7 @@
 
 struct android_context
 {
-	rdpContext rdpCtx;
+	rdpClientContext common;
 
 	ANDROID_EVENT_QUEUE* event_queue;
 	HANDLE thread;

--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -318,7 +318,7 @@ DWORD WINAPI mac_client_thread(void *param)
 	NSPoint loc = [event locationInWindow];
 	int x = (int)loc.x;
 	int y = (int)loc.y;
-	mf_scale_mouse_event(context, instance->input, PTR_FLAGS_MOVE, x, y);
+	mf_scale_mouse_event(context, PTR_FLAGS_MOVE, x, y);
 }
 
 - (void)mouseDown:(NSEvent *)event
@@ -331,7 +331,7 @@ DWORD WINAPI mac_client_thread(void *param)
 	NSPoint loc = [event locationInWindow];
 	int x = (int)loc.x;
 	int y = (int)loc.y;
-	mf_press_mouse_button(context, instance->input, 0, x, y, TRUE);
+	mf_press_mouse_button(context, 0, x, y, TRUE);
 }
 
 - (void)mouseUp:(NSEvent *)event
@@ -344,7 +344,7 @@ DWORD WINAPI mac_client_thread(void *param)
 	NSPoint loc = [event locationInWindow];
 	int x = (int)loc.x;
 	int y = (int)loc.y;
-	mf_press_mouse_button(context, instance->input, 0, x, y, FALSE);
+	mf_press_mouse_button(context, 0, x, y, FALSE);
 }
 
 - (void)rightMouseDown:(NSEvent *)event
@@ -357,7 +357,7 @@ DWORD WINAPI mac_client_thread(void *param)
 	NSPoint loc = [event locationInWindow];
 	int x = (int)loc.x;
 	int y = (int)loc.y;
-	mf_press_mouse_button(context, instance->input, 1, x, y, TRUE);
+	mf_press_mouse_button(context, 1, x, y, TRUE);
 }
 
 - (void)rightMouseUp:(NSEvent *)event
@@ -370,7 +370,7 @@ DWORD WINAPI mac_client_thread(void *param)
 	NSPoint loc = [event locationInWindow];
 	int x = (int)loc.x;
 	int y = (int)loc.y;
-	mf_press_mouse_button(context, instance->input, 1, x, y, FALSE);
+	mf_press_mouse_button(context, 1, x, y, FALSE);
 }
 
 - (void)otherMouseDown:(NSEvent *)event
@@ -384,7 +384,7 @@ DWORD WINAPI mac_client_thread(void *param)
 	int x = (int)loc.x;
 	int y = (int)loc.y;
 	int pressed = [event buttonNumber];
-	mf_press_mouse_button(context, instance->input, pressed, x, y, TRUE);
+	mf_press_mouse_button(context, pressed, x, y, TRUE);
 }
 
 - (void)otherMouseUp:(NSEvent *)event
@@ -398,7 +398,7 @@ DWORD WINAPI mac_client_thread(void *param)
 	int x = (int)loc.x;
 	int y = (int)loc.y;
 	int pressed = [event buttonNumber];
-	mf_press_mouse_button(context, instance->input, pressed, x, y, FALSE);
+	mf_press_mouse_button(context, pressed, x, y, FALSE);
 }
 
 - (void)scrollWheel:(NSEvent *)event
@@ -447,7 +447,7 @@ DWORD WINAPI mac_client_thread(void *param)
 	if (flags & PTR_FLAGS_WHEEL_NEGATIVE)
 		step = 0x100 - step;
 
-	mf_scale_mouse_event(context, instance->input, flags | step, 0, 0);
+	mf_scale_mouse_event(context, flags | step, 0, 0);
 }
 
 - (void)mouseDragged:(NSEvent *)event
@@ -461,7 +461,7 @@ DWORD WINAPI mac_client_thread(void *param)
 	int x = (int)loc.x;
 	int y = (int)loc.y;
 	// send mouse motion event to RDP server
-	mf_scale_mouse_event(context, instance->input, PTR_FLAGS_MOVE, x, y);
+	mf_scale_mouse_event(context, PTR_FLAGS_MOVE, x, y);
 }
 
 DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)

--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -826,22 +826,15 @@ static void mac_OnChannelConnectedEventHandler(void *context, const ChannelConne
 	settings = mfc->common.context.settings;
 	WINPR_ASSERT(settings);
 
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
-	{
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		if (settings->SoftwareGdi)
-			gdi_graphics_pipeline_init(mfc->common.context.gdi,
-			                           (RdpgfxClientContext *)e->pInterface);
-	}
-	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
+	if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
 	{
 		mac_cliprdr_init(mfc, (CliprdrClientContext *)e->pInterface);
 	}
 	else if (strcmp(e->name, ENCOMSP_SVC_CHANNEL_NAME) == 0)
 	{
 	}
+	else
+		freerdp_client_OnChannelConnectedEventHandler(context, e);
 }
 
 static void mac_OnChannelDisconnectedEventHandler(void *context,
@@ -856,22 +849,15 @@ static void mac_OnChannelDisconnectedEventHandler(void *context,
 	settings = mfc->common.context.settings;
 	WINPR_ASSERT(settings);
 
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
-	{
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		if (settings->SoftwareGdi)
-			gdi_graphics_pipeline_uninit(mfc->common.context.gdi,
-			                             (RdpgfxClientContext *)e->pInterface);
-	}
-	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
+	if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
 	{
 		mac_cliprdr_uninit(mfc, (CliprdrClientContext *)e->pInterface);
 	}
 	else if (strcmp(e->name, ENCOMSP_SVC_CHANNEL_NAME) == 0)
 	{
 	}
+	else
+		freerdp_client_OnChannelDisconnectedEventHandler(context, e);
 }
 
 BOOL mac_pre_connect(freerdp *instance)

--- a/client/Mac/cli/AppDelegate.m
+++ b/client/Mac/cli/AppDelegate.m
@@ -10,6 +10,8 @@
 #import "MacFreeRDP/mfreerdp.h"
 #import "MacFreeRDP/mf_client.h"
 #import "MacFreeRDP/MRDPView.h"
+
+#import <winpr/assert.h>
 #import <freerdp/client/cmdline.h>
 
 static AppDelegate *_singleDelegate = nil;
@@ -38,17 +40,22 @@ void mac_set_view_size(rdpContext *context, MRDPView *view);
 	[self CreateContext];
 	status = [self ParseCommandLineArguments];
 	mfc = (mfContext *)context;
+	WINPR_ASSERT(mfc);
+
 	mfc->view = (void *)mrdpView;
 
 	if (status == 0)
 	{
 		NSScreen *screen = [[NSScreen screens] objectAtIndex:0];
 		NSRect screenFrame = [screen frame];
+		rdpSettings *settings = context->settings;
 
-		if (context->instance->settings->Fullscreen)
+		WINPR_ASSERT(settings);
+
+		if (settings->Fullscreen)
 		{
-			context->instance->settings->DesktopWidth = screenFrame.size.width;
-			context->instance->settings->DesktopHeight = screenFrame.size.height;
+			settings->DesktopWidth = screenFrame.size.width;
+			settings->DesktopHeight = screenFrame.size.height;
 		}
 
 		PubSub_SubscribeConnectionResult(context->pubSub, AppDelegate_ConnectionResultEventHandler);
@@ -58,17 +65,17 @@ void mac_set_view_size(rdpContext *context, MRDPView *view);
 		freerdp_client_start(context);
 		NSString *winTitle;
 
-		if (mfc->context.settings->WindowTitle && mfc->context.settings->WindowTitle[0])
+		if (settings->WindowTitle && settings->WindowTitle[0])
 		{
-			winTitle = [[NSString alloc] initWithCString:mfc->context.settings->WindowTitle];
+			winTitle = [[NSString alloc] initWithCString:settings->WindowTitle];
 		}
 		else
 		{
 			winTitle = [[NSString alloc]
 			    initWithFormat:@"%@:%u",
-			                   [NSString stringWithCString:mfc->context.settings->ServerHostname
+			                   [NSString stringWithCString:settings->ServerHostname
 			                                      encoding:NSUTF8StringEncoding],
-			                   mfc -> context.settings->ServerPort];
+			                   settings -> ServerPort];
 		}
 
 		[window setTitle:winTitle];

--- a/client/Mac/cli/AppDelegate.m
+++ b/client/Mac/cli/AppDelegate.m
@@ -75,7 +75,7 @@ void mac_set_view_size(rdpContext *context, MRDPView *view);
 			    initWithFormat:@"%@:%u",
 			                   [NSString stringWithCString:settings->ServerHostname
 			                                      encoding:NSUTF8StringEncoding],
-			                   settings -> ServerPort];
+			                   settings->ServerPort];
 		}
 
 		[window setTitle:winTitle];

--- a/client/Mac/mf_client.h
+++ b/client/Mac/mf_client.h
@@ -29,12 +29,9 @@ extern "C"
 {
 #endif
 
-	FREERDP_API void mf_press_mouse_button(void* context, rdpInput* intput, int button, int x,
-	                                       int y, BOOL down);
-	FREERDP_API void mf_scale_mouse_event(void* context, rdpInput* input, UINT16 flags, UINT16 x,
-	                                      UINT16 y);
-	FREERDP_API void mf_scale_mouse_event_ex(void* context, rdpInput* input, UINT16 flags, UINT16 x,
-	                                         UINT16 y);
+	FREERDP_API void mf_press_mouse_button(void* context, int button, int x, int y, BOOL down);
+	FREERDP_API void mf_scale_mouse_event(void* context, UINT16 flags, UINT16 x, UINT16 y);
+	FREERDP_API void mf_scale_mouse_event_ex(void* context, UINT16 flags, UINT16 x, UINT16 y);
 
 	/**
 	 * Client Interface

--- a/client/Mac/mf_client.m
+++ b/client/Mac/mf_client.m
@@ -141,7 +141,7 @@ static void mf_scale_mouse_coordinates(mfContext *mfc, UINT16 *px, UINT16 *py)
 	*py = y;
 }
 
-void mf_scale_mouse_event(void *context, rdpInput *input, UINT16 flags, UINT16 x, UINT16 y)
+void mf_scale_mouse_event(void *context, UINT16 flags, UINT16 x, UINT16 y)
 {
 	mfContext *mfc = (mfContext *)context;
 	MRDPView *view = (MRDPView *)mfc->view;
@@ -150,10 +150,10 @@ void mf_scale_mouse_event(void *context, rdpInput *input, UINT16 flags, UINT16 x
 
 	if ((flags & (PTR_FLAGS_WHEEL | PTR_FLAGS_HWHEEL)) == 0)
 		mf_scale_mouse_coordinates(mfc, &x, &y);
-	freerdp_input_send_mouse_event(input, flags, x, y);
+	freerdp_client_send_button_event(&mfc->common, FALSE, flags, x, y);
 }
 
-void mf_scale_mouse_event_ex(void *context, rdpInput *input, UINT16 flags, UINT16 x, UINT16 y)
+void mf_scale_mouse_event_ex(void *context, UINT16 flags, UINT16 x, UINT16 y)
 {
 	mfContext *mfc = (mfContext *)context;
 	MRDPView *view = (MRDPView *)mfc->view;
@@ -161,10 +161,10 @@ void mf_scale_mouse_event_ex(void *context, rdpInput *input, UINT16 flags, UINT1
 	y = [view frame].size.height - y;
 
 	mf_scale_mouse_coordinates(mfc, &x, &y);
-	freerdp_input_send_extended_mouse_event(input, flags, x, y);
+	freerdp_client_send_extended_button_event(&mfc->common, FALSE, flags, x, y);
 }
 
-void mf_press_mouse_button(void *context, rdpInput *input, int button, int x, int y, BOOL down)
+void mf_press_mouse_button(void *context, int button, int x, int y, BOOL down)
 {
 	UINT16 flags = 0;
 	UINT16 xflags = 0;
@@ -178,23 +178,23 @@ void mf_press_mouse_button(void *context, rdpInput *input, int button, int x, in
 	switch (button)
 	{
 		case 0:
-			mf_scale_mouse_event(context, input, flags | PTR_FLAGS_BUTTON1, x, y);
+			mf_scale_mouse_event(context, flags | PTR_FLAGS_BUTTON1, x, y);
 			break;
 
 		case 1:
-			mf_scale_mouse_event(context, input, flags | PTR_FLAGS_BUTTON2, x, y);
+			mf_scale_mouse_event(context, flags | PTR_FLAGS_BUTTON2, x, y);
 			break;
 
 		case 2:
-			mf_scale_mouse_event(context, input, flags | PTR_FLAGS_BUTTON3, x, y);
+			mf_scale_mouse_event(context, flags | PTR_FLAGS_BUTTON3, x, y);
 			break;
 
 		case 3:
-			mf_scale_mouse_event_ex(context, input, xflags | PTR_XFLAGS_BUTTON1, x, y);
+			mf_scale_mouse_event_ex(context, xflags | PTR_XFLAGS_BUTTON1, x, y);
 			break;
 
 		case 4:
-			mf_scale_mouse_event_ex(context, input, xflags | PTR_XFLAGS_BUTTON2, x, y);
+			mf_scale_mouse_event_ex(context, xflags | PTR_XFLAGS_BUTTON2, x, y);
 			break;
 
 		default:

--- a/client/Mac/mf_client.m
+++ b/client/Mac/mf_client.m
@@ -65,14 +65,7 @@ static int mfreerdp_client_stop(rdpContext *context)
 {
 	mfContext *mfc = (mfContext *)context;
 
-	freerdp_abort_connect(context->instance);
-	if (mfc->common.thread)
-	{
-		SetEvent(mfc->stopEvent);
-		WaitForSingleObject(mfc->common.thread, INFINITE);
-		CloseHandle(mfc->common.thread);
-		mfc->common.thread = NULL;
-	}
+	freerdp_client_common_stop(context);
 
 	if (mfc->view_ownership)
 	{

--- a/client/Mac/mf_client.m
+++ b/client/Mac/mf_client.m
@@ -22,6 +22,9 @@
 #endif
 
 #include "mfreerdp.h"
+
+#include <winpr/assert.h>
+
 #include <freerdp/constants.h>
 #include <freerdp/utils/signal.h>
 #include <freerdp/client/cmdline.h>
@@ -63,12 +66,12 @@ static int mfreerdp_client_stop(rdpContext *context)
 	mfContext *mfc = (mfContext *)context;
 
 	freerdp_abort_connect(context->instance);
-	if (mfc->thread)
+	if (mfc->common.thread)
 	{
 		SetEvent(mfc->stopEvent);
-		WaitForSingleObject(mfc->thread, INFINITE);
-		CloseHandle(mfc->thread);
-		mfc->thread = NULL;
+		WaitForSingleObject(mfc->common.thread, INFINITE);
+		CloseHandle(mfc->common.thread);
+		mfc->common.thread = NULL;
 	}
 
 	if (mfc->view_ownership)
@@ -86,7 +89,12 @@ static BOOL mfreerdp_client_new(freerdp *instance, rdpContext *context)
 {
 	mfContext *mfc;
 	rdpSettings *settings;
+
+	WINPR_ASSERT(instance);
+
 	mfc = (mfContext *)instance->context;
+	WINPR_ASSERT(mfc);
+
 	mfc->stopEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
 	context->instance->PreConnect = mac_pre_connect;
 	context->instance->PostConnect = mac_post_connect;
@@ -119,10 +127,10 @@ static void mf_scale_mouse_coordinates(mfContext *mfc, UINT16 *px, UINT16 *py)
 	UINT16 y = *py;
 	UINT32 ww = mfc->client_width;
 	UINT32 wh = mfc->client_height;
-	UINT32 dw = mfc->context.settings->DesktopWidth;
-	UINT32 dh = mfc->context.settings->DesktopHeight;
+	UINT32 dw = mfc->common.context.settings->DesktopWidth;
+	UINT32 dh = mfc->common.context.settings->DesktopHeight;
 
-	if (!mfc->context.settings->SmartSizing || ((ww == dw) && (wh == dh)))
+	if (!mfc->common.context.settings->SmartSizing || ((ww == dw) && (wh == dh)))
 	{
 		y = y + mfc->yCurrentScroll;
 		x = x + mfc->xCurrentScroll;
@@ -203,6 +211,8 @@ void mf_press_mouse_button(void *context, rdpInput *input, int button, int x, in
 
 int RdpClientEntry(RDP_CLIENT_ENTRY_POINTS *pEntryPoints)
 {
+	WINPR_ASSERT(pEntryPoints);
+
 	pEntryPoints->Version = 1;
 	pEntryPoints->Size = sizeof(RDP_CLIENT_ENTRY_POINTS_V1);
 	pEntryPoints->GlobalInit = mfreerdp_client_global_init;

--- a/client/Mac/mfreerdp.h
+++ b/client/Mac/mfreerdp.h
@@ -32,8 +32,7 @@ typedef struct mf_context mfContext;
 
 struct mf_context
 {
-	rdpContext context;
-	DEFINE_RDP_CLIENT_COMMON();
+	rdpClientContext common;
 
 	void* view;
 	BOOL view_ownership;

--- a/client/Sample/tf_channels.c
+++ b/client/Sample/tf_channels.c
@@ -79,6 +79,7 @@ void tf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEven
 
 	WINPR_ASSERT(tf);
 	WINPR_ASSERT(e);
+
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
 		tf->rdpei = (RdpeiClientContext*)e->pInterface;
@@ -86,7 +87,7 @@ void tf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEven
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
 		RdpgfxClientContext* gfx = (RdpgfxClientContext*)e->pInterface;
-		gdi_graphics_pipeline_init(tf->context.gdi, gfx);
+		gdi_graphics_pipeline_init(tf->common.context.gdi, gfx);
 	}
 	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
@@ -109,13 +110,14 @@ void tf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnect
 
 	WINPR_ASSERT(tf);
 	WINPR_ASSERT(e);
+
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
 		tf->rdpei = NULL;
 	}
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_graphics_pipeline_uninit(tf->context.gdi, (RdpgfxClientContext*)e->pInterface);
+		gdi_graphics_pipeline_uninit(tf->common.context.gdi, (RdpgfxClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{

--- a/client/Sample/tf_channels.c
+++ b/client/Sample/tf_channels.c
@@ -80,16 +80,7 @@ void tf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEven
 	WINPR_ASSERT(tf);
 	WINPR_ASSERT(e);
 
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
-	{
-		tf->rdpei = (RdpeiClientContext*)e->pInterface;
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		RdpgfxClientContext* gfx = (RdpgfxClientContext*)e->pInterface;
-		gdi_graphics_pipeline_init(tf->common.context.gdi, gfx);
-	}
-	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
+	if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
 	}
 	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
@@ -102,6 +93,8 @@ void tf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEven
 	{
 		tf_encomsp_init(tf, (EncomspClientContext*)e->pInterface);
 	}
+	else
+		freerdp_client_OnChannelConnectedEventHandler(context, e);
 }
 
 void tf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnectedEventArgs* e)
@@ -111,15 +104,7 @@ void tf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnect
 	WINPR_ASSERT(tf);
 	WINPR_ASSERT(e);
 
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
-	{
-		tf->rdpei = NULL;
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_graphics_pipeline_uninit(tf->common.context.gdi, (RdpgfxClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
+	if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
 	}
 	else if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
@@ -132,4 +117,6 @@ void tf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnect
 	{
 		tf_encomsp_uninit(tf, (EncomspClientContext*)e->pInterface);
 	}
+	else
+		freerdp_client_OnChannelDisconnectedEventHandler(context, e);
 }

--- a/client/Sample/tf_freerdp.h
+++ b/client/Sample/tf_freerdp.h
@@ -30,7 +30,7 @@
 
 struct tf_context
 {
-	rdpContext context;
+	rdpClientContext common;
 
 	/* Channels */
 	RdpeiClientContext* rdpei;

--- a/client/Sample/tf_freerdp.h
+++ b/client/Sample/tf_freerdp.h
@@ -33,8 +33,6 @@ struct tf_context
 	rdpClientContext common;
 
 	/* Channels */
-	RdpeiClientContext* rdpei;
-	RdpgfxClientContext* gfx;
 	EncomspClientContext* encomsp;
 };
 typedef struct tf_context tfContext;

--- a/client/Wayland/wlf_channels.c
+++ b/client/Wayland/wlf_channels.c
@@ -108,13 +108,8 @@ void wlf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEve
 	WINPR_ASSERT(wlf);
 	WINPR_ASSERT(e);
 
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
+	if (FALSE)
 	{
-		wlf->rdpei = (RdpeiClientContext*)e->pInterface;
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_graphics_pipeline_init(wlf->common.context.gdi, (RdpgfxClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
@@ -131,18 +126,8 @@ void wlf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEve
 	{
 		wlf_disp_init(wlf->disp, (DispClientContext*)e->pInterface);
 	}
-	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_geometry_init(wlf->common.context.gdi, (GeometryClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_control_init(wlf->common.context.gdi, (VideoClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_data_init(wlf->common.context.gdi, (VideoClientContext*)e->pInterface);
-	}
+	else
+		freerdp_client_OnChannelConnectedEventHandler(context, e);
 }
 
 void wlf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnectedEventArgs* e)
@@ -152,13 +137,8 @@ void wlf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnec
 	WINPR_ASSERT(wlf);
 	WINPR_ASSERT(e);
 
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
+	if (FALSE)
 	{
-		wlf->rdpei = NULL;
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_graphics_pipeline_uninit(wlf->common.context.gdi, (RdpgfxClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
@@ -175,16 +155,6 @@ void wlf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnec
 	{
 		wlf_disp_uninit(wlf->disp, (DispClientContext*)e->pInterface);
 	}
-	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_geometry_uninit(wlf->common.context.gdi, (GeometryClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_control_uninit(wlf->common.context.gdi, (VideoClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_data_uninit(wlf->common.context.gdi, (VideoClientContext*)e->pInterface);
-	}
+	else
+		freerdp_client_OnChannelDisconnectedEventHandler(context, e);
 }

--- a/client/Wayland/wlf_channels.c
+++ b/client/Wayland/wlf_channels.c
@@ -64,7 +64,9 @@ wlf_encomsp_participant_created(EncomspClientContext* context,
 		return ERROR_INVALID_PARAMETER;
 
 	wlf = (wlfContext*)context->custom;
-	settings = wlf->context.settings;
+	WINPR_ASSERT(wlf);
+
+	settings = wlf->common.context.settings;
 
 	if (!settings)
 		return ERROR_INVALID_PARAMETER;
@@ -103,13 +105,16 @@ void wlf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEve
 {
 	wlfContext* wlf = (wlfContext*)context;
 
+	WINPR_ASSERT(wlf);
+	WINPR_ASSERT(e);
+
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
 		wlf->rdpei = (RdpeiClientContext*)e->pInterface;
 	}
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_graphics_pipeline_init(wlf->context.gdi, (RdpgfxClientContext*)e->pInterface);
+		gdi_graphics_pipeline_init(wlf->common.context.gdi, (RdpgfxClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
@@ -128,15 +133,15 @@ void wlf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEve
 	}
 	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_geometry_init(wlf->context.gdi, (GeometryClientContext*)e->pInterface);
+		gdi_video_geometry_init(wlf->common.context.gdi, (GeometryClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_control_init(wlf->context.gdi, (VideoClientContext*)e->pInterface);
+		gdi_video_control_init(wlf->common.context.gdi, (VideoClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_data_init(wlf->context.gdi, (VideoClientContext*)e->pInterface);
+		gdi_video_data_init(wlf->common.context.gdi, (VideoClientContext*)e->pInterface);
 	}
 }
 
@@ -144,13 +149,16 @@ void wlf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnec
 {
 	wlfContext* wlf = (wlfContext*)context;
 
+	WINPR_ASSERT(wlf);
+	WINPR_ASSERT(e);
+
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
 		wlf->rdpei = NULL;
 	}
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_graphics_pipeline_uninit(wlf->context.gdi, (RdpgfxClientContext*)e->pInterface);
+		gdi_graphics_pipeline_uninit(wlf->common.context.gdi, (RdpgfxClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
@@ -169,14 +177,14 @@ void wlf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnec
 	}
 	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_geometry_uninit(wlf->context.gdi, (GeometryClientContext*)e->pInterface);
+		gdi_video_geometry_uninit(wlf->common.context.gdi, (GeometryClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_control_uninit(wlf->context.gdi, (VideoClientContext*)e->pInterface);
+		gdi_video_control_uninit(wlf->common.context.gdi, (VideoClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_data_uninit(wlf->context.gdi, (VideoClientContext*)e->pInterface);
+		gdi_video_data_uninit(wlf->common.context.gdi, (VideoClientContext*)e->pInterface);
 	}
 }

--- a/client/Wayland/wlf_cliprdr.c
+++ b/client/Wayland/wlf_cliprdr.c
@@ -889,14 +889,18 @@ static UINT wlf_cliprdr_clipboard_file_range_failure(wClipboardDelegate* delegat
 wfClipboard* wlf_clipboard_new(wlfContext* wfc)
 {
 	rdpChannels* channels;
-	wfClipboard* clipboard = (wfClipboard*)calloc(1, sizeof(wfClipboard));
+	wfClipboard* clipboard;
+
+	WINPR_ASSERT(wfc);
+
+	clipboard = (wfClipboard*)calloc(1, sizeof(wfClipboard));
 
 	if (!clipboard)
 		goto fail;
 
 	InitializeCriticalSection(&clipboard->lock);
 	clipboard->wfc = wfc;
-	channels = wfc->context.channels;
+	channels = wfc->common.context.channels;
 	clipboard->log = WLog_Get(TAG);
 	clipboard->channels = channels;
 	clipboard->system = ClipboardCreate();

--- a/client/Wayland/wlf_input.c
+++ b/client/Wayland/wlf_input.c
@@ -59,6 +59,7 @@ static BOOL scale_signed_coordinates(rdpContext* context, int32_t* x, int32_t* y
 BOOL wlf_handle_pointer_enter(freerdp* instance, const UwacPointerEnterLeaveEvent* ev)
 {
 	uint32_t x, y;
+	rdpClientContext* cctx;
 
 	if (!instance || !ev || !instance->input)
 		return FALSE;
@@ -71,15 +72,20 @@ BOOL wlf_handle_pointer_enter(freerdp* instance, const UwacPointerEnterLeaveEven
 
 	WINPR_ASSERT(x <= UINT16_MAX);
 	WINPR_ASSERT(y <= UINT16_MAX);
-	return freerdp_input_send_mouse_event(instance->input, PTR_FLAGS_MOVE, (UINT16)x, (UINT16)y);
+	cctx = (rdpClientContext*)instance->context;
+	return freerdp_client_send_button_event(cctx, FALSE, PTR_FLAGS_MOVE, x, y);
 }
 
 BOOL wlf_handle_pointer_motion(freerdp* instance, const UwacPointerMotionEvent* ev)
 {
 	uint32_t x, y;
+	rdpClientContext* cctx;
 
-	if (!instance || !ev || !instance->input)
+	if (!instance || !ev)
 		return FALSE;
+
+	cctx = (rdpClientContext*)instance->context;
+	WINPR_ASSERT(cctx);
 
 	x = ev->x;
 	y = ev->y;
@@ -89,26 +95,27 @@ BOOL wlf_handle_pointer_motion(freerdp* instance, const UwacPointerMotionEvent* 
 
 	WINPR_ASSERT(x <= UINT16_MAX);
 	WINPR_ASSERT(y <= UINT16_MAX);
-	return freerdp_input_send_mouse_event(instance->input, PTR_FLAGS_MOVE, (UINT16)x, (UINT16)y);
+	return freerdp_client_send_button_event(cctx, FALSE, PTR_FLAGS_MOVE, x, y);
 }
 
 BOOL wlf_handle_pointer_buttons(freerdp* instance, const UwacPointerButtonEvent* ev)
 {
-	rdpInput* input;
+	rdpClientContext* cctx;
 	UINT16 flags = 0;
 	UINT16 xflags = 0;
 	uint32_t x, y;
 
-	if (!instance || !ev || !instance->input)
+	if (!instance || !ev)
 		return FALSE;
+
+	cctx = (rdpClientContext*)instance->context;
+	WINPR_ASSERT(cctx);
 
 	x = ev->x;
 	y = ev->y;
 
 	if (!wlf_scale_coordinates(instance->context, &x, &y, TRUE))
 		return FALSE;
-
-	input = instance->input;
 
 	if (ev->state == WL_POINTER_BUTTON_STATE_PRESSED)
 	{
@@ -146,10 +153,10 @@ BOOL wlf_handle_pointer_buttons(freerdp* instance, const UwacPointerButtonEvent*
 	WINPR_ASSERT(y <= UINT16_MAX);
 
 	if ((flags & ~PTR_FLAGS_DOWN) != 0)
-		return freerdp_input_send_mouse_event(input, flags, (UINT16)x, (UINT16)y);
+		return freerdp_client_send_button_event(cctx, FALSE, flags, x, y);
 
 	if ((xflags & ~PTR_XFLAGS_DOWN) != 0)
-		return freerdp_input_send_extended_mouse_event(input, xflags, (UINT16)x, (UINT16)y);
+		return freerdp_client_send_extended_button_event(cctx, FALSE, xflags, x, y);
 
 	return FALSE;
 }
@@ -177,20 +184,18 @@ BOOL wlf_handle_pointer_axis_discrete(freerdp* instance, const UwacPointerAxisEv
 static BOOL wlf_handle_wheel(freerdp* instance, uint32_t x, uint32_t y, uint32_t axis,
                              int32_t value)
 {
-	rdpInput* input;
+	rdpClientContext* cctx;
 	UINT16 flags = 0;
 	int32_t direction;
 	uint32_t avalue = (uint32_t)abs(value);
 
 	WINPR_ASSERT(instance);
 
-	input = instance->input;
-	WINPR_ASSERT(input);
+	cctx = (rdpClientContext*)instance->context;
+	WINPR_ASSERT(cctx);
 
 	if (!wlf_scale_coordinates(instance->context, &x, &y, TRUE))
 		return FALSE;
-
-	input = instance->input;
 
 	direction = value;
 	switch (axis)
@@ -224,7 +229,7 @@ static BOOL wlf_handle_wheel(freerdp* instance, uint32_t x, uint32_t y, uint32_t
 		/* Convert negative values to 9bit twos complement */
 		if (flags & PTR_FLAGS_WHEEL_NEGATIVE)
 			cflags = (flags & 0xFF00) | (0x100 - cval);
-		if (!freerdp_input_send_mouse_event(input, cflags, (UINT16)x, (UINT16)y))
+		if (!freerdp_client_send_wheel_event(cctx, cflags))
 			return FALSE;
 
 		avalue -= cval;
@@ -358,9 +363,13 @@ BOOL wlf_keyboard_modifiers(freerdp* instance, const UwacKeyboardModifiersEvent*
 {
 	rdpInput* input;
 	UINT16 syncFlags;
+	wlfContext* wlf;
 
 	if (!instance || !ev || !instance->input)
 		return FALSE;
+
+	wlf = (wlfContext*)instance->context;
+	WINPR_ASSERT(wlf);
 
 	input = instance->input;
 	syncFlags = 0;
@@ -370,13 +379,13 @@ BOOL wlf_keyboard_modifiers(freerdp* instance, const UwacKeyboardModifiersEvent*
 	if (ev->modifiers & UWAC_MOD_NUM_MASK)
 		syncFlags |= KBD_SYNC_NUM_LOCK;
 
-	if (!((wlfContext*)instance->context)->focusing)
+	if (!wlf->focusing)
 		return TRUE;
 
 	((wlfContext*)instance->context)->focusing = FALSE;
 
 	return freerdp_input_send_focus_in_event(input, syncFlags) &&
-	       freerdp_input_send_mouse_event(input, PTR_FLAGS_MOVE, 0, 0);
+	       freerdp_client_send_button_event(&wlf->common, FALSE, PTR_FLAGS_MOVE, 0, 0);
 }
 
 BOOL wlf_handle_touch_up(freerdp* instance, const UwacTouchUp* ev)
@@ -422,7 +431,7 @@ BOOL wlf_handle_touch_up(freerdp* instance, const UwacTouchUp* ev)
 
 		WINPR_ASSERT(x <= UINT16_MAX);
 		WINPR_ASSERT(y <= UINT16_MAX);
-		return freerdp_input_send_mouse_event(instance->input, flags, (UINT16)x, (UINT16)y);
+		return freerdp_client_send_button_event(&wlf->common, FALSE, flags, x, y);
 	}
 
 	if (!rdpei)
@@ -483,7 +492,7 @@ BOOL wlf_handle_touch_down(freerdp* instance, const UwacTouchDown* ev)
 
 		WINPR_ASSERT(x <= UINT16_MAX);
 		WINPR_ASSERT(y <= UINT16_MAX);
-		return freerdp_input_send_mouse_event(instance->input, flags, (UINT16)x, (UINT16)y);
+		return freerdp_client_send_button_event(&wlf->common, FALSE, flags, x, y);
 	}
 
 	WINPR_ASSERT(rdpei);
@@ -541,7 +550,7 @@ BOOL wlf_handle_touch_motion(freerdp* instance, const UwacTouchMotion* ev)
 
 		WINPR_ASSERT(x <= UINT16_MAX);
 		WINPR_ASSERT(y <= UINT16_MAX);
-		return freerdp_input_send_mouse_event(instance->input, flags, (UINT16)x, (UINT16)y);
+		return freerdp_client_send_button_event(&wlf->common, FALSE, flags, x, y);
 	}
 
 	if (!rdpei)

--- a/client/Wayland/wlf_input.c
+++ b/client/Wayland/wlf_input.c
@@ -413,7 +413,7 @@ BOOL wlf_handle_touch_up(freerdp* instance, const UwacTouchUp* ev)
 	if (!scale_signed_coordinates(instance->context, &x, &y, TRUE))
 		return FALSE;
 
-	RdpeiClientContext* rdpei = wlf->rdpei;
+	RdpeiClientContext* rdpei = wlf->common.rdpei;
 
 	if (wlf->contacts[i].emulate_mouse == TRUE)
 	{
@@ -469,7 +469,7 @@ BOOL wlf_handle_touch_down(freerdp* instance, const UwacTouchDown* ev)
 	if (!scale_signed_coordinates(instance->context, &x, &y, TRUE))
 		return FALSE;
 
-	RdpeiClientContext* rdpei = wlf->rdpei;
+	RdpeiClientContext* rdpei = wlf->common.rdpei;
 
 	// Emulate mouse click if touch is not possible, like in login screen
 	if (!rdpei)
@@ -532,7 +532,7 @@ BOOL wlf_handle_touch_motion(freerdp* instance, const UwacTouchMotion* ev)
 	if (!scale_signed_coordinates(instance->context, &x, &y, TRUE))
 		return FALSE;
 
-	RdpeiClientContext* rdpei = ((wlfContext*)instance->context)->rdpei;
+	RdpeiClientContext* rdpei = ((wlfContext*)instance->context)->common.rdpei;
 
 	if (wlf->contacts[i].emulate_mouse == TRUE)
 	{

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -679,12 +679,6 @@ static int wfl_client_start(rdpContext* context)
 	return 0;
 }
 
-static int wfl_client_stop(rdpContext* context)
-{
-	WINPR_UNUSED(context);
-	return 0;
-}
-
 static int RdpClientEntry(RDP_CLIENT_ENTRY_POINTS* pEntryPoints)
 {
 	ZeroMemory(pEntryPoints, sizeof(RDP_CLIENT_ENTRY_POINTS));
@@ -696,7 +690,7 @@ static int RdpClientEntry(RDP_CLIENT_ENTRY_POINTS* pEntryPoints)
 	pEntryPoints->ClientNew = wlf_client_new;
 	pEntryPoints->ClientFree = wlf_client_free;
 	pEntryPoints->ClientStart = wfl_client_start;
-	pEntryPoints->ClientStop = wfl_client_stop;
+	pEntryPoints->ClientStop = freerdp_client_common_stop;
 	return 0;
 }
 

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -90,7 +90,7 @@ static BOOL wl_update_buffer(wlfContext* context_w, INT32 ix, INT32 iy, INT32 iw
 	if (!data || (rc != UWAC_SUCCESS))
 		goto fail;
 
-	gdi = context_w->context.gdi;
+	gdi = context_w->common.context.gdi;
 
 	if (!gdi)
 		goto fail;
@@ -109,13 +109,13 @@ static BOOL wl_update_buffer(wlfContext* context_w, INT32 ix, INT32 iy, INT32 iw
 
 	if (!wlf_copy_image(gdi->primary_buffer, gdi->stride, gdi->width, gdi->height, data, stride,
 	                    geometry.width, geometry.height, &area,
-	                    context_w->context.settings->SmartSizing))
+	                    context_w->common.context.settings->SmartSizing))
 		goto fail;
 
-	if (!wlf_scale_coordinates(&context_w->context, &x, &y, FALSE))
+	if (!wlf_scale_coordinates(&context_w->common.context, &x, &y, FALSE))
 		goto fail;
 
-	if (!wlf_scale_coordinates(&context_w->context, &w, &h, FALSE))
+	if (!wlf_scale_coordinates(&context_w->common.context, &w, &h, FALSE))
 		goto fail;
 
 	if (UwacWindowAddDamage(context_w->window, x, y, w, h) != UWAC_SUCCESS)
@@ -157,10 +157,10 @@ static BOOL wl_refresh_display(wlfContext* context)
 {
 	rdpGdi* gdi;
 
-	if (!context || !context->context.gdi)
+	if (!context || !context->common.context.gdi)
 		return FALSE;
 
-	gdi = context->context.gdi;
+	gdi = context->common.context.gdi;
 	return wl_update_buffer(context, 0, 0, gdi->width, gdi->height);
 }
 
@@ -564,7 +564,7 @@ static int wlfreerdp_run(freerdp* instance)
 		if ((status != WAIT_TIMEOUT) && (status == WAIT_OBJECT_0))
 		{
 			timerEvent.now = GetTickCount64();
-			PubSub_OnTimer(context->context.pubSub, context, &timerEvent);
+			PubSub_OnTimer(context->common.context.pubSub, context, &timerEvent);
 		}
 	}
 

--- a/client/Wayland/wlfreerdp.h
+++ b/client/Wayland/wlfreerdp.h
@@ -56,8 +56,6 @@ struct wlf_context
 	BOOL focusing;
 
 	/* Channels */
-	RdpeiClientContext* rdpei;
-	RdpgfxClientContext* gfx;
 	EncomspClientContext* encomsp;
 	wfClipboard* clipboard;
 	wlfDispContext* disp;

--- a/client/Wayland/wlfreerdp.h
+++ b/client/Wayland/wlfreerdp.h
@@ -44,7 +44,7 @@ typedef struct touch_contact
 
 struct wlf_context
 {
-	rdpContext context;
+	rdpClientContext common;
 
 	UwacDisplay* display;
 	HANDLE displayHandle;

--- a/client/Windows/wf_channels.c
+++ b/client/Windows/wf_channels.c
@@ -20,6 +20,8 @@
 #include "config.h"
 #endif
 
+#include <winpr/assert.h>
+
 #include "wf_channels.h"
 
 #include "wf_rail.h"
@@ -34,7 +36,13 @@
 void wf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEventArgs* e)
 {
 	wfContext* wfc = (wfContext*)context;
-	rdpSettings* settings = wfc->context.settings;
+	rdpSettings* settings;
+
+	WINPR_ASSERT(wfc);
+	WINPR_ASSERT(e);
+
+	settings = wfc->common.context.settings;
+	WINPR_ASSERT(settings);
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
@@ -45,7 +53,7 @@ void wf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEven
 			WLog_WARN(TAG, "Channel " RDPGFX_DVC_CHANNEL_NAME
 			               " does not support hardware acceleration, using fallback.");
 
-		gdi_graphics_pipeline_init(wfc->context.gdi, (RdpgfxClientContext*)e->pInterface);
+		gdi_graphics_pipeline_init(wfc->common.context.gdi, (RdpgfxClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
@@ -64,29 +72,35 @@ void wf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEven
 	}
 	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_geometry_init(wfc->context.gdi, (GeometryClientContext*)e->pInterface);
+		gdi_video_geometry_init(wfc->common.context.gdi, (GeometryClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_control_init(wfc->context.gdi, (VideoClientContext*)e->pInterface);
+		gdi_video_control_init(wfc->common.context.gdi, (VideoClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_data_init(wfc->context.gdi, (VideoClientContext*)e->pInterface);
+		gdi_video_data_init(wfc->common.context.gdi, (VideoClientContext*)e->pInterface);
 	}
 }
 
 void wf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnectedEventArgs* e)
 {
 	wfContext* wfc = (wfContext*)context;
-	rdpSettings* settings = wfc->context.settings;
+	rdpSettings* settings;
+
+	WINPR_ASSERT(wfc);
+	WINPR_ASSERT(e);
+
+	settings = wfc->common.context.settings;
+	WINPR_ASSERT(settings);
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
 	}
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_graphics_pipeline_uninit(wfc->context.gdi, (RdpgfxClientContext*)e->pInterface);
+		gdi_graphics_pipeline_uninit(wfc->common.context.gdi, (RdpgfxClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
@@ -105,14 +119,14 @@ void wf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnect
 	}
 	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_geometry_uninit(wfc->context.gdi, (GeometryClientContext*)e->pInterface);
+		gdi_video_geometry_uninit(wfc->common.context.gdi, (GeometryClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_control_uninit(wfc->context.gdi, (VideoClientContext*)e->pInterface);
+		gdi_video_control_uninit(wfc->common.context.gdi, (VideoClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_data_uninit(wfc->context.gdi, (VideoClientContext*)e->pInterface);
+		gdi_video_data_uninit(wfc->common.context.gdi, (VideoClientContext*)e->pInterface);
 	}
 }

--- a/client/Windows/wf_channels.c
+++ b/client/Windows/wf_channels.c
@@ -44,18 +44,7 @@ void wf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEven
 	settings = wfc->common.context.settings;
 	WINPR_ASSERT(settings);
 
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
-	{
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		if (!settings->SoftwareGdi)
-			WLog_WARN(TAG, "Channel " RDPGFX_DVC_CHANNEL_NAME
-			               " does not support hardware acceleration, using fallback.");
-
-		gdi_graphics_pipeline_init(wfc->common.context.gdi, (RdpgfxClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
+	if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
 		wf_rail_init(wfc, (RailClientContext*)e->pInterface);
 	}
@@ -70,18 +59,8 @@ void wf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEven
 	{
 		wfc->disp = (DispClientContext*)e->pInterface;
 	}
-	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_geometry_init(wfc->common.context.gdi, (GeometryClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_control_init(wfc->common.context.gdi, (VideoClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_data_init(wfc->common.context.gdi, (VideoClientContext*)e->pInterface);
-	}
+	else
+		freerdp_client_OnChannelConnectedEventHandler(context, e);
 }
 
 void wf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnectedEventArgs* e)
@@ -95,14 +74,7 @@ void wf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnect
 	settings = wfc->common.context.settings;
 	WINPR_ASSERT(settings);
 
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
-	{
-	}
-	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_graphics_pipeline_uninit(wfc->common.context.gdi, (RdpgfxClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
+	if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
 	{
 		wf_rail_uninit(wfc, (RailClientContext*)e->pInterface);
 	}
@@ -117,16 +89,6 @@ void wf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnect
 	{
 		wfc->disp = NULL;
 	}
-	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_geometry_uninit(wfc->common.context.gdi, (GeometryClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_control_uninit(wfc->common.context.gdi, (VideoClientContext*)e->pInterface);
-	}
-	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_data_uninit(wfc->common.context.gdi, (VideoClientContext*)e->pInterface);
-	}
+	else
+		freerdp_client_OnChannelDisconnectedEventHandler(context, e);
 }

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -46,7 +46,6 @@
 #endif
 
 #include <freerdp/log.h>
-#include <freerdp/event.h>
 #include <freerdp/freerdp.h>
 #include <freerdp/constants.h>
 

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -26,6 +26,7 @@
 #include <winpr/windows.h>
 
 #include <winpr/crt.h>
+#include <winpr/assert.h>
 
 #include <errno.h>
 #include <stdio.h>
@@ -295,7 +296,7 @@ static void wf_add_system_menu(wfContext* wfc)
 		return;
 	}
 
-	if (wfc->context.settings->DynamicResolutionUpdate)
+	if (wfc->common.context.settings->DynamicResolutionUpdate)
 	{
 		return;
 	}
@@ -311,7 +312,7 @@ static void wf_add_system_menu(wfContext* wfc)
 	item_info.dwItemData = (ULONG_PTR)wfc;
 	InsertMenuItem(hMenu, 6, TRUE, &item_info);
 
-	if (wfc->context.settings->SmartSizing)
+	if (wfc->common.context.settings->SmartSizing)
 	{
 		CheckMenuItem(hMenu, SYSCOMMAND_ID_SMARTSIZING, MF_CHECKED);
 	}
@@ -488,9 +489,9 @@ static BOOL wf_authenticate_raw(freerdp* instance, const char* title, char** use
 
 	if (!(username && *username && password && *password))
 	{
-		if (!wfc->isConsole && wfc->context.settings->CredentialsFromStdin)
+		if (!wfc->isConsole && wfc->common.context.settings->CredentialsFromStdin)
 			WLog_ERR(TAG, "Flag for stdin read present but stdin is redirected; using GUI");
-		if (wfc->isConsole && wfc->context.settings->CredentialsFromStdin)
+		if (wfc->isConsole && wfc->common.context.settings->CredentialsFromStdin)
 			status = CredUICmdLinePromptForCredentialsA(
 			    title, NULL, 0, UserName, CREDUI_MAX_USERNAME_LENGTH + 1, Password,
 			    CREDUI_MAX_PASSWORD_LENGTH + 1, &fSave, dwFlags);
@@ -1181,13 +1182,19 @@ int freerdp_client_set_window_size(wfContext* wfc, int width, int height)
 
 void wf_size_scrollbars(wfContext* wfc, UINT32 client_width, UINT32 client_height)
 {
+	const rdpSettings* settings;
+	WINPR_ASSERT(wfc);
+
+	settings = wfc->common.context.settings;
+	WINPR_ASSERT(settings);
+
 	if (wfc->disablewindowtracking)
 		return;
 
 	// prevent infinite message loop
 	wfc->disablewindowtracking = TRUE;
 
-	if (wfc->context.settings->SmartSizing || wfc->context.settings->DynamicResolutionUpdate)
+	if (settings->SmartSizing || settings->DynamicResolutionUpdate)
 	{
 		wfc->xCurrentScroll = 0;
 		wfc->yCurrentScroll = 0;
@@ -1207,24 +1214,22 @@ void wf_size_scrollbars(wfContext* wfc, UINT32 client_width, UINT32 client_heigh
 		BOOL horiz = wfc->xScrollVisible;
 		BOOL vert = wfc->yScrollVisible;
 
-		if (!horiz && client_width < wfc->context.settings->DesktopWidth)
+		if (!horiz && client_width < settings->DesktopWidth)
 		{
 			horiz = TRUE;
 		}
 		else if (horiz &&
-		         client_width >=
-		             wfc->context.settings->DesktopWidth /* - GetSystemMetrics(SM_CXVSCROLL)*/)
+		         client_width >= settings->DesktopWidth /* - GetSystemMetrics(SM_CXVSCROLL)*/)
 		{
 			horiz = FALSE;
 		}
 
-		if (!vert && client_height < wfc->context.settings->DesktopHeight)
+		if (!vert && client_height < settings->DesktopHeight)
 		{
 			vert = TRUE;
 		}
 		else if (vert &&
-		         client_height >=
-		             wfc->context.settings->DesktopHeight /* - GetSystemMetrics(SM_CYHSCROLL)*/)
+		         client_height >= settings->DesktopHeight /* - GetSystemMetrics(SM_CYHSCROLL)*/)
 		{
 			vert = FALSE;
 		}
@@ -1259,12 +1264,12 @@ void wf_size_scrollbars(wfContext* wfc, UINT32 client_width, UINT32 client_heigh
 			// The horizontal scrolling range is defined by
 			// (bitmap_width) - (client_width). The current horizontal
 			// scroll value remains within the horizontal scrolling range.
-			wfc->xMaxScroll = MAX(wfc->context.settings->DesktopWidth - client_width, 0);
+			wfc->xMaxScroll = MAX(settings->DesktopWidth - client_width, 0);
 			wfc->xCurrentScroll = MIN(wfc->xCurrentScroll, wfc->xMaxScroll);
 			si.cbSize = sizeof(si);
 			si.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
 			si.nMin = wfc->xMinScroll;
-			si.nMax = wfc->context.settings->DesktopWidth;
+			si.nMax = settings->DesktopWidth;
 			si.nPage = client_width;
 			si.nPos = wfc->xCurrentScroll;
 			SetScrollInfo(wfc->hwnd, SB_HORZ, &si, TRUE);
@@ -1275,12 +1280,12 @@ void wf_size_scrollbars(wfContext* wfc, UINT32 client_width, UINT32 client_heigh
 			// The vertical scrolling range is defined by
 			// (bitmap_height) - (client_height). The current vertical
 			// scroll value remains within the vertical scrolling range.
-			wfc->yMaxScroll = MAX(wfc->context.settings->DesktopHeight - client_height, 0);
+			wfc->yMaxScroll = MAX(settings->DesktopHeight - client_height, 0);
 			wfc->yCurrentScroll = MIN(wfc->yCurrentScroll, wfc->yMaxScroll);
 			si.cbSize = sizeof(si);
 			si.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
 			si.nMin = wfc->yMinScroll;
-			si.nMax = wfc->context.settings->DesktopHeight;
+			si.nMax = settings->DesktopHeight;
 			si.nPage = client_height;
 			si.nPos = wfc->yCurrentScroll;
 			SetScrollInfo(wfc->hwnd, SB_VERT, &si, TRUE);
@@ -1396,9 +1401,10 @@ static int wfreerdp_client_start(rdpContext* context)
 	if (!wfc->keyboardThread)
 		return -1;
 
-	wfc->thread = CreateThread(NULL, 0, wf_client_thread, (void*)instance, 0, &wfc->mainThreadId);
+	wfc->common.thread =
+	    CreateThread(NULL, 0, wf_client_thread, (void*)instance, 0, &wfc->mainThreadId);
 
-	if (!wfc->thread)
+	if (!wfc->common.thread)
 		return -1;
 
 	return 0;
@@ -1408,12 +1414,12 @@ static int wfreerdp_client_stop(rdpContext* context)
 {
 	wfContext* wfc = (wfContext*)context;
 
-	if (wfc->thread)
+	if (wfc->common.thread)
 	{
 		PostThreadMessage(wfc->mainThreadId, WM_QUIT, 0, 0);
-		WaitForSingleObject(wfc->thread, INFINITE);
-		CloseHandle(wfc->thread);
-		wfc->thread = NULL;
+		WaitForSingleObject(wfc->common.thread, INFINITE);
+		CloseHandle(wfc->common.thread);
+		wfc->common.thread = NULL;
 		wfc->mainThreadId = 0;
 	}
 

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -1412,16 +1412,13 @@ static int wfreerdp_client_start(rdpContext* context)
 
 static int wfreerdp_client_stop(rdpContext* context)
 {
+	int rc;
 	wfContext* wfc = (wfContext*)context;
 
-	if (wfc->common.thread)
-	{
-		PostThreadMessage(wfc->mainThreadId, WM_QUIT, 0, 0);
-		WaitForSingleObject(wfc->common.thread, INFINITE);
-		CloseHandle(wfc->common.thread);
-		wfc->common.thread = NULL;
-		wfc->mainThreadId = 0;
-	}
+	WINPR_ASSERT(wfc);
+	PostThreadMessage(wfc->mainThreadId, WM_QUIT, 0, 0);
+	rc = freerdp_client_common_stop(context);
+	wfc->mainThreadId = 0;
 
 	if (wfc->keyboardThread)
 	{
@@ -1434,6 +1431,7 @@ static int wfreerdp_client_stop(rdpContext* context)
 
 	return 0;
 }
+
 
 int RdpClientEntry(RDP_CLIENT_ENTRY_POINTS* pEntryPoints)
 {

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -1431,7 +1431,6 @@ static int wfreerdp_client_stop(rdpContext* context)
 	return 0;
 }
 
-
 int RdpClientEntry(RDP_CLIENT_ENTRY_POINTS* pEntryPoints)
 {
 	pEntryPoints->Version = 1;

--- a/client/Windows/wf_client.h
+++ b/client/Windows/wf_client.h
@@ -78,8 +78,7 @@ extern "C"
 
 	struct wf_context
 	{
-		rdpContext context;
-		DEFINE_RDP_CLIENT_COMMON();
+		rdpClientContext common;
 
 		int offset_x;
 		int offset_y;

--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 
+#include <winpr/assert.h>
 #include <winpr/sysinfo.h>
 #include <freerdp/freerdp.h>
 
@@ -88,7 +89,7 @@ LRESULT CALLBACK wf_ll_kbd_proc(int nCode, WPARAM wParam, LPARAM lParam)
 				if (!wfc || !p)
 					return 1;
 
-				input = wfc->context.input;
+				input = wfc->common.context.input;
 				rdp_scancode = MAKE_RDP_SCANCODE((BYTE)p->scanCode, p->flags & LLKHF_EXTENDED);
 				DEBUG_KBD("keydown %d scanCode 0x%08lX flags 0x%08lX vkCode 0x%08lX",
 				          (wParam == WM_KEYDOWN), p->scanCode, p->flags, p->vkCode);
@@ -167,7 +168,7 @@ void wf_event_focus_in(wfContext* wfc)
 	rdpInput* input;
 	POINT pt;
 	RECT rc;
-	input = wfc->context.input;
+	input = wfc->common.context.input;
 	syncFlags = 0;
 
 	if (GetKeyState(VK_NUMLOCK))
@@ -198,8 +199,13 @@ static BOOL wf_event_process_WM_MOUSEWHEEL(wfContext* wfc, HWND hWnd, UINT Msg, 
 	int delta;
 	UINT16 flags = 0;
 	rdpInput* input;
+
+	WINPR_ASSERT(wfc);
+
+	input = wfc->common.context.input;
+	WINPR_ASSERT(input);
+
 	DefWindowProc(hWnd, Msg, wParam, lParam);
-	input = wfc->context.input;
 	delta = ((signed short)HIWORD(wParam)); /* GET_WHEEL_DELTA_WPARAM(wParam); */
 
 	if (horizontal)
@@ -220,7 +226,7 @@ static BOOL wf_event_process_WM_MOUSEWHEEL(wfContext* wfc, HWND hWnd, UINT Msg, 
 
 static void wf_sizing(wfContext* wfc, WPARAM wParam, LPARAM lParam)
 {
-	rdpSettings* settings = wfc->context.settings;
+	rdpSettings* settings = wfc->common.context.settings;
 	// Holding the CTRL key down while resizing the window will force the desktop aspect ratio.
 	LPRECT rect;
 
@@ -262,7 +268,7 @@ static void wf_send_resize(wfContext* wfc)
 	RECT windowRect;
 	int targetWidth = wfc->client_width;
 	int targetHeight = wfc->client_height;
-	rdpSettings* settings = wfc->context.settings;
+	rdpSettings* settings = wfc->common.context.settings;
 
 	if (settings->DynamicResolutionUpdate && wfc->disp != NULL)
 	{
@@ -319,8 +325,8 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 
 	if (wfc != NULL)
 	{
-		rdpInput* input = wfc->context.input;
-		rdpSettings* settings = wfc->context.settings;
+		rdpInput* input = wfc->common.context.input;
+		rdpSettings* settings = wfc->common.context.settings;
 
 		switch (Msg)
 		{
@@ -336,8 +342,8 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 				break;
 
 			case WM_GETMINMAXINFO:
-				if (wfc->context.settings->SmartSizing ||
-				    wfc->context.settings->DynamicResolutionUpdate)
+				if (wfc->common.context.settings->SmartSizing ||
+				    wfc->common.context.settings->DynamicResolutionUpdate)
 				{
 					processed = FALSE;
 				}
@@ -640,10 +646,11 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 				if (wParam == SYSCOMMAND_ID_SMARTSIZING)
 				{
 					HMENU hMenu = GetSystemMenu(wfc->hwnd, FALSE);
-					freerdp_settings_set_bool(wfc->context.settings, FreeRDP_SmartSizing,
-					                          !wfc->context.settings->SmartSizing);
+					freerdp_settings_set_bool(wfc->common.context.settings, FreeRDP_SmartSizing,
+					                          !wfc->common.context.settings->SmartSizing);
 					CheckMenuItem(hMenu, SYSCOMMAND_ID_SMARTSIZING,
-					              wfc->context.settings->SmartSizing ? MF_CHECKED : MF_UNCHECKED);
+					              wfc->common.context.settings->SmartSizing ? MF_CHECKED
+					                                                        : MF_UNCHECKED);
 				}
 				else
 				{
@@ -678,7 +685,7 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 				g_flipping_in = TRUE;
 
 			g_focus_hWnd = hWnd;
-			freerdp_set_focus(wfc->context.instance);
+			freerdp_set_focus(wfc->common.context.instance);
 			break;
 
 		case WM_KILLFOCUS:
@@ -727,7 +734,10 @@ BOOL wf_scale_blt(wfContext* wfc, HDC hdc, int x, int y, int w, int h, HDC hdcSr
 {
 	rdpSettings* settings;
 	UINT32 ww, wh, dw, dh;
-	settings = wfc->context.settings;
+	WINPR_ASSERT(wfc);
+
+	settings = wfc->common.context.settings;
+	WINPR_ASSERT(settings);
 
 	if (!wfc->client_width)
 		wfc->client_width = settings->DesktopWidth;
@@ -746,7 +756,7 @@ BOOL wf_scale_blt(wfContext* wfc, HDC hdc, int x, int y, int w, int h, HDC hdcSr
 	if (!wh)
 		wh = dh;
 
-	if (wfc->fullscreen || !wfc->context.settings->SmartSizing || (ww == dw && wh == dh))
+	if (wfc->fullscreen || !settings->SmartSizing || (ww == dw && wh == dh))
 	{
 		return BitBlt(hdc, x, y, w, h, wfc->primary->hdc, x1, y1, SRCCOPY);
 	}
@@ -763,13 +773,12 @@ BOOL wf_scale_blt(wfContext* wfc, HDC hdc, int x, int y, int w, int h, HDC hdcSr
 static BOOL wf_scale_mouse_pos(wfContext* wfc, UINT16* x, UINT16* y)
 {
 	int ww, wh, dw, dh;
-	rdpContext* context;
 	rdpSettings* settings;
 
 	if (!wfc || !x || !y)
 		return FALSE;
 
-	settings = wfc->context.settings;
+	settings = wfc->common.context.settings;
 
 	if (!settings)
 		return FALSE;
@@ -812,7 +821,7 @@ static BOOL wf_scale_mouse_event(wfContext* wfc, rdpInput* input, UINT16 flags, 
 	eventArgs.flags = flags;
 	eventArgs.x = x;
 	eventArgs.y = y;
-	PubSub_OnMouseEvent(wfc->context.pubSub, &wfc->context, &eventArgs);
+	PubSub_OnMouseEvent(wfc->common.context.pubSub, &wfc->common.context, &eventArgs);
 	return TRUE;
 }
 
@@ -837,7 +846,7 @@ static BOOL wf_scale_mouse_event_ex(wfContext* wfc, rdpInput* input, UINT16 flag
 	eventArgs.flags = flags;
 	eventArgs.x = x;
 	eventArgs.y = y;
-	PubSub_OnMouseEventEx(wfc->context.pubSub, &wfc->context, &eventArgs);
+	PubSub_OnMouseEventEx(wfc->common.context.pubSub, &wfc->common.context, &eventArgs);
 	return TRUE;
 }
 #endif

--- a/client/Windows/wf_floatbar.c
+++ b/client/Windows/wf_floatbar.c
@@ -701,7 +701,7 @@ wfFloatBar* wf_floatbar_new(wfContext* wfc, HINSTANCE window, DWORD flags)
 	if (!update_locked_state(floatbar))
 		goto fail;
 
-	if (!wf_floatbar_toggle_fullscreen(floatbar, wfc->context.settings->Fullscreen))
+	if (!wf_floatbar_toggle_fullscreen(floatbar, wfc->common.context.settings->Fullscreen))
 		goto fail;
 
 	return floatbar;

--- a/client/Windows/wf_gdi.c
+++ b/client/Windows/wf_gdi.c
@@ -71,8 +71,8 @@ static BOOL wf_decode_color(wfContext* wfc, const UINT32 srcColor, COLORREF* col
 	if (!wfc)
 		return FALSE;
 
-	gdi = wfc->context.gdi;
-	settings = wfc->context.settings;
+	gdi = wfc->common.context.gdi;
+	settings = wfc->common.context.settings;
 
 	if (!gdi || !settings)
 		return FALSE;
@@ -216,10 +216,10 @@ static BOOL wf_scale_rect(wfContext* wfc, RECT* source)
 	UINT32 ww, wh, dw, dh;
 	rdpSettings* settings;
 
-	if (!wfc || !source || !wfc->context.settings)
+	if (!wfc || !source || !wfc->common.context.settings)
 		return FALSE;
 
-	settings = wfc->context.settings;
+	settings = wfc->common.context.settings;
 
 	if (!settings)
 		return FALSE;
@@ -242,7 +242,7 @@ static BOOL wf_scale_rect(wfContext* wfc, RECT* source)
 	if (!wh)
 		wh = dh;
 
-	if (wfc->context.settings->SmartSizing && (ww != dw || wh != dh))
+	if (wfc->common.context.settings->SmartSizing && (ww != dw || wh != dh))
 	{
 		source->bottom = source->bottom * wh / dh + 20;
 		source->top = source->top * wh / dh - 20;
@@ -260,7 +260,7 @@ static BOOL wf_scale_rect(wfContext* wfc, RECT* source)
 void wf_invalidate_region(wfContext* wfc, UINT32 x, UINT32 y, UINT32 width, UINT32 height)
 {
 	RECT rect;
-	rdpGdi* gdi = wfc->context.gdi;
+	rdpGdi* gdi = wfc->common.context.gdi;
 	wfc->update_rect.left = x + wfc->offset_x;
 	wfc->update_rect.top = y + wfc->offset_y;
 	wfc->update_rect.right = wfc->update_rect.left + width;
@@ -278,11 +278,11 @@ void wf_invalidate_region(wfContext* wfc, UINT32 x, UINT32 y, UINT32 width, UINT
 void wf_update_offset(wfContext* wfc)
 {
 	rdpSettings* settings;
-	settings = wfc->context.settings;
+	settings = wfc->common.context.settings;
 
 	if (wfc->fullscreen)
 	{
-		if (wfc->context.settings->UseMultimon)
+		if (wfc->common.context.settings->UseMultimon)
 		{
 			int x = GetSystemMetrics(SM_XVIRTUALSCREEN);
 			int y = GetSystemMetrics(SM_YVIRTUALSCREEN);
@@ -321,11 +321,11 @@ void wf_update_offset(wfContext* wfc)
 void wf_resize_window(wfContext* wfc)
 {
 	rdpSettings* settings;
-	settings = wfc->context.settings;
+	settings = wfc->common.context.settings;
 
 	if (wfc->fullscreen)
 	{
-		if (wfc->context.settings->UseMultimon)
+		if (wfc->common.context.settings->UseMultimon)
 		{
 			int x = GetSystemMetrics(SM_XVIRTUALSCREEN);
 			int y = GetSystemMetrics(SM_YVIRTUALSCREEN);
@@ -341,7 +341,7 @@ void wf_resize_window(wfContext* wfc)
 			             GetSystemMetrics(SM_CYSCREEN), SWP_FRAMECHANGED);
 		}
 	}
-	else if (!wfc->context.settings->Decorations)
+	else if (!wfc->common.context.settings->Decorations)
 	{
 		SetWindowLongPtr(wfc->hwnd, GWL_STYLE, WS_CHILD);
 

--- a/client/Windows/wf_graphics.c
+++ b/client/Windows/wf_graphics.c
@@ -58,7 +58,7 @@ HBITMAP wf_create_dib(wfContext* wfc, UINT32 width, UINT32 height, UINT32 srcFor
 
 	if (data)
 		freerdp_image_copy(cdata, dstFormat, 0, 0, 0, width, height, data, srcFormat, 0, 0, 0,
-		                   &wfc->context.gdi->palette, FREERDP_FLIP_NONE);
+		                   &wfc->common.context.gdi->palette, FREERDP_FLIP_NONE);
 
 	if (pdata)
 		*pdata = cdata;

--- a/client/Windows/wf_rail.c
+++ b/client/Windows/wf_rail.c
@@ -879,7 +879,7 @@ static UINT wf_rail_server_start_cmd(RailClientContext* context)
 	RAIL_SYSPARAM_ORDER sysparam = { 0 };
 	RAIL_CLIENT_STATUS_ORDER clientStatus = { 0 };
 	wfContext* wfc = (wfContext*)context->custom;
-	rdpSettings* settings = wfc->context.settings;
+	rdpSettings* settings = wfc->common.context.settings;
 	clientStatus.flags = TS_RAIL_CLIENTSTATUS_ALLOWLOCALMOVESIZE;
 
 	if (settings->AutoReconnectionEnabled)

--- a/client/X11/xf_channels.c
+++ b/client/X11/xf_channels.c
@@ -21,6 +21,7 @@
 #include "config.h"
 #endif
 
+#include <winpr/assert.h>
 #include <freerdp/gdi/video.h>
 #include "xf_channels.h"
 
@@ -45,7 +46,7 @@ void xf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEven
 	WINPR_ASSERT(e);
 	WINPR_ASSERT(e->name);
 
-	settings = xfc->context.settings;
+	settings = xfc->common.context.settings;
 	WINPR_ASSERT(settings);
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
@@ -80,18 +81,18 @@ void xf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEven
 	}
 	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_geometry_init(xfc->context.gdi, (GeometryClientContext*)e->pInterface);
+		gdi_video_geometry_init(xfc->common.context.gdi, (GeometryClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
-			gdi_video_control_init(xfc->context.gdi, (VideoClientContext*)e->pInterface);
+			gdi_video_control_init(xfc->common.context.gdi, (VideoClientContext*)e->pInterface);
 		else
 			xf_video_control_init(xfc, (VideoClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_data_init(xfc->context.gdi, (VideoClientContext*)e->pInterface);
+		gdi_video_data_init(xfc->common.context.gdi, (VideoClientContext*)e->pInterface);
 	}
 }
 
@@ -104,7 +105,7 @@ void xf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnect
 	WINPR_ASSERT(e);
 	WINPR_ASSERT(e->name);
 
-	settings = xfc->context.settings;
+	settings = xfc->common.context.settings;
 	WINPR_ASSERT(settings);
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
@@ -139,17 +140,17 @@ void xf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnect
 	}
 	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_geometry_uninit(xfc->context.gdi, (GeometryClientContext*)e->pInterface);
+		gdi_video_geometry_uninit(xfc->common.context.gdi, (GeometryClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
-			gdi_video_control_uninit(xfc->context.gdi, (VideoClientContext*)e->pInterface);
+			gdi_video_control_uninit(xfc->common.context.gdi, (VideoClientContext*)e->pInterface);
 		else
 			xf_video_control_uninit(xfc, (VideoClientContext*)e->pInterface);
 	}
 	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_video_data_uninit(xfc->context.gdi, (VideoClientContext*)e->pInterface);
+		gdi_video_data_uninit(xfc->common.context.gdi, (VideoClientContext*)e->pInterface);
 	}
 }

--- a/client/X11/xf_channels.c
+++ b/client/X11/xf_channels.c
@@ -49,9 +49,8 @@ void xf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEven
 	settings = xfc->common.context.settings;
 	WINPR_ASSERT(settings);
 
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
+	if (FALSE)
 	{
-		xfc->rdpei = (RdpeiClientContext*)e->pInterface;
 	}
 #if defined(CHANNEL_TSMF_CLIENT)
 	else if (strcmp(e->name, TSMF_DVC_CHANNEL_NAME) == 0)
@@ -79,10 +78,6 @@ void xf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEven
 	{
 		xf_disp_init(xfc->xfDisp, (DispClientContext*)e->pInterface);
 	}
-	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_geometry_init(xfc->common.context.gdi, (GeometryClientContext*)e->pInterface);
-	}
 	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
@@ -90,10 +85,8 @@ void xf_OnChannelConnectedEventHandler(void* context, const ChannelConnectedEven
 		else
 			xf_video_control_init(xfc, (VideoClientContext*)e->pInterface);
 	}
-	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_data_init(xfc->common.context.gdi, (VideoClientContext*)e->pInterface);
-	}
+	else
+		freerdp_client_OnChannelConnectedEventHandler(context, e);
 }
 
 void xf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnectedEventArgs* e)
@@ -108,9 +101,8 @@ void xf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnect
 	settings = xfc->common.context.settings;
 	WINPR_ASSERT(settings);
 
-	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
+	if (FALSE)
 	{
-		xfc->rdpei = NULL;
 	}
 	else if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) == 0)
 	{
@@ -138,10 +130,6 @@ void xf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnect
 	{
 		xf_encomsp_uninit(xfc, (EncomspClientContext*)e->pInterface);
 	}
-	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_geometry_uninit(xfc->common.context.gdi, (GeometryClientContext*)e->pInterface);
-	}
 	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
 	{
 		if (settings->SoftwareGdi)
@@ -149,8 +137,6 @@ void xf_OnChannelDisconnectedEventHandler(void* context, const ChannelDisconnect
 		else
 			xf_video_control_uninit(xfc, (VideoClientContext*)e->pInterface);
 	}
-	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
-	{
-		gdi_video_data_uninit(xfc->common.context.gdi, (VideoClientContext*)e->pInterface);
-	}
+	else
+		freerdp_client_OnChannelDisconnectedEventHandler(context, e);
 }

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -768,6 +768,7 @@ void xf_toggle_fullscreen(xfContext* xfc)
 	if (xfc->debug)
 	{
 		XUngrabKeyboard(xfc->display, CurrentTime);
+		XUngrabPointer(xfc->display, CurrentTime);
 	}
 
 	xfc->fullscreen = (xfc->fullscreen) ? FALSE : TRUE;
@@ -976,6 +977,7 @@ static int _xf_error_handler(Display* d, XErrorEvent* ev)
 	 */
 
 	XUngrabKeyboard(d, CurrentTime);
+	XUngrabPointer(d, CurrentTime);
 	return xf_error_handler(d, ev);
 }
 

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1906,24 +1906,6 @@ static int xfreerdp_client_start(rdpContext* context)
 	return 0;
 }
 
-static int xfreerdp_client_stop(rdpContext* context)
-{
-	xfContext* xfc = (xfContext*)context;
-
-	WINPR_ASSERT(xfc);
-
-	freerdp_abort_connect(context->instance);
-
-	if (xfc->common.thread)
-	{
-		WaitForSingleObject(xfc->common.thread, INFINITE);
-		CloseHandle(xfc->common.thread);
-		xfc->common.thread = NULL;
-	}
-
-	return 0;
-}
-
 static Atom get_supported_atom(xfContext* xfc, const char* atomName)
 {
 	unsigned long i;
@@ -2151,6 +2133,6 @@ int RdpClientEntry(RDP_CLIENT_ENTRY_POINTS* pEntryPoints)
 	pEntryPoints->ClientNew = xfreerdp_client_new;
 	pEntryPoints->ClientFree = xfreerdp_client_free;
 	pEntryPoints->ClientStart = xfreerdp_client_start;
-	pEntryPoints->ClientStop = xfreerdp_client_stop;
+	pEntryPoints->ClientStop = freerdp_client_common_stop;
 	return 0;
 }

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -766,10 +766,7 @@ void xf_toggle_fullscreen(xfContext* xfc)
 	  to allow keyboard usage on the debugger
 	*/
 	if (xfc->debug)
-	{
-		XUngrabKeyboard(xfc->display, CurrentTime);
-		XUngrabPointer(xfc->display, CurrentTime);
-	}
+		xf_ungrab(xfc);
 
 	xfc->fullscreen = (xfc->fullscreen) ? FALSE : TRUE;
 	xfc->decorations = (xfc->fullscreen) ? FALSE : settings->Decorations;

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -47,6 +47,7 @@
 #endif
 
 #include <winpr/crt.h>
+#include <winpr/assert.h>
 #include <winpr/image.h>
 #include <winpr/stream.h>
 #include <winpr/clipboard.h>
@@ -2825,6 +2826,9 @@ xfClipboard* xf_clipboard_new(xfContext* xfc)
 	const char* selectionAtom;
 	xfCliprdrFormat* clientFormat;
 
+	WINPR_ASSERT(xfc);
+	WINPR_ASSERT(xfc->common.context.settings);
+
 	if (!(clipboard = (xfClipboard*)calloc(1, sizeof(xfClipboard))))
 	{
 		WLog_ERR(TAG, "failed to allocate xfClipboard data");
@@ -2839,8 +2843,8 @@ xfClipboard* xf_clipboard_new(xfContext* xfc)
 	clipboard->requestedFormatId = -1;
 	clipboard->root_window = DefaultRootWindow(xfc->display);
 	selectionAtom = "CLIPBOARD";
-	if (xfc->context.settings->XSelectionAtom)
-		selectionAtom = xfc->context.settings->XSelectionAtom;
+	if (xfc->common.context.settings->XSelectionAtom)
+		selectionAtom = xfc->common.context.settings->XSelectionAtom;
 	clipboard->clipboard_atom = XInternAtom(xfc->display, selectionAtom, FALSE);
 
 	if (clipboard->clipboard_atom == None)

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -445,7 +445,7 @@ static BOOL xf_event_MotionNotify(xfContext* xfc, const XMotionEvent* event, BOO
 {
 	WINPR_ASSERT(xfc);
 
-	if (xfc->xi_event || xfc->xi_rawevent)
+	if (xfc->xi_event)
 		return TRUE;
 
 	if (xfc->window)
@@ -534,7 +534,7 @@ static BOOL xf_grab_mouse(xfContext* xfc)
 		             ButtonPressMask | ButtonReleaseMask | PointerMotionMask | FocusChangeMask |
 		                 EnterWindowMask | LeaveWindowMask,
 		             GrabModeAsync, GrabModeAsync, xfc->window->handle, None, CurrentTime);
-		xfc->mouse_grabbed = TRUE;
+		xfc->common.mouse_grabbed = TRUE;
 	}
 	return TRUE;
 }
@@ -554,7 +554,7 @@ static BOOL xf_event_ButtonPress(xfContext* xfc, const XButtonEvent* event, BOOL
 {
 	xf_grab_mouse(xfc);
 
-	if (xfc->xi_event || xfc->xi_rawevent)
+	if (xfc->xi_event)
 		return TRUE;
 	return xf_generic_ButtonEvent(xfc, event->x, event->y, event->button, event->window, app, TRUE);
 }
@@ -563,7 +563,7 @@ static BOOL xf_event_ButtonRelease(xfContext* xfc, const XButtonEvent* event, BO
 {
 	xf_grab_mouse(xfc);
 
-	if (xfc->xi_event || xfc->xi_rawevent)
+	if (xfc->xi_event)
 		return TRUE;
 	return xf_generic_ButtonEvent(xfc, event->x, event->y, event->button, event->window, app,
 	                              FALSE);

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -417,7 +417,7 @@ BOOL xf_generic_MotionNotify(xfContext* xfc, int x, int y, int state, Window win
 	}
 
 	xf_event_adjust_coordinates(xfc, &x, &y);
-	freerdp_input_send_mouse_event(input, PTR_FLAGS_MOVE, x, y);
+	freerdp_client_send_button_event(&xfc->common, FALSE, PTR_FLAGS_MOVE, x, y);
 
 	if (xfc->fullscreen && !app)
 	{
@@ -442,7 +442,6 @@ BOOL xf_generic_ButtonEvent(xfContext* xfc, int x, int y, int button, Window win
                             BOOL down)
 {
 	UINT16 flags = 0;
-	rdpInput* input;
 	Window childWindow;
 	size_t i;
 
@@ -459,14 +458,12 @@ BOOL xf_generic_ButtonEvent(xfContext* xfc, int x, int y, int button, Window win
 		}
 	}
 
-	input = xfc->common.context.input;
-
 	if (flags != 0)
 	{
 		if (flags & (PTR_FLAGS_WHEEL | PTR_FLAGS_HWHEEL))
 		{
 			if (down)
-				freerdp_input_send_mouse_event(input, flags, 0, 0);
+				freerdp_client_send_wheel_event(&xfc->common, flags);
 		}
 		else
 		{
@@ -499,9 +496,9 @@ BOOL xf_generic_ButtonEvent(xfContext* xfc, int x, int y, int button, Window win
 			xf_event_adjust_coordinates(xfc, &x, &y);
 
 			if (extended)
-				freerdp_input_send_extended_mouse_event(input, flags, x, y);
+				freerdp_client_send_extended_button_event(&xfc->common, FALSE, flags, x, y);
 			else
-				freerdp_input_send_mouse_event(input, flags, x, y);
+				freerdp_client_send_button_event(&xfc->common, FALSE, flags, x, y);
 		}
 	}
 

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -444,11 +444,12 @@ BOOL xf_generic_RawMotionNotify(xfContext* xfc, int x, int y, Window window, BOO
 static BOOL xf_event_MotionNotify(xfContext* xfc, const XMotionEvent* event, BOOL app)
 {
 	WINPR_ASSERT(xfc);
+
+	if (xfc->xi_event || xfc->xi_rawevent)
+		return TRUE;
+
 	if (xfc->window)
 		xf_floatbar_set_root_y(xfc->window->floatbar, event->y);
-
-	if (xfc->use_xinput)
-		return TRUE;
 
 	return xf_generic_MotionNotify(xfc, event->x, event->y, event->state, event->window, app);
 }
@@ -533,6 +534,7 @@ static BOOL xf_grab_mouse(xfContext* xfc)
 		             ButtonPressMask | ButtonReleaseMask | PointerMotionMask | FocusChangeMask |
 		                 EnterWindowMask | LeaveWindowMask,
 		             GrabModeAsync, GrabModeAsync, xfc->window->handle, None, CurrentTime);
+		xfc->mouse_grabbed = TRUE;
 	}
 	return TRUE;
 }
@@ -551,18 +553,18 @@ static BOOL xf_grab_kbd(xfContext* xfc)
 static BOOL xf_event_ButtonPress(xfContext* xfc, const XButtonEvent* event, BOOL app)
 {
 	xf_grab_mouse(xfc);
-	if (xfc->use_xinput)
-		return TRUE;
 
+	if (xfc->xi_event || xfc->xi_rawevent)
+		return TRUE;
 	return xf_generic_ButtonEvent(xfc, event->x, event->y, event->button, event->window, app, TRUE);
 }
 
 static BOOL xf_event_ButtonRelease(xfContext* xfc, const XButtonEvent* event, BOOL app)
 {
 	xf_grab_mouse(xfc);
-	if (xfc->use_xinput)
-		return TRUE;
 
+	if (xfc->xi_event || xfc->xi_rawevent)
+		return TRUE;
 	return xf_generic_ButtonEvent(xfc, event->x, event->y, event->button, event->window, app,
 	                              FALSE);
 }

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -504,8 +504,38 @@ BOOL xf_generic_ButtonEvent(xfContext* xfc, int x, int y, int button, Window win
 
 	return TRUE;
 }
+
+static BOOL xf_grab_mouse(xfContext* xfc)
+{
+	WINPR_ASSERT(xfc);
+
+	if (!xfc->window)
+		return FALSE;
+
+	if (freerdp_settings_get_bool(xfc->common.context.settings, FreeRDP_GrabMouse))
+	{
+		XGrabPointer(xfc->display, xfc->window->handle, False,
+		             ButtonPressMask | ButtonReleaseMask | PointerMotionMask | FocusChangeMask |
+		                 EnterWindowMask | LeaveWindowMask,
+		             GrabModeAsync, GrabModeAsync, xfc->window->handle, None, CurrentTime);
+	}
+	return TRUE;
+}
+
+static BOOL xf_grab_kbd(xfContext* xfc)
+{
+	WINPR_ASSERT(xfc);
+
+	if (!xfc->window)
+		return FALSE;
+
+	XGrabKeyboard(xfc->display, xfc->window->handle, TRUE, GrabModeAsync, GrabModeAsync,
+	              CurrentTime);
+	return TRUE;
+}
 static BOOL xf_event_ButtonPress(xfContext* xfc, const XButtonEvent* event, BOOL app)
 {
+	xf_grab_mouse(xfc);
 	if (xfc->use_xinput)
 		return TRUE;
 
@@ -514,6 +544,7 @@ static BOOL xf_event_ButtonPress(xfContext* xfc, const XButtonEvent* event, BOOL
 
 static BOOL xf_event_ButtonRelease(xfContext* xfc, const XButtonEvent* event, BOOL app)
 {
+	xf_grab_mouse(xfc);
 	if (xfc->use_xinput)
 		return TRUE;
 
@@ -550,11 +581,9 @@ static BOOL xf_event_FocusIn(xfContext* xfc, const XFocusInEvent* event, BOOL ap
 
 	if (xfc->mouse_active && !app)
 	{
-		if (!xfc->window)
+		xf_grab_mouse(xfc);
+		if (!xf_grab_kbd(xfc))
 			return FALSE;
-
-		XGrabKeyboard(xfc->display, xfc->window->handle, TRUE, GrabModeAsync, GrabModeAsync,
-		              CurrentTime);
 	}
 
 	/* Release all keys, should already be done at FocusOut but might be missed
@@ -652,8 +681,7 @@ static BOOL xf_event_EnterNotify(xfContext* xfc, const XEnterWindowEvent* event,
 			XSetInputFocus(xfc->display, xfc->window->handle, RevertToPointerRoot, CurrentTime);
 
 		if (xfc->focused)
-			XGrabKeyboard(xfc->display, xfc->window->handle, TRUE, GrabModeAsync, GrabModeAsync,
-			              CurrentTime);
+			xf_grab_kbd(xfc);
 	}
 	else
 	{

--- a/client/X11/xf_event.h
+++ b/client/X11/xf_event.h
@@ -36,8 +36,9 @@ void xf_event_adjust_coordinates(xfContext* xfc, int* x, int* y);
 void xf_adjust_coordinates_to_screen(xfContext* xfc, UINT32* x, UINT32* y);
 
 BOOL xf_generic_MotionNotify(xfContext* xfc, int x, int y, int state, Window window, BOOL app);
-BOOL xf_generic_ButtonPress(xfContext* xfc, int x, int y, int button, Window window, BOOL app);
+BOOL xf_generic_RawMotionNotify(xfContext* xfc, int x, int y, Window window, BOOL app);
 BOOL xf_generic_ButtonEvent(xfContext* xfc, int x, int y, int button, Window window, BOOL app,
                             BOOL down);
+BOOL xf_generic_RawButtonEvent(xfContext* xfc, int button, BOOL app, BOOL down);
 
 #endif /* FREERDP_CLIENT_X11_EVENT_H */

--- a/client/X11/xf_floatbar.c
+++ b/client/X11/xf_floatbar.c
@@ -21,6 +21,8 @@
 #include <X11/extensions/shape.h>
 #include <X11/cursorfont.h>
 
+#include <winpr/assert.h>
+
 #include "xf_floatbar.h"
 #include "resource/close.xbm"
 #include "resource/lock.xbm"
@@ -100,7 +102,7 @@ static BOOL xf_floatbar_button_onclick_close(xfFloatbar* floatbar)
 	if (!floatbar)
 		return FALSE;
 
-	return freerdp_abort_connect(floatbar->xfc->context.instance);
+	return freerdp_abort_connect(floatbar->xfc->common.context.instance);
 }
 
 static BOOL xf_floatbar_button_onclick_minimize(xfFloatbar* floatbar)

--- a/client/X11/xf_gdi.c
+++ b/client/X11/xf_gdi.c
@@ -26,6 +26,8 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 
+#include <winpr/assert.h>
+
 #include <freerdp/gdi/gdi.h>
 #include <freerdp/codec/rfx.h>
 #include <freerdp/codec/nsc.h>
@@ -225,7 +227,12 @@ static Pixmap xf_brush_new(xfContext* xfc, UINT32 width, UINT32 height, UINT32 b
 	XImage* image;
 	rdpGdi* gdi;
 	UINT32 brushFormat;
-	gdi = xfc->context.gdi;
+
+	WINPR_ASSERT(xfc);
+
+	gdi = xfc->common.context.gdi;
+	WINPR_ASSERT(gdi);
+
 	bitmap = XCreatePixmap(xfc->display, xfc->drawable, width, height, xfc->depth);
 
 	if (data)
@@ -233,7 +240,7 @@ static Pixmap xf_brush_new(xfContext* xfc, UINT32 width, UINT32 height, UINT32 b
 		brushFormat = gdi_get_pixel_format(bpp);
 		cdata = (BYTE*)_aligned_malloc(width * height * 4ULL, 16);
 		freerdp_image_copy(cdata, gdi->dstFormat, 0, 0, 0, width, height, data, brushFormat, 0, 0,
-		                   0, &xfc->context.gdi->palette, FREERDP_FLIP_NONE);
+		                   0, &gdi->palette, FREERDP_FLIP_NONE);
 		image = XCreateImage(xfc->display, xfc->visual, xfc->depth, ZPixmap, 0, (char*)cdata, width,
 		                     height, xfc->scanline_pad, 0);
 		image->byte_order = LSBFirst;
@@ -898,7 +905,12 @@ static BOOL xf_gdi_surface_frame_marker(rdpContext* context,
 	rdpSettings* settings;
 	xfContext* xfc = (xfContext*)context;
 	BOOL ret = TRUE;
-	settings = xfc->context.settings;
+
+	WINPR_ASSERT(xfc);
+
+	settings = xfc->common.context.settings;
+	WINPR_ASSERT(settings);
+
 	xf_lock_x11(xfc);
 
 	switch (surface_frame_marker->frameAction)
@@ -921,7 +933,8 @@ static BOOL xf_gdi_surface_frame_marker(rdpContext* context,
 
 			if (settings->FrameAcknowledge > 0)
 			{
-				IFCALL(xfc->context.update->SurfaceFrameAcknowledge, context,
+				WINPR_ASSERT(xfc->common.context.update);
+				IFCALL(xfc->common.context.update->SurfaceFrameAcknowledge, context,
 				       surface_frame_marker->frameId);
 			}
 
@@ -1077,7 +1090,7 @@ static BOOL xf_gdi_surface_bits(rdpContext* context, const SURFACE_BITS_COMMAND*
 
 			if (!freerdp_image_copy(gdi->primary_buffer, gdi->dstFormat, gdi->stride, cmd->destLeft,
 			                        cmd->destTop, cmd->bmp.width, cmd->bmp.height, pSrcData, format,
-			                        0, 0, 0, &xfc->context.gdi->palette, FREERDP_FLIP_VERTICAL))
+			                        0, 0, 0, &gdi->palette, FREERDP_FLIP_VERTICAL))
 				goto fail;
 
 			region16_union_rect(&region, &region, &cmdRect);

--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -23,6 +23,7 @@
 #include "config.h"
 #endif
 
+#include <winpr/assert.h>
 #include <freerdp/log.h>
 #include "xf_gfx.h"
 #include "xf_rail.h"
@@ -37,10 +38,20 @@ static UINT xf_OutputUpdate(xfContext* xfc, xfGfxSurface* surface)
 	UINT32 surfaceX, surfaceY;
 	RECTANGLE_16 surfaceRect;
 	rdpGdi* gdi;
+	const rdpSettings* settings;
 	UINT32 nbRects, x;
 	double sx, sy;
 	const RECTANGLE_16* rects;
-	gdi = xfc->context.gdi;
+
+	WINPR_ASSERT(xfc);
+	WINPR_ASSERT(surface);
+
+	gdi = xfc->common.context.gdi;
+	WINPR_ASSERT(gdi);
+
+	settings = xfc->common.context.settings;
+	WINPR_ASSERT(settings);
+
 	surfaceX = surface->gdi.outputOriginX;
 	surfaceY = surface->gdi.outputOriginY;
 	surfaceRect.left = 0;
@@ -87,7 +98,7 @@ static UINT xf_OutputUpdate(xfContext* xfc, xfGfxSurface* surface)
 		}
 		else
 #ifdef WITH_XRENDER
-		    if (xfc->context.settings->SmartSizing || xfc->context.settings->MultiTouchGestures)
+		    if (settings->SmartSizing || settings->MultiTouchGestures)
 		{
 			XPutImage(xfc->display, xfc->primary, xfc->gc, surface->image, nXSrc, nYSrc, nXDst,
 			          nYDst, dwidth, dheight);
@@ -166,7 +177,14 @@ UINT xf_OutputExpose(xfContext* xfc, UINT32 x, UINT32 y, UINT32 width, UINT32 he
 	RECTANGLE_16 surfaceRect;
 	RECTANGLE_16 intersection;
 	UINT16* pSurfaceIds = NULL;
-	RdpgfxClientContext* context = xfc->context.gdi->gfx;
+	RdpgfxClientContext* context;
+
+	WINPR_ASSERT(xfc);
+	WINPR_ASSERT(xfc->common.context.gdi);
+
+	context = xfc->common.context.gdi->gfx;
+	WINPR_ASSERT(context);
+
 	invalidRect.left = x;
 	invalidRect.top = y;
 	invalidRect.right = x + width;
@@ -400,10 +418,19 @@ static UINT xf_DeleteSurface(RdpgfxClientContext* context,
 
 void xf_graphics_pipeline_init(xfContext* xfc, RdpgfxClientContext* gfx)
 {
-	rdpGdi* gdi = xfc->context.gdi;
+	rdpGdi* gdi;
+	const rdpSettings* settings;
+	WINPR_ASSERT(xfc);
+	WINPR_ASSERT(gfx);
+
+	settings = xfc->common.context.settings;
+	WINPR_ASSERT(settings);
+
+	gdi = xfc->common.context.gdi;
+
 	gdi_graphics_pipeline_init(gdi, gfx);
 
-	if (!xfc->context.settings->SoftwareGdi)
+	if (!settings->SoftwareGdi)
 	{
 		gfx->UpdateSurfaces = xf_UpdateSurfaces;
 		gfx->CreateSurface = xf_CreateSurface;
@@ -413,6 +440,10 @@ void xf_graphics_pipeline_init(xfContext* xfc, RdpgfxClientContext* gfx)
 
 void xf_graphics_pipeline_uninit(xfContext* xfc, RdpgfxClientContext* gfx)
 {
-	rdpGdi* gdi = xfc->context.gdi;
+	rdpGdi* gdi;
+
+	WINPR_ASSERT(xfc);
+
+	gdi = xfc->common.context.gdi;
 	gdi_graphics_pipeline_uninit(gdi, gfx);
 }

--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -31,6 +31,7 @@
 #endif
 
 #include <winpr/crt.h>
+#include <winpr/assert.h>
 
 #include <freerdp/codec/bitmap.h>
 #include <freerdp/codec/rfx.h>
@@ -52,12 +53,12 @@ BOOL xf_decode_color(xfContext* xfc, const UINT32 srcColor, XColor* color)
 	if (!xfc || !color)
 		return FALSE;
 
-	gdi = xfc->context.gdi;
+	gdi = xfc->common.context.gdi;
 
 	if (!gdi)
 		return FALSE;
 
-	settings = xfc->context.settings;
+	settings = xfc->common.context.settings;
 
 	if (!settings)
 		return FALSE;
@@ -248,7 +249,7 @@ static BOOL _xf_Pointer_GetCursorForCurrentScale(rdpContext* context, const rdpP
 	if (!context || !pointer || !context->gdi)
 		return FALSE;
 
-	settings = xfc->context.settings;
+	settings = xfc->common.context.settings;
 
 	if (!settings)
 		return FALSE;

--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -561,7 +561,7 @@ static int xf_input_touch_remote(xfContext* xfc, XIDeviceEvent* event, int evtyp
 	int x, y;
 	int touchId;
 	int contactId;
-	RdpeiClientContext* rdpei = xfc->rdpei;
+	RdpeiClientContext* rdpei = xfc->common.rdpei;
 
 	if (!rdpei)
 		return 0;

--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -76,9 +76,13 @@ int xf_input_init(xfContext* xfc, Window window)
 	XIDeviceInfo* info;
 	XIEventMask evmasks[64];
 	int opcode, event, error;
+	const rdpSettings* settings;
 	BYTE masks[8][XIMaskLen(XI_LASTEVENT)] = { 0 };
 
 	WINPR_ASSERT(xfc);
+
+	settings = xfc->common.context.settings;
+	WINPR_ASSERT(settings);
 
 	memset(xfc->contacts, 0, sizeof(xfc->contacts));
 	xfc->firstDist = -1.0;
@@ -102,7 +106,7 @@ int xf_input_init(xfContext* xfc, Window window)
 		return -1;
 	}
 
-	if (xfc->context.settings->MultiTouchInput)
+	if (settings->MultiTouchInput)
 		xfc->use_xinput = TRUE;
 
 	info = XIQueryDevice(xfc->display, XIAllDevices, &ndevices);
@@ -129,7 +133,7 @@ int xf_input_init(xfContext* xfc, Window window)
 			XIAnyClassInfo* class = dev->classes[j];
 			XITouchClassInfo* t = (XITouchClassInfo*)class;
 
-			if (xfc->context.settings->MultiTouchInput)
+			if (xfc->common.context.settings->MultiTouchInput)
 			{
 				WLog_INFO(TAG, "%s (%d) \"%s\" id: %d", xf_input_get_class_string(class->type),
 				          class->type, dev->name, dev->deviceid);
@@ -143,7 +147,7 @@ int xf_input_init(xfContext* xfc, Window window)
 			if ((class->type == XITouchClass) && (t->mode == XIDirectTouch) &&
 			    (strcmp(dev->name, "Virtual core pointer") != 0))
 			{
-				if (xfc->context.settings->MultiTouchInput)
+				if (settings->MultiTouchInput)
 				{
 					WLog_INFO(TAG, "%s %s touch device (id: %d, mode: %d), supporting %d touches.",
 					          dev->name, (t->mode == XIDirectTouch) ? "direct" : "dependent",
@@ -233,7 +237,7 @@ static void xf_input_detect_pan(xfContext* xfc)
 	rdpContext* ctx;
 
 	WINPR_ASSERT(xfc);
-	ctx = &xfc->context;
+	ctx = &xfc->common.context;
 	WINPR_ASSERT(ctx);
 
 	if (xfc->active_contacts != 2)
@@ -321,7 +325,7 @@ static void xf_input_detect_pinch(xfContext* xfc)
 	rdpContext* ctx;
 
 	WINPR_ASSERT(xfc);
-	ctx = &xfc->context;
+	ctx = &xfc->common.context;
 	WINPR_ASSERT(ctx);
 
 	if (xfc->active_contacts != 2)
@@ -659,13 +663,18 @@ int xf_input_init(xfContext* xfc, Window window)
 int xf_input_handle_event(xfContext* xfc, const XEvent* event)
 {
 #ifdef WITH_XI
+	const rdpSettings* settings;
+	WINPR_ASSERT(xfc);
 
-	if (xfc->context.settings->MultiTouchInput)
+	settings = xfc->common.context.settings;
+	WINPR_ASSERT(settings);
+
+	if (settings->MultiTouchInput)
 	{
 		return xf_input_handle_event_remote(xfc, event);
 	}
 
-	if (xfc->context.settings->MultiTouchGestures)
+	if (settings->MultiTouchGestures)
 	{
 		return xf_input_handle_event_local(xfc, event);
 	}

--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -648,20 +648,20 @@ int xf_input_event(xfContext* xfc, const XEvent* xevent, XIDeviceEvent* event, i
 	{
 		case XI_ButtonPress:
 			xfc->xi_event = TRUE;
-				xf_generic_ButtonEvent(xfc, (int)event->event_x, (int)event->event_y, event->detail,
-				                       event->event, xfc->remote_app, TRUE);
+			xf_generic_ButtonEvent(xfc, (int)event->event_x, (int)event->event_y, event->detail,
+			                       event->event, xfc->remote_app, TRUE);
 			break;
 
 		case XI_ButtonRelease:
 			xfc->xi_event = TRUE;
-				xf_generic_ButtonEvent(xfc, (int)event->event_x, (int)event->event_y, event->detail,
-				                       event->event, xfc->remote_app, FALSE);
+			xf_generic_ButtonEvent(xfc, (int)event->event_x, (int)event->event_y, event->detail,
+			                       event->event, xfc->remote_app, FALSE);
 			break;
 
 		case XI_Motion:
 			xfc->xi_event = TRUE;
-				xf_generic_MotionNotify(xfc, (int)event->event_x, (int)event->event_y,
-				                        event->detail, event->event, xfc->remote_app);
+			xf_generic_MotionNotify(xfc, (int)event->event_x, (int)event->event_y, event->detail,
+			                        event->event, xfc->remote_app);
 			break;
 		case XI_RawButtonPress:
 		case XI_RawButtonRelease:
@@ -674,7 +674,7 @@ int xf_input_event(xfContext* xfc, const XEvent* xevent, XIDeviceEvent* event, i
 				xf_generic_RawButtonEvent(xfc, ev->detail, xfc->remote_app,
 				                          evtype == XI_RawButtonPress);
 			}
-		break;
+			break;
 		case XI_RawMotion:
 			xfc->xi_rawevent = xfc->common.mouse_grabbed &&
 			                   freerdp_settings_get_bool(settings, FreeRDP_MouseUseRelativeMove);
@@ -691,7 +691,7 @@ int xf_input_event(xfContext* xfc, const XEvent* xevent, XIDeviceEvent* event, i
 
 				xf_generic_RawMotionNotify(xfc, (int)x, (int)y, event->event, xfc->remote_app);
 			}
-		break;
+			break;
 		default:
 			WLog_WARN(TAG, "[%s] Unhandled event %d: Event was registered but is not handled!");
 			break;

--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -648,27 +648,24 @@ int xf_input_event(xfContext* xfc, const XEvent* xevent, XIDeviceEvent* event, i
 	{
 		case XI_ButtonPress:
 			xfc->xi_event = TRUE;
-			if (!xfc->xi_rawevent)
 				xf_generic_ButtonEvent(xfc, (int)event->event_x, (int)event->event_y, event->detail,
 				                       event->event, xfc->remote_app, TRUE);
 			break;
 
 		case XI_ButtonRelease:
 			xfc->xi_event = TRUE;
-			if (!xfc->xi_rawevent)
 				xf_generic_ButtonEvent(xfc, (int)event->event_x, (int)event->event_y, event->detail,
 				                       event->event, xfc->remote_app, FALSE);
 			break;
 
 		case XI_Motion:
 			xfc->xi_event = TRUE;
-			if (!xfc->xi_rawevent)
 				xf_generic_MotionNotify(xfc, (int)event->event_x, (int)event->event_y,
 				                        event->detail, event->event, xfc->remote_app);
 			break;
 		case XI_RawButtonPress:
 		case XI_RawButtonRelease:
-			xfc->xi_rawevent = xfc->mouse_grabbed &&
+			xfc->xi_rawevent = xfc->common.mouse_grabbed &&
 			                   freerdp_settings_get_bool(settings, FreeRDP_MouseUseRelativeMove);
 
 			if (xfc->xi_rawevent)
@@ -679,7 +676,7 @@ int xf_input_event(xfContext* xfc, const XEvent* xevent, XIDeviceEvent* event, i
 			}
 		break;
 		case XI_RawMotion:
-			xfc->xi_rawevent = xfc->mouse_grabbed &&
+			xfc->xi_rawevent = xfc->common.mouse_grabbed &&
 			                   freerdp_settings_get_bool(settings, FreeRDP_MouseUseRelativeMove);
 
 			if (xfc->xi_rawevent)

--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -50,6 +50,8 @@
 
 #define MIN_FINGER_DIST 5
 
+static int xf_input_event(xfContext* xfc, XIDeviceEvent* event, int evtype);
+
 static const char* xf_input_get_class_string(int class)
 {
 	if (class == XIKeyClass)
@@ -68,16 +70,10 @@ static const char* xf_input_get_class_string(int class)
 
 int xf_input_init(xfContext* xfc, Window window)
 {
-	int i, j;
-	int nmasks = 0;
-	int ndevices = 0;
-	int major = 2;
-	int minor = 2;
-	XIDeviceInfo* info;
-	XIEventMask evmasks[64];
+	int major = XI_2_Major;
+	int minor = XI_2_Minor;
 	int opcode, event, error;
-	const rdpSettings* settings;
-	BYTE masks[8][XIMaskLen(XI_LASTEVENT)] = { 0 };
+	rdpSettings* settings;
 
 	WINPR_ASSERT(xfc);
 
@@ -100,89 +96,45 @@ int xf_input_init(xfContext* xfc, Window window)
 	xfc->XInputOpcode = opcode;
 	XIQueryVersion(xfc->display, &major, &minor);
 
-	if (major * 1000 + minor < 2002)
+	if ((major < XI_2_Major) || ((major == XI_2_Major) && (minor < 2)))
 	{
 		WLog_WARN(TAG, "Server does not support XI 2.2");
 		return -1;
 	}
 
-	if (settings->MultiTouchInput)
-		xfc->use_xinput = TRUE;
-
-	info = XIQueryDevice(xfc->display, XIAllDevices, &ndevices);
-
-	for (i = 0; i < ndevices; i++)
+	else
 	{
-		BOOL touch = FALSE;
-		XIDeviceInfo* dev = &info[i];
+		XIEventMask mask;
+		unsigned char mask_bytes[XIMaskLen(XI_LASTEVENT)] = { 0 };
 
-		for (j = 0; j < dev->num_classes; j++)
+		if (freerdp_settings_get_bool(settings, FreeRDP_MouseUseRelativeMove))
 		{
-			XIAnyClassInfo* class = dev->classes[j];
-			XITouchClassInfo* t = (XITouchClassInfo*)class;
+			XISetMask(mask_bytes, XI_RawMotion);
+			XISetMask(mask_bytes, XI_RawButtonPress);
+			XISetMask(mask_bytes, XI_RawButtonRelease);
+		    }
+		    else
+		    {
+			    XISetMask(mask_bytes, XI_Motion);
+			    XISetMask(mask_bytes, XI_ButtonPress);
+			    XISetMask(mask_bytes, XI_ButtonRelease);
+		    }
 
-			if ((class->type == XITouchClass) && (t->mode == XIDirectTouch) &&
-			    (strcmp(dev->name, "Virtual core pointer") != 0))
-			{
-				touch = TRUE;
-			}
-		}
+		    if (freerdp_settings_get_bool(settings, FreeRDP_MultiTouchGestures) ||
+		        freerdp_settings_get_bool(settings, FreeRDP_MultiTouchInput))
+		    {
+			    XISetMask(mask_bytes, XI_TouchBegin);
+			    XISetMask(mask_bytes, XI_TouchUpdate);
+			    XISetMask(mask_bytes, XI_TouchEnd);
+		        }
 
-		for (j = 0; j < dev->num_classes; j++)
-		{
-			XIAnyClassInfo* class = dev->classes[j];
-			XITouchClassInfo* t = (XITouchClassInfo*)class;
+		        mask.deviceid = XIAllMasterDevices;
+		        mask.mask_len = sizeof(mask_bytes);
+		        mask.mask = mask_bytes;
 
-			if (xfc->common.context.settings->MultiTouchInput)
-			{
-				WLog_INFO(TAG, "%s (%d) \"%s\" id: %d", xf_input_get_class_string(class->type),
-				          class->type, dev->name, dev->deviceid);
-			}
-
-			evmasks[nmasks].mask = masks[nmasks];
-			evmasks[nmasks].mask_len = sizeof(masks[0]);
-			ZeroMemory(masks[nmasks], sizeof(masks[0]));
-			evmasks[nmasks].deviceid = dev->deviceid;
-
-			if ((class->type == XITouchClass) && (t->mode == XIDirectTouch) &&
-			    (strcmp(dev->name, "Virtual core pointer") != 0))
-			{
-				if (settings->MultiTouchInput)
-				{
-					WLog_INFO(TAG, "%s %s touch device (id: %d, mode: %d), supporting %d touches.",
-					          dev->name, (t->mode == XIDirectTouch) ? "direct" : "dependent",
-					          dev->deviceid, t->mode, t->num_touches);
-				}
-
-				XISetMask(masks[nmasks], XI_TouchBegin);
-				XISetMask(masks[nmasks], XI_TouchUpdate);
-				XISetMask(masks[nmasks], XI_TouchEnd);
-				nmasks++;
-			}
-
-			if (xfc->use_xinput)
-			{
-				if (!touch && (class->type == XIButtonClass) &&
-				    strcmp(dev->name, "Virtual core pointer"))
-				{
-					WLog_INFO(TAG, "%s button device (id: %d, mode: %d)", dev->name, dev->deviceid,
-					          t->mode);
-					XISetMask(masks[nmasks], XI_ButtonPress);
-					XISetMask(masks[nmasks], XI_ButtonRelease);
-					XISetMask(masks[nmasks], XI_Motion);
-					nmasks++;
-				}
-			}
-		}
-	}
-
-	XIFreeDeviceInfo(info);
-
-	if (nmasks > 0)
-	{
-		Status xstatus = XISelectEvents(xfc->display, window, evmasks, nmasks);
-		if (xstatus != 0)
-			WLog_WARN(TAG, "XISelectEvents returned %d", xstatus);
+		        int scr = DefaultScreen(xfc->display);
+		        Window root = RootWindow(xfc->display, scr);
+		        XISelectEvents(xfc->display, root, &mask, 1);
 	}
 
 	return 0;
@@ -477,7 +429,7 @@ static int xf_input_handle_event_local(xfContext* xfc, const XEvent* event)
 				break;
 
 			default:
-				WLog_ERR(TAG, "unhandled xi type= %d", cookie.cc->evtype);
+				xf_input_event(xfc, cookie.cc->data, cookie.cc->evtype);
 				break;
 		}
 	}
@@ -572,26 +524,28 @@ static int xf_input_touch_remote(xfContext* xfc, XIDeviceEvent* event, int evtyp
 	y = (int)event->event_y;
 	xf_event_adjust_coordinates(xfc, &x, &y);
 
-	if (evtype == XI_TouchBegin)
+	switch (evtype)
 	{
-		WLog_DBG(TAG, "TouchBegin: %d", touchId);
-		rdpei->TouchBegin(rdpei, touchId, x, y, &contactId);
-	}
-	else if (evtype == XI_TouchUpdate)
-	{
-		WLog_DBG(TAG, "TouchUpdate: %d", touchId);
-		rdpei->TouchUpdate(rdpei, touchId, x, y, &contactId);
-	}
-	else if (evtype == XI_TouchEnd)
-	{
-		WLog_DBG(TAG, "TouchEnd: %d", touchId);
-		rdpei->TouchEnd(rdpei, touchId, x, y, &contactId);
+		case XI_TouchBegin:
+			WLog_DBG(TAG, "TouchBegin: %d", touchId);
+			rdpei->TouchBegin(rdpei, touchId, x, y, &contactId);
+			break;
+		case XI_TouchUpdate:
+			WLog_DBG(TAG, "TouchUpdate: %d", touchId);
+			rdpei->TouchUpdate(rdpei, touchId, x, y, &contactId);
+			break;
+		case XI_TouchEnd:
+			WLog_DBG(TAG, "TouchEnd: %d", touchId);
+			rdpei->TouchEnd(rdpei, touchId, x, y, &contactId);
+			break;
+		default:
+			break;
 	}
 
 	return 0;
 }
 
-static int xf_input_event(xfContext* xfc, XIDeviceEvent* event, int evtype)
+int xf_input_event(xfContext* xfc, XIDeviceEvent* event, int evtype)
 {
 	xf_input_show_cursor(xfc);
 
@@ -610,6 +564,29 @@ static int xf_input_event(xfContext* xfc, XIDeviceEvent* event, int evtype)
 		case XI_Motion:
 			xf_generic_MotionNotify(xfc, (int)event->event_x, (int)event->event_y, event->detail,
 			                        event->event, xfc->remote_app);
+			break;
+		case XI_RawButtonPress:
+		case XI_RawButtonRelease:
+		{
+			const XIRawEvent* ev = event;
+			xf_generic_RawButtonEvent(xfc, ev->detail, xfc->remote_app,
+			                          evtype == XI_RawButtonPress);
+		}
+		break;
+		case XI_RawMotion:
+		{
+			const XIRawEvent* ev = event;
+			double x = 0.0;
+			double y = 0.0;
+			if (XIMaskIsSet(ev->valuators.mask, 0))
+				x = ev->raw_values[0];
+			if (XIMaskIsSet(ev->valuators.mask, 1))
+				y = ev->raw_values[1];
+			xf_generic_RawMotionNotify(xfc, (int)x, (int)y, event->event, xfc->remote_app);
+		}
+		break;
+		default:
+			WLog_INFO(TAG, "xcxx");
 			break;
 	}
 
@@ -630,15 +607,9 @@ static int xf_input_handle_event_remote(xfContext* xfc, const XEvent* event)
 		switch (cookie.cc->evtype)
 		{
 			case XI_TouchBegin:
-				xf_input_touch_remote(xfc, cookie.cc->data, XI_TouchBegin);
-				break;
-
 			case XI_TouchUpdate:
-				xf_input_touch_remote(xfc, cookie.cc->data, XI_TouchUpdate);
-				break;
-
 			case XI_TouchEnd:
-				xf_input_touch_remote(xfc, cookie.cc->data, XI_TouchEnd);
+				xf_input_touch_remote(xfc, cookie.cc->data, cookie.cc->evtype);
 				break;
 
 			default:
@@ -673,8 +644,11 @@ int xf_input_handle_event(xfContext* xfc, const XEvent* event)
 	{
 		return xf_input_handle_event_remote(xfc, event);
 	}
-
-	if (settings->MultiTouchGestures)
+	else if (settings->MultiTouchGestures)
+	{
+		return xf_input_handle_event_local(xfc, event);
+	}
+	else
 	{
 		return xf_input_handle_event_local(xfc, event);
 	}

--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -50,7 +50,7 @@
 
 #define MIN_FINGER_DIST 5
 
-static int xf_input_event(xfContext* xfc, XIDeviceEvent* event, int evtype);
+static int xf_input_event(xfContext* xfc, const XEvent* xevent, XIDeviceEvent* event, int evtype);
 
 static const char* xf_input_get_class_string(int class)
 {
@@ -429,7 +429,7 @@ static int xf_input_handle_event_local(xfContext* xfc, const XEvent* event)
 				break;
 
 			default:
-				xf_input_event(xfc, cookie.cc->data, cookie.cc->evtype);
+				xf_input_event(xfc, event, cookie.cc->data, cookie.cc->evtype);
 				break;
 		}
 	}
@@ -545,8 +545,21 @@ static int xf_input_touch_remote(xfContext* xfc, XIDeviceEvent* event, int evtyp
 	return 0;
 }
 
-int xf_input_event(xfContext* xfc, XIDeviceEvent* event, int evtype)
+int xf_input_event(xfContext* xfc, const XEvent* xevent, XIDeviceEvent* event, int evtype)
 {
+	Window w;
+
+	WINPR_ASSERT(xfc);
+	WINPR_ASSERT(xevent);
+	WINPR_ASSERT(event);
+
+	w = xevent->xany.window;
+	if (w != xfc->window)
+	{
+		if (!xfc->remote_app)
+			return 0;
+	}
+
 	xf_input_show_cursor(xfc);
 
 	switch (evtype)
@@ -613,7 +626,7 @@ static int xf_input_handle_event_remote(xfContext* xfc, const XEvent* event)
 				break;
 
 			default:
-				xf_input_event(xfc, cookie.cc->data, cookie.cc->evtype);
+				xf_input_event(xfc, event, cookie.cc->data, cookie.cc->evtype);
 				break;
 		}
 	}

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -698,8 +698,7 @@ void xf_keyboard_handle_special_keys_release(xfContext* xfc, KeySym keysym)
 		}
 
 		xfc->mouse_active = FALSE;
-		XUngrabKeyboard(xfc->display, CurrentTime);
-		XUngrabPointer(xfc->display, CurrentTime);
+		xf_ungrab(xfc);
 	}
 
 	// ungrabbed
@@ -727,4 +726,12 @@ BOOL xf_keyboard_set_ime_status(rdpContext* context, UINT16 imeId, UINT32 imeSta
 	          ", imeConvMode=%08" PRIx32 ") ignored",
 	          imeId, imeState, imeConvMode);
 	return TRUE;
+}
+
+BOOL xf_ungrab(xfContext* xfc)
+{
+	WINPR_ASSERT(xfc);
+	XUngrabKeyboard(xfc->display, CurrentTime);
+	XUngrabPointer(xfc->display, CurrentTime);
+	xfc->mouse_grabbed = FALSE;
 }

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -699,6 +699,7 @@ void xf_keyboard_handle_special_keys_release(xfContext* xfc, KeySym keysym)
 
 		xfc->mouse_active = FALSE;
 		XUngrabKeyboard(xfc->display, CurrentTime);
+		XUngrabPointer(xfc->display, CurrentTime);
 	}
 
 	// ungrabbed

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -440,7 +440,7 @@ void xf_keyboard_focus_in(xfContext* xfc)
 		if (x >= 0 && x < xfc->window->width && y >= 0 && y < xfc->window->height)
 		{
 			xf_event_adjust_coordinates(xfc, &x, &y);
-			freerdp_input_send_mouse_event(input, PTR_FLAGS_MOVE, x, y);
+			freerdp_client_send_button_event(&xfc->common, FALSE, PTR_FLAGS_MOVE, x, y);
 		}
 	}
 }

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -437,7 +437,7 @@ void xf_keyboard_focus_in(xfContext* xfc)
 
 	if (XQueryPointer(xfc->display, xfc->window->handle, &w, &w, &d, &d, &x, &y, &state))
 	{
-		if (x >= 0 && x < xfc->window->width && y >= 0 && y < xfc->window->height)
+		if ((x >= 0) && (x < xfc->window->width) && (y >= 0) && (y < xfc->window->height))
 		{
 			xf_event_adjust_coordinates(xfc, &x, &y);
 			freerdp_client_send_button_event(&xfc->common, FALSE, PTR_FLAGS_MOVE, x, y);
@@ -733,5 +733,5 @@ BOOL xf_ungrab(xfContext* xfc)
 	WINPR_ASSERT(xfc);
 	XUngrabKeyboard(xfc->display, CurrentTime);
 	XUngrabPointer(xfc->display, CurrentTime);
-	xfc->mouse_grabbed = FALSE;
+	xfc->common.mouse_grabbed = FALSE;
 }

--- a/client/X11/xf_keyboard.h
+++ b/client/X11/xf_keyboard.h
@@ -61,4 +61,6 @@ BOOL xf_keyboard_set_indicators(rdpContext* context, UINT16 led_flags);
 BOOL xf_keyboard_set_ime_status(rdpContext* context, UINT16 imeId, UINT32 imeState,
                                 UINT32 imeConvMode);
 
+BOOL xf_ungrab(xfContext* xfc);
+
 #endif /* FREERDP_CLIENT_X11_XF_KEYBOARD_H */

--- a/client/X11/xf_monitor.c
+++ b/client/X11/xf_monitor.c
@@ -29,6 +29,7 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 
+#include <winpr/assert.h>
 #include <winpr/crt.h>
 
 #include <freerdp/log.h>
@@ -116,7 +117,12 @@ int xf_list_monitors(xfContext* xfc)
 static BOOL xf_is_monitor_id_active(xfContext* xfc, UINT32 id)
 {
 	UINT32 index;
-	rdpSettings* settings = xfc->context.settings;
+	const rdpSettings* settings;
+
+	WINPR_ASSERT(xfc);
+
+	settings = xfc->common.context.settings;
+	WINPR_ASSERT(settings);
 
 	if (!settings->NumMonitorIds)
 		return TRUE;
@@ -150,10 +156,10 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pMaxWidth, UINT32* pMaxHeight)
 	BOOL useXRandr = FALSE;
 #endif
 
-	if (!xfc || !pMaxWidth || !pMaxHeight || !xfc->context.settings)
+	if (!xfc || !pMaxWidth || !pMaxHeight || !xfc->common.context.settings)
 		return FALSE;
 
-	settings = xfc->context.settings;
+	settings = xfc->common.context.settings;
 	vscreen = &xfc->vscreen;
 	*pMaxWidth = settings->DesktopWidth;
 	*pMaxHeight = settings->DesktopHeight;

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -187,7 +187,7 @@ void xf_rail_end_local_move(xfContext* xfc, xfAppWindow* appWindow)
 	if ((appWindow->local_move.direction != _NET_WM_MOVERESIZE_MOVE_KEYBOARD) &&
 	    (appWindow->local_move.direction != _NET_WM_MOVERESIZE_SIZE_KEYBOARD))
 	{
-		freerdp_input_send_mouse_event(input, PTR_FLAGS_BUTTON1, x, y);
+		freerdp_client_send_button_event(&xfc->common, FALSE, PTR_FLAGS_BUTTON1, x, y);
 	}
 
 	/*

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -25,6 +25,7 @@
 #include <X11/Xatom.h>
 #include <X11/Xutil.h>
 
+#include <winpr/assert.h>
 #include <winpr/wlog.h>
 #include <winpr/print.h>
 
@@ -153,7 +154,13 @@ void xf_rail_end_local_move(xfContext* xfc, xfAppWindow* appWindow)
 	Window root_window;
 	Window child_window;
 	RAIL_WINDOW_MOVE_ORDER windowMove;
-	rdpInput* input = xfc->context.input;
+	rdpInput* input;
+
+	WINPR_ASSERT(xfc);
+
+	input = xfc->common.context.input;
+	WINPR_ASSERT(input);
+
 	/*
 	 * For keyboard moves send and explicit update to RDP server
 	 */
@@ -792,13 +799,19 @@ static void xf_rail_register_update_callbacks(rdpUpdate* update)
 static UINT xf_rail_server_execute_result(RailClientContext* context,
                                           const RAIL_EXEC_RESULT_ORDER* execResult)
 {
-	xfContext* xfc = (xfContext*)context->custom;
+	xfContext* xfc;
+
+	WINPR_ASSERT(context);
+	WINPR_ASSERT(execResult);
+
+	xfc = (xfContext*)context->custom;
+	WINPR_ASSERT(xfc);
 
 	if (execResult->execResult != RAIL_EXEC_S_OK)
 	{
 		WLog_ERR(TAG, "RAIL exec error: execResult=%s NtError=0x%X\n",
 		         error_code_names[execResult->execResult], execResult->rawResult);
-		freerdp_abort_connect(xfc->context.instance);
+		freerdp_abort_connect(xfc->common.context.instance);
 	}
 	else
 	{
@@ -826,8 +839,17 @@ static UINT xf_rail_server_start_cmd(RailClientContext* context)
 	RAIL_EXEC_ORDER exec = { 0 };
 	RAIL_SYSPARAM_ORDER sysparam = { 0 };
 	RAIL_CLIENT_STATUS_ORDER clientStatus = { 0 };
-	xfContext* xfc = (xfContext*)context->custom;
-	rdpSettings* settings = xfc->context.settings;
+	xfContext* xfc;
+	rdpSettings* settings;
+
+	WINPR_ASSERT(context);
+
+	xfc = (xfContext*)context->custom;
+	WINPR_ASSERT(xfc);
+
+	settings = xfc->common.context.settings;
+	WINPR_ASSERT(settings);
+
 	clientStatus.flags = TS_RAIL_CLIENTSTATUS_ALLOWLOCALMOVESIZE;
 
 	if (settings->AutoReconnectionEnabled)
@@ -1111,7 +1133,7 @@ int xf_rail_init(xfContext* xfc, RailClientContext* rail)
 		wObject* obj = HashTable_ValueObject(xfc->railWindows);
 		obj->fnObjectFree = rail_window_free;
 	}
-	xfc->railIconCache = RailIconCache_New(xfc->context.settings);
+	xfc->railIconCache = RailIconCache_New(xfc->common.context.settings);
 
 	if (!xfc->railIconCache)
 	{

--- a/client/X11/xf_video.c
+++ b/client/X11/xf_video.c
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+#include <winpr/assert.h>
 #include <freerdp/client/geometry.h>
 #include <freerdp/client/video.h>
 #include <freerdp/gdi/video.h>
@@ -63,6 +64,7 @@ static BOOL xfVideoShowSurface(VideoClientContext* video, const VideoSurface* su
 {
 	const xfVideoSurface* xfSurface = (const xfVideoSurface*)surface;
 	xfContext* xfc;
+	const rdpSettings* settings;
 
 	WINPR_ASSERT(video);
 	WINPR_ASSERT(xfSurface);
@@ -70,9 +72,12 @@ static BOOL xfVideoShowSurface(VideoClientContext* video, const VideoSurface* su
 	xfc = video->custom;
 	WINPR_ASSERT(xfc);
 
+	settings = xfc->common.context.settings;
+	WINPR_ASSERT(settings);
+
 #ifdef WITH_XRENDER
 
-	if (xfc->context.settings->SmartSizing || xfc->context.settings->MultiTouchGestures)
+	if (settings->SmartSizing || settings->MultiTouchGestures)
 	{
 		XPutImage(xfc->display, xfc->primary, xfc->gc, xfSurface->image, 0, 0, surface->x,
 		          surface->y, surface->w, surface->h);
@@ -106,7 +111,7 @@ void xf_video_control_init(xfContext* xfc, VideoClientContext* video)
 	WINPR_ASSERT(xfc);
 	WINPR_ASSERT(video);
 
-	gdi_video_control_init(xfc->context.gdi, video);
+	gdi_video_control_init(xfc->common.context.gdi, video);
 
 	/* X11 needs to be able to handle 32bpp colors directly. */
 	if (xfc->depth >= 24)
@@ -120,5 +125,6 @@ void xf_video_control_init(xfContext* xfc, VideoClientContext* video)
 
 void xf_video_control_uninit(xfContext* xfc, VideoClientContext* video)
 {
-	gdi_video_control_uninit(xfc->context.gdi, video);
+	WINPR_ASSERT(xfc);
+	gdi_video_control_uninit(xfc->common.context.gdi, video);
 }

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -55,6 +55,7 @@
 
 #include "xf_rail.h"
 #include "xf_input.h"
+#include "xf_keyboard.h"
 
 #define TAG CLIENT_TAG("x11")
 
@@ -894,7 +895,9 @@ void xf_StartLocalMoveSize(xfContext* xfc, xfAppWindow* appWindow, int direction
 	appWindow->local_move.root_y = y;
 	appWindow->local_move.state = LMS_STARTING;
 	appWindow->local_move.direction = direction;
-	XUngrabPointer(xfc->display, CurrentTime);
+
+	xf_ungrab(xfc);
+
 	xf_SendClientEvent(
 	    xfc, appWindow->handle,
 	    xfc->_NET_WM_MOVERESIZE, /* request X window manager to initiate a local move */

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -271,7 +271,6 @@ struct xf_context
 	xfClipboard* clipboard;
 	CliprdrClientContext* cliprdr;
 	xfVideoContext* xfVideo;
-	RdpeiClientContext* rdpei;
 	EncomspClientContext* encomsp;
 	xfDispContext* xfDisp;
 

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -300,8 +300,6 @@ struct xf_context
 #endif
 	BOOL xi_rawevent;
 	BOOL xi_event;
-
-	BOOL mouse_grabbed;
 };
 
 BOOL xf_create_window(xfContext* xfc);

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -203,7 +203,6 @@ struct xf_context
 #endif
 
 	BOOL focused;
-	BOOL use_xinput;
 	BOOL mouse_active;
 	BOOL fullscreen_toggle;
 	BOOL controlToggle;
@@ -299,6 +298,10 @@ struct xf_context
 	double px_vector;
 	double py_vector;
 #endif
+	BOOL xi_rawevent;
+	BOOL xi_event;
+
+	BOOL mouse_grabbed;
 };
 
 BOOL xf_create_window(xfContext* xfc);

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -141,8 +141,7 @@ typedef struct touch_contact
 
 struct xf_context
 {
-	rdpContext context;
-	DEFINE_RDP_CLIENT_COMMON();
+	rdpClientContext common;
 
 	GC gc;
 	int xfds;

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -1029,19 +1029,25 @@ BOOL freerdp_client_send_wheel_event(rdpClientContext* cctx, UINT16 mflags)
 		UINT rc;
 		UINT64 flags = 0;
 		INT32 x = 0, y = 0;
+		INT32 value = mflags & 0xFF;
+
+		if (mflags & PTR_FLAGS_WHEEL_NEGATIVE)
+			value = -1 * (0x100 - value);
+
 		if (mflags & PTR_FLAGS_WHEEL)
 		{
 			flags |= AINPUT_FLAGS_WHEEL;
-			x = flags & 0xff;
-			if (mflags & PTR_FLAGS_WHEEL_NEGATIVE)
-				x = -x;
+			y = value;
 		}
+
+		/* We have discrete steps, scale this so we can also support high
+		 * resolution wheels. */
+		value *= 0x10000;
+
 		if (mflags & PTR_FLAGS_HWHEEL)
 		{
 			flags |= AINPUT_FLAGS_WHEEL;
-			y = flags & 0xff;
-			if (mflags & PTR_FLAGS_WHEEL_NEGATIVE)
-				y = -y;
+			x = value;
 		}
 
 		WINPR_ASSERT(cctx->ainput->AInputSendInputEvent);

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -886,3 +886,20 @@ BOOL client_auto_reconnect_ex(freerdp* instance, BOOL (*window_events)(freerdp* 
 	WLog_ERR(TAG, "Maximum reconnect retries exceeded");
 	return FALSE;
 }
+
+int freerdp_client_common_stop(rdpContext* context)
+{
+	rdpClientContext* cctx = (rdpClientContext*)context;
+	WINPR_ASSERT(cctx);
+
+	freerdp_abort_connect(cctx->context.instance);
+
+	if (cctx->thread)
+	{
+		WaitForSingleObject(cctx->thread, INFINITE);
+		CloseHandle(cctx->thread);
+		cctx->thread = NULL;
+	}
+
+	return 0;
+}

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -1034,15 +1034,15 @@ BOOL freerdp_client_send_wheel_event(rdpClientContext* cctx, UINT16 mflags)
 		if (mflags & PTR_FLAGS_WHEEL_NEGATIVE)
 			value = -1 * (0x100 - value);
 
+		/* We have discrete steps, scale this so we can also support high
+		 * resolution wheels. */
+		value *= 0x10000;
+
 		if (mflags & PTR_FLAGS_WHEEL)
 		{
 			flags |= AINPUT_FLAGS_WHEEL;
 			y = value;
 		}
-
-		/* We have discrete steps, scale this so we can also support high
-		 * resolution wheels. */
-		value *= 0x10000;
 
 		if (mflags & PTR_FLAGS_HWHEEL)
 		{

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -1088,9 +1088,15 @@ BOOL freerdp_client_send_button_event(rdpClientContext* cctx, BOOL relative, UIN
 	if (cctx->ainput)
 	{
 		UINT64 flags = 0;
+		BOOL relativeInput =
+		    freerdp_settings_get_bool(cctx->context.settings, FreeRDP_MouseUseRelativeMove);
+
+		if (cctx->mouse_grabbed && relativeInput)
+			flags |= AINPUT_FLAGS_HAVE_REL;
 
 		if (relative)
 			flags |= AINPUT_FLAGS_REL;
+
 		if (mflags & PTR_FLAGS_DOWN)
 			flags |= AINPUT_FLAGS_DOWN;
 		if (mflags & PTR_FLAGS_BUTTON1)

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -1111,7 +1111,7 @@ BOOL freerdp_client_send_button_event(rdpClientContext* cctx, BOOL relative, UIN
 		{
 			cctx->lastX += x;
 			cctx->lastY += y;
-			WLog_WARN(TAG, "Relative mouse input but channel % not available, sending absolute!",
+			WLog_WARN(TAG, "Relative mouse input but channel %s not available, sending absolute!",
 			          AINPUT_DVC_CHANNEL_NAME);
 		}
 		else
@@ -1156,7 +1156,7 @@ BOOL freerdp_client_send_extended_button_event(rdpClientContext* cctx, BOOL rela
 		{
 			cctx->lastX += x;
 			cctx->lastY += y;
-			WLog_WARN(TAG, "Relative mouse input but channel % not available, sending absolute!",
+			WLog_WARN(TAG, "Relative mouse input but channel %s not available, sending absolute!",
 			          AINPUT_DVC_CHANNEL_NAME);
 		}
 		else

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -1145,8 +1145,7 @@ BOOL freerdp_client_send_extended_button_event(rdpClientContext* cctx, BOOL rela
 		if (mflags & PTR_XFLAGS_BUTTON2)
 			flags |= AINPUT_XFLAGS_BUTTON2;
 
-		ainput_send_diff_event(cctx, flags, x, y);
-		handled = TRUE;
+		handled = ainput_send_diff_event(cctx, flags, x, y);
 	}
 #endif
 

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -33,6 +33,29 @@
 #include <freerdp/client/cmdline.h>
 #include <freerdp/client/channels.h>
 
+#if defined(CHANNEL_AINPUT_CLIENT)
+#include <freerdp/client/ainput.h>
+#include <freerdp/channels/ainput.h>
+#endif
+
+#if defined(CHANNEL_VIDEO_CLIENT)
+#include <freerdp/client/video.h>
+#include <freerdp/channels/video.h>
+#include <freerdp/gdi/video.h>
+#endif
+
+#if defined(CHANNEL_RDPGFX_CLIENT)
+#include <freerdp/client/rdpgfx.h>
+#include <freerdp/channels/rdpgfx.h>
+#include <freerdp/gdi/gfx.h>
+#endif
+
+#if defined(CHANNEL_GEOMETRY_CLIENT)
+#include <freerdp/client/geometry.h>
+#include <freerdp/channels/geometry.h>
+#include <freerdp/gdi/video.h>
+#endif
+
 #include <freerdp/log.h>
 #define TAG CLIENT_TAG("common")
 
@@ -902,4 +925,94 @@ int freerdp_client_common_stop(rdpContext* context)
 	}
 
 	return 0;
+}
+
+void freerdp_client_OnChannelConnectedEventHandler(void* context,
+                                                   const ChannelConnectedEventArgs* e)
+{
+	rdpClientContext* cctx = (rdpClientContext*)context;
+
+	WINPR_ASSERT(cctx);
+	WINPR_ASSERT(e);
+
+	if (0)
+	{
+	}
+#if defined(CHANNEL_AINPUT_CLIENT)
+	else if (strcmp(e->name, AINPUT_DVC_CHANNEL_NAME) == 0)
+		cctx->ainput = (AInputClientContext*)e->pInterface;
+#endif
+#if defined(CHANNEL_RDPEI_CLIENT)
+	else if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
+	{
+		cctx->rdpei = (RdpeiClientContext*)e->pInterface;
+	}
+#endif
+#if defined(CHANNEL_RDPGFX_CLIENT)
+	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
+	{
+		gdi_graphics_pipeline_init(cctx->context.gdi, (RdpgfxClientContext*)e->pInterface);
+	}
+#endif
+#if defined(CHANNEL_GEOMETRY_CLIENT)
+	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
+	{
+		gdi_video_geometry_init(cctx->context.gdi, (GeometryClientContext*)e->pInterface);
+	}
+#endif
+#if defined(CHANNEL_VIDEO_CLIENT)
+	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
+	{
+		gdi_video_control_init(cctx->context.gdi, (VideoClientContext*)e->pInterface);
+	}
+	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
+	{
+		gdi_video_data_init(cctx->context.gdi, (VideoClientContext*)e->pInterface);
+	}
+#endif
+}
+
+void freerdp_client_OnChannelDisconnectedEventHandler(void* context,
+                                                      const ChannelDisconnectedEventArgs* e)
+{
+	rdpClientContext* cctx = (rdpClientContext*)context;
+
+	WINPR_ASSERT(cctx);
+	WINPR_ASSERT(e);
+
+	if (0)
+	{
+	}
+#if defined(CHANNEL_AINPUT_CLIENT)
+	else if (strcmp(e->name, AINPUT_DVC_CHANNEL_NAME) == 0)
+		cctx->ainput = NULL;
+#endif
+#if defined(CHANNEL_RDPEI_CLIENT)
+	else if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
+	{
+		cctx->rdpei = NULL;
+	}
+#endif
+#if defined(CHANNEL_RDPGFX_CLIENT)
+	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
+	{
+		gdi_graphics_pipeline_uninit(cctx->context.gdi, (RdpgfxClientContext*)e->pInterface);
+	}
+#endif
+#if defined(CHANNEL_GEOMETRY_CLIENT)
+	else if (strcmp(e->name, GEOMETRY_DVC_CHANNEL_NAME) == 0)
+	{
+		gdi_video_geometry_uninit(cctx->context.gdi, (GeometryClientContext*)e->pInterface);
+	}
+#endif
+#if defined(CHANNEL_VIDEO_CLIENT)
+	else if (strcmp(e->name, VIDEO_CONTROL_DVC_CHANNEL_NAME) == 0)
+	{
+		gdi_video_control_uninit(cctx->context.gdi, (VideoClientContext*)e->pInterface);
+	}
+	else if (strcmp(e->name, VIDEO_DATA_DVC_CHANNEL_NAME) == 0)
+	{
+		gdi_video_data_uninit(cctx->context.gdi, (VideoClientContext*)e->pInterface);
+	}
+#endif
 }

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2930,6 +2930,10 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 		{
 			settings->GrabMouse = enable;
 		}
+		CommandLineSwitchCase(arg, "mouse-relative")
+		{
+			settings->MouseUseRelativeMove = enable;
+		}
 		CommandLineSwitchCase(arg, "unmap-buttons")
 		{
 			settings->UnmapButtons = enable;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -46,6 +46,10 @@
 #include <freerdp/channels/urbdrc.h>
 #include <freerdp/channels/rdpdr.h>
 
+#if defined(CHANNEL_AINPUT_CLIENT)
+#include <freerdp/channels/ainput.h>
+#endif
+
 #include <freerdp/client/cmdline.h>
 #include <freerdp/version.h>
 
@@ -3540,6 +3544,16 @@ static BOOL freerdp_client_load_static_channel_addin(rdpChannels* channels, rdpS
 BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 {
 	UINT32 index;
+
+	/* Always load FreeRDP advanced input dynamic channel */
+#if defined(CHANNEL_AINPUT_CLIENT)
+	{
+		const char* p[] = { AINPUT_CHANNEL_NAME };
+
+		if (!freerdp_client_add_dynamic_channel(settings, ARRAYSIZE(p), p))
+			return FALSE;
+	}
+#endif
 
 	if (settings->AudioPlayback)
 	{

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -245,6 +245,8 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "Select monitors to use" },
 	{ "mouse-motion", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
 	  "Send mouse motion" },
+	{ "mouse-relative", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
+	  "Send mouse motion with relative addressing" },
 #if defined(CHANNEL_TSMF_CLIENT)
 	{ "multimedia", COMMAND_LINE_VALUE_OPTIONAL, "[sys:<sys>,][dev:<dev>,][decoder:<decoder>]",
 	  NULL, NULL, -1, "mmr", "[DEPRECATED] Redirect multimedia (video) use /video instead" },

--- a/config.h.in
+++ b/config.h.in
@@ -67,6 +67,9 @@
 #cmakedefine WITH_RDPDR
 
 /* Channels */
+#cmakedefine CHANNEL_AINPUT
+#cmakedefine CHANNEL_AINPUT_CLIENT
+#cmakedefine CHANNEL_AINPUT_SERVER
 #cmakedefine CHANNEL_AUDIN
 #cmakedefine CHANNEL_AUDIN_CLIENT
 #cmakedefine CHANNEL_AUDIN_SERVER

--- a/include/freerdp/channels/ainput.h
+++ b/include/freerdp/channels/ainput.h
@@ -1,0 +1,60 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Audio Input Redirection Virtual Channel
+ *
+ * Copyright 2022 Armin Novak <anovak@thincast.com>
+ * Copyright 2022 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_AINPUT_H
+#define FREERDP_CHANNEL_AINPUT_H
+
+#include <freerdp/api.h>
+#include <freerdp/dvc.h>
+#include <freerdp/types.h>
+
+#define AINPUT_CHANNEL_NAME "ainput"
+#define AINPUT_DVC_CHANNEL_NAME "FreeRDP::Advanced::Input"
+
+typedef enum
+{
+	MSG_AINPUT_VERSION = 0x01,
+	MSG_AINPUT_MOUSE = 0x02
+} eAInputMsgType;
+
+typedef enum
+{
+	AINPUT_FLAGS_WHEEL = 0x0001,
+	AINPUT_FLAGS_MOVE = 0x0004,
+	AINPUT_FLAGS_DOWN = 0x0008,
+
+	AINPUT_FLAGS_REL = 0x0010,
+
+	/* Pointer Flags */
+	AINPUT_FLAGS_BUTTON1 = 0x1000, /* left */
+	AINPUT_FLAGS_BUTTON2 = 0x2000, /* right */
+	AINPUT_FLAGS_BUTTON3 = 0x4000, /* middle */
+
+	/* Extended Pointer Flags */
+	AINPUT_XFLAGS_BUTTON1 = 0x0100,
+	AINPUT_XFLAGS_BUTTON2 = 0x0200
+} AInputEventFlags;
+
+typedef struct ainput_client_context AInputClientContext;
+
+#define AINPUT_VERSION_MAJOR 1
+#define AINPUT_VERSION_MINOR 0
+
+#endif /* FREERDP_CHANNEL_AINPUT_H */

--- a/include/freerdp/channels/ainput.h
+++ b/include/freerdp/channels/ainput.h
@@ -41,6 +41,7 @@ typedef enum
 	AINPUT_FLAGS_DOWN = 0x0008,
 
 	AINPUT_FLAGS_REL = 0x0010,
+	AINPUT_FLAGS_HAVE_REL = 0x0020,
 
 	/* Pointer Flags */
 	AINPUT_FLAGS_BUTTON1 = 0x1000, /* left */

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -83,20 +83,21 @@ extern "C"
 		rdpContext context;
 		ALIGN64 HANDLE thread; /**< (offset 0) */
 #if defined(CHANNEL_AINPUT_CLIENT)
-        ALIGN64 AInputClientContext* ainput; /**< (offset 1) */
+		ALIGN64 AInputClientContext* ainput; /**< (offset 1) */
 #else
 	    UINT64 reserved1;
 #endif
 
 #if defined(CHANNEL_RDPEI_CLIENT)
-        ALIGN64 RdpeiClientContext* rdpei; /**< (offset 2) */
+		ALIGN64 RdpeiClientContext* rdpei; /**< (offset 2) */
 #else
 	    UINT64 reserved2;
 #endif
 
-		ALIGN64 INT32 lastX;      /**< (offset 3) */
-		ALIGN64 INT32 lastY;      /**< (offset 4) */
-		UINT64 reserved[128 - 5]; /**< (offset 5) */
+		ALIGN64 INT32 lastX;        /**< (offset 3) */
+		ALIGN64 INT32 lastY;        /**< (offset 4) */
+		ALIGN64 BOOL mouse_grabbed; /** < (offset 5) */
+		UINT64 reserved[128 - 6];   /**< (offset 6) */
 	};
 
 	/* Common client functions */
@@ -141,9 +142,9 @@ extern "C"
 	                                                              char** username, char** password,
 	                                                              char** domain));
 	FREERDP_API
-	    WINPR_DEPRECATED_VAR("Use client_cli_authenticate_ex",
-	                         BOOL client_cli_gw_authenticate(freerdp* instance, char** username,
-	                                                         char** password, char** domain));
+	WINPR_DEPRECATED_VAR("Use client_cli_authenticate_ex",
+	                     BOOL client_cli_gw_authenticate(freerdp* instance, char** username,
+	                                                     char** password, char** domain));
 
 	FREERDP_API WINPR_DEPRECATED_VAR(
 	    "Use client_cli_verify_certificate_ex",
@@ -181,6 +182,9 @@ extern "C"
 	                                          BOOL (*window_events)(freerdp* instance));
 
 	FREERDP_API BOOL freerdp_client_send_wheel_event(rdpClientContext* cctx, UINT16 mflags);
+
+	FREERDP_API BOOL freerdp_client_send_mouse_event(rdpClientContext* cctx, UINT64 mflags, INT32 x,
+	                                                 INT32 y);
 
 	FREERDP_API BOOL freerdp_client_send_button_event(rdpClientContext* cctx, BOOL relative,
 	                                                  UINT16 mflags, INT32 x, INT32 y);

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -94,7 +94,9 @@ extern "C"
 	    UINT64 reserved2;
 #endif
 
-        UINT64 reserved[128 - 3]; /**< (offset 3) */
+		ALIGN64 INT32 lastX;      /**< (offset 3) */
+		ALIGN64 INT32 lastY;      /**< (offset 4) */
+		UINT64 reserved[128 - 5]; /**< (offset 5) */
 	};
 
 	/* Common client functions */

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -66,12 +66,10 @@ extern "C"
 
 	/* Common Client Interface */
 
-#define DEFINE_RDP_CLIENT_COMMON() HANDLE thread
-
 	struct rdp_client_context
 	{
 		rdpContext context;
-		DEFINE_RDP_CLIENT_COMMON();
+		HANDLE thread;
 	};
 
 	/* Common client functions */

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -146,6 +146,8 @@ extern "C"
 	FREERDP_API BOOL client_auto_reconnect_ex(freerdp* instance,
 	                                          BOOL (*window_events)(freerdp* instance));
 
+	FREERDP_API int freerdp_client_common_stop(rdpContext* context);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -81,14 +81,20 @@ extern "C"
 	struct rdp_client_context
 	{
 		rdpContext context;
-		HANDLE thread;
+		ALIGN64 HANDLE thread; /**< (offset 0) */
 #if defined(CHANNEL_AINPUT_CLIENT)
-		AInputClientContext* ainput;
+        ALIGN64 AInputClientContext* ainput; /**< (offset 1) */
+#else
+	    UINT64 reserved1;
 #endif
 
 #if defined(CHANNEL_RDPEI_CLIENT)
-		RdpeiClientContext* rdpei;
+        ALIGN64 RdpeiClientContext* rdpei; /**< (offset 2) */
+#else
+	    UINT64 reserved2;
 #endif
+
+        UINT64 reserved[128 - 3]; /**< (offset 3) */
 	};
 
 	/* Common client functions */

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -20,8 +20,20 @@
 #ifndef FREERDP_CLIENT_H
 #define FREERDP_CLIENT_H
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <freerdp/api.h>
 #include <freerdp/freerdp.h>
+#include <freerdp/event.h>
+
+#if defined(CHANNEL_AINPUT_CLIENT)
+#include <freerdp/client/ainput.h>
+#endif
+
+#if defined(CHANNEL_RDPEI_CLIENT)
+#include <freerdp/client/rdpei.h>
+#endif
 
 #ifdef __cplusplus
 extern "C"
@@ -70,6 +82,13 @@ extern "C"
 	{
 		rdpContext context;
 		HANDLE thread;
+#if defined(CHANNEL_AINPUT_CLIENT)
+		AInputClientContext* ainput;
+#endif
+
+#if defined(CHANNEL_RDPEI_CLIENT)
+		RdpeiClientContext* rdpei;
+#endif
 	};
 
 	/* Common client functions */
@@ -100,6 +119,13 @@ extern "C"
 
 	FREERDP_API BOOL client_cli_authenticate_ex(freerdp* instance, char** username, char** password,
 	                                            char** domain, rdp_auth_reason reason);
+
+	FREERDP_API void
+	freerdp_client_OnChannelConnectedEventHandler(void* context,
+	                                              const ChannelConnectedEventArgs* e);
+	FREERDP_API void
+	freerdp_client_OnChannelDisconnectedEventHandler(void* context,
+	                                                 const ChannelDisconnectedEventArgs* e);
 
 #if defined(WITH_FREERDP_DEPRECATED)
 	FREERDP_API WINPR_DEPRECATED_VAR("Use client_cli_authenticate_ex",

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -172,6 +172,15 @@ extern "C"
 	FREERDP_API BOOL client_auto_reconnect_ex(freerdp* instance,
 	                                          BOOL (*window_events)(freerdp* instance));
 
+	FREERDP_API BOOL freerdp_client_send_wheel_event(rdpClientContext* cctx, UINT16 mflags);
+
+	FREERDP_API BOOL freerdp_client_send_button_event(rdpClientContext* cctx, BOOL relative,
+	                                                  UINT16 mflags, INT32 x, INT32 y);
+
+	FREERDP_API BOOL freerdp_client_send_extended_button_event(rdpClientContext* cctx,
+	                                                           BOOL relative, UINT16 mflags,
+	                                                           INT32 x, INT32 y);
+
 	FREERDP_API int freerdp_client_common_stop(rdpContext* context);
 
 #ifdef __cplusplus

--- a/include/freerdp/client/ainput.h
+++ b/include/freerdp/client/ainput.h
@@ -1,0 +1,39 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Display Update Virtual Channel Extension
+ *
+ * Copyright 2013 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+ * Copyright 2015 Thincast Technologies GmbH
+ * Copyright 2015 DI (FH) Martin Haimberger <martin.haimberger@thincast.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_AINPUT_CLIENT_AINPUT_H
+#define FREERDP_CHANNEL_AINPUT_CLIENT_AINPUT_H
+
+#include <winpr/assert.h>
+#include <freerdp/channels/ainput.h>
+
+typedef UINT (*pcAInputSendInputEvent)(AInputClientContext* context, UINT64 flags, INT32 x,
+                                       INT32 y);
+
+struct ainput_client_context
+{
+	void* handle;
+	void* custom;
+
+	pcAInputSendInputEvent AInputSendInputEvent;
+};
+
+#endif /* FREERDP_CHANNEL_AINPUT_CLIENT_AINPUT_H */

--- a/include/freerdp/server/ainput.h
+++ b/include/freerdp/server/ainput.h
@@ -22,6 +22,7 @@
 #define FREERDP_CHANNEL_AINPUT_SERVER_H
 
 #include <freerdp/channels/wtsvc.h>
+#include <freerdp/channels/ainput.h>
 
 typedef enum AINPUT_SERVER_OPEN_RESULT
 {

--- a/include/freerdp/server/ainput.h
+++ b/include/freerdp/server/ainput.h
@@ -34,6 +34,10 @@ typedef enum AINPUT_SERVER_OPEN_RESULT
 
 typedef struct _ainput_server_context ainput_server_context;
 
+typedef UINT (*psAInputServerInitialize)(ainput_server_context* context, BOOL externalThread);
+typedef UINT (*psAInputServerPoll)(ainput_server_context* context);
+typedef BOOL (*psAInputServerChannelHandle)(ainput_server_context* context, HANDLE* handle);
+
 typedef UINT (*psAInputServerOpen)(ainput_server_context* context);
 typedef UINT (*psAInputServerClose)(ainput_server_context* context);
 typedef BOOL (*psAInputServerIsOpen)(ainput_server_context* context);
@@ -55,6 +59,28 @@ struct _ainput_server_context
 	 * Open the ainput channel.
 	 */
 	psAInputServerOpen Open;
+
+	/**
+	 * Optional: Set thread handling.
+	 * When externalThread=TRUE the application is responsible to call
+	 * ainput_server_context_poll periodically to process input events.
+	 *
+	 * Defaults to externalThread=FALSE
+	 */
+	psAInputServerInitialize Initialize;
+
+	/**
+	 * @brief Poll When externalThread=TRUE call periodically from your main loop.
+	 * if externalThread=FALSE do not call.
+	 */
+	psAInputServerPoll Poll;
+
+	/**
+	 * @brief Poll When externalThread=TRUE call to get a handle to wait for events.
+	 * Will return FALSE until the handle is available.
+	 */
+	psAInputServerChannelHandle ChannelHandle;
+
 	/**
 	 * Close the ainput channel.
 	 */

--- a/include/freerdp/server/ainput.h
+++ b/include/freerdp/server/ainput.h
@@ -40,8 +40,8 @@ typedef BOOL (*psAInputServerIsOpen)(ainput_server_context* context);
 
 typedef UINT (*psAInputServerOpenResult)(ainput_server_context* context,
                                          AINPUT_SERVER_OPEN_RESULT result);
-typedef UINT (*psAInputServerMouseEvent)(ainput_server_context* context, UINT64 flags, INT32 x,
-                                         INT32 y);
+typedef UINT (*psAInputServerMouseEvent)(ainput_server_context* context, UINT64 timestamp,
+                                         UINT64 flags, INT32 x, INT32 y);
 
 struct _ainput_server_context
 {

--- a/include/freerdp/server/ainput.h
+++ b/include/freerdp/server/ainput.h
@@ -1,0 +1,88 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * AInput Virtual Channel Extension
+ *
+ * Copyright 2022 Armin Novak <anovak@thincast.com>
+ * Copyright 2022 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_AINPUT_SERVER_H
+#define FREERDP_CHANNEL_AINPUT_SERVER_H
+
+#include <freerdp/channels/wtsvc.h>
+
+typedef enum AINPUT_SERVER_OPEN_RESULT
+{
+	AINPUT_SERVER_OPEN_RESULT_OK = 0,
+	AINPUT_SERVER_OPEN_RESULT_CLOSED = 1,
+	AINPUT_SERVER_OPEN_RESULT_NOTSUPPORTED = 2,
+	AINPUT_SERVER_OPEN_RESULT_ERROR = 3
+} AINPUT_SERVER_OPEN_RESULT;
+
+typedef struct _ainput_server_context ainput_server_context;
+
+typedef UINT (*psAInputServerOpen)(ainput_server_context* context);
+typedef UINT (*psAInputServerClose)(ainput_server_context* context);
+typedef BOOL (*psAInputServerIsOpen)(ainput_server_context* context);
+
+typedef UINT (*psAInputServerOpenResult)(ainput_server_context* context,
+                                         AINPUT_SERVER_OPEN_RESULT result);
+typedef UINT (*psAInputServerMouseEvent)(ainput_server_context* context, UINT64 flags, INT32 x,
+                                         INT32 y);
+
+struct _ainput_server_context
+{
+	HANDLE vcm;
+
+	/* Server self-defined pointer. */
+	void* data;
+
+	/*** APIs called by the server. ***/
+	/**
+	 * Open the ainput channel.
+	 */
+	psAInputServerOpen Open;
+	/**
+	 * Close the ainput channel.
+	 */
+	psAInputServerClose Close;
+	/**
+	 * Status of the ainput channel.
+	 */
+	psAInputServerIsOpen IsOpen;
+
+	/*** Callbacks registered by the server. ***/
+
+	/**
+	 * Receive ainput mouse event PDU.
+	 */
+	psAInputServerMouseEvent MouseEvent;
+
+	rdpContext* rdpcontext;
+};
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+	FREERDP_API ainput_server_context* ainput_server_context_new(HANDLE vcm);
+	FREERDP_API void ainput_server_context_free(ainput_server_context* context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FREERDP_CHANNEL_AINPUT_SERVER_H */

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -723,6 +723,7 @@ typedef struct _RDPDR_PARALLEL RDPDR_PARALLEL;
 #define FreeRDP_CredentialsFromStdin (1604)
 #define FreeRDP_UnmapButtons (1605)
 #define FreeRDP_OldLicenseBehaviour (1606)
+#define FreeRDP_MouseUseRelativeMove (1607)
 #define FreeRDP_ComputerName (1664)
 #define FreeRDP_ConnectionFile (1728)
 #define FreeRDP_AssistanceFile (1729)
@@ -1157,10 +1158,10 @@ struct rdp_settings
 	ALIGN64 BOOL PromptForCredentials; /* 1283 */
 
 	/* Settings used for smartcard emulation */
-	UINT64 padding1284[1285 - 1284];     /* 1284 */
-	ALIGN64 char* SmartcardCertificate;  /* 1285 */
-	ALIGN64 char* SmartcardPrivateKey;   /* 1286 */
-	UINT64 padding1344[1344 - 1287];     /* 1287 */
+	UINT64 padding1284[1285 - 1284];    /* 1284 */
+	ALIGN64 char* SmartcardCertificate; /* 1285 */
+	ALIGN64 char* SmartcardPrivateKey;  /* 1286 */
+	UINT64 padding1344[1344 - 1287];    /* 1287 */
 
 	/* Kerberos Authentication */
 	ALIGN64 char* KerberosKdc;       /* 1344 */
@@ -1225,7 +1226,8 @@ struct rdp_settings
 	ALIGN64 BOOL CredentialsFromStdin; /* 1604 */
 	ALIGN64 BOOL UnmapButtons;         /* 1605 */
 	ALIGN64 BOOL OldLicenseBehaviour;  /* 1606 */
-	UINT64 padding1664[1664 - 1607];   /* 1607 */
+	ALIGN64 BOOL MouseUseRelativeMove; /* 1607 */
+	UINT64 padding1664[1664 - 1608];   /* 1608 */
 
 	/* Names */
 	ALIGN64 char* ComputerName;      /* 1664 */

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -318,6 +318,9 @@ BOOL freerdp_settings_get_bool(const rdpSettings* settings, size_t id)
 		case FreeRDP_MouseMotion:
 			return settings->MouseMotion;
 
+		case FreeRDP_MouseUseRelativeMove:
+			return settings->MouseUseRelativeMove;
+
 		case FreeRDP_MstscCookieMode:
 			return settings->MstscCookieMode;
 
@@ -948,6 +951,10 @@ BOOL freerdp_settings_set_bool(rdpSettings* settings, size_t id, BOOL val)
 
 		case FreeRDP_MouseMotion:
 			settings->MouseMotion = cnv.c;
+			break;
+
+		case FreeRDP_MouseUseRelativeMove:
+			settings->MouseUseRelativeMove = cnv.c;
 			break;
 
 		case FreeRDP_MstscCookieMode:

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -109,6 +109,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_MouseAttached, 0, "FreeRDP_MouseAttached" },
 	{ FreeRDP_MouseHasWheel, 0, "FreeRDP_MouseHasWheel" },
 	{ FreeRDP_MouseMotion, 0, "FreeRDP_MouseMotion" },
+	{ FreeRDP_MouseUseRelativeMove, 0, "FreeRDP_MouseUseRelativeMove" },
 	{ FreeRDP_MstscCookieMode, 0, "FreeRDP_MstscCookieMode" },
 	{ FreeRDP_MultiTouchGestures, 0, "FreeRDP_MultiTouchGestures" },
 	{ FreeRDP_MultiTouchInput, 0, "FreeRDP_MultiTouchInput" },

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -98,6 +98,7 @@ static const size_t bool_list_indices[] = {
 	FreeRDP_MouseAttached,
 	FreeRDP_MouseHasWheel,
 	FreeRDP_MouseMotion,
+	FreeRDP_MouseUseRelativeMove,
 	FreeRDP_MstscCookieMode,
 	FreeRDP_MultiTouchGestures,
 	FreeRDP_MultiTouchInput,

--- a/scripts/android-build.conf
+++ b/scripts/android-build.conf
@@ -15,7 +15,7 @@ WITH_OPENSSL=1
 WITH_FFMPEG=0
 BUILD_DEPS=1
 DEPS_ONLY=0
-NDK_TARGET=23
+NDK_TARGET=26
 
 JPEG_TAG=master
 OPENH264_TAG=v1.8.0  # NOTE: NDK r15c or earlier needed in --openh624-ndk for v1.8.0
@@ -23,8 +23,7 @@ OPENSSL_TAG=OpenSSL_1_1_1m
 FFMPEG_TAG=n4.4.1
 
 SRC_DIR=$SCRIPT_PATH/..
-#BUILD_DST=$SCRIPT_PATH/../client/Android/Studio/freeRDPCore/src/main/jniLibs
-BUILD_DST=~/StudioProjects/tcclient-android/app/libs/
+BUILD_DST=$SCRIPT_PATH/../client/Android/Studio/freeRDPCore/src/main/jniLibs
 BUILD_SRC=$SRC_DIR/build
 
 CMAKE_BUILD_TYPE=Debug

--- a/scripts/android-build.conf
+++ b/scripts/android-build.conf
@@ -15,7 +15,7 @@ WITH_OPENSSL=1
 WITH_FFMPEG=0
 BUILD_DEPS=1
 DEPS_ONLY=0
-NDK_TARGET=26
+NDK_TARGET=23
 
 JPEG_TAG=master
 OPENH264_TAG=v1.8.0  # NOTE: NDK r15c or earlier needed in --openh624-ndk for v1.8.0
@@ -23,7 +23,8 @@ OPENSSL_TAG=OpenSSL_1_1_1m
 FFMPEG_TAG=n4.4.1
 
 SRC_DIR=$SCRIPT_PATH/..
-BUILD_DST=$SCRIPT_PATH/../client/Android/Studio/freeRDPCore/src/main/jniLibs
+#BUILD_DST=$SCRIPT_PATH/../client/Android/Studio/freeRDPCore/src/main/jniLibs
+BUILD_DST=~/StudioProjects/tcclient-android/app/libs/
 BUILD_SRC=$SRC_DIR/build
 
 CMAKE_BUILD_TYPE=Debug

--- a/server/Sample/CMakeLists.txt
+++ b/server/Sample/CMakeLists.txt
@@ -18,7 +18,7 @@
 set(MODULE_NAME "sfreerdp-server")
 set(MODULE_PREFIX "FREERDP_SERVER_SAMPLE")
 
-set(${MODULE_PREFIX}_SRCS
+set(SRCS
 	sfreerdp.c
 	sfreerdp.h
 	sf_audin.c
@@ -27,6 +27,10 @@ set(${MODULE_PREFIX}_SRCS
 	sf_rdpsnd.h
 	sf_encomsp.c
 	sf_encomsp.h)
+
+if (CHANNEL_AINPUT_SERVER)
+    list(APPEND SRCS sf_ainput.c sf_ainput.h)
+endif()
 
 	# On windows create dll version information.
 # Vendor, product and year are already set in top level CMakeLists.txt
@@ -41,15 +45,15 @@ if (WIN32)
     ${CMAKE_CURRENT_BINARY_DIR}/version.rc
     @ONLY)
 
-  set ( ${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_SRCS} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+  set ( SRCS ${SRCS} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
 endif()
 
-add_executable(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
+add_executable(${MODULE_NAME} ${SRCS})
 
-set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} freerdp-server)
-set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} winpr freerdp)
+list(APPEND LIBS freerdp-server)
+list(APPEND LIBS winpr freerdp)
 
-target_link_libraries(${MODULE_NAME} ${${MODULE_PREFIX}_LIBS})
+target_link_libraries(${MODULE_NAME} ${LIBS})
 install(TARGETS ${MODULE_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT server)
 if (WITH_DEBUG_SYMBOLS AND MSVC)
     install(FILES ${CMAKE_PDB_BINARY_DIR}/${MODULE_NAME}.pdb DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT symbols)

--- a/server/Sample/sf_ainput.c
+++ b/server/Sample/sf_ainput.c
@@ -1,0 +1,94 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * FreeRDP Sample Server (Advanced Input)
+ *
+ * Copyright 2022 Armin Novak <armin.novak@thincast.com>
+ * Copyright 2022 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <winpr/assert.h>
+
+#include "sfreerdp.h"
+
+#include "sf_ainput.h"
+
+#include <freerdp/server/server-common.h>
+#include <freerdp/server/ainput.h>
+
+#include <freerdp/log.h>
+#define TAG SERVER_TAG("sample.ainput")
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT sf_peer_ainput_mouse_event(ainput_server_context* context, UINT64 flags, INT32 x,
+                                       INT32 y)
+{
+	/* TODO: Implement */
+	WINPR_ASSERT(context);
+
+	WLog_WARN(TAG, "%s not implemented: 0x%08" PRIx64 ", %" PRId32 "x%" PRId32, __FUNCTION__, flags,
+	          x, y);
+	return CHANNEL_RC_OK;
+}
+
+void sf_peer_ainput_init(testPeerContext* context)
+{
+	WINPR_ASSERT(context);
+
+	context->ainput = ainput_server_context_new(context->vcm);
+	WINPR_ASSERT(context->ainput);
+
+	context->ainput->rdpcontext = &context->_p;
+	context->ainput->data = context;
+
+	context->ainput->MouseEvent = sf_peer_ainput_mouse_event;
+}
+
+BOOL sf_peer_ainput_start(testPeerContext* context)
+{
+	if (!context || !context->ainput || !context->ainput->Open)
+		return FALSE;
+
+	return context->ainput->Open(context->ainput) == CHANNEL_RC_OK;
+}
+
+BOOL sf_peer_ainput_stop(testPeerContext* context)
+{
+	if (!context || !context->ainput || !context->ainput->Close)
+		return FALSE;
+
+	return context->ainput->Close(context->ainput) == CHANNEL_RC_OK;
+}
+
+BOOL sf_peer_ainput_running(testPeerContext* context)
+{
+	if (!context || !context->ainput || !context->ainput->IsOpen)
+		return FALSE;
+
+	return context->ainput->IsOpen(context->ainput);
+}
+
+void sf_peer_ainput_uninit(testPeerContext* context)
+{
+	ainput_server_context_free(context->ainput);
+}

--- a/server/Sample/sf_ainput.c
+++ b/server/Sample/sf_ainput.c
@@ -40,14 +40,14 @@
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT sf_peer_ainput_mouse_event(ainput_server_context* context, UINT64 flags, INT32 x,
-                                       INT32 y)
+static UINT sf_peer_ainput_mouse_event(ainput_server_context* context, UINT64 timestamp,
+                                       UINT64 flags, INT32 x, INT32 y)
 {
 	/* TODO: Implement */
 	WINPR_ASSERT(context);
 
-	WLog_WARN(TAG, "%s not implemented: 0x%08" PRIx64 ", %" PRId32 "x%" PRId32, __FUNCTION__, flags,
-	          x, y);
+	WLog_WARN(TAG, "%s not implemented: 0x%08" PRIx64 ", 0x%08" PRIx64 ", %" PRId32 "x%" PRId32,
+	          __FUNCTION__, timestamp, flags, x, y);
 	return CHANNEL_RC_OK;
 }
 

--- a/server/Sample/sf_ainput.h
+++ b/server/Sample/sf_ainput.h
@@ -1,0 +1,37 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * FreeRDP Sample Server (Advanced Input)
+ *
+ * Copyright 2022 Armin Novak <armin.novak@thincast.com>
+ * Copyright 2022 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_SERVER_SAMPLE_SF_AINPUT_H
+#define FREERDP_SERVER_SAMPLE_SF_AINPUT_H
+
+#include <freerdp/freerdp.h>
+#include <freerdp/listener.h>
+#include <freerdp/server/ainput.h>
+
+#include "sfreerdp.h"
+
+void sf_peer_ainput_init(testPeerContext* context);
+void sf_peer_ainput_uninit(testPeerContext* context);
+
+BOOL sf_peer_ainput_running(testPeerContext* context);
+BOOL sf_peer_ainput_start(testPeerContext* context);
+BOOL sf_peer_ainput_stop(testPeerContext* context);
+
+#endif /* FREERDP_SERVER_SAMPLE_SF_AINPUT_H */

--- a/server/Sample/sfreerdp.h
+++ b/server/Sample/sfreerdp.h
@@ -25,6 +25,9 @@
 #include <freerdp/codec/rfx.h>
 #include <freerdp/codec/nsc.h>
 #include <freerdp/channels/wtsvc.h>
+#if defined(CHANNEL_AINPUT_SERVER)
+#include <freerdp/server/ainput.h>
+#endif
 #include <freerdp/server/audin.h>
 #include <freerdp/server/rdpsnd.h>
 #include <freerdp/server/encomsp.h>
@@ -55,6 +58,10 @@ struct test_peer_context
 	HANDLE debug_channel_thread;
 	audin_server_context* audin;
 	BOOL audin_open;
+#if defined(CHANNEL_AINPUT_SERVER)
+	ainput_server_context* ainput;
+	BOOL ainput_open;
+#endif
 	UINT32 frame_id;
 	RdpsndServerContext* rdpsnd;
 	EncomspServerContext* encomsp;

--- a/server/shadow/Win/win_rdp.c
+++ b/server/shadow/Win/win_rdp.c
@@ -245,7 +245,7 @@ static int shw_freerdp_client_start(rdpContext* context)
 	freerdp* instance = context->instance;
 	shw = (shwContext*)context;
 
-	if (!(shw->thread = CreateThread(NULL, 0, shw_client_thread, instance, 0, NULL)))
+	if (!(shw->common.thread = CreateThread(NULL, 0, shw_client_thread, instance, 0, NULL)))
 	{
 		WLog_ERR(TAG, "Failed to create thread");
 		return -1;

--- a/server/shadow/Win/win_rdp.h
+++ b/server/shadow/Win/win_rdp.h
@@ -30,8 +30,7 @@ typedef struct shw_context shwContext;
 
 struct shw_context
 {
-	rdpContext context;
-	DEFINE_RDP_CLIENT_COMMON();
+	rdpClientContext common;
 
 	HANDLE StopEvent;
 	freerdp* instance;

--- a/server/shadow/Win/win_shadow.c
+++ b/server/shadow/Win/win_shadow.c
@@ -291,9 +291,17 @@ static int win_shadow_surface_copy(winShadowSubsystem* subsystem)
 		rdpGdi* gdi;
 		shwContext* shw;
 		rdpContext* context;
+
+		WINPR_ASSERT(subsystem);
 		shw = subsystem->shw;
-		context = &shw->context;
+		WINPR_ASSERT(shw);
+
+		context = &shw->common.context;
+		WINPR_ASSERT(context);
+
 		gdi = context->gdi;
+		WINPR_ASSERT(gdi);
+
 		pDstData = gdi->primary_buffer;
 		nDstStep = gdi->width * 4;
 		DstFormat = gdi->dstFormat;


### PR DESCRIPTION
* Implements a custom FreeRDP channel to circumvent limitations of `[MS-RDPBCGR]` mouse events (allow sending relative position updates, more than 5 buttons, ...)
* Refactor clients to move generic channel code to `client/common`
* Automatically load the custom channel by all clients and use it, if the server supports it.
* Sample implementation in sample server. (Press `i` to toggle, just prints received events to `WLog`)