### PR TITLE
Urbrdc fix (#7417)

### DIFF
--- a/channels/urbdrc/client/data_transfer.c
+++ b/channels/urbdrc/client/data_transfer.c
@@ -1749,6 +1749,13 @@ static UINT urbdrc_process_transfer_request(IUDEVICE* pdev, URBDRC_CHANNEL_CALLB
 			break;
 	}
 
+	if (error)
+	{
+		WLog_Print(urbdrc->log, WLOG_WARN,
+		           "USB transfer request URB Function %08" PRIx32 " failed with %08" PRIx32,
+		           URB_Function, error);
+	}
+
 	return error;
 }
 

--- a/channels/urbdrc/client/libusb/libusb_udevman.c
+++ b/channels/urbdrc/client/libusb/libusb_udevman.c
@@ -195,6 +195,12 @@ static size_t udevman_register_udevice(IUDEVMAN* idevman, BYTE bus_number, BYTE 
 		/* register all device that match pid vid */
 		num = udev_new_by_id(urbdrc, udevman->context, idVendor, idProduct, &devArray);
 
+		if (num == 0)
+		{
+			WLog_Print(urbdrc->log, WLOG_WARN,
+			           "Could not find or redirect any usb devices by id %04x:%04x", idVendor, idProduct);
+		}
+
 		for (i = 0; i < num; i++)
 		{
 			UINT32 id;
@@ -834,7 +840,7 @@ static BOOL poll_libusb_events(UDEVMAN* udevman)
 {
 	int rc = LIBUSB_SUCCESS;
 	struct timeval tv = { 0, 500 };
-	if (libusb_try_lock_events(udevman->context))
+	if (libusb_try_lock_events(udevman->context) == 0)
 	{
 		if (libusb_event_handling_ok(udevman->context))
 		{
@@ -921,7 +927,7 @@ UINT freerdp_urbdrc_client_subsystem_entry(PFREERDP_URBDRC_SERVICE_ENTRY_POINTS 
 	udevman->next_device_id = BASE_USBDEVICE_NUM;
 	udevman->iface.plugin = pEntryPoints->plugin;
 	rc = libusb_init(&udevman->context);
-
+	
 	if (rc != LIBUSB_SUCCESS)
 		goto fail;
 


### PR DESCRIPTION
* fix libusb libusb_device usage (manually unref required usb devices, versus freeing all when we still hold references to the ones we want)
* disabled detach_kernel_driver & attach_kernel_driver on win32 since libusb does not support them
* fixed libusb async event handling

* add log for transfer request error

* Update libusb_udevice.c

* refactor code
