### PR TITLE
rdpecam/server: Remove wrong assertion

### DIFF
--- a/channels/rdpecam/server/camera_device_main.c
+++ b/channels/rdpecam/server/camera_device_main.c
@@ -685,8 +685,6 @@ static wStream* device_server_packet_new(size_t size, BYTE version, BYTE message
 {
 	wStream* s;
 
-	WINPR_ASSERT(size > 0);
-
 	/* Allocate what we need plus header bytes */
 	s = Stream_New(NULL, size + CAM_HEADER_SIZE);
 	if (!s)


### PR DESCRIPTION
Quoting the commit message here:

```
Some PDUs, like the Activate Device Request only contain the header.
As a result, the size of the rest of the PDU is 0.
The assertion for the PDU size in device_server_packet_new only 
considers the size of the body of the PDU.
When that value is 0, the assertion is hit and the server implementation
crashes.

To fix this issue, simply remove this assertion. Since the allocation 
size is always at least the header size, there won't ever be an attempt
to create a stream with a size of 0.
```

I honestly don't know why this crash is not hit in `stable-2.0`. The code is literally the same there.