### PR TITLE
[core,mcs] unify message channel handling

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -4469,8 +4469,6 @@ fail:
 
 BOOL rdp_recv_get_active_header(rdpRdp* rdp, wStream* s, UINT16* pChannelId, UINT16* length)
 {
-	UINT16 securityFlags = 0;
-
 	WINPR_ASSERT(rdp);
 	WINPR_ASSERT(rdp->context);
 
@@ -4479,18 +4477,6 @@ BOOL rdp_recv_get_active_header(rdpRdp* rdp, wStream* s, UINT16* pChannelId, UIN
 
 	if (freerdp_shall_disconnect_context(rdp->context))
 		return TRUE;
-
-	if (rdp->settings->UseRdpSecurityLayer)
-	{
-		if (!rdp_read_security_header(rdp, s, &securityFlags, length))
-			return FALSE;
-
-		if (securityFlags & SEC_ENCRYPT)
-		{
-			if (!rdp_decrypt(rdp, s, length, securityFlags))
-				return FALSE;
-		}
-	}
 
 	if (*pChannelId != MCS_GLOBAL_CHANNEL_ID)
 	{

--- a/libfreerdp/core/connection.h
+++ b/libfreerdp/core/connection.h
@@ -47,6 +47,7 @@ FREERDP_LOCAL BOOL rdp_client_redirect(rdpRdp* rdp);
 FREERDP_LOCAL BOOL rdp_client_skip_mcs_channel_join(rdpRdp* rdp);
 FREERDP_LOCAL BOOL rdp_client_connect_mcs_channel_join_confirm(rdpRdp* rdp, wStream* s);
 FREERDP_LOCAL BOOL rdp_client_connect_auto_detect(rdpRdp* rdp, wStream* s);
+
 FREERDP_LOCAL state_run_t rdp_client_connect_license(rdpRdp* rdp, wStream* s);
 FREERDP_LOCAL state_run_t rdp_client_connect_demand_active(rdpRdp* rdp, wStream* s);
 FREERDP_LOCAL state_run_t rdp_client_connect_confirm_active(rdpRdp* rdp, wStream* s);
@@ -71,5 +72,10 @@ FREERDP_LOCAL const char* rdp_get_state_string(const rdpRdp* rdp);
 FREERDP_LOCAL const char* rdp_client_connection_state_string(int state);
 
 FREERDP_LOCAL BOOL rdp_channels_from_mcs(rdpSettings* settings, const rdpRdp* rdp);
+
+FREERDP_LOCAL BOOL rdp_handle_message_channel(rdpRdp* rdp, wStream* s, UINT16 channelId,
+                                              UINT16 length);
+FREERDP_LOCAL BOOL rdp_handle_optional_rdp_decryption(rdpRdp* rdp, wStream* s, UINT16* length,
+                                                      UINT16* pSecurityFlags);
 
 #endif /* FREERDP_LIB_CORE_CONNECTION_H */

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -449,27 +449,13 @@ static state_run_t peer_recv_tpkt_pdu(freerdp_peer* client, wStream* s)
 
 	if (rdp_get_state(rdp) <= CONNECTION_STATE_LICENSING)
 	{
-		if (!rdp_read_security_header(rdp, s, &securityFlags, &length))
+		if (!rdp_handle_message_channel(rdp, s, channelId, length))
 			return STATE_RUN_FAILED;
-		if (securityFlags & SEC_ENCRYPT)
-		{
-			if (!rdp_decrypt(rdp, s, &length, securityFlags))
-				return STATE_RUN_FAILED;
-		}
-		return rdp_recv_message_channel_pdu(rdp, s, securityFlags);
+		return STATE_RUN_SUCCESS;
 	}
 
-	if (settings->UseRdpSecurityLayer)
-	{
-		if (!rdp_read_security_header(rdp, s, &securityFlags, &length))
-			return STATE_RUN_FAILED;
-
-		if (securityFlags & SEC_ENCRYPT)
-		{
-			if (!rdp_decrypt(rdp, s, &length, securityFlags))
-				return STATE_RUN_FAILED;
-		}
-	}
+	if (!rdp_handle_optional_rdp_decryption(rdp, s, &length, &securityFlags))
+		return STATE_RUN_FAILED;
 
 	if (channelId == MCS_GLOBAL_CHANNEL_ID)
 	{

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1620,6 +1620,14 @@ static state_run_t rdp_recv_tpkt_pdu(rdpRdp* rdp, wStream* s)
 		rdp->autodetect->bandwidthMeasureByteCount += length;
 	}
 
+	if (rdp->mcs->messageChannelId && (channelId == rdp->mcs->messageChannelId))
+	{
+		rdp->inPackets++;
+		if (!rdp_handle_message_channel(rdp, s, channelId, length))
+			return STATE_RUN_FAILED;
+		return STATE_RUN_SUCCESS;
+	}
+
 	if (rdp->settings->UseRdpSecurityLayer)
 	{
 		if (!rdp_read_security_header(rdp, s, &securityFlags, &length))
@@ -1713,14 +1721,6 @@ static state_run_t rdp_recv_tpkt_pdu(rdpRdp* rdp, wStream* s)
 				           pdu_type_to_str(pduType, buffer, sizeof(buffer)), diff);
 			}
 		}
-	}
-	else if (rdp->mcs->messageChannelId && (channelId == rdp->mcs->messageChannelId))
-	{
-		if (!rdp->settings->UseRdpSecurityLayer)
-			if (!rdp_read_security_header(rdp, s, &securityFlags, NULL))
-				return STATE_RUN_FAILED;
-		rdp->inPackets++;
-		rc = rdp_recv_message_channel_pdu(rdp, s, securityFlags);
 	}
 	else
 	{


### PR DESCRIPTION
@jens-maus I´ve merged #10680 without the unification changes, so your issue is fixed.

could you be so kind and also give this pr a try?
I think I got all instances now and handle the message channel the same in all places (without double RDP encryption/decryption)