### PR TITLE
[core,aad] fetch wellknown before GetAccessToken

### DIFF
--- a/client/SDL/common/aad/sdl_webview.cpp
+++ b/client/SDL/common/aad/sdl_webview.cpp
@@ -38,10 +38,11 @@ static BOOL sdl_webview_get_rdsaad_access_token(freerdp* instance, const char* s
 	WINPR_ASSERT(token);
 
 	WINPR_UNUSED(instance);
+	WINPR_UNUSED(instance->context);
 
-	std::string client_id = "5177bc73-fd99-4c77-a90c-76844c9b6999";
-	std::string redirect_uri =
-	    "ms-appx-web%3a%2f%2fMicrosoft.AAD.BrokerPlugin%2f5177bc73-fd99-4c77-a90c-76844c9b6999";
+	std::string client_id =
+	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdClientID);
+	std::string redirect_uri = "ms-appx-web%3a%2f%2fMicrosoft.AAD.BrokerPlugin%2f" + client_id;
 
 	*token = nullptr;
 
@@ -65,10 +66,12 @@ static BOOL sdl_webview_get_rdsaad_access_token(freerdp* instance, const char* s
 static BOOL sdl_webview_get_avd_access_token(freerdp* instance, char** token)
 {
 	WINPR_ASSERT(token);
+	WINPR_ASSERT(instance);
+	WINPR_ASSERT(instance->context);
 
-	std::string client_id = "a85cf173-4192-42f8-81fa-777a763e6e2c";
-	std::string redirect_uri =
-	    "ms-appx-web%3a%2f%2fMicrosoft.AAD.BrokerPlugin%2fa85cf173-4192-42f8-81fa-777a763e6e2c";
+	std::string client_id =
+	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdClientID);
+	std::string redirect_uri = "ms-appx-web%3a%2f%2fMicrosoft.AAD.BrokerPlugin%2f" + client_id;
 	std::string scope = "https%3A%2F%2Fwww.wvd.microsoft.com%2F.default";
 
 	*token = nullptr;

--- a/client/SDL/common/aad/sdl_webview.cpp
+++ b/client/SDL/common/aad/sdl_webview.cpp
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <winpr/string.h>
 #include <freerdp/log.h>
+#include <freerdp/utils/aad.h>
 
 #include "sdl_webview.hpp"
 #include "webview_impl.hpp"
@@ -44,9 +45,10 @@ static BOOL sdl_webview_get_rdsaad_access_token(freerdp* instance, const char* s
 
 	*token = nullptr;
 
-	auto url =
-	    "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=" + client_id +
-	    "&response_type=code&scope=" + scope + "&redirect_uri=" + redirect_uri;
+	std::string ep = freerdp_utils_aad_get_wellknown_string(instance->context,
+	                                                        AAD_WELLKNOWN_authorization_endpoint);
+	auto url = ep + "?client_id=" + client_id + "&response_type=code&scope=" + scope +
+	           "&redirect_uri=" + redirect_uri;
 
 	const std::string title = "FreeRDP WebView - AAD access token";
 	std::string code;
@@ -71,9 +73,10 @@ static BOOL sdl_webview_get_avd_access_token(freerdp* instance, char** token)
 
 	*token = nullptr;
 
-	auto url =
-	    "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=" + client_id +
-	    "&response_type=code&scope=" + scope + "&redirect_uri=" + redirect_uri;
+	std::string ep = freerdp_utils_aad_get_wellknown_string(instance->context,
+	                                                        AAD_WELLKNOWN_authorization_endpoint);
+	auto url = ep + "?client_id=" + client_id + "&response_type=code&scope=" + scope +
+	           "&redirect_uri=" + redirect_uri;
 	const std::string title = "FreeRDP WebView - AVD access token";
 	std::string code;
 	auto rc = webview_impl_run(title, url, code);

--- a/client/SDL/common/aad/sdl_webview.cpp
+++ b/client/SDL/common/aad/sdl_webview.cpp
@@ -40,7 +40,7 @@ static std::string from_settings(const rdpSettings* settings, FreeRDP_Settings_K
 	return val;
 }
 
-static std::string from_wellknown(rdpContext* context, AAD_WELLKNOWN_VALUES which)
+static std::string from_aad_wellknown(rdpContext* context, AAD_WELLKNOWN_VALUES which)
 {
 	auto val = freerdp_utils_aad_get_wellknown_string(context, which);
 
@@ -63,12 +63,12 @@ static BOOL sdl_webview_get_rdsaad_access_token(freerdp* instance, const char* s
 	WINPR_UNUSED(instance);
 	WINPR_UNUSED(instance->context);
 
-	std::string client_id = from_settings(instance->context->settings, FreeRDP_GatewayAvdClientID);
+	auto client_id = from_settings(instance->context->settings, FreeRDP_GatewayAvdClientID);
 	std::string redirect_uri = "ms-appx-web%3a%2f%2fMicrosoft.AAD.BrokerPlugin%2f" + client_id;
 
 	*token = nullptr;
 
-	std::string ep = from_wellknown(instance->context, AAD_WELLKNOWN_authorization_endpoint);
+	auto ep = from_aad_wellknown(instance->context, AAD_WELLKNOWN_authorization_endpoint);
 	auto url = ep + "?client_id=" + client_id + "&response_type=code&scope=" + scope +
 	           "&redirect_uri=" + redirect_uri;
 
@@ -90,13 +90,13 @@ static BOOL sdl_webview_get_avd_access_token(freerdp* instance, char** token)
 	WINPR_ASSERT(instance);
 	WINPR_ASSERT(instance->context);
 
-	std::string client_id = from_settings(instance->context->settings, FreeRDP_GatewayAvdClientID);
+	auto client_id = from_settings(instance->context->settings, FreeRDP_GatewayAvdClientID);
 	std::string redirect_uri = "ms-appx-web%3a%2f%2fMicrosoft.AAD.BrokerPlugin%2f" + client_id;
 	std::string scope = "https%3A%2F%2Fwww.wvd.microsoft.com%2F.default";
 
 	*token = nullptr;
 
-	std::string ep = from_wellknown(instance->context, AAD_WELLKNOWN_authorization_endpoint);
+	auto ep = from_aad_wellknown(instance->context, AAD_WELLKNOWN_authorization_endpoint);
 	auto url = ep + "?client_id=" + client_id + "&response_type=code&scope=" + scope +
 	           "&redirect_uri=" + redirect_uri;
 	const std::string title = "FreeRDP WebView - AVD access token";

--- a/client/SDL/common/aad/sdl_webview.cpp
+++ b/client/SDL/common/aad/sdl_webview.cpp
@@ -29,6 +29,29 @@
 
 #define TAG CLIENT_TAG("SDL.webview")
 
+static std::string from_settings(const rdpSettings* settings, FreeRDP_Settings_Keys_String id)
+{
+	auto val = freerdp_settings_get_string(settings, id);
+	if (!val)
+	{
+		WLog_WARN(TAG, "Settings key %s is NULL", freerdp_settings_get_name_for_key(id));
+		return "";
+	}
+	return val;
+}
+
+static std::string from_wellknown(rdpContext* context, AAD_WELLKNOWN_VALUES which)
+{
+	auto val = freerdp_utils_aad_get_wellknown_string(context, which);
+
+	if (!val)
+	{
+		WLog_WARN(TAG, "[wellknown] key %s is NULL", freerdp_utils_aad_wellknwon_value_name(which));
+		return "";
+	}
+	return val;
+}
+
 static BOOL sdl_webview_get_rdsaad_access_token(freerdp* instance, const char* scope,
                                                 const char* req_cnf, char** token)
 {
@@ -40,14 +63,12 @@ static BOOL sdl_webview_get_rdsaad_access_token(freerdp* instance, const char* s
 	WINPR_UNUSED(instance);
 	WINPR_UNUSED(instance->context);
 
-	std::string client_id =
-	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdClientID);
+	std::string client_id = from_settings(instance->context->settings, FreeRDP_GatewayAvdClientID);
 	std::string redirect_uri = "ms-appx-web%3a%2f%2fMicrosoft.AAD.BrokerPlugin%2f" + client_id;
 
 	*token = nullptr;
 
-	std::string ep = freerdp_utils_aad_get_wellknown_string(instance->context,
-	                                                        AAD_WELLKNOWN_authorization_endpoint);
+	std::string ep = from_wellknown(instance->context, AAD_WELLKNOWN_authorization_endpoint);
 	auto url = ep + "?client_id=" + client_id + "&response_type=code&scope=" + scope +
 	           "&redirect_uri=" + redirect_uri;
 
@@ -69,15 +90,13 @@ static BOOL sdl_webview_get_avd_access_token(freerdp* instance, char** token)
 	WINPR_ASSERT(instance);
 	WINPR_ASSERT(instance->context);
 
-	std::string client_id =
-	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdClientID);
+	std::string client_id = from_settings(instance->context->settings, FreeRDP_GatewayAvdClientID);
 	std::string redirect_uri = "ms-appx-web%3a%2f%2fMicrosoft.AAD.BrokerPlugin%2f" + client_id;
 	std::string scope = "https%3A%2F%2Fwww.wvd.microsoft.com%2F.default";
 
 	*token = nullptr;
 
-	std::string ep = freerdp_utils_aad_get_wellknown_string(instance->context,
-	                                                        AAD_WELLKNOWN_authorization_endpoint);
+	std::string ep = from_wellknown(instance->context, AAD_WELLKNOWN_authorization_endpoint);
 	auto url = ep + "?client_id=" + client_id + "&response_type=code&scope=" + scope +
 	           "&redirect_uri=" + redirect_uri;
 	const std::string title = "FreeRDP WebView - AVD access token";

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -1099,8 +1099,12 @@ static BOOL client_cli_get_avd_access_token(freerdp* instance, char** token)
 	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdClientID);
 	const char* base = freerdp_settings_get_string(instance->context->settings,
 	                                               FreeRDP_GatewayAzureActiveDirectory);
-	const char* tenantid =
-	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdAadtenantid);
+	const BOOL useTenant =
+	    freerdp_settings_get_bool(instance->context->settings, FreeRDP_GatewayAvdUseTenantid);
+	const char* tenantid = "common";
+	if (useTenant)
+		tenantid =
+		    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdAadtenantid);
 	if (!base || !tenantid || !client_id)
 		goto cleanup;
 

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -1039,11 +1039,7 @@ static BOOL client_cli_get_rdsaad_access_token(freerdp* instance, const char* sc
 
 	const char* client_id =
 	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdClientID);
-	const char* base =
-	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdArmpath);
-	const char* tenantid =
-	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdAadtenantid);
-	if (!base || !tenantid || !client_id)
+	if (!client_id)
 		goto cleanup;
 
 	winpr_asprintf(&redirect_uri, &redirec_uri_len,
@@ -1101,8 +1097,8 @@ static BOOL client_cli_get_avd_access_token(freerdp* instance, char** token)
 
 	const char* client_id =
 	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdClientID);
