### PR TITLE
Send resize on window state change

### DIFF
--- a/client/X11/xf_disp.c
+++ b/client/X11/xf_disp.c
@@ -270,6 +270,23 @@ static void xf_disp_OnTimer(void* context, const TimerEventArgs* e)
 	xf_disp_sendResize(xfDisp);
 }
 
+static void xf_disp_OnWindowStateChange(void* context, const WindowStateChangeEventArgs* e)
+{
+	xfContext* xfc;
+	xfDispContext* xfDisp;
+	rdpSettings* settings;
+
+	WINPR_UNUSED(e);
+
+	if (!xf_disp_check_context(context, &xfc, &xfDisp, &settings))
+		return;
+
+	if (!xfDisp->activated || !xfc->fullscreen)
+		return;
+
+	xf_disp_sendResize(xfDisp);
+}
+
 xfDispContext* xf_disp_new(xfContext* xfc)
 {
 	xfDispContext* ret;
@@ -303,6 +320,7 @@ xfDispContext* xf_disp_new(xfContext* xfc)
 	PubSub_SubscribeActivated(pubSub, xf_disp_OnActivated);
 	PubSub_SubscribeGraphicsReset(pubSub, xf_disp_OnGraphicsReset);
 	PubSub_SubscribeTimer(pubSub, xf_disp_OnTimer);
+	PubSub_SubscribeWindowStateChange(pubSub, xf_disp_OnWindowStateChange);
 	return ret;
 }
 
@@ -317,6 +335,7 @@ void xf_disp_free(xfDispContext* disp)
 		PubSub_UnsubscribeActivated(pubSub, xf_disp_OnActivated);
 		PubSub_UnsubscribeGraphicsReset(pubSub, xf_disp_OnGraphicsReset);
 		PubSub_UnsubscribeTimer(pubSub, xf_disp_OnTimer);
+		PubSub_UnsubscribeWindowStateChange(pubSub, xf_disp_OnWindowStateChange);
 	}
 
 	free(disp);


### PR DESCRIPTION
Currently if you connect to a server with `/dynamic-resolution`, resize the window so that it is smaller than the screen, then press `Ctrl+Alt+Enter` to enable full screen mode, the resolution won't be updated.

This PR should fix that issue.  After the window state changes to full screen, it will call `xf_disp_sendResize` to update the resolution.
