### PR TITLE
Ignore empty KDC URL when initializing client attributes

### DIFF
--- a/libfreerdp/core/credssp_auth.c
+++ b/libfreerdp/core/credssp_auth.c
@@ -205,7 +205,12 @@ static BOOL credssp_auth_client_init_cred_attributes(rdpCredsspAuth* auth)
 		ULONG buffer_size = 0;
 
 		str_size = ConvertUtf8ToWChar(auth->kerberosSettings.kdcUrl, NULL, 0);
-		if (str_size <= 0)
+		if (str_size == 0)
+		{
+			WLog_WARN(TAG, "Ignoring empty kdcUrl");
+			return TRUE;
+		}
+		if (str_size < 0)
 			return FALSE;
 		str_size++;
 


### PR DESCRIPTION
For example, on a rdp file generated on win10 the entry is present but empty, even with simple user/pass authentication.

Without this change, authentication fails as it tries to initialize the kerberos configuration with the empty URL.
