### PR TITLE
[cmake] prefer relative paths for debug symbols

### DIFF
--- a/cmake/CXXCompilerFlags.cmake
+++ b/cmake/CXXCompilerFlags.cmake
@@ -64,10 +64,14 @@ endif()
 
 CheckCXXFlag(-fno-omit-frame-pointer)
 
-CheckCXXFlag(-fmacro-prefix-map="${CMAKE_SOURCE_DIR}"="./")
-CheckCXXFlag(-fmacro-prefix-map="${CMAKE_BINARY_DIR}"="./build/")
-CheckCXXFlag(-ffile-prefix-map="${CMAKE_SOURCE_DIR}"="./")
-CheckCXXFlag(-ffile-prefix-map="${CMAKE_BINARY_DIR}"="./build")
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+		add_compile_options($<$<NOT:$<CONFIG:Debug>>:-fdebug-prefix-map=${CMAKE_SOURCE_DIR}=.>)
+		add_compile_options($<$<NOT:$<CONFIG:Debug>>:-fmacro-prefix-map=${CMAKE_SOURCE_DIR}=.>)
+		add_compile_options($<$<NOT:$<CONFIG:Debug>>:-ffile-prefix-map=${CMAKE_SOURCE_DIR}=.>)
+		add_compile_options($<$<NOT:$<CONFIG:Debug>>:-fdebug-prefix-map=${CMAKE_BINARY_DIR}=./build>)
+		add_compile_options($<$<NOT:$<CONFIG:Debug>>:-fmacro-prefix-map=${CMAKE_BINARY_DIR}=./build>)
+		add_compile_options($<$<NOT:$<CONFIG:Debug>>:-ffile-prefix-map=${CMAKE_BINARY_DIR}=./build>)
+endif()
 
 # https://stackoverflow.com/questions/4913922/possible-problems-with-nominmax-on-visual-c
 if (WIN32)

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -64,10 +64,14 @@ endif()
 
 CheckCFlag(-fno-omit-frame-pointer)
 
-CheckCFlag(-fmacro-prefix-map="${CMAKE_SOURCE_DIR}"="./")
-CheckCFlag(-fmacro-prefix-map="${CMAKE_BINARY_DIR}"="./build/")
-CheckCFlag(-ffile-prefix-map="${CMAKE_SOURCE_DIR}"="./")
-CheckCFlag(-ffile-prefix-map="${CMAKE_BINARY_DIR}"="./build")
+if (CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
+		add_compile_options($<$<NOT:$<CONFIG:Debug>>:-fdebug-prefix-map=${CMAKE_SOURCE_DIR}=.>)
+		add_compile_options($<$<NOT:$<CONFIG:Debug>>:-fmacro-prefix-map=${CMAKE_SOURCE_DIR}=.>)
+		add_compile_options($<$<NOT:$<CONFIG:Debug>>:-ffile-prefix-map=${CMAKE_SOURCE_DIR}=.>)
+		add_compile_options($<$<NOT:$<CONFIG:Debug>>:-fdebug-prefix-map=${CMAKE_BINARY_DIR}=./build>)
+		add_compile_options($<$<NOT:$<CONFIG:Debug>>:-fmacro-prefix-map=${CMAKE_BINARY_DIR}=./build>)
+		add_compile_options($<$<NOT:$<CONFIG:Debug>>:-ffile-prefix-map=${CMAKE_BINARY_DIR}=./build>)
+endif()
 
 set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} CACHE STRING "default CFLAGS")
 message("Using CFLAGS ${CMAKE_C_FLAGS}")


### PR DESCRIPTION
@hardening  you were right - there was a change with regard to debugging. (was hidden on my tests as the search path contains the correct paths to resolve the debug symbols)

