### PR TITLE
core: Allow NULL identity for NLA authentication

### DIFF
--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -336,9 +336,8 @@ static BOOL nla_client_setup_identity(rdpNla* nla)
 				freerdp_set_last_error_log(instance->context, FREERDP_ERROR_CONNECT_CANCELLED);
 				return FALSE;
 			case AUTH_NO_CREDENTIALS:
-				freerdp_set_last_error_log(instance->context,
-				                           FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
-				return FALSE;
+				WLog_INFO(TAG, "No credentials provided - using NULL identity");
+				break;
 			default:
 				return FALSE;
 		}


### PR DESCRIPTION
During the recent changes the possiblity to perform NLA auth using the current identity was removed.

In case we receive AUTH_NO_CREDENTIALS with NLA we should resume using a NULL-identity and not abort the connection.