### PR TITLE
[client,Android] Fix clipboard server-to-client

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_jni_utils.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_jni_utils.c
@@ -107,6 +107,19 @@ char* get_string_from_string_builder(JNIEnv* env, jobject strBuilder)
 	return result;
 }
 
+/* Because wchar_t is 4-byte in android */
+size_t utf16len(const uint16_t* ptr, int size)
+{
+	for (int i = 0; i < size; i++)
+	{
+		if (ptr[i] == 0)
+		{
+			return i;
+		}
+	}
+	return size - 1;
+}
+
 jstring jniNewStringUTF(JNIEnv* env, const char* in, int len)
 {
 	jstring out = NULL;

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_jni_utils.h
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_jni_utils.h
@@ -26,7 +26,7 @@ extern "C"
 	FREERDP_LOCAL char* get_string_from_string_builder(JNIEnv* env, jobject strBuilder);
 	FREERDP_LOCAL jobject create_string_builder(JNIEnv* env, char* initialStr);
 	FREERDP_LOCAL jstring jniNewStringUTF(JNIEnv* env, const char* in, int len);
-
+	FREERDP_LOCAL size_t utf16len(const uint16_t* ptr, int size);
 	FREERDP_LOCAL extern JavaVM* g_JavaVm;
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fix android server-to-client clipboard
Reproduce - connect to win7/win10 computer, and try to copy some text in connection, then paste it in another android app
Tested on win7/winserver2022

And few questions...
* What is "UTF8_STRING" constant (android_cliprdr.c:425)? Why we trying to register this clipboard format, but requesting format is CF_TEXT/CF_UNICODETEXT (android_cliprdr.c:255)?
* Is windows/xrdp servers always send CF_UNICODETEXT? I thing it is defined by application, which paste data into clipboard, and in this case it is worth doing some conversion using CF_LOCALE
* Is CF_UNICODETEXT is always UTF-16? All unicode in winapi is utf-16-le, but, if something went wrong.....