### PR TITLE
winpr: Fix compiler error with SHGetKnownFolderPath argument

### DIFF
--- a/winpr/libwinpr/path/shell.c
+++ b/winpr/libwinpr/path/shell.c
@@ -223,7 +223,7 @@ static char* GetPath_SYSTEM_CONFIG_HOME(void)
 #if defined(WIN32) && !defined(_UWP)
 
 	WCHAR* wpath = NULL;
-	if (FAILED(SHGetKnownFolderPath(&FOLDERID_ProgramData, 0, -1, &wpath)))
+	if (FAILED(SHGetKnownFolderPath(&FOLDERID_ProgramData, 0, (HANDLE)-1, &wpath)))
 		return NULL;
 
 	if (wpath)


### PR DESCRIPTION

    This commit fixes the following gcc compiler error.
    
    FreeRDP/winpr/libwinpr/path/shell.c:226:67: error: passing argument 3 of
    'SHGetKnownFolderPath' makes pointer from integer without a cast [-Wint-conversion]
      226 |         if (FAILED(SHGetKnownFolderPath(&FOLDERID_ProgramData, 0, -1, &wpath)))
          |                                                                   ^~
          |                                                                   |
          |                                                                   int
