### PR TITLE
[freerdp,api] add FREERDP_ENTRY_POINT

### DIFF
--- a/channels/ainput/client/ainput_main.c
+++ b/channels/ainput/client/ainput_main.c
@@ -175,7 +175,7 @@ static const IWTSVirtualChannelCallback ainput_functions = { ainput_on_data_rece
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT ainput_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
+FREERDP_ENTRY_POINT(UINT ainput_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints))
 {
 	return freerdp_generic_DVCPluginEntry(pEntryPoints, TAG, AINPUT_DVC_CHANNEL_NAME,
 	                                      sizeof(AINPUT_PLUGIN), sizeof(GENERIC_CHANNEL_CALLBACK),

--- a/channels/audin/client/alsa/audin_alsa.c
+++ b/channels/audin/client/alsa/audin_alsa.c
@@ -390,7 +390,8 @@ static UINT audin_alsa_parse_addin_args(AudinALSADevice* device, const ADDIN_ARG
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT alsa_freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(
+    UINT alsa_freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	const ADDIN_ARGV* args;
 	AudinALSADevice* alsa;

--- a/channels/audin/client/audin_main.c
+++ b/channels/audin/client/audin_main.c
@@ -967,7 +967,7 @@ BOOL audin_process_addin_args(AUDIN_PLUGIN* audin, const ADDIN_ARGV* args)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT audin_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
+FREERDP_ENTRY_POINT(UINT audin_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints))
 {
 	struct SubsystemEntry
 	{

--- a/channels/audin/client/ios/audin_ios.m
+++ b/channels/audin/client/ios/audin_ios.m
@@ -296,7 +296,8 @@ static UINT audin_ios_free(IAudinDevice *device)
 	return CHANNEL_RC_OK;
 }
 
-UINT ios_freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(
+    UINT ios_freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	DWORD errCode;
 	char errString[1024];

--- a/channels/audin/client/mac/audin_mac.m
+++ b/channels/audin/client/mac/audin_mac.m
@@ -381,7 +381,8 @@ static UINT audin_mac_parse_addin_args(AudinMacDevice *device, const ADDIN_ARGV 
 	return CHANNEL_RC_OK;
 }
 
-UINT mac_freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(
+    UINT mac_freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	DWORD errCode;
 	char errString[1024];

--- a/channels/audin/client/opensles/audin_opensl_es.c
+++ b/channels/audin/client/opensles/audin_opensl_es.c
@@ -292,7 +292,8 @@ static UINT audin_opensles_parse_addin_args(AudinOpenSLESDevice* device, const A
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT opensles_freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT opensles_freerdp_audin_client_subsystem_entry(
+    PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	const ADDIN_ARGV* args;
 	AudinOpenSLESDevice* opensles;

--- a/channels/audin/client/oss/audin_oss.c
+++ b/channels/audin/client/oss/audin_oss.c
@@ -443,7 +443,8 @@ static UINT audin_oss_parse_addin_args(AudinOSSDevice* device, const ADDIN_ARGV*
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT oss_freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(
+    UINT oss_freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	const ADDIN_ARGV* args;
 	AudinOSSDevice* oss;

--- a/channels/audin/client/pulse/audin_pulse.c
+++ b/channels/audin/client/pulse/audin_pulse.c
@@ -498,7 +498,8 @@ static UINT audin_pulse_parse_addin_args(AudinPulseDevice* device, const ADDIN_A
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT pulse_freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT pulse_freerdp_audin_client_subsystem_entry(
+    PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	const ADDIN_ARGV* args;
 	AudinPulseDevice* pulse;

--- a/channels/audin/client/sndio/audin_sndio.c
+++ b/channels/audin/client/sndio/audin_sndio.c
@@ -309,7 +309,8 @@ static UINT audin_sndio_parse_addin_args(AudinSndioDevice* device, ADDIN_ARGV* a
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT sndio_freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT sndio_freerdp_audin_client_subsystem_entry(
+    PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	ADDIN_ARGV* args;
 	AudinSndioDevice* sndio;

--- a/channels/audin/client/winmm/audin_winmm.c
+++ b/channels/audin/client/winmm/audin_winmm.c
@@ -493,7 +493,8 @@ static UINT audin_winmm_parse_addin_args(AudinWinmmDevice* device, const ADDIN_A
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT winmm_freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT winmm_freerdp_audin_client_subsystem_entry(
+    PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	const ADDIN_ARGV* args;
 	AudinWinmmDevice* winmm;

--- a/channels/cliprdr/client/cliprdr_main.c
+++ b/channels/cliprdr/client/cliprdr_main.c
@@ -1117,7 +1117,8 @@ static VOID VCAPITYPE cliprdr_virtual_channel_init_event_ex(LPVOID lpUserParam, 
 /* cliprdr is always built-in */
 #define VirtualChannelEntryEx cliprdr_VirtualChannelEntryEx
 
-BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS pEntryPoints, PVOID pInitHandle)
+FREERDP_ENTRY_POINT(BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS pEntryPoints,
+                                                         PVOID pInitHandle))
 {
 	UINT rc;
 	cliprdrPlugin* cliprdr;

--- a/channels/disp/client/disp_main.c
+++ b/channels/disp/client/disp_main.c
@@ -315,7 +315,7 @@ static const IWTSVirtualChannelCallback disp_callbacks = { disp_on_data_received
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT disp_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
+FREERDP_ENTRY_POINT(UINT disp_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints))
 {
 	return freerdp_generic_DVCPluginEntry(pEntryPoints, TAG, DISP_DVC_CHANNEL_NAME,
 	                                      sizeof(DISP_PLUGIN), sizeof(GENERIC_CHANNEL_CALLBACK),

--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -1970,7 +1970,8 @@ static int drdynvc_get_version(DrdynvcClientContext* context)
 /* drdynvc is always built-in */
 #define VirtualChannelEntryEx drdynvc_VirtualChannelEntryEx
 
-BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS_EX pEntryPoints, PVOID pInitHandle)
+FREERDP_ENTRY_POINT(BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS_EX pEntryPoints,
+                                                         PVOID pInitHandle))
 {
 	UINT rc;
 	drdynvcPlugin* drdynvc;

--- a/channels/drive/client/drive_main.c
+++ b/channels/drive/client/drive_main.c
@@ -1004,7 +1004,7 @@ out_error:
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT drive_DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT drive_DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints))
 {
 	RDPDR_DRIVE* drive;
 	UINT error;

--- a/channels/echo/client/echo_main.c
+++ b/channels/echo/client/echo_main.c
@@ -84,7 +84,7 @@ static const IWTSVirtualChannelCallback echo_callbacks = { echo_on_data_received
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT echo_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
+FREERDP_ENTRY_POINT(UINT echo_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints))
 {
 	return freerdp_generic_DVCPluginEntry(pEntryPoints, TAG, ECHO_DVC_CHANNEL_NAME,
 	                                      sizeof(ECHO_PLUGIN), sizeof(GENERIC_CHANNEL_CALLBACK),

--- a/channels/encomsp/client/encomsp_main.c
+++ b/channels/encomsp/client/encomsp_main.c
@@ -1230,7 +1230,8 @@ static VOID VCAPITYPE encomsp_virtual_channel_init_event_ex(LPVOID lpUserParam, 
 /* encomsp is always built-in */
 #define VirtualChannelEntryEx encomsp_VirtualChannelEntryEx
 
-BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS_EX pEntryPoints, PVOID pInitHandle)
+FREERDP_ENTRY_POINT(BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS_EX pEntryPoints,
+                                                         PVOID pInitHandle))
 {
 	BOOL isFreerdp = FALSE;
 	encomspPlugin* encomsp = (encomspPlugin*)calloc(1, sizeof(encomspPlugin));

--- a/channels/geometry/client/geometry_main.c
+++ b/channels/geometry/client/geometry_main.c
@@ -385,7 +385,7 @@ static void terminate_plugin_cb(GENERIC_DYNVC_PLUGIN* base)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT geometry_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
+FREERDP_ENTRY_POINT(UINT geometry_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints))
 {
 	return freerdp_generic_DVCPluginEntry(pEntryPoints, TAG, GEOMETRY_DVC_CHANNEL_NAME,
 	                                      sizeof(GEOMETRY_PLUGIN), sizeof(GENERIC_CHANNEL_CALLBACK),

--- a/channels/parallel/client/parallel_main.c
+++ b/channels/parallel/client/parallel_main.c
@@ -414,7 +414,7 @@ static void parallel_message_free(void* obj)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT parallel_DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT parallel_DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints))
 {
 	char* name;
 	char* path;

--- a/channels/printer/client/cups/printer_cups.c
+++ b/channels/printer/client/cups/printer_cups.c
@@ -406,7 +406,7 @@ static void printer_cups_release_ref_driver(rdpPrinterDriver* driver)
 		cups_driver->references--;
 }
 
-UINT cups_freerdp_printer_client_subsystem_entry(void* arg)
+FREERDP_ENTRY_POINT(UINT cups_freerdp_printer_client_subsystem_entry(void* arg))
 {
 	rdpPrinterDriver** ppPrinter = (rdpPrinterDriver**)arg;
 	if (!ppPrinter)

--- a/channels/printer/client/printer_main.c
+++ b/channels/printer/client/printer_main.c
@@ -1022,7 +1022,7 @@ static rdpPrinterDriver* printer_load_backend(const char* backend)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT printer_DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT printer_DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints))
 {
 	char* name;
 	char* driver_name;

--- a/channels/printer/client/win/printer_win.c
+++ b/channels/printer/client/win/printer_win.c
@@ -434,7 +434,7 @@ static void printer_win_release_ref_driver(rdpPrinterDriver* driver)
 		win->references--;
 }
 
-UINT win_freerdp_printer_client_subsystem_entry(void* arg)
+FREERDP_ENTRY_POINT(UINT win_freerdp_printer_client_subsystem_entry(void* arg))
 {
 	rdpPrinterDriver** ppPrinter = (rdpPrinterDriver**)arg;
 	if (!ppPrinter)

--- a/channels/rail/client/rail_main.c
+++ b/channels/rail/client/rail_main.c
@@ -673,7 +673,8 @@ static VOID VCAPITYPE rail_virtual_channel_init_event_ex(LPVOID lpUserParam, LPV
 /* rail is always built-in */
 #define VirtualChannelEntryEx rail_VirtualChannelEntryEx
 
-BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS pEntryPoints, PVOID pInitHandle)
+FREERDP_ENTRY_POINT(BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS pEntryPoints,
+                                                         PVOID pInitHandle))
 {
 	UINT rc;
 	railPlugin* rail;

--- a/channels/rdp2tcp/client/rdp2tcp_main.c
+++ b/channels/rdp2tcp/client/rdp2tcp_main.c
@@ -321,7 +321,8 @@ static VOID VCAPITYPE VirtualChannelInitEventEx(LPVOID lpUserParam, LPVOID pInit
 #else
 #define VirtualChannelEntryEx FREERDP_API VirtualChannelEntryEx
 #endif
-BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS pEntryPoints, PVOID pInitHandle)
+FREERDP_ENTRY_POINT(BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS pEntryPoints,
+                                                         PVOID pInitHandle))
 {
 	CHANNEL_ENTRY_POINTS_FREERDP_EX* pEntryPointsEx;
 	CHANNEL_DEF channelDef;

--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -2155,7 +2155,8 @@ static VOID VCAPITYPE rdpdr_virtual_channel_init_event_ex(LPVOID lpUserParam, LP
 #define TAG CHANNELS_TAG("rdpdr.client")
 #define VirtualChannelEntryEx rdpdr_VirtualChannelEntryEx
 
-BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS pEntryPoints, PVOID pInitHandle)
+FREERDP_ENTRY_POINT(BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS pEntryPoints,
+                                                         PVOID pInitHandle))
 {
 	UINT rc;
 	rdpdrPlugin* rdpdr;

--- a/channels/rdpei/client/rdpei_main.c
+++ b/channels/rdpei/client/rdpei_main.c
@@ -1471,7 +1471,7 @@ static const IWTSVirtualChannelCallback geometry_callbacks = { rdpei_on_data_rec
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT rdpei_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
+FREERDP_ENTRY_POINT(UINT rdpei_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints))
 {
 	return freerdp_generic_DVCPluginEntry(pEntryPoints, TAG, RDPEI_DVC_CHANNEL_NAME,
 	                                      sizeof(RDPEI_PLUGIN), sizeof(GENERIC_CHANNEL_CALLBACK),

--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -2403,7 +2403,7 @@ static const IWTSVirtualChannelCallback rdpgfx_callbacks = { rdpgfx_on_data_rece
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT rdpgfx_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
+FREERDP_ENTRY_POINT(UINT rdpgfx_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints))
 {
 	return freerdp_generic_DVCPluginEntry(pEntryPoints, TAG, RDPGFX_DVC_CHANNEL_NAME,
 	                                      sizeof(RDPGFX_PLUGIN), sizeof(GENERIC_CHANNEL_CALLBACK),

--- a/channels/rdpsnd/client/alsa/rdpsnd_alsa.c
+++ b/channels/rdpsnd/client/alsa/rdpsnd_alsa.c
@@ -515,7 +515,8 @@ static UINT rdpsnd_alsa_parse_addin_args(rdpsndDevicePlugin* device, const ADDIN
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT alsa_freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT alsa_freerdp_rdpsnd_client_subsystem_entry(
+    PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	const ADDIN_ARGV* args;
 	rdpsndAlsaPlugin* alsa;

--- a/channels/rdpsnd/client/fake/rdpsnd_fake.c
+++ b/channels/rdpsnd/client/fake/rdpsnd_fake.c
@@ -109,7 +109,8 @@ static UINT rdpsnd_fake_parse_addin_args(rdpsndFakePlugin* fake, const ADDIN_ARG
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT fake_freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT fake_freerdp_rdpsnd_client_subsystem_entry(
+    PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	const ADDIN_ARGV* args;
 	rdpsndFakePlugin* fake;

--- a/channels/rdpsnd/client/ios/rdpsnd_ios.c
+++ b/channels/rdpsnd/client/ios/rdpsnd_ios.c
@@ -264,7 +264,8 @@ static void rdpsnd_ios_free(rdpsndDevicePlugin* device)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT ios_freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT ios_freerdp_rdpsnd_client_subsystem_entry(
+    PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	rdpsndIOSPlugin* p = (rdpsndIOSPlugin*)calloc(1, sizeof(rdpsndIOSPlugin));
 

--- a/channels/rdpsnd/client/mac/rdpsnd_mac.m
+++ b/channels/rdpsnd/client/mac/rdpsnd_mac.m
@@ -382,7 +382,8 @@ static UINT rdpsnd_mac_play(rdpsndDevicePlugin *device, const BYTE *data, size_t
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT mac_freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT mac_freerdp_rdpsnd_client_subsystem_entry(
+    PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	rdpsndMacPlugin *mac;
 	mac = (rdpsndMacPlugin *)calloc(1, sizeof(rdpsndMacPlugin));

--- a/channels/rdpsnd/client/opensles/rdpsnd_opensles.c
+++ b/channels/rdpsnd/client/opensles/rdpsnd_opensles.c
@@ -332,8 +332,8 @@ static int rdpsnd_opensles_parse_addin_args(rdpsndDevicePlugin* device, ADDIN_AR
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT opensles_freerdp_rdpsnd_client_subsystem_entry(
-    PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT opensles_freerdp_rdpsnd_client_subsystem_entry(
+    PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	ADDIN_ARGV* args;
 	rdpsndopenslesPlugin* opensles;

--- a/channels/rdpsnd/client/oss/rdpsnd_oss.c
+++ b/channels/rdpsnd/client/oss/rdpsnd_oss.c
@@ -441,7 +441,8 @@ static int rdpsnd_oss_parse_addin_args(rdpsndDevicePlugin* device, const ADDIN_A
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT oss_freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT oss_freerdp_rdpsnd_client_subsystem_entry(
+    PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	const ADDIN_ARGV* args;
 	rdpsndOssPlugin* oss = (rdpsndOssPlugin*)calloc(1, sizeof(rdpsndOssPlugin));

--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -631,7 +631,8 @@ static UINT rdpsnd_pulse_parse_addin_args(rdpsndDevicePlugin* device, const ADDI
 	return CHANNEL_RC_OK;
 }
 
-UINT pulse_freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT pulse_freerdp_rdpsnd_client_subsystem_entry(
+    PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	const ADDIN_ARGV* args;
 	rdpsndPulsePlugin* pulse;

--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -1550,7 +1550,8 @@ fail:
 	return NULL;
 }
 /* rdpsnd is always built-in */
-BOOL VCAPITYPE rdpsnd_VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS pEntryPoints, PVOID pInitHandle)
+FREERDP_ENTRY_POINT(BOOL VCAPITYPE rdpsnd_VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS pEntryPoints,
+                                                                PVOID pInitHandle))
 {
 	UINT rc;
 	rdpsndPlugin* rdpsnd;
@@ -1769,7 +1770,7 @@ static UINT rdpsnd_plugin_terminated(IWTSPlugin* pPlugin)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT rdpsnd_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
+FREERDP_ENTRY_POINT(UINT rdpsnd_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints))
 {
 	UINT error = CHANNEL_RC_OK;
 	rdpsndPlugin* rdpsnd;

--- a/channels/rdpsnd/client/sndio/rdpsnd_sndio.c
+++ b/channels/rdpsnd/client/sndio/rdpsnd_sndio.c
@@ -179,7 +179,8 @@ static UINT rdpsnd_sndio_parse_addin_args(rdpsndDevicePlugin* device, ADDIN_ARGV
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT sndio_freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT sndio_freerdp_rdpsnd_client_subsystem_entry(
+    PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	ADDIN_ARGV* args;
 	rdpsndSndioPlugin* sndio;

--- a/channels/rdpsnd/client/winmm/rdpsnd_winmm.c
+++ b/channels/rdpsnd/client/winmm/rdpsnd_winmm.c
@@ -313,7 +313,8 @@ static void rdpsnd_winmm_parse_addin_args(rdpsndDevicePlugin* device, const ADDI
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT winmm_freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT winmm_freerdp_rdpsnd_client_subsystem_entry(
+    PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints))
 {
 	const ADDIN_ARGV* args;
 	rdpsndWinmmPlugin* winmm;

--- a/channels/remdesk/client/remdesk_main.c
+++ b/channels/remdesk/client/remdesk_main.c
@@ -1040,7 +1040,8 @@ static VOID VCAPITYPE remdesk_virtual_channel_init_event_ex(LPVOID lpUserParam, 
 /* remdesk is always built-in */
 #define VirtualChannelEntryEx remdesk_VirtualChannelEntryEx
 
-BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS pEntryPoints, PVOID pInitHandle)
+FREERDP_ENTRY_POINT(BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS pEntryPoints,
+                                                         PVOID pInitHandle))
 {
 	UINT rc;
 	remdeskPlugin* remdesk;

--- a/channels/serial/client/serial_main.c
+++ b/channels/serial/client/serial_main.c
@@ -813,7 +813,7 @@ static void serial_message_free(void* obj)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT serial_DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT serial_DeviceServiceEntry(PDEVICE_SERVICE_ENTRY_POINTS pEntryPoints))
 {
 	char* name;
 	char* path;

--- a/channels/sshagent/client/sshagent_main.c
+++ b/channels/sshagent/client/sshagent_main.c
@@ -345,7 +345,7 @@ static UINT sshagent_plugin_terminated(IWTSPlugin* pPlugin)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT sshagent_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
+FREERDP_ENTRY_POINT(UINT sshagent_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints))
 {
 	UINT status = CHANNEL_RC_OK;
 	SSHAGENT_PLUGIN* sshagent;

--- a/channels/tsmf/client/alsa/tsmf_alsa.c
+++ b/channels/tsmf/client/alsa/tsmf_alsa.c
@@ -224,7 +224,7 @@ static void tsmf_alsa_free(ITSMFAudioDevice* audio)
 	free(alsa);
 }
 
-ITSMFAudioDevice* alsa_freerdp_tsmf_client_audio_subsystem_entry(void)
+FREERDP_ENTRY_POINT(ITSMFAudioDevice* alsa_freerdp_tsmf_client_audio_subsystem_entry(void))
 {
 	TSMFAlsaAudioDevice* alsa = calloc(1, sizeof(TSMFAlsaAudioDevice));
 	if (!alsa)

--- a/channels/tsmf/client/ffmpeg/tsmf_ffmpeg.c
+++ b/channels/tsmf/client/ffmpeg/tsmf_ffmpeg.c
@@ -650,7 +650,7 @@ static BOOL CALLBACK InitializeAvCodecs(PINIT_ONCE once, PVOID param, PVOID* con
 	return TRUE;
 }
 
-ITSMFDecoder* ffmpeg_freerdp_tsmf_client_decoder_subsystem_entry(void)
+FREERDP_ENTRY_POINT(ITSMFDecoder* ffmpeg_freerdp_tsmf_client_decoder_subsystem_entry(void))
 {
 	TSMFFFmpegDecoder* decoder;
 	InitOnceExecuteOnce(&g_Initialized, InitializeAvCodecs, NULL, NULL);

--- a/channels/tsmf/client/gstreamer/tsmf_gstreamer.c
+++ b/channels/tsmf/client/gstreamer/tsmf_gstreamer.c
@@ -1009,7 +1009,7 @@ static BOOL tsmf_gstreamer_sync(ITSMFDecoder* decoder, void (*cb)(void*), void* 
 	return TRUE;
 }
 
-ITSMFDecoder* gstreamer_freerdp_tsmf_client_decoder_subsystem_entry(void)
+FREERDP_ENTRY_POINT(ITSMFDecoder* gstreamer_freerdp_tsmf_client_decoder_subsystem_entry(void))
 {
 	TSMFGstreamerDecoder* decoder;
 

--- a/channels/tsmf/client/oss/tsmf_oss.c
+++ b/channels/tsmf/client/oss/tsmf_oss.c
@@ -230,7 +230,7 @@ static void tsmf_oss_free(ITSMFAudioDevice* audio)
 	free(oss);
 }
 
-ITSMFAudioDevice* oss_freerdp_tsmf_client_audio_subsystem_entry(void)
+FREERDP_ENTRY_POINT(ITSMFAudioDevice* oss_freerdp_tsmf_client_audio_subsystem_entry(void))
 {
 	TSMFOssAudioDevice* oss = calloc(1, sizeof(TSMFOssAudioDevice));
 	if (!oss)

--- a/channels/tsmf/client/pulse/tsmf_pulse.c
+++ b/channels/tsmf/client/pulse/tsmf_pulse.c
@@ -398,7 +398,7 @@ static void tsmf_pulse_free(ITSMFAudioDevice* audio)
 	free(pulse);
 }
 
-ITSMFAudioDevice* pulse_freerdp_tsmf_client_audio_subsystem_entry(void)
+FREERDP_ENTRY_POINT(ITSMFAudioDevice* pulse_freerdp_tsmf_client_audio_subsystem_entry(void))
 {
 	TSMFPulseAudioDevice* pulse;
 	pulse = (TSMFPulseAudioDevice*)calloc(1, sizeof(TSMFPulseAudioDevice));

--- a/channels/tsmf/client/tsmf_main.c
+++ b/channels/tsmf/client/tsmf_main.c
@@ -552,7 +552,7 @@ static UINT tsmf_process_addin_args(IWTSPlugin* pPlugin, const ADDIN_ARGV* args)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT tsmf_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
+FREERDP_ENTRY_POINT(UINT tsmf_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints))
 {
 	UINT status = 0;
 	TSMF_PLUGIN* tsmf;

--- a/channels/urbdrc/client/libusb/libusb_udevman.c
+++ b/channels/urbdrc/client/libusb/libusb_udevman.c
@@ -895,7 +895,8 @@ static DWORD WINAPI poll_thread(LPVOID lpThreadParameter)
 	return 0;
 }
 
-UINT libusb_freerdp_urbdrc_client_subsystem_entry(PFREERDP_URBDRC_SERVICE_ENTRY_POINTS pEntryPoints)
+FREERDP_ENTRY_POINT(UINT libusb_freerdp_urbdrc_client_subsystem_entry(
+    PFREERDP_URBDRC_SERVICE_ENTRY_POINTS pEntryPoints))
 {
 	wObject* obj;
 	UINT rc;

--- a/channels/urbdrc/client/urbdrc_main.c
+++ b/channels/urbdrc/client/urbdrc_main.c
@@ -946,7 +946,7 @@ BOOL del_device(IUDEVMAN* idevman, UINT32 flags, BYTE busnum, BYTE devnum, UINT1
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT urbdrc_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
+FREERDP_ENTRY_POINT(UINT urbdrc_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints))
 {
 	UINT status = 0;
 	const ADDIN_ARGV* args;

--- a/channels/video/client/video_main.c
+++ b/channels/video/client/video_main.c
@@ -1165,7 +1165,7 @@ static UINT video_plugin_terminated(IWTSPlugin* pPlugin)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT video_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
+FREERDP_ENTRY_POINT(UINT video_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints))
 {
 	UINT error = CHANNEL_RC_OK;
 	VIDEO_PLUGIN* videoPlugin;

--- a/client/SDL/aad/wrapper/webview_impl.cpp
+++ b/client/SDL/aad/wrapper/webview_impl.cpp
@@ -27,7 +27,7 @@
 #include <sstream>
 #include "../webview_impl.hpp"
 
-std::vector<std::string> split(const std::string& input, const std::string& regex)
+static std::vector<std::string> split(const std::string& input, const std::string& regex)
 {
 	// passing -1 as the submatch index parameter performs splitting
 	std::regex re(regex);
@@ -35,7 +35,7 @@ std::vector<std::string> split(const std::string& input, const std::string& rege
 	return { first, last };
 }
 
-std::map<std::string, std::string> urlsplit(const std::string& url)
+static std::map<std::string, std::string> urlsplit(const std::string& url)
 {
 	auto pos = url.find("?");
 	if (pos == std::string::npos)

--- a/client/SDL/dialogs/font/convert_font_to_c.cpp
+++ b/client/SDL/dialogs/font/convert_font_to_c.cpp
@@ -66,7 +66,7 @@ static int read(FILE* out, const char* font, const char* outname)
 			if (!first)
 				fprintf(out, ",");
 			first = 0;
-			fprintf(out, "0x%02" PRIx8, buffer[x] & 0xFF);
+			fprintf(out, "0x%02x", buffer[x] & 0xFF);
 			if ((x % (LINEWIDTH / 5)) == 0)
 				fprintf(out, "\n");
 		}

--- a/include/freerdp/api.h
+++ b/include/freerdp/api.h
@@ -24,6 +24,13 @@
 #include <winpr/wlog.h>
 #include <winpr/platform.h>
 
+/* To silence missing prototype warnings for library entry points use this macro.
+ * It first declares the function as prototype and then again as function implementation
+ */
+#define FREERDP_ENTRY_POINT(fkt) \
+	fkt;                         \
+	fkt
+
 #ifdef _WIN32
 #define FREERDP_CC __cdecl
 #else

--- a/libfreerdp/core/aad.c
+++ b/libfreerdp/core/aad.c
@@ -209,23 +209,20 @@ cJSON* cJSON_ParseWithLength(const char* value, size_t buffer_length)
 
 static INLINE const char* aad_auth_result_to_string(DWORD code)
 {
-#define ERROR_CASE(x) \
-	case (x):         \
+#define ERROR_CASE(cd, x) \
+	if (cd == (x))        \
 		return #x;
-	switch (code)
-	{
-		ERROR_CASE(S_OK)
-		ERROR_CASE(SEC_E_INVALID_TOKEN)
-		ERROR_CASE(E_ACCESSDENIED)
-		ERROR_CASE(STATUS_LOGON_FAILURE)
-		ERROR_CASE(STATUS_NO_LOGON_SERVERS)
-		ERROR_CASE(STATUS_INVALID_LOGON_HOURS)
-		ERROR_CASE(STATUS_INVALID_WORKSTATION)
-		ERROR_CASE(STATUS_PASSWORD_EXPIRED)
-		ERROR_CASE(STATUS_ACCOUNT_DISABLED)
-		default:
-			return "Unknown error";
-	}
+
+	ERROR_CASE(code, S_OK)
+	ERROR_CASE(code, SEC_E_INVALID_TOKEN)
+	ERROR_CASE(code, E_ACCESSDENIED)
+	ERROR_CASE(code, STATUS_LOGON_FAILURE)
+	ERROR_CASE(code, STATUS_NO_LOGON_SERVERS)
+	ERROR_CASE(code, STATUS_INVALID_LOGON_HOURS)
+	ERROR_CASE(code, STATUS_INVALID_WORKSTATION)
+	ERROR_CASE(code, STATUS_PASSWORD_EXPIRED)
+	ERROR_CASE(code, STATUS_ACCOUNT_DISABLED)
+	return "Unknown error";
 }
 
 static BOOL aad_get_nonce(rdpAad* aad)

--- a/libfreerdp/core/gateway/wst.c
+++ b/libfreerdp/core/gateway/wst.c
@@ -378,7 +378,7 @@ static BOOL wst_handle_ok_or_forbidden(rdpWst* wst, HttpResponse** ppresponse, D
 		{
 			char* urlWithAuth = NULL;
 			size_t urlLen = 0;
-			char firstParam = (strchr(wst->gwpath, '?') > 0 ? '&' : '?');
+			char firstParam = (strchr(wst->gwpath, '?') != NULL) ? '&' : '?';
 			winpr_asprintf(
 			    &urlWithAuth, &urlLen, arm_query_param, wst->gwpath, firstParam,
 			    freerdp_settings_get_string(wst->settings, FreeRDP_GatewayHttpExtAuthBearer));

--- a/libfreerdp/emu/scard/smartcard_emulate.c
+++ b/libfreerdp/emu/scard/smartcard_emulate.c
@@ -2252,7 +2252,7 @@ LONG WINAPI Emulate_SCardReadCacheW(SmartcardEmulationContext* smartcard, SCARDC
 	return status;
 }
 
-static BOOL insert_data(wHashTable* table, DWORD FreshnessCounter, const void* key,
+static LONG insert_data(wHashTable* table, DWORD FreshnessCounter, const void* key,
                         const PBYTE Data, DWORD DataLen)
 {
 	BOOL rc;

--- a/server/shadow/X11/x11_shadow.c
+++ b/server/shadow/X11/x11_shadow.c
@@ -1483,12 +1483,12 @@ static void x11_shadow_subsystem_free(rdpShadowSubsystem* subsystem)
 	free(subsystem);
 }
 
-FREERDP_API const char* ShadowSubsystemName(void)
+FREERDP_ENTRY_POINT(FREERDP_API const char* ShadowSubsystemName(void))
 {
 	return "X11";
 }
 
-FREERDP_API int ShadowSubsystemEntry(RDP_SHADOW_ENTRY_POINTS* pEntryPoints)
+FREERDP_ENTRY_POINT(FREERDP_API int ShadowSubsystemEntry(RDP_SHADOW_ENTRY_POINTS* pEntryPoints))
 {
 	if (!pEntryPoints)
 		return -1;


### PR DESCRIPTION
C requires prototypes or compilers will complain about them missing. Our library entry points do not have such, therefore add the macro FREERDP_ENTRY_POINT which declares the function prototype automatically before the function.

fixes all `-Wmissing-prototypes` warnings from known false positives.