### PR TITLE
don't log an error when running GetCurrentThread from non winpr thread

### DIFF
--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -815,13 +815,6 @@ WINPR_THREAD* winpr_GetCurrentThread(VOID)
 		return (HANDLE)&mainThread;
 
 	ret = TlsGetValue(currentThreadTlsIndex);
-	if (!ret)
-	{
-		WLog_ERR(TAG, "function called, but no matching entry in thread list!");
-#if defined(WITH_DEBUG_THREADS)
-		DumpThreadHandles();
-#endif
-	}
 	return ret;
 }
 


### PR DESCRIPTION
Since https://github.com/FreeRDP/FreeRDP/commit/7c4a774e4eb9dfdf9271b6bbef2bb1b5191db398 this can legitimately happen in WaitForMultipleObjectsEx and is not actually an error.