### PR TITLE
[client,android] Fix keyboard ui issues

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
@@ -18,12 +18,15 @@ import android.graphics.Matrix;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.BitmapDrawable;
+import android.text.InputType;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
 
 import com.freerdp.freerdpcore.application.SessionState;
 import com.freerdp.freerdpcore.utils.DoubleGestureDetector;
@@ -407,5 +410,12 @@ public class SessionView extends View
 			                                            (int)mappedEvent.getY(), false);
 			return true;
 		}
+	}
+
+	@Override public InputConnection onCreateInputConnection(EditorInfo outAttrs)
+	{
+		super.onCreateInputConnection(outAttrs);
+		outAttrs.inputType = InputType.TYPE_CLASS_TEXT;
+		return null;
 	}
 }


### PR DESCRIPTION
Fix keyboard issues in android app

Keyboard opens without modifiers panel, modifiers panel opens without keyboard, opens system and extended keyboard at same time
Reproduce - sometimes on my phone when i open extended keyboard/default keyboard/keyboard in another app many times
<details>
  <summary>Modifiers panel exists, keyboard not. if i open keyboard again, modifiers will disappear</summary>
![image](https://github.com/FreeRDP/FreeRDP/assets/117029676/e993331b-b046-48fc-bc5c-afbd4e038fa3)
</details>

Opens numeric keyboard without any ability to change it to text keyboard
Reproduce - open any numeric field in app, eg connection port setting, then start connection
<details>
  <summary>Numeric keyboard</summary>
![image](https://github.com/FreeRDP/FreeRDP/assets/117029676/3f4ea0c0-a0b3-4fdc-9e9f-82d4115124ba)
</details>

Also i add hide zoom panel when keyboard is open. I thought from the code comments at  SessionActivity.java:570 that may be correct behavior, and it sometimes really bad when i trying to write some text on small screen....

upd. Idk why image tags dont work.....




