### PR TITLE
shadow: mention in "help" output that auth defaults to "required"

### DIFF
--- a/server/shadow/shadow.c
+++ b/server/shadow/shadow.c
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
 		  "maximum connections allowed to server, 0 to deactivate" },
 		{ "rect", COMMAND_LINE_VALUE_REQUIRED, "<x,y,w,h>", NULL, NULL, -1, NULL,
 		  "Select rectangle within monitor to share" },
-		{ "auth", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
+		{ "auth", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
 		  "Clients must authenticate" },
 		{ "remote-guard", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
 		  "Remote credential guard" },


### PR DESCRIPTION
`freerdp-shadow-cli` requires authorization by default, however the help output was saying:

    -auth (default:off)
        Clients must authenticate

Fix that.

-----------------------

Alternatively, since FreeRDP is very peculiar in how it handles command line options, it's possible that the phrase `-auth (default:off)` was referring to the inverse logic of `-auth` disabling authorization and `off` inverting the disabling, and then the complete `-auth (default:off)` was presumed to imply "enabled". Tell me if that's so, in which case that still needs to be changed because that's very confusing, especially for anyone coming from other cmdline utilities background.
