### PR TITLE
Fix processing of RemoteFX and NSCodec codec ids

### DIFF
--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -1030,6 +1030,7 @@ static BOOL gdi_surface_bits(rdpContext* context, const SURFACE_BITS_COMMAND* cm
 	switch (cmd->bmp.codecID)
 	{
 		case RDP_CODEC_ID_REMOTEFX:
+		case RDP_CODEC_ID_IMAGE_REMOTEFX:
 			if (!rfx_process_message(context->codecs->rfx, cmd->bmp.bitmapData,
 			                         cmd->bmp.bitmapDataLength, cmd->destLeft, cmd->destTop,
 			                         gdi->primary_buffer, gdi->dstFormat, gdi->stride, gdi->height,

--- a/libfreerdp/gdi/graphics.c
+++ b/libfreerdp/gdi/graphics.c
@@ -131,6 +131,7 @@ static BOOL gdi_Bitmap_Decompress(rdpContext* context, rdpBitmap* bitmap, const 
                                   UINT32 DstWidth, UINT32 DstHeight, UINT32 bpp, UINT32 length,
                                   BOOL compressed, UINT32 codecId)
 {
+	int status;
 	UINT32 SrcSize = length;
 	rdpGdi* gdi = context->gdi;
 	UINT32 size = DstWidth * DstHeight;
@@ -151,7 +152,70 @@ static BOOL gdi_Bitmap_Decompress(rdpContext* context, rdpBitmap* bitmap, const 
 
 	if (compressed)
 	{
-		if (bpp < 32)
+		if ((codecId == RDP_CODEC_ID_REMOTEFX) || (codecId == RDP_CODEC_ID_IMAGE_REMOTEFX))
+		{
+			RFX_TILE* tile;
+			RFX_RECT* rect;
+			RFX_MESSAGE* message;
+			REGION16 invalidRegion;
+			region16_init(&invalidRegion);
+
+			if (!freerdp_client_codecs_prepare(context->codecs, FREERDP_CODEC_REMOTEFX, gdi->width,
+			                                   gdi->height))
+				return FALSE;
+
+			message = rfx_process_message(context->codecs->rfx, pSrcData, SrcSize, bitmap->left,
+			                              bitmap->top, bitmap->data, bitmap->format, gdi->stride, gdi->height,
+			                              &invalidRegion);
+
+			if (!message)
+			{
+				WLog_ERR(TAG, "rfx_process_message failure");
+				return FALSE;
+			}
+
+			if ((message->numTiles == 1) && (message->numRects == 1) && (DstWidth <= 64) &&
+			    (DstHeight <= 64))
+			{
+				tile = message->tiles[0];
+				rect = &message->rects[0];
+
+				freerdp_image_copy(bitmap->data,PIXEL_FORMAT_XRGB32, DstWidth * 4, 0, 0, DstWidth,
+				                   DstHeight, tile->data, PIXEL_FORMAT_XRGB32, 64 * 4, 0, 0, NULL,
+				                   FREERDP_FLIP_VERTICAL);
+			}
+			else
+			{
+				WLog_WARN(TAG, "RfxMessage: numTiles: %d numRects: %d width: %d height: %d",
+				         message->numTiles, message->numRects, DstWidth, DstHeight);
+			}
+
+			rfx_message_free(context->codecs->rfx, message);
+
+			status = 1;
+		}
+		else if (codecId == RDP_CODEC_ID_NSCODEC)
+		{
+			if (!freerdp_client_codecs_prepare(context->codecs, FREERDP_CODEC_NSCODEC, gdi->width,
+			                                   gdi->height))
+				return FALSE;
+
+			status = nsc_process_message(context->codecs->nsc, 32, DstWidth, DstHeight, pSrcData,
+			                             SrcSize, bitmap->data, bitmap->format, 0, 0, 0, DstWidth,
+			                             DstHeight, FREERDP_FLIP_VERTICAL);
+
+			if (status < 1)
+			{
+				WLog_ERR(TAG, "nsc_process_message failure");
+				return FALSE;
+			}
+
+			return freerdp_image_copy(bitmap->data, bitmap->format, 0, 0, 0, DstWidth, DstHeight,
+			                          pSrcData, PIXEL_FORMAT_XRGB32, 0, 0, 0,
+			                          &gdi->palette,
+			                          FREERDP_FLIP_VERTICAL);
+		}
+		else if (bpp < 32)
 		{
 			if (!interleaved_decompress(context->codecs->interleaved, pSrcData, SrcSize, DstWidth,
 			                            DstHeight, bpp, bitmap->data, bitmap->format, 0, 0, 0,


### PR DESCRIPTION
Fix edge cases with RemoteFX and NSCodec IDs (RDP_CODEC_ID_REMOTEFX, RDP_CODEC_ID_IMAGE_REMOTEFX, RDP_CODEC_ID_NSCODEC). These were originally observed with Lync RDP traffic but could happen with anything, so it doesn't hurt to correctly process the codec ids to determine how to decode the images.