### PR TITLE
[client,x11] wrap XChangeProperty

### DIFF
--- a/client/X11/CMakeLists.txt
+++ b/client/X11/CMakeLists.txt
@@ -24,6 +24,8 @@ include_directories(${X11_INCLUDE_DIRS})
 include_directories(${OPENSSL_INCLUDE_DIR})
 
 set(${MODULE_PREFIX}_SRCS
+	xf_utils.h
+	xf_utils.c
 	xf_gdi.c
 	xf_gdi.h
 	xf_gfx.c

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1755,6 +1755,12 @@ BOOL xf_setup_x11(xfContext* xfc)
 		WLog_ERR(TAG, "Please check that the $DISPLAY environment variable is properly set.");
 		goto fail;
 	}
+	if (xfc->debug)
+	{
+		WLog_INFO(TAG, "Enabling X11 debug mode.");
+		XSynchronize(xfc->display, TRUE);
+		_def_error_handler = XSetErrorHandler(_xf_error_handler);
+	}
 
 	xfc->mutex = CreateMutex(NULL, FALSE, NULL);
 
@@ -1837,13 +1843,6 @@ BOOL xf_setup_x11(xfContext* xfc)
 	{
 		WLog_ERR(TAG, "Could not create xfds event");
 		goto fail;
-	}
-
-	if (xfc->debug)
-	{
-		WLog_INFO(TAG, "Enabling X11 debug mode.");
-		XSynchronize(xfc->display, TRUE);
-		_def_error_handler = XSetErrorHandler(_xf_error_handler);
 	}
 
 	xf_check_extensions(xfc);

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1740,8 +1740,11 @@ BOOL xf_setup_x11(xfContext* xfc)
 
 	WINPR_ASSERT(xfc);
 	xfc->UseXThreads = TRUE;
+
+#if !defined(NDEBUG)
 	/* uncomment below if debugging to prevent keyboard grap */
-	/* xfc->debug = TRUE; */
+	xfc->debug = TRUE;
+#endif
 
 	if (xfc->UseXThreads)
 	{

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -104,6 +104,7 @@
 #include "xf_input.h"
 #include "xf_channels.h"
 #include "xfreerdp.h"
+#include "xf_utils.h"
 
 #include <freerdp/log.h>
 #define TAG CLIENT_TAG("x11")
@@ -1778,9 +1779,9 @@ BOOL xf_setup_x11(xfContext* xfc)
 		int actual_format = 0;
 		unsigned long nitems = 0, after = 0;
 		unsigned char* data = NULL;
-		int status = XGetWindowProperty(xfc->display, RootWindowOfScreen(xfc->screen),
-		                                xfc->_NET_SUPPORTED, 0, 1024, False, XA_ATOM, &actual_type,
-		                                &actual_format, &nitems, &after, &data);
+		int status = LogTagAndXGetWindowProperty(
+		    TAG, xfc->display, RootWindowOfScreen(xfc->screen), xfc->_NET_SUPPORTED, 0, 1024, False,
+		    XA_ATOM, &actual_type, &actual_format, &nitems, &after, &data);
 
 		if ((status == Success) && (actual_type == XA_ATOM) && (actual_format == 32))
 		{

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -660,7 +660,7 @@ static void xf_cliprdr_provide_server_format_list(xfClipboard* clipboard)
 	}
 	else
 	{
-		XDeleteProperty(xfc->display, xfc->drawable, clipboard->raw_format_list_atom);
+		LogTagAndXDeleteProperty(TAG, xfc->display, xfc->drawable, clipboard->raw_format_list_atom);
 	}
 
 	Stream_Free(formats, TRUE);
@@ -984,7 +984,7 @@ static BOOL xf_cliprdr_get_requested_data(xfClipboard* clipboard, Atom target)
 		}
 	}
 
-	XDeleteProperty(xfc->display, xfc->drawable, clipboard->property_atom);
+	LogTagAndXDeleteProperty(TAG, xfc->display, xfc->drawable, clipboard->property_atom);
 	xf_cliprdr_process_requested_data(clipboard, has_data, data, bytes_left);
 
 	if (data)
@@ -1340,7 +1340,7 @@ static BOOL xf_cliprdr_process_selection_clear(xfClipboard* clipboard,
 	if (xf_cliprdr_is_self_owned(clipboard))
 		return FALSE;
 
-	XDeleteProperty(xfc->display, clipboard->root_window, clipboard->property_atom);
+	LogTagAndXDeleteProperty(TAG, xfc->display, clipboard->root_window, clipboard->property_atom);
 	return TRUE;
 }
 

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -48,6 +48,7 @@
 
 #include "xf_cliprdr.h"
 #include "xf_event.h"
+#include "xf_utils.h"
 
 #define TAG CLIENT_TAG("x11.cliprdr")
 
@@ -207,8 +208,8 @@ static void xf_cliprdr_set_raw_transfer_enabled(xfClipboard* clipboard, BOOL ena
 
 	xfc = clipboard->xfc;
 	WINPR_ASSERT(xfc);
-	XChangeProperty(xfc->display, xfc->drawable, clipboard->raw_transfer_atom, XA_INTEGER, 32,
-	                PropModeReplace, (BYTE*)&data, 1);
+	LogTagAndXChangeProperty(TAG, xfc->display, xfc->drawable, clipboard->raw_transfer_atom,
+	                         XA_INTEGER, 32, PropModeReplace, (BYTE*)&data, 1);
 }
 
 static BOOL xf_cliprdr_is_raw_transfer_available(xfClipboard* clipboard)
