### PR TITLE
With #8292 ClusterInfoFlags became application settable

### DIFF
--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -348,6 +348,8 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	    !freerdp_settings_set_bool(settings, FreeRDP_ServerMode,
 	                               (flags & FREERDP_SETTINGS_SERVER_MODE) ? TRUE : FALSE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_WaitForOutputBufferFlush, TRUE) ||
+	    !freerdp_settings_set_uint32(settings, FreeRDP_ClusterInfoFlags,
+	                                 REDIRECTION_SUPPORTED | (REDIRECTION_VERSION4 << 2)) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_MaxTimeInCheckLoop, 100) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_DesktopWidth, 1024) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_DesktopHeight, 768) ||


### PR DESCRIPTION
This pull adds the (previously lost) default value to keep compatible with older code that does not care about that field.