### PR TITLE
[core,capabilities] abort on invalid protocolVersion

### DIFF
--- a/include/freerdp/settings_types.h
+++ b/include/freerdp/settings_types.h
@@ -239,6 +239,9 @@ extern "C"
 #define MSTSC_COOKIE_MAX_LENGTH 9
 #define DEFAULT_COOKIE_MAX_LENGTH 0xFF
 
+	/* General capability set */
+#define TS_CAPS_PROTOCOLVERSION 0x200
+
 /* Order Support */
 #define NEG_DSTBLT_INDEX 0x00
 #define NEG_PATBLT_INDEX 0x01

--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -211,6 +211,14 @@ static BOOL rdp_read_general_capability_set(wStream* s, rdpSettings* settings)
 	Stream_Read_UINT16(s, settings->OsMinorType); /* osMinorType (2 bytes) */
 
 	Stream_Read_UINT16(s, settings->CapsProtocolVersion); /* protocolVersion (2 bytes) */
+	if (settings->CapsProtocolVersion != TS_CAPS_PROTOCOLVERSION)
+	{
+		WLog_ERR(TAG,
+		         "TS_GENERAL_CAPABILITYSET::protocolVersion(0x%04" PRIx16
+		         ") != TS_CAPS_PROTOCOLVERSION(0x%04" PRIx32 ")",
+		         settings->CapsProtocolVersion, TS_CAPS_PROTOCOLVERSION);
+		return FALSE;
+	}
 	Stream_Seek_UINT16(s);                                /* pad2OctetsA (2 bytes) */
 	Stream_Read_UINT16(
 	    s, settings->CapsGeneralCompressionTypes); /* generalCompressionTypes (2 bytes) */
@@ -269,6 +277,14 @@ static BOOL rdp_write_general_capability_set(wStream* s, const rdpSettings* sett
 		         "OsMajorType=%08" PRIx32 ", OsMinorType=%08" PRIx32
 		         " they need to be smaller %04" PRIx16,
 		         settings->OsMajorType, settings->OsMinorType, UINT16_MAX);
+		return FALSE;
+	}
+	if (settings->CapsProtocolVersion != TS_CAPS_PROTOCOLVERSION)
+	{
+		WLog_ERR(TAG,
+		         "TS_GENERAL_CAPABILITYSET::protocolVersion(0x%04" PRIx16
+		         ") != TS_CAPS_PROTOCOLVERSION(0x%04" PRIx32 ")",
+		         settings->CapsProtocolVersion, TS_CAPS_PROTOCOLVERSION);
 		return FALSE;
 	}
 	Stream_Write_UINT16(s, (UINT16)settings->OsMajorType); /* osMajorType (2 bytes) */

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -361,6 +361,10 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	if (!settings)
 		return NULL;
 
+	if (!freerdp_settings_set_uint16(settings, FreeRDP_CapsProtocolVersion,
+	                                 TS_CAPS_PROTOCOLVERSION))
+		goto out_fail;
+
 	if (!freerdp_settings_set_uint32(settings, FreeRDP_ClipboardFeatureMask,
 	                                 CLIPRDR_FLAG_DEFAULT_MASK))
 		goto out_fail;


### PR DESCRIPTION
TS_GENERAL_CAPABILITYSET::protocolVersion must be TS_CAPS_PROTOCOLVERSION(0x200) see [MS-RDPBCGR] 2.2.7.1.1 General Capability Set (TS_GENERAL_CAPABILITYSET)
checks for stuff detected in #10130