### PR TITLE
[winpr,crt] fix unicode conversion functions

### DIFF
--- a/winpr/libwinpr/crt/unicode_android.c
+++ b/winpr/libwinpr/crt/unicode_android.c
@@ -86,6 +86,11 @@ static int convert_int(JNIEnv* env, const void* data, size_t size, void* buffer,
 	jsize rlen = (*env)->GetArrayLength(env, res);
 	if (buffersize > 0)
 	{
+		if (rlen > buffersize)
+		{
+			SetLastError(ERROR_INSUFFICIENT_BUFFER);
+			return 0;
+		}
 		rlen = MIN(rlen, buffersize);
 		(*env)->GetByteArrayRegion(env, res, 0, rlen, buffer);
 	}
@@ -129,11 +134,7 @@ int int_MultiByteToWideChar(UINT CodePage, DWORD dwFlags, LPCSTR lpMultiByteStr,
 		cbCharLen = (int)len + 1;
 	}
 	else
-	{
-		cbCharLen = strnlen(lpMultiByteStr, cbMultiByte);
-		if (cbCharLen < cbMultiByte)
-			cbCharLen++;
-	}
+		cbCharLen = cbMultiByte;
 
 	WINPR_ASSERT(lpMultiByteStr);
 	switch (CodePage)
@@ -174,11 +175,7 @@ int int_WideCharToMultiByte(UINT CodePage, DWORD dwFlags, LPCWSTR lpWideCharStr,
 		cbCharLen = (int)len + 1;
 	}
 	else
-	{
-		cbCharLen = (int)_wcsnlen(lpWideCharStr, cchWideChar);
-		if (cbCharLen < cchWideChar)
-			cbCharLen++;
-	}
+		cbCharLen = cchWideChar;
 
 	/*
 	 * if cbMultiByte is 0, the function returns the required buffer size

--- a/winpr/libwinpr/crt/unicode_icu.c
+++ b/winpr/libwinpr/crt/unicode_icu.c
@@ -44,7 +44,7 @@
 int int_MultiByteToWideChar(UINT CodePage, DWORD dwFlags, LPCSTR lpMultiByteStr, int cbMultiByte,
                             LPWSTR lpWideCharStr, int cchWideChar)
 {
-	BOOL isNullTerminated = TRUE;
+	const BOOL isNullTerminated = cbMultiByte < 0;
 	LPWSTR targetStart;
 
 	WINPR_UNUSED(dwFlags);
@@ -55,18 +55,15 @@ int int_MultiByteToWideChar(UINT CodePage, DWORD dwFlags, LPCSTR lpMultiByteStr,
 		return 0;
 
 	size_t len;
-	if (cbMultiByte == -1)
+	if (isNullTerminated)
 		len = strlen(lpMultiByteStr) + 1;
 	else
-	{
-		len = strnlen(lpMultiByteStr, cbMultiByte);
-		isNullTerminated = (len < cbMultiByte);
-		if (isNullTerminated)
-			len++;
-	}
+		len = cbMultiByte;
+
 	if (len >= INT_MAX)
 		return -1;
 	cbMultiByte = (int)len;
+
 	/*
 	 * if cchWideChar is 0, the function returns the required buffer size
 	 * in characters for lpWideCharStr and makes no use of the output parameter itself.
@@ -136,7 +133,6 @@ int int_WideCharToMultiByte(UINT CodePage, DWORD dwFlags, LPCWSTR lpWideCharStr,
                             LPSTR lpMultiByteStr, int cbMultiByte, LPCSTR lpDefaultChar,
                             LPBOOL lpUsedDefaultChar)
 {
-	BOOL isNullTerminated = TRUE;
 	char* targetStart;
 
 	/* If cchWideChar is 0, the function fails */
@@ -150,12 +146,7 @@ int int_WideCharToMultiByte(UINT CodePage, DWORD dwFlags, LPCWSTR lpWideCharStr,
 	if (cchWideChar == -1)
 		len = _wcslen(lpWideCharStr) + 1;
 	else
-	{
-		len = _wcsnlen(lpWideCharStr, cchWideChar);
-		isNullTerminated = len < cchWideChar;
-		if (isNullTerminated)
-			len++;
-	}
+		len = cchWideChar;
 
 	if (len >= INT32_MAX)
 		return 0;


### PR DESCRIPTION
There are subtle differences between MultiByteToWideChar, WideCharToMultibyte and the ICU equivalents
