### PR TITLE
Winpr restrict primitives YUV

### DIFF
--- a/channels/rdpgfx/server/rdpgfx_main.c
+++ b/channels/rdpgfx/server/rdpgfx_main.c
@@ -1549,7 +1549,7 @@ BOOL rdpgfx_server_close(RdpgfxServerContext* context)
 	return TRUE;
 }
 
-static UINT rdpgfx_server_initialize(RdpgfxServerContext* context, BOOL externalThread)
+static BOOL rdpgfx_server_initialize(RdpgfxServerContext* context, BOOL externalThread)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(context->priv);
@@ -1558,11 +1558,11 @@ static UINT rdpgfx_server_initialize(RdpgfxServerContext* context, BOOL external
 	{
 		WLog_WARN(TAG, "Application error: RDPEGFX channel already initialized, "
 		               "calling in this state is not possible!");
-		return ERROR_INVALID_STATE;
+		return FALSE;
 	}
 
 	context->priv->ownThread = !externalThread;
-	return CHANNEL_RC_OK;
+	return TRUE;
 }
 
 RdpgfxServerContext* rdpgfx_server_context_new(HANDLE vcm)

--- a/include/freerdp/codec/color.h
+++ b/include/freerdp/codec/color.h
@@ -209,7 +209,7 @@ typedef struct gdi_palette gdiPalette;
 #if defined(WITH_FREERDP_DEPRECATED)
 #define ReadColor(...) FreeRDPReadColor(__VA_ARGS__)
 #endif
-	FREERDP_API UINT32 FreeRDPReadColor(const BYTE* src, UINT32 format);
+	FREERDP_API UINT32 FreeRDPReadColor(const BYTE* WINPR_RESTRICT src, UINT32 format);
 
 	/***
 	 *
@@ -225,8 +225,9 @@ typedef struct gdi_palette gdiPalette;
 #define WriteColor(...) FreeRDPWriteColor(__VA_ARGS__)
 #define WriteColorIgnoreAlpha(...) FreeRDPWriteColorIgnoreAlpha(__VA_ARGS__)
 #endif
-	FREERDP_API BOOL FreeRDPWriteColor(BYTE* dst, UINT32 format, UINT32 color);
-	FREERDP_API BOOL FreeRDPWriteColorIgnoreAlpha(BYTE* dst, UINT32 format, UINT32 color);
+	FREERDP_API BOOL FreeRDPWriteColor(BYTE* WINPR_RESTRICT dst, UINT32 format, UINT32 color);
+	FREERDP_API BOOL FreeRDPWriteColorIgnoreAlpha(BYTE* WINPR_RESTRICT dst, UINT32 format,
+	                                              UINT32 color);
 
 	/***
 	 *
@@ -297,12 +298,10 @@ typedef struct gdi_palette gdiPalette;
 	 *
 	 * @return          TRUE if success, FALSE otherwise
 	 */
-	FREERDP_API BOOL freerdp_image_copy_from_monochrome(BYTE* pDstData, UINT32 DstFormat,
-	                                                    UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
-	                                                    UINT32 nWidth, UINT32 nHeight,
-	                                                    const BYTE* pSrcData, UINT32 backColor,
-	                                                    UINT32 foreColor,
-	                                                    const gdiPalette* palette);
+	FREERDP_API BOOL freerdp_image_copy_from_monochrome(
+	    BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst,
+	    UINT32 nYDst, UINT32 nWidth, UINT32 nHeight, const BYTE* WINPR_RESTRICT pSrcData,
+	    UINT32 backColor, UINT32 foreColor, const gdiPalette* WINPR_RESTRICT palette);
 
 	/***
 	 *
@@ -323,13 +322,11 @@ typedef struct gdi_palette gdiPalette;
 	 *
 	 * @return              TRUE if success, FALSE otherwise
 	 */
-	FREERDP_API BOOL freerdp_image_copy_from_icon_data(BYTE* pDstData, UINT32 DstFormat,
-	                                                   UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
-	                                                   UINT16 nWidth, UINT16 nHeight,
-	                                                   const BYTE* bitsColor, UINT16 cbBitsColor,
-	                                                   const BYTE* bitsMask, UINT16 cbBitsMask,
-	                                                   const BYTE* colorTable, UINT16 cbColorTable,
-	                                                   UINT32 bpp);
+	FREERDP_API BOOL freerdp_image_copy_from_icon_data(
+	    BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst,
+	    UINT32 nYDst, UINT16 nWidth, UINT16 nHeight, const BYTE* WINPR_RESTRICT bitsColor,
+	    UINT16 cbBitsColor, const BYTE* WINPR_RESTRICT bitsMask, UINT16 cbBitsMask,
+	    const BYTE* WINPR_RESTRICT colorTable, UINT16 cbColorTable, UINT32 bpp);
 
 	/***
 	 *
@@ -350,9 +347,10 @@ typedef struct gdi_palette gdiPalette;
 	 * @return              TRUE if success, FALSE otherwise
 	 */
 	FREERDP_API BOOL freerdp_image_copy_from_pointer_data(
-	    BYTE* pDstData, UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
-	    UINT32 nWidth, UINT32 nHeight, const BYTE* xorMask, UINT32 xorMaskLength,
-	    const BYTE* andMask, UINT32 andMaskLength, UINT32 xorBpp, const gdiPalette* palette);
+	    BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst,
+	    UINT32 nYDst, UINT32 nWidth, UINT32 nHeight, const BYTE* WINPR_RESTRICT xorMask,
+	    UINT32 xorMaskLength, const BYTE* WINPR_RESTRICT andMask, UINT32 andMaskLength,
+	    UINT32 xorBpp, const gdiPalette* WINPR_RESTRICT palette);
 
 	/***
 	 *
@@ -398,9 +396,10 @@ typedef struct gdi_palette gdiPalette;
 	 *
 	 * @return          TRUE if success, FALSE otherwise
 	 */
-	FREERDP_API BOOL freerdp_image_scale(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep,
-	                                     UINT32 nXDst, UINT32 nYDst, UINT32 nDstWidth,
-	                                     UINT32 nDstHeight, const BYTE* pSrcData, DWORD SrcFormat,
+	FREERDP_API BOOL freerdp_image_scale(BYTE* WINPR_RESTRICT pDstData, DWORD DstFormat,
+	                                     UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
+	                                     UINT32 nDstWidth, UINT32 nDstHeight,
+	                                     const BYTE* WINPR_RESTRICT pSrcData, DWORD SrcFormat,
 	                                     UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc,
 	                                     UINT32 nSrcWidth, UINT32 nSrcHeight);
 
@@ -418,9 +417,9 @@ typedef struct gdi_palette gdiPalette;
 	 *
 	 * @return          TRUE if success, FALSE otherwise
 	 */
-	FREERDP_API BOOL freerdp_image_fill(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep,
-	                                    UINT32 nXDst, UINT32 nYDst, UINT32 nWidth, UINT32 nHeight,
-	                                    UINT32 color);
+	FREERDP_API BOOL freerdp_image_fill(BYTE* WINPR_RESTRICT pDstData, DWORD DstFormat,
+	                                    UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst, UINT32 nWidth,
+	                                    UINT32 nHeight, UINT32 color);
 
 #ifdef __cplusplus
 }

--- a/include/freerdp/primitives.h
+++ b/include/freerdp/primitives.h
@@ -20,6 +20,8 @@
 #ifndef FREERDP_PRIMITIVES_H
 #define FREERDP_PRIMITIVES_H
 
+#include <winpr/wtypes.h>
+
 #include <freerdp/api.h>
 #include <freerdp/types.h>
 #include <freerdp/codec/color.h>
@@ -83,70 +85,96 @@ typedef enum
 } avc444_frame_type;
 
 /* Function prototypes for all of the supported primitives. */
-typedef pstatus_t (*__copy_t)(const void* pSrc, void* pDst, INT32 bytes);
-typedef pstatus_t (*__copy_8u_t)(const BYTE* pSrc, BYTE* pDst, INT32 len);
-typedef pstatus_t (*__copy_8u_AC4r_t)(const BYTE* pSrc, INT32 srcStep, /* bytes */
-                                      BYTE* pDst, INT32 dstStep,       /* bytes */
-                                      INT32 width, INT32 height);      /* pixels */
-typedef pstatus_t (*__set_8u_t)(BYTE val, BYTE* pDst, UINT32 len);
-typedef pstatus_t (*__set_32s_t)(INT32 val, INT32* pDst, UINT32 len);
-typedef pstatus_t (*__set_32u_t)(UINT32 val, UINT32* pDst, UINT32 len);
-typedef pstatus_t (*__zero_t)(void* pDst, size_t bytes);
-typedef pstatus_t (*__alphaComp_argb_t)(const BYTE* pSrc1, UINT32 src1Step, const BYTE* pSrc2,
-                                        UINT32 src2Step, BYTE* pDst, UINT32 dstStep, UINT32 width,
-                                        UINT32 height);
-typedef pstatus_t (*__add_16s_t)(const INT16* pSrc1, const INT16* pSrc2, INT16* pDst, UINT32 len);
-typedef pstatus_t (*__lShiftC_16s_t)(const INT16* pSrc, UINT32 val, INT16* pSrcDst, UINT32 len);
-typedef pstatus_t (*__lShiftC_16u_t)(const UINT16* pSrc, UINT32 val, UINT16* pSrcDst, UINT32 len);
-typedef pstatus_t (*__rShiftC_16s_t)(const INT16* pSrc, UINT32 val, INT16* pSrcDst, UINT32 len);
-typedef pstatus_t (*__rShiftC_16u_t)(const UINT16* pSrc, UINT32 val, UINT16* pSrcDst, UINT32 len);
-typedef pstatus_t (*__shiftC_16s_t)(const INT16* pSrc, INT32 val, INT16* pSrcDst, UINT32 len);
-typedef pstatus_t (*__shiftC_16u_t)(const UINT16* pSrc, INT32 val, UINT16* pSrcDst, UINT32 len);
-typedef pstatus_t (*__sign_16s_t)(const INT16* pSrc, INT16* pDst, UINT32 len);
-typedef pstatus_t (*__yCbCrToRGB_16s8u_P3AC4R_t)(const INT16* const pSrc[3], UINT32 srcStep,
-                                                 BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
-                                                 const prim_size_t* roi);
-typedef pstatus_t (*__yCbCrToRGB_16s16s_P3P3_t)(const INT16* const pSrc[3], INT32 srcStep,
-                                                INT16* pDst[3], INT32 dstStep,
-                                                const prim_size_t* roi);
-typedef pstatus_t (*__RGBToYCbCr_16s16s_P3P3_t)(const INT16* const pSrc[3], INT32 srcStep,
-                                                INT16* pDst[3], INT32 dstStep,
-                                                const prim_size_t* roi);
-typedef pstatus_t (*__RGBToRGB_16s8u_P3AC4R_t)(const INT16* const pSrc[3], UINT32 srcStep,
-                                               BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
-                                               const prim_size_t* roi);
-typedef pstatus_t (*__YCoCgToRGB_8u_AC4R_t)(const BYTE* pSrc, INT32 srcStep, BYTE* pDst,
-                                            UINT32 DstFormat, INT32 dstStep, UINT32 width,
-                                            UINT32 height, UINT8 shift, BOOL withAlpha);
-typedef pstatus_t (*__RGB565ToARGB_16u32u_C3C4_t)(const UINT16* pSrc, INT32 srcStep, UINT32* pDst,
-                                                  INT32 dstStep, UINT32 width, UINT32 height,
-                                                  UINT32 format);
-typedef pstatus_t (*__YUV420ToRGB_8u_P3AC4R_t)(const BYTE* const pSrc[3], const UINT32 srcStep[3],
-                                               BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
-                                               const prim_size_t* roi);
-typedef pstatus_t (*__YUV444ToRGB_8u_P3AC4R_t)(const BYTE* const pSrc[3], const UINT32 srcStep[3],
-                                               BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
-                                               const prim_size_t* roi);
-typedef pstatus_t (*__RGBToYUV420_8u_P3AC4R_t)(const BYTE* pSrc, UINT32 SrcFormat, UINT32 srcStep,
-                                               BYTE* pDst[3], const UINT32 dstStep[3],
-                                               const prim_size_t* roi);
-typedef pstatus_t (*__RGBToYUV444_8u_P3AC4R_t)(const BYTE* pSrc, UINT32 SrcFormat, UINT32 srcStep,
-                                               BYTE* pDst[3], UINT32 dstStep[3],
-                                               const prim_size_t* roi);
-typedef pstatus_t (*__YUV420CombineToYUV444_t)(avc444_frame_type type, const BYTE* const pSrc[3],
-                                               const UINT32 srcStep[3], UINT32 nWidth,
-                                               UINT32 nHeight, BYTE* pDst[3],
-                                               const UINT32 dstStep[3], const RECTANGLE_16* roi);
-typedef pstatus_t (*__YUV444SplitToYUV420_t)(const BYTE* const pSrc[3], const UINT32 srcStep[3],
-                                             BYTE* pMainDst[3], const UINT32 dstMainStep[3],
-                                             BYTE* pAuxDst[3], const UINT32 srcAuxStep[3],
-                                             const prim_size_t* roi);
-typedef pstatus_t (*__RGBToAVC444YUV_t)(const BYTE* pSrc, UINT32 srcFormat, UINT32 srcStep,
-                                        BYTE* pMainDst[3], const UINT32 dstMainStep[3],
-                                        BYTE* pAuxDst[3], const UINT32 dstAuxStep[3],
-                                        const prim_size_t* roi);
-typedef pstatus_t (*__andC_32u_t)(const UINT32* pSrc, UINT32 val, UINT32* pDst, INT32 len);
-typedef pstatus_t (*__orC_32u_t)(const UINT32* pSrc, UINT32 val, UINT32* pDst, INT32 len);
+typedef pstatus_t (*__copy_t)(const void* WINPR_RESTRICT pSrc, void* WINPR_RESTRICT pDst,
+	                          INT32 bytes);
+typedef pstatus_t (*__copy_8u_t)(const BYTE* WINPR_RESTRICT pSrc, BYTE* WINPR_RESTRICT pDst,
+	                             INT32 len);
+typedef pstatus_t (*__copy_8u_AC4r_t)(const BYTE* WINPR_RESTRICT pSrc, INT32 srcStep, /* bytes */
+	                                  BYTE* WINPR_RESTRICT pDst, INT32 dstStep,       /* bytes */
+	                                  INT32 width, INT32 height);                     /* pixels */
+typedef pstatus_t (*__set_8u_t)(BYTE val, BYTE* WINPR_RESTRICT pDst, UINT32 len);
+typedef pstatus_t (*__set_32s_t)(INT32 val, INT32* WINPR_RESTRICT pDst, UINT32 len);
+typedef pstatus_t (*__set_32u_t)(UINT32 val, UINT32* WINPR_RESTRICT pDst, UINT32 len);
+typedef pstatus_t (*__zero_t)(void* WINPR_RESTRICT pDst, size_t bytes);
+typedef pstatus_t (*__alphaComp_argb_t)(const BYTE* WINPR_RESTRICT pSrc1, UINT32 src1Step,
+	                                    const BYTE* WINPR_RESTRICT pSrc2, UINT32 src2Step,
+	                                    BYTE* WINPR_RESTRICT pDst, UINT32 dstStep, UINT32 width,
+	                                    UINT32 height);
+typedef pstatus_t (*__add_16s_t)(const INT16* WINPR_RESTRICT pSrc1,
+	                             const INT16* WINPR_RESTRICT pSrc2, INT16* WINPR_RESTRICT pDst,
+	                             UINT32 len);
+typedef pstatus_t (*__lShiftC_16s_t)(const INT16* WINPR_RESTRICT pSrc, UINT32 val,
+	                                 INT16* WINPR_RESTRICT pSrcDst, UINT32 len);
+typedef pstatus_t (*__lShiftC_16u_t)(const UINT16* WINPR_RESTRICT pSrc, UINT32 val,
+	                                 UINT16* WINPR_RESTRICT pSrcDst, UINT32 len);
+typedef pstatus_t (*__rShiftC_16s_t)(const INT16* WINPR_RESTRICT pSrc, UINT32 val,
+	                                 INT16* WINPR_RESTRICT pSrcDst, UINT32 len);
+typedef pstatus_t (*__rShiftC_16u_t)(const UINT16* WINPR_RESTRICT pSrc, UINT32 val,
+	                                 UINT16* WINPR_RESTRICT pSrcDst, UINT32 len);
+typedef pstatus_t (*__shiftC_16s_t)(const INT16* WINPR_RESTRICT pSrc, INT32 val,
+	                                INT16* WINPR_RESTRICT pSrcDst, UINT32 len);
+typedef pstatus_t (*__shiftC_16u_t)(const UINT16* WINPR_RESTRICT pSrc, INT32 val,
+	                                UINT16* WINPR_RESTRICT pSrcDst, UINT32 len);
+typedef pstatus_t (*__sign_16s_t)(const INT16* WINPR_RESTRICT pSrc, INT16* WINPR_RESTRICT pDst,
+	                              UINT32 len);
+typedef pstatus_t (*__yCbCrToRGB_16s8u_P3AC4R_t)(const INT16* const WINPR_RESTRICT pSrc[3],
+	                                             UINT32 srcStep, BYTE* WINPR_RESTRICT pDst,
+	                                             UINT32 dstStep, UINT32 DstFormat,
+	                                             const prim_size_t* WINPR_RESTRICT roi);
+typedef pstatus_t (*__yCbCrToRGB_16s16s_P3P3_t)(const INT16* const WINPR_RESTRICT pSrc[3],
+	                                            INT32 srcStep, INT16* WINPR_RESTRICT pDst[3],
+	                                            INT32 dstStep,
+	                                            const prim_size_t* WINPR_RESTRICT roi);
+typedef pstatus_t (*__RGBToYCbCr_16s16s_P3P3_t)(const INT16* const WINPR_RESTRICT pSrc[3],
+	                                            INT32 srcStep, INT16* WINPR_RESTRICT pDst[3],
+	                                            INT32 dstStep,
+	                                            const prim_size_t* WINPR_RESTRICT roi);
+typedef pstatus_t (*__RGBToRGB_16s8u_P3AC4R_t)(const INT16* const WINPR_RESTRICT pSrc[3],
+	                                           UINT32 srcStep, BYTE* WINPR_RESTRICT pDst,
+	                                           UINT32 dstStep, UINT32 DstFormat,
+	                                           const prim_size_t* WINPR_RESTRICT roi);
+typedef pstatus_t (*__YCoCgToRGB_8u_AC4R_t)(const BYTE* WINPR_RESTRICT pSrc, INT32 srcStep,
+	                                        BYTE* WINPR_RESTRICT pDst, UINT32 DstFormat,
+	                                        INT32 dstStep, UINT32 width, UINT32 height, UINT8 shift,
+	                                        BOOL withAlpha);
+typedef pstatus_t (*__RGB565ToARGB_16u32u_C3C4_t)(const UINT16* WINPR_RESTRICT pSrc, INT32 srcStep,
+	                                              UINT32* WINPR_RESTRICT pDst, INT32 dstStep,
+	                                              UINT32 width, UINT32 height, UINT32 format);
+typedef pstatus_t (*__YUV420ToRGB_8u_P3AC4R_t)(const BYTE* const WINPR_RESTRICT pSrc[3],
+	                                           const UINT32 srcStep[3], BYTE* WINPR_RESTRICT pDst,
+	                                           UINT32 dstStep, UINT32 DstFormat,
+	                                           const prim_size_t* WINPR_RESTRICT roi);
+typedef pstatus_t (*__YUV444ToRGB_8u_P3AC4R_t)(const BYTE* const WINPR_RESTRICT pSrc[3],
+	                                           const UINT32 srcStep[3], BYTE* WINPR_RESTRICT pDst,
+	                                           UINT32 dstStep, UINT32 DstFormat,
+	                                           const prim_size_t* WINPR_RESTRICT roi);
+typedef pstatus_t (*__RGBToYUV420_8u_P3AC4R_t)(const BYTE* WINPR_RESTRICT pSrc, UINT32 SrcFormat,
+	                                           UINT32 srcStep, BYTE* WINPR_RESTRICT pDst[3],
+	                                           const UINT32 dstStep[3],
+	                                           const prim_size_t* WINPR_RESTRICT roi);
+typedef pstatus_t (*__RGBToYUV444_8u_P3AC4R_t)(const BYTE* WINPR_RESTRICT pSrc, UINT32 SrcFormat,
+	                                           UINT32 srcStep, BYTE* WINPR_RESTRICT pDst[3],
+	                                           UINT32 dstStep[3],
+	                                           const prim_size_t* WINPR_RESTRICT roi);
+typedef pstatus_t (*__YUV420CombineToYUV444_t)(avc444_frame_type type,
+	                                           const BYTE* const WINPR_RESTRICT pSrc[3],
+	                                           const UINT32 srcStep[3], UINT32 nWidth,
+	                                           UINT32 nHeight, BYTE* WINPR_RESTRICT pDst[3],
+	                                           const UINT32 dstStep[3],
+	                                           const RECTANGLE_16* WINPR_RESTRICT roi);
+typedef pstatus_t (*__YUV444SplitToYUV420_t)(
+	const BYTE* const WINPR_RESTRICT pSrc[3], const UINT32 srcStep[3],
+	BYTE* WINPR_RESTRICT pMainDst[3], const UINT32 dstMainStep[3], BYTE* WINPR_RESTRICT pAuxDst[3],
+	const UINT32 srcAuxStep[3], const prim_size_t* WINPR_RESTRICT roi);
+typedef pstatus_t (*__RGBToAVC444YUV_t)(const BYTE* WINPR_RESTRICT pSrc, UINT32 srcFormat,
+	                                    UINT32 srcStep, BYTE* WINPR_RESTRICT pMainDst[3],
+	                                    const UINT32 dstMainStep[3],
+	                                    BYTE* WINPR_RESTRICT pAuxDst[3], const UINT32 dstAuxStep[3],
+	                                    const prim_size_t* WINPR_RESTRICT roi);
+typedef pstatus_t (*__andC_32u_t)(const UINT32* WINPR_RESTRICT pSrc, UINT32 val,
+	                              UINT32* WINPR_RESTRICT pDst, INT32 len);
+typedef pstatus_t (*__orC_32u_t)(const UINT32* WINPR_RESTRICT pSrc, UINT32 val,
+	                             UINT32* WINPR_RESTRICT pDst, INT32 len);
 typedef pstatus_t (*primitives_uninit_t)(void);
 
 typedef struct

