### PR TITLE
SDL: Fix stored window offset for multimon

### DIFF
--- a/client/SDL/sdl_freerdp.cpp
+++ b/client/SDL/sdl_freerdp.cpp
@@ -644,8 +644,6 @@ static BOOL sdl_create_windows(SdlContext* sdl)
 		if (settings->UseMultimon)
 		{
 			flags |= SDL_WINDOW_BORDERLESS;
-			window.offset_x = 0 - startupX;
-			window.offset_y = 0 - startupY;
 		}
 		else
 		{
@@ -657,6 +655,16 @@ static BOOL sdl_create_windows(SdlContext* sdl)
 		                                 static_cast<int>(h), flags);
 		if (!window.window)
 			goto fail;
+
+		if (settings->UseMultimon)
+		{
+			int win_x;
+			int win_y;
+			SDL_GetWindowPosition(window.window, &win_x, &win_y);
+			window.offset_x = 0 - win_x;
+			window.offset_y = 0 - win_y;
+		}
+
 		sdl->windows.push_back(window);
 	}
 


### PR DESCRIPTION
Previously `SDL_WINDOWPOS_CENTERED_DISPLAY` was being stored in the `sdl_window_t` struct when multimonitor support was enabled, but the offset fields are expected to contain pixel values whereas this macro returns a magic value. This was causing issues when the values were evntually passed to `SDL_BlitSurface` and resulting in a black screen. With this change, each screen renders as expected.

This fixes #9441.