### PR TITLE
Proxy module fixes

### DIFF
--- a/server/proxy/modules/dyn-channel-dump/dyn-channel-dump.cpp
+++ b/server/proxy/modules/dyn-channel-dump/dyn-channel-dump.cpp
@@ -153,7 +153,8 @@ static BOOL dump_set_plugin_data(proxyPlugin* plugin, proxyData* pdata, ChannelD
 static bool dump_channel_enabled(proxyPlugin* plugin, proxyData* pdata, const std::string& name)
 {
 	auto config = dump_get_plugin_data(plugin, pdata);
-	WINPR_ASSERT(config);
+	if (!config)
+		return false;
 	return config->dump_enabled(name);
 }
 
@@ -169,6 +170,8 @@ static BOOL dump_dyn_channel_intercept_list(proxyPlugin* plugin, proxyData* pdat
 	if (data->intercept)
 	{
 		auto cdata = dump_get_plugin_data(plugin, pdata);
+		if (!cdata)
+			return FALSE;
 		auto front = cdata->filepath(data->name, false);
 		auto back = cdata->filepath(data->name, true);
 
@@ -213,6 +216,9 @@ static BOOL dump_dyn_channel_intercept(proxyPlugin* plugin, proxyData* pdata, vo
 	if (dump_channel_enabled(plugin, pdata, data->name))
 	{
 		auto cdata = dump_get_plugin_data(plugin, pdata);
+		if (!cdata)
+			return FALSE;
+
 		auto& stream = cdata->stream(data->name, data->isBackData);
 		auto buffer = reinterpret_cast<const char*>(Stream_ConstBuffer(data->data));
 		if (!stream.is_open() || !stream.good())

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -765,7 +765,8 @@ static BOOL pf_client_connect(freerdp* instance)
 
 	if (!freerdp_connect(instance))
 	{
-		pf_modules_run_hook(pc->pdata->module, HOOK_TYPE_CLIENT_LOGIN_FAILURE, pc->pdata, pc);
+		if (!pf_modules_run_hook(pc->pdata->module, HOOK_TYPE_CLIENT_LOGIN_FAILURE, pc->pdata, pc))
+			goto out;
 
 		if (!retry)
 			goto out;

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -578,7 +578,8 @@ static DWORD WINAPI pf_server_handle_peer(LPVOID arg)
 	pdata = ps->pdata;
 	WINPR_ASSERT(pdata);
 
-	pf_modules_run_hook(pdata->module, HOOK_TYPE_SERVER_SESSION_INITIALIZE, pdata, client);
+	if (!pf_modules_run_hook(pdata->module, HOOK_TYPE_SERVER_SESSION_INITIALIZE, pdata, client))
+		goto out_free_peer;
 
 	WINPR_ASSERT(client->Initialize);
 	client->Initialize(client);
@@ -586,7 +587,8 @@ static DWORD WINAPI pf_server_handle_peer(LPVOID arg)
 	PROXY_LOG_INFO(TAG, ps, "new connection: proxy address: %s, client address: %s",
 	               pdata->config->Host, client->hostname);
 
-	pf_modules_run_hook(pdata->module, HOOK_TYPE_SERVER_SESSION_STARTED, pdata, client);
+	if (!pf_modules_run_hook(pdata->module, HOOK_TYPE_SERVER_SESSION_STARTED, pdata, client))
+		goto out_free_peer;
 
 	while (1)
 	{


### PR DESCRIPTION
* Fix missing return value checks in proxy (abort if something fails)
* Fix missing `NULL` checks in `dyn-channel-dump`
* change logging, dump each packet into a separate file (use a counter per channel for both, incoming and outgoing to have the original order of traffic)
* add session handling to dump module
* fix an issue with the `drdynvc` state tracker