### PR TITLE
Add new cmakedefine flag for enforcing TL1.2 connection

### DIFF
--- a/include/config/config.h.in
+++ b/include/config/config.h.in
@@ -52,6 +52,8 @@
 #cmakedefine WITH_CHANNEL_GFXREDIR
 #cmakedefine WITH_CHANNEL_RDPAPPLIST
 
+#cmakedefine ENFORCE_TLSV1_2
+
 /* Plugins */
 #cmakedefine WITH_RDPDR
 

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -862,7 +862,12 @@ int tls_connect(rdpTls* tls, BIO* underlying)
 
 	if (!tls_prepare(tls, underlying, SSLv23_client_method(), options, TRUE))
 #else
-	if (!tls_prepare(tls, underlying, TLS_client_method(), options, TRUE))
+	#if defined ENFORCE_TLSV1_2
+		if (!tls_prepare(tls, underlying, TLSv1_2_client_method(), options, TRUE))
+	#else
+		if (!tls_prepare(tls, underlying, TLS_client_method(), options, TRUE))
+	#endif
+
 #endif
 		return 0;
 


### PR DESCRIPTION
I'm facing a TLS_CONNECT_ERROR issue where a customer has both TLS1.3 and TLS1.2 enabled on their windows 2019 server - which I believe has experimental support for TLS1.3. And because the server doesn't have full TLS1.3 support, calling `TLS_client_method` in `tls.c` - which negotiates the highest available TLS version, fails to establish a proper connection as the server sends back a `RST` after `ClientHello`. 

Note that this is not an issue with Windows 2022 server - which has full support for TLS1.3. With both TLS1.2 and TLS1.3 enabled on a win 2022 server, FreeRDP can connect just fine to the target VM. 


This PR adds a compile time directive to enforce TLS1.2 that is set through our application that consumes FreeRDP. 

Please advice if there is a less intrusive way to enforce TLS1.2 during the initial TLS handshake.