### PR TITLE
Fix errno undeclared error in json.c on Ubuntu

### DIFF
--- a/winpr/libwinpr/utils/json/json.c
+++ b/winpr/libwinpr/utils/json/json.c
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 #include <math.h>
+#include <errno.h>
 
 #include <winpr/json.h>
 #include <winpr/assert.h>


### PR DESCRIPTION
On Ubuntu 20.04, there is a compilation error:
```
/home/oleg/src/freerdp/winpr/libwinpr/utils/json/json.c:72:2: error: ‘errno’ undeclared (first use in this function)
   72 |  errno = 0;
      |  ^~~~~
/home/oleg/src/freerdp/winpr/libwinpr/utils/json/json.c:27:1: note: ‘errno’ is defined in header ‘<errno.h>’; did you forget to ‘#include <errno.h>’?
   26 | #include <cjson/cJSON.h>
  +++ |+#include <errno.h>
   27 | #endif
```
