### PR TITLE
Shadow fix missing/invalid return checks

### DIFF
--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -852,9 +852,7 @@ int shadow_server_init(rdpShadowServer* server)
 	if (status < 0)
 		goto fail;
 
-	status = shadow_server_init_certificate(server);
-
-	if (status < 0)
+	if (!shadow_server_init_certificate(server))
 		goto fail;
 
 	server->listener = freerdp_listener_new();

--- a/winpr/include/winpr/tools/makecert.h
+++ b/winpr/include/winpr/tools/makecert.h
@@ -31,9 +31,12 @@ extern "C"
 
 	WINPR_API int makecert_context_process(MAKECERT_CONTEXT* context, int argc, char** argv);
 
-	WINPR_API int makecert_context_set_output_file_name(MAKECERT_CONTEXT* context, char* name);
-	WINPR_API int makecert_context_output_certificate_file(MAKECERT_CONTEXT* context, char* path);
-	WINPR_API int makecert_context_output_private_key_file(MAKECERT_CONTEXT* context, char* path);
+	WINPR_API int makecert_context_set_output_file_name(MAKECERT_CONTEXT* context,
+	                                                    const char* name);
+	WINPR_API int makecert_context_output_certificate_file(MAKECERT_CONTEXT* context,
+	                                                       const char* path);
+	WINPR_API int makecert_context_output_private_key_file(MAKECERT_CONTEXT* context,
+	                                                       const char* path);
 
 	WINPR_API MAKECERT_CONTEXT* makecert_context_new(void);
 	WINPR_API void makecert_context_free(MAKECERT_CONTEXT* context);

--- a/winpr/tools/makecert/makecert.c
+++ b/winpr/tools/makecert/makecert.c
@@ -419,7 +419,7 @@ static int makecert_context_parse_arguments(MAKECERT_CONTEXT* context,
 	return 1;
 }
 
-int makecert_context_set_output_file_name(MAKECERT_CONTEXT* context, char* name)
+int makecert_context_set_output_file_name(MAKECERT_CONTEXT* context, const char* name)
 {
 	if (!context)
 		return -1;
@@ -436,7 +436,7 @@ int makecert_context_set_output_file_name(MAKECERT_CONTEXT* context, char* name)
 	return 1;
 }
 
-int makecert_context_output_certificate_file(MAKECERT_CONTEXT* context, char* path)
+int makecert_context_output_certificate_file(MAKECERT_CONTEXT* context, const char* path)
 {
 #ifdef WITH_OPENSSL
 	FILE* fp = NULL;
@@ -605,7 +605,7 @@ out_fail:
 #endif
 }
 
-int makecert_context_output_private_key_file(MAKECERT_CONTEXT* context, char* path)
+int makecert_context_output_private_key_file(MAKECERT_CONTEXT* context, const char* path)
 {
 #ifdef WITH_OPENSSL
 	FILE* fp = NULL;


### PR DESCRIPTION
* when an invalid/unsupported certificate was detected the return value check was broken and shadow did not abort
* clean up the path generating a certificate if none was detected