### PR TITLE
Log stream capacity

### DIFF
--- a/channels/audin/client/audin_main.c
+++ b/channels/audin/client/audin_main.c
@@ -568,7 +568,7 @@ static UINT audin_on_data_received(IWTSVirtualChannelCallback* pChannelCallback,
 	if (!audin)
 		return ERROR_INTERNAL_ERROR;
 
-	if (Stream_GetRemainingCapacity(data) < 1)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, data, 1))
 		return ERROR_NO_DATA;
 
 	Stream_Read_UINT8(data, MessageId);

--- a/channels/disp/server/disp_main.c
+++ b/channels/disp/server/disp_main.c
@@ -154,8 +154,8 @@ static UINT disp_recv_display_control_monitor_layout_pdu(wStream* s, DispServerC
 		return ERROR_INVALID_DATA;
 	}
 
-	if (!Stream_CheckAndLogRequiredLength(
-	        TAG, s, pdu.NumMonitors * 1ull * DISPLAY_CONTROL_MONITOR_LAYOUT_SIZE))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, pdu.NumMonitors,
+	                                            DISPLAY_CONTROL_MONITOR_LAYOUT_SIZE))
 		return ERROR_INVALID_DATA;
 
 	pdu.Monitors = (DISPLAY_CONTROL_MONITOR_LAYOUT*)calloc(pdu.NumMonitors,

--- a/channels/encomsp/client/encomsp_main.c
+++ b/channels/encomsp/client/encomsp_main.c
@@ -92,7 +92,7 @@ static UINT encomsp_read_unicode_string(wStream* s, ENCOMSP_UNICODE_STRING* str)
 		return ERROR_INVALID_DATA;
 	}
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, sizeof(WCHAR) * str->cchString))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, str->cchString, sizeof(WCHAR)))
 		return ERROR_INVALID_DATA;
 
 	Stream_Read(s, &(str->wString), (str->cchString * 2)); /* String (variable) */

--- a/channels/encomsp/server/encomsp_main.c
+++ b/channels/encomsp/server/encomsp_main.c
@@ -67,7 +67,7 @@ static int encomsp_read_unicode_string(wStream* s, ENCOMSP_UNICODE_STRING* str)
 	if (str->cchString > 1024)
 		return -1;
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, (str->cchString * 2ull)))
+    if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, str->cchString, sizeof(WCHAR)))
 		return -1;
 
 	Stream_Read(s, &(str->wString), (str->cchString * 2)); /* String (variable) */

--- a/channels/rdpgfx/client/rdpgfx_codec.c
+++ b/channels/rdpgfx/client/rdpgfx_codec.c
@@ -51,7 +51,7 @@ static UINT rdpgfx_read_h264_metablock(RDPGFX_PLUGIN* gfx, wStream* s, RDPGFX_H2
 
 	Stream_Read_UINT32(s, meta->numRegionRects); /* numRegionRects (4 bytes) */
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 8ull * meta->numRegionRects))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, meta->numRegionRects, 8ull))
 		goto error_out;
 
 	meta->regionRects = (RECTANGLE_16*)calloc(meta->numRegionRects, sizeof(RECTANGLE_16));
@@ -91,7 +91,7 @@ static UINT rdpgfx_read_h264_metablock(RDPGFX_PLUGIN* gfx, wStream* s, RDPGFX_H2
 		         index, regionRect->left, regionRect->top, regionRect->right, regionRect->bottom);
 	}
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 2ull * meta->numRegionRects))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, meta->numRegionRects, 2ull))
 	{
 		error = ERROR_INVALID_DATA;
 		goto error_out;

--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -521,7 +521,7 @@ static UINT rdpgfx_recv_reset_graphics_pdu(GENERIC_CHANNEL_CALLBACK* callback, w
 	Stream_Read_UINT32(s, pdu.height);       /* height (4 bytes) */
 	Stream_Read_UINT32(s, pdu.monitorCount); /* monitorCount (4 bytes) */
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 20ull * pdu.monitorCount))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, pdu.monitorCount, 20ull))
 		return ERROR_INVALID_DATA;
 
 	pdu.monitorDefArray = (MONITOR_DEF*)calloc(pdu.monitorCount, sizeof(MONITOR_DEF));
@@ -1001,7 +1001,7 @@ static UINT rdpgfx_recv_cache_import_reply_pdu(GENERIC_CHANNEL_CALLBACK* callbac
 
 	Stream_Read_UINT16(s, pdu.importedEntriesCount); /* cacheSlot (2 bytes) */
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 2ull * pdu.importedEntriesCount))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, pdu.importedEntriesCount, 2ull))
 		return ERROR_INVALID_DATA;
 
 	if (pdu.importedEntriesCount > RDPGFX_CACHE_ENTRY_MAX_COUNT)
@@ -1477,7 +1477,7 @@ static UINT rdpgfx_recv_solid_fill_pdu(GENERIC_CHANNEL_CALLBACK* callback, wStre
 
 	Stream_Read_UINT16(s, pdu.fillRectCount); /* fillRectCount (2 bytes) */
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 8ull * pdu.fillRectCount))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, pdu.fillRectCount, 8ull))
 		return ERROR_INVALID_DATA;
 
 	pdu.fillRects = (RECTANGLE_16*)calloc(pdu.fillRectCount, sizeof(RECTANGLE_16));
@@ -1547,7 +1547,7 @@ static UINT rdpgfx_recv_surface_to_surface_pdu(GENERIC_CHANNEL_CALLBACK* callbac
 
 	Stream_Read_UINT16(s, pdu.destPtsCount); /* destPtsCount (2 bytes) */
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 4ULL * pdu.destPtsCount))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, pdu.destPtsCount, 4ull))
 		return ERROR_INVALID_DATA;
 
 	pdu.destPts = (RDPGFX_POINT16*)calloc(pdu.destPtsCount, sizeof(RDPGFX_POINT16));
@@ -1663,7 +1663,7 @@ static UINT rdpgfx_recv_cache_to_surface_pdu(GENERIC_CHANNEL_CALLBACK* callback,
 	Stream_Read_UINT16(s, pdu.surfaceId);    /* surfaceId (2 bytes) */
 	Stream_Read_UINT16(s, pdu.destPtsCount); /* destPtsCount (2 bytes) */
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 4ull * pdu.destPtsCount))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, pdu.destPtsCount, 4ull))
 		return ERROR_INVALID_DATA;
 
 	pdu.destPts = (RDPGFX_POINT16*)calloc(pdu.destPtsCount, sizeof(RDPGFX_POINT16));

