### PR TITLE
Redirect channel fix

### DIFF
--- a/channels/rdpdr/client/rdpdr_capabilities.c
+++ b/channels/rdpdr/client/rdpdr_capabilities.c
@@ -258,7 +258,9 @@ UINT rdpdr_process_capability_request(rdpdrPlugin* rdpdr, wStream* s)
 UINT rdpdr_send_capability_response(rdpdrPlugin* rdpdr)
 {
 	wStream* s;
-	s = Stream_New(NULL, 256);
+
+	WINPR_ASSERT(rdpdr);
+	s = StreamPool_Take(rdpdr->pool, 256);
 
 	if (!s)
 	{

--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -165,7 +165,7 @@ static UINT rdpdr_send_device_list_remove_request(rdpdrPlugin* rdpdr, UINT32 cou
 	WINPR_ASSERT(rdpdr);
 	WINPR_ASSERT(ids || (count == 0));
 
-	s = Stream_New(NULL, count * sizeof(UINT32) + 8);
+	s = StreamPool_Take(rdpdr->pool, count * sizeof(UINT32) + 8);
 
 	if (!s)
 	{
@@ -1137,7 +1137,7 @@ static UINT rdpdr_send_client_announce_reply(rdpdrPlugin* rdpdr)
 
 	WINPR_ASSERT(rdpdr);
 
-	s = Stream_New(NULL, 12);
+	s = StreamPool_Take(rdpdr->pool, 12);
 
 	if (!s)
 	{
@@ -1174,7 +1174,8 @@ static UINT rdpdr_send_client_name_request(rdpdrPlugin* rdpdr)
 
 	computerNameLenW = ConvertToUnicode(CP_UTF8, 0, rdpdr->computerName, -1, &computerNameW, 0) * 2;
 	WINPR_ASSERT(computerNameLenW >= 0);
-	s = Stream_New(NULL, 16U + (size_t)computerNameLenW);
+
+	s = StreamPool_Take(rdpdr->pool, 16U + (size_t)computerNameLenW);
 
 	if (!s)
 	{
@@ -1342,7 +1343,7 @@ static UINT dummy_irp_response(rdpdrPlugin* rdpdr, wStream* s)
 	WINPR_ASSERT(rdpdr);
 	WINPR_ASSERT(s);
 
-	output = Stream_New(NULL, 256); // RDPDR_DEVICE_IO_RESPONSE_LENGTH
+	output = StreamPool_Take(rdpdr->pool, 256); // RDPDR_DEVICE_IO_RESPONSE_LENGTH
 	if (!output)
 	{
 		WLog_ERR(TAG, "Stream_New failed!");

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -129,6 +129,7 @@ typedef enum
 /* Early Capability Flags (Server to Client) */
 #define RNS_UD_SC_EDGE_ACTIONS_SUPPORTED 0x00000001
 #define RNS_UD_SC_DYNAMIC_DST_SUPPORTED 0x00000002
+#define RNS_UD_SC_EDGE_ACTIONS_SUPPORTED_V2 0x00000004
 
 /* Cluster Information Flags */
 #define REDIRECTION_SUPPORTED 0x00000001
@@ -1710,6 +1711,8 @@ extern "C"
 #endif
 
 	FREERDP_API void freerdp_dynamic_channel_collection_free(rdpSettings* settings);
+	FREERDP_API void freerdp_capability_buffer_free(rdpSettings* settings);
+	FREERDP_API BOOL freerdp_capability_buffer_copy(rdpSettings* settings, const rdpSettings* src);
 
 	FREERDP_API void freerdp_target_net_addresses_free(rdpSettings* settings);
 	FREERDP_API BOOL freerdp_target_net_addresses_copy(rdpSettings* settings, char** addresses,

--- a/libfreerdp/core/client.c
+++ b/libfreerdp/core/client.c
@@ -304,7 +304,8 @@ UINT freerdp_channels_attach(freerdp* instance)
 
 	channels = instance->context->channels;
 	hostname = freerdp_settings_get_string(instance->context->settings, FreeRDP_ServerHostname);
-	hostnameLength = strlen(hostname);
+	WINPR_ASSERT(hostname);
+	hostnameLength = strnlen(hostname, MAX_PATH);
 
 	for (index = 0; index < channels->clientDataCount; index++)
 	{
@@ -367,7 +368,8 @@ UINT freerdp_channels_detach(freerdp* instance)
 
 	WINPR_ASSERT(context->settings);
 	hostname = freerdp_settings_get_string(context->settings, FreeRDP_ServerHostname);
-	hostnameLength = strlen(hostname);
+	WINPR_ASSERT(hostname);
+	hostnameLength = strnlen(hostname, MAX_PATH);
 
 	for (index = 0; index < channels->clientDataCount; index++)
 	{
@@ -430,7 +432,8 @@ UINT freerdp_channels_post_connect(rdpChannels* channels, freerdp* instance)
 
 	channels->connected = TRUE;
 	hostname = freerdp_settings_get_string(instance->context->settings, FreeRDP_ServerHostname);
-	hostnameLength = strlen(hostname);
+	WINPR_ASSERT(hostname);
+	hostnameLength = strnlen(hostname, MAX_PATH);
 
 	for (index = 0; index < channels->clientDataCount; index++)
 	{

--- a/libfreerdp/core/client.c
+++ b/libfreerdp/core/client.c
@@ -303,7 +303,7 @@ UINT freerdp_channels_attach(freerdp* instance)
 	WINPR_ASSERT(instance->context->settings);
 
 	channels = instance->context->channels;
-	hostname = instance->context->settings->ServerHostname;
+	hostname = freerdp_settings_get_string(instance->context->settings, FreeRDP_ServerHostname);
 	hostnameLength = strlen(hostname);
 
 	for (index = 0; index < channels->clientDataCount; index++)
@@ -366,7 +366,7 @@ UINT freerdp_channels_detach(freerdp* instance)
 	WINPR_ASSERT(channels);
 
 	WINPR_ASSERT(context->settings);
-	hostname = context->settings->ServerHostname;
+	hostname = freerdp_settings_get_string(context->settings, FreeRDP_ServerHostname);
 	hostnameLength = strlen(hostname);
 
 	for (index = 0; index < channels->clientDataCount; index++)
@@ -429,7 +429,7 @@ UINT freerdp_channels_post_connect(rdpChannels* channels, freerdp* instance)
 	WINPR_ASSERT(instance->context->settings);
 
 	channels->connected = TRUE;
-	hostname = instance->context->settings->ServerHostname;
+	hostname = freerdp_settings_get_string(instance->context->settings, FreeRDP_ServerHostname);
 	hostnameLength = strlen(hostname);
 
 	for (index = 0; index < channels->clientDataCount; index++)
@@ -575,7 +575,7 @@ const char* freerdp_channels_get_name_by_id(freerdp* instance, UINT16 channelId)
 	if (!mcsChannel)
 		return NULL;
 
-	return (const char*)mcsChannel->Name;
+	return mcsChannel->Name;
 }
 
 BOOL freerdp_channels_process_message_free(wMessage* message, DWORD type)
@@ -913,6 +913,8 @@ static UINT VCAPITYPE FreeRDP_VirtualChannelInitEx(
 		{
 			CHANNEL_DEF* channel = freerdp_settings_get_pointer_array_writable(
 			    settings, FreeRDP_ChannelDefArray, settings->ChannelCount);
+			if (!channel)
+				continue;
 			strncpy(channel->name, pChannelDef->name, CHANNEL_NAME_LEN);
 			channel->options = pChannelDef->options;
 			settings->ChannelCount++;
@@ -990,6 +992,8 @@ static UINT VCAPITYPE FreeRDP_VirtualChannelInit(LPVOID* ppInitHandle, PCHANNEL_
 
 	for (index = 0; index < channelCount; index++)
 	{
+		UINT32 ChannelCount = freerdp_settings_get_uint32(settings, FreeRDP_ChannelCount);
+
 		pChannelDef = &pChannel[index];
 		pChannelOpenData = &channels->openDataList[channels->openDataCount];
 		pChannelOpenData->OpenHandle = InterlockedIncrement(&g_OpenHandleSeq);
@@ -1001,13 +1005,14 @@ static UINT VCAPITYPE FreeRDP_VirtualChannelInit(LPVOID* ppInitHandle, PCHANNEL_
 		strncpy(pChannelOpenData->name, pChannelDef->name, CHANNEL_NAME_LEN);
 		pChannelOpenData->options = pChannelDef->options;
 
-		if (settings->ChannelCount < CHANNEL_MAX_COUNT)
+		if (ChannelCount < CHANNEL_MAX_COUNT)
 		{
 			channel = freerdp_settings_get_pointer_array_writable(settings, FreeRDP_ChannelDefArray,
-			                                                      settings->ChannelCount);
+			                                                      ChannelCount++);
 			strncpy(channel->name, pChannelDef->name, CHANNEL_NAME_LEN);
 			channel->options = pChannelDef->options;
-			settings->ChannelCount++;
+			if (!freerdp_settings_set_uint32(settings, FreeRDP_ChannelCount, ChannelCount))
+				return ERROR_INTERNAL_ERROR;
 		}
 
 		channels->openDataCount++;
@@ -1273,6 +1278,11 @@ int freerdp_channels_client_load(rdpChannels* channels, rdpSettings* settings,
 	CHANNEL_ENTRY_POINTS_FREERDP EntryPoints = { 0 };
 	CHANNEL_CLIENT_DATA* pChannelClientData;
 
+	WINPR_ASSERT(channels);
+	WINPR_ASSERT(channels->instance);
+	WINPR_ASSERT(channels->instance->context);
+	WINPR_ASSERT(entry);
+
 	if (channels->clientDataCount + 1 > CHANNEL_MAX_COUNT)
 	{
 		WLog_ERR(TAG, "error: too many channels");
@@ -1296,7 +1306,7 @@ int freerdp_channels_client_load(rdpChannels* channels, rdpSettings* settings,
 	EntryPoints.pVirtualChannelWrite = FreeRDP_VirtualChannelWrite;
 	EntryPoints.MagicNumber = FREERDP_CHANNEL_MAGIC_NUMBER;
 	EntryPoints.pExtendedData = data;
-	EntryPoints.context = ((freerdp*)settings->instance)->context;
+	EntryPoints.context = channels->instance->context;
 	/* enable VirtualChannelInit */
 	channels->can_call_init = TRUE;
 	EnterCriticalSection(&channels->channelsLock);
@@ -1323,6 +1333,11 @@ int freerdp_channels_client_load_ex(rdpChannels* channels, rdpSettings* settings
 	CHANNEL_INIT_DATA* pChannelInitData = NULL;
 	CHANNEL_CLIENT_DATA* pChannelClientData = NULL;
 
+	WINPR_ASSERT(channels);
+	WINPR_ASSERT(channels->instance);
+	WINPR_ASSERT(channels->instance->context);
+	WINPR_ASSERT(entryEx);
+
 	if (channels->clientDataCount + 1 > CHANNEL_MAX_COUNT)
 	{
 		WLog_ERR(TAG, "error: too many channels");
@@ -1348,7 +1363,7 @@ int freerdp_channels_client_load_ex(rdpChannels* channels, rdpSettings* settings
 	EntryPointsEx.pVirtualChannelWriteEx = FreeRDP_VirtualChannelWriteEx;
 	EntryPointsEx.MagicNumber = FREERDP_CHANNEL_MAGIC_NUMBER;
 	EntryPointsEx.pExtendedData = data;
-	EntryPointsEx.context = ((freerdp*)settings->instance)->context;
+	EntryPointsEx.context = channels->instance->context;
 	/* enable VirtualChannelInit */
 	channels->can_call_init = TRUE;
 	EnterCriticalSection(&channels->channelsLock);

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -103,7 +103,18 @@ BOOL freerdp_connect(freerdp* instance)
 	instance->ConnectionCallbackState = CLIENT_STATE_PRECONNECT_PASSED;
 
 	if (status)
+	{
+		freerdp_settings_free(rdp->originalSettings);
+		rdp->originalSettings = freerdp_settings_clone(settings);
+		if (!rdp->originalSettings)
+			return 0;
+
+		BOOL ok = IFCALLRESULT(TRUE, instance->LoadChannels, instance);
+		if (!ok)
+			return 0;
+
 		status2 = freerdp_channels_pre_connect(instance->context->channels, instance);
+	}
 
 	if (settings->KeyboardLayout == KBD_JAPANESE ||
 	    settings->KeyboardLayout == KBD_JAPANESE_INPUT_SYSTEM_MS_IME2002)

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1890,6 +1890,13 @@ rdpRdp* rdp_new(rdpContext* context)
 	}
 	else
 		rdp->settings = context->settings;
+
+	/* Keep a backup copy of settings for later comparisons */
+	freerdp_settings_free(rdp->originalSettings);
+	rdp->originalSettings = freerdp_settings_clone(rdp->settings);
+	if (!rdp->originalSettings)
+		return FALSE;
+
 	rdp->settings->instance = context->instance;
 
 	context->settings = rdp->settings;
@@ -2092,6 +2099,7 @@ void rdp_free(rdpRdp* rdp)
 		rdp_reset_free(rdp);
 
 		freerdp_settings_free(rdp->settings);
+		freerdp_settings_free(rdp->originalSettings);
 
 		input_free(rdp->input);
 		update_free(rdp->update);

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -163,6 +163,7 @@ struct rdp_rdp
 	rdpLicense* license;
 	rdpRedirection* redirection;
 	rdpSettings* settings;
+	rdpSettings* originalSettings;
 	rdpTransport* transport;
 	rdpAutoDetect* autodetect;
 	rdpHeartbeat* heartbeat;

--- a/libfreerdp/core/settings.h
+++ b/libfreerdp/core/settings.h
@@ -44,5 +44,6 @@ FREERDP_LOCAL BOOL freerdp_settings_clone_keys(rdpSettings* dst, const rdpSettin
 FREERDP_LOCAL void freerdp_settings_free_keys(rdpSettings* dst, BOOL cleanup);
 FREERDP_LOCAL BOOL freerdp_settings_set_string_(rdpSettings* settings, size_t id, const char* val,
                                                 size_t len, BOOL cleanup);
+FREERDP_LOCAL BOOL freerdp_capability_buffer_allocate(rdpSettings* settings, UINT32 count);
 
 #endif /* FREERDP_LIB_CORE_SETTINGS_H */


### PR DESCRIPTION
* Fixes a client problem on redirect (reset `rdpSettings` on redirect to allow new negotiation of channels/settings/...)
* Fixes a regression (`Stream_New` instead of `StreamPool_Take` in `rdpdr`)
* Fixes a regression (missing `LoadChannels` callback)