### PR TITLE
[winpr,stream] assert Stream_Write_(U)INT[8|16|32] ranges

### DIFF
--- a/libfreerdp/core/multitransport.c
+++ b/libfreerdp/core/multitransport.c
@@ -151,7 +151,11 @@ BOOL multitransport_client_send_response(rdpMultitransport* multi, UINT32 reqId,
 	}
 
 	Stream_Write_UINT32(s, reqId); /* requestId (4 bytes) */
-	Stream_Write_UINT32(s, hr);    /* HResult (4 bytes) */
+
+	/* [MS-RDPBCGR] 2.2.15.2 Client Initiate Multitransport Response PDU defines this as 4byte
+	 * UNSIGNED but https://learn.microsoft.com/en-us/windows/win32/learnwin32/error-codes-in-com
+	 * defines this as signed... assume the spec is (implicitly) assuming twos complement. */
+	Stream_Write_INT32(s, hr); /* HResult (4 bytes) */
 	return rdp_send_message_channel_pdu(multi->rdp, s, SEC_TRANSPORT_RSP);
 }
 

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -537,8 +537,25 @@ static INLINE BOOL update_read_coord(wStream* s, INT32* coord, BOOL delta)
 
 	return TRUE;
 }
-static INLINE BOOL update_write_coord(wStream* s, INT32 coord)
+
+#define update_write_coord(s, coord) \
+	update_write_coord_int((s), (coord), #coord, __FILE__, __func__, __LINE__)
+
+static INLINE BOOL update_write_coord_int(wStream* s, INT32 coord, const char* name,
+                                          const char* file, const char* fkt, size_t line)
 {
+	if ((coord < 0) || (coord > UINT16_MAX))
+	{
+		const DWORD level = WLOG_WARN;
+		wLog* log = WLog_Get(TAG);
+		if (WLog_IsLevelActive(log, level))
+		{
+			WLog_PrintMessage(log, WLOG_MESSAGE_TEXT, level, line, file, fkt,
+			                  "[%s] 0 <= %" PRId32 " <= %" PRIu16, name, coord, UINT16_MAX);
+		}
+		return FALSE;
+	}
+
 	Stream_Write_UINT16(s, coord);
 	return TRUE;
 }
@@ -1255,13 +1272,17 @@ BOOL update_write_dstblt_order(wStream* s, ORDER_INFO* orderInfo, const DSTBLT_O
 
 	orderInfo->fieldFlags = 0;
 	orderInfo->fieldFlags |= ORDER_FIELD_01;
-	update_write_coord(s, dstblt->nLeftRect);
+	if (!update_write_coord(s, dstblt->nLeftRect))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_02;
-	update_write_coord(s, dstblt->nTopRect);
+	if (!update_write_coord(s, dstblt->nTopRect))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_03;
-	update_write_coord(s, dstblt->nWidth);
+	if (!update_write_coord(s, dstblt->nWidth))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_04;
-	update_write_coord(s, dstblt->nHeight);
+	if (!update_write_coord(s, dstblt->nHeight))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_05;
 	Stream_Write_UINT8(s, dstblt->bRop);
 	return TRUE;
@@ -1296,13 +1317,17 @@ BOOL update_write_patblt_order(wStream* s, ORDER_INFO* orderInfo, PATBLT_ORDER* 
 
 	orderInfo->fieldFlags = 0;
 	orderInfo->fieldFlags |= ORDER_FIELD_01;
-	update_write_coord(s, patblt->nLeftRect);
+	if (!update_write_coord(s, patblt->nLeftRect))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_02;
-	update_write_coord(s, patblt->nTopRect);
+	if (!update_write_coord(s, patblt->nTopRect))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_03;
-	update_write_coord(s, patblt->nWidth);
+	if (!update_write_coord(s, patblt->nWidth))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_04;
-	update_write_coord(s, patblt->nHeight);
+	if (!update_write_coord(s, patblt->nHeight))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_05;
 	Stream_Write_UINT8(s, patblt->bRop);
 	orderInfo->fieldFlags |= ORDER_FIELD_06;
@@ -1346,19 +1371,25 @@ BOOL update_write_scrblt_order(wStream* s, ORDER_INFO* orderInfo, const SCRBLT_O
 
 	orderInfo->fieldFlags = 0;
 	orderInfo->fieldFlags |= ORDER_FIELD_01;
-	update_write_coord(s, scrblt->nLeftRect);
+	if (!update_write_coord(s, scrblt->nLeftRect))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_02;
-	update_write_coord(s, scrblt->nTopRect);
+	if (!update_write_coord(s, scrblt->nTopRect))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_03;
-	update_write_coord(s, scrblt->nWidth);
+	if (!update_write_coord(s, scrblt->nWidth))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_04;
-	update_write_coord(s, scrblt->nHeight);
+	if (!update_write_coord(s, scrblt->nHeight))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_05;
 	Stream_Write_UINT8(s, scrblt->bRop);
 	orderInfo->fieldFlags |= ORDER_FIELD_06;
-	update_write_coord(s, scrblt->nXSrc);
+	if (!update_write_coord(s, scrblt->nXSrc))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_07;
-	update_write_coord(s, scrblt->nYSrc);
+	if (!update_write_coord(s, scrblt->nYSrc))
+		return FALSE;
 	return TRUE;
 }
 static BOOL update_read_opaque_rect_order(const char* orderName, wStream* s,
@@ -1422,13 +1453,17 @@ BOOL update_write_opaque_rect_order(wStream* s, ORDER_INFO* orderInfo,
 	// TODO: Color format conversion
 	orderInfo->fieldFlags = 0;
 	orderInfo->fieldFlags |= ORDER_FIELD_01;
-	update_write_coord(s, opaque_rect->nLeftRect);
+	if (!update_write_coord(s, opaque_rect->nLeftRect))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_02;
-	update_write_coord(s, opaque_rect->nTopRect);
+	if (!update_write_coord(s, opaque_rect->nTopRect))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_03;
-	update_write_coord(s, opaque_rect->nWidth);
+	if (!update_write_coord(s, opaque_rect->nWidth))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_04;
-	update_write_coord(s, opaque_rect->nHeight);
+	if (!update_write_coord(s, opaque_rect->nHeight))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_05;
 	byte = opaque_rect->color & 0x000000FF;
 	Stream_Write_UINT8(s, byte);
@@ -1702,13 +1737,17 @@ BOOL update_write_line_to_order(wStream* s, ORDER_INFO* orderInfo, const LINE_TO
 	orderInfo->fieldFlags |= ORDER_FIELD_01;
 	Stream_Write_UINT16(s, line_to->backMode);
 	orderInfo->fieldFlags |= ORDER_FIELD_02;
-	update_write_coord(s, line_to->nXStart);
+	if (!update_write_coord(s, line_to->nXStart))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_03;
-	update_write_coord(s, line_to->nYStart);
+	if (!update_write_coord(s, line_to->nYStart))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_04;
-	update_write_coord(s, line_to->nXEnd);
+	if (!update_write_coord(s, line_to->nXEnd))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_05;
-	update_write_coord(s, line_to->nYEnd);
+	if (!update_write_coord(s, line_to->nYEnd))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_06;
 	update_write_color(s, line_to->backColor);
 	orderInfo->fieldFlags |= ORDER_FIELD_07;
@@ -1800,19 +1839,25 @@ BOOL update_write_memblt_order(wStream* s, ORDER_INFO* orderInfo, const MEMBLT_O
 	orderInfo->fieldFlags |= ORDER_FIELD_01;
 	Stream_Write_UINT16(s, cacheId);
 	orderInfo->fieldFlags |= ORDER_FIELD_02;
-	update_write_coord(s, memblt->nLeftRect);
+	if (!update_write_coord(s, memblt->nLeftRect))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_03;
-	update_write_coord(s, memblt->nTopRect);
+	if (!update_write_coord(s, memblt->nTopRect))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_04;
-	update_write_coord(s, memblt->nWidth);
+	if (!update_write_coord(s, memblt->nWidth))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_05;
-	update_write_coord(s, memblt->nHeight);
+	if (!update_write_coord(s, memblt->nHeight))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_06;
 	Stream_Write_UINT8(s, memblt->bRop);
 	orderInfo->fieldFlags |= ORDER_FIELD_07;
-	update_write_coord(s, memblt->nXSrc);
+	if (!update_write_coord(s, memblt->nXSrc))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_08;
-	update_write_coord(s, memblt->nYSrc);
+	if (!update_write_coord(s, memblt->nYSrc))
+		return FALSE;
 	orderInfo->fieldFlags |= ORDER_FIELD_09;
 	Stream_Write_UINT16(s, memblt->cacheIndex);
 	return TRUE;

--- a/libfreerdp/core/timezone.c
+++ b/libfreerdp/core/timezone.c
@@ -226,10 +226,8 @@ BOOL rdp_read_client_time_zone(wStream* s, rdpSettings* settings)
 
 BOOL rdp_write_client_time_zone(wStream* s, rdpSettings* settings)
 {
-	LPTIME_ZONE_INFORMATION tz = { 0 };
-
 	WINPR_ASSERT(settings);
-	tz = settings->ClientTimeZone;
+	const LPTIME_ZONE_INFORMATION tz = settings->ClientTimeZone;
 
 	if (!tz)
 		return FALSE;
@@ -238,8 +236,12 @@ BOOL rdp_write_client_time_zone(wStream* s, rdpSettings* settings)
 	if (!Stream_EnsureRemainingCapacity(s, 4ull + sizeof(tz->StandardName)))
 		return FALSE;
 
-	/* Bias */
-	Stream_Write_UINT32(s, tz->Bias);
+	/* Bias defined in windows headers as LONG
+	 * but [MS-RDPBCGR] 2.2.1.11.1.1.1.1 Time Zone Information (TS_TIME_ZONE_INFORMATION) defines it
+	 * as unsigned.... assume the spec is buggy as an unsigned value only works on half of the
+	 * world.
+	 */
+	Stream_Write_INT32(s, tz->Bias);
 	/* standardName (64 bytes) */
 	Stream_Write(s, tz->StandardName, sizeof(tz->StandardName));
 	/* StandardDate */
@@ -250,7 +252,13 @@ BOOL rdp_write_client_time_zone(wStream* s, rdpSettings* settings)
 	/* StandardBias */
 	if (!Stream_EnsureRemainingCapacity(s, 4ull + sizeof(tz->DaylightName)))
 		return FALSE;
-	Stream_Write_UINT32(s, tz->StandardBias);
+
+	/* StandardBias defined in windows headers as LONG
+	 * but [MS-RDPBCGR] 2.2.1.11.1.1.1.1 Time Zone Information (TS_TIME_ZONE_INFORMATION) defines it
+	 * as unsigned.... assume the spec is buggy as an unsigned value only works on half of the
+	 * world.
+	 */
+	Stream_Write_INT32(s, tz->StandardBias);
 
 	/* daylightName (64 bytes) */
 	Stream_Write(s, tz->DaylightName, sizeof(tz->DaylightName));
@@ -261,7 +269,13 @@ BOOL rdp_write_client_time_zone(wStream* s, rdpSettings* settings)
 	/* DaylightBias */
 	if (!Stream_EnsureRemainingCapacity(s, 4ull))
 		return FALSE;
-	Stream_Write_UINT32(s, tz->DaylightBias);
+
+	/* DaylightBias defined in windows headers as LONG
+	 * but [MS-RDPBCGR] 2.2.1.11.1.1.1.1 Time Zone Information (TS_TIME_ZONE_INFORMATION) defines it
+	 * as unsigned.... assume the spec is buggy as an unsigned value only works on half of the
+	 * world.
+	 */
+	Stream_Write_INT32(s, tz->DaylightBias);
 
 	return TRUE;
 }

--- a/libfreerdp/crypto/per.c
+++ b/libfreerdp/crypto/per.c
@@ -333,6 +333,8 @@ BOOL per_read_integer16(wStream* s, UINT16* integer, UINT16 min)
 
 BOOL per_write_integer16(wStream* s, UINT16 integer, UINT16 min)
 {
+	if (min > integer)
+		return FALSE;
 	if (!Stream_EnsureRemainingCapacity(s, 2))
 		return FALSE;
 	Stream_Write_UINT16_BE(s, integer - min);

--- a/winpr/include/winpr/assert.h
+++ b/winpr/include/winpr/assert.h
@@ -39,6 +39,7 @@ extern "C"
 	{                                                                \
 		WINPR_PRAGMA_DIAG_PUSH                                       \
 		WINPR_PRAGMA_DIAG_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE \
+		WINPR_PRAGMA_DIAG_TAUTOLOGICAL_VALUE_RANGE_COMPARE           \
 		if (!(cond))                                                 \
 			winpr_int_assert(#cond, __FILE__, __func__, __LINE__);   \
 		WINPR_PRAGMA_DIAG_POP                                        \
@@ -58,7 +59,15 @@ extern "C"
 #endif
 
 #else
-#define WINPR_ASSERT(cond) assert(cond)
+#define WINPR_ASSERT(cond)                                           \
+	do                                                               \
+	{                                                                \
+		WINPR_PRAGMA_DIAG_PUSH                                       \
+		WINPR_PRAGMA_DIAG_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE \
+		WINPR_PRAGMA_DIAG_TAUTOLOGICAL_VALUE_RANGE_COMPARE           \
+		assert(cond);                                                \
+		WINPR_PRAGMA_DIAG_POP                                        \
+	} while (0)
 #endif
 
 #ifdef __cplusplus

--- a/winpr/include/winpr/platform.h
+++ b/winpr/include/winpr/platform.h
@@ -87,6 +87,12 @@
 	                                                                                        version \
 	                                                                                        3.9.0   \
 	                                                                                      */
+#define WINPR_PRAGMA_DIAG_TAUTOLOGICAL_VALUE_RANGE_COMPARE                                      \
+	_Pragma(                                                                                    \
+	    "clang diagnostic ignored \"-Wtautological-value-range-compare\"") /** @since           \
+	                                                                                    version \
+	                                                                                    3.10.0  \
+	                                                                                  */
 #define WINPR_PRAGMA_DIAG_IGNORED_FORMAT_NONLITERAL \
 	_Pragma("clang diagnostic ignored \"-Wformat-nonliteral\"") /** @since version 3.9.0 */
 #define WINPR_PRAGMA_DIAG_IGNORED_MISMATCHED_DEALLOC /** @since version 3.3.0 */ /* not supported \
@@ -119,6 +125,8 @@
 	_Pragma("GCC diagnostic ignored \"-Wformat-security\"")
 #define WINPR_PRAGMA_DIAG_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE /* not supported
 	_Pragma("GCC diagnostic ignored \"-Wtautological-constant-out-of-range-compare\"") */ /** @since version 3.9.0 */
+#define WINPR_PRAGMA_DIAG_TAUTOLOGICAL_VALUE_RANGE_COMPARE /* not supported
+	_Pragma("GCC diagnostic ignored \"-Wtautological-value-range-compare\"") */ /** @since version 3.10.0 */
 #define WINPR_PRAGMA_DIAG_IGNORED_FORMAT_NONLITERAL \
 	_Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"") /** @since version 3.9.0 */
 #if __GNUC__ >= 11
@@ -144,6 +152,7 @@
 #define WINPR_PRAGMA_DIAG_IGNORED_UNUSED_CONST_VAR
 #define WINPR_PRAGMA_DIAG_IGNORED_FORMAT_SECURITY
 #define WINPR_PRAGMA_DIAG_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE /** @since version 3.9.0 */
+#define WINPR_PRAGMA_DIAG_TAUTOLOGICAL_VALUE_RANGE_COMPARE           /** @since version 3.10.0 */
 #define WINPR_PRAGMA_DIAG_IGNORED_FORMAT_NONLITERAL  /** @since version 3.9.0 */
 #define WINPR_PRAGMA_DIAG_IGNORED_MISMATCHED_DEALLOC /** @since version 3.3.0 */
 #define WINPR_PRAGMA_DIAG_POP

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -1020,20 +1020,17 @@ extern "C"
 		Stream_Rewind(_s, sizeof(UINT64));
 	}
 
-	static INLINE void Stream_Zero(wStream* _s, size_t _n)
-	{
-		WINPR_ASSERT(_s);
-		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= (_n));
-		memset(_s->pointer, '\0', (_n));
-		Stream_Seek(_s, _n);
-	}
-
 	static INLINE void Stream_Fill(wStream* _s, int _v, size_t _n)
 	{
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= (_n));
 		memset(_s->pointer, _v, (_n));
 		Stream_Seek(_s, _n);
+	}
+
+	static INLINE void Stream_Zero(wStream* _s, size_t _n)
+	{
+		Stream_Fill(_s, '\0', _n);
 	}
 
 	static INLINE void Stream_Copy(wStream* _src, wStream* _dst, size_t _n)

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -790,79 +790,168 @@ extern "C"
 		memcpy(_b, (_s->pointer), (_n));
 	}
 
-	static INLINE void Stream_Write_UINT8(wStream* _s, UINT8 _v)
+#define Stream_Write_INT8(s, v)               \
+	do                                        \
+	{                                         \
+		WINPR_ASSERT((v) <= INT8_MAX);        \
+		WINPR_ASSERT((v) >= INT8_MIN);        \
+		Stream_Write_INT8_unchecked((s), (v)) \
+	} while (0)
+
+	static INLINE void Stream_Write_INT8_unchecked(wStream* _s, INT8 _v)
 	{
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 1);
-		*_s->pointer++ = (_v);
+
+		*_s->pointer++ = WINPR_STREAM_CAST(BYTE, _v);
 	}
 
-	static INLINE void Stream_Write_INT16(wStream* _s, INT16 _v)
+#define Stream_Write_UINT8(s, v)                \
+	do                                          \
+	{                                           \
+		WINPR_ASSERT((v) <= UINT8_MAX);         \
+		WINPR_ASSERT((v) >= 0);                 \
+		Stream_Write_UINT8_unchecked((s), (v)); \
+	} while (0)
+
+	static INLINE void Stream_Write_UINT8_unchecked(wStream* _s, UINT8 _v)
+	{
+		WINPR_ASSERT(_s);
+		WINPR_ASSERT(_s->pointer);
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 1);
+
+		*_s->pointer++ = WINPR_STREAM_CAST(BYTE, _v);
+	}
+
+#define Stream_Write_INT16(s, v)                \
+	do                                          \
+	{                                           \
+		WINPR_ASSERT((v) >= INT16_MIN);         \
+		WINPR_ASSERT((v) <= INT16_MAX);         \
+		Stream_Write_INT16_unchecked((s), (v)); \
+	} while (0)
+
+	static INLINE void Stream_Write_INT16_unchecked(wStream* _s, INT16 _v)
 	{
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 2);
-		*_s->pointer++ = (_v)&0xFF;
+
+		*_s->pointer++ = (_v) & 0xFF;
 		*_s->pointer++ = ((_v) >> 8) & 0xFF;
 	}
 
-	static INLINE void Stream_Write_UINT16(wStream* _s, UINT16 _v)
+#define Stream_Write_UINT16(s, v)                \
+	do                                           \
+	{                                            \
+		WINPR_ASSERT((v) <= UINT16_MAX);         \
+		WINPR_ASSERT((v) >= 0);                  \
+		Stream_Write_UINT16_unchecked((s), (v)); \
+	} while (0)
+
+	static INLINE void Stream_Write_UINT16_unchecked(wStream* _s, UINT16 _v)
 	{
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 2);
-		*_s->pointer++ = (_v)&0xFF;
+
+		*_s->pointer++ = (_v) & 0xFF;
 		*_s->pointer++ = ((_v) >> 8) & 0xFF;
 	}
 
-	static INLINE void Stream_Write_UINT16_BE(wStream* _s, UINT16 _v)
+#define Stream_Write_UINT16_BE(s, v)                \
+	do                                              \
+	{                                               \
+		WINPR_ASSERT((v) <= UINT16_MAX);            \
+		WINPR_ASSERT((v) >= 0);                     \
+		Stream_Write_UINT16_BE_unchecked((s), (v)); \
+	} while (0)
+
+	static INLINE void Stream_Write_UINT16_BE_unchecked(wStream* _s, UINT16 _v)
 	{
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 2);
+
 		*_s->pointer++ = ((_v) >> 8) & 0xFF;
-		*_s->pointer++ = (_v)&0xFF;
+		*_s->pointer++ = (_v) & 0xFF;
 	}
 
