### PR TITLE
Add WTSChannelGetOptions

### DIFF
--- a/include/freerdp/channels/wtsvc.h
+++ b/include/freerdp/channels/wtsvc.h
@@ -80,6 +80,7 @@ extern "C"
 	FREERDP_API void* WTSChannelGetHandleById(freerdp_peer* client, const UINT16 channel_id);
 	FREERDP_API const char* WTSChannelGetName(freerdp_peer* client, UINT16 channel_id);
 	FREERDP_API char** WTSGetAcceptedChannelNames(freerdp_peer* client, size_t* count);
+	FREERDP_API INT64 WTSChannelGetOptions(freerdp_peer* client, UINT16 channel_id);
 
 #ifdef __cplusplus
 }

--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -805,6 +805,21 @@ char** WTSGetAcceptedChannelNames(freerdp_peer* client, size_t* count)
 	return names;
 }
 
+INT64 WTSChannelGetOptions(freerdp_peer* client, UINT16 channel_id)
+{
+	rdpMcsChannel* channel;
+
+	if (!client || !client->context || !client->context->rdp)
+		return -1;
+
+	channel = wts_get_joined_channel_by_id(client->context->rdp->mcs, channel_id);
+
+	if (!channel)
+		return -1;
+
+	return (INT64)channel->options;
+}
+
 BOOL WINAPI FreeRDP_WTSStartRemoteControlSessionW(LPWSTR pTargetServerName, ULONG TargetLogonId,
                                                   BYTE HotkeyVk, USHORT HotkeyModifiers)
 {


### PR DESCRIPTION
Along with the existing `WTSChannelGetName` function, `WTSChannelGetOptions` enables the names and option flags of a peer's connected channels to be retrieved. This is useful for populating a client's channel definitions before it connects, for example in an RDP proxy where all channel data is simply passed through.

Could this change also be backported to `stable-2.0`? (See #7941 for reference.)