### PR TITLE
[core,capabilities] fix CapsProtocolVersion

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -221,8 +221,9 @@ static BOOL rdp_read_general_capability_set(wStream* s, rdpSettings* settings)
 		{
 			WLog_WARN(TAG,
 			          "TS_GENERAL_CAPABILITYSET::protocolVersion(0x%04" PRIx16
-			          " assuming old FreeRDP, ignoring protocol violation.",
+			          " assuming old FreeRDP, ignoring protocol violation, correcting value.",
 			          settings->CapsProtocolVersion);
+			settings->CapsProtocolVersion = TS_CAPS_PROTOCOLVERSION;
 		}
 		else
 			return FALSE;


### PR DESCRIPTION
if the wrong version 0x0000 is sent (older FreeRDP based servers) correct the value to TS_CAPS_PROTOCOLVERSION (0x0200) along with a warning message.