### PR TITLE
Improve management of default printer

### DIFF
--- a/channels/printer/client/cups/printer_cups.c
+++ b/channels/printer/client/cups/printer_cups.c
@@ -46,7 +46,6 @@ typedef struct
 
 	int id_sequence;
 	size_t references;
-	char* defaultPrinter;
 } rdpCupsPrinterDriver;
 
 typedef struct
@@ -277,7 +276,7 @@ static void printer_cups_release_ref_printer(rdpPrinter* printer)
 }
 
 static rdpPrinter* printer_cups_new_printer(rdpCupsPrinterDriver* cups_driver, const char* name,
-                                            const char* driverName)
+                                            const char* driverName, BOOL is_default)
 {
 	rdpCupsPrinter* cups_printer;
 
@@ -299,7 +298,7 @@ static rdpPrinter* printer_cups_new_printer(rdpCupsPrinterDriver* cups_driver, c
 	if (!cups_printer->printer.driver)
 		goto fail;
 
-	cups_printer->printer.is_default = strcmp(name, cups_driver->defaultPrinter) == 0;
+	cups_printer->printer.is_default = is_default;
 
 	cups_printer->printer.CreatePrintJob = printer_cups_create_printjob;
 	cups_printer->printer.FindPrintJob = printer_cups_find_printjob;
@@ -352,8 +351,8 @@ static rdpPrinter** printer_cups_enum_printers(rdpPrinterDriver* driver)
 	{
 		if (dest->instance == NULL)
 		{
-			rdpPrinter* current =
-			    printer_cups_new_printer((rdpCupsPrinterDriver*)driver, dest->name, NULL);
+			rdpPrinter* current = printer_cups_new_printer((rdpCupsPrinterDriver*)driver,
+			                                               dest->name, NULL, dest->is_default);
 			if (!current)
 			{
 				printer_cups_release_enum_printers(printers);
@@ -384,7 +383,7 @@ static rdpPrinter* printer_cups_get_printer(rdpPrinterDriver* driver, const char
 	rdpCupsPrinterDriver* cups_driver = (rdpCupsPrinterDriver*)driver;
 
 	WINPR_ASSERT(cups_driver);
-	return printer_cups_new_printer(cups_driver, name, driverName);
+	return printer_cups_new_printer(cups_driver, name, driverName, FALSE);
 }
 
 static void printer_cups_add_ref_driver(rdpPrinterDriver* driver)
@@ -407,7 +406,6 @@ static void printer_cups_release_ref_driver(rdpPrinterDriver* driver)
 	{
 		if (uniq_cups_driver == cups_driver)
 			uniq_cups_driver = NULL;
-		free(cups_driver->defaultPrinter);
 		free(cups_driver);
 	}
 	else
@@ -431,13 +429,6 @@ rdpPrinterDriver* cups_freerdp_printer_client_subsystem_entry(void)
 		uniq_cups_driver->driver.ReleaseRef = printer_cups_release_ref_driver;
 
 		uniq_cups_driver->id_sequence = 1;
-		uniq_cups_driver->defaultPrinter = _strdup(cupsGetDefault());
-
-		if (!uniq_cups_driver->defaultPrinter)
-		{
-			free(uniq_cups_driver);
-			return NULL;
-		}
 	}
 
 	WINPR_ASSERT(uniq_cups_driver->driver.AddRef);

--- a/channels/printer/client/cups/printer_cups.c
+++ b/channels/printer/client/cups/printer_cups.c
@@ -378,12 +378,12 @@ static rdpPrinter** printer_cups_enum_printers(rdpPrinterDriver* driver)
 }
 
 static rdpPrinter* printer_cups_get_printer(rdpPrinterDriver* driver, const char* name,
-                                            const char* driverName)
+                                            const char* driverName, BOOL isDefault)
 {
 	rdpCupsPrinterDriver* cups_driver = (rdpCupsPrinterDriver*)driver;
 
 	WINPR_ASSERT(cups_driver);
-	return printer_cups_new_printer(cups_driver, name, driverName, FALSE);
+	return printer_cups_new_printer(cups_driver, name, driverName, isDefault);
 }
 
 static void printer_cups_add_ref_driver(rdpPrinterDriver* driver)

--- a/channels/printer/client/printer_main.c
+++ b/channels/printer/client/printer_main.c
@@ -1072,7 +1072,7 @@ UINT printer_DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
 	if (name && name[0])
 	{
 		WINPR_ASSERT(driver->GetPrinter);
-		rdpPrinter* printer = driver->GetPrinter(driver, name, driver_name);
+		rdpPrinter* printer = driver->GetPrinter(driver, name, driver_name, device->IsDefault);
 
 		if (!printer)
 		{

--- a/channels/printer/client/win/printer_win.c
+++ b/channels/printer/client/win/printer_win.c
@@ -384,7 +384,7 @@ static rdpPrinter** printer_win_enum_printers(rdpPrinterDriver* driver)
 }
 
 static rdpPrinter* printer_win_get_printer(rdpPrinterDriver* driver, const char* name,
-                                           const char* driverName)
+                                           const char* driverName, BOOL isDefault)
 {
 	WCHAR* driverNameW = NULL;
 	WCHAR* nameW = NULL;
@@ -404,7 +404,7 @@ static rdpPrinter* printer_win_get_printer(rdpPrinterDriver* driver, const char*
 			return NULL;
 	}
 
-	myPrinter = printer_win_new_printer(win_driver, nameW, driverNameW, FALSE);
+	myPrinter = printer_win_new_printer(win_driver, nameW, driverNameW, isDefault);
 	free(driverNameW);
 	free(nameW);
 

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -502,7 +502,7 @@ BOOL freerdp_client_print_command_line_help_ex(int argc, char** argv,
 	printf("Serial Port Redirection: /serial:<name>,<device>,[SerCx2|SerCx|Serial],[permissive]\n");
 	printf("Serial Port Redirection: /serial:COM1,/dev/ttyS0\n");
 	printf("Parallel Port Redirection: /parallel:<name>,<device>\n");
-	printf("Printer Redirection: /printer:<device>,<driver>\n");
+	printf("Printer Redirection: /printer:<device>,<driver>,[default]\n");
 	printf("TCP redirection: /rdp2tcp:/usr/bin/rdp2tcp\n");
 	printf("\n");
 	printf("Audio Output Redirection: /sound:sys:oss,dev:1,format:1\n");

--- a/include/freerdp/client/printer.h
+++ b/include/freerdp/client/printer.h
@@ -34,7 +34,7 @@ typedef rdpPrinter** (*pcEnumPrinters)(rdpPrinterDriver* driver);
 typedef void (*pcReleaseEnumPrinters)(rdpPrinter** printers);
 
 typedef rdpPrinter* (*pcGetPrinter)(rdpPrinterDriver* driver, const char* name,
-                                    const char* driverName);
+                                    const char* driverName, BOOL isDefault);
 typedef void (*pcReferencePrinter)(rdpPrinter* printer);
 
 struct rdp_printer_driver

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -452,6 +452,7 @@ typedef struct
 {
 	RDPDR_DEVICE device;
 	char* DriverName;
+	BOOL IsDefault;
 } RDPDR_PRINTER;
 
 typedef struct

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -334,6 +334,11 @@ RDPDR_DEVICE* freerdp_device_new(UINT32 Type, size_t count, const char* args[])
 					if (!device.printer->DriverName)
 						goto fail;
 				}
+
+				if (count > 2)
+				{
+					device.printer->IsDefault = _stricmp(args[2], "default") == 0;
+				}
 				break;
 			case RDPDR_DTYP_SERIAL:
 				if (count > 1)


### PR DESCRIPTION
This PR is an improvement of #8177.

Printer are shared using two ways:
- ENUM to automatically share all the local printer
- GET to selectively share what printer to share

Since #8177, any printer shared (ENUM or GET) will be declared as the default printer if and only if it is the local default printer and this cannot be changed during execution.
Now, this behavior is sticked to the ENUM method. When you declare printers using GET, you can explicitely choose if the printer will be the default of not, and if you use freerdp as a library, you can even change that during a session.

