### PR TITLE
Add support to send a ServerRedirection PDU

### DIFF
--- a/include/freerdp/peer.h
+++ b/include/freerdp/peer.h
@@ -54,6 +54,13 @@ typedef BOOL (*psPeerPostConnect)(freerdp_peer* peer);
 typedef BOOL (*psPeerActivate)(freerdp_peer* peer);
 typedef BOOL (*psPeerLogon)(freerdp_peer* peer, const SEC_WINNT_AUTH_IDENTITY* identity,
                             BOOL automatic);
+typedef BOOL (*psPeerSendServerRedirection)(freerdp_peer* peer, UINT32 sessionId,
+                                            const char* targetNetAddress, const char* routingToken,
+                                            const char* userName, const char* domain,
+                                            const char* password, const char* targetFQDN,
+                                            const char* targetNetBiosName, DWORD tsvUrlLength,
+                                            const BYTE* tsvUrl, UINT32 targetNetAddressesCount,
+                                            const char** targetNetAddresses);
 typedef BOOL (*psPeerAdjustMonitorsLayout)(freerdp_peer* peer);
 typedef BOOL (*psPeerClientCapabilities)(freerdp_peer* peer);
 
@@ -124,6 +131,8 @@ struct rdp_freerdp_peer
 	ALIGN64 psPeerPostConnect PostConnect;
 	ALIGN64 psPeerActivate Activate;
 	ALIGN64 psPeerLogon Logon;
+
+	ALIGN64 psPeerSendServerRedirection SendServerRedirection;
 
 	ALIGN64 psPeerSendChannelData SendChannelData;
 	ALIGN64 psPeerReceiveChannelData ReceiveChannelData;


### PR DESCRIPTION
This PR should add the functionality of sending a Server Redirection PDU to a connected RDP client.

It has been implemented following the style of `core.redirection`.

I have tested with an xfreerdp client and recognises all fields properly. The client reconnects as expected.

I'm not sure if this method should be located in another place. It would be helpful if someone who knows more about this could point where it would make more sense to be located.

I assume this should be on the `stable-2.0` branch too.

Thank you.
