### PR TITLE
[cmdline] add missing return statement

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -502,7 +502,7 @@ static COMMAND_LINE_ARGUMENT_A* create_merged_args(const COMMAND_LINE_ARGUMENT_A
 	    calloc(count + ARRAYSIZE(global_cmd_args), sizeof(COMMAND_LINE_ARGUMENT_A));
 	*pcount = 0;
 	if (!largs)
-		NULL;
+		return NULL;
 
 	size_t lcount = 0;
 	const COMMAND_LINE_ARGUMENT_A* cur = custom;


### PR DESCRIPTION
I had this bug in my own code and was surprised it doesn't produce any compiler warnings. After a quick search for similar code patterns `if (...) NULL;` I was able to find this bug in FreeRDP.