### PR TITLE
Allow to disable encryption as a server

### DIFF
--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -1505,18 +1505,6 @@ BOOL nego_send_negotiation_response(rdpNego* nego)
 				if (!freerdp_settings_set_bool(settings, FreeRDP_UseRdpSecurityLayer, TRUE))
 					return FALSE;
 
-				if (freerdp_settings_get_uint32(settings, FreeRDP_EncryptionLevel) ==
-				    ENCRYPTION_LEVEL_NONE)
-				{
-					/**
-					 * If the server implementation did not explicitly set a
-					 * encryption level we default to client compatible
-					 */
-					if (!freerdp_settings_set_uint32(settings, FreeRDP_EncryptionLevel,
-					                                 ENCRYPTION_LEVEL_CLIENT_COMPATIBLE))
-						return FALSE;
-				}
-
 				if (freerdp_settings_get_bool(settings, FreeRDP_LocalConnection))
 				{
 					/**
@@ -1531,6 +1519,12 @@ BOOL nego_send_negotiation_response(rdpNego* nego)
 						return FALSE;
 					if (!freerdp_settings_set_uint32(settings, FreeRDP_EncryptionLevel,
 					                                 ENCRYPTION_LEVEL_NONE))
+						return FALSE;
+				}
+				else if (freerdp_settings_get_uint32(settings, FreeRDP_EncryptionLevel) == ENCRYPTION_LEVEL_NONE)
+				{
+					/* Server is configured not to use encryption. This should be reserved for debugging */
+					if (!freerdp_settings_set_bool(settings, FreeRDP_UseRdpSecurityLayer, FALSE))
 						return FALSE;
 				}
 				else if (!freerdp_settings_get_pointer(settings, FreeRDP_RdpServerRsaKey))

--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -1524,6 +1524,8 @@ BOOL nego_send_negotiation_response(rdpNego* nego)
 				else if (freerdp_settings_get_uint32(settings, FreeRDP_EncryptionLevel) == ENCRYPTION_LEVEL_NONE)
 				{
 					/* Server is configured not to use encryption. This should be reserved for debugging */
+					WLog_INFO(TAG,
+					          "Turning off encryption because EncryptionLevel is set to NONE.");
 					if (!freerdp_settings_set_bool(settings, FreeRDP_UseRdpSecurityLayer, FALSE))
 						return FALSE;
 				}

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -258,7 +258,8 @@ static BOOL freerdp_peer_initialize(freerdp_peer* client)
 		return FALSE;
 	}
 
-	if (freerdp_settings_get_bool(settings, FreeRDP_RdpSecurity))
+	if (freerdp_settings_get_bool(settings, FreeRDP_RdpSecurity) &&
+		freerdp_settings_get_uint32(settings, FreeRDP_EncryptionLevel) != ENCRYPTION_LEVEL_NONE)
 	{
 
 		if (!freerdp_certificate_is_rdp_security_compatible(cert))

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -941,7 +941,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	                                 CONNECTION_TYPE_AUTODETECT) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_NetworkAutoDetect, TRUE) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_EncryptionMethods, ENCRYPTION_METHOD_NONE) ||
-	    !freerdp_settings_set_uint32(settings, FreeRDP_EncryptionLevel, ENCRYPTION_LEVEL_NONE) ||
+	    !freerdp_settings_set_uint32(settings, FreeRDP_EncryptionLevel, ENCRYPTION_LEVEL_CLIENT_COMPATIBLE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_FIPSMode, FALSE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_CompressionEnabled, TRUE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_LogonNotify, TRUE) ||


### PR DESCRIPTION
This PR makes it possible to disable encryption when acting as a server, by setting `FreeRDP_EncryptionLevel` to `ENCRYPTION_LEVEL_NONE`. Previously, this was the default but was changed dynamically to `ENCRYPTION_LEVEL_CLIENT_COMPATIBLE`, so instead it set the default to `ENCRYPTION_LEVEL_CLIENT_COMPATIBLE` and allow disabling it by setting it to None.

This is incredibly useful for debugging.