### PR TITLE
[channels,rdpdr] fix user loggedon handling

### DIFF
--- a/channels/rdpdr/client/rdpdr_main.h
+++ b/channels/rdpdr/client/rdpdr_main.h
@@ -78,6 +78,7 @@ typedef struct
 	char computerName[256];
 
 	UINT32 sequenceId;
+	BOOL userLoggedOn;
 
 	/* hotplug support */
 	HANDLE hotplugThread;


### PR DESCRIPTION
PAKID_CORE_USER_LOGGEDON might happen in quite a lot of combinations not obvious from the spec at first glance. Relax state checks so that all valid combinations are allowed.