### PR TITLE
Bigendian

### DIFF
--- a/.github/workflows/alt-architectures.yml
+++ b/.github/workflows/alt-architectures.yml
@@ -79,6 +79,9 @@ jobs:
               libsdl2-ttf-dev \
               libwebkit2gtk-4.0-dev \
               libopus-dev \
+              libwebp-dev \
+              libpng-dev \
+              libjpeg-dev \
               liburiparser-dev \
               cmake \
               clang

--- a/.github/workflows/alt-architectures.yml
+++ b/.github/workflows/alt-architectures.yml
@@ -1,0 +1,97 @@
+name: '[arm,ppc,ricsv] architecture builds'
+on:
+  workflow_dispatch:
+    branches: [ master, stable* ]
+  schedule:
+    - cron: '30 5 * * SUN'
+
+jobs:
+  build_job:
+    runs-on: ubuntu-latest
+    name: "Test on ${{ matrix.distro }}/${{ matrix.arch }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: armv6
+            distro: bullseye
+          - arch: armv7
+            distro: bullseye
+          - arch: aarch64
+            distro: bullseye
+          - arch: s390x
+            distro: bullseye
+          - arch: ppc64le
+            distro: bullseye
+          - arch: riscv64
+            distro: ubuntu22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: uraimo/run-on-arch-action@master
+        name: "Run tests"
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+          githubToken: ${{ github.token }}
+          env: |
+            CTEST_OUTPUT_ON_FAILURE: 1
+            WLOG_LEVEL: 'trace'
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y \
+              libxrandr-dev \
+              libxinerama-dev \
+              libusb-1.0-0-dev \
+              xserver-xorg-dev \
+              libswscale-dev \
+              libswresample-dev \
+              libavutil-dev \
+              libavcodec-dev \
+              libcups2-dev \
+              libpulse-dev \
+              libasound2-dev \
+              libpcsclite-dev \
+              xsltproc \
+              libxcb-cursor-dev \
+              libxcursor-dev \
+              libcairo2-dev \
+              libfaad-dev \
+              libjpeg-dev \
+              libgsm1-dev \
+              ninja-build \
+              libxfixes-dev \
+              libxkbcommon-dev \
+              libwayland-dev \
+              libpam0g-dev \
+              libxdamage-dev \
+              libxcb-damage0-dev \
+              libxtst-dev \
+              libfuse3-dev \
+              libsystemd-dev \
+              libcairo2-dev \
+              libsoxr-dev \
+              libsdl2-dev \
+              docbook-xsl \
+              libkrb5-dev \
+              libcjson-dev \
+              libpkcs11-helper1-dev \
+              libsdl2-ttf-dev \
+              libwebkit2gtk-4.0-dev \
+              libopus-dev \
+              liburiparser-dev \
+              cmake \
+              clang
+          run: |
+            cmake -GNinja \
+              -C ci/cmake-preloads/config-linux-all.txt \
+              -B ci-build \
+              -S . \
+              -DCMAKE_INSTALL_PREFIX=/tmp/ci-test \
+              -DCMAKE_C_COMPILER=/usr/bin/clang \
+              -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+              -DUSE_UNWIND=OFF \
+              -DUSE_EXECINFO=OFF \
+              -DWITH_SANITIZE_ADDRESS=OFF
+            cmake --build ci-build --parallel $(nproc) --target install
+            cmake --build ci-build --parallel $(nproc) --target test

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -17,7 +17,7 @@ jobs:
       id: review
       with:
         # List of packages to install
-        apt_packages: libkrb5-dev,libxkbcommon-dev,libxkbfile-dev,libx11-dev,libwayland-dev,libxrandr-dev,libxi-dev,libxrender-dev,libxext-dev,libxinerama-dev,libxfixes-dev,libxcursor-dev,libxv-dev,libxdamage-dev,libxtst-dev,libcups2-dev,libcairo2-dev,libpcsclite-dev,libasound2-dev,libswscale-dev,libpulse-dev,libavcodec-dev,libavutil-dev,libfuse3-dev,libswresample-dev,libusb-1.0-0-dev,libudev-dev,libdbus-glib-1-dev,libpam0g-dev,uuid-dev,libxml2-dev,libcjson-dev,libsdl2-2.0-0,libsdl2-dev,libsdl2-ttf-dev,libsdl2-image-dev,libsystemd-dev,libpkcs11-helper1-dev,libwebkit2gtk-4.0-dev,liburiparser-dev,libopus-dev,opensc-pkcs11,libwebp-dev,libjpeg-dev,libpng-dev
+        apt_packages: libkrb5-dev,libxkbcommon-dev,libxkbfile-dev,libx11-dev,libwayland-dev,libxrandr-dev,libxi-dev,libxrender-dev,libxext-dev,libxinerama-dev,libxfixes-dev,libxcursor-dev,libxv-dev,libxdamage-dev,libxtst-dev,libcups2-dev,libcairo2-dev,libpcsclite-dev,libasound2-dev,libswscale-dev,libpulse-dev,libavcodec-dev,libavutil-dev,libfuse3-dev,libswresample-dev,libusb-1.0-0-dev,libudev-dev,libdbus-glib-1-dev,libpam0g-dev,uuid-dev,libxml2-dev,libcjson-dev,libsdl2-2.0-0,libsdl2-dev,libsdl2-ttf-dev,libsdl2-image-dev,libsystemd-dev,libpkcs11-helper1-dev,libwebkit2gtk-4.0-dev,liburiparser-dev,libopus-dev,opensc-pkcs11,libwebp-dev,libjpeg-dev,libpng-dev,xsltproc,docbook-xsl
 
         # CMake command to run in order to generate compile_commands.json
         build_dir: tidy

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -110,6 +110,9 @@ jobs:
          libwebkit2gtk-4.0-dev \
          clang \
          libopus-dev \
+         libwebp-dev \
+         libpng-dev \
+         libjpeg-dev \
          liburiparser-dev
        mkdir ci-build
        cd ci-build


### PR DESCRIPTION
A first try to get proper test coverage for alternate architectures:
* Build the whole thing on these architectures and let the `ctests` run
* Fix string constants, make them always `UTF-16-LE`

What is not yet addressed:

* ~~`TestFreeRDPCodecProgressive` has some big endian issue~~ reverted commit 6ba4aad9ab0d3a039f982494dc40c7fc56a35376.
* ~~`TestBacktrace` and `TestASN1` fail on `ppc64le`~~ disabled backtrace support, not working in container
* `TestConnect` has an issue with all of the builds, most likely some restriction of the container, needs to be investigated