### PR TITLE
[cmake] add clang-tidy support

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,47 @@
+---
+Checks:          '-*,abseil-*,altera-*,boost-*,bugprone-*,cert-*,clang-analyzer*,concurrency-*,cppcoreguidelines*,google-*,hicpp-*,llvm-*,modernize-*,objc-*,openmp-*,performance-*,portability-*,readability-*,-llvm-include-order,-google-readability-braces-around-statements,-hicpp-braces-around-statements,-altera-unroll-loops,-altera-struct-pack-align,-readability-braces-around-statements,-llvm-header-guard,-llvm-qualified-auto,-hicpp-uppercase-literal-suffix,-hicpp-signed-bitwisei,-cert-dcl16-c,-cert-env33-c,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-readability-function-cognitive-complexity,-readability-uppercase-literal-suffix,-readability-qualified-auto'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     file
+User:            nin
+CheckOptions:
+  - key:             llvm-else-after-return.WarnOnConditionVariables
+    value:           'false'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
+    value:           'false'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             cert-err33-c.CheckedFunctions
+    value:           '::aligned_alloc;::asctime_s;::at_quick_exit;::atexit;::bsearch;::bsearch_s;::btowc;::c16rtomb;::c32rtomb;::calloc;::clock;::cnd_broadcast;::cnd_init;::cnd_signal;::cnd_timedwait;::cnd_wait;::ctime_s;::fclose;::fflush;::fgetc;::fgetpos;::fgets;::fgetwc;::fopen;::fopen_s;::fprintf;::fprintf_s;::fputc;::fputs;::fputwc;::fputws;::fread;::freopen;::freopen_s;::fscanf;::fscanf_s;::fseek;::fsetpos;::ftell;::fwprintf;::fwprintf_s;::fwrite;::fwscanf;::fwscanf_s;::getc;::getchar;::getenv;::getenv_s;::gets_s;::getwc;::getwchar;::gmtime;::gmtime_s;::localtime;::localtime_s;::malloc;::mbrtoc16;::mbrtoc32;::mbsrtowcs;::mbsrtowcs_s;::mbstowcs;::mbstowcs_s;::memchr;::mktime;::mtx_init;::mtx_lock;::mtx_timedlock;::mtx_trylock;::mtx_unlock;::printf_s;::putc;::putwc;::raise;::realloc;::remove;::rename;::scanf;::scanf_s;::setlocale;::setvbuf;::signal;::snprintf;::snprintf_s;::sprintf;::sprintf_s;::sscanf;::sscanf_s;::strchr;::strerror_s;::strftime;::strpbrk;::strrchr;::strstr;::strtod;::strtof;::strtoimax;::strtok;::strtok_s;::strtol;::strtold;::strtoll;::strtoul;::strtoull;::strtoumax;::strxfrm;::swprintf;::swprintf_s;::swscanf;::swscanf_s;::thrd_create;::thrd_detach;::thrd_join;::thrd_sleep;::time;::timespec_get;::tmpfile;::tmpfile_s;::tmpnam;::tmpnam_s;::tss_create;::tss_get;::tss_set;::ungetc;::ungetwc;::vfprintf;::vfprintf_s;::vfscanf;::vfscanf_s;::vfwprintf;::vfwprintf_s;::vfwscanf;::vfwscanf_s;::vprintf_s;::vscanf;::vscanf_s;::vsnprintf;::vsnprintf_s;::vsprintf;::vsprintf_s;::vsscanf;::vsscanf_s;::vswprintf;::vswprintf_s;::vswscanf;::vswscanf_s;::vwprintf_s;::vwscanf;::vwscanf_s;::wcrtomb;::wcschr;::wcsftime;::wcspbrk;::wcsrchr;::wcsrtombs;::wcsrtombs_s;::wcsstr;::wcstod;::wcstof;::wcstoimax;::wcstok;::wcstok_s;::wcstol;::wcstold;::wcstoll;::wcstombs;::wcstombs_s;::wcstoul;::wcstoull;::wcstoumax;::wcsxfrm;::wctob;::wctrans;::wctype;::wmemchr;::wprintf_s;::wscanf;::wscanf_s;'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           'false'
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           'true'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             llvm-qualified-auto.AddConstToQualified
+    value:           'false'
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             llvm-else-after-return.WarnOnUnfixable
+    value:           'false'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+...
+
+

