### PR TITLE
Multitouch common

### DIFF
--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -124,7 +124,6 @@ typedef struct
 
 #if defined(WITH_XI)
 #define MAX_CONTACTS 20
-#define MAX_PENS 4
 
 typedef struct touch_contact
 {
@@ -136,17 +135,6 @@ typedef struct touch_contact
 	double last_y;
 
 } touchContact;
-
-typedef struct pen_device
-{
-	int deviceid;
-	BOOL is_eraser;
-	double max_pressure;
-	int hovering;
-	int pressed;
-	int last_x;
-	int last_y;
-} penDevice;
 
 #endif
 
@@ -303,8 +291,6 @@ struct xf_context
 	double z_vector;
 	double px_vector;
 	double py_vector;
-	penDevice pens[MAX_PENS];
-	int num_pens;
 #endif
 	BOOL xi_rawevent;
 	BOOL xi_event;

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -92,6 +92,19 @@ extern "C"
 		ALIGN64 UINT32 pressure;
 	} FreeRDP_TouchContact;
 
+#define FREERDP_MAX_PEN_DEVICES 10
+
+	typedef struct pen_device
+	{
+		ALIGN64 INT32 deviceid;
+		ALIGN64 UINT32 flags;
+		ALIGN64 double max_pressure;
+		ALIGN64 BOOL hovering;
+		ALIGN64 BOOL pressed;
+		ALIGN64 INT32 last_x;
+		ALIGN64 INT32 last_y;
+	} FreeRDP_PenDevice;
+
 	struct rdp_client_context
 	{
 		rdpContext context;
@@ -119,7 +132,8 @@ extern "C"
 	    UINT64 reserved3[2];
 #endif
 		ALIGN64 FreeRDP_TouchContact contacts[FREERDP_MAX_TOUCH_CONTACTS]; /**< (offset 8) */
-		UINT64 reserved[128 - 68];                                         /**< (offset 68) */
+		ALIGN64 FreeRDP_PenDevice pens[FREERDP_MAX_PEN_DEVICES];           /**< (offset 9) */
+		UINT64 reserved[128 - 9];                                          /**< (offset 9) */
 	};
 
 	/* Common client functions */
@@ -222,6 +236,27 @@ extern "C"
 
 	FREERDP_API BOOL freerdp_client_handle_touch(rdpClientContext* cctx, UINT32 flags, INT32 finger,
 	                                             UINT32 pressure, INT32 x, INT32 y);
+
+	typedef enum
+	{
+		FREERDP_PEN_REGISTER = 0x01,
+		FREERDP_PEN_ERASER_PRESSED = 0x02,
+		FREERDP_PEN_PRESS = 0x04,
+		FREERDP_PEN_MOTION = 0x08,
+		FREERDP_PEN_RELEASE = 0x10,
+		FREERDP_PEN_BARREL_PRESSED = 0x20,
+		FREERDP_PEN_HAS_PRESSURE = 0x40,
+		FREERDP_PEN_HAS_ROTATION = 0x40,
+		FREERDP_PEN_HAS_TILTX = 0x80,
+		FREERDP_PEN_HAS_TILTY = 0x100,
+		FREERDP_PEN_IS_INVERTED = 0x200
+	} FreeRDPPenEventType;
+
+	FREERDP_API BOOL freerdp_client_handle_pen(rdpClientContext* cctx, UINT32 flags, INT32 deviceid,
+	                                           ...);
+	FREERDP_API BOOL freerdp_client_is_pen(rdpClientContext* cctx, INT32 deviceid);
+
+	FREERDP_API BOOL freerdp_client_pen_cancel_all(rdpClientContext* cctx);
 
 	FREERDP_API BOOL freerdp_client_send_wheel_event(rdpClientContext* cctx, UINT16 mflags);
 

--- a/include/freerdp/client/rdpei.h
+++ b/include/freerdp/client/rdpei.h
@@ -46,15 +46,22 @@ extern "C"
 	typedef UINT (*pcRdpeiTouchRawEvent)(RdpeiClientContext* context, INT32 externalId, INT32 x,
 	                                     INT32 y, INT32* contactId, UINT32 contactFlags,
 	                                     UINT32 fieldFlags, ...);
+	typedef UINT (*pcRdpeiTouchRawEventVA)(RdpeiClientContext* context, INT32 externalId, INT32 x,
+	                                       INT32 y, INT32* contactId, UINT32 contactFlags,
+	                                       UINT32 fieldFlags, va_list args);
 
 	typedef UINT (*pcRdpeiAddPen)(RdpeiClientContext* context, INT32 externalId,
 	                              const RDPINPUT_PEN_CONTACT* contact);
 
 	typedef UINT (*pcRdpeiPen)(RdpeiClientContext* context, INT32 externalId, UINT32 fieldFlags,
 	                           INT32 x, INT32 y, ...);
+
 	typedef UINT (*pcRdpeiPenRawEvent)(RdpeiClientContext* context, INT32 externalId,
 	                                   UINT32 contactFlags, UINT32 fieldFlags, INT32 x, INT32 y,
 	                                   ...);
+	typedef UINT (*pcRdpeiPenRawEventVA)(RdpeiClientContext* context, INT32 externalId,
+	                                     UINT32 contactFlags, UINT32 fieldFlags, INT32 x, INT32 y,
+	                                     va_list args);
 
 	typedef UINT (*pcRdpeiSuspendTouch)(RdpeiClientContext* context);
 	typedef UINT (*pcRdpeiResumeTouch)(RdpeiClientContext* context);
@@ -87,9 +94,11 @@ extern "C"
 
 		pcRdpeiTouchEvent TouchCancel;
 		pcRdpeiTouchRawEvent TouchRawEvent;
+		pcRdpeiTouchRawEventVA TouchRawEventVA;
 
 		pcRdpeiPen PenCancel;
 		pcRdpeiPenRawEvent PenRawEvent;
+		pcRdpeiPenRawEventVA PenRawEventVA;
 
 		UINT32 clientFeaturesMask;
 	};


### PR DESCRIPTION
* move x11 code to client common (to be reused by other clients)
* add support for rotation and tilt flags
* add raw event functions to call
* add functions with `va_list` as well
* simplify internal handling of new contact detection

@digitalsignalperson could you have a look at this? only have a touch input device, no pen to test.
might also be a good idea to check how the `SDL` client handles the pen input.