### PR TITLE
Warn fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -71,6 +71,7 @@ Checks: >
     -readability-identifier-length,
     -readability-implicit-bool-conversion,
     -readability-magic-numbers,
+    -readability-math-missing-parentheses,
     -readability-misleading-indentation,
     -readability-qualified-auto,
     -readability-suspicious-call-argument,

--- a/channels/disp/client/disp_main.c
+++ b/channels/disp/client/disp_main.c
@@ -119,8 +119,8 @@ disp_send_display_control_monitor_layout_pdu(GENERIC_CHANNEL_CALLBACK* callback,
 			current.Height = 8192;
 
 		Stream_Write_UINT32(s, current.Flags);              /* Flags (4 bytes) */
-		Stream_Write_UINT32(s, current.Left);               /* Left (4 bytes) */
-		Stream_Write_UINT32(s, current.Top);                /* Top (4 bytes) */
+		Stream_Write_INT32(s, current.Left);                /* Left (4 bytes) */
+		Stream_Write_INT32(s, current.Top);                 /* Top (4 bytes) */
 		Stream_Write_UINT32(s, current.Width);              /* Width (4 bytes) */
 		Stream_Write_UINT32(s, current.Height);             /* Height (4 bytes) */
 		Stream_Write_UINT32(s, current.PhysicalWidth);      /* PhysicalWidth (4 bytes) */

--- a/channels/drive/client/drive_file.c
+++ b/channels/drive/client/drive_file.c
@@ -392,7 +392,7 @@ fail:
 
 BOOL drive_file_seek(DRIVE_FILE* file, UINT64 Offset)
 {
-	LARGE_INTEGER loffset;
+	LARGE_INTEGER loffset = { 0 };
 
 	if (!file)
 		return FALSE;
@@ -616,10 +616,10 @@ BOOL drive_file_set_information(DRIVE_FILE* file, UINT32 FsInformationClass, UIN
 {
 	INT64 size = 0;
 	WCHAR* fullpath = NULL;
-	ULARGE_INTEGER liCreationTime;
-	ULARGE_INTEGER liLastAccessTime;
-	ULARGE_INTEGER liLastWriteTime;
-	ULARGE_INTEGER liChangeTime;
+	ULARGE_INTEGER liCreationTime = { 0 };
+	ULARGE_INTEGER liLastAccessTime = { 0 };
+	ULARGE_INTEGER liLastWriteTime = { 0 };
+	ULARGE_INTEGER liChangeTime = { 0 };
 	FILETIME ftCreationTime;
 	FILETIME ftLastAccessTime;
 	FILETIME ftLastWriteTime;
@@ -628,7 +628,7 @@ BOOL drive_file_set_information(DRIVE_FILE* file, UINT32 FsInformationClass, UIN
 	FILETIME* pftLastWriteTime = NULL;
 	UINT32 FileAttributes = 0;
 	UINT32 FileNameLength = 0;
-	LARGE_INTEGER liSize;
+	LARGE_INTEGER liSize = { 0 };
 	UINT8 delete_pending = 0;
 	UINT8 ReplaceIfExists = 0;
 	DWORD attr = 0;

--- a/channels/rdpgfx/server/rdpgfx_main.c
+++ b/channels/rdpgfx/server/rdpgfx_main.c
@@ -293,10 +293,10 @@ static UINT rdpgfx_send_reset_graphics_pdu(RdpgfxServerContext* context,
 	for (UINT32 index = 0; index < pdu->monitorCount; index++)
 	{
 		const MONITOR_DEF* monitor = &(pdu->monitorDefArray[index]);
-		Stream_Write_UINT32(s, monitor->left);   /* left (4 bytes) */
-		Stream_Write_UINT32(s, monitor->top);    /* top (4 bytes) */
-		Stream_Write_UINT32(s, monitor->right);  /* right (4 bytes) */
-		Stream_Write_UINT32(s, monitor->bottom); /* bottom (4 bytes) */
+		Stream_Write_INT32(s, monitor->left);    /* left (4 bytes) */
+		Stream_Write_INT32(s, monitor->top);     /* top (4 bytes) */
+		Stream_Write_INT32(s, monitor->right);   /* right (4 bytes) */
+		Stream_Write_INT32(s, monitor->bottom);  /* bottom (4 bytes) */
 		Stream_Write_UINT32(s, monitor->flags);  /* flags (4 bytes) */
 	}
 

--- a/channels/urbdrc/client/data_transfer.c
+++ b/channels/urbdrc/client/data_transfer.c
@@ -493,9 +493,9 @@ static UINT urb_select_configuration(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* c
 	if (MsOutSize > 0)
 	{
 		/** CbTsUrbResult */
-		Stream_Write_UINT32(out, 8 + MsOutSize);
+		Stream_Write_UINT32(out, 8U + (UINT32)MsOutSize);
 		/** TS_URB_RESULT_HEADER Size*/
-		Stream_Write_UINT16(out, 8 + MsOutSize);
+		Stream_Write_UINT16(out, 8U + (UINT32)MsOutSize);
 	}
 	else
 	{

--- a/client/SDL/SDL2/dialogs/sdl_button.cpp
+++ b/client/SDL/SDL2/dialogs/sdl_button.cpp
@@ -36,10 +36,7 @@ SdlButton::SdlButton(SDL_Renderer* renderer, std::string label, int id, SDL_Rect
 	update_text(renderer, _name, buttonfontcolor, buttonbackgroundcolor);
 }
 
-SdlButton::SdlButton(SdlButton&& other) noexcept
-    : SdlWidget(std::move(other)), _name(std::move(other._name)), _id(other._id)
-{
-}
+SdlButton::SdlButton(SdlButton&& other) noexcept = default;
 
 SdlButton::~SdlButton() = default;
 

--- a/client/SDL/SDL2/dialogs/sdl_input_widgets.cpp
+++ b/client/SDL/SDL2/dialogs/sdl_input_widgets.cpp
@@ -284,6 +284,7 @@ int SdlInputWidgetList::run(std::vector<std::string>& result)
 	}
 	catch (...)
 	{
+		res = -2;
 	}
 
 	return res;

--- a/client/SDL/SDL2/dialogs/sdl_select.cpp
+++ b/client/SDL/SDL2/dialogs/sdl_select.cpp
@@ -42,11 +42,7 @@ SdlSelectWidget::SdlSelectWidget(SDL_Renderer* renderer, std::string label, SDL_
 	update_text(renderer);
 }
 
-SdlSelectWidget::SdlSelectWidget(SdlSelectWidget&& other) noexcept
-    : SdlWidget(std::move(other)), _text(std::move(other._text)), _mouseover(other._mouseover),
-      _highlight(other._highlight)
-{
-}
+SdlSelectWidget::SdlSelectWidget(SdlSelectWidget&& other) noexcept = default;
 
 SdlSelectWidget::~SdlSelectWidget() = default;
 

--- a/client/SDL/SDL2/sdl_utils.cpp
+++ b/client/SDL/SDL2/sdl_utils.cpp
@@ -213,7 +213,7 @@ BOOL sdl_push_user_event(Uint32 type, ...)
 			event->data2 = va_arg(ap, void*);
 			break;
 		case SDL_USEREVENT_CREATE_WINDOWS:
-			event->data1 = reinterpret_cast<void*>(va_arg(ap, void*));
+			event->data1 = va_arg(ap, void*);
 			break;
 		case SDL_USEREVENT_WINDOW_FULLSCREEN:
 		case SDL_USEREVENT_WINDOW_RESIZEABLE:

--- a/client/SDL/SDL3/dialogs/sdl_button.cpp
+++ b/client/SDL/SDL3/dialogs/sdl_button.cpp
@@ -36,10 +36,7 @@ SdlButton::SdlButton(SDL_Renderer* renderer, std::string label, int id, const SD
 	update_text(renderer, _name, buttonfontcolor, buttonbackgroundcolor);
 }
 
-SdlButton::SdlButton(SdlButton&& other) noexcept
-    : SdlWidget(std::move(other)), _name(std::move(other._name)), _id(other._id)
-{
-}
+SdlButton::SdlButton(SdlButton&& other) noexcept = default;
 
 SdlButton::~SdlButton() = default;
 

--- a/client/SDL/SDL3/dialogs/sdl_input_widgets.cpp
+++ b/client/SDL/SDL3/dialogs/sdl_input_widgets.cpp
@@ -284,6 +284,7 @@ int SdlInputWidgetList::run(std::vector<std::string>& result)
 	}
 	catch (...)
 	{
+		res = -2;
 	}
 
 	return res;

--- a/client/SDL/SDL3/dialogs/sdl_select.cpp
+++ b/client/SDL/SDL3/dialogs/sdl_select.cpp
@@ -42,11 +42,7 @@ SdlSelectWidget::SdlSelectWidget(SDL_Renderer* renderer, std::string label, cons
 	update_text(renderer);
 }
 
-SdlSelectWidget::SdlSelectWidget(SdlSelectWidget&& other) noexcept
-    : SdlWidget(std::move(other)), _text(std::move(other._text)), _mouseover(other._mouseover),
-      _highlight(other._highlight)
-{
-}
+SdlSelectWidget::SdlSelectWidget(SdlSelectWidget&& other) noexcept = default;
 
 bool SdlSelectWidget::set_mouseover(SDL_Renderer* renderer, bool mouseOver)
 {

--- a/client/SDL/SDL3/sdl_freerdp.cpp
+++ b/client/SDL/SDL3/sdl_freerdp.cpp
@@ -1730,8 +1730,8 @@ BOOL SdlContext::update_resizeable(BOOL enable)
 }
 
 SdlContext::SdlContext(rdpContext* context)
-    : _context(context), log(WLog_Get(SDL_TAG)), update_complete(true), disp(this), clip(this),
-      input(this), primary(nullptr, SDL_DestroySurface), rdp_thread_running(false)
+    : _context(context), log(WLog_Get(SDL_TAG)), update_complete(true), disp(this), input(this),
+      clip(this), primary(nullptr, SDL_DestroySurface), rdp_thread_running(false)
 {
 	WINPR_ASSERT(context);
 	grab_kbd_enabled = freerdp_settings_get_bool(context->settings, FreeRDP_GrabKeyboard);

--- a/client/SDL/SDL3/sdl_utils.cpp
+++ b/client/SDL/SDL3/sdl_utils.cpp
@@ -259,7 +259,7 @@ BOOL sdl_push_user_event(Uint32 type, ...)
 			event->data2 = va_arg(ap, void*);
 			break;
 		case SDL_EVENT_USER_CREATE_WINDOWS:
-			event->data1 = reinterpret_cast<void*>(va_arg(ap, void*));
+			event->data1 = va_arg(ap, void*);
 			break;
 		case SDL_EVENT_USER_WINDOW_FULLSCREEN:
 		case SDL_EVENT_USER_WINDOW_RESIZEABLE:

--- a/client/Wayland/wlfreerdp.c
+++ b/client/Wayland/wlfreerdp.c
@@ -478,7 +478,7 @@ static int wlfreerdp_run(freerdp* instance)
 	HANDLE handles[MAXIMUM_WAIT_OBJECTS] = { 0 };
 	DWORD status = WAIT_ABANDONED;
 	HANDLE timer = NULL;
-	LARGE_INTEGER due;
+	LARGE_INTEGER due = { 0 };
 
 	TimerEventArgs timerEvent;
 	EventArgsInit(&timerEvent, "xfreerdp");

--- a/client/X11/CMakeLists.txt
+++ b/client/X11/CMakeLists.txt
@@ -202,8 +202,6 @@ if (WITH_XFIXES)
 	endif()
 endif()
 
-include_directories(${PROJECT_SOURCE_DIR}/resources)
-
 list(APPEND PUB_LIBS
 	freerdp-client
 )

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1015,7 +1015,7 @@ static int freerdp_client_command_line_post_filter_int(void* context, COMMAND_LI
 		size_t count = 0;
 		char** ptr = CommandLineParseCommaSeparatedValues(arg->Value, &count);
 
-		if (!freerdp_client_add_device_channel(settings, count, (const char**)ptr))
+		if (!freerdp_client_add_device_channel(settings, count, (const char* const*)ptr))
 			status = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 		if (!freerdp_settings_set_bool(settings, FreeRDP_DeviceRedirection, TRUE))
 			status = COMMAND_LINE_ERROR;

--- a/client/common/file.c
+++ b/client/common/file.c
@@ -2310,7 +2310,8 @@ BOOL freerdp_client_populate_settings_from_rdp_file(const rdpFile* file, rdpSett
 		size_t count = 0;
 
 		char** ptr = CommandLineParseCommaSeparatedValuesEx(LOCATION_CHANNEL_NAME, NULL, &count);
-		const BOOL rc = freerdp_client_add_dynamic_channel(settings, count, (const char**)ptr);
+		const BOOL rc =
+		    freerdp_client_add_dynamic_channel(settings, count, (const char* const*)ptr);
 		CommandLineParserFree(ptr);
 		if (!rc)
 			return FALSE;

--- a/libfreerdp/core/gateway/http.c
+++ b/libfreerdp/core/gateway/http.c
@@ -1030,9 +1030,9 @@ static BOOL http_response_parse_header(HttpResponse* response)
 				break;
 		}
 
-		const int rc = http_response_parse_header_field(response, name, value);
+		const int res = http_response_parse_header_field(response, name, value);
 		*end_of_header = end_of_header_char;
-		if (!rc)
+		if (!res)
 			goto fail;
 	}
 

--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -2626,8 +2626,8 @@ static BOOL update_send_new_or_existing_window(rdpContext* context,
 
 	if ((orderInfo->fieldFlags & WINDOW_ORDER_FIELD_VIS_OFFSET) != 0)
 	{
-		Stream_Write_UINT32(s, stateOrder->visibleOffsetX);
-		Stream_Write_UINT32(s, stateOrder->visibleOffsetY);
+		Stream_Write_INT32(s, stateOrder->visibleOffsetX);
+		Stream_Write_INT32(s, stateOrder->visibleOffsetY);
 	}
 
 	if ((orderInfo->fieldFlags & WINDOW_ORDER_FIELD_VISIBILITY) != 0)

--- a/libfreerdp/crypto/er.c
+++ b/libfreerdp/crypto/er.c
@@ -410,13 +410,13 @@ int er_write_integer(wStream* s, INT32 value)
 	else if (value <= 32767 && value >= -32768)
 	{
 		er_write_length(s, 2, FALSE);
-		Stream_Write_UINT16_BE(s, value);
+		Stream_Write_INT16_BE(s, value);
 		return 3;
 	}
 	else
 	{
 		er_write_length(s, 4, FALSE);
-		Stream_Write_UINT32_BE(s, value);
+		Stream_Write_INT32_BE(s, value);
 		return 5;
 	}
 }

--- a/uwac/libuwac/uwac-input.c
+++ b/uwac/libuwac/uwac-input.c
@@ -287,7 +287,7 @@ static void keyboard_handle_leave(void* data, struct wl_keyboard* keyboard, uint
 	its.it_interval.tv_nsec = 0;
 	its.it_value.tv_sec = 0;
 	its.it_value.tv_nsec = 0;
-	timerfd_settime(input->repeat_timer_fd, 0, &its, NULL);
+	(void)timerfd_settime(input->repeat_timer_fd, 0, &its, NULL);
 
 	UwacPointerEnterLeaveEvent* event =
 	    (UwacPointerEnterLeaveEvent*)UwacDisplayNewEvent(input->display, UWAC_EVENT_POINTER_LEAVE);
@@ -403,7 +403,7 @@ static void keyboard_handle_key(void* data, struct wl_keyboard* keyboard, uint32
 		its.it_interval.tv_nsec = 0;
 		its.it_value.tv_sec = 0;
 		its.it_value.tv_nsec = 0;
-		timerfd_settime(input->repeat_timer_fd, 0, &its, NULL);
+		(void)timerfd_settime(input->repeat_timer_fd, 0, &its, NULL);
 	}
 	else if (state == WL_KEYBOARD_KEY_STATE_PRESSED &&
 	         xkb_keymap_key_repeats(input->xkb.keymap, code))
@@ -415,7 +415,7 @@ static void keyboard_handle_key(void* data, struct wl_keyboard* keyboard, uint32
 		its.it_interval.tv_nsec = input->repeat_rate_nsec;
 		its.it_value.tv_sec = input->repeat_delay_sec;
 		its.it_value.tv_nsec = input->repeat_delay_nsec;
-		timerfd_settime(input->repeat_timer_fd, 0, &its, NULL);
+		(void)timerfd_settime(input->repeat_timer_fd, 0, &its, NULL);
 	}
 
 	keyEvent = (UwacKeyEvent*)UwacDisplayNewEvent(input->display, UWAC_EVENT_KEY);

--- a/winpr/include/winpr/assert.h
+++ b/winpr/include/winpr/assert.h
@@ -34,15 +34,19 @@
 extern "C"
 {
 #endif
-#define WINPR_ASSERT(cond)                                           \
-	do                                                               \
-	{                                                                \
-		WINPR_PRAGMA_DIAG_PUSH                                       \
-		WINPR_PRAGMA_DIAG_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE \
-		WINPR_PRAGMA_DIAG_TAUTOLOGICAL_VALUE_RANGE_COMPARE           \
-		if (!(cond))                                                 \
-			winpr_int_assert(#cond, __FILE__, __func__, __LINE__);   \
-		WINPR_PRAGMA_DIAG_POP                                        \
+#define WINPR_ASSERT(cond)                                               \
+	do                                                                   \
+	{                                                                    \
+		WINPR_PRAGMA_DIAG_PUSH                                           \
+		WINPR_PRAGMA_DIAG_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE     \
+		WINPR_PRAGMA_DIAG_TAUTOLOGICAL_VALUE_RANGE_COMPARE               \
+		WINPR_PRAGMA_DIAG_IGNORED_UNKNOWN_PRAGMAS                        \
+		WINPR_DO_PRAGMA(coverity compliance deviate "NO_EFFECT:SUPPRESS" \
+		                                            "WINPR_ASSERT")      \
+                                                                         \
+		if (!(cond))                                                     \
+			winpr_int_assert(#cond, __FILE__, __func__, __LINE__);       \
+		WINPR_PRAGMA_DIAG_POP                                            \
 	} while (0)
 
 	static INLINE WINPR_NORETURN(void winpr_int_assert(const char* condstr, const char* file,
@@ -59,15 +63,17 @@ extern "C"
 #endif
 
 #else
-#define WINPR_ASSERT(cond)                                           \
-	do                                                               \
-	{                                                                \
-		WINPR_PRAGMA_DIAG_PUSH                                       \
-		WINPR_PRAGMA_DIAG_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE \
-		WINPR_PRAGMA_DIAG_TAUTOLOGICAL_VALUE_RANGE_COMPARE           \
-		_Pragma("coverity compliance deviate \"NO_EFFECT:SUPPRESS\" \"WINPR_ASSERT\"") \
-		assert(cond);                                                \
-		WINPR_PRAGMA_DIAG_POP                                        \
+#define WINPR_ASSERT(cond)                                               \
+	do                                                                   \
+	{                                                                    \
+		WINPR_PRAGMA_DIAG_PUSH                                           \
+		WINPR_PRAGMA_DIAG_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE     \
+		WINPR_PRAGMA_DIAG_TAUTOLOGICAL_VALUE_RANGE_COMPARE               \
+		WINPR_PRAGMA_DIAG_IGNORED_UNKNOWN_PRAGMAS                        \
+		WINPR_DO_PRAGMA(coverity compliance deviate "NO_EFFECT:SUPPRESS" \
+		                                            "WINPR_ASSERT")      \
+		assert(cond);                                                    \
+		WINPR_PRAGMA_DIAG_POP                                            \
 	} while (0)
 #endif
 

--- a/winpr/include/winpr/platform.h
+++ b/winpr/include/winpr/platform.h
@@ -22,7 +22,16 @@
 
 #include <stdlib.h>
 
+/* MSVC only defines _Pragma if you compile with /std:c11 with no extensions
+ * see
+ * https://learn.microsoft.com/en-us/cpp/preprocessor/pragma-directives-and-the-pragma-keyword?view=msvc-170#the-pragma-preprocessing-operator
+ */
+#if !defined(_MSC_VER)
 #define WINPR_DO_PRAGMA(x) _Pragma(#x)
+#else
+#define WINPR_DO_PRAGMA(x) __pragma(#x)
+#endif
+
 #if defined(__GNUC__)
 #define WINPR_PRAGMA_WARNING(msg) WINPR_DO_PRAGMA(GCC warning #msg)
 #elif defined(__clang__)
@@ -60,93 +69,102 @@
 #endif
 
 #if defined(__clang__)
-#define WINPR_PRAGMA_DIAG_PUSH _Pragma("clang diagnostic push")
+#define WINPR_PRAGMA_DIAG_PUSH WINPR_DO_PRAGMA(clang diagnostic push)
 #define WINPR_PRAGMA_DIAG_IGNORED_OVERLENGTH_STRINGS \
-	_Pragma("clang diagnostic ignored \"-Woverlength-strings\"") /** @since version 3.9.0 */
+	WINPR_DO_PRAGMA(clang diagnostic ignored "-Woverlength-strings") /** @since version 3.9.0 */
 #define WINPR_PRAGMA_DIAG_IGNORED_QUALIFIERS \
-	_Pragma("clang diagnostic ignored \"-Wdiscarded-qualifiers\"") /** @since version 3.9.0 */
-#define WINPR_PRAGMA_DIAG_IGNORED_PEDANTIC _Pragma("clang diagnostic ignored \"-Wpedantic\"")
+	WINPR_DO_PRAGMA(clang diagnostic ignored "-Wdiscarded-qualifiers") /** @since version 3.9.0 */
+#define WINPR_PRAGMA_DIAG_IGNORED_PEDANTIC WINPR_DO_PRAGMA(clang diagnostic ignored "-Wpedantic")
 #define WINPR_PRAGMA_DIAG_IGNORED_MISSING_PROTOTYPES \
-	_Pragma("clang diagnostic ignored \"-Wmissing-prototypes\"")
+	WINPR_DO_PRAGMA(clang diagnostic ignored "-Wmissing-prototypes")
 #define WINPR_PRAGMA_DIAG_IGNORED_STRICT_PROTOTYPES \
-	_Pragma("clang diagnostic ignored \"-Wstrict-prototypes\"")
+	WINPR_DO_PRAGMA(clang diagnostic ignored "-Wstrict-prototypes")
 #define WINPR_PRAGMA_DIAG_IGNORED_RESERVED_ID_MACRO \
-	_Pragma("clang diagnostic ignored \"-Wreserved-id-macro\"")
+	WINPR_DO_PRAGMA(clang diagnostic ignored "-Wreserved-id-macro")
 #define WINPR_PRAGMA_DIAG_IGNORED_UNUSED_MACRO \
-	_Pragma("clang diagnostic ignored \"-Wunused-macros\"")
+	WINPR_DO_PRAGMA(clang diagnostic ignored "-Wunused-macros")
+#define WINPR_PRAGMA_DIAG_IGNORED_UNKNOWN_PRAGMAS \
+	WINPR_DO_PRAGMA(clang diagnostic ignored "-Wunknown-pragmas") /** @since version 3.10.0 */
 
 #if __clang_major__ >= 13
 #define WINPR_PRAGMA_DIAG_IGNORED_RESERVED_IDENTIFIER \
-	_Pragma("clang diagnostic ignored \"-Wreserved-identifier\"")
+	WINPR_DO_PRAGMA(clang diagnostic ignored "-Wreserved-identifier")
 #else
 #define WINPR_PRAGMA_DIAG_IGNORED_RESERVED_IDENTIFIER
 #endif
 
 #define WINPR_PRAGMA_DIAG_IGNORED_ATOMIC_SEQ_CST \
-	_Pragma("clang diagnostic ignored \"-Watomic-implicit-seq-cst\"")
+	WINPR_DO_PRAGMA(clang diagnostic ignored "-Watomic-implicit-seq-cst")
 #define WINPR_PRAGMA_DIAG_IGNORED_UNUSED_CONST_VAR \
-	_Pragma("clang diagnostic ignored \"-Wunused-const-variable\"")
+	WINPR_DO_PRAGMA(clang diagnostic ignored "-Wunused-const-variable")
 #define WINPR_PRAGMA_DIAG_IGNORED_FORMAT_SECURITY \
-	_Pragma("clang diagnostic ignored \"-Wformat-security\"")
-#define WINPR_PRAGMA_DIAG_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE                                \
-	_Pragma("clang diagnostic ignored \"-Wtautological-constant-out-of-range-compare\"") /** @since \
-	                                                                                        version \
-	                                                                                        3.9.0   \
-	                                                                                      */
+	WINPR_DO_PRAGMA(clang diagnostic ignored "-Wformat-security")
+#define WINPR_PRAGMA_DIAG_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE           \
+	WINPR_DO_PRAGMA(clang diagnostic ignored                                   \
+	                "-Wtautological-constant-out-of-range-compare") /** @since \
+	                                                               version     \
+	                                                               3.9.0       \
+	                                                             */
 #if __clang_major__ >= 12
-#define WINPR_PRAGMA_DIAG_TAUTOLOGICAL_VALUE_RANGE_COMPARE                            \
-	_Pragma(                                                                          \
-	    "clang diagnostic ignored \"-Wtautological-value-range-compare\"") /** @since \
-	                                                                          version 3.10.0 */
+#define WINPR_PRAGMA_DIAG_TAUTOLOGICAL_VALUE_RANGE_COMPARE           \
+	WINPR_DO_PRAGMA(clang diagnostic ignored                         \
+	                "-Wtautological-value-range-compare") /** @since \
+	                                                             version 3.10.0 */
 #else
 #define WINPR_PRAGMA_DIAG_TAUTOLOGICAL_VALUE_RANGE_COMPARE
 #endif
 
 #define WINPR_PRAGMA_DIAG_IGNORED_FORMAT_NONLITERAL \
-	_Pragma("clang diagnostic ignored \"-Wformat-nonliteral\"") /** @since version 3.9.0 */
+	WINPR_DO_PRAGMA(clang diagnostic ignored "-Wformat-nonliteral") /** @since version 3.9.0 */
 #define WINPR_PRAGMA_DIAG_IGNORED_MISMATCHED_DEALLOC /** @since version 3.3.0 */ /* not supported \
-    _Pragma("clang diagnostic ignored \"-Wmismatched-dealloc\"") */
-#define WINPR_PRAGMA_DIAG_POP _Pragma("clang diagnostic pop")
-#define WINPR_PRAGMA_UNROLL_LOOP \
-	_Pragma("clang loop vectorize_width(8) interleave_count(8)") /** @since version 3.6.0 */
+    WINPR_DO_PRAGMA(clang diagnostic ignored "-Wmismatched-dealloc") */
+#define WINPR_PRAGMA_DIAG_POP WINPR_DO_PRAGMA(clang diagnostic pop)
+#define WINPR_PRAGMA_UNROLL_LOOP                                                          \
+	_Pragma("clang loop vectorize_width(8) interleave_count(8)") /** @since version 3.6.0 \
+	                                                              */
 #elif defined(__GNUC__)
-#define WINPR_PRAGMA_DIAG_PUSH _Pragma("GCC diagnostic push")
+#define WINPR_PRAGMA_DIAG_PUSH WINPR_DO_PRAGMA(GCC diagnostic push)
 #define WINPR_PRAGMA_DIAG_IGNORED_OVERLENGTH_STRINGS \
-	_Pragma("GCC diagnostic ignored \"-Woverlength-strings\"") /** @since version 3.9.0 */
+	WINPR_DO_PRAGMA(GCC diagnostic ignored "-Woverlength-strings") /** @since version 3.9.0 */
 #define WINPR_PRAGMA_DIAG_IGNORED_QUALIFIERS \
-	_Pragma("GCC diagnostic ignored \"-Wdiscarded-qualifiers\"") /** @since version 3.9.0 */
-#define WINPR_PRAGMA_DIAG_IGNORED_PEDANTIC _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+	WINPR_DO_PRAGMA(GCC diagnostic ignored "-Wdiscarded-qualifiers") /** @since version 3.9.0 */
+#define WINPR_PRAGMA_DIAG_IGNORED_PEDANTIC WINPR_DO_PRAGMA(GCC diagnostic ignored "-Wpedantic")
 #define WINPR_PRAGMA_DIAG_IGNORED_MISSING_PROTOTYPES \
-	_Pragma("GCC diagnostic ignored \"-Wmissing-prototypes\"")
+	WINPR_DO_PRAGMA(GCC diagnostic ignored "-Wmissing-prototypes")
 #define WINPR_PRAGMA_DIAG_IGNORED_STRICT_PROTOTYPES \
-	_Pragma("GCC diagnostic ignored \"-Wstrict-prototypes\"")
-#define WINPR_PRAGMA_DIAG_IGNORED_RESERVED_ID_MACRO /* not supported _Pragma("GCC diagnostic \
-                                                       ignored \"-Wreserved-id-macro\"") */
-#define WINPR_PRAGMA_DIAG_IGNORED_UNUSED_MACRO _Pragma("GCC diagnostic ignored \"-Wunused-macros\"")
+	WINPR_DO_PRAGMA(GCC diagnostic ignored "-Wstrict-prototypes")
+#define WINPR_PRAGMA_DIAG_IGNORED_RESERVED_ID_MACRO /* not supported WINPR_DO_PRAGMA(GCC         \
+                                                       diagnostic ignored "-Wreserved-id-macro") \
+                                                     */
+#define WINPR_PRAGMA_DIAG_IGNORED_UNUSED_MACRO \
+	WINPR_DO_PRAGMA(GCC diagnostic ignored "-Wunused-macros")
+#define WINPR_PRAGMA_DIAG_IGNORED_UNKNOWN_PRAGMAS \
+	WINPR_DO_PRAGMA(GCC diagnostic ignored "-Wunknown-pragmas") /** @since version 3.10.0 */
+
 #define WINPR_PRAGMA_DIAG_IGNORED_RESERVED_IDENTIFIER
-/* not supported	_Pragma("GCC diagnostic ignored \"-Wreserved-identifier\"") */
-#define WINPR_PRAGMA_DIAG_IGNORED_ATOMIC_SEQ_CST    /* not supported	_Pragma("GCC diagnostic \
-                                                       ignored                               \
-                                                       \"-Watomic-implicit-seq-cst\"") */
+/* not supported	WINPR_DO_PRAGMA(GCC diagnostic ignored "-Wreserved-identifier") */
+#define WINPR_PRAGMA_DIAG_IGNORED_ATOMIC_SEQ_CST /* not supported	WINPR_DO_PRAGMA(GCC diagnostic \
+                                                    ignored                                      \
+                                                    "-Watomic-implicit-seq-cst") */
 #define WINPR_PRAGMA_DIAG_IGNORED_UNUSED_CONST_VAR \
-	_Pragma("GCC diagnostic ignored \"-Wunused-const-variable\"")
+	WINPR_DO_PRAGMA(GCC diagnostic ignored "-Wunused-const-variable")
 #define WINPR_PRAGMA_DIAG_IGNORED_FORMAT_SECURITY \
-	_Pragma("GCC diagnostic ignored \"-Wformat-security\"")
+	WINPR_DO_PRAGMA(GCC diagnostic ignored "-Wformat-security")
 #define WINPR_PRAGMA_DIAG_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE /* not supported
-	_Pragma("GCC diagnostic ignored \"-Wtautological-constant-out-of-range-compare\"") */ /** @since version 3.9.0 */
+    WINPR_DO_PRAGMA(GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare") */ /** @since version 3.9.0 */
 #define WINPR_PRAGMA_DIAG_TAUTOLOGICAL_VALUE_RANGE_COMPARE /* not supported
-	_Pragma("GCC diagnostic ignored \"-Wtautological-value-range-compare\"") */ /** @since version 3.10.0 */
+    WINPR_DO_PRAGMA(GCC diagnostic ignored "-Wtautological-value-range-compare") */ /** @since version 3.10.0 */
 #define WINPR_PRAGMA_DIAG_IGNORED_FORMAT_NONLITERAL \
-	_Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"") /** @since version 3.9.0 */
+	WINPR_DO_PRAGMA(GCC diagnostic ignored "-Wformat-nonliteral") /** @since version 3.9.0 */
 #if __GNUC__ >= 11
 #define WINPR_PRAGMA_DIAG_IGNORED_MISMATCHED_DEALLOC \
-	_Pragma("GCC diagnostic ignored \"-Wmismatched-dealloc\"") /** @since version 3.3.0 */
+	WINPR_DO_PRAGMA(GCC diagnostic ignored "-Wmismatched-dealloc") /** @since version 3.3.0 */
 #else
 #define WINPR_PRAGMA_DIAG_IGNORED_MISMATCHED_DEALLOC
 #endif
-#define WINPR_PRAGMA_DIAG_POP _Pragma("GCC diagnostic pop")
+#define WINPR_PRAGMA_DIAG_POP WINPR_DO_PRAGMA(GCC diagnostic pop)
 #define WINPR_PRAGMA_UNROLL_LOOP \
-	_Pragma("GCC unroll 8") _Pragma("GCC ivdep") /** @since version 3.6.0 */
+	WINPR_DO_PRAGMA(GCC unroll 8) WINPR_DO_PRAGMA(GCC ivdep) /** @since version 3.6.0 */
 #else
 #define WINPR_PRAGMA_DIAG_PUSH
 #define WINPR_PRAGMA_DIAG_IGNORED_PEDANTIC
@@ -156,6 +174,7 @@
 #define WINPR_PRAGMA_DIAG_IGNORED_STRICT_PROTOTYPES
 #define WINPR_PRAGMA_DIAG_IGNORED_RESERVED_ID_MACRO
 #define WINPR_PRAGMA_DIAG_IGNORED_UNUSED_MACRO
+#define WINPR_PRAGMA_DIAG_IGNORED_UNKNOWN_PRAGMAS /** @since version 3.10.0 */
 #define WINPR_PRAGMA_DIAG_IGNORED_RESERVED_IDENTIFIER
 #define WINPR_PRAGMA_DIAG_IGNORED_ATOMIC_SEQ_CST
 #define WINPR_PRAGMA_DIAG_IGNORED_UNUSED_CONST_VAR
@@ -170,7 +189,7 @@
 
 #if defined(MSVC)
 #undef WINPR_PRAGMA_UNROLL_LOOP
-#define WINPR_PRAGMA_UNROLL_LOOP _Pragma("loop ( ivdep )") /** @since version 3.6.0 */
+#define WINPR_PRAGMA_UNROLL_LOOP WINPR_DO_PRAGMA(loop(ivdep)) /** @since version 3.6.0 */
 #endif
 
 WINPR_PRAGMA_DIAG_PUSH

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -916,6 +916,34 @@ extern "C"
 		*_s->pointer++ = (_v) & 0xFF;
 	}
 
+#define Stream_Write_INT16_BE(s, v)                \
+	do                                             \
+	{                                              \
+		WINPR_ASSERT((v) <= INT16_MAX);            \
+		WINPR_ASSERT((v) >= INT16_MIN);            \
+		Stream_Write_INT16_BE_unchecked((s), (v)); \
+	} while (0)
+
+	/** @brief writes a \b UINT16 as \b big endian to a \b wStream. The stream must be large enough
+	 * to hold the data.
+	 *
+	 * Do not use directly, use the define @ref Stream_Write_UINT16_BE instead
+	 *
+	 * \param _s The stream to write to, must not be \b NULL
+	 * \param _v The value to write
+	 *
+	 * @since version 3.10.0
+	 */
+	static INLINE void Stream_Write_INT16_BE_unchecked(wStream* _s, INT16 _v)
+	{
+		WINPR_ASSERT(_s);
+		WINPR_ASSERT(_s->pointer);
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 2);
+
+		*_s->pointer++ = ((_v) >> 8) & 0xFF;
+		*_s->pointer++ = (_v) & 0xFF;
+	}
+
 #define Stream_Write_UINT24_BE(s, v)                \
 	do                                              \
 	{                                               \
@@ -966,6 +994,40 @@ extern "C"
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 4);
 
+		*_s->pointer++ = (_v) & 0xFF;
+		*_s->pointer++ = ((_v) >> 8) & 0xFF;
+		*_s->pointer++ = ((_v) >> 16) & 0xFF;
+		*_s->pointer++ = ((_v) >> 24) & 0xFF;
+	}
+
+#define Stream_Write_INT32_BE(s, v)                \
+	do                                             \
+	{                                              \
+		WINPR_ASSERT((v) <= INT32_MAX);            \
+		WINPR_ASSERT((v) >= INT32_MIN);            \
+		Stream_Write_INT32_BE_unchecked((s), (v)); \
+	} while (0)
+
+	/** @brief writes a \b INT32 as \b little endian to a \b wStream. The stream must be large
+	 * enough to hold the data.
+	 *
+	 * Do not use directly, use the define @ref Stream_Write_INT32 instead
+	 *
+	 * \param _s The stream to write to, must not be \b NULL
+	 * \param _v The value to write
+	 *
+	 * @since version 3.10.0
+	 */
+	static INLINE void Stream_Write_INT32_BE_unchecked(wStream* _s, INT32 _v)
+	{
+		WINPR_ASSERT(_s);
+		WINPR_ASSERT(_s->pointer);
+		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 4);
+
+		*_s->pointer++ = (_v) & 0xFF;
+		*_s->pointer++ = ((_v) >> 8) & 0xFF;
+		*_s->pointer++ = ((_v) >> 16) & 0xFF;
+		*_s->pointer++ = ((_v) >> 24) & 0xFF;
 		*_s->pointer++ = (_v) & 0xFF;
 		*_s->pointer++ = ((_v) >> 8) & 0xFF;
 		*_s->pointer++ = ((_v) >> 16) & 0xFF;

--- a/winpr/libwinpr/crt/test/TestFormatSpecifiers.c
+++ b/winpr/libwinpr/crt/test/TestFormatSpecifiers.c
@@ -48,9 +48,8 @@ int TestFormatSpecifiers(int argc, char* argv[])
 		UINT8 arg = 0xFE;
 		const char* chk = "u8:254 o8:376 x8:fe X8:FE";
 
-		(void)(void)sprintf_s(fmt, sizeof(fmt),
-		                      "u8:%" PRIu8 " o8:%" PRIo8 " x8:%" PRIx8 " X8:%" PRIX8 "", arg, arg,
-		                      arg, arg);
+		(void)sprintf_s(fmt, sizeof(fmt), "u8:%" PRIu8 " o8:%" PRIo8 " x8:%" PRIx8 " X8:%" PRIX8 "",
+		                arg, arg, arg, arg);
 
 		if (strcmp(fmt, chk) != 0)
 		{

--- a/winpr/libwinpr/crypto/cipher.c
+++ b/winpr/libwinpr/crypto/cipher.c
@@ -462,6 +462,8 @@ static const EVP_CIPHER* winpr_openssl_get_evp_cipher(WINPR_CIPHER_TYPE cipher)
 		case WINPR_CIPHER_BLOWFISH_CTR:
 			evp = EVP_get_cipherbyname("blowfish-ctr");
 			break;
+		default:
+			break;
 	}
 
 	return evp;

--- a/winpr/libwinpr/smartcard/smartcard.c
+++ b/winpr/libwinpr/smartcard/smartcard.c
@@ -1100,7 +1100,7 @@ WINSCARDAPI char* WINAPI SCardGetReaderStateString(DWORD dwReaderState)
 	return buffer;
 }
 
-#define WINSCARD_LOAD_PROC(_name, ...)                                                         \
+#define WINSCARD_LOAD_PROC(_name)                                                              \
 	do                                                                                         \
 	{                                                                                          \
 		WINPR_PRAGMA_DIAG_PUSH                                                                 \

--- a/winpr/libwinpr/smartcard/smartcard_pcsc.c
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.c
@@ -48,7 +48,7 @@
 #include "../log.h"
 #define TAG WINPR_TAG("smartcard")
 
-#define WINSCARD_LOAD_PROC_EX(module, pcsc, _fname, _name, ...)              \
+#define WINSCARD_LOAD_PROC_EX(module, pcsc, _fname, _name)                   \
 	do                                                                       \
 	{                                                                        \
 		WINPR_PRAGMA_DIAG_PUSH                                               \
@@ -57,8 +57,7 @@
 		WINPR_PRAGMA_DIAG_POP                                                \
 	} while (0)
 
-#define WINSCARD_LOAD_PROC(module, pcsc, _name, ...) \
-	WINSCARD_LOAD_PROC_EX(module, pcsc, _name, _name, ##__VA_ARGS__)
+#define WINSCARD_LOAD_PROC(module, pcsc, _name) WINSCARD_LOAD_PROC_EX(module, pcsc, _name, _name)
 
 /**
  * PC/SC transactions:

--- a/winpr/libwinpr/synch/test/TestSynchAPC.c
+++ b/winpr/libwinpr/synch/test/TestSynchAPC.c
@@ -78,7 +78,7 @@ static VOID CALLBACK Timer2APCProc(LPVOID lpArg, DWORD dwTimerLowValue, DWORD dw
 
 static DWORD /*WINAPI*/ closeHandleTest(LPVOID lpThreadParameter)
 {
-	LARGE_INTEGER dueTime;
+	LARGE_INTEGER dueTime = { 0 };
 	UncleanCloseData* data = (UncleanCloseData*)lpThreadParameter;
 	data->endTest = FALSE;
 

--- a/winpr/libwinpr/synch/test/TestSynchWaitableTimer.c
+++ b/winpr/libwinpr/synch/test/TestSynchWaitableTimer.c
@@ -7,7 +7,7 @@ int TestSynchWaitableTimer(int argc, char* argv[])
 	DWORD status = 0;
 	HANDLE timer = NULL;
 	LONG period = 0;
-	LARGE_INTEGER due;
+	LARGE_INTEGER due = { 0 };
 	int result = -1;
 	WINPR_UNUSED(argc);
 	WINPR_UNUSED(argv);

--- a/winpr/libwinpr/synch/test/TestSynchWaitableTimerAPC.c
+++ b/winpr/libwinpr/synch/test/TestSynchWaitableTimerAPC.c
@@ -38,7 +38,7 @@ int TestSynchWaitableTimerAPC(int argc, char* argv[])
 	DWORD rc = 0;
 	HANDLE hTimer = NULL;
 	BOOL bSuccess = 0;
-	LARGE_INTEGER due;
+	LARGE_INTEGER due = { 0 };
 	APC_DATA apcData = { 0 };
 	WINPR_UNUSED(argc);
 	WINPR_UNUSED(argv);

--- a/winpr/libwinpr/sysinfo/sysinfo.c
+++ b/winpr/libwinpr/sysinfo/sysinfo.c
@@ -1001,8 +1001,8 @@ BOOL IsProcessorFeaturePresent(DWORD ProcessorFeature)
 DWORD GetTickCountPrecise(void)
 {
 #ifdef _WIN32
-	LARGE_INTEGER freq;
-	LARGE_INTEGER current;
+	LARGE_INTEGER freq = { 0 };
+	LARGE_INTEGER current = { 0 };
 	QueryPerformanceFrequency(&freq);
 	QueryPerformanceCounter(&current);
 	return (DWORD)(current.QuadPart * 1000LL / freq.QuadPart);

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -553,7 +553,7 @@ exit:
 
 		set_event(thread);
 
-		signal_thread_ready(thread);
+		(void)signal_thread_ready(thread);
 
 		if (thread->detached || !thread->started)
 			cleanup_handle(thread);

--- a/winpr/libwinpr/timezone/TimeZoneIanaAbbrevMap.c
+++ b/winpr/libwinpr/timezone/TimeZoneIanaAbbrevMap.c
@@ -81,7 +81,7 @@ static void append_timezone(const char* dir, const char* name)
 	tzset();
 	const time_t t = time(NULL);
 	struct tm lt = { 0 };
-	localtime_r(&t, &lt);
+	(void)localtime_r(&t, &lt);
 	append(tz, lt.tm_zone);
 	if (oldtz)
 	{

--- a/winpr/libwinpr/timezone/timezone.c
+++ b/winpr/libwinpr/timezone/timezone.c
@@ -393,7 +393,7 @@ static struct tm next_day(const struct tm* start)
 	cur.tm_isdst = -1;
 	cur.tm_mday++;
 	const time_t t = mktime(&cur);
-	localtime_r(&t, &cur);
+	(void)localtime_r(&t, &cur);
 	return cur;
 }
 
@@ -405,7 +405,7 @@ static struct tm adjust_time(const struct tm* start, int hour, int minute)
 	cur.tm_sec = 0;
 	cur.tm_isdst = -1;
 	const time_t t = mktime(&cur);
-	localtime_r(&t, &cur);
+	(void)localtime_r(&t, &cur);
 	return cur;
 }
 
@@ -426,7 +426,7 @@ static WORD get_transition_weekday_occurrence(const SYSTEMTIME* st)
 		next.tm_mday++;
 
 		struct tm cur = { 0 };
-		localtime_r(&t, &cur);
+		(void)localtime_r(&t, &cur);
 
 		if (cur.tm_mon + 1 != st->wMonth)
 			break;

--- a/winpr/libwinpr/utils/wlog/JournaldAppender.c
+++ b/winpr/libwinpr/utils/wlog/JournaldAppender.c
@@ -112,8 +112,12 @@ static BOOL WLog_JournaldAppender_WriteMessage(wLog* log, wLogAppender* appender
 	WLog_Layout_GetMessagePrefix(log, appender->Layout, message);
 
 	if (message->Level != WLOG_OFF)
-		(void)fprintf(journaldAppender->stream, formatStr, message->PrefixString,
-		              message->TextString);
+	{
+		WINPR_PRAGMA_DIAG_PUSH
+		WINPR_PRAGMA_DIAG_IGNORED_FORMAT_NONLITERAL(void)
+		fprintf(journaldAppender->stream, formatStr, message->PrefixString, message->TextString);
+		WINPR_PRAGMA_DIAG_POP
+	}
 	return TRUE;
 }
 


### PR DESCRIPTION
* fix `wStream` usage, write signed integers where required
* Add missing `wStream` functions
* fix `_Pragma` use, wrap in a macro as `MSVC` not always defines this standard C keyword...
* fix C++ move constructors, prefer `default` implementation to avoid `use after move`
* fix some missing casts