### PR TITLE
[codec,progressive] expose progressive simple

### DIFF
--- a/include/freerdp/codec/progressive.h
+++ b/include/freerdp/codec/progressive.h
@@ -62,6 +62,9 @@ extern "C"
 	                                                            UINT32 ThreadingFlags);
 	FREERDP_API void progressive_context_free(PROGRESSIVE_CONTEXT* progressive);
 
+	FREERDP_API BOOL progressive_rfx_write_message_progressive_simple(
+	    PROGRESSIVE_CONTEXT* progressive, wStream* s, const RFX_MESSAGE* msg);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -2640,8 +2640,8 @@ fail:
 	return rc;
 }
 
-static BOOL progressive_rfx_write_message_progressive_simple(PROGRESSIVE_CONTEXT* progressive,
-                                                             wStream* s, const RFX_MESSAGE* msg)
+BOOL progressive_rfx_write_message_progressive_simple(PROGRESSIVE_CONTEXT* progressive, wStream* s,
+                                                      const RFX_MESSAGE* msg)
 {
 	RFX_CONTEXT* context;
 


### PR DESCRIPTION
server implementations might require serializing messages to a simple tile, so expose this function.
