### PR TITLE
[winpr,sysinfo] fix use of GetComputerNameExA

### DIFF
--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -1165,7 +1165,7 @@ static UINT rdpdr_process_connect(rdpdrPlugin* rdpdr)
 		name = freerdp_settings_get_string(settings, FreeRDP_ComputerName);
 	if (!name)
 	{
-		DWORD size = sizeof(rdpdr->computerName) - 1;
+		DWORD size = ARRAYSIZE(rdpdr->computerName);
 		if (!GetComputerNameExA(ComputerNameNetBIOS, rdpdr->computerName, &size))
 			return ERROR_INTERNAL_ERROR;
 	}

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -321,7 +321,7 @@ static void settings_load_hkey_local_machine(rdpSettings* settings)
 static BOOL settings_init_computer_name(rdpSettings* settings)
 {
 	CHAR computerName[MAX_COMPUTERNAME_LENGTH + 1] = { 0 };
-	DWORD nSize = MAX_COMPUTERNAME_LENGTH;
+	DWORD nSize = ARRAYSIZE(computerName);
 
 	if (!GetComputerNameExA(ComputerNameNetBIOS, computerName, &nSize))
 		return FALSE;

--- a/winpr/libwinpr/sysinfo/test/TestGetComputerName.c
+++ b/winpr/libwinpr/sysinfo/test/TestGetComputerName.c
@@ -24,9 +24,9 @@ static BOOL Test_GetComputerName(void)
 	 *
 	 */
 
-	CHAR netbiosName1[MAX_COMPUTERNAME_LENGTH + 1];
-	CHAR netbiosName2[MAX_COMPUTERNAME_LENGTH + 1];
-	const DWORD netbiosBufferSize = sizeof(netbiosName1) / sizeof(CHAR);
+	CHAR netbiosName1[MAX_COMPUTERNAME_LENGTH + 1] = { 0 };
+	CHAR netbiosName2[MAX_COMPUTERNAME_LENGTH + 1] = { 0 };
+	const size_t netbiosBufferSize = ARRAYSIZE(netbiosName1);
 	DWORD dwSize = 0;
 	DWORD dwNameLength = 0;
 	DWORD dwError = 0;


### PR DESCRIPTION
The buffer must be large enough to hold MAX_COMPUTERNAME_LENGTH characters, so the buffer needs to be of size MAX_COMPUTERNAME_LENGTH + 1 or larger to hold the '\0' terminated string.