### PR TITLE
Fixed #8259: in remote app mode keep the keyboard state

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -615,7 +615,9 @@ static BOOL xf_event_FocusIn(xfContext* xfc, const XFocusInEvent* event, BOOL ap
 
 	/* Release all keys, should already be done at FocusOut but might be missed
 	 * if the WM decided to use an alternate event order */
-	xf_keyboard_release_all_keypress(xfc);
+	if (!xfc->remote_app)
+		xf_keyboard_release_all_keypress(xfc);
+
 	xf_pointer_update_scale(xfc);
 
 	if (app)
@@ -856,7 +858,8 @@ static BOOL xf_event_UnmapNotify(xfContext* xfc, const XUnmapEvent* event, BOOL 
 	WINPR_ASSERT(xfc);
 	WINPR_ASSERT(event);
 
-	xf_keyboard_release_all_keypress(xfc);
+	if (!xfc->remote_app)
+		xf_keyboard_release_all_keypress(xfc);
 
 	if (!app)
 		gdi_send_suppress_output(xfc->common.context.gdi, TRUE);


### PR DESCRIPTION
If the mouse enters/leaves the window or the window is unmapped in desktop session mode we can reset the keyboard modifiers state while in remote app mode these events have different meaning. Be more strict in the latter case and only reset on focus out