### PR TITLE
fix the issue of incorrect display of remote desktop cursor

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -1386,7 +1386,7 @@ static int wfreerdp_client_start(rdpContext* context)
 	wfc->wndClass.lpfnWndProc = wf_event_proc;
 	wfc->wndClass.cbClsExtra = 0;
 	wfc->wndClass.cbWndExtra = 0;
-	wfc->wndClass.hCursor = wfc->cursor;
+	wfc->wndClass.hCursor = NULL;
 	wfc->wndClass.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
 	wfc->wndClass.lpszMenuName = NULL;
 	wfc->wndClass.lpszClassName = wfc->wndClassName;


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setcursor

"If your application must set the cursor while it is in a window, make sure the class cursor for the specified window's class is set to NULL. If the class cursor is not NULL, the system restores the class cursor each time the mouse is moved."