### PR TITLE
Android app. Add setting "Use back button as Alt-f4"

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ApplicationSettingsActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ApplicationSettingsActivity.java
@@ -250,6 +250,13 @@ public class ApplicationSettingsActivity extends AppCompatPreferenceActivity
 		                              false);
 	}
 
+	public static boolean getUseBackAsAltf4(Context context)
+	{
+		SharedPreferences preferences = get(context);
+		return preferences.getBoolean(
+		    context.getString(R.string.preference_key_ui_use_back_as_altf4), true);
+	}
+
 	public static boolean getAcceptAllCertificates(Context context)
 	{
 		SharedPreferences preferences = get(context);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -704,8 +704,10 @@ public class SessionActivity extends AppCompatActivity
 		// hide keyboards (if any visible) or send alt+f4 to the session
 		if (sysKeyboardVisible || extKeyboardVisible)
 			showKeyboard(false, false);
-		else
+		else if (ApplicationSettingsActivity.getUseBackAsAltf4(this))
+		{
 			keyboardMapper.sendAltF4();
+		}
 	}
 
 	@Override public boolean onKeyLongPress(int keyCode, KeyEvent event)

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-de/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-de/strings.xml
@@ -126,6 +126,7 @@
     <string name="settings_ui_invert_scrolling">Invertiere Bildlauf</string>
     <string name="settings_ui_auto_scroll_touchpointer">Touch Zeiger automatischer Bildlauf</string>
     <string name="settings_ui_ask_on_exit">Zeige Dialog beim Beenden</string>
+    <string name="settings_ui_use_back_as_altf4">Verwenden Sie die "Zurück"-Taste als Alt+F4</string>
     <string name="settings_cat_power">Energiesparen</string>
     <string name="settings_power_disconnect_timeout">Schließe ungenutzte Verbindungen</string>
     <string name="settings_cat_security">Sicherheit</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-es/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-es/strings.xml
@@ -127,6 +127,7 @@
     <string name="settings_ui_invert_scrolling">invertir desplazamiento</string>
     <string name="settings_ui_auto_scroll_touchpointer">Puntero táctil de desplazamiento automático</string>
     <string name="settings_ui_ask_on_exit">Mostrar cuadro de diálogo en la salida</string>
+    <string name="settings_ui_use_back_as_altf4">Usar el botón "atrás" como Alt+F4</string>
     <string name="settings_cat_power">Ahorro de energía</string>
     <string name="settings_power_disconnect_timeout">Cerrar las conexiones inactivas</string>
     <string name="settings_cat_security">Seguridad</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-fr/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-fr/strings.xml
@@ -126,6 +126,7 @@
     <string name="settings_ui_invert_scrolling">"Inverser le défilement de la souris"</string>
     <string name="settings_ui_auto_scroll_touchpointer">"Défilement automatique du pointeur tactile"</string>
     <string name="settings_ui_ask_on_exit">"Confirmer au moment de quitter"</string>
+    <string name="settings_ui_use_back_as_altf4">Utiliser le bouton "retour" comme Alt+F4</string>
     <string name="settings_cat_power">"Economie d'énergie"</string>
     <string name="settings_power_disconnect_timeout">"Fermer les connexions inactives"</string>
     <string name="settings_cat_security">"Securité"</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-ja/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-ja/strings.xml
@@ -128,6 +128,7 @@
     <string name="settings_ui_invert_scrolling">Invert Scrolling</string>
     <string name="settings_ui_auto_scroll_touchpointer">Touch Pointer Auto Scroll</string>
     <string name="settings_ui_ask_on_exit">Show Dialog on Exit</string>
+    <string name="settings_ui_use_back_as_altf4">「戻る」ボタンを Alt+F4 として使用する</string>
     <string name="settings_cat_power">Power Saving</string>
     <string name="settings_cat_client">Client</string>
     <string name="settings_power_disconnect_timeout">Close idle Connections</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-ko/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-ko/strings.xml
@@ -167,6 +167,7 @@
     <string name="settings_ui_invert_scrolling">스크롤 뒤집기</string>
     <string name="settings_ui_auto_scroll_touchpointer">터치 포인터 자동 스크롤</string>
     <string name="settings_ui_ask_on_exit">종료할 때 다이얼로그 보이기</string>
+    <string name="settings_ui_use_back_as_altf4">뒤로 버튼을 Alt+F4로 사용</string>
     <string name="settings_cat_power">절전 기능</string>
     <string name="settings_cat_client">클라이언트</string>
     <string name="settings_power_disconnect_timeout">사용하지 않는 연결 종료</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-nb-rNO/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-nb-rNO/strings.xml
