### PR TITLE
Support for windows credential manager when username and password omitted

### DIFF
--- a/client/Windows/CMakeLists.txt
+++ b/client/Windows/CMakeLists.txt
@@ -35,6 +35,7 @@ set(${MODULE_PREFIX}_SRCS
 	wf_client.h
 	wf_floatbar.c
 	wf_floatbar.h
+	wf_defaults.h
 	wf_defaults.c
 	resource/wfreerdp.rc
 	resource/resource.h)

--- a/client/Windows/CMakeLists.txt
+++ b/client/Windows/CMakeLists.txt
@@ -35,6 +35,7 @@ set(${MODULE_PREFIX}_SRCS
 	wf_client.h
 	wf_floatbar.c
 	wf_floatbar.h
+	wf_defaults.c
 	resource/wfreerdp.rc
 	resource/resource.h)
 

--- a/client/Windows/cli/wfreerdp.c
+++ b/client/Windows/cli/wfreerdp.c
@@ -107,6 +107,8 @@ INT WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 		goto out;
 	}
 
+	AddDefaultSettings(settings);
+	
 	if (freerdp_client_start(context) != 0)
 		goto out;
 
@@ -145,3 +147,4 @@ int main()
 	return WinMain(NULL, NULL, NULL, 0);
 }
 #endif
+

--- a/client/Windows/cli/wfreerdp.c
+++ b/client/Windows/cli/wfreerdp.c
@@ -36,6 +36,7 @@
 #include "../resource/resource.h"
 
 #include "wf_client.h"
+#include "wf_defaults.h"
 
 #include <shellapi.h>
 

--- a/client/Windows/cli/wfreerdp.c
+++ b/client/Windows/cli/wfreerdp.c
@@ -109,7 +109,7 @@ INT WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	}
 
 	AddDefaultSettings(settings);
-	
+
 	if (freerdp_client_start(context) != 0)
 		goto out;
 
@@ -148,4 +148,3 @@ int main()
 	return WinMain(NULL, NULL, NULL, 0);
 }
 #endif
-

--- a/client/Windows/wf_defaults.c
+++ b/client/Windows/wf_defaults.c
@@ -1,0 +1,112 @@
+#include <Windows.h>
+#include <wincred.h>
+#include <stdio.h>
+#include <malloc.h>
+
+#pragma warning(disable : 4706 4094) // assignment within conditional expression
+
+#define FreeRDP_ServerHostname (20)
+#define FreeRDP_Username (21)
+#define FreeRDP_Password (22)
+#define FreeRDP_GatewayHostname (1986)
+#define FreeRDP_GatewayUsername (1987)
+#define FreeRDP_GatewayPassword (1988)
+
+typedef struct rdp_settings rdpSettings;
+
+EXTERN_C_START
+
+const char* freerdp_settings_get_string(const rdpSettings* settings, size_t id);
+BOOL freerdp_settings_set_string(rdpSettings* settings, size_t id, const char* param);
+
+EXTERN_C_END
+
+PCWSTR ValidateString(const BYTE* pb, ULONG cb)
+{
+	return pb &&                                       // present ?
+	               cb &&                               // size not 0 ?
+	               !(cb & (sizeof(WCHAR) - 1)) &&      // cb == n * sizeof(WCHAR) ?
+	               !*(WCHAR*)(pb + cb - sizeof(WCHAR)) // 0 terminated ?
+	           ? (PCWSTR)pb
+	           : 0;
+}
+
+void AddDefaultSettings_I(rdpSettings* settings, size_t idHostname, size_t idUsername,
+                          size_t idPassword)
+{
+	PCSTR ServerHostname = freerdp_settings_get_string(settings, idHostname);
+
+	if (!ServerHostname)
+	{
+		return;
+	}
+
+	BOOL bExistUserName = 0 != freerdp_settings_get_string(settings, idUsername);
+	BOOL bExistPassword = 0 != freerdp_settings_get_string(settings, idPassword);
+
+	if (bExistUserName && bExistPassword)
+	{
+		return;
+	}
+
+	PCREDENTIALA Credential;
+	PCWSTR lpWideCharStr;
+
+	PSTR Password;
+	PSTR UserName;
+
+	PSTR TargetName = 0;
+	int len = 0;
+
+	while (0 < (len = _vsnprintf(TargetName, len, "TERMSRV/%s", (va_list)&ServerHostname)))
+	{
+		if (TargetName)
+		{
+			if (CredReadA(TargetName, CRED_TYPE_GENERIC, 0, &Credential))
+			{
+				if (!bExistPassword)
+				{
+					ULONG cch = Credential->CredentialBlobSize;
+
+					if (lpWideCharStr = ValidateString(Credential->CredentialBlob, cch))
+					{
+						Password = 0, len = 0, cch /= sizeof(WCHAR);
+
+						while (len = WideCharToMultiByte(CP_UTF8, 0, lpWideCharStr, cch, Password,
+						                                 len, 0, 0))
+						{
+							if (Password)
+							{
+								freerdp_settings_set_string(settings, idPassword, Password);
+								break;
+							}
+
+							Password = (PSTR)alloca(len);
+						}
+					}
+				}
+
+				if (!bExistUserName)
+				{
+					if (UserName = Credential->UserName)
+					{
+						freerdp_settings_set_string(settings, idUsername, UserName);
+					}
+				}
+
+				CredFree(Credential);
+			}
+
+			break;
+		}
+
+		TargetName = (PSTR)alloca(++len);
+	}
+}
+
+EXTERN_C void WINAPI AddDefaultSettings(_Inout_ rdpSettings* settings)
+{
+	AddDefaultSettings_I(settings, FreeRDP_ServerHostname, FreeRDP_Username, FreeRDP_Password);
+	AddDefaultSettings_I(settings, FreeRDP_GatewayHostname, FreeRDP_GatewayUsername,
+	                     FreeRDP_GatewayPassword);
+}

