### PR TITLE
Ios

### DIFF
--- a/ci/cmake-preloads/config-ios.txt
+++ b/ci/cmake-preloads/config-ios.txt
@@ -1,5 +1,5 @@
 message("PRELOADING iOS cache")
-set (CMAKE_TOOLCHAIN_FILE "cmake/ios.toolchain.cmake" CACHE PATH "cmake toolchain file")
+set (CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/cmake/ios.toolchain.cmake" CACHE PATH "cmake toolchain file")
 set (FREERDP_IOS_EXTERNAL_SSL_PATH $ENV{FREERDP_IOS_EXTERNAL_SSL_PATH} CACHE PATH "android ssl")
 set (CMAKE_BUILD_TYPE "Debug" CACHE STRING "build type")
 set (CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "iOS platform to build")

--- a/client/iOS/FreeRDP/ios_freerdp.h
+++ b/client/iOS/FreeRDP/ios_freerdp.h
@@ -41,7 +41,9 @@ struct mf_info
 	CGContextRef bitmap_context;
 
 	// Events
-	int event_pipe_producer, event_pipe_consumer;
+	int event_pipe_producer;
+	int event_pipe_consumer;
+	HANDLE handle;
 
 	// Tracking connection state
 	volatile TSXConnectionState connection_state;

--- a/client/iOS/FreeRDP/ios_freerdp_events.h
+++ b/client/iOS/FreeRDP/ios_freerdp_events.h
@@ -18,9 +18,9 @@
 BOOL ios_events_send(mfInfo *mfi, NSDictionary *event_description);
 
 // For connection runloop: use to poll for queued input events
-BOOL ios_events_get_fds(mfInfo *mfi, void **read_fds, int *read_count, void **write_fds,
-                        int *write_count);
-BOOL ios_events_check_fds(mfInfo *mfi, fd_set *rfds);
+HANDLE ios_events_get_handle(mfInfo *mfi);
+BOOL ios_events_check_handle(mfInfo *mfi);
+
 BOOL ios_events_create_pipe(mfInfo *mfi);
 void ios_events_free_pipe(mfInfo *mfi);
 

--- a/client/iOS/FreeRDP/ios_freerdp_events.m
+++ b/client/iOS/FreeRDP/ios_freerdp_events.m
@@ -8,6 +8,8 @@
  http://mozilla.org/MPL/2.0/.
  */
 
+#include <winpr/assert.h>
+
 #include "ios_freerdp_events.h"
 
 #pragma mark -
@@ -18,6 +20,8 @@
 BOOL ios_events_send(mfInfo *mfi, NSDictionary *event_description)
 {
 	NSData *encoded_description = [NSKeyedArchiver archivedDataWithRootObject:event_description];
+
+	WINPR_ASSERT(mfi);
 
 	if ([encoded_description length] > 32000 || (mfi->event_pipe_producer == -1))
 		return FALSE;
@@ -49,24 +53,32 @@ static BOOL ios_events_handle_event(mfInfo *mfi, NSDictionary *event_description
 {
 	NSString *event_type = [event_description objectForKey:@"type"];
 	BOOL should_continue = TRUE;
+	rdpInput *input;
+
+	WINPR_ASSERT(mfi);
+
 	freerdp *instance = mfi->instance;
+	WINPR_ASSERT(instance);
+	WINPR_ASSERT(instance->context);
+
+	input = instance->context->input;
+	WINPR_ASSERT(input);
 
 	if ([event_type isEqualToString:@"mouse"])
 	{
-		instance->input->MouseEvent(
-		    instance->input, [[event_description objectForKey:@"flags"] unsignedShortValue],
-		    [[event_description objectForKey:@"coord_x"] unsignedShortValue],
-		    [[event_description objectForKey:@"coord_y"] unsignedShortValue]);
+		input->MouseEvent(input, [[event_description objectForKey:@"flags"] unsignedShortValue],
+		                  [[event_description objectForKey:@"coord_x"] unsignedShortValue],
+		                  [[event_description objectForKey:@"coord_y"] unsignedShortValue]);
 	}
 	else if ([event_type isEqualToString:@"keyboard"])
 	{
 		if ([[event_description objectForKey:@"subtype"] isEqualToString:@"scancode"])
 			freerdp_input_send_keyboard_event(
-			    instance->input, [[event_description objectForKey:@"flags"] unsignedShortValue],
+			    input, [[event_description objectForKey:@"flags"] unsignedShortValue],
 			    [[event_description objectForKey:@"scancode"] unsignedShortValue]);
 		else if ([[event_description objectForKey:@"subtype"] isEqualToString:@"unicode"])
 			freerdp_input_send_unicode_keyboard_event(
-			    instance->input, [[event_description objectForKey:@"flags"] unsignedShortValue],
+			    input, [[event_description objectForKey:@"flags"] unsignedShortValue],
 			    [[event_description objectForKey:@"unicode_char"] unsignedShortValue]);
 		else
 			NSLog(@"%s: doesn't know how to send keyboard input with subtype %@", __func__,
@@ -80,9 +92,14 @@ static BOOL ios_events_handle_event(mfInfo *mfi, NSDictionary *event_description
 	return should_continue;
 }
 
-BOOL ios_events_check_fds(mfInfo *mfi, fd_set *rfds)
+BOOL ios_events_check_handle(mfInfo *mfi)
 {
-	if ((mfi->event_pipe_consumer == -1) || !FD_ISSET(mfi->event_pipe_consumer, rfds))
+	WINPR_ASSERT(mfi);
+
+	if (WaitForSingleObject(mfi->handle, 0) != WAIT_OBJECT_0)
+		return TRUE;
+
+	if (mfi->event_pipe_consumer == -1)
 		return TRUE;
 
 	uint32_t archived_data_length = 0;
@@ -119,18 +136,18 @@ BOOL ios_events_check_fds(mfInfo *mfi, fd_set *rfds)
 	return ios_events_handle_event(mfi, unarchived_object_data);
 }
 
-BOOL ios_events_get_fds(mfInfo *mfi, void **read_fds, int *read_count, void **write_fds,
-                        int *write_count)
+HANDLE ios_events_get_handle(mfInfo *mfi)
 {
-	read_fds[*read_count] = (void *)(long)(mfi->event_pipe_consumer);
-	(*read_count)++;
-	return TRUE;
+	WINPR_ASSERT(mfi);
+	return mfi->handle;
 }
 
 // Sets up the event pipe
 BOOL ios_events_create_pipe(mfInfo *mfi)
 {
 	int pipe_fds[2];
+
+	WINPR_ASSERT(mfi);
 
 	if (pipe(pipe_fds) == -1)
 	{
@@ -140,14 +157,18 @@ BOOL ios_events_create_pipe(mfInfo *mfi)
 
 	mfi->event_pipe_consumer = pipe_fds[0];
 	mfi->event_pipe_producer = pipe_fds[1];
+	mfi->handle = CreateFileDescriptorEvent(NULL, FALSE, FALSE, mfi->event_pipe_consumer,
+	                                        WINPR_FD_READ | WINPR_FD_WRITE);
 	return TRUE;
 }
 
 void ios_events_free_pipe(mfInfo *mfi)
 {
+	WINPR_ASSERT(mfi);
 	int consumer_fd = mfi->event_pipe_consumer, producer_fd = mfi->event_pipe_producer;
 
 	mfi->event_pipe_consumer = mfi->event_pipe_producer = -1;
 	close(producer_fd);
 	close(consumer_fd);
+	CloseHandle(mfi->handle);
 }

--- a/client/iOS/FreeRDP/ios_freerdp_ui.h
+++ b/client/iOS/FreeRDP/ios_freerdp_ui.h
@@ -16,11 +16,14 @@ BOOL ios_ui_resize_window(rdpContext* context);
 
 BOOL ios_ui_authenticate(freerdp* instance, char** username, char** password, char** domain);
 BOOL ios_ui_gw_authenticate(freerdp* instance, char** username, char** password, char** domain);
-DWORD ios_ui_verify_certificate(freerdp* instance, const char* common_name, const char* subject,
-                                const char* issuer, const char* fingerprint, BOOL host_mismatch);
-DWORD ios_ui_verify_changed_certificate(freerdp* instance, const char* common_name,
-                                        const char* subject, const char* issuer,
-                                        const char* new_fingerprint, const char* old_subject,
-                                        const char* old_issuer, const char* old_fingerprint);
+DWORD ios_ui_verify_certificate_ex(freerdp* instance, const char* host, UINT16 port,
+                                   const char* common_name, const char* subject, const char* issuer,
+                                   const char* fingerprint, DWORD flags);
+
+DWORD ios_ui_verify_changed_certificate_ex(freerdp* instance, const char* host, UINT16 port,
+                                           const char* common_name, const char* subject,
+                                           const char* issuer, const char* fingerprint,
+                                           const char* old_subject, const char* old_issuer,
+                                           const char* old_fingerprint, DWORD flags);
 
 void ios_allocate_display_buffer(mfInfo* mfi);

--- a/client/iOS/FreeRDP/ios_freerdp_ui.m
+++ b/client/iOS/FreeRDP/ios_freerdp_ui.m
@@ -30,8 +30,8 @@ static BOOL ios_ui_authenticate_raw(freerdp *instance, char **username, char **p
 	                                 @"password",
 	                                 (*domain) ? [NSString stringWithUTF8String:*domain] : @"",
 	                                 @"domain",
-	                                 [NSString
-	                                     stringWithUTF8String:instance->settings->ServerHostname],
+	                                 [NSString stringWithUTF8String:instance->context->settings->
+	                                                                ServerHostname],
 	                                 @"hostname", // used for the auth prompt message; not changed
 	                                 nil];
 	// request auth UI
@@ -79,8 +79,9 @@ BOOL ios_ui_gw_authenticate(freerdp *instance, char **username, char **password,
 	return ios_ui_authenticate_raw(instance, username, password, domain, "gateway");
 }
 
-DWORD ios_ui_verify_certificate(freerdp *instance, const char *common_name, const char *subject,
-                                const char *issuer, const char *fingerprint, BOOL host_mismatch)
+DWORD ios_ui_verify_certificate_ex(freerdp *instance, const char *host, UINT16 port,
+                                   const char *common_name, const char *subject, const char *issuer,
+                                   const char *fingerprint, DWORD flags)
 {
 	// check whether we accept all certificates
 	if ([[NSUserDefaults standardUserDefaults] boolForKey:@"security.accept_certificates"] == YES)
@@ -112,13 +113,14 @@ DWORD ios_ui_verify_certificate(freerdp *instance, const char *common_name, cons
 	return 1;
 }
 
-DWORD ios_ui_verify_changed_certificate(freerdp *instance, const char *common_name,
-                                        const char *subject, const char *issuer,
-                                        const char *new_fingerprint, const char *old_subject,
-                                        const char *old_issuer, const char *old_fingerprint)
+DWORD ios_ui_verify_changed_certificate_ex(freerdp *instance, const char *host, UINT16 port,
+                                           const char *common_name, const char *subject,
+                                           const char *issuer, const char *fingerprint,
+                                           const char *old_subject, const char *old_issuer,
+                                           const char *old_fingerprint, DWORD flags)
 {
-	return ios_ui_verify_certificate(instance, common_name, subject, issuer, new_fingerprint,
-	                                 FALSE);
+	return ios_ui_verify_certificate_ex(instance, host, port, common_name, subject, issuer,
+	                                    fingerprint, flags);
 }
 
 #pragma mark -

--- a/client/iOS/Models/RDPSession.m
+++ b/client/iOS/Models/RDPSession.m
@@ -260,7 +260,8 @@ static void freeArguments(int argc, char **argv)
 	if (!addArgument(&argc, &argv, "/kbd:%d", 0x409))
 		goto out_free;
 
-	status = freerdp_client_settings_parse_command_line(_freerdp->settings, argc, argv, FALSE);
+	status =
+	    freerdp_client_settings_parse_command_line(_freerdp->context->settings, argc, argv, FALSE);
 
 	if (0 != status)
 		goto out_free;
@@ -296,7 +297,7 @@ out_free:
 - (void)connect
 {
 	// Set Screen Size to automatic if widht or height are still 0
-	rdpSettings *settings = _freerdp->settings;
+	rdpSettings *settings = _freerdp->context->settings;
 
 	if (settings->DesktopWidth == 0 || settings->DesktopHeight == 0)
 	{
@@ -413,7 +414,7 @@ out_free:
 
 - (rdpSettings *)getSessionParams
 {
-	return _freerdp->settings;
+	return _freerdp->context->settings;
 }
 
 - (NSString *)sessionName

--- a/cmake/ios.toolchain.cmake
+++ b/cmake/ios.toolchain.cmake
@@ -1,261 +1,931 @@
-# This file is based off of the Platform/Darwin.cmake and Platform/UnixPaths.cmake
-# files which are included with CMake 2.8.4
-# It has been altered for iOS development
-
-# Options:
+# This file is part of the ios-cmake project. It was retrieved from
+# https://github.com/leetal/ios-cmake.git, which is a fork of
+# https://github.com/gerstrong/ios-cmake.git, which is a fork of
+# https://github.com/cristeab/ios-cmake.git, which is a fork of
+# https://code.google.com/p/ios-cmake/. Which in turn is based off of
+# the Platform/Darwin.cmake and Platform/UnixPaths.cmake files which
+# are included with CMake 2.8.4
 #
-# IOS_PLATFORM = OS (default) or SIMULATOR
-#   This decides if SDKS will be selected from the iPhoneOS.platform or iPhoneSimulator.platform folders
-#   If not specified, it can be inferred if you pass CMAKE_OSX_ARCHITECTURES
-#	Otherwise the default is OS
-#   OS - used to build for iPhone and iPad physical devices, which have an arm arch.
-#   SIMULATOR - used to build for the Simulator platforms, which have an x86 arch.
+# The ios-cmake project is licensed under the new BSD license.
 #
-# CMAKE_IOS_DEVELOPER_ROOT = automatic(default) or /path/to/platform/Developer folder
-#   By default this location is automatically chosen based on the IOS_PLATFORM value above.
-#   If set manually, it will override the default location and force the user of a particular Developer Platform
+# Copyright (c) 2014, Bogdan Cristea and LTE Engineering Software,
+# Kitware, Inc., Insight Software Consortium.  All rights reserved.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
 #
-# CMAKE_IOS_SDK_ROOT = automatic(default) or /path/to/platform/Developer/SDKs/SDK folder
-#   By default this location is automatcially chosen based on the CMAKE_IOS_DEVELOPER_ROOT value.
-#   In this case it will always be the most up-to-date SDK found in the CMAKE_IOS_DEVELOPER_ROOT path.
-#   If set manually, this will force the use of a specific SDK version
-# This toolchain defines the following variables for use externally:
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
 #
-# IOS_SDK_VERSION: Version of iOS SDK being used.
-# CMAKE_OSX_ARCHITECTURES: Architectures being compiled for (generated from IOS_PLATFORM).
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# This file is based off of the Platform/Darwin.cmake and
+# Platform/UnixPaths.cmake files which are included with CMake 2.8.4
+# It has been altered for iOS development.
+#
+# Updated by Alex Stewart (alexs.mac@gmail.com)
+#
+# *****************************************************************************
+#      Now maintained by Alexander Widerberg (widerbergaren [at] gmail.com)
+#                      under the BSD-3-Clause license
+#                   https://github.com/leetal/ios-cmake
+# *****************************************************************************
+#
+#                           INFORMATION / HELP
+#
+# The following options control the behaviour of this toolchain:
+#
+# PLATFORM: (default "OS64")
+#    OS = Build for iPhoneOS.
+#    OS64 = Build for arm64 iphoneOS.
+#    OS64COMBINED = Build for arm64 x86_64 iphoneOS. Combined into FAT STATIC lib (supported on 3.14+ of CMakewith "-G Xcode" argument ONLY)
+#    SIMULATOR = Build for x86 i386 iphoneOS Simulator.
+#    SIMULATOR64 = Build for x86_64 iphoneOS Simulator.
+#    SIMULATORARM64 = Build for arm64 iphoneOS Simulator.
+#    TVOS = Build for arm64 tvOS.
+#    TVOSCOMBINED = Build for arm64 x86_64 tvOS. Combined into FAT STATIC lib (supported on 3.14+ of CMake with "-G Xcode" argument ONLY)
+#    SIMULATOR_TVOS = Build for x86_64 tvOS Simulator.
+#    WATCHOS = Build for armv7k arm64_32 for watchOS.
+#    WATCHOSCOMBINED = Build for armv7k arm64_32 x86_64 watchOS. Combined into FAT STATIC lib (supported on 3.14+ of CMake with "-G Xcode" argument ONLY)
+#    SIMULATOR_WATCHOS = Build for x86_64 for watchOS Simulator.
+#    MAC = Build for x86_64 macOS.
+#    MAC_ARM64 = Build for Apple Silicon macOS.
+#    MAC_CATALYST = Build for x86_64 macOS with Catalyst support (iOS toolchain on macOS).
+#                   Note: The build argument "MACOSX_DEPLOYMENT_TARGET" can be used to control min-version of macOS
+#    MAC_CATALYST_ARM64 = Build for Apple Silicon macOS with Catalyst support (iOS toolchain on macOS).
+#                         Note: The build argument "MACOSX_DEPLOYMENT_TARGET" can be used to control min-version of macOS
+#
+# CMAKE_OSX_SYSROOT: Path to the SDK to use.  By default this is
+#    automatically determined from PLATFORM and xcodebuild, but
+#    can also be manually specified (although this should not be required).
+#
+# CMAKE_DEVELOPER_ROOT: Path to the Developer directory for the platform
+#    being compiled for.  By default this is automatically determined from
+#    CMAKE_OSX_SYSROOT, but can also be manually specified (although this should
+#    not be required).
+#
+# DEPLOYMENT_TARGET: Minimum SDK version to target. Default 2.0 on watchOS and 9.0 on tvOS+iOS
+#
+# ENABLE_BITCODE: (1|0) Enables or disables bitcode support. Default 1 (true)
+#
+# ENABLE_ARC: (1|0) Enables or disables ARC support. Default 1 (true, ARC enabled by default)
+#
+# ENABLE_VISIBILITY: (1|0) Enables or disables symbol visibility support. Default 0 (false, visibility hidden by default)
+#
+# ENABLE_STRICT_TRY_COMPILE: (1|0) Enables or disables strict try_compile() on all Check* directives (will run linker
+#    to actually check if linking is possible). Default 0 (false, will set CMAKE_TRY_COMPILE_TARGET_TYPE to STATIC_LIBRARY)
+#
+# ARCHS: (armv7 armv7s armv7k arm64 arm64_32 i386 x86_64) If specified, will override the default architectures for the given PLATFORM
+#    OS = armv7 armv7s arm64 (if applicable)
+#    OS64 = arm64 (if applicable)
+#    SIMULATOR = i386
+#    SIMULATOR64 = x86_64
+#    SIMULATORARM64 = arm64
+#    TVOS = arm64
+#    SIMULATOR_TVOS = x86_64 (i386 has since long been deprecated)
+#    WATCHOS = armv7k arm64_32 (if applicable)
+#    SIMULATOR_WATCHOS = x86_64 (i386 has since long been deprecated)
+#    MAC = x86_64
+#    MAC_ARM64 = arm64
+#    MAC_CATALYST = x86_64
+#    MAC_CATALYST_ARM64 = arm64
+#
+# This toolchain defines the following properties (available via get_property()) for use externally:
+#
+# PLATFORM: The currently targeted platform.
+# XCODE_VERSION: Version number (not including Build version) of Xcode detected.
+# SDK_VERSION: Version of SDK being used.
+# OSX_ARCHITECTURES: Architectures being compiled for (generated from PLATFORM).
+# APPLE_TARGET_TRIPLE: Used by autoconf build systems. NOTE: If "ARCHS" are overridden, this will *NOT* be set!
 #
 # This toolchain defines the following macros for use externally:
 #
-# set_xcode_property (TARGET XCODE_PROPERTY XCODE_VALUE)
-#   A convenience macro for setting xcode specific properties on targets
-#   example: set_xcode_property (myioslib IPHONEOS_DEPLOYMENT_TARGET "3.1").
+# set_xcode_property (TARGET XCODE_PROPERTY XCODE_VALUE XCODE_VARIANT)
+#   A convenience macro for setting xcode specific properties on targets.
+#   Available variants are: All, Release, RelWithDebInfo, Debug, MinSizeRel
+#   example: set_xcode_property (myioslib IPHONEOS_DEPLOYMENT_TARGET "3.1" "all").
 #
 # find_host_package (PROGRAM ARGS)
 #   A macro used to find executable programs on the host system, not within the
-#   iOS environment.  Thanks to the android-cmake project for providing the
+#   environment. Thanks to the android-cmake project for providing the
 #   command.
+#
 
-#########
+cmake_minimum_required(VERSION 3.8.0)
 
-# Default to building for iPhoneOS if not specified otherwise, and we cannot
-# determine the platform from the CMAKE_OSX_ARCHITECTURES variable.  The use
-# of CMAKE_OSX_ARCHITECTURES is such that try_compile() projects can correctly
-# determine the value of IOS_PLATFORM from the root project, as
-# CMAKE_OSX_ARCHITECTURES is propagated to them by CMake.
-if (NOT DEFINED IOS_PLATFORM)
-  if (CMAKE_OSX_ARCHITECTURES)
-    if (CMAKE_OSX_ARCHITECTURES MATCHES ".*arm.*")
-      set(IOS_PLATFORM "OS")
-    elseif (CMAKE_OSX_ARCHITECTURES MATCHES "i386")
-      set(IOS_PLATFORM "SIMULATOR")
-    elseif (CMAKE_OSX_ARCHITECTURES MATCHES "x86_64")
-      set(IOS_PLATFORM "SIMULATOR")
-    endif()
-  endif()
-  if (NOT IOS_PLATFORM)
-    set(IOS_PLATFORM "OS")
-  endif()
+# CMake invokes the toolchain file twice during the first build, but only once during subsequent rebuilds.
+if(DEFINED ENV{_IOS_TOOLCHAIN_HAS_RUN})
+  return()
 endif()
-set(IOS_PLATFORM ${IOS_PLATFORM} CACHE STRING
-  "Type of iOS platform for which to build.")
+set(ENV{_IOS_TOOLCHAIN_HAS_RUN} true)
 
-# Check the platform selection and setup for developer root
-if ("${IOS_PLATFORM}" STREQUAL "OS")
-  set (XCODE_PLATFORM iPhoneOS)
-  set (IOS_PLATFORM_LOCATION "iPhoneOS.platform")
-  set (XCODE_IOS_PLATFORM iphoneos)
-  set (IOS_ARCH armv7 armv7s arm64)
+###############################################################################
+#                                  OPTIONS                                    #
+###############################################################################
 
-  # This causes the installers to properly locate the output libraries
-  set (CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphoneos")
-elseif ("${IOS_PLATFORM}" STREQUAL "SIMULATOR")
-  set (SIMULATOR true)
-  set (XCODE_PLATFORM iPhoneSimulator)
-  set (IOS_PLATFORM_LOCATION "iPhoneSimulator.platform")
-  set (XCODE_IOS_PLATFORM iphonesimulator)
-  set (IOS_ARCH i386 x86_64)
+option(DROP_32_BIT "Drops the 32-bit targets universally." YES)
 
-  # This causes the installers to properly locate the output libraries
-  set (CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphonesimulator")
-else ()
-  message (FATAL_ERROR "Unsupported IOS_PLATFORM value selected. Please choose OS or SIMULATOR")
+###############################################################################
+#                                END OPTIONS                                  #
+###############################################################################
+
+# List of supported platform values
+list(APPEND _supported_platforms
+        "OS" "OS64" "OS64COMBINED" "SIMULATOR" "SIMULATOR64" "SIMULATORARM64"
+        "TVOS" "TVOSCOMBINED" "SIMULATOR_TVOS"
+        "WATCHOS" "WATCHOSCOMBINED" "SIMULATOR_WATCHOS"
+        "MAC" "MAC_ARM64"
+        "MAC_CATALYST" "MAC_CATALYST_ARM64")
+
+# Cache what generator is used
+set(USED_CMAKE_GENERATOR "${CMAKE_GENERATOR}")
+
+# Check if using a CMake version capable of building combined FAT builds (simulator and target slices combined in one static lib)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.14")
+  set(MODERN_CMAKE YES)
+endif()
+
+# Get the Xcode version being used.
+# Problem: CMake runs toolchain files multiple times, but can't read cache variables on some runs.
+# Workaround: On first run (in which cache variables are always accessible), set an intermediary environment variable.
+#
+# NOTE: This pattern is used i many places in this toolchain to speed up checks of all sorts
+if(DEFINED XCODE_VERSION_INT)
+  # Environment variables are always preserved.
+  set(ENV{_XCODE_VERSION_INT} "${XCODE_VERSION_INT}")
+elseif(DEFINED ENV{_XCODE_VERSION_INT})
+  set(XCODE_VERSION_INT "$ENV{_XCODE_VERSION_INT}")
+elseif(NOT DEFINED XCODE_VERSION_INT)
+  find_program(XCODEBUILD_EXECUTABLE xcodebuild)
+  if(NOT XCODEBUILD_EXECUTABLE)
+    message(FATAL_ERROR "xcodebuild not found. Please install either the standalone commandline tools or Xcode.")
+  endif()
+  execute_process(COMMAND ${XCODEBUILD_EXECUTABLE} -version
+          OUTPUT_VARIABLE XCODE_VERSION_INT
+          ERROR_QUIET
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REGEX MATCH "Xcode [0-9\\.]+" XCODE_VERSION_INT "${XCODE_VERSION_INT}")
+  string(REGEX REPLACE "Xcode ([0-9\\.]+)" "\\1" XCODE_VERSION_INT "${XCODE_VERSION_INT}")
+  set(XCODE_VERSION_INT "${XCODE_VERSION_INT}" CACHE INTERNAL "")
+endif()
+
+# Assuming that xcode 12.0 is installed you most probably have ios sdk 14.0 or later installed (tested on Big Sur)
+# if you don't set a deployment target it will be set the way you only get 64-bit builds
+if(NOT DEFINED DEPLOYMENT_TARGET AND XCODE_VERSION_INT VERSION_GREATER 12.0)
+  # Temporarily fix the arm64 issues in CMake install-combined by excluding arm64 for simulator builds (needed for Apple Silicon...)
+  set(CMAKE_XCODE_ATTRIBUTE_EXCLUDED_ARCHS[sdk=iphonesimulator*] "arm64")
+endif()
+
+# Check if the platform variable is set
+if(DEFINED PLATFORM)
+  # Environment variables are always preserved.
+  set(ENV{_PLATFORM} "${PLATFORM}")
+elseif(DEFINED ENV{_PLATFORM})
+  set(PLATFORM "$ENV{_PLATFORM}")
+elseif(NOT DEFINED PLATFORM)
+  message(FATAL_ERROR "PLATFORM argument not set. Bailing configure since I don't know what target you want to build for!")
 endif ()
 
-# Set the architectures for which to build.
-if(NOT DEFINED CMAKE_OSX_ARCHITECTURES)
-  set(CMAKE_OSX_ARCHITECTURES ${IOS_ARCH})
-endif()
-message(STATUS "Configuring iOS build for ${CMAKE_OSX_ARCHITECTURES} architectures")
-set(CMAKE_OSX_ARCHITECTURES ${CMAKE_OSX_ARCHITECTURES} CACHE STRING "Build architecture for iOS")
-
-# Setup iOS developer location unless specified manually with CMAKE_IOS_DEVELOPER_ROOT
-if (NOT DEFINED CMAKE_IOS_DEVELOPER_ROOT)
-    set (CMAKE_IOS_DEVELOPER_ROOT "/Applications/Xcode.app/Contents/Developer/Platforms/${IOS_PLATFORM_LOCATION}/Developer")
-endif ()
-set (CMAKE_IOS_DEVELOPER_ROOT ${CMAKE_IOS_DEVELOPER_ROOT} CACHE PATH "Location of iOS Platform")
-
-# Find and use the most recent iOS sdk unless specified manually with CMAKE_IOS_SDK_ROOT
-if (NOT DEFINED CMAKE_IOS_SDK_ROOT)
-  file (GLOB _CMAKE_IOS_SDKS "${CMAKE_IOS_DEVELOPER_ROOT}/SDKs/*")
-  if (_CMAKE_IOS_SDKS)
-    list (SORT _CMAKE_IOS_SDKS)
-    list (REVERSE _CMAKE_IOS_SDKS)
-    list (GET _CMAKE_IOS_SDKS 0 CMAKE_IOS_SDK_ROOT)
-  else ()
-    message (FATAL_ERROR "No iOS SDKs found in default search path ${CMAKE_IOS_DEVELOPER_ROOT}. Manually set CMAKE_IOS_SDK_ROOT or install the iOS SDK.")
-  endif ()
-  message (STATUS "Toolchain using default iOS SDK: ${CMAKE_IOS_SDK_ROOT}")
-endif ()
-set (CMAKE_IOS_SDK_ROOT ${CMAKE_IOS_SDK_ROOT} CACHE PATH "Location of the selected iOS SDK")
-
-# Get the SDK version information.
-execute_process(COMMAND xcodebuild -sdk ${CMAKE_IOS_SDK_ROOT} -version SDKVersion
-  OUTPUT_VARIABLE IOS_SDK_VERSION
-  ERROR_QUIET
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-execute_process(COMMAND xcode-select -p OUTPUT_VARIABLE XCODE_DEVELOPER_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
-set(XCODE_CPP_INCLUDE_DIR "${XCODE_DEVELOPER_DIR}/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1")
-set(XCODE_SDK_INCLUDE_DIR "${XCODE_DEVELOPER_DIR}/Platforms/${XCODE_PLATFORM}.platform/Developer/SDKs/${XCODE_PLATFORM}.sdk/usr/include")
-
-set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES "${XCODE_CPP_INCLUDE_DIR}")
-include_directories(BEFORE SYSTEM "${XCODE_SDK_INCLUDE_DIR}")
-
-set (CMAKE_OSX_SYSROOT ${XCODE_IOS_PLATFORM})
-
-# Specify minimum version of deployment target.
-# Unless specified, the latest SDK version is used by default.
-if(NOT DEFINED IOS_DEPLOYMENT_TARGET)
-  if(DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
-    set(IOS_DEPLOYMENT_TARGET "${CMAKE_OSX_DEPLOYMENT_TARGET}" CACHE STRING "minimum iOS deployment target")
-  else()
-	 set(IOS_DEPLOYMENT_TARGET "${IOS_SDK_VERSION}" CACHE STRING "minimum iOS deployment target")
-  endif()
+if(PLATFORM MATCHES ".*COMBINED" AND NOT CMAKE_GENERATOR MATCHES "Xcode")
+  message(FATAL_ERROR "The combined builds support requires Xcode to be used as generator via '-G Xcode' command-line argument in CMake")
 endif()
 
-set(XCODE_IOS_PLATFORM_VERSION_FLAGS "-m${XCODE_IOS_PLATFORM}-version-min=${IOS_DEPLOYMENT_TARGET}")
-
-if(CMAKE_GENERATOR MATCHES "Xcode")
-    set(CMAKE_XCODE_ATTRIBUTE_ARCHS "${IOS_ARCH}")
-    set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "${IOS_DEPLOYMENT_TARGET}")
+# Safeguard that the platform value is set and is one of the supported values
+list(FIND _supported_platforms ${PLATFORM} contains_PLATFORM)
+if("${contains_PLATFORM}" EQUAL "-1")
+  string(REPLACE ";"  "\n * " _supported_platforms_formatted "${_supported_platforms}")
+  message(FATAL_ERROR " Invalid PLATFORM specified! Current value: ${PLATFORM}.\n"
+          " Supported PLATFORM values: \n * ${_supported_platforms_formatted}")
 endif()
 
-message(STATUS "Building for minimum iOS version: ${IOS_DEPLOYMENT_TARGET}"
-               " (SDK version: ${IOS_SDK_VERSION})")
-
-# Standard settings
-set (CMAKE_SYSTEM_NAME Darwin)
-set (CMAKE_SYSTEM_VERSION ${IOS_SDK_VERSION})
-set (UNIX TRUE)
-set (APPLE TRUE)
-set (IOS TRUE)
-set (APPLE_IOS TRUE)
-
-# Force unset of OS X-specific deployment target (otherwise autopopulated), required as of cmake 2.8.10.
-set(CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "Must be empty for iOS builds." FORCE)
-
-# Find the C & C++ compilers for the specified SDK.
-if (NOT CMAKE_C_COMPILER)
-  execute_process(COMMAND xcrun -sdk ${CMAKE_IOS_SDK_ROOT} -find clang
-    OUTPUT_VARIABLE CMAKE_C_COMPILER
-    ERROR_QUIET
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif()
-if (NOT CMAKE_CXX_COMPILER)
-  execute_process(COMMAND xcrun -sdk ${CMAKE_IOS_SDK_ROOT} -find clang++
-    OUTPUT_VARIABLE CMAKE_CXX_COMPILER
-    ERROR_QUIET
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+# Check if Apple Silicon is supported
+if(PLATFORM MATCHES "^(MAC_ARM64)$|^(MAC_CATALYST_ARM64)$" AND ${CMAKE_VERSION} VERSION_LESS "3.19.5")
+  message(FATAL_ERROR "Apple Silicon builds requires a minimum of CMake 3.19.5")
 endif()
 
-set(CMAKE_CXX_COMPILER_FORCED TRUE)
-set(CMAKE_CXX_COMPILER_WORKS TRUE)
-set(CMAKE_C_COMPILER_FORCED TRUE)
-set(CMAKE_C_COMPILER_WORKS TRUE)
+# Touch toolchain variable to suppress "unused variable" warning.
+# This happens if CMake is invoked with the same command line the second time.
+if(CMAKE_TOOLCHAIN_FILE)
+endif()
 
-# Hack: if a new cmake (which uses CMAKE_INSTALL_NAME_TOOL) runs on an old
-# build tree (where install_name_tool was hardcoded) and where
-# CMAKE_INSTALL_NAME_TOOL isn't in the cache and still cmake didn't fail in
-# CMakeFindBinUtils.cmake (because it isn't rerun) hardcode
-# CMAKE_INSTALL_NAME_TOOL here to install_name_tool, so it behaves as it did
-# before
-if (NOT DEFINED CMAKE_INSTALL_NAME_TOOL)
-  find_program(CMAKE_INSTALL_NAME_TOOL install_name_tool)
-endif (NOT DEFINED CMAKE_INSTALL_NAME_TOOL)
-
-# All iOS/Darwin specific settings - some may be redundant.
-set(CMAKE_SHARED_LIBRARY_PREFIX "lib")
-set(CMAKE_SHARED_LIBRARY_SUFFIX ".dylib")
-set(CMAKE_SHARED_MODULE_PREFIX "lib")
-set(CMAKE_SHARED_MODULE_SUFFIX ".so")
-set(CMAKE_MODULE_EXISTS 1)
-set(CMAKE_DL_LIBS "")
-
-set(CMAKE_C_OSX_COMPATIBILITY_VERSION_FLAG "-compatibility_version ")
-set(CMAKE_C_OSX_CURRENT_VERSION_FLAG "-current_version ")
-set(CMAKE_CXX_OSX_COMPATIBILITY_VERSION_FLAG "${CMAKE_C_OSX_COMPATIBILITY_VERSION_FLAG}")
-set(CMAKE_CXX_OSX_CURRENT_VERSION_FLAG "${CMAKE_C_OSX_CURRENT_VERSION_FLAG}")
-
-# Force variables set by FindThreads.cmake
+# Fix for PThread library not in path
 set(CMAKE_THREAD_LIBS_INIT "-lpthread")
 set(CMAKE_HAVE_THREADS_LIBRARY 1)
 set(CMAKE_USE_WIN32_THREADS_INIT 0)
 set(CMAKE_USE_PTHREADS_INIT 1)
 
-# change default target type for try_compile() calls (iOS doesn't support executable targets)
-set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+# Specify minimum version of deployment target.
+if(NOT DEFINED DEPLOYMENT_TARGET)
+  if (PLATFORM MATCHES "WATCHOS")
+    # Unless specified, SDK version 4.0 is used by default as minimum target version (watchOS).
+    set(DEPLOYMENT_TARGET "4.0")
+  elseif(PLATFORM STREQUAL "MAC")
+    # Unless specified, SDK version 10.13 (High sierra) is used by default as minimum target version (macos).
+    set(DEPLOYMENT_TARGET "10.13")
+  elseif(PLATFORM STREQUAL "MAC_ARM64")
+    # Unless specified, SDK version 11.0 (Big Sur) is used by default as minimum target version (macos on arm).
+    set(DEPLOYMENT_TARGET "11.0")
+  elseif(PLATFORM STREQUAL "MAC_CATALYST" OR PLATFORM STREQUAL "MAC_CATALYST_ARM64")
+    # Unless specified, SDK version 13.0 is used by default as minimum target version (mac catalyst minimum requirement).
+    set(DEPLOYMENT_TARGET "13.0")
+  else()
+    # Unless specified, SDK version 11.0 is used by default as minimum target version (iOS, tvOS).
+    set(DEPLOYMENT_TARGET "11.0")
+  endif()
+  message(STATUS "[DEFAULTS] Using the default min-version since DEPLOYMENT_TARGET not provided!")
+elseif(DEFINED DEPLOYMENT_TARGET AND PLATFORM MATCHES "^MAC_CATALYST" AND ${DEPLOYMENT_TARGET} VERSION_LESS "13.0")
+  message(FATAL_ERROR "Mac Catalyst builds requires a minimum deployment target of 13.0!")
+endif()
 
-# Hidden visibilty is required for cxx on iOS 
-set(CMAKE_C_FLAGS_INIT "")
-set(CMAKE_C_FLAGS "${XCODE_IOS_PLATFORM_VERSION_FLAGS} ${CMAKE_C_FLAGS}" CACHE STRING "" FORCE)
-set(CMAKE_CXX_FLAGS_INIT "")
-set(CMAKE_CXX_FLAGS "${XCODE_IOS_PLATFORM_VERSION_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden ${CMAKE_CXX_FLAGS}" CACHE STRING "" FORCE)
+# Store the DEPLOYMENT_TARGET in the cache
+set(DEPLOYMENT_TARGET "${DEPLOYMENT_TARGET}" CACHE INTERNAL "")
 
-set(CMAKE_C_LINK_FLAGS "-Wl,-search_paths_first ${CMAKE_C_LINK_FLAGS}")
-set(CMAKE_CXX_LINK_FLAGS "-Wl,-search_paths_first ${CMAKE_CXX_LINK_FLAGS}")
+# Handle the case where we are targeting iOS and a version above 10.3.4 (32-bit support dropped officially)
+if(PLATFORM STREQUAL "OS" AND DEPLOYMENT_TARGET VERSION_GREATER_EQUAL 10.3.4)
+  set(PLATFORM "OS64")
+  message(STATUS "Targeting minimum SDK version ${DEPLOYMENT_TARGET}. Dropping 32-bit support.")
+elseif(PLATFORM STREQUAL "SIMULATOR" AND DEPLOYMENT_TARGET VERSION_GREATER_EQUAL 10.3.4)
+  set(PLATFORM "SIMULATOR64")
+  message(STATUS "Targeting minimum SDK version ${DEPLOYMENT_TARGET}. Dropping 32-bit support.")
+endif()
+
+set(PLATFORM_INT "${PLATFORM}")
+
+if(DEFINED ARCHS)
+  string(REPLACE ";" "-" ARCHS_SPLIT "${ARCHS}")
+endif()
+
+# Determine the platform name and architectures for use in xcodebuild commands
+# from the specified PLATFORM_INT name.
+if(PLATFORM_INT STREQUAL "OS")
+  set(SDK_NAME iphoneos)
+  if(NOT ARCHS)
+    set(ARCHS armv7 armv7s arm64)
+    set(APPLE_TARGET_TRIPLE_INT arm-apple-ios$${DEPLOYMENT_TARGET})
+  else()
+    set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-ios${DEPLOYMENT_TARGET})  
+  endif()
+elseif(PLATFORM_INT STREQUAL "OS64")
+  set(SDK_NAME iphoneos)
+  if(NOT ARCHS)
+    if (XCODE_VERSION_INT VERSION_GREATER 10.0)
+      set(ARCHS arm64) # Add arm64e when Apple have fixed the integration issues with it, libarclite_iphoneos.a is currently missung bitcode markers for example
+    else()
+      set(ARCHS arm64)
+    endif()
+    set(APPLE_TARGET_TRIPLE_INT aarch64-apple-ios${DEPLOYMENT_TARGET})
+  else()
+    set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-ios${DEPLOYMENT_TARGET})
+  endif()
+elseif(PLATFORM_INT STREQUAL "OS64COMBINED")
+  set(SDK_NAME iphoneos)
+  if(MODERN_CMAKE)
+    if(NOT ARCHS)
+      if (XCODE_VERSION_INT VERSION_GREATER 10.0)
+        set(ARCHS arm64 x86_64) # Add arm64e when Apple have fixed the integration issues with it, libarclite_iphoneos.a is currently missung bitcode markers for example
+        set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=iphoneos*] "arm64")
+        set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=iphonesimulator*] "x86_64")
+        set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=iphoneos*] "arm64")
+        set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=iphonesimulator*] "x86_64")
+      else()
+        set(ARCHS arm64 x86_64)
+        set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=iphoneos*] "arm64")
+        set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=iphonesimulator*] "x86_64")
+        set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=iphoneos*] "arm64")
+        set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=iphonesimulator*] "x86_64")
+      endif()
+      set(APPLE_TARGET_TRIPLE_INT aarch64-x86_64-apple-ios${DEPLOYMENT_TARGET})
+    else()
+      set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-ios${DEPLOYMENT_TARGET})
+    endif()
+  else()
+    message(FATAL_ERROR "Please make sure that you are running CMake 3.14+ to make the OS64COMBINED setting work")
+  endif()
+elseif(PLATFORM_INT STREQUAL "SIMULATOR")
+  set(SDK_NAME iphonesimulator)
+  if(NOT ARCHS)
+    set(ARCHS i386)
+    set(APPLE_TARGET_TRIPLE_INT i386-apple-ios${DEPLOYMENT_TARGET}-simulator)
+  else()
+    set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-ios${DEPLOYMENT_TARGET}-simulator)
+  endif()
+  message(DEPRECATION "SIMULATOR IS DEPRECATED. Consider using SIMULATOR64 instead.")
+elseif(PLATFORM_INT STREQUAL "SIMULATOR64")
+  set(SDK_NAME iphonesimulator)
+  if(NOT ARCHS)
+    set(ARCHS x86_64)
+    set(APPLE_TARGET_TRIPLE_INT x86_64-apple-ios${DEPLOYMENT_TARGET}-simulator)
+  else()
+    set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-ios${DEPLOYMENT_TARGET}-simulator)
+  endif()
+elseif(PLATFORM_INT STREQUAL "SIMULATORARM64")
+  set(SDK_NAME iphonesimulator)
+  if(NOT ARCHS)
+    set(ARCHS arm64)
+    set(APPLE_TARGET_TRIPLE_INT aarch64-apple-ios${DEPLOYMENT_TARGET}-simulator)
+  else()
+    set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-ios${DEPLOYMENT_TARGET}-simulator)
+  endif()
+elseif(PLATFORM_INT STREQUAL "TVOS")
+  set(SDK_NAME appletvos)
+  if(NOT ARCHS)
+    set(ARCHS arm64)
+    set(APPLE_TARGET_TRIPLE_INT aarch64-apple-tvos${DEPLOYMENT_TARGET})
+  else()
+    set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-tvos${DEPLOYMENT_TARGET})
+  endif()
+elseif (PLATFORM_INT STREQUAL "TVOSCOMBINED")
+  set(SDK_NAME appletvos)
+  if(MODERN_CMAKE)
+    if(NOT ARCHS)
+      set(ARCHS arm64 x86_64)
+      set(APPLE_TARGET_TRIPLE_INT aarch64-x86_64-apple-tvos${DEPLOYMENT_TARGET})
+      set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=appletvos*] "arm64")
+      set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=appletvsimulator*] "x86_64")
+      set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=appletvos*] "arm64")
+      set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=appletvsimulator*] "x86_64")
+    else()
+      set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-tvos${DEPLOYMENT_TARGET})
+    endif()
+  else()
+    message(FATAL_ERROR "Please make sure that you are running CMake 3.14+ to make the TVOSCOMBINED setting work")
+  endif()
+elseif(PLATFORM_INT STREQUAL "SIMULATOR_TVOS")
+  set(SDK_NAME appletvsimulator)
+  if(NOT ARCHS)
+    set(ARCHS x86_64)
+    set(APPLE_TARGET_TRIPLE_INT x86_64-apple-tvos${DEPLOYMENT_TARGET}-simulator)
+  else()
+    set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-tvos${DEPLOYMENT_TARGET}-simulator)
+  endif()
+elseif(PLATFORM_INT STREQUAL "WATCHOS")
+  set(SDK_NAME watchos)
+  if(NOT ARCHS)
+    if (XCODE_VERSION_INT VERSION_GREATER 10.0)
+      set(ARCHS armv7k arm64_32)
+      set(APPLE_TARGET_TRIPLE_INT aarch64_32-apple-watchos${DEPLOYMENT_TARGET})
+    else()
+      set(ARCHS armv7k)
+      set(APPLE_TARGET_TRIPLE_INT arm-apple-watchos${DEPLOYMENT_TARGET})
+    endif()
+  else()
+    set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-watchos${DEPLOYMENT_TARGET})
+  endif()
+elseif(PLATFORM_INT STREQUAL "WATCHOSCOMBINED")
+  set(SDK_NAME watchos)
+  if(MODERN_CMAKE)
+    if(NOT ARCHS)
+      if (XCODE_VERSION_INT VERSION_GREATER 10.0)
+        set(ARCHS armv7k arm64_32 i386)
+        set(APPLE_TARGET_TRIPLE_INT aarch64_32-i386-apple-watchos${DEPLOYMENT_TARGET})
+        set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=watchos*] "armv7k arm64_32")
+        set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=watchsimulator*] "i386")
+        set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=watchos*] "armv7k arm64_32")
+        set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=watchsimulator*] "i386")
+      else()
+        set(ARCHS armv7k i386)
+        set(APPLE_TARGET_TRIPLE_INT arm-i386-apple-watchos${DEPLOYMENT_TARGET})
+        set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=watchos*] "armv7k")
+        set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=watchsimulator*] "i386")
+        set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=watchos*] "armv7k")
+        set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=watchsimulator*] "i386")
+      endif()
+    else()
+      set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-watchos${DEPLOYMENT_TARGET})
+    endif()
+  else()
+    message(FATAL_ERROR "Please make sure that you are running CMake 3.14+ to make the WATCHOSCOMBINED setting work")
+  endif()
+elseif(PLATFORM_INT STREQUAL "SIMULATOR_WATCHOS")
+  set(SDK_NAME watchsimulator)
+  if(NOT ARCHS)
+    set(ARCHS i386)
+    set(APPLE_TARGET_TRIPLE_INT i386-apple-watchos${DEPLOYMENT_TARGET}-simulator)
+  else()
+    set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-watchos${DEPLOYMENT_TARGET}-simulator)
+  endif()
+elseif(PLATFORM_INT STREQUAL "MAC" OR PLATFORM_INT STREQUAL "MAC_CATALYST")
+  set(SDK_NAME macosx)
+  if(NOT ARCHS)
+    set(ARCHS x86_64)
+  endif()
+  string(REPLACE ";" "-" ARCHS_SPLIT "${ARCHS}")
+  if(PLATFORM_INT STREQUAL "MAC")
+    set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-macosx${DEPLOYMENT_TARGET})
+  elseif(PLATFORM_INT STREQUAL "MAC_CATALYST")
+    set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-ios${DEPLOYMENT_TARGET}-macabi)
+  endif()
+elseif(PLATFORM_INT MATCHES "^(MAC_ARM64)$|^(MAC_CATALYST_ARM64)$")
+  set(SDK_NAME macosx)
+  if(NOT ARCHS)
+    set(ARCHS arm64)
+  endif()
+  string(REPLACE ";" "-" ARCHS_SPLIT "${ARCHS}")
+  if(PLATFORM_INT STREQUAL "MAC_ARM64")
+    set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-macosx${DEPLOYMENT_TARGET})
+  elseif(PLATFORM_INT STREQUAL "MAC_CATALYST_ARM64")
+    set(APPLE_TARGET_TRIPLE_INT ${ARCHS_SPLIT}-apple-ios${DEPLOYMENT_TARGET}-macabi)
+  endif()
+else()
+  message(FATAL_ERROR "Invalid PLATFORM: ${PLATFORM_INT}")
+endif()
+
+if(MODERN_CMAKE AND PLATFORM_INT MATCHES ".*COMBINED" AND NOT CMAKE_GENERATOR MATCHES "Xcode")
+  message(FATAL_ERROR "The COMBINED options only work with Xcode generator, -G Xcode")
+endif()
+
+if(CMAKE_GENERATOR MATCHES "Xcode" AND PLATFORM_INT MATCHES "^MAC_CATALYST")
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+  set(CMAKE_XCODE_ATTRIBUTE_SUPPORTED_PLATFORMS "macosx")
+  set(CMAKE_XCODE_EFFECTIVE_PLATFORMS "-maccatalyst")
+  if(NOT DEFINED MACOSX_DEPLOYMENT_TARGET)
+    set(CMAKE_XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "10.15")
+  else()
+    set(CMAKE_XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "${MACOSX_DEPLOYMENT_TARGET}")
+  endif()
+elseif(CMAKE_GENERATOR MATCHES "Xcode")
+  set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "${DEPLOYMENT_TARGET}")
+  if(NOT PLATFORM_INT MATCHES ".*COMBINED")
+    set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=${SDK_NAME}*] "${ARCHS}")
+    set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=${SDK_NAME}*] "${ARCHS}")
+  endif()
+endif()
+
+# If user did not specify the SDK root to use, then query xcodebuild for it.
+if(DEFINED CMAKE_OSX_SYSROOT_INT)
+  # Environment variables are always preserved.
+  set(ENV{_CMAKE_OSX_SYSROOT_INT} "${CMAKE_OSX_SYSROOT_INT}")
+elseif(DEFINED ENV{_CMAKE_OSX_SYSROOT_INT})
+  set(CMAKE_OSX_SYSROOT_INT "$ENV{_CMAKE_OSX_SYSROOT_INT}")
+elseif(NOT DEFINED CMAKE_OSX_SYSROOT_INT)
+  execute_process(COMMAND ${XCODEBUILD_EXECUTABLE} -version -sdk ${SDK_NAME} Path
+          OUTPUT_VARIABLE CMAKE_OSX_SYSROOT_INT
+          ERROR_QUIET
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+if (NOT DEFINED CMAKE_OSX_SYSROOT_INT AND NOT DEFINED CMAKE_OSX_SYSROOT)
+  message(SEND_ERROR "Please make sure that Xcode is installed and that the toolchain"
+          "is pointing to the correct path. Please run:"
+          "sudo xcode-select -s /Applications/Xcode.app/Contents/Developer"
+          "and see if that fixes the problem for you.")
+  message(FATAL_ERROR "Invalid CMAKE_OSX_SYSROOT: ${CMAKE_OSX_SYSROOT} "
+          "does not exist.")
+elseif(DEFINED CMAKE_OSX_SYSROOT_INT)
+  set(CMAKE_OSX_SYSROOT_INT "${CMAKE_OSX_SYSROOT_INT}" CACHE INTERNAL "")
+  # Specify the location or name of the platform SDK to be used in CMAKE_OSX_SYSROOT.
+  set(CMAKE_OSX_SYSROOT "${CMAKE_OSX_SYSROOT_INT}" CACHE INTERNAL "")
+endif()
+
+# Use bitcode or not
+if(NOT DEFINED ENABLE_BITCODE AND NOT ARCHS MATCHES "((^|;|, )(i386|x86_64))+")
+  # Unless specified, enable bitcode support by default
+  message(STATUS "[DEFAULTS] Enabling bitcode support by default. ENABLE_BITCODE not provided!")
+  set(ENABLE_BITCODE TRUE)
+elseif(NOT DEFINED ENABLE_BITCODE)
+  message(STATUS "[DEFAULTS] Disabling bitcode support by default on simulators. ENABLE_BITCODE not provided for override!")
+  set(ENABLE_BITCODE FALSE)
+endif()
+set(ENABLE_BITCODE_INT ${ENABLE_BITCODE} CACHE BOOL
+        "Whether or not to enable bitcode" FORCE)
+# Use ARC or not
+if(NOT DEFINED ENABLE_ARC)
+  # Unless specified, enable ARC support by default
+  set(ENABLE_ARC TRUE)
+  message(STATUS "[DEFAULTS] Enabling ARC support by default. ENABLE_ARC not provided!")
+endif()
+set(ENABLE_ARC_INT ${ENABLE_ARC} CACHE BOOL "Whether or not to enable ARC" FORCE)
+# Use hidden visibility or not
+if(NOT DEFINED ENABLE_VISIBILITY)
+  # Unless specified, disable symbols visibility by default
+  set(ENABLE_VISIBILITY FALSE)
+  message(STATUS "[DEFAULTS] Hiding symbols visibility by default. ENABLE_VISIBILITY not provided!")
+endif()
+set(ENABLE_VISIBILITY_INT ${ENABLE_VISIBILITY} CACHE BOOL "Whether or not to hide symbols from the dynamic linker (-fvisibility=hidden)" FORCE)
+# Set strict compiler checks or not
+if(NOT DEFINED ENABLE_STRICT_TRY_COMPILE)
+  # Unless specified, disable strict try_compile()
+  set(ENABLE_STRICT_TRY_COMPILE FALSE)
+  message(STATUS "[DEFAULTS] Using NON-strict compiler checks by default. ENABLE_STRICT_TRY_COMPILE not provided!")
+endif()
+set(ENABLE_STRICT_TRY_COMPILE_INT ${ENABLE_STRICT_TRY_COMPILE} CACHE BOOL
+        "Whether or not to use strict compiler checks" FORCE)
+
+# Get the SDK version information.
+if(DEFINED SDK_VERSION)
+  # Environment variables are always preserved.
+  set(ENV{_SDK_VERSION} "${SDK_VERSION}")
+elseif(DEFINED ENV{_SDK_VERSION})
+  set(SDK_VERSION "$ENV{_SDK_VERSION}")
+elseif(NOT DEFINED SDK_VERSION)
+  execute_process(COMMAND ${XCODEBUILD_EXECUTABLE} -sdk ${CMAKE_OSX_SYSROOT_INT} -version SDKVersion
+          OUTPUT_VARIABLE SDK_VERSION
+          ERROR_QUIET
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+# Find the Developer root for the specific iOS platform being compiled for
+# from CMAKE_OSX_SYSROOT.  Should be ../../ from SDK specified in
+# CMAKE_OSX_SYSROOT. There does not appear to be a direct way to obtain
+# this information from xcrun or xcodebuild.
+if (NOT DEFINED CMAKE_DEVELOPER_ROOT AND NOT CMAKE_GENERATOR MATCHES "Xcode")
+  get_filename_component(PLATFORM_SDK_DIR ${CMAKE_OSX_SYSROOT_INT} PATH)
+  get_filename_component(CMAKE_DEVELOPER_ROOT ${PLATFORM_SDK_DIR} PATH)
+  if (NOT EXISTS "${CMAKE_DEVELOPER_ROOT}")
+    message(FATAL_ERROR "Invalid CMAKE_DEVELOPER_ROOT: ${CMAKE_DEVELOPER_ROOT} does not exist.")
+  endif()
+endif()
+
+# Find the C & C++ compilers for the specified SDK.
+if(DEFINED CMAKE_C_COMPILER)
+  # Environment variables are always preserved.
+  set(ENV{_CMAKE_C_COMPILER} "${CMAKE_C_COMPILER}")
+elseif(DEFINED ENV{_CMAKE_C_COMPILER})
+  set(CMAKE_C_COMPILER "$ENV{_CMAKE_C_COMPILER}")
+  set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+elseif(NOT DEFINED CMAKE_C_COMPILER)
+  execute_process(COMMAND xcrun -sdk ${CMAKE_OSX_SYSROOT_INT} -find clang
+          OUTPUT_VARIABLE CMAKE_C_COMPILER
+          ERROR_QUIET
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+endif()
+if(DEFINED CMAKE_CXX_COMPILER)
+  # Environment variables are always preserved.
+  set(ENV{_CMAKE_CXX_COMPILER} "${CMAKE_CXX_COMPILER}")
+elseif(DEFINED ENV{_CMAKE_CXX_COMPILER})
+  set(CMAKE_CXX_COMPILER "$ENV{_CMAKE_CXX_COMPILER}")
+elseif(NOT DEFINED CMAKE_CXX_COMPILER)
+  execute_process(COMMAND xcrun -sdk ${CMAKE_OSX_SYSROOT_INT} -find clang++
+          OUTPUT_VARIABLE CMAKE_CXX_COMPILER
+          ERROR_QUIET
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+# Find (Apple's) libtool.
+if(DEFINED BUILD_LIBTOOL)
+  # Environment variables are always preserved.
+  set(ENV{_BUILD_LIBTOOL} "${BUILD_LIBTOOL}")
+elseif(DEFINED ENV{_BUILD_LIBTOOL})
+  set(BUILD_LIBTOOL "$ENV{_BUILD_LIBTOOL}")
+elseif(NOT DEFINED BUILD_LIBTOOL)
+  execute_process(COMMAND xcrun -sdk ${CMAKE_OSX_SYSROOT_INT} -find libtool
+          OUTPUT_VARIABLE BUILD_LIBTOOL
+          ERROR_QUIET
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+# Find the toolchain's provided install_name_tool if none is found on the host
+if(DEFINED CMAKE_INSTALL_NAME_TOOL)
+  # Environment variables are always preserved.
+  set(ENV{_CMAKE_INSTALL_NAME_TOOL} "${CMAKE_INSTALL_NAME_TOOL}")
+elseif(DEFINED ENV{_CMAKE_INSTALL_NAME_TOOL})
+  set(CMAKE_INSTALL_NAME_TOOL "$ENV{_CMAKE_INSTALL_NAME_TOOL}")
+elseif(NOT DEFINED CMAKE_INSTALL_NAME_TOOL)
+  execute_process(COMMAND xcrun -sdk ${CMAKE_OSX_SYSROOT_INT} -find install_name_tool
+          OUTPUT_VARIABLE CMAKE_INSTALL_NAME_TOOL_INT
+          ERROR_QUIET
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(CMAKE_INSTALL_NAME_TOOL ${CMAKE_INSTALL_NAME_TOOL_INT} CACHE INTERNAL "")
+endif()
+
+# Configure libtool to be used instead of ar + ranlib to build static libraries.
+# This is required on Xcode 7+, but should also work on previous versions of
+# Xcode.
+get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+foreach(lang ${languages})
+  set(CMAKE_${lang}_CREATE_STATIC_LIBRARY "${BUILD_LIBTOOL} -static -o <TARGET> <LINK_FLAGS> <OBJECTS> " CACHE INTERNAL "")
+endforeach()
+
+# CMake 3.14+ support building for iOS, watchOS and tvOS out of the box.
+if(MODERN_CMAKE)
+  if(SDK_NAME MATCHES "iphone")
+    set(CMAKE_SYSTEM_NAME iOS)
+  elseif(SDK_NAME MATCHES "macosx")
+    set(CMAKE_SYSTEM_NAME Darwin)
+  elseif(SDK_NAME MATCHES "appletv")
+    set(CMAKE_SYSTEM_NAME tvOS)
+  elseif(SDK_NAME MATCHES "watch")
+    set(CMAKE_SYSTEM_NAME watchOS)
+  endif()
+  # Provide flags for a combined FAT library build on newer CMake versions
+  if(PLATFORM_INT MATCHES ".*COMBINED")
+    set(CMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH "NO")
+    set(CMAKE_IOS_INSTALL_COMBINED YES)
+    message(STATUS "Will combine built (static) artifacts into FAT lib...")
+  endif()
+elseif(NOT DEFINED CMAKE_SYSTEM_NAME AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10")
+  # Legacy code path prior to CMake 3.14 or fallback if no CMAKE_SYSTEM_NAME specified
+  set(CMAKE_SYSTEM_NAME iOS)
+elseif(NOT DEFINED CMAKE_SYSTEM_NAME)
+  # Legacy code path prior to CMake 3.14 or fallback if no CMAKE_SYSTEM_NAME specified
+  set(CMAKE_SYSTEM_NAME Darwin)
+endif()
+# Standard settings.
+set(CMAKE_SYSTEM_VERSION ${SDK_VERSION} CACHE INTERNAL "")
+set(UNIX TRUE CACHE BOOL "")
+set(APPLE TRUE CACHE BOOL "")
+if(PLATFORM STREQUAL "MAC" OR PLATFORM STREQUAL "MAC_ARM64")
+  set(IOS FALSE CACHE BOOL "")
+  set(MACOS TRUE CACHE BOOL "")
+elseif(PLATFORM STREQUAL "MAC_CATALYST" OR PLATFORM STREQUAL "MAC_CATALYST_ARM64")
+  set(IOS TRUE CACHE BOOL "")
+  set(MACOS TRUE CACHE BOOL "")
+else()
+  set(IOS TRUE CACHE BOOL "")
+endif()
+set(CMAKE_AR ar CACHE FILEPATH "" FORCE)
+set(CMAKE_RANLIB ranlib CACHE FILEPATH "" FORCE)
+set(CMAKE_STRIP strip CACHE FILEPATH "" FORCE)
+# Set the architectures for which to build.
+set(CMAKE_OSX_ARCHITECTURES ${ARCHS} CACHE INTERNAL "")
+# Change the type of target generated for try_compile() so it'll work when cross-compiling, weak compiler checks
+if(NOT ENABLE_STRICT_TRY_COMPILE_INT)
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+endif()
+# All iOS/Darwin specific settings - some may be redundant.
+set(CMAKE_MACOSX_BUNDLE YES)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO")
+set(CMAKE_SHARED_LIBRARY_PREFIX "lib")
+set(CMAKE_SHARED_LIBRARY_SUFFIX ".dylib")
+set(CMAKE_SHARED_MODULE_PREFIX "lib")
+set(CMAKE_SHARED_MODULE_SUFFIX ".so")
+set(CMAKE_C_COMPILER_ABI ELF)
+set(CMAKE_CXX_COMPILER_ABI ELF)
+set(CMAKE_C_HAS_ISYSROOT 1)
+set(CMAKE_CXX_HAS_ISYSROOT 1)
+set(CMAKE_MODULE_EXISTS 1)
+set(CMAKE_DL_LIBS "")
+set(CMAKE_C_OSX_COMPATIBILITY_VERSION_FLAG "-compatibility_version ")
+set(CMAKE_C_OSX_CURRENT_VERSION_FLAG "-current_version ")
+set(CMAKE_CXX_OSX_COMPATIBILITY_VERSION_FLAG "${CMAKE_C_OSX_COMPATIBILITY_VERSION_FLAG}")
+set(CMAKE_CXX_OSX_CURRENT_VERSION_FLAG "${CMAKE_C_OSX_CURRENT_VERSION_FLAG}")
+
+if(ARCHS MATCHES "((^|;|, )(arm64|arm64e|x86_64))+")
+  set(CMAKE_C_SIZEOF_DATA_PTR 8)
+  set(CMAKE_CXX_SIZEOF_DATA_PTR 8)
+  if(ARCHS MATCHES "((^|;|, )(arm64|arm64e))+")
+    set(CMAKE_SYSTEM_PROCESSOR "aarch64")
+  else()
+    set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+  endif()
+else()
+  set(CMAKE_C_SIZEOF_DATA_PTR 4)
+  set(CMAKE_CXX_SIZEOF_DATA_PTR 4)
+  set(CMAKE_SYSTEM_PROCESSOR "arm")
+endif()
+
+# Note that only Xcode 7+ supports the newer more specific:
+# -m${SDK_NAME}-version-min flags, older versions of Xcode use:
+# -m(ios/ios-simulator)-version-min instead.
+if(${CMAKE_VERSION} VERSION_LESS "3.11")
+  if(PLATFORM_INT STREQUAL "OS" OR PLATFORM_INT STREQUAL "OS64")
+    if(XCODE_VERSION_INT VERSION_LESS 7.0)
+      set(SDK_NAME_VERSION_FLAGS
+              "-mios-version-min=${DEPLOYMENT_TARGET}")
+    else()
+      # Xcode 7.0+ uses flags we can build directly from SDK_NAME.
+      set(SDK_NAME_VERSION_FLAGS
+              "-m${SDK_NAME}-version-min=${DEPLOYMENT_TARGET}")
+    endif()
+  elseif(PLATFORM_INT STREQUAL "TVOS")
+    set(SDK_NAME_VERSION_FLAGS
+            "-mtvos-version-min=${DEPLOYMENT_TARGET}")
+  elseif(PLATFORM_INT STREQUAL "SIMULATOR_TVOS")
+    set(SDK_NAME_VERSION_FLAGS
+            "-mtvos-simulator-version-min=${DEPLOYMENT_TARGET}")
+  elseif(PLATFORM_INT STREQUAL "WATCHOS")
+    set(SDK_NAME_VERSION_FLAGS
+            "-mwatchos-version-min=${DEPLOYMENT_TARGET}")
+  elseif(PLATFORM_INT STREQUAL "SIMULATOR_WATCHOS")
+    set(SDK_NAME_VERSION_FLAGS
+            "-mwatchos-simulator-version-min=${DEPLOYMENT_TARGET}")
+  elseif(PLATFORM_INT STREQUAL "MAC")
+    set(SDK_NAME_VERSION_FLAGS
+            "-mmacosx-version-min=${DEPLOYMENT_TARGET}")
+  else()
+    # SIMULATOR or SIMULATOR64 both use -mios-simulator-version-min.
+    set(SDK_NAME_VERSION_FLAGS
+            "-mios-simulator-version-min=${DEPLOYMENT_TARGET}")
+  endif()
+elseif(NOT PLATFORM_INT MATCHES "^MAC_CATALYST")
+  # Newer versions of CMake sets the version min flags correctly, skip this for Mac Catalyst targets
+  set(CMAKE_OSX_DEPLOYMENT_TARGET ${DEPLOYMENT_TARGET})
+endif()
+
+if(DEFINED APPLE_TARGET_TRIPLE_INT)
+  set(APPLE_TARGET_TRIPLE ${APPLE_TARGET_TRIPLE_INT} CACHE INTERNAL "")
+  set(CMAKE_C_COMPILER_TARGET ${APPLE_TARGET_TRIPLE})
+  set(CMAKE_CXX_COMPILER_TARGET ${APPLE_TARGET_TRIPLE})
+  set(CMAKE_ASM_COMPILER_TARGET ${APPLE_TARGET_TRIPLE})
+endif()
+
+if(PLATFORM_INT MATCHES "^MAC_CATALYST")
+  set(C_TARGET_FLAGS "-isystem ${CMAKE_OSX_SYSROOT_INT}/System/iOSSupport/usr/include -iframework ${CMAKE_OSX_SYSROOT_INT}/System/iOSSupport/System/Library/Frameworks")
+endif()
+
+if(ENABLE_BITCODE_INT)
+  set(BITCODE "-fembed-bitcode")
+  set(CMAKE_XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE "bitcode")
+  set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "YES")
+else()
+  set(BITCODE "")
+  set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "NO")
+endif()
+
+if(ENABLE_ARC_INT)
+  set(FOBJC_ARC "-fobjc-arc")
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "YES")
+else()
+  set(FOBJC_ARC "-fno-objc-arc")
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "NO")
+endif()
+
+if(NOT ENABLE_VISIBILITY_INT)
+  foreach(lang ${languages})
+    set(CMAKE_${lang}_VISIBILITY_PRESET "hidden" CACHE INTERNAL "")
+  endforeach()
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN "YES")
+  set(VISIBILITY "-fvisibility=hidden -fvisibility-inlines-hidden")
+else()
+  foreach(lang ${languages})
+    set(CMAKE_${lang}_VISIBILITY_PRESET "default" CACHE INTERNAL "")
+  endforeach()
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN "NO")
+  set(VISIBILITY "-fvisibility=default")
+endif()
+
+if(DEFINED APPLE_TARGET_TRIPLE)
+  set(APPLE_TARGET_TRIPLE_FLAG "-target ${APPLE_TARGET_TRIPLE}")
+endif()
+
+#Check if Xcode generator is used, since that will handle these flags automagically
+if(CMAKE_GENERATOR MATCHES "Xcode")
+  message(STATUS "Not setting any manual command-line buildflags, since Xcode is selected as generator.")
+else()
+  # Hidden visibility is required for C++ on iOS.
+  set(CMAKE_C_FLAGS "${C_TARGET_FLAGS} ${APPLE_TARGET_TRIPLE_FLAG} ${SDK_NAME_VERSION_FLAGS} ${BITCODE} -fobjc-abi-version=2 ${FOBJC_ARC} ${CMAKE_C_FLAGS}")
+  set(CMAKE_CXX_FLAGS "${C_TARGET_FLAGS} ${APPLE_TARGET_TRIPLE_FLAG} ${SDK_NAME_VERSION_FLAGS} ${BITCODE} ${VISIBILITY} -fobjc-abi-version=2 ${FOBJC_ARC} ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -O0 -g ${CMAKE_CXX_FLAGS_DEBUG}")
+  set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS} -DNDEBUG -Os -ffast-math ${CMAKE_CXX_FLAGS_MINSIZEREL}")
+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS} -DNDEBUG -O2 -g -ffast-math ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -DNDEBUG -O3 -ffast-math ${CMAKE_CXX_FLAGS_RELEASE}")
+  set(CMAKE_C_LINK_FLAGS "${C_TARGET_FLAGS} ${SDK_NAME_VERSION_FLAGS} -Wl,-search_paths_first ${CMAKE_C_LINK_FLAGS}")
+  set(CMAKE_CXX_LINK_FLAGS "${C_TARGET_FLAGS} ${SDK_NAME_VERSION_FLAGS}  -Wl,-search_paths_first ${CMAKE_CXX_LINK_FLAGS}")
+  set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -x assembler-with-cpp -arch ${CMAKE_OSX_ARCHITECTURES} ${APPLE_TARGET_TRIPLE_FLAG}")
+endif()
+
+## Print status messages to inform of the current state
+message(STATUS "Configuring ${SDK_NAME} build for platform: ${PLATFORM_INT}, architecture(s): ${ARCHS}")
+message(STATUS "Using SDK: ${CMAKE_OSX_SYSROOT_INT}")
+message(STATUS "Using C compiler: ${CMAKE_C_COMPILER}")
+message(STATUS "Using CXX compiler: ${CMAKE_CXX_COMPILER}")
+message(STATUS "Using libtool: ${BUILD_LIBTOOL}")
+message(STATUS "Using install name tool: ${CMAKE_INSTALL_NAME_TOOL}")
+if(DEFINED APPLE_TARGET_TRIPLE)
+  message(STATUS "Autoconf target triple: ${APPLE_TARGET_TRIPLE}")
+endif()
+message(STATUS "Using minimum deployment version: ${DEPLOYMENT_TARGET}"
+        " (SDK version: ${SDK_VERSION})")
+if(MODERN_CMAKE)
+  message(STATUS "Merging integrated CMake 3.14+ iOS,tvOS,watchOS,macOS toolchain(s) with this toolchain!")
+endif()
+if(CMAKE_GENERATOR MATCHES "Xcode")
+  message(STATUS "Using Xcode version: ${XCODE_VERSION_INT}")
+endif()
+message(STATUS "CMake version: ${CMAKE_VERSION}")
+if(DEFINED SDK_NAME_VERSION_FLAGS)
+  message(STATUS "Using version flags: ${SDK_NAME_VERSION_FLAGS}")
+endif()
+message(STATUS "Using a data_ptr size of: ${CMAKE_CXX_SIZEOF_DATA_PTR}")
+if(ENABLE_BITCODE_INT)
+  message(STATUS "Bitcode: Enabled")
+else()
+  message(STATUS "Bitcode: Disabled")
+endif()
+
+if(ENABLE_ARC_INT)
+  message(STATUS "ARC: Enabled")
+else()
+  message(STATUS "ARC: Disabled")
+endif()
+
+if(ENABLE_VISIBILITY_INT)
+  message(STATUS "Hiding symbols: Disabled")
+else()
+  message(STATUS "Hiding symbols: Enabled")
+endif()
+
+# Set global properties
+set_property(GLOBAL PROPERTY PLATFORM "${PLATFORM}")
+set_property(GLOBAL PROPERTY APPLE_TARGET_TRIPLE "${APPLE_TARGET_TRIPLE_INT}")
+set_property(GLOBAL PROPERTY SDK_VERSION "${SDK_VERSION}")
+set_property(GLOBAL PROPERTY XCODE_VERSION "${XCODE_VERSION_INT}")
+set_property(GLOBAL PROPERTY OSX_ARCHITECTURES "${CMAKE_OSX_ARCHITECTURES}")
+
+# Export configurable variables for the try_compile() command.
+set(CMAKE_TRY_COMPILE_PLATFORM_VARIABLES
+        PLATFORM
+        XCODE_VERSION_INT
+        SDK_VERSION
+        DEPLOYMENT_TARGET
+        CMAKE_DEVELOPER_ROOT
+        CMAKE_OSX_SYSROOT_INT
+        ENABLE_BITCODE
+        ENABLE_ARC
+        CMAKE_ASM_COMPILER
+        CMAKE_C_COMPILER
+        CMAKE_C_COMPILER_TARGET
+        CMAKE_CXX_COMPILER
+        CMAKE_CXX_COMPILER_TARGET
+        BUILD_LIBTOOL
+        CMAKE_INSTALL_NAME_TOOL
+        CMAKE_C_FLAGS
+        CMAKE_CXX_FLAGS
+        CMAKE_CXX_FLAGS_DEBUG
+        CMAKE_CXX_FLAGS_MINSIZEREL
+        CMAKE_CXX_FLAGS_RELWITHDEBINFO
+        CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_C_LINK_FLAGS
+        CMAKE_CXX_LINK_FLAGS
+        CMAKE_ASM_FLAGS
+        )
 
 set(CMAKE_PLATFORM_HAS_INSTALLNAME 1)
