### PR TITLE
[compiler,warnings] disable -Wlanguage-extension-token

### DIFF
--- a/cmake/CXXCompilerFlags.cmake
+++ b/cmake/CXXCompilerFlags.cmake
@@ -43,6 +43,7 @@ if (ENABLE_WARNING_VERBOSE)
 			-Wno-reserved-identifier
 			-Wno-covered-switch-default
 			-Wno-disabled-macro-expansion
+			-Wno-language-extension-token
 			-Wno-ctad-maybe-unsupported
 			-Wno-c++98-compat
 			-Wno-c++98-compat-pedantic

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -43,6 +43,7 @@ if (ENABLE_WARNING_VERBOSE)
 			-Wno-reserved-identifier
 			-Wno-covered-switch-default
 			-Wno-disabled-macro-expansion
+			-Wno-language-extension-token
 		)
 	endif()
 


### PR DESCRIPTION
Expression Statements are not supported by ISO C but we require it for certain macros. Disable this warning as it just yields false positives.