### PR TITLE
Endianess

### DIFF
--- a/libfreerdp/codec/xcrush.c
+++ b/libfreerdp/codec/xcrush.c
@@ -847,7 +847,7 @@ static int xcrush_decompress_l1(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush,
 		if ((pSrcData + 2) > pSrcEnd)
 			return -1003;
 
-		Data_Read_UINT16(pSrcData, MatchCount);
+		MatchCount = winpr_Data_Get_UINT16(pSrcData);
 		MatchDetails = (const RDP61_MATCH_DETAILS*)&pSrcData[2];
 		Literals = (const BYTE*)&MatchDetails[MatchCount];
 		OutputOffset = 0;
@@ -857,9 +857,10 @@ static int xcrush_decompress_l1(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush,
 
 		for (MatchIndex = 0; MatchIndex < MatchCount; MatchIndex++)
 		{
-			Data_Read_UINT16(&MatchDetails[MatchIndex].MatchLength, MatchLength);
-			Data_Read_UINT16(&MatchDetails[MatchIndex].MatchOutputOffset, MatchOutputOffset);
-			Data_Read_UINT32(&MatchDetails[MatchIndex].MatchHistoryOffset, MatchHistoryOffset);
+			MatchLength = winpr_Data_Get_UINT16(&MatchDetails[MatchIndex].MatchLength);
+			MatchOutputOffset = winpr_Data_Get_UINT16(&MatchDetails[MatchIndex].MatchOutputOffset);
+			MatchHistoryOffset =
+			    winpr_Data_Get_UINT32(&MatchDetails[MatchIndex].MatchHistoryOffset);
 
 			if (MatchOutputOffset < OutputOffset)
 				return -1005;

--- a/libfreerdp/codec/xcrush.c
+++ b/libfreerdp/codec/xcrush.c
@@ -704,7 +704,7 @@ static int xcrush_generate_output(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush,
 	if (&OutputBuffer[2] >= &OutputBuffer[OutputSize])
 		return -6001; /* error */
 
-	Data_Write_UINT16(OutputBuffer, MatchCount);
+	winpr_Data_Write_UINT16(OutputBuffer, MatchCount);
 	MatchDetails = (RDP61_MATCH_DETAILS*)&OutputBuffer[2];
 	Literals = (BYTE*)&MatchDetails[MatchCount];
 
@@ -713,12 +713,12 @@ static int xcrush_generate_output(XCRUSH_CONTEXT* WINPR_RESTRICT xcrush,
 
 	for (MatchIndex = 0; MatchIndex < MatchCount; MatchIndex++)
 	{
-		Data_Write_UINT16(&MatchDetails[MatchIndex].MatchLength,
-		                  xcrush->OptimizedMatches[MatchIndex].MatchLength);
-		Data_Write_UINT16(&MatchDetails[MatchIndex].MatchOutputOffset,
-		                  xcrush->OptimizedMatches[MatchIndex].MatchOffset - HistoryOffset);
-		Data_Write_UINT32(&MatchDetails[MatchIndex].MatchHistoryOffset,
-		                  xcrush->OptimizedMatches[MatchIndex].ChunkOffset);
+		winpr_Data_Write_UINT16(&MatchDetails[MatchIndex].MatchLength,
+		                        xcrush->OptimizedMatches[MatchIndex].MatchLength);
+		winpr_Data_Write_UINT16(&MatchDetails[MatchIndex].MatchOutputOffset,
+		                        xcrush->OptimizedMatches[MatchIndex].MatchOffset - HistoryOffset);
+		winpr_Data_Write_UINT32(&MatchDetails[MatchIndex].MatchHistoryOffset,
+		                        xcrush->OptimizedMatches[MatchIndex].ChunkOffset);
 	}
 
 	CurrentOffset = HistoryOffset;

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -876,7 +876,7 @@ BYTE* freerdp_assistance_encrypt_pass_stub(const char* password, const char* pas
 	if (!pbIn || !pbOut)
 		goto fail;
 
-	Data_Write_UINT32(pbIn, cbPassStubW);
+	winpr_Data_Write_UINT32(pbIn, cbPassStubW);
 	CopyMemory(&pbIn[4], PassStubW, cbPassStubW);
 	rc4Ctx = winpr_RC4_New(PasswordHash, sizeof(PasswordHash));
 

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -876,7 +876,7 @@ BYTE* freerdp_assistance_encrypt_pass_stub(const char* password, const char* pas
 	if (!pbIn || !pbOut)
 		goto fail;
 
-	*((UINT32*)pbIn) = (UINT32)cbPassStubW;
+	Data_Write_UINT32(pbIn, cbPassStubW);
 	CopyMemory(&pbIn[4], PassStubW, cbPassStubW);
 	rc4Ctx = winpr_RC4_New(PasswordHash, sizeof(PasswordHash));
 

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -1337,11 +1337,12 @@ BOOL freerdp_assistance_populate_settings_from_assistance_file(rdpAssistanceFile
 
 	union
 	{
-		UINT32 port;
+		uintptr_t port;
 		void* data;
 	} cnv;
 	cnv.data = ArrayList_GetItem(file->MachinePorts, 0);
-	if (!freerdp_settings_set_uint32(settings, FreeRDP_ServerPort, cnv.port))
+	WINPR_ASSERT(cnv.port <= UINT32_MAX);
+	if (!freerdp_settings_set_uint32(settings, FreeRDP_ServerPort, (UINT32)cnv.port))
 		return FALSE;
 
 	if (!freerdp_target_net_adresses_reset(settings, ports))
@@ -1350,7 +1351,9 @@ BOOL freerdp_assistance_populate_settings_from_assistance_file(rdpAssistanceFile
 	for (size_t x = 0; x < ports; x++)
 	{
 		cnv.data = ArrayList_GetItem(file->MachinePorts, x);
-		if (!freerdp_settings_set_pointer_array(settings, FreeRDP_TargetNetPorts, x, &cnv.port))
+		WINPR_ASSERT(cnv.port <= UINT32_MAX);
+		const UINT32 port = (UINT32)cnv.port;
+		if (!freerdp_settings_set_pointer_array(settings, FreeRDP_TargetNetPorts, x, &port))
 			return FALSE;
 	}
 	for (size_t i = 0; i < addresses; i++)
@@ -1452,11 +1455,12 @@ void freerdp_assistance_print_file(rdpAssistanceFile* file, wLog* log, DWORD lev
 		{
 			union
 			{
-				UINT32 port;
+				uintptr_t port;
 				void* data;
 			} cnv;
 			cnv.data = ArrayList_GetItem(file->MachinePorts, x);
-			port = cnv.port;
+			WINPR_ASSERT(cnv.port <= UINT32_MAX);
+			port = (UINT32)cnv.port;
 		}
 		if (x < ArrayList_Count(file->MachineUris))
 			uri = ArrayList_GetItem(file->MachineUris, x);

--- a/winpr/include/winpr/endian.h
+++ b/winpr/include/winpr/endian.h
@@ -3,6 +3,8 @@
  * Endianness Macros
  *
  * Copyright 2013 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+ * Copyright 2024 Armin Novak <anovak@thincast.com>
+ * Copyright 2024 Thincast Technologies GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,171 +25,359 @@
 #include <winpr/winpr.h>
 #include <winpr/wtypes.h>
 #include <winpr/platform.h>
+#include <winpr/assert.h>
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
-#define Data_Read_UINT8_NE(_d, _v) \
-	do                             \
-	{                              \
-		_v = *((const BYTE*)_d);   \
-	} while (0)
+	static INLINE UINT8 winpr_Data_Get_UINT8(const void* d)
+	{
+		WINPR_ASSERT(d);
+		return *(const UINT8*)d;
+	}
 
-#define Data_Read_UINT8(_d, _v)  \
-	do                           \
-	{                            \
-		_v = *((const BYTE*)_d); \
-	} while (0)
+	static INLINE INT8 winpr_Data_Get_INT8(const void* d)
+	{
+		WINPR_ASSERT(d);
+		return *(const INT8*)d;
+	}
 
-#define Data_Read_UINT16_NE(_d, _v) \
-	do                              \
-	{                               \
-		_v = *((const UINT16*)_d);  \
-	} while (0)
+	static INLINE UINT16 winpr_Data_Get_UINT16_NE(const void* d)
+	{
+		return *(const UINT16*)d;
+	}
 
-#define Data_Read_UINT16(_d, _v)                                                               \
-	do                                                                                         \
-	{                                                                                          \
-		_v = (UINT16)(*((const BYTE*)_d)) + (UINT16)(((UINT16)(*((const BYTE*)_d + 1))) << 8); \
-	} while (0)
+	static INLINE UINT16 winpr_Data_Get_UINT16(const void* d)
+	{
+		const size_t typesize = sizeof(UINT16);
+		UINT16 v = 0;
+		for (size_t x = 0; x < typesize; x++)
+		{
+			v <<= 8;
+			v |= ((const UINT8*)d)[typesize - x - 1];
+		}
+		return v;
+	}
 
-#define Data_Read_UINT16_BE(_d, _v)                                                  \
-	do                                                                               \
-	{                                                                                \
-		_v = (((UINT16)(*(const BYTE*)_d)) << 8) + (UINT16)(*((const BYTE*)_d + 1)); \
-	} while (0)
+	static INLINE UINT16 winpr_Data_Get_UINT16_BE(const void* d)
+	{
+		const size_t typesize = sizeof(UINT16);
+		UINT16 v = 0;
+		for (size_t x = 0; x < typesize; x++)
+		{
+			v <<= 8;
+			v |= ((const UINT8*)d)[x];
+		}
+		return v;
+	}
 
-#define Data_Read_UINT32_NE(_d, _v) \
-	do                              \
-	{                               \
-		_v = *((UINT32*)_d);        \
-	} while (0)
+	static INLINE INT16 winpr_Data_Get_INT16_NE(const void* d)
+	{
+		return *(const INT16*)d;
+	}
 
-#define Data_Read_UINT32(_d, _v)                                                        \
-	do                                                                                  \
-	{                                                                                   \
-		_v = (UINT32)(*((const BYTE*)_d)) + (((UINT32)(*((const BYTE*)_d + 1))) << 8) + \
-		     (((UINT32)(*((const BYTE*)_d + 2))) << 16) +                               \
-		     (((UINT32)(*((const BYTE*)_d + 3))) << 24);                                \
-	} while (0)
+	static INLINE INT16 winpr_Data_Get_INT16(const void* d)
+	{
+		const UINT16 u16 = winpr_Data_Get_UINT16(d);
+		return (INT16)u16;
+	}
 
-#define Data_Read_UINT32_BE(_d, _v)                                                                \
-	do                                                                                             \
-	{                                                                                              \
-		_v = (((UINT32)(*((const BYTE*)_d))) << 24) + (((UINT32)(*((const BYTE*)_d + 1))) << 16) + \
-		     (((UINT32)(*((const BYTE*)_d + 2))) << 8) + (((UINT32)(*((const BYTE*)_d + 3))));     \
-	} while (0)
+	static INLINE INT16 winpr_Data_Get_INT16_BE(const void* d)
+	{
+		const UINT16 u16 = winpr_Data_Get_UINT16_BE(d);
+		return (INT16)u16;
+	}
 
-#define Data_Read_UINT64_NE(_d, _v) \
-	do                              \
-	{                               \
-		_v = *((UINT64*)_d);        \
-	} while (0)
+	static INLINE UINT32 winpr_Data_Get_UINT32_NE(const void* d)
+	{
+		return *(const UINT32*)d;
+	}
 
-#define Data_Read_UINT64(_d, _v)                                                        \
-	do                                                                                  \
-	{                                                                                   \
-		_v = (UINT64)(*((const BYTE*)_d)) + (((UINT64)(*((const BYTE*)_d + 1))) << 8) + \
-		     (((UINT64)(*((const BYTE*)_d + 2))) << 16) +                               \
-		     (((UINT64)(*((const BYTE*)_d + 3))) << 24) +                               \
-		     (((UINT64)(*((const BYTE*)_d + 4))) << 32) +                               \
-		     (((UINT64)(*((const BYTE*)_d + 5))) << 40) +                               \
-		     (((UINT64)(*((const BYTE*)_d + 6))) << 48) +                               \
-		     (((UINT64)(*((const BYTE*)_d + 7))) << 56);                                \
-	} while (0)
+	static INLINE UINT32 winpr_Data_Get_UINT32(const void* d)
+	{
+		const size_t typesize = sizeof(UINT32);
+		UINT32 v = 0;
+		for (size_t x = 0; x < typesize; x++)
+		{
+			v <<= 8;
+			v |= ((const UINT8*)d)[typesize - x - 1];
+		}
+		return v;
+	}
 
-#define Data_Read_UINT64_BE(_d, _v)                                                                \
-	do                                                                                             \
-	{                                                                                              \
-		_v = (((UINT64)(*((const BYTE*)_d))) << 56) + (((UINT64)(*((const BYTE*)_d + 1))) << 48) + \
-		     (((UINT64)(*((const BYTE*)_d + 2))) << 40) +                                          \
-		     (((UINT64)(*((const BYTE*)_d + 3))) << 32) +                                          \
-		     (((UINT64)(*((const BYTE*)_d + 4))) << 24) +                                          \
-		     (((UINT64)(*((const BYTE*)_d + 5))) << 16) +                                          \
-		     (((UINT64)(*((const BYTE*)_d + 6))) << 8) + (((UINT64)(*((const BYTE*)_d + 7))));     \
-	} while (0)
+	static INLINE UINT32 winpr_Data_Get_UINT32_BE(const void* d)
+	{
+		const size_t typesize = sizeof(UINT32);
+		UINT32 v = 0;
+		for (size_t x = 0; x < typesize; x++)
+		{
+			v <<= 8;
+			v |= ((const UINT8*)d)[x];
+		}
+		return v;
+	}
 
-#define Data_Write_UINT8_NE(_d, _v) \
-	do                              \
-	{                               \
-		*((UINT8*)_d) = v;          \
-	} while (0)
+	static INLINE INT32 winpr_Data_Get_INT32_NE(const void* d)
+	{
+		return *(const INT32*)d;
+	}
 
-#define Data_Write_UINT8(_d, _v) \
-	do                           \
-	{                            \
-		*_d = (UINT8)(_v);       \
-	} while (0)
+	static INLINE INT32 winpr_Data_Get_INT32(const void* d)
+	{
+		const UINT32 u32 = winpr_Data_Get_UINT32(d);
+		return (INT32)u32;
+	}
 
-#define Data_Write_UINT16_NE(_d, _v) \
-	do                               \
-	{                                \
-		*((UINT16*)_d) = _v;         \
-	} while (0)
+	static INLINE INT32 winpr_Data_Get_INT32_BE(const void* d)
+	{
+		const UINT32 u32 = winpr_Data_Get_UINT32_BE(d);
+		return (INT32)u32;
+	}
 
-#define Data_Write_UINT16(_d, _v)              \
-	do                                         \
-	{                                          \
-		*((BYTE*)_d) = (_v)&0xFF;              \
-		*((BYTE*)_d + 1) = ((_v) >> 8) & 0xFF; \
-	} while (0)
+	static INLINE UINT64 winpr_Data_Get_UINT64_NE(const void* d)
+	{
+		return *(const UINT64*)d;
+	}
 
-#define Data_Write_UINT16_BE(_d, _v)       \
-	do                                     \
-	{                                      \
-		*((BYTE*)_d) = ((_v) >> 8) & 0xFF; \
-		*((BYTE*)_d + 1) = (_v)&0xFF;      \
-	} while (0)
+	static INLINE UINT64 winpr_Data_Get_UINT64(const void* d)
+	{
+		const size_t typesize = sizeof(UINT64);
+		UINT64 v = 0;
+		for (size_t x = 0; x < typesize; x++)
+		{
+			v <<= 8;
+			v |= ((const UINT8*)d)[typesize - x - 1];
+		}
+		return v;
+	}
 
-#define Data_Write_UINT32_NE(_d, _v) \
-	do                               \
-	{                                \
-		*((UINT32*)_d) = _v;         \
-	} while (0)
+	static INLINE UINT64 winpr_Data_Get_UINT64_BE(const void* d)
+	{
+		const size_t typesize = sizeof(UINT64);
+		UINT64 v = 0;
+		for (size_t x = 0; x < typesize; x++)
+		{
+			v <<= 8;
+			v |= ((const UINT8*)d)[x];
+		}
+		return v;
+	}
 
-#define Data_Write_UINT32(_d, _v)               \
-	do                                          \
-	{                                           \
-		*((BYTE*)_d) = (_v)&0xFF;               \
-		*((BYTE*)_d + 1) = ((_v) >> 8) & 0xFF;  \
-		*((BYTE*)_d + 2) = ((_v) >> 16) & 0xFF; \
-		*((BYTE*)_d + 3) = ((_v) >> 24) & 0xFF; \
-	} while (0)
+	static INLINE INT64 winpr_Data_Get_INT64_NE(const void* d)
+	{
+		return *(const INT64*)d;
+	}
 
-#define Data_Write_UINT32_BE(_d, _v)                            \
-	do                                                          \
-	{                                                           \
-		Data_Write_UINT16_BE((BYTE*)_d, ((_v) >> 16 & 0xFFFF)); \
-		Data_Write_UINT16_BE((BYTE*)_d + 2, ((_v)&0xFFFF));     \
-	} while (0)
+	static INLINE INT64 winpr_Data_Get_INT64(const void* d)
+	{
+		const UINT64 u64 = winpr_Data_Get_UINT64(d);
+		return (INT64)u64;
+	}
 
-#define Data_Write_UINT64_NE(_d, _v) \
-	do                               \
-	{                                \
-		*((UINT64*)_d) = _v;         \
-	} while (0)
+	static INLINE INT64 winpr_Data_Get_INT64_BE(const void* d)
+	{
+		const UINT64 u64 = winpr_Data_Get_UINT64_BE(d);
+		return (INT64)u64;
+	}
 
-#define Data_Write_UINT64(_d, _v)                       \
-	do                                                  \
-	{                                                   \
-		*((BYTE*)_d) = (UINT64)(_v)&0xFF;               \
-		*((BYTE*)_d + 1) = ((UINT64)(_v) >> 8) & 0xFF;  \
-		*((BYTE*)_d + 2) = ((UINT64)(_v) >> 16) & 0xFF; \
-		*((BYTE*)_d + 3) = ((UINT64)(_v) >> 24) & 0xFF; \
-		*((BYTE*)_d + 4) = ((UINT64)(_v) >> 32) & 0xFF; \
-		*((BYTE*)_d + 5) = ((UINT64)(_v) >> 40) & 0xFF; \
-		*((BYTE*)_d + 6) = ((UINT64)(_v) >> 48) & 0xFF; \
-		*((BYTE*)_d + 7) = ((UINT64)(_v) >> 56) & 0xFF; \
-	} while (0)
+	static INLINE void winpr_Data_Write_UINT8_NE(void* d, UINT8 v)
+	{
+		WINPR_ASSERT(d);
+		*((UINT8*)d) = v;
+	}
 
-#define Data_Write_UINT64_BE(_d, _v)                                \
-	do                                                              \
-	{                                                               \
-		Data_Write_UINT32_BE((BYTE*)_d, ((_v) >> 32 & 0xFFFFFFFF)); \
-		Data_Write_UINT32_BE((BYTE*)_d + 4, ((_v)&0xFFFFFFFF));     \
-	} while (0)
+	static INLINE void winpr_Data_Write_UINT8(void* d, UINT8 v)
+	{
+		WINPR_ASSERT(d);
+		*((UINT8*)d) = v;
+	}
+
+	static INLINE void winpr_Data_Write_UINT16_NE(void* d, UINT16 v)
+	{
+		WINPR_ASSERT(d);
+		*((UINT16*)d) = v;
+	}
+
+	static INLINE void winpr_Data_Write_UINT16(void* d, UINT16 v)
+	{
+		WINPR_ASSERT(d);
+		((UINT8*)d)[0] = v & 0xFF;
+		((UINT8*)d)[1] = (v >> 8) & 0xFF;
+	}
+
+	static INLINE void winpr_Data_Write_UINT16_BE(void* d, UINT16 v)
+	{
+		WINPR_ASSERT(d);
+		((UINT8*)d)[1] = v & 0xFF;
+		((UINT8*)d)[0] = (v >> 8) & 0xFF;
+	}
+
+	static INLINE void winpr_Data_Write_UINT32_NE(void* d, UINT32 v)
+	{
+		WINPR_ASSERT(d);
+		*((UINT32*)d) = v;
+	}
+
+	static INLINE void winpr_Data_Write_UINT32(void* d, UINT32 v)
+	{
+		WINPR_ASSERT(d);
+		BYTE* b = (BYTE*)d;
+		winpr_Data_Write_UINT16(b, v & 0xFFFF);
+		winpr_Data_Write_UINT16(b + 2, (v >> 16) & 0xFFFF);
+	}
+
+	static INLINE void winpr_Data_Write_UINT32_BE(void* d, UINT32 v)
+	{
+		WINPR_ASSERT(d);
+		BYTE* b = (BYTE*)d;
+		winpr_Data_Write_UINT16_BE(b, (v >> 16) & 0xFFFF);
+		winpr_Data_Write_UINT16_BE(b + 2, v & 0xFFFF);
+	}
+
+	static INLINE void winpr_Data_Write_UINT64_NE(void* d, UINT64 v)
+	{
+		WINPR_ASSERT(d);
+		*((UINT64*)d) = v;
+	}
+
+	static INLINE void winpr_Data_Write_UINT64(void* d, UINT64 v)
+	{
+		WINPR_ASSERT(d);
+		BYTE* b = (BYTE*)d;
+		winpr_Data_Write_UINT32(b, v & 0xFFFFFFFF);
+		winpr_Data_Write_UINT32(b + 4, (v >> 32) & 0xFFFFFFFF);
+	}
+
+	static INLINE void winpr_Data_Write_UINT64_BE(void* d, UINT64 v)
+	{
+		WINPR_ASSERT(d);
+		BYTE* b = (BYTE*)d;
+		winpr_Data_Write_UINT32_BE(b, (v >> 32) & 0xFFFFFFFF);
+		winpr_Data_Write_UINT32_BE(b + 4, v & 0xFFFFFFFF);
+	}
+
+	static INLINE void winpr_Data_Write_INT8_NE(void* d, INT8 v)
+	{
+		WINPR_ASSERT(d);
+		*((INT8*)d) = v;
+	}
+
+	static INLINE void winpr_Data_Write_INT8(void* d, INT8 v)
+	{
+		WINPR_ASSERT(d);
+		*((INT8*)d) = v;
+	}
+
+	static INLINE void winpr_Data_Write_INT16_NE(void* d, INT16 v)
+	{
+		WINPR_ASSERT(d);
+		*((INT16*)d) = v;
+	}
+
+	static INLINE void winpr_Data_Write_INT16(void* d, INT16 v)
+	{
+		WINPR_ASSERT(d);
+		((UINT8*)d)[0] = v & 0xFF;
+		((UINT8*)d)[1] = (v >> 8) & 0xFF;
+	}
+
+	static INLINE void winpr_Data_Write_INT16_BE(void* d, INT16 v)
+	{
+		WINPR_ASSERT(d);
+		((UINT8*)d)[1] = v & 0xFF;
+		((UINT8*)d)[0] = (v >> 8) & 0xFF;
+	}
+
+	static INLINE void winpr_Data_Write_INT32_NE(void* d, INT32 v)
+	{
+		WINPR_ASSERT(d);
+		*((UINT32*)d) = v;
+	}
+
+	static INLINE void winpr_Data_Write_INT32(void* d, INT32 v)
+	{
+		WINPR_ASSERT(d);
+		BYTE* b = (BYTE*)d;
+		winpr_Data_Write_UINT16(b, v & 0xFFFF);
+		winpr_Data_Write_UINT16(b + 2, (v >> 16) & 0xFFFF);
+	}
+
+	static INLINE void winpr_Data_Write_INT32_BE(void* d, INT32 v)
+	{
+		WINPR_ASSERT(d);
+		BYTE* b = (BYTE*)d;
+		winpr_Data_Write_UINT16_BE(b, (v >> 16) & 0xFFFF);
+		winpr_Data_Write_UINT16_BE(b + 2, v & 0xFFFF);
+	}
+
+	static INLINE void winpr_Data_Write_INT64_NE(void* d, INT64 v)
+	{
+		WINPR_ASSERT(d);
+		*((UINT64*)d) = v;
+	}
+
+	static INLINE void winpr_Data_Write_INT64(void* d, INT64 v)
+	{
+		WINPR_ASSERT(d);
+		BYTE* b = (BYTE*)d;
+		winpr_Data_Write_UINT32(b, v & 0xFFFFFFFF);
+		winpr_Data_Write_UINT32(b + 4, (v >> 32) & 0xFFFFFFFF);
+	}
+
+	static INLINE void winpr_Data_Write_INT64_BE(void* d, INT64 v)
+	{
+		WINPR_ASSERT(d);
+		BYTE* b = (BYTE*)d;
+		winpr_Data_Write_UINT32_BE(b, (v >> 32) & 0xFFFFFFFF);
+		winpr_Data_Write_UINT32_BE(b + 4, v & 0xFFFFFFFF);
+	}
+
+#if defined(WINPR_DEPRECATED)
+#define Data_Read_UINT8_NE(_d, _v) _v = winpr_Data_Get_UINT8(_d)
+
+#define Data_Read_UINT8(_d, _v) _v = winpr_Data_Get_UINT8(_d)
+
+#define Data_Read_UINT16_NE(_d, _v) _v = winpr_Data_Get_UINT16_NE(_d)
+
+#define Data_Read_UINT16(_d, _v) _v = winpr_Data_Get_UINT16(_d)
+
+#define Data_Read_UINT16_BE(_d, _v) _v = winpr_Data_Get_UINT16_BE(_d)
+
+#define Data_Read_UINT32_NE(_d, _v) _v = winpr_Data_Get_UINT32_NE(_d)
+
+#define Data_Read_UINT32(_d, _v) _v = winpr_Data_Get_UINT32(_d)
+
+#define Data_Read_UINT32_BE(_d, _v) _v = winpr_Data_Get_UINT32_BE(_d)
+
+#define Data_Read_UINT64_NE(_d, _v) _v = winpr_Data_Get_UINT64_NE(_d)
+
+#define Data_Read_UINT64(_d, _v) _v = winpr_Data_Get_UINT64(_d)
+
+#define Data_Read_UINT64_BE(_d, _v) _v = winpr_Data_Get_UINT64_BE(_d)
+
+#define Data_Write_UINT8_NE(_d, _v) winpr_Data_Write_UINT8_NE(_d, _v)
+
+#define Data_Write_UINT8(_d, _v) winpr_Data_Write_UINT8(_d, _v)
+
+#define Data_Write_UINT16_NE(_d, _v) winpr_Data_Write_UINT16_NE(_d, _v)
+#define Data_Write_UINT16(_d, _v) winpr_Data_Write_UINT16(_d, _v)
+
+#define Data_Write_UINT16_BE(_d, _v) winpr_Data_Write_UINT16_BE(_d, _v)
+
+#define Data_Write_UINT32_NE(_d, _v) winpr_Data_Write_UINT32_NE(_d, _v)
+
+#define Data_Write_UINT32(_d, _v) winpr_Data_Write_UINT32(_d, _v)
+
+#define Data_Write_UINT32_BE(_d, _v) winpr_Data_Write_UINT32_BE(_d, _v)
+
+#define Data_Write_UINT64_NE(_d, _v) winpr_Data_Write_UINT64_NE(_d, _v)
+
+#define Data_Write_UINT64(_d, _v) winpr_Data_Write_UINT64(_d, _v)
+
+#define Data_Write_UINT64_BE(_d, _v) winpr_Data_Write_UINT64_BE(_d, _v)
+#endif
 
 #ifdef __cplusplus
 }

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -147,7 +147,7 @@ extern "C"
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= sizeof(UINT8));
 
-		const UINT8 v = *(_s)->pointer;
+		const UINT8 v = winpr_Data_Get_UINT8(_s->pointer);
 		if (seek)
 			Stream_Seek(_s, sizeof(UINT8));
 		return v;
@@ -155,8 +155,10 @@ extern "C"
 
 	static INLINE INT8 stream_read_i8(wStream* _s, BOOL seek)
 	{
-		const UINT8 v = stream_read_u8(_s, seek);
-		return WINPR_STREAM_CAST(INT8, v);
+		const INT8 v = winpr_Data_Get_INT8(_s->pointer);
+		if (seek)
+			Stream_Seek(_s, sizeof(INT8));
+		return v;
 	}
 
 	static INLINE UINT16 stream_read_u16_le(wStream* _s, BOOL seek)
@@ -165,12 +167,7 @@ extern "C"
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= typesize);
 
-		UINT16 v = 0;
-		for (size_t x = 0; x < typesize; x++)
-		{
-			v <<= 8;
-			v |= (_s)->pointer[typesize - x - 1];
-		}
+		const UINT16 v = winpr_Data_Get_UINT16(_s->pointer);
 		if (seek)
 			Stream_Seek(_s, typesize);
 		return v;
@@ -182,12 +179,7 @@ extern "C"
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= typesize);
 
-		UINT16 v = 0;
-		for (size_t x = 0; x < typesize; x++)
-		{
-			v <<= 8;
-			v |= (_s)->pointer[x];
-		}
+		const UINT16 v = winpr_Data_Get_UINT16_BE(_s->pointer);
 		if (seek)
 			Stream_Seek(_s, typesize);
 		return v;
@@ -195,14 +187,26 @@ extern "C"
 
 	static INLINE INT16 stream_read_i16_le(wStream* _s, BOOL seek)
 	{
-		const UINT16 v = stream_read_u16_le(_s, seek);
-		return WINPR_STREAM_CAST(INT16, v);
+		const size_t typesize = sizeof(INT16);
+		WINPR_ASSERT(_s);
+		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= typesize);
+
+		const INT16 v = winpr_Data_Get_INT16(_s->pointer);
+		if (seek)
+			Stream_Seek(_s, typesize);
+		return v;
 	}
 
 	static INLINE INT16 stream_read_i16_be(wStream* _s, BOOL seek)
 	{
-		const UINT16 v = stream_read_u16_be(_s, seek);
-		return WINPR_STREAM_CAST(INT16, v);
+		const size_t typesize = sizeof(INT16);
+		WINPR_ASSERT(_s);
+		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= typesize);
+
+		const INT16 v = winpr_Data_Get_INT16_BE(_s->pointer);
+		if (seek)
+			Stream_Seek(_s, typesize);
+		return v;
 	}
 
 	static INLINE UINT32 stream_read_u32_le(wStream* _s, BOOL seek)
@@ -211,12 +215,7 @@ extern "C"
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= typesize);
 
-		UINT32 v = 0;
-		for (size_t x = 0; x < typesize; x++)
-		{
-			v <<= 8;
-			v |= (_s)->pointer[typesize - x - 1];
-		}
+		const UINT32 v = winpr_Data_Get_UINT32(_s->pointer);
 		if (seek)
 			Stream_Seek(_s, typesize);
 		return v;
@@ -228,12 +227,7 @@ extern "C"
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= typesize);
 
-		UINT32 v = 0;
-		for (size_t x = 0; x < typesize; x++)
-		{
-			v <<= 8;
-			v |= (_s)->pointer[x];
-		}
+		const UINT32 v = winpr_Data_Get_UINT32_BE(_s->pointer);
 		if (seek)
 			Stream_Seek(_s, typesize);
 		return v;
@@ -241,14 +235,26 @@ extern "C"
 
 	static INLINE INT32 stream_read_i32_le(wStream* _s, BOOL seek)
 	{
-		const UINT32 v = stream_read_u32_le(_s, seek);
-		return WINPR_STREAM_CAST(INT32, v);
+		const size_t typesize = sizeof(INT32);
+		WINPR_ASSERT(_s);
+		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= typesize);
+
+		const INT32 v = winpr_Data_Get_INT32(_s->pointer);
+		if (seek)
+			Stream_Seek(_s, typesize);
+		return v;
 	}
 
 	static INLINE INT32 stream_read_i32_be(wStream* _s, BOOL seek)
 	{
-		const UINT32 v = stream_read_u32_be(_s, seek);
-		return WINPR_STREAM_CAST(INT32, v);
+		const size_t typesize = sizeof(INT32);
+		WINPR_ASSERT(_s);
+		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= typesize);
+
+		const INT32 v = winpr_Data_Get_INT32_BE(_s->pointer);
+		if (seek)
+			Stream_Seek(_s, typesize);
+		return v;
 	}
 
 	static INLINE UINT64 stream_read_u64_le(wStream* _s, BOOL seek)
