### PR TITLE
TestThreadExitThread: fix messages and wait timeout for the windows CI

### DIFF
--- a/winpr/libwinpr/thread/test/TestThreadExitThread.c
+++ b/winpr/libwinpr/thread/test/TestThreadExitThread.c
@@ -24,7 +24,7 @@ int TestThreadExitThread(int argc, char* argv[])
 
 	/* FIXME: create some noise to better guaranty the test validity and
 	 * decrease the number of loops */
-	for (i = 0; i < 5000; i++)
+	for (i = 0; i < 100; i++)
 	{
 		thread = CreateThread(NULL, 0, thread_func, NULL, 0, NULL);
 
@@ -34,7 +34,7 @@ int TestThreadExitThread(int argc, char* argv[])
 			return -1;
 		}
 
-		waitResult = WaitForSingleObject(thread, 100);
+		waitResult = WaitForSingleObject(thread, 300);
 		if (waitResult != WAIT_OBJECT_0)
 		{
 			/* When the thread exits before the internal thread_list
@@ -44,7 +44,7 @@ int TestThreadExitThread(int argc, char* argv[])
 			 * never get the signal.
 			 */
 			fprintf(stderr,
-			        "1 second should have been enough for the thread to be in a signaled state\n");
+			        "300ms should have been enough for the thread to be in a signaled state\n");
 			return -1;
 		}
 


### PR DESCRIPTION
Looks like for the windows x86_86 CI host 100ms is too small for a thread to terminate so let's wait for longer and decrease the number of loops.
