### PR TITLE
Winpr handle def remove

### DIFF
--- a/libfreerdp/core/tscredentials.c
+++ b/libfreerdp/core/tscredentials.c
@@ -1,6 +1,6 @@
 /* ============================================================================================================
  * this file has been generated using
- * tools/asn_parser_generator.py --input=libfreerdp/core/credssp.asn1 --output-kind=impls
+ * ./tools/asn_parser_generator.py --input=libfreerdp/core/credssp.asn1 --output-kind=impls
  * --output=libfreerdp/core/tscredentials.c
  *
  * /!\ If you want to modify this file you'd probably better change asn_parser_generator.py or the
@@ -844,7 +844,9 @@ BOOL ber_read_nla_TSRemoteGuardPackageCred_array(wStream* s, TSRemoteGuardPackag
 			free(retItems);
 			return FALSE;
 		}
+		retItems = tmpRet;
 
+		retItems = tmpRet;
 		memcpy(&retItems[ret], item, sizeof(*item));
 		free(item);
 		ret++;

--- a/libfreerdp/core/tscredentials.h
+++ b/libfreerdp/core/tscredentials.h
@@ -1,9 +1,10 @@
 /* ============================================================================================================
  * this file has been generated using
- * tools/asn_parser_generator.py --input=libfreerdp/core/credssp.asn1 --output-kind=headers --output=libfreerdp/core/tscredentials.h
+ * ./tools/asn_parser_generator.py --input=libfreerdp/core/credssp.asn1 --output-kind=headers
+ * --output=libfreerdp/core/tscredentials.h
  *
- * /!\ If you want to modify this file you'd probably better change asn_parser_generator.py or the corresponding ASN1 
- *     definition file
+ * /!\ If you want to modify this file you'd probably better change asn_parser_generator.py or the
+ * corresponding ASN1 definition file
  *
  * ============================================================================================================
  */

--- a/tools/asn_parser_generator.py
+++ b/tools/asn_parser_generator.py
@@ -520,6 +520,7 @@ BOOL ber_read_{prefix}{defName}_array(wStream* s, {defName}_t** pitems, size_t* 
             free(retItems);
             return FALSE;
         }}
+        retItems = tmpRet;
 
         memcpy(&retItems[ret], item, sizeof(*item));
         free(item);

--- a/winpr/libwinpr/comm/comm.h
+++ b/winpr/libwinpr/comm/comm.h
@@ -33,7 +33,7 @@
 
 struct winpr_comm
 {
-	WINPR_HANDLE_DEF();
+	WINPR_HANDLE common;
 
 	int fd;
 
@@ -97,6 +97,7 @@ typedef struct winpr_comm WINPR_COMM;
 void CommLog_Print(DWORD wlog_level, ...);
 
 BOOL CommIsHandled(HANDLE handle);
+BOOL CommIsHandleValid(HANDLE handle);
 BOOL CommCloseHandle(HANDLE handle);
 HANDLE_CREATOR* GetCommHandleCreator(void);
 

--- a/winpr/libwinpr/comm/comm_io.c
+++ b/winpr/libwinpr/comm/comm_io.c
@@ -36,17 +36,8 @@ BOOL _comm_set_permissive(HANDLE hDevice, BOOL permissive)
 {
 	WINPR_COMM* pComm = (WINPR_COMM*)hDevice;
 
-	if (hDevice == INVALID_HANDLE_VALUE)
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
+	if (!CommIsHandled(hDevice))
 		return FALSE;
-	}
-
-	if (!pComm || pComm->Type != HANDLE_TYPE_COMM)
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
-		return FALSE;
-	}
 
 	pComm->permissive = permissive;
 	return TRUE;
