### PR TITLE
Client callback defaults and argument refactoring

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,12 +1,1 @@
-/*
-!/Android
-!/common
-!/iOS
-!/Mac
-!/Sample
-!/Windows
-!/X11
-!/Wayland
-!/CMakeLists.txt
-!*.in
-Wayland/wlfreerdp.1
+

--- a/client/Sample/tf_freerdp.c
+++ b/client/Sample/tf_freerdp.c
@@ -323,9 +323,6 @@ static BOOL tf_client_new(freerdp* instance, rdpContext* context)
 	instance->PreConnect = tf_pre_connect;
 	instance->PostConnect = tf_post_connect;
 	instance->PostDisconnect = tf_post_disconnect;
-	instance->AuthenticateEx = client_cli_authenticate_ex;
-	instance->VerifyCertificateEx = client_cli_verify_certificate_ex;
-	instance->VerifyChangedCertificateEx = client_cli_verify_changed_certificate_ex;
 	instance->LogonErrorInfo = tf_logon_error_info;
 	/* TODO: Client display set up */
 	WINPR_UNUSED(tf);

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -622,11 +622,6 @@ static BOOL wlf_client_new(freerdp* instance, rdpContext* context)
 	instance->PreConnect = wl_pre_connect;
 	instance->PostConnect = wl_post_connect;
 	instance->PostDisconnect = wl_post_disconnect;
-	instance->AuthenticateEx = client_cli_authenticate_ex;
-	instance->ChooseSmartcard = client_cli_choose_smartcard;
-	instance->VerifyCertificateEx = client_cli_verify_certificate_ex;
-	instance->VerifyChangedCertificateEx = client_cli_verify_changed_certificate_ex;
-	instance->PresentGatewayMessage = client_cli_present_gateway_message;
 	instance->LogonErrorInfo = wlf_logon_error_info;
 	wfl->log = WLog_Get(TAG);
 	wfl->display = UwacOpenDisplay(NULL, &status);

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -1312,13 +1312,7 @@ static BOOL wfreerdp_client_new(freerdp* instance, rdpContext* context)
 	freerdp_settings_set_bool(context->settings, FreeRDP_CertificateCallbackPreferPEM, TRUE);
 #endif
 