-	static INLINE void Stream_Write_UINT24_BE(wStream* _s, UINT32 _v)
+#define Stream_Write_UINT24_BE(s, v)                \
+	do                                              \
+	{                                               \
+		WINPR_ASSERT((v) <= 0xFFFFFF);              \
+		WINPR_ASSERT((v) >= 0);                     \
+		Stream_Write_UINT24_BE_unchecked((s), (v)); \
+	} while (0)
+
+	static INLINE void Stream_Write_UINT24_BE_unchecked(wStream* _s, UINT32 _v)
 	{
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(_v <= 0x00FFFFFF);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 3);
+
 		*_s->pointer++ = ((_v) >> 16) & 0xFF;
 		*_s->pointer++ = ((_v) >> 8) & 0xFF;
-		*_s->pointer++ = (_v)&0xFF;
+		*_s->pointer++ = (_v) & 0xFF;
 	}
 
-	static INLINE void Stream_Write_INT32(wStream* _s, INT32 _v)
+#define Stream_Write_INT32(s, v)                \
+	do                                          \
+	{                                           \
+		WINPR_ASSERT((v) <= INT32_MAX);         \
+		WINPR_ASSERT((v) >= INT32_MIN);         \
+		Stream_Write_INT32_unchecked((s), (v)); \
+	} while (0)
+
+	static INLINE void Stream_Write_INT32_unchecked(wStream* _s, INT32 _v)
 	{
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 4);
-		*_s->pointer++ = (_v)&0xFF;
+
+		*_s->pointer++ = (_v) & 0xFF;
 		*_s->pointer++ = ((_v) >> 8) & 0xFF;
 		*_s->pointer++ = ((_v) >> 16) & 0xFF;
 		*_s->pointer++ = ((_v) >> 24) & 0xFF;
 	}
 
