### PR TITLE
Clip select settings

### DIFF
--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -2250,9 +2250,12 @@ xfClipboard* xf_clipboard_new(xfContext* xfc, BOOL relieveFilenameRestriction)
 	clipboard->system = ClipboardCreate();
 	clipboard->requestedFormatId = -1;
 	clipboard->root_window = DefaultRootWindow(xfc->display);
-	selectionAtom = "CLIPBOARD";
-	if (xfc->common.context.settings->XSelectionAtom)
-		selectionAtom = xfc->common.context.settings->XSelectionAtom;
+
+	selectionAtom =
+	    freerdp_settings_get_string(xfc->common.context.settings, FreeRDP_ClipboardUseSelection);
+	if (!selectionAtom)
+		selectionAtom = "CLIPBOARD";
+
 	clipboard->clipboard_atom = XInternAtom(xfc->display, selectionAtom, FALSE);
 
 	if (clipboard->clipboard_atom == None)

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3477,7 +3477,8 @@ static int freerdp_client_settings_parse_command_line_arguments_int(rdpSettings*
 					if (option_starts_with(usesel, cur))
 					{
 						const char* val = &cur[strlen(usesel)];
-						if (!copy_value(val, &settings->XSelectionAtom))
+						if (!freerdp_settings_set_string(settings, FreeRDP_ClipboardUseSelection,
+						                                 val))
 							rc = COMMAND_LINE_ERROR_MEMORY;
 						settings->RedirectClipboard = TRUE;
 					}

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -1701,18 +1701,6 @@ extern "C"
 		 * The zone below this point is ABI unstable, and
 		 * is therefore potentially subject to ABI breakage.
 		 */
-
-		/*
-		 * Extensions
-		 */
-
-		/* Extensions */
-		ALIGN64 INT32 num_extensions;              /*  */
-		ALIGN64 struct rdp_ext_set extensions[16]; /*  */
-
-		ALIGN64 BYTE* SettingsModified; /* byte array marking fields that have been modified from
-		                                   their default value - currently UNUSED! */
-		ALIGN64 char* XSelectionAtom;
 	};
 	typedef struct rdp_settings rdpSettings;
 

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -924,6 +924,7 @@ extern "C"
 #define FreeRDP_PreferIPv6OverIPv4 (4674)
 #define FreeRDP_RedirectClipboard (4800)
 #define FreeRDP_ClipboardFeatureMask (4801)
+#define FreeRDP_ClipboardUseSelection (4802)
 #define FreeRDP_StaticChannelCount (4928)
 #define FreeRDP_StaticChannelArraySize (4929)
 #define FreeRDP_StaticChannelArray (4930)
@@ -1656,7 +1657,8 @@ extern "C"
 
 		ALIGN64 BOOL RedirectClipboard;      /* 4800 */
 		ALIGN64 UINT32 ClipboardFeatureMask; /* 4801 */
