### PR TITLE
vcpkg:  Use vcpkg to manage dependencies #9924

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/CMakeCache.txt
 **/CMakeFiles
+build*
+.vs/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,301 @@
+{
+	"version": 7,
+	"cmakeMinimumRequired": {
+		"major": 3,
+		"minor": 27,
+		"patch": 0
+	},
+	"configurePresets": [
+		{
+			"name": "vcpkg",
+			"displayName": "Configure with vcpkg. please set VCPKG_ROOT environment first",
+			"toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+		},
+
+		{
+			"name": "default",
+			"displayName": "Freerdp library minimal features",
+			"description": "Freerdp library minimal features with vcpkg",
+			"inherits": "vcpkg",
+			"cacheVariables": {
+				"WITH_FFMPEG": "OFF",
+				"WITH_SWSCALE": "OFF",
+				"CHANNEL_URBDRC": "OFF",
+				"WITH_PKCS11": "OFF",
+				"WITH_CUPS": "OFF",
+				"WITH_MANPAGES": "OFF",
+				"WITH_KRB5": "OFF",
+				"WITH_CLIENT_COMMON": "ON",
+				"WITH_CLIENT": "OFF",
+				"WITH_SERVER": "OFF",
+				"WITH_PROXY": "OFF",
+				"WITH_SHADOW": "OFF",
+				"WITH_PLATFORM_SERVER": "OFF",
+				"WITH_VERBOSE_WINPR_ASSERT": "OFF",
+				"WITH_OPAQUE_SETTINGS": "OFF"
+			}
+		},
+		{
+			"name": "default-msvc",
+			"displayName": "Default using Visual Studio 17 2022",
+			"description": "Freerdp library minimal features using Visual Studio 17 2022",
+			"inherits": "default",
+			"generator": "Visual Studio 17 2022",
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Windows"
+			}
+		},
+		{
+			"name": "default-ninja",
+			"displayName": "Default using ninja",
+			"description": "Freerdp library minimal features using ninja",
+			"inherits": "default",
+			"generator": "Ninja"
+		},
+		{
+			"name": "default-android",
+			"displayName": "Default for android",
+			"description": "Freerdp library minimal features for android",
+			"hidden": true,
+			"inherits": "default-ninja",
+			"cacheVariables": {
+				"VCPKG_CHAINLOAD_TOOLCHAIN_FILE":
+				    "$env{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake"
+			}
+		},
+		{
+			"name": "default-android-arm64",
+			"displayName": "Default for android arm64",
+			"description": "Freerdp library minimal features for android arm64",
+			"inherits": "default-android",
+			"cacheVariables": {
+				"ANDROID_ABI": "arm64-v8a",
+				"VCPKG_TARGET_TRIPLET": "arm64-android"
+			}
+		},
+		{
+			"name": "default-android-arm64-make",
+			"displayName": "Default for android arm64 with make",
+			"description": "Freerdp library minimal features for android arm64 with make",
+			"inherits": "default-android-arm64",
+			"generator": "Unix Makefiles",
+			"cacheVariables": {
+				"CMAKE_MAKE_PROGRAM":
+				    "$env{ANDROID_NDK_HOME}/prebuilt/${hostSystemName}-x86_64/bin/make"
+			}
+		},
+		{
+			"name": "default-android-x86_64",
+			"displayName": "Default for android x86_64",
+			"description": "Freerdp library minimal features for android x86_64",
+			"inherits": "default-android",
+			"cacheVariables": {
+				"ANDROID_ABI": "x86_64",
+				"VCPKG_TARGET_TRIPLET": "x64-android"
+			}
+		},
+		{
+			"name": "default-android-x86_64-make",
+			"displayName": "Default for android x86_64 with make",
+			"description": "Freerdp library minimal features for android x86_64 with make",
+			"inherits": "default-android-x86_64",
+			"generator": "Unix Makefiles",
+			"cacheVariables": {
+				"CMAKE_MAKE_PROGRAM":
+				    "$env{ANDROID_NDK_HOME}/prebuilt/${hostSystemName}-x86_64/bin/make"
+			}
+		},
+
+		{
+			"name": "freerdp",
+			"displayName": "Freerdp library with ffmpeg etc",
+			"description": "Freerdp library with ffmpeg etc with vcpkg",
+			"inherits": "vcpkg",
+			"cacheVariables": {
+				"WITH_CLIENT_COMMON": "ON",
+				"WITH_CLIENT": "OFF",
+				"WITH_SERVER": "OFF",
+				"WITH_PROXY": "OFF",
+				"WITH_SHADOW": "OFF",
+				"WITH_PLATFORM_SERVER": "OFF",
+				"WITH_VERBOSE_WINPR_ASSERT": "OFF",
+				"WITH_OPAQUE_SETTINGS": "OFF",
+				"VCPKG_MANIFEST_FEATURES": "freerdp;channel"
+			}
+		},
+		{
+			"name": "freerdp-msvc",
+			"displayName": "Freerdp using Visual Studio 17 2022",
+			"description":
+			    "Freerdp library with ffmpeg etc  with vcpkg using Visual Studio 17 2022",
+			"inherits": "freerdp",
+			"generator": "Visual Studio 17 2022",
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Windows"
+			}
+		},
+		{
+			"name": "freerdp-ninja",
+			"displayName": "Freerdp using ninja",
+			"inherits": "freerdp",
+			"generator": "Ninja"
+		},
+		{
+			"name": "freerdp-android",
+			"displayName": "freerdp for android",
+			"hidden": true,
+			"inherits": "freerdp",
+			"generator": "Unix Makefiles",
+			"cacheVariables": {
+				"VCPKG_CHAINLOAD_TOOLCHAIN_FILE":
+				    "$env{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake"
+			}
+		},
+		{
+			"name": "freerdp-android-arm64",
+			"displayName": "Freerdp for android arm64",
+			"inherits": "freerdp-android",
+			"cacheVariables": {
+				"ANDROID_ABI": "arm64-v8a",
+				"VCPKG_TARGET_TRIPLET": "arm64-android"
+			}
+		},
+		{
+			"name": "freerdp-android-arm64-make",
+			"displayName": "Freerdp for android arm64 with make",
+			"inherits": "freerdp-android-arm64",
+			"generator": "Unix Makefiles",
+			"cacheVariables": {
+				"CMAKE_MAKE_PROGRAM":
+				    "$env{ANDROID_NDK_HOME}/prebuilt/${hostSystemName}-x86_64/bin/make"
+			}
+		},
+		{
+			"name": "freerdp-android-x86_64",
+			"displayName": "Freerdp for android x86_64",
+			"inherits": "freerdp-android",
+			"cacheVariables": {
+				"ANDROID_ABI": "x86_64",
+				"VCPKG_TARGET_TRIPLET": "x64-android"
+			}
+		},
+		{
+			"name": "freerdp-android-x86_64-make",
+			"displayName": "Freerdp for android x86_64 with make",
+			"inherits": "freerdp-android-x86_64",
+			"generator": "Unix Makefiles",
+			"cacheVariables": {
+				"CMAKE_MAKE_PROGRAM":
+				    "$env{ANDROID_NDK_HOME}/prebuilt/${hostSystemName}-x86_64/bin/make"
+			}
+		},
+
+		{
+			"name": "client",
+			"displayName": "Client",
+			"description": "Client with vcpkg",
+			"inherits": "vcpkg",
+			"cacheVariables": {
+				"WITH_CLIENT_COMMON": "ON",
+				"WITH_CLIENT": "ON",
+				"WITH_SERVER": "OFF",
+				"WITH_PROXY": "OFF",
+				"WITH_SHADOW": "OFF",
+				"WITH_PLATFORM_SERVER": "OFF",
+				"WITH_VERBOSE_WINPR_ASSERT": "OFF",
+				"WITH_OPAQUE_SETTINGS": "OFF",
+				"VCPKG_MANIFEST_FEATURES": "client;channel;freerdp"
+			}
+		},
+		{
+			"name": "client-msvc",
+			"displayName": "Client using Visual Studio",
+			"inherits": "client",
+			"generator": "Visual Studio 17 2022",
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Windows"
+			}
+		},
+		{
+			"name": "client-ninja",
+			"displayName": "Client using ninja",
+			"inherits": "client",
+			"generator": "Ninja"
+		},
+
+		{
+			"name": "server",
+			"displayName": "Server",
+			"description": "Server with vcpkg",
+			"inherits": "vcpkg",
+			"cacheVariables": {
+				"WITH_CLIENT_COMMON": "OFF",
+				"WITH_CLIENT": "OFF",
+				"WITH_SERVER": "ON",
+				"WITH_PROXY": "ON",
+				"WITH_SHADOW": "ON",
+				"WITH_PLATFORM_SERVER": "ON",
+				"WITH_VERBOSE_WINPR_ASSERT": "OFF",
+				"WITH_OPAQUE_SETTINGS": "OFF",
+				"VCPKG_MANIFEST_FEATURES": "channel;freerdp;server"
+			}
+		},
+		{
+			"name": "server-msvc",
+			"displayName": "Server using Visual Studio 17 2022",
+			"inherits": "server",
+			"generator": "Visual Studio 17 2022",
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Windows"
+			}
+		},
+		{
+			"name": "server-ninja",
+			"displayName": "Server using ninja",
+			"inherits": "server",
+			"generator": "Ninja"
+		},
+
+		{
+			"name": "all",
+			"displayName": "All",
+			"inherits": "vcpkg",
+			"cacheVariables": {
+				"WITH_CLIENT_COMMON": "ON",
+				"WITH_CLIENT": "ON",
+				"WITH_SERVER": "ON",
+				"WITH_PROXY": "ON",
+				"WITH_SHADOW": "ON",
+				"WITH_PLATFORM_SERVER": "ON",
+				"WITH_VERBOSE_WINPR_ASSERT": "OFF",
+				"WITH_OPAQUE_SETTINGS": "OFF",
+				"VCPKG_MANIFEST_FEATURES": "freerdp;channel;client;server"
+			}
+		},
+		{
+			"name": "all-msvc",
+			"displayName": "All using Visual Studio 17 2022",
+			"inherits": "all",
+			"generator": "Visual Studio 17 2022",
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Windows"
+			}
+		},
+		{
+			"name": "all-ninja",
+			"displayName": "All using ninja",
+			"inherits": "all",
+			"generator": "Ninja"
+		}
+	]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,66 @@
+{
+	"name": "freerdp",
+	"version-string": "3.3.0",
+	"description": "A free implementation of the Remote Desktop Protocol (RDP)",
+	"homepage": "https://github.com/FreeRDP/FreeRDP",
+	"license": "Apache-2.0",
+	"dependencies": [
+		"openssl",
+		"zlib"
+	],
+	"features": {
+		"channel": {
+			"description": "Enable channel feature",
+			"dependencies": [
+				{
+					"name": "alsa",
+					"platform": "linux"
+				},
+				"libusb"
+			]
+		},
+		"client": {
+			"description": "Enable client feature",
+			"dependencies": [
+				{
+					"name": "sdl2",
+					"platform": "windows | linux | macos"
+				},
+				{
+					"name": "sdl2-image",
+					"platform": "windows | linux | macos"
+				},
+				{
+					"name": "sdl2-ttf",
+					"platform": "windows | linux | macos"
+				}
+			]
+		},
+		"freerdp": {
+			"description": "Enable library feature",
+			"dependencies": [
+				"cjson",
+				{
+					"name": "ffmpeg",
+					"features": [
+						{
+							"name": "openh264",
+							"platform": "windows | linux | macos"
+						}
+					]
+				},
+				{
+					"name": "icu",
+					"platform": "linux | windows | macos"
+				},
+				{
+					"name": "uriparser",
+					"platform": "linux"
+				}
+			]
+		},
+		"server": {
+			"description": "Enable server feature"
+		}
+	}
+}


