### PR TITLE
remember participantId for use with assistance set control request

### DIFF
--- a/client/common/client.c
+++ b/client/common/client.c
@@ -984,7 +984,7 @@ BOOL freerdp_client_encomsp_set_control(EncomspClientContext* encomsp, BOOL cont
 	if (!encomsp)
 		return FALSE;
 
-	pdu.ParticipantId = 0;
+	pdu.ParticipantId = encomsp->participantId;
 	pdu.Flags = ENCOMSP_REQUEST_VIEW;
 
 	if (control)
@@ -1012,6 +1012,9 @@ client_encomsp_participant_created(EncomspClientContext* context,
 
 	settings = cctx->context.settings;
 	WINPR_ASSERT(settings);
+
+	if (participantCreated->Flags & ENCOMSP_IS_PARTICIPANT)
+		context->participantId = participantCreated->ParticipantId;
 
 	request = freerdp_settings_get_bool(settings, FreeRDP_RemoteAssistanceRequestControl);
 	if (request && (participantCreated->Flags & ENCOMSP_MAY_VIEW) &&

--- a/include/freerdp/client/encomsp.h
+++ b/include/freerdp/client/encomsp.h
@@ -71,6 +71,8 @@ struct s_encomsp_client_context
 	pcEncomspChangeParticipantControlLevel ChangeParticipantControlLevel;
 	pcEncomspGraphicsStreamPaused GraphicsStreamPaused;
 	pcEncomspGraphicsStreamResumed GraphicsStreamResumed;
+
+	UINT32 participantId;
 };
 
 #endif /* FREERDP_CHANNEL_ENCOMSP_CLIENT_ENCOMSP_H */


### PR DESCRIPTION
In freerdp_client_encomsp_set_control() participantId was set to 0. Usually this works fine but in some cases host ignores set control request unless it is sent with same participantId that was sent from host in participant_created_pdu. So save participantId and send it for control request.
https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemc/1d6d3484-0eff-44fa-9a4e-2ad6e1391c45