### PR TITLE
Disable dh_auto_test as tests are not build

### DIFF
--- a/packaging/deb/freerdp-nightly/rules
+++ b/packaging/deb/freerdp-nightly/rules
@@ -49,6 +49,8 @@ override_dh_install:
 
 	dh_install --fail-missing
 
+override_dh_auto_test:
+
 override_dh_clean:
 	rm -f config.h
 	dh_clean


### PR DESCRIPTION
the debian package is build with `-DBUILD_TESTING=OFF` and `dh_auto_test` issues the command `ninja test` which fails as the target does not exist.
This pull request disables `dh_auto_test` as we don´t want to enable test builds in production code (the build would expose all library symbols instead only public API functions)