### PR TITLE
[codecs] fix freerdp_bitmap_planar_context_new call

### DIFF
--- a/libfreerdp/core/codecs.c
+++ b/libfreerdp/core/codecs.c
@@ -110,7 +110,7 @@ BOOL freerdp_client_codecs_prepare(rdpCodecs* codecs, UINT32 flags, UINT32 width
 
 	if ((flags & FREERDP_CODEC_PLANAR))
 	{
-		if (!(codecs->planar = freerdp_bitmap_planar_context_new(FALSE, 64, 64)))
+		if (!(codecs->planar = freerdp_bitmap_planar_context_new(0, 64, 64)))
 		{
 			WLog_ERR(TAG, "Failed to create planar bitmap codec context");
 			return FALSE;


### PR DESCRIPTION
freerdp_bitmap_planar_context_new() expects flags as first argument not a BOOL, even if giving FALSE ends with the same result, it makes it more clear.

This is a micro, mostly cosmetic fix. Shouldn't we enable planar compression by default with planar (PLANAR_FORMAT_HEADER_RLE instead of 0) ?