-		UINT64 padding4928[4928 - 4802];     /* 4802 */
+		ALIGN64 char* ClipboardUseSelection; /* 4802 */
+		UINT64 padding4928[4928 - 4803];     /* 4803 */
 
 		/**
 		 * Static Virtual Channels

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -2636,6 +2636,9 @@ const char* freerdp_settings_get_string(const rdpSettings* settings, size_t id)
 		case FreeRDP_ClientProductId:
 			return settings->ClientProductId;
 
+		case FreeRDP_ClipboardUseSelection:
+			return settings->ClipboardUseSelection;
+
 		case FreeRDP_ComputerName:
 			return settings->ComputerName;
 
@@ -2937,6 +2940,9 @@ char* freerdp_settings_get_string_writable(rdpSettings* settings, size_t id)
 
 		case FreeRDP_ClientProductId:
 			return settings->ClientProductId;
+
+		case FreeRDP_ClipboardUseSelection:
+			return settings->ClipboardUseSelection;
 
 		case FreeRDP_ComputerName:
 			return settings->ComputerName;
@@ -3248,6 +3254,9 @@ BOOL freerdp_settings_set_string_(rdpSettings* settings, size_t id, char* val, s
 
 		case FreeRDP_ClientProductId:
 			return update_string_(&settings->ClientProductId, cnv.c, len);
+
+		case FreeRDP_ClipboardUseSelection:
+			return update_string_(&settings->ClipboardUseSelection, cnv.c, len);
 
 		case FreeRDP_ComputerName:
 			return update_string_(&settings->ComputerName, cnv.c, len);
@@ -3575,6 +3584,9 @@ BOOL freerdp_settings_set_string_copy_(rdpSettings* settings, size_t id, const c
 
 		case FreeRDP_ClientProductId:
 			return update_string_copy_(&settings->ClientProductId, cnv.cc, len, cleanup);
+
+		case FreeRDP_ClipboardUseSelection:
+			return update_string_copy_(&settings->ClipboardUseSelection, cnv.cc, len, cleanup);
 
 		case FreeRDP_ComputerName:
 			return update_string_copy_(&settings->ComputerName, cnv.cc, len, cleanup);

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -450,6 +450,8 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_ClientDir, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_ClientDir" },
 	{ FreeRDP_ClientHostname, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_ClientHostname" },
 	{ FreeRDP_ClientProductId, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_ClientProductId" },
+	{ FreeRDP_ClipboardUseSelection, FREERDP_SETTINGS_TYPE_STRING,
+	  "FreeRDP_ClipboardUseSelection" },
 	{ FreeRDP_ComputerName, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_ComputerName" },
 	{ FreeRDP_ConfigPath, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_ConfigPath" },
 	{ FreeRDP_ConnectionFile, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_ConnectionFile" },

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -741,7 +741,6 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 
 	settings_load_hkey_local_machine(settings);
 
-	settings->XSelectionAtom = NULL;
 	if (!freerdp_settings_set_string(settings, FreeRDP_ActionScript, "~/.config/freerdp/action.sh"))
 		goto out_fail;
 	if (!freerdp_settings_set_bool(settings, FreeRDP_SmartcardLogon, FALSE))
@@ -790,9 +789,6 @@ static void freerdp_settings_free_internal(rdpSettings* settings)
 	freerdp_dynamic_channel_collection_free(settings);
 
 	freerdp_capability_buffer_free(settings);
-	/* Extensions */
-	free(settings->XSelectionAtom);
-	settings->XSelectionAtom = NULL;
 
 	/* Free all strings, set other pointers NULL */
 	freerdp_settings_free_keys(settings, TRUE);
@@ -1071,9 +1067,6 @@ static BOOL freerdp_settings_int_buffer_copy(rdpSettings* _settings, const rdpSe
 	rc = freerdp_settings_set_string(_settings, FreeRDP_ActionScript,
 	                                 freerdp_settings_get_string(settings, FreeRDP_ActionScript));
 
-	if (settings->XSelectionAtom)
-		_settings->XSelectionAtom = _strdup(settings->XSelectionAtom);
-
 out_fail:
 	return rc;
 }
@@ -1120,7 +1113,6 @@ BOOL freerdp_settings_copy(rdpSettings* _settings, const rdpSettings* settings)
 	_settings->ServerLicenseProductIssuersCount = 0;
 	_settings->ServerLicenseProductIssuers = NULL;
 
-	_settings->XSelectionAtom = NULL;
 	if (!rc)
 		goto out_fail;
 

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -362,6 +362,7 @@ static const size_t string_list_indices[] = {
 	FreeRDP_ClientDir,
 	FreeRDP_ClientHostname,
 	FreeRDP_ClientProductId,
+	FreeRDP_ClipboardUseSelection,
 	FreeRDP_ComputerName,
 	FreeRDP_ConfigPath,
 	FreeRDP_ConnectionFile,


### PR DESCRIPTION
* replace unstable API symbol `XSelectionAtom` with `ClipboardUseSelection` as used by common command line parser
* remove unused unstable API symbols from settings