### PR TITLE
Refactor TestUnicodeConversion

### DIFF
--- a/winpr/libwinpr/crt/unicode.c
+++ b/winpr/libwinpr/crt/unicode.c
@@ -374,12 +374,16 @@ void ByteSwapUnicode(WCHAR* wstr, size_t length)
 SSIZE_T ConvertWCharToUtf8(const WCHAR* wstr, char* str, size_t len)
 {
 	if (!wstr)
+	{
+		if (str && len)
+			str[0] = 0;
 		return 0;
+	}
 
 	const int rc =
 	    WideCharToMultiByte(CP_UTF8, 0, wstr, -1, str, (int)MIN(INT32_MAX, len), NULL, NULL);
 	if (rc <= 0)
-		return rc;
+		return -1;
 	else if ((size_t)rc == len)
 	{
 		if (str && (str[rc - 1] != '\0'))
@@ -398,7 +402,10 @@ SSIZE_T ConvertWCharNToUtf8(const WCHAR* wstr, size_t wlen, char* str, size_t le
 	size_t iwlen = _wcsnlen(wstr, wlen);
 
 	if (wlen > INT32_MAX)
+	{
+		SetLastError(ERROR_INVALID_PARAMETER);
 		return -1;
+	}
 
 	if (iwlen < wlen)
 	{
@@ -425,13 +432,16 @@ SSIZE_T ConvertWCharNToUtf8(const WCHAR* wstr, size_t wlen, char* str, size_t le
 
 SSIZE_T ConvertMszWCharNToUtf8(const WCHAR* wstr, size_t wlen, char* str, size_t len)
 {
-	if (len == 0)
+	if (wlen == 0)
 		return 0;
 
-	WINPR_ASSERT(str);
+	WINPR_ASSERT(wstr);
 
 	if (wlen > INT32_MAX)
+	{
+		SetLastError(ERROR_INVALID_PARAMETER);
 		return -1;
+	}
 
 	const int iwlen = MIN(INT32_MAX, len);
 	const int rc = WideCharToMultiByte(CP_UTF8, 0, wstr, (int)wlen, str, (int)iwlen, NULL, NULL);
@@ -444,12 +454,16 @@ SSIZE_T ConvertMszWCharNToUtf8(const WCHAR* wstr, size_t wlen, char* str, size_t
 SSIZE_T ConvertUtf8ToWChar(const char* str, WCHAR* wstr, size_t wlen)
 {
 	if (!str)
+	{
+		if (wstr && wlen)
+			wstr[0] = 0;
 		return 0;
+	}
 
 	const int iwlen = MIN(INT32_MAX, wlen);
 	const int rc = MultiByteToWideChar(CP_UTF8, 0, str, -1, wstr, iwlen);
 	if (rc <= 0)
-		return rc;
+		return -1;
 	else if (iwlen == rc)
 	{
 		if (wstr && (wstr[rc - 1] != '\0'))
@@ -468,7 +482,10 @@ SSIZE_T ConvertUtf8NToWChar(const char* str, size_t len, WCHAR* wstr, size_t wle
 	WINPR_ASSERT(str);
 
 	if (len > INT32_MAX)
+	{
+		SetLastError(ERROR_INVALID_PARAMETER);
 		return -1;
+	}
 	if (ilen < len)
 	{
 		isNullTerminated = TRUE;
@@ -501,7 +518,10 @@ SSIZE_T ConvertMszUtf8NToWChar(const char* str, size_t len, WCHAR* wstr, size_t 
 	WINPR_ASSERT(str);
 
 	if (len > INT32_MAX)
+	{
+		SetLastError(ERROR_INVALID_PARAMETER);
 		return -1;
+	}
 
 	const int iwlen = MIN(INT32_MAX, wlen);
 	const int rc = MultiByteToWideChar(CP_UTF8, 0, str, (int)len, wstr, (int)iwlen);

--- a/winpr/libwinpr/crt/unicode_icu.c
+++ b/winpr/libwinpr/crt/unicode_icu.c
@@ -52,7 +52,10 @@ int int_MultiByteToWideChar(UINT CodePage, DWORD dwFlags, LPCSTR lpMultiByteStr,
 	/* If cbMultiByte is 0, the function fails */
 
 	if ((cbMultiByte == 0) || (cbMultiByte < -1))
+	{
+		SetLastError(ERROR_INVALID_PARAMETER);
 		return 0;
+	}
 
 	size_t len = 0;
 	if (isNullTerminated)
@@ -61,7 +64,10 @@ int int_MultiByteToWideChar(UINT CodePage, DWORD dwFlags, LPCSTR lpMultiByteStr,
 		len = cbMultiByte;
 
 	if (len >= INT_MAX)
-		return -1;
+	{
+		SetLastError(ERROR_INVALID_PARAMETER);
+		return 0;
+	}
 	cbMultiByte = (int)len;
 
 	/*
@@ -81,6 +87,7 @@ int int_MultiByteToWideChar(UINT CodePage, DWORD dwFlags, LPCSTR lpMultiByteStr,
 
 			default:
 				WLog_ERR(TAG, "Unsupported encoding %u", CodePage);
+				SetLastError(ERROR_INVALID_PARAMETER);
 				return 0;
 		}
 
@@ -137,7 +144,10 @@ int int_WideCharToMultiByte(UINT CodePage, DWORD dwFlags, LPCWSTR lpWideCharStr,
 	/* If cchWideChar is 0, the function fails */
 
 	if ((cchWideChar == 0) || (cchWideChar < -1))
+	{
+		SetLastError(ERROR_INVALID_PARAMETER);
 		return 0;
+	}
 
 	/* If cchWideChar is -1, the string is null-terminated */
 
@@ -148,7 +158,10 @@ int int_WideCharToMultiByte(UINT CodePage, DWORD dwFlags, LPCWSTR lpWideCharStr,
 		len = cchWideChar;
 
 	if (len >= INT32_MAX)
+	{
+		SetLastError(ERROR_INVALID_PARAMETER);
 		return 0;
+	}
 	cchWideChar = (int)len;
 
 	/*
@@ -168,6 +181,7 @@ int int_WideCharToMultiByte(UINT CodePage, DWORD dwFlags, LPCWSTR lpWideCharStr,
 
 			default:
 				WLog_ERR(TAG, "Unsupported encoding %u", CodePage);
+				SetLastError(ERROR_INVALID_PARAMETER);
 				return 0;
 		}
 


### PR DESCRIPTION
* added testcases when buffers reprensented empty string 
   * corrected the code to behave as the doc says
* added tests for the alloc versions

follow up of #9259