-	static INLINE void Stream_Write_UINT32(wStream* _s, UINT32 _v)
+#define Stream_Write_UINT32(s, v)                \
+	do                                           \
+	{                                            \
+		WINPR_ASSERT((v) <= UINT32_MAX);         \
+		WINPR_ASSERT((v) >= 0);                  \
+		Stream_Write_UINT32_unchecked((s), (v)); \
+	} while (0)
+
+	static INLINE void Stream_Write_UINT32_unchecked(wStream* _s, UINT32 _v)
 	{
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 4);
-		*_s->pointer++ = (_v)&0xFF;
+
+		*_s->pointer++ = (_v) & 0xFF;
 		*_s->pointer++ = ((_v) >> 8) & 0xFF;
 		*_s->pointer++ = ((_v) >> 16) & 0xFF;
 		*_s->pointer++ = ((_v) >> 24) & 0xFF;
 	}
 
-	static INLINE void Stream_Write_UINT32_BE(wStream* _s, UINT32 _v)
+#define Stream_Write_UINT32_BE(s, v)                \
+	do                                              \
+	{                                               \
+		WINPR_ASSERT((v) <= UINT32_MAX);            \
+		WINPR_ASSERT((v) >= 0);                     \
+		Stream_Write_UINT32_BE_unchecked((s), (v)); \
+	} while (0)
+
+	static INLINE void Stream_Write_UINT32_BE_unchecked(wStream* _s, UINT32 _v)
 	{
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 4);
+
 		Stream_Write_UINT16_BE(_s, ((_v) >> 16 & 0xFFFF));
