### PR TITLE
rdpdr: Fix detection of device unplug

### DIFF
--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -371,7 +371,7 @@ RDPDR_DEVICE* freerdp_device_new(UINT32 Type, size_t count, const char* args[])
 						goto fail;
 				}
 				if (count > 2)
-					device.drive->automount = (args[2] == NULL) ? FALSE : TRUE;
+					device.drive->automount = (args[2] == NULL) ? TRUE : FALSE;
 				break;
 			default:
 				goto fail;


### PR DESCRIPTION
Fixes setting of the `automount` flag for newly created redirection devices which (was inverted from the parameter passed in `rdpdr_load_drive`)