### PR TITLE
[server,proxy] stricter argument parsing

### DIFF
--- a/server/proxy/cli/freerdp_proxy.c
+++ b/server/proxy/cli/freerdp_proxy.c
@@ -69,7 +69,7 @@ static void pf_server_register_signal_handlers(void)
 #endif
 }
 
-static WINPR_NORETURN(void usage(const char* app))
+static int usage(const char* app)
 {
 	printf("Usage:\n");
 	printf("%s -h                               Display this help text.\n", app);
@@ -79,20 +79,20 @@ static WINPR_NORETURN(void usage(const char* app))
 	printf("%s --dump-config <config ini file>  Create a template <config.ini>\n", app);
 	printf("%s -v                               Print out binary version.\n", app);
 	printf("%s --version                        Print out binary version.\n", app);
-	exit(0);
+	return 0;
 }
 
-static WINPR_NORETURN(void version(const char* app))
+static int version(const char* app)
 {
 	printf("%s version %s", app, freerdp_get_version_string());
-	exit(0);
+	return 0;
 }
 
-static WINPR_NORETURN(void buildconfig(const char* app))
+static int buildconfig(const char* app)
 {
 	printf("This is FreeRDP version %s (%s)\n", FREERDP_VERSION_FULL, FREERDP_GIT_REVISION);
 	printf("%s", freerdp_get_build_config());
-	exit(0);
+	return 0;
 }
 
 int main(int argc, char* argv[])
@@ -107,29 +107,55 @@ int main(int argc, char* argv[])
 	WLog_DBG(TAG, "\tBuild config: %s", freerdp_get_build_config());
 
 	if (argc < 2)
-		usage(argv[0]);
+	{
+		status = usage(argv[0]);
+		goto fail;
+	}
 
 	const char* arg = argv[1];
 
 	if (_stricmp(arg, "-h") == 0)
-		usage(argv[0]);
+	{
+		status = usage(argv[0]);
+		goto fail;
+	}
 	else if (_stricmp(arg, "--help") == 0)
-		usage(argv[0]);
+	{
+		status = usage(argv[0]);
+		goto fail;
+	}
 	else if (_stricmp(arg, "--buildconfig") == 0)
-		buildconfig(argv[0]);
+	{
+		status = buildconfig(argv[0]);
+		goto fail;
+	}
 	else if (_stricmp(arg, "--dump-config") == 0)
 	{
-		if (argc <= 2)
-			usage(argv[0]);
-		pf_server_config_dump(argv[2]);
-		status = 0;
+		if (argc != 3)
+		{
+			status = usage(argv[0]);
+			goto fail;
+		}
+		status = pf_server_config_dump(argv[2]) ? 0 : -1;
 		goto fail;
 	}
 	else if (_stricmp(arg, "-v") == 0)
-		version(argv[0]);
+	{
+		status = version(argv[0]);
+		goto fail;
+	}
 	else if (_stricmp(arg, "--version") == 0)
-		version(argv[0]);
+	{
+		status = version(argv[0]);
+		goto fail;
+	}
+
 	const char* config_path = argv[1];
+	if (argc != 2)
+	{
+		status = usage(argv[0]);
+		goto fail;
+	}
 
 	proxyConfig* config = pf_server_config_load_file(config_path);
 	if (!config)


### PR DESCRIPTION
* Check number of arguments is valid (don't allow additional ones)
* Replace exit() with normal return for helper functions