### PR TITLE
[utils] use select instead of poll to read passphrases on macOS

### DIFF
--- a/libfreerdp/utils/passphrase.c
+++ b/libfreerdp/utils/passphrase.c
@@ -75,7 +75,7 @@ char* freerdp_passphrase_read(rdpContext* context, const char* prompt, char* buf
 #include <termios.h>
 #include <freerdp/utils/signal.h>
 
-#ifdef WINPR_HAVE_POLL_H
+#if defined(WINPR_HAVE_POLL_H) && !defined(__APPLE__)
 #include <poll.h>
 #else
 #include <time.h>
@@ -85,7 +85,7 @@ char* freerdp_passphrase_read(rdpContext* context, const char* prompt, char* buf
 static int wait_for_fd(int fd, int timeout)
 {
 	int status;
-#ifdef WINPR_HAVE_POLL_H
+#if defined(WINPR_HAVE_POLL_H) && !defined(__APPLE__)
 	struct pollfd pollset = { 0 };
 	pollset.fd = fd;
 	pollset.events = POLLIN;


### PR DESCRIPTION
According to the man page on macOS poll currently doesn't support devices. This includes `/dev/tty`.
In this use case poll will returned immediately indicating that something can be read but the following read returned `-1` (with errno set to EAGAIN).

Using select on macOS for passphrase reading prevents this problem.