### PR TITLE
fix freerdp_assistance_parse_address_list parsing

### DIFF
--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -207,7 +207,7 @@ static BOOL freerdp_assistance_parse_address_list(rdpAssistanceFile* file, char*
 	}
 	rc = TRUE;
 out:
-	return rc;	
+	return rc;
 }
 
 static BOOL freerdp_assistance_parse_connection_string1(rdpAssistanceFile* file)

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -180,33 +180,34 @@ static BOOL append_address(rdpAssistanceFile* file, const char* host, const char
 
 static BOOL freerdp_assistance_parse_address_list(rdpAssistanceFile* file, char* list)
 {
-	BOOL rc = FALSE;
-	char* p;
-
-	if (!file || !list)
-		return FALSE;
-
-	p = list;
-
-	while ((p = strchr(p, ';')) != NULL)
-	{
-		char* q = strchr(p, ':');
-
-		if (!q)
-			goto out;
-
-		*q = '\0';
-		q++;
-
-		if (!append_address(file, p, q))
-			goto out;
-
-		p = q;
-	}
-
+   WLog_DBG(TAG, "freerdp_assistance_parse_address_list list=%s", list);
+	
+   BOOL rc = FALSE;
+   
+   if (!file || !list)
+      return FALSE;
+	
+   char* strp = list;
+   char* s = ";";
+   char* token;
+   
+   // get the first token
+   token = strtok(strp, s);
+   
+   // walk through other tokens
+   while( token != NULL ) {
+      char* port = strchr(token, ':');
+      *port = '\0';
+      port++;
+   	
+      if (!append_address(file, token, port))
+        goto out;
+    
+      token = strtok(NULL, s);
+   }
 	rc = TRUE;
 out:
-	return rc;
+	return rc;	
 }
 
 static BOOL freerdp_assistance_parse_connection_string1(rdpAssistanceFile* file)

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -195,7 +195,8 @@ static BOOL freerdp_assistance_parse_address_list(rdpAssistanceFile* file, char*
 	token = strtok(strp, s);
 
 	// walk through other tokens
-	while( token != NULL ) {
+	while (token != NULL)
+	{
 		char* port = strchr(token, ':');
 		*port = '\0';
 		port++;

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -180,31 +180,31 @@ static BOOL append_address(rdpAssistanceFile* file, const char* host, const char
 
 static BOOL freerdp_assistance_parse_address_list(rdpAssistanceFile* file, char* list)
 {
-   WLog_DBG(TAG, "freerdp_assistance_parse_address_list list=%s", list);
-	
-   BOOL rc = FALSE;
-   
-   if (!file || !list)
-      return FALSE;
-	
-   char* strp = list;
-   char* s = ";";
-   char* token;
-   
-   // get the first token
-   token = strtok(strp, s);
-   
-   // walk through other tokens
-   while( token != NULL ) {
-      char* port = strchr(token, ':');
-      *port = '\0';
-      port++;
-   	
-      if (!append_address(file, token, port))
-        goto out;
-    
-      token = strtok(NULL, s);
-   }
+	WLog_DBG(TAG, "freerdp_assistance_parse_address_list list=%s", list);
+
+	BOOL rc = FALSE;
+
+	if (!file || !list)
+		return FALSE;
+
+	char* strp = list;
+	char* s = ";";
+	char* token;
+
+	// get the first token
+	token = strtok(strp, s);
+
+	// walk through other tokens
+	while( token != NULL ) {
+		char* port = strchr(token, ':');
+		*port = '\0';
+		port++;
+
+		if (!append_address(file, token, port))
+			goto out;
+
+		token = strtok(NULL, s);
+	}
 	rc = TRUE;
 out:
 	return rc;	


### PR DESCRIPTION
Fails to parse when connection string only has one host:port because there is no ";" character. Also when multiple host:port;host:port it skips first host:port and parses remaining host:port as ";host:port...end" of connection string:
eg:
;192.168.93.138:49626;192.168.93.139:49627;192.168.93.140:49628
;192.168.93.139:49627;192.168.93.140:49628
;192.168.93.140:49628