### PR TITLE
[core,gateway] improve warning for bad request

### DIFF
--- a/libfreerdp/core/gateway/arm.c
+++ b/libfreerdp/core/gateway/arm.c
@@ -842,7 +842,11 @@ static BOOL arm_handle_bad_request(rdpArm* arm, const HttpResponse* response, BO
 	    0)
 	{
 		*retry = TRUE;
-		WLog_DBG(TAG, "Starting your VM. It may take up to 5 minutes");
+		const cJSON* message = cJSON_GetObjectItemCaseSensitive(json, "Message");
+		if (!cJSON_IsString(message) || !message->valuestring)
+			WLog_WARN(TAG, "Starting your VM. It may take up to 5 minutes");
+		else
+			WLog_WARN(TAG, "%s", message->valuestring);
 	}
 	else
 	{


### PR DESCRIPTION
In case of E_PROXY_ORCHESTRATION_LB_SESSIONHOST_DEALLOCATED print a warning with the message body or a generic fallback should that not be provided.