### PR TITLE
Fix Clang -Wincompatible-pointer-types warnings

### DIFF
--- a/winpr/libwinpr/crypto/hash.c
+++ b/winpr/libwinpr/crypto/hash.c
@@ -241,7 +241,7 @@ BOOL winpr_HMAC_Init(WINPR_HMAC_CTX* ctx, WINPR_MD_TYPE md, const void* key, siz
 		return FALSE;
 
 	const char* param_name = OSSL_MAC_PARAM_DIGEST;
-	const OSSL_PARAM param[] = { OSSL_PARAM_construct_utf8_string(param_name, hash, 0),
+	const OSSL_PARAM param[] = { OSSL_PARAM_construct_utf8_string(param_name, (char*)hash, 0),
 		                         OSSL_PARAM_construct_end() };
 
 	if (EVP_MAC_init(ctx->xhmac, key, keylen, param) == 1)

--- a/winpr/libwinpr/smartcard/smartcard_pcsc.c
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.c
@@ -872,7 +872,7 @@ static LONG WINAPI PCSC_SCardListReaderGroupsW(SCARDCONTEXT hContext, LPWSTR msz
 }
 
 static LONG WINAPI PCSC_SCardListReaders_Internal(SCARDCONTEXT hContext, LPCSTR mszGroups,
-                                                  LPSTR mszReaders, LPDWORD pcchReaders)
+                                                  LPSTR* mszReaders, LPDWORD pcchReaders)
 {
 	PCSC_LONG status = SCARD_S_SUCCESS;
 	BOOL pcchReadersAlloc = FALSE;
@@ -912,12 +912,12 @@ static LONG WINAPI PCSC_SCardListReaders_Internal(SCARDCONTEXT hContext, LPCSTR 
 			else
 				PCSC_AddMemoryBlock(hContext, tmp);
 
-			*(char**)mszReaders = tmp;
+			*mszReaders = tmp;
 		}
 	}
 	else
 	{
-		status = g_PCSC.pfnSCardListReaders(hContext, mszGroups, mszReaders, &pcsc_cchReaders);
+		status = g_PCSC.pfnSCardListReaders(hContext, mszGroups, *mszReaders, &pcsc_cchReaders);
 	}
 
 	*pcchReaders = (DWORD)pcsc_cchReaders;
@@ -946,7 +946,7 @@ static LONG WINAPI PCSC_SCardListReadersA(SCARDCONTEXT hContext, LPCSTR mszGroup
 	if (!PCSC_LockCardContext(hContext))
 		return SCARD_E_INVALID_HANDLE;
 
-	status = PCSC_SCardListReaders_Internal(hContext, mszGroups, mszReaders, pcchReaders);
+	status = PCSC_SCardListReaders_Internal(hContext, mszGroups, &mszReaders, pcchReaders);
 
 	if (!PCSC_UnlockCardContext(hContext))
 		return SCARD_E_INVALID_HANDLE;
@@ -993,7 +993,7 @@ static LONG WINAPI PCSC_SCardListReadersW(SCARDCONTEXT hContext, LPCWSTR mszGrou
 	}
 
 	status =
-	    PCSC_SCardListReaders_Internal(hContext, mszGroupsA, (LPSTR*)&mszReadersA, pcchReaders);
+	    PCSC_SCardListReaders_Internal(hContext, mszGroupsA, &mszReadersA, pcchReaders);
 	if (status == SCARD_S_SUCCESS)
 	{
 		size_t size = 0;


### PR DESCRIPTION
Fixes two cases of Clang warnings for conversions between incompatible pointer types.

In case of the smartcard code, change the (local) function to take a double pointer, instead of a single pointer combined with sometimes casting the argument to a double pointer.

For the crypto code, add a cast much like how OpenSSL does this internally.

For a more detailed description, please see the individual commits :)