### PR TITLE
core: Allow change to smart card logon in Authentication callbacks

### DIFF
--- a/libfreerdp/core/utils.c
+++ b/libfreerdp/core/utils.c
@@ -44,6 +44,21 @@ BOOL utils_str_copy(const char* value, char** dst)
 	return (*dst) != NULL;
 }
 
+static BOOL utils_copy_smartcard_settings(const rdpSettings* settings, rdpSettings* origSettings)
+{
+	/* update original settings with provided smart card settings */
+	origSettings->SmartcardLogon = settings->SmartcardLogon;
+	origSettings->PasswordIsSmartcardPin = settings->PasswordIsSmartcardPin;
+	if (!utils_str_copy(settings->ReaderName, &origSettings->ReaderName))
+		return FALSE;
+	if (!utils_str_copy(settings->CspName, &origSettings->CspName))
+		return FALSE;
+	if (!utils_str_copy(settings->ContainerName, &origSettings->ContainerName))
+		return FALSE;
+
+	return TRUE;
+}
+
 auth_status utils_authenticate_gateway(freerdp* instance, rdp_auth_reason reason)
 {
 	rdpSettings* settings;
@@ -101,6 +116,9 @@ auth_status utils_authenticate_gateway(freerdp* instance, rdp_auth_reason reason
 	if (!utils_str_copy(settings->GatewayPassword, &origSettings->GatewayPassword))
 		return AUTH_FAILED;
 	if (!utils_sync_credentials(origSettings, FALSE))
+		return AUTH_FAILED;
+
+	if (!utils_copy_smartcard_settings(settings, origSettings))
 		return AUTH_FAILED;
 
 	return AUTH_SUCCESS;
@@ -183,6 +201,9 @@ auth_status utils_authenticate(freerdp* instance, rdp_auth_reason reason, BOOL o
 	if (!utils_str_copy(settings->Password, &origSettings->Password))
 		return AUTH_FAILED;
 	if (!utils_sync_credentials(origSettings, TRUE))
+		return AUTH_FAILED;
+
+	if (!utils_copy_smartcard_settings(settings, origSettings))
 		return AUTH_FAILED;
 
 	return AUTH_SUCCESS;


### PR DESCRIPTION
This PR adds a few changes so that a client is able to change the authentication/logon type in the Authentication callback. I.e. if the client was started without user/domain the authentication callback is now able to activate smart card logon by setting the SmartcardLogon setting along with csp/container/reader name.
