### PR TITLE
[codec] fix tile usage in progressive

### DIFF
--- a/libfreerdp/codec/progressive.h
+++ b/libfreerdp/codec/progressive.h
@@ -190,7 +190,7 @@ typedef struct
 	UINT32 gridWidth;
 	UINT32 gridHeight;
 	UINT32 gridSize;
-	RFX_PROGRESSIVE_TILE* tiles;
+	RFX_PROGRESSIVE_TILE** tiles;
 	size_t tilesSize;
 	UINT32 frameId;
 	UINT32 numUpdatedTiles;


### PR DESCRIPTION
This is a fix for #8816. 

When PROGRESSIVE_SURFACE_CONTEXT.tiles were reallocated, we were ending up with wrong tiles in PROGRESSIVE_BLOCK_REGION.tiles when the memory block was moved.
