### PR TITLE
[packaging] fix debian rules

### DIFF
--- a/packaging/deb/freerdp-nightly/rules
+++ b/packaging/deb/freerdp-nightly/rules
@@ -43,11 +43,14 @@ override_dh_shlibdeps:
 override_dh_strip:
 	dh_strip --dbg-package=freerdp-nightly-dbg
 
+override_dh_missing:
+	dh_missing --fail-missing
+
 override_dh_install:
 	mkdir -p debian/tmp/opt/freerdp-nightly/lib/cmake/
 	rm -rf debian/tmp/opt/freerdp-nightly/lib/freerdp3/*.a
 
-	dh_install --fail-missing
+	dh_install
 
 override_dh_auto_test:
 	true


### PR DESCRIPTION
dh_install --fail-missing was replaced by dh_missing --fail-missing
