### PR TITLE
proxy: improve channel treatment

### DIFF
--- a/include/freerdp/server/proxy/proxy_context.h
+++ b/include/freerdp/server/proxy/proxy_context.h
@@ -47,6 +47,28 @@ extern "C"
 	 * and set their cleanup function accordingly. */
 	FREERDP_API void intercept_context_entry_free(void* obj);
 
+	/** @brief how is handled a channel */
+	enum pf_utils_channel_mode
+	{
+		PF_UTILS_CHANNEL_NOT_HANDLED,
+		PF_UTILS_CHANNEL_BLOCK,
+		PF_UTILS_CHANNEL_PASSTHROUGH,
+		PF_UTILS_CHANNEL_INTERCEPT,
+	};
+	typedef enum pf_utils_channel_mode pf_utils_channel_mode;
+
+	/** @brief per channel configuration */
+	struct p_server_channel_context
+	{
+		char* channel_name;
+		UINT32 channel_id;
+		BOOL isDynamic;
+		pf_utils_channel_mode channelMode;
+	};
+	typedef struct p_server_channel_context pServerChannelContext;
+
+	void ChannelContext_free(pServerChannelContext* ctx);
+
 	/**
 	 * Wraps rdpContext and holds the state for the proxy's server.
 	 */
@@ -60,8 +82,11 @@ extern "C"
 		HANDLE dynvcReady;
 
 		wHashTable* interceptContextMap;
+		wHashTable* channelsById;
 	};
 	typedef struct p_server_context pServerContext;
+
+	pServerChannelContext* ChannelContext_new(pServerContext* ps, const char* name, UINT32 id);
 
 	/**
 	 * Wraps rdpContext and holds the state for the proxy's client.

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -2006,7 +2006,7 @@ BOOL gcc_write_client_monitor_data(wStream* s, const rdpMcs* mcs)
 			Stream_Write_UINT32(s, flags);  /* flags */
 		}
 	}
-	WLog_DBG(TAG, "[%s] FINISHED" PRIu32, __FUNCTION__);
+	WLog_DBG(TAG, "[%s] FINISHED", __FUNCTION__);
 	return TRUE;
 }
 

--- a/server/proxy/pf_utils.h
+++ b/server/proxy/pf_utils.h
@@ -22,6 +22,7 @@
 #define FREERDP_SERVER_PROXY_PFUTILS_H
 
 #include <freerdp/server/proxy/proxy_config.h>
+#include <freerdp/server/proxy/proxy_context.h>
 
 /**
  * @brief pf_utils_channel_is_passthrough Checks of a channel identified by 'name'
@@ -34,14 +35,6 @@
  *         e.g. proxy client and server are termination points and data passed
  *         between.
  */
-typedef enum
-{
-	PF_UTILS_CHANNEL_NOT_HANDLED,
-	PF_UTILS_CHANNEL_BLOCK,
-	PF_UTILS_CHANNEL_PASSTHROUGH,
-	PF_UTILS_CHANNEL_INTERCEPT,
-} pf_utils_channel_mode;
-
 pf_utils_channel_mode pf_utils_get_channel_mode(const proxyConfig* config, const char* name);
 const char* pf_utils_channel_mode_string(pf_utils_channel_mode mode);
 


### PR DESCRIPTION
This PR introduces per channel context so that we can speed up operations like retrieving the channel name from its id, or knowing what shall be done for a packet (no config ACL recomputation at each packet).

