### PR TITLE
[utils] fix windows console read

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -444,8 +444,8 @@ static void wf_post_disconnect(freerdp* instance)
 	free(wfc->window_title);
 }
 
-static CREDUI_INFOA wfUiInfo = { sizeof(CREDUI_INFOA), NULL, "Enter your credentials",
-	                             "Remote Desktop Security", NULL };
+static CREDUI_INFOW wfUiInfo = { sizeof(CREDUI_INFOW), NULL, L"Enter your credentials",
+	                             L"Remote Desktop Security", NULL };
 
 static BOOL wf_authenticate_raw(freerdp* instance, const char* title, char** username,
                                 char** password, char** domain)
@@ -470,22 +470,18 @@ static BOOL wf_authenticate_raw(freerdp* instance, const char* title, char** use
 
 	if (username && *username)
 	{
-		ConvertUtf8ToWChar(*username, UserNameW, ARRAYSIZE(UserNameW);
-		ConvertUtf8ToWChar(*username, UserW, ARRAYSIZE(UserW);
+		ConvertUtf8ToWChar(*username, UserNameW, ARRAYSIZE(UserNameW));
+		ConvertUtf8ToWChar(*username, UserW, ARRAYSIZE(UserW));
 	}
 
 	if (password && *password)
-	{
-		ConvertUtf8ToWChar(*password, PasswordW, ARRAYSIZE(PasswordW);
-	}
+		ConvertUtf8ToWChar(*password, PasswordW, ARRAYSIZE(PasswordW));
 
 	if (domain && *domain)
-	{
-		ConvertUtf8ToWChar(*domain, DomainW, ARRAYSIZE(DomainW);
-		strncpy(Domain, *domain, CREDUI_MAX_DOMAIN_TARGET_LENGTH);
-	}
+		ConvertUtf8ToWChar(*domain, DomainW, ARRAYSIZE(DomainW));
 
-	if (!(*UserName && *Password))
+	if ((_wcsnlen(UserNameW, ARRAYSIZE(UserNameW)) == 0) &&
+	    (_wcsnlen(PasswordW, ARRAYSIZE(PasswordW)) == 0))
 	{
 		WCHAR* titleW = ConvertUtf8ToWCharAlloc(title, NULL);
 		if (!wfc->isConsole && wfc->common.context.settings->CredentialsFromStdin)
@@ -509,9 +505,9 @@ static BOOL wf_authenticate_raw(freerdp* instance, const char* title, char** use
 		    CredUIParseUserNameW(UserNameW, UserW, ARRAYSIZE(UserW), DomainW, ARRAYSIZE(DomainW));
 		if (status != NO_ERROR)
 		{
-			CHAR UserW[CREDUI_MAX_USERNAME_LENGTH + 1] = { 0 };
-			CHAR UserNameW[CREDUI_MAX_USERNAME_LENGTH + 1] = { 0 };
-			CHAR DomainW[CREDUI_MAX_DOMAIN_TARGET_LENGTH + 1] = { 0 };
+			CHAR User[CREDUI_MAX_USERNAME_LENGTH + 1] = { 0 };
+			CHAR UserName[CREDUI_MAX_USERNAME_LENGTH + 1] = { 0 };
+			CHAR Domain[CREDUI_MAX_DOMAIN_TARGET_LENGTH + 1] = { 0 };
 
 			ConvertWCharNToUtf8(UserNameW, ARRAYSIZE(UserNameW), UserName, ARRAYSIZE(UserName));
 			ConvertWCharNToUtf8(UserW, ARRAYSIZE(UserW), User, ARRAYSIZE(User));
@@ -529,7 +525,7 @@ static BOOL wf_authenticate_raw(freerdp* instance, const char* title, char** use
 		return FALSE;
 	}
 
-	if (strlen(Domain) > 0)
+	if (_wcsnlen(DomainW, ARRAYSIZE(DomainW)) > 0)
 		*domain = ConvertWCharNToUtf8Alloc(DomainW, ARRAYSIZE(DomainW), NULL);
 	else
 		*domain = _strdup("\0");

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -466,7 +466,8 @@ static BOOL wf_authenticate_raw(freerdp* instance, const char* title, char** use
 	wfc = (wfContext*)instance->context;
 
 	fSave = FALSE;
-	dwFlags = CREDUI_FLAGS_DO_NOT_PERSIST | CREDUI_FLAGS_EXCLUDE_CERTIFICATES;
+	dwFlags = CREDUI_FLAGS_DO_NOT_PERSIST | CREDUI_FLAGS_EXCLUDE_CERTIFICATES |
+	          CREDUI_FLAGS_USERNAME_TARGET_CREDENTIALS;
 
 	if (username && *username)
 	{

--- a/libfreerdp/utils/CMakeLists.txt
+++ b/libfreerdp/utils/CMakeLists.txt
@@ -41,6 +41,7 @@ freerdp_library_add(${CMAKE_THREAD_LIBS_INIT})
 
 if(WIN32)
 	freerdp_library_add(ws2_32)
+	freerdp_library_add(Credui)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES SunOS)

--- a/libfreerdp/utils/passphrase.c
+++ b/libfreerdp/utils/passphrase.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <io.h>
 #include <conio.h>
+#include <wincred.h>
 
 static char read_chr(FILE* f)
 {
@@ -48,67 +49,19 @@ int freerdp_interruptible_getc(rdpContext* context, FILE* f)
 char* freerdp_passphrase_read(rdpContext* context, const char* prompt, char* buf, size_t bufsiz,
                               int from_stdin)
 {
-#define CTRLC 3
-#define BACKSPACE '\b'
-#define NEWLINE '\n'
-#define CARRIAGERETURN '\r'
-#define SHOW_ASTERISK TRUE
-
-	size_t read_cnt = 0, chr;
-
-	printf("%s ", prompt);
-	fflush(stdout);
-	while (read_cnt < bufsiz - 1 && (chr = freerdp_interruptible_getc(context, stdin)) &&
-	       chr != NEWLINE && chr != CARRIAGERETURN)
-	{
-		switch (chr)
-		{
-			case EOF:
-				goto end;
-			case BACKSPACE:
-			{
-				if (read_cnt > 0)
-				{
-					if (SHOW_ASTERISK)
-						printf("\b \b");
-					read_cnt--;
-				}
-			}
-			break;
-			case CTRLC:
-			{
-				if (read_cnt != 0)
-				{
-					while (read_cnt > 0)
-					{
-						if (SHOW_ASTERISK)
-							printf("\b \b");
-						read_cnt--;
-					}
-				}
-				else
-					goto fail;
-			}
-			break;
-			default:
-			{
-				*(buf + read_cnt) = chr;
-				read_cnt++;
-				if (SHOW_ASTERISK)
-					printf("*");
-			}
-			break;
-		}
-
-	end:
-		*(buf + read_cnt) = '\0';
-		printf("\n");
-		fflush(stdout);
-		return buf;
-	}
-fail:
-	errno = ENOSYS;
-	return NULL;
+	WCHAR UserNameW[CREDUI_MAX_USERNAME_LENGTH + 1] = { 'p', 'r', 'e', 'f', 'i',
+		                                                'l', 'l', 'e', 'd', '\0' };
+	WCHAR PasswordW[CREDUI_MAX_PASSWORD_LENGTH + 1] = { 0 };
+	BOOL fSave = FALSE;
+	DWORD dwFlags = 0;
+	WCHAR* promptW = ConvertUtf8ToWCharAlloc(prompt, NULL);
+	const DWORD status =
+	    CredUICmdLinePromptForCredentialsW(promptW, NULL, 0, UserNameW, ARRAYSIZE(UserNameW),
+	                                       PasswordW, ARRAYSIZE(PasswordW), &fSave, dwFlags);
+	free(promptW);
+	if (ConvertWCharNToUtf8(PasswordW, ARRAYSIZE(PasswordW), buf, bufsiz) < 0)
+		return NULL;
+	return buf;
 }
 
 #elif !defined(ANDROID)


### PR DESCRIPTION
On windows freerdp_interruptible_getc did not work at all. Fix this so that reading characters works. This still does not hide input for passwords or is actually interruptible, but at least it reads the data correctly.