### PR TITLE
[client,sdl] handle dialog on key up event

### DIFF
--- a/client/SDL/dialogs/sdl_connection_dialog.cpp
+++ b/client/SDL/dialogs/sdl_connection_dialog.cpp
@@ -49,7 +49,11 @@ SDLConnectionDialog::~SDLConnectionDialog()
 
 bool SDLConnectionDialog::visible() const
 {
-	return _window && _renderer;
+	if (!_window || !_renderer)
+		return false;
+
+	auto flags = SDL_GetWindowFlags(_window);
+	return (flags & (SDL_WINDOW_HIDDEN | SDL_WINDOW_MINIMIZED)) == 0;
 }
 
 bool SDLConnectionDialog::setTitle(const char* fmt, ...)

--- a/client/SDL/dialogs/sdl_input_widgets.cpp
+++ b/client/SDL/dialogs/sdl_input_widgets.cpp
@@ -164,10 +164,7 @@ int SdlInputWidgetList::run(std::vector<std::string>& result)
 				{
 					auto it = std::remove(pressed.begin(), pressed.end(), event.key.keysym.sym);
 					pressed.erase(it, pressed.end());
-				}
-				break;
-				case SDL_KEYDOWN:
-					pressed.push_back(event.key.keysym.sym);
+
 					switch (event.key.keysym.sym)
 					{
 						case SDLK_BACKSPACE:
@@ -210,6 +207,10 @@ int SdlInputWidgetList::run(std::vector<std::string>& result)
 						default:
 							break;
 					}
+				}
+				break;
+				case SDL_KEYDOWN:
+					pressed.push_back(event.key.keysym.sym);
 					break;
 				case SDL_TEXTINPUT:
 				{


### PR DESCRIPTION
Handle keyboard input dialog status change on key up event. If handled on key down event the dialog closes and the key up event is handled on the next SDL event queue (usually connection dialog cancel) Fixes #10133