### PR TITLE
[client,common] fix manpage generation

### DIFF
--- a/client/SDL/common/res/resource.cpp.in
+++ b/client/SDL/common/res/resource.cpp.in
@@ -25,3 +25,4 @@ std::vector<unsigned char> @CLASSNAME@::init() {
 	};
 	return std::vector<unsigned char>(data, data + sizeof(data));
 }
+

--- a/client/common/man/CMakeLists.txt
+++ b/client/common/man/CMakeLists.txt
@@ -4,6 +4,12 @@ else()
   include_directories(${CMAKE_BINARY_DIR}/include/)
 
   add_executable(generate_argument_manpage generate_argument_manpage.c ../cmdline.h)
+
+  # Ensure we build with host compiler and no compile/link flags used by other modules.
+  set_target_properties(
+    generate_argument_manpage PROPERTIES COMPILE_OPTIONS "" LINK_OPTIONS "" STATIC_LIBRARY_OPTIONS ""
+  )
+
   export(TARGETS generate_argument_manpage FILE "${CMAKE_BINARY_DIR}/GenerateArgumentManpageConfig.cmake")
 endif()
 


### PR DESCRIPTION
strip all compile/link flags for the manpage helper tool. This avoids linking/runtime issues with e.g. ASAN and other such tools used by nightly builds and others.