### PR TITLE
[Windows, clipboard] fix server don't support format to application exit.

### DIFF
--- a/client/Windows/wf_cliprdr.c
+++ b/client/Windows/wf_cliprdr.c
@@ -1935,7 +1935,7 @@ wf_cliprdr_server_format_list_response(CliprdrClientContext* context,
 	(void)formatListResponse;
 
 	if (formatListResponse->common.msgFlags != CB_RESPONSE_OK)
-		return E_FAIL;
+		WLog_WARN(TAG, "format list update failed");
 
 	return CHANNEL_RC_OK;
 }


### PR DESCRIPTION
[Windows, clipboard] fix server don't support format to application exit.
    
See: https://github.com/KangLin/RabbitRemoteControl/issues/31
