### PR TITLE
WinSCard API dynamic loading from custom library

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2890,6 +2890,11 @@ static int freerdp_client_settings_parse_command_line_arguments_int(rdpSettings*
 			if (!freerdp_settings_set_string(settings, FreeRDP_SspiModule, arg->Value))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
+		CommandLineSwitchCase(arg, "winscard-module")
+		{
+			if (!freerdp_settings_set_string(settings, FreeRDP_WinSCardModule, arg->Value))
+				return COMMAND_LINE_ERROR_MEMORY;
+		}
 		CommandLineSwitchCase(arg, "redirect-prefer")
 		{
 			size_t count = 0;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -435,6 +435,8 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "SSH Agent forwarding channel" },
 	{ "sspi-module", COMMAND_LINE_VALUE_REQUIRED, "<SSPI module path>", NULL, NULL, -1, NULL,
 	  "SSPI shared library module file path" },
+	{ "winscard-module", COMMAND_LINE_VALUE_REQUIRED, "<WinSCard module path>", NULL, NULL, -1,
+	  NULL, "WinSCard shared library module file path" },
 	{ "disable-output", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL,
 	  "Deactivate all graphics decoding in the client session. Useful for load tests with many "
 	  "simultaneous connections" },

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -647,6 +647,7 @@ extern "C"
 #define FreeRDP_AuthenticationPackageList (1110)
 #define FreeRDP_RdstlsSecurity (1111)
 #define FreeRDP_AadSecurity (1112)
+#define FreeRDP_WinSCardModule (1113)
 #define FreeRDP_MstscCookieMode (1152)
 #define FreeRDP_CookieMaxLength (1153)
 #define FreeRDP_PreconnectionId (1154)
@@ -1168,7 +1169,8 @@ extern "C"
 		ALIGN64 char* AuthenticationPackageList;   /* 1110 */
 		ALIGN64 BOOL RdstlsSecurity;               /* 1111 */
 		ALIGN64 BOOL AadSecurity;                  /* 1112 */
-		UINT64 padding1152[1152 - 1113];           /* 1113 */
+		ALIGN64 char* WinSCardModule;              /* 1113 */
+		UINT64 padding1152[1152 - 1114];           /* 1114 */
 
 		/* Connection Cookie */
 		ALIGN64 BOOL MstscCookieMode;      /* 1152 */

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -2828,6 +2828,9 @@ const char* freerdp_settings_get_string(const rdpSettings* settings, size_t id)
 		case FreeRDP_Username:
 			return settings->Username;
 
+		case FreeRDP_WinSCardModule:
+			return settings->WinSCardModule;
+
 		case FreeRDP_WindowTitle:
 			return settings->WindowTitle;
 
@@ -3105,6 +3108,9 @@ char* freerdp_settings_get_string_writable(rdpSettings* settings, size_t id)
 
 		case FreeRDP_Username:
 			return settings->Username;
+
+		case FreeRDP_WinSCardModule:
+			return settings->WinSCardModule;
 
 		case FreeRDP_WindowTitle:
 			return settings->WindowTitle;
@@ -3392,6 +3398,9 @@ BOOL freerdp_settings_set_string_(rdpSettings* settings, size_t id, char* val, s
 
 		case FreeRDP_Username:
 			return update_string_(&settings->Username, cnv.c, len);
+
+		case FreeRDP_WinSCardModule:
+			return update_string_(&settings->WinSCardModule, cnv.c, len);
 
 		case FreeRDP_WindowTitle:
 			return update_string_(&settings->WindowTitle, cnv.c, len);
@@ -3697,6 +3706,9 @@ BOOL freerdp_settings_set_string_copy_(rdpSettings* settings, size_t id, const c
 
 		case FreeRDP_Username:
 			return update_string_copy_(&settings->Username, cnv.cc, len, cleanup);
+
+		case FreeRDP_WinSCardModule:
+			return update_string_copy_(&settings->WinSCardModule, cnv.cc, len, cleanup);
 
 		case FreeRDP_WindowTitle:
 			return update_string_copy_(&settings->WindowTitle, cnv.cc, len, cleanup);

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -540,6 +540,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_UserSpecifiedServerName, FREERDP_SETTINGS_TYPE_STRING,
 	  "FreeRDP_UserSpecifiedServerName" },
 	{ FreeRDP_Username, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_Username" },
+	{ FreeRDP_WinSCardModule, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_WinSCardModule" },
 	{ FreeRDP_WindowTitle, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_WindowTitle" },
 	{ FreeRDP_WmClass, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_WmClass" },
 	{ FreeRDP_BitmapCacheV2CellInfo, FREERDP_SETTINGS_TYPE_POINTER,

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -430,6 +430,7 @@ static const size_t string_list_indices[] = {
 	FreeRDP_TransportDumpFile,
 	FreeRDP_UserSpecifiedServerName,
 	FreeRDP_Username,
+	FreeRDP_WinSCardModule,
 	FreeRDP_WindowTitle,
 	FreeRDP_WmClass,
 };

--- a/winpr/include/winpr/smartcard.h
+++ b/winpr/include/winpr/smartcard.h
@@ -1209,9 +1209,9 @@ extern "C"
 	WINSCARDAPI const char* WINAPI SCardGetCardStateString(DWORD dwCardState);
 	WINSCARDAPI char* WINAPI SCardGetReaderStateString(DWORD dwReaderState);
 
-	WINPR_API bool WinSCard_LoadApiTableFunctions(PSCardApiFunctionTable pWinSCardApiTable,
+	WINPR_API BOOL WinSCard_LoadApiTableFunctions(PSCardApiFunctionTable pWinSCardApiTable,
 	                                              HMODULE hWinSCardLibrary);
-	WINPR_API SCardApiFunctionTable const* WinPR_GetSCardApiFunctionTable(void);
+	WINPR_API const SCardApiFunctionTable* WinPR_GetSCardApiFunctionTable(void);
 
 #ifdef __cplusplus
 }

--- a/winpr/include/winpr/smartcard.h
+++ b/winpr/include/winpr/smartcard.h
@@ -1209,6 +1209,10 @@ extern "C"
 	WINSCARDAPI const char* WINAPI SCardGetCardStateString(DWORD dwCardState);
 	WINSCARDAPI char* WINAPI SCardGetReaderStateString(DWORD dwReaderState);
 
+	WINPR_API bool WinSCard_LoadApiTableFunctions(PSCardApiFunctionTable pWinSCardApiTable,
+	                                              HMODULE hWinSCardLibrary);
+	WINPR_API SCardApiFunctionTable const* WinPR_GetSCardApiFunctionTable(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/winpr/libwinpr/smartcard/CMakeLists.txt
+++ b/winpr/libwinpr/smartcard/CMakeLists.txt
@@ -44,8 +44,8 @@ endif()
 
 if(WIN32)
         list(APPEND ${MODULE_PREFIX}_SRCS
-                smartcard_winscard.c
-                smartcard_winscard.h)
+                smartcard_windows.c
+                smartcard_windows.h)
 endif()
 
 winpr_module_add(${${MODULE_PREFIX}_SRCS})

--- a/winpr/libwinpr/smartcard/smartcard.c
+++ b/winpr/libwinpr/smartcard/smartcard.c
@@ -1103,7 +1103,7 @@ WINSCARDAPI char* WINAPI SCardGetReaderStateString(DWORD dwReaderState)
 #define WINSCARD_LOAD_PROC(_name, ...) \
 	pWinSCardApiTable->pfn##_name = (fn##_name)GetProcAddress(hWinSCardLibrary, #_name);
 
-bool WinSCard_LoadApiTableFunctions(PSCardApiFunctionTable pWinSCardApiTable,
+BOOL WinSCard_LoadApiTableFunctions(PSCardApiFunctionTable pWinSCardApiTable,
                                     HMODULE hWinSCardLibrary)
 {
 	WINPR_ASSERT(pWinSCardApiTable);
@@ -1186,7 +1186,7 @@ bool WinSCard_LoadApiTableFunctions(PSCardApiFunctionTable pWinSCardApiTable,
 	WINSCARD_LOAD_PROC(SCardListReadersWithDeviceInstanceIdW);
 	WINSCARD_LOAD_PROC(SCardAudit);
 
-	return true;
+	return TRUE;
 }
 
 static const SCardApiFunctionTable WinPR_SCardApiFunctionTable = {
@@ -1271,9 +1271,7 @@ static const SCardApiFunctionTable WinPR_SCardApiFunctionTable = {
 	SCardAudit                             /* SCardAudit */
 };
 
-static SCardApiFunctionTable const* pWinPR_SCardApiFunctionTable = &WinPR_SCardApiFunctionTable;
-
-SCardApiFunctionTable const* WinPR_GetSCardApiFunctionTable(void)
+const SCardApiFunctionTable* WinPR_GetSCardApiFunctionTable(void)
 {
-	return pWinPR_SCardApiFunctionTable;
+	return &WinPR_SCardApiFunctionTable;
 }

--- a/winpr/libwinpr/smartcard/smartcard.h
+++ b/winpr/libwinpr/smartcard/smartcard.h
@@ -25,7 +25,7 @@
 #ifndef _WIN32
 #include "smartcard_pcsc.h"
 #else
-#include "smartcard_winscard.h"
+#include "smartcard_windows.h"
 #endif
 
 #endif /* WINPR_SMARTCARD_PRIVATE_H */

--- a/winpr/libwinpr/smartcard/smartcard_windows.c
+++ b/winpr/libwinpr/smartcard/smartcard_windows.c
@@ -19,17 +19,15 @@
 
 #include <winpr/config.h>
 
-#ifdef _WIN32
-
 #include <winpr/crt.h>
 #include <winpr/library.h>
 #include <winpr/smartcard.h>
 
-#include "smartcard_winscard.h"
+#include "smartcard_windows.h"
 
 static HMODULE g_WinSCardModule = NULL;
 
-SCardApiFunctionTable WinSCard_SCardApiFunctionTable = {
+static SCardApiFunctionTable Windows_SCardApiFunctionTable = {
 	0, /* dwVersion */
 	0, /* dwFlags */
 
@@ -111,95 +109,18 @@ SCardApiFunctionTable WinSCard_SCardApiFunctionTable = {
 	NULL  /* SCardAudit */
 };
 
-PSCardApiFunctionTable WinSCard_GetSCardApiFunctionTable(void)
+const SCardApiFunctionTable* Windows_GetSCardApiFunctionTable(void)
 {
-	return &WinSCard_SCardApiFunctionTable;
+	return &Windows_SCardApiFunctionTable;
 }
 
-int WinSCard_InitializeSCardApi(void)
+int Windows_InitializeSCardApi(void)
 {
 	g_WinSCardModule = LoadLibraryA("WinSCard.dll");
 
 	if (!g_WinSCardModule)
 		return -1;
 
-	WINSCARD_LOAD_PROC(SCardEstablishContext);
-	WINSCARD_LOAD_PROC(SCardReleaseContext);
-	WINSCARD_LOAD_PROC(SCardIsValidContext);
-	WINSCARD_LOAD_PROC(SCardListReaderGroupsA);
-	WINSCARD_LOAD_PROC(SCardListReaderGroupsW);
-	WINSCARD_LOAD_PROC(SCardListReadersA);
-	WINSCARD_LOAD_PROC(SCardListReadersW);
-	WINSCARD_LOAD_PROC(SCardListCardsA);
-	WINSCARD_LOAD_PROC(SCardListCardsW);
-	WINSCARD_LOAD_PROC(SCardListInterfacesA);
-	WINSCARD_LOAD_PROC(SCardListInterfacesW);
-	WINSCARD_LOAD_PROC(SCardGetProviderIdA);
-	WINSCARD_LOAD_PROC(SCardGetProviderIdW);
-	WINSCARD_LOAD_PROC(SCardGetCardTypeProviderNameA);
-	WINSCARD_LOAD_PROC(SCardGetCardTypeProviderNameW);
-	WINSCARD_LOAD_PROC(SCardIntroduceReaderGroupA);
-	WINSCARD_LOAD_PROC(SCardIntroduceReaderGroupW);
-	WINSCARD_LOAD_PROC(SCardForgetReaderGroupA);
-	WINSCARD_LOAD_PROC(SCardForgetReaderGroupW);
-	WINSCARD_LOAD_PROC(SCardIntroduceReaderA);
-	WINSCARD_LOAD_PROC(SCardIntroduceReaderW);
-	WINSCARD_LOAD_PROC(SCardForgetReaderA);
-	WINSCARD_LOAD_PROC(SCardForgetReaderW);
-	WINSCARD_LOAD_PROC(SCardAddReaderToGroupA);
-	WINSCARD_LOAD_PROC(SCardAddReaderToGroupW);
-	WINSCARD_LOAD_PROC(SCardRemoveReaderFromGroupA);
-	WINSCARD_LOAD_PROC(SCardRemoveReaderFromGroupW);
-	WINSCARD_LOAD_PROC(SCardIntroduceCardTypeA);
-	WINSCARD_LOAD_PROC(SCardIntroduceCardTypeW);
-	WINSCARD_LOAD_PROC(SCardSetCardTypeProviderNameA);
-	WINSCARD_LOAD_PROC(SCardSetCardTypeProviderNameW);
-	WINSCARD_LOAD_PROC(SCardForgetCardTypeA);
-	WINSCARD_LOAD_PROC(SCardForgetCardTypeW);
-	WINSCARD_LOAD_PROC(SCardFreeMemory);
-	WINSCARD_LOAD_PROC(SCardAccessStartedEvent);
-	WINSCARD_LOAD_PROC(SCardReleaseStartedEvent);
-	WINSCARD_LOAD_PROC(SCardLocateCardsA);
-	WINSCARD_LOAD_PROC(SCardLocateCardsW);
-	WINSCARD_LOAD_PROC(SCardLocateCardsByATRA);
-	WINSCARD_LOAD_PROC(SCardLocateCardsByATRW);
-	WINSCARD_LOAD_PROC(SCardGetStatusChangeA);
-	WINSCARD_LOAD_PROC(SCardGetStatusChangeW);
-	WINSCARD_LOAD_PROC(SCardCancel);
-	WINSCARD_LOAD_PROC(SCardConnectA);
-	WINSCARD_LOAD_PROC(SCardConnectW);
-	WINSCARD_LOAD_PROC(SCardReconnect);
-	WINSCARD_LOAD_PROC(SCardDisconnect);
-	WINSCARD_LOAD_PROC(SCardBeginTransaction);
-	WINSCARD_LOAD_PROC(SCardEndTransaction);
-	WINSCARD_LOAD_PROC(SCardCancelTransaction);
-	WINSCARD_LOAD_PROC(SCardState);
-	WINSCARD_LOAD_PROC(SCardStatusA);
-	WINSCARD_LOAD_PROC(SCardStatusW);
-	WINSCARD_LOAD_PROC(SCardTransmit);
-	WINSCARD_LOAD_PROC(SCardGetTransmitCount);
-	WINSCARD_LOAD_PROC(SCardControl);
-	WINSCARD_LOAD_PROC(SCardGetAttrib);
-	WINSCARD_LOAD_PROC(SCardSetAttrib);
-	WINSCARD_LOAD_PROC(SCardUIDlgSelectCardA);
-	WINSCARD_LOAD_PROC(SCardUIDlgSelectCardW);
-	WINSCARD_LOAD_PROC(GetOpenCardNameA);
-	WINSCARD_LOAD_PROC(GetOpenCardNameW);
-	WINSCARD_LOAD_PROC(SCardDlgExtendedError);
-	WINSCARD_LOAD_PROC(SCardReadCacheA);
-	WINSCARD_LOAD_PROC(SCardReadCacheW);
-	WINSCARD_LOAD_PROC(SCardWriteCacheA);
-	WINSCARD_LOAD_PROC(SCardWriteCacheW);
-	WINSCARD_LOAD_PROC(SCardGetReaderIconA);
-	WINSCARD_LOAD_PROC(SCardGetReaderIconW);
-	WINSCARD_LOAD_PROC(SCardGetDeviceTypeIdA);
-	WINSCARD_LOAD_PROC(SCardGetDeviceTypeIdW);
-	WINSCARD_LOAD_PROC(SCardGetReaderDeviceInstanceIdA);
-	WINSCARD_LOAD_PROC(SCardGetReaderDeviceInstanceIdW);
-	WINSCARD_LOAD_PROC(SCardListReadersWithDeviceInstanceIdA);
-	WINSCARD_LOAD_PROC(SCardListReadersWithDeviceInstanceIdW);
-	WINSCARD_LOAD_PROC(SCardAudit);
+	WinSCard_LoadApiTableFunctions(&Windows_SCardApiFunctionTable, g_WinSCardModule);
 	return 1;
 }
-
-#endif

--- a/winpr/libwinpr/smartcard/smartcard_windows.h
+++ b/winpr/libwinpr/smartcard/smartcard_windows.h
@@ -20,16 +20,9 @@
 #ifndef WINPR_SMARTCARD_WINSCARD_PRIVATE_H
 #define WINPR_SMARTCARD_WINSCARD_PRIVATE_H
 
-#ifdef _WIN32
-
 #include <winpr/smartcard.h>
 
-#define WINSCARD_LOAD_PROC(_name, ...) \
-	WinSCard_SCardApiFunctionTable.pfn##_name = (fn##_name)GetProcAddress(g_WinSCardModule, #_name);
-
-int WinSCard_InitializeSCardApi(void);
-PSCardApiFunctionTable WinSCard_GetSCardApiFunctionTable(void);
-
-#endif
+int Windows_InitializeSCardApi(void);
+const SCardApiFunctionTable* Windows_GetSCardApiFunctionTable(void);
 
 #endif /* WINPR_SMARTCARD_WINSCARD_PRIVATE_H */


### PR DESCRIPTION
Add support for loading a custom WinSCard API library dynamically instead of the WinPR WinSCard API implementation that wraps either the original Windows API or adapts pcsc-lite to behave like it. A new WinSCardModule FreeRDP setting has been added alongside the /winscard-module command-line parameter. The goal is to do the same as the SSPI API with the SspiModule FreeRDP setting + /sspi-module command-line argument, and allow us to develop a drop-in WinSCard API replacement in Rust (winscard-rs) to load with our Rust SSPI implementation (sspi-rs) and emulate smartcards at the application layer without using any system libraries. Since Kerberos needs to talk to WinSCard for the smartcards, we'll likely just have both the SSPI API and WinSCard API inside the same shared library, bundled together and fully aware of each other, we'll just pass the path to the same library in both places.