### PR TITLE
Redirection fixes

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -618,16 +618,7 @@ BOOL rdp_client_redirect(rdpRdp* rdp)
 	settings = rdp->settings;
 	WINPR_ASSERT(settings);
 
-	if (settings->RedirectionFlags & LB_LOAD_BALANCE_INFO)
-	{
-		if (settings->LoadBalanceInfo && (settings->LoadBalanceInfoLength > 0))
-		{
-			if (!nego_set_routing_token(rdp->nego, settings->LoadBalanceInfo,
-			                            settings->LoadBalanceInfoLength))
-				return FALSE;
-		}
-	}
-	else
+	if ((settings->RedirectionFlags & LB_LOAD_BALANCE_INFO) == 0)
 	{
 		BOOL haveRedirectAddress = FALSE;
 		UINT32 redirectionMask = settings->RedirectionPreferType;

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -391,6 +391,8 @@ static BOOL nla_client_setup_identity(rdpNla* nla)
 			        (const WCHAR*)settings->RedirectionPassword,
 			        settings->RedirectionPasswordLength / sizeof(WCHAR) - 1) < 0)
 				return FALSE;
+
+			usePassword = FALSE;
 		}
 
 		if (settings->RestrictedAdminModeRequired)

--- a/libfreerdp/core/redirection.c
+++ b/libfreerdp/core/redirection.c
@@ -665,10 +665,11 @@ static state_run_t rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 	Stream_Read_UINT32(s, redirection->sessionID); /* sessionID (4 bytes) */
 	Stream_Read_UINT32(s, redirection->flags);     /* redirFlags (4 bytes) */
 	WLog_INFO(TAG,
-	          "flags: 0x%04" PRIX16 ", redirFlags: %s [0x%08" PRIX32 "] length: %" PRIu16
-	          ", sessionID: 0x%08" PRIX32 "",
-	          flags, rdp_redirection_flags_to_string(redirection->flags, buffer, sizeof(buffer)),
-	          redirection->flags, length, redirection->sessionID);
+	          "flags: 0x%04" PRIX16 ", length: %" PRIu16 ", sessionID: 0x%08" PRIX32
+	          ", redirFlags: %s [0x%08" PRIX32 "]",
+	          flags, length, redirection->sessionID,
+	          rdp_redirection_flags_to_string(redirection->flags, buffer, sizeof(buffer)),
+	          redirection->flags);
 
 	/* Although MS-RDPBCGR does not mention any length constraints limits for the
 	 * variable length null-terminated unicode strings in the RDP_SERVER_REDIRECTION_PACKET


### PR DESCRIPTION
Hello.
Some little fixes.

The most important one is the one that makes `NLA` use the redirection password:
I've checked and mstsc client and Windows Remote Desktop client use the old password when reconnecting on a redirection process.
Though, other RDP clients use the new password.
If we have `RDSTLS`, we could rely on it for redirection with windows clients and use `NLA` for redirection with other clients to keep compatibility because I think most of the clients use the new password on `NLA` but don't support `RDSTLS`.