### PR TITLE
[cmake] watch config files

### DIFF
--- a/cmake/CleaningConfigureFile.cmake
+++ b/cmake/CleaningConfigureFile.cmake
@@ -6,9 +6,17 @@
 
 function(cleaning_configure_file SRC DST)
 	configure_file(${SRC} ${DST} ${ARGN})
-        set_property(
-                DIRECTORY
-                APPEND
-                PROPERTY ADDITIONAL_CLEAN_FILES ${DST}
-        )
+	set_property(
+ 	        DIRECTORY
+ 	        APPEND
+ 	        PROPERTY ADDITIONAL_CLEAN_FILES
+	       	${DST}
+ 	)
+	set_property(
+		DIRECTORY
+	       	APPEND
+	       	PROPERTY CMAKE_CONFIGURE_DEPENDS
+		${SRC}
+	       	${DST}
+	)
 endfunction()


### PR DESCRIPTION
As we do add configure_file output to clean target cmake configure must be rerun. To trigger that add source and generated file to CMAKE_CONFIGURE_DEPENDS
