### PR TITLE
core: Fix flag check to enable/disable RDSTLS security

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -661,7 +661,8 @@ BOOL rdp_client_redirect(rdpRdp* rdp)
 			return FALSE;
 	}
 
-	settings->RdstlsSecurity = settings->RedirectionFlags & LB_PASSWORD_IS_PK_ENCRYPTED;
+	settings->RdstlsSecurity =
+	    (settings->RedirectionFlags & LB_PASSWORD_IS_PK_ENCRYPTED) != 0 ? TRUE : FALSE;
 
 	WINPR_ASSERT(rdp->context);
 	WINPR_ASSERT(rdp->context->instance);


### PR DESCRIPTION
On some platforms (i.e. Mac) the `BOOL` type might be narrower than the `RedirectionFlags` type leading to an overflow when just assigning the logical AND result to the setting. This fix makes sure that the value is correctly set to either `TRUE` or `FALSE`.
