### PR TITLE
cmake: add TEST_WINPR_BACKTRACE option

### DIFF
--- a/cmake/ConfigOptions.cmake
+++ b/cmake/ConfigOptions.cmake
@@ -64,6 +64,7 @@ endif()
 option(BUILD_TESTING "Build unit tests" OFF)
 CMAKE_DEPENDENT_OPTION(TESTS_WTSAPI_EXTRA "Build extra WTSAPI tests (interactive)" OFF "BUILD_TESTING" OFF)
 CMAKE_DEPENDENT_OPTION(BUILD_COMM_TESTS "Build comm related tests (require comm port)" OFF "BUILD_TESTING" OFF)
+CMAKE_DEPENDENT_OPTION(TEST_WINPR_BACKTRACE "Test winpr backtrace functions" ON "BUILD_TESTING" OFF)
 
 option(WITH_SAMPLE "Build sample code" OFF)
 

--- a/winpr/libwinpr/utils/test/CMakeLists.txt
+++ b/winpr/libwinpr/utils/test/CMakeLists.txt
@@ -9,7 +9,6 @@ set(${MODULE_PREFIX}_TESTS
 	TestVersion.c
 	TestImage.c
 	TestBipBuffer.c
-	TestBacktrace.c
 	TestQueue.c
 	TestPrint.c
 	TestPubSub.c
@@ -26,6 +25,12 @@ set(${MODULE_PREFIX}_TESTS
 	TestStreamPool.c
 	TestMessageQueue.c
 	TestMessagePipe.c)
+
+if (TEST_WINPR_BACKTRACE)
+	set(${MODULE_PREFIX}_TESTS
+		${${MODULE_PREFIX}_TESTS}
+		TestBacktrace.c)
+endif()
 
 create_test_sourcelist(${MODULE_PREFIX}_SRCS
 	${${MODULE_PREFIX}_DRIVER}


### PR DESCRIPTION
This allows TestBacktrace to be disabled when building on platforms that
are known to have no working winpr_backtrace implementation.

Fixes: https://github.com/FreeRDP/FreeRDP/issues/7773