### PR TITLE
[server,drdynvc] use a hashtable for dynamic channels instead of an arraylist

### DIFF
--- a/libfreerdp/core/server.h
+++ b/libfreerdp/core/server.h
@@ -87,7 +87,7 @@ struct WTSVirtualChannelManager
 	psDVCCreationStatusCallback dvc_creation_status;
 	void* dvc_creation_status_userdata;
 
-	wArrayList* dynamicVirtualChannels;
+	wHashTable* dynamicVirtualChannels;
 };
 
 FREERDP_LOCAL BOOL WINAPI FreeRDP_WTSStartRemoteControlSessionW(LPWSTR pTargetServerName,


### PR DESCRIPTION
This speeds up all operations around dynamic channels.
