### PR TITLE
Adding .rdp file support to Android.

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/domain/BookmarkBase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/domain/BookmarkBase.java
@@ -40,6 +40,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 	protected int type;
 	private long id;
 	private String label;
+	private String rdpFileName;
 	private String username;
 	private String password;
 	private String domain;
@@ -53,6 +54,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 		type = parcel.readInt();
 		id = parcel.readLong();
 		label = parcel.readString();
+		rdpFileName = parcel.readString();
 		username = parcel.readString();
 		password = parcel.readString();
 		domain = parcel.readString();
@@ -73,6 +75,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 		type = TYPE_INVALID;
 		id = -1;
 		label = "";
+		rdpFileName = null;
 		username = "";
 		password = "";
 		domain = "";
@@ -111,6 +114,16 @@ public class BookmarkBase implements Parcelable, Cloneable
 	public void setLabel(String label)
 	{
 		this.label = label;
+	}
+
+	public String getRdpFileName()
+	{
+		return rdpFileName;
+	}
+
+	public void setRdpFileName(String rdpFileName)
+	{
+			this.rdpFileName = rdpFileName;
 	}
 
 	public String getUsername()
@@ -207,6 +220,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 		out.writeInt(type);
 		out.writeLong(id);
 		out.writeString(label);
+		out.writeString(rdpFileName);
 		out.writeString(username);
 		out.writeString(password);
 		out.writeString(domain);
@@ -226,6 +240,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 		SharedPreferences.Editor editor = sharedPrefs.edit();
 		editor.clear();
 		editor.putString("bookmark.label", label);
+		editor.putString("bookmark.rdpFileName", rdpFileName);
 		editor.putString("bookmark.username", username);
 		editor.putString("bookmark.password", password);
 		editor.putString("bookmark.domain", domain);
@@ -293,6 +308,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 	public void readFromSharedPreferences(SharedPreferences sharedPrefs)
 	{
 		label = sharedPrefs.getString("bookmark.label", "");
+		rdpFileName = sharedPrefs.getString("bookmark.rdpFileName", null);
 		username = sharedPrefs.getString("bookmark.username", "");
 		password = sharedPrefs.getString("bookmark.password", "");
 		domain = sharedPrefs.getString("bookmark.domain", "");

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -228,6 +228,10 @@ public class LibFreeRDP
 		ArrayList<String> args = new ArrayList<String>();
 
 		args.add(TAG);
+		if (bookmark.getRdpFileName() != null) {
+			args.add(bookmark.getRdpFileName());
+			args.add("/gt:,no-websockets");
+		}
 		args.add("/gdi:sw");
 
 		final String clientName = ApplicationSettingsActivity.getClientName(context);
@@ -241,12 +245,14 @@ public class LibFreeRDP
 			return false;
 		}
 
-		int port = bookmark.<ManualBookmark>get().getPort();
-		String hostname = bookmark.<ManualBookmark>get().getHostname();
-
-		args.add("/v:" + hostname);
-		args.add("/port:" + String.valueOf(port));
-
+		arg = bookmark.<ManualBookmark>get().getHostname();
+		if (!arg.isEmpty()) {
+			args.add("/v:" + arg);
+		}
+		arg = bookmark.<ManualBookmark>get().getPort() > 0 ? Integer.toString(bookmark.<ManualBookmark>get().getPort()): "";
+		if (!arg.isEmpty()) {
+			args.add("/port:" + arg);
+		}
 		arg = bookmark.getUsername();
 		if (!arg.isEmpty())
 		{


### PR DESCRIPTION
Currently you cannot pass .rdp files to FreeRDP libraries in Android. This feature adds the support for this.

How To Test
- Do not set the new variable entitled rdpFileName under Bookmark Base and it will function the same
- Set the new variable of Bookmark Base entitled rdpFileName to a proper .rdp file on your Android device that your application has access to and it will successfully initiate an RDP connection using the .rdp file.