### PR TITLE
fix: keyboard focus error when minimize window by click taskbar icon

### DIFF
--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -792,8 +792,9 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 		case WM_ACTIVATE:
 		{
 			int activate = (int)(short)LOWORD(wParam);
+			BOOL minimized_flag = (BOOL)HIWORD(wParam);
 
-			if (activate != WA_INACTIVE)
+			if (activate != WA_INACTIVE && minimized_flag)
 			{
 				if (alt_ctrl_down())
 					g_flipping_in = TRUE;


### PR DESCRIPTION
[windows client]When click the taskbar icon to minimize the window，then keyboard focus still in wfreerdp.exe. So use wParam‘s 
 high word to judge  whether the window is minimized. If window is minimized, then set `g_focus_hWnd = NULL`.
 