### PR TITLE
Warn fixes cov

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,6 +39,7 @@ Checks: >
     -cppcoreguidelines-avoid-non-const-global-variables,
     -cppcoreguidelines-macro-to-enum,
     -cppcoreguidelines-pro-type-vararg,
+    -cppcoreguidelines-pro-type-reinterpret-cast,
     -cppcoreguidelines-pro-bounds-pointer-arithmetic,
     -cppcoreguidelines-no-malloc,
     -google-readability-braces-around-statements,

--- a/libfreerdp/codec/planar.c
+++ b/libfreerdp/codec/planar.c
@@ -351,7 +351,7 @@ static INLINE INT32 planar_decompress_plane_rle_only(const BYTE* WINPR_RESTRICT 
 }
 
 static INLINE INT32 planar_decompress_plane_rle(const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
-                                                BYTE* WINPR_RESTRICT pDstData, INT32 nDstStep,
+                                                BYTE* WINPR_RESTRICT pDstData, UINT32 nDstStep,
                                                 UINT32 nXDst, UINT32 nYDst, UINT32 nWidth,
                                                 UINT32 nHeight, UINT32 nChannel, BOOL vFlip)
 {
@@ -488,7 +488,7 @@ static INLINE INT32 planar_decompress_plane_rle(const BYTE* WINPR_RESTRICT pSrcD
 	return (INT32)(srcp - pSrcData);
 }
 
-static INLINE INT32 planar_set_plane(BYTE bValue, BYTE* pDstData, INT32 nDstStep, UINT32 nXDst,
+static INLINE INT32 planar_set_plane(BYTE bValue, BYTE* pDstData, UINT32 nDstStep, UINT32 nXDst,
                                      UINT32 nYDst, UINT32 nWidth, UINT32 nHeight, UINT32 nChannel,
                                      BOOL vFlip)
 {

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -1143,7 +1143,7 @@ static INLINE INT16 progressive_rfx_srl_read(RFX_PROGRESSIVE_UPGRADE_STATE* WINP
 
 	if (mag > INT16_MAX)
 		mag = INT16_MAX;
-	return (INT16)(sign ? -1 * mag : mag);
+	return (INT16)(sign ? -1 * (int)mag : (INT16)mag);
 }
 
 static INLINE int

--- a/libfreerdp/utils/smartcard_call.c
+++ b/libfreerdp/utils/smartcard_call.c
@@ -227,7 +227,10 @@ static LONG smartcard_ListReaderGroupsW_Call(scard_call_context* smartcard, wStr
 		return SCARD_F_UNKNOWN_ERROR;
 
 	ret.msz = (BYTE*)mszGroups;
-	ret.cBytes = cchGroups * sizeof(WCHAR);
+
+	const size_t blen = sizeof(WCHAR) * cchGroups;
+	WINPR_ASSERT(blen <= UINT32_MAX);
+	ret.cBytes = (UINT32)blen;
 
 	if (status != SCARD_S_SUCCESS)
 		return status;
@@ -1303,7 +1306,9 @@ static LONG smartcard_StatusW_Call(scard_call_context* smartcard, wStream* out,
 
 	/* SCardStatusW returns number of characters, we need number of bytes */
 	WINPR_ASSERT(ret.cBytes != SCARD_AUTOALLOCATE);
-	ret.cBytes *= sizeof(WCHAR);
+	const size_t blen = sizeof(WCHAR) * ret.cBytes;
+	WINPR_ASSERT(blen <= UINT32_MAX);
+	ret.cBytes = (UINT32)blen;
 
 	status = smartcard_pack_status_return(out, &ret, TRUE);
 	if (status != SCARD_S_SUCCESS)

--- a/server/proxy/modules/dyn-channel-dump/dyn-channel-dump.cpp
+++ b/server/proxy/modules/dyn-channel-dump/dyn-channel-dump.cpp
@@ -382,7 +382,7 @@ static BOOL dump_session_started(proxyPlugin* plugin, proxyData* pdata, void* /*
 	std::string path(cpath);
 	std::string channels(cchannels);
 	std::vector<std::string> list = split(channels, "[;,]");
-	auto cfg = new ChannelData(path, list, custom->session());
+	auto cfg = new ChannelData(path, std::move(list), custom->session());
 	if (!cfg || !cfg->create())
 	{
 		delete cfg;

--- a/server/proxy/pf_config.c
+++ b/server/proxy/pf_config.c
@@ -155,12 +155,9 @@ static BOOL pf_config_get_uint16(wIniFile* ini, const char* section, const char*
 static BOOL pf_config_get_uint32(wIniFile* ini, const char* section, const char* key,
                                  UINT32* result, BOOL required)
 {
-	int val = 0;
-	const char* strval = NULL;
-
 	WINPR_ASSERT(result);
 
-	strval = IniFile_GetKeyValueString(ini, section, key);
+	const char* strval = IniFile_GetKeyValueString(ini, section, key);
 	if (!strval)
 	{
 		if (required)
@@ -168,8 +165,8 @@ static BOOL pf_config_get_uint32(wIniFile* ini, const char* section, const char*
 		return !required;
 	}
 
-	val = IniFile_GetKeyValueInt(ini, section, key);
-	if ((val < 0) || (val > INT32_MAX))
+	const int val = IniFile_GetKeyValueInt(ini, section, key);
+	if (val < 0)
 	{
 		WLog_ERR(TAG, "invalid value %d for key '%s.%s'.", val, section, key);
 		return FALSE;

--- a/server/proxy/pf_input.c
+++ b/server/proxy/pf_input.c
@@ -60,8 +60,7 @@ static BOOL pf_server_synchronize_event(rdpInput* input, UINT32 flags)
 	pc->input_state = flags;
 	pc->input_state_sync_pending = TRUE;
 
-	pf_server_check_and_sync_input_state(pc);
-	return TRUE;
+	return pf_server_check_and_sync_input_state(pc);
 }
 
 static BOOL pf_server_keyboard_event(rdpInput* input, UINT16 flags, UINT8 code)

--- a/winpr/libwinpr/path/path.c
+++ b/winpr/libwinpr/path/path.c
@@ -738,7 +738,7 @@ HRESULT PathCchStripPrefixW(PWSTR pszPath, size_t cchPath)
 			return S_FALSE;
 
 		const size_t rc = (_wcslen(&pszPath[4]) + 1);
-		if ((rc < 0) || ((INT64)cchPath < rc))
+		if (cchPath < rc)
 			return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
 
 		if (IsCharAlphaW(pszPath[4]) && (pszPath[5] == L':')) /* like C: */

--- a/winpr/libwinpr/utils/ini.c
+++ b/winpr/libwinpr/utils/ini.c
@@ -150,7 +150,6 @@ static FILE* IniFile_Open_File(wIniFile* ini, const char* filename)
 static BOOL IniFile_Load_File(wIniFile* ini, const char* filename)
 {
 	BOOL rc = FALSE;
-	INT64 fileSize = 0;
 
 	WINPR_ASSERT(ini);
 
@@ -161,7 +160,7 @@ static BOOL IniFile_Load_File(wIniFile* ini, const char* filename)
 	if (_fseeki64(fp, 0, SEEK_END) < 0)
 		goto out_file;
 
-	fileSize = _ftelli64(fp);
+	const INT64 fileSize = _ftelli64(fp);
 
 	if (fileSize < 0)
 		goto out_file;
@@ -173,9 +172,6 @@ static BOOL IniFile_Load_File(wIniFile* ini, const char* filename)
 	ini->nextLine = NULL;
 
 	if (fileSize < 1)
-		goto out_file;
-
-	if (fileSize > INT64_MAX)
 		goto out_file;
 
 	if (!IniFile_BufferResize(ini, (size_t)fileSize + 2))


### PR DESCRIPTION
* Fix type casts, integer expansion is tricky.
* Fix wrong function parameter types
* assert integer narrowing range check
* deactivate `reinterpret-cast` warnings