### PR TITLE
Fix #7793: Do not expose internal input API

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_event.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_event.c
@@ -96,14 +96,15 @@ static BOOL android_process_event(ANDROID_EVENT_QUEUE* queue, freerdp* inst)
 		if (event->type == EVENT_TYPE_KEY)
 		{
 			ANDROID_EVENT_KEY* key_event = (ANDROID_EVENT_KEY*)event;
-			context->input->KeyboardEvent(context->input, key_event->flags, key_event->scancode);
+			freerdp_input_send_keyboard_event(context->input, key_event->flags,
+			                                  key_event->scancode);
 			android_event_free((ANDROID_EVENT*)key_event);
 		}
 		else if (event->type == EVENT_TYPE_KEY_UNICODE)
 		{
 			ANDROID_EVENT_KEY* key_event = (ANDROID_EVENT_KEY*)event;
-			context->input->UnicodeKeyboardEvent(context->input, key_event->flags,
-			                                     key_event->scancode);
+			freerdp_input_send_keyboard_event(context->input, key_event->flags,
+			                                  key_event->scancode);
 			android_event_free((ANDROID_EVENT*)key_event);
 		}
 		else if (event->type == EVENT_TYPE_CURSOR)

--- a/client/iOS/FreeRDP/ios_freerdp_events.m
+++ b/client/iOS/FreeRDP/ios_freerdp_events.m
@@ -61,11 +61,11 @@ static BOOL ios_events_handle_event(mfInfo *mfi, NSDictionary *event_description
 	else if ([event_type isEqualToString:@"keyboard"])
 	{
 		if ([[event_description objectForKey:@"subtype"] isEqualToString:@"scancode"])
-			instance->input->KeyboardEvent(
+			freerdp_input_send_keyboard_event(
 			    instance->input, [[event_description objectForKey:@"flags"] unsignedShortValue],
 			    [[event_description objectForKey:@"scancode"] unsignedShortValue]);
 		else if ([[event_description objectForKey:@"subtype"] isEqualToString:@"unicode"])
-			instance->input->UnicodeKeyboardEvent(
+			freerdp_input_send_unicode_keyboard_event(
 			    instance->input, [[event_description objectForKey:@"flags"] unsignedShortValue],
 			    [[event_description objectForKey:@"unicode_char"] unsignedShortValue]);
 		else

--- a/include/freerdp/input.h
+++ b/include/freerdp/input.h
@@ -65,7 +65,7 @@ typedef struct rdp_input_proxy rdpInputProxy;
 /* Input Interface */
 
 typedef BOOL (*pSynchronizeEvent)(rdpInput* input, UINT32 flags);
-typedef BOOL (*pKeyboardEvent)(rdpInput* input, UINT16 flags, UINT16 code);
+typedef BOOL (*pKeyboardEvent)(rdpInput* input, UINT16 flags, UINT8 code);
 typedef BOOL (*pUnicodeKeyboardEvent)(rdpInput* input, UINT16 flags, UINT16 code);
 typedef BOOL (*pMouseEvent)(rdpInput* input, UINT16 flags, UINT16 x, UINT16 y);
 typedef BOOL (*pExtendedMouseEvent)(rdpInput* input, UINT16 flags, UINT16 x, UINT16 y);
@@ -95,7 +95,7 @@ extern "C"
 #endif
 
 	FREERDP_API BOOL freerdp_input_send_synchronize_event(rdpInput* input, UINT32 flags);
-	FREERDP_API BOOL freerdp_input_send_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code);
+	FREERDP_API BOOL freerdp_input_send_keyboard_event(rdpInput* input, UINT16 flags, UINT8 code);
 	FREERDP_API BOOL freerdp_input_send_keyboard_event_ex(rdpInput* input, BOOL down,
 	                                                      UINT32 rdp_scancode);
 	FREERDP_API BOOL freerdp_input_send_keyboard_pause_event(rdpInput* input);

--- a/include/freerdp/server/shadow.h
+++ b/include/freerdp/server/shadow.h
@@ -75,7 +75,7 @@ typedef BOOL (*pfnShadowClientCapabilities)(rdpShadowSubsystem* subsystem, rdpSh
 typedef BOOL (*pfnShadowSynchronizeEvent)(rdpShadowSubsystem* subsystem, rdpShadowClient* client,
                                           UINT32 flags);
 typedef BOOL (*pfnShadowKeyboardEvent)(rdpShadowSubsystem* subsystem, rdpShadowClient* client,
-                                       UINT16 flags, UINT16 code);
+                                       UINT16 flags, UINT8 code);
 typedef BOOL (*pfnShadowUnicodeKeyboardEvent)(rdpShadowSubsystem* subsystem,
                                               rdpShadowClient* client, UINT16 flags, UINT16 code);
 typedef BOOL (*pfnShadowMouseEvent)(rdpShadowSubsystem* subsystem, rdpShadowClient* client,

--- a/libfreerdp/core/fastpath.c
+++ b/libfreerdp/core/fastpath.c
@@ -674,7 +674,7 @@ static BOOL fastpath_recv_input_event_scancode(rdpFastPath* fastpath, wStream* s
 {
 	rdpInput* input;
 	UINT16 flags;
-	UINT16 code;
+	UINT8 code;
 
 	if (!fastpath || !fastpath->rdp || !fastpath->rdp->input || !s)
 		return FALSE;

--- a/libfreerdp/core/input.c
+++ b/libfreerdp/core/input.c
@@ -497,6 +497,12 @@ static BOOL input_recv_keyboard_event(rdpInput* input, wStream* s)
 	else
 		keyboardFlags |= KBD_FLAGS_DOWN;
 
+	if (keyCode & 0xFF00)
+		WLog_WARN(TAG,
+		          "Problematic [MS-RDPBCGR] 2.2.8.1.1.3.1.1.1 Keyboard Event (TS_KEYBOARD_EVENT) "
+		          "keyCode=0x%04" PRIx16
+		          ", high byte values should be sent in keyboardFlags field, ignoring.",
+		          keyCode);
 	return IFCALLRESULT(TRUE, input->KeyboardEvent, input, keyboardFlags, keyCode & 0xFF);
 }
 

--- a/libfreerdp/core/message.c
+++ b/libfreerdp/core/message.c
@@ -2967,7 +2967,7 @@ static int input_message_process_input_class(rdpInputProxy* proxy, wMessage* msg
 
 		case Input_KeyboardEvent:
 			IFCALL(proxy->KeyboardEvent, msg->context, (UINT16)(size_t)msg->wParam,
-			       (UINT16)(size_t)msg->lParam);
+			       (UINT8)(size_t)msg->lParam);
 			break;
 
 		case Input_UnicodeKeyboardEvent:

--- a/server/Mac/mf_peer.c
+++ b/server/Mac/mf_peer.c
@@ -329,13 +329,11 @@ static BOOL mf_peer_synchronize_event(rdpInput* input, UINT32 flags)
 	return TRUE;
 }
 
-void mf_peer_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
+void mf_peer_keyboard_event(rdpInput* input, UINT16 flags, UINT8 code)
 {
-	UINT16 down = 0x4000;
-	// UINT16 up = 0x8000;
 	bool state_down = FALSE;
 
-	if (flags == down)
+	if (flags == KBD_FLAGS_DOWN)
 	{
 		state_down = TRUE;
 	}

--- a/server/Sample/sfreerdp.c
+++ b/server/Sample/sfreerdp.c
@@ -761,7 +761,7 @@ static BOOL tf_peer_synchronize_event(rdpInput* input, UINT32 flags)
 	return TRUE;
 }
 
-static BOOL tf_peer_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
+static BOOL tf_peer_keyboard_event(rdpInput* input, UINT16 flags, UINT8 code)
 {
 	freerdp_peer* client;
 	rdpUpdate* update;
@@ -786,10 +786,10 @@ static BOOL tf_peer_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
 	tcontext = (testPeerContext*)context;
 	WINPR_ASSERT(tcontext);
 
-	WLog_DBG(TAG, "Client sent a keyboard event (flags:0x%04" PRIX16 " code:0x%04" PRIX16 ")",
-	         flags, code);
+	WLog_DBG(TAG, "Client sent a keyboard event (flags:0x%04" PRIX16 " code:0x%04" PRIX8 ")", flags,
+	         code);
 
-	if ((flags & 0x4000) && code == 0x22) /* 'g' key */
+	if ((flags & KBD_FLAGS_DOWN) && (code == RDP_SCANCODE_KEY_G)) /* 'g' key */
 	{
 		if (settings->DesktopWidth != 800)
 		{
@@ -810,7 +810,7 @@ static BOOL tf_peer_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
 		update->DesktopResize(update->context);
 		tcontext->activated = FALSE;
 	}
-	else if ((flags & 0x4000) && code == RDP_SCANCODE_KEY_C) /* 'c' key */
+	else if ((flags & KBD_FLAGS_DOWN) && code == RDP_SCANCODE_KEY_C) /* 'c' key */
 	{
 		if (tcontext->debug_channel)
 		{
@@ -818,22 +818,22 @@ static BOOL tf_peer_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
 			WTSVirtualChannelWrite(tcontext->debug_channel, (PCHAR) "test2", 5, &written);
 		}
 	}
-	else if ((flags & 0x4000) && code == RDP_SCANCODE_KEY_X) /* 'x' key */
+	else if ((flags & KBD_FLAGS_DOWN) && code == RDP_SCANCODE_KEY_X) /* 'x' key */
 	{
 		WINPR_ASSERT(client->Close);
 		client->Close(client);
 	}
-	else if ((flags & 0x4000) && code == RDP_SCANCODE_KEY_R) /* 'r' key */
+	else if ((flags & KBD_FLAGS_DOWN) && code == RDP_SCANCODE_KEY_R) /* 'r' key */
 	{
 		tcontext->audin_open = !tcontext->audin_open;
 	}
 #if defined(CHANNEL_AINPUT_SERVER)
-	else if ((flags & 0x4000) && code == RDP_SCANCODE_KEY_I) /* 'i' key */
+	else if ((flags & KBD_FLAGS_DOWN) && code == RDP_SCANCODE_KEY_I) /* 'i' key */
 	{
 		tcontext->ainput_open = !tcontext->ainput_open;
 	}
 #endif
-	else if ((flags & 0x4000) && code == RDP_SCANCODE_KEY_S) /* 's' key */
+	else if ((flags & KBD_FLAGS_DOWN) && code == RDP_SCANCODE_KEY_S) /* 's' key */
 	{
 	}
 

--- a/server/Windows/wf_input.c
+++ b/server/Windows/wf_input.c
@@ -24,7 +24,7 @@
 #include "wf_input.h"
 #include "wf_info.h"
 
-BOOL wf_peer_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
+BOOL wf_peer_keyboard_event(rdpInput* input, UINT16 flags, UINT8 code)
 {
 	INPUT keyboard_event;
 	WINPR_UNUSED(input);
@@ -188,7 +188,7 @@ BOOL wf_peer_extended_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UINT1
 	return TRUE;
 }
 
-BOOL wf_peer_keyboard_event_dummy(rdpInput* input, UINT16 flags, UINT16 code)
+BOOL wf_peer_keyboard_event_dummy(rdpInput* input, UINT16 flags, UINT8 code)
 {
 	WINPR_UNUSED(input);
 	WINPR_UNUSED(flags);

--- a/server/Windows/wf_input.h
+++ b/server/Windows/wf_input.h
@@ -22,13 +22,13 @@
 
 #include "wf_interface.h"
 
-BOOL wf_peer_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code);
+BOOL wf_peer_keyboard_event(rdpInput* input, UINT16 flags, UINT8 code);
 BOOL wf_peer_unicode_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code);
 BOOL wf_peer_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UINT16 y);
 BOOL wf_peer_extended_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UINT16 y);
 
 // dummy versions
-BOOL wf_peer_keyboard_event_dummy(rdpInput* input, UINT16 flags, UINT16 code);
+BOOL wf_peer_keyboard_event_dummy(rdpInput* input, UINT16 flags, UINT8 code);
 BOOL wf_peer_unicode_keyboard_event_dummy(rdpInput* input, UINT16 flags, UINT16 code);
 BOOL wf_peer_mouse_event_dummy(rdpInput* input, UINT16 flags, UINT16 x, UINT16 y);
 BOOL wf_peer_extended_mouse_event_dummy(rdpInput* input, UINT16 flags, UINT16 x, UINT16 y);

--- a/server/proxy/pf_input.c
+++ b/server/proxy/pf_input.c
@@ -62,7 +62,7 @@ static BOOL pf_server_synchronize_event(rdpInput* input, UINT32 flags)
 	return TRUE;
 }
 
-static BOOL pf_server_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
+static BOOL pf_server_keyboard_event(rdpInput* input, UINT16 flags, UINT8 code)
 {
 	const proxyConfig* config;
 	proxyKeyboardEventInfo event;

--- a/server/shadow/Mac/mac_shadow.c
+++ b/server/shadow/Mac/mac_shadow.c
@@ -41,7 +41,7 @@ static BOOL mac_shadow_input_synchronize_event(rdpShadowSubsystem* subsystem,
 }
 
 static BOOL mac_shadow_input_keyboard_event(rdpShadowSubsystem* subsystem, rdpShadowClient* client,
-                                            UINT16 flags, UINT16 code)
+                                            UINT16 flags, UINT8 code)
 {
 	DWORD vkcode;
 	DWORD keycode;

--- a/server/shadow/Win/win_shadow.c
+++ b/server/shadow/Win/win_shadow.c
@@ -45,7 +45,7 @@ static BOOL win_shadow_input_synchronize_event(rdpShadowSubsystem* subsystem,
 }
 
 static BOOL win_shadow_input_keyboard_event(rdpShadowSubsystem* subsystem, rdpShadowClient* client,
-                                            UINT16 flags, UINT16 code)
+                                            UINT16 flags, UINT8 code)
 {
 	UINT rc;
 	INPUT event;

--- a/server/shadow/X11/x11_shadow.c
+++ b/server/shadow/X11/x11_shadow.c
@@ -206,7 +206,7 @@ static BOOL x11_shadow_input_synchronize_event(rdpShadowSubsystem* subsystem,
 }
 
 static BOOL x11_shadow_input_keyboard_event(rdpShadowSubsystem* subsystem, rdpShadowClient* client,
-                                            UINT16 flags, UINT16 code)
+                                            UINT16 flags, UINT8 code)
 {
 #ifdef WITH_XTEST
 	x11ShadowSubsystem* x11 = (x11ShadowSubsystem*)subsystem;

--- a/server/shadow/shadow_input.c
+++ b/server/shadow/shadow_input.c
@@ -31,7 +31,7 @@ static BOOL shadow_input_synchronize_event(rdpInput* input, UINT32 flags)
 	return IFCALLRESULT(TRUE, subsystem->SynchronizeEvent, subsystem, client, flags);
 }
 
-static BOOL shadow_input_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
+static BOOL shadow_input_keyboard_event(rdpInput* input, UINT16 flags, UINT8 code)
 {
 	rdpShadowClient* client = (rdpShadowClient*)input->context;
 	rdpShadowSubsystem* subsystem = client->server->subsystem;

--- a/winpr/libwinpr/comm/comm.c
+++ b/winpr/libwinpr/comm/comm.c
@@ -1177,7 +1177,8 @@ static HANDLE_OPS ops = { CommIsHandled, CommCloseHandle,
 	                      NULL,          NULL,
 	                      NULL,          NULL,
 	                      NULL,          NULL,
-	                      NULL,          NULL };
+	                      NULL,          NULL,
+	                      NULL };
 
 /**
  * http://msdn.microsoft.com/en-us/library/windows/desktop/aa363198%28v=vs.85%29.aspx

--- a/winpr/libwinpr/handle/nonehandle.c
+++ b/winpr/libwinpr/handle/nonehandle.c
@@ -73,6 +73,7 @@ static HANDLE_OPS ops = { NoneHandleIsHandle,
 	                      NULL,
 	                      NULL,
 	                      NULL,
+	                      NULL,
 	                      NULL };
 
 HANDLE CreateNoneHandle()

--- a/winpr/libwinpr/input/keycode.c
+++ b/winpr/libwinpr/input/keycode.c
@@ -598,7 +598,7 @@ DWORD GetVirtualKeyCodeFromKeycode(DWORD keycode, DWORD dwFlags)
 
 DWORD GetKeycodeFromVirtualKeyCode(DWORD vkcode, DWORD dwFlags)
 {
-	int index;
+	DWORD index;
 	DWORD keycode = 0;
 
 	if (dwFlags & KEYCODE_TYPE_APPLE)

--- a/winpr/libwinpr/input/scancode.c
+++ b/winpr/libwinpr/input/scancode.c
@@ -133,7 +133,7 @@ DWORD GetVirtualKeyCodeFromVirtualScanCode(DWORD scancode, DWORD dwKeyboardType)
 
 DWORD GetVirtualScanCodeFromVirtualKeyCode(DWORD vkcode, DWORD dwKeyboardType)
 {
-	size_t i;
+	DWORD i;
 	DWORD scancode;
 	DWORD codeIndex;
 

--- a/winpr/libwinpr/pipe/pipe.c
+++ b/winpr/libwinpr/pipe/pipe.c
@@ -184,24 +184,28 @@ static BOOL PipeWrite(PVOID Object, LPCVOID lpBuffer, DWORD nNumberOfBytesToWrit
 	return TRUE;
 }
 
-static HANDLE_OPS ops = {
-	PipeIsHandled, PipeCloseHandle,
-	PipeGetFd,     NULL, /* CleanupHandle */
-	PipeRead,      NULL, /* FileReadEx */
-	NULL,                /* FileReadScatter */
-	PipeWrite,     NULL, /* FileWriteEx */
-	NULL,                /* FileWriteGather */
-	NULL,                /* FileGetFileSize */
-	NULL,                /*  FlushFileBuffers */
-	NULL,                /* FileSetEndOfFile */
-	NULL,                /* FileSetFilePointer */
-	NULL,                /* SetFilePointerEx */
-	NULL,                /* FileLockFile */
-	NULL,                /* FileLockFileEx */
-	NULL,                /* FileUnlockFile */
-	NULL,                /* FileUnlockFileEx */
-	NULL                 /* SetFileTime */
-};
+static HANDLE_OPS ops = { PipeIsHandled,
+	                      PipeCloseHandle,
+	                      PipeGetFd,
+	                      NULL, /* CleanupHandle */
+	                      PipeRead,
+	                      NULL, /* FileReadEx */
+	                      NULL, /* FileReadScatter */
+	                      PipeWrite,
+	                      NULL, /* FileWriteEx */
+	                      NULL, /* FileWriteGather */
+	                      NULL, /* FileGetFileSize */
+	                      NULL, /*  FlushFileBuffers */
+	                      NULL, /* FileSetEndOfFile */
+	                      NULL, /* FileSetFilePointer */
+	                      NULL, /* SetFilePointerEx */
+	                      NULL, /* FileLockFile */
+	                      NULL, /* FileLockFileEx */
+	                      NULL, /* FileUnlockFile */
+	                      NULL, /* FileUnlockFileEx */
+	                      NULL  /* SetFileTime */
+	                      ,
+	                      NULL };
 
 static BOOL NamedPipeIsHandled(HANDLE handle)
 {
@@ -446,6 +450,7 @@ static HANDLE_OPS namedOps = { NamedPipeIsHandled,
 	                           NULL,
 	                           NULL,
 	                           NamedPipeWrite,
+	                           NULL,
 	                           NULL,
 	                           NULL,
 	                           NULL,

--- a/winpr/libwinpr/sspicli/sspicli.c
+++ b/winpr/libwinpr/sspicli/sspicli.c
@@ -133,6 +133,7 @@ static HANDLE_OPS ops = { LogonUserIsHandled,
 	                      NULL,
 	                      NULL,
 	                      NULL,
+	                      NULL,
 	                      NULL };
 
 BOOL LogonUserA(LPCSTR lpszUsername, LPCSTR lpszDomain, LPCSTR lpszPassword, DWORD dwLogonType,

--- a/winpr/libwinpr/synch/event.c
+++ b/winpr/libwinpr/synch/event.c
@@ -245,16 +245,27 @@ static BOOL EventCloseHandle(HANDLE handle)
 	return EventCloseHandle_(event);
 }
 
-static HANDLE_OPS ops = { EventIsHandled, EventCloseHandle,
-	                      EventGetFd,     NULL, /* CleanupHandle */
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL };
+static HANDLE_OPS ops = { EventIsHandled,
+	                      EventCloseHandle,
+	                      EventGetFd,
+	                      NULL, /* CleanupHandle */
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL };
 
 HANDLE CreateEventW(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL bManualReset, BOOL bInitialState,
                     LPCWSTR lpName)

--- a/winpr/libwinpr/synch/mutex.c
+++ b/winpr/libwinpr/synch/mutex.c
@@ -103,16 +103,27 @@ BOOL MutexCloseHandle(HANDLE handle)
 	return TRUE;
 }
 
-static HANDLE_OPS ops = { MutexIsHandled, MutexCloseHandle,
-	                      MutexGetFd,     NULL, /* CleanupHandle */
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL };
+static HANDLE_OPS ops = { MutexIsHandled,
+	                      MutexCloseHandle,
+	                      MutexGetFd,
+	                      NULL, /* CleanupHandle */
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL };
 
 HANDLE CreateMutexW(LPSECURITY_ATTRIBUTES lpMutexAttributes, BOOL bInitialOwner, LPCWSTR lpName)
 {

--- a/winpr/libwinpr/synch/semaphore.c
+++ b/winpr/libwinpr/synch/semaphore.c
@@ -129,6 +129,7 @@ static HANDLE_OPS ops = { SemaphoreIsHandled,
 	                      NULL,
 	                      NULL,
 	                      NULL,
+	                      NULL,
 	                      NULL };
 
 HANDLE CreateSemaphoreW(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lInitialCount,

--- a/winpr/libwinpr/synch/timer.c
+++ b/winpr/libwinpr/synch/timer.c
@@ -300,16 +300,27 @@ static BOOL timer_drain_fd(int fd)
 	return ret >= 0;
 }
 
-static HANDLE_OPS ops = { TimerIsHandled, TimerCloseHandle,
-	                      TimerGetFd,     TimerCleanupHandle,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL,
-	                      NULL,           NULL };
+static HANDLE_OPS ops = { TimerIsHandled,
+	                      TimerCloseHandle,
+	                      TimerGetFd,
+	                      TimerCleanupHandle,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL,
+	                      NULL };
 
 /**
  * Waitable Timer

--- a/winpr/libwinpr/thread/process.c
+++ b/winpr/libwinpr/thread/process.c
@@ -526,6 +526,7 @@ static HANDLE_OPS ops = { ProcessHandleIsHandle,
 	                      NULL,
 	                      NULL,
 	                      NULL,
+	                      NULL,
 	                      NULL };
 
 HANDLE CreateProcessHandle(pid_t pid)

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -177,6 +177,7 @@ static HANDLE_OPS ops = { ThreadIsHandled,
 	                      NULL,
 	                      NULL,
 	                      NULL,
+	                      NULL,
 	                      NULL };
 
 static void dump_thread(WINPR_THREAD* thread)


### PR DESCRIPTION
Slow-Path input uses UINT16 for scancodes on wire, but only the
lower byte is actually used. (the extended fields are sent in
keyboardFlags field)
Hide this implementation detail and adjust the API to use UINT8
for the code instead just like the corresponding Fast-Path PDU