### PR TITLE
packaging/rpm: Enable FFmpeg support on Fedora 36+ and RHEL 9+

### DIFF
--- a/packaging/rpm/freerdp-nightly.spec
+++ b/packaging/rpm/freerdp-nightly.spec
@@ -86,6 +86,10 @@ BuildRequires: libjpeg-turbo-devel
 BuildRequires: libwayland-client-devel
 %endif
 
+%if 0%{?fedora} >= 36 || 0%{?rhel} >= 9
+BuildRequires: ffmpeg-free-devel
+%endif
+
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description
@@ -116,7 +120,7 @@ cp %{_topdir}/SOURCES/source_version freerdp-nightly-%{version}/.source_version
         -DWITH_CUPS=ON \
         -DWITH_PCSC=ON \
         -DWITH_JPEG=ON \
-%if %{defined suse_version}
+%if 0%{?fedora} >= 36 || 0%{?rhel} >= 9 || 0%{?suse_version}
         -DWITH_FFMPEG=ON \
         -DWITH_DSP_FFMPEG=ON \
 %endif


### PR DESCRIPTION
Since Fedora Linux 36, an FFmpeg implementation is provided in the base distribution as "ffmpeg-free". This implementation is sufficient for building FreeRDP with FFmpeg support.

This implementation is also available in Fedora Extra Packages for Enterprise Linux (EPEL) for Red Hat Enterprise Linux 9 and derivatives.

Thus, enable FFmpeg support when building for those distributions.

(cherry picked from commit d044a1e073ae0345fb43f5a36b7c2189d20ffb6a)