### PR TITLE
Fix #8176: Check fullscreen state and not setting

### DIFF
--- a/client/X11/xf_disp.c
+++ b/client/X11/xf_disp.c
@@ -115,7 +115,7 @@ static BOOL xf_update_last_sent(xfDispContext* xfDisp)
 
 static BOOL xf_disp_sendResize(xfDispContext* xfDisp)
 {
-	DISPLAY_CONTROL_MONITOR_LAYOUT layout;
+	DISPLAY_CONTROL_MONITOR_LAYOUT layout = { 0 };
 	xfContext* xfc;
 	rdpSettings* settings;
 
@@ -264,7 +264,7 @@ static void xf_disp_OnTimer(void* context, const TimerEventArgs* e)
 	if (!xf_disp_check_context(context, &xfc, &xfDisp, &settings))
 		return;
 
-	if (!xfDisp->activated || settings->Fullscreen)
+	if (!xfDisp->activated || xfc->fullscreen)
 		return;
 
 	xf_disp_sendResize(xfDisp);


### PR DESCRIPTION
Timer based dynamic resolution updates are disabled in fullscreen state. Check current value and not (permanent) setting
