### PR TITLE
[core,caps] Allow invalid TS_GENERAL_CAPABILITYSET::protocolVersion

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -217,7 +217,15 @@ static BOOL rdp_read_general_capability_set(wStream* s, rdpSettings* settings)
 		         "TS_GENERAL_CAPABILITYSET::protocolVersion(0x%04" PRIx16
 		         ") != TS_CAPS_PROTOCOLVERSION(0x%04" PRIx32 ")",
 		         settings->CapsProtocolVersion, TS_CAPS_PROTOCOLVERSION);
-		return FALSE;
+		if (settings->CapsProtocolVersion == 0x0000)
+		{
+			WLog_WARN(TAG,
+			          "TS_GENERAL_CAPABILITYSET::protocolVersion(0x%04" PRIx16
+			          " assuming old FreeRDP, ignoring protocol violation.",
+			          settings->CapsProtocolVersion);
+		}
+		else
+			return FALSE;
 	}
 	Stream_Seek_UINT16(s);                                /* pad2OctetsA (2 bytes) */
 	Stream_Read_UINT16(


### PR DESCRIPTION
some FreeRDP versions did send an invalid value of 0x0000 instead of the required 0x200. Log this kind of violation but continue.