### PR TITLE
Cmdline simplify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,11 @@ if (WITH_FREERDP_DEPRECATED)
 	add_definitions(-DWITH_FREERDP_DEPRECATED)
 endif()
 
+option(WITH_FREERDP_DEPRECATED_COMMANDLINE "Build FreeRDP deprecated command line options" OFF)
+if (WITH_FREERDP_DEPRECATED_COMMANDLINE)
+    add_definitions(-DWITH_FREERDP_DEPRECATED_COMMANDLINE)
+endif()
+
 # Make paths absolute
 if (CMAKE_INSTALL_PREFIX)
 	get_filename_component(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" ABSOLUTE)

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1873,7 +1873,7 @@ static int parse_gfx_options(rdpSettings* settings, const COMMAND_LINE_ARGUMENT_
 			{
 				const char* val = ptr[x];
 #ifdef WITH_GFX_H264
-				if (_strnicmp("AVC444", val, 7) == 0)
+				if (_strnicmp("AVC444", val, 6) == 0)
 				{
 					const int bval = parse_on_off_option(val);
 					if (bval < 0)
@@ -1882,7 +1882,7 @@ static int parse_gfx_options(rdpSettings* settings, const COMMAND_LINE_ARGUMENT_
 						GfxH264 = bval > 0;
 					codecSelected = TRUE;
 				}
-				else if (_strnicmp("AVC420", val, 7) == 0)
+				else if (_strnicmp("AVC420", val, 6) == 0)
 				{
 					const int bval = parse_on_off_option(val);
 					if (bval < 0)
@@ -1893,7 +1893,7 @@ static int parse_gfx_options(rdpSettings* settings, const COMMAND_LINE_ARGUMENT_
 				}
 				else
 #endif
-				    if (_strnicmp("RFX", val, 4) == 0)
+				    if (_strnicmp("RFX", val, 3) == 0)
 				{
 					const int bval = parse_on_off_option(val);
 					if (bval < 0)

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1552,7 +1552,7 @@ int freerdp_client_settings_command_line_status_print_ex(rdpSettings* settings, 
 			else
 				return COMMAND_LINE_ERROR;
 		}
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 		arg = CommandLineFindArgumentA(largs, "tune-list");
 		WINPR_ASSERT(arg);
 
@@ -1816,7 +1816,7 @@ static int parse_tls_options(rdpSettings* settings, const COMMAND_LINE_ARGUMENT_
 			rc = parse_tls_enforce(settings, &arg->Value[8]);
 	}
 
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 	CommandLineSwitchCase(arg, "tls-ciphers")
 	{
 		WLog_WARN(TAG, "Option /tls-ciphers is deprecated, use /tls:ciphers instead");
@@ -2675,7 +2675,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 			if (rc != 0)
 				return rc;
 		}
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 		CommandLineSwitchCase(arg, "kbd-remap")
 		{
 			WLog_WARN(TAG, "/kbd-remap:<key>=<value>,<key2>=<value2> is deprecated, use "
@@ -3190,7 +3190,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 			if (rc != 0)
 				return rc;
 		}
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 		CommandLineSwitchCase(arg, "gfx-thin-client")
 		{
 			WLog_WARN(TAG, "/gfx-thin-client is deprecated, use /gfx:thin-client[:on|off] instead");
@@ -3441,7 +3441,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 			if (!WLog_AddStringLogFilters(arg->Value))
 				return COMMAND_LINE_ERROR;
 		}
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 		CommandLineSwitchCase(arg, "sec-rdp")
 		{
 			WLog_WARN(TAG, "Option /sec-rdp is deprecated, use /sec:rdp[:on|off] instead");
@@ -3481,7 +3481,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 			}
 			free(ptr);
 		}
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 		CommandLineSwitchCase(arg, "tls-ciphers")
 		{
 			WLog_WARN(TAG, "Option /tls-ciphers:<cipher list> is deprecated, use "
@@ -3561,7 +3561,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 				return rc;
 		}
 
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 		CommandLineSwitchCase(arg, "cert-name")
 		{
 			WLog_WARN(TAG, "/cert-name is deprecated, use /cert:name instead");
@@ -3708,7 +3708,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 			if (rc != 0)
 				return rc;
 		}
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 		CommandLineSwitchCase(arg, "bitmap-cache")
 		{
 			WLog_WARN(TAG, "/bitmap-cache is deprecated, use /cache:bitmap[:on|off] instead");

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1558,6 +1558,7 @@ int freerdp_client_settings_command_line_status_print_ex(rdpSettings* settings, 
 
 		if (arg->Flags & COMMAND_LINE_ARGUMENT_PRESENT)
 		{
+			WLog_WARN(TAG, "Option /tune-list is deprecated, use /list:tune instead");
 			freerdp_client_print_tune_list(settings);
 		}
 
@@ -1566,6 +1567,7 @@ int freerdp_client_settings_command_line_status_print_ex(rdpSettings* settings, 
 
 		if (arg->Flags & COMMAND_LINE_ARGUMENT_PRESENT)
 		{
+			WLog_WARN(TAG, "Option /kbd-lang-list is deprecated, use /list:kbd-lang instead");
 			freerdp_client_print_codepages(arg->Value);
 		}
 
@@ -1574,6 +1576,7 @@ int freerdp_client_settings_command_line_status_print_ex(rdpSettings* settings, 
 
 		if (arg->Flags & COMMAND_LINE_VALUE_PRESENT)
 		{
+			WLog_WARN(TAG, "Option /kbd-list is deprecated, use /list:kbd instead");
 			freerdp_client_print_keyboard_list();
 		}
 
@@ -1582,6 +1585,7 @@ int freerdp_client_settings_command_line_status_print_ex(rdpSettings* settings, 
 
 		if (arg->Flags & COMMAND_LINE_VALUE_PRESENT)
 		{
+			WLog_WARN(TAG, "Option /monitor-list is deprecated, use /list:monitor instead");
 			settings->ListMonitors = TRUE;
 		}
 
@@ -1590,6 +1594,7 @@ int freerdp_client_settings_command_line_status_print_ex(rdpSettings* settings, 
 
 		if (arg->Flags & COMMAND_LINE_VALUE_PRESENT)
 		{
+			WLog_WARN(TAG, "Option /smartcard-list is deprecated, use /list:smartcard instead");
 			freerdp_smartcard_list(settings);
 		}
 
@@ -1598,6 +1603,8 @@ int freerdp_client_settings_command_line_status_print_ex(rdpSettings* settings, 
 
 		if (arg->Flags & COMMAND_LINE_VALUE_PRESENT)
 		{
+			WLog_WARN(TAG,
+			          "Option /kbd-scancode-list is deprecated, use /list:kbd-scancode instead");
 			freerdp_client_print_scancodes();
 			goto out;
 		}
@@ -3033,6 +3040,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 #if defined(WITH_FREERDP_DEPRECATED)
 		CommandLineSwitchCase(arg, "gfx-thin-client")
 		{
+			WLog_WARN(TAG, "/gfx-thin-client is deprecated, use /gfx:thin-client[:on|off] instead");
 			settings->GfxThinClient = enable;
 
 			if (settings->GfxThinClient)
@@ -3042,6 +3050,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 		}
 		CommandLineSwitchCase(arg, "gfx-small-cache")
 		{
+			WLog_WARN(TAG, "/gfx-small-cache is deprecated, use /gfx:small-cache[:on|off] instead");
 			settings->GfxSmallCache = enable;
 
 			if (enable)
@@ -3049,6 +3058,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 		}
 		CommandLineSwitchCase(arg, "gfx-progressive")
 		{
+			WLog_WARN(TAG, "/gfx-progressive is deprecated, use /gfx:progressive[:on|off] instead");
 			settings->GfxProgressive = enable;
 			settings->GfxThinClient = !enable;
 
@@ -3188,14 +3198,20 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 			for (x = 0; x < count; x++)
 			{
 				const char* cur = ptr[x];
+				const int bval = parse_on_off_option(cur);
+				if (bval < 0)
+				{
+					free(ptr);
+					return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
+				}
 				if (strcmp("rdp", cur) == 0) /* Standard RDP */
-					RdpSecurity = TRUE;
+					RdpSecurity = bval > 0;
 				else if (strcmp("tls", cur) == 0) /* TLS */
-					TlsSecurity = TRUE;
+					TlsSecurity = bval > 0;
 				else if (strcmp("nla", cur) == 0) /* NLA */
-					NlaSecurity = TRUE;
+					NlaSecurity = bval > 0;
 				else if (strcmp("ext", cur) == 0) /* NLA Extended */
-					ExtSecurity = TRUE;
+					ExtSecurity = bval > 0;
 				else
 				{
 					WLog_ERR(TAG, "unknown protocol security: %s", arg->Value);
@@ -3275,18 +3291,22 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 #if defined(WITH_FREERDP_DEPRECATED)
 		CommandLineSwitchCase(arg, "sec-rdp")
 		{
+			WLog_WARN(TAG, "Option /sec-rdp is deprecated, use /sec:rdp[:on|off] instead");
 			settings->RdpSecurity = enable;
 		}
 		CommandLineSwitchCase(arg, "sec-tls")
 		{
+			WLog_WARN(TAG, "Option /sec-tls is deprecated, use /sec:tls[:on|off] instead");
 			settings->TlsSecurity = enable;
 		}
 		CommandLineSwitchCase(arg, "sec-nla")
 		{
+			WLog_WARN(TAG, "Option /sec-nla is deprecated, use /sec:nla[:on|off] instead");
 			settings->NlaSecurity = enable;
 		}
 		CommandLineSwitchCase(arg, "sec-ext")
 		{
+			WLog_WARN(TAG, "Option /sec-ext is deprecated, use /sec:ext[:on|off] instead");
 			settings->ExtSecurity = enable;
 		}
 #endif
@@ -3311,24 +3331,32 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 #if defined(WITH_FREERDP_DEPRECATED)
 		CommandLineSwitchCase(arg, "tls-ciphers")
 		{
+			WLog_WARN(TAG, "Option /tls-ciphers:<cipher list> is deprecated, use "
+			               "/tls:ciphers:<cipher list> instead");
 			int rc = parse_tls_options(settings, arg);
 			if (rc != 0)
 				return rc;
 		}
 		CommandLineSwitchCase(arg, "tls-seclevel")
 		{
+			WLog_WARN(
+			    TAG,
+			    "Option /tls-seclevel:<level> is deprecated, use /tls:sec-level:<level> instead");
 			int rc = parse_tls_options(settings, arg);
 			if (rc != 0)
 				return rc;
 		}
 		CommandLineSwitchCase(arg, "tls-secrets-file")
 		{
+			WLog_WARN(TAG, "Option /tls-secrets-file:<filename> is deprecated, use "
+			               "/tls:secrets-file:<filename> instead");
 			int rc = parse_tls_options(settings, arg);
 			if (rc != 0)
 				return rc;
 		}
 		CommandLineSwitchCase(arg, "enforce-tlsv1_2")
 		{
+			WLog_WARN(TAG, "Option /enforce-tlsv1_2 is deprecated, use /tls:enforce:1.2 instead");
 			int rc = parse_tls_options(settings, arg);
 			if (rc != 0)
 				return rc;
@@ -3530,14 +3558,18 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 #if defined(WITH_FREERDP_DEPRECATED)
 		CommandLineSwitchCase(arg, "bitmap-cache")
 		{
+			WLog_WARN(TAG, "/bitmap-cache is deprecated, use /cache:bitmap[:on|off] instead");
 			settings->BitmapCacheEnabled = enable;
 		}
 		CommandLineSwitchCase(arg, "persist-cache")
 		{
+			WLog_WARN(TAG, "/persist-cache is deprecated, use /cache:persist[:on|off] instead");
 			settings->BitmapCachePersistEnabled = enable;
 		}
 		CommandLineSwitchCase(arg, "persist-cache-file")
 		{
+			WLog_WARN(TAG, "/persist-cache-file:<filename> is deprecated, use "
+			               "/cache:persist-file:<filename> instead");
 			if (!freerdp_settings_set_string(settings, FreeRDP_BitmapCachePersistFile, arg->Value))
 				return COMMAND_LINE_ERROR_MEMORY;
 
@@ -3545,14 +3577,18 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 		}
 		CommandLineSwitchCase(arg, "offscreen-cache")
 		{
+			WLog_WARN(TAG, "/bitmap-cache is deprecated, use /cache:bitmap[:on|off] instead");
 			settings->OffscreenSupportLevel = (UINT32)enable;
 		}
 		CommandLineSwitchCase(arg, "glyph-cache")
 		{
+			WLog_WARN(TAG, "/glyph-cache is deprecated, use /cache:glyph[:on|off] instead");
 			settings->GlyphSupportLevel = arg->Value ? GLYPH_SUPPORT_FULL : GLYPH_SUPPORT_NONE;
 		}
 		CommandLineSwitchCase(arg, "codec-cache")
 		{
+			WLog_WARN(TAG,
+			          "/codec-cache:<option> is deprecated, use /cache:codec:<option> instead");
 			if (!arg->Value)
 				return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 			settings->BitmapCacheV3Enabled = TRUE;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3001,36 +3001,44 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 
 			settings->LoadBalanceInfoLength = (UINT32)strlen((char*)settings->LoadBalanceInfo);
 		}
-#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE_COMMANDLINE)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 		CommandLineSwitchCase(arg, "app-workdir")
 		{
+			WLog_WARN(
+			    TAG,
+			    "/app-workdir:<directory> is deprecated, use /app:workdir:<directory> instead");
 			if (!freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationWorkingDir,
 			                                 arg->Value))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
 		CommandLineSwitchCase(arg, "app-name")
 		{
+			WLog_WARN(TAG, "/app-name:<directory> is deprecated, use /app:name:<name> instead");
 			if (!freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationName, arg->Value))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
 		CommandLineSwitchCase(arg, "app-icon")
 		{
+			WLog_WARN(TAG, "/app-icon:<filename> is deprecated, use /app:icon:<filename> instead");
 			if (!freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationIcon, arg->Value))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
 		CommandLineSwitchCase(arg, "app-cmd")
 		{
+			WLog_WARN(TAG, "/app-cmd:<command> is deprecated, use /app:cmd:<command> instead");
 			if (!freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationCmdLine,
 			                                 arg->Value))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
 		CommandLineSwitchCase(arg, "app-file")
 		{
+			WLog_WARN(TAG, "/app-file:<filename> is deprecated, use /app:file:<filename> instead");
 			if (!freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationFile, arg->Value))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
 		CommandLineSwitchCase(arg, "app-guid")
 		{
+			WLog_WARN(TAG, "/app-guid:<guid> is deprecated, use /app:guid:<guid> instead");
 			if (!freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationGuid, arg->Value))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
@@ -3304,6 +3312,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 #ifdef WITH_GFX_H264
 		CommandLineSwitchCase(arg, "gfx-h264")
 		{
+			WLog_WARN(TAG, "/gfx-h264 is deprecated, use /gfx:avc420 instead");
 			settings->SupportGraphicsPipeline = TRUE;
 			settings->GfxH264 = TRUE;
 
@@ -3527,22 +3536,22 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 #if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 		CommandLineSwitchCase(arg, "sec-rdp")
 		{
-			WLog_WARN(TAG, "Option /sec-rdp is deprecated, use /sec:rdp[:on|off] instead");
+			WLog_WARN(TAG, "/sec-rdp is deprecated, use /sec:rdp[:on|off] instead");
 			settings->RdpSecurity = enable;
 		}
 		CommandLineSwitchCase(arg, "sec-tls")
 		{
-			WLog_WARN(TAG, "Option /sec-tls is deprecated, use /sec:tls[:on|off] instead");
+			WLog_WARN(TAG, "/sec-tls is deprecated, use /sec:tls[:on|off] instead");
 			settings->TlsSecurity = enable;
 		}
 		CommandLineSwitchCase(arg, "sec-nla")
 		{
-			WLog_WARN(TAG, "Option /sec-nla is deprecated, use /sec:nla[:on|off] instead");
+			WLog_WARN(TAG, "/sec-nla is deprecated, use /sec:nla[:on|off] instead");
 			settings->NlaSecurity = enable;
 		}
 		CommandLineSwitchCase(arg, "sec-ext")
 		{
-			WLog_WARN(TAG, "Option /sec-ext is deprecated, use /sec:ext[:on|off] instead");
+			WLog_WARN(TAG, "/sec-ext is deprecated, use /sec:ext[:on|off] instead");
 			settings->ExtSecurity = enable;
 		}
 #endif
@@ -3567,7 +3576,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 #if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 		CommandLineSwitchCase(arg, "tls-ciphers")
 		{
-			WLog_WARN(TAG, "Option /tls-ciphers:<cipher list> is deprecated, use "
+			WLog_WARN(TAG, "/tls-ciphers:<cipher list> is deprecated, use "
 			               "/tls:ciphers:<cipher list> instead");
 			int rc = parse_tls_options(settings, arg);
 			if (rc != 0)
@@ -3575,16 +3584,15 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 		}
 		CommandLineSwitchCase(arg, "tls-seclevel")
 		{
-			WLog_WARN(
-			    TAG,
-			    "Option /tls-seclevel:<level> is deprecated, use /tls:sec-level:<level> instead");
+			WLog_WARN(TAG,
+			          "/tls-seclevel:<level> is deprecated, use /tls:sec-level:<level> instead");
 			int rc = parse_tls_options(settings, arg);
 			if (rc != 0)
 				return rc;
 		}
 		CommandLineSwitchCase(arg, "tls-secrets-file")
 		{
-			WLog_WARN(TAG, "Option /tls-secrets-file:<filename> is deprecated, use "
+			WLog_WARN(TAG, "/tls-secrets-file:<filename> is deprecated, use "
 			               "/tls:secrets-file:<filename> instead");
 			int rc = parse_tls_options(settings, arg);
 			if (rc != 0)
@@ -3592,7 +3600,7 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 		}
 		CommandLineSwitchCase(arg, "enforce-tlsv1_2")
 		{
-			WLog_WARN(TAG, "Option /enforce-tlsv1_2 is deprecated, use /tls:enforce:1.2 instead");
+			WLog_WARN(TAG, "/enforce-tlsv1_2 is deprecated, use /tls:enforce:1.2 instead");
 			int rc = parse_tls_options(settings, arg);
 			if (rc != 0)
 				return rc;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2042,11 +2042,12 @@ static int parse_kbd_options(rdpSettings* settings, const COMMAND_LINE_ARGUMENT_
 				{
 					const size_t olen = strlen(old);
 					const size_t alen = strlen(now);
-					char* tmp = calloc(olen + alen + 1, sizeof(char));
+					const size_t tlen = olen + alen + 2;
+					char* tmp = calloc(tlen, sizeof(char));
 					if (!tmp)
 						rc = COMMAND_LINE_ERROR_MEMORY;
 					else
-						_snprintf(tmp, olen + alen + 1, "%s,%s", old, now);
+						_snprintf(tmp, tlen, "%s,%s", old, now);
 					now = tmp;
 				}
 

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -32,8 +32,10 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "Admin (or console) session" },
 	{ "aero", COMMAND_LINE_VALUE_BOOL, NULL, NULL, BoolValueFalse, -1, NULL,
 	  "desktop composition" },
-	{ "app", COMMAND_LINE_VALUE_REQUIRED, "<path> or ||<alias>", NULL, NULL, -1, NULL,
-	  "Remote application program" },
+	{ "app", COMMAND_LINE_VALUE_REQUIRED,
+	  "program:[<path>|<||alias>],cmd:<command>,file:<filename>,guid:<guid>,icon:<filename>,name:<"
+	  "name>,workdir:<directory>",
+	  NULL, NULL, -1, NULL, "Remote application program" },
 #if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 	{ "app-cmd", COMMAND_LINE_VALUE_REQUIRED, "<parameters>", NULL, NULL, -1, NULL,
 	  "[DEPRECATED, use /app:cmd:<command>] Remote application command-line parameters" },

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -66,16 +66,22 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "Automatic reconnection" },
 	{ "auto-reconnect-max-retries", COMMAND_LINE_VALUE_REQUIRED, "<retries>", NULL, NULL, -1, NULL,
 	  "Automatic reconnection maximum retries, 0 for unlimited [0,1000]" },
+#if defined(WITH_FREERDP_DEPRECATED)
 	{ "bitmap-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
 	  "bitmap cache" },
 	{ "persist-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
 	  "persistent bitmap cache" },
 	{ "persist-cache-file", COMMAND_LINE_VALUE_REQUIRED, "<filename>", NULL, NULL, -1, NULL,
 	  "persistent bitmap cache file" },
+#endif
 	{ "bpp", COMMAND_LINE_VALUE_REQUIRED, "<depth>", "16", NULL, -1, NULL,
 	  "Session bpp (color depth)" },
 	{ "buildconfig", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT_BUILDCONFIG, NULL, NULL, NULL, -1,
 	  NULL, "Print the build configuration" },
+	{ "cache", COMMAND_LINE_VALUE_REQUIRED,
+	  "[bitmap[:on|off],codec[:rfx|nsc],glyph[:on|off],offscreen[:on|off],persist,persist-file:<"
+	  "filename>]",
+	  NULL, NULL, -1, NULL, "" },
 	{ "cert", COMMAND_LINE_VALUE_REQUIRED,
 	  "[deny,ignore,name:<name>,tofu,fingerprint:<hash>:<hash as hex>[,fingerprint:<hash>:<another "
 	  "hash>]]",
@@ -112,8 +118,10 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  " * use-selection:<atom>  ... (X11) Specify which X selection to access. Default is "
 	  "CLIPBOARD."
 	  " PRIMARY is the X-style middle-click selection." },
+#if defined(WITH_FREERDP_DEPRECATED)
 	{ "codec-cache", COMMAND_LINE_VALUE_REQUIRED, "[rfx|nsc|jpeg]", NULL, NULL, -1, NULL,
 	  "Bitmap codec cache" },
+#endif
 	{ "compression", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, "z", "compression" },
 	{ "compression-level", COMMAND_LINE_VALUE_REQUIRED, "<level>", NULL, NULL, -1, NULL,
 	  "Compression level (0,1,2)" },
@@ -188,9 +196,9 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  BoolValueTrue, NULL, -1, NULL, "RDP8 graphics pipeline using small cache mode" },
 	{ "[DEPRECATED] use /gfx:thin-client instead gfx-thin-client", COMMAND_LINE_VALUE_BOOL, NULL,
 	  BoolValueFalse, NULL, -1, NULL, "RDP8 graphics pipeline using thin client mode" },
-#endif
 	{ "glyph-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
 	  "Glyph cache (experimental)" },
+#endif
 	{ "gp", COMMAND_LINE_VALUE_REQUIRED, "<password>", NULL, NULL, -1, NULL, "Gateway password" },
 	{ "grab-keyboard", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
 	  "Grab keyboard" },
@@ -287,8 +295,10 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "[modem|broadband|broadband-low|broadband-high|wan|lan|auto]", NULL, NULL, -1, NULL,
 	  "Network connection type" },
 	{ "nsc", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "nscodec", "NSCodec support" },
+#if defined(WITH_FREERDP_DEPRECATED)
 	{ "offscreen-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
 	  "offscreen bitmap cache" },
+#endif
 	{ "orientation", COMMAND_LINE_VALUE_REQUIRED, "[0|90|180|270]", NULL, NULL, -1, NULL,
 	  "Orientation of display in degrees" },
 	{ "old-license", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -167,22 +167,28 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	{ "gestures", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
 	  "Consume multitouch input locally" },
 #ifdef WITH_GFX_H264
-	{ "gfx", COMMAND_LINE_VALUE_OPTIONAL, "[[RFX|AVC420|AVC444],mask:<value>]", NULL, NULL, -1,
-	  NULL, "RDP8 graphics pipeline" },
+	{ "gfx", COMMAND_LINE_VALUE_OPTIONAL,
+	  "[[RFX|AVC420|AVC444],mask:<value>,small-cache[:on|off],thin-client[:on|off],progressive[:on|"
+	  "off]]",
+	  NULL, NULL, -1, NULL, "RDP8 graphics pipeline" },
 #if defined(WITH_FREERDP_DEPRECATED)
 	{ "gfx-h264", COMMAND_LINE_VALUE_OPTIONAL,
 	  "[[AVC420|AVC444],mask:<value>] [DEPRECATED] use /gfx:avc420 instead", NULL, NULL, -1, NULL,
 	  "RDP8.1 graphics pipeline using H264 codec" },
 #endif
 #else
-	{ "gfx", COMMAND_LINE_VALUE_OPTIONAL, "RFX", NULL, NULL, -1, NULL, "RDP8 graphics pipeline" },
+	{ "gfx", COMMAND_LINE_VALUE_OPTIONAL,
+	  "RFX,mask:<value>,small-cache[:on|off],thin-client[:on|off],progressive[:on|off]]", NULL,
+	  NULL, -1, NULL, "RDP8 graphics pipeline" },
 #endif
-	{ "gfx-progressive", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
-	  "RDP8 graphics pipeline using progressive codec" },
-	{ "gfx-small-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
-	  "RDP8 graphics pipeline using small cache mode" },
-	{ "gfx-thin-client", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
-	  "RDP8 graphics pipeline using thin client mode" },
+#if defined(WITH_FREERDP_DEPRECATED)
+	{ "[DEPRECATED] use /gfx:progressive instead gfx-progressive", COMMAND_LINE_VALUE_BOOL, NULL,
+	  BoolValueFalse, NULL, -1, NULL, "RDP8 graphics pipeline using progressive codec" },
+	{ "[DEPRECATED] use /gfx:small-cache instead gfx-small-cache", COMMAND_LINE_VALUE_BOOL, NULL,
+	  BoolValueTrue, NULL, -1, NULL, "RDP8 graphics pipeline using small cache mode" },
+	{ "[DEPRECATED] use /gfx:thin-client instead gfx-thin-client", COMMAND_LINE_VALUE_BOOL, NULL,
+	  BoolValueFalse, NULL, -1, NULL, "RDP8 graphics pipeline using thin client mode" },
+#endif
 	{ "glyph-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
 	  "Glyph cache (experimental)" },
 	{ "gp", COMMAND_LINE_VALUE_REQUIRED, "<password>", NULL, NULL, -1, NULL, "Gateway password" },

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -223,29 +223,37 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	{ "jpeg-quality", COMMAND_LINE_VALUE_REQUIRED, "<percentage>", NULL, NULL, -1, NULL,
 	  "JPEG quality" },
 #endif
-	{ "kbd", COMMAND_LINE_VALUE_REQUIRED, "0x<id> or <name>", NULL, NULL, -1, NULL,
-	  "Keyboard layout" },
-	{ "kbd-lang", COMMAND_LINE_VALUE_REQUIRED, "0x<id>", NULL, NULL, -1, NULL,
-	  "Keyboard active language identifier" },
-	{ "kbd-fn-key", COMMAND_LINE_VALUE_REQUIRED, "<value>", NULL, NULL, -1, NULL,
-	  "Function key value" },
+	{ "kbd", COMMAND_LINE_VALUE_REQUIRED,
+	  "[layout:[0x<id>|<name>],lang:<0x<id>>,fn-key:<value>,type:<value>,subtype:<value>,unicode[:"
+	  "on|off],remap:<key1>=<value1>,remap:<key2>=<value2>]",
+	  NULL, NULL, -1, NULL,
+	  "Keyboard related options:"
+	  "* layout: set the keybouard layout announced to the server"
+	  "* lang: set the keyboard language identifier sent to the server"
+	  "* fn-key: Function key value" },
 #if defined(WITH_FREERDP_DEPRECATED)
+	{ "kbd-lang", COMMAND_LINE_VALUE_REQUIRED, "0x<id>", NULL, NULL, -1, NULL,
+	  "[deprecated use / kbd:lang:<value> instead] Keyboard active language identifier" },
+	{ "kbd-fn-key", COMMAND_LINE_VALUE_REQUIRED, "<value>", NULL, NULL, -1, NULL,
+	  "[deprecated use /kbd:fn-key:<value> instead] Function key value" },
 	{ "kbd-list", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT, NULL, NULL, NULL, -1, NULL,
 	  "[deprecated use /list:kbd instead] List keyboard layouts" },
 	{ "kbd-scancode-list", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT, NULL, NULL, NULL, -1, NULL,
 	  "[deprecated use list:kbd-scancode instead] List keyboard RDP scancodes" },
 	{ "kbd-lang-list", COMMAND_LINE_VALUE_OPTIONAL | COMMAND_LINE_PRINT, NULL, NULL, NULL, -1, NULL,
 	  "[deprecated use /list:kbd-lang instead] List keyboard languages" },
-#endif
 	{ "kbd-remap", COMMAND_LINE_VALUE_REQUIRED,
-	  "List of <key>=<value>,... pairs to remap scancodes", NULL, NULL, -1, NULL,
-	  "Keyboard scancode remapping" },
+	  "[deprecated use /kbd:remap instead] List of <key>=<value>,... pairs to remap scancodes",
+	  NULL, NULL, -1, NULL, "Keyboard scancode remapping" },
 	{ "kbd-subtype", COMMAND_LINE_VALUE_REQUIRED, "<id>", NULL, NULL, -1, NULL,
-	  "Keyboard subtype" },
-	{ "kbd-type", COMMAND_LINE_VALUE_REQUIRED, "<id>", NULL, NULL, -1, NULL, "Keyboard type" },
+	  "[deprecated use /kbd:subtype instead]Keyboard subtype" },
+	{ "kbd-type", COMMAND_LINE_VALUE_REQUIRED, "<id>", NULL, NULL, -1, NULL,
+	  "[deprecated use /kbd:type instead] Keyboard type" },
 	{ "kbd-unicode", COMMAND_LINE_VALUE_FLAG, "", NULL, NULL, -1, NULL,
-	  "Send unicode symbols, e.g. use the local keyboard map. ATTENTION: Does not work with every "
+	  "[deprecated use /kbd:unicode[:on|off] instead] Send unicode symbols, e.g. use the local "
+	  "keyboard map. ATTENTION: Does not work with every "
 	  "RDP server!" },
+#endif
 	{ "kerberos", COMMAND_LINE_VALUE_REQUIRED,
 	  "[kdc-url:<url>,lifetime:<time>,start-time:<time>,renewable-lifetime:<time>,cache:<path>,"
 	  "armor:<path>,pkinit-anchors:<path>,pkcs11-module:<name>]",

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -34,18 +34,20 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "desktop composition" },
 	{ "app", COMMAND_LINE_VALUE_REQUIRED, "<path> or ||<alias>", NULL, NULL, -1, NULL,
 	  "Remote application program" },
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 	{ "app-cmd", COMMAND_LINE_VALUE_REQUIRED, "<parameters>", NULL, NULL, -1, NULL,
-	  "Remote application command-line parameters" },
+	  "[DEPRECATED, use /app:cmd:<command>] Remote application command-line parameters" },
 	{ "app-file", COMMAND_LINE_VALUE_REQUIRED, "<file-name>", NULL, NULL, -1, NULL,
-	  "File to open with remote application" },
+	  "[DEPRECATED, use /app:file:<filename>] File to open with remote application" },
 	{ "app-guid", COMMAND_LINE_VALUE_REQUIRED, "<app-guid>", NULL, NULL, -1, NULL,
-	  "Remote application GUID" },
+	  "[DEPRECATED, use /app:guid:<guid>] Remote application GUID" },
 	{ "app-icon", COMMAND_LINE_VALUE_REQUIRED, "<icon-path>", NULL, NULL, -1, NULL,
-	  "Remote application icon for user interface" },
+	  "[DEPRECATED, use /app:icon:<filename>] Remote application icon for user interface" },
 	{ "app-name", COMMAND_LINE_VALUE_REQUIRED, "<app-name>", NULL, NULL, -1, NULL,
-	  "Remote application name for user interface" },
+	  "[DEPRECATED, use /app:name:<name>] Remote application name for user interface" },
 	{ "app-workdir", COMMAND_LINE_VALUE_REQUIRED, "<workspace path>", NULL, NULL, -1, NULL,
-	  "Remote application workspace path" },
+	  "[DEPRECATED, use /app:workdir:<directory>] Remote application workspace path" },
+#endif
 	{ "assistance", COMMAND_LINE_VALUE_REQUIRED, "<password>", NULL, NULL, -1, NULL,
 	  "Remote assistance password" },
 	{ "auto-request-control", COMMAND_LINE_VALUE_FLAG, "", NULL, NULL, -1, NULL,
@@ -66,13 +68,13 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "Automatic reconnection" },
 	{ "auto-reconnect-max-retries", COMMAND_LINE_VALUE_REQUIRED, "<retries>", NULL, NULL, -1, NULL,
 	  "Automatic reconnection maximum retries, 0 for unlimited [0,1000]" },
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 	{ "bitmap-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
-	  "bitmap cache" },
+	  "[DEPRECATED, use /cache:bitmap[:on|off]] bitmap cache" },
 	{ "persist-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
-	  "persistent bitmap cache" },
+	  "[DEPRECATED, use /cache:persist[:on|off]] persistent bitmap cache" },
 	{ "persist-cache-file", COMMAND_LINE_VALUE_REQUIRED, "<filename>", NULL, NULL, -1, NULL,
-	  "persistent bitmap cache file" },
+	  "[DEPRECATED, use /cache:persist-file:<filename>] persistent bitmap cache file" },
 #endif
 	{ "bpp", COMMAND_LINE_VALUE_REQUIRED, "<depth>", "16", NULL, -1, NULL,
 	  "Session bpp (color depth)" },
@@ -97,16 +99,16 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "subsequent connections if the certificate does not match"
 	  " * fingerprints ... A list of certificate hashes that are accepted unconditionally for a "
 	  "connection" },
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 	{ "cert-deny", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL,
-	  "[deprecated, use /cert:deny] Automatically abort connection for any certificate that can "
+	  "[DEPRECATED, use /cert:deny] Automatically abort connection for any certificate that can "
 	  "not be validated." },
 	{ "cert-ignore", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL,
-	  "[deprecated, use /cert:ignore] Ignore certificate" },
+	  "[DEPRECATED, use /cert:ignore] Ignore certificate" },
 	{ "cert-name", COMMAND_LINE_VALUE_REQUIRED, "<name>", NULL, NULL, -1, NULL,
-	  "[deprecated, use /cert:name:<name>] Certificate name" },
+	  "[DEPRECATED, use /cert:name:<name>] Certificate name" },
 	{ "cert-tofu", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL,
-	  "[deprecated, use /cert:tofu] Automatically accept certificate on first connect" },
+	  "[DEPRECATED, use /cert:tofu] Automatically accept certificate on first connect" },
 #endif
 	{ "client-build-number", COMMAND_LINE_VALUE_REQUIRED, "<number>", NULL, NULL, -1, NULL,
 	  "Client Build Number sent to server (influences smartcard behaviour, see [MS-RDPESC])" },
@@ -118,9 +120,9 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  " * use-selection:<atom>  ... (X11) Specify which X selection to access. Default is "
 	  "CLIPBOARD."
 	  " PRIMARY is the X-style middle-click selection." },
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 	{ "codec-cache", COMMAND_LINE_VALUE_REQUIRED, "[rfx|nsc|jpeg]", NULL, NULL, -1, NULL,
-	  "Bitmap codec cache" },
+	  "[DEPRECATED, use /cache:codec:[rfx|nsc|jpeg]] Bitmap codec cache" },
 #endif
 	{ "compression", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, "z", "compression" },
 	{ "compression-level", COMMAND_LINE_VALUE_REQUIRED, "<level>", NULL, NULL, -1, NULL,
@@ -179,25 +181,24 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "[[RFX|AVC420|AVC444],mask:<value>,small-cache[:on|off],thin-client[:on|off],progressive[:on|"
 	  "off]]",
 	  NULL, NULL, -1, NULL, "RDP8 graphics pipeline" },
-#if defined(WITH_FREERDP_DEPRECATED)
-	{ "gfx-h264", COMMAND_LINE_VALUE_OPTIONAL,
-	  "[[AVC420|AVC444],mask:<value>] [DEPRECATED] use /gfx:avc420 instead", NULL, NULL, -1, NULL,
-	  "RDP8.1 graphics pipeline using H264 codec" },
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
+	{ "gfx-h264", COMMAND_LINE_VALUE_OPTIONAL, "[[AVC420|AVC444],mask:<value>]", NULL, NULL, -1,
+	  NULL, "[DEPRECATED, use /gfx:avc420] RDP8.1 graphics pipeline using H264 codec" },
 #endif
 #else
 	{ "gfx", COMMAND_LINE_VALUE_OPTIONAL,
 	  "RFX,mask:<value>,small-cache[:on|off],thin-client[:on|off],progressive[:on|off]]", NULL,
 	  NULL, -1, NULL, "RDP8 graphics pipeline" },
 #endif
-#if defined(WITH_FREERDP_DEPRECATED)
-	{ "[DEPRECATED] use /gfx:progressive instead gfx-progressive", COMMAND_LINE_VALUE_BOOL, NULL,
-	  BoolValueFalse, NULL, -1, NULL, "RDP8 graphics pipeline using progressive codec" },
-	{ "[DEPRECATED] use /gfx:small-cache instead gfx-small-cache", COMMAND_LINE_VALUE_BOOL, NULL,
-	  BoolValueTrue, NULL, -1, NULL, "RDP8 graphics pipeline using small cache mode" },
-	{ "[DEPRECATED] use /gfx:thin-client instead gfx-thin-client", COMMAND_LINE_VALUE_BOOL, NULL,
-	  BoolValueFalse, NULL, -1, NULL, "RDP8 graphics pipeline using thin client mode" },
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
+	{ "gfx-progressive", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
+	  "[DEPRECATED, use /gfx:progressive] RDP8 graphics pipeline using progressive codec" },
+	{ "gfx-small-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
+	  "[DEPRECATED, use /gfx:small-cache] RDP8 graphics pipeline using small cache mode" },
+	{ "gfx-thin-client", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
+	  "[DEPRECATED, use /gfx:thin-client] RDP8 graphics pipeline using thin client mode" },
 	{ "glyph-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
-	  "Glyph cache (experimental)" },
+	  "[DEPRECATED, use /cache:glyph[:on|off]] Glyph cache (experimental)" },
 #endif
 	{ "gp", COMMAND_LINE_VALUE_REQUIRED, "<password>", NULL, NULL, -1, NULL, "Gateway password" },
 	{ "grab-keyboard", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
@@ -231,26 +232,26 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "* layout: set the keybouard layout announced to the server"
 	  "* lang: set the keyboard language identifier sent to the server"
 	  "* fn-key: Function key value" },
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 	{ "kbd-lang", COMMAND_LINE_VALUE_REQUIRED, "0x<id>", NULL, NULL, -1, NULL,
-	  "[deprecated use / kbd:lang:<value> instead] Keyboard active language identifier" },
+	  "[DEPRECATED, use / kbd:lang:<value>] Keyboard active language identifier" },
 	{ "kbd-fn-key", COMMAND_LINE_VALUE_REQUIRED, "<value>", NULL, NULL, -1, NULL,
-	  "[deprecated use /kbd:fn-key:<value> instead] Function key value" },
+	  "[DEPRECATED, use /kbd:fn-key:<value>] Function key value" },
 	{ "kbd-list", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT, NULL, NULL, NULL, -1, NULL,
-	  "[deprecated use /list:kbd instead] List keyboard layouts" },
+	  "[DEPRECATED, use /list:kbd] List keyboard layouts" },
 	{ "kbd-scancode-list", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT, NULL, NULL, NULL, -1, NULL,
-	  "[deprecated use list:kbd-scancode instead] List keyboard RDP scancodes" },
+	  "[DEPRECATED, use list:kbd-scancode] List keyboard RDP scancodes" },
 	{ "kbd-lang-list", COMMAND_LINE_VALUE_OPTIONAL | COMMAND_LINE_PRINT, NULL, NULL, NULL, -1, NULL,
-	  "[deprecated use /list:kbd-lang instead] List keyboard languages" },
+	  "[DEPRECATED, use /list:kbd-lang] List keyboard languages" },
 	{ "kbd-remap", COMMAND_LINE_VALUE_REQUIRED,
-	  "[deprecated use /kbd:remap instead] List of <key>=<value>,... pairs to remap scancodes",
-	  NULL, NULL, -1, NULL, "Keyboard scancode remapping" },
+	  "[DEPRECATED, use /kbd:remap] List of <key>=<value>,... pairs to remap scancodes", NULL, NULL,
+	  -1, NULL, "Keyboard scancode remapping" },
 	{ "kbd-subtype", COMMAND_LINE_VALUE_REQUIRED, "<id>", NULL, NULL, -1, NULL,
-	  "[deprecated use /kbd:subtype instead]Keyboard subtype" },
+	  "[DEPRECATED, use /kbd:subtype]Keyboard subtype" },
 	{ "kbd-type", COMMAND_LINE_VALUE_REQUIRED, "<id>", NULL, NULL, -1, NULL,
-	  "[deprecated use /kbd:type instead] Keyboard type" },
+	  "[DEPRECATED, use /kbd:type] Keyboard type" },
 	{ "kbd-unicode", COMMAND_LINE_VALUE_FLAG, "", NULL, NULL, -1, NULL,
-	  "[deprecated use /kbd:unicode[:on|off] instead] Send unicode symbols, e.g. use the local "
+	  "[DEPRECATED, use /kbd:unicode[:on|off]] Send unicode symbols, e.g. use the local "
 	  "keyboard map. ATTENTION: Does not work with every "
 	  "RDP server!" },
 #endif
