### PR TITLE
Use CMAKE_INSTALL_MANDIR for installing man pages.

### DIFF
--- a/cmake/InstallFreeRDPMan.cmake
+++ b/cmake/InstallFreeRDPMan.cmake
@@ -1,9 +1,7 @@
+include(GNUInstallDirs)
+
 function(install_freerdp_man manpage section)
  if(WITH_MANPAGES)
-   if(OPENBSD OR FREEBSD)
-       install(FILES ${manpage} DESTINATION man/man${section})
-    else()
-       install(FILES ${manpage} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/man/man${section})
-   endif()
+   install(FILES ${manpage} DESTINATION ${CMAKE_INSTALL_MANDIR}/man${section})
  endif()
 endfunction()


### PR DESCRIPTION
Some Unix-like systems (e.g. the BSDs) keep man pages in `man/`, others (e.g. Linux) keep man pages in `share/man/`.

By using `CMAKE_INSTALL_MANDIR` there's no need to maintain a list of per-OS locations, and the proper location can be
automatically detected.

Fixes man page installation on NetBSD.