-set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-dynamiclib -headerpad_max_install_names")
-set(CMAKE_SHARED_MODULE_CREATE_C_FLAGS "-bundle -headerpad_max_install_names")
+set(CMAKE_SHARED_LINKER_FLAGS "-rpath @executable_path/Frameworks -rpath @loader_path/Frameworks")
+set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-dynamiclib -Wl,-headerpad_max_install_names")
+set(CMAKE_SHARED_MODULE_CREATE_C_FLAGS "-bundle -Wl,-headerpad_max_install_names")
 set(CMAKE_SHARED_MODULE_LOADER_C_FLAG "-Wl,-bundle_loader,")
 set(CMAKE_SHARED_MODULE_LOADER_CXX_FLAG "-Wl,-bundle_loader,")
-set(CMAKE_FIND_LIBRARY_SUFFIXES ".dylib" ".so" ".a")
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".tbd" ".dylib" ".so" ".a")
+set(CMAKE_SHARED_LIBRARY_SONAME_C_FLAG "-install_name")
 
-# Set the find root to the iOS developer roots and to user defined paths.
-set(CMAKE_FIND_ROOT_PATH ${CMAKE_IOS_DEVELOPER_ROOT} ${CMAKE_IOS_SDK_ROOT}
-  ${CMAKE_PREFIX_PATH} CACHE STRING "iOS find search path root" FORCE)
+# Set the find root to the SDK developer roots.
+# Note: CMAKE_FIND_ROOT_PATH is only useful when cross-compiling. Thus, do not set on macOS builds.
+if(NOT PLATFORM_INT STREQUAL "MAC" AND NOT PLATFORM_INT STREQUAL "MAC_ARM64")
+  list(APPEND CMAKE_FIND_ROOT_PATH "${CMAKE_OSX_SYSROOT_INT}" CACHE INTERNAL "")
+  set(CMAKE_IGNORE_PATH "/System/Library/Frameworks;/usr/local/lib" CACHE INTERNAL "")
+endif()
 
 # Default to searching for frameworks first.
 set(CMAKE_FIND_FRAMEWORK FIRST)
 
 # Set up the default search directories for frameworks.
