### PR TITLE
[ci,assert] silence coverity on WINPR_ASSERT

### DIFF
--- a/winpr/include/winpr/assert.h
+++ b/winpr/include/winpr/assert.h
@@ -65,6 +65,7 @@ extern "C"
 		WINPR_PRAGMA_DIAG_PUSH                                       \
 		WINPR_PRAGMA_DIAG_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE \
 		WINPR_PRAGMA_DIAG_TAUTOLOGICAL_VALUE_RANGE_COMPARE           \
+		_Pragma("coverity compliance deviate \"NO_EFFECT:SUPPRESS\" \"WINPR_ASSERT\"") \
 		assert(cond);                                                \
 		WINPR_PRAGMA_DIAG_POP                                        \
 	} while (0)


### PR DESCRIPTION
silence covertiy NO_EFFECT with _Pragma when using WINPR_ASSERT. We´ve got a lot of situations where a check is mostly useless when functions are called correctly, but the check triggers on common errors. So silence this warning on our perfectly fine usage situations