### PR TITLE
[core,server] set freed pointer NULL

### DIFF
--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -1205,6 +1205,7 @@ static void peer_channel_queue_free_message(void* obj)
 		return;
 
 	free(msg->context);
+	msg->context = NULL;
 }
 
 void channel_free(rdpPeerChannel* channel)


### PR DESCRIPTION
Fixes #9271: after freeing the memory reset it to NULL to signal it was already handled.