### PR TITLE
proxy: fix treatment of client channels

### DIFF
--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -394,7 +394,7 @@ static BOOL pf_client_load_channels(freerdp* instance)
 		{
 			CHANNEL_DEF* channels = (CHANNEL_DEF*)freerdp_settings_get_pointer_array_writable(
 			    settings, FreeRDP_ChannelDefArray, 0);
-			size_t x, size = freerdp_settings_get_uint32(settings, FreeRDP_ChannelDefArraySize);
+			size_t x, size = freerdp_settings_get_uint32(settings, FreeRDP_ChannelCount);
 			UINT32 id = MCS_GLOBAL_CHANNEL_ID + 1;
 
 			WINPR_ASSERT(channels || (size == 0));


### PR DESCRIPTION
Iteration on channels was done with the wrong counter leading to incorrect behavior.