### PR TITLE
fix(winpr-json): typos causing make errors

### DIFF
--- a/winpr/libwinpr/utils/json/json.c
+++ b/winpr/libwinpr/utils/json/json.c
@@ -252,7 +252,7 @@ double WINPR_JSON_GetNumberValue(const WINPR_JSON* const item)
 	return cJSON_GetNumberValue((const cJSON*)item);
 #else
 	WINPR_UNUSED(item);
-	return nan(NULL);
+	return nan("");
 #endif
 }
 
@@ -623,8 +623,8 @@ BOOL WINPR_JSON_AddItemToArray(WINPR_JSON* array, WINPR_JSON* item)
 #elif defined(WITH_CJSON)
 	return cJSON_AddItemToArray((cJSON*)array, (cJSON*)item);
 #else
-	WINPR_UNUSED(object);
-	WINPR_UNUSED(name);
+	WINPR_UNUSED(array);
+	WINPR_UNUSED(item);
 	return FALSE;
 #endif
 }


### PR DESCRIPTION
I've tried to compile the latest master changes on a fresh install of PopOS 22.04 LTS running the following:
```
git clone https://github.com/FreeRDP/FreeRDP.git
cd FreeRDP
mkdir build
cd build
cmake ..
```
(I had to install a couple of additional packages to be able to move forward)

However, in the end, I ended up with the following error:
```
/home/User/Test/FreeRDP/winpr/libwinpr/utils/json/json.c:255:16: warning: argument 1 null where non-null expected [-Wnonnull]
  255 |         return nan(NULL);
      |                ^~~
```

To move forward and get rid of that error, I had to change the `return nan(NULL);` with `return nan("");`

After fixing the above error, I've faced another one:
```
[  8%] Building C object winpr/libwinpr/CMakeFiles/winpr.dir/utils/json/json.c.o
In file included from /home/User/Test/FreeRDP/winpr/include/winpr/json.h:24,
                 from /home/User/Test/FreeRDP/winpr/libwinpr/utils/json/json.c:23:
/home/User/Test/FreeRDP/winpr/libwinpr/utils/json/json.c: In function ‘WINPR_JSON_AddItemToArray’:
/home/User/Test/FreeRDP/winpr/libwinpr/utils/json/json.c:626:22: error: ‘object’ undeclared (first use in this function)
  626 |         WINPR_UNUSED(object);
      |                      ^~~~~~
```
Looking at the code it seemed like the else statement of `WINPR_JSON_AddItemToArray` was not aligned "after it was copied" with the func args, so I changed it from:
```
WINPR_UNUSED(object);
WINPR_UNUSED(name);
```
To:
```
WINPR_UNUSED(array);
WINPR_UNUSED(item);
```

I'm submitting those code changes as I see them as trivial code patches to prevent somebody else from facing the same errors.
