### PR TITLE
Fix calls of Stream_EnsureCapacity

### DIFF
--- a/channels/cliprdr/server/cliprdr_main.c
+++ b/channels/cliprdr/server/cliprdr_main.c
@@ -1113,7 +1113,7 @@ static UINT cliprdr_server_read(CliprdrServerContext* context)
 		Stream_Read_UINT16(s, header.msgFlags); /* msgFlags (2 bytes) */
 		Stream_Read_UINT32(s, header.dataLen);  /* dataLen (4 bytes) */
 
-		if (!Stream_EnsureCapacity(s, (header.dataLen + CLIPRDR_HEADER_LENGTH)))
+		if (!Stream_EnsureRemainingCapacity(s, header.dataLen))
 		{
 			WLog_ERR(TAG, "Stream_EnsureCapacity failed!");
 			return CHANNEL_RC_NO_MEMORY;

--- a/channels/rdpear/common/ndr.c
+++ b/channels/rdpear/common/ndr.c
@@ -258,7 +258,7 @@ BOOL ndr_start_constructed(NdrContext* context, wStream* s)
 {
 	WINPR_ASSERT(context);
 
-	if (!Stream_EnsureCapacity(s, 8))
+	if (!Stream_EnsureRemainingCapacity(s, 8))
 		return FALSE;
 
 	if (context->constructLevel == NDR_MAX_CONSTRUCTS)

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -2530,7 +2530,7 @@ int progressive_compress(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
 	if (numRects == 0)
 		return 0;
 
-	if (!Stream_EnsureCapacity(progressive->rects, numRects * sizeof(RFX_RECT)))
+	if (!Stream_EnsureRemainingCapacity(progressive->rects, numRects * sizeof(RFX_RECT)))
 		return -5;
 	rects = Stream_BufferAs(progressive->rects, RFX_RECT);
 	if (invalidRegion)


### PR DESCRIPTION
There were various places where `Stream_EnsureCapacity` was called instead of the expected `Stream_EnsureRemainingCapacity`. When the stream position is set to 0 the 2 calls are equivalent, but we had various places where it was not always the case.
