### PR TITLE
[winpr,crt] fix ICU string convert

### DIFF
--- a/winpr/libwinpr/crt/CMakeLists.txt
+++ b/winpr/libwinpr/crt/CMakeLists.txt
@@ -29,7 +29,7 @@ if (NOT WITH_ICU)
 endif(NOT WITH_ICU)
 
 if (WITH_ICU)
-	find_package(ICU REQUIRED i18n uc io)
+	find_package(ICU REQUIRED i18n uc io data)
 	winpr_include_directory_add(${ICU_INCLUDE_DIRS})
 	winpr_library_add_private(${ICU_LIBRARIES})
 endif (WITH_ICU)


### PR DESCRIPTION
use ucnv_convert to make conversion endian safe

(cherry picked from commit d47058011e7c5e628e47be0d968d0bb2ded63f99)

backport #9629 