### PR TITLE
core: Fix sending incorrect GUID in RDSTLS auth request

### DIFF
--- a/libfreerdp/core/rdstls.c
+++ b/libfreerdp/core/rdstls.c
@@ -224,20 +224,11 @@ static SSIZE_T rdstls_write_string(wStream* s, const char* str)
 
 static BOOL rdstls_write_data(wStream* s, UINT32 length, const BYTE* data)
 {
-	if (!Stream_EnsureRemainingCapacity(s, 2))
-		return -1;
-
 	if (!data)
-	{
-		return -1;
-		/* Write unicode null */
-		Stream_Write_UINT16(s, 2);
-		if (!Stream_EnsureRemainingCapacity(s, 2))
-			return -1;
+		return FALSE;
 
-		Stream_Write_UINT16(s, 0);
-		return TRUE;
-	}
+	if (!Stream_EnsureRemainingCapacity(s, 2))
+		return FALSE;
 
 	Stream_Write_UINT16(s, length);
 

--- a/libfreerdp/core/redirection.c
+++ b/libfreerdp/core/redirection.c
@@ -654,7 +654,7 @@ static state_run_t rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, 12))
 		return STATE_RUN_FAILED;
 
-	Stream_Read_UINT16(s, flags);                  /* flags (2 bytes) */
+	Stream_Read_UINT16(s, flags); /* flags (2 bytes) */
 	if (flags != SEC_REDIRECTION_PKT)
 	{
 		char buffer1[1024] = { 0 };
@@ -789,9 +789,8 @@ static state_run_t rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 
 	if (redirection->flags & LB_REDIRECTION_GUID)
 	{
-		if (!rdp_redirection_read_base64_wchar(LB_REDIRECTION_GUID, s,
-		                                       &redirection->RedirectionGuidLength,
-		                                       &redirection->RedirectionGuid))
+		if (!rdp_redirection_read_data(LB_REDIRECTION_GUID, s, &redirection->RedirectionGuidLength,
+		                               &redirection->RedirectionGuid))
 			return STATE_RUN_FAILED;
 	}
 


### PR DESCRIPTION
The spec states that the GUID must be sent as a Base64-encoded GUID in Unicode format. However in the redirection code we read the (correctly formatted) GUID and convert it to a binary BLOB.

This PR removes the unnecessary conversion which now results in a correct RDSTLS auth request.

It also removes some dead code in `rdstls_write_data`.
