### PR TITLE
gateway: Allow authentication using a NULL (current user) identity

### DIFF
--- a/libfreerdp/core/gateway/ncacn_http.c
+++ b/libfreerdp/core/gateway/ncacn_http.c
@@ -166,9 +166,8 @@ BOOL rpc_ncacn_http_auth_init(rdpContext* context, RpcChannel* channel)
 			freerdp_set_last_error_log(instance->context, FREERDP_ERROR_CONNECT_CANCELLED);
 			return FALSE;
 		case AUTH_NO_CREDENTIALS:
-			freerdp_set_last_error_log(instance->context,
-			                           FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
-			return FALSE;
+			WLog_INFO(TAG, "No credentials provided - using NULL identity");
+			break;
 		case AUTH_FAILED:
 		default:
 			return FALSE;
@@ -181,8 +180,9 @@ BOOL rpc_ncacn_http_auth_init(rdpContext* context, RpcChannel* channel)
 	                                FreeRDP_GatewayDomain, FreeRDP_GatewayPassword))
 		return FALSE;
 
+	SEC_WINNT_AUTH_IDENTITY* identityArg = (settings->GatewayUsername ? &identity : NULL);
 	const BOOL res =
-	    credssp_auth_setup_client(auth, "HTTP", settings->GatewayHostname, &identity, NULL);
+	    credssp_auth_setup_client(auth, "HTTP", settings->GatewayHostname, identityArg, NULL);
 
 	sspi_FreeAuthIdentity(&identity);
 

--- a/libfreerdp/core/gateway/rpc_bind.c
+++ b/libfreerdp/core/gateway/rpc_bind.c
@@ -141,8 +141,8 @@ static int rpc_bind_setup(rdpRpc* rpc)
 			freerdp_set_last_error_log(instance->context, FREERDP_ERROR_CONNECT_CANCELLED);
 			return -1;
 		case AUTH_NO_CREDENTIALS:
-			freerdp_set_last_error_log(context, FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
-			return 0;
+			WLog_INFO(TAG, "No credentials provided - using NULL identity");
+			break;
 		case AUTH_FAILED:
 		default:
 			return -1;
@@ -155,7 +155,8 @@ static int rpc_bind_setup(rdpRpc* rpc)
 	                                FreeRDP_GatewayDomain, FreeRDP_GatewayPassword))
 		return -1;
 
-	if (!credssp_auth_setup_client(rpc->auth, NULL, settings->GatewayHostname, &identity, NULL))
+	SEC_WINNT_AUTH_IDENTITY* identityArg = (settings->GatewayUsername ? &identity : NULL);
+	if (!credssp_auth_setup_client(rpc->auth, NULL, settings->GatewayHostname, identityArg, NULL))
 	{
 		sspi_FreeAuthIdentity(&identity);
 		return -1;

--- a/libfreerdp/core/gateway/wst.c
+++ b/libfreerdp/core/gateway/wst.c
@@ -82,9 +82,8 @@ static BOOL wst_get_gateway_credentials(rdpContext* context, rdp_auth_reason rea
 			freerdp_set_last_error_log(instance->context, FREERDP_ERROR_CONNECT_CANCELLED);
 			return FALSE;
 		case AUTH_NO_CREDENTIALS:
-			freerdp_set_last_error_log(instance->context,
-			                           FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS);
-			return FALSE;
+			WLog_INFO(TAG, "No credentials provided - using NULL identity");
+			return TRUE;
 		case AUTH_FAILED:
 		default:
 			return FALSE;
@@ -113,7 +112,8 @@ static BOOL wst_auth_init(rdpWst* wst, rdpTls* tls, TCHAR* authPkg)
 	                                FreeRDP_GatewayDomain, FreeRDP_GatewayPassword))
 		return FALSE;
 
-	if (!credssp_auth_setup_client(wst->auth, "HTTP", wst->gwhostname, &identity, NULL))
+	SEC_WINNT_AUTH_IDENTITY* identityArg = (settings->GatewayUsername ? &identity : NULL);
+	if (!credssp_auth_setup_client(wst->auth, "HTTP", wst->gwhostname, identityArg, NULL))
 	{
 		sspi_FreeAuthIdentity(&identity);
 		return FALSE;

--- a/libfreerdp/core/utils.c
+++ b/libfreerdp/core/utils.c
@@ -103,7 +103,7 @@ auth_status utils_authenticate_gateway(freerdp* instance, rdp_auth_reason reason
 		    instance->GatewayAuthenticate(instance, &settings->GatewayUsername,
 		                                  &settings->GatewayPassword, &settings->GatewayDomain);
 		if (!proceed)
-			return AUTH_NO_CREDENTIALS;
+			return AUTH_CANCELLED;
 	}
 
 	if (utils_str_is_empty(settings->GatewayUsername) ||


### PR DESCRIPTION
The PR also fixes a wrong return value in `utils_authenticate_gateway`