### PR TITLE
X11/cliprdr: Clear selection requests, when they become invalid

### DIFF
--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -1616,6 +1616,10 @@ static UINT xf_cliprdr_server_format_list(CliprdrClientContext* context,
 	xfc = clipboard->xfc;
 	WINPR_ASSERT(xfc);
 
+	/* Clear the active SelectionRequest, as it is now invalid */
+	free(clipboard->respond);
+	clipboard->respond = NULL;
+
 	xf_clipboard_formats_free(clipboard);
 	xf_cliprdr_clear_cached_data(clipboard);
 	clipboard->data_format_id = -1;
@@ -2049,6 +2053,8 @@ xf_cliprdr_server_format_data_response(CliprdrClientContext* context,
 	if (formatDataResponse->msgFlags == CB_RESPONSE_FAIL)
 	{
 		WLog_WARN(TAG, "Format Data Response PDU msgFlags is CB_RESPONSE_FAIL");
+		free(clipboard->respond);
+		clipboard->respond = NULL;
 		return CHANNEL_RC_OK;
 	}
 


### PR DESCRIPTION
Quoting the commit message here:
```
When a FormatDataRequest by xfreerdp is answered with the
CB_RESPONSE_FAIL flag, then the request was answered, but xfreerdp does
not mark it as answered, by leaving the request as pending.
This results in non-functional copy-paste actions, when copying
something from the server side, after the failed request.
A similar situation can happen, when a new FormatList is received,
while there is a pending FormatDataRequest.

Fix these situations by clearing the pending request, when a form of an
answer, either via CB_RESPONSE_FAIL flag or via new FormatList, is
received.

Fixes: https://github.com/FreeRDP/FreeRDP/issues/7757
```