### PR TITLE
[nla] initial server-side remote credential guard support

### DIFF
--- a/include/freerdp/peer.h
+++ b/include/freerdp/peer.h
@@ -31,6 +31,7 @@
 #include <winpr/sspi.h>
 #include <winpr/ntlm.h>
 #include <winpr/winsock.h>
+#include <winpr/secapi.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -42,146 +43,157 @@ extern "C"
 
 	typedef BOOL (*psPeerInitialize)(freerdp_peer* peer);
 #if defined(WITH_FREERDP_DEPRECATED)
-WINPR_DEPRECATED_VAR("Use psPeerGetEventHandle instead",
-                     typedef BOOL (*psPeerGetFileDescriptor)(freerdp_peer* peer, void** rfds,
-                                                             int* rcount);)
+	WINPR_DEPRECATED_VAR("Use psPeerGetEventHandle instead",
+	                     typedef BOOL (*psPeerGetFileDescriptor)(freerdp_peer* peer, void** rfds,
+	                                                             int* rcount);)
 #endif
-typedef HANDLE (*psPeerGetEventHandle)(freerdp_peer* peer);
-typedef DWORD (*psPeerGetEventHandles)(freerdp_peer* peer, HANDLE* events, DWORD count);
-typedef HANDLE (*psPeerGetReceiveEventHandle)(freerdp_peer* peer);
-typedef BOOL (*psPeerCheckFileDescriptor)(freerdp_peer* peer);
-typedef BOOL (*psPeerIsWriteBlocked)(freerdp_peer* peer);
-typedef int (*psPeerDrainOutputBuffer)(freerdp_peer* peer);
-typedef BOOL (*psPeerHasMoreToRead)(freerdp_peer* peer);
-typedef BOOL (*psPeerClose)(freerdp_peer* peer);
-typedef void (*psPeerDisconnect)(freerdp_peer* peer);
-typedef BOOL (*psPeerCapabilities)(freerdp_peer* peer);
-typedef BOOL (*psPeerPostConnect)(freerdp_peer* peer);
-typedef BOOL (*psPeerActivate)(freerdp_peer* peer);
-typedef BOOL (*psPeerLogon)(freerdp_peer* peer, const SEC_WINNT_AUTH_IDENTITY* identity,
-                            BOOL automatic);
-typedef BOOL (*psPeerSendServerRedirection)(freerdp_peer* peer, const rdpRedirection* redirection);
-typedef BOOL (*psPeerAdjustMonitorsLayout)(freerdp_peer* peer);
-typedef BOOL (*psPeerClientCapabilities)(freerdp_peer* peer);
+	typedef HANDLE (*psPeerGetEventHandle)(freerdp_peer* peer);
+	typedef DWORD (*psPeerGetEventHandles)(freerdp_peer* peer, HANDLE* events, DWORD count);
+	typedef HANDLE (*psPeerGetReceiveEventHandle)(freerdp_peer* peer);
+	typedef BOOL (*psPeerCheckFileDescriptor)(freerdp_peer* peer);
+	typedef BOOL (*psPeerIsWriteBlocked)(freerdp_peer* peer);
+	typedef int (*psPeerDrainOutputBuffer)(freerdp_peer* peer);
+	typedef BOOL (*psPeerHasMoreToRead)(freerdp_peer* peer);
+	typedef BOOL (*psPeerClose)(freerdp_peer* peer);
+	typedef void (*psPeerDisconnect)(freerdp_peer* peer);
+	typedef BOOL (*psPeerRemoteCredentials)(freerdp_peer* peer, KERB_TICKET_LOGON* logonCreds,
+	                                        MSV1_0_SUPPLEMENTAL_CREDENTIAL* suppCreds);
+	typedef BOOL (*psPeerCapabilities)(freerdp_peer* peer);
+	typedef BOOL (*psPeerPostConnect)(freerdp_peer* peer);
+	typedef BOOL (*psPeerActivate)(freerdp_peer* peer);
+	typedef BOOL (*psPeerLogon)(freerdp_peer* peer, const SEC_WINNT_AUTH_IDENTITY* identity,
+	                            BOOL automatic);
+	typedef BOOL (*psPeerSendServerRedirection)(freerdp_peer* peer,
+	                                            const rdpRedirection* redirection);
+	typedef BOOL (*psPeerAdjustMonitorsLayout)(freerdp_peer* peer);
+	typedef BOOL (*psPeerClientCapabilities)(freerdp_peer* peer);
 