@@ -275,11 +276,11 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	{ "microphone", COMMAND_LINE_VALUE_OPTIONAL,
 	  "[sys:<sys>,][dev:<dev>,][format:<format>,][rate:<rate>,][channel:<channel>]", NULL, NULL, -1,
 	  "mic", "Audio input (microphone)" },
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 	{ "smartcard-list", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT, NULL, NULL, NULL, -1, NULL,
-	  "[deprecated use /list:smartcard instead] List smartcard informations" },
+	  "[DEPRECATED, use /list:smartcard] List smartcard informations" },
 	{ "monitor-list", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT, NULL, NULL, NULL, -1, NULL,
-	  "[deprecated use /list:monitor instead] List detected monitors" },
+	  "[DEPRECATED, use /list:monitor] List detected monitors" },
 #endif
 	{ "monitors", COMMAND_LINE_VALUE_REQUIRED, "<id>[,<id>[,...]]", NULL, NULL, -1, NULL,
 	  "Select monitors to use" },
@@ -289,7 +290,7 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "Send mouse motion with relative addressing" },
 #if defined(CHANNEL_TSMF_CLIENT)
 	{ "multimedia", COMMAND_LINE_VALUE_OPTIONAL, "[sys:<sys>,][dev:<dev>,][decoder:<decoder>]",
-	  NULL, NULL, -1, "mmr", "[DEPRECATED] Redirect multimedia (video) use /video instead" },
+	  NULL, NULL, -1, "mmr", "[DEPRECATED], use /video] Redirect multimedia (video)" },
 #endif
 	{ "multimon", COMMAND_LINE_VALUE_OPTIONAL, "force", NULL, NULL, -1, NULL,
 	  "Use multiple monitors" },
