### PR TITLE
[channels,rdpdr] fix #9610

### DIFF
--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -1666,8 +1666,11 @@ static BOOL rdpdr_check_channel_state(rdpdrPlugin* rdpdr, UINT16 packetid)
 			return rdpdr_state_check(rdpdr, packetid, RDPDR_CHANNEL_STATE_ANNOUNCE, 1,
 			                         RDPDR_CHANNEL_STATE_INITIAL);
 		case PAKID_CORE_SERVER_CAPABILITY:
-			return rdpdr_state_check(rdpdr, packetid, RDPDR_CHANNEL_STATE_SERVER_CAPS, 1,
-			                         RDPDR_CHANNEL_STATE_NAME_REQUEST);
+			return rdpdr_state_check(rdpdr, packetid, RDPDR_CHANNEL_STATE_SERVER_CAPS, 6,
+			                         RDPDR_CHANNEL_STATE_NAME_REQUEST,
+			                         RDPDR_CHANNEL_STATE_SERVER_CAPS, RDPDR_CHANNEL_STATE_READY,
+			                         RDPDR_CHANNEL_STATE_CLIENT_CAPS, PAKID_CORE_CLIENTID_CONFIRM,
+			                         PAKID_CORE_USER_LOGGEDON);
 		case PAKID_CORE_CLIENTID_CONFIRM:
 			return rdpdr_state_check(rdpdr, packetid, RDPDR_CHANNEL_STATE_CLIENTID_CONFIRM, 3,
 			                         RDPDR_CHANNEL_STATE_CLIENT_CAPS, RDPDR_CHANNEL_STATE_READY,

--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -1559,7 +1559,7 @@ static UINT rdpdr_process_component(rdpdrPlugin* rdpdr, UINT16 component, UINT16
 	device = devman_get_device_by_type(rdpdr->devman, type);
 
 	if (!device)
-		return ERROR_INVALID_PARAMETER;
+		return ERROR_DEV_NOT_EXIST;
 
 	return IFCALLRESULT(ERROR_INVALID_PARAMETER, device->CustomComponentRequest, device, component,
 	                    packetId, s);
@@ -1829,7 +1829,16 @@ static UINT rdpdr_process_receive(rdpdrPlugin* rdpdr, wStream* s)
 
 			if (error != CHANNEL_RC_OK)
 			{
-				WLog_Print(rdpdr->log, WLOG_ERROR,
+				DWORD level = WLOG_ERROR;
+				if (rdpdr->ignoreInvalidDevices)
+				{
+					if (error == ERROR_DEV_NOT_EXIST)
+					{
+						level = WLOG_WARN;
+						error = CHANNEL_RC_OK;
+					}
+				}
+				WLog_Print(rdpdr->log, level,
 				           "Unknown message: Component: %s [0x%04" PRIX16
 				           "] PacketId: %s [0x%04" PRIX16 "]",
 				           rdpdr_component_string(component), component,


### PR DESCRIPTION
windows RDP server randomly sends PAKID_CORE_SERVER_CAPABILITY to reinitialize the rdpdr channel. Allow this message in all following states.