### PR TITLE
[winpr,include] fix reserved-identifier warnings

### DIFF
--- a/winpr/include/winpr/crt.h
+++ b/winpr/include/winpr/crt.h
@@ -30,6 +30,9 @@
 #include <winpr/spec.h>
 #include <winpr/string.h>
 
+WINPR_PRAGMA_DIAG_PUSH
+WINPR_PRAGMA_DIAG_IGNORED_RESERVED_IDENTIFIER
+
 #ifndef _WIN32
 
 #include <unistd.h>
@@ -236,5 +239,7 @@ extern "C"
 #if defined(_WIN32) && (!defined(__MINGW32__) || defined(_UCRT))
 #define winpr_aligned_calloc(count, size, alignment) _aligned_recalloc(NULL, count, size, alignment)
 #endif /* defined(_WIN32) && (!defined(__MINGW32__) || defined(_UCRT)) */
+
+WINPR_PRAGMA_DIAG_POP
 
 #endif /* WINPR_CRT_H */

--- a/winpr/include/winpr/io.h
+++ b/winpr/include/winpr/io.h
@@ -24,6 +24,9 @@
 #include <winpr/wtypes.h>
 #include <winpr/handle.h>
 
+WINPR_PRAGMA_DIAG_PUSH
+WINPR_PRAGMA_DIAG_IGNORED_RESERVED_IDENTIFIER
+
 #ifdef _WIN32
 
 #include <winioctl.h>
@@ -252,5 +255,7 @@ extern "C"
 
 #define ACCESS_FROM_CTL_CODE(ctrlCode) ((DWORD)((ctrlCode >> 14) & 0x3))
 #define FUNCTION_FROM_CTL_CODE(ctrlCode) ((DWORD)((ctrlCode >> 2) & 0xFFF))
+
+WINPR_PRAGMA_DIAG_POP
 
 #endif /* WINPR_IO_H */

--- a/winpr/include/winpr/secapi.h
+++ b/winpr/include/winpr/secapi.h
@@ -27,7 +27,7 @@
 
 #include <winpr/wtypes.h>
 
-typedef enum _KERB_LOGON_SUBMIT_TYPE
+typedef enum
 {
 	KerbInvalidValue = 0, /** @since version 3.9.0 */
 	KerbInteractiveLogon = 2,
@@ -46,7 +46,7 @@ typedef enum _KERB_LOGON_SUBMIT_TYPE
 } KERB_LOGON_SUBMIT_TYPE,
     *PKERB_LOGON_SUBMIT_TYPE;
 
