### PR TITLE
core/server: Ignore data PDUs for DVCs that were not opened successfully

### DIFF
--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -333,9 +333,27 @@ static BOOL wts_read_drdynvc_pdu(rdpPeerChannel* channel)
 				return wts_read_drdynvc_create_response(dvc, channel->receiveData, length);
 
 			case DATA_FIRST_PDU:
+				if (dvc->dvc_open_state != DVC_OPEN_STATE_SUCCEEDED)
+				{
+					WLog_ERR(TAG,
+					         "ChannelId %" PRIu32 " did not open successfully. "
+					         "Ignoring DYNVC_DATA_FIRST PDU",
+					         ChannelId);
+					return TRUE;
+				}
+
 				return wts_read_drdynvc_data_first(dvc, channel->receiveData, Sp, length);
 
 			case DATA_PDU:
+				if (dvc->dvc_open_state != DVC_OPEN_STATE_SUCCEEDED)
+				{
+					WLog_ERR(TAG,
+					         "ChannelId %" PRIu32 " did not open successfully. "
+					         "Ignoring DYNVC_DATA PDU",
+					         ChannelId);
+					return TRUE;
+				}
+
 				return wts_read_drdynvc_data(dvc, channel->receiveData, length);
 
 			case CLOSE_REQUEST_PDU:


### PR DESCRIPTION
Quoting the commit message here:

```
When a FreeRDP-based server tried to open a DVC, but the client answered
the DVC create request with a negative CreationStatus in the DVC create
response PDU, the server can then assume that no actual PDUs can be
received for that channel.
However, as long as the channel handle exists, FreeRDP happily forwards
any potential PDU for that handle disregarding the CreationStatus.
This is problematic, since the channel handling usually runs in its own
thread and as a result, the channel may not be destructed yet, when
receiving such stray PDU.
The PDU may be processed, even though it is not expected to be.

A situation, where this becomes problematic is the AUDIO_PLAYBACK_DVC
channel.
It may be the case, that the client answered the DVC create request
with a negative result, the server may try to close the handle and open
the static channel (RDPSND) instead, but before the server can close the
channel handle, the client actually sends PDUs regarding the format
negotiation.
In this case, the server may unintentionally already set things up,
which was not desired (the DVC is about to be closed anyway).

While this specific situation is hypothetical, since it would depend on
a malicious client, it is still possible to happen, especially since the
server implementation does not invoke the format negotiation, but
FreeRDP does it automatically, as soon as the DVC create request is
sent.

Fix this issue by discarding any data PDUs (DYNVC_DATA_FIRST and
DYNVC_DATA) of channels, that were not opened successfully.
```

Was working on a SVC fallback for audio output redirection (https://gitlab.gnome.org/pnowack/gnome-remote-desktop/-/commit/0f9f68b0d41869be51915bf9bc944b9d61e98488), then realized the situation described in the commit message.