### PR TITLE
core: Update smartcard settings on all platforms

### DIFF
--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -351,15 +351,15 @@ static BOOL nla_client_setup_identity(rdpNla* nla)
 	}
 	else if (settings->SmartcardLogon)
 	{
-#ifdef _WIN32
-		CERT_CREDENTIAL_INFO certInfo = { sizeof(CERT_CREDENTIAL_INFO), { 0 } };
-		LPSTR marshalledCredentials;
-
 		if (smartCardLogonWasDisabled)
 		{
 			if (!nla_adjust_settings_from_smartcard(nla))
 				return FALSE;
 		}
+
+#ifdef _WIN32
+		CERT_CREDENTIAL_INFO certInfo = { sizeof(CERT_CREDENTIAL_INFO), { 0 } };
+		LPSTR marshalledCredentials;
 
 		memcpy(certInfo.rgbHashOfCert, nla->certSha1, sizeof(certInfo.rgbHashOfCert));
 


### PR DESCRIPTION
Currently smartcard settings were only updated in the WIN32 code path. This must be done on all platforms to have the correct settings (i.e. pkinitArgs) correctly applied.
