### PR TITLE
[cmake] workaround for older GCC

### DIFF
--- a/cmake/CXXCompilerFlags.cmake
+++ b/cmake/CXXCompilerFlags.cmake
@@ -74,5 +74,10 @@ if (WIN32)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-DNOMINMAX>)
 endif()
 
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431
+if (CMAKE_COMPILER_IS_GNUCC AND (CMAKE_CXX_COMPILER_VERSION LESS 13))
+	CheckCFlag(-Wno-unknown-pragmas)
+endif()
+
 set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} CACHE STRING "default CXXFLAGS")
 message("Using CXXFLAGS ${CMAKE_CXX_FLAGS}")

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -57,6 +57,11 @@ if (ENABLE_WARNING_ERROR)
 	CheckCFlag(-Werror)
 endif()
 
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431
+if (CMAKE_COMPILER_IS_GNUCC AND (CMAKE_C_COMPILER_VERSION LESS 13))
+	CheckCFlag(-Wno-unknown-pragmas)
+endif()
+
 CheckCFlag(-fno-omit-frame-pointer)
 
 CheckCFlag(-fmacro-prefix-map="${CMAKE_SOURCE_DIR}"="./")

--- a/winpr/libwinpr/crt/string.c
+++ b/winpr/libwinpr/crt/string.c
@@ -199,12 +199,12 @@ int winpr_vasprintf(char** s, size_t* slen, WINPR_FORMAT_ARG const char* templ, 
 	if (length < 0)
 		return length;
 
-	char* str = calloc((size_t)length + 1ul, sizeof(char));
+	char* str = calloc((size_t)length + 1UL, sizeof(char));
 	if (!str)
 		return -1;
 
 	va_copy(ap, oap);
-	const int plen = vsnprintf(str, (size_t)length, templ, ap);
+	const int plen = vsnprintf(str, (size_t)length + 1UL, templ, ap);
 	va_end(ap);
 
 	if (length != plen)

--- a/winpr/libwinpr/crt/test/TestString.c
+++ b/winpr/libwinpr/crt/test/TestString.c
@@ -1,6 +1,7 @@
 
 #include <stdio.h>
 #include <winpr/crt.h>
+#include <winpr/string.h>
 #include <winpr/windows.h>
 
 static const CHAR testStringA[] = { 'T', 'h', 'e', ' ', 'q', 'u', 'i', 'c', 'k', ' ', 'b',
@@ -78,6 +79,31 @@ static BOOL test_url_escape(void)
 	return TRUE;
 }
 
+static BOOL test_winpr_asprintf(void)
+{
+	BOOL rc = FALSE;
+	const char test[] = "test string case";
+	const size_t len = strnlen(test, sizeof(test));
+
+	char* str = NULL;
+	size_t slen = 0;
+	const int res = winpr_asprintf(&str, &slen, "%s", test);
+	if (!str)
+		goto fail;
+	if (res < 0)
+		goto fail;
+	if ((size_t)res != len)
+		goto fail;
+	if (len != slen)
+		goto fail;
+	if (strnlen(str, slen + 10) != slen)
+		goto fail;
+	rc = TRUE;
+fail:
+	free(str);
+	return rc;
+}
+
 int TestString(int argc, char* argv[])
 {
 	const WCHAR* p = NULL;
@@ -87,6 +113,9 @@ int TestString(int argc, char* argv[])
 
 	WINPR_UNUSED(argc);
 	WINPR_UNUSED(argv);
+
+	if (!test_winpr_asprintf())
+		return -1;
 
 	if (!test_url_escape())
 		return -1;


### PR DESCRIPTION
To fix the missing pragma -Wunknown-pragmas support for older GCC disable this warning altogether if such a compiler is detected