### PR TITLE
[stable-2.0] channels/cliprdr: Fix writing incorrect PDU type for unlock PDUs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ Fixed issues:
 * Backported #8994: bounds checks for gdi/gfx rectangles
 * Backported #9023: enforce rdpdr client side state checks
 * Backported #6331: deactivate mouse grabbing by default
+* Cherry-pick out of #9172: channels/cliprdr: Fix writing incorrect PDU type for unlock PDUs
 
 # 2023-02-16 Version 2.10.0
 

--- a/channels/cliprdr/cliprdr_common.c
+++ b/channels/cliprdr/cliprdr_common.c
@@ -138,7 +138,7 @@ cliprdr_packet_unlock_clipdata_new(const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockCl
 	if (!unlockClipboardData)
 		return NULL;
 
-	s = cliprdr_packet_new(CB_LOCK_CLIPDATA, 0, 4);
+	s = cliprdr_packet_new(CB_UNLOCK_CLIPDATA, 0, 4);
 
 	if (!s)
 		return NULL;


### PR DESCRIPTION
Cherry-pick of the `channels/cliprdr: Fix writing incorrect PDU type for unlock PDUs` commit of https://github.com/FreeRDP/FreeRDP/pull/9172