### PR TITLE
[core,update] ensure EndPaint before DesktopResize

### DIFF
--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -3335,8 +3335,11 @@ void rdp_update_unlock(rdpUpdate* update)
 
 BOOL update_begin_paint(rdpUpdate* update)
 {
+	rdp_update_internal* up = update_cast(update);
 	WINPR_ASSERT(update);
 	rdp_update_lock(update);
+
+	up->withinBeginEndPaint = TRUE;
 
 	WINPR_ASSERT(update->context);
 
@@ -3370,6 +3373,13 @@ BOOL update_end_paint(rdpUpdate* update)
 	IFCALLRET(update->EndPaint, rc, update->context);
 	if (!rc)
 		WLog_WARN(TAG, "EndPaint call failed");
+
+	rdp_update_internal* up = update_cast(update);
+
+	if (!up->withinBeginEndPaint)
+		return rc;
+	up->withinBeginEndPaint = FALSE;
+
 	rdp_update_unlock(update);
 	return rc;
 }

--- a/libfreerdp/core/update.h
+++ b/libfreerdp/core/update.h
@@ -64,6 +64,7 @@ typedef struct
 	rdpBounds currentBounds;
 	rdpBounds previousBounds;
 	CRITICAL_SECTION mux;
+	BOOL withinBeginEndPaint;
 } rdp_update_internal;
 
 typedef struct

--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -1295,6 +1295,9 @@ BOOL gdi_resize_ex(rdpGdi* gdi, UINT32 width, UINT32 height, UINT32 stride, UINT
 
 	WINPR_ASSERT(gdi->context);
 	WINPR_ASSERT(gdi->context->update);
+
+	/* EndPaint might not have been called, ensure the update lock is released */
+	update_end_paint(gdi->context->update);
 	rdp_update_lock(gdi->context->update);
 
 	if (gdi->drawing == gdi->primary)


### PR DESCRIPTION
When DesktopResize is called EndPaint might not have been. Ensure the update-lock is released and data flushed before resizing.