### PR TITLE
[core] fix freezing connection to childSession

### DIFF
--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -104,6 +104,18 @@ static BOOL nego_process_negotiation_request(rdpNego* nego, wStream* s);
 static BOOL nego_process_negotiation_response(rdpNego* nego, wStream* s);
 static BOOL nego_process_negotiation_failure(rdpNego* nego, wStream* s);
 
+BOOL nego_update_settings_from_state(rdpNego* nego, rdpSettings* settings)
+{
+	WINPR_ASSERT(nego);
+
+	/* update settings with negotiated protocol security */
+	return freerdp_settings_set_uint32(settings, FreeRDP_RequestedProtocols,
+	                                   nego->RequestedProtocols) &&
+	       freerdp_settings_set_uint32(settings, FreeRDP_SelectedProtocol,
+	                                   nego->SelectedProtocol) &&
+	       freerdp_settings_set_uint32(settings, FreeRDP_NegotiationFlags, nego->flags);
+}
+
 /**
  * Negotiate protocol security and connect.
  *
@@ -243,13 +255,9 @@ BOOL nego_connect(rdpNego* nego)
 	}
 
 	WLog_DBG(TAG, "Negotiated %s security", protocol_security_string(nego->SelectedProtocol));
+
 	/* update settings with negotiated protocol security */
-	if (!freerdp_settings_set_uint32(settings, FreeRDP_RequestedProtocols,
-	                                 nego->RequestedProtocols))
-		return FALSE;
-	if (!freerdp_settings_set_uint32(settings, FreeRDP_SelectedProtocol, nego->SelectedProtocol))
-		return FALSE;
-	if (!freerdp_settings_set_uint32(settings, FreeRDP_NegotiationFlags, nego->flags))
+	if (!nego_update_settings_from_state(nego, settings))
 		return FALSE;
 
 	if (nego->SelectedProtocol == PROTOCOL_RDP)

--- a/libfreerdp/core/nego.h
+++ b/libfreerdp/core/nego.h
@@ -141,6 +141,8 @@ FREERDP_LOCAL BOOL nego_set_selected_protocol(rdpNego* nego, UINT32 SelectedProt
 FREERDP_LOCAL UINT32 nego_get_requested_protocols(rdpNego* nego);
 FREERDP_LOCAL BOOL nego_set_requested_protocols(rdpNego* nego, UINT32 RequestedProtocols);
 
+FREERDP_LOCAL BOOL nego_update_settings_from_state(rdpNego* nego, rdpSettings* settings);
+
 FREERDP_LOCAL BOOL nego_set_state(rdpNego* nego, NEGO_STATE state);
 FREERDP_LOCAL NEGO_STATE nego_get_state(rdpNego* nego);
 

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1442,7 +1442,7 @@ BOOL rdp_decrypt(rdpRdp* rdp, wStream* s, UINT16* pLength, UINT16 securityFlags)
 			goto unlock;
 
 		UINT16 len = 0;
-		Stream_Read_UINT16(s, len);    /* 0x10 */
+		Stream_Read_UINT16(s, len); /* 0x10 */
 		if (len != 0x10)
 			WLog_Print(rdp->log, WLOG_WARN, "ENCRYPTION_METHOD_FIPS length %" PRIu16 " != 0x10",
 			           len);
@@ -1851,6 +1851,9 @@ static state_run_t rdp_recv_callback_int(rdpTransport* transport, wStream* s, vo
 			else if (nla_get_state(rdp->nla) == NLA_STATE_POST_NEGO)
 			{
 				nego_recv(rdp->transport, s, (void*)rdp->nego);
+
+				if (!nego_update_settings_from_state(rdp->nego, rdp->settings))
+					return FALSE;
 
 				if (nego_get_state(rdp->nego) != NEGO_STATE_FINAL)
 				{


### PR DESCRIPTION
When connecting to child session(or a VM), we have CredSSP/Nego/ActivationSequence instead of Nego/CredSSP/ActivationSequence. Before the patch, we were not applying flags read in the NegoResponse to the settings and that was leading to FreeRDP thinking that the remote server was not supporting EXTENDED_CLIENT_DATA_SUPPORTED. That was later preventing some GCC blocks to be sent, and make the server unhappy and freeze the connection.
