### PR TITLE
Smartcard should be usable even when unable to get its ATR

### DIFF
--- a/libfreerdp/core/smartcardlogon.c
+++ b/libfreerdp/core/smartcardlogon.c
@@ -354,7 +354,6 @@ static BOOL smartcard_hw_enumerateCerts(const rdpSettings* settings, LPCWSTR csp
 		if (!getAtr(cert->info.reader, cert->info.atr, &cert->info.atrLength))
 		{
 			WLog_ERR(TAG, "unable to retrieve card ATR for key %s", cert->info.containerName);
-			goto endofloop;
 		}
 
 		/* ========= retrieve the certificate ===============*/


### PR DESCRIPTION
Retrieving a card's ATR can fail when its reader name as given by pcsc is longer than 64 bytes (see #7965 - reader names can be up to 128 bytes). We don't seem to use the ATR for anything, so perhaps it can be removed entirely, but at least failing to retrieve it should not make it unusable for login