### PR TITLE
Restrict overmatching MACH ifdef to only trigger on OSX and Mach

### DIFF
--- a/winpr/libwinpr/synch/wait.c
+++ b/winpr/libwinpr/synch/wait.c
@@ -60,7 +60,7 @@
 #include "../pipe/pipe.h"
 
 /* clock_gettime is not implemented on OSX prior to 10.12 */
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
 
 #include <mach/mach_time.h>
 


### PR DESCRIPTION
As said in line 62, this check is only intended for OSX.
```
/* clock_gettime is not implemented on OSX prior to 10.12 */
```

Hurd also uses Mach, but does not have the same shortcomings as OSX in this area.
https://www.gnu.org/software/hurd/hurd/porting/guidelines.html
```
#ifdef __MACH__
Some applications put Apple Darwin-specific code inside #ifdef __MACH__ guards. Such guard is clearly not enough, since not only Apple uses Mach as a kernel. This should be replaced by #if defined(__MACH__) && defined(__APPLE__)
```