### PR TITLE
[client,common] change /dynamic-resizing to BOOL option

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -2753,15 +2753,17 @@ static int parse_dynamic_resolution_options(rdpSettings* settings,
 	WINPR_ASSERT(settings);
 	WINPR_ASSERT(arg);
 
-	if (freerdp_settings_get_bool(settings, FreeRDP_SmartSizing))
+	const BOOL val = arg->Value != 0;
+
+	if (val && freerdp_settings_get_bool(settings, FreeRDP_SmartSizing))
 	{
 		WLog_ERR(TAG, "Smart sizing and dynamic resolution are mutually exclusive options");
 		return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 	}
 
-	if (!freerdp_settings_set_bool(settings, FreeRDP_SupportDisplayControl, TRUE))
+	if (!freerdp_settings_set_bool(settings, FreeRDP_SupportDisplayControl, val))
 		return COMMAND_LINE_ERROR;
-	if (!freerdp_settings_set_bool(settings, FreeRDP_DynamicResolutionUpdate, TRUE))
+	if (!freerdp_settings_set_bool(settings, FreeRDP_DynamicResolutionUpdate, val))
 		return COMMAND_LINE_ERROR;
 
 	return 0;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -151,7 +151,7 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  NULL, "record or replay dump" },
 	{ "dvc", COMMAND_LINE_VALUE_REQUIRED, "<channel>[,<options>]", NULL, NULL, -1, NULL,
 	  "Dynamic virtual channel" },
-	{ "dynamic-resolution", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL,
+	{ "dynamic-resolution", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
 	  "Send resolution updates when the window is resized" },
 	{ "echo", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "echo", "Echo channel" },
 	{ "encryption", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,


### PR DESCRIPTION
Allows to use +-/ prefixes to enable/disable the option. Brought up on matrix channel for uses with RDP files that enable the option. Now it can be disabled by adding -dynamic-resolution on command line.