### PR TITLE
[client,x11] log variable name for XGetAtomName

### DIFF
--- a/client/X11/xf_utils.c
+++ b/client/X11/xf_utils.c
@@ -40,9 +40,9 @@ static void write_log(wLog* log, DWORD level, const char* fname, const char* fkt
 	va_end(ap);
 }
 
-char* Safe_XGetAtomName(wLog* log, Display* display, Atom atom)
+char* Safe_XGetAtomNameEx(wLog* log, Display* display, Atom atom, const char* atomvar)
 {
-	WLog_Print(log, log_level, "XGetAtomName(0x%08" PRIx32 ")", atom);
+	WLog_Print(log, log_level, "XGetAtomName(%s, 0x%08" PRIx32 ")", atomvar, atom);
 	if (atom == None)
 		return strdup("Atom_None");
 	return XGetAtomName(display, atom);
@@ -54,7 +54,7 @@ Atom Logging_XInternAtom(wLog* log, Display* display, _Xconst char* atom_name, B
 	if (WLog_IsLevelActive(log, log_level))
 	{
 		WLog_Print(log, log_level, "XInternAtom(0x%08" PRIx32 ", %s, %s) -> 0x%08" PRIx32, display,
-		           atom_name, only_if_exists, atom);
+		           atom_name, only_if_exists ? "True" : "False", atom);
 	}
 	return atom;
 }

--- a/client/X11/xf_utils.h
+++ b/client/X11/xf_utils.h
@@ -25,7 +25,10 @@
 #include <X11/Xlib.h>
 #include "xfreerdp.h"
 
-char* Safe_XGetAtomName(wLog* log, Display* display, Atom atom);
+#define X_GET_ATOM_VAR_NAME(x) #x
+#define Safe_XGetAtomName(log, display, atom) \
+	Safe_XGetAtomNameEx((log), (display), (atom), X_GET_ATOM_VAR_NAME(atom))
+char* Safe_XGetAtomNameEx(wLog* log, Display* display, Atom atom, const char* varname);
 Atom Logging_XInternAtom(wLog* log, Display* display, _Xconst char* atom_name, Bool only_if_exists);
 
 typedef BOOL (*fn_action_script_run)(xfContext* xfc, const char* buffer, size_t size, void* user,


### PR DESCRIPTION
To better debug issues with calls log the name of the target variable to allow better tracing which call did fail