### PR TITLE
Sdl log fixes

### DIFF
--- a/client/SDL/dialogs/sdl_widget.cpp
+++ b/client/SDL/dialogs/sdl_widget.cpp
@@ -162,7 +162,8 @@ SDL_Texture* SdlWidget::render_text_wrapped(SDL_Renderer* renderer, const std::s
 SdlWidget::~SdlWidget()
 {
 	TTF_CloseFont(_font);
-	SDL_DestroyTexture(_image);
+	if (_image)
+		SDL_DestroyTexture(_image);
 }
 
 bool SdlWidget::error_ex(Uint32 res, const char* what, const char* file, size_t line,


### PR DESCRIPTION
fix an annoying misleading log entry when trying to free `null/uninitialized` texture variables.