### PR TITLE
mcs: drop a server-side warning on FreeRDP_ChannelDefArray::len

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -1858,7 +1858,7 @@ BOOL rdp_channels_from_mcs(rdpSettings* settings, const rdpRdp* rdp)
 	WINPR_ASSERT(mcs);
 
 	if (!freerdp_settings_set_pointer_len(settings, FreeRDP_ChannelDefArray, NULL,
-	                                      mcs->channelCount))
+	                                      CHANNEL_MAX_COUNT))
 		return FALSE;
 
 	for (x = 0; x < mcs->channelCount; x++)
@@ -1872,7 +1872,7 @@ BOOL rdp_channels_from_mcs(rdpSettings* settings, const rdpRdp* rdp)
 			return FALSE;
 	}
 
-	return TRUE;
+	return freerdp_settings_set_uint32(settings, FreeRDP_ChannelCount, mcs->channelCount);
 }
 
 /* Here we are in client state CONFIRM_ACTIVE.

--- a/libfreerdp/core/mcs.c
+++ b/libfreerdp/core/mcs.c
@@ -1468,9 +1468,6 @@ BOOL mcs_server_apply_to_settings(const rdpMcs* mcs, rdpSettings* settings)
 
 	if (!freerdp_settings_set_uint32(settings, FreeRDP_ChannelCount, mcs->channelCount))
 		goto fail;
-	if (!freerdp_settings_set_pointer_len(settings, FreeRDP_ChannelDefArray, NULL,
-	                                      mcs->channelCount))
-		goto fail;
 
 	for (UINT32 x = 0; x < mcs->channelCount; x++)
 	{


### PR DESCRIPTION
Server side we often see "FreeRDP_ChannelDefArray::len expected to be >= 31, but have XXX", where XXX is lower than 31.

This patche fixes that, the old code was setting the size of ChannelDefArray to the number of ChannelCount, which is usually not what we want. We want to keep it to 31 and have ChannelCount indicate how many of these channels are used.