--- a/channels/rdpgfx/server/rdpgfx_main.c
+++ b/channels/rdpgfx/server/rdpgfx_main.c
@@ -1141,7 +1141,7 @@ static UINT rdpgfx_recv_cache_import_offer_pdu(RdpgfxServerContext* context, wSt
 		return ERROR_INVALID_DATA;
 	}
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 12ull * pdu.cacheEntriesCount))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, pdu.cacheEntriesCount, 12ull))
 		return ERROR_INVALID_DATA;
 
 	for (index = 0; index < pdu.cacheEntriesCount; index++)

--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -281,7 +281,7 @@ static UINT rdpsnd_recv_server_audio_formats_pdu(rdpsndPlugin* rdpsnd, wStream* 
 	Stream_Seek_UINT8(s);                    /* bPad */
 	rdpsnd->NumberOfServerFormats = wNumberOfFormats;
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 14ull * wNumberOfFormats))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, wNumberOfFormats, 14ull))
 		return ERROR_BAD_LENGTH;
 
 	if (rdpsnd->NumberOfServerFormats > 0)

--- a/channels/rdpsnd/server/rdpsnd_main.c
+++ b/channels/rdpsnd/server/rdpsnd_main.c
@@ -198,7 +198,7 @@ static UINT rdpsnd_server_recv_formats(RdpsndServerContext* context, wStream* s)
 	Stream_Seek_UINT8(s);                               /* bPad */
 
 	/* this check is only a guess as cbSize can influence the size of a format record */
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 18ull * context->num_client_formats))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, context->num_client_formats, 18ull))
 		return ERROR_INVALID_DATA;
 
 	if (!context->num_client_formats)

--- a/channels/urbdrc/client/data_transfer.c
+++ b/channels/urbdrc/client/data_transfer.c
@@ -825,11 +825,14 @@ static UINT urb_isoch_transfer(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callbac
 	Stream_Read_UINT32(s, NumberOfPackets); /** NumberOfPackets */
 	Stream_Read_UINT32(s, ErrorCount);      /** ErrorCount */
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, NumberOfPackets * 12ULL + 4ULL))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, NumberOfPackets, 12ull))
 		return ERROR_INVALID_DATA;
 
 	packetDescriptorData = Stream_Pointer(s);
 	Stream_Seek(s, NumberOfPackets * 12);
+
+	if (!Stream_CheckAndLogRequiredLength(TAG, s, sizeof(UINT32)))
+		return ERROR_INVALID_DATA;
 	Stream_Read_UINT32(s, OutputBufferSize);
 
 	if (transferDir == USBD_TRANSFER_DIRECTION_OUT)

--- a/channels/urbdrc/common/msusb.c
+++ b/channels/urbdrc/common/msusb.c
@@ -64,7 +64,7 @@ static MSUSB_PIPE_DESCRIPTOR** msusb_mspipes_read(wStream* s, UINT32 NumberOfPip
 	UINT32 pnum;
 	MSUSB_PIPE_DESCRIPTOR** MsPipes;
 
-	if (Stream_GetRemainingCapacity(s) / 12 < NumberOfPipes)
+	if (!Stream_CheckAndLogRequiredCapacityOfSize(TAG, (s), NumberOfPipes, 12ull))
 		return NULL;
 
 	MsPipes = (MSUSB_PIPE_DESCRIPTOR**)calloc(NumberOfPipes, sizeof(MSUSB_PIPE_DESCRIPTOR*));
@@ -149,7 +149,7 @@ MSUSB_INTERFACE_DESCRIPTOR* msusb_msinterface_read(wStream* s)
 {
 	MSUSB_INTERFACE_DESCRIPTOR* MsInterface;
 
-	if (Stream_GetRemainingCapacity(s) < 12)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 12))
 		return NULL;
 
 	MsInterface = msusb_msinterface_new();
@@ -317,7 +317,7 @@ MSUSB_CONFIG_DESCRIPTOR* msusb_msconfig_read(wStream* s, UINT32 NumInterfaces)
 	MSUSB_CONFIG_DESCRIPTOR* MsConfig;
 	BYTE lenConfiguration, typeConfiguration;
 
-	if (Stream_GetRemainingCapacity(s) < 6ULL + NumInterfaces * 2ULL)
+	if (!Stream_CheckAndLogRequiredCapacityOfSize(TAG, (s), 3ULL + NumInterfaces, 2ULL))
 		return NULL;
 
 	MsConfig = msusb_msconfig_new();

--- a/libfreerdp/codec/clear.c
+++ b/libfreerdp/codec/clear.c
@@ -176,7 +176,7 @@ static BOOL clear_decompress_subcode_rlex(wStream* s, UINT32 bitmapDataByteCount
 		return FALSE;
 	}
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 3ull * paletteCount))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, paletteCount, 3ull))
 		return FALSE;
 
 	for (i = 0; i < paletteCount; i++)
@@ -689,7 +689,7 @@ static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* clear, wStream* s, UINT32
 					return FALSE;
 				}
 
-				if (!Stream_CheckAndLogRequiredLength(TAG, s, 3ull * vBarShortPixelCount))
+				if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, vBarShortPixelCount, 3ull))
 					return FALSE;
 
 				if (clear->ShortVBarStorageCursor >= CLEARCODEC_VBAR_SHORT_SIZE)

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -2253,7 +2253,7 @@ static INLINE INT32 progressive_wb_read_region_header(PROGRESSIVE_CONTEXT* progr
 	}
 
 	len = Stream_GetRemainingLength(s);
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 8ull * region->numRects))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, region->numRects, 8ull))
 	{
 		WLog_Print(progressive->log, WLOG_ERROR, "ProgressiveRegion data short for region->rects");
 		return -1015;

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -516,7 +516,7 @@ static BOOL rfx_process_message_channels(RFX_CONTEXT* context, wStream* s)
 		return FALSE;
 	}
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 5ull * numChannels))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, numChannels, 5ull))
 		return FALSE;
 
 	/* RFX_CHANNELT */
@@ -679,7 +679,7 @@ static BOOL rfx_process_message_region(RFX_CONTEXT* context, RFX_MESSAGE* messag
 		return TRUE;
 	}
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 8ull * message->numRects))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, message->numRects, 8ull))
 		return FALSE;
 
 	tmpRects = realloc(message->rects, message->numRects * sizeof(RFX_RECT));
