### PR TITLE
[channel] Fixed broken length check

### DIFF
--- a/libfreerdp/core/channels.c
+++ b/libfreerdp/core/channels.c
@@ -142,8 +142,6 @@ BOOL freerdp_channel_process(freerdp* instance, wStream* s, UINT16 channelId, si
 		         chunkLength);
 		return FALSE;
 	}
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, length))
-		return FALSE;
 
 	IFCALLRET(instance->ReceiveChannelData, rc, instance, channelId, Stream_Pointer(s), chunkLength,
 	          flags, length);


### PR DESCRIPTION
The length check for channel chunk data was wrong. Not only was it checked twice, the second check expected the whole fragmented data to be available.