-	if (wfc->isConsole)
-	{
-		instance->VerifyCertificateEx = wf_cli_verify_certificate_ex;
-		instance->VerifyChangedCertificateEx = client_cli_verify_changed_certificate_ex;
-		instance->PresentGatewayMessage = client_cli_present_gateway_message;
-	}
-	else
+	if (!wfc->isConsole)
 	{
 		instance->VerifyCertificateEx = wf_verify_certificate_ex;
 		instance->VerifyChangedCertificateEx = wf_verify_changed_certificate_ex;

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1875,11 +1875,6 @@ static BOOL xfreerdp_client_new(freerdp* instance, rdpContext* context)
 	instance->PostConnect = xf_post_connect;
 	instance->PostDisconnect = xf_post_disconnect;
 	instance->PostFinalDisconnect = xf_post_final_disconnect;
-	instance->AuthenticateEx = client_cli_authenticate_ex;
-	instance->ChooseSmartcard = client_cli_choose_smartcard;
-	instance->VerifyCertificateEx = client_cli_verify_certificate_ex;
-	instance->VerifyChangedCertificateEx = client_cli_verify_changed_certificate_ex;
-	instance->PresentGatewayMessage = client_cli_present_gateway_message;
 	instance->LogonErrorInfo = xf_logon_error_info;
 	PubSub_SubscribeTerminate(context->pubSub, xf_TerminateEventHandler);
 #ifdef WITH_XRENDER

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -530,8 +530,8 @@ BOOL client_cli_authenticate_ex(freerdp* instance, char** username, char** passw
 	return client_cli_authenticate_raw(instance, reason, username, password, domain);
 }
 
-BOOL client_cli_choose_smartcard(SmartcardCertInfo** cert_list, DWORD count, DWORD* choice,
-                                 BOOL gateway)
+BOOL client_cli_choose_smartcard(freerdp* instance, SmartcardCertInfo** cert_list, DWORD count,
+                                 DWORD* choice, BOOL gateway)
 {
 	unsigned long answer;
 	char* p = NULL;

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -150,8 +150,8 @@ extern "C"
 	FREERDP_API BOOL client_cli_authenticate_ex(freerdp* instance, char** username, char** password,
 	                                            char** domain, rdp_auth_reason reason);
 
-	FREERDP_API BOOL client_cli_choose_smartcard(SmartcardCertInfo** cert_list, DWORD count,
-	                                             DWORD* choice, BOOL gateway);
+	FREERDP_API BOOL client_cli_choose_smartcard(freerdp* instance, SmartcardCertInfo** cert_list,
+	                                             DWORD count, DWORD* choice, BOOL gateway);
 
 	FREERDP_API int client_cli_logon_error_info(freerdp* instance, UINT32 data, UINT32 type);
 

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -153,6 +153,8 @@ extern "C"
 	FREERDP_API BOOL client_cli_choose_smartcard(SmartcardCertInfo** cert_list, DWORD count,
 	                                             DWORD* choice, BOOL gateway);
 
+	FREERDP_API int client_cli_logon_error_info(freerdp* instance, UINT32 data, UINT32 type);
+
 	FREERDP_API void
 	freerdp_client_OnChannelConnectedEventHandler(void* context,
 	                                              const ChannelConnectedEventArgs* e);

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -136,8 +136,8 @@ extern "C"
 	                              char** domain);
 	typedef BOOL (*pAuthenticateEx)(freerdp* instance, char** username, char** password,
 	                                char** domain, rdp_auth_reason reason);
-	typedef BOOL (*pChooseSmartcard)(SmartcardCertInfo** cert_list, DWORD count, DWORD* choice,
-	                                 BOOL gateway);
+	typedef BOOL (*pChooseSmartcard)(freerdp* instance, SmartcardCertInfo** cert_list, DWORD count,
+	                                 DWORD* choice, BOOL gateway);
 
 	/** @brief Callback used if user interaction is required to accept
 	 *         an unknown certificate.

--- a/libfreerdp/core/smartcardlogon.c
+++ b/libfreerdp/core/smartcardlogon.c
@@ -724,7 +724,7 @@ BOOL smartcard_getCert(const rdpContext* context, SmartcardCertInfo** cert, BOOL
 		DWORD index;
 
 		if (!instance->ChooseSmartcard ||
-		    !instance->ChooseSmartcard(cert_list, count, &index, gateway))
+		    !instance->ChooseSmartcard(context->instance, cert_list, count, &index, gateway))
 		{
 			WLog_ERR(TAG, "more than one suitable smartcard certificate was found");
 			smartcardCertList_Free(cert_list, count);

--- a/libfreerdp/core/test/TestConnect.c
+++ b/libfreerdp/core/test/TestConnect.c
@@ -26,6 +26,13 @@ static int runInstance(int argc, char* argv[], freerdp** inst, DWORD timeout)
 	if (inst)
 		*inst = context->instance;
 
+	context->instance->ChooseSmartcard = NULL;
+	context->instance->PresentGatewayMessage = NULL;
+	context->instance->LogonErrorInfo = NULL;
+	context->instance->AuthenticateEx = NULL;
+	context->instance->VerifyCertificateEx = NULL;
+	context->instance->VerifyChangedCertificateEx = NULL;
+
 	if (!freerdp_settings_set_bool(context->settings, FreeRDP_DeactivateClientDecoding, TRUE))
 		return FALSE;
 


### PR DESCRIPTION
* Add `instance` argument to smartcard listing callback (required for any gui tool to have some context information)
* automatically initialize the client callbacks to the `cli` versions, clients can always override with custom implementations