### PR TITLE
core: Fix issues in settings copy code

### DIFF
--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -1012,9 +1012,9 @@ static BOOL freerdp_settings_int_buffer_copy(rdpSettings* _settings, const rdpSe
 
 		if (len < count)
 			goto out_fail;
-		if (!freerdp_settings_set_uint32(_settings, FreeRDP_DeviceCount, count))
-			goto out_fail;
 		if (!freerdp_settings_set_pointer_len(_settings, FreeRDP_DeviceArray, NULL, len))
+			goto out_fail;
+		if (!freerdp_settings_set_uint32(_settings, FreeRDP_DeviceCount, count))
 			goto out_fail;
 
 		for (index = 0; index < count; index++)
@@ -1031,9 +1031,9 @@ static BOOL freerdp_settings_int_buffer_copy(rdpSettings* _settings, const rdpSe
 
 		if (len < count)
 			goto out_fail;
-		if (!freerdp_settings_set_uint32(_settings, FreeRDP_StaticChannelCount, count))
-			goto out_fail;
 		if (!freerdp_settings_set_pointer_len(_settings, FreeRDP_StaticChannelArray, NULL, len))
+			goto out_fail;
+		if (!freerdp_settings_set_uint32(_settings, FreeRDP_StaticChannelCount, count))
 			goto out_fail;
 
 		for (index = 0; index < count; index++)
@@ -1051,11 +1051,9 @@ static BOOL freerdp_settings_int_buffer_copy(rdpSettings* _settings, const rdpSe
 
 		if (len < count)
 			goto out_fail;
-		if (!freerdp_settings_set_uint32(_settings, FreeRDP_DynamicChannelCount, count))
-			goto out_fail;
-		if (!freerdp_settings_set_uint32(_settings, FreeRDP_DynamicChannelCount, count))
-			goto out_fail;
 		if (!freerdp_settings_set_pointer_len(_settings, FreeRDP_DynamicChannelArray, NULL, len))
+			goto out_fail;
+		if (!freerdp_settings_set_uint32(_settings, FreeRDP_DynamicChannelCount, count))
 			goto out_fail;
 
 		for (index = 0; index < count; index++)


### PR DESCRIPTION
This code fixes an issue where some settings were lost when copying settings around. I.e. the device count was first set but then calling `freerdp_settings_set_pointer_len` caused the device count to be reset to 0 because we passed `NULL` for the data value.

This means the count got lost upon the first copy and further copies also resulted in losing the array data (because the count was set to 0).

This PR fixes this issue by first resetting the array and afterwards setting the correct count value.