-set(CMAKE_SYSTEM_FRAMEWORK_PATH
-  ${CMAKE_IOS_SDK_ROOT}/System/Library/Frameworks
-  ${CMAKE_IOS_SDK_ROOT}/System/Library/PrivateFrameworks
-  ${CMAKE_IOS_SDK_ROOT}/Developer/Library/Frameworks)
+if(PLATFORM_INT MATCHES "^MAC_CATALYST") 
+  set(CMAKE_FRAMEWORK_PATH
+          ${CMAKE_DEVELOPER_ROOT}/Library/PrivateFrameworks
+          ${CMAKE_OSX_SYSROOT_INT}/System/Library/Frameworks
+          ${CMAKE_OSX_SYSROOT_INT}/System/iOSSupport/System/Library/Frameworks
+          ${CMAKE_FRAMEWORK_PATH} CACHE INTERNAL "")
+else()
+  set(CMAKE_FRAMEWORK_PATH
+          ${CMAKE_DEVELOPER_ROOT}/Library/PrivateFrameworks
+          ${CMAKE_OSX_SYSROOT_INT}/System/Library/Frameworks
+          ${CMAKE_FRAMEWORK_PATH} CACHE INTERNAL "")
+endif()
 
-# Only search the specified iOS SDK, not the remainder of the host filesystem.
-set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM BOTH)
-set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+# By default, search both the specified iOS SDK and the remainder of the host filesystem.
+if(NOT CMAKE_FIND_ROOT_PATH_MODE_PROGRAM)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM BOTH CACHE INTERNAL "")
+endif()
+if(NOT CMAKE_FIND_ROOT_PATH_MODE_LIBRARY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH CACHE INTERNAL "")
+endif()
+if(NOT CMAKE_FIND_ROOT_PATH_MODE_INCLUDE)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH CACHE INTERNAL "")
+endif()
+if(NOT CMAKE_FIND_ROOT_PATH_MODE_PACKAGE)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH CACHE INTERNAL "")
+endif()
 
