### PR TITLE
pointer: Rename position to hotspot position in Color Pointer Update

### DIFF
--- a/include/freerdp/pointer.h
+++ b/include/freerdp/pointer.h
@@ -50,13 +50,13 @@ extern "C"
 
 	typedef struct
 	{
-		UINT32 cacheIndex;
-		UINT32 xPos;
-		UINT32 yPos;
-		UINT32 width;
-		UINT32 height;
-		UINT32 lengthAndMask;
-		UINT32 lengthXorMask;
+		UINT16 cacheIndex;
+		UINT16 hotSpotX;
+		UINT16 hotSpotY;
+		UINT16 width;
+		UINT16 height;
+		UINT16 lengthAndMask;
+		UINT16 lengthXorMask;
 		BYTE* xorMaskData;
 		BYTE* andMaskData;
 	} POINTER_COLOR_UPDATE;

--- a/libfreerdp/cache/pointer.c
+++ b/libfreerdp/cache/pointer.c
@@ -148,8 +148,8 @@ static BOOL update_pointer_color(rdpContext* context, const POINTER_COLOR_UPDATE
 	if (pointer == NULL)
 		return FALSE;
 	pointer->xorBpp = 24;
-	pointer->xPos = pointer_color->xPos;
-	pointer->yPos = pointer_color->yPos;
+	pointer->xPos = pointer_color->hotSpotX;
+	pointer->yPos = pointer_color->hotSpotY;
 	pointer->width = pointer_color->width;
 	pointer->height = pointer_color->height;
 
@@ -224,8 +224,8 @@ static BOOL update_pointer_new(rdpContext* context, const POINTER_NEW_UPDATE* po
 		return FALSE;
 
 	pointer->xorBpp = pointer_new->xorBpp;
-	pointer->xPos = pointer_new->colorPtrAttr.xPos;
-	pointer->yPos = pointer_new->colorPtrAttr.yPos;
+	pointer->xPos = pointer_new->colorPtrAttr.hotSpotX;
+	pointer->yPos = pointer_new->colorPtrAttr.hotSpotY;
 	pointer->width = pointer_new->colorPtrAttr.width;
 	pointer->height = pointer_new->colorPtrAttr.height;
 	if (!upate_pointer_copy_andxor(

--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -384,8 +384,8 @@ static BOOL _update_read_pointer_color(wStream* s, POINTER_COLOR_UPDATE* pointer
 		goto fail;
 
 	Stream_Read_UINT16(s, pointer_color->cacheIndex); /* cacheIndex (2 bytes) */
-	Stream_Read_UINT16(s, pointer_color->xPos);       /* xPos (2 bytes) */
-	Stream_Read_UINT16(s, pointer_color->yPos);       /* yPos (2 bytes) */
+	Stream_Read_UINT16(s, pointer_color->hotSpotX);   /* hotSpot.xPos (2 bytes) */
+	Stream_Read_UINT16(s, pointer_color->hotSpotY);   /* hotSpot.yPos (2 bytes) */
 	/**
 	 *  As stated in 2.2.9.1.1.4.4 Color Pointer Update:
 	 *  The maximum allowed pointer width/height is 96 pixels if the client indicated support
@@ -406,15 +406,15 @@ static BOOL _update_read_pointer_color(wStream* s, POINTER_COLOR_UPDATE* pointer
 
 	/**
 	 * There does not seem to be any documentation on why
-	 * xPos / yPos can be larger than width / height
+	 * hotSpot.xPos / hotSpot.yPos can be larger than width / height
 	 * so it is missing in documentation or a bug in implementation
 	 * 2.2.9.1.1.4.4 Color Pointer Update (TS_COLORPOINTERATTRIBUTE)
 	 */
-	if (pointer_color->xPos >= pointer_color->width)
-		pointer_color->xPos = 0;
+	if (pointer_color->hotSpotX >= pointer_color->width)
+		pointer_color->hotSpotX = 0;
 
-	if (pointer_color->yPos >= pointer_color->height)
-		pointer_color->yPos = 0;
+	if (pointer_color->hotSpotY >= pointer_color->height)
+		pointer_color->hotSpotY = 0;
 
 	if (pointer_color->lengthXorMask > 0)
 	{
@@ -525,8 +525,8 @@ static BOOL _update_read_pointer_large(wStream* s, POINTER_LARGE_UPDATE* pointer
 
 	Stream_Read_UINT16(s, pointer->xorBpp);
 	Stream_Read_UINT16(s, pointer->cacheIndex); /* cacheIndex (2 bytes) */
-	Stream_Read_UINT16(s, pointer->hotSpotX);   /* xPos (2 bytes) */
-	Stream_Read_UINT16(s, pointer->hotSpotY);   /* yPos (2 bytes) */
+	Stream_Read_UINT16(s, pointer->hotSpotX);   /* hotSpot.xPos (2 bytes) */
+	Stream_Read_UINT16(s, pointer->hotSpotY);   /* hotSpot.yPos (2 bytes) */
 
 	Stream_Read_UINT16(s, pointer->width);  /* width (2 bytes) */
 	Stream_Read_UINT16(s, pointer->height); /* height (2 bytes) */
@@ -2195,8 +2195,8 @@ static BOOL update_write_pointer_color(wStream* s, const POINTER_COLOR_UPDATE* p
 		return FALSE;
 
 	Stream_Write_UINT16(s, pointer_color->cacheIndex);
-	Stream_Write_UINT16(s, pointer_color->xPos);
-	Stream_Write_UINT16(s, pointer_color->yPos);
+	Stream_Write_UINT16(s, pointer_color->hotSpotX);
+	Stream_Write_UINT16(s, pointer_color->hotSpotY);
 	Stream_Write_UINT16(s, pointer_color->width);
 	Stream_Write_UINT16(s, pointer_color->height);
 	Stream_Write_UINT16(s, pointer_color->lengthAndMask);

--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -1987,8 +1987,8 @@ static int shadow_client_subsystem_process_message(rdpShadowClient* client, wMes
 			pointerNew.xorBpp = 24;
 			pointerColor = &(pointerNew.colorPtrAttr);
 			pointerColor->cacheIndex = 0;
-			pointerColor->xPos = msg->xHot;
-			pointerColor->yPos = msg->yHot;
+			pointerColor->hotSpotX = msg->xHot;
+			pointerColor->hotSpotY = msg->yHot;
 			pointerColor->width = msg->width;
 			pointerColor->height = msg->height;
 			pointerColor->lengthAndMask = msg->lengthAndMask;


### PR DESCRIPTION
Quoting the commit message here:

```
The attributes xPos and yPos for a Color Pointer Update are confusing,
as they may be confused with the xPos and yPos of the pointer bitmap on
the actual screen.
Rename these attributes to what they actually represent, and that is the
hotspot position.
xPos and yPos are still members of the hotspot. However, hotSpotX and
hotSpotY are much more clearer.
In addition to that, the Large Pointer Update uses the same names for
the hotspot coordinates.
```