### PR TITLE
cliprdr: Fix sending of server-side PDUs

### DIFF
--- a/channels/cliprdr/server/cliprdr_main.c
+++ b/channels/cliprdr/server/cliprdr_main.c
@@ -78,7 +78,7 @@
 static UINT cliprdr_server_packet_send(CliprdrServerPrivate* cliprdr, wStream* s)
 {
 	UINT rc;
-	size_t pos, size;
+	size_t pos;
 	BOOL status;
 	UINT32 dataLen;
 	ULONG written;
@@ -95,15 +95,13 @@ static UINT cliprdr_server_packet_send(CliprdrServerPrivate* cliprdr, wStream* s
 	dataLen = (UINT32)(pos - 8);
 	Stream_SetPosition(s, 4);
 	Stream_Write_UINT32(s, dataLen);
-	Stream_SetPosition(s, pos);
-	size = Stream_Length(s);
-	if (size > UINT32_MAX)
+	if (pos > UINT32_MAX)
 	{
 		rc = ERROR_INVALID_DATA;
 		goto fail;
 	}
 
-	status = WTSVirtualChannelWrite(cliprdr->ChannelHandle, (PCHAR)Stream_Buffer(s), (UINT32)size,
+	status = WTSVirtualChannelWrite(cliprdr->ChannelHandle, (PCHAR)Stream_Buffer(s), (UINT32)pos,
 	                                &written);
 	rc = status ? CHANNEL_RC_OK : ERROR_INTERNAL_ERROR;
 fail:


### PR DESCRIPTION
The old implementation used `Stream_GetLength` to obtain the amount of data to send. However some PDUs (i.e. CLIPRDR_FILECONTENTS_REQUEST) are overallocated as they contain optional data (clipDataId in this case).

We now use the position to determine the actual data written to the PDU instead of the amount of bytes allocated, avoid sending garbage data to the client.
