### PR TITLE
Backport [channels,rdpsnd] fix missing include

### DIFF
--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include <winpr/crt.h>
 #include <winpr/assert.h>


### PR DESCRIPTION
This cherry-picks the https://github.com/FreeRDP/FreeRDP/commit/2e9ee7a58305edfd8c691328cc7d37fbf636b4b8 commit to stable-2.0 to avoid build failure (which happened when building updated package in Fedora).
