### PR TITLE
[client,mac] Enable secure restorable state

### DIFF
--- a/client/Mac/cli/AppDelegate.m
+++ b/client/Mac/cli/AppDelegate.m
@@ -115,6 +115,11 @@ void mac_set_view_size(rdpContext *context, MRDPView *view);
 	return YES;
 }
 
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app
+{
+	return YES;
+}
+
 - (int)ParseCommandLineArguments
 {
 	int i;


### PR DESCRIPTION
Opt-in to using `NSSecureCoding` for restorable state. This is an optional feature that prevents a process-injection vulnerability. Since FreeRDP doesn't customize the saved/restored state, there is nothing more to do.

This prevents the client from printing a warning at runtime.