### PR TITLE
proxy: Fix smartcard emulation with clients with active rdpdr channel

### DIFF
--- a/server/proxy/channels/pf_channel_rdpdr.c
+++ b/server/proxy/channels/pf_channel_rdpdr.c
@@ -1021,7 +1021,7 @@ static BOOL filter_smartcard_io_requests(pf_channel_client_context* rdpdr, wStre
 	if (Stream_GetRemainingLength(s) >= 4)
 		Stream_Read_UINT32(s, deviceID);
 
-	WLog_DBG(TAG, "got: [%s | %s]: [0x%08]" PRIx32, rdpdr_component_string(component),
+	WLog_DBG(TAG, "got: [%s | %s]: [0x%08" PRIx32 "]", rdpdr_component_string(component),
 	         rdpdr_packetid_string(packetid), deviceID);
 
 	if (component != RDPDR_CTYP_CORE)
@@ -1425,7 +1425,7 @@ static BOOL filter_smartcard_device_list_announce_request(pf_channel_server_cont
 	size_t pos;
 	UINT16 component, packetid;
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 12))
+	if (!Stream_CheckAndLogRequiredLength(TAG, s, 8))
 		return FALSE;
 
 	pos = Stream_GetPosition(s);
@@ -1728,6 +1728,11 @@ static PfChannelResult pf_rdpdr_back_data(proxyData* pdata,
 		WLog_ERR(TAG, "error treating client back data");
 		return PF_CHANNEL_RESULT_ERROR;
 	}
+
+#if defined(WITH_PROXY_EMULATE_SMARTCARD)
+	if (pf_channel_smartcard_client_emulate(pdata->pc))
+		return PF_CHANNEL_RESULT_DROP;
+#endif
 	return PF_CHANNEL_RESULT_PASS;
 }
 
@@ -1745,6 +1750,11 @@ static PfChannelResult pf_rdpdr_front_data(proxyData* pdata,
 		WLog_ERR(TAG, "error treating front data");
 		return PF_CHANNEL_RESULT_ERROR;
 	}
+
+#if defined(WITH_PROXY_EMULATE_SMARTCARD)
+	if (pf_channel_smartcard_client_emulate(pdata->pc))
+		return PF_CHANNEL_RESULT_DROP;
+#endif
 	return PF_CHANNEL_RESULT_PASS;
 }
 


### PR DESCRIPTION
When a client connects to a proxy that has smartcard emulation active, both the emulated smartcard PDUs and the original client PDUs are sent to the server's rdpdr channel. This is because `pf_rdpdr_front_data` and `pf_rdpdr_back_data` always return `PF_CHANNEL_RESULT_PASS` which means the original client/server rdpdr PDU is always forwarded.

This PR fixes smartcard emulation by checking if smartcard emulation is enabled (using `pf_channel_smartcard_client_emulate`) and if this is the case `PF_CHANNEL_RESULT_DROP` will be returned.

The `Stream_CheckAndLogRequiredLength` was changed because clients might send an empty device list announcement which only consists of the header (two `UINT16`) and the device count (`UINT32` which is 0).

The PR also contains a small logging fix where an invalid format specifier was specified.