### PR TITLE
Option to suppress sending windows key to remote host.

### DIFF
--- a/client/Wayland/wlf_input.c
+++ b/client/Wayland/wlf_input.c
@@ -340,6 +340,10 @@ BOOL wlf_handle_key(freerdp* instance, const UwacKeyEvent* ev)
 	if (rdp_scancode == RDP_SCANCODE_UNKNOWN)
 		return TRUE;
 
+	if (( rdp_scancode == RDP_SCANCODE_LWIN || rdp_scancode == RDP_SCANCODE_RWIN ) &&
+		instance->context->settings->SuppressWinKey )
+		return TRUE;
+
 	return freerdp_input_send_keyboard_event_ex(input, ev->pressed, ev->repeated, rdp_scancode);
 }
 

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -548,6 +548,12 @@ BOOL xf_keyboard_handle_special_keys(xfContext* xfc, KeySym keysym)
 	XF_MODIFIER_KEYS mod = { 0 };
 	xk_keyboard_get_modifier_keys(xfc, &mod);
 
+	if ((keysym == XK_Super_L || keysym == XK_Super_R) &&
+		xfc->common.context.settings->SuppressWinKey)
+	{
+		return TRUE;
+	}
+
 	// remember state of RightCtrl to ungrab keyboard if next action is release of RightCtrl
 	// do not return anything such that the key could be used by client if ungrab is not the goal
 	if (keysym == XK_Control_R)

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -4083,6 +4083,10 @@ static int freerdp_client_settings_parse_command_line_arguments_int(rdpSettings*
 		{
 			settings->GrabMouse = enable;
 		}
+		CommandLineSwitchCase(arg, "suppress-win-key")
+		{
+			settings->SuppressWinKey = enable;
+		}
 		CommandLineSwitchCase(arg, "mouse-relative")
 		{
 			settings->MouseUseRelativeMove = enable;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -435,6 +435,7 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "SSH Agent forwarding channel" },
 	{ "sspi-module", COMMAND_LINE_VALUE_REQUIRED, "<SSPI module path>", NULL, NULL, -1, NULL,
 	  "SSPI shared library module file path" },
+	{ "suppress-win-key", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL, "suppress win key" },
 	{ "winscard-module", COMMAND_LINE_VALUE_REQUIRED, "<WinSCard module path>", NULL, NULL, -1,
 	  NULL, "WinSCard shared library module file path" },
 	{ "disable-output", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL,

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -856,6 +856,7 @@ extern "C"
 #define FreeRDP_HasExtendedMouseEvent (2635)
 #define FreeRDP_SuspendInput (2636)
 #define FreeRDP_KeyboardPipeName (2637)
+#define FreeRDP_SuppressWinKey (2638)
 #define FreeRDP_BrushSupportLevel (2688)
 #define FreeRDP_GlyphSupportLevel (2752)
 #define FreeRDP_GlyphCache (2753)
@@ -1485,7 +1486,8 @@ extern "C"
 		 */
 		ALIGN64 BOOL SuspendInput;       /* 2636 */
 		ALIGN64 char* KeyboardPipeName;  /* 2637 */
-		UINT64 padding2688[2688 - 2638]; /* 2638 */
+		ALIGN64 BOOL SuppressWinKey;     /* 2638 */
+		UINT64 padding2688[2688 - 2639]; /* 2639 */
 
 		/* Brush Capabilities */
 		ALIGN64 UINT32 BrushSupportLevel; /* 2688 */

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -552,6 +552,9 @@ BOOL freerdp_settings_get_bool(const rdpSettings* settings, size_t id)
 		case FreeRDP_SuppressOutput:
 			return settings->SuppressOutput;
 
+		case FreeRDP_SuppressWinKey:
+			return settings->SuppressWinKey;
+
 		case FreeRDP_SurfaceCommandsEnabled:
 			return settings->SurfaceCommandsEnabled;
 
@@ -1287,6 +1290,10 @@ BOOL freerdp_settings_set_bool(rdpSettings* settings, size_t id, BOOL val)
 
 		case FreeRDP_SuppressOutput:
 			settings->SuppressOutput = cnv.c;
+			break;
+
+		case FreeRDP_SuppressWinKey:
+			settings->SuppressWinKey = cnv.c;
 			break;
 
 		case FreeRDP_SurfaceCommandsEnabled:

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -229,6 +229,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_SupportStatusInfoPdu, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_SupportStatusInfoPdu" },
 	{ FreeRDP_SupportVideoOptimized, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_SupportVideoOptimized" },
 	{ FreeRDP_SuppressOutput, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_SuppressOutput" },
+	{ FreeRDP_SuppressWinKey, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_SuppressWinKey" },
 	{ FreeRDP_SurfaceCommandsEnabled, FREERDP_SETTINGS_TYPE_BOOL,
 	  "FreeRDP_SurfaceCommandsEnabled" },
 	{ FreeRDP_SurfaceFrameMarkerEnabled, FREERDP_SETTINGS_TYPE_BOOL,

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -168,6 +168,7 @@ static const size_t bool_list_indices[] = {
 	FreeRDP_SupportStatusInfoPdu,
 	FreeRDP_SupportVideoOptimized,
 	FreeRDP_SuppressOutput,
+	FreeRDP_SuppressWinKey,
 	FreeRDP_SurfaceCommandsEnabled,
 	FreeRDP_SurfaceFrameMarkerEnabled,
 	FreeRDP_SuspendInput,


### PR DESCRIPTION
Currently implemented only for X11 and wayland clients

This patch provides an option that allows the "Windows Logo" key (aka Super or Mod4) to be used on the local host without opening the start menu on a remote windows machine.

This can be tested by connecting to a remote windows machine and confirming the start menu does not open when the Windows logo key is pressed.