### PR TITLE
[core] Unify RDP state machine

### DIFF
--- a/libfreerdp/core/CMakeLists.txt
+++ b/libfreerdp/core/CMakeLists.txt
@@ -48,6 +48,8 @@ set(${MODULE_PREFIX}_GATEWAY_SRCS
 	${${MODULE_PREFIX}_GATEWAY_DIR}/ncacn_http.h)
 
 set(${MODULE_PREFIX}_SRCS
+    state.h
+    state.c
 	utils.c
 	utils.h
 	streamdump.c

--- a/libfreerdp/core/autodetect.c
+++ b/libfreerdp/core/autodetect.c
@@ -735,7 +735,7 @@ static BOOL autodetect_recv_netchar_request(rdpAutoDetect* autodetect, wStream* 
 	return success;
 }
 
-int autodetect_recv_request_packet(rdpAutoDetect* autodetect, wStream* s)
+state_run_t autodetect_recv_request_packet(rdpAutoDetect* autodetect, wStream* s)
 {
 	AUTODETECT_REQ_PDU autodetectReqPdu = { 0 };
 	const rdpSettings* settings;
@@ -748,7 +748,7 @@ int autodetect_recv_request_packet(rdpAutoDetect* autodetect, wStream* s)
 	WINPR_ASSERT(settings);
 
 	if (!Stream_CheckAndLogRequiredLength(AUTODETECT_TAG, s, 6))
-		return -1;
+		return STATE_RUN_FAILED;
 
 	Stream_Read_UINT8(s, autodetectReqPdu.headerLength);    /* headerLength (1 byte) */
 	Stream_Read_UINT8(s, autodetectReqPdu.headerTypeId);    /* headerTypeId (1 byte) */
@@ -823,10 +823,10 @@ fail:
 		autodetect->state = AUTODETECT_STATE_REQUEST;
 	else
 		autodetect->state = AUTODETECT_STATE_FAIL;
-	return success ? 0 : -1;
+	return success ? STATE_RUN_SUCCESS : STATE_RUN_FAILED;
 }
 
-int autodetect_recv_response_packet(rdpAutoDetect* autodetect, wStream* s)
+state_run_t autodetect_recv_response_packet(rdpAutoDetect* autodetect, wStream* s)
 {
 	AUTODETECT_RSP_PDU autodetectRspPdu = { 0 };
 	const rdpSettings* settings;
@@ -904,7 +904,7 @@ fail:
 	else
 		autodetect->state = AUTODETECT_STATE_FAIL;
 
-	return success ? 0 : -1;
+	return success ? STATE_RUN_SUCCESS : STATE_RUN_FAILED;
 }
 
 rdpAutoDetect* autodetect_new(rdpContext* context)

--- a/libfreerdp/core/autodetect.h
+++ b/libfreerdp/core/autodetect.h
@@ -30,6 +30,8 @@
 #include <winpr/stream.h>
 #include <winpr/sysinfo.h>
 
+#include "state.h"
+
 typedef enum
 {
 	AUTODETECT_STATE_INITIAL,
@@ -41,8 +43,8 @@ typedef enum
 
 FREERDP_LOCAL rdpAutoDetect* autodetect_new(rdpContext* context);
 FREERDP_LOCAL void autodetect_free(rdpAutoDetect* autodetect);
-FREERDP_LOCAL int autodetect_recv_request_packet(rdpAutoDetect* autodetect, wStream* s);
-FREERDP_LOCAL int autodetect_recv_response_packet(rdpAutoDetect* autodetect, wStream* s);
+FREERDP_LOCAL state_run_t autodetect_recv_request_packet(rdpAutoDetect* autodetect, wStream* s);
+FREERDP_LOCAL state_run_t autodetect_recv_response_packet(rdpAutoDetect* autodetect, wStream* s);
 
 FREERDP_LOCAL AUTODETECT_STATE autodetect_get_state(rdpAutoDetect* autodetect);
 

--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -4505,7 +4505,8 @@ BOOL rdp_recv_demand_active(rdpRdp* rdp, wStream* s)
 		 * We can receive a Save Session Info Data PDU containing a LogonErrorInfo
 		 * structure at this point from the server to indicate a connection error.
 		 */
-		if (rdp_recv_data_pdu(rdp, s) < 0)
+		state_run_t rc = rdp_recv_data_pdu(rdp, s);
+		if (state_run_failed(rc))
 			return FALSE;
 
 		return FALSE;

--- a/libfreerdp/core/connection.h
+++ b/libfreerdp/core/connection.h
@@ -26,6 +26,7 @@
 #include "nego.h"
 #include "mcs.h"
 #include "activation.h"
+#include "state.h"
 
 #include <freerdp/settings.h>
 #include <freerdp/api.h>
@@ -44,9 +45,9 @@ FREERDP_LOCAL BOOL rdp_client_reconnect(rdpRdp* rdp);
 FREERDP_LOCAL BOOL rdp_client_redirect(rdpRdp* rdp);
 FREERDP_LOCAL BOOL rdp_client_connect_mcs_channel_join_confirm(rdpRdp* rdp, wStream* s);
 FREERDP_LOCAL BOOL rdp_client_connect_auto_detect(rdpRdp* rdp, wStream* s);
-FREERDP_LOCAL int rdp_client_connect_license(rdpRdp* rdp, wStream* s);
-FREERDP_LOCAL int rdp_client_connect_demand_active(rdpRdp* rdp, wStream* s);
-FREERDP_LOCAL int rdp_client_connect_confirm_active(rdpRdp* rdp, wStream* s);
+FREERDP_LOCAL state_run_t rdp_client_connect_license(rdpRdp* rdp, wStream* s);
+FREERDP_LOCAL state_run_t rdp_client_connect_demand_active(rdpRdp* rdp, wStream* s);
+FREERDP_LOCAL state_run_t rdp_client_connect_confirm_active(rdpRdp* rdp, wStream* s);
 FREERDP_LOCAL BOOL rdp_client_transition_to_state(rdpRdp* rdp, CONNECTION_STATE state);
 
 FREERDP_LOCAL CONNECTION_STATE rdp_get_state(const rdpRdp* rdp);

--- a/libfreerdp/core/fastpath.c
+++ b/libfreerdp/core/fastpath.c
@@ -616,13 +616,13 @@ out_fail:
 	return -1;
 }
 
-int fastpath_recv_updates(rdpFastPath* fastpath, wStream* s)
+state_run_t fastpath_recv_updates(rdpFastPath* fastpath, wStream* s)
 {
-	int rc = -2;
+	state_run_t rc = STATE_RUN_FAILED;
 	rdpUpdate* update;
 
 	if (!fastpath || !fastpath->rdp || !fastpath->rdp->update || !s)
-		return -1;
+		return STATE_RUN_FAILED;
 
 	update = fastpath->rdp->update;
 
@@ -634,16 +634,16 @@ int fastpath_recv_updates(rdpFastPath* fastpath, wStream* s)
 		if (fastpath_recv_update_data(fastpath, s) < 0)
 		{
 			WLog_ERR(TAG, "fastpath_recv_update_data() fail");
-			rc = -3;
+			rc = STATE_RUN_FAILED;
 			goto fail;
 		}
 	}
 
-	rc = 0;
+	rc = STATE_RUN_SUCCESS;
 fail:
 
 	if (!update_end_paint(update))
-		return -4;
+		return STATE_RUN_FAILED;
 
 	return rc;
 }
