### PR TITLE
[server,proxy] add TlsSecLevel option to config

### DIFF
--- a/include/freerdp/server/proxy/proxy_config.h
+++ b/include/freerdp/server/proxy/proxy_config.h
@@ -109,6 +109,9 @@ extern "C"
 		size_t PrivateKeyPEMLength;
 
 		wIniFile* ini;
+
+		/* target continued */
+		UINT32 TargetTlsSecLevel;
 	};
 
 	/**

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -141,6 +141,10 @@ static BOOL pf_server_get_target_info(rdpContext* context, rdpSettings* settings
 			else
 				freerdp_settings_set_uint32(settings, FreeRDP_ServerPort, 3389);
 
+			if (!freerdp_settings_set_uint32(settings, FreeRDP_TlsSecLevel,
+			                                 config->TargetTlsSecLevel))
+				return FALSE;
+
 			if (!freerdp_settings_set_string(settings, FreeRDP_ServerHostname, config->TargetHost))
 			{
 				PROXY_LOG_ERR(TAG, ps, "strdup failed!");


### PR DESCRIPTION
To support legacy targets add the TlsSecLevel configuration option that is equivalent to the /tls:seclevel option of the client implementations. This allows automatic configuration of OpenSSL legacy providers if they are available.