### PR TITLE
[client,sdl] Always disable decorations in multimon session

### DIFF
--- a/client/SDL/sdl_disp.cpp
+++ b/client/SDL/sdl_disp.cpp
@@ -333,7 +333,9 @@ BOOL sdlDispContext::handle_window_event(const SDL_WindowEvent* ev)
 {
 	WINPR_ASSERT(ev);
 
-	auto bordered = freerdp_settings_get_bool(_sdl->context()->settings, FreeRDP_Decorations)
+	bool decorations = freerdp_settings_get_bool(_sdl->context()->settings, FreeRDP_Decorations) != 0;
+	bool multimon = freerdp_settings_get_bool(_sdl->context()->settings, FreeRDP_UseMultimon) != 0;
+	auto bordered = decorations && !multimon
 	                    ? SDL_TRUE
 	                    : SDL_FALSE;
 


### PR DESCRIPTION
This pull request modifies the code responsible for enabling/disabling borders on FreeRDP windows to consider whether the current session is multimonitor. IMO it doesn't really make sense for a multimonitor session to have borders, and removing the effective requirement that window decorations be explicitly disabled in this case makes for a nicer experience.

Additionally, this code was causing my graphics driver to sometimes hang when initially opening the windows, I would assume due to the combination of `SDL_WINDOW_BORDERLESS` and `SDL_SetWindowBordered(SDL_TRUE)`. As far as I can tell this is a bug in KWin 6, but removing this trigger is also nice.