### PR TITLE
fix warnings in static inline functions in installed headers

### DIFF
--- a/include/freerdp/codec/h264.h
+++ b/include/freerdp/codec/h264.h
@@ -77,7 +77,11 @@ extern "C"
 
 	static INLINE void free_h264_metablock(RDPGFX_H264_METABLOCK* meta)
 	{
-		RDPGFX_H264_METABLOCK m = { 0 };
+		RDPGFX_H264_METABLOCK m = {
+#ifndef __cplusplus
+			0
+#endif
+		};
 		if (!meta)
 			return;
 		free(meta->quantQualityVals);

--- a/winpr/include/winpr/pool.h
+++ b/winpr/include/winpr/pool.h
@@ -249,7 +249,11 @@ extern "C"
 
 	static INLINE VOID InitializeThreadpoolEnvironment(PTP_CALLBACK_ENVIRON pcbe)
 	{
-		const TP_CALLBACK_ENVIRON empty = { 0 };
+		const TP_CALLBACK_ENVIRON empty = {
+#ifndef __cplusplus
+			0
+#endif
+		};
 		*pcbe = empty;
 		pcbe->Version = 1;
 	}
@@ -257,6 +261,7 @@ extern "C"
 	static INLINE VOID DestroyThreadpoolEnvironment(PTP_CALLBACK_ENVIRON pcbe)
 	{
 		/* no actions, this may change in a future release. */
+		(void)pcbe;
 	}
 
 	static INLINE VOID SetThreadpoolCallbackPool(PTP_CALLBACK_ENVIRON pcbe, PTP_POOL ptpp)


### PR DESCRIPTION
= { 0 } has different meaning in C and C++: in C it initialises all members to 0, in C++ only the first one so the compiler warns that other members are not initialised. Use an empty initialiser list instead.

It's not very pretty; if you prefer a different style let me know :)