### PR TITLE
[client,cmdline] remove -fast-path option

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3899,11 +3899,6 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 #endif
 		}
 #endif
-		CommandLineSwitchCase(arg, "fast-path")
-		{
-			settings->FastPathInput = enable;
-			settings->FastPathOutput = enable;
-		}
 		CommandLineSwitchCase(arg, "max-fast-path-size")
 		{
 			LONGLONG val;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -154,8 +154,6 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  NULL, "RDP standard security encryption methods" },
 	{ "f", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL,
 	  "Fullscreen mode (<Ctrl>+<Alt>+<Enter> toggles fullscreen)" },
-	{ "fast-path", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
-	  "fast-path input/output" },
 	{ "fipsmode", COMMAND_LINE_VALUE_BOOL, NULL, NULL, NULL, -1, NULL, "FIPS mode" },
 	{ "floatbar", COMMAND_LINE_VALUE_OPTIONAL,
 	  "sticky:[on|off],default:[visible|hidden],show:[always|fullscreen|window]", NULL, NULL, -1,


### PR DESCRIPTION
This option is quite an expert setting and should not be exposed that prominently. Remove it as it can still be changed with the /tune option.