### PR TITLE
Color depth split

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -4368,8 +4368,6 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 	{
 		settings->FastPathOutput = TRUE;
 		settings->FrameMarkerCommandEnabled = TRUE;
-		if (!freerdp_settings_set_uint32(settings, FreeRDP_ColorDepth, 32))
-			return COMMAND_LINE_ERROR;
 	}
 
 	arg = CommandLineFindArgumentA(largs, "port");

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -2172,6 +2172,13 @@ enum rdp_settings_type
 	FREERDP_API const char* freerdp_encryption_methods_string(UINT32 EncryptionLevel, char* buffer,
 	                                                          size_t size);
 
+	/** \brief returns a string representation of \b RNS_UD_XXBPP_SUPPORT values
+	 *
+	 *  return A string reprenentation of the bitmask.
+	 */
+	FREERDP_API const char* freerdp_supported_color_depths_string(UINT16 mask, char* buffer,
+	                                                              size_t size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -513,6 +513,7 @@ typedef struct
 #define FreeRDP_SupportEdgeActionV1 (150)
 #define FreeRDP_SupportEdgeActionV2 (151)
 #define FreeRDP_SupportSkipChannelJoin (152)
+#define FreeRDP_SupportedColorDepths (153)
 #define FreeRDP_UseRdpSecurityLayer (192)
 #define FreeRDP_EncryptionMethods (193)
 #define FreeRDP_ExtEncryptionMethods (194)
@@ -974,8 +975,8 @@ struct rdp_settings
 	ALIGN64 BOOL SupportEdgeActionV1;     /* 150 */
 	ALIGN64 BOOL SupportEdgeActionV2;     /* 151 */
 	ALIGN64 BOOL SupportSkipChannelJoin;  /* 152 */
-
-	UINT64 padding0192[192 - 153]; /* 153 */
+	ALIGN64 UINT16 SupportedColorDepths;  /* 153 */
+	UINT64 padding0192[192 - 154];        /* 154 */
 
 	/* Client/Server Security Data */
 	ALIGN64 BOOL UseRdpSecurityLayer;                /* 192 */

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -2155,3 +2155,28 @@ const char* freerdp_encryption_methods_string(UINT32 EncryptionMethods, char* bu
 
 	return buffer;
 }
+
+const char* freerdp_supported_color_depths_string(UINT16 mask, char* buffer, size_t size)
+{
+	const UINT32 invalid = mask & ~(RNS_UD_32BPP_SUPPORT | RNS_UD_24BPP_SUPPORT |
+	                                RNS_UD_16BPP_SUPPORT | RNS_UD_15BPP_SUPPORT);
+
+	if (mask & RNS_UD_32BPP_SUPPORT)
+		winpr_str_append("RNS_UD_32BPP_SUPPORT", buffer, size, "|");
+	if (mask & RNS_UD_24BPP_SUPPORT)
+		winpr_str_append("RNS_UD_24BPP_SUPPORT", buffer, size, "|");
+	if (mask & RNS_UD_16BPP_SUPPORT)
+		winpr_str_append("RNS_UD_16BPP_SUPPORT", buffer, size, "|");
+	if (mask & RNS_UD_15BPP_SUPPORT)
+		winpr_str_append("RNS_UD_15BPP_SUPPORT", buffer, size, "|");
+
+	if (invalid != 0)
+	{
+		char str[32] = { 0 };
+		_snprintf(str, sizeof(str), "RNS_UD_INVALID[0x%04" PRIx16 "]", invalid);
+		winpr_str_append(str, buffer, size, "|");
+	}
+	char hex[32] = { 0 };
+	_snprintf(hex, sizeof(hex), "[0x%04" PRIx16 "]", mask);
+	return buffer;
+}

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -1375,6 +1375,9 @@ UINT16 freerdp_settings_get_uint16(const rdpSettings* settings, size_t id)
 		case FreeRDP_ProxyPort:
 			return settings->ProxyPort;
 
+		case FreeRDP_SupportedColorDepths:
+			return settings->SupportedColorDepths;
+
 		case FreeRDP_TLSMaxVersion:
 			return settings->TLSMaxVersion;
 
@@ -1441,6 +1444,10 @@ BOOL freerdp_settings_set_uint16(rdpSettings* settings, size_t id, UINT16 val)
 
 		case FreeRDP_ProxyPort:
 			settings->ProxyPort = cnv.c;
+			break;
+
+		case FreeRDP_SupportedColorDepths:
+			settings->SupportedColorDepths = cnv.c;
 			break;
 
 		case FreeRDP_TLSMaxVersion:

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -259,6 +259,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_OrderSupportFlags, FREERDP_SETTINGS_TYPE_UINT16, "FreeRDP_OrderSupportFlags" },
 	{ FreeRDP_OrderSupportFlagsEx, FREERDP_SETTINGS_TYPE_UINT16, "FreeRDP_OrderSupportFlagsEx" },
 	{ FreeRDP_ProxyPort, FREERDP_SETTINGS_TYPE_UINT16, "FreeRDP_ProxyPort" },
