### PR TITLE
Add settings to load a custom SSPI shared library module

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1772,6 +1772,11 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 			                                 arg->Value))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
+		CommandLineSwitchCase(arg, "sspi-module")
+		{
+			if (!freerdp_settings_set_string(settings, FreeRDP_SspiModule, arg->Value))
+				return COMMAND_LINE_ERROR_MEMORY;
+		}
 		CommandLineSwitchCase(arg, "redirect-prefer")
 		{
 			size_t count = 0;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -351,6 +351,8 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "SPN authentication service class" },
 	{ "ssh-agent", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "ssh-agent",
 	  "SSH Agent forwarding channel" },
+	{ "sspi-module", COMMAND_LINE_VALUE_REQUIRED, "<SSPI module path>", NULL, NULL, -1, NULL,
+	  "SSPI shared library module file path" },
 	{ "disable-output", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL,
 	  "Deactivate all graphics decoding in the client session. Useful for load tests with many "
 	  "simultaneous connections" },

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -635,6 +635,7 @@ typedef struct
 #define FreeRDP_NtlmSamFile (1103)
 #define FreeRDP_FIPSMode (1104)
 #define FreeRDP_TlsSecLevel (1105)
+#define FreeRDP_SspiModule (1106)
 #define FreeRDP_MstscCookieMode (1152)
 #define FreeRDP_CookieMaxLength (1153)
 #define FreeRDP_PreconnectionId (1154)
@@ -1119,7 +1120,8 @@ struct rdp_settings
 	ALIGN64 char* NtlmSamFile;                 /* 1103 */
 	ALIGN64 BOOL FIPSMode;                     /* 1104 */
 	ALIGN64 UINT32 TlsSecLevel;                /* 1105 */
-	UINT64 padding1152[1152 - 1106];           /* 1106 */
+	ALIGN64 char* SspiModule;                  /* 1106 */
+	UINT64 padding1152[1152 - 1107];           /* 1107 */
 
 	/* Connection Cookie */
 	ALIGN64 BOOL MstscCookieMode;      /* 1152 */

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -2574,6 +2574,9 @@ const char* freerdp_settings_get_string(const rdpSettings* settings, size_t id)
 		case FreeRDP_SmartcardPrivateKey:
 			return settings->SmartcardPrivateKey;
 
+		case FreeRDP_SspiModule:
+			return settings->SspiModule;
+
 		case FreeRDP_TargetNetAddress:
 			return settings->TargetNetAddress;
 
@@ -2831,6 +2834,9 @@ char* freerdp_settings_get_string_writable(rdpSettings* settings, size_t id)
 
 		case FreeRDP_SmartcardPrivateKey:
 			return settings->SmartcardPrivateKey;
+
+		case FreeRDP_SspiModule:
+			return settings->SspiModule;
 
 		case FreeRDP_TargetNetAddress:
 			return settings->TargetNetAddress;
@@ -3099,6 +3105,9 @@ BOOL freerdp_settings_set_string_(rdpSettings* settings, size_t id, const char* 
 
 		case FreeRDP_SmartcardPrivateKey:
 			return update_string(&settings->SmartcardPrivateKey, cnv.cc, len, cleanup);
+
+		case FreeRDP_SspiModule:
+			return update_string(&settings->SspiModule, cnv.cc, len, cleanup);
 
 		case FreeRDP_TargetNetAddress:
 			return update_string(&settings->TargetNetAddress, cnv.cc, len, cleanup);

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -387,6 +387,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_ShellWorkingDirectory, 7, "FreeRDP_ShellWorkingDirectory" },
 	{ FreeRDP_SmartcardCertificate, 7, "FreeRDP_SmartcardCertificate" },
 	{ FreeRDP_SmartcardPrivateKey, 7, "FreeRDP_SmartcardPrivateKey" },
+	{ FreeRDP_SspiModule, 7, "FreeRDP_SspiModule" },
 	{ FreeRDP_TargetNetAddress, 7, "FreeRDP_TargetNetAddress" },
 	{ FreeRDP_TransportDumpFile, 7, "FreeRDP_TransportDumpFile" },
 	{ FreeRDP_Username, 7, "FreeRDP_Username" },

