### PR TITLE
Replace __FUNCTION__ with __func__

### DIFF
--- a/winpr/include/winpr/assert.h
+++ b/winpr/include/winpr/assert.h
@@ -35,7 +35,7 @@
 		{                                                                                     \
 			wLog* _log_cached_ptr = WLog_Get("com.freerdp.winpr.assert");                     \
 			WLog_Print(_log_cached_ptr, WLOG_FATAL, "%s [%s:%s:%" PRIuz "]", #cond, __FILE__, \
-			           __FUNCTION__, (size_t)__LINE__);                                       \
+			           __func__, (size_t)__LINE__);                                           \
 			winpr_log_backtrace_ex(_log_cached_ptr, WLOG_FATAL, 20);                          \
 			abort();                                                                          \
 		}                                                                                     \

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -58,7 +58,7 @@ extern "C"
 
 #define Stream_CheckAndLogRequiredCapacityOfSize(tag, s, nmemb, size)                         \
 	Stream_CheckAndLogRequiredCapacityEx(tag, WLOG_WARN, s, nmemb, size, "%s(%s:%" PRIuz ")", \
-	                                     __FUNCTION__, __FILE__, (size_t)__LINE__)
+	                                     __func__, __FILE__, (size_t)__LINE__)
 #define Stream_CheckAndLogRequiredCapacity(tag, s, len) \
 	Stream_CheckAndLogRequiredCapacityOfSize((tag), (s), (len), 1)
 
@@ -71,7 +71,7 @@ extern "C"
 
 #define Stream_CheckAndLogRequiredCapacityOfSizeWLog(log, s, nmemb, size)                         \
 	Stream_CheckAndLogRequiredCapacityWLogEx(log, WLOG_WARN, s, nmemb, size, "%s(%s:%" PRIuz ")", \
-	                                         __FUNCTION__, __FILE__, (size_t)__LINE__)
+	                                         __func__, __FILE__, (size_t)__LINE__)
 
 #define Stream_CheckAndLogRequiredCapacityWLog(log, s, len) \
 	Stream_CheckAndLogRequiredCapacityOfSizeWLog((log), (s), (len), 1)
@@ -90,7 +90,7 @@ extern "C"
 
 #define Stream_CheckAndLogRequiredLengthOfSize(tag, s, nmemb, size)                         \
 	Stream_CheckAndLogRequiredLengthEx(tag, WLOG_WARN, s, nmemb, size, "%s(%s:%" PRIuz ")", \
-	                                   __FUNCTION__, __FILE__, (size_t)__LINE__)
+	                                   __func__, __FILE__, (size_t)__LINE__)
 #define Stream_CheckAndLogRequiredLength(tag, s, len) \
 	Stream_CheckAndLogRequiredLengthOfSize(tag, s, len, 1)
 
@@ -103,7 +103,7 @@ extern "C"
 
 #define Stream_CheckAndLogRequiredLengthOfSizeWLog(log, s, nmemb, size)                         \
 	Stream_CheckAndLogRequiredLengthWLogEx(log, WLOG_WARN, s, nmemb, size, "%s(%s:%" PRIuz ")", \
-	                                       __FUNCTION__, __FILE__, (size_t)__LINE__)
+	                                       __func__, __FILE__, (size_t)__LINE__)
 #define Stream_CheckAndLogRequiredLengthWLog(log, s, len) \
 	Stream_CheckAndLogRequiredLengthOfSizeWLog(log, s, len, 1)
 
@@ -498,7 +498,7 @@ extern "C"
 		memset(_s->buffer, 0, _s->capacity);
 	}
 
-#define Stream_SafeSeek(s, size) Stream_SafeSeekEx(s, size, __FILE__, __LINE__, __FUNCTION__)
+#define Stream_SafeSeek(s, size) Stream_SafeSeekEx(s, size, __FILE__, __LINE__, __func__)
 	WINPR_API BOOL Stream_SafeSeekEx(wStream* s, size_t size, const char* file, size_t line,
 	                                 const char* fkt);
 

--- a/winpr/include/winpr/synch.h
+++ b/winpr/include/winpr/synch.h
@@ -109,7 +109,7 @@ extern "C"
 	WINPR_API BOOL ResetEvent(HANDLE hEvent);
 
 #if defined(WITH_DEBUG_EVENTS)
-#define DumpEventHandles() DumpEventHandles_(__FUNCTION__, __FILE__, __LINE__)
+#define DumpEventHandles() DumpEventHandles_(__func__, __FILE__, __LINE__)
 	WINPR_API void DumpEventHandles_(const char* fkt, const char* file, size_t line);
 #endif
 #ifdef UNICODE

--- a/winpr/include/winpr/wlog.h
+++ b/winpr/include/winpr/wlog.h
@@ -78,7 +78,7 @@ extern "C"
 
 		size_t LineNumber;   /* __LINE__ */
 		LPCSTR FileName;     /* __FILE__ */
-		LPCSTR FunctionName; /* __FUNCTION__ */
+		LPCSTR FunctionName; /* __func__ */
 
 		/* Data Message */
 
@@ -121,7 +121,7 @@ extern "C"
 		if (WLog_IsLevelActive(_log, _log_level))                                      \
 		{                                                                              \
 			WLog_PrintMessage(_log, WLOG_MESSAGE_TEXT, _log_level, __LINE__, __FILE__, \
-			                  __FUNCTION__, __VA_ARGS__);                              \
+			                  __func__, __VA_ARGS__);                                  \
 		}                                                                              \
 	} while (0)
 
@@ -140,7 +140,7 @@ extern "C"
 		if (WLog_IsLevelActive(_log, _log_level))                                        \
 		{                                                                                \
 			WLog_PrintMessageVA(_log, WLOG_MESSAGE_TEXT, _log_level, __LINE__, __FILE__, \
-			                    __FUNCTION__, _args);                                    \
+			                    __func__, _args);                                        \
 		}                                                                                \
 	} while (0)
 
@@ -150,7 +150,7 @@ extern "C"
 		if (WLog_IsLevelActive(_log, _log_level))                                      \
 		{                                                                              \
 			WLog_PrintMessage(_log, WLOG_MESSAGE_DATA, _log_level, __LINE__, __FILE__, \
-			                  __FUNCTION__, __VA_ARGS__);                              \
+			                  __func__, __VA_ARGS__);                                  \
 		}                                                                              \
 	} while (0)
 
@@ -160,7 +160,7 @@ extern "C"
 		if (WLog_IsLevelActive(_log, _log_level))                                      \
 		{                                                                              \
 			WLog_PrintMessage(_log, WLOG_MESSAGE_DATA, _log_level, __LINE__, __FILE__, \
-			                  __FUNCTION__, __VA_ARGS__);                              \
+			                  __func__, __VA_ARGS__);                                  \
 		}                                                                              \
 	} while (0)
 
@@ -170,7 +170,7 @@ extern "C"
 		if (WLog_IsLevelActive(_log, _log_level))                                        \
 		{                                                                                \
 			WLog_PrintMessage(_log, WLOG_MESSAGE_PACKET, _log_level, __LINE__, __FILE__, \
-			                  __FUNCTION__, __VA_ARGS__);                                \
+			                  __func__, __VA_ARGS__);                                    \
 		}                                                                                \
 	} while (0)
 

