### PR TITLE
[core,streamdump] use dynamic logger

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -2077,7 +2077,6 @@ static UINT rdpgfx_recv_pdu(GENERIC_CHANNEL_CALLBACK* callback, wStream* s)
  */
 static UINT rdpgfx_on_data_received(IWTSVirtualChannelCallback* pChannelCallback, wStream* data)
 {
-	wStream* s = NULL;
 	int status = 0;
 	UINT32 DstSize = 0;
 	BYTE* pDstData = NULL;
@@ -2097,11 +2096,13 @@ static UINT rdpgfx_on_data_received(IWTSVirtualChannelCallback* pChannelCallback
 		return ERROR_INTERNAL_ERROR;
 	}
 
-	s = Stream_New(pDstData, DstSize);
+	wStream sbuffer = { 0 };
+	wStream* s = Stream_StaticConstInit(&sbuffer, pDstData, DstSize);
 
 	if (!s)
 	{
 		WLog_Print(gfx->log, WLOG_ERROR, "calloc failed!");
+		free(pDstData);
 		return CHANNEL_RC_NO_MEMORY;
 	}
 
@@ -2115,7 +2116,7 @@ static UINT rdpgfx_on_data_received(IWTSVirtualChannelCallback* pChannelCallback
 		}
 	}
 
-	Stream_Free(s, TRUE);
+	free(pDstData);
 	return error;
 }
 

--- a/libfreerdp/core/streamdump.c
+++ b/libfreerdp/core/streamdump.c
@@ -31,6 +31,8 @@
 
 #include "streamdump.h"
 
+#define TAG FREERDP_TAG("streamdump")
+
 struct stream_dump_context
 {
 	rdpTransportIo io;
@@ -41,6 +43,7 @@ struct stream_dump_context
 	CONNECTION_STATE state;
 	BOOL isServer;
 	BOOL nodelay;
+	wLog* log;
 };
 
 static UINT32 crc32b(const BYTE* data, size_t length)
@@ -292,7 +295,7 @@ static int stream_dump_transport_read(rdpTransport* transport, wStream* s)
 
 static BOOL stream_dump_register_write_handlers(rdpContext* context)
 {
-	rdpTransportIo dump;
+	rdpTransportIo dump = { 0 };
 	const rdpTransportIo* dfl = freerdp_get_io_callbacks(context);
 
 	if (!freerdp_settings_get_bool(context->settings, FreeRDP_TransportDump))
@@ -321,7 +324,7 @@ static int stream_dump_replay_transport_write(rdpTransport* transport, wStream* 
 	WINPR_ASSERT(s);
 
 	size = Stream_Length(s);
-	WLog_ERR("abc", "replay write %" PRIuz, size);
+	WLog_Print(ctx->dump->log, WLOG_TRACE, "replay write %" PRIuz, size);
 	// TODO: Compare with write file
 
 	return 1;
@@ -357,7 +360,7 @@ static int stream_dump_replay_transport_read(rdpTransport* transport, wStream* s
 
 	size = Stream_Length(s);
 	Stream_SetPosition(s, 0);
-	WLog_ERR("abc", "replay read %" PRIuz, size);
+	WLog_Print(ctx->dump->log, WLOG_TRACE, "replay read %" PRIuz, size);
 
 	if (slp > 0)
 	{
@@ -448,6 +451,7 @@ rdpStreamDumpContext* stream_dump_new(void)
 	rdpStreamDumpContext* dump = calloc(1, sizeof(rdpStreamDumpContext));
 	if (!dump)
 		return NULL;
+	dump->log = WLog_Get(TAG);
 
 	return dump;
 }

--- a/winpr/libwinpr/utils/wlog/Layout.c
+++ b/winpr/libwinpr/utils/wlog/Layout.c
@@ -253,7 +253,7 @@ BOOL WLog_Layout_GetMessagePrefix(wLog* log, wLogLayout* layout, wLogMessage* me
 		  &recurse }, /* log level */
 		{ ENTRY("%mi"), ENTRY("%02u"), NULL, (void*)(size_t)localTime.wMinute, NULL,
 		  &recurse }, /* minutes */
-		{ ENTRY("%ml"), ENTRY("%02u"), NULL, (void*)(size_t)localTime.wMilliseconds, NULL,
+		{ ENTRY("%ml"), ENTRY("%03u"), NULL, (void*)(size_t)localTime.wMilliseconds, NULL,
 		  &recurse },                                                   /* milliseconds */
 		{ ENTRY("%mn"), ENTRY("%s"), NULL, log->Name, NULL, &recurse }, /* module name */
 		{ ENTRY("%mo"), ENTRY("%u"), NULL, (void*)(size_t)localTime.wMonth, NULL,


### PR DESCRIPTION
* Decrease logging verbosity of streamdump
* Fix namespace of logger
* Use dynamic preallocated logger
* fix wlog format string for milliseconds ("%03u")
* small improvement for rdpgfx channel (use static stream)