### PR TITLE
[core,transport] make blocking mode available to transport IO interface.

### DIFF
--- a/include/freerdp/transport_io.h
+++ b/include/freerdp/transport_io.h
@@ -43,6 +43,7 @@ extern "C"
 	typedef SSIZE_T (*pTransportRead)(rdpTransport* transport, BYTE* data, size_t bytes);
 	typedef BOOL (*pTransportGetPublicKey)(rdpTransport* transport, const BYTE** data,
 	                                       DWORD* length);
+	typedef BOOL (*pTransportSetBlockingMode)(rdpTransport* transport, BOOL blocking);
 
 	struct rdp_transport_io
 	{
@@ -55,6 +56,7 @@ extern "C"
 		pTransportRWFkt WritePdu; /* Writes a whole PDU to the transport */
 		pTransportRead ReadBytes; /* Reads up to a requested amount of bytes from the transport */
 		pTransportGetPublicKey GetPublicKey;
+		pTransportSetBlockingMode SetBlockingMode;
 	};
 	typedef struct rdp_transport_io rdpTransportIo;
 

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -1447,6 +1447,13 @@ BOOL transport_set_blocking_mode(rdpTransport* transport, BOOL blocking)
 {
 	WINPR_ASSERT(transport);
 
+	return IFCALLRESULT(FALSE, transport->io.SetBlockingMode, transport, blocking);
+}
+
+static BOOL transport_default_set_blocking_mode(rdpTransport* transport, BOOL blocking)
+{
+	WINPR_ASSERT(transport);
+
 	transport->blocking = blocking;
 
 	if (transport->frontBio)
@@ -1554,6 +1561,7 @@ rdpTransport* transport_new(rdpContext* context)
 	transport->io.WritePdu = transport_default_write;
 	transport->io.ReadBytes = transport_read_layer;
 	transport->io.GetPublicKey = transport_default_get_public_key;
+	transport->io.SetBlockingMode = transport_default_set_blocking_mode;
 
 	transport->context = context;
 	transport->ReceivePool = StreamPool_New(TRUE, BUFFER_SIZE);


### PR DESCRIPTION
The expected blocking mode is needed for custom transport layer and should be exposed to the transport IO interface.