### PR TITLE
[client,x11] fix some rail z-ordering issues

### DIFF
--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -588,7 +588,7 @@ static BOOL xf_rail_window_common(rdpContext* context, const WINDOW_ORDER_INFO* 
 		}
 	}
 
-	if ((fieldFlags & WINDOW_ORDER_STATE_NEW) == 0)
+	if (fieldFlags & (WINDOW_ORDER_STATE_NEW | WINDOW_ORDER_FIELD_STYLE))
 		xf_SetWindowStyle(xfc, appWindow, appWindow->dwStyle, appWindow->dwExStyle);
 
 	/* We should only be using the visibility rects for shaping the window */

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -909,19 +909,16 @@ void xf_SetWindowStyle(xfContext* xfc, xfAppWindow* appWindow, UINT32 style, UIN
 	LogTagAndXChangeProperty(TAG, xfc->display, appWindow->handle, xfc->_NET_WM_WINDOW_TYPE,
 	                         XA_ATOM, 32, PropModeReplace, (BYTE*)&window_type, 1);
 
-	if (ex_style & (WS_EX_CONTROLPARENT | WS_EX_TOOLWINDOW | WS_EX_DLGMODALFRAME))
-		xf_XSetTransientForHint(xfc, appWindow);
+	const BOOL above = (ex_style & WS_EX_TOPMOST) != 0;
+	const BOOL transient = (style & WS_CHILD) == 0;
 
-	if (((ex_style & WS_EX_TOPMOST) != 0) && ((ex_style & WS_EX_TOOLWINDOW) == 0))
-	{
-		xf_SendClientEvent(xfc, appWindow->handle, xfc->_NET_WM_STATE, 4, _NET_WM_STATE_ADD,
-		                   xfc->_NET_WM_STATE_ABOVE, 0, 0);
-	}
-	else
-	{
-		xf_SendClientEvent(xfc, appWindow->handle, xfc->_NET_WM_STATE, 4, _NET_WM_STATE_REMOVE,
-		                   xfc->_NET_WM_STATE_ABOVE, 0, 0);
-	}
+	if (transient)
+		xf_XSetTransientForHint(
+		    xfc, appWindow); // xf_XSetTransientForHint only sets the hint if there is a parent
+
+	xf_SendClientEvent(xfc, appWindow->handle, xfc->_NET_WM_STATE, 4,
+	                   above ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE, xfc->_NET_WM_STATE_ABOVE,
+	                   0, 0);
 }
 
 void xf_SetWindowActions(xfContext* xfc, xfAppWindow* appWindow)


### PR DESCRIPTION
- Always call xf_XSetTransientForHint unless style has WS_CHILD set. xf_XSetTransientForHint in turn checks if a parent is set, which is basically the only hint we have for managing/forcing the z-order. Everything else is irrelevant in that regard (except WS_EX_TOPMOST) See https://learn.microsoft.com/en-us/windows/win32/winmsg/window-features#owned-windows
- Make _NET_WM_STATE_ABOVE only dependent on WS_EX_TOPMOST