### PR TITLE
Guard avcodec_register_all() calls

### DIFF
--- a/channels/tsmf/client/ffmpeg/tsmf_ffmpeg.c
+++ b/channels/tsmf/client/ffmpeg/tsmf_ffmpeg.c
@@ -615,7 +615,9 @@ static void tsmf_ffmpeg_free(ITSMFDecoder* decoder)
 static INIT_ONCE g_Initialized = INIT_ONCE_STATIC_INIT;
 static BOOL CALLBACK InitializeAvCodecs(PINIT_ONCE once, PVOID param, PVOID* context)
 {
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 10, 100)
 	avcodec_register_all();
+#endif
 	return TRUE;
 }
 

--- a/libfreerdp/codec/dsp_ffmpeg.c
+++ b/libfreerdp/codec/dsp_ffmpeg.c
@@ -573,7 +573,9 @@ BOOL freerdp_dsp_ffmpeg_supports_format(const AUDIO_FORMAT* format, BOOL encode)
 FREERDP_DSP_CONTEXT* freerdp_dsp_ffmpeg_context_new(BOOL encode)
 {
 	FREERDP_DSP_CONTEXT* context;
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 10, 100)
 	avcodec_register_all();
+#endif
 	context = calloc(1, sizeof(FREERDP_DSP_CONTEXT));
 
 	if (!context)


### PR DESCRIPTION
{channels/tsmf/client/ffmpeg/tsmf,libfreerdp/codec/dsp}_ffmpeg.c:
Guard calls to `avcodec_register_all()` against use beyond
`AV_VERSION_INT(58, 10, 100)`, where upstream ffmpeg made it obsolete.

This allows compiling with ffmpeg >= 5.0.
