### PR TITLE
[build] Build debian nightly with ninja

### DIFF
--- a/packaging/deb/freerdp-nightly/control
+++ b/packaging/deb/freerdp-nightly/control
@@ -12,6 +12,7 @@ Build-Depends:
  libssl-dev,
  docbook-xsl,
  xsltproc,
+ ninja-build,
  libxkbcommon-dev,
  libxkbfile-dev,
  libx11-dev,

--- a/packaging/deb/freerdp-nightly/rules
+++ b/packaging/deb/freerdp-nightly/rules
@@ -6,7 +6,8 @@ DEB_HOST_ARCH=$(shell dpkg-architecture -qDEB_HOST_ARCH)
 
 SANATIZE_ADDRESS = -DWITH_SANITIZE_ADDRESS=ON
 
-DEB_CMAKE_EXTRA_FLAGS :=  -DCMAKE_SKIP_RPATH=FALSE \
+DEB_CMAKE_EXTRA_FLAGS :=  -GNinja \
+                          -DCMAKE_SKIP_RPATH=FALSE \
                           -DCMAKE_SKIP_INSTALL_RPATH=FALSE \
                           -DWITH_PULSE=ON \
                           -DWITH_CHANNELS=ON \


### PR DESCRIPTION
Use `ninja` to build debian packages.
speeds up build a bit