### PR TITLE
Regression in update_check_flush

### DIFF
--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -1079,19 +1079,20 @@ static BOOL update_check_flush(rdpContext* context, size_t size)
 
 	wStream* s = update->us;
 
-	if (!update->us)
+	if (!s)
 	{
-		update_begin_paint(&update->common);
-		return FALSE;
+		if (!update_begin_paint(&update->common))
+			return FALSE;
+		s = update->us;
 	}
 
-	if (Stream_GetPosition(s) + size + 64 >= 0x3FFF)
+	if (Stream_GetPosition(s) + size + 64 >= FASTPATH_MAX_PACKET_SIZE)
 	{
+		// Too big for the current packet. Flush first
 		update_flush(context);
-		return TRUE;
 	}
 
-	return FALSE;
+	return TRUE;
 }
 
 static BOOL update_set_bounds(rdpContext* context, const rdpBounds* bounds)


### PR DESCRIPTION
If I'm not mistaken, and I absolutely could be, I believe that the return value of `update_check_flush` is wrong and has been for a long time. This never was an issue before https://github.com/FreeRDP/FreeRDP/commit/5f862846638cfa92742a69a76ec160a0ff8299ab as it wasn't checked, but now that it is I believe that it's causing issues.

My understanding is that this function should:
- create `s->us` by calling `begin` if missing
- flush if the buffer is full
- return false if an error occurs

Currently doing `BeginPaint`, `CreateWindow` then `EndPaint` fails on CreateWindow because of that. I do not think that this is wanted.

If I got it wrong feel free to explain :P