### PR TITLE
Turn BUILD_SHARED_LIBS off by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,12 +200,7 @@ endif(CMAKE_CROSSCOMPILING)
 # Turn on solution folders (2.8.4+)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-
-set(LIB_DEFAULT ON)
-if (IOS)
-	set(LIB_DEFAULT OFF)
-endif()
-option(BUILD_SHARED_LIBS "Build shared libraries" ${LIB_DEFAULT})
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(EXPORT_ALL_SYMBOLS "Export all symbols form library" OFF)
 
 if(BUILD_TESTING)

--- a/cmake/ConfigOptions.cmake
+++ b/cmake/ConfigOptions.cmake
@@ -199,7 +199,7 @@ if (BUILD_FUZZERS)
 
     set(BUILD_TESTING ON)
 
-    if (BUILD_SHARED_LIBS STREQUAL "OFF")
+    if (NOT BUILD_SHARED_LIBS)
         set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
         set(CMAKE_CXX_FLAGS "-static ${CMAKE_CXX_FLAGS}")
     endif()

--- a/winpr/CMakeLists.txt
+++ b/winpr/CMakeLists.txt
@@ -35,7 +35,7 @@ if (NOT FREERDP_UNIFIED_BUILD)
 	option(WITH_LIBRARY_VERSIONING "Use library version triplet" ON)
 
 	# Default to build shared libs
-	option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+	option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 	option(EXPORT_ALL_SYMBOLS "Export all symbols form library" OFF)
 
 	if (EXPORT_ALL_SYMBOLS)


### PR DESCRIPTION
Turn CMake BUILD_SHARED_LIBS off by default, meaning a default build produces static libraries, instead of multiple shared libraries. We already set BUILD_SHARED_LIBS to OFF in CI builds, and as far as I'm concerned, I always set it off in my projects. If I want to make C# bindings, I just link everything into a shared library which an explicit SHARED property on the cmake target.

This does not mean we stop supporting shared libraries, just that it won't be the *default*, which is really what I'd expect developers to want. Let's just have the few places where it's desirable to have shared libraries set BUILD_SHARED_LIBS to ON in their builds.