### PR TITLE
[client,X11] fix detection of need to use relative movements

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -450,7 +450,8 @@ static BOOL xf_event_MotionNotify(xfContext* xfc, const XMotionEvent* event, BOO
 {
 	WINPR_ASSERT(xfc);
 
-	if (xfc->xi_event)
+	if (xfc->xi_event ||
+	    (xfc->common.mouse_grabbed && freerdp_client_use_relative_mouse_events(&xfc->common)))
 		return TRUE;
 
 	if (xfc->window)
@@ -559,7 +560,8 @@ static BOOL xf_event_ButtonPress(xfContext* xfc, const XButtonEvent* event, BOOL
 {
 	xf_grab_mouse(xfc);
 
-	if (xfc->xi_event)
+	if (xfc->xi_event ||
+	    (xfc->common.mouse_grabbed && freerdp_client_use_relative_mouse_events(&xfc->common)))
 		return TRUE;
 	return xf_generic_ButtonEvent(xfc, event->x, event->y, event->button, event->window, app, TRUE);
 }
@@ -568,7 +570,8 @@ static BOOL xf_event_ButtonRelease(xfContext* xfc, const XButtonEvent* event, BO
 {
 	xf_grab_mouse(xfc);
 
-	if (xfc->xi_event)
+	if (xfc->xi_event ||
+	    (xfc->common.mouse_grabbed && freerdp_client_use_relative_mouse_events(&xfc->common)))
 		return TRUE;
 	return xf_generic_ButtonEvent(xfc, event->x, event->y, event->button, event->window, app,
 	                              FALSE);


### PR DESCRIPTION
As noted in issue #10006

>`xfreerdp` doesn't send relative mouse movements at all (only absolute; am I missing some other option to capture the mouse?).

I found flaws in the X11 client implementation; it doesn't register raw input handlers because the ainput channel may not be available at the time of connection.
Also, even if it successfully registers a handler, it sends two types of events at the same time: both absolute and relative.
This PR fixes both shortcomings. Relative movements now work correctly in `xfreerdp`, not just in `sdl-freerdp`.

![Capture](https://github.com/FreeRDP/FreeRDP/assets/45110640/58c30f5a-ec43-470a-a2c5-3baab378e535)
