### PR TITLE
Rename functions tls_ to rdp_tls_ and tls.h to rdptls.h to avoid conflicts with libtls

### DIFF
--- a/client/common/client.c
+++ b/client/common/client.c
@@ -634,7 +634,7 @@ static DWORD client_cli_accept_certificate(rdpSettings* settings)
 /** Callback set in the rdp_freerdp structure, and used to make a certificate validation
  *  when the connection requires it.
  *  This function will actually be called by tls_verify_certificate().
- *  @see rdp_client_connect() and tls_connect()
+ *  @see rdp_client_connect() and freerdp_tls_connect()
  *  @deprecated Use client_cli_verify_certificate_ex
  *  @param instance - pointer to the rdp_freerdp structure that contains the connection settings
  *  @param common_name
@@ -666,7 +666,7 @@ DWORD client_cli_verify_certificate(freerdp* instance, const char* common_name, 
 /** Callback set in the rdp_freerdp structure, and used to make a certificate validation
  *  when the connection requires it.
  *  This function will actually be called by tls_verify_certificate().
- *  @see rdp_client_connect() and tls_connect()
+ *  @see rdp_client_connect() and freerdp_tls_connect()
  *  @param instance     pointer to the rdp_freerdp structure that contains the connection settings
  *  @param host         The host currently connecting to
  *  @param port         The port currently connecting to
@@ -719,7 +719,7 @@ DWORD client_cli_verify_certificate_ex(freerdp* instance, const char* host, UINT
 /** Callback set in the rdp_freerdp structure, and used to make a certificate validation
  *  when a stored certificate does not match the remote counterpart.
  *  This function will actually be called by tls_verify_certificate().
- *  @see rdp_client_connect() and tls_connect()
+ *  @see rdp_client_connect() and freerdp_tls_connect()
  *  @deprecated Use client_cli_verify_changed_certificate_ex
  *  @param instance - pointer to the rdp_freerdp structure that contains the connection settings
  *  @param common_name
@@ -764,7 +764,7 @@ DWORD client_cli_verify_changed_certificate(freerdp* instance, const char* commo
 /** Callback set in the rdp_freerdp structure, and used to make a certificate validation
  *  when a stored certificate does not match the remote counterpart.
  *  This function will actually be called by tls_verify_certificate().
- *  @see rdp_client_connect() and tls_connect()
+ *  @see rdp_client_connect() and freerdp_tls_connect()
  *  @param instance        pointer to the rdp_freerdp structure that contains the connection
  * settings
  *  @param host            The host currently connecting to

--- a/include/freerdp/crypto/tls.h
+++ b/include/freerdp/crypto/tls.h
@@ -99,28 +99,29 @@ extern "C"
 {
 #endif
 
-	FREERDP_API const SSL_METHOD* tls_get_ssl_method(BOOL isDtls, BOOL isClient);
+	FREERDP_API const SSL_METHOD* freerdp_tls_get_ssl_method(BOOL isDtls, BOOL isClient);
 
-	FREERDP_API int tls_connect(rdpTls* tls, BIO* underlying);
+	FREERDP_API int freerdp_tls_connect(rdpTls* tls, BIO* underlying);
 
-	FREERDP_API TlsHandshakeResult tls_connect_ex(rdpTls* tls, BIO* underlying,
-	                                              const SSL_METHOD* methods);
+	FREERDP_API TlsHandshakeResult freerdp_tls_connect_ex(rdpTls* tls, BIO* underlying,
+	                                                      const SSL_METHOD* methods);
 
-	FREERDP_API BOOL tls_accept(rdpTls* tls, BIO* underlying, rdpSettings* settings);
+	FREERDP_API BOOL freerdp_tls_accept(rdpTls* tls, BIO* underlying, rdpSettings* settings);
 
-	FREERDP_API TlsHandshakeResult tls_accept_ex(rdpTls* tls, BIO* underlying,
-	                                             rdpSettings* settings, const SSL_METHOD* methods);
+	FREERDP_API TlsHandshakeResult freerdp_tls_accept_ex(rdpTls* tls, BIO* underlying,
+	                                                     rdpSettings* settings,
+	                                                     const SSL_METHOD* methods);
 
-	FREERDP_API TlsHandshakeResult tls_handshake(rdpTls* tls);
+	FREERDP_API TlsHandshakeResult freerdp_tls_handshake(rdpTls* tls);
 
-	FREERDP_API BOOL tls_send_alert(rdpTls* tls);
+	FREERDP_API BOOL freerdp_tls_send_alert(rdpTls* tls);
 
-	FREERDP_API int tls_write_all(rdpTls* tls, const BYTE* data, int length);
+	FREERDP_API int freerdp_tls_write_all(rdpTls* tls, const BYTE* data, int length);
 
-	FREERDP_API int tls_set_alert_code(rdpTls* tls, int level, int description);
+	FREERDP_API int freerdp_tls_set_alert_code(rdpTls* tls, int level, int description);
 
-	FREERDP_API rdpTls* tls_new(rdpSettings* settings);
-	FREERDP_API void tls_free(rdpTls* tls);
+	FREERDP_API rdpTls* freerdp_tls_new(rdpSettings* settings);
+	FREERDP_API void freerdp_tls_free(rdpTls* tls);
 
 #ifdef __cplusplus
 }

--- a/libfreerdp/core/gateway/http.h
+++ b/libfreerdp/core/gateway/http.h
@@ -23,7 +23,8 @@
 #include <winpr/stream.h>
 
 #include <freerdp/api.h>
-#include <freerdp/crypto/tls.h>
+
+#include "../../crypto/tls.h"
 
 #define HTTP_STATUS_CONTINUE 100
 #define HTTP_STATUS_SWITCH_PROTOCOLS 101

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -1752,7 +1752,7 @@ static BOOL rdg_send_http_request(rdpRdg* rdg, rdpTls* tls, const char* method,
 	sz = Stream_Length(s);
 
 	if (sz <= INT_MAX)
-		status = tls_write_all(tls, Stream_Buffer(s), (int)sz);
+		status = freerdp_tls_write_all(tls, Stream_Buffer(s), (int)sz);
 
 	Stream_Free(s, TRUE);
 	return (status >= 0);
@@ -1821,7 +1821,7 @@ static BOOL rdg_tls_connect(rdpRdg* rdg, rdpTls* tls, const char* peerAddress, i
 	tls->hostname = settings->GatewayHostname;
 	tls->port = (int)settings->GatewayPort;
 	tls->isGatewayTransport = TRUE;
-	status = tls_connect(tls, bufferedBio);
+	status = freerdp_tls_connect(tls, bufferedBio);
 	if (status < 1)
 	{
 		rdpContext* context = rdg->context;
@@ -2178,7 +2178,7 @@ static int rdg_write_websocket_data_packet(rdpRdg* rdg, const BYTE* buf, int isi
 
 	Stream_SealLength(sWS);
 
-	status = tls_write_all(rdg->tlsOut, Stream_Buffer(sWS), Stream_Length(sWS));
+	status = freerdp_tls_write_all(rdg->tlsOut, Stream_Buffer(sWS), Stream_Length(sWS));
 	Stream_Free(sWS, TRUE);
 
 	if (status < 0)
@@ -2224,7 +2224,7 @@ static int rdg_write_chunked_data_packet(rdpRdg* rdg, const BYTE* buf, int isize
 		return -1;
 	}
 
-	status = tls_write_all(rdg->tlsIn, Stream_Buffer(sChunk), (int)len);
+	status = freerdp_tls_write_all(rdg->tlsIn, Stream_Buffer(sChunk), (int)len);
 	Stream_Free(sChunk, TRUE);
 
 	if (status < 0)
@@ -2710,12 +2710,12 @@ rdpRdg* rdg_new(rdpContext* context)
 
 		sprintf_s(bracedUuid, sizeof(bracedUuid), "{%s}", stringUuid);
 		RpcStringFreeA(&stringUuid);
-		rdg->tlsOut = tls_new(rdg->settings);
+		rdg->tlsOut = freerdp_tls_new(rdg->settings);
 
 		if (!rdg->tlsOut)
 			goto rdg_alloc_error;
 
-		rdg->tlsIn = tls_new(rdg->settings);
+		rdg->tlsIn = freerdp_tls_new(rdg->settings);
 
 		if (!rdg->tlsIn)
 			goto rdg_alloc_error;
@@ -2785,8 +2785,8 @@ void rdg_free(rdpRdg* rdg)
 	if (!rdg)
 		return;
 
-	tls_free(rdg->tlsOut);
-	tls_free(rdg->tlsIn);
+	freerdp_tls_free(rdg->tlsOut);
+	freerdp_tls_free(rdg->tlsIn);
 	http_context_free(rdg->http);
 	credssp_auth_free(rdg->auth);
 

--- a/libfreerdp/core/gateway/rdg.h
+++ b/libfreerdp/core/gateway/rdg.h
@@ -30,7 +30,6 @@
 #include <freerdp/api.h>
 
 #include <freerdp/freerdp.h>
-#include <freerdp/crypto/tls.h>
 #include <freerdp/types.h>
 #include <freerdp/settings.h>
 

--- a/libfreerdp/core/gateway/rpc.c
+++ b/libfreerdp/core/gateway/rpc.c
@@ -356,7 +356,7 @@ SSIZE_T rpc_channel_write(RpcChannel* channel, const BYTE* data, size_t length)
 	if (!channel || (length > INT32_MAX))
 		return -1;
 
-	status = tls_write_all(channel->tls, data, (INT32)length);
+	status = freerdp_tls_write_all(channel->tls, data, (INT32)length);
 	return status;
 }
 
@@ -474,7 +474,7 @@ void rpc_channel_free(RpcChannel* channel)
 
 	credssp_auth_free(channel->auth);
 	http_context_free(channel->http);
-	tls_free(channel->tls);
+	freerdp_tls_free(channel->tls);
 	free(channel);
 }
 
@@ -705,7 +705,7 @@ static BOOL rpc_channel_tls_connect(RpcChannel* channel, UINT32 timeout)
 	}
 
 	channel->bio = bufferedBio;
-	tls = channel->tls = tls_new(settings);
+	tls = channel->tls = freerdp_tls_new(settings);
 
 	if (!tls)
 		return FALSE;
@@ -713,7 +713,7 @@ static BOOL rpc_channel_tls_connect(RpcChannel* channel, UINT32 timeout)
 	tls->hostname = settings->GatewayHostname;
 	tls->port = settings->GatewayPort;
 	tls->isGatewayTransport = TRUE;
-	tlsStatus = tls_connect(tls, bufferedBio);
+	tlsStatus = freerdp_tls_connect(tls, bufferedBio);
 
 	if (tlsStatus < 1)
 	{

--- a/libfreerdp/core/gateway/rpc.h
+++ b/libfreerdp/core/gateway/rpc.h
@@ -30,6 +30,8 @@
 #include <freerdp/log.h>
 #include <freerdp/utils/ringbuffer.h>
 
+#include "../../crypto/tls.h"
+
 typedef struct rdp_rpc rdpRpc;
 
 #pragma pack(push, 1)
@@ -83,7 +85,6 @@ typedef struct
 
 #include <freerdp/types.h>
 #include <freerdp/settings.h>
-#include <freerdp/crypto/tls.h>
 #include <freerdp/crypto/crypto.h>
 #include <freerdp/api.h>
 

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -28,7 +28,6 @@
 #include <ctype.h>
 
 #include <freerdp/log.h>
-#include <freerdp/crypto/tls.h>
 #include <freerdp/build-config.h>
 
 #include <winpr/crt.h>
@@ -42,6 +41,7 @@
 #include <winpr/debug.h>
 #include <winpr/asn1.h>
 
+#include "../crypto/tls.h"
 #include "nla.h"
 #include "utils.h"
 #include "credssp_auth.h"

--- a/libfreerdp/core/nla.h
+++ b/libfreerdp/core/nla.h
@@ -29,7 +29,6 @@ typedef struct rdp_nla rdpNla;
 #include <winpr/stream.h>
 #include <winpr/crypto.h>
 
-#include <freerdp/crypto/tls.h>
 #include <freerdp/crypto/ber.h>
 #include <freerdp/crypto/der.h>
 #include <freerdp/crypto/crypto.h>

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -263,7 +263,7 @@ static BOOL transport_default_connect_tls(rdpTransport* transport)
 	settings = context->settings;
 	WINPR_ASSERT(settings);
 
-	if (!(tls = tls_new(settings)))
+	if (!(tls = freerdp_tls_new(settings)))
 		return FALSE;
 
 	transport->tls = tls;
@@ -280,7 +280,7 @@ static BOOL transport_default_connect_tls(rdpTransport* transport)
 		tls->port = 3389;
 
 	tls->isGatewayTransport = FALSE;
-	tlsStatus = tls_connect(tls, transport->frontBio);
+	tlsStatus = freerdp_tls_connect(tls, transport->frontBio);
 
 	if (tlsStatus < 1)
 	{
@@ -483,11 +483,11 @@ static BOOL transport_default_accept_tls(rdpTransport* transport)
 	WINPR_ASSERT(settings);
 
 	if (!transport->tls)
-		transport->tls = tls_new(settings);
+		transport->tls = freerdp_tls_new(settings);
 
 	transport->layer = TRANSPORT_LAYER_TLS;
 
-	if (!tls_accept(transport->tls, transport->frontBio, settings))
+	if (!freerdp_tls_accept(transport->tls, transport->frontBio, settings))
 		return FALSE;
 
 	transport->frontBio = transport->tls->bio;
@@ -524,9 +524,9 @@ BOOL transport_accept_nla(rdpTransport* transport)
 		transport_set_nla_mode(transport, FALSE);
 		nla_free(transport->nla);
 		transport->nla = NULL;
-		tls_set_alert_code(transport->tls, TLS_ALERT_LEVEL_FATAL,
-		                   TLS_ALERT_DESCRIPTION_ACCESS_DENIED);
-		tls_send_alert(transport->tls);
+		freerdp_tls_set_alert_code(transport->tls, TLS_ALERT_LEVEL_FATAL,
+		                           TLS_ALERT_DESCRIPTION_ACCESS_DENIED);
+		freerdp_tls_send_alert(transport->tls);
 		return FALSE;
 	}
 
@@ -1229,7 +1229,7 @@ static BOOL transport_default_disconnect(rdpTransport* transport)
 
 	if (transport->tls)
 	{
-		tls_free(transport->tls);
+		freerdp_tls_free(transport->tls);
 		transport->tls = NULL;
 	}
 	else
@@ -1388,7 +1388,7 @@ rdpNla* transport_get_nla(rdpTransport* transport)
 BOOL transport_set_tls(rdpTransport* transport, rdpTls* tls)
 {
 	WINPR_ASSERT(transport);
-	tls_free(transport->tls);
+	freerdp_tls_free(transport->tls);
 	transport->tls = tls;
 	return TRUE;
 }

--- a/libfreerdp/core/transport.h
+++ b/libfreerdp/core/transport.h
@@ -43,7 +43,6 @@ typedef enum
 #include <winpr/collections.h>
 
 #include <freerdp/api.h>
-#include <freerdp/crypto/tls.h>
 
 #include <time.h>
 #include <freerdp/types.h>

--- a/libfreerdp/crypto/CMakeLists.txt
+++ b/libfreerdp/crypto/CMakeLists.txt
@@ -27,6 +27,7 @@ freerdp_module_add(
 	certificate.c
 	crypto.c
 	tls.c
+	tls.h
 	opensslcompat.c)
 
 freerdp_include_directory_add(${OPENSSL_INCLUDE_DIR})

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -599,7 +599,7 @@ static CryptoCert tls_get_certificate(rdpTls* tls, BOOL peer)
 	return cert;
 }
 
-static void tls_free_certificate(CryptoCert cert)
+static void freerdp_tls_free_certificate(CryptoCert cert)
 {
 	X509_free(cert->px509);
 	free(cert);
@@ -775,7 +775,7 @@ static void adjustSslOptions(int* options)
 #endif
 }
 
-const SSL_METHOD* tls_get_ssl_method(BOOL isDtls, BOOL isClient)
+const SSL_METHOD* freerdp_tls_get_ssl_method(BOOL isDtls, BOOL isClient)
 {
 	if (isClient)
 	{
@@ -794,7 +794,7 @@ const SSL_METHOD* tls_get_ssl_method(BOOL isDtls, BOOL isClient)
 	return (const SSL_METHOD*)SSLv23_server_method();
 }
 
-TlsHandshakeResult tls_connect_ex(rdpTls* tls, BIO* underlying, const SSL_METHOD* methods)
+TlsHandshakeResult freerdp_tls_connect_ex(rdpTls* tls, BIO* underlying, const SSL_METHOD* methods)
 {
 	WINPR_ASSERT(tls);
 
@@ -836,10 +836,10 @@ TlsHandshakeResult tls_connect_ex(rdpTls* tls, BIO* underlying, const SSL_METHOD
 	SSL_set_tlsext_host_name(tls->ssl, tls->hostname);
 #endif
 
-	return tls_handshake(tls);
+	return freerdp_tls_handshake(tls);
 }
 
-TlsHandshakeResult tls_handshake(rdpTls* tls)
+TlsHandshakeResult freerdp_tls_handshake(rdpTls* tls)
 {
 	TlsHandshakeResult ret = TLS_HANDSHAKE_ERROR;
 
@@ -887,13 +887,13 @@ TlsHandshakeResult tls_handshake(rdpTls* tls)
 			if (verify_status < 1)
 			{
 				WLog_ERR(TAG, "certificate not trusted, aborting.");
-				tls_send_alert(tls);
+				freerdp_tls_send_alert(tls);
 				ret = TLS_HANDSHAKE_VERIFY_ERROR;
 			}
 		}
 	} while (0);
 
-	tls_free_certificate(cert);
+	freerdp_tls_free_certificate(cert);
 	return ret;
 }
 
@@ -929,7 +929,7 @@ static int pollAndHandshake(rdpTls* tls)
 				return -1;
 		}
 
-		TlsHandshakeResult result = tls_handshake(tls);
+		TlsHandshakeResult result = freerdp_tls_handshake(tls);
 		switch (result)
 		{
 			case TLS_HANDSHAKE_CONTINUE:
@@ -944,12 +944,12 @@ static int pollAndHandshake(rdpTls* tls)
 	} while (TRUE);
 }
 
-int tls_connect(rdpTls* tls, BIO* underlying)
+int freerdp_tls_connect(rdpTls* tls, BIO* underlying)
 {
-	const SSL_METHOD* method = tls_get_ssl_method(FALSE, TRUE);
+	const SSL_METHOD* method = freerdp_tls_get_ssl_method(FALSE, TRUE);
 
 	WINPR_ASSERT(tls);
-	TlsHandshakeResult result = tls_connect_ex(tls, underlying, method);
+	TlsHandshakeResult result = freerdp_tls_connect_ex(tls, underlying, method);
 	switch (result)
 	{
 		case TLS_HANDSHAKE_SUCCESS:
@@ -977,11 +977,11 @@ static void tls_openssl_tlsext_debug_callback(SSL* s, int client_server, int typ
 }
 #endif
 
-BOOL tls_accept(rdpTls* tls, BIO* underlying, rdpSettings* settings)
+BOOL freerdp_tls_accept(rdpTls* tls, BIO* underlying, rdpSettings* settings)
 {
 	WINPR_ASSERT(tls);
 	TlsHandshakeResult res =
-	    tls_accept_ex(tls, underlying, settings, tls_get_ssl_method(FALSE, FALSE));
+	    freerdp_tls_accept_ex(tls, underlying, settings, freerdp_tls_get_ssl_method(FALSE, FALSE));
 	switch (res)
 	{
 		case TLS_HANDSHAKE_SUCCESS:
@@ -997,8 +997,8 @@ BOOL tls_accept(rdpTls* tls, BIO* underlying, rdpSettings* settings)
 	return pollAndHandshake(tls) > 0;
 }
 
-TlsHandshakeResult tls_accept_ex(rdpTls* tls, BIO* underlying, rdpSettings* settings,
-                                 const SSL_METHOD* methods)
+TlsHandshakeResult freerdp_tls_accept_ex(rdpTls* tls, BIO* underlying, rdpSettings* settings,
+                                         const SSL_METHOD* methods)
 {
 	WINPR_ASSERT(tls);
 
@@ -1140,10 +1140,10 @@ TlsHandshakeResult tls_accept_ex(rdpTls* tls, BIO* underlying, rdpSettings* sett
 	SSL_set_tlsext_debug_callback(tls->ssl, tls_openssl_tlsext_debug_callback);
 #endif
 
-	return tls_handshake(tls);
+	return freerdp_tls_handshake(tls);
 }
 
-BOOL tls_send_alert(rdpTls* tls)
+BOOL freerdp_tls_send_alert(rdpTls* tls)
 {
 	WINPR_ASSERT(tls);
 
@@ -1190,7 +1190,7 @@ BOOL tls_send_alert(rdpTls* tls)
 	return TRUE;
 }
 
-int tls_write_all(rdpTls* tls, const BYTE* data, int length)
+int freerdp_tls_write_all(rdpTls* tls, const BYTE* data, int length)
 {
 	WINPR_ASSERT(tls);
 	int status;
@@ -1226,7 +1226,7 @@ int tls_write_all(rdpTls* tls, const BYTE* data, int length)
 	return length;
 }
 
-int tls_set_alert_code(rdpTls* tls, int level, int description)
+int freerdp_tls_set_alert_code(rdpTls* tls, int level, int description)
 {
 	WINPR_ASSERT(tls);
 	tls->alertLevel = level;
@@ -1785,7 +1785,7 @@ void tls_print_certificate_name_mismatch_error(const char* hostname, UINT16 port
 	WLog_ERR(TAG, "A valid certificate for the wrong name should NOT be trusted!");
 }
 
-rdpTls* tls_new(rdpSettings* settings)
+rdpTls* freerdp_tls_new(rdpSettings* settings)
 {
 	rdpTls* tls;
 	tls = (rdpTls*)calloc(1, sizeof(rdpTls));
@@ -1811,7 +1811,7 @@ out_free:
 	return NULL;
 }
 
-void tls_free(rdpTls* tls)
+void freerdp_tls_free(rdpTls* tls)
 {
 	if (!tls)
 		return;

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -32,7 +32,7 @@
 #include <freerdp/utils/ringbuffer.h>
 
 #include <freerdp/log.h>
-#include <freerdp/crypto/tls.h>
+#include "../crypto/tls.h"
 #include "../core/tcp.h"
 #include "opensslcompat.h"
 

--- a/libfreerdp/crypto/tls.h
+++ b/libfreerdp/crypto/tls.h
@@ -17,11 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef FREERDP_CRYPTO_TLS_H
-#define FREERDP_CRYPTO_TLS_H
-
-#include "crypto.h"
-#include "certificate.h"
+#ifndef FREERDP_LIB_CRYPTO_TLS_H
+#define FREERDP_LIB_CRYPTO_TLS_H
 
 #include <winpr/crt.h>
 #include <winpr/sspi.h>
@@ -31,6 +28,7 @@
 
 #include <freerdp/api.h>
 #include <freerdp/types.h>
+#include <freerdp/crypto/certificate.h>
 
 #include <winpr/stream.h>
 
@@ -99,32 +97,32 @@ extern "C"
 {
 #endif
 
-	FREERDP_API const SSL_METHOD* freerdp_tls_get_ssl_method(BOOL isDtls, BOOL isClient);
+	FREERDP_LOCAL const SSL_METHOD* freerdp_tls_get_ssl_method(BOOL isDtls, BOOL isClient);
 
-	FREERDP_API int freerdp_tls_connect(rdpTls* tls, BIO* underlying);
+	FREERDP_LOCAL int freerdp_tls_connect(rdpTls* tls, BIO* underlying);
 
-	FREERDP_API TlsHandshakeResult freerdp_tls_connect_ex(rdpTls* tls, BIO* underlying,
-	                                                      const SSL_METHOD* methods);
+	FREERDP_LOCAL TlsHandshakeResult freerdp_tls_connect_ex(rdpTls* tls, BIO* underlying,
+	                                                        const SSL_METHOD* methods);
 
-	FREERDP_API BOOL freerdp_tls_accept(rdpTls* tls, BIO* underlying, rdpSettings* settings);
+	FREERDP_LOCAL BOOL freerdp_tls_accept(rdpTls* tls, BIO* underlying, rdpSettings* settings);
 
-	FREERDP_API TlsHandshakeResult freerdp_tls_accept_ex(rdpTls* tls, BIO* underlying,
-	                                                     rdpSettings* settings,
-	                                                     const SSL_METHOD* methods);
+	FREERDP_LOCAL TlsHandshakeResult freerdp_tls_accept_ex(rdpTls* tls, BIO* underlying,
+	                                                       rdpSettings* settings,
+	                                                       const SSL_METHOD* methods);
 
-	FREERDP_API TlsHandshakeResult freerdp_tls_handshake(rdpTls* tls);
+	FREERDP_LOCAL TlsHandshakeResult freerdp_tls_handshake(rdpTls* tls);
 
-	FREERDP_API BOOL freerdp_tls_send_alert(rdpTls* tls);
+	FREERDP_LOCAL BOOL freerdp_tls_send_alert(rdpTls* tls);
 
-	FREERDP_API int freerdp_tls_write_all(rdpTls* tls, const BYTE* data, int length);
+	FREERDP_LOCAL int freerdp_tls_write_all(rdpTls* tls, const BYTE* data, int length);
 
-	FREERDP_API int freerdp_tls_set_alert_code(rdpTls* tls, int level, int description);
+	FREERDP_LOCAL int freerdp_tls_set_alert_code(rdpTls* tls, int level, int description);
 
-	FREERDP_API rdpTls* freerdp_tls_new(rdpSettings* settings);
-	FREERDP_API void freerdp_tls_free(rdpTls* tls);
+	FREERDP_LOCAL rdpTls* freerdp_tls_new(rdpSettings* settings);
+	FREERDP_LOCAL void freerdp_tls_free(rdpTls* tls);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* FREERDP_CRYPTO_TLS_H */
+#endif /* FREERDP_LIB_CRYPTO_TLS_H */


### PR DESCRIPTION
Most changes done by sed,
Same issue was reported before: https://github.com/FreeRDP/FreeRDP/issues/2046.
In our case we link together libfreerdp and libtls, both have tls_free().