### PR TITLE
winpr: fix cache assertion before it's been created

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -372,13 +372,13 @@ static BOOL wf_post_connect(freerdp* instance)
 	wfc = (wfContext*)instance->context;
 	WINPR_ASSERT(wfc);
 
-	cache = instance->context->cache;
-	WINPR_ASSERT(cache);
-
 	wfc->primary = wf_image_new(wfc, settings->DesktopWidth, settings->DesktopHeight, format, NULL);
 
 	if (!gdi_init_ex(instance, format, 0, wfc->primary->pdata, NULL))
 		return FALSE;
+
+	cache = instance->context->cache;
+	WINPR_ASSERT(cache);
 
 	gdi = instance->context->gdi;
 


### PR DESCRIPTION
Cache assertion fails because the call below (gdi_init_ex) creates the cache. I just changed the order and put the assertion after gdi_init_ex has been called.
