### PR TITLE
core: Fix applying of pointer capabilities

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -1082,7 +1082,8 @@ static BOOL rdp_apply_pointer_capability_set(rdpSettings* settings, const rdpSet
 	if (!src->ColorPointerFlag)
 		settings->ColorPointerFlag = FALSE;
 
-	settings->PointerCacheSize = src->PointerCacheSize;
+	if (settings->ServerMode)
+		settings->PointerCacheSize = src->PointerCacheSize;
 
 	return TRUE;
 }


### PR DESCRIPTION
Only apply the pointer cache size to the settings if we are in server mode. This check got lost in a recent refactoring to caps parsing.