### PR TITLE
[winpr,crypto] OpenSSL3 md5 support

### DIFF
--- a/winpr/libwinpr/crypto/hash.c
+++ b/winpr/libwinpr/crypto/hash.c
@@ -546,6 +546,15 @@ BOOL winpr_Digest_Init_Allow_FIPS(WINPR_DIGEST_CTX* ctx, WINPR_MD_TYPE md)
 	}
 
 #if defined(WITH_OPENSSL)
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	if (md == WINPR_MD_MD5)
+	{
+		EVP_MD* md5 = EVP_MD_fetch(NULL, "MD5", "fips=no");
+		BOOL rc = winpr_Digest_Init_Internal(ctx, md5);
+		EVP_MD_free(md5);
+		return rc;
+	}
+#endif
 	const EVP_MD* evp = winpr_openssl_get_evp_md(md);
 	EVP_MD_CTX_set_flags(ctx->mdctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
 	return winpr_Digest_Init_Internal(ctx, evp);


### PR DESCRIPTION
Just like https://github.com/MariaDB/server/pull/2010 add support for OpenSSL3 MD5 in FIPS mode.