### PR TITLE
[channel,rdpecam] framerate support and h264 bitrate tuneup

### DIFF
--- a/channels/rdpecam/client/camera.h
+++ b/channels/rdpecam/client/camera.h
@@ -56,11 +56,6 @@
  */
 #define ECAM_SAMPLE_RESPONSE_BUFFER_SIZE (1024 * 4050)
 
-/* 4 Mbps max encoded bitrate seems to produce reasonably
- * good quality with H264_RATECONTROL_VBR.
- */
-#define ECAM_H264_ENCODED_BITRATE 4000000
-
 typedef struct s_ICamHal ICamHal;
 
 typedef struct


### PR DESCRIPTION
1. To determine camera frame rates and sizes, use ioctl `VIDIOC_ENUM_FRAMEINTERVALS` and `VIDIOC_ENUM_FRAMESIZES`. Get rid of hardcoded framerate 30 and `videoSizes` table.

2. Some tuneup of how max bitrate for h264 encoding is determined: use a table based on stream resolution (height). The values are smaller comparing to old fixed value of 4 Mbps, which should help with slow uplink connections.

This fix may also help with https://github.com/FreeRDP/FreeRDP/issues/10274

Cc: @progxaker,  @hardening, @akallabeth 
