### PR TITLE
Shadow resize

### DIFF
--- a/include/freerdp/server/shadow.h
+++ b/include/freerdp/server/shadow.h
@@ -116,6 +116,10 @@ struct rdp_shadow_client
 	RdpsndServerContext* rdpsnd;
 	audin_server_context* audin;
 	RdpgfxServerContext* rdpgfx;
+
+	BOOL resizeRequested;
+	UINT32 resizeWidth;
+	UINT32 resizeHeight;
 };
 
 struct rdp_shadow_server

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -1592,11 +1592,8 @@ BOOL rdp_server_reactivate(rdpRdp* rdp)
 		return FALSE;
 
 	rdp_finalize_set_flag(rdp, FINALIZE_DEACTIVATE_REACTIVATE);
-	if (!rdp_server_transition_to_state(rdp, CONNECTION_STATE_CAPABILITIES_EXCHANGE_DEMAND_ACTIVE))
-		return FALSE;
-
-	state_run_t rc = rdp_peer_handle_state_demand_active(client);
-	return state_run_success(rc);
+	return rdp_server_transition_to_state(rdp,
+	                                      CONNECTION_STATE_CAPABILITIES_EXCHANGE_DEMAND_ACTIVE);
 }
 
 static BOOL rdp_is_active_peer_state(CONNECTION_STATE state)


### PR DESCRIPTION
fixed 2 issues:
1. `rdp_server_reactivate` must not block
2. the shadow server should discard a peer that rejects the resize request