### PR TITLE
fix moving a window shrinks it 14x7 when connect to server 2019

### DIFF
--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -153,30 +153,36 @@ void xf_rail_end_local_move(xfContext* xfc, xfAppWindow* appWindow)
 	unsigned int mask;
 	Window root_window;
 	Window child_window;
-	RAIL_WINDOW_MOVE_ORDER windowMove;
 	rdpInput* input;
 
 	WINPR_ASSERT(xfc);
 
 	input = xfc->common.context.input;
 	WINPR_ASSERT(input);
+	
+	if ((appWindow->local_move.direction == _NET_WM_MOVERESIZE_MOVE_KEYBOARD) ||
+	    (appWindow->local_move.direction == _NET_WM_MOVERESIZE_SIZE_KEYBOARD))
+	{
+		RAIL_WINDOW_MOVE_ORDER windowMove;
 
-	/*
-	 * For keyboard moves send and explicit update to RDP server
-	 */
-	windowMove.windowId = appWindow->windowId;
-	/*
-	 * Calculate new size/position for the rail window(new values for
-	 * windowOffsetX/windowOffsetY/windowWidth/windowHeight) on the server
-	 *
-	 */
-	windowMove.left = appWindow->x - appWindow->resizeMarginLeft;
-	windowMove.top = appWindow->y - appWindow->resizeMarginTop;
-	windowMove.right =
-	    appWindow->x + appWindow->width +
-	    appWindow->resizeMarginRight; /* In the update to RDP the position is one past the window */
-	windowMove.bottom = appWindow->y + appWindow->height + appWindow->resizeMarginBottom;
-	xfc->rail->ClientWindowMove(xfc->rail, &windowMove);
+		/*
+		* For keyboard moves send and explicit update to RDP server
+		*/
+		windowMove.windowId = appWindow->windowId;
+		/*
+		* Calculate new size/position for the rail window(new values for
+		* windowOffsetX/windowOffsetY/windowWidth/windowHeight) on the server
+		*
+		*/
+		windowMove.left = appWindow->x - appWindow->resizeMarginLeft;
+		windowMove.top = appWindow->y - appWindow->resizeMarginTop;
+		windowMove.right =
+			appWindow->x + appWindow->width +
+			appWindow->resizeMarginRight; /* In the update to RDP the position is one past the window */
+		windowMove.bottom = appWindow->y + appWindow->height + appWindow->resizeMarginBottom;
+		xfc->rail->ClientWindowMove(xfc->rail, &windowMove);
+	}
+		
 	/*
 	 * Simulate button up at new position to end the local move (per RDP spec)
 	 */

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -159,30 +159,31 @@ void xf_rail_end_local_move(xfContext* xfc, xfAppWindow* appWindow)
 
 	input = xfc->common.context.input;
 	WINPR_ASSERT(input);
-	
+
 	if ((appWindow->local_move.direction == _NET_WM_MOVERESIZE_MOVE_KEYBOARD) ||
 	    (appWindow->local_move.direction == _NET_WM_MOVERESIZE_SIZE_KEYBOARD))
 	{
 		RAIL_WINDOW_MOVE_ORDER windowMove;
 
 		/*
-		* For keyboard moves send and explicit update to RDP server
-		*/
+		 * For keyboard moves send and explicit update to RDP server
+		 */
 		windowMove.windowId = appWindow->windowId;
 		/*
-		* Calculate new size/position for the rail window(new values for
-		* windowOffsetX/windowOffsetY/windowWidth/windowHeight) on the server
-		*
-		*/
+		 * Calculate new size/position for the rail window(new values for
+		 * windowOffsetX/windowOffsetY/windowWidth/windowHeight) on the server
+		 *
+		 */
 		windowMove.left = appWindow->x - appWindow->resizeMarginLeft;
 		windowMove.top = appWindow->y - appWindow->resizeMarginTop;
 		windowMove.right =
-			appWindow->x + appWindow->width +
-			appWindow->resizeMarginRight; /* In the update to RDP the position is one past the window */
+		    appWindow->x + appWindow->width +
+		    appWindow
+		        ->resizeMarginRight; /* In the update to RDP the position is one past the window */
 		windowMove.bottom = appWindow->y + appWindow->height + appWindow->resizeMarginBottom;
 		xfc->rail->ClientWindowMove(xfc->rail, &windowMove);
 	}
-		
+
 	/*
 	 * Simulate button up at new position to end the local move (per RDP spec)
 	 */


### PR DESCRIPTION
problem: when connect to app C:\Windows\system32\win32calc.exe on server 2019, every time we move the window, it shrinks.
root cause:  when local move end, we send Client Window Move PDU with incorrect window resize margin.

bug as  reference doc MS-RDPERP 1.3.2.5 RAIL Local Move/Resize:
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdperp/348a2e91-3ea5-415d-ad67-348d96c3f1bd

" Finally, when the user is done with the move/resize, the local RAIL window receives this notification and forwards a mouse button-up to the server to end move/size on the server. For keyboard-based moves and all resize operations, the client also sends a [Client Window Move PDU (section 2.2.2.7.4)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdperp/495acc38-df83-42ec-8ed1-b8d58c047262) to the server to inform the server of the window's new position and size. **(For mouse-based moves, the mouse button-up is sufficient to inform the window's final position).** "

It is redundant to send Client Window Move PDU if we end a mouse-based move.
