### PR TITLE
Fixed invalid password prompt on Windows system

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -486,7 +486,7 @@ static BOOL wf_authenticate_raw(freerdp* instance, const char* title, char** use
 		strncpy(Domain, *domain, CREDUI_MAX_DOMAIN_TARGET_LENGTH);
 	}
 
-	if (!(username && *username && password && *password))
+    if (!(*UserName && *Password))
 	{
 		if (!wfc->isConsole && wfc->context.settings->CredentialsFromStdin)
 			WLog_ERR(TAG, "Flag for stdin read present but stdin is redirected; using GUI");


### PR DESCRIPTION
The condition`!(username && *username && password && *password)` will always return false, so no matter input username/password is empty or not, the password prompt dialog will never show.