### PR TITLE
Adding CredSSP with Early User Auth support (sec:ext)

### DIFF
--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -318,7 +318,11 @@ static BOOL nego_try_connect(rdpNego* nego)
 			break;
 		case PROTOCOL_HYBRID:
 			WLog_DBG(TAG, "nego_security_connect with PROTOCOL_HYBRID");
-			nego->SecurityConnected = transport_connect_nla(nego->transport);
+			nego->SecurityConnected = transport_connect_nla(nego->transport, FALSE);
+			break;
+		case PROTOCOL_HYBRID_EX:
+			WLog_DBG(TAG, "nego_security_connect with PROTOCOL_HYBRID_EX");
+			nego->SecurityConnected = transport_connect_nla(nego->transport, TRUE);
 			break;
 		case PROTOCOL_SSL:
 			WLog_DBG(TAG, "nego_security_connect with PROTOCOL_SSL");

--- a/libfreerdp/core/nla.h
+++ b/libfreerdp/core/nla.h
@@ -40,6 +40,7 @@ typedef enum
 	NLA_STATE_INITIAL,
 	NLA_STATE_NEGO_TOKEN,
 	NLA_STATE_PUB_KEY_AUTH,
+	NLA_STATE_EARLY_USER_AUTH,
 	NLA_STATE_AUTH_INFO,
 	NLA_STATE_POST_NEGO,
 	NLA_STATE_FINAL
@@ -70,5 +71,6 @@ FREERDP_LOCAL BOOL nla_revert_to_self(rdpNla* nla);
 
 FREERDP_LOCAL rdpNla* nla_new(rdpContext* context, rdpTransport* transport);
 FREERDP_LOCAL void nla_free(rdpNla* nla);
+FREERDP_LOCAL void nla_set_early_user_auth(rdpNla* nla, BOOL earlyUserAuth);
 
 #endif /* FREERDP_LIB_CORE_NLA_H */

--- a/libfreerdp/core/transport.h
+++ b/libfreerdp/core/transport.h
@@ -60,7 +60,7 @@ FREERDP_LOCAL BOOL transport_attach(rdpTransport* transport, int sockfd);
 FREERDP_LOCAL BOOL transport_disconnect(rdpTransport* transport);
 FREERDP_LOCAL BOOL transport_connect_rdp(rdpTransport* transport);
 FREERDP_LOCAL BOOL transport_connect_tls(rdpTransport* transport);
-FREERDP_LOCAL BOOL transport_connect_nla(rdpTransport* transport);
+FREERDP_LOCAL BOOL transport_connect_nla(rdpTransport* transport, BOOL earlyUserAuth);
 FREERDP_LOCAL BOOL transport_connect_rdstls(rdpTransport* transport);
 FREERDP_LOCAL BOOL transport_connect_aad(rdpTransport* transport);
 FREERDP_LOCAL BOOL transport_accept_rdp(rdpTransport* transport);
@@ -128,5 +128,7 @@ FREERDP_LOCAL int transport_tcp_connect(rdpTransport* transport, const char* hos
 
 FREERDP_LOCAL rdpTransport* transport_new(rdpContext* context);
 FREERDP_LOCAL void transport_free(rdpTransport* transport);
+
+FREERDP_LOCAL void transport_set_early_user_auth_mode(rdpTransport* transport, BOOL EUAMode);
 
 #endif /* FREERDP_LIB_CORE_TRANSPORT_H */

--- a/winpr/libwinpr/utils/unwind/debug.c
+++ b/winpr/libwinpr/utils/unwind/debug.c
@@ -54,7 +54,7 @@ static _Unwind_Reason_Code unwind_backtrace_callback(struct _Unwind_Context* con
 	{
 		unwind_info_t* info = &ctx->info[ctx->pos++];
 		info->pc = _Unwind_GetIP(context);
-		info->langSpecificData = _Unwind_GetLanguageSpecificData(context);
+		info->langSpecificData = (void*)_Unwind_GetLanguageSpecificData(context);
 	}
 
 	return _URC_NO_REASON;


### PR DESCRIPTION
Recently I wasn't able to connect to my work servers using FreeRDP.

After digging I found that without using /sec:ext the server was closing the connection.

But with the command line switch it wasn't working, I found out that HYBRID_EX wasn't handled in nego.c.

Afterward I found out that we were receiving 4 bytes between the end of NLA and the MCS connect, I found out that it was the Early User Auth Result PDU (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/d0e560a3-25cb-4563-8bdc-6c4cc625bbfc).

I don't know RDP protocol neither the FreeRDP source code but I attempted to add support the best I can, trying to respect the way the code is architectured and using clang_format on the modified sources.

With this patch I can now connect to my work servers again, if it can help other people then I'm happy to share the patch.

