### PR TITLE
[cmake] Enable static building

### DIFF
--- a/cmake/ConfigOptions.cmake
+++ b/cmake/ConfigOptions.cmake
@@ -199,6 +199,11 @@ if (BUILD_FUZZERS)
 
     set(BUILD_TESTING ON)
 
+    if (BUILD_SHARED_LIBS STREQUAL "OFF")
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+        set(CMAKE_CXX_FLAGS "-static ${CMAKE_CXX_FLAGS}")
+    endif()
+
     # A special target with fuzzer and sanitizer flags.
     add_library(fuzzer_config INTERFACE)
 

--- a/packaging/deb/freerdp-nightly/rules
+++ b/packaging/deb/freerdp-nightly/rules
@@ -4,7 +4,7 @@ NULL =
 
 DEB_HOST_ARCH=$(shell dpkg-architecture -qDEB_HOST_ARCH)
 
-SANATIZE_ADDRESS = -DWITH_SANITIZE_ADDRESS=ON
+SANITIZE_ADDRESS = -DWITH_SANITIZE_ADDRESS=ON
 
 DEB_CMAKE_EXTRA_FLAGS :=  -GNinja \
                           -DCMAKE_SKIP_RPATH=FALSE \
@@ -29,7 +29,7 @@ DEB_CMAKE_EXTRA_FLAGS :=  -GNinja \
                           -DCMAKE_INSTALL_INCLUDEDIR=include \
                           -DCMAKE_INSTALL_LIBDIR=lib \
                           -DNO_CMAKE_PACKAGE_REGISTRY=ON \
-                          $(SANATIZE_ADDRESS) \
+                          $(SANITIZE_ADDRESS) \
                           $(NULL)
 
 %:


### PR DESCRIPTION
OSS Fuzz strongly recommends static linking for tests [1]. Patch enables static linking for a fuzzing test added in commit
2ad14696124b5a7689a323f56859efb329a3d25c ("Add fuzzer for certificate_data_set_pem()").

1. https://google.github.io/oss-fuzz/further-reading/fuzzer-environment/#runtime-dependencies

