### PR TITLE
Fix building with LibreSSL 2.7.0 or newer

### DIFF
--- a/libfreerdp/crypto/opensslcompat.c
+++ b/libfreerdp/crypto/opensslcompat.c
@@ -19,7 +19,8 @@
 
 #include "opensslcompat.h"
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 
 BIO_METHOD* BIO_meth_new(int type, const char* name)
 {

--- a/libfreerdp/crypto/opensslcompat.h
+++ b/libfreerdp/crypto/opensslcompat.h
@@ -30,7 +30,8 @@
 
 #include <openssl/opensslv.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 
 #include <openssl/bio.h>
 #include <openssl/rsa.h>

--- a/winpr/libwinpr/crypto/hash.c
+++ b/winpr/libwinpr/crypto/hash.c
@@ -151,7 +151,8 @@ WINPR_HMAC_CTX* winpr_HMAC_New(void)
 	WINPR_HMAC_CTX* ctx = NULL;
 #if defined(WITH_OPENSSL)
 	HMAC_CTX* hmac = NULL;
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 
 	if (!(hmac = (HMAC_CTX*)calloc(1, sizeof(HMAC_CTX))))
 		return NULL;
@@ -185,7 +186,8 @@ BOOL winpr_HMAC_Init(WINPR_HMAC_CTX* ctx, WINPR_MD_TYPE md, const BYTE* key, siz
 	if (!evp || !hmac)
 		return FALSE;
 
-#if (OPENSSL_VERSION_NUMBER < 0x10000000L) || defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER < 0x10000000L) || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 	HMAC_Init_ex(hmac, key, keylen, evp, NULL); /* no return value on OpenSSL 0.9.x */
 	return TRUE;
 #else
@@ -221,7 +223,8 @@ BOOL winpr_HMAC_Update(WINPR_HMAC_CTX* ctx, const BYTE* input, size_t ilen)
 {
 #if defined(WITH_OPENSSL)
 	HMAC_CTX* hmac = (HMAC_CTX*)ctx;
-#if (OPENSSL_VERSION_NUMBER < 0x10000000L) || defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER < 0x10000000L) || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 	HMAC_Update(hmac, input, ilen); /* no return value on OpenSSL 0.9.x */
 	return TRUE;
 #else
@@ -253,7 +256,8 @@ BOOL winpr_HMAC_Final(WINPR_HMAC_CTX* ctx, BYTE* output, size_t olen)
 
 #if defined(WITH_OPENSSL)
 	hmac = (HMAC_CTX*)ctx;
-#if (OPENSSL_VERSION_NUMBER < 0x10000000L) || defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER < 0x10000000L) || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 	HMAC_Final(hmac, output, NULL); /* no return value on OpenSSL 0.9.x */
 	return TRUE;
 #else
@@ -279,7 +283,8 @@ void winpr_HMAC_Free(WINPR_HMAC_CTX* ctx)
 
 	if (hmac)
 	{
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 		HMAC_CTX_cleanup(hmac);
 		free(hmac);
 #else
@@ -332,7 +337,8 @@ WINPR_DIGEST_CTX* winpr_Digest_New(void)
 	WINPR_DIGEST_CTX* ctx = NULL;
 #if defined(WITH_OPENSSL)
 	EVP_MD_CTX* mdctx;
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 	mdctx = EVP_MD_CTX_create();
 #else
 	mdctx = EVP_MD_CTX_new();
@@ -464,7 +470,8 @@ void winpr_Digest_Free(WINPR_DIGEST_CTX* ctx)
 
 	if (mdctx)
 	{
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 		EVP_MD_CTX_destroy(mdctx);
 #else
 		EVP_MD_CTX_free(mdctx);


### PR DESCRIPTION
With LibreSSL 2.7.0 (or newer versions) some more structs have made opaque, which requires a few changes:

- `BIO_meth_new()` and related functions are now defined by LibreSSL, the versions from `opensslcompat.{h,c}` does not need to be used anymore.
- `HMAC_CTX` is now opaque, `HMAC_CTX_new()`, `EVP_MD_CTX_new()`, and related functions should be used instead in winpr's `hash.c`.

----

This is a backport to the `stable-2.0` branch of #7999 