@@ -796,7 +796,7 @@ static BOOL rfx_process_message_tileset(RFX_CONTEXT* context, RFX_MESSAGE* messa
 	quants = context->quants = (UINT32*)pmem;
 
 	/* quantVals */
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 5ull * context->numQuant))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, context->numQuant, 5ull))
 		return FALSE;
 
 	for (i = 0; i < context->numQuant; i++)

--- a/libfreerdp/codec/zgfx.c
+++ b/libfreerdp/codec/zgfx.c
@@ -421,7 +421,7 @@ int zgfx_decompress(ZGFX_CONTEXT* zgfx, const BYTE* pSrcData, UINT32 SrcSize, BY
 		Stream_Read_UINT16(stream, segmentCount);     /* segmentCount (2 bytes) */
 		Stream_Read_UINT32(stream, uncompressedSize); /* uncompressedSize (4 bytes) */
 
-		if (!Stream_CheckAndLogRequiredLength(TAG, stream, sizeof(UINT32) * segmentCount))
+		if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, stream, segmentCount, sizeof(UINT32)))
 			goto fail;
 
 		pConcatenated = aligned_zgfx_malloc(uncompressedSize);

--- a/libfreerdp/core/activation.c
+++ b/libfreerdp/core/activation.c
@@ -34,7 +34,7 @@ static BOOL rdp_write_synchronize_pdu(wStream* s, const rdpSettings* settings)
 {
 	const UINT32 PduSource = freerdp_settings_get_uint32(settings, FreeRDP_PduSource);
 
-	if (Stream_GetRemainingCapacity(s) < 4)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 4))
 		return FALSE;
 	Stream_Write_UINT16(s, SYNCMSGTYPE_SYNC); /* messageType (2 bytes) */
 	Stream_Write_UINT16(s, PduSource);        /* targetUser (2 bytes) */
@@ -129,7 +129,7 @@ static BOOL rdp_write_client_control_pdu(wStream* s, UINT16 action, UINT16 grant
                                          UINT32 controlId)
 {
 	WINPR_ASSERT(s);
-	if (Stream_GetRemainingCapacity(s) < 8)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 8))
 		return FALSE;
 	Stream_Write_UINT16(s, action);    /* action (2 bytes) */
 	Stream_Write_UINT16(s, grantId);   /* grantId (2 bytes) */
@@ -172,7 +172,7 @@ BOOL rdp_send_server_control_cooperate_pdu(rdpRdp* rdp)
 	wStream* s = rdp_data_pdu_init(rdp);
 	if (!s)
 		return FALSE;
-	if (Stream_GetRemainingCapacity(s) < 8)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 8))
 	{
 		Stream_Free(s, TRUE);
 		return FALSE;
@@ -190,7 +190,7 @@ static BOOL rdp_send_server_control_granted_pdu(rdpRdp* rdp)
 	wStream* s = rdp_data_pdu_init(rdp);
 	if (!s)
 		return FALSE;
-	if (Stream_GetRemainingCapacity(s) < 8)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 8))
 	{
 		Stream_Free(s, TRUE);
 		return FALSE;
@@ -487,7 +487,7 @@ static BOOL rdp_write_client_font_list_pdu(wStream* s, UINT16 flags)
 {
 	WINPR_ASSERT(s);
 
-	if (Stream_GetRemainingCapacity(s) < 8)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 8))
 		return FALSE;
 	Stream_Write_UINT16(s, 0);     /* numberFonts (2 bytes) */
 	Stream_Write_UINT16(s, 0);     /* totalNumFonts (2 bytes) */
@@ -565,7 +565,7 @@ BOOL rdp_send_server_font_map_pdu(rdpRdp* rdp)
 	wStream* s = rdp_data_pdu_init(rdp);
 	if (!s)
 		return FALSE;
-	if (Stream_GetRemainingCapacity(s) < 8)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 8))
 	{
 		Stream_Free(s, TRUE);
 		return FALSE;
@@ -638,7 +638,7 @@ BOOL rdp_send_deactivate_all(rdpRdp* rdp)
 	if (!s)
 		return FALSE;
 
-	if (Stream_GetRemainingCapacity(s) < 7)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 7))
 		goto fail;
 
 	WINPR_ASSERT(rdp->settings);

--- a/libfreerdp/core/activation.c
+++ b/libfreerdp/core/activation.c
@@ -46,7 +46,7 @@ static BOOL rdp_recv_sync_pdu(rdpRdp* rdp, wStream* s, const char* what)
 	UINT16 msgType, targetUser;
 
 	WINPR_UNUSED(rdp);
-	if (!Stream_CheckAndLogRequiredLengthEx(TAG, WLOG_WARN, s, 4, "%s(%s:%" PRIuz ") %s",
+	if (!Stream_CheckAndLogRequiredLengthEx(TAG, WLOG_WARN, s, 4, 1, "%s(%s:%" PRIuz ") %s",
 	                                        __FUNCTION__, __FILE__, (size_t)__LINE__, what))
 		return FALSE;
 	Stream_Read_UINT16(s, msgType);

--- a/libfreerdp/core/activation.c
+++ b/libfreerdp/core/activation.c
@@ -47,7 +47,7 @@ static BOOL rdp_recv_sync_pdu(rdpRdp* rdp, wStream* s, const char* what)
 
 	WINPR_UNUSED(rdp);
 	if (!Stream_CheckAndLogRequiredLengthEx(TAG, WLOG_WARN, s, 4, "%s(%s:%" PRIuz ") %s",
-	                                        __FUNCTION__, __FILE__, __LINE__, what))
+	                                        __FUNCTION__, __FILE__, (size_t)__LINE__, what))
 		return FALSE;
 	Stream_Read_UINT16(s, msgType);
 	if (msgType != SYNCMSGTYPE_SYNC)

--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -131,7 +131,7 @@ static void rdp_write_capability_set_header(wStream* s, UINT16 length, UINT16 ty
 static size_t rdp_capability_set_start(wStream* s)
 {
 	size_t header = Stream_GetPosition(s);
-	if (Stream_GetRemainingCapacity(s) < CAPSET_HEADER_LENGTH)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), CAPSET_HEADER_LENGTH))
 		return SIZE_MAX;
 	Stream_Zero(s, CAPSET_HEADER_LENGTH);
 	return header;
@@ -3674,7 +3674,7 @@ BOOL rdp_print_capability_sets(wStream* s, size_t start, BOOL receiving)
 	}
 	else
 	{
-		if (Stream_GetRemainingCapacity(s) < 4)
+		if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 4))
 			goto fail;
 	}
 

