### PR TITLE
[channel,rdpecam] MJPEG input format support

### DIFF
--- a/channels/rdpecam/client/CMakeLists.txt
+++ b/channels/rdpecam/client/CMakeLists.txt
@@ -31,6 +31,16 @@ else()
 	message(FATAL_ERROR "libv4l-dev required for CHANNEL_RDPECAM_CLIENT")
 endif()
 
+option(RDPECAM_INPUT_FORMAT_H264 "[MS-RDPECAM] Enable H264 camera format (passthrough)" ON)
+if(RDPECAM_INPUT_FORMAT_H264)
+	add_definitions("-DWITH_INPUT_FORMAT_H264")
+endif()
+
+option(RDPECAM_INPUT_FORMAT_MJPG "[MS-RDPECAM] Enable MJPG camera format" ON)
+if(RDPECAM_INPUT_FORMAT_MJPG)
+	add_definitions("-DWITH_INPUT_FORMAT_MJPG")
+endif()
+
 include_directories(SYSTEM ${SWSCALE_INCLUDE_DIRS})
 
 set(${MODULE_PREFIX}_SRCS

--- a/channels/rdpecam/client/camera.h
+++ b/channels/rdpecam/client/camera.h
@@ -25,6 +25,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(WITH_INPUT_FORMAT_MJPG)
+#include <libavcodec/avcodec.h>
+#endif
+
 #include <libswscale/swscale.h>
 #include <libavutil/imgutils.h>
 
@@ -94,8 +98,15 @@ typedef struct
 	wStream* sampleRespBuffer;
 
 	H264_CONTEXT* h264;
+
+#if defined(WITH_INPUT_FORMAT_MJPG)
+	AVCodecContext* avContext;
+	AVPacket* avInputPkt;
+	AVFrame* avOutFrame;
+#endif
+
+	/* sws_scale */
 	struct SwsContext* sws;
-	int srcLineSizes[4];
 
 } CameraDeviceStream;
 

--- a/channels/rdpecam/client/camera_device_main.c
+++ b/channels/rdpecam/client/camera_device_main.c
@@ -24,11 +24,16 @@
 #define TAG CHANNELS_TAG("rdpecam-device.client")
 
 /* supported formats in preference order:
- * passthrough, I420 (used as input for H264 encoder), other YUV based, RGB based
+ * H264, MJPG, I420 (used as input for H264 encoder), other YUV based, RGB based
  */
 static const CAM_MEDIA_FORMAT_INFO supportedFormats[] = {
-	/* inputFormat, outputFormat */
-	{ CAM_MEDIA_FORMAT_H264, CAM_MEDIA_FORMAT_H264 }, /* passthrough: comment out to disable */
+/* inputFormat, outputFormat */
+#if defined(WITH_INPUT_FORMAT_H264)
+	{ CAM_MEDIA_FORMAT_H264, CAM_MEDIA_FORMAT_H264 }, /* passthrough */
+#endif
+#if defined(WITH_INPUT_FORMAT_MJPG)
+	{ CAM_MEDIA_FORMAT_MJPG, CAM_MEDIA_FORMAT_H264 },
+#endif
 	{ CAM_MEDIA_FORMAT_I420, CAM_MEDIA_FORMAT_H264 },
 	{ CAM_MEDIA_FORMAT_YUY2, CAM_MEDIA_FORMAT_H264 },
 	{ CAM_MEDIA_FORMAT_NV12, CAM_MEDIA_FORMAT_H264 },


### PR DESCRIPTION
Adding support for MJPEG camera format, using FFMPEG library decoder.

Higher end web cameras, supporting 720p and higher resolutions at 30 fps, are using MJPEG format. This allows to overcome USB 2.0 throughput limitation, that would otherwise be encountered with uncompressed formats, such as YUYV. Even laptop cameras typically use USB 2.0 bus internally, so MJPEG support is required for 720p and 1080p at 30 fps.

To check, if camera supports MJPEG format:
```
v4l2-ctl --list-formats --device=/dev/video0
```

Cc: @akallabeth, @hardening