### PR TITLE
Window fake monitor

### DIFF
--- a/client/SDL/SDL2/sdl_monitor.cpp
+++ b/client/SDL/SDL2/sdl_monitor.cpp
@@ -189,6 +189,10 @@ static BOOL sdl_apply_display_properties(SdlContext* sdl)
 	rdpSettings* settings = sdl->context()->settings;
 	WINPR_ASSERT(settings);
 
+	if (!freerdp_settings_get_bool(settings, FreeRDP_Fullscreen) &&
+	    !freerdp_settings_get_bool(settings, FreeRDP_UseMultimon))
+		return TRUE;
+
 	const UINT32 numIds = freerdp_settings_get_uint32(settings, FreeRDP_NumMonitorIds);
 	if (!freerdp_settings_set_pointer_len(settings, FreeRDP_MonitorDefArray, nullptr, numIds))
 		return FALSE;

--- a/client/SDL/SDL3/sdl_monitor.cpp
+++ b/client/SDL/SDL3/sdl_monitor.cpp
@@ -189,6 +189,9 @@ static BOOL sdl_apply_display_properties(SdlContext* sdl)
 
 	rdpSettings* settings = sdl->context()->settings;
 	WINPR_ASSERT(settings);
+	if (!freerdp_settings_get_bool(settings, FreeRDP_Fullscreen) &&
+	    !freerdp_settings_get_bool(settings, FreeRDP_UseMultimon))
+		return TRUE;
 
 	const UINT32 numIds = freerdp_settings_get_uint32(settings, FreeRDP_NumMonitorIds);
 	if (!freerdp_settings_set_pointer_len(settings, FreeRDP_MonitorDefArray, nullptr, numIds))

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -727,7 +727,8 @@ static int freerdp_client_command_line_pre_filter(void* context, int index, int 
 	return 0;
 }
 
-BOOL freerdp_client_add_device_channel(rdpSettings* settings, size_t count, const char** params)
+BOOL freerdp_client_add_device_channel(rdpSettings* settings, size_t count,
+                                       const char* const* params)
 {
 	WINPR_ASSERT(settings);
 	WINPR_ASSERT(params);
@@ -858,7 +859,8 @@ BOOL freerdp_client_del_static_channel(rdpSettings* settings, const char* name)
 	return freerdp_static_channel_collection_del(settings, name);
 }
 
-BOOL freerdp_client_add_static_channel(rdpSettings* settings, size_t count, const char** params)
+BOOL freerdp_client_add_static_channel(rdpSettings* settings, size_t count,
+                                       const char* const* params)
 {
 	ADDIN_ARGV* _args = NULL;
 
@@ -887,7 +889,8 @@ BOOL freerdp_client_del_dynamic_channel(rdpSettings* settings, const char* name)
 	return freerdp_dynamic_channel_collection_del(settings, name);
 }
 