-typedef BOOL (*psPeerSendChannelData)(freerdp_peer* peer, UINT16 channelId, const BYTE* data,
-                                      size_t size);
-typedef BOOL (*psPeerSendChannelPacket)(freerdp_peer* client, UINT16 channelId, size_t totalSize,
-                                        UINT32 flags, const BYTE* data, size_t chunkSize);
-typedef BOOL (*psPeerReceiveChannelData)(freerdp_peer* peer, UINT16 channelId, const BYTE* data,
-                                         size_t size, UINT32 flags, size_t totalSize);
+	typedef BOOL (*psPeerSendChannelData)(freerdp_peer* peer, UINT16 channelId, const BYTE* data,
+	                                      size_t size);
+	typedef BOOL (*psPeerSendChannelPacket)(freerdp_peer* client, UINT16 channelId,
+	                                        size_t totalSize, UINT32 flags, const BYTE* data,
+	                                        size_t chunkSize);
+	typedef BOOL (*psPeerReceiveChannelData)(freerdp_peer* peer, UINT16 channelId, const BYTE* data,
+	                                         size_t size, UINT32 flags, size_t totalSize);
 
-typedef HANDLE (*psPeerVirtualChannelOpen)(freerdp_peer* peer, const char* name, UINT32 flags);
-typedef BOOL (*psPeerVirtualChannelClose)(freerdp_peer* peer, HANDLE hChannel);
-typedef int (*psPeerVirtualChannelRead)(freerdp_peer* peer, HANDLE hChannel, BYTE* buffer,
-                                        UINT32 length);
-typedef int (*psPeerVirtualChannelWrite)(freerdp_peer* peer, HANDLE hChannel, const BYTE* buffer,
-                                         UINT32 length);
-typedef void* (*psPeerVirtualChannelGetData)(freerdp_peer* peer, HANDLE hChannel);
-typedef int (*psPeerVirtualChannelSetData)(freerdp_peer* peer, HANDLE hChannel, void* data);
-typedef BOOL (*psPeerSetState)(freerdp_peer* peer, CONNECTION_STATE state);
-typedef BOOL (*psPeerReachedState)(freerdp_peer* peer, CONNECTION_STATE state);
+	typedef HANDLE (*psPeerVirtualChannelOpen)(freerdp_peer* peer, const char* name, UINT32 flags);
+	typedef BOOL (*psPeerVirtualChannelClose)(freerdp_peer* peer, HANDLE hChannel);
+	typedef int (*psPeerVirtualChannelRead)(freerdp_peer* peer, HANDLE hChannel, BYTE* buffer,
+	                                        UINT32 length);
+	typedef int (*psPeerVirtualChannelWrite)(freerdp_peer* peer, HANDLE hChannel,
+	                                         const BYTE* buffer, UINT32 length);
+	typedef void* (*psPeerVirtualChannelGetData)(freerdp_peer* peer, HANDLE hChannel);
+	typedef int (*psPeerVirtualChannelSetData)(freerdp_peer* peer, HANDLE hChannel, void* data);
+	typedef BOOL (*psPeerSetState)(freerdp_peer* peer, CONNECTION_STATE state);
+	typedef BOOL (*psPeerReachedState)(freerdp_peer* peer, CONNECTION_STATE state);
 
-/** @brief the result of the license callback */
-typedef enum
-{
-	LICENSE_CB_INTERNAL_ERROR, /** an internal error happened in the callback */
-	LICENSE_CB_ABORT,          /** licensing process failed, abort the connection */
-	LICENSE_CB_IN_PROGRESS, /** incoming packet has been treated, we're waiting for further packets
-	                           to complete the workflow */
-	LICENSE_CB_COMPLETED    /** the licensing workflow has completed, go to next step */
-} LicenseCallbackResult;
+	/** @brief the result of the license callback */
+	typedef enum
+	{
+		LICENSE_CB_INTERNAL_ERROR, /** an internal error happened in the callback */
+		LICENSE_CB_ABORT,          /** licensing process failed, abort the connection */
+		LICENSE_CB_IN_PROGRESS,    /** incoming packet has been treated, we're waiting for further
+		                              packets    to complete the workflow */
+		LICENSE_CB_COMPLETED       /** the licensing workflow has completed, go to next step */
+	} LicenseCallbackResult;
 
