### PR TITLE
nla: Fix unicode issues with gateway code

### DIFF
--- a/libfreerdp/core/credssp_auth.h
+++ b/libfreerdp/core/credssp_auth.h
@@ -54,7 +54,7 @@ FREERDP_LOCAL void credssp_auth_take_input_buffer(rdpCredsspAuth* auth, SecBuffe
 FREERDP_LOCAL const SecBuffer* credssp_auth_get_output_buffer(rdpCredsspAuth* auth);
 FREERDP_LOCAL BOOL credssp_auth_have_output_token(rdpCredsspAuth* auth);
 FREERDP_LOCAL BOOL credssp_auth_is_complete(rdpCredsspAuth* auth);
-FREERDP_LOCAL const TCHAR* credssp_auth_pkg_name(rdpCredsspAuth* auth);
+FREERDP_LOCAL const char* credssp_auth_pkg_name(rdpCredsspAuth* auth);
 FREERDP_LOCAL size_t credssp_auth_trailer_size(rdpCredsspAuth* auth);
 FREERDP_LOCAL void credssp_auth_free(rdpCredsspAuth* auth);
 

--- a/libfreerdp/core/gateway/ncacn_http.c
+++ b/libfreerdp/core/gateway/ncacn_http.c
@@ -30,7 +30,7 @@
 
 #define TAG FREERDP_TAG("core.gateway.ntlm")
 
-#define AUTH_PKG CREDSSP_AUTH_PKG_NTLM
+#define AUTH_PKG NTLM_SSP_NAME
 
 static wStream* rpc_auth_http_request(HttpContext* http, const char* method, int contentLength,
                                       const SecBuffer* authToken, const char* auth_scheme)

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -44,9 +44,9 @@
 #define TAG FREERDP_TAG("core.gateway.rdg")
 
 #if defined(_WIN32) || defined(WITH_SPNEGO)
-#define AUTH_PKG CREDSSP_AUTH_PKG_SPNEGO
+#define AUTH_PKG NEGO_SSP_NAME
 #else
-#define AUTH_PKG CREDSSP_AUTH_PKG_NTLM
+#define AUTH_PKG NTLM_SSP_NAME
 #endif
 
 /* HTTP channel response fields present flags. */

--- a/libfreerdp/core/gateway/rpc_bind.c
+++ b/libfreerdp/core/gateway/rpc_bind.c
@@ -33,7 +33,7 @@
 
 #define TAG FREERDP_TAG("core.gateway.rpc")
 
-#define AUTH_PKG CREDSSP_AUTH_PKG_NTLM
+#define AUTH_PKG NTLM_SSP_NAME
 
 /**
  * Connection-Oriented RPC Protocol Client Details:


### PR DESCRIPTION
Gateway code was passing a char string as the package name to `credssp_auth_init`. When using Unicode builds this fails since `QuerySecurityPackageInfo` expects a wchar string.

Additionally with unicode builds, `credssp_auth_pkg_name` causes string type mismatches in the gateway code where a char string is expected.
