### PR TITLE
RDPECAM client MJPEG decoder fix to skip corrupted frames

### DIFF
--- a/channels/rdpecam/client/encoding.c
+++ b/channels/rdpecam/client/encoding.c
@@ -289,6 +289,10 @@ static BOOL ecam_init_mjpeg_decoder(CameraDeviceStream* stream)
 	stream->avContext->width = stream->currMediaType.Width;
 	stream->avContext->height = stream->currMediaType.Height;
 
+	/* AV_EF_EXPLODE flag is to abort decoding on minor error detection,
+	 * return error, so we can skip corrupted frames, if any */
+	stream->avContext->err_recognition |= AV_EF_EXPLODE;
+
 	if (avcodec_open2(stream->avContext, avcodec, NULL) < 0)
 	{
 		WLog_ERR(TAG, "avcodec_open2 failed");


### PR DESCRIPTION
Some cameras such as  Logitech Webcam C930e and newer modifications of C920 display these decoding errors with MJPEG format:
```
[mjpeg @ 0x7f9d102824c0] overread 8
[mjpeg @ 0x7f9d102824c0] EOI missing, emulating
```
or
```
[mjpeg @ 0x7f9d47583c40] mjpeg_decode_dc: bad vlc: 0:0 (0x7f9d47580048)
[mjpeg @ 0x7f9d47583c40] error dc
[mjpeg @ 0x7f9d47583c40] error y=134 x=117
```
The errors typically show up only while decoding first frame from camera. Beginning from second frame, there are no problems with decoding. I inspected the dumps of the first frame and I can confirm there is random partial data corruption.

Prior to this fix, when the 1st corrupted JPEG frame is being decoded, FFmpeg library detects and prints the problem, but `avcodec_send_packet` decoding API doesn't return an error (considers it minor). We then try to re-encode to H264. Since it's a 1st frame, it becomes bad H264 I-frame, which results in distorted image for ~10 seconds or so, until next good I-frame is generated. The effect of single corrupted frame is over-amplified.

This fix sets a special flag `AV_EF_EXPLODE`, that tells MJPEG decoder to abort decoding on minor error detection and return error. It allows us to skip corrupted frames.

Tested with C930e, verified the flag actually takes effect and we skip bad frames, so the above mentioned distorted image is no longer seen.

Cc: @akallabeth, @hardening, @jens-maus