### PR TITLE
(clipboard) Make sure there is always a Client Format List PUD after …

### DIFF
--- a/channels/cliprdr/client/cliprdr_main.c
+++ b/channels/cliprdr/client/cliprdr_main.c
@@ -621,6 +621,9 @@ static UINT cliprdr_client_capabilities(CliprdrClientContext* context,
 
 	Stream_Write_UINT32(s, flags); /* generalFlags */
 	WLog_Print(cliprdr->log, WLOG_DEBUG, "ClientCapabilities");
+
+	cliprdr->initialFormatListSent = FALSE;
+
 	return cliprdr_packet_send(cliprdr, s);
 }
 


### PR DESCRIPTION
After initializing the Clipboard virtual channel once, if the client (FreeRDP) receives a Server Monitor Ready PDU again, only the Client Clipboard Capabilities PDU message is sent back to the server. The Client Format List PDU to finalize the initialization sequence is missing.