### PR TITLE
[core,info] Fix rdp_info_read_string conversion check

### DIFF
--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -1084,7 +1084,7 @@ static BOOL rdp_info_read_string(const char* what, wStream* s, size_t size, size
 
 	size_t len = 0;
 	char* rc = ConvertWCharNToUtf8Alloc(str, size / sizeof(WCHAR), &len);
-	if (!rc || (len == 0))
+	if (!rc)
 	{
 		WLog_ERR(TAG, "failed to convert the %s string", what);
 		free(rc);


### PR DESCRIPTION
[Prior code](https://github.com/FreeRDP/FreeRDP/commit/5799fb2018c3e28d397169cb1af3ea30927636d7#diff-726f85029f4f14f421262dfc87712c509b51ac48e19f6bcef70bb4a28c494851L1176) read username and domain fields from the logon info packet and used `ConvertFromUnicode` to convert to UTF8; checking for failure with -1.

e.g.

![Screenshot 2023-07-31 at 15 45 11](https://github.com/FreeRDP/FreeRDP/assets/2573400/6b8f8ffe-4a24-4d03-a97e-5df00448e626)

Latest code uses `ConvertWCharNToUtf8Alloc` and checks for zero-length, but semantics are different. From the header:

```
	 *  \param pSize Ignored if NULL, otherwise receives the length of the result string in
	 * characters (strlen)
```

So, zero-length strings are no longer considered valid. However, the [spec](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/a2e946b4-820c-4d11-b4c9-8029a7df558f) does not indicate that these fields must hold a value, zero-length string should be valid.

This commit removes the length check after conversion to UTF8.
