### PR TITLE
winpr/{libwinpr/thread/thread.c,include/winpr/thread.h}: Keep DumpThr…

### DIFF
--- a/winpr/include/winpr/thread.h
+++ b/winpr/include/winpr/thread.h
@@ -248,10 +248,7 @@ extern "C"
 	/* CommandLineToArgvA is not present in the original Windows API, WinPR always exports it */
 
 	WINPR_API LPSTR* CommandLineToArgvA(LPCSTR lpCmdLine, int* pNumArgs);
-
-#if defined(WITH_DEBUG_THREADS)
 	WINPR_API VOID DumpThreadHandles(void);
-#endif
 
 #ifdef __cplusplus
 }

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -814,9 +814,9 @@ BOOL TerminateThread(HANDLE hThread, DWORD dwExitCode)
 	return TRUE;
 }
 
-#if defined(WITH_DEBUG_THREADS)
 VOID DumpThreadHandles(void)
 {
+#if defined(WITH_DEBUG_THREADS)
 	char** msg;
 	size_t used, i;
 	void* stack = winpr_backtrace(20);
@@ -879,6 +879,6 @@ VOID DumpThreadHandles(void)
 #endif
 
 	WLog_DBG(TAG, "---------------- End Dumping thread handles -------------");
-}
 #endif
+}
 #endif


### PR DESCRIPTION
…eadHandles as a symbol even if WITH_DEBUG_THREADS is OFF.

Without this patch, one would have to introduce an SOVERSION change in cases where FreeRDP was provided with debugging enabled first and then disabled.

To avoid such awkwardnesses, keep the DumpTheadHandles symbols around even if debugging is disabled.