### PR TITLE
[egfx] reset total decoded frames when receiving caps

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -376,6 +376,7 @@ static UINT rdpgfx_recv_caps_confirm_pdu(GENERIC_CHANNEL_CALLBACK* callback, wSt
 	Stream_Read_UINT32(s, capsSet.version); /* version (4 bytes) */
 	Stream_Read_UINT32(s, capsSet.length);  /* capsDataLength (4 bytes) */
 	Stream_Read_UINT32(s, capsSet.flags);   /* capsData (4 bytes) */
+	gfx->TotalDecodedFrames = 0;
 	gfx->ConnectionCaps = capsSet;
 	DEBUG_RDPGFX(gfx->log, "RecvCapsConfirmPdu: version: 0x%08" PRIX32 " flags: 0x%08" PRIX32 "",
 	             capsSet.version, capsSet.flags);


### PR DESCRIPTION
It seems like some windows servers don't like to receive ack frame messages with a totalDecodedFrame number that is bigger than the frameId. That can happen if the connection starts, some frames are decoded, we receive a renegotiate message, then egfx channel is reopened and the frame ids we receive go back to 1. In the previous situation, we ended up with sending an ack with frameId=1 and totalDecodedFrames=38, with the patch totalDecodedFrames is reset when receiving caps, so it's always lower than frameId.