### PR TITLE
[capabilities] properly set RemoteFxOnly

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -2780,7 +2780,7 @@ static BOOL rdp_read_bitmap_codecs_capability_set(wStream* s, rdpSettings* setti
 				Stream_Read_UINT32(&sub, captureFlags);   /* captureFlags (4 bytes) */
 				Stream_Read_UINT32(&sub, rfxCapsLength);  /* capsLength (4 bytes) */
 				settings->RemoteFxCaptureFlags = captureFlags;
-				settings->RemoteFxOnly = (captureFlags & CARDP_CAPS_CAPTURE_NON_CAC) ? TRUE : FALSE;
+				settings->RemoteFxOnly = (captureFlags & CARDP_CAPS_CAPTURE_NON_CAC) ? FALSE : TRUE;
 
 				if (rfxCapsLength)
 				{


### PR DESCRIPTION
The check was inverted, setting the flag properly now

(cherry picked from commit 73a722ec8e887d2f61bc8f80a9696701a07f84ae)

Backport of #8403 