### PR TITLE
fix connection abort when copy from remote wordpad, local windows 10,…

### DIFF
--- a/client/Windows/wf_cliprdr.c
+++ b/client/Windows/wf_cliprdr.c
@@ -2191,13 +2191,20 @@ wf_cliprdr_server_format_data_response(CliprdrClientContext* context,
 	if (!context || !formatDataResponse)
 		return ERROR_INTERNAL_ERROR;
 
-	if (formatDataResponse->common.msgFlags != CB_RESPONSE_OK)
-		return E_FAIL;
-
 	clipboard = (wfClipboard*)context->custom;
 
 	if (!clipboard)
 		return ERROR_INTERNAL_ERROR;
+
+	if (formatDataResponse->common.msgFlags != CB_RESPONSE_OK)
+	{
+		clipboard->hmem = NULL;
+
+		if (!SetEvent(clipboard->response_data_event))
+			return ERROR_INTERNAL_ERROR;
+
+		return CHANNEL_RC_OK;
+	}
 
 	hMem = GlobalAlloc(GMEM_MOVEABLE, formatDataResponse->common.dataLen);
 


### PR DESCRIPTION
problem: 
on windows 10, with clipboard history opened, connect remote desktop, copy text from wordpad, connection abort.

root cause:
with local clipboard history opened, when remote copy text from wordpad, local system will request some format that server can not support. I think it is not an error, it means just can not copy the format from remote. 

fix:
treat server clipboard message flag CB_RESPONSE_FAIL as normal.