### PR TITLE
[winpr,timezone] fix windows timezone mappings

### DIFF
--- a/winpr/libwinpr/timezone/TimeZoneNameMapUtils.c
+++ b/winpr/libwinpr/timezone/TimeZoneNameMapUtils.c
@@ -115,7 +115,28 @@ static const char* map_fallback(const char* iana, TimeZoneNameType type)
 	for (size_t x = 0; x < WindowsZonesNrElements; x++)
 	{
 		const WINDOWS_TZID_ENTRY* const entry = &WindowsZones[x];
-		if (strcmp(entry->tzid, iana) == 0)
+		if (strchr(entry->tzid, ' '))
+		{
+			const char* res = NULL;
+			char* tzid = _strdup(entry->tzid);
+			char* ctzid = tzid;
+			while (tzid)
+			{
+				char* space = strchr(tzid, ' ');
+				if (space)
+					*space++ = '\0';
+				if (strcmp(tzid, iana) == 0)
+				{
+					res = entry->windows;
+					break;
+				}
+				tzid = space;
+			}
+			free(ctzid);
+			if (res)
+				return res;
+		}
+		else if (strcmp(entry->tzid, iana) == 0)
 			return entry->windows;
 	}
 

--- a/winpr/libwinpr/timezone/WindowsZones.h
+++ b/winpr/libwinpr/timezone/WindowsZones.h
@@ -8,8 +8,8 @@
 
 typedef struct
 {
-	const char* windows;
 	const char* tzid;
+	const char* windows;
 } WINDOWS_TZID_ENTRY;
 
 extern const WINDOWS_TZID_ENTRY WindowsZones[];


### PR DESCRIPTION
On systems build without `-DWITH_TIMEZONE_ICU=ON` (and not windows) the fallback mapping was broken. 
* WINDOWS_TZID_ENTRY struct members were inverted
* Entries with multiple IANA entries (separated by space) are now each checked for a match