--- a/libfreerdp/core/fastpath.c
+++ b/libfreerdp/core/fastpath.c
@@ -117,19 +117,19 @@ static BOOL fastpath_write_update_header(wStream* s, FASTPATH_UPDATE_HEADER* fpU
 	fpUpdateHeader->updateHeader |= (fpUpdateHeader->fragmentation & 0x03) << 4;
 	fpUpdateHeader->updateHeader |= (fpUpdateHeader->compression & 0x03) << 6;
 
-	if (Stream_GetRemainingCapacity(s) < 1)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 1))
 		return FALSE;
 	Stream_Write_UINT8(s, fpUpdateHeader->updateHeader);
 
 	if (fpUpdateHeader->compression)
 	{
-		if (Stream_GetRemainingCapacity(s) < 1)
+		if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 1))
 			return FALSE;
 
 		Stream_Write_UINT8(s, fpUpdateHeader->compressionFlags);
 	}
 
-	if (Stream_GetRemainingCapacity(s) < 2)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 2))
 		return FALSE;
 
 	Stream_Write_UINT16(s, fpUpdateHeader->size);
@@ -149,7 +149,7 @@ static BOOL fastpath_write_update_pdu_header(wStream* s,
 	if (!s || !fpUpdatePduHeader || !rdp)
 		return FALSE;
 
-	if (Stream_GetRemainingCapacity(s) < 3)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 3))
 		return FALSE;
 
 	fpUpdatePduHeader->fpOutputHeader = 0;
@@ -164,13 +164,13 @@ static BOOL fastpath_write_update_pdu_header(wStream* s,
 		WINPR_ASSERT(rdp->settings);
 		if (rdp->settings->EncryptionMethods == ENCRYPTION_METHOD_FIPS)
 		{
-			if (Stream_GetRemainingCapacity(s) < 4)
+			if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 4))
 				return FALSE;
 
 			Stream_Write(s, fpUpdatePduHeader->fipsInformation, 4);
 		}
 
-		if (Stream_GetRemainingCapacity(s) < 8)
+		if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 8))
 			return FALSE;
 
 		Stream_Write(s, fpUpdatePduHeader->dataSignature, 8);
@@ -1198,7 +1198,7 @@ BOOL fastpath_send_update_pdu(rdpFastPath* fastpath, BYTE updateCode, wStream* s
 		fastpath_write_update_pdu_header(fs, &fpUpdatePduHeader, rdp);
 		fastpath_write_update_header(fs, &fpUpdateHeader);
 
-		if (Stream_GetRemainingCapacity(fs) < (size_t)DstSize + pad)
+		if (!Stream_CheckAndLogRequiredCapacity(TAG, (fs), (size_t)DstSize + pad))
 			return FALSE;
 		Stream_Write(fs, pDstData, DstSize);
 

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -526,8 +526,18 @@ static int rdg_websocket_read_wstream(BIO* bio, wStream* s,
 		encodingContext->state = WebsocketStateOpcodeAndFin;
 		return 0;
 	}
-	if (s == NULL || Stream_GetRemainingCapacity(s) != encodingContext->payloadLength)
+	if (s == NULL)
+	{
+		WLog_WARN(TAG, "wStream* s=%p", s);
 		return -1;
+	}
+	if (Stream_GetRemainingCapacity(s) != encodingContext->payloadLength)
+	{
+		WLog_WARN(TAG,
+		          "wStream::capacity [%" PRIuz "] != encodingContext::paylaodLangth [%" PRIuz "]",
+		          Stream_GetRemainingCapacity(s), encodingContext->payloadLength);
+		return -1;
+	}
 
 	ERR_clear_error();
 	status = BIO_read(bio, Stream_Pointer(s), encodingContext->payloadLength);

--- a/libfreerdp/core/gateway/rts.c
+++ b/libfreerdp/core/gateway/rts.c
@@ -1319,7 +1319,7 @@ static BOOL rts_version_command_write(wStream* buffer)
 {
 	WINPR_ASSERT(buffer);
 
-	if (Stream_GetRemainingCapacity(buffer) < 8)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (buffer), 8))
 		return FALSE;
 
 	Stream_Write_UINT32(buffer, RTS_CMD_VERSION); /* CommandType (4 bytes) */

--- a/libfreerdp/core/gateway/rts.c
+++ b/libfreerdp/core/gateway/rts.c
@@ -371,7 +371,7 @@ static BOOL rts_read_version(wStream* s, p_rt_version_t* version)
 	WINPR_ASSERT(s);
 	WINPR_ASSERT(version);
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 2 * sizeof(UINT8)))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, 2, sizeof(UINT8)))
 		return FALSE;
 	Stream_Read_UINT8(s, version->major);
 	Stream_Read_UINT8(s, version->minor);

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -2024,7 +2024,7 @@ BOOL gcc_read_server_network_data(wStream* s, rdpMcs* mcs)
 		mcs->channelCount = channelCount;
 	}
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 2ull * channelCount))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, channelCount, 2ull))
 		return FALSE;
 
 	for (UINT32 i = 0; i < parsedChannelCount; i++)

--- a/libfreerdp/core/input.c
+++ b/libfreerdp/core/input.c
@@ -692,7 +692,7 @@ BOOL input_recv(rdpInput* input, wStream* s)
 	Stream_Seek(s, 2);                   /* pad2Octets (2 bytes) */
 
 	/* Each input event uses 6 exactly bytes. */
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 6ull * numberEvents))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, numberEvents, 6ull))
 		return FALSE;
 
 	for (i = 0; i < numberEvents; i++)

--- a/libfreerdp/core/license.c
+++ b/libfreerdp/core/license.c
@@ -464,7 +464,7 @@ static BOOL license_check_stream_capacity(wStream* s, size_t expect, const char*
 	WINPR_ASSERT(where);
 
 	if (!Stream_CheckAndLogRequiredCapacityEx(TAG, WLOG_WARN, s, expect, 1, "%s(%s:%" PRIuz ") %s",
-	                                          __FUNCTION__, __FILE__, __LINE__, where))
+	                                          __FUNCTION__, __FILE__, (size_t)__LINE__, where))
 		return FALSE;
 
 	return TRUE;

