### PR TITLE
shadow: convert incoming key scancode to DWORD before |= KBDEXT

### DIFF
--- a/server/shadow/X11/x11_shadow.c
+++ b/server/shadow/X11/x11_shadow.c
@@ -212,6 +212,7 @@ static BOOL x11_shadow_input_keyboard_event(rdpShadowSubsystem* subsystem, rdpSh
 	x11ShadowSubsystem* x11 = (x11ShadowSubsystem*)subsystem;
 	DWORD vkcode;
 	DWORD keycode;
+	DWORD scancode;
 	BOOL extended = FALSE;
 
 	if (!client || !subsystem)
@@ -220,10 +221,11 @@ static BOOL x11_shadow_input_keyboard_event(rdpShadowSubsystem* subsystem, rdpSh
 	if (flags & KBD_FLAGS_EXTENDED)
 		extended = TRUE;
 
+	scancode = code;
 	if (extended)
-		code |= KBDEXT;
+		scancode |= KBDEXT;
 
-	vkcode = GetVirtualKeyCodeFromVirtualScanCode(code, 4);
+	vkcode = GetVirtualKeyCodeFromVirtualScanCode(scancode, 4);
 
 	if (extended)
 		vkcode |= KBDEXT;


### PR DESCRIPTION
KBDEXT is 0x100, so if we |= it onto a UINT8 it actually does nothing, making us interpret all scancodes as if they're non-extended.
