### PR TITLE
Correct typos and formatting errors in format strings

### DIFF
--- a/channels/audin/client/opensles/audin_opensl_es.c
+++ b/channels/audin/client/opensles/audin_opensl_es.c
@@ -120,7 +120,7 @@ static BOOL audin_opensles_format_supported(IAudinDevice* device, const AUDIO_FO
 			break;
 
 		default:
-			WLog_Print(opensles->log, WLOG_DEBUG, "Encoding '%s' [0x%04X" PRIX16 "] not supported",
+			WLog_Print(opensles->log, WLOG_DEBUG, "Encoding '%s' [0x%04" PRIX16 "] not supported",
 			           audio_format_get_tag_string(format->wFormatTag), format->wFormatTag);
 			break;
 	}

--- a/channels/urbdrc/client/data_transfer.c
+++ b/channels/urbdrc/client/data_transfer.c
@@ -1534,7 +1534,7 @@ static UINT urbdrc_process_transfer_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALL
 	Stream_Read_UINT16(s, Size);    /** size */
 	Stream_Read_UINT16(s, URB_Function);
 	Stream_Read_UINT32(s, RequestId);
-	WLog_Print(urbdrc->log, WLOG_DEBUG, "URB %s[" PRIu16 "]", urb_function_string(URB_Function),
+	WLog_Print(urbdrc->log, WLOG_DEBUG, "URB %s[%" PRIu16 "]", urb_function_string(URB_Function),
 	           URB_Function);
 
 	switch (URB_Function)

--- a/channels/urbdrc/client/libusb/libusb_udevice.c
+++ b/channels/urbdrc/client/libusb/libusb_udevice.c
@@ -550,7 +550,7 @@ static int libusb_udev_select_interface(IUDEVICE* idev, BYTE InterfaceNumber, BY
 		{
 			WLog_Print(urbdrc->log, WLOG_INFO,
 			           "select Interface(%" PRIu8 ") curr AlternateSetting(%" PRIu8
-			           ") new AlternateSetting(" PRIu8 ")",
+			           ") new AlternateSetting(%" PRIu8 ")",
 			           InterfaceNumber, MsInterfaces[InterfaceNumber]->AlternateSetting,
 			           AlternateSetting);
 

--- a/channels/urbdrc/client/libusb/libusb_udevman.c
+++ b/channels/urbdrc/client/libusb/libusb_udevman.c
@@ -239,7 +239,7 @@ static size_t udevman_register_udevice(IUDEVMAN* idevman, BYTE bus_number, BYTE 
 	}
 	else
 	{
-		WLog_Print(urbdrc->log, WLOG_ERROR, "udevman_register_udevice: Invalid flag=%08 " PRIx32,
+		WLog_Print(urbdrc->log, WLOG_ERROR, "udevman_register_udevice: Invalid flag=%08" PRIx32,
 		           flag);
 		return 0;
 	}

--- a/libfreerdp/codec/clear.c
+++ b/libfreerdp/codec/clear.c
@@ -1061,7 +1061,7 @@ INT32 clear_decompress(CLEAR_CONTEXT* clear, const BYTE* pSrcData, UINT32 SrcSiz
 			goto finish;
 
 		WLog_ERR(TAG,
-		         "invalid glyphFlags, missing flags: 0x%0x" PRIx8 " & 0x%02" PRIx32
+		         "invalid glyphFlags, missing flags: 0x%02" PRIx8 " & 0x%02" PRIx32
 		         " == 0x%02" PRIx32,
 		         glyphFlags, mask, glyphFlags & mask);
 		goto fail;

--- a/libfreerdp/codec/planar.c
+++ b/libfreerdp/codec/planar.c
@@ -1520,7 +1520,7 @@ BYTE* freerdp_bitmap_compress_planar(BITMAP_PLANAR_CONTEXT* context, const BYTE*
 
 #if defined(WITH_DEBUG_CODECS)
 			WLog_DBG(TAG,
-			         "R: [%" PRIu32 "/%" PRIu32 "] G: [%" PRIu32 "/%" PRIu32 "] B: [% " PRIu32
+			         "R: [%" PRIu32 "/%" PRIu32 "] G: [%" PRIu32 "/%" PRIu32 "] B: [%" PRIu32
 			         " / %" PRIu32 "] ",
 			         dstSizes[1], planeSize, dstSizes[2], planeSize, dstSizes[3], planeSize);
 #endif

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -1740,7 +1740,7 @@ static INLINE SSIZE_T progressive_process_tiles(PROGRESSIVE_CONTEXT* progressive
 					return -1032;
 				break;
 			default:
-				WLog_ERR(TAG, "Invalid block type %04 (%s)" PRIx16, blockType,
+				WLog_ERR(TAG, "Invalid block type %04" PRIx16 " (%s)", blockType,
 				         progressive_get_block_type_string(blockType));
 				return -1039;
 		}

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -1295,8 +1295,7 @@ BOOL rfx_process_message(RFX_CONTEXT* context, const BYTE* data, UINT32 length, 
 				{
 					region16_uninit(&updateRegion);
 					WLog_Print(context->priv->log, WLOG_ERROR,
-					           "nbUpdateRectx[% " PRIu32 " (%" PRIu32
-					           ")] freerdp_image_copy failed",
+					           "nbUpdateRectx[%" PRIu32 " (%" PRIu32 ")] freerdp_image_copy failed",
 					           j, nbUpdateRects);
 					return FALSE;
 				}

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -1147,7 +1147,7 @@ BOOL rdp_client_connect_auto_detect(rdpRdp* rdp, wStream* s)
 			}
 		}
 		else
-			WLog_WARN(TAG, "expected messageChannelId=" PRIu16 ", got %" PRIu16, messageChannelId,
+			WLog_WARN(TAG, "expected messageChannelId=%" PRIu16 ", got %" PRIu16, messageChannelId,
 			          channelId);
 
 		Stream_SetPosition(s, pos);

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -269,7 +269,7 @@ static BOOL rdg_read_http_unicode_string(wStream* s, const WCHAR** string, UINT1
 	/* Read length of the string */
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, 4))
 	{
-		WLog_ERR(TAG, "Could not read stream length, only have % " PRIuz " bytes", rem);
+		WLog_ERR(TAG, "Could not read stream length, only have %" PRIuz " bytes", rem);
 		return FALSE;
 	}
 	Stream_Read_UINT16(s, strLenBytes);
@@ -280,7 +280,7 @@ static BOOL rdg_read_http_unicode_string(wStream* s, const WCHAR** string, UINT1
 	/* seek past the string - if this fails something is wrong */
 	if (!Stream_SafeSeek(s, strLenBytes))
 	{
-		WLog_ERR(TAG, "Could not read stream data, only have % " PRIuz " bytes, expected %" PRIu16,
+		WLog_ERR(TAG, "Could not read stream data, only have %" PRIuz " bytes, expected %" PRIu16,
 		         rem - 4, strLenBytes);
 		return FALSE;
 	}

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -2279,7 +2279,7 @@ BOOL gcc_write_client_monitor_data(wStream* s, const rdpMcs* mcs)
 			const UINT32 flags = current->is_primary ? MONITOR_PRIMARY : 0;
 			WLog_DBG(TAG,
 			         "Monitor[%" PRIu32 "]: top=%" PRIu32 ", left=%" PRIu32 ", bottom=%" PRIu32
-			         ", right=%" PRIu32 ", flags" PRIu32,
+			         ", right=%" PRIu32 ", flags=%" PRIu32,
 			         i, top, left, bottom, right, flags);
 			Stream_Write_UINT32(s, left);   /* left */
 			Stream_Write_UINT32(s, top);    /* top */

--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -1201,7 +1201,7 @@ static BOOL nego_process_correlation_info(rdpNego* nego, wStream* s)
 	Stream_Seek(s, 16); /* skip reserved bytes */
 
 	WLog_INFO(TAG,
-	          "RDP_NEG_CORRELATION_INFO::correlationId = { %02 " PRIx8 ", %02" PRIx8 ", %02" PRIx8
+	          "RDP_NEG_CORRELATION_INFO::correlationId = { %02" PRIx8 ", %02" PRIx8 ", %02" PRIx8
 	          ", %02" PRIx8 ", %02" PRIx8 ", %02" PRIx8 ", %02" PRIx8 ", %02" PRIx8 ", %02" PRIx8
 	          ", %02" PRIx8 ", %02" PRIx8 ", %02" PRIx8 ", %02" PRIx8 ", %02" PRIx8 ", %02" PRIx8
 	          ", %02" PRIx8 " }",

--- a/libfreerdp/locale/keyboard_xkbfile.c
+++ b/libfreerdp/locale/keyboard_xkbfile.c
@@ -347,7 +347,7 @@ int freerdp_keyboard_init_xkbfile(DWORD* keyboardLayoutId, DWORD x11_keycode_to_
 	if (*keyboardLayoutId == 0)
 	{
 		detect_keyboard_layout_from_xkbfile(display, keyboardLayoutId);
-		DEBUG_KBD("detect_keyboard_layout_from_xkb: %" PRIu32 " (0x%08X" PRIX32 ")",
+		DEBUG_KBD("detect_keyboard_layout_from_xkb: %" PRIu32 " (0x%08" PRIX32 ")",
 		          *keyboardLayoutId, *keyboardLayoutId);
 	}
 

--- a/server/proxy/channels/pf_channel_rdpdr.c
+++ b/server/proxy/channels/pf_channel_rdpdr.c
@@ -463,7 +463,7 @@ static UINT rdpdr_process_client_name_request(pf_channel_server_context* rdpdr, 
 	if (!Stream_CheckAndLogRequiredLengthSrv(rdpdr->log, s, rdpdr->common.computerNameLen))
 	{
 		SERVER_RX_LOG(
-		    rdpdr->log, WLOG_WARN, "[%s | %s]: missing data, got " PRIu32 ", expected %" PRIu32,
+		    rdpdr->log, WLOG_WARN, "[%s | %s]: missing data, got %" PRIu32 ", expected %" PRIu32,
 		    rdpdr_component_string(RDPDR_CTYP_CORE), rdpdr_packetid_string(PAKID_CORE_CLIENT_NAME),
 		    Stream_GetRemainingLength(s), rdpdr->common.computerNameLen);
 		return ERROR_INVALID_DATA;

--- a/winpr/test/TestTypes.c
+++ b/winpr/test/TestTypes.c
@@ -104,7 +104,7 @@ static BOOL test_co_errors(void)
 		const LONG b = should[x];
 		if (a != b)
 		{
-			printf("mismatch[%" PRIuz "]: %0x" PRIx32 " vs %08" PRIx32 "\n", x, a, b);
+			printf("mismatch[%" PRIuz "]: %08" PRIx32 " vs %08" PRIx32 "\n", x, a, b);
 			return FALSE;
 		}
 	}


### PR DESCRIPTION
In several files, fixed typos in format strings that were causing unexpected output and formatting issues.