### PR TITLE
cmake: Revert warning compiler flag for MSVC

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -27,7 +27,7 @@ if (ENABLE_WARNING_VERBOSE)
 		endforeach()
 
 		set(C_WARNING_FLAGS
-			/Wall
+			/W3
 		)
 	else()
 		set(C_WARNING_FLAGS

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -27,7 +27,8 @@ if (ENABLE_WARNING_VERBOSE)
 		endforeach()
 
 		set(C_WARNING_FLAGS
-			/W3
+			/W4
+			/wo4324
 		)
 	else()
 		set(C_WARNING_FLAGS

--- a/include/freerdp/dvc.h
+++ b/include/freerdp/dvc.h
@@ -133,6 +133,8 @@ extern "C"
 		UINT(*OnNewChannelConnection)
 		(IWTSListenerCallback* pListenerCallback, IWTSVirtualChannel* pChannel, BYTE* Data,
 		 BOOL* pbAccept, IWTSVirtualChannelCallback** ppCallback);
+
+		void* pInterface;
 	};
 
 	struct s_IWTSVirtualChannelCallback
@@ -146,6 +148,8 @@ extern "C"
 		UINT(*OnClose)
 		(IWTSVirtualChannelCallback*
 		     pChannelCallback); /**< Notifies the user that the channel has been closed. */
+
+		void* pInterface;
 	};
 
 	/* The DVC Plugin entry points */


### PR DESCRIPTION
MSVC does not implemented /Wall very well as it floods the output with a
plethora of warnings from system headers.

This greatly reduces compile performance so this change reverts /Wall
back to /W3.