### PR TITLE
Export usage requirements

### DIFF
--- a/client/FreeRDP-ClientConfig.cmake.in
+++ b/client/FreeRDP-ClientConfig.cmake.in
@@ -1,6 +1,9 @@
 include(CMakeFindDependencyMacro)
 find_dependency(WinPR @FREERDP_VERSION@)
 find_dependency(FreeRDP @FREERDP_VERSION@)
+if("@WITH_SMARTCARD_EMULATE@")
+	find_dependency(ZLIB)
+endif()
 
 @PACKAGE_INIT@
 

--- a/libfreerdp/CMakeLists.txt
+++ b/libfreerdp/CMakeLists.txt
@@ -477,6 +477,13 @@ endif()
 set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "FreeRDP/libfreerdp")
 
 include(pkg-config-install-prefix)
+set(FREERDP_REQUIRES_PRIVATE "")
+if(cJSON_FOUND)
+    string(APPEND FREERDP_REQUIRES_PRIVATE " libcjson")
+endif()
+if(WITH_SMARTCARD_EMULATE)
+    string(APPEND FREERDP_REQUIRES_PRIVATE " zlib")
+endif()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/freerdp.pc.in ${CMAKE_CURRENT_BINARY_DIR}/freerdp${FREERDP_VERSION_MAJOR}.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/freerdp${FREERDP_VERSION_MAJOR}.pc DESTINATION ${PKG_CONFIG_PC_INSTALL_DIR})
 

--- a/libfreerdp/FreeRDPConfig.cmake.in
+++ b/libfreerdp/FreeRDPConfig.cmake.in
@@ -1,5 +1,11 @@
 include(CMakeFindDependencyMacro)
 find_dependency(WinPR @FREERDP_VERSION@)
+if("@cJSON_FOUND@" AND NOT "@BUILD_SHARED_LIBS@")
+	find_dependency(cJSON)
+endif()
+if("@WITH_SMARTCARD_EMULATE@" AND NOT "@BUILD_SHARED_LIBS@")
+	find_dependency(ZLIB)
+endif()
 
 @PACKAGE_INIT@
 

--- a/libfreerdp/freerdp.pc.in
+++ b/libfreerdp/freerdp.pc.in
@@ -14,7 +14,7 @@ Description: FreeRDP: A Remote Desktop Protocol Implementation
 URL: http://www.freerdp.com/
 Version: @FREERDP_VERSION@
 Requires: 
-Requires.private: winpr@FREERDP_API_VERSION@
+Requires.private: winpr@FREERDP_API_VERSION@ @FREERDP_REQUIRES_PRIVATE@
 Libs: -L${libdir} ${libs}
 Libs.private: -ldl -lpthread
 Cflags: -I${includedir}


### PR DESCRIPTION
Exported CMake Config may carry imported targets:
~~~
$<LINK_ONLY:cjson>
$<LINK_ONLY:ZLIB::ZLIB>
ZLIB::ZLIB
~~~
These must be resolved when the config is used.
Exported pc files did't carry these usage requirements at all.