### PR TITLE
proxy: correctly handle dynamic channel fragmentation

### DIFF
--- a/include/freerdp/server/proxy/proxy_context.h
+++ b/include/freerdp/server/proxy/proxy_context.h
@@ -36,7 +36,7 @@ extern "C"
 
 	typedef struct proxy_data proxyData;
 	typedef struct proxy_module proxyModule;
-	typedef struct p_server_channel_context pServerChannelContext;
+	typedef struct p_server_static_channel_context pServerStaticChannelContext;
 
 	typedef struct s_InterceptContextMapEntry
 	{
@@ -56,16 +56,6 @@ extern "C"
 		PF_UTILS_CHANNEL_INTERCEPT,	  /*!< inspect traffic from this channel */
 	} pf_utils_channel_mode;
 
-	/** @brief channel opened status */
-	typedef enum
-	{
-		CHANNEL_OPENSTATE_WAITING_OPEN_STATUS, /*!< dynamic channel waiting for create response */
-		CHANNEL_OPENSTATE_OPENED,			   /*!< opened */
-		CHANNEL_OPENSTATE_CLOSED			   /*!< dynamic channel has been opened then closed */
-	} PfChannelOpenStatus;
-
-	#define PF_DYNAMIC_CHANNEL_MASK 0xFFFF000000000000
-
 	/** @brief result of a channel treatment */
 	typedef enum
 	{
@@ -74,18 +64,16 @@ extern "C"
 		PF_CHANNEL_RESULT_ERROR  /*!< error during packet treatment */
 	} PfChannelResult;
 
-	typedef PfChannelResult (*proxyChannelDataFn)(proxyData* pdata, const pServerChannelContext* channel,
+	typedef PfChannelResult (*proxyChannelDataFn)(proxyData* pdata, const pServerStaticChannelContext* channel,
             const BYTE* xdata, size_t xsize, UINT32 flags,
             size_t totalSizepServer);
 	typedef void (*proxyChannelContextDtor)(void *context);
 
 	/** @brief per channel configuration */
-	struct p_server_channel_context
+	struct p_server_static_channel_context
 	{
 		char* channel_name;
-		UINT64 channel_id;
-		PfChannelOpenStatus openStatus;
-		BOOL isDynamic;
+		UINT32 channel_id;
 		pf_utils_channel_mode channelMode;
 		proxyChannelDataFn onFrontData;
 		proxyChannelDataFn onBackData;
@@ -93,7 +81,7 @@ extern "C"
 		void *context;
 	};
 
-	void ChannelContext_free(pServerChannelContext* ctx);
+	void StaticChannelContext_free(pServerStaticChannelContext* ctx);
 
 	/**
 	 * Wraps rdpContext and holds the state for the proxy's server.
@@ -112,7 +100,7 @@ extern "C"
 	};
 	typedef struct p_server_context pServerContext;
 
-	pServerChannelContext* ChannelContext_new(pServerContext* ps, const char* name, UINT64 id);
+	pServerStaticChannelContext* StaticChannelContext_new(pServerContext* ps, const char* name, UINT32 id);
 
 	/**
 	 * Wraps rdpContext and holds the state for the proxy's client.

--- a/server/proxy/channels/pf_channel_drdynvc.h
+++ b/server/proxy/channels/pf_channel_drdynvc.h
@@ -22,6 +22,6 @@
 #include <freerdp/server/proxy/proxy_context.h>
 
 
-BOOL pf_channel_setup_drdynvc(proxyData* pdata, pServerChannelContext* channel);
+BOOL pf_channel_setup_drdynvc(proxyData* pdata, pServerStaticChannelContext* channel);
 
 #endif /* SERVER_PROXY_CHANNELS_PF_CHANNEL_DRDYNVC_H_ */

--- a/server/proxy/channels/pf_channel_rdpdr.c
+++ b/server/proxy/channels/pf_channel_rdpdr.c
@@ -1714,7 +1714,7 @@ BOOL pf_channel_rdpdr_client_reset(pClientContext* pc)
 	return TRUE;
 }
 
