### PR TITLE
[core,redirection] fix length of redirection strings

### DIFF
--- a/ci/cmake-preloads/config-oss-fuzz.cmake
+++ b/ci/cmake-preloads/config-oss-fuzz.cmake
@@ -16,6 +16,8 @@ set (WITH_SWSCALE OFF CACHE BOOL "oss fuzz")
 set (WITH_LIBSYSTEMD OFF CACHE BOOL "oss fuzz")
 set (WITH_UNICODE_BUILTIN ON CACHE BOOL "oss fuzz")
 set (WITH_OPUS OFF CACHE BOOL "oss fuzz")
+set (WITH_CUPS OFF CACHE BOOL "oss fuzz")
+set (CHANNEL_URBDRC OFF CACHE BOOL "oss fuzz")
 
 set (BUILD_SHARED_LIBS OFF CACHE BOOL "oss fuzz")
 

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -797,9 +797,11 @@ static INLINE BOOL update_write_4byte_unsigned(wStream* s, UINT32 value)
 
 	return TRUE;
 }
+
 static INLINE BOOL update_read_delta(wStream* s, INT32* value)
 {
 	BYTE byte = 0;
+	UINT32 uvalue = 0;
 
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, 1))
 		return FALSE;
@@ -807,9 +809,9 @@ static INLINE BOOL update_read_delta(wStream* s, INT32* value)
 	Stream_Read_UINT8(s, byte);
 
 	if (byte & 0x40)
-		*value = (byte | ~0x3F);
+		uvalue = (byte | ~0x3F);
 	else
-		*value = (byte & 0x3F);
+		uvalue = (byte & 0x3F);
 
 	if (byte & 0x80)
 	{
@@ -817,8 +819,9 @@ static INLINE BOOL update_read_delta(wStream* s, INT32* value)
 			return FALSE;
 
 		Stream_Read_UINT8(s, byte);
-		*value = (*value << 8) | byte;
+		uvalue = (uvalue << 8) | byte;
 	}
+	*value = (INT32)uvalue;
 
 	return TRUE;
 }

