### PR TITLE
Fix untracked clipboard in Android

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -318,6 +318,12 @@ public class SessionActivity extends AppCompatActivity
 		                             View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
 	}
 
+	@Override public void onWindowFocusChanged(boolean hasFocus)
+	{
+		super.onWindowFocusChanged(hasFocus);
+		mClipboardManager.getPrimaryClipManually();
+	}
+
 	@Override protected void onStart()
 	{
 		super.onStart();

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/ClipboardManagerProxy.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/ClipboardManagerProxy.java
@@ -24,6 +24,8 @@ public abstract class ClipboardManagerProxy
 
 	public abstract void removeClipboardboardChangedListener(OnClipboardChangedListener listener);
 
+	public abstract void getPrimaryClipManually();
+
 	public static interface OnClipboardChangedListener {
 		void onClipboardChanged(String data);
 	}
@@ -45,6 +47,10 @@ public abstract class ClipboardManagerProxy
 
 		@Override
 		public void removeClipboardboardChangedListener(OnClipboardChangedListener listener)
+		{
+		}
+
+		@Override public void getPrimaryClipManually()
 		{
 		}
 	}
@@ -95,6 +101,11 @@ public abstract class ClipboardManagerProxy
 		{
 			mListener = null;
 			mClipboardManager.removePrimaryClipChangedListener(this);
+		}
+
+		@Override public void getPrimaryClipManually()
+		{
+			onPrimaryClipChanged();
 		}
 	}
 }


### PR DESCRIPTION
Copied text from other applications or clipboard which is already existed is not tracked by ClipboardManager.
Therefore, clipboard redirection from 'FreeRDP App' to 'Remote' is not working. 

The reason is that 'FreeRDP App' didn't request Android system's clip data at the right time
Fixed this problem by requesting Android system's clip data manually, when 'SessionActivity' get the focus.