### PR TITLE
misc: More int to BOOL conversion fixes

### DIFF
--- a/channels/cliprdr/client/cliprdr_main.c
+++ b/channels/cliprdr/client/cliprdr_main.c
@@ -193,11 +193,11 @@ static UINT cliprdr_process_general_capability(cliprdrPlugin* cliprdr, wStream* 
 
 	cliprdr_print_general_capability_flags(generalFlags);
 
-	cliprdr->useLongFormatNames = (generalFlags & CB_USE_LONG_FORMAT_NAMES);
-	cliprdr->streamFileClipEnabled = (generalFlags & CB_STREAM_FILECLIP_ENABLED);
-	cliprdr->fileClipNoFilePaths = (generalFlags & CB_FILECLIP_NO_FILE_PATHS);
-	cliprdr->canLockClipData = (generalFlags & CB_CAN_LOCK_CLIPDATA);
-	cliprdr->hasHugeFileSupport = (generalFlags & CB_HUGE_FILE_SUPPORT_ENABLED);
+	cliprdr->useLongFormatNames = (generalFlags & CB_USE_LONG_FORMAT_NAMES) ? TRUE : FALSE;
+	cliprdr->streamFileClipEnabled = (generalFlags & CB_STREAM_FILECLIP_ENABLED) ? TRUE : FALSE;
+	cliprdr->fileClipNoFilePaths = (generalFlags & CB_FILECLIP_NO_FILE_PATHS) ? TRUE : FALSE;
+	cliprdr->canLockClipData = (generalFlags & CB_CAN_LOCK_CLIPDATA) ? TRUE : FALSE;
+	cliprdr->hasHugeFileSupport = (generalFlags & CB_HUGE_FILE_SUPPORT_ENABLED) ? TRUE : FALSE;
 	cliprdr->capabilitiesReceived = TRUE;
 
 	capabilities.common.msgType = CB_CLIP_CAPS;
@@ -613,11 +613,11 @@ static UINT cliprdr_client_capabilities(CliprdrClientContext* context,
 	if (!cliprdr->hasHugeFileSupport)
 		flags &= ~CB_HUGE_FILE_SUPPORT_ENABLED;
 
-	cliprdr->useLongFormatNames = flags & CB_USE_LONG_FORMAT_NAMES;
-	cliprdr->streamFileClipEnabled = flags & CB_STREAM_FILECLIP_ENABLED;
-	cliprdr->fileClipNoFilePaths = flags & CB_FILECLIP_NO_FILE_PATHS;
-	cliprdr->canLockClipData = flags & CB_CAN_LOCK_CLIPDATA;
-	cliprdr->hasHugeFileSupport = flags & CB_HUGE_FILE_SUPPORT_ENABLED;
+	cliprdr->useLongFormatNames = (flags & CB_USE_LONG_FORMAT_NAMES) ? TRUE : FALSE;
+	cliprdr->streamFileClipEnabled = (flags & CB_STREAM_FILECLIP_ENABLED) ? TRUE : FALSE;
+	cliprdr->fileClipNoFilePaths = (flags & CB_FILECLIP_NO_FILE_PATHS) ? TRUE : FALSE;
+	cliprdr->canLockClipData = (flags & CB_CAN_LOCK_CLIPDATA) ? TRUE : FALSE;
+	cliprdr->hasHugeFileSupport = (flags & CB_HUGE_FILE_SUPPORT_ENABLED) ? TRUE : FALSE;
 
 	Stream_Write_UINT32(s, flags); /* generalFlags */
 	WLog_Print(cliprdr->log, WLOG_DEBUG, "ClientCapabilities");

--- a/channels/rail/rail_common.c
+++ b/channels/rail/rail_common.c
@@ -587,5 +587,5 @@ UINT rail_write_sysparam_order(wStream* s, const RAIL_SYSPARAM_ORDER* sysparam,
 
 BOOL rail_is_extended_spi_supported(UINT32 channelFlags)
 {
-	return channelFlags & TS_RAIL_ORDER_HANDSHAKE_EX_FLAGS_EXTENDED_SPI_SUPPORTED;
+	return (channelFlags & TS_RAIL_ORDER_HANDSHAKE_EX_FLAGS_EXTENDED_SPI_SUPPORTED) ? TRUE : FALSE;
 }

--- a/channels/rdpei/rdpei_common.c
+++ b/channels/rdpei/rdpei_common.c
@@ -261,7 +261,7 @@ BOOL rdpei_read_4byte_signed(wStream* s, INT32* value)
 	Stream_Read_UINT8(s, byte);
 
 	count = (byte & 0xC0) >> 6;
-	negative = (byte & 0x20);
+	negative = (byte & 0x20) ? TRUE : FALSE;
 
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, count))
 		return FALSE;

--- a/client/SDL/sdl_freerdp.cpp
+++ b/client/SDL/sdl_freerdp.cpp
@@ -795,7 +795,7 @@ static int sdl_run(SdlContext* sdl)
 					const SDL_bool enter = windowEvent.user.code != 0 ? SDL_TRUE : SDL_FALSE;
 
 					Uint32 curFlags = SDL_GetWindowFlags(window);
-					const BOOL isSet = (curFlags & SDL_WINDOW_FULLSCREEN);
+					const BOOL isSet = (curFlags & SDL_WINDOW_FULLSCREEN) ? TRUE : FALSE;
 					if (enter)
 						curFlags |= SDL_WINDOW_FULLSCREEN;
 					else

--- a/client/common/client_cliprdr_file.c
+++ b/client/common/client_cliprdr_file.c
@@ -1045,7 +1045,8 @@ static UINT cliprdr_file_send_client_file_contents_request(CliprdrFileContext* f
 	CLIPRDR_FILE_CONTENTS_REQUEST formatFileContentsRequest = {
 		.streamId = streamId,
 		.clipDataId = lockId,
-		.haveClipDataId = cliprdr_file_context_current_flags(file) & CB_CAN_LOCK_CLIPDATA,
+		.haveClipDataId =
+		    cliprdr_file_context_current_flags(file) & CB_CAN_LOCK_CLIPDATA ? TRUE : FALSE,
 		.listIndex = listIndex,
 		.dwFlags = dwFlags
 	};
@@ -2011,7 +2012,7 @@ static BOOL is_directory(const char* path)
 	if (!status)
 		return FALSE;
 
-	return fileInformation.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY;
+	return (fileInformation.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) ? TRUE : FALSE;
 }
 
 static BOOL add_directory(CliprdrLocalStream* stream, const char* path)

--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -596,7 +596,7 @@ BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32
 	const UINT32 copyDstWidth = nWidth * dstByte;
 	const UINT32 xSrcOffset = nXSrc * srcByte;
 	const UINT32 xDstOffset = nXDst * dstByte;
-	const BOOL vSrcVFlip = flags & FREERDP_FLIP_VERTICAL;
+	const BOOL vSrcVFlip = (flags & FREERDP_FLIP_VERTICAL) ? TRUE : FALSE;
 	UINT32 srcVOffset = 0;
 	INT32 srcVMultiplier = 1;
 	UINT32 dstVOffset = 0;

--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -599,8 +599,10 @@ static BOOL rdp_read_order_capability_set(wStream* s, rdpSettings* settings)
 
 	if (settings->OrderSupportFlags & ORDER_FLAGS_EXTRA_SUPPORT)
 	{
-		BitmapCacheV3Enabled = settings->OrderSupportFlagsEx & CACHE_BITMAP_V3_SUPPORT;
-		FrameMarkerCommandEnabled = settings->OrderSupportFlagsEx & ALTSEC_FRAME_MARKER_SUPPORT;
+		BitmapCacheV3Enabled =
+		    (settings->OrderSupportFlagsEx & CACHE_BITMAP_V3_SUPPORT) ? TRUE : FALSE;
+		FrameMarkerCommandEnabled =
+		    (settings->OrderSupportFlagsEx & ALTSEC_FRAME_MARKER_SUPPORT) ? TRUE : FALSE;
 	}
 
 	settings->BitmapCacheV3Enabled = BitmapCacheV3Enabled;
@@ -2284,7 +2286,8 @@ static BOOL rdp_read_draw_nine_grid_cache_capability_set(wStream* s, rdpSettings
 	                   settings->DrawNineGridCacheEntries); /* drawNineGridCacheEntries (2 bytes) */
 
 	settings->DrawNineGridEnabled =
-	    drawNineGridSupportLevel & (DRAW_NINEGRID_SUPPORTED | DRAW_NINEGRID_SUPPORTED_V2);
+	    (drawNineGridSupportLevel & (DRAW_NINEGRID_SUPPORTED | DRAW_NINEGRID_SUPPORTED_V2)) ? TRUE
+	                                                                                        : FALSE;
 
 	return TRUE;
 }