@@ -257,12 +263,7 @@ extern "C"
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= typesize);
 
-		UINT64 v = 0;
-		for (size_t x = 0; x < typesize; x++)
-		{
-			v <<= 8;
-			v |= (_s)->pointer[typesize - x - 1];
-		}
+		const UINT64 v = winpr_Data_Get_UINT64(_s->pointer);
 		if (seek)
 			Stream_Seek(_s, typesize);
 		return v;
@@ -274,12 +275,7 @@ extern "C"
 		WINPR_ASSERT(_s);
 		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= typesize);
 
-		UINT64 v = 0;
-		for (size_t x = 0; x < typesize; x++)
-		{
-			v <<= 8;
-			v |= (_s)->pointer[x];
-		}
+		const UINT64 v = winpr_Data_Get_UINT64_BE(_s->pointer);
 		if (seek)
 			Stream_Seek(_s, typesize);
 		return v;
@@ -287,14 +283,26 @@ extern "C"
 
 	static INLINE INT64 stream_read_i64_le(wStream* _s, BOOL seek)
 	{
-		const UINT64 v = stream_read_u64_le(_s, seek);
-		return WINPR_STREAM_CAST(INT64, v);
+		const size_t typesize = sizeof(INT64);
+		WINPR_ASSERT(_s);
+		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= typesize);
+
+		const INT64 v = winpr_Data_Get_INT64(_s->pointer);
+		if (seek)
+			Stream_Seek(_s, typesize);
+		return v;
 	}
 
 	static INLINE INT64 stream_read_i64_be(wStream* _s, BOOL seek)
 	{
-		const UINT64 v = stream_read_u64_be(_s, seek);
-		return WINPR_STREAM_CAST(INT64, v);
+		const size_t typesize = sizeof(INT64);
+		WINPR_ASSERT(_s);
+		WINPR_ASSERT(Stream_GetRemainingLength(_s) >= typesize);
+
+		const INT64 v = winpr_Data_Get_INT64_BE(_s->pointer);
+		if (seek)
+			Stream_Seek(_s, typesize);
+		return v;
 	}
 
 	/**
@@ -811,7 +819,8 @@ extern "C"
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 1);
 
-		*_s->pointer++ = WINPR_STREAM_CAST(BYTE, _v);
+		winpr_Data_Write_INT8(_s->pointer, _v);
+		_s->pointer += 1;
 	}
 
 #define Stream_Write_UINT8(s, v)                \
@@ -835,7 +844,8 @@ extern "C"
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 1);
 
-		*_s->pointer++ = WINPR_STREAM_CAST(BYTE, _v);
+		winpr_Data_Write_UINT8(_s->pointer, _v);
+		_s->pointer += 1;
 	}
 
 #define Stream_Write_INT16(s, v)                \
@@ -860,8 +870,8 @@ extern "C"
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 2);
 
-		*_s->pointer++ = (_v) & 0xFF;
-		*_s->pointer++ = ((_v) >> 8) & 0xFF;
+		winpr_Data_Write_INT16(_s->pointer, _v);
+		_s->pointer += 2;
 	}
 
 #define Stream_Write_UINT16(s, v)                \
@@ -886,8 +896,8 @@ extern "C"
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 2);
 
-		*_s->pointer++ = (_v) & 0xFF;
-		*_s->pointer++ = ((_v) >> 8) & 0xFF;
+		winpr_Data_Write_UINT16(_s->pointer, _v);
+		_s->pointer += 2;
 	}
 
 #define Stream_Write_UINT16_BE(s, v)                \
@@ -912,8 +922,8 @@ extern "C"
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 2);
 
-		*_s->pointer++ = ((_v) >> 8) & 0xFF;
-		*_s->pointer++ = (_v) & 0xFF;
+		winpr_Data_Write_UINT16_BE(_s->pointer, _v);
+		_s->pointer += 2;
 	}
 
 #define Stream_Write_INT16_BE(s, v)                \
@@ -940,8 +950,8 @@ extern "C"
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 2);
 
-		*_s->pointer++ = ((_v) >> 8) & 0xFF;
-		*_s->pointer++ = (_v) & 0xFF;
+		winpr_Data_Write_INT16_BE(_s->pointer, _v);
+		_s->pointer += 2;
 	}
 
 #define Stream_Write_UINT24_BE(s, v)                \
@@ -994,10 +1004,8 @@ extern "C"
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 4);
 
-		*_s->pointer++ = (_v) & 0xFF;
-		*_s->pointer++ = ((_v) >> 8) & 0xFF;
-		*_s->pointer++ = ((_v) >> 16) & 0xFF;
-		*_s->pointer++ = ((_v) >> 24) & 0xFF;
+		winpr_Data_Write_INT32(_s->pointer, _v);
+		_s->pointer += 4;
 	}
 
 #define Stream_Write_INT32_BE(s, v)                \
@@ -1024,10 +1032,8 @@ extern "C"
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 4);
 
-		*_s->pointer++ = ((_v) >> 24) & 0xFF;
-		*_s->pointer++ = ((_v) >> 16) & 0xFF;
-		*_s->pointer++ = ((_v) >> 8) & 0xFF;
-		*_s->pointer++ = (_v) & 0xFF;
+		winpr_Data_Write_INT32_BE(_s->pointer, _v);
+		_s->pointer += 4;
 	}
 
 #define Stream_Write_UINT32(s, v)                \
@@ -1052,10 +1058,8 @@ extern "C"
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 4);
 
-		*_s->pointer++ = (_v) & 0xFF;
-		*_s->pointer++ = ((_v) >> 8) & 0xFF;
-		*_s->pointer++ = ((_v) >> 16) & 0xFF;
-		*_s->pointer++ = ((_v) >> 24) & 0xFF;
+		winpr_Data_Write_UINT32(_s->pointer, _v);
+		_s->pointer += 4;
 	}
 
 #define Stream_Write_UINT32_BE(s, v)                \
@@ -1078,8 +1082,8 @@ extern "C"
 	{
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 4);
 
-		Stream_Write_UINT16_BE(_s, ((_v) >> 16 & 0xFFFF));
-		Stream_Write_UINT16_BE(_s, ((_v) & 0xFFFF));
+		winpr_Data_Write_UINT32_BE(_s->pointer, _v);
+		_s->pointer += 4;
 	}
 
 	/** @brief writes a \b UINT64 as \b little endian to a \b wStream. The stream must be large
@@ -1094,8 +1098,8 @@ extern "C"
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 8);
 
-		Stream_Write_UINT32(_s, ((_v) & 0xFFFFFFFFUL));
-		Stream_Write_UINT32(_s, ((_v) >> 32 & 0xFFFFFFFFUL));
+		winpr_Data_Write_UINT64(_s->pointer, _v);
+		_s->pointer += 8;
 	}
 
 	/** @brief writes a \b UINT64 as \b big endian to a \b wStream. The stream must be large enough
@@ -1110,8 +1114,8 @@ extern "C"
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 8);
 
-		Stream_Write_UINT32_BE(_s, ((_v) >> 32 & 0xFFFFFFFFUL));
-		Stream_Write_UINT32_BE(_s, ((_v) & 0xFFFFFFFFUL));
+		winpr_Data_Write_UINT64_BE(_s->pointer, _v);
+		_s->pointer += 8;
 	}
 
 	/** @brief writes a \b INT64 as \b little endian to a \b wStream. The stream must be large
@@ -1127,14 +1131,8 @@ extern "C"
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 8);
 
-		*_s->pointer++ = (_v) & 0xFF;
-		*_s->pointer++ = ((_v) >> 8) & 0xFF;
-		*_s->pointer++ = ((_v) >> 16) & 0xFF;
-		*_s->pointer++ = ((_v) >> 24) & 0xFF;
-		*_s->pointer++ = ((_v) >> 32) & 0xFF;
-		*_s->pointer++ = ((_v) >> 40) & 0xFF;
-		*_s->pointer++ = ((_v) >> 48) & 0xFF;
-		*_s->pointer++ = ((_v) >> 56) & 0xFF;
+		winpr_Data_Write_INT64(_s->pointer, _v);
+		_s->pointer += 8;
 	}
 
 	/** @brief writes a \b INT64 as \b big endian to a \b wStream. The stream must be large enough
@@ -1150,14 +1148,8 @@ extern "C"
 		WINPR_ASSERT(_s->pointer);
 		WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= 8);
 
-		*_s->pointer++ = (_v >> 56) & 0xFF;
-		*_s->pointer++ = ((_v) >> 48) & 0xFF;
-		*_s->pointer++ = ((_v) >> 40) & 0xFF;
-		*_s->pointer++ = ((_v) >> 32) & 0xFF;
-		*_s->pointer++ = ((_v) >> 24) & 0xFF;
-		*_s->pointer++ = ((_v) >> 16) & 0xFF;
-		*_s->pointer++ = ((_v) >> 8) & 0xFF;
-		*_s->pointer++ = ((_v) >> 0) & 0xFF;
+		winpr_Data_Write_INT64_BE(_s->pointer, _v);
+		_s->pointer += 8;
 	}
 
 	static INLINE void Stream_Write(wStream* _s, const void* _b, size_t _n)

--- a/winpr/include/winpr/winpr.h
+++ b/winpr/include/winpr/winpr.h
@@ -145,15 +145,16 @@ WINPR_API const char* winpr_get_build_config(void);
  * @return The casted pointer
  * @since version 3.9.0
  */
