### PR TITLE
[ci] update upload-artifact action to version 4

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -37,7 +37,7 @@ jobs:
           dry-run: false
           sanitizer: ${{ matrix.sanitizer }}
       - name: Upload crash
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.6
         if: failure() && steps.build.outcome == 'success'
         with:
           name: ${{ matrix.sanitizer }}-artifacts


### PR DESCRIPTION
upload-artifact@v3 will be deprecated in December 2024

https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/