### PR TITLE
X11/cliprdr: Rework server to client clipboard handling

### DIFF
--- a/channels/cliprdr/cliprdr_common.c
+++ b/channels/cliprdr/cliprdr_common.c
@@ -138,7 +138,7 @@ cliprdr_packet_unlock_clipdata_new(const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockCl
 	if (!unlockClipboardData)
 		return NULL;
 
-	s = cliprdr_packet_new(CB_LOCK_CLIPDATA, 0, 4);
+	s = cliprdr_packet_new(CB_UNLOCK_CLIPDATA, 0, 4);
 
 	if (!s)
 		return NULL;

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -780,6 +780,7 @@ static UINT xf_cliprdr_send_format_list(xfClipboard* clipboard, const CLIPRDR_FO
 		                                     .numFormats = numFormats,
 		                                     .formats = cnv.pv,
 		                                     .common.msgType = CB_FORMAT_LIST };
+	UINT ret;
 
 	WINPR_ASSERT(clipboard);
 	WINPR_ASSERT(formats || (numFormats == 0));
@@ -801,6 +802,10 @@ static UINT xf_cliprdr_send_format_list(xfClipboard* clipboard, const CLIPRDR_FO
 	xf_cliprdr_send_data_response(clipboard, NULL, NULL, 0);
 
 	xf_cliprdr_clear_cached_data(clipboard);
+
+	ret = cliprdr_file_context_notify_new_client_format_list(clipboard->file);
+	if (ret)
+		return ret;
 
 	WINPR_ASSERT(clipboard->context);
 	WINPR_ASSERT(clipboard->context->ClientFormatList);
@@ -1858,6 +1863,10 @@ static UINT xf_cliprdr_server_format_list(CliprdrClientContext* context,
 			}
 		}
 	}
+
+	ret = cliprdr_file_context_notify_new_server_format_list(clipboard->file);
+	if (ret)
+		return ret;
 
 	/* CF_RAW is always implicitly supported by the server */
 	{

--- a/include/freerdp/client/client_cliprdr_file.h
+++ b/include/freerdp/client/client_cliprdr_file.h
@@ -67,6 +67,12 @@ extern "C"
 
 	FREERDP_API BOOL cliprdr_file_context_clear(CliprdrFileContext* file);
 
+	FREERDP_API UINT
+	cliprdr_file_context_notify_new_server_format_list(CliprdrFileContext* file_context);
+
+	FREERDP_API UINT
+	cliprdr_file_context_notify_new_client_format_list(CliprdrFileContext* file_context);
+
 	/** \brief updates the files the client announces to the server
 	 *
 	 * \param file the file context to update

--- a/include/freerdp/server/audin.h
+++ b/include/freerdp/server/audin.h
@@ -105,10 +105,6 @@ extern "C"
 
 		/**
 		 * Send an Open PDU.
-		 *
-		 * In case of ExtraFormatData is not NULL, the SubFormat is always
-		 * KSDATAFORMAT_SUBTYPE_PCM, i.e. it is not required to be explicitly set by
-		 * the API user.
 		 */
 		psAudinServerOpen SendOpen;
 

--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -1506,7 +1506,7 @@ BOOL WINAPI FreeRDP_WTSVirtualChannelRead(HANDLE hChannelHandle, ULONG TimeOut, 
 		return FALSE;
 	}
 
-	messageCtx = (wtsChannelMessage*)(UINT_PTR)message.context;
+	messageCtx = message.context;
 
 	if (messageCtx == NULL)
 		return FALSE;


### PR DESCRIPTION
This gets rid of the multiple lock issue reported in https://github.com/FreeRDP/FreeRDP/issues/8846.

Quoting the main commit here:
```
The purpose of clipboard data locking is to make the other peer
retaining the current file list until a pending paste operation is done,
even though the clipboard selection changed.
As it may be difficult to determine, when a lock is needed, imitate the
same behaviour as mstsc:
When the server side supports clipboard data locking, always attempt to
lock the file list on the server regardless of what is advertised in a
FormatList PDU.
The Lock Clipboard Data PDU can even be already sent, before the
Format List Response PDU is sent.
This is also what mstsc, does: First, lock the new (potential) file
list, then unlock the file list, when the pending paste operation is
done.
So, rework the current clipboard implementation in that direction.

Since the implementation for timeouts for old file lists is a bit hard,
for now always force unlock pending locks, when the selection changes.
However, timeouts for old file lists can still be added in the future.

The reworked clipboard handling is done with the help of three hash
tables:

1. The inode table: This hash table manages all inodes for each file.
   The keys in this table are the inodes themselves, while the values
   the files and directories and their attributes (file size, last write
   time, etc.).
2. The clipdata table: This table manages the locks for each file list.
   The keys in this table represent the clip data id and the values the
   clip data entries, which have a reference to the clip data dir, a
   directory containing the whole selection, and some helper attributes,
   like the clip data id itself.
3. The request table: Every file size or file range request is managed
   here. When a FileContentsRequest is made, its stream id with the
   respective details are added to this table. When a response is
   received, these details can then be easily looked up here.
```

Tested with g-r-d and MS Windows RDS on Win 11.

Closes: https://github.com/FreeRDP/FreeRDP/issues/8846