### PR TITLE
fix build with openssl < 1.1.1

### DIFF
--- a/libfreerdp/crypto/privatekey.c
+++ b/libfreerdp/crypto/privatekey.c
@@ -482,13 +482,19 @@ char* freerdp_key_get_param(const rdpPrivateKey* key, enum FREERDP_KEY_PARAM par
 		switch (param)
 		{
 			case FREERDP_KEY_PARAM_RSA_D:
+#if OPENSSL_VERSION_NUMBER >= 0x10101007L
 				cbn = RSA_get0_d(rsa);
+#endif
 				break;
 			case FREERDP_KEY_PARAM_RSA_E:
+#if OPENSSL_VERSION_NUMBER >= 0x10101007L
 				cbn = RSA_get0_e(rsa);
+#endif
 				break;
 			case FREERDP_KEY_PARAM_RSA_N:
+#if OPENSSL_VERSION_NUMBER >= 0x10101007L
 				cbn = RSA_get0_n(rsa);
+#endif
 				break;
 			default:
 				return NULL;

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1107,7 +1107,7 @@ TlsHandshakeResult freerdp_tls_accept_ex(rdpTls* tls, BIO* underlying, rdpSettin
 	 * Disable SSL client site renegotiation.
 	 */
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x30000000L) && \
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L) && (OPENSSL_VERSION_NUMBER < 0x30000000L) && \
     !defined(LIBRESSL_VERSION_NUMBER)
 	options |= SSL_OP_NO_RENEGOTIATION;
 #endif

--- a/libfreerdp/emu/scard/smartcard_virtual_gids.c
+++ b/libfreerdp/emu/scard/smartcard_virtual_gids.c
@@ -1047,8 +1047,10 @@ static BOOL vgids_perform_digital_signature(vgidsContext* context)
 		{ g_PKCS1_SHA256, sizeof(g_PKCS1_SHA256), EVP_sha256() },
 		{ g_PKCS1_SHA384, sizeof(g_PKCS1_SHA384), EVP_sha384() },
 		{ g_PKCS1_SHA512, sizeof(g_PKCS1_SHA512), EVP_sha512() },
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
 		{ g_PKCS1_SHA512_224, sizeof(g_PKCS1_SHA512_224), EVP_sha512_224() },
 		{ g_PKCS1_SHA512_256, sizeof(g_PKCS1_SHA512_256), EVP_sha512_256() }
+#endif
 	};
 
 	if (!pk)


### PR DESCRIPTION
I'm building freerdp 3.2.0 on ubuntu xenial with openssl 1.1.0g, and find some openssl vars/funcs are introduced after 1.1.1:
- `RSA_get0_d`, `RSA_get0_e` and `RSA_get0_n` are introduced  by commit https://github.com/openssl/openssl/commit/6692ff7777ea3e75f964de7ee64761ec8565f9be in which `OPENSSL_VERSION_NUMBER` is `0x10101007L`: https://github.com/openssl/openssl/blob/6692ff7777ea3e75f964de7ee64761ec8565f9be/include/openssl/opensslv.h#L42
- `SSL_OP_NO_RENEGOTIATION` is introduced by commit https://github.com/openssl/openssl/commit/db0f35dda18403accabe98e7780f3dfc516f49de in which `OPENSSL_VERSION_NUMBER` is `0x10101000L`: https://github.com/openssl/openssl/blob/db0f35dda18403accabe98e7780f3dfc516f49de/include/openssl/opensslv.h#L42
- `EVP_sha512_224()` and `EVP_sha512_256()` are introduced  by commit https://github.com/openssl/openssl/commit/4bed94f0c11ef63587c6b2edb03c3c438e221604 in which `OPENSSL_VERSION_NUMBER` is `0x10101000L`: https://github.com/openssl/openssl/blob/4bed94f0c11ef63587c6b2edb03c3c438e221604/include/openssl/opensslv.h#L42

This commit will fix build error with openssl 1.1.0g.