### PR TITLE
[winpr,shell] log when a known path is NULL

### DIFF
--- a/winpr/include/winpr/path.h
+++ b/winpr/include/winpr/path.h
@@ -305,6 +305,7 @@ extern "C"
 {
 #endif
 
+	WINPR_API const char* GetKnownPathIdString(int id);
 	WINPR_API char* GetKnownPath(int id);
 	WINPR_API char* GetKnownSubPath(int id, const char* path);
 	WINPR_API char* GetEnvironmentPath(char* name);

--- a/winpr/libwinpr/path/path.c
+++ b/winpr/libwinpr/path/path.c
@@ -1057,3 +1057,24 @@ PCWSTR PathGetSharedLibraryExtensionW(unsigned long dwFlags)
 
 	return NULL;
 }
+
+const char* GetKnownPathIdString(int id)
+{
+	switch (id)
+	{
+		case KNOWN_PATH_HOME:
+			return "KNOWN_PATH_HOME";
+		case KNOWN_PATH_TEMP:
+			return "KNOWN_PATH_TEMP";
+		case KNOWN_PATH_XDG_DATA_HOME:
+			return "KNOWN_PATH_XDG_DATA_HOME";
+		case KNOWN_PATH_XDG_CONFIG_HOME:
+			return "KNOWN_PATH_XDG_CONFIG_HOME";
+		case KNOWN_PATH_XDG_CACHE_HOME:
+			return "KNOWN_PATH_XDG_CACHE_HOME";
+		case KNOWN_PATH_XDG_RUNTIME_DIR:
+			return "KNOWN_PATH_XDG_RUNTIME_DIR";
+		default:
+			return "KNOWN_PATH_UNKNOWN_ID";
+	}
+}

--- a/winpr/libwinpr/path/shell.c
+++ b/winpr/libwinpr/path/shell.c
@@ -32,6 +32,10 @@
 #include <winpr/environment.h>
 
 #include <winpr/path.h>
+#include <winpr/wlog.h>
+
+#include "../log.h"
+#define TAG WINPR_TAG("path.shell")
 
 #if defined(__IOS__)
 #include "shell_ios.h"
@@ -357,6 +361,8 @@ char* GetKnownPath(int id)
 			break;
 	}
 
+	if (!path)
+		WLog_WARN(TAG, "Path %s is %p", GetKnownPathIdString(id), path);
 	return path;
 }
 


### PR DESCRIPTION
* Add GetKnownPathIdString to get a string representation of the known path ID requested
* Added a log message if a requested path is NULL