### PR TITLE
Alpha fix

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -295,7 +295,13 @@ void xf_draw_screen_(xfContext* xfc, int x, int y, int w, int h, const char* fkt
 
 	if (w == 0 || h == 0)
 	{
-		WLog_WARN(TAG, "invalid width and/or height specified: w=%d h=%d", w, h);
+		WLog_WARN(TAG, "[%s] invalid width and/or height specified: w=%d h=%d", __FUNCTION__, w, h);
+		return;
+	}
+
+	if (!xfc->window)
+	{
+		WLog_WARN(TAG, "[%s] invalid xfc->window=%p", __FUNCTION__, xfc->window);
 		return;
 	}
 

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -638,7 +638,7 @@ static BOOL xf_event_FocusIn(xfContext* xfc, const XFocusInEvent* event, BOOL ap
 
 	/* Release all keys, should already be done at FocusOut but might be missed
 	 * if the WM decided to use an alternate event order */
-	if (!xfc->remote_app)
+	if (!app)
 		xf_keyboard_release_all_keypress(xfc);
 
 	xf_pointer_update_scale(xfc);
@@ -878,7 +878,7 @@ static BOOL xf_event_UnmapNotify(xfContext* xfc, const XUnmapEvent* event, BOOL 
 	WINPR_ASSERT(xfc);
 	WINPR_ASSERT(event);
 
-	if (!xfc->remote_app)
+	if (!app)
 		xf_keyboard_release_all_keypress(xfc);
 
 	if (!app)

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -319,7 +319,7 @@ int xf_keyboard_read_keyboard_state(xfContext* xfc)
 	Window wdummy;
 	UINT32 state = 0;
 
-	if (!xfc->remote_app)
+	if (!xfc->remote_app && xfc->window)
 	{
 		XQueryPointer(xfc->display, xfc->window->handle, &wdummy, &wdummy, &dummy, &dummy, &dummy,
 		              &dummy, &state);
@@ -448,7 +448,7 @@ void xf_keyboard_focus_in(xfContext* xfc)
 
 	/* finish with a mouse pointer position like mstsc.exe if required */
 
-	if (xfc->remote_app)
+	if (xfc->remote_app || !xfc->window)
 		return;
 
 	if (XQueryPointer(xfc->display, xfc->window->handle, &w, &w, &d, &d, &x, &y, &state))

--- a/include/freerdp/codec/color.h
+++ b/include/freerdp/codec/color.h
@@ -33,9 +33,13 @@
 #define FREERDP_PIXEL_FORMAT_IS_ABGR(_format) \
 	(FREERDP_PIXEL_FORMAT_TYPE(_format) == FREERDP_PIXEL_FORMAT_TYPE_ABGR)
 
-#define FREERDP_FLIP_NONE 0
-#define FREERDP_FLIP_VERTICAL 1
-#define FREERDP_FLIP_HORIZONTAL 2
+enum FREERDP_IMAGE_FLAGS
+{
+	FREERDP_FLIP_NONE = 0,
+	FREERDP_FLIP_VERTICAL = 1,
+	FREERDP_FLIP_HORIZONTAL = 2,
+	FREERDP_KEEP_DST_ALPHA = 4
+};
 
 #define FREERDP_PIXEL_FORMAT(_bpp, _type, _a, _r, _g, _b) \
 	((_bpp << 24) | (_type << 16) | (_a << 12) | (_r << 8) | (_g << 4) | (_b))

--- a/libfreerdp/codec/clear.c
+++ b/libfreerdp/codec/clear.c
@@ -125,7 +125,7 @@ static BOOL convert_color(BYTE* dst, UINT32 nDstStep, UINT32 DstFormat, UINT32 n
 		nHeight = nDstHeight - nYDst;
 
 	return freerdp_image_copy(dst, DstFormat, nDstStep, nXDst, nYDst, nWidth, nHeight, src,
-	                          SrcFormat, nSrcStep, 0, 0, palette, 0);
+	                          SrcFormat, nSrcStep, 0, 0, palette, FREERDP_KEEP_DST_ALPHA);
 }
 
 static BOOL clear_decompress_nscodec(NSC_CONTEXT* nsc, UINT32 width, UINT32 height, wStream* s,
@@ -1103,7 +1103,7 @@ INT32 clear_decompress(CLEAR_CONTEXT* clear, const BYTE* pSrcData, UINT32 SrcSiz
 	if (glyphData)
 	{
 		if (!freerdp_image_copy(glyphData, clear->format, 0, 0, 0, nWidth, nHeight, pDstData,
-		                        DstFormat, nDstStep, nXDst, nYDst, palette, FREERDP_FLIP_NONE))
+		                        DstFormat, nDstStep, nXDst, nYDst, palette, FREERDP_KEEP_DST_ALPHA))
 			goto fail;
 	}
 

--- a/libfreerdp/codec/interleaved.c
+++ b/libfreerdp/codec/interleaved.c
@@ -570,7 +570,7 @@ BOOL interleaved_decompress(BITMAP_INTERLEAVED_CONTEXT* interleaved, const BYTE*
 
 	if (!freerdp_image_copy(pDstData, DstFormat, nDstStep, nXDst, nYDst, nDstWidth, nDstHeight,
 	                        interleaved->TempBuffer, SrcFormat, scanline, 0, 0, palette,
-	                        FREERDP_FLIP_VERTICAL))
+	                        FREERDP_FLIP_VERTICAL | FREERDP_KEEP_DST_ALPHA))
 	{
 		WLog_ERR(TAG, "[%s] freerdp_image_copy failed", __FUNCTION__);
 		return FALSE;
@@ -628,7 +628,7 @@ BOOL interleaved_compress(BITMAP_INTERLEAVED_CONTEXT* interleaved, BYTE* pDstDat
 	}
 
 	if (!freerdp_image_copy(interleaved->TempBuffer, DstFormat, 0, 0, 0, nWidth, nHeight, pSrcData,
-	                        SrcFormat, nSrcStep, nXSrc, nYSrc, palette, FREERDP_FLIP_NONE))
+	                        SrcFormat, nSrcStep, nXSrc, nYSrc, palette, FREERDP_KEEP_DST_ALPHA))
 		return FALSE;
 
 	s = Stream_New(pDstData, *pDstSize);

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -2583,7 +2583,7 @@ INT32 progressive_decompress(PROGRESSIVE_CONTEXT* progressive, const BYTE* pSrcD
 
 			if (!freerdp_image_copy(pDstData, DstFormat, nDstStep, rect->left, rect->top, width,
 			                        height, tile->data, progressive->format, tile->stride, nXSrc,
-			                        nYSrc, NULL, FREERDP_FLIP_NONE))
+			                        nYSrc, NULL, FREERDP_KEEP_DST_ALPHA))
 			{
 				rc = -42;
 				break;

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -1253,9 +1253,10 @@ static UINT gdi_SolidFill(RdpgfxClientContext* context, const RDPGFX_SOLID_FILL_
 	b = solidFill->fillPixel.B;
 	g = solidFill->fillPixel.G;
 	r = solidFill->fillPixel.R;
-	/* a = solidFill->fillPixel.XA;
-	 * Ignore alpha channel, this is a solid fill. */
-	a = 0xFF;
+	if (FreeRDPColorHasAlpha(surface->format))
+		a = solidFill->fillPixel.XA;
+	else
+		a = 0xFF;
 	color = FreeRDPGetColor(surface->format, r, g, b, a);
 
 	for (index = 0; index < solidFill->fillRectCount; index++)


### PR DESCRIPTION
fixes alpha channel handling for rails mode with progressive and clear codec:
These codecs do not have alpha, so it is required to keep the destination alpha channel that has been set with the alpha codec