### PR TITLE
sdl client multimonitor support

### DIFF
--- a/client/SDL/sdl_disp.cpp
+++ b/client/SDL/sdl_disp.cpp
@@ -323,6 +323,8 @@ BOOL sdlDispContext::handle_window_event(const SDL_WindowEvent* ev)
 		case SDL_WINDOWEVENT_ENTER:
 			WINPR_ASSERT(_sdl);
 			_sdl->input.keyboard_grab(ev->windowID, SDL_TRUE);
+
+
 			return _sdl->input.keyboard_focus_in();
 		case SDL_WINDOWEVENT_FOCUS_GAINED:
 		case SDL_WINDOWEVENT_TAKE_FOCUS:

--- a/client/SDL/sdl_disp.cpp
+++ b/client/SDL/sdl_disp.cpp
@@ -323,8 +323,6 @@ BOOL sdlDispContext::handle_window_event(const SDL_WindowEvent* ev)
 		case SDL_WINDOWEVENT_ENTER:
 			WINPR_ASSERT(_sdl);
 			_sdl->input.keyboard_grab(ev->windowID, SDL_TRUE);
-
-
 			return _sdl->input.keyboard_focus_in();
 		case SDL_WINDOWEVENT_FOCUS_GAINED:
 		case SDL_WINDOWEVENT_TAKE_FOCUS:

--- a/client/SDL/sdl_disp.cpp
+++ b/client/SDL/sdl_disp.cpp
@@ -96,15 +96,12 @@ BOOL sdlDispContext::sendResize()
 	if (!settings_changed())
 		return TRUE;
 
