### PR TITLE
[winpr,pool] make Callback Environment API functions

### DIFF
--- a/winpr/include/winpr/pool.h
+++ b/winpr/include/winpr/pool.h
@@ -242,37 +242,17 @@ extern "C"
 #define WINPR_CALLBACK_ENVIRON 1
 #endif
 
-#ifdef WINPR_CALLBACK_ENVIRON
+#if defined(WINPR_CALLBACK_ENVIRON)
 	/* some version of mingw are missing Callback Environment functions */
 
 	/* Callback Environment */
 
-	static INLINE VOID InitializeThreadpoolEnvironment(PTP_CALLBACK_ENVIRON pcbe)
-	{
-		const TP_CALLBACK_ENVIRON empty = { 0 };
-		*pcbe = empty;
-		pcbe->Version = 1;
-	}
+	WINPR_API VOID InitializeThreadpoolEnvironment(PTP_CALLBACK_ENVIRON pcbe);
+	WINPR_API VOID DestroyThreadpoolEnvironment(PTP_CALLBACK_ENVIRON pcbe);
+	WINPR_API VOID SetThreadpoolCallbackPool(PTP_CALLBACK_ENVIRON pcbe, PTP_POOL ptpp);
+	WINPR_API VOID SetThreadpoolCallbackRunsLong(PTP_CALLBACK_ENVIRON pcbe);
+	WINPR_API VOID SetThreadpoolCallbackLibrary(PTP_CALLBACK_ENVIRON pcbe, PVOID mod);
 
-	static INLINE VOID DestroyThreadpoolEnvironment(PTP_CALLBACK_ENVIRON pcbe)
-	{
-		/* no actions, this may change in a future release. */
-	}
-
-	static INLINE VOID SetThreadpoolCallbackPool(PTP_CALLBACK_ENVIRON pcbe, PTP_POOL ptpp)
-	{
-		pcbe->Pool = ptpp;
-	}
-
-	static INLINE VOID SetThreadpoolCallbackRunsLong(PTP_CALLBACK_ENVIRON pcbe)
-	{
-		pcbe->u.s.LongFunction = 1;
-	}
-
-	static INLINE VOID SetThreadpoolCallbackLibrary(PTP_CALLBACK_ENVIRON pcbe, PVOID mod)
-	{
-		pcbe->RaceDll = mod;
-	}
 #endif
 
 #ifdef __cplusplus

--- a/winpr/libwinpr/pool/callback_cleanup.c
+++ b/winpr/libwinpr/pool/callback_cleanup.c
@@ -138,3 +138,39 @@ VOID DisassociateCurrentThreadFromCallback(PTP_CALLBACK_INSTANCE pci)
 }
 
 #endif /* WINPR_THREAD_POOL defined */
+
+#if defined(WINPR_CALLBACK_ENVIRON)
+VOID InitializeThreadpoolEnvironment(PTP_CALLBACK_ENVIRON pcbe)
+{
+	const TP_CALLBACK_ENVIRON empty = { 0 };
+	WINPR_ASSERT(pcbe);
+
+	*pcbe = empty;
+	pcbe->Version = 1;
+}
+
+VOID DestroyThreadpoolEnvironment(PTP_CALLBACK_ENVIRON pcbe)
+{
+	/* no actions, this may change in a future release. */
+	WINPR_UNUSED(pcbe);
+}
+
+VOID SetThreadpoolCallbackPool(PTP_CALLBACK_ENVIRON pcbe, PTP_POOL ptpp)
+{
+	WINPR_ASSERT(pcbe);
+	pcbe->Pool = ptpp;
+}
+
+VOID SetThreadpoolCallbackRunsLong(PTP_CALLBACK_ENVIRON pcbe)
+{
+	WINPR_ASSERT(pcbe);
+	pcbe->u.s.LongFunction = 1;
+}
+
+VOID SetThreadpoolCallbackLibrary(PTP_CALLBACK_ENVIRON pcbe, PVOID mod)
+{
+	WINPR_ASSERT(pcbe);
+	pcbe->RaceDll = mod;
+}
+
+#endif


### PR DESCRIPTION
while the windows API exposes these as static functions it is not sufficient for our implementation as every change would break ABI even during a stable release cycle.

Fixes the warnings that were tried to be solved with #8870
@hardening comments/suggestions?