### PR TITLE
do not always return FALSE when gdi is NULL

### DIFF
--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -3325,7 +3325,7 @@ BOOL update_begin_paint(rdpUpdate* update)
 	/* Reset the invalid regions, we start a new frame here. */
 	rdpGdi* gdi = update->context->gdi;
 	if (!gdi)
-		return FALSE;
+		return rc;
 
 	if (gdi->hdc && gdi->primary && gdi->primary->hdc)
 	{


### PR DESCRIPTION
In some cases where gdi is not instantiated, this always returns false. The desired behavior when there is no gdi is to return earlier without failing all the time. 