### PR TITLE
[client,x11] reset buffer length when sending

### DIFF
--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -945,6 +945,10 @@ static void xf_cliprdr_process_requested_data(xfClipboard* clipboard, BOOL hasDa
 	if (clipboard->incr_starts && hasData)
 		return;
 
+	/* Reset incr_data_length, as we've reached the end of a possible incremental update.
+	 * this ensures on next event that the buffer is not reused. */
+	clipboard->incr_data_length = 0;
+
 	format = xf_cliprdr_get_client_format_by_id(clipboard, clipboard->requestedFormatId);
 
 	if (!hasData || !data || !format)


### PR DESCRIPTION
When sending clipboard data reset the intermediate buffer position. This way the buffer is always 0 at beginning of reads, even if the same clipboard contents is requested in a different format.

Follow up to #10942 