### PR TITLE
Speedup

### DIFF
--- a/include/freerdp/codec/audio.h
+++ b/include/freerdp/codec/audio.h
@@ -209,7 +209,8 @@ extern "C"
 
 	FREERDP_API BOOL audio_format_read(wStream* s, AUDIO_FORMAT* format);
 	FREERDP_API BOOL audio_format_write(wStream* s, const AUDIO_FORMAT* format);
-	FREERDP_API BOOL audio_format_copy(const AUDIO_FORMAT* srcFormat, AUDIO_FORMAT* dstFormat);
+	FREERDP_API BOOL audio_format_copy(const AUDIO_FORMAT* WINPR_RESTRICT srcFormat,
+	                                   AUDIO_FORMAT* WINPR_RESTRICT dstFormat);
 	FREERDP_API BOOL audio_format_compatible(const AUDIO_FORMAT* with, const AUDIO_FORMAT* what);
 
 	FREERDP_API void audio_format_free(AUDIO_FORMAT* format);

--- a/include/freerdp/codec/color.h
+++ b/include/freerdp/codec/color.h
@@ -376,16 +376,15 @@ typedef struct gdi_palette gdiPalette;
 	FREERDP_API BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep,
 	                                    UINT32 nXDst, UINT32 nYDst, UINT32 nWidth, UINT32 nHeight,
 	                                    const BYTE* pSrcData, DWORD SrcFormat, UINT32 nSrcStep,
-	                                    UINT32 nXSrc, UINT32 nYSrc, const gdiPalette* palette,
-	                                    UINT32 flags);
+	                                    UINT32 nXSrc, UINT32 nYSrc,
+	                                    const gdiPalette* WINPR_RESTRICT palette, UINT32 flags);
 
 	/*** Same as freerdp_image_copy() but only for overlapping source and destination
 	 */
 	FREERDP_API BOOL freerdp_image_copy_overlap(
-	    BYTE* WINPR_RESTRICT pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
-	    UINT32 nWidth, UINT32 nHeight, const BYTE* WINPR_RESTRICT pSrcData, DWORD SrcFormat,
-	    UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc, const gdiPalette* WINPR_RESTRICT palette,
-	    UINT32 flags);
+	    BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst, UINT32 nWidth,
+	    UINT32 nHeight, const BYTE* pSrcData, DWORD SrcFormat, UINT32 nSrcStep, UINT32 nXSrc,
+	    UINT32 nYSrc, const gdiPalette* WINPR_RESTRICT palette, UINT32 flags);
 
 	/*** Same as freerdp_image_copy() but only for non overlapping source and destination
 	 */

--- a/include/freerdp/codec/color.h
+++ b/include/freerdp/codec/color.h
@@ -280,7 +280,8 @@ typedef struct gdi_palette gdiPalette;
 	 * @return          A buffer allocated with winpr_aligned_malloc(width * height, 16)
 	 *                  if successful, NULL otherwise.
 	 */
-	FREERDP_API BYTE* freerdp_glyph_convert(UINT32 width, UINT32 height, const BYTE* data);
+	FREERDP_API BYTE* freerdp_glyph_convert(UINT32 width, UINT32 height,
+	                                        const BYTE* WINPR_RESTRICT data);
 
 	/***
 	 *

--- a/include/freerdp/codec/dsp.h
+++ b/include/freerdp/codec/dsp.h
@@ -37,14 +37,19 @@ extern "C"
 	WINPR_ATTR_MALLOC(freerdp_dsp_context_free, 1)
 	FREERDP_API FREERDP_DSP_CONTEXT* freerdp_dsp_context_new(BOOL encoder);
 
-	FREERDP_API BOOL freerdp_dsp_supports_format(const AUDIO_FORMAT* format, BOOL encode);
-	FREERDP_API BOOL freerdp_dsp_encode(FREERDP_DSP_CONTEXT* context, const AUDIO_FORMAT* srcFormat,
-	                                    const BYTE* data, size_t length, wStream* out);
-	FREERDP_API BOOL freerdp_dsp_decode(FREERDP_DSP_CONTEXT* context, const AUDIO_FORMAT* srcFormat,
-	                                    const BYTE* data, size_t length, wStream* out);
+	FREERDP_API BOOL freerdp_dsp_supports_format(const AUDIO_FORMAT* WINPR_RESTRICT format,
+	                                             BOOL encode);
+	FREERDP_API BOOL freerdp_dsp_encode(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+	                                    const AUDIO_FORMAT* WINPR_RESTRICT srcFormat,
+	                                    const BYTE* WINPR_RESTRICT data, size_t length,
+	                                    wStream* WINPR_RESTRICT out);
+	FREERDP_API BOOL freerdp_dsp_decode(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+	                                    const AUDIO_FORMAT* WINPR_RESTRICT srcFormat,
+	                                    const BYTE* WINPR_RESTRICT data, size_t length,
+	                                    wStream* out);
 
-	FREERDP_API BOOL freerdp_dsp_context_reset(FREERDP_DSP_CONTEXT* context,
-	                                           const AUDIO_FORMAT* targetFormat,
+	FREERDP_API BOOL freerdp_dsp_context_reset(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+	                                           const AUDIO_FORMAT* WINPR_RESTRICT targetFormat,
 	                                           UINT32 FramesPerPacket);
 
 #ifdef __cplusplus

--- a/include/freerdp/codec/interleaved.h
+++ b/include/freerdp/codec/interleaved.h
@@ -33,22 +33,27 @@ extern "C"
 
 	typedef struct S_BITMAP_INTERLEAVED_CONTEXT BITMAP_INTERLEAVED_CONTEXT;
 
-	FREERDP_API BOOL interleaved_decompress(BITMAP_INTERLEAVED_CONTEXT* interleaved,
-	                                        const BYTE* pSrcData, UINT32 SrcSize, UINT32 nSrcWidth,
-	                                        UINT32 nSrcHeight, UINT32 bpp, BYTE* pDstData,
-	                                        UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst,
-	                                        UINT32 nYDst, UINT32 nDstWidth, UINT32 nDstHeight,
-	                                        const gdiPalette* palette);
+	FREERDP_API BOOL interleaved_decompress(BITMAP_INTERLEAVED_CONTEXT* WINPR_RESTRICT interleaved,
+	                                        const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
+	                                        UINT32 nSrcWidth, UINT32 nSrcHeight, UINT32 bpp,
+	                                        BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat,
+	                                        UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
+	                                        UINT32 nDstWidth, UINT32 nDstHeight,
+	                                        const gdiPalette* WINPR_RESTRICT palette);
 
-	FREERDP_API BOOL interleaved_compress(BITMAP_INTERLEAVED_CONTEXT* interleaved, BYTE* pDstData,
-	                                      UINT32* pDstSize, UINT32 nWidth, UINT32 nHeight,
-	                                      const BYTE* pSrcData, UINT32 SrcFormat, UINT32 nSrcStep,
-	                                      UINT32 nXSrc, UINT32 nYSrc, const gdiPalette* palette,
+	FREERDP_API BOOL interleaved_compress(BITMAP_INTERLEAVED_CONTEXT* WINPR_RESTRICT interleaved,
+	                                      BYTE* WINPR_RESTRICT pDstData,
+	                                      UINT32* WINPR_RESTRICT pDstSize, UINT32 nWidth,
+	                                      UINT32 nHeight, const BYTE* WINPR_RESTRICT pSrcData,
+	                                      UINT32 SrcFormat, UINT32 nSrcStep, UINT32 nXSrc,
+	                                      UINT32 nYSrc, const gdiPalette* WINPR_RESTRICT palette,
 	                                      UINT32 bpp);
 
-	FREERDP_API BOOL bitmap_interleaved_context_reset(BITMAP_INTERLEAVED_CONTEXT* interleaved);
+	FREERDP_API BOOL
+	bitmap_interleaved_context_reset(BITMAP_INTERLEAVED_CONTEXT* WINPR_RESTRICT interleaved);
 
-	FREERDP_API void bitmap_interleaved_context_free(BITMAP_INTERLEAVED_CONTEXT* interleaved);
+	FREERDP_API void
+	bitmap_interleaved_context_free(BITMAP_INTERLEAVED_CONTEXT* WINPR_RESTRICT interleaved);
 
 	WINPR_ATTR_MALLOC(bitmap_interleaved_context_free, 1)
 	FREERDP_API BITMAP_INTERLEAVED_CONTEXT* bitmap_interleaved_context_new(BOOL Compressor);

--- a/include/freerdp/codec/nsc.h
+++ b/include/freerdp/codec/nsc.h
@@ -50,21 +50,25 @@ extern "C"
 	                                                                   UINT32 pixel_format));
 #endif
 
-	FREERDP_API BOOL nsc_context_set_parameters(NSC_CONTEXT* context, NSC_PARAMETER what,
-	                                            UINT32 value);
+	FREERDP_API BOOL nsc_context_set_parameters(NSC_CONTEXT* WINPR_RESTRICT context,
+	                                            NSC_PARAMETER what, UINT32 value);
 
-	FREERDP_API BOOL nsc_process_message(NSC_CONTEXT* context, UINT16 bpp, UINT32 width,
-	                                     UINT32 height, const BYTE* data, UINT32 length,
-	                                     BYTE* pDstData, UINT32 DstFormat, UINT32 nDstStride,
-	                                     UINT32 nXDst, UINT32 nYDst, UINT32 nWidth, UINT32 nHeight,
-	                                     UINT32 flip);
-	FREERDP_API BOOL nsc_compose_message(NSC_CONTEXT* context, wStream* s, const BYTE* bmpdata,
-	                                     UINT32 width, UINT32 height, UINT32 rowstride);
-	FREERDP_API BOOL nsc_decompose_message(NSC_CONTEXT* context, wStream* s, BYTE* bmpdata,
+	FREERDP_API BOOL nsc_process_message(NSC_CONTEXT* WINPR_RESTRICT context, UINT16 bpp,
+	                                     UINT32 width, UINT32 height, const BYTE* data,
+	                                     UINT32 length, BYTE* pDstData, UINT32 DstFormat,
+	                                     UINT32 nDstStride, UINT32 nXDst, UINT32 nYDst,
+	                                     UINT32 nWidth, UINT32 nHeight, UINT32 flip);
+	FREERDP_API BOOL nsc_compose_message(NSC_CONTEXT* WINPR_RESTRICT context,
+	                                     wStream* WINPR_RESTRICT s,
+	                                     const BYTE* WINPR_RESTRICT bmpdata, UINT32 width,
+	                                     UINT32 height, UINT32 rowstride);
+	FREERDP_API BOOL nsc_decompose_message(NSC_CONTEXT* WINPR_RESTRICT context,
+	                                       wStream* WINPR_RESTRICT s, BYTE* WINPR_RESTRICT bmpdata,
 	                                       UINT32 x, UINT32 y, UINT32 width, UINT32 height,
 	                                       UINT32 rowstride, UINT32 format, UINT32 flip);
 
-	FREERDP_API BOOL nsc_context_reset(NSC_CONTEXT* context, UINT32 width, UINT32 height);
+	FREERDP_API BOOL nsc_context_reset(NSC_CONTEXT* WINPR_RESTRICT context, UINT32 width,
+	                                   UINT32 height);
 
 	FREERDP_API void nsc_context_free(NSC_CONTEXT* context);
 

--- a/include/freerdp/codec/planar.h
+++ b/include/freerdp/codec/planar.h
@@ -45,13 +45,14 @@ extern "C"
 
 	typedef struct S_BITMAP_PLANAR_CONTEXT BITMAP_PLANAR_CONTEXT;
 
-	FREERDP_API BYTE* freerdp_bitmap_compress_planar(BITMAP_PLANAR_CONTEXT* context,
-	                                                 const BYTE* data, UINT32 format, UINT32 width,
-	                                                 UINT32 height, UINT32 scanline, BYTE* dstData,
-	                                                 UINT32* pDstSize);
+	FREERDP_API BYTE* freerdp_bitmap_compress_planar(BITMAP_PLANAR_CONTEXT* WINPR_RESTRICT context,
+	                                                 const BYTE* WINPR_RESTRICT data, UINT32 format,
+	                                                 UINT32 width, UINT32 height, UINT32 scanline,
+	                                                 BYTE* WINPR_RESTRICT dstData,
+	                                                 UINT32* WINPR_RESTRICT pDstSize);
 
-	FREERDP_API BOOL freerdp_bitmap_planar_context_reset(BITMAP_PLANAR_CONTEXT* context,
-	                                                     UINT32 width, UINT32 height);
+	FREERDP_API BOOL freerdp_bitmap_planar_context_reset(
+	    BITMAP_PLANAR_CONTEXT* WINPR_RESTRICT context, UINT32 width, UINT32 height);
 
 	FREERDP_API void freerdp_bitmap_planar_context_free(BITMAP_PLANAR_CONTEXT* context);
 
@@ -59,14 +60,17 @@ extern "C"
 	FREERDP_API BITMAP_PLANAR_CONTEXT* freerdp_bitmap_planar_context_new(DWORD flags, UINT32 width,
 	                                                                     UINT32 height);
 
-	FREERDP_API void freerdp_planar_switch_bgr(BITMAP_PLANAR_CONTEXT* planar, BOOL bgr);
-	FREERDP_API void freerdp_planar_topdown_image(BITMAP_PLANAR_CONTEXT* planar, BOOL topdown);
+	FREERDP_API void freerdp_planar_switch_bgr(BITMAP_PLANAR_CONTEXT* WINPR_RESTRICT planar,
+	                                           BOOL bgr);
+	FREERDP_API void freerdp_planar_topdown_image(BITMAP_PLANAR_CONTEXT* WINPR_RESTRICT planar,
+	                                              BOOL topdown);
 
-	FREERDP_API BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar, const BYTE* pSrcData,
-	                                   UINT32 SrcSize, UINT32 nSrcWidth, UINT32 nSrcHeight,
-	                                   BYTE* pDstData, UINT32 DstFormat, UINT32 nDstStep,
-	                                   UINT32 nXDst, UINT32 nYDst, UINT32 nDstWidth,
-	                                   UINT32 nDstHeight, BOOL vFlip);
+	FREERDP_API BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* WINPR_RESTRICT planar,
+	                                   const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
+	                                   UINT32 nSrcWidth, UINT32 nSrcHeight,
+	                                   BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat,
+	                                   UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
+	                                   UINT32 nDstWidth, UINT32 nDstHeight, BOOL vFlip);
 
 #ifdef __cplusplus
 }

--- a/include/freerdp/codec/progressive.h
+++ b/include/freerdp/codec/progressive.h
@@ -37,25 +37,29 @@ extern "C"
 
 	typedef struct S_PROGRESSIVE_CONTEXT PROGRESSIVE_CONTEXT;
 
-	FREERDP_API int progressive_compress(PROGRESSIVE_CONTEXT* progressive, const BYTE* pSrcData,
-	                                     UINT32 SrcSize, UINT32 SrcFormat, UINT32 Width,
-	                                     UINT32 Height, UINT32 ScanLine,
-	                                     const REGION16* invalidRegion, BYTE** ppDstData,
-	                                     UINT32* pDstSize);
+	FREERDP_API int progressive_compress(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+	                                     const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
+	                                     UINT32 SrcFormat, UINT32 Width, UINT32 Height,
+	                                     UINT32 ScanLine,
+	                                     const REGION16* WINPR_RESTRICT invalidRegion,
+	                                     BYTE** WINPR_RESTRICT ppDstData,
+	                                     UINT32* WINPR_RESTRICT pDstSize);
 
-	FREERDP_API INT32 progressive_decompress(PROGRESSIVE_CONTEXT* progressive, const BYTE* pSrcData,
-	                                         UINT32 SrcSize, BYTE* pDstData, UINT32 DstFormat,
+	FREERDP_API INT32 progressive_decompress(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+	                                         const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
+	                                         BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat,
 	                                         UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
-	                                         REGION16* invalidRegion, UINT16 surfaceId,
-	                                         UINT32 frameId);
+	                                         REGION16* WINPR_RESTRICT invalidRegion,
+	                                         UINT16 surfaceId, UINT32 frameId);
 
-	FREERDP_API INT32 progressive_create_surface_context(PROGRESSIVE_CONTEXT* progressive,
-	                                                     UINT16 surfaceId, UINT32 width,
-	                                                     UINT32 height);
-	FREERDP_API int progressive_delete_surface_context(PROGRESSIVE_CONTEXT* progressive,
-	                                                   UINT16 surfaceId);
+	FREERDP_API INT32
+	progressive_create_surface_context(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+	                                   UINT16 surfaceId, UINT32 width, UINT32 height);
+	FREERDP_API int
+	progressive_delete_surface_context(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+	                                   UINT16 surfaceId);
 
-	FREERDP_API BOOL progressive_context_reset(PROGRESSIVE_CONTEXT* progressive);
+	FREERDP_API BOOL progressive_context_reset(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive);
 
 	FREERDP_API void progressive_context_free(PROGRESSIVE_CONTEXT* progressive);
 

--- a/include/freerdp/codec/yuv.h
+++ b/include/freerdp/codec/yuv.h
@@ -31,27 +31,32 @@ extern "C"
 
 	typedef struct S_YUV_CONTEXT YUV_CONTEXT;
 
-	FREERDP_API BOOL yuv420_context_decode(YUV_CONTEXT* context, const BYTE* pYUVData[3],
-	                                       const UINT32 iStride[3], UINT32 yuvHeight,
-	                                       DWORD DstFormat, BYTE* dest, UINT32 nDstStep,
-	                                       const RECTANGLE_16* regionRects, UINT32 numRegionRects);
-	FREERDP_API BOOL yuv420_context_encode(YUV_CONTEXT* context, const BYTE* rgbData,
-	                                       UINT32 srcStep, UINT32 srcFormat,
-	                                       const UINT32 iStride[3], BYTE* yuvData[3],
-	                                       const RECTANGLE_16* regionRects, UINT32 numRegionRects);
-
-	FREERDP_API BOOL yuv444_context_decode(YUV_CONTEXT* context, BYTE type, const BYTE* pYUVData[3],
-	                                       const UINT32 iStride[3], UINT32 srcYuvHeight,
-	                                       BYTE* pYUVDstData[3], const UINT32 iDstStride[3],
-	                                       DWORD DstFormat, BYTE* dest, UINT32 nDstStep,
-	                                       const RECTANGLE_16* regionRects, UINT32 numRegionRects);
-	FREERDP_API BOOL yuv444_context_encode(YUV_CONTEXT* context, BYTE version, const BYTE* pSrcData,
-	                                       UINT32 nSrcStep, UINT32 SrcFormat,
-	                                       const UINT32 iStride[3], BYTE* pYUVLumaData[3],
-	                                       BYTE* pYUVChromaData[3], const RECTANGLE_16* regionRects,
+	FREERDP_API BOOL yuv420_context_decode(
+	    YUV_CONTEXT* WINPR_RESTRICT context, const BYTE* WINPR_RESTRICT pYUVData[3],
+	    const UINT32 iStride[3], UINT32 yuvHeight, DWORD DstFormat, BYTE* WINPR_RESTRICT dest,
+	    UINT32 nDstStep, const RECTANGLE_16* WINPR_RESTRICT regionRects, UINT32 numRegionRects);
+	FREERDP_API BOOL yuv420_context_encode(YUV_CONTEXT* WINPR_RESTRICT context,
+	                                       const BYTE* WINPR_RESTRICT rgbData, UINT32 srcStep,
+	                                       UINT32 srcFormat, const UINT32 iStride[3],
+	                                       BYTE* WINPR_RESTRICT yuvData[3],
+	                                       const RECTANGLE_16* WINPR_RESTRICT regionRects,
 	                                       UINT32 numRegionRects);
 
-	FREERDP_API BOOL yuv_context_reset(YUV_CONTEXT* context, UINT32 width, UINT32 height);
+	FREERDP_API BOOL yuv444_context_decode(
+	    YUV_CONTEXT* WINPR_RESTRICT context, BYTE type, const BYTE* WINPR_RESTRICT pYUVData[3],
+	    const UINT32 iStride[3], UINT32 srcYuvHeight, BYTE* WINPR_RESTRICT pYUVDstData[3],
+	    const UINT32 iDstStride[3], DWORD DstFormat, BYTE* WINPR_RESTRICT dest, UINT32 nDstStep,
+	    const RECTANGLE_16* WINPR_RESTRICT regionRects, UINT32 numRegionRects);
+	FREERDP_API BOOL yuv444_context_encode(YUV_CONTEXT* WINPR_RESTRICT context, BYTE version,
+	                                       const BYTE* WINPR_RESTRICT pSrcData, UINT32 nSrcStep,
+	                                       UINT32 SrcFormat, const UINT32 iStride[3],
+	                                       BYTE* WINPR_RESTRICT pYUVLumaData[3],
+	                                       BYTE* WINPR_RESTRICT pYUVChromaData[3],
+	                                       const RECTANGLE_16* WINPR_RESTRICT regionRects,
+	                                       UINT32 numRegionRects);
+
+	FREERDP_API BOOL yuv_context_reset(YUV_CONTEXT* WINPR_RESTRICT context, UINT32 width,
+	                                   UINT32 height);
 
 	FREERDP_API void yuv_context_free(YUV_CONTEXT* context);
 

--- a/include/freerdp/codec/zgfx.h
+++ b/include/freerdp/codec/zgfx.h
@@ -39,15 +39,20 @@ extern "C"
 
 	typedef struct S_ZGFX_CONTEXT ZGFX_CONTEXT;
 
-	FREERDP_API int zgfx_decompress(ZGFX_CONTEXT* zgfx, const BYTE* pSrcData, UINT32 SrcSize,
-	                                BYTE** ppDstData, UINT32* pDstSize, UINT32 flags);
-	FREERDP_API int zgfx_compress(ZGFX_CONTEXT* zgfx, const BYTE* pSrcData, UINT32 SrcSize,
-	                              BYTE** ppDstData, UINT32* pDstSize, UINT32* pFlags);
-	FREERDP_API int zgfx_compress_to_stream(ZGFX_CONTEXT* zgfx, wStream* sDst,
-	                                        const BYTE* pUncompressed, UINT32 uncompressedSize,
-	                                        UINT32* pFlags);
+	FREERDP_API int zgfx_decompress(ZGFX_CONTEXT* WINPR_RESTRICT zgfx,
+	                                const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
+	                                BYTE** WINPR_RESTRICT ppDstData,
+	                                UINT32* WINPR_RESTRICT pDstSize, UINT32 flags);
+	FREERDP_API int zgfx_compress(ZGFX_CONTEXT* WINPR_RESTRICT zgfx,
+	                              const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
+	                              BYTE** WINPR_RESTRICT ppDstData, UINT32* pDstSize,
+	                              UINT32* WINPR_RESTRICT pFlags);
+	FREERDP_API int zgfx_compress_to_stream(ZGFX_CONTEXT* WINPR_RESTRICT zgfx,
+	                                        wStream* WINPR_RESTRICT sDst,
+	                                        const BYTE* WINPR_RESTRICT pUncompressed,
+	                                        UINT32 uncompressedSize, UINT32* WINPR_RESTRICT pFlags);
 
-	FREERDP_API void zgfx_context_reset(ZGFX_CONTEXT* zgfx, BOOL flush);
+	FREERDP_API void zgfx_context_reset(ZGFX_CONTEXT* WINPR_RESTRICT zgfx, BOOL flush);
 
 	FREERDP_API void zgfx_context_free(ZGFX_CONTEXT* zgfx);
 

--- a/include/freerdp/codecs.h
+++ b/include/freerdp/codecs.h
@@ -79,7 +79,6 @@ extern "C"
 	FREERDP_API WINPR_DEPRECATED_VAR("Use freerdp_client_codecs_free",
 	                                 void codecs_free(rdpCodecs* codecs));
 
-	WINPR_ATTR_MALLOC(codecs_free, 1)
 	FREERDP_API WINPR_DEPRECATED_VAR("Use freerdp_client_codecs_new",
 	                                 rdpCodecs* codecs_new(rdpContext* context));
 

--- a/libfreerdp/codec/audio.c
+++ b/libfreerdp/codec/audio.c
@@ -201,7 +201,8 @@ BOOL audio_format_write(wStream* s, const AUDIO_FORMAT* format)
 	return TRUE;
 }
 
-BOOL audio_format_copy(const AUDIO_FORMAT* srcFormat, AUDIO_FORMAT* dstFormat)
+BOOL audio_format_copy(const AUDIO_FORMAT* WINPR_RESTRICT srcFormat,
+                       AUDIO_FORMAT* WINPR_RESTRICT dstFormat)
 {
 	if (!srcFormat || !dstFormat)
 		return FALSE;

--- a/libfreerdp/codec/bitmap.c
+++ b/libfreerdp/codec/bitmap.c
@@ -22,22 +22,22 @@
 #include <freerdp/codec/bitmap.h>
 #include <freerdp/codec/planar.h>
 
-static INLINE UINT16 GETPIXEL16(const void* d, UINT32 x, UINT32 y, UINT32 w)
+static INLINE UINT16 GETPIXEL16(const void* WINPR_RESTRICT d, UINT32 x, UINT32 y, UINT32 w)
 {
-	const BYTE* src = (const BYTE*)d + ((y * w + x) * sizeof(UINT16));
+	const BYTE* WINPR_RESTRICT src = (const BYTE*)d + ((y * w + x) * sizeof(UINT16));
 	return (UINT16)(((UINT16)src[1] << 8) | (UINT16)src[0]);
 }
 
-static INLINE UINT32 GETPIXEL32(const void* d, UINT32 x, UINT32 y, UINT32 w)
+static INLINE UINT32 GETPIXEL32(const void* WINPR_RESTRICT d, UINT32 x, UINT32 y, UINT32 w)
 {
-	const BYTE* src = (const BYTE*)d + ((y * w + x) * sizeof(UINT32));
+	const BYTE* WINPR_RESTRICT src = (const BYTE*)d + ((y * w + x) * sizeof(UINT32));
 	return (((UINT32)src[3]) << 24) | (((UINT32)src[2]) << 16) | (((UINT32)src[1]) << 8) |
 	       (src[0] & 0xFF);
 }
 
 /*****************************************************************************/
