### PR TITLE
[strtok] replace function with strtok_s

### DIFF
--- a/client/common/client_cliprdr_file.c
+++ b/client/common/client_cliprdr_file.c
@@ -39,6 +39,7 @@
 #endif
 
 #include <winpr/crt.h>
+#include <winpr/string.h>
 #include <winpr/assert.h>
 #include <winpr/image.h>
 #include <winpr/stream.h>
@@ -2277,7 +2278,9 @@ static BOOL cliprdr_local_stream_update(CliprdrLocalStream* stream, const char* 
 	char* copy = strndup(data, size);
 	if (!copy)
 		return FALSE;
-	char* ptr = strtok(copy, "\r\n");
+
+	char* saveptr = NULL;
+	char* ptr = strtok_s(copy, "\r\n", &saveptr);
 	while (ptr)
 	{
 		const char* name = ptr;
@@ -2295,7 +2298,7 @@ static BOOL cliprdr_local_stream_update(CliprdrLocalStream* stream, const char* 
 			if (!res)
 				goto fail;
 		}
-		ptr = strtok(NULL, "\r\n");
+		ptr = strtok_s(NULL, "\r\n", &saveptr);
 	}
 
 	rc = TRUE;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -25,6 +25,7 @@
 #include <errno.h>
 
 #include <winpr/assert.h>
+#include <winpr/string.h>
 #include <winpr/crt.h>
 #include <winpr/wlog.h>
 #include <winpr/path.h>
@@ -4147,7 +4148,8 @@ static void fill_credential_strings(COMMAND_LINE_ARGUMENT_A* args)
 	if (arg && ((arg->Flags & COMMAND_LINE_ARGUMENT_PRESENT) != 0))
 	{
 		const char* gwcreds[] = { "p:", "access-token:" };
-		char* tok = strtok(arg->Value, ",");
+		char* saveptr = NULL;
+		char* tok = strtok_s(arg->Value, ",", &saveptr);
 		while (tok)
 		{
 			for (size_t x = 0; x < ARRAYSIZE(gwcreds); x++)
@@ -4159,7 +4161,7 @@ static void fill_credential_strings(COMMAND_LINE_ARGUMENT_A* args)
 					FillMemory(val, strlen(val), '*');
 				}
 			}
-			tok = strtok(NULL, ",");
+			tok = strtok_s(NULL, ",", &saveptr);
 		}
 	}
 }

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -300,7 +300,8 @@ static BOOL freerdp_assistance_parse_address_list(rdpAssistanceFile* file, char*
 	char* s = ";";
 
 	// get the first token
-	char* token = strtok(strp, s);
+	char* saveptr = NULL;
+	char* token = strtok_s(strp, s, &saveptr);
 
 	// walk through other tokens
 	while (token != NULL)
@@ -314,7 +315,7 @@ static BOOL freerdp_assistance_parse_address_list(rdpAssistanceFile* file, char*
 		if (!append_address(file, token, port))
 			goto out;
 
-		token = strtok(NULL, s);
+		token = strtok_s(NULL, s, &saveptr);
 	}
 	rc = TRUE;
 out:

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -2868,13 +2868,14 @@ static void log_build_warn(rdpRdp* rdp, const char* what, const char* msg,
 
 	if (config && list)
 	{
-		char* tok = strtok(config, " ");
+		char* saveptr = NULL;
+		char* tok = strtok_s(config, " ", &saveptr);
 		while (tok)
 		{
 			if (cmp(rdp->log, tok))
 				winpr_str_append(tok, list, len, " ");
 
-			tok = strtok(NULL, " ");
+			tok = strtok_s(NULL, " ", &saveptr);
 		}
 	}
 	free(config);
@@ -2885,11 +2886,13 @@ static void log_build_warn(rdpRdp* rdp, const char* what, const char* msg,
 		{
 			WLog_Print(rdp->log, WLOG_WARN, "*************************************************");
 			WLog_Print(rdp->log, WLOG_WARN, "This build is using [%s] build options:", what);
-			char* tok = strtok(list, " ");
+
+			char* saveptr = NULL;
+			char* tok = strtok_s(list, " ", &saveptr);
 			while (tok)
 			{
 				WLog_Print(rdp->log, WLOG_WARN, "* '%s'", tok);
-				tok = strtok(NULL, " ");
+				tok = strtok_s(NULL, " ", &saveptr);
 			}
 			WLog_Print(rdp->log, WLOG_WARN, "");
 			WLog_Print(rdp->log, WLOG_WARN, "[%s] build options %s", what, msg);

--- a/libfreerdp/core/redirection.c
+++ b/libfreerdp/core/redirection.c
@@ -24,6 +24,7 @@
 #include "settings.h"
 
 #include <winpr/crt.h>
+#include <winpr/string.h>
 #include <freerdp/log.h>
 #include <freerdp/crypto/certificate.h>
 #include <freerdp/redirection.h>
@@ -258,7 +259,8 @@ static BOOL rdp_redirection_read_base64_wchar(UINT32 flag, wStream* s, UINT32* p
 
 	size_t rlen = utf8_len;
 	size_t wpos = 0;
-	char* tok = strtok(utf8, "\r\n");
+	char* saveptr = NULL;
+	char* tok = strtok_s(utf8, "\r\n", &saveptr);
 	while (tok)
 	{
 		const size_t len = strnlen(tok, rlen);
@@ -273,7 +275,7 @@ static BOOL rdp_redirection_read_base64_wchar(UINT32 flag, wStream* s, UINT32* p
 		wpos += bplen;
 		free(bptr);
 
-		tok = strtok(NULL, "\r\n");
+		tok = strtok_s(NULL, "\r\n", &saveptr);
 	}
 	*pLength = wpos;
 

--- a/winpr/libwinpr/registry/registry_reg.c
+++ b/winpr/libwinpr/registry/registry_reg.c
@@ -25,6 +25,7 @@
 #include <string.h>
 
 #include <winpr/wtypes.h>
+#include <winpr/string.h>
 #include <winpr/assert.h>
 #include <winpr/crt.h>
 #include <winpr/file.h>
@@ -114,7 +115,7 @@ static BOOL reg_load_start(Reg* reg)
 
 	reg->buffer[file_size] = '\n';
 	reg->buffer[file_size + 1] = '\0';
-	reg->next_line = strtok(reg->buffer, "\n");
+	reg->next_line = strtok_s(reg->buffer, "\n", &reg->saveptr);
 	return TRUE;
 }
 
@@ -295,7 +296,7 @@ static char* reg_load_get_next_line(Reg* reg)
 		return NULL;
 
 	reg->line = reg->next_line;
-	reg->next_line = strtok(NULL, "\n");
+	reg->next_line = strtok_s(NULL, "\n", &reg->saveptr);
 	reg->line_length = strlen(reg->line);
 	return reg->line;
 }

--- a/winpr/libwinpr/registry/registry_reg.h
+++ b/winpr/libwinpr/registry/registry_reg.h
@@ -35,6 +35,7 @@ struct s_reg
 	char* filename;
 	BOOL read_only;
 	RegKey* root_key;
+	char* saveptr;
 };
 
 struct s_reg_val


### PR DESCRIPTION
Since strtok is not thread safe replace it with strtok_s (WinPR wrapper around strtok_r for systems not supporting the ISO function names)