### PR TITLE
[core,proxy] fix nonblocking BIO reads

### DIFF
--- a/libfreerdp/core/gateway/arm.c
+++ b/libfreerdp/core/gateway/arm.c
@@ -124,7 +124,7 @@ static BOOL arm_tls_connect(rdpArm* arm, rdpTls* tls, int timeout)
 
 	if (isProxyConnection)
 	{
-		if (!proxy_connect(settings, bufferedBio, proxyUsername, proxyPassword,
+		if (!proxy_connect(arm->context, bufferedBio, proxyUsername, proxyPassword,
 		                   freerdp_settings_get_string(settings, FreeRDP_GatewayHostname),
 		                   (UINT16)freerdp_settings_get_uint32(settings, FreeRDP_GatewayPort)))
 		{

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -1301,7 +1301,7 @@ static BOOL rdg_tls_connect(rdpRdg* rdg, rdpTls* tls, const char* peerAddress, i
 
 	if (isProxyConnection)
 	{
-		if (!proxy_connect(settings, bufferedBio, proxyUsername, proxyPassword,
+		if (!proxy_connect(rdg->context, bufferedBio, proxyUsername, proxyPassword,
 		                   settings->GatewayHostname, (UINT16)settings->GatewayPort))
 		{
 			BIO_free_all(bufferedBio);

--- a/libfreerdp/core/gateway/rpc.c
+++ b/libfreerdp/core/gateway/rpc.c
@@ -759,7 +759,7 @@ static BOOL rpc_channel_tls_connect(RpcChannel* channel, UINT32 timeout)
 
 	if (channel->client->isProxy)
 	{
-		if (!proxy_connect(settings, bufferedBio, proxyUsername, proxyPassword,
+		if (!proxy_connect(context, bufferedBio, proxyUsername, proxyPassword,
 		                   settings->GatewayHostname, settings->GatewayPort))
 		{
 			BIO_free_all(bufferedBio);

--- a/libfreerdp/core/gateway/wst.c
+++ b/libfreerdp/core/gateway/wst.c
@@ -254,7 +254,7 @@ static BOOL wst_tls_connect(rdpWst* wst, rdpTls* tls, int timeout)
 
 	if (isProxyConnection)
 	{
-		if (!proxy_connect(settings, bufferedBio, proxyUsername, proxyPassword, wst->gwhostname,
+		if (!proxy_connect(wst->context, bufferedBio, proxyUsername, proxyPassword, wst->gwhostname,
 		                   wst->gwport))
 		{
 			BIO_free_all(bufferedBio);

--- a/libfreerdp/core/proxy.h
+++ b/libfreerdp/core/proxy.h
@@ -26,7 +26,7 @@
 BOOL proxy_prepare(rdpSettings* settings, const char** lpPeerHostname, UINT16* lpPeerPort,
                    const char** lpProxyUsername, const char** lpProxyPassword);
 
-BOOL proxy_connect(rdpSettings* settings, BIO* bio, const char* proxyUsername,
+BOOL proxy_connect(rdpContext* context, BIO* bio, const char* proxyUsername,
                    const char* proxyPassword, const char* hostname, UINT16 port);
 
 #endif /* FREERDP_LIB_CORE_HTTP_PROXY_H */

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -595,8 +595,8 @@ BOOL transport_connect(rdpTransport* transport, const char* hostname, UINT16 por
 
 		if (isProxyConnection)
 		{
-			if (!proxy_connect(settings, transport->frontBio, proxyUsername, proxyPassword,
-			                   hostname, port))
+			if (!proxy_connect(context, transport->frontBio, proxyUsername, proxyPassword, hostname,
+			                   port))
 				return FALSE;
 		}
 


### PR DESCRIPTION
In case of non-blocking BIO layers the proxy read functions bailed out with an error. Retry reading in that case unless the TcpConnectTimeout is exceeded