### PR TITLE
Fixed cast-quality warnings

### DIFF
--- a/channels/echo/server/echo_main.c
+++ b/channels/echo/server/echo_main.c
@@ -19,6 +19,7 @@
  * limitations under the License.
  */
 
+#include <winpr/assert.h>
 #include <freerdp/config.h>
 
 #include <stdio.h>
@@ -327,8 +328,16 @@ static UINT echo_server_close(echo_server_context* context)
 
 static BOOL echo_server_request(echo_server_context* context, const BYTE* buffer, UINT32 length)
 {
+	union
+	{
+		const BYTE* cpv;
+		CHAR* pv;
+	} cnv;
+	cnv.cpv = buffer;
 	echo_server* echo = (echo_server*)context;
-	return WTSVirtualChannelWrite(echo->echo_channel, (PCHAR)buffer, length, NULL);
+	WINPR_ASSERT(echo);
+
+	return WTSVirtualChannelWrite(echo->echo_channel, cnv.pv, length, NULL);
 }
 
 echo_server_context* echo_server_context_new(HANDLE vcm)

--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -1712,6 +1712,12 @@ UINT rdpsnd_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 
 	if (!rdpsnd)
 	{
+		union
+		{
+			const void* cev;
+			void* ev;
+		} cnv;
+
 		rdpsnd = allocatePlugin();
 		if (!rdpsnd)
 		{
@@ -1726,8 +1732,9 @@ UINT rdpsnd_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 		rdpsnd->dynamic = TRUE;
 
 		/* user data pointer is not const, cast to avoid warning. */
+		cnv.cev = pEntryPoints->GetPluginData(pEntryPoints);
 		WINPR_ASSERT(pEntryPoints->GetPluginData);
-		rdpsnd->channelEntryPoints.pExtendedData = (void*)pEntryPoints->GetPluginData(pEntryPoints);
+		rdpsnd->channelEntryPoints.pExtendedData = cnv.ev;
 
 		error = pEntryPoints->RegisterPlugin(pEntryPoints, RDPSND_CHANNEL_NAME, &rdpsnd->iface);
 	}

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
@@ -236,7 +236,7 @@ static void android_Pointer_Free(rdpContext* context, rdpPointer* pointer)
 	WINPR_ASSERT(context);
 }
 
-static BOOL android_Pointer_Set(rdpContext* context, const rdpPointer* pointer)
+static BOOL android_Pointer_Set(rdpContext* context, rdpPointer* pointer)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(pointer);

--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -52,7 +52,7 @@
 
 static BOOL mf_Pointer_New(rdpContext *context, rdpPointer *pointer);
 static void mf_Pointer_Free(rdpContext *context, rdpPointer *pointer);
-static BOOL mf_Pointer_Set(rdpContext *context, const rdpPointer *pointer);
+static BOOL mf_Pointer_Set(rdpContext *context, rdpPointer *pointer);
 static BOOL mf_Pointer_SetNull(rdpContext *context);
 static BOOL mf_Pointer_SetDefault(rdpContext *context);
 static BOOL mf_Pointer_SetPosition(rdpContext *context, UINT32 x, UINT32 y);
@@ -1195,7 +1195,7 @@ void mf_Pointer_Free(rdpContext *context, rdpPointer *pointer)
 	}
 }
 
-BOOL mf_Pointer_Set(rdpContext *context, const rdpPointer *pointer)
+BOOL mf_Pointer_Set(rdpContext *context, rdpPointer *pointer)
 {
 	mfContext *mfc = (mfContext *)context;
 	MRDPView *view = (MRDPView *)mfc->view;

--- a/client/Wayland/wlf_pointer.c
+++ b/client/Wayland/wlf_pointer.c
@@ -66,10 +66,10 @@ static void wlf_Pointer_Free(rdpContext* context, rdpPointer* pointer)
 		_aligned_free(ptr->data);
 }
 
-static BOOL wlf_Pointer_Set(rdpContext* context, const rdpPointer* pointer)
+static BOOL wlf_Pointer_Set(rdpContext* context, rdpPointer* pointer)
 {
 	wlfContext* wlf = (wlfContext*)context;
-	const wlfPointer* ptr = (const wlfPointer*)pointer;
+	wlfPointer* ptr = (wlfPointer*)pointer;
 	void* data;
 	UINT32 w, h, x, y;
 	size_t size;

--- a/client/Windows/wf_graphics.c
+++ b/client/Windows/wf_graphics.c
@@ -289,7 +289,7 @@ static BOOL wf_Pointer_Free(rdpContext* context, rdpPointer* pointer)
 	return TRUE;
 }
 
