### PR TITLE
fix x11 black RAIL window when connect to server 2019

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1436,7 +1436,10 @@ static int xf_logon_error_info(freerdp* instance, UINT32 data, UINT32 type)
 	const char* str_data = freerdp_get_logon_error_info_data(data);
 	const char* str_type = freerdp_get_logon_error_info_type(type);
 	WLog_INFO(TAG, "Logon Error Info %s [%s]", str_data, str_type);
-	xf_rail_disable_remoteapp_mode(xfc);
+	if(type != LOGON_MSG_SESSION_CONTINUE)
+	{
+	    xf_rail_disable_remoteapp_mode(xfc);
+	}
 	return 1;
 }
 


### PR DESCRIPTION
problem: xfreerdp  connect server 2019 app, sometimes get a black window.
root cause:  the log print "Error Info SESSION_ID [LOGON_MSG_SESSION_CONTINUE]",  when the app window created later, the paint event is suppressed, so the window is black. but LOGON_MSG_SESSION_CONTINUE is normal state, we should not disable app mode at this time.