--- a/ci/cmake-preloads/config-qa-static.cmake
+++ b/ci/cmake-preloads/config-qa-static.cmake
@@ -6,38 +6,10 @@ set (WITH_VERBOSE_WINPR_ASSERT OFF CACHE BOOL "qa default")
 set (BUILD_SHARED_LIBS OFF CACHE BOOL "qa default")
 
 set (BUILD_WITH_CLANG_TIDY OFF CACHE BOOL "qa default")
-find_program(CLANG_EXE
-    NAMES
-        clang-20
-        clang-19
-        clang-18
-        clang-17
-        clang-16
-        clang-15
-        clang-14
-        clang-13
-        clang-12
-        clang-11
-        clang-10
-        clang
-    REQUIRED
-)
-set (CMAKE_C_COMPILER "${CLANG_EXE}" CACHE STRING "qa default")
 
-find_program(CLANG_XX_EXE
-    NAMES
-        clang++-20
-        clang++-19
-        clang++-18
-        clang++-17
-        clang++-16
-        clang++-15
-        clang++-14
-        clang++-13
-        clang++-12
-        clang++-11
-        clang++-10
-        clang++
-    REQUIRED
-)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ClangDetectTool.cmake)
+clang_detect_tool(CLANG_EXE clang REQUIRED)
+clang_detect_tool(CLANG_XX_EXE clang++ REQUIRED)
+
+set (CMAKE_C_COMPILER "${CLANG_EXE}" CACHE STRING "qa default")
 set (CMAKE_CXX_COMPILER "${CLANG_XX_EXE}" CACHE STRING "qa default")

--- a/ci/cmake-preloads/config-qa-static.cmake
+++ b/ci/cmake-preloads/config-qa-static.cmake
@@ -13,3 +13,4 @@ clang_detect_tool(CLANG_XX_EXE clang++ REQUIRED)
 
 set (CMAKE_C_COMPILER "${CLANG_EXE}" CACHE STRING "qa default")
 set (CMAKE_CXX_COMPILER "${CLANG_XX_EXE}" CACHE STRING "qa default")
