### PR TITLE
[channels,rdpdr] send only used caps to server

### DIFF
--- a/channels/rdpdr/client/rdpdr_main.h
+++ b/channels/rdpdr/client/rdpdr_main.h
@@ -113,6 +113,7 @@ typedef struct
 	wStreamPool* pool;
 	wLog* log;
 	BOOL async;
+	BOOL capabilities[6];
 } rdpdrPlugin;
 
 BOOL rdpdr_state_advance(rdpdrPlugin* rdpdr, enum RDPDR_CHANNEL_STATE next);


### PR DESCRIPTION
When using RDPDR only send capabilities to server we have activated, e.g. smartcard, drive, printer, port (serial or parallel) redirection