@@ -653,9 +654,9 @@ static void xf_cliprdr_provide_server_format_list(xfClipboard* clipboard)
 
 	if (formats)
 	{
-		XChangeProperty(xfc->display, xfc->drawable, clipboard->raw_format_list_atom,
-		                clipboard->raw_format_list_atom, 8, PropModeReplace, Stream_Buffer(formats),
-		                Stream_Length(formats));
+		LogTagAndXChangeProperty(TAG, xfc->display, xfc->drawable, clipboard->raw_format_list_atom,
+		                         clipboard->raw_format_list_atom, 8, PropModeReplace,
+		                         Stream_Buffer(formats), Stream_Length(formats));
 	}
 	else
 	{
@@ -1023,8 +1024,9 @@ static void xf_cliprdr_provide_targets(xfClipboard* clipboard, const XSelectionE
 
 	if (respond->property != None)
 	{
-		XChangeProperty(xfc->display, respond->requestor, respond->property, XA_ATOM, 32,
-		                PropModeReplace, (BYTE*)clipboard->targets, clipboard->numTargets);
+		LogTagAndXChangeProperty(TAG, xfc->display, respond->requestor, respond->property, XA_ATOM,
+		                         32, PropModeReplace, (BYTE*)clipboard->targets,
+		                         clipboard->numTargets);
 	}
 }
 
@@ -1039,8 +1041,9 @@ static void xf_cliprdr_provide_timestamp(xfClipboard* clipboard, const XSelectio
 
 	if (respond->property != None)
 	{
-		XChangeProperty(xfc->display, respond->requestor, respond->property, XA_INTEGER, 32,
-		                PropModeReplace, (BYTE*)&clipboard->selection_ownership_timestamp, 1);
+		LogTagAndXChangeProperty(TAG, xfc->display, respond->requestor, respond->property,
+		                         XA_INTEGER, 32, PropModeReplace,
+		                         (BYTE*)&clipboard->selection_ownership_timestamp, 1);
 	}
 }
 
@@ -1056,8 +1059,8 @@ static void xf_cliprdr_provide_data(xfClipboard* clipboard, const XSelectionEven
 
 	if (respond->property != None)
 	{
-		XChangeProperty(xfc->display, respond->requestor, respond->property, respond->target, 8,
-		                PropModeReplace, data, size);
+		LogTagAndXChangeProperty(TAG, xfc->display, respond->requestor, respond->property,
+		                         respond->target, 8, PropModeReplace, data, size);
 	}
 }
 
@@ -1640,8 +1643,8 @@ static void xf_cliprdr_prepare_to_set_selection_owner(xfContext* xfc, xfClipboar
 	 * anyway! */
 	Atom value = clipboard->timestamp_property_atom;
 
-	XChangeProperty(xfc->display, xfc->drawable, clipboard->timestamp_property_atom, XA_ATOM, 32,
-	                PropModeReplace, (BYTE*)&value, 1);
+	LogTagAndXChangeProperty(TAG, xfc->display, xfc->drawable, clipboard->timestamp_property_atom,
+	                         XA_ATOM, 32, PropModeReplace, (BYTE*)&value, 1);
 	XFlush(xfc->display);
 }
 
@@ -1808,8 +1811,8 @@ xf_cliprdr_server_format_data_request(CliprdrClientContext* context,
 	if (rawTransfer)
 	{
 		format = xf_cliprdr_get_client_format_by_id(clipboard, CF_RAW);
-		XChangeProperty(xfc->display, xfc->drawable, clipboard->property_atom, XA_INTEGER, 32,
-		                PropModeReplace, (BYTE*)&formatId, 1);
+		LogTagAndXChangeProperty(TAG, xfc->display, xfc->drawable, clipboard->property_atom,
+		                         XA_INTEGER, 32, PropModeReplace, (BYTE*)&formatId, 1);
 	}
 	else
 		format = xf_cliprdr_get_client_format_by_id(clipboard, formatId);

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -233,9 +233,9 @@ static BOOL xf_cliprdr_is_raw_transfer_available(xfClipboard* clipboard)
 
 	if (owner != None)
 	{
-		result =
-		    XGetWindowProperty(xfc->display, owner, clipboard->raw_transfer_atom, 0, 4, 0,
-		                       XA_INTEGER, &type, &format, &length, &bytes_left, (BYTE**)&data);
+		result = LogTagAndXGetWindowProperty(TAG, xfc->display, owner, clipboard->raw_transfer_atom,
+		                                     0, 4, 0, XA_INTEGER, &type, &format, &length,
+		                                     &bytes_left, (BYTE**)&data);
 	}
 
 	if (data)
@@ -536,9 +536,9 @@ static CLIPRDR_FORMAT* xf_cliprdr_get_raw_server_formats(xfClipboard* clipboard,
 	WINPR_ASSERT(xfc);
 
 	*numFormats = 0;
-	XGetWindowProperty(xfc->display, clipboard->owner, clipboard->raw_format_list_atom, 0, 4096,
-	                   False, clipboard->raw_format_list_atom, &type, &format, &length, &remaining,
-	                   &data);
+	LogTagAndXGetWindowProperty(
+	    TAG, xfc->display, clipboard->owner, clipboard->raw_format_list_atom, 0, 4096, False,
+	    clipboard->raw_format_list_atom, &type, &format, &length, &remaining, &data);
 
 	if (data && length > 0 && format == 8 && type == clipboard->raw_format_list_atom)
 	{
@@ -578,8 +578,8 @@ static CLIPRDR_FORMAT* xf_cliprdr_get_formats_from_targets(xfClipboard* clipboar
 	WINPR_ASSERT(xfc);
 
 	*numFormats = 0;
-	XGetWindowProperty(xfc->display, xfc->drawable, clipboard->property_atom, 0, 200, 0, XA_ATOM,
-	                   &atom, &format_property, &length, &bytes_left, &data);
+	LogTagAndXGetWindowProperty(TAG, xfc->display, xfc->drawable, clipboard->property_atom, 0, 200,
+	                            0, XA_ATOM, &atom, &format_property, &length, &bytes_left, &data);
 
 	if (length > 0)
 	{
@@ -917,8 +917,8 @@ static BOOL xf_cliprdr_get_requested_data(xfClipboard* clipboard, Atom target)
 		return FALSE;
 	}
 
-	XGetWindowProperty(xfc->display, xfc->drawable, clipboard->property_atom, 0, 0, 0, target,
-	                   &type, &format_property, &length, &bytes_left, &data);
+	LogTagAndXGetWindowProperty(TAG, xfc->display, xfc->drawable, clipboard->property_atom, 0, 0, 0,
+	                            target, &type, &format_property, &length, &bytes_left, &data);
 
 	if (data)
 	{
@@ -954,9 +954,9 @@ static BOOL xf_cliprdr_get_requested_data(xfClipboard* clipboard, Atom target)
 			clipboard->incr_starts = 0;
 			has_data = TRUE;
 		}
-		else if (XGetWindowProperty(xfc->display, xfc->drawable, clipboard->property_atom, 0,
-		                            bytes_left, 0, target, &type, &format_property, &length, &dummy,
-		                            &data) == Success)
+		else if (LogTagAndXGetWindowProperty(
+		             TAG, xfc->display, xfc->drawable, clipboard->property_atom, 0, bytes_left, 0,
+		             target, &type, &format_property, &length, &dummy, &data) == Success)
 		{
 			if (clipboard->incr_starts)
 			{
@@ -1245,9 +1245,9 @@ static BOOL xf_cliprdr_process_selection_request(xfClipboard* clipboard,
 
 			if (formatId == CF_RAW)
 			{
-				if (XGetWindowProperty(xfc->display, xevent->requestor, clipboard->property_atom, 0,
-				                       4, 0, XA_INTEGER, &type, &fmt, &length, &bytes_left,
-				                       &data) != Success)
+				if (LogTagAndXGetWindowProperty(
+				        TAG, xfc->display, xevent->requestor, clipboard->property_atom, 0, 4, 0,
+				        XA_INTEGER, &type, &fmt, &length, &bytes_left, &data) != Success)
 				{
 				}
 

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -1078,7 +1078,7 @@ static void log_selection_event(xfContext* xfc, const XEvent* event)
 			case SelectionClear:
 			{
 				const XSelectionClearEvent* xevent = &event->xselectionclear;
-				char* selection = XGetAtomName(xfc->display, xevent->selection);
+				char* selection = Safe_XGetAtomName(xfc->display, xevent->selection);
 				WLog_Print(_log_cached_ptr, level, "got event %s [selection %s]",
 				           x11_event_string(event->type), selection);
 				XFree(selection);
@@ -1087,9 +1087,9 @@ static void log_selection_event(xfContext* xfc, const XEvent* event)
 			case SelectionNotify:
 			{
 				const XSelectionEvent* xevent = &event->xselection;
-				char* selection = XGetAtomName(xfc->display, xevent->selection);
-				char* target = XGetAtomName(xfc->display, xevent->target);
-				char* property = XGetAtomName(xfc->display, xevent->property);
+				char* selection = Safe_XGetAtomName(xfc->display, xevent->selection);
+				char* target = Safe_XGetAtomName(xfc->display, xevent->target);
+				char* property = Safe_XGetAtomName(xfc->display, xevent->property);
 				WLog_Print(_log_cached_ptr, level,
 				           "got event %s [selection %s, target %s, property %s]",
 				           x11_event_string(event->type), selection, target, property);
@@ -1101,9 +1101,9 @@ static void log_selection_event(xfContext* xfc, const XEvent* event)
 			case SelectionRequest:
 			{
 				const XSelectionRequestEvent* xevent = &event->xselectionrequest;
-				char* selection = XGetAtomName(xfc->display, xevent->selection);
-				char* target = XGetAtomName(xfc->display, xevent->target);
-				char* property = XGetAtomName(xfc->display, xevent->property);
+				char* selection = Safe_XGetAtomName(xfc->display, xevent->selection);
+				char* target = Safe_XGetAtomName(xfc->display, xevent->target);
+				char* property = Safe_XGetAtomName(xfc->display, xevent->property);
 				WLog_Print(_log_cached_ptr, level,
 				           "got event %s [selection %s, target %s, property %s]",
 				           x11_event_string(event->type), selection, target, property);
@@ -1115,7 +1115,7 @@ static void log_selection_event(xfContext* xfc, const XEvent* event)
 			case PropertyNotify:
 			{
 				const XPropertyEvent* xevent = &event->xproperty;
-				char* atom = XGetAtomName(xfc->display, xevent->atom);
+				char* atom = Safe_XGetAtomName(xfc->display, xevent->atom);
 				WLog_Print(_log_cached_ptr, level, "got event %s [atom %s]",
 				           x11_event_string(event->type), atom);
 				XFree(atom);

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -31,6 +31,7 @@
 
 #include "xf_window.h"
 #include "xf_rail.h"
+#include "xf_utils.h"
 
 #include <freerdp/log.h>
 #define TAG CLIENT_TAG("x11")
@@ -683,9 +684,11 @@ error:
 static void xf_rail_set_window_icon(xfContext* xfc, xfAppWindow* railWindow, xfRailIcon* icon,
                                     BOOL replace)
 {
-	XChangeProperty(xfc->display, railWindow->handle, xfc->_NET_WM_ICON, XA_CARDINAL, 32,
-	                replace ? PropModeReplace : PropModeAppend, (unsigned char*)icon->data,
-	                icon->length);
+	WINPR_ASSERT(xfc);
+
+	LogTagAndXChangeProperty(TAG, xfc->display, railWindow->handle, xfc->_NET_WM_ICON, XA_CARDINAL,
+	                         32, replace ? PropModeReplace : PropModeAppend,
+	                         (unsigned char*)icon->data, icon->length);
 	XFlush(xfc->display);
 }
 

--- a/client/X11/xf_utils.c
+++ b/client/X11/xf_utils.c
@@ -18,7 +18,11 @@
  * limitations under the License.
  */
 
+#include <winpr/assert.h>
+
 #include "xf_utils.h"
+
+static const DWORD level = WLOG_TRACE;
 
 int LogTagAndXChangeProperty(const char* tag, Display* display, Window w, Atom property, Atom type,
                              int format, int mode, const unsigned char* data, int nelements)
@@ -30,8 +34,6 @@ int LogTagAndXChangeProperty(const char* tag, Display* display, Window w, Atom p
 int LogDynAndXChangeProperty(wLog* log, Display* display, Window w, Atom property, Atom type,
                              int format, int mode, const unsigned char* data, int nelements)
 {
-	const DWORD level = WLOG_TRACE;
-
 	if (WLog_IsLevelActive(log, level))
 	{
 		char* propstr = XGetAtomName(display, property);
@@ -42,4 +44,22 @@ int LogDynAndXChangeProperty(wLog* log, Display* display, Window w, Atom propert
 		XFree(typestr);
 	}
 	return XChangeProperty(display, w, property, type, format, mode, data, nelements);
+}
+
+int LogTagAndXDeleteProperty(const char* tag, Display* display, Window w, Atom property)
+{
+	wLog* log = WLog_Get(tag);
+	return LogDynAndXDeleteProperty(log, display, w, property);
+}
+
+int LogDynAndXDeleteProperty(wLog* log, Display* display, Window w, Atom property)
+{
+	if (WLog_IsLevelActive(log, level))
+	{
+		char* propstr = XGetAtomName(display, property);
+		WLog_Print(log, WLOG_DEBUG, "XDeleteProperty(%p, %d, %s [%d])", display, w, propstr,
+		           property);
+		XFree(propstr);
+	}
+	return XDeleteProperty(display, w, property);
 }

--- a/client/X11/xf_utils.c
+++ b/client/X11/xf_utils.c
@@ -63,3 +63,38 @@ int LogDynAndXDeleteProperty(wLog* log, Display* display, Window w, Atom propert
 	}
 	return XDeleteProperty(display, w, property);
 }
+
+int LogTagAndXGetWindowProperty(const char* tag, Display* display, Window w, Atom property,
+                                long long_offset, long long_length, int delete, Atom req_type,
+                                Atom* actual_type_return, int* actual_format_return,
+                                unsigned long* nitems_return, unsigned long* bytes_after_return,
+                                unsigned char** prop_return)
+{
+	wLog* log = WLog_Get(tag);
+	return LogDynAndXGetWindowProperty(log, display, w, property, long_offset, long_length, delete,
+	                                   req_type, actual_type_return, actual_format_return,
+	                                   nitems_return, bytes_after_return, prop_return);
+}
+
+int LogDynAndXGetWindowProperty(wLog* log, Display* display, Window w, Atom property,
+                                long long_offset, long long_length, int delete, Atom req_type,
+                                Atom* actual_type_return, int* actual_format_return,
+                                unsigned long* nitems_return, unsigned long* bytes_after_return,
+                                unsigned char** prop_return)
+{
+	if (WLog_IsLevelActive(log, level))
+	{
+		char* propstr = XGetAtomName(display, property);
+		char* req_type_str = XGetAtomName(display, req_type);
+		WLog_Print(log, WLOG_DEBUG,
+		           "XGetWindowProperty(%p, %d, %s [%d], %ld, %ld, %d, %s [%d], %p, %p, %p, %p, %p)",
+		           display, w, propstr, property, long_offset, long_length, delete, req_type_str,
+		           req_type, actual_type_return, actual_format_return, nitems_return,
+		           bytes_after_return, prop_return);
+		XFree(propstr);
+		XFree(req_type_str);
+	}
+	return XGetWindowProperty(display, w, property, long_offset, long_length, delete, req_type,
+	                          actual_type_return, actual_format_return, nitems_return,
+	                          bytes_after_return, prop_return);
+}

--- a/client/X11/xf_utils.c
+++ b/client/X11/xf_utils.c
@@ -22,7 +22,7 @@
 
 #include "xf_utils.h"
 
-static const DWORD level = WLOG_TRACE;
+static const DWORD log_level = WLOG_TRACE;
 
 static void write_log(wLog* log, DWORD level, const char* fname, const char* fkt, size_t line, ...)
 {
@@ -52,11 +52,11 @@ int LogDynAndXChangeProperty_ex(wLog* log, const char* file, const char* fkt, si
                                 Display* display, Window w, Atom property, Atom type, int format,
                                 int mode, const unsigned char* data, int nelements)
 {
-	if (WLog_IsLevelActive(log, level))
+	if (WLog_IsLevelActive(log, log_level))
 	{
 		char* propstr = Safe_XGetAtomName(display, property);
 		char* typestr = Safe_XGetAtomName(display, type);
-		write_log(log, level, file, fkt, line,
+		write_log(log, log_level, file, fkt, line,
 		          "XChangeProperty(%p, %d, %s [%d], %s [%d], %d, %d, %p, %d)", display, w, propstr,
 		          property, typestr, type, format, mode, data, nelements);
 		XFree(propstr);
@@ -75,10 +75,10 @@ int LogTagAndXDeleteProperty_ex(const char* tag, const char* file, const char* f
 int LogDynAndXDeleteProperty_ex(wLog* log, const char* file, const char* fkt, size_t line,
                                 Display* display, Window w, Atom property)
 {
-	if (WLog_IsLevelActive(log, level))
+	if (WLog_IsLevelActive(log, log_level))
 	{
 		char* propstr = Safe_XGetAtomName(display, property);
-		write_log(log, level, file, fkt, line, "XDeleteProperty(%p, %d, %s [%d])", display, w,
+		write_log(log, log_level, file, fkt, line, "XDeleteProperty(%p, %d, %s [%d])", display, w,
 		          propstr, property);
 		XFree(propstr);
 	}
@@ -105,11 +105,11 @@ int LogDynAndXGetWindowProperty_ex(wLog* log, const char* file, const char* fkt,
                                    unsigned long* nitems_return, unsigned long* bytes_after_return,
                                    unsigned char** prop_return)
 {
-	if (WLog_IsLevelActive(log, level))
+	if (WLog_IsLevelActive(log, log_level))
 	{
 		char* propstr = Safe_XGetAtomName(display, property);
 		char* req_type_str = Safe_XGetAtomName(display, req_type);
-		write_log(log, level, file, fkt, line,
+		write_log(log, log_level, file, fkt, line,
 		          "XGetWindowProperty(%p, %d, %s [%d], %ld, %ld, %d, %s [%d], %p, %p, %p, %p, %p)",
 		          display, w, propstr, property, long_offset, long_length, delete, req_type_str,
 		          req_type, actual_type_return, actual_format_return, nitems_return,

--- a/client/X11/xf_utils.c
+++ b/client/X11/xf_utils.c
@@ -24,73 +24,89 @@
 
 static const DWORD level = WLOG_TRACE;
 
-int LogTagAndXChangeProperty(const char* tag, Display* display, Window w, Atom property, Atom type,
-                             int format, int mode, const unsigned char* data, int nelements)
+static void write_log(wLog* log, DWORD level, const char* fname, const char* fkt, size_t line, ...)
 {
-	wLog* log = WLog_Get(tag);
-	return LogDynAndXChangeProperty(log, display, w, property, type, format, mode, data, nelements);
+	va_list ap;
+	va_start(ap, line);
+	WLog_PrintMessageVA(log, WLOG_MESSAGE_TEXT, level, line, fname, fkt, ap);
+	va_end(ap);
 }
 
-int LogDynAndXChangeProperty(wLog* log, Display* display, Window w, Atom property, Atom type,
-                             int format, int mode, const unsigned char* data, int nelements)
+int LogTagAndXChangeProperty_ex(const char* tag, const char* file, const char* fkt, size_t line,
+                                Display* display, Window w, Atom property, Atom type, int format,
+                                int mode, const unsigned char* data, int nelements)
+{
+	wLog* log = WLog_Get(tag);
+	return LogDynAndXChangeProperty_ex(log, file, fkt, line, display, w, property, type, format,
+	                                   mode, data, nelements);
+}
+
+int LogDynAndXChangeProperty_ex(wLog* log, const char* file, const char* fkt, size_t line,
+                                Display* display, Window w, Atom property, Atom type, int format,
+                                int mode, const unsigned char* data, int nelements)
 {
 	if (WLog_IsLevelActive(log, level))
 	{
 		char* propstr = XGetAtomName(display, property);
 		char* typestr = XGetAtomName(display, type);
-		WLog_Print(log, WLOG_DEBUG, "XChangeProperty(%p, %d, %s [%d], %s [%d], %d, %d, %p, %d)",
-		           display, w, propstr, property, typestr, type, format, mode, data, nelements);
+		write_log(log, level, file, fkt, line,
+		          "XChangeProperty(%p, %d, %s [%d], %s [%d], %d, %d, %p, %d)", display, w, propstr,
+		          property, typestr, type, format, mode, data, nelements);
 		XFree(propstr);
 		XFree(typestr);
 	}
 	return XChangeProperty(display, w, property, type, format, mode, data, nelements);
 }
 
-int LogTagAndXDeleteProperty(const char* tag, Display* display, Window w, Atom property)
+int LogTagAndXDeleteProperty_ex(const char* tag, const char* file, const char* fkt, size_t line,
+                                Display* display, Window w, Atom property)
 {
 	wLog* log = WLog_Get(tag);
-	return LogDynAndXDeleteProperty(log, display, w, property);
+	return LogDynAndXDeleteProperty_ex(log, file, fkt, line, display, w, property);
 }
 
-int LogDynAndXDeleteProperty(wLog* log, Display* display, Window w, Atom property)
+int LogDynAndXDeleteProperty_ex(wLog* log, const char* file, const char* fkt, size_t line,
+                                Display* display, Window w, Atom property)
 {
 	if (WLog_IsLevelActive(log, level))
 	{
 		char* propstr = XGetAtomName(display, property);
-		WLog_Print(log, WLOG_DEBUG, "XDeleteProperty(%p, %d, %s [%d])", display, w, propstr,
-		           property);
+		write_log(log, level, file, fkt, line, "XDeleteProperty(%p, %d, %s [%d])", display, w,
+		          propstr, property);
 		XFree(propstr);
 	}
 	return XDeleteProperty(display, w, property);
 }
 
-int LogTagAndXGetWindowProperty(const char* tag, Display* display, Window w, Atom property,
-                                long long_offset, long long_length, int delete, Atom req_type,
-                                Atom* actual_type_return, int* actual_format_return,
-                                unsigned long* nitems_return, unsigned long* bytes_after_return,
-                                unsigned char** prop_return)
+int LogTagAndXGetWindowProperty_ex(const char* tag, const char* file, const char* fkt, size_t line,
+                                   Display* display, Window w, Atom property, long long_offset,
+                                   long long_length, int delete, Atom req_type,
+                                   Atom* actual_type_return, int* actual_format_return,
+                                   unsigned long* nitems_return, unsigned long* bytes_after_return,
+                                   unsigned char** prop_return)
 {
 	wLog* log = WLog_Get(tag);
-	return LogDynAndXGetWindowProperty(log, display, w, property, long_offset, long_length, delete,
-	                                   req_type, actual_type_return, actual_format_return,
-	                                   nitems_return, bytes_after_return, prop_return);
+	return LogDynAndXGetWindowProperty_ex(
+	    log, file, fkt, line, display, w, property, long_offset, long_length, delete, req_type,
+	    actual_type_return, actual_format_return, nitems_return, bytes_after_return, prop_return);
 }
 
-int LogDynAndXGetWindowProperty(wLog* log, Display* display, Window w, Atom property,
-                                long long_offset, long long_length, int delete, Atom req_type,
-                                Atom* actual_type_return, int* actual_format_return,
-                                unsigned long* nitems_return, unsigned long* bytes_after_return,
-                                unsigned char** prop_return)
+int LogDynAndXGetWindowProperty_ex(wLog* log, const char* file, const char* fkt, size_t line,
+                                   Display* display, Window w, Atom property, long long_offset,
+                                   long long_length, int delete, Atom req_type,
+                                   Atom* actual_type_return, int* actual_format_return,
+                                   unsigned long* nitems_return, unsigned long* bytes_after_return,
+                                   unsigned char** prop_return)
 {
 	if (WLog_IsLevelActive(log, level))
 	{
 		char* propstr = XGetAtomName(display, property);
 		char* req_type_str = XGetAtomName(display, req_type);
-		WLog_Print(log, WLOG_DEBUG,
-		           "XGetWindowProperty(%p, %d, %s [%d], %ld, %ld, %d, %s [%d], %p, %p, %p, %p, %p)",
-		           display, w, propstr, property, long_offset, long_length, delete, req_type_str,
-		           req_type, actual_type_return, actual_format_return, nitems_return,
-		           bytes_after_return, prop_return);
+		write_log(log, level, file, fkt, line,
+		          "XGetWindowProperty(%p, %d, %s [%d], %ld, %ld, %d, %s [%d], %p, %p, %p, %p, %p)",
+		          display, w, propstr, property, long_offset, long_length, delete, req_type_str,
+		          req_type, actual_type_return, actual_format_return, nitems_return,
+		          bytes_after_return, prop_return);
 		XFree(propstr);
 		XFree(req_type_str);
 	}

--- a/client/X11/xf_utils.c
+++ b/client/X11/xf_utils.c
@@ -1,0 +1,45 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * X11 helper utilities
+ *
+ * Copyright 2023 Armin Novak <armin.novak@thincast.com>
+ * Copyringht 2023 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "xf_utils.h"
+
+int LogTagAndXChangeProperty(const char* tag, Display* display, Window w, Atom property, Atom type,
+                             int format, int mode, const unsigned char* data, int nelements)
+{
+	wLog* log = WLog_Get(tag);
+	return LogDynAndXChangeProperty(log, display, w, property, type, format, mode, data, nelements);
+}
+
+int LogDynAndXChangeProperty(wLog* log, Display* display, Window w, Atom property, Atom type,
+                             int format, int mode, const unsigned char* data, int nelements)
+{
+	const DWORD level = WLOG_TRACE;
+
+	if (WLog_IsLevelActive(log, level))
+	{
+		char* propstr = XGetAtomName(display, property);
+		char* typestr = XGetAtomName(display, type);
+		WLog_Print(log, WLOG_DEBUG, "XChangeProperty(%p, %d, %s [%d], %s [%d], %d, %d, %p, %d)",
+		           display, w, propstr, property, typestr, type, format, mode, data, nelements);
+		XFree(propstr);
+		XFree(typestr);
+	}
+	return XChangeProperty(display, w, property, type, format, mode, data, nelements);
+}

--- a/client/X11/xf_utils.c
+++ b/client/X11/xf_utils.c
@@ -32,6 +32,13 @@ static void write_log(wLog* log, DWORD level, const char* fname, const char* fkt
 	va_end(ap);
 }
 
+char* Safe_XGetAtomName(Display* display, Atom atom)
+{
+	if (atom == None)
+		return strdup("Atom_None");
+	return XGetAtomName(display, atom);
+}
+
 int LogTagAndXChangeProperty_ex(const char* tag, const char* file, const char* fkt, size_t line,
                                 Display* display, Window w, Atom property, Atom type, int format,
                                 int mode, const unsigned char* data, int nelements)
@@ -47,8 +54,8 @@ int LogDynAndXChangeProperty_ex(wLog* log, const char* file, const char* fkt, si
 {
 	if (WLog_IsLevelActive(log, level))
 	{
-		char* propstr = XGetAtomName(display, property);
-		char* typestr = XGetAtomName(display, type);
+		char* propstr = Safe_XGetAtomName(display, property);
+		char* typestr = Safe_XGetAtomName(display, type);
 		write_log(log, level, file, fkt, line,
 		          "XChangeProperty(%p, %d, %s [%d], %s [%d], %d, %d, %p, %d)", display, w, propstr,
 		          property, typestr, type, format, mode, data, nelements);
@@ -70,7 +77,7 @@ int LogDynAndXDeleteProperty_ex(wLog* log, const char* file, const char* fkt, si
 {
 	if (WLog_IsLevelActive(log, level))
 	{
-		char* propstr = XGetAtomName(display, property);
+		char* propstr = Safe_XGetAtomName(display, property);
 		write_log(log, level, file, fkt, line, "XDeleteProperty(%p, %d, %s [%d])", display, w,
 		          propstr, property);
 		XFree(propstr);
@@ -100,8 +107,8 @@ int LogDynAndXGetWindowProperty_ex(wLog* log, const char* file, const char* fkt,
 {
 	if (WLog_IsLevelActive(log, level))
 	{
-		char* propstr = XGetAtomName(display, property);
-		char* req_type_str = XGetAtomName(display, req_type);
+		char* propstr = Safe_XGetAtomName(display, property);
+		char* req_type_str = Safe_XGetAtomName(display, req_type);
 		write_log(log, level, file, fkt, line,
 		          "XGetWindowProperty(%p, %d, %s [%d], %ld, %ld, %d, %s [%d], %p, %p, %p, %p, %p)",
 		          display, w, propstr, property, long_offset, long_length, delete, req_type_str,

--- a/client/X11/xf_utils.h
+++ b/client/X11/xf_utils.h
@@ -23,21 +23,54 @@
 
 #include <X11/Xlib.h>
 
-int LogTagAndXGetWindowProperty(const char* tag, Display* display, Window w, Atom property,
-                                long long_offset, long long_length, Bool delete, Atom req_type,
-                                Atom* actual_type_return, int* actual_format_return,
-                                unsigned long* nitems_return, unsigned long* bytes_after_return,
-                                unsigned char** prop_return);
-int LogDynAndXGetWindowProperty(wLog* log, Display* display, Window w, Atom property,
-                                long long_offset, long long_length, Bool delete, Atom req_type,
-                                Atom* actual_type_return, int* actual_format_return,
-                                unsigned long* nitems_return, unsigned long* bytes_after_return,
-                                unsigned char** prop_return);
+#define LogTagAndXGetWindowProperty(tag, display, w, property, long_offset, long_length, delete,   \
+                                    req_type, actual_type_return, actual_format_return,            \
+                                    nitems_return, bytes_after_return, prop_return)                \
+	LogTagAndXGetWindowProperty_ex((tag), __FILE__, __FUNCTION__, __LINE__, (display), (w),        \
+	                               (property), (long_offset), (long_length), (delete), (req_type), \
+	                               (actual_type_return), (actual_format_return), (nitems_return),  \
+	                               (bytes_after_return), (prop_return))
+int LogTagAndXGetWindowProperty_ex(const char* tag, const char* file, const char* fkt, size_t line,
+                                   Display* display, Window w, Atom property, long long_offset,
+                                   long long_length, Bool delete, Atom req_type,
+                                   Atom* actual_type_return, int* actual_format_return,
+                                   unsigned long* nitems_return, unsigned long* bytes_after_return,
+                                   unsigned char** prop_return);
 
-int LogTagAndXChangeProperty(const char* tag, Display* display, Window w, Atom property, Atom type,
-                             int format, int mode, _Xconst unsigned char* data, int nelements);
-int LogDynAndXChangeProperty(wLog* log, Display* display, Window w, Atom property, Atom type,
-                             int format, int mode, _Xconst unsigned char* data, int nelements);
+#define LogDynAndXGetWindowProperty(log, display, w, property, long_offset, long_length, delete,   \
+                                    req_type, actual_type_return, actual_format_return,            \
+                                    nitems_return, bytes_after_return, prop_return)                \
+	LogDynAndXGetWindowProperty_ex((log), __FILE__, __FUNCTION__, __LINE__, (display), (w),        \
+	                               (property), (long_offset), (long_length), (delete), (req_type), \
+	                               (actual_type_return), (actual_format_return), (nitems_return),  \
+	                               (bytes_after_return), (prop_return))
+int LogDynAndXGetWindowProperty_ex(wLog* log, const char* file, const char* fkt, size_t line,
+                                   Display* display, Window w, Atom property, long long_offset,
+                                   long long_length, Bool delete, Atom req_type,
+                                   Atom* actual_type_return, int* actual_format_return,
+                                   unsigned long* nitems_return, unsigned long* bytes_after_return,
+                                   unsigned char** prop_return);
 
-int LogTagAndXDeleteProperty(const char* tag, Display* display, Window w, Atom property);
-int LogDynAndXDeleteProperty(wLog* log, Display* display, Window w, Atom property);
+#define LogTagAndXChangeProperty(tag, display, w, property, type, format, mode, data, nelements) \
+	LogTagAndXChangeProperty_ex((tag), __FILE__, __FUNCTION__, __LINE__, (display), (w),         \
+	                            (property), (type), (format), (mode), (data), (nelements))
+int LogTagAndXChangeProperty_ex(const char* tag, const char* file, const char* fkt, size_t line,
+                                Display* display, Window w, Atom property, Atom type, int format,
+                                int mode, _Xconst unsigned char* data, int nelements);
+
+#define LogDynAndXChangeProperty(log, display, w, property, type, format, mode, data, nelements) \
+	LogDynAndXChangeProperty_ex((log), __FILE__, __FUNCTION__, __LINE__, (display), (w),         \
+	                            (property), (type), (format), (mode), (data), (nelements))
+int LogDynAndXChangeProperty_ex(wLog* log, const char* file, const char* fkt, size_t line,
+                                Display* display, Window w, Atom property, Atom type, int format,
+                                int mode, _Xconst unsigned char* data, int nelements);
+
+#define LogTagAndXDeleteProperty(tag, display, w, property) \
+	LogTagAndXDeleteProperty_ex((tag), __FILE__, __FUNCTION__, __LINE__, (display), (w), (property))
+int LogTagAndXDeleteProperty_ex(const char* tag, const char* file, const char* fkt, size_t line,
+                                Display* display, Window w, Atom property);
+
+#define LogDynAndXDeleteProperty(log, display, w, property) \
+	LogDynAndXDeleteProperty_ex((log), __FILE__, __FUNCTION__, __LINE__, (display), (w), (property))
+int LogDynAndXDeleteProperty_ex(wLog* log, const char* file, const char* fkt, size_t line,
+                                Display* display, Window w, Atom property);

--- a/client/X11/xf_utils.h
+++ b/client/X11/xf_utils.h
@@ -23,6 +23,8 @@
 
 #include <X11/Xlib.h>
 
+char* Safe_XGetAtomName(Display* display, Atom atom);
+
 #define LogTagAndXGetWindowProperty(tag, display, w, property, long_offset, long_length, delete,   \
                                     req_type, actual_type_return, actual_format_return,            \
                                     nitems_return, bytes_after_return, prop_return)                \

--- a/client/X11/xf_utils.h
+++ b/client/X11/xf_utils.h
@@ -27,3 +27,6 @@ int LogTagAndXChangeProperty(const char* tag, Display* display, Window w, Atom p
                              int format, int mode, _Xconst unsigned char* data, int nelements);
 int LogDynAndXChangeProperty(wLog* log, Display* display, Window w, Atom property, Atom type,
                              int format, int mode, _Xconst unsigned char* data, int nelements);
+
+int LogTagAndXDeleteProperty(const char* tag, Display* display, Window w, Atom property);
+int LogDynAndXDeleteProperty(wLog* log, Display* display, Window w, Atom property);

--- a/client/X11/xf_utils.h
+++ b/client/X11/xf_utils.h
@@ -23,6 +23,17 @@
 
 #include <X11/Xlib.h>
 
+int LogTagAndXGetWindowProperty(const char* tag, Display* display, Window w, Atom property,
+                                long long_offset, long long_length, Bool delete, Atom req_type,
+                                Atom* actual_type_return, int* actual_format_return,
+                                unsigned long* nitems_return, unsigned long* bytes_after_return,
+                                unsigned char** prop_return);
+int LogDynAndXGetWindowProperty(wLog* log, Display* display, Window w, Atom property,
+                                long long_offset, long long_length, Bool delete, Atom req_type,
+                                Atom* actual_type_return, int* actual_format_return,
+                                unsigned long* nitems_return, unsigned long* bytes_after_return,
+                                unsigned char** prop_return);
+
 int LogTagAndXChangeProperty(const char* tag, Display* display, Window w, Atom property, Atom type,
                              int format, int mode, _Xconst unsigned char* data, int nelements);
 int LogDynAndXChangeProperty(wLog* log, Display* display, Window w, Atom property, Atom type,

--- a/client/X11/xf_utils.h
+++ b/client/X11/xf_utils.h
@@ -1,0 +1,29 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * X11 helper utilities
+ *
+ * Copyright 2023 Armin Novak <armin.novak@thincast.com>
+ * Copyringht 2023 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <winpr/wlog.h>
+
+#include <X11/Xlib.h>
+
+int LogTagAndXChangeProperty(const char* tag, Display* display, Window w, Atom property, Atom type,
+                             int format, int mode, _Xconst unsigned char* data, int nelements);
+int LogDynAndXChangeProperty(wLog* log, Display* display, Window w, Atom property, Atom type,
+                             int format, int mode, _Xconst unsigned char* data, int nelements);

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -55,6 +55,7 @@
 #include "xf_rail.h"
 #include "xf_input.h"
 #include "xf_keyboard.h"
+#include "xf_utils.h"
 
 #define TAG CLIENT_TAG("x11")
 
@@ -110,12 +111,15 @@ typedef struct
 
 static void xf_SetWindowTitleText(xfContext* xfc, Window window, const char* name)
 {
+	WINPR_ASSERT(xfc);
+	WINPR_ASSERT(name);
+
 	const size_t i = strnlen(name, MAX_PATH);
 	XStoreName(xfc->display, window, name);
 	Atom wm_Name = xfc->_NET_WM_NAME;
 	Atom utf8Str = xfc->UTF8_STRING;
-	XChangeProperty(xfc->display, window, wm_Name, utf8Str, 8, PropModeReplace,
-	                (const unsigned char*)name, (int)i);
+	LogTagAndXChangeProperty(TAG, xfc->display, window, wm_Name, utf8Str, 8, PropModeReplace,
+	                         (const unsigned char*)name, (int)i);
 }
 
 /**
@@ -425,35 +429,35 @@ BOOL xf_GetWorkArea(xfContext* xfc)
 
 void xf_SetWindowDecorations(xfContext* xfc, Window window, BOOL show)
 {
-	PropMotifWmHints hints;
-	hints.decorations = (show) ? MWM_DECOR_ALL : 0;
-	hints.functions = MWM_FUNC_ALL;
-	hints.flags = MWM_HINTS_DECORATIONS | MWM_HINTS_FUNCTIONS;
-	hints.inputMode = 0;
-	hints.status = 0;
-	XChangeProperty(xfc->display, window, xfc->_MOTIF_WM_HINTS, xfc->_MOTIF_WM_HINTS, 32,
-	                PropModeReplace, (BYTE*)&hints, PROP_MOTIF_WM_HINTS_ELEMENTS);
+	PropMotifWmHints hints = { .decorations = (show) ? MWM_DECOR_ALL : 0,
+		                       .functions = MWM_FUNC_ALL,
+		                       .flags = MWM_HINTS_DECORATIONS | MWM_HINTS_FUNCTIONS,
+		                       .inputMode = 0,
+		                       .status = 0 };
+	WINPR_ASSERT(xfc);
+	LogTagAndXChangeProperty(TAG, xfc->display, window, xfc->_MOTIF_WM_HINTS, xfc->_MOTIF_WM_HINTS,
+	                         32, PropModeReplace, (BYTE*)&hints, PROP_MOTIF_WM_HINTS_ELEMENTS);
 }
 
 void xf_SetWindowUnlisted(xfContext* xfc, Window window)
 {
-	Atom window_state[2];
-	window_state[0] = xfc->_NET_WM_STATE_SKIP_PAGER;
-	window_state[1] = xfc->_NET_WM_STATE_SKIP_TASKBAR;
-	XChangeProperty(xfc->display, window, xfc->_NET_WM_STATE, XA_ATOM, 32, PropModeReplace,
-	                (BYTE*)&window_state, 2);
+	WINPR_ASSERT(xfc);
+	const Atom window_state[] = { xfc->_NET_WM_STATE_SKIP_PAGER, xfc->_NET_WM_STATE_SKIP_TASKBAR };
+	LogTagAndXChangeProperty(TAG, xfc->display, window, xfc->_NET_WM_STATE, XA_ATOM, 32,
+	                         PropModeReplace, (BYTE*)&window_state, 2);
 }
 
 static void xf_SetWindowPID(xfContext* xfc, Window window, pid_t pid)
 {
 	Atom am_wm_pid;
 
+	WINPR_ASSERT(xfc);
 	if (!pid)
 		pid = getpid();
 
 	am_wm_pid = xfc->_NET_WM_PID;
-	XChangeProperty(xfc->display, window, am_wm_pid, XA_CARDINAL, 32, PropModeReplace, (BYTE*)&pid,
-	                1);
+	LogTagAndXChangeProperty(TAG, xfc->display, window, am_wm_pid, XA_CARDINAL, 32, PropModeReplace,
+	                         (BYTE*)&pid, 1);
 }
 
 static const char* get_shm_id(void)
@@ -561,8 +565,8 @@ xfWindow* xf_CreateDesktopWindow(xfContext* xfc, char* name, int width, int heig
 	if (xfc->grab_keyboard)
 		input_mask |= EnterWindowMask | LeaveWindowMask;
 
-	XChangeProperty(xfc->display, window->handle, xfc->_NET_WM_ICON, XA_CARDINAL, 32,
-	                PropModeReplace, (BYTE*)xf_icon_prop, ARRAYSIZE(xf_icon_prop));
+	LogTagAndXChangeProperty(TAG, xfc->display, window->handle, xfc->_NET_WM_ICON, XA_CARDINAL, 32,
+	                         PropModeReplace, (BYTE*)xf_icon_prop, ARRAYSIZE(xf_icon_prop));
 
 	if (parentWindow)
 		XReparentWindow(xfc->display, window->handle, parentWindow, 0, 0);
@@ -720,8 +724,8 @@ void xf_SetWindowStyle(xfContext* xfc, xfAppWindow* appWindow, UINT32 style, UIN
 		XChangeWindowAttributes(xfc->display, appWindow->handle, CWOverrideRedirect, &attrs);
 	}
 
-	XChangeProperty(xfc->display, appWindow->handle, xfc->_NET_WM_WINDOW_TYPE, XA_ATOM, 32,
-	                PropModeReplace, (BYTE*)&window_type, 1);
+	LogTagAndXChangeProperty(TAG, xfc->display, appWindow->handle, xfc->_NET_WM_WINDOW_TYPE,
+	                         XA_ATOM, 32, PropModeReplace, (BYTE*)&window_type, 1);
 }
 
 void xf_SetWindowText(xfContext* xfc, xfAppWindow* appWindow, const char* name)

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -362,8 +362,9 @@ BOOL xf_GetWindowProperty(xfContext* xfc, Window window, Atom property, int leng
 	if (property == None)
 		return FALSE;
 
-	status = XGetWindowProperty(xfc->display, window, property, 0, length, False, AnyPropertyType,
-	                            &actual_type, &actual_format, nitems, bytes, prop);
+	status = LogTagAndXGetWindowProperty(TAG, xfc->display, window, property, 0, length, False,
+	                                     AnyPropertyType, &actual_type, &actual_format, nitems,
+	                                     bytes, prop);
 
 	if (status != Success)
 		return FALSE;


### PR DESCRIPTION
to debug bug reports occuring only with certain setups wrap the function call with a logging edition so we have the arguments available in the log for debugging.