### PR DESCRIPTION
### Documents:
- https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html
- https://learn.microsoft.com/vcpkg/get_started/overview
- https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration

### Usage:

- cmake >= v3.27.0
- get vcpkg

  ```
  git clone https://github.com/microsoft/vcpkg.git
  ```

- Set environment variable `VCPKG_ROOT` 
- mkdir build in FreeRDP

  ```
  cd FreeRDP
  mkdir build
  ```

- CMake configure

   ```
   cd build
   cmake .. --preset default-msvc     # in windows
   cmake .. --preset default-ninja      # in ubuntu
   ```

  If not set VCPKG_ROOT. please set CMAKE_TOOLCHAIN_FILE

  ```
  cmake .. --preset default-msvc  -DCMAKE_TOOLCHAIN_FILE="d:/source/vcpkg/scripts/buildsystems/vcpkg.cmake"
  ```

  See: 
  - https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration
  - https://learn.microsoft.com/zh-cn/vcpkg/consume/manifest-mode?tabs=cmake%2Cbuild-cmake
- build

  ```
  cmake --build .
  ```

  The dependencies is installed `vcpkg_installed`
- install
  ```
  cmake --install . --prefix install
  ```
### It is divided into the following features(in vcpkg.json):

    freerdp(include libfreerdp, libwinpr, libwinpr-tool).
    channel
    client
    server

