### PR TITLE
Int narrow cleanups

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -71,6 +71,7 @@ Checks: >
     -readability-identifier-length,
     -readability-implicit-bool-conversion,
     -readability-magic-numbers,
+    -readability-misleading-indentation,
     -readability-qualified-auto,
     -readability-suspicious-call-argument,
     -readability-uppercase-literal-suffix,

--- a/libfreerdp/core/childsession.c
+++ b/libfreerdp/core/childsession.c
@@ -76,7 +76,8 @@ static int transport_bio_named_write(BIO* bio, const char* buf, int size)
 		return 0;
 	}
 
-	return written;
+	WINPR_ASSERT(written <= INT32_MAX);
+	return (int)written;
 }
 
 static BOOL treatReadResult(WINPR_BIO_NAMED* ptr, DWORD readBytes)
@@ -221,7 +222,7 @@ static int transport_bio_named_read(BIO* bio, char* buf, int size)
 	if ((size >= 0) && ret)
 	{
 		DataChunk chunks[2] = { 0 };
-		int nchunks = ringbuffer_peek(&ptr->readBuffer, chunks, ret);
+		const int nchunks = ringbuffer_peek(&ptr->readBuffer, chunks, ret);
 		for (int i = 0; i < nchunks; i++)
 		{
 			memcpy(buf, chunks[i].data, chunks[i].size);
@@ -230,7 +231,7 @@ static int transport_bio_named_read(BIO* bio, char* buf, int size)
 
 		ringbuffer_commit_read_bytes(&ptr->readBuffer, ret);
 
-		WLog_VRB(TAG, "(%d)=%d nchunks=%d", size, ret, nchunks);
+		WLog_VRB(TAG, "(%d)=%" PRIdz " nchunks=%d", size, ret, nchunks);
 	}
 
 	if (!ringbuffer_used(&ptr->readBuffer))
@@ -245,7 +246,8 @@ static int transport_bio_named_read(BIO* bio, char* buf, int size)
 	if (ret <= 0)
 		BIO_set_flags(bio, (BIO_FLAGS_SHOULD_RETRY | BIO_FLAGS_READ));
 
-	return ret;
+	WINPR_ASSERT(ret <= INT32_MAX);
+	return (int)ret;
 }
 
 static int transport_bio_named_puts(BIO* bio, const char* str)
@@ -253,7 +255,7 @@ static int transport_bio_named_puts(BIO* bio, const char* str)
 	WINPR_ASSERT(bio);
 	WINPR_ASSERT(str);
 
-	return transport_bio_named_write(bio, str, strlen(str));
+	return transport_bio_named_write(bio, str, (int)strnlen(str, INT32_MAX));
 }
 
 static int transport_bio_named_gets(BIO* bio, char* str, int size)

--- a/libfreerdp/core/fastpath.c
+++ b/libfreerdp/core/fastpath.c
@@ -1066,9 +1066,12 @@ BOOL fastpath_send_multiple_input_pdu(rdpFastPath* fastpath, wStream* s, size_t 
 		if (!security_lock(rdp))
 			goto fail;
 
-		int sec_bytes = fastpath_get_sec_bytes(fastpath->rdp);
+		const size_t sec_bytes = fastpath_get_sec_bytes(fastpath->rdp);
+		if (sec_bytes + 3ULL > length)
+			goto fail;
+
 		BYTE* fpInputEvents = Stream_PointerAs(s, BYTE) + sec_bytes;
-		UINT16 fpInputEvents_length = length - 3 - sec_bytes;
+		const UINT16 fpInputEvents_length = (UINT16)length - 3 - sec_bytes;
 
 		WINPR_ASSERT(rdp->settings);
 		if (rdp->settings->EncryptionMethods == ENCRYPTION_METHOD_FIPS)

--- a/libfreerdp/core/gateway/arm.c
+++ b/libfreerdp/core/gateway/arm.c
@@ -140,7 +140,7 @@ static BOOL arm_tls_connect(rdpArm* arm, rdpTls* tls, int timeout)
 	}
 
 	tls->hostname = freerdp_settings_get_string(settings, FreeRDP_GatewayHostname);
