### PR TITLE
Fixed compile error for old openssl

### DIFF
--- a/winpr/libwinpr/crypto/hash.c
+++ b/winpr/libwinpr/crypto/hash.c
@@ -182,7 +182,7 @@ WINPR_HMAC_CTX* winpr_HMAC_New(void)
 	if (!(ctx->hmac = (HMAC_CTX*)calloc(1, sizeof(HMAC_CTX))))
 		goto fail;
 
-	HMAC_CTX_init(hmac);
+	HMAC_CTX_init(ctx->hmac);
 #else
 
 	if (!(ctx->hmac = HMAC_CTX_new()))
@@ -196,6 +196,7 @@ WINPR_HMAC_CTX* winpr_HMAC_New(void)
 
 fail:
 	winpr_HMAC_Free(ctx);
+	return NULL;
 }
 
 BOOL winpr_HMAC_Init(WINPR_HMAC_CTX* ctx, WINPR_MD_TYPE md, const BYTE* key, size_t keylen)


### PR DESCRIPTION
(cherry picked from commit f3082b3798ea77548d830de8dfd384da9274799d)
Backport #8351 