--- a/libfreerdp/core/license.c
+++ b/libfreerdp/core/license.c
@@ -463,12 +463,10 @@ static BOOL license_check_stream_capacity(wStream* s, size_t expect, const char*
 {
 	WINPR_ASSERT(where);
 
-	if (Stream_GetRemainingCapacity(s) < expect)
-	{
-		WLog_WARN(TAG, "short capacity %s, expected %" PRIuz " bytes, got %" PRIuz, where, expect,
-		          Stream_GetRemainingCapacity(s));
+	if (!Stream_CheckAndLogRequiredCapacityEx(TAG, WLOG_WARN, s, expect, 1, "%s(%s:%" PRIuz ") %s",
+	                                          __FUNCTION__, __FILE__, __LINE__, where))
 		return FALSE;
-	}
+
 	return TRUE;
 }
 

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -2457,7 +2457,7 @@ static CACHE_COLOR_TABLE_ORDER* update_read_cache_color_table_order(rdpUpdate* u
 		goto fail;
 	}
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 4ull * cache_color_table->numberColors))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, cache_color_table->numberColors, 4ull))
 		goto fail;
 
 	colorTable = (UINT32*)&cache_color_table->colorTable;
@@ -2557,7 +2557,8 @@ static CACHE_GLYPH_ORDER* update_read_cache_glyph_order(rdpUpdate* update, wStre
 		if (!cache_glyph_order->unicodeCharacters)
 			goto fail;
 
-		if (!Stream_CheckAndLogRequiredLength(TAG, s, sizeof(WCHAR) * cache_glyph_order->cGlyphs))
+		if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, cache_glyph_order->cGlyphs,
+		                                            sizeof(WCHAR)))
 			goto fail;
 
 		Stream_Read_UTF16_String(s, cache_glyph_order->unicodeCharacters,
@@ -2664,7 +2665,7 @@ static CACHE_GLYPH_V2_ORDER* update_read_cache_glyph_v2_order(rdpUpdate* update,
 		if (!cache_glyph_v2->unicodeCharacters)
 			goto fail;
 
-		if (!Stream_CheckAndLogRequiredLength(TAG, s, sizeof(WCHAR) * cache_glyph_v2->cGlyphs))
+		if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, cache_glyph_v2->cGlyphs, sizeof(WCHAR)))
 			goto fail;
 
 		Stream_Read_UTF16_String(s, cache_glyph_v2->unicodeCharacters, cache_glyph_v2->cGlyphs);
@@ -2729,7 +2730,7 @@ static BOOL update_decompress_brush(wStream* s, BYTE* output, size_t outSize, BY
 	const BYTE* palette = Stream_Pointer(s) + 16;
 	const size_t bytesPerPixel = ((bpp + 1) / 8);
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 16ULL + bytesPerPixel * 4ULL))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, 4ULL + bytesPerPixel, 4ULL))
 		return FALSE;
 
 	for (y = 7; y >= 0; y--)
@@ -2829,7 +2830,7 @@ static CACHE_BRUSH_ORDER* update_read_cache_brush_order(rdpUpdate* update, wStre
 				/* uncompressed brush */
 				UINT32 scanline = (cache_brush->bpp / 8) * 8;
 
-				if (!Stream_CheckAndLogRequiredLength(TAG, s, 8ull * scanline))
+				if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, scanline, 8ull))
 					goto fail;
 
 				for (i = 7; i >= 0; i--)
@@ -2967,7 +2968,7 @@ update_read_create_offscreen_bitmap_order(wStream* s,
 			deleteList->indices = new_indices;
 		}
 
-		if (!Stream_CheckAndLogRequiredLength(TAG, s, 2ull * deleteList->cIndices))
+		if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, deleteList->cIndices, 2ull))
 			return FALSE;
 
 		for (i = 0; i < deleteList->cIndices; i++)

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -944,7 +944,7 @@ static BOOL rdp_recv_monitor_layout_pdu(rdpRdp* rdp, wStream* s)
 
 	Stream_Read_UINT32(s, monitorCount); /* monitorCount (4 bytes) */
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 20ull * monitorCount))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, monitorCount, 20ull))
 		return FALSE;
 
 	monitorDefArray = (MONITOR_DEF*)calloc(monitorCount, sizeof(MONITOR_DEF));

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -165,7 +165,7 @@ BOOL rdp_write_security_header(wStream* s, UINT16 flags)
 {
 	WINPR_ASSERT(s);
 
-	if (Stream_GetRemainingCapacity(s) < 4)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 4))
 		return FALSE;
 
 	/* Basic Security Header */
@@ -239,7 +239,7 @@ BOOL rdp_write_share_control_header(wStream* s, UINT16 length, UINT16 type, UINT
 
 	if (length < RDP_PACKET_HEADER_MAX_LENGTH)
 		return FALSE;
-	if (Stream_GetRemainingCapacity(s) < 6)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 6))
 		return FALSE;
 	length -= RDP_PACKET_HEADER_MAX_LENGTH;
 	/* Share Control Header */
@@ -278,7 +278,7 @@ BOOL rdp_write_share_data_header(wStream* s, UINT16 length, BYTE type, UINT32 sh
 	if (length < headerLen)
 		return FALSE;
 	length -= headerLen;
-	if (Stream_GetRemainingCapacity(s) < 12)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 12))
 		return FALSE;
 
 	/* Share Data Header */

--- a/libfreerdp/core/tpdu.c
+++ b/libfreerdp/core/tpdu.c
@@ -116,7 +116,7 @@ BOOL tpdu_read_header(wStream* s, BYTE* code, BYTE* li, UINT16 tpktlength)
 
 BOOL tpdu_write_header(wStream* s, UINT16 length, BYTE code)
 {
-	if (Stream_GetRemainingCapacity(s) < 3)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 3))
 		return FALSE;
 
 	Stream_Write_UINT8(s, length); /* LI */
@@ -128,7 +128,7 @@ BOOL tpdu_write_header(wStream* s, UINT16 length, BYTE code)
 	}
 	else
 	{
-		if (Stream_GetRemainingCapacity(s) < 5)
+		if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 5))
 			return FALSE;
 		Stream_Write_UINT16(s, 0); /* DST-REF */
 		Stream_Write_UINT16(s, 0); /* SRC-REF */

--- a/libfreerdp/core/tpkt.c
+++ b/libfreerdp/core/tpkt.c
@@ -156,7 +156,7 @@ BOOL tpkt_ensure_stream_consumed_(wStream* s, UINT16 length, const char* fkt)
 
 BOOL tpkt_write_header(wStream* s, UINT16 length)
 {
-	if (Stream_GetRemainingCapacity(s) < 4)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 4))
 		return FALSE;
 	Stream_Write_UINT8(s, 3);          /* version */
 	Stream_Write_UINT8(s, 0);          /* reserved */