--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -81,10 +81,11 @@ BYTE* freerdp_glyph_convert(UINT32 width, UINT32 height, const BYTE* data)
 	return dstData;
 }
 
-BOOL freerdp_image_copy_from_monochrome(BYTE* pDstData, UINT32 DstFormat, UINT32 nDstStep,
-                                        UINT32 nXDst, UINT32 nYDst, UINT32 nWidth, UINT32 nHeight,
-                                        const BYTE* pSrcData, UINT32 backColor, UINT32 foreColor,
-                                        const gdiPalette* palette)
+BOOL freerdp_image_copy_from_monochrome(BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat,
+                                        UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst, UINT32 nWidth,
+                                        UINT32 nHeight, const BYTE* WINPR_RESTRICT pSrcData,
+                                        UINT32 backColor, UINT32 foreColor,
+                                        const gdiPalette* WINPR_RESTRICT palette)
 {
 	UINT32 x, y;
 	BOOL vFlip;
@@ -190,11 +191,12 @@ static INLINE UINT32 round_up(UINT32 a, UINT32 b)
 	return b * div_ceil(a, b);
 }
 
-BOOL freerdp_image_copy_from_icon_data(BYTE* pDstData, UINT32 DstFormat, UINT32 nDstStep,
-                                       UINT32 nXDst, UINT32 nYDst, UINT16 nWidth, UINT16 nHeight,
-                                       const BYTE* bitsColor, UINT16 cbBitsColor,
-                                       const BYTE* bitsMask, UINT16 cbBitsMask,
-                                       const BYTE* colorTable, UINT16 cbColorTable, UINT32 bpp)
+BOOL freerdp_image_copy_from_icon_data(BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat,
+                                       UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst, UINT16 nWidth,
+                                       UINT16 nHeight, const BYTE* WINPR_RESTRICT bitsColor,
+                                       UINT16 cbBitsColor, const BYTE* WINPR_RESTRICT bitsMask,
+                                       UINT16 cbBitsMask, const BYTE* WINPR_RESTRICT colorTable,
+                                       UINT16 cbColorTable, UINT32 bpp)
 {
 	DWORD format;
 	gdiPalette palette;
@@ -299,12 +301,10 @@ BOOL freerdp_image_copy_from_icon_data(BYTE* pDstData, UINT32 DstFormat, UINT32 
 	return TRUE;
 }
 
-static BOOL freerdp_image_copy_from_pointer_data_1bpp(BYTE* pDstData, UINT32 DstFormat,
-                                                      UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
-                                                      UINT32 nWidth, UINT32 nHeight,
-                                                      const BYTE* xorMask, UINT32 xorMaskLength,
-                                                      const BYTE* andMask, UINT32 andMaskLength,
-                                                      UINT32 xorBpp)
+static BOOL freerdp_image_copy_from_pointer_data_1bpp(
+    BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
+    UINT32 nWidth, UINT32 nHeight, const BYTE* WINPR_RESTRICT xorMask, UINT32 xorMaskLength,
+    const BYTE* WINPR_RESTRICT andMask, UINT32 andMaskLength, UINT32 xorBpp)
 {
 	UINT32 x, y;
 	BOOL vFlip;
@@ -388,12 +388,11 @@ static BOOL freerdp_image_copy_from_pointer_data_1bpp(BYTE* pDstData, UINT32 Dst
 	return TRUE;
 }
 
-static BOOL freerdp_image_copy_from_pointer_data_xbpp(BYTE* pDstData, UINT32 DstFormat,
-                                                      UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
-                                                      UINT32 nWidth, UINT32 nHeight,
-                                                      const BYTE* xorMask, UINT32 xorMaskLength,
-                                                      const BYTE* andMask, UINT32 andMaskLength,
-                                                      UINT32 xorBpp, const gdiPalette* palette)
+static BOOL freerdp_image_copy_from_pointer_data_xbpp(
+    BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
+    UINT32 nWidth, UINT32 nHeight, const BYTE* WINPR_RESTRICT xorMask, UINT32 xorMaskLength,
+    const BYTE* WINPR_RESTRICT andMask, UINT32 andMaskLength, UINT32 xorBpp,
+    const gdiPalette* palette)
 {
 	UINT32 x, y;
 	BOOL vFlip;
@@ -522,13 +521,13 @@ static BOOL freerdp_image_copy_from_pointer_data_xbpp(BYTE* pDstData, UINT32 Dst
  * http://msdn.microsoft.com/en-us/library/windows/hardware/ff556138/
  */
 
-BOOL freerdp_image_copy_from_pointer_data(BYTE* pDstData, UINT32 DstFormat, UINT32 nDstStep,
-                                          UINT32 nXDst, UINT32 nYDst, UINT32 nWidth, UINT32 nHeight,
-                                          const BYTE* xorMask, UINT32 xorMaskLength,
-                                          const BYTE* andMask, UINT32 andMaskLength, UINT32 xorBpp,
-                                          const gdiPalette* palette)
+BOOL freerdp_image_copy_from_pointer_data(BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat,
+                                          UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
+                                          UINT32 nWidth, UINT32 nHeight,
+                                          const BYTE* WINPR_RESTRICT xorMask, UINT32 xorMaskLength,
+                                          const BYTE* WINPR_RESTRICT andMask, UINT32 andMaskLength,
+                                          UINT32 xorBpp, const gdiPalette* palette)
 {
-	UINT32 y;
 	UINT32 dstBitsPerPixel;
 	UINT32 dstBytesPerPixel;
 	dstBitsPerPixel = FreeRDPGetBitsPerPixel(DstFormat);
@@ -537,9 +536,9 @@ BOOL freerdp_image_copy_from_pointer_data(BYTE* pDstData, UINT32 DstFormat, UINT
 	if (nDstStep <= 0)
 		nDstStep = dstBytesPerPixel * nWidth;
 
-	for (y = nYDst; y < nHeight; y++)
+	for (UINT32 y = nYDst; y < nHeight; y++)
 	{
-		BYTE* pDstLine = &pDstData[y * nDstStep + nXDst * dstBytesPerPixel];
+		BYTE* WINPR_RESTRICT pDstLine = &pDstData[y * nDstStep + nXDst * dstBytesPerPixel];
 		memset(pDstLine, 0, 1ull * dstBytesPerPixel * (nWidth - nXDst));
 	}
 
@@ -586,10 +585,12 @@ static INLINE BOOL overlapping(const BYTE* pDstData, UINT32 nXDst, UINT32 nYDst,
 	return FALSE;
 }
 
-BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32 nXDst,
-                        UINT32 nYDst, UINT32 nWidth, UINT32 nHeight, const BYTE* pSrcData,
-                        DWORD SrcFormat, UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc,
-                        const gdiPalette* palette, UINT32 flags)
+static BOOL freerdp_image_copy_no_overlap(BYTE* WINPR_RESTRICT pDstData, DWORD DstFormat,
+                                          UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
+                                          UINT32 nWidth, UINT32 nHeight,
+                                          const BYTE* WINPR_RESTRICT pSrcData, DWORD SrcFormat,
+                                          UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc,
+                                          const gdiPalette* WINPR_RESTRICT palette, UINT32 flags)
 {
 	const UINT32 dstByte = FreeRDPGetBytesPerPixel(DstFormat);
 	const UINT32 srcByte = FreeRDPGetBytesPerPixel(SrcFormat);
@@ -622,9 +623,117 @@ BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32
 
 	if (((flags & FREERDP_KEEP_DST_ALPHA) != 0) && FreeRDPColorHasAlpha(DstFormat))
 	{
-		UINT32 x, y;
+		for (UINT32 y = 0; y < nHeight; y++)
+		{
+			const BYTE* WINPR_RESTRICT srcLine =
+			    &pSrcData[(y + nYSrc) * nSrcStep * srcVMultiplier + srcVOffset];
+			BYTE* WINPR_RESTRICT dstLine =
+			    &pDstData[(y + nYDst) * nDstStep * dstVMultiplier + dstVOffset];
 
-		for (y = 0; y < nHeight; y++)
+			UINT32 color = FreeRDPReadColor(&srcLine[nXSrc * srcByte], SrcFormat);
+			UINT32 oldColor = color;
+			UINT32 dstColor = FreeRDPConvertColor(color, SrcFormat, DstFormat, palette);
+			FreeRDPWriteColorIgnoreAlpha(&dstLine[nXDst * dstByte], DstFormat, dstColor);
+			for (UINT32 x = 1; x < nWidth; x++)
+			{
+				color = FreeRDPReadColor(&srcLine[(x + nXSrc) * srcByte], SrcFormat);
+				if (color == oldColor)
+				{
+					FreeRDPWriteColorIgnoreAlpha(&dstLine[(x + nXDst) * dstByte], DstFormat,
+					                             dstColor);
+				}
+				else
+				{
+					oldColor = color;
+					dstColor = FreeRDPConvertColor(color, SrcFormat, DstFormat, palette);
+					FreeRDPWriteColorIgnoreAlpha(&dstLine[(x + nXDst) * dstByte], DstFormat,
+					                             dstColor);
+				}
+			}
+		}
+	}
+	else if (FreeRDPAreColorFormatsEqualNoAlpha(SrcFormat, DstFormat))
+	{
+		for (UINT32 y = 0; y < nHeight; y++)
+		{
+			const BYTE* WINPR_RESTRICT srcLine =
+			    &pSrcData[(y + nYSrc) * nSrcStep * srcVMultiplier + srcVOffset];
+			BYTE* WINPR_RESTRICT dstLine =
+			    &pDstData[(y + nYDst) * nDstStep * dstVMultiplier + dstVOffset];
+			memcpy(&dstLine[xDstOffset], &srcLine[xSrcOffset], copyDstWidth);
+		}
+	}
+	else
+	{
+		for (UINT32 y = 0; y < nHeight; y++)
+		{
+			const BYTE* WINPR_RESTRICT srcLine =
+			    &pSrcData[(y + nYSrc) * nSrcStep * srcVMultiplier + srcVOffset];
+			BYTE* WINPR_RESTRICT dstLine =
+			    &pDstData[(y + nYDst) * nDstStep * dstVMultiplier + dstVOffset];
+
+			UINT32 color = FreeRDPReadColor(&srcLine[nXSrc * srcByte], SrcFormat);
+			UINT32 oldColor = color;
+			UINT32 dstColor = FreeRDPConvertColor(color, SrcFormat, DstFormat, palette);
+			FreeRDPWriteColor(&dstLine[nXDst * dstByte], DstFormat, dstColor);
+			for (UINT32 x = 1; x < nWidth; x++)
+			{
+				color = FreeRDPReadColor(&srcLine[(x + nXSrc) * srcByte], SrcFormat);
+				if (color == oldColor)
+				{
+					FreeRDPWriteColor(&dstLine[(x + nXDst) * dstByte], DstFormat, dstColor);
+				}
+				else
+				{
+					oldColor = color;
+					dstColor = FreeRDPConvertColor(color, SrcFormat, DstFormat, palette);
+					FreeRDPWriteColor(&dstLine[(x + nXDst) * dstByte], DstFormat, dstColor);
+				}
+			}
+		}
+	}
+
+	return TRUE;
+}
+
+static BOOL freerdp_image_copy_overlap(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep,
+                                       UINT32 nXDst, UINT32 nYDst, UINT32 nWidth, UINT32 nHeight,
+                                       const BYTE* pSrcData, DWORD SrcFormat, UINT32 nSrcStep,
+                                       UINT32 nXSrc, UINT32 nYSrc, const gdiPalette* palette,
+                                       UINT32 flags)
+{
+	const UINT32 dstByte = FreeRDPGetBytesPerPixel(DstFormat);
+	const UINT32 srcByte = FreeRDPGetBytesPerPixel(SrcFormat);
+	const UINT32 copyDstWidth = nWidth * dstByte;
+	const UINT32 xSrcOffset = nXSrc * srcByte;
+	const UINT32 xDstOffset = nXDst * dstByte;
+	const BOOL vSrcVFlip = (flags & FREERDP_FLIP_VERTICAL) ? TRUE : FALSE;
+	UINT32 srcVOffset = 0;
+	INT32 srcVMultiplier = 1;
+	UINT32 dstVOffset = 0;
+	INT32 dstVMultiplier = 1;
+
+	if ((nHeight > INT32_MAX) || (nWidth > INT32_MAX))
+		return FALSE;
+
+	if (!pDstData || !pSrcData)
+		return FALSE;
+
+	if (nDstStep == 0)
+		nDstStep = nWidth * FreeRDPGetBytesPerPixel(DstFormat);
+
+	if (nSrcStep == 0)
+		nSrcStep = nWidth * FreeRDPGetBytesPerPixel(SrcFormat);
+
+	if (vSrcVFlip)
+	{
+		srcVOffset = (nHeight - 1) * nSrcStep;
+		srcVMultiplier = -1;
+	}
+
+	if (((flags & FREERDP_KEEP_DST_ALPHA) != 0) && FreeRDPColorHasAlpha(DstFormat))
+	{
+		for (UINT32 y = 0; y < nHeight; y++)
 		{
 			const BYTE* srcLine = &pSrcData[(y + nYSrc) * nSrcStep * srcVMultiplier + srcVOffset];
 			BYTE* dstLine = &pDstData[(y + nYDst) * nDstStep * dstVMultiplier + dstVOffset];
@@ -633,7 +742,7 @@ BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32
 			UINT32 oldColor = color;
 			UINT32 dstColor = FreeRDPConvertColor(color, SrcFormat, DstFormat, palette);
 			FreeRDPWriteColorIgnoreAlpha(&dstLine[nXDst * dstByte], DstFormat, dstColor);
-			for (x = 1; x < nWidth; x++)
+			for (UINT32 x = 1; x < nWidth; x++)
 			{
 				color = FreeRDPReadColor(&srcLine[(x + nXSrc) * srcByte], SrcFormat);
 				if (color == oldColor)
@@ -655,59 +764,8 @@ BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32
 	{
 		INT32 y;
 
-		if (overlapping(pDstData, nXDst, nYDst, nDstStep, dstByte, pSrcData, nXSrc, nYSrc, nSrcStep,
-		                srcByte, nWidth, nHeight))
-		{
-			/* Copy down */
-			if (nYDst < nYSrc)
-			{
-				for (y = 0; y < (INT32)nHeight; y++)
-				{
-					const BYTE* srcLine =
-					    &pSrcData[(y + nYSrc) * nSrcStep * srcVMultiplier + srcVOffset];
-					BYTE* dstLine = &pDstData[(y + nYDst) * nDstStep * dstVMultiplier + dstVOffset];
-					memcpy(&dstLine[xDstOffset], &srcLine[xSrcOffset], copyDstWidth);
-				}
-			}
-			/* Copy up */
-			else if (nYDst > nYSrc)
-			{
-				for (y = nHeight - 1; y >= 0; y--)
-				{
-					const BYTE* srcLine =
-					    &pSrcData[(y + nYSrc) * nSrcStep * srcVMultiplier + srcVOffset];
-					BYTE* dstLine = &pDstData[(y + nYDst) * nDstStep * dstVMultiplier + dstVOffset];
-					memcpy(&dstLine[xDstOffset], &srcLine[xSrcOffset], copyDstWidth);
-				}
-			}
-			/* Copy left */
-			else if (nXSrc > nXDst)
-			{
-				for (y = 0; y < (INT32)nHeight; y++)
-				{
-					const BYTE* srcLine =
-					    &pSrcData[(y + nYSrc) * nSrcStep * srcVMultiplier + srcVOffset];
-					BYTE* dstLine = &pDstData[(y + nYDst) * nDstStep * dstVMultiplier + dstVOffset];
-					memmove(&dstLine[xDstOffset], &srcLine[xSrcOffset], copyDstWidth);
-				}
-			}
-			/* Copy right */
-			else if (nXSrc < nXDst)
-			{
-				for (y = (INT32)nHeight - 1; y >= 0; y--)
-				{
-					const BYTE* srcLine =
-					    &pSrcData[(y + nYSrc) * nSrcStep * srcVMultiplier + srcVOffset];
-					BYTE* dstLine = &pDstData[(y + nYDst) * nDstStep * dstVMultiplier + dstVOffset];
-					memmove(&dstLine[xDstOffset], &srcLine[xSrcOffset], copyDstWidth);
-				}
-			}
-			/* Source and destination are equal... */
-			else
-			{
-			}
-		}
-		else
+		/* Copy down */
+		if (nYDst < nYSrc)
 		{
 			for (y = 0; y < (INT32)nHeight; y++)
 			{
@@ -717,12 +775,47 @@ BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32
 				memcpy(&dstLine[xDstOffset], &srcLine[xSrcOffset], copyDstWidth);
 			}
 		}
+		/* Copy up */
+		else if (nYDst > nYSrc)
+		{
+			for (y = nHeight - 1; y >= 0; y--)
+			{
+				const BYTE* srcLine =
+				    &pSrcData[(y + nYSrc) * nSrcStep * srcVMultiplier + srcVOffset];
+				BYTE* dstLine = &pDstData[(y + nYDst) * nDstStep * dstVMultiplier + dstVOffset];
+				memcpy(&dstLine[xDstOffset], &srcLine[xSrcOffset], copyDstWidth);
+			}
+		}
+		/* Copy left */
+		else if (nXSrc > nXDst)
+		{
+			for (y = 0; y < (INT32)nHeight; y++)
+			{
+				const BYTE* srcLine =
+				    &pSrcData[(y + nYSrc) * nSrcStep * srcVMultiplier + srcVOffset];
+				BYTE* dstLine = &pDstData[(y + nYDst) * nDstStep * dstVMultiplier + dstVOffset];
+				memmove(&dstLine[xDstOffset], &srcLine[xSrcOffset], copyDstWidth);
+			}
+		}
+		/* Copy right */
+		else if (nXSrc < nXDst)
+		{
+			for (y = (INT32)nHeight - 1; y >= 0; y--)
+			{
+				const BYTE* srcLine =
+				    &pSrcData[(y + nYSrc) * nSrcStep * srcVMultiplier + srcVOffset];
+				BYTE* dstLine = &pDstData[(y + nYDst) * nDstStep * dstVMultiplier + dstVOffset];
+				memmove(&dstLine[xDstOffset], &srcLine[xSrcOffset], copyDstWidth);
+			}
+		}
+		/* Source and destination are equal... */
+		else
+		{
+		}
 	}
 	else
 	{
-		UINT32 x, y;
-
-		for (y = 0; y < nHeight; y++)
+		for (UINT32 y = 0; y < nHeight; y++)
 		{
 			const BYTE* srcLine = &pSrcData[(y + nYSrc) * nSrcStep * srcVMultiplier + srcVOffset];
 			BYTE* dstLine = &pDstData[(y + nYDst) * nDstStep * dstVMultiplier + dstVOffset];
@@ -731,7 +824,7 @@ BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32
 			UINT32 oldColor = color;
 			UINT32 dstColor = FreeRDPConvertColor(color, SrcFormat, DstFormat, palette);
 			FreeRDPWriteColor(&dstLine[nXDst * dstByte], DstFormat, dstColor);
-			for (x = 1; x < nWidth; x++)
+			for (UINT32 x = 1; x < nWidth; x++)
 			{
 				color = FreeRDPReadColor(&srcLine[(x + nXSrc) * srcByte], SrcFormat);
 				if (color == oldColor)
@@ -751,14 +844,45 @@ BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32
 	return TRUE;
 }
 
-BOOL freerdp_image_fill(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32 nXDst,
-                        UINT32 nYDst, UINT32 nWidth, UINT32 nHeight, UINT32 color)
+BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32 nXDst,
+                        UINT32 nYDst, UINT32 nWidth, UINT32 nHeight, const BYTE* pSrcData,
+                        DWORD SrcFormat, UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc,
+                        const gdiPalette* palette, UINT32 flags)
+{
+	const UINT32 dstByte = FreeRDPGetBytesPerPixel(DstFormat);
+	const UINT32 srcByte = FreeRDPGetBytesPerPixel(SrcFormat);
+
+	if ((nHeight > INT32_MAX) || (nWidth > INT32_MAX))
+		return FALSE;
+
+	if (!pDstData || !pSrcData)
+		return FALSE;
+
+	if (nDstStep == 0)
+		nDstStep = nWidth * FreeRDPGetBytesPerPixel(DstFormat);
+
+	if (nSrcStep == 0)
+		nSrcStep = nWidth * FreeRDPGetBytesPerPixel(SrcFormat);
+
+	const BOOL ovl = overlapping(pDstData, nXDst, nYDst, nDstStep, dstByte, pSrcData, nXSrc, nYSrc,
+	                             nSrcStep, srcByte, nWidth, nHeight);
+	if (ovl)
+		return freerdp_image_copy_overlap(pDstData, DstFormat, nDstStep, nXDst, nYDst, nWidth,
+		                                  nHeight, pSrcData, SrcFormat, nSrcStep, nXSrc, nYSrc,
+		                                  palette, flags);
+	return freerdp_image_copy_no_overlap(pDstData, DstFormat, nDstStep, nXDst, nYDst, nWidth,
+	                                     nHeight, pSrcData, SrcFormat, nSrcStep, nXSrc, nYSrc,
+	                                     palette, flags);
+}
+
+BOOL freerdp_image_fill(BYTE* WINPR_RESTRICT pDstData, DWORD DstFormat, UINT32 nDstStep,
+                        UINT32 nXDst, UINT32 nYDst, UINT32 nWidth, UINT32 nHeight, UINT32 color)
 {
 	if ((nWidth == 0) || (nHeight == 0))
 		return TRUE;
 	const UINT32 bpp = FreeRDPGetBytesPerPixel(DstFormat);
-	BYTE* pFirstDstLine;
-	BYTE* pFirstDstLineXOffset;
+	BYTE* WINPR_RESTRICT pFirstDstLine;
+	BYTE* WINPR_RESTRICT pFirstDstLineXOffset;
 
 	if (nDstStep == 0)
 		nDstStep = (nXDst + nWidth) * FreeRDPGetBytesPerPixel(DstFormat);
@@ -804,10 +928,10 @@ static int av_format_for_buffer(UINT32 format)
 }
 #endif
 
-BOOL freerdp_image_scale(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32 nXDst,
-                         UINT32 nYDst, UINT32 nDstWidth, UINT32 nDstHeight, const BYTE* pSrcData,
-                         DWORD SrcFormat, UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc,
-                         UINT32 nSrcWidth, UINT32 nSrcHeight)
+BOOL freerdp_image_scale(BYTE* WINPR_RESTRICT pDstData, DWORD DstFormat, UINT32 nDstStep,
+                         UINT32 nXDst, UINT32 nYDst, UINT32 nDstWidth, UINT32 nDstHeight,
+                         const BYTE* WINPR_RESTRICT pSrcData, DWORD SrcFormat, UINT32 nSrcStep,
+                         UINT32 nXSrc, UINT32 nYSrc, UINT32 nSrcWidth, UINT32 nSrcHeight)
 {
 	BOOL rc = FALSE;
 
@@ -818,16 +942,18 @@ BOOL freerdp_image_scale(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT3
 		nSrcStep = nSrcWidth * FreeRDPGetBytesPerPixel(SrcFormat);
 
 #if defined(WITH_SWSCALE) || defined(WITH_CAIRO)
-	const BYTE* src = &pSrcData[nXSrc * FreeRDPGetBytesPerPixel(SrcFormat) + nYSrc * nSrcStep];
-	BYTE* dst = &pDstData[nXDst * FreeRDPGetBytesPerPixel(DstFormat) + nYDst * nDstStep];
+	const BYTE* WINPR_RESTRICT src =
+	    &pSrcData[nXSrc * FreeRDPGetBytesPerPixel(SrcFormat) + nYSrc * nSrcStep];
+	BYTE* WINPR_RESTRICT dst =
+	    &pDstData[nXDst * FreeRDPGetBytesPerPixel(DstFormat) + nYDst * nDstStep];
 #endif
 
 	/* direct copy is much faster than scaling, so check if we can simply copy... */
 	if ((nDstWidth == nSrcWidth) && (nDstHeight == nSrcHeight))
 	{
-		return freerdp_image_copy(pDstData, DstFormat, nDstStep, nXDst, nYDst, nDstWidth,
-		                          nDstHeight, pSrcData, SrcFormat, nSrcStep, nXSrc, nYSrc, NULL,
-		                          FREERDP_FLIP_NONE);
+		return freerdp_image_copy_no_overlap(pDstData, DstFormat, nDstStep, nXDst, nYDst, nDstWidth,
+		                                     nDstHeight, pSrcData, SrcFormat, nSrcStep, nXSrc,
+		                                     nYSrc, NULL, FREERDP_FLIP_NONE);
 	}
 	else
 #if defined(WITH_SWSCALE)
@@ -1366,7 +1492,7 @@ void FreeRDPSplitColor(UINT32 color, UINT32 format, BYTE* _r, BYTE* _g, BYTE* _b
 	}
 }
 
-BOOL FreeRDPWriteColorIgnoreAlpha(BYTE* dst, UINT32 format, UINT32 color)
+BOOL FreeRDPWriteColorIgnoreAlpha(BYTE* WINPR_RESTRICT dst, UINT32 format, UINT32 color)
 {
 	switch (format)
 	{
@@ -1391,7 +1517,7 @@ BOOL FreeRDPWriteColorIgnoreAlpha(BYTE* dst, UINT32 format, UINT32 color)
 	}
 }
 
-BOOL FreeRDPWriteColor(BYTE* dst, UINT32 format, UINT32 color)
+BOOL FreeRDPWriteColor(BYTE* WINPR_RESTRICT dst, UINT32 format, UINT32 color)
 {
 	switch (FreeRDPGetBitsPerPixel(format))
 	{
@@ -1433,7 +1559,7 @@ BOOL FreeRDPWriteColor(BYTE* dst, UINT32 format, UINT32 color)
 	return TRUE;
 }
 
-UINT32 FreeRDPReadColor(const BYTE* src, UINT32 format)
+UINT32 FreeRDPReadColor(const BYTE* WINPR_RESTRICT src, UINT32 format)
 {
 	UINT32 color;
 

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -797,13 +797,14 @@ static INLINE size_t progressive_rfx_get_band_h_count(size_t level)
 		return (64 + (1 << (level - 1))) >> level;
 }
 
-static INLINE void progressive_rfx_dwt_2d_decode_block(INT16* buffer, INT16* temp, size_t level)
+static INLINE void progressive_rfx_dwt_2d_decode_block(INT16* WINPR_RESTRICT buffer,
+                                                       INT16* WINPR_RESTRICT temp, size_t level)
 {
 	size_t nDstStepX;
 	size_t nDstStepY;
-	INT16 *HL, *LH;
-	INT16 *HH, *LL;
-	INT16 *L, *H, *LLx;
+	INT16 *WINPR_RESTRICT HL, *WINPR_RESTRICT LH;
+	INT16 *WINPR_RESTRICT HH, *WINPR_RESTRICT LL;
+	INT16 *WINPR_RESTRICT L, *WINPR_RESTRICT H, *WINPR_RESTRICT LLx;
 
 	const size_t nBandL = progressive_rfx_get_band_l_count(level);
 	const size_t nBandH = progressive_rfx_get_band_h_count(level);
@@ -835,7 +836,7 @@ static INLINE void progressive_rfx_dwt_2d_decode_block(INT16* buffer, INT16* tem
 	                       nBandL + nBandH);
 }
 
-void rfx_dwt_2d_extrapolate_decode(INT16* buffer, INT16* temp)
+void rfx_dwt_2d_extrapolate_decode(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT temp)
 {
 	WINPR_ASSERT(buffer);
 	WINPR_ASSERT(temp);

--- a/libfreerdp/codec/rfx_decode.c
+++ b/libfreerdp/codec/rfx_decode.c
@@ -35,8 +35,10 @@
 
 #include "rfx_decode.h"
 
-void rfx_decode_component(RFX_CONTEXT* context, const UINT32* quantization_values, const BYTE* data,
-                          int size, INT16* buffer)
+void rfx_decode_component(RFX_CONTEXT* WINPR_RESTRICT context,
+                          const UINT32* WINPR_RESTRICT quantization_values,
+                          const BYTE* WINPR_RESTRICT data, size_t size,
+                          INT16* WINPR_RESTRICT buffer)
 {
 	INT16* dwt_buffer;
 	dwt_buffer = BufferPool_Take(context->priv->BufferPool, -1); /* dwt_buffer */

--- a/libfreerdp/codec/rfx_decode.h
+++ b/libfreerdp/codec/rfx_decode.h
@@ -20,12 +20,17 @@
 #ifndef FREERDP_LIB_CODEC_RFX_DECODE_H
 #define FREERDP_LIB_CODEC_RFX_DECODE_H
 
+#include <winpr/wtypes.h>
+
 #include <freerdp/codec/rfx.h>
 #include <freerdp/api.h>
 
 /* stride is bytes between rows in the output buffer. */
-FREERDP_LOCAL BOOL rfx_decode_rgb(RFX_CONTEXT* context, const RFX_TILE* tile, BYTE* rgb_buffer,
-                                  UINT32 stride);
-FREERDP_LOCAL void rfx_decode_component(RFX_CONTEXT* context, const UINT32* quantization_values,
-                                        const BYTE* data, int size, INT16* buffer);
+FREERDP_LOCAL BOOL rfx_decode_rgb(RFX_CONTEXT* WINPR_RESTRICT context,
+                                  const RFX_TILE* WINPR_RESTRICT tile,
+                                  BYTE* WINPR_RESTRICT rgb_buffer, UINT32 stride);
+FREERDP_LOCAL void rfx_decode_component(RFX_CONTEXT* WINPR_RESTRICT context,
+                                        const UINT32* WINPR_RESTRICT quantization_values,
+                                        const BYTE* WINPR_RESTRICT data, size_t size,
+                                        INT16* WINPR_RESTRICT buffer);
 #endif /* FREERDP_LIB_CODEC_RFX_DECODE_H */

--- a/libfreerdp/codec/rfx_dwt.c
+++ b/libfreerdp/codec/rfx_dwt.c
@@ -25,11 +25,12 @@
 
 #include "rfx_dwt.h"
 
-static void rfx_dwt_2d_decode_block(INT16* buffer, INT16* idwt, int subband_width)
+static void rfx_dwt_2d_decode_block(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT idwt,
+                                    int subband_width)
 {
-	INT16 *dst, *l, *h;
-	INT16 *l_dst, *h_dst;
-	INT16 *hl, *lh, *hh, *ll;
+	INT16 *WINPR_RESTRICT dst, *WINPR_RESTRICT l, *WINPR_RESTRICT h;
+	INT16 *WINPR_RESTRICT l_dst, *WINPR_RESTRICT h_dst;
+	INT16 *WINPR_RESTRICT hl, *WINPR_RESTRICT lh, *WINPR_RESTRICT hh, *WINPR_RESTRICT ll;
 	int total_width;
 	int x, y;
 	int n;
@@ -109,30 +110,31 @@ static void rfx_dwt_2d_decode_block(INT16* buffer, INT16* idwt, int subband_widt
 	}
 }
 
-void rfx_dwt_2d_decode(INT16* buffer, INT16* dwt_buffer)
+void rfx_dwt_2d_decode(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer)
 {
+	WINPR_ASSERT(buffer);
+	WINPR_ASSERT(dwt_buffer);
+
 	rfx_dwt_2d_decode_block(&buffer[3840], dwt_buffer, 8);
 	rfx_dwt_2d_decode_block(&buffer[3072], dwt_buffer, 16);
 	rfx_dwt_2d_decode_block(&buffer[0], dwt_buffer, 32);
 }
 
-static void rfx_dwt_2d_encode_block(INT16* buffer, INT16* dwt, int subband_width)
+static void rfx_dwt_2d_encode_block(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt,
+                                    UINT32 subband_width)
 {
 	INT16 *src, *l, *h;
 	INT16 *l_src, *h_src;
 	INT16 *hl, *lh, *hh, *ll;
-	int total_width;
-	int x, y;
-	int n;
 
-	total_width = subband_width << 1;
+	const UINT32 total_width = subband_width << 1;
 
 	/* DWT in vertical direction, results in 2 sub-bands in L, H order in tmp buffer dwt. */
-	for (x = 0; x < total_width; x++)
+	for (UINT32 x = 0; x < total_width; x++)
 	{
-		for (n = 0; n < subband_width; n++)
+		for (UINT32 n = 0; n < subband_width; n++)
 		{
-			y = n << 1;
+			UINT32 y = n << 1;
 			l = dwt + n * total_width + x;
 			h = l + subband_width * total_width;
 			src = buffer + y * total_width + x;
@@ -160,12 +162,12 @@ static void rfx_dwt_2d_encode_block(INT16* buffer, INT16* dwt, int subband_width
 	hh = buffer + subband_width * subband_width * 2;
 	h_src = dwt + subband_width * subband_width * 2;
 
-	for (y = 0; y < subband_width; y++)
+	for (UINT32 y = 0; y < subband_width; y++)
 	{
 		/* L */
-		for (n = 0; n < subband_width; n++)
+		for (UINT32 n = 0; n < subband_width; n++)
 		{
-			x = n << 1;
+			UINT32 x = n << 1;
 
 			/* HL */
 			hl[n] =
@@ -175,9 +177,9 @@ static void rfx_dwt_2d_encode_block(INT16* buffer, INT16* dwt, int subband_width
 		}
 
 		/* H */
-		for (n = 0; n < subband_width; n++)
+		for (UINT32 n = 0; n < subband_width; n++)
 		{
-			x = n << 1;
+			UINT32 x = n << 1;
 
 			/* HH */
 			hh[n] =
@@ -196,8 +198,11 @@ static void rfx_dwt_2d_encode_block(INT16* buffer, INT16* dwt, int subband_width
 	}
 }
 
-void rfx_dwt_2d_encode(INT16* buffer, INT16* dwt_buffer)
+void rfx_dwt_2d_encode(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer)
 {
+	WINPR_ASSERT(buffer);
+	WINPR_ASSERT(dwt_buffer);
+
 	rfx_dwt_2d_encode_block(&buffer[0], dwt_buffer, 32);
 	rfx_dwt_2d_encode_block(&buffer[3072], dwt_buffer, 16);
 	rfx_dwt_2d_encode_block(&buffer[3840], dwt_buffer, 8);

--- a/libfreerdp/codec/rfx_dwt.h
+++ b/libfreerdp/codec/rfx_dwt.h
@@ -20,11 +20,15 @@
 #ifndef FREERDP_LIB_CODEC_RFX_DWT_H
 #define FREERDP_LIB_CODEC_RFX_DWT_H
 
+#include <winpr/wtypes.h>
 #include <freerdp/codec/rfx.h>
 #include <freerdp/api.h>
 
-FREERDP_LOCAL void rfx_dwt_2d_decode(INT16* buffer, INT16* dwt_buffer);
-FREERDP_LOCAL void rfx_dwt_2d_encode(INT16* buffer, INT16* dwt_buffer);
-FREERDP_LOCAL void rfx_dwt_2d_extrapolate_decode(INT16* buffer, INT16* dwt_buffer);
+FREERDP_LOCAL void rfx_dwt_2d_decode(INT16* WINPR_RESTRICT buffer,
+                                     INT16* WINPR_RESTRICT dwt_buffer);
+FREERDP_LOCAL void rfx_dwt_2d_encode(INT16* WINPR_RESTRICT buffer,
+                                     INT16* WINPR_RESTRICT dwt_buffer);
+FREERDP_LOCAL void rfx_dwt_2d_extrapolate_decode(INT16* WINPR_RESTRICT buffer,
+                                                 INT16* WINPR_RESTRICT dwt_buffer);
 
 #endif /* FREERDP_LIB_CODEC_RFX_DWT_H */

--- a/libfreerdp/codec/rfx_neon.c
+++ b/libfreerdp/codec/rfx_neon.c
@@ -33,7 +33,8 @@
 /* rfx_decode_YCbCr_to_RGB_NEON code now resides in the primitives library. */
 
 static __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
-rfx_quantization_decode_block_NEON(INT16* buffer, const int buffer_size, const UINT32 factor)
+rfx_quantization_decode_block_NEON(INT16* WINPR_RESTRICT buffer, const int buffer_size,
+                                   const UINT32 factor)
 {
 	int16x8_t quantFactors = vdupq_n_s16(factor);
 	int16x8_t* buf = (int16x8_t*)buffer;
@@ -48,8 +49,12 @@ rfx_quantization_decode_block_NEON(INT16* buffer, const int buffer_size, const U
 	} while (buf < buf_end);
 }
 
-static void rfx_quantization_decode_NEON(INT16* buffer, const UINT32* quantVals)
+static void rfx_quantization_decode_NEON(INT16* WINPR_RESTRICT buffer,
+                                         const UINT32* WINPR_RESTRICT quantVals)
 {
+	WINPR_ASSERT(buffer);
+	WINPR_ASSERT(quantVals);
+
 	rfx_quantization_decode_block_NEON(&buffer[0], 1024, quantVals[8] - 1);    /* HL1 */
 	rfx_quantization_decode_block_NEON(&buffer[1024], 1024, quantVals[7] - 1); /* LH1 */
 	rfx_quantization_decode_block_NEON(&buffer[2048], 1024, quantVals[9] - 1); /* HH1 */
@@ -63,7 +68,8 @@ static void rfx_quantization_decode_NEON(INT16* buffer, const UINT32* quantVals)
 }
 
 static __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
-rfx_dwt_2d_decode_block_horiz_NEON(INT16* l, INT16* h, INT16* dst, int subband_width)
+rfx_dwt_2d_decode_block_horiz_NEON(INT16* WINPR_RESTRICT l, INT16* WINPR_RESTRICT h,
+                                   INT16* WINPR_RESTRICT dst, int subband_width)
 {
 	int y, n;
 	INT16* l_ptr = l;
@@ -126,7 +132,8 @@ rfx_dwt_2d_decode_block_horiz_NEON(INT16* l, INT16* h, INT16* dst, int subband_w
 }
 
 static __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
-rfx_dwt_2d_decode_block_vert_NEON(INT16* l, INT16* h, INT16* dst, int subband_width)
+rfx_dwt_2d_decode_block_vert_NEON(INT16* WINPR_RESTRICT l, INT16* WINPR_RESTRICT h,
+                                  INT16* WINPR_RESTRICT dst, int subband_width)
 {
 	int x, n;
 	INT16* l_ptr = l;
@@ -197,7 +204,8 @@ rfx_dwt_2d_decode_block_vert_NEON(INT16* l, INT16* h, INT16* dst, int subband_wi
 }
 
 static __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
-rfx_dwt_2d_decode_block_NEON(INT16* buffer, INT16* idwt, int subband_width)
+rfx_dwt_2d_decode_block_NEON(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT idwt,
+                             int subband_width)
 {
 	INT16 *hl, *lh, *hh, *ll;
 	INT16 *l_dst, *h_dst;
@@ -218,7 +226,7 @@ rfx_dwt_2d_decode_block_NEON(INT16* buffer, INT16* idwt, int subband_width)
 	rfx_dwt_2d_decode_block_vert_NEON(l_dst, h_dst, buffer, subband_width);
 }
 
-static void rfx_dwt_2d_decode_NEON(INT16* buffer, INT16* dwt_buffer)
+static void rfx_dwt_2d_decode_NEON(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer)
 {
 	rfx_dwt_2d_decode_block_NEON(buffer + 3840, dwt_buffer, 8);
 	rfx_dwt_2d_decode_block_NEON(buffer + 3072, dwt_buffer, 16);
@@ -462,7 +470,8 @@ static INLINE size_t prfx_get_band_h_count(size_t level)
 		return (64 + (1 << (level - 1))) >> level;
 }
 
-static INLINE void rfx_dwt_2d_decode_extrapolate_block_neon(INT16* buffer, INT16* temp,
+static INLINE void rfx_dwt_2d_decode_extrapolate_block_neon(INT16* WINPR_RESTRICT buffer,
+                                                            INT16* WINPR_RESTRICT temp,
                                                             size_t level)
 {
 	size_t nDstStepX;
@@ -504,7 +513,8 @@ static INLINE void rfx_dwt_2d_decode_extrapolate_block_neon(INT16* buffer, INT16
 	                               nBandL + nBandH);
 }
 
-static void rfx_dwt_2d_extrapolate_decode_neon(INT16* buffer, INT16* temp)
+static void rfx_dwt_2d_extrapolate_decode_neon(INT16* WINPR_RESTRICT buffer,
+                                               INT16* WINPR_RESTRICT temp)
 {
 	WINPR_ASSERT(buffer);
 	WINPR_ASSERT(temp);

--- a/libfreerdp/codec/rfx_quantization.c
+++ b/libfreerdp/codec/rfx_quantization.c
@@ -41,7 +41,8 @@
  * LL3		4032		8x8		64
  */
 
-static void rfx_quantization_decode_block(const primitives_t* prims, INT16* buffer, int buffer_size,
+static void rfx_quantization_decode_block(const primitives_t* WINPR_RESTRICT prims,
+                                          INT16* WINPR_RESTRICT buffer, UINT32 buffer_size,
                                           UINT32 factor)
 {
 	if (factor == 0)
@@ -50,9 +51,11 @@ static void rfx_quantization_decode_block(const primitives_t* prims, INT16* buff
 	prims->lShiftC_16s(buffer, factor, buffer, buffer_size);
 }
 
-void rfx_quantization_decode(INT16* buffer, const UINT32* quantVals)
+void rfx_quantization_decode(INT16* WINPR_RESTRICT buffer, const UINT32* WINPR_RESTRICT quantVals)
 {
 	const primitives_t* prims = primitives_get();
+	WINPR_ASSERT(buffer);
+	WINPR_ASSERT(quantVals);
 
 	rfx_quantization_decode_block(prims, &buffer[0], 1024, quantVals[8] - 1);    /* HL1 */
 	rfx_quantization_decode_block(prims, &buffer[1024], 1024, quantVals[7] - 1); /* LH1 */
@@ -66,7 +69,8 @@ void rfx_quantization_decode(INT16* buffer, const UINT32* quantVals)
 	rfx_quantization_decode_block(prims, &buffer[4032], 64, quantVals[0] - 1);   /* LL3 */
 }
 
-static void rfx_quantization_encode_block(INT16* buffer, int buffer_size, UINT32 factor)
+static void rfx_quantization_encode_block(INT16* WINPR_RESTRICT buffer, size_t buffer_size,
+                                          UINT32 factor)
 {
 	INT16* dst;
 	INT16 half;
@@ -82,8 +86,12 @@ static void rfx_quantization_encode_block(INT16* buffer, int buffer_size, UINT32
 	}
 }
 
-void rfx_quantization_encode(INT16* buffer, const UINT32* quantization_values)
+void rfx_quantization_encode(INT16* WINPR_RESTRICT buffer,
+                             const UINT32* WINPR_RESTRICT quantization_values)
 {
+	WINPR_ASSERT(buffer);
+	WINPR_ASSERT(quantization_values);
+
 	rfx_quantization_encode_block(buffer, 1024, quantization_values[8] - 6);        /* HL1 */
 	rfx_quantization_encode_block(buffer + 1024, 1024, quantization_values[7] - 6); /* LH1 */
 	rfx_quantization_encode_block(buffer + 2048, 1024, quantization_values[9] - 6); /* HH1 */

--- a/libfreerdp/codec/rfx_rlgr.c
+++ b/libfreerdp/codec/rfx_rlgr.c
@@ -135,8 +135,8 @@ static INLINE UINT32 lzcnt_s(UINT32 x)
 	return __lzcnt(x);
 }
 
-int rfx_rlgr_decode(RLGR_MODE mode, const BYTE* pSrcData, UINT32 SrcSize, INT16* pDstData,
-                    UINT32 rDstSize)
+int rfx_rlgr_decode(RLGR_MODE mode, const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
+                    INT16* WINPR_RESTRICT pDstData, UINT32 rDstSize)
 {
 	int vk = 0;
 	size_t run = 0;
@@ -629,8 +629,8 @@ static void rfx_rlgr_code_gr(RFX_BITSTREAM* bs, int* krp, UINT32 val)
 	}
 }
 
-int rfx_rlgr_encode(RLGR_MODE mode, const INT16* data, UINT32 data_size, BYTE* buffer,
-                    UINT32 buffer_size)
+int rfx_rlgr_encode(RLGR_MODE mode, const INT16* WINPR_RESTRICT data, UINT32 data_size,
+                    BYTE* WINPR_RESTRICT buffer, UINT32 buffer_size)
 {
 	int k;
 	int kp;

--- a/libfreerdp/codec/rfx_sse2.c
+++ b/libfreerdp/codec/rfx_sse2.c
@@ -82,8 +82,12 @@ rfx_quantization_decode_block_sse2(INT16* buffer, const int buffer_size, const U
 	} while (ptr < buf_end);
 }
 
-static void rfx_quantization_decode_sse2(INT16* buffer, const UINT32* quantVals)
+static void rfx_quantization_decode_sse2(INT16* WINPR_RESTRICT buffer,
+                                         const UINT32* WINPR_RESTRICT quantVals)
 {
+	WINPR_ASSERT(buffer);
+	WINPR_ASSERT(quantVals);
+
 	_mm_prefetch_buffer((char*)buffer, 4096 * sizeof(INT16));
 	rfx_quantization_decode_block_sse2(&buffer[0], 1024, quantVals[8] - 1);    /* HL1 */
 	rfx_quantization_decode_block_sse2(&buffer[1024], 1024, quantVals[7] - 1); /* LH1 */
@@ -120,8 +124,12 @@ rfx_quantization_encode_block_sse2(INT16* buffer, const int buffer_size, const U
 	} while (ptr < buf_end);
 }
 
-static void rfx_quantization_encode_sse2(INT16* buffer, const UINT32* quantization_values)
+static void rfx_quantization_encode_sse2(INT16* WINPR_RESTRICT buffer,
+                                         const UINT32* WINPR_RESTRICT quantization_values)
 {
+	WINPR_ASSERT(buffer);
+	WINPR_ASSERT(quantization_values);
+
 	_mm_prefetch_buffer((char*)buffer, 4096 * sizeof(INT16));
 	rfx_quantization_encode_block_sse2(buffer, 1024, quantization_values[8] - 6);        /* HL1 */
 	rfx_quantization_encode_block_sse2(buffer + 1024, 1024, quantization_values[7] - 6); /* LH1 */
@@ -312,8 +320,11 @@ rfx_dwt_2d_decode_block_sse2(INT16* buffer, INT16* idwt, int subband_width)
 	rfx_dwt_2d_decode_block_vert_sse2(l_dst, h_dst, buffer, subband_width);
 }
 
-static void rfx_dwt_2d_decode_sse2(INT16* buffer, INT16* dwt_buffer)
+static void rfx_dwt_2d_decode_sse2(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer)
 {
+	WINPR_ASSERT(buffer);
+	WINPR_ASSERT(dwt_buffer);
+
 	_mm_prefetch_buffer((char*)buffer, 4096 * sizeof(INT16));
 	rfx_dwt_2d_decode_block_sse2(&buffer[3840], dwt_buffer, 8);
 	rfx_dwt_2d_decode_block_sse2(&buffer[3072], dwt_buffer, 16);
@@ -445,8 +456,11 @@ rfx_dwt_2d_encode_block_sse2(INT16* buffer, INT16* dwt, int subband_width)
 	rfx_dwt_2d_encode_block_horiz_sse2(h_src, lh, hh, subband_width);
 }
 
-static void rfx_dwt_2d_encode_sse2(INT16* buffer, INT16* dwt_buffer)
+static void rfx_dwt_2d_encode_sse2(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer)
 {
+	WINPR_ASSERT(buffer);
+	WINPR_ASSERT(dwt_buffer);
+
 	_mm_prefetch_buffer((char*)buffer, 4096 * sizeof(INT16));
 	rfx_dwt_2d_encode_block_sse2(buffer, dwt_buffer, 32);
 	rfx_dwt_2d_encode_block_sse2(buffer + 3072, dwt_buffer, 16);

--- a/libfreerdp/codec/rfx_types.h
+++ b/libfreerdp/codec/rfx_types.h
@@ -165,15 +165,17 @@ struct S_RFX_CONTEXT
 	struct S_RFX_MESSAGE currentMessage;
 
 	/* routines */
-	void (*quantization_decode)(INT16* buffer, const UINT32* quantization_values);
-	void (*quantization_encode)(INT16* buffer, const UINT32* quantization_values);
-	void (*dwt_2d_decode)(INT16* buffer, INT16* dwt_buffer);
-	void (*dwt_2d_extrapolate_decode)(INT16* src, INT16* temp);
-	void (*dwt_2d_encode)(INT16* buffer, INT16* dwt_buffer);
-	int (*rlgr_decode)(RLGR_MODE mode, const BYTE* data, UINT32 data_size, INT16* buffer,
-	                   UINT32 buffer_size);
-	int (*rlgr_encode)(RLGR_MODE mode, const INT16* data, UINT32 data_size, BYTE* buffer,
-	                   UINT32 buffer_size);
+	void (*quantization_decode)(INT16* WINPR_RESTRICT buffer,
+	                            const UINT32* WINPR_RESTRICT quantization_values);
+	void (*quantization_encode)(INT16* WINPR_RESTRICT buffer,
+	                            const UINT32* WINPR_RESTRICT quantization_values);
+	void (*dwt_2d_decode)(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer);
+	void (*dwt_2d_extrapolate_decode)(INT16* WINPR_RESTRICT src, INT16* WINPR_RESTRICT temp);
+	void (*dwt_2d_encode)(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer);
+	int (*rlgr_decode)(RLGR_MODE mode, const BYTE* WINPR_RESTRICT data, UINT32 data_size,
+	                   INT16* WINPR_RESTRICT buffer, UINT32 buffer_size);
+	int (*rlgr_encode)(RLGR_MODE mode, const INT16* WINPR_RESTRICT data, UINT32 data_size,
+	                   BYTE* WINPR_RESTRICT buffer, UINT32 buffer_size);
 
 	/* private definitions */
 	RFX_CONTEXT_PRIV* priv;

--- a/libfreerdp/primitives/prim_YCoCg_opt.c
+++ b/libfreerdp/primitives/prim_YCoCg_opt.c
@@ -37,9 +37,10 @@ static primitives_t* generic = NULL;
 
 #ifdef WITH_SSE2
 /* ------------------------------------------------------------------------- */
-static pstatus_t ssse3_YCoCgRToRGB_8u_AC4R_invert(const BYTE* pSrc, UINT32 srcStep, BYTE* pDst,
-                                                  UINT32 DstFormat, UINT32 dstStep, UINT32 width,
-                                                  UINT32 height, UINT8 shift, BOOL withAlpha)
+static pstatus_t ssse3_YCoCgRToRGB_8u_AC4R_invert(const BYTE* WINPR_RESTRICT pSrc, UINT32 srcStep,
+                                                  BYTE* WINPR_RESTRICT pDst, UINT32 DstFormat,
+                                                  UINT32 dstStep, UINT32 width, UINT32 height,
+                                                  UINT8 shift, BOOL withAlpha)
 {
 	const BYTE* sptr = pSrc;
 	BYTE* dptr = (BYTE*)pDst;
@@ -216,7 +217,8 @@ static pstatus_t ssse3_YCoCgRToRGB_8u_AC4R_invert(const BYTE* pSrc, UINT32 srcSt
 }
 
 /* ------------------------------------------------------------------------- */
-static pstatus_t ssse3_YCoCgRToRGB_8u_AC4R_no_invert(const BYTE* pSrc, UINT32 srcStep, BYTE* pDst,
+static pstatus_t ssse3_YCoCgRToRGB_8u_AC4R_no_invert(const BYTE* WINPR_RESTRICT pSrc,
+                                                     UINT32 srcStep, BYTE* WINPR_RESTRICT pDst,
                                                      UINT32 DstFormat, UINT32 dstStep, UINT32 width,
                                                      UINT32 height, UINT8 shift, BOOL withAlpha)
 {
@@ -401,9 +403,10 @@ static pstatus_t ssse3_YCoCgRToRGB_8u_AC4R_no_invert(const BYTE* pSrc, UINT32 sr
 
 #ifdef WITH_SSE2
 /* ------------------------------------------------------------------------- */
-static pstatus_t ssse3_YCoCgRToRGB_8u_AC4R(const BYTE* pSrc, INT32 srcStep, BYTE* pDst,
-                                           UINT32 DstFormat, INT32 dstStep, UINT32 width,
-                                           UINT32 height, UINT8 shift, BOOL withAlpha)
+static pstatus_t ssse3_YCoCgRToRGB_8u_AC4R(const BYTE* WINPR_RESTRICT pSrc, INT32 srcStep,
+                                           BYTE* WINPR_RESTRICT pDst, UINT32 DstFormat,
+                                           INT32 dstStep, UINT32 width, UINT32 height, UINT8 shift,
+                                           BOOL withAlpha)
 {
 	switch (DstFormat)
 	{
@@ -424,9 +427,10 @@ static pstatus_t ssse3_YCoCgRToRGB_8u_AC4R(const BYTE* pSrc, INT32 srcStep, BYTE
 }
 #elif defined(WITH_NEON)
 
-static pstatus_t neon_YCoCgToRGB_8u_X(const BYTE* pSrc, INT32 srcStep, BYTE* pDst, UINT32 DstFormat,
-                                      INT32 dstStep, UINT32 width, UINT32 height, UINT8 shift,
-                                      BYTE bPos, BYTE gPos, BYTE rPos, BYTE aPos, BOOL alpha)
+static pstatus_t neon_YCoCgToRGB_8u_X(const BYTE* WINPR_RESTRICT pSrc, INT32 srcStep,
+                                      BYTE* WINPR_RESTRICT pDst, UINT32 DstFormat, INT32 dstStep,
+                                      UINT32 width, UINT32 height, UINT8 shift, BYTE bPos,
+                                      BYTE gPos, BYTE rPos, BYTE aPos, BOOL alpha)
 {
 	UINT32 y;
 	BYTE* dptr = pDst;
@@ -502,9 +506,10 @@ static pstatus_t neon_YCoCgToRGB_8u_X(const BYTE* pSrc, INT32 srcStep, BYTE* pDs
 
 	return PRIMITIVES_SUCCESS;
 }
-static pstatus_t neon_YCoCgToRGB_8u_AC4R(const BYTE* pSrc, INT32 srcStep, BYTE* pDst,
-                                         UINT32 DstFormat, INT32 dstStep, UINT32 width,
-                                         UINT32 height, UINT8 shift, BOOL withAlpha)
+
+static pstatus_t neon_YCoCgToRGB_8u_AC4R(const BYTE* WINPR_RESTRICT pSrc, INT32 srcStep,
+                                         BYTE* WINPR_RESTRICT pDst, UINT32 DstFormat, INT32 dstStep,
+                                         UINT32 width, UINT32 height, UINT8 shift, BOOL withAlpha)
 {
 	switch (DstFormat)
 	{
@@ -548,7 +553,7 @@ static pstatus_t neon_YCoCgToRGB_8u_AC4R(const BYTE* pSrc, INT32 srcStep, BYTE* 
 #endif /* WITH_SSE2 */
 
 /* ------------------------------------------------------------------------- */
-void primitives_init_YCoCg_opt(primitives_t* prims)
+void primitives_init_YCoCg_opt(primitives_t* WINPR_RESTRICT prims)
 {
 	generic = primitives_get_generic();
 	primitives_init_YCoCg(prims);

--- a/libfreerdp/primitives/prim_YUV.c
+++ b/libfreerdp/primitives/prim_YUV.c
@@ -21,6 +21,8 @@
  * limitations under the License.
  */
 
+#include <winpr/wtypes.h>
+
 #include <freerdp/config.h>
 
 #include <freerdp/types.h>
@@ -28,9 +30,10 @@
 #include <freerdp/codec/color.h>
 #include "prim_internal.h"
 
-static pstatus_t general_LumaToYUV444(const BYTE* const pSrcRaw[3], const UINT32 srcStep[3],
-                                      BYTE* pDstRaw[3], const UINT32 dstStep[3],
-                                      const RECTANGLE_16* roi)
+static pstatus_t general_LumaToYUV444(const BYTE* const WINPR_RESTRICT pSrcRaw[3],
+                                      const UINT32 srcStep[3], BYTE* WINPR_RESTRICT pDstRaw[3],
+                                      const UINT32 dstStep[3],
+                                      const RECTANGLE_16* WINPR_RESTRICT roi)
 {
 	const UINT32 nWidth = roi->right - roi->left;
 	const UINT32 nHeight = roi->bottom - roi->top;
@@ -87,8 +90,8 @@ static pstatus_t general_LumaToYUV444(const BYTE* const pSrcRaw[3], const UINT32
 	return PRIMITIVES_SUCCESS;
 }
 
-static pstatus_t general_ChromaFilter(BYTE* pDst[3], const UINT32 dstStep[3],
-                                      const RECTANGLE_16* roi)
+static pstatus_t general_ChromaFilter(BYTE* WINPR_RESTRICT pDst[3], const UINT32 dstStep[3],
+                                      const RECTANGLE_16* WINPR_RESTRICT roi)
 {
 	const UINT32 oddY = 1;
 	const UINT32 evenY = 0;
@@ -136,9 +139,10 @@ static pstatus_t general_ChromaFilter(BYTE* pDst[3], const UINT32 dstStep[3],
 	return PRIMITIVES_SUCCESS;
 }
 
-static pstatus_t general_ChromaV1ToYUV444(const BYTE* const pSrcRaw[3], const UINT32 srcStep[3],
-                                          BYTE* pDstRaw[3], const UINT32 dstStep[3],
-                                          const RECTANGLE_16* roi)
+static pstatus_t general_ChromaV1ToYUV444(const BYTE* const WINPR_RESTRICT pSrcRaw[3],
+                                          const UINT32 srcStep[3], BYTE* WINPR_RESTRICT pDstRaw[3],
+                                          const UINT32 dstStep[3],
+                                          const RECTANGLE_16* WINPR_RESTRICT roi)
 {
 	const UINT32 mod = 16;
 	UINT32 uY = 0;
@@ -211,9 +215,11 @@ static pstatus_t general_ChromaV1ToYUV444(const BYTE* const pSrcRaw[3], const UI
 	return general_ChromaFilter(pDst, dstStep, roi);
 }
 
-static pstatus_t general_ChromaV2ToYUV444(const BYTE* const pSrc[3], const UINT32 srcStep[3],
-                                          UINT32 nTotalWidth, UINT32 nTotalHeight, BYTE* pDst[3],
-                                          const UINT32 dstStep[3], const RECTANGLE_16* roi)
+static pstatus_t general_ChromaV2ToYUV444(const BYTE* const WINPR_RESTRICT pSrc[3],
+                                          const UINT32 srcStep[3], UINT32 nTotalWidth,
+                                          UINT32 nTotalHeight, BYTE* WINPR_RESTRICT pDst[3],
+                                          const UINT32 dstStep[3],
+                                          const RECTANGLE_16* WINPR_RESTRICT roi)
 {
 	UINT32 x, y;
 	const UINT32 nWidth = roi->right - roi->left;
@@ -261,10 +267,12 @@ static pstatus_t general_ChromaV2ToYUV444(const BYTE* const pSrc[3], const UINT3
 	return general_ChromaFilter(pDst, dstStep, roi);
 }
 
-static pstatus_t general_YUV420CombineToYUV444(avc444_frame_type type, const BYTE* const pSrc[3],
+static pstatus_t general_YUV420CombineToYUV444(avc444_frame_type type,
+                                               const BYTE* const WINPR_RESTRICT pSrc[3],
                                                const UINT32 srcStep[3], UINT32 nWidth,
-                                               UINT32 nHeight, BYTE* pDst[3],
-                                               const UINT32 dstStep[3], const RECTANGLE_16* roi)
+                                               UINT32 nHeight, BYTE* WINPR_RESTRICT pDst[3],
+                                               const UINT32 dstStep[3],
+                                               const RECTANGLE_16* WINPR_RESTRICT roi)
 {
 	if (!pSrc || !pSrc[0] || !pSrc[1] || !pSrc[2])
 		return -1;
@@ -291,10 +299,11 @@ static pstatus_t general_YUV420CombineToYUV444(avc444_frame_type type, const BYT
 	}
 }
 
-static pstatus_t general_YUV444SplitToYUV420(const BYTE* const pSrc[3], const UINT32 srcStep[3],
-                                             BYTE* pMainDst[3], const UINT32 dstMainStep[3],
-                                             BYTE* pAuxDst[3], const UINT32 dstAuxStep[3],
-                                             const prim_size_t* roi)
+static pstatus_t
+general_YUV444SplitToYUV420(const BYTE* const WINPR_RESTRICT pSrc[3], const UINT32 srcStep[3],
+                            BYTE* WINPR_RESTRICT pMainDst[3], const UINT32 dstMainStep[3],
+                            BYTE* WINPR_RESTRICT pAuxDst[3], const UINT32 dstAuxStep[3],
+                            const prim_size_t* WINPR_RESTRICT roi)
 {
 	UINT32 x, y, uY = 0, vY = 0;
 	UINT32 halfWidth, halfHeight;
@@ -377,10 +386,11 @@ static pstatus_t general_YUV444SplitToYUV420(const BYTE* const pSrc[3], const UI
 	return PRIMITIVES_SUCCESS;
 }
 
-static pstatus_t general_YUV444ToRGB_8u_P3AC4R_general(const BYTE* const pSrc[3],
-                                                       const UINT32 srcStep[3], BYTE* pDst,
-                                                       UINT32 dstStep, UINT32 DstFormat,
-                                                       const prim_size_t* roi)
+static pstatus_t general_YUV444ToRGB_8u_P3AC4R_general(const BYTE* const WINPR_RESTRICT pSrc[3],
+                                                       const UINT32 srcStep[3],
+                                                       BYTE* WINPR_RESTRICT pDst, UINT32 dstStep,
+                                                       UINT32 DstFormat,
+                                                       const prim_size_t* WINPR_RESTRICT roi)
 {
 	UINT32 x, y;
 	UINT32 nWidth, nHeight;
@@ -411,25 +421,24 @@ static pstatus_t general_YUV444ToRGB_8u_P3AC4R_general(const BYTE* const pSrc[3]
 	return PRIMITIVES_SUCCESS;
 }
 
-static pstatus_t general_YUV444ToRGB_8u_P3AC4R_BGRX(const BYTE* const pSrc[3],
-                                                    const UINT32 srcStep[3], BYTE* pDst,
-                                                    UINT32 dstStep, UINT32 DstFormat,
-                                                    const prim_size_t* roi)
+static pstatus_t general_YUV444ToRGB_8u_P3AC4R_BGRX(const BYTE* const WINPR_RESTRICT pSrc[3],
+                                                    const UINT32 srcStep[3],
+                                                    BYTE* WINPR_RESTRICT pDst, UINT32 dstStep,
+                                                    UINT32 DstFormat,
+                                                    const prim_size_t* WINPR_RESTRICT roi)
 {
-	UINT32 x, y;
-	UINT32 nWidth, nHeight;
 	const DWORD formatSize = FreeRDPGetBytesPerPixel(DstFormat);
-	nWidth = roi->width;
-	nHeight = roi->height;
+	const UINT32 nWidth = roi->width;
+	const UINT32 nHeight = roi->height;
 
-	for (y = 0; y < nHeight; y++)
+	for (UINT32 y = 0; y < nHeight; y++)
 	{
 		const BYTE* pY = pSrc[0] + y * srcStep[0];
 		const BYTE* pU = pSrc[1] + y * srcStep[1];
 		const BYTE* pV = pSrc[2] + y * srcStep[2];
 		BYTE* pRGB = pDst + y * dstStep;
 
-		for (x = 0; x < nWidth; x++)
+		for (UINT32 x = 0; x < nWidth; x++)
 		{
 			const BYTE Y = pY[x];
 			const BYTE U = pU[x];
@@ -444,9 +453,10 @@ static pstatus_t general_YUV444ToRGB_8u_P3AC4R_BGRX(const BYTE* const pSrc[3],
 	return PRIMITIVES_SUCCESS;
 }
 
-static pstatus_t general_YUV444ToRGB_8u_P3AC4R(const BYTE* const pSrc[3], const UINT32 srcStep[3],
-                                               BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
-                                               const prim_size_t* roi)
+static pstatus_t general_YUV444ToRGB_8u_P3AC4R(const BYTE* const WINPR_RESTRICT pSrc[3],
+                                               const UINT32 srcStep[3], BYTE* WINPR_RESTRICT pDst,
+                                               UINT32 dstStep, UINT32 DstFormat,
+                                               const prim_size_t* WINPR_RESTRICT roi)
 {
 	switch (DstFormat)
 	{
@@ -464,9 +474,10 @@ static pstatus_t general_YUV444ToRGB_8u_P3AC4R(const BYTE* const pSrc[3], const 
  * | G | = ( | 256   -48   -120 | | U - 128 | ) >> 8
  * | B |   ( | 256   475      0 | | V - 128 | )
  */
-static pstatus_t general_YUV420ToRGB_8u_P3AC4R(const BYTE* const pSrc[3], const UINT32 srcStep[3],
-                                               BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
-                                               const prim_size_t* roi)
+static pstatus_t general_YUV420ToRGB_8u_P3AC4R(const BYTE* const WINPR_RESTRICT pSrc[3],
+                                               const UINT32 srcStep[3], BYTE* WINPR_RESTRICT pDst,
+                                               UINT32 dstStep, UINT32 DstFormat,
+                                               const prim_size_t* WINPR_RESTRICT roi)
 {
 	UINT32 x, y;
 	UINT32 dstPad;
@@ -608,9 +619,10 @@ static INLINE BYTE RGB2V(INT32 R, INT32 G, INT32 B)
 	return ((128 * R - 116 * G - 12 * B) >> 8) + 128;
 }
 
-static pstatus_t general_RGBToYUV444_8u_P3AC4R(const BYTE* pSrc, UINT32 SrcFormat,
-                                               const UINT32 srcStep, BYTE* pDst[3],
-                                               UINT32 dstStep[3], const prim_size_t* roi)
+static pstatus_t general_RGBToYUV444_8u_P3AC4R(const BYTE* WINPR_RESTRICT pSrc, UINT32 SrcFormat,
+                                               const UINT32 srcStep, BYTE* WINPR_RESTRICT pDst[3],
+                                               UINT32 dstStep[3],
+                                               const prim_size_t* WINPR_RESTRICT roi)
 {
 	const UINT32 bpp = FreeRDPGetBytesPerPixel(SrcFormat);
 	UINT32 x, y;
@@ -639,8 +651,10 @@ static pstatus_t general_RGBToYUV444_8u_P3AC4R(const BYTE* pSrc, UINT32 SrcForma
 	return PRIMITIVES_SUCCESS;
 }
 
-static INLINE pstatus_t general_RGBToYUV420_BGRX(const BYTE* pSrc, UINT32 srcStep, BYTE* pDst[3],
-                                                 const UINT32 dstStep[3], const prim_size_t* roi)
+static INLINE pstatus_t general_RGBToYUV420_BGRX(const BYTE* WINPR_RESTRICT pSrc, UINT32 srcStep,
+                                                 BYTE* WINPR_RESTRICT pDst[3],
+                                                 const UINT32 dstStep[3],
+                                                 const prim_size_t* WINPR_RESTRICT roi)
 {
 	UINT32 x, y, i;
 	size_t x1 = 0, x2 = 4, x3 = srcStep, x4 = srcStep + 4;
@@ -705,8 +719,10 @@ static INLINE pstatus_t general_RGBToYUV420_BGRX(const BYTE* pSrc, UINT32 srcSte
 	return PRIMITIVES_SUCCESS;
 }
 
-static INLINE pstatus_t general_RGBToYUV420_RGBX(const BYTE* pSrc, UINT32 srcStep, BYTE* pDst[3],
-                                                 const UINT32 dstStep[3], const prim_size_t* roi)
+static INLINE pstatus_t general_RGBToYUV420_RGBX(const BYTE* WINPR_RESTRICT pSrc, UINT32 srcStep,
+                                                 BYTE* WINPR_RESTRICT pDst[3],
+                                                 const UINT32 dstStep[3],
+                                                 const prim_size_t* WINPR_RESTRICT roi)
 {
 	UINT32 x, y, i;
 	size_t x1 = 0, x2 = 4, x3 = srcStep, x4 = srcStep + 4;
@@ -771,9 +787,10 @@ static INLINE pstatus_t general_RGBToYUV420_RGBX(const BYTE* pSrc, UINT32 srcSte
 	return PRIMITIVES_SUCCESS;
 }
 
-static INLINE pstatus_t general_RGBToYUV420_ANY(const BYTE* pSrc, UINT32 srcFormat, UINT32 srcStep,
-                                                BYTE* pDst[3], const UINT32 dstStep[3],
-                                                const prim_size_t* roi)
+static INLINE pstatus_t general_RGBToYUV420_ANY(const BYTE* WINPR_RESTRICT pSrc, UINT32 srcFormat,
+                                                UINT32 srcStep, BYTE* WINPR_RESTRICT pDst[3],
+                                                const UINT32 dstStep[3],
+                                                const prim_size_t* WINPR_RESTRICT roi)
 {
 	const UINT32 bpp = FreeRDPGetBytesPerPixel(srcFormat);
 	UINT32 x, y, i;
@@ -848,9 +865,10 @@ static INLINE pstatus_t general_RGBToYUV420_ANY(const BYTE* pSrc, UINT32 srcForm
 	return PRIMITIVES_SUCCESS;
 }
 
-static pstatus_t general_RGBToYUV420_8u_P3AC4R(const BYTE* pSrc, UINT32 srcFormat, UINT32 srcStep,
-                                               BYTE* pDst[3], const UINT32 dstStep[3],
-                                               const prim_size_t* roi)
+static pstatus_t general_RGBToYUV420_8u_P3AC4R(const BYTE* WINPR_RESTRICT pSrc, UINT32 srcFormat,
+                                               UINT32 srcStep, BYTE* WINPR_RESTRICT pDst[3],
+                                               const UINT32 dstStep[3],
+                                               const prim_size_t* WINPR_RESTRICT roi)
 {
 	switch (srcFormat)
 	{
@@ -867,14 +885,13 @@ static pstatus_t general_RGBToYUV420_8u_P3AC4R(const BYTE* pSrc, UINT32 srcForma
 	}
 }
 
-static INLINE void general_RGBToAVC444YUV_BGRX_DOUBLE_ROW(const BYTE* srcEven, const BYTE* srcOdd,
-                                                          BYTE* b1Even, BYTE* b1Odd, BYTE* b2,
-                                                          BYTE* b3, BYTE* b4, BYTE* b5, BYTE* b6,
-                                                          BYTE* b7, UINT32 width)
+static INLINE void general_RGBToAVC444YUV_BGRX_DOUBLE_ROW(
+    const BYTE* WINPR_RESTRICT srcEven, const BYTE* WINPR_RESTRICT srcOdd,
+    BYTE* WINPR_RESTRICT b1Even, BYTE* WINPR_RESTRICT b1Odd, BYTE* WINPR_RESTRICT b2,
+    BYTE* WINPR_RESTRICT b3, BYTE* WINPR_RESTRICT b4, BYTE* WINPR_RESTRICT b5,
+    BYTE* WINPR_RESTRICT b6, BYTE* WINPR_RESTRICT b7, UINT32 width)
 {
-	UINT32 x;
-
-	for (x = 0; x < width; x += 2)
+	for (UINT32 x = 0; x < width; x += 2)
 	{
 		const BOOL lastX = (x + 1) >= width;
 		BYTE Y1e, Y2e, U1e, V1e, U2e, V2e;
@@ -964,10 +981,12 @@ static INLINE void general_RGBToAVC444YUV_BGRX_DOUBLE_ROW(const BYTE* srcEven, c
 	}
 }
 
-static INLINE pstatus_t general_RGBToAVC444YUV_BGRX(const BYTE* pSrc, UINT32 srcStep,
-                                                    BYTE* pDst1[3], const UINT32 dst1Step[3],
-                                                    BYTE* pDst2[3], const UINT32 dst2Step[3],
-                                                    const prim_size_t* roi)
+static INLINE pstatus_t general_RGBToAVC444YUV_BGRX(const BYTE* WINPR_RESTRICT pSrc, UINT32 srcStep,
+                                                    BYTE* WINPR_RESTRICT pDst1[3],
+                                                    const UINT32 dst1Step[3],
+                                                    BYTE* WINPR_RESTRICT pDst2[3],
+                                                    const UINT32 dst2Step[3],
+                                                    const prim_size_t* WINPR_RESTRICT roi)
 {
 	/**
 	 * Note:
@@ -998,14 +1017,13 @@ static INLINE pstatus_t general_RGBToAVC444YUV_BGRX(const BYTE* pSrc, UINT32 src
 	return PRIMITIVES_SUCCESS;
 }
 
-static INLINE void general_RGBToAVC444YUV_RGBX_DOUBLE_ROW(const BYTE* srcEven, const BYTE* srcOdd,
-                                                          BYTE* b1Even, BYTE* b1Odd, BYTE* b2,
-                                                          BYTE* b3, BYTE* b4, BYTE* b5, BYTE* b6,
-                                                          BYTE* b7, UINT32 width)
+static INLINE void general_RGBToAVC444YUV_RGBX_DOUBLE_ROW(
+    const BYTE* WINPR_RESTRICT srcEven, const BYTE* WINPR_RESTRICT srcOdd,
+    BYTE* WINPR_RESTRICT b1Even, BYTE* WINPR_RESTRICT b1Odd, BYTE* WINPR_RESTRICT b2,
+    BYTE* WINPR_RESTRICT b3, BYTE* WINPR_RESTRICT b4, BYTE* WINPR_RESTRICT b5,
+    BYTE* WINPR_RESTRICT b6, BYTE* WINPR_RESTRICT b7, UINT32 width)
 {
-	UINT32 x;
-
-	for (x = 0; x < width; x += 2)
+	for (UINT32 x = 0; x < width; x += 2)
 	{
 		const BOOL lastX = (x + 1) >= width;
 		BYTE Y1e, Y2e, U1e, V1e, U2e, V2e;
@@ -1095,19 +1113,20 @@ static INLINE void general_RGBToAVC444YUV_RGBX_DOUBLE_ROW(const BYTE* srcEven, c
 	}
 }
 
-static INLINE pstatus_t general_RGBToAVC444YUV_RGBX(const BYTE* pSrc, UINT32 srcStep,
-                                                    BYTE* pDst1[3], const UINT32 dst1Step[3],
-                                                    BYTE* pDst2[3], const UINT32 dst2Step[3],
-                                                    const prim_size_t* roi)
+static INLINE pstatus_t general_RGBToAVC444YUV_RGBX(const BYTE* WINPR_RESTRICT pSrc, UINT32 srcStep,
+                                                    BYTE* WINPR_RESTRICT pDst1[3],
+                                                    const UINT32 dst1Step[3],
+                                                    BYTE* WINPR_RESTRICT pDst2[3],
+                                                    const UINT32 dst2Step[3],
+                                                    const prim_size_t* WINPR_RESTRICT roi)
 {
 	/**
 	 * Note:
 	 * Read information in function general_RGBToAVC444YUV_ANY below !
 	 */
-	UINT32 y;
 	const BYTE* pMaxSrc = pSrc + (roi->height - 1) * srcStep;
 
-	for (y = 0; y < roi->height; y += 2)
+	for (UINT32 y = 0; y < roi->height; y += 2)
 	{
 		const BOOL last = (y >= (roi->height - 1));
 		const BYTE* srcEven = y < roi->height ? pSrc + y * srcStep : pMaxSrc;
@@ -1129,15 +1148,14 @@ static INLINE pstatus_t general_RGBToAVC444YUV_RGBX(const BYTE* pSrc, UINT32 src
 	return PRIMITIVES_SUCCESS;
 }
 
-static INLINE void general_RGBToAVC444YUV_ANY_DOUBLE_ROW(const BYTE* srcEven, const BYTE* srcOdd,
-                                                         UINT32 srcFormat, BYTE* b1Even,
-                                                         BYTE* b1Odd, BYTE* b2, BYTE* b3, BYTE* b4,
-                                                         BYTE* b5, BYTE* b6, BYTE* b7, UINT32 width)
+static INLINE void general_RGBToAVC444YUV_ANY_DOUBLE_ROW(
+    const BYTE* WINPR_RESTRICT srcEven, const BYTE* WINPR_RESTRICT srcOdd, UINT32 srcFormat,
+    BYTE* WINPR_RESTRICT b1Even, BYTE* WINPR_RESTRICT b1Odd, BYTE* WINPR_RESTRICT b2,
+    BYTE* WINPR_RESTRICT b3, BYTE* WINPR_RESTRICT b4, BYTE* WINPR_RESTRICT b5,
+    BYTE* WINPR_RESTRICT b6, BYTE* WINPR_RESTRICT b7, UINT32 width)
 {
 	const UINT32 bpp = FreeRDPGetBytesPerPixel(srcFormat);
-	UINT32 x;
-
-	for (x = 0; x < width; x += 2)
+	for (UINT32 x = 0; x < width; x += 2)
 	{
 		const BOOL lastX = (x + 1) >= width;
 		BYTE Y1e, Y2e, U1e, V1e, U2e, V2e;
@@ -1227,10 +1245,10 @@ static INLINE void general_RGBToAVC444YUV_ANY_DOUBLE_ROW(const BYTE* srcEven, co
 	}
 }
 
-static INLINE pstatus_t general_RGBToAVC444YUV_ANY(const BYTE* pSrc, UINT32 srcFormat,
-                                                   UINT32 srcStep, BYTE* pDst1[3],
-                                                   const UINT32 dst1Step[3], BYTE* pDst2[3],
-                                                   const UINT32 dst2Step[3], const prim_size_t* roi)
+static INLINE pstatus_t general_RGBToAVC444YUV_ANY(
+    const BYTE* WINPR_RESTRICT pSrc, UINT32 srcFormat, UINT32 srcStep,
+    BYTE* WINPR_RESTRICT pDst1[3], const UINT32 dst1Step[3], BYTE* WINPR_RESTRICT pDst2[3],
+    const UINT32 dst2Step[3], const prim_size_t* WINPR_RESTRICT roi)
 {
 	/**
 	 * Note: According to [MS-RDPEGFX 2.2.4.4 RFX_AVC420_BITMAP_STREAM] the
@@ -1289,10 +1307,9 @@ static INLINE pstatus_t general_RGBToAVC444YUV_ANY(const BYTE* pSrc, UINT32 srcF
 	 *  }
 	 *
 	 */
-	UINT32 y;
 	const BYTE* pMaxSrc = pSrc + (roi->height - 1) * srcStep;
 
-	for (y = 0; y < roi->height; y += 2)
+	for (UINT32 y = 0; y < roi->height; y += 2)
 	{
 		const BOOL last = (y >= (roi->height - 1));
 		const BYTE* srcEven = y < roi->height ? pSrc + y * srcStep : pMaxSrc;
@@ -1314,10 +1331,12 @@ static INLINE pstatus_t general_RGBToAVC444YUV_ANY(const BYTE* pSrc, UINT32 srcF
 	return PRIMITIVES_SUCCESS;
 }
 
-static INLINE pstatus_t general_RGBToAVC444YUV(const BYTE* pSrc, UINT32 srcFormat, UINT32 srcStep,
-                                               BYTE* pDst1[3], const UINT32 dst1Step[3],
-                                               BYTE* pDst2[3], const UINT32 dst2Step[3],
-                                               const prim_size_t* roi)
+static INLINE pstatus_t general_RGBToAVC444YUV(const BYTE* WINPR_RESTRICT pSrc, UINT32 srcFormat,
+                                               UINT32 srcStep, BYTE* WINPR_RESTRICT pDst1[3],
+                                               const UINT32 dst1Step[3],
+                                               BYTE* WINPR_RESTRICT pDst2[3],
+                                               const UINT32 dst2Step[3],
+                                               const prim_size_t* WINPR_RESTRICT roi)
 {
 	if (!pSrc || !pDst1 || !dst1Step || !pDst2 || !dst2Step)
 		return -1;
@@ -1355,15 +1374,17 @@ static INLINE pstatus_t general_RGBToAVC444YUV(const BYTE* pSrc, UINT32 srcForma
 }
 
 static INLINE void general_RGBToAVC444YUVv2_ANY_DOUBLE_ROW(
-    const BYTE* srcEven, const BYTE* srcOdd, UINT32 srcFormat, BYTE* yLumaDstEven,
-    BYTE* yLumaDstOdd, BYTE* uLumaDst, BYTE* vLumaDst, BYTE* yEvenChromaDst1, BYTE* yEvenChromaDst2,
-    BYTE* yOddChromaDst1, BYTE* yOddChromaDst2, BYTE* uChromaDst1, BYTE* uChromaDst2,
-    BYTE* vChromaDst1, BYTE* vChromaDst2, UINT32 width)
+    const BYTE* WINPR_RESTRICT srcEven, const BYTE* WINPR_RESTRICT srcOdd, UINT32 srcFormat,
+    BYTE* WINPR_RESTRICT yLumaDstEven, BYTE* WINPR_RESTRICT yLumaDstOdd,
+    BYTE* WINPR_RESTRICT uLumaDst, BYTE* WINPR_RESTRICT vLumaDst,
+    BYTE* WINPR_RESTRICT yEvenChromaDst1, BYTE* WINPR_RESTRICT yEvenChromaDst2,
+    BYTE* WINPR_RESTRICT yOddChromaDst1, BYTE* WINPR_RESTRICT yOddChromaDst2,
+    BYTE* WINPR_RESTRICT uChromaDst1, BYTE* WINPR_RESTRICT uChromaDst2,
+    BYTE* WINPR_RESTRICT vChromaDst1, BYTE* WINPR_RESTRICT vChromaDst2, UINT32 width)
 {
-	UINT32 x;
 	const UINT32 bpp = FreeRDPGetBytesPerPixel(srcFormat);
 
-	for (x = 0; x < width; x += 2)
+	for (UINT32 x = 0; x < width; x += 2)
 	{
 		BYTE Ya, Ua, Va;
 		BYTE Yb, Ub, Vb;
@@ -1478,11 +1499,10 @@ static INLINE void general_RGBToAVC444YUVv2_ANY_DOUBLE_ROW(
 	}
 }
 
-static INLINE pstatus_t general_RGBToAVC444YUVv2_ANY(const BYTE* pSrc, UINT32 srcFormat,
-                                                     UINT32 srcStep, BYTE* pDst1[3],
-                                                     const UINT32 dst1Step[3], BYTE* pDst2[3],
-                                                     const UINT32 dst2Step[3],
-                                                     const prim_size_t* roi)
+static INLINE pstatus_t general_RGBToAVC444YUVv2_ANY(
+    const BYTE* WINPR_RESTRICT pSrc, UINT32 srcFormat, UINT32 srcStep,
+    BYTE* WINPR_RESTRICT pDst1[3], const UINT32 dst1Step[3], BYTE* WINPR_RESTRICT pDst2[3],
+    const UINT32 dst2Step[3], const prim_size_t* WINPR_RESTRICT roi)
 {
 	/**
 	 * Note: According to [MS-RDPEGFX 2.2.4.4 RFX_AVC420_BITMAP_STREAM] the
@@ -1534,12 +1554,10 @@ static INLINE pstatus_t general_RGBToAVC444YUVv2_ANY(const BYTE* pSrc, UINT32 sr
 	 *  }
 	 *
 	 */
-	UINT32 y;
-
 	if (roi->height < 1 || roi->width < 1)
 		return !PRIMITIVES_SUCCESS;
 
-	for (y = 0; y < roi->height; y += 2)
+	for (UINT32 y = 0; y < roi->height; y += 2)
 	{
 		const BYTE* srcEven = (pSrc + y * srcStep);
 		const BYTE* srcOdd = (y < roi->height - 1) ? (srcEven + srcStep) : NULL;
@@ -1565,14 +1583,15 @@ static INLINE pstatus_t general_RGBToAVC444YUVv2_ANY(const BYTE* pSrc, UINT32 sr
 }
 
 static INLINE void general_RGBToAVC444YUVv2_BGRX_DOUBLE_ROW(
-    const BYTE* srcEven, const BYTE* srcOdd, BYTE* yLumaDstEven, BYTE* yLumaDstOdd, BYTE* uLumaDst,
-    BYTE* vLumaDst, BYTE* yEvenChromaDst1, BYTE* yEvenChromaDst2, BYTE* yOddChromaDst1,
-    BYTE* yOddChromaDst2, BYTE* uChromaDst1, BYTE* uChromaDst2, BYTE* vChromaDst1,
-    BYTE* vChromaDst2, UINT32 width)
+    const BYTE* WINPR_RESTRICT srcEven, const BYTE* WINPR_RESTRICT srcOdd,
+    BYTE* WINPR_RESTRICT yLumaDstEven, BYTE* WINPR_RESTRICT yLumaDstOdd,
+    BYTE* WINPR_RESTRICT uLumaDst, BYTE* WINPR_RESTRICT vLumaDst,
+    BYTE* WINPR_RESTRICT yEvenChromaDst1, BYTE* WINPR_RESTRICT yEvenChromaDst2,
+    BYTE* WINPR_RESTRICT yOddChromaDst1, BYTE* WINPR_RESTRICT yOddChromaDst2,
+    BYTE* WINPR_RESTRICT uChromaDst1, BYTE* WINPR_RESTRICT uChromaDst2,
+    BYTE* WINPR_RESTRICT vChromaDst1, BYTE* WINPR_RESTRICT vChromaDst2, UINT32 width)
 {
-	UINT32 x;
-
-	for (x = 0; x < width; x += 2)
+	for (UINT32 x = 0; x < width; x += 2)
 	{
 		BYTE Ya, Ua, Va;
 		BYTE Yb, Ub, Vb;
@@ -1687,17 +1706,17 @@ static INLINE void general_RGBToAVC444YUVv2_BGRX_DOUBLE_ROW(
 	}
 }
 
-static INLINE pstatus_t general_RGBToAVC444YUVv2_BGRX(const BYTE* pSrc, UINT32 srcStep,
-                                                      BYTE* pDst1[3], const UINT32 dst1Step[3],
-                                                      BYTE* pDst2[3], const UINT32 dst2Step[3],
-                                                      const prim_size_t* roi)
+static INLINE pstatus_t general_RGBToAVC444YUVv2_BGRX(const BYTE* WINPR_RESTRICT pSrc,
+                                                      UINT32 srcStep, BYTE* WINPR_RESTRICT pDst1[3],
+                                                      const UINT32 dst1Step[3],
+                                                      BYTE* WINPR_RESTRICT pDst2[3],
+                                                      const UINT32 dst2Step[3],
+                                                      const prim_size_t* WINPR_RESTRICT roi)
 {
-	UINT32 y;
-
 	if (roi->height < 1 || roi->width < 1)
 		return !PRIMITIVES_SUCCESS;
 
-	for (y = 0; y < roi->height; y += 2)
+	for (UINT32 y = 0; y < roi->height; y += 2)
 	{
 		const BYTE* srcEven = (pSrc + y * srcStep);
 		const BYTE* srcOdd = (y < roi->height - 1) ? (srcEven + srcStep) : NULL;
@@ -1722,10 +1741,12 @@ static INLINE pstatus_t general_RGBToAVC444YUVv2_BGRX(const BYTE* pSrc, UINT32 s
 	return PRIMITIVES_SUCCESS;
 }
 
-static INLINE pstatus_t general_RGBToAVC444YUVv2(const BYTE* pSrc, UINT32 srcFormat, UINT32 srcStep,
-                                                 BYTE* pDst1[3], const UINT32 dst1Step[3],
-                                                 BYTE* pDst2[3], const UINT32 dst2Step[3],
-                                                 const prim_size_t* roi)
+static INLINE pstatus_t general_RGBToAVC444YUVv2(const BYTE* WINPR_RESTRICT pSrc, UINT32 srcFormat,
+                                                 UINT32 srcStep, BYTE* WINPR_RESTRICT pDst1[3],
+                                                 const UINT32 dst1Step[3],
+                                                 BYTE* WINPR_RESTRICT pDst2[3],
+                                                 const UINT32 dst2Step[3],
+                                                 const prim_size_t* WINPR_RESTRICT roi)
 {
 	switch (srcFormat)
 	{
@@ -1742,7 +1763,7 @@ static INLINE pstatus_t general_RGBToAVC444YUVv2(const BYTE* pSrc, UINT32 srcFor
 	return !PRIMITIVES_SUCCESS;
 }
 
-void primitives_init_YUV(primitives_t* prims)
+void primitives_init_YUV(primitives_t* WINPR_RESTRICT prims)
 {
 	prims->YUV420ToRGB_8u_P3AC4R = general_YUV420ToRGB_8u_P3AC4R;
 	prims->YUV444ToRGB_8u_P3AC4R = general_YUV444ToRGB_8u_P3AC4R;

--- a/libfreerdp/primitives/prim_add_opt.c
+++ b/libfreerdp/primitives/prim_add_opt.c
@@ -43,7 +43,7 @@ SSE3_SSD_ROUTINE(sse3_add_16s, INT16, generic->add_16s, _mm_adds_epi16,
 #endif
 
 /* ------------------------------------------------------------------------- */
-void primitives_init_add_opt(primitives_t* prims)
+void primitives_init_add_opt(primitives_t* WINPR_RESTRICT prims)
 {
 	generic = primitives_get_generic();
 	primitives_init_add(prims);

--- a/libfreerdp/primitives/prim_alphaComp_opt.c
+++ b/libfreerdp/primitives/prim_alphaComp_opt.c
@@ -43,8 +43,9 @@ static primitives_t* generic = NULL;
 #ifdef WITH_SSE2
 #if !defined(WITH_IPP) || defined(ALL_PRIMITIVES_VERSIONS)
 
-static pstatus_t sse2_alphaComp_argb(const BYTE* pSrc1, UINT32 src1Step, const BYTE* pSrc2,
-                                     UINT32 src2Step, BYTE* pDst, UINT32 dstStep, UINT32 width,
+static pstatus_t sse2_alphaComp_argb(const BYTE* WINPR_RESTRICT pSrc1, UINT32 src1Step,
+                                     const BYTE* WINPR_RESTRICT pSrc2, UINT32 src2Step,
+                                     BYTE* WINPR_RESTRICT pDst, UINT32 dstStep, UINT32 width,
                                      UINT32 height)
 {
 	const UINT32* sptr1 = (const UINT32*)pSrc1;
@@ -218,7 +219,7 @@ static pstatus_t ipp_alphaComp_argb(const BYTE* pSrc1, INT32 src1Step, const BYT
 #endif
 
 /* ------------------------------------------------------------------------- */
-void primitives_init_alphaComp_opt(primitives_t* prims)
+void primitives_init_alphaComp_opt(primitives_t* WINPR_RESTRICT prims)
 {
 	generic = primitives_get_generic();
 	primitives_init_alphaComp(prims);

--- a/libfreerdp/primitives/prim_andor_opt.c
+++ b/libfreerdp/primitives/prim_andor_opt.c
@@ -43,7 +43,7 @@ SSE3_SCD_PRE_ROUTINE(sse3_orC_32u, UINT32, generic->orC_32u, _mm_or_si128, *dptr
 #endif
 
 /* ------------------------------------------------------------------------- */
-void primitives_init_andor_opt(primitives_t* prims)
+void primitives_init_andor_opt(primitives_t* WINPR_RESTRICT prims)
 {
 	generic = primitives_get_generic();
 	primitives_init_andor(prims);

--- a/libfreerdp/primitives/prim_colors.c
+++ b/libfreerdp/primitives/prim_colors.c
@@ -29,9 +29,10 @@
 #define MINMAX(_v_, _l_, _h_) ((_v_) < (_l_) ? (_l_) : ((_v_) > (_h_) ? (_h_) : (_v_)))
 #endif /* !MINMAX */
 /* ------------------------------------------------------------------------- */
-static pstatus_t general_yCbCrToRGB_16s8u_P3AC4R_BGRX(const INT16* const pSrc[3], UINT32 srcStep,
-                                                      BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
-                                                      const prim_size_t* roi)
+static pstatus_t general_yCbCrToRGB_16s8u_P3AC4R_BGRX(const INT16* const WINPR_RESTRICT pSrc[3],
+                                                      UINT32 srcStep, BYTE* WINPR_RESTRICT pDst,
+                                                      UINT32 dstStep, UINT32 DstFormat,
+                                                      const prim_size_t* WINPR_RESTRICT roi)
 {
 	UINT32 x, y;
 	BYTE* pRGB = pDst;
@@ -70,9 +71,10 @@ static pstatus_t general_yCbCrToRGB_16s8u_P3AC4R_BGRX(const INT16* const pSrc[3]
 	return PRIMITIVES_SUCCESS;
 }
 
-static pstatus_t general_yCbCrToRGB_16s8u_P3AC4R_general(const INT16* const pSrc[3], UINT32 srcStep,
-                                                         BYTE* pDst, UINT32 dstStep,
-                                                         UINT32 DstFormat, const prim_size_t* roi)
+static pstatus_t general_yCbCrToRGB_16s8u_P3AC4R_general(const INT16* const WINPR_RESTRICT pSrc[3],
+                                                         UINT32 srcStep, BYTE* WINPR_RESTRICT pDst,
+                                                         UINT32 dstStep, UINT32 DstFormat,
+                                                         const prim_size_t* WINPR_RESTRICT roi)
 {
 	UINT32 x, y;
 	BYTE* pRGB = pDst;
@@ -112,9 +114,10 @@ static pstatus_t general_yCbCrToRGB_16s8u_P3AC4R_general(const INT16* const pSrc
 	return PRIMITIVES_SUCCESS;
 }
 
-static pstatus_t general_yCbCrToRGB_16s8u_P3AC4R(const INT16* const pSrc[3], UINT32 srcStep,
-                                                 BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
-                                                 const prim_size_t* roi)
+static pstatus_t general_yCbCrToRGB_16s8u_P3AC4R(const INT16* const WINPR_RESTRICT pSrc[3],
+                                                 UINT32 srcStep, BYTE* WINPR_RESTRICT pDst,
+                                                 UINT32 dstStep, UINT32 DstFormat,
+                                                 const prim_size_t* WINPR_RESTRICT roi)
 {
 	switch (DstFormat)
 	{
@@ -131,9 +134,10 @@ static pstatus_t general_yCbCrToRGB_16s8u_P3AC4R(const INT16* const pSrc[3], UIN
 
 /* ------------------------------------------------------------------------- */
 
-static pstatus_t general_yCbCrToRGB_16s16s_P3P3(const INT16* const pSrc[3], INT32 srcStep,
-                                                INT16* pDst[3], INT32 dstStep,
-                                                const prim_size_t* roi) /* region of interest */
+static pstatus_t
+general_yCbCrToRGB_16s16s_P3P3(const INT16* const WINPR_RESTRICT pSrc[3], INT32 srcStep,
+                               INT16* WINPR_RESTRICT pDst[3], INT32 dstStep,
+                               const prim_size_t* WINPR_RESTRICT roi) /* region of interest */
 {
 	/**
 	 * The decoded YCbCr coeffectients are represented as 11.5 fixed-point
@@ -210,9 +214,10 @@ static pstatus_t general_yCbCrToRGB_16s16s_P3P3(const INT16* const pSrc[3], INT3
 }
 
 /* ------------------------------------------------------------------------- */
-static pstatus_t general_RGBToYCbCr_16s16s_P3P3(const INT16* const pSrc[3], INT32 srcStep,
-                                                INT16* pDst[3], INT32 dstStep,
-                                                const prim_size_t* roi) /* region of interest */
+static pstatus_t
+general_RGBToYCbCr_16s16s_P3P3(const INT16* const WINPR_RESTRICT pSrc[3], INT32 srcStep,
+                               INT16* WINPR_RESTRICT pDst[3], INT32 dstStep,
+                               const prim_size_t* WINPR_RESTRICT roi) /* region of interest */
 {
 	/* The encoded YCbCr coefficients are represented as 11.5 fixed-point
 	 * numbers:
@@ -434,13 +439,12 @@ static INLINE fkt_writeScanline getScanlineWriteFunction(DWORD format)
 }
 
 /* ------------------------------------------------------------------------- */
-static pstatus_t
-general_RGBToRGB_16s8u_P3AC4R_general(const INT16* const pSrc[3], /* 16-bit R,G, and B arrays */
-                                      UINT32 srcStep, /* bytes between rows in source data */
-                                      BYTE* pDst,     /* 32-bit interleaved ARGB (ABGR?) data */
-                                      UINT32 dstStep, /* bytes between rows in dest data */
-                                      UINT32 DstFormat,
-                                      const prim_size_t* roi) /* region of interest */
+static pstatus_t general_RGBToRGB_16s8u_P3AC4R_general(
+    const INT16* const WINPR_RESTRICT pSrc[3], /* 16-bit R,G, and B arrays */
+    UINT32 srcStep,                            /* bytes between rows in source data */
+    BYTE* WINPR_RESTRICT pDst,                 /* 32-bit interleaved ARGB (ABGR?) data */
+    UINT32 dstStep,                            /* bytes between rows in dest data */
+    UINT32 DstFormat, const prim_size_t* WINPR_RESTRICT roi) /* region of interest */
 {
 	const INT16* r = pSrc[0];
 	const INT16* g = pSrc[1];
@@ -462,13 +466,12 @@ general_RGBToRGB_16s8u_P3AC4R_general(const INT16* const pSrc[3], /* 16-bit R,G,
 	return PRIMITIVES_SUCCESS;
 }
 
-static pstatus_t
-general_RGBToRGB_16s8u_P3AC4R_BGRX(const INT16* const pSrc[3], /* 16-bit R,G, and B arrays */
-                                   UINT32 srcStep, /* bytes between rows in source data */
-                                   BYTE* pDst,     /* 32-bit interleaved ARGB (ABGR?) data */
-                                   UINT32 dstStep, /* bytes between rows in dest data */
-                                   UINT32 DstFormat,
-                                   const prim_size_t* roi) /* region of interest */
+static pstatus_t general_RGBToRGB_16s8u_P3AC4R_BGRX(
+    const INT16* const WINPR_RESTRICT pSrc[3], /* 16-bit R,G, and B arrays */
+    UINT32 srcStep,                            /* bytes between rows in source data */
+    BYTE* WINPR_RESTRICT pDst,                 /* 32-bit interleaved ARGB (ABGR?) data */
+    UINT32 dstStep,                            /* bytes between rows in dest data */
+    UINT32 DstFormat, const prim_size_t* WINPR_RESTRICT roi) /* region of interest */
 {
 	const INT16* r = pSrc[0];
 	const INT16* g = pSrc[1];
@@ -489,12 +492,12 @@ general_RGBToRGB_16s8u_P3AC4R_BGRX(const INT16* const pSrc[3], /* 16-bit R,G, an
 	return PRIMITIVES_SUCCESS;
 }
 
-static pstatus_t
-general_RGBToRGB_16s8u_P3AC4R(const INT16* const pSrc[3], /* 16-bit R,G, and B arrays */
-                              UINT32 srcStep,             /* bytes between rows in source data */
-                              BYTE* pDst,                 /* 32-bit interleaved ARGB (ABGR?) data */
-                              UINT32 dstStep,             /* bytes between rows in dest data */
-                              UINT32 DstFormat, const prim_size_t* roi) /* region of interest */
+static pstatus_t general_RGBToRGB_16s8u_P3AC4R(
+    const INT16* const WINPR_RESTRICT pSrc[3], /* 16-bit R,G, and B arrays */
+    UINT32 srcStep,                            /* bytes between rows in source data */
+    BYTE* WINPR_RESTRICT pDst,                 /* 32-bit interleaved ARGB (ABGR?) data */
+    UINT32 dstStep,                            /* bytes between rows in dest data */
+    UINT32 DstFormat, const prim_size_t* WINPR_RESTRICT roi) /* region of interest */
 {
 	switch (DstFormat)
 	{

--- a/libfreerdp/primitives/prim_colors_opt.c
+++ b/libfreerdp/primitives/prim_colors_opt.c
@@ -52,7 +52,7 @@ static primitives_t* generic = NULL;
 
 #ifdef DO_PREFETCH
 /*---------------------------------------------------------------------------*/
-static inline void GNU_INLINE _mm_prefetch_buffer(char* buffer, int num_bytes)
+static inline void GNU_INLINE _mm_prefetch_buffer(char* WINPR_RESTRICT buffer, int num_bytes)
 {
 	__m128i* buf = (__m128i*)buffer;
 	unsigned int i;
@@ -65,9 +65,10 @@ static inline void GNU_INLINE _mm_prefetch_buffer(char* buffer, int num_bytes)
 #endif /* DO_PREFETCH */
 
 /*---------------------------------------------------------------------------*/
-static pstatus_t sse2_yCbCrToRGB_16s16s_P3P3(const INT16* const pSrc[3], int srcStep,
-                                             INT16* pDst[3], int dstStep,
-                                             const prim_size_t* roi) /* region of interest */
+static pstatus_t
+sse2_yCbCrToRGB_16s16s_P3P3(const INT16* const WINPR_RESTRICT pSrc[3], int srcStep,
+                            INT16* WINPR_RESTRICT pDst[3], int dstStep,
+                            const prim_size_t* WINPR_RESTRICT roi) /* region of interest */
 {
 	__m128i zero, max, r_cr, g_cb, g_cr, b_cb, c4096;
 	const __m128i *y_buf, *cb_buf, *cr_buf;
@@ -192,9 +193,10 @@ static pstatus_t sse2_yCbCrToRGB_16s16s_P3P3(const INT16* const pSrc[3], int src
 }
 
 /*---------------------------------------------------------------------------*/
-static pstatus_t sse2_yCbCrToRGB_16s8u_P3AC4R_BGRX(const INT16* const pSrc[3], UINT32 srcStep,
-                                                   BYTE* pDst, UINT32 dstStep,
-                                                   const prim_size_t* roi) /* region of interest */
+static pstatus_t
+sse2_yCbCrToRGB_16s8u_P3AC4R_BGRX(const INT16* const WINPR_RESTRICT pSrc[3], UINT32 srcStep,
+                                  BYTE* WINPR_RESTRICT pDst, UINT32 dstStep,
+                                  const prim_size_t* WINPR_RESTRICT roi) /* region of interest */
 {
 	const __m128i zero = _mm_setzero_si128();
 	const __m128i max = _mm_set1_epi16(255);
@@ -379,9 +381,10 @@ static pstatus_t sse2_yCbCrToRGB_16s8u_P3AC4R_BGRX(const INT16* const pSrc[3], U
 }
 
 /*---------------------------------------------------------------------------*/
-static pstatus_t sse2_yCbCrToRGB_16s8u_P3AC4R_RGBX(const INT16* const pSrc[3], UINT32 srcStep,
-                                                   BYTE* pDst, UINT32 dstStep,
-                                                   const prim_size_t* roi) /* region of interest */
+static pstatus_t
+sse2_yCbCrToRGB_16s8u_P3AC4R_RGBX(const INT16* const WINPR_RESTRICT pSrc[3], UINT32 srcStep,
+                                  BYTE* WINPR_RESTRICT pDst, UINT32 dstStep,
+                                  const prim_size_t* WINPR_RESTRICT roi) /* region of interest */
 {
 	const __m128i zero = _mm_setzero_si128();
 	const __m128i max = _mm_set1_epi16(255);
@@ -565,9 +568,10 @@ static pstatus_t sse2_yCbCrToRGB_16s8u_P3AC4R_RGBX(const INT16* const pSrc[3], U
 	return PRIMITIVES_SUCCESS;
 }
 
-static pstatus_t sse2_yCbCrToRGB_16s8u_P3AC4R(const INT16* const pSrc[3], UINT32 srcStep,
-                                              BYTE* pDst, UINT32 dstStep, UINT32 DstFormat,
-                                              const prim_size_t* roi) /* region of interest */
+static pstatus_t
+sse2_yCbCrToRGB_16s8u_P3AC4R(const INT16* const WINPR_RESTRICT pSrc[3], UINT32 srcStep,
+                             BYTE* WINPR_RESTRICT pDst, UINT32 dstStep, UINT32 DstFormat,
+                             const prim_size_t* WINPR_RESTRICT roi) /* region of interest */
 {
 	if (((ULONG_PTR)(pSrc[0]) & 0x0f) || ((ULONG_PTR)(pSrc[1]) & 0x0f) ||
 	    ((ULONG_PTR)(pSrc[2]) & 0x0f) || ((ULONG_PTR)(pDst)&0x0f) || (srcStep & 0x0f) ||
@@ -594,9 +598,10 @@ static pstatus_t sse2_yCbCrToRGB_16s8u_P3AC4R(const INT16* const pSrc[3], UINT32
 /* The encodec YCbCr coeffectients are represented as 11.5 fixed-point
  * numbers. See the general code above.
  */
-static pstatus_t sse2_RGBToYCbCr_16s16s_P3P3(const INT16* const pSrc[3], int srcStep,
-                                             INT16* pDst[3], int dstStep,
-                                             const prim_size_t* roi) /* region of interest */
+static pstatus_t
+sse2_RGBToYCbCr_16s16s_P3P3(const INT16* const WINPR_RESTRICT pSrc[3], int srcStep,
+                            INT16* WINPR_RESTRICT pDst[3], int dstStep,
+                            const prim_size_t* WINPR_RESTRICT roi) /* region of interest */
 {
 	__m128i min, max, y_r, y_g, y_b, cb_r, cb_g, cb_b, cr_r, cr_g, cr_b;
 	const __m128i* r_buf = (const __m128i*)(pSrc[0]);
@@ -718,12 +723,12 @@ static pstatus_t sse2_RGBToYCbCr_16s16s_P3P3(const INT16* const pSrc[3], int src
 }
 
 /*---------------------------------------------------------------------------*/
-static pstatus_t
-sse2_RGBToRGB_16s8u_P3AC4R_BGRX(const INT16* const pSrc[3], /* 16-bit R,G, and B arrays */
-                                UINT32 srcStep,             /* bytes between rows in source data */
-                                BYTE* pDst,             /* 32-bit interleaved ARGB (ABGR?) data */
-                                UINT32 dstStep,         /* bytes between rows in dest data */
-                                const prim_size_t* roi) /* region of interest */
+static pstatus_t sse2_RGBToRGB_16s8u_P3AC4R_BGRX(
+    const INT16* const WINPR_RESTRICT pSrc[3], /* 16-bit R,G, and B arrays */
+    UINT32 srcStep,                            /* bytes between rows in source data */
+    BYTE* WINPR_RESTRICT pDst,                 /* 32-bit interleaved ARGB (ABGR?) data */
+    UINT32 dstStep,                            /* bytes between rows in dest data */
+    const prim_size_t* WINPR_RESTRICT roi)     /* region of interest */
 {
 	const UINT16* pr = (const UINT16*)(pSrc[0]);
 	const UINT16* pg = (const UINT16*)(pSrc[1]);
@@ -822,12 +827,12 @@ sse2_RGBToRGB_16s8u_P3AC4R_BGRX(const INT16* const pSrc[3], /* 16-bit R,G, and B
 	return PRIMITIVES_SUCCESS;
 }
 
-static pstatus_t
-sse2_RGBToRGB_16s8u_P3AC4R_RGBX(const INT16* const pSrc[3], /* 16-bit R,G, and B arrays */
-                                UINT32 srcStep,             /* bytes between rows in source data */
-                                BYTE* pDst,             /* 32-bit interleaved ARGB (ABGR?) data */
-                                UINT32 dstStep,         /* bytes between rows in dest data */
-                                const prim_size_t* roi) /* region of interest */
+static pstatus_t sse2_RGBToRGB_16s8u_P3AC4R_RGBX(
+    const INT16* const WINPR_RESTRICT pSrc[3], /* 16-bit R,G, and B arrays */
+    UINT32 srcStep,                            /* bytes between rows in source data */
+    BYTE* WINPR_RESTRICT pDst,                 /* 32-bit interleaved ARGB (ABGR?) data */
+    UINT32 dstStep,                            /* bytes between rows in dest data */
+    const prim_size_t* WINPR_RESTRICT roi)     /* region of interest */
 {
 	const UINT16* pr = (const UINT16*)(pSrc[0]);
 	const UINT16* pg = (const UINT16*)(pSrc[1]);
@@ -926,12 +931,12 @@ sse2_RGBToRGB_16s8u_P3AC4R_RGBX(const INT16* const pSrc[3], /* 16-bit R,G, and B
 	return PRIMITIVES_SUCCESS;
 }
 
-static pstatus_t
-sse2_RGBToRGB_16s8u_P3AC4R_XBGR(const INT16* const pSrc[3], /* 16-bit R,G, and B arrays */
-                                UINT32 srcStep,             /* bytes between rows in source data */
-                                BYTE* pDst,             /* 32-bit interleaved ARGB (ABGR?) data */
-                                UINT32 dstStep,         /* bytes between rows in dest data */
-                                const prim_size_t* roi) /* region of interest */
+static pstatus_t sse2_RGBToRGB_16s8u_P3AC4R_XBGR(
+    const INT16* const WINPR_RESTRICT pSrc[3], /* 16-bit R,G, and B arrays */
+    UINT32 srcStep,                            /* bytes between rows in source data */
+    BYTE* WINPR_RESTRICT pDst,                 /* 32-bit interleaved ARGB (ABGR?) data */
+    UINT32 dstStep,                            /* bytes between rows in dest data */
+    const prim_size_t* WINPR_RESTRICT roi)     /* region of interest */
 {
 	const UINT16* pr = (const UINT16*)(pSrc[0]);
 	const UINT16* pg = (const UINT16*)(pSrc[1]);
@@ -1030,12 +1035,12 @@ sse2_RGBToRGB_16s8u_P3AC4R_XBGR(const INT16* const pSrc[3], /* 16-bit R,G, and B
 	return PRIMITIVES_SUCCESS;
 }
 
-static pstatus_t
-sse2_RGBToRGB_16s8u_P3AC4R_XRGB(const INT16* const pSrc[3], /* 16-bit R,G, and B arrays */
-                                UINT32 srcStep,             /* bytes between rows in source data */
-                                BYTE* pDst,             /* 32-bit interleaved ARGB (ABGR?) data */
-                                UINT32 dstStep,         /* bytes between rows in dest data */
-                                const prim_size_t* roi) /* region of interest */
+static pstatus_t sse2_RGBToRGB_16s8u_P3AC4R_XRGB(
+    const INT16* const WINPR_RESTRICT pSrc[3], /* 16-bit R,G, and B arrays */
+    UINT32 srcStep,                            /* bytes between rows in source data */
+    BYTE* WINPR_RESTRICT pDst,                 /* 32-bit interleaved ARGB (ABGR?) data */
+    UINT32 dstStep,                            /* bytes between rows in dest data */
+    const prim_size_t* WINPR_RESTRICT roi)     /* region of interest */
 {
 	const UINT16* pr = (const UINT16*)(pSrc[0]);
 	const UINT16* pg = (const UINT16*)(pSrc[1]);
@@ -1135,11 +1140,11 @@ sse2_RGBToRGB_16s8u_P3AC4R_XRGB(const INT16* const pSrc[3], /* 16-bit R,G, and B
 }
 
 static pstatus_t
-sse2_RGBToRGB_16s8u_P3AC4R(const INT16* const pSrc[3], /* 16-bit R,G, and B arrays */
-                           UINT32 srcStep,             /* bytes between rows in source data */
-                           BYTE* pDst,                 /* 32-bit interleaved ARGB (ABGR?) data */
-                           UINT32 dstStep,             /* bytes between rows in dest data */
-                           UINT32 DstFormat, const prim_size_t* roi)
+sse2_RGBToRGB_16s8u_P3AC4R(const INT16* const WINPR_RESTRICT pSrc[3], /* 16-bit R,G, and B arrays */
+                           UINT32 srcStep,            /* bytes between rows in source data */
+                           BYTE* WINPR_RESTRICT pDst, /* 32-bit interleaved ARGB (ABGR?) data */
+                           UINT32 dstStep,            /* bytes between rows in dest data */
+                           UINT32 DstFormat, const prim_size_t* WINPR_RESTRICT roi)
 {
 	if (((ULONG_PTR)pSrc[0] & 0x0f) || ((ULONG_PTR)pSrc[1] & 0x0f) || ((ULONG_PTR)pSrc[2] & 0x0f) ||
 	    (srcStep & 0x0f) || ((ULONG_PTR)pDst & 0x0f) || (dstStep & 0x0f))

--- a/libfreerdp/primitives/prim_set_opt.c
+++ b/libfreerdp/primitives/prim_set_opt.c
@@ -35,7 +35,7 @@ static primitives_t* generic = NULL;
 /* ========================================================================= */
 #ifdef WITH_SSE2
 #if !defined(WITH_IPP) || defined(ALL_PRIMITIVES_VERSIONS)
-static pstatus_t sse2_set_8u(BYTE val, BYTE* pDst, UINT32 len)
+static pstatus_t sse2_set_8u(BYTE val, BYTE* WINPR_RESTRICT pDst, UINT32 len)
 {
 	BYTE byte, *dptr;
 	__m128i xmm0;
@@ -121,7 +121,7 @@ static pstatus_t sse2_set_8u(BYTE val, BYTE* pDst, UINT32 len)
 /* ------------------------------------------------------------------------- */
 #ifdef WITH_SSE2
 #if !defined(WITH_IPP) || defined(ALL_PRIMITIVES_VERSIONS)
-static pstatus_t sse2_set_32u(UINT32 val, UINT32* pDst, UINT32 len)
+static pstatus_t sse2_set_32u(UINT32 val, UINT32* WINPR_RESTRICT pDst, UINT32 len)
 {
 	const primitives_t* prim = primitives_get_generic();
 	UINT32* dptr = (UINT32*)pDst;
@@ -213,7 +213,7 @@ static pstatus_t sse2_set_32u(UINT32 val, UINT32* pDst, UINT32 len)
 }
 
 /* ------------------------------------------------------------------------- */
-static pstatus_t sse2_set_32s(INT32 val, INT32* pDst, UINT32 len)
+static pstatus_t sse2_set_32s(INT32 val, INT32* WINPR_RESTRICT pDst, UINT32 len)
 {
 	UINT32 uval = *((UINT32*)&val);
 	return sse2_set_32u(uval, (UINT32*)pDst, len);
@@ -223,7 +223,7 @@ static pstatus_t sse2_set_32s(INT32 val, INT32* pDst, UINT32 len)
 
 #ifdef WITH_IPP
 /* ------------------------------------------------------------------------- */
-static pstatus_t ipp_wrapper_set_32u(UINT32 val, UINT32* pDst, INT32 len)
+static pstatus_t ipp_wrapper_set_32u(UINT32 val, UINT32* WINPR_RESTRICT pDst, INT32 len)
 {
 	/* A little type conversion, then use the signed version. */
 	INT32 sval = *((INT32*)&val);
@@ -232,7 +232,7 @@ static pstatus_t ipp_wrapper_set_32u(UINT32 val, UINT32* pDst, INT32 len)
 #endif
 
 /* ------------------------------------------------------------------------- */
-void primitives_init_set_opt(primitives_t* prims)
+void primitives_init_set_opt(primitives_t* WINPR_RESTRICT prims)
 {
 	generic = primitives_get_generic();
 	primitives_init_set(prims);

--- a/libfreerdp/primitives/prim_shift_opt.c
+++ b/libfreerdp/primitives/prim_shift_opt.c
@@ -56,15 +56,15 @@ SSE3_SCD_ROUTINE(sse2_rShiftC_16u, UINT16, generic->rShiftC_16u, _mm_srli_epi16,
  */
 
 /* ------------------------------------------------------------------------- */
-void primitives_init_shift_opt(primitives_t* prims)
+void primitives_init_shift_opt(primitives_t* WINPR_RESTRICT prims)
 {
 	generic = primitives_get_generic();
 	primitives_init_shift(prims);
 #if defined(WITH_IPP)
-	prims->lShiftC_16s = (__lShiftC_16s_t)ippsLShiftC_16s;
-	prims->rShiftC_16s = (__rShiftC_16s_t)ippsRShiftC_16s;
-	prims->lShiftC_16u = (__lShiftC_16u_t)ippsLShiftC_16u;
-	prims->rShiftC_16u = (__rShiftC_16u_t)ippsRShiftC_16u;
+	prims->lShiftC_16s = ippsLShiftC_16s;
+	prims->rShiftC_16s = ippsRShiftC_16s;
+	prims->lShiftC_16u = ippsLShiftC_16u;
+	prims->rShiftC_16u = ippsRShiftC_16u;
 #elif defined(WITH_SSE2)
 
 	if (IsProcessorFeaturePresent(PF_SSE2_INSTRUCTIONS_AVAILABLE) &&

--- a/libfreerdp/primitives/prim_sign_opt.c
+++ b/libfreerdp/primitives/prim_sign_opt.c
@@ -30,7 +30,8 @@ static primitives_t* generic = NULL;
 
 #ifdef WITH_SSE2
 /* ------------------------------------------------------------------------- */
-static pstatus_t ssse3_sign_16s(const INT16* pSrc, INT16* pDst, UINT32 len)
+static pstatus_t ssse3_sign_16s(const INT16* WINPR_RESTRICT pSrc, INT16* WINPR_RESTRICT pDst,
+                                UINT32 len)
 {
 	const INT16* sptr = (const INT16*)pSrc;
 	INT16* dptr = (INT16*)pDst;
@@ -152,7 +153,7 @@ static pstatus_t ssse3_sign_16s(const INT16* pSrc, INT16* pDst, UINT32 len)
 #endif /* WITH_SSE2 */
 
 /* ------------------------------------------------------------------------- */
-void primitives_init_sign_opt(primitives_t* prims)
+void primitives_init_sign_opt(primitives_t* WINPR_RESTRICT prims)
 {
 	generic = primitives_get_generic();
 	primitives_init_sign(prims);


### PR DESCRIPTION
follow up to #9319 
use `WINPR_RESTRICT` for `YUV` primitives