### PR TITLE
[build,c++] add CXXCompilerFlags to (un)set warnings

### DIFF
--- a/client/SDL/CMakeLists.txt
+++ b/client/SDL/CMakeLists.txt
@@ -39,6 +39,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/)
 include(CommonConfigOptions)
 
 include(ConfigureFreeRDP)
+include(CXXCompilerFlags)
 
 option(WITH_DEBUG_SDL_EVENTS "[dangerous, not for release builds!] Debug SDL events" ${DEFAULT_DEBUG_OPTION})
 option(WITH_DEBUG_SDL_KBD_EVENTS "[dangerous, not for release builds!] Debug SDL keyboard events" ${DEFAULT_DEBUG_OPTION})

--- a/client/SDL/SDL2/sdl_disp.cpp
+++ b/client/SDL/SDL2/sdl_disp.cpp
@@ -33,8 +33,8 @@
 #include <freerdp/log.h>
 #define TAG CLIENT_TAG("sdl.disp")
 
-#define RESIZE_MIN_DELAY 200 /* minimum delay in ms between two resizes */
-#define MAX_RETRIES 5
+static constexpr UINT64 RESIZE_MIN_DELAY = 200; /* minimum delay in ms between two resizes */
+static constexpr unsigned MAX_RETRIES = 5;
 
 BOOL sdlDispContext::settings_changed()
 {

--- a/client/SDL/SDL3/sdl_disp.cpp
+++ b/client/SDL/SDL3/sdl_disp.cpp
@@ -33,8 +33,8 @@
 #include <freerdp/log.h>
 #define TAG CLIENT_TAG("sdl.disp")
 
-#define RESIZE_MIN_DELAY 200 /* minimum delay in ms between two resizes */
-#define MAX_RETRIES 5
+static constexpr UINT64 RESIZE_MIN_DELAY = 200; /* minimum delay in ms between two resizes */
+static constexpr unsigned MAX_RETRIES = 5;
 
 BOOL sdlDispContext::settings_changed()
 {

--- a/cmake/CXXCompilerFlags.cmake
+++ b/cmake/CXXCompilerFlags.cmake
@@ -42,6 +42,7 @@ if (ENABLE_WARNING_VERBOSE)
 			-Wno-unsafe-buffer-usage
 			-Wno-reserved-identifier
 			-Wno-covered-switch-default
+			-Wno-disabled-macro-expansion
 			-Wno-ctad-maybe-unsupported
 		)
 	endif()

--- a/cmake/CXXCompilerFlags.cmake
+++ b/cmake/CXXCompilerFlags.cmake
@@ -1,0 +1,60 @@
+include(CheckCXXCompilerFlag)
+
+macro (checkCXXFlag FLAG)
+	check_cxx_compiler_flag("${FLAG}" CXXFLAG${FLAG})
+	if(CXXFLAG${FLAG})
+		string(APPEND CMAKE_CXX_FLAGS " ${FLAG}")
+	else()
+		message(WARNING "compiler does not support ${FLAG}")
+	endif()
+endmacro()
+
+option(ENABLE_WARNING_VERBOSE "enable -Weveryting (and some exceptions) for compile" ON)
+option(ENABLE_WARNING_ERROR "enable -Werror for compile" OFF)
+
+if (ENABLE_WARNING_VERBOSE)
+	if (MSVC)
+		# Remove previous warning definitions,
+		# NMake is otherwise complaining.
+		foreach (flags_var_to_scrub
+			CMAKE_CXX_FLAGS
+			CMAKE_CXX_FLAGS_DEBUG
+			CMAKE_CXX_FLAGS_RELEASE
+			CMAKE_CXX_FLAGS_RELWITHDEBINFO
+			CMAKE_CXX_FLAGS_MINSIZEREL)
+			string (REGEX REPLACE "(^| )[/-]W[ ]*[1-9]" " "
+			"${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
+		endforeach()
+
+		set(C_WARNING_FLAGS
+			/W4
+			/wo4324
+		)
+	else()
+		set(C_WARNING_FLAGS
+			-Weverything
+			-Wall
+			-Wpedantic
+			-Wno-padded
+			-Wno-switch-enum
+			-Wno-cast-align
+			-Wno-declaration-after-statement
+			-Wno-unsafe-buffer-usage
+			-Wno-reserved-identifier
+			-Wno-covered-switch-default
+			-Wno-ctad-maybe-unsupported
+		)
+	endif()
+
+	foreach(FLAG ${C_WARNING_FLAGS})
+		CheckCXXFlag(${FLAG})
+	endforeach()
+endif()
+
+
+if (ENABLE_WARNING_ERROR)
+	CheckCXXFlag(-Werror)
+endif()
+
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} CACHE STRING "default CXXFLAGS")
+message("Using CXXFLAGS ${CMAKE_CXX_FLAGS}")

--- a/cmake/CXXCompilerFlags.cmake
+++ b/cmake/CXXCompilerFlags.cmake
@@ -44,6 +44,9 @@ if (ENABLE_WARNING_VERBOSE)
 			-Wno-covered-switch-default
 			-Wno-disabled-macro-expansion
 			-Wno-ctad-maybe-unsupported
+			-Wno-c++98-compat
+			-Wno-c++98-compat-pedantic
+			-Wno-pre-c++17-compat
 		)
 	endif()
 

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -42,6 +42,7 @@ if (ENABLE_WARNING_VERBOSE)
 			-Wno-unsafe-buffer-usage
 			-Wno-reserved-identifier
 			-Wno-covered-switch-default
+			-Wno-disabled-macro-expansion
 		)
 	endif()
 

--- a/server/proxy/modules/bitmap-filter/CMakeLists.txt
+++ b/server/proxy/modules/bitmap-filter/CMakeLists.txt
@@ -44,6 +44,7 @@ message("project ${PROJECT_NAME} is using version ${PROJECT_VERSION}")
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake/)
 include(CommonConfigOptions)
+include(CXXCompilerFlags)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/server/proxy/modules/demo/CMakeLists.txt
+++ b/server/proxy/modules/demo/CMakeLists.txt
@@ -37,6 +37,7 @@ message("project ${PROJECT_NAME} is using version ${PROJECT_VERSION}")
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake/)
 include(CommonConfigOptions)
+include(CXXCompilerFlags)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/server/proxy/modules/dyn-channel-dump/CMakeLists.txt
+++ b/server/proxy/modules/dyn-channel-dump/CMakeLists.txt
@@ -36,6 +36,7 @@ message("project ${PROJECT_NAME} is using version ${PROJECT_VERSION}")
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake/)
 include(CommonConfigOptions)
+include(CXXCompilerFlags)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
* Just like with the C components and CompilerFlags.cmake add a configuration for C++ that disables specific warnings only found in C++ code.
* Disable useless `C++` warnings (old standard compatibility, ...)
* Disable `-Wno-disabled-macro-expansion` as the warning is only providing useless information for our project
* Fix some constants changed for `SDL3 API`