--- a/libfreerdp/core/nla.h
+++ b/libfreerdp/core/nla.h
@@ -62,6 +62,9 @@ FREERDP_LOCAL DWORD nla_get_error(rdpNla* nla);
 
 FREERDP_LOCAL BOOL nla_set_service_principal(rdpNla* nla, LPTSTR principal);
 
+FREERDP_LOCAL BOOL nla_set_sspi_module(rdpNla* nla, const char* sspiModule);
+FREERDP_LOCAL BOOL nla_sspi_module_init(rdpNla* nla);
+
 FREERDP_LOCAL BOOL nla_impersonate(rdpNla* nla);
 FREERDP_LOCAL BOOL nla_revert_to_self(rdpNla* nla);
 

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -396,6 +396,7 @@ static const size_t string_list_indices[] = {
 	FreeRDP_ShellWorkingDirectory,
 	FreeRDP_SmartcardCertificate,
 	FreeRDP_SmartcardPrivateKey,
+	FreeRDP_SspiModule,
 	FreeRDP_TargetNetAddress,
 	FreeRDP_TransportDumpFile,
 	FreeRDP_Username,

--- a/winpr/CMakeLists.txt
+++ b/winpr/CMakeLists.txt
@@ -70,6 +70,13 @@ elseif(WITH_GSSAPI)
 	endif()
 endif()
 
+# This option MUST be off to avoid symbol conflicts when loading an external SSPI module library
+option(SSPI_DLL "Define and export SSPI API symbols for usage as a Windows SSPI DLL replacement" OFF)
+
+if(SSPI_DLL)
+	add_definitions("-DSSPI_DLL")
+endif()
+
 include(CMakeDependentOption)
 CMAKE_DEPENDENT_OPTION(WITH_GSS_NO_NTLM_FALLBACK "Do not fall back to NTLM if no kerberos ticket available" OFF "WITH_GSSAPI" OFF)
 if (WITH_GSS_NO_NTLM_FALLBACK)

--- a/winpr/include/winpr/sspi.h
+++ b/winpr/include/winpr/sspi.h
@@ -1053,6 +1053,8 @@ extern "C"
 {
 #endif
 
+#ifdef SSPI_DLL
+
 	/* Package Management */
 
 	WINPR_API SECURITY_STATUS SEC_ENTRY EnumerateSecurityPackagesA(ULONG* pcPackages,
@@ -1147,6 +1149,8 @@ extern "C"
 	WINPR_API SECURITY_STATUS SEC_ENTRY VerifySignature(PCtxtHandle phContext,
 	                                                    PSecBufferDesc pMessage, ULONG MessageSeqNo,
 	                                                    PULONG pfQOP);
+
+#endif /* SSPI_DLL */
 
 #ifdef __cplusplus
 }

--- a/winpr/libwinpr/sspi/sspi_export.c
+++ b/winpr/libwinpr/sspi/sspi_export.c
@@ -39,6 +39,8 @@ typedef LONG SECURITY_STATUS;
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #endif
 
+#ifdef SSPI_DLL
+
 /**
  * Standard SSPI API
  */
@@ -321,6 +323,8 @@ SSPI_EXPORT SECURITY_STATUS SEC_ENTRY VerifySignature(void* phContext, void* pMe
 {
 	return sspi_VerifySignature(phContext, pMessage, MessageSeqNo, pfQOP);
 }
+
+#endif /* SSPI_DLL */
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop

--- a/winpr/libwinpr/sspi/test/TestAcquireCredentialsHandle.c
+++ b/winpr/libwinpr/sspi/test/TestAcquireCredentialsHandle.c
@@ -22,7 +22,7 @@ int TestAcquireCredentialsHandle(int argc, char* argv[])
 	WINPR_UNUSED(argv);
 
 	sspi_GlobalInit();
-	table = InitSecurityInterface();
+	table = InitSecurityInterfaceEx(0);
 	identity.User = (UINT16*)_strdup(test_User);
 	identity.Domain = (UINT16*)_strdup(test_Domain);
 	identity.Password = (UINT16*)_strdup(test_Password);

--- a/winpr/libwinpr/sspi/test/TestEnumerateSecurityPackages.c
+++ b/winpr/libwinpr/sspi/test/TestEnumerateSecurityPackages.c
@@ -11,13 +11,15 @@ int TestEnumerateSecurityPackages(int argc, char* argv[])
 	ULONG cPackages;
 	SECURITY_STATUS status;
 	SecPkgInfo* pPackageInfo;
+	SecurityFunctionTable* table;
 
 	WINPR_UNUSED(argc);
 	WINPR_UNUSED(argv);
 
 	sspi_GlobalInit();
+	table = InitSecurityInterfaceEx(0);
 
-	status = EnumerateSecurityPackages(&cPackages, &pPackageInfo);
+	status = table->EnumerateSecurityPackages(&cPackages, &pPackageInfo);
 
 	if (status != SEC_E_OK)
 	{
@@ -32,7 +34,7 @@ int TestEnumerateSecurityPackages(int argc, char* argv[])
 		_tprintf(_T("\"%s\", \"%s\"\n"), pPackageInfo[index].Name, pPackageInfo[index].Comment);
 	}
 
-	FreeContextBuffer(pPackageInfo);
+	table->FreeContextBuffer(pPackageInfo);
 	sspi_GlobalFinish();
 
 	return 0;

--- a/winpr/libwinpr/sspi/test/TestInitializeSecurityContext.c
+++ b/winpr/libwinpr/sspi/test/TestInitializeSecurityContext.c
@@ -30,8 +30,8 @@ int TestInitializeSecurityContext(int argc, char* argv[])
 	WINPR_UNUSED(argv);
 
 	sspi_GlobalInit();
-	table = InitSecurityInterface();
-	status = QuerySecurityPackageInfo(NTLM_SSP_NAME, &pPackageInfo);
+	table = InitSecurityInterfaceEx(0);
+	status = table->QuerySecurityPackageInfo(NTLM_SSP_NAME, &pPackageInfo);
 
 	if (status != SEC_E_OK)
 	{
@@ -109,7 +109,7 @@ fail:
 	if (SecIsValidHandle(&credentials))
 		table->FreeCredentialsHandle(&credentials);
 
-	FreeContextBuffer(pPackageInfo);
+	table->FreeContextBuffer(pPackageInfo);
 	sspi_GlobalFinish();
 	return rc;
 }

--- a/winpr/libwinpr/sspi/test/TestQuerySecurityPackageInfo.c
+++ b/winpr/libwinpr/sspi/test/TestQuerySecurityPackageInfo.c
@@ -9,12 +9,15 @@ int TestQuerySecurityPackageInfo(int argc, char* argv[])
 	int rc;
 	SECURITY_STATUS status;
 	SecPkgInfo* pPackageInfo;
+	SecurityFunctionTable* table;
 
 	WINPR_UNUSED(argc);
 	WINPR_UNUSED(argv);
 
 	sspi_GlobalInit();
-	status = QuerySecurityPackageInfo(NTLM_SSP_NAME, &pPackageInfo);
+	table = InitSecurityInterfaceEx(0);
+
+	status = table->QuerySecurityPackageInfo(NTLM_SSP_NAME, &pPackageInfo);
 
 	if (status != SEC_E_OK)
 		rc = -1;
@@ -25,7 +28,7 @@ int TestQuerySecurityPackageInfo(int argc, char* argv[])
 		rc = 0;
 	}
 
-	FreeContextBuffer(pPackageInfo);
+	table->FreeContextBuffer(pPackageInfo);
 	sspi_GlobalFinish();
 	return rc;
 }


### PR DESCRIPTION
This pull requests as a new SspiModule setting that can be set to the full path to a shared library that exports the same APIs as secur32.dll on Windows. FreeRDP is already designed to use either the Windows SSPI modules or the WinPR SSPI modules, so it's a relatively minor change. I also added the "--sspi-module" command-line parameter to set the SspiModule setting.

I am working on [portable SSPI modules](https://github.com/Devolutions/sspi-rs) in pure Rust that can be injected in FreeRDP, but also any other project that can use the SSPI APIs (we have lots of other protocols where Kerberos support is becoming a problem). Some improvements are still required, but we've managed to get Kerberos connectivity using sspi-rs this week.

We intend to start replacing the WinPR SSPI modules by sspi-rs Rust SSPI modules in Remote Desktop Manager for all of our platforms, and enjoy the exact same level of NTLM/Kerberos support that does not rely on system SSPI or GSSAPI libraries. This of course includes platforms like Android and iOS where system GSSAPI libraries are not present.