### PR TITLE
common: Minor code cleanup of rdp file handling

### DIFF
--- a/client/common/file.c
+++ b/client/common/file.c
@@ -1067,7 +1067,7 @@ BOOL freerdp_client_populate_rdp_file_from_settings(rdpFile* file, const rdpSett
 	file->BandwidthAutoDetect =
 	    (freerdp_settings_get_uint32(settings, FreeRDP_ConnectionType) >= 7) ? TRUE : FALSE;
 	file->NetworkAutoDetect =
-	    freerdp_settings_get_bool(settings, FreeRDP_NetworkAutoDetect) ? 0 : 1;
+	    freerdp_settings_get_bool(settings, FreeRDP_NetworkAutoDetect) ? 1 : 0;
 	file->AutoReconnectionEnabled =
 	    freerdp_settings_get_bool(settings, FreeRDP_AutoReconnectionEnabled);
 	file->RedirectSmartCards = freerdp_settings_get_bool(settings, FreeRDP_RedirectSmartCards);
@@ -1926,14 +1926,14 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 	{
 		if (file->BandwidthAutoDetect != 0)
 		{
-			if ((~file->NetworkAutoDetect) && (file->NetworkAutoDetect != 0))
+			if ((~file->NetworkAutoDetect) && (file->NetworkAutoDetect == 0))
 			{
 				WLog_WARN(TAG,
 				          "Got networkautodetect:i:%" PRIu32 " and bandwidthautodetect:i:%" PRIu32
-				          ". Correcting to networkautodetect:i:0",
+				          ". Correcting to networkautodetect:i:1",
 				          file->NetworkAutoDetect, file->BandwidthAutoDetect);
 				WLog_WARN(TAG,
-				          "Add networkautodetect:i:0 to your RDP file to eliminate this warning.");
+				          "Add networkautodetect:i:1 to your RDP file to eliminate this warning.");
 			}
 
 			if (!freerdp_set_connection_type(settings, CONNECTION_TYPE_AUTODETECT))
@@ -1942,13 +1942,13 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 		}
 		if (!freerdp_settings_set_bool(settings, FreeRDP_NetworkAutoDetect,
 		                               (file->BandwidthAutoDetect != 0) ||
-		                                   (file->NetworkAutoDetect == 0)))
+		                                   (file->NetworkAutoDetect != 0)))
 			return FALSE;
 	}
 
 	if (~file->NetworkAutoDetect)
 	{
-		if (file->NetworkAutoDetect == 0)
+		if (file->NetworkAutoDetect != 0)
 		{
 			if ((~file->BandwidthAutoDetect) && (file->BandwidthAutoDetect == 0))
 			{
@@ -1967,7 +1967,7 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 		}
 		if (!freerdp_settings_set_bool(settings, FreeRDP_NetworkAutoDetect,
 		                               (file->BandwidthAutoDetect != 0) ||
-		                                   (file->NetworkAutoDetect == 0)))
+		                                   (file->NetworkAutoDetect != 0)))
 			return FALSE;
 	}
 

--- a/client/common/file.c
+++ b/client/common/file.c
@@ -66,7 +66,6 @@ static const BYTE BOM_UTF16_LE[2] = { 0xFF, 0xFE };
 
 struct rdp_file_line
 {
-	char* text;
 	char* name;
 	LPSTR sValue;
 	PBYTE bValue;
@@ -212,18 +211,256 @@ struct rdp_file
 	DWORD flags;
 };
 
+static SSIZE_T freerdp_client_rdp_file_add_line(rdpFile* file);
+static rdpFileLine* freerdp_client_rdp_file_find_line_by_name(rdpFile* file, const char* name);
 static void freerdp_client_file_string_check_free(LPSTR str);
