### PR TITLE
proxy: Fix handling of in drdynvc DATA_FIRST_PDU in proxy

### DIFF
--- a/server/proxy/channels/pf_channel_drdynvc.c
+++ b/server/proxy/channels/pf_channel_drdynvc.c
@@ -406,19 +406,19 @@ static PfChannelResult DynvcTrackerPeekFn(ChannelStateTracker* tracker, BOOL fir
 				    trackerState->CurrentDataReceived, trackerState->currentDataLength);
 				return PF_CHANNEL_RESULT_ERROR;
 			}
-
-			if (trackerState->CurrentDataReceived == trackerState->currentDataLength)
-			{
-				trackerState->currentDataLength = 0;
-				trackerState->CurrentDataFragments = 0;
-				trackerState->CurrentDataReceived = 0;
-			}
 		}
 		else
 		{
 			trackerState->CurrentDataFragments = 0;
 			trackerState->CurrentDataReceived = 0;
 		}
+	}
+
+	if (trackerState->CurrentDataReceived == trackerState->currentDataLength)
+	{
+		trackerState->currentDataLength = 0;
+		trackerState->CurrentDataFragments = 0;
+		trackerState->CurrentDataReceived = 0;
 	}
 
 	switch (dynChannel->channelMode)


### PR DESCRIPTION
During tests I sometimes received DATA_FIRST_PDUs that were not part of a fragmented message but contained a complete PDU.

The documentation is not quite clear about if this is a possible scenario or a protocol violation. However in the description of the Data field it says:

> If the sum of the DVC header size and the value specified by the Length field is less than 1600 bytes, then the actual data length equals the value specified by the Length field.

This hints that DATA_FIRST_PDU might also contain complete Data and does not necessarily mean to be the first part of a fragmented PDU.

To avoid connections to be dropped in this case I moved the "package complete" check out of the `DATA_PDU` conditional. This change fixed the connection drops in my case without any side effects.