### PR TITLE
Get AAD working again

### DIFF
--- a/client/SDL/sdl_webview.cpp
+++ b/client/SDL/sdl_webview.cpp
@@ -85,13 +85,12 @@ BOOL sdl_webview_get_aad_auth_code(freerdp* instance, const char* hostname, char
 	*redirect_uri =
 	    "ms-appx-web%3a%2f%2fMicrosoft.AAD.BrokerPlugin%2f5177bc73-fd99-4c77-a90c-76844c9b6999";
 
-	auto url = QString("https://login.microsoftonline.com/common/oauth2/v2.0/"
-	                   "authorize?client_id=%1&response_type="
-	                   "code&scope=ms-device-service%%3A%%2F%%2Ftermsrv.wvd.microsoft.com%%2Fname%%"
-	                   "2F%2%%2Fuser_impersonation&redirect_uri=%3")
-	               .arg(*client_id)
-	               .arg(hostname)
-	               .arg(*redirect_uri);
+	auto url =
+	    QString("https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=") +
+	    QString(*client_id) +
+	    QString("&response_type=code&scope=ms-device-service%3A%2F%2Ftermsrv.wvd.microsoft.com%"
+	            "2Fname%2F") +
+	    QString(hostname) + QString("%2Fuser_impersonation&redirect_uri=") + QString(*redirect_uri);
 
 	QWebEngineUrlScheme::registerScheme(QWebEngineUrlScheme("ms-appx-web"));
 

--- a/libfreerdp/core/aad.c
+++ b/libfreerdp/core/aad.c
@@ -416,7 +416,7 @@ static BOOL aad_send_token_request(rdpAad* aad, BIO* bio, const char* auth_code,
 	size_t req_body_len = 0;
 	size_t req_header_len = 0;
 	const int trc = winpr_asprintf(&req_body, &req_body_len, token_http_request_body, client_id,
-	                               auth_code, aad->kid, redirect_uri);
+	                               auth_code, aad->hostname, aad->kid, redirect_uri);
 	if (trc < 0)
 		goto fail;
 	const int trh = winpr_asprintf(&req_header, &req_header_len, token_http_request_header, trc);


### PR DESCRIPTION
Fix missing argument to token request body (probably linked to #9050). Also fix formatting issue in sdl_webview where apparently there's no way of printing a literal "%3" or "%2" without `QString::arg` replacing it.