### PR TITLE
[core,redirection] Fix sending redirection certificate

### DIFF
--- a/include/freerdp/redirection.h
+++ b/include/freerdp/redirection.h
@@ -43,6 +43,9 @@
 
 #define LB_PASSWORD_MAX_LENGTH 512
 
+#define ELEMENT_TYPE_CERTIFICATE 32
+#define ENCODING_TYPE_ASN1_DER 1
+
 #ifdef __cplusplus
 extern "C"
 {


### PR DESCRIPTION
This is a little thing missing in the `Server Redirection`.

This PR is based on the previous TODO comment it changes.

Another and simpler way would be to just set the certificate in `DER` format, save it as `rdpCertificate` and only build the `TARGET_CERTIFICATE_CONTAINER` when sending.