### PR TITLE
fix smartcard listing

### DIFF
--- a/include/freerdp/utils/smartcardlogon.h
+++ b/include/freerdp/utils/smartcardlogon.h
@@ -37,8 +37,6 @@ typedef struct
 	char* domainHint;
 	char* subject;
 	char* issuer;
-	BYTE atr[256];
-	DWORD atrLength;
 	BYTE sha1Hash[20];
 } SmartcardCertInfo;
 

--- a/winpr/libwinpr/ncrypt/test/TestNCryptSmartcard.c
+++ b/winpr/libwinpr/ncrypt/test/TestNCryptSmartcard.c
@@ -121,11 +121,12 @@ int TestNCryptSmartcard(int argc, char* argv[])
 					printf("\treader: %s\n", readerStr);
 			}
 
+			cbOutput = 0;
 			status =
 			    NCryptGetProperty(phKey, NCRYPT_CERTIFICATE_PROPERTY, NULL, 0, &cbOutput, dwFlags);
 			if (status != ERROR_SUCCESS)
 			{
-				/* WLog_ERR(TAG, "unable to retrieve certificate for key '%s'", keyNameStr); */
+				WLog_ERR(TAG, "unable to retrieve certificate len for key '%s'", keyNameStr);
 				goto endofloop;
 			}
 


### PR DESCRIPTION
This commit fixes various bugs that I've noticed on some windows systems with smartcards that contains multiple certificates:

* With some drivers if you retrieve the ATR while enumerating the NCrypt keys, it seems to confuse the NCrypt key context (and you're unable to retrieve certificate property). As we don't use the ATR, let's remove the ATR retrieval.
* if don't give any user or domain on the command line, in settings you get User=Domain=NULL, but if you pass /u:user, you get User="user" and Domain = ""(empty string not NULL). The smartcard filtering by user/domain was not ready for that.
