### PR TITLE
Make rdp2tcp work again

### DIFF
--- a/channels/rdp2tcp/client/rdp2tcp_main.c
+++ b/channels/rdp2tcp/client/rdp2tcp_main.c
@@ -316,7 +316,7 @@ static VOID VCAPITYPE VirtualChannelInitEventEx(LPVOID lpUserParam, LPVOID pInit
 	}
 }
 
-#if 1
+#if 0
 #define VirtualChannelEntryEx rdp2tcp_VirtualChannelEntryEx
 #else
 #define VirtualChannelEntryEx FREERDP_API VirtualChannelEntryEx


### PR DESCRIPTION
Remove FREERDP_API from VirtualChannelEntryEx functon definition thus making FreeRDP recognize this code as a virtual channel plugin.