### PR TITLE
[core] add log for experimental settings

### DIFF
--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -21,6 +21,7 @@
 
 #include <freerdp/config.h>
 
+#include <string.h>
 #include <stdarg.h>
 
 #include "rdp.h"
@@ -701,6 +702,8 @@ BOOL freerdp_context_new_ex(freerdp* instance, rdpSettings* settings)
 	BOOL ret = TRUE;
 
 	WINPR_ASSERT(instance);
+
+	rdp_log_build_warnings();
 
 	instance->context = context = (rdpContext*)calloc(1, instance->ContextSize);
 

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -1504,6 +1504,8 @@ BOOL freerdp_peer_context_new_ex(freerdp_peer* client, const rdpSettings* settin
 	rdpContext* context;
 	BOOL ret = TRUE;
 
+	rdp_log_build_warnings();
+
 	if (!client)
 		return FALSE;
 

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -289,4 +289,6 @@ const char* rdp_security_flag_string(UINT32 securityFlags, char* buffer, size_t 
 BOOL rdp_set_backup_settings(rdpRdp* rdp);
 BOOL rdp_reset_runtime_settings(rdpRdp* rdp);
 
+void rdp_log_build_warnings(void);
+
 #endif /* FREERDP_LIB_CORE_RDP_H */


### PR DESCRIPTION
Too often experimental flags had been used without the user noticing that. As bug reports are hard to analyze without proper information take this approach and inform about experimental flags in use by logging these.