### PR TITLE
[client,sdl] Add WSAStartup

### DIFF
--- a/client/SDL/sdl_freerdp.c
+++ b/client/SDL/sdl_freerdp.c
@@ -963,6 +963,17 @@ terminate:
  * if available. */
 static BOOL sdl_client_global_init(void)
 {
+#if defined(_WIN32)
+	WSADATA wsaData = { 0 };
+	const DWORD wVersionRequested = MAKEWORD(1, 1);
+	const int rc = WSAStartup(wVersionRequested, &wsaData);
+	if (rc != 0)
+	{
+		WLog_ERR(SDL_TAG, "WSAStartup failed with %s [%d]", gai_strerrorA(rc), rc);
+		return FALSE;
+	}
+#endif
+
 	if (freerdp_handle_signals() != 0)
 		return FALSE;
 
@@ -972,6 +983,9 @@ static BOOL sdl_client_global_init(void)
 /* Optional global tear down */
 static void sdl_client_global_uninit(void)
 {
+#if defined(_WIN32)
+	WSACleanup();
+#endif
 }
 
 static int sdl_logon_error_info(freerdp* instance, UINT32 data, UINT32 type)

--- a/client/SDL/sdl_monitor.c
+++ b/client/SDL/sdl_monitor.c
@@ -59,6 +59,7 @@ int sdl_list_monitors(sdlContext* sdl)
 	SDL_Init(SDL_INIT_VIDEO);
 	const int nmonitors = SDL_GetNumVideoDisplays();
 
+	printf("listing %d monitors:\n", nmonitors);
 	for (int i = 0; i < nmonitors; i++)
 	{
 		SDL_Rect rect = { 0 };

--- a/client/SDL/sdl_utils.h
+++ b/client/SDL/sdl_utils.h
@@ -28,7 +28,8 @@
 const char* sdl_event_type_str(Uint32 type);
 const char* sdl_error_string(Uint32 res);
 
-#define sdl_log_error(res, log, what) sdl_log_error(res, log, what, __FILE__ __LINE__, __FUNCTION__)
+#define sdl_log_error(res, log, what) \
+	sdl_log_error_ex(res, log, what, __FILE__, __LINE__, __FUNCTION__)
 BOOL sdl_log_error_ex(Uint32 res, wLog* log, const char* what, const char* file, size_t line,
                       const char* fkt);
 

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1580,7 +1580,10 @@ int freerdp_client_settings_command_line_status_print_ex(rdpSettings* settings, 
 			else if (option_equals("smartcard", arg->Value))
 				freerdp_smartcard_list(settings);
 			else
+			{
+				freerdp_client_print_command_line_help_ex(argc, argv, custom);
 				return COMMAND_LINE_ERROR;
+			}
 		}
 #if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 		arg = CommandLineFindArgumentA(largs, "tune-list");


### PR DESCRIPTION
Windows requires WSAStartup to be called for the client to work.