+
+static BOOL freerdp_client_rdp_file_find_integer_entry(rdpFile* file, const char* name,
+                                                       DWORD** outValue, rdpFileLine** outLine)
+{
+	WINPR_ASSERT(file);
+	WINPR_ASSERT(name);
+	WINPR_ASSERT(outValue);
+	WINPR_ASSERT(outLine);
+
+	*outValue = NULL;
+	*outLine = NULL;
+
+	if (_stricmp(name, "use multimon") == 0)
+		*outValue = &file->UseMultiMon;
+	else if (_stricmp(name, "maximizetocurrentdisplays") == 0)
+		*outValue = &file->MaximizeToCurrentDisplays;
+	else if (_stricmp(name, "singlemoninwindowedmode") == 0)
+		*outValue = &file->SingleMonInWindowedMode;
+	else if (_stricmp(name, "screen mode id") == 0)
+		*outValue = &file->ScreenModeId;
+	else if (_stricmp(name, "span monitors") == 0)
+		*outValue = &file->SpanMonitors;
+	else if (_stricmp(name, "smart sizing") == 0)
+		*outValue = &file->SmartSizing;
+	else if (_stricmp(name, "dynamic resolution") == 0)
+		*outValue = &file->DynamicResolution;
+	else if (_stricmp(name, "enablesuperpan") == 0)
+		*outValue = &file->EnableSuperSpan;
+	else if (_stricmp(name, "superpanaccelerationfactor") == 0)
+		*outValue = &file->SuperSpanAccelerationFactor;
+	else if (_stricmp(name, "desktopwidth") == 0)
+		*outValue = &file->DesktopWidth;
+	else if (_stricmp(name, "desktopheight") == 0)
+		*outValue = &file->DesktopHeight;
+	else if (_stricmp(name, "desktop size id") == 0)
+		*outValue = &file->DesktopSizeId;
+	else if (_stricmp(name, "session bpp") == 0)
+		*outValue = &file->SessionBpp;
+	else if (_stricmp(name, "desktopscalefactor") == 0)
+		*outValue = &file->DesktopScaleFactor;
+	else if (_stricmp(name, "compression") == 0)
+		*outValue = &file->Compression;
+	else if (_stricmp(name, "keyboardhook") == 0)
+		*outValue = &file->KeyboardHook;
+	else if (_stricmp(name, "disable ctrl+alt+del") == 0)
+		*outValue = &file->DisableCtrlAltDel;
+	else if (_stricmp(name, "audiomode") == 0)
+		*outValue = &file->AudioMode;
+	else if (_stricmp(name, "audioqualitymode") == 0)
+		*outValue = &file->AudioQualityMode;
+	else if (_stricmp(name, "audiocapturemode") == 0)
+		*outValue = &file->AudioCaptureMode;
+	else if (_stricmp(name, "encode redirected video capture") == 0)
+		*outValue = &file->EncodeRedirectedVideoCapture;
+	else if (_stricmp(name, "redirected video capture encoding quality") == 0)
+		*outValue = &file->RedirectedVideoCaptureEncodingQuality;
+	else if (_stricmp(name, "videoplaybackmode") == 0)
+		*outValue = &file->VideoPlaybackMode;
+	else if (_stricmp(name, "connection type") == 0)
+		*outValue = &file->ConnectionType;
+	else if (_stricmp(name, "networkautodetect") == 0)
+		*outValue = &file->NetworkAutoDetect;
+	else if (_stricmp(name, "bandwidthautodetect") == 0)
+		*outValue = &file->BandwidthAutoDetect;
+	else if (_stricmp(name, "pinconnectionbar") == 0)
+		*outValue = &file->PinConnectionBar;
+	else if (_stricmp(name, "displayconnectionbar") == 0)
+		*outValue = &file->DisplayConnectionBar;
+	else if (_stricmp(name, "workspaceid") == 0)
+		*outValue = &file->WorkspaceId;
+	else if (_stricmp(name, "enableworkspacereconnect") == 0)
+		*outValue = &file->EnableWorkspaceReconnect;
+	else if (_stricmp(name, "disable wallpaper") == 0)
+		*outValue = &file->DisableWallpaper;
+	else if (_stricmp(name, "allow font smoothing") == 0)
+		*outValue = &file->AllowFontSmoothing;
+	else if (_stricmp(name, "allow desktop composition") == 0)
+		*outValue = &file->AllowDesktopComposition;
+	else if (_stricmp(name, "disable full window drag") == 0)
+		*outValue = &file->DisableFullWindowDrag;
+	else if (_stricmp(name, "disable menu anims") == 0)
+		*outValue = &file->DisableMenuAnims;
+	else if (_stricmp(name, "disable themes") == 0)
+		*outValue = &file->DisableThemes;
+	else if (_stricmp(name, "disable cursor setting") == 0)
+		*outValue = &file->DisableCursorSetting;
+	else if (_stricmp(name, "bitmapcachesize") == 0)
+		*outValue = &file->BitmapCacheSize;
+	else if (_stricmp(name, "bitmapcachepersistenable") == 0)
+		*outValue = &file->BitmapCachePersistEnable;
+	else if (_stricmp(name, "server port") == 0)
+		*outValue = &file->ServerPort;
+	else if (_stricmp(name, "redirectdrives") == 0)
+		*outValue = &file->RedirectDrives;
+	else if (_stricmp(name, "redirectprinters") == 0)
+		*outValue = &file->RedirectPrinters;
+	else if (_stricmp(name, "redirectcomports") == 0)
+		*outValue = &file->RedirectComPorts;
+	else if (_stricmp(name, "redirectsmartcards") == 0)
+		*outValue = &file->RedirectSmartCards;
+	else if (_stricmp(name, "redirectclipboard") == 0)
+		*outValue = &file->RedirectClipboard;
+	else if (_stricmp(name, "redirectposdevices") == 0)
+		*outValue = &file->RedirectPosDevices;
+	else if (_stricmp(name, "redirectdirectx") == 0)
+		*outValue = &file->RedirectDirectX;
+	else if (_stricmp(name, "disableprinterredirection") == 0)
+		*outValue = &file->DisablePrinterRedirection;
+	else if (_stricmp(name, "disableclipboardredirection") == 0)
+		*outValue = &file->DisableClipboardRedirection;
+	else if (_stricmp(name, "connect to console") == 0)
+		*outValue = &file->ConnectToConsole;
+	else if (_stricmp(name, "administrative session") == 0)
+		*outValue = &file->AdministrativeSession;
+	else if (_stricmp(name, "autoreconnection enabled") == 0)
+		*outValue = &file->AutoReconnectionEnabled;
+	else if (_stricmp(name, "autoreconnect max retries") == 0)
+		*outValue = &file->AutoReconnectMaxRetries;
+	else if (_stricmp(name, "public mode") == 0)
+		*outValue = &file->PublicMode;
+	else if (_stricmp(name, "authentication level") == 0)
+		*outValue = &file->AuthenticationLevel;
+	else if (_stricmp(name, "promptcredentialonce") == 0)
+		*outValue = &file->PromptCredentialOnce;
+	else if ((_stricmp(name, "prompt for credentials") == 0))
+		*outValue = &file->PromptForCredentials;
+	else if (_stricmp(name, "negotiate security layer") == 0)
+		*outValue = &file->NegotiateSecurityLayer;
+	else if (_stricmp(name, "enablecredsspsupport") == 0)
+		*outValue = &file->EnableCredSSPSupport;
+	else if (_stricmp(name, "remoteapplicationmode") == 0)
+		*outValue = &file->RemoteApplicationMode;
+	else if (_stricmp(name, "remoteapplicationexpandcmdline") == 0)
+		*outValue = &file->RemoteApplicationExpandCmdLine;
+	else if (_stricmp(name, "remoteapplicationexpandworkingdir") == 0)
+		*outValue = &file->RemoteApplicationExpandWorkingDir;
+	else if (_stricmp(name, "disableconnectionsharing") == 0)
+		*outValue = &file->DisableConnectionSharing;
+	else if (_stricmp(name, "disableremoteappcapscheck") == 0)
+		*outValue = &file->DisableRemoteAppCapsCheck;
+	else if (_stricmp(name, "gatewayusagemethod") == 0)
+		*outValue = &file->GatewayUsageMethod;
+	else if (_stricmp(name, "gatewayprofileusagemethod") == 0)
+		*outValue = &file->GatewayProfileUsageMethod;
+	else if (_stricmp(name, "gatewaycredentialssource") == 0)
+		*outValue = &file->GatewayCredentialsSource;
+	else if (_stricmp(name, "use redirection server name") == 0)
+		*outValue = &file->UseRedirectionServerName;
+	else if (_stricmp(name, "rdgiskdcproxy") == 0)
+		*outValue = &file->RdgIsKdcProxy;
+	else
+	{
+		rdpFileLine* line = freerdp_client_rdp_file_find_line_by_name(file, name);
+		if (!line)
+			return FALSE;
+		if (!(line->flags & RDP_FILE_LINE_FLAG_TYPE_INTEGER))
+			return FALSE;
+
+		*outLine = line;
+	}
+
+	return TRUE;
+}
+
+static BOOL freerdp_client_rdp_file_find_string_entry(rdpFile* file, const char* name,
+                                                      LPSTR** outValue, rdpFileLine** outLine)
+{
+	WINPR_ASSERT(file);
+	WINPR_ASSERT(name);
+	WINPR_ASSERT(outValue);
+	WINPR_ASSERT(outLine);
+
+	*outValue = NULL;
+	*outLine = NULL;
+
+	if (_stricmp(name, "username") == 0)
+		*outValue = &file->Username;
+	else if (_stricmp(name, "domain") == 0)
+		*outValue = &file->Domain;
+	else if (_stricmp(name, "password") == 0)
+		*outValue = &file->Password;
+	else if (_stricmp(name, "full address") == 0)
+		*outValue = &file->FullAddress;
+	else if (_stricmp(name, "alternate full address") == 0)
+		*outValue = &file->AlternateFullAddress;
+	else if (_stricmp(name, "usbdevicestoredirect") == 0)
+		*outValue = &file->UsbDevicesToRedirect;
+	else if (_stricmp(name, "camerastoredirect") == 0)
+		*outValue = &file->RedirectCameras;
+	else if (_stricmp(name, "loadbalanceinfo") == 0)
+		*outValue = &file->LoadBalanceInfo;
+	else if (_stricmp(name, "remoteapplicationname") == 0)
+		*outValue = &file->RemoteApplicationName;
+	else if (_stricmp(name, "remoteapplicationicon") == 0)
+		*outValue = &file->RemoteApplicationIcon;
+	else if (_stricmp(name, "remoteapplicationprogram") == 0)
+		*outValue = &file->RemoteApplicationProgram;
+	else if (_stricmp(name, "remoteapplicationfile") == 0)
+		*outValue = &file->RemoteApplicationFile;
+	else if (_stricmp(name, "remoteapplicationguid") == 0)
+		*outValue = &file->RemoteApplicationGuid;
+	else if (_stricmp(name, "remoteapplicationcmdline") == 0)
+		*outValue = &file->RemoteApplicationCmdLine;
+	else if (_stricmp(name, "alternate shell") == 0)
+		*outValue = &file->AlternateShell;
+	else if (_stricmp(name, "shell working directory") == 0)
+		*outValue = &file->ShellWorkingDirectory;
+	else if (_stricmp(name, "gatewayhostname") == 0)
+		*outValue = &file->GatewayHostname;
+	else if (_stricmp(name, "gatewayaccesstoken") == 0)
+		*outValue = &file->GatewayAccessToken;
+	else if (_stricmp(name, "kdcproxyname") == 0)
+		*outValue = &file->KdcProxyName;
+	else if (_stricmp(name, "drivestoredirect") == 0)
+		*outValue = &file->DrivesToRedirect;
+	else if (_stricmp(name, "devicestoredirect") == 0)
+		*outValue = &file->DevicesToRedirect;
+	else if (_stricmp(name, "winposstr") == 0)
+		*outValue = &file->WinPosStr;
+	else if (_stricmp(name, "pcb") == 0)
+		*outValue = &file->PreconnectionBlob;
+	else if (_stricmp(name, "selectedmonitors") == 0)
+		*outValue = &file->SelectedMonitors;
+	else
+	{
+		rdpFileLine* line = freerdp_client_rdp_file_find_line_by_name(file, name);
+		if (!line)
+			return FALSE;
+		if (!(line->flags & RDP_FILE_LINE_FLAG_TYPE_STRING))
+			return FALSE;
+
+		*outLine = line;
+	}
+
+	return TRUE;
+}
+
 /*
  * Set an integer in a rdpFile
  *
  * @return FALSE if a standard name was set, TRUE for a non-standard name, FALSE on error
  *
  */
