### PR TITLE
[winpr,sspi] fix kerberos resource cleanup

### DIFF
--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -344,11 +344,8 @@ cleanup:
 	if (rv)
 		kerberos_log_msg(ctx, rv);
 
-	if (domain)
 		free(domain);
-	if (username)
 		free(username);
-	if (password)
 		free(password);
 
 	if (principal)
@@ -360,7 +357,16 @@ cleanup:
 		krb5_get_init_creds_opt_free(ctx, gic_opt);
 #endif
 	if (ctx)
+	{
+		if (!credentials)
+		{
+			if (ccache)
+				krb5_cc_close(ctx, ccache);
+			if (keytab)
+				krb5_kt_close(ctx, keytab);
+		}
 		krb5_free_context(ctx);
+	}
 
 	/* If we managed to get credentials set the output */
 	if (credentials)


### PR DESCRIPTION
kerberos cache and keytab were not properly cleaned up for cases where the credentials were not available in kerberos