### PR TITLE
X11: fix pointer/integer type mismatch

### DIFF
--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -587,7 +587,7 @@ static void wlf_client_free(freerdp* instance, rdpContext* context)
 	DeleteCriticalSection(&wlf->critical);
 }
 
-static void* uwac_event_clone(const void* val)
+static void* uwac_event_clone(void* val)
 {
 	UwacEvent* copy;
 	UwacEvent* ev = (UwacEvent*)val;

--- a/client/X11/xf_graphics.c
+++ b/client/X11/xf_graphics.c
@@ -438,7 +438,7 @@ static BOOL xf_Pointer_New(rdpContext* context, rdpPointer* pointer)
 
 #endif
 fail:
-	WLog_DBG(TAG, "%s: %ld", __func__, rc ? pointer : -1);
+	WLog_DBG(TAG, "%s: %p", __func__, rc ? pointer : NULL);
 	return rc;
 }
 


### PR DESCRIPTION
Fixed on master in 2da280b8a1748052b70b3f5a1ef0d8e932c33adc.