### PR TITLE
[channels,printer] fix backend load function

### DIFF
--- a/channels/printer/client/cups/printer_cups.c
+++ b/channels/printer/client/cups/printer_cups.c
@@ -406,14 +406,18 @@ static void printer_cups_release_ref_driver(rdpPrinterDriver* driver)
 		cups_driver->references--;
 }
 
-rdpPrinterDriver* cups_freerdp_printer_client_subsystem_entry(void)
+UINT cups_freerdp_printer_client_subsystem_entry(void* arg)
 {
+	rdpPrinterDriver** ppPrinter = (rdpPrinterDriver**)arg;
+	if (!ppPrinter)
+		return ERROR_INVALID_PARAMETER;
+
 	if (!uniq_cups_driver)
 	{
 		uniq_cups_driver = (rdpCupsPrinterDriver*)calloc(1, sizeof(rdpCupsPrinterDriver));
 
 		if (!uniq_cups_driver)
-			return NULL;
+			return ERROR_OUTOFMEMORY;
 
 		uniq_cups_driver->driver.EnumPrinters = printer_cups_enum_printers;
 		uniq_cups_driver->driver.ReleaseEnumPrinters = printer_cups_release_enum_printers;
@@ -428,5 +432,6 @@ rdpPrinterDriver* cups_freerdp_printer_client_subsystem_entry(void)
 	WINPR_ASSERT(uniq_cups_driver->driver.AddRef);
 	uniq_cups_driver->driver.AddRef(&uniq_cups_driver->driver);
 
-	return &uniq_cups_driver->driver;
+	*ppPrinter = &uniq_cups_driver->driver;
+	return CHANNEL_RC_OK;
 }

--- a/channels/printer/client/printer_main.c
+++ b/channels/printer/client/printer_main.c
@@ -998,7 +998,7 @@ error_out:
 
 static rdpPrinterDriver* printer_load_backend(const char* backend)
 {
-	typedef rdpPrinterDriver* (*backend_load_t)(void);
+	typedef UINT (*backend_load_t)(rdpPrinterDriver**);
 	union
 	{
 		PVIRTUALCHANNELENTRY entry;
@@ -1009,7 +1009,12 @@ static rdpPrinterDriver* printer_load_backend(const char* backend)
 	if (!fktconv.entry)
 		return NULL;
 
-	return fktconv.backend();
+	rdpPrinterDriver* printer = NULL;
+	const UINT rc = fktconv.backend(&printer);
+	if (rc != CHANNEL_RC_OK)
+		return NULL;
+
+	return printer;
 }
 
 /**

--- a/channels/printer/client/win/printer_win.c
+++ b/channels/printer/client/win/printer_win.c
@@ -434,14 +434,18 @@ static void printer_win_release_ref_driver(rdpPrinterDriver* driver)
 		win->references--;
 }
 
-rdpPrinterDriver* win_freerdp_printer_client_subsystem_entry(void)
+UINT win_freerdp_printer_client_subsystem_entry(void* arg)
 {
+	rdpPrinterDriver** ppPrinter = (rdpPrinterDriver**)arg;
+	if (!ppPrinter)
+		return ERROR_INVALID_PARAMETER;
+
 	if (!win_driver)
 	{
 		win_driver = (rdpWinPrinterDriver*)calloc(1, sizeof(rdpWinPrinterDriver));
 
 		if (!win_driver)
-			return NULL;
+			return ERROR_OUTOFMEMORY;
 
 		win_driver->driver.EnumPrinters = printer_win_enum_printers;
 		win_driver->driver.ReleaseEnumPrinters = printer_win_release_enum_printers;
@@ -455,5 +459,6 @@ rdpPrinterDriver* win_freerdp_printer_client_subsystem_entry(void)
 
 	win_driver->driver.AddRef(&win_driver->driver);
 
-	return &win_driver->driver;
+	*ppPrinter = &win_driver->driver;
+	return CHANNEL_RC_OK;
 }


### PR DESCRIPTION
changed the signature of the backend loader function. the previous version casted the allocated pointer to UINT which might not be able to hold a pointer.