### PR TITLE
Refactor: Improve error message in is_within_surface function

### DIFF
--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -54,8 +54,8 @@ static BOOL is_within_surface(const gdiGfxSurface* surface, const RDPGFX_SURFACE
 	if (!is_rect_valid(&rect, surface->width, surface->height))
 	{
 		WLog_ERR(TAG,
-		         "Command rect %" PRIu32 "x" PRIu32 "-" PRIu32 "x" PRIu32
-		         " not within bounds of " PRIu32 "x" PRIu32,
+		         "Command rect %" PRIu32 "x%" PRIu32 "-%" PRIu32 "x%" PRIu32
+		         " not within bounds of %" PRIu32 "x%" PRIu32,
 		         rect.left, rect.top, cmd->width, cmd->height, surface->width, surface->height);
 		return FALSE;
 	}


### PR DESCRIPTION
In the function is_within_surface, the error message for out-of-bounds command rectangles has been enhanced for better clarity. The code has been modified to display the rectangle coordinates and surface dimensions in the error message. This change aims to make debugging easier and improve the overall code quality.
