### PR TITLE
[client] Add command line flag to disable Ctrl+Alt+M hotkey to minimize application

### DIFF
--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -640,8 +640,10 @@ BOOL xf_keyboard_handle_special_keys(xfContext* xfc, KeySym keysym)
 		{
 			case XK_m:
 			case XK_M:
-				xf_minimize(xfc);
-				return TRUE;
+				if(freerdp_settings_get_bool(xfc->common.context.settings, FreeRDP_MinimizeHotkey)) {
+					xf_minimize(xfc);
+					return TRUE;
+				}
 			case XK_c:
 			case XK_C:
 				/* Ctrl-Alt-C: toggle control */

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -5241,6 +5241,11 @@ static int freerdp_client_settings_parse_command_line_arguments_int(
 			if (!freerdp_settings_set_bool(settings, FreeRDP_ToggleFullscreen, enable))
 				return fail_at(arg, COMMAND_LINE_ERROR);
 		}
+		CommandLineSwitchCase(arg, "minimize-hotkey")
+		{
+			if (!freerdp_settings_set_bool(settings, FreeRDP_MinimizeHotkey, enable))
+				return fail_at(arg, COMMAND_LINE_ERROR);
+		}
 		CommandLineSwitchCase(arg, "force-console-callbacks")
 		{
 			if (!freerdp_settings_set_bool(settings, FreeRDP_UseCommonStdioCallbacks, enable))

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -491,6 +491,8 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 #endif
 	{ "toggle-fullscreen", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
 	  "Alt+Ctrl+Enter to toggle fullscreen" },
+	{ "minimize-hotkey", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
+	  "Alt+Ctrl+M to minimize application" },
 	{ "tune", COMMAND_LINE_VALUE_REQUIRED, "<setting:value>,<setting:value>", "", NULL, -1, NULL,
 	  "[experimental] directly manipulate freerdp settings, use with extreme caution!" },
 #if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)

--- a/include/freerdp/settings_types_private.h
+++ b/include/freerdp/settings_types_private.h
@@ -835,6 +835,8 @@ struct rdp_settings
 	 * The zone below this point is ABI unstable, and
 	 * is therefore potentially subject to ABI breakage.
 	 */
+
+	SETTINGS_DEPRECATED(ALIGN64 BOOL MinimizeHotkey);          /* 6000 */
 };
 
 #ifdef __cplusplus

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -360,6 +360,9 @@ BOOL freerdp_settings_get_bool(const rdpSettings* settings, FreeRDP_Settings_Key
 		case FreeRDP_MaximizeShell:
 			return settings->MaximizeShell;
 
+		case FreeRDP_MinimizeHotkey:
+			return settings->MinimizeHotkey;
+
 		case FreeRDP_MouseAttached:
 			return settings->MouseAttached;
 
@@ -1065,6 +1068,10 @@ BOOL freerdp_settings_set_bool(rdpSettings* settings, FreeRDP_Settings_Keys_Bool
 
 		case FreeRDP_MaximizeShell:
 			settings->MaximizeShell = cnv.c;
+			break;
+
+		case FreeRDP_MinimizeHotkey:
+			settings->MinimizeHotkey = cnv.c;
 			break;
 
 		case FreeRDP_MouseAttached:

--- a/libfreerdp/common/settings_str.h
+++ b/libfreerdp/common/settings_str.h
@@ -154,6 +154,7 @@ static const struct settings_str_entry settings_map[] = {
 	  "FreeRDP_LongCredentialsSupported" },
 	{ FreeRDP_LyncRdpMode, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_LyncRdpMode" },
 	{ FreeRDP_MaximizeShell, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_MaximizeShell" },
+	{ FreeRDP_MinimizeHotkey, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_MinimizeHotkey" },
 	{ FreeRDP_MouseAttached, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_MouseAttached" },
 	{ FreeRDP_MouseHasWheel, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_MouseHasWheel" },
 	{ FreeRDP_MouseMotion, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_MouseMotion" },

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -933,6 +933,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	    !freerdp_settings_set_uint32(settings, FreeRDP_GatewayPort, 443) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_DesktopResize, TRUE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_ToggleFullscreen, TRUE) ||
+	    !freerdp_settings_set_bool(settings, FreeRDP_MinimizeHotkey, TRUE) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_DesktopPosX, UINT32_MAX) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_DesktopPosY, UINT32_MAX) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_SoftwareGdi, TRUE) ||

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -104,6 +104,7 @@ static const size_t bool_list_indices[] = {
 	FreeRDP_LongCredentialsSupported,
 	FreeRDP_LyncRdpMode,
 	FreeRDP_MaximizeShell,
+	FreeRDP_MinimizeHotkey,
 	FreeRDP_MouseAttached,
 	FreeRDP_MouseHasWheel,
 	FreeRDP_MouseMotion,


### PR DESCRIPTION
I added a command line flag to disable the Ctrl+Alt+M hotkey for minimizing the application. Some of our users need this hotkey inside the RDP session.

I guess include/freerdp/settings_types_private.h should be updated to include the new setting into the stable ABI.