### PR TITLE
the default Swiss keyboard layout is German, French is a variant

### DIFF
--- a/libfreerdp/locale/xkb_layout_ids.c
+++ b/libfreerdp/locale/xkb_layout_ids.c
@@ -802,7 +802,7 @@ static const XKB_LAYOUT xkbLayouts[] = {
 	{ "sk", KBD_SLOVAK, sk_variants },                           /* Slovakia */
 	{ "es", KBD_SPANISH, es_variants },                          /* Spain */
 	{ "se", KBD_SWEDISH, se_variants },                          /* Sweden */
-	{ "ch", KBD_SWISS_FRENCH, ch_variants },                     /* Switzerland */
+	{ "ch", KBD_SWISS_GERMAN, ch_variants },                     /* Switzerland */
 	{ "sy", KBD_SYRIAC, sy_variants },                           /* Syria */
 	{ "tj", 0, tj_variants },                                    /* Tajikistan */
 	{ "lk", 0, lk_variants },                                    /* Sri Lanka */


### PR DESCRIPTION
I use the Swiss German keyboard layout. When connecting to a Windows Terminal Server it selects automatically the Swiss French keyboard layout. The same when connecting to xrdp:
```
Jun 30 16:25:14 lxdev05.psi.ch xrdp[4137]: [INFO ] xrdp_load_keyboard_layout: model [] variant [] layout [ch(fr)] options []
```
after applying this fix both select the Swiss German keyboard layout correctly:
```
Jun 30 16:34:28 lxdev05.psi.ch xrdp[5967]: [INFO ] xrdp_load_keyboard_layout: model [] variant [] layout [ch] options []
```
When I select the Swiss French keyboard layout on my desktop, it detects and uses the Swiss French layout also remote.
