### PR TITLE
winpr: skip TestBacktrace when there is no viable backtrace implement…

### DIFF
--- a/winpr/libwinpr/utils/test/CMakeLists.txt
+++ b/winpr/libwinpr/utils/test/CMakeLists.txt
@@ -44,5 +44,7 @@ foreach(test ${${MODULE_PREFIX}_TESTS})
 	add_test(${TestName} ${TESTING_OUTPUT_DIRECTORY}/${MODULE_NAME} ${TestName})
 endforeach()
 
+set_property(TEST TestBacktrace PROPERTY SKIP_RETURN_CODE 77)
+
 set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "WinPR/Test")
 

--- a/winpr/libwinpr/utils/test/TestBacktrace.c
+++ b/winpr/libwinpr/utils/test/TestBacktrace.c
@@ -1,8 +1,10 @@
+#include <winpr/config.h>
 #include <stdio.h>
 #include <winpr/debug.h>
 
 int TestBacktrace(int argc, char* argv[])
 {
+#if defined(HAVE_EXECINFO_H) || defined(ANDROID) || ((defined(_WIN32) || defined(_WIN64)) && !defined(_UWP))
 	int rc = -1;
 	size_t used, x;
 	char** msg;
@@ -31,4 +33,8 @@ int TestBacktrace(int argc, char* argv[])
 	winpr_backtrace_free(stack);
 	free(msg);
 	return rc;
+#else
+	/* Use return code 77 to indicate the test should be skipped */
+	return 77;
+#endif
 }


### PR DESCRIPTION
Fixes: https://github.com/FreeRDP/FreeRDP/issues/7773