### PR TITLE
core: Add possibility to distinguish between auth cancelled and no creds

### DIFF
--- a/libfreerdp/core/gateway/ncacn_http.c
+++ b/libfreerdp/core/gateway/ncacn_http.c
@@ -161,21 +161,24 @@ BOOL rpc_ncacn_http_auth_init(rdpContext* context, RpcChannel* channel)
 		case AUTH_SUCCESS:
 		case AUTH_SKIP:
 			break;
+		case AUTH_CANCELLED:
+			freerdp_set_last_error_log(instance->context, FREERDP_ERROR_CONNECT_CANCELLED);
+			return FALSE;
 		case AUTH_NO_CREDENTIALS:
 			freerdp_set_last_error_log(instance->context,
 			                           FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
-			return TRUE;
+			return FALSE;
 		case AUTH_FAILED:
 		default:
 			return FALSE;
 	}
 
 	if (!credssp_auth_init(auth, AUTH_PKG, tls->Bindings))
-		return TRUE;
+		return FALSE;
 
 	if (sspi_SetAuthIdentityA(&identity, settings->GatewayUsername, settings->GatewayDomain,
 	                          settings->GatewayPassword) < 0)
-		return TRUE;
+		return FALSE;
 
 	credssp_auth_setup_client(auth, "HTTP", settings->GatewayHostname, &identity, NULL);
 

--- a/libfreerdp/core/gateway/ncacn_http.c
+++ b/libfreerdp/core/gateway/ncacn_http.c
@@ -180,13 +180,14 @@ BOOL rpc_ncacn_http_auth_init(rdpContext* context, RpcChannel* channel)
 	                          settings->GatewayPassword) < 0)
 		return FALSE;
 
-	credssp_auth_setup_client(auth, "HTTP", settings->GatewayHostname, &identity, NULL);
+	const BOOL res =
+	    credssp_auth_setup_client(auth, "HTTP", settings->GatewayHostname, &identity, NULL);
 
 	sspi_FreeAuthIdentity(&identity);
 
 	credssp_auth_set_flags(auth, ISC_REQ_CONFIDENTIALITY);
 
-	return TRUE;
+	return res;
 }
 
 void rpc_ncacn_http_auth_uninit(RpcChannel* channel)

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -1121,10 +1121,10 @@ static BOOL rdg_send_tunnel_authorization(rdpRdg* rdg)
 		return FALSE;
 	}
 
-	Stream_Write_UINT16(s, PKT_TYPE_TUNNEL_AUTH);      /* Type (2 bytes) */
-	Stream_Write_UINT16(s, 0);                         /* Reserved (2 bytes) */
-	Stream_Write_UINT32(s, packetSize);                /* PacketLength (4 bytes) */
-	Stream_Write_UINT16(s, 0);                         /* FieldsPresent (2 bytes) */
+	Stream_Write_UINT16(s, PKT_TYPE_TUNNEL_AUTH);                  /* Type (2 bytes) */
+	Stream_Write_UINT16(s, 0);                                     /* Reserved (2 bytes) */
+	Stream_Write_UINT32(s, packetSize);                            /* PacketLength (4 bytes) */
+	Stream_Write_UINT16(s, 0);                                     /* FieldsPresent (2 bytes) */
 	Stream_Write_UINT16(s, (UINT16)clientNameLen * sizeof(WCHAR)); /* Client name string length */
 	Stream_Write_UTF16_String(s, clientName, (size_t)clientNameLen);
 	Stream_SealLength(s);
