### PR TITLE
SDL2: sdl_kbd: parse keyboard config once instead of at each keypress

### DIFF
--- a/client/SDL/SDL2/sdl_kbd.cpp
+++ b/client/SDL/SDL2/sdl_kbd.cpp
@@ -555,27 +555,27 @@ BOOL sdlInput::keyboard_handle_event(const SDL_KeyboardEvent* ev)
 	const UINT32 rdp_scancode = sdl_scancode_to_rdp(ev->keysym.scancode);
 	const SDL_Keymod mods = SDL_GetModState();
 
-	if ((mods & hotkey_modmask) == hotkey_modmask)
+	if ((mods & _hotkeyModmask) == _hotkeyModmask)
 	{
 		if (ev->type == SDL_KEYDOWN)
 		{
-			if (ev->keysym.scancode == hotkey_fullscreen)
+			if (ev->keysym.scancode == _hotkeyFullscreen)
 			{
 				_sdl->update_fullscreen(!_sdl->fullscreen);
 				return TRUE;
 			}
-			if (ev->keysym.scancode == hotkey_resizable)
+			if (ev->keysym.scancode == _hotkeyResizable)
 			{
 				_sdl->update_resizeable(!_sdl->resizeable);
 				return TRUE;
 			}
 
-			if (ev->keysym.scancode == hotkey_grab)
+			if (ev->keysym.scancode == _hotkeyGrab)
 			{
 				keyboard_grab(ev->windowID, _sdl->grab_kbd ? SDL_FALSE : SDL_TRUE);
 				return TRUE;
 			}
-			if (ev->keysym.scancode == hotkey_disconnect)
+			if (ev->keysym.scancode == _hotkeyDisconnect)
 			{
 				freerdp_abort_connect_context(_sdl->context());
 				return TRUE;
@@ -622,9 +622,9 @@ BOOL sdlInput::mouse_grab(Uint32 windowID, SDL_bool enable)
 
 sdlInput::sdlInput(SdlContext* sdl) : _sdl(sdl), _lastWindowID(UINT32_MAX)
 {
-	hotkey_modmask = prefToMask();
-	hotkey_fullscreen = prefKeyValue("SDL_Fullscreen", SDL_SCANCODE_RETURN);
-	hotkey_resizable = prefKeyValue("SDL_Resizeable", SDL_SCANCODE_R);
-	hotkey_grab = prefKeyValue("SDL_Grab", SDL_SCANCODE_G);
-	hotkey_disconnect = prefKeyValue("SDL_Disconnect", SDL_SCANCODE_D);
+	_hotkeyModmask = prefToMask();
+	_hotkeyFullscreen = prefKeyValue("SDL_Fullscreen", SDL_SCANCODE_RETURN);
+	_hotkeyResizable = prefKeyValue("SDL_Resizeable", SDL_SCANCODE_R);
+	_hotkeyGrab = prefKeyValue("SDL_Grab", SDL_SCANCODE_G);
+	_hotkeyDisconnect = prefKeyValue("SDL_Disconnect", SDL_SCANCODE_D);
 }

--- a/client/SDL/SDL2/sdl_kbd.cpp
+++ b/client/SDL/SDL2/sdl_kbd.cpp
@@ -554,33 +554,28 @@ BOOL sdlInput::keyboard_handle_event(const SDL_KeyboardEvent* ev)
 	WINPR_ASSERT(ev);
 	const UINT32 rdp_scancode = sdl_scancode_to_rdp(ev->keysym.scancode);
 	const SDL_Keymod mods = SDL_GetModState();
-	const auto mask = prefToMask();
-	const auto valFullscreen = prefKeyValue("SDL_Fullscreen", SDL_SCANCODE_RETURN);
-	const auto valResizeable = prefKeyValue("SDL_Resizeable", SDL_SCANCODE_R);
-	const auto valGrab = prefKeyValue("SDL_Grab", SDL_SCANCODE_G);
-	const auto valDisconnect = prefKeyValue("SDL_Disconnect", SDL_SCANCODE_D);
 
-	if ((mods & mask) == mask)
+	if ((mods & hotkey_modmask) == hotkey_modmask)
 	{
 		if (ev->type == SDL_KEYDOWN)
 		{
-			if (ev->keysym.scancode == valFullscreen)
+			if (ev->keysym.scancode == hotkey_fullscreen)
 			{
 				_sdl->update_fullscreen(!_sdl->fullscreen);
 				return TRUE;
 			}
-			if (ev->keysym.scancode == valResizeable)
+			if (ev->keysym.scancode == hotkey_resizable)
 			{
 				_sdl->update_resizeable(!_sdl->resizeable);
 				return TRUE;
 			}
 
-			if (ev->keysym.scancode == valGrab)
+			if (ev->keysym.scancode == hotkey_grab)
 			{
 				keyboard_grab(ev->windowID, _sdl->grab_kbd ? SDL_FALSE : SDL_TRUE);
 				return TRUE;
 			}
-			if (ev->keysym.scancode == valDisconnect)
+			if (ev->keysym.scancode == hotkey_disconnect)
 			{
 				freerdp_abort_connect_context(_sdl->context());
 				return TRUE;
@@ -627,4 +622,9 @@ BOOL sdlInput::mouse_grab(Uint32 windowID, SDL_bool enable)
 
 sdlInput::sdlInput(SdlContext* sdl) : _sdl(sdl), _lastWindowID(UINT32_MAX)
 {
+	hotkey_modmask = prefToMask();
+	hotkey_fullscreen = prefKeyValue("SDL_Fullscreen", SDL_SCANCODE_RETURN);
+	hotkey_resizable = prefKeyValue("SDL_Resizeable", SDL_SCANCODE_R);
+	hotkey_grab = prefKeyValue("SDL_Grab", SDL_SCANCODE_G);
+	hotkey_disconnect = prefKeyValue("SDL_Disconnect", SDL_SCANCODE_D);
 }

--- a/client/SDL/SDL2/sdl_kbd.hpp
+++ b/client/SDL/SDL2/sdl_kbd.hpp
@@ -68,6 +68,9 @@ class sdlInput
 	std::atomic<bool> _remapInitialized = false;
 
 	// hotkey handling
-	uint32_t hotkey_modmask; // modifier keys mask
-	uint32_t hotkey_fullscreen, hotkey_resizable, hotkey_grab, hotkey_disconnect;
+	uint32_t _hotkeyModmask; // modifier keys mask
+	uint32_t _hotkeyFullscreen;
+	uint32_t _hotkeyResizable;
+	uint32_t _hotkeyGrab;
+	uint32_t _hotkeyDisconnect;
 };

--- a/client/SDL/SDL2/sdl_kbd.hpp
+++ b/client/SDL/SDL2/sdl_kbd.hpp
@@ -66,4 +66,8 @@ class sdlInput
 	Uint32 _lastWindowID;
 	std::map<uint32_t, uint32_t> _remapList;
 	std::atomic<bool> _remapInitialized = false;
+
+	// hotkey handling
+	uint32_t hotkey_modmask; // modifier keys mask
+	uint32_t hotkey_fullscreen, hotkey_resizable, hotkey_grab, hotkey_disconnect;
 };

--- a/client/SDL/SDL3/sdl_kbd.cpp
+++ b/client/SDL/SDL3/sdl_kbd.cpp
@@ -540,33 +540,28 @@ BOOL sdlInput::keyboard_handle_event(const SDL_KeyboardEvent* ev)
 	WINPR_ASSERT(ev);
 	const UINT32 rdp_scancode = sdl_scancode_to_rdp(ev->keysym.scancode);
 	const SDL_Keymod mods = SDL_GetModState();
-	const auto mask = prefToMask();
-	const auto valFullscreen = prefKeyValue("SDL_Fullscreen", SDL_SCANCODE_RETURN);
-	const auto valResizeable = prefKeyValue("SDL_Resizeable", SDL_SCANCODE_R);
-	const auto valGrab = prefKeyValue("SDL_Grab", SDL_SCANCODE_G);
-	const auto valDisconnect = prefKeyValue("SDL_Disconnect", SDL_SCANCODE_D);
 
-	if ((mods & mask) == mask)
+	if ((mods & _hotkeyModmask) == _hotkeyModmask)
 	{
 		if (ev->type == SDL_EVENT_KEY_DOWN)
 		{
-			if (ev->keysym.scancode == valFullscreen)
+			if (ev->keysym.scancode == _hotkeyFullscreen)
 			{
 				_sdl->update_fullscreen(!_sdl->fullscreen);
 				return TRUE;
 			}
-			if (ev->keysym.scancode == valResizeable)
+			if (ev->keysym.scancode == _hotkeyResizable)
 			{
 				_sdl->update_resizeable(!_sdl->resizeable);
 				return TRUE;
 			}
 
-			if (ev->keysym.scancode == valGrab)
+			if (ev->keysym.scancode == _hotkeyGrab)
 			{
 				keyboard_grab(ev->windowID, _sdl->grab_kbd ? SDL_FALSE : SDL_TRUE);
 				return TRUE;
 			}
-			if (ev->keysym.scancode == valDisconnect)
+			if (ev->keysym.scancode == _hotkeyDisconnect)
 			{
 				freerdp_abort_connect_context(_sdl->context());
 				return TRUE;
@@ -613,4 +608,9 @@ BOOL sdlInput::mouse_grab(Uint32 windowID, SDL_bool enable)
 
 sdlInput::sdlInput(SdlContext* sdl) : _sdl(sdl), _lastWindowID(UINT32_MAX)
 {
+	_hotkeyModmask = prefToMask();
+	_hotkeyFullscreen = prefKeyValue("SDL_Fullscreen", SDL_SCANCODE_RETURN);
+	_hotkeyResizable = prefKeyValue("SDL_Resizeable", SDL_SCANCODE_R);
+	_hotkeyGrab = prefKeyValue("SDL_Grab", SDL_SCANCODE_G);
+	_hotkeyDisconnect = prefKeyValue("SDL_Disconnect", SDL_SCANCODE_D);
 }

--- a/client/SDL/SDL3/sdl_kbd.hpp
+++ b/client/SDL/SDL3/sdl_kbd.hpp
@@ -66,4 +66,11 @@ class sdlInput
 	Uint32 _lastWindowID;
 	std::map<uint32_t, uint32_t> _remapList;
 	std::atomic<bool> _remapInitialized = false;
+
+	// hotkey handling
+	uint32_t _hotkeyModmask; // modifier keys mask
+	uint32_t _hotkeyFullscreen;
+	uint32_t _hotkeyResizable;
+	uint32_t _hotkeyGrab;
+	uint32_t _hotkeyDisconnect;
 };


### PR DESCRIPTION
Currently, sdl-freerdp.json file is parsed at every keypress, which is just wrong.  Instead, parse it at startup and remember the key configuration for the whole session.

The same should be done for SDL3 I guess.