### PR TITLE
fix moving a window shrinks it 14x7 when connect to server 2019

### DIFF
--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -138,10 +138,10 @@ void xf_rail_adjust_position(xfContext* xfc, xfAppWindow* appWindow)
 		 * Calculate new size/position for the rail window(new values for
 		 * windowOffsetX/windowOffsetY/windowWidth/windowHeight) on the server
 		 */
-		windowMove.left = appWindow->x;
-		windowMove.top = appWindow->y;
-		windowMove.right = windowMove.left + appWindow->width;
-		windowMove.bottom = windowMove.top + appWindow->height;
+		windowMove.left = appWindow->x - appWindow->resizeMarginLeft;
+		windowMove.top = appWindow->y - appWindow->resizeMarginTop;
+		windowMove.right = appWindow->x + appWindow->width + appWindow->resizeMarginRight;
+		windowMove.bottom = appWindow->y + appWindow->height + appWindow->resizeMarginBottom;
 		xfc->rail->ClientWindowMove(xfc->rail, &windowMove);
 	}
 }
@@ -171,12 +171,12 @@ void xf_rail_end_local_move(xfContext* xfc, xfAppWindow* appWindow)
 	 * windowOffsetX/windowOffsetY/windowWidth/windowHeight) on the server
 	 *
 	 */
-	windowMove.left = appWindow->x;
-	windowMove.top = appWindow->y;
+	windowMove.left = appWindow->x - appWindow->resizeMarginLeft;
+	windowMove.top = appWindow->y - appWindow->resizeMarginTop;
 	windowMove.right =
-	    windowMove.left +
-	    appWindow->width; /* In the update to RDP the position is one past the window */
-	windowMove.bottom = windowMove.top + appWindow->height;
+	    appWindow->x +
+	    appWindow->width + appWindow->resizeMarginRight; /* In the update to RDP the position is one past the window */
+	windowMove.bottom = appWindow->y + appWindow->height + appWindow->resizeMarginBottom;
 	xfc->rail->ClientWindowMove(xfc->rail, &windowMove);
 	/*
 	 * Simulate button up at new position to end the local move (per RDP spec)
@@ -351,6 +351,18 @@ static BOOL xf_rail_window_common(rdpContext* context, const WINDOW_ORDER_INFO* 
 	{
 		appWindow->windowWidth = windowState->windowWidth;
 		appWindow->windowHeight = windowState->windowHeight;
+	}
+	
+	if (fieldFlags & WINDOW_ORDER_FIELD_RESIZE_MARGIN_X)
+	{
+		appWindow->resizeMarginLeft = windowState->resizeMarginLeft;
+		appWindow->resizeMarginRight = windowState->resizeMarginRight;
+	}
+	
+	if (fieldFlags & WINDOW_ORDER_FIELD_RESIZE_MARGIN_Y)
+	{
+		appWindow->resizeMarginTop = windowState->resizeMarginTop;
+		appWindow->resizeMarginBottom = windowState->resizeMarginBottom;
 	}
 
 	if (fieldFlags & WINDOW_ORDER_FIELD_OWNER)

--- a/client/X11/xf_window.h
+++ b/client/X11/xf_window.h
@@ -135,6 +135,11 @@ struct xf_app_window
 
 	UINT32 localWindowOffsetCorrX;
 	UINT32 localWindowOffsetCorrY;
+	
+	UINT32 resizeMarginLeft;
+	UINT32 resizeMarginTop;
+	UINT32 resizeMarginRight;
+	UINT32 resizeMarginBottom;
 
 	GC gc;
 	int shmid;


### PR DESCRIPTION
problem: connect to server 2019, every time we move the RAIL window, it shrinks.
root cause: Window positions sent using Client Window Move PDU SHOULD include hit-testable margins(Window Resize Margins).

reference doc: 
MS-RDPERP 1.3.4
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdperp/a7a1793b-090c-4599-b12d-ca7bba00281c

MS-RDPERP 2.2.2.7.4
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdperp/495acc38-df83-42ec-8ed1-b8d58c047262

for lower version server,  server will not send resize margins, so all resize margins is 0, this fix work as before.

TODO:
this pull request only fix window that is resizable(mspaint), because server only send resize margins for resizable window(MS-RDPERP 3.2.5.1.6). other window(calc) still shrinks when move, we can caculate resize margins from window size change, because the only reason of size change is client window move pdu, i will open another pull request when test ok. 
