### PR TITLE
[winpr,input] fix GetKeycodeFromVirtualKeyCode(code, KEYCODE_TYPE_XKB)

### DIFF
--- a/client/Mac/MRDPView.m
+++ b/client/Mac/MRDPView.m
@@ -493,7 +493,7 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 		keyCode = fixKeyCode(keyCode, keyChar, mfc->appleKeyboardType);
 	}
 
-	vkcode = GetVirtualKeyCodeFromKeycode(keyCode + 8, KEYCODE_TYPE_APPLE);
+	vkcode = GetVirtualKeyCodeFromKeycode(keyCode, WINPR_KEYCODE_TYPE_APPLE);
 	scancode = GetVirtualScanCodeFromVirtualKeyCode(vkcode, 4);
 	keyFlags |= (scancode & KBDEXT) ? KBDEXT : 0;
 	scancode &= 0xFF;
@@ -530,7 +530,7 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 		keyCode = fixKeyCode(keyCode, keyChar, mfc->appleKeyboardType);
 	}
 
-	vkcode = GetVirtualKeyCodeFromKeycode(keyCode + 8, KEYCODE_TYPE_APPLE);
+	vkcode = GetVirtualKeyCodeFromKeycode(keyCode, WINPR_KEYCODE_TYPE_APPLE);
 	scancode = GetVirtualScanCodeFromVirtualKeyCode(vkcode, 4);
 	keyFlags |= (scancode & KBDEXT) ? KBDEXT : 0;
 	scancode &= 0xFF;
@@ -557,9 +557,9 @@ DWORD fixKeyCode(DWORD keyCode, unichar keyChar, enum APPLE_KEYBOARD_TYPE type)
 		return;
 
 	keyFlags = 0;
-	key = [event keyCode] + 8;
+	key = [event keyCode];
 	modFlags = [event modifierFlags] & NSEventModifierFlagDeviceIndependentFlagsMask;
-	vkcode = GetVirtualKeyCodeFromKeycode(key, KEYCODE_TYPE_APPLE);
+	vkcode = GetVirtualKeyCodeFromKeycode(key, WINPR_KEYCODE_TYPE_APPLE);
 	scancode = GetVirtualScanCodeFromVirtualKeyCode(vkcode, 4);
 	keyFlags |= (scancode & KBDEXT) ? KBDEXT : 0;
 	scancode &= 0xFF;

