### PR TITLE
[core,gcc] Fix applying RedirectionVersionMask

### DIFF
--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -2076,9 +2076,9 @@ BOOL gcc_write_client_cluster_data(wStream* s, const rdpMcs* mcs)
 		/* REDIRECTION_VERSION6 requires multitransport enabled.
 		 * if we run without that use REDIRECTION_VERSION5 */
 		if (freerdp_settings_get_bool(settings, FreeRDP_SupportMultitransport))
-			flags |= (REDIRECTION_VERSION6 << 4);
+			flags |= (REDIRECTION_VERSION6 << 2);
 		else
-			flags |= (REDIRECTION_VERSION5 << 4);
+			flags |= (REDIRECTION_VERSION5 << 2);
 	}
 
 	WLog_VRB(TAG, "write ClusterInfoFlags=%s, RedirectedSessionId=0x%08" PRIx32,


### PR DESCRIPTION
The RedirectionVersionMask is 0x3c i.e. 00111100.
So the left shift operation to set RedirectionVersion is of 2 places.
