### PR TITLE
proxy: correctly use the RemoteApp flag

### DIFF
--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -270,7 +270,6 @@ static BOOL pf_client_pre_connect(freerdp* instance)
 	                               config->DeviceRedirection) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_SupportDisplayControl,
 	                               config->DisplayControl) ||
-	    !freerdp_settings_set_bool(settings, FreeRDP_RemoteApplicationMode, config->RemoteApp) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_MultiTouchInput, config->Multitouch))
 		return FALSE;
 


### PR DESCRIPTION
The flag was forcing the remoteApp usage when set, while all the other equivalent flags just enable the feature. This patch fixes that, so now setting `RemoteApp = TRUE` just enables the front client to do remoteApps.