@@ -2397,8 +2400,10 @@ static BOOL rdp_read_draw_gdiplus_cache_capability_set(wStream* s, rdpSettings* 
 	Stream_Seek(s, 8);                              /* GdipCacheChunkSize (8 bytes) */
 	Stream_Seek(s, 6);                              /* GdipImageCacheProperties (6 bytes) */
 
-	settings->DrawGdiPlusEnabled = drawGDIPlusSupportLevel & DRAW_GDIPLUS_SUPPORTED;
-	settings->DrawGdiPlusCacheEnabled = drawGdiplusCacheLevel & DRAW_GDIPLUS_CACHE_LEVEL_ONE;
+	settings->DrawGdiPlusEnabled =
+	    (drawGDIPlusSupportLevel & DRAW_GDIPLUS_SUPPORTED) ? TRUE : FALSE;
+	settings->DrawGdiPlusCacheEnabled =
+	    (drawGdiplusCacheLevel & DRAW_GDIPLUS_CACHE_LEVEL_ONE) ? TRUE : FALSE;
 
 	return TRUE;
 }
@@ -2492,7 +2497,7 @@ static BOOL rdp_read_remote_programs_capability_set(wStream* s, rdpSettings* set
 
 	Stream_Read_UINT32(s, railSupportLevel); /* railSupportLevel (4 bytes) */
 
-	settings->RemoteApplicationMode = railSupportLevel & RAIL_LEVEL_SUPPORTED;
+	settings->RemoteApplicationMode = (railSupportLevel & RAIL_LEVEL_SUPPORTED) ? TRUE : FALSE;
 	settings->RemoteApplicationSupportLevel = railSupportLevel;
 	return TRUE;
 }

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -2097,8 +2097,10 @@ BOOL gcc_read_client_cluster_data(wStream* s, rdpMcs* mcs)
 	if (settings->ClusterInfoFlags & REDIRECTED_SESSIONID_FIELD_VALID)
 		settings->RedirectedSessionId = redirectedSessionId;
 
