### PR TITLE
revert changes so that the osmajortype/osminortype is not overwritten

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -162,17 +162,26 @@ static BOOL rdp_read_general_capability_set(wStream* s, rdpSettings* settings)
 	if (Stream_GetRemainingLength(s) < 20)
 		return FALSE;
 
-	Stream_Read_UINT16(s, settings->OsMajorType); /* osMajorType (2 bytes) */
-	Stream_Read_UINT16(s, settings->OsMinorType); /* osMinorType (2 bytes) */
-	Stream_Seek_UINT16(s);                        /* protocolVersion (2 bytes) */
-	Stream_Seek_UINT16(s);                        /* pad2OctetsA (2 bytes) */
-	Stream_Seek_UINT16(s);                        /* generalCompressionTypes (2 bytes) */
-	Stream_Read_UINT16(s, extraFlags);            /* extraFlags (2 bytes) */
-	Stream_Seek_UINT16(s);                        /* updateCapabilityFlag (2 bytes) */
-	Stream_Seek_UINT16(s);                        /* remoteUnshareFlag (2 bytes) */
-	Stream_Seek_UINT16(s);                        /* generalCompressionLevel (2 bytes) */
-	Stream_Read_UINT8(s, refreshRectSupport);     /* refreshRectSupport (1 byte) */
-	Stream_Read_UINT8(s, suppressOutputSupport);  /* suppressOutputSupport (1 byte) */
+	if (settings->ServerMode)
+	{
+		Stream_Read_UINT16(s, settings->OsMajorType); /* osMajorType (2 bytes) */
+		Stream_Read_UINT16(s, settings->OsMinorType); /* osMinorType (2 bytes) */
+	}
+	else
+	{
+		Stream_Seek_UINT16(s); /* osMajorType (2 bytes) */
+		Stream_Seek_UINT16(s); /* osMinorType (2 bytes) */
+	}
+
+	Stream_Seek_UINT16(s);                       /* protocolVersion (2 bytes) */
+	Stream_Seek_UINT16(s);                       /* pad2OctetsA (2 bytes) */
+	Stream_Seek_UINT16(s);                       /* generalCompressionTypes (2 bytes) */
+	Stream_Read_UINT16(s, extraFlags);           /* extraFlags (2 bytes) */
+	Stream_Seek_UINT16(s);                       /* updateCapabilityFlag (2 bytes) */
+	Stream_Seek_UINT16(s);                       /* remoteUnshareFlag (2 bytes) */
+	Stream_Seek_UINT16(s);                       /* generalCompressionLevel (2 bytes) */
+	Stream_Read_UINT8(s, refreshRectSupport);    /* refreshRectSupport (1 byte) */
+	Stream_Read_UINT8(s, suppressOutputSupport); /* suppressOutputSupport (1 byte) */
 	settings->NoBitmapCompressionHeader = (extraFlags & NO_BITMAP_COMPRESSION_HDR) ? TRUE : FALSE;
 	settings->LongCredentialsSupported = (extraFlags & LONG_CREDENTIALS_SUPPORTED) ? TRUE : FALSE;
 


### PR DESCRIPTION
2.8.0 introduced a regression overwriting the client capabilies.
The code cherry picked was intended in 2.8.0 was intended to work with a new setting struct.
The changes that made this new struct were not backported to 2.0-stable.