--- a/winpr/libwinpr/crt/test/TestFormatSpecifiers.c
+++ b/winpr/libwinpr/crt/test/TestFormatSpecifiers.c
@@ -21,7 +21,7 @@ int TestFormatSpecifiers(int argc, char* argv[])
 
 		if (strcmp(fmt, chk))
 		{
-			fprintf(stderr, "%s failed size_t test: got [%s] instead of [%s]\n", __FUNCTION__, fmt,
+			fprintf(stderr, "%s failed size_t test: got [%s] instead of [%s]\n", __func__, fmt,
 			        chk);
 			errors++;
 		}
@@ -37,7 +37,7 @@ int TestFormatSpecifiers(int argc, char* argv[])
 
 		if (strcmp(fmt, chk))
 		{
-			fprintf(stderr, "%s failed INT8 test: got [%s] instead of [%s]\n", __FUNCTION__, fmt,
+			fprintf(stderr, "%s failed INT8 test: got [%s] instead of [%s]\n", __func__, fmt,
 			        chk);
 			errors++;
 		}
@@ -53,7 +53,7 @@ int TestFormatSpecifiers(int argc, char* argv[])
 
 		if (strcmp(fmt, chk))
 		{
-			fprintf(stderr, "%s failed UINT8 test: got [%s] instead of [%s]\n", __FUNCTION__, fmt,
+			fprintf(stderr, "%s failed UINT8 test: got [%s] instead of [%s]\n", __func__, fmt,
 			        chk);
 			errors++;
 		}
@@ -69,7 +69,7 @@ int TestFormatSpecifiers(int argc, char* argv[])
 
 		if (strcmp(fmt, chk))
 		{
-			fprintf(stderr, "%s failed INT16 test: got [%s] instead of [%s]\n", __FUNCTION__, fmt,
+			fprintf(stderr, "%s failed INT16 test: got [%s] instead of [%s]\n", __func__, fmt,
 			        chk);
 			errors++;
 		}
@@ -86,7 +86,7 @@ int TestFormatSpecifiers(int argc, char* argv[])
 
 		if (strcmp(fmt, chk))
 		{
-			fprintf(stderr, "%s failed UINT16 test: got [%s] instead of [%s]\n", __FUNCTION__, fmt,
+			fprintf(stderr, "%s failed UINT16 test: got [%s] instead of [%s]\n", __func__, fmt,
 			        chk);
 			errors++;
 		}
@@ -102,7 +102,7 @@ int TestFormatSpecifiers(int argc, char* argv[])
 
 		if (strcmp(fmt, chk))
 		{
-			fprintf(stderr, "%s failed INT32 test: got [%s] instead of [%s]\n", __FUNCTION__, fmt,
+			fprintf(stderr, "%s failed INT32 test: got [%s] instead of [%s]\n", __func__, fmt,
 			        chk);
 			errors++;
 		}
@@ -119,7 +119,7 @@ int TestFormatSpecifiers(int argc, char* argv[])
 
 		if (strcmp(fmt, chk))
 		{
-			fprintf(stderr, "%s failed UINT16 test: got [%s] instead of [%s]\n", __FUNCTION__, fmt,
+			fprintf(stderr, "%s failed UINT16 test: got [%s] instead of [%s]\n", __func__, fmt,
 			        chk);
 			errors++;
 		}
@@ -135,7 +135,7 @@ int TestFormatSpecifiers(int argc, char* argv[])
 
 		if (strcmp(fmt, chk))
 		{
-			fprintf(stderr, "%s failed INT64 test: got [%s] instead of [%s]\n", __FUNCTION__, fmt,
+			fprintf(stderr, "%s failed INT64 test: got [%s] instead of [%s]\n", __func__, fmt,
 			        chk);
 			errors++;
 		}
@@ -153,7 +153,7 @@ int TestFormatSpecifiers(int argc, char* argv[])
 
 		if (strcmp(fmt, chk))
 		{
-			fprintf(stderr, "%s failed UINT64 test: got [%s] instead of [%s]\n", __FUNCTION__, fmt,
+			fprintf(stderr, "%s failed UINT64 test: got [%s] instead of [%s]\n", __func__, fmt,
 			        chk);
 			errors++;
 		}
@@ -161,7 +161,7 @@ int TestFormatSpecifiers(int argc, char* argv[])
 
 	if (errors)
 	{
-		fprintf(stderr, "%s produced %u errors\n", __FUNCTION__, errors);
+		fprintf(stderr, "%s produced %u errors\n", __func__, errors);
 		return -1;
 	}
 

--- a/winpr/libwinpr/crt/test/TestUnicodeConversion.c
+++ b/winpr/libwinpr/crt/test/TestUnicodeConversion.c
@@ -71,7 +71,7 @@ static BOOL check_short_buffer(const char* prefix, int rc, size_t buffersize,
 }
 
 #define compare_utf16(what, buffersize, rc, inputlen, test) \
-	compare_utf16_int((what), (buffersize), (rc), (inputlen), (test), __FUNCTION__, __LINE__)
+	compare_utf16_int((what), (buffersize), (rc), (inputlen), (test), __func__, __LINE__)
 static BOOL compare_utf16_int(const WCHAR* what, size_t buffersize, SSIZE_T rc, SSIZE_T inputlen,
                               const testcase_t* test, const char* fkt, size_t line)
 {
@@ -121,7 +121,7 @@ static BOOL compare_utf16_int(const WCHAR* what, size_t buffersize, SSIZE_T rc, 
 }
 
 #define compare_utf8(what, buffersize, rc, inputlen, test) \
-	compare_utf8_int((what), (buffersize), (rc), (inputlen), (test), __FUNCTION__, __LINE__)
+	compare_utf8_int((what), (buffersize), (rc), (inputlen), (test), __func__, __LINE__)
 static BOOL compare_utf8_int(const char* what, size_t buffersize, SSIZE_T rc, SSIZE_T inputlen,
                              const testcase_t* test, const char* fkt, size_t line)
 {
@@ -180,7 +180,7 @@ static BOOL test_convert_to_utf16(const testcase_t* test)
 	if ((rc2 < 0) || ((size_t)rc2 != wlen))
 	{
 		char prefix[8192] = { 0 };
-		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, -1, test, __FUNCTION__, __LINE__);
+		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, -1, test, __func__, __LINE__);
 		fprintf(stderr, "%s ConvertUtf8ToWChar(%s, NULL, 0) expected %" PRIuz ", got %" PRIdz "\n",
 		        prefix, test->utf8, wlen, rc2);
 		return FALSE;
@@ -207,7 +207,7 @@ static BOOL test_convert_to_utf16_n(const testcase_t* test)
 	if ((rc2 < 0) || ((size_t)rc2 != wlen))
 	{
 		char prefix[8192] = { 0 };
-		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, test->utf8len, test, __FUNCTION__,
+		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, test->utf8len, test, __func__,
 		              __LINE__);
 		fprintf(stderr,
 		        "%s ConvertUtf8NToWChar(%s, %" PRIuz ", NULL, 0) expected %" PRIuz ", got %" PRIdz
@@ -244,7 +244,7 @@ static BOOL test_convert_to_utf8(const testcase_t* test)
 	if ((rc2 < 0) || ((size_t)rc2 != wlen))
 	{
 		char prefix[8192] = { 0 };
-		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, -1, test, __FUNCTION__, __LINE__);
+		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, -1, test, __func__, __LINE__);
 		fprintf(stderr, "%s ConvertWCharToUtf8(%s, NULL, 0) expected %" PRIuz ", got %" PRIdz "\n",
 		        prefix, test->utf8, wlen, rc2);
 		return FALSE;
@@ -272,7 +272,7 @@ static BOOL test_convert_to_utf8_n(const testcase_t* test)
 	if ((rc2 < 0) || ((size_t)rc2 != wlen))
 	{
 		char prefix[8192] = { 0 };
-		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, test->utf16len, test, __FUNCTION__,
+		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, test->utf16len, test, __func__,
 		              __LINE__);
 		fprintf(stderr,
 		        "%s ConvertWCharNToUtf8(%s, %" PRIuz ", NULL, 0) expected %" PRIuz ", got %" PRIdz
@@ -322,7 +322,7 @@ static BOOL test_conversion(const testcase_t* testcases, size_t count)
 #if defined(WITH_WINPR_DEPRECATED)
 
 #define compare_win_utf16(what, buffersize, rc, inputlen, test) \
-	compare_win_utf16_int((what), (buffersize), (rc), (inputlen), (test), __FUNCTION__, __LINE__)
+	compare_win_utf16_int((what), (buffersize), (rc), (inputlen), (test), __func__, __LINE__)
 static BOOL compare_win_utf16_int(const WCHAR* what, size_t buffersize, int rc, int inputlen,
                                   const testcase_t* test, const char* fkt, size_t line)
 {
@@ -392,7 +392,7 @@ static BOOL compare_win_utf16_int(const WCHAR* what, size_t buffersize, int rc, 
 }
 
 #define compare_win_utf8(what, buffersize, rc, inputlen, test) \
-	compare_win_utf8_int((what), (buffersize), (rc), (inputlen), (test), __FUNCTION__, __LINE__)
+	compare_win_utf8_int((what), (buffersize), (rc), (inputlen), (test), __func__, __LINE__)
 static BOOL compare_win_utf8_int(const char* what, size_t buffersize, SSIZE_T rc, SSIZE_T inputlen,
                                  const testcase_t* test, const char* fkt, size_t line)
 {
@@ -470,7 +470,7 @@ static BOOL test_win_convert_to_utf16(const testcase_t* test)
 	if (rc2 != wlen + 1)
 	{
 		char prefix[8192] = { 0 };
-		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, -1, test, __FUNCTION__, __LINE__);
+		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, -1, test, __func__, __LINE__);
 		fprintf(stderr,
 		        "%s MultiByteToWideChar(CP_UTF8, 0, %s, [-1], NULL, 0) expected %" PRIuz
 		        ", got %d\n",
@@ -503,7 +503,7 @@ static BOOL test_win_convert_to_utf16_n(const testcase_t* test)
 	if (rc2 != wlen)
 	{
 		char prefix[8192] = { 0 };
-		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, test->utf8len, test, __FUNCTION__,
+		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, test->utf8len, test, __func__,
 		              __LINE__);
 		fprintf(stderr,
 		        "%s MultiByteToWideChar(CP_UTF8, 0, %s, %" PRIuz ", NULL, 0) expected %" PRIuz
@@ -544,7 +544,7 @@ static BOOL test_win_convert_to_utf8(const testcase_t* test)
 	if (rc2 != wlen)
 	{
 		char prefix[8192] = { 0 };
-		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, -1, test, __FUNCTION__, __LINE__);
+		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, -1, test, __func__, __LINE__);
 		fprintf(stderr,
 		        "%s WideCharToMultiByte(CP_UTF8, 0, %s, -1, NULL, 0, NULL, NULL) expected %" PRIuz
 		        ", got %d\n",
@@ -579,7 +579,7 @@ static BOOL test_win_convert_to_utf8_n(const testcase_t* test)
 	if (rc2 != wlen)
 	{
 		char prefix[8192] = { 0 };
-		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, test->utf16len, test, __FUNCTION__,
+		create_prefix(prefix, ARRAYSIZE(prefix), 0, rc2, test->utf16len, test, __func__,
 		              __LINE__);
 		fprintf(stderr,
 		        "%s WideCharToMultiByte(CP_UTF8, 0, %s, %" PRIuz

--- a/winpr/libwinpr/crypto/test/TestCryptoCipher.c
+++ b/winpr/libwinpr/crypto/test/TestCryptoCipher.c
@@ -22,7 +22,7 @@ static BOOL test_crypto_cipher_aes_128_cbc(void)
 
 	if (!(ctx = winpr_Cipher_New(WINPR_CIPHER_AES_128_CBC, WINPR_ENCRYPT, key, iv)))
 	{
-		fprintf(stderr, "%s: winpr_Cipher_New (encrypt) failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Cipher_New (encrypt) failed\n", __func__);
 		return FALSE;
 	}
 
@@ -35,14 +35,14 @@ static BOOL test_crypto_cipher_aes_128_cbc(void)
 
 	if (!winpr_Cipher_Update(ctx, ibuf, ilen, obuf, &olen))
 	{
-		fprintf(stderr, "%s: winpr_Cipher_New (encrypt) failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Cipher_New (encrypt) failed\n", __func__);
 		goto out;
 	}
 	xlen += olen;
 
 	if (!winpr_Cipher_Final(ctx, obuf + xlen, &olen))
 	{
-		fprintf(stderr, "%s: winpr_Cipher_Final (encrypt) failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Cipher_Final (encrypt) failed\n", __func__);
 		goto out;
 	}
 	xlen += olen;
@@ -50,7 +50,7 @@ static BOOL test_crypto_cipher_aes_128_cbc(void)
 	if (xlen != ilen)
 	{
 		fprintf(stderr, "%s: error, xlen (%" PRIuz ") != ilen (%" PRIuz ") (encrypt)\n",
-		        __FUNCTION__, xlen, ilen);
+		        __func__, xlen, ilen);
 		goto out;
 	}
 
@@ -60,7 +60,7 @@ static BOOL test_crypto_cipher_aes_128_cbc(void)
 
 	if (!(ctx = winpr_Cipher_New(WINPR_CIPHER_AES_128_CBC, WINPR_DECRYPT, key, iv)))
 	{
-		fprintf(stderr, "%s: winpr_Cipher_New (decrypt) failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Cipher_New (decrypt) failed\n", __func__);
 		return FALSE;
 	}
 
@@ -74,14 +74,14 @@ static BOOL test_crypto_cipher_aes_128_cbc(void)
 
 	if (!winpr_Cipher_Update(ctx, ibuf, ilen, obuf, &olen))
 	{
-		fprintf(stderr, "%s: winpr_Cipher_New (decrypt) failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Cipher_New (decrypt) failed\n", __func__);
 		goto out;
 	}
 	xlen += olen;
 
 	if (!winpr_Cipher_Final(ctx, obuf + xlen, &olen))
 	{
-		fprintf(stderr, "%s: winpr_Cipher_Final (decrypt) failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Cipher_Final (decrypt) failed\n", __func__);
 		goto out;
 	}
 	xlen += olen;
@@ -89,13 +89,13 @@ static BOOL test_crypto_cipher_aes_128_cbc(void)
 	if (xlen != ilen)
 	{
 		fprintf(stderr, "%s: error, xlen (%" PRIuz ") != ilen (%" PRIuz ") (decrypt)\n",
-		        __FUNCTION__, xlen, ilen);
+		        __func__, xlen, ilen);
 		goto out;
 	}
 
 	if (strcmp((const char*)obuf, plaintext))
 	{
-		fprintf(stderr, "%s: error, decrypted data does not match plaintext\n", __FUNCTION__);
+		fprintf(stderr, "%s: error, decrypted data does not match plaintext\n", __func__);
 		goto out;
 	}
 
@@ -121,21 +121,21 @@ static BOOL test_crypto_cipher_rc4(void)
 
 	if (!(text = (BYTE*)calloc(1, len)))
 	{
-		fprintf(stderr, "%s: failed to allocate text buffer (len=%" PRIuz ")\n", __FUNCTION__, len);
+		fprintf(stderr, "%s: failed to allocate text buffer (len=%" PRIuz ")\n", __func__, len);
 		goto out;
 	}
 
 	if ((ctx = winpr_RC4_New(TEST_RC4_KEY,
 	                         strnlen((const char*)TEST_RC4_KEY, sizeof(TEST_RC4_KEY)))) == NULL)
 	{
-		fprintf(stderr, "%s: winpr_RC4_New failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_RC4_New failed\n", __func__);
 		goto out;
 	}
 	rc = winpr_RC4_Update(ctx, len, (const BYTE*)TEST_RC4_PLAINTEXT, text);
 	winpr_RC4_Free(ctx);
 	if (!rc)
 	{
-		fprintf(stderr, "%s: winpr_RC4_Update failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_RC4_Update failed\n", __func__);
 		goto out;
 	}
 
@@ -147,7 +147,7 @@ static BOOL test_crypto_cipher_rc4(void)
 		actual = winpr_BinToHexString(text, len, FALSE);
 		expected = winpr_BinToHexString(TEST_RC4_CIPHERTEXT, len, FALSE);
 
-		fprintf(stderr, "%s: unexpected RC4 ciphertext: Actual: %s Expected: %s\n", __FUNCTION__,
+		fprintf(stderr, "%s: unexpected RC4 ciphertext: Actual: %s Expected: %s\n", __func__,
 		        actual, expected);
 
 		free(actual);

--- a/winpr/libwinpr/crypto/test/TestCryptoHash.c
+++ b/winpr/libwinpr/crypto/test/TestCryptoHash.c
@@ -16,23 +16,23 @@ static BOOL test_crypto_hash_md5(void)
 
 	if (!(ctx = winpr_Digest_New()))
 	{
-		fprintf(stderr, "%s: winpr_Digest_New failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Digest_New failed\n", __func__);
 		return FALSE;
 	}
 	if (!winpr_Digest_Init(ctx, WINPR_MD_MD5))
 	{
-		fprintf(stderr, "%s: winpr_Digest_Init failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Digest_Init failed\n", __func__);
 		goto out;
 	}
 	if (!winpr_Digest_Update(ctx, (const BYTE*)TEST_MD5_DATA,
 	                         strnlen(TEST_MD5_DATA, sizeof(TEST_MD5_DATA))))
 	{
-		fprintf(stderr, "%s: winpr_Digest_Update failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Digest_Update failed\n", __func__);
 		goto out;
 	}
 	if (!winpr_Digest_Final(ctx, hash, sizeof(hash)))
 	{
-		fprintf(stderr, "%s: winpr_Digest_Final failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Digest_Final failed\n", __func__);
 		goto out;
 	}
 	if (memcmp(hash, TEST_MD5_HASH, WINPR_MD5_DIGEST_LENGTH) != 0)
@@ -69,23 +69,23 @@ static BOOL test_crypto_hash_md4(void)
 
 	if (!(ctx = winpr_Digest_New()))
 	{
-		fprintf(stderr, "%s: winpr_Digest_New failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Digest_New failed\n", __func__);
 		return FALSE;
 	}
 	if (!winpr_Digest_Init(ctx, WINPR_MD_MD4))
 	{
-		fprintf(stderr, "%s: winpr_Digest_Init failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Digest_Init failed\n", __func__);
 		goto out;
 	}
 	if (!winpr_Digest_Update(ctx, (const BYTE*)TEST_MD4_DATA,
 	                         strnlen(TEST_MD4_DATA, sizeof(TEST_MD4_DATA))))
 	{
-		fprintf(stderr, "%s: winpr_Digest_Update failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Digest_Update failed\n", __func__);
 		goto out;
 	}
 	if (!winpr_Digest_Final(ctx, hash, sizeof(hash)))
 	{
-		fprintf(stderr, "%s: winpr_Digest_Final failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Digest_Final failed\n", __func__);
 		goto out;
 	}
 	if (memcmp(hash, TEST_MD4_HASH, WINPR_MD4_DIGEST_LENGTH) != 0)
@@ -122,23 +122,23 @@ static BOOL test_crypto_hash_sha1(void)
 
 	if (!(ctx = winpr_Digest_New()))
 	{
-		fprintf(stderr, "%s: winpr_Digest_New failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Digest_New failed\n", __func__);
 		return FALSE;
 	}
 	if (!winpr_Digest_Init(ctx, WINPR_MD_SHA1))
 	{
-		fprintf(stderr, "%s: winpr_Digest_Init failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Digest_Init failed\n", __func__);
 		goto out;
 	}
 	if (!winpr_Digest_Update(ctx, (const BYTE*)TEST_SHA1_DATA,
 	                         strnlen(TEST_SHA1_DATA, sizeof(TEST_SHA1_DATA))))
 	{
-		fprintf(stderr, "%s: winpr_Digest_Update failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Digest_Update failed\n", __func__);
 		goto out;
 	}
 	if (!winpr_Digest_Final(ctx, hash, sizeof(hash)))
 	{
-		fprintf(stderr, "%s: winpr_Digest_Final failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_Digest_Final failed\n", __func__);
 		goto out;
 	}
 
@@ -178,30 +178,30 @@ static BOOL test_crypto_hash_hmac_md5(void)
 
 	if (!(ctx = winpr_HMAC_New()))
 	{
-		fprintf(stderr, "%s: winpr_HMAC_New failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_HMAC_New failed\n", __func__);
 		return FALSE;
 	}
 
 	if (!winpr_HMAC_Init(ctx, WINPR_MD_MD5, TEST_HMAC_MD5_KEY, WINPR_MD5_DIGEST_LENGTH))
 	{
-		fprintf(stderr, "%s: winpr_HMAC_Init failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_HMAC_Init failed\n", __func__);
 		goto out;
 	}
 	if (!winpr_HMAC_Update(ctx, (const BYTE*)TEST_HMAC_MD5_DATA,
 	                       strnlen(TEST_HMAC_MD5_DATA, sizeof(TEST_HMAC_MD5_DATA))))
 	{
-		fprintf(stderr, "%s: winpr_HMAC_Update failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_HMAC_Update failed\n", __func__);
 		goto out;
 	}
 	if (!winpr_HMAC_Update(ctx, (const BYTE*)TEST_HMAC_MD5_DATA,
 	                       strnlen(TEST_HMAC_MD5_DATA, sizeof(TEST_HMAC_MD5_DATA))))
 	{
-		fprintf(stderr, "%s: winpr_HMAC_Update failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_HMAC_Update failed\n", __func__);
 		goto out;
 	}
 	if (!winpr_HMAC_Final(ctx, hash, sizeof(hash)))
 	{
-		fprintf(stderr, "%s: winpr_HMAC_Final failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_HMAC_Final failed\n", __func__);
 		goto out;
 	}
 
@@ -241,30 +241,30 @@ static BOOL test_crypto_hash_hmac_sha1(void)
 
 	if (!(ctx = winpr_HMAC_New()))
 	{
-		fprintf(stderr, "%s: winpr_HMAC_New failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_HMAC_New failed\n", __func__);
 		return FALSE;
 	}
 
 	if (!winpr_HMAC_Init(ctx, WINPR_MD_SHA1, TEST_HMAC_SHA1_KEY, WINPR_SHA1_DIGEST_LENGTH))
 	{
-		fprintf(stderr, "%s: winpr_HMAC_Init failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_HMAC_Init failed\n", __func__);
 		goto out;
 	}
 	if (!winpr_HMAC_Update(ctx, (const BYTE*)TEST_HMAC_SHA1_DATA,
 	                       strnlen(TEST_HMAC_SHA1_DATA, sizeof(TEST_HMAC_SHA1_DATA))))
 	{
-		fprintf(stderr, "%s: winpr_HMAC_Update failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_HMAC_Update failed\n", __func__);
 		goto out;
 	}
 	if (!winpr_HMAC_Update(ctx, (const BYTE*)TEST_HMAC_SHA1_DATA,
 	                       strnlen(TEST_HMAC_SHA1_DATA, sizeof(TEST_HMAC_SHA1_DATA))))
 	{
-		fprintf(stderr, "%s: winpr_HMAC_Update failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_HMAC_Update failed\n", __func__);
 		goto out;
 	}
 	if (!winpr_HMAC_Final(ctx, hash, sizeof(hash)))
 	{
-		fprintf(stderr, "%s: winpr_HMAC_Final failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: winpr_HMAC_Final failed\n", __func__);
 		goto out;
 	}
 

--- a/winpr/libwinpr/library/test/TestLibraryGetModuleFileName.c
+++ b/winpr/libwinpr/library/test/TestLibraryGetModuleFileName.c
@@ -18,14 +18,14 @@ int TestLibraryGetModuleFileName(int argc, char* argv[])
 	if (len != 2)
 	{
 		printf("%s: GetModuleFileNameA unexpectedly returned %" PRIu32 " instead of 2\n",
-		       __FUNCTION__, len);
+		       __func__, len);
 		return -1;
 	}
 	if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
 	{
 		printf("%s: Invalid last error value: 0x%08" PRIX32
 		       ". Expected 0x%08X (ERROR_INSUFFICIENT_BUFFER)\n",
-		       __FUNCTION__, GetLastError(), ERROR_INSUFFICIENT_BUFFER);
+		       __func__, GetLastError(), ERROR_INSUFFICIENT_BUFFER);
 		return -1;
 	}
 
@@ -34,19 +34,19 @@ int TestLibraryGetModuleFileName(int argc, char* argv[])
 	len = GetModuleFileNameA(NULL, ModuleFileName, sizeof(ModuleFileName));
 	if (len == 0)
 	{
-		printf("%s: GetModuleFileNameA failed with error 0x%08" PRIX32 "\n", __FUNCTION__,
+		printf("%s: GetModuleFileNameA failed with error 0x%08" PRIX32 "\n", __func__,
 		       GetLastError());
 		return -1;
 	}
 	if (len == sizeof(ModuleFileName))
 	{
-		printf("%s: GetModuleFileNameA unexpectedly returned nSize\n", __FUNCTION__);
+		printf("%s: GetModuleFileNameA unexpectedly returned nSize\n", __func__);
 		return -1;
 	}
 	if (GetLastError() != ERROR_SUCCESS)
 	{
 		printf("%s: Invalid last error value: 0x%08" PRIX32 ". Expected 0x%08X (ERROR_SUCCESS)\n",
-		       __FUNCTION__, GetLastError(), ERROR_SUCCESS);
+		       __func__, GetLastError(), ERROR_SUCCESS);
 		return -1;
 	}
 

--- a/winpr/libwinpr/library/test/TestLibraryGetProcAddress.c
+++ b/winpr/libwinpr/library/test/TestLibraryGetProcAddress.c
@@ -21,7 +21,7 @@ int TestLibraryGetProcAddress(int argc, char* argv[])
 	WINPR_UNUSED(argv);
 	if (!GetModuleFileNameA(NULL, LibraryPath, PATHCCH_MAX_CCH))
 	{
-		printf("%s: GetModuleFilenameA failed: 0x%08" PRIX32 "\n", __FUNCTION__, GetLastError());
+		printf("%s: GetModuleFilenameA failed: 0x%08" PRIX32 "\n", __func__, GetLastError());
 		return -1;
 	}
 
@@ -29,7 +29,7 @@ int TestLibraryGetProcAddress(int argc, char* argv[])
 
 	if (!(p = strrchr(LibraryPath, PathGetSeparatorA(PATH_STYLE_NATIVE))))
 	{
-		printf("%s: Error identifying module directory path\n", __FUNCTION__);
+		printf("%s: Error identifying module directory path\n", __func__);
 		return -1;
 	}
 
@@ -37,23 +37,23 @@ int TestLibraryGetProcAddress(int argc, char* argv[])
 	NativePathCchAppendA(LibraryPath, PATHCCH_MAX_CCH, "TestLibraryA");
 	SharedLibraryExtension = PathGetSharedLibraryExtensionA(PATH_SHARED_LIB_EXT_WITH_DOT);
 	NativePathCchAddExtensionA(LibraryPath, PATHCCH_MAX_CCH, SharedLibraryExtension);
-	printf("%s: Loading Library: '%s'\n", __FUNCTION__, LibraryPath);
+	printf("%s: Loading Library: '%s'\n", __func__, LibraryPath);
 
 	if (!(library = LoadLibraryA(LibraryPath)))
 	{
-		printf("%s: LoadLibraryA failure: 0x%08" PRIX32 "\n", __FUNCTION__, GetLastError());
+		printf("%s: LoadLibraryA failure: 0x%08" PRIX32 "\n", __func__, GetLastError());
 		return -1;
 	}
 
 	if (!(pFunctionA = (TEST_AB_FN)GetProcAddress(library, "FunctionA")))
 	{
-		printf("%s: GetProcAddress failure (FunctionA)\n", __FUNCTION__);
+		printf("%s: GetProcAddress failure (FunctionA)\n", __func__);
 		return -1;
 	}
 
 	if (!(pFunctionB = (TEST_AB_FN)GetProcAddress(library, "FunctionB")))
 	{
-		printf("%s: GetProcAddress failure (FunctionB)\n", __FUNCTION__);
+		printf("%s: GetProcAddress failure (FunctionB)\n", __func__);
 		return -1;
 	}
 
@@ -63,7 +63,7 @@ int TestLibraryGetProcAddress(int argc, char* argv[])
 
 	if (c != (a * b))
 	{
-		printf("%s: pFunctionA call failed\n", __FUNCTION__);
+		printf("%s: pFunctionA call failed\n", __func__);
 		return -1;
 	}
 
@@ -73,13 +73,13 @@ int TestLibraryGetProcAddress(int argc, char* argv[])
 
 	if (c != (a / b))
 	{
-		printf("%s: pFunctionB call failed\n", __FUNCTION__);
+		printf("%s: pFunctionB call failed\n", __func__);
 		return -1;
 	}
 
 	if (!FreeLibrary(library))
 	{
-		printf("%s: FreeLibrary failure: 0x%08" PRIX32 "\n", __FUNCTION__, GetLastError());
+		printf("%s: FreeLibrary failure: 0x%08" PRIX32 "\n", __func__, GetLastError());
 		return -1;
 	}
 

--- a/winpr/libwinpr/library/test/TestLibraryLoadLibrary.c
+++ b/winpr/libwinpr/library/test/TestLibraryLoadLibrary.c
@@ -16,7 +16,7 @@ int TestLibraryLoadLibrary(int argc, char* argv[])
 	WINPR_UNUSED(argv);
 	if (!GetModuleFileNameA(NULL, LibraryPath, PATHCCH_MAX_CCH))
 	{
-		printf("%s: GetModuleFilenameA failed: 0x%08" PRIX32 "\n", __FUNCTION__, GetLastError());
+		printf("%s: GetModuleFilenameA failed: 0x%08" PRIX32 "\n", __func__, GetLastError());
 		return -1;
 	}
 
@@ -24,7 +24,7 @@ int TestLibraryLoadLibrary(int argc, char* argv[])
 
 	if (!(p = strrchr(LibraryPath, PathGetSeparatorA(PATH_STYLE_NATIVE))))
 	{
-		printf("%s: Error identifying module directory path\n", __FUNCTION__);
+		printf("%s: Error identifying module directory path\n", __func__);
 		return -1;
 	}
 	*p = 0;
@@ -33,17 +33,17 @@ int TestLibraryLoadLibrary(int argc, char* argv[])
 	SharedLibraryExtension = PathGetSharedLibraryExtensionA(PATH_SHARED_LIB_EXT_WITH_DOT);
 	NativePathCchAddExtensionA(LibraryPath, PATHCCH_MAX_CCH, SharedLibraryExtension);
 
-	printf("%s: Loading Library: '%s'\n", __FUNCTION__, LibraryPath);
+	printf("%s: Loading Library: '%s'\n", __func__, LibraryPath);
 
 	if (!(library = LoadLibraryA(LibraryPath)))
 	{
-		printf("%s: LoadLibraryA failure: 0x%08" PRIX32 "\n", __FUNCTION__, GetLastError());
+		printf("%s: LoadLibraryA failure: 0x%08" PRIX32 "\n", __func__, GetLastError());
 		return -1;
 	}
 
 	if (!FreeLibrary(library))
 	{
-		printf("%s: FreeLibrary failure: 0x%08" PRIX32 "\n", __FUNCTION__, GetLastError());
+		printf("%s: FreeLibrary failure: 0x%08" PRIX32 "\n", __func__, GetLastError());
 		return -1;
 	}
 

--- a/winpr/libwinpr/path/test/TestPathAllocCanonicalize.c
+++ b/winpr/libwinpr/path/test/TestPathAllocCanonicalize.c
@@ -7,6 +7,6 @@
 
 int TestPathAllocCanonicalize(int argc, char* argv[])
 {
-	printf("Warning: %s is not implemented!\n", __FUNCTION__);
+	printf("Warning: %s is not implemented!\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathCchAppendEx.c
+++ b/winpr/libwinpr/path/test/TestPathCchAppendEx.c
@@ -7,6 +7,6 @@
 
 int TestPathCchAppendEx(int argc, char* argv[])
 {
-	printf("Warning: %s is not implemented!\n", __FUNCTION__);
+	printf("Warning: %s is not implemented!\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathCchCanonicalize.c
+++ b/winpr/libwinpr/path/test/TestPathCchCanonicalize.c
@@ -7,6 +7,6 @@
 
 int TestPathCchCanonicalize(int argc, char* argv[])
 {
-	printf("Warning: %s is not implemented!\n", __FUNCTION__);
+	printf("Warning: %s is not implemented!\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathCchCanonicalizeEx.c
+++ b/winpr/libwinpr/path/test/TestPathCchCanonicalizeEx.c
@@ -7,6 +7,6 @@
 
 int TestPathCchCanonicalizeEx(int argc, char* argv[])
 {
-	printf("Warning: %s is not implemented!\n", __FUNCTION__);
+	printf("Warning: %s is not implemented!\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathCchCombine.c
+++ b/winpr/libwinpr/path/test/TestPathCchCombine.c
@@ -7,6 +7,6 @@
 
 int TestPathCchCombine(int argc, char* argv[])
 {
-	printf("Warning: %s is not implemented!\n", __FUNCTION__);
+	printf("Warning: %s is not implemented!\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathCchCombineEx.c
+++ b/winpr/libwinpr/path/test/TestPathCchCombineEx.c
@@ -7,6 +7,6 @@
 
 int TestPathCchCombineEx(int argc, char* argv[])
 {
-	printf("Warning: %s is not implemented!\n", __FUNCTION__);
+	printf("Warning: %s is not implemented!\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathCchIsRoot.c
+++ b/winpr/libwinpr/path/test/TestPathCchIsRoot.c
@@ -7,6 +7,6 @@
 
 int TestPathCchIsRoot(int argc, char* argv[])
 {
-	printf("Warning: %s is not implemented!\n", __FUNCTION__);
+	printf("Warning: %s is not implemented!\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathCchRemoveBackslash.c
+++ b/winpr/libwinpr/path/test/TestPathCchRemoveBackslash.c
@@ -7,6 +7,6 @@
 
 int TestPathCchRemoveBackslash(int argc, char* argv[])
 {
-	printf("Warning: %s is not implemented!\n", __FUNCTION__);
+	printf("Warning: %s is not implemented!\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathCchRemoveBackslashEx.c
+++ b/winpr/libwinpr/path/test/TestPathCchRemoveBackslashEx.c
@@ -7,6 +7,6 @@
 
 int TestPathCchRemoveBackslashEx(int argc, char* argv[])
 {
-	printf("Warning: %s is not implemented!\n", __FUNCTION__);
+	printf("Warning: %s is not implemented!\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathCchRemoveExtension.c
+++ b/winpr/libwinpr/path/test/TestPathCchRemoveExtension.c
@@ -7,6 +7,6 @@
 
 int TestPathCchRemoveExtension(int argc, char* argv[])
 {
-	printf("Warning: %s is not implemented!\n", __FUNCTION__);
+	printf("Warning: %s is not implemented!\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathCchRemoveFileSpec.c
+++ b/winpr/libwinpr/path/test/TestPathCchRemoveFileSpec.c
@@ -7,6 +7,6 @@
 
 int TestPathCchRemoveFileSpec(int argc, char* argv[])
 {
-	printf("Warning: %s is not implemented!\n", __FUNCTION__);
+	printf("Warning: %s is not implemented!\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathCchRenameExtension.c
+++ b/winpr/libwinpr/path/test/TestPathCchRenameExtension.c
@@ -7,6 +7,6 @@
 
 int TestPathCchRenameExtension(int argc, char* argv[])
 {
-	printf("Warning: %s is not implemented!\n", __FUNCTION__);
+	printf("Warning: %s is not implemented!\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathCchSkipRoot.c
+++ b/winpr/libwinpr/path/test/TestPathCchSkipRoot.c
@@ -7,6 +7,6 @@
 
 int TestPathCchSkipRoot(int argc, char* argv[])
 {
-	printf("Warning: %s is not implemented!\n", __FUNCTION__);
+	printf("Warning: %s is not implemented!\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathCchStripToRoot.c
+++ b/winpr/libwinpr/path/test/TestPathCchStripToRoot.c
@@ -7,6 +7,6 @@
 
 int TestPathCchStripToRoot(int argc, char* argv[])
 {
-	printf("Warning: %s is not implemented!\n", __FUNCTION__);
+	printf("Warning: %s is not implemented!\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/path/test/TestPathMakePath.c
+++ b/winpr/libwinpr/path/test/TestPathMakePath.c
@@ -79,6 +79,6 @@ int TestPathMakePath(int argc, char* argv[])
 	}
 
 	free(path);
-	printf("%s success!\n", __FUNCTION__);
+	printf("%s success!\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/pipe/test/TestPipeCreateNamedPipe.c
+++ b/winpr/libwinpr/pipe/test/TestPipeCreateNamedPipe.c
@@ -39,19 +39,19 @@ static DWORD WINAPI named_pipe_client_thread(LPVOID arg)
 
 	if (hNamedPipe == INVALID_HANDLE_VALUE)
 	{
-		printf("%s: Named Pipe CreateFile failure: INVALID_HANDLE_VALUE\n", __FUNCTION__);
+		printf("%s: Named Pipe CreateFile failure: INVALID_HANDLE_VALUE\n", __func__);
 		goto out;
 	}
 
 	if (!(lpReadBuffer = (BYTE*)malloc(PIPE_BUFFER_SIZE)))
 	{
-		printf("%s: Error allocating read buffer\n", __FUNCTION__);
+		printf("%s: Error allocating read buffer\n", __func__);
 		goto out;
 	}
 
 	if (!(lpWriteBuffer = (BYTE*)malloc(PIPE_BUFFER_SIZE)))
 	{
-		printf("%s: Error allocating write buffer\n", __FUNCTION__);
+		printf("%s: Error allocating write buffer\n", __func__);
 		goto out;
 	}
 
@@ -63,7 +63,7 @@ static DWORD WINAPI named_pipe_client_thread(LPVOID arg)
 	               NULL) ||
 	    lpNumberOfBytesWritten != nNumberOfBytesToWrite)
 	{
-		printf("%s: Client NamedPipe WriteFile failure\n", __FUNCTION__);
+		printf("%s: Client NamedPipe WriteFile failure\n", __func__);
 		goto out;
 	}
 
@@ -74,7 +74,7 @@ static DWORD WINAPI named_pipe_client_thread(LPVOID arg)
 	if (!ReadFile(hNamedPipe, lpReadBuffer, nNumberOfBytesToRead, &lpNumberOfBytesRead, NULL) ||
 	    lpNumberOfBytesRead != nNumberOfBytesToRead)
 	{
-		printf("%s: Client NamedPipe ReadFile failure\n", __FUNCTION__);
+		printf("%s: Client NamedPipe ReadFile failure\n", __func__);
 		goto out;
 	}
 
@@ -110,13 +110,13 @@ static DWORD WINAPI named_pipe_server_thread(LPVOID arg)
 
 	if (!hNamedPipe)
 	{
-		printf("%s: CreateNamedPipe failure: NULL handle\n", __FUNCTION__);
+		printf("%s: CreateNamedPipe failure: NULL handle\n", __func__);
 		goto out;
 	}
 
 	if (hNamedPipe == INVALID_HANDLE_VALUE)
 	{
-		printf("%s: CreateNamedPipe failure: INVALID_HANDLE_VALUE\n", __FUNCTION__);
+		printf("%s: CreateNamedPipe failure: INVALID_HANDLE_VALUE\n", __func__);
 		goto out;
 	}
 
@@ -135,19 +135,19 @@ static DWORD WINAPI named_pipe_server_thread(LPVOID arg)
 
 	if (!fConnected)
 	{
-		printf("%s: ConnectNamedPipe failure\n", __FUNCTION__);
+		printf("%s: ConnectNamedPipe failure\n", __func__);
 		goto out;
 	}
 
 	if (!(lpReadBuffer = (BYTE*)calloc(1, PIPE_BUFFER_SIZE)))
 	{
-		printf("%s: Error allocating read buffer\n", __FUNCTION__);
+		printf("%s: Error allocating read buffer\n", __func__);
 		goto out;
 	}
 
 	if (!(lpWriteBuffer = (BYTE*)malloc(PIPE_BUFFER_SIZE)))
 	{
-		printf("%s: Error allocating write buffer\n", __FUNCTION__);
+		printf("%s: Error allocating write buffer\n", __func__);
 		goto out;
 	}
 
@@ -157,7 +157,7 @@ static DWORD WINAPI named_pipe_server_thread(LPVOID arg)
 	if (!ReadFile(hNamedPipe, lpReadBuffer, nNumberOfBytesToRead, &lpNumberOfBytesRead, NULL) ||
 	    lpNumberOfBytesRead != nNumberOfBytesToRead)
 	{
-		printf("%s: Server NamedPipe ReadFile failure\n", __FUNCTION__);
+		printf("%s: Server NamedPipe ReadFile failure\n", __func__);
 		goto out;
 	}
 
@@ -171,7 +171,7 @@ static DWORD WINAPI named_pipe_server_thread(LPVOID arg)
 	               NULL) ||
 	    lpNumberOfBytesWritten != nNumberOfBytesToWrite)
 	{
-		printf("%s: Server NamedPipe WriteFile failure\n", __FUNCTION__);
+		printf("%s: Server NamedPipe WriteFile failure\n", __func__);
 		goto out;
 	}
 
@@ -208,7 +208,7 @@ static DWORD WINAPI named_pipe_single_thread(LPVOID arg)
 		                                   PIPE_UNLIMITED_INSTANCES, PIPE_BUFFER_SIZE,
 		                                   PIPE_BUFFER_SIZE, 0, NULL)))
 		{
-			printf("%s: CreateNamedPipe #%d failed\n", __FUNCTION__, i);
+			printf("%s: CreateNamedPipe #%d failed\n", __func__, i);
 			goto out;
 		}
 	}
@@ -221,28 +221,28 @@ static DWORD WINAPI named_pipe_single_thread(LPVOID arg)
 
 		if (strcmp(lpszPipeNameSt, p->name))
 		{
-			printf("%s: Pipe name mismatch for pipe #%d ([%s] instead of [%s])\n", __FUNCTION__, i,
+			printf("%s: Pipe name mismatch for pipe #%d ([%s] instead of [%s])\n", __func__, i,
 			       p->name, lpszPipeNameSt);
 			goto out;
 		}
 
 		if (p->clientfd != -1)
 		{
-			printf("%s: Unexpected client fd value for pipe #%d (%d instead of -1)\n", __FUNCTION__,
+			printf("%s: Unexpected client fd value for pipe #%d (%d instead of -1)\n", __func__,
 			       i, p->clientfd);
 			goto out;
 		}
 
 		if (p->serverfd < 1)
 		{
-			printf("%s: Unexpected server fd value for pipe #%d (%d is not > 0)\n", __FUNCTION__, i,
+			printf("%s: Unexpected server fd value for pipe #%d (%d is not > 0)\n", __func__, i,
 			       p->serverfd);
 			goto out;
 		}
 
 		if (p->ServerMode == FALSE)
 		{
-			printf("%s: Unexpected ServerMode value for pipe #%d (0 instead of 1)\n", __FUNCTION__,
+			printf("%s: Unexpected ServerMode value for pipe #%d (0 instead of 1)\n", __func__,
 			       i);
 			goto out;
 		}
@@ -256,7 +256,7 @@ static DWORD WINAPI named_pipe_single_thread(LPVOID arg)
 		if ((clients[i] = CreateFile(lpszPipeNameSt, GENERIC_READ | GENERIC_WRITE, 0, NULL,
 		                             OPEN_EXISTING, 0, NULL)) == INVALID_HANDLE_VALUE)
 		{
-			printf("%s: CreateFile #%d failed\n", __FUNCTION__, i);
+			printf("%s: CreateFile #%d failed\n", __func__, i);
 			goto out;
 		}
 
@@ -273,7 +273,7 @@ static DWORD WINAPI named_pipe_single_thread(LPVOID arg)
 
 		if (!fConnected)
 		{
-			printf("%s: ConnectNamedPipe #%d failed. (%" PRIu32 ")\n", __FUNCTION__, i,
+			printf("%s: ConnectNamedPipe #%d failed. (%" PRIu32 ")\n", __func__, i,
 			       GetLastError());
 			goto out;
 		}
@@ -287,14 +287,14 @@ static DWORD WINAPI named_pipe_single_thread(LPVOID arg)
 
 		if (p->clientfd < 1)
 		{
-			printf("%s: Unexpected client fd value for pipe #%d (%d is not > 0)\n", __FUNCTION__, i,
+			printf("%s: Unexpected client fd value for pipe #%d (%d is not > 0)\n", __func__, i,
 			       p->clientfd);
 			goto out;
 		}
 
 		if (p->ServerMode)
 		{
-			printf("%s: Unexpected ServerMode value for pipe #%d (1 instead of 0)\n", __FUNCTION__,
+			printf("%s: Unexpected ServerMode value for pipe #%d (1 instead of 0)\n", __func__,
 			       i);
 			goto out;
 		}
@@ -311,19 +311,19 @@ static DWORD WINAPI named_pipe_single_thread(LPVOID arg)
 			if (!WriteFile(clients[i], sndbuf, sizeof(sndbuf), &dwWritten, NULL) ||
 			    dwWritten != sizeof(sndbuf))
 			{
-				printf("%s: Error writing to client end of pipe #%d\n", __FUNCTION__, i);
+				printf("%s: Error writing to client end of pipe #%d\n", __func__, i);
 				goto out;
 			}
 
 			if (!ReadFile(servers[i], rcvbuf, dwWritten, &dwRead, NULL) || dwRead != dwWritten)
 			{
-				printf("%s: Error reading on server end of pipe #%d\n", __FUNCTION__, i);
+				printf("%s: Error reading on server end of pipe #%d\n", __func__, i);
 				goto out;
 			}
 
 			if (memcmp(sndbuf, rcvbuf, sizeof(sndbuf)))
 			{
-				printf("%s: Error data read on server end of pipe #%d is corrupted\n", __FUNCTION__,
+				printf("%s: Error data read on server end of pipe #%d is corrupted\n", __func__,
 				       i);
 				goto out;
 			}
@@ -339,19 +339,19 @@ static DWORD WINAPI named_pipe_single_thread(LPVOID arg)
 			if (!WriteFile(servers[i], sndbuf, sizeof(sndbuf), &dwWritten, NULL) ||
 			    dwWritten != sizeof(sndbuf))
 			{
-				printf("%s: Error writing to server end of pipe #%d\n", __FUNCTION__, i);
+				printf("%s: Error writing to server end of pipe #%d\n", __func__, i);
 				goto out;
 			}
 
 			if (!ReadFile(clients[i], rcvbuf, dwWritten, &dwRead, NULL) || dwRead != dwWritten)
 			{
-				printf("%s: Error reading on client end of pipe #%d\n", __FUNCTION__, i);
+				printf("%s: Error reading on client end of pipe #%d\n", __func__, i);
 				goto out;
 			}
 
 			if (memcmp(sndbuf, rcvbuf, sizeof(sndbuf)))
 			{
-				printf("%s: Error data read on client end of pipe #%d is corrupted\n", __FUNCTION__,
+				printf("%s: Error data read on client end of pipe #%d is corrupted\n", __func__,
 				       i);
 				goto out;
 			}
@@ -372,7 +372,7 @@ static DWORD WINAPI named_pipe_single_thread(LPVOID arg)
 		{
 			printf("%s: Error ReadFile on client should have failed after DisconnectNamedPipe on "
 			       "server\n",
-			       __FUNCTION__);
+			       __func__);
 			goto out;
 		}
 
@@ -381,7 +381,7 @@ static DWORD WINAPI named_pipe_single_thread(LPVOID arg)
 			printf(
 			    "%s: Error WriteFile on client end should have failed after DisconnectNamedPipe on "
 			    "server\n",
-			    __FUNCTION__);
+			    __func__);
 			goto out;
 		}
 	}
@@ -403,7 +403,7 @@ static DWORD WINAPI named_pipe_single_thread(LPVOID arg)
 		{
 			printf(
 			    "%s: Error ReadFile on client end should have failed after CloseHandle on server\n",
-			    __FUNCTION__);
+			    __func__);
 			goto out;
 		}
 
@@ -411,7 +411,7 @@ static DWORD WINAPI named_pipe_single_thread(LPVOID arg)
 		{
 			printf("%s: Error WriteFile on client end should have failed after CloseHandle on "
 			       "server\n",
-			       __FUNCTION__);
+			       __func__);
 			goto out;
 		}
 	}
@@ -432,7 +432,7 @@ static DWORD WINAPI named_pipe_single_thread(LPVOID arg)
 		{
 			printf(
 			    "%s: Error ReadFile on server end should have failed after CloseHandle on client\n",
-			    __FUNCTION__);
+			    __func__);
 			goto out;
 		}
 
@@ -440,7 +440,7 @@ static DWORD WINAPI named_pipe_single_thread(LPVOID arg)
 		{
 			printf("%s: Error WriteFile on server end should have failed after CloseHandle on "
 			       "client\n",
-			       __FUNCTION__);
+			       __func__);
 			goto out;
 		}
 	}

--- a/winpr/libwinpr/pipe/test/TestPipeCreateNamedPipeOverlapped.c
+++ b/winpr/libwinpr/pipe/test/TestPipeCreateNamedPipeOverlapped.c
@@ -358,12 +358,12 @@ int TestPipeCreateNamedPipeOverlapped(int argc, char* argv[])
 
 	if (WAIT_OBJECT_0 != WaitForSingleObject(ClientThread, INFINITE))
 	{
-		printf("%s: Failed to wait for client thread: %" PRIu32 "\n", __FUNCTION__, GetLastError());
+		printf("%s: Failed to wait for client thread: %" PRIu32 "\n", __func__, GetLastError());
 		goto out;
 	}
 	if (WAIT_OBJECT_0 != WaitForSingleObject(ServerThread, INFINITE))
 	{
-		printf("%s: Failed to wait for server thread: %" PRIu32 "\n", __FUNCTION__, GetLastError());
+		printf("%s: Failed to wait for server thread: %" PRIu32 "\n", __func__, GetLastError());
 		goto out;
 	}
 
@@ -383,12 +383,12 @@ out:
 	if (result == 0)
 	{
 		printf("%s: Error, this test is currently expected not to succeed on this platform.\n",
-		       __FUNCTION__);
+		       __func__);
 		result = -1;
 	}
 	else
 	{
-		printf("%s: This test is currently expected to fail on this platform.\n", __FUNCTION__);
+		printf("%s: This test is currently expected to fail on this platform.\n", __func__);
 		result = 0;
 	}
 #endif

--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
@@ -38,7 +38,7 @@
 
 #define NTLM_CheckAndLogRequiredCapacity(tag, s, nmemb, what)                                    \
 	Stream_CheckAndLogRequiredCapacityEx(tag, WLOG_WARN, s, nmemb, 1, "%s(%s:%" PRIuz ") " what, \
-	                                     __FUNCTION__, __FILE__, (size_t)__LINE__)
+	                                     __func__, __FILE__, (size_t)__LINE__)
 
 static char NTLM_CLIENT_SIGN_MAGIC[] = "session key to client-to-server signing key magic constant";
 static char NTLM_SERVER_SIGN_MAGIC[] = "session key to server-to-client signing key magic constant";
@@ -111,7 +111,7 @@ BOOL ntlm_write_version_info(wStream* s, const NTLM_VERSION_INFO* versionInfo)
 
 	if (!Stream_CheckAndLogRequiredCapacityEx(
 	        TAG, WLOG_WARN, s, 5ull + sizeof(versionInfo->Reserved), 1ull,
-	        "%s(%s:%" PRIuz ") NTLM_VERSION_INFO", __FUNCTION__, __FILE__, (size_t)__LINE__))
+	        "%s(%s:%" PRIuz ") NTLM_VERSION_INFO", __func__, __FILE__, (size_t)__LINE__))
 		return FALSE;
 
 	Stream_Write_UINT8(s, versionInfo->ProductMajorVersion); /* ProductMajorVersion (1 byte) */

--- a/winpr/libwinpr/sspi/NTLM/ntlm_message.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_message.c
@@ -37,7 +37,7 @@
 
 #define NTLM_CheckAndLogRequiredCapacity(tag, s, nmemb, what)                                    \
 	Stream_CheckAndLogRequiredCapacityEx(tag, WLOG_WARN, s, nmemb, 1, "%s(%s:%" PRIuz ") " what, \
-	                                     __FUNCTION__, __FILE__, (size_t)__LINE__)
+	                                     __func__, __FILE__, (size_t)__LINE__)
 
 static const char NTLM_SIGNATURE[8] = { 'N', 'T', 'L', 'M', 'S', 'S', 'P', '\0' };
 
@@ -436,7 +436,7 @@ static BOOL ntlm_write_negotiate_flags(wStream* s, UINT32 flags, const char* nam
 	WINPR_ASSERT(name);
 
 	if (!Stream_CheckAndLogRequiredCapacityEx(TAG, WLOG_WARN, s, 4ull, 1ull,
-	                                          "%s(%s:%" PRIuz ") %s::NegotiateFlags", __FUNCTION__,
+	                                          "%s(%s:%" PRIuz ") %s::NegotiateFlags", __func__,
 	                                          __FILE__, (size_t)__LINE__, name))
 		return FALSE;
 

--- a/winpr/libwinpr/synch/test/TestSynchBarrier.c
+++ b/winpr/libwinpr/synch/test/TestSynchBarrier.c
@@ -74,17 +74,17 @@ static BOOL TestSynchBarrierWithFlags(DWORD dwFlags, DWORD dwThreads, DWORD dwLo
 	expectedFalseCount = dwLoops * (dwThreads - 1);
 	printf("%s: >> Testing with flags 0x%08" PRIx32 ". Using %" PRIu32
 	       " threads performing %" PRIu32 " loops\n",
-	       __FUNCTION__, dwFlags, dwThreads, dwLoops);
+	       __func__, dwFlags, dwThreads, dwLoops);
 
 	if (!(threads = calloc(dwThreads, sizeof(HANDLE))))
 	{
-		printf("%s: error allocatin thread array memory\n", __FUNCTION__);
+		printf("%s: error allocatin thread array memory\n", __func__);
 		return FALSE;
 	}
 
 	if (!InitializeSynchronizationBarrier(&gBarrier, dwThreads, -1))
 	{
-		printf("%s: InitializeSynchronizationBarrier failed. GetLastError() = 0x%08x", __FUNCTION__,
+		printf("%s: InitializeSynchronizationBarrier failed. GetLastError() = 0x%08x", __func__,
 		       GetLastError());
 		free(threads);
 		DeleteSynchronizationBarrier(&gBarrier);
@@ -93,7 +93,7 @@ static BOOL TestSynchBarrierWithFlags(DWORD dwFlags, DWORD dwThreads, DWORD dwLo
 
 	if (!(gStartEvent = CreateEvent(NULL, TRUE, FALSE, NULL)))
 	{
-		printf("%s: CreateEvent failed with error 0x%08x", __FUNCTION__, GetLastError());
+		printf("%s: CreateEvent failed with error 0x%08x", __func__, GetLastError());
 		free(threads);
 		DeleteSynchronizationBarrier(&gBarrier);
 		return FALSE;
@@ -104,7 +104,7 @@ static BOOL TestSynchBarrierWithFlags(DWORD dwFlags, DWORD dwThreads, DWORD dwLo
 		if (!(threads[i] = CreateThread(NULL, 0, test_synch_barrier_thread, &p, 0, NULL)))
 		{
 			printf("%s: CreateThread failed for thread #%" PRIu32 " with error 0x%08x\n",
-			       __FUNCTION__, i, GetLastError());
+			       __func__, i, GetLastError());
 			InterlockedIncrement(&gErrorCount);
 			break;
 		}
@@ -114,7 +114,7 @@ static BOOL TestSynchBarrierWithFlags(DWORD dwFlags, DWORD dwThreads, DWORD dwLo
 	{
 		if (!SetEvent(gStartEvent))
 		{
-			printf("%s: SetEvent(gStartEvent) failed with error = 0x%08x)\n", __FUNCTION__,
+			printf("%s: SetEvent(gStartEvent) failed with error = 0x%08x)\n", __func__,
 			       GetLastError());
 			InterlockedIncrement(&gErrorCount);
 		}
@@ -125,14 +125,14 @@ static BOOL TestSynchBarrierWithFlags(DWORD dwFlags, DWORD dwThreads, DWORD dwLo
 			{
 				printf("%s: WaitForSingleObject(thread[%" PRIu32 "] unexpectedly returned %" PRIu32
 				       " (error = 0x%08x)\n",
-				       __FUNCTION__, i, dwStatus, GetLastError());
+				       __func__, i, dwStatus, GetLastError());
 				InterlockedIncrement(&gErrorCount);
 			}
 
 			if (!CloseHandle(threads[i]))
 			{
 				printf("%s: CloseHandle(thread[%" PRIu32 "]) failed with error = 0x%08x)\n",
-				       __FUNCTION__, i, GetLastError());
+				       __func__, i, GetLastError());
 				InterlockedIncrement(&gErrorCount);
 			}
 		}
@@ -142,7 +142,7 @@ static BOOL TestSynchBarrierWithFlags(DWORD dwFlags, DWORD dwThreads, DWORD dwLo
 
 	if (!CloseHandle(gStartEvent))
 	{
-		printf("%s: CloseHandle(gStartEvent) failed with error = 0x%08x)\n", __FUNCTION__,
+		printf("%s: CloseHandle(gStartEvent) failed with error = 0x%08x)\n", __func__,
 		       GetLastError());
 		InterlockedIncrement(&gErrorCount);
 	}
@@ -158,17 +158,17 @@ static BOOL TestSynchBarrierWithFlags(DWORD dwFlags, DWORD dwThreads, DWORD dwLo
 	if (p.falseCount != (INT64)expectedFalseCount)
 		InterlockedIncrement(&gErrorCount);
 
-	printf("%s: error count:  %" PRId32 "\n", __FUNCTION__, gErrorCount);
-	printf("%s: thread count: %" PRId32 " (expected %" PRIu32 ")\n", __FUNCTION__, p.threadCount,
+	printf("%s: error count:  %" PRId32 "\n", __func__, gErrorCount);
+	printf("%s: thread count: %" PRId32 " (expected %" PRIu32 ")\n", __func__, p.threadCount,
 	       dwThreads);
-	printf("%s: true count:   %" PRId32 " (expected %" PRIu32 ")\n", __FUNCTION__, p.trueCount,
+	printf("%s: true count:   %" PRId32 " (expected %" PRIu32 ")\n", __func__, p.trueCount,
 	       expectedTrueCount);
-	printf("%s: false count:  %" PRId32 " (expected %" PRIu32 ")\n", __FUNCTION__, p.falseCount,
+	printf("%s: false count:  %" PRId32 " (expected %" PRIu32 ")\n", __func__, p.falseCount,
 	       expectedFalseCount);
 
 	if (gErrorCount > 0)
 	{
-		printf("%s: Error test failed with %" PRId32 " reported errors\n", __FUNCTION__,
+		printf("%s: Error test failed with %" PRId32 " reported errors\n", __func__,
 		       gErrorCount);
 		return FALSE;
 	}
@@ -187,7 +187,7 @@ int TestSynchBarrier(int argc, char* argv[])
 	WINPR_UNUSED(argv);
 
 	GetNativeSystemInfo(&sysinfo);
-	printf("%s: Number of processors: %" PRIu32 "\n", __FUNCTION__, sysinfo.dwNumberOfProcessors);
+	printf("%s: Number of processors: %" PRIu32 "\n", __func__, sysinfo.dwNumberOfProcessors);
 	dwMinThreads = sysinfo.dwNumberOfProcessors;
 	dwMaxThreads = sysinfo.dwNumberOfProcessors * 4;
 
@@ -200,7 +200,7 @@ int TestSynchBarrier(int argc, char* argv[])
 		fprintf(
 		    stderr,
 		    "%s: InitializeSynchronizationBarrier unecpectedly succeeded with lTotalThreads = 0\n",
-		    __FUNCTION__);
+		    __func__);
 		return -1;
 	}
 
@@ -209,7 +209,7 @@ int TestSynchBarrier(int argc, char* argv[])
 		fprintf(
 		    stderr,
 		    "%s: InitializeSynchronizationBarrier unecpectedly succeeded with lTotalThreads = -1\n",
-		    __FUNCTION__);
+		    __func__);
 		return -1;
 	}
 
@@ -218,7 +218,7 @@ int TestSynchBarrier(int argc, char* argv[])
 		fprintf(
 		    stderr,
 		    "%s: InitializeSynchronizationBarrier unecpectedly succeeded with lSpinCount = -2\n",
-		    __FUNCTION__);
+		    __func__);
 		return -1;
 	}
 
@@ -228,7 +228,7 @@ int TestSynchBarrier(int argc, char* argv[])
 	{
 		fprintf(stderr,
 		        "%s: TestSynchBarrierWithFlags(0) unecpectedly succeeded with lTotalThreads = -1\n",
-		        __FUNCTION__);
+		        __func__);
 		return -1;
 	}
 
@@ -238,7 +238,7 @@ int TestSynchBarrier(int argc, char* argv[])
 		fprintf(stderr,
 		        "%s: TestSynchBarrierWithFlags(SYNCHRONIZATION_BARRIER_FLAGS_SPIN_ONLY) "
 		        "unecpectedly succeeded with lTotalThreads = -1\n",
-		        __FUNCTION__);
+		        __func__);
 		return -1;
 	}
 
@@ -248,10 +248,10 @@ int TestSynchBarrier(int argc, char* argv[])
 		fprintf(stderr,
 		        "%s: TestSynchBarrierWithFlags(SYNCHRONIZATION_BARRIER_FLAGS_BLOCK_ONLY) "
 		        "unecpectedly succeeded with lTotalThreads = -1\n",
-		        __FUNCTION__);
+		        __func__);
 		return -1;
 	}
 
-	printf("%s: Test successfully completed\n", __FUNCTION__);
+	printf("%s: Test successfully completed\n", __func__);
 	return 0;
 }

--- a/winpr/libwinpr/synch/test/TestSynchInit.c
+++ b/winpr/libwinpr/synch/test/TestSynchInit.c
@@ -35,7 +35,7 @@ static BOOL CALLBACK TestOnceFunction(PINIT_ONCE once, PVOID param, PVOID* conte
 	{
 		return TRUE;
 	}
-	fprintf(stderr, "%s: error: called again after success\n", __FUNCTION__);
+	fprintf(stderr, "%s: error: called again after success\n", __func__);
 	InterlockedIncrement(pErrors);
 	return FALSE;
 }
@@ -50,7 +50,7 @@ static DWORD WINAPI TestThreadFunction(LPVOID lpParam)
 	InterlockedIncrement(pTestThreadFunctionCalls);
 	if (WaitForSingleObject(hStartEvent, INFINITE) != WAIT_OBJECT_0)
 	{
-		fprintf(stderr, "%s: error: failed to wait for start event\n", __FUNCTION__);
+		fprintf(stderr, "%s: error: failed to wait for start event\n", __func__);
 		InterlockedIncrement(pErrors);
 		return 0;
 	}
@@ -59,7 +59,7 @@ static DWORD WINAPI TestThreadFunction(LPVOID lpParam)
 	calls = InterlockedIncrement(pInitOnceExecuteOnceCalls);
 	if (!ok && calls > TEST_NUM_FAILURES)
 	{
-		fprintf(stderr, "%s: InitOnceExecuteOnce failed unexpectedly\n", __FUNCTION__);
+		fprintf(stderr, "%s: InitOnceExecuteOnce failed unexpectedly\n", __func__);
 		InterlockedIncrement(pErrors);
 	}
 	return 0;

--- a/winpr/libwinpr/synch/test/TestSynchMultipleThreads.c
+++ b/winpr/libwinpr/synch/test/TestSynchMultipleThreads.c
@@ -26,7 +26,7 @@ static int start_threads(DWORD count, HANDLE* threads)
 
 		if (!threads[i])
 		{
-			fprintf(stderr, "%s: CreateThread [%" PRIu32 "] failure\n", __FUNCTION__, i);
+			fprintf(stderr, "%s: CreateThread [%" PRIu32 "] failure\n", __func__, i);
 			return -1;
 		}
 	}
@@ -48,7 +48,7 @@ static int close_threads(DWORD count, HANDLE* threads)
 
 		if (!CloseHandle(threads[i]))
 		{
-			fprintf(stderr, "%s: CloseHandle [%" PRIu32 "] failure\n", __FUNCTION__, i);
+			fprintf(stderr, "%s: CloseHandle [%" PRIu32 "] failure\n", __func__, i);
 			rc = -1;
 		}
 		threads[i] = NULL;
@@ -65,7 +65,7 @@ static BOOL TestWaitForAll(void)
 	/* WaitForAll, timeout */
 	if (start_threads(THREADS, threads))
 	{
-		fprintf(stderr, "%s: start_threads failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: start_threads failed\n", __func__);
 		goto fail;
 	}
 
@@ -73,13 +73,13 @@ static BOOL TestWaitForAll(void)
 	if (ret != WAIT_TIMEOUT)
 	{
 		fprintf(stderr, "%s: WaitForMultipleObjects bWaitAll, timeout 50 failed, ret=%d\n",
-		        __FUNCTION__, ret);
+		        __func__, ret);
 		goto fail;
 	}
 
 	if (WaitForMultipleObjects(THREADS, threads, TRUE, INFINITE) != WAIT_OBJECT_0)
 	{
-		fprintf(stderr, "%s: WaitForMultipleObjects bWaitAll, INFINITE failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: WaitForMultipleObjects bWaitAll, INFINITE failed\n", __func__);
 		goto fail;
 	}
 
@@ -87,7 +87,7 @@ static BOOL TestWaitForAll(void)
 fail:
 	if (close_threads(THREADS, threads))
 	{
-		fprintf(stderr, "%s: close_threads failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: close_threads failed\n", __func__);
 		return FALSE;
 	}
 
@@ -102,20 +102,20 @@ static BOOL TestWaitOne(void)
 	/* WaitForAll, timeout */
 	if (start_threads(THREADS, threads))
 	{
-		fprintf(stderr, "%s: start_threads failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: start_threads failed\n", __func__);
 		goto fail;
 	}
 
 	ret = WaitForMultipleObjects(THREADS, threads, FALSE, INFINITE);
 	if (ret > (WAIT_OBJECT_0 + THREADS))
 	{
-		fprintf(stderr, "%s: WaitForMultipleObjects INFINITE failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: WaitForMultipleObjects INFINITE failed\n", __func__);
 		goto fail;
 	}
 
 	if (WaitForMultipleObjects(THREADS, threads, TRUE, INFINITE) != WAIT_OBJECT_0)
 	{
-		fprintf(stderr, "%s: WaitForMultipleObjects bWaitAll, INFINITE failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: WaitForMultipleObjects bWaitAll, INFINITE failed\n", __func__);
 		goto fail;
 	}
 
@@ -123,7 +123,7 @@ static BOOL TestWaitOne(void)
 fail:
 	if (close_threads(THREADS, threads))
 	{
-		fprintf(stderr, "%s: close_threads failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: close_threads failed\n", __func__);
 		return FALSE;
 	}
 
@@ -138,28 +138,28 @@ static BOOL TestWaitOneTimeout(void)
 	/* WaitForAll, timeout */
 	if (start_threads(THREADS, threads))
 	{
-		fprintf(stderr, "%s: start_threads failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: start_threads failed\n", __func__);
 		goto fail;
 	}
 
 	ret = WaitForMultipleObjects(THREADS, threads, FALSE, 1);
 	if (ret != WAIT_TIMEOUT)
 	{
-		fprintf(stderr, "%s: WaitForMultipleObjects timeout 50 failed, ret=%d\n", __FUNCTION__,
+		fprintf(stderr, "%s: WaitForMultipleObjects timeout 50 failed, ret=%d\n", __func__,
 		        ret);
 		goto fail;
 	}
 
 	if (WaitForMultipleObjects(THREADS, threads, TRUE, INFINITE) != WAIT_OBJECT_0)
 	{
-		fprintf(stderr, "%s: WaitForMultipleObjects bWaitAll, INFINITE failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: WaitForMultipleObjects bWaitAll, INFINITE failed\n", __func__);
 		goto fail;
 	}
 	rc = TRUE;
 fail:
 	if (close_threads(THREADS, threads))
 	{
-		fprintf(stderr, "%s: close_threads failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: close_threads failed\n", __func__);
 		return FALSE;
 	}
 
@@ -174,7 +174,7 @@ static BOOL TestWaitOneTimeoutMultijoin(void)
 	/* WaitForAll, timeout */
 	if (start_threads(THREADS, threads))
 	{
-		fprintf(stderr, "%s: start_threads failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: start_threads failed\n", __func__);
 		goto fail;
 	}
 
@@ -183,7 +183,7 @@ static BOOL TestWaitOneTimeoutMultijoin(void)
 		ret = WaitForMultipleObjects(THREADS, threads, FALSE, 0);
 		if (ret != WAIT_TIMEOUT)
 		{
-			fprintf(stderr, "%s: WaitForMultipleObjects timeout 0 failed, ret=%d\n", __FUNCTION__,
+			fprintf(stderr, "%s: WaitForMultipleObjects timeout 0 failed, ret=%d\n", __func__,
 			        ret);
 			goto fail;
 		}
@@ -191,7 +191,7 @@ static BOOL TestWaitOneTimeoutMultijoin(void)
 
 	if (WaitForMultipleObjects(THREADS, threads, TRUE, INFINITE) != WAIT_OBJECT_0)
 	{
-		fprintf(stderr, "%s: WaitForMultipleObjects bWaitAll, INFINITE failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: WaitForMultipleObjects bWaitAll, INFINITE failed\n", __func__);
 		goto fail;
 	}
 
@@ -199,7 +199,7 @@ static BOOL TestWaitOneTimeoutMultijoin(void)
 fail:
 	if (close_threads(THREADS, threads))
 	{
-		fprintf(stderr, "%s: close_threads failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: close_threads failed\n", __func__);
 		return FALSE;
 	}
 
@@ -213,7 +213,7 @@ static BOOL TestDetach(void)
 	/* WaitForAll, timeout */
 	if (start_threads(THREADS, threads))
 	{
-		fprintf(stderr, "%s: start_threads failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: start_threads failed\n", __func__);
 		goto fail;
 	}
 
@@ -221,7 +221,7 @@ static BOOL TestDetach(void)
 fail:
 	if (close_threads(THREADS, threads))
 	{
-		fprintf(stderr, "%s: close_threads failed\n", __FUNCTION__);
+		fprintf(stderr, "%s: close_threads failed\n", __func__);
 		return FALSE;
 	}
 

--- a/winpr/libwinpr/synch/test/TestSynchMutex.c
+++ b/winpr/libwinpr/synch/test/TestSynchMutex.c
@@ -10,7 +10,7 @@ static BOOL test_mutex_basic(void)
 
 	if (!(mutex = CreateMutex(NULL, FALSE, NULL)))
 	{
-		printf("%s: CreateMutex failed\n", __FUNCTION__);
+		printf("%s: CreateMutex failed\n", __func__);
 		return FALSE;
 	}
 
@@ -18,25 +18,25 @@ static BOOL test_mutex_basic(void)
 
 	if (rc != WAIT_OBJECT_0)
 	{
-		printf("%s: WaitForSingleObject on mutex failed with %" PRIu32 "\n", __FUNCTION__, rc);
+		printf("%s: WaitForSingleObject on mutex failed with %" PRIu32 "\n", __func__, rc);
 		return FALSE;
 	}
 
 	if (!ReleaseMutex(mutex))
 	{
-		printf("%s: ReleaseMutex failed\n", __FUNCTION__);
+		printf("%s: ReleaseMutex failed\n", __func__);
 		return FALSE;
 	}
 
 	if (ReleaseMutex(mutex))
 	{
-		printf("%s: ReleaseMutex unexpectedly succeeded on released mutex\n", __FUNCTION__);
+		printf("%s: ReleaseMutex unexpectedly succeeded on released mutex\n", __func__);
 		return FALSE;
 	}
 
 	if (!CloseHandle(mutex))
 	{
-		printf("%s: CloseHandle on mutex failed\n", __FUNCTION__);
+		printf("%s: CloseHandle on mutex failed\n", __func__);
 		return FALSE;
 	}
 
@@ -50,7 +50,7 @@ static BOOL test_mutex_recursive(void)
 
 	if (!(mutex = CreateMutex(NULL, TRUE, NULL)))
 	{
-		printf("%s: CreateMutex failed\n", __FUNCTION__);
+		printf("%s: CreateMutex failed\n", __func__);
 		return FALSE;
 	}
 
@@ -61,7 +61,7 @@ static BOOL test_mutex_recursive(void)
 		if (rc != WAIT_OBJECT_0)
 		{
 			printf("%s: WaitForSingleObject #%" PRIu32 " on mutex failed with %" PRIu32 "\n",
-			       __FUNCTION__, i, rc);
+			       __func__, i, rc);
 			return FALSE;
 		}
 	}
@@ -70,7 +70,7 @@ static BOOL test_mutex_recursive(void)
 	{
 		if (!ReleaseMutex(mutex))
 		{
-			printf("%s: ReleaseMutex #%" PRIu32 " failed\n", __FUNCTION__, i);
+			printf("%s: ReleaseMutex #%" PRIu32 " failed\n", __func__, i);
 			return FALSE;
 		}
 	}
@@ -78,19 +78,19 @@ static BOOL test_mutex_recursive(void)
 	if (!ReleaseMutex(mutex))
 	{
 		/* Note: The mutex was initially owned ! */
-		printf("%s: Final ReleaseMutex failed\n", __FUNCTION__);
+		printf("%s: Final ReleaseMutex failed\n", __func__);
 		return FALSE;
 	}
 
 	if (ReleaseMutex(mutex))
 	{
-		printf("%s: ReleaseMutex unexpectedly succeeded on released mutex\n", __FUNCTION__);
+		printf("%s: ReleaseMutex unexpectedly succeeded on released mutex\n", __func__);
 		return FALSE;
 	}
 
 	if (!CloseHandle(mutex))
 	{
-		printf("%s: CloseHandle on mutex failed\n", __FUNCTION__);
+		printf("%s: CloseHandle on mutex failed\n", __func__);
 		return FALSE;
 	}
 
@@ -108,7 +108,7 @@ static DWORD WINAPI test_mutex_thread1(LPVOID lpParam)
 
 	if (WaitForSingleObject(hStartEvent, INFINITE) != WAIT_OBJECT_0)
 	{
-		fprintf(stderr, "%s: failed to wait for start event\n", __FUNCTION__);
+		fprintf(stderr, "%s: failed to wait for start event\n", __func__);
 		return 0;
 	}
 
@@ -127,7 +127,7 @@ static DWORD WINAPI test_mutex_thread1(LPVOID lpParam)
 		fprintf(stderr,
 		        "%s: WaitForSingleObject on thread1_mutex1 unexpectedly returned %" PRIu32
 		        " instead of WAIT_TIMEOUT (%u)\n",
-		        __FUNCTION__, rc, WAIT_TIMEOUT);
+		        __func__, rc, WAIT_TIMEOUT);
 		return 0;
 	}
 
@@ -138,13 +138,13 @@ static DWORD WINAPI test_mutex_thread1(LPVOID lpParam)
 		fprintf(stderr,
 		        "%s: WaitForSingleObject on thread1_mutex2 unexpectedly returned %" PRIu32
 		        " instead of WAIT_OBJECT_0\n",
-		        __FUNCTION__, rc);
+		        __func__, rc);
 		return 0;
 	}
 
 	if (!ReleaseMutex(thread1_mutex2))
 	{
-		fprintf(stderr, "%s: ReleaseMutex failed on thread1_mutex2\n", __FUNCTION__);
+		fprintf(stderr, "%s: ReleaseMutex failed on thread1_mutex2\n", __func__);
 		return 0;
 	}
 
@@ -159,19 +159,19 @@ static BOOL test_mutex_threading(void)
 
 	if (!(thread1_mutex1 = CreateMutex(NULL, TRUE, NULL)))
 	{
-		printf("%s: CreateMutex thread1_mutex1 failed\n", __FUNCTION__);
+		printf("%s: CreateMutex thread1_mutex1 failed\n", __func__);
 		goto fail;
 	}
 
 	if (!(thread1_mutex2 = CreateMutex(NULL, FALSE, NULL)))
 	{
-		printf("%s: CreateMutex thread1_mutex2 failed\n", __FUNCTION__);
+		printf("%s: CreateMutex thread1_mutex2 failed\n", __func__);
 		goto fail;
 	}
 
 	if (!(hStartEvent = CreateEvent(NULL, TRUE, FALSE, NULL)))
 	{
-		fprintf(stderr, "%s: error creating start event\n", __FUNCTION__);
+		fprintf(stderr, "%s: error creating start event\n", __func__);
 		goto fail;
 	}
 
@@ -179,7 +179,7 @@ static BOOL test_mutex_threading(void)
 
 	if (!(hThread = CreateThread(NULL, 0, test_mutex_thread1, (LPVOID)hStartEvent, 0, NULL)))
 	{
-		fprintf(stderr, "%s: error creating test_mutex_thread_1\n", __FUNCTION__);
+		fprintf(stderr, "%s: error creating test_mutex_thread_1\n", __func__);
 		goto fail;
 	}
 
@@ -187,7 +187,7 @@ static BOOL test_mutex_threading(void)
 
 	if (!thread1_failed)
 	{
-		fprintf(stderr, "%s: thread1 premature success\n", __FUNCTION__);
+		fprintf(stderr, "%s: thread1 premature success\n", __func__);
 		goto fail;
 	}
 
@@ -195,13 +195,13 @@ static BOOL test_mutex_threading(void)
 
 	if (WaitForSingleObject(hThread, 2000) != WAIT_OBJECT_0)
 	{
-		fprintf(stderr, "%s: thread1 premature success\n", __FUNCTION__);
+		fprintf(stderr, "%s: thread1 premature success\n", __func__);
 		goto fail;
 	}
 
 	if (thread1_failed)
 	{
-		fprintf(stderr, "%s: thread1 has not reported success\n", __FUNCTION__);
+		fprintf(stderr, "%s: thread1 has not reported success\n", __func__);
 		goto fail;
 	}
 
@@ -212,13 +212,13 @@ static BOOL test_mutex_threading(void)
 
 	if (!ReleaseMutex(thread1_mutex1))
 	{
-		printf("%s: ReleaseMutex unexpectedly failed on thread1_mutex1\n", __FUNCTION__);
+		printf("%s: ReleaseMutex unexpectedly failed on thread1_mutex1\n", __func__);
 		goto fail;
 	}
 
 	if (ReleaseMutex(thread1_mutex2))
 	{
-		printf("%s: ReleaseMutex unexpectedly succeeded on thread1_mutex2\n", __FUNCTION__);
+		printf("%s: ReleaseMutex unexpectedly succeeded on thread1_mutex2\n", __func__);
 		goto fail;
 	}
 

--- a/winpr/libwinpr/sysinfo/test/TestGetComputerName.c
+++ b/winpr/libwinpr/sysinfo/test/TestGetComputerName.c
@@ -39,14 +39,14 @@ static BOOL Test_GetComputerName(void)
 	if (GetComputerNameA(NULL, &dwSize) == TRUE)
 	{
 		fprintf(stderr, "%s: (1) GetComputerNameA unexpectedly succeeded with null buffer\n",
-		        __FUNCTION__);
+		        __func__);
 		return FALSE;
 	}
 	if ((dwError = GetLastError()) != ERROR_BUFFER_OVERFLOW)
 	{
 		fprintf(stderr,
 		        "%s: (2) GetLastError returned 0x%08" PRIX32 " (expected ERROR_BUFFER_OVERFLOW)\n",
-		        __FUNCTION__, dwError);
+		        __func__, dwError);
 		return FALSE;
 	}
 
@@ -56,14 +56,14 @@ static BOOL Test_GetComputerName(void)
 	{
 		fprintf(stderr,
 		        "%s: (3) GetComputerNameA unexpectedly succeeded with zero size parameter\n",
-		        __FUNCTION__);
+		        __func__);
 		return FALSE;
 	}
 	if ((dwError = GetLastError()) != ERROR_BUFFER_OVERFLOW)
 	{
 		fprintf(stderr,
 		        "%s: (4) GetLastError returned 0x%08" PRIX32 " (expected ERROR_BUFFER_OVERFLOW)\n",
-		        __FUNCTION__, dwError);
+		        __func__, dwError);
 		return FALSE;
 	}
 	/* check if returned size is valid: must be the size of the buffer required, including the
@@ -73,7 +73,7 @@ static BOOL Test_GetComputerName(void)
 		fprintf(stderr,
 		        "%s: (5) GetComputerNameA returned wrong size %" PRIu32
 		        " (expected something in the range from 2 to %" PRIu32 ")\n",
-		        __FUNCTION__, dwSize, netbiosBufferSize);
+		        __func__, dwSize, netbiosBufferSize);
 		return FALSE;
 	}
 	dwNameLength = dwSize - 1;
@@ -82,7 +82,7 @@ static BOOL Test_GetComputerName(void)
 	if (GetComputerNameA(netbiosName1, &dwSize) == FALSE)
 	{
 		fprintf(stderr, "%s: (6) GetComputerNameA failed with error: 0x%08" PRIX32 "\n",
-		        __FUNCTION__, GetLastError());
+		        __func__, GetLastError());
 		return FALSE;
 	}
 	/* check if returned size is valid */
@@ -90,13 +90,13 @@ static BOOL Test_GetComputerName(void)
 	{
 		fprintf(stderr,
 		        "%s: (7) GetComputerNameA returned wrong size %" PRIu32 " (expected %" PRIu32 ")\n",
-		        __FUNCTION__, dwSize, dwNameLength);
+		        __func__, dwSize, dwNameLength);
 		return FALSE;
 	}
 	/* check if string is correctly terminated */
 	if (netbiosName1[dwSize] != 0)
 	{
-		fprintf(stderr, "%s: (8) string termination error\n", __FUNCTION__);
+		fprintf(stderr, "%s: (8) string termination error\n", __func__);
 		return FALSE;
 	}
 
@@ -105,7 +105,7 @@ static BOOL Test_GetComputerName(void)
 	if (GetComputerNameA(netbiosName2, &dwSize) == FALSE)
 	{
 		fprintf(stderr, "%s: (9) GetComputerNameA failed with error: 0x%08" PRIX32 "\n",
-		        __FUNCTION__, GetLastError());
+		        __func__, GetLastError());
 		return FALSE;
 	}
 	/* check if returned size is valid */
@@ -114,20 +114,20 @@ static BOOL Test_GetComputerName(void)
 		fprintf(stderr,
 		        "%s: (10) GetComputerNameA returned wrong size %" PRIu32 " (expected %" PRIu32
 		        ")\n",
-		        __FUNCTION__, dwSize, dwNameLength);
+		        __func__, dwSize, dwNameLength);
 		return FALSE;
 	}
 	/* check if string is correctly terminated */
 	if (netbiosName2[dwSize] != 0)
 	{
-		fprintf(stderr, "%s: (11) string termination error\n", __FUNCTION__);
+		fprintf(stderr, "%s: (11) string termination error\n", __func__);
 		return FALSE;
 	}
 
 	/* compare the results */
 	if (strcmp(netbiosName1, netbiosName2))
 	{
-		fprintf(stderr, "%s: (12) string compare mismatch\n", __FUNCTION__);
+		fprintf(stderr, "%s: (12) string compare mismatch\n", __func__);
 		return FALSE;
 	}
 
@@ -137,7 +137,7 @@ static BOOL Test_GetComputerName(void)
 	{
 		fprintf(stderr,
 		        "%s: (13) GetComputerNameA unexpectedly succeeded with limited buffer size\n",
-		        __FUNCTION__);
+		        __func__);
 		return FALSE;
 	}
 	/* check if returned size is valid */
@@ -146,7 +146,7 @@ static BOOL Test_GetComputerName(void)
 		fprintf(stderr,
 		        "%s: (14) GetComputerNameA returned wrong size %" PRIu32 " (expected %" PRIu32
 		        ")\n",
-		        __FUNCTION__, dwSize, dwNameLength + 1);
+		        __func__, dwSize, dwNameLength + 1);
 		return FALSE;
 	}
 
@@ -214,14 +214,14 @@ static BOOL Test_GetComputerNameEx_Format(COMPUTER_NAME_FORMAT format)
 	if (GetComputerNameExA(format, NULL, &dwSize) == TRUE)
 	{
 		fprintf(stderr, "%s: (1/%d) GetComputerNameExA unexpectedly succeeded with null buffer\n",
-		        __FUNCTION__, format);
+		        __func__, format);
 		return FALSE;
 	}
 	if ((dwError = GetLastError()) != ERROR_MORE_DATA)
 	{
 		fprintf(stderr,
 		        "%s: (2/%d) GetLastError returned 0x%08" PRIX32 " (expected ERROR_MORE_DATA)\n",
-		        __FUNCTION__, format, dwError);
+		        __func__, format, dwError);
 		return FALSE;
 	}
 
@@ -231,14 +231,14 @@ static BOOL Test_GetComputerNameEx_Format(COMPUTER_NAME_FORMAT format)
 	{
 		fprintf(stderr,
 		        "%s: (3/%d) GetComputerNameExA unexpectedly succeeded with zero size parameter\n",
-		        __FUNCTION__, format);
+		        __func__, format);
 		return FALSE;
 	}
 	if ((dwError = GetLastError()) != ERROR_MORE_DATA)
 	{
 		fprintf(stderr,
 		        "%s: (4/%d) GetLastError returned 0x%08" PRIX32 " (expected ERROR_MORE_DATA)\n",
-		        __FUNCTION__, format, dwError);
+		        __func__, format, dwError);
 		return FALSE;
 	}
 	/* check if returned size is valid: must be the size of the buffer required, including the
@@ -248,7 +248,7 @@ static BOOL Test_GetComputerNameEx_Format(COMPUTER_NAME_FORMAT format)
 		fprintf(stderr,
 		        "%s: (5/%d) GetComputerNameExA returned wrong size %" PRIu32
 		        " (expected something in the range from %" PRIu32 " to %" PRIu32 ")\n",
-		        __FUNCTION__, format, dwSize, dwMinSize, nameBufferSize);
+		        __func__, format, dwSize, dwMinSize, nameBufferSize);
 		return FALSE;
 	}
 	dwNameLength = dwSize - 1;
@@ -257,7 +257,7 @@ static BOOL Test_GetComputerNameEx_Format(COMPUTER_NAME_FORMAT format)
 	if (GetComputerNameExA(format, computerName1, &dwSize) == FALSE)
 	{
 		fprintf(stderr, "%s: (6/%d) GetComputerNameExA failed with error: 0x%08" PRIX32 "\n",
-		        __FUNCTION__, format, GetLastError());
+		        __func__, format, GetLastError());
 		return FALSE;
 	}
 	/* check if returned size is valid */
@@ -266,13 +266,13 @@ static BOOL Test_GetComputerNameEx_Format(COMPUTER_NAME_FORMAT format)
 		fprintf(stderr,
 		        "%s: (7/%d) GetComputerNameExA returned wrong size %" PRIu32 " (expected %" PRIu32
 		        ")\n",
-		        __FUNCTION__, format, dwSize, dwNameLength);
+		        __func__, format, dwSize, dwNameLength);
 		return FALSE;
 	}
 	/* check if string is correctly terminated */
 	if (computerName1[dwSize] != 0)
 	{
-		fprintf(stderr, "%s: (8/%d) string termination error\n", __FUNCTION__, format);
+		fprintf(stderr, "%s: (8/%d) string termination error\n", __func__, format);
 		return FALSE;
 	}
 
@@ -281,7 +281,7 @@ static BOOL Test_GetComputerNameEx_Format(COMPUTER_NAME_FORMAT format)
 	if (GetComputerNameExA(format, computerName2, &dwSize) == FALSE)
 	{
 		fprintf(stderr, "%s: (9/%d) GetComputerNameExA failed with error: 0x%08" PRIX32 "\n",
-		        __FUNCTION__, format, GetLastError());
+		        __func__, format, GetLastError());
 		return FALSE;
 	}
 	/* check if returned size is valid */
@@ -290,20 +290,20 @@ static BOOL Test_GetComputerNameEx_Format(COMPUTER_NAME_FORMAT format)
 		fprintf(stderr,
 		        "%s: (10/%d) GetComputerNameExA returned wrong size %" PRIu32 " (expected %" PRIu32
 		        ")\n",
-		        __FUNCTION__, format, dwSize, dwNameLength);
+		        __func__, format, dwSize, dwNameLength);
 		return FALSE;
 	}
 	/* check if string is correctly terminated */
 	if (computerName2[dwSize] != 0)
 	{
-		fprintf(stderr, "%s: (11/%d) string termination error\n", __FUNCTION__, format);
+		fprintf(stderr, "%s: (11/%d) string termination error\n", __func__, format);
 		return FALSE;
 	}
 
 	/* compare the results */
 	if (strcmp(computerName1, computerName2))
 	{
-		fprintf(stderr, "%s: (12/%d) string compare mismatch\n", __FUNCTION__, format);
+		fprintf(stderr, "%s: (12/%d) string compare mismatch\n", __func__, format);
 		return FALSE;
 	}
 
@@ -313,7 +313,7 @@ static BOOL Test_GetComputerNameEx_Format(COMPUTER_NAME_FORMAT format)
 	{
 		fprintf(stderr,
 		        "%s: (13/%d) GetComputerNameExA unexpectedly succeeded with limited buffer size\n",
-		        __FUNCTION__, format);
+		        __func__, format);
 		return FALSE;
 	}
 	/* check if returned size is valid */
@@ -322,7 +322,7 @@ static BOOL Test_GetComputerNameEx_Format(COMPUTER_NAME_FORMAT format)
 		fprintf(stderr,
 		        "%s: (14/%d) GetComputerNameExA returned wrong size %" PRIu32 " (expected %" PRIu32
 		        ")\n",
-		        __FUNCTION__, format, dwSize, dwNameLength + 1);
+		        __func__, format, dwSize, dwNameLength + 1);
 		return FALSE;
 	}
 

