### PR TITLE
[stable-2.0] codec/progressive: Fix wrong usage of subband diffing flag

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,7 @@ Fixed issues:
 * Backported #7957: Server DVC API improvements
 * Backported #7760: Fixed osMinorType values
 * Backported #8013: Add missing osMajorType values
+* Backported #8076: Fix wrong usage of subband diffing flag (tile artifact fix)
 
 # 2022-04-25 Version 2.7.0
 

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -896,7 +896,7 @@ static INLINE int progressive_rfx_decode_component(PROGRESSIVE_CONTEXT* progress
 		return status;
 
 	CopyMemory(sign, buffer, 4096 * 2);
-	if (!subbandDiff)
+	if (!extrapolate)
 	{
 		rfx_differential_decode(buffer + 4032, 64);
 		progressive_rfx_decode_block(prims, &buffer[0], 1024, shift->HL1);    /* HL1 */


### PR DESCRIPTION
Backport of https://github.com/FreeRDP/FreeRDP/pull/8076