### PR TITLE
Server channel event

### DIFF
--- a/channels/location/server/location_main.c
+++ b/channels/location/server/location_main.c
@@ -75,7 +75,6 @@ static UINT location_server_open_channel(location_server* location)
 {
 	LocationServerContext* context = &location->context;
 	DWORD Error = ERROR_SUCCESS;
-	HANDLE hEvent;
 	DWORD BytesReturned = 0;
 	PULONG pSessionId = NULL;
 	UINT32 channelId;
@@ -92,14 +91,6 @@ static UINT location_server_open_channel(location_server* location)
 
 	location->SessionId = (DWORD)*pSessionId;
 	WTSFreeMemory(pSessionId);
-	hEvent = WTSVirtualChannelManagerGetEventHandle(location->context.vcm);
-
-	if (WaitForSingleObject(hEvent, 1000) == WAIT_FAILED)
-	{
-		Error = GetLastError();
-		WLog_ERR(TAG, "WaitForSingleObject failed with error %" PRIu32 "!", Error);
-		return Error;
-	}
 
 	location->location_channel = WTSVirtualChannelOpenEx(
 	    location->SessionId, LOCATION_DVC_CHANNEL_NAME, WTS_CHANNEL_OPTION_DYNAMIC);

--- a/channels/rdpecam/server/camera_device_enumerator_main.c
+++ b/channels/rdpecam/server/camera_device_enumerator_main.c
@@ -74,7 +74,6 @@ static UINT enumerator_server_open_channel(enumerator_server* enumerator)
 {
 	CamDevEnumServerContext* context = &enumerator->context;
 	DWORD Error = ERROR_SUCCESS;
-	HANDLE hEvent;
 	DWORD BytesReturned = 0;
 	PULONG pSessionId = NULL;
 	UINT32 channelId;
@@ -91,14 +90,6 @@ static UINT enumerator_server_open_channel(enumerator_server* enumerator)
 
 	enumerator->SessionId = (DWORD)*pSessionId;
 	WTSFreeMemory(pSessionId);
-	hEvent = WTSVirtualChannelManagerGetEventHandle(enumerator->context.vcm);
-
-	if (WaitForSingleObject(hEvent, 1000) == WAIT_FAILED)
-	{
-		Error = GetLastError();
-		WLog_ERR(TAG, "WaitForSingleObject failed with error %" PRIu32 "!", Error);
-		return Error;
-	}
 
 	enumerator->enumerator_channel = WTSVirtualChannelOpenEx(
 	    enumerator->SessionId, RDPECAM_CONTROL_DVC_CHANNEL_NAME, WTS_CHANNEL_OPTION_DYNAMIC);

--- a/channels/rdpecam/server/camera_device_main.c
+++ b/channels/rdpecam/server/camera_device_main.c
@@ -74,7 +74,6 @@ static UINT device_server_open_channel(device_server* device)
 {
 	CameraDeviceServerContext* context = &device->context;
 	DWORD Error = ERROR_SUCCESS;
-	HANDLE hEvent;
 	DWORD BytesReturned = 0;
 	PULONG pSessionId = NULL;
 	UINT32 channelId;
@@ -91,14 +90,6 @@ static UINT device_server_open_channel(device_server* device)
 
 	device->SessionId = (DWORD)*pSessionId;
 	WTSFreeMemory(pSessionId);
-	hEvent = WTSVirtualChannelManagerGetEventHandle(device->context.vcm);
-
-	if (WaitForSingleObject(hEvent, 1000) == WAIT_FAILED)
-	{
-		Error = GetLastError();
-		WLog_ERR(TAG, "WaitForSingleObject failed with error %" PRIu32 "!", Error);
-		return Error;
-	}
 
 	device->device_channel = WTSVirtualChannelOpenEx(device->SessionId, context->virtualChannelName,
 	                                                 WTS_CHANNEL_OPTION_DYNAMIC);

--- a/channels/telemetry/server/telemetry_main.c
+++ b/channels/telemetry/server/telemetry_main.c
@@ -74,7 +74,6 @@ static UINT telemetry_server_open_channel(telemetry_server* telemetry)
 {
 	TelemetryServerContext* context = &telemetry->context;
 	DWORD Error = ERROR_SUCCESS;
-	HANDLE hEvent;
 	DWORD BytesReturned = 0;
 	PULONG pSessionId = NULL;
 	UINT32 channelId;
@@ -91,14 +90,6 @@ static UINT telemetry_server_open_channel(telemetry_server* telemetry)
 
 	telemetry->SessionId = (DWORD)*pSessionId;
 	WTSFreeMemory(pSessionId);
-	hEvent = WTSVirtualChannelManagerGetEventHandle(telemetry->context.vcm);
-
-	if (WaitForSingleObject(hEvent, 1000) == WAIT_FAILED)
-	{
-		Error = GetLastError();
-		WLog_ERR(TAG, "WaitForSingleObject failed with error %" PRIu32 "!", Error);
-		return Error;
-	}
 
 	telemetry->telemetry_channel = WTSVirtualChannelOpenEx(
 	    telemetry->SessionId, TELEMETRY_DVC_CHANNEL_NAME, WTS_CHANNEL_OPTION_DYNAMIC);

--- a/client/SDL/sdl_freerdp.cpp
+++ b/client/SDL/sdl_freerdp.cpp
@@ -1211,7 +1211,7 @@ static DWORD WINAPI sdl_client_thread_proc(SdlContext* sdl)
 			break;
 		}
 
-		status = WaitForMultipleObjects(nCount, handles, FALSE, 100);
+		status = WaitForMultipleObjects(nCount, handles, FALSE, INFINITE);
 
 		if (status == WAIT_FAILED)
 		{

--- a/client/Sample/tf_freerdp.c
+++ b/client/Sample/tf_freerdp.c
@@ -262,7 +262,7 @@ static DWORD WINAPI tf_client_thread_proc(LPVOID arg)
 			break;
 		}
 
-		status = WaitForMultipleObjects(nCount, handles, FALSE, 100);
+		status = WaitForMultipleObjects(nCount, handles, FALSE, INFINITE);
 
 		if (status == WAIT_FAILED)
 		{

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -1046,7 +1046,7 @@ static DWORD WINAPI wf_client_thread(LPVOID lpParam)
 			nCount += tmp;
 		}
 
-		if (MsgWaitForMultipleObjects(nCount, handles, FALSE, 1000, QS_ALLINPUT) == WAIT_FAILED)
+		if (MsgWaitForMultipleObjects(nCount, handles, FALSE, INFINITE, QS_ALLINPUT) == WAIT_FAILED)
 		{
 			WLog_ERR(TAG, "wfreerdp_run: WaitForMultipleObjects failed: 0x%08lX", GetLastError());
 			break;

--- a/libfreerdp/core/gateway/tsg.c
+++ b/libfreerdp/core/gateway/tsg.c
@@ -2792,12 +2792,13 @@ static int tsg_read(rdpTsg* tsg, BYTE* data, size_t length)
 
 		if (transport_get_blocking(rpc->transport))
 		{
-			while (WaitForSingleObject(rpc->client->PipeEvent, 0) != WAIT_OBJECT_0)
+			DWORD rc;
+			while ((rc = WaitForSingleObject(rpc->client->PipeEvent, 1000)) != WAIT_OBJECT_0)
 			{
+				if (rc == WAIT_FAILED)
+					return -1;
 				if (!tsg_check_event_handles(tsg))
 					return -1;
-
-				WaitForSingleObject(rpc->client->PipeEvent, 100);
 			}
 		}
 	} while (transport_get_blocking(rpc->transport));

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -985,20 +985,16 @@ BOOL pf_server_run(proxyServer* server)
 
 		WINPR_ASSERT(server->stopEvent);
 		eventHandles[eventCount++] = server->stopEvent;
-		status = WaitForMultipleObjects(eventCount, eventHandles, FALSE, 1000);
-
-		if (WAIT_FAILED == status)
-			break;
-
-		if (WaitForSingleObject(server->stopEvent, 0) == WAIT_OBJECT_0)
-			break;
+		status = WaitForMultipleObjects(eventCount, eventHandles, FALSE, INFINITE);
 
 		if (WAIT_FAILED == status)
 		{
-			WLog_ERR(TAG, "select failed");
-			rc = FALSE;
+			WLog_ERR(TAG, "WaitForMultipleObjects failed");
 			break;
 		}
+
+		if (WaitForSingleObject(server->stopEvent, 0) == WAIT_OBJECT_0)
+			break;
 
 		WINPR_ASSERT(listener->CheckFileDescriptor);
 		if (listener->CheckFileDescriptor(listener) != TRUE)


### PR DESCRIPTION
* Remove timed wait after `WTSQuerySessionInformationA` before `WTSVirtualChannelOpenEx` (looks like some leftover from really long ago, anyone has a clue why that was added?)
* Do some cleanups / fixes in `server.c` core API
* Replace timed `WaitForMultipleObjects` with `INFINITE` (if there are issues we better fix them properly instead of using polling)