-
-static BOOL freerdp_client_rdp_file_set_integer(rdpFile* file, const char* name, long value,
-                                                SSIZE_T index)
+static BOOL freerdp_client_rdp_file_set_integer(rdpFile* file, const char* name, long value)
 {
-	BOOL standard = TRUE;
+	DWORD* targetValue = NULL;
+	rdpFileLine* line = NULL;
 #ifdef DEBUG_CLIENT_FILE
 	WLog_DBG(TAG, "%s:i:%ld", name, value);
 #endif
@@ -231,169 +468,43 @@ static BOOL freerdp_client_rdp_file_set_integer(rdpFile* file, const char* name,
 	if (value < 0)
 		return FALSE;
 
-	if (_stricmp(name, "use multimon") == 0)
-		file->UseMultiMon = (UINT32)value;
-	else if (_stricmp(name, "maximizetocurrentdisplays") == 0)
-		file->MaximizeToCurrentDisplays = (UINT32)value;
-	else if (_stricmp(name, "singlemoninwindowedmode") == 0)
-		file->SingleMonInWindowedMode = (UINT32)value;
-	else if (_stricmp(name, "screen mode id") == 0)
-		file->ScreenModeId = (UINT32)value;
-	else if (_stricmp(name, "span monitors") == 0)
-		file->SpanMonitors = (UINT32)value;
-	else if (_stricmp(name, "smart sizing") == 0)
-		file->SmartSizing = (UINT32)value;
-	else if (_stricmp(name, "dynamic resolution") == 0)
-		file->DynamicResolution = (UINT32)value;
-	else if (_stricmp(name, "enablesuperpan") == 0)
-		file->EnableSuperSpan = (UINT32)value;
-	else if (_stricmp(name, "superpanaccelerationfactor") == 0)
-		file->SuperSpanAccelerationFactor = (UINT32)value;
-	else if (_stricmp(name, "desktopwidth") == 0)
-		file->DesktopWidth = (UINT32)value;
-	else if (_stricmp(name, "desktopheight") == 0)
-		file->DesktopHeight = (UINT32)value;
-	else if (_stricmp(name, "desktop size id") == 0)
-		file->DesktopSizeId = (UINT32)value;
-	else if (_stricmp(name, "session bpp") == 0)
-		file->SessionBpp = (UINT32)value;
-	else if (_stricmp(name, "desktopscalefactor") == 0)
-		file->DesktopScaleFactor = (UINT32)value;
-	else if (_stricmp(name, "compression") == 0)
-		file->Compression = (UINT32)value;
-	else if (_stricmp(name, "keyboardhook") == 0)
-		file->KeyboardHook = (UINT32)value;
-	else if (_stricmp(name, "disable ctrl+alt+del") == 0)
-		file->DisableCtrlAltDel = (UINT32)value;
-	else if (_stricmp(name, "audiomode") == 0)
-		file->AudioMode = (UINT32)value;
-	else if (_stricmp(name, "audioqualitymode") == 0)
-		file->AudioQualityMode = (UINT32)value;
-	else if (_stricmp(name, "audiocapturemode") == 0)
-		file->AudioCaptureMode = (UINT32)value;
-	else if (_stricmp(name, "encode redirected video capture") == 0)
-		file->EncodeRedirectedVideoCapture = (UINT32)value;
-	else if (_stricmp(name, "redirected video capture encoding quality") == 0)
-		file->RedirectedVideoCaptureEncodingQuality = (UINT32)value;
-	else if (_stricmp(name, "videoplaybackmode") == 0)
-		file->VideoPlaybackMode = (UINT32)value;
-	else if (_stricmp(name, "connection type") == 0)
-		file->ConnectionType = (UINT32)value;
-	else if (_stricmp(name, "networkautodetect") == 0)
-		file->NetworkAutoDetect = (UINT32)value;
-	else if (_stricmp(name, "bandwidthautodetect") == 0)
-		file->BandwidthAutoDetect = (UINT32)value;
-	else if (_stricmp(name, "pinconnectionbar") == 0)
-		file->PinConnectionBar = (UINT32)value;
-	else if (_stricmp(name, "displayconnectionbar") == 0)
-		file->DisplayConnectionBar = (UINT32)value;
-	else if (_stricmp(name, "workspaceid") == 0)
-		file->WorkspaceId = (UINT32)value;
-	else if (_stricmp(name, "enableworkspacereconnect") == 0)
-		file->EnableWorkspaceReconnect = (UINT32)value;
-	else if (_stricmp(name, "disable wallpaper") == 0)
-		file->DisableWallpaper = (UINT32)value;
-	else if (_stricmp(name, "allow font smoothing") == 0)
-		file->AllowFontSmoothing = (UINT32)value;
-	else if (_stricmp(name, "allow desktop composition") == 0)
-		file->AllowDesktopComposition = (UINT32)value;
-	else if (_stricmp(name, "disable full window drag") == 0)
-		file->DisableFullWindowDrag = (UINT32)value;
-	else if (_stricmp(name, "disable menu anims") == 0)
-		file->DisableMenuAnims = (UINT32)value;
-	else if (_stricmp(name, "disable themes") == 0)
-		file->DisableThemes = (UINT32)value;
-	else if (_stricmp(name, "disable cursor setting") == 0)
-		file->DisableCursorSetting = (UINT32)value;
-	else if (_stricmp(name, "bitmapcachesize") == 0)
-		file->BitmapCacheSize = (UINT32)value;
-	else if (_stricmp(name, "bitmapcachepersistenable") == 0)
-		file->BitmapCachePersistEnable = (UINT32)value;
-	else if (_stricmp(name, "server port") == 0)
-		file->ServerPort = (UINT32)value;
-	else if (_stricmp(name, "redirectdrives") == 0)
-		file->RedirectDrives = (UINT32)value;
-	else if (_stricmp(name, "redirectprinters") == 0)
-		file->RedirectPrinters = (UINT32)value;
-	else if (_stricmp(name, "redirectcomports") == 0)
-		file->RedirectComPorts = (UINT32)value;
-	else if (_stricmp(name, "redirectsmartcards") == 0)
-		file->RedirectSmartCards = (UINT32)value;
-	else if (_stricmp(name, "redirectclipboard") == 0)
-		file->RedirectClipboard = (UINT32)value;
-	else if (_stricmp(name, "redirectposdevices") == 0)
-		file->RedirectPosDevices = (UINT32)value;
-	else if (_stricmp(name, "redirectdirectx") == 0)
-		file->RedirectDirectX = (UINT32)value;
-	else if (_stricmp(name, "disableprinterredirection") == 0)
-		file->DisablePrinterRedirection = (UINT32)value;
-	else if (_stricmp(name, "disableclipboardredirection") == 0)
-		file->DisableClipboardRedirection = (UINT32)value;
-	else if (_stricmp(name, "connect to console") == 0)
-		file->ConnectToConsole = (UINT32)value;
-	else if (_stricmp(name, "administrative session") == 0)
-		file->AdministrativeSession = (UINT32)value;
-	else if (_stricmp(name, "autoreconnection enabled") == 0)
-		file->AutoReconnectionEnabled = (UINT32)value;
-	else if (_stricmp(name, "autoreconnect max retries") == 0)
-		file->AutoReconnectMaxRetries = (UINT32)value;
-	else if (_stricmp(name, "public mode") == 0)
-		file->PublicMode = (UINT32)value;
-	else if (_stricmp(name, "authentication level") == 0)
-		file->AuthenticationLevel = (UINT32)value;
-	else if (_stricmp(name, "promptcredentialonce") == 0)
-		file->PromptCredentialOnce = (UINT32)value;
-	else if ((_stricmp(name, "prompt for credentials") == 0))
-		file->PromptForCredentials = (UINT32)value;
-	else if (_stricmp(name, "negotiate security layer") == 0)
-		file->NegotiateSecurityLayer = (UINT32)value;
-	else if (_stricmp(name, "enablecredsspsupport") == 0)
-		file->EnableCredSSPSupport = (UINT32)value;
-	else if (_stricmp(name, "remoteapplicationmode") == 0)
-		file->RemoteApplicationMode = (UINT32)value;
-	else if (_stricmp(name, "remoteapplicationexpandcmdline") == 0)
-		file->RemoteApplicationExpandCmdLine = (UINT32)value;
-	else if (_stricmp(name, "remoteapplicationexpandworkingdir") == 0)
-		file->RemoteApplicationExpandWorkingDir = (UINT32)value;
-	else if (_stricmp(name, "disableconnectionsharing") == 0)
-		file->DisableConnectionSharing = (UINT32)value;
-	else if (_stricmp(name, "disableremoteappcapscheck") == 0)
-		file->DisableRemoteAppCapsCheck = (UINT32)value;
-	else if (_stricmp(name, "gatewayusagemethod") == 0)
-		file->GatewayUsageMethod = (UINT32)value;
-	else if (_stricmp(name, "gatewayprofileusagemethod") == 0)
-		file->GatewayProfileUsageMethod = (UINT32)value;
-	else if (_stricmp(name, "gatewaycredentialssource") == 0)
-		file->GatewayCredentialsSource = (UINT32)value;
-	else if (_stricmp(name, "use redirection server name") == 0)
-		file->UseRedirectionServerName = (UINT32)value;
-	else if (_stricmp(name, "rdgiskdcproxy") == 0)
-		file->RdgIsKdcProxy = (UINT32)value;
-	else
-		standard = FALSE;
-
-	if (index >= 0)
+	if (!freerdp_client_rdp_file_find_integer_entry(file, name, &targetValue, &line))
 	{
-		file->lines[index].name = _strdup(name);
-
-		if (!file->lines[index].name)
+		SSIZE_T index = freerdp_client_rdp_file_add_line(file);
+		if (index == -1)
 			return FALSE;
-
-		file->lines[index].iValue = value;
-		file->lines[index].flags = RDP_FILE_LINE_FLAG_FORMATTED;
-		file->lines[index].flags |= RDP_FILE_LINE_FLAG_TYPE_INTEGER;
-
-		if (standard)
-			file->lines[index].flags |= RDP_FILE_LINE_FLAG_STANDARD;
-
-		file->lines[index].valueLength = 0;
+		line = &file->lines[index];
 	}
 
-	return !standard;
+	if (targetValue)
+	{
+		*targetValue = (DWORD)value;
+		return TRUE;
+	}
+
+	if (line)
+	{
+		free(line->name);
+		line->name = _strdup(name);
+		if (!line->name)
+		{
+			free(line->name);
+			line->name = NULL;
+			return FALSE;
+		}
+
+		line->iValue = value;
+		line->flags = RDP_FILE_LINE_FLAG_FORMATTED;
+		line->flags |= RDP_FILE_LINE_FLAG_TYPE_INTEGER;
+		line->valueLength = 0;
+		return TRUE;
+	}
+
+	return FALSE;
 }
 
 static BOOL freerdp_client_parse_rdp_file_integer(rdpFile* file, const char* name,
-                                                  const char* value, SSIZE_T index)
+                                                  const char* value)
 {
 	char* endptr;
 	long ivalue;
@@ -415,8 +526,7 @@ static BOOL freerdp_client_parse_rdp_file_integer(rdpFile* file, const char* nam
 		}
 	}
 