@@ -303,9 +304,9 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "[modem|broadband|broadband-low|broadband-high|wan|lan|auto]", NULL, NULL, -1, NULL,
 	  "Network connection type" },
 	{ "nsc", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "nscodec", "NSCodec support" },
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 	{ "offscreen-cache", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
-	  "offscreen bitmap cache" },
+	  "[DEPRECATED, use /cache:offscreen[:on|off]] offscreen bitmap cache" },
 #endif
 	{ "orientation", COMMAND_LINE_VALUE_REQUIRED, "[0|90|180|270]", NULL, NULL, -1, NULL,
 	  "Orientation of display in degrees" },
@@ -359,15 +360,15 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "Scaling factor for app store applications" },
 	{ "sec", COMMAND_LINE_VALUE_REQUIRED, "[rdp|tls|nla|ext]", NULL, NULL, -1, NULL,
 	  "Force specific protocol security" },
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 	{ "sec-ext", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
-	  "[deprecated use /sec:ext instead] NLA extended protocol security" },
+	  "[DEPRECATED, use /sec:ext] NLA extended protocol security" },
 	{ "sec-nla", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
-	  "[deprecated use /sec:nla instead] NLA protocol security" },
+	  "[DEPRECATED, use /sec:nla] NLA protocol security" },
 	{ "sec-rdp", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
-	  "[deprecated use /sec:rdp instead] RDP protocol security" },
+	  "[DEPRECATED, use /sec:rdp] RDP protocol security" },
 	{ "sec-tls", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
-	  "[deprecated use /sec:tls instead] TLS protocol security" },
+	  "[DEPRECATED, use /sec:tls] TLS protocol security" },
 #endif
 	{ "serial", COMMAND_LINE_VALUE_OPTIONAL, "<name>[,<path>[,<driver>[,permissive]]]", NULL, NULL,
 	  -1, "tty", "Redirect serial device" },
