### PR TITLE
[cmake] Locate PkgConfig module with find_package() instead of include(FindPkgConfig)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,6 @@ include(CheckIncludeFiles)
 include(CheckLibraryExists)
 include(CheckSymbolExists)
 include(CheckStructHasMember)
-include(FindPkgConfig)
 include(TestBigEndian)
 
 include(FindFeature)

--- a/client/SDL/aad/CMakeLists.txt
+++ b/client/SDL/aad/CMakeLists.txt
@@ -38,7 +38,6 @@ if (WITH_WEBVIEW)
         ${WEBKIT}
       )
     else()
-      include(FindPkgConfig)
       find_package(PkgConfig REQUIRED)
       pkg_check_modules(WEBVIEW_GTK webkit2gtk-4.0 REQUIRED)
       include_directories(${WEBVIEW_GTK_INCLUDE_DIRS})

--- a/client/common/CMakeLists.txt
+++ b/client/common/CMakeLists.txt
@@ -49,7 +49,6 @@ endif()
 
 option(WITH_FUSE "Build clipboard with FUSE file copy support" ${OPT_FUSE_DEFAULT})
 if(WITH_FUSE)
-	include(FindPkgConfig)
 	find_package(PkgConfig REQUIRED)
 
 	pkg_check_modules(FUSE3 fuse3)

--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -8,7 +8,7 @@
 set(REQUIRED_AVCODEC_VERSION 0.8)
 set(REQUIRED_AVCODEC_API_VERSION 53.25.0)
 
-include(FindPkgConfig)
+find_package(PkgConfig)
 
 if (PKG_CONFIG_FOUND)
 	pkg_check_modules(AVCODEC libavcodec)

--- a/cmake/FindKRB5.cmake
+++ b/cmake/FindKRB5.cmake
@@ -167,7 +167,6 @@ endfunction()
 #
 # * First search with pkg-config (prefer MIT over Heimdal)
 # * Then try to find krb5-config (generic, krb5-config.mit and last krb5-config.heimdal)
-include(FindPkgConfig)
 find_package(PkgConfig REQUIRED)
 
 if (KRB5_ROOT_CONFIG)

--- a/cmake/FindPCSC.cmake
+++ b/cmake/FindPCSC.cmake
@@ -4,7 +4,7 @@
 #  PCSC_INCLUDE_DIRS - pcsc include directories
 #  PCSC_LIBRARIES - libraries needed for linking
 
-include(FindPkgConfig)
+find_package(PkgConfig)
 
 if(PKG_CONFIG_FOUND)
 	pkg_check_modules(PC_PCSC QUIET libpcsclite)

--- a/cmake/FindPkcs11.cmake
+++ b/cmake/FindPkcs11.cmake
@@ -5,7 +5,7 @@
 #  PKCS11_INCLUDE_DIRS  - combined include directories
 #  PKCS11_LIBRARIES    - combined libraries to link
 
-include(FindPkgConfig)
+find_package(PkgConfig)
 
 if (PKG_CONFIG_FOUND)
 	pkg_check_modules(PKCS11 libpkcs11-helper-1)

--- a/cmake/FindPulse.cmake
+++ b/cmake/FindPulse.cmake
@@ -1,5 +1,5 @@
 
-include(FindPkgConfig)
+find_package(PkgConfig)
 
 if(PKG_CONFIG_FOUND)
 	pkg_check_modules(PULSE libpulse)

--- a/cmake/FindSWScale.cmake
+++ b/cmake/FindSWScale.cmake
@@ -1,5 +1,5 @@
 
-include(FindPkgConfig)
+find_package(PkgConfig)
 
 if (PKG_CONFIG_FOUND)
 	pkg_check_modules(SWScale libswscale)

--- a/cmake/FindWayland.cmake
+++ b/cmake/FindWayland.cmake
@@ -25,7 +25,7 @@
 # limitations under the License.
 #=============================================================================
 
-include(FindPkgConfig)
+find_package(PkgConfig)
 
 if(PKG_CONFIG_FOUND)
     pkg_check_modules(WAYLAND_SCANNER_PC wayland-scanner)

--- a/rdtk/CMakeLists.txt
+++ b/rdtk/CMakeLists.txt
@@ -70,7 +70,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/)
 include(CheckIncludeFiles)
 include(CheckLibraryExists)
 include(CheckStructHasMember)
-include(FindPkgConfig)
 include(TestBigEndian)
 
 # Check for cmake compatibility (enable/disable features)

--- a/uwac/CMakeLists.txt
+++ b/uwac/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 
 # Find required libraries
 if (UWAC_HAVE_PIXMAN_REGION)
-	include(FindPkgConfig)
+	find_package(PkgConfig REQUIRED)
 	pkg_check_modules(pixman REQUIRED pixman-1)
 	include_directories(${pixman_INCLUDE_DIRS})
 elseif (FREERDP_UNIFIED_BUILD)

--- a/winpr/CMakeLists.txt
+++ b/winpr/CMakeLists.txt
@@ -101,7 +101,6 @@ include(CheckIncludeFiles)
 include(CheckLibraryExists)
 include(CheckSymbolExists)
 include(CheckStructHasMember)
-include(FindPkgConfig)
 include(TestBigEndian)
 
 # Include our extra modules


### PR DESCRIPTION
This is the contemporary way of including find modules and including the find module this way avoids cmake errors in conjunction with find_package_handle_standard_args().

## How To Test

Perform a `--fresh` cmake run on an OS type that uses `pkg-config` and observe that there are no more warnings of the type:

```
CMake Warning (dev) at /usr/share/cmake-3.XX/Modules/FindPackageHandleStandardArgs.cmake:LLL (message):
  The package name passed to `find_package_handle_standard_args` (PkgConfig)
  does not match the name of the calling package (RealPackageName).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  [...]
```