### PR TITLE
[core,smartcard] allow userhint to match UPN

### DIFF
--- a/libfreerdp/core/smartcardlogon.c
+++ b/libfreerdp/core/smartcardlogon.c
@@ -222,11 +222,14 @@ static BOOL set_info_certificate(SmartcardCertInfo* cert, BYTE* certBytes, DWORD
 		return FALSE;
 	}
 
-	if (userFilter && cert->userHint && strcmp(cert->userHint, userFilter) != 0)
+	if (userFilter && (!cert->upn || (strcmp(cert->upn, userFilter) != 0)))
 	{
-		WLog_DBG(TAG, "discarding non matching cert by user %s@%s", cert->userHint,
-		         cert->domainHint);
-		return FALSE;
+		if (cert->userHint && strcmp(cert->userHint, userFilter) != 0)
+		{
+			WLog_DBG(TAG, "discarding non matching cert by user %s@%s", cert->userHint,
+			         cert->domainHint);
+			return FALSE;
+		}
 	}
 
 	if (domainFilter && cert->domainHint && strcmp(cert->domainHint, domainFilter) != 0)


### PR DESCRIPTION
the username might match the UPN of the smartcard certificate. If not fall back to compare to userHint