### PR TITLE
[core,gateway] only encode a cookie line if there is a cookie

### DIFF
--- a/libfreerdp/core/gateway/http.c
+++ b/libfreerdp/core/gateway/http.c
@@ -561,10 +561,10 @@ static BOOL http_encode_cookie_line(wStream* s, wListDictionary* cookies)
 		status = http_encode_print(s, "%s=%s", (char*)keys[x], cur);
 	}
 
+	status = http_encode_print(s, "\r\n");
 unlock:
 	free(keys);
 	ListDictionary_Unlock(cookies);
-	status = http_encode_print(s, "\r\n");
 	return status;
 }
 


### PR DESCRIPTION
if cookie length was 0 a empty line was added and this would cut off the http header and move following headers in the body