--- a/client/Windows/wf_defaults.c
+++ b/client/Windows/wf_defaults.c
@@ -4,18 +4,7 @@
 #include <malloc.h>
 #include <freerdp/settings.h>
 
-#pragma warning(disable : 4706 4094) // assignment within conditional expression
-
-#define FreeRDP_ServerHostname (20)
-#define FreeRDP_Username (21)
-#define FreeRDP_Password (22)
-#define FreeRDP_GatewayHostname (1986)
-#define FreeRDP_GatewayUsername (1987)
-#define FreeRDP_GatewayPassword (1988)
-
-typedef struct rdp_settings rdpSettings;
-
-PCWSTR ValidateString(const BYTE* pb, ULONG cb)
+static PCWSTR ValidateString(const BYTE* pb, ULONG cb)
 {
 	if (!pb || !cb)
 		return 0;
@@ -29,7 +18,7 @@ PCWSTR ValidateString(const BYTE* pb, ULONG cb)
 	return (PCWSTR)pb;
 }
 
-void AddDefaultSettings_I(rdpSettings* settings, size_t idHostname, size_t idUsername,
+static void AddDefaultSettings_I(rdpSettings* settings, size_t idHostname, size_t idUsername,
                           size_t idPassword)
 {
 	PCSTR ServerHostname = freerdp_settings_get_string(settings, idHostname);
@@ -93,7 +82,7 @@ void AddDefaultSettings_I(rdpSettings* settings, size_t idHostname, size_t idUse
 	CredFree(Credential);
 }
 
-EXTERN_C void WINAPI AddDefaultSettings(_Inout_ rdpSettings* settings)
+void WINAPI AddDefaultSettings(_Inout_ rdpSettings* settings)
 {
 	AddDefaultSettings_I(settings, FreeRDP_ServerHostname, FreeRDP_Username, FreeRDP_Password);
 	AddDefaultSettings_I(settings, FreeRDP_GatewayHostname, FreeRDP_GatewayUsername, FreeRDP_GatewayPassword);

--- a/client/Windows/wf_defaults.c
+++ b/client/Windows/wf_defaults.c
@@ -103,7 +103,6 @@ static void AddDefaultSettings_I(rdpSettings* settings, size_t idHostname, size_
 		}
 	}
 
-
 fail:
 	CredFree(Credential);
 	free(TargetName);

--- a/client/Windows/wf_defaults.h
+++ b/client/Windows/wf_defaults.h
@@ -1,7 +1,6 @@
 /**
  * FreeRDP: A Remote Desktop Protocol Implementation
  *
- * Copyright 2014 Marc-Andre Moreau <marcandre.moreau@gmail.com>
  * Copyright 2022 Stefan Koell
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/client/Windows/wf_defaults.h
+++ b/client/Windows/wf_defaults.h
@@ -1,0 +1,8 @@
+#ifndef FREERDP_CLIENT_WIN_DEFAULTS_H
+#define FREERDP_CLIENT_WIN_DEFAULTS_H
+
+#include <freerdp/settings.h>
+
+void WINAPI AddDefaultSettings(_Inout_ rdpSettings* settings);
+
+#endif /* FREERDP_CLIENT_WIN_DEFAULTS_H */

--- a/client/Windows/wf_defaults.h
+++ b/client/Windows/wf_defaults.h
@@ -1,3 +1,22 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ *
+ * Copyright 2014 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+ * Copyright 2022 Stefan Koell
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef FREERDP_CLIENT_WIN_DEFAULTS_H
 #define FREERDP_CLIENT_WIN_DEFAULTS_H
 


### PR DESCRIPTION
* added wf_defaults.c (also in CMakeLists.txt) which provides the capability to read credential manager entries and set username and password in the rdpSettings accordingly
* the same will be done if a gateway host is specified without credentials
* the behavior will be similar to mstsc.exe on windows

To test the implementation, create a new "Generic Credential" in the Windows Credential Manager and use the following values:
**Internet or network address:** TERMSRV/[your RDP server name or IP]
**User name:** the username to log on to the RDP server
**Password:** the password to log on to the RDP server

Feature PR discussion:
https://matrix.to/#/!mnXPZoPpWIGqYeWkOf:matrix.org/$Is6wfkc_qDECcMvvUydVkIm21I6MxIBbkrZkJxL_Z1A?via=matrix.org&via=tchncs.de&via=windcorp.ru
