### PR TITLE
Implement pen functionality for X11

### DIFF
--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -713,7 +713,7 @@ static int xf_input_pen_remote(xfContext* xfc, XIDeviceEvent* event, int evtype,
 				rdpei->PenHoverUpdate(rdpei, pen_index, RDPINPUT_PEN_CONTACT_PENFLAGS_PRESENT, x, y,
 				                      penFlags);
 			}
-			else if (xfc->pens[pen_index].last_x != x && xfc->pens[pen_index].last_y != y)
+			else
 			{
 				WLog_DBG(TAG, "Pen hover begin %d", pen_index);
 				xfc->pens[pen_index].hovering = TRUE;
@@ -724,10 +724,9 @@ static int xf_input_pen_remote(xfContext* xfc, XIDeviceEvent* event, int evtype,
 		case XI_ButtonRelease:
 			WLog_DBG(TAG, "Pen release %d", pen_index);
 			xfc->pens[pen_index].pressed = FALSE;
+			xfc->pens[pen_index].hovering = TRUE;
 			rdpei->PenUpdate(rdpei, pen_index, fieldFlags, x, y, penFlags, penPressure);
 			rdpei->PenEnd(rdpei, pen_index, RDPINPUT_PEN_CONTACT_PENFLAGS_PRESENT, x, y, penFlags);
-			rdpei->PenHoverCancel(rdpei, pen_index, RDPINPUT_PEN_CONTACT_PENFLAGS_PRESENT, x, y,
-			                      penFlags);
 			break;
 		default:
 			break;

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -124,6 +124,7 @@ typedef struct
 
 #if defined(WITH_XI)
 #define MAX_CONTACTS 20
+#define MAX_PENS 4
 
 typedef struct touch_contact
 {
@@ -135,6 +136,18 @@ typedef struct touch_contact
 	double last_y;
 
 } touchContact;
+
+typedef struct pen_device
+{
+	int deviceid;
+	BOOL is_eraser;
+	double max_pressure;
+	int hovering;
+	int pressed;
+	int last_x;
+	int last_y;
+} penDevice;
+
 #endif
 
 struct xf_context
@@ -290,6 +303,8 @@ struct xf_context
 	double z_vector;
 	double px_vector;
 	double py_vector;
+	penDevice pens[MAX_PENS];
+	int num_pens;
 #endif
 	BOOL xi_rawevent;
 	BOOL xi_event;

--- a/include/freerdp/client/rdpei.h
+++ b/include/freerdp/client/rdpei.h
@@ -78,6 +78,9 @@ extern "C"
 		pcRdpeiPen PenBegin;
 		pcRdpeiPen PenUpdate;
 		pcRdpeiPen PenEnd;
+		pcRdpeiPen PenHoverBegin;
+		pcRdpeiPen PenHoverUpdate;
+		pcRdpeiPen PenHoverCancel;
 
 		pcRdpeiSuspendTouch SuspendTouch;
 		pcRdpeiResumeTouch ResumeTouch;


### PR DESCRIPTION
# Description

Implements pen with pressure, eraser, and hover. 
https://github.com/FreeRDP/FreeRDP/issues/7260

![image](https://github.com/FreeRDP/FreeRDP/assets/45611618/5f999ee0-4e71-483e-b5a5-5f482fc72690)

# Testing
How to test per the above picture:
- have an X11 desktop with a tablet and pen/stylus that has a tip and an eraser (e.g. MPP pens, like microsoft surface)
- use xfreerdp to connect to a windows machine with powerpoint, and use the `+multitouch` option
- in powerpoint, pick the black pen and make it as thick as possible 
![image](https://github.com/FreeRDP/FreeRDP/assets/45611618/69b274b6-4720-46b6-ac2c-eedc1fd88eb0)
- zoom in to 400% to make the pressure sensitivity obvious
- draw a line varying the pressure and see the thickness of the line be affected
- reduce the line thickness and try writing some words. Ensure that the writing is smooth and nothing skips
- hover the pen above the screen and move it around - notice the cursor is a black dot that follows the pen around
- flip over to the eraser and hover it over the screen. observe it have the eraser tip cursor like shown here:
![image](https://github.com/FreeRDP/FreeRDP/assets/45611618/e17bee4f-11bc-4de0-9892-e520248baa92)
- try erasing some of your previous lines
- switch back and forth with pen and eraser like you normally would writing and observe inking/erasing working as expected

Known issues:
- After using the eraser and going from pen down to hovering, the hover icon might switch over to the black dot, but pressing the eraser back into the screen will continue to use the eraser properly. This was somewhat mitigated by trying to force an UPDATE | CANCEL immediately after pen up, but it impacted performance of writing (skips parts if writing fast). There something tricky about managing the state transition with penFlags for using the eraser (PEN_FLAG_INVERTED). See the 2nd commit for additional context.

Exiting the hover state feels a little hacky because X11 does not give you any event to say "pen proximity is away from screen". It simply stops giving you motion events. So exiting the hover state was done whenever any other non-hover input event happened.

In my testing, I had to add pen hover for switching back and forth with the pen tip and eraser tip to work. On a regular windows device like a surface pro, you always see the pen hover cursors before and after any inking or erasing events, so I think it makes sense.

# Design notes

Pen behaviour is very similar to multitouch, except while X11 gives explicit events for XI_TouchBegin, XI_TouchUpdate, and XI_TouchEnd, as far as I could see for pen stuff you only get XI_ButtonPress, XI_Motion, and XI_ButtonRelease, and it's up to you to correctly interpret what's going on. Furthermore, a challenge is that pen not only has a active state, but a hovering state. So a complete picture would be PenHoverBegin, PenHoverUpdate, PenHoverEnd, PenDrawBegin, PenDrawUpdate, PenDrawEnd, all while complying with [[MS-RDPEI] 3.1.1.1 Touch Contact State Transitions](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpei/797930c0-d5ca-4da5-a801-97813d3b750e)

![](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpei/ms-rdpei_files/image002.png)

Some helpful tools to see what all the states are before starting coding:
- `libinput debug-events`
- `xinput test-xi2 --root`
 
Possibly useful observations from xinput:
- I see `EVENT type 1 (DeviceChanged)` every time between switching to a different input device (mouse, touch, pen, keyboard)
- Initially only a "ipts 045E:001F Pen Pen (0)" was seen on my Surface Pro 5 (surface linux kernel with ipts), but on first time using the eraser I got a HierarchyChanged event where a "ipts ... Pen Eraser ..."  device was added.
    - **should probably detect HierarchyChanged and re-initialize xf_input_init when that happens**

Additional info and notes:
- Browsing various X11 touch/stylus implementations, they all seem to rely on the fact that pressure is always the 3rd valuator value. In my implementation, I used this index, but we can also do a string comparison because the valuator name should have "Pressure" in it.
- max_pressure must be determined from querying the input devices, so this should also be refreshed whenever devices are added/removed
- rdpei has MAX_PEN_CONTACTS = 4 so simultaneous pen contacts are apparently possible, but directly on my Surface Pro 5 in windows 10 this does not seem to work with the 2 pens I have. It may need special devices like Surface Hub or similar.


Also here's a branch for the first commit of the patch on 2.10.0: https://github.com/digitalsignalperson/FreeRDP/tree/2.10.0_archlinux-pendev3