### PR TITLE
Updated supported RDP versions

### DIFF
--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -90,7 +90,11 @@ typedef enum
 	RDP_VERSION_10_4 = 0x00080009,
 	RDP_VERSION_10_5 = 0x0008000a,
 	RDP_VERSION_10_6 = 0x0008000b,
-	RDP_VERSION_10_7 = 0x0008000C
+	RDP_VERSION_10_7 = 0x0008000C,
+	RDP_VERSION_10_8 = 0x0008000D,
+	RDP_VERSION_10_9 = 0x0008000E,
+	RDP_VERSION_10_10 = 0x0008000F,
+	RDP_VERSION_10_11 = 0x00080010,
 } RDP_VERSION;
 
 /* Color depth */
@@ -1824,6 +1828,8 @@ extern "C"
 
 	FREERDP_API char* freerdp_rail_support_flags_to_string(UINT32 flags, char* buffer,
 	                                                       size_t length);
+
+	FREERDP_API const char* freerdp_rdp_version_string(UINT32 version);
 
 #ifdef __cplusplus
 }

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -1839,3 +1839,40 @@ char* freerdp_rail_support_flags_to_string(UINT32 flags, char* buffer, size_t le
 		winpr_str_append("RAIL_LEVEL_LANGUAGE_IME_SYNC_SUPPORTED", buffer, length, "|");
 	return buffer;
 }
+
+const char* freerdp_rdp_version_string(UINT32 version)
+{
+	switch (version)
+	{
+		case RDP_VERSION_4:
+			return "RDP_VERSION_4";
+		case RDP_VERSION_5_PLUS:
+			return "RDP_VERSION_5_PLUS";
+		case RDP_VERSION_10_0:
+			return "RDP_VERSION_10_0";
+		case RDP_VERSION_10_1:
+			return "RDP_VERSION_10_1";
+		case RDP_VERSION_10_2:
+			return "RDP_VERSION_10_2";
+		case RDP_VERSION_10_3:
+			return "RDP_VERSION_10_3";
+		case RDP_VERSION_10_4:
+			return "RDP_VERSION_10_4";
+		case RDP_VERSION_10_5:
+			return "RDP_VERSION_10_5";
+		case RDP_VERSION_10_6:
+			return "RDP_VERSION_10_6";
+		case RDP_VERSION_10_7:
+			return "RDP_VERSION_10_7";
+		case RDP_VERSION_10_8:
+			return "RDP_VERSION_10_8";
+		case RDP_VERSION_10_9:
+			return "RDP_VERSION_10_9";
+		case RDP_VERSION_10_10:
+			return "RDP_VERSION_10_11";
+		case RDP_VERSION_10_11:
+			return "RDP_VERSION_10_11";
+		default:
+			return "RDP_VERSION_UNKNOWN";
+	}
+}

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -81,6 +81,10 @@ static DWORD rdp_version_common(DWORD serverVersion, DWORD clientVersion)
 		case RDP_VERSION_10_5:
 		case RDP_VERSION_10_6:
 		case RDP_VERSION_10_7:
+		case RDP_VERSION_10_8:
+		case RDP_VERSION_10_9:
+		case RDP_VERSION_10_10:
+		case RDP_VERSION_10_11:
 			return version;
 
 		default:

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -355,7 +355,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	    !freerdp_settings_set_bool(settings, FreeRDP_Fullscreen, FALSE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_GrabKeyboard, TRUE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_Decorations, TRUE) ||
-	    !freerdp_settings_set_uint32(settings, FreeRDP_RdpVersion, RDP_VERSION_10_7) ||
+	    !freerdp_settings_set_uint32(settings, FreeRDP_RdpVersion, RDP_VERSION_10_11) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_ColorDepth, 16) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_ExtSecurity, FALSE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_NlaSecurity, TRUE) ||


### PR DESCRIPTION
* New defines for 10.8, 10.9, 10.10, 10.11 protocol versions
* New function returning a string representation of the protocol version
* Use 10.11 by default now