--- a/libfreerdp/locale/keyboard.c
+++ b/libfreerdp/locale/keyboard.c
@@ -267,7 +267,7 @@ static int freerdp_keyboard_init_apple(DWORD* keyboardLayoutId,
 	for (keycode = 0; keycode < 256; keycode++)
 	{
 		vkcode = keycode_to_vkcode[keycode] =
-		    GetVirtualKeyCodeFromKeycode(keycode, KEYCODE_TYPE_APPLE);
+		    GetVirtualKeyCodeFromKeycode(keycode, WINPR_KEYCODE_TYPE_APPLE);
 		x11_keycode_to_rdp_scancode[keycode] =
 		    GetVirtualScanCodeFromVirtualKeyCode(vkcode, WINPR_KBD_TYPE_IBM_ENHANCED);
 	}
@@ -287,7 +287,7 @@ static int freerdp_keyboard_init_x11_evdev(DWORD* keyboardLayoutId,
 	for (keycode = 0; keycode < 256; keycode++)
 	{
 		vkcode = keycode_to_vkcode[keycode] =
-		    GetVirtualKeyCodeFromKeycode(keycode, KEYCODE_TYPE_XKB);
+		    GetVirtualKeyCodeFromKeycode(keycode, WINPR_KEYCODE_TYPE_XKB);
 		x11_keycode_to_rdp_scancode[keycode] =
 		    GetVirtualScanCodeFromVirtualKeyCode(vkcode, WINPR_KBD_TYPE_IBM_ENHANCED);
 	}

--- a/server/shadow/Mac/mac_shadow.c
+++ b/server/shadow/Mac/mac_shadow.c
@@ -61,12 +61,8 @@ static BOOL mac_shadow_input_keyboard_event(rdpShadowSubsystem* subsystem, rdpSh
 	if (extended)
 		vkcode |= KBDEXT;
 
-	keycode = GetKeycodeFromVirtualKeyCode(vkcode, KEYCODE_TYPE_APPLE);
+	keycode = GetKeycodeFromVirtualKeyCode(vkcode, WINPR_KEYCODE_TYPE_APPLE);
 
-	if (keycode < 8)
-		return TRUE;
-
-	keycode -= 8;
 	source = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
 
 	if (flags & KBD_FLAGS_DOWN)

--- a/server/shadow/X11/x11_shadow.c
+++ b/server/shadow/X11/x11_shadow.c
@@ -230,7 +230,7 @@ static BOOL x11_shadow_input_keyboard_event(rdpShadowSubsystem* subsystem, rdpSh
 	if (extended)
 		vkcode |= KBDEXT;
 
-	keycode = GetKeycodeFromVirtualKeyCode(vkcode, KEYCODE_TYPE_XKB);
+	keycode = GetKeycodeFromVirtualKeyCode(vkcode, WINPR_KEYCODE_TYPE_XKB);
 
 	if (keycode != 0)
 	{

--- a/winpr/include/winpr/input.h
+++ b/winpr/include/winpr/input.h
@@ -891,12 +891,15 @@ extern "C"
 	WINPR_API DWORD GetVirtualScanCodeFromVirtualKeyCode(DWORD vkcode,
 	                                                     DWORD /* WINPR_KBD_TYPE */ dwKeyboardType);
 
-#define KEYCODE_TYPE_APPLE 0x00000001
-#define KEYCODE_TYPE_EVDEV 0x00000002
-#define KEYCODE_TYPE_XKB 0x00000003
+	typedef enum
+	{
+		WINPR_KEYCODE_TYPE_APPLE = 0x00000001,
+		WINPR_KEYCODE_TYPE_EVDEV = 0x00000002,
+		WINPR_KEYCODE_TYPE_XKB = 0x00000003
+	} WINPR_KEYCODE_TYPE;
 
-	WINPR_API DWORD GetVirtualKeyCodeFromKeycode(DWORD keycode, DWORD dwFlags);
-	WINPR_API DWORD GetKeycodeFromVirtualKeyCode(DWORD keycode, DWORD dwFlags);
+	WINPR_API DWORD GetVirtualKeyCodeFromKeycode(DWORD keycode, WINPR_KEYCODE_TYPE type);
+	WINPR_API DWORD GetKeycodeFromVirtualKeyCode(DWORD keycode, WINPR_KEYCODE_TYPE type);
 
 #ifdef __cplusplus
 }

--- a/winpr/libwinpr/input/keycode.c
+++ b/winpr/libwinpr/input/keycode.c
@@ -878,41 +878,32 @@ DWORD GetVirtualKeyCodeFromKeycode(DWORD keycode, DWORD dwFlags)
 DWORD GetKeycodeFromVirtualKeyCode(DWORD vkcode, DWORD dwFlags)
 {
 	DWORD index;
-	DWORD keycode = 0;
+	DWORD* targetArray;
+	size_t targetSize;
 
-	if (dwFlags & KEYCODE_TYPE_APPLE)
+	switch (dwFlags)
 	{
-		for (index = 0; index < ARRAYSIZE(KEYCODE_TO_VKCODE_APPLE); index++)
-		{
-			if (vkcode == KEYCODE_TO_VKCODE_APPLE[index])
-			{
-				keycode = index;
-				break;
-			}
-		}
-	}
-	else if (dwFlags & KEYCODE_TYPE_EVDEV)
-	{
-		for (index = 0; index < ARRAYSIZE(KEYCODE_TO_VKCODE_EVDEV); index++)
-		{
-			if (vkcode == KEYCODE_TO_VKCODE_EVDEV[index])
-			{
-				keycode = index;
-				break;
-			}
-		}
-	}
-	else if (dwFlags & KEYCODE_TYPE_XKB)
-	{
-		for (index = 0; index < ARRAYSIZE(KEYCODE_TO_VKCODE_XKB); index++)
-		{
-			if (vkcode == KEYCODE_TO_VKCODE_XKB[index])
-			{
-				keycode = index;
-				break;
-			}
-		}
+		case KEYCODE_TYPE_APPLE:
+			targetArray = KEYCODE_TO_VKCODE_APPLE;
+			targetSize = ARRAYSIZE(KEYCODE_TO_VKCODE_APPLE);
+			break;
+		case KEYCODE_TYPE_EVDEV:
+			targetArray = KEYCODE_TO_VKCODE_EVDEV;
+			targetSize = ARRAYSIZE(KEYCODE_TO_VKCODE_EVDEV);
+			break;
+		case KEYCODE_TYPE_XKB:
+			targetArray = KEYCODE_TO_VKCODE_XKB;
+			targetSize = ARRAYSIZE(KEYCODE_TO_VKCODE_XKB);
+			break;
+		default:
+			return 0;
 	}
 
-	return keycode;
+	for (index = 0; index < targetSize; index++)
+	{
+		if (vkcode == targetArray[index])
+			return index;
+	}
+
+	return 0;
 }

--- a/winpr/libwinpr/input/keycode.c
+++ b/winpr/libwinpr/input/keycode.c
@@ -847,26 +847,28 @@ static DWORD KEYCODE_TO_VKCODE_XKB[256] = {
 	0                              /* 255 */
 };
 
-DWORD GetVirtualKeyCodeFromKeycode(DWORD keycode, DWORD dwFlags)
+DWORD GetVirtualKeyCodeFromKeycode(DWORD keycode, WINPR_KEYCODE_TYPE type)
 {
 	DWORD vkcode;
 
 	vkcode = VK_NONE;
 
-	if (dwFlags & KEYCODE_TYPE_APPLE)
+	switch (type)
 	{
-		if (keycode < 0xFF)
-			vkcode = KEYCODE_TO_VKCODE_APPLE[keycode & 0xFF];
-	}
-	else if (dwFlags & KEYCODE_TYPE_EVDEV)
-	{
-		if (keycode < 0xFF)
-			vkcode = KEYCODE_TO_VKCODE_EVDEV[keycode & 0xFF];
-	}
-	else if (dwFlags & KEYCODE_TYPE_XKB)
-	{
-		if (keycode < 0xFF)
-			vkcode = KEYCODE_TO_VKCODE_XKB[keycode & 0xFF];
+		case WINPR_KEYCODE_TYPE_APPLE:
+			if (keycode < 0xFF)
+				vkcode = KEYCODE_TO_VKCODE_APPLE[keycode & 0xFF];
+			break;
+		case WINPR_KEYCODE_TYPE_EVDEV:
+			if (keycode < 0xFF)
+				vkcode = KEYCODE_TO_VKCODE_EVDEV[keycode & 0xFF];
+			break;
+		case WINPR_KEYCODE_TYPE_XKB:
+			if (keycode < 0xFF)
+				vkcode = KEYCODE_TO_VKCODE_XKB[keycode & 0xFF];
+			break;
+		default:
+			break;
 	}
 
 	if (!vkcode)
@@ -875,23 +877,23 @@ DWORD GetVirtualKeyCodeFromKeycode(DWORD keycode, DWORD dwFlags)
 	return vkcode;
 }
 
-DWORD GetKeycodeFromVirtualKeyCode(DWORD vkcode, DWORD dwFlags)
+DWORD GetKeycodeFromVirtualKeyCode(DWORD vkcode, WINPR_KEYCODE_TYPE type)
 {
 	DWORD index;
 	DWORD* targetArray;
 	size_t targetSize;
 
-	switch (dwFlags)
+	switch (type)
 	{
-		case KEYCODE_TYPE_APPLE:
+		case WINPR_KEYCODE_TYPE_APPLE:
 			targetArray = KEYCODE_TO_VKCODE_APPLE;
 			targetSize = ARRAYSIZE(KEYCODE_TO_VKCODE_APPLE);
 			break;
-		case KEYCODE_TYPE_EVDEV:
+		case WINPR_KEYCODE_TYPE_EVDEV:
 			targetArray = KEYCODE_TO_VKCODE_EVDEV;
 			targetSize = ARRAYSIZE(KEYCODE_TO_VKCODE_EVDEV);
 			break;
-		case KEYCODE_TYPE_XKB:
+		case WINPR_KEYCODE_TYPE_XKB:
 			targetArray = KEYCODE_TO_VKCODE_XKB;
 			targetSize = ARRAYSIZE(KEYCODE_TO_VKCODE_XKB);
 			break;


### PR DESCRIPTION
As KEYCODE_TYPE_XKB is 3, in the previous code we were doing some "and masking" and so when calling GetKeycodeFromVirtualKeyCode(code, KEYCODE_TYPE_XKB), the function was always interpreting the virtual key code with the apple layout. This patch fixes that and also mutualize the search in the code array.