### PR TITLE
use cmake object libraries for built-in virtual channel plugins

### DIFF
--- a/channels/CMakeLists.txt
+++ b/channels/CMakeLists.txt
@@ -173,7 +173,7 @@ macro(add_channel_client_library _module_prefix _module_name _channel_name _dyna
 	set(${_module_prefix}_CHANNEL ${_channel_name} PARENT_SCOPE)
 	set(${_module_prefix}_ENTRY ${_entry} PARENT_SCOPE)
 
-	add_library(${_module_name} STATIC ${${_module_prefix}_SRCS})
+	add_library(${_module_name} OBJECT ${${_module_prefix}_SRCS})
     set_property(TARGET ${_module_name} PROPERTY FOLDER "Channels/${CHANNEL_NAME}/Client")
 
 	if (${_module_prefix}_LIBS)
@@ -191,7 +191,7 @@ macro(add_channel_client_subsystem_library _module_prefix _module_name _channel_
 	set(${_module_prefix}_NAME ${_module_name} PARENT_SCOPE)
 	set(${_module_prefix}_TYPE ${_type} PARENT_SCOPE)
 
-	add_library(${_module_name} STATIC ${${_module_prefix}_SRCS})
+	add_library(${_module_name} OBJECT ${${_module_prefix}_SRCS})
 	set_property(TARGET ${_module_name} PROPERTY FOLDER "Channels/${_channel_name}/Client/Subsystem/${CHANNEL_SUBSYSTEM}")
 
 	if (${_module_prefix}_LIBS)
@@ -210,7 +210,7 @@ macro(add_channel_server_library _module_prefix _module_name _channel_name _dyna
 	set(${_module_prefix}_CHANNEL ${_channel_name} PARENT_SCOPE)
 	set(${_module_prefix}_ENTRY ${_entry} PARENT_SCOPE)
 
-	add_library(${_module_name} STATIC ${${_module_prefix}_SRCS})
+	add_library(${_module_name} OBJECT ${${_module_prefix}_SRCS})
 	set_property(TARGET ${_module_name} PROPERTY FOLDER "Channels/${CHANNEL_NAME}/Server")
 
 	if (${_module_prefix}_LIBS)


### PR DESCRIPTION
Built-in virtual channel plugins have always been built as individual static libraries that freerdp-client links to, but recent changes [introduced a cyclic dependency](https://cmake.org/cmake/help/latest/command/target_link_libraries.html#cyclic-dependencies-of-static-libraries) where some virtual channel plugins would also need to link to freerdp-client. Linkers don't behave consistently with cyclic dependencies, and clang from the Android NDK is stricter than on other platforms. Since Android CI builds use shared libraries, the issue is avoided, but we make a single shared library with everything statically linked into it, so we've hit the issue.

As a permanent fix for the problem, I've just switched to CMake object libraries, which is the recommended solution that avoids having to fix the cyclic dependency in the code. Back when we first built this part of the CMake build system, object libraries required a version of CMake we could not assume was available, but that was so long ago that this is no longer an issue.