### PR TITLE
Use GFX small cache by default

### DIFF
--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -173,7 +173,7 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 #endif
 	{ "gfx-progressive", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
 	  "RDP8 graphics pipeline using progressive codec" },
-	{ "gfx-small-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
+	{ "gfx-small-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
 	  "RDP8 graphics pipeline using small cache mode" },
 	{ "gfx-thin-client", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
 	  "RDP8 graphics pipeline using thin client mode" },

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -582,7 +582,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	    !freerdp_settings_set_bool(settings, FreeRDP_AutoReconnectionEnabled, FALSE) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_AutoReconnectMaxRetries, 20) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_GfxThinClient, TRUE) ||
-	    !freerdp_settings_set_bool(settings, FreeRDP_GfxSmallCache, FALSE) ||
+	    !freerdp_settings_set_bool(settings, FreeRDP_GfxSmallCache, TRUE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_GfxProgressive, FALSE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_GfxProgressiveV2, FALSE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_GfxPlanar, TRUE) ||


### PR DESCRIPTION
RAILS does have some problems if this is not enabled and there is no real benefit for not setting it, so default it
