### PR TITLE
proxy: Fix NLA to TLS fallback connection

### DIFF
--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -542,6 +542,7 @@ owned by rdpRdp */
 
 	FREERDP_API BOOL freerdp_context_new(freerdp* instance);
 	FREERDP_API BOOL freerdp_context_new_ex(freerdp* instance, rdpSettings* settings);
+	FREERDP_API BOOL freerdp_context_reset(freerdp* instance);
 	FREERDP_API void freerdp_context_free(freerdp* instance);
 
 	FREERDP_API BOOL freerdp_connect(freerdp* instance);

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -780,6 +780,17 @@ fail:
 	return FALSE;
 }
 
+BOOL freerdp_context_reset(freerdp* instance)
+{
+	if (!instance)
+		return FALSE;
+
+	WINPR_ASSERT(instance->context);
+	rdpRdp* rdp = instance->context->rdp;
+
+	return rdp_reset_runtime_settings(rdp);
+}
+
 /** Deallocator function for a rdp context.
  *  The function will deallocate the resources from the 'instance' parameter that were allocated
  * from a call to freerdp_context_new(). If the ContextFree callback is set in the 'instance'

--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -571,7 +571,7 @@ static BOOL rdp_write_extended_info_packet(rdpRdp* rdp, wStream* s)
 		if (tz)
 			rlen = strnlen(tz, 254);
 		Stream_Write_UINT16(s, (UINT16)rlen);
-		if (Stream_Write_UTF16_String_From_UTF8(s, rlen / sizeof(WCHAR), tz, rlen, FALSE) < 0)
+		if (Stream_Write_UTF16_String_From_UTF8(s, rlen, tz, rlen, FALSE) < 0)
 			goto fail;
 		Stream_Write_UINT16(s, settings->DynamicDaylightTimeDisabled ? 0x01 : 0x00);
 	}

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -721,6 +721,10 @@ static BOOL pf_client_connect_without_nla(pClientContext* pc)
 	WINPR_ASSERT(pc);
 	instance = pc->context.instance;
 	WINPR_ASSERT(instance);
+
+	if (!freerdp_context_reset(instance))
+		return FALSE;
+
 	settings = pc->context.settings;
 	WINPR_ASSERT(settings);
 
@@ -733,7 +737,7 @@ static BOOL pf_client_connect_without_nla(pClientContext* pc)
 
 	/* do not allow next connection failure */
 	pc->allow_next_conn_failure = FALSE;
-	return freerdp_reconnect(instance);
+	return freerdp_connect(instance);
 }
 
 static BOOL pf_client_connect(freerdp* instance)


### PR DESCRIPTION
Currently the proxy's TLS fallback if an NLA connection attempt failed
is broken. There are two issues with the current code that this PR
fixes:

- freerdp_reconnect is used which requires an already established
  connection to work correctly. This is not the case since the NLA
  connectin attempt failed. This resulted in a seemingly working TLS
  connection but i.e. channels where missing/not working.
- The fallback connection attempt just altered the NLA security setting
  in the instance's settings. However these settings have been already
  modified by the NLA connection attempt so we need to create a copy of
  the original connection settings before doing the first connect.

The PR also introduces freerdp_reset_context which restores the initial
connection settings for the given instance.