### PR TITLE
Sdl client fix

### DIFF
--- a/client/SDL/SDL3/sdl_clip.cpp
+++ b/client/SDL/SDL3/sdl_clip.cpp
@@ -242,7 +242,7 @@ UINT sdlClip::MonitorReady(CliprdrClientContext* context, const CLIPRDR_MONITOR_
 		return ret;
 
 	clipboard->_sync = true;
-	SDL_ClipboardEvent ev = { SDL_EVENT_CLIPBOARD_UPDATE, 0, 0, false, NULL, 0 };
+	SDL_ClipboardEvent ev = { SDL_EVENT_CLIPBOARD_UPDATE, 0, 0, false, 0, nullptr };
 	if (!clipboard->handle_update(ev))
 		return ERROR_INTERNAL_ERROR;
 

--- a/client/SDL/SDL3/sdl_monitor.cpp
+++ b/client/SDL/SDL3/sdl_monitor.cpp
@@ -207,7 +207,7 @@ static BOOL sdl_apply_display_properties(SdlContext* sdl)
 		float vdpi = dpi;
 		SDL_Rect rect = {};
 
-		if (SDL_GetDisplayBounds(*id, &rect) < 0)
+		if (!SDL_GetDisplayBounds(*id, &rect))
 			return FALSE;
 
 		WINPR_ASSERT(rect.w > 0);

--- a/winpr/include/winpr/platform.h
+++ b/winpr/include/winpr/platform.h
@@ -22,6 +22,15 @@
 
 #include <stdlib.h>
 
+#define WINPR_DO_PRAGMA(x) _Pragma(#x)
+#if defined(__GNUC__)
+#define WINPR_PRAGMA_WARNING(msg) WINPR_DO_PRAGMA(GCC warning #msg)
+#elif defined(__clang__)
+#define WINPR_PRAGMA_WARNING(msg) WINPR_DO_PRAGMA(GCC warning #msg)
+#elif defined(_MSC_VER)
+#define WINPR_PRAGMA_WARNING(msg) WINPR_DO_PRAGMA(message \x28 #msg \x29)
+#endif
+
 #if defined(__clang__)
 #define WINPR_PRAGMA_DIAG_PUSH _Pragma("clang diagnostic push")
 #define WINPR_PRAGMA_DIAG_IGNORED_OVERLENGTH_STRINGS \


### PR DESCRIPTION
* some small fixes for sdl client
* new macro for `#warning` that also works with `MSVC`