### PR TITLE
include null byte in Authorization Request PDU

### DIFF
--- a/libfreerdp/core/aad.c
+++ b/libfreerdp/core/aad.c
@@ -505,6 +505,10 @@ static int aad_send_auth_request(rdpAad* aad, const char* ts_nonce)
 	if (stream_sprintf(s, "{\"rdp_assertion\":\"%s.%s.%s\"}", jws_header, jws_payload,
 	                   jws_signature) < 0)
 		goto fail;
+
+	/* Include null terminator in PDU */
+	Stream_Write_UINT8(s, 0);
+
 	Stream_SealLength(s);
 
 	if (transport_write(aad->transport, s) < 0)


### PR DESCRIPTION
The RDS AAD Auth PDUs have no packet headers to indicate length. Instead, these packets are zero-terminated strings. Somehow, Windows accepts Authentication Request PDUs without a terminating null byte during regular connections, but not through WVD websocket gateways.