--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -274,7 +274,7 @@ PALETTE_UPDATE* update_read_palette(rdpUpdate* update, wStream* s)
 	if (palette_update->number > 256)
 		palette_update->number = 256;
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 3ull * palette_update->number))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, palette_update->number, 3ull))
 		goto fail;
 
 	/* paletteEntries */
@@ -2341,7 +2341,7 @@ BOOL update_read_refresh_rect(rdpUpdate* update, wStream* s)
 	Stream_Read_UINT8(s, numberOfAreas);
 	Stream_Seek(s, 3); /* pad3Octects */
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 8ull * numberOfAreas))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, numberOfAreas, 8ull))
 		return FALSE;
 
 	for (BYTE index = 0; index < numberOfAreas; index++)

--- a/libfreerdp/core/window.c
+++ b/libfreerdp/core/window.c
@@ -372,7 +372,7 @@ static BOOL update_read_window_state_order(wStream* s, WINDOW_ORDER_INFO* orderI
 
 			windowState->windowRects = newRect;
 
-			if (!Stream_CheckAndLogRequiredLength(TAG, s, 8ull * windowState->numWindowRects))
+			if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, windowState->numWindowRects, 8ull))
 				return FALSE;
 
 			/* windowRects */
@@ -416,7 +416,8 @@ static BOOL update_read_window_state_order(wStream* s, WINDOW_ORDER_INFO* orderI
 
 			windowState->visibilityRects = newRect;
 
-			if (!Stream_CheckAndLogRequiredLength(TAG, s, 8ull * windowState->numVisibilityRects))
+			if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, windowState->numVisibilityRects,
+			                                            8ull))
 				return FALSE;
 
 			/* visibilityRects */
@@ -912,7 +913,7 @@ static BOOL update_read_desktop_actively_monitored_order(wStream* s, WINDOW_ORDE
 
 		Stream_Read_UINT8(s, monitored_desktop->numWindowIds); /* numWindowIds (1 byte) */
 
-		if (!Stream_CheckAndLogRequiredLength(TAG, s, 4ull * monitored_desktop->numWindowIds))
+		if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, monitored_desktop->numWindowIds, 4ull))
 			return FALSE;
 
 		if (monitored_desktop->numWindowIds > 0)

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -841,7 +841,7 @@ static UINT gdi_SurfaceCommand_Alpha(rdpGdi* gdi, RdpgfxClientContext* context,
 
 	if (compressed == 0)
 	{
-		if (!Stream_CheckAndLogRequiredLength(TAG, s, cmd->height * cmd->width * 1ULL))
+		if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, cmd->height, cmd->width))
 			return ERROR_INVALID_DATA;
 
 		for (UINT32 y = cmd->top; y < cmd->top + cmd->height; y++)

--- a/libfreerdp/utils/cliprdr_utils.c
+++ b/libfreerdp/utils/cliprdr_utils.c
@@ -82,7 +82,7 @@ UINT cliprdr_parse_file_list(const BYTE* format_data, UINT32 format_data_length,
 
 	Stream_Read_UINT32(s, count); /* cItems (4 bytes) */
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, CLIPRDR_FILEDESCRIPTOR_SIZE * count * 1ull))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, count, CLIPRDR_FILEDESCRIPTOR_SIZE))
 	{
 		result = ERROR_INCORRECT_SIZE;
 		goto out;

--- a/libfreerdp/utils/smartcard_pack.c
+++ b/libfreerdp/utils/smartcard_pack.c
@@ -160,7 +160,7 @@ static LONG smartcard_ndr_read(wStream* s, BYTE** data, size_t min, size_t eleme
 	if (len > SIZE_MAX / 2)
 		return STATUS_BUFFER_TOO_SMALL;
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, len * elementSize * 1ull))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, len, elementSize))
 		return STATUS_BUFFER_TOO_SMALL;
 
 	len *= elementSize;

--- a/server/proxy/channels/pf_channel_rdpdr.c
+++ b/server/proxy/channels/pf_channel_rdpdr.c
@@ -133,22 +133,24 @@ typedef struct
 	} while (0)
 
 #define Stream_CheckAndLogRequiredLengthSrv(log, s, len)                                       \
-	Stream_CheckAndLogRequiredLengthWLogEx(log, WLOG_WARN, s, len,                             \
+	Stream_CheckAndLogRequiredLengthWLogEx(log, WLOG_WARN, s, len, 1,                          \
 	                                       proxy_client_rx " %s(%s:%" PRIuz ")", __FUNCTION__, \
 	                                       __FILE__, (size_t)__LINE__)
 #define Stream_CheckAndLogRequiredLengthClient(log, s, len)                                    \
-	Stream_CheckAndLogRequiredLengthWLogEx(log, WLOG_WARN, s, len,                             \
+	Stream_CheckAndLogRequiredLengthWLogEx(log, WLOG_WARN, s, len, 1,                          \
 	                                       proxy_server_rx " %s(%s:%" PRIuz ")", __FUNCTION__, \
 	                                       __FILE__, (size_t)__LINE__)
 #define Stream_CheckAndLogRequiredLengthRx(srv, log, s, len) \
-	Stream_CheckAndLogRequiredLengthRx_(srv, log, s, len, __FUNCTION__, __FILE__, __LINE__)
-static BOOL Stream_CheckAndLogRequiredLengthRx_(BOOL srv, wLog* log, wStream* s, size_t len,
-                                                const char* fkt, const char* file, size_t line)
+	Stream_CheckAndLogRequiredLengthRx_(srv, log, s, len, 1, __FUNCTION__, __FILE__, __LINE__)
+static BOOL Stream_CheckAndLogRequiredLengthRx_(BOOL srv, wLog* log, wStream* s, size_t nmemb,
+                                                size_t size, const char* fkt, const char* file,
+                                                size_t line)
 {
 	const char* fmt =
 	    srv ? proxy_server_rx " %s(%s:%" PRIuz ")" : proxy_client_rx " %s(%s:%" PRIuz ")";
 
-	return Stream_CheckAndLogRequiredLengthWLogEx(log, WLOG_WARN, s, len, fmt, fkt, file, line);
+	return Stream_CheckAndLogRequiredLengthWLogEx(log, WLOG_WARN, s, nmemb, size, fmt, fkt, file,
+	                                              line);
 }
 
 static const char* rdpdr_server_state_to_string(pf_channel_server_state state)
@@ -1526,7 +1528,7 @@ static BOOL filter_smartcard_device_list_remove(pf_channel_server_context* rdpdr
 	if (count == 0)
 		return TRUE;
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, count * sizeof(UINT32)))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, count, sizeof(UINT32)))
 		return TRUE;
 
 	for (x = 0; x < count; x++)