-		Stream_Write_UINT16_BE(_s, ((_v)&0xFFFF));
+		Stream_Write_UINT16_BE(_s, ((_v) & 0xFFFF));
 	}
 
 	static INLINE void Stream_Write_UINT64(wStream* _s, UINT64 _v)
@@ -870,7 +959,8 @@ extern "C"
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 8);
-		Stream_Write_UINT32(_s, ((_v)&0xFFFFFFFFUL));
+
+		Stream_Write_UINT32(_s, ((_v) & 0xFFFFFFFFUL));
 		Stream_Write_UINT32(_s, ((_v) >> 16 & 0xFFFFFFFFUL));
 	}
 
@@ -879,8 +969,9 @@ extern "C"
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 8);
+
 		Stream_Write_UINT32_BE(_s, ((_v) >> 16 & 0xFFFFFFFFUL));
-		Stream_Write_UINT32_BE(_s, ((_v)&0xFFFFFFFFUL));
+		Stream_Write_UINT32_BE(_s, ((_v) & 0xFFFFFFFFUL));
 	}
 
 	static INLINE void Stream_Write(wStream* _s, const void* _b, size_t _n)

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -798,6 +798,13 @@ extern "C"
 		Stream_Write_INT8_unchecked((s), (v)) \
 	} while (0)
 
