### PR TITLE
gateway: Do not encrypt message during RPC NTLM auth

### DIFF
--- a/libfreerdp/core/credssp_auth.c
+++ b/libfreerdp/core/credssp_auth.c
@@ -498,6 +498,8 @@ BOOL credssp_auth_encrypt(rdpCredsspAuth* auth, const SecBuffer* plaintext, SecB
 	buffers[0].pvBuffer = buf;
 
 	buffers[1].BufferType = SECBUFFER_DATA;
+	if (plaintext->BufferType & SECBUFFER_READONLY)
+		buffers[1].BufferType |= SECBUFFER_READONLY;
 	buffers[1].pvBuffer = buf + auth->sizes.cbSecurityTrailer;
 	buffers[1].cbBuffer = plaintext->cbBuffer;
 	CopyMemory(buffers[1].pvBuffer, plaintext->pvBuffer, plaintext->cbBuffer);

--- a/libfreerdp/core/gateway/rpc_client.c
+++ b/libfreerdp/core/gateway/rpc_client.c
@@ -1064,6 +1064,7 @@ BOOL rpc_client_write_call(rdpRpc* rpc, wStream* s, UINT16 opnum)
 
 	plaintext.pvBuffer = buffer;
 	plaintext.cbBuffer = offset;
+	plaintext.BufferType = SECBUFFER_READONLY;
 	if (!credssp_auth_encrypt(auth, &plaintext, &ciphertext, &size, rpc->SendSeqNum++))
 		goto fail;
 


### PR DESCRIPTION
Commit 2de7a4c2498b6d2405cbf1209a58a42957698e44 introduced major changes in the gateway authentication code. One of these changes was to decouple NTLM specific authentication from the gateway code.

However with these changes, gateway authenciation with the old RPC code stopped working and returned an authentication error. The problem is that currently `credssp_auth_encrypt` encrypts the given message along creating a signature.

The old code prevented encryption of the message by specifying `SECBUFFER_READONLY` on the message buffer. The native Windows SSPI then leaves this buffer as-is and gateway authentication works again.

This fix only applies to Windows platforms using the native SSPI API. Interestingly this works on other platforms using the WinPR SSPI so there seems to be a difference between the implementations (but that's a topic for another PR).
