### PR TITLE
uwac-window: Change protocol selection order and make ivi surface-id configurable

### DIFF
--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -485,6 +485,22 @@ UwacWindow* UwacCreateWindowShm(UwacDisplay* display, uint32_t width, uint32_t h
 
 	wl_surface_set_user_data(w->surface, w);
 
+#if BUILD_IVI
+	if (display->ivi_application)
+	{
+		w->ivi_surface = ivi_application_surface_create(display->ivi_application, 1, w->surface);
+		assert(w->ivi_surface);
+		ivi_surface_add_listener(w->ivi_surface, &ivi_surface_listener, w);
+	} else
+#endif
+#if BUILD_FULLSCREEN_SHELL
+	if (display->fullscreen_shell)
+	{
+		zwp_fullscreen_shell_v1_present_surface(display->fullscreen_shell, w->surface,
+                                                 ZWP_FULLSCREEN_SHELL_V1_PRESENT_METHOD_CENTER,
+                                                 NULL);
+	} else
+#endif
 	if (display->xdg_base)
 	{
 		w->xdg_surface = xdg_wm_base_get_xdg_surface(display->xdg_base, w->surface);
@@ -509,22 +525,6 @@ UwacWindow* UwacCreateWindowShm(UwacDisplay* display, uint32_t width, uint32_t h
 		wl_surface_commit(w->surface);
 		wl_display_roundtrip(w->display->display);
 	}
-#if BUILD_IVI
-	else if (display->ivi_application)
-	{
-		w->ivi_surface = ivi_application_surface_create(display->ivi_application, 1, w->surface);
-		assert(w->ivi_surface);
-		ivi_surface_add_listener(w->ivi_surface, &ivi_surface_listener, w);
-	}
-#endif
-#if BUILD_FULLSCREEN_SHELL
-	else if (display->fullscreen_shell)
-	{
-		zwp_fullscreen_shell_v1_present_surface(display->fullscreen_shell, w->surface,
-		                                        ZWP_FULLSCREEN_SHELL_V1_PRESENT_METHOD_CENTER,
-		                                        NULL);
-	}
-#endif
 	else
 	{
 		w->shell_surface = wl_shell_get_shell_surface(display->shell, w->surface);

--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include <assert.h>
 #include <sys/mman.h>
+#include <errno.h>
 
 #include "uwac-priv.h"
 #include "uwac-utils.h"
@@ -486,9 +487,23 @@ UwacWindow* UwacCreateWindowShm(UwacDisplay* display, uint32_t width, uint32_t h
 	wl_surface_set_user_data(w->surface, w);
 
 #if BUILD_IVI
+	uint32_t ivi_surface_id = 1;
+	char* env = getenv("IVI_SURFACE_ID");
+	if (env)
+	{
+		unsigned long val;
+		char* endp;
+
+		errno = 0;
+		val = strtoul(env, &endp, 10);
+
+		if (!errno && val != 0 && val != ULONG_MAX)
+			ivi_surface_id = val;
+	}
+
 	if (display->ivi_application)
 	{
-		w->ivi_surface = ivi_application_surface_create(display->ivi_application, 1, w->surface);
+		w->ivi_surface = ivi_application_surface_create(display->ivi_application, ivi_surface_id, w->surface);
 		assert(w->ivi_surface);
 		ivi_surface_add_listener(w->ivi_surface, &ivi_surface_listener, w);
 	} else


### PR DESCRIPTION
**uwac-window: Change protocol selection order** 

The current order of protocol selection is xdg_base followed by
ivi_application followed by fullscreen_shell. As a result xdg_base
protocol will be selected even if ivi_application protocol is needed.

The order is now changed to ivi_application followed by fullscreen_shell
followed by xdg_base. It is now possible to select any one of the three
protocols by appropriately defining BUILD_IVI and BUILD_FULLSCREEN_SHELL
macro.

Signed-off-by: Kshitij Kadam <Kshitij.Kadam@ifm.com>

**uwac-window: Make ivi surface-id configurable** 

The ivi surface-id is made configurable by fetching it from the
environment variables. An environment variable IVI_SURFACE_ID needs to
be set to the required surface-id. In case it is not set then the code
will take 1 as the default surface-id.

Signed-off-by: Kshitij Kadam <Kshitij.Kadam@ifm.com>