### PR TITLE
[client,SDL] check for timer initialized

### DIFF
--- a/client/SDL/sdl_disp.cpp
+++ b/client/SDL/sdl_disp.cpp
@@ -293,6 +293,9 @@ UINT sdlDispContext::sendLayout(const rdpMonitor* monitors, size_t nmonitors)
 
 BOOL sdlDispContext::addTimer()
 {
+	if (SDL_WasInit(SDL_INIT_TIMER) == 0)
+		return FALSE;
+
 	SDL_RemoveTimer(_timer);
 	WLog_Print(_sdl->log, WLOG_TRACE, "adding new display check timer");
 


### PR DESCRIPTION
before manipulating SDL timers check if the SDL subsystem was actually initialized. Fixes #9736