### PR TITLE
[core,primitive] fix rgb primitive copy without conversion.

### DIFF
--- a/libfreerdp/primitives/prim_copy.c
+++ b/libfreerdp/primitives/prim_copy.c
@@ -309,6 +309,23 @@ static INLINE pstatus_t generic_image_copy_no_overlap_dst_alpha(
 					break;
 			}
 			break;
+		case PIXEL_FORMAT_RGBX32:
+		case PIXEL_FORMAT_RGBA32:
+			switch (DstFormat)
+			{
+				case PIXEL_FORMAT_RGBX32:
+				case PIXEL_FORMAT_RGBA32:
+					return generic_image_copy_bgrx32_bgrx32(
+					    pDstData, nDstStep, nXDst, nYDst, nWidth, nHeight, pSrcData, nSrcStep,
+					    nXSrc, nYSrc, srcVMultiplier, srcVOffset, dstVMultiplier, dstVOffset);
+				case PIXEL_FORMAT_RGB24:
+					return generic_image_copy_bgr24_bgrx32(
+					    pDstData, nDstStep, nXDst, nYDst, nWidth, nHeight, pSrcData, nSrcStep,
+					    nXSrc, nYSrc, srcVMultiplier, srcVOffset, dstVMultiplier, dstVOffset);
+				default:
+					break;
+			}
+			break;
 		default:
 			break;
 	}

--- a/libfreerdp/primitives/sse/prim_copy_avx2.c
+++ b/libfreerdp/primitives/sse/prim_copy_avx2.c
@@ -196,6 +196,19 @@ static pstatus_t avx2_image_copy_no_overlap_dst_alpha(
 					break;
 			}
 			break;
+		case PIXEL_FORMAT_RGBX32:
+		case PIXEL_FORMAT_RGBA32:
+			switch (DstFormat)
+			{
+				case PIXEL_FORMAT_RGBX32:
+				case PIXEL_FORMAT_RGBA32:
+					return avx2_image_copy_bgrx32_bgrx32(
+					    pDstData, nDstStep, nXDst, nYDst, nWidth, nHeight, pSrcData, nSrcStep,
+					    nXSrc, nYSrc, srcVMultiplier, srcVOffset, dstVMultiplier, dstVOffset);
+				default:
+					break;
+			}
+			break;
 		default:
 			break;
 	}

--- a/libfreerdp/primitives/sse/prim_copy_sse4_1.c
+++ b/libfreerdp/primitives/sse/prim_copy_sse4_1.c
@@ -180,6 +180,19 @@ static pstatus_t sse_image_copy_no_overlap_dst_alpha(
 					break;
 			}
 			break;
+		case PIXEL_FORMAT_RGBX32:
+		case PIXEL_FORMAT_RGBA32:
+			switch (DstFormat)
+			{
+				case PIXEL_FORMAT_RGBX32:
+				case PIXEL_FORMAT_RGBA32:
+					return sse_image_copy_bgrx32_bgrx32(
+					    pDstData, nDstStep, nXDst, nYDst, nWidth, nHeight, pSrcData, nSrcStep,
+					    nXSrc, nYSrc, srcVMultiplier, srcVOffset, dstVMultiplier, dstVOffset);
+				default:
+					break;
+			}
+			break;
 		default:
 			break;
 	}


### PR DESCRIPTION
Use existing BGRx copy function to support RGBx copy because there is no conversion and the color order does not actually matter. This change will preserve the alpha channel when using RGBx as surface pixel format.