### PR TITLE
[clang-tidy] disable bugprone-macro-parentheses

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,6 +23,7 @@ Checks: >
     -altera-unroll-loops,
     -bugprone-easily-swappable-parameters,
     -bugprone-assignment-in-if-condition,
+    -bugprone-macro-parentheses,
     -cert-dcl16-c,
     -cert-env33-c,
     -cert-dcl50-cpp,


### PR DESCRIPTION
this check has too many false positives (when the macro arguments are types for example) so disable this.