### PR TITLE
core: Fix broken server reactivation

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -1592,8 +1592,11 @@ BOOL rdp_server_reactivate(rdpRdp* rdp)
 		return FALSE;
 
 	rdp_finalize_set_flag(rdp, FINALIZE_DEACTIVATE_REACTIVATE);
-	return rdp_server_transition_to_state(rdp,
-	                                      CONNECTION_STATE_CAPABILITIES_EXCHANGE_DEMAND_ACTIVE);
+	if (!rdp_server_transition_to_state(rdp, CONNECTION_STATE_CAPABILITIES_EXCHANGE_DEMAND_ACTIVE))
+		return FALSE;
+
+	state_run_t rc = rdp_peer_handle_state_demand_active(client);
+	return state_run_success(rc);
 }
 
 static BOOL rdp_is_active_peer_state(CONNECTION_STATE state)


### PR DESCRIPTION
This commit reverts 34f44ce4a184a2edaa586545cb20b152c859c891

With this change in place the proxy is broken and disconnects the client upon connection establishment.