-	freerdp_client_rdp_file_set_integer(file, name, ivalue, index);
-	return TRUE;
+	return freerdp_client_rdp_file_set_integer(file, name, ivalue);
 }
 
 /**
@@ -428,97 +538,55 @@ static BOOL freerdp_client_parse_rdp_file_integer(rdpFile* file, const char* nam
  * @return 0 on success, 1 if the key wasn't found (not a standard key), -1 on error
  */
 
-static int freerdp_client_rdp_file_set_string(rdpFile* file, const char* name, const char* value,
-                                              SSIZE_T index)
+static BOOL freerdp_client_rdp_file_set_string(rdpFile* file, const char* name, const char* value)
 {
-	int standard = 0;
-	LPSTR* tmp = NULL;
+	LPSTR* targetValue = NULL;
+	rdpFileLine* line = NULL;
 #ifdef DEBUG_CLIENT_FILE
 	WLog_DBG(TAG, "%s:s:%s", name, value);
 #endif
 
-	if (!file)
-		return -1;
+	if (!name || !value)
+		return FALSE;
 
-	if (_stricmp(name, "username") == 0)
-		tmp = &file->Username;
-	else if (_stricmp(name, "domain") == 0)
-		tmp = &file->Domain;
-	else if (_stricmp(name, "password") == 0)
-		tmp = &file->Password;
-	else if (_stricmp(name, "full address") == 0)
-		tmp = &file->FullAddress;
-	else if (_stricmp(name, "alternate full address") == 0)
-		tmp = &file->AlternateFullAddress;
-	else if (_stricmp(name, "usbdevicestoredirect") == 0)
-		tmp = &file->UsbDevicesToRedirect;
-	else if (_stricmp(name, "camerastoredirect") == 0)
-		tmp = &file->RedirectCameras;
-	else if (_stricmp(name, "loadbalanceinfo") == 0)
-		tmp = &file->LoadBalanceInfo;
-	else if (_stricmp(name, "remoteapplicationname") == 0)
-		tmp = &file->RemoteApplicationName;
-	else if (_stricmp(name, "remoteapplicationicon") == 0)
-		tmp = &file->RemoteApplicationIcon;
-	else if (_stricmp(name, "remoteapplicationprogram") == 0)
-		tmp = &file->RemoteApplicationProgram;
-	else if (_stricmp(name, "remoteapplicationfile") == 0)
-		tmp = &file->RemoteApplicationFile;
-	else if (_stricmp(name, "remoteapplicationguid") == 0)
-		tmp = &file->RemoteApplicationGuid;
-	else if (_stricmp(name, "remoteapplicationcmdline") == 0)
-		tmp = &file->RemoteApplicationCmdLine;
-	else if (_stricmp(name, "alternate shell") == 0)
-		tmp = &file->AlternateShell;
-	else if (_stricmp(name, "shell working directory") == 0)
-		tmp = &file->ShellWorkingDirectory;
-	else if (_stricmp(name, "gatewayhostname") == 0)
-		tmp = &file->GatewayHostname;
-	else if (_stricmp(name, "gatewayaccesstoken") == 0)
-		tmp = &file->GatewayAccessToken;
-	else if (_stricmp(name, "kdcproxyname") == 0)
-		tmp = &file->KdcProxyName;
-	else if (_stricmp(name, "drivestoredirect") == 0)
-		tmp = &file->DrivesToRedirect;
-	else if (_stricmp(name, "devicestoredirect") == 0)
-		tmp = &file->DevicesToRedirect;
-	else if (_stricmp(name, "winposstr") == 0)
-		tmp = &file->WinPosStr;
-	else if (_stricmp(name, "pcb") == 0)
-		tmp = &file->PreconnectionBlob;
-	else if (_stricmp(name, "selectedmonitors") == 0)
-		tmp = &file->SelectedMonitors;
-	else
-		standard = 1;
-
-	if (tmp && !(*tmp = _strdup(value)))
-		return -1;
-
-	if (index >= 0)
+	if (!freerdp_client_rdp_file_find_string_entry(file, name, &targetValue, &line))
 	{
-		if (!file->lines)
-			return -1;
-
-		file->lines[index].name = _strdup(name);
-		file->lines[index].sValue = _strdup(value);
-
-		if (!file->lines[index].name || !file->lines[index].sValue)
-		{
-			free(file->lines[index].name);
-			free(file->lines[index].sValue);
-			return -1;
-		}
-
-		file->lines[index].flags = RDP_FILE_LINE_FLAG_FORMATTED;
-		file->lines[index].flags |= RDP_FILE_LINE_FLAG_TYPE_STRING;
-
-		if (standard == 0)
-			file->lines[index].flags |= RDP_FILE_LINE_FLAG_STANDARD;
-
-		file->lines[index].valueLength = 0;
+		SSIZE_T index = freerdp_client_rdp_file_add_line(file);
+		if (index == -1)
+			return FALSE;
+		line = &file->lines[index];
 	}
 
-	return standard;
+	if (targetValue)
+	{
+		*targetValue = _strdup(value);
+		if (!(*targetValue))
+			return FALSE;
+		return TRUE;
+	}
+
+	if (line)
+	{
+		free(line->name);
+		free(line->sValue);
+		line->name = _strdup(name);
+		line->sValue = _strdup(value);
+		if (!line->name || !line->sValue)
+		{
+			free(line->name);
+			free(line->sValue);
+			line->name = NULL;
+			line->sValue = NULL;
+			return FALSE;
+		}
+
+		line->flags = RDP_FILE_LINE_FLAG_FORMATTED;
+		line->flags |= RDP_FILE_LINE_FLAG_TYPE_STRING;
+		line->valueLength = 0;
+		return TRUE;
+	}
+
+	return FALSE;
 }
 
 static BOOL freerdp_client_add_option(rdpFile* file, const char* option)