-# Find (Apple's) libtool.
-execute_process(COMMAND xcrun -sdk ${CMAKE_IOS_SDK_ROOT} -find libtool
-  OUTPUT_VARIABLE IOS_LIBTOOL
-  ERROR_QUIET
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-# Configure libtool to be used instead of ar + ranlib to build static libraries.
-# This is required on Xcode 7+, but should also work on previous versions of Xcode.
-set(CMAKE_C_CREATE_STATIC_LIBRARY
-  "${IOS_LIBTOOL} -static -o <TARGET> <LINK_FLAGS> <OBJECTS> ")
-set(CMAKE_CXX_CREATE_STATIC_LIBRARY
-  "${IOS_LIBTOOL} -static -o <TARGET> <LINK_FLAGS> <OBJECTS> ")
+#
+# Some helper-macros below to simplify and beautify the CMakeFile
+#
 
-# This little macro lets you set any XCode specific property.
-macro(set_xcode_property TARGET XCODE_PROPERTY XCODE_VALUE)
-  set_property(TARGET ${TARGET} PROPERTY
-    XCODE_ATTRIBUTE_${XCODE_PROPERTY} ${XCODE_VALUE})
+# This little macro lets you set any Xcode specific property.
+macro(set_xcode_property TARGET XCODE_PROPERTY XCODE_VALUE XCODE_RELVERSION)
+  set(XCODE_RELVERSION_I "${XCODE_RELVERSION}")
+  if(XCODE_RELVERSION_I STREQUAL "All")
+    set_property(TARGET ${TARGET} PROPERTY XCODE_ATTRIBUTE_${XCODE_PROPERTY} "${XCODE_VALUE}")
+  else()
+    set_property(TARGET ${TARGET} PROPERTY XCODE_ATTRIBUTE_${XCODE_PROPERTY}[variant=${XCODE_RELVERSION_I}] "${XCODE_VALUE}")
+  endif()
 endmacro(set_xcode_property)
 
 # This macro lets you find executable programs on the host system.
@@ -263,12 +933,13 @@ macro(find_host_package)
   set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
   set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY NEVER)
   set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE NEVER)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE NEVER)
