### PR TITLE
winpr/string.h: #include <stdio.h> for snprintf

### DIFF
--- a/winpr/include/winpr/string.h
+++ b/winpr/include/winpr/string.h
@@ -22,6 +22,7 @@
 #define WINPR_CRT_STRING_H
 
 #include <wchar.h>
+#include <stdio.h>
 #include <string.h>
 #include <winpr/config.h>
 #include <winpr/winpr.h>


### PR DESCRIPTION
Fixes failure with -Werror=implicit-function-declaration.

```
FAILED: libfreerdp/CMakeFiles/freerdp.dir/core/state.c.o
/usr/bin/ccache /usr/bin/cc -DEXT_PATH=\"/usr/local/lib64/freerdp3/extensions\" -DFREERDP_EXPORTS -DNDEBUG -DWITH_OPENSSL -DWITH_VERBOSE_WINPR_ASSERT -DWITH_WAYLAND -DWITH_X11 -DWITH_XKBFILE -D_FILE_OFFSET_BITS=64 -Dfreerdp_EXPORTS -I/home/floppym/src/FreeRDP/winpr/include -I/home/floppym/src/FreeRDP/build/winpr/include -I/home/floppym/src/FreeRDP/build -I/home/floppym/src/FreeRDP/build/include -I/home/floppym/src/FreeRDP/include -Werror=implicit-function-declaration -fPIC -Wall -fvisibility=hidden -Wimplicit-function-declaration -Wredundant-decls -fno-omit-frame-pointer -O3 -DNDEBUG -flto=auto -fno-fat-lto-objects -fPIC -std=gnu11 -MD -MT libfreerdp/CMakeFiles/freerdp.dir/core/state.c.o -MF libfreerdp/CMakeFiles/freerdp.dir/core/state.c.o.d -o libfreerdp/CMakeFiles/freerdp.dir/core/state.c.o -c /home/floppym/src/FreeRDP/libfreerdp/core/state.c
In file included from /home/floppym/src/FreeRDP/libfreerdp/core/state.c:24:
/home/floppym/src/FreeRDP/libfreerdp/core/state.c: In function ‘state_run_result_string’:
/home/floppym/src/FreeRDP/winpr/include/winpr/string.h:186:19: error: implicit declaration of function ‘snprintf’ [-Werror=implicit-function-declaration]
  186 | #define _snprintf snprintf
      |                   ^~~~~~~~
/home/floppym/src/FreeRDP/libfreerdp/core/state.c:67:9: note: in expansion of macro ‘_snprintf’
   67 |         _snprintf(buffer, buffersize, "%s [%d]", name, status);
      |         ^~~~~~~~~
/home/floppym/src/FreeRDP/libfreerdp/core/state.c:25:1: note: include ‘<stdio.h>’ or provide a declaration of ‘snprintf’
   24 | #include <winpr/string.h>
  +++ |+#include <stdio.h>
   25 |
/home/floppym/src/FreeRDP/winpr/include/winpr/string.h:186:19: warning: incompatible implicit declaration of built-in function ‘snprintf’ [-Wbuiltin-declaration-mismatch]
  186 | #define _snprintf snprintf
      |                   ^~~~~~~~
/home/floppym/src/FreeRDP/libfreerdp/core/state.c:67:9: note: in expansion of macro ‘_snprintf’
   67 |         _snprintf(buffer, buffersize, "%s [%d]", name, status);
      |         ^~~~~~~~~
/home/floppym/src/FreeRDP/winpr/include/winpr/string.h:186:19: note: include ‘<stdio.h>’ or provide a declaration of ‘snprintf’
  186 | #define _snprintf snprintf
      |                   ^~~~~~~~
/home/floppym/src/FreeRDP/libfreerdp/core/state.c:67:9: note: in expansion of macro ‘_snprintf’
   67 |         _snprintf(buffer, buffersize, "%s [%d]", name, status);
      |         ^~~~~~~~~
cc1: some warnings being treated as errors
```

Bug: https://bugs.gentoo.org/881695