### PR TITLE
[channels,rdpsnd] fix rdpsnd channel cleanup

### DIFF
--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -520,8 +520,8 @@ static void dvcman_free(drdynvcPlugin* drdynvc, IWTSVirtualChannelManager* pChan
 	WINPR_ASSERT(dvcman);
 	WINPR_UNUSED(drdynvc);
 
-	ArrayList_Free(dvcman->plugins);
 	HashTable_Free(dvcman->channelsById);
+	ArrayList_Free(dvcman->plugins);
 	ArrayList_Free(dvcman->plugin_names);
 	HashTable_Free(dvcman->listeners);
 


### PR DESCRIPTION
The rdpsnd channel needs to keep the resources allocated until the last user (static, dynamic channel) is terminated.