+  set(_TOOLCHAIN_IOS ${IOS})
   set(IOS FALSE)
-
   find_package(${ARGN})
-
-  set(IOS TRUE)
-  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY)
-  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+  set(IOS ${_TOOLCHAIN_IOS})
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM BOTH)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)
 endmacro(find_host_package)

--- a/scripts/OpenSSL-DownloadAndBuild.command
+++ b/scripts/OpenSSL-DownloadAndBuild.command
@@ -21,7 +21,7 @@ MIN_SDK_VERSION="10.0"
 INSTALLDIR="external"
 
 # Architectures to build
-ARCHS="i386 x86_64 armv7 armv7s arm64"
+ARCHS="arm64"
 
 # Use default SDK version if not set
 if [ -z ${SDK_VERSION} ]; then

--- a/scripts/OpenSSL-DownloadAndBuild.command
+++ b/scripts/OpenSSL-DownloadAndBuild.command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -xe
 # 
 # Copyright 2015 Thincast Technologies GmbH
 # 
@@ -9,19 +9,19 @@
 
 ## Settings
 # openssl version to use
-OPENSSLVERSION="1.0.2q"
-SHA256SUM="5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684"
+OPENSSLVERSION="3.0.2"
+SHA256SUM="98e91ccead4d4756ae3c9cde5e09191a8e586d9f4d50838e7ec09d6411dfdb63"
 # SDK version to use - if not set latest version found is used
 SDK_VERSION=""
 
 # Minimum SDK version the application supports
