### PR TITLE
do not resize client window if emart sizing is enabled

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -200,7 +200,7 @@ static BOOL wf_desktop_resize(rdpContext* context)
 
 	if (wfc->fullscreen != TRUE)
 	{
-		if (wfc->hwnd)
+		if (wfc->hwnd && !settings->SmartSizing)
 			SetWindowPos(wfc->hwnd, HWND_TOP, -1, -1, settings->DesktopWidth + wfc->diff.x,
 			             settings->DesktopHeight + wfc->diff.y, SWP_NOMOVE);
 	}


### PR DESCRIPTION
If smart-sizing option is enabled in windows client and the server's desktop resolution changes, do not change the size of the client window.
This is because I would assume that if the user has enabled smart-sizing, they would intend for the window to be set to a particular size and not change.
Also, when connecting to windows 10 server, `wf_desktop_resize()` is called once just after connect and so if wfreerdp is run with `/smart-sizing:WxH` then the window will start at the size `WxH` but then immediately change to the desktop resolution of the server which makes the `/smart-sizing:WxH` parameter effectively do nothing.