### PR TITLE
core: Fix handling of logon errors during nla_client_begin

### DIFF
--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -505,6 +505,16 @@ int nla_client_begin(rdpNla* nla)
 			nla_set_state(nla, NLA_STATE_FINAL);
 			break;
 		default:
+			switch (credssp_auth_sspi_error(nla->auth))
+			{
+				case SEC_E_LOGON_DENIED:
+				case SEC_E_NO_CREDENTIALS:
+					freerdp_set_last_error_log(nla->rdpcontext,
+					                           FREERDP_ERROR_CONNECT_LOGON_FAILURE);
+					break;
+				default:
+					break;
+			}
 			return -1;
 	}
 


### PR DESCRIPTION
Under certain circumstances `InitializeSecurityContext` returns an error if a wrong password was provided. This PR checks the returned status code and correctly sets the last error code. This allows a client application to ask the user again for credentials.

A scenario where this happens is when a user tries to connect with a wrong password and both machines are joined to the same domain.