-	tls->port = settings->GatewayPort;
+	tls->port = MIN(UINT16_MAX, settings->GatewayPort);
 	tls->isGatewayTransport = TRUE;
 	status = freerdp_tls_connect(tls, bufferedBio);
 	if (status < 1)
@@ -241,7 +241,7 @@ static BOOL arm_send_http_request(rdpArm* arm, rdpTls* tls, const char* method,
 	const size_t sz = Stream_Length(s);
 
 	if (sz <= INT_MAX)
-		status = freerdp_tls_write_all(tls, Stream_Buffer(s), (int)sz);
+		status = freerdp_tls_write_all(tls, Stream_Buffer(s), sz);
 
 	Stream_Free(s, TRUE);
 	if (status >= 0 && content_length > 0 && data)

--- a/libfreerdp/core/gateway/arm.c
+++ b/libfreerdp/core/gateway/arm.c
@@ -239,9 +239,7 @@ static BOOL arm_send_http_request(rdpArm* arm, rdpTls* tls, const char* method,
 		return FALSE;
 
 	const size_t sz = Stream_Length(s);
-
-	if (sz <= INT_MAX)
-		status = freerdp_tls_write_all(tls, Stream_Buffer(s), sz);
+	status = freerdp_tls_write_all(tls, Stream_Buffer(s), sz);
 
 	Stream_Free(s, TRUE);
 	if (status >= 0 && content_length > 0 && data)

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -1249,7 +1249,7 @@ static BOOL rdg_send_http_request(rdpRdg* rdg, rdpTls* tls, const char* method,
 	sz = Stream_Length(s);
 
 	if (sz <= INT_MAX)
-		status = freerdp_tls_write_all(tls, Stream_Buffer(s), (int)sz);
+		status = freerdp_tls_write_all(tls, Stream_Buffer(s), sz);
 
 	Stream_Free(s, TRUE);
 	return (status >= 0);
@@ -1316,7 +1316,7 @@ static BOOL rdg_tls_connect(rdpRdg* rdg, rdpTls* tls, const char* peerAddress, i
 	}
 
 	tls->hostname = settings->GatewayHostname;
-	tls->port = (int)settings->GatewayPort;
+	tls->port = MIN(UINT16_MAX, settings->GatewayPort);
 	tls->isGatewayTransport = TRUE;
 	status = freerdp_tls_connect(tls, bufferedBio);
 	if (status < 1)
@@ -1722,13 +1722,7 @@ static int rdg_write_chunked_data_packet(rdpRdg* rdg, const BYTE* buf, int isize
 	Stream_SealLength(sChunk);
 	len = Stream_Length(sChunk);
 
-	if (len > INT_MAX)
-	{
-		Stream_Free(sChunk, TRUE);
-		return -1;
-	}
-
-	status = freerdp_tls_write_all(rdg->tlsIn, Stream_Buffer(sChunk), (int)len);
+	status = freerdp_tls_write_all(rdg->tlsIn, Stream_Buffer(sChunk), len);
 	Stream_Free(sChunk, TRUE);
 
 	if (status < 0)

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -1238,18 +1238,14 @@ static BOOL rdg_auth_init(rdpRdg* rdg, rdpTls* tls, TCHAR* authPkg)
 static BOOL rdg_send_http_request(rdpRdg* rdg, rdpTls* tls, const char* method,
                                   TRANSFER_ENCODING transferEncoding)
 {
-	size_t sz = 0;
-	wStream* s = NULL;
 	int status = -1;
-	s = rdg_build_http_request(rdg, method, transferEncoding);
+	wStream* s = rdg_build_http_request(rdg, method, transferEncoding);
 
 	if (!s)
 		return FALSE;
 
-	sz = Stream_Length(s);
-
-	if (sz <= INT_MAX)
-		status = freerdp_tls_write_all(tls, Stream_Buffer(s), sz);
+	const size_t sz = Stream_Length(s);
+	status = freerdp_tls_write_all(tls, Stream_Buffer(s), sz);
 
 	Stream_Free(s, TRUE);
 	return (status >= 0);

--- a/libfreerdp/core/gateway/rpc.c
+++ b/libfreerdp/core/gateway/rpc.c
@@ -483,13 +483,10 @@ SSIZE_T rpc_channel_read(RpcChannel* channel, wStream* s, size_t length)
 
 SSIZE_T rpc_channel_write(RpcChannel* channel, const BYTE* data, size_t length)
 {
-	int status = 0;
-
-	if (!channel || (length > INT32_MAX))
+	if (!channel)
 		return -1;
 
-	status = freerdp_tls_write_all(channel->tls, data, (INT32)length);
-	return status;
+	return freerdp_tls_write_all(channel->tls, data, length);
 }
 
 BOOL rpc_in_channel_transition_to_state(RpcInChannel* inChannel, CLIENT_IN_CHANNEL_STATE state)
@@ -770,7 +767,7 @@ static BOOL rpc_channel_tls_connect(RpcChannel* channel, UINT32 timeout)
 		return FALSE;
 
 	tls->hostname = settings->GatewayHostname;
-	tls->port = settings->GatewayPort;
+	tls->port = MIN(UINT16_MAX, settings->GatewayPort);
 	tls->isGatewayTransport = TRUE;
 	int tlsStatus = freerdp_tls_connect(tls, bufferedBio);
 

--- a/libfreerdp/core/gateway/rpc_client.c
+++ b/libfreerdp/core/gateway/rpc_client.c
@@ -1007,7 +1007,9 @@ int rpc_in_channel_send_pdu(RpcInChannel* inChannel, const BYTE* buffer, size_t 
 		inChannel->SenderAvailableWindow -= status;
 	}
 
-	return status;
+	if (status > INT32_MAX)
+		return -1;
+	return (int)status;
 }
 
 BOOL rpc_client_write_call(rdpRpc* rpc, wStream* s, UINT16 opnum)

--- a/libfreerdp/core/gateway/wst.c
+++ b/libfreerdp/core/gateway/wst.c
@@ -208,7 +208,7 @@ static BOOL wst_recv_auth_token(rdpCredsspAuth* auth, HttpResponse* response)
 	return TRUE;
 }
 
-static BOOL wst_tls_connect(rdpWst* wst, rdpTls* tls, int timeout)
+static BOOL wst_tls_connect(rdpWst* wst, rdpTls* tls, UINT32 timeout)
 {
 	WINPR_ASSERT(wst);
 	WINPR_ASSERT(tls);
@@ -269,7 +269,7 @@ static BOOL wst_tls_connect(rdpWst* wst, rdpTls* tls, int timeout)
 	}
 
 	tls->hostname = wst->gwhostname;
-	tls->port = wst->gwport;
+	tls->port = MIN(UINT16_MAX, wst->gwport);
 	tls->isGatewayTransport = TRUE;
 	status = freerdp_tls_connect(tls, bufferedBio);
 	if (status < 1)
@@ -346,7 +346,7 @@ static BOOL wst_send_http_request(rdpWst* wst, rdpTls* tls)
 	sz = Stream_Length(s);
 
 	if (sz <= INT_MAX)
-		status = freerdp_tls_write_all(tls, Stream_Buffer(s), (int)sz);
+		status = freerdp_tls_write_all(tls, Stream_Buffer(s), sz);
 
 	Stream_Free(s, TRUE);
 	return (status >= 0);

--- a/libfreerdp/core/gateway/wst.c
+++ b/libfreerdp/core/gateway/wst.c
@@ -332,21 +332,15 @@ out:
 
 static BOOL wst_send_http_request(rdpWst* wst, rdpTls* tls)
 {
-	size_t sz = 0;
-	wStream* s = NULL;
-	int status = -1;
 	WINPR_ASSERT(wst);
 	WINPR_ASSERT(tls);
 
-	s = wst_build_http_request(wst);
-
+	wStream* s = wst_build_http_request(wst);
 	if (!s)
 		return FALSE;
 
-	sz = Stream_Length(s);
-
-	if (sz <= INT_MAX)
-		status = freerdp_tls_write_all(tls, Stream_Buffer(s), sz);
+	const size_t sz = Stream_Length(s);
+	int status = freerdp_tls_write_all(tls, Stream_Buffer(s), sz);
 
 	Stream_Free(s, TRUE);
 	return (status >= 0);

--- a/libfreerdp/core/license.c
+++ b/libfreerdp/core/license.c
@@ -1618,7 +1618,7 @@ BOOL license_read_scope_list(wStream* s, SCOPE_LIST* scopeList)
 
 	Stream_Read_UINT32(s, scopeCount); /* ScopeCount (4 bytes) */
 
-	if (!license_check_stream_length(s, scopeCount * 4ull, "license scope list::count"))
+	if (!license_check_stream_length(s, 4ll * scopeCount, "license scope list::count"))
 		return FALSE;
 
 	if (!license_scope_list_resize(scopeList, scopeCount))

--- a/libfreerdp/core/streamdump.c
+++ b/libfreerdp/core/streamdump.c
@@ -335,7 +335,7 @@ static int stream_dump_replay_transport_read(rdpTransport* transport, wStream* s
 	rdpContext* ctx = transport_get_context(transport);
 
 	size_t size = 0;
-	time_t slp = 0;
+	UINT64 slp = 0;
 	UINT64 ts = 0;
 	UINT32 flags = 0;
 

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -303,7 +303,7 @@ static BOOL transport_default_connect_tls(rdpTransport* transport)
 
 	tls->hostname = settings->ServerHostname;
 	tls->serverName = settings->UserSpecifiedServerName;
-	tls->port = settings->ServerPort;
+	tls->port = MIN(UINT16_MAX, settings->ServerPort);
 
 	if (tls->port == 0)
 		tls->port = 3389;

--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -2894,7 +2894,7 @@ update_send_new_or_existing_notification_icons(rdpContext* context,
 
 	/* Write Hdr */
 	Stream_Write_UINT8(s, controlFlags);             /* Header (1 byte) */
-	Stream_Write_INT16(s, orderSize);                /* OrderSize (2 bytes) */
+	Stream_Write_UINT16(s, orderSize);               /* OrderSize (2 bytes) */
 	Stream_Write_UINT32(s, orderInfo->fieldFlags);   /* FieldsPresentFlags (4 bytes) */
 	Stream_Write_UINT32(s, orderInfo->windowId);     /* WindowID (4 bytes) */
 	Stream_Write_UINT32(s, orderInfo->notifyIconId); /* NotifyIconId (4 bytes) */

--- a/libfreerdp/crypto/base64.c
+++ b/libfreerdp/crypto/base64.c
@@ -307,7 +307,6 @@ static INLINE char* base64_encode_ex(const BYTE* WINPR_RESTRICT alphabet,
                                      BOOL crLf, size_t lineSize)
 {
 	int c = 0;
-	char* ret = NULL;
 	size_t blocks = 0;
 	size_t outLen = (length + 3) * 4 / 3;
 	size_t extra = 0;
@@ -319,9 +318,11 @@ static INLINE char* base64_encode_ex(const BYTE* WINPR_RESTRICT alphabet,
 	size_t outCounter = 0;
 
 	const BYTE* q = data;
-	BYTE* p = ret = malloc(outLen + extra + 1ull);
+	BYTE* p = malloc(outLen + extra + 1ull);
 	if (!p)
 		return NULL;
+
+	char* ret = (char*)p;
 
 	/* b1, b2, b3 are input bytes
 	 *

--- a/libfreerdp/crypto/base64.c
+++ b/libfreerdp/crypto/base64.c
@@ -307,10 +307,8 @@ static INLINE char* base64_encode_ex(const BYTE* WINPR_RESTRICT alphabet,
                                      BOOL crLf, size_t lineSize)
 {
 	int c = 0;
-	const BYTE* q = NULL;
-	char* p = NULL;
 	char* ret = NULL;
-	int blocks = 0;
+	size_t blocks = 0;
 	size_t outLen = (length + 3) * 4 / 3;
 	size_t extra = 0;
 	if (crLf)
@@ -320,8 +318,8 @@ static INLINE char* base64_encode_ex(const BYTE* WINPR_RESTRICT alphabet,
 	}
 	size_t outCounter = 0;
 
-	q = data;
-	p = ret = (char*)malloc(outLen + extra + 1ull);
+	const BYTE* q = data;
+	BYTE* p = ret = malloc(outLen + extra + 1ull);
 	if (!p)
 		return NULL;
 
@@ -339,7 +337,7 @@ static INLINE char* base64_encode_ex(const BYTE* WINPR_RESTRICT alphabet,
 
 	/* first treat complete blocks */
 	blocks = length - (length % 3);
-	for (int i = 0; i < blocks; i += 3, q += 3)
+	for (size_t i = 0; i < blocks; i += 3, q += 3)
 	{
 		c = (q[0] << 16) + (q[1] << 8) + q[2];
 
@@ -414,7 +412,7 @@ static INLINE void* base64_decode(const signed char* WINPR_RESTRICT alphabet,
 	BYTE* data = NULL;
 	size_t nBlocks = 0;
 	size_t outputLen = 0;
-	int remainder = length % 4;
+	const size_t remainder = length % 4;
 
 	if ((pad && remainder > 0) || (remainder == 1))
 		return NULL;

--- a/libfreerdp/crypto/tls.h
+++ b/libfreerdp/crypto/tls.h
@@ -115,7 +115,7 @@ extern "C"
 
 	FREERDP_LOCAL BOOL freerdp_tls_send_alert(rdpTls* tls);
 
-	FREERDP_LOCAL int freerdp_tls_write_all(rdpTls* tls, const BYTE* data, int length);
+	FREERDP_LOCAL int freerdp_tls_write_all(rdpTls* tls, const BYTE* data, size_t length);
 
 	FREERDP_LOCAL int freerdp_tls_set_alert_code(rdpTls* tls, int level, int description);
 

--- a/libfreerdp/gdi/pen.c
+++ b/libfreerdp/gdi/pen.c
@@ -52,7 +52,8 @@ HGDI_PEN gdi_CreatePen(UINT32 fnPenStyle, UINT32 nWidth, UINT32 crColor, UINT32 
 	hPen->objectType = GDIOBJECT_PEN;
 	hPen->style = fnPenStyle;
 	hPen->color = crColor;
-	hPen->width = nWidth;
+	WINPR_ASSERT(nWidth <= INT32_MAX);
+	hPen->width = (int)nWidth;
 	hPen->format = format;
 	hPen->palette = palette;
 	return hPen;

--- a/rdtk/librdtk/rdtk_font.c
+++ b/rdtk/librdtk/rdtk_font.c
@@ -429,7 +429,7 @@ static int rdtk_font_parse_descriptor_buffer(rdtkFont* font, uint8_t* buffer, si
 		*q = '\0';
 		errno = 0;
 		{
-			long val = strtoul(p, NULL, 0);
+			long val = strtol(p, NULL, 0);
 
 			if ((errno != 0) || (val < INT32_MIN) || (val > INT32_MAX))
 				return -1;

--- a/winpr/include/winpr/comm.h
+++ b/winpr/include/winpr/comm.h
@@ -224,11 +224,11 @@ typedef struct
 	BYTE ByteSize;
 	BYTE Parity;
 	BYTE StopBits;
-	char XonChar;
-	char XoffChar;
-	char ErrorChar;
-	char EofChar;
-	char EvtChar;
+	BYTE XonChar;
+	BYTE XoffChar;
+	BYTE ErrorChar;
+	BYTE EofChar;
+	BYTE EvtChar;
 	WORD wReserved1;
 } DCB, *LPDCB;
 

--- a/winpr/libwinpr/comm/comm.h
+++ b/winpr/libwinpr/comm/comm.h
@@ -75,7 +75,7 @@ struct winpr_comm
 	ULONG WaitEventMask;
 	ULONG PendingEvents;
 
-	char eventChar;
+	BYTE eventChar;
 	/* NB: CloseHandle() has to free resources */
 };
 

--- a/winpr/libwinpr/comm/comm_io.c
+++ b/winpr/libwinpr/comm/comm_io.c
@@ -75,7 +75,7 @@ BOOL CommReadFile(HANDLE hDevice, LPVOID lpBuffer, DWORD nNumberOfBytesToRead,
 	COMMTIMEOUTS* pTimeouts = NULL;
 	UCHAR vmin = 0;
 	UCHAR vtime = 0;
-	ULONGLONG Tmax = 0;
+	LONGLONG Tmax = 0;
 	struct timeval tmaxTimeout;
 	struct timeval* pTmaxTimeout = NULL;
 	struct termios currentTermios;
@@ -184,8 +184,8 @@ BOOL CommReadFile(HANDLE hDevice, LPVOID lpBuffer, DWORD nNumberOfBytesToRead,
 	else
 	{
 		/* Tmax */
-		Tmax = 1ull * nNumberOfBytesToRead * pTimeouts->ReadTotalTimeoutMultiplier +
-		       1ull * pTimeouts->ReadTotalTimeoutConstant;
+		Tmax = 1ll * nNumberOfBytesToRead * pTimeouts->ReadTotalTimeoutMultiplier +
+		       1ll * pTimeouts->ReadTotalTimeoutConstant;
 
 		/* INDEFinitely */
 		if ((Tmax == 0) && (pTimeouts->ReadIntervalTimeout < MAXULONG) &&
@@ -404,8 +404,8 @@ BOOL CommWriteFile(HANDLE hDevice, LPCVOID lpBuffer, DWORD nNumberOfBytesToWrite
 #endif
 
 	/* ms */
-	ULONGLONG Tmax = 1ull * nNumberOfBytesToWrite * pComm->timeouts.WriteTotalTimeoutMultiplier +
-	                 1ull * pComm->timeouts.WriteTotalTimeoutConstant;
+	LONGLONG Tmax = 1ll * nNumberOfBytesToWrite * pComm->timeouts.WriteTotalTimeoutMultiplier +
+	                1ll * pComm->timeouts.WriteTotalTimeoutConstant;
 	/* NB: select() may update the timeout argument to indicate
 	 * how much time was left. Keep the timeout variable out of
 	 * the while() */

--- a/winpr/libwinpr/sspi/Schannel/schannel_openssl.c
+++ b/winpr/libwinpr/sspi/Schannel/schannel_openssl.c
@@ -33,6 +33,8 @@
 #include <openssl/err.h>
 #include <openssl/bio.h>
 
+#define LIMIT_INTMAX(a) ((a) > INT32_MAX) ? INT32_MAX : (int)(a)
+
 struct S_SCHANNEL_OPENSSL
 {
 	SSL* ssl;
@@ -377,7 +379,8 @@ SECURITY_STATUS schannel_openssl_client_process_tokens(SCHANNEL_OPENSSL* context
 				return SEC_E_INVALID_TOKEN;
 
 			ERR_clear_error();
-			status = BIO_write(context->bioRead, pBuffer->pvBuffer, pBuffer->cbBuffer);
+			status =
+			    BIO_write(context->bioRead, pBuffer->pvBuffer, LIMIT_INTMAX(pBuffer->cbBuffer));
 			if (status < 0)
 				return SEC_E_INVALID_TOKEN;
 		}
@@ -442,7 +445,7 @@ SECURITY_STATUS schannel_openssl_server_process_tokens(SCHANNEL_OPENSSL* context
 			return SEC_E_INVALID_TOKEN;
 
 		ERR_clear_error();
-		status = BIO_write(context->bioRead, pBuffer->pvBuffer, pBuffer->cbBuffer);
+		status = BIO_write(context->bioRead, pBuffer->pvBuffer, LIMIT_INTMAX(pBuffer->cbBuffer));
 		if (status >= 0)
 			status = SSL_accept(context->ssl);
 
@@ -506,7 +509,8 @@ SECURITY_STATUS schannel_openssl_encrypt_message(SCHANNEL_OPENSSL* context, PSec
 	if ((!pStreamHeaderBuffer) || (!pStreamBodyBuffer) || (!pStreamTrailerBuffer))
 		return SEC_E_INVALID_TOKEN;
 
-	status = SSL_write(context->ssl, pStreamBodyBuffer->pvBuffer, pStreamBodyBuffer->cbBuffer);
+	status = SSL_write(context->ssl, pStreamBodyBuffer->pvBuffer,
+	                   LIMIT_INTMAX(pStreamBodyBuffer->cbBuffer));
 
 	if (status < 0)
 	{
@@ -553,9 +557,9 @@ SECURITY_STATUS schannel_openssl_decrypt_message(SCHANNEL_OPENSSL* context, PSec
 		return SEC_E_INVALID_TOKEN;
 
 	ERR_clear_error();
-	status = BIO_write(context->bioRead, pBuffer->pvBuffer, pBuffer->cbBuffer);
+	status = BIO_write(context->bioRead, pBuffer->pvBuffer, LIMIT_INTMAX(pBuffer->cbBuffer));
 	if (status > 0)
-		status = SSL_read(context->ssl, pBuffer->pvBuffer, pBuffer->cbBuffer);
+		status = SSL_read(context->ssl, pBuffer->pvBuffer, LIMIT_INTMAX(pBuffer->cbBuffer));
 
 	if (status < 0)
 	{

--- a/winpr/libwinpr/utils/collections/ArrayList.c
+++ b/winpr/libwinpr/utils/collections/ArrayList.c
@@ -236,11 +236,13 @@ static BOOL ArrayList_Shift(wArrayList* arrayList, size_t index, SSIZE_T count)
 	}
 	else if (count < 0)
 	{
-		INT64 chunk = arrayList->size - index + count;
-
-		if (chunk > 0)
+		const size_t off = index + (size_t)(-1 * count);
+		if (off < arrayList->size)
+		{
+			const size_t chunk = arrayList->size - off;
 			MoveMemory(&arrayList->array[index], &arrayList->array[index - count],
-			           (size_t)chunk * sizeof(void*));
+			           chunk * sizeof(void*));
+		}
 
 		arrayList->size += count;
 	}
@@ -493,9 +495,12 @@ SSIZE_T ArrayList_LastIndexOf(wArrayList* arrayList, const void* obj, SSIZE_T st
 	if (startIndex < 0)
 		sindex = 0;
 
-	cindex = (size_t)count;
+	cindex = count;
 	if (count < 0)
-		cindex = arrayList->size;
+	{
+		WINPR_ASSERT(arrayList->size <= SSIZE_MAX);
+		cindex = (SSIZE_T)arrayList->size;
+	}
 
 	SSIZE_T index = sindex + cindex;
 	for (; index > sindex; index--)

--- a/winpr/libwinpr/utils/collections/BitStream.c
+++ b/winpr/libwinpr/utils/collections/BitStream.c
@@ -106,8 +106,9 @@ void BitDump(const char* tag, UINT32 level, const BYTE* buffer, UINT32 length, U
 	for (; i < length; i += 8)
 	{
 		const char* str = strs[buffer[i / 8]];
-		const int nbits = (length - i) > 8 ? 8 : (length - i);
-		const int rc = _snprintf(&pbuffer[pos], length - pos, "%.*s ", nbits, str);
+		const DWORD nbits = (length - i) > 8 ? 8 : (length - i);
+		WINPR_ASSERT(nbits <= INT32_MAX);
+		const int rc = _snprintf(&pbuffer[pos], length - pos, "%.*s ", (int)nbits, str);
 		if (rc < 0)
 			return;
 

--- a/winpr/libwinpr/utils/collections/StreamPool.c
+++ b/winpr/libwinpr/utils/collections/StreamPool.c
@@ -187,7 +187,8 @@ static void StreamPool_ShiftAvailable(wStreamPool* pool, size_t index, INT64 cou
 
 wStream* StreamPool_Take(wStreamPool* pool, size_t size)
 {
-	SSIZE_T foundIndex = -1;
+	BOOL found = FALSE;
+	size_t foundIndex = 0;
 	wStream* s = NULL;
 
 	StreamPool_Lock(pool);
@@ -201,12 +202,13 @@ wStream* StreamPool_Take(wStreamPool* pool, size_t size)
 
 		if (Stream_Capacity(s) >= size)
 		{
+			found = TRUE;
 			foundIndex = index;
 			break;
 		}
 	}
 
-	if (foundIndex < 0)
+	if (!found)
 	{
 		s = Stream_New(NULL, size);
 		if (!s)

--- a/winpr/libwinpr/utils/execinfo/debug.c
+++ b/winpr/libwinpr/utils/execinfo/debug.c
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <fcntl.h>
 
@@ -57,7 +58,8 @@ void* winpr_execinfo_backtrace(DWORD size)
 		return NULL;
 	}
 
-	const int rc = backtrace(data->buffer, size);
+	assert(size <= INT32_MAX);
+	const int rc = backtrace(data->buffer, (int)size);
 	if (rc < 0)
 	{
 		free(data);
@@ -80,7 +82,8 @@ char** winpr_execinfo_backtrace_symbols(void* buffer, size_t* used)
 	if (used)
 		*used = data->used;
 
-	return backtrace_symbols(data->buffer, data->used);
+	assert(data->used < INT32_MAX);
+	return backtrace_symbols(data->buffer, (int)data->used);
 }
 
 void winpr_execinfo_backtrace_symbols_fd(void* buffer, int fd)
@@ -90,5 +93,6 @@ void winpr_execinfo_backtrace_symbols_fd(void* buffer, int fd)
 	if (!data)
 		return;
 
-	backtrace_symbols_fd(data->buffer, data->used, fd);
+	assert(data->used <= INT32_MAX);
+	backtrace_symbols_fd(data->buffer, (int)data->used, fd);
 }

--- a/winpr/libwinpr/utils/image.c
+++ b/winpr/libwinpr/utils/image.c
@@ -626,7 +626,8 @@ static void* winpr_convert_to_jpeg(const void* data, size_t size, UINT32 width, 
 
 	cinfo.image_width = width;
 	cinfo.image_height = height;
-	cinfo.input_components = (bpp + 7) / 8;
+	WINPR_ASSERT(bpp <= INT32_MAX / 8);
+	cinfo.input_components = (int)(bpp + 7) / 8;
 	cinfo.in_color_space = (bpp > 24) ? JCS_EXT_BGRA : JCS_EXT_BGR;
 	cinfo.data_precision = 8;
 
@@ -900,7 +901,9 @@ static SSIZE_T save_png_to_buffer(UINT32 bpp, UINT32 width, UINT32 height, const
 	png_free(png_ptr, row_pointers);
 
 	/* Finish writing. */
-	rc = state.size;
+	if (state.size > SSIZE_MAX)
+		goto fail;
+	rc = (SSIZE_T)state.size;
 	*pDstData = state.buffer;
 fail:
 	png_destroy_write_struct(&png_ptr, &info_ptr);


### PR DESCRIPTION
do some overflow checks or `asserts` before shortening integers