@@ -526,11 +594,9 @@ static BOOL freerdp_client_add_option(rdpFile* file, const char* option)
 	return freerdp_addin_argv_add_argument(file->args, option);
 }
 
-static SSIZE_T freerdp_client_parse_rdp_file_add_line(rdpFile* file, const char* line,
-                                                      SSIZE_T index)
+static SSIZE_T freerdp_client_rdp_file_add_line(rdpFile* file)
 {
-	if (index < 0)
-		index = (SSIZE_T)file->lineCount;
+	SSIZE_T index = (SSIZE_T)file->lineCount;
 
 	while ((file->lineCount + 1) > file->lineSize)
 	{
@@ -547,38 +613,18 @@ static SSIZE_T freerdp_client_parse_rdp_file_add_line(rdpFile* file, const char*
 	}
 
 	ZeroMemory(&(file->lines[file->lineCount]), sizeof(rdpFileLine));
-	file->lines[file->lineCount].text = _strdup(line);
-
-	if (!file->lines[file->lineCount].text)
-		return -1;
-
 	file->lines[file->lineCount].index = (size_t)index;
 	(file->lineCount)++;
 	return index;
 }
 
-static BOOL freerdp_client_parse_rdp_file_string(rdpFile* file, char* name, char* value,
-                                                 SSIZE_T index)
+static BOOL freerdp_client_parse_rdp_file_string(rdpFile* file, char* name, char* value)
 {
-	BOOL ret = TRUE;
-	char* valueA = _strdup(value);
-
-	if (!valueA)
-	{
-		WLog_ERR(TAG, "Failed to convert RDP file string option %s [value=%s]", name, value);
-		return FALSE;
-	}
-
-	if (freerdp_client_rdp_file_set_string(file, name, valueA, index) == -1)
-		ret = FALSE;
-
-	free(valueA);
-	return ret;
+	return freerdp_client_rdp_file_set_string(file, name, value);
 }
 
-static BOOL freerdp_client_parse_rdp_file_option(rdpFile* file, const char* option, SSIZE_T index)
+static BOOL freerdp_client_parse_rdp_file_option(rdpFile* file, const char* option)
 {
-	WINPR_UNUSED(index);
 	return freerdp_client_add_option(file, option);
 }
 
@@ -668,6 +714,17 @@ static BOOL trim_strings(rdpFile* file)
 		return FALSE;
 	if (!trim(&file->SelectedMonitors))
 		return FALSE;
+
+	for (size_t i = 0; i < file->lineCount; ++i)
+	{
+		rdpFileLine* curLine = &file->lines[i];
+		if (curLine->flags & RDP_FILE_LINE_FLAG_TYPE_STRING)
+		{
+			if (!trim(&curLine->sValue))
+				return FALSE;
+		}
+	}
+
 	return TRUE;
 }
 
