### PR TITLE
[utils,passphrase] allow popen

### DIFF
--- a/libfreerdp/utils/passphrase.c
+++ b/libfreerdp/utils/passphrase.c
@@ -236,6 +236,7 @@ static const char* freerdp_passphrase_read_askpass(const char* prompt, char* buf
 
 	(void)sprintf_s(command, sizeof(command), "%s 'FreeRDP authentication\n%s'", askpass_env,
 	                prompt);
+	// NOLINTNEXTLINE(clang-analyzer-optin.taint.GenericTaint)
 	FILE* askproc = popen(command, "r");
 	if (!askproc)
 		return NULL;

--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -1458,6 +1458,7 @@ HANDLE GetFileHandleForFileDescriptor(int fd)
 
 	(void)setvbuf(fp, NULL, _IONBF, 0);
 
+	// NOLINTNEXTLINE(clang-analyzer-unix.Stream)
 	pFile = FileHandle_New(fp);
 	if (!pFile)
 		return INVALID_HANDLE_VALUE;


### PR DESCRIPTION
silence clang-analyzer as we require popen for FREERDP_ASKPASS
