### PR TITLE
to stable-2.0 branch: rdpsnd_pulse: optimize writes and allow reconnections

### DIFF
--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -381,7 +381,7 @@ static BOOL rdpsnd_pulse_open(rdpsndDevicePlugin* device, const AUDIO_FORMAT* fo
 
 	if (pulse->latency > 0)
 	{
-		buffer_attr.maxlength = pa_usec_to_bytes(pulse->latency * 2 * 1000, &pulse->sample_spec);
+		buffer_attr.maxlength = (UINT32)-1;
 		buffer_attr.tlength = pa_usec_to_bytes(pulse->latency * 1000, &pulse->sample_spec);
 		buffer_attr.prebuf = (UINT32)-1;
 		buffer_attr.minreq = (UINT32)-1;
@@ -557,6 +557,7 @@ static BOOL rdpsnd_pulse_set_volume(rdpsndDevicePlugin* device, UINT32 value)
 static UINT rdpsnd_pulse_play(rdpsndDevicePlugin* device, const BYTE* data, size_t size)
 {
 	size_t length;
+	void* pa_data;
 	int status;
 	pa_usec_t latency;
 	int negative;
@@ -569,16 +570,16 @@ static UINT rdpsnd_pulse_play(rdpsndDevicePlugin* device, const BYTE* data, size
 
 	while (size > 0)
 	{
-		while ((length = pa_stream_writable_size(pulse->stream)) == 0)
-			pa_threaded_mainloop_wait(pulse->mainloop);
+		length = size;
 
-		if (length == (size_t)-1)
+		status = pa_stream_begin_write(pulse->stream, &pa_data, &length);
+
+		if (status < 0)
 			break;
 
-		if (length > size)
-			length = size;
+		memcpy(pa_data, data, length);
 
-		status = pa_stream_write(pulse->stream, data, length, NULL, 0LL, PA_SEEK_RELATIVE);
+		status = pa_stream_write(pulse->stream, pa_data, length, NULL, 0LL, PA_SEEK_RELATIVE);
 
 		if (status < 0)
 		{

--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -412,11 +412,11 @@ static BOOL rdpsnd_pulse_open_stream(rdpsndDevicePlugin* device)
 
 	if (pulse->latency > 0)
 	{
-		buffer_attr.maxlength = (UINT32)-1;
+		buffer_attr.maxlength = UINT32_MAX;
 		buffer_attr.tlength = pa_usec_to_bytes(pulse->latency * 1000, &pulse->sample_spec);
-		buffer_attr.prebuf = (UINT32)-1;
-		buffer_attr.minreq = (UINT32)-1;
-		buffer_attr.fragsize = (UINT32)-1;
+		buffer_attr.prebuf = UINT32_MAX;
+		buffer_attr.minreq = UINT32_MAX;
+		buffer_attr.fragsize = UINT32_MAX;
 		flags |= PA_STREAM_ADJUST_LATENCY;
 	}
 

--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -28,6 +28,7 @@
 #include <string.h>
 
 #include <winpr/crt.h>
+#include <winpr/assert.h>
 #include <winpr/stream.h>
 #include <winpr/cmdline.h>
 
@@ -53,6 +54,35 @@ struct rdpsnd_pulse_plugin
 	UINT32 volume;
 };
 
+static BOOL rdpsnd_check_pulse(rdpsndPulsePlugin* pulse, BOOL haveStream)
+{
+	BOOL rc = TRUE;
+	WINPR_ASSERT(pulse);
+
+	if (!pulse->context)
+	{
+		WLog_WARN(TAG, "pulse->context=%p", pulse->context);
+		rc = FALSE;
+	}
+
+	if (haveStream)
+	{
+		if (!pulse->stream)
+		{
+			WLog_WARN(TAG, "pulse->stream=%p", pulse->stream);
+			rc = FALSE;
+		}
+	}
+
+	if (!pulse->mainloop)
+	{
+		WLog_WARN(TAG, "pulse->mainloop=%p", pulse->mainloop);
+		rc = FALSE;
+	}
+
+	return rc;
+}
+
 static BOOL rdpsnd_pulse_format_supported(rdpsndDevicePlugin* device, const AUDIO_FORMAT* format);
 
 static void rdpsnd_pulse_get_sink_info(pa_context* c, const pa_sink_info* i, int eol,
@@ -65,7 +95,8 @@ static void rdpsnd_pulse_get_sink_info(pa_context* c, const pa_sink_info* i, int
 	;
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)userdata;
 
-	if (!pulse || !c || !i)
+	WINPR_ASSERT(c);
+	if (!rdpsnd_check_pulse(pulse, FALSE) || !i)
 		return;
 
 	for (x = 0; x < i->volume.channels; x++)
@@ -97,6 +128,10 @@ static void rdpsnd_pulse_context_state_callback(pa_context* context, void* userd
 {
 	pa_context_state_t state;
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)userdata;
+
+	WINPR_ASSERT(context);
+	WINPR_ASSERT(pulse);
+
 	state = pa_context_get_state(context);
 
 	switch (state)
@@ -121,7 +156,7 @@ static BOOL rdpsnd_pulse_connect(rdpsndDevicePlugin* device)
 	pa_context_state_t state;
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)device;
 
-	if (!pulse->context)
+	if (!rdpsnd_check_pulse(pulse, FALSE))
 		return FALSE;
 
 	if (pa_context_connect(pulse->context, NULL, 0, NULL))
@@ -173,11 +208,18 @@ static BOOL rdpsnd_pulse_connect(rdpsndDevicePlugin* device)
 static void rdpsnd_pulse_stream_success_callback(pa_stream* stream, int success, void* userdata)
 {
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)userdata;
+
+	if (!rdpsnd_check_pulse(pulse, TRUE))
+		return;
+
 	pa_threaded_mainloop_signal(pulse->mainloop, 0);
 }
 
 static void rdpsnd_pulse_wait_for_operation(rdpsndPulsePlugin* pulse, pa_operation* operation)
 {
+	if (!rdpsnd_check_pulse(pulse, TRUE))
+		return;
+
 	if (!operation)
 		return;
 
@@ -193,6 +235,11 @@ static void rdpsnd_pulse_stream_state_callback(pa_stream* stream, void* userdata
 {
 	pa_stream_state_t state;
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)userdata;
+
+	WINPR_ASSERT(stream);
+	if (!rdpsnd_check_pulse(pulse, TRUE))
+		return;
+
 	state = pa_stream_get_state(stream);
 
 	switch (state)
@@ -214,6 +261,11 @@ static void rdpsnd_pulse_stream_state_callback(pa_stream* stream, void* userdata
 static void rdpsnd_pulse_stream_request_callback(pa_stream* stream, size_t length, void* userdata)
 {
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)userdata;
+
+	WINPR_ASSERT(stream);
+	if (!rdpsnd_check_pulse(pulse, TRUE))
+		return;
+
 	pa_threaded_mainloop_signal(pulse->mainloop, 0);
 }
 
@@ -221,15 +273,20 @@ static void rdpsnd_pulse_close(rdpsndDevicePlugin* device)
 {
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)device;
 
-	if (!pulse->context || !pulse->stream)
+	WINPR_ASSERT(pulse);
+
+	if (!rdpsnd_check_pulse(pulse, FALSE))
 		return;
 
 	pa_threaded_mainloop_lock(pulse->mainloop);
-	rdpsnd_pulse_wait_for_operation(
-	    pulse, pa_stream_drain(pulse->stream, rdpsnd_pulse_stream_success_callback, pulse));
-	pa_stream_disconnect(pulse->stream);
-	pa_stream_unref(pulse->stream);
-	pulse->stream = NULL;
+	if (pulse->stream)
+	{
+		rdpsnd_pulse_wait_for_operation(
+		    pulse, pa_stream_drain(pulse->stream, rdpsnd_pulse_stream_success_callback, pulse));
+		pa_stream_disconnect(pulse->stream);
+		pa_stream_unref(pulse->stream);
+		pulse->stream = NULL;
+	}
 	pa_threaded_mainloop_unlock(pulse->mainloop);
 }
 
@@ -237,7 +294,9 @@ static BOOL rdpsnd_pulse_set_format_spec(rdpsndPulsePlugin* pulse, const AUDIO_F
 {
 	pa_sample_spec sample_spec = { 0 };
 
-	if (!pulse->context)
+	WINPR_ASSERT(format);
+
+	if (!rdpsnd_check_pulse(pulse, FALSE))
 		return FALSE;
 
 	if (!rdpsnd_pulse_format_supported(&pulse->device, format))
@@ -287,10 +346,12 @@ static BOOL rdpsnd_pulse_open(rdpsndDevicePlugin* device, const AUDIO_FORMAT* fo
 	pa_stream_state_t state;
 	pa_stream_flags_t flags;
 	pa_buffer_attr buffer_attr = { 0 };
-	char ss[PA_SAMPLE_SPEC_SNPRINT_MAX];
+	char ss[PA_SAMPLE_SPEC_SNPRINT_MAX] = { 0 };
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)device;
 
-	if (!pulse->context || pulse->stream)
+	WINPR_ASSERT(format);
+
+	if (!rdpsnd_check_pulse(pulse, FALSE))
 		return TRUE;
 
 	if (!rdpsnd_pulse_set_format_spec(pulse, format))
@@ -369,9 +430,7 @@ static void rdpsnd_pulse_free(rdpsndDevicePlugin* device)
 	rdpsnd_pulse_close(device);
 
 	if (pulse->mainloop)
-	{
 		pa_threaded_mainloop_stop(pulse->mainloop);
-	}
 
 	if (pulse->context)
 	{
@@ -394,6 +453,7 @@ static BOOL rdpsnd_pulse_default_format(rdpsndDevicePlugin* device, const AUDIO_
                                         AUDIO_FORMAT* defaultFormat)
 {
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)device;
+
 	if (!pulse || !defaultFormat)
 		return FALSE;
 
@@ -415,6 +475,9 @@ static BOOL rdpsnd_pulse_default_format(rdpsndDevicePlugin* device, const AUDIO_
 
 BOOL rdpsnd_pulse_format_supported(rdpsndDevicePlugin* device, const AUDIO_FORMAT* format)
 {
+	WINPR_ASSERT(device);
+	WINPR_ASSERT(format);
+
 	switch (format->wFormatTag)
 	{
 		case WAVE_FORMAT_PCM:
@@ -439,10 +502,7 @@ static UINT32 rdpsnd_pulse_get_volume(rdpsndDevicePlugin* device)
 	pa_operation* o;
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)device;
 
-	if (!pulse)
-		return 0;
-
-	if (!pulse->context || !pulse->mainloop)
+	if (!rdpsnd_check_pulse(pulse, FALSE))
 		return 0;
 
 	pa_threaded_mainloop_lock(pulse->mainloop);
@@ -452,26 +512,40 @@ static UINT32 rdpsnd_pulse_get_volume(rdpsndDevicePlugin* device)
 	return pulse->volume;
 }
 
+static void rdpsnd_set_volume_success_cb(pa_context* c, int success, void* userdata)
+{
+	rdpsndPulsePlugin* pulse = userdata;
+
+	if (!rdpsnd_check_pulse(pulse, TRUE))
+		return;
+	WINPR_ASSERT(c);
+
+	WLog_INFO(TAG, "%s: %d", __FUNCTION__, success);
+}
+
 static BOOL rdpsnd_pulse_set_volume(rdpsndDevicePlugin* device, UINT32 value)
 {
-	pa_cvolume cv;
+	pa_cvolume cv = { 0 };
 	pa_volume_t left;
 	pa_volume_t right;
 	pa_operation* operation;
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)device;
 
-	if (!pulse->context || !pulse->stream)
+	if (!rdpsnd_check_pulse(pulse, TRUE))
+	{
+		WLog_WARN(TAG, "%s called before pulse backend was initialized");
 		return FALSE;
+	}
 
 	left = (pa_volume_t)(value & 0xFFFF);
 	right = (pa_volume_t)((value >> 16) & 0xFFFF);
 	pa_cvolume_init(&cv);
 	cv.channels = 2;
-	cv.values[0] = PA_VOLUME_MUTED + (left * (PA_VOLUME_NORM - PA_VOLUME_MUTED)) / 0xFFFF;
-	cv.values[1] = PA_VOLUME_MUTED + (right * (PA_VOLUME_NORM - PA_VOLUME_MUTED)) / 0xFFFF;
+	cv.values[0] = PA_VOLUME_MUTED + (left * (PA_VOLUME_NORM - PA_VOLUME_MUTED)) / PA_VOLUME_NORM;
+	cv.values[1] = PA_VOLUME_MUTED + (right * (PA_VOLUME_NORM - PA_VOLUME_MUTED)) / PA_VOLUME_NORM;
 	pa_threaded_mainloop_lock(pulse->mainloop);
 	operation = pa_context_set_sink_input_volume(pulse->context, pa_stream_get_index(pulse->stream),
-	                                             &cv, NULL, NULL);
+	                                             &cv, rdpsnd_set_volume_success_cb, pulse);
 
 	if (operation)
 		pa_operation_unref(operation);
@@ -488,7 +562,7 @@ static UINT rdpsnd_pulse_play(rdpsndDevicePlugin* device, const BYTE* data, size
 	int negative;
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)device;
 
-	if (!pulse->stream || !data)
+	if (!rdpsnd_check_pulse(pulse, TRUE) || !data)
 		return 0;
 
 	pa_threaded_mainloop_lock(pulse->mainloop);
@@ -522,11 +596,6 @@ static UINT rdpsnd_pulse_play(rdpsndDevicePlugin* device, const BYTE* data, size
 	return latency / 1000;
 }
 
-/**
- * Function description
- *
- * @return 0 on success, otherwise a Win32 error code
- */
 static UINT rdpsnd_pulse_parse_addin_args(rdpsndDevicePlugin* device, ADDIN_ARGV* args)
 {
 	int status;
@@ -538,6 +607,10 @@ static UINT rdpsnd_pulse_parse_addin_args(rdpsndDevicePlugin* device, ADDIN_ARGV
 		                                            { NULL, 0, NULL, NULL, NULL, -1, NULL, NULL } };
 	flags =
 	    COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
+
+	WINPR_ASSERT(pulse);
+	WINPR_ASSERT(args);
+
 	status = CommandLineParseArgumentsA(args->argc, args->argv, rdpsnd_pulse_args, flags, pulse,
 	                                    NULL, NULL);
 
@@ -570,16 +643,14 @@ static UINT rdpsnd_pulse_parse_addin_args(rdpsndDevicePlugin* device, ADDIN_ARGV
 #define freerdp_rdpsnd_client_subsystem_entry FREERDP_API freerdp_rdpsnd_client_subsystem_entry
 #endif
 
-/**
- * Function description
- *
- * @return 0 on success, otherwise a Win32 error code
- */
 UINT freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS pEntryPoints)
 {
 	ADDIN_ARGV* args;
 	rdpsndPulsePlugin* pulse;
 	UINT ret;
+
+	WINPR_ASSERT(pEntryPoints);
+
 	pulse = (rdpsndPulsePlugin*)calloc(1, sizeof(rdpsndPulsePlugin));
 
 	if (!pulse)

--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -128,6 +128,8 @@ struct rdpsnd_plugin
 	BOOL initialized;
 
 	UINT16 wVersion;
+	UINT32 volume;
+	BOOL applyVolume;
 };
 
 static const char* rdpsnd_is_dyn_str(BOOL dynamic)
@@ -375,6 +377,20 @@ static UINT rdpsnd_recv_training_pdu(rdpsndPlugin* rdpsnd, wStream* s)
 	return rdpsnd_send_training_confirm_pdu(rdpsnd, wTimeStamp, wPackSize);
 }
 
+static BOOL rdpsnd_apply_volume(rdpsndPlugin* rdpsnd)
+{
+	WINPR_ASSERT(rdpsnd);
+
+	if (rdpsnd->isOpen && rdpsnd->applyVolume && rdpsnd->device)
+	{
+		BOOL rc = IFCALLRESULT(TRUE, rdpsnd->device->SetVolume, rdpsnd->device, rdpsnd->volume);
+		if (!rc)
+			return FALSE;
+		rdpsnd->applyVolume = FALSE;
+	}
+	return TRUE;
+}
+
 static BOOL rdpsnd_ensure_device_is_open(rdpsndPlugin* rdpsnd, UINT32 wFormatNo,
                                          const AUDIO_FORMAT* format)
 {
@@ -423,7 +439,7 @@ static BOOL rdpsnd_ensure_device_is_open(rdpsndPlugin* rdpsnd, UINT32 wFormatNo,
 		rdpsnd->totalPlaySize = 0;
 	}
 
-	return TRUE;
+	return rdpsnd_apply_volume(rdpsnd);
 }
 
 /**
@@ -712,7 +728,7 @@ static void rdpsnd_recv_close_pdu(rdpsndPlugin* rdpsnd)
  */
 static UINT rdpsnd_recv_volume_pdu(rdpsndPlugin* rdpsnd, wStream* s)
 {
-	BOOL rc = FALSE;
+	BOOL rc = TRUE;
 	UINT32 dwVolume;
 
 	if (Stream_GetRemainingLength(s) < 4)
@@ -721,8 +737,10 @@ static UINT rdpsnd_recv_volume_pdu(rdpsndPlugin* rdpsnd, wStream* s)
 	Stream_Read_UINT32(s, dwVolume);
 	WLog_Print(rdpsnd->log, WLOG_DEBUG, "%s Volume: 0x%08" PRIX32 "",
 	           rdpsnd_is_dyn_str(rdpsnd->dynamic), dwVolume);
-	if (rdpsnd->device)
-		rc = IFCALLRESULT(FALSE, rdpsnd->device->SetVolume, rdpsnd->device, dwVolume);
+
+	rdpsnd->volume = dwVolume;
+	rdpsnd->applyVolume = TRUE;
+	rc = rdpsnd_apply_volume(rdpsnd);
 
 	if (!rc)
 	{

--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -126,6 +126,8 @@ struct rdpsnd_plugin
 	HANDLE thread;
 	wMessageQueue* queue;
 	BOOL initialized;
+
+	UINT16 wVersion;
 };
 
 static const char* rdpsnd_is_dyn_str(BOOL dynamic)
@@ -268,9 +270,9 @@ static UINT rdpsnd_send_client_audio_formats(rdpsndPlugin* rdpsnd)
 static UINT rdpsnd_recv_server_audio_formats_pdu(rdpsndPlugin* rdpsnd, wStream* s)
 {
 	UINT16 index;
-	UINT16 wVersion;
 	UINT16 wNumberOfFormats;
 	UINT ret = ERROR_BAD_LENGTH;
+
 	audio_formats_free(rdpsnd->ServerFormats, rdpsnd->NumberOfServerFormats);
 	rdpsnd->NumberOfServerFormats = 0;
 	rdpsnd->ServerFormats = NULL;
@@ -285,7 +287,7 @@ static UINT rdpsnd_recv_server_audio_formats_pdu(rdpsndPlugin* rdpsnd, wStream* 
 	Stream_Seek_UINT16(s); /* wDGramPort */
 	Stream_Read_UINT16(s, wNumberOfFormats);
 	Stream_Read_UINT8(s, rdpsnd->cBlockNo); /* cLastBlockConfirmed */
-	Stream_Read_UINT16(s, wVersion);        /* wVersion */
+	Stream_Read_UINT16(s, rdpsnd->wVersion); /* wVersion */
 	Stream_Seek_UINT8(s);                   /* bPad */
 	rdpsnd->NumberOfServerFormats = wNumberOfFormats;
 
@@ -312,7 +314,7 @@ static UINT rdpsnd_recv_server_audio_formats_pdu(rdpsndPlugin* rdpsnd, wStream* 
 
 	if (ret == CHANNEL_RC_OK)
 	{
-		if (wVersion >= CHANNEL_VERSION_WIN_7)
+		if (rdpsnd->wVersion >= CHANNEL_VERSION_WIN_7)
 			ret = rdpsnd_send_quality_mode_pdu(rdpsnd);
 	}
 


### PR DESCRIPTION
This is a backportof https://github.com/FreeRDP/FreeRDP/pull/9528 to `stable-2.0` branch.

Two extra changes backported from master to eliminate most of code base differences:
- cherry picked from commit 1819c24808a0a6d69ef93220411a1d69a271a1aa "Remember received sound volume and apply on open."
- cherry picked from commit 5521a73e9097949f61ff39e70c8a365e76d7312e "Some rdpsnd debug improvements"