@@ -675,7 +732,6 @@ BOOL freerdp_client_parse_rdp_file_buffer_ex(rdpFile* file, const BYTE* buffer, 
                                              rdp_file_fkt_parse parse)
 {
 	BOOL rc = FALSE;
-	SSIZE_T index;
 	size_t length;
 	char* line;
 	char* type;
@@ -685,6 +741,8 @@ BOOL freerdp_client_parse_rdp_file_buffer_ex(rdpFile* file, const BYTE* buffer, 
 	char *name, *value;
 	char* copy = NULL;
 
+	if (!file)
+		return FALSE;
 	if (size < 2)
 		return FALSE;
 
@@ -710,7 +768,6 @@ BOOL freerdp_client_parse_rdp_file_buffer_ex(rdpFile* file, const BYTE* buffer, 
 		memcpy(copy, buffer, size);
 	}
 
-	index = 0;
 	line = strtok_s(copy, "\r\n", &context);
 
 	while (line)
@@ -720,13 +777,9 @@ BOOL freerdp_client_parse_rdp_file_buffer_ex(rdpFile* file, const BYTE* buffer, 
 		if (length > 1)
 		{
 			beg = line;
-
-			if (freerdp_client_parse_rdp_file_add_line(file, line, index) == -1)
-				goto fail;
-
 			if (beg[0] == '/')
 			{
-				if (!freerdp_client_parse_rdp_file_option(file, line, index))
+				if (!freerdp_client_parse_rdp_file_option(file, line))
 					goto fail;
 
 				goto next_line; /* FreeRDP option */
@@ -757,13 +810,13 @@ BOOL freerdp_client_parse_rdp_file_buffer_ex(rdpFile* file, const BYTE* buffer, 
 			else if (*type == 'i')
 			{
 				/* integer type */
-				if (!freerdp_client_parse_rdp_file_integer(file, name, value, index))
+				if (!freerdp_client_parse_rdp_file_integer(file, name, value))
 					goto fail;
 			}
 			else if (*type == 's')
 			{
 				/* string type */
-				if (!freerdp_client_parse_rdp_file_string(file, name, value, index))
+				if (!freerdp_client_parse_rdp_file_string(file, name, value))
 					goto fail;
 			}
 			else if (*type == 'b')
@@ -775,7 +828,6 @@ BOOL freerdp_client_parse_rdp_file_buffer_ex(rdpFile* file, const BYTE* buffer, 
 
 	next_line:
 		line = strtok_s(NULL, "\r\n", &context);
-		index++;
 	}
 
 	rc = trim_strings(file);
@@ -797,11 +849,14 @@ BOOL freerdp_client_parse_rdp_file_ex(rdpFile* file, const char* name, rdp_file_
 	size_t read_size;
 	INT64 file_size;
 	const char* fname = name;
+
+	if (!file || !name)
+		return FALSE;
+
 	if (_strnicmp(fname, "file://", 7) == 0)
 		fname = &name[7];
 
 	fp = winpr_fopen(fname, "r");
-
 	if (!fp)
 	{
 		WLog_ERR(TAG, "Failed to open RDP file %s", name);
@@ -854,11 +909,10 @@ BOOL freerdp_client_parse_rdp_file_ex(rdpFile* file, const char* name, rdp_file_
 static INLINE BOOL FILE_POPULATE_STRING(char** _target, const rdpSettings* _settings,
                                         size_t _option)
 {
-	const char* str;
-	if (!_target || !_settings)
-		return FALSE;
+	WINPR_ASSERT(_target);
+	WINPR_ASSERT(_settings);
 
-	str = freerdp_settings_get_string(_settings, _option);
+	const char* str = freerdp_settings_get_string(_settings, _option);
 	freerdp_client_file_string_check_free(*_target);
 	*_target = (void*)~((size_t)NULL);
 	if (str)
@@ -889,6 +943,9 @@ BOOL freerdp_client_populate_rdp_file_from_settings(rdpFile* file, const rdpSett
 	const char* GatewayHostname = NULL;
 	char* redirectCameras = NULL;
 	char* redirectUsb = NULL;
+
+	if (!file || !settings)
+		return FALSE;
 
 	if (!FILE_POPULATE_STRING(&file->Domain, settings, FreeRDP_Domain) ||
 	    !FILE_POPULATE_STRING(&file->Username, settings, FreeRDP_Username) ||
@@ -1102,6 +1159,10 @@ BOOL freerdp_client_write_rdp_file(const rdpFile* file, const char* name, BOOL u
 	char* buffer;
 	int status = 0;
 	WCHAR* unicodestr = NULL;
+
+	if (!file || !name)
+		return FALSE;
+
 	size = freerdp_client_write_rdp_file_buffer(file, NULL, 0);
 	if (size == 0)
 		return FALSE;
@@ -1213,6 +1274,9 @@ static SSIZE_T freerdp_client_write_setting_to_buffer(char** buffer, size_t* buf
 size_t freerdp_client_write_rdp_file_buffer(const rdpFile* file, char* buffer, size_t size)
 {
 	size_t totalSize = 0;
+
+	if (!file)
+		return 0;
 
 	/* either buffer and size are null or non-null */
 	if ((!buffer || !size) && (buffer || size))
@@ -1341,6 +1405,24 @@ size_t freerdp_client_write_rdp_file_buffer(const rdpFile* file, char* buffer, s
 	WRITE_SETTING_STR("pcb:s:%s", file->PreconnectionBlob);
 	WRITE_SETTING_STR("selectedmonitors:s:%s", file->SelectedMonitors);
 
+	/* custom parameters */
+	for (size_t i = 0; i < file->lineCount; ++i)
+	{
+		SSIZE_T res;
+		const rdpFileLine* curLine = &file->lines[i];
+
+		if (curLine->flags & RDP_FILE_LINE_FLAG_TYPE_INTEGER)
+			res = freerdp_client_write_setting_to_buffer(&buffer, &size, "%s:i:%" PRIu32,
+			                                             curLine->name, (UINT32)curLine->iValue);
+		else if (curLine->flags & RDP_FILE_LINE_FLAG_TYPE_STRING)
+			res = freerdp_client_write_setting_to_buffer(&buffer, &size, "%s:s:%s", curLine->name,
+			                                             curLine->sValue);
+		if (res < 0)
+			return 0;
+
+		totalSize += (size_t)res;
+	}
+
 	return totalSize;
 }
 
@@ -1381,6 +1463,9 @@ fail:
 BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* settings)
 {
 	BOOL setDefaultConnectionType = TRUE;
+
+	if (!file || !settings)
+		return FALSE;
 
 	if (~((size_t)file->Domain))
 	{
@@ -2159,15 +2244,6 @@ BOOL freerdp_client_populate_settings_from_rdp_file(rdpFile* file, rdpSettings* 
 	return TRUE;
 }
 
-static rdpFileLine* freerdp_client_rdp_file_find_line_index(rdpFile* file, SSIZE_T index)
-{
-	rdpFileLine* line;
-	if (index < 0)
-		return NULL;
-	line = &(file->lines[index]);
-	return line;
-}
-
 static rdpFileLine* freerdp_client_rdp_file_find_line_by_name(rdpFile* file, const char* name)
 {
 	size_t index;
@@ -2199,128 +2275,44 @@ static rdpFileLine* freerdp_client_rdp_file_find_line_by_name(rdpFile* file, con
  */
 int freerdp_client_rdp_file_set_string_option(rdpFile* file, const char* name, const char* value)
 {
-	int length;
-	char* text;
-	rdpFileLine* line;
-	length = _scprintf("%s:s:%s", name, value);
-	if (length < 0)
-		return -1;
-	text = (char*)malloc((size_t)length + 1);
-
-	if (!text)
-		return -1;
-
-	sprintf_s(text, (size_t)length + 1, "%s:s:%s", name, value ? value : "");
-	text[length] = '\0';
-	line = freerdp_client_rdp_file_find_line_by_name(file, name);
-
-	if (line)
-	{
-		free(line->sValue);
-		line->sValue = _strdup(value);
-
-		if (!line->sValue)
-			goto out_fail;
-
-		free(line->text);
-		line->text = text;
-	}
-	else
-	{
-		SSIZE_T index = freerdp_client_parse_rdp_file_add_line(file, text, -1);
-
-		if (index == -1)
-			goto out_fail;
-
-		if (!freerdp_client_rdp_file_find_line_index(file, index))
-			goto out_fail;
-
-		if (freerdp_client_rdp_file_set_string(file, name, value, index) == -1)
-			goto out_fail;
-
-		free(text);
-	}
-
-	return 0;
-out_fail:
-	free(text);
-	return -1;
+	return freerdp_client_rdp_file_set_string(file, name, value);
 }
 
 const char* freerdp_client_rdp_file_get_string_option(rdpFile* file, const char* name)
 {
-	rdpFileLine* line;
-	line = freerdp_client_rdp_file_find_line_by_name(file, name);
+	LPSTR* value = NULL;
+	rdpFileLine* line = NULL;
 
-	if (!line)
-		return NULL;
+	if (freerdp_client_rdp_file_find_string_entry(file, name, &value, &line))
+	{
+		if (value)
+			return *value;
+		if (line)
+			return line->sValue;
+	}
 
-	if (!(line->flags & RDP_FILE_LINE_FLAG_TYPE_STRING))
-		return NULL;
-
-	return line->sValue;
+	return NULL;
 }
 
 int freerdp_client_rdp_file_set_integer_option(rdpFile* file, const char* name, int value)
 {
-	SSIZE_T index;
-	char* text;
-	rdpFileLine* line;
-	const int length = _scprintf("%s:i:%d", name, value);
-
-	if (length < 0)
-		return -1;
-
-	text = (char*)malloc((size_t)length + 1);
-	line = freerdp_client_rdp_file_find_line_by_name(file, name);
-
-	if (!text)
-		return -1;
-
-	sprintf_s(text, (size_t)length + 1, "%s:i:%d", name, value);
-	text[length] = '\0';
-
-	if (line)
-	{
-		line->iValue = value;
-		free(line->text);
-		line->text = text;
-	}
-	else
-	{
-		index = freerdp_client_parse_rdp_file_add_line(file, text, -1);
-
-		if (index < 0)
-		{
-			free(text);
-			return -1;
-		}
-
-		if (!freerdp_client_rdp_file_find_line_index(file, index))
-		{
-			free(text);
-			return -1;
-		}
-
-		freerdp_client_rdp_file_set_integer(file, name, value, index);
-		free(text);
-	}
-
-	return 0;
+	return freerdp_client_rdp_file_set_integer(file, name, value);
 }
 
 int freerdp_client_rdp_file_get_integer_option(rdpFile* file, const char* name)
 {
-	rdpFileLine* line;
-	line = freerdp_client_rdp_file_find_line_by_name(file, name);
+	DWORD* value = NULL;
+	rdpFileLine* line = NULL;
 
-	if (!line)
-		return -1;
+	if (freerdp_client_rdp_file_find_integer_entry(file, name, &value, &line))
+	{
+		if (value)
+			return *value;
+		if (line)
+			return (int)line->iValue;
+	}
 
-	if (!(line->flags & RDP_FILE_LINE_FLAG_TYPE_INTEGER))
-		return -1;
-
-	return (int)line->iValue;
+	return -1;
 }
 
 static void freerdp_client_file_string_check_free(LPSTR str)
@@ -2371,7 +2363,6 @@ void freerdp_client_rdp_file_free(rdpFile* file)
 			size_t i;
 			for (i = 0; i < file->lineCount; i++)
 			{
-				free(file->lines[i].text);
 				free(file->lines[i].name);
 				free(file->lines[i].sValue);
 			}


### PR DESCRIPTION
This PR contains various changes to rdp file handling:

The old code had a strange mixture of handling settings. When loading a file every line of the file was cached in `rdpFile::lines`. Sometimes functions would operate on these cached lines, sometimes they would operate on the actual values in the `rdpFile` instance.

On the other hand if an `rdpFile` instance was created from `rdpSettings`, this line cache simply did not exist, causing functions to behave differently, depending on whether the instance was created by reading a file or by populating it from `rdpSettings`.

The new implementation has now a single way of accessing values ( `find_integer_entry`/`find_string_entry`) and the `rdpFile::lines` data is used to handle unknown settings.

The PR also adds some argument checking and assertions.