### PR TITLE
core: Add CAPI support for enumerating smart card key containers

### DIFF
--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -225,7 +225,8 @@ static BOOL nla_adjust_settings_from_smartcard(rdpNla* nla)
 			WLog_ERR(TAG, "unable to set CSP name");
 			goto out;
 		}
-		else if (!freerdp_settings_set_string(settings, FreeRDP_CspName, MS_SCARD_PROV_A))
+		if (!settings->CspName &&
+		    !freerdp_settings_set_string(settings, FreeRDP_CspName, MS_SCARD_PROV_A))
 		{
 			WLog_ERR(TAG, "unable to set CSP name");
 			goto out;


### PR DESCRIPTION
Windows seems to favor using the legacy Crypto API (CAPI) for enumerating RSA key containers and only relies on the newer CNG APIs for ECC keys.

This PR adds support for CAPI key container enumeration on Windows.

The PR also fixes an issue where the CSP was always set to the MS Base Smart Card Provider during NLA authentication.
