### PR TITLE
libfreerdp: fix cmake typo

### DIFF
--- a/libfreerdp/codec/CMakeLists.txt
+++ b/libfreerdp/codec/CMakeLists.txt
@@ -64,7 +64,7 @@ include (DetectIntrinsicSupport)
 
 if(WITH_SSE2)
 
-    if (HAVE_SSE_OR_AVC)
+    if (HAVE_SSE_OR_AVX)
 	if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
 		if (CODEC_SSE2_SRCS)
 			set_source_files_properties(${CODEC_SSE2_SRCS} PROPERTIES COMPILE_FLAGS "-msse2" )


### PR DESCRIPTION
The refactor of the intrinsics detection on the last version broke building on i686. Basically, the typo meant that while SSE2 was enabled for the project, it was not for the compiler.
