### PR TITLE
core: Fix possible memory leak in smartcard certificate enumeration

### DIFF
--- a/libfreerdp/core/smartcardlogon.c
+++ b/libfreerdp/core/smartcardlogon.c
@@ -132,7 +132,10 @@ static BOOL add_cert_to_list(SmartcardCertInfo*** certInfoList, size_t* count,
 	for (size_t i = 0; i < curCount; ++i)
 	{
 		if (_wcscmp(curInfoList[i]->containerName, certInfo->containerName) == 0)
+		{
+			smartcardCertInfo_Free(certInfo);
 			return TRUE;
+		}
 	}
 
 	curInfoList = realloc(curInfoList, sizeof(SmartcardCertInfo*) * (curCount + 1));


### PR DESCRIPTION
When enumerating smartcard certificates we check if we have duplicates in our certificate list. In case we detect a duplicate we just return `TRUE` (indicating that we consumed the certificate info) but do not free the smartcard info instance.
