### PR TITLE
gateway: Do not fail if unprocessed padding bytes are detected

### DIFF
--- a/libfreerdp/core/gateway/rpc_client.c
+++ b/libfreerdp/core/gateway/rpc_client.c
@@ -348,8 +348,8 @@ static int rpc_client_recv_pdu(rdpRpc* rpc, RPC_PDU* pdu)
 	const size_t after = Stream_GetRemainingLength(pdu->s);
 	if (after > 0)
 	{
-		WLog_ERR(TAG, "incompletely parsed RPC PDU, %" PRIuz " byte remain", before);
-		return -1;
+		/* Just log so we do not fail if we have some unprocessed padding bytes */
+		WLog_WARN(TAG, "Incompletely parsed RPC PDU (%" PRIuz " bytes remain)", after);
 	}
 
 	return rc;


### PR DESCRIPTION
Sometimes the RPC PDUs have unprocessed data (padding bytes) at their end. In that case do not fail but just log a warning with the correct amount of remaining bytes.
