### PR TITLE
disp: Remove wrong assert

### DIFF
--- a/channels/disp/client/disp_main.c
+++ b/channels/disp/client/disp_main.c
@@ -284,7 +284,6 @@ static UINT disp_on_new_channel_connection(IWTSListenerCallback* pListenerCallba
 
 	WINPR_ASSERT(listener_callback);
 	WINPR_ASSERT(pChannel);
-	WINPR_ASSERT(Data);
 	WINPR_ASSERT(pbAccept);
 	WINPR_ASSERT(ppCallback);
 


### PR DESCRIPTION
`dvcman_create_channel` calls the `OnNewChannelConnection` with `Data` set to `NULL`, therefore the `assert` in the display channel's callback will always trigger.