-typedef LicenseCallbackResult (*psPeerLicenseCallback)(freerdp_peer* peer, wStream* s);
+	typedef LicenseCallbackResult (*psPeerLicenseCallback)(freerdp_peer* peer, wStream* s);
 
-struct rdp_freerdp_peer
-{
-	ALIGN64 rdpContext* context;
+	struct rdp_freerdp_peer
+	{
+		ALIGN64 rdpContext* context;
 
-	ALIGN64 int sockfd;
-	ALIGN64 char hostname[50];
+		ALIGN64 int sockfd;
+		ALIGN64 char hostname[50];
 
 #if defined(WITH_FREERDP_DEPRECATED)
-	WINPR_DEPRECATED_VAR("Use rdpContext::update instead", ALIGN64 rdpUpdate* update;)
-	WINPR_DEPRECATED_VAR("Use rdpContext::settings instead", ALIGN64 rdpSettings* settings;)
-	WINPR_DEPRECATED_VAR("Use rdpContext::autodetect instead", ALIGN64 rdpAutoDetect* autodetect;)
+		WINPR_DEPRECATED_VAR("Use rdpContext::update instead", ALIGN64 rdpUpdate* update;)
+		WINPR_DEPRECATED_VAR("Use rdpContext::settings instead", ALIGN64 rdpSettings* settings;)
+		WINPR_DEPRECATED_VAR("Use rdpContext::autodetect instead",
+		                     ALIGN64 rdpAutoDetect* autodetect;)
 #else
 	UINT64 reservedX[3];
 #endif
 
-	ALIGN64 void* ContextExtra;
-	ALIGN64 size_t ContextSize;
-	ALIGN64 psPeerContextNew ContextNew;
-	ALIGN64 psPeerContextFree ContextFree;
+		ALIGN64 void* ContextExtra;
+		ALIGN64 size_t ContextSize;
+		ALIGN64 psPeerContextNew ContextNew;
+		ALIGN64 psPeerContextFree ContextFree;
 
-	ALIGN64 psPeerInitialize Initialize;
+		ALIGN64 psPeerInitialize Initialize;
 #if defined(WITH_FREERDP_DEPRECATED)
-	WINPR_DEPRECATED_VAR("Use freerdp_peer::GetEventHandle instead",
-	                     ALIGN64 psPeerGetFileDescriptor GetFileDescriptor;)
+		WINPR_DEPRECATED_VAR("Use freerdp_peer::GetEventHandle instead",
+		                     ALIGN64 psPeerGetFileDescriptor GetFileDescriptor;)
 #else
 	UINT64 reserved;
 #endif
-	ALIGN64 psPeerGetEventHandle GetEventHandle;
-	ALIGN64 psPeerGetReceiveEventHandle GetReceiveEventHandle;
-	ALIGN64 psPeerCheckFileDescriptor CheckFileDescriptor;
-	ALIGN64 psPeerClose Close;
-	ALIGN64 psPeerDisconnect Disconnect;
+		ALIGN64 psPeerGetEventHandle GetEventHandle;
+		ALIGN64 psPeerGetReceiveEventHandle GetReceiveEventHandle;
+		ALIGN64 psPeerCheckFileDescriptor CheckFileDescriptor;
+		ALIGN64 psPeerClose Close;
+		ALIGN64 psPeerDisconnect Disconnect;
 
-	ALIGN64 psPeerCapabilities Capabilities;
-	ALIGN64 psPeerPostConnect PostConnect;
-	ALIGN64 psPeerActivate Activate;
-	ALIGN64 psPeerLogon Logon;
+		ALIGN64 psPeerCapabilities Capabilities;
+		ALIGN64 psPeerPostConnect PostConnect;
+		ALIGN64 psPeerActivate Activate;
+		ALIGN64 psPeerLogon Logon;
 
-	ALIGN64 psPeerSendServerRedirection SendServerRedirection;
+		ALIGN64 psPeerSendServerRedirection SendServerRedirection;
 
-	ALIGN64 psPeerSendChannelData SendChannelData;
-	ALIGN64 psPeerReceiveChannelData ReceiveChannelData;
+		ALIGN64 psPeerSendChannelData SendChannelData;
+		ALIGN64 psPeerReceiveChannelData ReceiveChannelData;
 
-	ALIGN64 psPeerVirtualChannelOpen VirtualChannelOpen;
-	ALIGN64 psPeerVirtualChannelClose VirtualChannelClose;
-	ALIGN64 psPeerVirtualChannelRead VirtualChannelRead;
-	ALIGN64 psPeerVirtualChannelWrite VirtualChannelWrite;
-	ALIGN64 psPeerVirtualChannelGetData VirtualChannelGetData;
-	ALIGN64 psPeerVirtualChannelSetData VirtualChannelSetData;
+		ALIGN64 psPeerVirtualChannelOpen VirtualChannelOpen;
+		ALIGN64 psPeerVirtualChannelClose VirtualChannelClose;
+		ALIGN64 psPeerVirtualChannelRead VirtualChannelRead;
+		ALIGN64 psPeerVirtualChannelWrite VirtualChannelWrite;
+		ALIGN64 psPeerVirtualChannelGetData VirtualChannelGetData;
+		ALIGN64 psPeerVirtualChannelSetData VirtualChannelSetData;
 
-	ALIGN64 int pId;
-	ALIGN64 UINT32 ack_frame_id;
-	ALIGN64 BOOL local;
-	ALIGN64 BOOL connected;
-	ALIGN64 BOOL activated;
-	ALIGN64 BOOL authenticated;
-	ALIGN64 SEC_WINNT_AUTH_IDENTITY identity;
+		ALIGN64 int pId;
+		ALIGN64 UINT32 ack_frame_id;
+		ALIGN64 BOOL local;
+		ALIGN64 BOOL connected;
+		ALIGN64 BOOL activated;
+		ALIGN64 BOOL authenticated;
+		ALIGN64 SEC_WINNT_AUTH_IDENTITY identity;
 
-	ALIGN64 psPeerIsWriteBlocked IsWriteBlocked;
-	ALIGN64 psPeerDrainOutputBuffer DrainOutputBuffer;
-	ALIGN64 psPeerHasMoreToRead HasMoreToRead;
-	ALIGN64 psPeerGetEventHandles GetEventHandles;
-	ALIGN64 psPeerAdjustMonitorsLayout AdjustMonitorsLayout;
-	ALIGN64 psPeerClientCapabilities ClientCapabilities;
+		ALIGN64 psPeerIsWriteBlocked IsWriteBlocked;
+		ALIGN64 psPeerDrainOutputBuffer DrainOutputBuffer;
+		ALIGN64 psPeerHasMoreToRead HasMoreToRead;
+		ALIGN64 psPeerGetEventHandles GetEventHandles;
+		ALIGN64 psPeerAdjustMonitorsLayout AdjustMonitorsLayout;
+		ALIGN64 psPeerClientCapabilities ClientCapabilities;
 #if defined(WITH_FREERDP_DEPRECATED)
-	WINPR_DEPRECATED_VAR("Use freerdp_peer::SspiNtlmHashCallback instead",
-	                     ALIGN64 psPeerComputeNtlmHash ComputeNtlmHash;)
+		WINPR_DEPRECATED_VAR("Use freerdp_peer::SspiNtlmHashCallback instead",
+		                     ALIGN64 psPeerComputeNtlmHash ComputeNtlmHash;)
 #else
 	UINT64 reserved2;
 #endif
-	ALIGN64 psPeerLicenseCallback LicenseCallback;
+		ALIGN64 psPeerLicenseCallback LicenseCallback;
 
-	ALIGN64 psPeerSendChannelPacket SendChannelPacket;
+		ALIGN64 psPeerSendChannelPacket SendChannelPacket;
 
-	/**
-	 * @brief SetState Function pointer allowing to manually set the state of the
-	 * internal state machine.
-	 *
-	 * This is useful if certain parts of a RDP connection must be skipped (e.g.
-	 * when replaying a RDP connection dump the authentication/negotiate parts
-	 * must be skipped)
-	 *
-	 * \note Must be called after \b Initialize as that also modifies the state.
-	 */
-	ALIGN64 psPeerSetState SetState;
-	ALIGN64 psPeerReachedState ReachedState;
-	ALIGN64 psSspiNtlmHashCallback SspiNtlmHashCallback;
-};
+		/**
+		 * @brief SetState Function pointer allowing to manually set the state of the
+		 * internal state machine.
+		 *
+		 * This is useful if certain parts of a RDP connection must be skipped (e.g.
+		 * when replaying a RDP connection dump the authentication/negotiate parts
+		 * must be skipped)
+		 *
+		 * \note Must be called after \b Initialize as that also modifies the state.
+		 */
+		ALIGN64 psPeerSetState SetState;
+		ALIGN64 psPeerReachedState ReachedState;
+		ALIGN64 psSspiNtlmHashCallback SspiNtlmHashCallback;
+		/**
+		 * @brief RemoteCredentials Function pointer that will be called when remote
+		 * credentials guard are used by the peer and we receive the logonCreds (kerberos)
+		 * and supplementary creds (NTLM).
+		 */
+		ALIGN64 psPeerRemoteCredentials RemoteCredentials;
+	};
 
 	FREERDP_API BOOL freerdp_peer_context_new(freerdp_peer* client);
 	FREERDP_API BOOL freerdp_peer_context_new_ex(freerdp_peer* client, const rdpSettings* settings);

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -651,6 +651,7 @@ extern "C"
 #define FreeRDP_RdstlsSecurity (1111)
 #define FreeRDP_AadSecurity (1112)
 #define FreeRDP_WinSCardModule (1113)