@@ -832,7 +832,7 @@ static BOOL fastpath_recv_input_event(rdpFastPath* fastpath, wStream* s)
 	return TRUE;
 }
 
-int fastpath_recv_inputs(rdpFastPath* fastpath, wStream* s)
+state_run_t fastpath_recv_inputs(rdpFastPath* fastpath, wStream* s)
 {
 	BYTE i;
 
@@ -846,7 +846,7 @@ int fastpath_recv_inputs(rdpFastPath* fastpath, wStream* s)
 		 * as one additional byte here.
 		 */
 		if (!Stream_CheckAndLogRequiredLength(TAG, s, 1))
-			return -1;
+			return STATE_RUN_FAILED;
 
 		Stream_Read_UINT8(s, fastpath->numberEvents); /* eventHeader (1 byte) */
 	}
@@ -854,10 +854,10 @@ int fastpath_recv_inputs(rdpFastPath* fastpath, wStream* s)
 	for (i = 0; i < fastpath->numberEvents; i++)
 	{
 		if (!fastpath_recv_input_event(fastpath, s))
-			return -1;
+			return STATE_RUN_FAILED;
 	}
 
-	return 0;
+	return STATE_RUN_SUCCESS;
 }
 
 static UINT32 fastpath_get_sec_bytes(rdpRdp* rdp)

