### PR TITLE
Make credential dialog work with SDL3

### DIFF
--- a/client/SDL/SDL3/dialogs/sdl_input_widgets.cpp
+++ b/client/SDL/SDL3/dialogs/sdl_input_widgets.cpp
@@ -30,7 +30,7 @@ SdlInputWidgetList::SdlInputWidgetList(const std::string& title,
 	    title.c_str(), total_width, static_cast<int>(total_height),
 	    SDL_WINDOW_HIGH_PIXEL_DENSITY | SDL_WINDOW_MOUSE_FOCUS | SDL_WINDOW_INPUT_FOCUS, &_window,
 	    &_renderer);
-	if (rc != 0)
+	if (!rc)
 		widget_log_error(rc, "SDL_CreateWindowAndRenderer");
 	else
 	{

--- a/client/SDL/SDL3/dialogs/sdl_widget.cpp
+++ b/client/SDL/SDL3/dialogs/sdl_widget.cpp
@@ -195,13 +195,20 @@ SdlWidget::~SdlWidget()
 		SDL_DestroyTexture(_image);
 }
 
-bool SdlWidget::error_ex(Sint32 res, const char* what, const char* file, size_t line,
+bool SdlWidget::error_ex(bool success, const char* what, const char* file, size_t line,
                          const char* fkt)
 {
+	if (success)
+	{
+		// Flip SDL3 convention to existing code convention to minimize code changes
+		return false;
+	}
 	static wLog* log = nullptr;
 	if (!log)
 		log = WLog_Get(TAG);
-	return sdl_log_error_ex(res, log, what, file, line, fkt);
+	// Use -1 as it indicates error similar to SDL2 conventions
+	// sdl_log_error_ex treats any value other than 0 as SDL error
+	return sdl_log_error_ex(-1, log, what, file, line, fkt);
 }
 
 static bool draw_rect(SDL_Renderer* renderer, const SDL_FRect* rect, SDL_Color color)

--- a/client/SDL/SDL3/dialogs/sdl_widget.hpp
+++ b/client/SDL/SDL3/dialogs/sdl_widget.hpp
@@ -68,7 +68,7 @@ class SdlWidget
 	[[nodiscard]] const SDL_FRect& rect() const;
 
 #define widget_log_error(res, what) SdlWidget::error_ex(res, what, __FILE__, __LINE__, __func__)
-	static bool error_ex(Sint32 res, const char* what, const char* file, size_t line,
+	static bool error_ex(bool success, const char* what, const char* file, size_t line,
 	                     const char* fkt);
 
   private:


### PR DESCRIPTION
When using `master` branch with SDL3 the credentials dialog was not working for me.

Looking at code and API documentation seems like code was not fully changed from SDL2->SDL3 API conventions.


Tested by successfully working with real RDP host using SDL3 with wayland video driver and following flags

```
/gateway:g:<censored>,u:<censored>
/u:<censored>
/v:<censored>
/audio-mode:0
+compression
/multimon
+toggle-fullscreen
```