-BOOL freerdp_client_add_dynamic_channel(rdpSettings* settings, size_t count, const char** params)
+BOOL freerdp_client_add_dynamic_channel(rdpSettings* settings, size_t count,
+                                        const char* const* params)
 {
 	ADDIN_ARGV* _args = NULL;
 
@@ -1057,7 +1060,7 @@ static int freerdp_client_command_line_post_filter_int(void* context, COMMAND_LI
 	{
 		size_t count = 0;
 		char** ptr = CommandLineParseCommaSeparatedValues(arg->Value, &count);
-		if (!freerdp_client_add_static_channel(settings, count, ptr))
+		if (!freerdp_client_add_static_channel(settings, count, (const char* const*)ptr))
 			status = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 		CommandLineParserFree(ptr);
 		if (status)
@@ -1067,7 +1070,7 @@ static int freerdp_client_command_line_post_filter_int(void* context, COMMAND_LI
 	{
 		size_t count = 0;
 		char** ptr = CommandLineParseCommaSeparatedValues(arg->Value, &count);
-		if (!freerdp_client_add_dynamic_channel(settings, count, ptr))
+		if (!freerdp_client_add_dynamic_channel(settings, count, (const char* const*)ptr))
 			status = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 		CommandLineParserFree(ptr);
 		if (status)
@@ -1077,7 +1080,7 @@ static int freerdp_client_command_line_post_filter_int(void* context, COMMAND_LI
 	{
 		size_t count = 0;
 		char** ptr = CommandLineParseCommaSeparatedValuesEx(arg->Name, arg->Value, &count);
-		if (!freerdp_client_add_device_channel(settings, count, ptr))
+		if (!freerdp_client_add_device_channel(settings, count, (const char* const*)ptr))
 			status = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 		CommandLineParserFree(ptr);
 		if (status)
@@ -1088,7 +1091,7 @@ static int freerdp_client_command_line_post_filter_int(void* context, COMMAND_LI
 	{
 		size_t count = 0;
 		char** ptr = CommandLineParseCommaSeparatedValuesEx(arg->Name, arg->Value, &count);
-		if (!freerdp_client_add_device_channel(settings, count, ptr))
+		if (!freerdp_client_add_device_channel(settings, count, (const char* const*)ptr))
 			status = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 		CommandLineParserFree(ptr);
 		if (status)
@@ -1100,7 +1103,7 @@ static int freerdp_client_command_line_post_filter_int(void* context, COMMAND_LI
 	{
 		size_t count = 0;
 		char** ptr = CommandLineParseCommaSeparatedValuesEx(arg->Name, arg->Value, &count);
-		if (!freerdp_client_add_device_channel(settings, count, ptr))
+		if (!freerdp_client_add_device_channel(settings, count, (const char* const*)ptr))
 			status = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 		CommandLineParserFree(ptr);
 		if (status)
@@ -1111,7 +1114,7 @@ static int freerdp_client_command_line_post_filter_int(void* context, COMMAND_LI
 	{
 		size_t count = 0;
 		char** ptr = CommandLineParseCommaSeparatedValuesEx(arg->Name, arg->Value, &count);
-		if (!freerdp_client_add_device_channel(settings, count, ptr))
+		if (!freerdp_client_add_device_channel(settings, count, (const char* const*)ptr))
 			status = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 		CommandLineParserFree(ptr);
 		if (status)
@@ -1121,7 +1124,7 @@ static int freerdp_client_command_line_post_filter_int(void* context, COMMAND_LI
 	{
 		size_t count = 0;
 		char** ptr = CommandLineParseCommaSeparatedValuesEx(arg->Name, arg->Value, &count);
-		if (!freerdp_client_add_device_channel(settings, count, ptr))
+		if (!freerdp_client_add_device_channel(settings, count, (const char* const*)ptr))
 			status = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 		CommandLineParserFree(ptr);
 		if (status)
@@ -1132,7 +1135,7 @@ static int freerdp_client_command_line_post_filter_int(void* context, COMMAND_LI
 		size_t count = 0;
 		char** ptr =
 		    CommandLineParseCommaSeparatedValuesEx(URBDRC_CHANNEL_NAME, arg->Value, &count);
-		if (!freerdp_client_add_dynamic_channel(settings, count, ptr))
+		if (!freerdp_client_add_dynamic_channel(settings, count, (const char* const*)ptr))
 			status = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 		CommandLineParserFree(ptr);
 		if (status)
@@ -1181,9 +1184,9 @@ static int freerdp_client_command_line_post_filter_int(void* context, COMMAND_LI
 		size_t count = 0;
 		char** ptr =
 		    CommandLineParseCommaSeparatedValuesEx(RDPSND_CHANNEL_NAME, arg->Value, &count);
-		if (!freerdp_client_add_static_channel(settings, count, ptr))
+		if (!freerdp_client_add_static_channel(settings, count, (const char* const*)ptr))
 			status = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
-		if (!freerdp_client_add_dynamic_channel(settings, count, ptr))
+		if (!freerdp_client_add_dynamic_channel(settings, count, (const char* const*)ptr))
 			status = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 
 		CommandLineParserFree(ptr);
@@ -1194,7 +1197,7 @@ static int freerdp_client_command_line_post_filter_int(void* context, COMMAND_LI
 	{
 		size_t count = 0;
 		char** ptr = CommandLineParseCommaSeparatedValuesEx(AUDIN_CHANNEL_NAME, arg->Value, &count);
-		if (!freerdp_client_add_dynamic_channel(settings, count, ptr))
+		if (!freerdp_client_add_dynamic_channel(settings, count, (const char* const*)ptr))
 			status = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 		CommandLineParserFree(ptr);
 		if (status)

--- a/include/freerdp/client/cmdline.h
+++ b/include/freerdp/client/cmdline.h
@@ -104,12 +104,12 @@ extern "C"
 	FREERDP_API BOOL freerdp_set_connection_type(rdpSettings* settings, UINT32 type);
 
 	FREERDP_API BOOL freerdp_client_add_device_channel(rdpSettings* settings, size_t count,
-	                                                   const char** params);
+	                                                   const char* const* params);
 	FREERDP_API BOOL freerdp_client_add_static_channel(rdpSettings* settings, size_t count,
-	                                                   const char** params);
+	                                                   const char* const* params);
 	FREERDP_API BOOL freerdp_client_del_static_channel(rdpSettings* settings, const char* name);
 	FREERDP_API BOOL freerdp_client_add_dynamic_channel(rdpSettings* settings, size_t count,
-	                                                    const char** params);
+	                                                    const char* const* params);
 	FREERDP_API BOOL freerdp_client_del_dynamic_channel(rdpSettings* settings, const char* name);
 
 #ifdef __cplusplus

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -153,7 +153,7 @@ extern "C"
 	FREERDP_API void freerdp_addin_argv_free(ADDIN_ARGV* args);
 
 	WINPR_ATTR_MALLOC(freerdp_addin_argv_free, 1)
-	FREERDP_API ADDIN_ARGV* freerdp_addin_argv_new(size_t argc, const char* argv[]);
+	FREERDP_API ADDIN_ARGV* freerdp_addin_argv_new(size_t argc, const char* const argv[]);
 
 	WINPR_ATTR_MALLOC(freerdp_addin_argv_free, 1)
 	FREERDP_API ADDIN_ARGV* freerdp_addin_argv_clone(const ADDIN_ARGV* args);
@@ -193,7 +193,8 @@ extern "C"
 	FREERDP_API void freerdp_device_free(RDPDR_DEVICE* device);
 
 	WINPR_ATTR_MALLOC(freerdp_device_free, 1)
-	FREERDP_API RDPDR_DEVICE* freerdp_device_new(UINT32 Type, size_t count, const char* args[]);
+	FREERDP_API RDPDR_DEVICE* freerdp_device_new(UINT32 Type, size_t count,
+	                                             const char* const args[]);
 
 	WINPR_ATTR_MALLOC(freerdp_device_free, 1)
 	FREERDP_API RDPDR_DEVICE* freerdp_device_clone(const RDPDR_DEVICE* device);

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -300,7 +300,7 @@ RDPDR_DEVICE* freerdp_device_collection_find_type(rdpSettings* settings, UINT32 
 	return NULL;
 }
 
-RDPDR_DEVICE* freerdp_device_new(UINT32 Type, size_t count, const char* args[])
+RDPDR_DEVICE* freerdp_device_new(UINT32 Type, size_t count, const char* const args[])
 {
 	size_t size = 0;
 	union
@@ -779,7 +779,7 @@ void freerdp_addin_argv_free(ADDIN_ARGV* args)
 	free(args);
 }
 
-ADDIN_ARGV* freerdp_addin_argv_new(size_t argc, const char* argv[])
+ADDIN_ARGV* freerdp_addin_argv_new(size_t argc, const char* const argv[])
 {
 	if (argc > INT32_MAX)
 		return NULL;

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -120,6 +120,9 @@ static int freerdp_connect_begin(freerdp* instance)
 
 	freerdp_settings_print_warnings(settings);
 	if (status)
+		status = freerdp_settings_enforce_monitor_exists(settings);
+
+	if (status)
 		status = freerdp_settings_check_client_after_preconnect(settings);
 
 	if (status)

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -1680,8 +1680,9 @@ BOOL freerdp_settings_enforce_monitor_exists(rdpSettings* settings)
 {
 	const UINT32 nrIds = freerdp_settings_get_uint32(settings, FreeRDP_NumMonitorIds);
 	const UINT32 count = freerdp_settings_get_uint32(settings, FreeRDP_MonitorCount);
-	const BOOL useMonitors = freerdp_settings_get_bool(settings, FreeRDP_Fullscreen) ||
-	                         freerdp_settings_get_bool(settings, FreeRDP_UseMultimon);
+	const BOOL fullscreen = freerdp_settings_get_bool(settings, FreeRDP_Fullscreen);
+	const BOOL multimon = freerdp_settings_get_bool(settings, FreeRDP_UseMultimon);
+	const BOOL useMonitors = fullscreen || multimon;
 
 	if (nrIds == 0)
 	{
@@ -1721,6 +1722,19 @@ BOOL freerdp_settings_enforce_monitor_exists(rdpSettings* settings)
 		monitor->attributes.orientation = orientation;
 		monitor->attributes.desktopScaleFactor = desktopScaleFactor;
 		monitor->attributes.deviceScaleFactor = deviceScaleFactor;
+	}
+	else if (fullscreen || (multimon && (count == 1)))
+	{
+
+		/* not all platforms start primary monitor at 0/0, so enforce this to avoid issues with
+		 * fullscreen mode */
+		rdpMonitor* monitor =
+		    freerdp_settings_get_pointer_array_writable(settings, FreeRDP_MonitorDefArray, 0);
+		if (!monitor)
+			return FALSE;
+		monitor->x = 0;
+		monitor->y = 0;
+		monitor->is_primary = TRUE;
 	}
 
 	return TRUE;

--- a/libfreerdp/core/settings.h
+++ b/libfreerdp/core/settings.h
@@ -35,6 +35,7 @@
 
 #include <string.h>
 
+FREERDP_LOCAL BOOL freerdp_settings_enforce_monitor_exists(rdpSettings* settings);
 FREERDP_LOCAL void freerdp_settings_print_warnings(const rdpSettings* settings);
 FREERDP_LOCAL BOOL freerdp_settings_check_client_after_preconnect(const rdpSettings* settings);
 FREERDP_LOCAL BOOL freerdp_settings_set_default_order_support(rdpSettings* settings);


### PR DESCRIPTION
Enforce monitor layout requirements for windowed mode and fullscreen mode before checking the layouts meet multimonitor requirements.

* This way we always send a valid monitor layout in single monitor / windowed mode (start at 0/0 and primary=TRUE)