### PR TITLE
[build,mac] require cJSON

### DIFF
--- a/scripts/bundle-mac-os.sh
+++ b/scripts/bundle-mac-os.sh
@@ -280,7 +280,9 @@ cmake -GNinja -Bfreerdp -S"$SCRIPT_PATH/.." \
 	-DWITH_INTERNAL_RC4=ON \
 	-DWITH_INTERNAL_MD4=ON \
 	-DWITH_INTERNAL_MD5=ON \
-    -DCHANNEL_RDPEAR=OFF
+	-DCHANNEL_RDPEAR=OFF \
+	-DWITH_CJSON_REQUIRED=ON
+
 cmake --build freerdp
 cmake --install freerdp
 


### PR DESCRIPTION
we build with cJSON, so enforce it during build. Prevents other installed libraries to be considered.
