### PR TITLE
[server,shadow] improve shadow help and startup checks

### DIFF
--- a/server/shadow/freerdp-shadow-cli.1.in
+++ b/server/shadow/freerdp-shadow-cli.1.in
@@ -64,6 +64,14 @@ Print the version and exit.
 .IP /help
 Print the help and exit.
 
+.SH USAGE
+
+#MANPAGE_NAME@ - start the shadow server on port 3389 with NLA security, SAM database at /etc/winpr/SAM
+.br
+@MANPAGE_NAME@ /sam-file:SAM.db - same as above, but a custom SAM database provided as argument
+.br
+@MANPAGE_NAME@ -sec-nla - start the shadow server on port 3380 with TLS/NLA security. This allows authenticating against PAM with unix users. Be aware that the password is transmitted plain text like with basic HTTP auth
+
 .SH EXAMPLES
 @MANPAGE_NAME@ /port:12345
 

--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -55,6 +55,14 @@ static int shadow_server_print_command_line_help(int argc, char** argv,
 
 	printf("Usage: %s [options]\n", argv[0]);
 	printf("\n");
+	printf("Notes: By default NLA security is active.\n");
+	printf("\tIn this mode a SAM database is required.\n");
+	printf("\tProvide one with /sam-file:<file with path>\n");
+	printf("\telse the default path /etc/winpr/SAM is used.\n");
+	printf("\tIf there is no existing SAM file authentication for all users will fail.\n");
+	printf(
+	    "\n\tIf authentication against PAM is desired, start with -sec-nla (requires compiled in "
+	    "support for PAM)\n\n");
 	printf("Syntax:\n");
 	printf("    /flag (enables flag)\n");
 	printf("    /option:<value> (specifies option with value)\n");


### PR DESCRIPTION
a SAM file is required for the shadow server to work if NLA is activated. Better document that and abort startup if no file is available.