### PR TITLE
clang tidy fix

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -57,6 +57,7 @@ Checks: >
     -readability-magic-numbers,
     -readability-qualified-auto,
     -readability-uppercase-literal-suffix,
+    -readability-isolate-declaration,
     -performance-no-int-to-ptr
 WarningsAsErrors: ''
 HeaderFilterRegex: ''

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,7 @@ Checks: >
     -cert-env33-c,
     -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
     -clang-analyzer-valist.Uninitialized,
+    -cppcoreguidelines-init-variables,
     -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
     -cppcoreguidelines-owning-memory,
     -cppcoreguidelines-avoid-do-while,


### PR DESCRIPTION
This PR relaxes some checks with clang-tidy to make our life easier during PR.  Each commit has the arguments to relax these checks.