### PR TITLE
location: Increase buffer size for printing channel info

### DIFF
--- a/channels/location/client/location_main.c
+++ b/channels/location/client/location_main.c
@@ -182,8 +182,8 @@ static UINT location_on_data_received(IWTSVirtualChannelCallback* pChannelCallba
 					break;
 			}
 
-			char cbuffer[32] = { 0 };
-			char sbuffer[32] = { 0 };
+			char cbuffer[64] = { 0 };
+			char sbuffer[64] = { 0 };
 			WLog_Print(plugin->baseDynPlugin.log, WLOG_DEBUG,
 			           "Server version %s, client version %s",
 			           location_version_str(callback->serverVersion, sbuffer, sizeof(sbuffer)),


### PR DESCRIPTION
The current buffer size of 32 bytes was too small to hold the version info string which resulted in a non-null terminated buffer (`_snprintf` does not null-terminate the buffer if it is too small) being printed.
