### PR TITLE
[channels,drdynvc] Add settings to enable synchronous dynamic channels.

### DIFF
--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -2011,7 +2011,10 @@ FREERDP_ENTRY_POINT(BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS_E
 		drdynvc->context = context;
 		context->GetVersion = drdynvc_get_version;
 		drdynvc->rdpcontext = pEntryPointsEx->context;
-		if (!freerdp_settings_get_bool(drdynvc->rdpcontext->settings, FreeRDP_TransportDumpReplay))
+		if (!freerdp_settings_get_bool(drdynvc->rdpcontext->settings,
+		                               FreeRDP_TransportDumpReplay) &&
+		    !freerdp_settings_get_bool(drdynvc->rdpcontext->settings,
+		                               FreeRDP_SynchronousDynamicChannels))
 			drdynvc->async = TRUE;
 	}
 

--- a/include/freerdp/settings_types_private.h
+++ b/include/freerdp/settings_types_private.h
@@ -770,7 +770,8 @@ struct rdp_settings
 	SETTINGS_DEPRECATED(ALIGN64 UINT32 DynamicChannelArraySize);   /* 5057 */
 	SETTINGS_DEPRECATED(ALIGN64 ADDIN_ARGV** DynamicChannelArray); /* 5058 */
 	SETTINGS_DEPRECATED(ALIGN64 BOOL SupportDynamicChannels);      /* 5059 */
-	UINT64 padding5184[5184 - 5060];                               /* 5060 */
+	SETTINGS_DEPRECATED(ALIGN64 BOOL SynchronousDynamicChannels);  /* 5060 */
+	UINT64 padding5184[5184 - 5061];                               /* 5061 */
 
 	SETTINGS_DEPRECATED(ALIGN64 BOOL SupportEchoChannel);        /* 5184 */
 	SETTINGS_DEPRECATED(ALIGN64 BOOL SupportDisplayControl);     /* 5185 */

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -573,6 +573,9 @@ BOOL freerdp_settings_get_bool(const rdpSettings* settings, FreeRDP_Settings_Key
 		case FreeRDP_SuspendInput:
 			return settings->SuspendInput;
 
+		case FreeRDP_SynchronousDynamicChannels:
+			return settings->SynchronousDynamicChannels;
+
 		case FreeRDP_TcpKeepAlive:
 			return settings->TcpKeepAlive;
 
@@ -1328,6 +1331,10 @@ BOOL freerdp_settings_set_bool(rdpSettings* settings, FreeRDP_Settings_Keys_Bool
 
 		case FreeRDP_SuspendInput:
 			settings->SuspendInput = cnv.c;
+			break;
+
+		case FreeRDP_SynchronousDynamicChannels:
+			settings->SynchronousDynamicChannels = cnv.c;
 			break;
 
 		case FreeRDP_TcpKeepAlive:

--- a/libfreerdp/common/settings_str.h
+++ b/libfreerdp/common/settings_str.h
@@ -241,6 +241,8 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_SurfaceFrameMarkerEnabled, FREERDP_SETTINGS_TYPE_BOOL,
 	  "FreeRDP_SurfaceFrameMarkerEnabled" },
 	{ FreeRDP_SuspendInput, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_SuspendInput" },
+	{ FreeRDP_SynchronousDynamicChannels, FREERDP_SETTINGS_TYPE_BOOL,
+	  "FreeRDP_SynchronousDynamicChannels" },
 	{ FreeRDP_TcpKeepAlive, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_TcpKeepAlive" },
 	{ FreeRDP_TlsSecurity, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_TlsSecurity" },
 	{ FreeRDP_ToggleFullscreen, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_ToggleFullscreen" },

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -175,6 +175,7 @@ static const size_t bool_list_indices[] = {
 	FreeRDP_SurfaceCommandsEnabled,
 	FreeRDP_SurfaceFrameMarkerEnabled,
 	FreeRDP_SuspendInput,
+	FreeRDP_SynchronousDynamicChannels,
 	FreeRDP_TcpKeepAlive,
 	FreeRDP_TlsSecurity,
 	FreeRDP_ToggleFullscreen,


### PR DESCRIPTION
The drdynvc channel already supports synchronous mode (without threads) but is not exposed through a public setting.

This patch adds such setting so thin clients can run synchronous dynamic channels as needed.

Other legacy static channels should also support synchronous mode and should come in future PR.