@@ -416,16 +417,16 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "servers have a buggy TLS "
 	  "version negotiation and might fail without this. Defaults to TLS 1.2 if no argument is "
 	  "supplied. Use 1.0 for windows 7" },
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 	{ "tls-ciphers", COMMAND_LINE_VALUE_REQUIRED, "[netmon|ma|ciphers]", NULL, NULL, -1, NULL,
-	  "[deprecated, use /tls:ciphers instead] Allowed TLS ciphers" },
+	  "[DEPRECATED, use /tls:ciphers] Allowed TLS ciphers" },
 	{ "tls-seclevel", COMMAND_LINE_VALUE_REQUIRED, "<level>", "1", NULL, -1, NULL,
-	  "[deprecated, use /tls:seclevel instead]TLS security level - defaults to 1" },
+	  "[DEPRECATED, use /tls:seclevel] TLS security level - defaults to 1" },
 	{ "tls-secrets-file", COMMAND_LINE_VALUE_REQUIRED, "<filename>", NULL, NULL, -1, NULL,
-	  "[deprecated, use /tls:secrets:file instead] File were TLS secrets will be stored in the "
+	  "[DEPRECATED, use /tls:secrets:file] File were TLS secrets will be stored in the "
 	  "SSLKEYLOGFILE format" },
 	{ "enforce-tlsv1_2", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
-	  "[deprecated, use /tls:enforce-tlsv1_2 instead] Force use of TLS1.2 for connection. Some "
+	  "[DEPRECATED, use /tls:enforce:1.2] Force use of TLS1.2 for connection. Some "
 	  "servers have a buggy TLS version negotiation and "
 	  "might fail without this" },
 #endif
@@ -433,9 +434,9 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "Alt+Ctrl+Enter to toggle fullscreen" },
 	{ "tune", COMMAND_LINE_VALUE_REQUIRED, "<setting:value>,<setting:value>", "", NULL, -1, NULL,
 	  "[experimental] directly manipulate freerdp settings, use with extreme caution!" },
-#if defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 	{ "tune-list", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT, NULL, NULL, NULL, -1, NULL,
-	  "[deprecated use /list:tune instead] Print options allowed for /tune" },
+	  "[DEPRECATED, use /list:tune] Print options allowed for /tune" },
 #endif
 	{ "u", COMMAND_LINE_VALUE_REQUIRED, "[[<domain>\\]<user>|<user>[@<domain>]]", NULL, NULL, -1,
 	  NULL, "Username" },


### PR DESCRIPTION
* Groups a lot of options logically connected
* Adds a new `CMake` option to enable/disable deprecated command line separate from deprecated functions
* Added/Unified logging messages for deprecated options