### PR TITLE
[packaging] return true in dh_auto_test

### DIFF
--- a/packaging/deb/freerdp-nightly/rules
+++ b/packaging/deb/freerdp-nightly/rules
@@ -50,6 +50,7 @@ override_dh_install:
 	dh_install --fail-missing
 
 override_dh_auto_test:
+	true
 
 override_dh_clean:
 	rm -f config.h


### PR DESCRIPTION
We do not build the unit tests for nightly packages as that would change the API, so always return true for test result