@@ -91,17 +82,8 @@ BOOL CommReadFile(HANDLE hDevice, LPVOID lpBuffer, DWORD nNumberOfBytesToRead,
 	struct termios currentTermios;
 	EnterCriticalSection(&pComm->ReadLock); /* KISSer by the function's beginning */
 
-	if (hDevice == INVALID_HANDLE_VALUE)
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
+	if (!CommIsHandled(hDevice))
 		goto return_false;
-	}
-
-	if (!pComm || pComm->Type != HANDLE_TYPE_COMM)
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
-		goto return_false;
-	}
 
 	if (lpOverlapped != NULL)
 	{
@@ -383,17 +365,8 @@ BOOL CommWriteFile(HANDLE hDevice, LPCVOID lpBuffer, DWORD nNumberOfBytesToWrite
 	struct timeval tmaxTimeout, *pTmaxTimeout;
 	EnterCriticalSection(&pComm->WriteLock); /* KISSer by the function's beginning */
 
-	if (hDevice == INVALID_HANDLE_VALUE)
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
+	if (!CommIsHandled(hDevice))
 		goto return_false;
-	}
-
-	if (!pComm || pComm->Type != HANDLE_TYPE_COMM)
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
-		goto return_false;
-	}
 
 	if (lpOverlapped != NULL)
 	{

--- a/winpr/libwinpr/comm/comm_ioctl.c
+++ b/winpr/libwinpr/comm/comm_ioctl.c
@@ -66,24 +66,15 @@ const char* _comm_serial_ioctl_name(ULONG number)
 	return "(unknown ioctl name)";
 }
 
-static BOOL _CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID lpInBuffer,
-                                 DWORD nInBufferSize, LPVOID lpOutBuffer, DWORD nOutBufferSize,
-                                 LPDWORD lpBytesReturned, LPOVERLAPPED lpOverlapped)
+static BOOL s_CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID lpInBuffer,
+                                  DWORD nInBufferSize, LPVOID lpOutBuffer, DWORD nOutBufferSize,
+                                  LPDWORD lpBytesReturned, LPOVERLAPPED lpOverlapped)
 {
 	WINPR_COMM* pComm = (WINPR_COMM*)hDevice;
 	SERIAL_DRIVER* pServerSerialDriver = NULL;
 
-	if (hDevice == INVALID_HANDLE_VALUE)
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
+	if (!CommIsHandleValid(hDevice))
 		return FALSE;
-	}
-
-	if (!pComm || pComm->Type != HANDLE_TYPE_COMM || !pComm->fd)
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
-		return FALSE;
-	}
 
 	if (lpOverlapped)
 	{
@@ -656,14 +647,17 @@ BOOL CommDeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID lpInBuffe
 		return FALSE;
 	}
 
-	if (!pComm || pComm->Type != HANDLE_TYPE_COMM || !pComm->fd)
+	if (!CommIsHandled(hDevice))
+		return FALSE;
+
+	if (!pComm->fd)
 	{
 		SetLastError(ERROR_INVALID_HANDLE);
 		return FALSE;
 	}
 
-	result = _CommDeviceIoControl(hDevice, dwIoControlCode, lpInBuffer, nInBufferSize, lpOutBuffer,
-	                              nOutBufferSize, lpBytesReturned, lpOverlapped);
+	result = s_CommDeviceIoControl(hDevice, dwIoControlCode, lpInBuffer, nInBufferSize, lpOutBuffer,
+	                               nOutBufferSize, lpBytesReturned, lpOverlapped);
 
 	if (lpBytesReturned && *lpBytesReturned != nOutBufferSize)
 	{

--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -61,15 +61,7 @@
 
 static BOOL FileIsHandled(HANDLE handle)
 {
-	WINPR_FILE* pFile = (WINPR_FILE*)handle;
-
-	if (!pFile || (pFile->Type != HANDLE_TYPE_FILE))
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
-		return FALSE;
-	}
-
-	return TRUE;
+	return WINPR_HANDLE_IS_HANDLED(handle, HANDLE_TYPE_FILE, FALSE);
 }
 
 static int FileGetFd(HANDLE handle)
@@ -809,7 +801,7 @@ static HANDLE FileCreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dw
 	}
 
 	WINPR_HANDLE_SET_TYPE_AND_MODE(pFile, HANDLE_TYPE_FILE, WINPR_FD_READ);
-	pFile->ops = &fileOps;
+	pFile->common.ops = &fileOps;
 
 	pFile->lpFileName = _strdup(lpFileName);
 	if (!pFile->lpFileName)
