### PR TITLE
[rdg,websockets] Fix Http Negotiate for Websocket

### DIFF
--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -722,6 +722,7 @@ static BOOL rdg_recv_auth_token(wLog* log, rdpCredsspAuth* auth, HttpResponse* r
 	{
 		case HTTP_STATUS_DENIED:
 		case HTTP_STATUS_OK:
+		case HTTP_STATUS_SWITCH_PROTOCOLS:
 			break;
 		default:
 			http_response_log_error_status(log, WLOG_WARN, response);


### PR DESCRIPTION
When using negotiate in non direct NTLM mode the success response contains an aditional token for the authentication layer. Add HTTP_STATUS_SWITCH_PROTOCOLS to the list of valid HTTP status codes where to extract the last auth token