--- a/winpr/libwinpr/utils/stream.c
+++ b/winpr/libwinpr/utils/stream.c
@@ -34,7 +34,7 @@
 	{                                                                                      \
 		if (!(cond))                                                                       \
 		{                                                                                  \
-			WLog_FATAL(STREAM_TAG, "%s [%s:%s:%" PRIuz "]", #cond, __FILE__, __FUNCTION__, \
+			WLog_FATAL(STREAM_TAG, "%s [%s:%s:%" PRIuz "]", #cond, __FILE__, __func__,     \
 			           (size_t)__LINE__);                                                  \
 			winpr_log_backtrace(STREAM_TAG, WLOG_FATAL, 20);                               \
 			abort();                                                                       \

--- a/winpr/libwinpr/utils/test/TestBitStream.c
+++ b/winpr/libwinpr/utils/test/TestBitStream.c
@@ -66,22 +66,22 @@ int TestBitStream(int argc, char* argv[])
 	BitStream_Write_Bits(bs, 0xF, 4);  /* 1111 */
 	BitStream_Write_Bits(bs, 0xA, 4);  /* 0101 */
 	BitStream_Flush(bs);
-	BitDump(__FUNCTION__, WLOG_INFO, buffer, bs->position, BITDUMP_MSB_FIRST);
+	BitDump(__func__, WLOG_INFO, buffer, bs->position, BITDUMP_MSB_FIRST);
 	BitStream_Write_Bits(bs, 3, 2);    /* 11 */
 	BitStream_Write_Bits(bs, 0, 3);    /* 000 */
 	BitStream_Write_Bits(bs, 0x2D, 6); /* 101101 */
 	BitStream_Write_Bits(bs, 0x19, 5); /* 11001 */
 	// BitStream_Flush(bs); /* flush should be done automatically here (32 bits written) */
-	BitDump(__FUNCTION__, WLOG_INFO, buffer, bs->position, BITDUMP_MSB_FIRST);
+	BitDump(__func__, WLOG_INFO, buffer, bs->position, BITDUMP_MSB_FIRST);
 	BitStream_Write_Bits(bs, 3, 2); /* 11 */
 	BitStream_Flush(bs);
-	BitDump(__FUNCTION__, WLOG_INFO, buffer, bs->position, BITDUMP_MSB_FIRST);
+	BitDump(__func__, WLOG_INFO, buffer, bs->position, BITDUMP_MSB_FIRST);
 	BitStream_Write_Bits(bs, 00, 2);  /* 00 */
 	BitStream_Write_Bits(bs, 0xF, 4); /* 1111 */
 	BitStream_Write_Bits(bs, 0, 20);
 	BitStream_Write_Bits(bs, 0xAFF, 12); /* 111111110101 */
 	BitStream_Flush(bs);
-	BitDump(__FUNCTION__, WLOG_INFO, buffer, bs->position, BITDUMP_MSB_FIRST);
+	BitDump(__func__, WLOG_INFO, buffer, bs->position, BITDUMP_MSB_FIRST);
 	BitStream_Free(bs);
 	return 0;
 }

--- a/winpr/libwinpr/utils/test/TestStream.c
+++ b/winpr/libwinpr/utils/test/TestStream.c
@@ -142,14 +142,14 @@ static BOOL TestStream_Create(size_t count, BOOL selfAlloc)
 		{
 			if (!(buffer = malloc(cap)))
 			{
-				printf("%s: failed to allocate buffer of size %" PRIuz "\n", __FUNCTION__, cap);
+				printf("%s: failed to allocate buffer of size %" PRIuz "\n", __func__, cap);
 				goto fail;
 			}
 		}
 
 		if (!(s = Stream_New(selfAlloc ? buffer : NULL, len)))
 		{
-			printf("%s: Stream_New failed for stream #%" PRIuz "\n", __FUNCTION__, i);
+			printf("%s: Stream_New failed for stream #%" PRIuz "\n", __func__, i);
 			goto fail;
 		}
 
@@ -175,7 +175,7 @@ static BOOL TestStream_Create(size_t count, BOOL selfAlloc)
 
 			if (memcmp(buffer, Stream_Buffer(s), cap))
 			{
-				printf("%s: buffer memory corruption\n", __FUNCTION__);
+				printf("%s: buffer memory corruption\n", __func__);
 				goto fail;
 			}
 		}
@@ -204,7 +204,7 @@ static BOOL TestStream_Extent(UINT32 maxSize)
 
 	if (!(s = Stream_New(NULL, 1)))
 	{
-		printf("%s: Stream_New failed\n", __FUNCTION__);
+		printf("%s: Stream_New failed\n", __func__);
 		return FALSE;
 	}
 
@@ -226,7 +226,7 @@ static BOOL TestStream_Extent(UINT32 maxSize)
 
 		if (!TestStream_Verify(s, i, i, i))
 		{
-			printf("%s: failed to verify stream in iteration %" PRIu32 "\n", __FUNCTION__, i);
+			printf("%s: failed to verify stream in iteration %" PRIu32 "\n", __func__, i);
 			goto fail;
 		}
 	}
