### PR TITLE
expose last NLA/CredSSP SSPI error code (freerdp_get_nla_sspi_error)

### DIFF
--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -631,6 +631,8 @@ owned by rdpRdp */
 	FREERDP_API BOOL freerdp_nla_impersonate(rdpContext* context);
 	FREERDP_API BOOL freerdp_nla_revert_to_self(rdpContext* context);
 
+	FREERDP_API UINT32 freerdp_get_nla_sspi_error(rdpContext* context);
+
 	FREERDP_API void clearChannelError(rdpContext* context);
 	FREERDP_API HANDLE getChannelErrorEventHandle(rdpContext* context);
 	FREERDP_API UINT getChannelError(rdpContext* context);

--- a/libfreerdp/core/credssp_auth.c
+++ b/libfreerdp/core/credssp_auth.c
@@ -65,6 +65,7 @@ struct rdp_credssp_auth
 	SecBuffer output_buffer;
 	ULONG flags;
 	SecPkgContext_Sizes sizes;
+	SECURITY_STATUS sspi_error;
 	enum AUTH_STATE state;
 #ifdef UNICODE
 	char* pkgNameA;
@@ -441,6 +442,7 @@ int credssp_auth_authenticate(rdpCredsspAuth* auth)
 		WLog_ERR(TAG, "%s failed with %s [0x%08X]",
 		         auth->server ? "AcceptSecurityContext" : "InitializeSecurityContext",
 		         GetSecurityStatusString(status), status);
+		auth->sspi_error = status;
 		return -1;
 	}
 }
@@ -651,6 +653,12 @@ const char* credssp_auth_pkg_name(rdpCredsspAuth* auth)
 #else
 	return auth->info->Name;
 #endif
+}
+
+UINT32 credssp_auth_sspi_error(rdpCredsspAuth* auth)
+{
+	WINPR_ASSERT(auth);
+	return (UINT32)auth->sspi_error;
 }
 
 void credssp_auth_free(rdpCredsspAuth* auth)

--- a/libfreerdp/core/credssp_auth.h
+++ b/libfreerdp/core/credssp_auth.h
@@ -56,6 +56,7 @@ FREERDP_LOCAL BOOL credssp_auth_have_output_token(rdpCredsspAuth* auth);
 FREERDP_LOCAL BOOL credssp_auth_is_complete(rdpCredsspAuth* auth);
 FREERDP_LOCAL const char* credssp_auth_pkg_name(rdpCredsspAuth* auth);
 FREERDP_LOCAL size_t credssp_auth_trailer_size(rdpCredsspAuth* auth);
+FREERDP_LOCAL UINT32 credssp_auth_sspi_error(rdpCredsspAuth* auth);
 FREERDP_LOCAL void credssp_auth_free(rdpCredsspAuth* auth);
 
 #endif /* FREERDP_LIB_CORE_CREDSSP_AUTH_H */

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -1131,6 +1131,19 @@ BOOL freerdp_nla_revert_to_self(rdpContext* context)
 	return nla_revert_to_self(nla);
 }
 
+UINT32 freerdp_get_nla_sspi_error(rdpContext* context)
+{
+	rdpNla* nla;
+
+	WINPR_ASSERT(context);
+	WINPR_ASSERT(context->rdp);
+	WINPR_ASSERT(context->rdp->transport);
+
+	nla = transport_get_nla(context->rdp->transport);
+
+	return nla_get_sspi_error(nla);
+}
+
 HANDLE getChannelErrorEventHandle(rdpContext* context)
 {
 	WINPR_ASSERT(context);

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -1790,3 +1790,9 @@ DWORD nla_get_error(rdpNla* nla)
 		return ERROR_INTERNAL_ERROR;
 	return nla->errorCode;
 }
+
+UINT32 nla_get_sspi_error(rdpNla* nla)
+{
+	WINPR_ASSERT(nla);
+	return credssp_auth_sspi_error(nla->auth);
+}

--- a/libfreerdp/core/nla.h
+++ b/libfreerdp/core/nla.h
@@ -57,6 +57,7 @@ FREERDP_LOCAL BOOL nla_set_state(rdpNla* nla, NLA_STATE state);
 FREERDP_LOCAL const char* nla_get_state_str(NLA_STATE state);
 
 FREERDP_LOCAL DWORD nla_get_error(rdpNla* nla);
+FREERDP_LOCAL UINT32 nla_get_sspi_error(rdpNla* nla);
 
 FREERDP_LOCAL BOOL nla_set_service_principal(rdpNla* nla, const char* service,
                                              const char* hostname);


### PR DESCRIPTION
Through our recent work with [Kerberos in sspi-rs](https://github.com/Devolutions/sspi-rs/blob/master/src/utils.rs#L51), we've had to diagnose issues where the last SSPI error code would be extremely useful to report better error messages in the user interface, such as a connection failure caused by a clock skew (happens all the time). Until now, the SSPI error code in credssp_auth_authenticate was simply discarded in case of authentication failure. This pull request saves that last error code into the credssp context, and exposes it to the nla context, which is then exposed externally through freerdp_get_nla_sspi_error.

Ideally, the internal Kerberos error code could also be propagated, but it's more difficult to do since we'd need to use custom SSPI context attributes. For now, we've managed to map most Kerberos error codes to meaningful SSPI error codes, the only thing missing was a way to get that SSPI error code propagated all the way to the application calling the FreeRDP APIs.

This way, we can warn users about a clock skew being the cause for their Kerberos authentication failures, which will save us tons of hours of debugging trying to figure it from logs, especially on a mobile device where it's very tricky.

