### PR TITLE
codec/audio: Add missing format id for Opus codec

### DIFF
--- a/include/freerdp/codec/audio.h
+++ b/include/freerdp/codec/audio.h
@@ -192,6 +192,8 @@ extern "C"
 #endif /* !WAVE_FORMAT_LUCENT_G723 */
 #define WAVE_FORMAT_AAC_MS 0xA106
 
+#define WAVE_FORMAT_OPUS 0x704F
+
 #define WAVE_FORMAT_EXTENSIBLE 0xFFFE
 
 	/**


### PR DESCRIPTION
```
Id taken from [0].

[0]: https://learn.microsoft.com/en-us/windows/win32/medfound/audio-subtype-guids
```