@@ -1659,6 +1659,9 @@ static BOOL rdg_get_gateway_credentials(rdpContext* context, rdp_auth_reason rea
 		case AUTH_SUCCESS:
 		case AUTH_SKIP:
 			return TRUE;
+		case AUTH_CANCELLED:
+			freerdp_set_last_error_log(instance->context, FREERDP_ERROR_CONNECT_CANCELLED);
+			return FALSE;
 		case AUTH_NO_CREDENTIALS:
 			freerdp_set_last_error_log(instance->context,
 			                           FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);

--- a/libfreerdp/core/gateway/rpc_bind.c
+++ b/libfreerdp/core/gateway/rpc_bind.c
@@ -136,6 +136,9 @@ static int rpc_bind_setup(rdpRpc* rpc)
 		case AUTH_SUCCESS:
 		case AUTH_SKIP:
 			break;
+		case AUTH_CANCELLED:
+			freerdp_set_last_error_log(instance->context, FREERDP_ERROR_CONNECT_CANCELLED);
+			return FALSE;
 		case AUTH_NO_CREDENTIALS:
 			freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
 			return 0;

--- a/libfreerdp/core/gateway/rpc_bind.c
+++ b/libfreerdp/core/gateway/rpc_bind.c
@@ -138,7 +138,7 @@ static int rpc_bind_setup(rdpRpc* rpc)
 			break;
 		case AUTH_CANCELLED:
 			freerdp_set_last_error_log(instance->context, FREERDP_ERROR_CONNECT_CANCELLED);
-			return FALSE;
+			return -1;
 		case AUTH_NO_CREDENTIALS:
 			freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
 			return 0;

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -330,6 +330,9 @@ static BOOL nla_client_setup_identity(rdpNla* nla)
 			case AUTH_SKIP:
 			case AUTH_SUCCESS:
 				break;
+			case AUTH_CANCELLED:
+				freerdp_set_last_error_log(instance->context, FREERDP_ERROR_CONNECT_CANCELLED);
+				return FALSE;
 			case AUTH_NO_CREDENTIALS:
 				freerdp_set_last_error_log(instance->context,
 				                           FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -218,6 +218,10 @@ BOOL transport_connect_rdp(rdpTransport* transport)
 		case AUTH_SUCCESS:
 		case AUTH_NO_CREDENTIALS:
 			return TRUE;
+		case AUTH_CANCELLED:
+			freerdp_set_last_error_if_not(transport_get_context(transport),
+			                              FREERDP_ERROR_CONNECT_CANCELLED);
+			return FALSE;
 		default:
 			return FALSE;
 	}
@@ -240,6 +244,9 @@ BOOL transport_connect_tls(rdpTransport* transport)
 			case AUTH_SUCCESS:
 			case AUTH_NO_CREDENTIALS:
 				break;
+			case AUTH_CANCELLED:
+				freerdp_set_last_error_if_not(context, FREERDP_ERROR_CONNECT_CANCELLED);
+				return FALSE;
 			default:
 				return FALSE;
 		}

--- a/libfreerdp/core/utils.c
+++ b/libfreerdp/core/utils.c
@@ -84,6 +84,10 @@ auth_status utils_authenticate_gateway(freerdp* instance, rdp_auth_reason reason
 		                                  &settings->GatewayPassword, &settings->GatewayDomain);
 
 	if (!proceed)
+		return AUTH_CANCELLED;
+
+	if (utils_str_is_empty(settings->GatewayUsername) ||
+	    utils_str_is_empty(settings->GatewayPassword))
 		return AUTH_NO_CREDENTIALS;
 
 	if (!utils_sync_credentials(settings, FALSE))
@@ -163,6 +167,9 @@ auth_status utils_authenticate(freerdp* instance, rdp_auth_reason reason, BOOL o
 		                                 &settings->Domain);
 
 	if (!proceed)
+		return AUTH_CANCELLED;
+
+	if (utils_str_is_empty(settings->Username) || utils_str_is_empty(settings->Password))
 		return AUTH_NO_CREDENTIALS;
 
 	if (!utils_sync_credentials(settings, TRUE))

--- a/libfreerdp/core/utils.h
+++ b/libfreerdp/core/utils.h
@@ -29,6 +29,7 @@ typedef enum
 	AUTH_SUCCESS,
 	AUTH_SKIP,
 	AUTH_NO_CREDENTIALS,
+	AUTH_CANCELLED,
 	AUTH_FAILED
 } auth_status;
 


### PR DESCRIPTION
Currently if the authentication callback returns `FALSE` the utils function handle this as scenario as no credentials provided (returns `AUTH_NO_CREDENTIALS)`.

This PR introduces a new `auth_status` called `AUTH_CANCELLED` that is returned if the authentication callback returns `FALSE`. If the callback returns `TRUE` and username or password are empty the util function will continue to return `AUTH_NO_CREDENTIALS`.

The PR also fixes some incorrect returns in RPC over HTTP gateway code.
