### PR TITLE
Sdl client improve

### DIFF
--- a/client/SDL/CMakeLists.txt
+++ b/client/SDL/CMakeLists.txt
@@ -18,6 +18,17 @@
 set(MODULE_NAME "sdl-client")
 set(MODULE_PREFIX "FREERDP_CLIENT_X11_CONTROL")
 
+include(ConfigOptions)
+option(WITH_DEBUG_SDL_EVENTS "[dangerous, not for release builds!] Debug SDL events" OFF)
+option(WITH_DEBUG_SDL_KBD_EVENTS "[dangerous, not for release builds!] Debug SDL keyboard events" OFF)
+
+if (WITH_DEBUG_SDL_EVENTS)
+	add_definitions(-DWITH_DEBUG_SDL_EVENTS)
+endif()
+if (WITH_DEBUG_SDL_KBD_EVENTS)
+	add_definitions(-DWITH_DEBUG_SDL_KBD_EVENTS)
+endif()
+
 include_directories(${SDL2_INCLUDE_DIRS})
 set(SRCS
     sdl_utils.c

--- a/client/SDL/sdl_freerdp.c
+++ b/client/SDL/sdl_freerdp.c
@@ -678,8 +678,10 @@ static int sdl_run(sdlContext* sdl)
 		while (!freerdp_shall_disconnect_context(&sdl->common.context) &&
 		       SDL_PollEvent(&windowEvent))
 		{
+#if defined(WITH_DEBUG_SDL_EVENTS)
 			SDL_Log("got event %s [0x%08" PRIx32 "]", sdl_event_type_str(windowEvent.type),
 			        windowEvent.type);
+#endif
 			switch (windowEvent.type)
 			{
 				case SDL_QUIT:

--- a/client/SDL/sdl_freerdp.h
+++ b/client/SDL/sdl_freerdp.h
@@ -52,6 +52,11 @@ typedef struct
 	sdl_window_t windows[16];
 
 	HANDLE thread;
+	HANDLE initialize;
+	HANDLE initialized;
+	HANDLE update_complete;
+	HANDLE windows_created;
+	int exit_code;
 
 	SDL_Surface* primary;
 
@@ -61,7 +66,7 @@ typedef struct
 	wLog* log;
 } sdlContext;
 
-void update_resizeable(sdlContext* sdl, BOOL enable);
-void update_fullscreen(sdlContext* sdl, BOOL enter);
+BOOL update_resizeable(sdlContext* sdl, BOOL enable);
+BOOL update_fullscreen(sdlContext* sdl, BOOL enter);
 
 #endif /* FREERDP_CLIENT_SDL_H */

--- a/client/SDL/sdl_kbd.c
+++ b/client/SDL/sdl_kbd.c
@@ -420,8 +420,10 @@ static UINT32 sdl_scancode_to_rdp(Uint32 scancode)
 		}
 	}
 
-	WLog_INFO(TAG, "got %s [%s] -> [%s]", SDL_GetScancodeName(scancode),
-	          sdl_scancode_name(scancode), sdl_rdp_scancode_name(rdp));
+#if defined(WITH_DEBUG_SDL_KBD_EVENTS)
+	WLog_DBG(TAG, "got %s [%s] -> [%s]", SDL_GetScancodeName(scancode), sdl_scancode_name(scancode),
+	         sdl_rdp_scancode_name(rdp));
+#endif
 	return rdp;
 }
 

--- a/client/SDL/sdl_pointer.h
+++ b/client/SDL/sdl_pointer.h
@@ -21,7 +21,10 @@
 #define FREERDP_CLIENT_SDL_POINTER_H
 
 #include <freerdp/graphics.h>
+#include "sdl_freerdp.h"
 
 BOOL sdl_register_pointer(rdpGraphics* graphics);
+
+BOOL sdl_Pointer_Set_Process(SDL_UserEvent* uptr);
 
 #endif /* FREERDP_CLIENT_SDL_POINTER_H */

