### PR TITLE
[ci,workflow] set USE_UNWIND=OFF again

### DIFF
--- a/.github/workflows/alt-architectures.yml
+++ b/.github/workflows/alt-architectures.yml
@@ -97,6 +97,7 @@ jobs:
               -DCMAKE_INSTALL_PREFIX=/tmp/ci-test \
               -DCMAKE_C_COMPILER=/usr/bin/clang \
               -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+              -DUSE_UNWIND=OFF \
               -DUSE_EXECINFO=OFF \
               -DWITH_SANITIZE_ADDRESS=OFF
             cmake --build ci-build --parallel $(nproc) --target install


### PR DESCRIPTION
arm builds do not work with unwind backtrace on.
[winpr_unwind_backtrace]: _Unwind_Backtrace failed with _URC_FAILURE [0x09]