-MIN_SDK_VERSION="10.0"
+MIN_SDK_VERSION="15.0"
 
 ## Defaults
 INSTALLDIR="external"
 
 # Architectures to build
-ARCHS="arm64"
+ARCHS="arm64 x86_64"
 
 # Use default SDK version if not set
 if [ -z ${SDK_VERSION} ]; then
@@ -30,9 +30,6 @@ fi
 
 CORES=`sysctl hw.ncpu | awk '{print $2}'`
 MAKEOPTS="-j $CORES"
-# disable parallell builds since openssl build
-# fails sometimes
-MAKEOPTS=""
 
 DEVELOPER=`xcode-select -print-path`
 if [ ! -d "$DEVELOPER" ]; then
@@ -44,16 +41,6 @@ if [ ! -d "$DEVELOPER" ]; then
   exit 1
 fi
 
-function run {
-    "$@"
-    local status=$?
-    if [ $status -ne 0 ]; then
-        echo "error with $@" >&2
-        exit $status
-    fi
-    return $status
-}
-
 # Functions
 function buildArch(){
     ARCH=$1
@@ -61,36 +48,38 @@ function buildArch(){
     then
         PLATFORM="iPhoneSimulator"
     else
-        run sed -ie "s!static volatile sig_atomic_t intr_signal;!static volatile intr_signal;!" "crypto/ui/ui_openssl.c"
+        sed -ie "s!static volatile sig_atomic_t intr_signal;!static volatile intr_signal;!" "crypto/ui/ui_openssl.c"
         PLATFORM="iPhoneOS"
     fi
 
-    run export CROSS_TOP="${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer"
-    run export CROSS_SDK="${PLATFORM}${SDK_VERSION}.sdk"
-    run export BUILD_TOOLS="${DEVELOPER}"
-    run export CC="${BUILD_TOOLS}/usr/bin/gcc -arch ${ARCH}"
+    export CROSS_TOP="${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer"
+    export CROSS_SDK="${PLATFORM}${SDK_VERSION}.sdk"
+    export BUILD_TOOLS="${DEVELOPER}"
+    export CC="${BUILD_TOOLS}/usr/bin/gcc -arch ${ARCH}"
     if [ ! -z $MIN_SDK_VERSION ]; then
-        run export CC="$CC -miphoneos-version-min=${MIN_SDK_VERSION}"
+        export CC="$CC -miphoneos-version-min=${MIN_SDK_VERSION}"
     fi
     echo "Building openssl-${OPENSSLVERSION} for ${PLATFORM} ${SDK_VERSION} ${ARCH} (min SDK set: ${MIN_SDK_VERSION:-"none"})"
 
     LOGFILE="BuildLog.darwin-${ARCH}.txt"
     echo -n " Please wait ..."
     if [[ "$OPENSSLVERSION" =~ 1.0.0. ]]; then
-        run ./Configure BSD-generic32 > "${LOGFILE}" 2>&1
+        CONFIG_ARGS=BSD-generic32
     elif [ "${ARCH}" == "x86_64" ]; then
-        run ./Configure darwin64-x86_64-cc > "${LOGFILE}" 2>&1
+        CONFIG_ARGS=darwin64-x86_64-cc
     elif [ "${ARCH}" == "i386" ]; then
-        run ./Configure iphoneos-cross no-asm > "${LOGFILE}" 2>&1
+        CONFIG_ARGS="iphoneos-cross no-asm"
     else
-        run ./Configure iphoneos-cross  > "${LOGFILE}" 2>&1
+        CONFIG_ARGS=iphoneos-cross
     fi
 
-    run make ${MAKEOPTS} >> ${LOGFILE} 2>&1
+    ./Configure $CONFIG_ARGS  2>&1 | tee ${LOGFILE}
+
+    make ${MAKEOPTS} 2>&1 | tee ${LOGFILE}
     echo " Done. Build log saved in ${LOGFILE}"
-    run cp libcrypto.a ../../lib/libcrypto_${ARCH}.a
-    run cp libssl.a ../../lib/libssl_${ARCH}.a
-    run make clean >/dev/null 2>&1
+    cp libcrypto.a ../../lib/libcrypto_${ARCH}.a
+    cp libssl.a ../../lib/libssl_${ARCH}.a
+    make clean 2>&1 | tee ${LOGFILE}
 }
 
 # main
@@ -104,14 +93,14 @@ fi
 
 cd $INSTALLDIR
 if [ ! -d openssl ];then
-    run mkdir openssl
+    mkdir openssl
 fi
-run cd openssl
+cd openssl
 CS=`shasum -a 256 "openssl-$OPENSSLVERSION.tar.gz" | cut -d ' ' -f1`
 if [ ! "$CS" = "$SHA256SUM" ]; then
     echo "Downloading OpenSSL Version $OPENSSLVERSION ..."
-    run rm -f "openssl-$OPENSSLVERSION.tar.gz"
-    run curl -o "openssl-$OPENSSLVERSION.tar.gz" https://www.openssl.org/source/openssl-$OPENSSLVERSION.tar.gz
+    rm -f "openssl-$OPENSSLVERSION.tar.gz"
+    curl -o "openssl-$OPENSSLVERSION.tar.gz" https://www.openssl.org/source/openssl-$OPENSSLVERSION.tar.gz
 
     CS=`shasum -a 256 "openssl-$OPENSSLVERSION.tar.gz" | cut -d ' ' -f1`
     if [ ! "$CS" = "$SHA256SUM" ]; then
@@ -121,19 +110,19 @@ if [ ! "$CS" = "$SHA256SUM" ]; then
 fi
 
 # remove old build dir
-run rm -rf openssltmp
-run mkdir openssltmp
-run cd openssltmp
+rm -rf openssltmp
+mkdir openssltmp
+cd openssltmp
 
 echo "Unpacking OpenSSL ..."
-run tar xfz "../openssl-$OPENSSLVERSION.tar.gz"
+tar xfz "../openssl-$OPENSSLVERSION.tar.gz"
 if [ ! $? = 0 ]; then
     echo "Unpacking failed."
     exit 1
 fi
 echo
 
-run cd "openssl-$OPENSSLVERSION"
+cd "openssl-$OPENSSLVERSION"
 
 case `pwd` in
      *\ * )
