### PR TITLE
[channel,rdpecam] uvc_h264 xu_descriptor pointer fix

### DIFF
--- a/channels/rdpecam/client/v4l/uvc_h264.c
+++ b/channels/rdpecam/client/v4l/uvc_h264.c
@@ -375,9 +375,10 @@ static uint8_t get_guid_unit_id_from_device(libusb_device* device, const uint8_t
 				    interface->bInterfaceSubClass != USB_VIDEO_CONTROL)
 					continue;
 
-				const xu_descriptor* desc = (const xu_descriptor*)interface->extra;
-				while (((const uint8_t*)desc) < interface->extra + interface->extra_length)
+				const uint8_t* ptr = interface->extra;
+				while (ptr < interface->extra + interface->extra_length)
 				{
+					const xu_descriptor* desc = (const xu_descriptor*)ptr;
 					if (desc->bDescriptorType == USB_VIDEO_CONTROL_INTERFACE &&
 					    desc->bDescriptorSubType == USB_VIDEO_CONTROL_XU_TYPE &&
 					    memcmp(desc->guidExtensionCode, guid, 16) == 0)
@@ -390,7 +391,7 @@ static uint8_t get_guid_unit_id_from_device(libusb_device* device, const uint8_t
 						         ddesc.idVendor, ddesc.idProduct, unit_id);
 						return unit_id;
 					}
-					desc++;
+					ptr += desc->bLength;
 				}
 			}
 		}


### PR DESCRIPTION
`desc++` doesn't work because `desc->bLength` has different length every time, more or less than `sizeof (xu_descriptor)`

Fragment of `lsusb -v` output:

```
      VideoControl Interface Descriptor:
        bLength                27
        bDescriptorType        36
        bDescriptorSubtype      6 (EXTENSION_UNIT)
        bUnitID                12
        guidExtensionCode         {a29e7641-de04-47e3-8b2b-f4341aff003b}
        bNumControl            11
        bNrPins                 1
        baSourceID( 0)          3
        bControlSize            2
        bmControls( 0)       0x07
        bmControls( 1)       0x7f
        iExtension              0 
      VideoControl Interface Descriptor:
        bLength                26
        bDescriptorType        36
        bDescriptorSubtype      6 (EXTENSION_UNIT)
        bUnitID                13
        guidExtensionCode         {13612d26-5aaa-46c4-b13d-ff4d9a60db86}
        bNumControl             1
        bNrPins                 1
        baSourceID( 0)          3
        bControlSize            1
        bmControls( 0)       0x02
        iExtension              0 
      VideoControl Interface Descriptor:
        bLength                 9
        bDescriptorType        36
        bDescriptorSubtype      3 (OUTPUT_TERMINAL)
        bTerminalID             4
        wTerminalType      0x0101 USB Streaming
        bAssocTerminal          0
        bSourceID               3
        iTerminal               0 
```