### PR TITLE
cmdline: Always reinitialize NetworkAutoDetect

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -980,6 +980,7 @@ BOOL freerdp_set_connection_type(rdpSettings* settings, UINT32 type)
 		settings->DisableFullWindowDrag = TRUE;
 		settings->DisableMenuAnims = TRUE;
 		settings->DisableThemes = TRUE;
+		settings->NetworkAutoDetect = FALSE;
 	}
 	else if (type == CONNECTION_TYPE_BROADBAND_LOW)
 	{
@@ -989,6 +990,7 @@ BOOL freerdp_set_connection_type(rdpSettings* settings, UINT32 type)
 		settings->DisableFullWindowDrag = TRUE;
 		settings->DisableMenuAnims = TRUE;
 		settings->DisableThemes = FALSE;
+		settings->NetworkAutoDetect = FALSE;
 	}
 	else if (type == CONNECTION_TYPE_SATELLITE)
 	{
@@ -998,6 +1000,7 @@ BOOL freerdp_set_connection_type(rdpSettings* settings, UINT32 type)
 		settings->DisableFullWindowDrag = TRUE;
 		settings->DisableMenuAnims = TRUE;
 		settings->DisableThemes = FALSE;
+		settings->NetworkAutoDetect = FALSE;
 	}
 	else if (type == CONNECTION_TYPE_BROADBAND_HIGH)
 	{
@@ -1007,6 +1010,7 @@ BOOL freerdp_set_connection_type(rdpSettings* settings, UINT32 type)
 		settings->DisableFullWindowDrag = TRUE;
 		settings->DisableMenuAnims = TRUE;
 		settings->DisableThemes = FALSE;
+		settings->NetworkAutoDetect = FALSE;
 	}
 	else if (type == CONNECTION_TYPE_WAN)
 	{
@@ -1016,6 +1020,7 @@ BOOL freerdp_set_connection_type(rdpSettings* settings, UINT32 type)
 		settings->DisableFullWindowDrag = FALSE;
 		settings->DisableMenuAnims = FALSE;
 		settings->DisableThemes = FALSE;
+		settings->NetworkAutoDetect = FALSE;
 	}
 	else if (type == CONNECTION_TYPE_LAN)
 	{
@@ -1025,6 +1030,7 @@ BOOL freerdp_set_connection_type(rdpSettings* settings, UINT32 type)
 		settings->DisableFullWindowDrag = FALSE;
 		settings->DisableMenuAnims = FALSE;
 		settings->DisableThemes = FALSE;
+		settings->NetworkAutoDetect = FALSE;
 	}
 	else if (type == CONNECTION_TYPE_AUTODETECT)
 	{


### PR DESCRIPTION
Always reinitialize NetworkAutoDetect, otherwise it might end set to
previous value and not the desired one. This happens when the client
sets /network:lan , in which case NetworkAutoDetect remains set to
TRUE because freerdp_set_connection_type() was previously called in
prepare_default_settings() and NetworkAutoDetect is never updated by
freerdp_set_connection_type() afterward.