### PR TITLE
drdynvc: code cleanup of the client dynamic channel

### DIFF
--- a/channels/drdynvc/client/drdynvc_main.h
+++ b/channels/drdynvc/client/drdynvc_main.h
@@ -70,11 +70,19 @@ typedef struct
 	rdpContext* context;
 } DVCMAN_ENTRY_POINTS;
 
+typedef enum
+{
+	DVC_CHANNEL_INIT,
+	DVC_CHANNEL_RUNNING,
+	DVC_CHANNEL_CLOSED
+} DVC_CHANNEL_STATE;
+
 typedef struct
 {
 	IWTSVirtualChannel iface;
 
-	int status;
+	volatile LONG refCounter;
+	DVC_CHANNEL_STATE state;
 	DVCMAN* dvcman;
 	void* pInterface;
 	UINT32 channel_id;


### PR DESCRIPTION
This patch does various cleanups in the client dynamic channel. The main goal of the cleanup was to add the sending of Close messages to the server when a channel is locally closed. The refcounter is there to ensures that the DVC_CHANNEL is not freed while some pieces of code are still holding a reference on it.

I did some tests by using a custom server-side echo channel at https://github.com/hardening/echoChannel, it allows to send a given amount of packets and then close (to test server-side initiated closes). It compiles with mingw (so under linux) and so it can be easily deployed (no deps).

