### PR TITLE
Add #include to declare winpr_strerror

### DIFF
--- a/winpr/libwinpr/sysinfo/cpufeatures/cpu-features.c
+++ b/winpr/libwinpr/sysinfo/cpufeatures/cpu-features.c
@@ -73,6 +73,7 @@
 #include <sys/system_properties.h>
 #include <unistd.h>
 #include <winpr/wtypes.h>
+#include <winpr/debug.h>
 
 static pthread_once_t g_once;
 static int g_inited;


### PR DESCRIPTION
Fixes failing builds with Android NDK r26 with freerdp 3.4.0. Noticed in vcpkg.
~~~
/mnt/vcpkg-ci/b/freerdp/src/3.4.0-7803785a45.clean/winpr/libwinpr/sysinfo/cpufeatures/cpu-features.c:148:38: error: call to undeclared function 'winpr_strerror'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                D("Can't open %s: %s\n", pathname, winpr_strerror(errno, ebuffer, sizeof(ebuffer)));
                                                   ^
/mnt/vcpkg-ci/b/freerdp/src/3.4.0-7803785a45.clean/winpr/libwinpr/sysinfo/cpufeatures/cpu-features.c:148:38: warning: format specifies type 'char *' but the argument has type 'int' [-Wformat]
                D("Can't open %s: %s\n", pathname, winpr_strerror(errno, ebuffer, sizeof(ebuffer)));
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                  %d
/mnt/vcpkg-ci/b/freerdp/src/3.4.0-7803785a45.clean/winpr/libwinpr/sysinfo/cpufeatures/cpu-features.c:94:11: note: expanded from macro 'D'
                        printf(__VA_ARGS__);       \
                               ^~~~~~~~~~~
~~~