-	settings->ConsoleSession = (settings->ClusterInfoFlags & REDIRECTED_SESSIONID_FIELD_VALID);
-	settings->RedirectSmartCards = (settings->ClusterInfoFlags & REDIRECTED_SMARTCARD);
+	settings->ConsoleSession =
+	    (settings->ClusterInfoFlags & REDIRECTED_SESSIONID_FIELD_VALID) ? TRUE : FALSE;
+	settings->RedirectSmartCards =
+	    (settings->ClusterInfoFlags & REDIRECTED_SMARTCARD) ? TRUE : FALSE;
 
 	if (blockLength != 8)
 	{
@@ -2220,7 +2222,7 @@ BOOL gcc_read_client_monitor_data(wStream* s, rdpMcs* mcs)
 		current->y = top;
 		current->width = right - left + 1;
 		current->height = bottom - top + 1;
-		current->is_primary = (flags & MONITOR_PRIMARY);
+		current->is_primary = (flags & MONITOR_PRIMARY) ? TRUE : FALSE;
 	}
 
 	return TRUE;

--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -78,7 +78,7 @@ static BOOL rdp_read_info_null_string(const char* what, UINT32 flags, wStream* s
 {
 	CHAR* ret = NULL;
 
-	const BOOL unicode = flags & INFO_UNICODE;
+	const BOOL unicode = (flags & INFO_UNICODE) ? TRUE : FALSE;
 	const size_t nullSize = unicode ? sizeof(WCHAR) : sizeof(CHAR);
 
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, (size_t)(cbLen)))
@@ -608,7 +608,7 @@ static BOOL rdp_read_info_string(UINT32 flags, wStream* s, size_t cbLenNonNull, 
 	} terminator;
 	CHAR* ret = NULL;
 
-	const BOOL unicode = flags & INFO_UNICODE;
+	const BOOL unicode = (flags & INFO_UNICODE) ? TRUE : FALSE;
 	const size_t nullSize = unicode ? sizeof(WCHAR) : sizeof(CHAR);
 
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, (size_t)(cbLenNonNull + nullSize)))

