### PR TITLE
[client,common] Fix minor code errors

### DIFF
--- a/client/common/client.c
+++ b/client/common/client.c
@@ -1887,6 +1887,8 @@ static FreeRDP_PenDevice* freerdp_client_get_pen(rdpClientContext* cctx, INT32 d
 static BOOL freerdp_client_register_pen(rdpClientContext* cctx, UINT32 flags, INT32 deviceid,
                                         double pressure)
 {
+	static const INT32 null_deviceid = 0;
+
 	WINPR_ASSERT(cctx);
 	WINPR_ASSERT((flags & FREERDP_PEN_REGISTER) != 0);
 	if (freerdp_client_is_pen(cctx, deviceid))
@@ -1896,7 +1898,7 @@ static BOOL freerdp_client_register_pen(rdpClientContext* cctx, UINT32 flags, IN
 	}
 
 	size_t pos = 0;
-	FreeRDP_PenDevice* pen = freerdp_client_get_pen(cctx, deviceid, &pos);
+	FreeRDP_PenDevice* pen = freerdp_client_get_pen(cctx, null_deviceid, &pos);
 	if (pen)
 	{
 		const FreeRDP_PenDevice empty = { 0 };

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -1871,7 +1871,7 @@ static FreeRDP_PenDevice* freerdp_client_get_pen(rdpClientContext* cctx, INT32 d
 {
 	WINPR_ASSERT(cctx);
 
-	for (size_t i = 0; i < ARRAYSIZE(cctx->contacts); i++)
+	for (size_t i = 0; i < ARRAYSIZE(cctx->pens); i++)
 	{
 		FreeRDP_PenDevice* pen = &cctx->pens[i];
 		if (deviceid == pen->deviceid)
@@ -2056,7 +2056,7 @@ BOOL freerdp_client_pen_cancel_all(rdpClientContext* cctx)
 	if (!rdpei)
 		return FALSE;
 
-	for (size_t i = 0; i < ARRAYSIZE(cctx->contacts); i++)
+	for (size_t i = 0; i < ARRAYSIZE(cctx->pens); i++)
 	{
 		FreeRDP_PenDevice* pen = &cctx->pens[i];
 		if (pen->hovering)


### PR DESCRIPTION
Pass null device id rather than `deviceid` to find an empty pen device slot.

Hello! Please let me know if there is any misunderstanding.

Regards,
Hodol Han