+	/** @brief writes a \b INT8 to a \b wStream. The stream must be large enough to hold the data.
+	 *
+	 * Do not use directly, use the define @ref Stream_Write_INT8 instead
+	 *
+	 * \param _s The stream to write to, must not be \b NULL
+	 * \param _v The value to write
+	 */
 	static INLINE void Stream_Write_INT8_unchecked(wStream* _s, INT8 _v)
 	{
 		WINPR_ASSERT(_s);
@@ -815,6 +822,13 @@ extern "C"
 		Stream_Write_UINT8_unchecked((s), (v)); \
 	} while (0)
 
+	/** @brief writes a \b UINT8 to a \b wStream. The stream must be large enough to hold the data.
+	 *
+	 * Do not use directly, use the define @ref Stream_Write_UINT8 instead
+	 *
+	 * \param _s The stream to write to, must not be \b NULL
+	 * \param _v The value to write
+	 */
 	static INLINE void Stream_Write_UINT8_unchecked(wStream* _s, UINT8 _v)
 	{
 		WINPR_ASSERT(_s);
@@ -832,6 +846,14 @@ extern "C"
 		Stream_Write_INT16_unchecked((s), (v)); \
 	} while (0)
 
+	/** @brief writes a \b INT16 as \b little endian to a \b wStream. The stream must be large
+	 * enough to hold the data.
+	 *
+	 * Do not use directly, use the define @ref Stream_Write_INT16 instead
+	 *
+	 * \param _s The stream to write to, must not be \b NULL
+	 * \param _v The value to write
+	 */
 	static INLINE void Stream_Write_INT16_unchecked(wStream* _s, INT16 _v)
 	{
 		WINPR_ASSERT(_s);
@@ -850,6 +872,14 @@ extern "C"
 		Stream_Write_UINT16_unchecked((s), (v)); \
 	} while (0)
 