--- a/server/proxy/channels/pf_channel_rdpdr.c
+++ b/server/proxy/channels/pf_channel_rdpdr.c
@@ -135,11 +135,11 @@ typedef struct
 #define Stream_CheckAndLogRequiredLengthSrv(log, s, len)                                       \
 	Stream_CheckAndLogRequiredLengthWLogEx(log, WLOG_WARN, s, len,                             \
 	                                       proxy_client_rx " %s(%s:%" PRIuz ")", __FUNCTION__, \
-	                                       __FILE__, __LINE__)
+	                                       __FILE__, (size_t)__LINE__)
 #define Stream_CheckAndLogRequiredLengthClient(log, s, len)                                    \
 	Stream_CheckAndLogRequiredLengthWLogEx(log, WLOG_WARN, s, len,                             \
 	                                       proxy_server_rx " %s(%s:%" PRIuz ")", __FUNCTION__, \
-	                                       __FILE__, __LINE__)
+	                                       __FILE__, (size_t)__LINE__)
 #define Stream_CheckAndLogRequiredLengthRx(srv, log, s, len) \
 	Stream_CheckAndLogRequiredLengthRx_(srv, log, s, len, __FUNCTION__, __FILE__, __LINE__)
 static BOOL Stream_CheckAndLogRequiredLengthRx_(BOOL srv, wLog* log, wStream* s, size_t len,

--- a/winpr/include/winpr/assert.h
+++ b/winpr/include/winpr/assert.h
@@ -35,7 +35,7 @@
 		{                                                                                     \
 			wLog* _log_cached_ptr = WLog_Get("com.freerdp.winpr.assert");                     \
 			WLog_Print(_log_cached_ptr, WLOG_FATAL, "%s [%s:%s:%" PRIuz "]", #cond, __FILE__, \
-			           __FUNCTION__, __LINE__);                                               \
+			           __FUNCTION__, (size_t)__LINE__);                                       \
 			winpr_log_backtrace_ex(_log_cached_ptr, WLOG_FATAL, 20);                          \
 			abort();                                                                          \
 		}                                                                                     \

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -88,22 +88,31 @@ extern "C"
 	WINPR_API wStream* Stream_StaticInit(wStream* s, BYTE* buffer, size_t size);
 	WINPR_API void Stream_Free(wStream* s, BOOL bFreeBuffer);
 
-#define Stream_CheckAndLogRequiredLength(tag, s, len)                                             \
-	Stream_CheckAndLogRequiredLengthEx(tag, WLOG_WARN, s, len, "%s(%s:%" PRIuz ")", __FUNCTION__, \
-	                                   __FILE__, __LINE__)
-	WINPR_API BOOL Stream_CheckAndLogRequiredLengthEx(const char* tag, DWORD level, wStream* s,
-	                                                  UINT64 len, const char* fmt, ...);
-	WINPR_API BOOL Stream_CheckAndLogRequiredLengthExVa(const char* tag, DWORD level, wStream* s,
-	                                                    UINT64 len, const char* fmt, va_list args);
+#define Stream_CheckAndLogRequiredLengthOfSize(tag, s, nmemb, size)                         \
+	Stream_CheckAndLogRequiredLengthEx(tag, WLOG_WARN, s, nmemb, size, "%s(%s:%" PRIuz ")", \
+	                                   __FUNCTION__, __FILE__, (size_t)__LINE__)
+#define Stream_CheckAndLogRequiredLength(tag, s, len) \
+	Stream_CheckAndLogRequiredLengthOfSize(tag, s, len, 1)
 
-#define Stream_CheckAndLogRequiredLengthWLog(log, s, len)                               \
-	Stream_CheckAndLogRequiredLengthWLogEx(log, WLOG_WARN, s, len, "%s(%s:%" PRIuz ")", \
-	                                       __FUNCTION__, __FILE__, __LINE__)
+	WINPR_API BOOL Stream_CheckAndLogRequiredLengthEx(const char* tag, DWORD level, wStream* s,
+	                                                  size_t nmemb, size_t size, const char* fmt,
+	                                                  ...);
+	WINPR_API BOOL Stream_CheckAndLogRequiredLengthExVa(const char* tag, DWORD level, wStream* s,
+	                                                    size_t nmemb, size_t size, const char* fmt,
+	                                                    va_list args);
+
+#define Stream_CheckAndLogRequiredLengthOfSizeWLog(log, s, nmemb, size)                         \
+	Stream_CheckAndLogRequiredLengthWLogEx(log, WLOG_WARN, s, nmemb, size, "%s(%s:%" PRIuz ")", \
+	                                       __FUNCTION__, __FILE__, (size_t)__LINE__)
+#define Stream_CheckAndLogRequiredLengthWLog(log, s, len) \
+	Stream_CheckAndLogRequiredLengthOfSizeWLog(log, s, len, 1)
+
 	WINPR_API BOOL Stream_CheckAndLogRequiredLengthWLogEx(wLog* log, DWORD level, wStream* s,
-	                                                      UINT64 len, const char* fmt, ...);
+	                                                      size_t nmemb, size_t size,
+	                                                      const char* fmt, ...);
 	WINPR_API BOOL Stream_CheckAndLogRequiredLengthWLogExVa(wLog* log, DWORD level, wStream* s,
-	                                                        UINT64 len, const char* fmt,
-	                                                        va_list args);
+	                                                        size_t nmemb, size_t size,
+	                                                        const char* fmt, va_list args);
 
 	static INLINE void Stream_Seek(wStream* s, size_t _offset)
 	{

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -56,6 +56,33 @@ extern "C"
 	WINPR_API BOOL Stream_EnsureCapacity(wStream* s, size_t size);
 	WINPR_API BOOL Stream_EnsureRemainingCapacity(wStream* s, size_t size);
 
+#define Stream_CheckAndLogRequiredCapacityOfSize(tag, s, nmemb, size)                         \
+	Stream_CheckAndLogRequiredCapacityEx(tag, WLOG_WARN, s, nmemb, size, "%s(%s:%" PRIuz ")", \
+	                                     __FUNCTION__, __FILE__, (size_t)__LINE__)
+#define Stream_CheckAndLogRequiredCapacity(tag, s, len) \
+	Stream_CheckAndLogRequiredCapacityOfSize((tag), (s), (len), 1)
+
+	WINPR_API BOOL Stream_CheckAndLogRequiredCapacityEx(const char* tag, DWORD level, wStream* s,
+	                                                    size_t nmemb, size_t size, const char* fmt,
+	                                                    ...);
+	WINPR_API BOOL Stream_CheckAndLogRequiredCapacityExVa(const char* tag, DWORD level, wStream* s,
+	                                                      size_t nmemb, size_t size,
+	                                                      const char* fmt, va_list args);
+
+#define Stream_CheckAndLogRequiredCapacityOfSizeWLog(log, s, nmemb, size)                         \
+	Stream_CheckAndLogRequiredCapacityWLogEx(log, WLOG_WARN, s, nmemb, size, "%s(%s:%" PRIuz ")", \
+	                                         __FUNCTION__, __FILE__, (size_t)__LINE__)
+
+#define Stream_CheckAndLogRequiredCapacityWLog(log, s, len) \
+	Stream_CheckAndLogRequiredCapacityOfSizeWLog((log), (s), (len), 1)
+
+	WINPR_API BOOL Stream_CheckAndLogRequiredCapacityWLogEx(wLog* log, DWORD level, wStream* s,
+	                                                        size_t nmemb, size_t size,
+	                                                        const char* fmt, ...);
+	WINPR_API BOOL Stream_CheckAndLogRequiredCapacityWLogExVa(wLog* log, DWORD level, wStream* s,
+	                                                          size_t nmemb, size_t size,
+	                                                          const char* fmt, va_list args);
+
 	WINPR_API wStream* Stream_New(BYTE* buffer, size_t size);
 	WINPR_API wStream* Stream_StaticConstInit(wStream* s, const BYTE* buffer, size_t size);
 	WINPR_API wStream* Stream_StaticInit(wStream* s, BYTE* buffer, size_t size);

--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
@@ -38,7 +38,7 @@
 
 #define NTLM_CheckAndLogRequiredCapacity(tag, s, nmemb, what)                                    \
 	Stream_CheckAndLogRequiredCapacityEx(tag, WLOG_WARN, s, nmemb, 1, "%s(%s:%" PRIuz ") " what, \
-	                                     __FUNCTION__, __FILE__, __LINE__)
+	                                     __FUNCTION__, __FILE__, (size_t)__LINE__)
 
 static char NTLM_CLIENT_SIGN_MAGIC[] = "session key to client-to-server signing key magic constant";
 static char NTLM_SERVER_SIGN_MAGIC[] = "session key to server-to-client signing key magic constant";
