### PR TITLE
Fix wayland scaling

### DIFF
--- a/uwac/libuwac/CMakeLists.txt
+++ b/uwac/libuwac/CMakeLists.txt
@@ -38,6 +38,7 @@ macro(generate_protocol_file PROTO)
 endmacro()
 
 generate_protocol_file(xdg-shell)
+generate_protocol_file(viewporter)
 generate_protocol_file(xdg-decoration-unstable-v1)
 generate_protocol_file(server-decoration)
 generate_protocol_file(ivi-application)

--- a/uwac/libuwac/uwac-display.c
+++ b/uwac/libuwac/uwac-display.c
@@ -226,6 +226,10 @@ static void registry_handle_global(void* data, struct wl_registry* registry, uin
 		d->xdg_base = wl_registry_bind(registry, id, &xdg_wm_base_interface, 1);
 		xdg_wm_base_add_listener(d->xdg_base, &xdg_wm_base_listener, d);
 	}
+	else if (strcmp(interface, "wp_viewporter") == 0)
+	{
+		d->viewporter = wl_registry_bind(registry, id, &wp_viewporter_interface, 1);
+	}
 	else if (strcmp(interface, "zwp_keyboard_shortcuts_inhibit_manager_v1") == 0)
 	{
 		d->keyboard_inhibit_manager =
@@ -561,6 +565,9 @@ UwacReturnCode UwacCloseDisplay(UwacDisplay** pdisplay)
 
 	if (display->shm)
 		wl_shm_destroy(display->shm);
+
+	if (display->viewporter)
+		wp_viewporter_destroy(display->viewporter);
 
 	if (display->subcompositor)
 		wl_subcompositor_destroy(display->subcompositor);

--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -824,10 +824,11 @@ static void pointer_handle_motion(void* data, struct wl_pointer* pointer, uint32
 
 	UwacWindow* window = input->pointer_focus;
 
-	int sx_i = wl_fixed_to_int(sx_w);
-	int sy_i = wl_fixed_to_int(sy_w);
-	double sx_d = wl_fixed_to_double(sx_w);
-	double sy_d = wl_fixed_to_double(sy_w);
+	int scale = window->display->actual_scale;
+	int sx_i = wl_fixed_to_int(sx_w) * scale;
+	int sy_i = wl_fixed_to_int(sy_w) * scale;
+	double sx_d = wl_fixed_to_double(sx_w) * scale;
+	double sy_d = wl_fixed_to_double(sy_w) * scale;
 
 	if (!window || (sx_i < 0) || (sy_i < 0))
 		return;

--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -102,7 +102,10 @@ static UwacReturnCode set_cursor_image(UwacSeat* seat, uint32_t serial)
 	if (!seat || !seat->display || !seat->default_cursor || !seat->default_cursor->images)
 		return UWAC_ERROR_INTERNAL;
 
-	int scale = seat->pointer_focus->display->actual_scale;
+	int scale = 1;
+	if (seat->pointer_focus)
+		scale = seat->pointer_focus->display->actual_scale;
+
 	switch (seat->pointer_type)
 	{
 		case 2: /* Custom poiner */

--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -102,6 +102,7 @@ static UwacReturnCode set_cursor_image(UwacSeat* seat, uint32_t serial)
 	if (!seat || !seat->display || !seat->default_cursor || !seat->default_cursor->images)
 		return UWAC_ERROR_INTERNAL;
 
+	int scale = seat->pointer_focus->display->actual_scale;
 	switch (seat->pointer_type)
 	{
 		case 2: /* Custom poiner */
@@ -113,8 +114,8 @@ static UwacReturnCode set_cursor_image(UwacSeat* seat, uint32_t serial)
 				return UWAC_ERROR_INTERNAL;
 
 			surface = seat->pointer_surface;
-			x = image->hotspot_x;
-			y = image->hotspot_y;
+			x = image->hotspot_x / scale;
+			y = image->hotspot_y / scale;
 			break;
 		case 1: /* NULL pointer */
 			break;
@@ -136,6 +137,7 @@ static UwacReturnCode set_cursor_image(UwacSeat* seat, uint32_t serial)
 
 	if (surface && buffer)
 	{
+		wl_surface_set_buffer_scale(surface, scale);
 		wl_surface_attach(surface, buffer, 0, 0);
 		wl_surface_damage(surface, 0, 0, image->width, image->height);
 		wl_surface_commit(surface);

--- a/uwac/libuwac/uwac-output.c
+++ b/uwac/libuwac/uwac-output.c
@@ -88,7 +88,7 @@ static void output_handle_scale(void* data, struct wl_output* wl_output, int32_t
 	UwacOutput* output = data;
 	assert(output);
 
-	output->scale = scale;
+	output->display->actual_scale = output->scale = scale;
 }
 
 static void output_handle_name(void* data, struct wl_output* wl_output, const char* name)

--- a/uwac/libuwac/uwac-priv.h
+++ b/uwac/libuwac/uwac-priv.h
@@ -128,6 +128,7 @@ struct uwac_display
 	UwacTask dispatch_fd_task;
 	uint32_t serial;
 	uint32_t pointer_focus_serial;
+	int actual_scale;
 
 	struct wl_list windows;
 

--- a/uwac/libuwac/uwac-priv.h
+++ b/uwac/libuwac/uwac-priv.h
@@ -31,6 +31,7 @@
 #include "keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
 #include "xdg-decoration-unstable-v1-client-protocol.h"
 #include "server-decoration-client-protocol.h"
+#include "viewporter-client-protocol.h"
 
 #ifdef BUILD_IVI
 #include "ivi-application-client-protocol.h"
@@ -92,6 +93,7 @@ struct uwac_display
 	struct wl_display* display;
 	struct wl_registry* registry;
 	struct wl_compositor* compositor;
+	struct wp_viewporter* viewporter;
 	struct wl_subcompositor* subcompositor;
 	struct wl_shell* shell;
 	struct xdg_toplevel* xdg_toplevel;

--- a/uwac/libuwac/uwac-priv.h
+++ b/uwac/libuwac/uwac-priv.h
@@ -250,6 +250,7 @@ struct uwac_window
 	ssize_t drawingBufferIdx;
 	ssize_t pendingBufferIdx;
 	struct wl_surface* surface;
+	struct wp_viewport* viewport;
 	struct wl_shell_surface* shell_surface;
 	struct xdg_surface* xdg_surface;
 	struct xdg_toplevel* xdg_toplevel;

--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -680,11 +680,17 @@ static const struct wl_callback_listener frame_listener = { frame_done_cb };
 static void damage_surface(UwacWindow* window, UwacBuffer* buffer, int scale)
 {
 	int nrects, i;
+	int x, y, w, h;
 	const pixman_box32_t* box = pixman_region32_rectangles(&buffer->damage, &nrects);
 
 	for (i = 0; i < nrects; i++, box++)
-		wl_surface_damage(window->surface, box->x1 / scale, box->y1 / scale,
-		                  (box->x2 - box->x1) / scale, (box->y2 - box->y1) / scale);
+	{
+		x = ((int)floor(box->x1 / scale)) - 1;
+		y = ((int)floor(box->y1 / scale)) - 1;
+		w = ((int)ceil((box->x2 - box->x1) / scale)) + 2;
+		h = ((int)ceil((box->y2 - box->y1) / scale)) + 2;
+		wl_surface_damage(window->surface, x, y, w, h);
+	}
 
 	pixman_region32_clear(&buffer->damage);
 }
@@ -692,11 +698,17 @@ static void damage_surface(UwacWindow* window, UwacBuffer* buffer, int scale)
 static void damage_surface(UwacWindow* window, UwacBuffer* buffer, int scale)
 {
 	uint32_t nrects, i;
+	int x, y, w, h;
 	const RECTANGLE_16* box = region16_rects(&buffer->damage, &nrects);
 
 	for (i = 0; i < nrects; i++, box++)
-		wl_surface_damage(window->surface, box->left / scale, box->top / scale,
-		                  (box->right - box->left) / scale, (box->bottom - box->top) / scale);
+	{
+		x = ((int)floor(box->left / scale)) - 1;
+		y = ((int)floor(box->top / scale)) - 1;
+		w = ((int)ceil((box->right - box->left) / scale)) + 2;
+		h = ((int)ceil((box->bottom - box->top) / scale)) + 2;
+		wl_surface_damage(window->surface, x, y, w, h);
+	}
 
 	region16_clear(&buffer->damage);
 }

--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -563,9 +563,12 @@ UwacWindow* UwacCreateWindowShm(UwacDisplay* display, uint32_t width, uint32_t h
 		wl_shell_surface_set_toplevel(w->shell_surface);
 	}
 
-	w->viewport = wp_viewporter_get_viewport(display->viewporter, w->surface);
-	if (display->actual_scale != 1)
-		wl_surface_set_buffer_scale(w->surface, display->actual_scale);
+	if (display->viewporter)
+	{
+		w->viewport = wp_viewporter_get_viewport(display->viewporter, w->surface);
+		if (display->actual_scale != 1)
+			wl_surface_set_buffer_scale(w->surface, display->actual_scale);
+	}
 
 	wl_list_insert(display->windows.prev, &w->link);
 	display->last_error = UWAC_SUCCESS;

--- a/uwac/protocols/viewporter.xml
+++ b/uwac/protocols/viewporter.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="viewporter">
+
+  <copyright>
+    Copyright © 2013-2016 Collabora, Ltd.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="wp_viewporter" version="1">
+    <description summary="surface cropping and scaling">
+      The global interface exposing surface cropping and scaling
+      capabilities is used to instantiate an interface extension for a
+      wl_surface object. This extended interface will then allow
+      cropping and scaling the surface contents, effectively
+      disconnecting the direct relationship between the buffer and the
+      surface size.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="unbind from the cropping and scaling interface">
+	Informs the server that the client will not be using this
+	protocol object anymore. This does not affect any other objects,
+	wp_viewport objects included.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="viewport_exists" value="0"
+             summary="the surface already has a viewport object associated"/>
+    </enum>
+
+    <request name="get_viewport">
+      <description summary="extend surface interface for crop and scale">
+	Instantiate an interface extension for the given wl_surface to
+	crop and scale its content. If the given wl_surface already has
+	a wp_viewport object associated, the viewport_exists
+	protocol error is raised.
+      </description>
+      <arg name="id" type="new_id" interface="wp_viewport"
+           summary="the new viewport interface id"/>
+      <arg name="surface" type="object" interface="wl_surface"
+           summary="the surface"/>
+    </request>
+  </interface>
+
+  <interface name="wp_viewport" version="1">
+    <description summary="crop and scale interface to a wl_surface">
+      An additional interface to a wl_surface object, which allows the
+      client to specify the cropping and scaling of the surface
+      contents.
+
+      This interface works with two concepts: the source rectangle (src_x,
+      src_y, src_width, src_height), and the destination size (dst_width,
+      dst_height). The contents of the source rectangle are scaled to the
+      destination size, and content outside the source rectangle is ignored.
+      This state is double-buffered, and is applied on the next
+      wl_surface.commit.
+
+      The two parts of crop and scale state are independent: the source
+      rectangle, and the destination size. Initially both are unset, that
+      is, no scaling is applied. The whole of the current wl_buffer is
+      used as the source, and the surface size is as defined in
+      wl_surface.attach.
+
+      If the destination size is set, it causes the surface size to become
+      dst_width, dst_height. The source (rectangle) is scaled to exactly
+      this size. This overrides whatever the attached wl_buffer size is,
+      unless the wl_buffer is NULL. If the wl_buffer is NULL, the surface
+      has no content and therefore no size. Otherwise, the size is always
+      at least 1x1 in surface local coordinates.
+
+      If the source rectangle is set, it defines what area of the wl_buffer is
+      taken as the source. If the source rectangle is set and the destination
+      size is not set, then src_width and src_height must be integers, and the
+      surface size becomes the source rectangle size. This results in cropping
+      without scaling. If src_width or src_height are not integers and
+      destination size is not set, the bad_size protocol error is raised when
+      the surface state is applied.
+
+      The coordinate transformations from buffer pixel coordinates up to
+      the surface-local coordinates happen in the following order:
+        1. buffer_transform (wl_surface.set_buffer_transform)
+        2. buffer_scale (wl_surface.set_buffer_scale)
+        3. crop and scale (wp_viewport.set*)
+      This means, that the source rectangle coordinates of crop and scale
+      are given in the coordinates after the buffer transform and scale,
+      i.e. in the coordinates that would be the surface-local coordinates
+      if the crop and scale was not applied.
+
+      If src_x or src_y are negative, the bad_value protocol error is raised.
+      Otherwise, if the source rectangle is partially or completely outside of
+      the non-NULL wl_buffer, then the out_of_buffer protocol error is raised
+      when the surface state is applied. A NULL wl_buffer does not raise the
+      out_of_buffer error.
+
+      If the wl_surface associated with the wp_viewport is destroyed,
+      all wp_viewport requests except 'destroy' raise the protocol error
+      no_surface.
+
+      If the wp_viewport object is destroyed, the crop and scale
+      state is removed from the wl_surface. The change will be applied
+      on the next wl_surface.commit.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="remove scaling and cropping from the surface">
+	The associated wl_surface's crop and scale state is removed.
+	The change is applied on the next wl_surface.commit.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="bad_value" value="0"
+	     summary="negative or zero values in width or height"/>
+      <entry name="bad_size" value="1"
+	     summary="destination size is not integer"/>
+      <entry name="out_of_buffer" value="2"
+	     summary="source rectangle extends outside of the content area"/>
+      <entry name="no_surface" value="3"
+	     summary="the wl_surface was destroyed"/>
+    </enum>
+
+    <request name="set_source">
+      <description summary="set the source rectangle for cropping">
+	Set the source rectangle of the associated wl_surface. See
+	wp_viewport for the description, and relation to the wl_buffer
+	size.
+
+	If all of x, y, width and height are -1.0, the source rectangle is
+	unset instead. Any other set of values where width or height are zero
+	or negative, or x or y are negative, raise the bad_value protocol
+	error.
+
+	The crop and scale state is double-buffered state, and will be
+	applied on the next wl_surface.commit.
+      </description>
+      <arg name="x" type="fixed" summary="source rectangle x"/>
+      <arg name="y" type="fixed" summary="source rectangle y"/>
+      <arg name="width" type="fixed" summary="source rectangle width"/>
+      <arg name="height" type="fixed" summary="source rectangle height"/>
+    </request>
+
+    <request name="set_destination">
+      <description summary="set the surface size for scaling">
+	Set the destination size of the associated wl_surface. See
+	wp_viewport for the description, and relation to the wl_buffer
+	size.
+
+	If width is -1 and height is -1, the destination size is unset
+	instead. Any other pair of values for width and height that
+	contains zero or negative values raises the bad_value protocol
+	error.
+
+	The crop and scale state is double-buffered state, and will be
+	applied on the next wl_surface.commit.
+      </description>
+      <arg name="width" type="int" summary="surface width"/>
+      <arg name="height" type="int" summary="surface height"/>
+    </request>
+  </interface>
+
+</protocol>


### PR DESCRIPTION
Hi,
When a wayland is used without any scaling the `uwac` client works fine. The problem starts when there is some scaling applied (eg. I have scale=2.0 because of the HiDPI display). Then the FreeRDP is creating eg. a FullHD window size on a 4K display and compositor scales it (and it is blurry).
I started the work to fix this problem. I am almost there but there are still some problems to solve:
- [x] ~~Fix damage support - I still have artifacts/glitches on screen updates~~
- [x] ~~Fix mouse input - working on original/unscaled part of window only~~
- [x] ~~Fix wrong pointer size (I reported the problem in https://github.com/FreeRDP/FreeRDP/issues/9687 and now I think I know how to fix this)~~

I don't know when and if I could solve the above problems/update this PR, so that's why I am sharing this work at this stage... and maybe someone will help me with this or give some hints...