### PR TITLE
Make rdp2tcp channel use BUILTIN_CHANNELS macro

### DIFF
--- a/channels/rdp2tcp/client/rdp2tcp_main.c
+++ b/channels/rdp2tcp/client/rdp2tcp_main.c
@@ -316,7 +316,7 @@ static VOID VCAPITYPE VirtualChannelInitEventEx(LPVOID lpUserParam, LPVOID pInit
 	}
 }
 
-#if 1
+#ifdef BUILTIN_CHANNELS
 #define VirtualChannelEntryEx rdp2tcp_VirtualChannelEntryEx
 #else
 #define VirtualChannelEntryEx FREERDP_API VirtualChannelEntryEx


### PR DESCRIPTION
Make rdp2tcp channel work by making use of BUILTIN_CHANNELS macro in channels/rdp2tcp/client/rdp2tcp_main.c

If one launches remmina, creates an RDP connection, goes to "Advanced" tab, sets "TCP redirection" to a path to rdp2tcp binary and tries to connect, it fails with the following   error message:

```
[14:23:41:463] [1176063:1176398] [ERROR][com.winpr.library] - GetProcAddress: could not find procedure VirtualChannelEntryEx: /usr/lib64/freerdp2/librdp2tcp-client.so: undefined symbol: VirtualChannelEntryEx
[14:23:41:463] [1176063:1176398] [WARN][com.freerdp.addin] - Failed to load channel rdp2tcp [(nil)]
[14:23:41:463] [1176063:1176398] [ERROR][com.winpr.library] - GetProcAddress: could not find procedure VirtualChannelEntry: /usr/lib64/freerdp2/librdp2tcp-client.so: undefined symbol: VirtualChannelEntry
[14:23:41:463] [1176063:1176398] [WARN][com.freerdp.addin] - Failed to load channel rdp2tcp [(nil)]
[14:23:41:463] [1176063:1176398] [ERROR][com.winpr.library] - GetProcAddress: could not find procedure VirtualChannelEntryEx: /usr/lib64/freerdp2/librdp2tcp-client.so: undefined symbol: VirtualChannelEntryEx
[14:23:41:463] [1176063:1176398] [WARN][com.freerdp.addin] - Failed to load channel rdp2tcp [(nil)]
[14:23:41:464] [1176063:1176398] [ERROR][com.winpr.library] - GetProcAddress: could not find procedure VirtualChannelEntry: /usr/lib64/freerdp2/librdp2tcp-client.so: undefined symbol: VirtualChannelEntry
[14:23:41:464] [1176063:1176398] [WARN][com.freerdp.addin] - Failed to load channel rdp2tcp [(nil)]
[14:23:41:464] [1176063:1176398] [ERROR][com.freerdp.core] - freerdp_connect:freerdp_set_last_error_ex ERRCONNECT_PRE_CONNECT_FAILED [0x00020001]
[14:23:41:464] [1176063:1176398] [ERROR][com.freerdp.core] - freerdp_pre_connect failed
libfreerdp returned code is 00020001
```

This commit addresses the issue. Please consider applying.

NB: rdp2tcp itself may be taken from https://github.com/V-E-O/rdp2tcp.