### PR TITLE
[sdl] Only blit rectangles to windows that they intersect

### DIFF
--- a/client/SDL/sdl_freerdp.cpp
+++ b/client/SDL/sdl_freerdp.cpp
@@ -339,8 +339,14 @@ static bool sdl_draw_to_window_rect(SdlContext* sdl, SdlWindow& window, SDL_Surf
 		return sdl_draw_to_window_rect(sdl, window, surface, offset,
 		                               { 0, 0, surface->w, surface->h });
 	}
+
+	bool multimon = freerdp_settings_get_bool(sdl->context()->settings, FreeRDP_UseMultimon) != 0;
+	SDL_Rect windowRect = window.rect();
 	for (auto& srcRect : rects)
 	{
+		if (multimon && SDL_HasIntersection(&srcRect, &windowRect) == SDL_FALSE)
+			continue;
+
 		if (!sdl_draw_to_window_rect(sdl, window, surface, offset, srcRect))
 			return false;
 	}


### PR DESCRIPTION
This pull request modifies the `sdl_draw_to_window_rect` to skip attempting to blit rects which do not intersect the window the function is currently operating on. This prevents `SdlWindow#blit` from returning false and short-circuiting the drawing loop. In a single-window session, it's reasonable to assume that something is wrong if any of the rectangles being blitted do not interesect the window, but in a multimon session each rectangle will only be applicable for one window. Because the primary window is always handled first, all rectangles which intersect a different window will fail to be blitted to the primary one and immediately short-circuit the draw loop.

This PR doesn't modify the analogous functions for smart-sizing, because currently smart-sizing appears to be completely broken on SDL with multimon enabled.