### PR TITLE
Fixed ownership of negoToken

### DIFF
--- a/libfreerdp/core/credssp_auth.c
+++ b/libfreerdp/core/credssp_auth.c
@@ -466,13 +466,17 @@ BOOL credssp_auth_revert_to_self(rdpCredsspAuth* auth)
 	return TRUE;
 }
 
-void credssp_auth_set_input_buffer(rdpCredsspAuth* auth, SecBuffer* buffer)
+void credssp_auth_take_input_buffer(rdpCredsspAuth* auth, SecBuffer* buffer)
 {
 	WINPR_ASSERT(auth);
 	WINPR_ASSERT(buffer);
 
 	auth->input_buffer = *buffer;
 	auth->input_buffer.BufferType = SECBUFFER_TOKEN;
+
+	/* Invalidate original, rdpCredsspAuth now has ownership of the buffer */
+	SecBuffer empty = { 0 };
+	*buffer = empty;
 }
 
 const SecBuffer* credssp_auth_get_output_buffer(rdpCredsspAuth* auth)
@@ -547,6 +551,7 @@ void credssp_auth_free(rdpCredsspAuth* auth)
 	free(ntlm_settings->samFile);
 
 	free(auth->spn);
+	sspi_SecBufferFree(&auth->input_buffer);
 	sspi_SecBufferFree(&auth->output_buffer);
 
 	free(auth);

--- a/libfreerdp/core/credssp_auth.h
+++ b/libfreerdp/core/credssp_auth.h
@@ -49,7 +49,7 @@ FREERDP_LOCAL BOOL credssp_auth_impersonate(rdpCredsspAuth* auth);
 FREERDP_LOCAL BOOL credssp_auth_revert_to_self(rdpCredsspAuth* auth);
 FREERDP_LOCAL BOOL credssp_auth_set_spn(rdpCredsspAuth* auth, const char* service,
                                         const char* hostname);
-FREERDP_LOCAL void credssp_auth_set_input_buffer(rdpCredsspAuth* auth, SecBuffer* buffer);
+FREERDP_LOCAL void credssp_auth_take_input_buffer(rdpCredsspAuth* auth, SecBuffer* buffer);
 FREERDP_LOCAL const SecBuffer* credssp_auth_get_output_buffer(rdpCredsspAuth* auth);
 FREERDP_LOCAL BOOL credssp_auth_have_output_token(rdpCredsspAuth* auth);
 FREERDP_LOCAL BOOL credssp_auth_is_complete(rdpCredsspAuth* auth);

--- a/libfreerdp/core/gateway/ncacn_http.c
+++ b/libfreerdp/core/gateway/ncacn_http.c
@@ -122,11 +122,12 @@ BOOL rpc_ncacn_http_recv_in_channel_response(RpcChannel* inChannel, HttpResponse
 	if (token64)
 		crypto_base64_decode(token64, strlen(token64), &authTokenData, &authTokenLength);
 
+	buffer.pvBuffer = authTokenData;
+	buffer.cbBuffer = authTokenLength;
+
 	if (authTokenData && authTokenLength)
 	{
-		buffer.pvBuffer = authTokenData;
-		buffer.cbBuffer = authTokenLength;
-		credssp_auth_set_input_buffer(auth, &buffer);
+		credssp_auth_take_input_buffer(auth, &buffer);
 		return TRUE;
 	}
 
@@ -250,11 +251,12 @@ BOOL rpc_ncacn_http_recv_out_channel_response(RpcChannel* outChannel, HttpRespon
 	if (token64)
 		crypto_base64_decode(token64, strlen(token64), &authTokenData, &authTokenLength);
 
+	buffer.pvBuffer = authTokenData;
+	buffer.cbBuffer = authTokenLength;
+
 	if (authTokenData && authTokenLength)
 	{
-		buffer.pvBuffer = authTokenData;
-		buffer.cbBuffer = authTokenLength;
-		credssp_auth_set_input_buffer(auth, &buffer);
+		credssp_auth_take_input_buffer(auth, &buffer);
 		return TRUE;
 	}
 

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -1238,7 +1238,7 @@ static BOOL rdg_recv_auth_token(rdpCredsspAuth* auth, HttpResponse* response)
 	{
 		authToken.pvBuffer = authTokenData;
 		authToken.cbBuffer = authTokenLength;
-		credssp_auth_set_input_buffer(auth, &authToken);
+		credssp_auth_take_input_buffer(auth, &authToken);
 	}
 
 	rc = credssp_auth_authenticate(auth);

--- a/libfreerdp/core/gateway/rpc_bind.c
+++ b/libfreerdp/core/gateway/rpc_bind.c
@@ -344,7 +344,7 @@ BOOL rpc_recv_bind_ack_pdu(rdpRpc* rpc, wStream* s)
 
 	buffer.pvBuffer = auth_data;
 	buffer.cbBuffer = header.common.auth_length;
-	credssp_auth_set_input_buffer(rpc->auth, &buffer);
+	credssp_auth_take_input_buffer(rpc->auth, &buffer);
 
 	if (credssp_auth_authenticate(rpc->auth) < 0)
 		goto fail;

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -530,7 +530,7 @@ static int nla_client_recv_nego_token(rdpNla* nla)
 {
 	int rc;
 
-	credssp_auth_set_input_buffer(nla->auth, &nla->negoToken);
+	credssp_auth_take_input_buffer(nla->auth, &nla->negoToken);
 	rc = credssp_auth_authenticate(nla->auth);
 
 	switch (rc)
@@ -781,7 +781,7 @@ static int nla_server_authenticate(rdpNla* nla)
 			return -1;
 
 		WLog_DBG(TAG, "Receiving Authentication Token");
-		credssp_auth_set_input_buffer(nla->auth, &nla->negoToken);
+		credssp_auth_take_input_buffer(nla->auth, &nla->negoToken);
 
 		res = credssp_auth_authenticate(nla->auth);
 
@@ -1687,6 +1687,7 @@ void nla_free(rdpNla* nla)
 
 	sspi_SecBufferFree(&nla->pubKeyAuth);
 	sspi_SecBufferFree(&nla->authInfo);
+	sspi_SecBufferFree(&nla->negoToken);
 	sspi_SecBufferFree(&nla->ClientNonce);
 	sspi_SecBufferFree(&nla->PublicKey);
 	sspi_SecBufferFree(&nla->tsCredentials);


### PR DESCRIPTION
* Ensure negoToken is cleaned up in nla_free
* Renamed function credssp_auth_take_input_buffer now invalidates input buffer an takes ownership of that buffer