### PR TITLE
Fix gfxredir_server.. undeclared here

### DIFF
--- a/include/freerdp/server/gfxredir.h
+++ b/include/freerdp/server/gfxredir.h
@@ -92,9 +92,10 @@ extern "C"
 		UINT32 confirmedCapsVersion;
 	};
 
+	FREERDP_API void gfxredir_server_context_free(GfxRedirServerContext* context);
+
 	WINPR_ATTR_MALLOC(gfxredir_server_context_free, 1)
 	FREERDP_API GfxRedirServerContext* gfxredir_server_context_new(HANDLE vcm);
-	FREERDP_API void gfxredir_server_context_free(GfxRedirServerContext* context);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Trying to include `gfxredir.h` fails with:
```
In file included from /usr/local/lib/pkgconfig/../../include/winpr3/winpr/winpr.h:22:
/usr/local/lib/pkgconfig/../../include/freerdp3/freerdp/server/gfxredir.h:95:27: error: ‘gfxredir_server_context_free’ undeclared here (not in a function); did you mean ‘audin_server_context_free’?
   95 |         WINPR_ATTR_MALLOC(gfxredir_server_context_free, 1)
```

This was apparently broken in https://github.com/FreeRDP/FreeRDP/commit/bb42d425edd9467977f4673589c05028ec4701dc.

Merry christmas!