### PR TITLE
[client,win32] Child session fixes

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -1022,7 +1022,7 @@ static DWORD WINAPI wf_client_thread(LPVOID lpParam)
 	rdpSettings* settings = context->settings;
 	WINPR_ASSERT(settings);
 
-	while (1)
+	while (!freerdp_shall_disconnect_context(instance->context))
 	{
 		HANDLE handles[MAXIMUM_WAIT_OBJECTS] = { 0 };
 		DWORD nCount = 0;
@@ -1045,7 +1045,9 @@ static DWORD WINAPI wf_client_thread(LPVOID lpParam)
 			nCount += tmp;
 		}
 
-		if (MsgWaitForMultipleObjects(nCount, handles, FALSE, 1000, QS_ALLINPUT) == WAIT_FAILED)
+		DWORD status = MsgWaitForMultipleObjectsEx(nCount, handles, 5 * 1000, QS_ALLINPUT,
+		                                           MWMO_ALERTABLE | MWMO_INPUTAVAILABLE);
+		if (status == WAIT_FAILED)
 		{
 			WLog_ERR(TAG, "wfreerdp_run: WaitForMultipleObjects failed: 0x%08lX", GetLastError());
 			break;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -4753,11 +4753,14 @@ static int freerdp_client_settings_parse_command_line_arguments_int(
 			                                 "vs-debug") ||
 			    !freerdp_settings_set_string(settings, FreeRDP_ServerHostname, "localhost") ||
 			    !freerdp_settings_set_string(settings, FreeRDP_AuthenticationPackageList, "ntlm") ||
+			    !freerdp_settings_set_string(settings, FreeRDP_ClientAddress, "0.0.0.0") ||
 			    !freerdp_settings_set_bool(settings, FreeRDP_NegotiateSecurityLayer, FALSE) ||
 			    !freerdp_settings_set_bool(settings, FreeRDP_VmConnectMode, TRUE) ||
 			    !freerdp_settings_set_bool(settings, FreeRDP_ConnectChildSession, TRUE) ||
 			    !freerdp_settings_set_bool(settings, FreeRDP_NlaSecurity, TRUE) ||
-			    !freerdp_settings_set_uint32(settings, FreeRDP_AuthenticationLevel, 0))
+			    !freerdp_settings_set_uint32(settings, FreeRDP_AuthenticationLevel, 0) ||
+			    !freerdp_settings_set_bool(settings, FreeRDP_NetworkAutoDetect, TRUE) ||
+			    !freerdp_settings_set_uint32(settings, FreeRDP_ConnectionType, CONNECTION_TYPE_LAN))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
 #endif

--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -469,8 +469,12 @@ static BOOL rdp_write_extended_info_packet(rdpRdp* rdp, wStream* s)
 	rdpSettings* settings = rdp->settings;
 	WINPR_ASSERT(settings);
 
-	const UINT16 clientAddressFamily =
-	    settings->IPv6Enabled ? ADDRESS_FAMILY_INET6 : ADDRESS_FAMILY_INET;
+	UINT16 clientAddressFamily = ADDRESS_FAMILY_INET;
+	if (settings->ConnectChildSession)
+		clientAddressFamily = 0x0000;
+	else if (settings->IPv6Enabled)
+		clientAddressFamily = ADDRESS_FAMILY_INET6;
+
 	WCHAR* clientAddress = ConvertUtf8ToWCharAlloc(settings->ClientAddress, &cbClientAddress);
 
 	if (cbClientAddress > (UINT16_MAX / sizeof(WCHAR)))

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -985,6 +985,7 @@ static int pollAndHandshake(rdpTls* tls)
 			case WAIT_OBJECT_0:
 				break;
 			case WAIT_TIMEOUT:
+			case WAIT_IO_COMPLETION:
 				continue;
 			default:
 				WLog_ERR(TAG, "error during WaitForSingleObject(): 0x%08" PRIX32 "", status);


### PR DESCRIPTION
It seems like WaitFor[Single|Multiple]Object calls aren't reliable on pipes, especially on the pipe opened for childSession access. The object can be marked as signaled even if no data is available, making the connection laggy and unresponsive (nearly unusable in some cases).
This patch works around that by using ReadFileEx() with overlapped instead of simple ReadFile() and use asynchronous reads.