### PR TITLE
[core,settigs] default to 32bpp session color depth

### DIFF
--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -388,7 +388,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	    !freerdp_settings_set_bool(settings, FreeRDP_GrabKeyboard, TRUE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_Decorations, TRUE) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_RdpVersion, RDP_VERSION_10_11) ||
-	    !freerdp_settings_set_uint32(settings, FreeRDP_ColorDepth, 16) ||
+	    !freerdp_settings_set_uint32(settings, FreeRDP_ColorDepth, 32) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_AadSecurity, FALSE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_ExtSecurity, FALSE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_NlaSecurity, TRUE) ||


### PR DESCRIPTION
there is no real reason to default to `16bpp` nowadays.