### PR TITLE
[win32,childsession] Fix invalid pipe path with 32 bits builds

### DIFF
--- a/libfreerdp/core/childsession.c
+++ b/libfreerdp/core/childsession.c
@@ -484,6 +484,23 @@ static BOOL createChildSessionTransport(HANDLE* pFile)
 		goto out;
 	}
 
+	const BYTE startOfPath[] = { '\\', 0, '\\', 0, '.', 0, '\\', 0 };
+	if (_wcsncmp(pipePath, (WCHAR*)startOfPath, 4))
+	{
+		/* when compiled under 32 bits, the path may miss "\\.\" at the beginning of the string
+		 * so add it if it's not there
+		 */
+		size_t len = _wcslen(pipePath);
+		if (len > 0x80 - (8 + 1))
+		{
+			WLog_ERR(TAG, "pipePath is too long to be adjusted");
+			goto out;
+		}
+
+		memmove(pipePath + 8, pipePath, (len + 1) * sizeof(WCHAR));
+		memcpy(pipePath, startOfPath, 8);
+	}
+
 	ConvertWCharNToUtf8(pipePath, 0x80, pipePathA, sizeof(pipePathA));
 	WLog_DBG(TAG, "child session is at '%s'", pipePathA);
 


### PR DESCRIPTION
When compiled as x86 (32 bits) the path returned by WinStationCreateChildSessionTransport is sometime missing the beginning of the pipe path.