--- a/libfreerdp/core/redirection.c
+++ b/libfreerdp/core/redirection.c
@@ -243,7 +243,7 @@ static BOOL rdp_redirection_read_base64_wchar(UINT32 flag, wStream* s, UINT32* p
 	const WCHAR* wchar = (const WCHAR*)ptr;
 
 	size_t utf8_len = 0;
-	char* utf8 = ConvertWCharNToUtf8Alloc(wchar, *pLength, &utf8_len);
+	char* utf8 = ConvertWCharNToUtf8Alloc(wchar, *pLength / sizeof(WCHAR), &utf8_len);
 	if (!utf8)
 		goto fail;
 

--- a/libfreerdp/core/test/CMakeLists.txt
+++ b/libfreerdp/core/test/CMakeLists.txt
@@ -10,7 +10,8 @@ set(${MODULE_PREFIX}_TESTS
 	TestSettings.c)
 
 set(FUZZERS
-    TestFuzzFastpath.c
+	TestFuzzCoreClient.c
+	TestFuzzCoreServer.c
     TestFuzzCryptoCertificateDataSetPEM.c
 )
 
@@ -35,7 +36,7 @@ add_definitions(-DTESTING_SRC_DIRECTORY="${PROJECT_SOURCE_DIR}")
 target_link_libraries(${MODULE_NAME} freerdp winpr freerdp-client)
 
 include (AddFuzzerTest)
-add_fuzzer_test("${FUZZERS}" "freerdp winpr")
+add_fuzzer_test("${FUZZERS}" "freerdp-client freerdp winpr")
 
 set_target_properties(${MODULE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${TESTING_OUTPUT_DIRECTORY}")
 

--- a/libfreerdp/core/test/TestFuzzCoreServer.c
+++ b/libfreerdp/core/test/TestFuzzCoreServer.c
@@ -1,0 +1,108 @@
+#include <freerdp/peer.h>
+
+#include "../fastpath.h"
+#include "../surface.h"
+#include "../window.h"
+#include "../info.h"
+#include "../multitransport.h"
+
+static BOOL test_server(const uint8_t* Data, size_t Size)
+{
+	freerdp_peer* client = calloc(1, sizeof(freerdp_peer));
+	if (!client)
+		goto fail;
+	client->ContextSize = sizeof(rdpContext);
+	if (!freerdp_peer_context_new(client))
+		goto fail;
+
+	WINPR_ASSERT(client->context);
+	rdpRdp* rdp = client->context->rdp;
+	WINPR_ASSERT(rdp);
+
+	wStream sbuffer = { 0 };
+	wStream* s = Stream_StaticConstInit(&sbuffer, Data, Size);
+
+	{
+		rdpFastPath* fastpath = rdp->fastpath;
+		WINPR_ASSERT(fastpath);
+
+		fastpath_recv_updates(fastpath, s);
+		fastpath_recv_inputs(fastpath, s);
+
+		UINT16 length = 0;
+		fastpath_read_header_rdp(fastpath, s, &length);
+		fastpath_decrypt(fastpath, s, &length);
+	}
+
+	{
+		UINT16 length = 0;
+		UINT16 flags = 0;
+		UINT16 channelId = 0;
+		UINT16 tpktLength = 0;
+		UINT16 remainingLength = 0;
+		UINT16 type = 0;
+		UINT16 securityFlags = 0;
+		UINT32 share_id = 0;
+		BYTE compressed_type = 0;
+		BYTE btype = 0;
+		UINT16 compressed_len = 0;
+		rdp_read_security_header(rdp, s, &flags, &length);
+		rdp_read_header(rdp, s, &length, &channelId);
+		rdp_read_share_control_header(rdp, s, &tpktLength, &remainingLength, &type, &channelId);
+		rdp_read_share_data_header(rdp, s, &length, &btype, &share_id, &compressed_type,
+		                           &compressed_len);
+		rdp_recv_message_channel_pdu(rdp, s, securityFlags);
+	}
+	{
+		rdpUpdate* update = rdp->update;
+		UINT16 channelId = 0;
+		UINT16 length = 0;
+		UINT16 pduSource = 0;
+		UINT16 pduLength = 0;
+		update_recv_order(update, s);
+		update_recv_altsec_window_order(update, s);
+		update_recv_play_sound(update, s);
+		update_recv_pointer(update, s);
+		update_recv_surfcmds(update, s);
+		rdp_recv_get_active_header(rdp, s, &channelId, &length);
+		rdp_recv_demand_active(rdp, s, pduSource, length);
+		rdp_recv_confirm_active(rdp, s, pduLength);
+	}
+	{
+		rdpNla* nla = nla_new(rdp->context, rdp->transport);
+		nla_recv_pdu(nla, s);
+		nla_free(nla);
+	}
+	{
+		rdp_recv_heartbeat_packet(rdp, s);
+		rdp->state = CONNECTION_STATE_SECURE_SETTINGS_EXCHANGE;
+		rdp_recv_client_info(rdp, s);
+		rdp_recv_save_session_info(rdp, s);
+	}
+	{
+		freerdp_is_valid_mcs_create_request(Data, Size);
+		freerdp_is_valid_mcs_create_response(Data, Size);
+	}
+	{
+		multitransport_recv_request(rdp->multitransport, s);
+		multitransport_recv_response(rdp->multitransport, s);
+	}
+	{
+		autodetect_recv_request_packet(rdp->autodetect, RDP_TRANSPORT_TCP, s);
+		autodetect_recv_response_packet(rdp->autodetect, RDP_TRANSPORT_TCP, s);
+	}
+	{
+		rdp_recv_deactivate_all(rdp, s);
+		rdp_recv_server_synchronize_pdu(rdp, s);
+		rdp_recv_client_synchronize_pdu(rdp, s);
+	}
+fail:
+	freerdp_peer_context_free(client);
+	free(client);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+	test_server(Data, Size);
+	return 0;
+}

--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -2031,7 +2031,9 @@ static BOOL update_send_cache_brush(rdpContext* context, const CACHE_BRUSH_ORDER
 		return FALSE;
 
 	const size_t em = Stream_GetPosition(s);
-	WINPR_ASSERT(em > bm + 13);
+	if (em <= bm + 13)
+		return FALSE;
+
 	const size_t orderLength = (em - bm) - 13;
 	WINPR_ASSERT(orderLength <= UINT16_MAX);
 	Stream_SetPosition(s, bm);


### PR DESCRIPTION
length field is in bytes, when converting from UCS-2 use size in WCHAR