### PR TITLE
Add WTSChannelGetOptions (for retrieving peer channel option flags)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 # 20xx-xx-xx Version 2.x.x
 
 Noteworthy changes:
+* Backported API to get peer accepted channel option flags
 * Backported API to get peer accepted channel names
 * Backported Stream_CheckAndLogRequiredLength
 * Backported server side handling for [MS-RDPET] (#7954)
@@ -603,4 +604,3 @@ Virtual Channels:
 * rdpsnd (Sound Redirection)
 	* alsa support
 	* pulse support
-

--- a/include/freerdp/channels/wtsvc.h
+++ b/include/freerdp/channels/wtsvc.h
@@ -82,6 +82,7 @@ extern "C"
 	FREERDP_API void* WTSChannelGetHandleByName(freerdp_peer* client, const char* channel_name);
 	FREERDP_API void* WTSChannelGetHandleById(freerdp_peer* client, const UINT16 channel_id);
 	FREERDP_API const char* WTSChannelGetName(freerdp_peer* client, UINT16 channel_id);
+	FREERDP_API INT64 WTSChannelGetOptions(freerdp_peer* client, UINT16 channel_id);
 	FREERDP_API char** WTSGetAcceptedChannelNames(freerdp_peer* client, size_t* count);
 
 	FREERDP_API UINT32 WTSChannelGetIdByHandle(HANDLE hChannelHandle);

--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -696,6 +696,21 @@ const char* WTSChannelGetName(freerdp_peer* client, UINT16 channel_id)
 	return (const char*)channel->Name;
 }
 
+INT64 WTSChannelGetOptions(freerdp_peer* client, UINT16 channel_id)
+{
+	rdpMcsChannel* channel;
+
+	if (!client || !client->context || !client->context->rdp)
+		return -1;
+
+	channel = wts_get_joined_channel_by_id(client->context->rdp->mcs, channel_id);
+
+	if (!channel)
+		return -1;
+
+	return (INT64)channel->options;
+}
+
 char** WTSGetAcceptedChannelNames(freerdp_peer* client, size_t* count)
 {
 	rdpMcs* mcs;


### PR DESCRIPTION
Along with the existing `WTSChannelGetName` function, `WTSChannelGetOptions` enables the names and option flags of a peer's connected channels to be retrieved. This is useful for populating a client's channel definitions before it connects, for example in an RDP proxy where all channel data is simply passed through.

Backport of #7945
