### PR TITLE
core: fix api in a fuzzing test

### DIFF
--- a/libfreerdp/core/test/TestFuzzCryptoCertificateDataSetPEM.c
+++ b/libfreerdp/core/test/TestFuzzCryptoCertificateDataSetPEM.c
@@ -1,23 +1,23 @@
 #include <stddef.h>
 #include <stdint.h>
-#include <freerdp/crypto/certificate.h>
+#include <freerdp/crypto/certificate_store.h>
 
 int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
 {
-	char* buf = calloc(Size + 1, sizeof(char));
-	rdpCertificateData* cert_data = certificate_data_new("somehost", 1234);
-	if (!buf || !cert_data)
+	char* pem = calloc(Size + 1, sizeof(char));
+	if (pem == NULL)
 		goto cleanup;
+	memcpy(pem, Data, Size);
+	pem[Size] = '\0';
 
-	memcpy(buf, Data, Size);
-	if (!certificate_data_set_pem(cert_data, buf))
-	{
+	rdpCertificateData* data = NULL;
+	data = freerdp_certificate_data_new_from_pem("somehost", 1234, pem, Size);
+	if (!data)
 		goto cleanup;
-	}
 
 cleanup:
-	certificate_data_free(cert_data);
-	free(buf);
+	freerdp_certificate_data_free(data);
+	free(pem);
 
 	return 0;
 }


### PR DESCRIPTION
API has been changed in d1ddf7a6c7781ae4963ebfc3070a4b7fd5d1c97d ("[crypto,test] update to new cert/crypto API").