### PR TITLE
[client,x11] fix reading of work area

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1934,6 +1934,8 @@ BOOL xf_setup_x11(xfContext* xfc)
 	    Logging_XInternAtom(xfc->log, xfc->display, "_XWAYLAND_MAY_GRAB_KEYBOARD", False);
 	xfc->_NET_WM_ICON = Logging_XInternAtom(xfc->log, xfc->display, "_NET_WM_ICON", False);
 	xfc->_MOTIF_WM_HINTS = Logging_XInternAtom(xfc->log, xfc->display, "_MOTIF_WM_HINTS", False);
+	xfc->_NET_NUMBER_OF_DESKTOPS =
+	    Logging_XInternAtom(xfc->log, xfc->display, "_NET_NUMBER_OF_DESKTOPS", False);
 	xfc->_NET_CURRENT_DESKTOP =
 	    Logging_XInternAtom(xfc->log, xfc->display, "_NET_CURRENT_DESKTOP", False);
 	xfc->_NET_WORKAREA = Logging_XInternAtom(xfc->log, xfc->display, "_NET_WORKAREA", False);

--- a/client/X11/xf_window.h
+++ b/client/X11/xf_window.h
@@ -160,7 +160,6 @@ struct xf_app_window
 
 void xf_ewmhints_init(xfContext* xfc);
 
-BOOL xf_GetCurrentDesktop(xfContext* xfc);
 BOOL xf_GetWorkArea(xfContext* xfc);
 
 void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen);

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -223,6 +223,7 @@ struct xf_context
 
 	Atom _NET_WM_ICON;
 	Atom _MOTIF_WM_HINTS;
+	Atom _NET_NUMBER_OF_DESKTOPS;
 	Atom _NET_CURRENT_DESKTOP;
 	Atom _NET_WORKAREA;
 


### PR DESCRIPTION
https://specifications.freedesktop.org/wm-spec/1.4/ar01s03.html _NET_CURRENT_DESKTOP might not be supported by a window manager. Ignore failures there and just take the first monitor dimensions.