### PR TITLE
[rdpsnd,ios] Fix rdpsnd_ios_open method signature

### DIFF
--- a/channels/rdpsnd/client/ios/rdpsnd_ios.c
+++ b/channels/rdpsnd/client/ios/rdpsnd_ios.c
@@ -144,7 +144,7 @@ static UINT rdpsnd_ios_play(rdpsndDevicePlugin* device, const BYTE* data, size_t
 }
 
 static BOOL rdpsnd_ios_open(rdpsndDevicePlugin* device, const AUDIO_FORMAT* format,
-                            int __unused latency)
+                            UINT32 __unused latency)
 {
 	rdpsndIOSPlugin* p = THIS(device);
 


### PR DESCRIPTION
Fixes compilation with `WITH_IOSAUDIO`.