### PR TITLE
[winpr,utils] pretty print stacktrace

### DIFF
--- a/winpr/libwinpr/utils/debug.c
+++ b/winpr/libwinpr/utils/debug.c
@@ -193,7 +193,7 @@ void winpr_log_backtrace_ex(wLog* log, DWORD level, DWORD size)
 	if (msg)
 	{
 		for (x = 0; x < used; x++)
-			WLog_Print(log, level, "%" PRIuz ": %s\n", x, msg[x]);
+			WLog_Print(log, level, "%" PRIuz ": %s", x, msg[x]);
 	}
 	free(msg);
 


### PR DESCRIPTION
do not add an additional newline in the messages.