+#define FreeRDP_RemoteCredentialGuard (1114)
 #define FreeRDP_MstscCookieMode (1152)
 #define FreeRDP_CookieMaxLength (1153)
 #define FreeRDP_PreconnectionId (1154)
@@ -1185,7 +1186,8 @@ extern "C"
 		ALIGN64 BOOL RdstlsSecurity;               /* 1111 */
 		ALIGN64 BOOL AadSecurity;                  /* 1112 */
 		ALIGN64 char* WinSCardModule;              /* 1113 */
-		UINT64 padding1152[1152 - 1114];           /* 1114 */
+		ALIGN64 BOOL RemoteCredentialGuard;        /* 1114 */
+		UINT64 padding1152[1152 - 1115];           /* 1115 */
 
 		/* Connection Cookie */
 		ALIGN64 BOOL MstscCookieMode;      /* 1152 */
@@ -1491,8 +1493,8 @@ extern "C"
 		 * If used by an implementation ensure proper state resync after reenabling
 		 * input
 		 */
-		ALIGN64 BOOL SuspendInput;       /* 2636 */
-		ALIGN64 char* KeyboardPipeName;  /* 2637 */
+		ALIGN64 BOOL SuspendInput;          /* 2636 */
+		ALIGN64 char* KeyboardPipeName;     /* 2637 */
 		ALIGN64 BOOL HasRelativeMouseEvent; /* 2638 */
 		ALIGN64 BOOL HasQoeEvent;           /* 2639 */
 		UINT64 padding2688[2688 - 2640];    /* 2640 */
