### PR TITLE
[winpr,sysinfo] unify time function use

### DIFF
--- a/libfreerdp/primitives/test/prim_test.c
+++ b/libfreerdp/primitives/test/prim_test.c
@@ -36,31 +36,15 @@ int test_sizes[] = { 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096 };
 
 /* ------------------------------------------------------------------------- */
 
-#ifdef _WIN32
-float _delta_time(const struct timespec* t0, const struct timespec* t1)
+float measure_delta_time(UINT64 t0, UINT64 t1)
 {
-	return 0.0f;
+	INT64 diff = (INT64)(t1 - t0);
+	double retval = diff / 1000000000.0;
+	return (retval < 0.0) ? 0.0f : (float)retval;
 }
-#else
-float _delta_time(const struct timespec* t0, const struct timespec* t1)
-{
-	INT64 secs = (INT64)(t1->tv_sec) - (INT64)(t0->tv_sec);
-	long nsecs = t1->tv_nsec - t0->tv_nsec;
-	double retval = NAN;
-
-	if (nsecs < 0)
-	{
-		--secs;
-		nsecs += 1000000000;
-	}
-
-	retval = (double)secs + (double)nsecs / (double)1000000000.0;
-	return (retval < 0.0) ? 0.0 : (float)retval;
-}
-#endif
 
 /* ------------------------------------------------------------------------- */
