### PR TITLE
Removed ALAW/ULAW from supported backend formats

### DIFF
--- a/channels/audin/client/alsa/audin_alsa.c
+++ b/channels/audin/client/alsa/audin_alsa.c
@@ -240,10 +240,6 @@ static BOOL audin_alsa_format_supported(IAudinDevice* device, const AUDIO_FORMAT
 
 			break;
 
-		case WAVE_FORMAT_ALAW:
-		case WAVE_FORMAT_MULAW:
-			return TRUE;
-
 		default:
 			return FALSE;
 	}

--- a/channels/audin/client/oss/audin_oss.c
+++ b/channels/audin/client/oss/audin_oss.c
@@ -114,10 +114,6 @@ static BOOL audin_oss_format_supported(IAudinDevice* device, const AUDIO_FORMAT*
 
 			break;
 
-		case WAVE_FORMAT_ALAW:
-		case WAVE_FORMAT_MULAW:
-			return TRUE;
-
 		default:
 			return FALSE;
 	}

--- a/channels/audin/client/pulse/audin_pulse.c
+++ b/channels/audin/client/pulse/audin_pulse.c
@@ -234,17 +234,6 @@ static BOOL audin_pulse_format_supported(IAudinDevice* device, const AUDIO_FORMA
 
 			break;
 
-		case WAVE_FORMAT_ALAW:  /* A-LAW */
-		case WAVE_FORMAT_MULAW: /* U-LAW */
-			if (format->cbSize == 0 && (format->nSamplesPerSec <= PA_RATE_MAX) &&
-			    (format->wBitsPerSample == 8) &&
-			    (format->nChannels >= 1 && format->nChannels <= PA_CHANNELS_MAX))
-			{
-				return TRUE;
-			}
-
-			break;
-
 		default:
 			return FALSE;
 	}

--- a/channels/rdpsnd/client/alsa/rdpsnd_alsa.c
+++ b/channels/rdpsnd/client/alsa/rdpsnd_alsa.c
@@ -212,10 +212,6 @@ static BOOL rdpsnd_alsa_set_format(rdpsndDevicePlugin* device, const AUDIO_FORMA
 
 				break;
 
-			case WAVE_FORMAT_ALAW:
-			case WAVE_FORMAT_MULAW:
-				break;
-
 			default:
 				return FALSE;
 		}

--- a/channels/rdpsnd/client/oss/rdpsnd_oss.c
+++ b/channels/rdpsnd/client/oss/rdpsnd_oss.c
@@ -114,10 +114,6 @@ static BOOL rdpsnd_oss_format_supported(rdpsndDevicePlugin* device, const AUDIO_
 
 			break;
 
-		case WAVE_FORMAT_MULAW:
-		case WAVE_FORMAT_ALAW:
-			break;
-
 		default:
 			return FALSE;
 	}

--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -484,15 +484,7 @@ BOOL rdpsnd_pulse_format_supported(rdpsndDevicePlugin* device, const AUDIO_FORMA
 
 			break;
 
-		case WAVE_FORMAT_ALAW:
-		case WAVE_FORMAT_MULAW:
-			if (format->cbSize == 0 && (format->nSamplesPerSec <= PA_RATE_MAX) &&
-			    (format->wBitsPerSample == 8) &&
-			    (format->nChannels >= 1 && format->nChannels <= PA_CHANNELS_MAX))
-			{
-				return TRUE;
-			}
-
+		default:
 			break;
 	}
 


### PR DESCRIPTION
pulse/alsa/oss do not reliably work with ALAW/ULAW codecs with all
hardware available.
Since these formats are poor quality anyway, deactivate them for
audin channel.