### PR TITLE
Fix proxy rdpdr/smartcard handling

### DIFF
--- a/server/proxy/channels/pf_channel_smartcard.c
+++ b/server/proxy/channels/pf_channel_smartcard.c
@@ -81,9 +81,9 @@ static BOOL pf_channel_client_write_iostatus(wStream* out, const SMARTCARD_OPERA
 	WINPR_ASSERT(out);
 
 	pos = Stream_GetPosition(out);
+	Stream_SetPosition(out, 0);
 	if (!Stream_CheckAndLogRequiredLength(TAG, out, 16))
 		return FALSE;
-	Stream_SetPosition(out, 0);
 
 	Stream_Read_UINT16(out, component);
 	Stream_Read_UINT16(out, packetid);


### PR DESCRIPTION
This PR fixes two issues with proxy device/smartcard redirection:
- rdpdr client might receive a server capabilities request while in running state (i.e. seen this when server redirects).
- stream in smartcard redirection was checked for remaining length before its position was reset