### PR TITLE
Explicit remdesk, encomsp channel event init handling

### DIFF
--- a/channels/encomsp/client/encomsp_main.c
+++ b/channels/encomsp/client/encomsp_main.c
@@ -1171,6 +1171,9 @@ static VOID VCAPITYPE encomsp_virtual_channel_init_event_ex(LPVOID lpUserParam, 
 
 	switch (event)
 	{
+		case CHANNEL_EVENT_INITIALIZED:
+			break;
+
 		case CHANNEL_EVENT_CONNECTED:
 			if ((error = encomsp_virtual_channel_event_connected(encomsp, pData, dataLength)))
 				WLog_ERR(TAG,

--- a/channels/remdesk/client/remdesk_main.c
+++ b/channels/remdesk/client/remdesk_main.c
@@ -819,6 +819,9 @@ static VOID VCAPITYPE remdesk_virtual_channel_open_event_ex(LPVOID lpUserParam, 
 
 	switch (event)
 	{
+		case CHANNEL_EVENT_INITIALIZED:
+			break;
+
 		case CHANNEL_EVENT_DATA_RECEIVED:
 			if (!remdesk || (remdesk->OpenHandle != openHandle))
 			{
@@ -848,6 +851,7 @@ static VOID VCAPITYPE remdesk_virtual_channel_open_event_ex(LPVOID lpUserParam, 
 		default:
 			WLog_ERR(TAG, "unhandled event %" PRIu32 "!", event);
 			error = ERROR_INTERNAL_ERROR;
+			break;
 	}
 
 	if (error && remdesk && remdesk->rdpcontext)


### PR DESCRIPTION
Make sure CHANNEL_EVENT_INITIALIZED are handled explicitly to do nothing in remdesk, encomsp virtual channels. This may no longer be required since the time I had to patch this, but it doesn't hurt to clean it up a little bit instead of going to the "default" switch case statement.