### PR TITLE
Set `NTLMSSP_NEGOTIATE_LM_KEY` in when sending AM on ntlmv2

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm_message.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_message.c
@@ -1225,6 +1225,7 @@ SECURITY_STATUS ntlm_write_AuthenticateMessage(NTLM_CONTEXT* context, const PSec
 	if (context->NTLMv2)
 	{
 		message->NegotiateFlags |= NTLMSSP_NEGOTIATE_56;
+		message->NegotiateFlags |= NTLMSSP_NEGOTIATE_LM_KEY;
 
 		if (context->SendVersionInfo)
 			message->NegotiateFlags |= NTLMSSP_NEGOTIATE_VERSION;


### PR DESCRIPTION
Server gets zeros as `LmChallengeResponse` because when the freerdp client sends the `AuthenticateMessage`, the  `NTLMSSP_NEGOTIATE_LM_KEY` flag should be set in order for `LmChallengeResponse` to be sent.
However, the method (`ntlm_write_AuthenticateMessage`) start with flag mask `message->NegotiateFlags` as 0 in no case the bit `NTLMSSP_NEGOTIATE_LM_KEY` is set. 
I've set it under `NTLMv2` because of a precedent in a different function.