### PR TITLE
[build,attr] fix WINPR_ATTR_MALLOC

### DIFF
--- a/include/freerdp/codec/audio.h
+++ b/include/freerdp/codec/audio.h
@@ -213,11 +213,10 @@ extern "C"
 	FREERDP_API BOOL audio_format_compatible(const AUDIO_FORMAT* with, const AUDIO_FORMAT* what);
 
 	FREERDP_API void audio_format_free(AUDIO_FORMAT* format);
-
-	WINPR_ATTR_MALLOC(audio_format_free, 1)
-	FREERDP_API AUDIO_FORMAT* audio_format_new(void);
-
 	FREERDP_API void audio_formats_free(AUDIO_FORMAT* formats, size_t count);
+
+	WINPR_ATTR_MALLOC(audio_formats_free, 1)
+	FREERDP_API AUDIO_FORMAT* audio_format_new(void);
 
 	WINPR_ATTR_MALLOC(audio_formats_free, 1)
 	FREERDP_API AUDIO_FORMAT* audio_formats_new(size_t count);

--- a/winpr/include/winpr/asn1.h
+++ b/winpr/include/winpr/asn1.h
@@ -159,8 +159,6 @@ extern "C"
 	/* encoder functions */
 
 	WINPR_API void WinPrAsn1Encoder_Free(WinPrAsn1Encoder** penc);
-
-	WINPR_ATTR_MALLOC(WinPrAsn1Encoder_Free, 1)
 	WINPR_API WinPrAsn1Encoder* WinPrAsn1Encoder_New(WinPrAsn1EncodingRule encoding);
 
 	WINPR_API void WinPrAsn1Encoder_Reset(WinPrAsn1Encoder* enc);

--- a/winpr/libwinpr/crypto/rc4.h
+++ b/winpr/libwinpr/crypto/rc4.h
@@ -25,9 +25,10 @@
 
 typedef struct winpr_int_rc4_ctx winpr_int_RC4_CTX;
 
+void winpr_int_rc4_free(winpr_int_RC4_CTX* ctx);
+
 WINPR_ATTR_MALLOC(winpr_int_rc4_free, 1)
 winpr_int_RC4_CTX* winpr_int_rc4_new(const BYTE* key, size_t keylength);
 BOOL winpr_int_rc4_update(winpr_int_RC4_CTX* ctx, size_t length, const BYTE* input, BYTE* output);
