### PR TITLE
[channels,settings] add a setting to ignore invalid devices

### DIFF
--- a/channels/rdpdr/client/irp.c
+++ b/channels/rdpdr/client/irp.c
@@ -107,7 +107,7 @@ IRP* irp_new(DEVMAN* devman, wStreamPool* pool, wStream* s, wLog* log, UINT* err
 	if (!device)
 	{
 		if (error)
-			*error = ERROR_INVALID_PARAMETER;
+			*error = ERROR_DEV_NOT_EXIST;
 
 		return NULL;
 	}

--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -1067,6 +1067,8 @@ static UINT rdpdr_process_connect(rdpdrPlugin* rdpdr)
 	settings = rdpdr->rdpcontext->settings;
 	WINPR_ASSERT(settings);
 
+	rdpdr->ignoreInvalidDevices = settings->IgnoreInvalidDevices;
+
 	if (settings->ClientHostname)
 		strncpy(rdpdr->computerName, settings->ClientHostname, sizeof(rdpdr->computerName) - 1);
 	else
@@ -1411,7 +1413,7 @@ static UINT rdpdr_process_irp(rdpdrPlugin* rdpdr, wStream* s)
 	{
 		WLog_Print(rdpdr->log, WLOG_ERROR, "irp_new failed with %" PRIu32 "!", error);
 
-		if (error == CHANNEL_RC_OK)
+		if (error == CHANNEL_RC_OK || (error == ERROR_DEV_NOT_EXIST && rdpdr->ignoreInvalidDevices))
 		{
 			return dummy_irp_response(rdpdr, s);
 		}

--- a/channels/rdpdr/client/rdpdr_main.h
+++ b/channels/rdpdr/client/rdpdr_main.h
@@ -54,6 +54,7 @@ typedef struct
 	wMessageQueue* queue;
 
 	DEVMAN* devman;
+	BOOL ignoreInvalidDevices;
 
 	UINT16 serverVersionMajor;
 	UINT16 serverVersionMinor;

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -875,6 +875,7 @@ typedef struct
 #define FreeRDP_DeviceCount (4161)
 #define FreeRDP_DeviceArraySize (4162)
 #define FreeRDP_DeviceArray (4163)
+#define FreeRDP_IgnoreInvalidDevices (4164)
 #define FreeRDP_RedirectDrives (4288)
 #define FreeRDP_RedirectHomeDrive (4289)
 #define FreeRDP_DrivesToRedirect (4290)
@@ -1569,7 +1570,8 @@ struct rdp_settings
 	ALIGN64 UINT32 DeviceCount;         /* 4161 */
 	ALIGN64 UINT32 DeviceArraySize;     /* 4162 */
 	ALIGN64 RDPDR_DEVICE** DeviceArray; /* 4163 */
-	UINT64 padding4288[4288 - 4164];    /* 4164 */
+	ALIGN64 BOOL IgnoreInvalidDevices;  /* 4164 */
+	UINT64 padding4288[4288 - 4165];    /* 4165 */
 
 	/* Drive Redirection */
 	ALIGN64 BOOL RedirectDrives;     /* 4288 */

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -306,6 +306,9 @@ BOOL freerdp_settings_get_bool(const rdpSettings* settings, size_t id)
 		case FreeRDP_IgnoreCertificate:
 			return settings->IgnoreCertificate;
 
+		case FreeRDP_IgnoreInvalidDevices:
+			return settings->IgnoreInvalidDevices;
+
 		case FreeRDP_JpegCodec:
 			return settings->JpegCodec;
 
@@ -947,6 +950,10 @@ BOOL freerdp_settings_set_bool(rdpSettings* settings, size_t id, BOOL val)
 
 		case FreeRDP_IgnoreCertificate:
 			settings->IgnoreCertificate = cnv.c;
+			break;
+
+		case FreeRDP_IgnoreInvalidDevices:
+			settings->IgnoreInvalidDevices = cnv.c;
 			break;
 
 		case FreeRDP_JpegCodec:

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -130,6 +130,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_HiDefRemoteApp, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_HiDefRemoteApp" },
 	{ FreeRDP_IPv6Enabled, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_IPv6Enabled" },
 	{ FreeRDP_IgnoreCertificate, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_IgnoreCertificate" },
+	{ FreeRDP_IgnoreInvalidDevices, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_IgnoreInvalidDevices" },
 	{ FreeRDP_JpegCodec, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_JpegCodec" },
 	{ FreeRDP_KerberosRdgIsProxy, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_KerberosRdgIsProxy" },
 	{ FreeRDP_ListMonitors, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_ListMonitors" },

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -86,6 +86,7 @@ static const size_t bool_list_indices[] = {
 	FreeRDP_HiDefRemoteApp,
 	FreeRDP_IPv6Enabled,
 	FreeRDP_IgnoreCertificate,
+	FreeRDP_IgnoreInvalidDevices,
 	FreeRDP_JpegCodec,
 	FreeRDP_KerberosRdgIsProxy,
 	FreeRDP_ListMonitors,


### PR DESCRIPTION
Add a setting `IgnoreInvalidDevices`. This is an escape hatch to optionally revert the behaviour of [df4c076](https://github.com/devolutions/freerdp/commit/df4c076946bc8716b8bf3fb9e512374b57cca1cb) - in #8909 we see a case where a server sends an IRP for an non-existent device, despite all rdpdr forwarding options being disabled.

If `IgnoreInvalidDevices` is set to `TRUE`, `rdpdr` will send a dummy response instead of returning an error (and preventing the connection from succeeding).