### PR TITLE
[codec,progressive] revert 4e24b966c86fdf494a782f0dfcfc43a057a2ea60

### DIFF
--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -2442,7 +2442,6 @@ INT32 progressive_decompress(PROGRESSIVE_CONTEXT* progressive, const BYTE* pSrcD
 	}
 
 	region16_uninit(&clippingRects);
-	surface->numUpdatedTiles = 0;
 fail:
 	return rc;
 }


### PR DESCRIPTION
do not reset progressive surface numUpdatedTiles after progressive_decompress pass. The updates might accumulate until the frameId changes, only then reset.

fixes the long standing graphical glitches when moving windows.