### PR TITLE
Fix HAVE_AF_VSOCK_H always being 0

### DIFF
--- a/libfreerdp/core/CMakeLists.txt
+++ b/libfreerdp/core/CMakeLists.txt
@@ -18,7 +18,8 @@
 set(MODULE_NAME "freerdp-core")
 set(MODULE_PREFIX "FREERDP_CORE")
 
-check_include_files("ctype.h;linux/vm_sockets.h" HAVE_AF_VSOCK_H)
+# We use some fields that are only defined in linux 5.11+
+check_symbol_exists(VMADDR_FLAG_TO_HOST "ctype.h;sys/socket.h;linux/vm_sockets.h" HAVE_AF_VSOCK_H)
 
 freerdp_definition_add(EXT_PATH="${FREERDP_EXTENSION_PATH}")
 


### PR DESCRIPTION
### Description

On current linux builds (at least I'm using 6.9.9) only including `linux/vm_sockets.h` to detect whether it's available or not fails as so:
```
/usr/include/linux/vm_sockets.h:182:39: error: invalid application of ‘sizeof’ to incomplete type ‘struct sockaddr’
      182 |         unsigned char svm_zero[sizeof(struct sockaddr) -
          |                                       ^~~~~~
        /usr/include/linux/vm_sockets.h:183:39: error: ‘sa_family_t’ undeclared here (not in a function)
      183 |                                sizeof(sa_family_t) -
          |                                       ^~~~~~~~~~~
```

This means that currently, even if available, `HAVE_AF_VSOCK_H` is always false.

(You'd be right to point out that this should likely be fixed in `linux/vm_sockets.h` by adding an include to `sys/socket.h`... but I'm not familiar with Linux kernel development)

### Content of the PR

- add `sys/socket.h` in the check for it to pass when `linux/vm_sockets.h` is available.