### PR TITLE
Add `find_dependency` for exported cmake config

### DIFF
--- a/client/FreeRDP-ClientConfig.cmake.in
+++ b/client/FreeRDP-ClientConfig.cmake.in
@@ -1,3 +1,6 @@
+include(CMakeFindDependencyMacro)
+find_dependency(WinPR @FREERDP_VERSION@)
+find_dependency(FreeRDP @FREERDP_VERSION@)
 
 @PACKAGE_INIT@
 

--- a/libfreerdp/FreeRDPConfig.cmake.in
+++ b/libfreerdp/FreeRDPConfig.cmake.in
@@ -1,3 +1,5 @@
+include(CMakeFindDependencyMacro)
+find_dependency(WinPR @FREERDP_VERSION@)
 
 @PACKAGE_INIT@
 

--- a/server/FreeRDP-ServerConfig.cmake.in
+++ b/server/FreeRDP-ServerConfig.cmake.in
@@ -1,3 +1,6 @@
+include(CMakeFindDependencyMacro)
+find_dependency(WinPR @FREERDP_VERSION@)
+find_dependency(FreeRDP @FREERDP_VERSION@)
 
 @PACKAGE_INIT@
 

--- a/server/shadow/FreeRDP-ShadowConfig.cmake.in
+++ b/server/shadow/FreeRDP-ShadowConfig.cmake.in
@@ -1,3 +1,7 @@
+include(CMakeFindDependencyMacro)
+find_dependency(WinPR @FREERDP_VERSION@)
+find_dependency(FreeRDP @FREERDP_VERSION@)
+find_dependency(FreeRDP-Server @FREERDP_VERSION@)
 
 @PACKAGE_INIT@
 


### PR DESCRIPTION
This PR adds `find_dependency` calls to make the exported cmake config files pull in the configs which provide the imported targets used in interface link libraries properties.

e.g. 
~~~cmake
find_package(FreeRDP-Client CONFIG REQUIRED)
target_link_libraries(main PRIVATE freerdp-client)
~~~
would fail without this change due to lack of a definition of `winpr`, https://github.com/microsoft/vcpkg/pull/32416#issuecomment-1655083721.