### PR TITLE
winpr/input: Add missing korean keyboard type

### DIFF
--- a/winpr/include/winpr/input.h
+++ b/winpr/include/winpr/input.h
@@ -875,7 +875,8 @@ extern "C"
 		WINPR_KBD_TYPE_IBM_ENHANCED = 0x00000004, /* IBM enhanced (101-key or 102-key) keyboard */
 		WINPR_KBD_TYPE_NOKIA_1050 = 0x00000005,   /* Nokia 1050 and similar keyboards */
 		WINPR_KBD_TYPE_NOKIA_9140 = 0x00000006,   /* Nokia 9140 and similar keyboards */
-		WINPR_KBD_TYPE_JAPANESE = 0x00000007      /* Japanese keyboard */
+		WINPR_KBD_TYPE_JAPANESE = 0x00000007,     /* Japanese keyboard */
+		WINPR_KBD_TYPE_KOREAN = 0x00000008        /* Korean keyboard */
 	};
 
 	/**


### PR DESCRIPTION
Quoting the commit here:
```
The keyboard types in 2.2.1.3.2 Client Core Data (TS_UD_CS_CORE)
([MS-RDPBCGR]) contain a korean keyboard type, which is not yet present
in WinPR. So, add it.
```