### PR TITLE
[winpr,utils] fix winpr_strerror argument types

### DIFF
--- a/scripts/abi-suppr.txt
+++ b/scripts/abi-suppr.txt
@@ -7,3 +7,8 @@ name = rdp_settings
 [suppress_type]
 type_kind = struct
 has_data_members_inserted_at = end
+
+# winpr_strerror did use unsigned instead of signed int as argument
+[suppress_function]
+change_kine = function-subtype-change
+name = winpr_strerror

--- a/winpr/include/winpr/debug.h
+++ b/winpr/include/winpr/debug.h
@@ -36,7 +36,7 @@ extern "C"
 	WINPR_API void winpr_backtrace_free(void* buffer);
 	WINPR_API char** winpr_backtrace_symbols(void* buffer, size_t* used);
 	WINPR_API void winpr_backtrace_symbols_fd(void* buffer, int fd);
-	WINPR_API char* winpr_strerror(DWORD dw, char* dmsg, size_t size);
+	WINPR_API char* winpr_strerror(INT32 dw, char* dmsg, size_t size);
 
 #ifdef __cplusplus
 }

--- a/winpr/libwinpr/utils/debug.c
+++ b/winpr/libwinpr/utils/debug.c
@@ -230,14 +230,14 @@ fail:
 	winpr_backtrace_free(stack);
 }
 
-char* winpr_strerror(DWORD dw, char* dmsg, size_t size)
+char* winpr_strerror(INT32 dw, char* dmsg, size_t size)
 {
 #ifdef __STDC_LIB_EXT1__
-	strerror_s((int)dw, dmsg, size);
+	strerror_s(dw, dmsg, size);
 #elif defined(WINPR_HAVE_STRERROR_R)
-	strerror_r((int)dw, dmsg, size);
+	strerror_r(dw, dmsg, size);
 #else
-	(void)_snprintf(dmsg, size, "%s", strerror((int)dw));
+	(void)_snprintf(dmsg, size, "%s", strerror(dw));
 #endif
 	return dmsg;
 }


### PR DESCRIPTION
`errno` is of type int, so use a signed INT32 as argument type to avoid warings with sign conversions