### PR TITLE
[winpr,pool] fix winpr_SetThreadpoolThreadMaximum

### DIFF
--- a/winpr/libwinpr/pool/pool.c
+++ b/winpr/libwinpr/pool/pool.c
@@ -249,7 +249,7 @@ VOID winpr_SetThreadpoolThreadMaximum(PTP_POOL ptpp, DWORD cthrdMost)
 		ArrayList_Clear(ptpp->Threads);
 		ResetEvent(ptpp->TerminateEvent);
 	}
-	ArrayList_Lock(ptpp->Threads);
+	ArrayList_Unlock(ptpp->Threads);
 	winpr_SetThreadpoolThreadMinimum(ptpp, ptpp->Minimum);
 }
 


### PR DESCRIPTION
unlock the arraylist, don´t lock it twice.