### PR TITLE
[winpr,collections] fixes for ListDictionary

### DIFF
--- a/winpr/include/winpr/collections.h
+++ b/winpr/include/winpr/collections.h
@@ -276,11 +276,13 @@ extern "C"
 	 *
 	 *  @param listDictionary A dictionary to query, must not be \b NULL
 	 *  @param key The key identifying the entry, if set cloned with \b fnObjectNew
+	 *  @param value The value to store for the \b key. May be \b NULL. if set cloned with \b
+	 * fnObjectNew
 	 *
 	 *  @return \b TRUE for successfull addition, \b FALSE for failure
 	 */
 	WINPR_API BOOL ListDictionary_Add(wListDictionary* listDictionary, const void* key,
-	                                  void* value);
+	                                  const void* value);
 
 	/** @brief Remove an item from the dictionary and return the value. Cleanup is up to the caller.
 	 *
@@ -358,7 +360,7 @@ extern "C"
 	 *  @return \b TRUE for success, \b FALSE in case of failure
 	 */
 	WINPR_API BOOL ListDictionary_SetItemValue(wListDictionary* listDictionary, const void* key,
-	                                           void* value);
+	                                           const void* value);
 
 	/** @brief allocate a new dictionary
 	 *

--- a/winpr/libwinpr/utils/collections/ListDictionary.c
+++ b/winpr/libwinpr/utils/collections/ListDictionary.c
@@ -212,7 +212,8 @@ static void item_set(wListDictionary* listDictionary, wListDictionaryItem* item,
 		item->value = value;
 }
 
-static wListDictionaryItem* new_item(wListDictionary* listDictionary, const void* key, void* value)
+static wListDictionaryItem* new_item(wListDictionary* listDictionary, const void* key,
+                                     const void* value)
 {
 	wListDictionaryItem* item = (wListDictionaryItem*)calloc(1, sizeof(wListDictionaryItem));
 	if (!item)
@@ -226,7 +227,7 @@ static wListDictionaryItem* new_item(wListDictionary* listDictionary, const void
 		goto fail;
 
 	item_set(listDictionary, item, value);
-	if (!item->value)
+	if (value && !item->value)
 		goto fail;
 
 	return item;
@@ -240,7 +241,7 @@ fail:
  * Adds an entry with the specified key and value into the ListDictionary.
  */
 
-BOOL ListDictionary_Add(wListDictionary* listDictionary, const void* key, void* value)
+BOOL ListDictionary_Add(wListDictionary* listDictionary, const void* key, const void* value)
 {
 	BOOL ret = FALSE;
 
@@ -484,7 +485,8 @@ void* ListDictionary_GetItemValue(wListDictionary* listDictionary, const void* k
  * Set an item value using key
  */
 
-BOOL ListDictionary_SetItemValue(wListDictionary* listDictionary, const void* key, void* value)
+BOOL ListDictionary_SetItemValue(wListDictionary* listDictionary, const void* key,
+                                 const void* value)
 {
 	BOOL status = FALSE;
 	wListDictionaryItem* item;


### PR DESCRIPTION
* Make ListDictionary_Add and ListDictionary_SetItemValue arguments const
* Allow ListDictionary_Add to store NULL values

Follow up to #9104 