### PR TITLE
Do not fail on certificates without subject

### DIFF
--- a/libfreerdp/crypto/certificate_data.c
+++ b/libfreerdp/crypto/certificate_data.c
@@ -70,7 +70,7 @@ static BOOL freerdp_certificate_data_load_cache(rdpCertificateData* data)
 
 	data->cached_subject = freerdp_certificate_get_subject(data->cert);
 	if (!data->cached_subject)
-		goto fail;
+		data->cached_subject = calloc(1, 1);
 
 	size_t pemlen = 0;
 	data->cached_pem = freerdp_certificate_get_pem(data->cert, &pemlen);
@@ -83,7 +83,7 @@ static BOOL freerdp_certificate_data_load_cache(rdpCertificateData* data)
 
 	data->cached_issuer = freerdp_certificate_get_issuer(data->cert);
 	if (!data->cached_issuer)
-		goto fail;
+		data->cached_issuer = calloc(1, 1);
 
 	rc = TRUE;
 fail:

--- a/libfreerdp/crypto/x509_utils.c
+++ b/libfreerdp/crypto/x509_utils.c
@@ -103,7 +103,7 @@ char* x509_utils_get_subject(const X509* xcert)
 	}
 	subject = crypto_print_name(X509_get_subject_name(xcert));
 	if (!subject)
-		WLog_ERR(TAG, "certificate does not have a subject!");
+		WLog_WARN(TAG, "certificate does not have a subject!");
 	return subject;
 }
 
@@ -524,7 +524,7 @@ char* x509_utils_get_issuer(const X509* xcert)
 	}
 	issuer = crypto_print_name(X509_get_issuer_name(xcert));
 	if (!issuer)
-		WLog_ERR(TAG, "certificate does not have an issuer!");
+		WLog_WARN(TAG, "certificate does not have an issuer!");
 	return issuer;
 }
 


### PR DESCRIPTION
It is possible to implement an rdp client that accepts certificates by fingerprint by using VerifyCertificateEx. In case the server uses a certificate without subject (which, apparently, is not mandated by X509) freerdp_certificate_data_load_cache fails and the certificate is refused even before calling VerifyCertificateEx. This commit changes freerdp_certificate_data_load_cache to consider that missing subject is the same as an empty string.

Also downgrade the log message complaining about missing subject and issuer to a warning.

To generate a certificate without these fields, you can run:
```
openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3650 -nodes -subj "/"
```
