### PR TITLE
Fix DPI issue when parent-window specified

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -1346,6 +1346,7 @@ static void wfreerdp_client_free(freerdp* instance, rdpContext* context)
 
 static int wfreerdp_client_start(rdpContext* context)
 {
+	int dpiAwareness = 0;
 	HWND hWndParent;
 	HINSTANCE hInstance;
 	wfContext* wfc = (wfContext*)context;
@@ -1361,6 +1362,13 @@ static int wfreerdp_client_start(rdpContext* context)
 	hWndParent = (HWND)context->settings->ParentWindowId;
 	context->settings->EmbeddedWindow = (hWndParent) ? TRUE : FALSE;
 	wfc->hWndParent = hWndParent;
+
+	if (context->settings->EmbeddedWindow)
+	{
+		dpiAwareness = GetDpiForWindow(hWndParent);
+		if (dpiAwareness == 0x000000c0)
+			SetProcessDPIAware();
+	}
 
 	/* initial windows system item position where we will insert new menu item
 	 * after default 5 items (restore, move, size, minimize, maximize)


### PR DESCRIPTION
This change should fix DPI scaling issue when wfreerdp.exe is started using parent-handle argument of a control/window with SystemAware or PerMonitorDpiAware mode.

This was tested on two machines but I'm not sure if the usage of these APIs is correct. Please let me know if there's a better way or if there are issues with my suggested implementation.

Thank you!