@@ -1680,20 +1682,20 @@ extern "C"
 		ALIGN64 BOOL SupportDynamicChannels;      /* 5059 */
 		UINT64 padding5184[5184 - 5060];          /* 5060 */
 
-		ALIGN64 BOOL SupportEchoChannel;      /* 5184 */
-		ALIGN64 BOOL SupportDisplayControl;   /* 5185 */
-		ALIGN64 BOOL SupportGeometryTracking; /* 5186 */
-		ALIGN64 BOOL SupportSSHAgentChannel;  /* 5187 */
-		ALIGN64 BOOL SupportVideoOptimized;   /* 5188 */
-		ALIGN64 char* RDP2TCPArgs;            /* 5189 */
-		ALIGN64 BOOL TcpKeepAlive;            /* 5190 */
-		ALIGN64 UINT32 TcpKeepAliveRetries;   /* 5191 */
-		ALIGN64 UINT32 TcpKeepAliveDelay;     /* 5192 */
-		ALIGN64 UINT32 TcpKeepAliveInterval;  /* 5193 */
-		ALIGN64 UINT32 TcpAckTimeout;         /* 5194 */
-		ALIGN64 char* ActionScript;           /* 5195 */
-		ALIGN64 UINT32 Floatbar;              /* 5196 */
-		ALIGN64 UINT32 TcpConnectTimeout;     /* 5197 */
+		ALIGN64 BOOL SupportEchoChannel;        /* 5184 */
+		ALIGN64 BOOL SupportDisplayControl;     /* 5185 */
+		ALIGN64 BOOL SupportGeometryTracking;   /* 5186 */
+		ALIGN64 BOOL SupportSSHAgentChannel;    /* 5187 */
+		ALIGN64 BOOL SupportVideoOptimized;     /* 5188 */
+		ALIGN64 char* RDP2TCPArgs;              /* 5189 */
+		ALIGN64 BOOL TcpKeepAlive;              /* 5190 */
+		ALIGN64 UINT32 TcpKeepAliveRetries;     /* 5191 */
+		ALIGN64 UINT32 TcpKeepAliveDelay;       /* 5192 */
+		ALIGN64 UINT32 TcpKeepAliveInterval;    /* 5193 */
+		ALIGN64 UINT32 TcpAckTimeout;           /* 5194 */
+		ALIGN64 char* ActionScript;             /* 5195 */
+		ALIGN64 UINT32 Floatbar;                /* 5196 */
+		ALIGN64 UINT32 TcpConnectTimeout;       /* 5197 */
 		ALIGN64 UINT32 FakeMouseMotionInterval; /* 5198 */
 		UINT64 padding5312[5312 - 5199];        /* 5199 */
 

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -465,6 +465,9 @@ BOOL freerdp_settings_get_bool(const rdpSettings* settings, size_t id)
 		case FreeRDP_RemoteConsoleAudio:
 			return settings->RemoteConsoleAudio;
 