--- a/server/shadow/shadow_client.c
+++ b/server/shadow/shadow_client.c
@@ -807,7 +807,7 @@ static BOOL shadow_client_caps_test_version(RdpgfxServerContext* context, rdpSha
 
 			flags = pdu.capsSet->flags;
 
-			clientSettings->GfxSmallCache = (flags & RDPGFX_CAPS_FLAG_SMALL_CACHE);
+			clientSettings->GfxSmallCache = (flags & RDPGFX_CAPS_FLAG_SMALL_CACHE) ? TRUE : FALSE;
 
 			avc444v2 = avc444 = !(flags & RDPGFX_CAPS_FLAG_AVC_DISABLED);
 			if (!freerdp_settings_get_bool(srvSettings, FreeRDP_GfxAVC444v2) || !h264)
@@ -941,9 +941,9 @@ static UINT shadow_client_rdpgfx_caps_advertise(RdpgfxServerContext* context,
 				freerdp_settings_set_bool(clientSettings, FreeRDP_GfxAVC444, FALSE);
 
 				freerdp_settings_set_bool(clientSettings, FreeRDP_GfxThinClient,
-				                          (flags & RDPGFX_CAPS_FLAG_THINCLIENT));
+				                          (flags & RDPGFX_CAPS_FLAG_THINCLIENT) ? TRUE : FALSE);
 				freerdp_settings_set_bool(clientSettings, FreeRDP_GfxSmallCache,
-				                          (flags & RDPGFX_CAPS_FLAG_SMALL_CACHE));
+				                          (flags & RDPGFX_CAPS_FLAG_SMALL_CACHE) ? TRUE : FALSE);
 
 #ifndef WITH_GFX_H264
 				freerdp_settings_set_bool(clientSettings, FreeRDP_GfxH264, FALSE);
@@ -952,7 +952,8 @@ static UINT shadow_client_rdpgfx_caps_advertise(RdpgfxServerContext* context,
 
 				if (h264)
 					freerdp_settings_set_bool(clientSettings, FreeRDP_GfxH264,
-					                          (flags & RDPGFX_CAPS_FLAG_AVC420_ENABLED));
+					                          (flags & RDPGFX_CAPS_FLAG_AVC420_ENABLED) ? TRUE
+					                                                                    : FALSE);
 				else
 					freerdp_settings_set_bool(clientSettings, FreeRDP_GfxH264, FALSE);
 #endif
@@ -981,9 +982,9 @@ static UINT shadow_client_rdpgfx_caps_advertise(RdpgfxServerContext* context,
 				freerdp_settings_set_bool(clientSettings, FreeRDP_GfxH264, FALSE);
 
 				freerdp_settings_set_bool(clientSettings, FreeRDP_GfxThinClient,
-				                          (flags & RDPGFX_CAPS_FLAG_THINCLIENT));
+				                          (flags & RDPGFX_CAPS_FLAG_THINCLIENT) ? TRUE : FALSE);
 				freerdp_settings_set_bool(clientSettings, FreeRDP_GfxSmallCache,
-				                          (flags & RDPGFX_CAPS_FLAG_SMALL_CACHE));
+				                          (flags & RDPGFX_CAPS_FLAG_SMALL_CACHE) ? TRUE : FALSE);
 
 				WINPR_ASSERT(context->CapsConfirm);
 				return context->CapsConfirm(context, &pdu);

--- a/winpr/libwinpr/synch/barrier.c
+++ b/winpr/libwinpr/synch/barrier.c
@@ -181,8 +181,8 @@ BOOL WINAPI winpr_EnterSynchronizationBarrier(LPSYNCHRONIZATION_BARRIER lpBarrie
 	if (remainingThreads > 0)
 	{
 		DWORD dwProcessors = lpBarrier->Reserved4;
-		BOOL spinOnly = dwFlags & SYNCHRONIZATION_BARRIER_FLAGS_SPIN_ONLY;
-		BOOL blockOnly = dwFlags & SYNCHRONIZATION_BARRIER_FLAGS_BLOCK_ONLY;
+		BOOL spinOnly = (dwFlags & SYNCHRONIZATION_BARRIER_FLAGS_SPIN_ONLY) ? TRUE : FALSE;
+		BOOL blockOnly = (dwFlags & SYNCHRONIZATION_BARRIER_FLAGS_BLOCK_ONLY) ? TRUE : FALSE;
 		BOOL block = TRUE;
 
 		/**


### PR DESCRIPTION
This is a follow up to #9129.

This PR fixes some problematic `int` to `BOOL` conversions that might cause overflows when checking for bit flags.
