### PR TITLE
SDL: Fix primary monitor logic

### DIFF
--- a/client/SDL/sdl_monitor.cpp
+++ b/client/SDL/sdl_monitor.cpp
@@ -247,7 +247,7 @@ static BOOL sdl_apply_display_properties(SdlContext* sdl)
 		monitor->y = rect.y;
 		monitor->width = rect.w;
 		monitor->height = rect.h;
-		monitor->is_primary = (rect.x == 0) && (rect.y == 0);
+		monitor->is_primary = x == 0;
 		monitor->attributes.desktopScaleFactor = factor;
 		monitor->attributes.deviceScaleFactor = 100;
 		monitor->attributes.orientation = rdp_orientation;


### PR DESCRIPTION
Previously SDL was using the monitor positioned at the top-left of the desktop workspace, but this isn't necessarily the primary display. The doc for [`SDL_GetDisplayBounds`](https://wiki.libsdl.org/SDL2/SDL_GetDisplayBounds) indicates that the primary display is always given index 0, and on my system at least this seems to hold true under Plasma X11 and Wayland sessions. Granted, the doc also indicates that the primary display will always be located at 0,0, but as I mentioned before I don't think this makes any sense.

SDL 3 adds the [`SDL_GetPrimaryDisplay`](https://wiki.libsdl.org/SDL3/SDL_GetPrimaryDisplay) function which can replace this logic once FreeRDP is ported to it.