### PR TITLE
[core,gateway] cleanup http response

### DIFF
--- a/libfreerdp/core/gateway/arm.c
+++ b/libfreerdp/core/gateway/arm.c
@@ -378,6 +378,7 @@ BOOL arm_resolve_endpoint(rdpContext* context, DWORD timeout)
 
 	rc = TRUE;
 arm_error:
+	http_response_free(response);
 	arm_free(arm);
 	free(message);
 	return rc;

--- a/libfreerdp/core/gateway/http.c
+++ b/libfreerdp/core/gateway/http.c
@@ -339,6 +339,7 @@ BOOL http_context_enable_websocket_upgrade(HttpContext* context, BOOL enable)
 		if (winpr_RAND(key, sizeof(key)) != 0)
 			return FALSE;
 
+		free(context->SecWebsocketKey);
 		context->SecWebsocketKey = crypto_base64_encode(key, sizeof(key));
 		if (!context->SecWebsocketKey)
 			return FALSE;


### PR DESCRIPTION
also if http_context_enable_websocket_upgrade was called multiple times it could memory leak previos SecWebsocketKey values