@@ -111,7 +111,7 @@ BOOL ntlm_write_version_info(wStream* s, const NTLM_VERSION_INFO* versionInfo)
 
 	if (!Stream_CheckAndLogRequiredCapacityEx(
 	        TAG, WLOG_WARN, s, 5ull + sizeof(versionInfo->Reserved), 1ull,
-	        "%s(%s:%" PRIuz ") NTLM_VERSION_INFO", __FUNCTION__, __FILE__, __LINE__))
+	        "%s(%s:%" PRIuz ") NTLM_VERSION_INFO", __FUNCTION__, __FILE__, (size_t)__LINE__))
 		return FALSE;
 
 	Stream_Write_UINT8(s, versionInfo->ProductMajorVersion); /* ProductMajorVersion (1 byte) */

--- a/winpr/libwinpr/sspi/NTLM/ntlm_message.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_message.c
@@ -37,7 +37,7 @@
 
 #define NTLM_CheckAndLogRequiredCapacity(tag, s, nmemb, what)                                    \
 	Stream_CheckAndLogRequiredCapacityEx(tag, WLOG_WARN, s, nmemb, 1, "%s(%s:%" PRIuz ") " what, \
-	                                     __FUNCTION__, __FILE__, __LINE__)
+	                                     __FUNCTION__, __FILE__, (size_t)__LINE__)
 
 static const char NTLM_SIGNATURE[8] = { 'N', 'T', 'L', 'M', 'S', 'S', 'P', '\0' };
 
@@ -437,7 +437,7 @@ static BOOL ntlm_write_negotiate_flags(wStream* s, UINT32 flags, const char* nam
 
 	if (!Stream_CheckAndLogRequiredCapacityEx(TAG, WLOG_WARN, s, 4ull, 1ull,
 	                                          "%s(%s:%" PRIuz ") %s::NegotiateFlags", __FUNCTION__,
-	                                          __FILE__, __LINE__, name))
+	                                          __FILE__, (size_t)__LINE__, name))
 		return FALSE;
 
 	WLog_DBG(TAG, "Write flags %s", ntlm_negotiate_flags_string(buffer, ARRAYSIZE(buffer), flags));

--- a/winpr/libwinpr/utils/image.c
+++ b/winpr/libwinpr/utils/image.c
@@ -385,7 +385,7 @@ static int winpr_image_bitmap_read_buffer(wImage* image, const BYTE* buffer, siz
 		goto fail;
 	if (!Stream_SafeSeek(s, bf.bfOffBits - Stream_GetPosition(s)))
 		goto fail;
-	if (Stream_GetRemainingCapacity(s) < bi.biSizeImage)
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, s, bi.biSizeImage))
 		goto fail;
 
 	if (bi.biWidth < 0)

--- a/winpr/libwinpr/utils/stream.c
+++ b/winpr/libwinpr/utils/stream.c
@@ -290,7 +290,7 @@ BOOL Stream_Write_UTF16_String(wStream* s, const WCHAR* src, size_t length)
 	if (!s || !src)
 		return FALSE;
 
-	if (!Stream_CheckAndLogRequiredCapacity(STREAM_TAG, (s), sizeof(WCHAR) * length))
+	if (!Stream_CheckAndLogRequiredCapacityOfSize(STREAM_TAG, (s), length, sizeof(WCHAR)))
 		return FALSE;
 
 	for (x = 0; x < length; x++)

--- a/winpr/libwinpr/utils/stream.c
+++ b/winpr/libwinpr/utils/stream.c
@@ -35,7 +35,7 @@
 		if (!(cond))                                                                       \
 		{                                                                                  \
 			WLog_FATAL(STREAM_TAG, "%s [%s:%s:%" PRIuz "]", #cond, __FILE__, __FUNCTION__, \
-			           __LINE__);                                                          \
+			           (size_t)__LINE__);                                                  \
 			winpr_log_backtrace(STREAM_TAG, WLOG_FATAL, 20);                               \
 			abort();                                                                       \
 		}                                                                                  \


### PR DESCRIPTION
* Split length argument of `Stream_CheckAndLogRemainingLength*` functions to have better logging
* Similar to `Stream_CheckAndLogRemainingLength` add functions to check and log remaining capacity.