-	/* TODO: Multimonitor support for wayland
-	if (sdl->fullscreen && (settings->MonitorCount > 0))
+	if (_sdl->fullscreen && (settings->MonitorCount > 0))
 	{
-	    if (sdlDisp->sendLayout(settings->MonitorDefArray,
-	                           settings->MonitorCount) != CHANNEL_RC_OK)
-	        return FALSE;
+		if (sendLayout(settings->MonitorDefArray, settings->MonitorCount) != CHANNEL_RC_OK)
+			return FALSE;
 	}
 	else
-	*/
 	{
 		_waitingResize = TRUE;
 		layout.Flags = DISPLAY_CONTROL_MONITOR_PRIMARY;

--- a/client/SDL/sdl_freerdp.cpp
+++ b/client/SDL/sdl_freerdp.cpp
@@ -615,21 +615,29 @@ static BOOL sdl_create_windows(SdlContext* sdl)
 	BOOL rc = FALSE;
 
 	// TODO: Multimonitor setup
-	const size_t windowCount = sdl->context()->settings->UseMultimon ? SDL_GetNumVideoDisplays() : 1;
 
-	for (size_t x = 0; x < windowCount; x++)
+
+	UINT32 windowCount = freerdp_settings_get_uint32(sdl->context()->settings, FreeRDP_MonitorCount);
+
+	for (UINT32 x = 0; x < windowCount; x++)
 	{
-		SDL_Rect displaySize;
-		SDL_GetDisplayBounds(x,&displaySize);
-		const UINT32 w = displaySize.w;
-		const UINT32 h = displaySize.h;
+		auto monitor = static_cast<rdpMonitor*>(
+		    freerdp_settings_get_pointer_array_writable(sdl->context()->settings, FreeRDP_MonitorDefArray, x));
+
+		Uint32 w = monitor->width;
+		Uint32 h = monitor->height;
+		if (!(sdl->context()->settings->UseMultimon || sdl->context()->settings->Fullscreen) ){
+			w = sdl->context()->settings->DesktopWidth;
+			h = sdl->context()->settings->DesktopHeight;
+		}
+
 
 		sdl_window_t window = {};
 		Uint32 flags = SDL_WINDOW_SHOWN;
 		Uint32 startupX = SDL_WINDOWPOS_UNDEFINED;
 		Uint32 startupY = SDL_WINDOWPOS_UNDEFINED;
 
-		if (sdl->highDpi)
+		if (monitor->highDpi)
 		{
 #if SDL_VERSION_ATLEAST(2, 0, 1)
 			flags |= SDL_WINDOW_ALLOW_HIGHDPI;
@@ -645,15 +653,19 @@ static BOOL sdl_create_windows(SdlContext* sdl)
 		if (sdl->context()->settings->UseMultimon)
 		{
 			flags |= SDL_WINDOW_BORDERLESS;
-			startupX = displaySize.x;
-			startupY = displaySize.y;
+			startupX = monitor->x;
+			startupY = monitor->y;
+			window.offset_x = 0-startupX;
+			window.offset_y = 0-startupY;
+		}else{
+			window.offset_x = 0;
+			window.offset_y = 0;
 		}
 
 
 		window.window = SDL_CreateWindow(title, startupX, startupY,
 		                                 static_cast<int>(w), static_cast<int>(h), flags);
-		window.offset_x = 0-startupX;
-		window.offset_y = 0-startupY;
+
 
 		if (!window.window)
 			goto fail;

--- a/client/SDL/sdl_freerdp.cpp
+++ b/client/SDL/sdl_freerdp.cpp
@@ -627,8 +627,8 @@ static BOOL sdl_create_windows(SdlContext* sdl)
 
 		sdl_window_t window = {};
 		Uint32 flags = SDL_WINDOW_SHOWN;
-		Uint32 startupX = SDL_WINDOWPOS_UNDEFINED;
-		Uint32 startupY = SDL_WINDOWPOS_UNDEFINED;
+		Uint32 startupX = SDL_WINDOWPOS_CENTERED_DISPLAY(x);
+		Uint32 startupY = SDL_WINDOWPOS_CENTERED_DISPLAY(x);
 
 		if (monitor->attributes.desktopScaleFactor > 100)
 		{
@@ -645,8 +645,6 @@ static BOOL sdl_create_windows(SdlContext* sdl)
 		if (sdl->context()->settings->UseMultimon)
 		{
 			flags |= SDL_WINDOW_BORDERLESS;
-			startupX = monitor->x;
-			startupY = monitor->y;
 			window.offset_x = 0 - startupX;
 			window.offset_y = 0 - startupY;
 		}

--- a/client/SDL/sdl_freerdp.cpp
+++ b/client/SDL/sdl_freerdp.cpp
@@ -606,23 +606,23 @@ static BOOL sdl_create_windows(SdlContext* sdl)
 {
 	WINPR_ASSERT(sdl);
 
-	auto title = sdl_window_get_title(sdl->context()->settings);
+	auto settings = sdl->context()->settings;
+	auto title = sdl_window_get_title(settings);
 	BOOL rc = FALSE;
 
-	UINT32 windowCount =
-	    freerdp_settings_get_uint32(sdl->context()->settings, FreeRDP_MonitorCount);
+	UINT32 windowCount = freerdp_settings_get_uint32(settings, FreeRDP_MonitorCount);
 
 	for (UINT32 x = 0; x < windowCount; x++)
 	{
-		auto monitor = static_cast<rdpMonitor*>(freerdp_settings_get_pointer_array_writable(
-		    sdl->context()->settings, FreeRDP_MonitorDefArray, x));
+		auto monitor = static_cast<rdpMonitor*>(
+		    freerdp_settings_get_pointer_array_writable(settings, FreeRDP_MonitorDefArray, x));
 
 		Uint32 w = monitor->width;
 		Uint32 h = monitor->height;
-		if (!(sdl->context()->settings->UseMultimon || sdl->context()->settings->Fullscreen))
+		if (!(settings->UseMultimon || settings->Fullscreen))
 		{
-			w = sdl->context()->settings->DesktopWidth;
-			h = sdl->context()->settings->DesktopHeight;
+			w = settings->DesktopWidth;
+			h = settings->DesktopHeight;
 		}
 
 		sdl_window_t window = {};
@@ -637,12 +637,12 @@ static BOOL sdl_create_windows(SdlContext* sdl)
 #endif
 		}
 
-		if (sdl->context()->settings->Fullscreen && !sdl->context()->settings->UseMultimon)
+		if (settings->Fullscreen && !settings->UseMultimon)
 		{
 			flags |= SDL_WINDOW_FULLSCREEN;
 		}
 
-		if (sdl->context()->settings->UseMultimon)
+		if (settings->UseMultimon)
 		{
 			flags |= SDL_WINDOW_BORDERLESS;
 			window.offset_x = 0 - startupX;

--- a/client/SDL/sdl_freerdp.hpp
+++ b/client/SDL/sdl_freerdp.hpp
@@ -63,7 +63,7 @@ class SdlContext
 	bool resizeable = false;
 	bool grab_mouse = false;
 	bool grab_kbd = false;
-	bool highDpi = false;
+	//bool highDpi = false;
 
 	std::vector<sdl_window_t> windows;
 

--- a/client/SDL/sdl_freerdp.hpp
+++ b/client/SDL/sdl_freerdp.hpp
@@ -63,7 +63,6 @@ class SdlContext
 	bool resizeable = false;
 	bool grab_mouse = false;
 	bool grab_kbd = false;
-	//bool highDpi = false;
 
 	std::vector<sdl_window_t> windows;
 

--- a/client/SDL/sdl_kbd.cpp
+++ b/client/SDL/sdl_kbd.cpp
@@ -339,7 +339,7 @@ BOOL sdlInput::keyboard_focus_in()
 	return TRUE;
 }
 
-/* This function is called to update the keyboard indocator LED */
+/* This function is called to update the keyboard indicator LED */
 BOOL sdlInput::keyboard_set_indicators(rdpContext* context, UINT16 led_flags)
 {
 	WINPR_UNUSED(context);
@@ -430,34 +430,25 @@ BOOL sdlInput::keyboard_handle_event(const SDL_KeyboardEvent* ev)
 	const SDL_Keymod mask = KMOD_RSHIFT;
 	if ((mods & mask) == mask)
 	{
-		switch (ev->keysym.scancode)
+		if (ev->type == SDL_KEYDOWN)
 		{
-			case SDL_SCANCODE_RETURN:
-				if (ev->type == SDL_KEYDOWN)
-				{
+			switch (ev->keysym.scancode)
+			{
+				case SDL_SCANCODE_RETURN:
 					_sdl->update_fullscreen(!_sdl->fullscreen);
-				}
-				return TRUE;
-			case SDL_SCANCODE_R:
-				if (ev->type == SDL_KEYDOWN)
-				{
+					return TRUE;
+				case SDL_SCANCODE_R:
 					_sdl->update_resizeable(!_sdl->resizeable);
-				}
-				return TRUE;
-			case SDL_SCANCODE_G:
-				if (ev->type == SDL_KEYDOWN)
-				{
+					return TRUE;
+				case SDL_SCANCODE_G:
 					keyboard_grab(ev->windowID, _sdl->grab_kbd ? SDL_FALSE : SDL_TRUE);
-				}
-				return TRUE;
-			case SDL_SCANCODE_D:
-				if (ev->type == SDL_KEYDOWN)
-				{
+					return TRUE;
+				case SDL_SCANCODE_D:
 					freerdp_abort_connect_context(_sdl->context());
-				}
-				return true;
-			default:
-				break;
+					return true;
+				default:
+					break;
+			}
 		}
 	}
 	return freerdp_input_send_keyboard_event_ex(_sdl->context()->input, ev->type == SDL_KEYDOWN,
@@ -477,6 +468,24 @@ BOOL sdlInput::keyboard_grab(Uint32 windowID, SDL_bool enable)
 	WLog_WARN(TAG, "Keyboard grabbing not supported by SDL2 < 2.0.16");
 	return FALSE;
 #endif
+}
+
+BOOL sdlInput::mouse_focus(Uint32 windowID)
+{
+	static Uint32 lastWindowID = -1;
+
+	if (lastWindowID != windowID)
+	{
+		lastWindowID = windowID;
+		SDL_Window* window = SDL_GetWindowFromID(windowID);
+		if (!window)
+			return FALSE;
+
+		SDL_RaiseWindow(window);
+		return TRUE;
+	}else{
+		return TRUE;
+	};
 }
 
 BOOL sdlInput::mouse_grab(Uint32 windowID, SDL_bool enable)

--- a/client/SDL/sdl_kbd.cpp
+++ b/client/SDL/sdl_kbd.cpp
@@ -483,7 +483,9 @@ BOOL sdlInput::mouse_focus(Uint32 windowID)
 
 		SDL_RaiseWindow(window);
 		return TRUE;
-	}else{
+	}
+	else
+	{
 		return TRUE;
 	};
 }

--- a/client/SDL/sdl_kbd.cpp
+++ b/client/SDL/sdl_kbd.cpp
@@ -472,22 +472,16 @@ BOOL sdlInput::keyboard_grab(Uint32 windowID, SDL_bool enable)
 
 BOOL sdlInput::mouse_focus(Uint32 windowID)
 {
-	static Uint32 lastWindowID = -1;
-
-	if (lastWindowID != windowID)
+	if (_lastWindowID != windowID)
 	{
-		lastWindowID = windowID;
+		_lastWindowID = windowID;
 		SDL_Window* window = SDL_GetWindowFromID(windowID);
 		if (!window)
 			return FALSE;
 
 		SDL_RaiseWindow(window);
-		return TRUE;
 	}
-	else
-	{
-		return TRUE;
-	};
+	return TRUE;
 }
 
 BOOL sdlInput::mouse_grab(Uint32 windowID, SDL_bool enable)
@@ -506,7 +500,7 @@ BOOL sdlInput::mouse_grab(Uint32 windowID, SDL_bool enable)
 #endif
 }
 
-sdlInput::sdlInput(SdlContext* sdl) : _sdl(sdl)
+sdlInput::sdlInput(SdlContext* sdl) : _sdl(sdl), _lastWindowID(UINT32_MAX)
 {
 	WINPR_ASSERT(_sdl);
 }

--- a/client/SDL/sdl_kbd.cpp
+++ b/client/SDL/sdl_kbd.cpp
@@ -430,34 +430,25 @@ BOOL sdlInput::keyboard_handle_event(const SDL_KeyboardEvent* ev)
 	const SDL_Keymod mask = KMOD_RSHIFT;
 	if ((mods & mask) == mask)
 	{
-		switch (ev->keysym.scancode)
+		if (ev->type == SDL_KEYDOWN)
 		{
-			case SDL_SCANCODE_RETURN:
-				if (ev->type == SDL_KEYDOWN)
-				{
+			switch (ev->keysym.scancode)
+			{
+				case SDL_SCANCODE_RETURN:
 					_sdl->update_fullscreen(!_sdl->fullscreen);
-				}
-				return TRUE;
-			case SDL_SCANCODE_R:
-				if (ev->type == SDL_KEYDOWN)
-				{
+					return TRUE;
+				case SDL_SCANCODE_R:
 					_sdl->update_resizeable(!_sdl->resizeable);
-				}
-				return TRUE;
-			case SDL_SCANCODE_G:
-				if (ev->type == SDL_KEYDOWN)
-				{
+					return TRUE;
+				case SDL_SCANCODE_G:
 					keyboard_grab(ev->windowID, _sdl->grab_kbd ? SDL_FALSE : SDL_TRUE);
-				}
-				return TRUE;
-			case SDL_SCANCODE_D:
-				if (ev->type == SDL_KEYDOWN)
-				{
+					return TRUE;
+				case SDL_SCANCODE_D:
 					freerdp_abort_connect_context(_sdl->context());
-				}
-				return true;
-			default:
-				break;
+					return true;
+				default:
+					break;
+			}
 		}
 	}
 	return freerdp_input_send_keyboard_event_ex(_sdl->context()->input, ev->type == SDL_KEYDOWN,

--- a/client/SDL/sdl_kbd.cpp
+++ b/client/SDL/sdl_kbd.cpp
@@ -430,25 +430,34 @@ BOOL sdlInput::keyboard_handle_event(const SDL_KeyboardEvent* ev)
 	const SDL_Keymod mask = KMOD_RSHIFT;
 	if ((mods & mask) == mask)
 	{
-		if (ev->type == SDL_KEYDOWN)
+		switch (ev->keysym.scancode)
 		{
-			switch (ev->keysym.scancode)
-			{
-				case SDL_SCANCODE_RETURN:
+			case SDL_SCANCODE_RETURN:
+				if (ev->type == SDL_KEYDOWN)
+				{
 					_sdl->update_fullscreen(!_sdl->fullscreen);
-					return TRUE;
-				case SDL_SCANCODE_R:
+				}
+				return TRUE;
+			case SDL_SCANCODE_R:
+				if (ev->type == SDL_KEYDOWN)
+				{
 					_sdl->update_resizeable(!_sdl->resizeable);
-					return TRUE;
-				case SDL_SCANCODE_G:
+				}
+				return TRUE;
+			case SDL_SCANCODE_G:
+				if (ev->type == SDL_KEYDOWN)
+				{
 					keyboard_grab(ev->windowID, _sdl->grab_kbd ? SDL_FALSE : SDL_TRUE);
-					return TRUE;
-				case SDL_SCANCODE_D:
+				}
+				return TRUE;
+			case SDL_SCANCODE_D:
+				if (ev->type == SDL_KEYDOWN)
+				{
 					freerdp_abort_connect_context(_sdl->context());
-					return true;
-				default:
-					break;
-			}
+				}
+				return true;
+			default:
+				break;
 		}
 	}
 	return freerdp_input_send_keyboard_event_ex(_sdl->context()->input, ev->type == SDL_KEYDOWN,

--- a/client/SDL/sdl_kbd.hpp
+++ b/client/SDL/sdl_kbd.hpp
@@ -37,6 +37,7 @@ class sdlInput
 	BOOL keyboard_handle_event(const SDL_KeyboardEvent* ev);
 
 	BOOL keyboard_grab(Uint32 windowID, SDL_bool enable);
+	BOOL mouse_focus(Uint32 windowID);
 	BOOL mouse_grab(Uint32 windowID, SDL_bool enable);
 
   public:

--- a/client/SDL/sdl_kbd.hpp
+++ b/client/SDL/sdl_kbd.hpp
@@ -47,4 +47,5 @@ class sdlInput
 
   private:
 	SdlContext* _sdl;
+	Uint32 _lastWindowID;
 };

--- a/client/SDL/sdl_monitor.cpp
+++ b/client/SDL/sdl_monitor.cpp
@@ -194,9 +194,9 @@ static BOOL sdl_apply_display_properties(SdlContext* sdl)
 		SDL_GetDisplayBounds(*id, &rect);
 		SDL_GetDisplayDPI(*id, nullptr, &hdpi, &vdpi);
 
-		sdl->highDpi = hdpi > 100;
+		bool highDpi = hdpi > 100;
 
-		if (sdl->highDpi)
+		if (highDpi)
 		{
 			// HighDPI is problematic with SDL: We can only get native resolution by creating a
 			// window. Work around this by checking the supported resolutions (and keep maximum)
@@ -244,6 +244,7 @@ static BOOL sdl_apply_display_properties(SdlContext* sdl)
 		monitor->y = rect.y;
 		monitor->width = rect.w;
 		monitor->height = rect.h;
+		monitor->highDpi = highDpi;
 		monitor->is_primary = (rect.x == 0) && (rect.y == 0);
 		monitor->attributes.desktopScaleFactor = 100;
 		monitor->attributes.deviceScaleFactor = 100;

--- a/client/SDL/sdl_monitor.cpp
+++ b/client/SDL/sdl_monitor.cpp
@@ -187,12 +187,13 @@ static BOOL sdl_apply_display_properties(SdlContext* sdl)
 		    freerdp_settings_get_pointer_array(settings, FreeRDP_MonitorIds, x));
 		WINPR_ASSERT(id);
 
-		float hdpi;
-		float vdpi;
+		float ddpi = 1.0f;
+		float hdpi = 1.0f;
+		float vdpi = 1.0f;
 		SDL_Rect rect = {};
 
 		SDL_GetDisplayBounds(*id, &rect);
-		SDL_GetDisplayDPI(*id, nullptr, &hdpi, &vdpi);
+		SDL_GetDisplayDPI(*id, &ddpi, &hdpi, &vdpi);
 
 		bool highDpi = hdpi > 100;
 
@@ -239,14 +240,15 @@ static BOOL sdl_apply_display_properties(SdlContext* sdl)
 		    freerdp_settings_get_pointer_array_writable(settings, FreeRDP_MonitorDefArray, x));
 		WINPR_ASSERT(monitor);
 
+		/* windows uses 96 dpi as 'default' and the scale factors are in percent. */
+		const auto factor = ddpi / 96.0f * 100.0f;
 		monitor->orig_screen = x;
 		monitor->x = rect.x;
 		monitor->y = rect.y;
 		monitor->width = rect.w;
 		monitor->height = rect.h;
-		monitor->highDpi = highDpi;
 		monitor->is_primary = (rect.x == 0) && (rect.y == 0);
-		monitor->attributes.desktopScaleFactor = 100;
+		monitor->attributes.desktopScaleFactor = factor;
 		monitor->attributes.deviceScaleFactor = 100;
 		monitor->attributes.orientation = rdp_orientation;
 		monitor->attributes.physicalWidth = rect.w / hdpi;

--- a/client/SDL/sdl_monitor.cpp
+++ b/client/SDL/sdl_monitor.cpp
@@ -193,6 +193,9 @@ static BOOL sdl_apply_display_properties(SdlContext* sdl)
 
 		SDL_GetDisplayBounds(*id, &rect);
 		SDL_GetDisplayDPI(*id, nullptr, &hdpi, &vdpi);
+
+		sdl->highDpi = hdpi > 100;
+
 		if (sdl->highDpi)
 		{
 			// HighDPI is problematic with SDL: We can only get native resolution by creating a

--- a/client/SDL/sdl_monitor.cpp
+++ b/client/SDL/sdl_monitor.cpp
@@ -194,9 +194,9 @@ static BOOL sdl_apply_display_properties(SdlContext* sdl)
 		SDL_GetDisplayBounds(*id, &rect);
 		SDL_GetDisplayDPI(*id, nullptr, &hdpi, &vdpi);
 
-		bool highDpi = hdpi > 100;
+		sdl->highDpi = hdpi > 100;
 
-		if (highDpi)
+		if (sdl->highDpi)
 		{
 			// HighDPI is problematic with SDL: We can only get native resolution by creating a
 			// window. Work around this by checking the supported resolutions (and keep maximum)
@@ -244,7 +244,6 @@ static BOOL sdl_apply_display_properties(SdlContext* sdl)
 		monitor->y = rect.y;
 		monitor->width = rect.w;
 		monitor->height = rect.h;
-		monitor->highDpi = highDpi;
 		monitor->is_primary = (rect.x == 0) && (rect.y == 0);
 		monitor->attributes.desktopScaleFactor = 100;
 		monitor->attributes.deviceScaleFactor = 100;

--- a/client/SDL/sdl_touch.cpp
+++ b/client/SDL/sdl_touch.cpp
@@ -200,11 +200,12 @@ BOOL sdl_handle_mouse_motion(SdlContext* sdl, const SDL_MouseMotionEvent* ev)
 {
 	WINPR_ASSERT(sdl);
 	WINPR_ASSERT(ev);
-
+	sdl->input.mouse_focus(ev->windowID);
 	const BOOL relative =
 	    freerdp_settings_get_bool(sdl->context()->settings, FreeRDP_MouseUseRelativeMove);
 	INT32 x = relative ? ev->xrel : ev->x;
 	INT32 y = relative ? ev->yrel : ev->y;
+
 	sdl_scale_coordinates(sdl, ev->windowID, &x, &y, TRUE, TRUE);
 	return freerdp_client_send_button_event(sdl->common(), relative, PTR_FLAGS_MOVE, x, y);
 }

--- a/client/SDL/sdl_touch.cpp
+++ b/client/SDL/sdl_touch.cpp
@@ -200,12 +200,12 @@ BOOL sdl_handle_mouse_motion(SdlContext* sdl, const SDL_MouseMotionEvent* ev)
 {
 	WINPR_ASSERT(sdl);
 	WINPR_ASSERT(ev);
+
 	sdl->input.mouse_focus(ev->windowID);
 	const BOOL relative =
 	    freerdp_settings_get_bool(sdl->context()->settings, FreeRDP_MouseUseRelativeMove);
 	INT32 x = relative ? ev->xrel : ev->x;
 	INT32 y = relative ? ev->yrel : ev->y;
-
 	sdl_scale_coordinates(sdl, ev->windowID, &x, &y, TRUE, TRUE);
 	return freerdp_client_send_button_event(sdl->common(), relative, PTR_FLAGS_MOVE, x, y);
 }

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -427,7 +427,6 @@ extern "C"
 		INT32 height;
 		UINT32 is_primary;
 		UINT32 orig_screen;
-		BOOL highDpi;
 		MONITOR_ATTRIBUTES attributes;
 	} rdpMonitor;
 

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -427,6 +427,7 @@ extern "C"
 		INT32 height;
 		UINT32 is_primary;
 		UINT32 orig_screen;
+		BOOL highDpi;
 		MONITOR_ATTRIBUTES attributes;
 	} rdpMonitor;
 


### PR DESCRIPTION
based on https://github.com/DanAtIntegrateIT/FreeRDP/tree/integrateit

@DanAtIntegrateIT did take your work and did some small changes to that (so that it works not only on windows ;))
any feedback welcome.

NOTE: This is a basic multimonitor support, so don´t expect flawless operation and fancy monitor layouts to work out of the box.
Also no `gfx` drawing support (eliminating the virtual framebuffer and pushing updates from surface buffer directly to window)