-void _floatprint(float t, char* output)
+void measure_floatprint(float t, char* output)
 {
 	/* I don't want to link against -lm, so avoid log,exp,... */
 	float f = 10.0;

--- a/libfreerdp/utils/stopwatch.c
+++ b/libfreerdp/utils/stopwatch.c
@@ -22,38 +22,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <winpr/sysinfo.h>
 #include <freerdp/utils/stopwatch.h>
-
-#ifdef _WIN32
-LARGE_INTEGER stopwatch_freq = { 0 };
-#else
-#include <sys/time.h>
-#endif
 
 static void stopwatch_set_time(UINT64* usecs)
 {
-#ifdef _WIN32
-	LARGE_INTEGER perfcount;
-	QueryPerformanceCounter(&perfcount);
-	*usecs = (perfcount.QuadPart * 1000000) / stopwatch_freq.QuadPart;
-#else
-	struct timeval tv;
-	gettimeofday(&tv, NULL);
-	*usecs = tv.tv_sec * 1000000 + tv.tv_usec;
-#endif
+	const UINT64 ns = winpr_GetTickCount64NS();
+	*usecs = WINPR_TIME_NS_TO_US(ns);
 }
 
 STOPWATCH* stopwatch_create(void)
 {
-	STOPWATCH* sw = NULL;
-#ifdef _WIN32
-	if (stopwatch_freq.QuadPart == 0)
-	{
-		QueryPerformanceFrequency(&stopwatch_freq);
-	}
-#endif
-
-	sw = (STOPWATCH*)malloc(sizeof(STOPWATCH));
+	STOPWATCH* sw = (STOPWATCH*)calloc(1, sizeof(STOPWATCH));
 	if (!sw)
 		return NULL;
 	stopwatch_reset(sw);

--- a/winpr/include/winpr/sysinfo.h
+++ b/winpr/include/winpr/sysinfo.h
@@ -322,6 +322,17 @@ extern "C"
 
 #endif
 
+#define WINPR_TIME_NS_TO_S(ns) ((ns) / 1000000000ull)
+#define WINPR_TIME_NS_TO_MS(ns) ((ns) / 1000000ull)
+#define WINPR_TIME_NS_TO_US(ns) ((ns) / 1000ull)
+
+#define WINPR_TIME_NS_REM_NS(ns) ((ns) % 1000000000ull)
+#define WINPR_TIME_NS_REM_US(ns) (WINPR_TIME_NS_REM_NS(ns) / 1000ull)
+#define WINPR_TIME_NS_REM_MS(ns) (WINPR_TIME_NS_REM_US(ns) / 1000ull)
+
+	WINPR_API UINT64 winpr_GetTickCount64NS(void);
+	WINPR_API UINT64 winpr_GetUnixTimeNS(void);
+
 	WINPR_API DWORD GetTickCountPrecise(void);
 
 	WINPR_API BOOL IsProcessorFeaturePresentEx(DWORD ProcessorFeature);

--- a/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_compute.c
@@ -248,15 +248,12 @@ BOOL ntlm_write_ntlm_v2_response(wStream* s, const NTLMv2_RESPONSE* response)
 
 void ntlm_current_time(BYTE* timestamp)
 {
-	FILETIME filetime = { 0 };
-	ULARGE_INTEGER time64 = { 0 };
+	FILETIME ft = { 0 };
 
 	WINPR_ASSERT(timestamp);
 
-	GetSystemTimeAsFileTime(&filetime);
-	time64.u.LowPart = filetime.dwLowDateTime;
-	time64.u.HighPart = filetime.dwHighDateTime;
-	CopyMemory(timestamp, &(time64.QuadPart), 8);
+	GetSystemTimeAsFileTime(&ft);
+	CopyMemory(timestamp, &(ft), sizeof(ft));
 }
 
 /**

--- a/winpr/libwinpr/synch/timer.c
+++ b/winpr/libwinpr/synch/timer.c
@@ -707,11 +707,11 @@ static void timespec_add_ms(struct timespec* tspec, UINT32 ms)
 
 static void timespec_gettimeofday(struct timespec* tspec)
 {
-	struct timeval tval;
 	WINPR_ASSERT(tspec);
-	gettimeofday(&tval, NULL);
-	tspec->tv_sec = tval.tv_sec;
-	tspec->tv_nsec = tval.tv_usec * 1000;
+
+	const UINT64 ns = winpr_GetUnixTimeNS();
+	tspec->tv_sec = WINPR_TIME_NS_TO_S(ns);
+	tspec->tv_nsec = WINPR_TIME_NS_REM_NS(ns);
 }
 
 static INT64 timespec_compare(const struct timespec* tspec1, const struct timespec* tspec2)

--- a/winpr/libwinpr/utils/wlog/PacketMessage.c
+++ b/winpr/libwinpr/utils/wlog/PacketMessage.c
@@ -29,26 +29,10 @@
 #include <winpr/crt.h>
 #include <winpr/file.h>
 #include <winpr/stream.h>
+#include <winpr/sysinfo.h>
 
 #include "../../log.h"
 #define TAG WINPR_TAG("utils.wlog")
-
-#ifndef _WIN32
-#include <sys/time.h>
-#else
-#include <time.h>
-#include <sys/timeb.h>
-#include <winpr/windows.h>
-
-static int gettimeofday(struct timeval* tp, void* tz)
-{
-	struct _timeb timebuffer;
-	_ftime(&timebuffer);
-	tp->tv_sec = (long)timebuffer.time;
-	tp->tv_usec = timebuffer.millitm * 1000;
-	return 0;
-}
-#endif
 
 static BOOL Pcap_Read_Header(wPcap* pcap, wPcapHeader* header)
 {
@@ -89,8 +73,7 @@ static BOOL Pcap_Read_Record(wPcap* pcap, wPcapRecord* record)
 
 static BOOL Pcap_Add_Record(wPcap* pcap, void* data, UINT32 length)
 {
-	wPcapRecord* record;
-	struct timeval tp;
+	wPcapRecord* record = NULL;
 
 	if (!pcap->tail)
 	{
@@ -117,9 +100,10 @@ static BOOL Pcap_Add_Record(wPcap* pcap, void* data, UINT32 length)
 	record->length = length;
 	record->header.incl_len = length;
 	record->header.orig_len = length;
-	gettimeofday(&tp, 0);
-	record->header.ts_sec = tp.tv_sec;
-	record->header.ts_usec = tp.tv_usec;
+
+	UINT64 ns = winpr_GetUnixTimeNS();
+	record->header.ts_sec = WINPR_TIME_NS_TO_S(ns);
+	record->header.ts_usec = WINPR_TIME_NS_REM_US(ns);
 	return TRUE;
 }
 
@@ -380,7 +364,6 @@ BOOL WLog_PacketMessage_Write(wPcap* pcap, void* data, size_t length, DWORD flag
 {
 	wTcpHeader tcp;
 	wIPv4Header ipv4;
-	struct timeval tp;
 	wPcapRecord record;
 	wEthernetHeader ethernet;
 	ethernet.Type = 0x0800;
@@ -474,9 +457,11 @@ BOOL WLog_PacketMessage_Write(wPcap* pcap, void* data, size_t length, DWORD flag
 	record.header.incl_len = (UINT32)record.length + offset;
 	record.header.orig_len = (UINT32)record.length + offset;
 	record.next = NULL;
-	gettimeofday(&tp, 0);
-	record.header.ts_sec = tp.tv_sec;
-	record.header.ts_usec = tp.tv_usec;
+
+	UINT64 ns = winpr_GetUnixTimeNS();
+	record.header.ts_sec = WINPR_TIME_NS_TO_S(ns);
+	record.header.ts_usec = WINPR_TIME_NS_REM_US(ns);
+
 	if (!Pcap_Write_RecordHeader(pcap, &record.header) ||
 	    !WLog_PacketMessage_Write_EthernetHeader(pcap, &ethernet) ||
 	    !WLog_PacketMessage_Write_IPv4Header(pcap, &ipv4) ||


### PR DESCRIPTION
* Add new function winpr_GetTickCount64NS for high resolution tick count with (up to) nanosecond resolution
* Add new function winpr_GetUnixTimeNS for high resolution system time as nanoseconds since 1.1.1970
* Replace use of clock_gettime and gettimeofday in whole project with these new functions