### PR TITLE
common: Fix parsing of rdp file domain info

### DIFF
--- a/client/common/file.c
+++ b/client/common/file.c
@@ -1399,7 +1399,7 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 		if (!freerdp_settings_set_string(settings, FreeRDP_Username, user))
 			return FALSE;
 
-		if (domain)
+		if (!(~((size_t)file->Domain)) && domain)
 		{
 			if (!freerdp_settings_set_string(settings, FreeRDP_Domain, domain))
 				return FALSE;


### PR DESCRIPTION
`freerdp_parse_username` always returns non-NULL domain information when called. This currently results in `settings->domain` being overridden in every case, even though we might have read domain information from the file before.

This PR fixes this issue by checking if domain information was present in the file and if not use the parsed domain informatin.
