### PR TITLE
Resolves the issue of out-of-bounds reading of uninitialized data causing request processing failure.

### DIFF
--- a/channels/cliprdr/cliprdr_common.c
+++ b/channels/cliprdr/cliprdr_common.c
@@ -360,7 +360,7 @@ UINT cliprdr_read_file_contents_request(wStream* s, CLIPRDR_FILE_CONTENTS_REQUES
 	Stream_Read_UINT32(s, request->nPositionHigh); /* nPositionHigh (4 bytes) */
 	Stream_Read_UINT32(s, request->cbRequested);   /* cbRequested (4 bytes) */
 
-	if (Stream_GetRemainingLength(s) >= 4)
+	if (Stream_GetRemainingLength(s) >= sizeof(CLIPRDR_FILE_CONTENTS_REQUEST) - sizeof(CLIPRDR_HEADER) - sizeof(BOOL))
 	{
 		Stream_Read_UINT32(s, request->clipDataId); /* clipDataId (4 bytes) */
 		request->haveClipDataId = TRUE;

--- a/channels/cliprdr/cliprdr_common.c
+++ b/channels/cliprdr/cliprdr_common.c
@@ -360,7 +360,7 @@ UINT cliprdr_read_file_contents_request(wStream* s, CLIPRDR_FILE_CONTENTS_REQUES
 	Stream_Read_UINT32(s, request->nPositionHigh); /* nPositionHigh (4 bytes) */
 	Stream_Read_UINT32(s, request->cbRequested);   /* cbRequested (4 bytes) */
 
-	if (Stream_GetRemainingLength(s) >= sizeof(CLIPRDR_FILE_CONTENTS_REQUEST) - sizeof(CLIPRDR_HEADER) - sizeof(BOOL))
+	if (request->common.dataLen >= sizeof(CLIPRDR_FILE_CONTENTS_REQUEST) - sizeof(CLIPRDR_HEADER) - sizeof(BOOL))
 	{
 		Stream_Read_UINT32(s, request->clipDataId); /* clipDataId (4 bytes) */
 		request->haveClipDataId = TRUE;


### PR DESCRIPTION
## Problem
An internal error occasionally occurs when pasting files to a remote desktop via cliprdr.
## Analysis
The cliprdr_packet_file_contents_request_new function always allocates 36 bytes to the wStream object, even if haveClipDataId is FALSE. However, when reading the wStream object (in cliprdr_read_file_contents_request function), it determines whether there is a ClipDataId based on its length.
