### PR TITLE
windows client toggle inputs on/off when client window gains/looses focus

### DIFF
--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -707,6 +707,8 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 		case WM_SETFOCUS:
 			DEBUG_KBD("getting focus %X", hWnd);
 
+			freerdp_settings_set_bool(wfc->common.context.settings, FreeRDP_SuspendInput, FALSE);
+
 			if (alt_ctrl_down())
 				g_flipping_in = TRUE;
 
@@ -715,6 +717,8 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 			break;
 
 		case WM_KILLFOCUS:
+			freerdp_settings_set_bool(wfc->common.context.settings, FreeRDP_SuspendInput, TRUE);
+
 			if (g_focus_hWnd == hWnd && wfc && !wfc->fullscreen)
 			{
 				DEBUG_KBD("loosing focus %X", hWnd);


### PR DESCRIPTION
Before this patch mouse movement input is captured by client even when client window is not focused. This is probably not intended? I suppose this could be a matter of personal preference?
Example:

https://user-images.githubusercontent.com/4453789/189767961-3cda433a-72a2-41f5-9b9f-51e4de4fd680.mp4

After patch:

https://user-images.githubusercontent.com/4453789/189768653-2f0fb83b-961a-4cdd-9f8a-62140cbfd80a.mp4

