### PR TITLE
Add new transport io layer design and support custom socket.

### DIFF
--- a/libfreerdp/core/streamdump.c
+++ b/libfreerdp/core/streamdump.c
@@ -386,6 +386,16 @@ static int stream_dump_replay_transport_tcp_connect(rdpContext* context, rdpSett
 	return 42;
 }
 
+static rdpTransportLayer* stream_dump_replay_transport_connect_layer(rdpTransport* transport,
+                                                                     const char* hostname, int port,
+                                                                     DWORD timeout)
+{
+	WINPR_ASSERT(transport);
+	WINPR_ASSERT(hostname);
+
+	return NULL;
+}
+
 static BOOL stream_dump_replay_transport_tls_connect(rdpTransport* transport)
 {
 	WINPR_ASSERT(transport);
@@ -425,6 +435,7 @@ static BOOL stream_dump_register_read_handlers(rdpContext* context)
 	dump.TCPConnect = stream_dump_replay_transport_tcp_connect;
 	dump.TLSAccept = stream_dump_replay_transport_accept;
 	dump.TLSConnect = stream_dump_replay_transport_tls_connect;
+	dump.ConnectLayer = stream_dump_replay_transport_connect_layer;
 	if (!freerdp_set_io_callbacks(context, &dump))
 		return FALSE;
 	return freerdp_io_callback_set_event(context, TRUE);

--- a/libfreerdp/core/tcp.h
+++ b/libfreerdp/core/tcp.h
@@ -27,6 +27,7 @@
 #include <freerdp/settings.h>
 #include <freerdp/freerdp.h>
 #include <freerdp/api.h>
+#include <freerdp/transport_io.h>
 
 #include <winpr/crt.h>
 #include <winpr/synch.h>
@@ -101,6 +102,9 @@ FREERDP_LOCAL int freerdp_tcp_connect(rdpContext* context, const char* hostname,
 
 FREERDP_LOCAL int freerdp_tcp_default_connect(rdpContext* context, rdpSettings* settings,
                                               const char* hostname, int port, DWORD timeout);
+
+FREERDP_LOCAL rdpTransportLayer*
+freerdp_tcp_connect_layer(rdpContext* context, const char* hostname, int port, DWORD timeout);
 
 FREERDP_LOCAL char* freerdp_tcp_get_peer_address(SOCKET sockfd);
 

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -471,7 +471,6 @@ BOOL transport_connect_aad(rdpTransport* transport)
 
 BOOL transport_connect(rdpTransport* transport, const char* hostname, UINT16 port, DWORD timeout)
 {
-	int sockfd = 0;
 	BOOL status = FALSE;
 	rdpSettings* settings = NULL;
 	rdpContext* context = transport_get_context(transport);
@@ -570,16 +569,20 @@ BOOL transport_connect(rdpTransport* transport, const char* hostname, UINT16 por
 		BOOL isProxyConnection =
 		    proxy_prepare(settings, &proxyHostname, &peerPort, &proxyUsername, &proxyPassword);
 
+		rdpTransportLayer* layer = NULL;
 		if (isProxyConnection)
-			sockfd = transport_tcp_connect(transport, proxyHostname, peerPort, timeout);
+			layer = transport_connect_layer(transport, proxyHostname, peerPort, timeout);
 		else
-			sockfd = transport_tcp_connect(transport, hostname, port, timeout);
+			layer = transport_connect_layer(transport, hostname, port, timeout);
 
-		if (sockfd < 0)
+		if (!layer)
 			return FALSE;
 
-		if (!transport_attach(transport, sockfd))
+		if (!transport_attach_layer(transport, layer))
+		{
+			transport_layer_free(layer);
 			return FALSE;
+		}
 
 		if (isProxyConnection)
 		{
@@ -1477,6 +1480,59 @@ static BOOL transport_default_set_blocking_mode(rdpTransport* transport, BOOL bl
 	return TRUE;
 }
 
+rdpTransportLayer* transport_connect_layer(rdpTransport* transport, const char* hostname, int port,
+                                           DWORD timeout)
+{
+	WINPR_ASSERT(transport);
+
+	return IFCALLRESULT(NULL, transport->io.ConnectLayer, transport, hostname, port, timeout);
+}
+
+rdpTransportLayer* transport_default_connect_layer(rdpTransport* transport, const char* hostname,
+                                                   int port, DWORD timeout)
+{
+	rdpContext* context = transport_get_context(transport);
+	WINPR_ASSERT(context);
+
+	return freerdp_tcp_connect_layer(context, hostname, port, timeout);
+}
+
+BOOL transport_attach_layer(rdpTransport* transport, rdpTransportLayer* layer)
+{
+	WINPR_ASSERT(transport);
+	WINPR_ASSERT(layer);
+
+	return IFCALLRESULT(FALSE, transport->io.AttachLayer, transport, layer);
+}
+
+BOOL transport_default_attach_layer(rdpTransport* transport, rdpTransportLayer* layer)
+{
+	BIO* layerBio = BIO_new(BIO_s_transport_layer());
+	if (!layerBio)
+		goto fail;
+
+	BIO* bufferedBio = BIO_new(BIO_s_buffered_socket());
+	if (!bufferedBio)
+		goto fail;
+
+	bufferedBio = BIO_push(bufferedBio, layerBio);
+	if (!bufferedBio)
+		goto fail;
+
+	/* BIO takes over the layer reference at this point. */
+	BIO_set_data(layerBio, layer);
+
+	transport->frontBio = bufferedBio;
+
+	return TRUE;
+
+fail:
+	if (layerBio)
+		BIO_free_all(layerBio);
+
+	return FALSE;
+}
+
 void transport_set_gateway_enabled(rdpTransport* transport, BOOL GatewayEnabled)
 {
 	WINPR_ASSERT(transport);
@@ -1574,6 +1630,8 @@ rdpTransport* transport_new(rdpContext* context)
 	transport->io.ReadBytes = transport_read_layer;
 	transport->io.GetPublicKey = transport_default_get_public_key;
 	transport->io.SetBlockingMode = transport_default_set_blocking_mode;
+	transport->io.ConnectLayer = transport_default_connect_layer;
+	transport->io.AttachLayer = transport_default_attach_layer;
 
 	transport->context = context;
 	transport->ReceivePool = StreamPool_New(TRUE, BUFFER_SIZE);
@@ -1808,4 +1866,207 @@ void transport_set_early_user_auth_mode(rdpTransport* transport, BOOL EUAMode)
 	WINPR_ASSERT(transport);
 	transport->earlyUserAuth = EUAMode;
 	WLog_Print(transport->log, WLOG_DEBUG, "Early User Auth Mode: %s", EUAMode ? "on" : "off");
+}
+
+rdpTransportLayer* transport_layer_new(rdpTransport* transport, size_t contextSize)
+{
+	rdpTransportLayer* layer = (rdpTransportLayer*)calloc(1, sizeof(rdpTransportLayer));
+	if (!layer)
+		return NULL;
+
+	if (contextSize)
+	{
+		layer->userContext = calloc(1, contextSize);
+		if (!layer->userContext)
+		{
+			free(layer);
+			return NULL;
+		}
+	}
+
+	return layer;
+}
+
+void transport_layer_free(rdpTransportLayer* layer)
+{
+	if (!layer)
+		return;
+
+	IFCALL(layer->Close, layer->userContext);
+	free(layer->userContext);
+	free(layer);
+}
+
+static int transport_layer_bio_write(BIO* bio, const char* buf, int size)
+{
+	if (!buf || !size)
+		return 0;
+	if (size < 0)
+		return -1;
+
+	WINPR_ASSERT(bio);
+
+	rdpTransportLayer* layer = (rdpTransportLayer*)BIO_get_data(bio);
+	if (!layer)
+		return -1;
+
+	BIO_clear_flags(bio, BIO_FLAGS_WRITE | BIO_FLAGS_SHOULD_RETRY);
+
+	int status = IFCALLRESULT(-1, layer->Write, layer->userContext, buf, size);
+
+	if (status >= 0 && status < size)
+		BIO_set_flags(bio, (BIO_FLAGS_WRITE | BIO_FLAGS_SHOULD_RETRY));
+
+	return status;
+}
+
+static int transport_layer_bio_read(BIO* bio, char* buf, int size)
+{
+	if (!buf || !size)
+		return 0;
+	if (size < 0)
+		return -1;
+
+	WINPR_ASSERT(bio);
+
+	rdpTransportLayer* layer = (rdpTransportLayer*)BIO_get_data(bio);
+	if (!layer)
+		return -1;
+
+	BIO_clear_flags(bio, BIO_FLAGS_READ | BIO_FLAGS_SHOULD_RETRY);
+
+	int status = IFCALLRESULT(-1, layer->Read, layer->userContext, buf, size);
+
+	if (status == 0)
+		BIO_set_flags(bio, (BIO_FLAGS_READ | BIO_FLAGS_SHOULD_RETRY));
+
+	return status;
+}
+
+static int transport_layer_bio_puts(BIO* bio, const char* str)
+{
+	return 1;
+}
+
+static int transport_layer_bio_gets(BIO* bio, char* str, int size)
+{
+	return 1;
+}
+
+static long transport_layer_bio_ctrl(BIO* bio, int cmd, long arg1, void* arg2)
+{
+	WINPR_ASSERT(bio);
+
+	rdpTransportLayer* layer = (rdpTransportLayer*)BIO_get_data(bio);
+	if (!layer)
+		return -1;
+
+	int status = -1;
+	switch (cmd)
+	{
+		case BIO_C_GET_EVENT:
+			*((HANDLE*)arg2) = IFCALLRESULT(NULL, layer->GetEvent, layer->userContext);
+			status = 1;
+			break;
+
+		case BIO_C_SET_NONBLOCK:
+			status = 1;
+			break;
+
+		case BIO_C_WAIT_READ:
+		{
+			int timeout = (int)arg1;
+			BOOL r = IFCALLRESULT(FALSE, layer->Wait, layer->userContext, FALSE, timeout);
+			/* Convert timeout to error return */
+			if (!r)
+			{
+				errno = ETIMEDOUT;
+				status = 0;
+			}
+			else
+				status = 1;
+			break;
+		}
+
+		case BIO_C_WAIT_WRITE:
+		{
+			int timeout = (int)arg1;
+			BOOL r = IFCALLRESULT(FALSE, layer->Wait, layer->userContext, TRUE, timeout);
+			/* Convert timeout to error return */
+			if (!r)
+			{
+				errno = ETIMEDOUT;
+				status = 0;
+			}
+			else
+				status = 1;
+			break;
+		}
+
+		case BIO_CTRL_GET_CLOSE:
+			status = BIO_get_shutdown(bio);
+			break;
+
+		case BIO_CTRL_SET_CLOSE:
+			BIO_set_shutdown(bio, (int)arg1);
+			status = 1;
+			break;
+
+		case BIO_CTRL_FLUSH:
+		case BIO_CTRL_DUP:
+			status = 1;
+			break;
+
+		default:
+			status = 0;
+			break;
+	}
+
+	return status;
+}
+
+static int transport_layer_bio_new(BIO* bio)
+{
+	WINPR_ASSERT(bio);
+
+	BIO_set_flags(bio, BIO_FLAGS_SHOULD_RETRY);
+	BIO_set_init(bio, 1);
+	return 1;
+}
+
+static int transport_layer_bio_free(BIO* bio)
+{
+	if (!bio)
+		return 0;
+
+	rdpTransportLayer* layer = (rdpTransportLayer*)BIO_get_data(bio);
+	if (layer)
+		transport_layer_free(layer);
+
+	BIO_set_data(bio, NULL);
+	BIO_set_init(bio, 0);
+	BIO_set_flags(bio, 0);
+
+	return 1;
+}
+
+BIO_METHOD* BIO_s_transport_layer(void)
+{
+	static BIO_METHOD* bio_methods = NULL;
+
+	if (bio_methods == NULL)
+	{
+		if (!(bio_methods = BIO_meth_new(BIO_TYPE_SIMPLE, "TransportLayer")))
+			return NULL;
+
+		BIO_meth_set_write(bio_methods, transport_layer_bio_write);
+		BIO_meth_set_read(bio_methods, transport_layer_bio_read);
+		BIO_meth_set_puts(bio_methods, transport_layer_bio_puts);
+		BIO_meth_set_gets(bio_methods, transport_layer_bio_gets);
+		BIO_meth_set_ctrl(bio_methods, transport_layer_bio_ctrl);
+		BIO_meth_set_create(bio_methods, transport_layer_bio_new);
+		BIO_meth_set_destroy(bio_methods, transport_layer_bio_free);
+	}
+
+	return bio_methods;
 }

--- a/libfreerdp/core/transport.h
+++ b/libfreerdp/core/transport.h
@@ -74,6 +74,23 @@ FREERDP_LOCAL BOOL transport_connect_childsession(rdpTransport* transport);
  * \return \b TRUE in case of success, \b FALSE otherwise.
  */
 FREERDP_LOCAL BOOL transport_attach(rdpTransport* transport, int sockfd);
+
+/**! \brief Attach a transport layer
+ *
+ * The ownership of the transport layer provided by \b layer is taken if and only if the function is
+ * successful. In such a case the caller must no longer free or otherwise use the layer. If the
+ * function fails it is up to the caller to free the layer.
+ *
+ * The implementation can be overridden by
+ * transport_set_io_callbacks(rdpTransportIo::AttachLayer)
+ *
+ * \param transport The transport instance to attach the socket to
+ * \param layer The layer to attach to the transport
+ *
+ * \return \b TRUE in case of success, \b FALSE otherwise.
+ */
+FREERDP_LOCAL BOOL transport_attach_layer(rdpTransport* transport, rdpTransportLayer* layer);
+
 FREERDP_LOCAL BOOL transport_disconnect(rdpTransport* transport);
 FREERDP_LOCAL BOOL transport_connect_rdp(rdpTransport* transport);
 FREERDP_LOCAL BOOL transport_connect_tls(rdpTransport* transport);
@@ -107,9 +124,6 @@ FREERDP_LOCAL void transport_set_rdstls_mode(rdpTransport* transport, BOOL Rdstl
 FREERDP_LOCAL void transport_set_aad_mode(rdpTransport* transport, BOOL AadMode);
 FREERDP_LOCAL BOOL transport_is_write_blocked(rdpTransport* transport);
 FREERDP_LOCAL int transport_drain_output_buffer(rdpTransport* transport);
-
-FREERDP_LOCAL wStream* transport_receive_pool_take(rdpTransport* transport);
-FREERDP_LOCAL int transport_receive_pool_return(rdpTransport* transport, wStream* pdu);
 
 FREERDP_LOCAL BOOL transport_io_callback_set_event(rdpTransport* transport, BOOL set);
 
@@ -146,11 +160,16 @@ FREERDP_LOCAL BOOL transport_set_recv_callbacks(rdpTransport* transport, Transpo
 FREERDP_LOCAL int transport_tcp_connect(rdpTransport* transport, const char* hostname, int port,
                                         DWORD timeout);
 
+FREERDP_LOCAL rdpTransportLayer*
+transport_connect_layer(rdpTransport* transport, const char* hostname, int port, DWORD timeout);
+
 FREERDP_LOCAL void transport_free(rdpTransport* transport);
 
 WINPR_ATTR_MALLOC(transport_free, 1)
 FREERDP_LOCAL rdpTransport* transport_new(rdpContext* context);
 
 FREERDP_LOCAL void transport_set_early_user_auth_mode(rdpTransport* transport, BOOL EUAMode);
+
+FREERDP_LOCAL BIO_METHOD* BIO_s_transport_layer(void);
 
 #endif /* FREERDP_LIB_CORE_TRANSPORT_H */


### PR DESCRIPTION
The original TCPConnect/Attach will remain valid until all existing gateways are migrated, and then should become obsolete.