### PR TITLE
shadow: Fix typo with rdpSettings data type

### DIFF
--- a/server/shadow/Win/win_wds.c
+++ b/server/shadow/Win/win_wds.c
@@ -764,7 +764,7 @@ int win_shadow_wds_init(winShadowSubsystem* subsystem)
 		return status;
 	}
 
-	rdpSetting* settings = subsystem->shw->settings;
+	rdpSettings* settings = subsystem->shw->settings;
 	if (!freerdp_assistance_populate_settings_from_assistance_file(file, settings))
 		return -1;
 	if (!freerdp_settings_set_string(settings, FreeRDP_Domain, "RDP"))


### PR DESCRIPTION
    
    This commit fixes the following compiler error.
    
    FreeRDP/server/shadow/Win/win_wds.c:767:9: error: unknown type name 'rdpSetting';
    did you mean 'rdpSettings'?
      767 |         rdpSetting* settings = subsystem->shw->settings;
          |         ^~~~~~~~~~
          |         rdpSettings
    
    The typo was introduced in ba41d5e532121a698b02b00981771802b4fec310 commit.
