### PR TITLE
Fix: Prevent RemoteAPP window minimization on desktop switch in Gnome

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -23,6 +23,8 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 
+#include <string.h>
+
 #include <winpr/assert.h>
 
 #include <freerdp/log.h>
@@ -35,6 +37,7 @@
 #include "xf_input.h"
 #include "xf_gfx.h"
 #include "xf_graphics.h"
+#include "xf_utils.h"
 
 #include "xf_event.h"
 
@@ -982,7 +985,7 @@ static BOOL xf_event_PropertyNotify(xfContext* xfc, const XPropertyEvent* event,
 			if (status)
 			{
 				/* If the window is in the iconic state */
-				if (((UINT32)*prop == 3))
+				if (((UINT32)*prop == 3) && !IsGnome())
 				{
 					minimized = TRUE;
 					if (appWindow)

--- a/client/X11/xf_utils.c
+++ b/client/X11/xf_utils.c
@@ -18,7 +18,9 @@
  * limitations under the License.
  */
 
+#include <string.h>
 #include <winpr/assert.h>
+#include <winpr/wtypes.h>
 
 #include "xf_utils.h"
 
@@ -149,4 +151,10 @@ int LogDynAndXGetWindowProperty_ex(wLog* log, const char* file, const char* fkt,
 	return XGetWindowProperty(display, w, property, long_offset, long_length, delete, req_type,
 	                          actual_type_return, actual_format_return, nitems_return,
 	                          bytes_after_return, prop_return);
+}
+
+BOOL IsGnome(void)
+{
+	char* env = getenv("DESKTOP_SESSION");
+	return (env != NULL && strcmp(env, "gnome") == 0);
 }

--- a/client/X11/xf_utils.h
+++ b/client/X11/xf_utils.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <winpr/wlog.h>
+#include <winpr/wtypes.h>
 
 #include <X11/Xlib.h>
 
@@ -89,3 +90,5 @@ int LogTagAndXConvertSelection_ex(const char* tag, const char* file, const char*
 int LogDynAndXConvertSelection_ex(wLog* log, const char* file, const char* fkt, size_t line,
                                   Display* display, Atom selection, Atom target, Atom property,
                                   Window requestor, Time time);
+
+BOOL IsGnome(void);


### PR DESCRIPTION
## Summary
This PR addresses an issue where RemoteAPP windows were unintentionally minimized when switching desktops in Gnome (WM Mutter).

## Changes
- Modified `xf_event_PropertyNotify` in `xf_event.c` to check for the Gnome session before setting the minimized state.
- Added a condition to skip setting the minimized state if the desktop session is Gnome.

## Testing
Tested on Gnome with Wayland+Mutter and confirmed that RemoteAPP windows are no longer minimized when switching desktops.

## Issue
Fixes #[2946](https://github.com/FreeRDP/FreeRDP/issues/2946)

## Future Work
I have identified other issues with Mutter, related to window behavior during maximization and subsequent restoration. These issues did not appear with KWin + Wayland. I will work on fixing these problems for Gnome users in future pull requests.
