### PR TITLE
fix use of return code from list_provider_keys()

### DIFF
--- a/libfreerdp/core/smartcardlogon.c
+++ b/libfreerdp/core/smartcardlogon.c
@@ -460,7 +460,7 @@ static BOOL smartcard_hw_enumerateCerts(const rdpSettings* settings, LPCWSTR csp
 		status = list_provider_keys(settings, provider, csp, scope, userFilter, domainFilter,
 		                            &cert_list, &count);
 		NCryptFreeObject((NCRYPT_HANDLE)provider);
-		if (status != ERROR_SUCCESS)
+		if (!status)
 		{
 			WLog_ERR(TAG, "error listing keys from CSP loaded from %s", Pkcs11Module);
 			goto out;


### PR DESCRIPTION
`list_provider_keys()` returns a Boolean, true == success. But `smartcard_hw_enumerateCerts()` expects the return value on success to be `ERROR_SUCCESS == 0`, and so inverts success/failure.

I ran into this while getting the new PKINIT-in-NLA support to work with a hardware token.