### PR TITLE
winpr: fix unitary test when CreateProcess is CreateProcessW

### DIFF
--- a/winpr/include/winpr/crt.h
+++ b/winpr/include/winpr/crt.h
@@ -39,39 +39,39 @@
 
 #ifndef _strtoui64
 #define _strtoui64 strtoull
-#endif
+#endif /* _strtoui64 */
 
 #ifndef _strtoi64
 #define _strtoi64 strtoll
-#endif
+#endif /* _strtoi64 */
 
 #ifndef _rotl
 static INLINE UINT32 _rotl(UINT32 value, int shift)
 {
 	return (value << shift) | (value >> (32 - shift));
 }
-#endif
+#endif /* _rotl */
 
 #ifndef _rotl64
 static INLINE UINT64 _rotl64(UINT64 value, int shift)
 {
 	return (value << shift) | (value >> (64 - shift));
 }
-#endif
+#endif /* _rotl64 */
 
 #ifndef _rotr
 static INLINE UINT32 _rotr(UINT32 value, int shift)
 {
 	return (value >> shift) | (value << (32 - shift));
 }
-#endif
+#endif /* _rotr */
 
 #ifndef _rotr64
 static INLINE UINT64 _rotr64(UINT64 value, int shift)
 {
 	return (value >> shift) | (value << (64 - shift));
 }
-#endif
+#endif /* _rotr64 */
 
 #if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 2))
 
@@ -94,7 +94,7 @@ static INLINE UINT64 _byteswap_uint64(UINT64 _val)
 	        ((_val) >> 56));
 }
 
-#endif
+#endif /* (__GNUC__ > 4) || ... */
 
 #if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8))
 
@@ -107,7 +107,7 @@ static INLINE UINT16 _byteswap_ushort(UINT16 _val)
 	return (UINT16)(((_val) >> 8U) | ((_val) << 8U));
 }
 
-#endif
+#endif /* (__GNUC__ > 4) || ... */
 
 #define CopyMemory(Destination, Source, Length) memcpy((Destination), (Source), (Length))
 #define MoveMemory(Destination, Source, Length) memmove((Destination), (Source), (Length))
@@ -135,7 +135,7 @@ extern "C"
 #ifndef _ERRNO_T_DEFINED
 #define _ERRNO_T_DEFINED
 typedef int errno_t;
-#endif
+#endif /* _ERRNO_T_DEFINED */
 
 #if defined(__clang__)
 #pragma clang diagnostic pop
@@ -174,6 +174,6 @@ extern "C"
 }
 #endif
 
-#endif
+#endif /* _WIN32 */
 
 #endif /* WINPR_CRT_H */

--- a/winpr/include/winpr/string.h
+++ b/winpr/include/winpr/string.h
@@ -75,7 +75,7 @@ extern "C"
 #define _wcschr wcschr
 #define _wcsrchr wcsrchr
 
-#endif
+#endif /* _WIN32 */
 
 #if !defined(_WIN32) || defined(_UWP)
 

--- a/winpr/libwinpr/crt/alignment.c
+++ b/winpr/libwinpr/crt/alignment.c
@@ -249,4 +249,4 @@ void _aligned_free(void* memblock)
 	free(pMem->base_addr);
 }
 
-#endif
+#endif /* _WIN32 */

--- a/winpr/libwinpr/thread/test/TestThreadCreateProcess.c
+++ b/winpr/libwinpr/thread/test/TestThreadCreateProcess.c
@@ -15,7 +15,14 @@ int TestThreadCreateProcess(int argc, char* argv[])
 	BOOL status;
 	DWORD exitCode;
 	LPCTSTR lpApplicationName;
-	LPTSTR lpCommandLine;
+
+#ifdef _WIN32
+	TCHAR lpCommandLine[200] = _T("cmd /C set");
+#else
+	TCHAR lpCommandLine[200] = _T("printenv");
+#endif
+
+	//LPTSTR lpCommandLine;
 	LPSECURITY_ATTRIBUTES lpProcessAttributes;
 	LPSECURITY_ATTRIBUTES lpThreadAttributes;
 	BOOL bInheritHandles;
@@ -38,12 +45,6 @@ int TestThreadCreateProcess(int argc, char* argv[])
 	lpszEnvironmentBlock = GetEnvironmentStrings();
 
 	lpApplicationName = NULL;
-
-#ifdef _WIN32
-	lpCommandLine = _T("cmd /C set");
-#else
-	lpCommandLine = _T("printenv");
-#endif
 
 	lpProcessAttributes = NULL;
 	lpThreadAttributes = NULL;


### PR DESCRIPTION
As the second argument of CreateProcessW is modified to split with spaces and so this can not be a const arg.
