### PR TITLE
[channel,urbdrc] fix type of usb hotplug callback

### DIFF
--- a/channels/urbdrc/client/libusb/libusb_udevman.c
+++ b/channels/urbdrc/client/libusb/libusb_udevman.c
@@ -581,8 +581,8 @@ static BOOL device_is_filtered(struct libusb_device* dev,
 	return filtered;
 }
 
-static int hotplug_callback(struct libusb_context* ctx, struct libusb_device* dev,
-                            libusb_hotplug_event event, void* user_data)
+static int LIBUSB_CALL hotplug_callback(struct libusb_context* ctx, struct libusb_device* dev,
+                                        libusb_hotplug_event event, void* user_data)
 {
 	VID_PID_PAIR pair;
 	struct libusb_device_descriptor desc;


### PR DESCRIPTION
The libusb_hotplug_callback_fn uses LIBUSB_CALL call type

(cherry picked from commit 024deccad7b1c8a5fdd38c1b1becdea54776cde6)

Backport https://github.com/FreeRDP/FreeRDP/pull/8498