### PR TITLE
[client,common] add command line argument /from

### DIFF
--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -163,6 +163,10 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "smooth fonts (ClearType)" },
 	{ "frame-ack", COMMAND_LINE_VALUE_REQUIRED, "<number>", NULL, NULL, -1, NULL,
 	  "Number of frame acknowledgement" },
+	{ "args-from", COMMAND_LINE_VALUE_REQUIRED, "<file>|stdin|fd:<number>", NULL, NULL, -1, NULL,
+	  "Read command line from a file, stdin or file descriptor. This argument can not be combined "
+	  "with any other. "
+	  "Provide one argument per line." },
 	{ "from-stdin", COMMAND_LINE_VALUE_OPTIONAL, "force", NULL, NULL, -1, NULL,
 	  "Read credentials from stdin. With <force> the prompt is done before connection, otherwise "
 	  "on server request." },


### PR DESCRIPTION
This new argument allows reading all command line options from a file or from stdin. It is a standalone argument and can not be combined with any other.
