### PR TITLE
ci: update oss fuzz toolchain CMake

### DIFF
--- a/ci/cmake-preloads/config-oss-fuzz.cmake
+++ b/ci/cmake-preloads/config-oss-fuzz.cmake
@@ -14,6 +14,8 @@ set (WITH_AAD OFF CACHE BOOL "oss fuzz")
 set (WITH_FFMPEG OFF CACHE BOOL "oss fuzz")
 set (WITH_SWSCALE OFF CACHE BOOL "oss fuzz")
 set (WITH_LIBSYSTEMD OFF CACHE BOOL "oss fuzz")
+set (WITH_UNICODE_BUILTIN ON CACHE BOOL "oss fuzz")
+set (WITH_OPUS OFF CACHE BOOL "oss fuzz")
 
 set (BUILD_SHARED_LIBS OFF CACHE BOOL "oss fuzz")
 


### PR DESCRIPTION
Follows up commit c24011b8cba2 ("[oss-fuzz] add cmake toolchain file").

Needed for https://github.com/google/oss-fuzz/pull/11813
