### PR TITLE
fix:[locale,keyboard] fix keyboard input confused for linux x86_64

### DIFF
--- a/libfreerdp/locale/keyboard.c
+++ b/libfreerdp/locale/keyboard.c
@@ -279,11 +279,11 @@ static int freerdp_keyboard_init_x11_evdev(DWORD* keyboardLayoutId,
 	WINPR_ASSERT(x11_keycode_to_rdp_scancode);
 	for (size_t keycode = 0; keycode < count; keycode++)
 	{
-		const DWORD vkcode = GetVirtualKeyCodeFromKeycode(keycode, WINPR_KEYCODE_TYPE_EVDEV);
+		const DWORD vkcode = GetVirtualKeyCodeFromKeycode(keycode, WINPR_KEYCODE_TYPE_XKB);
 		x11_keycode_to_rdp_scancode[keycode] =
 		    GetVirtualScanCodeFromVirtualKeyCode(vkcode, WINPR_KBD_TYPE_IBM_ENHANCED);
 	}
-	maptype = WINPR_KEYCODE_TYPE_EVDEV;
+	maptype = WINPR_KEYCODE_TYPE_XKB;
 
 	return 0;
 }


### PR DESCRIPTION
linux x86_64 connect Windows server 2016(share desktop or vapp), keyboard typing is confusing.
freerdp_keyboard_init_x11_evdev -> GetVirtualKeyCodeFromKeycode, parameter should use WINPR_KEYCODE_TYPE_XKB instead of WINPR_KEYCODE_TYPE_EVDEV , can get correct result.