### PR TITLE
don't close freerdp_peer underlying socket twice

### DIFF
--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -1234,6 +1234,8 @@ static void freerdp_peer_disconnect(freerdp_peer* client)
 
 	transport = freerdp_get_transport(client->context);
 	transport_disconnect(transport);
+	// the socket is now closed, don't attempt to close it again in freerdp_peer_free
+	client->sockfd = -1;
 }
 
 static BOOL freerdp_peer_send_channel_data(freerdp_peer* client, UINT16 channelId, const BYTE* data,
@@ -1495,7 +1497,10 @@ void freerdp_peer_free(freerdp_peer* client)
 		return;
 
 	sspi_FreeAuthIdentity(&client->identity);
-	closesocket((SOCKET)client->sockfd);
+	if (socket >= 0)
+	{
+		closesocket((SOCKET)client->sockfd);
+	}
 	free(client);
 }
 


### PR DESCRIPTION
freerdp_peer->Disconnect calls BIO_free which then calls close on the underlying file descriptor.

Then when freerdp_peer_free is called, the file descriptor is closed again.

This is problematic if the file descriptor is recycled in between:

thread 1: freerdp_peer_new(42);
thread 1: freerdp_peer->Disconnect() closes 42
thread 2: opens a file with fd 42
thread 1: freerdp_peer_free closes 42
thread 2: uses closed file descriptor 42

