### PR TITLE
[stable-2.0] rdpecam/server: Remove wrong assertion

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 Fixed issues:
 * Backported #8690: Update h264 to use new FFMPEG API
 * Backported #7306: early bail from update_read_window_state_order breaks protocol
+* Backported #8903: rdpecam/server: Remove wrong assertion
 
 # 2023-02-16 Version 2.10.0
 

--- a/channels/rdpecam/server/camera_device_main.c
+++ b/channels/rdpecam/server/camera_device_main.c
@@ -686,8 +686,6 @@ static wStream* device_server_packet_new(size_t size, BYTE version, BYTE message
 {
 	wStream* s;
 
-	WINPR_ASSERT(size > 0);
-
 	/* Allocate what we need plus header bytes */
 	s = Stream_New(NULL, size + CAM_HEADER_SIZE);
 	if (!s)


### PR DESCRIPTION
Backport of https://github.com/FreeRDP/FreeRDP/pull/8903