### PR TITLE
[crypto,tls] fix AcceptedKey checks

### DIFF
--- a/include/freerdp/crypto/certificate.h
+++ b/include/freerdp/crypto/certificate.h
@@ -65,6 +65,8 @@ extern "C"
 	FREERDP_API char* freerdp_certificate_get_fingerprint(const rdpCertificate* certificate);
 	FREERDP_API char* freerdp_certificate_get_pem(const rdpCertificate* certificate,
 	                                              size_t* pLength);
+	FREERDP_API char* freerdp_certificate_get_pem_ex(const rdpCertificate* certificate,
+	                                                 size_t* pLength, BOOL withCertChain);
 	FREERDP_API BYTE* freerdp_certificate_get_der(const rdpCertificate* certificate,
 	                                              size_t* pLength);
 

--- a/include/freerdp/crypto/certificate_data.h
+++ b/include/freerdp/crypto/certificate_data.h
@@ -60,6 +60,8 @@ extern "C"
 	FREERDP_API UINT16 freerdp_certificate_data_get_port(const rdpCertificateData* cert);
 
 	FREERDP_API const char* freerdp_certificate_data_get_pem(const rdpCertificateData* cert);
+	FREERDP_API const char* freerdp_certificate_data_get_pem_ex(const rdpCertificateData* cert,
+	                                                            BOOL withFullChain);
 	FREERDP_API const char* freerdp_certificate_data_get_subject(const rdpCertificateData* cert);
 	FREERDP_API const char* freerdp_certificate_data_get_issuer(const rdpCertificateData* cert);
 	FREERDP_API const char*

--- a/libfreerdp/crypto/certificate.c
+++ b/libfreerdp/crypto/certificate.c
@@ -1426,6 +1426,12 @@ fail:
 
 char* freerdp_certificate_get_pem(const rdpCertificate* cert, size_t* pLength)
 {
+	return freerdp_certificate_get_pem_ex(cert, pLength, TRUE);
+}
+
+char* freerdp_certificate_get_pem_ex(const rdpCertificate* cert, size_t* pLength,
+                                     BOOL withCertChain)
+{
 	char* pem = NULL;
 	WINPR_ASSERT(cert);
 
@@ -1455,7 +1461,7 @@ char* freerdp_certificate_get_pem(const rdpCertificate* cert, size_t* pLength)
 		goto fail;
 	}
 
-	if (cert->chain)
+	if (cert->chain && withCertChain)
 	{
 		int count = sk_X509_num(cert->chain);
 		for (int x = 0; x < count; x++)

--- a/libfreerdp/crypto/certificate_store.c
+++ b/libfreerdp/crypto/certificate_store.c
@@ -116,7 +116,7 @@ BOOL freerdp_certificate_store_save_data(rdpCertificateStore* store, const rdpCe
 	if (!fp)
 		goto fail;
 
-	fprintf(fp, "%s", freerdp_certificate_data_get_pem(data));
+	fprintf(fp, "%s", freerdp_certificate_data_get_pem_ex(data, FALSE));
 
 	rc = TRUE;
 fail:


### PR DESCRIPTION
* Add freerdp_certificate_get_pem_ex to extract PEM for cert only
* Compare only certificate without certificate chain
* Store only certificate PEM without chain for later comparison
* Do the same for locally accepted certificates, only store the `PEM` without the chain.