### PR TITLE
Advertise Image RFX GUID rather than RFX GUID when rfx-mode:image

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3739,7 +3739,10 @@ static int freerdp_client_settings_parse_command_line_arguments_int(rdpSettings*
 			if (option_equals(arg->Value, "video"))
 				settings->RemoteFxCodecMode = 0x00;
 			else if (option_equals(arg->Value, "image"))
+			{
+				settings->RemoteFxImageCodec = TRUE;
 				settings->RemoteFxCodecMode = 0x02;
+			}
 		}
 		CommandLineSwitchCase(arg, "frame-ack")
 		{


### PR DESCRIPTION
Hi, 

While I'm implementing Image Remote FX on xrdp, I found an issue that seems like a FreeRDP bug. 

FreeRDP sends CODEC_GUID_REMOTEFX when `/rfx /rfx-mode:image`. As far as I understand, client should send CODEC_GUID_IMAGE_REMOTEFX rather than CODEC_GUID_REMOTEFX in that case. 

There're some codes to send CODEC_GUID_IMAGE_REMOTEFX however they're not kicked even `/rfx-mode:image` is specified in command line options. My change is quite simple to kick them.

https://github.com/FreeRDP/FreeRDP/blob/2e7f3877834b06ab6893e363bf632fc1a1234314/libfreerdp/core/capabilities.c#L3343-L3344
https://github.com/FreeRDP/FreeRDP/blob/2e7f3877834b06ab6893e363bf632fc1a1234314/libfreerdp/core/capabilities.c#L3412-L3430

See also [MS-RDPBCGR] 2.2.7.2.10.1.1 Bitmap Codec (TS_BITMAPCODEC)
https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/86507fed-a0ee-4242-b802-237534a8f65e