@@ -951,7 +943,7 @@ HANDLE_CREATOR* GetFileHandleCreator(void)
 static WINPR_FILE* FileHandle_New(FILE* fp)
 {
 	WINPR_FILE* pFile;
-	char name[MAX_PATH];
+	char name[MAX_PATH] = { 0 };
 
 	_snprintf(name, sizeof(name), "device_%d", fileno(fp));
 	pFile = (WINPR_FILE*)calloc(1, sizeof(WINPR_FILE));
@@ -961,7 +953,7 @@ static WINPR_FILE* FileHandle_New(FILE* fp)
 		return NULL;
 	}
 	pFile->fp = fp;
-	pFile->ops = &shmOps;
+	pFile->common.ops = &shmOps;
 	pFile->lpFileName = _strdup(name);
 
 	WINPR_HANDLE_SET_TYPE_AND_MODE(pFile, HANDLE_TYPE_FILE, WINPR_FD_READ);

--- a/winpr/libwinpr/file/file.h
+++ b/winpr/libwinpr/file/file.h
@@ -39,7 +39,7 @@
 
 struct winpr_file
 {
-	WINPR_HANDLE_DEF();
+	WINPR_HANDLE common;
 
 	FILE* fp;
 

--- a/winpr/libwinpr/file/namedPipeClient.c
+++ b/winpr/libwinpr/file/namedPipeClient.c
@@ -48,15 +48,7 @@ static HANDLE_CREATOR _NamedPipeClientHandleCreator;
 
 static BOOL NamedPipeClientIsHandled(HANDLE handle)
 {
-	WINPR_NAMED_PIPE* pFile = (WINPR_NAMED_PIPE*)handle;
-
-	if (!pFile || (pFile->Type != HANDLE_TYPE_NAMED_PIPE) || (pFile == INVALID_HANDLE_VALUE))
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
-		return FALSE;
-	}
-
-	return TRUE;
+	return WINPR_HANDLE_IS_HANDLED(handle, HANDLE_TYPE_NAMED_PIPE, TRUE);
 }
 
 static BOOL NamedPipeClientCloseHandle(HANDLE handle)
