### PR TITLE
Fix XCRUSH context reset

### DIFF
--- a/libfreerdp/codec/xcrush.c
+++ b/libfreerdp/codec/xcrush.c
@@ -941,6 +941,11 @@ int xcrush_decompress(XCRUSH_CONTEXT* xcrush, const BYTE* pSrcData, UINT32 SrcSi
 		return status;
 	}
 
+	if (Level2ComprFlags & PACKET_FLUSHED)
+	{
+		xcrush_context_reset(xcrush, FALSE);
+	}
+
 	status =
 	    mppc_decompress(xcrush->mppc, pSrcData, SrcSize, &pDstData, &DstSize, Level2ComprFlags);
 


### PR DESCRIPTION
Fix XCRUSH context resetting. This issue was originally observed with Lync RDP traffic while replaying a recorded pcap file offline.