### PR TITLE
[client,x11] fix typo in help

### DIFF
--- a/client/X11/cli/xfreerdp.c
+++ b/client/X11/cli/xfreerdp.c
@@ -43,7 +43,7 @@ static void xfreerdp_print_help(void)
 	printf("\tAction Script\n");
 	printf("\t\tExecutes a predefined script on key press.\n");
 	printf("\t\tShould the script not exist it is ignored.\n");
-	printf("\t\tScripts can be provided at the default localtion ~/.config/freerdp/action.sh or as "
+	printf("\t\tScripts can be provided at the default location ~/.config/freerdp/action.sh or as "
 	       "command line argument /action:script:<path>\n");
 	printf("\t\tThe script will receive the current key combination as argument.\n");
 	printf("\t\tThe output of the script is parsed for 'key-local' which tells that the script "

--- a/client/X11/man/xfreerdp-shortcuts.1.xml
+++ b/client/X11/man/xfreerdp-shortcuts.1.xml
@@ -17,7 +17,7 @@
             <term>Action Script</term>
             <listitem><para>executes a predefined script on key press.</para></listitem>
             <listitem><para>Should the script not exist it is ignored.</para></listitem>
-            <listitem><para>Scripts can be provided at the default localtion ~/.config/freerdp/action.sh or as command line argument /action:script:&lt;path&gt;.</para></listitem>
+            <listitem><para>Scripts can be provided at the default location ~/.config/freerdp/action.sh or as command line argument /action:script:&lt;path&gt;.</para></listitem>
             <listitem><para>The script will receive the current key combination as argument.</para></listitem>
             <listitem><para>The output of the script is parsed for key-local which tells that the script used the key combination, otherwise the combination is forwarded to the remote.</para></listitem>
 		</varlistentry>


### PR DESCRIPTION
There is a typo in the xfreerdp client help. It says "localtion" instead of "location". Let's fix it.