@@ -258,14 +258,14 @@ fail:
 		Stream_Read_##_t(_s, _b);                                      \
 		if (_a != _b)                                                  \
 		{                                                              \
-			printf("%s: test1 " #_t "_LE failed\n", __FUNCTION__);     \
+			printf("%s: test1 " #_t "_LE failed\n", __func__);     \
 			_r = FALSE;                                                \
 		}                                                              \
 		for (_i = 0; _i < sizeof(_t); _i++)                            \
 		{                                                              \
 			if (((_a >> (_i * 8)) & 0xFF) != _p[_i])                   \
 			{                                                          \
-				printf("%s: test2 " #_t "_LE failed\n", __FUNCTION__); \
+				printf("%s: test2 " #_t "_LE failed\n", __func__); \
 				_r = FALSE;                                            \
 				break;                                                 \
 			}                                                          \
@@ -276,14 +276,14 @@ fail:
 		Stream_Read_##_t##_BE(_s, _b);                                 \
 		if (_a != _b)                                                  \
 		{                                                              \
-			printf("%s: test1 " #_t "_BE failed\n", __FUNCTION__);     \
+			printf("%s: test1 " #_t "_BE failed\n", __func__);     \
 			_r = FALSE;                                                \
 		}                                                              \
 		for (_i = 0; _i < sizeof(_t); _i++)                            \
 		{                                                              \
 			if (((_a >> (_i * 8)) & 0xFF) != _p[sizeof(_t) - _i - 1])  \
 			{                                                          \
-				printf("%s: test2 " #_t "_BE failed\n", __FUNCTION__); \
+				printf("%s: test2 " #_t "_BE failed\n", __func__); \
 				_r = FALSE;                                            \
 				break;                                                 \
 			}                                                          \
@@ -299,7 +299,7 @@ static BOOL TestStream_Reading(void)
 
 	if (!(s = Stream_New(src, sizeof(src))))
 	{
-		printf("%s: Stream_New failed\n", __FUNCTION__);
+		printf("%s: Stream_New failed\n", __func__);
 		return FALSE;
 	}
 

--- a/winpr/libwinpr/utils/test/TestWLogCallback.c
+++ b/winpr/libwinpr/utils/test/TestWLogCallback.c
@@ -58,19 +58,19 @@ static BOOL CallbackAppenderMessage(const wLogMessage* msg)
 
 static BOOL CallbackAppenderData(const wLogMessage* msg)
 {
-	fprintf(stdout, "%s\n", __FUNCTION__);
+	fprintf(stdout, "%s\n", __func__);
 	return TRUE;
 }
 
 static BOOL CallbackAppenderImage(const wLogMessage* msg)
 {
-	fprintf(stdout, "%s\n", __FUNCTION__);
+	fprintf(stdout, "%s\n", __func__);
 	return TRUE;
 }
 
 static BOOL CallbackAppenderPackage(const wLogMessage* msg)
 {
-	fprintf(stdout, "%s\n", __FUNCTION__);
+	fprintf(stdout, "%s\n", __func__);
 	return TRUE;
 }
 
@@ -86,7 +86,7 @@ int TestWLogCallback(int argc, char* argv[])
 	WINPR_UNUSED(argc);
 	WINPR_UNUSED(argv);
 
-	function = __FUNCTION__;
+	function = __func__;
 
 	root = WLog_GetRoot();
 

--- a/winpr/libwinpr/utils/wlog/Appender.c
+++ b/winpr/libwinpr/utils/wlog/Appender.c
@@ -126,7 +126,7 @@ static wLogAppender* WLog_Appender_New(wLog* log, DWORD logAppenderType)
 			appender = (wLogAppender*)WLog_UdpAppender_New(log);
 			break;
 		default:
-			fprintf(stderr, "%s: unknown handler type %" PRIu32 "\n", __FUNCTION__,
+			fprintf(stderr, "%s: unknown handler type %" PRIu32 "\n", __func__,
 			        logAppenderType);
 			appender = NULL;
 			break;

--- a/winpr/libwinpr/utils/wlog/JournaldAppender.c
+++ b/winpr/libwinpr/utils/wlog/JournaldAppender.c
@@ -104,7 +104,7 @@ static BOOL WLog_JournaldAppender_WriteMessage(wLog* log, wLogAppender* appender
 		case WLOG_OFF:
 			return TRUE;
 		default:
-			fprintf(stderr, "%s: unknown level %" PRIu32 "\n", __FUNCTION__, message->Level);
+			fprintf(stderr, "%s: unknown level %" PRIu32 "\n", __func__, message->Level);
 			return FALSE;
 	}
 

--- a/winpr/libwinpr/wtsapi/test/TestWtsApiEnumerateProcesses.c
+++ b/winpr/libwinpr/wtsapi/test/TestWtsApiEnumerateProcesses.c
@@ -17,7 +17,7 @@ int TestWtsApiEnumerateProcesses(int argc, char* argv[])
 #ifndef _WIN32
 	if (!GetEnvironmentVariableA("WTSAPI_LIBRARY", NULL, 0))
 	{
-		printf("%s: No RDS environment detected, skipping test\n", __FUNCTION__);
+		printf("%s: No RDS environment detected, skipping test\n", __func__);
 		return 0;
 	}
 #endif

--- a/winpr/libwinpr/wtsapi/test/TestWtsApiEnumerateSessions.c
+++ b/winpr/libwinpr/wtsapi/test/TestWtsApiEnumerateSessions.c
@@ -18,7 +18,7 @@ int TestWtsApiEnumerateSessions(int argc, char* argv[])
 #ifndef _WIN32
 	if (!GetEnvironmentVariableA("WTSAPI_LIBRARY", NULL, 0))
 	{
-		printf("%s: No RDS environment detected, skipping test\n", __FUNCTION__);
+		printf("%s: No RDS environment detected, skipping test\n", __func__);
 		return 0;
 	}
 #endif

--- a/winpr/libwinpr/wtsapi/test/TestWtsApiQuerySessionInformation.c
+++ b/winpr/libwinpr/wtsapi/test/TestWtsApiQuerySessionInformation.c
@@ -21,7 +21,7 @@ int TestWtsApiQuerySessionInformation(int argc, char* argv[])
 #ifndef _WIN32
 	if (!GetEnvironmentVariableA("WTSAPI_LIBRARY", NULL, 0))
 	{
-		printf("%s: No RDS environment detected, skipping test\n", __FUNCTION__);
+		printf("%s: No RDS environment detected, skipping test\n", __func__);
 		return 0;
 	}
 #endif

--- a/winpr/libwinpr/wtsapi/test/TestWtsApiSessionNotification.c
+++ b/winpr/libwinpr/wtsapi/test/TestWtsApiSessionNotification.c
@@ -16,7 +16,7 @@ int TestWtsApiSessionNotification(int argc, char* argv[])
 #ifndef _WIN32
 	if (!GetEnvironmentVariableA("WTSAPI_LIBRARY", NULL, 0))
 	{
-		printf("%s: No RDS environment detected, skipping test\n", __FUNCTION__);
+		printf("%s: No RDS environment detected, skipping test\n", __func__);
 		return 0;
 	}
 #else
@@ -25,7 +25,7 @@ int TestWtsApiSessionNotification(int argc, char* argv[])
 	                     NULL, NULL, NULL);
 	if (!hWnd)
 	{
-		printf("%s: error creating message-only window: %" PRIu32 "\n", __FUNCTION__,
+		printf("%s: error creating message-only window: %" PRIu32 "\n", __func__,
 		       GetLastError());
 		return -1;
 	}
@@ -37,7 +37,7 @@ int TestWtsApiSessionNotification(int argc, char* argv[])
 
 	if (!bSuccess)
 	{
-		printf("%s: WTSRegisterSessionNotification failed: %" PRIu32 "\n", __FUNCTION__,
+		printf("%s: WTSRegisterSessionNotification failed: %" PRIu32 "\n", __func__,
 		       GetLastError());
 		return -1;
 	}
@@ -54,7 +54,7 @@ int TestWtsApiSessionNotification(int argc, char* argv[])
 
 	if (!bSuccess)
 	{
-		printf("%s: WTSUnRegisterSessionNotification failed: %" PRIu32 "\n", __FUNCTION__,
+		printf("%s: WTSUnRegisterSessionNotification failed: %" PRIu32 "\n", __func__,
 		       GetLastError());
 		return -1;
 	}

--- a/winpr/libwinpr/wtsapi/test/TestWtsApiShutdownSystem.c
+++ b/winpr/libwinpr/wtsapi/test/TestWtsApiShutdownSystem.c
@@ -15,7 +15,7 @@ int TestWtsApiShutdownSystem(int argc, char* argv[])
 #ifndef _WIN32
 	if (!GetEnvironmentVariableA("WTSAPI_LIBRARY", NULL, 0))
 	{
-		printf("%s: No RDS environment detected, skipping test\n", __FUNCTION__);
+		printf("%s: No RDS environment detected, skipping test\n", __func__);
 		return 0;
 	}
 #endif

--- a/winpr/libwinpr/wtsapi/test/TestWtsApiWaitSystemEvent.c
+++ b/winpr/libwinpr/wtsapi/test/TestWtsApiWaitSystemEvent.c
@@ -17,7 +17,7 @@ int TestWtsApiWaitSystemEvent(int argc, char* argv[])
 #ifndef _WIN32
 	if (!GetEnvironmentVariableA("WTSAPI_LIBRARY", NULL, 0))
 	{
-		printf("%s: No RDS environment detected, skipping test\n", __FUNCTION__);
+		printf("%s: No RDS environment detected, skipping test\n", __func__);
 		return 0;
 	}
 #endif


### PR DESCRIPTION
Use `__func__` instead of `__FUNCTION__`, which is a GCC extension.

The `__func__` identifier is standard since C99, however Visual Studio supports it since VS2015.