### PR TITLE
[core] allow to specify the hostname used for AAD

### DIFF
--- a/include/freerdp/settings_types_private.h
+++ b/include/freerdp/settings_types_private.h
@@ -71,7 +71,8 @@ struct rdp_settings
 	SETTINGS_DEPRECATED(ALIGN64 char* AcceptedCert);            /* 27 */
 	SETTINGS_DEPRECATED(ALIGN64 UINT32 AcceptedCertLength);     /* 28 */
 	SETTINGS_DEPRECATED(ALIGN64 char* UserSpecifiedServerName); /* 29 */
-	UINT64 padding0064[64 - 30];                                /* 30 */
+	SETTINGS_DEPRECATED(ALIGN64 char* AadServerHostname);       /* 30 */
+	UINT64 padding0064[64 - 31];                                /* 31 */
 	/* resource management related options */
 	SETTINGS_DEPRECATED(ALIGN64 UINT32 ThreadingFlags); /* 64 */
 

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -2613,6 +2613,9 @@ const char* freerdp_settings_get_string(const rdpSettings* settings,
 
 	switch (id)
 	{
+		case FreeRDP_AadServerHostname:
+			return settings->AadServerHostname;
+
 		case FreeRDP_AcceptedCert:
 			return settings->AcceptedCert;
 
@@ -2919,6 +2922,9 @@ char* freerdp_settings_get_string_writable(rdpSettings* settings, FreeRDP_Settin
 
 	switch (id)
 	{
+		case FreeRDP_AadServerHostname:
+			return settings->AadServerHostname;
+
 		case FreeRDP_AcceptedCert:
 			return settings->AcceptedCert;
 
@@ -3235,6 +3241,9 @@ BOOL freerdp_settings_set_string_(rdpSettings* settings, FreeRDP_Settings_Keys_S
 
 	switch (id)
 	{
+		case FreeRDP_AadServerHostname:
+			return update_string_(&settings->AadServerHostname, cnv.c, len);
+
 		case FreeRDP_AcceptedCert:
 			return update_string_(&settings->AcceptedCert, cnv.c, len);
 
@@ -3566,6 +3575,9 @@ BOOL freerdp_settings_set_string_copy_(rdpSettings* settings, FreeRDP_Settings_K
 
 	switch (id)
 	{
+		case FreeRDP_AadServerHostname:
+			return update_string_copy_(&settings->AadServerHostname, cnv.cc, len, cleanup);
+
 		case FreeRDP_AcceptedCert:
 			return update_string_copy_(&settings->AcceptedCert, cnv.cc, len, cleanup);
 

--- a/libfreerdp/common/settings_str.h
+++ b/libfreerdp/common/settings_str.h
@@ -435,6 +435,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_XPan, FREERDP_SETTINGS_TYPE_INT32, "FreeRDP_XPan" },
 	{ FreeRDP_YPan, FREERDP_SETTINGS_TYPE_INT32, "FreeRDP_YPan" },
 	{ FreeRDP_ParentWindowId, FREERDP_SETTINGS_TYPE_UINT64, "FreeRDP_ParentWindowId" },
+	{ FreeRDP_AadServerHostname, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_AadServerHostname" },
 	{ FreeRDP_AcceptedCert, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_AcceptedCert" },
 	{ FreeRDP_ActionScript, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_ActionScript" },
 	{ FreeRDP_AllowedTlsCiphers, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_AllowedTlsCiphers" },

--- a/libfreerdp/core/aad.c
+++ b/libfreerdp/core/aad.c
@@ -282,7 +282,9 @@ int aad_client_begin(rdpAad* aad)
 	WINPR_ASSERT(instance);
 
 	/* Get the host part of the hostname */
-	const char* hostname = freerdp_settings_get_string(settings, FreeRDP_ServerHostname);
+	const char* hostname = freerdp_settings_get_string(settings, FreeRDP_AadServerHostname);
+	if (!hostname)
+		hostname = freerdp_settings_get_string(settings, FreeRDP_ServerHostname);
 	if (!hostname)
 	{
 		WLog_Print(aad->log, WLOG_ERROR, "FreeRDP_ServerHostname == NULL");

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -349,6 +349,7 @@ static const size_t uint64_list_indices[] = {
 
 #define have_string_list_indices
 static const size_t string_list_indices[] = {
+	FreeRDP_AadServerHostname,
 	FreeRDP_AcceptedCert,
 	FreeRDP_ActionScript,
 	FreeRDP_AllowedTlsCiphers,


### PR DESCRIPTION
The previous code was assuming that the host name used for doing AAD was ServerHostname parameter. But when you connect directly to Azure hosts you most likely connect by IP and use short name for the AAD host, so you need to be able to give ServerHostname=<IP of host> and AadServerHostname=<shortname>.
