### PR TITLE
[channels] Add synchronous static channel setting.

### DIFF
--- a/channels/rdpdr/client/rdpdr_main.h
+++ b/channels/rdpdr/client/rdpdr_main.h
@@ -112,6 +112,7 @@ typedef struct
 	rdpContext* rdpcontext;
 	wStreamPool* pool;
 	wLog* log;
+	BOOL async;
 } rdpdrPlugin;
 
 BOOL rdpdr_state_advance(rdpdrPlugin* rdpdr, enum RDPDR_CHANNEL_STATE next);

--- a/include/freerdp/settings_types_private.h
+++ b/include/freerdp/settings_types_private.h
@@ -760,7 +760,8 @@ struct rdp_settings
 	SETTINGS_DEPRECATED(ALIGN64 UINT32 StaticChannelCount);       /* 4928 */
 	SETTINGS_DEPRECATED(ALIGN64 UINT32 StaticChannelArraySize);   /* 4929 */
 	SETTINGS_DEPRECATED(ALIGN64 ADDIN_ARGV** StaticChannelArray); /* 4930 */
-	UINT64 padding5056[5056 - 4931];                              /* 4931 */
+	SETTINGS_DEPRECATED(ALIGN64 BOOL SynchronousStaticChannels);  /* 4931 */
+	UINT64 padding5056[5056 - 4932];                              /* 4932 */
 
 	/**
 	 * Dynamic Virtual Channels

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -576,6 +576,9 @@ BOOL freerdp_settings_get_bool(const rdpSettings* settings, FreeRDP_Settings_Key
 		case FreeRDP_SynchronousDynamicChannels:
 			return settings->SynchronousDynamicChannels;
 
+		case FreeRDP_SynchronousStaticChannels:
+			return settings->SynchronousStaticChannels;
+
 		case FreeRDP_TcpKeepAlive:
 			return settings->TcpKeepAlive;
 
@@ -1335,6 +1338,10 @@ BOOL freerdp_settings_set_bool(rdpSettings* settings, FreeRDP_Settings_Keys_Bool
 
 		case FreeRDP_SynchronousDynamicChannels:
 			settings->SynchronousDynamicChannels = cnv.c;
+			break;
+
+		case FreeRDP_SynchronousStaticChannels:
+			settings->SynchronousStaticChannels = cnv.c;
 			break;
 
 		case FreeRDP_TcpKeepAlive:

--- a/libfreerdp/common/settings_str.h
+++ b/libfreerdp/common/settings_str.h
@@ -243,6 +243,8 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_SuspendInput, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_SuspendInput" },
 	{ FreeRDP_SynchronousDynamicChannels, FREERDP_SETTINGS_TYPE_BOOL,
 	  "FreeRDP_SynchronousDynamicChannels" },
+	{ FreeRDP_SynchronousStaticChannels, FREERDP_SETTINGS_TYPE_BOOL,
+	  "FreeRDP_SynchronousStaticChannels" },
 	{ FreeRDP_TcpKeepAlive, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_TcpKeepAlive" },
 	{ FreeRDP_TlsSecurity, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_TlsSecurity" },
 	{ FreeRDP_ToggleFullscreen, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_ToggleFullscreen" },

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -176,6 +176,7 @@ static const size_t bool_list_indices[] = {
 	FreeRDP_SurfaceFrameMarkerEnabled,
 	FreeRDP_SuspendInput,
 	FreeRDP_SynchronousDynamicChannels,
+	FreeRDP_SynchronousStaticChannels,
 	FreeRDP_TcpKeepAlive,
 	FreeRDP_TlsSecurity,
 	FreeRDP_ToggleFullscreen,


### PR DESCRIPTION
Only rdpsnd and rdpdr use this setting in this PR for now. Note that rdpsnd could use SynchronousDynamicChannel setting depending on which channel it operates upon.