-#define WINPR_REINTERPRET_CAST(ptr, srcType, dstType) \
-	__extension__({                                   \
-		union                                         \
-		{                                             \
-			srcType src;                              \
-			dstType dst;                              \
-		} cnv;                                        \
-		cnv.src = ptr;                                \
-		cnv.dst;                                      \
+#define WINPR_REINTERPRET_CAST(ptr, srcType, dstType)            \
+	__extension__({                                              \
+		union                                                    \
+		{                                                        \
+			srcType src;                                         \
+			dstType dst;                                         \
+		} cnv;                                                   \
+		WINPR_STATIC_ASSERT(sizeof(srcType) == sizeof(dstType)); \
+		cnv.src = ptr;                                           \
+		cnv.dst;                                                 \
 	})
 
 /**

--- a/winpr/libwinpr/crt/string.c
+++ b/winpr/libwinpr/crt/string.c
@@ -536,7 +536,7 @@ DWORD CharUpperBuffW(LPWSTR lpsz, DWORD cchLength)
 	{
 		WCHAR value = winpr_Data_Get_UINT16(&lpsz[i]);
 		value = WINPR_TOUPPERW(value);
-		Data_Write_UINT16(&lpsz[i], value);
+		winpr_Data_Write_UINT16(&lpsz[i], value);
 	}
 
 	return cchLength;
@@ -603,7 +603,7 @@ DWORD CharLowerBuffW(LPWSTR lpsz, DWORD cchLength)
 	{
 		WCHAR value = winpr_Data_Get_UINT16(&lpsz[i]);
 		value = WINPR_TOLOWERW(value);
-		Data_Write_UINT16(&lpsz[i], value);
+		winpr_Data_Write_UINT16(&lpsz[i], value);
 	}
 
 	return cchLength;

--- a/winpr/libwinpr/crt/string.c
+++ b/winpr/libwinpr/crt/string.c
@@ -532,11 +532,9 @@ DWORD CharUpperBuffA(LPSTR lpsz, DWORD cchLength)
 
 DWORD CharUpperBuffW(LPWSTR lpsz, DWORD cchLength)
 {
-	WCHAR value = 0;
-
 	for (DWORD i = 0; i < cchLength; i++)
 	{
-		Data_Read_UINT16(&lpsz[i], value);
+		WCHAR value = winpr_Data_Get_UINT16(&lpsz[i]);
 		value = WINPR_TOUPPERW(value);
 		Data_Write_UINT16(&lpsz[i], value);
 	}
@@ -601,11 +599,9 @@ DWORD CharLowerBuffA(LPSTR lpsz, DWORD cchLength)
 
 DWORD CharLowerBuffW(LPWSTR lpsz, DWORD cchLength)
 {
-	WCHAR value = 0;
-
 	for (DWORD i = 0; i < cchLength; i++)
 	{
-		Data_Read_UINT16(&lpsz[i], value);
+		WCHAR value = winpr_Data_Get_UINT16(&lpsz[i]);
 		value = WINPR_TOLOWERW(value);
 		Data_Write_UINT16(&lpsz[i], value);
 	}

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -864,11 +864,11 @@ static BOOL kerberos_hash_channel_bindings(WINPR_DIGEST_CTX* md5, SEC_CHANNEL_BI
 {
 	BYTE buf[4];
 
-	Data_Write_UINT32(buf, bindings->dwInitiatorAddrType);
+	winpr_Data_Write_UINT32(buf, bindings->dwInitiatorAddrType);
 	if (!winpr_Digest_Update(md5, buf, 4))
 		return FALSE;
 
-	Data_Write_UINT32(buf, bindings->cbInitiatorLength);
+	winpr_Data_Write_UINT32(buf, bindings->cbInitiatorLength);
 	if (!winpr_Digest_Update(md5, buf, 4))
 		return FALSE;
 
@@ -877,11 +877,11 @@ static BOOL kerberos_hash_channel_bindings(WINPR_DIGEST_CTX* md5, SEC_CHANNEL_BI
 	                         bindings->cbInitiatorLength))
 		return FALSE;
 
-	Data_Write_UINT32(buf, bindings->dwAcceptorAddrType);
+	winpr_Data_Write_UINT32(buf, bindings->dwAcceptorAddrType);
 	if (!winpr_Digest_Update(md5, buf, 4))
 		return FALSE;
 
-	Data_Write_UINT32(buf, bindings->cbAcceptorLength);
+	winpr_Data_Write_UINT32(buf, bindings->cbAcceptorLength);
 	if (!winpr_Digest_Update(md5, buf, 4))
 		return FALSE;
 
@@ -890,7 +890,7 @@ static BOOL kerberos_hash_channel_bindings(WINPR_DIGEST_CTX* md5, SEC_CHANNEL_BI
 	                         bindings->cbAcceptorLength))
 		return FALSE;
 
-	Data_Write_UINT32(buf, bindings->cbApplicationDataLength);
+	winpr_Data_Write_UINT32(buf, bindings->cbApplicationDataLength);
 	if (!winpr_Digest_Update(md5, buf, 4))
 		return FALSE;
 
@@ -1076,8 +1076,8 @@ static SECURITY_STATUS SEC_ENTRY kerberos_InitializeSecurityContextA(
 			/* Write the checksum (delegation not implemented) */
 			cksum.data = cksum_contents;
 			cksum.length = sizeof(cksum_contents);
-			Data_Write_UINT32(cksum_contents, 16);
-			Data_Write_UINT32((cksum_contents + 20), context->flags);
+			winpr_Data_Write_UINT32(cksum_contents, 16);
+			winpr_Data_Write_UINT32((cksum_contents + 20), context->flags);
 
 			if (bindings_buffer)
 			{
@@ -1865,17 +1865,18 @@ static SECURITY_STATUS SEC_ENTRY kerberos_EncryptMessage(PCtxtHandle phContext, 
 	encrypt_iov[1].data.data = data_buffer->pvBuffer;
 
 	/* Write the GSS header with 0 in RRC */
-	Data_Write_UINT16_BE(header, TOK_ID_WRAP);
+	winpr_Data_Write_UINT16_BE(header, TOK_ID_WRAP);
 	header[2] = flags;
 	header[3] = (char)0xFF;
-	Data_Write_UINT32(header + 4, 0);
-	Data_Write_UINT64_BE(header + 8, (context->local_seq + MessageSeqNo));
+	winpr_Data_Write_UINT32(header + 4, 0);
+	winpr_Data_Write_UINT64_BE(header + 8, (context->local_seq + MessageSeqNo));
 
 	/* Copy header to be encrypted */
 	CopyMemory(encrypt_iov[2].data.data, header, 16);
 
 	/* Set the correct RRC */
-	Data_Write_UINT16_BE(header + 6, 16 + encrypt_iov[3].data.length + encrypt_iov[4].data.length);
+	winpr_Data_Write_UINT16_BE(header + 6,
+	                           16 + encrypt_iov[3].data.length + encrypt_iov[4].data.length);
 
 	if (krb_log_exec(krb5glue_encrypt_iov, creds->ctx, key, usage, encrypt_iov,
 	                 ARRAYSIZE(encrypt_iov)))
@@ -1978,8 +1979,8 @@ static SECURITY_STATUS SEC_ENTRY kerberos_DecryptMessage(PCtxtHandle phContext,
 		return SEC_E_INTERNAL_ERROR;
 
 	/* Validate the encrypted header */
-	Data_Write_UINT16_BE(iov[2].data.data + 4, ec);
-	Data_Write_UINT16_BE(iov[2].data.data + 6, rrc);
+	winpr_Data_Write_UINT16_BE(iov[2].data.data + 4, ec);
+	winpr_Data_Write_UINT16_BE(iov[2].data.data + 6, rrc);
 	if (memcmp(iov[2].data.data, header, 16) != 0)
 		return SEC_E_MESSAGE_ALTERED;
 
@@ -2041,10 +2042,10 @@ static SECURITY_STATUS SEC_ENTRY kerberos_MakeSignature(PCtxtHandle phContext, U
 
 	/* Write the header */
 	header = sig_buffer->pvBuffer;
-	Data_Write_UINT16_BE(header, TOK_ID_MIC);
+	winpr_Data_Write_UINT16_BE(header, TOK_ID_MIC);
 	header[2] = flags;
 	memset(header + 3, 0xFF, 5);
-	Data_Write_UINT64_BE(header + 8, (context->local_seq + MessageSeqNo));
+	winpr_Data_Write_UINT64_BE(header + 8, (context->local_seq + MessageSeqNo));
 
 	/* Set up the iov array */
 	iov[0].data.data = data_buffer->pvBuffer;

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -1925,11 +1925,11 @@ static SECURITY_STATUS SEC_ENTRY kerberos_DecryptMessage(PCtxtHandle phContext,
 
 	/* Read in header information */
 	header = sig_buffer->pvBuffer;
-	Data_Read_UINT16_BE(header, tok_id);
+	tok_id = winpr_Data_Get_UINT16_BE(header);
 	flags = header[2];
-	Data_Read_UINT16_BE((header + 4), ec);
-	Data_Read_UINT16_BE((header + 6), rrc);
-	Data_Read_UINT64_BE((header + 8), seq_no);
+	ec = winpr_Data_Get_UINT16_BE((header + 4));
+	rrc = winpr_Data_Get_UINT16_BE((header + 6));
+	seq_no = winpr_Data_Get_UINT64_BE((header + 8));
 
 	/* Check that the header is valid */
 	if (tok_id != TOK_ID_WRAP || (BYTE)header[3] != 0xFF)
@@ -2096,9 +2096,9 @@ static SECURITY_STATUS SEC_ENTRY kerberos_VerifySignature(PCtxtHandle phContext,
 
 	/* Read in header info */
 	header = sig_buffer->pvBuffer;
-	Data_Read_UINT16_BE(header, tok_id);
+	tok_id = winpr_Data_Get_UINT16_BE(header);
 	flags = header[2];
-	Data_Read_UINT64_BE((header + 8), seq_no);
+	seq_no = winpr_Data_Get_UINT64_BE((header + 8));
 
 	/* Validate header */
 	if (tok_id != TOK_ID_MIC)

--- a/winpr/libwinpr/sspi/Kerberos/krb5glue_mit.c
+++ b/winpr/libwinpr/sspi/Kerberos/krb5glue_mit.c
@@ -114,7 +114,7 @@ BOOL krb5glue_authenticator_validate_chksum(krb5glue_authenticator authenticator
 	if (!authenticator || !authenticator->checksum ||
 	    authenticator->checksum->checksum_type != cksumtype || authenticator->checksum->length < 24)
 		return FALSE;
-	Data_Read_UINT32((authenticator->checksum->contents + 20), (*flags));
+	*flags = winpr_Data_Get_UINT32((authenticator->checksum->contents + 20));
 	return TRUE;
 }
 

--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -1083,7 +1083,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_EncryptMessage(PCtxtHandle phContext, ULON
 	if (hmac &&
 	    winpr_HMAC_Init(hmac, WINPR_MD_MD5, context->SendSigningKey, WINPR_MD5_DIGEST_LENGTH))
 	{
-		Data_Write_UINT32(&value, SeqNo);
+		winpr_Data_Write_UINT32(&value, SeqNo);
 		winpr_HMAC_Update(hmac, (void*)&value, 4);
 		winpr_HMAC_Update(hmac, data, length);
 		winpr_HMAC_Final(hmac, digest, WINPR_MD5_DIGEST_LENGTH);
@@ -1119,9 +1119,9 @@ static SECURITY_STATUS SEC_ENTRY ntlm_EncryptMessage(PCtxtHandle phContext, ULON
 	{
 		BYTE* signature = signature_buffer->pvBuffer;
 		/* Concatenate version, ciphertext and sequence number to build signature */
-		Data_Write_UINT32(signature, version);
+		winpr_Data_Write_UINT32(signature, version);
 		CopyMemory(&signature[4], (void*)checksum, 8);
-		Data_Write_UINT32(&signature[12], SeqNo);
+		winpr_Data_Write_UINT32(&signature[12], SeqNo);
 	}
 	context->SendSeqNum++;
 #ifdef WITH_DEBUG_NTLM
@@ -1182,7 +1182,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_DecryptMessage(PCtxtHandle phContext, PSec
 	if (hmac &&
 	    winpr_HMAC_Init(hmac, WINPR_MD_MD5, context->RecvSigningKey, WINPR_MD5_DIGEST_LENGTH))
 	{
-		Data_Write_UINT32(&value, SeqNo);
+		winpr_Data_Write_UINT32(&value, SeqNo);
 		winpr_HMAC_Update(hmac, (void*)&value, 4);
 		winpr_HMAC_Update(hmac, data_buffer->pvBuffer, data_buffer->cbBuffer);
 		winpr_HMAC_Final(hmac, digest, WINPR_MD5_DIGEST_LENGTH);
@@ -1205,9 +1205,9 @@ static SECURITY_STATUS SEC_ENTRY ntlm_DecryptMessage(PCtxtHandle phContext, PSec
 	/* RC4-encrypt first 8 bytes of digest */
 	winpr_RC4_Update(context->RecvRc4Seal, 8, digest, checksum);
 	/* Concatenate version, ciphertext and sequence number to build signature */
-	Data_Write_UINT32(expected_signature, version);
+	winpr_Data_Write_UINT32(expected_signature, version);
 	CopyMemory(&expected_signature[4], (void*)checksum, 8);
-	Data_Write_UINT32(&expected_signature[12], SeqNo);
+	winpr_Data_Write_UINT32(&expected_signature[12], SeqNo);
 	context->RecvSeqNum++;
 
 	if (memcmp(signature_buffer->pvBuffer, expected_signature, 16) != 0)
@@ -1258,7 +1258,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_MakeSignature(PCtxtHandle phContext, ULONG
 		return SEC_E_INTERNAL_ERROR;
 	}
 
-	Data_Write_UINT32(&seq_no, MessageSeqNo);
+	winpr_Data_Write_UINT32(&seq_no, MessageSeqNo);
 	winpr_HMAC_Update(hmac, (BYTE*)&seq_no, 4);
 	winpr_HMAC_Update(hmac, data_buffer->pvBuffer, data_buffer->cbBuffer);
 	winpr_HMAC_Final(hmac, digest, WINPR_MD5_DIGEST_LENGTH);
@@ -1267,9 +1267,9 @@ static SECURITY_STATUS SEC_ENTRY ntlm_MakeSignature(PCtxtHandle phContext, ULONG
 	winpr_RC4_Update(context->SendRc4Seal, 8, digest, checksum);
 
 	BYTE* signature = sig_buffer->pvBuffer;
-	Data_Write_UINT32(signature, 1L);
+	winpr_Data_Write_UINT32(signature, 1L);
 	CopyMemory(&signature[4], checksum, 8);
-	Data_Write_UINT32(&signature[12], seq_no);
+	winpr_Data_Write_UINT32(&signature[12], seq_no);
 	sig_buffer->cbBuffer = 16;
 
 	return SEC_E_OK;
@@ -1309,7 +1309,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_VerifySignature(PCtxtHandle phContext,
 		return SEC_E_INTERNAL_ERROR;
 	}
 
-	Data_Write_UINT32(&seq_no, MessageSeqNo);
+	winpr_Data_Write_UINT32(&seq_no, MessageSeqNo);
 	winpr_HMAC_Update(hmac, (BYTE*)&seq_no, 4);
 	winpr_HMAC_Update(hmac, data_buffer->pvBuffer, data_buffer->cbBuffer);
 	winpr_HMAC_Final(hmac, digest, WINPR_MD5_DIGEST_LENGTH);
@@ -1317,9 +1317,9 @@ static SECURITY_STATUS SEC_ENTRY ntlm_VerifySignature(PCtxtHandle phContext,
 
 	winpr_RC4_Update(context->RecvRc4Seal, 8, digest, checksum);
 
-	Data_Write_UINT32(signature, 1L);
+	winpr_Data_Write_UINT32(signature, 1L);
 	CopyMemory(&signature[4], checksum, 8);
-	Data_Write_UINT32(&signature[12], seq_no);
+	winpr_Data_Write_UINT32(&signature[12], seq_no);
 
 	if (memcmp(sig_buffer->pvBuffer, signature, 16) != 0)
 		return SEC_E_MESSAGE_ALTERED;

--- a/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
@@ -109,14 +109,13 @@ static BOOL ntlm_av_pair_list_init(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairLis
 
 static INLINE BOOL ntlm_av_pair_get_id(const NTLM_AV_PAIR* pAvPair, size_t size, UINT16* pair)
 {
-	UINT16 AvId = 0;
 	if (!pAvPair || !pair)
 		return FALSE;
 
 	if (size < sizeof(NTLM_AV_PAIR))
 		return FALSE;
 
-	Data_Read_UINT16(&pAvPair->AvId, AvId);
+	const UINT16 AvId = winpr_Data_Get_UINT16(&pAvPair->AvId);
 
 	*pair = AvId;
 	return TRUE;
@@ -142,14 +141,13 @@ ULONG ntlm_av_pair_list_length(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairList)
 
 static INLINE BOOL ntlm_av_pair_get_len(const NTLM_AV_PAIR* pAvPair, size_t size, size_t* pAvLen)
 {
-	UINT16 AvLen = 0;
 	if (!pAvPair)
 		return FALSE;
 
 	if (size < sizeof(NTLM_AV_PAIR))
 		return FALSE;
 
-	Data_Read_UINT16(&pAvPair->AvLen, AvLen);
+	const UINT16 AvLen = winpr_Data_Get_UINT16(&pAvPair->AvLen);
 
 	*pAvLen = AvLen;
 	return TRUE;

--- a/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
@@ -86,13 +86,13 @@ static NTLM_AV_PAIR* ntlm_av_pair_next(NTLM_AV_PAIR* pAvPairList, size_t* pcbAvP
 static INLINE void ntlm_av_pair_set_id(NTLM_AV_PAIR* pAvPair, UINT16 id)
 {
 	WINPR_ASSERT(pAvPair);
-	Data_Write_UINT16(&pAvPair->AvId, id);
+	winpr_Data_Write_UINT16(&pAvPair->AvId, id);
 }
 
 static INLINE void ntlm_av_pair_set_len(NTLM_AV_PAIR* pAvPair, UINT16 len)
 {
 	WINPR_ASSERT(pAvPair);
-	Data_Write_UINT16(&pAvPair->AvLen, len);
+	winpr_Data_Write_UINT16(&pAvPair->AvLen, len);
 }
 
 static BOOL ntlm_av_pair_list_init(NTLM_AV_PAIR* pAvPairList, size_t cbAvPairList)
@@ -461,10 +461,10 @@ static void ntlm_compute_single_host_data(NTLM_CONTEXT* context)
 	 * different or if they are on different hosts, then the information MUST be ignored.
 	 * Any fields after the MachineID field MUST be ignored on receipt.
 	 */
-	Data_Write_UINT32(&context->SingleHostData.Size, 48);
-	Data_Write_UINT32(&context->SingleHostData.Z4, 0);
-	Data_Write_UINT32(&context->SingleHostData.DataPresent, 1);
-	Data_Write_UINT32(&context->SingleHostData.CustomData, SECURITY_MANDATORY_MEDIUM_RID);
+	winpr_Data_Write_UINT32(&context->SingleHostData.Size, 48);
+	winpr_Data_Write_UINT32(&context->SingleHostData.Z4, 0);
+	winpr_Data_Write_UINT32(&context->SingleHostData.DataPresent, 1);
+	winpr_Data_Write_UINT32(&context->SingleHostData.CustomData, SECURITY_MANDATORY_MEDIUM_RID);
 	FillMemory(context->SingleHostData.MachineID, 32, 0xAA);
 }
 
@@ -727,7 +727,7 @@ BOOL ntlm_construct_authenticate_target_info(NTLM_CONTEXT* context)
 	if (context->UseMIC)
 	{
 		UINT32 flags = 0;
-		Data_Write_UINT32(&flags, MSV_AV_FLAGS_MESSAGE_INTEGRITY_CHECK);
+		winpr_Data_Write_UINT32(&flags, MSV_AV_FLAGS_MESSAGE_INTEGRITY_CHECK);
 
 		if (!ntlm_av_pair_add(AuthenticateTargetInfo, cbAuthenticateTargetInfo, MsvAvFlags,
 		                      (PBYTE)&flags, 4))

--- a/winpr/libwinpr/sspi/NTLM/ntlm_message.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_message.c
@@ -1040,7 +1040,7 @@ SECURITY_STATUS ntlm_read_AuthenticateMessage(NTLM_CONTEXT* context, PSecBuffer 
 		                     context->NTLMv2Response.Challenge.cbAvPairs, MsvAvFlags, &cbAvFlags);
 
 		if (AvFlags)
-			Data_Read_UINT32(ntlm_av_pair_get_value_pointer(AvFlags), flags);
+			flags = winpr_Data_Get_UINT32(ntlm_av_pair_get_value_pointer(AvFlags));
 	}
 
 	if (!ntlm_read_message_fields_buffer(

--- a/winpr/libwinpr/sspi/sspi_gss.c
+++ b/winpr/libwinpr/sspi/sspi_gss.c
@@ -41,7 +41,7 @@ BOOL sspi_gss_wrap_token(SecBuffer* buf, const WinPrAsn1_OID* oid, uint16_t tok_
 	WINPR_ASSERT(oid);
 	WINPR_ASSERT(token);
 
-	Data_Write_UINT16_BE(tok_id_buf, tok_id);
+	winpr_Data_Write_UINT16_BE(tok_id_buf, tok_id);
 
 	enc = WinPrAsn1Encoder_New(WINPR_ASN1_DER);
 	if (!enc)

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -906,11 +906,11 @@ HANDLE _GetCurrentThread(VOID)
 
 DWORD GetCurrentThreadId(VOID)
 {
-	pthread_t tid = 0;
-	tid = pthread_self();
+	pthread_t tid = pthread_self();
 	/* Since pthread_t can be 64-bits on some systems, take just the    */
 	/* lower 32-bits of it for the thread ID returned by this function. */
-	return WINPR_REINTERPRET_CAST(tid, pthread_t, DWORD) & 0xffffffffUL;
+	uintptr_t ptid = WINPR_REINTERPRET_CAST(tid, pthread_t, uintptr_t);
+	return ptid & UINT32_MAX;
 }
 
 typedef struct


### PR DESCRIPTION
* fix a few endianess issues reported
* refactor the macros to static functions
* rename functions to use `winpr_` prefix for uniqueness
* deprecate old macro names
* `Static_Assert` `WINPR_REINTERPRET_CAST` required predicates