### PR TITLE
Fixes clang error

### DIFF
--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -598,7 +598,7 @@ static void wlf_client_free(freerdp* instance, rdpContext* context)
 	DeleteCriticalSection(&wlf->critical);
 }
 
-static void* uwac_event_clone(const void* val)
+static void* uwac_event_clone(void* val)
 {
 	UwacEvent* copy;
 	const UwacEvent* ev = (const UwacEvent*)val;


### PR DESCRIPTION
error: incompatible function pointer types assigning to 'OBJECT_NEW_FN' (aka 'void *(*)(void *)') from 'void *(const void *)' [-Wincompatible-function-pointer-types]
|         obj->fnObjectNew = uwac_event_clone;
|                          ^ ~~~~~~~~~~~~~~~~

When using clang, an error occured due to type mismatch.