### PR TITLE
[channels,rdpear] default to OFF

### DIFF
--- a/channels/rdpear/ChannelOptions.cmake
+++ b/channels/rdpear/ChannelOptions.cmake
@@ -1,7 +1,7 @@
 
 set(OPTION_DEFAULT OFF)
-set(OPTION_CLIENT_DEFAULT ON)
-set(OPTION_SERVER_DEFAULT ON)
+set(OPTION_CLIENT_DEFAULT OFF)
+set(OPTION_SERVER_DEFAULT OFF)
 
 define_channel_options(NAME "rdpear" TYPE "dynamic"
 	DESCRIPTION "Authentication redirection Virtual Channel Extension"


### PR DESCRIPTION
Since the channel was introduced late in the 3.x series require users to explicitly enable it to not break existing build setups.