### PR TITLE
[client,common] add WITH_INSTALL_CLIENT_DESKTOP_FILES

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -18,6 +18,7 @@
 # Clients
 
 include(CMakeDependentOption)
+include(InstallFreeRDPDesktop)
 
 if(WITH_CLIENT_COMMON)
 	add_subdirectory(common)

--- a/client/SDL/SDL2/CMakeLists.txt
+++ b/client/SDL/SDL2/CMakeLists.txt
@@ -77,5 +77,6 @@ if (NOT WITH_CLIENT_SDL_VERSIONED)
 endif()
 
 install(TARGETS ${MODULE_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT client)
+install_freerdp_desktop("${MODULE_NAME}")
 
 add_subdirectory(man)

--- a/client/SDL/SDL3/CMakeLists.txt
+++ b/client/SDL/SDL3/CMakeLists.txt
@@ -76,5 +76,6 @@ if (NOT WITH_CLIENT_SDL_VERSIONED)
 	)
 endif()
 install(TARGETS ${MODULE_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT client)
+install_freerdp_desktop("${MODULE_NAME}" "${MODULE_NAME}")
 
 add_subdirectory(man)

--- a/client/Sample/CMakeLists.txt
+++ b/client/Sample/CMakeLists.txt
@@ -56,3 +56,4 @@ target_link_libraries(${PROJECT_NAME} PRIVATE ${LIBS})
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER "Client/Sample")
 install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT client)
+install_freerdp_desktop("${PROJECT_NAME}")

--- a/client/X11/cli/CMakeLists.txt
+++ b/client/X11/cli/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND LIBS
 target_link_libraries(${MODULE_NAME} PRIVATE ${LIBS})
 
 install(TARGETS ${MODULE_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT client)
+install_freerdp_desktop("${MODULE_NAME}")
 
 set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "Client/X11")
 

--- a/cmake/InstallFreeRDPDesktop.cmake
+++ b/cmake/InstallFreeRDPDesktop.cmake
@@ -1,0 +1,39 @@
+include(GNUInstallDirs)
+
+option(WITH_INSTALL_CLIENT_DESKTOP_FILES "Install .desktop files for clients" OFF)
+
+set(DESKTOP_RESOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../resources" CACHE INTERNAL "")
+
+function(install_freerdp_desktop name)
+	if(WITH_INSTALL_CLIENT_DESKTOP_FILES)        
+        get_target_property(FREERDP_APP_NAME ${name} OUTPUT_NAME)
+        set(FREERDP_BIN_NAME "${CMAKE_INSTALL_FULL_BINDIR}/${FREERDP_APP_NAME}")
+		set(FREERDP_DESKTOP_NAME "${CMAKE_CURRENT_BINARY_DIR}/${FREERDP_BIN_NAME}.desktop")
+        set(FREERDP_DESKTOP_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/${FREERDP_BIN_NAME}-file.desktop")
+        configure_file(
+            ${DESKTOP_RESOURCE_DIR}/freerdp.desktop.template
+			${FREERDP_DESKTOP_NAME}
+            @ONLY
+        )
+        configure_file(
+            ${DESKTOP_RESOURCE_DIR}/freerdp-file.desktop.template
+            ${FREERDP_DESKTOP_FILE_NAME}
+            @ONLY
+        )
+		install(
+            FILES 
+				${FREERDP_DESKTOP_NAME}
+                ${FREERDP_DESKTOP_FILE_NAME}
+            DESTINATION
+                ${CMAKE_INSTALL_DATAROOTDIR}/applications
+        )
+        install(
+            FILES
+                ${DESKTOP_RESOURCE_DIR}/FreeRDP_Icon.svg
+            DESTINATION
+                ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps
+            RENAME
+                FreeRDP.svg
+        )
+	endif()
+endfunction()

--- a/resources/freerdp-file.desktop.template
+++ b/resources/freerdp-file.desktop.template
@@ -1,0 +1,16 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=@FREERDP_APP_NAME@
+Comment=Access remote desktops with FreeRDP
+Categories=GTK;GNOME;X-GNOME-NetworkSettings;Network;
+Keywords=remote desktop;rdp;
+TryExec=@FREERDP_BIN_NAME@
+Exec=@FREERDP_BIN_NAME@ %U
+Icon=FreeRDP
+MimeType=x-scheme-handler/rdp;
+Actions=Edit;
+Terminal=true
+StartupNotify=true
+NoDisplay=true
+X-Desktop-File-Install-Version=0.24

--- a/resources/freerdp.desktop.template
+++ b/resources/freerdp.desktop.template
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Name=@FREERDP_APP_NAME@
+X-GNOME-FullName=FreeRDP Remote Desktop Client
+GenericName=FreeRDP RDP Client
+Comment=Connect to RDP servers for remote work or administration
+Exec=@FREERDP_BIN_NAME@
+Icon=FreeRDP
+Terminal=true
+Type=Application
+Keywords=remote desktop;rdp;
+Categories=GTK;GNOME;X-GNOME-NetworkSettings;Network;
+MimeType=x-scheme-handler/rdp;
+StartupNotify=true
+StartupWMClass=com.freerdp.FreeRDP


### PR DESCRIPTION
This new CMake option allows installing .desktop files and application icons if turned on.