### PR TITLE
[client,common] set default callbacks before ClientNew

### DIFF
--- a/client/common/client.c
+++ b/client/common/client.c
@@ -68,20 +68,16 @@ static BOOL freerdp_client_common_new(freerdp* instance, rdpContext* context)
 	WINPR_ASSERT(context);
 
 	instance->LoadChannels = freerdp_client_load_channels;
+	instance->AuthenticateEx = client_cli_authenticate_ex;
+	instance->ChooseSmartcard = client_cli_choose_smartcard;
+	instance->VerifyCertificateEx = client_cli_verify_certificate_ex;
+	instance->VerifyChangedCertificateEx = client_cli_verify_changed_certificate_ex;
+	instance->PresentGatewayMessage = client_cli_present_gateway_message;
+	instance->LogonErrorInfo = client_cli_logon_error_info;
 
 	pEntryPoints = instance->pClientEntryPoints;
 	WINPR_ASSERT(pEntryPoints);
-	const BOOL rc = IFCALLRESULT(TRUE, pEntryPoints->ClientNew, instance, context);
-	if (rc)
-	{
-		instance->AuthenticateEx = client_cli_authenticate_ex;
-		instance->ChooseSmartcard = client_cli_choose_smartcard;
-		instance->VerifyCertificateEx = client_cli_verify_certificate_ex;
-		instance->VerifyChangedCertificateEx = client_cli_verify_changed_certificate_ex;
-		instance->PresentGatewayMessage = client_cli_present_gateway_message;
-		instance->LogonErrorInfo = client_cli_logon_error_info;
-	}
-	return rc;
+	return IFCALLRESULT(TRUE, pEntryPoints->ClientNew, instance, context);
 }
 
 static void freerdp_client_common_free(freerdp* instance, rdpContext* context)


### PR DESCRIPTION
ohterwise the default callbacks might override custom callbacks set by an implementation by accident
