### PR TITLE
[ci,tidy] allow integer bool conditions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -49,6 +49,8 @@ AnalyzeTemporaryDtors: false
 FormatStyle:     file
 User:            nin
 CheckOptions:
+  - key:             readability-implicit-bool-conversion.AllowIntegerConditions
+    value:           'true'
   - key:             llvm-else-after-return.WarnOnConditionVariables
     value:           'false'
   - key:             modernize-loop-convert.MinConfidence


### PR DESCRIPTION
We heavily rely on our custom BOOL type which is a typedef to int32_t. Consider this a valid bool condition for
readability-implicit-bool-conversion