### PR TITLE
X11 client: ignore grab related LeaveNotify events

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -672,6 +672,8 @@ static BOOL xf_event_EnterNotify(xfContext* xfc, const XEnterWindowEvent* event,
 
 static BOOL xf_event_LeaveNotify(xfContext* xfc, const XLeaveWindowEvent* event, BOOL app)
 {
+	if (event->mode == NotifyGrab || event->mode == NotifyUngrab)
+		return TRUE;
 	if (!app)
 	{
 		xfc->mouse_active = FALSE;


### PR DESCRIPTION
This fixes click and drag or more generally any press-hold-release combinations for the primary mouse button.
Without this, click and drag, drag and drop and in, some remote applications that presumably rely on the full press-release sequence, even button presses don't always work.

(cherry picked from commit 06219e4ecb7a03223df0e02050ebd3c557561678)