### PR TITLE
[client,sdl] relax CriticalSection locking

### DIFF
--- a/client/SDL/sdl_freerdp.cpp
+++ b/client/SDL/sdl_freerdp.cpp
@@ -1332,10 +1332,7 @@ static DWORD WINAPI sdl_client_thread_proc(SdlContext* sdl)
 		}
 	}
 
-	{ /* lock here so we do not process any SDL events while disconnecting the RDP session. */
-		std::lock_guard<CriticalSection> lock(sdl->critical);
-		freerdp_disconnect(instance);
-	}
+	freerdp_disconnect(instance);
 
 terminate:
 	if (freerdp_settings_get_bool(settings, FreeRDP_AuthenticationOnly))


### PR DESCRIPTION
When disconnecting the SDL client it is sufficient to no longer process SDL events. Locking the CriticalSection during disconnect might lead to a deadlock.