### PR TITLE
cliprdr: Fix an issue with file format filtering on Windows

### DIFF
--- a/channels/cliprdr/client/cliprdr_format.h
+++ b/channels/cliprdr/client/cliprdr_format.h
@@ -31,5 +31,7 @@ UINT cliprdr_process_format_data_request(cliprdrPlugin* cliprdr, wStream* s, UIN
                                          UINT16 msgFlags);
 UINT cliprdr_process_format_data_response(cliprdrPlugin* cliprdr, wStream* s, UINT32 dataLen,
                                           UINT16 msgFlags);
+CLIPRDR_FORMAT_LIST cliprdr_filter_format_list(const CLIPRDR_FORMAT_LIST* list, const UINT32 mask,
+                                               const UINT32 checkMask);
 
 #endif /* FREERDP_CHANNEL_CLIPRDR_CLIENT_FORMAT_H */

--- a/channels/cliprdr/client/cliprdr_main.c
+++ b/channels/cliprdr/client/cliprdr_main.c
@@ -39,6 +39,7 @@
 #include "../cliprdr_common.h"
 
 const char* type_FileGroupDescriptorW = "FileGroupDescriptorW";
+const char* type_FileContents = "FileContents";
 
 static const char* CB_MSG_TYPE_STRINGS(UINT32 type)
 {
@@ -660,68 +661,6 @@ static UINT cliprdr_temp_directory(CliprdrClientContext* context,
 	return cliprdr_packet_send(cliprdr, s);
 }
 
-static CLIPRDR_FORMAT_LIST cliprdr_filter_local_format_list(const CLIPRDR_FORMAT_LIST* list,
-                                                            const UINT32 mask)
-{
-	const UINT32 all = CLIPRDR_FLAG_LOCAL_TO_REMOTE | CLIPRDR_FLAG_LOCAL_TO_REMOTE_FILES;
-	WINPR_ASSERT(list);
-
-	CLIPRDR_FORMAT_LIST filtered = { 0 };
-	filtered.common.msgType = CB_FORMAT_LIST;
-	filtered.numFormats = list->numFormats;
-	filtered.formats = calloc(filtered.numFormats, sizeof(CLIPRDR_FORMAT_LIST));
-
-	size_t wpos = 0;
-	if ((mask & all) == all)
-	{
-		for (size_t x = 0; x < list->numFormats; x++)
-		{
-			const CLIPRDR_FORMAT* format = &list->formats[x];
-			CLIPRDR_FORMAT* cur = &filtered.formats[x];
-			cur->formatId = format->formatId;
-			if (format->formatName)
-				cur->formatName = _strdup(format->formatName);
-			wpos++;
-		}
-	}
-	else if ((mask & CLIPRDR_FLAG_LOCAL_TO_REMOTE_FILES) != 0)
-	{
-		for (size_t x = 0; x < list->numFormats; x++)
-		{
-			const CLIPRDR_FORMAT* format = &list->formats[x];
-			CLIPRDR_FORMAT* cur = &filtered.formats[wpos];
-
-			if (!format->formatName)
-				continue;
-			if (strcmp(format->formatName, type_FileGroupDescriptorW) == 0)
-			{
-				cur->formatId = format->formatId;
-				cur->formatName = _strdup(format->formatName);
-				wpos++;
-				break;
-			}
-		}
-	}
-	else if ((mask & CLIPRDR_FLAG_LOCAL_TO_REMOTE) != 0)
-	{
-		for (size_t x = 0; x < list->numFormats; x++)
-		{
-			const CLIPRDR_FORMAT* format = &list->formats[x];
-			CLIPRDR_FORMAT* cur = &filtered.formats[wpos];
-
-			if (!format->formatName || (strcmp(format->formatName, type_FileGroupDescriptorW) != 0))
-			{
-				cur->formatId = format->formatId;
-				if (format->formatName)
-					cur->formatName = _strdup(format->formatName);
-				wpos++;
-			}
-		}
-	}
-	filtered.numFormats = wpos;
-	return filtered;
-}
-
 /**
  * Function description
  *
@@ -741,7 +680,8 @@ static UINT cliprdr_client_format_list(CliprdrClientContext* context,
 
 	const UINT32 mask =
 	    freerdp_settings_get_uint32(context->rdpcontext->settings, FreeRDP_ClipboardFeatureMask);
-	CLIPRDR_FORMAT_LIST filterList = cliprdr_filter_local_format_list(formatList, mask);
+	CLIPRDR_FORMAT_LIST filterList = cliprdr_filter_format_list(
+	    formatList, mask, CLIPRDR_FLAG_LOCAL_TO_REMOTE | CLIPRDR_FLAG_LOCAL_TO_REMOTE_FILES);
 
 	/* Allow initial format list from monitor ready, but ignore later attempts */
 	if ((filterList.numFormats == 0) && cliprdr->initialFormatListSent)

--- a/channels/cliprdr/client/cliprdr_main.h
+++ b/channels/cliprdr/client/cliprdr_main.h
@@ -56,5 +56,6 @@ CliprdrClientContext* cliprdr_get_client_interface(cliprdrPlugin* cliprdr);
 UINT cliprdr_send_error_response(cliprdrPlugin* cliprdr, UINT16 type);
 
 extern const char* type_FileGroupDescriptorW;
+extern const char* type_FileContents;
 
 #endif /* FREERDP_CHANNEL_CLIPRDR_CLIENT_MAIN_H */


### PR DESCRIPTION
This PR fixes an issue caused by clipboard format filtering which discarded all formats but `FileGroupDescriptorW` to enable clipboard file transfer. However at least on windows we also need `FileContents` to be placed in the clipboard to make file transfer work correctly.

The PR also unifies list filtering into a single functions instead of having two different functions.
