### PR TITLE
[core,gateway] copy data for credssp

### DIFF
--- a/libfreerdp/core/gateway/rpc_bind.c
+++ b/libfreerdp/core/gateway/rpc_bind.c
@@ -345,8 +345,11 @@ BOOL rpc_recv_bind_ack_pdu(rdpRpc* rpc, wStream* s)
 	auth_data = Stream_Pointer(s);
 	Stream_SetPosition(s, end);
 
-	buffer.pvBuffer = auth_data;
 	buffer.cbBuffer = header.common.auth_length;
+	buffer.pvBuffer = malloc(buffer.cbBuffer);
+	if (!buffer.pvBuffer)
+		goto fail;
+	memcpy(buffer.pvBuffer, auth_data, buffer.cbBuffer);
 	credssp_auth_take_input_buffer(rpc->auth, &buffer);
 
 	if (credssp_auth_authenticate(rpc->auth) < 0)


### PR DESCRIPTION
the authentication data needs to be copied for use in credssp fixes #8811
