### PR TITLE
[core,update] do not require EndPaint callback

### DIFF
--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -3322,7 +3322,7 @@ BOOL update_begin_paint(rdpUpdate* update)
 
 BOOL update_end_paint(rdpUpdate* update)
 {
-	BOOL rc = FALSE;
+	BOOL rc = TRUE;
 
 	if (!update)
 		return FALSE;


### PR DESCRIPTION
Some RDP servers start sending graphics updates too early for us to process. This triggered a bug that at that point the EndPaint callback is not available, as the connection is not fully established.
