### PR TITLE
[codec] fixed region16_union_rect

### DIFF
--- a/libfreerdp/codec/region.c
+++ b/libfreerdp/codec/region.c
@@ -496,7 +496,6 @@ BOOL region16_union_rect(REGION16* dst, const REGION16* src, const RECTANGLE_16*
 	UINT32 usedRects, srcNbRects;
 	UINT16 topInterBand;
 	WINPR_ASSERT(src);
-	WINPR_ASSERT(src->data);
 	WINPR_ASSERT(dst);
 	srcExtents = region16_extents(src);
 	dstExtents = region16_extents_noconst(dst);
@@ -658,8 +657,8 @@ BOOL region16_union_rect(REGION16* dst, const REGION16* src, const RECTANGLE_16*
 		dstRect++;
 	}
 
-	if ((src == dst) && (src->data->size > 0) && (src->data != &empty_region))
-		free(src->data);
+	if ((src == dst) && (dst->data != &empty_region))
+		free(dst->data);
 
 	dstExtents->top = MIN(rect->top, srcExtents->top);
 	dstExtents->left = MIN(rect->left, srcExtents->left);
@@ -673,10 +672,7 @@ BOOL region16_union_rect(REGION16* dst, const REGION16* src, const RECTANGLE_16*
 	dst->data = newItems;
 
 	if (!dst->data)
-	{
-		free(newItems);
 		return FALSE;
-	}
 
 	dst->data->nbRects = usedRects;
 	return region16_simplify_bands(dst);


### PR DESCRIPTION
* If source and destination are equal, free the buffer on destination to avoid compiler warnings.
* Remove assert that is not required

