### PR TITLE
[smartcard] fix smartcard listing with /kerberos:pkcs11-module:<path>

### DIFF
--- a/libfreerdp/core/smartcardlogon.c
+++ b/libfreerdp/core/smartcardlogon.c
@@ -603,6 +603,9 @@ static BOOL smartcard_hw_enumerateCerts(const rdpSettings* settings, LPCWSTR csp
 		/* load a unique CSP by pkcs11 module path */
 		LPCSTR paths[] = { Pkcs11Module, NULL };
 
+		if (!csp)
+			csp = MS_SCARD_PROV;
+
 		status = winpr_NCryptOpenStorageProviderEx(&provider, csp, 0, paths);
 		if (status != ERROR_SUCCESS)
 		{


### PR DESCRIPTION
When a PKCS11 module was provided, the CSP could not be set by command line arguments, leading to an error when loading the ncrypt module, and an empty smartcard list.