### PR TITLE
[server,shadow] fix initialization of [MS-RDPEGFX]

### DIFF
--- a/server/shadow/shadow_rdpgfx.c
+++ b/server/shadow/shadow_rdpgfx.c
@@ -39,7 +39,7 @@ int shadow_client_rdpgfx_init(rdpShadowClient* client)
 
 	rdpgfx->custom = client;
 
-	if (!IFCALLRESULT(CHANNEL_RC_OK, rdpgfx->Initialize, rdpgfx, FALSE))
+	if (!IFCALLRESULT(CHANNEL_RC_OK, rdpgfx->Initialize, rdpgfx, TRUE))
 		return -1;
 
 	return 1;


### PR DESCRIPTION
the channel was initialized with handling messages in a thread and handling the channel messages on main thread. fix that.
