### PR TITLE
Fix zeroing protocolVersion capability

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -166,6 +166,7 @@ static BOOL rdp_apply_general_capability_set(rdpSettings* settings, const rdpSet
 		settings->OsMinorType = src->OsMinorType;
 	}
 
+	settings->CapsProtocolVersion = src->CapsProtocolVersion;
 	settings->NoBitmapCompressionHeader = src->NoBitmapCompressionHeader;
 	settings->LongCredentialsSupported = src->LongCredentialsSupported;
 	settings->AutoReconnectionPacketSupported = src->AutoReconnectionPacketSupported;


### PR DESCRIPTION
Closes: #10059

Issue introduced here:
https://github.com/FreeRDP/FreeRDP/commit/7cef0cb8d#diff-23782638b8d86b1e888e5cc37a2b4789ddc107c5321803ab4bce2b99563c7aebL253

In 2.x `protocolVersion` capability send to server was a constant value `CAPS_PROTOCOL_VERSION = 0x0200`.
Changes in 3.0.0 intended to use server protocol version, but instead a literal `0` was send. This lead to closing RDP connection from server side in some server implementations.