### PR TITLE
Clear openssl error queue after connecting with nla

### DIFF
--- a/client/iOS/Additions/TSXAdditions.m
+++ b/client/iOS/Additions/TSXAdditions.m
@@ -220,6 +220,7 @@
 	BIO_set_flags(context, BIO_FLAGS_BASE64_NO_NL);
 
 	// Encode all the data
+	ERR_clear_error();
 	BIO_write(context, [self bytes], [self length]);
 	(void)BIO_flush(context);
 

--- a/libfreerdp/core/gateway/http.c
+++ b/libfreerdp/core/gateway/http.c
@@ -835,6 +835,7 @@ HttpResponse* http_response_recv(rdpTls* tls, BOOL readContentLength)
 		size_t s;
 		char* end;
 		/* Read until we encounter \r\n\r\n */
+		ERR_clear_error();
 		int status = BIO_read(tls->bio, Stream_Pointer(response->data), 1);
 
 		if (status <= 0)
@@ -951,6 +952,7 @@ HttpResponse* http_response_recv(rdpTls* tls, BOOL readContentLength)
 			if (!Stream_EnsureRemainingCapacity(response->data, bodyLength - response->BodyLength))
 				goto out_error;
 
+			ERR_clear_error();
 			status = BIO_read(tls->bio, Stream_Pointer(response->data),
 			                  bodyLength - response->BodyLength);
 

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -361,6 +361,7 @@ static BOOL rdg_write_chunked(BIO* bio, wStream* sPacket)
 		return FALSE;
 	}
 
+	ERR_clear_error();
 	status = BIO_write(bio, Stream_Buffer(sChunk), (int)len);
 	Stream_Free(sChunk, TRUE);
 
