### PR TITLE
uwac: fix window handling/viewport

### DIFF
--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -86,6 +86,8 @@ static void xdg_handle_toplevel_configure(void* data, struct xdg_toplevel* xdg_t
 {
 	UwacWindow* window = (UwacWindow*)data;
 	int scale = window->display->actual_scale;
+	int32_t actual_width = width;
+	int32_t actual_height = height;
 	width *= scale;
 	height *= scale;
 	UwacConfigureEvent* event = NULL;
@@ -156,10 +158,9 @@ static void xdg_handle_toplevel_configure(void* data, struct xdg_toplevel* xdg_t
 		if (window->viewport)
 		{
 			wp_viewport_set_source(window->viewport, wl_fixed_from_int(0), wl_fixed_from_int(0),
-			                       wl_fixed_from_int(window->width * scale),
-			                       wl_fixed_from_int(window->height * scale));
-			wp_viewport_set_destination(window->viewport, window->width * scale,
-			                            window->height * scale);
+			                       wl_fixed_from_int(actual_width),
+			                       wl_fixed_from_int(actual_height));
+			wp_viewport_set_destination(window->viewport, actual_width, actual_height);
 		}
 	}
 	else


### PR DESCRIPTION
Parameters passed to wp_viewport_set_destination was scaled instead of the actual window size. In fact I noticed this problem when I was testing the initial change (c29ba7985) but was not sure about how to fix this and moreover, the tiling manager which I am using (sway) is immediatelly tiling the window and all seems fine in day-to-day use with tiled window.
The problem was only visible when the window was changed to floating: the window content was scaled properly but the viewport was twice as big (thus a whole window). What is worse it seems that the scaling was done multiple times making a huge window size in some circumstances.

Now in new sway version 1.9 authors added an assert which prevents from having a window which overlaps different renderers and this also trigger this problem in FreeRDP, because when starting the window size was too big.
This was leading to:
wp_viewport@31: error 2: source rectangle out of buffer bounds or even sway crash

This commit is fixing this problem by using a proper window size values (initially passed to a function and saved to additional variables before scaling calculation).
Window size is now correct even when changed to a floating window.