-	const char* base =
-	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdArmpath);
+	const char* base = freerdp_settings_get_string(instance->context->settings,
+	                                               FreeRDP_GatewayAzureActiveDirectory);
 	const char* tenantid =
 	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdAadtenantid);
 	if (!base || !tenantid || !client_id)

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -1017,6 +1017,7 @@ static char* extract_authorization_code(char* url)
 	return NULL;
 }
 
+#if defined(WITH_AAD)
 static BOOL client_cli_get_rdsaad_access_token(freerdp* instance, const char* scope,
                                                const char* req_cnf, char** token)
 {
@@ -1034,11 +1035,12 @@ static BOOL client_cli_get_rdsaad_access_token(freerdp* instance, const char* sc
 
 	*token = NULL;
 
-	printf("Browse to: https://login.microsoftonline.com/common/oauth2/v2.0/"
-	       "authorize?client_id=%s&response_type="
+	const char* ep = freerdp_utils_aad_get_wellknown_string(instance->context,
+	                                                        AAD_WELLKNOWN_authorization_endpoint);
+	printf("Browse to: %s?client_id=%s&response_type="
 	       "code&scope=%s&redirect_uri=%s"
 	       "\n",
-	       client_id, scope, redirect_uri);
+	       ep, client_id, scope, redirect_uri);
 	printf("Paste redirect URL here: \n");
 
 	if (freerdp_interruptible_get_line(instance->context, &url, &size, stdin) < 0)
@@ -1078,11 +1080,12 @@ static BOOL client_cli_get_avd_access_token(freerdp* instance, char** token)
 
 	*token = NULL;
 
-	printf("Browse to: https://login.microsoftonline.com/common/oauth2/v2.0/"
-	       "authorize?client_id=%s&response_type="
+	const char* ep = freerdp_utils_aad_get_wellknown_string(instance->context,
+	                                                        AAD_WELLKNOWN_authorization_endpoint);
+	printf("Browse to: %s?client_id=%s&response_type="
 	       "code&scope=%s&redirect_uri=%s"
 	       "\n",
-	       client_id, scope, redirect_uri);
+	       ep, client_id, scope, redirect_uri);
 	printf("Paste redirect URL here: \n");
 
 	if (freerdp_interruptible_get_line(instance->context, &url, &size, stdin) < 0)
@@ -1106,12 +1109,18 @@ cleanup:
 	free(url);
 	return rc && (*token != NULL);
 }
+#endif
 
 BOOL client_cli_get_access_token(freerdp* instance, AccessTokenType tokenType, char** token,
                                  size_t count, ...)
 {
 	WINPR_ASSERT(instance);
 	WINPR_ASSERT(token);
+
+#if !defined(WITH_AAD)
+	WLog_ERR(TAG, "Build does not support AAD authentication");
+	return FALSE;
+#else
 	switch (tokenType)
 	{
 		case ACCESS_TOKEN_TYPE_AAD:
@@ -1148,6 +1157,7 @@ BOOL client_cli_get_access_token(freerdp* instance, AccessTokenType tokenType, c
 			WLog_ERR(TAG, "Unexpected value for AccessTokenType [%" PRIuz "], aborting", tokenType);
 			return FALSE;
 	}
+#endif
 }
 
 BOOL client_common_get_access_token(freerdp* instance, const char* request, char** token)
@@ -1163,8 +1173,9 @@ BOOL client_common_get_access_token(freerdp* instance, const char* request, char
 
 	wLog* log = WLog_Get(TAG);
 
-	if (!freerdp_http_request("https://login.microsoftonline.com/common/oauth2/v2.0/token", request,
-	                          &resp_code, &response, &response_length))
+	const char* token_ep =
+	    freerdp_utils_aad_get_wellknown_string(instance->context, AAD_WELLKNOWN_token_endpoint);
+	if (!freerdp_http_request(token_ep, request, &resp_code, &response, &response_length))
 	{
 		WLog_ERR(TAG, "access token request failed");
 		return FALSE;

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -1021,19 +1021,35 @@ static char* extract_authorization_code(char* url)
 static BOOL client_cli_get_rdsaad_access_token(freerdp* instance, const char* scope,
                                                const char* req_cnf, char** token)
 {
+	WINPR_ASSERT(instance);
+	WINPR_ASSERT(instance->context);
+
 	size_t size = 0;
 	char* url = NULL;
 	char* token_request = NULL;
-	const char* client_id = "a85cf173-4192-42f8-81fa-777a763e6e2c";
-	const char* redirect_uri =
-	    "https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fnativeclient";
+	char* redirect_uri = NULL;
+	size_t redirec_uri_len = 0;
 
-	WINPR_ASSERT(instance);
 	WINPR_ASSERT(scope);
 	WINPR_ASSERT(req_cnf);
 	WINPR_ASSERT(token);
 
+	BOOL rc = FALSE;
 	*token = NULL;
+
+	const char* client_id =
+	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdClientID);
+	const char* base =
+	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdArmpath);
+	const char* tenantid =
+	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdAadtenantid);
+	if (!base || !tenantid || !client_id)
+		goto cleanup;
+
+	winpr_asprintf(&redirect_uri, &redirec_uri_len,
+	               "ms-appx-web%%3a%%2f%%2fMicrosoft.AAD.BrokerPlugin%%2f%s", client_id);
+	if (!redirect_uri)
+		goto cleanup;
 
 	const char* ep = freerdp_utils_aad_get_wellknown_string(instance->context,
 	                                                        AAD_WELLKNOWN_authorization_endpoint);
@@ -1046,7 +1062,6 @@ static BOOL client_cli_get_rdsaad_access_token(freerdp* instance, const char* sc
 	if (freerdp_interruptible_get_line(instance->context, &url, &size, stdin) < 0)
 		return FALSE;
 
-	BOOL rc = FALSE;
 	char* code = extract_authorization_code(url);
 	if (!code)
 		goto cleanup;
@@ -1060,6 +1075,7 @@ static BOOL client_cli_get_rdsaad_access_token(freerdp* instance, const char* sc
 	rc = client_common_get_access_token(instance, token_request, token);
 
 cleanup:
+	free(redirect_uri);
 	free(token_request);
 	free(url);
 	return rc && (*token != NULL);
@@ -1067,18 +1083,35 @@ cleanup:
 
 static BOOL client_cli_get_avd_access_token(freerdp* instance, char** token)
 {
+	WINPR_ASSERT(instance);
+	WINPR_ASSERT(instance->context);
+
 	size_t size = 0;
 	char* url = NULL;
 	char* token_request = NULL;
-	const char* client_id = "a85cf173-4192-42f8-81fa-777a763e6e2c";
-	const char* redirect_uri =
-	    "https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fnativeclient";
+	char* redirect_uri = NULL;
+	size_t redirec_uri_len = 0;
 	const char* scope = "https%3A%2F%2Fwww.wvd.microsoft.com%2F.default";
 
-	WINPR_ASSERT(instance);
 	WINPR_ASSERT(token);
 
+	BOOL rc = FALSE;
+
 	*token = NULL;
+
+	const char* client_id =
+	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdClientID);
+	const char* base =
+	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdArmpath);
+	const char* tenantid =
+	    freerdp_settings_get_string(instance->context->settings, FreeRDP_GatewayAvdAadtenantid);
+	if (!base || !tenantid || !client_id)
+		goto cleanup;
+
+	winpr_asprintf(&redirect_uri, &redirec_uri_len,
+	               "https%%3A%%2F%%2F%s%%2F%s%%2Foauth2%%2Fnativeclient", base, tenantid);
+	if (!redirect_uri)
+		goto cleanup;
 
 	const char* ep = freerdp_utils_aad_get_wellknown_string(instance->context,
 	                                                        AAD_WELLKNOWN_authorization_endpoint);
@@ -1089,9 +1122,8 @@ static BOOL client_cli_get_avd_access_token(freerdp* instance, char** token)
 	printf("Paste redirect URL here: \n");
 
 	if (freerdp_interruptible_get_line(instance->context, &url, &size, stdin) < 0)
-		return FALSE;
+		goto cleanup;
 
-	BOOL rc = FALSE;
 	char* code = extract_authorization_code(url);
 	if (!code)
 		goto cleanup;
@@ -1105,6 +1137,7 @@ static BOOL client_cli_get_avd_access_token(freerdp* instance, char** token)
 	rc = client_common_get_access_token(instance, token_request, token);
 
 cleanup:
+	free(redirect_uri);
 	free(token_request);
 	free(url);
 	return rc && (*token != NULL);

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3716,7 +3716,7 @@ static int parse_aad_options(rdpSettings* settings, const COMMAND_LINE_ARGUMENT_
 		};
 		const struct app_map amap[] = { { "tenantid:", FreeRDP_GatewayAvdAadtenantid,
 			                              parse_app_option_program },
-			                            { "base:", FreeRDP_GatewayAvdArmpath, NULL } };
+			                            { "ad:", FreeRDP_GatewayAzureActiveDirectory, NULL } };
 		for (size_t x = 0; x < count; x++)
 		{
 			BOOL handled = FALSE;
@@ -4614,7 +4614,7 @@ static int freerdp_client_settings_parse_command_line_arguments_int(
 				return fail_at(arg, COMMAND_LINE_ERROR_UNEXPECTED_VALUE);
 		}
 #endif
-		CommandLineSwitchCase(arg, "aad")
+		CommandLineSwitchCase(arg, "azure")
 		{
 			int rc = parse_aad_options(settings, arg);
 			if (rc != 0)

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3696,6 +3696,64 @@ static int parse_app_option_program(rdpSettings* settings, const char* cmd)
 	return CHANNEL_RC_OK;
 }
 
+static int parse_aad_options(rdpSettings* settings, const COMMAND_LINE_ARGUMENT_A* arg)
+{
+	WINPR_ASSERT(settings);
+	WINPR_ASSERT(arg);
+
+	int rc = CHANNEL_RC_OK;
+	size_t count = 0;
+	char** ptr = CommandLineParseCommaSeparatedValues(arg->Value, &count);
+	if (!ptr || (count == 0))
+		rc = COMMAND_LINE_ERROR;
+	else
+	{
+		struct app_map
+		{
+			const char* name;
+			SSIZE_T id;
+			int (*fkt)(rdpSettings* settings, const char* value);
+		};
+		const struct app_map amap[] = { { "tenantid:", FreeRDP_GatewayAvdAadtenantid,
+			                              parse_app_option_program },
+			                            { "base:", FreeRDP_GatewayAvdArmpath, NULL } };
+		for (size_t x = 0; x < count; x++)
+		{
+			BOOL handled = FALSE;
+			const char* val = ptr[x];
+
+			for (size_t y = 0; y < ARRAYSIZE(amap); y++)
+			{
+				const struct app_map* cur = &amap[y];
+				if (option_starts_with(cur->name, val))
+				{
+					const char* xval = &val[strlen(cur->name)];
+					if (cur->fkt)
+						rc = cur->fkt(settings, xval);
+					else
+					{
+						const char* name = freerdp_settings_get_name_for_key(cur->id);
+						if (!freerdp_settings_set_value_for_name(settings, name, xval))
+							rc = COMMAND_LINE_ERROR_MEMORY;
+					}
+
+					handled = TRUE;
+					break;
+				}
+			}
+
+			if (!handled)
+				rc = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
+
+			if (rc != 0)
+				break;
+		}
+	}
+
+	CommandLineParserFree(ptr);
+	return rc;
+}
+
 static int parse_app_options(rdpSettings* settings, const COMMAND_LINE_ARGUMENT_A* arg)
 {
 	WINPR_ASSERT(settings);
@@ -4556,6 +4614,12 @@ static int freerdp_client_settings_parse_command_line_arguments_int(
 				return fail_at(arg, COMMAND_LINE_ERROR_UNEXPECTED_VALUE);
 		}
 #endif
+		CommandLineSwitchCase(arg, "aad")
+		{
+			int rc = parse_aad_options(settings, arg);
+			if (rc != 0)
+				return fail_at(arg, rc);
+		}
 		CommandLineSwitchCase(arg, "app")
 		{
 			int rc = parse_app_options(settings, arg);

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3722,6 +3722,25 @@ static int parse_aad_options(rdpSettings* settings, const COMMAND_LINE_ARGUMENT_
 			BOOL handled = FALSE;
 			const char* val = ptr[x];
 
+			if (option_starts_with("use-tenantid", val))
+			{
+				PARSE_ON_OFF_RESULT bval = parse_on_off_option(val);
+				if (bval == PARSE_FAIL)
+				{
+					rc = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
+					break;
+				}
+				else
+				{
+					if (!freerdp_settings_set_bool(settings, FreeRDP_GatewayAvdUseTenantid,
+					                               bval != PARSE_OFF))
+					{
+						rc = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
+						break;
+					}
+				}
+				continue;
+			}
 			for (size_t y = 0; y < ARRAYSIZE(amap); y++)
 			{
 				const struct app_map* cur = &amap[y];

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -26,6 +26,8 @@
 
 static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	{ "a", COMMAND_LINE_VALUE_REQUIRED, "<addin>[,<options>]", NULL, NULL, -1, "addin", "Addin" },
+	{ "aad", COMMAND_LINE_VALUE_REQUIRED, "[tenantid:<id>],[base:<url>]", NULL, NULL, -1, NULL,
+	  "AAD options" },
 	{ "action-script", COMMAND_LINE_VALUE_REQUIRED, "<file-name>", "~/.config/freerdp/action.sh",
 	  NULL, -1, NULL, "Action script" },
 	{ "admin", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "console",

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -26,8 +26,8 @@
 
 static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	{ "a", COMMAND_LINE_VALUE_REQUIRED, "<addin>[,<options>]", NULL, NULL, -1, "addin", "Addin" },
-	{ "aad", COMMAND_LINE_VALUE_REQUIRED, "[tenantid:<id>],[base:<url>]", NULL, NULL, -1, NULL,
-	  "AAD options" },
+	{ "azure", COMMAND_LINE_VALUE_REQUIRED, "[tenantid:<id>],[ad:<url>]", NULL, NULL, -1, NULL,
+	  "AzureAD options" },
 	{ "action-script", COMMAND_LINE_VALUE_REQUIRED, "<file-name>", "~/.config/freerdp/action.sh",
 	  NULL, -1, NULL, "Action script" },
 	{ "admin", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "console",

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -26,8 +26,8 @@
 
 static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	{ "a", COMMAND_LINE_VALUE_REQUIRED, "<addin>[,<options>]", NULL, NULL, -1, "addin", "Addin" },
-	{ "azure", COMMAND_LINE_VALUE_REQUIRED, "[tenantid:<id>],[ad:<url>]", NULL, NULL, -1, NULL,
-	  "AzureAD options" },
+	{ "azure", COMMAND_LINE_VALUE_REQUIRED, "[tenantid:<id>],[use-tenantid[:[on|off]],[ad:<url>]",
+	  NULL, NULL, -1, NULL, "AzureAD options" },
 	{ "action-script", COMMAND_LINE_VALUE_REQUIRED, "<file-name>", "~/.config/freerdp/action.sh",
 	  NULL, -1, NULL, "Action script" },
 	{ "admin", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "console",

--- a/include/freerdp/settings_types_private.h
+++ b/include/freerdp/settings_types_private.h
@@ -482,7 +482,10 @@ struct rdp_settings
 	SETTINGS_DEPRECATED(ALIGN64 BOOL GatewayIgnoreRedirectionPolicy);  /** 2012
 		                                                                * @since version 3.4.0
 		                                                                */
-	UINT64 padding2015[2015 - 2013];                                   /* 2013 */
+	SETTINGS_DEPRECATED(ALIGN64 char* GatewayAvdClientID);             /** 2013
+		                                                                * @since version 3.10.0
+		                                                                */
+	UINT64 padding2015[2015 - 2014];                                   /* 2014 */
 
 	/* Proxy */
 	SETTINGS_DEPRECATED(ALIGN64 UINT32 ProxyType);    /* 2015 */

--- a/include/freerdp/settings_types_private.h
+++ b/include/freerdp/settings_types_private.h
@@ -485,7 +485,9 @@ struct rdp_settings
 	SETTINGS_DEPRECATED(ALIGN64 char* GatewayAvdClientID);             /** 2013
 		                                                                * @since version 3.10.0
 		                                                                */
-	UINT64 padding2015[2015 - 2014];                                   /* 2014 */
+	SETTINGS_DEPRECATED(ALIGN64 char* GatewayAzureActiveDirectory);    /** 2014
+		                                                                * @since version 3.10.0
+		                                                                */
 
 	/* Proxy */
 	SETTINGS_DEPRECATED(ALIGN64 UINT32 ProxyType);    /* 2015 */

--- a/include/freerdp/settings_types_private.h
+++ b/include/freerdp/settings_types_private.h
@@ -495,7 +495,10 @@ struct rdp_settings
 	SETTINGS_DEPRECATED(ALIGN64 UINT16 ProxyPort);    /* 2017 */
 	SETTINGS_DEPRECATED(ALIGN64 char* ProxyUsername); /* 2018 */
 	SETTINGS_DEPRECATED(ALIGN64 char* ProxyPassword); /* 2019 */
-	UINT64 padding2112[2112 - 2020];                  /* 2020 */
+	SETTINGS_DEPRECATED(ALIGN64 BOOL GatewayAvdUseTenantid); /** 2020
+		                                                      * @since version 3.10.0
+		                                                      */
+	UINT64 padding2112[2112 - 2021];                         /* 2021 */
 
 	/**
 	 * RemoteApp

--- a/include/freerdp/utils/aad.h
+++ b/include/freerdp/utils/aad.h
@@ -25,24 +25,115 @@
  *  \since version 3.0.0
  */
 #include <winpr/wlog.h>
+#include <winpr/json.h>
 
 #include <freerdp/api.h>
+#include <freerdp/types.h>
 #include <freerdp/config.h>
 
-#ifdef WITH_AAD
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
-/** Helper to retrieve the AAD access token from JSON input
- *
- *  @param data The JSON to parse
- *  @param length The number of bytes of the JSON data
- *
- *  @since version 3.0.0
- *
- * @return The token string or \b NULL
- */
-WINPR_ATTR_MALLOC(free, 1)
-FREERDP_API char* freerdp_utils_aad_get_access_token(wLog* log, const char* data, size_t length);
+	/** @enum Expected wellknown fields to be supported
+	 *  @since version 3.10.0
+	 */
+	typedef enum
+	{
+		AAD_WELLKNOWN_token_endpoint = 0,
+		AAD_WELLKNOWN_token_endpoint_auth_methods_supported,
+		AAD_WELLKNOWN_jwks_uri,
+		AAD_WELLKNOWN_response_modes_supported,
+		AAD_WELLKNOWN_subject_types_supported,
+		AAD_WELLKNOWN_id_token_signing_alg_values_supported,
+		AAD_WELLKNOWN_response_types_supported,
+		AAD_WELLKNOWN_scopes_supported,
+		AAD_WELLKNOWN_issuer,
+		AAD_WELLKNOWN_request_uri_parameter_supported,
+		AAD_WELLKNOWN_userinfo_endpoint,
+		AAD_WELLKNOWN_authorization_endpoint,
+		AAD_WELLKNOWN_device_authorization_endpoint,
+		AAD_WELLKNOWN_http_logout_supported,
+		AAD_WELLKNOWN_frontchannel_logout_supported,
+		AAD_WELLKNOWN_end_session_endpoint,
+		AAD_WELLKNOWN_claims_supported,
+		AAD_WELLKNOWN_kerberos_endpoint,
+		AAD_WELLKNOWN_tenant_region_scope,
+		AAD_WELLKNOWN_cloud_instance_name,
+		AAD_WELLKNOWN_cloud_graph_host_name,
+		AAD_WELLKNOWN_msgraph_host,
+		AAD_WELLKNOWN_rbac_url
+	} AAD_WELLKNOWN_VALUES;
 
+	/** Helper to retrieve the AAD access token from JSON input
+	 *
+	 *  @param data The JSON to parse
+	 *  @param length The number of bytes of the JSON data
+	 *
+	 *  @since version 3.0.0
+	 *
+	 * @return The token string or \b NULL
+	 */
+	WINPR_ATTR_MALLOC(free, 1)
+	FREERDP_API char* freerdp_utils_aad_get_access_token(wLog* log, const char* data,
+	                                                     size_t length);
+
+	/** Helper to stringify \ref AAD_WELLKNOWN_VALUES enum
+	 *
+	 *  @param which The enum value to stringify
+	 *
+	 *  @return The string representation of the enum value
+	 *  @since version 3.10.0
+	 */
+	FREERDP_API const char* freerdp_utils_aad_wellknwon_value_name(AAD_WELLKNOWN_VALUES which);
+
+	/** Helper to extract a string from AAD::wellknown JSON
+	 *
+	 * @param context The rdpContext to query for
+	 * @param which The enum value of the field to query
+	 *  @return A constant string to be used for queries or \b NULL in case it does not exist.
+	 *
+	 *  @since version 3.10.0
+	 */
+	FREERDP_API const char* freerdp_utils_aad_get_wellknown_string(rdpContext* context,
+	                                                               AAD_WELLKNOWN_VALUES which);
+
+	/** Helper to extract a string from AAD::wellknown JSON
+	 *
+	 * @param context The rdpContext to query for
+	 * @param which The raw string name of the field to query
+	 *  @return A constant string to be used for queries or \b NULL in case it does not exist.
+	 *
+	 *  @since version 3.10.0
+	 */
+	FREERDP_API const char* freerdp_utils_aad_get_wellknown_custom_string(rdpContext* context,
+	                                                                      const char* which);
+
+	/** Helper to extract a \b WINPR_JSON object from AAD::wellknown JSON
+	 *
+	 * @param context The rdpContext to query for
+	 * @param which The enum value of the field to query
+	 *  @return A \b WINPR_JSON object to be used for queries or \b NULL in case it does not exist.
+	 *
+	 *  @since version 3.10.0
+	 */
+	FREERDP_API WINPR_JSON* freerdp_utils_aad_get_wellknown_object(rdpContext* context,
+	                                                               AAD_WELLKNOWN_VALUES which);
+
+	/** Helper to extract a \b WINPR_JSON object from AAD::wellknown JSON
+	 *
+	 * @param context The rdpContext to query for
+	 * @param which The raw string name of the field to query
+	 *  @return A \b WINPR_JSON object to be used for queries or \b NULL in case it does not exist.
+	 *
+	 *  @since version 3.10.0
+	 */
+	FREERDP_API WINPR_JSON* freerdp_utils_aad_get_wellknown_custom_object(rdpContext* context,
+	                                                                      const char* which);
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* FREERDP_UTILS_AAD_H */

--- a/include/freerdp/utils/aad.h
+++ b/include/freerdp/utils/aad.h
@@ -132,6 +132,17 @@ extern "C"
 	FREERDP_API WINPR_JSON* freerdp_utils_aad_get_wellknown_custom_object(rdpContext* context,
 	                                                                      const char* which);
 
+	/** Helper to fetch a \b WINPR_JSON object from AAD/ARM::wellknown JSON
+	 *
+	 * @param context The rdpContext to query for
+	 * @param which The raw string name of the field to query
+	 *  @return A \b WINPR_JSON object to be used for queries or \b NULL in case it does not exist.
+	 *
+	 *  @since version 3.10.0
+	 */
+	WINPR_ATTR_MALLOC(WINPR_JSON_Delete, 1)
+	WINPR_JSON* freerdp_utils_aad_get_wellknown(wLog* log, const char* base, const char* tenantid);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -2772,6 +2772,9 @@ const char* freerdp_settings_get_string(const rdpSettings* settings,
 		case FreeRDP_GatewayAvdArmpath:
 			return settings->GatewayAvdArmpath;
 
+		case FreeRDP_GatewayAvdClientID:
+			return settings->GatewayAvdClientID;
+
 		case FreeRDP_GatewayAvdDiagnosticserviceurl:
 			return settings->GatewayAvdDiagnosticserviceurl;
 
@@ -3080,6 +3083,9 @@ char* freerdp_settings_get_string_writable(rdpSettings* settings, FreeRDP_Settin
 
 		case FreeRDP_GatewayAvdArmpath:
 			return settings->GatewayAvdArmpath;
+
+		case FreeRDP_GatewayAvdClientID:
+			return settings->GatewayAvdClientID;
 
 		case FreeRDP_GatewayAvdDiagnosticserviceurl:
 			return settings->GatewayAvdDiagnosticserviceurl;
@@ -3399,6 +3405,9 @@ BOOL freerdp_settings_set_string_(rdpSettings* settings, FreeRDP_Settings_Keys_S
 
 		case FreeRDP_GatewayAvdArmpath:
 			return update_string_(&settings->GatewayAvdArmpath, cnv.c, len);
+
+		case FreeRDP_GatewayAvdClientID:
+			return update_string_(&settings->GatewayAvdClientID, cnv.c, len);
 
 		case FreeRDP_GatewayAvdDiagnosticserviceurl:
 			return update_string_(&settings->GatewayAvdDiagnosticserviceurl, cnv.c, len);
@@ -3734,6 +3743,9 @@ BOOL freerdp_settings_set_string_copy_(rdpSettings* settings, FreeRDP_Settings_K
 
 		case FreeRDP_GatewayAvdArmpath:
 			return update_string_copy_(&settings->GatewayAvdArmpath, cnv.cc, len, cleanup);
+
+		case FreeRDP_GatewayAvdClientID:
+			return update_string_copy_(&settings->GatewayAvdClientID, cnv.cc, len, cleanup);
 
 		case FreeRDP_GatewayAvdDiagnosticserviceurl:
 			return update_string_copy_(&settings->GatewayAvdDiagnosticserviceurl, cnv.cc, len,

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -2787,6 +2787,9 @@ const char* freerdp_settings_get_string(const rdpSettings* settings,
 		case FreeRDP_GatewayAvdWvdEndpointPool:
 			return settings->GatewayAvdWvdEndpointPool;
 
+		case FreeRDP_GatewayAzureActiveDirectory:
+			return settings->GatewayAzureActiveDirectory;
+
 		case FreeRDP_GatewayDomain:
 			return settings->GatewayDomain;
 
@@ -3098,6 +3101,9 @@ char* freerdp_settings_get_string_writable(rdpSettings* settings, FreeRDP_Settin
 
 		case FreeRDP_GatewayAvdWvdEndpointPool:
 			return settings->GatewayAvdWvdEndpointPool;
+
+		case FreeRDP_GatewayAzureActiveDirectory:
+			return settings->GatewayAzureActiveDirectory;
 
 		case FreeRDP_GatewayDomain:
 			return settings->GatewayDomain;
@@ -3420,6 +3426,9 @@ BOOL freerdp_settings_set_string_(rdpSettings* settings, FreeRDP_Settings_Keys_S
 
 		case FreeRDP_GatewayAvdWvdEndpointPool:
 			return update_string_(&settings->GatewayAvdWvdEndpointPool, cnv.c, len);
+
+		case FreeRDP_GatewayAzureActiveDirectory:
+			return update_string_(&settings->GatewayAzureActiveDirectory, cnv.c, len);
 
 		case FreeRDP_GatewayDomain:
 			return update_string_(&settings->GatewayDomain, cnv.c, len);
@@ -3760,6 +3769,10 @@ BOOL freerdp_settings_set_string_copy_(rdpSettings* settings, FreeRDP_Settings_K
 
 		case FreeRDP_GatewayAvdWvdEndpointPool:
 			return update_string_copy_(&settings->GatewayAvdWvdEndpointPool, cnv.cc, len, cleanup);
+
+		case FreeRDP_GatewayAzureActiveDirectory:
+			return update_string_copy_(&settings->GatewayAzureActiveDirectory, cnv.cc, len,
+			                           cleanup);
 
 		case FreeRDP_GatewayDomain:
 			return update_string_copy_(&settings->GatewayDomain, cnv.cc, len, cleanup);

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -240,6 +240,9 @@ BOOL freerdp_settings_get_bool(const rdpSettings* settings, FreeRDP_Settings_Key
 		case FreeRDP_GatewayArmTransport:
 			return settings->GatewayArmTransport;
 
+		case FreeRDP_GatewayAvdUseTenantid:
+			return settings->GatewayAvdUseTenantid;
+
 		case FreeRDP_GatewayBypassLocal:
 			return settings->GatewayBypassLocal;
 
@@ -902,6 +905,10 @@ BOOL freerdp_settings_set_bool(rdpSettings* settings, FreeRDP_Settings_Keys_Bool
 
 		case FreeRDP_GatewayArmTransport:
 			settings->GatewayArmTransport = cnv.c;
+			break;
+
+		case FreeRDP_GatewayAvdUseTenantid:
+			settings->GatewayAvdUseTenantid = cnv.c;
 			break;
 
 		case FreeRDP_GatewayBypassLocal:

--- a/libfreerdp/common/settings_str.h
+++ b/libfreerdp/common/settings_str.h
@@ -490,6 +490,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_GatewayAvdActivityhint, FREERDP_SETTINGS_TYPE_STRING,
 	  "FreeRDP_GatewayAvdActivityhint" },
 	{ FreeRDP_GatewayAvdArmpath, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_GatewayAvdArmpath" },
+	{ FreeRDP_GatewayAvdClientID, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_GatewayAvdClientID" },
 	{ FreeRDP_GatewayAvdDiagnosticserviceurl, FREERDP_SETTINGS_TYPE_STRING,
 	  "FreeRDP_GatewayAvdDiagnosticserviceurl" },
 	{ FreeRDP_GatewayAvdGeo, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_GatewayAvdGeo" },

--- a/libfreerdp/common/settings_str.h
+++ b/libfreerdp/common/settings_str.h
@@ -498,6 +498,8 @@ static const struct settings_str_entry settings_map[] = {
 	  "FreeRDP_GatewayAvdHubdiscoverygeourl" },
 	{ FreeRDP_GatewayAvdWvdEndpointPool, FREERDP_SETTINGS_TYPE_STRING,
 	  "FreeRDP_GatewayAvdWvdEndpointPool" },
+	{ FreeRDP_GatewayAzureActiveDirectory, FREERDP_SETTINGS_TYPE_STRING,
+	  "FreeRDP_GatewayAzureActiveDirectory" },
 	{ FreeRDP_GatewayDomain, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_GatewayDomain" },
 	{ FreeRDP_GatewayHostname, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_GatewayHostname" },
 	{ FreeRDP_GatewayHttpExtAuthBearer, FREERDP_SETTINGS_TYPE_STRING,

--- a/libfreerdp/common/settings_str.h
+++ b/libfreerdp/common/settings_str.h
@@ -109,6 +109,7 @@ static const struct settings_str_entry settings_map[] = {
 	  "FreeRDP_FrameMarkerCommandEnabled" },
 	{ FreeRDP_Fullscreen, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_Fullscreen" },
 	{ FreeRDP_GatewayArmTransport, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_GatewayArmTransport" },
+	{ FreeRDP_GatewayAvdUseTenantid, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_GatewayAvdUseTenantid" },
 	{ FreeRDP_GatewayBypassLocal, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_GatewayBypassLocal" },
 	{ FreeRDP_GatewayEnabled, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_GatewayEnabled" },
 	{ FreeRDP_GatewayHttpExtAuthSspiNtlm, FREERDP_SETTINGS_TYPE_BOOL,

--- a/libfreerdp/core/aad.c
+++ b/libfreerdp/core/aad.c
@@ -854,17 +854,13 @@ cleanup:
 WINPR_ATTR_MALLOC(WINPR_JSON_Delete, 1)
 static WINPR_JSON* aad_get_wellknown(wLog* log, const char* base, const char* tenantid)
 {
-	const char* curbase = "login.microsoftonline.com";
-	const char* curtenantid = "common";
-	if (tenantid)
-		curtenantid = tenantid;
-	if (base)
-		curbase = base;
+	WINPR_ASSERT(base);
+	WINPR_ASSERT(tenantid);
 
 	char* str = NULL;
 	size_t len = 0;
-	winpr_asprintf(&str, &len, "https://%s/%s/v2.0/.well-known/openid-configuration", curbase,
-	               curtenantid);
+	winpr_asprintf(&str, &len, "https://%s/%s/v2.0/.well-known/openid-configuration", base,
+	               tenantid);
 
 	if (!str)
 	{

--- a/libfreerdp/core/aad.c
+++ b/libfreerdp/core/aad.c
@@ -32,6 +32,7 @@
 #include <winpr/json.h>
 
 #include "transport.h"
+#include "rdp.h"
 
 #include "aad.h"
 
@@ -47,10 +48,12 @@ struct rdp_aad
 	char* hostname;
 	char* scope;
 	wLog* log;
+	WINPR_JSON* wellknown;
 };
 
 #ifdef WITH_AAD
 
+static BOOL aad_fetch_wellknown(rdpAad* aad);
 static BOOL get_encoded_rsa_params(wLog* wlog, rdpPrivateKey* key, char** e, char** n);
 static BOOL generate_pop_key(rdpAad* aad);
 
@@ -186,8 +189,22 @@ static BOOL aad_get_nonce(rdpAad* aad)
 	size_t response_length = 0;
 	WINPR_JSON* json = NULL;
 
-	if (!freerdp_http_request("https://login.microsoftonline.com/common/oauth2/v2.0/token",
-	                          "grant_type=srv_challenge", &resp_code, &response, &response_length))
+	WINPR_JSON* obj = WINPR_JSON_GetObjectItem(aad->wellknown, "token_endpoint");
+	if (!obj)
+	{
+		WLog_Print(aad->log, WLOG_ERROR, "wellknown does not have 'token_endpoint', aborting");
+		return FALSE;
+	}
+	const char* url = WINPR_JSON_GetStringValue(obj);
+	if (!url)
+	{
+		WLog_Print(aad->log, WLOG_ERROR,
+		           "wellknown does have 'token_endpoint=NULL' value, aborting");
+		return FALSE;
+	}
+
+	if (!freerdp_http_request(url, "grant_type=srv_challenge", &resp_code, &response,
+	                          &response_length))
 	{
 		WLog_Print(aad->log, WLOG_ERROR, "nonce request failed");
 		goto fail;
@@ -269,6 +286,10 @@ int aad_client_begin(rdpAad* aad)
 		WLog_Print(aad->log, WLOG_ERROR, "instance->GetAccessToken == NULL");
 		return -1;
 	}
+
+	if (!aad_fetch_wellknown(aad))
+		return -1;
+
 	const BOOL arc = instance->GetAccessToken(instance, ACCESS_TOKEN_TYPE_AAD, &aad->access_token,
 	                                          2, aad->scope, aad->kid);
 	if (!arc)
@@ -775,6 +796,7 @@ void aad_free(rdpAad* aad)
 	free(aad->access_token);
 	free(aad->kid);
 	freerdp_key_free(aad->key);
+	WINPR_JSON_Delete(aad->wellknown);
 
 	free(aad);
 }
@@ -794,7 +816,6 @@ BOOL aad_is_supported(void)
 #endif
 }
 
-#ifdef WITH_AAD
 char* freerdp_utils_aad_get_access_token(wLog* log, const char* data, size_t length)
 {
 	char* token = NULL;
@@ -829,4 +850,154 @@ cleanup:
 	WINPR_JSON_Delete(json);
 	return token;
 }
-#endif
+
+WINPR_ATTR_MALLOC(WINPR_JSON_Delete, 1)
+static WINPR_JSON* aad_get_wellknown(wLog* log, const char* base, const char* tenantid)
+{
+	const char* curbase = "login.microsoftonline.com";
+	const char* curtenantid = "common";
+	if (tenantid)
+		curtenantid = tenantid;
+	if (base)
+		curbase = base;
+
+	char* str = NULL;
+	size_t len = 0;
+	winpr_asprintf(&str, &len, "https://%s/%s/v2.0/.well-known/openid-configuration", curbase,
+	               curtenantid);
+
+	if (!str)
+	{
+		WLog_Print(log, WLOG_ERROR, "failed to create request URL for tenantid='%s'", tenantid);
+		return NULL;
+	}
+
+	BYTE* response = NULL;
+	long resp_code = 0;
+	size_t response_length = 0;
+	const BOOL rc = freerdp_http_request(str, NULL, &resp_code, &response, &response_length);
+	if (!rc || (resp_code != HTTP_STATUS_OK))
+	{
+		WLog_Print(log, WLOG_ERROR, "request for '%s' failed with: %s", str,
+		           freerdp_http_status_string(resp_code));
+		free(str);
+		free(response);
+		return NULL;
+	}
+	free(str);
+
+	WINPR_JSON* json = WINPR_JSON_ParseWithLength((const char*)response, response_length);
+	free(response);
+
+	if (!json)
+		WLog_Print(log, WLOG_ERROR, "failed to parse reponse as JSON");
+
+	return json;
+}
+
+BOOL aad_fetch_wellknown(rdpAad* aad)
+{
+	WINPR_ASSERT(aad);
+	WINPR_ASSERT(aad->rdpcontext);
+
+	const char* base =
+	    freerdp_settings_get_string(aad->rdpcontext->settings, FreeRDP_GatewayAvdArmpath);
+	const char* tenantid =
+	    freerdp_settings_get_string(aad->rdpcontext->settings, FreeRDP_GatewayAvdAadtenantid);
+	WINPR_JSON_Delete(aad->wellknown);
+	aad->wellknown = aad_get_wellknown(aad->log, base, tenantid);
+	return aad->wellknown ? TRUE : FALSE;
+}
+
+const char* freerdp_utils_aad_get_wellknown_string(rdpContext* context, AAD_WELLKNOWN_VALUES which)
+{
+	return freerdp_utils_aad_get_wellknown_custom_string(
+	    context, freerdp_utils_aad_wellknwon_value_name(which));
+}
+
+const char* freerdp_utils_aad_get_wellknown_custom_string(rdpContext* context, const char* which)
+{
+	WINPR_ASSERT(context);
+	WINPR_ASSERT(context->rdp);
+	rdpAad* aad = context->rdp->aad;
+	if (!aad || !aad->wellknown)
+		return NULL;
+
+	WINPR_JSON* obj = WINPR_JSON_GetObjectItem(aad->wellknown, which);
+	if (!obj)
+		return NULL;
+
+	return WINPR_JSON_GetStringValue(obj);
+}
+
+const char* freerdp_utils_aad_wellknwon_value_name(AAD_WELLKNOWN_VALUES which)
+{
+	switch (which)
+	{
+		case AAD_WELLKNOWN_token_endpoint:
+			return "token_endpoint";
+		case AAD_WELLKNOWN_token_endpoint_auth_methods_supported:
+			return "token_endpoint_auth_methods_supported";
+		case AAD_WELLKNOWN_jwks_uri:
+			return "jwks_uri";
+		case AAD_WELLKNOWN_response_modes_supported:
+			return "response_modes_supported";
+		case AAD_WELLKNOWN_subject_types_supported:
+			return "subject_types_supported";
+		case AAD_WELLKNOWN_id_token_signing_alg_values_supported:
+			return "id_token_signing_alg_values_supported";
+		case AAD_WELLKNOWN_response_types_supported:
+			return "response_types_supported";
+		case AAD_WELLKNOWN_scopes_supported:
+			return "scopes_supported";
+		case AAD_WELLKNOWN_issuer:
+			return "issuer";
+		case AAD_WELLKNOWN_request_uri_parameter_supported:
+			return "request_uri_parameter_supported";
+		case AAD_WELLKNOWN_userinfo_endpoint:
+			return "userinfo_endpoint";
+		case AAD_WELLKNOWN_authorization_endpoint:
+			return "authorization_endpoint";
+		case AAD_WELLKNOWN_device_authorization_endpoint:
+			return "device_authorization_endpoint";
+		case AAD_WELLKNOWN_http_logout_supported:
+			return "http_logout_supported";
+		case AAD_WELLKNOWN_frontchannel_logout_supported:
+			return "frontchannel_logout_supported";
+		case AAD_WELLKNOWN_end_session_endpoint:
+			return "end_session_endpoint";
+		case AAD_WELLKNOWN_claims_supported:
+			return "claims_supported";
+		case AAD_WELLKNOWN_kerberos_endpoint:
+			return "kerberos_endpoint";
+		case AAD_WELLKNOWN_tenant_region_scope:
+			return "tenant_region_scope";
+		case AAD_WELLKNOWN_cloud_instance_name:
+			return "cloud_instance_name";
+		case AAD_WELLKNOWN_cloud_graph_host_name:
+			return "cloud_graph_host_name";
+		case AAD_WELLKNOWN_msgraph_host:
+			return "msgraph_host";
+		case AAD_WELLKNOWN_rbac_url:
+			return "rbac_url";
+		default:
+			return "UNKNOWN";
+	}
+}
+
+WINPR_JSON* freerdp_utils_aad_get_wellknown_object(rdpContext* context, AAD_WELLKNOWN_VALUES which)
+{
+	return freerdp_utils_aad_get_wellknown_custom_object(
+	    context, freerdp_utils_aad_wellknwon_value_name(which));
+}
+
+WINPR_JSON* freerdp_utils_aad_get_wellknown_custom_object(rdpContext* context, const char* which)
+{
+	WINPR_ASSERT(context);
+	WINPR_ASSERT(context->rdp);
+	rdpAad* aad = context->rdp->aad;
+	if (!aad || !aad->wellknown)
+		return NULL;
+
+	return WINPR_JSON_GetObjectItem(aad->wellknown, which);
+}

--- a/libfreerdp/core/aad.c
+++ b/libfreerdp/core/aad.c
@@ -868,8 +868,12 @@ BOOL aad_fetch_wellknown(rdpAad* aad)
 
 	const char* base =
 	    freerdp_settings_get_string(aad->rdpcontext->settings, FreeRDP_GatewayAzureActiveDirectory);
-	const char* tenantid =
-	    freerdp_settings_get_string(aad->rdpcontext->settings, FreeRDP_GatewayAvdAadtenantid);
+	const BOOL useTenant =
+	    freerdp_settings_get_bool(aad->rdpcontext->settings, FreeRDP_GatewayAvdUseTenantid);
+	const char* tenantid = "common";
+	if (useTenant)
+		tenantid =
+		    freerdp_settings_get_string(aad->rdpcontext->settings, FreeRDP_GatewayAvdAadtenantid);
 	rdp->wellknown = freerdp_utils_aad_get_wellknown(aad->log, base, tenantid);
 	return rdp->wellknown ? TRUE : FALSE;
 }

--- a/libfreerdp/core/aad.c
+++ b/libfreerdp/core/aad.c
@@ -857,7 +857,7 @@ BOOL aad_fetch_wellknown(rdpAad* aad)
 	WINPR_ASSERT(aad->rdpcontext);
 
 	const char* base =
-	    freerdp_settings_get_string(aad->rdpcontext->settings, FreeRDP_GatewayAvdArmpath);
+	    freerdp_settings_get_string(aad->rdpcontext->settings, FreeRDP_GatewayAzureActiveDirectory);
 	const char* tenantid =
 	    freerdp_settings_get_string(aad->rdpcontext->settings, FreeRDP_GatewayAvdAadtenantid);
 	WINPR_JSON_Delete(aad->wellknown);
@@ -993,7 +993,7 @@ WINPR_JSON* freerdp_utils_aad_get_wellknown(wLog* log, const char* base, const c
 	free(response);
 
 	if (!json)
-		WLog_Print(log, WLOG_ERROR, "failed to parse reponse as JSON");
+		WLog_Print(log, WLOG_ERROR, "failed to parse response as JSON");
 
 	return json;
 }

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -335,7 +335,7 @@ BOOL rdp_client_connect(rdpRdp* rdp)
 	UINT32 TcpConnectTimeout = freerdp_settings_get_uint32(settings, FreeRDP_TcpConnectTimeout);
 	if (settings->GatewayArmTransport)
 	{
-		if (!arm_resolve_endpoint(rdp->context, TcpConnectTimeout))
+		if (!arm_resolve_endpoint(rdp->log, rdp->context, TcpConnectTimeout))
 		{
 			WLog_ERR(TAG, "error retrieving ARM configuration");
 			return FALSE;

--- a/libfreerdp/core/gateway/arm.c
+++ b/libfreerdp/core/gateway/arm.c
@@ -170,8 +170,12 @@ static BOOL arm_fetch_wellknown(rdpArm* arm)
 
 	const char* base =
 	    freerdp_settings_get_string(arm->context->settings, FreeRDP_GatewayAzureActiveDirectory);
-	const char* tenantid =
-	    freerdp_settings_get_string(arm->context->settings, FreeRDP_GatewayAvdAadtenantid);
+	const BOOL useTenant =
+	    freerdp_settings_get_bool(arm->context->settings, FreeRDP_GatewayAvdUseTenantid);
+	const char* tenantid = "common";
+	if (useTenant)
+		tenantid =
+		    freerdp_settings_get_string(arm->context->settings, FreeRDP_GatewayAvdAadtenantid);
 
 	rdp->wellknown = freerdp_utils_aad_get_wellknown(arm->log, base, tenantid);
 	return rdp->wellknown ? TRUE : FALSE;

--- a/libfreerdp/core/gateway/arm.c
+++ b/libfreerdp/core/gateway/arm.c
@@ -165,7 +165,7 @@ static BOOL arm_fetch_wellknown(rdpArm* arm)
 	WINPR_ASSERT(arm->context);
 
 	const char* base =
-	    freerdp_settings_get_string(arm->context->settings, FreeRDP_GatewayAvdArmpath);
+	    freerdp_settings_get_string(arm->context->settings, FreeRDP_GatewayAzureActiveDirectory);
 	const char* tenantid =
 	    freerdp_settings_get_string(arm->context->settings, FreeRDP_GatewayAvdAadtenantid);
 	WINPR_JSON_Delete(arm->wellknown);

--- a/libfreerdp/core/gateway/arm.h
+++ b/libfreerdp/core/gateway/arm.h
@@ -20,8 +20,12 @@
 #ifndef FREERDP_LIB_CORE_GATEWAY_ARM_H
 #define FREERDP_LIB_CORE_GATEWAY_ARM_H
 
-#include <freerdp/api.h>
+#include <winpr/wtypes.h>
+#include <winpr/wlog.h>
 
-FREERDP_LOCAL BOOL arm_resolve_endpoint(rdpContext* context, DWORD timeout);
+#include <freerdp/api.h>
+#include <freerdp/types.h>
+
+FREERDP_LOCAL BOOL arm_resolve_endpoint(wLog* log, rdpContext* context, DWORD timeout);
 
 #endif /* FREERDP_LIB_CORE_GATEWAY_ARM_H */

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -26,6 +26,7 @@
 #include <winpr/string.h>
 #include <winpr/synch.h>
 #include <winpr/assert.h>
+#include <winpr/json.h>
 
 #include "rdp.h"
 
@@ -2523,6 +2524,7 @@ void rdp_free(rdpRdp* rdp)
 		if (rdp->abortEvent)
 			(void)CloseHandle(rdp->abortEvent);
 		aad_free(rdp->aad);
+		WINPR_JSON_Delete(rdp->wellknown);
 		DeleteCriticalSection(&rdp->critical);
 		free(rdp);
 	}

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -21,6 +21,7 @@
 #ifndef FREERDP_LIB_CORE_RDP_H
 #define FREERDP_LIB_CORE_RDP_H
 
+#include <winpr/json.h>
 #include <freerdp/config.h>
 
 #include "nla.h"
@@ -206,6 +207,7 @@ struct rdp_rdp
 
 	wLog* log;
 	char log_context[64];
+	WINPR_JSON* wellknown;
 };
 
 FREERDP_LOCAL BOOL rdp_read_security_header(rdpRdp* rdp, wStream* s, UINT16* flags, UINT16* length);

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -829,6 +829,8 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 			goto out_fail;
 		if (!freerdp_settings_set_string(settings, FreeRDP_GatewayAvdAadtenantid, "common"))
 			goto out_fail;
+		if (!freerdp_settings_set_bool(settings, FreeRDP_GatewayAvdUseTenantid, FALSE))
+			goto out_fail;
 		if (!freerdp_settings_set_uint32(settings, FreeRDP_DesktopPhysicalWidth, 1000))
 			goto out_fail;
 		if (!freerdp_settings_set_uint32(settings, FreeRDP_DesktopPhysicalHeight, 1000))

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -821,6 +821,14 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 
 	if (!server && !remote)
 	{
+		if (!freerdp_settings_set_string(settings, FreeRDP_GatewayAvdClientID,
+		                                 "a85cf173-4192-42f8-81fa-777a763e6e2c"))
+			goto out_fail;
+		if (!freerdp_settings_set_string(settings, FreeRDP_GatewayAvdArmpath,
+		                                 "login.microsoftonline.com"))
+			goto out_fail;
+		if (!freerdp_settings_set_string(settings, FreeRDP_GatewayAvdAadtenantid, "common"))
+			goto out_fail;
 		if (!freerdp_settings_set_uint32(settings, FreeRDP_DesktopPhysicalWidth, 1000))
 			goto out_fail;
 		if (!freerdp_settings_set_uint32(settings, FreeRDP_DesktopPhysicalHeight, 1000))

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -824,7 +824,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 		if (!freerdp_settings_set_string(settings, FreeRDP_GatewayAvdClientID,
 		                                 "a85cf173-4192-42f8-81fa-777a763e6e2c"))
 			goto out_fail;
-		if (!freerdp_settings_set_string(settings, FreeRDP_GatewayAvdArmpath,
+		if (!freerdp_settings_set_string(settings, FreeRDP_GatewayAzureActiveDirectory,
 		                                 "login.microsoftonline.com"))
 			goto out_fail;
 		if (!freerdp_settings_set_string(settings, FreeRDP_GatewayAvdAadtenantid, "common"))

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -390,6 +390,7 @@ static const size_t string_list_indices[] = {
 	FreeRDP_GatewayAvdAadtenantid,
 	FreeRDP_GatewayAvdActivityhint,
 	FreeRDP_GatewayAvdArmpath,
+	FreeRDP_GatewayAvdClientID,
 	FreeRDP_GatewayAvdDiagnosticserviceurl,
 	FreeRDP_GatewayAvdGeo,
 	FreeRDP_GatewayAvdHubdiscoverygeourl,

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -395,6 +395,7 @@ static const size_t string_list_indices[] = {
 	FreeRDP_GatewayAvdGeo,
 	FreeRDP_GatewayAvdHubdiscoverygeourl,
 	FreeRDP_GatewayAvdWvdEndpointPool,
+	FreeRDP_GatewayAzureActiveDirectory,
 	FreeRDP_GatewayDomain,
 	FreeRDP_GatewayHostname,
 	FreeRDP_GatewayHttpExtAuthBearer,

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -64,6 +64,7 @@ static const size_t bool_list_indices[] = {
 	FreeRDP_FrameMarkerCommandEnabled,
 	FreeRDP_Fullscreen,
 	FreeRDP_GatewayArmTransport,
+	FreeRDP_GatewayAvdUseTenantid,
 	FreeRDP_GatewayBypassLocal,
 	FreeRDP_GatewayEnabled,
 	FreeRDP_GatewayHttpExtAuthSspiNtlm,

--- a/tools/update-settings-tests
+++ b/tools/update-settings-tests
@@ -163,7 +163,7 @@ def write_setter(f, entry_dict, entry_type, entry_name, postfix):
     f.write('BOOL freerdp_settings_set_' + entry_name.lower())
     f.write(postfix)
     f.write('(rdpSettings* settings, ' + typestr + ' id, ')
-    if isString and len(postfix) > 0 or isPointer:
+    if isString or isPointer:
         f.write('const ')
     if not isPointer:
         f.write(entry_type + ' val')
@@ -255,6 +255,8 @@ try:
             if sline.startswith('*'):
                 continue
             if 'padding' in sline:
+                continue
+            if 'version' in sline:
                 continue
 
             if sline.startswith('SETTINGS_DEPRECATED(ALIGN64'):


### PR DESCRIPTION
All of the URL we need for AAD authentication are dependent on a tenantid. Fetch the wellknown file for the desired tenantid from https://login.microsoftonline.com/{tenantid}/v2.0/.well-known/openid-configuration and parse as JSON to have them available later on.

this is now working for `AAD` and `AVD` (the fetch of the `wellknown`)
everything else is out of scope for the pr, needs follow ups.