### PR TITLE
fix issue with using find_library for Windows system libraries

### DIFF
--- a/client/Windows/CMakeLists.txt
+++ b/client/Windows/CMakeLists.txt
@@ -99,13 +99,10 @@ endif()
 list(APPEND LIBS freerdp-client)
 list(APPEND LIBS winpr freerdp)
 
-find_library(MSIMG32 NAME msimg32 REQUIRED)
-find_library(CREDUI NAME credui REQUIRED)
-list(APPEND LIBS ${MSIMG32} ${CREDUI})
+list(APPEND LIBS msimg32.lib credui.lib)
 
-find_library(NTDLL NAME ntdll) # optional, only required with MINGW
-if (NTDLL)
-    list(APPEND LIBS ${NTDLL})
+if (MINGW)
+	list(APPEND LIBS ntdll.lib) # only required with MINGW
 endif()
 target_link_libraries(${MODULE_NAME} PRIVATE ${LIBS})
 

--- a/winpr/libwinpr/wtsapi/CMakeLists.txt
+++ b/winpr/libwinpr/wtsapi/CMakeLists.txt
@@ -20,13 +20,9 @@ winpr_module_add(wtsapi.c)
 if(WIN32)
 	winpr_module_add(wtsapi_win32.c wtsapi_win32.h)
 
-    # Only required with MINGW
-    find_library(NTDLL
-        NAME ntdll
-    )
-    if (NTDLL)
-        winpr_library_add_private(${NTDLL})
-    endif()
+	if (MINGW)
+		winpr_library_add_private(ntdll.lib) # Only required with MINGW
+	endif()
 endif()
 
 if(BUILD_TESTING)


### PR DESCRIPTION
Fix issue introduced by https://github.com/FreeRDP/FreeRDP/commit/eb67f41a50c816085a1493ab69379b935d585379

using find_library for Windows system libraries will only work if you're using a visual studio command prompt (vcvarsall.bat), so it totally breaks using the Visual Studio generators from a clean prompt. In any case, [I did ask CMakeAid on twitter and the best approach is really to just explicitly provide the .lib import library for the DLL we want to link to](https://twitter.com/cmake_aid/status/1694064020339265848).

![F4J0n6gWcAAByAI](https://github.com/FreeRDP/FreeRDP/assets/295841/712b9d45-a9d3-40b0-aa59-7def063f28ad)

Since ntdll was added for mingw specifically, I put it behind if(MINGW) conditions