### PR TITLE
[stable-2.0] core/server: Ignore data PDUs for DVCs that were not opened successfully

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+# 20xx-xx-xx Version 2.x.x
+
+Fixed issues:
+* Backported #8581: Ignore data PDUs for DVCs that were not opened successfully
+
 # 2022-11-16 Version 2.9.0
 
 Notewhorth changes:

--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -291,9 +291,27 @@ static BOOL wts_read_drdynvc_pdu(rdpPeerChannel* channel)
 					return wts_read_drdynvc_create_response(dvc, channel->receiveData, length);
 
 				case DATA_FIRST_PDU:
+					if (dvc->dvc_open_state != DVC_OPEN_STATE_SUCCEEDED)
+					{
+						WLog_ERR(TAG,
+						         "ChannelId %" PRIu32 " did not open successfully. "
+						         "Ignoring DYNVC_DATA_FIRST PDU",
+						         ChannelId);
+						return TRUE;
+					}
+
 					return wts_read_drdynvc_data_first(dvc, channel->receiveData, Sp, length);
 
 				case DATA_PDU:
+					if (dvc->dvc_open_state != DVC_OPEN_STATE_SUCCEEDED)
+					{
+						WLog_ERR(TAG,
+						         "ChannelId %" PRIu32 " did not open successfully. "
+						         "Ignoring DYNVC_DATA PDU",
+						         ChannelId);
+						return TRUE;
+					}
+
 					return wts_read_drdynvc_data(dvc, channel->receiveData, length);
 
 				case CLOSE_REQUEST_PDU:


### PR DESCRIPTION
Backport of https://github.com/FreeRDP/FreeRDP/pull/8581