### PR TITLE
[core,freerdp] fix automatic reconnect after auth

### DIFF
--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -193,12 +193,7 @@ BOOL freerdp_connect(freerdp* instance)
 	WINPR_ASSERT(rdp);
 	WINPR_ASSERT(rdp->settings);
 
-	if (rc < 0)
-		return FALSE;
-
-	if (rc == 0)
-		goto freerdp_connect_finally;
-
+	if (rc > 0)
 	/* Pointers might have changed in between */
 	{
 		rdp_update_internal* up = update_cast(rdp->update);
@@ -211,10 +206,7 @@ BOOL freerdp_connect(freerdp* instance)
 			if (up->pcap_rfx)
 				up->dump_rfx = TRUE;
 		}
-	}
 
-	if (rc > 0)
-	{
 		pointer_cache_register_callbacks(instance->context->update);
 		status = IFCALLRESULT(TRUE, instance->PostConnect, instance);
 		instance->ConnectionCallbackState = CLIENT_STATE_POSTCONNECT_PASSED;


### PR DESCRIPTION
In freerdp_connect do an automatic reconnect if we failed with a FREERDP_ERROR_CONNECT_TRANSPORT_FAILED
This way we can prevent connection disconnects if the remote was disconnected due to timeout (e.g. Auth-Dialog was open for a long time)