### PR TITLE
[core,client] add channel poll registration API

### DIFF
--- a/include/freerdp/channels/channels.h
+++ b/include/freerdp/channels/channels.h
@@ -33,6 +33,9 @@ extern "C"
 {
 #endif
 
+	/** @since version 3.9.0 */
+	typedef BOOL (*freerdp_channel_handle_fkt_t)(rdpContext* context, void* userdata);
+
 	FREERDP_API int freerdp_channels_client_load(rdpChannels* channels, rdpSettings* settings,
 	                                             PVIRTUALCHANNELENTRY entry, void* data);
 	FREERDP_API int freerdp_channels_client_load_ex(rdpChannels* channels, rdpSettings* settings,
@@ -49,6 +52,40 @@ extern "C"
 
 	FREERDP_API void* freerdp_channels_get_static_channel_interface(rdpChannels* channels,
 	                                                                const char* name);
+
+	/** @brief A channel may register an event handle and a callback function to be called by \b
+	 * freerdp_check_event_handles
+	 *
+	 *  If a channel can not or does not want to use a thread to process data asynchronously it can
+	 * register a \b non-blocking function that does this processing. Notification is done with the
+	 * \b event-handle which will trigger the RDP loop. So this function is triggered until the \b
+	 * event-handle is reset.
+	 *  @note This function may be called even without the \b event-handle to be set, so it must be
+	 * capable of handling these calls properly.
+	 *
+	 *  @param channels A pointer to the channels instance to register with. Must not be \b NULL
+	 *  @param handle A \b event-handle to be used to notify the RDP main thread that the callback
+	 * function should be called again. Must not be \b INVALID_HANDLE_PARAM
+	 *  @param fkt The callback function responsible to handle the channel specifics. Must not be \b
+	 * NULL
+	 *  @param userdata A pointer to a channel specific context. Most likely the channel context.
+	 * May be \b NULL if not required.
+	 *
+	 *  @return \b TRUE if successful, \b FALSE if any error occurs.
+	 *  @since version 3.9.0 */
+	FREERDP_API BOOL freerdp_client_channel_register(rdpChannels* channels, HANDLE handle,
+	                                                 freerdp_channel_handle_fkt_t fkt,
+	                                                 void* userdata);
+
+	/** @brief Remove an existing registration for \b event-handle from the channels instance
+	 *
+	 *  @param channels A pointer to the channels instance to register with. Must not be \b NULL
+	 *  @param handle A \b event-handle to be used to notify the RDP main thread that the callback
+	 * function should be called again. Must not be \b INVALID_HANDLE_PARAM
+	 *
+	 *  @return \b TRUE if successful, \b FALSE if any error occurs.
+	 *  @since version 3.9.0 */
+	FREERDP_API BOOL freerdp_client_channel_unregister(rdpChannels* channels, HANDLE handle);
 
 	FREERDP_API HANDLE freerdp_channels_get_event_handle(freerdp* instance);
 	FREERDP_API int freerdp_channels_process_pending_messages(freerdp* instance);

--- a/libfreerdp/core/client.h
+++ b/libfreerdp/core/client.h
@@ -107,6 +107,8 @@ struct rdp_channels
 
 	DrdynvcClientContext* drdynvc;
 	CRITICAL_SECTION channelsLock;
+
+	wHashTable* channelEvents;
 };
 
 FREERDP_LOCAL void freerdp_channels_free(rdpChannels* channels);
@@ -120,5 +122,10 @@ FREERDP_LOCAL void freerdp_channels_close(rdpChannels* channels, freerdp* instan
 FREERDP_LOCAL void freerdp_channels_register_instance(rdpChannels* channels, freerdp* instance);
 FREERDP_LOCAL UINT freerdp_channels_pre_connect(rdpChannels* channels, freerdp* instance);
 FREERDP_LOCAL UINT freerdp_channels_post_connect(rdpChannels* channels, freerdp* instance);
+
+/** @since version 3.9.0 */
+FREERDP_LOCAL SSIZE_T freerdp_client_channel_get_registered_event_handles(rdpChannels* channels,
+                                                                          HANDLE* events,
+                                                                          DWORD count);
 
 #endif /* FREERDP_LIB_CORE_CLIENT_H */

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -391,7 +391,11 @@ DWORD freerdp_get_event_handles(rdpContext* context, HANDLE* events, DWORD count
 	else
 		return 0;
 
-	return nCount;
+	const SSIZE_T rc = freerdp_client_channel_get_registered_event_handles(
+	    context->channels, &events[nCount], count - nCount);
+	if (rc < 0)
+		return 0;
+	return nCount + (DWORD)rc;
 }
 
 /* Resend mouse cursor position to prevent session lock in prevent-session-lock mode */


### PR DESCRIPTION
Add a new API that allows channels to register/unregister an event-handle along with a callback function to be called by the RDP main thread.
This allows background processing of channel specifics without the need for a channel specific thread.