### PR TITLE
FreeRDP forces primary monitor (x,y) to 0, 0 which breaks multi-monitor geometry checks 

### DIFF
--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -2198,26 +2198,25 @@ BOOL gcc_write_client_monitor_data(wStream* s, const rdpMcs* mcs)
 			{
 				baseX = current->x;
 				baseY = current->y;
-				break;
 			}
 		}
 
 		for (UINT32 i = 0; i < settings->MonitorCount; i++)
 		{
 			const rdpMonitor* current = &settings->MonitorDefArray[i];
-			const UINT32 left = WINPR_ASSERTING_INT_CAST(uint32_t, current->x - baseX);
-			const UINT32 top = WINPR_ASSERTING_INT_CAST(uint32_t, current->y - baseY);
-			const UINT32 right = left + WINPR_ASSERTING_INT_CAST(uint32_t, current->width - 1);
-			const UINT32 bottom = top + WINPR_ASSERTING_INT_CAST(uint32_t, current->height - 1);
-			const UINT32 flags = current->is_primary ? MONITOR_PRIMARY : 0;
+			const INT32 left = WINPR_ASSERTING_INT_CAST(int32_t, current->x - baseX);
+			const INT32 top = WINPR_ASSERTING_INT_CAST(int32_t, current->y - baseY);
+			const INT32 right = left + WINPR_ASSERTING_INT_CAST(int32_t, current->width - 1);
+			const INT32 bottom = top + WINPR_ASSERTING_INT_CAST(int32_t, current->height - 1);
+			const INT32 flags = current->is_primary ? MONITOR_PRIMARY : 0;
 			WLog_DBG(TAG,
 			         "Monitor[%" PRIu32 "]: top=%" PRIu32 ", left=%" PRIu32 ", bottom=%" PRIu32
 			         ", right=%" PRIu32 ", flags=%" PRIu32,
 			         i, top, left, bottom, right, flags);
-			Stream_Write_UINT32(s, left);   /* left */
-			Stream_Write_UINT32(s, top);    /* top */
-			Stream_Write_UINT32(s, right);  /* right */
-			Stream_Write_UINT32(s, bottom); /* bottom */
+			Stream_Write_INT32(s, left);   /* left */
+			Stream_Write_INT32(s, top);    /* top */
+			Stream_Write_INT32(s, right);  /* right */
+			Stream_Write_INT32(s, bottom); /* bottom */
 			Stream_Write_UINT32(s, flags);  /* flags */
 		}
 	}

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -1763,8 +1763,6 @@ BOOL freerdp_settings_enforce_monitor_exists(rdpSettings* settings)
 		    freerdp_settings_get_pointer_array_writable(settings, FreeRDP_MonitorDefArray, 0);
 		if (!monitor)
 			return FALSE;
-		monitor->x = 0;
-		monitor->y = 0;
 		monitor->is_primary = TRUE;
 	}
 


### PR DESCRIPTION
*  I am using SDL3 client over wayland (KWIN)
* I have 3 monitor setup with middle monitor being the primary:

![Image](https://github.com/user-attachments/assets/a62ae3cf-d35b-417a-ad3f-e9b68f186e82)

The multi monitor geometry checks fail due to code in `freerdp_settings_enforce_monitor_exists` introduced in 392a0857280943002b1fffc4a5fd25deedec3ed2 forcing x and y of primary monitor to 0,0


Applying proposed changes fixes the geometry checks while ensuring monitor info is shifted so that top left of main monitor is still reported at (0,0) per `2.2.1.3.6.1 Monitor Definition (TS_MONITOR_DEF)` spec, and allows me to connect to Windows 11 RDP host.

There are other patches I had to apply to make SDL3 work and test this change but they felt separate from this issue:

* https://github.com/FreeRDP/FreeRDP/pull/11092
* https://github.com/FreeRDP/FreeRDP/pull/11093