### PR TITLE
audin (client): Do not bother the dsp if the format is supported

### DIFF
--- a/channels/audin/client/audin_main.c
+++ b/channels/audin/client/audin_main.c
@@ -438,8 +438,11 @@ static BOOL audin_open_device(AUDIN_PLUGIN* audin, AUDIN_CHANNEL_CALLBACK* callb
 		return FALSE;
 	}
 
-	if (!freerdp_dsp_context_reset(audin->dsp_context, audin->format, audin->FramesPerPacket))
-		return FALSE;
+	if (!supported)
+	{
+		if (!freerdp_dsp_context_reset(audin->dsp_context, audin->format, audin->FramesPerPacket))
+			return FALSE;
+	}
 
 	IFCALLRET(audin->device->Open, error, audin->device, audin_receive_wave_data, callback);
 


### PR DESCRIPTION
This fix an issue that only happen in very few cases:
* FFMPEG is enabled
* the chosen codec is PCM

But in this case (that should work), freerdp_dsp_context_reset is called, fails, resulting in no sound.