### PR TITLE
Fix ASN.1 integer decoding

### DIFF
--- a/winpr/libwinpr/utils/asn1/asn1.c
+++ b/winpr/libwinpr/utils/asn1/asn1.c
@@ -1020,7 +1020,7 @@ static size_t WinPrAsn1DecReadIntegerLike(WinPrAsn1Decoder* dec, WinPrAsn1_tag e
 	size_t ret = readTagAndLen(dec, &dec->source, &tag, &len);
 	if (!ret || (tag != expectedTag))
 		return 0;
-	if (!Stream_CheckAndLogRequiredLength(TAG, &dec->source, len) || (len > 4))
+	if (len == 0 || !Stream_CheckAndLogRequiredLength(TAG, &dec->source, len) || (len > 4))
 		return 0;
 
 	WinPrAsn1_INTEGER val = 0;

--- a/winpr/libwinpr/utils/asn1/asn1.c
+++ b/winpr/libwinpr/utils/asn1/asn1.c
@@ -1024,13 +1024,20 @@ static size_t WinPrAsn1DecReadIntegerLike(WinPrAsn1Decoder* dec, WinPrAsn1_tag e
 		return 0;
 
 	WinPrAsn1_INTEGER val = 0;
-	for (size_t x = 0; x < len; x++)
+	UINT8 v = 0;
+
+	Stream_Read_UINT8(&dec->source, v);
+	if (v & 0x80)
+		val = 0xFFFFFFFF;
+	val |= v;
+
+	for (size_t x = 1; x < len; x++)
 	{
-		INT8 v = 0;
-		Stream_Read_INT8(&dec->source, v);
+		Stream_Read_UINT8(&dec->source, v);
 		val = (WinPrAsn1_INTEGER)(((UINT32)val) << 8);
 		val |= v;
 	}
+
 	*target = val;
 	ret += len;
 


### PR DESCRIPTION
Treat ASN.1 encoded integers with a leading zero byte and the MSB of the second byte set as non-negative