+	/** @brief writes a \b UINT16 as \b little endian to a \b wStream. The stream must be large
+	 * enough to hold the data.
+	 *
+	 * Do not use directly, use the define @ref Stream_Write_UINT16 instead
+	 *
+	 * \param _s The stream to write to, must not be \b NULL
+	 * \param _v The value to write
+	 */
 	static INLINE void Stream_Write_UINT16_unchecked(wStream* _s, UINT16 _v)
 	{
 		WINPR_ASSERT(_s);
@@ -868,6 +898,14 @@ extern "C"
 		Stream_Write_UINT16_BE_unchecked((s), (v)); \
 	} while (0)
 
+	/** @brief writes a \b UINT16 as \b big endian to a \b wStream. The stream must be large enough
+	 * to hold the data.
+	 *
+	 * Do not use directly, use the define @ref Stream_Write_UINT16_BE instead
+	 *
+	 * \param _s The stream to write to, must not be \b NULL
+	 * \param _v The value to write
+	 */
 	static INLINE void Stream_Write_UINT16_BE_unchecked(wStream* _s, UINT16 _v)
 	{
 		WINPR_ASSERT(_s);
@@ -886,6 +924,14 @@ extern "C"
 		Stream_Write_UINT24_BE_unchecked((s), (v)); \
 	} while (0)
 
