### PR TITLE
crypto: Don't rely on OpenSSL 1.1.x symbols

### DIFF
--- a/libfreerdp/crypto/crypto.c
+++ b/libfreerdp/crypto/crypto.c
@@ -950,11 +950,12 @@ WINPR_MD_TYPE crypto_cert_get_signature_alg(X509* xcert)
 {
 	WINPR_ASSERT(xcert);
 
-	EVP_PKEY* evp = X509_get0_pubkey(xcert);
+	EVP_PKEY* evp = X509_get_pubkey(xcert);
 	WINPR_ASSERT(evp);
 
 	int hash_nid = 0;
 	const int res = EVP_PKEY_get_default_digest_nid(evp, &hash_nid);
+	EVP_PKEY_free(evp);
 	if (res <= 0)
 		return WINPR_MD_NONE;
 


### PR DESCRIPTION
Commit e93433fb21231dba2b989b38e058706c3e46d9e2 backports some code from FreeRDP 3.0. However, such code relies on a symbol not present in OpenSSL 1.0.x, effectively bumbing the minimum required version:
```
libfreerdp/crypto/crypto.c:953:18: warning: implicit declaration of function 'X509_get0_pubkey'; did you mean 'X509_get_pubkey'? [-Wimplicit-function-declaration]
```

Drop X509_get0_pubkey() usage in favor of X509_get_pubkey(). Free the returned public key.