+		case FreeRDP_RemoteCredentialGuard:
+			return settings->RemoteCredentialGuard;
+
 		case FreeRDP_RemoteFxCodec:
 			return settings->RemoteFxCodec;
 
@@ -1180,6 +1183,10 @@ BOOL freerdp_settings_set_bool(rdpSettings* settings, size_t id, BOOL val)
 
 		case FreeRDP_RemoteConsoleAudio:
 			settings->RemoteConsoleAudio = cnv.c;
+			break;
+
+		case FreeRDP_RemoteCredentialGuard:
+			settings->RemoteCredentialGuard = cnv.c;
 			break;
 
 		case FreeRDP_RemoteFxCodec:

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -192,6 +192,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_RemoteAssistanceRequestControl, FREERDP_SETTINGS_TYPE_BOOL,
 	  "FreeRDP_RemoteAssistanceRequestControl" },
 	{ FreeRDP_RemoteConsoleAudio, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_RemoteConsoleAudio" },
+	{ FreeRDP_RemoteCredentialGuard, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_RemoteCredentialGuard" },
 	{ FreeRDP_RemoteFxCodec, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_RemoteFxCodec" },
 	{ FreeRDP_RemoteFxImageCodec, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_RemoteFxImageCodec" },
 	{ FreeRDP_RemoteFxOnly, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_RemoteFxOnly" },

--- a/libfreerdp/core/nego.h
+++ b/libfreerdp/core/nego.h
@@ -114,6 +114,9 @@ FREERDP_LOCAL BOOL nego_set_target(rdpNego* nego, const char* hostname, UINT16 p
 FREERDP_LOCAL void nego_set_negotiation_enabled(rdpNego* nego, BOOL NegotiateSecurityLayer);
 FREERDP_LOCAL void nego_set_restricted_admin_mode_required(rdpNego* nego,
                                                            BOOL RestrictedAdminModeRequired);
+FREERDP_LOCAL void nego_set_RCG_required(rdpNego* nego, BOOL enabled);
+FREERDP_LOCAL void nego_set_RCG_supported(rdpNego* nego, BOOL enabled);
+FREERDP_LOCAL BOOL nego_get_remoteCredentialGuard(rdpNego* nego);
 FREERDP_LOCAL void nego_set_childsession_enabled(rdpNego* nego, BOOL ChildSessionEnabled);
 FREERDP_LOCAL void nego_set_gateway_enabled(rdpNego* nego, BOOL GatewayEnabled);
 FREERDP_LOCAL void nego_set_gateway_bypass_local(rdpNego* nego, BOOL GatewayBypassLocal);

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -267,6 +267,7 @@ static BOOL freerdp_peer_initialize(freerdp_peer* client)
 		}
 	}
 
+	nego_set_RCG_supported(rdp->nego, settings->RemoteCredentialGuard);
 	if (!rdp_server_transition_to_state(rdp, CONNECTION_STATE_INITIAL))
 		return FALSE;
 

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -139,6 +139,7 @@ static const size_t bool_list_indices[] = {
 	FreeRDP_RemoteAssistanceMode,
 	FreeRDP_RemoteAssistanceRequestControl,
 	FreeRDP_RemoteConsoleAudio,
+	FreeRDP_RemoteCredentialGuard,
 	FreeRDP_RemoteFxCodec,
 	FreeRDP_RemoteFxImageCodec,
 	FreeRDP_RemoteFxOnly,

--- a/server/shadow/shadow.c
+++ b/server/shadow/shadow.c
@@ -56,6 +56,8 @@ int main(int argc, char** argv)
 		  "Select rectangle within monitor to share" },
 		{ "auth", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
 		  "Clients must authenticate" },
+		{ "remote-guard", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
+		  "Remote credential guard" },
 		{ "may-view", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
 		  "Clients may view without prompt" },
 		{ "may-interact", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,

--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -303,6 +303,10 @@ int shadow_server_parse_command_line(rdpShadowServer* server, int argc, char** a
 		{
 			server->authentication = arg->Value ? TRUE : FALSE;
 		}
+		CommandLineSwitchCase(arg, "remote-guard")
+		{
+			settings->RemoteCredentialGuard = arg->Value ? TRUE : FALSE;
+		}
 		CommandLineSwitchCase(arg, "sec")
 		{
 			if (strcmp("rdp", arg->Value) == 0) /* Standard RDP */

--- a/winpr/include/winpr/secapi.h
+++ b/winpr/include/winpr/secapi.h
@@ -1,0 +1,78 @@
+/**
+ * WinPR: Windows Portable Runtime
+ * Schannel Security Package
+ *
+ * Copyright 2023 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WINPR_SECAPI_H_
+#define WINPR_SECAPI_H_
+
+#ifdef _WIN32
+#define _NTDEF_
+#include <ntsecapi.h>
+#else
+
+#include <winpr/wtypes.h>
+
+typedef enum _KERB_LOGON_SUBMIT_TYPE
+{
+	KerbInteractiveLogon = 2,
+	KerbSmartCardLogon = 6,
+	KerbWorkstationUnlockLogon = 7,
+	KerbSmartCardUnlockLogon = 8,
+	KerbProxyLogon = 9,
+	KerbTicketLogon = 10,
+	KerbTicketUnlockLogon = 11,
+	KerbS4ULogon = 12,
+	KerbCertificateLogon = 13,
+	KerbCertificateS4ULogon = 14,
+	KerbCertificateUnlockLogon = 15,
+	KerbNoElevationLogon = 83,
+	KerbLuidLogon = 84
+} KERB_LOGON_SUBMIT_TYPE,
+    *PKERB_LOGON_SUBMIT_TYPE;
+
+typedef struct _KERB_TICKET_LOGON
+{
+	KERB_LOGON_SUBMIT_TYPE MessageType;
+	ULONG Flags;
+	ULONG ServiceTicketLength;
+	ULONG TicketGrantingTicketLength;
+	PUCHAR ServiceTicket;
+	PUCHAR TicketGrantingTicket;
+} KERB_TICKET_LOGON, *PKERB_TICKET_LOGON;
+
+#define KERB_LOGON_FLAG_ALLOW_EXPIRED_TICKET 0x1
+
+#define MSV1_0_OWF_PASSWORD_LENGTH 16
+
+typedef struct _MSV1_0_SUPPLEMENTAL_CREDENTIAL
+{
+	ULONG Version;
+	ULONG Flags;
+	UCHAR LmPassword[MSV1_0_OWF_PASSWORD_LENGTH];
+	UCHAR NtPassword[MSV1_0_OWF_PASSWORD_LENGTH];
+} MSV1_0_SUPPLEMENTAL_CREDENTIAL, *PMSV1_0_SUPPLEMENTAL_CREDENTIAL;
+
+#define MSV1_0_CRED_VERSION_REMOTE 0xffff0002
+
+#endif /* _WIN32 */
+
+#ifndef KERB_LOGON_FLAG_REDIRECTED
+#define KERB_LOGON_FLAG_REDIRECTED 0x2
+#endif
+
+#endif /* WINPR_SECAPI_H_ */


### PR DESCRIPTION
Adds support for server-side remote credential guard in NLA. When enabled that allows the remote user to connect without shipping credentials in TSCred packets. Instead it will send his TGT encoded with a TGS from the remote server. This way the server is able to populate that TGT in a local credential cache without knowing the user's password.

The patch only treats the NLA part and does not contain the associated RDPEAR channel that allows to have the complete interaction to retrieve new access tokens.