### PR TITLE
Auth callback fix

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -650,7 +650,7 @@ static void wf_report_error(char* wszMessage, DWORD dwErrCode)
 static DWORD wf_is_x509_certificate_trusted(const char* common_name, const char* subject,
                                             const char* issuer, const char* fingerprint)
 {
-	size_t derPubKeyLen;
+	DWORD derPubKeyLen;
 	char* derPubKey;
 
 	HRESULT hr = CRYPT_E_NOT_FOUND;

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -133,8 +133,37 @@ extern "C"
 
 	typedef BOOL (*pConnectCallback)(freerdp* instance);
 	typedef void (*pPostDisconnect)(freerdp* instance);
+
+	/** \brief Authentication callback function pointer definition
+	 *
+	 * \param freerdp A pointer to the instance to work on
+	 * \param username A pointer to the username string. On input the current username, on output
+	 * the username that should be used. Must not be NULL. \param password A pointer to the password
+	 * string. On input the current password, on output the password that sohould be used. Must not
+	 * be NULL. \param domain A pointer to the domain string. On input the current domain, on output
+	 * the domain that sohould be used. Must not be NULL.
+	 *
+	 * \return \b FALSE no valid credentials supplied, continue without \b TRUE valid credentials
+	 * should be available.
+	 */
+
 	typedef BOOL (*pAuthenticate)(freerdp* instance, char** username, char** password,
 	                              char** domain);
+
+	/** \brief Extended authentication callback function pointer definition
+	 *
+	 * \param freerdp A pointer to the instance to work on
+	 * \param username A pointer to the username string. On input the current username, on output
+	 * the username that should be used. Must not be NULL. \param password A pointer to the password
+	 * string. On input the current password, on output the password that sohould be used. Must not
+	 * be NULL. \param domain A pointer to the domain string. On input the current domain, on output
+	 * the domain that sohould be used. Must not be NULL. \param reason The reason the callback was
+	 * called. (e.g. NLA, TLS, RDP, GATEWAY, ...)
+	 *
+	 * \return \b FALSE to abort the connection, \b TRUE otherwise.
+	 * \note To not provide valid credentials and not abort the connection return \b TRUE and empty
+	 * (as in empty string) credentials
+	 */
 	typedef BOOL (*pAuthenticateEx)(freerdp* instance, char** username, char** password,
 	                                char** domain, rdp_auth_reason reason);
 	typedef BOOL (*pChooseSmartcard)(freerdp* instance, SmartcardCertInfo** cert_list, DWORD count,

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -614,7 +614,8 @@ owned by rdpRdp */
 	FREERDP_API const char* freerdp_get_last_error_string(UINT32 error);
 	FREERDP_API const char* freerdp_get_last_error_category(UINT32 error);
 
-	FREERDP_API void freerdp_set_last_error(rdpContext* context, UINT32 lastError);
+#define freerdp_set_last_error(context, lastError) \
+	freerdp_set_last_error_ex((context), (lastError), __FUNCTION__, __FILE__, __LINE__)
 
 #define freerdp_set_last_error_if_not(context, lastError)             \
 	do                                                                \

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -990,31 +990,41 @@ const char* freerdp_get_last_error_category(UINT32 code)
 	return string;
 }
 
-void freerdp_set_last_error(rdpContext* context, UINT32 lastError)
-{
-	freerdp_set_last_error_ex(context, lastError, NULL, NULL, -1);
-}
-
 void freerdp_set_last_error_ex(rdpContext* context, UINT32 lastError, const char* fkt,
                                const char* file, int line)
 {
+	static wLog* _log = NULL;
+	if (_log)
+		_log = WLog_Get(TAG);
+
 	WINPR_ASSERT(context);
 
 	if (lastError)
-		WLog_ERR(TAG, "%s %s [0x%08" PRIX32 "]", fkt, freerdp_get_last_error_name(lastError),
-		         lastError);
+	{
+		if (WLog_IsLevelActive(_log, WLOG_ERROR))
+		{
+			WLog_PrintMessage(_log, WLOG_MESSAGE_TEXT, WLOG_ERROR, line, file, fkt,
+			                  "%s [0x%08" PRIX32 "]", freerdp_get_last_error_name(lastError),
+			                  lastError);
+		}
+	}
 
 	if (lastError == FREERDP_ERROR_SUCCESS)
 	{
-		WLog_DBG(TAG, "%s resetting error state", fkt);
+		if (WLog_IsLevelActive(_log, WLOG_DEBUG))
+			WLog_PrintMessage(_log, WLOG_MESSAGE_TEXT, WLOG_DEBUG, line, file, fkt,
+			                  "resetting error state");
 	}
 	else if (context->LastError != FREERDP_ERROR_SUCCESS)
 	{
-		WLog_ERR(TAG, "%s: TODO: Trying to set error code %s, but %s already set!", fkt,
-		         freerdp_get_last_error_name(lastError),
-		         freerdp_get_last_error_name(context->LastError));
+		if (WLog_IsLevelActive(_log, WLOG_ERROR))
+		{
+			WLog_PrintMessage(_log, WLOG_MESSAGE_TEXT, WLOG_ERROR, line, file, fkt,
+			                  "TODO: Trying to set error code %s, but %s already set!",
+			                  freerdp_get_last_error_name(lastError),
+			                  freerdp_get_last_error_name(context->LastError));
+		}
 	}
-
 	context->LastError = lastError;
 }
 

--- a/libfreerdp/core/utils.c
+++ b/libfreerdp/core/utils.c
@@ -89,7 +89,7 @@ auth_status utils_authenticate_gateway(freerdp* instance, rdp_auth_reason reason
 	if (!instance->GatewayAuthenticate && !instance->AuthenticateEx)
 		return AUTH_NO_CREDENTIALS;
 
-	if (instance->AuthenticateEx)
+	if (!instance->GatewayAuthenticate)
 		proceed =
 		    instance->AuthenticateEx(instance, &settings->GatewayUsername,
 		                             &settings->GatewayPassword, &settings->GatewayDomain, reason);
@@ -177,7 +177,7 @@ auth_status utils_authenticate(freerdp* instance, rdp_auth_reason reason, BOOL o
 	if (!instance->Authenticate && !instance->AuthenticateEx)
 		return AUTH_NO_CREDENTIALS;
 
-	if (instance->AuthenticateEx)
+	if (!instance->Authenticate)
 		proceed = instance->AuthenticateEx(instance, &settings->Username, &settings->Password,
 		                                   &settings->Domain, reason);
 	else

--- a/libfreerdp/core/utils.c
+++ b/libfreerdp/core/utils.c
@@ -90,16 +90,21 @@ auth_status utils_authenticate_gateway(freerdp* instance, rdp_auth_reason reason
 		return AUTH_NO_CREDENTIALS;
 
 	if (!instance->GatewayAuthenticate)
+	{
 		proceed =
 		    instance->AuthenticateEx(instance, &settings->GatewayUsername,
 		                             &settings->GatewayPassword, &settings->GatewayDomain, reason);
+		if (!proceed)
+			return AUTH_CANCELLED;
+	}
 	else
+	{
 		proceed =
 		    instance->GatewayAuthenticate(instance, &settings->GatewayUsername,
 		                                  &settings->GatewayPassword, &settings->GatewayDomain);
-
-	if (!proceed)
-		return AUTH_CANCELLED;
+		if (!proceed)
+			return AUTH_NO_CREDENTIALS;
+	}
 
 	if (utils_str_is_empty(settings->GatewayUsername) ||
 	    utils_str_is_empty(settings->GatewayPassword))
@@ -178,14 +183,19 @@ auth_status utils_authenticate(freerdp* instance, rdp_auth_reason reason, BOOL o
 		return AUTH_NO_CREDENTIALS;
 
 	if (!instance->Authenticate)
+	{
 		proceed = instance->AuthenticateEx(instance, &settings->Username, &settings->Password,
 		                                   &settings->Domain, reason);
+		if (!proceed)
+			return AUTH_CANCELLED;
+	}
 	else
+	{
 		proceed = instance->Authenticate(instance, &settings->Username, &settings->Password,
 		                                 &settings->Domain);
-
-	if (!proceed)
-		return AUTH_CANCELLED;
+		if (!proceed)
+			return AUTH_NO_CREDENTIALS;
+	}
 
 	if (utils_str_is_empty(settings->Username) || utils_str_is_empty(settings->Password))
 		return AUTH_NO_CREDENTIALS;


### PR DESCRIPTION
* reported in #8774 

1. With recent library changes and default callbacks for authentication it is required that we prefer the legacy callbacks if set. 
2. Improve logging with `freerdp_set_last_error` : always log the location it was called instead of the function itself
3. some cleanups with `SelectedProtocol` in `nego`