### PR TITLE
fix RAIL abort when reconnect

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -368,9 +368,7 @@ static BOOL xf_event_Expose(xfContext* xfc, const XExposeEvent* event, BOOL app)
 	}
 	else
 	{
-		xfAppWindow* appWindow;
-		appWindow = xf_AppWindowFromX11Window(xfc, event->window);
-
+		xfAppWindow* appWindow = xf_AppWindowFromX11Window(xfc, event->window);
 		if (appWindow)
 		{
 			xf_UpdateWindowArea(xfc, appWindow, x, y, w, h);
@@ -621,15 +619,12 @@ static BOOL xf_event_FocusIn(xfContext* xfc, const XFocusInEvent* event, BOOL ap
 
 	if (app)
 	{
-		xfAppWindow* appWindow;
-		appWindow = xf_AppWindowFromX11Window(xfc, event->window);
+		xfAppWindow* appWindow = xf_AppWindowFromX11Window(xfc, event->window);
 
 		/* Update the server with any window changes that occurred while the window was not focused.
 		 */
 		if (appWindow)
-		{
 			xf_rail_adjust_position(xfc, appWindow);
-		}
 	}
 
 	xf_keyboard_focus_in(xfc);
@@ -673,13 +668,10 @@ static BOOL xf_event_ClientMessage(xfContext* xfc, const XClientMessageEvent* ev
 	{
 		if (app)
 		{
-			xfAppWindow* appWindow;
-			appWindow = xf_AppWindowFromX11Window(xfc, event->window);
+			xfAppWindow* appWindow = xf_AppWindowFromX11Window(xfc, event->window);
 
 			if (appWindow)
-			{
 				xf_rail_send_client_system_command(xfc, appWindow->windowId, SC_CLOSE);
-			}
 
 			return TRUE;
 		}
@@ -834,14 +826,12 @@ static BOOL xf_event_ConfigureNotify(xfContext* xfc, const XConfigureEvent* even
 
 static BOOL xf_event_MapNotify(xfContext* xfc, const XMapEvent* event, BOOL app)
 {
-	xfAppWindow* appWindow;
-
 	WINPR_ASSERT(xfc);
 	if (!app)
 		gdi_send_suppress_output(xfc->common.context.gdi, FALSE);
 	else
 	{
-		appWindow = xf_AppWindowFromX11Window(xfc, event->window);
+		xfAppWindow* appWindow = xf_AppWindowFromX11Window(xfc, event->window);
 
 		if (appWindow && (appWindow->rail_state == WINDOW_SHOW))
 		{
@@ -860,8 +850,6 @@ static BOOL xf_event_MapNotify(xfContext* xfc, const XMapEvent* event, BOOL app)
 
 static BOOL xf_event_UnmapNotify(xfContext* xfc, const XUnmapEvent* event, BOOL app)
 {
-	xfAppWindow* appWindow;
-
 	WINPR_ASSERT(xfc);
 	WINPR_ASSERT(event);
 
@@ -871,12 +859,10 @@ static BOOL xf_event_UnmapNotify(xfContext* xfc, const XUnmapEvent* event, BOOL 
 		gdi_send_suppress_output(xfc->common.context.gdi, TRUE);
 	else
 	{
-		appWindow = xf_AppWindowFromX11Window(xfc, event->window);
+		xfAppWindow* appWindow = xf_AppWindowFromX11Window(xfc, event->window);
 
 		if (appWindow)
-		{
 			appWindow->is_mapped = FALSE;
-		}
 	}
 
 	return TRUE;
@@ -1099,7 +1085,6 @@ static BOOL xf_event_suppress_events(xfContext* xfc, xfAppWindow* appWindow, con
 BOOL xf_event_process(freerdp* instance, const XEvent* event)
 {
 	BOOL status = TRUE;
-	xfAppWindow* appWindow;
 	xfContext* xfc;
 	rdpSettings* settings;
 
@@ -1114,7 +1099,7 @@ BOOL xf_event_process(freerdp* instance, const XEvent* event)
 
 	if (xfc->remote_app)
 	{
-		appWindow = xf_AppWindowFromX11Window(xfc, event->xany.window);
+		xfAppWindow* appWindow = xf_AppWindowFromX11Window(xfc, event->xany.window);
 
 		if (appWindow)
 		{

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -90,9 +90,8 @@ void xf_rail_disable_remoteapp_mode(xfContext* xfc)
 
 void xf_rail_send_activate(xfContext* xfc, Window xwindow, BOOL enabled)
 {
-	xfAppWindow* appWindow;
 	RAIL_ACTIVATE_ORDER activate;
-	appWindow = xf_AppWindowFromX11Window(xfc, xwindow);
+	xfAppWindow* appWindow = xf_AppWindowFromX11Window(xfc, xwindow);
 
 	if (!appWindow)
 		return;

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -1159,6 +1159,12 @@ xfAppWindow* xf_AppWindowFromX11Window(xfContext* xfc, Window wnd)
 	int count;
 	ULONG_PTR* pKeys = NULL;
 	xfAppWindow* appWindow;
+	
+	if(NULL == xfc->railWindows)
+	{
+		return NULL;
+	}
+	
 	count = HashTable_GetKeys(xfc->railWindows, &pKeys);
 
 	for (index = 0; index < count; index++)

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -1155,21 +1155,19 @@ void xf_DestroyWindow(xfContext* xfc, xfAppWindow* appWindow)
 
 xfAppWindow* xf_AppWindowFromX11Window(xfContext* xfc, Window wnd)
 {
-	int index;
-	int count;
+	size_t index;
+	size_t count;
 	ULONG_PTR* pKeys = NULL;
-	xfAppWindow* appWindow;
-	
-	if(NULL == xfc->railWindows)
-	{
+
+	WINPR_ASSERT(xfc);
+	if (!xfc->railWindows)
 		return NULL;
-	}
-	
+
 	count = HashTable_GetKeys(xfc->railWindows, &pKeys);
 
 	for (index = 0; index < count; index++)
 	{
-		appWindow = xf_rail_get_window(xfc, *(UINT64*)pKeys[index]);
+		const xfAppWindow* appWindow = xf_rail_get_window(xfc, *(UINT64*)pKeys[index]);
 
 		if (!appWindow)
 		{


### PR DESCRIPTION
bug: xfreerdp abort when reconnect
rootcause: when network break, RAIL windows will be free after channel disconnect, but during attempting reconnect, RAIL window event process may still running, and try to get RAIL window in hash table.