-static INLINE UINT16 IN_PIXEL16(const void* in_ptr, UINT32 in_x, UINT32 in_y, UINT32 in_w,
-                                UINT16 in_last_pixel)
+static INLINE UINT16 IN_PIXEL16(const void* WINPR_RESTRICT in_ptr, UINT32 in_x, UINT32 in_y,
+                                UINT32 in_w, UINT16 in_last_pixel)
 {
 	if (in_ptr == 0)
 		return 0;
@@ -48,8 +48,8 @@ static INLINE UINT16 IN_PIXEL16(const void* in_ptr, UINT32 in_x, UINT32 in_y, UI
 }
 
 /*****************************************************************************/
-static INLINE UINT32 IN_PIXEL32(const void* in_ptr, UINT32 in_x, UINT32 in_y, UINT32 in_w,
-                                UINT32 in_last_pixel)
+static INLINE UINT32 IN_PIXEL32(const void* WINPR_RESTRICT in_ptr, UINT32 in_x, UINT32 in_y,
+                                UINT32 in_w, UINT32 in_last_pixel)
 {
 	if (in_ptr == 0)
 		return 0;
@@ -61,7 +61,8 @@ static INLINE UINT32 IN_PIXEL32(const void* in_ptr, UINT32 in_x, UINT32 in_y, UI
 
 /*****************************************************************************/
 /* color */
-static UINT16 out_color_count_2(UINT16 in_count, wStream* in_s, UINT16 in_data)
+static INLINE UINT16 out_color_count_2(UINT16 in_count, wStream* WINPR_RESTRICT in_s,
+                                       UINT16 in_data)
 {
 	if (in_count > 0)
 	{
@@ -92,7 +93,8 @@ static UINT16 out_color_count_2(UINT16 in_count, wStream* in_s, UINT16 in_data)
 
 /*****************************************************************************/
 /* color */
-static UINT16 out_color_count_3(UINT16 in_count, wStream* in_s, UINT32 in_data)
+static INLINE UINT16 out_color_count_3(UINT16 in_count, wStream* WINPR_RESTRICT in_s,
+                                       UINT32 in_data)
 {
 	if (in_count > 0)
 	{
@@ -127,7 +129,8 @@ static UINT16 out_color_count_3(UINT16 in_count, wStream* in_s, UINT32 in_data)
 
 /*****************************************************************************/
 /* copy */
-static INLINE UINT16 out_copy_count_2(UINT16 in_count, wStream* in_s, wStream* in_data)
+static INLINE UINT16 out_copy_count_2(UINT16 in_count, wStream* WINPR_RESTRICT in_s,
+                                      wStream* WINPR_RESTRICT in_data)
 
 {
 	if (in_count > 0)
@@ -159,7 +162,8 @@ static INLINE UINT16 out_copy_count_2(UINT16 in_count, wStream* in_s, wStream* i
 	in_count = out_copy_count_2(in_count, in_s, in_data)
 /*****************************************************************************/
 /* copy */
-static INLINE UINT16 out_copy_count_3(UINT16 in_count, wStream* in_s, wStream* in_data)
+static INLINE UINT16 out_copy_count_3(UINT16 in_count, wStream* WINPR_RESTRICT in_s,
+                                      wStream* WINPR_RESTRICT in_data)
 {
 	if (in_count > 0)
 	{
@@ -191,8 +195,8 @@ static INLINE UINT16 out_copy_count_3(UINT16 in_count, wStream* in_s, wStream* i
 
 /*****************************************************************************/
 /* bicolor */
-static INLINE UINT16 out_bicolor_count_2(UINT16 in_count, wStream* in_s, UINT16 in_color1,
-                                         UINT16 in_color2)
+static INLINE UINT16 out_bicolor_count_2(UINT16 in_count, wStream* WINPR_RESTRICT in_s,
+                                         UINT16 in_color1, UINT16 in_color2)
 {
 	if (in_count > 0)
 	{
@@ -225,8 +229,8 @@ static INLINE UINT16 out_bicolor_count_2(UINT16 in_count, wStream* in_s, UINT16 
 
 /*****************************************************************************/
 /* bicolor */
-static INLINE UINT16 out_bicolor_count_3(UINT16 in_count, wStream* in_s, UINT32 in_color1,
-                                         UINT32 in_color2)
+static INLINE UINT16 out_bicolor_count_3(UINT16 in_count, wStream* WINPR_RESTRICT in_s,
+                                         UINT32 in_color1, UINT32 in_color2)
 {
 	if (in_count > 0)
 	{
@@ -263,7 +267,7 @@ static INLINE UINT16 out_bicolor_count_3(UINT16 in_count, wStream* in_s, UINT32 
 
 /*****************************************************************************/
 /* fill */
-static INLINE UINT16 out_fill_count_2(UINT16 in_count, wStream* in_s)
+static INLINE UINT16 out_fill_count_2(UINT16 in_count, wStream* WINPR_RESTRICT in_s)
 {
 	if (in_count > 0)
 	{
@@ -291,7 +295,7 @@ static INLINE UINT16 out_fill_count_2(UINT16 in_count, wStream* in_s)
 
 /*****************************************************************************/
 /* fill */
-static INLINE UINT16 out_fill_count_3(UINT16 in_count, wStream* in_s)
+static INLINE UINT16 out_fill_count_3(UINT16 in_count, wStream* WINPR_RESTRICT in_s)
 {
 	if (in_count > 0)
 	{
@@ -318,7 +322,7 @@ static INLINE UINT16 out_fill_count_3(UINT16 in_count, wStream* in_s)
 
 /*****************************************************************************/
 /* mix */
-static INLINE UINT16 out_mix_count_2(UINT16 in_count, wStream* in_s)
+static INLINE UINT16 out_mix_count_2(UINT16 in_count, wStream* WINPR_RESTRICT in_s)
 {
 	if (in_count > 0)
 	{
@@ -346,7 +350,7 @@ static INLINE UINT16 out_mix_count_2(UINT16 in_count, wStream* in_s)
 
 /*****************************************************************************/
 /* mix */
-static INLINE UINT16 out_mix_count_3(UINT16 in_count, wStream* in_s)
+static INLINE UINT16 out_mix_count_3(UINT16 in_count, wStream* WINPR_RESTRICT in_s)
 {
 	if (in_count > 0)
 	{
@@ -375,8 +379,8 @@ static INLINE UINT16 out_mix_count_3(UINT16 in_count, wStream* in_s)
 
 /*****************************************************************************/
 /* fom */
-static INLINE UINT16 out_from_count_2(UINT16 in_count, wStream* in_s, const char* in_mask,
-                                      size_t in_mask_len)
+static INLINE UINT16 out_from_count_2(UINT16 in_count, wStream* WINPR_RESTRICT in_s,
+                                      const char* WINPR_RESTRICT in_mask, size_t in_mask_len)
 {
 	if (in_count > 0)
 	{
@@ -407,8 +411,8 @@ static INLINE UINT16 out_from_count_2(UINT16 in_count, wStream* in_s, const char
 
 /*****************************************************************************/
 /* fill or mix (fom) */
-static INLINE UINT16 out_from_count_3(UINT16 in_count, wStream* in_s, const char* in_mask,
-                                      size_t in_mask_len)
+static INLINE UINT16 out_from_count_3(UINT16 in_count, wStream* WINPR_RESTRICT in_s,
+                                      const char* WINPR_RESTRICT in_mask, size_t in_mask_len)
 {
 	if (in_count > 0)
 	{
@@ -457,11 +461,12 @@ static INLINE UINT16 out_from_count_3(UINT16 in_count, wStream* in_s, const char
 		bicolor_spin = FALSE; \
 	} while (0)
 
-static SSIZE_T freerdp_bitmap_compress_24(const void* srcData, UINT32 width, UINT32 height,
-                                          wStream* s, UINT32 byte_limit, UINT32 start_line,
-                                          wStream* temp_s, UINT32 e)
+static INLINE SSIZE_T freerdp_bitmap_compress_24(const void* WINPR_RESTRICT srcData, UINT32 width,
+                                                 UINT32 height, wStream* WINPR_RESTRICT s,
+                                                 UINT32 byte_limit, UINT32 start_line,
+                                                 wStream* WINPR_RESTRICT temp_s, UINT32 e)
 {
-	char fom_mask[8192]; /* good for up to 64K bitmap */
+	char fom_mask[8192] = { 0 }; /* good for up to 64K bitmap */
 	SSIZE_T lines_sent = 0;
 	UINT16 count = 0;
 	UINT16 color_count = 0;
@@ -762,11 +767,12 @@ static SSIZE_T freerdp_bitmap_compress_24(const void* srcData, UINT32 width, UIN
 	return lines_sent;
 }
 
-static SSIZE_T freerdp_bitmap_compress_16(const void* srcData, UINT32 width, UINT32 height,
-                                          wStream* s, UINT32 bpp, UINT32 byte_limit,
-                                          UINT32 start_line, wStream* temp_s, UINT32 e)
+static INLINE SSIZE_T freerdp_bitmap_compress_16(const void* WINPR_RESTRICT srcData, UINT32 width,
+                                                 UINT32 height, wStream* WINPR_RESTRICT s,
+                                                 UINT32 bpp, UINT32 byte_limit, UINT32 start_line,
+                                                 wStream* WINPR_RESTRICT temp_s, UINT32 e)
 {
-	char fom_mask[8192]; /* good for up to 64K bitmap */
+	char fom_mask[8192] = { 0 }; /* good for up to 64K bitmap */
 	SSIZE_T lines_sent = 0;
 	UINT16 count = 0;
 	UINT16 color_count = 0;
@@ -1065,9 +1071,9 @@ static SSIZE_T freerdp_bitmap_compress_16(const void* srcData, UINT32 width, UIN
 	return lines_sent;
 }
 
-SSIZE_T freerdp_bitmap_compress(const void* srcData, UINT32 width, UINT32 height, wStream* s,
-                                UINT32 bpp, UINT32 byte_limit, UINT32 start_line, wStream* temp_s,
-                                UINT32 e)
+SSIZE_T freerdp_bitmap_compress(const void* WINPR_RESTRICT srcData, UINT32 width, UINT32 height,
+                                wStream* WINPR_RESTRICT s, UINT32 bpp, UINT32 byte_limit,
+                                UINT32 start_line, wStream* WINPR_RESTRICT temp_s, UINT32 e)
 {
 	Stream_SetPosition(temp_s, 0);
 

--- a/libfreerdp/codec/bulk.c
+++ b/libfreerdp/codec/bulk.c
@@ -73,7 +73,7 @@ static INLINE const char* bulk_get_compression_flags_string(UINT32 flags)
 }
 #endif
 
-static UINT32 bulk_compression_level(rdpBulk* bulk)
+static UINT32 bulk_compression_level(rdpBulk* WINPR_RESTRICT bulk)
 {
 	rdpSettings* settings = NULL;
 	WINPR_ASSERT(bulk);
@@ -86,7 +86,7 @@ static UINT32 bulk_compression_level(rdpBulk* bulk)
 	return bulk->CompressionLevel;
 }
 
-UINT32 bulk_compression_max_size(rdpBulk* bulk)
+UINT32 bulk_compression_max_size(rdpBulk* WINPR_RESTRICT bulk)
 {
 	WINPR_ASSERT(bulk);
 	bulk_compression_level(bulk);
@@ -146,8 +146,9 @@ static INLINE int bulk_compress_validate(rdpBulk* bulk, const BYTE* pSrcData, UI
 }
 #endif
 
-int bulk_decompress(rdpBulk* bulk, const BYTE* pSrcData, UINT32 SrcSize, const BYTE** ppDstData,
-                    UINT32* pDstSize, UINT32 flags)
+int bulk_decompress(rdpBulk* WINPR_RESTRICT bulk, const BYTE* WINPR_RESTRICT pSrcData,
+                    UINT32 SrcSize, const BYTE** WINPR_RESTRICT ppDstData,
+                    UINT32* WINPR_RESTRICT pDstSize, UINT32 flags)
 {
 	UINT32 type = 0;
 	int status = -1;
@@ -239,8 +240,9 @@ int bulk_decompress(rdpBulk* bulk, const BYTE* pSrcData, UINT32 SrcSize, const B
 	return status;
 }
 
-int bulk_compress(rdpBulk* bulk, const BYTE* pSrcData, UINT32 SrcSize, const BYTE** ppDstData,
-                  UINT32* pDstSize, UINT32* pFlags)
+int bulk_compress(rdpBulk* WINPR_RESTRICT bulk, const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
+                  const BYTE** WINPR_RESTRICT ppDstData, UINT32* WINPR_RESTRICT pDstSize,
+                  UINT32* WINPR_RESTRICT pFlags)
 {
 	int status = -1;
 	rdpMetrics* metrics = NULL;
@@ -324,7 +326,7 @@ int bulk_compress(rdpBulk* bulk, const BYTE* pSrcData, UINT32 SrcSize, const BYT
 	return status;
 }
 
-void bulk_reset(rdpBulk* bulk)
+void bulk_reset(rdpBulk* WINPR_RESTRICT bulk)
 {
 	WINPR_ASSERT(bulk);
 

--- a/libfreerdp/codec/bulk.h
+++ b/libfreerdp/codec/bulk.h
@@ -28,14 +28,16 @@ typedef struct rdp_bulk rdpBulk;
 #define BULK_COMPRESSION_FLAGS_MASK 0xE0
 #define BULK_COMPRESSION_TYPE_MASK 0x0F
 
-FREERDP_LOCAL UINT32 bulk_compression_max_size(rdpBulk* bulk);
+FREERDP_LOCAL UINT32 bulk_compression_max_size(rdpBulk* WINPR_RESTRICT bulk);
 
-FREERDP_LOCAL int bulk_decompress(rdpBulk* bulk, const BYTE* pSrcData, UINT32 SrcSize,
-                                  const BYTE** ppDstData, UINT32* pDstSize, UINT32 flags);
-FREERDP_LOCAL int bulk_compress(rdpBulk* bulk, const BYTE* pSrcData, UINT32 SrcSize,
-                                const BYTE** ppDstData, UINT32* pDstSize, UINT32* pFlags);
+FREERDP_LOCAL int bulk_decompress(rdpBulk* WINPR_RESTRICT bulk, const BYTE* WINPR_RESTRICT pSrcData,
+                                  UINT32 SrcSize, const BYTE** WINPR_RESTRICT ppDstData,
+                                  UINT32* WINPR_RESTRICT pDstSize, UINT32 flags);
+FREERDP_LOCAL int bulk_compress(rdpBulk* WINPR_RESTRICT bulk, const BYTE* WINPR_RESTRICT pSrcData,
+                                UINT32 SrcSize, const BYTE** WINPR_RESTRICT ppDstData,
+                                UINT32* WINPR_RESTRICT pDstSize, UINT32* WINPR_RESTRICT pFlags);
 
-FREERDP_LOCAL void bulk_reset(rdpBulk* bulk);
+FREERDP_LOCAL void bulk_reset(rdpBulk* WINPR_RESTRICT bulk);
 
 FREERDP_LOCAL void bulk_free(rdpBulk* bulk);
 

--- a/libfreerdp/codec/clear.c
+++ b/libfreerdp/codec/clear.c
@@ -82,7 +82,7 @@ static const UINT32 CLEAR_LOG2_FLOOR[256] = {
 
 static const BYTE CLEAR_8BIT_MASKS[9] = { 0x00, 0x01, 0x03, 0x07, 0x0F, 0x1F, 0x3F, 0x7F, 0xFF };
 
-static void clear_reset_vbar_storage(CLEAR_CONTEXT* clear, BOOL zero)
+static void clear_reset_vbar_storage(CLEAR_CONTEXT* WINPR_RESTRICT clear, BOOL zero)
 {
 	if (zero)
 	{
@@ -105,7 +105,7 @@ static void clear_reset_vbar_storage(CLEAR_CONTEXT* clear, BOOL zero)
 	clear->ShortVBarStorageCursor = 0;
 }
 
-static void clear_reset_glyph_cache(CLEAR_CONTEXT* clear)
+static void clear_reset_glyph_cache(CLEAR_CONTEXT* WINPR_RESTRICT clear)
 {
 	for (size_t i = 0; i < ARRAYSIZE(clear->GlyphCache); i++)
 		winpr_aligned_free(clear->GlyphCache[i].pixels);
@@ -113,10 +113,11 @@ static void clear_reset_glyph_cache(CLEAR_CONTEXT* clear)
 	ZeroMemory(clear->GlyphCache, sizeof(clear->GlyphCache));
 }
 
-static BOOL convert_color(BYTE* dst, UINT32 nDstStep, UINT32 DstFormat, UINT32 nXDst, UINT32 nYDst,
-                          UINT32 nWidth, UINT32 nHeight, const BYTE* src, UINT32 nSrcStep,
-                          UINT32 SrcFormat, UINT32 nDstWidth, UINT32 nDstHeight,
-                          const gdiPalette* palette)
+static BOOL convert_color(BYTE* WINPR_RESTRICT dst, UINT32 nDstStep, UINT32 DstFormat, UINT32 nXDst,
+                          UINT32 nYDst, UINT32 nWidth, UINT32 nHeight,
+                          const BYTE* WINPR_RESTRICT src, UINT32 nSrcStep, UINT32 SrcFormat,
+                          UINT32 nDstWidth, UINT32 nDstHeight,
+                          const gdiPalette* WINPR_RESTRICT palette)
 {
 	if (nWidth + nXDst > nDstWidth)
 		nWidth = nDstWidth - nXDst;
@@ -129,8 +130,9 @@ static BOOL convert_color(BYTE* dst, UINT32 nDstStep, UINT32 DstFormat, UINT32 n
 	                                     FREERDP_KEEP_DST_ALPHA);
 }
 
-static BOOL clear_decompress_nscodec(NSC_CONTEXT* nsc, UINT32 width, UINT32 height, wStream* s,
-                                     UINT32 bitmapDataByteCount, BYTE* pDstData, UINT32 DstFormat,
+static BOOL clear_decompress_nscodec(NSC_CONTEXT* WINPR_RESTRICT nsc, UINT32 width, UINT32 height,
+                                     wStream* WINPR_RESTRICT s, UINT32 bitmapDataByteCount,
+                                     BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat,
                                      UINT32 nDstStep, UINT32 nXDstRel, UINT32 nYDstRel)
 {
 	BOOL rc = 0;
@@ -145,8 +147,9 @@ static BOOL clear_decompress_nscodec(NSC_CONTEXT* nsc, UINT32 width, UINT32 heig
 	return rc;
 }
 
-static BOOL clear_decompress_subcode_rlex(wStream* s, UINT32 bitmapDataByteCount, UINT32 width,
-                                          UINT32 height, BYTE* pDstData, UINT32 DstFormat,
+static BOOL clear_decompress_subcode_rlex(wStream* WINPR_RESTRICT s, UINT32 bitmapDataByteCount,
+                                          UINT32 width, UINT32 height,
+                                          BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat,
                                           UINT32 nDstStep, UINT32 nXDstRel, UINT32 nYDstRel,
                                           UINT32 nDstWidth, UINT32 nDstHeight)
 {
@@ -323,7 +326,7 @@ static BOOL clear_decompress_subcode_rlex(wStream* s, UINT32 bitmapDataByteCount
 	return TRUE;
 }
 
-static BOOL clear_resize_buffer(CLEAR_CONTEXT* clear, UINT32 width, UINT32 height)
+static BOOL clear_resize_buffer(CLEAR_CONTEXT* WINPR_RESTRICT clear, UINT32 width, UINT32 height)
 {
 	UINT32 size = 0;
 
@@ -350,11 +353,13 @@ static BOOL clear_resize_buffer(CLEAR_CONTEXT* clear, UINT32 width, UINT32 heigh
 	return TRUE;
 }
 
-static BOOL clear_decompress_residual_data(CLEAR_CONTEXT* clear, wStream* s,
-                                           UINT32 residualByteCount, UINT32 nWidth, UINT32 nHeight,
-                                           BYTE* pDstData, UINT32 DstFormat, UINT32 nDstStep,
-                                           UINT32 nXDst, UINT32 nYDst, UINT32 nDstWidth,
-                                           UINT32 nDstHeight, const gdiPalette* palette)
+static BOOL clear_decompress_residual_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
+                                           wStream* WINPR_RESTRICT s, UINT32 residualByteCount,
+                                           UINT32 nWidth, UINT32 nHeight,
+                                           BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat,
+                                           UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
+                                           UINT32 nDstWidth, UINT32 nDstHeight,
+                                           const gdiPalette* WINPR_RESTRICT palette)
 {
 	UINT32 nSrcStep = 0;
 	UINT32 suboffset = 0;
@@ -441,11 +446,13 @@ static BOOL clear_decompress_residual_data(CLEAR_CONTEXT* clear, wStream* s,
 	                     palette);
 }
 
-static BOOL clear_decompress_subcodecs_data(CLEAR_CONTEXT* clear, wStream* s,
-                                            UINT32 subcodecByteCount, UINT32 nWidth, UINT32 nHeight,
-                                            BYTE* pDstData, UINT32 DstFormat, UINT32 nDstStep,
-                                            UINT32 nXDst, UINT32 nYDst, UINT32 nDstWidth,
-                                            UINT32 nDstHeight, const gdiPalette* palette)
+static BOOL clear_decompress_subcodecs_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
+                                            wStream* WINPR_RESTRICT s, UINT32 subcodecByteCount,
+                                            UINT32 nWidth, UINT32 nHeight,
+                                            BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat,
+                                            UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
+                                            UINT32 nDstWidth, UINT32 nDstHeight,
+                                            const gdiPalette* WINPR_RESTRICT palette)
 {
 	UINT16 xStart = 0;
 	UINT16 yStart = 0;
@@ -547,7 +554,8 @@ static BOOL clear_decompress_subcodecs_data(CLEAR_CONTEXT* clear, wStream* s,
 	return TRUE;
 }
 
-static BOOL resize_vbar_entry(CLEAR_CONTEXT* clear, CLEAR_VBAR_ENTRY* vBarEntry)
+static BOOL resize_vbar_entry(CLEAR_CONTEXT* WINPR_RESTRICT clear,
+                              CLEAR_VBAR_ENTRY* WINPR_RESTRICT vBarEntry)
 {
 	if (vBarEntry->count > vBarEntry->size)
 	{
@@ -580,10 +588,12 @@ static BOOL resize_vbar_entry(CLEAR_CONTEXT* clear, CLEAR_VBAR_ENTRY* vBarEntry)
 	return TRUE;
 }
 
-static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* clear, wStream* s, UINT32 bandsByteCount,
-                                        UINT32 nWidth, UINT32 nHeight, BYTE* pDstData,
-                                        UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst,
-                                        UINT32 nYDst, UINT32 nDstWidth, UINT32 nDstHeight)
+static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
+                                        wStream* WINPR_RESTRICT s, UINT32 bandsByteCount,
+                                        UINT32 nWidth, UINT32 nHeight,
+                                        BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat,
+                                        UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
+                                        UINT32 nDstWidth, UINT32 nDstHeight)
 {
 	UINT32 suboffset = 0;
 
@@ -885,11 +895,13 @@ static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* clear, wStream* s, UINT32
 	return TRUE;
 }
 
-static BOOL clear_decompress_glyph_data(CLEAR_CONTEXT* clear, wStream* s, UINT32 glyphFlags,
-                                        UINT32 nWidth, UINT32 nHeight, BYTE* pDstData,
+static BOOL clear_decompress_glyph_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
+                                        wStream* WINPR_RESTRICT s, UINT32 glyphFlags, UINT32 nWidth,
+                                        UINT32 nHeight, BYTE* WINPR_RESTRICT pDstData,
                                         UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst,
                                         UINT32 nYDst, UINT32 nDstWidth, UINT32 nDstHeight,
-                                        const gdiPalette* palette, BYTE** ppGlyphData)
+                                        const gdiPalette* WINPR_RESTRICT palette,
+                                        BYTE** WINPR_RESTRICT ppGlyphData)
 {
 	UINT16 glyphIndex = 0;
 
@@ -992,7 +1004,7 @@ static BOOL clear_decompress_glyph_data(CLEAR_CONTEXT* clear, wStream* s, UINT32
 	return TRUE;
 }
 
-static INLINE BOOL updateContextFormat(CLEAR_CONTEXT* clear, UINT32 DstFormat)
+static INLINE BOOL updateContextFormat(CLEAR_CONTEXT* WINPR_RESTRICT clear, UINT32 DstFormat)
 {
 	if (!clear || !clear->nsc)
 		return FALSE;
@@ -1001,10 +1013,11 @@ static INLINE BOOL updateContextFormat(CLEAR_CONTEXT* clear, UINT32 DstFormat)
 	return nsc_context_set_parameters(clear->nsc, NSC_COLOR_FORMAT, DstFormat);
 }
 
-INT32 clear_decompress(CLEAR_CONTEXT* clear, const BYTE* pSrcData, UINT32 SrcSize, UINT32 nWidth,
-                       UINT32 nHeight, BYTE* pDstData, UINT32 DstFormat, UINT32 nDstStep,
-                       UINT32 nXDst, UINT32 nYDst, UINT32 nDstWidth, UINT32 nDstHeight,
-                       const gdiPalette* palette)
+INT32 clear_decompress(CLEAR_CONTEXT* WINPR_RESTRICT clear, const BYTE* WINPR_RESTRICT pSrcData,
+                       UINT32 SrcSize, UINT32 nWidth, UINT32 nHeight, BYTE* WINPR_RESTRICT pDstData,
+                       UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
+                       UINT32 nDstWidth, UINT32 nDstHeight,
+                       const gdiPalette* WINPR_RESTRICT palette)
 {
 	INT32 rc = -1;
 	BYTE seqNumber = 0;
@@ -1131,14 +1144,14 @@ fail:
 	return rc;
 }
 
-int clear_compress(CLEAR_CONTEXT* clear, const BYTE* pSrcData, UINT32 SrcSize, BYTE** ppDstData,
-                   UINT32* pDstSize)
+int clear_compress(CLEAR_CONTEXT* WINPR_RESTRICT clear, const BYTE* WINPR_RESTRICT pSrcData,
+                   UINT32 SrcSize, BYTE** WINPR_RESTRICT ppDstData, UINT32* WINPR_RESTRICT pDstSize)
 {
 	WLog_ERR(TAG, "TODO: not implemented!");
 	return 1;
 }
 
-BOOL clear_context_reset(CLEAR_CONTEXT* clear)
+BOOL clear_context_reset(CLEAR_CONTEXT* WINPR_RESTRICT clear)
 {
 	if (!clear)
 		return FALSE;

--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -51,7 +51,7 @@ static INLINE DWORD FreeRDPAreColorFormatsEqualNoAlpha_int(DWORD first, DWORD se
 	return (first & mask) == (second & mask);
 }
 
-BYTE* freerdp_glyph_convert(UINT32 width, UINT32 height, const BYTE* data)
+BYTE* freerdp_glyph_convert(UINT32 width, UINT32 height, const BYTE* WINPR_RESTRICT data)
 {
 	/*
 	 * converts a 1-bit-per-pixel glyph to a one-byte-per-pixel glyph:

--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -586,6 +586,153 @@ static INLINE BOOL overlapping(const BYTE* pDstData, UINT32 nXDst, UINT32 nYDst,
 	return FALSE;
 }
 
+static INLINE BOOL freerdp_image_copy_bgr24_bgrx32(BYTE* WINPR_RESTRICT pDstData, UINT32 nDstStep,
+                                                   UINT32 nXDst, UINT32 nYDst, UINT32 nWidth,
+                                                   UINT32 nHeight,
+                                                   const BYTE* WINPR_RESTRICT pSrcData,
+                                                   UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc,
+                                                   SSIZE_T srcVMultiplier, SSIZE_T srcVOffset,
+                                                   SSIZE_T dstVMultiplier, SSIZE_T dstVOffset)
+{
+
+	const SSIZE_T srcByte = 3;
+	const SSIZE_T dstByte = 4;
+
+	for (SSIZE_T y = 0; y < nHeight; y++)
+	{
+		const BYTE* WINPR_RESTRICT srcLine =
+		    &pSrcData[srcVMultiplier * (y + nYSrc) * nSrcStep + srcVOffset];
+		BYTE* WINPR_RESTRICT dstLine =
+		    &pDstData[dstVMultiplier * (y + nYDst) * nDstStep + dstVOffset];
+
+		for (SSIZE_T x = 0; x < nWidth; x++)
+		{
+			dstLine[(x + nXDst) * dstByte + 0] = srcLine[(x + nXSrc) * srcByte + 0];
+			dstLine[(x + nXDst) * dstByte + 1] = srcLine[(x + nXSrc) * srcByte + 1];
+			dstLine[(x + nXDst) * dstByte + 2] = srcLine[(x + nXSrc) * srcByte + 2];
+		}
+	}
+
+	return TRUE;
+}
+
+static INLINE BOOL freerdp_image_copy_bgrx32_bgrx32(BYTE* WINPR_RESTRICT pDstData, UINT32 nDstStep,
+                                                    UINT32 nXDst, UINT32 nYDst, UINT32 nWidth,
+                                                    UINT32 nHeight,
+                                                    const BYTE* WINPR_RESTRICT pSrcData,
+                                                    UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc,
+                                                    SSIZE_T srcVMultiplier, SSIZE_T srcVOffset,
+                                                    SSIZE_T dstVMultiplier, SSIZE_T dstVOffset)
+{
+
+	const SSIZE_T srcByte = 4;
+	const SSIZE_T dstByte = 4;
+
+	for (SSIZE_T y = 0; y < nHeight; y++)
+	{
+		const BYTE* WINPR_RESTRICT srcLine =
+		    &pSrcData[srcVMultiplier * (y + nYSrc) * nSrcStep + srcVOffset];
+		BYTE* WINPR_RESTRICT dstLine =
+		    &pDstData[dstVMultiplier * (y + nYDst) * nDstStep + dstVOffset];
+
+		for (SSIZE_T x = 0; x < nWidth; x++)
+		{
+			dstLine[(x + nXDst) * dstByte + 0] = srcLine[(x + nXSrc) * srcByte + 0];
+			dstLine[(x + nXDst) * dstByte + 1] = srcLine[(x + nXSrc) * srcByte + 1];
+			dstLine[(x + nXDst) * dstByte + 2] = srcLine[(x + nXSrc) * srcByte + 2];
+		}
+	}
+
+	return TRUE;
+}
+
+static INLINE BOOL freerdp_image_copy_generic(
+    BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
+    UINT32 nWidth, UINT32 nHeight, const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcFormat,
+    UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc, const gdiPalette* WINPR_RESTRICT palette,
+    SSIZE_T srcVMultiplier, SSIZE_T srcVOffset, SSIZE_T dstVMultiplier, SSIZE_T dstVOffset)
+{
+
+	const SSIZE_T srcByte = 4;
+	const SSIZE_T dstByte = 4;
+
+	for (SSIZE_T y = 0; y < nHeight; y++)
+	{
+		const BYTE* WINPR_RESTRICT srcLine =
+		    &pSrcData[srcVMultiplier * (y + nYSrc) * nSrcStep + srcVOffset];
+		BYTE* WINPR_RESTRICT dstLine =
+		    &pDstData[dstVMultiplier * (y + nYDst) * nDstStep + dstVOffset];
+
+		UINT32 color = FreeRDPReadColor_int(&srcLine[nXSrc * srcByte], SrcFormat);
+		UINT32 oldColor = color;
+		UINT32 dstColor = FreeRDPConvertColor(color, SrcFormat, DstFormat, palette);
+		FreeRDPWriteColorIgnoreAlpha_int(&dstLine[nXDst * dstByte], DstFormat, dstColor);
+		for (SSIZE_T x = 1; x < nWidth; x++)
+		{
+			color = FreeRDPReadColor_int(&srcLine[(x + nXSrc) * srcByte], SrcFormat);
+			if (color == oldColor)
+			{
+				FreeRDPWriteColorIgnoreAlpha_int(&dstLine[(x + nXDst) * dstByte], DstFormat,
+				                                 dstColor);
+			}
+			else
+			{
+				oldColor = color;
+				dstColor = FreeRDPConvertColor(color, SrcFormat, DstFormat, palette);
+				FreeRDPWriteColorIgnoreAlpha_int(&dstLine[(x + nXDst) * dstByte], DstFormat,
+				                                 dstColor);
+			}
+		}
+	}
+
+	return TRUE;
+}
+
+static INLINE BOOL freerdp_image_copy_no_overlap_dst_alpha(
+    BYTE* WINPR_RESTRICT pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
+    UINT32 nWidth, UINT32 nHeight, const BYTE* WINPR_RESTRICT pSrcData, DWORD SrcFormat,
+    UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc, const gdiPalette* WINPR_RESTRICT palette,
+    SSIZE_T srcVMultiplier, SSIZE_T srcVOffset, SSIZE_T dstVMultiplier, SSIZE_T dstVOffset)
+{
+	WINPR_ASSERT(pDstData);
+	WINPR_ASSERT(pSrcData);
+
+	switch (SrcFormat)
+	{
+		case PIXEL_FORMAT_BGR24:
+			switch (DstFormat)
+			{
+				case PIXEL_FORMAT_BGRX32:
+				case PIXEL_FORMAT_BGRA32:
+					return freerdp_image_copy_bgr24_bgrx32(
+					    pDstData, nDstStep, nXDst, nYDst, nWidth, nHeight, pSrcData, nSrcStep,
+					    nXSrc, nYSrc, srcVMultiplier, srcVOffset, dstVMultiplier, dstVOffset);
+				default:
+					break;
+			}
+			break;
+		case PIXEL_FORMAT_BGRX32:
+		case PIXEL_FORMAT_BGRA32:
+			switch (DstFormat)
+			{
+				case PIXEL_FORMAT_BGRX32:
+				case PIXEL_FORMAT_BGRA32:
+					return freerdp_image_copy_bgrx32_bgrx32(
+					    pDstData, nDstStep, nXDst, nYDst, nWidth, nHeight, pSrcData, nSrcStep,
+					    nXSrc, nYSrc, srcVMultiplier, srcVOffset, dstVMultiplier, dstVOffset);
+				default:
+					break;
+			}
+			break;
+		default:
+			break;
+	}
+
+	return freerdp_image_copy_generic(pDstData, DstFormat, nDstStep, nXDst, nYDst, nWidth, nHeight,
+	                                  pSrcData, SrcFormat, nSrcStep, nXSrc, nYSrc, palette,
+	                                  srcVMultiplier, srcVOffset, dstVMultiplier, dstVOffset);
+}
+
 BOOL freerdp_image_copy_no_overlap(BYTE* WINPR_RESTRICT pDstData, DWORD DstFormat, UINT32 nDstStep,
                                    UINT32 nXDst, UINT32 nYDst, UINT32 nWidth, UINT32 nHeight,
                                    const BYTE* WINPR_RESTRICT pSrcData, DWORD SrcFormat,
@@ -625,36 +772,10 @@ BOOL freerdp_image_copy_no_overlap(BYTE* WINPR_RESTRICT pDstData, DWORD DstForma
 	}
 
 	if (((flags & FREERDP_KEEP_DST_ALPHA) != 0) && FreeRDPColorHasAlpha(DstFormat))
-	{
-		for (SSIZE_T y = 0; y < nHeight; y++)
-		{
-			const BYTE* WINPR_RESTRICT srcLine =
-			    &pSrcData[srcVMultiplier * (y + nYSrc) * nSrcStep + srcVOffset];
-			BYTE* WINPR_RESTRICT dstLine =
-			    &pDstData[dstVMultiplier * (y + nYDst) * nDstStep + dstVOffset];
-
-			UINT32 color = FreeRDPReadColor_int(&srcLine[nXSrc * srcByte], SrcFormat);
-			UINT32 oldColor = color;
-			UINT32 dstColor = FreeRDPConvertColor(color, SrcFormat, DstFormat, palette);
-			FreeRDPWriteColorIgnoreAlpha_int(&dstLine[nXDst * dstByte], DstFormat, dstColor);
-			for (SSIZE_T x = 1; x < nWidth; x++)
-			{
-				color = FreeRDPReadColor_int(&srcLine[(x + nXSrc) * srcByte], SrcFormat);
-				if (color == oldColor)
-				{
-					FreeRDPWriteColorIgnoreAlpha_int(&dstLine[(x + nXDst) * dstByte], DstFormat,
-					                                 dstColor);
-				}
-				else
-				{
-					oldColor = color;
-					dstColor = FreeRDPConvertColor(color, SrcFormat, DstFormat, palette);
-					FreeRDPWriteColorIgnoreAlpha_int(&dstLine[(x + nXDst) * dstByte], DstFormat,
-					                                 dstColor);
-				}
-			}
-		}
-	}
+		return freerdp_image_copy_no_overlap_dst_alpha(
+		    pDstData, DstFormat, nDstStep, nXDst, nYDst, nWidth, nHeight, pSrcData, SrcFormat,
+		    nSrcStep, nXSrc, nYSrc, palette, srcVMultiplier, srcVOffset, dstVMultiplier,
+		    dstVOffset);
 	else if (FreeRDPAreColorFormatsEqualNoAlpha_int(SrcFormat, DstFormat))
 	{
 		if (!vSrcVFlip && (nDstStep == nSrcStep) && (xSrcOffset == 0) && (xDstOffset == 0))
@@ -747,32 +868,10 @@ BOOL freerdp_image_copy_overlap(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep
 
 	if (((flags & FREERDP_KEEP_DST_ALPHA) != 0) && FreeRDPColorHasAlpha(DstFormat))
 	{
-		for (SSIZE_T y = 0; y < nHeight; y++)
-		{
-			const BYTE* srcLine = &pSrcData[srcVMultiplier * (y + nYSrc) * nSrcStep + srcVOffset];
-			BYTE* dstLine = &pDstData[dstVMultiplier * (y + nYDst) * nDstStep + dstVOffset];
-
-			UINT32 color = FreeRDPReadColor_int(&srcLine[nXSrc * srcByte], SrcFormat);
-			UINT32 oldColor = color;
-			UINT32 dstColor = FreeRDPConvertColor(color, SrcFormat, DstFormat, palette);
-			FreeRDPWriteColorIgnoreAlpha_int(&dstLine[nXDst * dstByte], DstFormat, dstColor);
-			for (UINT32 x = 1; x < nWidth; x++)
-			{
-				color = FreeRDPReadColor_int(&srcLine[(x + nXSrc) * srcByte], SrcFormat);
-				if (color == oldColor)
-				{
-					FreeRDPWriteColorIgnoreAlpha_int(&dstLine[(x + nXDst) * dstByte], DstFormat,
-					                                 dstColor);
-				}
-				else
-				{
-					oldColor = color;
-					dstColor = FreeRDPConvertColor(color, SrcFormat, DstFormat, palette);
-					FreeRDPWriteColorIgnoreAlpha_int(&dstLine[(x + nXDst) * dstByte], DstFormat,
-					                                 dstColor);
-				}
-			}
-		}
+		return freerdp_image_copy_no_overlap_dst_alpha(
+		    pDstData, DstFormat, nDstStep, nXDst, nYDst, nWidth, nHeight, pSrcData, SrcFormat,
+		    nSrcStep, nXSrc, nYSrc, palette, srcVMultiplier, srcVOffset, dstVMultiplier,
+		    dstVOffset);
 	}
 	else if (FreeRDPAreColorFormatsEqualNoAlpha_int(SrcFormat, DstFormat))
 	{

--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -711,7 +711,7 @@ BOOL freerdp_image_copy_no_overlap(BYTE* WINPR_RESTRICT pDstData, DWORD DstForma
 BOOL freerdp_image_copy_overlap(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32 nXDst,
                                 UINT32 nYDst, UINT32 nWidth, UINT32 nHeight, const BYTE* pSrcData,
                                 DWORD SrcFormat, UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc,
-                                const gdiPalette* palette, UINT32 flags)
+                                const gdiPalette* WINPR_RESTRICT palette, UINT32 flags)
 {
 	const UINT32 dstByte = FreeRDPGetBytesPerPixel(DstFormat);
 	const UINT32 srcByte = FreeRDPGetBytesPerPixel(SrcFormat);
@@ -859,7 +859,7 @@ BOOL freerdp_image_copy_overlap(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep
 BOOL freerdp_image_copy(BYTE* pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32 nXDst,
                         UINT32 nYDst, UINT32 nWidth, UINT32 nHeight, const BYTE* pSrcData,
                         DWORD SrcFormat, UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc,
-                        const gdiPalette* palette, UINT32 flags)
+                        const gdiPalette* WINPR_RESTRICT palette, UINT32 flags)
 {
 	const UINT32 dstByte = FreeRDPGetBytesPerPixel(DstFormat);
 	const UINT32 srcByte = FreeRDPGetBytesPerPixel(SrcFormat);

--- a/libfreerdp/codec/dsp.c
+++ b/libfreerdp/codec/dsp.c
@@ -121,7 +121,7 @@ struct S_FREERDP_DSP_CONTEXT
 };
 
 #if defined(WITH_OPUS)
-static BOOL opus_is_valid_samplerate(const AUDIO_FORMAT* format)
+static BOOL opus_is_valid_samplerate(const AUDIO_FORMAT* WINPR_RESTRICT format)
 {
 	WINPR_ASSERT(format);
 
@@ -139,14 +139,15 @@ static BOOL opus_is_valid_samplerate(const AUDIO_FORMAT* format)
 }
 #endif
 
-static INT16 read_int16(const BYTE* src)
+static INT16 read_int16(const BYTE* WINPR_RESTRICT src)
 {
 	return (INT16)(src[0] | (src[1] << 8));
 }
 
-static BOOL freerdp_dsp_channel_mix(FREERDP_DSP_CONTEXT* context, const BYTE* src, size_t size,
-                                    const AUDIO_FORMAT* srcFormat, const BYTE** data,
-                                    size_t* length)
+static BOOL freerdp_dsp_channel_mix(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                    const BYTE* WINPR_RESTRICT src, size_t size,
+                                    const AUDIO_FORMAT* WINPR_RESTRICT srcFormat,
+                                    const BYTE** WINPR_RESTRICT data, size_t* WINPR_RESTRICT length)
 {
 	UINT32 bpp;
 	size_t samples;
@@ -231,8 +232,10 @@ static BOOL freerdp_dsp_channel_mix(FREERDP_DSP_CONTEXT* context, const BYTE* sr
  * http://download.microsoft.com/download/9/8/6/9863C72A-A3AA-4DDB-B1BA-CA8D17EFD2D4/RIFFNEW.pdf
  */
 
-static BOOL freerdp_dsp_resample(FREERDP_DSP_CONTEXT* context, const BYTE* src, size_t size,
-                                 const AUDIO_FORMAT* srcFormat, const BYTE** data, size_t* length)
+static BOOL freerdp_dsp_resample(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                 const BYTE* WINPR_RESTRICT src, size_t size,
+                                 const AUDIO_FORMAT* WINPR_RESTRICT srcFormat,
+                                 const BYTE** WINPR_RESTRICT data, size_t* WINPR_RESTRICT length)
 {
 #if defined(WITH_SOXR)
 	soxr_error_t error;
@@ -315,7 +318,8 @@ static const INT16 ima_step_size_table[] = {
 	12635, 13899, 15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767
 };
 
-static UINT16 dsp_decode_ima_adpcm_sample(ADPCM* adpcm, unsigned int channel, BYTE sample)
+static UINT16 dsp_decode_ima_adpcm_sample(ADPCM* WINPR_RESTRICT adpcm, unsigned int channel,
+                                          BYTE sample)
 {
 	INT32 ss;
 	INT32 d;
@@ -352,8 +356,9 @@ static UINT16 dsp_decode_ima_adpcm_sample(ADPCM* adpcm, unsigned int channel, BY
 	return (UINT16)d;
 }
 
-static BOOL freerdp_dsp_decode_ima_adpcm(FREERDP_DSP_CONTEXT* context, const BYTE* src, size_t size,
-                                         wStream* out)
+static BOOL freerdp_dsp_decode_ima_adpcm(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                         const BYTE* WINPR_RESTRICT src, size_t size,
+                                         wStream* WINPR_RESTRICT out)
 {
 	BYTE sample;
 	UINT16 decoded;
@@ -432,8 +437,9 @@ static BOOL freerdp_dsp_decode_ima_adpcm(FREERDP_DSP_CONTEXT* context, const BYT
 }
 
 #if defined(WITH_GSM)
-static BOOL freerdp_dsp_decode_gsm610(FREERDP_DSP_CONTEXT* context, const BYTE* src, size_t size,
-                                      wStream* out)
+static BOOL freerdp_dsp_decode_gsm610(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                      const BYTE* WINPR_RESTRICT src, size_t size,
+                                      wStream* WINPR_RESTRICT out)
 {
 	size_t offset = 0;
 
@@ -461,8 +467,9 @@ static BOOL freerdp_dsp_decode_gsm610(FREERDP_DSP_CONTEXT* context, const BYTE* 
 	return TRUE;
 }
 
-static BOOL freerdp_dsp_encode_gsm610(FREERDP_DSP_CONTEXT* context, const BYTE* src, size_t size,
-                                      wStream* out)
+static BOOL freerdp_dsp_encode_gsm610(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                      const BYTE* WINPR_RESTRICT src, size_t size,
+                                      wStream* WINPR_RESTRICT out)
 {
 	size_t offset = 0;
 
@@ -489,8 +496,9 @@ static BOOL freerdp_dsp_encode_gsm610(FREERDP_DSP_CONTEXT* context, const BYTE* 
 #endif
 
 #if defined(WITH_LAME)
-static BOOL freerdp_dsp_decode_mp3(FREERDP_DSP_CONTEXT* context, const BYTE* src, size_t size,
-                                   wStream* out)
+static BOOL freerdp_dsp_decode_mp3(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                   const BYTE* WINPR_RESTRICT src, size_t size,
+                                   wStream* WINPR_RESTRICT out)
 {
 	int rc;
 	short* pcm_l;
@@ -525,8 +533,9 @@ static BOOL freerdp_dsp_decode_mp3(FREERDP_DSP_CONTEXT* context, const BYTE* src
 	return TRUE;
 }
 
-static BOOL freerdp_dsp_encode_mp3(FREERDP_DSP_CONTEXT* context, const BYTE* src, size_t size,
-                                   wStream* out)
+static BOOL freerdp_dsp_encode_mp3(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                   const BYTE* WINPR_RESTRICT src, size_t size,
+                                   wStream* WINPR_RESTRICT out)
 {
 	size_t samples_per_channel;
 	int rc;
@@ -553,8 +562,9 @@ static BOOL freerdp_dsp_encode_mp3(FREERDP_DSP_CONTEXT* context, const BYTE* src
 #endif
 
 #if defined(WITH_FAAC)
-static BOOL freerdp_dsp_encode_faac(FREERDP_DSP_CONTEXT* context, const BYTE* src, size_t size,
-                                    wStream* out)
+static BOOL freerdp_dsp_encode_faac(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                    const BYTE* WINPR_RESTRICT src, size_t size,
+                                    wStream* WINPR_RESTRICT out)
 {
 	const int16_t* inSamples = (const int16_t*)src;
 	unsigned int bpp;
@@ -593,8 +603,9 @@ static BOOL freerdp_dsp_encode_faac(FREERDP_DSP_CONTEXT* context, const BYTE* sr
 #endif
 
 #if defined(WITH_OPUS)
-static BOOL freerdp_dsp_decode_opus(FREERDP_DSP_CONTEXT* context, const BYTE* src, size_t size,
-                                    wStream* out)
+static BOOL freerdp_dsp_decode_opus(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                    const BYTE* WINPR_RESTRICT src, size_t size,
+                                    wStream* WINPR_RESTRICT out)
 {
 	size_t max_size = 5760;
 	int frames;
@@ -616,8 +627,9 @@ static BOOL freerdp_dsp_decode_opus(FREERDP_DSP_CONTEXT* context, const BYTE* sr
 	return TRUE;
 }
 
-static BOOL freerdp_dsp_encode_opus(FREERDP_DSP_CONTEXT* context, const BYTE* src, size_t size,
-                                    wStream* out)
+static BOOL freerdp_dsp_encode_opus(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                    const BYTE* WINPR_RESTRICT src, size_t size,
+                                    wStream* WINPR_RESTRICT out)
 {
 	if (!context || !src || !out)
 		return FALSE;
@@ -638,8 +650,9 @@ static BOOL freerdp_dsp_encode_opus(FREERDP_DSP_CONTEXT* context, const BYTE* sr
 #endif
 
 #if defined(WITH_FAAD2)
-static BOOL freerdp_dsp_decode_faad(FREERDP_DSP_CONTEXT* context, const BYTE* src, size_t size,
-                                    wStream* out)
+static BOOL freerdp_dsp_decode_faad(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                    const BYTE* WINPR_RESTRICT src, size_t size,
+                                    wStream* WINPR_RESTRICT out)
 {
 	NeAACDecFrameInfo info;
 	size_t offset = 0;
@@ -725,7 +738,7 @@ static const struct
 	                          { 1, 4 }, { 5, 4 }, { 2, 0 }, { 6, 0 }, { 2, 4 }, { 6, 4 },
 	                          { 3, 0 }, { 7, 0 }, { 3, 4 }, { 7, 4 } };
 
-static BYTE dsp_encode_ima_adpcm_sample(ADPCM* adpcm, int channel, INT16 sample)
+static BYTE dsp_encode_ima_adpcm_sample(ADPCM* WINPR_RESTRICT adpcm, int channel, INT16 sample)
 {
 	INT32 e;
 	INT32 d;
@@ -788,8 +801,9 @@ static BYTE dsp_encode_ima_adpcm_sample(ADPCM* adpcm, int channel, INT16 sample)
 	return enc;
 }
 
-static BOOL freerdp_dsp_encode_ima_adpcm(FREERDP_DSP_CONTEXT* context, const BYTE* src, size_t size,
-                                         wStream* out)
+static BOOL freerdp_dsp_encode_ima_adpcm(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                         const BYTE* WINPR_RESTRICT src, size_t size,
+                                         wStream* WINPR_RESTRICT out)
 {
 	INT16 sample;
 	BYTE encoded;
@@ -873,7 +887,8 @@ static const INT32 ms_adpcm_coeffs1[7] = { 256, 512, 0, 192, 240, 460, 392 };
 
 static const INT32 ms_adpcm_coeffs2[7] = { 0, -256, 0, 64, 0, -208, -232 };
 
-static INLINE INT16 freerdp_dsp_decode_ms_adpcm_sample(ADPCM* adpcm, BYTE sample, int channel)
+static INLINE INT16 freerdp_dsp_decode_ms_adpcm_sample(ADPCM* WINPR_RESTRICT adpcm, BYTE sample,
+                                                       int channel)
 {
 	INT8 nibble;
 	INT32 presample;
@@ -898,8 +913,9 @@ static INLINE INT16 freerdp_dsp_decode_ms_adpcm_sample(ADPCM* adpcm, BYTE sample
 	return (INT16)presample;
 }
 
-static BOOL freerdp_dsp_decode_ms_adpcm(FREERDP_DSP_CONTEXT* context, const BYTE* src, size_t size,
-                                        wStream* out)
+static BOOL freerdp_dsp_decode_ms_adpcm(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                        const BYTE* WINPR_RESTRICT src, size_t size,
+                                        wStream* WINPR_RESTRICT out)
 {
 	BYTE sample;
 	const size_t out_size = size * 4;
@@ -979,7 +995,8 @@ static BOOL freerdp_dsp_decode_ms_adpcm(FREERDP_DSP_CONTEXT* context, const BYTE
 	return TRUE;
 }
 
-static BYTE freerdp_dsp_encode_ms_adpcm_sample(ADPCM* adpcm, INT32 sample, int channel)
+static BYTE freerdp_dsp_encode_ms_adpcm_sample(ADPCM* WINPR_RESTRICT adpcm, INT32 sample,
+                                               int channel)
 {
 	INT32 presample;
 	INT32 errordelta;
@@ -1014,8 +1031,9 @@ static BYTE freerdp_dsp_encode_ms_adpcm_sample(ADPCM* adpcm, INT32 sample, int c
 	return ((BYTE)errordelta) & 0x0F;
 }
 
-static BOOL freerdp_dsp_encode_ms_adpcm(FREERDP_DSP_CONTEXT* context, const BYTE* src, size_t size,
-                                        wStream* out)
+static BOOL freerdp_dsp_encode_ms_adpcm(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                        const BYTE* WINPR_RESTRICT src, size_t size,
+                                        wStream* WINPR_RESTRICT out)
 {
 	size_t start;
 	INT32 sample;
@@ -1222,8 +1240,9 @@ void freerdp_dsp_context_free(FREERDP_DSP_CONTEXT* context)
 #endif
 }
 
-BOOL freerdp_dsp_encode(FREERDP_DSP_CONTEXT* context, const AUDIO_FORMAT* srcFormat,
-                        const BYTE* data, size_t length, wStream* out)
+BOOL freerdp_dsp_encode(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                        const AUDIO_FORMAT* WINPR_RESTRICT srcFormat,
+                        const BYTE* WINPR_RESTRICT data, size_t length, wStream* WINPR_RESTRICT out)
 {
 #if defined(WITH_DSP_FFMPEG)
 	return freerdp_dsp_ffmpeg_encode(context, srcFormat, data, length, out);
@@ -1287,8 +1306,9 @@ BOOL freerdp_dsp_encode(FREERDP_DSP_CONTEXT* context, const AUDIO_FORMAT* srcFor
 #endif
 }
 
-BOOL freerdp_dsp_decode(FREERDP_DSP_CONTEXT* context, const AUDIO_FORMAT* srcFormat,
-                        const BYTE* data, size_t length, wStream* out)
+BOOL freerdp_dsp_decode(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                        const AUDIO_FORMAT* WINPR_RESTRICT srcFormat,
+                        const BYTE* WINPR_RESTRICT data, size_t length, wStream* WINPR_RESTRICT out)
 {
 #if defined(WITH_DSP_FFMPEG)
 	return freerdp_dsp_ffmpeg_decode(context, srcFormat, data, length, out);
@@ -1339,7 +1359,7 @@ BOOL freerdp_dsp_decode(FREERDP_DSP_CONTEXT* context, const AUDIO_FORMAT* srcFor
 #endif
 }
 
-BOOL freerdp_dsp_supports_format(const AUDIO_FORMAT* format, BOOL encode)
+BOOL freerdp_dsp_supports_format(const AUDIO_FORMAT* WINPR_RESTRICT format, BOOL encode)
 {
 #if defined(WITH_DSP_FFMPEG)
 	return freerdp_dsp_ffmpeg_supports_format(format, encode);
@@ -1404,7 +1424,8 @@ BOOL freerdp_dsp_supports_format(const AUDIO_FORMAT* format, BOOL encode)
 #endif
 }
 
-BOOL freerdp_dsp_context_reset(FREERDP_DSP_CONTEXT* context, const AUDIO_FORMAT* targetFormat,
+BOOL freerdp_dsp_context_reset(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                               const AUDIO_FORMAT* WINPR_RESTRICT targetFormat,
                                UINT32 FramesPerPacket)
 {
 #if defined(WITH_DSP_FFMPEG)

--- a/libfreerdp/codec/dsp_ffmpeg.c
+++ b/libfreerdp/codec/dsp_ffmpeg.c
@@ -92,7 +92,7 @@ static BOOL ffmpeg_codec_is_filtered(enum AVCodecID id, BOOL encoder)
 	}
 }
 
-static enum AVCodecID ffmpeg_get_avcodec(const AUDIO_FORMAT* format)
+static enum AVCodecID ffmpeg_get_avcodec(const AUDIO_FORMAT* WINPR_RESTRICT format)
 {
 	if (!format)
 		return AV_CODEC_ID_NONE;
@@ -144,7 +144,7 @@ static enum AVCodecID ffmpeg_get_avcodec(const AUDIO_FORMAT* format)
 	}
 }
 
-static int ffmpeg_sample_format(const AUDIO_FORMAT* format)
+static int ffmpeg_sample_format(const AUDIO_FORMAT* WINPR_RESTRICT format)
 {
 	switch (format->wFormatTag)
 	{
@@ -184,7 +184,7 @@ static int ffmpeg_sample_format(const AUDIO_FORMAT* format)
 	}
 }
 
-static void ffmpeg_close_context(FREERDP_DSP_CONTEXT* context)
+static void ffmpeg_close_context(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context)
 {
 	if (context)
 	{
@@ -223,7 +223,7 @@ static void ffmpeg_close_context(FREERDP_DSP_CONTEXT* context)
 	}
 }
 
-static BOOL ffmpeg_open_context(FREERDP_DSP_CONTEXT* context)
+static BOOL ffmpeg_open_context(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context)
 {
 	int ret = 0;
 
@@ -370,7 +370,8 @@ fail:
 }
 
 #if defined(SWRESAMPLE_FOUND)
-static BOOL ffmpeg_resample_frame(SwrContext* context, AVFrame* in, AVFrame* out)
+static BOOL ffmpeg_resample_frame(SwrContext* WINPR_RESTRICT context, AVFrame* WINPR_RESTRICT in,
+                                  AVFrame* WINPR_RESTRICT out)
 {
 	int ret = 0;
 
@@ -401,7 +402,8 @@ static BOOL ffmpeg_resample_frame(SwrContext* context, AVFrame* in, AVFrame* out
 	return TRUE;
 }
 #else
-static BOOL ffmpeg_resample_frame(AVAudioResampleContext* context, AVFrame* in, AVFrame* out)
+static BOOL ffmpeg_resample_frame(AVAudioResampleContext* WINPR_RESTRICT context,
+                                  AVFrame* WINPR_RESTRICT in, AVFrame* WINPR_RESTRICT out)
 {
 	int ret;
 
@@ -433,8 +435,8 @@ static BOOL ffmpeg_resample_frame(AVAudioResampleContext* context, AVFrame* in, 
 }
 #endif
 
-static BOOL ffmpeg_encode_frame(AVCodecContext* context, AVFrame* in, AVPacket* packet,
-                                wStream* out)
+static BOOL ffmpeg_encode_frame(AVCodecContext* WINPR_RESTRICT context, AVFrame* WINPR_RESTRICT in,
+                                AVPacket* WINPR_RESTRICT packet, wStream* WINPR_RESTRICT out)
 {
 	if (in->format == AV_SAMPLE_FMT_FLTP)
 	{
@@ -497,8 +499,9 @@ static BOOL ffmpeg_encode_frame(AVCodecContext* context, AVFrame* in, AVPacket* 
 	return TRUE;
 }
 
-static BOOL ffmpeg_fill_frame(AVFrame* frame, const AUDIO_FORMAT* inputFormat, const BYTE* data,
-                              size_t size)
+static BOOL ffmpeg_fill_frame(AVFrame* WINPR_RESTRICT frame,
+                              const AUDIO_FORMAT* WINPR_RESTRICT inputFormat,
+                              const BYTE* WINPR_RESTRICT data, size_t size)
 {
 	int ret = 0;
 	int bpp = 0;
@@ -525,8 +528,9 @@ static BOOL ffmpeg_fill_frame(AVFrame* frame, const AUDIO_FORMAT* inputFormat, c
 	return TRUE;
 }
 #if defined(SWRESAMPLE_FOUND)
-static BOOL ffmpeg_decode(AVCodecContext* dec_ctx, AVPacket* pkt, AVFrame* frame,
-                          SwrContext* resampleContext, AVFrame* resampled, wStream* out)
+static BOOL ffmpeg_decode(AVCodecContext* WINPR_RESTRICT dec_ctx, AVPacket* WINPR_RESTRICT pkt,
+                          AVFrame* WINPR_RESTRICT frame, SwrContext* WINPR_RESTRICT resampleContext,
+                          AVFrame* WINPR_RESTRICT resampled, wStream* WINPR_RESTRICT out)
 #else
 static BOOL ffmpeg_decode(AVCodecContext* dec_ctx, AVPacket* pkt, AVFrame* frame,
                           AVAudioResampleContext* resampleContext, AVFrame* resampled, wStream* out)
@@ -611,7 +615,7 @@ static BOOL ffmpeg_decode(AVCodecContext* dec_ctx, AVPacket* pkt, AVFrame* frame
 	return TRUE;
 }
 
-BOOL freerdp_dsp_ffmpeg_supports_format(const AUDIO_FORMAT* format, BOOL encode)
+BOOL freerdp_dsp_ffmpeg_supports_format(const AUDIO_FORMAT* WINPR_RESTRICT format, BOOL encode)
 {
 	enum AVCodecID id = ffmpeg_get_avcodec(format);
 
@@ -658,8 +662,8 @@ void freerdp_dsp_ffmpeg_context_free(FREERDP_DSP_CONTEXT* context)
 	}
 }
 
-BOOL freerdp_dsp_ffmpeg_context_reset(FREERDP_DSP_CONTEXT* context,
-                                      const AUDIO_FORMAT* targetFormat)
+BOOL freerdp_dsp_ffmpeg_context_reset(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                      const AUDIO_FORMAT* WINPR_RESTRICT targetFormat)
 {
 	if (!context || !targetFormat)
 		return FALSE;
@@ -669,9 +673,11 @@ BOOL freerdp_dsp_ffmpeg_context_reset(FREERDP_DSP_CONTEXT* context,
 	return ffmpeg_open_context(context);
 }
 
-static BOOL freerdp_dsp_channel_mix(FREERDP_DSP_CONTEXT* context, const BYTE* src, size_t size,
-                                    const AUDIO_FORMAT* srcFormat, const BYTE** data,
-                                    size_t* length, AUDIO_FORMAT* dstFormat)
+static BOOL freerdp_dsp_channel_mix(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                                    const BYTE* WINPR_RESTRICT src, size_t size,
+                                    const AUDIO_FORMAT* WINPR_RESTRICT srcFormat,
+                                    const BYTE** WINPR_RESTRICT data, size_t* WINPR_RESTRICT length,
+                                    AUDIO_FORMAT* WINPR_RESTRICT dstFormat)
 {
 	UINT32 bpp = 0;
 	size_t samples = 0;
@@ -756,8 +762,10 @@ static BOOL freerdp_dsp_channel_mix(FREERDP_DSP_CONTEXT* context, const BYTE* sr
 	return FALSE;
 }
 
-BOOL freerdp_dsp_ffmpeg_encode(FREERDP_DSP_CONTEXT* context, const AUDIO_FORMAT* format,
-                               const BYTE* data, size_t length, wStream* out)
+BOOL freerdp_dsp_ffmpeg_encode(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                               const AUDIO_FORMAT* WINPR_RESTRICT format,
+                               const BYTE* WINPR_RESTRICT data, size_t length,
+                               wStream* WINPR_RESTRICT out)
 {
 	AUDIO_FORMAT fmt = { 0 };
 
@@ -830,8 +838,10 @@ BOOL freerdp_dsp_ffmpeg_encode(FREERDP_DSP_CONTEXT* context, const AUDIO_FORMAT*
 	}
 }
 
-BOOL freerdp_dsp_ffmpeg_decode(FREERDP_DSP_CONTEXT* context, const AUDIO_FORMAT* srcFormat,
-                               const BYTE* data, size_t length, wStream* out)
+BOOL freerdp_dsp_ffmpeg_decode(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
+                               const AUDIO_FORMAT* WINPR_RESTRICT srcFormat,
+                               const BYTE* WINPR_RESTRICT data, size_t length,
+                               wStream* WINPR_RESTRICT out)
 {
 	if (!context || !srcFormat || !data || !out || context->encoder)
 		return FALSE;

--- a/libfreerdp/codec/h264.h
+++ b/libfreerdp/codec/h264.h
@@ -30,14 +30,16 @@ extern "C"
 {
 #endif
 
-	typedef BOOL (*pfnH264SubsystemInit)(H264_CONTEXT* h264);
-	typedef void (*pfnH264SubsystemUninit)(H264_CONTEXT* h264);
+	typedef BOOL (*pfnH264SubsystemInit)(H264_CONTEXT* WINPR_RESTRICT h264);
+	typedef void (*pfnH264SubsystemUninit)(H264_CONTEXT* WINPR_RESTRICT h264);
 
-	typedef int (*pfnH264SubsystemDecompress)(H264_CONTEXT* h264, const BYTE* pSrcData,
-	                                          UINT32 SrcSize);
-	typedef int (*pfnH264SubsystemCompress)(H264_CONTEXT* h264, const BYTE** pSrcYuv,
-	                                        const UINT32* pStride, BYTE** ppDstData,
-	                                        UINT32* pDstSize);
+	typedef int (*pfnH264SubsystemDecompress)(H264_CONTEXT* WINPR_RESTRICT h264,
+	                                          const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize);
+	typedef int (*pfnH264SubsystemCompress)(H264_CONTEXT* WINPR_RESTRICT h264,
+	                                        const BYTE** WINPR_RESTRICT pSrcYuv,
+	                                        const UINT32* WINPR_RESTRICT pStride,
+	                                        BYTE** WINPR_RESTRICT ppDstData,
+	                                        UINT32* WINPR_RESTRICT pDstSize);
 
 	struct S_H264_CONTEXT_SUBSYSTEM
 	{

--- a/libfreerdp/codec/h264_ffmpeg.c
+++ b/libfreerdp/codec/h264_ffmpeg.c
@@ -91,7 +91,7 @@ typedef struct
 #endif
 } H264_CONTEXT_LIBAVCODEC;
 
-static void libavcodec_destroy_encoder(H264_CONTEXT* h264)
+static void libavcodec_destroy_encoder(H264_CONTEXT* WINPR_RESTRICT h264)
 {
 	H264_CONTEXT_LIBAVCODEC* sys = NULL;
 
@@ -114,7 +114,7 @@ static void libavcodec_destroy_encoder(H264_CONTEXT* h264)
 	sys->codecEncoderContext = NULL;
 }
 
-static BOOL libavcodec_create_encoder(H264_CONTEXT* h264)
+static BOOL libavcodec_create_encoder(H264_CONTEXT* WINPR_RESTRICT h264)
 {
 	BOOL recreate = FALSE;
 	H264_CONTEXT_LIBAVCODEC* sys = NULL;
@@ -186,7 +186,8 @@ EXCEPTION:
 	return FALSE;
 }
 
-static int libavcodec_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSize)
+static int libavcodec_decompress(H264_CONTEXT* WINPR_RESTRICT h264,
+                                 const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize)
 {
 	union
 	{
@@ -324,8 +325,10 @@ fail:
 	return rc;
 }
 
-static int libavcodec_compress(H264_CONTEXT* h264, const BYTE** pSrcYuv, const UINT32* pStride,
-                               BYTE** ppDstData, UINT32* pDstSize)
+static int libavcodec_compress(H264_CONTEXT* WINPR_RESTRICT h264,
+                               const BYTE** WINPR_RESTRICT pSrcYuv,
+                               const UINT32* WINPR_RESTRICT pStride,
+                               BYTE** WINPR_RESTRICT ppDstData, UINT32* WINPR_RESTRICT pDstSize)
 {
 	union
 	{
@@ -454,7 +457,7 @@ fail:
 	return rc;
 }
 
-static void libavcodec_uninit(H264_CONTEXT* h264)
+static void libavcodec_uninit(H264_CONTEXT* WINPR_RESTRICT h264)
 {
 	WINPR_ASSERT(h264);
 
@@ -577,7 +580,7 @@ static enum AVPixelFormat libavcodec_get_format(struct AVCodecContext* ctx,
 }
 #endif
 
-static BOOL libavcodec_init(H264_CONTEXT* h264)
+static BOOL libavcodec_init(H264_CONTEXT* WINPR_RESTRICT h264)
 {
 	H264_CONTEXT_LIBAVCODEC* sys = NULL;
 

--- a/libfreerdp/codec/h264_openh264.c
+++ b/libfreerdp/codec/h264_openh264.c
@@ -68,13 +68,15 @@ static const char* openh264_library_names[] = {
 };
 #endif
 
-static void openh264_trace_callback(H264_CONTEXT* h264, int level, const char* message)
+static void openh264_trace_callback(H264_CONTEXT* WINPR_RESTRICT h264, int level,
+                                    const char* WINPR_RESTRICT message)
 {
 	if (h264)
 		WLog_Print(h264->log, WLOG_TRACE, "%d - %s", level, message);
 }
 
-static int openh264_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSize)
+static int openh264_decompress(H264_CONTEXT* WINPR_RESTRICT h264,
+                               const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize)
 {
 	DECODING_STATE state = dsInvalidArgument;
 	SBufferInfo sBufferInfo = { 0 };
@@ -179,8 +181,10 @@ static int openh264_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 
 	return 1;
 }
 
-static int openh264_compress(H264_CONTEXT* h264, const BYTE** pYUVData, const UINT32* iStride,
-                             BYTE** ppDstData, UINT32* pDstSize)
+static int openh264_compress(H264_CONTEXT* WINPR_RESTRICT h264,
+                             const BYTE** WINPR_RESTRICT pYUVData,
+                             const UINT32* WINPR_RESTRICT iStride, BYTE** WINPR_RESTRICT ppDstData,
+                             UINT32* WINPR_RESTRICT pDstSize)
 {
 	int status = 0;
 	SFrameBSInfo info = { 0 };
@@ -384,7 +388,7 @@ static int openh264_compress(H264_CONTEXT* h264, const BYTE** pYUVData, const UI
 	return 1;
 }
 
-static void openh264_uninit(H264_CONTEXT* h264)
+static void openh264_uninit(H264_CONTEXT* WINPR_RESTRICT h264)
 {
 	H264_CONTEXT_OPENH264* sysContexts = NULL;
 
@@ -483,7 +487,7 @@ static BOOL openh264_load_functionpointers(H264_CONTEXT* h264, const char* name)
 }
 #endif
 
-static BOOL openh264_init(H264_CONTEXT* h264)
+static BOOL openh264_init(H264_CONTEXT* WINPR_RESTRICT h264)
 {
 #if defined(WITH_OPENH264_LOADING)
 	BOOL success = FALSE;

--- a/libfreerdp/codec/include/bitmap.c
+++ b/libfreerdp/codec/include/bitmap.c
@@ -24,7 +24,8 @@
 /**
  * Write a foreground/background image to a destination buffer.
  */
-static INLINE BYTE* WRITEFGBGIMAGE(BYTE* pbDest, const BYTE* pbDestEnd, UINT32 rowDelta,
+static INLINE BYTE* WRITEFGBGIMAGE(BYTE* WINPR_RESTRICT pbDest,
+                                   const BYTE* WINPR_RESTRICT pbDestEnd, UINT32 rowDelta,
                                    BYTE bitmask, PIXEL fgPel, INT32 cBits)
 {
 	PIXEL xorPixel;
@@ -58,7 +59,8 @@ static INLINE BYTE* WRITEFGBGIMAGE(BYTE* pbDest, const BYTE* pbDestEnd, UINT32 r
  * Write a foreground/background image to a destination buffer
  * for the first line of compressed data.
  */
-static INLINE BYTE* WRITEFIRSTLINEFGBGIMAGE(BYTE* pbDest, const BYTE* pbDestEnd, BYTE bitmask,
+static INLINE BYTE* WRITEFIRSTLINEFGBGIMAGE(BYTE* WINPR_RESTRICT pbDest,
+                                            const BYTE* WINPR_RESTRICT pbDestEnd, BYTE bitmask,
                                             PIXEL fgPel, UINT32 cBits)
 {
 	BYTE mask = 0x01;
@@ -89,8 +91,9 @@ static INLINE BYTE* WRITEFIRSTLINEFGBGIMAGE(BYTE* pbDest, const BYTE* pbDestEnd,
 /**
  * Decompress an RLE compressed bitmap.
  */
-static INLINE BOOL RLEDECOMPRESS(const BYTE* pbSrcBuffer, UINT32 cbSrcBuffer, BYTE* pbDestBuffer,
-                                 UINT32 rowDelta, UINT32 width, UINT32 height)
+static INLINE BOOL RLEDECOMPRESS(const BYTE* WINPR_RESTRICT pbSrcBuffer, UINT32 cbSrcBuffer,
+                                 BYTE* WINPR_RESTRICT pbDestBuffer, UINT32 rowDelta, UINT32 width,
+                                 UINT32 height)
 {
 #if defined(WITH_DEBUG_CODECS)
 	char sbuffer[128] = { 0 };

--- a/libfreerdp/codec/interleaved.c
+++ b/libfreerdp/codec/interleaved.c
@@ -525,11 +525,12 @@ struct S_BITMAP_INTERLEAVED_CONTEXT
 	wStream* bts;
 };
 
-BOOL interleaved_decompress(BITMAP_INTERLEAVED_CONTEXT* interleaved, const BYTE* pSrcData,
-                            UINT32 SrcSize, UINT32 nSrcWidth, UINT32 nSrcHeight, UINT32 bpp,
-                            BYTE* pDstData, UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst,
-                            UINT32 nYDst, UINT32 nDstWidth, UINT32 nDstHeight,
-                            const gdiPalette* palette)
+BOOL interleaved_decompress(BITMAP_INTERLEAVED_CONTEXT* WINPR_RESTRICT interleaved,
+                            const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize, UINT32 nSrcWidth,
+                            UINT32 nSrcHeight, UINT32 bpp, BYTE* WINPR_RESTRICT pDstData,
+                            UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
+                            UINT32 nDstWidth, UINT32 nDstHeight,
+                            const gdiPalette* WINPR_RESTRICT palette)
 {
 	UINT32 scanline = 0;
 	UINT32 SrcFormat = 0;
@@ -632,10 +633,11 @@ BOOL interleaved_decompress(BITMAP_INTERLEAVED_CONTEXT* interleaved, const BYTE*
 	return TRUE;
 }
 
-BOOL interleaved_compress(BITMAP_INTERLEAVED_CONTEXT* interleaved, BYTE* pDstData, UINT32* pDstSize,
-                          UINT32 nWidth, UINT32 nHeight, const BYTE* pSrcData, UINT32 SrcFormat,
-                          UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc, const gdiPalette* palette,
-                          UINT32 bpp)
+BOOL interleaved_compress(BITMAP_INTERLEAVED_CONTEXT* WINPR_RESTRICT interleaved,
+                          BYTE* WINPR_RESTRICT pDstData, UINT32* pDstSize, UINT32 nWidth,
+                          UINT32 nHeight, const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcFormat,
+                          UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc,
+                          const gdiPalette* WINPR_RESTRICT palette, UINT32 bpp)
 {
 	BOOL status = 0;
 	wStream* s = NULL;
@@ -705,7 +707,7 @@ BOOL interleaved_compress(BITMAP_INTERLEAVED_CONTEXT* interleaved, BYTE* pDstDat
 	return status;
 }
 
-BOOL bitmap_interleaved_context_reset(BITMAP_INTERLEAVED_CONTEXT* interleaved)
+BOOL bitmap_interleaved_context_reset(BITMAP_INTERLEAVED_CONTEXT* WINPR_RESTRICT interleaved)
 {
 	if (!interleaved)
 		return FALSE;
@@ -743,7 +745,7 @@ fail:
 	return NULL;
 }
 
-void bitmap_interleaved_context_free(BITMAP_INTERLEAVED_CONTEXT* interleaved)
+void bitmap_interleaved_context_free(BITMAP_INTERLEAVED_CONTEXT* WINPR_RESTRICT interleaved)
 {
 	if (!interleaved)
 		return;

--- a/libfreerdp/codec/nsc.c
+++ b/libfreerdp/codec/nsc.c
@@ -46,7 +46,7 @@
 	} while (0)
 #endif
 
-static BOOL nsc_decode(NSC_CONTEXT* context)
+static BOOL nsc_decode(NSC_CONTEXT* WINPR_RESTRICT context)
 {
 	UINT16 rw = 0;
 	BYTE shift = 0;
@@ -188,7 +188,7 @@ static BOOL nsc_rle_decode(const BYTE* WINPR_RESTRICT in, size_t inSize, BYTE* W
 	return TRUE;
 }
 
-static BOOL nsc_rle_decompress_data(NSC_CONTEXT* context)
+static BOOL nsc_rle_decompress_data(NSC_CONTEXT* WINPR_RESTRICT context)
 {
 	if (!context)
 		return FALSE;
@@ -236,7 +236,7 @@ static BOOL nsc_rle_decompress_data(NSC_CONTEXT* context)
 	return TRUE;
 }
 
-static BOOL nsc_stream_initialize(NSC_CONTEXT* context, wStream* s)
+static BOOL nsc_stream_initialize(NSC_CONTEXT* WINPR_RESTRICT context, wStream* WINPR_RESTRICT s)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(context->priv);
@@ -265,7 +265,7 @@ static BOOL nsc_stream_initialize(NSC_CONTEXT* context, wStream* s)
 	return Stream_CheckAndLogRequiredLengthWLog(context->priv->log, s, total);
 }
 
-static BOOL nsc_context_initialize(NSC_CONTEXT* context, wStream* s)
+static BOOL nsc_context_initialize(NSC_CONTEXT* WINPR_RESTRICT context, wStream* WINPR_RESTRICT s)
 {
 	if (!nsc_stream_initialize(context, s))
 		return FALSE;
@@ -317,7 +317,7 @@ static BOOL nsc_context_initialize(NSC_CONTEXT* context, wStream* s)
 	return TRUE;
 }
 
-static void nsc_profiler_print(NSC_CONTEXT_PRIV* priv)
+static void nsc_profiler_print(NSC_CONTEXT_PRIV* WINPR_RESTRICT priv)
 {
 	WINPR_UNUSED(priv);
 
@@ -329,7 +329,7 @@ static void nsc_profiler_print(NSC_CONTEXT_PRIV* priv)
 	PROFILER_PRINT_FOOTER
 }
 
-BOOL nsc_context_reset(NSC_CONTEXT* context, UINT32 width, UINT32 height)
+BOOL nsc_context_reset(NSC_CONTEXT* WINPR_RESTRICT context, UINT32 width, UINT32 height)
 {
 	if (!context)
 		return FALSE;

--- a/libfreerdp/codec/nsc_encode.c
+++ b/libfreerdp/codec/nsc_encode.c
@@ -54,9 +54,10 @@ typedef struct
 	UINT8 ChromaSubsamplingLevel;
 } NSC_MESSAGE;
 
-static BOOL nsc_write_message(NSC_CONTEXT* context, wStream* s, const NSC_MESSAGE* message);
+static BOOL nsc_write_message(NSC_CONTEXT* WINPR_RESTRICT context, wStream* WINPR_RESTRICT s,
+                              const NSC_MESSAGE* WINPR_RESTRICT message);
 
-static BOOL nsc_context_initialize_encode(NSC_CONTEXT* context)
+static BOOL nsc_context_initialize_encode(NSC_CONTEXT* WINPR_RESTRICT context)
 {
 	UINT32 length = 0;
 	UINT32 tempWidth = 0;
@@ -109,7 +110,8 @@ fail:
 	return FALSE;
 }
 
-static BOOL nsc_encode_argb_to_aycocg(NSC_CONTEXT* context, const BYTE* data, UINT32 scanline)
+static BOOL nsc_encode_argb_to_aycocg(NSC_CONTEXT* WINPR_RESTRICT context,
+                                      const BYTE* WINPR_RESTRICT data, UINT32 scanline)
 {
 	UINT16 y = 0;
 	UINT16 rw = 0;
@@ -268,7 +270,7 @@ static BOOL nsc_encode_argb_to_aycocg(NSC_CONTEXT* context, const BYTE* data, UI
 	return TRUE;
 }
 
-static BOOL nsc_encode_subsampling(NSC_CONTEXT* context)
+static BOOL nsc_encode_subsampling(NSC_CONTEXT* WINPR_RESTRICT context)
 {
 	UINT32 tempWidth = 0;
 	UINT32 tempHeight = 0;
@@ -312,7 +314,8 @@ static BOOL nsc_encode_subsampling(NSC_CONTEXT* context)
 	return TRUE;
 }
 
-BOOL nsc_encode(NSC_CONTEXT* context, const BYTE* bmpdata, UINT32 rowstride)
+BOOL nsc_encode(NSC_CONTEXT* WINPR_RESTRICT context, const BYTE* WINPR_RESTRICT bmpdata,
+                UINT32 rowstride)
 {
 	if (!context || !bmpdata || (rowstride == 0))
 		return FALSE;
@@ -329,7 +332,8 @@ BOOL nsc_encode(NSC_CONTEXT* context, const BYTE* bmpdata, UINT32 rowstride)
 	return TRUE;
 }
 
-static UINT32 nsc_rle_encode(const BYTE* in, BYTE* out, UINT32 originalSize)
+static UINT32 nsc_rle_encode(const BYTE* WINPR_RESTRICT in, BYTE* WINPR_RESTRICT out,
+                             UINT32 originalSize)
 {
 	UINT32 left = 0;
 	UINT32 runlength = 1;
@@ -383,7 +387,7 @@ static UINT32 nsc_rle_encode(const BYTE* in, BYTE* out, UINT32 originalSize)
 	return planeSize;
 }
 
-static void nsc_rle_compress_data(NSC_CONTEXT* context)
+static void nsc_rle_compress_data(NSC_CONTEXT* WINPR_RESTRICT context)
 {
 	UINT32 planeSize = 0;
 	UINT32 originalSize = 0;
@@ -412,8 +416,8 @@ static void nsc_rle_compress_data(NSC_CONTEXT* context)
 	}
 }
 
-static UINT32 nsc_compute_byte_count(NSC_CONTEXT* context, UINT32* ByteCount, UINT32 width,
-                                     UINT32 height)
+static UINT32 nsc_compute_byte_count(NSC_CONTEXT* WINPR_RESTRICT context,
+                                     UINT32* WINPR_RESTRICT ByteCount, UINT32 width, UINT32 height)
 {
 	UINT32 tempWidth = 0;
 	UINT32 tempHeight = 0;
@@ -440,7 +444,8 @@ static UINT32 nsc_compute_byte_count(NSC_CONTEXT* context, UINT32* ByteCount, UI
 	return maxPlaneSize;
 }
 
-BOOL nsc_write_message(NSC_CONTEXT* context, wStream* s, const NSC_MESSAGE* message)
+BOOL nsc_write_message(NSC_CONTEXT* WINPR_RESTRICT context, wStream* WINPR_RESTRICT s,
+                       const NSC_MESSAGE* WINPR_RESTRICT message)
 {
 	UINT32 totalPlaneByteCount = 0;
 	totalPlaneByteCount = message->LumaPlaneByteCount + message->OrangeChromaPlaneByteCount +
@@ -476,8 +481,9 @@ BOOL nsc_write_message(NSC_CONTEXT* context, wStream* s, const NSC_MESSAGE* mess
 	return TRUE;
 }
 
-BOOL nsc_compose_message(NSC_CONTEXT* context, wStream* s, const BYTE* WINPR_RESTRICT data,
-                         UINT32 width, UINT32 height, UINT32 scanline)
+BOOL nsc_compose_message(NSC_CONTEXT* WINPR_RESTRICT context, wStream* WINPR_RESTRICT s,
+                         const BYTE* WINPR_RESTRICT data, UINT32 width, UINT32 height,
+                         UINT32 scanline)
 {
 	BOOL rc = 0;
 	NSC_MESSAGE message = { 0 };
@@ -515,9 +521,9 @@ BOOL nsc_compose_message(NSC_CONTEXT* context, wStream* s, const BYTE* WINPR_RES
 	return nsc_write_message(context, s, &message);
 }
 
-BOOL nsc_decompose_message(NSC_CONTEXT* context, wStream* s, BYTE* WINPR_RESTRICT bmpdata, UINT32 x,
-                           UINT32 y, UINT32 width, UINT32 height, UINT32 rowstride, UINT32 format,
-                           UINT32 flip)
+BOOL nsc_decompose_message(NSC_CONTEXT* WINPR_RESTRICT context, wStream* WINPR_RESTRICT s,
+                           BYTE* WINPR_RESTRICT bmpdata, UINT32 x, UINT32 y, UINT32 width,
+                           UINT32 height, UINT32 rowstride, UINT32 format, UINT32 flip)
 {
 	size_t size = Stream_GetRemainingLength(s);
 

--- a/libfreerdp/codec/nsc_encode.h
+++ b/libfreerdp/codec/nsc_encode.h
@@ -24,6 +24,7 @@
 
 #include <freerdp/api.h>
 
-FREERDP_LOCAL BOOL nsc_encode(NSC_CONTEXT* context, const BYTE* bmpdata, UINT32 rowstride);
+FREERDP_LOCAL BOOL nsc_encode(NSC_CONTEXT* WINPR_RESTRICT context,
+                              const BYTE* WINPR_RESTRICT bmpdata, UINT32 rowstride);
 
 #endif /* FREERDP_LIB_CODEC_NSC_ENCODE_H */

--- a/libfreerdp/codec/planar.c
+++ b/libfreerdp/codec/planar.c
@@ -22,6 +22,7 @@
 #include <freerdp/config.h>
 
 #include <winpr/crt.h>
+#include <winpr/wtypes.h>
 #include <winpr/assert.h>
 #include <winpr/print.h>
 
@@ -94,7 +95,7 @@ struct S_BITMAP_PLANAR_CONTEXT
 	BOOL topdown;
 };
 
-static INLINE UINT32 planar_invert_format(BITMAP_PLANAR_CONTEXT* planar, BOOL alpha,
+static INLINE UINT32 planar_invert_format(BITMAP_PLANAR_CONTEXT* WINPR_RESTRICT planar, BOOL alpha,
                                           UINT32 DstFormat)
 {
 
@@ -157,14 +158,16 @@ static INLINE UINT32 planar_invert_format(BITMAP_PLANAR_CONTEXT* planar, BOOL al
 	return DstFormat;
 }
 
-static INLINE BOOL freerdp_bitmap_planar_compress_plane_rle(const BYTE* plane, UINT32 width,
-                                                            UINT32 height, BYTE* outPlane,
-                                                            UINT32* dstSize);
-static INLINE BYTE* freerdp_bitmap_planar_delta_encode_plane(const BYTE* inPlane, UINT32 width,
-                                                             UINT32 height, BYTE* outPlane);
+static INLINE BOOL freerdp_bitmap_planar_compress_plane_rle(const BYTE* WINPR_RESTRICT plane,
+                                                            UINT32 width, UINT32 height,
+                                                            BYTE* outPlane,
+                                                            UINT32* WINPR_RESTRICT dstSize);
+static INLINE BYTE* freerdp_bitmap_planar_delta_encode_plane(const BYTE* WINPR_RESTRICT inPlane,
+                                                             UINT32 width, UINT32 height,
+                                                             BYTE* WINPR_RESTRICT outPlane);
 
-static INLINE INT32 planar_skip_plane_rle(const BYTE* pSrcData, UINT32 SrcSize, UINT32 nWidth,
-                                          UINT32 nHeight)
+static INLINE INT32 planar_skip_plane_rle(const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
+                                          UINT32 nWidth, UINT32 nHeight)
 {
 	UINT32 used = 0;
 	BYTE controlByte = 0;
@@ -227,8 +230,9 @@ static INLINE INT32 planar_skip_plane_rle(const BYTE* pSrcData, UINT32 SrcSize, 
 	return (INT32)used;
 }
 
-static INLINE INT32 planar_decompress_plane_rle_only(const BYTE* pSrcData, UINT32 SrcSize,
-                                                     BYTE* pDstData, UINT32 nWidth, UINT32 nHeight)
+static INLINE INT32 planar_decompress_plane_rle_only(const BYTE* WINPR_RESTRICT pSrcData,
+                                                     UINT32 SrcSize, BYTE* WINPR_RESTRICT pDstData,
+                                                     UINT32 nWidth, UINT32 nHeight)
 {
 	UINT32 pixel = 0;
 	UINT32 cRawBytes = 0;
@@ -346,10 +350,10 @@ static INLINE INT32 planar_decompress_plane_rle_only(const BYTE* pSrcData, UINT3
 	return (INT32)(srcp - pSrcData);
 }
 
-static INLINE INT32 planar_decompress_plane_rle(const BYTE* pSrcData, UINT32 SrcSize,
-                                                BYTE* pDstData, INT32 nDstStep, UINT32 nXDst,
-                                                UINT32 nYDst, UINT32 nWidth, UINT32 nHeight,
-                                                UINT32 nChannel, BOOL vFlip)
+static INLINE INT32 planar_decompress_plane_rle(const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
+                                                BYTE* WINPR_RESTRICT pDstData, INT32 nDstStep,
+                                                UINT32 nXDst, UINT32 nYDst, UINT32 nWidth,
+                                                UINT32 nHeight, UINT32 nChannel, BOOL vFlip)
 {
 	UINT32 pixel = 0;
 	UINT32 cRawBytes = 0;
@@ -523,8 +527,9 @@ static INLINE INT32 planar_set_plane(BYTE bValue, BYTE* pDstData, INT32 nDstStep
 	return 0;
 }
 
-static INLINE BOOL writeLine(BYTE** ppRgba, UINT32 DstFormat, UINT32 width, const BYTE** ppR,
-                             const BYTE** ppG, const BYTE** ppB, const BYTE** ppA)
+static INLINE BOOL writeLine(BYTE** WINPR_RESTRICT ppRgba, UINT32 DstFormat, UINT32 width,
+                             const BYTE** WINPR_RESTRICT ppR, const BYTE** WINPR_RESTRICT ppG,
+                             const BYTE** WINPR_RESTRICT ppB, const BYTE** WINPR_RESTRICT ppA)
 {
 	WINPR_ASSERT(ppRgba);
 	WINPR_ASSERT(ppR);
@@ -584,10 +589,11 @@ static INLINE BOOL writeLine(BYTE** ppRgba, UINT32 DstFormat, UINT32 width, cons
 	}
 }
 
-static INLINE BOOL planar_decompress_planes_raw(const BYTE* pSrcData[4], BYTE* pDstData,
-                                                UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst,
-                                                UINT32 nYDst, UINT32 nWidth, UINT32 nHeight,
-                                                BOOL vFlip, UINT32 totalHeight)
+static INLINE BOOL planar_decompress_planes_raw(const BYTE* WINPR_RESTRICT pSrcData[4],
+                                                BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat,
+                                                UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
+                                                UINT32 nWidth, UINT32 nHeight, BOOL vFlip,
+                                                UINT32 totalHeight)
 {
 	INT32 beg = 0;
 	INT32 end = 0;
@@ -649,9 +655,9 @@ static INLINE BOOL planar_decompress_planes_raw(const BYTE* pSrcData[4], BYTE* p
 	return TRUE;
 }
 
-static BOOL planar_subsample_expand(const BYTE* plane, size_t planeLength, UINT32 nWidth,
-                                    UINT32 nHeight, UINT32 nPlaneWidth, UINT32 nPlaneHeight,
-                                    BYTE* deltaPlane)
+static BOOL planar_subsample_expand(const BYTE* WINPR_RESTRICT plane, size_t planeLength,
+                                    UINT32 nWidth, UINT32 nHeight, UINT32 nPlaneWidth,
+                                    UINT32 nPlaneHeight, BYTE* WINPR_RESTRICT deltaPlane)
 {
 	size_t pos = 0;
 	WINPR_UNUSED(planeLength);
@@ -686,8 +692,9 @@ static BOOL planar_subsample_expand(const BYTE* plane, size_t planeLength, UINT3
 	return TRUE;
 }
 
-BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar, const BYTE* pSrcData, UINT32 SrcSize,
-                       UINT32 nSrcWidth, UINT32 nSrcHeight, BYTE* pDstData, UINT32 DstFormat,
+BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* WINPR_RESTRICT planar,
+                       const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize, UINT32 nSrcWidth,
+                       UINT32 nSrcHeight, BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat,
                        UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst, UINT32 nDstWidth,
                        UINT32 nDstHeight, BOOL vFlip)
 {
@@ -1105,9 +1112,10 @@ BOOL planar_decompress(BITMAP_PLANAR_CONTEXT* planar, const BYTE* pSrcData, UINT
 	return TRUE;
 }
 
-static INLINE BOOL freerdp_split_color_planes(BITMAP_PLANAR_CONTEXT* planar, const BYTE* data,
-                                              UINT32 format, UINT32 width, UINT32 height,
-                                              UINT32 scanline, BYTE* planes[4])
+static INLINE BOOL freerdp_split_color_planes(BITMAP_PLANAR_CONTEXT* WINPR_RESTRICT planar,
+                                              const BYTE* WINPR_RESTRICT data, UINT32 format,
+                                              UINT32 width, UINT32 height, UINT32 scanline,
+                                              BYTE* WINPR_RESTRICT planes[4])
 {
 	WINPR_ASSERT(planar);
 
@@ -1155,8 +1163,9 @@ static INLINE BOOL freerdp_split_color_planes(BITMAP_PLANAR_CONTEXT* planar, con
 	return TRUE;
 }
 
-static INLINE UINT32 freerdp_bitmap_planar_write_rle_bytes(const BYTE* pInBuffer, UINT32 cRawBytes,
-                                                           UINT32 nRunLength, BYTE* pOutBuffer,
+static INLINE UINT32 freerdp_bitmap_planar_write_rle_bytes(const BYTE* WINPR_RESTRICT pInBuffer,
+                                                           UINT32 cRawBytes, UINT32 nRunLength,
+                                                           BYTE* WINPR_RESTRICT pOutBuffer,
                                                            UINT32 outBufferSize)
 {
 	const BYTE* pInput = NULL;
@@ -1269,8 +1278,9 @@ static INLINE UINT32 freerdp_bitmap_planar_write_rle_bytes(const BYTE* pInBuffer
 	return (pOutput - pOutBuffer);
 }
 
-static INLINE UINT32 freerdp_bitmap_planar_encode_rle_bytes(const BYTE* pInBuffer,
-                                                            UINT32 inBufferSize, BYTE* pOutBuffer,
+static INLINE UINT32 freerdp_bitmap_planar_encode_rle_bytes(const BYTE* WINPR_RESTRICT pInBuffer,
+                                                            UINT32 inBufferSize,
+                                                            BYTE* WINPR_RESTRICT pOutBuffer,
                                                             UINT32 outBufferSize)
 {
 	BYTE symbol = 0;
@@ -1348,8 +1358,9 @@ static INLINE UINT32 freerdp_bitmap_planar_encode_rle_bytes(const BYTE* pInBuffe
 	return nTotalBytesWritten;
 }
 
-BOOL freerdp_bitmap_planar_compress_plane_rle(const BYTE* inPlane, UINT32 width, UINT32 height,
-                                              BYTE* outPlane, UINT32* dstSize)
+BOOL freerdp_bitmap_planar_compress_plane_rle(const BYTE* WINPR_RESTRICT inPlane, UINT32 width,
+                                              UINT32 height, BYTE* WINPR_RESTRICT outPlane,
+                                              UINT32* WINPR_RESTRICT dstSize)
 {
 	UINT32 index = 0;
 	const BYTE* pInput = NULL;
@@ -1389,9 +1400,11 @@ BOOL freerdp_bitmap_planar_compress_plane_rle(const BYTE* inPlane, UINT32 width,
 	return TRUE;
 }
 
-static INLINE BOOL freerdp_bitmap_planar_compress_planes_rle(BYTE* inPlanes[4], UINT32 width,
-                                                             UINT32 height, BYTE* outPlanes,
-                                                             UINT32* dstSizes, BOOL skipAlpha)
+static INLINE BOOL freerdp_bitmap_planar_compress_planes_rle(BYTE* WINPR_RESTRICT inPlanes[4],
+                                                             UINT32 width, UINT32 height,
+                                                             BYTE* WINPR_RESTRICT outPlanes,
+                                                             UINT32* WINPR_RESTRICT dstSizes,
+                                                             BOOL skipAlpha)
 {
 	UINT32 outPlanesSize = width * height * 4;
 
@@ -1440,8 +1453,8 @@ static INLINE BOOL freerdp_bitmap_planar_compress_planes_rle(BYTE* inPlanes[4], 
 	return TRUE;
 }
 
-BYTE* freerdp_bitmap_planar_delta_encode_plane(const BYTE* inPlane, UINT32 width, UINT32 height,
-                                               BYTE* outPlane)
+BYTE* freerdp_bitmap_planar_delta_encode_plane(const BYTE* WINPR_RESTRICT inPlane, UINT32 width,
+                                               UINT32 height, BYTE* WINPR_RESTRICT outPlane)
 {
 	char s2c = 0;
 	BYTE* outPtr = NULL;
@@ -1478,8 +1491,9 @@ BYTE* freerdp_bitmap_planar_delta_encode_plane(const BYTE* inPlane, UINT32 width
 	return outPlane;
 }
 
-static INLINE BOOL freerdp_bitmap_planar_delta_encode_planes(BYTE* inPlanes[4], UINT32 width,
-                                                             UINT32 height, BYTE* outPlanes[4])
+static INLINE BOOL freerdp_bitmap_planar_delta_encode_planes(BYTE* WINPR_RESTRICT inPlanes[4],
+                                                             UINT32 width, UINT32 height,
+                                                             BYTE* WINPR_RESTRICT outPlanes[4])
 {
 	for (UINT32 i = 0; i < 4; i++)
 	{
@@ -1493,9 +1507,10 @@ static INLINE BOOL freerdp_bitmap_planar_delta_encode_planes(BYTE* inPlanes[4], 
 	return TRUE;
 }
 
-BYTE* freerdp_bitmap_compress_planar(BITMAP_PLANAR_CONTEXT* context, const BYTE* data,
-                                     UINT32 format, UINT32 width, UINT32 height, UINT32 scanline,
-                                     BYTE* dstData, UINT32* pDstSize)
+BYTE* freerdp_bitmap_compress_planar(BITMAP_PLANAR_CONTEXT* WINPR_RESTRICT context,
+                                     const BYTE* WINPR_RESTRICT data, UINT32 format, UINT32 width,
+                                     UINT32 height, UINT32 scanline, BYTE* WINPR_RESTRICT dstData,
+                                     UINT32* WINPR_RESTRICT pDstSize)
 {
 	UINT32 size = 0;
 	BYTE* dstp = NULL;
@@ -1667,8 +1682,8 @@ BYTE* freerdp_bitmap_compress_planar(BITMAP_PLANAR_CONTEXT* context, const BYTE*
 	return dstData;
 }
 
-BOOL freerdp_bitmap_planar_context_reset(BITMAP_PLANAR_CONTEXT* context, UINT32 width,
-                                         UINT32 height)
+BOOL freerdp_bitmap_planar_context_reset(BITMAP_PLANAR_CONTEXT* WINPR_RESTRICT context,
+                                         UINT32 width, UINT32 height)
 {
 	if (!context)
 		return FALSE;
@@ -1772,13 +1787,13 @@ void freerdp_bitmap_planar_context_free(BITMAP_PLANAR_CONTEXT* context)
 	winpr_aligned_free(context);
 }
 
-void freerdp_planar_switch_bgr(BITMAP_PLANAR_CONTEXT* planar, BOOL bgr)
+void freerdp_planar_switch_bgr(BITMAP_PLANAR_CONTEXT* WINPR_RESTRICT planar, BOOL bgr)
 {
 	WINPR_ASSERT(planar);
 	planar->bgr = bgr;
 }
 
-void freerdp_planar_topdown_image(BITMAP_PLANAR_CONTEXT* planar, BOOL topdown)
+void freerdp_planar_topdown_image(BITMAP_PLANAR_CONTEXT* WINPR_RESTRICT planar, BOOL topdown)
 {
 	WINPR_ASSERT(planar);
 	planar->topdown = topdown;

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -55,8 +55,9 @@ typedef struct
 	BOOL mode;
 } RFX_PROGRESSIVE_UPGRADE_STATE;
 
-static INLINE void progressive_component_codec_quant_read(wStream* s,
-                                                          RFX_COMPONENT_CODEC_QUANT* quantVal)
+static INLINE void
+progressive_component_codec_quant_read(wStream* WINPR_RESTRICT s,
+                                       RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT quantVal)
 {
 	BYTE b = 0;
 	Stream_Read_UINT8(s, b);
@@ -76,7 +77,7 @@ static INLINE void progressive_component_codec_quant_read(wStream* s,
 	quantVal->HH1 = b >> 4;
 }
 
-static INLINE void progressive_rfx_quant_ladd(RFX_COMPONENT_CODEC_QUANT* q, int val)
+static INLINE void progressive_rfx_quant_ladd(RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q, int val)
 {
 	q->HL1 += val; /* HL1 */
 	q->LH1 += val; /* LH1 */
@@ -90,8 +91,8 @@ static INLINE void progressive_rfx_quant_ladd(RFX_COMPONENT_CODEC_QUANT* q, int 
 	q->LL3 += val; /* LL3 */
 }
 
-static INLINE void progressive_rfx_quant_add(const RFX_COMPONENT_CODEC_QUANT* q1,
-                                             const RFX_COMPONENT_CODEC_QUANT* q2,
+static INLINE void progressive_rfx_quant_add(const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q1,
+                                             const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q2,
                                              RFX_COMPONENT_CODEC_QUANT* dst)
 {
 	dst->HL1 = q1->HL1 + q2->HL1; /* HL1 */
@@ -106,7 +107,7 @@ static INLINE void progressive_rfx_quant_add(const RFX_COMPONENT_CODEC_QUANT* q1
 	dst->LL3 = q1->LL3 + q2->LL3; /* LL3 */
 }
 
-static INLINE void progressive_rfx_quant_lsub(RFX_COMPONENT_CODEC_QUANT* q, int val)
+static INLINE void progressive_rfx_quant_lsub(RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q, int val)
 {
 	q->HL1 -= val; /* HL1 */
 	q->LH1 -= val; /* LH1 */
@@ -120,8 +121,8 @@ static INLINE void progressive_rfx_quant_lsub(RFX_COMPONENT_CODEC_QUANT* q, int 
 	q->LL3 -= val; /* LL3 */
 }
 
-static INLINE void progressive_rfx_quant_sub(const RFX_COMPONENT_CODEC_QUANT* q1,
-                                             const RFX_COMPONENT_CODEC_QUANT* q2,
+static INLINE void progressive_rfx_quant_sub(const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q1,
+                                             const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q2,
                                              RFX_COMPONENT_CODEC_QUANT* dst)
 {
 	dst->HL1 = q1->HL1 - q2->HL1; /* HL1 */
@@ -136,8 +137,8 @@ static INLINE void progressive_rfx_quant_sub(const RFX_COMPONENT_CODEC_QUANT* q1
 	dst->LL3 = q1->LL3 - q2->LL3; /* LL3 */
 }
 
-static INLINE BOOL progressive_rfx_quant_lcmp_less_equal(const RFX_COMPONENT_CODEC_QUANT* q,
-                                                         int val)
+static INLINE BOOL
+progressive_rfx_quant_lcmp_less_equal(const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q, int val)
 {
 	if (q->HL1 > val)
 		return FALSE; /* HL1 */
@@ -172,8 +173,9 @@ static INLINE BOOL progressive_rfx_quant_lcmp_less_equal(const RFX_COMPONENT_COD
 	return TRUE;
 }
 
-static INLINE BOOL progressive_rfx_quant_cmp_less_equal(const RFX_COMPONENT_CODEC_QUANT* q1,
-                                                        const RFX_COMPONENT_CODEC_QUANT* q2)
+static INLINE BOOL
+progressive_rfx_quant_cmp_less_equal(const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q1,
+                                     const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q2)
 {
 	if (q1->HL1 > q2->HL1)
 		return FALSE; /* HL1 */
@@ -208,8 +210,8 @@ static INLINE BOOL progressive_rfx_quant_cmp_less_equal(const RFX_COMPONENT_CODE
 	return TRUE;
 }
 
-static INLINE BOOL progressive_rfx_quant_lcmp_greater_equal(const RFX_COMPONENT_CODEC_QUANT* q,
-                                                            int val)
+static INLINE BOOL
+progressive_rfx_quant_lcmp_greater_equal(const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q, int val)
 {
 	if (q->HL1 < val)
 		return FALSE; /* HL1 */
@@ -244,8 +246,9 @@ static INLINE BOOL progressive_rfx_quant_lcmp_greater_equal(const RFX_COMPONENT_
 	return TRUE;
 }
 
-static INLINE BOOL progressive_rfx_quant_cmp_greater_equal(const RFX_COMPONENT_CODEC_QUANT* q1,
-                                                           const RFX_COMPONENT_CODEC_QUANT* q2)
+static INLINE BOOL
+progressive_rfx_quant_cmp_greater_equal(const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q1,
+                                        const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q2)
 {
 	if (q1->HL1 < q2->HL1)
 		return FALSE; /* HL1 */
@@ -280,8 +283,9 @@ static INLINE BOOL progressive_rfx_quant_cmp_greater_equal(const RFX_COMPONENT_C
 	return TRUE;
 }
 
-static INLINE BOOL progressive_rfx_quant_cmp_equal(const RFX_COMPONENT_CODEC_QUANT* q1,
-                                                   const RFX_COMPONENT_CODEC_QUANT* q2)
+static INLINE BOOL
+progressive_rfx_quant_cmp_equal(const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q1,
+                                const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q2)
 {
 	if (q1->HL1 != q2->HL1)
 		return FALSE; /* HL1 */
@@ -316,8 +320,9 @@ static INLINE BOOL progressive_rfx_quant_cmp_equal(const RFX_COMPONENT_CODEC_QUA
 	return TRUE;
 }
 
-static INLINE BOOL progressive_set_surface_data(PROGRESSIVE_CONTEXT* progressive, UINT16 surfaceId,
-                                                void* pData)
+static INLINE BOOL progressive_set_surface_data(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                                UINT16 surfaceId,
+                                                PROGRESSIVE_SURFACE_CONTEXT* WINPR_RESTRICT pData)
 {
 	ULONG_PTR key = 0;
 	key = ((ULONG_PTR)surfaceId) + 1;
@@ -330,7 +335,7 @@ static INLINE BOOL progressive_set_surface_data(PROGRESSIVE_CONTEXT* progressive
 }
 
 static INLINE PROGRESSIVE_SURFACE_CONTEXT*
-progressive_get_surface_data(PROGRESSIVE_CONTEXT* progressive, UINT16 surfaceId)
+progressive_get_surface_data(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive, UINT16 surfaceId)
 {
 	void* key = (void*)(((ULONG_PTR)surfaceId) + 1);
 
@@ -340,7 +345,7 @@ progressive_get_surface_data(PROGRESSIVE_CONTEXT* progressive, UINT16 surfaceId)
 	return HashTable_GetItemValue(progressive->SurfaceContexts, key);
 }
 
-static void progressive_tile_free(RFX_PROGRESSIVE_TILE* tile)
+static void progressive_tile_free(RFX_PROGRESSIVE_TILE* WINPR_RESTRICT tile)
 {
 	if (tile)
 	{
@@ -383,7 +388,7 @@ static INLINE RFX_PROGRESSIVE_TILE* progressive_tile_new(void)
 	tile->stride = 4 * tile->width;
 
 	size_t dataLen = 1ull * tile->stride * tile->height;
-	tile->data = (BYTE*)winpr_aligned_malloc(dataLen, 16);
+	tile->data = (BYTE*)winpr_aligned_calloc(dataLen, sizeof(BYTE), 16);
 	if (!tile->data)
 		goto fail;
 	memset(tile->data, 0xFF, dataLen);
@@ -405,7 +410,8 @@ fail:
 	return NULL;
 }
 
-static BOOL progressive_allocate_tile_cache(PROGRESSIVE_SURFACE_CONTEXT* surface, size_t min)
+static BOOL progressive_allocate_tile_cache(PROGRESSIVE_SURFACE_CONTEXT* WINPR_RESTRICT surface,
+                                            size_t min)
 {
 	size_t oldIndex = 0;
 
@@ -468,9 +474,10 @@ static PROGRESSIVE_SURFACE_CONTEXT* progressive_surface_context_new(UINT16 surfa
 	return surface;
 }
 
-static BOOL progressive_surface_tile_replace(PROGRESSIVE_SURFACE_CONTEXT* surface,
-                                             PROGRESSIVE_BLOCK_REGION* region,
-                                             const RFX_PROGRESSIVE_TILE* tile, BOOL upgrade)
+static BOOL progressive_surface_tile_replace(PROGRESSIVE_SURFACE_CONTEXT* WINPR_RESTRICT surface,
+                                             PROGRESSIVE_BLOCK_REGION* WINPR_RESTRICT region,
+                                             const RFX_PROGRESSIVE_TILE* WINPR_RESTRICT tile,
+                                             BOOL upgrade)
 {
 	RFX_PROGRESSIVE_TILE* t = NULL;
 
@@ -550,8 +557,8 @@ static BOOL progressive_surface_tile_replace(PROGRESSIVE_SURFACE_CONTEXT* surfac
 	return TRUE;
 }
 
-INT32 progressive_create_surface_context(PROGRESSIVE_CONTEXT* progressive, UINT16 surfaceId,
-                                         UINT32 width, UINT32 height)
+INT32 progressive_create_surface_context(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                         UINT16 surfaceId, UINT32 width, UINT32 height)
 {
 	PROGRESSIVE_SURFACE_CONTEXT* surface = progressive_get_surface_data(progressive, surfaceId);
 
@@ -572,7 +579,8 @@ INT32 progressive_create_surface_context(PROGRESSIVE_CONTEXT* progressive, UINT1
 	return 1;
 }
 
-int progressive_delete_surface_context(PROGRESSIVE_CONTEXT* progressive, UINT16 surfaceId)
+int progressive_delete_surface_context(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                       UINT16 surfaceId)
 {
 	progressive_set_surface_data(progressive, surfaceId, NULL);
 
@@ -597,10 +605,10 @@ int progressive_delete_surface_context(PROGRESSIVE_CONTEXT* progressive, UINT16 
  * LL3      4015        9x9         81
  */
 
-static INLINE void progressive_rfx_idwt_x(const INT16* pLowBand, size_t nLowStep,
-                                          const INT16* pHighBand, size_t nHighStep, INT16* pDstBand,
-                                          size_t nDstStep, size_t nLowCount, size_t nHighCount,
-                                          size_t nDstCount)
+static INLINE void progressive_rfx_idwt_x(const INT16* WINPR_RESTRICT pLowBand, size_t nLowStep,
+                                          const INT16* WINPR_RESTRICT pHighBand, size_t nHighStep,
+                                          INT16* WINPR_RESTRICT pDstBand, size_t nDstStep,
+                                          size_t nLowCount, size_t nHighCount, size_t nDstCount)
 {
 	INT16 L0 = 0;
 	INT16 H0 = 0;
@@ -670,10 +678,10 @@ static INLINE void progressive_rfx_idwt_x(const INT16* pLowBand, size_t nLowStep
 	}
 }
 
-static INLINE void progressive_rfx_idwt_y(const INT16* pLowBand, size_t nLowStep,
-                                          const INT16* pHighBand, size_t nHighStep, INT16* pDstBand,
-                                          size_t nDstStep, size_t nLowCount, size_t nHighCount,
-                                          size_t nDstCount)
+static INLINE void progressive_rfx_idwt_y(const INT16* WINPR_RESTRICT pLowBand, size_t nLowStep,
+                                          const INT16* WINPR_RESTRICT pHighBand, size_t nHighStep,
+                                          INT16* WINPR_RESTRICT pDstBand, size_t nDstStep,
+                                          size_t nLowCount, size_t nHighCount, size_t nDstCount)
 {
 	INT16 L0 = 0;
 	INT16 H0 = 0;
@@ -763,17 +771,18 @@ static INLINE size_t progressive_rfx_get_band_h_count(size_t level)
 		return (64 + (1 << (level - 1))) >> level;
 }
 
-static INLINE void progressive_rfx_dwt_2d_decode_block(INT16* buffer, INT16* temp, size_t level)
+static INLINE void progressive_rfx_dwt_2d_decode_block(INT16* WINPR_RESTRICT buffer,
+                                                       INT16* WINPR_RESTRICT temp, size_t level)
 {
 	size_t nDstStepX = 0;
 	size_t nDstStepY = 0;
-	INT16* HL = NULL;
-	INT16* LH = NULL;
-	INT16* HH = NULL;
-	INT16* LL = NULL;
-	INT16* L = NULL;
-	INT16* H = NULL;
-	INT16* LLx = NULL;
+	const INT16* WINPR_RESTRICT HL = NULL;
+	const INT16* WINPR_RESTRICT LH = NULL;
+	const INT16* WINPR_RESTRICT HH = NULL;
+	INT16* WINPR_RESTRICT LL = NULL;
+	INT16* WINPR_RESTRICT L = NULL;
+	INT16* WINPR_RESTRICT H = NULL;
+	INT16* WINPR_RESTRICT LLx = NULL;
 
 	const size_t nBandL = progressive_rfx_get_band_l_count(level);
 	const size_t nBandH = progressive_rfx_get_band_h_count(level);
@@ -805,7 +814,7 @@ static INLINE void progressive_rfx_dwt_2d_decode_block(INT16* buffer, INT16* tem
 	                       nBandL + nBandH);
 }
 
-void rfx_dwt_2d_extrapolate_decode(INT16* buffer, INT16* temp)
+void rfx_dwt_2d_extrapolate_decode(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT temp)
 {
 	WINPR_ASSERT(buffer);
 	WINPR_ASSERT(temp);
@@ -814,9 +823,10 @@ void rfx_dwt_2d_extrapolate_decode(INT16* buffer, INT16* temp)
 	progressive_rfx_dwt_2d_decode_block(&buffer[0], temp, 1);
 }
 
-static INLINE int progressive_rfx_dwt_2d_decode(PROGRESSIVE_CONTEXT* progressive, INT16* buffer,
-                                                INT16* current, BOOL coeffDiff, BOOL extrapolate,
-                                                BOOL reverse)
+static INLINE int progressive_rfx_dwt_2d_decode(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                                INT16* WINPR_RESTRICT buffer,
+                                                INT16* WINPR_RESTRICT current, BOOL coeffDiff,
+                                                BOOL extrapolate, BOOL reverse)
 {
 	const primitives_t* prims = primitives_get();
 
@@ -856,8 +866,9 @@ static INLINE int progressive_rfx_dwt_2d_decode(PROGRESSIVE_CONTEXT* progressive
 	return 1;
 }
 
-static INLINE void progressive_rfx_decode_block(const primitives_t* prims, INT16* buffer,
-                                                UINT32 length, UINT32 shift)
+static INLINE void progressive_rfx_decode_block(const primitives_t* prims,
+                                                INT16* WINPR_RESTRICT buffer, UINT32 length,
+                                                UINT32 shift)
 {
 	if (!shift)
 		return;
@@ -865,11 +876,11 @@ static INLINE void progressive_rfx_decode_block(const primitives_t* prims, INT16
 	prims->lShiftC_16s(buffer, shift, buffer, length);
 }
 
-static INLINE int progressive_rfx_decode_component(PROGRESSIVE_CONTEXT* progressive,
-                                                   const RFX_COMPONENT_CODEC_QUANT* shift,
-                                                   const BYTE* data, UINT32 length, INT16* buffer,
-                                                   INT16* current, INT16* sign, BOOL coeffDiff,
-                                                   BOOL subbandDiff, BOOL extrapolate)
+static INLINE int progressive_rfx_decode_component(
+    PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+    const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT shift, const BYTE* WINPR_RESTRICT data,
+    UINT32 length, INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT current,
+    INT16* WINPR_RESTRICT sign, BOOL coeffDiff, BOOL subbandDiff, BOOL extrapolate)
 {
 	int status = 0;
 	const primitives_t* prims = primitives_get();
@@ -912,10 +923,11 @@ static INLINE int progressive_rfx_decode_component(PROGRESSIVE_CONTEXT* progress
 	                                     FALSE);
 }
 
-static INLINE int progressive_decompress_tile_first(PROGRESSIVE_CONTEXT* progressive,
-                                                    RFX_PROGRESSIVE_TILE* tile,
-                                                    PROGRESSIVE_BLOCK_REGION* region,
-                                                    const PROGRESSIVE_BLOCK_CONTEXT* context)
+static INLINE int
+progressive_decompress_tile_first(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                  RFX_PROGRESSIVE_TILE* WINPR_RESTRICT tile,
+                                  PROGRESSIVE_BLOCK_REGION* WINPR_RESTRICT region,
+                                  const PROGRESSIVE_BLOCK_CONTEXT* WINPR_RESTRICT context)
 {
 	int rc = 0;
 	BOOL diff = 0;
@@ -1051,7 +1063,8 @@ fail:
 	return rc;
 }
 
-static INLINE INT16 progressive_rfx_srl_read(RFX_PROGRESSIVE_UPGRADE_STATE* state, UINT32 numBits)
+static INLINE INT16 progressive_rfx_srl_read(RFX_PROGRESSIVE_UPGRADE_STATE* WINPR_RESTRICT state,
+                                             UINT32 numBits)
 {
 	UINT32 k = 0;
 	UINT32 bit = 0;
@@ -1138,7 +1151,8 @@ static INLINE INT16 progressive_rfx_srl_read(RFX_PROGRESSIVE_UPGRADE_STATE* stat
 	return sign ? -1 * mag : mag;
 }
 
-static INLINE int progressive_rfx_upgrade_state_finish(RFX_PROGRESSIVE_UPGRADE_STATE* state)
+static INLINE int
+progressive_rfx_upgrade_state_finish(RFX_PROGRESSIVE_UPGRADE_STATE* WINPR_RESTRICT state)
 {
 	UINT32 pad = 0;
 	wBitStream* srl = NULL;
@@ -1165,9 +1179,10 @@ static INLINE int progressive_rfx_upgrade_state_finish(RFX_PROGRESSIVE_UPGRADE_S
 	return 1;
 }
 
-static INLINE int progressive_rfx_upgrade_block(RFX_PROGRESSIVE_UPGRADE_STATE* state, INT16* buffer,
-                                                INT16* sign, UINT32 length, UINT32 shift,
-                                                UINT32 bitPos, UINT32 numBits)
+static INLINE int progressive_rfx_upgrade_block(RFX_PROGRESSIVE_UPGRADE_STATE* WINPR_RESTRICT state,
+                                                INT16* WINPR_RESTRICT buffer,
+                                                INT16* WINPR_RESTRICT sign, UINT32 length,
+                                                UINT32 shift, UINT32 bitPos, UINT32 numBits)
 {
 	INT16 input = 0;
 	wBitStream* raw = NULL;
@@ -1220,11 +1235,15 @@ static INLINE int progressive_rfx_upgrade_block(RFX_PROGRESSIVE_UPGRADE_STATE* s
 	return 1;
 }
 
-static INLINE int progressive_rfx_upgrade_component(
-    PROGRESSIVE_CONTEXT* progressive, const RFX_COMPONENT_CODEC_QUANT* shift,
-    const RFX_COMPONENT_CODEC_QUANT* bitPos, const RFX_COMPONENT_CODEC_QUANT* numBits,
-    INT16* buffer, INT16* current, INT16* sign, const BYTE* srlData, UINT32 srlLen,
-    const BYTE* rawData, UINT32 rawLen, BOOL coeffDiff, BOOL subbandDiff, BOOL extrapolate)
+static INLINE int
+progressive_rfx_upgrade_component(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                  const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT shift,
+                                  const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT bitPos,
+                                  const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT numBits,
+                                  INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT current,
+                                  INT16* WINPR_RESTRICT sign, const BYTE* WINPR_RESTRICT srlData,
+                                  UINT32 srlLen, const BYTE* WINPR_RESTRICT rawData, UINT32 rawLen,
+                                  BOOL coeffDiff, BOOL subbandDiff, BOOL extrapolate)
 {
 	int rc = 0;
 	UINT32 aRawLen = 0;
@@ -1315,10 +1334,11 @@ static INLINE int progressive_rfx_upgrade_component(
 	                                     TRUE);
 }
 
-static INLINE int progressive_decompress_tile_upgrade(PROGRESSIVE_CONTEXT* progressive,
-                                                      RFX_PROGRESSIVE_TILE* tile,
-                                                      PROGRESSIVE_BLOCK_REGION* region,
-                                                      const PROGRESSIVE_BLOCK_CONTEXT* context)
+static INLINE int
+progressive_decompress_tile_upgrade(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                    RFX_PROGRESSIVE_TILE* WINPR_RESTRICT tile,
+                                    PROGRESSIVE_BLOCK_REGION* WINPR_RESTRICT region,
+                                    const PROGRESSIVE_BLOCK_CONTEXT* WINPR_RESTRICT context)
 {
 	int status = 0;
 	BOOL coeffDiff = 0;
@@ -1489,11 +1509,11 @@ fail:
 	return status;
 }
 
-static INLINE BOOL progressive_tile_read_upgrade(PROGRESSIVE_CONTEXT* progressive, wStream* s,
-                                                 UINT16 blockType, UINT32 blockLen,
-                                                 PROGRESSIVE_SURFACE_CONTEXT* surface,
-                                                 PROGRESSIVE_BLOCK_REGION* region,
-                                                 const PROGRESSIVE_BLOCK_CONTEXT* context)
+static INLINE BOOL progressive_tile_read_upgrade(
+    PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive, wStream* WINPR_RESTRICT s, UINT16 blockType,
+    UINT32 blockLen, PROGRESSIVE_SURFACE_CONTEXT* WINPR_RESTRICT surface,
+    PROGRESSIVE_BLOCK_REGION* WINPR_RESTRICT region,
+    const PROGRESSIVE_BLOCK_CONTEXT* WINPR_RESTRICT context)
 {
 	RFX_PROGRESSIVE_TILE tile = { 0 };
 	const size_t expect = 20;
@@ -1567,11 +1587,12 @@ static INLINE BOOL progressive_tile_read_upgrade(PROGRESSIVE_CONTEXT* progressiv
 	return progressive_surface_tile_replace(surface, region, &tile, TRUE);
 }
 
-static INLINE BOOL progressive_tile_read(PROGRESSIVE_CONTEXT* progressive, BOOL simple, wStream* s,
-                                         UINT16 blockType, UINT32 blockLen,
-                                         PROGRESSIVE_SURFACE_CONTEXT* surface,
-                                         PROGRESSIVE_BLOCK_REGION* region,
-                                         const PROGRESSIVE_BLOCK_CONTEXT* context)
+static INLINE BOOL progressive_tile_read(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                         BOOL simple, wStream* WINPR_RESTRICT s, UINT16 blockType,
+                                         UINT32 blockLen,
+                                         PROGRESSIVE_SURFACE_CONTEXT* WINPR_RESTRICT surface,
+                                         PROGRESSIVE_BLOCK_REGION* WINPR_RESTRICT region,
+                                         const PROGRESSIVE_BLOCK_CONTEXT* WINPR_RESTRICT context)
 {
 	RFX_PROGRESSIVE_TILE tile = { 0 };
 	size_t expect = simple ? 16 : 17;
@@ -1665,10 +1686,11 @@ static void CALLBACK progressive_process_tiles_tile_work_callback(PTP_CALLBACK_I
 	}
 }
 
-static INLINE SSIZE_T progressive_process_tiles(PROGRESSIVE_CONTEXT* progressive, wStream* s,
-                                                PROGRESSIVE_BLOCK_REGION* region,
-                                                PROGRESSIVE_SURFACE_CONTEXT* surface,
-                                                const PROGRESSIVE_BLOCK_CONTEXT* context)
+static INLINE SSIZE_T progressive_process_tiles(
+    PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive, wStream* WINPR_RESTRICT s,
+    PROGRESSIVE_BLOCK_REGION* WINPR_RESTRICT region,
+    PROGRESSIVE_SURFACE_CONTEXT* WINPR_RESTRICT surface,
+    const PROGRESSIVE_BLOCK_CONTEXT* WINPR_RESTRICT context)
 {
 	int status = 0;
 	size_t end = 0;
@@ -1834,12 +1856,13 @@ fail:
 	return (SSIZE_T)(end - start);
 }
 
-static INLINE SSIZE_T progressive_wb_sync(PROGRESSIVE_CONTEXT* progressive, wStream* s,
-                                          UINT16 blockType, UINT32 blockLen)
+static INLINE SSIZE_T progressive_wb_sync(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                          wStream* WINPR_RESTRICT s, UINT16 blockType,
+                                          UINT32 blockLen)
 {
 	const UINT32 magic = 0xCACCACCA;
 	const UINT16 version = 0x0100;
-	PROGRESSIVE_BLOCK_SYNC sync;
+	PROGRESSIVE_BLOCK_SYNC sync = { 0 };
 
 	sync.blockType = blockType;
 	sync.blockLen = blockLen;
@@ -1885,10 +1908,11 @@ static INLINE SSIZE_T progressive_wb_sync(PROGRESSIVE_CONTEXT* progressive, wStr
 	return 0;
 }
 
-static INLINE SSIZE_T progressive_wb_frame_begin(PROGRESSIVE_CONTEXT* progressive, wStream* s,
-                                                 UINT16 blockType, UINT32 blockLen)
+static INLINE SSIZE_T progressive_wb_frame_begin(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                                 wStream* WINPR_RESTRICT s, UINT16 blockType,
+                                                 UINT32 blockLen)
 {
-	PROGRESSIVE_BLOCK_FRAME_BEGIN frameBegin;
+	PROGRESSIVE_BLOCK_FRAME_BEGIN frameBegin = { 0 };
 
 	frameBegin.blockType = blockType;
 	frameBegin.blockLen = blockLen;
@@ -1936,10 +1960,11 @@ static INLINE SSIZE_T progressive_wb_frame_begin(PROGRESSIVE_CONTEXT* progressiv
 	return 0;
 }
 
-static INLINE SSIZE_T progressive_wb_frame_end(PROGRESSIVE_CONTEXT* progressive, wStream* s,
-                                               UINT16 blockType, UINT32 blockLen)
+static INLINE SSIZE_T progressive_wb_frame_end(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                               wStream* WINPR_RESTRICT s, UINT16 blockType,
+                                               UINT32 blockLen)
 {
-	PROGRESSIVE_BLOCK_FRAME_END frameEnd;
+	PROGRESSIVE_BLOCK_FRAME_END frameEnd = { 0 };
 
 	frameEnd.blockType = blockType;
 	frameEnd.blockLen = blockLen;
@@ -1973,8 +1998,9 @@ static INLINE SSIZE_T progressive_wb_frame_end(PROGRESSIVE_CONTEXT* progressive,
 	return 0;
 }
 
-static INLINE SSIZE_T progressive_wb_context(PROGRESSIVE_CONTEXT* progressive, wStream* s,
-                                             UINT16 blockType, UINT32 blockLen)
+static INLINE SSIZE_T progressive_wb_context(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                             wStream* WINPR_RESTRICT s, UINT16 blockType,
+                                             UINT32 blockLen)
 {
 	PROGRESSIVE_BLOCK_CONTEXT* context = &progressive->context;
 	context->blockType = blockType;
@@ -2020,14 +2046,14 @@ static INLINE SSIZE_T progressive_wb_context(PROGRESSIVE_CONTEXT* progressive, w
 	return 0;
 }
 
-static INLINE SSIZE_T progressive_wb_read_region_header(PROGRESSIVE_CONTEXT* progressive,
-                                                        wStream* s, UINT16 blockType,
-                                                        UINT32 blockLen,
-                                                        PROGRESSIVE_BLOCK_REGION* region)
+static INLINE SSIZE_T progressive_wb_read_region_header(
+    PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive, wStream* WINPR_RESTRICT s, UINT16 blockType,
+    UINT32 blockLen, PROGRESSIVE_BLOCK_REGION* WINPR_RESTRICT region)
 {
 	SSIZE_T len = 0;
 
 	memset(region, 0, sizeof(PROGRESSIVE_BLOCK_REGION));
+
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, 12))
 		return -1011;
 
@@ -2099,8 +2125,9 @@ static INLINE SSIZE_T progressive_wb_read_region_header(PROGRESSIVE_CONTEXT* pro
 	return len;
 }
 
-static INLINE SSIZE_T progressive_wb_skip_region(PROGRESSIVE_CONTEXT* progressive, wStream* s,
-                                                 UINT16 blockType, UINT32 blockLen)
+static INLINE SSIZE_T progressive_wb_skip_region(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                                 wStream* WINPR_RESTRICT s, UINT16 blockType,
+                                                 UINT32 blockLen)
 {
 	SSIZE_T rc = 0;
 	size_t total = 0;
@@ -2120,10 +2147,11 @@ static INLINE SSIZE_T progressive_wb_skip_region(PROGRESSIVE_CONTEXT* progressiv
 	return rc;
 }
 
-static INLINE SSIZE_T progressive_wb_region(PROGRESSIVE_CONTEXT* progressive, wStream* s,
-                                            UINT16 blockType, UINT32 blockLen,
-                                            PROGRESSIVE_SURFACE_CONTEXT* surface,
-                                            PROGRESSIVE_BLOCK_REGION* region)
+static INLINE SSIZE_T progressive_wb_region(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                            wStream* WINPR_RESTRICT s, UINT16 blockType,
+                                            UINT32 blockLen,
+                                            PROGRESSIVE_SURFACE_CONTEXT* WINPR_RESTRICT surface,
+                                            PROGRESSIVE_BLOCK_REGION* WINPR_RESTRICT region)
 {
 	SSIZE_T rc = -1;
 	UINT16 boxLeft = 0;
@@ -2240,9 +2268,10 @@ static INLINE SSIZE_T progressive_wb_region(PROGRESSIVE_CONTEXT* progressive, wS
 	return (size_t)rc;
 }
 
-static SSIZE_T progressive_parse_block(PROGRESSIVE_CONTEXT* progressive, wStream* s,
-                                       PROGRESSIVE_SURFACE_CONTEXT* surface,
-                                       PROGRESSIVE_BLOCK_REGION* region)
+static SSIZE_T progressive_parse_block(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                       wStream* WINPR_RESTRICT s,
+                                       PROGRESSIVE_SURFACE_CONTEXT* WINPR_RESTRICT surface,
+                                       PROGRESSIVE_BLOCK_REGION* WINPR_RESTRICT region)
 {
 	UINT16 blockType = 0;
 	UINT32 blockLen = 0;
@@ -2308,9 +2337,12 @@ static SSIZE_T progressive_parse_block(PROGRESSIVE_CONTEXT* progressive, wStream
 	return rc;
 }
 
-static BOOL update_tiles(PROGRESSIVE_CONTEXT* progressive, PROGRESSIVE_SURFACE_CONTEXT* surface,
-                         BYTE* pDstData, UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst,
-                         UINT32 nYDst, PROGRESSIVE_BLOCK_REGION* region, REGION16* invalidRegion)
+static BOOL update_tiles(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                         PROGRESSIVE_SURFACE_CONTEXT* WINPR_RESTRICT surface,
+                         BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat, UINT32 nDstStep,
+                         UINT32 nXDst, UINT32 nYDst,
+                         PROGRESSIVE_BLOCK_REGION* WINPR_RESTRICT region,
+                         REGION16* WINPR_RESTRICT invalidRegion)
 {
 	BOOL rc = TRUE;
 	REGION16 clippingRects = { 0 };
@@ -2384,10 +2416,11 @@ fail:
 	return rc;
 }
 
-INT32 progressive_decompress(PROGRESSIVE_CONTEXT* progressive, const BYTE* pSrcData, UINT32 SrcSize,
-                             BYTE* pDstData, UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDst,
-                             UINT32 nYDst, REGION16* invalidRegion, UINT16 surfaceId,
-                             UINT32 frameId)
+INT32 progressive_decompress(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                             const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
+                             BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat, UINT32 nDstStep,
+                             UINT32 nXDst, UINT32 nYDst, REGION16* WINPR_RESTRICT invalidRegion,
+                             UINT16 surfaceId, UINT32 frameId)
 {
 	INT32 rc = 1;
 

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -75,10 +75,11 @@
  */
 static const UINT32 rfx_default_quantization_values[] = { 6, 6, 6, 6, 7, 7, 8, 8, 8, 9 };
 
-static INLINE BOOL rfx_write_progressive_tile_simple(RFX_CONTEXT* rfx, wStream* s,
-                                                     const RFX_TILE* tile);
+static INLINE BOOL rfx_write_progressive_tile_simple(RFX_CONTEXT* WINPR_RESTRICT rfx,
+                                                     wStream* WINPR_RESTRICT s,
+                                                     const RFX_TILE* WINPR_RESTRICT tile);
 
-static void rfx_profiler_create(RFX_CONTEXT* context)
+static INLINE void rfx_profiler_create(RFX_CONTEXT* WINPR_RESTRICT context)
 {
 	if (!context || !context->priv)
 		return;
@@ -99,7 +100,7 @@ static void rfx_profiler_create(RFX_CONTEXT* context)
 	PROFILER_CREATE(context->priv->prof_rfx_encode_format_rgb, "rfx_encode_format_rgb")
 }
 
-static void rfx_profiler_free(RFX_CONTEXT* context)
+static INLINE void rfx_profiler_free(RFX_CONTEXT* WINPR_RESTRICT context)
 {
 	if (!context || !context->priv)
 		return;
@@ -120,7 +121,7 @@ static void rfx_profiler_free(RFX_CONTEXT* context)
 	PROFILER_FREE(context->priv->prof_rfx_encode_format_rgb)
 }
 
-static void rfx_profiler_print(RFX_CONTEXT* context)
+static INLINE void rfx_profiler_print(RFX_CONTEXT* WINPR_RESTRICT context)
 {
 	if (!context || !context->priv)
 		return;
@@ -144,7 +145,7 @@ static void rfx_profiler_print(RFX_CONTEXT* context)
 	PROFILER_PRINT_FOOTER
 }
 
-static void rfx_tile_init(void* obj)
+static INLINE void rfx_tile_init(void* obj)
 {
 	RFX_TILE* tile = (RFX_TILE*)obj;
 	if (tile)
@@ -160,7 +161,7 @@ static void rfx_tile_init(void* obj)
 	}
 }
 
-static void* rfx_decoder_tile_new(const void* val)
+static INLINE void* rfx_decoder_tile_new(const void* val)
 {
 	const size_t size = 4 * 64 * 64;
 	RFX_TILE* tile = NULL;
@@ -179,7 +180,7 @@ static void* rfx_decoder_tile_new(const void* val)
 	return tile;
 }
 
-static void rfx_decoder_tile_free(void* obj)
+static INLINE void rfx_decoder_tile_free(void* obj)
 {
 	RFX_TILE* tile = (RFX_TILE*)obj;
 
@@ -192,13 +193,13 @@ static void rfx_decoder_tile_free(void* obj)
 	}
 }
 
-static void* rfx_encoder_tile_new(const void* val)
+static INLINE void* rfx_encoder_tile_new(const void* val)
 {
 	WINPR_UNUSED(val);
 	return winpr_aligned_calloc(1, sizeof(RFX_TILE), 32);
 }
 
-static void rfx_encoder_tile_free(void* obj)
+static INLINE void rfx_encoder_tile_free(void* obj)
 {
 	winpr_aligned_free(obj);
 }
@@ -392,7 +393,7 @@ void rfx_context_free(RFX_CONTEXT* context)
 	winpr_aligned_free(context);
 }
 
-static RFX_TILE* rfx_message_get_tile(RFX_MESSAGE* message, UINT32 index)
+static INLINE RFX_TILE* rfx_message_get_tile(RFX_MESSAGE* WINPR_RESTRICT message, UINT32 index)
 {
 	WINPR_ASSERT(message);
 	WINPR_ASSERT(message->tiles);
@@ -400,7 +401,8 @@ static RFX_TILE* rfx_message_get_tile(RFX_MESSAGE* message, UINT32 index)
 	return message->tiles[index];
 }
 
-static const RFX_RECT* rfx_message_get_rect_const(const RFX_MESSAGE* message, UINT32 index)
+static INLINE const RFX_RECT* rfx_message_get_rect_const(const RFX_MESSAGE* WINPR_RESTRICT message,
+                                                         UINT32 index)
 {
 	WINPR_ASSERT(message);
 	WINPR_ASSERT(message->rects);
@@ -408,7 +410,7 @@ static const RFX_RECT* rfx_message_get_rect_const(const RFX_MESSAGE* message, UI
 	return &message->rects[index];
 }
 
-static RFX_RECT* rfx_message_get_rect(RFX_MESSAGE* message, UINT32 index)
+static INLINE RFX_RECT* rfx_message_get_rect(RFX_MESSAGE* WINPR_RESTRICT message, UINT32 index)
 {
 	WINPR_ASSERT(message);
 	WINPR_ASSERT(message->rects);
@@ -416,32 +418,33 @@ static RFX_RECT* rfx_message_get_rect(RFX_MESSAGE* message, UINT32 index)
 	return &message->rects[index];
 }
 
-void rfx_context_set_pixel_format(RFX_CONTEXT* context, UINT32 pixel_format)
+void rfx_context_set_pixel_format(RFX_CONTEXT* WINPR_RESTRICT context, UINT32 pixel_format)
 {
 	WINPR_ASSERT(context);
 	context->pixel_format = pixel_format;
 	context->bits_per_pixel = FreeRDPGetBitsPerPixel(pixel_format);
 }
 
-UINT32 rfx_context_get_pixel_format(RFX_CONTEXT* context)
+UINT32 rfx_context_get_pixel_format(RFX_CONTEXT* WINPR_RESTRICT context)
 {
 	WINPR_ASSERT(context);
 	return context->pixel_format;
 }
 
-void rfx_context_set_palette(RFX_CONTEXT* context, const BYTE* palette)
+void rfx_context_set_palette(RFX_CONTEXT* WINPR_RESTRICT context,
+                             const BYTE* WINPR_RESTRICT palette)
 {
 	WINPR_ASSERT(context);
 	context->palette = palette;
 }
 
-const BYTE* rfx_context_get_palette(RFX_CONTEXT* context)
+const BYTE* rfx_context_get_palette(RFX_CONTEXT* WINPR_RESTRICT context)
 {
 	WINPR_ASSERT(context);
 	return context->palette;
 }
 
-BOOL rfx_context_reset(RFX_CONTEXT* context, UINT32 width, UINT32 height)
+BOOL rfx_context_reset(RFX_CONTEXT* WINPR_RESTRICT context, UINT32 width, UINT32 height)
 {
 	if (!context)
 		return FALSE;
@@ -454,7 +457,8 @@ BOOL rfx_context_reset(RFX_CONTEXT* context, UINT32 width, UINT32 height)
 	return TRUE;
 }
 
-static BOOL rfx_process_message_sync(RFX_CONTEXT* context, wStream* s)
+static INLINE BOOL rfx_process_message_sync(RFX_CONTEXT* WINPR_RESTRICT context,
+                                            wStream* WINPR_RESTRICT s)
 {
 	UINT32 magic = 0;
 
@@ -486,7 +490,8 @@ static BOOL rfx_process_message_sync(RFX_CONTEXT* context, wStream* s)
 	return TRUE;
 }
 
-static BOOL rfx_process_message_codec_versions(RFX_CONTEXT* context, wStream* s)
+static INLINE BOOL rfx_process_message_codec_versions(RFX_CONTEXT* WINPR_RESTRICT context,
+                                                      wStream* WINPR_RESTRICT s)
 {
 	BYTE numCodecs = 0;
 
@@ -529,7 +534,8 @@ static BOOL rfx_process_message_codec_versions(RFX_CONTEXT* context, wStream* s)
 	return TRUE;
 }
 
-static BOOL rfx_process_message_channels(RFX_CONTEXT* context, wStream* s)
+static INLINE BOOL rfx_process_message_channels(RFX_CONTEXT* WINPR_RESTRICT context,
+                                                wStream* WINPR_RESTRICT s)
 {
 	BYTE channelId = 0;
 	BYTE numChannels = 0;
@@ -585,7 +591,8 @@ static BOOL rfx_process_message_channels(RFX_CONTEXT* context, wStream* s)
 	return TRUE;
 }
 
-static BOOL rfx_process_message_context(RFX_CONTEXT* context, wStream* s)
+static INLINE BOOL rfx_process_message_context(RFX_CONTEXT* WINPR_RESTRICT context,
+                                               wStream* WINPR_RESTRICT s)
 {
 	BYTE ctxId = 0;
 	UINT16 tileSize = 0;
@@ -637,8 +644,10 @@ static BOOL rfx_process_message_context(RFX_CONTEXT* context, wStream* s)
 	return TRUE;
 }
 
-static BOOL rfx_process_message_frame_begin(RFX_CONTEXT* context, RFX_MESSAGE* message, wStream* s,
-                                            UINT16* pExpectedBlockType)
+static INLINE BOOL rfx_process_message_frame_begin(RFX_CONTEXT* WINPR_RESTRICT context,
+                                                   RFX_MESSAGE* WINPR_RESTRICT message,
+                                                   wStream* WINPR_RESTRICT s,
+                                                   UINT16* WINPR_RESTRICT pExpectedBlockType)
 {
 	UINT32 frameIdx = 0;
 	UINT16 numRegions = 0;
@@ -668,8 +677,10 @@ static BOOL rfx_process_message_frame_begin(RFX_CONTEXT* context, RFX_MESSAGE* m
 	return TRUE;
 }
 
-static BOOL rfx_process_message_frame_end(RFX_CONTEXT* context, RFX_MESSAGE* message, wStream* s,
-                                          UINT16* pExpectedBlockType)
+static INLINE BOOL rfx_process_message_frame_end(RFX_CONTEXT* WINPR_RESTRICT context,
+                                                 RFX_MESSAGE* WINPR_RESTRICT message,
+                                                 wStream* WINPR_RESTRICT s,
+                                                 UINT16* WINPR_RESTRICT pExpectedBlockType)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(context->priv);
@@ -688,7 +699,7 @@ static BOOL rfx_process_message_frame_end(RFX_CONTEXT* context, RFX_MESSAGE* mes
 	return TRUE;
 }
 
-static BOOL rfx_resize_rects(RFX_MESSAGE* message)
+static INLINE BOOL rfx_resize_rects(RFX_MESSAGE* WINPR_RESTRICT message)
 {
 	WINPR_ASSERT(message);
 
@@ -700,8 +711,10 @@ static BOOL rfx_resize_rects(RFX_MESSAGE* message)
 	return TRUE;
 }
 
-static BOOL rfx_process_message_region(RFX_CONTEXT* context, RFX_MESSAGE* message, wStream* s,
-                                       UINT16* pExpectedBlockType)
+static INLINE BOOL rfx_process_message_region(RFX_CONTEXT* WINPR_RESTRICT context,
+                                              RFX_MESSAGE* WINPR_RESTRICT message,
+                                              wStream* WINPR_RESTRICT s,
+                                              UINT16* WINPR_RESTRICT pExpectedBlockType)
 {
 	UINT16 regionType = 0;
 	UINT16 numTileSets = 0;
@@ -793,15 +806,16 @@ typedef struct
 	RFX_CONTEXT* context;
 } RFX_TILE_PROCESS_WORK_PARAM;
 
-static void CALLBACK rfx_process_message_tile_work_callback(PTP_CALLBACK_INSTANCE instance,
-                                                            void* context, PTP_WORK work)
+static INLINE void CALLBACK rfx_process_message_tile_work_callback(PTP_CALLBACK_INSTANCE instance,
+                                                                   void* context, PTP_WORK work)
 {
 	RFX_TILE_PROCESS_WORK_PARAM* param = (RFX_TILE_PROCESS_WORK_PARAM*)context;
 	WINPR_ASSERT(param);
 	rfx_decode_rgb(param->context, param->tile, param->tile->data, 64 * 4);
 }
 
-static BOOL rfx_allocate_tiles(RFX_MESSAGE* message, size_t count, BOOL allocOnly)
+static INLINE BOOL rfx_allocate_tiles(RFX_MESSAGE* WINPR_RESTRICT message, size_t count,
+                                      BOOL allocOnly)
 {
 	WINPR_ASSERT(message);
 
@@ -820,8 +834,11 @@ static BOOL rfx_allocate_tiles(RFX_MESSAGE* message, size_t count, BOOL allocOnl
 
 	return TRUE;
 }
-static BOOL rfx_process_message_tileset(RFX_CONTEXT* context, RFX_MESSAGE* message, wStream* s,
-                                        UINT16* pExpectedBlockType)
+
+static INLINE BOOL rfx_process_message_tileset(RFX_CONTEXT* WINPR_RESTRICT context,
+                                               RFX_MESSAGE* WINPR_RESTRICT message,
+                                               wStream* WINPR_RESTRICT s,
+                                               UINT16* WINPR_RESTRICT pExpectedBlockType)
 {
 	BOOL rc = 0;
 	size_t close_cnt = 0;
@@ -1116,9 +1133,10 @@ static BOOL rfx_process_message_tileset(RFX_CONTEXT* context, RFX_MESSAGE* messa
 	return rc;
 }
 
-BOOL rfx_process_message(RFX_CONTEXT* context, const BYTE* data, UINT32 length, UINT32 left,
-                         UINT32 top, BYTE* dst, UINT32 dstFormat, UINT32 dstStride,
-                         UINT32 dstHeight, REGION16* invalidRegion)
+BOOL rfx_process_message(RFX_CONTEXT* WINPR_RESTRICT context, const BYTE* WINPR_RESTRICT data,
+                         UINT32 length, UINT32 left, UINT32 top, BYTE* WINPR_RESTRICT dst,
+                         UINT32 dstFormat, UINT32 dstStride, UINT32 dstHeight,
+                         REGION16* WINPR_RESTRICT invalidRegion)
 {
 	REGION16 updateRegion = { 0 };
 	wStream inStream = { 0 };
@@ -1358,7 +1376,8 @@ BOOL rfx_process_message(RFX_CONTEXT* context, const BYTE* data, UINT32 length, 
 	return FALSE;
 }
 
-const UINT32* rfx_message_get_quants(const RFX_MESSAGE* message, UINT16* numQuantVals)
+const UINT32* rfx_message_get_quants(const RFX_MESSAGE* WINPR_RESTRICT message,
+                                     UINT16* WINPR_RESTRICT numQuantVals)
 {
 	WINPR_ASSERT(message);
 	if (numQuantVals)
@@ -1366,7 +1385,8 @@ const UINT32* rfx_message_get_quants(const RFX_MESSAGE* message, UINT16* numQuan
 	return message->quantVals;
 }
 
-const RFX_TILE** rfx_message_get_tiles(const RFX_MESSAGE* message, UINT16* numTiles)
+const RFX_TILE** rfx_message_get_tiles(const RFX_MESSAGE* WINPR_RESTRICT message,
+                                       UINT16* WINPR_RESTRICT numTiles)
 {
 	WINPR_ASSERT(message);
 	if (numTiles)
@@ -1374,13 +1394,14 @@ const RFX_TILE** rfx_message_get_tiles(const RFX_MESSAGE* message, UINT16* numTi
 	return (const RFX_TILE**)message->tiles;
 }
 
-UINT16 rfx_message_get_tile_count(const RFX_MESSAGE* message)
+UINT16 rfx_message_get_tile_count(const RFX_MESSAGE* WINPR_RESTRICT message)
 {
 	WINPR_ASSERT(message);
 	return message->numTiles;
 }
 
-const RFX_RECT* rfx_message_get_rects(const RFX_MESSAGE* message, UINT16* numRects)
+const RFX_RECT* rfx_message_get_rects(const RFX_MESSAGE* WINPR_RESTRICT message,
+                                      UINT16* WINPR_RESTRICT numRects)
 {
 	WINPR_ASSERT(message);
 	if (numRects)
@@ -1388,13 +1409,13 @@ const RFX_RECT* rfx_message_get_rects(const RFX_MESSAGE* message, UINT16* numRec
 	return message->rects;
 }
 
-UINT16 rfx_message_get_rect_count(const RFX_MESSAGE* message)
+UINT16 rfx_message_get_rect_count(const RFX_MESSAGE* WINPR_RESTRICT message)
 {
 	WINPR_ASSERT(message);
 	return message->numRects;
 }
 
-void rfx_message_free(RFX_CONTEXT* context, RFX_MESSAGE* message)
+void rfx_message_free(RFX_CONTEXT* WINPR_RESTRICT context, RFX_MESSAGE* WINPR_RESTRICT message)
 {
 	if (!message)
 		return;
@@ -1429,7 +1450,7 @@ void rfx_message_free(RFX_CONTEXT* context, RFX_MESSAGE* message)
 		winpr_aligned_free(message);
 }
 
-static void rfx_update_context_properties(RFX_CONTEXT* context)
+static INLINE void rfx_update_context_properties(RFX_CONTEXT* WINPR_RESTRICT context)
 {
 	UINT16 properties = 0;
 
@@ -1444,7 +1465,8 @@ static void rfx_update_context_properties(RFX_CONTEXT* context)
 	context->properties = properties;
 }
 
-static void rfx_write_message_sync(const RFX_CONTEXT* context, wStream* s)
+static INLINE void rfx_write_message_sync(const RFX_CONTEXT* WINPR_RESTRICT context,
+                                          wStream* WINPR_RESTRICT s)
 {
 	WINPR_ASSERT(context);
 
@@ -1454,7 +1476,8 @@ static void rfx_write_message_sync(const RFX_CONTEXT* context, wStream* s)
 	Stream_Write_UINT16(s, WF_VERSION_1_0); /* version (2 bytes) */
 }
 
-static void rfx_write_message_codec_versions(const RFX_CONTEXT* context, wStream* s)
+static INLINE void rfx_write_message_codec_versions(const RFX_CONTEXT* WINPR_RESTRICT context,
+                                                    wStream* WINPR_RESTRICT s)
 {
 	WINPR_ASSERT(context);
 
@@ -1465,7 +1488,8 @@ static void rfx_write_message_codec_versions(const RFX_CONTEXT* context, wStream
 	Stream_Write_UINT16(s, WF_VERSION_1_0);     /* codecs.version (2 bytes) */
 }
 
-static void rfx_write_message_channels(const RFX_CONTEXT* context, wStream* s)
+static INLINE void rfx_write_message_channels(const RFX_CONTEXT* WINPR_RESTRICT context,
+                                              wStream* WINPR_RESTRICT s)
 {
 	WINPR_ASSERT(context);
 
@@ -1477,7 +1501,8 @@ static void rfx_write_message_channels(const RFX_CONTEXT* context, wStream* s)
 	Stream_Write_UINT16(s, context->height); /* Channel.height (2 bytes) */
 }
 
-static void rfx_write_message_context(RFX_CONTEXT* context, wStream* s)
+static INLINE void rfx_write_message_context(RFX_CONTEXT* WINPR_RESTRICT context,
+                                             wStream* WINPR_RESTRICT s)
 {
 	UINT16 properties = 0;
 	WINPR_ASSERT(context);
@@ -1498,7 +1523,8 @@ static void rfx_write_message_context(RFX_CONTEXT* context, wStream* s)
 	rfx_update_context_properties(context);
 }
 
-static BOOL rfx_compose_message_header(RFX_CONTEXT* context, wStream* s)
+static INLINE BOOL rfx_compose_message_header(RFX_CONTEXT* WINPR_RESTRICT context,
+                                              wStream* WINPR_RESTRICT s)
 {
 	WINPR_ASSERT(context);
 	if (!Stream_EnsureRemainingCapacity(s, 12 + 10 + 12 + 13))
@@ -1511,13 +1537,13 @@ static BOOL rfx_compose_message_header(RFX_CONTEXT* context, wStream* s)
 	return TRUE;
 }
 
-static size_t rfx_tile_length(const RFX_TILE* tile)
+static INLINE size_t rfx_tile_length(const RFX_TILE* WINPR_RESTRICT tile)
 {
 	WINPR_ASSERT(tile);
 	return 19ull + tile->YLen + tile->CbLen + tile->CrLen;
 }
 
-static BOOL rfx_write_tile(wStream* s, const RFX_TILE* tile)
+static INLINE BOOL rfx_write_tile(wStream* WINPR_RESTRICT s, const RFX_TILE* WINPR_RESTRICT tile)
 {
 	const size_t blockLen = rfx_tile_length(tile);
 
@@ -1546,16 +1572,16 @@ struct S_RFX_TILE_COMPOSE_WORK_PARAM
 	RFX_CONTEXT* context;
 };
 
-static void CALLBACK rfx_compose_message_tile_work_callback(PTP_CALLBACK_INSTANCE instance,
-                                                            void* context, PTP_WORK work)
+static INLINE void CALLBACK rfx_compose_message_tile_work_callback(PTP_CALLBACK_INSTANCE instance,
+                                                                   void* context, PTP_WORK work)
 {
 	RFX_TILE_COMPOSE_WORK_PARAM* param = (RFX_TILE_COMPOSE_WORK_PARAM*)context;
 	WINPR_ASSERT(param);
 	rfx_encode_rgb(param->context, param->tile);
 }
 
-static BOOL computeRegion(const RFX_RECT* rects, size_t numRects, REGION16* region, size_t width,
-                          size_t height)
+static INLINE BOOL computeRegion(const RFX_RECT* WINPR_RESTRICT rects, size_t numRects,
+                                 REGION16* WINPR_RESTRICT region, size_t width, size_t height)
 {
 	const RECTANGLE_16 mainRect = { 0, 0, width, height };
 
@@ -1578,7 +1604,7 @@ static BOOL computeRegion(const RFX_RECT* rects, size_t numRects, REGION16* regi
 
 #define TILE_NO(v) ((v) / 64)
 
-static BOOL setupWorkers(RFX_CONTEXT* context, size_t nbTiles)
+static INLINE BOOL setupWorkers(RFX_CONTEXT* WINPR_RESTRICT context, size_t nbTiles)
 {
 	WINPR_ASSERT(context);
 
@@ -1603,7 +1629,7 @@ static BOOL setupWorkers(RFX_CONTEXT* context, size_t nbTiles)
 	return TRUE;
 }
 
-static BOOL rfx_ensure_tiles(RFX_MESSAGE* message, size_t count)
+static INLINE BOOL rfx_ensure_tiles(RFX_MESSAGE* WINPR_RESTRICT message, size_t count)
 {
 	WINPR_ASSERT(message);
 
@@ -1614,8 +1640,9 @@ static BOOL rfx_ensure_tiles(RFX_MESSAGE* message, size_t count)
 	return rfx_allocate_tiles(message, alloc, TRUE);
 }
 
-RFX_MESSAGE* rfx_encode_message(RFX_CONTEXT* context, const RFX_RECT* rects, size_t numRects,
-                                const BYTE* data, UINT32 w, UINT32 h, size_t s)
+RFX_MESSAGE* rfx_encode_message(RFX_CONTEXT* WINPR_RESTRICT context,
+                                const RFX_RECT* WINPR_RESTRICT rects, size_t numRects,
+                                const BYTE* WINPR_RESTRICT data, UINT32 w, UINT32 h, size_t s)
 {
 	const UINT32 width = (UINT32)w;
 	const UINT32 height = (UINT32)h;
@@ -1843,7 +1870,8 @@ skip_encoding_loop:
 	return NULL;
 }
 
-static BOOL rfx_clone_rects(RFX_MESSAGE* dst, const RFX_MESSAGE* src)
+static INLINE BOOL rfx_clone_rects(RFX_MESSAGE* WINPR_RESTRICT dst,
+                                   const RFX_MESSAGE* WINPR_RESTRICT src)
 {
 	WINPR_ASSERT(dst);
 	WINPR_ASSERT(src);
@@ -1865,7 +1893,8 @@ static BOOL rfx_clone_rects(RFX_MESSAGE* dst, const RFX_MESSAGE* src)
 	return TRUE;
 }
 
-static BOOL rfx_clone_quants(RFX_MESSAGE* dst, const RFX_MESSAGE* src)
+static INLINE BOOL rfx_clone_quants(RFX_MESSAGE* WINPR_RESTRICT dst,
+                                    const RFX_MESSAGE* WINPR_RESTRICT src)
 {
 	WINPR_ASSERT(dst);
 	WINPR_ASSERT(src);
@@ -1883,8 +1912,9 @@ static BOOL rfx_clone_quants(RFX_MESSAGE* dst, const RFX_MESSAGE* src)
 	return TRUE;
 }
 
-static RFX_MESSAGE* rfx_split_message(RFX_CONTEXT* context, RFX_MESSAGE* message,
-                                      size_t* numMessages, size_t maxDataSize)
+static INLINE RFX_MESSAGE* rfx_split_message(RFX_CONTEXT* WINPR_RESTRICT context,
+                                             RFX_MESSAGE* WINPR_RESTRICT message,
+                                             size_t* WINPR_RESTRICT numMessages, size_t maxDataSize)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(message);
@@ -1944,7 +1974,7 @@ free_messages:
 	return NULL;
 }
 
-const RFX_MESSAGE* rfx_message_list_get(const RFX_MESSAGE_LIST* messages, size_t idx)
+const RFX_MESSAGE* rfx_message_list_get(const RFX_MESSAGE_LIST* WINPR_RESTRICT messages, size_t idx)
 {
 	WINPR_ASSERT(messages);
 	if (idx >= messages->count)
@@ -1962,8 +1992,9 @@ void rfx_message_list_free(RFX_MESSAGE_LIST* messages)
 	free(messages);
 }
 
-static RFX_MESSAGE_LIST* rfx_message_list_new(RFX_CONTEXT* context, RFX_MESSAGE* messages,
-                                              size_t count)
+static INLINE RFX_MESSAGE_LIST* rfx_message_list_new(RFX_CONTEXT* WINPR_RESTRICT context,
+                                                     RFX_MESSAGE* WINPR_RESTRICT messages,
+                                                     size_t count)
 {
 	WINPR_ASSERT(context);
 	RFX_MESSAGE_LIST* msg = calloc(1, sizeof(RFX_MESSAGE_LIST));
@@ -1975,9 +2006,11 @@ static RFX_MESSAGE_LIST* rfx_message_list_new(RFX_CONTEXT* context, RFX_MESSAGE*
 	return msg;
 }
 
-RFX_MESSAGE_LIST* rfx_encode_messages(RFX_CONTEXT* context, const RFX_RECT* rects, size_t numRects,
-                                      const BYTE* data, UINT32 width, UINT32 height,
-                                      UINT32 scanline, size_t* numMessages, size_t maxDataSize)
+RFX_MESSAGE_LIST* rfx_encode_messages(RFX_CONTEXT* WINPR_RESTRICT context,
+                                      const RFX_RECT* WINPR_RESTRICT rects, size_t numRects,
+                                      const BYTE* WINPR_RESTRICT data, UINT32 width, UINT32 height,
+                                      UINT32 scanline, size_t* WINPR_RESTRICT numMessages,
+                                      size_t maxDataSize)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(numMessages);
@@ -1995,7 +2028,9 @@ RFX_MESSAGE_LIST* rfx_encode_messages(RFX_CONTEXT* context, const RFX_RECT* rect
 	return rfx_message_list_new(context, list, *numMessages);
 }
 
-static BOOL rfx_write_message_tileset(RFX_CONTEXT* context, wStream* s, const RFX_MESSAGE* message)
+static INLINE BOOL rfx_write_message_tileset(RFX_CONTEXT* WINPR_RESTRICT context,
+                                             wStream* WINPR_RESTRICT s,
+                                             const RFX_MESSAGE* WINPR_RESTRICT message)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(message);
@@ -2043,8 +2078,9 @@ static BOOL rfx_write_message_tileset(RFX_CONTEXT* context, wStream* s, const RF
 	return TRUE;
 }
 
-static BOOL rfx_write_message_frame_begin(RFX_CONTEXT* context, wStream* s,
-                                          const RFX_MESSAGE* message)
+static INLINE BOOL rfx_write_message_frame_begin(RFX_CONTEXT* WINPR_RESTRICT context,
+                                                 wStream* WINPR_RESTRICT s,
+                                                 const RFX_MESSAGE* WINPR_RESTRICT message)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(message);
@@ -2061,7 +2097,9 @@ static BOOL rfx_write_message_frame_begin(RFX_CONTEXT* context, wStream* s,
 	return TRUE;
 }
 
-static BOOL rfx_write_message_region(RFX_CONTEXT* context, wStream* s, const RFX_MESSAGE* message)
+static INLINE BOOL rfx_write_message_region(RFX_CONTEXT* WINPR_RESTRICT context,
+                                            wStream* WINPR_RESTRICT s,
+                                            const RFX_MESSAGE* WINPR_RESTRICT message)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(message);
@@ -2095,8 +2133,9 @@ static BOOL rfx_write_message_region(RFX_CONTEXT* context, wStream* s, const RFX
 	return TRUE;
 }
 
-static BOOL rfx_write_message_frame_end(RFX_CONTEXT* context, wStream* s,
-                                        const RFX_MESSAGE* message)
+static INLINE BOOL rfx_write_message_frame_end(RFX_CONTEXT* WINPR_RESTRICT context,
+                                               wStream* WINPR_RESTRICT s,
+                                               const RFX_MESSAGE* WINPR_RESTRICT message)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(message);
@@ -2111,7 +2150,8 @@ static BOOL rfx_write_message_frame_end(RFX_CONTEXT* context, wStream* s,
 	return TRUE;
 }
 
-BOOL rfx_write_message(RFX_CONTEXT* context, wStream* s, const RFX_MESSAGE* message)
+BOOL rfx_write_message(RFX_CONTEXT* WINPR_RESTRICT context, wStream* WINPR_RESTRICT s,
+                       const RFX_MESSAGE* WINPR_RESTRICT message)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(message);
@@ -2135,8 +2175,10 @@ BOOL rfx_write_message(RFX_CONTEXT* context, wStream* s, const RFX_MESSAGE* mess
 	return TRUE;
 }
 
-BOOL rfx_compose_message(RFX_CONTEXT* context, wStream* s, const RFX_RECT* rects, size_t numRects,
-                         const BYTE* data, UINT32 width, UINT32 height, UINT32 scanline)
+BOOL rfx_compose_message(RFX_CONTEXT* WINPR_RESTRICT context, wStream* WINPR_RESTRICT s,
+                         const RFX_RECT* WINPR_RESTRICT rects, size_t numRects,
+                         const BYTE* WINPR_RESTRICT data, UINT32 width, UINT32 height,
+                         UINT32 scanline)
 {
 	WINPR_ASSERT(context);
 	RFX_MESSAGE* message =
@@ -2149,32 +2191,33 @@ BOOL rfx_compose_message(RFX_CONTEXT* context, wStream* s, const RFX_RECT* rects
 	return ret;
 }
 
-BOOL rfx_context_set_mode(RFX_CONTEXT* context, RLGR_MODE mode)
+BOOL rfx_context_set_mode(RFX_CONTEXT* WINPR_RESTRICT context, RLGR_MODE mode)
 {
 	WINPR_ASSERT(context);
 	context->mode = mode;
 	return TRUE;
 }
 
-RLGR_MODE rfx_context_get_mode(RFX_CONTEXT* context)
+RLGR_MODE rfx_context_get_mode(RFX_CONTEXT* WINPR_RESTRICT context)
 {
 	WINPR_ASSERT(context);
 	return context->mode;
 }
 
-UINT32 rfx_context_get_frame_idx(const RFX_CONTEXT* context)
+UINT32 rfx_context_get_frame_idx(const RFX_CONTEXT* WINPR_RESTRICT context)
 {
 	WINPR_ASSERT(context);
 	return context->frameIdx;
 }
 
-UINT32 rfx_message_get_frame_idx(const RFX_MESSAGE* message)
+UINT32 rfx_message_get_frame_idx(const RFX_MESSAGE* WINPR_RESTRICT message)
 {
 	WINPR_ASSERT(message);
 	return message->frameIdx;
 }
 
-static INLINE BOOL rfx_write_progressive_wb_sync(RFX_CONTEXT* rfx, wStream* s)
+static INLINE BOOL rfx_write_progressive_wb_sync(RFX_CONTEXT* WINPR_RESTRICT rfx,
+                                                 wStream* WINPR_RESTRICT s)
 {
 	const UINT32 blockLen = 12;
 	WINPR_ASSERT(rfx);
@@ -2190,7 +2233,8 @@ static INLINE BOOL rfx_write_progressive_wb_sync(RFX_CONTEXT* rfx, wStream* s)
 	return TRUE;
 }
 
-static INLINE BOOL rfx_write_progressive_wb_context(RFX_CONTEXT* rfx, wStream* s)
+static INLINE BOOL rfx_write_progressive_wb_context(RFX_CONTEXT* WINPR_RESTRICT rfx,
+                                                    wStream* WINPR_RESTRICT s)
 {
 	const UINT32 blockLen = 10;
 	WINPR_ASSERT(rfx);
@@ -2207,8 +2251,9 @@ static INLINE BOOL rfx_write_progressive_wb_context(RFX_CONTEXT* rfx, wStream* s
 	return TRUE;
 }
 
-static INLINE BOOL rfx_write_progressive_region(RFX_CONTEXT* rfx, wStream* s,
-                                                const RFX_MESSAGE* msg)
+static INLINE BOOL rfx_write_progressive_region(RFX_CONTEXT* WINPR_RESTRICT rfx,
+                                                wStream* WINPR_RESTRICT s,
+                                                const RFX_MESSAGE* WINPR_RESTRICT msg)
 {
 	/* RFX_REGION */
 	UINT32 blockLen = 18;
@@ -2285,8 +2330,9 @@ static INLINE BOOL rfx_write_progressive_region(RFX_CONTEXT* rfx, wStream* s,
 	return (used == blockLen);
 }
 
-static INLINE BOOL rfx_write_progressive_frame_begin(RFX_CONTEXT* rfx, wStream* s,
-                                                     const RFX_MESSAGE* msg)
+static INLINE BOOL rfx_write_progressive_frame_begin(RFX_CONTEXT* WINPR_RESTRICT rfx,
+                                                     wStream* WINPR_RESTRICT s,
+                                                     const RFX_MESSAGE* WINPR_RESTRICT msg)
 {
 	const UINT32 blockLen = 12;
 	WINPR_ASSERT(rfx);
@@ -2304,7 +2350,8 @@ static INLINE BOOL rfx_write_progressive_frame_begin(RFX_CONTEXT* rfx, wStream* 
 	return TRUE;
 }
 
-static INLINE BOOL rfx_write_progressive_frame_end(RFX_CONTEXT* rfx, wStream* s)
+static INLINE BOOL rfx_write_progressive_frame_end(RFX_CONTEXT* WINPR_RESTRICT rfx,
+                                                   wStream* WINPR_RESTRICT s)
 {
 	const UINT32 blockLen = 6;
 	WINPR_ASSERT(rfx);
@@ -2319,8 +2366,9 @@ static INLINE BOOL rfx_write_progressive_frame_end(RFX_CONTEXT* rfx, wStream* s)
 	return TRUE;
 }
 
-static INLINE BOOL rfx_write_progressive_tile_simple(RFX_CONTEXT* rfx, wStream* s,
-                                                     const RFX_TILE* tile)
+static INLINE BOOL rfx_write_progressive_tile_simple(RFX_CONTEXT* WINPR_RESTRICT rfx,
+                                                     wStream* WINPR_RESTRICT s,
+                                                     const RFX_TILE* WINPR_RESTRICT tile)
 {
 	UINT32 blockLen = 0;
 	WINPR_ASSERT(rfx);
@@ -2383,7 +2431,9 @@ const char* rfx_get_progressive_block_type_string(UINT16 blockType)
 	}
 }
 
-BOOL rfx_write_message_progressive_simple(RFX_CONTEXT* context, wStream* s, const RFX_MESSAGE* msg)
+BOOL rfx_write_message_progressive_simple(RFX_CONTEXT* WINPR_RESTRICT context,
+                                          wStream* WINPR_RESTRICT s,
+                                          const RFX_MESSAGE* WINPR_RESTRICT msg)
 {
 	WINPR_ASSERT(s);
 	WINPR_ASSERT(msg);

--- a/libfreerdp/codec/rfx_decode.c
+++ b/libfreerdp/codec/rfx_decode.c
@@ -35,10 +35,10 @@
 
 #include "rfx_decode.h"
 
-void rfx_decode_component(RFX_CONTEXT* WINPR_RESTRICT context,
-                          const UINT32* WINPR_RESTRICT quantization_values,
-                          const BYTE* WINPR_RESTRICT data, size_t size,
-                          INT16* WINPR_RESTRICT buffer)
+static INLINE void rfx_decode_component(RFX_CONTEXT* WINPR_RESTRICT context,
+                                        const UINT32* WINPR_RESTRICT quantization_values,
+                                        const BYTE* WINPR_RESTRICT data, size_t size,
+                                        INT16* WINPR_RESTRICT buffer)
 {
 	INT16* dwt_buffer = NULL;
 	dwt_buffer = BufferPool_Take(context->priv->BufferPool, -1); /* dwt_buffer */
@@ -62,7 +62,8 @@ void rfx_decode_component(RFX_CONTEXT* WINPR_RESTRICT context,
 /* rfx_decode_ycbcr_to_rgb code now resides in the primitives library. */
 
 /* stride is bytes between rows in the output buffer. */
-BOOL rfx_decode_rgb(RFX_CONTEXT* context, const RFX_TILE* tile, BYTE* rgb_buffer, UINT32 stride)
+BOOL rfx_decode_rgb(RFX_CONTEXT* WINPR_RESTRICT context, const RFX_TILE* WINPR_RESTRICT tile,
+                    BYTE* WINPR_RESTRICT rgb_buffer, UINT32 stride)
 {
 	union
 	{

--- a/libfreerdp/codec/rfx_decode.h
+++ b/libfreerdp/codec/rfx_decode.h
@@ -29,8 +29,5 @@
 FREERDP_LOCAL BOOL rfx_decode_rgb(RFX_CONTEXT* WINPR_RESTRICT context,
                                   const RFX_TILE* WINPR_RESTRICT tile,
                                   BYTE* WINPR_RESTRICT rgb_buffer, UINT32 stride);
-FREERDP_LOCAL void rfx_decode_component(RFX_CONTEXT* WINPR_RESTRICT context,
-                                        const UINT32* WINPR_RESTRICT quantization_values,
-                                        const BYTE* WINPR_RESTRICT data, size_t size,
-                                        INT16* WINPR_RESTRICT buffer);
+
 #endif /* FREERDP_LIB_CODEC_RFX_DECODE_H */

--- a/libfreerdp/codec/rfx_differential.h
+++ b/libfreerdp/codec/rfx_differential.h
@@ -23,7 +23,7 @@
 #include <freerdp/codec/rfx.h>
 #include <freerdp/api.h>
 
-static INLINE void rfx_differential_decode(INT16* buffer, int size)
+static INLINE void rfx_differential_decode(INT16* WINPR_RESTRICT buffer, size_t size)
 {
 	INT16* ptr = buffer;
 	INT16* end = &buffer[size - 1];
@@ -35,7 +35,7 @@ static INLINE void rfx_differential_decode(INT16* buffer, int size)
 	}
 }
 
-static INLINE void rfx_differential_encode(INT16* buffer, int size)
+static INLINE void rfx_differential_encode(INT16* WINPR_RESTRICT buffer, size_t size)
 {
 	INT16 n1 = buffer[0];
 	for (int x = 0; x < size - 1; x++)

--- a/libfreerdp/codec/rfx_dwt.c
+++ b/libfreerdp/codec/rfx_dwt.c
@@ -25,7 +25,8 @@
 
 #include "rfx_dwt.h"
 
-static void rfx_dwt_2d_decode_block(INT16* buffer, INT16* idwt, size_t subband_width)
+static INLINE void rfx_dwt_2d_decode_block(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT idwt,
+                                           size_t subband_width)
 {
 	INT16* dst = NULL;
 	INT16* l = NULL;
@@ -114,7 +115,7 @@ static void rfx_dwt_2d_decode_block(INT16* buffer, INT16* idwt, size_t subband_w
 	}
 }
 
-void rfx_dwt_2d_decode(INT16* buffer, INT16* dwt_buffer)
+void rfx_dwt_2d_decode(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer)
 {
 	WINPR_ASSERT(buffer);
 	WINPR_ASSERT(dwt_buffer);
@@ -124,7 +125,8 @@ void rfx_dwt_2d_decode(INT16* buffer, INT16* dwt_buffer)
 	rfx_dwt_2d_decode_block(&buffer[0], dwt_buffer, 32);
 }
 
-static void rfx_dwt_2d_encode_block(INT16* buffer, INT16* dwt, UINT32 subband_width)
+static void rfx_dwt_2d_encode_block(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt,
+                                    UINT32 subband_width)
 {
 	INT16* src = NULL;
 	INT16* l = NULL;
@@ -207,7 +209,7 @@ static void rfx_dwt_2d_encode_block(INT16* buffer, INT16* dwt, UINT32 subband_wi
 	}
 }
 
-void rfx_dwt_2d_encode(INT16* buffer, INT16* dwt_buffer)
+void rfx_dwt_2d_encode(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer)
 {
 	WINPR_ASSERT(buffer);
 	WINPR_ASSERT(dwt_buffer);

--- a/libfreerdp/codec/rfx_dwt.h
+++ b/libfreerdp/codec/rfx_dwt.h
@@ -24,8 +24,11 @@
 #include <freerdp/codec/rfx.h>
 #include <freerdp/api.h>
 
-FREERDP_LOCAL void rfx_dwt_2d_decode(INT16* buffer, INT16* dwt_buffer);
-FREERDP_LOCAL void rfx_dwt_2d_encode(INT16* buffer, INT16* dwt_buffer);
-FREERDP_LOCAL void rfx_dwt_2d_extrapolate_decode(INT16* buffer, INT16* dwt_buffer);
+FREERDP_LOCAL void rfx_dwt_2d_decode(INT16* WINPR_RESTRICT buffer,
+                                     INT16* WINPR_RESTRICT dwt_buffer);
+FREERDP_LOCAL void rfx_dwt_2d_encode(INT16* WINPR_RESTRICT buffer,
+                                     INT16* WINPR_RESTRICT dwt_buffer);
+FREERDP_LOCAL void rfx_dwt_2d_extrapolate_decode(INT16* WINPR_RESTRICT buffer,
+                                                 INT16* WINPR_RESTRICT dwt_buffer);
 
 #endif /* FREERDP_LIB_CODEC_RFX_DWT_H */

--- a/libfreerdp/codec/rfx_encode.c
+++ b/libfreerdp/codec/rfx_encode.c
@@ -39,9 +39,10 @@
 
 #define MINMAX(_v, _l, _h) ((_v) < (_l) ? (_l) : ((_v) > (_h) ? (_h) : (_v)))
 
-static void rfx_encode_format_rgb(const BYTE* rgb_data, int width, int height, int rowstride,
-                                  UINT32 pixel_format, const BYTE* palette, INT16* r_buf,
-                                  INT16* g_buf, INT16* b_buf)
+static void rfx_encode_format_rgb(const BYTE* WINPR_RESTRICT rgb_data, int width, int height,
+                                  int rowstride, UINT32 pixel_format,
+                                  const BYTE* WINPR_RESTRICT palette, INT16* WINPR_RESTRICT r_buf,
+                                  INT16* WINPR_RESTRICT g_buf, INT16* WINPR_RESTRICT b_buf)
 {
 	int x_exceed = 0;
 	int y_exceed = 0;
@@ -233,8 +234,10 @@ static void rfx_encode_format_rgb(const BYTE* rgb_data, int width, int height, i
 
 /* rfx_encode_rgb_to_ycbcr code now resides in the primitives library. */
 
-static void rfx_encode_component(RFX_CONTEXT* context, const UINT32* quantization_values,
-                                 INT16* data, BYTE* buffer, int buffer_size, int* size)
+static void rfx_encode_component(RFX_CONTEXT* WINPR_RESTRICT context,
+                                 const UINT32* WINPR_RESTRICT quantization_values,
+                                 INT16* WINPR_RESTRICT data, BYTE* WINPR_RESTRICT buffer,
+                                 int buffer_size, int* WINPR_RESTRICT size)
 {
 	INT16* dwt_buffer = NULL;
 	dwt_buffer = BufferPool_Take(context->priv->BufferPool, -1); /* dwt_buffer */
@@ -255,7 +258,7 @@ static void rfx_encode_component(RFX_CONTEXT* context, const UINT32* quantizatio
 	BufferPool_Return(context->priv->BufferPool, dwt_buffer);
 }
 
-void rfx_encode_rgb(RFX_CONTEXT* context, RFX_TILE* tile)
+void rfx_encode_rgb(RFX_CONTEXT* WINPR_RESTRICT context, RFX_TILE* WINPR_RESTRICT tile)
 {
 	union
 	{

--- a/libfreerdp/codec/rfx_encode.h
+++ b/libfreerdp/codec/rfx_encode.h
@@ -23,6 +23,7 @@
 #include <freerdp/codec/rfx.h>
 #include <freerdp/api.h>
 
-FREERDP_LOCAL void rfx_encode_rgb(RFX_CONTEXT* context, RFX_TILE* tile);
+FREERDP_LOCAL void rfx_encode_rgb(RFX_CONTEXT* WINPR_RESTRICT context,
+                                  RFX_TILE* WINPR_RESTRICT tile);
 
 #endif /* FREERDP_LIB_CODEC_RFX_ENCODE_H */

--- a/libfreerdp/codec/rfx_quantization.c
+++ b/libfreerdp/codec/rfx_quantization.c
@@ -41,8 +41,9 @@
  * LL3		4032		8x8		64
  */
 
-static void rfx_quantization_decode_block(const primitives_t* WINPR_RESTRICT prims, INT16* buffer,
-                                          UINT32 buffer_size, UINT32 factor)
+static INLINE void rfx_quantization_decode_block(const primitives_t* WINPR_RESTRICT prims,
+                                                 INT16* WINPR_RESTRICT buffer, UINT32 buffer_size,
+                                                 UINT32 factor)
 {
 	if (factor == 0)
 		return;
@@ -50,7 +51,7 @@ static void rfx_quantization_decode_block(const primitives_t* WINPR_RESTRICT pri
 	prims->lShiftC_16s(buffer, factor, buffer, buffer_size);
 }
 
-void rfx_quantization_decode(INT16* buffer, const UINT32* WINPR_RESTRICT quantVals)
+void rfx_quantization_decode(INT16* WINPR_RESTRICT buffer, const UINT32* WINPR_RESTRICT quantVals)
 {
 	const primitives_t* prims = primitives_get();
 	WINPR_ASSERT(buffer);
@@ -68,7 +69,8 @@ void rfx_quantization_decode(INT16* buffer, const UINT32* WINPR_RESTRICT quantVa
 	rfx_quantization_decode_block(prims, &buffer[4032], 64, quantVals[0] - 1);   /* LL3 */
 }
 
-static void rfx_quantization_encode_block(INT16* buffer, size_t buffer_size, UINT32 factor)
+static INLINE void rfx_quantization_encode_block(INT16* WINPR_RESTRICT buffer, size_t buffer_size,
+                                                 UINT32 factor)
 {
 	INT16 half = 0;
 
@@ -83,7 +85,8 @@ static void rfx_quantization_encode_block(INT16* buffer, size_t buffer_size, UIN
 	}
 }
 
-void rfx_quantization_encode(INT16* buffer, const UINT32* WINPR_RESTRICT quantization_values)
+void rfx_quantization_encode(INT16* WINPR_RESTRICT buffer,
+                             const UINT32* WINPR_RESTRICT quantization_values)
 {
 	WINPR_ASSERT(buffer);
 	WINPR_ASSERT(quantization_values);

--- a/libfreerdp/codec/rfx_quantization.h
+++ b/libfreerdp/codec/rfx_quantization.h
@@ -23,7 +23,9 @@
 #include <freerdp/codec/rfx.h>
 #include <freerdp/api.h>
 
-FREERDP_LOCAL void rfx_quantization_decode(INT16* buffer, const UINT32* quantization_values);
-FREERDP_LOCAL void rfx_quantization_encode(INT16* buffer, const UINT32* quantization_values);
+FREERDP_LOCAL void rfx_quantization_decode(INT16* WINPR_RESTRICT buffer,
+                                           const UINT32* WINPR_RESTRICT quantization_values);
+FREERDP_LOCAL void rfx_quantization_encode(INT16* WINPR_RESTRICT buffer,
+                                           const UINT32* WINPR_RESTRICT quantization_values);
 
 #endif /* FREERDP_LIB_CODEC_RFX_QUANTIZATION_H */

--- a/libfreerdp/codec/rfx_sse2.c
+++ b/libfreerdp/codec/rfx_sse2.c
@@ -49,7 +49,8 @@
 		_val = _mm_min_epi16(_max, _mm_max_epi16(_val, _min)); \
 	} while (0)
 
-static __inline void __attribute__((ATTRIBUTES)) _mm_prefetch_buffer(char* buffer, int num_bytes)
+static __inline void __attribute__((ATTRIBUTES))
+_mm_prefetch_buffer(char* WINPR_RESTRICT buffer, int num_bytes)
 {
 	__m128i* buf = (__m128i*)buffer;
 
@@ -64,7 +65,8 @@ static __inline void __attribute__((ATTRIBUTES)) _mm_prefetch_buffer(char* buffe
 /* rfx_encode_rgb_to_ycbcr_sse2 code now resides in the primitives library. */
 
 static __inline void __attribute__((ATTRIBUTES))
-rfx_quantization_decode_block_sse2(INT16* buffer, const size_t buffer_size, const UINT32 factor)
+rfx_quantization_decode_block_sse2(INT16* WINPR_RESTRICT buffer, const size_t buffer_size,
+                                   const UINT32 factor)
 {
 	__m128i a;
 	__m128i* ptr = (__m128i*)buffer;
@@ -82,7 +84,8 @@ rfx_quantization_decode_block_sse2(INT16* buffer, const size_t buffer_size, cons
 	} while (ptr < buf_end);
 }
 
-static void rfx_quantization_decode_sse2(INT16* buffer, const UINT32* WINPR_RESTRICT quantVals)
+static void rfx_quantization_decode_sse2(INT16* WINPR_RESTRICT buffer,
+                                         const UINT32* WINPR_RESTRICT quantVals)
 {
 	WINPR_ASSERT(buffer);
 	WINPR_ASSERT(quantVals);
@@ -101,7 +104,8 @@ static void rfx_quantization_decode_sse2(INT16* buffer, const UINT32* WINPR_REST
 }
 
 static __inline void __attribute__((ATTRIBUTES))
-rfx_quantization_encode_block_sse2(INT16* buffer, const int buffer_size, const UINT32 factor)
+rfx_quantization_encode_block_sse2(INT16* WINPR_RESTRICT buffer, const int buffer_size,
+                                   const UINT32 factor)
 {
 	__m128i a;
 	__m128i* ptr = (__m128i*)buffer;
@@ -123,7 +127,7 @@ rfx_quantization_encode_block_sse2(INT16* buffer, const int buffer_size, const U
 	} while (ptr < buf_end);
 }
 
-static void rfx_quantization_encode_sse2(INT16* buffer,
+static void rfx_quantization_encode_sse2(INT16* WINPR_RESTRICT buffer,
                                          const UINT32* WINPR_RESTRICT quantization_values)
 {
 	WINPR_ASSERT(buffer);
@@ -144,7 +148,8 @@ static void rfx_quantization_encode_sse2(INT16* buffer,
 }
 
 static __inline void __attribute__((ATTRIBUTES))
-rfx_dwt_2d_decode_block_horiz_sse2(INT16* l, INT16* h, INT16* dst, int subband_width)
+rfx_dwt_2d_decode_block_horiz_sse2(INT16* WINPR_RESTRICT l, INT16* WINPR_RESTRICT h,
+                                   INT16* WINPR_RESTRICT dst, int subband_width)
 {
 	INT16* l_ptr = l;
 	INT16* h_ptr = h;
@@ -218,7 +223,8 @@ rfx_dwt_2d_decode_block_horiz_sse2(INT16* l, INT16* h, INT16* dst, int subband_w
 }
 
 static __inline void __attribute__((ATTRIBUTES))
-rfx_dwt_2d_decode_block_vert_sse2(INT16* l, INT16* h, INT16* dst, int subband_width)
+rfx_dwt_2d_decode_block_vert_sse2(INT16* WINPR_RESTRICT l, INT16* WINPR_RESTRICT h,
+                                  INT16* WINPR_RESTRICT dst, int subband_width)
 {
 	INT16* l_ptr = l;
 	INT16* h_ptr = h;
@@ -295,7 +301,8 @@ rfx_dwt_2d_decode_block_vert_sse2(INT16* l, INT16* h, INT16* dst, int subband_wi
 }
 
 static __inline void __attribute__((ATTRIBUTES))
-rfx_dwt_2d_decode_block_sse2(INT16* buffer, INT16* idwt, int subband_width)
+rfx_dwt_2d_decode_block_sse2(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT idwt,
+                             int subband_width)
 {
 	INT16* hl = NULL;
 	INT16* lh = NULL;
@@ -321,7 +328,7 @@ rfx_dwt_2d_decode_block_sse2(INT16* buffer, INT16* idwt, int subband_width)
 	rfx_dwt_2d_decode_block_vert_sse2(l_dst, h_dst, buffer, subband_width);
 }
 
-static void rfx_dwt_2d_decode_sse2(INT16* buffer, INT16* dwt_buffer)
+static void rfx_dwt_2d_decode_sse2(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer)
 {
 	WINPR_ASSERT(buffer);
 	WINPR_ASSERT(dwt_buffer);
@@ -333,7 +340,8 @@ static void rfx_dwt_2d_decode_sse2(INT16* buffer, INT16* dwt_buffer)
 }
 
 static __inline void __attribute__((ATTRIBUTES))
-rfx_dwt_2d_encode_block_vert_sse2(INT16* src, INT16* l, INT16* h, int subband_width)
+rfx_dwt_2d_encode_block_vert_sse2(INT16* WINPR_RESTRICT src, INT16* WINPR_RESTRICT l,
+                                  INT16* WINPR_RESTRICT h, int subband_width)
 {
 	int total_width = 0;
 	__m128i src_2n;
@@ -383,7 +391,8 @@ rfx_dwt_2d_encode_block_vert_sse2(INT16* src, INT16* l, INT16* h, int subband_wi
 }
 
 static __inline void __attribute__((ATTRIBUTES))
-rfx_dwt_2d_encode_block_horiz_sse2(INT16* src, INT16* l, INT16* h, int subband_width)
+rfx_dwt_2d_encode_block_horiz_sse2(INT16* WINPR_RESTRICT src, INT16* WINPR_RESTRICT l,
+                                   INT16* WINPR_RESTRICT h, int subband_width)
 {
 	int first = 0;
 	__m128i src_2n;
@@ -432,7 +441,8 @@ rfx_dwt_2d_encode_block_horiz_sse2(INT16* src, INT16* l, INT16* h, int subband_w
 }
 
 static __inline void __attribute__((ATTRIBUTES))
-rfx_dwt_2d_encode_block_sse2(INT16* buffer, INT16* dwt, int subband_width)
+rfx_dwt_2d_encode_block_sse2(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt,
+                             int subband_width)
 {
 	INT16* hl = NULL;
 	INT16* lh = NULL;
@@ -457,7 +467,7 @@ rfx_dwt_2d_encode_block_sse2(INT16* buffer, INT16* dwt, int subband_width)
 	rfx_dwt_2d_encode_block_horiz_sse2(h_src, lh, hh, subband_width);
 }
 
-static void rfx_dwt_2d_encode_sse2(INT16* buffer, INT16* dwt_buffer)
+static void rfx_dwt_2d_encode_sse2(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer)
 {
 	WINPR_ASSERT(buffer);
 	WINPR_ASSERT(dwt_buffer);

--- a/libfreerdp/codec/rfx_types.h
+++ b/libfreerdp/codec/rfx_types.h
@@ -165,11 +165,13 @@ struct S_RFX_CONTEXT
 	struct S_RFX_MESSAGE currentMessage;
 
 	/* routines */
-	void (*quantization_decode)(INT16* buffer, const UINT32* WINPR_RESTRICT quantization_values);
-	void (*quantization_encode)(INT16* buffer, const UINT32* WINPR_RESTRICT quantization_values);
-	void (*dwt_2d_decode)(INT16* buffer, INT16* dwt_buffer);
-	void (*dwt_2d_extrapolate_decode)(INT16* src, INT16* temp);
-	void (*dwt_2d_encode)(INT16* buffer, INT16* dwt_buffer);
+	void (*quantization_decode)(INT16* WINPR_RESTRICT buffer,
+	                            const UINT32* WINPR_RESTRICT quantization_values);
+	void (*quantization_encode)(INT16* WINPR_RESTRICT buffer,
+	                            const UINT32* WINPR_RESTRICT quantization_values);
+	void (*dwt_2d_decode)(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer);
+	void (*dwt_2d_extrapolate_decode)(INT16* WINPR_RESTRICT src, INT16* WINPR_RESTRICT temp);
+	void (*dwt_2d_encode)(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer);
 	int (*rlgr_decode)(RLGR_MODE mode, const BYTE* WINPR_RESTRICT data, UINT32 data_size,
 	                   INT16* WINPR_RESTRICT buffer, UINT32 buffer_size);
 	int (*rlgr_encode)(RLGR_MODE mode, const INT16* WINPR_RESTRICT data, UINT32 data_size,

--- a/libfreerdp/codec/test/TestFreeRDPCodecCopy.c
+++ b/libfreerdp/codec/test/TestFreeRDPCodecCopy.c
@@ -1,5 +1,8 @@
 
 #include <math.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
 
 #include <winpr/sysinfo.h>
 
@@ -86,6 +89,8 @@ int TestFreeRDPCodecCopy(int argc, char* argv[])
 	WINPR_UNUSED(argc);
 	WINPR_UNUSED(argv);
 
+	UINT32 width = 192;
+	UINT32 height = 108;
 	const UINT32 formats[] = {
 		PIXEL_FORMAT_ABGR15, PIXEL_FORMAT_ARGB15, PIXEL_FORMAT_BGR15,  PIXEL_FORMAT_BGR16,
 		PIXEL_FORMAT_BGR24,  PIXEL_FORMAT_RGB15,  PIXEL_FORMAT_RGB16,  PIXEL_FORMAT_RGB24,
@@ -93,15 +98,28 @@ int TestFreeRDPCodecCopy(int argc, char* argv[])
 		PIXEL_FORMAT_BGRA32, PIXEL_FORMAT_RGBA32, PIXEL_FORMAT_BGRX32, PIXEL_FORMAT_RGBX32,
 	};
 
+	if (argc == 3)
+	{
+		errno = 0;
+		width = strtoul(argv[1], NULL, 0);
+		height = strtoul(argv[2], NULL, 0);
+		if ((errno != 0) || (width == 0) || (height == 0))
+		{
+			char buffer[128] = { 0 };
+			fprintf(stderr, "%s failed: width=%" PRIu32 ", height=%" PRIu32 ", errno=%s\n",
+			        __func__, width, height, winpr_strerror(errno, buffer, sizeof(buffer)));
+			return -1;
+		}
+	}
 	for (size_t x = 0; x < ARRAYSIZE(formats); x++)
 	{
 		const UINT32 SrcFormat = formats[x];
 		for (size_t y = 0; y < ARRAYSIZE(formats); y++)
 		{
 			const UINT32 DstFormat = formats[y];
-			if (!TestFreeRDPImageCopy(1920, 1080, SrcFormat, DstFormat, TEST_RUNS))
+			if (!TestFreeRDPImageCopy(width, height, SrcFormat, DstFormat, TEST_RUNS))
 				return -1;
-			if (!TestFreeRDPImageCopy_no_overlap(1920, 1080, SrcFormat, DstFormat, TEST_RUNS))
+			if (!TestFreeRDPImageCopy_no_overlap(width, height, SrcFormat, DstFormat, TEST_RUNS))
 				return -1;
 		}
 	}

--- a/libfreerdp/codec/xcrush.c
+++ b/libfreerdp/codec/xcrush.c
@@ -161,7 +161,7 @@ static const char* xcrush_get_level_1_compression_flags_string(UINT32 flags)
 }
 #endif
 
-static UINT32 xcrush_update_hash(const BYTE* data, UINT32 size)
+static UINT32 xcrush_update_hash(const BYTE* WINPR_RESTRICT data, UINT32 size)
 {
 	const BYTE* end = NULL;
 	UINT32 seed = 5381; /* same value as in djb2 */
@@ -186,7 +186,9 @@ static UINT32 xcrush_update_hash(const BYTE* data, UINT32 size)
 	return (UINT16)seed;
 }
 
-static int xcrush_append_chunk(XCRUSH_CONTEXT* xcrush, const BYTE* data, UINT32* beg, UINT32 end)
+static int xcrush_append_chunk(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush,
+                               const BYTE* WINPR_RESTRICT data, UINT32* WINPR_RESTRICT beg,
+                               UINT32 end)
 {
 	UINT32 size = 0;
 
@@ -214,8 +216,9 @@ static int xcrush_append_chunk(XCRUSH_CONTEXT* xcrush, const BYTE* data, UINT32*
 	return 1;
 }
 
-static int xcrush_compute_chunks(XCRUSH_CONTEXT* xcrush, const BYTE* data, UINT32 size,
-                                 UINT32* pIndex)
+static int xcrush_compute_chunks(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush,
+                                 const BYTE* WINPR_RESTRICT data, UINT32 size,
+                                 UINT32* WINPR_RESTRICT pIndex)
 {
 	UINT32 offset = 0;
 	UINT32 rotation = 0;
@@ -288,7 +291,8 @@ static int xcrush_compute_chunks(XCRUSH_CONTEXT* xcrush, const BYTE* data, UINT3
 	return 0;
 }
 
-static UINT32 xcrush_compute_signatures(XCRUSH_CONTEXT* xcrush, const BYTE* data, UINT32 size)
+static UINT32 xcrush_compute_signatures(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush,
+                                        const BYTE* WINPR_RESTRICT data, UINT32 size)
 {
 	UINT32 index = 0;
 
@@ -298,7 +302,8 @@ static UINT32 xcrush_compute_signatures(XCRUSH_CONTEXT* xcrush, const BYTE* data
 	return 0;
 }
 
-static void xcrush_clear_hash_table_range(XCRUSH_CONTEXT* xcrush, UINT32 beg, UINT32 end)
+static void xcrush_clear_hash_table_range(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush, UINT32 beg,
+                                          UINT32 end)
 {
 	WINPR_ASSERT(xcrush);
 
@@ -325,8 +330,9 @@ static void xcrush_clear_hash_table_range(XCRUSH_CONTEXT* xcrush, UINT32 beg, UI
 	}
 }
 
-static int xcrush_find_next_matching_chunk(XCRUSH_CONTEXT* xcrush, XCRUSH_CHUNK* chunk,
-                                           XCRUSH_CHUNK** pNextChunk)
+static int xcrush_find_next_matching_chunk(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush,
+                                           XCRUSH_CHUNK* WINPR_RESTRICT chunk,
+                                           XCRUSH_CHUNK** WINPR_RESTRICT pNextChunk)
 {
 	UINT32 index = 0;
 	XCRUSH_CHUNK* next = NULL;
@@ -357,8 +363,9 @@ static int xcrush_find_next_matching_chunk(XCRUSH_CONTEXT* xcrush, XCRUSH_CHUNK*
 	return 1;
 }
 
-static int xcrush_insert_chunk(XCRUSH_CONTEXT* xcrush, XCRUSH_SIGNATURE* signature, UINT32 offset,
-                               XCRUSH_CHUNK** pPrevChunk)
+static int xcrush_insert_chunk(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush,
+                               XCRUSH_SIGNATURE* WINPR_RESTRICT signature, UINT32 offset,
+                               XCRUSH_CHUNK** WINPR_RESTRICT pPrevChunk)
 {
 	UINT32 seed = 0;
 	UINT32 index = 0;
@@ -402,9 +409,10 @@ static int xcrush_insert_chunk(XCRUSH_CONTEXT* xcrush, XCRUSH_SIGNATURE* signatu
 	return 1;
 }
 
-static int xcrush_find_match_length(XCRUSH_CONTEXT* xcrush, UINT32 MatchOffset, UINT32 ChunkOffset,
-                                    UINT32 HistoryOffset, UINT32 SrcSize, UINT32 MaxMatchLength,
-                                    XCRUSH_MATCH_INFO* MatchInfo)
+static int xcrush_find_match_length(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush, UINT32 MatchOffset,
+                                    UINT32 ChunkOffset, UINT32 HistoryOffset, UINT32 SrcSize,
+                                    UINT32 MaxMatchLength,
+                                    XCRUSH_MATCH_INFO* WINPR_RESTRICT MatchInfo)
 {
 	UINT32 MatchSymbol = 0;
 	UINT32 ChunkSymbol = 0;
@@ -497,7 +505,7 @@ static int xcrush_find_match_length(XCRUSH_CONTEXT* xcrush, UINT32 MatchOffset, 
 	return (int)TotalMatchLength;
 }
 
-static int xcrush_find_all_matches(XCRUSH_CONTEXT* xcrush, UINT32 SignatureIndex,
+static int xcrush_find_all_matches(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush, UINT32 SignatureIndex,
                                    UINT32 HistoryOffset, UINT32 SrcOffset, UINT32 SrcSize)
 {
 	UINT32 j = 0;
@@ -599,7 +607,7 @@ static int xcrush_find_all_matches(XCRUSH_CONTEXT* xcrush, UINT32 SignatureIndex
 	return (int)j;
 }
 
-static int xcrush_optimize_matches(XCRUSH_CONTEXT* xcrush)
+static int xcrush_optimize_matches(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush)
 {
 	UINT32 j = 0;
 	UINT32 MatchDiff = 0;
@@ -665,8 +673,9 @@ static int xcrush_optimize_matches(XCRUSH_CONTEXT* xcrush)
 	return (int)TotalMatchLength;
 }
 
-static int xcrush_generate_output(XCRUSH_CONTEXT* xcrush, BYTE* OutputBuffer, UINT32 OutputSize,
-                                  UINT32 HistoryOffset, UINT32* pDstSize)
+static int xcrush_generate_output(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush,
+                                  BYTE* WINPR_RESTRICT OutputBuffer, UINT32 OutputSize,
+                                  UINT32 HistoryOffset, UINT32* WINPR_RESTRICT pDstSize)
 {
 	BYTE* Literals = NULL;
 	BYTE* OutputEnd = NULL;
@@ -748,6 +757,24 @@ static int xcrush_generate_output(XCRUSH_CONTEXT* xcrush, BYTE* OutputBuffer, UI
 	return 1;
 }
 
+static INLINE size_t xcrush_copy_bytes_no_overlap(BYTE* WINPR_RESTRICT dst,
+                                                  const BYTE* WINPR_RESTRICT src, size_t num)
+{
+	// src and dst overlaps
+	// we should copy the area that doesn't overlap repeatly
+	const size_t diff = (dst > src) ? dst - src : src - dst;
+	const size_t rest = num % diff;
+	const size_t end = num - rest;
+
+	for (size_t a = 0; a < end; a += diff)
+		memcpy(&dst[a], &src[a], diff);
+
+	if (rest != 0)
+		memcpy(&dst[end], &src[end], rest);
+
+	return num;
+}
+
 static INLINE size_t xcrush_copy_bytes(BYTE* dst, const BYTE* src, size_t num)
 {
 	WINPR_ASSERT(dst);
@@ -756,25 +783,15 @@ static INLINE size_t xcrush_copy_bytes(BYTE* dst, const BYTE* src, size_t num)
 	if (src + num < dst || src > dst + num)
 		memcpy(dst, src, num);
 	else if (src != dst)
-	{
-		// src and dst overlaps
-		// we should copy the area that doesn't overlap repeatly
-		const size_t diff = (dst > src) ? dst - src : src - dst;
-		const size_t rest = num % diff;
-		const size_t end = num - rest;
-
-		for (size_t a = 0; a < end; a += diff)
-			memcpy(&dst[a], &src[a], diff);
-
-		if (rest != 0)
-			memcpy(&dst[end], &src[end], rest);
-	}
+		return xcrush_copy_bytes_no_overlap(dst, src, num);
 
 	return num;
 }
 
-static int xcrush_decompress_l1(XCRUSH_CONTEXT* xcrush, const BYTE* pSrcData, UINT32 SrcSize,
-                                const BYTE** ppDstData, UINT32* pDstSize, UINT32 flags)
+static int xcrush_decompress_l1(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush,
+                                const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
+                                const BYTE** WINPR_RESTRICT ppDstData,
+                                UINT32* WINPR_RESTRICT pDstSize, UINT32 flags)
 {
 	const BYTE* pSrcEnd = NULL;
 	const BYTE* Literals = NULL;
@@ -894,8 +911,9 @@ static int xcrush_decompress_l1(XCRUSH_CONTEXT* xcrush, const BYTE* pSrcData, UI
 	return 1;
 }
 
-int xcrush_decompress(XCRUSH_CONTEXT* xcrush, const BYTE* pSrcData, UINT32 SrcSize,
-                      const BYTE** ppDstData, UINT32* pDstSize, UINT32 flags)
+int xcrush_decompress(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush, const BYTE* WINPR_RESTRICT pSrcData,
+                      UINT32 SrcSize, const BYTE** WINPR_RESTRICT ppDstData,
+                      UINT32* WINPR_RESTRICT pDstSize, UINT32 flags)
 {
 	int status = 0;
 	UINT32 DstSize = 0;
@@ -940,8 +958,10 @@ int xcrush_decompress(XCRUSH_CONTEXT* xcrush, const BYTE* pSrcData, UINT32 SrcSi
 	return status;
 }
 
-static int xcrush_compress_l1(XCRUSH_CONTEXT* xcrush, const BYTE* pSrcData, UINT32 SrcSize,
-                              BYTE* pDstData, UINT32* pDstSize, UINT32* pFlags)
+static int xcrush_compress_l1(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush,
+                              const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
+                              BYTE* WINPR_RESTRICT pDstData, UINT32* WINPR_RESTRICT pDstSize,
+                              UINT32* WINPR_RESTRICT pFlags)
 {
 	int status = 0;
 	UINT32 Flags = 0;
@@ -1013,8 +1033,10 @@ static int xcrush_compress_l1(XCRUSH_CONTEXT* xcrush, const BYTE* pSrcData, UINT
 	return 1;
 }
 
-int xcrush_compress(XCRUSH_CONTEXT* xcrush, const BYTE* pSrcData, UINT32 SrcSize, BYTE* pDstBuffer,
-                    const BYTE** ppDstData, UINT32* pDstSize, UINT32* pFlags)
+int xcrush_compress(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush, const BYTE* WINPR_RESTRICT pSrcData,
+                    UINT32 SrcSize, BYTE* WINPR_RESTRICT pDstBuffer,
+                    const BYTE** WINPR_RESTRICT ppDstData, UINT32* WINPR_RESTRICT pDstSize,
+                    UINT32* WINPR_RESTRICT pFlags)
 {
 	int status = 0;
 	UINT32 DstSize = 0;
@@ -1122,7 +1144,7 @@ int xcrush_compress(XCRUSH_CONTEXT* xcrush, const BYTE* pSrcData, UINT32 SrcSize
 	return 1;
 }
 
-void xcrush_context_reset(XCRUSH_CONTEXT* xcrush, BOOL flush)
+void xcrush_context_reset(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush, BOOL flush)
 {
 	WINPR_ASSERT(xcrush);
 

--- a/libfreerdp/codec/yuv.c
+++ b/libfreerdp/codec/yuv.c
@@ -67,9 +67,10 @@ struct S_YUV_CONTEXT
 	YUV_COMBINE_WORK_PARAM* work_combined_params;
 };
 
-static INLINE BOOL avc420_yuv_to_rgb(const BYTE* pYUVData[3], const UINT32 iStride[3],
-                                     const RECTANGLE_16* rect, UINT32 nDstStep, BYTE* pDstData,
-                                     DWORD DstFormat)
+static INLINE BOOL avc420_yuv_to_rgb(const BYTE* WINPR_RESTRICT pYUVData[3],
+                                     const UINT32 iStride[3],
+                                     const RECTANGLE_16* WINPR_RESTRICT rect, UINT32 nDstStep,
+                                     BYTE* WINPR_RESTRICT pDstData, DWORD DstFormat)
 {
 	primitives_t* prims = primitives_get();
 	prim_size_t roi;
@@ -99,9 +100,10 @@ static INLINE BOOL avc420_yuv_to_rgb(const BYTE* pYUVData[3], const UINT32 iStri
 	return TRUE;
 }
 
-static INLINE BOOL avc444_yuv_to_rgb(const BYTE* pYUVData[3], const UINT32 iStride[3],
-                                     const RECTANGLE_16* rect, UINT32 nDstStep, BYTE* pDstData,
-                                     DWORD DstFormat)
+static INLINE BOOL avc444_yuv_to_rgb(const BYTE* WINPR_RESTRICT pYUVData[3],
+                                     const UINT32 iStride[3],
+                                     const RECTANGLE_16* WINPR_RESTRICT rect, UINT32 nDstStep,
+                                     BYTE* WINPR_RESTRICT pDstData, DWORD DstFormat)
 {
 	primitives_t* prims = primitives_get();
 	prim_size_t roi;
@@ -157,7 +159,7 @@ static void CALLBACK yuv444_process_work_callback(PTP_CALLBACK_INSTANCE instance
 		WLog_WARN(TAG, "avc444_yuv_to_rgb failed");
 }
 
-BOOL yuv_context_reset(YUV_CONTEXT* context, UINT32 width, UINT32 height)
+BOOL yuv_context_reset(YUV_CONTEXT* WINPR_RESTRICT context, UINT32 width, UINT32 height)
 {
 	BOOL rc = FALSE;
 	WINPR_ASSERT(context);
@@ -275,11 +277,11 @@ void yuv_context_free(YUV_CONTEXT* context)
 	winpr_aligned_free(context);
 }
 
-static INLINE YUV_PROCESS_WORK_PARAM pool_decode_param(const RECTANGLE_16* rect,
-                                                       YUV_CONTEXT* context,
-                                                       const BYTE* pYUVData[3],
+static INLINE YUV_PROCESS_WORK_PARAM pool_decode_param(const RECTANGLE_16* WINPR_RESTRICT rect,
+                                                       YUV_CONTEXT* WINPR_RESTRICT context,
+                                                       const BYTE* WINPR_RESTRICT pYUVData[3],
                                                        const UINT32 iStride[3], UINT32 DstFormat,
-                                                       BYTE* dest, UINT32 nDstStep)
+                                                       BYTE* WINPR_RESTRICT dest, UINT32 nDstStep)
 {
 	YUV_PROCESS_WORK_PARAM current = { 0 };
 
@@ -303,8 +305,8 @@ static INLINE YUV_PROCESS_WORK_PARAM pool_decode_param(const RECTANGLE_16* rect,
 	return current;
 }
 
-static BOOL submit_object(PTP_WORK* work_object, PTP_WORK_CALLBACK cb, const void* param,
-                          YUV_CONTEXT* context)
+static BOOL submit_object(PTP_WORK* WINPR_RESTRICT work_object, PTP_WORK_CALLBACK cb,
+                          const void* WINPR_RESTRICT param, YUV_CONTEXT* WINPR_RESTRICT context)
 {
 	union
 	{
@@ -347,7 +349,8 @@ static void free_objects(PTP_WORK* work_objects, UINT32 waitCount)
 	}
 }
 
-static BOOL intersects(UINT32 pos, const RECTANGLE_16* regionRects, UINT32 numRegionRects)
+static BOOL intersects(UINT32 pos, const RECTANGLE_16* WINPR_RESTRICT regionRects,
+                       UINT32 numRegionRects)
 {
 	WINPR_ASSERT(regionRects || (numRegionRects == 0));
 
@@ -366,7 +369,8 @@ static BOOL intersects(UINT32 pos, const RECTANGLE_16* regionRects, UINT32 numRe
 	return FALSE;
 }
 
-static RECTANGLE_16 clamp(YUV_CONTEXT* context, const RECTANGLE_16* rect, UINT32 srcHeight)
+static RECTANGLE_16 clamp(YUV_CONTEXT* WINPR_RESTRICT context,
+                          const RECTANGLE_16* WINPR_RESTRICT rect, UINT32 srcHeight)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(rect);
@@ -380,9 +384,11 @@ static RECTANGLE_16 clamp(YUV_CONTEXT* context, const RECTANGLE_16* rect, UINT32
 	return c;
 }
 
-static BOOL pool_decode(YUV_CONTEXT* context, PTP_WORK_CALLBACK cb, const BYTE* pYUVData[3],
-                        const UINT32 iStride[3], UINT32 yuvHeight, UINT32 DstFormat, BYTE* dest,
-                        UINT32 nDstStep, const RECTANGLE_16* regionRects, UINT32 numRegionRects)
+static BOOL pool_decode(YUV_CONTEXT* WINPR_RESTRICT context, PTP_WORK_CALLBACK cb,
+                        const BYTE* WINPR_RESTRICT pYUVData[3], const UINT32 iStride[3],
+                        UINT32 yuvHeight, UINT32 DstFormat, BYTE* WINPR_RESTRICT dest,
+                        UINT32 nDstStep, const RECTANGLE_16* WINPR_RESTRICT regionRects,
+                        UINT32 numRegionRects)
 {
 	BOOL rc = FALSE;
 	UINT32 waitCount = 0;
@@ -459,7 +465,8 @@ fail:
 	return rc;
 }
 
-static INLINE BOOL check_rect(const YUV_CONTEXT* yuv, const RECTANGLE_16* rect, UINT32 nDstWidth,
+static INLINE BOOL check_rect(const YUV_CONTEXT* WINPR_RESTRICT yuv,
+                              const RECTANGLE_16* WINPR_RESTRICT rect, UINT32 nDstWidth,
                               UINT32 nDstHeight)
 {
 	WINPR_ASSERT(yuv);
@@ -511,9 +518,10 @@ static void CALLBACK yuv444_combine_work_callback(PTP_CALLBACK_INSTANCE instance
 		WLog_WARN(TAG, "YUV420CombineToYUV444 failed");
 }
 
-static INLINE YUV_COMBINE_WORK_PARAM pool_decode_rect_param(
-    const RECTANGLE_16* rect, YUV_CONTEXT* context, BYTE type, const BYTE* pYUVData[3],
-    const UINT32 iStride[3], BYTE* pYUVDstData[3], const UINT32 iDstStride[3])
+static INLINE YUV_COMBINE_WORK_PARAM
+pool_decode_rect_param(const RECTANGLE_16* WINPR_RESTRICT rect, YUV_CONTEXT* WINPR_RESTRICT context,
+                       BYTE type, const BYTE* WINPR_RESTRICT pYUVData[3], const UINT32 iStride[3],
+                       BYTE* WINPR_RESTRICT pYUVDstData[3], const UINT32 iDstStride[3])
 {
 	YUV_COMBINE_WORK_PARAM current = { 0 };
 
@@ -542,10 +550,10 @@ static INLINE YUV_COMBINE_WORK_PARAM pool_decode_rect_param(
 	return current;
 }
 
-static BOOL pool_decode_rect(YUV_CONTEXT* context, BYTE type, const BYTE* pYUVData[3],
-                             const UINT32 iStride[3], BYTE* pYUVDstData[3],
-                             const UINT32 iDstStride[3], const RECTANGLE_16* regionRects,
-                             UINT32 numRegionRects)
+static BOOL pool_decode_rect(YUV_CONTEXT* WINPR_RESTRICT context, BYTE type,
+                             const BYTE* WINPR_RESTRICT pYUVData[3], const UINT32 iStride[3],
+                             BYTE* WINPR_RESTRICT pYUVDstData[3], const UINT32 iDstStride[3],
+                             const RECTANGLE_16* WINPR_RESTRICT regionRects, UINT32 numRegionRects)
 {
 	BOOL rc = FALSE;
 	UINT32 waitCount = 0;
@@ -597,10 +605,12 @@ fail:
 	return rc;
 }
 
-BOOL yuv444_context_decode(YUV_CONTEXT* context, BYTE type, const BYTE* pYUVData[3],
-                           const UINT32 iStride[3], UINT32 srcYuvHeight, BYTE* pYUVDstData[3],
-                           const UINT32 iDstStride[3], DWORD DstFormat, BYTE* dest, UINT32 nDstStep,
-                           const RECTANGLE_16* regionRects, UINT32 numRegionRects)
+BOOL yuv444_context_decode(YUV_CONTEXT* WINPR_RESTRICT context, BYTE type,
+                           const BYTE* WINPR_RESTRICT pYUVData[3], const UINT32 iStride[3],
+                           UINT32 srcYuvHeight, BYTE* WINPR_RESTRICT pYUVDstData[3],
+                           const UINT32 iDstStride[3], DWORD DstFormat, BYTE* WINPR_RESTRICT dest,
+                           UINT32 nDstStep, const RECTANGLE_16* WINPR_RESTRICT regionRects,
+                           UINT32 numRegionRects)
 {
 	const BYTE* pYUVCDstData[3];
 
@@ -628,9 +638,11 @@ BOOL yuv444_context_decode(YUV_CONTEXT* context, BYTE type, const BYTE* pYUVData
 	                   srcYuvHeight, DstFormat, dest, nDstStep, regionRects, numRegionRects);
 }
 
-BOOL yuv420_context_decode(YUV_CONTEXT* context, const BYTE* pYUVData[3], const UINT32 iStride[3],
-                           UINT32 yuvHeight, DWORD DstFormat, BYTE* dest, UINT32 nDstStep,
-                           const RECTANGLE_16* regionRects, UINT32 numRegionRects)
+BOOL yuv420_context_decode(YUV_CONTEXT* WINPR_RESTRICT context,
+                           const BYTE* WINPR_RESTRICT pYUVData[3], const UINT32 iStride[3],
+                           UINT32 yuvHeight, DWORD DstFormat, BYTE* WINPR_RESTRICT dest,
+                           UINT32 nDstStep, const RECTANGLE_16* WINPR_RESTRICT regionRects,
+                           UINT32 numRegionRects)
 {
 	return pool_decode(context, yuv420_process_work_callback, pYUVData, iStride, yuvHeight,
 	                   DstFormat, dest, nDstStep, regionRects, numRegionRects);
@@ -741,10 +753,10 @@ static void CALLBACK yuv444v2_encode_work_callback(PTP_CALLBACK_INSTANCE instanc
 	}
 }
 
-static INLINE YUV_ENCODE_WORK_PARAM pool_encode_fill(const RECTANGLE_16* rect, YUV_CONTEXT* context,
-                                                     const BYTE* pSrcData, UINT32 nSrcStep,
-                                                     UINT32 SrcFormat, const UINT32 iStride[],
-                                                     BYTE* pYUVLumaData[], BYTE* pYUVChromaData[])
+static INLINE YUV_ENCODE_WORK_PARAM pool_encode_fill(
+    const RECTANGLE_16* WINPR_RESTRICT rect, YUV_CONTEXT* WINPR_RESTRICT context,
+    const BYTE* WINPR_RESTRICT pSrcData, UINT32 nSrcStep, UINT32 SrcFormat, const UINT32 iStride[],
+    BYTE* WINPR_RESTRICT pYUVLumaData[], BYTE* WINPR_RESTRICT pYUVChromaData[])
 {
 	YUV_ENCODE_WORK_PARAM current = { 0 };
 
@@ -776,10 +788,11 @@ static INLINE YUV_ENCODE_WORK_PARAM pool_encode_fill(const RECTANGLE_16* rect, Y
 	return current;
 }
 
-static BOOL pool_encode(YUV_CONTEXT* context, PTP_WORK_CALLBACK cb, const BYTE* pSrcData,
-                        UINT32 nSrcStep, UINT32 SrcFormat, const UINT32 iStride[],
-                        BYTE* pYUVLumaData[], BYTE* pYUVChromaData[],
-                        const RECTANGLE_16* regionRects, UINT32 numRegionRects)
+static BOOL pool_encode(YUV_CONTEXT* WINPR_RESTRICT context, PTP_WORK_CALLBACK cb,
+                        const BYTE* WINPR_RESTRICT pSrcData, UINT32 nSrcStep, UINT32 SrcFormat,
+                        const UINT32 iStride[], BYTE* WINPR_RESTRICT pYUVLumaData[],
+                        BYTE* WINPR_RESTRICT pYUVChromaData[],
+                        const RECTANGLE_16* WINPR_RESTRICT regionRects, UINT32 numRegionRects)
 {
 	BOOL rc = FALSE;
 	primitives_t* prims = primitives_get();
@@ -856,9 +869,10 @@ fail:
 	return rc;
 }
 
-BOOL yuv420_context_encode(YUV_CONTEXT* context, const BYTE* pSrcData, UINT32 nSrcStep,
-                           UINT32 SrcFormat, const UINT32 iStride[3], BYTE* pYUVData[3],
-                           const RECTANGLE_16* regionRects, UINT32 numRegionRects)
+BOOL yuv420_context_encode(YUV_CONTEXT* WINPR_RESTRICT context, const BYTE* WINPR_RESTRICT pSrcData,
+                           UINT32 nSrcStep, UINT32 SrcFormat, const UINT32 iStride[3],
+                           BYTE* WINPR_RESTRICT pYUVData[3],
+                           const RECTANGLE_16* WINPR_RESTRICT regionRects, UINT32 numRegionRects)
 {
 	if (!context || !pSrcData || !iStride || !pYUVData || !regionRects)
 		return FALSE;
@@ -867,10 +881,11 @@ BOOL yuv420_context_encode(YUV_CONTEXT* context, const BYTE* pSrcData, UINT32 nS
 	                   pYUVData, NULL, regionRects, numRegionRects);
 }
 
-BOOL yuv444_context_encode(YUV_CONTEXT* context, BYTE version, const BYTE* pSrcData,
-                           UINT32 nSrcStep, UINT32 SrcFormat, const UINT32 iStride[3],
-                           BYTE* pYUVLumaData[3], BYTE* pYUVChromaData[3],
-                           const RECTANGLE_16* regionRects, UINT32 numRegionRects)
+BOOL yuv444_context_encode(YUV_CONTEXT* WINPR_RESTRICT context, BYTE version,
+                           const BYTE* WINPR_RESTRICT pSrcData, UINT32 nSrcStep, UINT32 SrcFormat,
+                           const UINT32 iStride[3], BYTE* WINPR_RESTRICT pYUVLumaData[3],
+                           BYTE* WINPR_RESTRICT pYUVChromaData[3],
+                           const RECTANGLE_16* WINPR_RESTRICT regionRects, UINT32 numRegionRects)
 {
 	PTP_WORK_CALLBACK cb = NULL;
 	switch (version)

--- a/libfreerdp/codec/zgfx.c
+++ b/libfreerdp/codec/zgfx.c
@@ -114,7 +114,7 @@ static const ZGFX_TOKEN ZGFX_TOKEN_TABLE[] = {
 	{ 0 }
 };
 
-static INLINE BOOL zgfx_GetBits(ZGFX_CONTEXT* zgfx, UINT32 nbits)
+static INLINE BOOL zgfx_GetBits(ZGFX_CONTEXT* WINPR_RESTRICT zgfx, UINT32 nbits)
 {
 	if (!zgfx)
 		return FALSE;
@@ -136,7 +136,8 @@ static INLINE BOOL zgfx_GetBits(ZGFX_CONTEXT* zgfx, UINT32 nbits)
 	return TRUE;
 }
 
-static void zgfx_history_buffer_ring_write(ZGFX_CONTEXT* zgfx, const BYTE* src, size_t count)
+static INLINE void zgfx_history_buffer_ring_write(ZGFX_CONTEXT* WINPR_RESTRICT zgfx,
+                                                  const BYTE* WINPR_RESTRICT src, size_t count)
 {
 	UINT32 front = 0;
 
@@ -167,7 +168,8 @@ static void zgfx_history_buffer_ring_write(ZGFX_CONTEXT* zgfx, const BYTE* src, 
 	}
 }
 
-static void zgfx_history_buffer_ring_read(ZGFX_CONTEXT* zgfx, int offset, BYTE* dst, UINT32 count)
+static INLINE void zgfx_history_buffer_ring_read(ZGFX_CONTEXT* WINPR_RESTRICT zgfx, int offset,
+                                                 BYTE* WINPR_RESTRICT dst, UINT32 count)
 {
 	UINT32 front = 0;
 	UINT32 index = 0;
@@ -214,7 +216,8 @@ static void zgfx_history_buffer_ring_read(ZGFX_CONTEXT* zgfx, int offset, BYTE* 
 	} while ((bytesLeft -= bytes) > 0);
 }
 
-static BOOL zgfx_decompress_segment(ZGFX_CONTEXT* zgfx, wStream* stream, size_t segmentSize)
+static INLINE BOOL zgfx_decompress_segment(ZGFX_CONTEXT* WINPR_RESTRICT zgfx,
+                                           wStream* WINPR_RESTRICT stream, size_t segmentSize)
 {
 	BYTE c = 0;
 	BYTE flags = 0;
@@ -377,13 +380,14 @@ static BOOL zgfx_decompress_segment(ZGFX_CONTEXT* zgfx, wStream* stream, size_t 
  * the actual available data, so ensure that it will never be a
  * out of bounds read.
  */
-static BYTE* aligned_zgfx_malloc(size_t size)
+static INLINE BYTE* aligned_zgfx_malloc(size_t size)
 {
 	return malloc(size + 64);
 }
 
-static BOOL zgfx_append(ZGFX_CONTEXT* zgfx, BYTE** ppConcatenated, size_t uncompressedSize,
-                        size_t* pUsed)
+static INLINE BOOL zgfx_append(ZGFX_CONTEXT* WINPR_RESTRICT zgfx,
+                               BYTE** WINPR_RESTRICT ppConcatenated, size_t uncompressedSize,
+                               size_t* WINPR_RESTRICT pUsed)
 {
 	WINPR_ASSERT(zgfx);
 	WINPR_ASSERT(ppConcatenated);
@@ -405,8 +409,9 @@ static BOOL zgfx_append(ZGFX_CONTEXT* zgfx, BYTE** ppConcatenated, size_t uncomp
 	return TRUE;
 }
 
-int zgfx_decompress(ZGFX_CONTEXT* zgfx, const BYTE* pSrcData, UINT32 SrcSize, BYTE** ppDstData,
-                    UINT32* pDstSize, UINT32 flags)
+int zgfx_decompress(ZGFX_CONTEXT* WINPR_RESTRICT zgfx, const BYTE* WINPR_RESTRICT pSrcData,
+                    UINT32 SrcSize, BYTE** WINPR_RESTRICT ppDstData,
+                    UINT32* WINPR_RESTRICT pDstSize, UINT32 flags)
 {
 	int status = -1;
 	BYTE descriptor = 0;
@@ -488,8 +493,9 @@ fail:
 	return status;
 }
 
-static BOOL zgfx_compress_segment(ZGFX_CONTEXT* zgfx, wStream* s, const BYTE* pSrcData,
-                                  UINT32 SrcSize, UINT32* pFlags)
+static BOOL zgfx_compress_segment(ZGFX_CONTEXT* WINPR_RESTRICT zgfx, wStream* WINPR_RESTRICT s,
+                                  const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
+                                  UINT32* WINPR_RESTRICT pFlags)
 {
 	/* FIXME: Currently compression not implemented. Just copy the raw source */
 	if (!Stream_EnsureRemainingCapacity(s, SrcSize + 1))
@@ -504,8 +510,9 @@ static BOOL zgfx_compress_segment(ZGFX_CONTEXT* zgfx, wStream* s, const BYTE* pS
 	return TRUE;
 }
 
-int zgfx_compress_to_stream(ZGFX_CONTEXT* zgfx, wStream* sDst, const BYTE* pUncompressed,
-                            UINT32 uncompressedSize, UINT32* pFlags)
+int zgfx_compress_to_stream(ZGFX_CONTEXT* WINPR_RESTRICT zgfx, wStream* WINPR_RESTRICT sDst,
+                            const BYTE* WINPR_RESTRICT pUncompressed, UINT32 uncompressedSize,
+                            UINT32* WINPR_RESTRICT pFlags)
 {
 	int fragment = 0;
 	UINT16 maxLength = 0;
@@ -586,8 +593,9 @@ int zgfx_compress_to_stream(ZGFX_CONTEXT* zgfx, wStream* sDst, const BYTE* pUnco
 	return status;
 }
 
-int zgfx_compress(ZGFX_CONTEXT* zgfx, const BYTE* pSrcData, UINT32 SrcSize, BYTE** ppDstData,
-                  UINT32* pDstSize, UINT32* pFlags)
+int zgfx_compress(ZGFX_CONTEXT* WINPR_RESTRICT zgfx, const BYTE* WINPR_RESTRICT pSrcData,
+                  UINT32 SrcSize, BYTE** WINPR_RESTRICT ppDstData, UINT32* WINPR_RESTRICT pDstSize,
+                  UINT32* WINPR_RESTRICT pFlags)
 {
 	int status = 0;
 	wStream* s = Stream_New(NULL, SrcSize);
@@ -598,7 +606,7 @@ int zgfx_compress(ZGFX_CONTEXT* zgfx, const BYTE* pSrcData, UINT32 SrcSize, BYTE
 	return status;
 }
 
-void zgfx_context_reset(ZGFX_CONTEXT* zgfx, BOOL flush)
+void zgfx_context_reset(ZGFX_CONTEXT* WINPR_RESTRICT zgfx, BOOL flush)
 {
 	zgfx->HistoryIndex = 0;
 }

--- a/libfreerdp/gdi/CMakeLists.txt
+++ b/libfreerdp/gdi/CMakeLists.txt
@@ -20,6 +20,11 @@ set(MODULE_PREFIX "FREERDP_GDI")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
+option(WITH_GFX_FRAME_DUMP "Dump GFX commands to directory" OFF)
+if (WITH_GFX_FRAME_DUMP)
+    freerdp_definition_add(-DWITH_GFX_FRAME_DUMP)
+endif()
+
 file(GLOB ${MODULE_PREFIX}_SRCS
 	LIST_DIRECTORIES false
 	RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -912,6 +912,38 @@ fail:
 	return status;
 }
 
+#if defined(WITH_GFX_FRAME_DUMP)
+static void dump_cmd(const RDPGFX_SURFACE_COMMAND* cmd, UINT32 frameId)
+{
+	static UINT64 xxx = 0;
+	const char* path = "/tmp/dump/";
+	WINPR_ASSERT(cmd);
+	char* fname[1024] = { 0 };
+
+	snprintf(fname, sizeof(fname), "%s/%08" PRIx32 ".raw", path, xxx++);
+	FILE* fp = fopen(fname, "w");
+	if (!fp)
+		return;
+	fprintf(fp, "frameid: %" PRIu32 "\n", frameId);
+	fprintf(fp, "surfaceId: %" PRIu32 "\n", cmd->surfaceId);
+	fprintf(fp, "codecId: %" PRIu32 "\n", cmd->codecId);
+	fprintf(fp, "contextId: %" PRIu32 "\n", cmd->contextId);
+	fprintf(fp, "format: %" PRIu32 "\n", cmd->format);
+	fprintf(fp, "left: %" PRIu32 "\n", cmd->left);
+	fprintf(fp, "top: %" PRIu32 "\n", cmd->top);
+	fprintf(fp, "right: %" PRIu32 "\n", cmd->right);
+	fprintf(fp, "bottom: %" PRIu32 "\n", cmd->bottom);
+	fprintf(fp, "width: %" PRIu32 "\n", cmd->width);
+	fprintf(fp, "height: %" PRIu32 "\n", cmd->height);
+	fprintf(fp, "length: %" PRIu32 "\n", cmd->length);
+
+	char* bdata = crypto_base64_encode_ex(cmd->data, cmd->length, FALSE);
+	fprintf(fp, "data: %s\n", bdata);
+	free(bdata);
+	fclose(fp);
+}
+#endif
+
 /**
  * Function description
  *
@@ -1014,6 +1046,9 @@ static UINT gdi_SurfaceCommand(RdpgfxClientContext* context, const RDPGFX_SURFAC
 	           cmd->contextId, FreeRDPGetColorFormatName(cmd->format), cmd->left, cmd->top,
 	           cmd->right, cmd->bottom, cmd->width, cmd->height, cmd->length, (void*)cmd->data,
 	           (void*)cmd->extra);
+#if defined(WITH_GFX_FRAME_DUMP)
+	dump_cmd(cmd, gdi->frameId);
+#endif
 
 	switch (cmd->codecId)
 	{


### PR DESCRIPTION
consistently apply `INLINE` and `WINPR_RESTRICT` to aid compiler optimizations