### PR TITLE
[channel,rail] keep reference to rdpContext

### DIFF
--- a/channels/rail/client/CMakeLists.txt
+++ b/channels/rail/client/CMakeLists.txt
@@ -20,6 +20,7 @@ define_channel_client("rail")
 set(${MODULE_PREFIX}_SRCS
 	../rail_common.h
 	../rail_common.c
+	client_rails.c
 	rail_main.c
 	rail_main.h
 	rail_orders.c

--- a/channels/rail/client/client_rails.c
+++ b/channels/rail/client/client_rails.c
@@ -1,7 +1,8 @@
 
 #include <freerdp/freerdp.h>
-
 #include <freerdp/client/rail.h>
+
+#include "rail_main.h"
 
 UINT client_rail_server_start_cmd(RailClientContext* context)
 {
@@ -10,15 +11,13 @@ UINT client_rail_server_start_cmd(RailClientContext* context)
 	RAIL_EXEC_ORDER exec = { 0 };
 	RAIL_SYSPARAM_ORDER sysparam = { 0 };
 	RAIL_CLIENT_STATUS_ORDER clientStatus = { 0 };
-	rdpClientContext* ctx;
-	rdpSettings* settings;
 
 	WINPR_ASSERT(context);
+	railPlugin* rail = context->handle;
+	WINPR_ASSERT(rail);
+	WINPR_ASSERT(rail->rdpcontext);
 
-	ctx = (rdpClientContext*)context->custom;
-	WINPR_ASSERT(ctx);
-
-	settings = ctx->context.settings;
+	const rdpSettings* settings = rail->rdpcontext->settings;
 	WINPR_ASSERT(settings);
 
 	clientStatus.flags = TS_RAIL_CLIENTSTATUS_ALLOWLOCALMOVESIZE;

--- a/client/common/CMakeLists.txt
+++ b/client/common/CMakeLists.txt
@@ -27,7 +27,6 @@ endif()
 
 set(SRCS
 	client.c
-	client_rails.c
 	cmdline.c
 	cmdline.h
 	file.c


### PR DESCRIPTION
we need to access `rdpContext` from `client_rail_server_start_cmd` so move the function implementation to channel code.