+	/** @brief writes a \b UINT24 as \b big endian to a \b wStream. The stream must be large enough
+	 * to hold the data.
+	 *
+	 * Do not use directly, use the define @ref Stream_Write_UINT24_BE instead
+	 *
+	 * \param _s The stream to write to, must not be \b NULL
+	 * \param _v The value to write
+	 */
 	static INLINE void Stream_Write_UINT24_BE_unchecked(wStream* _s, UINT32 _v)
 	{
 		WINPR_ASSERT(_s);
@@ -906,6 +952,14 @@ extern "C"
 		Stream_Write_INT32_unchecked((s), (v)); \
 	} while (0)
 
+	/** @brief writes a \b INT32 as \b little endian to a \b wStream. The stream must be large
+	 * enough to hold the data.
+	 *
+	 * Do not use directly, use the define @ref Stream_Write_INT32 instead
+	 *
+	 * \param _s The stream to write to, must not be \b NULL
+	 * \param _v The value to write
+	 */
 	static INLINE void Stream_Write_INT32_unchecked(wStream* _s, INT32 _v)
 	{
 		WINPR_ASSERT(_s);
@@ -926,6 +980,14 @@ extern "C"
 		Stream_Write_UINT32_unchecked((s), (v)); \
 	} while (0)
 