--- a/libfreerdp/core/heartbeat.c
+++ b/libfreerdp/core/heartbeat.c
@@ -23,7 +23,7 @@
 
 #include "heartbeat.h"
 
-int rdp_recv_heartbeat_packet(rdpRdp* rdp, wStream* s)
+state_run_t rdp_recv_heartbeat_packet(rdpRdp* rdp, wStream* s)
 {
 	BYTE reserved;
 	BYTE period;
@@ -36,7 +36,7 @@ int rdp_recv_heartbeat_packet(rdpRdp* rdp, wStream* s)
 	WINPR_ASSERT(s);
 
 	if (!Stream_CheckAndLogRequiredLength(AUTODETECT_TAG, s, 4))
-		return -1;
+		return STATE_RUN_FAILED;
 
 	Stream_Read_UINT8(s, reserved); /* reserved (1 byte) */
 	Stream_Read_UINT8(s, period);   /* period (1 byte) */
@@ -52,10 +52,10 @@ int rdp_recv_heartbeat_packet(rdpRdp* rdp, wStream* s)
 	if (!rc)
 	{
 		WLog_ERR(HEARTBEAT_TAG, "heartbeat->ServerHeartbeat callback failed!");
-		return -1;
+		return STATE_RUN_FAILED;
 	}
 
-	return 0;
+	return STATE_RUN_SUCCESS;
 }
 
 BOOL freerdp_heartbeat_send_heartbeat_pdu(freerdp_peer* peer, BYTE period, BYTE count1, BYTE count2)

--- a/libfreerdp/core/heartbeat.h
+++ b/libfreerdp/core/heartbeat.h
@@ -29,7 +29,9 @@
 
 #include <winpr/stream.h>
 
-int rdp_recv_heartbeat_packet(rdpRdp* rdp, wStream* s);
+#include "state.h"
+
+FREERDP_LOCAL state_run_t rdp_recv_heartbeat_packet(rdpRdp* rdp, wStream* s);
 
 FREERDP_LOCAL rdpHeartbeat* heartbeat_new(void);
 FREERDP_LOCAL void heartbeat_free(rdpHeartbeat* heartbeat);

--- a/libfreerdp/core/license.h
+++ b/libfreerdp/core/license.h
@@ -23,6 +23,7 @@
 #define FREERDP_LIB_CORE_LICENSE_H
 
 #include "rdp.h"
+#include "state.h"
 
 #include <freerdp/crypto/crypto.h>
 #include <freerdp/crypto/certificate.h>
@@ -58,7 +59,7 @@ typedef struct
 
 FREERDP_LOCAL BOOL license_send_valid_client_error_packet(rdpRdp* rdp);
 
-FREERDP_LOCAL int license_recv(rdpLicense* license, wStream* s);
+FREERDP_LOCAL state_run_t license_recv(rdpLicense* license, wStream* s);
 
 /* the configuration is applied from settings. Set FreeRDP_ServerLicense* settings */
 FREERDP_LOCAL BOOL license_server_configure(rdpLicense* license);

--- a/libfreerdp/core/multitransport.c
+++ b/libfreerdp/core/multitransport.c
@@ -72,12 +72,12 @@ static BOOL multitransport_compare(const rdpMultitransport* srv, const rdpMultit
 	return TRUE;
 }
 
-int multitransport_client_recv_request(rdpMultitransport* multitransport, wStream* s)
+state_run_t multitransport_client_recv_request(rdpMultitransport* multitransport, wStream* s)
 {
 	WINPR_ASSERT(multitransport);
 
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, 24))
-		return -1;
+		return STATE_RUN_FAILED;
 
 	Stream_Read_UINT32(s, multitransport->requestId);         /* requestId (4 bytes) */
 	Stream_Read_UINT16(s, multitransport->requestedProtocol); /* requestedProtocol (2 bytes) */
