### PR TITLE
[winpr] define WINPR_ASSERT to assert

### DIFF
--- a/winpr/include/winpr/assert.h
+++ b/winpr/include/winpr/assert.h
@@ -41,10 +41,8 @@
 		}                                                                                     \
 	} while (0)
 #else
-#define WINPR_ASSERT(cond) \
-	do                     \
-	{                      \
-	} while (0)
+#include <assert.h>
+#define WINPR_ASSERT(cond) assert(cond)
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
If WITH_VERBOSE_WINPR_ASSERT is not set define WINPR_ASSERT to be the normal C assert
