### PR TITLE
remote assistance allow ip addresses of minimum length 7 (x.x.x.x)

### DIFF
--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -457,7 +457,7 @@ static BOOL freerdp_assistance_parse_connection_string2(rdpAssistanceFile* file)
 		q++;
 		length = strlen(p);
 
-		if (length > 8)
+		if (length > 6)
 		{
 			if (!append_address(file, p, port))
 				goto out_fail;


### PR DESCRIPTION
Minimum valid IP address is x.x.x.x (length 7)?