### PR TITLE
[cli, gateway] replace gateway type delimiter from "," to ":"

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2396,10 +2396,10 @@ static BOOL parse_gateway_type_option(rdpSettings* settings, const char* value)
 	}
 	else
 	{
-		char* c = strchr(value, ',');
+		char* c = strchr(value, ':');
 		while (c)
 		{
-			char* next = strchr(c + 1, ',');
+			char* next = strchr(c + 1, ':');
 			if (next)
 				*next = '\0';
 			*c++ = '\0';
@@ -2430,6 +2430,8 @@ static BOOL parse_gateway_type_option(rdpSettings* settings, const char* value)
 			    !freerdp_settings_set_bool(settings, FreeRDP_GatewayHttpTransport, TRUE))
 				return FALSE;
 		}
+		else
+			return FALSE;
 	}
 	return TRUE;
 }

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -169,7 +169,7 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	{ "gateway", COMMAND_LINE_VALUE_REQUIRED,
 	  "g:<gateway>[:<port>],u:<user>,d:<domain>,p:<password>,usage-method:["
 	  "direct|detect],access-token:<"
-	  "token>,type:[rpc|http[,no-websockets][,extauth-sspi-ntlm]|auto[,no-websockets][,extauth-"
+	  "token>,type:[rpc|http[:no-websockets][:extauth-sspi-ntlm]|auto[:no-websockets][:extauth-"
 	  "sspi-ntlm]],",
 	  NULL, NULL, -1, "gw", "Gateway Hostname" },
 #if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)


### PR DESCRIPTION
the new gateway parameter delimits its sub-parameters with , so it is not possible to use this character for sub-sub parameters

example: /gateway:type:http,no-websockets,g:gateway

with the patch this would change to

/gateway:type:http:no-websockets,g:gateway

