### PR TITLE
autodetect: prepare for multi-transport

### DIFF
--- a/include/freerdp/autodetect.h
+++ b/include/freerdp/autodetect.h
@@ -30,18 +30,26 @@ extern "C"
 #endif
 	typedef struct rdp_autodetect rdpAutoDetect;
 
-	typedef BOOL (*pRTTMeasureRequest)(rdpAutoDetect* autodetect, UINT16 sequenceNumber);
-	typedef BOOL (*pRTTMeasureResponse)(rdpAutoDetect* autodetect, UINT16 sequenceNumber);
-	typedef BOOL (*pBandwidthMeasureStart)(rdpAutoDetect* autodetect, UINT16 sequenceNumber);
-	typedef BOOL (*pBandwidthMeasureStop)(rdpAutoDetect* autodetect, UINT16 sequenceNumber);
-	typedef BOOL (*pBandwidthMeasureResults)(rdpAutoDetect* autodetect, UINT16 responseType,
+	typedef BOOL (*pRTTMeasureRequest)(rdpAutoDetect* autodetect, RDP_TRANSPORT_TYPE transport,
+	                                   UINT16 sequenceNumber);
+	typedef BOOL (*pRTTMeasureResponse)(rdpAutoDetect* autodetect, RDP_TRANSPORT_TYPE transport,
+	                                    UINT16 sequenceNumber);
+	typedef BOOL (*pBandwidthMeasureStart)(rdpAutoDetect* autodetect, RDP_TRANSPORT_TYPE transport,
+	                                       UINT16 sequenceNumber);
+	typedef BOOL (*pBandwidthMeasureStop)(rdpAutoDetect* autodetect, RDP_TRANSPORT_TYPE transport,
+	                                      UINT16 sequenceNumber);
+	typedef BOOL (*pBandwidthMeasureResults)(rdpAutoDetect* autodetect,
+	                                         RDP_TRANSPORT_TYPE transport, UINT16 responseType,
 	                                         UINT16 sequenceNumber);
-	typedef BOOL (*pNetworkCharacteristicsResult)(rdpAutoDetect* autodetect, UINT16 sequenceNumber);
-	typedef BOOL (*pClientBandwidthMeasureResult)(rdpAutoDetect* autodetect, UINT16 responseType,
+	typedef BOOL (*pNetworkCharacteristicsResult)(rdpAutoDetect* autodetect,
+	                                              RDP_TRANSPORT_TYPE transport,
+	                                              UINT16 sequenceNumber);
+	typedef BOOL (*pClientBandwidthMeasureResult)(rdpAutoDetect* autodetect,
+	                                              RDP_TRANSPORT_TYPE transport, UINT16 responseType,
 	                                              UINT16 sequenceNumber, UINT32 timeDelta,
 	                                              UINT32 byteCount);
-	typedef BOOL (*pRxTxReceived)(rdpAutoDetect* autodetect, UINT16 requestType,
-	                              UINT16 sequenceNumber);
+	typedef BOOL (*pRxTxReceived)(rdpAutoDetect* autodetect, RDP_TRANSPORT_TYPE transport,
+	                              UINT16 requestType, UINT16 sequenceNumber);
 
 	struct rdp_autodetect
 	{

--- a/include/freerdp/types.h
+++ b/include/freerdp/types.h
@@ -77,6 +77,14 @@ typedef struct
 	UINT32 height;
 } RECTANGLE_32;
 
+/** @brief type of RDP transport */
+typedef enum
+{
+	RDP_TRANSPORT_TCP = 0,
+	RDP_TRANSPORT_UDP_R,
+	RDP_TRANSPORT_UDP_L
+} RDP_TRANSPORT_TYPE;
+
 /* Plugin events */
 
 #include <freerdp/message.h>

--- a/libfreerdp/core/autodetect.h
+++ b/libfreerdp/core/autodetect.h
@@ -43,20 +43,26 @@ typedef enum
 
 FREERDP_LOCAL rdpAutoDetect* autodetect_new(rdpContext* context);
 FREERDP_LOCAL void autodetect_free(rdpAutoDetect* autodetect);
-FREERDP_LOCAL state_run_t autodetect_recv_request_packet(rdpAutoDetect* autodetect, wStream* s);
-FREERDP_LOCAL state_run_t autodetect_recv_response_packet(rdpAutoDetect* autodetect, wStream* s);
+FREERDP_LOCAL state_run_t autodetect_recv_request_packet(rdpAutoDetect* autodetect,
+                                                         RDP_TRANSPORT_TYPE transport, wStream* s);
+FREERDP_LOCAL state_run_t autodetect_recv_response_packet(rdpAutoDetect* autodetect,
+                                                          RDP_TRANSPORT_TYPE transport, wStream* s);
 
 FREERDP_LOCAL AUTODETECT_STATE autodetect_get_state(rdpAutoDetect* autodetect);
 
 FREERDP_LOCAL void autodetect_register_server_callbacks(rdpAutoDetect* autodetect);
 FREERDP_LOCAL BOOL autodetect_send_connecttime_rtt_measure_request(rdpAutoDetect* autodetect,
+                                                                   RDP_TRANSPORT_TYPE transport,
                                                                    UINT16 sequenceNumber);
 FREERDP_LOCAL BOOL autodetect_send_connecttime_bandwidth_measure_start(rdpAutoDetect* autodetect,
+                                                                       RDP_TRANSPORT_TYPE transport,
                                                                        UINT16 sequenceNumber);
 FREERDP_LOCAL BOOL autodetect_send_bandwidth_measure_payload(rdpAutoDetect* autodetect,
+                                                             RDP_TRANSPORT_TYPE transport,
                                                              UINT16 payloadLength,
                                                              UINT16 sequenceNumber);
 FREERDP_LOCAL BOOL autodetect_send_connecttime_bandwidth_measure_stop(rdpAutoDetect* autodetect,
+                                                                      RDP_TRANSPORT_TYPE transport,
                                                                       UINT16 payloadLength,
                                                                       UINT16 sequenceNumber);
 

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -541,7 +541,8 @@ static state_run_t peer_recv_handle_auto_detect(freerdp_peer* client, wStream* s
 		{
 			case CONNECTION_STATE_CONNECT_TIME_AUTO_DETECT_REQUEST:
 			{
-				if (autodetect_send_connecttime_rtt_measure_request(rdp->autodetect, 0x23))
+				if (autodetect_send_connecttime_rtt_measure_request(rdp->autodetect,
+				                                                    RDP_TRANSPORT_TCP, 0x23))
 					ret = STATE_RUN_SUCCESS;
 				rdp_server_transition_to_state(rdp,
 				                               CONNECTION_STATE_CONNECT_TIME_AUTO_DETECT_RESPONSE);

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1179,13 +1179,13 @@ state_run_t rdp_recv_message_channel_pdu(rdpRdp* rdp, wStream* s, UINT16 securit
 	if (securityFlags & SEC_AUTODETECT_REQ)
 	{
 		/* Server Auto-Detect Request PDU */
-		return autodetect_recv_request_packet(rdp->autodetect, s);
+		return autodetect_recv_request_packet(rdp->autodetect, RDP_TRANSPORT_TCP, s);
 	}
 
 	if (securityFlags & SEC_AUTODETECT_RSP)
 	{
 		/* Client Auto-Detect Response PDU */
-		return autodetect_recv_response_packet(rdp->autodetect, s);
+		return autodetect_recv_response_packet(rdp->autodetect, RDP_TRANSPORT_TCP, s);
 	}
 
 	if (securityFlags & SEC_HEARTBEAT)


### PR DESCRIPTION
Autodetect packets can be transported either in TCP TPKT packets or be contained in multi-transport subheaders (transported on UDP). These changes do the appropriate modifications so that in further developments we can take the transport type in account when treating / writing these packets.