### PR TITLE
proxy: fix channel id shift between front and back

### DIFF
--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -65,6 +65,9 @@ extern "C"
 {
 #endif
 
+#define MCS_BASE_CHANNEL_ID 1001
+#define MCS_GLOBAL_CHANNEL_ID 1003
+
 /* Flags used by certificate callbacks */
 #define VERIFY_CERT_FLAG_NONE 0x00
 #define VERIFY_CERT_FLAG_LEGACY 0x02

--- a/include/freerdp/server/proxy/proxy_context.h
+++ b/include/freerdp/server/proxy/proxy_context.h
@@ -74,7 +74,8 @@ extern "C"
 	struct p_server_static_channel_context
 	{
 		char* channel_name;
-		UINT32 channel_id;
+		UINT32 front_channel_id;
+		UINT32 back_channel_id;
 		pf_utils_channel_mode channelMode;
 		proxyChannelDataFn onFrontData;
 		proxyChannelDataFn onBackData;
@@ -97,7 +98,8 @@ extern "C"
 		HANDLE dynvcReady;
 
 		wHashTable* interceptContextMap;
-		wHashTable* channelsById;
+		wHashTable* channelsByFrontId;
+		wHashTable* channelsByBackId;
 	};
 	typedef struct p_server_context pServerContext;
 

--- a/libfreerdp/core/mcs.h
+++ b/libfreerdp/core/mcs.h
@@ -33,9 +33,6 @@ typedef struct rdp_mcs rdpMcs;
 #include <winpr/stream.h>
 #include <winpr/wtsapi.h>
 
-#define MCS_BASE_CHANNEL_ID 1001
-#define MCS_GLOBAL_CHANNEL_ID 1003
-
 enum MCS_Result
 {
 	MCS_Result_successful = 0,

--- a/server/proxy/channels/pf_channel_rdpdr.c
+++ b/server/proxy/channels/pf_channel_rdpdr.c
@@ -1709,7 +1709,7 @@ static PfChannelResult pf_rdpdr_back_data(proxyData* pdata,
 	WINPR_ASSERT(pdata);
 	WINPR_ASSERT(channel);
 
-	if (!pf_channel_rdpdr_client_handle(pdata->pc, channel->channel_id, channel->channel_name,
+	if (!pf_channel_rdpdr_client_handle(pdata->pc, channel->back_channel_id, channel->channel_name,
 	                                    xdata, xsize, flags, totalSize))
 	{
 		WLog_ERR(TAG, "error treating client back data");
@@ -1731,7 +1731,7 @@ static PfChannelResult pf_rdpdr_front_data(proxyData* pdata,
 	WINPR_ASSERT(pdata);
 	WINPR_ASSERT(channel);
 
-	if (!pf_channel_rdpdr_server_handle(pdata->ps, channel->channel_id, channel->channel_name,
+	if (!pf_channel_rdpdr_server_handle(pdata->ps, channel->front_channel_id, channel->channel_name,
 	                                    xdata, xsize, flags, totalSize))
 	{
 		WLog_ERR(TAG, "error treating front data");

--- a/server/proxy/pf_channel.c
+++ b/server/proxy/pf_channel.c
@@ -160,7 +160,7 @@ PfChannelResult channelTracker_flushCurrent(ChannelStateTracker* t, BOOL first, 
 	{
 		proxyChannelDataEventInfo ev;
 
-		ev.channel_id = channel->channel_id;
+		ev.channel_id = channel->front_channel_id;
 		ev.channel_name = channel->channel_name;
 		ev.data = Stream_Buffer(t->currentPacket);
 		ev.data_len = Stream_GetPosition(t->currentPacket);
@@ -176,7 +176,7 @@ PfChannelResult channelTracker_flushCurrent(ChannelStateTracker* t, BOOL first, 
 
 	ps = pdata->ps;
 	r = ps->context.peer->SendChannelPacket(
-	    ps->context.peer, channel->channel_id, t->currentPacketSize, flags,
+	    ps->context.peer, channel->front_channel_id, t->currentPacketSize, flags,
 	    Stream_Buffer(t->currentPacket), Stream_GetPosition(t->currentPacket));
 
 	return r ? PF_CHANNEL_RESULT_DROP : PF_CHANNEL_RESULT_ERROR;
@@ -195,7 +195,7 @@ static PfChannelResult pf_channel_generic_back_data(proxyData* pdata,
 	switch (channel->channelMode)
 	{
 		case PF_UTILS_CHANNEL_PASSTHROUGH:
-			ev.channel_id = channel->channel_id;
+			ev.channel_id = channel->back_channel_id;
 			ev.channel_name = channel->channel_name;
 			ev.data = xdata;
 			ev.data_len = xsize;
@@ -229,7 +229,7 @@ static PfChannelResult pf_channel_generic_front_data(proxyData* pdata,
 	switch (channel->channelMode)
 	{
 		case PF_UTILS_CHANNEL_PASSTHROUGH:
-			ev.channel_id = channel->channel_id;
+			ev.channel_id = channel->front_channel_id;
 			ev.channel_name = channel->channel_name;
 			ev.data = xdata;
 			ev.data_len = xsize;

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -194,7 +194,6 @@ static BOOL pf_server_setup_channels(freerdp_peer* peer)
 	size_t accepted_channels_count;
 	size_t i;
 	pServerContext* ps = (pServerContext*)peer->context;
-	wHashTable* byId = ps->channelsById;
 
 	accepted_channels = WTSGetAcceptedChannelNames(peer, &accepted_channels_count);
 	if (!accepted_channels)
@@ -243,7 +242,8 @@ static BOOL pf_server_setup_channels(freerdp_peer* peer)
 			}
 		}
 
-		if (!HashTable_Insert(byId, &channelContext->channel_id, channelContext))
+		if (!HashTable_Insert(ps->channelsByFrontId, &channelContext->front_channel_id,
+		                      channelContext))
 		{
 			StaticChannelContext_free(channelContext);
 			PROXY_LOG_ERR(TAG, ps, "error inserting channelContext in byId table for '%s'", cname);
@@ -339,7 +339,6 @@ static BOOL pf_server_activate(freerdp_peer* peer)
 	WINPR_ASSERT(pdata);
 
 	settings = peer->context->settings;
-	WINPR_ASSERT(settings);
 
 	settings->CompressionLevel = PACKET_COMPR_TYPE_RDP8;
 	if (!pf_modules_run_hook(pdata->module, HOOK_TYPE_SERVER_ACTIVATE, pdata, peer))
@@ -408,7 +407,7 @@ static BOOL pf_server_receive_channel_data_hook(freerdp_peer* peer, UINT16 chann
 	if (!pc)
 		goto original_cb;
 
-	channel = HashTable_GetItemValue(ps->channelsById, &channelId64);
+	channel = HashTable_GetItemValue(ps->channelsByFrontId, &channelId64);
 	if (!channel)
 	{
 		PROXY_LOG_ERR(TAG, ps, "channel id=%" PRIu64 " not registered here, dropping", channelId64);


### PR DESCRIPTION
When some channels are filtered, some misalignment of channel ids could happen. This patch keeps track of the back and front channel ids to correctly identify a channel and send packets with the correct channel id.