+set (CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++" CACHE STRING "qa-default")

--- a/ci/cmake-preloads/config-qa-static.cmake
+++ b/ci/cmake-preloads/config-qa-static.cmake
@@ -4,3 +4,40 @@ set (WITH_SERVER ON CACHE BOOL "qa default")
 set (WITH_SAMPLE ON CACHE BOOL "qa default")
 set (WITH_VERBOSE_WINPR_ASSERT OFF CACHE BOOL "qa default")
 set (BUILD_SHARED_LIBS OFF CACHE BOOL "qa default")
+
+set (BUILD_WITH_CLANG_TIDY OFF CACHE BOOL "qa default")
+find_program(CLANG_EXE
+    NAMES
+        clang-20
+        clang-19
+        clang-18
+        clang-17
+        clang-16
+        clang-15
+        clang-14
+        clang-13
+        clang-12
+        clang-11
+        clang-10
+        clang
+    REQUIRED
+)
+set (CMAKE_C_COMPILER "${CLANG_EXE}" CACHE STRING "qa default")
+
+find_program(CLANG_XX_EXE
+    NAMES
+        clang++-20
+        clang++-19
+        clang++-18
+        clang++-17
+        clang++-16
+        clang++-15
+        clang++-14
+        clang++-13
+        clang++-12
+        clang++-11
+        clang++-10
+        clang++
+    REQUIRED
+)
+set (CMAKE_CXX_COMPILER "${CLANG_XX_EXE}" CACHE STRING "qa default")

--- a/ci/cmake-preloads/config-qa.cmake
+++ b/ci/cmake-preloads/config-qa.cmake
@@ -14,5 +14,40 @@ set (WITH_FFMPEG ON CACHE BOOL "qa default")
 set (WITH_SANITIZE_ADDRESS ON CACHE BOOL "qa default")
 set (CMAKE_C_FLAGS "-Weverything -Wno-exit-time-destructors -Wno-cast-align -Wno-documentation -Wno-documentation-unknown-command -Wno-padded -Wno-covered-switch-default -Wno-declaration-after-statement" CACHE STRING "qa default")
 set (CMAKE_CXX_FLAGS "-Weverything -Wno-exit-time-destructors -Wno-cast-align -Wno-documentation -Wno-documentation-unknown-command -Wno-padded -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-covered-switch-default -Wno-declaration-after-statement" CACHE STRING "qa default")
-set (CMAKE_C_COMPILER "/usr/bin/clang-10" CACHE STRING "qa default")
-set (CMAKE_CXX_COMPILER "/usr/bin/clang++-10" CACHE STRING "qa default")
+
+set (BUILD_WITH_CLANG_TIDY ON CACHE BOOL "qa default")
+find_program(CLANG_EXE
+    NAMES
+        clang-20
+        clang-19
+        clang-18
+        clang-17
+        clang-16
+        clang-15
+        clang-14
+        clang-13
+        clang-12
+        clang-11
+        clang-10
+        clang
+    REQUIRED
+)
+set (CMAKE_C_COMPILER "${CLANG_EXE}" CACHE STRING "qa default")
+
+find_program(CLANG_XX_EXE
+    NAMES
+        clang++-20
+        clang++-19
+        clang++-18
+        clang++-17
+        clang++-16
+        clang++-15
+        clang++-14
+        clang++-13
+        clang++-12
+        clang++-11
+        clang++-10
+        clang++
+    REQUIRED
+)
+set (CMAKE_CXX_COMPILER "${CLANG_XX_EXE}" CACHE STRING "qa default")

--- a/ci/cmake-preloads/config-qa.cmake
+++ b/ci/cmake-preloads/config-qa.cmake
@@ -16,38 +16,10 @@ set (CMAKE_C_FLAGS "-Weverything -Wno-exit-time-destructors -Wno-cast-align -Wno
 set (CMAKE_CXX_FLAGS "-Weverything -Wno-exit-time-destructors -Wno-cast-align -Wno-documentation -Wno-documentation-unknown-command -Wno-padded -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-covered-switch-default -Wno-declaration-after-statement" CACHE STRING "qa default")
 
 set (BUILD_WITH_CLANG_TIDY ON CACHE BOOL "qa default")
-find_program(CLANG_EXE
-    NAMES
-        clang-20
-        clang-19
-        clang-18
-        clang-17
-        clang-16
-        clang-15
-        clang-14
-        clang-13
-        clang-12
-        clang-11
-        clang-10
-        clang
-    REQUIRED
-)
-set (CMAKE_C_COMPILER "${CLANG_EXE}" CACHE STRING "qa default")
 
-find_program(CLANG_XX_EXE
-    NAMES
-        clang++-20
-        clang++-19
-        clang++-18
-        clang++-17
-        clang++-16
-        clang++-15
-        clang++-14
-        clang++-13
-        clang++-12
-        clang++-11
-        clang++-10
-        clang++
-    REQUIRED
-)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ClangDetectTool.cmake)
+clang_detect_tool(CLANG_EXE clang REQUIRED)
+clang_detect_tool(CLANG_XX_EXE clang++ REQUIRED)
+
+set (CMAKE_C_COMPILER "${CLANG_EXE}" CACHE STRING "qa default")
 set (CMAKE_CXX_COMPILER "${CLANG_XX_EXE}" CACHE STRING "qa default")

--- a/cmake/ClangDetectTool.cmake
+++ b/cmake/ClangDetectTool.cmake
@@ -1,0 +1,48 @@
+function (clang_detect_tool VAR NAME OPTS)
+	set(NAMES "")
+	foreach(CNT RANGE 12 22)
+		list(APPEND NAMES "${NAME}-${CNT}")
+	endforeach()
+	list(REVERSE NAMES)
+	list(APPEND NAMES ${NAME})
+
+	find_program(${VAR}
+		NAMES ${NAMES}
+		${OPTS}
+	)
+	if (NOT ${VAR})
+		message(WARNING "clang tool ${NAME} (${VAR}) not detected, skipping")
+		unset(${VAR})
+		return()
+	endif()
+
+	execute_process(
+		COMMAND ${${VAR}} "--version"
+		OUTPUT_VARIABLE _CLANG_TOOL_VERSION
+		RESULT_VARIABLE _CLANG_TOOL_VERSION_FAILED
+	)
+
+	if (_CLANG_TOOL_VERSION_FAILED)
+		message(WARNING "A problem was encounterd with ${${VAR}}")
+		message(WARNING "${_CLANG_TOOL_VERSION_FAILED}")
+		unset(${VAR})
+		return()
+	endif()
+
+	string(REGEX MATCH "([7-9]|[1-9][0-9])\\.[0-9]\\.[0-9]" CLANG_TOOL_VERSION
+		"${_CLANG_TOOL_VERSION}")
+
+	if (NOT CLANG_TOOL_VERSION)
+		message(WARNING "problem parsing ${NAME} version for ${${VAR}}")
+		unset(${VAR})
+		return()
+	endif()
+
+	set(_CLANG_TOOL_MINIMUM_VERSION "12.0.0")
+	if (${CLANG_TOOL_VERSION} VERSION_LESS ${_CLANG_TOOL_MINIMUM_VERSION})
+		message(WARNING "clang-format version ${CLANG_TOOL_VERSION} not supported")
+		message(WARNING "Minimum version required: ${_CLANG_TOOL_MINIMUM_VERSION}")
+		unset(${VAR})
+		return()
+	endif()
+endfunction()

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -1,52 +1,12 @@
 # get all project files
 file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.c *.h *.m *.java)
