### PR TITLE
Proxy fix

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -1655,14 +1655,12 @@ static BOOL rdp_server_send_sync(rdpRdp* rdp)
 
 BOOL rdp_server_accept_confirm_active(rdpRdp* rdp, wStream* s, UINT16 pduLength)
 {
-	freerdp_peer* peer;
-
 	WINPR_ASSERT(rdp);
 	WINPR_ASSERT(rdp->context);
 	WINPR_ASSERT(rdp->settings);
 	WINPR_ASSERT(s);
 
-	peer = rdp->context->peer;
+	freerdp_peer* peer = rdp->context->peer;
 	WINPR_ASSERT(peer);
 
 	if (rdp_get_state(rdp) != CONNECTION_STATE_CAPABILITIES_EXCHANGE_CONFIRM_ACTIVE)
@@ -1681,7 +1679,10 @@ BOOL rdp_server_accept_confirm_active(rdpRdp* rdp, wStream* s, UINT16 pduLength)
 		return FALSE;
 
 	if (peer->ClientCapabilities && !peer->ClientCapabilities(peer))
+	{
+		WLog_WARN(TAG, "peer->ClientCapabilities failed");
 		return FALSE;
+	}
 
 	if (rdp->settings->SaltedChecksum)
 		rdp->do_secure_checksum = TRUE;

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -1035,6 +1035,10 @@ static state_run_t peer_recv_callback_internal(rdpTransport* transport, wStream*
 				else
 					ret = STATE_RUN_SUCCESS;
 				free(monitors);
+
+				const size_t len = Stream_GetRemainingLength(s);
+				if (!state_run_failed(ret) && (len > 0))
+					ret = STATE_RUN_CONTINUE;
 			}
 			else
 			{

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -1159,6 +1159,10 @@ static state_run_t peer_recv_callback(rdpTransport* transport, wStream* s, void*
 	state_run_t rc = STATE_RUN_FAILED;
 	const size_t start = Stream_GetPosition(s);
 	const rdpContext* context = transport_get_context(transport);
+	DWORD level = WLOG_TRACE;
+	static wLog* log = NULL;
+	if (!log)
+		log = WLog_Get(TAG);
 
 	WINPR_ASSERT(context);
 	do
@@ -1170,9 +1174,13 @@ static state_run_t peer_recv_callback(rdpTransport* transport, wStream* s, void*
 			Stream_SetPosition(s, start);
 		rc = peer_recv_callback_internal(transport, s, extra);
 
-		WLog_VRB(TAG, "(server)[%s -> %s] current return %s [%" PRIuz " bytes not processed]", old,
-		         rdp_get_state_string(rdp), state_run_result_string(rc, buffer, sizeof(buffer)),
-		         Stream_GetRemainingLength(s));
+		const size_t len = Stream_GetRemainingLength(s);
+		if ((len > 0) && !state_run_continue(rc))
+			level = WLOG_WARN;
+		WLog_Print(log, level,
+		           "(server)[%s -> %s] current return %s [%" PRIuz " bytes not processed]", old,
+		           rdp_get_state_string(rdp), state_run_result_string(rc, buffer, sizeof(buffer)),
+		           len);
 	} while (state_run_continue(rc));
 
 	return rc;


### PR DESCRIPTION
fixes an issue with `xfreerdp 2.0` (and maybe others) if a deactivate/reactivate sequence occurs against a `FreeRDP3` based server