### PR TITLE
make local gettimeofday helper static

### DIFF
--- a/libfreerdp/utils/pcap.c
+++ b/libfreerdp/utils/pcap.c
@@ -38,7 +38,7 @@
 #include <sys/timeb.h>
 #include <winpr/windows.h>
 
-int gettimeofday(struct timeval* tp, void* tz)
+static int gettimeofday(struct timeval* tp, void* tz)
 {
 	struct _timeb timebuffer;
 	_ftime(&timebuffer);


### PR DESCRIPTION
We have a local gettimeofday() helper for Windows in libfreerdp/utils/pcap.c that wasn't defined as static. There was no reason not to make it static, and it caused a symbol conflict with LibreSSL on Windows.