--- a/client/SDL/sdl_utils.c
+++ b/client/SDL/sdl_utils.c
@@ -92,6 +92,16 @@ const char* sdl_event_type_str(Uint32 type)
 		EV_CASE_STR(SDL_RENDER_TARGETS_RESET);
 		EV_CASE_STR(SDL_RENDER_DEVICE_RESET);
 		EV_CASE_STR(SDL_USEREVENT);
+
+		EV_CASE_STR(SDL_USEREVENT_UPDATE);
+		EV_CASE_STR(SDL_USEREVENT_CREATE_WINDOWS);
+		EV_CASE_STR(SDL_USEREVENT_WINDOW_RESIZEABLE);
+		EV_CASE_STR(SDL_USEREVENT_WINDOW_FULLSCREEN);
+		EV_CASE_STR(SDL_USEREVENT_POINTER_NULL);
+		EV_CASE_STR(SDL_USEREVENT_POINTER_DEFAULT);
+		EV_CASE_STR(SDL_USEREVENT_POINTER_POSITION);
+		EV_CASE_STR(SDL_USEREVENT_POINTER_SET);
+
 		EV_CASE_STR(SDL_LASTEVENT);
 		default:
 			return "SDL_UNKNOWNEVENT";
@@ -120,4 +130,43 @@ BOOL sdl_log_error_ex(Uint32 res, wLog* log, const char* what, const char* file,
 
 	WLog_Print(log, WLOG_ERROR, "[%s:%" PRIuz "][%s]: %s", fkt, line, what, msg);
 	return TRUE;
+}
+
+BOOL sdl_push_user_event(Uint32 type, ...)
+{
+	SDL_Event ev = { 0 };
+	SDL_UserEvent* event = &ev.user;
+
+	va_list ap;
+	va_start(ap, type);
+	event->type = type;
+	switch (type)
+	{
+		case SDL_USEREVENT_UPDATE:
+			event->data1 = va_arg(ap, void*);
+			break;
+		case SDL_USEREVENT_POINTER_POSITION:
+			event->data1 = (void*)va_arg(ap, UINT32);
+			event->data2 = (void*)va_arg(ap, UINT32);
+			break;
+		case SDL_USEREVENT_POINTER_SET:
+			event->data1 = va_arg(ap, void*);
+			event->data2 = va_arg(ap, void*);
+			break;
+		case SDL_USEREVENT_CREATE_WINDOWS:
+			event->data1 = (void*)va_arg(ap, void*);
+			break;
+		case SDL_USEREVENT_WINDOW_FULLSCREEN:
+		case SDL_USEREVENT_WINDOW_RESIZEABLE:
+			event->data1 = va_arg(ap, void*);
+			event->code = (va_arg(ap, BOOL) == TRUE) ? 1 : 0;
+			break;
+		case SDL_USEREVENT_POINTER_NULL:
+		case SDL_USEREVENT_POINTER_DEFAULT:
+			break;
+		default:
+			return FALSE;
+	}
+	va_end(ap);
+	return SDL_PushEvent(&ev) == 1;
 }

--- a/client/SDL/sdl_utils.h
+++ b/client/SDL/sdl_utils.h
@@ -25,6 +25,20 @@
 #include <stdbool.h>
 #include <SDL.h>
 
+enum
+{
+	SDL_USEREVENT_UPDATE = SDL_USEREVENT + 1,
+	SDL_USEREVENT_CREATE_WINDOWS,
+	SDL_USEREVENT_WINDOW_RESIZEABLE,
+	SDL_USEREVENT_WINDOW_FULLSCREEN,
+	SDL_USEREVENT_POINTER_NULL,
+	SDL_USEREVENT_POINTER_DEFAULT,
+	SDL_USEREVENT_POINTER_POSITION,
+	SDL_USEREVENT_POINTER_SET
+};
+
+BOOL sdl_push_user_event(Uint32 type, ...);
+
 const char* sdl_event_type_str(Uint32 type);
 const char* sdl_error_string(Uint32 res);
 


### PR DESCRIPTION
refactor client event handling

As some OS require the SDL handling on main thread refactor the client to only call SDL functions there.