### PR TITLE
Backport API to get peer accepted channel names

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,8 @@
 # 20xx-xx-xx Version 2.x.x
 
 Noteworthy changes:
- 
+* Backported API to get peer accepted channel names
+
 Fixed issues:
 * Fixed #7837: Prevent out of bound reads for FFMPEG
 * Backported #7859 and #7861: Unwind support for backtrace generation

--- a/include/freerdp/channels/wtsvc.h
+++ b/include/freerdp/channels/wtsvc.h
@@ -76,6 +76,7 @@ extern "C"
 	FREERDP_API void* WTSChannelGetHandleByName(freerdp_peer* client, const char* channel_name);
 	FREERDP_API void* WTSChannelGetHandleById(freerdp_peer* client, const UINT16 channel_id);
 	FREERDP_API const char* WTSChannelGetName(freerdp_peer* client, UINT16 channel_id);
+	FREERDP_API char** WTSGetAcceptedChannelNames(freerdp_peer* client, size_t* count);
 
 #ifdef __cplusplus
 }

--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -670,6 +670,28 @@ const char* WTSChannelGetName(freerdp_peer* client, UINT16 channel_id)
 	return (const char*)channel->Name;
 }
 
+char** WTSGetAcceptedChannelNames(freerdp_peer* client, size_t* count)
+{
+	rdpMcs* mcs;
+	char** names;
+	UINT32 index;
+
+	if (!client || !client->context || !count)
+		return NULL;
+
+	mcs = client->context->rdp->mcs;
+	*count = mcs->channelCount;
+
+	names = (char**)calloc(mcs->channelCount, sizeof(char*));
+	if (!names)
+		return NULL;
+
+	for (index = 0; index < mcs->channelCount; index++)
+		names[index] = mcs->channels[index].Name;
+
+	return names;
+}
+
 BOOL WINAPI FreeRDP_WTSStartRemoteControlSessionW(LPWSTR pTargetServerName, ULONG TargetLogonId,
                                                   BYTE HotkeyVk, USHORT HotkeyModifiers)
 {


### PR DESCRIPTION
Backport `WTSGetAcceptedChannelNames` from `master`.
