### PR TITLE
Fix sdl3-freerdp blurry scaling on wayland when scale factor > 1

### DIFF
--- a/client/SDL/SDL3/sdl_disp.cpp
+++ b/client/SDL/SDL3/sdl_disp.cpp
@@ -51,8 +51,7 @@ BOOL sdlDispContext::settings_changed()
 	    freerdp_settings_get_uint16(settings, FreeRDP_DesktopOrientation))
 		return TRUE;
 
-	if (_lastSentDesktopScaleFactor !=
-	    freerdp_settings_get_uint32(settings, FreeRDP_DesktopScaleFactor))
+	if (_lastSentDesktopScaleFactor != _targetDesktopScaleFactor)
 		return TRUE;
 
 	if (_lastSentDeviceScaleFactor !=
@@ -75,7 +74,7 @@ BOOL sdlDispContext::update_last_sent()
 	_lastSentWidth = _targetWidth;
 	_lastSentHeight = _targetHeight;
 	_lastSentDesktopOrientation = freerdp_settings_get_uint16(settings, FreeRDP_DesktopOrientation);
-	_lastSentDesktopScaleFactor = freerdp_settings_get_uint32(settings, FreeRDP_DesktopScaleFactor);
+	_lastSentDesktopScaleFactor = _targetDesktopScaleFactor;
 	_lastSentDeviceScaleFactor = freerdp_settings_get_uint32(settings, FreeRDP_DeviceScaleFactor);
 	// TODO _fullscreen = _sdl->fullscreen;
 	return TRUE;
@@ -116,8 +115,7 @@ BOOL sdlDispContext::sendResize()
 		layout.Width = WINPR_ASSERTING_INT_CAST(uint32_t, _targetWidth);
 		layout.Height = WINPR_ASSERTING_INT_CAST(uint32_t, _targetHeight);
 		layout.Orientation = freerdp_settings_get_uint16(settings, FreeRDP_DesktopOrientation);
-		layout.DesktopScaleFactor =
-		    freerdp_settings_get_uint32(settings, FreeRDP_DesktopScaleFactor);
+		layout.DesktopScaleFactor = _targetDesktopScaleFactor;
 		layout.DeviceScaleFactor = freerdp_settings_get_uint32(settings, FreeRDP_DeviceScaleFactor);
 		layout.PhysicalWidth = WINPR_ASSERTING_INT_CAST(uint32_t, _targetWidth);
 		layout.PhysicalHeight = WINPR_ASSERTING_INT_CAST(uint32_t, _targetHeight);
@@ -356,13 +354,19 @@ BOOL sdlDispContext::handle_window_event(const SDL_WindowEvent* ev)
 		case SDL_EVENT_WINDOW_RESTORED:
 			gdi_send_suppress_output(_sdl->context()->gdi, FALSE);
 			return TRUE;
-
-		case SDL_EVENT_WINDOW_RESIZED:
+		case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:
 		case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
-			_targetWidth = ev->data1;
-			_targetHeight = ev->data2;
+		{
+			if (freerdp_settings_get_bool(_sdl->context()->settings,
+			                              FreeRDP_DynamicResolutionUpdate))
+			{
+				const auto& window = _sdl->windows.at(ev->windowID);
+				const auto factor = SDL_GetWindowDisplayScale(window.window());
+				_targetDesktopScaleFactor = static_cast<UINT32>(100 * factor);
+			}
+			assert(SDL_GetWindowSizeInPixels(it->second.window(), &_targetWidth, &_targetHeight));
 			return addTimer();
-
+		}
 		case SDL_EVENT_WINDOW_MOUSE_LEAVE:
 			WINPR_ASSERT(_sdl);
 			_sdl->input.keyboard_grab(ev->windowID, false);
@@ -456,6 +460,8 @@ sdlDispContext::sdlDispContext(SdlContext* sdl) : _sdl(sdl)
 	    int32_t, freerdp_settings_get_uint32(settings, FreeRDP_DesktopWidth));
 	_lastSentHeight = _targetHeight = WINPR_ASSERTING_INT_CAST(
 	    int32_t, freerdp_settings_get_uint32(settings, FreeRDP_DesktopHeight));
+	_lastSentDesktopScaleFactor = _targetDesktopScaleFactor =
+	    freerdp_settings_get_uint32(settings, FreeRDP_DesktopScaleFactor);
 	PubSub_SubscribeActivated(pubSub, sdlDispContext::OnActivated);
 	PubSub_SubscribeGraphicsReset(pubSub, sdlDispContext::OnGraphicsReset);
 	addTimer();

--- a/client/SDL/SDL3/sdl_disp.hpp
+++ b/client/SDL/SDL3/sdl_disp.hpp
@@ -45,6 +45,11 @@ class sdlDispContext
 
 	BOOL handle_window_event(const SDL_WindowEvent* ev);
 
+	[[nodiscard]] UINT32 scale_factor() const
+	{
+		return _lastSentDesktopScaleFactor;
+	}
+
   private:
 	UINT DisplayControlCaps(UINT32 maxNumMonitors, UINT32 maxMonitorAreaFactorA,
 	                        UINT32 maxMonitorAreaFactorB);
@@ -75,6 +80,7 @@ class sdlDispContext
 	UINT16 _lastSentDesktopOrientation = 0;
 	UINT32 _lastSentDesktopScaleFactor = 0;
 	UINT32 _lastSentDeviceScaleFactor = 0;
+	UINT32 _targetDesktopScaleFactor = 0;
 	SDL_TimerID _timer = 0;
 	unsigned _timer_retries = 0;
 };

--- a/client/SDL/SDL3/sdl_window.cpp
+++ b/client/SDL/SDL3/sdl_window.cpp
@@ -29,6 +29,7 @@ SdlWindow::SdlWindow(const std::string& title, Sint32 startupX, Sint32 startupY,
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, startupY);
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, width);
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, height);
+	SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN, true);
 	// SDL_SetProperty(props, SDL_PROP_WINDOW_CREATE_FL);
 	_window = SDL_CreateWindowWithProperties(props);
 	SDL_DestroyProperties(props);
@@ -65,7 +66,7 @@ SDL_Rect SdlWindow::rect() const
 	if (_window)
 	{
 		SDL_GetWindowPosition(_window, &rect.x, &rect.y);
-		SDL_GetWindowSize(_window, &rect.w, &rect.h);
+		SDL_GetWindowSizeInPixels(_window, &rect.w, &rect.h);
 	}
 	return rect;
 }


### PR DESCRIPTION
Draw the window using pixel coordinates instead of mouse coordinates for SDL3 HiDPI, and pass the window scale factor to the RDP server. This should fix #10689 by eliminating blurry scaling on Wayland when scale > 1. 

Currently, this patch is quite hacky, and any help in improving it would be greatly appreciated.