-# minimum version required
-set(_CLANG_FORMAT_MINIMUM_VERSION 10.0.0)
 
-find_program(CLANG_FORMAT
-	NAMES
-	clang-format-20
-	clang-format-19
-	clang-format-18
-	clang-format-17
-	clang-format-16
-	clang-format-15
-	clang-format-14
-	clang-format-13
-	clang-format-12
-	clang-format-11
-	clang-format-10
-	clang-format
-	)
+include(ClangDetectTool)
+clang_detect_tool(CLANG_FORMAT clang-format)
 
 if (NOT CLANG_FORMAT)
 	message(WARNING "clang-format not found in path! code format target not available.")
 else()
-	execute_process(
-		COMMAND ${CLANG_FORMAT} "--version"
-		OUTPUT_VARIABLE _CLANG_FORMAT_VERSION
-		RESULT_VARIABLE _CLANG_FORMAT_VERSION_FAILED
-		)
-
-	if (_CLANG_FORMAT_VERSION_FAILED)
-		message(WARNING "A problem was encounterd with ${CLANG_FORMAT}")
-		return()
-	endif()
-
-	string(REGEX MATCH "([7-9]|[1-9][0-9])\\.[0-9]\\.[0-9]" CLANG_FORMAT_VERSION
-		"${_CLANG_FORMAT_VERSION}")
-
-	if (NOT CLANG_FORMAT_VERSION)
-		message(WARNING "problem parsing clang-format version for ${CLANG_FORMAT}")
-		return()
-	endif()
-
-	if (${CLANG_FORMAT_VERSION} VERSION_LESS ${_CLANG_FORMAT_MINIMUM_VERSION})
-		message(WARNING "clang-format version ${CLANG_FORMAT_VERSION} not supported")
-		message(WARNING "Minimum version required: ${_CLANG_FORMAT_MINIMUM_VERSION}")
-		return()
-	endif()
-
 	add_custom_target(
 			clangformat
 			COMMAND ${CLANG_FORMAT}

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -1,12 +1,21 @@
 # get all project files
 file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.c *.h *.m *.java)
 # minimum version required
