### PR TITLE
fix type conversion issue with `_Unwind_GetLanguageSpecificData`

### DIFF
--- a/winpr/libwinpr/utils/unwind/debug.c
+++ b/winpr/libwinpr/utils/unwind/debug.c
@@ -104,7 +104,7 @@ static _Unwind_Reason_Code unwind_backtrace_callback(struct _Unwind_Context* con
 	{
 		unwind_info_t* info = &ctx->info[ctx->pos++];
 		info->pc = _Unwind_GetIP(context);
-		info->langSpecificData = _Unwind_GetLanguageSpecificData(context);
+		info->langSpecificData = (void *) _Unwind_GetLanguageSpecificData(context);
 	}
 
 	return _URC_NO_REASON;


### PR DESCRIPTION
Seeing incompatible type conversion build failure with 3.8.0 release build with newer clang

```
  /tmp/freerdp-20240830-26880-qdym8p/FreeRDP-3.8.0/winpr/libwinpr/utils/unwind/debug.c:107:26: error: incompatible integer to pointer conversion assigning to 'void *' from 'uintptr_t' (aka 'unsigned long') [-Wint-conversion]
                  info->langSpecificData = _Unwind_GetLanguageSpecificData(context);
                                         ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  1 error generated.
```

relates to https://github.com/Homebrew/homebrew-core/pull/182939