### PR TITLE
sspi: Do not call copy on empty strings

### DIFF
--- a/winpr/libwinpr/sspi/sspi_winpr.c
+++ b/winpr/libwinpr/sspi/sspi_winpr.c
@@ -353,17 +353,17 @@ int sspi_SetAuthIdentityWithLengthW(SEC_WINNT_AUTH_IDENTITY* identity, const WCH
 	sspi_FreeAuthIdentity(identity);
 	identity->Flags &= ~SEC_WINNT_AUTH_IDENTITY_ANSI;
 	identity->Flags |= SEC_WINNT_AUTH_IDENTITY_UNICODE;
-	if (user)
+	if (user && userLen > 0)
 	{
 		if (!copy(&identity->User, &identity->UserLength, user, userLen))
 			return -1;
 	}
-	if (domain)
+	if (domain && domainLen > 0)
 	{
 		if (!copy(&identity->Domain, &identity->DomainLength, domain, domainLen))
 			return -1;
 	}
-	if (password)
+	if (password && passwordLen > 0)
 	{
 		if (!copy(&identity->Password, &identity->PasswordLength, password, passwordLen))
 			return -1;


### PR DESCRIPTION
It might happen that the username/domain/password strings are set to an empty string. This means that the null pointer check will pass but the application will assert in the copy helper function.

This fix simple checks the length of the identity strings and only calls copy in case the length is greater than 0.
