### PR TITLE
[winpr,image] add winpr_bitmap_write_ex

### DIFF
--- a/winpr/include/winpr/image.h
+++ b/winpr/include/winpr/image.h
@@ -83,6 +83,8 @@ extern "C"
 
 	WINPR_API int winpr_bitmap_write(const char* filename, const BYTE* data, size_t width,
 	                                 size_t height, size_t bpp);
+	WINPR_API int winpr_bitmap_write_ex(const char* filename, const BYTE* data, size_t stride,
+	                                    size_t width, size_t height, size_t bpp);
 	WINPR_API BYTE* winpr_bitmap_construct_header(size_t width, size_t height, size_t bpp);
 
 	WINPR_API int winpr_image_write(wImage* image, const char* filename);


### PR DESCRIPTION
Added a helper function writing a bitmap from an image that has a stride that is not width * <bytes per pixel>
