### PR TITLE
[winpr,wlog] extend wLog to allow logging custom data

### DIFF
--- a/client/common/client.c
+++ b/client/common/client.c
@@ -1740,9 +1740,11 @@ BOOL freerdp_client_handle_pen(rdpClientContext* cctx, UINT32 flags, INT32 devic
 	WINPR_ASSERT(rdpei);
 
 	UINT32 normalizedpressure = 1024;
-	INT32 x, y;
-	UINT16 rotation;
-	INT16 tiltX, tiltY;
+	INT32 x = 0;
+	INT32 y = 0;
+	UINT16 rotation = 0;
+	INT16 tiltX = 0;
+	INT16 tiltY = 0;
 	va_list args;
 	va_start(args, deviceid);
 

--- a/libfreerdp/core/gateway/rts.c
+++ b/libfreerdp/core/gateway/rts.c
@@ -1196,8 +1196,8 @@ static BOOL rts_write_pdu_header(wStream* s, const rpcconn_rts_hdr_t* header)
 	return TRUE;
 }
 
-static int rts_receive_window_size_command_read(rdpRpc* rpc, wStream* buffer,
-                                                UINT32* ReceiveWindowSize)
+static BOOL rts_receive_window_size_command_read(rdpRpc* rpc, wStream* buffer,
+                                                 UINT32* ReceiveWindowSize)
 {
 	UINT32 val;
 
@@ -1205,12 +1205,12 @@ static int rts_receive_window_size_command_read(rdpRpc* rpc, wStream* buffer,
 	WINPR_ASSERT(buffer);
 
 	if (!Stream_CheckAndLogRequiredLength(TAG, buffer, 4))
-		return -1;
+		return FALSE;
 	Stream_Read_UINT32(buffer, val);
 	if (ReceiveWindowSize)
 		*ReceiveWindowSize = val; /* ReceiveWindowSize (4 bytes) */
 
-	return 4;
+	return TRUE;
 }
 
 static BOOL rts_receive_window_size_command_write(wStream* s, UINT32 ReceiveWindowSize)
@@ -1626,13 +1626,13 @@ BOOL rts_recv_CONN_C2_pdu(rdpRpc* rpc, wStream* buffer)
 		return FALSE;
 
 	rc = rts_version_command_read(rpc, buffer);
-	if (rc < 0)
+	if (!rc)
 		return rc;
 	rc = rts_receive_window_size_command_read(rpc, buffer, &ReceiveWindowSize);
-	if (rc < 0)
+	if (!rc)
 		return rc;
 	rc = rts_connection_timeout_command_read(rpc, buffer, &ConnectionTimeout);
-	if (rc < 0)
+	if (!rc)
 		return rc;
 	WLog_DBG(TAG,
 	         "Receiving CONN/C2 RTS PDU: ConnectionTimeout: %" PRIu32 " ReceiveWindowSize: %" PRIu32

--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -441,8 +441,9 @@ static BOOL rdp_read_extended_info_packet(rdpRdp* rdp, wStream* s)
 
 		if (!Stream_CheckAndLogRequiredLength(TAG, s, 2))
 			return FALSE;
-		Stream_Read_UINT16(s, settings->DynamicDaylightTimeDisabled);
-		if (settings->DynamicDaylightTimeDisabled > 1)
+		UINT16 DynamicDaylightTimeDisabled = 0;
+		Stream_Read_UINT16(s, DynamicDaylightTimeDisabled);
+		if (DynamicDaylightTimeDisabled > 1)
 		{
 			WLog_WARN(TAG,
 			          "[MS-RDPBCGR] 2.2.1.11.1.1.1 Extended Info Packet "
@@ -451,6 +452,9 @@ static BOOL rdp_read_extended_info_packet(rdpRdp* rdp, wStream* s)
 			          settings->DynamicDaylightTimeDisabled);
 			return FALSE;
 		}
+		if (!freerdp_settings_set_bool(settings, FreeRDP_DynamicDaylightTimeDisabled,
+		                               DynamicDaylightTimeDisabled != 0))
+			return FALSE;
 	}
 
 end:

--- a/server/proxy/channels/pf_channel_rdpdr.c
+++ b/server/proxy/channels/pf_channel_rdpdr.c
@@ -32,7 +32,7 @@
 #include <freerdp/channels/channels.h>
 #include <freerdp/utils/rdpdr_utils.h>
 
-#define TAG PROXY_TAG("channel.rdpdr")
+#define RTAG PROXY_TAG("channel.rdpdr")
 
 #define SCARD_DEVICE_ID UINT32_MAX
 
@@ -1106,14 +1106,12 @@ static BOOL pf_channel_rdpdr_rewrite_device_list(pf_channel_client_context* rdpd
 	WINPR_ASSERT(ps);
 
 	const size_t pos = Stream_GetPosition(s);
-	if (Stream_Length(s) < 4)
-	{
-		WLog_ERR(TAG, "Short stream, got %" PRIuz ", require at least 4", Stream_Length(s));
-		return FALSE;
-	}
-
 	UINT16 component, packetid;
 	Stream_SetPosition(s, 0);
+
+	if (!Stream_CheckAndLogRequiredLengthWLog(rdpdr->log, s, 4))
+		return FALSE;
+
 	Stream_Read_UINT16(s, component);
 	Stream_Read_UINT16(s, packetid);
 	if ((component != RDPDR_CTYP_CORE) || (packetid != PAKID_CORE_DEVICELIST_ANNOUNCE))
@@ -1126,7 +1124,7 @@ static BOOL pf_channel_rdpdr_rewrite_device_list(pf_channel_client_context* rdpd
 	    HashTable_GetItemValue(ps->interceptContextMap, RDPDR_SVC_CHANNEL_NAME);
 	if (!srv)
 	{
-		WLog_ERR(TAG, "No channel %s in intercep map", RDPDR_SVC_CHANNEL_NAME);
+		WLog_Print(rdpdr->log, WLOG_ERROR, "No channel %s in intercep map", RDPDR_SVC_CHANNEL_NAME);
 		return FALSE;
 	}
 
@@ -1178,7 +1176,9 @@ static BOOL rdpdr_process_server_loggedon_request(pServerContext* ps, pClientCon
                                                   pf_channel_client_context* rdpdr, wStream* s,
                                                   UINT16 component, UINT16 packetid)
 {
-	WLog_DBG(TAG, "[%s | %s]", rdpdr_component_string(component), rdpdr_packetid_string(packetid));
+	WINPR_ASSERT(rdpdr);
+	WLog_Print(rdpdr->log, WLOG_DEBUG, "[%s | %s]", rdpdr_component_string(component),
+	           rdpdr_packetid_string(packetid));
 	if (rdpdr_send_emulated_scard_device_remove(pc, rdpdr) != CHANNEL_RC_OK)
 		return FALSE;
 	if (rdpdr_send_emulated_scard_device_list_announce_request(pc, rdpdr) != CHANNEL_RC_OK)
@@ -1207,8 +1207,8 @@ static BOOL filter_smartcard_io_requests(pf_channel_client_context* rdpdr, wStre
 	if (Stream_GetRemainingLength(s) >= 4)
 		Stream_Read_UINT32(s, deviceID);
 
-	WLog_DBG(TAG, "got: [%s | %s]: [0x%08" PRIx32 "]", rdpdr_component_string(component),
-	         rdpdr_packetid_string(packetid), deviceID);
+	WLog_Print(rdpdr->log, WLOG_DEBUG, "got: [%s | %s]: [0x%08" PRIx32 "]",
+	           rdpdr_component_string(component), rdpdr_packetid_string(packetid), deviceID);
 
 	if (component != RDPDR_CTYP_CORE)
 		goto fail;
@@ -1222,8 +1222,8 @@ static BOOL filter_smartcard_io_requests(pf_channel_client_context* rdpdr, wStre
 		case PAKID_CORE_DEVICELIST_REMOVE:
 		case PAKID_CORE_SERVER_CAPABILITY:
 		case PAKID_CORE_CLIENT_CAPABILITY:
-			WLog_WARN(TAG, "Filtering client -> server message [%s | %s]",
-			          rdpdr_component_string(component), rdpdr_packetid_string(packetid));
+			WLog_Print(rdpdr->log, WLOG_WARN, "Filtering client -> server message [%s | %s]",
+			           rdpdr_component_string(component), rdpdr_packetid_string(packetid));
 			*pPacketid = packetid;
 			break;
 		case PAKID_CORE_USER_LOGGEDON:
@@ -1238,8 +1238,10 @@ static BOOL filter_smartcard_io_requests(pf_channel_client_context* rdpdr, wStre
 		default:
 			if (deviceID != SCARD_DEVICE_ID)
 				goto fail;
-			WLog_WARN(TAG, "Got [%s | %s] for deviceID 0x%08" PRIx32 ", TODO: Not handled!",
-			          rdpdr_component_string(component), rdpdr_packetid_string(packetid), deviceID);
+			WLog_Print(rdpdr->log, WLOG_WARN,
+			           "Got [%s | %s] for deviceID 0x%08" PRIx32 ", TODO: Not handled!",
+			           rdpdr_component_string(component), rdpdr_packetid_string(packetid),
+			           deviceID);
 			goto fail;
 	}
 
@@ -1325,8 +1327,9 @@ BOOL pf_channel_rdpdr_client_handle(pClientContext* pc, UINT16 channelId, const 
 	rdpdr = HashTable_GetItemValue(pc->interceptContextMap, channel_name);
 	if (!rdpdr)
 	{
-		WLog_ERR(TAG, "Channel %s [0x%04" PRIx16 "] missing context in interceptContextMap",
-		         channel_name, channelId);
+		CLIENT_RX_LOG(rdpdr->log, WLOG_ERROR,
+		              "Channel %s [0x%04" PRIx16 "] missing context in interceptContextMap",
+		              channel_name, channelId);
 		return FALSE;
 	}
 	s = rdpdr->common.buffer;
@@ -1608,7 +1611,8 @@ static BOOL filter_smartcard_device_list_announce(pf_channel_server_context* rdp
 			if (count == 1)
 				return TRUE;
 
-			WLog_INFO(TAG, "Filtering smartcard device 0x%08" PRIx32 "", DeviceId);
+			WLog_Print(rdpdr->log, WLOG_INFO, "Filtering smartcard device 0x%08" PRIx32 "",
+			           DeviceId);
 
 			memmove(dst, Stream_ConstPointer(s), Stream_GetRemainingLength(s));
 			Stream_SetPosition(s, pos);
@@ -1660,8 +1664,8 @@ static BOOL filter_smartcard_device_list_announce_request(pf_channel_server_cont
 		case PAKID_CORE_SERVER_CAPABILITY:
 		case PAKID_CORE_CLIENT_CAPABILITY:
 		case PAKID_CORE_USER_LOGGEDON:
-			WLog_WARN(TAG, "Filtering client -> server message [%s | %s]",
-			          rdpdr_component_string(component), rdpdr_packetid_string(packetid));
+			WLog_Print(rdpdr->log, WLOG_WARN, "Filtering client -> server message [%s | %s]",
+			           rdpdr_component_string(component), rdpdr_packetid_string(packetid));
 			goto fail;
 		default:
 			break;
@@ -1692,6 +1696,16 @@ static void stream_free(void* obj)
 	Stream_Free(s, TRUE);
 }
 
+static const char* pf_channel_rdpdr_client_context(void* arg)
+{
+	pClientContext* pc = arg;
+	if (!pc)
+		return "pc=null";
+	if (!pc->pdata)
+		return "pc->pdata=null";
+	return pc->pdata->session_id;
+}
+
 BOOL pf_channel_rdpdr_client_new(pClientContext* pc)
 {
 	wObject* obj;
@@ -1703,7 +1717,10 @@ BOOL pf_channel_rdpdr_client_new(pClientContext* pc)
 	rdpdr = calloc(1, sizeof(pf_channel_client_context));
 	if (!rdpdr)
 		return FALSE;
-	rdpdr->log = WLog_Get(TAG);
+	rdpdr->log = WLog_Get(RTAG);
+	WINPR_ASSERT(rdpdr->log);
+
+	WLog_SetContext(rdpdr->log, pf_channel_rdpdr_client_context, pc);
 	if (!pf_channel_rdpdr_common_context_new(&rdpdr->common, pf_channel_rdpdr_client_context_free))
 		goto fail;
 
@@ -1743,6 +1760,16 @@ static void pf_channel_rdpdr_server_context_free(InterceptContextMapEntry* base)
 	free(entry);
 }
 
+static const char* pf_channel_rdpdr_server_context(void* arg)
+{
+	pServerContext* ps = arg;
+	if (!ps)
+		return "ps=null";
+	if (!ps->pdata)
+		return "ps->pdata=null";
+	return ps->pdata->session_id;
+}
+
 BOOL pf_channel_rdpdr_server_new(pServerContext* ps)
 {
 	pf_channel_server_context* rdpdr;
@@ -1755,7 +1782,10 @@ BOOL pf_channel_rdpdr_server_new(pServerContext* ps)
 	rdpdr = calloc(1, sizeof(pf_channel_server_context));
 	if (!rdpdr)
 		return FALSE;
-	rdpdr->log = WLog_Get(TAG);
+	rdpdr->log = WLog_Get(RTAG);
+	WINPR_ASSERT(rdpdr->log);
+	WLog_SetContext(rdpdr->log, pf_channel_rdpdr_server_context, ps);
+
 	if (!pf_channel_rdpdr_common_context_new(&rdpdr->common, pf_channel_rdpdr_server_context_free))
 		goto fail;
 	rdpdr->state = STATE_SERVER_INITIAL;

--- a/winpr/include/winpr/wlog.h
+++ b/winpr/include/winpr/wlog.h
@@ -115,6 +115,18 @@ extern "C"
 	WINPR_API DWORD WLog_GetLogLevel(wLog* log);
 	WINPR_API BOOL WLog_IsLevelActive(wLog* _log, DWORD _log_level);
 
+	/** @brief Set a custom context for a dynamic logger.
+	 *  This can be used to print a customized prefix, e.g. some session id for a specific context
+	 *
+	 *  @param log The logger to ste the context for. Must not be \b NULL
+	 *  @param fkt A function pointer that is called to get the custimized string.
+	 *  @param context A context \b fkt is called with. Caller must ensure it is still allocated
+	 * when \b log is used
+	 *
+	 *  @return \b TRUE for success, \b FALSE otherwise.
+	 */
+	WINPR_API BOOL WLog_SetContext(wLog* log, const char* (*fkt)(void*), void* context);
+
 #define WLog_Print(_log, _log_level, ...)                                              \
 	do                                                                                 \
 	{                                                                                  \

--- a/winpr/libwinpr/utils/test/TestLinkedList.c
+++ b/winpr/libwinpr/utils/test/TestLinkedList.c
@@ -22,7 +22,7 @@ int TestLinkedList(int argc, char* argv[])
 
 	if (count != 3)
 	{
-		printf("LinkedList_Count: expected 3, actual: %d\n", count);
+		printf("LinkedList_Count: expected 3, actual: %" PRIuz "\n", count);
 		return -1;
 	}
 
@@ -41,7 +41,7 @@ int TestLinkedList(int argc, char* argv[])
 
 	if (count != 1)
 	{
-		printf("LinkedList_Count: expected 1, actual: %d\n", count);
+		printf("LinkedList_Count: expected 1, actual: %" PRIuz "\n", count);
 		return -1;
 	}
 
@@ -60,7 +60,7 @@ int TestLinkedList(int argc, char* argv[])
 
 	if (count != 0)
 	{
-		printf("LinkedList_Count: expected 0, actual: %d\n", count);
+		printf("LinkedList_Count: expected 0, actual: %" PRIuz "\n", count);
 		return -1;
 	}
 
@@ -74,7 +74,7 @@ int TestLinkedList(int argc, char* argv[])
 
 	if (count != 3)
 	{
-		printf("LinkedList_Count: expected 3, actual: %d\n", count);
+		printf("LinkedList_Count: expected 3, actual: %" PRIuz "\n", count);
 		return -1;
 	}
 

--- a/winpr/libwinpr/utils/test/TestListDictionary.c
+++ b/winpr/libwinpr/utils/test/TestListDictionary.c
@@ -137,8 +137,8 @@ int TestListDictionary(int argc, char* argv[])
 	count = ListDictionary_Count(list);
 	if (strncmp(value, val1, 4) || count != 1)
 	{
-		printf("ListDictionary_Remove_Head: Expected : %s, Actual: %s Count: %d\n", val1, value,
-		       count);
+		printf("ListDictionary_Remove_Head: Expected : %s, Actual: %s Count: %" PRIuz "\n", val1,
+		       value, count);
 		return -1;
 	}
 
@@ -146,8 +146,8 @@ int TestListDictionary(int argc, char* argv[])
 	count = ListDictionary_Count(list);
 	if (strncmp(value, val3, 4) || count != 0)
 	{
-		printf("ListDictionary_Remove_Head: Expected : %s, Actual: %s Count: %d\n", val3, value,
-		       count);
+		printf("ListDictionary_Remove_Head: Expected : %s, Actual: %s Count: %" PRIuz "\n", val3,
+		       value, count);
 		return -1;
 	}
 

--- a/winpr/libwinpr/utils/wlog/wlog.c
+++ b/winpr/libwinpr/utils/wlog/wlog.c
@@ -367,7 +367,7 @@ BOOL WLog_PrintMessageVA(wLog* log, DWORD type, DWORD level, size_t line, const 
 
 			if (!strchr(message.FormatString, '%'))
 			{
-				message.TextString = (LPCSTR)message.FormatString;
+				message.TextString = message.FormatString;
 				status = WLog_Write(log, &message);
 			}
 			else
@@ -1069,3 +1069,12 @@ BOOL WLog_Uninit(void)
 	return TRUE;
 }
 #endif
+
+BOOL WLog_SetContext(wLog* log, const char* (*fkt)(void*), void* context)
+{
+	WINPR_ASSERT(log);
+
+	log->custom = fkt;
+	log->context = context;
+	return TRUE;
+}

--- a/winpr/libwinpr/utils/wlog/wlog.h
+++ b/winpr/libwinpr/utils/wlog/wlog.h
@@ -79,6 +79,8 @@ struct s_wLog
 	DWORD ChildrenCount;
 	DWORD ChildrenSize;
 	CRITICAL_SECTION lock;
+	const char* (*custom)(void*);
+	void* context;
 };
 
 extern const char* WLOG_LEVELS[7];


### PR DESCRIPTION
A logger allocated with WLog_Get now can have a customized context by setting it with WLog_SetContext. Along with the newly introduced format specifier %ctx an additional field is printed for the context.