### Preset
- Completed

  "default"                     - Freerdp library minimal features
  "default-msvc"                - Default using Visual Studio 17 2022
  "default-ninja"               - Default using ninja
  "default-android-arm64"       - Default for android arm64
  "default-android-arm64-make"  - Default for android arm64 with make
  "default-android-x86_64"      - Default for android x86_64
  "default-android-x86_64-make" - Default for android x86_64 with make
  "freerdp"                     - Freerdp library with ffmpeg etc
  "freerdp-msvc"                - Freerdp using Visual Studio 17 2022
  "freerdp-ninja"               - Freerdp using ninja
  "freerdp-android-arm64"       - Freerdp for android arm64
  "freerdp-android-arm64-make"  - Freerdp for android arm64 with make
  "freerdp-android-x86_64"      - Freerdp for android x86_64
  "freerdp-android-x86_64-make" - Freerdp for android x86_64 with make
  "client"                      - Client
  "client-msvc"                 - Client using Visual Studio
  "client-ninja"                - Client using ninja
  "server"                      - Server
  "server-msvc"                 - Server using Visual Studio 17 2022
  "server-ninja"                - Server using ninja
  "all"                         - All
  "all-msvc"                    - All using Visual Studio 17 2022
  "all-ninja"                   - All using ninja

- Unfinished
  -  macos . I don't have a device, please add it who has a device.