### PR TITLE
[core,freerdp] New API freerdp_presist_credentials

### DIFF
--- a/client/common/client.c
+++ b/client/common/client.c
@@ -295,8 +295,7 @@ int freerdp_client_settings_parse_command_line(rdpSettings* settings, int argc, 
 
 int freerdp_client_settings_parse_command_line_ex(
     rdpSettings* settings, int argc, char** argv, BOOL allowUnknown, COMMAND_LINE_ARGUMENT_A* args,
-    size_t count, int (*handle_option)(const COMMAND_LINE_ARGUMENT_A* arg, void* custom),
-    void* handle_userdata)
+    size_t count, freerdp_command_line_handle_option_t handle_option, void* handle_userdata)
 {
 	int status = 0;
 

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -72,9 +72,6 @@
 #include <freerdp/log.h>
 #define TAG CLIENT_TAG("common.cmdline")
 
-typedef int (*freerdp_command_line_handle_option_t)(const COMMAND_LINE_ARGUMENT_A* arg,
-                                                    void* custom);
-
 static const char str_force[] = "force";
 
 static const char* option_starts_with(const char* what, const char* val);

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -21,6 +21,7 @@
 #define FREERDP_CLIENT_H
 
 #include <winpr/cmdline.h>
+#include <freerdp/client/cmdline.h>
 
 #include <freerdp/config.h>
 #include <freerdp/api.h>
@@ -170,8 +171,7 @@ extern "C"
 	FREERDP_API int freerdp_client_settings_parse_command_line_ex(
 	    rdpSettings* settings, int argc, char** argv, BOOL allowUnknown,
 	    COMMAND_LINE_ARGUMENT_A* args, size_t count,
-	    int (*handle_option)(const COMMAND_LINE_ARGUMENT_A* arg, void* custom),
-	    void* handle_userdata);
+	    freerdp_command_line_handle_option_t handle_option, void* handle_userdata);
 
 	FREERDP_API int freerdp_client_settings_parse_connection_file(rdpSettings* settings,
 	                                                              const char* filename);

--- a/include/freerdp/client/cmdline.h
+++ b/include/freerdp/client/cmdline.h
@@ -31,6 +31,18 @@ extern "C"
 {
 #endif
 
+	/** @brief Callback function type definition for command line handling
+	 *
+	 *  @param arg A pointer to the argument to handle
+	 *  @param void* A pointer to user defined data
+	 *
+	 *  @return \b 0 for success or a \b COMMAND_LINE_ERROR code
+	 *
+	 *  @since version 3.12.0
+	 */
+	typedef int (*freerdp_command_line_handle_option_t)(const COMMAND_LINE_ARGUMENT_A* arg,
+	                                                    void* custom);
+
 	/** \brief parses command line arguments to appropriate settings values.
 	 *
 	 * \param settings The settings instance to store the parsed values to
@@ -63,8 +75,7 @@ extern "C"
 	FREERDP_API int freerdp_client_settings_parse_command_line_arguments_ex(
 	    rdpSettings* settings, int argc, char** argv, BOOL allowUnknown,
 	    COMMAND_LINE_ARGUMENT_A* args, size_t count,
-	    int (*handle_option)(const COMMAND_LINE_ARGUMENT_A* arg, void* custom),
-	    void* handle_userdata);
+	    freerdp_command_line_handle_option_t handle_option, void* handle_userdata);
 
 	FREERDP_API int freerdp_client_settings_command_line_status_print(rdpSettings* settings,
 	                                                                  int status, int argc,

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -748,7 +748,7 @@ owned by rdpRdp */
 	 * state, ...)
 	 *  \since version 3.12.0
 	 */
-	FREERDP_API BOOL freerdp_presist_credentials(rdpContext* context);
+	FREERDP_API BOOL freerdp_persist_credentials(rdpContext* context);
 
 #ifdef __cplusplus
 }

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -736,6 +736,20 @@ owned by rdpRdp */
 	FREERDP_API BOOL freerdp_is_valid_mcs_create_request(const BYTE* data, size_t size);
 	FREERDP_API BOOL freerdp_is_valid_mcs_create_response(const BYTE* data, size_t size);
 
+	/** \brief Persist the current credentials (gateway, target server, ...)
+	 *
+	 *  FreeRDP internally keeps a backup of connection settings to revert to whenever a reconnect
+	 * is required. If a client modifies settings during runtime after pre-connect call this
+	 * function or the credentials will be lost on any reconnect, redirect, ...
+	 *
+	 *  \param context The RDP context to use, must not be \b NULL
+	 *
+	 *  \return \b TRUE if successful, \b FALSE if settings could not be applied (wrong session
+	 * state, ...)
+	 *  \since version 3.12.0
+	 */
+	FREERDP_API BOOL freerdp_presist_credentials(rdpContext* context);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -1459,3 +1459,11 @@ BOOL freerdp_is_valid_mcs_create_response(const BYTE* data, size_t size)
 	test_mcs_free(mcs);
 	return result;
 }
+
+BOOL freerdp_presist_credentials(rdpContext* context)
+{
+	if (!context)
+		return FALSE;
+	WINPR_ASSERT(context->rdp);
+	return utils_persist_credentials(context->rdp->originalSettings, context->rdp->settings);
+}

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -1460,7 +1460,7 @@ BOOL freerdp_is_valid_mcs_create_response(const BYTE* data, size_t size)
 	return result;
 }
 
-BOOL freerdp_presist_credentials(rdpContext* context)
+BOOL freerdp_persist_credentials(rdpContext* context)
 {
 	if (!context)
 		return FALSE;

--- a/libfreerdp/core/utils.c
+++ b/libfreerdp/core/utils.c
@@ -253,6 +253,29 @@ BOOL utils_sync_credentials(rdpSettings* settings, BOOL toGateway)
 	return TRUE;
 }
 
+BOOL utils_persist_credentials(rdpSettings* settings, const rdpSettings* current)
+{
+	if (!settings || !current)
+		return FALSE;
+
+	const SSIZE_T keys[] = { FreeRDP_GatewayUsername, FreeRDP_GatewayDomain,
+		                     FreeRDP_GatewayPassword, FreeRDP_Username,
+		                     FreeRDP_Domain,          FreeRDP_Password };
+
+	for (size_t x = 0; x < ARRAYSIZE(keys); x++)
+	{
+		const SSIZE_T key = keys[x];
+		if (!freerdp_settings_copy_item(settings, current, key))
+		{
+			WLog_ERR(TAG, "Failed to copy %s from current to backup settings",
+			         freerdp_settings_get_name_for_key(key));
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}
+
 BOOL utils_str_is_empty(const char* str)
 {
 	if (!str)

--- a/libfreerdp/core/utils.h
+++ b/libfreerdp/core/utils.h
@@ -50,6 +50,7 @@ BOOL utils_abort_event_is_set(const rdpRdp* rdp);
 BOOL utils_reset_abort(rdpRdp* rdp);
 BOOL utils_abort_connect(rdpRdp* rdp);
 BOOL utils_sync_credentials(rdpSettings* settings, BOOL toGateway);
+BOOL utils_persist_credentials(rdpSettings* settings, const rdpSettings* current);
 
 BOOL utils_str_is_empty(const char* str);
 BOOL utils_str_copy(const char* value, char** dst);


### PR DESCRIPTION
A new function that allows persisting runtime changes to credential settings so reconnect/redirect/... does not lose current values.