### PR TITLE
Clip dir fix

### DIFF
--- a/channels/cliprdr/client/cliprdr_main.h
+++ b/channels/cliprdr/client/cliprdr_main.h
@@ -49,6 +49,7 @@ typedef struct
 	BOOL fileClipNoFilePaths;
 	BOOL canLockClipData;
 	BOOL hasHugeFileSupport;
+	BOOL initialFormatListSent;
 } cliprdrPlugin;
 
 CliprdrClientContext* cliprdr_get_client_interface(cliprdrPlugin* cliprdr);


### PR DESCRIPTION
* Improved version of #9012
* Initially client must send a format list (we use an empty one) to enable server side clipboard updates.
* `xfreerdp` should only send formats that are actually in the clipboard instead of every supported format