@@ -208,7 +200,7 @@ static HANDLE NamedPipeClientCreateFileA(LPCSTR lpFileName, DWORD dwDesiredAcces
 	s.sun_family = AF_UNIX;
 	sprintf_s(s.sun_path, ARRAYSIZE(s.sun_path), "%s", pNamedPipe->lpFilePath);
 	status = connect(pNamedPipe->clientfd, (struct sockaddr*)&s, sizeof(struct sockaddr_un));
-	pNamedPipe->ops = &ops;
+	pNamedPipe->common.ops = &ops;
 
 	if (status != 0)
 	{
@@ -301,10 +293,9 @@ int GetNamePipeFileDescriptor(HANDLE hNamedPipe)
 {
 #ifndef _WIN32
 	int fd;
-	WINPR_NAMED_PIPE* pNamedPipe;
-	pNamedPipe = (WINPR_NAMED_PIPE*)hNamedPipe;
+	WINPR_NAMED_PIPE* pNamedPipe = (WINPR_NAMED_PIPE*)hNamedPipe;
 
-	if (!pNamedPipe || pNamedPipe->Type != HANDLE_TYPE_NAMED_PIPE)
+	if (!NamedPipeClientIsHandled(hNamedPipe))
 		return -1;
 
 	fd = (pNamedPipe->ServerMode) ? pNamedPipe->serverfd : pNamedPipe->clientfd;

--- a/winpr/libwinpr/handle/nonehandle.c
+++ b/winpr/libwinpr/handle/nonehandle.c
@@ -35,15 +35,7 @@ static BOOL NoneHandleCloseHandle(HANDLE handle)
 
 static BOOL NoneHandleIsHandle(HANDLE handle)
 {
-	WINPR_NONE_HANDLE* none = (WINPR_NONE_HANDLE*)handle;
-
-	if (!none || none->Type != HANDLE_TYPE_NONE)
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
-		return FALSE;
-	}
-
-	return TRUE;
+	return WINPR_HANDLE_IS_HANDLED(handle, HANDLE_TYPE_NONE, FALSE);
 }
 
 static int NoneHandleGetFd(HANDLE handle)
@@ -76,15 +68,14 @@ static HANDLE_OPS ops = { NoneHandleIsHandle,
 	                      NULL,
 	                      NULL };
 
-HANDLE CreateNoneHandle()
+HANDLE CreateNoneHandle(void)
 {
-	WINPR_NONE_HANDLE* none;
-	none = (WINPR_NONE_HANDLE*)calloc(1, sizeof(WINPR_NONE_HANDLE));
+	WINPR_NONE_HANDLE* none = (WINPR_NONE_HANDLE*)calloc(1, sizeof(WINPR_NONE_HANDLE));
 
 	if (!none)
 		return NULL;
 
-	none->ops = &ops;
+	none->common.ops = &ops;
 	return (HANDLE)none;
 }
 

--- a/winpr/libwinpr/handle/nonehandle.h
+++ b/winpr/libwinpr/handle/nonehandle.h
@@ -28,7 +28,7 @@
 
 struct winpr_none_handle
 {
-	WINPR_HANDLE_DEF();
+	WINPR_HANDLE common;
 };
 
 typedef struct winpr_none_handle WINPR_NONE_HANDLE;

--- a/winpr/libwinpr/nt/nt.c
+++ b/winpr/libwinpr/nt/nt.c
@@ -66,7 +66,7 @@ VOID _InitializeObjectAttributes(POBJECT_ATTRIBUTES InitializedAttributes,
 
 struct winpr_nt_file
 {
-	WINPR_HANDLE_DEF();
+	WINPR_HANDLE common;
 
 	ACCESS_MASK DesiredAccess;
 	OBJECT_ATTRIBUTES ObjectAttributes;

--- a/winpr/libwinpr/pipe/pipe.h
+++ b/winpr/libwinpr/pipe/pipe.h
@@ -29,7 +29,7 @@
 
 struct winpr_pipe
 {
-	WINPR_HANDLE_DEF();
+	WINPR_HANDLE common;
 
 	int fd;
 };
@@ -41,7 +41,7 @@ typedef void (*fnUnrefNamedPipe)(WINPR_NAMED_PIPE* pNamedPipe);
 
 struct winpr_named_pipe
 {
-	WINPR_HANDLE_DEF();
+	WINPR_HANDLE common;
 
 	int clientfd;
 	int serverfd;

--- a/winpr/libwinpr/security/security.c
+++ b/winpr/libwinpr/security/security.c
@@ -27,6 +27,8 @@
 
 #include <winpr/security.h>
 
+#include "../handle/handle.h"
+
 /**
  * api-ms-win-security-base-l1-2-0.dll:
  *
@@ -210,3 +212,15 @@ BOOL SetSecurityDescriptorSacl(PSECURITY_DESCRIPTOR pSecurityDescriptor, BOOL bS
 }
 
 #endif
+
+BOOL AccessTokenIsValid(HANDLE handle)
+{
+	WINPR_HANDLE* h = (WINPR_HANDLE*)handle;
+
+	if (!h || (h->Type != HANDLE_TYPE_ACCESS_TOKEN))
+	{
+		SetLastError(ERROR_INVALID_PARAMETER);
+		return FALSE;
+	}
+	return TRUE;
+}

--- a/winpr/libwinpr/security/security.h
+++ b/winpr/libwinpr/security/security.h
@@ -28,7 +28,7 @@
 
 struct winpr_access_token
 {
-	WINPR_HANDLE_DEF();
+	WINPR_HANDLE common;
 
 	LPSTR Username;
 	LPSTR Domain;
@@ -37,6 +37,8 @@ struct winpr_access_token
 	DWORD GroupId;
 };
 typedef struct winpr_access_token WINPR_ACCESS_TOKEN;
+
+BOOL AccessTokenIsValid(HANDLE handle);
 
 #endif
 

--- a/winpr/libwinpr/shell/shell.c
+++ b/winpr/libwinpr/shell/shell.c
@@ -54,7 +54,10 @@ BOOL GetUserProfileDirectoryA(HANDLE hToken, LPSTR lpProfileDir, LPDWORD lpcchSi
 	WINPR_ACCESS_TOKEN* token;
 	token = (WINPR_ACCESS_TOKEN*)hToken;
 
-	if (!token || (token->Type != HANDLE_TYPE_ACCESS_TOKEN) || !lpcchSize)
+	if (!AccessTokenIsValid(hToken))
+		return FALSE;
+
+	if (!lpcchSize)
 	{
 		SetLastError(ERROR_INVALID_PARAMETER);
 		return FALSE;

--- a/winpr/libwinpr/sspicli/sspicli.c
+++ b/winpr/libwinpr/sspicli/sspicli.c
@@ -78,15 +78,7 @@ static BOOL LogonUserCloseHandle(HANDLE handle);
 
 static BOOL LogonUserIsHandled(HANDLE handle)
 {
-	WINPR_ACCESS_TOKEN* pLogonUser = (WINPR_ACCESS_TOKEN*)handle;
-
-	if (!pLogonUser || (pLogonUser->Type != HANDLE_TYPE_ACCESS_TOKEN))
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
-		return FALSE;
-	}
-
-	return TRUE;
+	return WINPR_HANDLE_IS_HANDLED(handle, HANDLE_TYPE_ACCESS_TOKEN, FALSE);
 }
 
 static int LogonUserGetFd(HANDLE handle)
@@ -151,7 +143,7 @@ BOOL LogonUserA(LPCSTR lpszUsername, LPCSTR lpszDomain, LPCSTR lpszPassword, DWO
 		return FALSE;
 
 	WINPR_HANDLE_SET_TYPE_AND_MODE(token, HANDLE_TYPE_ACCESS_TOKEN, WINPR_FD_READ);
-	token->ops = &ops;
+	token->common.ops = &ops;
 	token->Username = _strdup(lpszUsername);
 
 	if (!token->Username)

--- a/winpr/libwinpr/synch/event.c
+++ b/winpr/libwinpr/synch/event.c
@@ -183,15 +183,7 @@ static BOOL EventCloseHandle(HANDLE handle);
 
 static BOOL EventIsHandled(HANDLE handle)
 {
-	WINPR_TIMER* pEvent = (WINPR_TIMER*)handle;
-
-	if (!pEvent || (pEvent->Type != HANDLE_TYPE_EVENT))
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
-		return FALSE;
-	}
-
-	return TRUE;
+	return WINPR_HANDLE_IS_HANDLED(handle, HANDLE_TYPE_EVENT, FALSE);
 }
 
 static int EventGetFd(HANDLE handle)
@@ -304,7 +296,7 @@ HANDLE CreateEventA(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL bManualReset, 
 	event->impl.fds[1] = -1;
 	event->bAttached = FALSE;
 	event->bManualReset = bManualReset;
-	event->ops = &ops;
+	event->common.ops = &ops;
 	WINPR_HANDLE_SET_TYPE_AND_MODE(event, HANDLE_TYPE_EVENT, FD_READ);
 
 	if (!event->bManualReset)
@@ -440,7 +432,7 @@ HANDLE CreateFileDescriptorEventW(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL 
 		event->bAttached = TRUE;
 		event->bManualReset = bManualReset;
 		winpr_event_init_from_fd(&event->impl, FileDescriptor);
-		event->ops = &ops;
+		event->common.ops = &ops;
 		WINPR_HANDLE_SET_TYPE_AND_MODE(event, HANDLE_TYPE_EVENT, mode);
 		handle = (HANDLE)event;
 	}
@@ -510,7 +502,7 @@ int SetEventFileDescriptor(HANDLE hEvent, int FileDescriptor, ULONG mode)
 		close(event->impl.fds[0]);
 
 	event->bAttached = TRUE;
-	event->Mode = mode;
+	event->common.Mode = mode;
 	event->impl.fds[0] = FileDescriptor;
 	return 0;
 #else

--- a/winpr/libwinpr/synch/event.h
+++ b/winpr/libwinpr/synch/event.h
@@ -36,7 +36,7 @@ typedef struct winpr_event_impl WINPR_EVENT_IMPL;
 
 struct winpr_event
 {
-	WINPR_HANDLE_DEF();
+	WINPR_HANDLE common;
 
 	WINPR_EVENT_IMPL impl;
 	BOOL bAttached;

--- a/winpr/libwinpr/synch/mutex.c
+++ b/winpr/libwinpr/synch/mutex.c
@@ -39,15 +39,7 @@ static BOOL MutexCloseHandle(HANDLE handle);
 
 static BOOL MutexIsHandled(HANDLE handle)
 {
-	WINPR_TIMER* pMutex = (WINPR_TIMER*)handle;
-
-	if (!pMutex || (pMutex->Type != HANDLE_TYPE_MUTEX))
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
-		return FALSE;
-	}
-
-	return TRUE;
+	return WINPR_HANDLE_IS_HANDLED(handle, HANDLE_TYPE_MUTEX, FALSE);
 }
 
 static int MutexGetFd(HANDLE handle)
@@ -159,7 +151,7 @@ HANDLE CreateMutexA(LPSECURITY_ATTRIBUTES lpMutexAttributes, BOOL bInitialOwner,
 		pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
 		pthread_mutex_init(&mutex->mutex, &attr);
 		WINPR_HANDLE_SET_TYPE_AND_MODE(mutex, HANDLE_TYPE_MUTEX, WINPR_FD_READ);
-		mutex->ops = &ops;
+		mutex->common.ops = &ops;
 		handle = (HANDLE)mutex;
 
 		if (bInitialOwner)

--- a/winpr/libwinpr/synch/semaphore.c
+++ b/winpr/libwinpr/synch/semaphore.c
@@ -38,15 +38,7 @@ static BOOL SemaphoreCloseHandle(HANDLE handle);
 
 static BOOL SemaphoreIsHandled(HANDLE handle)
 {
-	WINPR_TIMER* pSemaphore = (WINPR_TIMER*)handle;
-
-	if (!pSemaphore || (pSemaphore->Type != HANDLE_TYPE_SEMAPHORE))
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
-		return FALSE;
-	}
-
-	return TRUE;
+	return WINPR_HANDLE_IS_HANDLED(handle, HANDLE_TYPE_SEMAPHORE, FALSE);
 }
 
 static int SemaphoreGetFd(HANDLE handle)
@@ -145,7 +137,7 @@ HANDLE CreateSemaphoreW(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lIniti
 	semaphore->pipe_fd[0] = -1;
 	semaphore->pipe_fd[1] = -1;
 	semaphore->sem = (winpr_sem_t*)NULL;
-	semaphore->ops = &ops;
+	semaphore->common.ops = &ops;
 #ifdef WINPR_PIPE_SEMAPHORE
 
 	if (pipe(semaphore->pipe_fd) < 0)

--- a/winpr/libwinpr/synch/synch.h
+++ b/winpr/libwinpr/synch/synch.h
@@ -50,7 +50,7 @@
 
 struct winpr_mutex
 {
-	WINPR_HANDLE_DEF();
+	WINPR_HANDLE common;
 	char* name;
 	pthread_mutex_t mutex;
 };
@@ -58,7 +58,7 @@ typedef struct winpr_mutex WINPR_MUTEX;
 
 struct winpr_semaphore
 {
-	WINPR_HANDLE_DEF();
+	WINPR_HANDLE common;
 
 	int pipe_fd[2];
 	winpr_sem_t* sem;
@@ -85,7 +85,7 @@ typedef struct winpr_semaphore WINPR_SEMAPHORE;
 
 struct winpr_timer
 {
-	WINPR_HANDLE_DEF();
+	WINPR_HANDLE common;
 
 	int fd;
 	BOOL bInit;
@@ -120,7 +120,7 @@ typedef struct winpr_timer_queue_timer WINPR_TIMER_QUEUE_TIMER;
 
 struct winpr_timer_queue
 {
-	WINPR_HANDLE_DEF();
+	WINPR_HANDLE common;
 
 	pthread_t thread;
 	pthread_attr_t attr;
@@ -137,7 +137,7 @@ typedef struct winpr_timer_queue WINPR_TIMER_QUEUE;
 
 struct winpr_timer_queue_timer
 {
-	WINPR_HANDLE_DEF();
+	WINPR_HANDLE common;
 
 	ULONG Flags;
 	DWORD DueTime;

--- a/winpr/libwinpr/synch/timer.c
+++ b/winpr/libwinpr/synch/timer.c
@@ -49,15 +49,7 @@ static BOOL TimerCloseHandle(HANDLE handle);
 
 static BOOL TimerIsHandled(HANDLE handle)
 {
-	WINPR_TIMER* pTimer = (WINPR_TIMER*)handle;
-
-	if (!pTimer || (pTimer->Type != HANDLE_TYPE_TIMER))
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
-		return FALSE;
-	}
-
-	return TRUE;
+	return WINPR_HANDLE_IS_HANDLED(handle, HANDLE_TYPE_TIMER, FALSE);
 }
 
 static int TimerGetFd(HANDLE handle)
@@ -351,7 +343,7 @@ HANDLE CreateWaitableTimerA(LPSECURITY_ATTRIBUTES lpTimerAttributes, BOOL bManua
 		if (lpTimerName)
 			timer->name = strdup(lpTimerName);
 
-		timer->ops = &ops;
+		timer->common.ops = &ops;
 #if defined(TIMER_IMPL_DISPATCH) || defined(TIMER_IMPL_POSIX)
 		if (!winpr_event_init(&timer->event))
 			goto fail;

--- a/winpr/libwinpr/thread/process.c
+++ b/winpr/libwinpr/thread/process.c
@@ -484,15 +484,7 @@ static BOOL ProcessHandleCloseHandle(HANDLE handle)
 
 static BOOL ProcessHandleIsHandle(HANDLE handle)
 {
-	WINPR_PROCESS* process = (WINPR_PROCESS*)handle;
-
-	if (!process || process->Type != HANDLE_TYPE_PROCESS)
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
-		return FALSE;
-	}
-
-	return TRUE;
+	return WINPR_HANDLE_IS_HANDLED(handle, HANDLE_TYPE_PROCESS, FALSE);
 }
 
 static int ProcessGetFd(HANDLE handle)
@@ -538,8 +530,8 @@ HANDLE CreateProcessHandle(pid_t pid)
 		return NULL;
 
 	process->pid = pid;
-	process->Type = HANDLE_TYPE_PROCESS;
-	process->ops = &ops;
+	process->common.Type = HANDLE_TYPE_PROCESS;
+	process->common.ops = &ops;
 	return (HANDLE)process;
 }
 

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -106,15 +106,7 @@ static void cleanup_handle(void* obj);
 
 static BOOL ThreadIsHandled(HANDLE handle)
 {
-	WINPR_THREAD* pThread = (WINPR_THREAD*)handle;
-
-	if (!pThread || (pThread->Type != HANDLE_TYPE_THREAD))
-	{
-		SetLastError(ERROR_INVALID_HANDLE);
-		return FALSE;
-	}
-
-	return TRUE;
+	return WINPR_HANDLE_IS_HANDLED(handle, HANDLE_TYPE_THREAD, FALSE);
 }
 
 static int ThreadGetFd(HANDLE handle)
@@ -261,7 +253,7 @@ static BOOL initializeThreads(PINIT_ONCE InitOnce, PVOID Parameter, PVOID* Conte
 		goto out;
 	}
 
-	mainThread.Type = HANDLE_TYPE_THREAD;
+	mainThread.common.Type = HANDLE_TYPE_THREAD;
 	mainThreadId = pthread_self();
 
 	currentThreadTlsIndex = TlsAlloc();
@@ -421,7 +413,7 @@ HANDLE CreateThread(LPSECURITY_ATTRIBUTES lpThreadAttributes, SIZE_T dwStackSize
 	thread->lpParameter = lpParameter;
 	thread->lpStartAddress = lpStartAddress;
 	thread->lpThreadAttributes = lpThreadAttributes;
-	thread->ops = &ops;
+	thread->common.ops = &ops;
 #if defined(WITH_DEBUG_THREADS)
 	thread->create_stack = winpr_backtrace(20);
 	dump_thread(thread);

--- a/winpr/libwinpr/thread/thread.h
+++ b/winpr/libwinpr/thread/thread.h
@@ -37,7 +37,7 @@ typedef struct winpr_APC_item WINPR_APC_ITEM;
 
 struct winpr_thread
 {
-	WINPR_HANDLE_DEF();
+	WINPR_HANDLE common;
 
 	BOOL started;
 	WINPR_EVENT_IMPL event;
@@ -67,7 +67,7 @@ WINPR_THREAD* winpr_GetCurrentThread(VOID);
 
 typedef struct
 {
-	WINPR_HANDLE_DEF();
+	WINPR_HANDLE common;
 
 	pid_t pid;
 	int status;


### PR DESCRIPTION
* Replaces `WINPR_HANDLE_DEF` with `WINPR_HANDLE`, a `typedef struct` to ensure type safety
* Add common functions checking for valid handles
* Fix a `use-after-free` in `TSCredentials`