### PR TITLE
Fix app windows destroy will do close(0)

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -799,6 +799,7 @@ int xf_AppWindowCreate(xfContext* xfc, xfAppWindow* appWindow)
 
 	xf_FixWindowCoordinates(xfc, &appWindow->x, &appWindow->y, &appWindow->width,
 	                        &appWindow->height);
+	appWindow->shmid = -1;
 	appWindow->decorations = FALSE;
 	appWindow->fullscreen = FALSE;
 	appWindow->local_move.state = LMS_NOT_ACTIVE;


### PR DESCRIPTION
appWindow->shmid was not initailized to -1 on creation of app window, that will be close fd = 0 (close(XX->shmid)). everytimes in app windows destroy (Call xf_DestroyWindow ).

```C
void xf_DestroyWindow(xfContext* xfc, xfAppWindow* appWindow)
{
         ...

	if (appWindow->shmid >= 0)
		close(appWindow->shmid);

	shm_unlink(get_shm_id());
	appWindow->xfwin = (Window*)-1;
	appWindow->shmid = -1;
	free(appWindow->title);
	free(appWindow->windowRects);
	free(appWindow->visibilityRects);
	free(appWindow);
}
```