### PR TITLE
Allow PAKID_CORE_CLIENTID_CONFIRM in RDPDR_CHANNEL_STATE_NAME_REQUEST

### DIFF
--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -170,6 +170,11 @@ BOOL rdpdr_state_advance(rdpdrPlugin* rdpdr, enum RDPDR_CHANNEL_STATE next)
 		WLog_Print(rdpdr->log, WLOG_DEBUG, "[RDPDR] transition from %s to %s",
 		           rdpdr_state_str(rdpdr->state), rdpdr_state_str(next));
 	rdpdr->state = next;
+
+	if (next == RDPDR_CHANNEL_STATE_READY)
+	{
+		rdpdr->hasBeenReady = TRUE;
+	}
 	return TRUE;
 }
 
@@ -1596,6 +1601,7 @@ static UINT rdpdr_process_init(rdpdrPlugin* rdpdr)
 	WINPR_ASSERT(rdpdr->devman);
 
 	rdpdr->userLoggedOn = FALSE; /* reset possible received state */
+	rdpdr->hasBeenReady = FALSE; /* likewise */
 	if (!device_foreach(rdpdr, TRUE, device_init, rdpdr->log))
 		return ERROR_INTERNAL_ERROR;
 	return CHANNEL_RC_OK;
@@ -1673,9 +1679,10 @@ static BOOL rdpdr_check_channel_state(rdpdrPlugin* rdpdr, UINT16 packetid)
 			                         RDPDR_CHANNEL_STATE_CLIENT_CAPS, PAKID_CORE_CLIENTID_CONFIRM,
 			                         PAKID_CORE_USER_LOGGEDON);
 		case PAKID_CORE_CLIENTID_CONFIRM:
-			return rdpdr_state_check(rdpdr, packetid, RDPDR_CHANNEL_STATE_CLIENTID_CONFIRM, 3,
+			return rdpdr_state_check(rdpdr, packetid, RDPDR_CHANNEL_STATE_CLIENTID_CONFIRM, 4,
 			                         RDPDR_CHANNEL_STATE_CLIENT_CAPS, RDPDR_CHANNEL_STATE_READY,
-			                         RDPDR_CHANNEL_STATE_USER_LOGGEDON);
+			                         RDPDR_CHANNEL_STATE_USER_LOGGEDON,
+			                         RDPDR_CHANNEL_STATE_NAME_REQUEST);
 		case PAKID_CORE_USER_LOGGEDON:
 			if (!rdpdr_check_extended_pdu_flag(rdpdr, RDPDR_USER_LOGGEDON_PDU))
 				return FALSE;

--- a/channels/rdpdr/client/rdpdr_main.h
+++ b/channels/rdpdr/client/rdpdr_main.h
@@ -113,6 +113,7 @@ typedef struct
 	wStreamPool* pool;
 	wLog* log;
 	BOOL async;
+	BOOL hasBeenReady;
 } rdpdrPlugin;
 
 BOOL rdpdr_state_advance(rdpdrPlugin* rdpdr, enum RDPDR_CHANNEL_STATE next);


### PR DESCRIPTION
Occasionally servers can send this sequence which breaks the channel state machine leading to all smartcard operations failing. This patch modifies the state transitions to tolerate the observed sequence of operations.

In my testing, this fixes the issue I mentioned in https://github.com/FreeRDP/FreeRDP/issues/9506#issuecomment-2112745653 - but it's maybe not the best way to fix the problem. For example it's possible that adding RDPDR_CHANNEL_STATE_NAME_REQUEST to the allowable states in PAKID_CORE_CLIENTID_CONFIRM breaks something else I didn't see in my testing - I'm not familiar enough with this codebase or protocol to say for sure. So consider this PR a suggestion and a chance for discussion rather than a perfect solution :)