### PR TITLE
Few fixes for the clipboard handling in xfreerdp3

### DIFF
--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -2030,6 +2030,26 @@ xf_cliprdr_server_format_data_response(CliprdrClientContext* context,
 	return CHANNEL_RC_OK;
 }
 
+static BOOL xf_cliprdr_is_valid_unix_filename(LPCWSTR filename)
+{
+	LPCWSTR c;
+
+	if (!filename)
+		return FALSE;
+
+	if (filename[0] == L'\0')
+		return FALSE;
+
+	/* Reserved characters */
+	for (c = filename; *c; ++c)
+	{
+		if (*c == L'/')
+			return FALSE;
+	}
+
+	return TRUE;
+}
+
 xfClipboard* xf_clipboard_new(xfContext* xfc, BOOL relieveFilenameRestriction)
 {
 	int n = 0;
@@ -2205,6 +2225,13 @@ xfClipboard* xf_clipboard_new(xfContext* xfc, BOOL relieveFilenameRestriction)
 	clipboard->targets[1] = XInternAtom(xfc->display, "TARGETS", FALSE);
 	clipboard->numTargets = 2;
 	clipboard->incr_atom = XInternAtom(xfc->display, "INCR", FALSE);
+
+	if (relieveFilenameRestriction)
+	{
+		WLog_DBG(TAG, "Relieving CLIPRDR filename restriction");
+		ClipboardGetDelegate(clipboard->system)->IsFileNameComponentValid =
+		    xf_cliprdr_is_valid_unix_filename;
+	}
 
 	return clipboard;
 

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -102,6 +102,7 @@ struct xf_clipboard
 	int requestedFormatId;
 
 	BYTE* data;
+	UINT32 data_format;
 	BYTE* data_raw;
 	BOOL data_raw_format;
 
@@ -1260,10 +1261,7 @@ static BOOL xf_cliprdr_process_selection_request(xfClipboard* clipboard,
 				}
 			}
 
-			/* We can compare format names by pointer value here as they are both
-			 * taken from the same clipboard->serverFormats array */
-			matchingFormat = format && (formatId == format->formatId);
-
+			matchingFormat = formatId == clipboard->data_format;
 			if (matchingFormat && (clipboard->data != 0) && !rawTransfer)
 			{
 				UINT32 DstSize = 0;
@@ -1996,6 +1994,7 @@ xf_cliprdr_server_format_data_response(CliprdrClientContext* context,
 
 	clipboard->data = pDstData;
 	clipboard->data_length = DstSize;
+	clipboard->data_format = dstFormatId;
 	/* We have to copy the original data again, as pSrcData is now owned
 	 * by clipboard->system. Memory allocation failure is not fatal here
 	 * as this is only a cached value. */

--- a/client/common/client_cliprdr_file.c
+++ b/client/common/client_cliprdr_file.c
@@ -2287,7 +2287,7 @@ BOOL cliprdr_file_context_clear(CliprdrFileContext* file)
 {
 	WINPR_ASSERT(file);
 
-	WLog_Print(file->log, WLOG_DEBUG, "clear file clipbaord...");
+	WLog_Print(file->log, WLOG_DEBUG, "clear file clipboard...");
 
 	HashTable_Foreach(file->local_streams, local_stream_discard, file);
 	HashTable_Foreach(file->remote_streams, remote_stream_discard, file);


### PR DESCRIPTION
See the individual commit messages for details.

The changes allow again to copy-paste files, where the filenames contain characters, that are not allowed in MS Windows RDS. As before, this behaviour is only active, when *not* connecting to MS Windows RDS.

Copying lone files on the server and pasting them on the client side works now again. For large folders, the current behaviour is still broken as before (Did not have the time to look into that issue too, so I created https://github.com/FreeRDP/FreeRDP/issues/8846 for this).

Tested against g-r-d compiled against FreeRDP 3.0.