### PR TITLE
[core,settings] add missing autoreconnect option

### DIFF
--- a/include/freerdp/settings_types_private.h
+++ b/include/freerdp/settings_types_private.h
@@ -213,7 +213,8 @@ struct rdp_settings
 	SETTINGS_DEPRECATED(ALIGN64 ARC_CS_PRIVATE_PACKET* ClientAutoReconnectCookie); /* 834 */
 	SETTINGS_DEPRECATED(ALIGN64 ARC_SC_PRIVATE_PACKET* ServerAutoReconnectCookie); /* 835 */
 	SETTINGS_DEPRECATED(ALIGN64 BOOL PrintReconnectCookie);                        /* 836 */
-	UINT64 padding0896[896 - 837];                                                 /* 837 */
+	SETTINGS_DEPRECATED(ALIGN64 BOOL AutoReconnectionPacketSupported);             /* 837 */
+	UINT64 padding0896[896 - 838];                                                 /* 838 */
 
 	/* Client Info (Time Zone) */
 	SETTINGS_DEPRECATED(ALIGN64 TIME_ZONE_INFORMATION* ClientTimeZone); /* 896 */

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -105,6 +105,9 @@ BOOL freerdp_settings_get_bool(const rdpSettings* settings, FreeRDP_Settings_Key
 		case FreeRDP_AutoReconnectionEnabled:
 			return settings->AutoReconnectionEnabled;
 
+		case FreeRDP_AutoReconnectionPacketSupported:
+			return settings->AutoReconnectionPacketSupported;
+
 		case FreeRDP_BitmapCacheEnabled:
 			return settings->BitmapCacheEnabled;
 
@@ -713,6 +716,10 @@ BOOL freerdp_settings_set_bool(rdpSettings* settings, FreeRDP_Settings_Keys_Bool
 
 		case FreeRDP_AutoReconnectionEnabled:
 			settings->AutoReconnectionEnabled = cnv.c;
+			break;
+
+		case FreeRDP_AutoReconnectionPacketSupported:
+			settings->AutoReconnectionPacketSupported = cnv.c;
 			break;
 
 		case FreeRDP_BitmapCacheEnabled:

--- a/libfreerdp/common/settings_str.h
+++ b/libfreerdp/common/settings_str.h
@@ -50,6 +50,8 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_AutoLogonEnabled, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_AutoLogonEnabled" },
 	{ FreeRDP_AutoReconnectionEnabled, FREERDP_SETTINGS_TYPE_BOOL,
 	  "FreeRDP_AutoReconnectionEnabled" },
+	{ FreeRDP_AutoReconnectionPacketSupported, FREERDP_SETTINGS_TYPE_BOOL,
+	  "FreeRDP_AutoReconnectionPacketSupported" },
 	{ FreeRDP_BitmapCacheEnabled, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_BitmapCacheEnabled" },
 	{ FreeRDP_BitmapCachePersistEnabled, FREERDP_SETTINGS_TYPE_BOOL,
 	  "FreeRDP_BitmapCachePersistEnabled" },

--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -168,7 +168,7 @@ static BOOL rdp_apply_general_capability_set(rdpSettings* settings, const rdpSet
 
 	settings->NoBitmapCompressionHeader = src->NoBitmapCompressionHeader;
 	settings->LongCredentialsSupported = src->LongCredentialsSupported;
-	settings->AutoReconnectionEnabled = src->AutoReconnectionEnabled;
+	settings->AutoReconnectionPacketSupported = src->AutoReconnectionPacketSupported;
 	if (!src->FastPathOutput)
 		settings->FastPathOutput = FALSE;
 
@@ -223,7 +223,8 @@ static BOOL rdp_read_general_capability_set(wStream* s, rdpSettings* settings)
 	settings->NoBitmapCompressionHeader = (extraFlags & NO_BITMAP_COMPRESSION_HDR) ? TRUE : FALSE;
 	settings->LongCredentialsSupported = (extraFlags & LONG_CREDENTIALS_SUPPORTED) ? TRUE : FALSE;
 
-	settings->AutoReconnectionEnabled = (extraFlags & AUTORECONNECT_SUPPORTED) ? TRUE : FALSE;
+	settings->AutoReconnectionPacketSupported =
+	    (extraFlags & AUTORECONNECT_SUPPORTED) ? TRUE : FALSE;
 	settings->FastPathOutput = (extraFlags & FASTPATH_OUTPUT_SUPPORTED) ? TRUE : FALSE;
 	settings->SaltedChecksum = (extraFlags & ENC_SALTED_CHECKSUM) ? TRUE : FALSE;
 	settings->RefreshRect = refreshRectSupport;
@@ -252,7 +253,7 @@ static BOOL rdp_write_general_capability_set(wStream* s, const rdpSettings* sett
 	if (settings->NoBitmapCompressionHeader)
 		extraFlags |= NO_BITMAP_COMPRESSION_HDR;
 
-	if (settings->AutoReconnectionEnabled)
+	if (settings->AutoReconnectionPacketSupported)
 		extraFlags |= AUTORECONNECT_SUPPORTED;
 
 	if (settings->FastPathOutput)

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -19,6 +19,7 @@ static const size_t bool_list_indices[] = {
 	FreeRDP_AutoDenyCertificate,
 	FreeRDP_AutoLogonEnabled,
 	FreeRDP_AutoReconnectionEnabled,
+	FreeRDP_AutoReconnectionPacketSupported,
 	FreeRDP_BitmapCacheEnabled,
 	FreeRDP_BitmapCachePersistEnabled,
 	FreeRDP_BitmapCacheV3Enabled,


### PR DESCRIPTION
Discovered as part of #10059 
Split settings, there was a double use for AutoReconnectEnabled. AutoReconnectEnabled is a setting responsible for client side autoreconnection.
AutoReconnectPacketSupported is a flag set by the server to announce support for AutoReconnectPacket allowing fast reconnect.