@@ -85,7 +85,7 @@ int multitransport_client_recv_request(rdpMultitransport* multitransport, wStrea
 	Stream_Read(s, multitransport->securityCookie,
 	            sizeof(multitransport->securityCookie)); /* securityCookie (16 bytes) */
 
-	return 0;
+	return STATE_RUN_SUCCESS;
 }
 
 BOOL multitransport_server_send_request(rdpMultitransport* multitransport)

--- a/libfreerdp/core/multitransport.h
+++ b/libfreerdp/core/multitransport.h
@@ -23,6 +23,7 @@
 typedef struct rdp_multitransport rdpMultitransport;
 
 #include "rdp.h"
+#include "state.h"
 
 #include <freerdp/freerdp.h>
 #include <freerdp/api.h>
@@ -35,7 +36,8 @@ typedef enum
 	INITIATE_REQUEST_PROTOCOL_UDPFECL = 0x02
 } MultitransportRequestProtocol;
 
-FREERDP_LOCAL int multitransport_client_recv_request(rdpMultitransport* multitransport, wStream* s);
+FREERDP_LOCAL state_run_t multitransport_client_recv_request(rdpMultitransport* multitransport,
+                                                             wStream* s);
 FREERDP_LOCAL BOOL multitransport_server_send_request(rdpMultitransport* multitransport);
 
 FREERDP_LOCAL BOOL multitransport_server_recv_response(rdpMultitransport* multitransport,

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -230,7 +230,7 @@ FREERDP_LOCAL BOOL rdp_send_pdu(rdpRdp* rdp, wStream* s, UINT16 type, UINT16 cha
 
 FREERDP_LOCAL wStream* rdp_data_pdu_init(rdpRdp* rdp);
 FREERDP_LOCAL BOOL rdp_send_data_pdu(rdpRdp* rdp, wStream* s, BYTE type, UINT16 channel_id);
-FREERDP_LOCAL int rdp_recv_data_pdu(rdpRdp* rdp, wStream* s);
+FREERDP_LOCAL state_run_t rdp_recv_data_pdu(rdpRdp* rdp, wStream* s);
 
 FREERDP_LOCAL BOOL rdp_send(rdpRdp* rdp, wStream* s, UINT16 channelId);
 
@@ -241,11 +241,12 @@ FREERDP_LOCAL BOOL rdp_channel_send_packet(rdpRdp* rdp, UINT16 channelId, size_t
 
 FREERDP_LOCAL wStream* rdp_message_channel_pdu_init(rdpRdp* rdp);
 FREERDP_LOCAL BOOL rdp_send_message_channel_pdu(rdpRdp* rdp, wStream* s, UINT16 sec_flags);
-FREERDP_LOCAL int rdp_recv_message_channel_pdu(rdpRdp* rdp, wStream* s, UINT16 securityFlags);
+FREERDP_LOCAL state_run_t rdp_recv_message_channel_pdu(rdpRdp* rdp, wStream* s,
+                                                       UINT16 securityFlags);
 
-FREERDP_LOCAL int rdp_recv_out_of_sequence_pdu(rdpRdp* rdp, wStream* s);
+FREERDP_LOCAL state_run_t rdp_recv_out_of_sequence_pdu(rdpRdp* rdp, wStream* s);
 
-FREERDP_LOCAL int rdp_recv_callback(rdpTransport* transport, wStream* s, void* extra);
+FREERDP_LOCAL state_run_t rdp_recv_callback(rdpTransport* transport, wStream* s, void* extra);
 
 FREERDP_LOCAL int rdp_check_fds(rdpRdp* rdp);
 

--- a/libfreerdp/core/redirection.h
+++ b/libfreerdp/core/redirection.h
@@ -31,7 +31,7 @@ typedef struct rdp_redirection rdpRedirection;
 #include <winpr/wlog.h>
 #include <winpr/stream.h>
 
-FREERDP_LOCAL int rdp_recv_enhanced_security_redirection_packet(rdpRdp* rdp, wStream* s);
+FREERDP_LOCAL state_run_t rdp_recv_enhanced_security_redirection_packet(rdpRdp* rdp, wStream* s);
 
 FREERDP_LOCAL int rdp_redirection_apply_settings(rdpRdp* rdp);
 

--- a/libfreerdp/core/state.c
+++ b/libfreerdp/core/state.c
@@ -1,0 +1,69 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ *
+ * RDP state machine types and helper functions
+ *
+ * Copyright 2022 Armin Novak <anovak@thincast.com>
+ * Copyright 2022 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "state.h"
+
+#include <winpr/string.h>
+
+BOOL state_run_failed(state_run_t status)
+{
+	return status == STATE_RUN_FAILED;
+}
+
+BOOL state_run_success(state_run_t status)
+{
+	if (status == STATE_RUN_CONTINUE)
+		return TRUE;
+	return status >= STATE_RUN_SUCCESS;
+}
+
+const char* state_run_result_string(state_run_t status, char* buffer, size_t buffersize)
+{
+	const char* name;
+
+	switch (status)
+	{
+		case STATE_RUN_ACTIVE:
+			name = "STATE_RUN_ACTIVE";
+			break;
+		case STATE_RUN_REDIRECT:
+			name = "STATE_RUN_REDIRECT";
+			break;
+		case STATE_RUN_SUCCESS:
+			name = "STATE_RUN_SUCCESS";
+			break;
+		case STATE_RUN_FAILED:
+			name = "STATE_RUN_FAILED";
+			break;
+		case STATE_RUN_TRY_AGAIN:
+			name = "STATE_RUN_TRY_AGAIN";
+			break;
+		case STATE_RUN_CONTINUE:
+			name = "STATE_RUN_CONTINUE";
+			break;
+		default:
+			name = "STATE_RUN_UNKNOWN";
+			break;
+	}
+
+	_snprintf(buffer, buffersize, "%s [%d]", name, status);
+	return buffer;
+}

--- a/libfreerdp/core/state.h
+++ b/libfreerdp/core/state.h
@@ -1,0 +1,43 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ *
+ * RDP state machine types and helper functions
+ *
+ * Copyright 2022 Armin Novak <anovak@thincast.com>
+ * Copyright 2022 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_LIB_CORE_STATE_H
+#define FREERDP_LIB_CORE_STATE_H
+
+#include <winpr/wtypes.h>
+#include <freerdp/api.h>
+
+typedef enum
+{
+	STATE_RUN_ACTIVE = 2,
+	STATE_RUN_REDIRECT = 1,
+	STATE_RUN_SUCCESS = 0,
+	STATE_RUN_FAILED = -1,
+	STATE_RUN_TRY_AGAIN = -23,
+	STATE_RUN_CONTINUE = -24
+} state_run_t;
+
+FREERDP_LOCAL BOOL state_run_failed(state_run_t status);
+FREERDP_LOCAL BOOL state_run_success(state_run_t status);
+FREERDP_LOCAL const char* state_run_result_string(state_run_t status, char* buffer,
+                                                  size_t buffersize);
+
+#endif /* FREERDP_LIB_CORE_STATE_H */

--- a/libfreerdp/core/transport.h
+++ b/libfreerdp/core/transport.h
@@ -50,7 +50,9 @@ typedef enum
 #include <freerdp/settings.h>
 #include <freerdp/transport_io.h>
 
-typedef int (*TransportRecv)(rdpTransport* transport, wStream* stream, void* extra);
+#include "state.h"
+
+typedef state_run_t (*TransportRecv)(rdpTransport* transport, wStream* stream, void* extra);
 
 FREERDP_LOCAL wStream* transport_send_stream_init(rdpTransport* transport, size_t size);
 FREERDP_LOCAL BOOL transport_connect(rdpTransport* transport, const char* hostname, UINT16 port,


### PR DESCRIPTION
Up to this commit the client and server state machine handling used different return values for state machine changes. This is fixed with this commit:
* Use common enum return values
* Use common helper functions
