### PR TITLE
[core,channels] fix check stream capacity in freerdp_channel_send_packet

### DIFF
--- a/libfreerdp/core/channels.c
+++ b/libfreerdp/core/channels.c
@@ -304,7 +304,7 @@ BOOL freerdp_channel_send_packet(rdpRdp* rdp, UINT16 channelId, size_t totalSize
 	if (!s)
 		return FALSE;
 
-	if (!Stream_EnsureCapacity(s, chunkSize + 8))
+	if (!Stream_EnsureRemainingCapacity(s, chunkSize + 8))
 	{
 		Stream_Release(s);
 		return FALSE;

--- a/libfreerdp/core/channels.c
+++ b/libfreerdp/core/channels.c
@@ -304,14 +304,14 @@ BOOL freerdp_channel_send_packet(rdpRdp* rdp, UINT16 channelId, size_t totalSize
 	if (!s)
 		return FALSE;
 
-	Stream_Write_UINT32(s, (UINT32)totalSize);
-	Stream_Write_UINT32(s, flags);
-
 	if (!Stream_EnsureCapacity(s, chunkSize))
 	{
 		Stream_Release(s);
 		return FALSE;
 	}
+
+	Stream_Write_UINT32(s, (UINT32)totalSize);
+	Stream_Write_UINT32(s, flags);
 
 	Stream_Write(s, data, chunkSize);
 

--- a/libfreerdp/core/channels.c
+++ b/libfreerdp/core/channels.c
@@ -304,7 +304,7 @@ BOOL freerdp_channel_send_packet(rdpRdp* rdp, UINT16 channelId, size_t totalSize
 	if (!s)
 		return FALSE;
 
-	if (!Stream_EnsureCapacity(s, chunkSize))
+	if (!Stream_EnsureCapacity(s, chunkSize + 8))
 	{
 		Stream_Release(s);
 		return FALSE;


### PR DESCRIPTION
I got a program crash in the freerdp_channel_send_packet call

```
Thread 5 "freerdp-shadow-" received signal SIGABRT, Aborted.
[Switching to Thread 0x7dab2bfff700 (LWP 11070)]
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
(gdb) bt
#0  0x00007dab364a986b in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007dab36494535 in __GI_abort () at abort.c:79
#2  0x00000000004600f2 in winpr_int_assert
    (condstr=0x6c1288 "Stream_GetRemainingCapacity(_s) >= _n", file=0x6c1188 "/opt/src/FreeRDP3/winpr/include/winpr/stream.h", fkt=0x700638 <__func__.8556.lto_priv.2394> "Stream_Write", line=631) at /opt/src/FreeRDP3/winpr/include/winpr/assert.h:48
#3  0x00000000004603f3 in Stream_Write (_s=0x7dab2001cda0, _b=0x7daaf4002160, _n=4087)
    at /opt/src/FreeRDP3/winpr/include/winpr/stream.h:631
#4  0x0000000000460e3f in freerdp_channel_send_packet
    (rdp=0x7dab2c00e540, channelId=1004, totalSize=4087, flags=3, data=0x7daaf4002160 "rDRI\001", chunkSize=4087)
    at /opt/src/FreeRDP3/libfreerdp/core/channels.c:312
#5  0x0000000000460697 in freerdp_channel_send (rdp=0x7dab2c00e540, channelId=1004, data=0x7daaf4002160 "rDRI\001", size=4087)
    at /opt/src/FreeRDP3/libfreerdp/core/channels.c:102
#6  0x000000000043f2aa in rdp_send_channel_data (rdp=0x7dab2c00e540, channelId=1004, data=0x7daaf4002160 "rDRI\001", size=4087)
    at /opt/src/FreeRDP3/libfreerdp/core/rdp.c:2142
#7  0x00000000005159bf in freerdp_peer_send_channel_data (client=0x7dab2c000f00, channelId=1004, data=0x7daaf4002160 "rDRI\001", size=4087)
    at /opt/src/FreeRDP3/libfreerdp/core/peer.c:1245
#8  0x00000000004f18a7 in WTSVirtualChannelManagerCheckFileDescriptorEx (hServer=0x7dab2c064900, autoOpen=1)
    at /opt/src/FreeRDP3/libfreerdp/core/server.c:614
#9  0x00000000004f190a in WTSVirtualChannelManagerCheckFileDescriptor (hServer=0x7dab2c064900)
    at /opt/src/FreeRDP3/libfreerdp/core/server.c:630
(gdb) up
#1  0x00007dab36494535 in __GI_abort () at abort.c:79
(gdb) up
#2  0x00000000004600f2 in winpr_int_assert (condstr=0x6c1288 "Stream_GetRemainingCapacity(_s) >= _n", 
    file=0x6c1188 "/opt/src/FreeRDP3/winpr/include/winpr/stream.h", fkt=0x700638 <__func__.8556.lto_priv.2394> "Stream_Write", line=631)
    at /opt/src/FreeRDP3/winpr/include/winpr/assert.h:48
48			abort();
(gdb) up
#3  0x00000000004603f3 in Stream_Write (_s=0x7dab2001cda0, _b=0x7daaf4002160, _n=4087)
    at /opt/src/FreeRDP3/winpr/include/winpr/stream.h:631
631				WINPR_ASSERT(Stream_GetRemainingCapacity(_s) >= _n);
(gdb) print _n
$1 = 4087
(gdb) print Stream_GetRemainingCapacity(_s)
$2 = 4073
(gdb) up
#4  0x0000000000460e3f in freerdp_channel_send_packet (rdp=0x7dab2c00e540, channelId=1004, totalSize=4087, flags=3, data=0x7daaf4002160 "rDRI\001", 
    chunkSize=4087) at /opt/src/FreeRDP3/libfreerdp/core/channels.c:312
312		Stream_Write(s, data, chunkSize);
(gdb) print Stream_GetRemainingCapacity(s)
$3 = 4073
(gdb) print chunkSize
$4 = 4087
(gdb) print totalSize
$5 = 4087
(gdb) print *s
$8 = {buffer = 0x7dab2000abf0 "\003", pointer = 0x7dab2000ac07 "0\003Ř\302\001\240V/", length = 4096, capacity = 4096, count = 1, 
  pool = 0x7dab2c02ebc0, isAllocatedStream = 1, isOwner = 1}
```

I used the freerdp version-3.7.0.
My little patch will fix the problem.

Thanks!