### PR TITLE
rdp: notify the Activate state as soon as it happens

### DIFF
--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1631,6 +1631,9 @@ static state_run_t rdp_handle_sc_flags(rdpRdp* rdp, wStream* s, UINT32 flag,
 		{
 			if (!rdp_client_transition_to_state(rdp, nextState))
 				status = STATE_RUN_FAILED;
+			else
+				status = (rdp_get_state(rdp) == CONNECTION_STATE_ACTIVE) ? STATE_RUN_ACTIVE
+				                                                         : STATE_RUN_SUCCESS;
 		}
 		else
 		{


### PR DESCRIPTION
Without the patch, we parse more packets and the calling code doesn't have the opportunity to invoke PostConnect callback (make the connection not work in the proxy)

