### PR TITLE
[client,file] add kdcproxyname to parsing options

### DIFF
--- a/client/common/file.c
+++ b/client/common/file.c
@@ -1058,9 +1058,11 @@ BOOL freerdp_client_populate_rdp_file_from_settings(rdpFile* file, const rdpSett
 		file->UsbDevicesToRedirect = redirectUsb;
 
 #endif
-	file->RedirectClipboard = freerdp_settings_get_bool(settings, FreeRDP_RedirectClipboard);
-	file->RedirectPrinters = freerdp_settings_get_bool(settings, FreeRDP_RedirectPrinters);
-	file->RedirectDrives = freerdp_settings_get_bool(settings, FreeRDP_RedirectDrives);
+	file->RedirectClipboard =
+	    freerdp_settings_get_bool(settings, FreeRDP_RedirectClipboard) ? 1 : 0;
+	file->RedirectPrinters = freerdp_settings_get_bool(settings, FreeRDP_RedirectPrinters) ? 1 : 0;
+	file->RedirectDrives = freerdp_settings_get_bool(settings, FreeRDP_RedirectDrives) ? 1 : 0;
+	file->RdgIsKdcProxy = freerdp_settings_get_bool(settings, FreeRDP_KerberosRdgIsProxy) ? 1 : 0;
 	file->RedirectComPorts = (freerdp_settings_get_bool(settings, FreeRDP_RedirectSerialPorts) ||
 	                          freerdp_settings_get_bool(settings, FreeRDP_RedirectParallelPorts));
 	if (!FILE_POPULATE_STRING(&file->DrivesToRedirect, settings, FreeRDP_DrivesToRedirect) ||
@@ -2129,6 +2131,13 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 	if (~((size_t)file->KdcProxyName))
 	{
 		if (!freerdp_settings_set_string(settings, FreeRDP_KerberosKdcUrl, file->KdcProxyName))
+			return FALSE;
+	}
+
+	if (~((size_t)file->RdgIsKdcProxy))
+	{
+		if (!freerdp_settings_set_bool(settings, FreeRDP_KerberosRdgIsProxy,
+		                               file->RdgIsKdcProxy != 0))
 			return FALSE;
 	}
 

--- a/client/common/file.c
+++ b/client/common/file.c
@@ -1064,7 +1064,8 @@ BOOL freerdp_client_populate_rdp_file_from_settings(rdpFile* file, const rdpSett
 	file->RedirectComPorts = (freerdp_settings_get_bool(settings, FreeRDP_RedirectSerialPorts) ||
 	                          freerdp_settings_get_bool(settings, FreeRDP_RedirectParallelPorts));
 	if (!FILE_POPULATE_STRING(&file->DrivesToRedirect, settings, FreeRDP_DrivesToRedirect) ||
-	    !FILE_POPULATE_STRING(&file->PreconnectionBlob, settings, FreeRDP_PreconnectionBlob))
+	    !FILE_POPULATE_STRING(&file->PreconnectionBlob, settings, FreeRDP_PreconnectionBlob) ||
+	    !FILE_POPULATE_STRING(&file->KdcProxyName, settings, FreeRDP_KerberosKdcUrl))
 		return FALSE;
 
 	{
@@ -2122,6 +2123,12 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 		if (!freerdp_settings_set_string(settings, FreeRDP_PreconnectionBlob,
 		                                 file->PreconnectionBlob) ||
 		    !freerdp_settings_set_bool(settings, FreeRDP_SendPreconnectionPdu, TRUE))
+			return FALSE;
+	}
+
+	if (~((size_t)file->KdcProxyName))
+	{
+		if (!freerdp_settings_set_string(settings, FreeRDP_KerberosKdcUrl, file->KdcProxyName))
 			return FALSE;
 	}
 

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -721,6 +721,7 @@ typedef struct
 #define FreeRDP_KerberosCache (1349)
 #define FreeRDP_KerberosArmor (1350)
 #define FreeRDP_KerberosKeytab (1351)
+#define FreeRDP_KerberosRdgIsProxy (1352)
 #define FreeRDP_IgnoreCertificate (1408)
 #define FreeRDP_CertificateName (1409)
 #define FreeRDP_CertificateFile (1410)
@@ -1249,7 +1250,8 @@ struct rdp_settings
 	ALIGN64 char* KerberosCache;             /* 1349 */
 	ALIGN64 char* KerberosArmor;             /* 1350 */
 	ALIGN64 char* KerberosKeytab;            /* 1351 */
-	UINT64 padding1408[1408 - 1352];         /* 1352 */
+	ALIGN64 BOOL KerberosRdgIsProxy;         /* 1352 */
+	UINT64 padding1408[1408 - 1353];         /* 1353 */
 
 	/* Server Certificate */
 	ALIGN64 BOOL IgnoreCertificate;                /* 1408 */

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -289,6 +289,9 @@ BOOL freerdp_settings_get_bool(const rdpSettings* settings, size_t id)
 		case FreeRDP_JpegCodec:
 			return settings->JpegCodec;
 
+		case FreeRDP_KerberosRdgIsProxy:
+			return settings->KerberosRdgIsProxy;
+
 		case FreeRDP_ListMonitors:
 			return settings->ListMonitors;
 
@@ -916,6 +919,10 @@ BOOL freerdp_settings_set_bool(rdpSettings* settings, size_t id, BOOL val)
 
 		case FreeRDP_JpegCodec:
 			settings->JpegCodec = cnv.c;
+			break;
+
+		case FreeRDP_KerberosRdgIsProxy:
+			settings->KerberosRdgIsProxy = cnv.c;
 			break;
 
 		case FreeRDP_ListMonitors:

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -132,6 +132,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_IPv6Enabled, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_IPv6Enabled" },
 	{ FreeRDP_IgnoreCertificate, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_IgnoreCertificate" },
 	{ FreeRDP_JpegCodec, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_JpegCodec" },
+	{ FreeRDP_KerberosRdgIsProxy, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_KerberosRdgIsProxy" },
 	{ FreeRDP_ListMonitors, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_ListMonitors" },
 	{ FreeRDP_LocalConnection, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_LocalConnection" },
 	{ FreeRDP_LogonErrors, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_LogonErrors" },

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -87,6 +87,7 @@ static const size_t bool_list_indices[] = {
 	FreeRDP_IPv6Enabled,
 	FreeRDP_IgnoreCertificate,
 	FreeRDP_JpegCodec,
+	FreeRDP_KerberosRdgIsProxy,
 	FreeRDP_ListMonitors,
 	FreeRDP_LocalConnection,
 	FreeRDP_LogonErrors,


### PR DESCRIPTION
* parse `rdp file` option `kdcproxyname` to setting `FreeRDP_KerberosKdcUrl`
* parse `rdp file` option `rdgiskdcproxy` to setting `FreeRDP_KerberosRdgIsProxy`