### PR TITLE
Refactor cleanups

### DIFF
--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -2209,6 +2209,10 @@ extern "C"
 	 */
 	FREERDP_API const char* freerdp_rdpdr_dtyp_string(UINT32 type);
 
+	FREERDP_API const char* freerdp_encryption_level_string(UINT32 EncryptionLevel);
+	FREERDP_API const char* freerdp_encryption_methods_string(UINT32 EncryptionLevel, char* buffer,
+	                                                          size_t size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -2082,3 +2082,50 @@ const char* freerdp_rdpdr_dtyp_string(UINT32 type)
 			return "RDPDR_DTYP_UNKNOWN";
 	}
 }
+
+const char* freerdp_encryption_level_string(UINT32 EncryptionLevel)
+{
+	switch (EncryptionLevel)
+	{
+		case ENCRYPTION_LEVEL_NONE:
+			return "ENCRYPTION_LEVEL_NONE";
+		case ENCRYPTION_LEVEL_LOW:
+			return "ENCRYPTION_LEVEL_LOW";
+		case ENCRYPTION_LEVEL_CLIENT_COMPATIBLE:
+			return "ENCRYPTION_LEVEL_CLIENT_COMPATIBLE";
+		case ENCRYPTION_LEVEL_HIGH:
+			return "ENCRYPTION_LEVEL_HIGH";
+		case ENCRYPTION_LEVEL_FIPS:
+			return "ENCRYPTION_LEVEL_FIPS";
+		default:
+			return "ENCRYPTION_LEVEL_UNKNOWN";
+	}
+}
+
+const char* freerdp_encryption_methods_string(UINT32 EncryptionMethods, char* buffer, size_t size)
+{
+	if (EncryptionMethods == ENCRYPTION_METHOD_NONE)
+	{
+		winpr_str_append("ENCRYPTION_METHOD_NONE", buffer, size, "|");
+		return buffer;
+	}
+
+	if (EncryptionMethods & ENCRYPTION_METHOD_40BIT)
+	{
+		winpr_str_append("ENCRYPTION_METHOD_40BIT", buffer, size, "|");
+	}
+	if (EncryptionMethods & ENCRYPTION_METHOD_128BIT)
+	{
+		winpr_str_append("ENCRYPTION_METHOD_128BIT", buffer, size, "|");
+	}
+	if (EncryptionMethods & ENCRYPTION_METHOD_56BIT)
+	{
+		winpr_str_append("ENCRYPTION_METHOD_56BIT", buffer, size, "|");
+	}
+	if (EncryptionMethods & ENCRYPTION_METHOD_FIPS)
+	{
+		winpr_str_append("ENCRYPTION_METHOD_FIPS", buffer, size, "|");
+	}
+
+	return buffer;
+}

--- a/libfreerdp/core/certificate.c
+++ b/libfreerdp/core/certificate.c
@@ -1018,7 +1018,7 @@ void key_free(rdpRsaKey* key)
 	free(key);
 }
 