@@ -143,22 +132,22 @@ case `pwd` in
 esac
 
 # Cleanup old build artifacts
-run rm -rf ../../include
-run mkdir -p ../../include
+rm -rf ../../include
+mkdir -p ../../include
 
-run rm -rf ../../lib
-run mkdir -p ../../lib
+rm -rf ../../lib
+mkdir -p ../../lib
 
 for i in ${ARCHS}; do
     buildArch $i
 done
 
 echo "Copying header files ..."
-run cp -r include/ ../../include/
+cp -r include/ ../../include/
 echo
 
 echo "Combining to unversal binary"
-run lipo -create ../../lib/libcrypto_*.a -o ../../lib/libcrypto.a
-run lipo -create ../../lib/libssl_*.a -o ../../lib/libssl.a
+lipo -create ../../lib/libcrypto_*.a -o ../../lib/libcrypto.a
+lipo -create ../../lib/libssl_*.a -o ../../lib/libssl.a
 
 echo "Finished. Please verify the contens of the openssl folder in \"$INSTALLDIR\""

--- a/winpr/libwinpr/path/shell_ios.m
+++ b/winpr/libwinpr/path/shell_ios.m
@@ -24,7 +24,7 @@
 
 #include "shell_ios.h"
 
-NSString *ios_get_directory_for_search_path(NSString *searchPath)
+NSString *ios_get_directory_for_search_path(NSSearchPathDirectory searchPath)
 {
 	return [NSSearchPathForDirectoriesInDomains(searchPath, NSUserDomainMask, YES) lastObject];
 }


### PR DESCRIPTION
@iiordanov I´ve fixed the `iOS` build of `FreeRDP` (and the `CI builder` so that we have proper compile checks)
If you fix the client compile, you can create a pr with `set (WITH_CLIENT ON CACHE BOOL "enable iOS client")` in `ci/cmake-preloads/config-ios.txt` and we´ll see if the client will compile.

How to compile:
1. `./scripts/OpenSSL-DownloadAndBuild.command`
1. `cmake  -C <path to>/ci/cmake-preloads/config-ios.txt -D CMAKE_BUILD_TYPE=Debug -DPLATFORM=OS64 -DCMAKE_VERBOSE_MAKEFILE=ON -B<builddr> -S<sourcedir>`
2. `cmake --build <builddir>`

you might add `-GXcode` if you have xcode set up or change `-DPLATFORM=OS64` to any defined in `cmake/ios.toolchain.cmake` (just be sure you have `OpenSSL` compiled accordingly as well)