### PR TITLE
[ci,timezone] remove clang-format off

### DIFF
--- a/winpr/libwinpr/timezone/utils/tzextract.cs
+++ b/winpr/libwinpr/timezone/utils/tzextract.cs
@@ -30,8 +30,6 @@ internal class Program
 			fs.WriteLine("");
 			fs.WriteLine("#include \"" + fname + ".h\"");
 			fs.WriteLine("");
-			fs.WriteLine("// clang-format off");
-			fs.WriteLine("");
 			fs.WriteLine("static const " + fname + "Entry " + fname + "[] ={");
 
 			bool first = true;
@@ -61,8 +59,6 @@ internal class Program
 			fs.WriteLine("};");
 			fs.WriteLine("");
 			fs.WriteLine("static const size_t " + fname + "Size = ARRAYSIZE(" + fname + ");");
-			fs.WriteLine("");
-			fs.WriteLine("// clang-format on");
 		}
 		return true;
 	}
@@ -173,7 +169,6 @@ internal class Program
 			fs.WriteLine("");
 			fs.WriteLine("#include \"" + fname + ".h\"");
 			fs.WriteLine("");
-			fs.WriteLine("// clang-format off");
 			fs.WriteLine("const WINDOWS_TZID_ENTRY " + fname + "[] = {");
 
 			foreach (XmlNode mzone in mzones)
@@ -189,7 +184,6 @@ internal class Program
 			fs.WriteLine("};");
 			fs.WriteLine("");
 			fs.WriteLine("const size_t " + fname + "NrElements = ARRAYSIZE(" + fname + ");");
-			fs.WriteLine("// clang-format on");
 		}
 		stdout.WriteLine("Finished update");
 		return true;


### PR DESCRIPTION
we do format the files now properly before creating the automated pull, the workaround is no longer required