### PR TITLE
[channels,rdpdr] enforce client state checks

### DIFF
--- a/channels/rdpdr/client/rdpdr_capabilities.c
+++ b/channels/rdpdr/client/rdpdr_capabilities.c
@@ -149,6 +149,9 @@ UINT rdpdr_process_capability_request(rdpdrPlugin* rdpdr, wStream* s)
 	if (!rdpdr || !s)
 		return CHANNEL_RC_NULL_DATA;
 
+	WINPR_ASSERT(rdpdr->state == RDPDR_CHANNEL_STATE_SERVER_CAPS);
+	rdpdr_state_advance(rdpdr, RDPDR_CHANNEL_STATE_CLIENT_CAPS);
+
 	if (!Stream_CheckAndLogRequiredLengthWLog(rdpdr->log, s, 4))
 		return ERROR_INVALID_DATA;
 

--- a/channels/rdpdr/client/rdpdr_main.h
+++ b/channels/rdpdr/client/rdpdr_main.h
@@ -42,11 +42,25 @@
 #include <CoreServices/CoreServices.h>
 #endif
 
+enum RDPDR_CHANNEL_STATE
+{
+	RDPDR_CHANNEL_STATE_INITIAL = 0,
+	RDPDR_CHANNEL_STATE_ANNOUNCE,
+	RDPDR_CHANNEL_STATE_ANNOUNCE_REPLY,
+	RDPDR_CHANNEL_STATE_NAME_REQUEST,
+	RDPDR_CHANNEL_STATE_SERVER_CAPS,
+	RDPDR_CHANNEL_STATE_CLIENT_CAPS,
+	RDPDR_CHANNEL_STATE_CLIENTID_CONFIRM,
+	RDPDR_CHANNEL_STATE_READY,
+	RDPDR_CHANNEL_STATE_USER_LOGGEDON
+};
+
 typedef struct
 {
 	CHANNEL_DEF channelDef;
 	CHANNEL_ENTRY_POINTS_FREERDP_EX channelEntryPoints;
 
+	enum RDPDR_CHANNEL_STATE state;
 	HANDLE thread;
 	wStream* data_in;
 	void* InitHandle;
@@ -81,6 +95,7 @@ typedef struct
 	wLog* log;
 } rdpdrPlugin;
 
+BOOL rdpdr_state_advance(rdpdrPlugin* rdpdr, enum RDPDR_CHANNEL_STATE next);
 UINT rdpdr_send(rdpdrPlugin* rdpdr, wStream* s);
 
 #endif /* FREERDP_CHANNEL_RDPDR_CLIENT_MAIN_H */


### PR DESCRIPTION
Keep track of client channel state and abort on invalid messages for a certain state
