### PR TITLE
[winpr,file] make handle creators return const

### DIFF
--- a/winpr/libwinpr/comm/CMakeLists.txt
+++ b/winpr/libwinpr/comm/CMakeLists.txt
@@ -24,7 +24,7 @@ if (NOT WIN32)
 		comm.h
 	)
 	if(UNIX AND NOT IOS AND NOT EMSCRIPTEN)
-		add_definitions(-DWINPR_HAVE_SERIAL_SUPPORT)
+		winpr_definition_add(-DWINPR_HAVE_SERIAL_SUPPORT)
 		list(APPEND ${MODULE_PREFIX}_SRCS
 			comm_io.c
 			comm_ioctl.c

--- a/winpr/libwinpr/comm/comm.c
+++ b/winpr/libwinpr/comm/comm.c
@@ -68,7 +68,7 @@ typedef struct comm_device COMM_DEVICE;
 /* _CommDevices is a NULL-terminated array with a maximun of COMM_DEVICE_MAX COMM_DEVICE */
 #define COMM_DEVICE_MAX 128
 static COMM_DEVICE** sCommDevices = NULL;
-static CRITICAL_SECTION sCommDevicesLock;
+static CRITICAL_SECTION sCommDevicesLock = { 0 };
 
 static pthread_once_t sCommInitialized = PTHREAD_ONCE_INIT;
 
@@ -82,11 +82,11 @@ static int CommGetFd(HANDLE handle)
 	return comm->fd;
 }
 
-HANDLE_CREATOR* GetCommHandleCreator(void)
+const HANDLE_CREATOR* GetCommHandleCreator(void)
 {
 #if defined(WINPR_HAVE_SERIAL_SUPPORT)
-	sCommHandleCreator.IsHandled = IsCommDevice;
-	sCommHandleCreator.CreateFileA = CommCreateFileA;
+	static const HANDLE_CREATOR sCommHandleCreator = { .IsHandled = IsCommDevice,
+		                                               .CreateFileA = CommCreateFileA };
 	return &sCommHandleCreator;
 #else
 	return NULL;

--- a/winpr/libwinpr/comm/comm.h
+++ b/winpr/libwinpr/comm/comm.h
@@ -105,7 +105,7 @@ void CommLog_Print(DWORD wlog_level, ...);
 BOOL CommIsHandled(HANDLE handle);
 BOOL CommIsHandleValid(HANDLE handle);
 BOOL CommCloseHandle(HANDLE handle);
-HANDLE_CREATOR* GetCommHandleCreator(void);
+const HANDLE_CREATOR* GetCommHandleCreator(void);
 
 #if defined(WINPR_HAVE_SYS_EVENTFD_H)
 #ifndef WITH_EVENTFD_READ_WRITE

--- a/winpr/libwinpr/file/CMakeLists.txt
+++ b/winpr/libwinpr/file/CMakeLists.txt
@@ -15,7 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-winpr_module_add(generic.c namedPipeClient.c pattern.c file.c)
+winpr_module_add(
+    generic.c
+    namedPipeClient.c
+    namedPipeClient.h
+    pattern.c
+    file.c
+)
 
 if(BUILD_TESTING)
 	add_subdirectory(test)

--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -976,9 +976,9 @@ static BOOL IsFileDevice(LPCTSTR lpDeviceName)
 	return TRUE;
 }
 
-static HANDLE_CREATOR FileHandleCreator = { IsFileDevice, FileCreateFileA };
+static const HANDLE_CREATOR FileHandleCreator = { IsFileDevice, FileCreateFileA };
 
-HANDLE_CREATOR* GetFileHandleCreator(void)
+const HANDLE_CREATOR* GetFileHandleCreator(void)
 {
 	return &FileHandleCreator;
 }

--- a/winpr/libwinpr/file/file.h
+++ b/winpr/libwinpr/file/file.h
@@ -57,7 +57,7 @@ struct winpr_file
 };
 typedef struct winpr_file WINPR_FILE;
 
