### PR TITLE
[cmake,gcc,clang] use -fmacro-prefix-map and -ffile-prefix-map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,10 +239,6 @@ if(CMAKE_COMPILER_IS_GNUCC)
 	endif()
 endif()
 
-if(CMAKE_COMPILER_IS_CLANG)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-c11-extensions -Wno-gnu")
-endif()
-
 set(THREAD_PREFER_PTHREAD_FLAG TRUE)
 
 if(NOT IOS)
@@ -251,12 +247,6 @@ endif()
 
 # Enable address sanitizer, where supported and when required
 if(CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNUCC)
-	CHECK_C_COMPILER_FLAG ("-fno-omit-frame-pointer" fno-omit-frame-pointer)
-
-	if (fno-omit-frame-pointer)
-		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer")
-	endif()
-
 	set(CMAKE_REQUIRED_LINK_OPTIONS_SAVED ${CMAKE_REQUIRED_LINK_OPTIONS})
 	file(WRITE ${PROJECT_BINARY_DIR}/foo.txt "")
 	if(WITH_SANITIZE_ADDRESS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,18 +239,6 @@ if(CMAKE_COMPILER_IS_GNUCC)
 	endif()
 endif()
 
-# When building with Unix Makefiles and doing any release builds
-# try to set __FILE__ to relative paths via a make specific macro
-if (CMAKE_GENERATOR MATCHES "Unix Makefile*")
-	if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-		string(TOUPPER ${CMAKE_BUILD_TYPE} UPPER_BUILD_TYPE)
-		CHECK_C_COMPILER_FLAG (-Wno-builtin-macro-redefined Wno-builtin-macro-redefined)
-		if(Wno-builtin-macro-redefined)
-			set(CMAKE_C_FLAGS_${UPPER_BUILD_TYPE} "${CMAKE_C_FLAGS_${UPPER_BUILD_TYPE}} -Wno-builtin-macro-redefined -D__FILE__='\"$(subst ${PROJECT_BINARY_DIR}/,,$(subst ${PROJECT_SOURCE_DIR}/,,$(abspath $<)))\"'")
-		endif()
-	endif()
-endif()
-
 if(CMAKE_COMPILER_IS_CLANG)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-c11-extensions -Wno-gnu")
 endif()

--- a/cmake/CFlagsToVar.cmake
+++ b/cmake/CFlagsToVar.cmake
@@ -1,5 +1,8 @@
 function(CFlagsToVar NAME)
 	set(C_FLAGS ${CMAKE_C_FLAGS})
+	string(REPLACE "${CMAKE_SOURCE_DIR}" "<src dir>" C_FLAGS "${C_FLAGS}")
+	string(REPLACE "${CMAKE_BINARY_DIR}" "<build dir>" C_FLAGS "${C_FLAGS}")
+
 	if (CMAKE_BUILD_TYPE)
 	    string(TOUPPER "${CMAKE_BUILD_TYPE}" CAPS_BUILD_TYPE)
 	    string(APPEND C_FLAGS " ${CMAKE_C_FLAGS_${CAPS_BUILD_TYPE}}")

--- a/cmake/CXXCompilerFlags.cmake
+++ b/cmake/CXXCompilerFlags.cmake
@@ -61,6 +61,11 @@ if (ENABLE_WARNING_ERROR)
 	CheckCXXFlag(-Werror)
 endif()
 
+CheckCXXFlag(-fmacro-prefix-map="${CMAKE_SOURCE_DIR}"="./")
+CheckCXXFlag(-fmacro-prefix-map="${CMAKE_BINARY_DIR}"="./build/")
+CheckCXXFlag(-ffile-prefix-map="${CMAKE_SOURCE_DIR}"="./")
+CheckCXXFlag(-ffile-prefix-map="${CMAKE_BINARY_DIR}"="./build")
+
 # https://stackoverflow.com/questions/4913922/possible-problems-with-nominmax-on-visual-c
 if (WIN32)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-DNOMINMAX>)

--- a/cmake/CXXCompilerFlags.cmake
+++ b/cmake/CXXCompilerFlags.cmake
@@ -48,6 +48,7 @@ if (ENABLE_WARNING_VERBOSE)
 			-Wno-c++98-compat-pedantic
 			-Wno-pre-c++17-compat
 			-Wno-exit-time-destructors
+			-Wno-gnu-zero-variadic-macro-arguments
 		)
 	endif()
 
@@ -60,6 +61,8 @@ endif()
 if (ENABLE_WARNING_ERROR)
 	CheckCXXFlag(-Werror)
 endif()
+
+CheckCXXFlag(-fno-omit-frame-pointer)
 
 CheckCXXFlag(-fmacro-prefix-map="${CMAKE_SOURCE_DIR}"="./")
 CheckCXXFlag(-fmacro-prefix-map="${CMAKE_BINARY_DIR}"="./build/")

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -43,7 +43,8 @@ if (ENABLE_WARNING_VERBOSE)
 			-Wno-reserved-identifier
 			-Wno-covered-switch-default
 			-Wno-disabled-macro-expansion
-            -Wno-pre-c11-compat
+			-Wno-pre-c11-compat
+			-Wno-gnu-zero-variadic-macro-arguments
 		)
 	endif()
 
@@ -55,6 +56,8 @@ endif()
 if (ENABLE_WARNING_ERROR)
 	CheckCFlag(-Werror)
 endif()
+
+CheckCFlag(-fno-omit-frame-pointer)
 
 CheckCFlag(-fmacro-prefix-map="${CMAKE_SOURCE_DIR}"="./")
 CheckCFlag(-fmacro-prefix-map="${CMAKE_BINARY_DIR}"="./build/")

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -52,10 +52,14 @@ if (ENABLE_WARNING_VERBOSE)
 	endforeach()
 endif()
 
-
 if (ENABLE_WARNING_ERROR)
 	CheckCFlag(-Werror)
 endif()
+
+CheckCFlag(-fmacro-prefix-map="${CMAKE_SOURCE_DIR}"="./")
+CheckCFlag(-fmacro-prefix-map="${CMAKE_BINARY_DIR}"="./build/")
+CheckCFlag(-ffile-prefix-map="${CMAKE_SOURCE_DIR}"="./")
+CheckCFlag(-ffile-prefix-map="${CMAKE_BINARY_DIR}"="./build")
 
 set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} CACHE STRING "default CFLAGS")
 message("Using CFLAGS ${CMAKE_C_FLAGS}")


### PR DESCRIPTION
Instead of some bash path substitution only working with Makefiles use the compiler options to map source and build directories to some defaults