### PR TITLE
Revert "* libfreerdp-codec: fix XCRUSH context reset"

### DIFF
--- a/libfreerdp/codec/xcrush.c
+++ b/libfreerdp/codec/xcrush.c
@@ -941,11 +941,6 @@ int xcrush_decompress(XCRUSH_CONTEXT* xcrush, const BYTE* pSrcData, UINT32 SrcSi
 		return status;
 	}
 
-	if (Level2ComprFlags & PACKET_FLUSHED)
-	{
-		xcrush_context_reset(xcrush, FALSE);
-	}
-
 	status =
 	    mppc_decompress(xcrush->mppc, pSrcData, SrcSize, &pDstData, &DstSize, Level2ComprFlags);
 


### PR DESCRIPTION
Revert the recent change to call xcrush_context_reset(xcrush, FALSE); when Level2ComprFlags & PACKET_FLUSHED is true. I know this was once required to fix xcrush-related issues while replaying pcap files, but it apparently causes random decompression corruption failures for regular connections. Let's just revert the change for now, and revisit it later.