### PR TITLE
[android] Fix signing configuration via  release.properties file

### DIFF
--- a/client/Android/Studio/.gitignore
+++ b/client/Android/Studio/.gitignore
@@ -15,6 +15,9 @@ gen/
 # Local configuration file (sdk path, etc)
 local.properties
 
+# Local release signing configuration file
+release.properties
+
 # Windows thumbnail db
 Thumbs.db
 

--- a/client/Android/Studio/build.gradle
+++ b/client/Android/Studio/build.gradle
@@ -1,21 +1,25 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-Properties properties = new Properties()
+Properties releaseProperties = new Properties()
 File file = new File('release.properties')
 if (file.canRead()) {
-    properties.load(new FileInputStream(file))
+    releaseProperties.load(new FileInputStream(file))
 }
    
 if (!hasProperty('RELEASE_STORE_FILE')) {
-    ext.RELEASE_STORE_FILE='nokeyfile'
+    ext.RELEASE_STORE_FILE=releaseProperties['RELEASE_STORE_FILE']
 }
 if (!hasProperty('RELEASE_KEY_ALIAS')) {
-    ext.RELEASE_KEY_ALIAS=''
+    ext.RELEASE_KEY_ALIAS=releaseProperties['RELEASE_KEY_ALIAS']
 }
 if (!hasProperty('RELEASE_KEY_ALIAS')) {
-    ext.RELEASE_KEY_ALIAS=''
+    ext.RELEASE_KEY_ALIAS=releaseProperties['RELEASE_KEY_ALIAS']
 }
 if (!hasProperty('RELEASE_KEY_PASSWORD')) {
-    ext.RELEASE_KEY_PASSWORD=''
+    ext.RELEASE_KEY_PASSWORD=releaseProperties['RELEASE_KEY_PASSWORD']
+}
+
+if (!hasProperty('RELEASE_STORE_PASSWORD')) {
+    ext.RELEASE_STORE_PASSWORD=releaseProperties['RELEASE_STORE_PASSWORD']
 }
 
 ext {


### PR DESCRIPTION
When I try to build [Studio](https://github.com/FreeRDP/FreeRDP/tree/master/client/Android/Studio) project as is I get an error from gradle:
```
A problem occurred evaluating project ':aFreeRDP'.
> Could not get unknown property 'RELEASE_STORE_PASSWORD' for SigningConfig$AgpDecorated_Decorated ...
```
From these [lines](https://github.com/FreeRDP/FreeRDP/blob/a41360e3b083b727edee6546270c9fd423c35e63/client/Android/Studio/build.gradle#L1-L19) all signing parameters are supposed to be set in release.properties file. But even if this file presented and contains all needed values it goes nowhere. I fixed the code to actually get values from file and populate them to aFreeRDP package.