### PR TITLE
[drdynvc] improvements of server-side DRDYNVC

### DIFF
--- a/libfreerdp/core/server.h
+++ b/libfreerdp/core/server.h
@@ -82,6 +82,7 @@ struct WTSVirtualChannelManager
 	rdpPeerChannel* drdynvc_channel;
 	BYTE drdynvc_state;
 	LONG dvc_channel_id_seq;
+	UINT16 dvc_spoken_version;
 
 	psDVCCreationStatusCallback dvc_creation_status;
 	void* dvc_creation_status_userdata;


### PR DESCRIPTION
This patch prepares the reading of the dynamic channel version so that next we can take in account this to take advantage of advanced features in last versions (compressions or priorities).
The patch also implement notifying the VCM event when the dynamic channel becomes ready so that users of FreeRDP can just do calls to `WTSVirtualChannelManagerGetDrdynvcState` when the channel event is set (no blind calls).
