### PR TITLE
[clang-tidy] deactivate bugprone-branch-clone check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,6 +24,7 @@ Checks: >
     -cppcoreguidelines-interfaces-global-init,
     -bugprone-easily-swappable-parameters,
     -bugprone-assignment-in-if-condition,
+    -bugprone-branch-clone,
     -bugprone-macro-parentheses,
     -cert-dcl16-c,
     -cert-env33-c,


### PR DESCRIPTION
The check triggers on switch cases running the same function and, more importantly, on our macro CommandLineSwitchStart. Not usable for this project, deactivating the check.