### PR TITLE
[crypto] Added sha3 define guards

### DIFF
--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -1202,6 +1202,7 @@ WINPR_MD_TYPE crypto_cert_get_signature_alg(X509* xcert)
 			return WINPR_MD_SHA512;
 		case NID_ripemd160:
 			return WINPR_MD_RIPEMD160;
+#if (OPENSSL_VERSION_NUMBER >= 0x1010101fL) || defined(LIBRESSL_VERSION_NUMBER)
 		case NID_sha3_224:
 			return WINPR_MD_SHA3_224;
 		case NID_sha3_256:
@@ -1210,6 +1211,7 @@ WINPR_MD_TYPE crypto_cert_get_signature_alg(X509* xcert)
 			return WINPR_MD_SHA3_384;
 		case NID_sha3_512:
 			return WINPR_MD_SHA3_512;
+#endif
 		case NID_shake128:
 			return WINPR_MD_SHAKE128;
 		case NID_shake256:


### PR DESCRIPTION
sha3 is only supported with OpenSSL 1.1.1a or later
