### PR TITLE
Fix incompatible pointer type issues

### DIFF
--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -85,7 +85,7 @@ static BOOL rdp_read_info_null_string(const char* what, UINT32 flags, wStream* s
 
 	if (cbLen > 0)
 	{
-		const WCHAR* domain = Stream_Pointer(s);
+		const WCHAR* domain = (WCHAR*)Stream_Pointer(s);
 
 		if (isNullTerminated && (max > 0))
 			max -= nullSize;

--- a/libfreerdp/core/redirection.c
+++ b/libfreerdp/core/redirection.c
@@ -86,7 +86,7 @@ static void redirection_free_data(BYTE** str, UINT32* length)
 	*str = NULL;
 }
 
-static BOOL redirection_copy_data(char** dst, UINT32* plen, const char* str, UINT32 len)
+static BOOL redirection_copy_data(BYTE** dst, UINT32* plen, const BYTE* str, UINT32 len)
 {
 	redirection_free_data(dst, plen);
 

--- a/libfreerdp/core/redirection.c
+++ b/libfreerdp/core/redirection.c
@@ -109,7 +109,7 @@ static BOOL freerdp_settings_set_pointer_len(rdpSettings* settings, size_t id, c
 	switch (id)
 	{
 		case FreeRDP_TargetNetAddress:
-			pdata = &settings->TargetNetAddress;
+			pdata = (BYTE**)&settings->TargetNetAddress;
 			plen = &settings->TargetNetAddressCount;
 			break;
 		case FreeRDP_LoadBalanceInfo:


### PR DESCRIPTION
FreeRDP 2.11.7 doesn't compile in Fedora 40 due to use of `-Werror=incompatible-pointer-types`. This PR fixes it.