### PR TITLE
Fixed const warnings for codec decompress routines

### DIFF
--- a/include/freerdp/codec/mppc.h
+++ b/include/freerdp/codec/mppc.h
@@ -37,7 +37,7 @@ extern "C"
 	FREERDP_API int mppc_compress(MPPC_CONTEXT* mppc, const BYTE* pSrcData, UINT32 SrcSize,
 	                              BYTE** ppDstData, UINT32* pDstSize, UINT32* pFlags);
 	FREERDP_API int mppc_decompress(MPPC_CONTEXT* mppc, const BYTE* pSrcData, UINT32 SrcSize,
-	                                BYTE** ppDstData, UINT32* pDstSize, UINT32 flags);
+	                                const BYTE** ppDstData, UINT32* pDstSize, UINT32 flags);
 
 	FREERDP_API void mppc_set_compression_level(MPPC_CONTEXT* mppc, DWORD CompressionLevel);
 

--- a/include/freerdp/codec/ncrush.h
+++ b/include/freerdp/codec/ncrush.h
@@ -37,7 +37,7 @@ extern "C"
 	FREERDP_API int ncrush_compress(NCRUSH_CONTEXT* ncrush, const BYTE* pSrcData, UINT32 SrcSize,
 	                                BYTE** ppDstData, UINT32* pDstSize, UINT32* pFlags);
 	FREERDP_API int ncrush_decompress(NCRUSH_CONTEXT* ncrush, const BYTE* pSrcData, UINT32 SrcSize,
-	                                  BYTE** ppDstData, UINT32* pDstSize, UINT32 flags);
+	                                  const BYTE** ppDstData, UINT32* pDstSize, UINT32 flags);
 
 	FREERDP_API void ncrush_context_reset(NCRUSH_CONTEXT* ncrush, BOOL flush);
 

--- a/include/freerdp/codec/xcrush.h
+++ b/include/freerdp/codec/xcrush.h
@@ -35,7 +35,7 @@ extern "C"
 	FREERDP_API int xcrush_compress(XCRUSH_CONTEXT* xcrush, const BYTE* pSrcData, UINT32 SrcSize,
 	                                BYTE** ppDstData, UINT32* pDstSize, UINT32* pFlags);
 	FREERDP_API int xcrush_decompress(XCRUSH_CONTEXT* xcrush, const BYTE* pSrcData, UINT32 SrcSize,
-	                                  BYTE** ppDstData, UINT32* pDstSize, UINT32 flags);
+	                                  const BYTE** ppDstData, UINT32* pDstSize, UINT32 flags);
 
 	FREERDP_API void xcrush_context_reset(XCRUSH_CONTEXT* xcrush, BOOL flush);
 

--- a/libfreerdp/codec/mppc.c
+++ b/libfreerdp/codec/mppc.c
@@ -86,8 +86,8 @@ static const UINT32 MPPC_MATCH_TABLE[256] = {
 
 //#define DEBUG_MPPC	1
 
-int mppc_decompress(MPPC_CONTEXT* mppc, const BYTE* pSrcData, UINT32 SrcSize, BYTE** ppDstData,
-                    UINT32* pDstSize, UINT32 flags)
+int mppc_decompress(MPPC_CONTEXT* mppc, const BYTE* pSrcData, UINT32 SrcSize,
+                    const BYTE** ppDstData, UINT32* pDstSize, UINT32 flags)
 {
 	BYTE Literal;
 	BYTE* SrcPtr;

--- a/libfreerdp/codec/ncrush.c
+++ b/libfreerdp/codec/ncrush.c
@@ -1991,7 +1991,7 @@ static INLINE void NCrushWriteFinish(BYTE** DstPtr, UINT32 accumulator)
 }
 
 int ncrush_decompress(NCRUSH_CONTEXT* ncrush, const BYTE* pSrcData, UINT32 SrcSize,
-                      BYTE** ppDstData, UINT32* pDstSize, UINT32 flags)
+                      const BYTE** ppDstData, UINT32* pDstSize, UINT32 flags)
 {
 	UINT32 index;
 	UINT32 bits;

--- a/libfreerdp/codec/xcrush.c
+++ b/libfreerdp/codec/xcrush.c
@@ -874,7 +874,7 @@ static int xcrush_decompress_l1(XCRUSH_CONTEXT* xcrush, const BYTE* pSrcData, UI
 }
 
 int xcrush_decompress(XCRUSH_CONTEXT* xcrush, const BYTE* pSrcData, UINT32 SrcSize,
-                      BYTE** ppDstData, UINT32* pDstSize, UINT32 flags)
+                      const BYTE** ppDstData, UINT32* pDstSize, UINT32 flags)
 {
 	int status = 0;
 	UINT32 DstSize = 0;

--- a/libfreerdp/core/bulk.c
+++ b/libfreerdp/core/bulk.c
@@ -129,7 +129,7 @@ static INLINE int bulk_compress_validate(rdpBulk* bulk, BYTE* pSrcData, UINT32 S
 }
 #endif
 
-int bulk_decompress(rdpBulk* bulk, BYTE* pSrcData, UINT32 SrcSize, BYTE** ppDstData,
+int bulk_decompress(rdpBulk* bulk, const BYTE* pSrcData, UINT32 SrcSize, const BYTE** ppDstData,
                     UINT32* pDstSize, UINT32 flags)
 {
 	UINT32 type;

--- a/libfreerdp/core/bulk.h
+++ b/libfreerdp/core/bulk.h
@@ -34,8 +34,8 @@ typedef struct rdp_bulk rdpBulk;
 
 FREERDP_LOCAL UINT32 bulk_compression_max_size(rdpBulk* bulk);
 
-FREERDP_LOCAL int bulk_decompress(rdpBulk* bulk, BYTE* pSrcData, UINT32 SrcSize, BYTE** ppDstData,
-                                  UINT32* pDstSize, UINT32 flags);
+FREERDP_LOCAL int bulk_decompress(rdpBulk* bulk, const BYTE* pSrcData, UINT32 SrcSize,
+                                  const BYTE** ppDstData, UINT32* pDstSize, UINT32 flags);
 FREERDP_LOCAL int bulk_compress(rdpBulk* bulk, BYTE* pSrcData, UINT32 SrcSize, BYTE** ppDstData,
                                 UINT32* pDstSize, UINT32* pFlags);
 


### PR DESCRIPTION
various `*_decompress` routines return a pointer to some internal buffer via argument. Make that `const` so we don´t accidentally override it (and avoid cast warnings this way)