### PR TITLE
Fix rdstls write data

### DIFF
--- a/libfreerdp/core/rdstls.c
+++ b/libfreerdp/core/rdstls.c
@@ -456,7 +456,7 @@ static BOOL rdstls_process_authentication_request_with_password(rdpRdstls* rdstl
 	    freerdp_settings_get_uint32(settings, FreeRDP_RedirectionGuidLength);
 	serverUsername = freerdp_settings_get_string(settings, FreeRDP_Username);
 	serverDomain = freerdp_settings_get_string(settings, FreeRDP_Domain);
-	serverPassword = freerdp_settings_get_pointer(settings, FreeRDP_Password);
+	serverPassword = freerdp_settings_get_string(settings, FreeRDP_Password);
 
 	rdstls->resultCode = ERROR_SUCCESS;
 

--- a/libfreerdp/core/rdstls.c
+++ b/libfreerdp/core/rdstls.c
@@ -224,11 +224,19 @@ static SSIZE_T rdstls_write_string(wStream* s, const char* str)
 
 static BOOL rdstls_write_data(wStream* s, UINT32 length, const BYTE* data)
 {
-	if (!data)
-		return FALSE;
-
 	if (!Stream_EnsureRemainingCapacity(s, 2))
 		return FALSE;
+
+	if (!data)
+	{
+		/* Write unicode null */
+		Stream_Write_UINT16(s, 2);
+		if (!Stream_EnsureRemainingCapacity(s, 2))
+			return FALSE;
+
+		Stream_Write_UINT16(s, 0);
+		return TRUE;
+	}
 
 	Stream_Write_UINT16(s, length);
 


### PR DESCRIPTION
It is possible to send an empty `REDIRECTION_GUID`, this PR allows it.
Also, the configured password was got wrongly as a pointer so it wasn't used to authenticate.

