### PR TITLE
[client,X11] ignore mouse events not originating in session window

### DIFF
--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -756,6 +756,16 @@ int xf_input_event(xfContext* xfc, const XEvent* xevent, XIDeviceEvent* event, i
 	WINPR_ASSERT(xevent);
 	WINPR_ASSERT(event);
 
+	/* When not running RAILS we only care about events for this window.
+	 * filter out anything else, like floatbar window events
+	 */
+	const Window w = xevent->xany.window;
+	if (w != xfc->window)
+	{
+		if (!xfc->remote_app)
+			return 0;
+	}
+
 	settings = xfc->common.context.settings;
 	WINPR_ASSERT(settings);
 


### PR DESCRIPTION
Fixes https://github.com/FreeRDP/FreeRDP/issues/8640
This is a relaunch of d4be1717c23db7845d3344243cf3918cecb7b7ac, which was deleted by e136444f51b12f45f07b94953d73f04ceb0ce502.