### PR TITLE
locale: Fix X11 keyboard layout detection

### DIFF
--- a/libfreerdp/locale/keyboard_x11.c
+++ b/libfreerdp/locale/keyboard_x11.c
@@ -58,8 +58,14 @@ static BOOL parse_xkb_rule_names(char* xkb_rule, unsigned long num_bytes, char**
 			case 1: // model
 				break;
 			case 2: // layout
+			{
+				/* If multiple languages are present we just take the first one */
+				char* delimiter = strchr(ptr, ',');
+				if (delimiter)
+					*delimiter = '\0';
 				*layout = ptr;
 				break;
+			}
 			case 3: // variant
 				*variant = ptr;
 				break;


### PR DESCRIPTION
This fixes an issue with keyboard layout detection reintroduced in #8960

The problem has already been fixed in #6688 but got lost after refactoring.

The issue is that the layout specifier might be a comma separated list with country specifiers i.e. `"at,us"` which was not correctly handled.