+	{ FreeRDP_SupportedColorDepths, FREERDP_SETTINGS_TYPE_UINT16, "FreeRDP_SupportedColorDepths" },
 	{ FreeRDP_TLSMaxVersion, FREERDP_SETTINGS_TYPE_UINT16, "FreeRDP_TLSMaxVersion" },
 	{ FreeRDP_TLSMinVersion, FREERDP_SETTINGS_TYPE_UINT16, "FreeRDP_TLSMinVersion" },
 	{ FreeRDP_TextANSICodePage, FREERDP_SETTINGS_TYPE_UINT16, "FreeRDP_TextANSICodePage" },

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -1332,6 +1332,7 @@ BOOL gcc_read_client_core_data(wStream* s, rdpMcs* mcs, UINT16 blockLength)
 BOOL gcc_write_client_core_data(wStream* s, const rdpMcs* mcs)
 {
 	char buffer[2048] = { 0 };
+	char dbuffer[2048] = { 0 };
 	WCHAR* clientName = NULL;
 	size_t clientNameLength;
 	BYTE connectionType;
@@ -1392,10 +1393,9 @@ BOOL gcc_write_client_core_data(wStream* s, const rdpMcs* mcs)
 	if (!Stream_EnsureRemainingCapacity(s, 6))
 		return FALSE;
 
-	WLog_DBG(TAG,
-	         "Sending highColorDepth=%s, supportedColorDepths=0x%04" PRIx16
-	         ", earlyCapabilityFlags=%s",
-	         HighColorToString(highColorDepth), SupportedColorDepths,
+	WLog_DBG(TAG, "Sending highColorDepth=%s, supportedColorDepths=%s, earlyCapabilityFlags=%s",
+	         HighColorToString(highColorDepth),
+	         freerdp_supported_color_depths_string(SupportedColorDepths, dbuffer, sizeof(dbuffer)),
 	         rdp_early_client_caps_string(earlyCapabilityFlags, buffer, sizeof(buffer)));
 	Stream_Write_UINT16(s, highColorDepth);       /* highColorDepth */
 	Stream_Write_UINT16(s, SupportedColorDepths); /* supportedColorDepths */

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -356,6 +356,11 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	if (!freerdp_server_license_issuers_copy(settings, issuers, ARRAYSIZE(issuers)))
 		goto out_fail;
 
+	if (!freerdp_settings_set_uint16(settings, FreeRDP_SupportedColorDepths,
+	                                 RNS_UD_32BPP_SUPPORT | RNS_UD_24BPP_SUPPORT |
+	                                     RNS_UD_16BPP_SUPPORT | RNS_UD_15BPP_SUPPORT))
+		goto out_fail;
+
 	if (!freerdp_settings_set_bool(settings, FreeRDP_UnicodeInput, TRUE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_HasHorizontalWheel, TRUE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_HasExtendedMouseEvent, TRUE) ||

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -195,6 +195,7 @@ static const size_t uint16_list_indices[] = {
 	FreeRDP_OrderSupportFlags,
 	FreeRDP_OrderSupportFlagsEx,
 	FreeRDP_ProxyPort,
+	FreeRDP_SupportedColorDepths,
 	FreeRDP_TLSMaxVersion,
 	FreeRDP_TLSMinVersion,
 	FreeRDP_TextANSICodePage,


### PR DESCRIPTION
* Expose `SupportedColorDepths` via `rdpSettings`
* Do not insist on `32bpp` for `gfx` or `rfx` modes