-typedef struct _KERB_TICKET_LOGON
+typedef struct
 {
 	KERB_LOGON_SUBMIT_TYPE MessageType;
 	ULONG Flags;
@@ -60,7 +60,7 @@ typedef struct _KERB_TICKET_LOGON
 
 #define MSV1_0_OWF_PASSWORD_LENGTH 16
 
-typedef struct _MSV1_0_SUPPLEMENTAL_CREDENTIAL
+typedef struct
 {
 	ULONG Version;
 	ULONG Flags;

--- a/winpr/include/winpr/spec.h
+++ b/winpr/include/winpr/spec.h
@@ -22,6 +22,10 @@
 
 #include <winpr/platform.h>
 
+WINPR_PRAGMA_DIAG_PUSH
+WINPR_PRAGMA_DIAG_IGNORED_RESERVED_ID_MACRO
+WINPR_PRAGMA_DIAG_IGNORED_RESERVED_IDENTIFIER
+
 #ifdef _WIN32
 
 #include <specstrings.h>
@@ -30,9 +34,6 @@
 #endif
 
 #else
-
-WINPR_PRAGMA_DIAG_PUSH
-WINPR_PRAGMA_DIAG_IGNORED_RESERVED_ID_MACRO
 
 #define DUMMYUNIONNAME u
 #define DUMMYUNIONNAME1 u1
@@ -957,10 +958,6 @@ extern "C++"
 #define CONTAINING_RECORD(address, type, field) \
 	((type*)((PCHAR)(address) - (ULONG_PTR)(&((type*)0)->field)))
 
-#if defined(__clang__)
-WINPR_PRAGMA_DIAG_POP
-#endif
-
 #endif
 
 #if defined(_WIN32) || defined(__CYGWIN__)
@@ -982,5 +979,7 @@ WINPR_PRAGMA_DIAG_POP
 #define DECLSPEC_IMPORT
 #endif
 #endif
+
+WINPR_PRAGMA_DIAG_POP
 
 #endif /* WINPR_SPEC_H */

--- a/winpr/include/winpr/sspi.h
+++ b/winpr/include/winpr/sspi.h
@@ -504,7 +504,7 @@ typedef struct
 #define PSecPkgCredentials_SSIProvider PSecPkgCredentials_SSIProviderA
 #endif
 
-typedef struct _SecPkgCredentials_Cert
+typedef struct
 {
 	unsigned long EncodedCertSize;
 	unsigned char* EncodedCert;
@@ -752,7 +752,7 @@ typedef struct
 #ifndef SEC_WINNT_AUTH_IDENTITY_VERSION_2
 #define SEC_WINNT_AUTH_IDENTITY_VERSION_2 0x201
 
-typedef struct _SEC_WINNT_AUTH_IDENTITY_EX2
+typedef struct
 {
 	UINT32 Version;
 	UINT16 cbHeaderLength;
@@ -775,7 +775,7 @@ typedef struct _SEC_WINNT_AUTH_IDENTITY_EX2
 
 // https://docs.microsoft.com/en-us/windows/win32/api/sspi/ns-sspi-sec_winnt_auth_identity_info
 
-typedef union _SEC_WINNT_AUTH_IDENTITY_INFO
+typedef union
 {
 	SEC_WINNT_AUTH_IDENTITY_EXW AuthIdExw;
 	SEC_WINNT_AUTH_IDENTITY_EXA AuthIdExa;

--- a/winpr/include/winpr/string.h
+++ b/winpr/include/winpr/string.h
@@ -28,6 +28,9 @@
 #include <winpr/winpr.h>
 #include <winpr/wtypes.h>
 
+WINPR_PRAGMA_DIAG_PUSH
+WINPR_PRAGMA_DIAG_IGNORED_RESERVED_IDENTIFIER
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -430,5 +433,7 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
+
+WINPR_PRAGMA_DIAG_POP
 
 #endif /* WINPR_CRT_STRING_H */

--- a/winpr/include/winpr/thread.h
+++ b/winpr/include/winpr/thread.h
@@ -178,7 +178,13 @@ extern "C"
 	DECLSPEC_NORETURN WINPR_API VOID ExitProcess(UINT uExitCode);
 	WINPR_API BOOL GetExitCodeProcess(HANDLE hProcess, LPDWORD lpExitCode);
 
+	WINPR_PRAGMA_DIAG_PUSH
+	WINPR_PRAGMA_DIAG_IGNORED_RESERVED_IDENTIFIER
+
 	WINPR_API HANDLE _GetCurrentProcess(void);
+
+	WINPR_PRAGMA_DIAG_POP
+
 	WINPR_API DWORD GetCurrentProcessId(void);
 
 	WINPR_API BOOL TerminateProcess(HANDLE hProcess, UINT uExitCode);
@@ -238,7 +244,11 @@ extern "C"
 	WINPR_API VOID ExitThread(DWORD dwExitCode);
 	WINPR_API BOOL GetExitCodeThread(HANDLE hThread, LPDWORD lpExitCode);
 
+	WINPR_PRAGMA_DIAG_PUSH
+	WINPR_PRAGMA_DIAG_IGNORED_RESERVED_IDENTIFIER
 	WINPR_API HANDLE _GetCurrentThread(void);
+	WINPR_PRAGMA_DIAG_POP
+
 	WINPR_API DWORD GetCurrentThreadId(void);
 
 	typedef void (*PAPCFUNC)(ULONG_PTR Parameter);
@@ -268,8 +278,13 @@ extern "C"
 /*
  * GetCurrentProcess / GetCurrentThread cause a conflict on Mac OS X
  */
+WINPR_PRAGMA_DIAG_PUSH
+WINPR_PRAGMA_DIAG_IGNORED_RESERVED_IDENTIFIER
+
 #define _GetCurrentProcess GetCurrentProcess
 #define _GetCurrentThread GetCurrentThread
+
+WINPR_PRAGMA_DIAG_POP
 
 #endif
 

--- a/winpr/include/winpr/winsock.h
+++ b/winpr/include/winpr/winsock.h
@@ -25,6 +25,9 @@
 #include <winpr/wtypes.h>
 #include <winpr/windows.h>
 
+WINPR_PRAGMA_DIAG_PUSH
+WINPR_PRAGMA_DIAG_IGNORED_RESERVED_IDENTIFIER
+
 #ifdef _WIN32
 
 #define _accept accept
@@ -364,5 +367,7 @@ extern "C"
 #endif
 
 #endif /* _WIN32 */
+
+WINPR_PRAGMA_DIAG_POP
 
 #endif /* WINPR_WINSOCK_H */

--- a/winpr/include/winpr/wtsapi.h
+++ b/winpr/include/winpr/wtsapi.h
@@ -29,6 +29,9 @@
 
 #define CHANNEL_CHUNK_MAX_LENGTH 16256
 
+WINPR_PRAGMA_DIAG_PUSH
+WINPR_PRAGMA_DIAG_IGNORED_RESERVED_IDENTIFIER
+
 #ifdef _WIN32
 
 #define CurrentTime _CurrentTime /* Workaround for X11 "CurrentTime" header conflict */
@@ -1514,5 +1517,7 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
+
+WINPR_PRAGMA_DIAG_POP
 
 #endif /* WINPR_WTSAPI_H */


### PR DESCRIPTION
* Remove symbols where possible
* Use #pragma where the symbols are implementing ISO or windows functions