### PR TITLE
[winpr,assert] eliminate c++ warnings

### DIFF
--- a/winpr/include/winpr/assert.h
+++ b/winpr/include/winpr/assert.h
@@ -34,8 +34,9 @@
 		if (!(cond))                                                                          \
 		{                                                                                     \
 			wLog* _log_cached_ptr = WLog_Get("com.freerdp.winpr.assert");                     \
+			const size_t line = __LINE__;                                                     \
 			WLog_Print(_log_cached_ptr, WLOG_FATAL, "%s [%s:%s:%" PRIuz "]", #cond, __FILE__, \
-			           __FUNCTION__, (size_t)__LINE__);                                       \
+			           __FUNCTION__, line);                                                   \
 			winpr_log_backtrace_ex(_log_cached_ptr, WLOG_FATAL, 20);                          \
 			abort();                                                                          \
 		}                                                                                     \

--- a/winpr/include/winpr/collections.h
+++ b/winpr/include/winpr/collections.h
@@ -514,18 +514,37 @@ extern "C"
 		return PubSub_OnEvent(pubSub, #name, context, &e->e);                                   \
 	}
 
+#ifdef __cplusplus
 #define DEFINE_EVENT_SUBSCRIBE(name)                                                              \
 	static INLINE int PubSub_Subscribe##name(wPubSub* pubSub, p##name##EventHandler EventHandler) \
 	{                                                                                             \
-		return PubSub_Subscribe(pubSub, #name, (pEventHandler)EventHandler);                      \
+		pEventHandler handler = reinterpret_cast<pEventHandler>(EventHandler);                    \
+		return PubSub_Subscribe(pubSub, #name, handler);                                          \
 	}
 
 #define DEFINE_EVENT_UNSUBSCRIBE(name)                                             \
 	static INLINE int PubSub_Unsubscribe##name(wPubSub* pubSub,                    \
 	                                           p##name##EventHandler EventHandler) \
 	{                                                                              \
-		return PubSub_Unsubscribe(pubSub, #name, (pEventHandler)EventHandler);     \
+		pEventHandler handler = reinterpret_cast<pEventHandler>(EventHandler);     \
+		return PubSub_Unsubscribe(pubSub, #name, handler);                         \
 	}
+#else
+#define DEFINE_EVENT_SUBSCRIBE(name)                                                              \
+	static INLINE int PubSub_Subscribe##name(wPubSub* pubSub, p##name##EventHandler EventHandler) \
+	{                                                                                             \
+		pEventHandler handler = (pEventHandler)EventHandler;                                      \
+		return PubSub_Subscribe(pubSub, #name, handler);                                          \
+	}
+
+#define DEFINE_EVENT_UNSUBSCRIBE(name)                                             \
+	static INLINE int PubSub_Unsubscribe##name(wPubSub* pubSub,                    \
+	                                           p##name##EventHandler EventHandler) \
+	{                                                                              \
+		pEventHandler handler = (pEventHandler)EventHandler;                       \
+		return PubSub_Unsubscribe(pubSub, #name, handler);                         \
+	}
+#endif
 
 #define DEFINE_EVENT_BEGIN(name) \
 	typedef struct               \

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -300,7 +300,7 @@ extern "C"
 	{
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 1);
-		*_s->pointer++ = (UINT8)(_v);
+		*_s->pointer++ = (_v);
 	}
 
 	static INLINE void Stream_Write_INT16(wStream* _s, INT16 _v)

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -367,14 +367,14 @@ extern "C"
 	{
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 8);
-		*_s->pointer++ = (UINT64)(_v)&0xFF;
-		*_s->pointer++ = ((UINT64)(_v) >> 8) & 0xFF;
-		*_s->pointer++ = ((UINT64)(_v) >> 16) & 0xFF;
-		*_s->pointer++ = ((UINT64)(_v) >> 24) & 0xFF;
-		*_s->pointer++ = ((UINT64)(_v) >> 32) & 0xFF;
-		*_s->pointer++ = ((UINT64)(_v) >> 40) & 0xFF;
-		*_s->pointer++ = ((UINT64)(_v) >> 48) & 0xFF;
-		*_s->pointer++ = ((UINT64)(_v) >> 56) & 0xFF;
+		*_s->pointer++ = (_v)&0xFF;
+		*_s->pointer++ = (_v >> 8) & 0xFF;
+		*_s->pointer++ = (_v >> 16) & 0xFF;
+		*_s->pointer++ = (_v >> 24) & 0xFF;
+		*_s->pointer++ = (_v >> 32) & 0xFF;
+		*_s->pointer++ = (_v >> 40) & 0xFF;
+		*_s->pointer++ = (_v >> 48) & 0xFF;
+		*_s->pointer++ = (_v >> 56) & 0xFF;
 	}
 	static INLINE void Stream_Write(wStream* _s, const void* _b, size_t _n)
 	{


### PR DESCRIPTION
Eliminate cast warnings when used in C++ code
