### PR TITLE
[warnings] fix mismatched-dealloc

### DIFF
--- a/libfreerdp/codec/dsp_ffmpeg.c
+++ b/libfreerdp/codec/dsp_ffmpeg.c
@@ -656,7 +656,10 @@ FREERDP_DSP_CONTEXT* freerdp_dsp_ffmpeg_context_new(BOOL encode)
 	return context;
 
 fail:
+	WINPR_PRAGMA_DIAG_PUSH
+	WINPR_PRAGMA_DIAG_IGNORED_MISMATCHED_DEALLOC
 	freerdp_dsp_ffmpeg_context_free(context);
+	WINPR_PRAGMA_DIAG_POP
 	return NULL;
 }
 

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -804,7 +804,10 @@ ADDIN_ARGV* freerdp_addin_argv_new(size_t argc, const char* argv[])
 	return args;
 
 fail:
+	WINPR_PRAGMA_DIAG_PUSH
+	WINPR_PRAGMA_DIAG_IGNORED_MISMATCHED_DEALLOC
 	freerdp_addin_argv_free(args);
+	WINPR_PRAGMA_DIAG_POP
 	return NULL;
 }
 

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -833,7 +833,10 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 
 	return settings;
 out_fail:
+	WINPR_PRAGMA_DIAG_PUSH
+	WINPR_PRAGMA_DIAG_IGNORED_MISMATCHED_DEALLOC
 	freerdp_settings_free(settings);
+	WINPR_PRAGMA_DIAG_POP
 	return NULL;
 }
 
@@ -1164,7 +1167,10 @@ rdpSettings* freerdp_settings_clone(const rdpSettings* settings)
 
 	return _settings;
 out_fail:
+	WINPR_PRAGMA_DIAG_PUSH
+	WINPR_PRAGMA_DIAG_IGNORED_MISMATCHED_DEALLOC
 	freerdp_settings_free(_settings);
+	WINPR_PRAGMA_DIAG_POP
 	return NULL;
 }
 #ifdef _MSC_VER

--- a/server/proxy/pf_config.c
+++ b/server/proxy/pf_config.c
@@ -582,7 +582,11 @@ proxyConfig* server_config_load_ini(wIniFile* ini)
 	}
 	return config;
 out:
+	WINPR_PRAGMA_DIAG_PUSH
+	WINPR_PRAGMA_DIAG_IGNORED_MISMATCHED_DEALLOC
 	pf_server_config_free(config);
+	WINPR_PRAGMA_DIAG_POP
+
 	return NULL;
 }
 
@@ -989,7 +993,10 @@ BOOL pf_config_clone(proxyConfig** dst, const proxyConfig* config)
 	return TRUE;
 
 fail:
+	WINPR_PRAGMA_DIAG_PUSH
+	WINPR_PRAGMA_DIAG_IGNORED_MISMATCHED_DEALLOC
 	pf_server_config_free(tmp);
+	WINPR_PRAGMA_DIAG_POP
 	return FALSE;
 }
 


### PR DESCRIPTION
Some allocator functions have an error path where the corresponding free function is called. Since the memory in the allocator function was allocated using malloc/calloc the free function does not match. Silence warnings with pragma macros