-void winpr_int_rc4_free(winpr_int_RC4_CTX* ctx);
 
 #endif

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -880,8 +880,8 @@ static SECURITY_STATUS SEC_ENTRY kerberos_InitializeSecurityContextA(
 			/* Write the checksum (delegation not implemented) */
 			cksum.data = cksum_contents;
 			cksum.length = sizeof(cksum_contents);
-			Data_Write_UINT32(cksum.data, 16);
-			Data_Write_UINT32((cksum.data + 20), context->flags);
+			Data_Write_UINT32(cksum_contents, 16);
+			Data_Write_UINT32((cksum_contents + 20), context->flags);
 
 			if (bindings_buffer)
 			{
@@ -1536,9 +1536,9 @@ static SECURITY_STATUS SEC_ENTRY kerberos_EncryptMessage(PCtxtHandle phContext, 
 	/* Set up the iov array in sig_buffer */
 	header = sig_buffer->pvBuffer;
 	encrypt_iov[2].data.data = header + 16;
-	encrypt_iov[3].data.data = encrypt_iov[2].data.data + encrypt_iov[2].data.length;
-	encrypt_iov[4].data.data = encrypt_iov[3].data.data + encrypt_iov[3].data.length;
-	encrypt_iov[0].data.data = encrypt_iov[4].data.data + encrypt_iov[4].data.length;
+	encrypt_iov[3].data.data = (BYTE*)encrypt_iov[2].data.data + encrypt_iov[2].data.length;
+	encrypt_iov[4].data.data = (BYTE*)encrypt_iov[3].data.data + encrypt_iov[3].data.length;
+	encrypt_iov[0].data.data = (BYTE*)encrypt_iov[4].data.data + encrypt_iov[4].data.length;
 	encrypt_iov[1].data.data = data_buffer->pvBuffer;
 
 	/* Write the GSS header with 0 in RRC */
@@ -1644,8 +1644,8 @@ static SECURITY_STATUS SEC_ENTRY kerberos_DecryptMessage(PCtxtHandle phContext,
 	iov[0].data.data = header + 16 + rrc + ec;
 	iov[1].data.data = data_buffer->pvBuffer;
 	iov[2].data.data = header + 16 + ec;
-	iov[3].data.data = iov[2].data.data + iov[2].data.length;
-	iov[4].data.data = iov[3].data.data + iov[3].data.length;
+	iov[3].data.data = (BYTE*)iov[2].data.data + iov[2].data.length;
+	iov[4].data.data = (BYTE*)iov[3].data.data + iov[3].data.length;
 
 	if (krb_log_exec(krb5glue_decrypt_iov, context->ctx, key, usage, iov, ARRAYSIZE(iov)))
 		return SEC_E_INTERNAL_ERROR;

--- a/winpr/libwinpr/sspi/Kerberos/krb5glue_heimdal.c
+++ b/winpr/libwinpr/sspi/Kerberos/krb5glue_heimdal.c
@@ -138,7 +138,9 @@ BOOL krb5glue_authenticator_validate_chksum(krb5glue_authenticator authenticator
 	if (!authenticator || !authenticator->cksum || authenticator->cksum->cksumtype != cksumtype ||
 	    authenticator->cksum->checksum.length < 24)
 		return FALSE;
-	Data_Read_UINT32((authenticator->cksum->checksum.data + 20), (*flags));
+
+	const BYTE* data = authenticator->cksum->checksum.data;
+	Data_Read_UINT32((data + 20), (*flags));
 	return TRUE;
 }
 

--- a/winpr/libwinpr/utils/image.c
+++ b/winpr/libwinpr/utils/image.c
@@ -406,8 +406,9 @@ int winpr_image_read_buffer(wImage* image, const BYTE* buffer, size_t size)
 	         (sig[8] == 'W') && (sig[9] == 'E') && (sig[10] == 'B') && (sig[11] == 'P'))
 	{
 		image->type = WINPR_IMAGE_WEBP;
-		const SSIZE_T rc = winpr_convert_from_webp(buffer, size, &image->width, &image->height,
-		                                           &image->bitsPerPixel, &image->data);
+		const SSIZE_T rc =
+		    winpr_convert_from_webp((const char*)buffer, size, &image->width, &image->height,
+		                            &image->bitsPerPixel, ((char**)&image->data));
 		if (rc >= 0)
 		{
 			image->bytesPerPixel = (image->bitsPerPixel + 7) / 8;
@@ -420,8 +421,9 @@ int winpr_image_read_buffer(wImage* image, const BYTE* buffer, size_t size)
 	         (sig[10] == 0x00))
 	{
 		image->type = WINPR_IMAGE_JPEG;
-		const SSIZE_T rc = winpr_convert_from_jpeg(buffer, size, &image->width, &image->height,
-		                                           &image->bitsPerPixel, &image->data);
+		const SSIZE_T rc =
+		    winpr_convert_from_jpeg((const char*)buffer, size, &image->width, &image->height,
+		                            &image->bitsPerPixel, ((char**)&image->data));
 		if (rc >= 0)
 		{
 			image->bytesPerPixel = (image->bitsPerPixel + 7) / 8;
@@ -433,8 +435,9 @@ int winpr_image_read_buffer(wImage* image, const BYTE* buffer, size_t size)
 	         (sig[4] == '\r') && (sig[5] == '\n') && (sig[6] == 0x1A) && (sig[7] == '\n'))
 	{
 		image->type = WINPR_IMAGE_PNG;
-		const SSIZE_T rc = winpr_convert_from_png(buffer, size, &image->width, &image->height,
-		                                          &image->bitsPerPixel, &image->data);
+		const SSIZE_T rc =
+		    winpr_convert_from_png((const char*)buffer, size, &image->width, &image->height,
+		                           &image->bitsPerPixel, ((char**)&image->data));
 		if (rc >= 0)
 		{
 			image->bytesPerPixel = (image->bitsPerPixel + 7) / 8;
@@ -478,7 +481,7 @@ void* winpr_convert_to_jpeg(const void* data, size_t size, UINT32 width, UINT32 
 #if !defined(WINPR_UTILS_IMAGE_JPEG)
 	return NULL;
 #else
-	char* outbuffer = NULL;
+	BYTE* outbuffer = NULL;
 	unsigned long outsize = 0;
 	struct jpeg_compress_struct cinfo = { 0 };
 
@@ -513,8 +516,8 @@ void* winpr_convert_to_jpeg(const void* data, size_t size, UINT32 width, UINT32 
 	const unsigned char* cdata = data;
 	for (size_t x = 0; x < height; x++)
 	{
-		const size_t offset = x * stride;
-		const unsigned char* coffset = &cdata[offset];
+		const JDIMENSION offset = x * stride;
+		const JSAMPROW coffset = &cdata[offset];
 		if (jpeg_write_scanlines(&cinfo, &coffset, 1) != 1)
 			goto fail;
 	}


### PR DESCRIPTION
* do not use this attribute if the free function takes pointer to pointer
* audio_format_new must be freed by audio_formats_free
