### PR TITLE
[core,gateway] read leftover http body in the rdg IN channel.

### DIFF
--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -1505,6 +1505,16 @@ static BOOL rdg_establish_data_connection(rdpRdg* rdg, rdpTls* tls, const char* 
 		if (!rdg_send_http_request(rdg, tls, method, TransferEncodingChunked))
 			return FALSE;
 
+		response = http_response_recv(tls, TRUE);
+		if (!response)
+		{
+			WLog_Print(rdg->log, WLOG_INFO, "RD Gateway HTTP transport broken.");
+			*rpcFallback = TRUE;
+			return FALSE;
+		}
+
+		http_response_free(response);
+
 		if (rdg->extAuth == HTTP_EXTENDED_AUTH_SSPI_NTLM)
 		{
 			/* create a new auth context for SSPI_NTLM. This must be done after the last


### PR DESCRIPTION
If the HTTP body after the final HTTP request sent in the RDG IN channel remains unprocessed in the network stack, it could confuse the event polling system in some cases.