-set(_CLANG_FORMAT_MINIMUM_VERSION 7.0.0)
+set(_CLANG_FORMAT_MINIMUM_VERSION 10.0.0)
 
 find_program(CLANG_FORMAT
 	NAMES
-	clang-format-8
-	clang-format-7
+	clang-format-20
+	clang-format-19
+	clang-format-18
+	clang-format-17
+	clang-format-16
+	clang-format-15
+	clang-format-14
+	clang-format-13
+	clang-format-12
+	clang-format-11
+	clang-format-10
 	clang-format
 	)
 

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -1,0 +1,29 @@
+option(BUILD_WITH_CLANG_TIDY "Build with clang-tidy for extra warnings" OFF)
+
+if (BUILD_WITH_CLANG_TIDY)
+    find_program(CLANG_TIDY_EXE
+        NAMES
+            clang-tidy-20
+            clang-tidy-19
+            clang-tidy-18
+            clang-tidy-17
+            clang-tidy-16
+            clang-tidy-15
+            clang-tidy-14
+            clang-tidy-13
+            clang-tidy-12
+            clang-tidy-11
+            clang-tidy-10
+            clang-tidy
+        REQUIRED
+    )
+    set(CLANG_TIDY_COMMAND "${CLANG_TIDY_EXE}" --config-file=${CMAKE_SOURCE_DIR}/.clang-tidy)
+
+    set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY_COMMAND}" --extra-arg=-std=gnu11)
+    set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}" --extra-arg=-std=gnu++17)
+    set(CMAKE_OBJC_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
+else()
+    unset(CMAKE_C_CLANG_TIDY)
+    unset(CMAKE_CXX_CLANG_TIDY)
+    unset(CMAKE_OBJC_CLANG_TIDY)
+endif()

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -1,22 +1,9 @@
 option(BUILD_WITH_CLANG_TIDY "Build with clang-tidy for extra warnings" OFF)
 
 if (BUILD_WITH_CLANG_TIDY)
-    find_program(CLANG_TIDY_EXE
-        NAMES
-            clang-tidy-20
-            clang-tidy-19
-            clang-tidy-18
-            clang-tidy-17
-            clang-tidy-16
-            clang-tidy-15
-            clang-tidy-14
-            clang-tidy-13
-            clang-tidy-12
-            clang-tidy-11
-            clang-tidy-10
-            clang-tidy
-        REQUIRED
-    )
+    include(ClangDetectTool)
+    clang_detect_tool(CLANG_TIDY_EXE clang-tidy REQUIRED)
+
     set(CLANG_TIDY_COMMAND "${CLANG_TIDY_EXE}" --config-file=${CMAKE_SOURCE_DIR}/.clang-tidy)
 
     set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY_COMMAND}" --extra-arg=-std=gnu11)

--- a/cmake/CommonConfigOptions.cmake
+++ b/cmake/CommonConfigOptions.cmake
@@ -27,4 +27,5 @@ include(PreventInSourceBuilds)
 include(GNUInstallDirsWrapper)
 include(MSVCRuntime)
 include(ConfigureRPATH)
+include(ClangTidy)
 


### PR DESCRIPTION
1. update `clang-format` detection to support newer versions
2. add a `.clang-tidy` configuration file to enable (currently almost all) analyzers
1. Integrate `clang-tidy` with `CMake`, by setting `-DBUILD_WITH_CLANG_TIDY=ON` `clang-tidy` is invoked during the 
build.
1. Integrate `clang-tidy` with `jenkins CI` to have the warnings available for each pull request
2. unify `clang/llvm` tool detection, try `<tool>-<version>` over `<tool>` and enforce a minimum of `clang-12`
 
this is a first step for cleaning up `FreeRDP` code base, following this pr I´ll start fixing the issues detected one by one as #9795 grew much too large and is hard to merge.