### PR TITLE
remove superfluous manpage build dependencies

### DIFF
--- a/cmake/InstallFreeRDPMan.cmake
+++ b/cmake/InstallFreeRDPMan.cmake
@@ -41,9 +41,6 @@ function(generate_and_install_freerdp_man_from_xml template manpage dependencies
 		${manpage}.manpage ALL
                 DEPENDS
 			${manpage}
-                        ${manpage}.xml
-                        ${template}.xml.in
-                        generate_argument_docbook
 		)
 	install_freerdp_man(${CMAKE_CURRENT_BINARY_DIR}/${manpage} 1)
     endif()


### PR DESCRIPTION
The `${manpage}.manpage` custom target in `generate_and_install_freerdp_man_from_xml` should only declare as dependencies the build targets we wish to add to `ALL`, and should not include the sub-dependencies of those build targets.

Resolves #9804