-static BOOL wf_Pointer_Set(rdpContext* context, const rdpPointer* pointer)
+static BOOL wf_Pointer_Set(rdpContext* context, rdpPointer* pointer)
 {
 	HCURSOR hCur;
 	wfContext* wfc = (wfContext*)context;

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -663,11 +663,15 @@ static BOOL xf_clipboard_copy_formats(xfClipboard* clipboard, const CLIPRDR_FORM
 static UINT xf_cliprdr_send_format_list(xfClipboard* clipboard, const CLIPRDR_FORMAT* formats,
                                         UINT32 numFormats)
 {
-	CLIPRDR_FORMAT_LIST formatList = { 0 };
-	formatList.msgFlags = CB_RESPONSE_OK;
-	formatList.numFormats = numFormats;
-	formatList.formats = (CLIPRDR_FORMAT*)formats;
-	formatList.msgType = CB_FORMAT_LIST;
+	union
+	{
+		const CLIPRDR_FORMAT* cpv;
+		CLIPRDR_FORMAT* pv;
+	} cnv = { .cpv = formats };
+	const CLIPRDR_FORMAT_LIST formatList = { .msgFlags = CB_RESPONSE_OK,
+		                                     .numFormats = numFormats,
+		                                     .formats = cnv.pv,
+		                                     .msgType = CB_FORMAT_LIST };
 
 	if (!xf_clipboard_changed(clipboard, formats, numFormats))
 		return CHANNEL_RC_OK;

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -573,9 +573,15 @@ static BOOL xf_event_ButtonRelease(xfContext* xfc, const XButtonEvent* event, BO
 static BOOL xf_event_KeyPress(xfContext* xfc, const XKeyEvent* event, BOOL app)
 {
 	KeySym keysym;
-	char str[256];
+	char str[256] = { 0 };
+	union
+	{
+		const XKeyEvent* cev;
+		XKeyEvent* ev;
+	} cnv;
+	cnv.cev = event;
 	WINPR_UNUSED(app);
-	XLookupString((XKeyEvent*)event, str, sizeof(str), &keysym, NULL);
+	XLookupString(cnv.ev, str, sizeof(str), &keysym, NULL);
 	xf_keyboard_key_press(xfc, event, keysym);
 	return TRUE;
 }
@@ -583,9 +589,16 @@ static BOOL xf_event_KeyPress(xfContext* xfc, const XKeyEvent* event, BOOL app)
 static BOOL xf_event_KeyRelease(xfContext* xfc, const XKeyEvent* event, BOOL app)
 {
 	KeySym keysym;
-	char str[256];
+	char str[256] = { 0 };
+	union
+	{
+		const XKeyEvent* cev;
+		XKeyEvent* ev;
+	} cnv;
+	cnv.cev = event;
+
 	WINPR_UNUSED(app);
-	XLookupString((XKeyEvent*)event, str, sizeof(str), &keysym, NULL);
+	XLookupString(cnv.ev, str, sizeof(str), &keysym, NULL);
 	xf_keyboard_key_release(xfc, event, keysym);
 	return TRUE;
 }

--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -226,13 +226,13 @@ static BOOL xf_Bitmap_SetSurface(rdpContext* context, rdpBitmap* bitmap, BOOL pr
 	return TRUE;
 }
 
-static BOOL _xf_Pointer_GetCursorForCurrentScale(rdpContext* context, const rdpPointer* pointer,
+static BOOL _xf_Pointer_GetCursorForCurrentScale(rdpContext* context, rdpPointer* pointer,
                                                  Cursor* cursor)
 {
 #ifdef WITH_XCURSOR
 	UINT32 CursorFormat;
 	xfContext* xfc = (xfContext*)context;
-	xfPointer* xpointer = (xfPointer*)pointer;
+	xfPointer* xpointer = pointer;
 	XcursorImage ci = { 0 };
 	rdpSettings* settings;
 	UINT32 xTargetSize;
@@ -448,9 +448,16 @@ static void xf_Pointer_Free(rdpContext* context, rdpPointer* pointer)
 static BOOL xf_Pointer_Set(rdpContext* context, const rdpPointer* pointer)
 {
 #ifdef WITH_XCURSOR
+	union
+	{
+		const rdpPointer* cpv;
+		rdpPointer* pv;
+	} cnv;
 	xfContext* xfc = (xfContext*)context;
 	Window handle = xf_Pointer_get_window(xfc);
-	xfc->pointer = (xfPointer*)pointer;
+
+	cnv.cpv = pointer;
+	xfc->pointer = cnv.pv;
 
 	/* in RemoteApp mode, window can be null if none has had focus */
 

--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -445,19 +445,13 @@ static void xf_Pointer_Free(rdpContext* context, rdpPointer* pointer)
 #endif
 }
 
-static BOOL xf_Pointer_Set(rdpContext* context, const rdpPointer* pointer)
+static BOOL xf_Pointer_Set(rdpContext* context, rdpPointer* pointer)
 {
 #ifdef WITH_XCURSOR
-	union
-	{
-		const rdpPointer* cpv;
-		rdpPointer* pv;
-	} cnv;
 	xfContext* xfc = (xfContext*)context;
 	Window handle = xf_Pointer_get_window(xfc);
 
-	cnv.cpv = pointer;
-	xfc->pointer = cnv.pv;
+	xfc->pointer = pointer;
 
 	/* in RemoteApp mode, window can be null if none has had focus */
 

--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -105,7 +105,7 @@ static BOOL register_input_events(xfContext* xfc, Window window)
 				case XITouchClass:
 					if (settings->MultiTouchInput)
 					{
-						XITouchClassInfo* t = (XITouchClassInfo*)class;
+						const XITouchClassInfo* t = (const XITouchClassInfo*)class;
 						if (t->mode == XIDirectTouch)
 						{
 							WLog_DBG(
@@ -121,7 +121,7 @@ static BOOL register_input_events(xfContext* xfc, Window window)
 					break;
 				case XIButtonClass:
 				{
-					XIButtonClassInfo* t = (XIButtonClassInfo*)class;
+					const XIButtonClassInfo* t = (const XIButtonClassInfo*)class;
 					WLog_DBG(TAG, "%s button device (id: %d, mode: %d)", dev->name, dev->deviceid,
 					         t->num_buttons);
 					XISetMask(masks[nmasks], XI_ButtonPress);

--- a/client/iOS/FreeRDP/ios_freerdp.m
+++ b/client/iOS/FreeRDP/ios_freerdp.m
@@ -147,7 +147,7 @@ static void ios_Pointer_Free(rdpContext *context, rdpPointer *pointer)
 		return;
 }
 
-static BOOL ios_Pointer_Set(rdpContext *context, const rdpPointer *pointer)
+static BOOL ios_Pointer_Set(rdpContext *context, rdpPointer *pointer)
 {
 	if (!context)
 		return FALSE;

--- a/include/freerdp/graphics.h
+++ b/include/freerdp/graphics.h
@@ -81,7 +81,7 @@ extern "C"
 
 	typedef BOOL (*pPointer_New)(rdpContext* context, rdpPointer* pointer);
 	typedef void (*pPointer_Free)(rdpContext* context, rdpPointer* pointer);
-	typedef BOOL (*pPointer_Set)(rdpContext* context, const rdpPointer* pointer);
+	typedef BOOL (*pPointer_Set)(rdpContext* context, rdpPointer* pointer);
 	typedef BOOL (*pPointer_SetNull)(rdpContext* context);
 	typedef BOOL (*pPointer_SetDefault)(rdpContext* context);
 	typedef BOOL (*pPointer_SetPosition)(rdpContext* context, UINT32 x, UINT32 y);

--- a/libfreerdp/codec/clear.c
+++ b/libfreerdp/codec/clear.c
@@ -961,6 +961,7 @@ INT32 clear_decompress(CLEAR_CONTEXT* clear, const BYTE* pSrcData, UINT32 SrcSiz
 	UINT32 residualByteCount;
 	UINT32 bandsByteCount;
 	UINT32 subcodecByteCount;
+	wStream sbuffer = { 0 };
 	wStream* s;
 	BYTE* glyphData = NULL;
 
@@ -973,7 +974,7 @@ INT32 clear_decompress(CLEAR_CONTEXT* clear, const BYTE* pSrcData, UINT32 SrcSiz
 	if ((nWidth > 0xFFFF) || (nHeight > 0xFFFF))
 		return -1004;
 
-	s = Stream_New((BYTE*)pSrcData, SrcSize);
+	s = Stream_StaticConstInit(&sbuffer, pSrcData, SrcSize);
 
 	if (!s)
 		return -2005;
@@ -1076,7 +1077,6 @@ INT32 clear_decompress(CLEAR_CONTEXT* clear, const BYTE* pSrcData, UINT32 SrcSiz
 finish:
 	rc = 0;
 fail:
-	Stream_Free(s, FALSE);
 	return rc;
 }
 

--- a/libfreerdp/codec/nsc.c
+++ b/libfreerdp/codec/nsc.c
@@ -423,11 +423,12 @@ BOOL nsc_process_message(NSC_CONTEXT* context, UINT16 bpp, UINT32 width, UINT32 
                          UINT32 nHeight, UINT32 flip)
 {
 	wStream* s;
+	wStream sbuffer = { 0 };
 	BOOL ret;
 	if (!context || !data || !pDstData)
 		return FALSE;
 
-	s = Stream_New((BYTE*)data, length);
+	s = Stream_StaticConstInit(&sbuffer, data, length);
 
 	if (!s)
 		return FALSE;
@@ -458,14 +459,12 @@ BOOL nsc_process_message(NSC_CONTEXT* context, UINT16 bpp, UINT32 width, UINT32 
 			break;
 
 		default:
-			Stream_Free(s, TRUE);
 			return FALSE;
 	}
 
 	context->width = width;
 	context->height = height;
 	ret = nsc_context_initialize(context, s);
-	Stream_Free(s, FALSE);
 
 	if (!ret)
 		return FALSE;

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -1528,6 +1528,11 @@ RFX_MESSAGE* rfx_encode_message(RFX_CONTEXT* context, const RFX_RECT* rects, siz
 			for (xIdx = startTileX, gridRelX = startTileX * 64; xIdx <= endTileX;
 			     xIdx++, gridRelX += 64)
 			{
+				union
+				{
+					const BYTE* cpv;
+					BYTE* pv;
+				} cnv;
 				int tileWidth = 64;
 
 				if ((xIdx == endTileX) && (gridRelX + 64 > width))
@@ -1560,7 +1565,8 @@ RFX_MESSAGE* rfx_encode_message(RFX_CONTEXT* context, const RFX_RECT* rects, siz
 				}
 
 				/* Cast away const */
-				tile->data = (BYTE*)&data[(ay * scanline) + (ax * bytesPerPixel)];
+				cnv.cpv = &data[(ay * scanline) + (ax * bytesPerPixel)];
+				tile->data = cnv.pv;
 				tile->quantIdxY = context->quantIdxY;
 				tile->quantIdxCb = context->quantIdxCb;
 				tile->quantIdxCr = context->quantIdxCr;

--- a/libfreerdp/codec/rfx_decode.c
+++ b/libfreerdp/codec/rfx_decode.c
@@ -62,6 +62,11 @@ void rfx_decode_component(RFX_CONTEXT* context, const UINT32* quantization_value
 /* stride is bytes between rows in the output buffer. */
 BOOL rfx_decode_rgb(RFX_CONTEXT* context, const RFX_TILE* tile, BYTE* rgb_buffer, UINT32 stride)
 {
+	union
+	{
+		const INT16** cpv;
+		INT16** pv;
+	} cnv;
 	BOOL rc = TRUE;
 	BYTE* pBuffer;
 	INT16* pSrcDst[3];
@@ -81,9 +86,9 @@ BOOL rfx_decode_rgb(RFX_CONTEXT* context, const RFX_TILE* tile, BYTE* rgb_buffer
 	rfx_decode_component(context, cr_quants, tile->CrData, tile->CrLen, pSrcDst[2]); /* CrData */
 	PROFILER_ENTER(context->priv->prof_rfx_ycbcr_to_rgb)
 
-	if (prims->yCbCrToRGB_16s8u_P3AC4R((const INT16**)pSrcDst, 64 * sizeof(INT16), rgb_buffer,
-	                                   stride, context->pixel_format,
-	                                   &roi_64x64) != PRIMITIVES_SUCCESS)
+	cnv.pv = pSrcDst;
+	if (prims->yCbCrToRGB_16s8u_P3AC4R(cnv.cpv, 64 * sizeof(INT16), rgb_buffer, stride,
+	                                   context->pixel_format, &roi_64x64) != PRIMITIVES_SUCCESS)
 		rc = FALSE;
 
 	PROFILER_EXIT(context->priv->prof_rfx_ycbcr_to_rgb)

--- a/libfreerdp/codec/rfx_encode.c
+++ b/libfreerdp/codec/rfx_encode.c
@@ -254,6 +254,11 @@ static void rfx_encode_component(RFX_CONTEXT* context, const UINT32* quantizatio
 
 void rfx_encode_rgb(RFX_CONTEXT* context, RFX_TILE* tile)
 {
+	union
+	{
+		const INT16** cpv;
+		INT16** pv;
+	} cnv;
 	BYTE* pBuffer;
 	INT16* pSrcDst[3];
 	int YLen, CbLen, CrLen;
@@ -278,8 +283,10 @@ void rfx_encode_rgb(RFX_CONTEXT* context, RFX_TILE* tile)
 	                      pSrcDst[2]);
 	PROFILER_EXIT(context->priv->prof_rfx_encode_format_rgb)
 	PROFILER_ENTER(context->priv->prof_rfx_rgb_to_ycbcr)
-	prims->RGBToYCbCr_16s16s_P3P3((const INT16**)pSrcDst, 64 * sizeof(INT16), pSrcDst,
-	                              64 * sizeof(INT16), &roi_64x64);
+
+	cnv.pv = pSrcDst;
+	prims->RGBToYCbCr_16s16s_P3P3(cnv.cpv, 64 * sizeof(INT16), pSrcDst, 64 * sizeof(INT16),
+	                              &roi_64x64);
 	PROFILER_EXIT(context->priv->prof_rfx_rgb_to_ycbcr)
 	/**
 	 * We need to clear the buffers as the RLGR encoder expects it to be initialized to zero.

--- a/libfreerdp/codec/yuv.c
+++ b/libfreerdp/codec/yuv.c
@@ -282,10 +282,18 @@ static INLINE YUV_PROCESS_WORK_PARAM pool_decode_param(const RECTANGLE_16* rect,
 static BOOL submit_object(PTP_WORK* work_object, PTP_WORK_CALLBACK cb, const void* param,
                           YUV_CONTEXT* context)
 {
+	union
+	{
+		const void* cpv;
+		void* pv;
+	} cnv;
+
+	cnv.cpv = param;
+
 	if (!work_object || !param || !context)
 		return FALSE;
 
-	*work_object = CreateThreadpoolWork(cb, (void*)param, &context->ThreadPoolEnv);
+	*work_object = CreateThreadpoolWork(cb, cnv.pv, &context->ThreadPoolEnv);
 	if (!*work_object)
 		return FALSE;
 

--- a/libfreerdp/core/client.c
+++ b/libfreerdp/core/client.c
@@ -308,21 +308,29 @@ UINT freerdp_channels_attach(freerdp* instance)
 
 	for (index = 0; index < channels->clientDataCount; index++)
 	{
-		ChannelAttachedEventArgs e;
+		union
+		{
+			const void* cpv;
+			void* pv;
+		} cnv;
+		ChannelAttachedEventArgs e = { 0 };
 		CHANNEL_OPEN_DATA* pChannelOpenData = NULL;
+
+		cnv.cpv = hostname;
 		pChannelClientData = &channels->clientDataList[index];
 
 		if (pChannelClientData->pChannelInitEventProc)
 		{
+
 			pChannelClientData->pChannelInitEventProc(pChannelClientData->pInitHandle,
-			                                          CHANNEL_EVENT_ATTACHED, (LPVOID)hostname,
+			                                          CHANNEL_EVENT_ATTACHED, cnv.pv,
 			                                          (UINT)hostnameLength);
 		}
 		else if (pChannelClientData->pChannelInitEventProcEx)
 		{
 			pChannelClientData->pChannelInitEventProcEx(
 			    pChannelClientData->lpUserParam, pChannelClientData->pInitHandle,
-			    CHANNEL_EVENT_ATTACHED, (LPVOID)hostname, (UINT)hostnameLength);
+			    CHANNEL_EVENT_ATTACHED, cnv.pv, (UINT)hostnameLength);
 		}
 
 		if (getChannelError(instance->context) != CHANNEL_RC_OK)
@@ -363,21 +371,29 @@ UINT freerdp_channels_detach(freerdp* instance)
 
 	for (index = 0; index < channels->clientDataCount; index++)
 	{
-		ChannelDetachedEventArgs e;
+		union
+		{
+			const void* cpv;
+			void* pv;
+		} cnv;
+
+		ChannelDetachedEventArgs e = { 0 };
 		CHANNEL_OPEN_DATA* pChannelOpenData;
+
+		cnv.cpv = hostname;
 		pChannelClientData = &channels->clientDataList[index];
 
 		if (pChannelClientData->pChannelInitEventProc)
 		{
 			pChannelClientData->pChannelInitEventProc(pChannelClientData->pInitHandle,
-			                                          CHANNEL_EVENT_DETACHED, (LPVOID)hostname,
+			                                          CHANNEL_EVENT_DETACHED, cnv.pv,
 			                                          (UINT)hostnameLength);
 		}
 		else if (pChannelClientData->pChannelInitEventProcEx)
 		{
 			pChannelClientData->pChannelInitEventProcEx(
 			    pChannelClientData->lpUserParam, pChannelClientData->pInitHandle,
-			    CHANNEL_EVENT_DETACHED, (LPVOID)hostname, (UINT)hostnameLength);
+			    CHANNEL_EVENT_DETACHED, cnv.pv, (UINT)hostnameLength);
 		}
 
 		if (getChannelError(context) != CHANNEL_RC_OK)
@@ -418,21 +434,27 @@ UINT freerdp_channels_post_connect(rdpChannels* channels, freerdp* instance)
 
 	for (index = 0; index < channels->clientDataCount; index++)
 	{
-		ChannelConnectedEventArgs e;
+		union
+		{
+			const void* pcb;
+			void* pb;
+		} cnv;
+		ChannelConnectedEventArgs e = { 0 };
 		CHANNEL_OPEN_DATA* pChannelOpenData;
 		pChannelClientData = &channels->clientDataList[index];
 
+		cnv.pcb = hostname;
 		if (pChannelClientData->pChannelInitEventProc)
 		{
 			pChannelClientData->pChannelInitEventProc(pChannelClientData->pInitHandle,
-			                                          CHANNEL_EVENT_CONNECTED, (LPVOID)hostname,
+			                                          CHANNEL_EVENT_CONNECTED, cnv.pb,
 			                                          (UINT)hostnameLength);
 		}
 		else if (pChannelClientData->pChannelInitEventProcEx)
 		{
 			pChannelClientData->pChannelInitEventProcEx(
 			    pChannelClientData->lpUserParam, pChannelClientData->pInitHandle,
-			    CHANNEL_EVENT_CONNECTED, (LPVOID)hostname, (UINT)hostnameLength);
+			    CHANNEL_EVENT_CONNECTED, cnv.pb, (UINT)hostnameLength);
 		}
 
 		if (getChannelError(instance->context) != CHANNEL_RC_OK)

--- a/libfreerdp/core/gateway/ntlm.c
+++ b/libfreerdp/core/gateway/ntlm.c
@@ -440,7 +440,15 @@ BOOL ntlm_client_set_input_buffer(rdpNtlm* ntlm, BOOL copy, const void* data, si
 		memcpy(ntlm->inputBuffer[0].pvBuffer, data, size);
 	}
 	else
-		ntlm->inputBuffer[0].pvBuffer = (void*)data;
+	{
+		union
+		{
+			const void* cpv;
+			void* pv;
+		} cnv;
+		cnv.cpv = data;
+		ntlm->inputBuffer[0].pvBuffer = cnv.pv;
+	}
 
 	return TRUE;
 }

--- a/libfreerdp/core/input.c
+++ b/libfreerdp/core/input.c
@@ -676,7 +676,6 @@ BOOL input_recv(rdpInput* input, wStream* s)
 BOOL input_register_client_callbacks(rdpInput* input)
 {
 	rdpSettings* settings;
-	rdp_input_internal* in = input_cast(input);
 
 	if (!input->context)
 		return FALSE;

--- a/libfreerdp/core/listener.c
+++ b/libfreerdp/core/listener.c
@@ -299,7 +299,7 @@ static DWORD freerdp_listener_get_event_handles(freerdp_listener* instance, HAND
 BOOL freerdp_peer_set_local_and_hostname(freerdp_peer* client,
                                          const struct sockaddr_storage* peer_addr)
 {
-	void* sin_addr = NULL;
+	const void* sin_addr = NULL;
 	const BYTE localhost6_bytes[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };
 
 	WINPR_ASSERT(client);
@@ -307,16 +307,17 @@ BOOL freerdp_peer_set_local_and_hostname(freerdp_peer* client,
 
 	if (peer_addr->ss_family == AF_INET)
 	{
-		sin_addr = &(((struct sockaddr_in*)peer_addr)->sin_addr);
+		const UINT32* usin_addr = sin_addr = &(((const struct sockaddr_in*)peer_addr)->sin_addr);
 
-		if ((*(UINT32*)sin_addr) == 0x0100007f)
+		if ((*usin_addr) == 0x0100007f)
 			client->local = TRUE;
 	}
 	else if (peer_addr->ss_family == AF_INET6)
 	{
-		sin_addr = &(((struct sockaddr_in6*)peer_addr)->sin6_addr);
+		const struct sockaddr_in6* usin_addr = sin_addr =
+		    &(((const struct sockaddr_in6*)peer_addr)->sin6_addr);
 
-		if (memcmp(sin_addr, localhost6_bytes, 16) == 0)
+		if (memcmp(usin_addr, localhost6_bytes, 16) == 0)
 			client->local = TRUE;
 	}
 

--- a/libfreerdp/utils/stopwatch.c
+++ b/libfreerdp/utils/stopwatch.c
@@ -88,7 +88,7 @@ void stopwatch_reset(STOPWATCH* stopwatch)
 
 double stopwatch_get_elapsed_time_in_seconds(STOPWATCH* stopwatch)
 {
-	return (stopwatch->elapsed / 1000000.0);
+	return (stopwatch->elapsed / 1000000.0f);
 }
 
 void stopwatch_get_elapsed_time_in_useconds(STOPWATCH* stopwatch, UINT32* sec, UINT32* usec)

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -883,8 +883,8 @@ void channel_data_free(void* obj)
 	proxyChannelDataEventInfo* dst = obj;
 	if (dst)
 	{
-		free((void*)dst->data);
-		free((void*)dst->channel_name);
+		free(dst->data);
+		free(dst->channel_name);
 		free(dst);
 	}
 }
@@ -910,7 +910,7 @@ static void* channel_data_copy(const void* obj)
 	dst->data = malloc(src->data_len);
 	if (!dst->data)
 		goto fail;
-	memcpy((void*)dst->data, src->data, src->data_len);
+	memcpy(dst->data, src->data, src->data_len);
 	return dst;
 
 fail:

--- a/winpr/include/winpr/bitstream.h
+++ b/winpr/include/winpr/bitstream.h
@@ -20,6 +20,7 @@
 #ifndef WINPR_UTILS_BITSTREAM_H
 #define WINPR_UTILS_BITSTREAM_H
 
+#include <winpr/assert.h>
 #include <winpr/winpr.h>
 #include <winpr/wtypes.h>
 
@@ -49,6 +50,8 @@ extern "C"
 
 	static INLINE void BitStream_Prefetch(wBitStream* _bs)
 	{
+		WINPR_ASSERT(_bs);
+
 		(_bs->prefetch) = 0;
 		if (((UINT32)(_bs->pointer - _bs->buffer) + 4) < (_bs->capacity))
 			(_bs->prefetch) |= ((UINT32) * (_bs->pointer + 4) << 24);
@@ -62,6 +65,7 @@ extern "C"
 
 	static INLINE void BitStream_Fetch(wBitStream* _bs)
 	{
+		WINPR_ASSERT(_bs);
 		(_bs->accumulator) = 0;
 		if (((UINT32)(_bs->pointer - _bs->buffer) + 0) < (_bs->capacity))
 			(_bs->accumulator) |= ((UINT32) * (_bs->pointer + 0) << 24);
@@ -76,6 +80,7 @@ extern "C"
 
 	static INLINE void BitStream_Flush(wBitStream* _bs)
 	{
+		WINPR_ASSERT(_bs);
 		if (((UINT32)(_bs->pointer - _bs->buffer) + 0) < (_bs->capacity))
 			*(_bs->pointer + 0) = (BYTE)((UINT32)_bs->accumulator >> 24);
 		if (((UINT32)(_bs->pointer - _bs->buffer) + 1) < (_bs->capacity))
@@ -88,6 +93,7 @@ extern "C"
 
 	static INLINE void BitStream_Shift(wBitStream* _bs, UINT32 _nbits)
 	{
+		WINPR_ASSERT(_bs);
 		if (_nbits == 0)
 		{
 		}
@@ -126,12 +132,14 @@ extern "C"
 
 	static INLINE void BitStream_Shift32(wBitStream* _bs)
 	{
+		WINPR_ASSERT(_bs);
 		BitStream_Shift(_bs, 16);
 		BitStream_Shift(_bs, 16);
 	}
 
 	static INLINE void BitStream_Write_Bits(wBitStream* _bs, UINT32 _bits, UINT32 _nbits)
 	{
+		WINPR_ASSERT(_bs);
 		_bs->position += _nbits;
 		_bs->offset += _nbits;
 		if (_bs->offset < 32)
@@ -156,6 +164,7 @@ extern "C"
 
 	static INLINE size_t BitStream_GetRemainingLength(wBitStream* _bs)
 	{
+		WINPR_ASSERT(_bs);
 		return (_bs->length - _bs->position);
 	}
 

--- a/winpr/libwinpr/clipboard/synthetic.c
+++ b/winpr/libwinpr/clipboard/synthetic.c
@@ -330,55 +330,58 @@ static void* clipboard_synthesize_image_bmp(wClipboard* clipboard, UINT32 format
  */
 
 static void* clipboard_synthesize_html_format(wClipboard* clipboard, UINT32 formatId,
-                                              const void* data, UINT32* pSize)
+                                              const void* pData, UINT32* pSize)
 {
-	char* pSrcData = NULL;
+	union
+	{
+		const void* cpv;
+		const char* cpc;
+		const BYTE* cpb;
+		WCHAR* pv;
+	} pSrcData;
 	char* pDstData = NULL;
-	INT64 SrcSize = (INT64)*pSize;
+
+	pSrcData.cpv = NULL;
+
+	WINPR_ASSERT(clipboard);
+	WINPR_ASSERT(pSize);
 
 	if (formatId == ClipboardGetFormatId(clipboard, "text/html"))
 	{
+		INT64 SrcSize = (INT64)*pSize;
 		char* body;
-		BYTE bom[2];
-		char num[20];
-		const WCHAR* wstr;
+		char num[20] = { 0 };
+
+		/* Create a copy, we modify the input data */
+		pSrcData.pv = calloc(1, SrcSize + 1);
+		if (!pSrcData.pv)
+			goto fail;
+		memcpy(pSrcData.pv, pData, SrcSize);
 
 		if (SrcSize > 2)
 		{
 			if (SrcSize > INT_MAX)
 				return NULL;
-			CopyMemory(bom, data, 2);
 
-			if ((bom[0] == 0xFE) && (bom[1] == 0xFF))
+			/* Check the BOM (Byte Order Mark) */
+			if ((pSrcData.cpb[0] == 0xFE) && (pSrcData.cpb[1] == 0xFF))
+				ByteSwapUnicode(pSrcData.pv, (int)(SrcSize / 2));
+
+			/* Check if we have WCHAR, convert to UTF-8 */
+			if ((pSrcData.cpb[0] == 0xFF) && (pSrcData.cpb[1] == 0xFE))
 			{
-				ByteSwapUnicode((WCHAR*)data, (int)(SrcSize / 2));
+				char* utfString = NULL;
+				ConvertFromUnicode(CP_UTF8, 0, &pSrcData.pv[1], (int)(SrcSize - 2) / 2, &utfString,
+				                   0, NULL, NULL);
+				free(pSrcData.pv);
+				pSrcData.cpc = utfString;
 			}
-
-			if ((bom[0] == 0xFF) && (bom[1] == 0xFE))
-			{
-				wstr = (const WCHAR*)&((BYTE*)data)[2];
-				ConvertFromUnicode(CP_UTF8, 0, wstr, (int)(SrcSize - 2) / 2, &pSrcData, 0, NULL,
-				                   NULL);
-			}
-		}
-
-		if (!pSrcData)
-		{
-			pSrcData = (char*)calloc(1, SrcSize + 1);
-
-			if (!pSrcData)
-				return NULL;
-
-			CopyMemory(pSrcData, data, SrcSize);
 		}
 
 		pDstData = (char*)calloc(1, SrcSize + 200);
 
 		if (!pDstData)
-		{
-			free(pSrcData);
-			return NULL;
-		}
+			goto fail;
 
 		sprintf_s(pDstData, SrcSize + 200,
 		          "Version:0.9\r\n"
@@ -386,10 +389,10 @@ static void* clipboard_synthesize_html_format(wClipboard* clipboard, UINT32 form
 		          "EndHTML:0000000000\r\n"
 		          "StartFragment:0000000000\r\n"
 		          "EndFragment:0000000000\r\n");
-		body = strstr(pSrcData, "<body");
+		body = strstr(pSrcData.cpc, "<body");
 
 		if (!body)
-			body = strstr(pSrcData, "<BODY");
+			body = strstr(pSrcData.cpc, "<BODY");
 
 		/* StartHTML */
 		sprintf_s(num, sizeof(num), "%010" PRIuz "", strnlen(pDstData, SrcSize + 200));
@@ -402,7 +405,7 @@ static void* clipboard_synthesize_html_format(wClipboard* clipboard, UINT32 form
 		/* StartFragment */
 		sprintf_s(num, sizeof(num), "%010" PRIuz "", strnlen(pDstData, SrcSize + 200));
 		CopyMemory(&pDstData[69], num, 10);
-		strcat(pDstData, pSrcData);
+		strcat(pDstData, pSrcData.cpc);
 		/* EndFragment */
 		sprintf_s(num, sizeof(num), "%010" PRIuz "", strnlen(pDstData, SrcSize + 200));
 		CopyMemory(&pDstData[93], num, 10);
@@ -415,9 +418,9 @@ static void* clipboard_synthesize_html_format(wClipboard* clipboard, UINT32 form
 		sprintf_s(num, sizeof(num), "%010" PRIuz "", strnlen(pDstData, SrcSize + 200));
 		CopyMemory(&pDstData[43], num, 10);
 		*pSize = (UINT32)strlen(pDstData) + 1;
-		free(pSrcData);
 	}
-
+fail:
+	free(pSrcData.pv);
 	return pDstData;
 }
 

--- a/winpr/libwinpr/nt/nt.c
+++ b/winpr/libwinpr/nt/nt.c
@@ -19,6 +19,7 @@
  * limitations under the License.
  */
 
+#include <winpr/assert.h>
 #include <winpr/config.h>
 
 #include <winpr/crt.h>
@@ -113,7 +114,18 @@ PTEB NtCurrentTeb(void)
 
 VOID _RtlInitAnsiString(PANSI_STRING DestinationString, PCSZ SourceString)
 {
-	DestinationString->Buffer = (PCHAR)SourceString;
+	union
+	{
+		const char* cpv;
+		char* pv;
+	} cnv;
+
+	WINPR_ASSERT(DestinationString);
+	WINPR_ASSERT(SourceString);
+
+	cnv.cpv = SourceString;
+
+	DestinationString->Buffer = cnv.pv;
 
 	if (!SourceString)
 	{
@@ -135,7 +147,17 @@ VOID _RtlInitAnsiString(PANSI_STRING DestinationString, PCSZ SourceString)
 
 VOID _RtlInitUnicodeString(PUNICODE_STRING DestinationString, PCWSTR SourceString)
 {
-	DestinationString->Buffer = (PWSTR)SourceString;
+	union
+	{
+		const WCHAR* cpv;
+		WCHAR* pv;
+	} cnv;
+
+	WINPR_ASSERT(DestinationString);
+	WINPR_ASSERT(SourceString);
+
+	cnv.cpv = SourceString;
+	DestinationString->Buffer = cnv.pv;
 
 	if (!SourceString)
 	{

--- a/winpr/libwinpr/pipe/pipe.c
+++ b/winpr/libwinpr/pipe/pipe.c
@@ -434,7 +434,15 @@ BOOL NamedPipeWrite(PVOID Object, LPCVOID lpBuffer, DWORD nNumberOfBytesToWrite,
 		/* synchronous behavior */
 		lpOverlapped->Internal = 1;
 		lpOverlapped->InternalHigh = (ULONG_PTR)nNumberOfBytesToWrite;
-		lpOverlapped->Pointer = (PVOID)lpBuffer;
+		{
+			union
+			{
+				LPCVOID cpv;
+				PVOID pv;
+			} cnv;
+			cnv.cpv = lpBuffer;
+			lpOverlapped->Pointer = cnv.pv;
+		}
 		SetEvent(lpOverlapped->hEvent);
 #endif
 	}

--- a/winpr/libwinpr/sspi/CredSSP/credssp.c
+++ b/winpr/libwinpr/sspi/CredSSP/credssp.c
@@ -51,6 +51,11 @@ static SECURITY_STATUS SEC_ENTRY credssp_InitializeSecurityContextA(
 
 	if (!context)
 	{
+		union
+		{
+			const void* cpv;
+			void* pv;
+		} cnv;
 		context = credssp_ContextNew();
 
 		if (!context)
@@ -65,7 +70,9 @@ static SECURITY_STATUS SEC_ENTRY credssp_InitializeSecurityContextA(
 		}
 
 		sspi_SecureHandleSetLowerPointer(phNewContext, context);
-		sspi_SecureHandleSetUpperPointer(phNewContext, (void*)CREDSSP_PACKAGE_NAME);
+
+		cnv.cpv = CREDSSP_PACKAGE_NAME;
+		sspi_SecureHandleSetUpperPointer(phNewContext, cnv.pv);
 	}
 
 	return SEC_E_OK;
@@ -119,6 +126,11 @@ static SECURITY_STATUS SEC_ENTRY credssp_AcquireCredentialsHandleA(
 
 	if (fCredentialUse == SECPKG_CRED_OUTBOUND)
 	{
+		union
+		{
+			const void* cpv;
+			void* pv;
+		} cnv;
 		credentials = sspi_CredentialsNew();
 
 		if (!credentials)
@@ -127,7 +139,9 @@ static SECURITY_STATUS SEC_ENTRY credssp_AcquireCredentialsHandleA(
 		identity = (SEC_WINNT_AUTH_IDENTITY*)pAuthData;
 		CopyMemory(&(credentials->identity), identity, sizeof(SEC_WINNT_AUTH_IDENTITY));
 		sspi_SecureHandleSetLowerPointer(phCredential, (void*)credentials);
-		sspi_SecureHandleSetUpperPointer(phCredential, (void*)CREDSSP_PACKAGE_NAME);
+
+		cnv.cpv = CREDSSP_PACKAGE_NAME;
+		sspi_SecureHandleSetUpperPointer(phCredential, cnv.pv);
 		return SEC_E_OK;
 	}
 

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -631,6 +631,11 @@ static SECURITY_STATUS SEC_ENTRY kerberos_InitializeSecurityContextA(
 	context = (KRB_CONTEXT*)sspi_SecureHandleGetLowerPointer(phContext);
 	if (!context)
 	{
+		union
+		{
+			const void* cpv;
+			void* pv;
+		} cnv;
 		context = kerberos_ContextNew();
 
 		if (!context)
@@ -646,7 +651,9 @@ static SECURITY_STATUS SEC_ENTRY kerberos_InitializeSecurityContextA(
 		}
 
 		sspi_SecureHandleSetLowerPointer(phNewContext, context);
-		sspi_SecureHandleSetUpperPointer(phNewContext, (void*)KRB_PACKAGE_NAME);
+
+		cnv.cpv = KRB_PACKAGE_NAME;
+		sspi_SecureHandleSetUpperPointer(phNewContext, cnv.pv);
 	}
 	else
 		credentials = context->credentials;

--- a/winpr/libwinpr/utils/collections/ArrayList.c
+++ b/winpr/libwinpr/utils/collections/ArrayList.c
@@ -175,7 +175,15 @@ void ArrayList_SetItem(wArrayList* arrayList, size_t index, const void* obj)
 		if (arrayList->object.fnObjectNew)
 			arrayList->array[index] = arrayList->object.fnObjectNew(obj);
 		else
-			arrayList->array[index] = (void*)obj;
+		{
+			union
+			{
+				const void* cpv;
+				void* pv;
+			} cnv;
+			cnv.cpv = obj;
+			arrayList->array[index] = cnv.pv;
+		}
 	}
 }
 

--- a/winpr/libwinpr/utils/collections/BitStream.c
+++ b/winpr/libwinpr/utils/collections/BitStream.c
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+#include <winpr/assert.h>
 #include <winpr/config.h>
 
 #include <winpr/print.h>
@@ -96,17 +97,17 @@ static const char* BYTE_BIT_STRINGS_MSB[256] = {
 void BitDump(const char* tag, UINT32 level, const BYTE* buffer, UINT32 length, UINT32 flags)
 {
 	DWORD i;
-	int nbits;
-	const char* str;
-	const char** strs;
-	char pbuffer[64 * 8 + 1];
+	const char** strs = (flags & BITDUMP_MSB_FIRST) ? BYTE_BIT_STRINGS_MSB : BYTE_BIT_STRINGS_LSB;
+	char pbuffer[64 * 8 + 1] = { 0 };
 	size_t pos = 0;
-	strs = (flags & BITDUMP_MSB_FIRST) ? BYTE_BIT_STRINGS_MSB : BYTE_BIT_STRINGS_LSB;
+
+	WINPR_ASSERT(tag);
+	WINPR_ASSERT(buffer || (length == 0));
 
 	for (i = 0; i < length; i += 8)
 	{
-		str = strs[buffer[i / 8]];
-		nbits = (length - i) > 8 ? 8 : (length - i);
+		const char* str = strs[buffer[i / 8]];
+		const int nbits = (length - i) > 8 ? 8 : (length - i);
 		pos += trio_snprintf(&pbuffer[pos], length - pos, "%.*s ", nbits, str);
 
 		if ((i % 64) == 0)
@@ -135,144 +136,31 @@ UINT32 ReverseBits32(UINT32 bits, UINT32 nbits)
 	return rbits;
 }
 
-#if 0
-
-/**
- * These are the original functions from which the macros are derived.
- * Since it is much easier to develop and debug functions than macros,
- * we keep a copy here for later improvements and modifications.
- */
-
-WINPR_API void BitStream_Prefetch(wBitStream* bs);
-WINPR_API void BitStream_Fetch(wBitStream* bs);
-WINPR_API void BitStream_Flush(wBitStream* bs);
-WINPR_API void BitStream_Shift(wBitStream* bs, UINT32 nbits);
-WINPR_API void BitStream_Write_Bits(wBitStream* bs, UINT32 bits, UINT32 nbits);
-
-void BitStream_Prefetch(wBitStream* bs)
-{
-	(bs->prefetch) = 0;
-
-	if ((bs->pointer - bs->buffer) < (bs->capacity + 4))
-		(bs->prefetch) |= (*(bs->pointer + 4) << 24);
-
-	if ((bs->pointer - bs->buffer) < (bs->capacity + 5))
-		(bs->prefetch) |= (*(bs->pointer + 5) << 16);
-
-	if ((bs->pointer - bs->buffer) < (bs->capacity + 6))
-		(bs->prefetch) |= (*(bs->pointer + 6) << 8);
-
-	if ((bs->pointer - bs->buffer) < (bs->capacity + 7))
-		(bs->prefetch) |= (*(bs->pointer + 7) << 0);
-}
-
-void BitStream_Fetch(wBitStream* bs)
-{
-	(bs->accumulator) = 0;
-
-	if ((bs->pointer - bs->buffer) < (bs->capacity + 0))
-		(bs->accumulator) |= (*(bs->pointer + 0) << 24);
-
-	if ((bs->pointer - bs->buffer) < (bs->capacity + 1))
-		(bs->accumulator) |= (*(bs->pointer + 1) << 16);
-
-	if ((bs->pointer - bs->buffer) < (bs->capacity + 2))
-		(bs->accumulator) |= (*(bs->pointer + 2) << 8);
-
-	if ((bs->pointer - bs->buffer) < (bs->capacity + 3))
-		(bs->accumulator) |= (*(bs->pointer + 3) << 0);
-
-	BitStream_Prefetch(bs);
-}
-
-void BitStream_Flush(wBitStream* bs)
-{
-	if ((bs->pointer - bs->buffer) < (bs->capacity + 0))
-		*(bs->pointer + 0) = (bs->accumulator >> 24);
-
-	if ((bs->pointer - bs->buffer) < (bs->capacity + 1))
-		*(bs->pointer + 1) = (bs->accumulator >> 16);
-
-	if ((bs->pointer - bs->buffer) < (bs->capacity + 2))
-		*(bs->pointer + 2) = (bs->accumulator >> 8);
-
-	if ((bs->pointer - bs->buffer) < (bs->capacity + 3))
-		*(bs->pointer + 3) = (bs->accumulator >> 0);
-}
-
-void BitStream_Shift(wBitStream* bs, UINT32 nbits)
-{
-	bs->accumulator <<= nbits;
-	bs->position += nbits;
-	bs->offset += nbits;
-
-	if (bs->offset < 32)
-	{
-		bs->mask = ((1 << nbits) - 1);
-		bs->accumulator |= ((bs->prefetch >> (32 - nbits)) & bs->mask);
-		bs->prefetch <<= nbits;
-	}
-	else
-	{
-		bs->mask = ((1 << nbits) - 1);
-		bs->accumulator |= ((bs->prefetch >> (32 - nbits)) & bs->mask);
-		bs->prefetch <<= nbits;
-		bs->offset -= 32;
-		bs->pointer += 4;
-		BitStream_Prefetch(bs);
-
-		if (bs->offset)
-		{
-			bs->mask = ((1 << bs->offset) - 1);
-			bs->accumulator |= ((bs->prefetch >> (32 - bs->offset)) & bs->mask);
-			bs->prefetch <<= bs->offset;
-		}
-	}
-}
-
-void BitStream_Write_Bits(wBitStream* bs, UINT32 bits, UINT32 nbits)
-{
-	bs->position += nbits;
-	bs->offset += nbits;
-
-	if (bs->offset < 32)
-	{
-		bs->accumulator |= (bits << (32 - bs->offset));
-	}
-	else
-	{
-		bs->offset -= 32;
-		bs->mask = ((1 << (nbits - bs->offset)) - 1);
-		bs->accumulator |= ((bits >> bs->offset) & bs->mask);
-		BitStream_Flush(bs);
-		bs->accumulator = 0;
-		bs->pointer += 4;
-
-		if (bs->offset)
-		{
-			bs->mask = ((1 << bs->offset) - 1);
-			bs->accumulator |= ((bits & bs->mask) << (32 - bs->offset));
-		}
-	}
-}
-
-#endif
-
 void BitStream_Attach(wBitStream* bs, const BYTE* buffer, UINT32 capacity)
 {
+	union
+	{
+		const BYTE* cpv;
+		BYTE* pv;
+	} cnv;
+
+	WINPR_ASSERT(bs);
+	WINPR_ASSERT(buffer);
+
+	cnv.cpv = buffer;
+
 	bs->position = 0;
-	bs->buffer = buffer;
+	bs->buffer = cnv.pv;
 	bs->offset = 0;
 	bs->accumulator = 0;
-	bs->pointer = (BYTE*)bs->buffer;
+	bs->pointer = cnv.pv;
 	bs->capacity = capacity;
 	bs->length = bs->capacity * 8;
 }
 
-wBitStream* BitStream_New()
+wBitStream* BitStream_New(void)
 {
-	wBitStream* bs = NULL;
-	bs = (wBitStream*)calloc(1, sizeof(wBitStream));
+	wBitStream* bs = (wBitStream*)calloc(1, sizeof(wBitStream));
 
 	return bs;
 }

--- a/winpr/libwinpr/utils/collections/HashTable.c
+++ b/winpr/libwinpr/utils/collections/HashTable.c
@@ -241,7 +241,15 @@ static INLINE void setKey(wHashTable* table, wKeyValuePair* pair, const void* ke
 	if (table->key.fnObjectNew)
 		pair->key = table->key.fnObjectNew(key);
 	else
-		pair->key = (void*)key;
+	{
+		union
+		{
+			const void* cpv;
+			void* pv;
+		} cnv;
+		cnv.cpv = key;
+		pair->key = cnv.pv;
+	}
 }
 
 static INLINE void setValue(wHashTable* table, wKeyValuePair* pair, const void* value)
@@ -253,7 +261,15 @@ static INLINE void setValue(wHashTable* table, wKeyValuePair* pair, const void* 
 	if (table->value.fnObjectNew)
 		pair->value = table->value.fnObjectNew(value);
 	else
-		pair->value = (void*)value;
+	{
+		union
+		{
+			const void* cpv;
+			void* pv;
+		} cnv;
+		cnv.cpv = value;
+		pair->value = cnv.pv;
+	}
 }
 
 /**
@@ -413,7 +429,7 @@ BOOL HashTable_Remove(wHashTable* table, const void* key)
 	disposePair(table, pair);
 	table->numOfElements--;
 
-	if (!table->foreachRecursionLevel && table->lowerRehashThreshold > 0.0)
+	if (!table->foreachRecursionLevel && table->lowerRehashThreshold > 0.0f)
 	{
 		float elementToBucketRatio = (float)table->numOfElements / (float)table->numOfBuckets;
 

--- a/winpr/libwinpr/utils/collections/LinkedList.c
+++ b/winpr/libwinpr/utils/collections/LinkedList.c
@@ -185,7 +185,15 @@ static wLinkedListNode* LinkedList_Create(wLinkedList* list, const void* value)
 	if (list->object.fnObjectNew)
 		node->value = list->object.fnObjectNew(value);
 	else
-		node->value = (void*)value;
+	{
+		union
+		{
+			const void* cpv;
+			void* pv;
+		} cnv;
+		cnv.cpv = value;
+		node->value = cnv.pv;
+	}
 
 	if (list->object.fnObjectInit)
 		list->object.fnObjectInit(node);

--- a/winpr/libwinpr/utils/collections/ListDictionary.c
+++ b/winpr/libwinpr/utils/collections/ListDictionary.c
@@ -179,7 +179,15 @@ BOOL ListDictionary_Add(wListDictionary* listDictionary, const void* key, void* 
 	if (!item)
 		goto out_error;
 
-	item->key = (void*)key;
+	{
+		union
+		{
+			const void* cpv;
+			void* pv;
+		} cnv;
+		cnv.cpv = key;
+		item->key = cnv.pv;
+	}
 	item->value = value;
 	item->next = NULL;
 

--- a/winpr/libwinpr/utils/trio/trio.c
+++ b/winpr/libwinpr/utils/trio/trio.c
@@ -3001,22 +3001,20 @@ TRIO_PRIVATE void TrioWriteDouble TRIO_ARGS6((self, number, flags, width, precis
 	/* Normal numbers */
 	if (flags & FLAGS_LONGDOUBLE)
 	{
-		baseDigits =
-		    (base == 10) ? LDBL_DIG : (int)trio_floor(LDBL_MANT_DIG / TrioLogarithmBase(base));
+		const trio_long_double_t tmp = trio_floor(LDBL_MANT_DIG / TrioLogarithmBase(base));
+		baseDigits = (base == 10) ? LDBL_DIG : (int)tmp;
 		epsilon = LDBL_EPSILON;
 	}
 	else if (flags & FLAGS_SHORT)
 	{
-		baseDigits = (base == BASE_DECIMAL)
-		                 ? FLT_DIG
-		                 : (int)trio_floor(FLT_MANT_DIG / TrioLogarithmBase(base));
+		const trio_long_double_t tmp = trio_floor(FLT_MANT_DIG / TrioLogarithmBase(base));
+		baseDigits = (base == BASE_DECIMAL) ? FLT_DIG : (int)tmp;
 		epsilon = FLT_EPSILON;
 	}
 	else
 	{
-		baseDigits = (base == BASE_DECIMAL)
-		                 ? DBL_DIG
-		                 : (int)trio_floor(DBL_MANT_DIG / TrioLogarithmBase(base));
+		const trio_long_double_t tmp = trio_floor(DBL_MANT_DIG / TrioLogarithmBase(base));
+		baseDigits = (base == BASE_DECIMAL) ? DBL_DIG : (int)tmp;
 		epsilon = DBL_EPSILON;
 	}
 
@@ -3082,7 +3080,10 @@ reprocess:
 			workNumber = TRIO_FABS(workNumber);
 			if (workNumber - trio_floor(workNumber) < epsilon)
 				workNumber--;
-			leadingFractionZeroes = (int)trio_floor(workNumber);
+			{
+				const trio_long_double_t tmp = trio_floor(workNumber);
+				leadingFractionZeroes = (int)tmp;
+			}
 		}
 	}
 
@@ -3099,7 +3100,8 @@ reprocess:
 		}
 		else
 		{
-			exponent = (int)trio_floor(workNumber);
+			const trio_long_double_t tmp = trio_floor(workNumber);
+			exponent = (int)tmp;
 			workNumber = number;
 			/*
 			 * The expression A * 10^-B is equivalent to A / 10^B but the former
@@ -3139,7 +3141,8 @@ reprocess:
 	integerDigits = 1;
 	if (integerNumber > epsilon)
 	{
-		integerDigits += (int)TrioLogarithm(integerNumber, base);
+		const trio_long_double_t tmp = TrioLogarithm(integerNumber, base);
+		integerDigits += (int)tmp;
 	}
 
 	fractionDigits = precision;
@@ -3162,10 +3165,11 @@ reprocess:
 		workNumber = number * dblFractionBase + TRIO_SUFFIX_LONG(0.5);
 		if (trio_floor(number * dblFractionBase) != trio_floor(workNumber))
 		{
+			const trio_long_double_t tmp1 = TrioLogarithm(number * dblFractionBase, base);
+			const trio_long_double_t tmp2 = TrioLogarithm(workNumber, base);
 			adjustNumber = TRUE;
 			/* Remove a leading fraction zero if fraction is rounded up */
-			if ((int)TrioLogarithm(number * dblFractionBase, base) !=
-			    (int)TrioLogarithm(workNumber, base))
+			if ((int)tmp1 != (int)tmp2)
 			{
 				--leadingFractionZeroes;
 			}
@@ -3218,11 +3222,13 @@ reprocess:
 		{
 			if (workNumber > 1.0)
 			{
+				trio_long_double_t tmp;
 				/* Adjust if number was rounded up one digit (ie. 99 to 100) */
 				integerNumber = trio_floor(workNumber);
 				fractionNumber = 0.0;
-				integerDigits =
-				    (integerNumber > epsilon) ? 1 + (int)TrioLogarithm(integerNumber, base) : 1;
+				tmp = TrioLogarithm(integerNumber, base);
+
+				integerDigits = (integerNumber > epsilon) ? 1 + (int)tmp : 1;
 				if (flags & FLAGS_FLOAT_G)
 				{
 					if (flags & FLAGS_ALTERNATIVE)
@@ -3322,11 +3328,15 @@ reprocess:
 		trailingZeroes = fractionDigits - fractionDigitsInspect;
 		for (i = 0; i < fractionDigitsInspect; i++)
 		{
+			trio_long_double_t tmp;
+
 			workFractionNumber *= dblBase;
 			workFractionAdjust *= dblBase;
 			workNumber = trio_floor(workFractionNumber + workFractionAdjust);
 			workFractionNumber -= workNumber;
-			offset = (int)trio_fmod(workNumber, dblBase);
+
+			tmp = trio_fmod(workNumber, dblBase);
+			offset = (int)tmp;
 			if (offset == 0)
 			{
 				trailingZeroes++;
@@ -3359,10 +3369,9 @@ reprocess:
 	exponentDigits = 0;
 	if (flags & FLAGS_FLOAT_E)
 	{
-		exponentDigits =
-		    (uExponent == 0)
-		        ? 1
-		        : (int)trio_ceil(TrioLogarithm((double)(uExponent + 1), (isHex) ? 10 : base));
+		const trio_long_double_t tmp =
+		    trio_ceil(TrioLogarithm((double)(uExponent + 1), (isHex) ? 10 : base));
+		exponentDigits = (uExponent == 0) ? 1 : (int)tmp;
 	}
 	requireTwoDigitExponent = ((base == BASE_DECIMAL) && (exponentDigits == 1));
 	if (exponentDigits > 0)
@@ -3434,7 +3443,8 @@ reprocess:
 		}
 		else
 		{
-			self->OutStream(self, digits[(int)trio_fmod(workNumber, dblBase)]);
+			const trio_long_double_t tmp = trio_fmod(workNumber, dblBase);
+			self->OutStream(self, digits[(int)tmp]);
 		}
 
 #if TRIO_FEATURE_QUOTE
@@ -3477,6 +3487,7 @@ reprocess:
 		}
 		else
 		{
+			trio_long_double_t tmp;
 			fractionNumber *= dblBase;
 			fractionAdjust *= dblBase;
 			workNumber = trio_floor(fractionNumber + fractionAdjust);
@@ -3490,7 +3501,9 @@ reprocess:
 			{
 				fractionNumber -= workNumber;
 			}
-			offset = (int)trio_fmod(workNumber, dblBase);
+
+			tmp = trio_fmod(workNumber, dblBase);
+			offset = (int)tmp;
 			if (offset == 0)
 			{
 				trailingZeroes++;
@@ -3520,6 +3533,7 @@ reprocess:
 	/* Output exponent */
 	if (exponentDigits > 0)
 	{
+		trio_long_double_t tmp;
 		self->OutStream(self, isHex ? ((flags & FLAGS_UPPER) ? 'P' : 'p')
 		                            : ((flags & FLAGS_UPPER) ? 'E' : 'e'));
 		self->OutStream(self, (isExponentNegative) ? '-' : '+');
@@ -3530,7 +3544,9 @@ reprocess:
 
 		if (isHex)
 			base = 10;
-		exponentBase = (int)TrioPower(base, exponentDigits - 1);
+
+		tmp = TrioPower(base, exponentDigits - 1);
+		exponentBase = (int)tmp;
 		for (i = 0; i < exponentDigits; i++)
 		{
 			self->OutStream(self, digits[(uExponent / exponentBase) % base]);

--- a/winpr/libwinpr/utils/trio/triostr.c
+++ b/winpr/libwinpr/utils/trio/triostr.c
@@ -1032,7 +1032,13 @@ TRIO_PUBLIC_STRING char* trio_substring_max TRIO_ARGS3((string, max, substring),
 		{
 			if (trio_equal_max(substring, size, &string[count]))
 			{
-				result = (char*)&string[count];
+				union
+				{
+					const char* cpv;
+					char* pv;
+				} cnv;
+				cnv.cpv = &string[count];
+				result = cnv.pv;
 				break;
 			}
 		}
@@ -1202,7 +1208,15 @@ TRIO_PUBLIC_STRING trio_long_double_t trio_to_long_double TRIO_ARGS2((source, en
 		value = -value;
 
 	if (endp)
-		*endp = (char*)source;
+	{
+		union
+		{
+			const char* cpv;
+			char* pv;
+		} cnv;
+		cnv.cpv = source;
+		*endp = cnv.pv;
+	}
 	return value;
 #endif
 }

--- a/winpr/libwinpr/utils/wlog/Layout.c
+++ b/winpr/libwinpr/utils/wlog/Layout.c
@@ -86,7 +86,13 @@ BOOL WLog_Layout_GetMessagePrefix(wLog* log, wLogLayout* layout, wLogMessage* me
 			{
 				if ((p[0] == 'l') && (p[1] == 'v')) /* log level */
 				{
-					args[argc++] = (void*)WLOG_LEVELS[message->Level];
+					union
+					{
+						const void* cpv;
+						void* pv;
+					} cnv;
+					cnv.cpv = WLOG_LEVELS[message->Level];
+					args[argc++] = cnv.pv;
 					format[index++] = '%';
 					format[index++] = 's';
 					p++;
@@ -111,14 +117,28 @@ BOOL WLog_Layout_GetMessagePrefix(wLog* log, wLogLayout* layout, wLogMessage* me
 					else
 						file = (const char*)message->FileName;
 
-					args[argc++] = (void*)file;
+					{
+						union
+						{
+							const void* cpv;
+							void* pv;
+						} cnv;
+						cnv.cpv = file;
+						args[argc++] = cnv.pv;
+					}
 					format[index++] = '%';
 					format[index++] = 's';
 					p++;
 				}
 				else if ((p[0] == 'f') && (p[1] == 'n')) /* function */
 				{
-					args[argc++] = (void*)message->FunctionName;
+					union
+					{
+						const void* cpv;
+						void* pv;
+					} cnv;
+					cnv.cpv = message->FunctionName;
+					args[argc++] = cnv.pv;
 					format[index++] = '%';
 					format[index++] = 's';
 					p++;

--- a/winpr/libwinpr/utils/wlog/wlog.c
+++ b/winpr/libwinpr/utils/wlog/wlog.c
@@ -790,16 +790,15 @@ LONG WLog_GetFilterLogLevel(wLog* log)
 
 static BOOL WLog_ParseName(wLog* log, LPCSTR name)
 {
+	const char* cp = name;
 	char* p;
-	size_t count;
+	size_t count = 1;
 	LPSTR names;
-	count = 1;
-	p = (char*)name;
 
-	while ((p = strchr(p, '.')) != NULL)
+	while ((cp = strchr(cp, '.')) != NULL)
 	{
 		count++;
-		p++;
+		cp++;
 	}
 
 	names = _strdup(name);

--- a/winpr/libwinpr/winsock/winsock.c
+++ b/winpr/libwinpr/winsock/winsock.c
@@ -1156,10 +1156,15 @@ int _select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds,
             const struct timeval* timeout)
 {
 	int status;
-
+	union
+	{
+		const struct timeval* cpv;
+		struct timeval* pv;
+	} cnv;
+	cnv.cpv = timeout;
 	do
 	{
-		status = select(nfds, readfds, writefds, exceptfds, (struct timeval*)timeout);
+		status = select(nfds, readfds, writefds, exceptfds, cnv.pv);
 	} while ((status < 0) && (errno == EINTR));
 
 	return status;

--- a/winpr/libwinpr/wtsapi/wtsapi.c
+++ b/winpr/libwinpr/wtsapi/wtsapi.c
@@ -681,7 +681,13 @@ BOOL WTSRegisterWtsApiFunctionTable(const WtsApiFunctionTable* table)
 	/* Use InitOnceExecuteOnce here as well - otherwise a table set with this
 	   function is overriden on the first use of a WTS* API call (due to
 	   wtsapiInitOnce not being set). */
-	InitOnceExecuteOnce(&wtsapiInitOnce, InitializeWtsApiStubs, (PVOID)table, NULL);
+	union
+	{
+		const void* cpv;
+		void* pv;
+	} cnv;
+	cnv.cpv = table;
+	InitOnceExecuteOnce(&wtsapiInitOnce, InitializeWtsApiStubs, cnv.pv, NULL);
 	if (!g_WtsApi)
 		return FALSE;
 	return TRUE;


### PR DESCRIPTION
Eliminate all `const-qual` warnings that we are responsible for (`OpenSSL` related ones stay)