### PR TITLE
winpr: fix WaitForMultipleObjectsEx(alertable) call from non winpr threads

### DIFF
--- a/winpr/libwinpr/synch/sleep.c
+++ b/winpr/libwinpr/synch/sleep.c
@@ -63,15 +63,17 @@ DWORD SleepEx(DWORD dwMilliseconds, BOOL bAlertable)
 	DWORD ret = WAIT_FAILED;
 	BOOL autoSignalled;
 
-	if (!thread)
+	if (thread)
 	{
-		WLog_ERR(TAG, "unable to retrieve currentThread");
-		return WAIT_FAILED;
+		/* treat re-entrancy if a completion is calling us */
+		if (thread->apc.treatingCompletions)
+			bAlertable = FALSE;
 	}
-
-	/* treat re-entrancy if a completion is calling us */
-	if (thread->apc.treatingCompletions)
+	else
+	{
+		/* called from a non WinPR thread */
 		bAlertable = FALSE;
+	}
 
 	if (!bAlertable || !thread->apc.length)
 	{


### PR DESCRIPTION
When WaitForMultipleObjectsEx is called with the alertable flag set from a non WinPR thread, we shall not try to treat APC, as for sure there is no APC scheduled, as previous call that would have scheduled such APC would have failed.