### PR TITLE
SDL3 client: improve the treatment of clipboard data requests

### DIFF
--- a/client/SDL/SDL3/sdl_clip.hpp
+++ b/client/SDL/SDL3/sdl_clip.hpp
@@ -34,10 +34,11 @@
 #include "sdl_types.hpp"
 #include "sdl_utils.hpp"
 
+/** @brief a clipboard format request */
 class ClipRequest
 {
   public:
-	ClipRequest(UINT32 format, std::string mime);
+	ClipRequest(UINT32 format, const std::string& mime);
 	ClipRequest(const ClipRequest& other) = default;
 	ClipRequest(ClipRequest&& other) = default;
 	~ClipRequest() = default;
@@ -45,10 +46,13 @@ class ClipRequest
 	[[nodiscard]] uint32_t format() const;
 	[[nodiscard]] std::string formatstr() const;
 	[[nodiscard]] std::string mime() const;
+	[[nodiscard]] bool success() const;
+	void setSuccess(bool status);
 
   private:
 	uint32_t _format;
 	std::string _mime;
+	bool _success;
 };
 
 class CliprdrFormat
@@ -77,6 +81,7 @@ class CliprdrFormat
 	std::string _formatName;
 };
 
+/** @brief object that handles clipboard context for the SDL3 client */
 class sdlClip
 {
   public:
@@ -93,16 +98,7 @@ class sdlClip
 	void clearServerFormats();
 	UINT SendFormatListResponse(BOOL status);
 	UINT SendDataResponse(const BYTE* data, size_t size);
-	UINT SendDataRequest(uint32_t formatID, const std::string& mime)
-	{
-		CLIPRDR_FORMAT_DATA_REQUEST request = { .requestedFormatId = formatID };
-
-		_request_queue.push({ formatID, mime });
-
-		WINPR_ASSERT(_ctx);
-		WINPR_ASSERT(_ctx->ClientFormatDataRequest);
-		return _ctx->ClientFormatDataRequest(_ctx, &request);
-	}
+	UINT SendDataRequest(uint32_t formatID, const std::string& mime);
 
 	std::string getServerFormat(uint32_t id);
 	uint32_t serverIdForMime(const std::string& mime);


### PR DESCRIPTION
This patch adds a success flag on clipboard data requests, so that we can react correctly in the SDL handler. I've also made some errors non fatal like if you requests a kind of data that doesn't exist the client should not terminate