### PR TITLE
Fix arm neon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,7 +506,6 @@ if(ANDROID)
 
 	if(ANDROID_ABI STREQUAL arm64-v8a)
 		# https://github.com/android/ndk/issues/910
-		add_definitions(-D__ARM_NEON)
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfloat-abi=softfp")
 	endif()
 

--- a/libfreerdp/CMakeLists.txt
+++ b/libfreerdp/CMakeLists.txt
@@ -322,7 +322,7 @@ set(PRIMITIVES_OPT_SRCS
 
 ### IPP Variable debugging
 if(WITH_IPP)
-    if(CMAKE_COMPILER_IS_GNUCC)
+    if(CMAKE_COMPILER_IS_GNUCC OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
         foreach(INCLDIR ${IPP_INCLUDE_DIRS})
             set(OPTIMIZATION "${OPTIMIZATION} -I${INCLDIR}")
         endforeach(INCLDIR)
@@ -344,9 +344,11 @@ if(WITH_SSE2)
             PROPERTIES COMPILE_FLAGS "${OPTIMIZATION} /arch:SSE2")
     endif()
 elseif(WITH_NEON)
-    if(CMAKE_COMPILER_IS_GNUCC)
-        set_source_files_properties(${PRIMITIVES_OPT_SRCS}
-            PROPERTIES COMPILE_FLAGS "${OPTIMIZATION} -mfpu=neon")
+    if(CMAKE_COMPILER_IS_GNUCC OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+        if (NOT MSVC_ARM64 AND NOT ARCH_ARM64)
+            set_source_files_properties(${PRIMITIVES_OPT_SRCS}
+                PROPERTIES COMPILE_FLAGS "${OPTIMIZATION} -mfpu=neon")
+        endif()
     endif()
     # TODO: Add MSVC equivalent
 endif()

--- a/libfreerdp/codec/rfx_neon.c
+++ b/libfreerdp/codec/rfx_neon.c
@@ -19,7 +19,7 @@
 
 #include <freerdp/config.h>
 
-#if defined(__ARM_NEON)
+#if defined(WITH_NEON)
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -239,4 +239,4 @@ void rfx_init_neon(RFX_CONTEXT* context)
 	}
 }
 
-#endif // __ARM_NEON
+#endif // WITH_NEON


### PR DESCRIPTION
Remove duplicated check for `NEON`:
* Only check `WITH_NEON` and do not rely on defined symbols