### PR TITLE
[winpr,timezone] restore TZ after decoding current time

### DIFF
--- a/libfreerdp/core/timezone.c
+++ b/libfreerdp/core/timezone.c
@@ -93,20 +93,20 @@ static void log_timezone_(const TIME_ZONE_INFORMATION* tzif, DWORD result, const
 	DWORD level = WLOG_TRACE;
 	wLog* log = WLog_Get(TIMEZONE_TAG);
 	log_print(log, level, file, fkt, line, "TIME_ZONE_INFORMATION {");
-	log_print(log, level, file, fkt, line, "  Bias=%" PRIu32, tzif->Bias);
+	log_print(log, level, file, fkt, line, "  Bias=%" PRId32, tzif->Bias);
 	(void)ConvertWCharNToUtf8(tzif->StandardName, ARRAYSIZE(tzif->StandardName), buffer,
 	                          ARRAYSIZE(buffer));
 	log_print(log, level, file, fkt, line, "  StandardName=%s", buffer);
 	log_print(log, level, file, fkt, line, "  StandardDate=%s",
 	          systemtime2str(&tzif->StandardDate, buffer, sizeof(buffer)));
-	log_print(log, level, file, fkt, line, "  StandardBias=%" PRIu32, tzif->StandardBias);
+	log_print(log, level, file, fkt, line, "  StandardBias=%" PRId32, tzif->StandardBias);
 
 	(void)ConvertWCharNToUtf8(tzif->DaylightName, ARRAYSIZE(tzif->DaylightName), buffer,
 	                          ARRAYSIZE(buffer));
 	log_print(log, level, file, fkt, line, "  DaylightName=%s", buffer);
 	log_print(log, level, file, fkt, line, "  DaylightDate=%s",
 	          systemtime2str(&tzif->DaylightDate, buffer, sizeof(buffer)));
-	log_print(log, level, file, fkt, line, "  DaylightBias=%" PRIu32, tzif->DaylightBias);
+	log_print(log, level, file, fkt, line, "  DaylightBias=%" PRId32, tzif->DaylightBias);
 
 	switch (result)
 	{

--- a/winpr/libwinpr/timezone/timezone.c
+++ b/winpr/libwinpr/timezone/timezone.c
@@ -880,11 +880,11 @@ DWORD EnumDynamicTimeZoneInformation(const DWORD dwIndex,
 
 	struct tm* local_time = localtime_r(&t, &tres);
 
-	if (entry->Iana)
-		restoreSavedTZ(tzcopy);
-
 	if (local_time)
 		dynamic_time_zone_from_localtime(local_time, lpTimeZoneInformation);
+
+	if (entry->Iana)
+		restoreSavedTZ(tzcopy);
 
 	return ERROR_SUCCESS;
 }


### PR DESCRIPTION
* fix a bug inherited from the spec https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/05ada9e4-a468-494b-8694-eb806a0ecc89 the timezone bias must be signed to work, so also handle it like that when printing out debug information
* restore the original `TZ` variable only after extracting the whole timezone data