+	/** @brief writes a \b UINT32 as \b little endian to a \b wStream. The stream must be large
+	 * enough to hold the data.
+	 *
+	 * Do not use directly, use the define @ref Stream_Write_UINT32 instead
+	 *
+	 * \param _s The stream to write to, must not be \b NULL
+	 * \param _v The value to write
+	 */
 	static INLINE void Stream_Write_UINT32_unchecked(wStream* _s, UINT32 _v)
 	{
 		WINPR_ASSERT(_s);
@@ -946,6 +1008,14 @@ extern "C"
 		Stream_Write_UINT32_BE_unchecked((s), (v)); \
 	} while (0)
 
+	/** @brief writes a \b UINT32 as \b big endian to a \b wStream. The stream must be large enough
+	 * to hold the data.
+	 *
+	 * Do not use directly, use the define @ref Stream_Write_UINT32_BE instead
+	 *
+	 * \param _s The stream to write to, must not be \b NULL
+	 * \param _v The value to write
+	 */
 	static INLINE void Stream_Write_UINT32_BE_unchecked(wStream* _s, UINT32 _v)
 	{
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 4);
@@ -954,6 +1024,12 @@ extern "C"
 		Stream_Write_UINT16_BE(_s, ((_v) & 0xFFFF));
 	}
 
+	/** @brief writes a \b UINT64 as \b little endian to a \b wStream. The stream must be large
+	 * enough to hold the data.
+	 *
+	 * \param _s The stream to write to, must not be \b NULL
+	 * \param _v The value to write
+	 */
 	static INLINE void Stream_Write_UINT64(wStream* _s, UINT64 _v)
 	{
 		WINPR_ASSERT(_s);
@@ -964,6 +1040,12 @@ extern "C"
 		Stream_Write_UINT32(_s, ((_v) >> 16 & 0xFFFFFFFFUL));
 	}
 
+	/** @brief writes a \b UINT64 as \b big endian to a \b wStream. The stream must be large enough
+	 * to hold the data.
+	 *
+	 * \param _s The stream to write to, must not be \b NULL
+	 * \param _v The value to write
+	 */
 	static INLINE void Stream_Write_UINT64_BE(wStream* _s, UINT64 _v)
 	{
 		WINPR_ASSERT(_s);


### PR DESCRIPTION
* Split `Stream_Write_*` into a define that checks the input variable for range violations and an `Stream_Write_*_unchecked` `static inline` function that actually writes.
* The limits are asserted so invalid values can be found during runtime