-static PfChannelResult pf_rdpdr_back_data(proxyData* pdata, const pServerChannelContext* channel,
+static PfChannelResult pf_rdpdr_back_data(proxyData* pdata, const pServerStaticChannelContext* channel,
                                           const BYTE* xdata, size_t xsize, UINT32 flags,
                                           size_t totalSize)
 {
@@ -1730,7 +1730,7 @@ static PfChannelResult pf_rdpdr_back_data(proxyData* pdata, const pServerChannel
 	return PF_CHANNEL_RESULT_PASS;
 }
 
-static PfChannelResult pf_rdpdr_front_data(proxyData* pdata, const pServerChannelContext* channel,
+static PfChannelResult pf_rdpdr_front_data(proxyData* pdata, const pServerStaticChannelContext* channel,
                                            const BYTE* xdata, size_t xsize, UINT32 flags,
                                            size_t totalSize)
 {
@@ -1746,7 +1746,7 @@ static PfChannelResult pf_rdpdr_front_data(proxyData* pdata, const pServerChanne
 	return PF_CHANNEL_RESULT_PASS;
 }
 
-BOOL pf_channel_setup_rdpdr(pServerContext* ps, pServerChannelContext* channel)
+BOOL pf_channel_setup_rdpdr(pServerContext* ps, pServerStaticChannelContext* channel)
 {
 	channel->onBackData = pf_rdpdr_back_data;
 	channel->onFrontData = pf_rdpdr_front_data;

--- a/server/proxy/pf_channel.c
+++ b/server/proxy/pf_channel.c
@@ -25,7 +25,7 @@
 
 #define TAG PROXY_TAG("channel")
 
-ChannelStateTracker* channelTracker_new(pServerChannelContext* channel, ChannelTrackerPeekFn fn, void* data)
+ChannelStateTracker* channelTracker_new(pServerStaticChannelContext* channel, ChannelTrackerPeekFn fn, void* data)
 {
 	ChannelStateTracker* ret = calloc(1, sizeof(ChannelStateTracker));
 	if (!ret)
@@ -134,7 +134,7 @@ PfChannelResult channelTracker_flushCurrent(ChannelStateTracker* t, BOOL first, 
 {
 	proxyData* pdata;
 	pServerContext* ps;
-	pServerChannelContext* channel;
+	pServerStaticChannelContext* channel;
 	UINT32 flags = CHANNEL_FLAG_FIRST;
 	BOOL r;
 	const char* direction = toBack ? "F->B" : "B->F";
@@ -178,7 +178,7 @@ PfChannelResult channelTracker_flushCurrent(ChannelStateTracker* t, BOOL first, 
 
 
 
-static PfChannelResult pf_channel_generic_back_data(proxyData* pdata, const pServerChannelContext* channel,
+static PfChannelResult pf_channel_generic_back_data(proxyData* pdata, const pServerStaticChannelContext* channel,
             const BYTE* xdata, size_t xsize, UINT32 flags,
             size_t totalSize)
 {
@@ -209,7 +209,7 @@ static PfChannelResult pf_channel_generic_back_data(proxyData* pdata, const pSer
 	}
 }
 
-static PfChannelResult pf_channel_generic_front_data(proxyData* pdata, const pServerChannelContext* channel,
+static PfChannelResult pf_channel_generic_front_data(proxyData* pdata, const pServerStaticChannelContext* channel,
             const BYTE* xdata, size_t xsize, UINT32 flags,
             size_t totalSize)
 {
@@ -241,7 +241,7 @@ static PfChannelResult pf_channel_generic_front_data(proxyData* pdata, const pSe
 }
 
 
-BOOL pf_channel_setup_generic(pServerChannelContext* channel)
+BOOL pf_channel_setup_generic(pServerStaticChannelContext* channel)
 {
 	channel->onBackData = pf_channel_generic_back_data;
 	channel->onFrontData = pf_channel_generic_front_data;

--- a/server/proxy/pf_channel.h
+++ b/server/proxy/pf_channel.h
@@ -35,7 +35,7 @@ typedef PfChannelResult (*ChannelTrackerPeekFn)(ChannelStateTracker* tracker, BO
 
 /** @brief a tracker for channel packets */
 struct _ChannelStateTracker {
-	pServerChannelContext* channel;
+	pServerStaticChannelContext* channel;
 	ChannelTrackerMode mode;
 	wStream* currentPacket;
 	size_t currentPacketReceived;
@@ -47,7 +47,7 @@ struct _ChannelStateTracker {
 	proxyData* pdata;
 };
 
-ChannelStateTracker* channelTracker_new(pServerChannelContext* channel, ChannelTrackerPeekFn fn, void* data);
+ChannelStateTracker* channelTracker_new(pServerStaticChannelContext* channel, ChannelTrackerPeekFn fn, void* data);
 
 void channelTracker_free(ChannelStateTracker* t);
 
@@ -57,8 +57,8 @@ PfChannelResult channelTracker_update(ChannelStateTracker* tracker, const BYTE* 
 PfChannelResult channelTracker_flushCurrent(ChannelStateTracker* t, BOOL first, BOOL last, BOOL toFront);
 
 
-BOOL pf_channel_setup_rdpdr(pServerContext* ps, pServerChannelContext* channel);
-BOOL pf_channel_setup_generic(pServerChannelContext* channel);
+BOOL pf_channel_setup_rdpdr(pServerContext* ps, pServerStaticChannelContext* channel);
+BOOL pf_channel_setup_generic(pServerStaticChannelContext* channel);
 
 
 #endif /* SERVER_PROXY_PF_CHANNEL_H_ */

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -381,7 +381,7 @@ static BOOL pf_client_receive_channel_data_hook(freerdp* instance, UINT16 channe
 	pClientContext* pc;
 	pServerContext* ps;
 	proxyData* pdata;
-	pServerChannelContext* channel;
+	pServerStaticChannelContext* channel;
 	UINT16 server_channel_id;
 	UINT64 channelId64 = channelId;
 

--- a/server/proxy/pf_context.c
+++ b/server/proxy/pf_context.c
@@ -37,30 +37,29 @@
 
 static UINT32 ChannelId_Hash(const void* key)
 {
-	const UINT64* v = (const UINT64*)key;
-	return (*v & 0xFFFFFFFF) + (*v >> 32);
+	const UINT32* v = (const UINT32*)key;
+	return *v;
 }
 
-static BOOL ChannelId_Compare(const UINT64* v1, const UINT64* v2)
+static BOOL ChannelId_Compare(const UINT32* v1, const UINT32* v2)
 {
 	return (*v1 == *v2);
 }
 
-pServerChannelContext* ChannelContext_new(pServerContext* ps, const char* name, UINT64 id)
+pServerStaticChannelContext* StaticChannelContext_new(pServerContext* ps, const char* name, UINT32 id)
 {
-	pServerChannelContext* ret = calloc(1, sizeof(*ret));
+	pServerStaticChannelContext* ret = calloc(1, sizeof(*ret));
 	if (!ret)
 	{
 		PROXY_LOG_ERR(TAG, ps, "error allocating channel context for '%s'", name);
 		return NULL;
 	}
 
-	ret->openStatus = CHANNEL_OPENSTATE_OPENED;
 	ret->channel_id = id;
 	ret->channel_name = _strdup(name);
 	if (!ret->channel_name)
 	{
-		PROXY_LOG_ERR(TAG, ps, "error allocating name in channel context for '%s'", ret);
+		PROXY_LOG_ERR(TAG, ps, "error allocating name in channel context for '%s'", name);
 		free(ret);
 		return NULL;
 	}
@@ -69,7 +68,7 @@ pServerChannelContext* ChannelContext_new(pServerContext* ps, const char* name, 
 	return ret;
 }
 
-void ChannelContext_free(pServerChannelContext* ctx)
+void StaticChannelContext_free(pServerStaticChannelContext* ctx)
 {
 	if (!ctx)
 		return;
@@ -120,7 +119,7 @@ static BOOL client_to_proxy_context_new(freerdp_peer* client, rdpContext* ctx)
 	obj->fnObjectEquals = (OBJECT_EQUALS_FN)ChannelId_Compare;
 
 	obj = HashTable_ValueObject(context->channelsById);
-	obj->fnObjectFree = (OBJECT_FREE_FN)ChannelContext_free;
+	obj->fnObjectFree = (OBJECT_FREE_FN)StaticChannelContext_free;
 	return TRUE;
 
 error:

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -202,12 +202,12 @@ static BOOL pf_server_setup_channels(freerdp_peer* peer)
 
 	for (i = 0; i < accepted_channels_count; i++)
 	{
-		pServerChannelContext* channelContext;
+		pServerStaticChannelContext* channelContext;
 		const char* cname = accepted_channels[i];
 		UINT16 channelId = WTSChannelGetId(peer, cname);
 
 		PROXY_LOG_INFO(TAG, ps, "Accepted channel: %s (%d)", cname, channelId);
-		channelContext = ChannelContext_new(ps, cname, channelId);
+		channelContext = StaticChannelContext_new(ps, cname, channelId);
 		if (!channelContext)
 		{
 			PROXY_LOG_ERR(TAG, ps, "error seting up channelContext for '%s'", cname);
@@ -219,7 +219,7 @@ static BOOL pf_server_setup_channels(freerdp_peer* peer)
 			if (!pf_channel_setup_drdynvc(ps->pdata, channelContext))
 			{
 				PROXY_LOG_ERR(TAG, ps, "error while setting up dynamic channel");
-				ChannelContext_free(channelContext);
+				StaticChannelContext_free(channelContext);
 				return FALSE;
 			}
 		}
@@ -228,7 +228,7 @@ static BOOL pf_server_setup_channels(freerdp_peer* peer)
 			if (!pf_channel_setup_rdpdr(ps, channelContext))
 			{
 				PROXY_LOG_ERR(TAG, ps, "error while setting up redirection channel");
-				ChannelContext_free(channelContext);
+				StaticChannelContext_free(channelContext);
 				return FALSE;
 			}
 		}
@@ -237,14 +237,14 @@ static BOOL pf_server_setup_channels(freerdp_peer* peer)
 			if (!pf_channel_setup_generic(channelContext))
 			{
 				PROXY_LOG_ERR(TAG, ps, "error while setting up generic channel");
-				ChannelContext_free(channelContext);
+				StaticChannelContext_free(channelContext);
 				return FALSE;
 			}
 		}
 
 		if (!HashTable_Insert(byId, &channelContext->channel_id, channelContext))
 		{
-			ChannelContext_free(channelContext);
+			StaticChannelContext_free(channelContext);
 			PROXY_LOG_ERR(TAG, ps, "error inserting channelContext in byId table for '%s'", cname);
 			return FALSE;
 		}
@@ -385,7 +385,7 @@ static BOOL pf_server_receive_channel_data_hook(freerdp_peer* peer, UINT16 chann
 	pClientContext* pc;
 	proxyData* pdata;
 	const proxyConfig* config;
-	const pServerChannelContext* channel;
+	const pServerStaticChannelContext* channel;
 	UINT64 channelId64 = channelId;
 
 	WINPR_ASSERT(peer);


### PR DESCRIPTION
This big patch fixes fragmentation handling in the dynamic channel. We used to have a single state to handle fragmentation at the main dynamic channel level, but in fact packets can be fragmented per sub channel. So we have to maintain a fragmentation
state per sub channel, this involve treating dynamic and static channels differently (so the size of the patch that has to implement state tracking per dynamic channels).
