### PR TITLE
Load channels and winpr checks

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3629,7 +3629,6 @@ BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 		{ FreeRDP_EncomspVirtualChannel, ENCOMSP_SVC_CHANNEL_NAME, settings },
 #endif
 		{ FreeRDP_RemdeskVirtualChannel, REMDESK_SVC_CHANNEL_NAME, settings },
-		{ FreeRDP_RDP2TCPArgs, RDP2TCP_DVC_CHANNEL_NAME, settings->RDP2TCPArgs },
 		{ FreeRDP_RemoteApplicationMode, RAIL_SVC_CHANNEL_NAME, settings }
 	};
 	size_t i;
@@ -3854,6 +3853,13 @@ BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 					return FALSE;
 			}
 		}
+	}
+
+	if (settings->RDP2TCPArgs)
+	{
+		if (!freerdp_client_load_static_channel_addin(channels, settings, RDP2TCP_DVC_CHANNEL_NAME,
+		                                              settings->RDP2TCPArgs))
+			return FALSE;
 	}
 
 	/* step 4: do the static channels loading and init */

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -794,8 +794,12 @@ BOOL GetExitCodeThread(HANDLE hThread, LPDWORD lpExitCode)
 	WINPR_HANDLE* Object;
 	WINPR_THREAD* thread;
 
-	if (!winpr_Handle_GetInfo(hThread, &Type, &Object))
+	if (!winpr_Handle_GetInfo(hThread, &Type, &Object) || Object->Type != HANDLE_TYPE_THREAD)
+	{
+		WLog_ERR(TAG, "hThread is not a thread");
+		SetLastError(ERROR_INVALID_PARAMETER);
 		return FALSE;
+	}
 
 	thread = (WINPR_THREAD*)Object;
 	*lpExitCode = thread->dwExitCode;
@@ -893,8 +897,12 @@ DWORD ResumeThread(HANDLE hThread)
 	WINPR_HANDLE* Object;
 	WINPR_THREAD* thread;
 
-	if (!winpr_Handle_GetInfo(hThread, &Type, &Object))
+	if (!winpr_Handle_GetInfo(hThread, &Type, &Object) || Object->Type != HANDLE_TYPE_THREAD)
+	{
+		WLog_ERR(TAG, "hThread is not a thread");
+		SetLastError(ERROR_INVALID_PARAMETER);
 		return (DWORD)-1;
+	}
 
 	thread = (WINPR_THREAD*)Object;
 


### PR DESCRIPTION
Fix the loading of the rdp2tcp channel.
Adds checks for the kind of object for events and threads.