### PR TITLE
Fix MSVC arm64

### DIFF
--- a/winpr/include/winpr/intrin.h
+++ b/winpr/include/winpr/intrin.h
@@ -22,7 +22,7 @@
 #ifndef WINPR_INTRIN_H
 #define WINPR_INTRIN_H
 
-#if !defined(_WIN32) || defined(__MINGW32__)
+#if !defined(_WIN32) || defined(__MINGW32__) || defined(_M_ARM64)
 
 /**
  * __lzcnt16, __lzcnt, __lzcnt64:


### PR DESCRIPTION
From vcpkg port, fixes:
~~~
FAILED: freerdp3.dll freerdp3.lib 
cmd.exe /C "cd . && D:\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -E vs_link_dll --intdir=libfreerdp\CMakeFiles\freerdp.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1438~1.331\bin\Hostx64\arm64\link.exe  @CMakeFiles\freerdp.rsp  /out:freerdp3.dll /implib:freerdp3.lib /pdb:freerdp3.pdb /dll /version:3.3 /machine:ARM64 /nologo    /debug /INCREMENTAL  /INCREMENTAL:NO /LTCG  && cd ."
LINK: command "C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1438~1.331\bin\Hostx64\arm64\link.exe @CMakeFiles\freerdp.rsp /out:freerdp3.dll /implib:freerdp3.lib /pdb:freerdp3.pdb /dll /version:3.3 /machine:ARM64 /nologo /debug /INCREMENTAL /INCREMENTAL:NO /LTCG /MANIFEST:EMBED,ID=2" failed (exit code 1120) with the following output:
   Creating library freerdp3.lib and object freerdp3.exp


rfx_rlgr.c.obj : error LNK2001: unresolved external symbol __lzcnt


freerdp3.dll : fatal error LNK1120: 1 unresolved externals
~~~