### PR TITLE
Fix wlfreerdp pointer cursors

### DIFF
--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -134,7 +134,7 @@ static UwacReturnCode set_cursor_image(UwacSeat* seat, uint32_t serial)
 
 	if (surface && buffer)
 	{
-		wl_surface_attach(surface, buffer, -x, -y);
+		wl_surface_attach(surface, buffer, 0, 0);
 		wl_surface_damage(surface, 0, 0, image->width, image->height);
 		wl_surface_commit(surface);
 	}

--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -729,6 +729,7 @@ static void pointer_handle_enter(void* data, struct wl_pointer* pointer, uint32_
 	}
 
 	input->display->serial = serial;
+	input->display->pointer_focus_serial = serial;
 	window = wl_surface_get_user_data(surface);
 	if (window)
 		window->pointer_enter_serial = serial;
@@ -1191,5 +1192,5 @@ UwacReturnCode UwacSeatSetMouseCursor(UwacSeat* seat, const void* data, size_t l
 	}
 	if (seat && !seat->default_cursor)
 		return UWAC_SUCCESS;
-	return set_cursor_image(seat, seat->display->serial);
+	return set_cursor_image(seat, seat->display->pointer_focus_serial);
 }

--- a/uwac/libuwac/uwac-priv.h
+++ b/uwac/libuwac/uwac-priv.h
@@ -121,6 +121,7 @@ struct uwac_display
 	bool running;
 	UwacTask dispatch_fd_task;
 	uint32_t serial;
+	uint32_t pointer_focus_serial;
 
 	struct wl_list windows;
 


### PR DESCRIPTION
Two commits:

    uwac/input: Set the right serial when setting cursor
    
    The serial in wl_pointer.set_cursor must exactly match the one from
    wl_pointer.enter, it should not use whatever serial for any input class


and


    uwac/input: Don't pass hotspot as offset when attaching cursor buffer
    
    Passing a non-zero offset to cursor buffer and then calling
    wl_pointer.set_cursor doesn't make much sense, as any offset will
    immediately be reset. The protocol specifies the cursor set by
    wl_pointer.set_cursor to be
    
    > The parameters hotspot_x and hotspot_y define the position of
    > the pointer surface relative to the pointer location. Its
    > top-left corner is always at (x, y) - (hotspot_x, hotspot_y),
    > where (x, y) are the coordinates of the pointer location, in
    > surface-local coordinates.
    
    This leaves no room available for any previously set offsets to be kept
