### PR TITLE
rail: add missing server-side calls

### DIFF
--- a/channels/rail/server/rail_main.c
+++ b/channels/rail/server/rail_main.c
@@ -1295,6 +1295,46 @@ static UINT rail_recv_client_cloak_order(RailServerContext* context, RAIL_CLOAK*
 	return error;
 }
 
+static UINT rail_recv_client_text_scale_order(RailServerContext* context, wStream* s)
+{
+	UINT error;
+	UINT32 TextScaleFactor;
+
+	if (!context || !s)
+		return ERROR_INVALID_PARAMETER;
+
+	if (!Stream_CheckAndLogRequiredLength(TAG, s, 4))
+		return ERROR_INVALID_DATA;
+
+	Stream_Read_UINT32(s, TextScaleFactor);
+	IFCALLRET(context->ClientTextScale, error, context, TextScaleFactor);
+
+	if (error)
+		WLog_ERR(TAG, "context.TextScale failed with error %" PRIu32 "", error);
+
+	return error;
+}
+
+static UINT rail_recv_client_caret_blink(RailServerContext* context, wStream* s)
+{
+	UINT error;
+	UINT32 CaretBlinkRate;
+
+	if (!context || !s)
+		return ERROR_INVALID_PARAMETER;
+
+	if (!Stream_CheckAndLogRequiredLength(TAG, s, 4))
+		return ERROR_INVALID_DATA;
+
+	Stream_Read_UINT32(s, CaretBlinkRate);
+	IFCALLRET(context->ClientCaretBlinkRate, error, context, CaretBlinkRate);
+
+	if (error)
+		WLog_ERR(TAG, "context.CaretBlinkRate failed with error %" PRIu32 "", error);
+
+	return error;
+}
+
 static DWORD WINAPI rail_server_thread(LPVOID arg)
 {
 	RailServerContext* context = (RailServerContext*)arg;
@@ -1667,6 +1707,16 @@ UINT rail_server_handle_messages(RailServerContext* context)
 		{
 			RAIL_CLOAK cloak;
 			return rail_recv_client_cloak_order(context, &cloak, s);
+		}
+
+		case TS_RAIL_ORDER_TEXTSCALEINFO:
+		{
+			return rail_recv_client_text_scale_order(context, s);
+		}
+
+		case TS_RAIL_ORDER_CARETBLINKINFO:
+		{
+			return rail_recv_client_caret_blink(context, s);
 		}
 
 		default:

--- a/include/freerdp/server/rail.h
+++ b/include/freerdp/server/rail.h
@@ -66,6 +66,8 @@ extern "C"
 	typedef UINT (*psRailClientCompartmentInfo)(RailServerContext* context,
 	                                            const RAIL_COMPARTMENT_INFO_ORDER* compartmentInfo);
 	typedef UINT (*psRailClientCloak)(RailServerContext* context, const RAIL_CLOAK* cloak);
+	typedef UINT (*psRailClientTextScale)(RailServerContext* context, UINT32 TextScale);
+	typedef UINT (*psRailClientCaretBlinkRate)(RailServerContext* context, UINT32 CaretBlinkRate);
 
 	/* Server side messages sending methods */
 	typedef UINT (*psRailServerHandshake)(RailServerContext* context,
@@ -118,6 +120,8 @@ extern "C"
 		psRailClientLanguageImeInfo ClientLanguageImeInfo;
 		psRailClientCompartmentInfo ClientCompartmentInfo;
 		psRailClientCloak ClientCloak;
+		psRailClientTextScale ClientTextScale;
+		psRailClientCaretBlinkRate ClientCaretBlinkRate;
 
 		/* Methods for sending server side messages */
 		psRailServerHandshake ServerHandshake;


### PR DESCRIPTION
This patch adds support for text_scale and caret_blink messages on the server-side.