@@ -167,6 +167,7 @@
     <string name="settings_ui_invert_scrolling">Inverter rulling</string>
     <string name="settings_ui_auto_scroll_touchpointer">Autorulling for trykkpeker</string>
     <string name="settings_ui_ask_on_exit">Vis dialogvindu ved avslutning</string>
+    <string name="settings_ui_use_back_as_altf4">Bruk "tilbake"-knappen som Alt+F4</string>
     <string name="settings_cat_power">Strømsparing</string>
     <string name="settings_cat_client">Klient</string>
     <string name="settings_power_disconnect_timeout">Lukk tilkoblinger ved lediggang</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-nl/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-nl/strings.xml
@@ -127,6 +127,7 @@
     <string name="settings_ui_invert_scrolling">Scrollen omkeren</string>
     <string name="settings_ui_auto_scroll_touchpointer">Touch Pointer Auto Scroll</string>
     <string name="settings_ui_ask_on_exit">Toon dialoog bij sluiten</string>
+    <string name="settings_ui_use_back_as_altf4">Gebruik de "terug"-knop als Alt+F4</string>
     <string name="settings_cat_power">Energiebesparing</string>
     <string name="settings_power_disconnect_timeout">Sluit inactieve ingen</string>
     <string name="settings_cat_security">Beveiliging</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-pt-rBR/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-pt-rBR/strings.xml
@@ -167,6 +167,7 @@
     <string name="settings_ui_invert_scrolling">Inverter a rolagem</string>
     <string name="settings_ui_auto_scroll_touchpointer">Rolagem automática do ponteiro de toque</string>
     <string name="settings_ui_ask_on_exit">Mostrar diálogo ao sair</string>
+    <string name="settings_ui_use_back_as_altf4">Usar o botão "voltar" como Alt+F4</string>
     <string name="settings_cat_power">Economia de energia</string>
     <string name="settings_cat_client">Cliente</string>
     <string name="settings_power_disconnect_timeout">Fechar as conexões inativas</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values-zh/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values-zh/strings.xml
@@ -132,6 +132,7 @@
     <string name="settings_ui_invert_scrolling">逆向滚动</string>
     <string name="settings_ui_auto_scroll_touchpointer">触控指针自动滚动</string>
     <string name="settings_ui_ask_on_exit">退出时显示会话框</string>
+    <string name="settings_ui_use_back_as_altf4">将“返回”按钮用作 Alt+F4</string>
     <string name="settings_cat_power">省电</string>
     <string name="settings_cat_client">客户端</string>
     <string name="settings_power_disconnect_timeout">关闭空闲连接</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -167,6 +167,7 @@
     <string name="settings_ui_invert_scrolling">Invert Scrolling</string>
     <string name="settings_ui_auto_scroll_touchpointer">Touch Pointer Auto Scroll</string>
     <string name="settings_ui_ask_on_exit">Show Dialog on Exit</string>
+    <string name="settings_ui_use_back_as_altf4">Use \"back\" button as Alt+F4</string>
     <string name="settings_cat_power">Power Saving</string>
     <string name="settings_cat_client">Client</string>
     <string name="settings_power_disconnect_timeout">Close idle Connections</string>
@@ -224,6 +225,7 @@
     <string name="preference_key_ui_swap_mouse_buttons" translatable="false">ui.swap_mouse_buttons</string>
     <string name="preference_key_ui_hide_zoom_controls" translatable="false">ui.hide_zoom_controls</string>
     <string name="preference_key_ui_hide_action_bar" translatable="false">ui.hide_action_bar</string>
+    <string name="preference_key_ui_use_back_as_altf4" translatable="false">ui.use_back_as_altf4</string>
     <string-array name="debug_array" translatable="false">
         <item>OFF</item>
         <item>FATAL</item>

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_ui.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_ui.xml
@@ -27,4 +27,8 @@
         android:defaultValue="true"
         android:key="@string/preference_key_ui_hide_action_bar"
         android:title="@string/settings_ui_hide_action_bar" />
+    <CheckBoxPreference
+        android:defaultValue="true"
+        android:key="@string/preference_key_ui_use_back_as_altf4"
+        android:title="@string/settings_ui_use_back_as_altf4" />
 </PreferenceScreen>


### PR DESCRIPTION
Sometimes android keyboard stucks, and user(especially i am) can automatically press "back" button more than one time. It leads to closing apps on remote computer. PR adds a checkbox to disable this.