### PR TITLE
[codec,xcrush] follow up to #8529

### DIFF
--- a/libfreerdp/codec/xcrush.c
+++ b/libfreerdp/codec/xcrush.c
@@ -759,12 +759,12 @@ static INLINE size_t xcrush_copy_bytes(BYTE* dst, const BYTE* src, size_t num)
 
 	if (src + num < dst || src > dst + num)
 		memcpy(dst, src, num);
-	else
+	else if (src != dst)
 	{
 		// src and dst overlaps
 		// we should copy the area that doesn't overlap repeatly
 		const size_t diff = (dst > src) ? dst - src : src - dst;
-		const size_t rest = (diff > 0) ? num % diff : 0;
+		const size_t rest = num % diff;
 		const size_t end = num - rest;
 
 		for (size_t a = 0; a < end; a += diff)


### PR DESCRIPTION
There was still an issue left, if diff == 0 then the loop counter did never increment.
Skip this case now completely as the memory does not need to be copied anyway.
