### PR TITLE
[rdg] fix PAA Rdg-Auth-Scheme header

### DIFF
--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -2744,6 +2744,8 @@ rdpRdg* rdg_new(rdpContext* context)
 					if (!http_context_set_rdg_auth_scheme(rdg->http, "PAA"))
 						goto rdg_alloc_error;
 
+					break;
+
 				case HTTP_EXTENDED_AUTH_SSPI_NTLM:
 					if (!http_context_set_rdg_auth_scheme(rdg->http, "SSPI_NTLM"))
 						goto rdg_alloc_error;


### PR DESCRIPTION
when implementing EXTAUTH_SSPI_NTLM I accidentally forgot a break statement.
This effectively broke PAA / GatewayAccessToken authentication