### PR TITLE
[libuwac] fix keyboard "sticky" keys when entering window

### DIFF
--- a/uwac/libuwac/uwac-output.c
+++ b/uwac/libuwac/uwac-output.c
@@ -88,7 +88,9 @@ static void output_handle_scale(void* data, struct wl_output* wl_output, int32_t
 	UwacOutput* output = data;
 	assert(output);
 
-	output->display->actual_scale = output->scale = scale;
+	output->scale = scale;
+	if (scale > output->display->actual_scale)
+		output->display->actual_scale = scale;
 }
 
 static void output_handle_name(void* data, struct wl_output* wl_output, const char* name)


### PR DESCRIPTION
The commit is fixing the following problem:
When the freerdp window gets keyboard focus and is notified, it wrongly process keys which are *held*, not a freshly pressed.

The comment in the code explains it more.