### PR TITLE
Audio input negotiated format must be cleaned after closing.

### DIFF
--- a/channels/audin/server/audin.c
+++ b/channels/audin/server/audin.c
@@ -528,6 +528,8 @@ static BOOL audin_server_close(audin_server_context* context)
 		audin->audin_channel = NULL;
 	}
 
+	audin->audin_negotiated_format = NULL;
+
 	return TRUE;
 }
 


### PR DESCRIPTION
Fix format negotiation error when the audio input channel is closed and then open again.