@@ -435,6 +436,7 @@ static BOOL rdg_write_websocket(BIO* bio, wStream* sPacket, WEBSOCKET_OPCODE opc
 
 	Stream_SealLength(sWS);
 
+	ERR_clear_error();
 	status = BIO_write(bio, Stream_Buffer(sWS), Stream_Length(sWS));
 	Stream_Free(sWS, TRUE);
 
@@ -467,6 +469,7 @@ static int rdg_websocket_read_data(BIO* bio, BYTE* pBuffer, size_t size,
 		return 0;
 	}
 
+	ERR_clear_error();
 	status =
 	    BIO_read(bio, pBuffer,
 	             (encodingContext->payloadLength < size ? encodingContext->payloadLength : size));
@@ -492,6 +495,7 @@ static int rdg_websocket_read_discard(BIO* bio, rdg_http_websocket_context* enco
 		return 0;
 	}
 
+	ERR_clear_error();
 	status = BIO_read(bio, _dummy, sizeof(_dummy));
 	if (status <= 0)
 		return status;
@@ -517,6 +521,7 @@ static int rdg_websocket_read_wstream(BIO* bio, wStream* s,
 	if (s == NULL || Stream_GetRemainingCapacity(s) != encodingContext->payloadLength)
 		return -1;
 
+	ERR_clear_error();
 	status = BIO_read(bio, Stream_Pointer(s), encodingContext->payloadLength);
 	if (status <= 0)
 		return status;
@@ -564,6 +569,7 @@ static BOOL rdg_websocket_reply_close(BIO* bio, wStream* s)
 	}
 	Stream_SealLength(closeFrame);
 
+	ERR_clear_error();
 	status = BIO_write(bio, Stream_Buffer(closeFrame), Stream_Length(closeFrame));
 	Stream_Free(closeFrame, TRUE);
 
@@ -590,6 +596,7 @@ static BOOL rdg_websocket_reply_pong(BIO* bio, wStream* s)
 	Stream_Write_UINT32(closeFrame, maskingKey); /* dummy masking key. */
 	Stream_SealLength(closeFrame);
 
+	ERR_clear_error();
 	status = BIO_write(bio, Stream_Buffer(closeFrame), Stream_Length(closeFrame));
 
 	if (status < 0)
@@ -684,6 +691,7 @@ static int rdg_websocket_read(BIO* bio, BYTE* pBuffer, size_t size,
 			case WebsocketStateOpcodeAndFin:
 			{
 				BYTE buffer[1];
+				ERR_clear_error();
 				status = BIO_read(bio, (char*)buffer, 1);
 				if (status <= 0)
 					return (effectiveDataLen > 0 ? effectiveDataLen : status);
@@ -699,6 +707,7 @@ static int rdg_websocket_read(BIO* bio, BYTE* pBuffer, size_t size,
 			{
 				BYTE buffer[1];
 				BYTE len;
+				ERR_clear_error();
 				status = BIO_read(bio, (char*)buffer, 1);
 				if (status <= 0)
 					return (effectiveDataLen > 0 ? effectiveDataLen : status);
@@ -726,6 +735,7 @@ static int rdg_websocket_read(BIO* bio, BYTE* pBuffer, size_t size,
 				BYTE lenLength = (encodingContext->state == WebsocketStateShortLength ? 2 : 8);
 				while (encodingContext->lengthAndMaskPosition < lenLength)
 				{
+					ERR_clear_error();
 					status = BIO_read(bio, (char*)buffer, 1);
 					if (status <= 0)
 						return (effectiveDataLen > 0 ? effectiveDataLen : status);
@@ -774,6 +784,7 @@ static int rdg_chuncked_read(BIO* bio, BYTE* pBuffer, size_t size,
 		{
 			case ChunkStateData:
 			{
+				ERR_clear_error();
 				status = BIO_read(
 				    bio, pBuffer,
 				    (size > encodingContext->nextOffset ? encodingContext->nextOffset : size));
@@ -800,6 +811,7 @@ static int rdg_chuncked_read(BIO* bio, BYTE* pBuffer, size_t size,
 				char _dummy[2];
 				WINPR_ASSERT(encodingContext->nextOffset == 0);
 				WINPR_ASSERT(encodingContext->headerFooterPos < 2);
+				ERR_clear_error();
 				status = BIO_read(bio, _dummy, 2 - encodingContext->headerFooterPos);
 				if (status >= 0)
 				{
@@ -822,6 +834,7 @@ static int rdg_chuncked_read(BIO* bio, BYTE* pBuffer, size_t size,
 				WINPR_ASSERT(encodingContext->nextOffset == 0);
 				while (encodingContext->headerFooterPos < 10 && !_haveNewLine)
 				{
+					ERR_clear_error();
 					status = BIO_read(bio, dst, 1);
 					if (status >= 0)
 					{

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -875,6 +875,7 @@ static int rdg_socket_read(BIO* bio, BYTE* pBuffer, size_t size,
 	switch (encodingContext->httpTransferEncoding)
 	{
 		case TransferEncodingIdentity:
+			ERR_clear_error();
 			return BIO_read(bio, pBuffer, size);
 		case TransferEncodingChunked:
 			return rdg_chuncked_read(bio, pBuffer, size, &encodingContext->context.chunked);

--- a/libfreerdp/core/gateway/rpc.c
+++ b/libfreerdp/core/gateway/rpc.c
@@ -333,6 +333,7 @@ SSIZE_T rpc_channel_read(RpcChannel* channel, wStream* s, size_t length)
 	if (!channel || (length > INT32_MAX))
 		return -1;
 
+	ERR_clear_error();
 	status = BIO_read(channel->tls->bio, Stream_Pointer(s), (INT32)length);
 
 	if (status > 0)

--- a/libfreerdp/core/proxy.c
+++ b/libfreerdp/core/proxy.c
@@ -586,6 +586,7 @@ static BOOL http_proxy_connect(BIO* bufferedBio, const char* proxyUsername,
 		goto fail;
 
 	Stream_Write(s, CRLF CRLF, 4);
+	ERR_clear_error();
 	status = BIO_write(bufferedBio, Stream_Buffer(s), Stream_GetPosition(s));
 
 	if ((status < 0) || ((size_t)status != Stream_GetPosition(s)))
@@ -727,6 +728,7 @@ static BOOL socks_proxy_connect(BIO* bufferedBio, const char* proxyUsername,
 	if (nauthMethods > 1)
 		buf[3] = AUTH_M_USR_PASS;
 
+	ERR_clear_error();
 	status = BIO_write(bufferedBio, buf, writeLen);
 
 	if (status != writeLen)
@@ -770,6 +772,7 @@ static BOOL socks_proxy_connect(BIO* bufferedBio, const char* proxyUsername,
 				*ptr = userpassLen;
 				ptr++;
 				memcpy(ptr, proxyPassword, userpassLen);
+				ERR_clear_error();
 				status = BIO_write(bufferedBio, buf, 3 + usernameLen + userpassLen);
 
 				if (status != 3 + usernameLen + userpassLen)
@@ -807,6 +810,7 @@ static BOOL socks_proxy_connect(BIO* bufferedBio, const char* proxyUsername,
 	/* follows DST.PORT in netw. format */
 	buf[hostnlen + 5] = (port >> 8) & 0xff;
 	buf[hostnlen + 6] = port & 0xff;
+	ERR_clear_error();
 	status = BIO_write(bufferedBio, buf, hostnlen + 7U);
 
 	if ((status < 0) || ((size_t)status != (hostnlen + 7U)))

--- a/libfreerdp/core/proxy.c
+++ b/libfreerdp/core/proxy.c
@@ -604,6 +604,7 @@ static BOOL http_proxy_connect(BIO* bufferedBio, const char* proxyUsername,
 			goto fail;
 		}
 
+		ERR_clear_error();
 		status =
 		    BIO_read(bufferedBio, (BYTE*)recv_buf + resultsize, sizeof(recv_buf) - resultsize - 1);
 
@@ -661,6 +662,7 @@ static int recv_socks_reply(BIO* bufferedBio, BYTE* buf, int len, char* reason, 
 
 	for (;;)
 	{
+		ERR_clear_error();
 		status = BIO_read(bufferedBio, buf, len);
 
 		if (status > 0)

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -491,6 +491,7 @@ static int transport_bio_buffered_write(BIO* bio, const char* buf, int num)
 	{
 		while (chunks[i].size)
 		{
+			ERR_clear_error();
 			status = BIO_write(next_bio, chunks[i].data, chunks[i].size);
 
 			if (status <= 0)
@@ -528,6 +529,7 @@ static int transport_bio_buffered_read(BIO* bio, char* buf, int size)
 	BIO* next_bio = BIO_next(bio);
 	ptr->readBlocked = FALSE;
 	BIO_clear_flags(bio, BIO_FLAGS_READ);
+	ERR_clear_error();
 	status = BIO_read(next_bio, buf, size);
 
 	if (status <= 0)

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -592,6 +592,7 @@ static SSIZE_T transport_read_layer(rdpTransport* transport, BYTE* data, size_t 
 	{
 		const SSIZE_T tr = (SSIZE_T)bytes - read;
 		int r = (int)((tr > INT_MAX) ? INT_MAX : tr);
+		ERR_clear_error();
 		int status = BIO_read(transport->frontBio, data + read, r);
 
 		if (freerdp_shall_disconnect_context(context))
@@ -907,6 +908,7 @@ static int transport_default_write(rdpTransport* transport, wStream* s)
 
 	while (length > 0)
 	{
+		ERR_clear_error();
 		status = BIO_write(transport->frontBio, Stream_Pointer(s), length);
 
 		if (status <= 0)

--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -360,6 +360,7 @@ static char* crypto_print_name(X509_NAME* name)
 		if (!buffer)
 			return NULL;
 
+		ERR_clear_error();
 		BIO_read(outBIO, buffer, (int)size);
 	}
 
@@ -1066,6 +1067,7 @@ BYTE* crypto_cert_pem(X509* xcert, STACK_OF(X509) * chain, size_t* plength)
 		goto fail;
 	}
 
+	ERR_clear_error();
 	status = BIO_read(bio, pemCert, length);
 
 	if (status < 0)
@@ -1088,6 +1090,7 @@ BYTE* crypto_cert_pem(X509* xcert, STACK_OF(X509) * chain, size_t* plength)
 
 		length = new_len;
 		pemCert = new_cert;
+		ERR_clear_error();
 		status = BIO_read(bio, &pemCert[offset], length - offset);
 
 		if (status < 0)

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -216,6 +216,7 @@ static int bio_rdp_tls_puts(BIO* bio, const char* str)
 		return 0;
 
 	size = strlen(str);
+	ERR_clear_error();
 	status = BIO_write(bio, str, size);
 	return status;
 }

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1071,6 +1071,7 @@ int tls_write_all(rdpTls* tls, const BYTE* data, int length)
 
 	while (offset < length)
 	{
+		ERR_clear_error();
 		status = BIO_write(bio, &data[offset], length - offset);
 
 		if (status > 0)

--- a/winpr/libwinpr/sspi/Schannel/schannel_openssl.c
+++ b/winpr/libwinpr/sspi/Schannel/schannel_openssl.c
@@ -354,6 +354,7 @@ SECURITY_STATUS schannel_openssl_client_process_tokens(SCHANNEL_OPENSSL* context
 			if (!pBuffer)
 				return SEC_E_INVALID_TOKEN;
 
+			ERR_clear_error();
 			status = BIO_write(context->bioRead, pBuffer->pvBuffer, pBuffer->cbBuffer);
 			if (status < 0)
 				return SEC_E_INVALID_TOKEN;
@@ -370,6 +371,7 @@ SECURITY_STATUS schannel_openssl_client_process_tokens(SCHANNEL_OPENSSL* context
 		if (status == 1)
 			context->connected = TRUE;
 
+		ERR_clear_error();
 		status = BIO_read(context->bioWrite, context->ReadBuffer, SCHANNEL_CB_MAX_TOKEN);
 
 		if (pOutput->cBuffers < 1)
@@ -417,6 +419,7 @@ SECURITY_STATUS schannel_openssl_server_process_tokens(SCHANNEL_OPENSSL* context
 		if (!pBuffer)
 			return SEC_E_INVALID_TOKEN;
 
+		ERR_clear_error();
 		status = BIO_write(context->bioRead, pBuffer->pvBuffer, pBuffer->cbBuffer);
 		if (status >= 0)
 			status = SSL_accept(context->ssl);
@@ -431,6 +434,7 @@ SECURITY_STATUS schannel_openssl_server_process_tokens(SCHANNEL_OPENSSL* context
 		if (status == 1)
 			context->connected = TRUE;
 
+		ERR_clear_error();
 		status = BIO_read(context->bioWrite, context->ReadBuffer, SCHANNEL_CB_MAX_TOKEN);
 		if (status < 0)
 		{
@@ -488,6 +492,7 @@ SECURITY_STATUS schannel_openssl_encrypt_message(SCHANNEL_OPENSSL* context, PSec
 		WLog_ERR(TAG, "SSL_write: %s", openssl_get_ssl_error_string(ssl_error));
 	}
 
+	ERR_clear_error();
 	status = BIO_read(context->bioWrite, context->ReadBuffer, SCHANNEL_CB_MAX_TOKEN);
 
 	if (status > 0)
@@ -525,6 +530,7 @@ SECURITY_STATUS schannel_openssl_decrypt_message(SCHANNEL_OPENSSL* context, PSec
 	if (!pBuffer)
 		return SEC_E_INVALID_TOKEN;
 
+	ERR_clear_error();
 	status = BIO_write(context->bioRead, pBuffer->pvBuffer, pBuffer->cbBuffer);
 	if (status > 0)
 		status = SSL_read(context->ssl, pBuffer->pvBuffer, pBuffer->cbBuffer);

--- a/winpr/tools/makecert/makecert.c
+++ b/winpr/tools/makecert/makecert.c
@@ -100,6 +100,7 @@ static char* makecert_read_str(BIO* bio, size_t* pOffset)
 
 		length = new_len;
 		x509_str = new_str;
+		ERR_clear_error();
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L
 		status = BIO_read_ex(bio, &x509_str[offset], length - offset, &readBytes);
 #else

--- a/winpr/tools/makecert/makecert.c
+++ b/winpr/tools/makecert/makecert.c
@@ -31,6 +31,7 @@
 #include <openssl/crypto.h>
 #include <openssl/conf.h>
 #include <openssl/pem.h>
+#include <openssl/err.h>
 #include <openssl/rsa.h>
 #include <openssl/pkcs12.h>
 #include <openssl/x509v3.h>


### PR DESCRIPTION
This is necessary when using pkcs11 due to a bug in openssl where errors emitted by unrelated operations can cause BIO_should_retry() to report false negatives (see [Issue #11889](https://github.com/openssl/openssl/issues/11889))