### PR TITLE
winpr asn1: fixes and more features

### DIFF
--- a/winpr/include/winpr/asn1.h
+++ b/winpr/include/winpr/asn1.h
@@ -154,6 +154,9 @@ extern "C"
 	WINPR_API BOOL WinPrAsn1EncSetContainer(WinPrAsn1Encoder* enc);
 	WINPR_API BOOL WinPrAsn1EncContextualSetContainer(WinPrAsn1Encoder* enc, WinPrAsn1_tagId tagId);
 	WINPR_API BOOL WinPrAsn1EncContextualContainer(WinPrAsn1Encoder* enc, WinPrAsn1_tagId tagId);
+	WINPR_API BOOL WinPrAsn1EncOctetStringContainer(WinPrAsn1Encoder* enc);
+	WINPR_API BOOL WinPrAsn1EncContextualOctetStringContainer(WinPrAsn1Encoder* enc,
+	                                                          WinPrAsn1_tagId tagId);
 	WINPR_API size_t WinPrAsn1EncEndContainer(WinPrAsn1Encoder* enc);
 
 	WINPR_API size_t WinPrAsn1EncInteger(WinPrAsn1Encoder* enc, WinPrAsn1_INTEGER integer);


### PR DESCRIPTION
This patches adds support for octet string containers that are used by SPNego (a subfield is contained in an octet string record).
It also adds a performance test to test reallocations in asn1 encoder.
It fixes reallocation problems for both chunks and containers.
