### PR TITLE
Wayland: fix memory issues in wlfreerdp

### DIFF
--- a/include/freerdp/update.h
+++ b/include/freerdp/update.h
@@ -66,7 +66,6 @@ typedef struct _BITMAP_DATA BITMAP_DATA;
 
 struct _BITMAP_UPDATE
 {
-	UINT32 count;
 	UINT32 number;
 	BITMAP_DATA* rectangles;
 	BOOL skipCompression;

--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -215,20 +215,10 @@ BITMAP_UPDATE* update_read_bitmap_update(rdpUpdate* update, wStream* s)
 	Stream_Read_UINT16(s, bitmapUpdate->number); /* numberRectangles (2 bytes) */
 	WLog_Print(up->log, WLOG_TRACE, "BitmapUpdate: %" PRIu32 "", bitmapUpdate->number);
 
-	if (bitmapUpdate->number > bitmapUpdate->count)
-	{
-		UINT32 count = bitmapUpdate->number * 2;
-		BITMAP_DATA* newdata =
-		    (BITMAP_DATA*)realloc(bitmapUpdate->rectangles, sizeof(BITMAP_DATA) * count);
+	bitmapUpdate->rectangles = (BITMAP_DATA*)calloc(bitmapUpdate->number, sizeof(BITMAP_DATA));
 
-		if (!newdata)
-			goto fail;
-
-		bitmapUpdate->rectangles = newdata;
-		ZeroMemory(&bitmapUpdate->rectangles[bitmapUpdate->count],
-		           sizeof(BITMAP_DATA) * (count - bitmapUpdate->count));
-		bitmapUpdate->count = count;
-	}
+	if (!bitmapUpdate->rectangles)
+		goto fail;
 
 	/* rectangles */
 	for (i = 0; i < bitmapUpdate->number; i++)

--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -1535,7 +1535,7 @@ static BOOL shadow_client_send_bitmap_update(rdpShadowClient* client, BYTE* pSrc
 	cols = (nWidth / 64) + ((nWidth % 64) ? 1 : 0);
 	k = 0;
 	totalBitmapSize = 0;
-	bitmapUpdate.count = bitmapUpdate.number = rows * cols;
+	bitmapUpdate.number = rows * cols;
 
 	if (!(bitmapData = (BITMAP_DATA*)calloc(bitmapUpdate.number, sizeof(BITMAP_DATA))))
 		return FALSE;
@@ -1613,8 +1613,8 @@ static BOOL shadow_client_send_bitmap_update(rdpShadowClient* client, BYTE* pSrc
 		}
 	}
 
-	bitmapUpdate.count = bitmapUpdate.number = k;
-	updateSizeEstimate = totalBitmapSize + (k * bitmapUpdate.count) + 16;
+	bitmapUpdate.number = k;
+	updateSizeEstimate = totalBitmapSize + (k * bitmapUpdate.number) + 16;
 
 	if (updateSizeEstimate > maxUpdateSize)
 	{
@@ -1649,7 +1649,7 @@ static BOOL shadow_client_send_bitmap_update(rdpShadowClient* client, BYTE* pSrc
 
 			if ((newUpdateSize >= maxUpdateSize) || (i + 1) >= k)
 			{
-				bitmapUpdate.count = bitmapUpdate.number = j;
+				bitmapUpdate.number = j;
 				IFCALLRET(update->BitmapUpdate, ret, context, &bitmapUpdate);
 
 				if (!ret)

--- a/uwac/libuwac/uwac-priv.h
+++ b/uwac/libuwac/uwac-priv.h
@@ -255,6 +255,14 @@ struct uwac_window
 	int pointer_current_cursor;
 };
 
+/**@brief data to pass to wl_buffer release listener */
+struct uwac_buffer_release_data
+{
+	UwacWindow* window;
+	int bufferIdx;
+};
+typedef struct uwac_buffer_release_data UwacBufferReleaseData;
+
 /* in uwa-display.c */
 UwacEvent* UwacDisplayNewEvent(UwacDisplay* d, int type);
 int UwacDisplayWatchFd(UwacDisplay* display, int fd, uint32_t events, UwacTask* task);


### PR DESCRIPTION
1. This fixes #7426: wlfreerdp crashes from time to time with `malloc(): unaligned tcache chunk detected` message.

    It happened due to directly passed references to allocated buffers into buffer_release callback, while those buffers could be re-allocated to another memory region (at `UwacWindowShmAllocBuffers()`, line `newBuffers = xrealloc(w->buffers, (w->nbuffers + nbuffers) * sizeof(UwacBuffer));`) and thus buffer_release ended up corrupting memory (writing into free'd region). Fixed that by passing pointer to UwacWindow and buffer's index into listener instead, so that callback uses actual buffer address to set `used` property to `false`.

2. Also fixed twice-as-much memory allocation in `update_read_bitmap_update()` redundant as of refactoring made at e5767f07. Previously `BITMAP_UPDATE` could be reused, and so `count` tracked how many rectangles were actually allocated, and `update_read_bitmap_update()` allocated twice `rectangles` number for reserve. Currently a new `BITMAP_UPDATE` instance is allocated every time, so there's no point to keep it that way anymore.