### PR TITLE
Add SSPI SetCredentialsAttributes missing definitions + Kerberos KDC URL custom attribute

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -862,6 +862,11 @@ static int freerdp_client_command_line_post_filter(void* context, COMMAND_LINE_A
 
 		free(ptr.p);
 	}
+	CommandLineSwitchCase(arg, "kdc-url")
+	{
+		if (!freerdp_settings_set_string(settings, FreeRDP_KerberosKdcUrl, arg->Value))
+			return COMMAND_LINE_ERROR_MEMORY;
+	}
 	CommandLineSwitchCase(arg, "kerberos")
 	{
 		size_t count;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -862,11 +862,6 @@ static int freerdp_client_command_line_post_filter(void* context, COMMAND_LINE_A
 
 		free(ptr.p);
 	}
-	CommandLineSwitchCase(arg, "kdc-url")
-	{
-		if (!freerdp_settings_set_string(settings, FreeRDP_KerberosKdcUrl, arg->Value))
-			return COMMAND_LINE_ERROR_MEMORY;
-	}
 	CommandLineSwitchCase(arg, "kerberos")
 	{
 		size_t count;
@@ -876,6 +871,7 @@ static int freerdp_client_command_line_post_filter(void* context, COMMAND_LINE_A
 		{
 			size_t x;
 			const CmdLineSubOptions opts[] = {
+				{ "kdc-url:", FreeRDP_KerberosKdcUrl, CMDLINE_SUBOPTION_STRING, NULL },
 				{ "start-time:", FreeRDP_KerberosStartTime, CMDLINE_SUBOPTION_STRING, NULL },
 				{ "lifetime:", FreeRDP_KerberosLifeTime, CMDLINE_SUBOPTION_STRING, NULL },
 				{ "renewable-lifetime:", FreeRDP_KerberosRenewableLifeTime,

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -224,6 +224,7 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	{ "kbd-unicode", COMMAND_LINE_VALUE_FLAG, "", NULL, NULL, -1, NULL,
 	  "Send unicode symbols, e.g. use the local keyboard map. ATTENTION: Does not work with every "
 	  "RDP server!" },
+	{ "kdc-url", COMMAND_LINE_VALUE_REQUIRED, "<url>", NULL, NULL, -1, NULL, "KDC server URL" },
 	{ "kerberos", COMMAND_LINE_VALUE_REQUIRED,
 	  "[lifetime:<time>,start-time:<time>,renewable-lifetime:<time>,cache:<path>,armor:<path>,"
 	  "pkinit-anchors:<path>,pkcs11-module:<name>]",

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -224,7 +224,6 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	{ "kbd-unicode", COMMAND_LINE_VALUE_FLAG, "", NULL, NULL, -1, NULL,
 	  "Send unicode symbols, e.g. use the local keyboard map. ATTENTION: Does not work with every "
 	  "RDP server!" },
-	{ "kdc-url", COMMAND_LINE_VALUE_REQUIRED, "<url>", NULL, NULL, -1, NULL, "KDC server URL" },
 	{ "kerberos", COMMAND_LINE_VALUE_REQUIRED,
 	  "[lifetime:<time>,start-time:<time>,renewable-lifetime:<time>,cache:<path>,armor:<path>,"
 	  "pkinit-anchors:<path>,pkcs11-module:<name>]",

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -678,7 +678,7 @@ typedef struct
 #define FreeRDP_ReaderName (1293)
 #define FreeRDP_ContainerName (1294)
 #define FreeRDP_CspName (1295)
-#define FreeRDP_KerberosKdc (1344)
+#define FreeRDP_KerberosKdcUrl (1344)
 #define FreeRDP_KerberosRealm (1345)
 #define FreeRDP_KerberosStartTime (1346)
 #define FreeRDP_KerberosLifeTime (1347)
@@ -1186,7 +1186,7 @@ struct rdp_settings
 	UINT64 padding1344[1344 - 1296];    /* 1296 */
 
 	/* Kerberos Authentication */
-	ALIGN64 char* KerberosKdc;               /* 1344 */
+	ALIGN64 char* KerberosKdcUrl;            /* 1344 */
 	ALIGN64 char* KerberosRealm;             /* 1345 */
 	ALIGN64 char* KerberosStartTime;         /* 1346 */
 	ALIGN64 char* KerberosLifeTime;          /* 1347 */

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -2465,8 +2465,8 @@ const char* freerdp_settings_get_string(const rdpSettings* settings, size_t id)
 		case FreeRDP_KerberosCache:
 			return settings->KerberosCache;
 
-		case FreeRDP_KerberosKdc:
-			return settings->KerberosKdc;
+		case FreeRDP_KerberosKdcUrl:
+			return settings->KerberosKdcUrl;
 
 		case FreeRDP_KerberosKeytab:
 			return settings->KerberosKeytab;
@@ -2729,8 +2729,8 @@ char* freerdp_settings_get_string_writable(rdpSettings* settings, size_t id)
 		case FreeRDP_KerberosCache:
 			return settings->KerberosCache;
 
-		case FreeRDP_KerberosKdc:
-			return settings->KerberosKdc;
+		case FreeRDP_KerberosKdcUrl:
+			return settings->KerberosKdcUrl;
 
 		case FreeRDP_KerberosKeytab:
 			return settings->KerberosKeytab;
@@ -3003,8 +3003,8 @@ BOOL freerdp_settings_set_string_(rdpSettings* settings, size_t id, const char* 
 		case FreeRDP_KerberosCache:
 			return update_string(&settings->KerberosCache, cnv.cc, len, cleanup);
 
-		case FreeRDP_KerberosKdc:
-			return update_string(&settings->KerberosKdc, cnv.cc, len, cleanup);
+		case FreeRDP_KerberosKdcUrl:
+			return update_string(&settings->KerberosKdcUrl, cnv.cc, len, cleanup);
 
 		case FreeRDP_KerberosKeytab:
 			return update_string(&settings->KerberosKeytab, cnv.cc, len, cleanup);

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -348,7 +348,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_ImeFileName, 7, "FreeRDP_ImeFileName" },
 	{ FreeRDP_KerberosArmor, 7, "FreeRDP_KerberosArmor" },
 	{ FreeRDP_KerberosCache, 7, "FreeRDP_KerberosCache" },
-	{ FreeRDP_KerberosKdc, 7, "FreeRDP_KerberosKdc" },
+	{ FreeRDP_KerberosKdcUrl, 7, "FreeRDP_KerberosKdcUrl" },
 	{ FreeRDP_KerberosKeytab, 7, "FreeRDP_KerberosKeytab" },
 	{ FreeRDP_KerberosLifeTime, 7, "FreeRDP_KerberosLifeTime" },
 	{ FreeRDP_KerberosRealm, 7, "FreeRDP_KerberosRealm" },

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -958,12 +958,14 @@ static BOOL nla_client_init_cred_handle(rdpNla* nla)
 #ifdef UNICODE
 		SecPkgCredentials_KdcUrlW secAttr = { NULL };
 		ConvertToUnicode(CP_UTF8, 0, kerbSettings->kdcUrl, -1, &secAttr.KdcUrl, 0);
-		nla->table->SetCredentialsAttributesW(&nla->credentials, SECPKG_CRED_ATTR_KDC_URL, (void*) &secAttr, sizeof(secAttr));
+		nla->table->SetCredentialsAttributesW(&nla->credentials, SECPKG_CRED_ATTR_KDC_URL,
+		                                      (void*)&secAttr, sizeof(secAttr));
 		free(secAttr.KdcUrl);
 #else
 		SecPkgCredentials_KdcUrlA secAttr = { NULL };
 		secAttr.KdcUrl = kerbSettings->kdcUrl;
-		nla->table->SetCredentialsAttributesA(&nla->credentials, SECPKG_CRED_ATTR_KDC_URL, (void*) &secAttr, sizeof(secAttr));
+		nla->table->SetCredentialsAttributesA(&nla->credentials, SECPKG_CRED_ATTR_KDC_URL,
+		                                      (void*)&secAttr, sizeof(secAttr));
 #endif
 	}
 

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -940,6 +940,37 @@ static BOOL nla_setup_kerberos(rdpNla* nla)
 }
 
 /**
+ * Initialize SSPI credential attributes
+ * @param nla
+ */
+
+static BOOL nla_client_init_cred_handle(rdpNla* nla)
+{
+	SEC_WINPR_KERBEROS_SETTINGS* kerbSettings;
+
+	WINPR_ASSERT(nla);
+	kerbSettings = nla->kerberosSettings;
+	WINPR_ASSERT(kerbSettings);
+	WINPR_ASSERT(nla->table->SetCredentialsAttributes);
+
+	if (kerbSettings->kdcUrl)
+	{
+#ifdef UNICODE
+		SecPkgCredentials_KdcUrlW secAttr = { NULL };
+		ConvertToUnicode(CP_UTF8, 0, kerbSettings->kdcUrl, -1, &secAttr.KdcUrl, 0);
+		nla->table->SetCredentialsAttributesW(&nla->credentials, SECPKG_CRED_ATTR_KDC_URL, (void*) &secAttr, sizeof(secAttr));
+		free(secAttr.KdcUrl);
+#else
+		SecPkgCredentials_KdcUrlA secAttr = { NULL };
+		secAttr.KdcUrl = kerbSettings->kdcUrl;
+		nla->table->SetCredentialsAttributesA(&nla->credentials, SECPKG_CRED_ATTR_KDC_URL, (void*) &secAttr, sizeof(secAttr));
+#endif
+	}
+
+	return TRUE;
+}
+
+/**
  * Initialize NTLM/Kerberos SSP authentication module (client).
  * @param credssp
  */
@@ -1019,6 +1050,8 @@ static int nla_client_init(rdpNla* nla)
 		         GetSecurityStatusString(nla->status), nla->status);
 		return -1;
 	}
+
+	nla_client_init_cred_handle(nla);
 
 	nla->haveContext = FALSE;
 	nla->haveInputBuffer = FALSE;

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -958,8 +958,13 @@ static BOOL nla_client_init_cred_handle(rdpNla* nla)
 #ifdef UNICODE
 		SecPkgCredentials_KdcUrlW secAttr = { NULL };
 		ConvertToUnicode(CP_UTF8, 0, kerbSettings->kdcUrl, -1, &secAttr.KdcUrl, 0);
+
+		if (!secAttr.KdcUrl)
+			return FALSE;
+
 		nla->table->SetCredentialsAttributesW(&nla->credentials, SECPKG_CRED_ATTR_KDC_URL,
 		                                      (void*)&secAttr, sizeof(secAttr));
+
 		free(secAttr.KdcUrl);
 #else
 		SecPkgCredentials_KdcUrlA secAttr = { NULL };
@@ -1053,7 +1058,8 @@ static int nla_client_init(rdpNla* nla)
 		return -1;
 	}
 
-	nla_client_init_cred_handle(nla);
+	if (!nla_client_init_cred_handle(nla))
+		return -1;
 
 	nla->haveContext = FALSE;
 	nla->haveInputBuffer = FALSE;

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -883,6 +883,16 @@ static BOOL nla_setup_kerberos(rdpNla* nla)
 	kerbSettings = nla->kerberosSettings;
 	WINPR_ASSERT(kerbSettings);
 
+	if (settings->KerberosKdcUrl)
+	{
+		kerbSettings->kdcUrl = _strdup(settings->KerberosKdcUrl);
+		if (!kerbSettings->kdcUrl)
+		{
+			WLog_ERR(TAG, "unable to copy kdcUrl");
+			return FALSE;
+		}
+	}
+
 	if (settings->KerberosLifeTime &&
 	    !parseKerberosDeltat(settings->KerberosLifeTime, &kerbSettings->lifeTime, "lifetime"))
 		return FALSE;
@@ -2655,6 +2665,7 @@ void nla_free(rdpNla* nla)
 	sspi_SecBufferFree(&nla->tsCredentials);
 
 	free(nla->ServicePrincipalName);
+	free(nla->kerberosSettings->kdcUrl);
 	free(nla->kerberosSettings->armorCache);
 	free(nla->kerberosSettings->cache);
 	free(nla->kerberosSettings->pkinitX509Anchors);

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -357,7 +357,7 @@ static const size_t string_list_indices[] = {
 	FreeRDP_ImeFileName,
 	FreeRDP_KerberosArmor,
 	FreeRDP_KerberosCache,
-	FreeRDP_KerberosKdc,
+	FreeRDP_KerberosKdcUrl,
 	FreeRDP_KerberosKeytab,
 	FreeRDP_KerberosLifeTime,
 	FreeRDP_KerberosRealm,

--- a/winpr/include/winpr/sspi.h
+++ b/winpr/include/winpr/sspi.h
@@ -1032,6 +1032,20 @@ typedef SECURITY_STATUS(SEC_ENTRY* SET_CONTEXT_ATTRIBUTES_FN_W)(PCtxtHandle phCo
 #define SET_CONTEXT_ATTRIBUTES_FN SET_CONTEXT_ATTRIBUTES_FN_A
 #endif
 
+typedef SECURITY_STATUS (SEC_ENTRY* SET_CREDENTIALS_ATTRIBUTES_FN_A)(PCredHandle phCredential,
+	ULONG ulAttribute, void* pBuffer, ULONG cbBuffer);
+
+typedef SECURITY_STATUS (SEC_ENTRY* SET_CREDENTIALS_ATTRIBUTES_FN_W)(PCredHandle phCredential,
+	ULONG ulAttribute, void* pBuffer, ULONG cbBuffer);
+
+#ifdef UNICODE
+#define SetCredentialsAttributes SetCredentialsAttributesW
+#define SET_CREDENTIALS_ATTRIBUTES_FN SET_CREDENTIALS_ATTRIBUTES_FN_W
+#else
+#define SetCredentialsAttributes SetCredentialsAttributesA
+#define SET_CREDENTIALS_ATTRIBUTES_FN SET_CREDENTIALS_ATTRIBUTES_FN_A
+#endif
+
 #define SECURITY_SUPPORT_PROVIDER_INTERFACE_VERSION \
 	1 /* Interface has all routines through DecryptMessage */
 #define SECURITY_SUPPORT_PROVIDER_INTERFACE_VERSION_2 \
@@ -1071,6 +1085,7 @@ typedef struct
 	ENCRYPT_MESSAGE_FN EncryptMessage;
 	DECRYPT_MESSAGE_FN DecryptMessage;
 	SET_CONTEXT_ATTRIBUTES_FN_A SetContextAttributesA;
+	SET_CREDENTIALS_ATTRIBUTES_FN_A SetCredentialsAttributesA;
 } SecurityFunctionTableA;
 typedef SecurityFunctionTableA* PSecurityFunctionTableA;
 
@@ -1104,6 +1119,7 @@ typedef struct
 	ENCRYPT_MESSAGE_FN EncryptMessage;
 	DECRYPT_MESSAGE_FN DecryptMessage;
 	SET_CONTEXT_ATTRIBUTES_FN_W SetContextAttributesW;
+	SET_CREDENTIALS_ATTRIBUTES_FN_W SetCredentialsAttributesW;
 } SecurityFunctionTableW;
 typedef SecurityFunctionTableW* PSecurityFunctionTableW;
 
@@ -1239,6 +1255,10 @@ extern "C"
 
 	/* Custom API */
 
+/* Extended SECPKG_CRED_ATTR IDs begin at 500 */
+#define SECPKG_CRED_ATTR_KDC_URL 501
+
+/* Extended SECPKG_ATTR IDs begin at 1000 */
 #define SECPKG_ATTR_AUTH_IDENTITY 1001
 #define SECPKG_ATTR_AUTH_PASSWORD 1002
 #define SECPKG_ATTR_AUTH_NTLM_HASH 1003

--- a/winpr/include/winpr/sspi.h
+++ b/winpr/include/winpr/sspi.h
@@ -1258,6 +1258,26 @@ extern "C"
 /* Extended SECPKG_CRED_ATTR IDs begin at 500 */
 #define SECPKG_CRED_ATTR_KDC_URL 501
 
+	typedef struct
+	{
+		SEC_CHAR* KdcUrl;
+	} SecPkgCredentials_KdcUrlA;
+	typedef SecPkgCredentials_KdcUrlA* PSecPkgCredentials_KdcUrlA;
+
+	typedef struct
+	{
+		SEC_WCHAR* KdcUrl;
+	} SecPkgCredentials_KdcUrlW;
+	typedef SecPkgCredentials_KdcUrlW* PSecPkgCredentials_KdcUrlW;
+
+#ifdef UNICODE
+#define SecPkgCredentials_KdcUrl SecPkgCredentials_KdcUrlW
+#define PSecPkgCredentials_KdcUrl PSecPkgCredentials_KdcUrlW
+#else
+#define SecPkgCredentials_KdcUrl SecPkgCredentials_KdcUrlA
+#define PSecPkgCredentials_KdcUrl PSecPkgCredentials_KdcUrlA
+#endif
+
 /* Extended SECPKG_ATTR IDs begin at 1000 */
 #define SECPKG_ATTR_AUTH_IDENTITY 1001
 #define SECPKG_ATTR_AUTH_PASSWORD 1002

--- a/winpr/include/winpr/sspi.h
+++ b/winpr/include/winpr/sspi.h
@@ -461,6 +461,10 @@ typedef struct
 /* Security Credentials Attributes */
 
 #define SECPKG_CRED_ATTR_NAMES 1
+#define SECPKG_CRED_ATTR_SSI_PROVIDER 2
+#define SECPKG_CRED_ATTR_KDC_PROXY_SETTINGS 3
+#define SECPKG_CRED_ATTR_CERT 4
+#define SECPKG_CRED_ATTR_PAC_BYPASS 5
 
 typedef struct
 {
@@ -481,6 +485,65 @@ typedef SecPkgCredentials_NamesW* PSecPkgCredentials_NamesW;
 #define SecPkgCredentials_Names SecPkgCredentials_NamesA
 #define PSecPkgCredentials_Names PSecPkgCredentials_NamesA
 #endif
+
+typedef struct _SecPkgCredentials_SSIProviderW
+{
+	SEC_WCHAR* sProviderName;
+	unsigned long ProviderInfoLength;
+	char* ProviderInfo;
+} SecPkgCredentials_SSIProviderW, *PSecPkgCredentials_SSIProviderW;
+
+typedef struct _SecPkgCredentials_SSIProviderA
+{
+	SEC_CHAR* sProviderName;
+	unsigned long ProviderInfoLength;
+	char* ProviderInfo;
+} SecPkgCredentials_SSIProviderA, *PSecPkgCredentials_SSIProviderA;
+
+#ifdef UNICODE
+#define SecPkgCredentials_SSIProvider SecPkgCredentials_SSIProviderW
+#define PSecPkgCredentials_SSIProvider PSecPkgCredentials_SSIProviderW
+#else
+#define SecPkgCredentials_SSIProvider SecPkgCredentials_SSIProviderA
+#define PSecPkgCredentials_SSIProvider PSecPkgCredentials_SSIProviderA
+#endif
+
+#define KDC_PROXY_SETTINGS_V1 1
+#define KDC_PROXY_SETTINGS_FLAGS_FORCEPROXY 0x1
+
+typedef struct _SecPkgCredentials_KdcProxySettingsW
+{
+	ULONG Version;
+	ULONG Flags;
+	USHORT ProxyServerOffset;
+	USHORT ProxyServerLength;
+	USHORT ClientTlsCredOffset;
+	USHORT ClientTlsCredLength;
+} SecPkgCredentials_KdcProxySettingsW, *PSecPkgCredentials_KdcProxySettingsW;
+
+typedef struct _SecPkgCredentials_KdcProxySettingsA
+{
+	ULONG Version;
+	ULONG Flags;
+	USHORT ProxyServerOffset;
+	USHORT ProxyServerLength;
+	USHORT ClientTlsCredOffset;
+	USHORT ClientTlsCredLength;
+} SecPkgCredentials_KdcProxySettingsA, *PSecPkgCredentials_KdcProxySettingsA;
+
+#ifdef UNICODE
+#define SecPkgCredentials_KdcProxySettings SecPkgCredentials_KdcProxySettingsW
+#define PSecPkgCredentials_KdcProxySettings PSecPkgCredentials_KdcProxySettingsW
+#else
+#define SecPkgCredentials_KdcProxySettings SecPkgCredentials_KdcProxySettingsA
+#define PSecPkgCredentials_KdcProxySettings SecPkgCredentials_KdcProxySettingsA
+#endif
+
+typedef struct _SecPkgCredentials_Cert
+{
+	unsigned long EncodedCertSize;
+	unsigned char* EncodedCert;
+} SecPkgCredentials_Cert, *PSecPkgCredentials_Cert;
 
 #endif /* !defined(_WIN32) || defined(_UWP) */
 

--- a/winpr/include/winpr/sspi.h
+++ b/winpr/include/winpr/sspi.h
@@ -1032,11 +1032,13 @@ typedef SECURITY_STATUS(SEC_ENTRY* SET_CONTEXT_ATTRIBUTES_FN_W)(PCtxtHandle phCo
 #define SET_CONTEXT_ATTRIBUTES_FN SET_CONTEXT_ATTRIBUTES_FN_A
 #endif
 
-typedef SECURITY_STATUS (SEC_ENTRY* SET_CREDENTIALS_ATTRIBUTES_FN_A)(PCredHandle phCredential,
-	ULONG ulAttribute, void* pBuffer, ULONG cbBuffer);
+typedef SECURITY_STATUS(SEC_ENTRY* SET_CREDENTIALS_ATTRIBUTES_FN_A)(PCredHandle phCredential,
+                                                                    ULONG ulAttribute,
+                                                                    void* pBuffer, ULONG cbBuffer);
 
-typedef SECURITY_STATUS (SEC_ENTRY* SET_CREDENTIALS_ATTRIBUTES_FN_W)(PCredHandle phCredential,
-	ULONG ulAttribute, void* pBuffer, ULONG cbBuffer);
+typedef SECURITY_STATUS(SEC_ENTRY* SET_CREDENTIALS_ATTRIBUTES_FN_W)(PCredHandle phCredential,
+                                                                    ULONG ulAttribute,
+                                                                    void* pBuffer, ULONG cbBuffer);
 
 #ifdef UNICODE
 #define SetCredentialsAttributes SetCredentialsAttributesW

--- a/winpr/include/winpr/sspi.h
+++ b/winpr/include/winpr/sspi.h
@@ -739,6 +739,7 @@ typedef struct
 
 typedef struct
 {
+	char* kdcUrl;
 	char* keytab;
 	char* cache;
 	char* armorCache;

--- a/winpr/libwinpr/sspi/CredSSP/credssp.c
+++ b/winpr/libwinpr/sspi/CredSSP/credssp.c
@@ -223,7 +223,7 @@ static SECURITY_STATUS SEC_ENTRY credssp_VerifySignature(PCtxtHandle phContext,
 }
 
 const SecurityFunctionTableA CREDSSP_SecurityFunctionTableA = {
-	1,                                   /* dwVersion */
+	3,                                   /* dwVersion */
 	NULL,                                /* EnumerateSecurityPackages */
 	credssp_QueryCredentialsAttributesA, /* QueryCredentialsAttributes */
 	credssp_AcquireCredentialsHandleA,   /* AcquireCredentialsHandle */
@@ -251,10 +251,11 @@ const SecurityFunctionTableA CREDSSP_SecurityFunctionTableA = {
 	credssp_EncryptMessage,              /* EncryptMessage */
 	credssp_DecryptMessage,              /* DecryptMessage */
 	NULL,                                /* SetContextAttributes */
+	NULL,                                /* SetCredentialsAttributes */
 };
 
 const SecurityFunctionTableW CREDSSP_SecurityFunctionTableW = {
-	1,                                   /* dwVersion */
+	3,                                   /* dwVersion */
 	NULL,                                /* EnumerateSecurityPackages */
 	credssp_QueryCredentialsAttributesW, /* QueryCredentialsAttributes */
 	credssp_AcquireCredentialsHandleW,   /* AcquireCredentialsHandle */
@@ -282,6 +283,7 @@ const SecurityFunctionTableW CREDSSP_SecurityFunctionTableW = {
 	credssp_EncryptMessage,              /* EncryptMessage */
 	credssp_DecryptMessage,              /* DecryptMessage */
 	NULL,                                /* SetContextAttributes */
+	NULL,                                /* SetCredentialsAttributes */
 };
 
 const SecPkgInfoA CREDSSP_SecPkgInfoA = {

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -1224,6 +1224,34 @@ static SECURITY_STATUS SEC_ENTRY kerberos_QueryContextAttributesW(PCtxtHandle ph
 	return kerberos_QueryContextAttributesA(phContext, ulAttribute, pBuffer);
 }
 
+static SECURITY_STATUS SEC_ENTRY kerberos_SetContextAttributesW(PCtxtHandle phContext,
+                                                            ULONG ulAttribute, void* pBuffer,
+                                                            ULONG cbBuffer)
+{
+	return SEC_E_UNSUPPORTED_FUNCTION;
+}
+
+static SECURITY_STATUS SEC_ENTRY kerberos_SetContextAttributesA(PCtxtHandle phContext,
+                                                            ULONG ulAttribute, void* pBuffer,
+                                                            ULONG cbBuffer)
+{
+	return SEC_E_UNSUPPORTED_FUNCTION;
+}
+
+static SECURITY_STATUS SEC_ENTRY kerberos_SetCredentialsAttributesW(PCredHandle phCredential,
+                                                            ULONG ulAttribute, void* pBuffer,
+                                                            ULONG cbBuffer)
+{
+	return SEC_E_UNSUPPORTED_FUNCTION;
+}
+
+static SECURITY_STATUS SEC_ENTRY kerberos_SetCredentialsAttributesA(PCredHandle phCredential,
+                                                            ULONG ulAttribute, void* pBuffer,
+                                                            ULONG cbBuffer)
+{
+	return SEC_E_UNSUPPORTED_FUNCTION;
+}
+
 static SECURITY_STATUS SEC_ENTRY kerberos_EncryptMessage(PCtxtHandle phContext, ULONG fQOP,
                                                          PSecBufferDesc pMessage,
                                                          ULONG MessageSeqNo)
@@ -1574,7 +1602,7 @@ static SECURITY_STATUS SEC_ENTRY kerberos_VerifySignature(PCtxtHandle phContext,
 }
 
 const SecurityFunctionTableA KERBEROS_SecurityFunctionTableA = {
-	1,                                    /* dwVersion */
+	3,                                    /* dwVersion */
 	NULL,                                 /* EnumerateSecurityPackages */
 	kerberos_QueryCredentialsAttributesA, /* QueryCredentialsAttributes */
 	kerberos_AcquireCredentialsHandleA,   /* AcquireCredentialsHandle */
@@ -1601,11 +1629,12 @@ const SecurityFunctionTableA KERBEROS_SecurityFunctionTableA = {
 	NULL,                                 /* QuerySecurityContextToken */
 	kerberos_EncryptMessage,              /* EncryptMessage */
 	kerberos_DecryptMessage,              /* DecryptMessage */
-	NULL,                                 /* SetContextAttributes */
+	kerberos_SetContextAttributesA,       /* SetContextAttributes */
+	kerberos_SetCredentialsAttributesA,   /* SetCredentialsAttributes */
 };
 
 const SecurityFunctionTableW KERBEROS_SecurityFunctionTableW = {
-	1,                                    /* dwVersion */
+	3,                                    /* dwVersion */
 	NULL,                                 /* EnumerateSecurityPackages */
 	kerberos_QueryCredentialsAttributesW, /* QueryCredentialsAttributes */
 	kerberos_AcquireCredentialsHandleW,   /* AcquireCredentialsHandle */
@@ -1632,5 +1661,6 @@ const SecurityFunctionTableW KERBEROS_SecurityFunctionTableW = {
 	NULL,                                 /* QuerySecurityContextToken */
 	kerberos_EncryptMessage,              /* EncryptMessage */
 	kerberos_DecryptMessage,              /* DecryptMessage */
-	NULL,                                 /* SetContextAttributes */
+	kerberos_SetContextAttributesW,       /* SetContextAttributes */
+	kerberos_SetCredentialsAttributesW,   /* SetCredentialsAttributes */
 };

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -1228,22 +1228,23 @@ static SECURITY_STATUS SEC_ENTRY kerberos_QueryContextAttributesW(PCtxtHandle ph
 }
 
 static SECURITY_STATUS SEC_ENTRY kerberos_SetContextAttributesW(PCtxtHandle phContext,
-                                                            ULONG ulAttribute, void* pBuffer,
-                                                            ULONG cbBuffer)
+                                                                ULONG ulAttribute, void* pBuffer,
+                                                                ULONG cbBuffer)
 {
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
 static SECURITY_STATUS SEC_ENTRY kerberos_SetContextAttributesA(PCtxtHandle phContext,
-                                                            ULONG ulAttribute, void* pBuffer,
-                                                            ULONG cbBuffer)
+                                                                ULONG ulAttribute, void* pBuffer,
+                                                                ULONG cbBuffer)
 {
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
 static SECURITY_STATUS SEC_ENTRY kerberos_SetCredentialsAttributesX(PCredHandle phCredential,
-                                                            ULONG ulAttribute, void* pBuffer,
-                                                            ULONG cbBuffer, BOOL unicode)
+                                                                    ULONG ulAttribute,
+                                                                    void* pBuffer, ULONG cbBuffer,
+                                                                    BOOL unicode)
 {
 #ifdef WITH_GSSAPI
 	KRB_CREDENTIALS* credentials;
@@ -1252,7 +1253,7 @@ static SECURITY_STATUS SEC_ENTRY kerberos_SetCredentialsAttributesX(PCredHandle 
 		return SEC_E_INVALID_HANDLE;
 
 	credentials = sspi_SecureHandleGetLowerPointer(phCredential);
-	
+
 	if (!credentials)
 		return SEC_E_INVALID_HANDLE;
 
@@ -1261,26 +1262,34 @@ static SECURITY_STATUS SEC_ENTRY kerberos_SetCredentialsAttributesX(PCredHandle 
 
 	if (ulAttribute == SECPKG_CRED_ATTR_KDC_URL)
 	{
-		if (credentials->kdc_url) {
+		if (credentials->kdc_url)
+		{
 			free(credentials->kdc_url);
 			credentials->kdc_url = NULL;
 		}
 
-		if (unicode) {
-			SEC_WCHAR* KdcUrl = ((SecPkgCredentials_KdcUrlW*) pBuffer)->KdcUrl;
+		if (unicode)
+		{
+			SEC_WCHAR* KdcUrl = ((SecPkgCredentials_KdcUrlW*)pBuffer)->KdcUrl;
 
-			if (KdcUrl) {
-				ConvertFromUnicode(CP_UTF8, 0, (WCHAR*) KdcUrl, -1, &credentials->kdc_url, 0, NULL, NULL);
+			if (KdcUrl)
+			{
+				ConvertFromUnicode(CP_UTF8, 0, (WCHAR*)KdcUrl, -1, &credentials->kdc_url, 0, NULL,
+				                   NULL);
 			}
-		} else {
-			SEC_CHAR* KdcUrl = ((SecPkgCredentials_KdcUrlA*) pBuffer)->KdcUrl;
+		}
+		else
+		{
+			SEC_CHAR* KdcUrl = ((SecPkgCredentials_KdcUrlA*)pBuffer)->KdcUrl;
 
-			if (KdcUrl) {
+			if (KdcUrl)
+			{
 				credentials->kdc_url = _strdup(KdcUrl);
 			}
 		}
 
-		WLog_WARN(TAG, "Kerberos SSPI module does not support KDC URL injection yet: %s", credentials->kdc_url);
+		WLog_WARN(TAG, "Kerberos SSPI module does not support KDC URL injection yet: %s",
+		          credentials->kdc_url);
 	}
 
 	return SEC_E_UNSUPPORTED_FUNCTION;
@@ -1290,15 +1299,15 @@ static SECURITY_STATUS SEC_ENTRY kerberos_SetCredentialsAttributesX(PCredHandle 
 }
 
 static SECURITY_STATUS SEC_ENTRY kerberos_SetCredentialsAttributesW(PCredHandle phCredential,
-                                                            ULONG ulAttribute, void* pBuffer,
-                                                            ULONG cbBuffer)
+                                                                    ULONG ulAttribute,
+                                                                    void* pBuffer, ULONG cbBuffer)
 {
 	return kerberos_SetCredentialsAttributesX(phCredential, ulAttribute, pBuffer, cbBuffer, TRUE);
 }
 
 static SECURITY_STATUS SEC_ENTRY kerberos_SetCredentialsAttributesA(PCredHandle phCredential,
-                                                            ULONG ulAttribute, void* pBuffer,
-                                                            ULONG cbBuffer)
+                                                                    ULONG ulAttribute,
+                                                                    void* pBuffer, ULONG cbBuffer)
 {
 	return kerberos_SetCredentialsAttributesX(phCredential, ulAttribute, pBuffer, cbBuffer, FALSE);
 }

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -1294,8 +1294,7 @@ static SECURITY_STATUS SEC_ENTRY kerberos_SetCredentialsAttributesX(PCredHandle 
 			}
 		}
 
-		WLog_WARN(TAG, "Kerberos SSPI module does not support KDC URL injection yet: %s",
-		          credentials->kdc_url);
+		return SEC_E_UNSUPPORTED_FUNCTION;
 	}
 
 	return SEC_E_UNSUPPORTED_FUNCTION;

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -1276,6 +1276,9 @@ static SECURITY_STATUS SEC_ENTRY kerberos_SetCredentialsAttributesX(PCredHandle 
 			{
 				ConvertFromUnicode(CP_UTF8, 0, (WCHAR*)KdcUrl, -1, &credentials->kdc_url, 0, NULL,
 				                   NULL);
+
+				if (!credentials->kdc_url)
+					return SEC_E_INSUFFICIENT_MEMORY;
 			}
 		}
 		else
@@ -1285,6 +1288,9 @@ static SECURITY_STATUS SEC_ENTRY kerberos_SetCredentialsAttributesX(PCredHandle 
 			if (KdcUrl)
 			{
 				credentials->kdc_url = _strdup(KdcUrl);
+
+				if (!credentials->kdc_url)
+					return SEC_E_INSUFFICIENT_MEMORY;
 			}
 		}
 

--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -963,6 +963,20 @@ static SECURITY_STATUS SEC_ENTRY ntlm_SetContextAttributesA(PCtxtHandle phContex
 	return ntlm_SetContextAttributesW(phContext, ulAttribute, pBuffer, cbBuffer);
 }
 
+static SECURITY_STATUS SEC_ENTRY ntlm_SetCredentialsAttributesW(PCredHandle phCredential,
+                                                            ULONG ulAttribute, void* pBuffer,
+                                                            ULONG cbBuffer)
+{
+	return SEC_E_UNSUPPORTED_FUNCTION;
+}
+
+static SECURITY_STATUS SEC_ENTRY ntlm_SetCredentialsAttributesA(PCredHandle phCredential,
+                                                            ULONG ulAttribute, void* pBuffer,
+                                                            ULONG cbBuffer)
+{
+	return SEC_E_UNSUPPORTED_FUNCTION;
+}
+
 static SECURITY_STATUS SEC_ENTRY ntlm_RevertSecurityContext(PCtxtHandle phContext)
 {
 	return SEC_E_OK;
@@ -1264,7 +1278,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_VerifySignature(PCtxtHandle phContext,
 }
 
 const SecurityFunctionTableA NTLM_SecurityFunctionTableA = {
-	1,                                /* dwVersion */
+	3,                                /* dwVersion */
 	NULL,                             /* EnumerateSecurityPackages */
 	ntlm_QueryCredentialsAttributesA, /* QueryCredentialsAttributes */
 	ntlm_AcquireCredentialsHandleA,   /* AcquireCredentialsHandle */
@@ -1292,10 +1306,11 @@ const SecurityFunctionTableA NTLM_SecurityFunctionTableA = {
 	ntlm_EncryptMessage,              /* EncryptMessage */
 	ntlm_DecryptMessage,              /* DecryptMessage */
 	ntlm_SetContextAttributesA,       /* SetContextAttributes */
+	ntlm_SetCredentialsAttributesA,   /* SetCredentialsAttributes */
 };
 
 const SecurityFunctionTableW NTLM_SecurityFunctionTableW = {
-	1,                                /* dwVersion */
+	3,                                /* dwVersion */
 	NULL,                             /* EnumerateSecurityPackages */
 	ntlm_QueryCredentialsAttributesW, /* QueryCredentialsAttributes */
 	ntlm_AcquireCredentialsHandleW,   /* AcquireCredentialsHandle */
@@ -1322,7 +1337,8 @@ const SecurityFunctionTableW NTLM_SecurityFunctionTableW = {
 	NULL,                             /* QuerySecurityContextToken */
 	ntlm_EncryptMessage,              /* EncryptMessage */
 	ntlm_DecryptMessage,              /* DecryptMessage */
-	ntlm_SetContextAttributesA,       /* SetContextAttributes */
+	ntlm_SetContextAttributesW,       /* SetContextAttributes */
+	ntlm_SetCredentialsAttributesW,   /* SetCredentialsAttributes */
 };
 
 const SecPkgInfoA NTLM_SecPkgInfoA = {

--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -964,15 +964,15 @@ static SECURITY_STATUS SEC_ENTRY ntlm_SetContextAttributesA(PCtxtHandle phContex
 }
 
 static SECURITY_STATUS SEC_ENTRY ntlm_SetCredentialsAttributesW(PCredHandle phCredential,
-                                                            ULONG ulAttribute, void* pBuffer,
-                                                            ULONG cbBuffer)
+                                                                ULONG ulAttribute, void* pBuffer,
+                                                                ULONG cbBuffer)
 {
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
 static SECURITY_STATUS SEC_ENTRY ntlm_SetCredentialsAttributesA(PCredHandle phCredential,
-                                                            ULONG ulAttribute, void* pBuffer,
-                                                            ULONG cbBuffer)
+                                                                ULONG ulAttribute, void* pBuffer,
+                                                                ULONG cbBuffer)
 {
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }

--- a/winpr/libwinpr/sspi/Negotiate/negotiate.c
+++ b/winpr/libwinpr/sspi/Negotiate/negotiate.c
@@ -1203,8 +1203,8 @@ static SECURITY_STATUS SEC_ENTRY negotiate_SetContextAttributesA(PCtxtHandle phC
 }
 
 static SECURITY_STATUS SEC_ENTRY negotiate_SetCredentialsAttributesW(PCredHandle phCredential,
-                                                            ULONG ulAttribute, void* pBuffer,
-                                                            ULONG cbBuffer)
+                                                                     ULONG ulAttribute,
+                                                                     void* pBuffer, ULONG cbBuffer)
 {
 	MechCred* creds;
 
@@ -1224,15 +1224,16 @@ static SECURITY_STATUS SEC_ENTRY negotiate_SetCredentialsAttributesW(PCredHandle
 		WINPR_ASSERT(cred->mech->pkg);
 		WINPR_ASSERT(cred->mech->pkg->table);
 		WINPR_ASSERT(cred->mech->pkg->table_w->SetCredentialsAttributesW);
-		cred->mech->pkg->table_w->SetCredentialsAttributesW(&cred->cred, ulAttribute, pBuffer, cbBuffer);
+		cred->mech->pkg->table_w->SetCredentialsAttributesW(&cred->cred, ulAttribute, pBuffer,
+		                                                    cbBuffer);
 	}
 
 	return SEC_E_OK;
 }
 
 static SECURITY_STATUS SEC_ENTRY negotiate_SetCredentialsAttributesA(PCredHandle phCredential,
-                                                            ULONG ulAttribute, void* pBuffer,
-                                                            ULONG cbBuffer)
+                                                                     ULONG ulAttribute,
+                                                                     void* pBuffer, ULONG cbBuffer)
 {
 	MechCred* creds;
 
@@ -1252,7 +1253,8 @@ static SECURITY_STATUS SEC_ENTRY negotiate_SetCredentialsAttributesA(PCredHandle
 		WINPR_ASSERT(cred->mech->pkg);
 		WINPR_ASSERT(cred->mech->pkg->table);
 		WINPR_ASSERT(cred->mech->pkg->table->SetCredentialsAttributesA);
-		cred->mech->pkg->table->SetCredentialsAttributesA(&cred->cred, ulAttribute, pBuffer, cbBuffer);
+		cred->mech->pkg->table->SetCredentialsAttributesA(&cred->cred, ulAttribute, pBuffer,
+		                                                  cbBuffer);
 	}
 
 	return SEC_E_OK;

--- a/winpr/libwinpr/sspi/Negotiate/negotiate.c
+++ b/winpr/libwinpr/sspi/Negotiate/negotiate.c
@@ -1206,14 +1206,56 @@ static SECURITY_STATUS SEC_ENTRY negotiate_SetCredentialsAttributesW(PCredHandle
                                                             ULONG ulAttribute, void* pBuffer,
                                                             ULONG cbBuffer)
 {
-	return SEC_E_UNSUPPORTED_FUNCTION;
+	MechCred* creds;
+
+	creds = sspi_SecureHandleGetLowerPointer(phCredential);
+
+	if (!creds)
+		return SEC_E_INVALID_HANDLE;
+
+	for (size_t i = 0; i < MECH_COUNT; i++)
+	{
+		MechCred* cred = &creds[i];
+
+		if (!cred->valid)
+			continue;
+
+		WINPR_ASSERT(cred->mech);
+		WINPR_ASSERT(cred->mech->pkg);
+		WINPR_ASSERT(cred->mech->pkg->table);
+		WINPR_ASSERT(cred->mech->pkg->table_w->SetCredentialsAttributesW);
+		cred->mech->pkg->table_w->SetCredentialsAttributesW(&cred->cred, ulAttribute, pBuffer, cbBuffer);
+	}
+
+	return SEC_E_OK;
 }
 
 static SECURITY_STATUS SEC_ENTRY negotiate_SetCredentialsAttributesA(PCredHandle phCredential,
                                                             ULONG ulAttribute, void* pBuffer,
                                                             ULONG cbBuffer)
 {
-	return SEC_E_UNSUPPORTED_FUNCTION;
+	MechCred* creds;
+
+	creds = sspi_SecureHandleGetLowerPointer(phCredential);
+
+	if (!creds)
+		return SEC_E_INVALID_HANDLE;
+
+	for (size_t i = 0; i < MECH_COUNT; i++)
+	{
+		MechCred* cred = &creds[i];
+
+		if (!cred->valid)
+			continue;
+
+		WINPR_ASSERT(cred->mech);
+		WINPR_ASSERT(cred->mech->pkg);
+		WINPR_ASSERT(cred->mech->pkg->table);
+		WINPR_ASSERT(cred->mech->pkg->table->SetCredentialsAttributesA);
+		cred->mech->pkg->table->SetCredentialsAttributesA(&cred->cred, ulAttribute, pBuffer, cbBuffer);
+	}
+
+	return SEC_E_OK;
 }
 
 static SECURITY_STATUS SEC_ENTRY negotiate_AcquireCredentialsHandleW(

--- a/winpr/libwinpr/sspi/Negotiate/negotiate.c
+++ b/winpr/libwinpr/sspi/Negotiate/negotiate.c
@@ -1207,6 +1207,8 @@ static SECURITY_STATUS SEC_ENTRY negotiate_SetCredentialsAttributesW(PCredHandle
                                                                      void* pBuffer, ULONG cbBuffer)
 {
 	MechCred* creds;
+	BOOL success = FALSE;
+	SECURITY_STATUS secStatus;
 
 	creds = sspi_SecureHandleGetLowerPointer(phCredential);
 
@@ -1217,18 +1219,21 @@ static SECURITY_STATUS SEC_ENTRY negotiate_SetCredentialsAttributesW(PCredHandle
 	{
 		MechCred* cred = &creds[i];
 
-		if (!cred->valid)
-			continue;
-
 		WINPR_ASSERT(cred->mech);
 		WINPR_ASSERT(cred->mech->pkg);
 		WINPR_ASSERT(cred->mech->pkg->table);
 		WINPR_ASSERT(cred->mech->pkg->table_w->SetCredentialsAttributesW);
-		cred->mech->pkg->table_w->SetCredentialsAttributesW(&cred->cred, ulAttribute, pBuffer,
-		                                                    cbBuffer);
+		secStatus = cred->mech->pkg->table_w->SetCredentialsAttributesW(&cred->cred, ulAttribute,
+		                                                                pBuffer, cbBuffer);
+
+		if (secStatus == SEC_E_OK)
+		{
+			success = TRUE;
+		}
 	}
 
-	return SEC_E_OK;
+	// return success if at least one submodule accepts the credential attribute
+	return (success ? SEC_E_OK : SEC_E_UNSUPPORTED_FUNCTION);
 }
 
 static SECURITY_STATUS SEC_ENTRY negotiate_SetCredentialsAttributesA(PCredHandle phCredential,
@@ -1236,6 +1241,8 @@ static SECURITY_STATUS SEC_ENTRY negotiate_SetCredentialsAttributesA(PCredHandle
                                                                      void* pBuffer, ULONG cbBuffer)
 {
 	MechCred* creds;
+	BOOL success = FALSE;
+	SECURITY_STATUS secStatus;
 
 	creds = sspi_SecureHandleGetLowerPointer(phCredential);
 
@@ -1253,11 +1260,17 @@ static SECURITY_STATUS SEC_ENTRY negotiate_SetCredentialsAttributesA(PCredHandle
 		WINPR_ASSERT(cred->mech->pkg);
 		WINPR_ASSERT(cred->mech->pkg->table);
 		WINPR_ASSERT(cred->mech->pkg->table->SetCredentialsAttributesA);
-		cred->mech->pkg->table->SetCredentialsAttributesA(&cred->cred, ulAttribute, pBuffer,
-		                                                  cbBuffer);
+		secStatus = cred->mech->pkg->table->SetCredentialsAttributesA(&cred->cred, ulAttribute,
+		                                                              pBuffer, cbBuffer);
+
+		if (secStatus == SEC_E_OK)
+		{
+			success = TRUE;
+		}
 	}
 
-	return SEC_E_OK;
+	// return success if at least one submodule accepts the credential attribute
+	return (success ? SEC_E_OK : SEC_E_UNSUPPORTED_FUNCTION);
 }
 
 static SECURITY_STATUS SEC_ENTRY negotiate_AcquireCredentialsHandleW(

--- a/winpr/libwinpr/sspi/Negotiate/negotiate.c
+++ b/winpr/libwinpr/sspi/Negotiate/negotiate.c
@@ -1202,6 +1202,20 @@ static SECURITY_STATUS SEC_ENTRY negotiate_SetContextAttributesA(PCtxtHandle phC
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
+static SECURITY_STATUS SEC_ENTRY negotiate_SetCredentialsAttributesW(PCredHandle phCredential,
+                                                            ULONG ulAttribute, void* pBuffer,
+                                                            ULONG cbBuffer)
+{
+	return SEC_E_UNSUPPORTED_FUNCTION;
+}
+
+static SECURITY_STATUS SEC_ENTRY negotiate_SetCredentialsAttributesA(PCredHandle phCredential,
+                                                            ULONG ulAttribute, void* pBuffer,
+                                                            ULONG cbBuffer)
+{
+	return SEC_E_UNSUPPORTED_FUNCTION;
+}
+
 static SECURITY_STATUS SEC_ENTRY negotiate_AcquireCredentialsHandleW(
     SEC_WCHAR* pszPrincipal, SEC_WCHAR* pszPackage, ULONG fCredentialUse, void* pvLogonID,
     void* pAuthData, SEC_GET_KEY_FN pGetKeyFn, void* pvGetKeyArgument, PCredHandle phCredential,
@@ -1413,7 +1427,7 @@ static SECURITY_STATUS SEC_ENTRY negotiate_VerifySignature(PCtxtHandle phContext
 }
 
 const SecurityFunctionTableA NEGOTIATE_SecurityFunctionTableA = {
-	1,                                     /* dwVersion */
+	3,                                     /* dwVersion */
 	NULL,                                  /* EnumerateSecurityPackages */
 	negotiate_QueryCredentialsAttributesA, /* QueryCredentialsAttributes */
 	negotiate_AcquireCredentialsHandleA,   /* AcquireCredentialsHandle */
@@ -1441,10 +1455,11 @@ const SecurityFunctionTableA NEGOTIATE_SecurityFunctionTableA = {
 	negotiate_EncryptMessage,              /* EncryptMessage */
 	negotiate_DecryptMessage,              /* DecryptMessage */
 	negotiate_SetContextAttributesA,       /* SetContextAttributes */
+	negotiate_SetCredentialsAttributesA,   /* SetCredentialsAttributes */
 };
 
 const SecurityFunctionTableW NEGOTIATE_SecurityFunctionTableW = {
-	1,                                     /* dwVersion */
+	3,                                     /* dwVersion */
 	NULL,                                  /* EnumerateSecurityPackages */
 	negotiate_QueryCredentialsAttributesW, /* QueryCredentialsAttributes */
 	negotiate_AcquireCredentialsHandleW,   /* AcquireCredentialsHandle */
@@ -1472,4 +1487,5 @@ const SecurityFunctionTableW NEGOTIATE_SecurityFunctionTableW = {
 	negotiate_EncryptMessage,              /* EncryptMessage */
 	negotiate_DecryptMessage,              /* DecryptMessage */
 	negotiate_SetContextAttributesW,       /* SetContextAttributes */
+	negotiate_SetCredentialsAttributesW,   /* SetCredentialsAttributes */
 };

--- a/winpr/libwinpr/sspi/Schannel/schannel.c
+++ b/winpr/libwinpr/sspi/Schannel/schannel.c
@@ -358,7 +358,7 @@ static SECURITY_STATUS SEC_ENTRY schannel_DecryptMessage(PCtxtHandle phContext,
 }
 
 const SecurityFunctionTableA SCHANNEL_SecurityFunctionTableA = {
-	1,                                    /* dwVersion */
+	3,                                    /* dwVersion */
 	NULL,                                 /* EnumerateSecurityPackages */
 	schannel_QueryCredentialsAttributesA, /* QueryCredentialsAttributes */
 	schannel_AcquireCredentialsHandleA,   /* AcquireCredentialsHandle */
@@ -386,10 +386,11 @@ const SecurityFunctionTableA SCHANNEL_SecurityFunctionTableA = {
 	schannel_EncryptMessage,              /* EncryptMessage */
 	schannel_DecryptMessage,              /* DecryptMessage */
 	NULL,                                 /* SetContextAttributes */
+	NULL,                                 /* SetCredentialsAttributes */
 };
 
 const SecurityFunctionTableW SCHANNEL_SecurityFunctionTableW = {
-	1,                                    /* dwVersion */
+	3,                                    /* dwVersion */
 	NULL,                                 /* EnumerateSecurityPackages */
 	schannel_QueryCredentialsAttributesW, /* QueryCredentialsAttributes */
 	schannel_AcquireCredentialsHandleW,   /* AcquireCredentialsHandle */
@@ -417,6 +418,7 @@ const SecurityFunctionTableW SCHANNEL_SecurityFunctionTableW = {
 	schannel_EncryptMessage,              /* EncryptMessage */
 	schannel_DecryptMessage,              /* DecryptMessage */
 	NULL,                                 /* SetContextAttributes */
+	NULL,                                 /* SetCredentialsAttributes */
 };
 
 const SecPkgInfoA SCHANNEL_SecPkgInfoA = {

--- a/winpr/libwinpr/sspi/sspi.h
+++ b/winpr/libwinpr/sspi/sspi.h
@@ -81,7 +81,8 @@ enum SecurityFunctionTableIndex
 	QuerySecurityContextTokenIndex = 25,
 	EncryptMessageIndex = 26,
 	DecryptMessageIndex = 27,
-	SetContextAttributesIndex = 28
+	SetContextAttributesIndex = 28,
+	SetCredentialsAttributesIndex = 29
 };
 
 BOOL IsSecurityStatusError(SECURITY_STATUS status);

--- a/winpr/libwinpr/sspi/sspi_export.c
+++ b/winpr/libwinpr/sspi/sspi_export.c
@@ -285,18 +285,16 @@ SSPI_EXPORT SECURITY_STATUS SEC_ENTRY SetContextAttributesA(void* phContext, ULO
 
 extern SECURITY_STATUS SEC_ENTRY sspi_SetCredentialsAttributesW(void*, ULONG, void*, ULONG);
 
-static SECURITY_STATUS SEC_ENTRY SetCredentialsAttributesW(void* phCredential,
-                                                            ULONG ulAttribute, void* pBuffer,
-                                                            ULONG cbBuffer)
+static SECURITY_STATUS SEC_ENTRY SetCredentialsAttributesW(void* phCredential, ULONG ulAttribute,
+                                                           void* pBuffer, ULONG cbBuffer)
 {
 	return sspi_SetCredentialsAttributesW(phCredential, ulAttribute, pBuffer, cbBuffer);
 }
 
 extern SECURITY_STATUS SEC_ENTRY sspi_SetCredentialsAttributesA(void*, ULONG, void*, ULONG);
 
-static SECURITY_STATUS SEC_ENTRY SetCredentialsAttributesA(void* phCredential,
-                                                            ULONG ulAttribute, void* pBuffer,
-                                                            ULONG cbBuffer)
+static SECURITY_STATUS SEC_ENTRY SetCredentialsAttributesA(void* phCredential, ULONG ulAttribute,
+                                                           void* pBuffer, ULONG cbBuffer)
 {
 	return sspi_SetCredentialsAttributesA(phCredential, ulAttribute, pBuffer, cbBuffer);
 }

--- a/winpr/libwinpr/sspi/sspi_export.c
+++ b/winpr/libwinpr/sspi/sspi_export.c
@@ -283,6 +283,24 @@ SSPI_EXPORT SECURITY_STATUS SEC_ENTRY SetContextAttributesA(void* phContext, ULO
 	return sspi_SetContextAttributesA(phContext, ulAttribute, pBuffer, cbBuffer);
 }
 
+extern SECURITY_STATUS SEC_ENTRY sspi_SetCredentialsAttributesW(void*, ULONG, void*, ULONG);
+
+static SECURITY_STATUS SEC_ENTRY SetCredentialsAttributesW(void* phCredential,
+                                                            ULONG ulAttribute, void* pBuffer,
+                                                            ULONG cbBuffer)
+{
+	return sspi_SetCredentialsAttributesW(phCredential, ulAttribute, pBuffer, cbBuffer);
+}
+
+extern SECURITY_STATUS SEC_ENTRY sspi_SetCredentialsAttributesA(void*, ULONG, void*, ULONG);
+
+static SECURITY_STATUS SEC_ENTRY SetCredentialsAttributesA(void* phCredential,
+                                                            ULONG ulAttribute, void* pBuffer,
+                                                            ULONG cbBuffer)
+{
+	return sspi_SetCredentialsAttributesA(phCredential, ulAttribute, pBuffer, cbBuffer);
+}
+
 extern SECURITY_STATUS SEC_ENTRY sspi_RevertSecurityContext(void*);
 
 SSPI_EXPORT SECURITY_STATUS SEC_ENTRY RevertSecurityContext(void* phContext)

--- a/winpr/libwinpr/sspi/sspi_winpr.c
+++ b/winpr/libwinpr/sspi/sspi_winpr.c
@@ -1070,6 +1070,74 @@ static SECURITY_STATUS SEC_ENTRY winpr_QueryCredentialsAttributesA(PCredHandle p
 	return status;
 }
 
+static SECURITY_STATUS SEC_ENTRY winpr_SetCredentialsAttributesW(PCredHandle phCredential,
+                                                            ULONG ulAttribute, void* pBuffer,
+                                                            ULONG cbBuffer)
+{
+	SEC_WCHAR* Name;
+	SECURITY_STATUS status;
+	const SecurityFunctionTableW* table;
+	Name = (SEC_WCHAR*)sspi_SecureHandleGetUpperPointer(phCredential);
+
+	if (!Name)
+		return SEC_E_SECPKG_NOT_FOUND;
+
+	table = sspi_GetSecurityFunctionTableWByNameW(Name);
+
+	if (!table)
+		return SEC_E_SECPKG_NOT_FOUND;
+
+	if (!table->SetCredentialsAttributesW)
+	{
+		WLog_WARN(TAG, "[%s]: Security module does not provide an implementation", __FUNCTION__);
+		return SEC_E_UNSUPPORTED_FUNCTION;
+	}
+
+	status = table->SetCredentialsAttributesW(phCredential, ulAttribute, pBuffer, cbBuffer);
+
+	if (IsSecurityStatusError(status))
+	{
+		WLog_WARN(TAG, "SetCredentialsAttributesW status %s [0x%08" PRIX32 "]",
+		          GetSecurityStatusString(status), status);
+	}
+
+	return status;
+}
+
+static SECURITY_STATUS SEC_ENTRY winpr_SetCredentialsAttributesA(PCredHandle phCredential,
+                                                            ULONG ulAttribute, void* pBuffer,
+                                                            ULONG cbBuffer)
+{
+	char* Name;
+	SECURITY_STATUS status;
+	const SecurityFunctionTableA* table;
+	Name = (char*)sspi_SecureHandleGetUpperPointer(phCredential);
+
+	if (!Name)
+		return SEC_E_SECPKG_NOT_FOUND;
+
+	table = sspi_GetSecurityFunctionTableAByNameA(Name);
+
+	if (!table)
+		return SEC_E_SECPKG_NOT_FOUND;
+
+	if (!table->SetCredentialsAttributesA)
+	{
+		WLog_WARN(TAG, "[%s]: Security module does not provide an implementation", __FUNCTION__);
+		return SEC_E_UNSUPPORTED_FUNCTION;
+	}
+
+	status = table->SetCredentialsAttributesA(phCredential, ulAttribute, pBuffer, cbBuffer);
+
+	if (IsSecurityStatusError(status))
+	{
+		WLog_WARN(TAG, "SetCredentialsAttributesA status %s [0x%08" PRIX32 "]",
+		          GetSecurityStatusString(status), status);
+	}
+
+	return status;
+}
+
 /* Context Management */
 
 static SECURITY_STATUS SEC_ENTRY
@@ -1658,7 +1726,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_VerifySignature(PCtxtHandle phContext,
 }
 
 static SecurityFunctionTableA winpr_SecurityFunctionTableA = {
-	1,                                 /* dwVersion */
+	3,                                 /* dwVersion */
 	winpr_EnumerateSecurityPackagesA,  /* EnumerateSecurityPackages */
 	winpr_QueryCredentialsAttributesA, /* QueryCredentialsAttributes */
 	winpr_AcquireCredentialsHandleA,   /* AcquireCredentialsHandle */
@@ -1686,10 +1754,11 @@ static SecurityFunctionTableA winpr_SecurityFunctionTableA = {
 	winpr_EncryptMessage,              /* EncryptMessage */
 	winpr_DecryptMessage,              /* DecryptMessage */
 	winpr_SetContextAttributesA,       /* SetContextAttributes */
+	winpr_SetCredentialsAttributesA,   /* SetCredentialsAttributes */
 };
 
 static SecurityFunctionTableW winpr_SecurityFunctionTableW = {
-	1,                                 /* dwVersion */
+	3,                                 /* dwVersion */
 	winpr_EnumerateSecurityPackagesW,  /* EnumerateSecurityPackages */
 	winpr_QueryCredentialsAttributesW, /* QueryCredentialsAttributes */
 	winpr_AcquireCredentialsHandleW,   /* AcquireCredentialsHandle */
@@ -1717,4 +1786,5 @@ static SecurityFunctionTableW winpr_SecurityFunctionTableW = {
 	winpr_EncryptMessage,              /* EncryptMessage */
 	winpr_DecryptMessage,              /* DecryptMessage */
 	winpr_SetContextAttributesW,       /* SetContextAttributes */
+	winpr_SetCredentialsAttributesW,   /* SetCredentialsAttributes */
 };

--- a/winpr/libwinpr/sspi/sspi_winpr.c
+++ b/winpr/libwinpr/sspi/sspi_winpr.c
@@ -1071,8 +1071,8 @@ static SECURITY_STATUS SEC_ENTRY winpr_QueryCredentialsAttributesA(PCredHandle p
 }
 
 static SECURITY_STATUS SEC_ENTRY winpr_SetCredentialsAttributesW(PCredHandle phCredential,
-                                                            ULONG ulAttribute, void* pBuffer,
-                                                            ULONG cbBuffer)
+                                                                 ULONG ulAttribute, void* pBuffer,
+                                                                 ULONG cbBuffer)
 {
 	SEC_WCHAR* Name;
 	SECURITY_STATUS status;
@@ -1105,8 +1105,8 @@ static SECURITY_STATUS SEC_ENTRY winpr_SetCredentialsAttributesW(PCredHandle phC
 }
 
 static SECURITY_STATUS SEC_ENTRY winpr_SetCredentialsAttributesA(PCredHandle phCredential,
-                                                            ULONG ulAttribute, void* pBuffer,
-                                                            ULONG cbBuffer)
+                                                                 ULONG ulAttribute, void* pBuffer,
+                                                                 ULONG cbBuffer)
 {
 	char* Name;
 	SECURITY_STATUS status;


### PR DESCRIPTION
This pull request adds the required SSPI plumbing for SetCredentialsAttributes calls along with missing SECPKG_CRED_ATTR IDs and structure definitions. It also adds a custom SECPKG_CRED_ATTR_KDC_URL extended attribute meant to pass the KDC URL from FreeRDP settings down to the Kerberos SSPI module (--kdc-url). Windows SSPI only supports an explicit KDC proxy server configuration through SECPKG_CRED_ATTR_KDC_PROXY_SETTINGS, and it uses a weird, error-prone format. The URL format can encode all KDC server "types" nicely, where we can assume a default protocol (TCP) and port (88), like this:

- IT-HELP-DC.ad.it-help.ninja
- IT-HELP-DC.ad.it-help.ninja:88
- tcp://IT-HELP-DC.ad.it-help.ninja:88
- udp://IT-HELP-DC.ad.it-help.ninja:88
- http://kdc.ad.it-help.ninja/KdcProxy
- https://kdc.ad.it-help.ninja:4343/KdcProxy

This KDC URL can then be parsed and injected into Kerberos SSPI modules that support it. For now, the WinPR Kerberos SSPI module just throws a warning because it doesn't yet support an explicit KDC server configuration, but we can implement it in a separate pull request using [krb5_init_context_profile](https://web.mit.edu/kerberos/krb5-devel/doc/plugindev/profile.html) to create an in-memory profile without a krb5.conf file on disk.

The KDC proxy settings injection through SECPKG_CRED_ATTR_KDC_PROXY_SETTINGS is also left up to a future pull request for support on Windows, alongside support for parsing KDCProxyName from .RDP file settings. It will also requires URL to "Name" format conversions helpers (https://kdc.ad.it-help.ninja:4343/KdcProxy -> kdc.ad.it-help.ninja:4343:KdcProxy, yes, that's really a ':' instead of '/', it's a cursed format).

This pull request is of high importance to me because it unblocks proper FreeRDP settings to inject a KDC URL when used with my Rust SSPI modules. [sspi-rs progresses well](https://github.com/Devolutions/sspi-rs/pull/21), and we've got it built for Windows, macOS, Linux, Android and iOS, and we're basically just improving KDC detection methods now + adding ways to explicit inject the KDC information on a per-connection basis, within the same process.