### PR TITLE
[tests] disable TestSynchMultipleThreads

### DIFF
--- a/winpr/libwinpr/synch/test/CMakeLists.txt
+++ b/winpr/libwinpr/synch/test/CMakeLists.txt
@@ -12,7 +12,7 @@ set(${MODULE_PREFIX}_TESTS
 	TestSynchCritical.c
 	TestSynchSemaphore.c
 	TestSynchThread.c
-	TestSynchMultipleThreads.c
+    #	TestSynchMultipleThreads.c
 	TestSynchTimerQueue.c
 	TestSynchWaitableTimer.c
 	TestSynchWaitableTimerAPC.c


### PR DESCRIPTION
the test is buggy as the native implementation on windows often segfaults.
