### PR TITLE
[server,proxy] ensure PEM length is strlen(pem) + 1

### DIFF
--- a/server/proxy/pf_config.c
+++ b/server/proxy/pf_config.c
@@ -410,7 +410,7 @@ static char* pf_config_decode_base64(const char* data, const char* name, size_t*
 		return NULL;
 	}
 
-	*pLength = decoded_length;
+	*pLength = strnlen(decoded, decoded_length) + 1;
 	return decoded;
 }
 


### PR DESCRIPTION
The decoded base64 data might contain PEM with/without/with multiple '\0' at the end of the string. We do not want to drag this through our code so ensure the length matches the string length including '\0'