### PR TITLE
#5726 add vsock support for client and server

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2315,7 +2315,13 @@ static int parse_host_options(rdpSettings* settings, const COMMAND_LINE_ARGUMENT
 	/* ipv4 */
 	if (!p)
 	{
-		p = strchr(arg->Value, ':');
+		const char scheme[] = "://";
+		const char* val = strstr(arg->Value, scheme);
+		if (val)
+			val += strnlen(scheme, sizeof(scheme));
+		else
+			val = arg->Value;
+		p = strchr(val, ':');
 
 		if (p)
 		{

--- a/include/config/config.h.in
+++ b/include/config/config.h.in
@@ -187,4 +187,6 @@
 #cmakedefine WITH_PROXY_MODULES
 #cmakedefine WITH_PROXY_EMULATE_SMARTCARD
 
+#cmakedefine HAVE_AF_VSOCK_H
+
 #endif /* FREERDP_CONFIG_H */

--- a/libfreerdp/core/CMakeLists.txt
+++ b/libfreerdp/core/CMakeLists.txt
@@ -18,6 +18,8 @@
 set(MODULE_NAME "freerdp-core")
 set(MODULE_PREFIX "FREERDP_CORE")
 
+CHECK_INCLUDE_FILES("ctype.h;linux/vm_sockets.h" HAVE_AF_VSOCK_H)
+
 freerdp_definition_add(-DEXT_PATH="${FREERDP_EXTENSION_PATH}")
 
 freerdp_include_directory_add(${OPENSSL_INCLUDE_DIR})

--- a/libfreerdp/core/utils.c
+++ b/libfreerdp/core/utils.c
@@ -288,3 +288,14 @@ BOOL utils_abort_event_is_set(rdpRdp* rdp)
 	status = WaitForSingleObject(rdp->abortEvent, 0);
 	return status == WAIT_OBJECT_0;
 }
+
+const char* utils_is_vsock(const char* hostname)
+{
+	if (!hostname)
+		return NULL;
+
+	const char vsock[8] = "vsock://";
+	if (strncmp(hostname, vsock, sizeof(vsock)) == 0)
+		return &hostname[sizeof(vsock)];
+	return NULL;
+}

--- a/libfreerdp/core/utils.h
+++ b/libfreerdp/core/utils.h
@@ -45,4 +45,6 @@ BOOL utils_sync_credentials(rdpSettings* settings, BOOL toGateway);
 BOOL utils_str_is_empty(const char* str);
 BOOL utils_str_copy(const char* value, char** dst);
 
+const char* utils_is_vsock(const char* hostname);
+
 #endif /* FREERDP_LIB_CORE_UTILS_H */


### PR DESCRIPTION
Run the server with:
A) `/opt/freerdp/bin/freerdp-shadow-cli /bind-address:vsock://-1 /port:3389` to accept connections between host and guest. (VMADDR_CID_ANY)
B) `/opt/freerdp/bin/freerdp-shadow-cli /bind-address:vsock://1 /port:3389` to accept local connections on the same machine. (host to same host or guest to same guest) (VMADDR_CID_LOCAL)

Run the client with:
A) `/opt/freerdp/bin/wlfreerdp /v:vsock://3:3389 /u:user /p:secret -sec:tls /cert:ignore` to connect to the virtual machine with CID 3 on port 3389 from the host. Change the CID to the integer matching your VM.
B) `/opt/freerdp/bin/wlfreerdp /v:vsock://2:3389 /u:user /p:secret  -sec:tls /cert:ignore` to connect to the host from the virtual machine.
C) `/opt/freerdp/bin/wlfreerdp /v:vsock://1:3389 /u:user /p:secret -sec:tls /cert:ignore` to connect to a local running running instance.