### PR TITLE
fix IFCALLRESULT expand to wrong expression; fix show black window when connect transparent app in windows server 2012r2

### DIFF
--- a/include/freerdp/api.h
+++ b/include/freerdp/api.h
@@ -92,7 +92,7 @@
 		});                                                                \
 	})
 #else
-#define IFCALLRESULT(_default_return, _cb, ...) (_cb != NULL) ? _cb(__VA_ARGS__) : (_default_return)
+#define IFCALLRESULT(_default_return, _cb, ...) ((_cb != NULL) ? _cb(__VA_ARGS__) : (_default_return))
 #endif
 
 #ifdef __GNUC__

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -648,7 +648,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	    !freerdp_settings_set_bool(settings, FreeRDP_NSCodecAllowDynamicColorFidelity, TRUE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_AutoReconnectionEnabled, FALSE) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_AutoReconnectMaxRetries, 20) ||
-	    !freerdp_settings_set_bool(settings, FreeRDP_GfxThinClient, TRUE) ||
+	    !freerdp_settings_set_bool(settings, FreeRDP_GfxThinClient, FALSE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_GfxSmallCache, TRUE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_GfxProgressive, FALSE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_GfxProgressiveV2, FALSE) ||


### PR DESCRIPTION
1、
if (!IFCALLRESULT(TRUE, pointer->New, context, pointer))
		goto out_fail;

2、
cmd:  wfreerdp.exe ...  /gfx:rfx ... 
when connect to windows server 2012r2, there is no alpha command.