### PR TITLE
Send relative mouse events using TS_RELPOINTER_EVENT only when capability present

### DIFF
--- a/client/common/client.c
+++ b/client/common/client.c
@@ -1574,8 +1574,9 @@ BOOL freerdp_client_send_button_event(rdpClientContext* cctx, BOOL relative, UIN
 
 	WINPR_ASSERT(cctx);
 
-	const BOOL relativeInput = freerdp_client_use_relative_mouse_events(cctx);
-	if (relative && relativeInput)
+	const BOOL haveRelative =
+	    freerdp_settings_get_bool(cctx->context.settings, FreeRDP_HasRelativeMouseEvent);
+	if (relative && haveRelative)
 	{
 		return freerdp_input_send_rel_mouse_event(cctx->context.input, mflags, x, y);
 	}
@@ -1585,7 +1586,7 @@ BOOL freerdp_client_send_button_event(rdpClientContext* cctx, BOOL relative, UIN
 	{
 		UINT64 flags = 0;
 
-		if (cctx->mouse_grabbed && relativeInput)
+		if (cctx->mouse_grabbed && freerdp_client_use_relative_mouse_events(cctx))
 			flags |= AINPUT_FLAGS_HAVE_REL;
 
 		if (relative)
@@ -1630,7 +1631,9 @@ BOOL freerdp_client_send_extended_button_event(rdpClientContext* cctx, BOOL rela
 	BOOL handled = FALSE;
 	WINPR_ASSERT(cctx);
 
-	if (relative && freerdp_client_use_relative_mouse_events(cctx))
+	const BOOL haveRelative =
+	    freerdp_settings_get_bool(cctx->context.settings, FreeRDP_HasRelativeMouseEvent);
+	if (relative && haveRelative)
 	{
 		return freerdp_input_send_rel_mouse_event(cctx->context.input, mflags, x, y);
 	}


### PR DESCRIPTION
Fixes #10006

![Capture](https://github.com/FreeRDP/FreeRDP/assets/45110640/8604af7f-4d0a-4551-974a-0d62e6576168)