-HANDLE_CREATOR* GetFileHandleCreator(void);
+const HANDLE_CREATOR* GetFileHandleCreator(void);
 
 UINT32 map_posix_err(int fs_errno);
 

--- a/winpr/libwinpr/file/generic.c
+++ b/winpr/libwinpr/file/generic.c
@@ -178,9 +178,8 @@ static wArrayList* HandleCreators;
 
 static pthread_once_t HandleCreatorsInitialized = PTHREAD_ONCE_INIT;
 
-extern HANDLE_CREATOR* GetNamedPipeClientHandleCreator(void);
-
 #include "../comm/comm.h"
+#include "namedPipeClient.h"
 
 static void HandleCreatorsInit(void)
 {
@@ -194,7 +193,7 @@ static void HandleCreatorsInit(void)
 	 * Register all file handle creators.
 	 */
 	ArrayList_Append(HandleCreators, GetNamedPipeClientHandleCreator());
-	HANDLE_CREATOR* serial = GetCommHandleCreator();
+	const HANDLE_CREATOR* serial = GetCommHandleCreator();
 	if (serial)
 		ArrayList_Append(HandleCreators, serial);
 	ArrayList_Append(HandleCreators, GetFileHandleCreator());
@@ -250,7 +249,7 @@ HANDLE CreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode,
 
 	for (size_t i = 0; i <= ArrayList_Count(HandleCreators); i++)
 	{
-		HANDLE_CREATOR* creator = ArrayList_GetItem(HandleCreators, i);
+		const HANDLE_CREATOR* creator = ArrayList_GetItem(HandleCreators, i);
 
 		if (creator && creator->IsHandled(lpFileName))
 		{

--- a/winpr/libwinpr/file/namedPipeClient.c
+++ b/winpr/libwinpr/file/namedPipeClient.c
@@ -43,8 +43,7 @@
 #include "../handle/handle.h"
 
 #include "../pipe/pipe.h"
-
-static HANDLE_CREATOR NamedPipeClientHandleCreator;
+#include "namedPipeClient.h"
 
 static BOOL NamedPipeClientIsHandled(HANDLE handle)
 {
@@ -225,11 +224,11 @@ static HANDLE NamedPipeClientCreateFileA(LPCSTR lpFileName, DWORD dwDesiredAcces
 	return hNamedPipe;
 }
 
-extern HANDLE_CREATOR* GetNamedPipeClientHandleCreator(void);
-HANDLE_CREATOR* GetNamedPipeClientHandleCreator(void)
+const HANDLE_CREATOR* GetNamedPipeClientHandleCreator(void)
 {
-	NamedPipeClientHandleCreator.IsHandled = IsNamedPipeFileNameA;
-	NamedPipeClientHandleCreator.CreateFileA = NamedPipeClientCreateFileA;
+	static const HANDLE_CREATOR NamedPipeClientHandleCreator = { .IsHandled = IsNamedPipeFileNameA,
+		                                                         .CreateFileA =
+		                                                             NamedPipeClientCreateFileA };
 	return &NamedPipeClientHandleCreator;
 }
 

--- a/winpr/libwinpr/file/namedPipeClient.h
+++ b/winpr/libwinpr/file/namedPipeClient.h
@@ -1,0 +1,25 @@
+/**
+ * WinPR: Windows Portable Runtime
+ * File Functions
+ *
+ * Copyright 2024 Armin Novak <anovak@thincast.com>
+ * Copyright 2024 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <winpr/file.h>
+
+extern const HANDLE_CREATOR* GetNamedPipeClientHandleCreator(void);


### PR DESCRIPTION
* let the file handle creators return const HANDLE_CREATOR
* for comm port use winpr_definition_add(-DWINPR_HAVE_SERIAL_SUPPORT) to have the definition visible at correct scope
* create namedPipeClient.h for handle creator function declaration