-rdpCertificate* certificate_clone(rdpCertificate* certificate)
+rdpCertificate* certificate_clone(const rdpCertificate* certificate)
 {
 	UINT32 index;
 

--- a/libfreerdp/core/certificate.h
+++ b/libfreerdp/core/certificate.h
@@ -50,7 +50,7 @@ FREERDP_LOCAL BOOL certificate_read_server_certificate(rdpCertificate* certifica
 FREERDP_LOCAL BOOL certificate_write_server_certificate(rdpCertificate* certificate,
                                                         UINT32 dwVersion, wStream* s);
 
-FREERDP_LOCAL rdpCertificate* certificate_clone(rdpCertificate* certificate);
+FREERDP_LOCAL rdpCertificate* certificate_clone(const rdpCertificate* certificate);
 
 FREERDP_LOCAL rdpCertificate* certificate_new(void);
 FREERDP_LOCAL void certificate_free(rdpCertificate* certificate);

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -110,6 +110,11 @@ static int freerdp_connect_begin(freerdp* instance)
 		if (!rdp->originalSettings)
 			return 0;
 
+		freerdp_settings_free(rdp->remoteSettings);
+		rdp->remoteSettings = freerdp_settings_new(0);
+		if (!rdp->remoteSettings)
+			return 0;
+
 		WINPR_ASSERT(instance->LoadChannels);
 		if (!instance->LoadChannels(instance))
 			return 0;

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -105,14 +105,7 @@ static int freerdp_connect_begin(freerdp* instance)
 
 	if (status)
 	{
-		freerdp_settings_free(rdp->originalSettings);
-		rdp->originalSettings = freerdp_settings_clone(settings);
-		if (!rdp->originalSettings)
-			return 0;
-
-		freerdp_settings_free(rdp->remoteSettings);
-		rdp->remoteSettings = freerdp_settings_new(0);
-		if (!rdp->remoteSettings)
+		if (!rdp_set_backup_settings(rdp))
 			return 0;
 
 		WINPR_ASSERT(instance->LoadChannels);

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -1240,7 +1240,7 @@ static BOOL freerdp_peer_send_server_redirection_pdu(freerdp_peer* peer,
 	if (!rdp_send_pdu(peer->context->rdp, s, PDU_TYPE_SERVER_REDIRECTION, 0))
 		goto fail;
 
-	return TRUE;
+	return rdp_reset_runtime_settings(peer->context->rdp);
 fail:
 	Stream_Release(s);
 	return FALSE;

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -2045,7 +2045,8 @@ BOOL freerdp_get_stats(rdpRdp* rdp, UINT64* inBytes, UINT64* outBytes, UINT64* i
 rdpRdp* rdp_new(rdpContext* context)
 {
 	rdpRdp* rdp;
-	DWORD flags;
+	DWORD flags = 0;
+	DWORD remoteFlags = 0;
 	rdp = (rdpRdp*)calloc(1, sizeof(rdpRdp));
 
 	if (!rdp)
@@ -2057,6 +2058,8 @@ rdpRdp* rdp_new(rdpContext* context)
 
 	if (context->ServerMode)
 		flags |= FREERDP_SETTINGS_SERVER_MODE;
+	else
+		remoteFlags |= FREERDP_SETTINGS_SERVER_MODE;
 
 	if (!context->settings)
 	{
@@ -2073,6 +2076,11 @@ rdpRdp* rdp_new(rdpContext* context)
 	rdp->originalSettings = freerdp_settings_clone(rdp->settings);
 	if (!rdp->originalSettings)
 		return FALSE;
+
+	freerdp_settings_free(rdp->remoteSettings);
+	rdp->remoteSettings = freerdp_settings_new(remoteFlags);
+	if (!rdp->remoteSettings)
+		return false;
 
 	rdp->settings->instance = context->instance;
 
@@ -2279,6 +2287,7 @@ void rdp_free(rdpRdp* rdp)
 
 		freerdp_settings_free(rdp->settings);
 		freerdp_settings_free(rdp->originalSettings);
+		freerdp_settings_free(rdp->remoteSettings);
 
 		input_free(rdp->input);
 		update_free(rdp->update);

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -286,4 +286,7 @@ BOOL rdp_reset_rc4_decrypt_keys(rdpRdp* rdp);
 
 const char* rdp_security_flag_string(UINT32 securityFlags, char* buffer, size_t size);
 
+BOOL rdp_set_backup_settings(rdpRdp* rdp);
+BOOL rdp_reset_runtime_settings(rdpRdp* rdp);
+
 #endif /* FREERDP_LIB_CORE_RDP_H */

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -156,6 +156,7 @@ struct rdp_rdp
 	rdpRedirection* redirection;
 	rdpSettings* settings;
 	rdpSettings* originalSettings;
+	rdpSettings* remoteSettings;
 	rdpTransport* transport;
 	rdpAutoDetect* autodetect;
 	rdpHeartbeat* heartbeat;

--- a/libfreerdp/core/redirection.c
+++ b/libfreerdp/core/redirection.c
@@ -35,14 +35,14 @@ struct rdp_redirection
 	UINT32 flags;
 	UINT32 sessionID;
 	BYTE* TsvUrl;
-	DWORD TsvUrlLength;
+	UINT32 TsvUrlLength;
 	char* Username;
 	char* Domain;
 	BYTE* Password;
-	DWORD PasswordLength;
+	UINT32 PasswordLength;
 	char* TargetFQDN;
 	BYTE* LoadBalanceInfo;
-	DWORD LoadBalanceInfoLength;
+	UINT32 LoadBalanceInfoLength;
 	char* TargetNetBiosName;
 	char* TargetNetAddress;
 	UINT32 TargetNetAddressesCount;
@@ -79,9 +79,9 @@ static void redirection_free_string(char** str)
 static void redirection_free_data(BYTE** str, UINT32* length)
 {
 	WINPR_ASSERT(str);
-	WINPR_ASSERT(length);
 	free(*str);
-	*length = 0;
+	if (length)
+		*length = 0;
 	*str = NULL;
 }
 
@@ -158,7 +158,7 @@ static void rdp_print_redirection_flags(UINT32 flags)
 
 static BOOL rdp_redirection_read_unicode_string(wStream* s, char** str, size_t maxLength)
 {
-	UINT32 length;
+	UINT32 length = 0;
 	const WCHAR* wstr = NULL;
 
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, 4))
@@ -168,18 +168,15 @@ static BOOL rdp_redirection_read_unicode_string(wStream* s, char** str, size_t m
 
 	if ((length % 2) || length < 2 || length > maxLength)
 	{
-		WLog_ERR(TAG,
-		         "rdp_redirection_read_string failure: invalid unicode string length: %" PRIu32 "",
+		WLog_ERR(TAG, "[%s] failure: invalid unicode string length: %" PRIu32 "", __FUNCTION__,
 		         length);
 		return FALSE;
 	}
 
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, length))
 	{
-		WLog_ERR(TAG,
-		         "rdp_redirection_read_string failure: insufficient stream length (%" PRIu32
-		         " bytes required)",
-		         length);
+		WLog_ERR(TAG, "[%s] failure: insufficient stream length (%" PRIu32 " bytes required)",
+		         __FUNCTION__, length);
 		return FALSE;
 	}
 
@@ -187,7 +184,7 @@ static BOOL rdp_redirection_read_unicode_string(wStream* s, char** str, size_t m
 
 	if (wstr[length / 2 - 1])
 	{
-		WLog_ERR(TAG, "rdp_redirection_read_string failure: unterminated unicode string");
+		WLog_ERR(TAG, "[%s] failure: unterminated unicode string", __FUNCTION__);
 		return FALSE;
 	}
 
@@ -195,7 +192,7 @@ static BOOL rdp_redirection_read_unicode_string(wStream* s, char** str, size_t m
 	*str = ConvertWCharNToUtf8Alloc(wstr, length / sizeof(WCHAR), NULL);
 	if (!*str)
 	{
-		WLog_ERR(TAG, "rdp_redirection_read_string failure: string conversion failed");
+		WLog_ERR(TAG, "[%s] failure: string conversion failed", __FUNCTION__);
 		return FALSE;
 	}
 
@@ -205,8 +202,8 @@ static BOOL rdp_redirection_read_unicode_string(wStream* s, char** str, size_t m
 
 int rdp_redirection_apply_settings(rdpRdp* rdp)
 {
-	rdpSettings* settings;
-	rdpRedirection* redirection;
+	rdpSettings* settings = NULL;
+	rdpRedirection* redirection = NULL;
 
 	if (!rdp_reset_runtime_settings(rdp))
 		return -1;
@@ -354,7 +351,7 @@ static BOOL rdp_redirection_read_data(UINT32 flag, wStream* s, UINT32* pLength, 
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, *pLength))
 		return FALSE;
 
-	redirection_free_data(pData, pLength);
+	redirection_free_data(pData, NULL);
 	*pData = (BYTE*)malloc(*pLength);
 
 	if (!*pData)
@@ -368,8 +365,8 @@ static BOOL rdp_redirection_read_data(UINT32 flag, wStream* s, UINT32* pLength, 
 
 static state_run_t rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 {
-	UINT16 flags;
-	UINT16 length;
+	UINT16 flags = 0;
+	UINT16 length = 0;
 	rdpRedirection* redirection = rdp->redirection;
 
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, 12))
@@ -515,9 +512,8 @@ static state_run_t rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 
 	if (redirection->flags & LB_TARGET_NET_ADDRESSES)
 	{
-		size_t i;
-		UINT32 count;
-		UINT32 targetNetAddressesLength;
+		UINT32 count = 0;
+		UINT32 targetNetAddressesLength = 0;
 
 		if (!Stream_CheckAndLogRequiredLength(TAG, s, 8))
 			return STATE_RUN_FAILED;
@@ -530,14 +526,14 @@ static state_run_t rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 		if (!redirection->TargetNetAddresses)
 			return STATE_RUN_FAILED;
 
-		WLog_DBG(TAG, "TargetNetAddressesCount: %" PRIu32 "", redirection->TargetNetAddressesCount);
+		WLog_DBG(TAG, "TargetNetAddressesCount: %" PRIu32 "", count);
 
-		for (i = 0; i < count; i++)
+		for (UINT32 i = 0; i < count; i++)
 		{
 			if (!rdp_redirection_read_unicode_string(s, &(redirection->TargetNetAddresses[i]), 80))
 				return STATE_RUN_FAILED;
 
-			WLog_DBG(TAG, "TargetNetAddresses[%" PRIuz "]: %s", i,
+			WLog_DBG(TAG, "TargetNetAddresses[%" PRIu32 "]: %s", i,
 			         redirection->TargetNetAddresses[i]);
 		}
 	}
@@ -577,8 +573,7 @@ state_run_t rdp_recv_enhanced_security_redirection_packet(rdpRdp* rdp, wStream* 
 
 rdpRedirection* redirection_new(void)
 {
-	rdpRedirection* redirection;
-	redirection = (rdpRedirection*)calloc(1, sizeof(rdpRedirection));
+	rdpRedirection* redirection = (rdpRedirection*)calloc(1, sizeof(rdpRedirection));
 
 	if (redirection)
 	{
@@ -726,7 +721,6 @@ BOOL rdp_write_enhanced_security_redirection_packet(wStream* s, const rdpRedirec
 
 	if (redirection->flags & LB_TARGET_NET_ADDRESSES)
 	{
-		UINT32 i;
 		UINT32 length = sizeof(UINT32);
 
 		if (!Stream_EnsureRemainingCapacity(s, 2 * sizeof(UINT32)))
@@ -735,7 +729,7 @@ BOOL rdp_write_enhanced_security_redirection_packet(wStream* s, const rdpRedirec
 		const size_t start = Stream_GetPosition(s);
 		Stream_Seek_UINT32(s); /* length of field */
 		Stream_Write_UINT32(s, redirection->TargetNetAddressesCount);
-		for (i = 0; i < redirection->TargetNetAddressesCount; i++)
+		for (UINT32 i = 0; i < redirection->TargetNetAddressesCount; i++)
 		{
 			const SSIZE_T rcc =
 			    redir_write_string(LB_TARGET_NET_ADDRESSES, s, redirection->TargetNetAddresses[i]);

--- a/libfreerdp/core/redirection.c
+++ b/libfreerdp/core/redirection.c
@@ -208,17 +208,11 @@ int rdp_redirection_apply_settings(rdpRdp* rdp)
 	rdpSettings* settings;
 	rdpRedirection* redirection;
 
-	WINPR_ASSERT(rdp);
-
-	freerdp_settings_free(rdp->settings);
-	rdp->context->settings = rdp->settings = freerdp_settings_clone(rdp->originalSettings);
+	if (!rdp_reset_runtime_settings(rdp))
+		return -1;
 
 	settings = rdp->settings;
 	WINPR_ASSERT(settings);
-
-	freerdp_settings_free(rdp->remoteSettings);
-	rdp->remoteSettings = freerdp_settings_new(0);
-	WINPR_ASSERT(rdp->remoteSettings);
 
 	redirection = rdp->redirection;
 	WINPR_ASSERT(redirection);

--- a/libfreerdp/core/redirection.c
+++ b/libfreerdp/core/redirection.c
@@ -216,6 +216,10 @@ int rdp_redirection_apply_settings(rdpRdp* rdp)
 	settings = rdp->settings;
 	WINPR_ASSERT(settings);
 
+	freerdp_settings_free(rdp->remoteSettings);
+	rdp->remoteSettings = freerdp_settings_new(0);
+	WINPR_ASSERT(rdp->remoteSettings);
+
 	redirection = rdp->redirection;
 	WINPR_ASSERT(redirection);
 

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -374,7 +374,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	                               (flags & FREERDP_SETTINGS_SERVER_MODE) ? TRUE : FALSE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_WaitForOutputBufferFlush, TRUE) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_ClusterInfoFlags,
-	                                 REDIRECTION_SUPPORTED | (REDIRECTION_VERSION4 << 2)) ||
+	                                 REDIRECTION_SUPPORTED | (REDIRECTION_VERSION6 << 2)) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_DesktopWidth, 1024) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_DesktopHeight, 768) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_Workarea, FALSE) ||


### PR DESCRIPTION
1. Fixes a bug introduced in #8611 
2. move `rcvSettings` to context (preparation for gcc settings split)
3. add some stringification functions (always nice to have for logging)
4. update settings default to use `REDIRECTION_VERSION6` 
5. some code cleanups