### PR TITLE
[client,sdl] wrap sdl windows in c++ class

### DIFF
--- a/client/SDL/CMakeLists.txt
+++ b/client/SDL/CMakeLists.txt
@@ -86,7 +86,10 @@ set(SRCS
     sdl_freerdp.hpp
     sdl_freerdp.cpp
     sdl_channels.hpp
-    sdl_channels.cpp)
+    sdl_channels.cpp
+    sdl_window.hpp
+    sdl_window.cpp
+)
 
 add_subdirectory(aad)
 set(LIBS

--- a/client/SDL/sdl_freerdp.hpp
+++ b/client/SDL/sdl_freerdp.hpp
@@ -36,13 +36,7 @@
 #include "sdl_disp.hpp"
 #include "sdl_kbd.hpp"
 #include "sdl_utils.hpp"
-
-typedef struct
-{
-	SDL_Window* window;
-	int offset_x;
-	int offset_y;
-} sdl_window_t;
+#include "sdl_window.hpp"
 
 using SDLSurfacePtr = std::unique_ptr<SDL_Surface, decltype(&SDL_FreeSurface)>;
 using SDLPixelFormatPtr = std::unique_ptr<SDL_PixelFormat, decltype(&SDL_FreeFormat)>;
@@ -64,7 +58,7 @@ class SdlContext
 	bool grab_mouse = false;
 	bool grab_kbd = false;
 
-	std::vector<sdl_window_t> windows;
+	std::vector<SdlWindow> windows;
 
 	CriticalSection critical;
 	std::thread thread;

--- a/client/SDL/sdl_monitor.cpp
+++ b/client/SDL/sdl_monitor.cpp
@@ -283,7 +283,7 @@ static BOOL sdl_detect_single_window(SdlContext* sdl, UINT32* pMaxWidth, UINT32*
 		if (freerdp_settings_get_uint32(settings, FreeRDP_NumMonitorIds) == 0)
 		{
 			const size_t id =
-			    (sdl->windows.size() > 0) ? SDL_GetWindowDisplayIndex(sdl->windows[0].window) : 0;
+			    (sdl->windows.size() > 0) ? SDL_GetWindowDisplayIndex(sdl->windows[0].window()) : 0;
 			if (!freerdp_settings_set_pointer_len(settings, FreeRDP_MonitorIds, &id, 1))
 				return FALSE;
 		}

--- a/client/SDL/sdl_touch.cpp
+++ b/client/SDL/sdl_touch.cpp
@@ -57,17 +57,17 @@ BOOL sdl_scale_coordinates(SdlContext* sdl, Uint32 windowId, INT32* px, INT32* p
 	for (const auto& window : sdl->windows)
 	{
 		int w, h;
-		const Uint32 id = SDL_GetWindowID(window.window);
+		const Uint32 id = SDL_GetWindowID(window.window());
 		if (id != windowId)
 		{
 			continue;
 		}
-		SDL_GetWindowSize(window.window, &w, &h);
+		SDL_GetWindowSize(window.window(), &w, &h);
 
 		sx = w / static_cast<double>(gdi->width);
 		sy = h / static_cast<double>(gdi->height);
-		offset_x = window.offset_x;
-		offset_y = window.offset_y;
+		offset_x = window.offsetX();
+		offset_y = window.offsetY();
 		break;
 	}
 

--- a/client/SDL/sdl_window.cpp
+++ b/client/SDL/sdl_window.cpp
@@ -1,0 +1,63 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * SDL Client
+ *
+ * Copyright 2023 Armin Novak <armin.novak@thincast.com>
+ * Copyright 2023 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sdl_window.hpp"
+
+SdlWindow::SdlWindow(const std::string& title, Sint32 startupX, Sint32 startupY, Sint32 width,
+                     Sint32 height, Uint32 flags)
+    : _window(SDL_CreateWindow(title.c_str(), startupX, startupY, width, height, flags)),
+      _offset_x(0), _offset_y(0)
+{
+}
+
+SdlWindow::SdlWindow(SdlWindow&& other)
+    : _window(other._window), _offset_x(other._offset_x), _offset_y(other._offset_y)
+{
+	other._window = nullptr;
+}
+
+SdlWindow::~SdlWindow()
+{
+	SDL_DestroyWindow(_window);
+}
+
+SDL_Window* SdlWindow::window() const
+{
+	return _window;
+}
+
+Sint32 SdlWindow::offsetX() const
+{
+	return _offset_x;
+}
+
+void SdlWindow::setOffsetX(Sint32 x)
+{
+	_offset_x = x;
+}
+
+void SdlWindow::setOffsetY(Sint32 y)
+{
+	_offset_y = y;
+}
+
+Sint32 SdlWindow::offsetY() const
+{
+	return _offset_y;
+}

--- a/client/SDL/sdl_window.hpp
+++ b/client/SDL/sdl_window.hpp
@@ -1,0 +1,48 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * SDL Client
+ *
+ * Copyright 2023 Armin Novak <armin.novak@thincast.com>
+ * Copyright 2023 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <SDL.h>
+
+class SdlWindow
+{
+  public:
+	SdlWindow(const std::string& title, Sint32 startupX, Sint32 startupY, Sint32 width,
+	          Sint32 height, Uint32 flags);
+	SdlWindow(SdlWindow&& other);
+	~SdlWindow();
+
+	SDL_Window* window() const;
+
+	Sint32 offsetX() const;
+	void setOffsetX(Sint32 x);
+
+	void setOffsetY(Sint32 y);
+	Sint32 offsetY() const;
+
+  private:
+	SDL_Window* _window;
+	Sint32 _offset_x;
+	Sint32 _offset_y;
+
+  private:
+	SdlWindow(const SdlWindow& other) = delete;
+};


### PR DESCRIPTION
use RAII for SDL window creation/destruction by wrapping it in SdlWindow constructor/destructor
