### PR TITLE
[core,codecs] fix API function names

### DIFF
--- a/include/freerdp/codecs.h
+++ b/include/freerdp/codecs.h
@@ -54,7 +54,7 @@ extern "C"
 
 	struct rdp_codecs
 	{
-		rdpContext* context;
+		UINT32 ThreadingFlags;
 
 		RFX_CONTEXT* rfx;
 		NSC_CONTEXT* nsc;
@@ -71,10 +71,17 @@ extern "C"
 	FREERDP_API BOOL freerdp_client_codecs_reset(rdpCodecs* codecs, UINT32 flags, UINT32 width,
 	                                             UINT32 height);
 
-	FREERDP_API void codecs_free(rdpCodecs* codecs);
+	FREERDP_API void freerdp_client_codecs_free(rdpCodecs* codecs);
+
+	WINPR_ATTR_MALLOC(freerdp_client_codecs_free, 1)
+	FREERDP_API rdpCodecs* freerdp_client_codecs_new(UINT32 TheadingFlags);
+
+	FREERDP_API WINPR_DEPRECATED_VAR("Use freerdp_client_codecs_free",
+	                                 void codecs_free(rdpCodecs* codecs));
 
 	WINPR_ATTR_MALLOC(codecs_free, 1)
-	FREERDP_API rdpCodecs* codecs_new(rdpContext* context);
+	FREERDP_API WINPR_DEPRECATED_VAR("Use freerdp_client_codecs_new",
+	                                 rdpCodecs* codecs_new(rdpContext* context));
 
 #ifdef __cplusplus
 }

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -207,8 +207,9 @@ static BOOL rdp_client_reset_codecs(rdpContext* context)
 
 	if (!freerdp_settings_get_bool(settings, FreeRDP_DeactivateClientDecoding))
 	{
-		codecs_free(context->codecs);
-		context->codecs = codecs_new(context);
+		const UINT32 flags = freerdp_settings_get_uint32(settings, FreeRDP_ThreadingFlags);
+		freerdp_client_codecs_free(context->codecs);
+		context->codecs = freerdp_client_codecs_new(flags);
 
 		if (!context->codecs)
 			return FALSE;
@@ -495,7 +496,7 @@ BOOL rdp_client_disconnect(rdpRdp* rdp)
 	if (freerdp_channels_disconnect(context->channels, context->instance) != CHANNEL_RC_OK)
 		return FALSE;
 
-	codecs_free(context->codecs);
+	freerdp_client_codecs_free(context->codecs);
 	context->codecs = NULL;
 	return TRUE;
 }

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -896,7 +896,7 @@ void freerdp_context_free(freerdp* instance)
 	freerdp_channels_free(ctx->channels);
 	ctx->channels = NULL;
 
-	codecs_free(ctx->codecs);
+	freerdp_client_codecs_free(ctx->codecs);
 	ctx->codecs = NULL;
 
 	stream_dump_free(ctx->dump);

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -1859,8 +1859,9 @@ BOOL gdi_graphics_pipeline_init_ex(rdpGdi* gdi, RdpgfxClientContext* gfx,
 	{
 		const UINT32 w = freerdp_settings_get_uint32(settings, FreeRDP_DesktopWidth);
 		const UINT32 h = freerdp_settings_get_uint32(settings, FreeRDP_DesktopHeight);
+		const UINT32 flags = freerdp_settings_get_uint32(settings, FreeRDP_ThreadingFlags);
 
-		gfx->codecs = codecs_new(context);
+		gfx->codecs = freerdp_client_codecs_new(flags);
 		if (!gfx->codecs)
 			return FALSE;
 		if (!freerdp_client_codecs_prepare(gfx->codecs, FREERDP_CODEC_ALL, w, h))
@@ -1895,7 +1896,7 @@ void gdi_graphics_pipeline_uninit(rdpGdi* gdi, RdpgfxClientContext* gfx)
 		return;
 
 	gfx->custom = NULL;
-	codecs_free(gfx->codecs);
+	freerdp_client_codecs_free(gfx->codecs);
 	gfx->codecs = NULL;
 	DeleteCriticalSection(&gfx->mux);
 	PROFILER_PRINT_HEADER


### PR DESCRIPTION
Update function names to conform to rest of header.

* deprecate codecs_new and codecs_free
* add new freerdp_client_codecs_new and freerdp_client_codecs_free