### PR TITLE
fix ffmpeg source tarball url

### DIFF
--- a/scripts/android-build-ffmpeg.sh
+++ b/scripts/android-build-ffmpeg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCM_URL=https://github.com/FFmpeg/FFmpeg
+SCM_URL=https://github.com/FFmpeg/FFmpeg/archive
 SCM_TAG=n4.4.1
 SCM_HASH=82b43cc67296bcd01a59ae6b327cdb50121d3a9e35f41a30de1edd71bb4a6666
 


### PR DESCRIPTION
Looks like it's a typo introduced by cherry-pick.