### PR TITLE
Fix all unused warnings

### DIFF
--- a/channels/ainput/client/ainput_main.c
+++ b/channels/ainput/client/ainput_main.c
@@ -145,7 +145,8 @@ static UINT ainput_on_close(IWTSVirtualChannelCallback* pChannelCallback)
 	return CHANNEL_RC_OK;
 }
 
-static UINT init_plugin_cb(GENERIC_DYNVC_PLUGIN* base, rdpContext* rcontext, rdpSettings* settings)
+static UINT init_plugin_cb(GENERIC_DYNVC_PLUGIN* base, WINPR_ATTR_UNUSED rdpContext* rcontext,
+                           WINPR_ATTR_UNUSED rdpSettings* settings)
 {
 	AINPUT_PLUGIN* ainput = (AINPUT_PLUGIN*)base;
 	AInputClientContext* context = (AInputClientContext*)calloc(1, sizeof(AInputClientContext));

--- a/channels/audin/client/audin_main.c
+++ b/channels/audin/client/audin_main.c
@@ -639,8 +639,10 @@ static UINT audin_on_close(IWTSVirtualChannelCallback* pChannelCallback)
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT audin_on_new_channel_connection(IWTSListenerCallback* pListenerCallback,
-                                            IWTSVirtualChannel* pChannel, BYTE* Data,
-                                            BOOL* pbAccept, IWTSVirtualChannelCallback** ppCallback)
+                                            IWTSVirtualChannel* pChannel,
+                                            WINPR_ATTR_UNUSED BYTE* Data,
+                                            WINPR_ATTR_UNUSED BOOL* pbAccept,
+                                            IWTSVirtualChannelCallback** ppCallback)
 {
 	GENERIC_LISTENER_CALLBACK* listener_callback = (GENERIC_LISTENER_CALLBACK*)pListenerCallback;
 

--- a/channels/audin/server/audin.c
+++ b/channels/audin/server/audin.c
@@ -191,8 +191,8 @@ static UINT audin_server_recv_open_reply(audin_server_context* context, wStream*
 	return error;
 }
 
-static UINT audin_server_recv_data_incoming(audin_server_context* context, wStream* s,
-                                            const SNDIN_PDU* header)
+static UINT audin_server_recv_data_incoming(audin_server_context* context,
+                                            WINPR_ATTR_UNUSED wStream* s, const SNDIN_PDU* header)
 {
 	audin_server* audin = (audin_server*)context;
 	SNDIN_DATA_INCOMING pdu = { 0 };
@@ -794,8 +794,9 @@ static UINT audin_server_receive_format_change_default(audin_server_context* con
 	return CHANNEL_RC_OK;
 }
 
-static UINT audin_server_incoming_data_default(audin_server_context* context,
-                                               const SNDIN_DATA_INCOMING* data_incoming)
+static UINT
+audin_server_incoming_data_default(audin_server_context* context,
+                                   WINPR_ATTR_UNUSED const SNDIN_DATA_INCOMING* data_incoming)
 {
 	audin_server* audin = (audin_server*)context;
 	WINPR_ASSERT(audin);

--- a/channels/client/addin.c
+++ b/channels/client/addin.c
@@ -82,9 +82,9 @@ void* freerdp_channels_client_find_static_entry(const char* name, const char* id
 
 extern const STATIC_ADDIN_TABLE CLIENT_STATIC_ADDIN_TABLE[];
 
-static FREERDP_ADDIN** freerdp_channels_list_client_static_addins(LPCSTR pszName,
-                                                                  LPCSTR pszSubsystem,
-                                                                  LPCSTR pszType, DWORD dwFlags)
+static FREERDP_ADDIN** freerdp_channels_list_client_static_addins(
+    WINPR_ATTR_UNUSED LPCSTR pszName, WINPR_ATTR_UNUSED LPCSTR pszSubsystem,
+    WINPR_ATTR_UNUSED LPCSTR pszType, WINPR_ATTR_UNUSED DWORD dwFlags)
 {
 	DWORD nAddins = 0;
 	FREERDP_ADDIN** ppAddins = NULL;
@@ -160,7 +160,8 @@ static HANDLE FindFirstFileUTF8(LPCSTR pszSearchPath, WIN32_FIND_DATAW* FindData
 }
 
 static FREERDP_ADDIN** freerdp_channels_list_dynamic_addins(LPCSTR pszName, LPCSTR pszSubsystem,
-                                                            LPCSTR pszType, DWORD dwFlags)
+                                                            LPCSTR pszType,
+                                                            WINPR_ATTR_UNUSED DWORD dwFlags)
 {
 	int nDashes = 0;
 	HANDLE hFind = NULL;

--- a/channels/client/generic_dynvc.c
+++ b/channels/client/generic_dynvc.c
@@ -24,8 +24,9 @@
 #define TAG FREERDP_TAG("genericdynvc")
 
 static UINT generic_on_new_channel_connection(IWTSListenerCallback* pListenerCallback,
-                                              IWTSVirtualChannel* pChannel, BYTE* Data,
-                                              BOOL* pbAccept,
+                                              IWTSVirtualChannel* pChannel,
+                                              WINPR_ATTR_UNUSED BYTE* Data,
+                                              WINPR_ATTR_UNUSED BOOL* pbAccept,
                                               IWTSVirtualChannelCallback** ppCallback)
 {
 	GENERIC_CHANNEL_CALLBACK* callback = NULL;

--- a/channels/cliprdr/client/cliprdr_format.c
+++ b/channels/cliprdr/client/cliprdr_format.c
@@ -150,8 +150,8 @@ error_out:
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT cliprdr_process_format_list_response(cliprdrPlugin* cliprdr, wStream* s, UINT32 dataLen,
-                                          UINT16 msgFlags)
+UINT cliprdr_process_format_list_response(cliprdrPlugin* cliprdr, WINPR_ATTR_UNUSED wStream* s,
+                                          UINT32 dataLen, UINT16 msgFlags)
 {
 	CLIPRDR_FORMAT_LIST_RESPONSE formatListResponse = { 0 };
 	CliprdrClientContext* context = cliprdr_get_client_interface(cliprdr);

--- a/channels/cliprdr/client/cliprdr_main.c
+++ b/channels/cliprdr/client/cliprdr_main.c
@@ -189,8 +189,9 @@ static UINT cliprdr_process_general_capability(cliprdrPlugin* cliprdr, wStream* 
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT cliprdr_process_clip_caps(cliprdrPlugin* cliprdr, wStream* s, UINT32 length,
-                                      UINT16 flags)
+static UINT cliprdr_process_clip_caps(cliprdrPlugin* cliprdr, wStream* s,
+                                      WINPR_ATTR_UNUSED UINT32 length,
+                                      WINPR_ATTR_UNUSED UINT16 flags)
 {
 	UINT16 lengthCapability = 0;
 	UINT16 cCapabilitiesSets = 0;
@@ -246,8 +247,8 @@ static UINT cliprdr_process_clip_caps(cliprdrPlugin* cliprdr, wStream* s, UINT32
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT cliprdr_process_monitor_ready(cliprdrPlugin* cliprdr, wStream* s, UINT32 length,
-                                          UINT16 flags)
+static UINT cliprdr_process_monitor_ready(cliprdrPlugin* cliprdr, WINPR_ATTR_UNUSED wStream* s,
+                                          UINT32 length, UINT16 flags)
 {
 	CLIPRDR_MONITOR_READY monitorReady = { 0 };
 	CliprdrClientContext* context = cliprdr_get_client_interface(cliprdr);
@@ -981,8 +982,9 @@ static VOID VCAPITYPE cliprdr_virtual_channel_open_event_ex(LPVOID lpUserParam, 
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT cliprdr_virtual_channel_event_connected(cliprdrPlugin* cliprdr, LPVOID pData,
-                                                    UINT32 dataLength)
+static UINT cliprdr_virtual_channel_event_connected(cliprdrPlugin* cliprdr,
+                                                    WINPR_ATTR_UNUSED LPVOID pData,
+                                                    WINPR_ATTR_UNUSED UINT32 dataLength)
 {
 	DWORD status = 0;
 	WINPR_ASSERT(cliprdr);

--- a/channels/disp/client/disp_main.c
+++ b/channels/disp/client/disp_main.c
@@ -271,8 +271,9 @@ static UINT disp_send_monitor_layout(DispClientContext* context, UINT32 NumMonit
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT disp_plugin_initialize(GENERIC_DYNVC_PLUGIN* base, rdpContext* rcontext,
-                                   rdpSettings* settings)
+static UINT disp_plugin_initialize(GENERIC_DYNVC_PLUGIN* base,
+                                   WINPR_ATTR_UNUSED rdpContext* rcontext,
+                                   WINPR_ATTR_UNUSED rdpSettings* settings)
 {
 	DispClientContext* context = NULL;
 	DISP_PLUGIN* disp = (DISP_PLUGIN*)base;

--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -517,7 +517,7 @@ static UINT dvcman_channel_close(DVCMAN_CHANNEL* channel, BOOL perRequest, BOOL 
 	return error;
 }
 
-static DVCMAN_CHANNEL* dvcman_channel_new(drdynvcPlugin* drdynvc,
+static DVCMAN_CHANNEL* dvcman_channel_new(WINPR_ATTR_UNUSED drdynvcPlugin* drdynvc,
                                           IWTSVirtualChannelManager* pChannelMgr, UINT32 ChannelId,
                                           const char* ChannelName)
 {
@@ -828,7 +828,7 @@ static UINT dvcman_receive_channel_data_first(DVCMAN_CHANNEL* channel, UINT32 le
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT dvcman_receive_channel_data(DVCMAN_CHANNEL* channel, wStream* data,
-                                        UINT32 ThreadingFlags)
+                                        WINPR_ATTR_UNUSED UINT32 ThreadingFlags)
 {
 	UINT status = CHANNEL_RC_OK;
 	size_t dataSize = Stream_GetRemainingLength(data);

--- a/channels/drdynvc/server/drdynvc_main.c
+++ b/channels/drdynvc/server/drdynvc_main.c
@@ -31,7 +31,7 @@
 
 #define TAG CHANNELS_TAG("drdynvc.server")
 
-static DWORD WINAPI drdynvc_server_thread(LPVOID arg)
+static DWORD WINAPI drdynvc_server_thread(WINPR_ATTR_UNUSED LPVOID arg)
 {
 #if 0
 	wStream* s;

--- a/channels/encomsp/client/encomsp_main.c
+++ b/channels/encomsp/client/encomsp_main.c
@@ -1090,8 +1090,9 @@ static DWORD WINAPI encomsp_virtual_channel_client_thread(LPVOID arg)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT encomsp_virtual_channel_event_connected(encomspPlugin* encomsp, LPVOID pData,
-                                                    UINT32 dataLength)
+static UINT encomsp_virtual_channel_event_connected(encomspPlugin* encomsp,
+                                                    WINPR_ATTR_UNUSED LPVOID pData,
+                                                    WINPR_ATTR_UNUSED UINT32 dataLength)
 {
 	WINPR_ASSERT(encomsp);
 

--- a/channels/geometry/client/geometry_main.c
+++ b/channels/geometry/client/geometry_main.c
@@ -340,7 +340,8 @@ static const IWTSVirtualChannelCallback geometry_callbacks = { geometry_on_data_
 	                                                           NULL, /* Open */
 	                                                           geometry_on_close, NULL };
 
-static UINT init_plugin_cb(GENERIC_DYNVC_PLUGIN* base, rdpContext* rcontext, rdpSettings* settings)
+static UINT init_plugin_cb(GENERIC_DYNVC_PLUGIN* base, WINPR_ATTR_UNUSED rdpContext* rcontext,
+                           rdpSettings* settings)
 {
 	GeometryClientContext* context = NULL;
 	GEOMETRY_PLUGIN* geometry = (GEOMETRY_PLUGIN*)base;

--- a/channels/location/client/location_main.c
+++ b/channels/location/client/location_main.c
@@ -449,7 +449,8 @@ static UINT location_on_close(IWTSVirtualChannelCallback* pChannelCallback)
 	return res;
 }
 
-static UINT location_init(GENERIC_DYNVC_PLUGIN* plugin, rdpContext* context, rdpSettings* settings)
+static UINT location_init(GENERIC_DYNVC_PLUGIN* plugin, WINPR_ATTR_UNUSED rdpContext* context,
+                          WINPR_ATTR_UNUSED rdpSettings* settings)
 {
 	LOCATION_PLUGIN* loc = (LOCATION_PLUGIN*)plugin;
 

--- a/channels/parallel/client/parallel_main.c
+++ b/channels/parallel/client/parallel_main.c
@@ -252,12 +252,14 @@ static UINT parallel_process_irp_write(PARALLEL_DEVICE* parallel, IRP* irp)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT parallel_process_irp_device_control(PARALLEL_DEVICE* parallel, IRP* irp)
+static UINT parallel_process_irp_device_control(WINPR_ATTR_UNUSED PARALLEL_DEVICE* parallel,
+                                                IRP* irp)
 {
 	WINPR_ASSERT(parallel);
 	WINPR_ASSERT(irp);
 
 	Stream_Write_UINT32(irp->output, 0); /* OutputBufferLength */
+	WINPR_ASSERT(irp->Complete);
 	return irp->Complete(irp);
 }
 

--- a/channels/printer/client/printer_main.c
+++ b/channels/printer/client/printer_main.c
@@ -562,7 +562,8 @@ static UINT printer_process_irp_write(PRINTER_DEVICE* printer_dev, IRP* irp)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT printer_process_irp_device_control(PRINTER_DEVICE* printer_dev, IRP* irp)
+static UINT printer_process_irp_device_control(WINPR_ATTR_UNUSED PRINTER_DEVICE* printer_dev,
+                                               IRP* irp)
 {
 	WINPR_ASSERT(printer_dev);
 	WINPR_ASSERT(irp);

--- a/channels/rail/client/rail_main.c
+++ b/channels/rail/client/rail_main.c
@@ -568,7 +568,8 @@ static VOID VCAPITYPE rail_virtual_channel_open_event_ex(LPVOID lpUserParam, DWO
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT rail_virtual_channel_event_connected(railPlugin* rail, LPVOID pData, UINT32 dataLength)
+static UINT rail_virtual_channel_event_connected(railPlugin* rail, WINPR_ATTR_UNUSED LPVOID pData,
+                                                 WINPR_ATTR_UNUSED UINT32 dataLength)
 {
 	RailClientContext* context = rail_get_client_interface(rail);
 	UINT status = CHANNEL_RC_OK;

--- a/channels/rdp2tcp/client/rdp2tcp_main.c
+++ b/channels/rdp2tcp/client/rdp2tcp_main.c
@@ -189,7 +189,8 @@ static void dataReceived(Plugin* plugin, void* pData, UINT32 dataLength, UINT32 
 		closeChannel(plugin);
 }
 
-static void VCAPITYPE VirtualChannelOpenEventEx(LPVOID lpUserParam, DWORD openHandle, UINT event,
+static void VCAPITYPE VirtualChannelOpenEventEx(LPVOID lpUserParam,
+                                                WINPR_ATTR_UNUSED DWORD openHandle, UINT event,
                                                 LPVOID pData, UINT32 dataLength, UINT32 totalLength,
                                                 UINT32 dataFlags)
 {
@@ -240,7 +241,8 @@ static void channel_initialized(Plugin* plugin)
 }
 
 static VOID VCAPITYPE VirtualChannelInitEventEx(LPVOID lpUserParam, LPVOID pInitHandle, UINT event,
-                                                LPVOID pData, UINT dataLength)
+                                                WINPR_ATTR_UNUSED LPVOID pData,
+                                                WINPR_ATTR_UNUSED UINT dataLength)
 {
 	Plugin* plugin = (Plugin*)lpUserParam;
 

--- a/channels/rdpdr/client/rdpdr_capabilities.c
+++ b/channels/rdpdr/client/rdpdr_capabilities.c
@@ -115,7 +115,7 @@ static BOOL rdpdr_write_printer_capset(rdpdrPlugin* rdpdr, wStream* s)
 }
 
 /* Process printer direction capability set */
-static UINT rdpdr_process_printer_capset(rdpdrPlugin* rdpdr, wStream* s,
+static UINT rdpdr_process_printer_capset(WINPR_ATTR_UNUSED rdpdrPlugin* rdpdr, wStream* s,
                                          const RDPDR_CAPABILITY_HEADER* header)
 {
 	WINPR_ASSERT(header);
@@ -133,7 +133,7 @@ static BOOL rdpdr_write_port_capset(rdpdrPlugin* rdpdr, wStream* s)
 }
 
 /* Process port redirection capability set */
-static UINT rdpdr_process_port_capset(rdpdrPlugin* rdpdr, wStream* s,
+static UINT rdpdr_process_port_capset(WINPR_ATTR_UNUSED rdpdrPlugin* rdpdr, wStream* s,
                                       const RDPDR_CAPABILITY_HEADER* header)
 {
 	WINPR_ASSERT(header);
@@ -151,7 +151,7 @@ static BOOL rdpdr_write_drive_capset(rdpdrPlugin* rdpdr, wStream* s)
 }
 
 /* Process drive redirection capability set */
-static UINT rdpdr_process_drive_capset(rdpdrPlugin* rdpdr, wStream* s,
+static UINT rdpdr_process_drive_capset(WINPR_ATTR_UNUSED rdpdrPlugin* rdpdr, wStream* s,
                                        const RDPDR_CAPABILITY_HEADER* header)
 {
 	WINPR_ASSERT(header);
@@ -169,7 +169,7 @@ static BOOL rdpdr_write_smartcard_capset(rdpdrPlugin* rdpdr, wStream* s)
 }
 
 /* Process smartcard redirection capability set */
-static UINT rdpdr_process_smartcard_capset(rdpdrPlugin* rdpdr, wStream* s,
+static UINT rdpdr_process_smartcard_capset(WINPR_ATTR_UNUSED rdpdrPlugin* rdpdr, wStream* s,
                                            const RDPDR_CAPABILITY_HEADER* header)
 {
 	WINPR_ASSERT(header);

--- a/channels/rdpdr/server/rdpdr_main.c
+++ b/channels/rdpdr/server/rdpdr_main.c
@@ -1165,8 +1165,9 @@ static UINT rdpdr_server_receive_device_list_remove_request(RdpdrServerContext* 
 }
 
 static UINT rdpdr_server_receive_io_create_request(RdpdrServerContext* context, wStream* s,
-                                                   UINT32 DeviceId, UINT32 FileId,
-                                                   UINT32 CompletionId)
+                                                   WINPR_ATTR_UNUSED UINT32 DeviceId,
+                                                   WINPR_ATTR_UNUSED UINT32 FileId,
+                                                   WINPR_ATTR_UNUSED UINT32 CompletionId)
 {
 	const WCHAR* path = NULL;
 	UINT32 DesiredAccess = 0;
@@ -1201,8 +1202,9 @@ static UINT rdpdr_server_receive_io_create_request(RdpdrServerContext* context, 
 }
 
 static UINT rdpdr_server_receive_io_close_request(RdpdrServerContext* context, wStream* s,
-                                                  UINT32 DeviceId, UINT32 FileId,
-                                                  UINT32 CompletionId)
+                                                  WINPR_ATTR_UNUSED UINT32 DeviceId,
+                                                  WINPR_ATTR_UNUSED UINT32 FileId,
+                                                  WINPR_ATTR_UNUSED UINT32 CompletionId)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(context->priv);
@@ -1220,8 +1222,9 @@ static UINT rdpdr_server_receive_io_close_request(RdpdrServerContext* context, w
 }
 
 static UINT rdpdr_server_receive_io_read_request(RdpdrServerContext* context, wStream* s,
-                                                 UINT32 DeviceId, UINT32 FileId,
-                                                 UINT32 CompletionId)
+                                                 WINPR_ATTR_UNUSED UINT32 DeviceId,
+                                                 WINPR_ATTR_UNUSED UINT32 FileId,
+                                                 WINPR_ATTR_UNUSED UINT32 CompletionId)
 {
 	UINT32 Length = 0;
 	UINT64 Offset = 0;
@@ -1243,8 +1246,9 @@ static UINT rdpdr_server_receive_io_read_request(RdpdrServerContext* context, wS
 }
 
 static UINT rdpdr_server_receive_io_write_request(RdpdrServerContext* context, wStream* s,
-                                                  UINT32 DeviceId, UINT32 FileId,
-                                                  UINT32 CompletionId)
+                                                  WINPR_ATTR_UNUSED UINT32 DeviceId,
+                                                  WINPR_ATTR_UNUSED UINT32 FileId,
+                                                  WINPR_ATTR_UNUSED UINT32 CompletionId)
 {
 	UINT32 Length = 0;
 	UINT64 Offset = 0;
@@ -1272,8 +1276,9 @@ static UINT rdpdr_server_receive_io_write_request(RdpdrServerContext* context, w
 }
 
 static UINT rdpdr_server_receive_io_device_control_request(RdpdrServerContext* context, wStream* s,
-                                                           UINT32 DeviceId, UINT32 FileId,
-                                                           UINT32 CompletionId)
+                                                           WINPR_ATTR_UNUSED UINT32 DeviceId,
+                                                           WINPR_ATTR_UNUSED UINT32 FileId,
+                                                           WINPR_ATTR_UNUSED UINT32 CompletionId)
 {
 	UINT32 OutputBufferLength = 0;
 	UINT32 InputBufferLength = 0;
@@ -1302,10 +1307,9 @@ static UINT rdpdr_server_receive_io_device_control_request(RdpdrServerContext* c
 	return CHANNEL_RC_OK;
 }
 
-static UINT rdpdr_server_receive_io_query_volume_information_request(RdpdrServerContext* context,
-                                                                     wStream* s, UINT32 DeviceId,
-                                                                     UINT32 FileId,
-                                                                     UINT32 CompletionId)
+static UINT rdpdr_server_receive_io_query_volume_information_request(
+    RdpdrServerContext* context, wStream* s, WINPR_ATTR_UNUSED UINT32 DeviceId,
+    WINPR_ATTR_UNUSED UINT32 FileId, WINPR_ATTR_UNUSED UINT32 CompletionId)
 {
 	UINT32 FsInformationClass = 0;
 	UINT32 Length = 0;
@@ -1331,10 +1335,9 @@ static UINT rdpdr_server_receive_io_query_volume_information_request(RdpdrServer
 	return CHANNEL_RC_OK;
 }
 
-static UINT rdpdr_server_receive_io_set_volume_information_request(RdpdrServerContext* context,
-                                                                   wStream* s, UINT32 DeviceId,
-                                                                   UINT32 FileId,
-                                                                   UINT32 CompletionId)
+static UINT rdpdr_server_receive_io_set_volume_information_request(
+    RdpdrServerContext* context, wStream* s, WINPR_ATTR_UNUSED UINT32 DeviceId,
+    WINPR_ATTR_UNUSED UINT32 FileId, WINPR_ATTR_UNUSED UINT32 CompletionId)
 {
 	UINT32 FsInformationClass = 0;
 	UINT32 Length = 0;
@@ -1363,8 +1366,10 @@ static UINT rdpdr_server_receive_io_set_volume_information_request(RdpdrServerCo
 }
 
 static UINT rdpdr_server_receive_io_query_information_request(RdpdrServerContext* context,
-                                                              wStream* s, UINT32 DeviceId,
-                                                              UINT32 FileId, UINT32 CompletionId)
+                                                              wStream* s,
+                                                              WINPR_ATTR_UNUSED UINT32 DeviceId,
+                                                              WINPR_ATTR_UNUSED UINT32 FileId,
+                                                              WINPR_ATTR_UNUSED UINT32 CompletionId)
 {
 	UINT32 FsInformationClass = 0;
 	UINT32 Length = 0;
@@ -1393,8 +1398,9 @@ static UINT rdpdr_server_receive_io_query_information_request(RdpdrServerContext
 }
 
 static UINT rdpdr_server_receive_io_set_information_request(RdpdrServerContext* context, wStream* s,
-                                                            UINT32 DeviceId, UINT32 FileId,
-                                                            UINT32 CompletionId)
+                                                            WINPR_ATTR_UNUSED UINT32 DeviceId,
+                                                            WINPR_ATTR_UNUSED UINT32 FileId,
+                                                            WINPR_ATTR_UNUSED UINT32 CompletionId)
 {
 	UINT32 FsInformationClass = 0;
 	UINT32 Length = 0;
@@ -1423,8 +1429,9 @@ static UINT rdpdr_server_receive_io_set_information_request(RdpdrServerContext* 
 }
 
 static UINT rdpdr_server_receive_io_query_directory_request(RdpdrServerContext* context, wStream* s,
-                                                            UINT32 DeviceId, UINT32 FileId,
-                                                            UINT32 CompletionId)
+                                                            WINPR_ATTR_UNUSED UINT32 DeviceId,
+                                                            WINPR_ATTR_UNUSED UINT32 FileId,
+                                                            WINPR_ATTR_UNUSED UINT32 CompletionId)
 {
 	BYTE InitialQuery = 0;
 	UINT32 FsInformationClass = 0;
@@ -1455,8 +1462,10 @@ static UINT rdpdr_server_receive_io_query_directory_request(RdpdrServerContext* 
 }
 
 static UINT rdpdr_server_receive_io_change_directory_request(RdpdrServerContext* context,
-                                                             wStream* s, UINT32 DeviceId,
-                                                             UINT32 FileId, UINT32 CompletionId)
+                                                             wStream* s,
+                                                             WINPR_ATTR_UNUSED UINT32 DeviceId,
+                                                             WINPR_ATTR_UNUSED UINT32 FileId,
+                                                             WINPR_ATTR_UNUSED UINT32 CompletionId)
 {
 	BYTE WatchTree = 0;
 	UINT32 CompletionFilter = 0;
@@ -1505,8 +1514,9 @@ static UINT rdpdr_server_receive_io_directory_control_request(RdpdrServerContext
 }
 
 static UINT rdpdr_server_receive_io_lock_control_request(RdpdrServerContext* context, wStream* s,
-                                                         UINT32 DeviceId, UINT32 FileId,
-                                                         UINT32 CompletionId)
+                                                         WINPR_ATTR_UNUSED UINT32 DeviceId,
+                                                         WINPR_ATTR_UNUSED UINT32 FileId,
+                                                         WINPR_ATTR_UNUSED UINT32 CompletionId)
 {
 	UINT32 Operation = 0;
 	UINT32 Lock = 0;
@@ -1548,7 +1558,7 @@ static UINT rdpdr_server_receive_io_lock_control_request(RdpdrServerContext* con
 }
 
 static UINT rdpdr_server_receive_device_io_request(RdpdrServerContext* context, wStream* s,
-                                                   const RDPDR_HEADER* header)
+                                                   WINPR_ATTR_UNUSED const RDPDR_HEADER* header)
 {
 	UINT32 DeviceId = 0;
 	UINT32 FileId = 0;
@@ -1820,8 +1830,9 @@ static UINT rdpdr_server_receive_prn_cache_rename_cachedata(RdpdrServerContext* 
 	return CHANNEL_RC_OK;
 }
 
-static UINT rdpdr_server_receive_prn_cache_data_request(RdpdrServerContext* context, wStream* s,
-                                                        const RDPDR_HEADER* header)
+static UINT
+rdpdr_server_receive_prn_cache_data_request(RdpdrServerContext* context, wStream* s,
+                                            WINPR_ATTR_UNUSED const RDPDR_HEADER* header)
 {
 	UINT32 EventId = 0;
 
@@ -1851,7 +1862,7 @@ static UINT rdpdr_server_receive_prn_cache_data_request(RdpdrServerContext* cont
 }
 
 static UINT rdpdr_server_receive_prn_using_xps_request(RdpdrServerContext* context, wStream* s,
-                                                       const RDPDR_HEADER* header)
+                                                       WINPR_ATTR_UNUSED const RDPDR_HEADER* header)
 {
 	UINT32 PrinterId = 0;
 	UINT32 Flags = 0;

--- a/channels/rdpecam/client/camera_device_enum_main.c
+++ b/channels/rdpecam/client/camera_device_enum_main.c
@@ -78,8 +78,8 @@ UINT ecam_channel_send_generic_msg(CameraPlugin* ecam, GENERIC_CHANNEL_CALLBACK*
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT ecam_channel_write(CameraPlugin* ecam, GENERIC_CHANNEL_CALLBACK* hchannel, CAM_MSG_ID msg,
-                        wStream* out, BOOL freeStream)
+UINT ecam_channel_write(WINPR_ATTR_UNUSED CameraPlugin* ecam, GENERIC_CHANNEL_CALLBACK* hchannel,
+                        CAM_MSG_ID msg, wStream* out, BOOL freeStream)
 {
 	if (!hchannel || !out)
 		return ERROR_INVALID_PARAMETER;
@@ -180,8 +180,8 @@ static UINT ecam_enumerate_devices(CameraPlugin* ecam, GENERIC_CHANNEL_CALLBACK*
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT ecam_process_select_version_response(CameraPlugin* ecam,
-                                                 GENERIC_CHANNEL_CALLBACK* hchannel, wStream* s,
-                                                 BYTE serverVersion)
+                                                 GENERIC_CHANNEL_CALLBACK* hchannel,
+                                                 WINPR_ATTR_UNUSED wStream* s, BYTE serverVersion)
 {
 	const BYTE clientVersion = ECAM_PROTO_VERSION;
 
@@ -289,7 +289,9 @@ static UINT ecam_on_close(IWTSVirtualChannelCallback* pChannelCallback)
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT ecam_on_new_channel_connection(IWTSListenerCallback* pListenerCallback,
-                                           IWTSVirtualChannel* pChannel, BYTE* Data, BOOL* pbAccept,
+                                           IWTSVirtualChannel* pChannel,
+                                           WINPR_ATTR_UNUSED BYTE* Data,
+                                           WINPR_ATTR_UNUSED BOOL* pbAccept,
                                            IWTSVirtualChannelCallback** ppCallback)
 {
 	GENERIC_LISTENER_CALLBACK* hlistener = (GENERIC_LISTENER_CALLBACK*)pListenerCallback;

--- a/channels/rdpecam/client/camera_device_main.c
+++ b/channels/rdpecam/client/camera_device_main.c
@@ -289,7 +289,8 @@ static UINT ecam_dev_process_start_streams_request(CameraDevice* dev,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT ecam_dev_process_property_list_request(CameraDevice* dev,
-                                                   GENERIC_CHANNEL_CALLBACK* hchannel, wStream* s)
+                                                   GENERIC_CHANNEL_CALLBACK* hchannel,
+                                                   WINPR_ATTR_UNUSED wStream* s)
 {
 	WINPR_ASSERT(dev);
 	// TODO: supported properties implementation
@@ -538,7 +539,8 @@ static UINT ecam_dev_send_stream_list_response(CameraDevice* dev,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT ecam_dev_process_stream_list_request(CameraDevice* dev,
-                                                 GENERIC_CHANNEL_CALLBACK* hchannel, wStream* s)
+                                                 GENERIC_CHANNEL_CALLBACK* hchannel,
+                                                 WINPR_ATTR_UNUSED wStream* s)
 {
 	return ecam_dev_send_stream_list_response(dev, hchannel);
 }
@@ -549,7 +551,8 @@ static UINT ecam_dev_process_stream_list_request(CameraDevice* dev,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT ecam_dev_process_activate_device_request(CameraDevice* dev,
-                                                     GENERIC_CHANNEL_CALLBACK* hchannel, wStream* s)
+                                                     GENERIC_CHANNEL_CALLBACK* hchannel,
+                                                     WINPR_ATTR_UNUSED wStream* s)
 {
 	WINPR_ASSERT(dev);
 
@@ -657,7 +660,7 @@ static UINT ecam_dev_on_data_received(IWTSVirtualChannelCallback* pChannelCallba
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT ecam_dev_on_open(IWTSVirtualChannelCallback* pChannelCallback)
+static UINT ecam_dev_on_open(WINPR_ATTR_UNUSED IWTSVirtualChannelCallback* pChannelCallback)
 {
 	WLog_DBG(TAG, "entered");
 	return CHANNEL_RC_OK;
@@ -693,8 +696,9 @@ static UINT ecam_dev_on_close(IWTSVirtualChannelCallback* pChannelCallback)
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT ecam_dev_on_new_channel_connection(IWTSListenerCallback* pListenerCallback,
-                                               IWTSVirtualChannel* pChannel, BYTE* Data,
-                                               BOOL* pbAccept,
+                                               IWTSVirtualChannel* pChannel,
+                                               WINPR_ATTR_UNUSED BYTE* Data,
+                                               WINPR_ATTR_UNUSED BOOL* pbAccept,
                                                IWTSVirtualChannelCallback** ppCallback)
 {
 	GENERIC_LISTENER_CALLBACK* hlistener = (GENERIC_LISTENER_CALLBACK*)pListenerCallback;
@@ -727,7 +731,8 @@ static UINT ecam_dev_on_new_channel_connection(IWTSListenerCallback* pListenerCa
  *
  * @return CameraDevice pointer or NULL in case of error
  */
-CameraDevice* ecam_dev_create(CameraPlugin* ecam, const char* deviceId, const char* deviceName)
+CameraDevice* ecam_dev_create(CameraPlugin* ecam, const char* deviceId,
+                              WINPR_ATTR_UNUSED const char* deviceName)
 {
 	WINPR_ASSERT(ecam);
 	WINPR_ASSERT(ecam->hlistener);

--- a/channels/rdpecam/client/v4l/camera_v4l.c
+++ b/channels/rdpecam/client/v4l/camera_v4l.c
@@ -287,8 +287,8 @@ error:
  *
  * @return number of video capture devices
  */
-static UINT cam_v4l_enumerate(ICamHal* ihal, ICamHalEnumCallback callback, CameraPlugin* ecam,
-                              GENERIC_CHANNEL_CALLBACK* hchannel)
+static UINT cam_v4l_enumerate(WINPR_ATTR_UNUSED ICamHal* ihal, ICamHalEnumCallback callback,
+                              CameraPlugin* ecam, GENERIC_CHANNEL_CALLBACK* hchannel)
 {
 	UINT count = 0;
 
@@ -693,7 +693,8 @@ static UINT cam_v4l_stream_start(ICamHal* ihal, CameraDevice* dev, int streamInd
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT cam_v4l_stream_stop_by_device_id(ICamHal* ihal, const char* deviceId, int streamIndex)
+static UINT cam_v4l_stream_stop_by_device_id(ICamHal* ihal, const char* deviceId,
+                                             WINPR_ATTR_UNUSED int streamIndex)
 {
 	CamV4lHal* hal = (CamV4lHal*)ihal;
 

--- a/channels/rdpecam/server/camera_device_enumerator_main.c
+++ b/channels/rdpecam/server/camera_device_enumerator_main.c
@@ -124,7 +124,7 @@ static UINT enumerator_server_open_channel(enumerator_server* enumerator)
 }
 
 static UINT enumerator_server_handle_select_version_request(CamDevEnumServerContext* context,
-                                                            wStream* s,
+                                                            WINPR_ATTR_UNUSED wStream* s,
                                                             const CAM_SHARED_MSG_HEADER* header)
 {
 	CAM_SELECT_VERSION_REQUEST pdu = { 0 };

--- a/channels/rdpecam/server/camera_device_main.c
+++ b/channels/rdpecam/server/camera_device_main.c
@@ -123,7 +123,8 @@ static UINT device_server_open_channel(device_server* device)
 	return Error;
 }
 
-static UINT device_server_handle_success_response(CameraDeviceServerContext* context, wStream* s,
+static UINT device_server_handle_success_response(CameraDeviceServerContext* context,
+                                                  WINPR_ATTR_UNUSED wStream* s,
                                                   const CAM_SHARED_MSG_HEADER* header)
 {
 	CAM_SUCCESS_RESPONSE pdu = { 0 };
@@ -747,9 +748,9 @@ static UINT device_server_write_and_send_header(CameraDeviceServerContext* conte
 	return device_server_packet_send(context, s);
 }
 
-static UINT
-device_send_activate_device_request_pdu(CameraDeviceServerContext* context,
-                                        const CAM_ACTIVATE_DEVICE_REQUEST* activateDeviceRequest)
+static UINT device_send_activate_device_request_pdu(
+    CameraDeviceServerContext* context,
+    WINPR_ATTR_UNUSED const CAM_ACTIVATE_DEVICE_REQUEST* activateDeviceRequest)
 {
 	WINPR_ASSERT(context);
 
@@ -758,15 +759,16 @@ device_send_activate_device_request_pdu(CameraDeviceServerContext* context,
 
 static UINT device_send_deactivate_device_request_pdu(
     CameraDeviceServerContext* context,
-    const CAM_DEACTIVATE_DEVICE_REQUEST* deactivateDeviceRequest)
+    WINPR_ATTR_UNUSED const CAM_DEACTIVATE_DEVICE_REQUEST* deactivateDeviceRequest)
 {
 	WINPR_ASSERT(context);
 
 	return device_server_write_and_send_header(context, CAM_MSG_ID_DeactivateDeviceRequest);
 }
 
-static UINT device_send_stream_list_request_pdu(CameraDeviceServerContext* context,
-                                                const CAM_STREAM_LIST_REQUEST* streamListRequest)
+static UINT device_send_stream_list_request_pdu(
+    CameraDeviceServerContext* context,
+    WINPR_ATTR_UNUSED const CAM_STREAM_LIST_REQUEST* streamListRequest)
 {
 	WINPR_ASSERT(context);
 
@@ -843,8 +845,9 @@ device_send_start_streams_request_pdu(CameraDeviceServerContext* context,
 	return device_server_packet_send(context, s);
 }
 
-static UINT device_send_stop_streams_request_pdu(CameraDeviceServerContext* context,
-                                                 const CAM_STOP_STREAMS_REQUEST* stopStreamsRequest)
+static UINT device_send_stop_streams_request_pdu(
+    CameraDeviceServerContext* context,
+    WINPR_ATTR_UNUSED const CAM_STOP_STREAMS_REQUEST* stopStreamsRequest)
 {
 	WINPR_ASSERT(context);
 
@@ -868,9 +871,9 @@ static UINT device_send_sample_request_pdu(CameraDeviceServerContext* context,
 	return device_server_packet_send(context, s);
 }
 
-static UINT
-device_send_property_list_request_pdu(CameraDeviceServerContext* context,
-                                      const CAM_PROPERTY_LIST_REQUEST* propertyListRequest)
+static UINT device_send_property_list_request_pdu(
+    CameraDeviceServerContext* context,
+    WINPR_ATTR_UNUSED const CAM_PROPERTY_LIST_REQUEST* propertyListRequest)
 {
 	WINPR_ASSERT(context);
 

--- a/channels/rdpgfx/client/rdpgfx_codec.c
+++ b/channels/rdpgfx/client/rdpgfx_codec.c
@@ -37,7 +37,8 @@
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT rdpgfx_read_h264_metablock(RDPGFX_PLUGIN* gfx, wStream* s, RDPGFX_H264_METABLOCK* meta)
+static UINT rdpgfx_read_h264_metablock(WINPR_ATTR_UNUSED RDPGFX_PLUGIN* gfx, wStream* s,
+                                       RDPGFX_H264_METABLOCK* meta)
 {
 	RECTANGLE_16* regionRect = NULL;
 	RDPGFX_H264_QUANT_QUALITY* quantQualityVal = NULL;

--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -2341,7 +2341,8 @@ static void* rdpgfx_get_cache_slot_data(RdpgfxClientContext* context, UINT16 cac
 	return pData;
 }
 
-static UINT init_plugin_cb(GENERIC_DYNVC_PLUGIN* base, rdpContext* rcontext, rdpSettings* settings)
+static UINT init_plugin_cb(GENERIC_DYNVC_PLUGIN* base, rdpContext* rcontext,
+                           WINPR_ATTR_UNUSED rdpSettings* settings)
 {
 	RdpgfxClientContext* context = NULL;
 	RDPGFX_PLUGIN* gfx = (RDPGFX_PLUGIN*)base;

--- a/channels/rdpsnd/client/alsa/rdpsnd_alsa.c
+++ b/channels/rdpsnd/client/alsa/rdpsnd_alsa.c
@@ -326,7 +326,8 @@ static void rdpsnd_alsa_free(rdpsndDevicePlugin* device)
 	free(alsa);
 }
 
-static BOOL rdpsnd_alsa_format_supported(rdpsndDevicePlugin* device, const AUDIO_FORMAT* format)
+static BOOL rdpsnd_alsa_format_supported(WINPR_ATTR_UNUSED rdpsndDevicePlugin* device,
+                                         const AUDIO_FORMAT* format)
 {
 	switch (format->wFormatTag)
 	{

--- a/channels/rdpsnd/client/fake/rdpsnd_fake.c
+++ b/channels/rdpsnd/client/fake/rdpsnd_fake.c
@@ -38,16 +38,19 @@ typedef struct
 	rdpsndDevicePlugin device;
 } rdpsndFakePlugin;
 
-static BOOL rdpsnd_fake_open(rdpsndDevicePlugin* device, const AUDIO_FORMAT* format, UINT32 latency)
+static BOOL rdpsnd_fake_open(WINPR_ATTR_UNUSED rdpsndDevicePlugin* device,
+                             WINPR_ATTR_UNUSED const AUDIO_FORMAT* format,
+                             WINPR_ATTR_UNUSED UINT32 latency)
 {
 	return TRUE;
 }
 
-static void rdpsnd_fake_close(rdpsndDevicePlugin* device)
+static void rdpsnd_fake_close(WINPR_ATTR_UNUSED rdpsndDevicePlugin* device)
 {
 }
 
-static BOOL rdpsnd_fake_set_volume(rdpsndDevicePlugin* device, UINT32 value)
+static BOOL rdpsnd_fake_set_volume(WINPR_ATTR_UNUSED rdpsndDevicePlugin* device,
+                                   WINPR_ATTR_UNUSED UINT32 value)
 {
 	return TRUE;
 }
@@ -62,12 +65,14 @@ static void rdpsnd_fake_free(rdpsndDevicePlugin* device)
 	free(fake);
 }
 
-static BOOL rdpsnd_fake_format_supported(rdpsndDevicePlugin* device, const AUDIO_FORMAT* format)
+static BOOL rdpsnd_fake_format_supported(WINPR_ATTR_UNUSED rdpsndDevicePlugin* device,
+                                         WINPR_ATTR_UNUSED const AUDIO_FORMAT* format)
 {
 	return TRUE;
 }
 
-static UINT rdpsnd_fake_play(rdpsndDevicePlugin* device, const BYTE* data, size_t size)
+static UINT rdpsnd_fake_play(WINPR_ATTR_UNUSED rdpsndDevicePlugin* device,
+                             WINPR_ATTR_UNUSED const BYTE* data, WINPR_ATTR_UNUSED size_t size)
 {
 	return CHANNEL_RC_OK;
 }

--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -87,8 +87,8 @@ static BOOL rdpsnd_check_pulse(rdpsndPulsePlugin* pulse, BOOL haveStream)
 
 static BOOL rdpsnd_pulse_format_supported(rdpsndDevicePlugin* device, const AUDIO_FORMAT* format);
 
-static void rdpsnd_pulse_get_sink_info(pa_context* c, const pa_sink_info* i, int eol,
-                                       void* userdata)
+static void rdpsnd_pulse_get_sink_info(pa_context* c, const pa_sink_info* i,
+                                       WINPR_ATTR_UNUSED int eol, void* userdata)
 {
 	UINT16 dwVolumeLeft = ((50 * 0xFFFF) / 100);  /* 50% */
 	UINT16 dwVolumeRight = ((50 * 0xFFFF) / 100); /* 50% */
@@ -208,7 +208,8 @@ static BOOL rdpsnd_pulse_connect(rdpsndDevicePlugin* device)
 	return rc;
 }
 
-static void rdpsnd_pulse_stream_success_callback(pa_stream* stream, int success, void* userdata)
+static void rdpsnd_pulse_stream_success_callback(WINPR_ATTR_UNUSED pa_stream* stream,
+                                                 WINPR_ATTR_UNUSED int success, void* userdata)
 {
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)userdata;
 
@@ -262,7 +263,8 @@ static void rdpsnd_pulse_stream_state_callback(pa_stream* stream, void* userdata
 	}
 }
 
-static void rdpsnd_pulse_stream_request_callback(pa_stream* stream, size_t length, void* userdata)
+static void rdpsnd_pulse_stream_request_callback(pa_stream* stream, WINPR_ATTR_UNUSED size_t length,
+                                                 void* userdata)
 {
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)userdata;
 

--- a/channels/remdesk/client/remdesk_main.c
+++ b/channels/remdesk/client/remdesk_main.c
@@ -135,13 +135,15 @@ static UINT remdesk_generate_expert_blob(remdeskPlugin* remdesk)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT remdesk_recv_ctl_server_announce_pdu(remdeskPlugin* remdesk, wStream* s,
-                                                 REMDESK_CHANNEL_HEADER* header)
+static UINT remdesk_recv_ctl_server_announce_pdu(WINPR_ATTR_UNUSED remdeskPlugin* remdesk,
+                                                 WINPR_ATTR_UNUSED wStream* s,
+                                                 WINPR_ATTR_UNUSED REMDESK_CHANNEL_HEADER* header)
 {
 	WINPR_ASSERT(remdesk);
 	WINPR_ASSERT(s);
 	WINPR_ASSERT(header);
 
+	WLog_ERR("TODO", "TODO: implement");
 	return CHANNEL_RC_OK;
 }
 
@@ -151,7 +153,7 @@ static UINT remdesk_recv_ctl_server_announce_pdu(remdeskPlugin* remdesk, wStream
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT remdesk_recv_ctl_version_info_pdu(remdeskPlugin* remdesk, wStream* s,
-                                              REMDESK_CHANNEL_HEADER* header)
+                                              WINPR_ATTR_UNUSED REMDESK_CHANNEL_HEADER* header)
 {
 	UINT32 versionMajor = 0;
 	UINT32 versionMinor = 0;
@@ -222,8 +224,9 @@ static UINT remdesk_send_ctl_version_info_pdu(remdeskPlugin* remdesk)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT remdesk_recv_ctl_result_pdu(remdeskPlugin* remdesk, wStream* s,
-                                        REMDESK_CHANNEL_HEADER* header, UINT32* pResult)
+static UINT remdesk_recv_ctl_result_pdu(WINPR_ATTR_UNUSED remdeskPlugin* remdesk, wStream* s,
+                                        WINPR_ATTR_UNUSED REMDESK_CHANNEL_HEADER* header,
+                                        UINT32* pResult)
 {
 	UINT32 result = 0;
 
@@ -666,9 +669,10 @@ static UINT remdesk_process_receive(remdeskPlugin* remdesk, wStream* s)
 	return status;
 }
 
-static void remdesk_process_connect(remdeskPlugin* remdesk)
+static void remdesk_process_connect(WINPR_ATTR_UNUSED remdeskPlugin* remdesk)
 {
 	WINPR_ASSERT(remdesk);
+	WLog_ERR("TODO", "TODO: implement");
 }
 
 /**
@@ -843,8 +847,9 @@ static DWORD WINAPI remdesk_virtual_channel_client_thread(LPVOID arg)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT remdesk_virtual_channel_event_connected(remdeskPlugin* remdesk, LPVOID pData,
-                                                    UINT32 dataLength)
+static UINT remdesk_virtual_channel_event_connected(remdeskPlugin* remdesk,
+                                                    WINPR_ATTR_UNUSED LPVOID pData,
+                                                    WINPR_ATTR_UNUSED UINT32 dataLength)
 {
 	UINT error = 0;
 

--- a/channels/remdesk/server/remdesk_main.c
+++ b/channels/remdesk/server/remdesk_main.c
@@ -138,8 +138,9 @@ out:
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT remdesk_recv_ctl_version_info_pdu(RemdeskServerContext* context, wStream* s,
-                                              REMDESK_CHANNEL_HEADER* header)
+static UINT remdesk_recv_ctl_version_info_pdu(WINPR_ATTR_UNUSED RemdeskServerContext* context,
+                                              wStream* s,
+                                              WINPR_ATTR_UNUSED REMDESK_CHANNEL_HEADER* header)
 {
 	UINT32 versionMajor = 0;
 	UINT32 versionMinor = 0;
@@ -204,8 +205,8 @@ static UINT remdesk_recv_ctl_remote_control_desktop_pdu(RemdeskServerContext* co
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT remdesk_recv_ctl_authenticate_pdu(RemdeskServerContext* context, wStream* s,
-                                              REMDESK_CHANNEL_HEADER* header)
+static UINT remdesk_recv_ctl_authenticate_pdu(WINPR_ATTR_UNUSED RemdeskServerContext* context,
+                                              wStream* s, REMDESK_CHANNEL_HEADER* header)
 {
 	size_t cchTmpStringW = 0;
 	const WCHAR* expertBlobW = NULL;

--- a/channels/urbdrc/client/data_transfer.c
+++ b/channels/urbdrc/client/data_transfer.c
@@ -51,9 +51,10 @@ static void usb_process_get_port_status(IUDEVICE* pdev, wStream* out)
 	}
 }
 
-static UINT urb_write_completion(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback, BOOL noAck,
-                                 wStream* out, UINT32 InterfaceId, UINT32 MessageId,
-                                 UINT32 RequestId, UINT32 usbd_status, UINT32 OutputBufferSize)
+static UINT urb_write_completion(WINPR_ATTR_UNUSED IUDEVICE* pdev,
+                                 GENERIC_CHANNEL_CALLBACK* callback, BOOL noAck, wStream* out,
+                                 UINT32 InterfaceId, UINT32 MessageId, UINT32 RequestId,
+                                 UINT32 usbd_status, UINT32 OutputBufferSize)
 {
 	if (!out)
 		return ERROR_INVALID_PARAMETER;
@@ -176,7 +177,8 @@ static UINT urbdrc_process_cancel_request(IUDEVICE* pdev, wStream* s, IUDEVMAN* 
 	return ERROR_SUCCESS;
 }
 
-static UINT urbdrc_process_retract_device_request(IUDEVICE* pdev, wStream* s, IUDEVMAN* udevman)
+static UINT urbdrc_process_retract_device_request(WINPR_ATTR_UNUSED IUDEVICE* pdev, wStream* s,
+                                                  IUDEVMAN* udevman)
 {
 	UINT32 Reason = 0;
 	URBDRC_PLUGIN* urbdrc = NULL;
@@ -727,8 +729,9 @@ static UINT urb_control_transfer(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callb
 
 static void urb_bulk_transfer_cb(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback, wStream* out,
                                  UINT32 InterfaceId, BOOL noAck, UINT32 MessageId, UINT32 RequestId,
-                                 UINT32 NumberOfPackets, UINT32 status, UINT32 StartFrame,
-                                 UINT32 ErrorCount, UINT32 OutputBufferSize)
+                                 WINPR_ATTR_UNUSED UINT32 NumberOfPackets, UINT32 status,
+                                 WINPR_ATTR_UNUSED UINT32 StartFrame,
+                                 WINPR_ATTR_UNUSED UINT32 ErrorCount, UINT32 OutputBufferSize)
 {
 	if (!pdev->isChannelClosed(pdev))
 		urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId, status,
@@ -776,7 +779,8 @@ static UINT urb_bulk_or_interrupt_transfer(IUDEVICE* pdev, GENERIC_CHANNEL_CALLB
 	return (uint32_t)rc;
 }
 
-static void urb_isoch_transfer_cb(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback, wStream* out,
+static void urb_isoch_transfer_cb(WINPR_ATTR_UNUSED IUDEVICE* pdev,
+                                  GENERIC_CHANNEL_CALLBACK* callback, wStream* out,
                                   UINT32 InterfaceId, BOOL noAck, UINT32 MessageId,
                                   UINT32 RequestId, UINT32 NumberOfPackets, UINT32 status,
                                   UINT32 StartFrame, UINT32 ErrorCount, UINT32 OutputBufferSize)

--- a/channels/urbdrc/client/libusb/libusb_udevice.c
+++ b/channels/urbdrc/client/libusb/libusb_udevice.c
@@ -787,7 +787,7 @@ static int libusb_udev_select_configuration(IUDEVICE* idev, UINT32 bConfiguratio
 	return 0;
 }
 
-static int libusb_udev_control_pipe_request(IUDEVICE* idev, UINT32 RequestId,
+static int libusb_udev_control_pipe_request(IUDEVICE* idev, WINPR_ATTR_UNUSED UINT32 RequestId,
                                             UINT32 EndpointAddress, UINT32* UsbdStatus, int command)
 {
 	int error = 0;
@@ -931,7 +931,8 @@ static UINT32 libusb_udev_control_query_device_text(IUDEVICE* idev, UINT32 TextT
 	return S_OK;
 }
 
-static int libusb_udev_os_feature_descriptor_request(IUDEVICE* idev, UINT32 RequestId,
+static int libusb_udev_os_feature_descriptor_request(IUDEVICE* idev,
+                                                     WINPR_ATTR_UNUSED UINT32 RequestId,
                                                      BYTE Recipient, BYTE InterfaceNumber,
                                                      BYTE Ms_PageIndex, UINT16 Ms_featureDescIndex,
                                                      UINT32* UsbdStatus, UINT32* BufferSize,
@@ -1221,8 +1222,9 @@ static int libusb_udev_query_device_port_status(IUDEVICE* idev, UINT32* UsbdStat
 
 static int libusb_udev_isoch_transfer(IUDEVICE* idev, GENERIC_CHANNEL_CALLBACK* callback,
                                       UINT32 MessageId, UINT32 RequestId, UINT32 EndpointAddress,
-                                      UINT32 TransferFlags, UINT32 StartFrame, UINT32 ErrorCount,
-                                      BOOL NoAck, const BYTE* packetDescriptorData,
+                                      WINPR_ATTR_UNUSED UINT32 TransferFlags, UINT32 StartFrame,
+                                      UINT32 ErrorCount, BOOL NoAck,
+                                      WINPR_ATTR_UNUSED const BYTE* packetDescriptorData,
                                       UINT32 NumberOfPackets, UINT32 BufferSize, const BYTE* Buffer,
                                       t_isoch_transfer_cb cb, UINT32 Timeout)
 {
@@ -1289,10 +1291,12 @@ static int libusb_udev_isoch_transfer(IUDEVICE* idev, GENERIC_CHANNEL_CALLBACK* 
 	return rc;
 }
 
-static BOOL libusb_udev_control_transfer(IUDEVICE* idev, UINT32 RequestId, UINT32 EndpointAddress,
-                                         UINT32 TransferFlags, BYTE bmRequestType, BYTE Request,
-                                         UINT16 Value, UINT16 Index, UINT32* UrbdStatus,
-                                         UINT32* BufferSize, BYTE* Buffer, UINT32 Timeout)
+static BOOL libusb_udev_control_transfer(IUDEVICE* idev, WINPR_ATTR_UNUSED UINT32 RequestId,
+                                         WINPR_ATTR_UNUSED UINT32 EndpointAddress,
+                                         WINPR_ATTR_UNUSED UINT32 TransferFlags, BYTE bmRequestType,
+                                         BYTE Request, UINT16 Value, UINT16 Index,
+                                         UINT32* UrbdStatus, UINT32* BufferSize, BYTE* Buffer,
+                                         UINT32 Timeout)
 {
 	int status = 0;
 	UDEVICE* pdev = (UDEVICE*)idev;
@@ -1644,7 +1648,7 @@ static int udev_get_device_handle(URBDRC_PLUGIN* urbdrc, libusb_context* ctx, UD
 }
 
 static int udev_get_hub_handle(URBDRC_PLUGIN* urbdrc, libusb_context* ctx, UDEVICE* pdev,
-                               UINT16 bus_number, UINT16 dev_number)
+                               UINT16 bus_number, WINPR_ATTR_UNUSED UINT16 dev_number)
 {
 	int error = -1;
 	LIBUSB_DEVICE** libusb_list = NULL;

--- a/channels/urbdrc/client/urbdrc_main.c
+++ b/channels/urbdrc/client/urbdrc_main.c
@@ -444,7 +444,8 @@ static BOOL urbdrc_announce_devices(IUDEVMAN* udevman)
 	return error == ERROR_SUCCESS;
 }
 
-static UINT urbdrc_device_control_channel(GENERIC_CHANNEL_CALLBACK* callback, wStream* s)
+static UINT urbdrc_device_control_channel(GENERIC_CHANNEL_CALLBACK* callback,
+                                          WINPR_ATTR_UNUSED wStream* s)
 {
 	URBDRC_PLUGIN* urbdrc = (URBDRC_PLUGIN*)callback->plugin;
 	IUDEVMAN* udevman = urbdrc->udevman;
@@ -647,8 +648,9 @@ static UINT urbdrc_on_close(IWTSVirtualChannelCallback* pChannelCallback)
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT urbdrc_on_new_channel_connection(IWTSListenerCallback* pListenerCallback,
-                                             IWTSVirtualChannel* pChannel, BYTE* pData,
-                                             BOOL* pbAccept,
+                                             IWTSVirtualChannel* pChannel,
+                                             WINPR_ATTR_UNUSED BYTE* pData,
+                                             WINPR_ATTR_UNUSED BOOL* pbAccept,
                                              IWTSVirtualChannelCallback** ppCallback)
 {
 	GENERIC_LISTENER_CALLBACK* listener_callback = (GENERIC_LISTENER_CALLBACK*)pListenerCallback;

--- a/channels/urbdrc/common/urbdrc_helpers.c
+++ b/channels/urbdrc/common/urbdrc_helpers.c
@@ -195,7 +195,9 @@ static const char* call_to_string_proxy(BOOL client, UINT32 interfaceId, UINT32 
 	}
 }
 
-static const char* call_to_string_stub(BOOL client, UINT32 interfaceNr, UINT32 functionId)
+static const char* call_to_string_stub(WINPR_ATTR_UNUSED BOOL client,
+                                       WINPR_ATTR_UNUSED UINT32 interfaceNr,
+                                       WINPR_ATTR_UNUSED UINT32 functionId)
 {
 	return "QUERY_DEVICE_TEXT_RSP             [stub  |client]";
 }

--- a/client/SDL/SDL2/dialogs/sdl_connection_dialog.cpp
+++ b/client/SDL/SDL2/dialogs/sdl_connection_dialog.cpp
@@ -485,7 +485,7 @@ void SDLConnectionDialog::resetTimer()
 	_running = false;
 }
 
-Uint32 SDLConnectionDialog::timeout(Uint32 intervalMS, void* pvthis)
+Uint32 SDLConnectionDialog::timeout([[maybe_unused]] Uint32 intervalMS, void* pvthis)
 {
 	auto self = static_cast<SDLConnectionDialog*>(pvthis);
 	self->hide();

--- a/client/SDL/SDL2/dialogs/sdl_dialogs.cpp
+++ b/client/SDL/SDL2/dialogs/sdl_dialogs.cpp
@@ -201,7 +201,8 @@ BOOL sdl_choose_smartcard(freerdp* instance, SmartcardCertInfo** cert_list, DWOR
 	return res;
 }
 
-SSIZE_T sdl_retry_dialog(freerdp* instance, const char* what, size_t current, void* userarg)
+SSIZE_T sdl_retry_dialog(freerdp* instance, const char* what, size_t current,
+                         [[maybe_unused]] void* userarg)
 {
 	WINPR_ASSERT(instance);
 	WINPR_ASSERT(instance->context);
@@ -256,8 +257,9 @@ SSIZE_T sdl_retry_dialog(freerdp* instance, const char* what, size_t current, vo
 	return WINPR_ASSERTING_INT_CAST(SSIZE_T, delay);
 }
 
-BOOL sdl_present_gateway_message(freerdp* instance, UINT32 type, BOOL isDisplayMandatory,
-                                 BOOL isConsentMandatory, size_t length, const WCHAR* wmessage)
+BOOL sdl_present_gateway_message(freerdp* instance, [[maybe_unused]] UINT32 type,
+                                 BOOL isDisplayMandatory, BOOL isConsentMandatory, size_t length,
+                                 const WCHAR* wmessage)
 {
 	if (!isDisplayMandatory)
 		return TRUE;

--- a/client/SDL/SDL2/dialogs/sdl_widget.cpp
+++ b/client/SDL/SDL2/dialogs/sdl_widget.cpp
@@ -42,7 +42,8 @@ static const SDL_Color backgroundcolor = { 0x38, 0x36, 0x35, 0xff };
 
 static const Uint32 hpadding = 10;
 
-SdlWidget::SdlWidget(SDL_Renderer* renderer, SDL_Rect rect, bool input) : _rect(rect), _input(input)
+SdlWidget::SdlWidget([[maybe_unused]] SDL_Renderer* renderer, SDL_Rect rect, bool input)
+    : _rect(rect), _input(input)
 {
 	assert(renderer);
 

--- a/client/SDL/SDL2/sdl_freerdp.cpp
+++ b/client/SDL/SDL2/sdl_freerdp.cpp
@@ -339,8 +339,8 @@ class SdlEventUpdateTriggerGuard
 	SdlEventUpdateTriggerGuard& operator=(SdlEventUpdateTriggerGuard&&) = delete;
 };
 
-static bool sdl_draw_to_window_rect(SdlContext* sdl, SdlWindow& window, SDL_Surface* surface,
-                                    SDL_Point offset, SDL_Rect srcRect)
+static bool sdl_draw_to_window_rect([[maybe_unused]] SdlContext* sdl, SdlWindow& window,
+                                    SDL_Surface* surface, SDL_Point offset, SDL_Rect srcRect)
 {
 	SDL_Rect dstRect = { offset.x + srcRect.x, offset.y + srcRect.y, srcRect.w, srcRect.h };
 	return window.blit(surface, srcRect, dstRect);
@@ -677,7 +677,8 @@ static const char* sdl_window_get_title(rdpSettings* settings)
 	return freerdp_settings_get_string(settings, FreeRDP_WindowTitle);
 }
 
-static void sdl_term_handler(int signum, const char* signame, void* context)
+static void sdl_term_handler([[maybe_unused]] int signum, [[maybe_unused]] const char* signame,
+                             [[maybe_unused]] void* context)
 {
 	sdl_push_quit();
 }
@@ -1464,7 +1465,7 @@ static BOOL sdl_client_new(freerdp* instance, rdpContext* context)
 	return TRUE;
 }
 
-static void sdl_client_free(freerdp* instance, rdpContext* context)
+static void sdl_client_free([[maybe_unused]] freerdp* instance, rdpContext* context)
 {
 	auto sdl = reinterpret_cast<sdl_rdp_context*>(context);
 

--- a/client/SDL/SDL2/sdl_monitor.cpp
+++ b/client/SDL/SDL2/sdl_monitor.cpp
@@ -56,7 +56,7 @@ using VIRTUAL_SCREEN = struct
 /* See MSDN Section on Multiple Display Monitors: http://msdn.microsoft.com/en-us/library/dd145071
  */
 
-int sdl_list_monitors(SdlContext* sdl)
+int sdl_list_monitors([[maybe_unused]] SdlContext* sdl)
 {
 	SDL_Init(SDL_INIT_VIDEO);
 	const int nmonitors = SDL_GetNumVideoDisplays();

--- a/client/SDL/SDL3/dialogs/sdl_connection_dialog.cpp
+++ b/client/SDL/SDL3/dialogs/sdl_connection_dialog.cpp
@@ -483,7 +483,8 @@ void SDLConnectionDialog::resetTimer()
 	_running = false;
 }
 
-Uint32 SDLConnectionDialog::timeout(void* pvthis, SDL_TimerID timerID, Uint32 intervalMS)
+Uint32 SDLConnectionDialog::timeout(void* pvthis, [[maybe_unused]] SDL_TimerID timerID,
+                                    [[maybe_unused]] Uint32 intervalMS)
 {
 	auto self = static_cast<SDLConnectionDialog*>(pvthis);
 	self->hide();

--- a/client/SDL/SDL3/dialogs/sdl_dialogs.cpp
+++ b/client/SDL/SDL3/dialogs/sdl_dialogs.cpp
@@ -201,7 +201,8 @@ BOOL sdl_choose_smartcard(freerdp* instance, SmartcardCertInfo** cert_list, DWOR
 	return res;
 }
 
-SSIZE_T sdl_retry_dialog(freerdp* instance, const char* what, size_t current, void* userarg)
+SSIZE_T sdl_retry_dialog(freerdp* instance, const char* what, size_t current,
+                         [[maybe_unused]] void* userarg)
 {
 	WINPR_ASSERT(instance);
 	WINPR_ASSERT(instance->context);
@@ -254,8 +255,9 @@ SSIZE_T sdl_retry_dialog(freerdp* instance, const char* what, size_t current, vo
 	return WINPR_ASSERTING_INT_CAST(ssize_t, delay);
 }
 
-BOOL sdl_present_gateway_message(freerdp* instance, UINT32 type, BOOL isDisplayMandatory,
-                                 BOOL isConsentMandatory, size_t length, const WCHAR* wmessage)
+BOOL sdl_present_gateway_message(freerdp* instance, [[maybe_unused]] UINT32 type,
+                                 BOOL isDisplayMandatory, BOOL isConsentMandatory, size_t length,
+                                 const WCHAR* wmessage)
 {
 	if (!isDisplayMandatory)
 		return TRUE;

--- a/client/SDL/SDL3/dialogs/sdl_widget.cpp
+++ b/client/SDL/SDL3/dialogs/sdl_widget.cpp
@@ -42,7 +42,7 @@ static const SDL_Color backgroundcolor = { 0x38, 0x36, 0x35, 0xff };
 
 static const Uint32 hpadding = 10;
 
-SdlWidget::SdlWidget(SDL_Renderer* renderer, const SDL_FRect& rect, bool input)
+SdlWidget::SdlWidget([[maybe_unused]] SDL_Renderer* renderer, const SDL_FRect& rect, bool input)
     : _rect(rect), _input(input)
 {
 	assert(renderer);

--- a/client/SDL/SDL3/sdl_clip.cpp
+++ b/client/SDL/SDL3/sdl_clip.cpp
@@ -523,7 +523,7 @@ UINT sdlClip::ReceiveServerFormatList(CliprdrClientContext* context,
 	return clipboard->SendFormatListResponse(rc);
 }
 
-UINT sdlClip::ReceiveFormatListResponse(CliprdrClientContext* context,
+UINT sdlClip::ReceiveFormatListResponse(WINPR_ATTR_UNUSED CliprdrClientContext* context,
                                         const CLIPRDR_FORMAT_LIST_RESPONSE* formatListResponse)
 {
 	WINPR_ASSERT(context);

--- a/client/SDL/SDL3/sdl_disp.cpp
+++ b/client/SDL/SDL3/sdl_disp.cpp
@@ -195,7 +195,7 @@ void sdlDispContext::OnGraphicsReset(void* context, const GraphicsResetEventArgs
 	}
 }
 
-Uint32 sdlDispContext::OnTimer(void* param, SDL_TimerID timerID, Uint32 interval)
+Uint32 sdlDispContext::OnTimer(void* param, [[maybe_unused]] SDL_TimerID timerID, Uint32 interval)
 {
 	auto ctx = static_cast<sdlDispContext*>(param);
 	if (!ctx)

--- a/client/SDL/SDL3/sdl_freerdp.cpp
+++ b/client/SDL/SDL3/sdl_freerdp.cpp
@@ -340,8 +340,8 @@ class SdlEventUpdateTriggerGuard
 	SdlEventUpdateTriggerGuard& operator=(SdlEventUpdateTriggerGuard&&) = delete;
 };
 
-static bool sdl_draw_to_window_rect(SdlContext* sdl, SdlWindow& window, SDL_Surface* surface,
-                                    SDL_Point offset, const SDL_Rect& srcRect)
+static bool sdl_draw_to_window_rect([[maybe_unused]] SdlContext* sdl, SdlWindow& window,
+                                    SDL_Surface* surface, SDL_Point offset, const SDL_Rect& srcRect)
 {
 	SDL_Rect dstRect = { offset.x + srcRect.x, offset.y + srcRect.y, srcRect.w, srcRect.h };
 	return window.blit(surface, srcRect, dstRect);
@@ -675,7 +675,8 @@ static const char* sdl_window_get_title(rdpSettings* settings)
 	return freerdp_settings_get_string(settings, FreeRDP_WindowTitle);
 }
 
-static void sdl_term_handler(int signum, const char* signame, void* context)
+static void sdl_term_handler([[maybe_unused]] int signum, [[maybe_unused]] const char* signame,
+                             [[maybe_unused]] void* context)
 {
 	sdl_push_quit();
 }
@@ -1449,7 +1450,7 @@ static BOOL sdl_client_new(freerdp* instance, rdpContext* context)
 	return TRUE;
 }
 
-static void sdl_client_free(freerdp* instance, rdpContext* context)
+static void sdl_client_free([[maybe_unused]] freerdp* instance, rdpContext* context)
 {
 	auto sdl = reinterpret_cast<sdl_rdp_context*>(context);
 

--- a/client/SDL/SDL3/sdl_monitor.cpp
+++ b/client/SDL/SDL3/sdl_monitor.cpp
@@ -56,7 +56,7 @@ typedef struct
 /* See MSDN Section on Multiple Display Monitors: http://msdn.microsoft.com/en-us/library/dd145071
  */
 
-int sdl_list_monitors(SdlContext* sdl)
+int sdl_list_monitors([[maybe_unused]] SdlContext* sdl)
 {
 	SDL_Init(SDL_INIT_VIDEO);
 

--- a/client/SDL/SDL3/sdl_window.cpp
+++ b/client/SDL/SDL3/sdl_window.cpp
@@ -21,7 +21,7 @@
 #include "sdl_utils.hpp"
 
 SdlWindow::SdlWindow(const std::string& title, Sint32 startupX, Sint32 startupY, Sint32 width,
-                     Sint32 height, Uint32 flags)
+                     Sint32 height, [[maybe_unused]] Uint32 flags)
 {
 	auto props = SDL_CreateProperties();
 	SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_TITLE_STRING, title.c_str());

--- a/client/SDL/common/res/sdl_resource_manager.cpp
+++ b/client/SDL/common/res/sdl_resource_manager.cpp
@@ -68,7 +68,8 @@ const std::vector<unsigned char>* SDLResourceManager::data(const std::string& ty
 #endif
 }
 
-std::string SDLResourceManager::filename(const std::string& type, const std::string& id)
+std::string SDLResourceManager::filename([[maybe_unused]] const std::string& type,
+                                         [[maybe_unused]] const std::string& id)
 {
 #if defined(SDL_RESOURCE_ROOT)
 	std::string uuid = type + "/" + id;

--- a/client/Wayland/wlf_cliprdr.c
+++ b/client/Wayland/wlf_cliprdr.c
@@ -706,7 +706,7 @@ static UINT wlf_cliprdr_server_format_list(CliprdrClientContext* context,
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT
-wlf_cliprdr_server_format_list_response(CliprdrClientContext* context,
+wlf_cliprdr_server_format_list_response(WINPR_ATTR_UNUSED CliprdrClientContext* context,
                                         const CLIPRDR_FORMAT_LIST_RESPONSE* formatListResponse)
 {
 	WINPR_ASSERT(context);

--- a/client/Wayland/wlf_disp.c
+++ b/client/Wayland/wlf_disp.c
@@ -158,8 +158,9 @@ static BOOL wlf_disp_sendResize(wlfDispContext* wlfDisp)
 	return wlf_update_last_sent(wlfDisp);
 }
 
-static BOOL wlf_disp_set_window_resizable(wlfDispContext* wlfDisp)
+static BOOL wlf_disp_set_window_resizable(WINPR_ATTR_UNUSED wlfDispContext* wlfDisp)
 {
+	WLog_ERR("TODO", "TODO: implement");
 #if 0 // TODO
 #endif
 	return TRUE;

--- a/client/Wayland/wlf_pointer.c
+++ b/client/Wayland/wlf_pointer.c
@@ -144,10 +144,11 @@ static BOOL wlf_Pointer_SetDefault(rdpContext* context)
 	return TRUE;
 }
 
-static BOOL wlf_Pointer_SetPosition(rdpContext* context, UINT32 x, UINT32 y)
+static BOOL wlf_Pointer_SetPosition(WINPR_ATTR_UNUSED rdpContext* context,
+                                    WINPR_ATTR_UNUSED UINT32 x, WINPR_ATTR_UNUSED UINT32 y)
 {
 	// TODO
-	WLog_WARN(TAG, "not implemented");
+	WLog_ERR("TODO", "TODO: implement");
 	return TRUE;
 }
 

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -297,8 +297,8 @@ BOOL xf_picture_transform_required(xfContext* xfc)
 }
 #endif /* WITH_XRENDER defined */
 
-void xf_draw_screen_(xfContext* xfc, int x, int y, int w, int h, const char* fkt, const char* file,
-                     int line)
+void xf_draw_screen_(xfContext* xfc, int x, int y, int w, int h, const char* fkt,
+                     WINPR_ATTR_UNUSED const char* file, WINPR_ATTR_UNUSED int line)
 {
 	if (!xfc)
 	{
@@ -828,7 +828,7 @@ void xf_minimize(xfContext* xfc)
 	PubSub_OnWindowStateChange(context->pubSub, context, &e);
 }
 
-void xf_lock_x11_(xfContext* xfc, const char* fkt)
+void xf_lock_x11_(xfContext* xfc, WINPR_ATTR_UNUSED const char* fkt)
 {
 	if (!xfc->UseXThreads)
 		(void)WaitForSingleObject(xfc->mutex, INFINITE);
@@ -838,7 +838,7 @@ void xf_lock_x11_(xfContext* xfc, const char* fkt)
 	xfc->locked++;
 }
 
-void xf_unlock_x11_(xfContext* xfc, const char* fkt)
+void xf_unlock_x11_(xfContext* xfc, WINPR_ATTR_UNUSED const char* fkt)
 {
 	if (xfc->locked == 0)
 		WLog_WARN(TAG, "X11: trying to unlock although not locked!");
@@ -1321,7 +1321,8 @@ static BOOL xf_process_pipe(rdpContext* context, const char* pipe)
 	return TRUE;
 }
 
-static void cleanup_pipe(int signum, const char* signame, void* context)
+static void cleanup_pipe(WINPR_ATTR_UNUSED int signum, WINPR_ATTR_UNUSED const char* signame,
+                         void* context)
 {
 	const char* pipe = context;
 	if (!pipe)
@@ -2085,7 +2086,7 @@ static BOOL xfreerdp_client_new(freerdp* instance, rdpContext* context)
 	return TRUE;
 }
 
-static void xfreerdp_client_free(freerdp* instance, rdpContext* context)
+static void xfreerdp_client_free(WINPR_ATTR_UNUSED freerdp* instance, rdpContext* context)
 {
 	if (!context)
 		return;

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -429,7 +429,7 @@ static const CLIPRDR_FORMAT* xf_cliprdr_get_server_format_by_atom(xfClipboard* c
  * @return 0 on success, otherwise a Win32 error code
  */
 static UINT xf_cliprdr_send_data_request(xfClipboard* clipboard, UINT32 formatId,
-                                         const xfCliprdrFormat* cformat)
+                                         WINPR_ATTR_UNUSED const xfCliprdrFormat* cformat)
 {
 	CLIPRDR_FORMAT_DATA_REQUEST request = { 0 };
 	request.requestedFormatId = formatId;
@@ -2054,9 +2054,9 @@ out:
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT
-xf_cliprdr_server_format_list_response(CliprdrClientContext* context,
-                                       const CLIPRDR_FORMAT_LIST_RESPONSE* formatListResponse)
+static UINT xf_cliprdr_server_format_list_response(
+    WINPR_ATTR_UNUSED CliprdrClientContext* context,
+    WINPR_ATTR_UNUSED const CLIPRDR_FORMAT_LIST_RESPONSE* formatListResponse)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(formatListResponse);

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -174,8 +174,8 @@ const char* x11_event_string(int event)
 	} while (0)
 #endif
 
-static BOOL xf_action_script_append(xfContext* xfc, const char* buffer, size_t size, void* user,
-                                    const char* what, const char* arg)
+static BOOL xf_action_script_append(xfContext* xfc, const char* buffer, size_t size,
+                                    WINPR_ATTR_UNUSED void* user, const char* what, const char* arg)
 {
 	WINPR_ASSERT(xfc);
 	WINPR_UNUSED(what);
@@ -456,7 +456,8 @@ BOOL xf_generic_MotionNotify(xfContext* xfc, int x, int y, int state, Window win
 	return TRUE;
 }
 
-BOOL xf_generic_RawMotionNotify(xfContext* xfc, int x, int y, Window window, BOOL app)
+BOOL xf_generic_RawMotionNotify(xfContext* xfc, int x, int y, WINPR_ATTR_UNUSED Window window,
+                                BOOL app)
 {
 	WINPR_ASSERT(xfc);
 

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -103,8 +103,8 @@ static void xf_keyboard_clear(xfContext* xfc)
 	ZeroMemory(xfc->KeyboardState, sizeof(xfc->KeyboardState));
 }
 
-static BOOL xf_action_script_append(xfContext* xfc, const char* buffer, size_t size, void* user,
-                                    const char* what, const char* arg)
+static BOOL xf_action_script_append(xfContext* xfc, const char* buffer, size_t size,
+                                    WINPR_ATTR_UNUSED void* user, const char* what, const char* arg)
 {
 	WINPR_ASSERT(xfc);
 	WINPR_UNUSED(what);

--- a/client/X11/xf_video.c
+++ b/client/X11/xf_video.c
@@ -62,7 +62,8 @@ static VideoSurface* xfVideoCreateSurface(VideoClientContext* video, UINT32 x, U
 }
 
 static BOOL xfVideoShowSurface(VideoClientContext* video, const VideoSurface* surface,
-                               UINT32 destinationWidth, UINT32 destinationHeight)
+                               WINPR_ATTR_UNUSED UINT32 destinationWidth,
+                               WINPR_ATTR_UNUSED UINT32 destinationHeight)
 {
 	const xfVideoSurface* xfSurface = (const xfVideoSurface*)surface;
 	xfContext* xfc = NULL;

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -1110,8 +1110,9 @@ BOOL xf_AppWindowCreate(xfContext* xfc, xfAppWindow* appWindow)
 	return TRUE;
 }
 
-void xf_SetWindowMinMaxInfo(xfContext* xfc, xfAppWindow* appWindow, int maxWidth, int maxHeight,
-                            int maxPosX, int maxPosY, int minTrackWidth, int minTrackHeight,
+void xf_SetWindowMinMaxInfo(xfContext* xfc, xfAppWindow* appWindow, WINPR_ATTR_UNUSED int maxWidth,
+                            WINPR_ATTR_UNUSED int maxHeight, WINPR_ATTR_UNUSED int maxPosX,
+                            WINPR_ATTR_UNUSED int maxPosY, int minTrackWidth, int minTrackHeight,
                             int maxTrackWidth, int maxTrackHeight)
 {
 	XSizeHints* size_hints = NULL;

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -572,8 +572,8 @@ BOOL client_cli_authenticate_ex(freerdp* instance, char** username, char** passw
 	return client_cli_authenticate_raw(instance, reason, username, password, domain);
 }
 
-BOOL client_cli_choose_smartcard(freerdp* instance, SmartcardCertInfo** cert_list, DWORD count,
-                                 DWORD* choice, BOOL gateway)
+BOOL client_cli_choose_smartcard(WINPR_ATTR_UNUSED freerdp* instance, SmartcardCertInfo** cert_list,
+                                 DWORD count, DWORD* choice, BOOL gateway)
 {
 	unsigned long answer = 0;
 	char* p = NULL;

--- a/client/common/client_cliprdr_file.c
+++ b/client/common/client_cliprdr_file.c
@@ -379,7 +379,7 @@ static BOOL maybe_steal_inode(const void* key, void* value, void* arg)
 	return TRUE;
 }
 
-static BOOL notify_delete_child(void* data, size_t index, va_list ap)
+static BOOL notify_delete_child(void* data, WINPR_ATTR_UNUSED size_t index, va_list ap)
 {
 	CliprdrFuseFile* child = data;
 
@@ -398,7 +398,7 @@ static BOOL notify_delete_child(void* data, size_t index, va_list ap)
 	return TRUE;
 }
 
-static BOOL invalidate_inode(void* data, size_t index, va_list ap)
+static BOOL invalidate_inode(void* data, WINPR_ATTR_UNUSED size_t index, va_list ap)
 {
 	CliprdrFuseFile* fuse_file = data;
 
@@ -517,7 +517,8 @@ static void clear_no_cdi_entry(CliprdrFileContext* file_context)
 	HashTable_Unlock(file_context->inode_table);
 }
 
-static BOOL clear_clip_data_entries(const void* key, void* value, void* arg)
+static BOOL clear_clip_data_entries(WINPR_ATTR_UNUSED const void* key, void* value,
+                                    WINPR_ATTR_UNUSED void* arg)
 {
 	clear_entry_selection(value);
 
@@ -657,8 +658,9 @@ static CliprdrFuseFile* get_fuse_file_by_ino(CliprdrFileContext* file_context, f
 	return HashTable_GetItemValue(file_context->inode_table, (void*)(uintptr_t)fuse_ino);
 }
 
-static CliprdrFuseFile* get_fuse_file_by_name_from_parent(CliprdrFileContext* file_context,
-                                                          CliprdrFuseFile* parent, const char* name)
+static CliprdrFuseFile*
+get_fuse_file_by_name_from_parent(WINPR_ATTR_UNUSED CliprdrFileContext* file_context,
+                                  CliprdrFuseFile* parent, const char* name)
 {
 	WINPR_ASSERT(file_context);
 	WINPR_ASSERT(parent);
@@ -834,7 +836,7 @@ static void cliprdr_file_fuse_lookup(fuse_req_t fuse_req, fuse_ino_t parent_ino,
 }
 
 static void cliprdr_file_fuse_getattr(fuse_req_t fuse_req, fuse_ino_t fuse_ino,
-                                      struct fuse_file_info* file_info)
+                                      WINPR_ATTR_UNUSED struct fuse_file_info* file_info)
 {
 	CliprdrFileContext* file_context = fuse_req_userdata(fuse_req);
 	CliprdrFuseFile* fuse_file = NULL;
@@ -956,7 +958,7 @@ static BOOL request_file_range_async(CliprdrFileContext* file_context, CliprdrFu
 }
 
 static void cliprdr_file_fuse_read(fuse_req_t fuse_req, fuse_ino_t fuse_ino, size_t size,
-                                   off_t offset, struct fuse_file_info* file_info)
+                                   off_t offset, WINPR_ATTR_UNUSED struct fuse_file_info* file_info)
 {
 	CliprdrFileContext* file_context = fuse_req_userdata(fuse_req);
 	CliprdrFuseFile* fuse_file = NULL;
@@ -1026,7 +1028,8 @@ static void cliprdr_file_fuse_opendir(fuse_req_t fuse_req, fuse_ino_t fuse_ino,
 }
 
 static void cliprdr_file_fuse_readdir(fuse_req_t fuse_req, fuse_ino_t fuse_ino, size_t max_size,
-                                      off_t offset, struct fuse_file_info* file_info)
+                                      off_t offset,
+                                      WINPR_ATTR_UNUSED struct fuse_file_info* file_info)
 {
 	CliprdrFileContext* file_context = fuse_req_userdata(fuse_req);
 	CliprdrFuseFile* fuse_file = NULL;
@@ -1317,7 +1320,7 @@ cliprdr_file_context_send_contents_response(CliprdrFileContext* file,
 	return file->context->ClientFileContentsResponse(file->context, &response);
 }
 
-static BOOL dump_streams(const void* key, void* value, void* arg)
+static BOOL dump_streams(const void* key, void* value, WINPR_ATTR_UNUSED void* arg)
 {
 	const UINT32* ukey = key;
 	CliprdrLocalStream* cur = value;
@@ -1767,7 +1770,7 @@ static char* get_parent_path(const char* filepath)
 	return parent_path;
 }
 
-static BOOL is_fuse_file_not_parent(const void* key, void* value, void* arg)
+static BOOL is_fuse_file_not_parent(WINPR_ATTR_UNUSED const void* key, void* value, void* arg)
 {
 	CliprdrFuseFile* fuse_file = value;
 	CliprdrFuseFindParentContext* find_context = arg;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1475,7 +1475,7 @@ BOOL freerdp_set_connection_type(rdpSettings* settings, UINT32 type)
 	return TRUE;
 }
 
-static UINT32 freerdp_get_keyboard_layout_for_type(const char* name, DWORD type)
+static UINT32 freerdp_get_keyboard_layout_for_type(const char* name, WINPR_ATTR_UNUSED DWORD type)
 {
 	UINT32 res = 0;
 	size_t count = 0;
@@ -2010,7 +2010,7 @@ static BOOL prepare_default_settings(rdpSettings* settings, COMMAND_LINE_ARGUMEN
 	return freerdp_set_connection_type(settings, CONNECTION_TYPE_AUTODETECT);
 }
 
-static BOOL setSmartcardEmulation(const char* value, rdpSettings* settings)
+static BOOL setSmartcardEmulation(WINPR_ATTR_UNUSED const char* value, rdpSettings* settings)
 {
 	return freerdp_settings_set_bool(settings, FreeRDP_SmartcardEmulation, TRUE);
 }
@@ -5426,7 +5426,7 @@ static int parse_command_line(rdpSettings* settings, const COMMAND_LINE_ARGUMENT
 
 static int freerdp_client_settings_parse_command_line_arguments_int(
     rdpSettings* settings, int argc, char* argv[], BOOL allowUnknown,
-    COMMAND_LINE_ARGUMENT_A* largs, size_t count,
+    COMMAND_LINE_ARGUMENT_A* largs, WINPR_ATTR_UNUSED size_t count,
     freerdp_command_line_handle_option_t handle_option, void* handle_userdata)
 {
 	char* user = NULL;

--- a/libfreerdp/cache/bitmap.c
+++ b/libfreerdp/cache/bitmap.c
@@ -475,7 +475,8 @@ fail:
 	return NULL;
 }
 
-void free_bitmap_update(rdpContext* context, BITMAP_UPDATE* pointer)
+void free_bitmap_update(WINPR_ATTR_UNUSED rdpContext* context,
+                        WINPR_ATTR_UNUSED BITMAP_UPDATE* pointer)
 {
 	if (!pointer)
 		return;
@@ -534,7 +535,7 @@ fail:
 	return NULL;
 }
 
-void free_cache_bitmap_order(rdpContext* context, CACHE_BITMAP_ORDER* order)
+void free_cache_bitmap_order(WINPR_ATTR_UNUSED rdpContext* context, CACHE_BITMAP_ORDER* order)
 {
 	if (order)
 		free(order->bitmapDataStream);
@@ -571,7 +572,8 @@ fail:
 	return NULL;
 }
 
-void free_cache_bitmap_v2_order(rdpContext* context, CACHE_BITMAP_V2_ORDER* order)
+void free_cache_bitmap_v2_order(WINPR_ATTR_UNUSED rdpContext* context,
+                                WINPR_ATTR_UNUSED CACHE_BITMAP_V2_ORDER* order)
 {
 	if (order)
 		free(order->bitmapDataStream);
@@ -608,7 +610,7 @@ fail:
 	return NULL;
 }
 
-void free_cache_bitmap_v3_order(rdpContext* context, CACHE_BITMAP_V3_ORDER* order)
+void free_cache_bitmap_v3_order(WINPR_ATTR_UNUSED rdpContext* context, CACHE_BITMAP_V3_ORDER* order)
 {
 	if (order)
 		free(order->bitmapData.data);

--- a/libfreerdp/cache/cache.c
+++ b/libfreerdp/cache/cache.c
@@ -113,7 +113,8 @@ fail:
 	return NULL;
 }
 
-void free_cache_color_table_order(rdpContext* context, CACHE_COLOR_TABLE_ORDER* order)
+void free_cache_color_table_order(WINPR_ATTR_UNUSED rdpContext* context,
+                                  CACHE_COLOR_TABLE_ORDER* order)
 {
 	free(order);
 }
@@ -144,7 +145,7 @@ fail:
 	return NULL;
 }
 
-void free_surface_bits_command(rdpContext* context, SURFACE_BITS_COMMAND* order)
+void free_surface_bits_command(WINPR_ATTR_UNUSED rdpContext* context, SURFACE_BITS_COMMAND* order)
 {
 	if (order)
 		free(order->bmp.bitmapData);

--- a/libfreerdp/cache/glyph.c
+++ b/libfreerdp/cache/glyph.c
@@ -806,7 +806,7 @@ fail:
 	return NULL;
 }
 
-void free_cache_glyph_order(rdpContext* context, CACHE_GLYPH_ORDER* glyph)
+void free_cache_glyph_order(WINPR_ATTR_UNUSED rdpContext* context, CACHE_GLYPH_ORDER* glyph)
 {
 	if (glyph)
 	{
@@ -869,7 +869,7 @@ fail:
 	return NULL;
 }
 
-void free_cache_glyph_v2_order(rdpContext* context, CACHE_GLYPH_V2_ORDER* glyph)
+void free_cache_glyph_v2_order(WINPR_ATTR_UNUSED rdpContext* context, CACHE_GLYPH_V2_ORDER* glyph)
 {
 	if (glyph)
 	{

--- a/libfreerdp/cache/palette.c
+++ b/libfreerdp/cache/palette.c
@@ -119,7 +119,7 @@ void palette_cache_free(rdpPaletteCache* paletteCache)
 	}
 }
 
-void free_palette_update(rdpContext* context, PALETTE_UPDATE* pointer)
+void free_palette_update(WINPR_ATTR_UNUSED rdpContext* context, PALETTE_UPDATE* pointer)
 {
 	free(pointer);
 }

--- a/libfreerdp/cache/pointer.c
+++ b/libfreerdp/cache/pointer.c
@@ -523,7 +523,7 @@ fail:
 	return NULL;
 }
 
-void free_pointer_new_update(rdpContext* context, POINTER_NEW_UPDATE* pointer)
+void free_pointer_new_update(WINPR_ATTR_UNUSED rdpContext* context, POINTER_NEW_UPDATE* pointer)
 {
 	if (!pointer)
 		return;

--- a/libfreerdp/codec/bitmap.c
+++ b/libfreerdp/codec/bitmap.c
@@ -465,9 +465,10 @@ static INLINE UINT16 out_from_count_3(UINT16 in_count, wStream* WINPR_RESTRICT i
 	} while (0)
 
 static INLINE SSIZE_T freerdp_bitmap_compress_24(const void* WINPR_RESTRICT srcData, UINT32 width,
-                                                 UINT32 height, wStream* WINPR_RESTRICT s,
-                                                 UINT32 byte_limit, UINT32 start_line,
-                                                 wStream* WINPR_RESTRICT temp_s, UINT32 e)
+                                                 WINPR_ATTR_UNUSED UINT32 height,
+                                                 wStream* WINPR_RESTRICT s, UINT32 byte_limit,
+                                                 UINT32 start_line, wStream* WINPR_RESTRICT temp_s,
+                                                 UINT32 e)
 {
 	int8_t fom_mask[8192] = { 0 }; /* good for up to 64K bitmap */
 	SSIZE_T lines_sent = 0;
@@ -774,8 +775,9 @@ static INLINE SSIZE_T freerdp_bitmap_compress_24(const void* WINPR_RESTRICT srcD
 }
 
 static INLINE SSIZE_T freerdp_bitmap_compress_16(const void* WINPR_RESTRICT srcData, UINT32 width,
-                                                 UINT32 height, wStream* WINPR_RESTRICT s,
-                                                 UINT32 bpp, UINT32 byte_limit, UINT32 start_line,
+                                                 WINPR_ATTR_UNUSED UINT32 height,
+                                                 wStream* WINPR_RESTRICT s, UINT32 bpp,
+                                                 UINT32 byte_limit, UINT32 start_line,
                                                  wStream* WINPR_RESTRICT temp_s, UINT32 e)
 {
 	int8_t fom_mask[8192] = { 0 }; /* good for up to 64K bitmap */

--- a/libfreerdp/codec/clear.c
+++ b/libfreerdp/codec/clear.c
@@ -1150,8 +1150,11 @@ fail:
 	return rc;
 }
 
-int clear_compress(CLEAR_CONTEXT* WINPR_RESTRICT clear, const BYTE* WINPR_RESTRICT pSrcData,
-                   UINT32 SrcSize, BYTE** WINPR_RESTRICT ppDstData, UINT32* WINPR_RESTRICT pDstSize)
+int clear_compress(WINPR_ATTR_UNUSED CLEAR_CONTEXT* WINPR_RESTRICT clear,
+                   WINPR_ATTR_UNUSED const BYTE* WINPR_RESTRICT pSrcData,
+                   WINPR_ATTR_UNUSED UINT32 SrcSize,
+                   WINPR_ATTR_UNUSED BYTE** WINPR_RESTRICT ppDstData,
+                   WINPR_ATTR_UNUSED UINT32* WINPR_RESTRICT pDstSize)
 {
 	WLog_ERR(TAG, "TODO: not implemented!");
 	return 1;

--- a/libfreerdp/codec/dsp.c
+++ b/libfreerdp/codec/dsp.c
@@ -1460,7 +1460,7 @@ BOOL freerdp_dsp_supports_format(const AUDIO_FORMAT* WINPR_RESTRICT format, BOOL
 
 BOOL freerdp_dsp_context_reset(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
                                const AUDIO_FORMAT* WINPR_RESTRICT targetFormat,
-                               UINT32 FramesPerPacket)
+                               WINPR_ATTR_UNUSED UINT32 FramesPerPacket)
 {
 #if defined(WITH_FDK_AAC)
 	WINPR_ASSERT(targetFormat);

--- a/libfreerdp/codec/dsp_ffmpeg.c
+++ b/libfreerdp/codec/dsp_ffmpeg.c
@@ -60,7 +60,7 @@ struct S_FREERDP_DSP_CONTEXT
 #endif
 };
 
-static BOOL ffmpeg_codec_is_filtered(enum AVCodecID id, BOOL encoder)
+static BOOL ffmpeg_codec_is_filtered(enum AVCodecID id, WINPR_ATTR_UNUSED BOOL encoder)
 {
 	switch (id)
 	{

--- a/libfreerdp/codec/h264.c
+++ b/libfreerdp/codec/h264.c
@@ -109,8 +109,9 @@ BOOL avc420_ensure_buffer(H264_CONTEXT* h264, UINT32 stride, UINT32 width, UINT3
 }
 
 INT32 avc420_decompress(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSize, BYTE* pDstData,
-                        DWORD DstFormat, UINT32 nDstStep, UINT32 nDstWidth, UINT32 nDstHeight,
-                        const RECTANGLE_16* regionRects, UINT32 numRegionRects)
+                        DWORD DstFormat, UINT32 nDstStep, WINPR_ATTR_UNUSED UINT32 nDstWidth,
+                        WINPR_ATTR_UNUSED UINT32 nDstHeight, const RECTANGLE_16* regionRects,
+                        UINT32 numRegionRects)
 {
 	int status = 0;
 	const BYTE* pYUVData[3];
@@ -511,8 +512,8 @@ fail:
 
 static BOOL avc444_process_rects(H264_CONTEXT* h264, const BYTE* pSrcData, UINT32 SrcSize,
                                  BYTE* pDstData, UINT32 DstFormat, UINT32 nDstStep,
-                                 UINT32 nDstWidth, UINT32 nDstHeight, const RECTANGLE_16* rects,
-                                 UINT32 nrRects, avc444_frame_type type)
+                                 WINPR_ATTR_UNUSED UINT32 nDstWidth, UINT32 nDstHeight,
+                                 const RECTANGLE_16* rects, UINT32 nrRects, avc444_frame_type type)
 {
 	const BYTE* pYUVData[3];
 	BYTE* pYUVDstData[3];
@@ -640,7 +641,9 @@ INT32 avc444_decompress(H264_CONTEXT* h264, BYTE op, const RECTANGLE_16* regionR
 static INIT_ONCE subsystems_once = INIT_ONCE_STATIC_INIT;
 static const H264_CONTEXT_SUBSYSTEM* subSystems[MAX_SUBSYSTEMS] = { 0 };
 
-static BOOL CALLBACK h264_register_subsystems(PINIT_ONCE once, PVOID param, PVOID* context)
+static BOOL CALLBACK h264_register_subsystems(WINPR_ATTR_UNUSED PINIT_ONCE once,
+                                              WINPR_ATTR_UNUSED PVOID param,
+                                              WINPR_ATTR_UNUSED PVOID* context)
 {
 	int i = 0;
 

--- a/libfreerdp/codec/interleaved.c
+++ b/libfreerdp/codec/interleaved.c
@@ -377,7 +377,8 @@ static INLINE UINT32 ExtractRunLength(UINT32 code, const BYTE* pbOrderHdr, const
 #define ensure_capacity(start, end, size, base) \
 	ensure_capacity_((start), (end), (size), (base), __func__, __FILE__, __LINE__)
 static INLINE BOOL ensure_capacity_(const BYTE* start, const BYTE* end, size_t size, size_t base,
-                                    const char* fkt, const char* file, size_t line)
+                                    const char* fkt, WINPR_ATTR_UNUSED const char* file,
+                                    size_t line)
 {
 	const size_t available = (uintptr_t)end - (uintptr_t)start;
 	const BOOL rc = available >= size * base;
@@ -717,7 +718,7 @@ BOOL bitmap_interleaved_context_reset(BITMAP_INTERLEAVED_CONTEXT* WINPR_RESTRICT
 	return TRUE;
 }
 
-BITMAP_INTERLEAVED_CONTEXT* bitmap_interleaved_context_new(BOOL Compressor)
+BITMAP_INTERLEAVED_CONTEXT* bitmap_interleaved_context_new(WINPR_ATTR_UNUSED BOOL Compressor)
 {
 	BITMAP_INTERLEAVED_CONTEXT* interleaved = NULL;
 	interleaved = (BITMAP_INTERLEAVED_CONTEXT*)winpr_aligned_recalloc(

--- a/libfreerdp/codec/jpeg.c
+++ b/libfreerdp/codec/jpeg.c
@@ -56,8 +56,11 @@ fail:
 
 #else
 
-BOOL jpeg_decompress(const BYTE* input, BYTE* output, int width, int height, int size, int bpp)
+BOOL jpeg_decompress(WINPR_ATTR_UNUSED const BYTE* input, WINPR_ATTR_UNUSED BYTE* output,
+                     WINPR_ATTR_UNUSED int width, WINPR_ATTR_UNUSED int height,
+                     WINPR_ATTR_UNUSED int size, WINPR_ATTR_UNUSED int bpp)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 

--- a/libfreerdp/codec/neon/nsc_neon.c
+++ b/libfreerdp/codec/neon/nsc_neon.c
@@ -32,7 +32,7 @@
 #define TAG FREERDP_TAG("codec.nsc.neon")
 #endif
 
-void nsc_init_neon_int(NSC_CONTEXT* WINPR_RESTRICT context)
+void nsc_init_neon_int(WINPR_ATTR_UNUSED NSC_CONTEXT* WINPR_RESTRICT context)
 {
 #if defined(NEON_INTRINSICS_ENABLED)
 	WLog_WARN(TAG, "TODO: Implement neon optimized version of this function");

--- a/libfreerdp/codec/nsc.c
+++ b/libfreerdp/codec/nsc.c
@@ -433,7 +433,8 @@ BOOL nsc_context_set_parameters(NSC_CONTEXT* WINPR_RESTRICT context, NSC_PARAMET
 BOOL nsc_process_message(NSC_CONTEXT* WINPR_RESTRICT context, UINT16 bpp, UINT32 width,
                          UINT32 height, const BYTE* data, UINT32 length,
                          BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat, UINT32 nDstStride,
-                         UINT32 nXDst, UINT32 nYDst, UINT32 nWidth, UINT32 nHeight, UINT32 flip)
+                         UINT32 nXDst, UINT32 nYDst, UINT32 nWidth,
+                         WINPR_ATTR_UNUSED UINT32 nHeight, UINT32 flip)
 {
 	wStream* s = NULL;
 	wStream sbuffer = { 0 };

--- a/libfreerdp/codec/nsc_encode.c
+++ b/libfreerdp/codec/nsc_encode.c
@@ -444,8 +444,8 @@ static UINT32 nsc_compute_byte_count(NSC_CONTEXT* WINPR_RESTRICT context,
 	return maxPlaneSize;
 }
 
-BOOL nsc_write_message(NSC_CONTEXT* WINPR_RESTRICT context, wStream* WINPR_RESTRICT s,
-                       const NSC_MESSAGE* WINPR_RESTRICT message)
+BOOL nsc_write_message(WINPR_ATTR_UNUSED NSC_CONTEXT* WINPR_RESTRICT context,
+                       wStream* WINPR_RESTRICT s, const NSC_MESSAGE* WINPR_RESTRICT message)
 {
 	UINT32 totalPlaneByteCount = 0;
 	totalPlaneByteCount = message->LumaPlaneByteCount + message->OrangeChromaPlaneByteCount +

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -871,11 +871,13 @@ static INLINE void progressive_rfx_decode_block(const primitives_t* prims,
 	prims->lShiftC_16s_inplace(buffer, shift, length);
 }
 
-static INLINE int progressive_rfx_decode_component(
-    PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
-    const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT shift, const BYTE* WINPR_RESTRICT data,
-    UINT32 length, INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT current,
-    INT16* WINPR_RESTRICT sign, BOOL coeffDiff, BOOL subbandDiff, BOOL extrapolate)
+static INLINE int
+progressive_rfx_decode_component(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+                                 const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT shift,
+                                 const BYTE* WINPR_RESTRICT data, UINT32 length,
+                                 INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT current,
+                                 INT16* WINPR_RESTRICT sign, BOOL coeffDiff,
+                                 WINPR_ATTR_UNUSED BOOL subbandDiff, BOOL extrapolate)
 {
 	int status = 0;
 	const primitives_t* prims = primitives_get();
@@ -1179,7 +1181,8 @@ progressive_rfx_upgrade_state_finish(RFX_PROGRESSIVE_UPGRADE_STATE* WINPR_RESTRI
 static INLINE int progressive_rfx_upgrade_block(RFX_PROGRESSIVE_UPGRADE_STATE* WINPR_RESTRICT state,
                                                 INT16* WINPR_RESTRICT buffer,
                                                 INT16* WINPR_RESTRICT sign, UINT32 length,
-                                                UINT32 shift, UINT32 bitPos, UINT32 numBits)
+                                                UINT32 shift, WINPR_ATTR_UNUSED UINT32 bitPos,
+                                                UINT32 numBits)
 {
 	if (!numBits)
 		return 1;
@@ -1236,15 +1239,14 @@ static INLINE int progressive_rfx_upgrade_block(RFX_PROGRESSIVE_UPGRADE_STATE* W
 	return 1;
 }
 
-static INLINE int
-progressive_rfx_upgrade_component(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
-                                  const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT shift,
-                                  const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT bitPos,
-                                  const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT numBits,
-                                  INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT current,
-                                  INT16* WINPR_RESTRICT sign, const BYTE* WINPR_RESTRICT srlData,
-                                  UINT32 srlLen, const BYTE* WINPR_RESTRICT rawData, UINT32 rawLen,
-                                  BOOL coeffDiff, BOOL subbandDiff, BOOL extrapolate)
+static INLINE int progressive_rfx_upgrade_component(
+    PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
+    const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT shift,
+    const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT bitPos,
+    const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT numBits, INT16* WINPR_RESTRICT buffer,
+    INT16* WINPR_RESTRICT current, INT16* WINPR_RESTRICT sign, const BYTE* WINPR_RESTRICT srlData,
+    UINT32 srlLen, const BYTE* WINPR_RESTRICT rawData, UINT32 rawLen, BOOL coeffDiff,
+    WINPR_ATTR_UNUSED BOOL subbandDiff, BOOL extrapolate)
 {
 	int rc = 0;
 	UINT32 aRawLen = 0;
@@ -1515,7 +1517,7 @@ static INLINE BOOL progressive_tile_read_upgrade(
     PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive, wStream* WINPR_RESTRICT s, UINT16 blockType,
     UINT32 blockLen, PROGRESSIVE_SURFACE_CONTEXT* WINPR_RESTRICT surface,
     PROGRESSIVE_BLOCK_REGION* WINPR_RESTRICT region,
-    const PROGRESSIVE_BLOCK_CONTEXT* WINPR_RESTRICT context)
+    WINPR_ATTR_UNUSED const PROGRESSIVE_BLOCK_CONTEXT* WINPR_RESTRICT context)
 {
 	RFX_PROGRESSIVE_TILE tile = { 0 };
 	const size_t expect = 20;
@@ -1589,12 +1591,11 @@ static INLINE BOOL progressive_tile_read_upgrade(
 	return progressive_surface_tile_replace(surface, region, &tile, TRUE);
 }
 
-static INLINE BOOL progressive_tile_read(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,
-                                         BOOL simple, wStream* WINPR_RESTRICT s, UINT16 blockType,
-                                         UINT32 blockLen,
-                                         PROGRESSIVE_SURFACE_CONTEXT* WINPR_RESTRICT surface,
-                                         PROGRESSIVE_BLOCK_REGION* WINPR_RESTRICT region,
-                                         const PROGRESSIVE_BLOCK_CONTEXT* WINPR_RESTRICT context)
+static INLINE BOOL progressive_tile_read(
+    PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive, BOOL simple, wStream* WINPR_RESTRICT s,
+    UINT16 blockType, UINT32 blockLen, PROGRESSIVE_SURFACE_CONTEXT* WINPR_RESTRICT surface,
+    PROGRESSIVE_BLOCK_REGION* WINPR_RESTRICT region,
+    WINPR_ATTR_UNUSED const PROGRESSIVE_BLOCK_CONTEXT* WINPR_RESTRICT context)
 {
 	RFX_PROGRESSIVE_TILE tile = { 0 };
 	size_t expect = simple ? 16 : 17;

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -640,10 +640,9 @@ static INLINE BOOL rfx_process_message_context(RFX_CONTEXT* WINPR_RESTRICT conte
 	return TRUE;
 }
 
-static INLINE BOOL rfx_process_message_frame_begin(RFX_CONTEXT* WINPR_RESTRICT context,
-                                                   RFX_MESSAGE* WINPR_RESTRICT message,
-                                                   wStream* WINPR_RESTRICT s,
-                                                   UINT16* WINPR_RESTRICT pExpectedBlockType)
+static INLINE BOOL rfx_process_message_frame_begin(
+    RFX_CONTEXT* WINPR_RESTRICT context, WINPR_ATTR_UNUSED RFX_MESSAGE* WINPR_RESTRICT message,
+    wStream* WINPR_RESTRICT s, UINT16* WINPR_RESTRICT pExpectedBlockType)
 {
 	UINT32 frameIdx = 0;
 	UINT16 numRegions = 0;
@@ -673,10 +672,9 @@ static INLINE BOOL rfx_process_message_frame_begin(RFX_CONTEXT* WINPR_RESTRICT c
 	return TRUE;
 }
 
-static INLINE BOOL rfx_process_message_frame_end(RFX_CONTEXT* WINPR_RESTRICT context,
-                                                 RFX_MESSAGE* WINPR_RESTRICT message,
-                                                 wStream* WINPR_RESTRICT s,
-                                                 UINT16* WINPR_RESTRICT pExpectedBlockType)
+static INLINE BOOL rfx_process_message_frame_end(
+    RFX_CONTEXT* WINPR_RESTRICT context, WINPR_ATTR_UNUSED RFX_MESSAGE* WINPR_RESTRICT message,
+    WINPR_ATTR_UNUSED wStream* WINPR_RESTRICT s, UINT16* WINPR_RESTRICT pExpectedBlockType)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(context->priv);
@@ -802,8 +800,9 @@ typedef struct
 	RFX_CONTEXT* context;
 } RFX_TILE_PROCESS_WORK_PARAM;
 
-static INLINE void CALLBACK rfx_process_message_tile_work_callback(PTP_CALLBACK_INSTANCE instance,
-                                                                   void* context, PTP_WORK work)
+static INLINE void CALLBACK
+rfx_process_message_tile_work_callback(WINPR_ATTR_UNUSED PTP_CALLBACK_INSTANCE instance,
+                                       void* context, WINPR_ATTR_UNUSED PTP_WORK work)
 {
 	RFX_TILE_PROCESS_WORK_PARAM* param = (RFX_TILE_PROCESS_WORK_PARAM*)context;
 	WINPR_ASSERT(param);
@@ -1470,8 +1469,9 @@ static INLINE void rfx_update_context_properties(RFX_CONTEXT* WINPR_RESTRICT con
 	context->properties = properties;
 }
 
-static INLINE void rfx_write_message_sync(const RFX_CONTEXT* WINPR_RESTRICT context,
-                                          wStream* WINPR_RESTRICT s)
+static INLINE void
+rfx_write_message_sync(WINPR_ATTR_UNUSED const RFX_CONTEXT* WINPR_RESTRICT context,
+                       WINPR_ATTR_UNUSED wStream* WINPR_RESTRICT s)
 {
 	WINPR_ASSERT(context);
 
@@ -1481,8 +1481,9 @@ static INLINE void rfx_write_message_sync(const RFX_CONTEXT* WINPR_RESTRICT cont
 	Stream_Write_UINT16(s, WF_VERSION_1_0); /* version (2 bytes) */
 }
 
-static INLINE void rfx_write_message_codec_versions(const RFX_CONTEXT* WINPR_RESTRICT context,
-                                                    wStream* WINPR_RESTRICT s)
+static INLINE void
+rfx_write_message_codec_versions(WINPR_ATTR_UNUSED const RFX_CONTEXT* WINPR_RESTRICT context,
+                                 wStream* WINPR_RESTRICT s)
 {
 	WINPR_ASSERT(context);
 
@@ -1578,8 +1579,9 @@ struct S_RFX_TILE_COMPOSE_WORK_PARAM
 	RFX_CONTEXT* context;
 };
 
-static INLINE void CALLBACK rfx_compose_message_tile_work_callback(PTP_CALLBACK_INSTANCE instance,
-                                                                   void* context, PTP_WORK work)
+static INLINE void CALLBACK
+rfx_compose_message_tile_work_callback(WINPR_ATTR_UNUSED PTP_CALLBACK_INSTANCE instance,
+                                       void* context, WINPR_ATTR_UNUSED PTP_WORK work)
 {
 	RFX_TILE_COMPOSE_WORK_PARAM* param = (RFX_TILE_COMPOSE_WORK_PARAM*)context;
 	WINPR_ASSERT(param);
@@ -2092,9 +2094,9 @@ static INLINE BOOL rfx_write_message_tileset(RFX_CONTEXT* WINPR_RESTRICT context
 	return TRUE;
 }
 
-static INLINE BOOL rfx_write_message_frame_begin(RFX_CONTEXT* WINPR_RESTRICT context,
-                                                 wStream* WINPR_RESTRICT s,
-                                                 const RFX_MESSAGE* WINPR_RESTRICT message)
+static INLINE BOOL
+rfx_write_message_frame_begin(WINPR_ATTR_UNUSED RFX_CONTEXT* WINPR_RESTRICT context,
+                              wStream* WINPR_RESTRICT s, const RFX_MESSAGE* WINPR_RESTRICT message)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(message);
@@ -2111,7 +2113,7 @@ static INLINE BOOL rfx_write_message_frame_begin(RFX_CONTEXT* WINPR_RESTRICT con
 	return TRUE;
 }
 
-static INLINE BOOL rfx_write_message_region(RFX_CONTEXT* WINPR_RESTRICT context,
+static INLINE BOOL rfx_write_message_region(WINPR_ATTR_UNUSED RFX_CONTEXT* WINPR_RESTRICT context,
                                             wStream* WINPR_RESTRICT s,
                                             const RFX_MESSAGE* WINPR_RESTRICT message)
 {
@@ -2149,9 +2151,9 @@ static INLINE BOOL rfx_write_message_region(RFX_CONTEXT* WINPR_RESTRICT context,
 	return TRUE;
 }
 
-static INLINE BOOL rfx_write_message_frame_end(RFX_CONTEXT* WINPR_RESTRICT context,
-                                               wStream* WINPR_RESTRICT s,
-                                               const RFX_MESSAGE* WINPR_RESTRICT message)
+static INLINE BOOL rfx_write_message_frame_end(
+    WINPR_ATTR_UNUSED RFX_CONTEXT* WINPR_RESTRICT context, wStream* WINPR_RESTRICT s,
+    WINPR_ATTR_UNUSED const RFX_MESSAGE* WINPR_RESTRICT message)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(message);
@@ -2232,7 +2234,7 @@ UINT32 rfx_message_get_frame_idx(const RFX_MESSAGE* WINPR_RESTRICT message)
 	return message->frameIdx;
 }
 
-static INLINE BOOL rfx_write_progressive_wb_sync(RFX_CONTEXT* WINPR_RESTRICT rfx,
+static INLINE BOOL rfx_write_progressive_wb_sync(WINPR_ATTR_UNUSED RFX_CONTEXT* WINPR_RESTRICT rfx,
                                                  wStream* WINPR_RESTRICT s)
 {
 	const UINT32 blockLen = 12;
@@ -2249,8 +2251,8 @@ static INLINE BOOL rfx_write_progressive_wb_sync(RFX_CONTEXT* WINPR_RESTRICT rfx
 	return TRUE;
 }
 
-static INLINE BOOL rfx_write_progressive_wb_context(RFX_CONTEXT* WINPR_RESTRICT rfx,
-                                                    wStream* WINPR_RESTRICT s)
+static INLINE BOOL rfx_write_progressive_wb_context(
+    WINPR_ATTR_UNUSED RFX_CONTEXT* WINPR_RESTRICT rfx, wStream* WINPR_RESTRICT s)
 {
 	const UINT32 blockLen = 10;
 	WINPR_ASSERT(rfx);
@@ -2346,9 +2348,9 @@ static INLINE BOOL rfx_write_progressive_region(RFX_CONTEXT* WINPR_RESTRICT rfx,
 	return (used == blockLen);
 }
 
-static INLINE BOOL rfx_write_progressive_frame_begin(RFX_CONTEXT* WINPR_RESTRICT rfx,
-                                                     wStream* WINPR_RESTRICT s,
-                                                     const RFX_MESSAGE* WINPR_RESTRICT msg)
+static INLINE BOOL
+rfx_write_progressive_frame_begin(WINPR_ATTR_UNUSED RFX_CONTEXT* WINPR_RESTRICT rfx,
+                                  wStream* WINPR_RESTRICT s, const RFX_MESSAGE* WINPR_RESTRICT msg)
 {
 	const UINT32 blockLen = 12;
 	WINPR_ASSERT(rfx);
@@ -2366,8 +2368,8 @@ static INLINE BOOL rfx_write_progressive_frame_begin(RFX_CONTEXT* WINPR_RESTRICT
 	return TRUE;
 }
 
-static INLINE BOOL rfx_write_progressive_frame_end(RFX_CONTEXT* WINPR_RESTRICT rfx,
-                                                   wStream* WINPR_RESTRICT s)
+static INLINE BOOL rfx_write_progressive_frame_end(
+    WINPR_ATTR_UNUSED RFX_CONTEXT* WINPR_RESTRICT rfx, wStream* WINPR_RESTRICT s)
 {
 	const UINT32 blockLen = 6;
 	WINPR_ASSERT(rfx);
@@ -2382,9 +2384,9 @@ static INLINE BOOL rfx_write_progressive_frame_end(RFX_CONTEXT* WINPR_RESTRICT r
 	return TRUE;
 }
 
-static INLINE BOOL rfx_write_progressive_tile_simple(RFX_CONTEXT* WINPR_RESTRICT rfx,
-                                                     wStream* WINPR_RESTRICT s,
-                                                     const RFX_TILE* WINPR_RESTRICT tile)
+static INLINE BOOL
+rfx_write_progressive_tile_simple(WINPR_ATTR_UNUSED RFX_CONTEXT* WINPR_RESTRICT rfx,
+                                  wStream* WINPR_RESTRICT s, const RFX_TILE* WINPR_RESTRICT tile)
 {
 	UINT32 blockLen = 0;
 	WINPR_ASSERT(rfx);

--- a/libfreerdp/codec/zgfx.c
+++ b/libfreerdp/codec/zgfx.c
@@ -416,7 +416,7 @@ static INLINE BOOL zgfx_append(ZGFX_CONTEXT* WINPR_RESTRICT zgfx,
 
 int zgfx_decompress(ZGFX_CONTEXT* WINPR_RESTRICT zgfx, const BYTE* WINPR_RESTRICT pSrcData,
                     UINT32 SrcSize, BYTE** WINPR_RESTRICT ppDstData,
-                    UINT32* WINPR_RESTRICT pDstSize, UINT32 flags)
+                    UINT32* WINPR_RESTRICT pDstSize, WINPR_ATTR_UNUSED UINT32 flags)
 {
 	int status = -1;
 	BYTE descriptor = 0;
@@ -498,9 +498,9 @@ fail:
 	return status;
 }
 
-static BOOL zgfx_compress_segment(ZGFX_CONTEXT* WINPR_RESTRICT zgfx, wStream* WINPR_RESTRICT s,
-                                  const BYTE* WINPR_RESTRICT pSrcData, UINT32 SrcSize,
-                                  UINT32* WINPR_RESTRICT pFlags)
+static BOOL zgfx_compress_segment(WINPR_ATTR_UNUSED ZGFX_CONTEXT* WINPR_RESTRICT zgfx,
+                                  wStream* WINPR_RESTRICT s, const BYTE* WINPR_RESTRICT pSrcData,
+                                  UINT32 SrcSize, UINT32* WINPR_RESTRICT pFlags)
 {
 	/* FIXME: Currently compression not implemented. Just copy the raw source */
 	if (!Stream_EnsureRemainingCapacity(s, SrcSize + 1))
@@ -618,7 +618,7 @@ int zgfx_compress(ZGFX_CONTEXT* WINPR_RESTRICT zgfx, const BYTE* WINPR_RESTRICT 
 	return status;
 }
 
-void zgfx_context_reset(ZGFX_CONTEXT* WINPR_RESTRICT zgfx, BOOL flush)
+void zgfx_context_reset(ZGFX_CONTEXT* WINPR_RESTRICT zgfx, WINPR_ATTR_UNUSED BOOL flush)
 {
 	zgfx->HistoryIndex = 0;
 }

--- a/libfreerdp/common/addin.c
+++ b/libfreerdp/common/addin.c
@@ -369,7 +369,8 @@ PVIRTUALCHANNELENTRY freerdp_load_dynamic_channel_addin_entry(LPCSTR pszName, LP
 
 static FREERDP_LOAD_CHANNEL_ADDIN_ENTRY_FN freerdp_load_static_channel_addin_entry = NULL;
 
-int freerdp_register_addin_provider(FREERDP_LOAD_CHANNEL_ADDIN_ENTRY_FN provider, DWORD dwFlags)
+int freerdp_register_addin_provider(FREERDP_LOAD_CHANNEL_ADDIN_ENTRY_FN provider,
+                                    WINPR_ATTR_UNUSED DWORD dwFlags)
 {
 	freerdp_load_static_channel_addin_entry = provider;
 	return 0;

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -675,7 +675,7 @@ static BOOL freerdp_assistance_parse_all_elements_of(rdpAssistanceFile* file, ch
 }
 
 static BOOL freerdp_assistance_parse_all_elements_of_l(rdpAssistanceFile* file, char* data,
-                                                       size_t len)
+                                                       WINPR_ATTR_UNUSED size_t len)
 {
 	UINT32 p = 0;
 	const char* n = NULL;
@@ -803,7 +803,7 @@ char* freerdp_assistance_construct_expert_blob(const char* name, const char* pas
 	return ExpertBlob;
 }
 
-char* freerdp_assistance_generate_pass_stub(DWORD flags)
+char* freerdp_assistance_generate_pass_stub(WINPR_ATTR_UNUSED DWORD flags)
 {
 	UINT32 nums[14];
 	char* passStub = NULL;

--- a/libfreerdp/core/autodetect.c
+++ b/libfreerdp/core/autodetect.c
@@ -130,7 +130,8 @@ static const char* autodetect_request_type_to_string_buffer(UINT32 requestType, 
 }
 
 static BOOL autodetect_send_rtt_measure_request(rdpAutoDetect* autodetect,
-                                                RDP_TRANSPORT_TYPE transport, UINT16 sequenceNumber)
+                                                WINPR_ATTR_UNUSED RDP_TRANSPORT_TYPE transport,
+                                                UINT16 sequenceNumber)
 {
 	UINT16 requestType = 0;
 	wStream* s = NULL;
@@ -179,7 +180,7 @@ static BOOL autodetect_send_rtt_measure_response(rdpAutoDetect* autodetect, UINT
 }
 
 static BOOL autodetect_send_bandwidth_measure_start(rdpAutoDetect* autodetect,
-                                                    RDP_TRANSPORT_TYPE transport,
+                                                    WINPR_ATTR_UNUSED RDP_TRANSPORT_TYPE transport,
                                                     UINT16 sequenceNumber)
 {
 	UINT16 requestType = 0;
@@ -206,9 +207,10 @@ static BOOL autodetect_send_bandwidth_measure_start(rdpAutoDetect* autodetect,
 	return rdp_send_message_channel_pdu(autodetect->context->rdp, s, SEC_AUTODETECT_REQ);
 }
 
-static BOOL autodetect_send_bandwidth_measure_payload(rdpAutoDetect* autodetect,
-                                                      RDP_TRANSPORT_TYPE transport,
-                                                      UINT16 sequenceNumber, UINT16 payloadLength)
+static BOOL
+autodetect_send_bandwidth_measure_payload(rdpAutoDetect* autodetect,
+                                          WINPR_ATTR_UNUSED RDP_TRANSPORT_TYPE transport,
+                                          UINT16 sequenceNumber, UINT16 payloadLength)
 {
 	wStream* s = NULL;
 
@@ -246,7 +248,7 @@ static BOOL autodetect_send_bandwidth_measure_payload(rdpAutoDetect* autodetect,
 }
 
 static BOOL autodetect_send_bandwidth_measure_stop(rdpAutoDetect* autodetect,
-                                                   RDP_TRANSPORT_TYPE transport,
+                                                   WINPR_ATTR_UNUSED RDP_TRANSPORT_TYPE transport,
                                                    UINT16 sequenceNumber, UINT16 payloadLength)
 {
 	UINT16 requestType = 0;
@@ -354,7 +356,8 @@ static BOOL autodetect_send_bandwidth_measure_results(rdpAutoDetect* autodetect,
 	return rdp_send_message_channel_pdu(autodetect->context->rdp, s, SEC_AUTODETECT_RSP);
 }
 
-static BOOL autodetect_send_netchar_result(rdpAutoDetect* autodetect, RDP_TRANSPORT_TYPE transport,
+static BOOL autodetect_send_netchar_result(rdpAutoDetect* autodetect,
+                                           WINPR_ATTR_UNUSED RDP_TRANSPORT_TYPE transport,
                                            UINT16 sequenceNumber,
                                            const rdpNetworkCharacteristicsResult* result)
 {
@@ -436,7 +439,8 @@ autodetect_on_connect_time_auto_detect_progress_default(rdpAutoDetect* autodetec
 }
 
 static BOOL autodetect_recv_rtt_measure_request(rdpAutoDetect* autodetect,
-                                                RDP_TRANSPORT_TYPE transport, wStream* s,
+                                                WINPR_ATTR_UNUSED RDP_TRANSPORT_TYPE transport,
+                                                WINPR_ATTR_UNUSED wStream* s,
                                                 const AUTODETECT_REQ_PDU* autodetectReqPdu)
 {
 	WINPR_ASSERT(autodetect);
@@ -457,7 +461,8 @@ static BOOL autodetect_recv_rtt_measure_request(rdpAutoDetect* autodetect,
 }
 
 static BOOL autodetect_recv_rtt_measure_response(rdpAutoDetect* autodetect,
-                                                 RDP_TRANSPORT_TYPE transport, wStream* s,
+                                                 RDP_TRANSPORT_TYPE transport,
+                                                 WINPR_ATTR_UNUSED wStream* s,
                                                  const AUTODETECT_RSP_PDU* autodetectRspPdu)
 {
 	BOOL success = TRUE;
@@ -489,7 +494,8 @@ static BOOL autodetect_recv_rtt_measure_response(rdpAutoDetect* autodetect,
 }
 
 static BOOL autodetect_recv_bandwidth_measure_start(rdpAutoDetect* autodetect,
-                                                    RDP_TRANSPORT_TYPE transport, wStream* s,
+                                                    WINPR_ATTR_UNUSED RDP_TRANSPORT_TYPE transport,
+                                                    WINPR_ATTR_UNUSED wStream* s,
                                                     const AUTODETECT_REQ_PDU* autodetectReqPdu)
 {
 	WINPR_ASSERT(autodetect);
@@ -519,9 +525,10 @@ static BOOL autodetect_recv_bandwidth_measure_start(rdpAutoDetect* autodetect,
 	return TRUE;
 }
 
-static BOOL autodetect_recv_bandwidth_measure_payload(rdpAutoDetect* autodetect,
-                                                      RDP_TRANSPORT_TYPE transport, wStream* s,
-                                                      const AUTODETECT_REQ_PDU* autodetectReqPdu)
+static BOOL
+autodetect_recv_bandwidth_measure_payload(rdpAutoDetect* autodetect,
+                                          WINPR_ATTR_UNUSED RDP_TRANSPORT_TYPE transport,
+                                          wStream* s, const AUTODETECT_REQ_PDU* autodetectReqPdu)
 {
 	UINT16 payloadLength = 0;
 

--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -792,7 +792,8 @@ static BOOL rdp_print_order_capability_set(wStream* s)
 }
 #endif
 
-static BOOL rdp_apply_bitmap_cache_capability_set(rdpSettings* settings, const rdpSettings* src)
+static BOOL rdp_apply_bitmap_cache_capability_set(WINPR_ATTR_UNUSED rdpSettings* settings,
+                                                  WINPR_ATTR_UNUSED const rdpSettings* src)
 {
 	WINPR_ASSERT(settings);
 	WINPR_ASSERT(src);
@@ -913,7 +914,8 @@ static BOOL rdp_print_bitmap_cache_capability_set(wStream* s)
 }
 #endif
 
-static BOOL rdp_apply_control_capability_set(rdpSettings* settings, const rdpSettings* src)
+static BOOL rdp_apply_control_capability_set(WINPR_ATTR_UNUSED rdpSettings* settings,
+                                             WINPR_ATTR_UNUSED const rdpSettings* src)
 {
 	WINPR_ASSERT(settings);
 	WINPR_ASSERT(src);
@@ -982,8 +984,8 @@ static BOOL rdp_print_control_capability_set(wStream* s)
 }
 #endif
 
-static BOOL rdp_apply_window_activation_capability_set(rdpSettings* settings,
-                                                       const rdpSettings* src)
+static BOOL rdp_apply_window_activation_capability_set(WINPR_ATTR_UNUSED rdpSettings* settings,
+                                                       WINPR_ATTR_UNUSED const rdpSettings* src)
 {
 	WINPR_ASSERT(settings);
 	WINPR_ASSERT(src);
@@ -1164,7 +1166,8 @@ static BOOL rdp_print_pointer_capability_set(wStream* s)
 }
 #endif
 
-static BOOL rdp_apply_share_capability_set(rdpSettings* settings, const rdpSettings* src)
+static BOOL rdp_apply_share_capability_set(WINPR_ATTR_UNUSED rdpSettings* settings,
+                                           WINPR_ATTR_UNUSED const rdpSettings* src)
 {
 	WINPR_ASSERT(settings);
 	WINPR_ASSERT(src);
@@ -1227,7 +1230,8 @@ static BOOL rdp_print_share_capability_set(wStream* s)
 }
 #endif
 
-static BOOL rdp_apply_color_cache_capability_set(rdpSettings* settings, const rdpSettings* src)
+static BOOL rdp_apply_color_cache_capability_set(WINPR_ATTR_UNUSED rdpSettings* settings,
+                                                 WINPR_ATTR_UNUSED const rdpSettings* src)
 {
 	WINPR_ASSERT(settings);
 	WINPR_ASSERT(src);
@@ -1531,7 +1535,8 @@ static BOOL rdp_print_input_capability_set(wStream* s)
 }
 #endif
 
-static BOOL rdp_apply_font_capability_set(rdpSettings* settings, const rdpSettings* src)
+static BOOL rdp_apply_font_capability_set(WINPR_ATTR_UNUSED rdpSettings* settings,
+                                          WINPR_ATTR_UNUSED const rdpSettings* src)
 {
 	WINPR_ASSERT(settings);
 	WINPR_ASSERT(src);

--- a/libfreerdp/core/client.c
+++ b/libfreerdp/core/client.c
@@ -131,7 +131,9 @@ static void channel_queue_free(void* obj)
 	channel_queue_message_free(msg);
 }
 
-static BOOL CALLBACK init_channel_handles_table(PINIT_ONCE once, PVOID param, PVOID* context)
+static BOOL CALLBACK init_channel_handles_table(WINPR_ATTR_UNUSED PINIT_ONCE once,
+                                                WINPR_ATTR_UNUSED PVOID param,
+                                                WINPR_ATTR_UNUSED PVOID* context)
 {
 	g_ChannelHandles = HashTable_New(TRUE);
 	return TRUE;
@@ -276,7 +278,7 @@ static UINT freerdp_drdynvc_on_channel_detached(DrdynvcClientContext* context, c
 	return status;
 }
 
-void freerdp_channels_register_instance(rdpChannels* channels, freerdp* instance)
+void freerdp_channels_register_instance(WINPR_ATTR_UNUSED rdpChannels* channels, freerdp* instance)
 {
 	/* store instance in TLS so future VirtualChannelInit calls can use it */
 	g_Instance = instance;
@@ -705,8 +707,9 @@ static BOOL freerdp_channels_process_sync(rdpChannels* channels, freerdp* instan
  * called only from main thread
  */
 #if defined(WITH_FREERDP_DEPRECATED)
-BOOL freerdp_channels_get_fds(rdpChannels* channels, freerdp* instance, void** read_fds,
-                              int* read_count, void** write_fds, int* write_count)
+BOOL freerdp_channels_get_fds(rdpChannels* channels, WINPR_ATTR_UNUSED freerdp* instance,
+                              void** read_fds, int* read_count, WINPR_ATTR_UNUSED void** write_fds,
+                              WINPR_ATTR_UNUSED int* write_count)
 {
 	void* pfd = NULL;
 	pfd = GetEventWaitObject(MessageQueue_Event(channels->queue));
@@ -1382,7 +1385,7 @@ static BOOL freerdp_channels_is_loaded_ex(rdpChannels* channels, PVIRTUALCHANNEL
 	return FALSE;
 }
 
-int freerdp_channels_client_load(rdpChannels* channels, rdpSettings* settings,
+int freerdp_channels_client_load(rdpChannels* channels, WINPR_ATTR_UNUSED rdpSettings* settings,
                                  PVIRTUALCHANNELENTRY entry, void* data)
 {
 	int status = 0;
@@ -1435,7 +1438,7 @@ int freerdp_channels_client_load(rdpChannels* channels, rdpSettings* settings,
 	return 0;
 }
 
-int freerdp_channels_client_load_ex(rdpChannels* channels, rdpSettings* settings,
+int freerdp_channels_client_load_ex(rdpChannels* channels, WINPR_ATTR_UNUSED rdpSettings* settings,
                                     PVIRTUALCHANNELENTRYEX entryEx, void* data)
 {
 	int status = 0;

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -2133,7 +2133,7 @@ BOOL rdp_channels_from_mcs(rdpSettings* settings, const rdpRdp* rdp)
  * 1. send the CONFIRM_ACTIVE PDU to the server
  * 2. register callbacks, the server can now start sending stuff
  */
-state_run_t rdp_client_connect_confirm_active(rdpRdp* rdp, wStream* s)
+state_run_t rdp_client_connect_confirm_active(rdpRdp* rdp, WINPR_ATTR_UNUSED wStream* s)
 {
 	WINPR_ASSERT(rdp);
 	WINPR_ASSERT(rdp->settings);

--- a/libfreerdp/core/fastpath.c
+++ b/libfreerdp/core/fastpath.c
@@ -333,7 +333,7 @@ static BOOL fastpath_recv_update_common(rdpFastPath* fastpath, wStream* s)
 	return rc;
 }
 
-static BOOL fastpath_recv_update_synchronize(rdpFastPath* fastpath, wStream* s)
+static BOOL fastpath_recv_update_synchronize(WINPR_ATTR_UNUSED rdpFastPath* fastpath, wStream* s)
 {
 	/* server 2008 can send invalid synchronize packet with missing padding,
 	  so don't return FALSE even if the packet is invalid */
@@ -704,7 +704,8 @@ static BOOL fastpath_recv_input_event_scancode(rdpFastPath* fastpath, wStream* s
 	return IFCALLRESULT(TRUE, input->KeyboardEvent, input, flags, code);
 }
 
-static BOOL fastpath_recv_input_event_mouse(rdpFastPath* fastpath, wStream* s, BYTE eventFlags)
+static BOOL fastpath_recv_input_event_mouse(rdpFastPath* fastpath, wStream* s,
+                                            WINPR_ATTR_UNUSED BYTE eventFlags)
 {
 	rdpInput* input = NULL;
 	UINT16 pointerFlags = 0;
@@ -726,7 +727,8 @@ static BOOL fastpath_recv_input_event_mouse(rdpFastPath* fastpath, wStream* s, B
 	return IFCALLRESULT(TRUE, input->MouseEvent, input, pointerFlags, xPos, yPos);
 }
 
-static BOOL fastpath_recv_input_event_relmouse(rdpFastPath* fastpath, wStream* s, BYTE eventFlags)
+static BOOL fastpath_recv_input_event_relmouse(rdpFastPath* fastpath, wStream* s,
+                                               WINPR_ATTR_UNUSED BYTE eventFlags)
 {
 	rdpInput* input = NULL;
 	UINT16 pointerFlags = 0;
@@ -759,7 +761,8 @@ static BOOL fastpath_recv_input_event_relmouse(rdpFastPath* fastpath, wStream* s
 	return IFCALLRESULT(TRUE, input->RelMouseEvent, input, pointerFlags, xDelta, yDelta);
 }
 
-static BOOL fastpath_recv_input_event_qoe(rdpFastPath* fastpath, wStream* s, BYTE eventFlags)
+static BOOL fastpath_recv_input_event_qoe(rdpFastPath* fastpath, wStream* s,
+                                          WINPR_ATTR_UNUSED BYTE eventFlags)
 {
 	WINPR_ASSERT(fastpath);
 	WINPR_ASSERT(fastpath->rdp);
@@ -787,7 +790,8 @@ static BOOL fastpath_recv_input_event_qoe(rdpFastPath* fastpath, wStream* s, BYT
 	return IFCALLRESULT(TRUE, input->QoEEvent, input, timestampMS);
 }
 
-static BOOL fastpath_recv_input_event_mousex(rdpFastPath* fastpath, wStream* s, BYTE eventFlags)
+static BOOL fastpath_recv_input_event_mousex(rdpFastPath* fastpath, wStream* s,
+                                             WINPR_ATTR_UNUSED BYTE eventFlags)
 {
 	rdpInput* input = NULL;
 	UINT16 pointerFlags = 0;
@@ -821,7 +825,8 @@ static BOOL fastpath_recv_input_event_mousex(rdpFastPath* fastpath, wStream* s, 
 	return IFCALLRESULT(TRUE, input->ExtendedMouseEvent, input, pointerFlags, xPos, yPos);
 }
 
-static BOOL fastpath_recv_input_event_sync(rdpFastPath* fastpath, wStream* s, BYTE eventFlags)
+static BOOL fastpath_recv_input_event_sync(rdpFastPath* fastpath, WINPR_ATTR_UNUSED wStream* s,
+                                           BYTE eventFlags)
 {
 	rdpInput* input = NULL;
 
@@ -1155,7 +1160,7 @@ wStream* fastpath_update_pdu_init(rdpFastPath* fastpath)
 	return transport_send_stream_init(fastpath->rdp->transport, FASTPATH_MAX_PACKET_SIZE);
 }
 
-wStream* fastpath_update_pdu_init_new(rdpFastPath* fastpath)
+wStream* fastpath_update_pdu_init_new(WINPR_ATTR_UNUSED rdpFastPath* fastpath)
 {
 	wStream* s = NULL;
 	s = Stream_New(NULL, FASTPATH_MAX_PACKET_SIZE);

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -318,7 +318,8 @@ BOOL freerdp_abort_connect_context(rdpContext* context)
 }
 
 #if defined(WITH_FREERDP_DEPRECATED)
-BOOL freerdp_get_fds(freerdp* instance, void** rfds, int* rcount, void** wfds, int* wcount)
+BOOL freerdp_get_fds(freerdp* instance, void** rfds, int* rcount, WINPR_ATTR_UNUSED void** wfds,
+                     WINPR_ATTR_UNUSED int* wcount)
 {
 	rdpRdp* rdp = NULL;
 

--- a/libfreerdp/core/gateway/rts.c
+++ b/libfreerdp/core/gateway/rts.c
@@ -1234,7 +1234,7 @@ static BOOL rts_write_pdu_header(wStream* s, const rpcconn_rts_hdr_t* header)
 	return TRUE;
 }
 
-static BOOL rts_receive_window_size_command_read(rdpRpc* rpc, wStream* buffer,
+static BOOL rts_receive_window_size_command_read(WINPR_ATTR_UNUSED rdpRpc* rpc, wStream* buffer,
                                                  UINT64* ReceiveWindowSize)
 {
 	WINPR_ASSERT(rpc);
@@ -1320,7 +1320,7 @@ static BOOL rts_flow_control_ack_command_write(wStream* s, UINT32 BytesReceived,
 	return TRUE;
 }
 
-static BOOL rts_connection_timeout_command_read(rdpRpc* rpc, wStream* buffer,
+static BOOL rts_connection_timeout_command_read(WINPR_ATTR_UNUSED rdpRpc* rpc, wStream* buffer,
                                                 UINT64* ConnectionTimeout)
 {
 	WINPR_ASSERT(rpc);
@@ -1379,7 +1379,7 @@ static BOOL rts_client_keepalive_command_write(wStream* s, UINT32 ClientKeepaliv
 	return TRUE;
 }
 
-static BOOL rts_version_command_read(rdpRpc* rpc, wStream* buffer)
+static BOOL rts_version_command_read(WINPR_ATTR_UNUSED rdpRpc* rpc, wStream* buffer)
 {
 	WINPR_ASSERT(rpc);
 	WINPR_ASSERT(buffer);
@@ -1468,7 +1468,8 @@ static BOOL rts_association_group_id_command_write(wStream* s, const BYTE* Assoc
 	return TRUE;
 }
 
-static int rts_destination_command_read(rdpRpc* rpc, wStream* buffer, UINT32* Destination)
+static int rts_destination_command_read(WINPR_ATTR_UNUSED rdpRpc* rpc, wStream* buffer,
+                                        UINT32* Destination)
 {
 	UINT32 val = 0;
 	WINPR_ASSERT(rpc);
@@ -2181,7 +2182,7 @@ static int rts_recv_OUT_R1_A2_pdu(rdpRpc* rpc, wStream* buffer)
 	return 1;
 }
 
-static int rts_recv_OUT_R2_A6_pdu(rdpRpc* rpc, wStream* buffer)
+static int rts_recv_OUT_R2_A6_pdu(rdpRpc* rpc, WINPR_ATTR_UNUSED wStream* buffer)
 {
 	int status = 0;
 	RpcVirtualConnection* connection = NULL;
@@ -2216,7 +2217,7 @@ static int rts_recv_OUT_R2_A6_pdu(rdpRpc* rpc, wStream* buffer)
 	return 1;
 }
 
-static int rts_recv_OUT_R2_B3_pdu(rdpRpc* rpc, wStream* buffer)
+static int rts_recv_OUT_R2_B3_pdu(rdpRpc* rpc, WINPR_ATTR_UNUSED wStream* buffer)
 {
 	RpcVirtualConnection* connection = NULL;
 

--- a/libfreerdp/core/gateway/tsg.c
+++ b/libfreerdp/core/gateway/tsg.c
@@ -326,7 +326,8 @@ static BOOL TsProxyReadTunnelContext(wLog* log, wStream* s, CONTEXT_HANDLE* tunn
 	return TRUE;
 }
 
-static BOOL TsProxyWriteTunnelContext(wLog* log, wStream* s, const CONTEXT_HANDLE* tunnelContext)
+static BOOL TsProxyWriteTunnelContext(WINPR_ATTR_UNUSED wLog* log, wStream* s,
+                                      const CONTEXT_HANDLE* tunnelContext)
 {
 	if (!Stream_EnsureRemainingCapacity(s, 20))
 		return FALSE;
@@ -337,7 +338,8 @@ static BOOL TsProxyWriteTunnelContext(wLog* log, wStream* s, const CONTEXT_HANDL
 	return TRUE;
 }
 
-static BOOL tsg_ndr_pointer_write(wLog* log, wStream* s, UINT32* index, DWORD length)
+static BOOL tsg_ndr_pointer_write(WINPR_ATTR_UNUSED wLog* log, wStream* s, UINT32* index,
+                                  DWORD length)
 {
 	WINPR_ASSERT(index);
 	const UINT32 ndrPtr = 0x20000 + (*index) * 4;
@@ -393,7 +395,8 @@ static BOOL tsg_ndr_pointer_read(wLog* log, wStream* s, UINT32* index, UINT32* p
 	return TRUE;
 }
 
-static BOOL tsg_ndr_write_string(wLog* log, wStream* s, const WCHAR* str, size_t length)
+static BOOL tsg_ndr_write_string(WINPR_ATTR_UNUSED wLog* log, wStream* s, const WCHAR* str,
+                                 size_t length)
 {
 	if (!Stream_EnsureRemainingCapacity(s, 12 + length) || (length > UINT32_MAX))
 		return FALSE;
@@ -469,7 +472,8 @@ static BOOL tsg_ndr_read_packet_header(wLog* log, wStream* s, TSG_PACKET_HEADER*
 	return TRUE;
 }
 
-static BOOL tsg_ndr_write_packet_header(wLog* log, wStream* s, const TSG_PACKET_HEADER* header)
+static BOOL tsg_ndr_write_packet_header(WINPR_ATTR_UNUSED wLog* log, wStream* s,
+                                        const TSG_PACKET_HEADER* header)
 {
 	WINPR_ASSERT(header);
 	if (!Stream_EnsureRemainingCapacity(s, 2 * sizeof(UINT16)))
@@ -489,7 +493,8 @@ static BOOL tsg_ndr_read_nap(wLog* log, wStream* s, TSG_CAPABILITY_NAP* nap)
 	return TRUE;
 }
 
-static BOOL tsg_ndr_write_nap(wLog* log, wStream* s, const TSG_CAPABILITY_NAP* nap)
+static BOOL tsg_ndr_write_nap(WINPR_ATTR_UNUSED wLog* log, wStream* s,
+                              const TSG_CAPABILITY_NAP* nap)
 {
 	WINPR_ASSERT(nap);
 

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -1117,7 +1117,7 @@ static BOOL updateEarlyClientCaps(rdpSettings* settings, UINT32 earlyCapabilityF
 }
 
 static BOOL updateEarlyServerCaps(rdpSettings* settings, UINT32 earlyCapabilityFlags,
-                                  UINT32 connectionType)
+                                  WINPR_ATTR_UNUSED UINT32 connectionType)
 {
 	WINPR_ASSERT(settings);
 

--- a/libfreerdp/core/mcs.c
+++ b/libfreerdp/core/mcs.c
@@ -1010,7 +1010,7 @@ out:
  * @param s stream
  */
 
-BOOL mcs_recv_erect_domain_request(rdpMcs* mcs, wStream* s)
+BOOL mcs_recv_erect_domain_request(WINPR_ATTR_UNUSED rdpMcs* mcs, wStream* s)
 {
 	UINT16 length = 0;
 	UINT32 subHeight = 0;
@@ -1243,7 +1243,7 @@ BOOL mcs_send_channel_join_request(rdpMcs* mcs, UINT16 channelId)
  * @param mcs mcs module
  */
 
-BOOL mcs_recv_channel_join_confirm(rdpMcs* mcs, wStream* s, UINT16* channelId)
+BOOL mcs_recv_channel_join_confirm(WINPR_ATTR_UNUSED rdpMcs* mcs, wStream* s, UINT16* channelId)
 {
 	UINT16 length = 0;
 	BYTE result = 0;
@@ -1312,7 +1312,7 @@ fail:
  * @param mcs mcs module
  */
 
-BOOL mcs_recv_disconnect_provider_ultimatum(rdpMcs* mcs, wStream* s, int* reason)
+BOOL mcs_recv_disconnect_provider_ultimatum(WINPR_ATTR_UNUSED rdpMcs* mcs, wStream* s, int* reason)
 {
 	BYTE b1 = 0;
 	BYTE b2 = 0;

--- a/libfreerdp/core/multitransport.c
+++ b/libfreerdp/core/multitransport.c
@@ -185,15 +185,17 @@ state_run_t multitransport_recv_response(rdpMultitransport* multi, wStream* s)
 	return IFCALLRESULT(STATE_RUN_SUCCESS, multi->MtResponse, multi, requestId, hr);
 }
 
-static state_run_t multitransport_no_udp(rdpMultitransport* multi, UINT32 reqId, UINT16 reqProto,
-                                         const BYTE* cookie)
+static state_run_t multitransport_no_udp(rdpMultitransport* multi, UINT32 reqId,
+                                         WINPR_ATTR_UNUSED UINT16 reqProto,
+                                         WINPR_ATTR_UNUSED const BYTE* cookie)
 {
 	return multitransport_client_send_response(multi, reqId, E_ABORT) ? STATE_RUN_SUCCESS
 	                                                                  : STATE_RUN_FAILED;
 }
 
-static state_run_t multitransport_server_handle_response(rdpMultitransport* multi, UINT32 reqId,
-                                                         UINT32 hrResponse)
+static state_run_t multitransport_server_handle_response(rdpMultitransport* multi,
+                                                         WINPR_ATTR_UNUSED UINT32 reqId,
+                                                         WINPR_ATTR_UNUSED UINT32 hrResponse)
 {
 	rdpRdp* rdp = multi->rdp;
 
@@ -203,7 +205,7 @@ static state_run_t multitransport_server_handle_response(rdpMultitransport* mult
 	return STATE_RUN_CONTINUE;
 }
 
-rdpMultitransport* multitransport_new(rdpRdp* rdp, UINT16 protocol)
+rdpMultitransport* multitransport_new(rdpRdp* rdp, WINPR_ATTR_UNUSED UINT16 protocol)
 {
 	WINPR_ASSERT(rdp);
 

--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -780,7 +780,7 @@ BOOL nego_recv_response(rdpNego* nego)
  * @return \b 0 for success, \b -1 for failure
  */
 
-int nego_recv(rdpTransport* transport, wStream* s, void* extra)
+int nego_recv(WINPR_ATTR_UNUSED rdpTransport* transport, wStream* s, void* extra)
 {
 	BYTE li = 0;
 	BYTE type = 0;
@@ -1160,7 +1160,7 @@ fail:
 	return rc;
 }
 
-static BOOL nego_process_correlation_info(rdpNego* nego, wStream* s)
+static BOOL nego_process_correlation_info(WINPR_ATTR_UNUSED rdpNego* nego, wStream* s)
 {
 	UINT8 type = 0;
 	UINT8 flags = 0;

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -1153,7 +1153,8 @@ static BOOL nla_read_TSCspDataDetail(WinPrAsn1Decoder* dec, rdpSettings* setting
 	return set_creds_octetstring_to_settings(dec, 4, TRUE, FreeRDP_CspName, settings);
 }
 
-static BOOL nla_read_KERB_TICKET_LOGON(rdpNla* nla, wStream* s, KERB_TICKET_LOGON* ticket)
+static BOOL nla_read_KERB_TICKET_LOGON(WINPR_ATTR_UNUSED rdpNla* nla, wStream* s,
+                                       KERB_TICKET_LOGON* ticket)
 {
 	WINPR_ASSERT(nla);
 
@@ -1202,7 +1203,7 @@ typedef enum
 	RCG_TYPE_NTLM
 } RemoteGuardPackageCredType;
 
-static BOOL nla_read_TSRemoteGuardPackageCred(rdpNla* nla, WinPrAsn1Decoder* dec,
+static BOOL nla_read_TSRemoteGuardPackageCred(WINPR_ATTR_UNUSED rdpNla* nla, WinPrAsn1Decoder* dec,
                                               RemoteGuardPackageCredType* credsType,
                                               wStream* payload)
 {

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -47,24 +47,27 @@
 /* Exposed type definitions in public headers have the wrong type.
  * assert to the correct types internally to trigger the ci checkers on wrong data passed */
 #define get_checked_uint16(value) get_checked_uint16_int((value), __FILE__, __func__, __LINE__)
-static inline UINT16 get_checked_uint16_int(UINT32 value, const char* file, const char* fkt,
-                                            size_t line)
+static inline UINT16 get_checked_uint16_int(UINT32 value, WINPR_ATTR_UNUSED const char* file,
+                                            WINPR_ATTR_UNUSED const char* fkt,
+                                            WINPR_ATTR_UNUSED size_t line)
 {
 	WINPR_ASSERT_AT(value <= UINT16_MAX, file, fkt, line);
 	return (UINT16)value;
 }
 
 #define get_checked_uint8(value) get_checked_uint8_int((value), __FILE__, __func__, __LINE__)
-static inline UINT8 get_checked_uint8_int(UINT32 value, const char* file, const char* fkt,
-                                          size_t line)
+static inline UINT8 get_checked_uint8_int(UINT32 value, WINPR_ATTR_UNUSED const char* file,
+                                          WINPR_ATTR_UNUSED const char* fkt,
+                                          WINPR_ATTR_UNUSED size_t line)
 {
 	WINPR_ASSERT_AT(value <= UINT8_MAX, file, fkt, line);
 	return (UINT8)value;
 }
 
 #define get_checked_int16(value) get_checked_int16_int((value), __FILE__, __func__, __LINE__)
-static inline INT16 get_checked_int16_int(INT32 value, const char* file, const char* fkt,
-                                          size_t line)
+static inline INT16 get_checked_int16_int(INT32 value, WINPR_ATTR_UNUSED const char* file,
+                                          WINPR_ATTR_UNUSED const char* fkt,
+                                          WINPR_ATTR_UNUSED size_t line)
 {
 	WINPR_ASSERT_AT(value <= INT16_MAX, file, fkt, line);
 	WINPR_ASSERT_AT(value >= INT16_MIN, file, fkt, line);
@@ -73,8 +76,10 @@ static inline INT16 get_checked_int16_int(INT32 value, const char* file, const c
 
 #define gdi_rob3_code_string_checked(value) \
 	gdi_rob3_code_string_checked_int((value), __FILE__, __func__, __LINE__)
-static inline const char* gdi_rob3_code_string_checked_int(UINT32 rob, const char* file,
-                                                           const char* fkt, size_t line)
+static inline const char* gdi_rob3_code_string_checked_int(UINT32 rob,
+                                                           WINPR_ATTR_UNUSED const char* file,
+                                                           WINPR_ATTR_UNUSED const char* fkt,
+                                                           WINPR_ATTR_UNUSED size_t line)
 {
 	WINPR_ASSERT_AT((rob) <= UINT8_MAX, file, fkt, line);
 	return gdi_rop3_code_string((BYTE)rob);
@@ -82,8 +87,9 @@ static inline const char* gdi_rob3_code_string_checked_int(UINT32 rob, const cha
 
 #define gdi_rop3_code_checked(value) \
 	gdi_rop3_code_checked_int((value), __FILE__, __func__, __LINE__)
-static inline DWORD gdi_rop3_code_checked_int(UINT32 code, const char* file, const char* fkt,
-                                              size_t line)
+static inline DWORD gdi_rop3_code_checked_int(UINT32 code, WINPR_ATTR_UNUSED const char* file,
+                                              WINPR_ATTR_UNUSED const char* fkt,
+                                              WINPR_ATTR_UNUSED size_t line)
 {
 	WINPR_ASSERT_AT(code <= UINT8_MAX, file, fkt, line);
 	return gdi_rop3_code((UINT8)code);
@@ -1089,7 +1095,7 @@ static INLINE BOOL update_read_delta_rects(wStream* s, DELTA_RECT* rectangles, c
 }
 
 static INLINE BOOL update_read_delta_points(wStream* s, DELTA_POINT** points, UINT32 number,
-                                            INT16 x, INT16 y)
+                                            WINPR_ATTR_UNUSED INT16 x, WINPR_ATTR_UNUSED INT16 y)
 {
 	BYTE flags = 0;
 	BYTE* zeroBits = NULL;
@@ -2677,7 +2683,7 @@ fail:
 }
 
 size_t update_approximate_cache_bitmap_v3_order(CACHE_BITMAP_V3_ORDER* cache_bitmap_v3,
-                                                UINT16* flags)
+                                                WINPR_ATTR_UNUSED UINT16* flags)
 {
 	BITMAP_DATA_EX* bitmapData = &cache_bitmap_v3->bitmapData;
 	return 64 + bitmapData->length;
@@ -2717,7 +2723,7 @@ BOOL update_write_cache_bitmap_v3_order(wStream* s, CACHE_BITMAP_V3_ORDER* cache
 
 WINPR_ATTR_MALLOC(free_cache_color_table_order, 2)
 static CACHE_COLOR_TABLE_ORDER* update_read_cache_color_table_order(rdpUpdate* update, wStream* s,
-                                                                    UINT16 flags)
+                                                                    WINPR_ATTR_UNUSED UINT16 flags)
 {
 	UINT32* colorTable = NULL;
 	CACHE_COLOR_TABLE_ORDER* cache_color_table = calloc(1, sizeof(CACHE_COLOR_TABLE_ORDER));
@@ -3034,11 +3040,13 @@ static BOOL update_decompress_brush(wStream* s, BYTE* output, size_t outSize, BY
 
 	return TRUE;
 }
-static BOOL update_compress_brush(wStream* s, const BYTE* input, BYTE bpp)
+static BOOL update_compress_brush(WINPR_ATTR_UNUSED wStream* s, WINPR_ATTR_UNUSED const BYTE* input,
+                                  WINPR_ATTR_UNUSED BYTE bpp)
 {
 	return FALSE;
 }
-static CACHE_BRUSH_ORDER* update_read_cache_brush_order(rdpUpdate* update, wStream* s, UINT16 flags)
+static CACHE_BRUSH_ORDER* update_read_cache_brush_order(rdpUpdate* update, wStream* s,
+                                                        WINPR_ATTR_UNUSED UINT16 flags)
 {
 	BOOL rc = 0;
 	BYTE iBitmapFormat = 0;
@@ -3315,7 +3323,8 @@ static BOOL update_read_switch_surface_order(wStream* s, SWITCH_SURFACE_ORDER* s
 	Stream_Read_UINT16(s, switch_surface->bitmapId); /* bitmapId (2 bytes) */
 	return TRUE;
 }
-size_t update_approximate_switch_surface_order(const SWITCH_SURFACE_ORDER* switch_surface)
+size_t update_approximate_switch_surface_order(
+    WINPR_ATTR_UNUSED const SWITCH_SURFACE_ORDER* switch_surface)
 {
 	return 2;
 }
@@ -3515,7 +3524,8 @@ static BOOL update_read_field_flags(wStream* s, UINT32* fieldFlags, BYTE flags, 
 
 	return TRUE;
 }
-BOOL update_write_field_flags(wStream* s, UINT32 fieldFlags, BYTE flags, BYTE fieldBytes)
+BOOL update_write_field_flags(wStream* s, UINT32 fieldFlags, WINPR_ATTR_UNUSED BYTE flags,
+                              BYTE fieldBytes)
 {
 	BYTE byte = 0;
 
@@ -4054,7 +4064,7 @@ static BOOL update_recv_primary_order(rdpUpdate* update, wStream* s, BYTE flags)
 	return rc;
 }
 
-static BOOL update_recv_secondary_order(rdpUpdate* update, wStream* s, BYTE flags)
+static BOOL update_recv_secondary_order(rdpUpdate* update, wStream* s, WINPR_ATTR_UNUSED BYTE flags)
 {
 	BOOL rc = FALSE;
 	size_t start = 0;

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -108,7 +108,8 @@ static HANDLE freerdp_peer_virtual_channel_open(freerdp_peer* client, const char
 	return (HANDLE)peerChannel;
 }
 
-static BOOL freerdp_peer_virtual_channel_close(freerdp_peer* client, HANDLE hChannel)
+static BOOL freerdp_peer_virtual_channel_close(WINPR_ATTR_UNUSED freerdp_peer* client,
+                                               HANDLE hChannel)
 {
 	rdpMcsChannel* mcsChannel = NULL;
 	rdpPeerChannel* peerChannel = NULL;
@@ -202,7 +203,8 @@ static int freerdp_peer_virtual_channel_write(freerdp_peer* client, HANDLE hChan
 	return 1;
 }
 
-static void* freerdp_peer_virtual_channel_get_data(freerdp_peer* client, HANDLE hChannel)
+static void* freerdp_peer_virtual_channel_get_data(WINPR_ATTR_UNUSED freerdp_peer* client,
+                                                   HANDLE hChannel)
 {
 	rdpPeerChannel* peerChannel = (rdpPeerChannel*)hChannel;
 
@@ -213,7 +215,8 @@ static void* freerdp_peer_virtual_channel_get_data(freerdp_peer* client, HANDLE 
 	return peerChannel->extra;
 }
 
-static int freerdp_peer_virtual_channel_set_data(freerdp_peer* client, HANDLE hChannel, void* data)
+static int freerdp_peer_virtual_channel_set_data(WINPR_ATTR_UNUSED freerdp_peer* client,
+                                                 HANDLE hChannel, void* data)
 {
 	rdpPeerChannel* peerChannel = (rdpPeerChannel*)hChannel;
 
@@ -330,7 +333,8 @@ static BOOL freerdp_peer_check_fds(freerdp_peer* peer)
 	return TRUE;
 }
 
-static state_run_t peer_recv_data_pdu(freerdp_peer* client, wStream* s, UINT16 totalLength)
+static state_run_t peer_recv_data_pdu(freerdp_peer* client, wStream* s,
+                                      WINPR_ATTR_UNUSED UINT16 totalLength)
 {
 	BYTE type = 0;
 	UINT16 length = 0;
@@ -781,7 +785,8 @@ static state_run_t rdp_peer_handle_state_active(freerdp_peer* client)
 	return ret;
 }
 
-static state_run_t peer_recv_callback_internal(rdpTransport* transport, wStream* s, void* extra)
+static state_run_t peer_recv_callback_internal(WINPR_ATTR_UNUSED rdpTransport* transport,
+                                               wStream* s, void* extra)
 {
 	UINT32 SelectedProtocol = 0;
 	freerdp_peer* client = (freerdp_peer*)extra;
@@ -1296,7 +1301,8 @@ static BOOL freerdp_peer_has_more_to_read(freerdp_peer* peer)
 	return transport_have_more_bytes_to_read(peer->context->rdp->transport);
 }
 
-static LicenseCallbackResult freerdp_peer_nolicense(freerdp_peer* peer, wStream* s)
+static LicenseCallbackResult freerdp_peer_nolicense(freerdp_peer* peer,
+                                                    WINPR_ATTR_UNUSED wStream* s)
 {
 	rdpRdp* rdp = NULL;
 

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -973,7 +973,8 @@ fail:
 	return rc;
 }
 
-static BOOL rdp_recv_server_shutdown_denied_pdu(rdpRdp* rdp, wStream* s)
+static BOOL rdp_recv_server_shutdown_denied_pdu(WINPR_ATTR_UNUSED rdpRdp* rdp,
+                                                WINPR_ATTR_UNUSED wStream* s)
 {
 	return TRUE;
 }
@@ -1851,7 +1852,8 @@ static state_run_t rdp_client_exchange_monitor_layout(rdpRdp* rdp, wStream* s)
 	return status;
 }
 
-static state_run_t rdp_recv_callback_int(rdpTransport* transport, wStream* s, void* extra)
+static state_run_t rdp_recv_callback_int(WINPR_ATTR_UNUSED rdpTransport* transport, wStream* s,
+                                         void* extra)
 {
 	state_run_t status = STATE_RUN_SUCCESS;
 	rdpRdp* rdp = (rdpRdp*)extra;
@@ -2797,7 +2799,7 @@ static BOOL parse_on_off_option(const char* value)
 
 #define STR(x) #x
 
-static BOOL option_is_runtime_checks(wLog* log, const char* tok)
+static BOOL option_is_runtime_checks(WINPR_ATTR_UNUSED wLog* log, const char* tok)
 {
 	const char* experimental[] = { STR(WITH_VERBOSE_WINPR_ASSERT) };
 	for (size_t x = 0; x < ARRAYSIZE(experimental); x++)
@@ -2811,7 +2813,7 @@ static BOOL option_is_runtime_checks(wLog* log, const char* tok)
 	return FALSE;
 }
 
-static BOOL option_is_experimental(wLog* log, const char* tok)
+static BOOL option_is_experimental(WINPR_ATTR_UNUSED wLog* log, const char* tok)
 {
 	const char* experimental[] = { STR(WITH_DSP_EXPERIMENTAL), STR(WITH_VAAPI) };
 	for (size_t x = 0; x < ARRAYSIZE(experimental); x++)

--- a/libfreerdp/core/rdstls.c
+++ b/libfreerdp/core/rdstls.c
@@ -218,7 +218,7 @@ static BOOL rdstls_set_state(rdpRdstls* rdstls, RDSTLS_STATE state)
 	return rc;
 }
 
-static BOOL rdstls_write_capabilities(rdpRdstls* rdstls, wStream* s)
+static BOOL rdstls_write_capabilities(WINPR_ATTR_UNUSED rdpRdstls* rdstls, wStream* s)
 {
 	if (!Stream_EnsureRemainingCapacity(s, 6))
 		return FALSE;
@@ -304,7 +304,8 @@ static BOOL rdstls_write_authentication_request_with_password(rdpRdstls* rdstls,
 	return TRUE;
 }
 
-static BOOL rdstls_write_authentication_request_with_cookie(rdpRdstls* rdstls, wStream* s)
+static BOOL rdstls_write_authentication_request_with_cookie(WINPR_ATTR_UNUSED rdpRdstls* rdstls,
+                                                            WINPR_ATTR_UNUSED wStream* s)
 {
 	// TODO
 	return FALSE;
@@ -351,7 +352,7 @@ static BOOL rdstls_process_capabilities(rdpRdstls* rdstls, wStream* s)
 	return TRUE;
 }
 
-static BOOL rdstls_read_unicode_string(wLog* log, wStream* s, char** str)
+static BOOL rdstls_read_unicode_string(WINPR_ATTR_UNUSED wLog* log, wStream* s, char** str)
 {
 	UINT16 length = 0;
 
@@ -378,7 +379,8 @@ static BOOL rdstls_read_unicode_string(wLog* log, wStream* s, char** str)
 	return TRUE;
 }
 
-static BOOL rdstls_read_data(wLog* log, wStream* s, UINT16* pLength, const BYTE** pData)
+static BOOL rdstls_read_data(WINPR_ATTR_UNUSED wLog* log, wStream* s, UINT16* pLength,
+                             const BYTE** pData)
 {
 	UINT16 length = 0;
 
@@ -511,7 +513,8 @@ fail:
 	return rc;
 }
 
-static BOOL rdstls_process_authentication_request_with_cookie(rdpRdstls* rdstls, wStream* s)
+static BOOL rdstls_process_authentication_request_with_cookie(WINPR_ATTR_UNUSED rdpRdstls* rdstls,
+                                                              WINPR_ATTR_UNUSED wStream* s)
 {
 	// TODO
 	return FALSE;
@@ -605,7 +608,7 @@ static BOOL rdstls_process_authentication_response(rdpRdstls* rdstls, wStream* s
 	return TRUE;
 }
 
-static BOOL rdstls_send(rdpTransport* transport, wStream* s, void* extra)
+static BOOL rdstls_send(WINPR_ATTR_UNUSED rdpTransport* transport, wStream* s, void* extra)
 {
 	rdpRdstls* rdstls = (rdpRdstls*)extra;
 	rdpSettings* settings = NULL;
@@ -663,7 +666,7 @@ static BOOL rdstls_send(rdpTransport* transport, wStream* s, void* extra)
 	return TRUE;
 }
 
-static int rdstls_recv(rdpTransport* transport, wStream* s, void* extra)
+static int rdstls_recv(WINPR_ATTR_UNUSED rdpTransport* transport, wStream* s, void* extra)
 {
 	UINT16 version = 0;
 	UINT16 pduType = 0;

--- a/libfreerdp/core/redirection.c
+++ b/libfreerdp/core/redirection.c
@@ -215,8 +215,8 @@ static BOOL rdp_redirection_write_data(wStream* s, size_t length, const void* da
 	return TRUE;
 }
 
-static BOOL rdp_redirection_write_base64_wchar(UINT32 flag, wStream* s, size_t length,
-                                               const void* data)
+static BOOL rdp_redirection_write_base64_wchar(WINPR_ATTR_UNUSED UINT32 flag, wStream* s,
+                                               size_t length, const void* data)
 {
 	BOOL rc = FALSE;
 
@@ -933,7 +933,7 @@ void redirection_free(rdpRedirection* redirection)
 	}
 }
 
-static SSIZE_T redir_write_string(UINT32 flag, wStream* s, const char* str)
+static SSIZE_T redir_write_string(WINPR_ATTR_UNUSED UINT32 flag, wStream* s, const char* str)
 {
 	const size_t length = (strlen(str) + 1);
 	if (!Stream_EnsureRemainingCapacity(s, 4ull + length * sizeof(WCHAR)))
@@ -946,7 +946,8 @@ static SSIZE_T redir_write_string(UINT32 flag, wStream* s, const char* str)
 	return (SSIZE_T)(Stream_GetPosition(s) - pos);
 }
 
-static BOOL redir_write_data(UINT32 flag, wStream* s, UINT32 length, const BYTE* data)
+static BOOL redir_write_data(WINPR_ATTR_UNUSED UINT32 flag, wStream* s, UINT32 length,
+                             const BYTE* data)
 {
 	if (!Stream_EnsureRemainingCapacity(s, 4ull + length))
 		return FALSE;

--- a/libfreerdp/core/security.c
+++ b/libfreerdp/core/security.c
@@ -201,17 +201,16 @@ BOOL security_session_key_blob(const BYTE* master_secret, size_t master_len,
 	                            client_len, server_random, server_len, &output[32], out_len - 32);
 }
 
-void security_mac_salt_key(const BYTE* session_key_blob, size_t session_len,
-                           const BYTE* client_random, size_t client_len, const BYTE* server_random,
-                           size_t server_len, BYTE* output, size_t out_len)
+void security_mac_salt_key(const BYTE* session_key_blob, WINPR_ATTR_UNUSED size_t session_len,
+                           WINPR_ATTR_UNUSED const BYTE* client_random,
+                           WINPR_ATTR_UNUSED size_t client_len,
+                           WINPR_ATTR_UNUSED const BYTE* server_random,
+                           WINPR_ATTR_UNUSED size_t server_len, BYTE* output,
+                           WINPR_ATTR_UNUSED size_t out_len)
 {
 	/* MacSaltKey = First128Bits(SessionKeyBlob) */
 	WINPR_ASSERT(out_len >= 16);
 	WINPR_ASSERT(session_len >= 16);
-	WINPR_UNUSED(client_random);
-	WINPR_UNUSED(client_len);
-	WINPR_UNUSED(server_random);
-	WINPR_UNUSED(server_len);
 	memcpy(output, session_key_blob, 16);
 }
 
@@ -293,7 +292,7 @@ BOOL security_licensing_encryption_key(const BYTE* session_key_blob, size_t sess
 	                                        output, out_len);
 }
 
-static void security_UINT32_le(BYTE* output, size_t out_len, UINT32 value)
+static void security_UINT32_le(BYTE* output, WINPR_ATTR_UNUSED size_t out_len, UINT32 value)
 {
 	WINPR_ASSERT(output);
 	WINPR_ASSERT(out_len >= 4);
@@ -390,6 +389,8 @@ BOOL security_mac_signature(rdpRdp* rdp, const BYTE* data, UINT32 length, BYTE* 
 	WINPR_ASSERT(data || (length == 0));
 	WINPR_ASSERT(output);
 	WINPR_ASSERT(out_len >= 8);
+	if (out_len < 8)
+		return FALSE;
 
 	security_UINT32_le(length_le, sizeof(length_le), length); /* length must be little-endian */
 
@@ -459,6 +460,8 @@ BOOL security_salted_mac_signature(rdpRdp* rdp, const BYTE* data, UINT32 length,
 	WINPR_ASSERT(data || (length == 0));
 	WINPR_ASSERT(output);
 	WINPR_ASSERT(out_len >= 8);
+	if (out_len < 8)
+		return FALSE;
 
 	security_UINT32_le(length_le, sizeof(length_le), length); /* length must be little-endian */
 
@@ -565,7 +568,8 @@ static BOOL security_X(const BYTE* master_secret, size_t master_len, const BYTE*
 	                               out_len - 32);
 }
 
-static void fips_expand_key_bits(const BYTE* in, size_t in_len, BYTE* out, size_t out_len)
+static void fips_expand_key_bits(const BYTE* in, WINPR_ATTR_UNUSED size_t in_len, BYTE* out,
+                                 WINPR_ATTR_UNUSED size_t out_len)
 {
 	BYTE buf[21] = { 0 };
 
@@ -896,7 +900,8 @@ BOOL security_hmac_signature(const BYTE* data, size_t length, BYTE* output, size
 
 	WINPR_ASSERT(rdp);
 	WINPR_ASSERT(output);
-	WINPR_ASSERT(out_len >= 8);
+	if (out_len < 8)
+		return FALSE;
 
 	security_UINT32_le(use_count_le, sizeof(use_count_le), rdp->encrypt_use_count);
 

--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -878,63 +878,91 @@ INT64 WTSChannelGetOptions(freerdp_peer* client, UINT16 channel_id)
 	return (INT64)channel->options;
 }
 
-BOOL WINAPI FreeRDP_WTSStartRemoteControlSessionW(LPWSTR pTargetServerName, ULONG TargetLogonId,
-                                                  BYTE HotkeyVk, USHORT HotkeyModifiers)
+BOOL WINAPI FreeRDP_WTSStartRemoteControlSessionW(WINPR_ATTR_UNUSED LPWSTR pTargetServerName,
+                                                  WINPR_ATTR_UNUSED ULONG TargetLogonId,
+                                                  WINPR_ATTR_UNUSED BYTE HotkeyVk,
+                                                  WINPR_ATTR_UNUSED USHORT HotkeyModifiers)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSStartRemoteControlSessionA(LPSTR pTargetServerName, ULONG TargetLogonId,
-                                                  BYTE HotkeyVk, USHORT HotkeyModifiers)
+BOOL WINAPI FreeRDP_WTSStartRemoteControlSessionA(WINPR_ATTR_UNUSED LPSTR pTargetServerName,
+                                                  WINPR_ATTR_UNUSED ULONG TargetLogonId,
+                                                  WINPR_ATTR_UNUSED BYTE HotkeyVk,
+                                                  WINPR_ATTR_UNUSED USHORT HotkeyModifiers)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSStartRemoteControlSessionExW(LPWSTR pTargetServerName, ULONG TargetLogonId,
-                                                    BYTE HotkeyVk, USHORT HotkeyModifiers,
-                                                    DWORD flags)
+BOOL WINAPI FreeRDP_WTSStartRemoteControlSessionExW(WINPR_ATTR_UNUSED LPWSTR pTargetServerName,
+                                                    WINPR_ATTR_UNUSED ULONG TargetLogonId,
+                                                    WINPR_ATTR_UNUSED BYTE HotkeyVk,
+                                                    WINPR_ATTR_UNUSED USHORT HotkeyModifiers,
+                                                    WINPR_ATTR_UNUSED DWORD flags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSStartRemoteControlSessionExA(LPSTR pTargetServerName, ULONG TargetLogonId,
-                                                    BYTE HotkeyVk, USHORT HotkeyModifiers,
-                                                    DWORD flags)
+BOOL WINAPI FreeRDP_WTSStartRemoteControlSessionExA(WINPR_ATTR_UNUSED LPSTR pTargetServerName,
+                                                    WINPR_ATTR_UNUSED ULONG TargetLogonId,
+                                                    WINPR_ATTR_UNUSED BYTE HotkeyVk,
+                                                    WINPR_ATTR_UNUSED USHORT HotkeyModifiers,
+                                                    WINPR_ATTR_UNUSED DWORD flags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSStopRemoteControlSession(ULONG LogonId)
+BOOL WINAPI FreeRDP_WTSStopRemoteControlSession(WINPR_ATTR_UNUSED ULONG LogonId)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSConnectSessionW(ULONG LogonId, ULONG TargetLogonId, PWSTR pPassword,
-                                       BOOL bWait)
+BOOL WINAPI FreeRDP_WTSConnectSessionW(WINPR_ATTR_UNUSED ULONG LogonId,
+                                       WINPR_ATTR_UNUSED ULONG TargetLogonId,
+                                       WINPR_ATTR_UNUSED PWSTR pPassword,
+                                       WINPR_ATTR_UNUSED BOOL bWait)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSConnectSessionA(ULONG LogonId, ULONG TargetLogonId, PSTR pPassword,
-                                       BOOL bWait)
+BOOL WINAPI FreeRDP_WTSConnectSessionA(WINPR_ATTR_UNUSED ULONG LogonId,
+                                       WINPR_ATTR_UNUSED ULONG TargetLogonId,
+                                       WINPR_ATTR_UNUSED PSTR pPassword,
+                                       WINPR_ATTR_UNUSED BOOL bWait)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSEnumerateServersW(LPWSTR pDomainName, DWORD Reserved, DWORD Version,
-                                         PWTS_SERVER_INFOW* ppServerInfo, DWORD* pCount)
+BOOL WINAPI FreeRDP_WTSEnumerateServersW(WINPR_ATTR_UNUSED LPWSTR pDomainName,
+                                         WINPR_ATTR_UNUSED DWORD Reserved,
+                                         WINPR_ATTR_UNUSED DWORD Version,
+                                         WINPR_ATTR_UNUSED PWTS_SERVER_INFOW* ppServerInfo,
+                                         WINPR_ATTR_UNUSED DWORD* pCount)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSEnumerateServersA(LPSTR pDomainName, DWORD Reserved, DWORD Version,
-                                         PWTS_SERVER_INFOA* ppServerInfo, DWORD* pCount)
+BOOL WINAPI FreeRDP_WTSEnumerateServersA(WINPR_ATTR_UNUSED LPSTR pDomainName,
+                                         WINPR_ATTR_UNUSED DWORD Reserved,
+                                         WINPR_ATTR_UNUSED DWORD Version,
+                                         WINPR_ATTR_UNUSED PWTS_SERVER_INFOA* ppServerInfo,
+                                         WINPR_ATTR_UNUSED DWORD* pCount)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-HANDLE WINAPI FreeRDP_WTSOpenServerW(LPWSTR pServerName)
+HANDLE WINAPI FreeRDP_WTSOpenServerW(WINPR_ATTR_UNUSED LPWSTR pServerName)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return INVALID_HANDLE_VALUE;
 }
 
@@ -1056,8 +1084,9 @@ error_vcm_alloc:
 	return INVALID_HANDLE_VALUE;
 }
 
-HANDLE WINAPI FreeRDP_WTSOpenServerExW(LPWSTR pServerName)
+HANDLE WINAPI FreeRDP_WTSOpenServerExW(WINPR_ATTR_UNUSED LPWSTR pServerName)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return INVALID_HANDLE_VALUE;
 }
 
@@ -1088,55 +1117,85 @@ VOID WINAPI FreeRDP_WTSCloseServer(HANDLE hServer)
 	}
 }
 
-BOOL WINAPI FreeRDP_WTSEnumerateSessionsW(HANDLE hServer, DWORD Reserved, DWORD Version,
-                                          PWTS_SESSION_INFOW* ppSessionInfo, DWORD* pCount)
+BOOL WINAPI FreeRDP_WTSEnumerateSessionsW(WINPR_ATTR_UNUSED HANDLE hServer,
+                                          WINPR_ATTR_UNUSED DWORD Reserved,
+                                          WINPR_ATTR_UNUSED DWORD Version,
+                                          WINPR_ATTR_UNUSED PWTS_SESSION_INFOW* ppSessionInfo,
+                                          WINPR_ATTR_UNUSED DWORD* pCount)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSEnumerateSessionsA(HANDLE hServer, DWORD Reserved, DWORD Version,
-                                          PWTS_SESSION_INFOA* ppSessionInfo, DWORD* pCount)
+BOOL WINAPI FreeRDP_WTSEnumerateSessionsA(WINPR_ATTR_UNUSED HANDLE hServer,
+                                          WINPR_ATTR_UNUSED DWORD Reserved,
+                                          WINPR_ATTR_UNUSED DWORD Version,
+                                          WINPR_ATTR_UNUSED PWTS_SESSION_INFOA* ppSessionInfo,
+                                          WINPR_ATTR_UNUSED DWORD* pCount)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSEnumerateSessionsExW(HANDLE hServer, DWORD* pLevel, DWORD Filter,
-                                            PWTS_SESSION_INFO_1W* ppSessionInfo, DWORD* pCount)
+BOOL WINAPI FreeRDP_WTSEnumerateSessionsExW(WINPR_ATTR_UNUSED HANDLE hServer,
+                                            WINPR_ATTR_UNUSED DWORD* pLevel,
+                                            WINPR_ATTR_UNUSED DWORD Filter,
+                                            WINPR_ATTR_UNUSED PWTS_SESSION_INFO_1W* ppSessionInfo,
+                                            WINPR_ATTR_UNUSED DWORD* pCount)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSEnumerateSessionsExA(HANDLE hServer, DWORD* pLevel, DWORD Filter,
-                                            PWTS_SESSION_INFO_1A* ppSessionInfo, DWORD* pCount)
+BOOL WINAPI FreeRDP_WTSEnumerateSessionsExA(WINPR_ATTR_UNUSED HANDLE hServer,
+                                            WINPR_ATTR_UNUSED DWORD* pLevel,
+                                            WINPR_ATTR_UNUSED DWORD Filter,
+                                            WINPR_ATTR_UNUSED PWTS_SESSION_INFO_1A* ppSessionInfo,
+                                            WINPR_ATTR_UNUSED DWORD* pCount)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSEnumerateProcessesW(HANDLE hServer, DWORD Reserved, DWORD Version,
-                                           PWTS_PROCESS_INFOW* ppProcessInfo, DWORD* pCount)
+BOOL WINAPI FreeRDP_WTSEnumerateProcessesW(WINPR_ATTR_UNUSED HANDLE hServer,
+                                           WINPR_ATTR_UNUSED DWORD Reserved,
+                                           WINPR_ATTR_UNUSED DWORD Version,
+                                           WINPR_ATTR_UNUSED PWTS_PROCESS_INFOW* ppProcessInfo,
+                                           WINPR_ATTR_UNUSED DWORD* pCount)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSEnumerateProcessesA(HANDLE hServer, DWORD Reserved, DWORD Version,
-                                           PWTS_PROCESS_INFOA* ppProcessInfo, DWORD* pCount)
+BOOL WINAPI FreeRDP_WTSEnumerateProcessesA(WINPR_ATTR_UNUSED HANDLE hServer,
+                                           WINPR_ATTR_UNUSED DWORD Reserved,
+                                           WINPR_ATTR_UNUSED DWORD Version,
+                                           WINPR_ATTR_UNUSED PWTS_PROCESS_INFOA* ppProcessInfo,
+                                           WINPR_ATTR_UNUSED DWORD* pCount)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSTerminateProcess(HANDLE hServer, DWORD ProcessId, DWORD ExitCode)
+BOOL WINAPI FreeRDP_WTSTerminateProcess(WINPR_ATTR_UNUSED HANDLE hServer,
+                                        WINPR_ATTR_UNUSED DWORD ProcessId,
+                                        WINPR_ATTR_UNUSED DWORD ExitCode)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSQuerySessionInformationW(HANDLE hServer, DWORD SessionId,
-                                                WTS_INFO_CLASS WTSInfoClass, LPWSTR* ppBuffer,
-                                                DWORD* pBytesReturned)
+BOOL WINAPI FreeRDP_WTSQuerySessionInformationW(WINPR_ATTR_UNUSED HANDLE hServer,
+                                                WINPR_ATTR_UNUSED DWORD SessionId,
+                                                WINPR_ATTR_UNUSED WTS_INFO_CLASS WTSInfoClass,
+                                                WINPR_ATTR_UNUSED LPWSTR* ppBuffer,
+                                                WINPR_ATTR_UNUSED DWORD* pBytesReturned)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSQuerySessionInformationA(HANDLE hServer, DWORD SessionId,
+BOOL WINAPI FreeRDP_WTSQuerySessionInformationA(HANDLE hServer, WINPR_ATTR_UNUSED DWORD SessionId,
                                                 WTS_INFO_CLASS WTSInfoClass, LPSTR* ppBuffer,
                                                 DWORD* pBytesReturned)
 {
@@ -1168,65 +1227,96 @@ BOOL WINAPI FreeRDP_WTSQuerySessionInformationA(HANDLE hServer, DWORD SessionId,
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSQueryUserConfigW(LPWSTR pServerName, LPWSTR pUserName,
-                                        WTS_CONFIG_CLASS WTSConfigClass, LPWSTR* ppBuffer,
-                                        DWORD* pBytesReturned)
+BOOL WINAPI FreeRDP_WTSQueryUserConfigW(WINPR_ATTR_UNUSED LPWSTR pServerName,
+                                        WINPR_ATTR_UNUSED LPWSTR pUserName,
+                                        WINPR_ATTR_UNUSED WTS_CONFIG_CLASS WTSConfigClass,
+                                        WINPR_ATTR_UNUSED LPWSTR* ppBuffer,
+                                        WINPR_ATTR_UNUSED DWORD* pBytesReturned)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSQueryUserConfigA(LPSTR pServerName, LPSTR pUserName,
-                                        WTS_CONFIG_CLASS WTSConfigClass, LPSTR* ppBuffer,
-                                        DWORD* pBytesReturned)
+BOOL WINAPI FreeRDP_WTSQueryUserConfigA(WINPR_ATTR_UNUSED LPSTR pServerName,
+                                        WINPR_ATTR_UNUSED LPSTR pUserName,
+                                        WINPR_ATTR_UNUSED WTS_CONFIG_CLASS WTSConfigClass,
+                                        WINPR_ATTR_UNUSED LPSTR* ppBuffer,
+                                        WINPR_ATTR_UNUSED DWORD* pBytesReturned)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSSetUserConfigW(LPWSTR pServerName, LPWSTR pUserName,
-                                      WTS_CONFIG_CLASS WTSConfigClass, LPWSTR pBuffer,
-                                      DWORD DataLength)
+BOOL WINAPI FreeRDP_WTSSetUserConfigW(WINPR_ATTR_UNUSED LPWSTR pServerName,
+                                      WINPR_ATTR_UNUSED LPWSTR pUserName,
+                                      WINPR_ATTR_UNUSED WTS_CONFIG_CLASS WTSConfigClass,
+                                      WINPR_ATTR_UNUSED LPWSTR pBuffer,
+                                      WINPR_ATTR_UNUSED DWORD DataLength)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSSetUserConfigA(LPSTR pServerName, LPSTR pUserName,
-                                      WTS_CONFIG_CLASS WTSConfigClass, LPSTR pBuffer,
-                                      DWORD DataLength)
+BOOL WINAPI FreeRDP_WTSSetUserConfigA(WINPR_ATTR_UNUSED LPSTR pServerName,
+                                      WINPR_ATTR_UNUSED LPSTR pUserName,
+                                      WINPR_ATTR_UNUSED WTS_CONFIG_CLASS WTSConfigClass,
+                                      WINPR_ATTR_UNUSED LPSTR pBuffer,
+                                      WINPR_ATTR_UNUSED DWORD DataLength)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSSendMessageW(HANDLE hServer, DWORD SessionId, LPWSTR pTitle,
-                                    DWORD TitleLength, LPWSTR pMessage, DWORD MessageLength,
-                                    DWORD Style, DWORD Timeout, DWORD* pResponse, BOOL bWait)
+BOOL WINAPI
+FreeRDP_WTSSendMessageW(WINPR_ATTR_UNUSED HANDLE hServer, WINPR_ATTR_UNUSED DWORD SessionId,
+                        WINPR_ATTR_UNUSED LPWSTR pTitle, WINPR_ATTR_UNUSED DWORD TitleLength,
+                        WINPR_ATTR_UNUSED LPWSTR pMessage, WINPR_ATTR_UNUSED DWORD MessageLength,
+                        WINPR_ATTR_UNUSED DWORD Style, WINPR_ATTR_UNUSED DWORD Timeout,
+                        WINPR_ATTR_UNUSED DWORD* pResponse, WINPR_ATTR_UNUSED BOOL bWait)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSSendMessageA(HANDLE hServer, DWORD SessionId, LPSTR pTitle,
-                                    DWORD TitleLength, LPSTR pMessage, DWORD MessageLength,
-                                    DWORD Style, DWORD Timeout, DWORD* pResponse, BOOL bWait)
+BOOL WINAPI
+FreeRDP_WTSSendMessageA(WINPR_ATTR_UNUSED HANDLE hServer, WINPR_ATTR_UNUSED DWORD SessionId,
+                        WINPR_ATTR_UNUSED LPSTR pTitle, WINPR_ATTR_UNUSED DWORD TitleLength,
+                        WINPR_ATTR_UNUSED LPSTR pMessage, WINPR_ATTR_UNUSED DWORD MessageLength,
+                        WINPR_ATTR_UNUSED DWORD Style, WINPR_ATTR_UNUSED DWORD Timeout,
+                        WINPR_ATTR_UNUSED DWORD* pResponse, WINPR_ATTR_UNUSED BOOL bWait)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSDisconnectSession(HANDLE hServer, DWORD SessionId, BOOL bWait)
+BOOL WINAPI FreeRDP_WTSDisconnectSession(WINPR_ATTR_UNUSED HANDLE hServer,
+                                         WINPR_ATTR_UNUSED DWORD SessionId,
+                                         WINPR_ATTR_UNUSED BOOL bWait)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSLogoffSession(HANDLE hServer, DWORD SessionId, BOOL bWait)
+BOOL WINAPI FreeRDP_WTSLogoffSession(WINPR_ATTR_UNUSED HANDLE hServer,
+                                     WINPR_ATTR_UNUSED DWORD SessionId,
+                                     WINPR_ATTR_UNUSED BOOL bWait)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSShutdownSystem(HANDLE hServer, DWORD ShutdownFlag)
+BOOL WINAPI FreeRDP_WTSShutdownSystem(WINPR_ATTR_UNUSED HANDLE hServer,
+                                      WINPR_ATTR_UNUSED DWORD ShutdownFlag)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSWaitSystemEvent(HANDLE hServer, DWORD EventMask, DWORD* pEventFlags)
+BOOL WINAPI FreeRDP_WTSWaitSystemEvent(WINPR_ATTR_UNUSED HANDLE hServer,
+                                       WINPR_ATTR_UNUSED DWORD EventMask,
+                                       WINPR_ATTR_UNUSED DWORD* pEventFlags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
@@ -1267,7 +1357,8 @@ fail:
 	return NULL;
 }
 
-HANDLE WINAPI FreeRDP_WTSVirtualChannelOpen(HANDLE hServer, DWORD SessionId, LPSTR pVirtualName)
+HANDLE WINAPI FreeRDP_WTSVirtualChannelOpen(HANDLE hServer, WINPR_ATTR_UNUSED DWORD SessionId,
+                                            LPSTR pVirtualName)
 {
 	size_t length = 0;
 	rdpMcs* mcs = NULL;
@@ -1502,8 +1593,8 @@ BOOL WINAPI FreeRDP_WTSVirtualChannelClose(HANDLE hChannelHandle)
 	return ret;
 }
 
-BOOL WINAPI FreeRDP_WTSVirtualChannelRead(HANDLE hChannelHandle, ULONG TimeOut, PCHAR Buffer,
-                                          ULONG BufferSize, PULONG pBytesRead)
+BOOL WINAPI FreeRDP_WTSVirtualChannelRead(HANDLE hChannelHandle, WINPR_ATTR_UNUSED ULONG TimeOut,
+                                          PCHAR Buffer, ULONG BufferSize, PULONG pBytesRead)
 {
 	BYTE* buffer = NULL;
 	wMessage message = { 0 };
@@ -1646,13 +1737,15 @@ fail:
 	return ret;
 }
 
-BOOL WINAPI FreeRDP_WTSVirtualChannelPurgeInput(HANDLE hChannelHandle)
+BOOL WINAPI FreeRDP_WTSVirtualChannelPurgeInput(WINPR_ATTR_UNUSED HANDLE hChannelHandle)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return TRUE;
 }
 
-BOOL WINAPI FreeRDP_WTSVirtualChannelPurgeOutput(HANDLE hChannelHandle)
+BOOL WINAPI FreeRDP_WTSVirtualChannelPurgeOutput(WINPR_ATTR_UNUSED HANDLE hChannelHandle)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return TRUE;
 }
 
@@ -1785,152 +1878,215 @@ VOID WINAPI FreeRDP_WTSFreeMemory(PVOID pMemory)
 	free(pMemory);
 }
 
-BOOL WINAPI FreeRDP_WTSFreeMemoryExW(WTS_TYPE_CLASS WTSTypeClass, PVOID pMemory,
-                                     ULONG NumberOfEntries)
+BOOL WINAPI FreeRDP_WTSFreeMemoryExW(WINPR_ATTR_UNUSED WTS_TYPE_CLASS WTSTypeClass,
+                                     WINPR_ATTR_UNUSED PVOID pMemory,
+                                     WINPR_ATTR_UNUSED ULONG NumberOfEntries)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSFreeMemoryExA(WTS_TYPE_CLASS WTSTypeClass, PVOID pMemory,
-                                     ULONG NumberOfEntries)
+BOOL WINAPI FreeRDP_WTSFreeMemoryExA(WINPR_ATTR_UNUSED WTS_TYPE_CLASS WTSTypeClass,
+                                     WINPR_ATTR_UNUSED PVOID pMemory,
+                                     WINPR_ATTR_UNUSED ULONG NumberOfEntries)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSRegisterSessionNotification(HWND hWnd, DWORD dwFlags)
+BOOL WINAPI FreeRDP_WTSRegisterSessionNotification(WINPR_ATTR_UNUSED HWND hWnd,
+                                                   WINPR_ATTR_UNUSED DWORD dwFlags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSUnRegisterSessionNotification(HWND hWnd)
+BOOL WINAPI FreeRDP_WTSUnRegisterSessionNotification(WINPR_ATTR_UNUSED HWND hWnd)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSRegisterSessionNotificationEx(HANDLE hServer, HWND hWnd, DWORD dwFlags)
+BOOL WINAPI FreeRDP_WTSRegisterSessionNotificationEx(WINPR_ATTR_UNUSED HANDLE hServer,
+                                                     WINPR_ATTR_UNUSED HWND hWnd,
+                                                     WINPR_ATTR_UNUSED DWORD dwFlags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSUnRegisterSessionNotificationEx(HANDLE hServer, HWND hWnd)
+BOOL WINAPI FreeRDP_WTSUnRegisterSessionNotificationEx(WINPR_ATTR_UNUSED HANDLE hServer,
+                                                       WINPR_ATTR_UNUSED HWND hWnd)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSQueryUserToken(ULONG SessionId, PHANDLE phToken)
+BOOL WINAPI FreeRDP_WTSQueryUserToken(WINPR_ATTR_UNUSED ULONG SessionId,
+                                      WINPR_ATTR_UNUSED PHANDLE phToken)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSEnumerateProcessesExW(HANDLE hServer, DWORD* pLevel, DWORD SessionId,
-                                             LPWSTR* ppProcessInfo, DWORD* pCount)
+BOOL WINAPI FreeRDP_WTSEnumerateProcessesExW(WINPR_ATTR_UNUSED HANDLE hServer,
+                                             WINPR_ATTR_UNUSED DWORD* pLevel,
+                                             WINPR_ATTR_UNUSED DWORD SessionId,
+                                             WINPR_ATTR_UNUSED LPWSTR* ppProcessInfo,
+                                             WINPR_ATTR_UNUSED DWORD* pCount)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSEnumerateProcessesExA(HANDLE hServer, DWORD* pLevel, DWORD SessionId,
-                                             LPSTR* ppProcessInfo, DWORD* pCount)
+BOOL WINAPI FreeRDP_WTSEnumerateProcessesExA(WINPR_ATTR_UNUSED HANDLE hServer,
+                                             WINPR_ATTR_UNUSED DWORD* pLevel,
+                                             WINPR_ATTR_UNUSED DWORD SessionId,
+                                             WINPR_ATTR_UNUSED LPSTR* ppProcessInfo,
+                                             WINPR_ATTR_UNUSED DWORD* pCount)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSEnumerateListenersW(HANDLE hServer, PVOID pReserved, DWORD Reserved,
-                                           PWTSLISTENERNAMEW pListeners, DWORD* pCount)
+BOOL WINAPI FreeRDP_WTSEnumerateListenersW(WINPR_ATTR_UNUSED HANDLE hServer,
+                                           WINPR_ATTR_UNUSED PVOID pReserved,
+                                           WINPR_ATTR_UNUSED DWORD Reserved,
+                                           WINPR_ATTR_UNUSED PWTSLISTENERNAMEW pListeners,
+                                           WINPR_ATTR_UNUSED DWORD* pCount)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSEnumerateListenersA(HANDLE hServer, PVOID pReserved, DWORD Reserved,
-                                           PWTSLISTENERNAMEA pListeners, DWORD* pCount)
+BOOL WINAPI FreeRDP_WTSEnumerateListenersA(WINPR_ATTR_UNUSED HANDLE hServer,
+                                           WINPR_ATTR_UNUSED PVOID pReserved,
+                                           WINPR_ATTR_UNUSED DWORD Reserved,
+                                           WINPR_ATTR_UNUSED PWTSLISTENERNAMEA pListeners,
+                                           WINPR_ATTR_UNUSED DWORD* pCount)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSQueryListenerConfigW(HANDLE hServer, PVOID pReserved, DWORD Reserved,
-                                            LPWSTR pListenerName, PWTSLISTENERCONFIGW pBuffer)
+BOOL WINAPI FreeRDP_WTSQueryListenerConfigW(WINPR_ATTR_UNUSED HANDLE hServer,
+                                            WINPR_ATTR_UNUSED PVOID pReserved,
+                                            WINPR_ATTR_UNUSED DWORD Reserved,
+                                            WINPR_ATTR_UNUSED LPWSTR pListenerName,
+                                            WINPR_ATTR_UNUSED PWTSLISTENERCONFIGW pBuffer)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSQueryListenerConfigA(HANDLE hServer, PVOID pReserved, DWORD Reserved,
-                                            LPSTR pListenerName, PWTSLISTENERCONFIGA pBuffer)
+BOOL WINAPI FreeRDP_WTSQueryListenerConfigA(WINPR_ATTR_UNUSED HANDLE hServer,
+                                            WINPR_ATTR_UNUSED PVOID pReserved,
+                                            WINPR_ATTR_UNUSED DWORD Reserved,
+                                            WINPR_ATTR_UNUSED LPSTR pListenerName,
+                                            WINPR_ATTR_UNUSED PWTSLISTENERCONFIGA pBuffer)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSCreateListenerW(HANDLE hServer, PVOID pReserved, DWORD Reserved,
-                                       LPWSTR pListenerName, PWTSLISTENERCONFIGW pBuffer,
-                                       DWORD flag)
+BOOL WINAPI FreeRDP_WTSCreateListenerW(WINPR_ATTR_UNUSED HANDLE hServer,
+                                       WINPR_ATTR_UNUSED PVOID pReserved,
+                                       WINPR_ATTR_UNUSED DWORD Reserved,
+                                       WINPR_ATTR_UNUSED LPWSTR pListenerName,
+                                       WINPR_ATTR_UNUSED PWTSLISTENERCONFIGW pBuffer,
+                                       WINPR_ATTR_UNUSED DWORD flag)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSCreateListenerA(HANDLE hServer, PVOID pReserved, DWORD Reserved,
-                                       LPSTR pListenerName, PWTSLISTENERCONFIGA pBuffer, DWORD flag)
+BOOL WINAPI FreeRDP_WTSCreateListenerA(WINPR_ATTR_UNUSED HANDLE hServer,
+                                       WINPR_ATTR_UNUSED PVOID pReserved,
+                                       WINPR_ATTR_UNUSED DWORD Reserved,
+                                       WINPR_ATTR_UNUSED LPSTR pListenerName,
+                                       WINPR_ATTR_UNUSED PWTSLISTENERCONFIGA pBuffer,
+                                       WINPR_ATTR_UNUSED DWORD flag)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSSetListenerSecurityW(HANDLE hServer, PVOID pReserved, DWORD Reserved,
-                                            LPWSTR pListenerName,
-                                            SECURITY_INFORMATION SecurityInformation,
-                                            PSECURITY_DESCRIPTOR pSecurityDescriptor)
+BOOL WINAPI FreeRDP_WTSSetListenerSecurityW(
+    WINPR_ATTR_UNUSED HANDLE hServer, WINPR_ATTR_UNUSED PVOID pReserved,
+    WINPR_ATTR_UNUSED DWORD Reserved, WINPR_ATTR_UNUSED LPWSTR pListenerName,
+    WINPR_ATTR_UNUSED SECURITY_INFORMATION SecurityInformation,
+    WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSSetListenerSecurityA(HANDLE hServer, PVOID pReserved, DWORD Reserved,
-                                            LPSTR pListenerName,
-                                            SECURITY_INFORMATION SecurityInformation,
-                                            PSECURITY_DESCRIPTOR pSecurityDescriptor)
+BOOL WINAPI FreeRDP_WTSSetListenerSecurityA(
+    WINPR_ATTR_UNUSED HANDLE hServer, WINPR_ATTR_UNUSED PVOID pReserved,
+    WINPR_ATTR_UNUSED DWORD Reserved, WINPR_ATTR_UNUSED LPSTR pListenerName,
+    WINPR_ATTR_UNUSED SECURITY_INFORMATION SecurityInformation,
+    WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSGetListenerSecurityW(HANDLE hServer, PVOID pReserved, DWORD Reserved,
-                                            LPWSTR pListenerName,
-                                            SECURITY_INFORMATION SecurityInformation,
-                                            PSECURITY_DESCRIPTOR pSecurityDescriptor, DWORD nLength,
-                                            LPDWORD lpnLengthNeeded)
+BOOL WINAPI FreeRDP_WTSGetListenerSecurityW(
+    WINPR_ATTR_UNUSED HANDLE hServer, WINPR_ATTR_UNUSED PVOID pReserved,
+    WINPR_ATTR_UNUSED DWORD Reserved, WINPR_ATTR_UNUSED LPWSTR pListenerName,
+    WINPR_ATTR_UNUSED SECURITY_INFORMATION SecurityInformation,
+    WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor, WINPR_ATTR_UNUSED DWORD nLength,
+    WINPR_ATTR_UNUSED LPDWORD lpnLengthNeeded)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSGetListenerSecurityA(HANDLE hServer, PVOID pReserved, DWORD Reserved,
-                                            LPSTR pListenerName,
-                                            SECURITY_INFORMATION SecurityInformation,
-                                            PSECURITY_DESCRIPTOR pSecurityDescriptor, DWORD nLength,
-                                            LPDWORD lpnLengthNeeded)
+BOOL WINAPI FreeRDP_WTSGetListenerSecurityA(
+    WINPR_ATTR_UNUSED HANDLE hServer, WINPR_ATTR_UNUSED PVOID pReserved,
+    WINPR_ATTR_UNUSED DWORD Reserved, WINPR_ATTR_UNUSED LPSTR pListenerName,
+    WINPR_ATTR_UNUSED SECURITY_INFORMATION SecurityInformation,
+    WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor, WINPR_ATTR_UNUSED DWORD nLength,
+    WINPR_ATTR_UNUSED LPDWORD lpnLengthNeeded)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL CDECL FreeRDP_WTSEnableChildSessions(BOOL bEnable)
+BOOL CDECL FreeRDP_WTSEnableChildSessions(WINPR_ATTR_UNUSED BOOL bEnable)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL CDECL FreeRDP_WTSIsChildSessionsEnabled(PBOOL pbEnabled)
+BOOL CDECL FreeRDP_WTSIsChildSessionsEnabled(WINPR_ATTR_UNUSED PBOOL pbEnabled)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL CDECL FreeRDP_WTSGetChildSessionId(PULONG pSessionId)
+BOOL CDECL FreeRDP_WTSGetChildSessionId(WINPR_ATTR_UNUSED PULONG pSessionId)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
 DWORD WINAPI FreeRDP_WTSGetActiveConsoleSessionId(void)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0xFFFFFFFF;
 }
-BOOL WINAPI FreeRDP_WTSLogoffUser(HANDLE hServer)
+BOOL WINAPI FreeRDP_WTSLogoffUser(WINPR_ATTR_UNUSED HANDLE hServer)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL WINAPI FreeRDP_WTSLogonUser(HANDLE hServer, LPCSTR username, LPCSTR password, LPCSTR domain)
+BOOL WINAPI FreeRDP_WTSLogonUser(WINPR_ATTR_UNUSED HANDLE hServer,
+                                 WINPR_ATTR_UNUSED LPCSTR username,
+                                 WINPR_ATTR_UNUSED LPCSTR password, WINPR_ATTR_UNUSED LPCSTR domain)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -1635,8 +1635,9 @@ BOOL identity_set_from_smartcard_hash(SEC_WINNT_AUTH_IDENTITY_W* identity,
                                       const rdpSettings* settings,
                                       FreeRDP_Settings_Keys_String userId,
                                       FreeRDP_Settings_Keys_String domainId,
-                                      FreeRDP_Settings_Keys_String pwdId, const BYTE* certSha1,
-                                      size_t sha1len)
+                                      FreeRDP_Settings_Keys_String pwdId,
+                                      WINPR_ATTR_UNUSED const BYTE* certSha1,
+                                      WINPR_ATTR_UNUSED size_t sha1len)
 {
 #ifdef _WIN32
 	CERT_CREDENTIAL_INFO certInfo = { sizeof(CERT_CREDENTIAL_INFO), { 0 } };

--- a/libfreerdp/core/smartcardlogon.c
+++ b/libfreerdp/core/smartcardlogon.c
@@ -381,10 +381,10 @@ out:
 }
 #endif /* _WIN32 */
 
-static BOOL list_provider_keys(const rdpSettings* settings, NCRYPT_PROV_HANDLE provider,
-                               LPCWSTR csp, LPCWSTR scope, const char* userFilter,
-                               const char* domainFilter, SmartcardCertInfo*** pcerts,
-                               size_t* pcount)
+static BOOL list_provider_keys(WINPR_ATTR_UNUSED const rdpSettings* settings,
+                               NCRYPT_PROV_HANDLE provider, LPCWSTR csp, LPCWSTR scope,
+                               const char* userFilter, const char* domainFilter,
+                               SmartcardCertInfo*** pcerts, size_t* pcount)
 {
 	BOOL ret = FALSE;
 	NCryptKeyName* keyName = NULL;

--- a/libfreerdp/core/streamdump.c
+++ b/libfreerdp/core/streamdump.c
@@ -376,8 +376,11 @@ static int stream_dump_replay_transport_read(rdpTransport* transport, wStream* s
 	return 1;
 }
 
-static int stream_dump_replay_transport_tcp_connect(rdpContext* context, rdpSettings* settings,
-                                                    const char* hostname, int port, DWORD timeout)
+static int stream_dump_replay_transport_tcp_connect(WINPR_ATTR_UNUSED rdpContext* context,
+                                                    WINPR_ATTR_UNUSED rdpSettings* settings,
+                                                    WINPR_ATTR_UNUSED const char* hostname,
+                                                    WINPR_ATTR_UNUSED int port,
+                                                    WINPR_ATTR_UNUSED DWORD timeout)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(settings);
@@ -386,9 +389,9 @@ static int stream_dump_replay_transport_tcp_connect(rdpContext* context, rdpSett
 	return 42;
 }
 
-static rdpTransportLayer* stream_dump_replay_transport_connect_layer(rdpTransport* transport,
-                                                                     const char* hostname, int port,
-                                                                     DWORD timeout)
+static rdpTransportLayer* stream_dump_replay_transport_connect_layer(
+    WINPR_ATTR_UNUSED rdpTransport* transport, WINPR_ATTR_UNUSED const char* hostname,
+    WINPR_ATTR_UNUSED int port, WINPR_ATTR_UNUSED DWORD timeout)
 {
 	WINPR_ASSERT(transport);
 	WINPR_ASSERT(hostname);
@@ -396,13 +399,13 @@ static rdpTransportLayer* stream_dump_replay_transport_connect_layer(rdpTranspor
 	return NULL;
 }
 
-static BOOL stream_dump_replay_transport_tls_connect(rdpTransport* transport)
+static BOOL stream_dump_replay_transport_tls_connect(WINPR_ATTR_UNUSED rdpTransport* transport)
 {
 	WINPR_ASSERT(transport);
 	return TRUE;
 }
 
-static BOOL stream_dump_replay_transport_accept(rdpTransport* transport)
+static BOOL stream_dump_replay_transport_accept(WINPR_ATTR_UNUSED rdpTransport* transport)
 {
 	WINPR_ASSERT(transport);
 	return TRUE;

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -103,8 +103,10 @@ typedef struct
 static int transport_bio_simple_init(BIO* bio, SOCKET socket, int shutdown);
 static int transport_bio_simple_uninit(BIO* bio);
 
-static long transport_bio_simple_callback(BIO* bio, int mode, const char* argp, int argi, long argl,
-                                          long ret)
+static long transport_bio_simple_callback(WINPR_ATTR_UNUSED BIO* bio, WINPR_ATTR_UNUSED int mode,
+                                          WINPR_ATTR_UNUSED const char* argp,
+                                          WINPR_ATTR_UNUSED int argi, WINPR_ATTR_UNUSED long argl,
+                                          WINPR_ATTR_UNUSED long ret)
 {
 	return 1;
 }
@@ -178,12 +180,13 @@ static int transport_bio_simple_read(BIO* bio, char* buf, int size)
 	return -1;
 }
 
-static int transport_bio_simple_puts(BIO* bio, const char* str)
+static int transport_bio_simple_puts(WINPR_ATTR_UNUSED BIO* bio, WINPR_ATTR_UNUSED const char* str)
 {
 	return 1;
 }
 
-static int transport_bio_simple_gets(BIO* bio, char* str, int size)
+static int transport_bio_simple_gets(WINPR_ATTR_UNUSED BIO* bio, WINPR_ATTR_UNUSED char* str,
+                                     WINPR_ATTR_UNUSED int size)
 {
 	return 1;
 }
@@ -461,8 +464,10 @@ typedef struct
 	RingBuffer xmitBuffer;
 } WINPR_BIO_BUFFERED_SOCKET;
 
-static long transport_bio_buffered_callback(BIO* bio, int mode, const char* argp, int argi,
-                                            long argl, long ret)
+static long transport_bio_buffered_callback(WINPR_ATTR_UNUSED BIO* bio, WINPR_ATTR_UNUSED int mode,
+                                            WINPR_ATTR_UNUSED const char* argp,
+                                            WINPR_ATTR_UNUSED int argi, WINPR_ATTR_UNUSED long argl,
+                                            WINPR_ATTR_UNUSED long ret)
 {
 	return 1;
 }
@@ -567,12 +572,14 @@ out:
 	return status;
 }
 
-static int transport_bio_buffered_puts(BIO* bio, const char* str)
+static int transport_bio_buffered_puts(WINPR_ATTR_UNUSED BIO* bio,
+                                       WINPR_ATTR_UNUSED const char* str)
 {
 	return 1;
 }
 
-static int transport_bio_buffered_gets(BIO* bio, char* str, int size)
+static int transport_bio_buffered_gets(WINPR_ATTR_UNUSED BIO* bio, WINPR_ATTR_UNUSED char* str,
+                                       WINPR_ATTR_UNUSED int size)
 {
 	return 1;
 }
@@ -900,7 +907,7 @@ static void peer_free(t_peer* peer)
 }
 
 static int freerdp_tcp_connect_multi(rdpContext* context, char** hostnames, const UINT32* ports,
-                                     UINT32 count, UINT16 port, UINT32 timeout)
+                                     UINT32 count, UINT16 port, WINPR_ATTR_UNUSED UINT32 timeout)
 {
 	UINT32 sindex = count;
 	SOCKET sockfd = INVALID_SOCKET;

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -740,8 +740,9 @@ fail:
 #define WLog_ERR_BIO(transport, biofunc, bio) \
 	transport_bio_error_log(transport, biofunc, bio, __FILE__, __func__, __LINE__)
 
-static void transport_bio_error_log(rdpTransport* transport, LPCSTR biofunc, BIO* bio, LPCSTR file,
-                                    LPCSTR func, DWORD line)
+static void transport_bio_error_log(rdpTransport* transport, LPCSTR biofunc,
+                                    WINPR_ATTR_UNUSED BIO* bio, LPCSTR file, LPCSTR func,
+                                    DWORD line)
 {
 	unsigned long sslerr = 0;
 	int saveerrno = 0;
@@ -1908,7 +1909,8 @@ void transport_set_early_user_auth_mode(rdpTransport* transport, BOOL EUAMode)
 	WLog_Print(transport->log, WLOG_DEBUG, "Early User Auth Mode: %s", EUAMode ? "on" : "off");
 }
 
-rdpTransportLayer* transport_layer_new(rdpTransport* transport, size_t contextSize)
+rdpTransportLayer* transport_layer_new(WINPR_ATTR_UNUSED rdpTransport* transport,
+                                       size_t contextSize)
 {
 	rdpTransportLayer* layer = (rdpTransportLayer*)calloc(1, sizeof(rdpTransportLayer));
 	if (!layer)
@@ -1983,12 +1985,13 @@ static int transport_layer_bio_read(BIO* bio, char* buf, int size)
 	return status;
 }
 
-static int transport_layer_bio_puts(BIO* bio, const char* str)
+static int transport_layer_bio_puts(WINPR_ATTR_UNUSED BIO* bio, WINPR_ATTR_UNUSED const char* str)
 {
 	return 1;
 }
 
-static int transport_layer_bio_gets(BIO* bio, char* str, int size)
+static int transport_layer_bio_gets(WINPR_ATTR_UNUSED BIO* bio, WINPR_ATTR_UNUSED char* str,
+                                    WINPR_ATTR_UNUSED int size)
 {
 	return 1;
 }

--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -2737,8 +2737,9 @@ static BOOL update_send_window_update(rdpContext* context, const WINDOW_ORDER_IN
 	return update_send_new_or_existing_window(context, orderInfo, stateOrder);
 }
 
-static UINT16 update_calculate_window_icon_order(const WINDOW_ORDER_INFO* orderInfo,
-                                                 const WINDOW_ICON_ORDER* iconOrder)
+static UINT16
+update_calculate_window_icon_order(WINPR_ATTR_UNUSED const WINDOW_ORDER_INFO* orderInfo,
+                                   const WINDOW_ICON_ORDER* iconOrder)
 {
 	UINT16 orderSize = 23;
 

--- a/libfreerdp/core/utils.c
+++ b/libfreerdp/core/utils.c
@@ -374,7 +374,7 @@ static BOOL disable_port(rdpSettings* settings)
 	return remove_rdpdr_type(settings, RDPDR_DTYP_PARALLEL);
 }
 
-static BOOL disable_pnp(rdpSettings* settings)
+static BOOL disable_pnp(WINPR_ATTR_UNUSED rdpSettings* settings)
 {
 	// TODO(akallabeth): [MS-RDPEPNP] related stuff is disabled.
 	return TRUE;

--- a/libfreerdp/core/window.c
+++ b/libfreerdp/core/window.c
@@ -508,7 +508,8 @@ static BOOL update_read_window_cached_icon_order(wStream* s, WINDOW_ORDER_INFO* 
 	    s, &window_cached_icon->cachedIcon); /* cachedIcon (CACHED_ICON_INFO) */
 }
 
-static void update_read_window_delete_order(wStream* s, WINDOW_ORDER_INFO* orderInfo)
+static void update_read_window_delete_order(WINPR_ATTR_UNUSED wStream* s,
+                                            WINPR_ATTR_UNUSED WINDOW_ORDER_INFO* orderInfo)
 {
 	/* window deletion event */
 }
@@ -939,7 +940,9 @@ static BOOL update_read_notification_icon_state_order(wStream* s, WINDOW_ORDER_I
 	return TRUE;
 }
 
-static void update_read_notification_icon_delete_order(wStream* s, WINDOW_ORDER_INFO* orderInfo)
+static void
+update_read_notification_icon_delete_order(WINPR_ATTR_UNUSED wStream* s,
+                                           WINPR_ATTR_UNUSED WINDOW_ORDER_INFO* orderInfo)
 {
 	/* notification icon deletion event */
 }
@@ -1040,7 +1043,8 @@ static BOOL update_read_desktop_actively_monitored_order(wStream* s, WINDOW_ORDE
 	return TRUE;
 }
 
-static void update_read_desktop_non_monitored_order(wStream* s, WINDOW_ORDER_INFO* orderInfo)
+static void update_read_desktop_non_monitored_order(WINPR_ATTR_UNUSED wStream* s,
+                                                    WINPR_ATTR_UNUSED WINDOW_ORDER_INFO* orderInfo)
 {
 	/* non-monitored desktop notification event */
 }

--- a/libfreerdp/crypto/ber.c
+++ b/libfreerdp/crypto/ber.c
@@ -351,7 +351,7 @@ BOOL ber_read_enumerated(wStream* s, BYTE* enumerated, BYTE count)
 	return TRUE;
 }
 
-void ber_write_enumerated(wStream* s, BYTE enumerated, BYTE count)
+void ber_write_enumerated(wStream* s, BYTE enumerated, WINPR_ATTR_UNUSED BYTE count)
 {
 	ber_write_universal_tag(s, BER_TAG_ENUMERATED, FALSE);
 	ber_write_length(s, 1);

--- a/libfreerdp/crypto/certificate.c
+++ b/libfreerdp/crypto/certificate.c
@@ -639,7 +639,8 @@ fail:
 	return rc;
 }
 
-static BOOL certificate_process_server_public_key(rdpCertificate* cert, wStream* s, UINT32 length)
+static BOOL certificate_process_server_public_key(rdpCertificate* cert, wStream* s,
+                                                  WINPR_ATTR_UNUSED UINT32 length)
 {
 	char magic[sizeof(rsa_magic)] = { 0 };
 	UINT32 keylen = 0;

--- a/libfreerdp/crypto/er.c
+++ b/libfreerdp/crypto/er.c
@@ -261,7 +261,7 @@ BOOL er_read_enumerated(wStream* s, BYTE* enumerated, BYTE count)
 	return TRUE;
 }
 
-void er_write_enumerated(wStream* s, BYTE enumerated, BYTE count, BOOL flag)
+void er_write_enumerated(wStream* s, BYTE enumerated, WINPR_ATTR_UNUSED BYTE count, BOOL flag)
 {
 	er_write_universal_tag(s, ER_TAG_ENUMERATED, FALSE);
 	er_write_length(s, 1, flag);

--- a/libfreerdp/crypto/per.c
+++ b/libfreerdp/crypto/per.c
@@ -380,7 +380,7 @@ BOOL per_read_enumerated(wStream* s, BYTE* enumerated, BYTE count)
  * @return \b TRUE for success, \b FALSE otherwise
  */
 
-BOOL per_write_enumerated(wStream* s, BYTE enumerated, BYTE count)
+BOOL per_write_enumerated(wStream* s, BYTE enumerated, WINPR_ATTR_UNUSED BYTE count)
 {
 	if (!Stream_EnsureRemainingCapacity(s, 1))
 		return FALSE;

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -258,7 +258,8 @@ static int bio_rdp_tls_puts(BIO* bio, const char* str)
 	return BIO_write(bio, str, (int)size);
 }
 
-static int bio_rdp_tls_gets(BIO* bio, char* str, int size)
+static int bio_rdp_tls_gets(WINPR_ATTR_UNUSED BIO* bio, WINPR_ATTR_UNUSED char* str,
+                            WINPR_ATTR_UNUSED int size)
 {
 	return 1;
 }
@@ -708,7 +709,9 @@ out_free:
 static INIT_ONCE secrets_file_idx_once = INIT_ONCE_STATIC_INIT;
 static int secrets_file_idx = -1;
 
-static BOOL CALLBACK secrets_file_init_cb(PINIT_ONCE once, PVOID param, PVOID* context)
+static BOOL CALLBACK secrets_file_init_cb(WINPR_ATTR_UNUSED PINIT_ONCE once,
+                                          WINPR_ATTR_UNUSED PVOID param,
+                                          WINPR_ATTR_UNUSED PVOID* context)
 {
 	secrets_file_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
 
@@ -839,7 +842,8 @@ static BOOL tls_prepare(rdpTls* tls, BIO* underlying, SSL_METHOD* method, int op
 	return TRUE;
 }
 
-static void adjustSslOptions(int* options) // NOLINT(readability-non-const-parameter)
+static void
+adjustSslOptions(WINPR_ATTR_UNUSED int* options) // NOLINT(readability-non-const-parameter)
 {
 	WINPR_ASSERT(options);
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
@@ -2017,7 +2021,8 @@ void tls_print_new_certificate_warn(rdpCertificateStore* store, const char* host
 	free(path);
 }
 
-void tls_print_certificate_error(rdpCertificateStore* store, rdpCertificateData* stored_data,
+void tls_print_certificate_error(rdpCertificateStore* store,
+                                 WINPR_ATTR_UNUSED rdpCertificateData* stored_data,
                                  const char* hostname, UINT16 port, const char* fingerprint)
 {
 	char* path = freerdp_certificate_store_get_cert_path(store, hostname, port);

--- a/libfreerdp/emu/scard/smartcard_emulate.c
+++ b/libfreerdp/emu/scard/smartcard_emulate.c
@@ -1680,8 +1680,9 @@ LONG WINAPI Emulate_SCardConnectW(SmartcardEmulationContext* smartcard, SCARDCON
 }
 
 LONG WINAPI Emulate_SCardReconnect(SmartcardEmulationContext* smartcard, SCARDHANDLE hCard,
-                                   DWORD dwShareMode, DWORD dwPreferredProtocols,
-                                   DWORD dwInitialization, LPDWORD pdwActiveProtocol)
+                                   DWORD dwShareMode, WINPR_ATTR_UNUSED DWORD dwPreferredProtocols,
+                                   WINPR_ATTR_UNUSED DWORD dwInitialization,
+                                   LPDWORD pdwActiveProtocol)
 {
 	LONG status = scard_handle_valid(smartcard, hCard);
 

--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -325,8 +325,9 @@ static const BYTE GDI_BS_HATCHED_PATTERNS[] = {
 };
 
 #define gdi_rop3_code_checked(code) gdi_rop3_code_checked_int((code), __FILE__, __func__, __LINE__)
-static inline DWORD gdi_rop3_code_checked_int(UINT32 code, const char* file, const char* fkt,
-                                              size_t line)
+static inline DWORD gdi_rop3_code_checked_int(UINT32 code, WINPR_ATTR_UNUSED const char* file,
+                                              WINPR_ATTR_UNUSED const char* fkt,
+                                              WINPR_ATTR_UNUSED size_t line)
 {
 	WINPR_ASSERT_AT(code <= UINT8_MAX, file, fkt, line);
 	return gdi_rop3_code((UINT8)code);
@@ -969,31 +970,36 @@ out_fail:
 	return ret;
 }
 
-static BOOL gdi_polygon_sc(rdpContext* context, const POLYGON_SC_ORDER* polygon_sc)
+static BOOL gdi_polygon_sc(WINPR_ATTR_UNUSED rdpContext* context,
+                           WINPR_ATTR_UNUSED const POLYGON_SC_ORDER* polygon_sc)
 {
 	WLog_WARN(TAG, "not implemented");
 	return FALSE;
 }
 
-static BOOL gdi_polygon_cb(rdpContext* context, POLYGON_CB_ORDER* polygon_cb)
+static BOOL gdi_polygon_cb(WINPR_ATTR_UNUSED rdpContext* context,
+                           WINPR_ATTR_UNUSED POLYGON_CB_ORDER* polygon_cb)
 {
 	WLog_WARN(TAG, "not implemented");
 	return FALSE;
 }
 
-static BOOL gdi_ellipse_sc(rdpContext* context, const ELLIPSE_SC_ORDER* ellipse_sc)
+static BOOL gdi_ellipse_sc(WINPR_ATTR_UNUSED rdpContext* context,
+                           WINPR_ATTR_UNUSED const ELLIPSE_SC_ORDER* ellipse_sc)
 {
 	WLog_WARN(TAG, "not implemented");
 	return FALSE;
 }
 
-static BOOL gdi_ellipse_cb(rdpContext* context, const ELLIPSE_CB_ORDER* ellipse_cb)
+static BOOL gdi_ellipse_cb(WINPR_ATTR_UNUSED rdpContext* context,
+                           WINPR_ATTR_UNUSED const ELLIPSE_CB_ORDER* ellipse_cb)
 {
 	WLog_WARN(TAG, "not implemented");
 	return FALSE;
 }
 
-static BOOL gdi_frame_marker(rdpContext* context, const FRAME_MARKER_ORDER* frameMarker)
+static BOOL gdi_frame_marker(WINPR_ATTR_UNUSED rdpContext* context,
+                             WINPR_ATTR_UNUSED const FRAME_MARKER_ORDER* frameMarker)
 {
 	return TRUE;
 }

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -317,7 +317,8 @@ static UINT gdi_call_update_surfaces(RdpgfxClientContext* context)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT gdi_EndFrame(RdpgfxClientContext* context, const RDPGFX_END_FRAME_PDU* endFrame)
+static UINT gdi_EndFrame(RdpgfxClientContext* context,
+                         WINPR_ATTR_UNUSED const RDPGFX_END_FRAME_PDU* endFrame)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(endFrame);

--- a/libfreerdp/gdi/graphics.c
+++ b/libfreerdp/gdi/graphics.c
@@ -103,7 +103,7 @@ static BOOL gdi_Bitmap_New(rdpContext* context, rdpBitmap* bitmap)
 	return TRUE;
 }
 
-static void gdi_Bitmap_Free(rdpContext* context, rdpBitmap* bitmap)
+static void gdi_Bitmap_Free(WINPR_ATTR_UNUSED rdpContext* context, rdpBitmap* bitmap)
 {
 	gdiBitmap* gdi_bitmap = (gdiBitmap*)bitmap;
 
@@ -305,7 +305,7 @@ static BOOL gdi_Glyph_New(rdpContext* context, rdpGlyph* glyph)
 	return TRUE;
 }
 
-static void gdi_Glyph_Free(rdpContext* context, rdpGlyph* glyph)
+static void gdi_Glyph_Free(WINPR_ATTR_UNUSED rdpContext* context, rdpGlyph* glyph)
 {
 	gdiGlyph* gdi_glyph = NULL;
 	gdi_glyph = (gdiGlyph*)glyph;
@@ -428,8 +428,10 @@ static BOOL gdi_Glyph_BeginDraw(rdpContext* context, INT32 x, INT32 y, INT32 wid
 	return TRUE;
 }
 
-static BOOL gdi_Glyph_EndDraw(rdpContext* context, INT32 x, INT32 y, INT32 width, INT32 height,
-                              UINT32 bgcolor, UINT32 fgcolor)
+static BOOL gdi_Glyph_EndDraw(rdpContext* context, WINPR_ATTR_UNUSED INT32 x,
+                              WINPR_ATTR_UNUSED INT32 y, WINPR_ATTR_UNUSED INT32 width,
+                              WINPR_ATTR_UNUSED INT32 height, WINPR_ATTR_UNUSED UINT32 bgcolor,
+                              WINPR_ATTR_UNUSED UINT32 fgcolor)
 {
 	rdpGdi* gdi = NULL;
 

--- a/libfreerdp/gdi/shape.c
+++ b/libfreerdp/gdi/shape.c
@@ -241,7 +241,8 @@ BOOL gdi_FillRect(HGDI_DC hdc, const HGDI_RECT rect, HGDI_BRUSH hbr)
  * @param nCount number of points
  * @return nonzero if successful, 0 otherwise
  */
-BOOL gdi_Polygon(HGDI_DC hdc, GDI_POINT* lpPoints, int nCount)
+BOOL gdi_Polygon(WINPR_ATTR_UNUSED HGDI_DC hdc, WINPR_ATTR_UNUSED GDI_POINT* lpPoints,
+                 WINPR_ATTR_UNUSED int nCount)
 {
 	WLog_ERR(TAG, "Not implemented!");
 	return FALSE;
@@ -256,7 +257,8 @@ BOOL gdi_Polygon(HGDI_DC hdc, GDI_POINT* lpPoints, int nCount)
  * @param nCount count of number of points in lpPolyCounts
  * @return nonzero if successful, 0 otherwise
  */
-BOOL gdi_PolyPolygon(HGDI_DC hdc, GDI_POINT* lpPoints, int* lpPolyCounts, int nCount)
+BOOL gdi_PolyPolygon(WINPR_ATTR_UNUSED HGDI_DC hdc, WINPR_ATTR_UNUSED GDI_POINT* lpPoints,
+                     WINPR_ATTR_UNUSED int* lpPolyCounts, WINPR_ATTR_UNUSED int nCount)
 {
 	WLog_ERR(TAG, "Not implemented!");
 	return FALSE;

--- a/libfreerdp/gdi/video.c
+++ b/libfreerdp/gdi/video.c
@@ -52,8 +52,8 @@ void gdi_video_geometry_uninit(rdpGdi* gdi, GeometryClientContext* geom)
 	WINPR_UNUSED(geom);
 }
 
-static VideoSurface* gdiVideoCreateSurface(VideoClientContext* video, UINT32 x, UINT32 y,
-                                           UINT32 width, UINT32 height)
+static VideoSurface* gdiVideoCreateSurface(WINPR_ATTR_UNUSED VideoClientContext* video, UINT32 x,
+                                           UINT32 y, UINT32 width, UINT32 height)
 {
 	return VideoClient_CreateCommonContext(sizeof(VideoSurface), x, y, width, height);
 }
@@ -139,7 +139,7 @@ void gdi_video_control_init(rdpGdi* gdi, VideoClientContext* video)
 	video->setGeometry(video, gdi->geometry);
 }
 
-void gdi_video_control_uninit(rdpGdi* gdi, VideoClientContext* video)
+void gdi_video_control_uninit(rdpGdi* gdi, WINPR_ATTR_UNUSED VideoClientContext* video)
 {
 	WINPR_ASSERT(gdi);
 	gdi->video = NULL;
@@ -159,14 +159,14 @@ static void gdi_video_timer(void* context, const TimerEventArgs* timer)
 		gdi->video->timer(gdi->video, timer->now);
 }
 
-void gdi_video_data_init(rdpGdi* gdi, VideoClientContext* video)
+void gdi_video_data_init(rdpGdi* gdi, WINPR_ATTR_UNUSED VideoClientContext* video)
 {
 	WINPR_ASSERT(gdi);
 	WINPR_ASSERT(gdi->context);
 	PubSub_SubscribeTimer(gdi->context->pubSub, gdi_video_timer);
 }
 
-void gdi_video_data_uninit(rdpGdi* gdi, VideoClientContext* context)
+void gdi_video_data_uninit(rdpGdi* gdi, WINPR_ATTR_UNUSED VideoClientContext* context)
 {
 	WINPR_ASSERT(gdi);
 	WINPR_ASSERT(gdi->context);

--- a/libfreerdp/locale/keyboard.c
+++ b/libfreerdp/locale/keyboard.c
@@ -263,7 +263,7 @@ static int freerdp_detect_keyboard(DWORD* keyboardLayoutId)
 	return 0;
 }
 
-static int freerdp_keyboard_init_apple(const DWORD* keyboardLayoutId,
+static int freerdp_keyboard_init_apple(WINPR_ATTR_UNUSED const DWORD* keyboardLayoutId,
                                        DWORD* x11_keycode_to_rdp_scancode, size_t count)
 {
 	WINPR_ASSERT(x11_keycode_to_rdp_scancode);
@@ -281,7 +281,7 @@ static int freerdp_keyboard_init_apple(const DWORD* keyboardLayoutId,
 	return 0;
 }
 
-static int freerdp_keyboard_init_x11_evdev(const DWORD* keyboardLayoutId,
+static int freerdp_keyboard_init_x11_evdev(WINPR_ATTR_UNUSED const DWORD* keyboardLayoutId,
                                            DWORD* x11_keycode_to_rdp_scancode, size_t count)
 {
 	WINPR_ASSERT(keyboardLayoutId);

--- a/libfreerdp/locale/keyboard_xkbfile.c
+++ b/libfreerdp/locale/keyboard_xkbfile.c
@@ -433,7 +433,7 @@ static int xkb_cmp(const void* pva, const void* pvb)
 
 static BOOL try_add(size_t offset, const char* xkb_keyname, DWORD* x11_keycode_to_rdp_scancode,
 
-                    size_t count)
+                    WINPR_ATTR_UNUSED size_t count)
 {
 	static BOOL initialized = FALSE;
 	static XKB_KEY_NAME_SCANCODE copy[ARRAYSIZE(XKB_KEY_NAME_SCANCODE_TABLE)] = { 0 };

--- a/libfreerdp/primitives/prim_YUV.c
+++ b/libfreerdp/primitives/prim_YUV.c
@@ -171,7 +171,8 @@ static inline pstatus_t general_ChromaV1ToYUV444(const BYTE* WINPR_RESTRICT pSrc
 
 static inline pstatus_t general_ChromaV2ToYUV444(const BYTE* WINPR_RESTRICT pSrc[3],
                                                  const UINT32 srcStep[3], UINT32 nTotalWidth,
-                                                 UINT32 nTotalHeight, BYTE* WINPR_RESTRICT pDst[3],
+                                                 WINPR_ATTR_UNUSED UINT32 nTotalHeight,
+                                                 BYTE* WINPR_RESTRICT pDst[3],
                                                  const UINT32 dstStep[3],
                                                  const RECTANGLE_16* WINPR_RESTRICT roi)
 {

--- a/libfreerdp/primitives/prim_copy.c
+++ b/libfreerdp/primitives/prim_copy.c
@@ -257,9 +257,9 @@ pstatus_t generic_image_copy_no_overlap_convert(
 pstatus_t generic_image_copy_no_overlap_memcpy(
     BYTE* WINPR_RESTRICT pDstData, DWORD DstFormat, UINT32 nDstStep, UINT32 nXDst, UINT32 nYDst,
     UINT32 nWidth, UINT32 nHeight, const BYTE* WINPR_RESTRICT pSrcData, DWORD SrcFormat,
-    UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc, const gdiPalette* WINPR_RESTRICT palette,
-    SSIZE_T srcVMultiplier, SSIZE_T srcVOffset, SSIZE_T dstVMultiplier, SSIZE_T dstVOffset,
-    UINT32 flags)
+    UINT32 nSrcStep, UINT32 nXSrc, UINT32 nYSrc,
+    WINPR_ATTR_UNUSED const gdiPalette* WINPR_RESTRICT palette, SSIZE_T srcVMultiplier,
+    SSIZE_T srcVOffset, SSIZE_T dstVMultiplier, SSIZE_T dstVOffset, WINPR_ATTR_UNUSED UINT32 flags)
 {
 	const SSIZE_T dstByte = FreeRDPGetBytesPerPixel(DstFormat);
 	const SSIZE_T srcByte = FreeRDPGetBytesPerPixel(SrcFormat);

--- a/libfreerdp/primitives/sse/prim_YUV_sse4.1.c
+++ b/libfreerdp/primitives/sse/prim_YUV_sse4.1.c
@@ -464,7 +464,7 @@ static inline pstatus_t sse41_YUV444ToRGB_8u_P3AC4R_BGRX_DOUBLE_ROW(
 
 static inline void BGRX_fillRGB_single(size_t offset, BYTE* WINPR_RESTRICT pRGB,
                                        const BYTE* WINPR_RESTRICT pY, const BYTE* WINPR_RESTRICT pU,
-                                       const BYTE* WINPR_RESTRICT pV, BOOL filter)
+                                       const BYTE* WINPR_RESTRICT pV, WINPR_ATTR_UNUSED BOOL filter)
 {
 	WINPR_ASSERT(pRGB);
 	WINPR_ASSERT(pY);
@@ -1021,10 +1021,10 @@ static INLINE void sse41_RGBToAVC444YUV_BGRX_DOUBLE_ROW(
 	                                       b7, width);
 }
 
-static pstatus_t sse41_RGBToAVC444YUV_BGRX(const BYTE* WINPR_RESTRICT pSrc, UINT32 srcFormat,
-                                           UINT32 srcStep, BYTE* WINPR_RESTRICT pDst1[],
-                                           const UINT32 dst1Step[], BYTE* WINPR_RESTRICT pDst2[],
-                                           const UINT32 dst2Step[],
+static pstatus_t sse41_RGBToAVC444YUV_BGRX(const BYTE* WINPR_RESTRICT pSrc,
+                                           WINPR_ATTR_UNUSED UINT32 srcFormat, UINT32 srcStep,
+                                           BYTE* WINPR_RESTRICT pDst1[], const UINT32 dst1Step[],
+                                           BYTE* WINPR_RESTRICT pDst2[], const UINT32 dst2Step[],
                                            const prim_size_t* WINPR_RESTRICT roi)
 {
 	if (roi->height < 1 || roi->width < 1)
@@ -1347,10 +1347,10 @@ static INLINE void sse41_RGBToAVC444YUVv2_BGRX_DOUBLE_ROW(
 	                                         uChromaDst2, vChromaDst1, vChromaDst2, width);
 }
 
-static pstatus_t sse41_RGBToAVC444YUVv2_BGRX(const BYTE* WINPR_RESTRICT pSrc, UINT32 srcFormat,
-                                             UINT32 srcStep, BYTE* WINPR_RESTRICT pDst1[],
-                                             const UINT32 dst1Step[], BYTE* WINPR_RESTRICT pDst2[],
-                                             const UINT32 dst2Step[],
+static pstatus_t sse41_RGBToAVC444YUVv2_BGRX(const BYTE* WINPR_RESTRICT pSrc,
+                                             WINPR_ATTR_UNUSED UINT32 srcFormat, UINT32 srcStep,
+                                             BYTE* WINPR_RESTRICT pDst1[], const UINT32 dst1Step[],
+                                             BYTE* WINPR_RESTRICT pDst2[], const UINT32 dst2Step[],
                                              const prim_size_t* WINPR_RESTRICT roi)
 {
 	if (roi->height < 1 || roi->width < 1)
@@ -1603,7 +1603,7 @@ static pstatus_t sse41_ChromaV1ToYUV444(const BYTE* WINPR_RESTRICT pSrcRaw[3],
 }
 
 static pstatus_t sse41_ChromaV2ToYUV444(const BYTE* WINPR_RESTRICT pSrc[3], const UINT32 srcStep[3],
-                                        UINT32 nTotalWidth, UINT32 nTotalHeight,
+                                        UINT32 nTotalWidth, WINPR_ATTR_UNUSED UINT32 nTotalHeight,
                                         BYTE* WINPR_RESTRICT pDst[3], const UINT32 dstStep[3],
                                         const RECTANGLE_16* WINPR_RESTRICT roi)
 {

--- a/libfreerdp/primitives/sse/prim_colors_sse2.c
+++ b/libfreerdp/primitives/sse/prim_colors_sse2.c
@@ -222,8 +222,9 @@ sse2_yCbCrToRGB_16s16s_P3P3(const INT16* WINPR_RESTRICT pSrc[3], int srcStep,
 
 /*---------------------------------------------------------------------------*/
 static pstatus_t
-sse2_yCbCrToRGB_16s8u_P3AC4R_BGRX(const INT16* WINPR_RESTRICT pSrc[3], UINT32 srcStep,
-                                  BYTE* WINPR_RESTRICT pDst, UINT32 dstStep,
+sse2_yCbCrToRGB_16s8u_P3AC4R_BGRX(const INT16* WINPR_RESTRICT pSrc[3],
+                                  WINPR_ATTR_UNUSED UINT32 srcStep, BYTE* WINPR_RESTRICT pDst,
+                                  UINT32 dstStep,
                                   const prim_size_t* WINPR_RESTRICT roi) /* region of interest */
 {
 	const __m128i zero = _mm_setzero_si128();
@@ -407,8 +408,9 @@ sse2_yCbCrToRGB_16s8u_P3AC4R_BGRX(const INT16* WINPR_RESTRICT pSrc[3], UINT32 sr
 
 /*---------------------------------------------------------------------------*/
 static pstatus_t
-sse2_yCbCrToRGB_16s8u_P3AC4R_RGBX(const INT16* WINPR_RESTRICT pSrc[3], UINT32 srcStep,
-                                  BYTE* WINPR_RESTRICT pDst, UINT32 dstStep,
+sse2_yCbCrToRGB_16s8u_P3AC4R_RGBX(const INT16* WINPR_RESTRICT pSrc[3],
+                                  WINPR_ATTR_UNUSED UINT32 srcStep, BYTE* WINPR_RESTRICT pDst,
+                                  UINT32 dstStep,
                                   const prim_size_t* WINPR_RESTRICT roi) /* region of interest */
 {
 	const __m128i zero = _mm_setzero_si128();

--- a/libfreerdp/utils/passphrase.c
+++ b/libfreerdp/utils/passphrase.c
@@ -119,7 +119,7 @@ static int wait_for_fd(int fd, int timeout)
 	return status;
 }
 
-static void replace_char(char* buffer, size_t buffer_len, const char* toreplace)
+static void replace_char(char* buffer, WINPR_ATTR_UNUSED size_t buffer_len, const char* toreplace)
 {
 	while (*toreplace != '\0')
 	{

--- a/libfreerdp/utils/smartcard_call.c
+++ b/libfreerdp/utils/smartcard_call.c
@@ -139,7 +139,8 @@ static LONG smartcard_EstablishContext_Call(scard_call_context* smartcard, wStre
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_ReleaseContext_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_ReleaseContext_Call(scard_call_context* smartcard,
+                                          WINPR_ATTR_UNUSED wStream* out,
                                           SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -161,7 +162,8 @@ static LONG smartcard_ReleaseContext_Call(scard_call_context* smartcard, wStream
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_IsValidContext_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_IsValidContext_Call(scard_call_context* smartcard,
+                                          WINPR_ATTR_UNUSED wStream* out,
                                           SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -428,7 +430,8 @@ static LONG smartcard_ListReadersW_Call(scard_call_context* smartcard, wStream* 
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_IntroduceReaderGroupA_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_IntroduceReaderGroupA_Call(scard_call_context* smartcard,
+                                                 WINPR_ATTR_UNUSED wStream* out,
                                                  SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -445,7 +448,8 @@ static LONG smartcard_IntroduceReaderGroupA_Call(scard_call_context* smartcard, 
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_IntroduceReaderGroupW_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_IntroduceReaderGroupW_Call(scard_call_context* smartcard,
+                                                 WINPR_ATTR_UNUSED wStream* out,
                                                  SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -462,7 +466,8 @@ static LONG smartcard_IntroduceReaderGroupW_Call(scard_call_context* smartcard, 
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_IntroduceReaderA_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_IntroduceReaderA_Call(scard_call_context* smartcard,
+                                            WINPR_ATTR_UNUSED wStream* out,
                                             SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -480,7 +485,8 @@ static LONG smartcard_IntroduceReaderA_Call(scard_call_context* smartcard, wStre
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_IntroduceReaderW_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_IntroduceReaderW_Call(scard_call_context* smartcard,
+                                            WINPR_ATTR_UNUSED wStream* out,
                                             SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -498,7 +504,8 @@ static LONG smartcard_IntroduceReaderW_Call(scard_call_context* smartcard, wStre
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_ForgetReaderA_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_ForgetReaderA_Call(scard_call_context* smartcard,
+                                         WINPR_ATTR_UNUSED wStream* out,
                                          SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -515,7 +522,8 @@ static LONG smartcard_ForgetReaderA_Call(scard_call_context* smartcard, wStream*
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_ForgetReaderW_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_ForgetReaderW_Call(scard_call_context* smartcard,
+                                         WINPR_ATTR_UNUSED wStream* out,
                                          SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -532,7 +540,8 @@ static LONG smartcard_ForgetReaderW_Call(scard_call_context* smartcard, wStream*
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_AddReaderToGroupA_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_AddReaderToGroupA_Call(scard_call_context* smartcard,
+                                             WINPR_ATTR_UNUSED wStream* out,
                                              SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -550,7 +559,8 @@ static LONG smartcard_AddReaderToGroupA_Call(scard_call_context* smartcard, wStr
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_AddReaderToGroupW_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_AddReaderToGroupW_Call(scard_call_context* smartcard,
+                                             WINPR_ATTR_UNUSED wStream* out,
                                              SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -568,7 +578,8 @@ static LONG smartcard_AddReaderToGroupW_Call(scard_call_context* smartcard, wStr
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_RemoveReaderFromGroupA_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_RemoveReaderFromGroupA_Call(scard_call_context* smartcard,
+                                                  WINPR_ATTR_UNUSED wStream* out,
                                                   SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -586,7 +597,8 @@ static LONG smartcard_RemoveReaderFromGroupA_Call(scard_call_context* smartcard,
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_RemoveReaderFromGroupW_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_RemoveReaderFromGroupW_Call(scard_call_context* smartcard,
+                                                  WINPR_ATTR_UNUSED wStream* out,
                                                   SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -777,7 +789,8 @@ static LONG smartcard_ReadCacheW_Call(scard_call_context* smartcard, wStream* ou
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_WriteCacheA_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_WriteCacheA_Call(scard_call_context* smartcard,
+                                       WINPR_ATTR_UNUSED wStream* out,
                                        SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -797,7 +810,8 @@ static LONG smartcard_WriteCacheA_Call(scard_call_context* smartcard, wStream* o
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_WriteCacheW_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_WriteCacheW_Call(scard_call_context* smartcard,
+                                       WINPR_ATTR_UNUSED wStream* out,
                                        SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -1026,7 +1040,7 @@ fail:
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_Cancel_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_Cancel_Call(scard_call_context* smartcard, WINPR_ATTR_UNUSED wStream* out,
                                   SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -1136,7 +1150,7 @@ static LONG smartcard_Reconnect_Call(scard_call_context* smartcard, wStream* out
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_Disconnect_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_Disconnect_Call(scard_call_context* smartcard, WINPR_ATTR_UNUSED wStream* out,
                                       SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -1155,7 +1169,8 @@ static LONG smartcard_Disconnect_Call(scard_call_context* smartcard, wStream* ou
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_BeginTransaction_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_BeginTransaction_Call(scard_call_context* smartcard,
+                                            WINPR_ATTR_UNUSED wStream* out,
                                             SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -1170,7 +1185,8 @@ static LONG smartcard_BeginTransaction_Call(scard_call_context* smartcard, wStre
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_EndTransaction_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_EndTransaction_Call(scard_call_context* smartcard,
+                                          WINPR_ATTR_UNUSED wStream* out,
                                           SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -1441,7 +1457,7 @@ static LONG smartcard_GetAttrib_Call(scard_call_context* smartcard, wStream* out
 	return status;
 }
 
-static LONG smartcard_SetAttrib_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_SetAttrib_Call(scard_call_context* smartcard, WINPR_ATTR_UNUSED wStream* out,
                                      SMARTCARD_OPERATION* operation)
 {
 	Long_Return ret = { 0 };
@@ -1461,7 +1477,8 @@ static LONG smartcard_SetAttrib_Call(scard_call_context* smartcard, wStream* out
 	return ret.ReturnCode;
 }
 
-static LONG smartcard_AccessStartedEvent_Call(scard_call_context* smartcard, wStream* out,
+static LONG smartcard_AccessStartedEvent_Call(scard_call_context* smartcard,
+                                              WINPR_ATTR_UNUSED wStream* out,
                                               SMARTCARD_OPERATION* operation)
 {
 	LONG status = SCARD_S_SUCCESS;

--- a/libfreerdp/utils/smartcard_pack.c
+++ b/libfreerdp/utils/smartcard_pack.c
@@ -1717,7 +1717,7 @@ LONG smartcard_pack_redir_scard_context(wStream* s, const REDIR_SCARDCONTEXT* co
 	return SCARD_S_SUCCESS;
 }
 
-LONG smartcard_unpack_redir_scard_context_ref(wStream* s, UINT32 pbContextNdrPtr,
+LONG smartcard_unpack_redir_scard_context_ref(wStream* s, WINPR_ATTR_UNUSED UINT32 pbContextNdrPtr,
                                               REDIR_SCARDCONTEXT* context)
 {
 	UINT32 length = 0;

--- a/rdtk/librdtk/rdtk_font.c
+++ b/rdtk/librdtk/rdtk_font.c
@@ -240,7 +240,8 @@ static int rdtk_font_convert_descriptor_code_to_utf8(const char* str, uint8_t* u
 	return 1;
 }
 
-static int rdtk_font_parse_descriptor_buffer(rdtkFont* font, char* buffer, size_t size)
+static int rdtk_font_parse_descriptor_buffer(rdtkFont* font, char* buffer,
+                                             WINPR_ATTR_UNUSED size_t size)
 {
 	int rc = -1;
 

--- a/rdtk/librdtk/rdtk_label.c
+++ b/rdtk/librdtk/rdtk_label.c
@@ -25,8 +25,8 @@
 #include "rdtk_label.h"
 
 int rdtk_label_draw(rdtkSurface* surface, uint16_t nXDst, uint16_t nYDst, uint16_t nWidth,
-                    uint16_t nHeight, rdtkLabel* label, const char* text, uint16_t hAlign,
-                    uint16_t vAlign)
+                    uint16_t nHeight, WINPR_ATTR_UNUSED rdtkLabel* label, const char* text,
+                    WINPR_ATTR_UNUSED uint16_t hAlign, WINPR_ATTR_UNUSED uint16_t vAlign)
 {
 	uint16_t offsetX = 0;
 	uint16_t offsetY = 0;

--- a/server/Sample/sf_ainput.c
+++ b/server/Sample/sf_ainput.c
@@ -38,8 +38,8 @@
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT sf_peer_ainput_mouse_event(ainput_server_context* context, UINT64 timestamp,
-                                       UINT64 flags, INT32 x, INT32 y)
+static UINT sf_peer_ainput_mouse_event(WINPR_ATTR_UNUSED ainput_server_context* context,
+                                       UINT64 timestamp, UINT64 flags, INT32 x, INT32 y)
 {
 	/* TODO: Implement */
 	WINPR_ASSERT(context);

--- a/server/Sample/sf_audin.c
+++ b/server/Sample/sf_audin.c
@@ -34,7 +34,8 @@
 
 #if defined(CHANNEL_AUDIN_SERVER)
 
-static UINT sf_peer_audin_data(audin_server_context* audin, const SNDIN_DATA* data)
+static UINT sf_peer_audin_data(WINPR_ATTR_UNUSED audin_server_context* audin,
+                               const SNDIN_DATA* data)
 {
 	/* TODO: Implement */
 	WINPR_ASSERT(audin);

--- a/server/proxy/channels/pf_channel_rdpdr.c
+++ b/server/proxy/channels/pf_channel_rdpdr.c
@@ -521,8 +521,9 @@ static UINT rdpdr_send_client_name_request(pClientContext* pc, pf_channel_client
 
 #define rdpdr_ignore_capset(srv, log, s, header) \
 	rdpdr_ignore_capset_((srv), (log), (s), header, __func__)
-static UINT rdpdr_ignore_capset_(BOOL srv, wLog* log, wStream* s,
-                                 const RDPDR_CAPABILITY_HEADER* header, const char* fkt)
+static UINT rdpdr_ignore_capset_(WINPR_ATTR_UNUSED BOOL srv, WINPR_ATTR_UNUSED wLog* log,
+                                 wStream* s, const RDPDR_CAPABILITY_HEADER* header,
+                                 WINPR_ATTR_UNUSED const char* fkt)
 {
 	WINPR_ASSERT(s);
 	WINPR_ASSERT(header);
@@ -1509,8 +1510,8 @@ static BOOL pf_channel_rdpdr_common_context_new(pf_channel_common_context* commo
 }
 
 static BOOL pf_channel_rdpdr_client_pass_message(pServerContext* ps, pClientContext* pc,
-                                                 UINT16 channelId, const char* channel_name,
-                                                 wStream* s)
+                                                 WINPR_ATTR_UNUSED UINT16 channelId,
+                                                 const char* channel_name, wStream* s)
 {
 	pf_channel_client_context* rdpdr = NULL;
 

--- a/server/proxy/cli/freerdp_proxy.c
+++ b/server/proxy/cli/freerdp_proxy.c
@@ -89,7 +89,7 @@ static int version(const char* app)
 	return 0;
 }
 
-static int buildconfig(const char* app)
+static int buildconfig(WINPR_ATTR_UNUSED const char* app)
 {
 	printf("This is FreeRDP version %s (%s)\n", FREERDP_VERSION_FULL, FREERDP_GIT_REVISION);
 	printf("%s", freerdp_get_build_config());

--- a/server/proxy/modules/bitmap-filter/bitmap-filter.cpp
+++ b/server/proxy/modules/bitmap-filter/bitmap-filter.cpp
@@ -118,7 +118,9 @@ class DynChannelState
 	uint32_t _channelId = 0;
 };
 
-static BOOL filter_client_pre_connect(proxyPlugin* plugin, proxyData* pdata, void* custom)
+static BOOL filter_client_pre_connect([[maybe_unused]] proxyPlugin* plugin,
+                                      [[maybe_unused]] proxyData* pdata,
+                                      [[maybe_unused]] void* custom)
 {
 	WINPR_ASSERT(plugin);
 	WINPR_ASSERT(pdata);
@@ -131,7 +133,9 @@ static BOOL filter_client_pre_connect(proxyPlugin* plugin, proxyData* pdata, voi
 	return freerdp_settings_set_bool(settings, FreeRDP_BitmapCachePersistEnabled, FALSE);
 }
 
-static BOOL filter_dyn_channel_intercept_list(proxyPlugin* plugin, proxyData* pdata, void* arg)
+static BOOL filter_dyn_channel_intercept_list([[maybe_unused]] proxyPlugin* plugin,
+                                              [[maybe_unused]] proxyData* pdata,
+                                              [[maybe_unused]] void* arg)
 {
 	auto data = static_cast<proxyChannelToInterceptData*>(arg);
 
@@ -146,7 +150,9 @@ static BOOL filter_dyn_channel_intercept_list(proxyPlugin* plugin, proxyData* pd
 	return TRUE;
 }
 
-static BOOL filter_static_channel_intercept_list(proxyPlugin* plugin, proxyData* pdata, void* arg)
+static BOOL filter_static_channel_intercept_list([[maybe_unused]] proxyPlugin* plugin,
+                                                 [[maybe_unused]] proxyData* pdata,
+                                                 [[maybe_unused]] void* arg)
 {
 	auto data = static_cast<proxyChannelToInterceptData*>(arg);
 

--- a/server/proxy/modules/demo/demo.cpp
+++ b/server/proxy/modules/demo/demo.cpp
@@ -36,7 +36,7 @@ struct demo_custom_data
 static constexpr char plugin_name[] = "demo";
 static constexpr char plugin_desc[] = "this is a test plugin";
 
-static BOOL demo_plugin_unload(proxyPlugin* plugin)
+static BOOL demo_plugin_unload([[maybe_unused]] proxyPlugin* plugin)
 {
 	WINPR_ASSERT(plugin);
 
@@ -49,7 +49,9 @@ static BOOL demo_plugin_unload(proxyPlugin* plugin)
 	return TRUE;
 }
 
-static BOOL demo_client_init_connect(proxyPlugin* plugin, proxyData* pdata, void* custom)
+static BOOL demo_client_init_connect([[maybe_unused]] proxyPlugin* plugin,
+                                     [[maybe_unused]] proxyData* pdata,
+                                     [[maybe_unused]] void* custom)
 {
 	WINPR_ASSERT(plugin);
 	WINPR_ASSERT(pdata);
@@ -59,7 +61,9 @@ static BOOL demo_client_init_connect(proxyPlugin* plugin, proxyData* pdata, void
 	return TRUE;
 }
 
-static BOOL demo_client_uninit_connect(proxyPlugin* plugin, proxyData* pdata, void* custom)
+static BOOL demo_client_uninit_connect([[maybe_unused]] proxyPlugin* plugin,
+                                       [[maybe_unused]] proxyData* pdata,
+                                       [[maybe_unused]] void* custom)
 {
 	WINPR_ASSERT(plugin);
 	WINPR_ASSERT(pdata);
@@ -69,7 +73,9 @@ static BOOL demo_client_uninit_connect(proxyPlugin* plugin, proxyData* pdata, vo
 	return TRUE;
 }
 
-static BOOL demo_client_pre_connect(proxyPlugin* plugin, proxyData* pdata, void* custom)
+static BOOL demo_client_pre_connect([[maybe_unused]] proxyPlugin* plugin,
+                                    [[maybe_unused]] proxyData* pdata,
+                                    [[maybe_unused]] void* custom)
 {
 	WINPR_ASSERT(plugin);
 	WINPR_ASSERT(pdata);
@@ -79,7 +85,9 @@ static BOOL demo_client_pre_connect(proxyPlugin* plugin, proxyData* pdata, void*
 	return TRUE;
 }
 
-static BOOL demo_client_post_connect(proxyPlugin* plugin, proxyData* pdata, void* custom)
+static BOOL demo_client_post_connect([[maybe_unused]] proxyPlugin* plugin,
+                                     [[maybe_unused]] proxyData* pdata,
+                                     [[maybe_unused]] void* custom)
 {
 	WINPR_ASSERT(plugin);
 	WINPR_ASSERT(pdata);
@@ -89,7 +97,9 @@ static BOOL demo_client_post_connect(proxyPlugin* plugin, proxyData* pdata, void
 	return TRUE;
 }
 
-static BOOL demo_client_post_disconnect(proxyPlugin* plugin, proxyData* pdata, void* custom)
+static BOOL demo_client_post_disconnect([[maybe_unused]] proxyPlugin* plugin,
+                                        [[maybe_unused]] proxyData* pdata,
+                                        [[maybe_unused]] void* custom)
 {
 	WINPR_ASSERT(plugin);
 	WINPR_ASSERT(pdata);
@@ -99,7 +109,9 @@ static BOOL demo_client_post_disconnect(proxyPlugin* plugin, proxyData* pdata, v
 	return TRUE;
 }
 
-static BOOL demo_client_x509_certificate(proxyPlugin* plugin, proxyData* pdata, void* custom)
+static BOOL demo_client_x509_certificate([[maybe_unused]] proxyPlugin* plugin,
+                                         [[maybe_unused]] proxyData* pdata,
+                                         [[maybe_unused]] void* custom)
 {
 	WINPR_ASSERT(plugin);
 	WINPR_ASSERT(pdata);
@@ -109,7 +121,9 @@ static BOOL demo_client_x509_certificate(proxyPlugin* plugin, proxyData* pdata, 
 	return TRUE;
 }
 
-static BOOL demo_client_login_failure(proxyPlugin* plugin, proxyData* pdata, void* custom)
+static BOOL demo_client_login_failure([[maybe_unused]] proxyPlugin* plugin,
+                                      [[maybe_unused]] proxyData* pdata,
+                                      [[maybe_unused]] void* custom)
 {
 	WINPR_ASSERT(plugin);
 	WINPR_ASSERT(pdata);
@@ -119,7 +133,8 @@ static BOOL demo_client_login_failure(proxyPlugin* plugin, proxyData* pdata, voi
 	return TRUE;
 }
 
-static BOOL demo_client_end_paint(proxyPlugin* plugin, proxyData* pdata, void* custom)
+static BOOL demo_client_end_paint([[maybe_unused]] proxyPlugin* plugin,
+                                  [[maybe_unused]] proxyData* pdata, [[maybe_unused]] void* custom)
 {
 	WINPR_ASSERT(plugin);
 	WINPR_ASSERT(pdata);
@@ -129,7 +144,8 @@ static BOOL demo_client_end_paint(proxyPlugin* plugin, proxyData* pdata, void* c
 	return TRUE;
 }
 
-static BOOL demo_client_redirect(proxyPlugin* plugin, proxyData* pdata, void* custom)
+static BOOL demo_client_redirect([[maybe_unused]] proxyPlugin* plugin,
+                                 [[maybe_unused]] proxyData* pdata, [[maybe_unused]] void* custom)
 {
 	WINPR_ASSERT(plugin);
 	WINPR_ASSERT(pdata);
@@ -139,7 +155,9 @@ static BOOL demo_client_redirect(proxyPlugin* plugin, proxyData* pdata, void* cu
 	return TRUE;
 }
 
-static BOOL demo_server_post_connect(proxyPlugin* plugin, proxyData* pdata, void* custom)
+static BOOL demo_server_post_connect([[maybe_unused]] proxyPlugin* plugin,
+                                     [[maybe_unused]] proxyData* pdata,
+                                     [[maybe_unused]] void* custom)
 {
 	WINPR_ASSERT(plugin);
 	WINPR_ASSERT(pdata);
@@ -149,7 +167,9 @@ static BOOL demo_server_post_connect(proxyPlugin* plugin, proxyData* pdata, void
 	return TRUE;
 }
 
-static BOOL demo_server_peer_activate(proxyPlugin* plugin, proxyData* pdata, void* custom)
+static BOOL demo_server_peer_activate([[maybe_unused]] proxyPlugin* plugin,
+                                      [[maybe_unused]] proxyData* pdata,
+                                      [[maybe_unused]] void* custom)
 {
 	WINPR_ASSERT(plugin);
 	WINPR_ASSERT(pdata);
@@ -159,7 +179,9 @@ static BOOL demo_server_peer_activate(proxyPlugin* plugin, proxyData* pdata, voi
 	return TRUE;
 }
 
-static BOOL demo_server_channels_init(proxyPlugin* plugin, proxyData* pdata, void* custom)
+static BOOL demo_server_channels_init([[maybe_unused]] proxyPlugin* plugin,
+                                      [[maybe_unused]] proxyData* pdata,
+                                      [[maybe_unused]] void* custom)
 {
 	WINPR_ASSERT(plugin);
 	WINPR_ASSERT(pdata);
@@ -169,7 +191,9 @@ static BOOL demo_server_channels_init(proxyPlugin* plugin, proxyData* pdata, voi
 	return TRUE;
 }
 
-static BOOL demo_server_channels_free(proxyPlugin* plugin, proxyData* pdata, void* custom)
+static BOOL demo_server_channels_free([[maybe_unused]] proxyPlugin* plugin,
+                                      [[maybe_unused]] proxyData* pdata,
+                                      [[maybe_unused]] void* custom)
 {
 	WINPR_ASSERT(plugin);
 	WINPR_ASSERT(pdata);
@@ -179,7 +203,9 @@ static BOOL demo_server_channels_free(proxyPlugin* plugin, proxyData* pdata, voi
 	return TRUE;
 }
 
-static BOOL demo_server_session_end(proxyPlugin* plugin, proxyData* pdata, void* custom)
+static BOOL demo_server_session_end([[maybe_unused]] proxyPlugin* plugin,
+                                    [[maybe_unused]] proxyData* pdata,
+                                    [[maybe_unused]] void* custom)
 {
 	WINPR_ASSERT(plugin);
 	WINPR_ASSERT(pdata);
@@ -189,7 +215,9 @@ static BOOL demo_server_session_end(proxyPlugin* plugin, proxyData* pdata, void*
 	return TRUE;
 }
 
-static BOOL demo_filter_keyboard_event(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL demo_filter_keyboard_event([[maybe_unused]] proxyPlugin* plugin,
+                                       [[maybe_unused]] proxyData* pdata,
+                                       [[maybe_unused]] void* param)
 {
 	proxyPluginsManager* mgr = nullptr;
 	auto event_data = static_cast<const proxyKeyboardEventInfo*>(param);
@@ -214,7 +242,9 @@ static BOOL demo_filter_keyboard_event(proxyPlugin* plugin, proxyData* pdata, vo
 	return TRUE;
 }
 
-static BOOL demo_filter_unicode_event(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL demo_filter_unicode_event([[maybe_unused]] proxyPlugin* plugin,
+                                      [[maybe_unused]] proxyData* pdata,
+                                      [[maybe_unused]] void* param)
 {
 	proxyPluginsManager* mgr = nullptr;
 	auto event_data = static_cast<const proxyUnicodeEventInfo*>(param);
@@ -239,7 +269,8 @@ static BOOL demo_filter_unicode_event(proxyPlugin* plugin, proxyData* pdata, voi
 	return TRUE;
 }
 
-static BOOL demo_mouse_event(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL demo_mouse_event([[maybe_unused]] proxyPlugin* plugin,
+                             [[maybe_unused]] proxyData* pdata, [[maybe_unused]] void* param)
 {
 	auto event_data = static_cast<const proxyMouseEventInfo*>(param);
 
@@ -251,7 +282,8 @@ static BOOL demo_mouse_event(proxyPlugin* plugin, proxyData* pdata, void* param)
 	return TRUE;
 }
 
-static BOOL demo_mouse_ex_event(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL demo_mouse_ex_event([[maybe_unused]] proxyPlugin* plugin,
+                                [[maybe_unused]] proxyData* pdata, [[maybe_unused]] void* param)
 {
 	auto event_data = static_cast<const proxyMouseExEventInfo*>(param);
 
@@ -263,7 +295,9 @@ static BOOL demo_mouse_ex_event(proxyPlugin* plugin, proxyData* pdata, void* par
 	return TRUE;
 }
 
-static BOOL demo_client_channel_data(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL demo_client_channel_data([[maybe_unused]] proxyPlugin* plugin,
+                                     [[maybe_unused]] proxyData* pdata,
+                                     [[maybe_unused]] void* param)
 {
 	const auto* channel = static_cast<const proxyChannelDataEventInfo*>(param);
 
@@ -276,7 +310,9 @@ static BOOL demo_client_channel_data(proxyPlugin* plugin, proxyData* pdata, void
 	return TRUE;
 }
 
-static BOOL demo_server_channel_data(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL demo_server_channel_data([[maybe_unused]] proxyPlugin* plugin,
+                                     [[maybe_unused]] proxyData* pdata,
+                                     [[maybe_unused]] void* param)
 {
 	const auto* channel = static_cast<const proxyChannelDataEventInfo*>(param);
 
@@ -289,7 +325,9 @@ static BOOL demo_server_channel_data(proxyPlugin* plugin, proxyData* pdata, void
 	return TRUE;
 }
 
-static BOOL demo_dynamic_channel_create(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL demo_dynamic_channel_create([[maybe_unused]] proxyPlugin* plugin,
+                                        [[maybe_unused]] proxyData* pdata,
+                                        [[maybe_unused]] void* param)
 {
 	const auto* channel = static_cast<const proxyChannelDataEventInfo*>(param);
 
@@ -301,7 +339,9 @@ static BOOL demo_dynamic_channel_create(proxyPlugin* plugin, proxyData* pdata, v
 	return TRUE;
 }
 
-static BOOL demo_server_fetch_target_addr(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL demo_server_fetch_target_addr([[maybe_unused]] proxyPlugin* plugin,
+                                          [[maybe_unused]] proxyData* pdata,
+                                          [[maybe_unused]] void* param)
 {
 	auto event_data = static_cast<const proxyFetchTargetEventInfo*>(param);
 
@@ -313,7 +353,8 @@ static BOOL demo_server_fetch_target_addr(proxyPlugin* plugin, proxyData* pdata,
 	return TRUE;
 }
 
-static BOOL demo_server_peer_logon(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL demo_server_peer_logon([[maybe_unused]] proxyPlugin* plugin,
+                                   [[maybe_unused]] proxyData* pdata, [[maybe_unused]] void* param)
 {
 	auto info = static_cast<const proxyServerPeerLogon*>(param);
 	WINPR_ASSERT(plugin);
@@ -325,7 +366,9 @@ static BOOL demo_server_peer_logon(proxyPlugin* plugin, proxyData* pdata, void* 
 	return TRUE;
 }
 
-static BOOL demo_dyn_channel_intercept_list(proxyPlugin* plugin, proxyData* pdata, void* arg)
+static BOOL demo_dyn_channel_intercept_list([[maybe_unused]] proxyPlugin* plugin,
+                                            [[maybe_unused]] proxyData* pdata,
+                                            [[maybe_unused]] void* arg)
 {
 	auto data = static_cast<proxyChannelToInterceptData*>(arg);
 
@@ -337,7 +380,9 @@ static BOOL demo_dyn_channel_intercept_list(proxyPlugin* plugin, proxyData* pdat
 	return TRUE;
 }
 
-static BOOL demo_static_channel_intercept_list(proxyPlugin* plugin, proxyData* pdata, void* arg)
+static BOOL demo_static_channel_intercept_list([[maybe_unused]] proxyPlugin* plugin,
+                                               [[maybe_unused]] proxyData* pdata,
+                                               [[maybe_unused]] void* arg)
 {
 	auto data = static_cast<proxyChannelToInterceptData*>(arg);
 
@@ -349,7 +394,9 @@ static BOOL demo_static_channel_intercept_list(proxyPlugin* plugin, proxyData* p
 	return TRUE;
 }
 
-static BOOL demo_dyn_channel_intercept(proxyPlugin* plugin, proxyData* pdata, void* arg)
+static BOOL demo_dyn_channel_intercept([[maybe_unused]] proxyPlugin* plugin,
+                                       [[maybe_unused]] proxyData* pdata,
+                                       [[maybe_unused]] void* arg)
 {
 	auto data = static_cast<proxyDynChannelInterceptData*>(arg);
 

--- a/server/proxy/modules/dyn-channel-dump/dyn-channel-dump.cpp
+++ b/server/proxy/modules/dyn-channel-dump/dyn-channel-dump.cpp
@@ -101,7 +101,7 @@ class ChannelData
 		_base /= str;
 	}
 
-	bool add(const std::string& name, bool back)
+	bool add(const std::string& name, WINPR_ATTR_UNUSED bool back)
 	{
 		std::lock_guard<std::mutex> guard(_mux);
 		if (_map.find(name) == _map.end())
@@ -285,7 +285,8 @@ static BOOL dump_dyn_channel_intercept_list(proxyPlugin* plugin, proxyData* pdat
 	return TRUE;
 }
 
-static BOOL dump_static_channel_intercept_list(proxyPlugin* plugin, proxyData* pdata, void* arg)
+static BOOL dump_static_channel_intercept_list([[maybe_unused]] proxyPlugin* plugin,
+                                               [[maybe_unused]] proxyData* pdata, void* arg)
 {
 	auto data = static_cast<proxyChannelToInterceptData*>(arg);
 

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -93,7 +93,7 @@ static void pf_client_on_error_info(void* ctx, const ErrorInfoEventArgs* e)
 	freerdp_send_error_info(ps->context.rdp);
 }
 
-static void pf_client_on_activated(void* ctx, const ActivatedEventArgs* e)
+static void pf_client_on_activated(void* ctx, WINPR_ATTR_UNUSED const ActivatedEventArgs* e)
 {
 	pClientContext* pc = (pClientContext*)ctx;
 	pServerContext* ps = NULL;
@@ -334,7 +334,7 @@ typedef struct
 	UINT32 backId;
 } UpdateBackIdArgs;
 
-static BOOL updateBackIdFn(const void* key, void* value, void* arg)
+static BOOL updateBackIdFn(WINPR_ATTR_UNUSED const void* key, void* value, void* arg)
 {
 	pServerStaticChannelContext* current = (pServerStaticChannelContext*)value;
 	UpdateBackIdArgs* updateArgs = (UpdateBackIdArgs*)arg;

--- a/server/proxy/pf_config.c
+++ b/server/proxy/pf_config.c
@@ -1027,7 +1027,8 @@ static BOOL config_plugin_unload(proxyPlugin* plugin)
 	return TRUE;
 }
 
-static BOOL config_plugin_keyboard_event(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL config_plugin_keyboard_event(proxyPlugin* plugin, WINPR_ATTR_UNUSED proxyData* pdata,
+                                         void* param)
 {
 	BOOL rc = 0;
 	const struct config_plugin_data* custom = NULL;
@@ -1051,7 +1052,8 @@ static BOOL config_plugin_keyboard_event(proxyPlugin* plugin, proxyData* pdata, 
 	return rc;
 }
 
-static BOOL config_plugin_unicode_event(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL config_plugin_unicode_event(proxyPlugin* plugin, WINPR_ATTR_UNUSED proxyData* pdata,
+                                        void* param)
 {
 	BOOL rc = 0;
 	const struct config_plugin_data* custom = NULL;
@@ -1075,7 +1077,8 @@ static BOOL config_plugin_unicode_event(proxyPlugin* plugin, proxyData* pdata, v
 	return rc;
 }
 
-static BOOL config_plugin_mouse_event(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL config_plugin_mouse_event(proxyPlugin* plugin, WINPR_ATTR_UNUSED proxyData* pdata,
+                                      void* param)
 {
 	BOOL rc = 0;
 	const struct config_plugin_data* custom = NULL;
@@ -1098,7 +1101,8 @@ static BOOL config_plugin_mouse_event(proxyPlugin* plugin, proxyData* pdata, voi
 	return rc;
 }
 
-static BOOL config_plugin_mouse_ex_event(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL config_plugin_mouse_ex_event(proxyPlugin* plugin, WINPR_ATTR_UNUSED proxyData* pdata,
+                                         void* param)
 {
 	BOOL rc = 0;
 	const struct config_plugin_data* custom = NULL;
@@ -1121,7 +1125,8 @@ static BOOL config_plugin_mouse_ex_event(proxyPlugin* plugin, proxyData* pdata, 
 	return rc;
 }
 
-static BOOL config_plugin_client_channel_data(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL config_plugin_client_channel_data(WINPR_ATTR_UNUSED proxyPlugin* plugin,
+                                              WINPR_ATTR_UNUSED proxyData* pdata, void* param)
 {
 	const proxyChannelDataEventInfo* channel = (const proxyChannelDataEventInfo*)(param);
 
@@ -1134,7 +1139,8 @@ static BOOL config_plugin_client_channel_data(proxyPlugin* plugin, proxyData* pd
 	return TRUE;
 }
 
-static BOOL config_plugin_server_channel_data(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL config_plugin_server_channel_data(WINPR_ATTR_UNUSED proxyPlugin* plugin,
+                                              WINPR_ATTR_UNUSED proxyData* pdata, void* param)
 {
 	const proxyChannelDataEventInfo* channel = (const proxyChannelDataEventInfo*)(param);
 
@@ -1147,7 +1153,8 @@ static BOOL config_plugin_server_channel_data(proxyPlugin* plugin, proxyData* pd
 	return TRUE;
 }
 
-static BOOL config_plugin_dynamic_channel_create(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL config_plugin_dynamic_channel_create(proxyPlugin* plugin,
+                                                 WINPR_ATTR_UNUSED proxyData* pdata, void* param)
 {
 	BOOL accept = 0;
 	const proxyChannelDataEventInfo* channel = (const proxyChannelDataEventInfo*)(param);
@@ -1212,7 +1219,8 @@ static BOOL config_plugin_dynamic_channel_create(proxyPlugin* plugin, proxyData*
 	return accept;
 }
 
-static BOOL config_plugin_channel_create(proxyPlugin* plugin, proxyData* pdata, void* param)
+static BOOL config_plugin_channel_create(proxyPlugin* plugin, WINPR_ATTR_UNUSED proxyData* pdata,
+                                         void* param)
 {
 	BOOL accept = 0;
 	const proxyChannelDataEventInfo* channel = (const proxyChannelDataEventInfo*)(param);

--- a/server/proxy/pf_modules.c
+++ b/server/proxy/pf_modules.c
@@ -332,8 +332,8 @@ BOOL pf_modules_run_filter(proxyModule* module, PF_FILTER_TYPE type, proxyData* 
  * @context: current session server's rdpContext instance.
  * @info: pointer to per-session data.
  */
-static BOOL pf_modules_set_plugin_data(proxyPluginsManager* mgr, const char* plugin_name,
-                                       proxyData* pdata, void* data)
+static BOOL pf_modules_set_plugin_data(WINPR_ATTR_UNUSED proxyPluginsManager* mgr,
+                                       const char* plugin_name, proxyData* pdata, void* data)
 {
 	union
 	{
@@ -363,8 +363,8 @@ static BOOL pf_modules_set_plugin_data(proxyPluginsManager* mgr, const char* plu
  * if there's no data related to `plugin_name` in `context` (current session), a NULL will be
  * returned.
  */
-static void* pf_modules_get_plugin_data(proxyPluginsManager* mgr, const char* plugin_name,
-                                        proxyData* pdata)
+static void* pf_modules_get_plugin_data(WINPR_ATTR_UNUSED proxyPluginsManager* mgr,
+                                        const char* plugin_name, proxyData* pdata)
 {
 	union
 	{
@@ -378,7 +378,7 @@ static void* pf_modules_get_plugin_data(proxyPluginsManager* mgr, const char* pl
 	return HashTable_GetItemValue(pdata->modules_info, ccharconv.cp);
 }
 
-static void pf_modules_abort_connect(proxyPluginsManager* mgr, proxyData* pdata)
+static void pf_modules_abort_connect(WINPR_ATTR_UNUSED proxyPluginsManager* mgr, proxyData* pdata)
 {
 	WINPR_ASSERT(pdata);
 	WLog_DBG(TAG, "is called!");

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -392,7 +392,7 @@ static BOOL pf_server_logon(freerdp_peer* peer, const SEC_WINNT_AUTH_IDENTITY* i
 	return TRUE;
 }
 
-static BOOL pf_server_adjust_monitor_layout(freerdp_peer* peer)
+static BOOL pf_server_adjust_monitor_layout(WINPR_ATTR_UNUSED freerdp_peer* peer)
 {
 	WINPR_ASSERT(peer);
 	/* proxy as is, there's no need to do anything here */

--- a/server/proxy/pf_utils.c
+++ b/server/proxy/pf_utils.c
@@ -70,7 +70,7 @@ end:
 	return rc;
 }
 
-BOOL pf_utils_is_passthrough(const proxyConfig* config)
+BOOL pf_utils_is_passthrough(WINPR_ATTR_UNUSED const proxyConfig* config)
 {
 	WINPR_ASSERT(config);
 

--- a/server/shadow/X11/x11_shadow.c
+++ b/server/shadow/X11/x11_shadow.c
@@ -196,8 +196,9 @@ static int x11_shadow_pam_authenticate(rdpShadowSubsystem* subsystem, rdpShadowC
 
 #endif
 
-static BOOL x11_shadow_input_synchronize_event(rdpShadowSubsystem* subsystem,
-                                               rdpShadowClient* client, UINT32 flags)
+static BOOL x11_shadow_input_synchronize_event(WINPR_ATTR_UNUSED rdpShadowSubsystem* subsystem,
+                                               WINPR_ATTR_UNUSED rdpShadowClient* client,
+                                               WINPR_ATTR_UNUSED UINT32 flags)
 {
 	/* TODO: Implement */
 	WLog_WARN(TAG, "not implemented");
@@ -250,9 +251,10 @@ static BOOL x11_shadow_input_keyboard_event(rdpShadowSubsystem* subsystem, rdpSh
 	return TRUE;
 }
 
-static BOOL x11_shadow_input_unicode_keyboard_event(rdpShadowSubsystem* subsystem,
-                                                    rdpShadowClient* client, UINT16 flags,
-                                                    UINT16 code)
+static BOOL x11_shadow_input_unicode_keyboard_event(WINPR_ATTR_UNUSED rdpShadowSubsystem* subsystem,
+                                                    WINPR_ATTR_UNUSED rdpShadowClient* client,
+                                                    WINPR_ATTR_UNUSED UINT16 flags,
+                                                    WINPR_ATTR_UNUSED UINT16 code)
 {
 	/* TODO: Implement */
 	WLog_WARN(TAG, "not implemented");

--- a/winpr/include/winpr/pool.h
+++ b/winpr/include/winpr/pool.h
@@ -254,7 +254,7 @@ extern "C"
 		pcbe->Version = 1;
 	}
 
-	static INLINE VOID DestroyThreadpoolEnvironment(PTP_CALLBACK_ENVIRON pcbe)
+	static INLINE VOID DestroyThreadpoolEnvironment(WINPR_ATTR_UNUSED PTP_CALLBACK_ENVIRON pcbe)
 	{
 		/* no actions, this may change in a future release. */
 	}

--- a/winpr/libwinpr/bcrypt/bcrypt.c
+++ b/winpr/libwinpr/bcrypt/bcrypt.c
@@ -18,6 +18,7 @@
  */
 
 #include <winpr/config.h>
+#include <winpr/wlog.h>
 
 #ifndef _WIN32
 #include <winpr/bcrypt.h>
@@ -27,87 +28,126 @@
  * http://msdn.microsoft.com/en-us/library/windows/desktop/aa376210/
  */
 
-NTSTATUS BCryptOpenAlgorithmProvider(BCRYPT_ALG_HANDLE* phAlgorithm, LPCWSTR pszAlgId,
-                                     LPCWSTR pszImplementation, ULONG dwFlags)
+NTSTATUS BCryptOpenAlgorithmProvider(WINPR_ATTR_UNUSED BCRYPT_ALG_HANDLE* phAlgorithm,
+                                     WINPR_ATTR_UNUSED LPCWSTR pszAlgId,
+                                     WINPR_ATTR_UNUSED LPCWSTR pszImplementation,
+                                     WINPR_ATTR_UNUSED ULONG dwFlags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 
-NTSTATUS BCryptCloseAlgorithmProvider(BCRYPT_ALG_HANDLE hAlgorithm, ULONG dwFlags)
+NTSTATUS BCryptCloseAlgorithmProvider(WINPR_ATTR_UNUSED BCRYPT_ALG_HANDLE hAlgorithm,
+                                      WINPR_ATTR_UNUSED ULONG dwFlags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 
-NTSTATUS BCryptGetProperty(BCRYPT_HANDLE hObject, LPCWSTR pszProperty, PUCHAR pbOutput,
-                           ULONG cbOutput, ULONG* pcbResult, ULONG dwFlags)
+NTSTATUS BCryptGetProperty(WINPR_ATTR_UNUSED BCRYPT_HANDLE hObject,
+                           WINPR_ATTR_UNUSED LPCWSTR pszProperty, WINPR_ATTR_UNUSED PUCHAR pbOutput,
+                           WINPR_ATTR_UNUSED ULONG cbOutput, WINPR_ATTR_UNUSED ULONG* pcbResult,
+                           WINPR_ATTR_UNUSED ULONG dwFlags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 
-NTSTATUS BCryptCreateHash(BCRYPT_ALG_HANDLE hAlgorithm, BCRYPT_HASH_HANDLE* phHash,
-                          PUCHAR pbHashObject, ULONG cbHashObject, PUCHAR pbSecret, ULONG cbSecret,
-                          ULONG dwFlags)
+NTSTATUS BCryptCreateHash(WINPR_ATTR_UNUSED BCRYPT_ALG_HANDLE hAlgorithm,
+                          WINPR_ATTR_UNUSED BCRYPT_HASH_HANDLE* phHash,
+                          WINPR_ATTR_UNUSED PUCHAR pbHashObject,
+                          WINPR_ATTR_UNUSED ULONG cbHashObject, WINPR_ATTR_UNUSED PUCHAR pbSecret,
+                          WINPR_ATTR_UNUSED ULONG cbSecret, WINPR_ATTR_UNUSED ULONG dwFlags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 
-NTSTATUS BCryptDestroyHash(BCRYPT_HASH_HANDLE hHash)
+NTSTATUS BCryptDestroyHash(WINPR_ATTR_UNUSED BCRYPT_HASH_HANDLE hHash)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 
-NTSTATUS BCryptHashData(BCRYPT_HASH_HANDLE hHash, PUCHAR pbInput, ULONG cbInput, ULONG dwFlags)
+NTSTATUS BCryptHashData(WINPR_ATTR_UNUSED BCRYPT_HASH_HANDLE hHash,
+                        WINPR_ATTR_UNUSED PUCHAR pbInput, WINPR_ATTR_UNUSED ULONG cbInput,
+                        WINPR_ATTR_UNUSED ULONG dwFlags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 
-NTSTATUS BCryptFinishHash(BCRYPT_HASH_HANDLE hHash, PUCHAR pbOutput, ULONG cbOutput, ULONG dwFlags)
+NTSTATUS BCryptFinishHash(WINPR_ATTR_UNUSED BCRYPT_HASH_HANDLE hHash,
+                          WINPR_ATTR_UNUSED PUCHAR pbOutput, WINPR_ATTR_UNUSED ULONG cbOutput,
+                          WINPR_ATTR_UNUSED ULONG dwFlags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 
-NTSTATUS BCryptGenRandom(BCRYPT_ALG_HANDLE hAlgorithm, PUCHAR pbBuffer, ULONG cbBuffer,
-                         ULONG dwFlags)
+NTSTATUS BCryptGenRandom(WINPR_ATTR_UNUSED BCRYPT_ALG_HANDLE hAlgorithm,
+                         WINPR_ATTR_UNUSED PUCHAR pbBuffer, WINPR_ATTR_UNUSED ULONG cbBuffer,
+                         WINPR_ATTR_UNUSED ULONG dwFlags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 
-NTSTATUS BCryptGenerateSymmetricKey(BCRYPT_ALG_HANDLE hAlgorithm, BCRYPT_KEY_HANDLE* phKey,
-                                    PUCHAR pbKeyObject, ULONG cbKeyObject, PUCHAR pbSecret,
-                                    ULONG cbSecret, ULONG dwFlags)
+NTSTATUS BCryptGenerateSymmetricKey(WINPR_ATTR_UNUSED BCRYPT_ALG_HANDLE hAlgorithm,
+                                    WINPR_ATTR_UNUSED BCRYPT_KEY_HANDLE* phKey,
+                                    WINPR_ATTR_UNUSED PUCHAR pbKeyObject,
+                                    WINPR_ATTR_UNUSED ULONG cbKeyObject,
+                                    WINPR_ATTR_UNUSED PUCHAR pbSecret,
+                                    WINPR_ATTR_UNUSED ULONG cbSecret,
+                                    WINPR_ATTR_UNUSED ULONG dwFlags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 
-NTSTATUS BCryptGenerateKeyPair(BCRYPT_ALG_HANDLE hAlgorithm, BCRYPT_KEY_HANDLE* phKey,
-                               ULONG dwLength, ULONG dwFlags)
+NTSTATUS BCryptGenerateKeyPair(WINPR_ATTR_UNUSED BCRYPT_ALG_HANDLE hAlgorithm,
+                               WINPR_ATTR_UNUSED BCRYPT_KEY_HANDLE* phKey,
+                               WINPR_ATTR_UNUSED ULONG dwLength, WINPR_ATTR_UNUSED ULONG dwFlags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 
-NTSTATUS BCryptImportKey(BCRYPT_ALG_HANDLE hAlgorithm, BCRYPT_KEY_HANDLE hImportKey,
-                         LPCWSTR pszBlobType, BCRYPT_KEY_HANDLE* phKey, PUCHAR pbKeyObject,
-                         ULONG cbKeyObject, PUCHAR pbInput, ULONG cbInput, ULONG dwFlags)
+NTSTATUS BCryptImportKey(WINPR_ATTR_UNUSED BCRYPT_ALG_HANDLE hAlgorithm,
+                         WINPR_ATTR_UNUSED BCRYPT_KEY_HANDLE hImportKey,
+                         WINPR_ATTR_UNUSED LPCWSTR pszBlobType,
+                         WINPR_ATTR_UNUSED BCRYPT_KEY_HANDLE* phKey,
+                         WINPR_ATTR_UNUSED PUCHAR pbKeyObject, WINPR_ATTR_UNUSED ULONG cbKeyObject,
+                         WINPR_ATTR_UNUSED PUCHAR pbInput, WINPR_ATTR_UNUSED ULONG cbInput,
+                         WINPR_ATTR_UNUSED ULONG dwFlags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 
-NTSTATUS BCryptDestroyKey(BCRYPT_KEY_HANDLE hKey)
+NTSTATUS BCryptDestroyKey(WINPR_ATTR_UNUSED BCRYPT_KEY_HANDLE hKey)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 
-NTSTATUS BCryptEncrypt(BCRYPT_KEY_HANDLE hKey, PUCHAR pbInput, ULONG cbInput, VOID* pPaddingInfo,
-                       PUCHAR pbIV, ULONG cbIV, PUCHAR pbOutput, ULONG cbOutput, ULONG* pcbResult,
-                       ULONG dwFlags)
+NTSTATUS BCryptEncrypt(WINPR_ATTR_UNUSED BCRYPT_KEY_HANDLE hKey, WINPR_ATTR_UNUSED PUCHAR pbInput,
+                       WINPR_ATTR_UNUSED ULONG cbInput, WINPR_ATTR_UNUSED VOID* pPaddingInfo,
+                       WINPR_ATTR_UNUSED PUCHAR pbIV, WINPR_ATTR_UNUSED ULONG cbIV,
+                       WINPR_ATTR_UNUSED PUCHAR pbOutput, WINPR_ATTR_UNUSED ULONG cbOutput,
+                       WINPR_ATTR_UNUSED ULONG* pcbResult, WINPR_ATTR_UNUSED ULONG dwFlags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 
-NTSTATUS BCryptDecrypt(BCRYPT_KEY_HANDLE hKey, PUCHAR pbInput, ULONG cbInput, VOID* pPaddingInfo,
-                       PUCHAR pbIV, ULONG cbIV, PUCHAR pbOutput, ULONG cbOutput, ULONG* pcbResult,
-                       ULONG dwFlags)
+NTSTATUS BCryptDecrypt(WINPR_ATTR_UNUSED BCRYPT_KEY_HANDLE hKey, WINPR_ATTR_UNUSED PUCHAR pbInput,
+                       WINPR_ATTR_UNUSED ULONG cbInput, WINPR_ATTR_UNUSED VOID* pPaddingInfo,
+                       WINPR_ATTR_UNUSED PUCHAR pbIV, WINPR_ATTR_UNUSED ULONG cbIV,
+                       WINPR_ATTR_UNUSED PUCHAR pbOutput, WINPR_ATTR_UNUSED ULONG cbOutput,
+                       WINPR_ATTR_UNUSED ULONG* pcbResult, WINPR_ATTR_UNUSED ULONG dwFlags)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 

--- a/winpr/libwinpr/clipboard/synthetic.c
+++ b/winpr/libwinpr/clipboard/synthetic.c
@@ -108,8 +108,10 @@ static void* clipboard_synthesize_cf_oemtext(wClipboard* clipboard, UINT32 forma
  * System locale identifier associated with CF_TEXT
  */
 
-static void* clipboard_synthesize_cf_locale(wClipboard* clipboard, UINT32 formatId,
-                                            const void* data, UINT32* pSize)
+static void* clipboard_synthesize_cf_locale(WINPR_ATTR_UNUSED wClipboard* clipboard,
+                                            WINPR_ATTR_UNUSED UINT32 formatId,
+                                            WINPR_ATTR_UNUSED const void* data,
+                                            WINPR_ATTR_UNUSED UINT32* pSize)
 {
 	UINT32* pDstData = NULL;
 	pDstData = (UINT32*)malloc(sizeof(UINT32));
@@ -263,8 +265,9 @@ static void* clipboard_synthesize_cf_dib(wClipboard* clipboard, UINT32 formatId,
  * BITMAPV5HEADER structure followed by the bitmap color space information and the bitmap bits.
  */
 
-static void* clipboard_synthesize_cf_dibv5(wClipboard* clipboard, UINT32 formatId, const void* data,
-                                           UINT32* pSize)
+static void* clipboard_synthesize_cf_dibv5(wClipboard* clipboard, UINT32 formatId,
+                                           WINPR_ATTR_UNUSED const void* data,
+                                           WINPR_ATTR_UNUSED UINT32* pSize)
 {
 	if (formatId == CF_DIB)
 	{
@@ -325,8 +328,8 @@ fail:
  * Bitmap file format.
  */
 
-static void* clipboard_synthesize_image_bmp(wClipboard* clipboard, UINT32 formatId,
-                                            const void* data, UINT32* pSize)
+static void* clipboard_synthesize_image_bmp(WINPR_ATTR_UNUSED wClipboard* clipboard,
+                                            UINT32 formatId, const void* data, UINT32* pSize)
 {
 	UINT32 SrcSize = *pSize;
 
@@ -402,7 +405,8 @@ static void* clipboard_synthesize_image_bmp_to_png(wClipboard* clipboard, UINT32
 	                                                pSize);
 }
 
-static void* clipboard_synthesize_image_format_to_bmp(wClipboard* clipboard, UINT32 srcFormatId,
+static void* clipboard_synthesize_image_format_to_bmp(wClipboard* clipboard,
+                                                      WINPR_ATTR_UNUSED UINT32 srcFormatId,
                                                       const void* data, UINT32* pSize)
 {
 	WINPR_ASSERT(clipboard);

--- a/winpr/libwinpr/clipboard/synthetic_file.c
+++ b/winpr/libwinpr/clipboard/synthetic_file.c
@@ -536,7 +536,8 @@ error:
 	return NULL;
 }
 
-static void* convert_any_uri_list_to_filedescriptors(wClipboard* clipboard, UINT32 formatId,
+static void* convert_any_uri_list_to_filedescriptors(wClipboard* clipboard,
+                                                     WINPR_ATTR_UNUSED UINT32 formatId,
                                                      UINT32* pSize)
 {
 	FILEDESCRIPTORW* descriptors = NULL;
@@ -1216,27 +1217,31 @@ static UINT delegate_file_request_range(wClipboardDelegate* delegate,
 	return NO_ERROR;
 }
 
-static UINT dummy_file_size_success(wClipboardDelegate* delegate,
-                                    const wClipboardFileSizeRequest* request, UINT64 fileSize)
+static UINT dummy_file_size_success(WINPR_ATTR_UNUSED wClipboardDelegate* delegate,
+                                    WINPR_ATTR_UNUSED const wClipboardFileSizeRequest* request,
+                                    WINPR_ATTR_UNUSED UINT64 fileSize)
 {
 	return ERROR_NOT_SUPPORTED;
 }
 
-static UINT dummy_file_size_failure(wClipboardDelegate* delegate,
-                                    const wClipboardFileSizeRequest* request, UINT errorCode)
+static UINT dummy_file_size_failure(WINPR_ATTR_UNUSED wClipboardDelegate* delegate,
+                                    WINPR_ATTR_UNUSED const wClipboardFileSizeRequest* request,
+                                    WINPR_ATTR_UNUSED UINT errorCode)
 {
 	return ERROR_NOT_SUPPORTED;
 }
 
-static UINT dummy_file_range_success(wClipboardDelegate* delegate,
-                                     const wClipboardFileRangeRequest* request, const BYTE* data,
-                                     UINT32 size)
+static UINT dummy_file_range_success(WINPR_ATTR_UNUSED wClipboardDelegate* delegate,
+                                     WINPR_ATTR_UNUSED const wClipboardFileRangeRequest* request,
+                                     WINPR_ATTR_UNUSED const BYTE* data,
+                                     WINPR_ATTR_UNUSED UINT32 size)
 {
 	return ERROR_NOT_SUPPORTED;
 }
 
-static UINT dummy_file_range_failure(wClipboardDelegate* delegate,
-                                     const wClipboardFileRangeRequest* request, UINT errorCode)
+static UINT dummy_file_range_failure(WINPR_ATTR_UNUSED wClipboardDelegate* delegate,
+                                     WINPR_ATTR_UNUSED const wClipboardFileRangeRequest* request,
+                                     WINPR_ATTR_UNUSED UINT errorCode)
 {
 	return ERROR_NOT_SUPPORTED;
 }

--- a/winpr/libwinpr/comm/comm.c
+++ b/winpr/libwinpr/comm/comm.c
@@ -206,7 +206,7 @@ void CommLog_Print(DWORD level, ...)
 	va_end(ap);
 }
 
-BOOL BuildCommDCBA(LPCSTR lpDef, LPDCB lpDCB)
+BOOL BuildCommDCBA(WINPR_ATTR_UNUSED LPCSTR lpDef, WINPR_ATTR_UNUSED LPDCB lpDCB)
 {
 	if (!CommInitialized())
 		return FALSE;
@@ -217,7 +217,7 @@ BOOL BuildCommDCBA(LPCSTR lpDef, LPDCB lpDCB)
 	return FALSE;
 }
 
-BOOL BuildCommDCBW(LPCWSTR lpDef, LPDCB lpDCB)
+BOOL BuildCommDCBW(WINPR_ATTR_UNUSED LPCWSTR lpDef, WINPR_ATTR_UNUSED LPDCB lpDCB)
 {
 	if (!CommInitialized())
 		return FALSE;
@@ -228,7 +228,8 @@ BOOL BuildCommDCBW(LPCWSTR lpDef, LPDCB lpDCB)
 	return FALSE;
 }
 
-BOOL BuildCommDCBAndTimeoutsA(LPCSTR lpDef, LPDCB lpDCB, LPCOMMTIMEOUTS lpCommTimeouts)
+BOOL BuildCommDCBAndTimeoutsA(WINPR_ATTR_UNUSED LPCSTR lpDef, WINPR_ATTR_UNUSED LPDCB lpDCB,
+                              WINPR_ATTR_UNUSED LPCOMMTIMEOUTS lpCommTimeouts)
 {
 	if (!CommInitialized())
 		return FALSE;
@@ -239,7 +240,8 @@ BOOL BuildCommDCBAndTimeoutsA(LPCSTR lpDef, LPDCB lpDCB, LPCOMMTIMEOUTS lpCommTi
 	return FALSE;
 }
 
-BOOL BuildCommDCBAndTimeoutsW(LPCWSTR lpDef, LPDCB lpDCB, LPCOMMTIMEOUTS lpCommTimeouts)
+BOOL BuildCommDCBAndTimeoutsW(WINPR_ATTR_UNUSED LPCWSTR lpDef, WINPR_ATTR_UNUSED LPDCB lpDCB,
+                              WINPR_ATTR_UNUSED LPCOMMTIMEOUTS lpCommTimeouts)
 {
 	if (!CommInitialized())
 		return FALSE;
@@ -250,7 +252,8 @@ BOOL BuildCommDCBAndTimeoutsW(LPCWSTR lpDef, LPDCB lpDCB, LPCOMMTIMEOUTS lpCommT
 	return FALSE;
 }
 
-BOOL CommConfigDialogA(LPCSTR lpszName, HWND hWnd, LPCOMMCONFIG lpCC)
+BOOL CommConfigDialogA(WINPR_ATTR_UNUSED LPCSTR lpszName, WINPR_ATTR_UNUSED HWND hWnd,
+                       WINPR_ATTR_UNUSED LPCOMMCONFIG lpCC)
 {
 	if (!CommInitialized())
 		return FALSE;
@@ -261,7 +264,8 @@ BOOL CommConfigDialogA(LPCSTR lpszName, HWND hWnd, LPCOMMCONFIG lpCC)
 	return FALSE;
 }
 
-BOOL CommConfigDialogW(LPCWSTR lpszName, HWND hWnd, LPCOMMCONFIG lpCC)
+BOOL CommConfigDialogW(WINPR_ATTR_UNUSED LPCWSTR lpszName, WINPR_ATTR_UNUSED HWND hWnd,
+                       WINPR_ATTR_UNUSED LPCOMMCONFIG lpCC)
 {
 	if (!CommInitialized())
 		return FALSE;
@@ -272,24 +276,8 @@ BOOL CommConfigDialogW(LPCWSTR lpszName, HWND hWnd, LPCOMMCONFIG lpCC)
 	return FALSE;
 }
 
-BOOL GetCommConfig(HANDLE hCommDev, LPCOMMCONFIG lpCC, LPDWORD lpdwSize)
-{
-	WINPR_COMM* pComm = (WINPR_COMM*)hCommDev;
-
-	if (!CommInitialized())
-		return FALSE;
-
-	/* TODO: not implemented */
-
-	if (!pComm)
-		return FALSE;
-
-	CommLog_Print(WLOG_ERROR, "Not implemented");
-	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
-	return FALSE;
-}
-
-BOOL SetCommConfig(HANDLE hCommDev, LPCOMMCONFIG lpCC, DWORD dwSize)
+BOOL GetCommConfig(HANDLE hCommDev, WINPR_ATTR_UNUSED LPCOMMCONFIG lpCC,
+                   WINPR_ATTR_UNUSED LPDWORD lpdwSize)
 {
 	WINPR_COMM* pComm = (WINPR_COMM*)hCommDev;
 
@@ -306,7 +294,25 @@ BOOL SetCommConfig(HANDLE hCommDev, LPCOMMCONFIG lpCC, DWORD dwSize)
 	return FALSE;
 }
 
-BOOL GetCommMask(HANDLE hFile, PDWORD lpEvtMask)
+BOOL SetCommConfig(HANDLE hCommDev, WINPR_ATTR_UNUSED LPCOMMCONFIG lpCC,
+                   WINPR_ATTR_UNUSED DWORD dwSize)
+{
+	WINPR_COMM* pComm = (WINPR_COMM*)hCommDev;
+
+	if (!CommInitialized())
+		return FALSE;
+
+	/* TODO: not implemented */
+
+	if (!pComm)
+		return FALSE;
+
+	CommLog_Print(WLOG_ERROR, "Not implemented");
+	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+	return FALSE;
+}
+
+BOOL GetCommMask(HANDLE hFile, WINPR_ATTR_UNUSED PDWORD lpEvtMask)
 {
 	WINPR_COMM* pComm = (WINPR_COMM*)hFile;
 
@@ -323,7 +329,7 @@ BOOL GetCommMask(HANDLE hFile, PDWORD lpEvtMask)
 	return FALSE;
 }
 
-BOOL SetCommMask(HANDLE hFile, DWORD dwEvtMask)
+BOOL SetCommMask(HANDLE hFile, WINPR_ATTR_UNUSED DWORD dwEvtMask)
 {
 	WINPR_COMM* pComm = (WINPR_COMM*)hFile;
 
@@ -340,7 +346,7 @@ BOOL SetCommMask(HANDLE hFile, DWORD dwEvtMask)
 	return FALSE;
 }
 
-BOOL GetCommModemStatus(HANDLE hFile, PDWORD lpModemStat)
+BOOL GetCommModemStatus(HANDLE hFile, WINPR_ATTR_UNUSED PDWORD lpModemStat)
 {
 	WINPR_COMM* pComm = (WINPR_COMM*)hFile;
 
@@ -807,7 +813,8 @@ BOOL SetCommTimeouts(HANDLE hFile, LPCOMMTIMEOUTS lpCommTimeouts)
 	return TRUE;
 }
 
-BOOL GetDefaultCommConfigA(LPCSTR lpszName, LPCOMMCONFIG lpCC, LPDWORD lpdwSize)
+BOOL GetDefaultCommConfigA(WINPR_ATTR_UNUSED LPCSTR lpszName, WINPR_ATTR_UNUSED LPCOMMCONFIG lpCC,
+                           WINPR_ATTR_UNUSED LPDWORD lpdwSize)
 {
 	if (!CommInitialized())
 		return FALSE;
@@ -818,7 +825,8 @@ BOOL GetDefaultCommConfigA(LPCSTR lpszName, LPCOMMCONFIG lpCC, LPDWORD lpdwSize)
 	return FALSE;
 }
 
-BOOL GetDefaultCommConfigW(LPCWSTR lpszName, LPCOMMCONFIG lpCC, LPDWORD lpdwSize)
+BOOL GetDefaultCommConfigW(WINPR_ATTR_UNUSED LPCWSTR lpszName, WINPR_ATTR_UNUSED LPCOMMCONFIG lpCC,
+                           WINPR_ATTR_UNUSED LPDWORD lpdwSize)
 {
 	if (!CommInitialized())
 		return FALSE;
@@ -829,7 +837,8 @@ BOOL GetDefaultCommConfigW(LPCWSTR lpszName, LPCOMMCONFIG lpCC, LPDWORD lpdwSize
 	return FALSE;
 }
 
-BOOL SetDefaultCommConfigA(LPCSTR lpszName, LPCOMMCONFIG lpCC, DWORD dwSize)
+BOOL SetDefaultCommConfigA(WINPR_ATTR_UNUSED LPCSTR lpszName, WINPR_ATTR_UNUSED LPCOMMCONFIG lpCC,
+                           WINPR_ATTR_UNUSED DWORD dwSize)
 {
 	if (!CommInitialized())
 		return FALSE;
@@ -840,7 +849,8 @@ BOOL SetDefaultCommConfigA(LPCSTR lpszName, LPCOMMCONFIG lpCC, DWORD dwSize)
 	return FALSE;
 }
 
-BOOL SetDefaultCommConfigW(LPCWSTR lpszName, LPCOMMCONFIG lpCC, DWORD dwSize)
+BOOL SetDefaultCommConfigW(WINPR_ATTR_UNUSED LPCWSTR lpszName, WINPR_ATTR_UNUSED LPCOMMCONFIG lpCC,
+                           WINPR_ATTR_UNUSED DWORD dwSize)
 {
 	if (!CommInitialized())
 		return FALSE;
@@ -885,7 +895,8 @@ BOOL ClearCommBreak(HANDLE hFile)
 	return FALSE;
 }
 
-BOOL ClearCommError(HANDLE hFile, PDWORD lpErrors, LPCOMSTAT lpStat)
+BOOL ClearCommError(HANDLE hFile, WINPR_ATTR_UNUSED PDWORD lpErrors,
+                    WINPR_ATTR_UNUSED LPCOMSTAT lpStat)
 {
 	WINPR_COMM* pComm = (WINPR_COMM*)hFile;
 
@@ -942,7 +953,7 @@ BOOL SetupComm(HANDLE hFile, DWORD dwInQueue, DWORD dwOutQueue)
 	return TRUE;
 }
 
-BOOL EscapeCommFunction(HANDLE hFile, DWORD dwFunc)
+BOOL EscapeCommFunction(HANDLE hFile, WINPR_ATTR_UNUSED DWORD dwFunc)
 {
 	WINPR_COMM* pComm = (WINPR_COMM*)hFile;
 
@@ -959,7 +970,7 @@ BOOL EscapeCommFunction(HANDLE hFile, DWORD dwFunc)
 	return FALSE;
 }
 
-BOOL TransmitCommChar(HANDLE hFile, char cChar)
+BOOL TransmitCommChar(HANDLE hFile, WINPR_ATTR_UNUSED char cChar)
 {
 	WINPR_COMM* pComm = (WINPR_COMM*)hFile;
 
@@ -976,7 +987,8 @@ BOOL TransmitCommChar(HANDLE hFile, char cChar)
 	return FALSE;
 }
 
-BOOL WaitCommEvent(HANDLE hFile, PDWORD lpEvtMask, LPOVERLAPPED lpOverlapped)
+BOOL WaitCommEvent(HANDLE hFile, WINPR_ATTR_UNUSED PDWORD lpEvtMask,
+                   WINPR_ATTR_UNUSED LPOVERLAPPED lpOverlapped)
 {
 	WINPR_COMM* pComm = (WINPR_COMM*)hFile;
 

--- a/winpr/libwinpr/comm/comm_sercx2_sys.c
+++ b/winpr/libwinpr/comm/comm_sercx2_sys.c
@@ -39,7 +39,8 @@
  * request with a STATUS_SUCCESS status code.
  */
 
-static BOOL set_serial_chars(WINPR_COMM* pComm, const SERIAL_CHARS* pSerialChars)
+static BOOL set_serial_chars(WINPR_ATTR_UNUSED WINPR_COMM* pComm,
+                             WINPR_ATTR_UNUSED const SERIAL_CHARS* pSerialChars)
 {
 	WINPR_ASSERT(pComm);
 	WINPR_ASSERT(pSerialChars);
@@ -47,7 +48,7 @@ static BOOL set_serial_chars(WINPR_COMM* pComm, const SERIAL_CHARS* pSerialChars
 	return TRUE;
 }
 
-static BOOL get_serial_chars(WINPR_COMM* pComm, SERIAL_CHARS* pSerialChars)
+static BOOL get_serial_chars(WINPR_ATTR_UNUSED WINPR_COMM* pComm, SERIAL_CHARS* pSerialChars)
 {
 	WINPR_ASSERT(pComm);
 	WINPR_ASSERT(pSerialChars);

--- a/winpr/libwinpr/comm/comm_serial_sys.c
+++ b/winpr/libwinpr/comm/comm_serial_sys.c
@@ -154,7 +154,7 @@ static const speed_t BAUD_TABLE[][3] = {
 
 static BOOL commstatus_error(WINPR_COMM* pComm, const char* ctrl);
 
-static BOOL get_properties(WINPR_COMM* pComm, COMMPROP* pProperties)
+static BOOL get_properties(WINPR_ATTR_UNUSED WINPR_COMM* pComm, COMMPROP* pProperties)
 {
 	WINPR_ASSERT(pComm);
 	/* http://msdn.microsoft.com/en-us/library/windows/hardware/jj680684%28v=vs.85%29.aspx
@@ -1128,7 +1128,7 @@ static BOOL get_wait_mask(WINPR_COMM* pComm, ULONG* pWaitMask)
 	return TRUE;
 }
 
-static BOOL set_queue_size(WINPR_COMM* pComm, const SERIAL_QUEUE_SIZE* pQueueSize)
+static BOOL set_queue_size(WINPR_ATTR_UNUSED WINPR_COMM* pComm, const SERIAL_QUEUE_SIZE* pQueueSize)
 {
 	WINPR_ASSERT(pComm);
 	WINPR_ASSERT(pQueueSize);
@@ -1606,7 +1606,7 @@ static BOOL get_dtrrts(WINPR_COMM* pComm, ULONG* pMask)
 	return TRUE;
 }
 
-static BOOL config_size(WINPR_COMM* pComm, ULONG* pSize)
+static BOOL config_size(WINPR_ATTR_UNUSED WINPR_COMM* pComm, ULONG* pSize)
 {
 	WINPR_ASSERT(pComm);
 	WINPR_ASSERT(pSize);
@@ -1640,7 +1640,7 @@ static BOOL immediate_char(WINPR_COMM* pComm, const UCHAR* pChar)
 	return result;
 }
 
-static BOOL reset_device(WINPR_COMM* pComm)
+static BOOL reset_device(WINPR_ATTR_UNUSED WINPR_COMM* pComm)
 {
 	/* http://msdn.microsoft.com/en-us/library/dn265347%28v=vs.85%29.aspx */
 	return TRUE;

--- a/winpr/libwinpr/crt/alignment.c
+++ b/winpr/libwinpr/crt/alignment.c
@@ -221,7 +221,8 @@ fail:
 	return newMemblock;
 }
 
-size_t winpr_aligned_msize(void* memblock, size_t alignment, size_t offset)
+size_t winpr_aligned_msize(void* memblock, WINPR_ATTR_UNUSED size_t alignment,
+                           WINPR_ATTR_UNUSED size_t offset)
 {
 	WINPR_ALIGNED_MEM* pMem = NULL;
 

--- a/winpr/libwinpr/crt/conversion.c
+++ b/winpr/libwinpr/crt/conversion.c
@@ -26,7 +26,7 @@
 
 #ifndef _WIN32
 
-errno_t _itoa_s(int value, char* buffer, size_t sizeInCharacters, int radix)
+errno_t _itoa_s(int value, char* buffer, size_t sizeInCharacters, WINPR_ATTR_UNUSED int radix)
 {
 	int length = sprintf_s(NULL, 0, "%d", value);
 

--- a/winpr/libwinpr/crt/unicode_icu.c
+++ b/winpr/libwinpr/crt/unicode_icu.c
@@ -143,9 +143,10 @@ int int_MultiByteToWideChar(UINT CodePage, DWORD dwFlags, LPCSTR lpMultiByteStr,
 	return cchWideChar;
 }
 
-int int_WideCharToMultiByte(UINT CodePage, DWORD dwFlags, LPCWSTR lpWideCharStr, int cchWideChar,
-                            LPSTR lpMultiByteStr, int cbMultiByte, LPCSTR lpDefaultChar,
-                            LPBOOL lpUsedDefaultChar)
+int int_WideCharToMultiByte(UINT CodePage, WINPR_ATTR_UNUSED DWORD dwFlags, LPCWSTR lpWideCharStr,
+                            int cchWideChar, LPSTR lpMultiByteStr, int cbMultiByte,
+                            WINPR_ATTR_UNUSED LPCSTR lpDefaultChar,
+                            WINPR_ATTR_UNUSED LPBOOL lpUsedDefaultChar)
 {
 	/* If cchWideChar is 0, the function fails */
 

--- a/winpr/libwinpr/crypto/cert.c
+++ b/winpr/libwinpr/crypto/cert.c
@@ -149,6 +149,7 @@
  */
 
 #include <winpr/crt.h>
+#include <winpr/wlog.h>
 #include <winpr/wincrypt.h>
 
 #ifndef _WIN32
@@ -156,7 +157,8 @@
 #include "crypto.h"
 
 HCERTSTORE CertOpenStore(LPCSTR lpszStoreProvider, DWORD dwMsgAndCertEncodingType,
-                         HCRYPTPROV_LEGACY hCryptProv, DWORD dwFlags, const void* pvPara)
+                         WINPR_ATTR_UNUSED HCRYPTPROV_LEGACY hCryptProv,
+                         WINPR_ATTR_UNUSED DWORD dwFlags, WINPR_ATTR_UNUSED const void* pvPara)
 {
 	WINPR_CERTSTORE* certstore = NULL;
 
@@ -171,7 +173,8 @@ HCERTSTORE CertOpenStore(LPCSTR lpszStoreProvider, DWORD dwMsgAndCertEncodingTyp
 	return (HCERTSTORE)certstore;
 }
 
-HCERTSTORE CertOpenSystemStoreW(HCRYPTPROV_LEGACY hProv, LPCWSTR szSubsystemProtocol)
+HCERTSTORE CertOpenSystemStoreW(HCRYPTPROV_LEGACY hProv,
+                                WINPR_ATTR_UNUSED LPCWSTR szSubsystemProtocol)
 {
 	HCERTSTORE hCertStore = NULL;
 
@@ -180,12 +183,13 @@ HCERTSTORE CertOpenSystemStoreW(HCRYPTPROV_LEGACY hProv, LPCWSTR szSubsystemProt
 	return hCertStore;
 }
 
-HCERTSTORE CertOpenSystemStoreA(HCRYPTPROV_LEGACY hProv, LPCSTR szSubsystemProtocol)
+HCERTSTORE CertOpenSystemStoreA(HCRYPTPROV_LEGACY hProv,
+                                WINPR_ATTR_UNUSED LPCSTR szSubsystemProtocol)
 {
 	return CertOpenSystemStoreW(hProv, NULL);
 }
 
-BOOL CertCloseStore(HCERTSTORE hCertStore, DWORD dwFlags)
+BOOL CertCloseStore(HCERTSTORE hCertStore, WINPR_ATTR_UNUSED DWORD dwFlags)
 {
 	WINPR_CERTSTORE* certstore = NULL;
 
@@ -196,27 +200,39 @@ BOOL CertCloseStore(HCERTSTORE hCertStore, DWORD dwFlags)
 	return TRUE;
 }
 
-PCCERT_CONTEXT CertFindCertificateInStore(HCERTSTORE hCertStore, DWORD dwCertEncodingType,
-                                          DWORD dwFindFlags, DWORD dwFindType,
-                                          const void* pvFindPara, PCCERT_CONTEXT pPrevCertContext)
+PCCERT_CONTEXT CertFindCertificateInStore(WINPR_ATTR_UNUSED HCERTSTORE hCertStore,
+                                          WINPR_ATTR_UNUSED DWORD dwCertEncodingType,
+                                          WINPR_ATTR_UNUSED DWORD dwFindFlags,
+                                          WINPR_ATTR_UNUSED DWORD dwFindType,
+                                          WINPR_ATTR_UNUSED const void* pvFindPara,
+                                          WINPR_ATTR_UNUSED PCCERT_CONTEXT pPrevCertContext)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return (PCCERT_CONTEXT)1;
 }
 
-PCCERT_CONTEXT CertEnumCertificatesInStore(HCERTSTORE hCertStore, PCCERT_CONTEXT pPrevCertContext)
+PCCERT_CONTEXT CertEnumCertificatesInStore(WINPR_ATTR_UNUSED HCERTSTORE hCertStore,
+                                           WINPR_ATTR_UNUSED PCCERT_CONTEXT pPrevCertContext)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return (PCCERT_CONTEXT)NULL;
 }
 
-DWORD CertGetNameStringW(PCCERT_CONTEXT pCertContext, DWORD dwType, DWORD dwFlags, void* pvTypePara,
-                         LPWSTR pszNameString, DWORD cchNameString)
+DWORD CertGetNameStringW(WINPR_ATTR_UNUSED PCCERT_CONTEXT pCertContext,
+                         WINPR_ATTR_UNUSED DWORD dwType, WINPR_ATTR_UNUSED DWORD dwFlags,
+                         WINPR_ATTR_UNUSED void* pvTypePara, WINPR_ATTR_UNUSED LPWSTR pszNameString,
+                         WINPR_ATTR_UNUSED DWORD cchNameString)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return 0;
 }
 
-DWORD CertGetNameStringA(PCCERT_CONTEXT pCertContext, DWORD dwType, DWORD dwFlags, void* pvTypePara,
-                         LPSTR pszNameString, DWORD cchNameString)
+DWORD CertGetNameStringA(WINPR_ATTR_UNUSED PCCERT_CONTEXT pCertContext,
+                         WINPR_ATTR_UNUSED DWORD dwType, WINPR_ATTR_UNUSED DWORD dwFlags,
+                         WINPR_ATTR_UNUSED void* pvTypePara, WINPR_ATTR_UNUSED LPSTR pszNameString,
+                         WINPR_ATTR_UNUSED DWORD cchNameString)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return 0;
 }
 

--- a/winpr/libwinpr/crypto/cipher.c
+++ b/winpr/libwinpr/crypto/cipher.c
@@ -581,8 +581,8 @@ WINPR_CIPHER_CTX* winpr_Cipher_New(WINPR_CIPHER_TYPE cipher, WINPR_CRYPTO_OPERAT
 }
 
 WINPR_API WINPR_CIPHER_CTX* winpr_Cipher_NewEx(WINPR_CIPHER_TYPE cipher, WINPR_CRYPTO_OPERATION op,
-                                               const void* key, size_t keylen, const void* iv,
-                                               size_t ivlen)
+                                               const void* key, WINPR_ATTR_UNUSED size_t keylen,
+                                               const void* iv, WINPR_ATTR_UNUSED size_t ivlen)
 {
 	if (cipher == WINPR_CIPHER_ARC4_128)
 	{

--- a/winpr/libwinpr/crypto/crypto.c
+++ b/winpr/libwinpr/crypto/crypto.c
@@ -18,7 +18,7 @@
  */
 
 #include <winpr/config.h>
-
+#include <winpr/wlog.h>
 #include <winpr/crypto.h>
 
 /**
@@ -208,7 +208,7 @@ out:
 	return FALSE;
 }
 
-BOOL CryptUnprotectMemory(LPVOID pData, DWORD cbData, DWORD dwFlags)
+BOOL CryptUnprotectMemory(LPVOID pData, WINPR_ATTR_UNUSED DWORD cbData, DWORD dwFlags)
 {
 	BYTE* pPlainText = NULL;
 	size_t cbOut = 0;
@@ -262,41 +262,58 @@ out:
 	return FALSE;
 }
 
-BOOL CryptProtectData(DATA_BLOB* pDataIn, LPCWSTR szDataDescr, DATA_BLOB* pOptionalEntropy,
-                      PVOID pvReserved, CRYPTPROTECT_PROMPTSTRUCT* pPromptStruct, DWORD dwFlags,
-                      DATA_BLOB* pDataOut)
+BOOL CryptProtectData(WINPR_ATTR_UNUSED DATA_BLOB* pDataIn, WINPR_ATTR_UNUSED LPCWSTR szDataDescr,
+                      WINPR_ATTR_UNUSED DATA_BLOB* pOptionalEntropy,
+                      WINPR_ATTR_UNUSED PVOID pvReserved,
+                      WINPR_ATTR_UNUSED CRYPTPROTECT_PROMPTSTRUCT* pPromptStruct,
+                      WINPR_ATTR_UNUSED DWORD dwFlags, WINPR_ATTR_UNUSED DATA_BLOB* pDataOut)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL CryptUnprotectData(DATA_BLOB* pDataIn, LPWSTR* ppszDataDescr, DATA_BLOB* pOptionalEntropy,
-                        PVOID pvReserved, CRYPTPROTECT_PROMPTSTRUCT* pPromptStruct, DWORD dwFlags,
-                        DATA_BLOB* pDataOut)
+BOOL CryptUnprotectData(WINPR_ATTR_UNUSED DATA_BLOB* pDataIn,
+                        WINPR_ATTR_UNUSED LPWSTR* ppszDataDescr,
+                        WINPR_ATTR_UNUSED DATA_BLOB* pOptionalEntropy,
+                        WINPR_ATTR_UNUSED PVOID pvReserved,
+                        WINPR_ATTR_UNUSED CRYPTPROTECT_PROMPTSTRUCT* pPromptStruct,
+                        WINPR_ATTR_UNUSED DWORD dwFlags, WINPR_ATTR_UNUSED DATA_BLOB* pDataOut)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL CryptStringToBinaryW(LPCWSTR pszString, DWORD cchString, DWORD dwFlags, BYTE* pbBinary,
-                          DWORD* pcbBinary, DWORD* pdwSkip, DWORD* pdwFlags)
+BOOL CryptStringToBinaryW(WINPR_ATTR_UNUSED LPCWSTR pszString, WINPR_ATTR_UNUSED DWORD cchString,
+                          WINPR_ATTR_UNUSED DWORD dwFlags, WINPR_ATTR_UNUSED BYTE* pbBinary,
+                          WINPR_ATTR_UNUSED DWORD* pcbBinary, WINPR_ATTR_UNUSED DWORD* pdwSkip,
+                          WINPR_ATTR_UNUSED DWORD* pdwFlags)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL CryptStringToBinaryA(LPCSTR pszString, DWORD cchString, DWORD dwFlags, BYTE* pbBinary,
-                          DWORD* pcbBinary, DWORD* pdwSkip, DWORD* pdwFlags)
+BOOL CryptStringToBinaryA(WINPR_ATTR_UNUSED LPCSTR pszString, WINPR_ATTR_UNUSED DWORD cchString,
+                          WINPR_ATTR_UNUSED DWORD dwFlags, WINPR_ATTR_UNUSED BYTE* pbBinary,
+                          WINPR_ATTR_UNUSED DWORD* pcbBinary, WINPR_ATTR_UNUSED DWORD* pdwSkip,
+                          WINPR_ATTR_UNUSED DWORD* pdwFlags)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL CryptBinaryToStringW(CONST BYTE* pbBinary, DWORD cbBinary, DWORD dwFlags, LPWSTR pszString,
-                          DWORD* pcchString)
+BOOL CryptBinaryToStringW(WINPR_ATTR_UNUSED CONST BYTE* pbBinary, WINPR_ATTR_UNUSED DWORD cbBinary,
+                          WINPR_ATTR_UNUSED DWORD dwFlags, WINPR_ATTR_UNUSED LPWSTR pszString,
+                          WINPR_ATTR_UNUSED DWORD* pcchString)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL CryptBinaryToStringA(CONST BYTE* pbBinary, DWORD cbBinary, DWORD dwFlags, LPSTR pszString,
-                          DWORD* pcchString)
+BOOL CryptBinaryToStringA(WINPR_ATTR_UNUSED CONST BYTE* pbBinary, WINPR_ATTR_UNUSED DWORD cbBinary,
+                          WINPR_ATTR_UNUSED DWORD dwFlags, WINPR_ATTR_UNUSED LPSTR pszString,
+                          WINPR_ATTR_UNUSED DWORD* pcchString)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 

--- a/winpr/libwinpr/crypto/hash.c
+++ b/winpr/libwinpr/crypto/hash.c
@@ -631,7 +631,7 @@ BOOL winpr_Digest_Update(WINPR_DIGEST_CTX* ctx, const void* input, size_t ilen)
 	return TRUE;
 }
 
-BOOL winpr_Digest_Final(WINPR_DIGEST_CTX* ctx, void* output, size_t olen)
+BOOL winpr_Digest_Final(WINPR_DIGEST_CTX* ctx, void* output, WINPR_ATTR_UNUSED size_t olen)
 {
 	WINPR_ASSERT(ctx);
 

--- a/winpr/libwinpr/environment/environment.c
+++ b/winpr/libwinpr/environment/environment.c
@@ -26,6 +26,7 @@
 #include <winpr/error.h>
 #include <winpr/file.h>
 #include <winpr/string.h>
+#include <winpr/wlog.h>
 
 #include <winpr/environment.h>
 
@@ -97,50 +98,61 @@ DWORD GetCurrentDirectoryA(DWORD nBufferLength, LPSTR lpBuffer)
 	}
 }
 
-DWORD GetCurrentDirectoryW(DWORD nBufferLength, LPWSTR lpBuffer)
+DWORD GetCurrentDirectoryW(WINPR_ATTR_UNUSED DWORD nBufferLength, WINPR_ATTR_UNUSED LPWSTR lpBuffer)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	return 0;
 }
 
-BOOL SetCurrentDirectoryA(LPCSTR lpPathName)
+BOOL SetCurrentDirectoryA(WINPR_ATTR_UNUSED LPCSTR lpPathName)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	return TRUE;
 }
 
-BOOL SetCurrentDirectoryW(LPCWSTR lpPathName)
+BOOL SetCurrentDirectoryW(WINPR_ATTR_UNUSED LPCWSTR lpPathName)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	return TRUE;
 }
 
-DWORD SearchPathA(LPCSTR lpPath, LPCSTR lpFileName, LPCSTR lpExtension, DWORD nBufferLength,
-                  LPSTR lpBuffer, LPSTR* lpFilePart)
+DWORD SearchPathA(WINPR_ATTR_UNUSED LPCSTR lpPath, WINPR_ATTR_UNUSED LPCSTR lpFileName,
+                  WINPR_ATTR_UNUSED LPCSTR lpExtension, WINPR_ATTR_UNUSED DWORD nBufferLength,
+                  WINPR_ATTR_UNUSED LPSTR lpBuffer, WINPR_ATTR_UNUSED LPSTR* lpFilePart)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	return 0;
 }
 
-DWORD SearchPathW(LPCWSTR lpPath, LPCWSTR lpFileName, LPCWSTR lpExtension, DWORD nBufferLength,
-                  LPWSTR lpBuffer, LPWSTR* lpFilePart)
+DWORD SearchPathW(WINPR_ATTR_UNUSED LPCWSTR lpPath, WINPR_ATTR_UNUSED LPCWSTR lpFileName,
+                  WINPR_ATTR_UNUSED LPCWSTR lpExtension, WINPR_ATTR_UNUSED DWORD nBufferLength,
+                  WINPR_ATTR_UNUSED LPWSTR lpBuffer, WINPR_ATTR_UNUSED LPWSTR* lpFilePart)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	return 0;
 }
 
 LPSTR GetCommandLineA(VOID)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	return NULL;
 }
 
 LPWSTR GetCommandLineW(VOID)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	return NULL;
 }
 
-BOOL NeedCurrentDirectoryForExePathA(LPCSTR ExeName)
+BOOL NeedCurrentDirectoryForExePathA(WINPR_ATTR_UNUSED LPCSTR ExeName)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	return TRUE;
 }
 
-BOOL NeedCurrentDirectoryForExePathW(LPCWSTR ExeName)
+BOOL NeedCurrentDirectoryForExePathW(WINPR_ATTR_UNUSED LPCWSTR ExeName)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	return TRUE;
 }
 
@@ -177,8 +189,10 @@ DWORD GetEnvironmentVariableA(LPCSTR lpName, LPSTR lpBuffer, DWORD nSize)
 #endif
 }
 
-DWORD GetEnvironmentVariableW(LPCWSTR lpName, LPWSTR lpBuffer, DWORD nSize)
+DWORD GetEnvironmentVariableW(WINPR_ATTR_UNUSED LPCWSTR lpName, WINPR_ATTR_UNUSED LPWSTR lpBuffer,
+                              WINPR_ATTR_UNUSED DWORD nSize)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	SetLastError(ERROR_ENVVAR_NOT_FOUND);
 	return 0;
 }
@@ -208,8 +222,9 @@ BOOL SetEnvironmentVariableA(LPCSTR lpName, LPCSTR lpValue)
 #endif
 }
 
-BOOL SetEnvironmentVariableW(LPCWSTR lpName, LPCWSTR lpValue)
+BOOL SetEnvironmentVariableW(WINPR_ATTR_UNUSED LPCWSTR lpName, WINPR_ATTR_UNUSED LPCWSTR lpValue)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	return FALSE;
 }
 
@@ -289,26 +304,33 @@ LPCH GetEnvironmentStringsA(VOID)
 
 LPWCH GetEnvironmentStringsW(VOID)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	return NULL;
 }
 
-BOOL SetEnvironmentStringsA(LPCH NewEnvironment)
+BOOL SetEnvironmentStringsA(WINPR_ATTR_UNUSED LPCH NewEnvironment)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	return TRUE;
 }
 
-BOOL SetEnvironmentStringsW(LPWCH NewEnvironment)
+BOOL SetEnvironmentStringsW(WINPR_ATTR_UNUSED LPWCH NewEnvironment)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	return TRUE;
 }
 
-DWORD ExpandEnvironmentStringsA(LPCSTR lpSrc, LPSTR lpDst, DWORD nSize)
+DWORD ExpandEnvironmentStringsA(WINPR_ATTR_UNUSED LPCSTR lpSrc, WINPR_ATTR_UNUSED LPSTR lpDst,
+                                WINPR_ATTR_UNUSED DWORD nSize)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	return 0;
 }
 
-DWORD ExpandEnvironmentStringsW(LPCWSTR lpSrc, LPWSTR lpDst, DWORD nSize)
+DWORD ExpandEnvironmentStringsW(WINPR_ATTR_UNUSED LPCWSTR lpSrc, WINPR_ATTR_UNUSED LPWSTR lpDst,
+                                WINPR_ATTR_UNUSED DWORD nSize)
 {
+	WLog_ERR("TODO", "TODO: not implemented");
 	return 0;
 }
 

--- a/winpr/libwinpr/error/error.c
+++ b/winpr/libwinpr/error/error.c
@@ -20,6 +20,7 @@
 #include <winpr/config.h>
 
 #include <winpr/error.h>
+#include <winpr/wlog.h>
 
 #ifndef _WIN32
 
@@ -29,11 +30,13 @@
 
 UINT GetErrorMode(void)
 {
+	WLog_ERR("TODO", "TOdO: implement");
 	return 0;
 }
 
-UINT SetErrorMode(UINT uMode)
+UINT SetErrorMode(WINPR_ATTR_UNUSED UINT uMode)
 {
+	WLog_ERR("TODO", "TOdO: implement");
 	return 0;
 }
 
@@ -56,43 +59,56 @@ VOID SetLastError(DWORD dwErrCode)
 	}
 }
 
-VOID RestoreLastError(DWORD dwErrCode)
+VOID RestoreLastError(WINPR_ATTR_UNUSED DWORD dwErrCode)
 {
+	WLog_ERR("TODO", "TOdO: implement");
 }
 
-VOID RaiseException(DWORD dwExceptionCode, DWORD dwExceptionFlags, DWORD nNumberOfArguments,
-                    CONST ULONG_PTR* lpArguments)
+VOID RaiseException(WINPR_ATTR_UNUSED DWORD dwExceptionCode,
+                    WINPR_ATTR_UNUSED DWORD dwExceptionFlags,
+                    WINPR_ATTR_UNUSED DWORD nNumberOfArguments,
+                    WINPR_ATTR_UNUSED CONST ULONG_PTR* lpArguments)
 {
+	WLog_ERR("TODO", "TOdO: implement");
 }
 
-LONG UnhandledExceptionFilter(PEXCEPTION_POINTERS ExceptionInfo)
+LONG UnhandledExceptionFilter(WINPR_ATTR_UNUSED PEXCEPTION_POINTERS ExceptionInfo)
 {
+	WLog_ERR("TODO", "TOdO: implement");
 	return 0;
 }
 
 LPTOP_LEVEL_EXCEPTION_FILTER
-SetUnhandledExceptionFilter(LPTOP_LEVEL_EXCEPTION_FILTER lpTopLevelExceptionFilter)
+SetUnhandledExceptionFilter(
+    WINPR_ATTR_UNUSED LPTOP_LEVEL_EXCEPTION_FILTER lpTopLevelExceptionFilter)
 {
+	WLog_ERR("TODO", "TOdO: implement");
 	return NULL;
 }
 
-PVOID AddVectoredExceptionHandler(ULONG First, PVECTORED_EXCEPTION_HANDLER Handler)
+PVOID AddVectoredExceptionHandler(WINPR_ATTR_UNUSED ULONG First,
+                                  WINPR_ATTR_UNUSED PVECTORED_EXCEPTION_HANDLER Handler)
 {
+	WLog_ERR("TODO", "TOdO: implement");
 	return NULL;
 }
 
-ULONG RemoveVectoredExceptionHandler(PVOID Handle)
+ULONG RemoveVectoredExceptionHandler(WINPR_ATTR_UNUSED PVOID Handle)
 {
+	WLog_ERR("TODO", "TOdO: implement");
 	return 0;
 }
 
-PVOID AddVectoredContinueHandler(ULONG First, PVECTORED_EXCEPTION_HANDLER Handler)
+PVOID AddVectoredContinueHandler(WINPR_ATTR_UNUSED ULONG First,
+                                 WINPR_ATTR_UNUSED PVECTORED_EXCEPTION_HANDLER Handler)
 {
+	WLog_ERR("TODO", "TOdO: implement");
 	return NULL;
 }
 
-ULONG RemoveVectoredContinueHandler(PVOID Handle)
+ULONG RemoveVectoredContinueHandler(WINPR_ATTR_UNUSED PVOID Handle)
 {
+	WLog_ERR("TODO", "TOdO: implement");
 	return 0;
 }
 

--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -390,8 +390,9 @@ static BOOL FileGetFileInformationByHandle(HANDLE hFile,
 	return TRUE;
 }
 
-static BOOL FileLockFileEx(HANDLE hFile, DWORD dwFlags, DWORD dwReserved,
-                           DWORD nNumberOfBytesToLockLow, DWORD nNumberOfBytesToLockHigh,
+static BOOL FileLockFileEx(HANDLE hFile, DWORD dwFlags, WINPR_ATTR_UNUSED DWORD dwReserved,
+                           WINPR_ATTR_UNUSED DWORD nNumberOfBytesToLockLow,
+                           WINPR_ATTR_UNUSED DWORD nNumberOfBytesToLockHigh,
                            LPOVERLAPPED lpOverlapped)
 {
 #ifdef __sun
@@ -463,8 +464,10 @@ static BOOL FileLockFileEx(HANDLE hFile, DWORD dwFlags, DWORD dwReserved,
 	return TRUE;
 }
 
-static BOOL FileUnlockFile(HANDLE hFile, DWORD dwFileOffsetLow, DWORD dwFileOffsetHigh,
-                           DWORD nNumberOfBytesToUnlockLow, DWORD nNumberOfBytesToUnlockHigh)
+static BOOL FileUnlockFile(HANDLE hFile, WINPR_ATTR_UNUSED DWORD dwFileOffsetLow,
+                           WINPR_ATTR_UNUSED DWORD dwFileOffsetHigh,
+                           WINPR_ATTR_UNUSED DWORD nNumberOfBytesToUnlockLow,
+                           WINPR_ATTR_UNUSED DWORD nNumberOfBytesToUnlockHigh)
 {
 	WINPR_FILE* pFile = (WINPR_FILE*)hFile;
 #ifdef __sun
@@ -506,8 +509,10 @@ static BOOL FileUnlockFile(HANDLE hFile, DWORD dwFileOffsetLow, DWORD dwFileOffs
 	return TRUE;
 }
 
-static BOOL FileUnlockFileEx(HANDLE hFile, DWORD dwReserved, DWORD nNumberOfBytesToUnlockLow,
-                             DWORD nNumberOfBytesToUnlockHigh, LPOVERLAPPED lpOverlapped)
+static BOOL FileUnlockFileEx(HANDLE hFile, WINPR_ATTR_UNUSED DWORD dwReserved,
+                             WINPR_ATTR_UNUSED DWORD nNumberOfBytesToUnlockLow,
+                             WINPR_ATTR_UNUSED DWORD nNumberOfBytesToUnlockHigh,
+                             LPOVERLAPPED lpOverlapped)
 {
 	WINPR_FILE* pFile = (WINPR_FILE*)hFile;
 #ifdef __sun
@@ -575,7 +580,7 @@ static struct timespec filetimeToTimespec(const FILETIME* ftime)
 	return ts;
 }
 
-static BOOL FileSetFileTime(HANDLE hFile, const FILETIME* lpCreationTime,
+static BOOL FileSetFileTime(HANDLE hFile, WINPR_ATTR_UNUSED const FILETIME* lpCreationTime,
                             const FILETIME* lpLastAccessTime, const FILETIME* lpLastWriteTime)
 {
 	struct timespec times[2] = { { UTIME_OMIT, UTIME_OMIT },
@@ -971,7 +976,7 @@ static HANDLE FileCreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dw
 	return pFile;
 }
 
-static BOOL IsFileDevice(LPCTSTR lpDeviceName)
+static BOOL IsFileDevice(WINPR_ATTR_UNUSED LPCTSTR lpDeviceName)
 {
 	return TRUE;
 }
@@ -1029,12 +1034,13 @@ HANDLE GetStdHandle(DWORD nStdHandle)
 	return (HANDLE)pFile;
 }
 
-BOOL SetStdHandle(DWORD nStdHandle, HANDLE hHandle)
+BOOL SetStdHandle(WINPR_ATTR_UNUSED DWORD nStdHandle, WINPR_ATTR_UNUSED HANDLE hHandle)
 {
 	return FALSE;
 }
 
-BOOL SetStdHandleEx(DWORD dwStdHandle, HANDLE hNewHandle, HANDLE* phOldHandle)
+BOOL SetStdHandleEx(WINPR_ATTR_UNUSED DWORD dwStdHandle, WINPR_ATTR_UNUSED HANDLE hNewHandle,
+                    WINPR_ATTR_UNUSED HANDLE* phOldHandle)
 {
 	return FALSE;
 }

--- a/winpr/libwinpr/file/generic.c
+++ b/winpr/libwinpr/file/generic.c
@@ -22,6 +22,7 @@
 #include <winpr/config.h>
 
 #include <winpr/crt.h>
+#include <winpr/wlog.h>
 #include <winpr/string.h>
 #include <winpr/path.h>
 #include <winpr/file.h>
@@ -470,7 +471,8 @@ BOOL FlushFileBuffers(HANDLE hFile)
 	return FALSE;
 }
 
-BOOL WINAPI GetFileAttributesExA(LPCSTR lpFileName, GET_FILEEX_INFO_LEVELS fInfoLevelId,
+BOOL WINAPI GetFileAttributesExA(LPCSTR lpFileName,
+                                 WINPR_ATTR_UNUSED GET_FILEEX_INFO_LEVELS fInfoLevelId,
                                  LPVOID lpFileInformation)
 {
 	LPWIN32_FILE_ATTRIBUTE_DATA fd = lpFileInformation;
@@ -1057,7 +1059,8 @@ HANDLE FindFirstFileW(LPCWSTR lpFileName, LPWIN32_FIND_DATAW lpFindFileData)
 	LPSTR utfFileName = NULL;
 	HANDLE h = NULL;
 	if (!lpFileName)
-		return FALSE;
+		return INVALID_HANDLE_VALUE;
+
 	LPWIN32_FIND_DATAA fd = (LPWIN32_FIND_DATAA)calloc(1, sizeof(WIN32_FIND_DATAA));
 
 	if (!fd)
@@ -1093,15 +1096,25 @@ out:
 	return h;
 }
 
-HANDLE FindFirstFileExA(LPCSTR lpFileName, FINDEX_INFO_LEVELS fInfoLevelId, LPVOID lpFindFileData,
-                        FINDEX_SEARCH_OPS fSearchOp, LPVOID lpSearchFilter, DWORD dwAdditionalFlags)
+HANDLE FindFirstFileExA(WINPR_ATTR_UNUSED LPCSTR lpFileName,
+                        WINPR_ATTR_UNUSED FINDEX_INFO_LEVELS fInfoLevelId,
+                        WINPR_ATTR_UNUSED LPVOID lpFindFileData,
+                        WINPR_ATTR_UNUSED FINDEX_SEARCH_OPS fSearchOp,
+                        WINPR_ATTR_UNUSED LPVOID lpSearchFilter,
+                        WINPR_ATTR_UNUSED DWORD dwAdditionalFlags)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return INVALID_HANDLE_VALUE;
 }
 
-HANDLE FindFirstFileExW(LPCWSTR lpFileName, FINDEX_INFO_LEVELS fInfoLevelId, LPVOID lpFindFileData,
-                        FINDEX_SEARCH_OPS fSearchOp, LPVOID lpSearchFilter, DWORD dwAdditionalFlags)
+HANDLE FindFirstFileExW(WINPR_ATTR_UNUSED LPCWSTR lpFileName,
+                        WINPR_ATTR_UNUSED FINDEX_INFO_LEVELS fInfoLevelId,
+                        WINPR_ATTR_UNUSED LPVOID lpFindFileData,
+                        WINPR_ATTR_UNUSED FINDEX_SEARCH_OPS fSearchOp,
+                        WINPR_ATTR_UNUSED LPVOID lpSearchFilter,
+                        WINPR_ATTR_UNUSED DWORD dwAdditionalFlags)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return INVALID_HANDLE_VALUE;
 }
 
@@ -1222,7 +1235,8 @@ BOOL FindClose(HANDLE hFindFile)
 	return TRUE;
 }
 
-BOOL CreateDirectoryA(LPCSTR lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttributes)
+BOOL CreateDirectoryA(LPCSTR lpPathName,
+                      WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpSecurityAttributes)
 {
 	if (!mkdir(lpPathName, S_IRUSR | S_IWUSR | S_IXUSR))
 		return TRUE;

--- a/winpr/libwinpr/file/namedPipeClient.c
+++ b/winpr/libwinpr/file/namedPipeClient.c
@@ -116,11 +116,12 @@ static HANDLE_OPS ops = {
 	NULL, /* FileGetFileInformationByHandle */
 };
 
-static HANDLE NamedPipeClientCreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess,
-                                         DWORD dwShareMode,
-                                         LPSECURITY_ATTRIBUTES lpSecurityAttributes,
-                                         DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes,
-                                         HANDLE hTemplateFile)
+static HANDLE
+NamedPipeClientCreateFileA(LPCSTR lpFileName, WINPR_ATTR_UNUSED DWORD dwDesiredAccess,
+                           WINPR_ATTR_UNUSED DWORD dwShareMode,
+                           WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpSecurityAttributes,
+                           WINPR_ATTR_UNUSED DWORD dwCreationDisposition,
+                           DWORD dwFlagsAndAttributes, WINPR_ATTR_UNUSED HANDLE hTemplateFile)
 {
 	int status = 0;
 	struct sockaddr_un s = { 0 };

--- a/winpr/libwinpr/handle/handle.c
+++ b/winpr/libwinpr/handle/handle.c
@@ -60,21 +60,27 @@ BOOL CloseHandle(HANDLE hObject)
 	return FALSE;
 }
 
-BOOL DuplicateHandle(HANDLE hSourceProcessHandle, HANDLE hSourceHandle, HANDLE hTargetProcessHandle,
-                     LPHANDLE lpTargetHandle, DWORD dwDesiredAccess, BOOL bInheritHandle,
-                     DWORD dwOptions)
+BOOL DuplicateHandle(WINPR_ATTR_UNUSED HANDLE hSourceProcessHandle,
+                     WINPR_ATTR_UNUSED HANDLE hSourceHandle,
+                     WINPR_ATTR_UNUSED HANDLE hTargetProcessHandle,
+                     WINPR_ATTR_UNUSED LPHANDLE lpTargetHandle,
+                     WINPR_ATTR_UNUSED DWORD dwDesiredAccess, WINPR_ATTR_UNUSED BOOL bInheritHandle,
+                     WINPR_ATTR_UNUSED DWORD dwOptions)
 {
 	*((ULONG_PTR*)lpTargetHandle) = (ULONG_PTR)hSourceHandle;
 	return TRUE;
 }
 
-BOOL GetHandleInformation(HANDLE hObject, LPDWORD lpdwFlags)
+BOOL GetHandleInformation(WINPR_ATTR_UNUSED HANDLE hObject, WINPR_ATTR_UNUSED LPDWORD lpdwFlags)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL SetHandleInformation(HANDLE hObject, DWORD dwMask, DWORD dwFlags)
+BOOL SetHandleInformation(WINPR_ATTR_UNUSED HANDLE hObject, WINPR_ATTR_UNUSED DWORD dwMask,
+                          WINPR_ATTR_UNUSED DWORD dwFlags)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 

--- a/winpr/libwinpr/interlocked/interlocked.c
+++ b/winpr/libwinpr/interlocked/interlocked.c
@@ -20,6 +20,7 @@
 #include <winpr/config.h>
 
 #include <winpr/assert.h>
+#include <winpr/wlog.h>
 #include <winpr/platform.h>
 #include <winpr/synch.h>
 #include <winpr/handle.h>
@@ -97,13 +98,16 @@ WINPR_PSLIST_ENTRY InterlockedPushEntrySList(WINPR_PSLIST_HEADER ListHead,
 #endif
 }
 
-WINPR_PSLIST_ENTRY InterlockedPushListSListEx(WINPR_PSLIST_HEADER ListHead, WINPR_PSLIST_ENTRY List,
-                                              WINPR_PSLIST_ENTRY ListEnd, ULONG Count)
+WINPR_PSLIST_ENTRY InterlockedPushListSListEx(WINPR_ATTR_UNUSED WINPR_PSLIST_HEADER ListHead,
+                                              WINPR_ATTR_UNUSED WINPR_PSLIST_ENTRY List,
+                                              WINPR_ATTR_UNUSED WINPR_PSLIST_ENTRY ListEnd,
+                                              WINPR_ATTR_UNUSED ULONG Count)
 {
 	WINPR_ASSERT(ListHead);
 	WINPR_ASSERT(List);
 	WINPR_ASSERT(ListEnd);
 
+	WLog_ERR("TODO", "TODO: implement");
 #ifdef _WIN64
 
 #else

--- a/winpr/libwinpr/io/device.c
+++ b/winpr/libwinpr/io/device.c
@@ -120,10 +120,11 @@ static char* GetDeviceFileUnixDomainSocketFilePathA(LPCSTR lpName)
  * http://msdn.microsoft.com/en-us/library/windows/hardware/ff548397/
  */
 
-NTSTATUS _IoCreateDeviceEx(PDRIVER_OBJECT_EX DriverObject, ULONG DeviceExtensionSize,
-                           PUNICODE_STRING DeviceName, DEVICE_TYPE DeviceType,
-                           ULONG DeviceCharacteristics, BOOLEAN Exclusive,
-                           PDEVICE_OBJECT_EX* DeviceObject)
+NTSTATUS _IoCreateDeviceEx(WINPR_ATTR_UNUSED PDRIVER_OBJECT_EX DriverObject,
+                           WINPR_ATTR_UNUSED ULONG DeviceExtensionSize, PUNICODE_STRING DeviceName,
+                           WINPR_ATTR_UNUSED DEVICE_TYPE DeviceType,
+                           WINPR_ATTR_UNUSED ULONG DeviceCharacteristics,
+                           WINPR_ATTR_UNUSED BOOLEAN Exclusive, PDEVICE_OBJECT_EX* DeviceObject)
 {
 	int status = 0;
 	char* DeviceBasePath = NULL;

--- a/winpr/libwinpr/io/io.c
+++ b/winpr/libwinpr/io/io.c
@@ -48,8 +48,10 @@
 
 #define TAG WINPR_TAG("io")
 
-BOOL GetOverlappedResult(HANDLE hFile, LPOVERLAPPED lpOverlapped,
-                         LPDWORD lpNumberOfBytesTransferred, BOOL bWait)
+BOOL GetOverlappedResult(WINPR_ATTR_UNUSED HANDLE hFile,
+                         WINPR_ATTR_UNUSED LPOVERLAPPED lpOverlapped,
+                         WINPR_ATTR_UNUSED LPDWORD lpNumberOfBytesTransferred,
+                         WINPR_ATTR_UNUSED BOOL bWait)
 {
 #if 1
 	WLog_ERR(TAG, "Not implemented");
@@ -127,73 +129,86 @@ BOOL GetOverlappedResult(HANDLE hFile, LPOVERLAPPED lpOverlapped,
 #endif
 }
 
-BOOL GetOverlappedResultEx(HANDLE hFile, LPOVERLAPPED lpOverlapped,
-                           LPDWORD lpNumberOfBytesTransferred, DWORD dwMilliseconds,
-                           BOOL bAlertable)
+BOOL GetOverlappedResultEx(WINPR_ATTR_UNUSED HANDLE hFile,
+                           WINPR_ATTR_UNUSED LPOVERLAPPED lpOverlapped,
+                           WINPR_ATTR_UNUSED LPDWORD lpNumberOfBytesTransferred,
+                           WINPR_ATTR_UNUSED DWORD dwMilliseconds,
+                           WINPR_ATTR_UNUSED BOOL bAlertable)
 {
 	WLog_ERR(TAG, "Not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
 	return FALSE;
 }
 
-BOOL DeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, LPVOID lpInBuffer, DWORD nInBufferSize,
-                     LPVOID lpOutBuffer, DWORD nOutBufferSize, LPDWORD lpBytesReturned,
-                     LPOVERLAPPED lpOverlapped)
+BOOL DeviceIoControl(WINPR_ATTR_UNUSED HANDLE hDevice, WINPR_ATTR_UNUSED DWORD dwIoControlCode,
+                     WINPR_ATTR_UNUSED LPVOID lpInBuffer, WINPR_ATTR_UNUSED DWORD nInBufferSize,
+                     WINPR_ATTR_UNUSED LPVOID lpOutBuffer, WINPR_ATTR_UNUSED DWORD nOutBufferSize,
+                     WINPR_ATTR_UNUSED LPDWORD lpBytesReturned,
+                     WINPR_ATTR_UNUSED LPOVERLAPPED lpOverlapped)
 {
 	WLog_ERR(TAG, "Not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
 	return FALSE;
 }
 
-HANDLE CreateIoCompletionPort(HANDLE FileHandle, HANDLE ExistingCompletionPort,
-                              ULONG_PTR CompletionKey, DWORD NumberOfConcurrentThreads)
+HANDLE CreateIoCompletionPort(WINPR_ATTR_UNUSED HANDLE FileHandle,
+                              WINPR_ATTR_UNUSED HANDLE ExistingCompletionPort,
+                              WINPR_ATTR_UNUSED ULONG_PTR CompletionKey,
+                              WINPR_ATTR_UNUSED DWORD NumberOfConcurrentThreads)
 {
 	WLog_ERR(TAG, "Not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
 	return NULL;
 }
 
-BOOL GetQueuedCompletionStatus(HANDLE CompletionPort, LPDWORD lpNumberOfBytesTransferred,
-                               PULONG_PTR lpCompletionKey, LPOVERLAPPED* lpOverlapped,
-                               DWORD dwMilliseconds)
+BOOL GetQueuedCompletionStatus(WINPR_ATTR_UNUSED HANDLE CompletionPort,
+                               WINPR_ATTR_UNUSED LPDWORD lpNumberOfBytesTransferred,
+                               WINPR_ATTR_UNUSED PULONG_PTR lpCompletionKey,
+                               WINPR_ATTR_UNUSED LPOVERLAPPED* lpOverlapped,
+                               WINPR_ATTR_UNUSED DWORD dwMilliseconds)
 {
 	WLog_ERR(TAG, "Not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
 	return FALSE;
 }
 
-BOOL GetQueuedCompletionStatusEx(HANDLE CompletionPort, LPOVERLAPPED_ENTRY lpCompletionPortEntries,
-                                 ULONG ulCount, PULONG ulNumEntriesRemoved, DWORD dwMilliseconds,
-                                 BOOL fAlertable)
+BOOL GetQueuedCompletionStatusEx(WINPR_ATTR_UNUSED HANDLE CompletionPort,
+                                 WINPR_ATTR_UNUSED LPOVERLAPPED_ENTRY lpCompletionPortEntries,
+                                 WINPR_ATTR_UNUSED ULONG ulCount,
+                                 WINPR_ATTR_UNUSED PULONG ulNumEntriesRemoved,
+                                 WINPR_ATTR_UNUSED DWORD dwMilliseconds,
+                                 WINPR_ATTR_UNUSED BOOL fAlertable)
 {
 	WLog_ERR(TAG, "Not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
 	return FALSE;
 }
 
-BOOL PostQueuedCompletionStatus(HANDLE CompletionPort, DWORD dwNumberOfBytesTransferred,
-                                ULONG_PTR dwCompletionKey, LPOVERLAPPED lpOverlapped)
+BOOL PostQueuedCompletionStatus(WINPR_ATTR_UNUSED HANDLE CompletionPort,
+                                WINPR_ATTR_UNUSED DWORD dwNumberOfBytesTransferred,
+                                WINPR_ATTR_UNUSED ULONG_PTR dwCompletionKey,
+                                WINPR_ATTR_UNUSED LPOVERLAPPED lpOverlapped)
 {
 	WLog_ERR(TAG, "Not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
 	return FALSE;
 }
 
-BOOL CancelIo(HANDLE hFile)
+BOOL CancelIo(WINPR_ATTR_UNUSED HANDLE hFile)
 {
 	WLog_ERR(TAG, "Not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
 	return FALSE;
 }
 
-BOOL CancelIoEx(HANDLE hFile, LPOVERLAPPED lpOverlapped)
+BOOL CancelIoEx(WINPR_ATTR_UNUSED HANDLE hFile, WINPR_ATTR_UNUSED LPOVERLAPPED lpOverlapped)
 {
 	WLog_ERR(TAG, "Not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
 	return FALSE;
 }
 
-BOOL CancelSynchronousIo(HANDLE hThread)
+BOOL CancelSynchronousIo(WINPR_ATTR_UNUSED HANDLE hThread)
 {
 	WLog_ERR(TAG, "Not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);

--- a/winpr/libwinpr/library/library.c
+++ b/winpr/libwinpr/library/library.c
@@ -83,7 +83,7 @@
 
 #endif
 
-DLL_DIRECTORY_COOKIE AddDllDirectory(PCWSTR NewDirectory)
+DLL_DIRECTORY_COOKIE AddDllDirectory(WINPR_ATTR_UNUSED PCWSTR NewDirectory)
 {
 	/* TODO: Implement */
 	WLog_ERR(TAG, "not implemented");
@@ -91,7 +91,7 @@ DLL_DIRECTORY_COOKIE AddDllDirectory(PCWSTR NewDirectory)
 	return NULL;
 }
 
-BOOL RemoveDllDirectory(DLL_DIRECTORY_COOKIE Cookie)
+BOOL RemoveDllDirectory(WINPR_ATTR_UNUSED DLL_DIRECTORY_COOKIE Cookie)
 {
 	/* TODO: Implement */
 	WLog_ERR(TAG, "not implemented");
@@ -99,7 +99,7 @@ BOOL RemoveDllDirectory(DLL_DIRECTORY_COOKIE Cookie)
 	return FALSE;
 }
 
-BOOL SetDefaultDllDirectories(DWORD DirectoryFlags)
+BOOL SetDefaultDllDirectories(WINPR_ATTR_UNUSED DWORD DirectoryFlags)
 {
 	/* TODO: Implement */
 	WLog_ERR(TAG, "not implemented");
@@ -210,7 +210,7 @@ BOOL FreeLibrary(HMODULE hLibModule)
 	return TRUE;
 }
 
-HMODULE GetModuleHandleA(LPCSTR lpModuleName)
+HMODULE GetModuleHandleA(WINPR_ATTR_UNUSED LPCSTR lpModuleName)
 {
 	/* TODO: Implement */
 	WLog_ERR(TAG, "not implemented");
@@ -218,7 +218,7 @@ HMODULE GetModuleHandleA(LPCSTR lpModuleName)
 	return NULL;
 }
 
-HMODULE GetModuleHandleW(LPCWSTR lpModuleName)
+HMODULE GetModuleHandleW(WINPR_ATTR_UNUSED LPCWSTR lpModuleName)
 {
 	/* TODO: Implement */
 	WLog_ERR(TAG, "not implemented");

--- a/winpr/libwinpr/memory/memory.c
+++ b/winpr/libwinpr/memory/memory.c
@@ -20,6 +20,7 @@
 #include <winpr/config.h>
 
 #include <winpr/crt.h>
+#include <winpr/wlog.h>
 
 #include <winpr/memory.h>
 
@@ -76,9 +77,13 @@
 
 #include "memory.h"
 
-HANDLE CreateFileMappingA(HANDLE hFile, LPSECURITY_ATTRIBUTES lpAttributes, DWORD flProtect,
-                          DWORD dwMaximumSizeHigh, DWORD dwMaximumSizeLow, LPCSTR lpName)
+HANDLE CreateFileMappingA(WINPR_ATTR_UNUSED HANDLE hFile,
+                          WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpAttributes,
+                          WINPR_ATTR_UNUSED DWORD flProtect,
+                          WINPR_ATTR_UNUSED DWORD dwMaximumSizeHigh,
+                          WINPR_ATTR_UNUSED DWORD dwMaximumSizeLow, WINPR_ATTR_UNUSED LPCSTR lpName)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	if (hFile != INVALID_HANDLE_VALUE)
 	{
 		return NULL; /* not yet implemented */
@@ -87,41 +92,62 @@ HANDLE CreateFileMappingA(HANDLE hFile, LPSECURITY_ATTRIBUTES lpAttributes, DWOR
 	return NULL;
 }
 
-HANDLE CreateFileMappingW(HANDLE hFile, LPSECURITY_ATTRIBUTES lpAttributes, DWORD flProtect,
-                          DWORD dwMaximumSizeHigh, DWORD dwMaximumSizeLow, LPCWSTR lpName)
+HANDLE CreateFileMappingW(WINPR_ATTR_UNUSED HANDLE hFile,
+                          WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpAttributes,
+                          WINPR_ATTR_UNUSED DWORD flProtect,
+                          WINPR_ATTR_UNUSED DWORD dwMaximumSizeHigh,
+                          WINPR_ATTR_UNUSED DWORD dwMaximumSizeLow,
+                          WINPR_ATTR_UNUSED LPCWSTR lpName)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return NULL;
 }
 
-HANDLE OpenFileMappingA(DWORD dwDesiredAccess, BOOL bInheritHandle, LPCSTR lpName)
+HANDLE OpenFileMappingA(WINPR_ATTR_UNUSED DWORD dwDesiredAccess,
+                        WINPR_ATTR_UNUSED BOOL bInheritHandle, WINPR_ATTR_UNUSED LPCSTR lpName)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return NULL;
 }
 
-HANDLE OpenFileMappingW(DWORD dwDesiredAccess, BOOL bInheritHandle, LPCWSTR lpName)
+HANDLE OpenFileMappingW(WINPR_ATTR_UNUSED DWORD dwDesiredAccess,
+                        WINPR_ATTR_UNUSED BOOL bInheritHandle, WINPR_ATTR_UNUSED LPCWSTR lpName)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return NULL;
 }
 
-LPVOID MapViewOfFile(HANDLE hFileMappingObject, DWORD dwDesiredAccess, DWORD dwFileOffsetHigh,
-                     DWORD dwFileOffsetLow, size_t dwNumberOfBytesToMap)
+LPVOID MapViewOfFile(WINPR_ATTR_UNUSED HANDLE hFileMappingObject,
+                     WINPR_ATTR_UNUSED DWORD dwDesiredAccess,
+                     WINPR_ATTR_UNUSED DWORD dwFileOffsetHigh,
+                     WINPR_ATTR_UNUSED DWORD dwFileOffsetLow,
+                     WINPR_ATTR_UNUSED size_t dwNumberOfBytesToMap)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return NULL;
 }
 
-LPVOID MapViewOfFileEx(HANDLE hFileMappingObject, DWORD dwDesiredAccess, DWORD dwFileOffsetHigh,
-                       DWORD dwFileOffsetLow, size_t dwNumberOfBytesToMap, LPVOID lpBaseAddress)
+LPVOID MapViewOfFileEx(WINPR_ATTR_UNUSED HANDLE hFileMappingObject,
+                       WINPR_ATTR_UNUSED DWORD dwDesiredAccess,
+                       WINPR_ATTR_UNUSED DWORD dwFileOffsetHigh,
+                       WINPR_ATTR_UNUSED DWORD dwFileOffsetLow,
+                       WINPR_ATTR_UNUSED size_t dwNumberOfBytesToMap,
+                       WINPR_ATTR_UNUSED LPVOID lpBaseAddress)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return NULL;
 }
 
-BOOL FlushViewOfFile(LPCVOID lpBaseAddress, size_t dwNumberOfBytesToFlush)
+BOOL FlushViewOfFile(WINPR_ATTR_UNUSED LPCVOID lpBaseAddress,
+                     WINPR_ATTR_UNUSED size_t dwNumberOfBytesToFlush)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL UnmapViewOfFile(LPCVOID lpBaseAddress)
+BOOL UnmapViewOfFile(WINPR_ATTR_UNUSED LPCVOID lpBaseAddress)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 

--- a/winpr/libwinpr/ncrypt/ncrypt.c
+++ b/winpr/libwinpr/ncrypt/ncrypt.c
@@ -99,7 +99,8 @@ SECURITY_STATUS winpr_NCryptDefault_dtor(NCRYPT_HANDLE handle)
 }
 
 SECURITY_STATUS NCryptEnumStorageProviders(DWORD* wProviderCount,
-                                           NCryptProviderName** ppProviderList, DWORD dwFlags)
+                                           NCryptProviderName** ppProviderList,
+                                           WINPR_ATTR_UNUSED DWORD dwFlags)
 {
 	NCryptProviderName* ret = NULL;
 	size_t stringAllocSize = 0;

--- a/winpr/libwinpr/ncrypt/ncrypt_pkcs11.c
+++ b/winpr/libwinpr/ncrypt/ncrypt_pkcs11.c
@@ -660,7 +660,7 @@ static SECURITY_STATUS parseKeyName(LPCWSTR pszKeyName, CK_SLOT_ID* slotId, CK_B
 
 static SECURITY_STATUS NCryptP11EnumKeys(NCRYPT_PROV_HANDLE hProvider, LPCWSTR pszScope,
                                          NCryptKeyName** ppKeyName, PVOID* ppEnumState,
-                                         DWORD dwFlags)
+                                         WINPR_ATTR_UNUSED DWORD dwFlags)
 {
 	NCryptP11ProviderHandle* provider = (NCryptP11ProviderHandle*)hProvider;
 	P11EnumKeysState* state = (P11EnumKeysState*)*ppEnumState;
@@ -979,7 +979,8 @@ static SECURITY_STATUS check_for_piv_container_name(NCryptP11KeyHandle* key, BYT
 
 static SECURITY_STATUS NCryptP11KeyGetProperties(NCryptP11KeyHandle* keyHandle,
                                                  NCryptKeyGetPropertyEnum property, PBYTE pbOutput,
-                                                 DWORD cbOutput, DWORD* pcbResult, DWORD dwFlags)
+                                                 DWORD cbOutput, DWORD* pcbResult,
+                                                 WINPR_ATTR_UNUSED DWORD dwFlags)
 {
 	SECURITY_STATUS ret = NTE_FAIL;
 	CK_RV rv = 0;
@@ -1202,7 +1203,8 @@ static SECURITY_STATUS NCryptP11GetProperty(NCRYPT_HANDLE hObject, NCryptKeyGetP
 }
 
 static SECURITY_STATUS NCryptP11OpenKey(NCRYPT_PROV_HANDLE hProvider, NCRYPT_KEY_HANDLE* phKey,
-                                        LPCWSTR pszKeyName, DWORD dwLegacyKeySpec, DWORD dwFlags)
+                                        LPCWSTR pszKeyName, WINPR_ATTR_UNUSED DWORD dwLegacyKeySpec,
+                                        WINPR_ATTR_UNUSED DWORD dwFlags)
 {
 	SECURITY_STATUS ret = 0;
 	CK_SLOT_ID slotId = 0;
@@ -1272,8 +1274,8 @@ fail:
 }
 
 SECURITY_STATUS NCryptOpenP11StorageProviderEx(NCRYPT_PROV_HANDLE* phProvider,
-                                               LPCWSTR pszProviderName, DWORD dwFlags,
-                                               LPCSTR* modulePaths)
+                                               WINPR_ATTR_UNUSED LPCWSTR pszProviderName,
+                                               WINPR_ATTR_UNUSED DWORD dwFlags, LPCSTR* modulePaths)
 {
 	SECURITY_STATUS status = ERROR_INVALID_PARAMETER;
 	LPCSTR defaultPaths[] = { "p11-kit-proxy.so", "opensc-pkcs11.so", NULL };

--- a/winpr/libwinpr/path/include/PathAllocCombine.h
+++ b/winpr/libwinpr/path/include/PathAllocCombine.h
@@ -27,8 +27,8 @@
 
 #if DEFINE_UNICODE
 
-HRESULT PATH_ALLOC_COMBINE(PCWSTR pszPathIn, PCWSTR pszMore, unsigned long dwFlags,
-                           PWSTR* ppszPathOut)
+HRESULT PATH_ALLOC_COMBINE(PCWSTR pszPathIn, PCWSTR pszMore,
+                           WINPR_ATTR_UNUSED unsigned long dwFlags, PWSTR* ppszPathOut)
 {
 	WLog_WARN("TODO", "has known bugs and needs fixing.");
 
@@ -98,7 +98,8 @@ HRESULT PATH_ALLOC_COMBINE(PCWSTR pszPathIn, PCWSTR pszMore, unsigned long dwFla
 
 #else
 
-HRESULT PATH_ALLOC_COMBINE(PCSTR pszPathIn, PCSTR pszMore, unsigned long dwFlags, PSTR* ppszPathOut)
+HRESULT PATH_ALLOC_COMBINE(PCSTR pszPathIn, PCSTR pszMore, WINPR_ATTR_UNUSED unsigned long dwFlags,
+                           PSTR* ppszPathOut)
 {
 	WLog_WARN("TODO", "has known bugs and needs fixing.");
 

--- a/winpr/libwinpr/path/include/PathCchAddSeparatorEx.h
+++ b/winpr/libwinpr/path/include/PathCchAddSeparatorEx.h
@@ -9,8 +9,8 @@
 
 #if DEFINE_UNICODE
 
-HRESULT PATH_CCH_ADD_SEPARATOR_EX(PWSTR pszPath, size_t cchPath, PWSTR* ppszEnd,
-                                  size_t* pcchRemaining)
+HRESULT PATH_CCH_ADD_SEPARATOR_EX(PWSTR pszPath, size_t cchPath, WINPR_ATTR_UNUSED PWSTR* ppszEnd,
+                                  WINPR_ATTR_UNUSED size_t* pcchRemaining)
 {
 	size_t pszPathLength;
 
@@ -35,8 +35,9 @@ HRESULT PATH_CCH_ADD_SEPARATOR_EX(PWSTR pszPath, size_t cchPath, PWSTR* ppszEnd,
 
 #else
 
-HRESULT PATH_CCH_ADD_SEPARATOR_EX(PSTR pszPath, size_t cchPath, PSTR* ppszEnd,
-                                  size_t* pcchRemaining)
+HRESULT PATH_CCH_ADD_SEPARATOR_EX(WINPR_ATTR_UNUSED PSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath,
+                                  WINPR_ATTR_UNUSED PSTR* ppszEnd,
+                                  WINPR_ATTR_UNUSED size_t* pcchRemaining)
 {
 	size_t pszPathLength;
 

--- a/winpr/libwinpr/path/path.c
+++ b/winpr/libwinpr/path/path.c
@@ -136,13 +136,13 @@
  * PathCchRemoveBackslash
  */
 
-HRESULT PathCchRemoveBackslashA(PSTR pszPath, size_t cchPath)
+HRESULT PathCchRemoveBackslashA(WINPR_ATTR_UNUSED PSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
 }
 
-HRESULT PathCchRemoveBackslashW(PWSTR pszPath, size_t cchPath)
+HRESULT PathCchRemoveBackslashW(WINPR_ATTR_UNUSED PWSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
@@ -206,15 +206,17 @@ HRESULT PathCchRemoveBackslashW(PWSTR pszPath, size_t cchPath)
 #undef CUR_PATH_SEPARATOR_CHR
 #undef PATH_CCH_ADD_SEPARATOR_EX
 
-HRESULT PathCchRemoveBackslashExA(PSTR pszPath, size_t cchPath, PSTR* ppszEnd,
-                                  size_t* pcchRemaining)
+HRESULT PathCchRemoveBackslashExA(WINPR_ATTR_UNUSED PSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath,
+                                  WINPR_ATTR_UNUSED PSTR* ppszEnd,
+                                  WINPR_ATTR_UNUSED size_t* pcchRemaining)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
 }
 
-HRESULT PathCchRemoveBackslashExW(PWSTR pszPath, size_t cchPath, PWSTR* ppszEnd,
-                                  size_t* pcchRemaining)
+HRESULT PathCchRemoveBackslashExW(WINPR_ATTR_UNUSED PWSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath,
+                                  WINPR_ATTR_UNUSED PWSTR* ppszEnd,
+                                  WINPR_ATTR_UNUSED size_t* pcchRemaining)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
@@ -352,13 +354,15 @@ HRESULT PathCchRemoveBackslashExW(PWSTR pszPath, size_t cchPath, PWSTR* ppszEnd,
  * PathCchAppendEx
  */
 
-HRESULT PathCchAppendExA(PSTR pszPath, size_t cchPath, PCSTR pszMore, unsigned long dwFlags)
+HRESULT PathCchAppendExA(WINPR_ATTR_UNUSED PSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath,
+                         WINPR_ATTR_UNUSED PCSTR pszMore, WINPR_ATTR_UNUSED unsigned long dwFlags)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
 }
 
-HRESULT PathCchAppendExW(PWSTR pszPath, size_t cchPath, PCWSTR pszMore, unsigned long dwFlags)
+HRESULT PathCchAppendExW(WINPR_ATTR_UNUSED PWSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath,
+                         WINPR_ATTR_UNUSED PCWSTR pszMore, WINPR_ATTR_UNUSED unsigned long dwFlags)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
@@ -368,13 +372,16 @@ HRESULT PathCchAppendExW(PWSTR pszPath, size_t cchPath, PCWSTR pszMore, unsigned
  * PathCchCanonicalize
  */
 
-HRESULT PathCchCanonicalizeA(PSTR pszPathOut, size_t cchPathOut, PCSTR pszPathIn)
+HRESULT PathCchCanonicalizeA(WINPR_ATTR_UNUSED PSTR pszPathOut, WINPR_ATTR_UNUSED size_t cchPathOut,
+                             WINPR_ATTR_UNUSED PCSTR pszPathIn)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
 }
 
-HRESULT PathCchCanonicalizeW(PWSTR pszPathOut, size_t cchPathOut, PCWSTR pszPathIn)
+HRESULT PathCchCanonicalizeW(WINPR_ATTR_UNUSED PWSTR pszPathOut,
+                             WINPR_ATTR_UNUSED size_t cchPathOut,
+                             WINPR_ATTR_UNUSED PCWSTR pszPathIn)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
@@ -384,15 +391,19 @@ HRESULT PathCchCanonicalizeW(PWSTR pszPathOut, size_t cchPathOut, PCWSTR pszPath
  * PathCchCanonicalizeEx
  */
 
-HRESULT PathCchCanonicalizeExA(PSTR pszPathOut, size_t cchPathOut, PCSTR pszPathIn,
-                               unsigned long dwFlags)
+HRESULT PathCchCanonicalizeExA(WINPR_ATTR_UNUSED PSTR pszPathOut,
+                               WINPR_ATTR_UNUSED size_t cchPathOut,
+                               WINPR_ATTR_UNUSED PCSTR pszPathIn,
+                               WINPR_ATTR_UNUSED unsigned long dwFlags)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
 }
 
-HRESULT PathCchCanonicalizeExW(PWSTR pszPathOut, size_t cchPathOut, PCWSTR pszPathIn,
-                               unsigned long dwFlags)
+HRESULT PathCchCanonicalizeExW(WINPR_ATTR_UNUSED PWSTR pszPathOut,
+                               WINPR_ATTR_UNUSED size_t cchPathOut,
+                               WINPR_ATTR_UNUSED PCWSTR pszPathIn,
+                               WINPR_ATTR_UNUSED unsigned long dwFlags)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
@@ -402,13 +413,17 @@ HRESULT PathCchCanonicalizeExW(PWSTR pszPathOut, size_t cchPathOut, PCWSTR pszPa
  * PathAllocCanonicalize
  */
 
-HRESULT PathAllocCanonicalizeA(PCSTR pszPathIn, unsigned long dwFlags, PSTR* ppszPathOut)
+HRESULT PathAllocCanonicalizeA(WINPR_ATTR_UNUSED PCSTR pszPathIn,
+                               WINPR_ATTR_UNUSED unsigned long dwFlags,
+                               WINPR_ATTR_UNUSED PSTR* ppszPathOut)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
 }
 
-HRESULT PathAllocCanonicalizeW(PCWSTR pszPathIn, unsigned long dwFlags, PWSTR* ppszPathOut)
+HRESULT PathAllocCanonicalizeW(WINPR_ATTR_UNUSED PCWSTR pszPathIn,
+                               WINPR_ATTR_UNUSED unsigned long dwFlags,
+                               WINPR_ATTR_UNUSED PWSTR* ppszPathOut)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
@@ -418,13 +433,15 @@ HRESULT PathAllocCanonicalizeW(PCWSTR pszPathIn, unsigned long dwFlags, PWSTR* p
  * PathCchCombine
  */
 
-HRESULT PathCchCombineA(PSTR pszPathOut, size_t cchPathOut, PCSTR pszPathIn, PCSTR pszMore)
+HRESULT PathCchCombineA(WINPR_ATTR_UNUSED PSTR pszPathOut, WINPR_ATTR_UNUSED size_t cchPathOut,
+                        WINPR_ATTR_UNUSED PCSTR pszPathIn, WINPR_ATTR_UNUSED PCSTR pszMore)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
 }
 
-HRESULT PathCchCombineW(PWSTR pszPathOut, size_t cchPathOut, PCWSTR pszPathIn, PCWSTR pszMore)
+HRESULT PathCchCombineW(WINPR_ATTR_UNUSED PWSTR pszPathOut, WINPR_ATTR_UNUSED size_t cchPathOut,
+                        WINPR_ATTR_UNUSED PCWSTR pszPathIn, WINPR_ATTR_UNUSED PCWSTR pszMore)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
@@ -434,15 +451,17 @@ HRESULT PathCchCombineW(PWSTR pszPathOut, size_t cchPathOut, PCWSTR pszPathIn, P
  * PathCchCombineEx
  */
 
-HRESULT PathCchCombineExA(PSTR pszPathOut, size_t cchPathOut, PCSTR pszPathIn, PCSTR pszMore,
-                          unsigned long dwFlags)
+HRESULT PathCchCombineExA(WINPR_ATTR_UNUSED PSTR pszPathOut, WINPR_ATTR_UNUSED size_t cchPathOut,
+                          WINPR_ATTR_UNUSED PCSTR pszPathIn, WINPR_ATTR_UNUSED PCSTR pszMore,
+                          WINPR_ATTR_UNUSED unsigned long dwFlags)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
 }
 
-HRESULT PathCchCombineExW(PWSTR pszPathOut, size_t cchPathOut, PCWSTR pszPathIn, PCWSTR pszMore,
-                          unsigned long dwFlags)
+HRESULT PathCchCombineExW(WINPR_ATTR_UNUSED PWSTR pszPathOut, WINPR_ATTR_UNUSED size_t cchPathOut,
+                          WINPR_ATTR_UNUSED PCWSTR pszPathIn, WINPR_ATTR_UNUSED PCWSTR pszMore,
+                          WINPR_ATTR_UNUSED unsigned long dwFlags)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
@@ -564,7 +583,8 @@ HRESULT PathCchFindExtensionA(PCSTR pszPath, size_t cchPath, PCSTR* ppszExt)
 	return S_OK;
 }
 
-HRESULT PathCchFindExtensionW(PCWSTR pszPath, size_t cchPath, PCWSTR* ppszExt)
+HRESULT PathCchFindExtensionW(WINPR_ATTR_UNUSED PCWSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath,
+                              WINPR_ATTR_UNUSED PCWSTR* ppszExt)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
@@ -574,13 +594,15 @@ HRESULT PathCchFindExtensionW(PCWSTR pszPath, size_t cchPath, PCWSTR* ppszExt)
  * PathCchRenameExtension
  */
 
-HRESULT PathCchRenameExtensionA(PSTR pszPath, size_t cchPath, PCSTR pszExt)
+HRESULT PathCchRenameExtensionA(WINPR_ATTR_UNUSED PSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath,
+                                WINPR_ATTR_UNUSED PCSTR pszExt)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
 }
 
-HRESULT PathCchRenameExtensionW(PWSTR pszPath, size_t cchPath, PCWSTR pszExt)
+HRESULT PathCchRenameExtensionW(WINPR_ATTR_UNUSED PWSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath,
+                                WINPR_ATTR_UNUSED PCWSTR pszExt)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
@@ -590,13 +612,13 @@ HRESULT PathCchRenameExtensionW(PWSTR pszPath, size_t cchPath, PCWSTR pszExt)
  * PathCchRemoveExtension
  */
 
-HRESULT PathCchRemoveExtensionA(PSTR pszPath, size_t cchPath)
+HRESULT PathCchRemoveExtensionA(WINPR_ATTR_UNUSED PSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
 }
 
-HRESULT PathCchRemoveExtensionW(PWSTR pszPath, size_t cchPath)
+HRESULT PathCchRemoveExtensionW(WINPR_ATTR_UNUSED PWSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
@@ -606,13 +628,13 @@ HRESULT PathCchRemoveExtensionW(PWSTR pszPath, size_t cchPath)
  * PathCchIsRoot
  */
 
-BOOL PathCchIsRootA(PCSTR pszPath)
+BOOL PathCchIsRootA(WINPR_ATTR_UNUSED PCSTR pszPath)
 {
 	WLog_ERR(TAG, "not implemented");
 	return FALSE;
 }
 
-BOOL PathCchIsRootW(PCWSTR pszPath)
+BOOL PathCchIsRootW(WINPR_ATTR_UNUSED PCWSTR pszPath)
 {
 	WLog_ERR(TAG, "not implemented");
 	return FALSE;
@@ -654,13 +676,13 @@ BOOL PathIsUNCExW(PCWSTR pszPath, PCWSTR* ppszServer)
  * PathCchSkipRoot
  */
 
-HRESULT PathCchSkipRootA(PCSTR pszPath, PCSTR* ppszRootEnd)
+HRESULT PathCchSkipRootA(WINPR_ATTR_UNUSED PCSTR pszPath, WINPR_ATTR_UNUSED PCSTR* ppszRootEnd)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
 }
 
-HRESULT PathCchSkipRootW(PCWSTR pszPath, PCWSTR* ppszRootEnd)
+HRESULT PathCchSkipRootW(WINPR_ATTR_UNUSED PCWSTR pszPath, WINPR_ATTR_UNUSED PCWSTR* ppszRootEnd)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
@@ -670,13 +692,13 @@ HRESULT PathCchSkipRootW(PCWSTR pszPath, PCWSTR* ppszRootEnd)
  * PathCchStripToRoot
  */
 
-HRESULT PathCchStripToRootA(PSTR pszPath, size_t cchPath)
+HRESULT PathCchStripToRootA(WINPR_ATTR_UNUSED PSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
 }
 
-HRESULT PathCchStripToRootW(PWSTR pszPath, size_t cchPath)
+HRESULT PathCchStripToRootW(WINPR_ATTR_UNUSED PWSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
@@ -764,13 +786,13 @@ HRESULT PathCchStripPrefixW(PWSTR pszPath, size_t cchPath)
  * PathCchRemoveFileSpec
  */
 
-HRESULT PathCchRemoveFileSpecA(PSTR pszPath, size_t cchPath)
+HRESULT PathCchRemoveFileSpecA(WINPR_ATTR_UNUSED PSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;
 }
 
-HRESULT PathCchRemoveFileSpecW(PWSTR pszPath, size_t cchPath)
+HRESULT PathCchRemoveFileSpecW(WINPR_ATTR_UNUSED PWSTR pszPath, WINPR_ATTR_UNUSED size_t cchPath)
 {
 	WLog_ERR(TAG, "not implemented");
 	return E_NOTIMPL;

--- a/winpr/libwinpr/path/shell.c
+++ b/winpr/libwinpr/path/shell.c
@@ -497,7 +497,7 @@ fail:
 	return NULL;
 }
 
-BOOL PathMakePathA(LPCSTR path, LPSECURITY_ATTRIBUTES lpAttributes)
+BOOL PathMakePathA(LPCSTR path, WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpAttributes)
 {
 #if defined(_UWP)
 	return FALSE;
@@ -550,7 +550,7 @@ BOOL PathMakePathA(LPCSTR path, LPSECURITY_ATTRIBUTES lpAttributes)
 #endif
 }
 
-BOOL PathMakePathW(LPCWSTR path, LPSECURITY_ATTRIBUTES lpAttributes)
+BOOL PathMakePathW(LPCWSTR path, WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpAttributes)
 {
 #if defined(_UWP)
 	return FALSE;

--- a/winpr/libwinpr/pipe/pipe.c
+++ b/winpr/libwinpr/pipe/pipe.c
@@ -728,9 +728,12 @@ out:
 	return INVALID_HANDLE_VALUE;
 }
 
-HANDLE CreateNamedPipeW(LPCWSTR lpName, DWORD dwOpenMode, DWORD dwPipeMode, DWORD nMaxInstances,
-                        DWORD nOutBufferSize, DWORD nInBufferSize, DWORD nDefaultTimeOut,
-                        LPSECURITY_ATTRIBUTES lpSecurityAttributes)
+HANDLE CreateNamedPipeW(WINPR_ATTR_UNUSED LPCWSTR lpName, WINPR_ATTR_UNUSED DWORD dwOpenMode,
+                        WINPR_ATTR_UNUSED DWORD dwPipeMode, WINPR_ATTR_UNUSED DWORD nMaxInstances,
+                        WINPR_ATTR_UNUSED DWORD nOutBufferSize,
+                        WINPR_ATTR_UNUSED DWORD nInBufferSize,
+                        WINPR_ATTR_UNUSED DWORD nDefaultTimeOut,
+                        WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpSecurityAttributes)
 {
 	WLog_ERR(TAG, "is not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
@@ -803,17 +806,21 @@ BOOL DisconnectNamedPipe(HANDLE hNamedPipe)
 	return TRUE;
 }
 
-BOOL PeekNamedPipe(HANDLE hNamedPipe, LPVOID lpBuffer, DWORD nBufferSize, LPDWORD lpBytesRead,
-                   LPDWORD lpTotalBytesAvail, LPDWORD lpBytesLeftThisMessage)
+BOOL PeekNamedPipe(WINPR_ATTR_UNUSED HANDLE hNamedPipe, WINPR_ATTR_UNUSED LPVOID lpBuffer,
+                   WINPR_ATTR_UNUSED DWORD nBufferSize, WINPR_ATTR_UNUSED LPDWORD lpBytesRead,
+                   WINPR_ATTR_UNUSED LPDWORD lpTotalBytesAvail,
+                   WINPR_ATTR_UNUSED LPDWORD lpBytesLeftThisMessage)
 {
 	WLog_ERR(TAG, "Not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
 	return FALSE;
 }
 
-BOOL TransactNamedPipe(HANDLE hNamedPipe, LPVOID lpInBuffer, DWORD nInBufferSize,
-                       LPVOID lpOutBuffer, DWORD nOutBufferSize, LPDWORD lpBytesRead,
-                       LPOVERLAPPED lpOverlapped)
+BOOL TransactNamedPipe(WINPR_ATTR_UNUSED HANDLE hNamedPipe, WINPR_ATTR_UNUSED LPVOID lpInBuffer,
+                       WINPR_ATTR_UNUSED DWORD nInBufferSize, WINPR_ATTR_UNUSED LPVOID lpOutBuffer,
+                       WINPR_ATTR_UNUSED DWORD nOutBufferSize,
+                       WINPR_ATTR_UNUSED LPDWORD lpBytesRead,
+                       WINPR_ATTR_UNUSED LPOVERLAPPED lpOverlapped)
 {
 	WLog_ERR(TAG, "Not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
@@ -858,7 +865,7 @@ BOOL WaitNamedPipeA(LPCSTR lpNamedPipeName, DWORD nTimeOut)
 	return status;
 }
 
-BOOL WaitNamedPipeW(LPCWSTR lpNamedPipeName, DWORD nTimeOut)
+BOOL WaitNamedPipeW(WINPR_ATTR_UNUSED LPCWSTR lpNamedPipeName, WINPR_ATTR_UNUSED DWORD nTimeOut)
 {
 	WLog_ERR(TAG, "Not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
@@ -908,23 +915,25 @@ BOOL SetNamedPipeHandleState(HANDLE hNamedPipe, LPDWORD lpMode, LPDWORD lpMaxCol
 	return TRUE;
 }
 
-BOOL ImpersonateNamedPipeClient(HANDLE hNamedPipe)
+BOOL ImpersonateNamedPipeClient(WINPR_ATTR_UNUSED HANDLE hNamedPipe)
 {
 	WLog_ERR(TAG, "Not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
 	return FALSE;
 }
 
-BOOL GetNamedPipeClientComputerNameA(HANDLE Pipe, LPCSTR ClientComputerName,
-                                     ULONG ClientComputerNameLength)
+BOOL GetNamedPipeClientComputerNameA(WINPR_ATTR_UNUSED HANDLE Pipe,
+                                     WINPR_ATTR_UNUSED LPCSTR ClientComputerName,
+                                     WINPR_ATTR_UNUSED ULONG ClientComputerNameLength)
 {
 	WLog_ERR(TAG, "Not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
 	return FALSE;
 }
 
-BOOL GetNamedPipeClientComputerNameW(HANDLE Pipe, LPCWSTR ClientComputerName,
-                                     ULONG ClientComputerNameLength)
+BOOL GetNamedPipeClientComputerNameW(WINPR_ATTR_UNUSED HANDLE Pipe,
+                                     WINPR_ATTR_UNUSED LPCWSTR ClientComputerName,
+                                     WINPR_ATTR_UNUSED ULONG ClientComputerNameLength)
 {
 	WLog_ERR(TAG, "Not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);

--- a/winpr/libwinpr/pool/callback.c
+++ b/winpr/libwinpr/pool/callback.c
@@ -21,6 +21,7 @@
 
 #include <winpr/crt.h>
 #include <winpr/pool.h>
+#include <winpr/wlog.h>
 #include <winpr/library.h>
 
 #ifdef WINPR_THREAD_POOL
@@ -40,13 +41,14 @@ static BOOL CALLBACK init_module(PINIT_ONCE once, PVOID param, PVOID* context)
 }
 #endif
 
-BOOL winpr_CallbackMayRunLong(PTP_CALLBACK_INSTANCE pci)
+BOOL winpr_CallbackMayRunLong(WINPR_ATTR_UNUSED PTP_CALLBACK_INSTANCE pci)
 {
 #ifdef _WIN32
 	InitOnceExecuteOnce(&init_once_module, init_module, NULL, NULL);
 	if (pCallbackMayRunLong)
 		return pCallbackMayRunLong(pci);
 #endif
+	WLog_ERR("TODO", "TODO: implement");
 	/* No default implementation */
 	return FALSE;
 }

--- a/winpr/libwinpr/pool/callback_cleanup.c
+++ b/winpr/libwinpr/pool/callback_cleanup.c
@@ -60,7 +60,8 @@ static BOOL CALLBACK init_module(PINIT_ONCE once, PVOID param, PVOID* context)
 }
 #endif
 
-VOID SetEventWhenCallbackReturns(PTP_CALLBACK_INSTANCE pci, HANDLE evt)
+VOID SetEventWhenCallbackReturns(WINPR_ATTR_UNUSED PTP_CALLBACK_INSTANCE pci,
+                                 WINPR_ATTR_UNUSED HANDLE evt)
 {
 #ifdef _WIN32
 	InitOnceExecuteOnce(&init_once_module, init_module, NULL, NULL);
@@ -70,10 +71,12 @@ VOID SetEventWhenCallbackReturns(PTP_CALLBACK_INSTANCE pci, HANDLE evt)
 		return;
 	}
 #endif
+	WLog_ERR("TODO", "TODO: implement");
 	/* No default implementation */
 }
 
-VOID ReleaseSemaphoreWhenCallbackReturns(PTP_CALLBACK_INSTANCE pci, HANDLE sem, DWORD crel)
+VOID ReleaseSemaphoreWhenCallbackReturns(WINPR_ATTR_UNUSED PTP_CALLBACK_INSTANCE pci,
+                                         WINPR_ATTR_UNUSED HANDLE sem, WINPR_ATTR_UNUSED DWORD crel)
 {
 #ifdef _WIN32
 	InitOnceExecuteOnce(&init_once_module, init_module, NULL, NULL);
@@ -84,9 +87,11 @@ VOID ReleaseSemaphoreWhenCallbackReturns(PTP_CALLBACK_INSTANCE pci, HANDLE sem, 
 	}
 #endif
 	/* No default implementation */
+	WLog_ERR("TODO", "TODO: implement");
 }
 
-VOID ReleaseMutexWhenCallbackReturns(PTP_CALLBACK_INSTANCE pci, HANDLE mut)
+VOID ReleaseMutexWhenCallbackReturns(WINPR_ATTR_UNUSED PTP_CALLBACK_INSTANCE pci,
+                                     WINPR_ATTR_UNUSED HANDLE mut)
 {
 #ifdef _WIN32
 	InitOnceExecuteOnce(&init_once_module, init_module, NULL, NULL);
@@ -97,9 +102,11 @@ VOID ReleaseMutexWhenCallbackReturns(PTP_CALLBACK_INSTANCE pci, HANDLE mut)
 	}
 #endif
 	/* No default implementation */
+	WLog_ERR("TODO", "TODO: implement");
 }
 
-VOID LeaveCriticalSectionWhenCallbackReturns(PTP_CALLBACK_INSTANCE pci, PCRITICAL_SECTION pcs)
+VOID LeaveCriticalSectionWhenCallbackReturns(WINPR_ATTR_UNUSED PTP_CALLBACK_INSTANCE pci,
+                                             WINPR_ATTR_UNUSED PCRITICAL_SECTION pcs)
 {
 #ifdef _WIN32
 	InitOnceExecuteOnce(&init_once_module, init_module, NULL, NULL);
@@ -109,9 +116,11 @@ VOID LeaveCriticalSectionWhenCallbackReturns(PTP_CALLBACK_INSTANCE pci, PCRITICA
 	}
 #endif
 	/* No default implementation */
+	WLog_ERR("TODO", "TODO: implement");
 }
 
-VOID FreeLibraryWhenCallbackReturns(PTP_CALLBACK_INSTANCE pci, HMODULE mod)
+VOID FreeLibraryWhenCallbackReturns(WINPR_ATTR_UNUSED PTP_CALLBACK_INSTANCE pci,
+                                    WINPR_ATTR_UNUSED HMODULE mod)
 {
 #ifdef _WIN32
 	InitOnceExecuteOnce(&init_once_module, init_module, NULL, NULL);
@@ -122,9 +131,10 @@ VOID FreeLibraryWhenCallbackReturns(PTP_CALLBACK_INSTANCE pci, HMODULE mod)
 	}
 #endif
 	/* No default implementation */
+	WLog_ERR("TODO", "TODO: implement");
 }
 
-VOID DisassociateCurrentThreadFromCallback(PTP_CALLBACK_INSTANCE pci)
+VOID DisassociateCurrentThreadFromCallback(WINPR_ATTR_UNUSED PTP_CALLBACK_INSTANCE pci)
 {
 #ifdef _WIN32
 	InitOnceExecuteOnce(&init_once_module, init_module, NULL, NULL);
@@ -134,6 +144,7 @@ VOID DisassociateCurrentThreadFromCallback(PTP_CALLBACK_INSTANCE pci)
 		return;
 	}
 #endif
+	WLog_ERR("TODO", "TODO: implement");
 	/* No default implementation */
 }
 

--- a/winpr/libwinpr/pool/cleanup_group.c
+++ b/winpr/libwinpr/pool/cleanup_group.c
@@ -92,8 +92,9 @@ VOID winpr_SetThreadpoolCallbackCleanupGroup(PTP_CALLBACK_ENVIRON pcbe, PTP_CLEA
 #endif
 }
 
-VOID winpr_CloseThreadpoolCleanupGroupMembers(PTP_CLEANUP_GROUP ptpcg, BOOL fCancelPendingCallbacks,
-                                              PVOID pvCleanupContext)
+VOID winpr_CloseThreadpoolCleanupGroupMembers(WINPR_ATTR_UNUSED PTP_CLEANUP_GROUP ptpcg,
+                                              WINPR_ATTR_UNUSED BOOL fCancelPendingCallbacks,
+                                              WINPR_ATTR_UNUSED PVOID pvCleanupContext)
 {
 #ifdef _WIN32
 	InitOnceExecuteOnce(&init_once_module, init_module, NULL, NULL);

--- a/winpr/libwinpr/pool/io.c
+++ b/winpr/libwinpr/pool/io.c
@@ -21,29 +21,38 @@
 
 #include <winpr/crt.h>
 #include <winpr/pool.h>
+#include <winpr/wlog.h>
 
 #ifdef WINPR_THREAD_POOL
 
-PTP_IO winpr_CreateThreadpoolIo(HANDLE fl, PTP_WIN32_IO_CALLBACK pfnio, PVOID pv,
-                                PTP_CALLBACK_ENVIRON pcbe)
+PTP_IO winpr_CreateThreadpoolIo(WINPR_ATTR_UNUSED HANDLE fl,
+                                WINPR_ATTR_UNUSED PTP_WIN32_IO_CALLBACK pfnio,
+                                WINPR_ATTR_UNUSED PVOID pv,
+                                WINPR_ATTR_UNUSED PTP_CALLBACK_ENVIRON pcbe)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return NULL;
 }
 
-VOID winpr_CloseThreadpoolIo(PTP_IO pio)
+VOID winpr_CloseThreadpoolIo(WINPR_ATTR_UNUSED PTP_IO pio)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 }
 
-VOID winpr_StartThreadpoolIo(PTP_IO pio)
+VOID winpr_StartThreadpoolIo(WINPR_ATTR_UNUSED PTP_IO pio)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 }
 
-VOID winpr_CancelThreadpoolIo(PTP_IO pio)
+VOID winpr_CancelThreadpoolIo(WINPR_ATTR_UNUSED PTP_IO pio)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 }
 
-VOID winpr_WaitForThreadpoolIoCallbacks(PTP_IO pio, BOOL fCancelPendingCallbacks)
+VOID winpr_WaitForThreadpoolIoCallbacks(WINPR_ATTR_UNUSED PTP_IO pio,
+                                        WINPR_ATTR_UNUSED BOOL fCancelPendingCallbacks)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 }
 
 #endif

--- a/winpr/libwinpr/pool/synch.c
+++ b/winpr/libwinpr/pool/synch.c
@@ -21,24 +21,33 @@
 
 #include <winpr/crt.h>
 #include <winpr/pool.h>
+#include <winpr/wlog.h>
 
 #ifdef WINPR_THREAD_POOL
 
-PTP_WAIT winpr_CreateThreadpoolWait(PTP_WAIT_CALLBACK pfnwa, PVOID pv, PTP_CALLBACK_ENVIRON pcbe)
+PTP_WAIT winpr_CreateThreadpoolWait(WINPR_ATTR_UNUSED PTP_WAIT_CALLBACK pfnwa,
+                                    WINPR_ATTR_UNUSED PVOID pv,
+                                    WINPR_ATTR_UNUSED PTP_CALLBACK_ENVIRON pcbe)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return NULL;
 }
 
-VOID winpr_CloseThreadpoolWait(PTP_WAIT pwa)
+VOID winpr_CloseThreadpoolWait(WINPR_ATTR_UNUSED PTP_WAIT pwa)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 }
 
-VOID winpr_SetThreadpoolWait(PTP_WAIT pwa, HANDLE h, PFILETIME pftTimeout)
+VOID winpr_SetThreadpoolWait(WINPR_ATTR_UNUSED PTP_WAIT pwa, WINPR_ATTR_UNUSED HANDLE h,
+                             WINPR_ATTR_UNUSED PFILETIME pftTimeout)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 }
 
-VOID winpr_WaitForThreadpoolWaitCallbacks(PTP_WAIT pwa, BOOL fCancelPendingCallbacks)
+VOID winpr_WaitForThreadpoolWaitCallbacks(WINPR_ATTR_UNUSED PTP_WAIT pwa,
+                                          WINPR_ATTR_UNUSED BOOL fCancelPendingCallbacks)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 }
 
 #endif

--- a/winpr/libwinpr/pool/timer.c
+++ b/winpr/libwinpr/pool/timer.c
@@ -21,30 +21,41 @@
 
 #include <winpr/crt.h>
 #include <winpr/pool.h>
+#include <winpr/wlog.h>
 
 #ifdef WINPR_THREAD_POOL
 
-PTP_TIMER winpr_CreateThreadpoolTimer(PTP_TIMER_CALLBACK pfnti, PVOID pv, PTP_CALLBACK_ENVIRON pcbe)
+PTP_TIMER winpr_CreateThreadpoolTimer(WINPR_ATTR_UNUSED PTP_TIMER_CALLBACK pfnti,
+                                      WINPR_ATTR_UNUSED PVOID pv,
+                                      WINPR_ATTR_UNUSED PTP_CALLBACK_ENVIRON pcbe)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return NULL;
 }
 
-VOID winpr_CloseThreadpoolTimer(PTP_TIMER pti)
+VOID winpr_CloseThreadpoolTimer(WINPR_ATTR_UNUSED PTP_TIMER pti)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 }
 
-BOOL winpr_IsThreadpoolTimerSet(PTP_TIMER pti)
+BOOL winpr_IsThreadpoolTimerSet(WINPR_ATTR_UNUSED PTP_TIMER pti)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return FALSE;
 }
 
-VOID winpr_SetThreadpoolTimer(PTP_TIMER pti, PFILETIME pftDueTime, DWORD msPeriod,
-                              DWORD msWindowLength)
+VOID winpr_SetThreadpoolTimer(WINPR_ATTR_UNUSED PTP_TIMER pti,
+                              WINPR_ATTR_UNUSED PFILETIME pftDueTime,
+                              WINPR_ATTR_UNUSED DWORD msPeriod,
+                              WINPR_ATTR_UNUSED DWORD msWindowLength)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 }
 
-VOID winpr_WaitForThreadpoolTimerCallbacks(PTP_TIMER pti, BOOL fCancelPendingCallbacks)
+VOID winpr_WaitForThreadpoolTimerCallbacks(WINPR_ATTR_UNUSED PTP_TIMER pti,
+                                           WINPR_ATTR_UNUSED BOOL fCancelPendingCallbacks)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 }
 
 #endif

--- a/winpr/libwinpr/pool/work.c
+++ b/winpr/libwinpr/pool/work.c
@@ -155,8 +155,9 @@ VOID winpr_SubmitThreadpoolWork(PTP_WORK pwk)
 	// NOLINTNEXTLINE(clang-analyzer-unix.Malloc): Queue_Enqueue takes ownership of callbackInstance
 }
 
-BOOL winpr_TrySubmitThreadpoolCallback(PTP_SIMPLE_CALLBACK pfns, PVOID pv,
-                                       PTP_CALLBACK_ENVIRON pcbe)
+BOOL winpr_TrySubmitThreadpoolCallback(WINPR_ATTR_UNUSED PTP_SIMPLE_CALLBACK pfns,
+                                       WINPR_ATTR_UNUSED PVOID pv,
+                                       WINPR_ATTR_UNUSED PTP_CALLBACK_ENVIRON pcbe)
 {
 #ifdef _WIN32
 	InitOnceExecuteOnce(&init_once_module, init_module, NULL, NULL);
@@ -169,7 +170,8 @@ BOOL winpr_TrySubmitThreadpoolCallback(PTP_SIMPLE_CALLBACK pfns, PVOID pv,
 	return FALSE;
 }
 
-VOID winpr_WaitForThreadpoolWorkCallbacks(PTP_WORK pwk, BOOL fCancelPendingCallbacks)
+VOID winpr_WaitForThreadpoolWorkCallbacks(PTP_WORK pwk,
+                                          WINPR_ATTR_UNUSED BOOL fCancelPendingCallbacks)
 {
 	HANDLE event = NULL;
 	PTP_POOL pool = NULL;

--- a/winpr/libwinpr/registry/registry.c
+++ b/winpr/libwinpr/registry/registry.c
@@ -57,65 +57,73 @@ LONG RegCloseKey(HKEY hKey)
 	return 0;
 }
 
-LONG RegCopyTreeW(HKEY hKeySrc, LPCWSTR lpSubKey, HKEY hKeyDest)
+LONG RegCopyTreeW(WINPR_ATTR_UNUSED HKEY hKeySrc, WINPR_ATTR_UNUSED LPCWSTR lpSubKey,
+                  WINPR_ATTR_UNUSED HKEY hKeyDest)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegCopyTreeA(HKEY hKeySrc, LPCSTR lpSubKey, HKEY hKeyDest)
+LONG RegCopyTreeA(WINPR_ATTR_UNUSED HKEY hKeySrc, WINPR_ATTR_UNUSED LPCSTR lpSubKey,
+                  WINPR_ATTR_UNUSED HKEY hKeyDest)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegCreateKeyExW(HKEY hKey, LPCWSTR lpSubKey, DWORD Reserved, LPWSTR lpClass, DWORD dwOptions,
-                     REGSAM samDesired, LPSECURITY_ATTRIBUTES lpSecurityAttributes, PHKEY phkResult,
-                     LPDWORD lpdwDisposition)
+LONG RegCreateKeyExW(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCWSTR lpSubKey,
+                     WINPR_ATTR_UNUSED DWORD Reserved, WINPR_ATTR_UNUSED LPWSTR lpClass,
+                     WINPR_ATTR_UNUSED DWORD dwOptions, WINPR_ATTR_UNUSED REGSAM samDesired,
+                     WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpSecurityAttributes,
+                     WINPR_ATTR_UNUSED PHKEY phkResult, WINPR_ATTR_UNUSED LPDWORD lpdwDisposition)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegCreateKeyExA(HKEY hKey, LPCSTR lpSubKey, DWORD Reserved, LPSTR lpClass, DWORD dwOptions,
-                     REGSAM samDesired, LPSECURITY_ATTRIBUTES lpSecurityAttributes, PHKEY phkResult,
-                     LPDWORD lpdwDisposition)
+LONG RegCreateKeyExA(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCSTR lpSubKey,
+                     WINPR_ATTR_UNUSED DWORD Reserved, WINPR_ATTR_UNUSED LPSTR lpClass,
+                     WINPR_ATTR_UNUSED DWORD dwOptions, WINPR_ATTR_UNUSED REGSAM samDesired,
+                     WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpSecurityAttributes,
+                     WINPR_ATTR_UNUSED PHKEY phkResult, WINPR_ATTR_UNUSED LPDWORD lpdwDisposition)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegDeleteKeyExW(HKEY hKey, LPCWSTR lpSubKey, REGSAM samDesired, DWORD Reserved)
+LONG RegDeleteKeyExW(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCWSTR lpSubKey,
+                     WINPR_ATTR_UNUSED REGSAM samDesired, WINPR_ATTR_UNUSED DWORD Reserved)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegDeleteKeyExA(HKEY hKey, LPCSTR lpSubKey, REGSAM samDesired, DWORD Reserved)
+LONG RegDeleteKeyExA(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCSTR lpSubKey,
+                     WINPR_ATTR_UNUSED REGSAM samDesired, WINPR_ATTR_UNUSED DWORD Reserved)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegDeleteTreeW(HKEY hKey, LPCWSTR lpSubKey)
+LONG RegDeleteTreeW(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCWSTR lpSubKey)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegDeleteTreeA(HKEY hKey, LPCSTR lpSubKey)
+LONG RegDeleteTreeA(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCSTR lpSubKey)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegDeleteValueW(HKEY hKey, LPCWSTR lpValueName)
+LONG RegDeleteValueW(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCWSTR lpValueName)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegDeleteValueA(HKEY hKey, LPCSTR lpValueName)
+LONG RegDeleteValueA(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCSTR lpValueName)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
@@ -127,109 +135,134 @@ LONG RegDisablePredefinedCacheEx(void)
 	return -1;
 }
 
-LONG RegEnumKeyExW(HKEY hKey, DWORD dwIndex, LPWSTR lpName, LPDWORD lpcName, LPDWORD lpReserved,
-                   LPWSTR lpClass, LPDWORD lpcClass, PFILETIME lpftLastWriteTime)
+LONG RegEnumKeyExW(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED DWORD dwIndex,
+                   WINPR_ATTR_UNUSED LPWSTR lpName, WINPR_ATTR_UNUSED LPDWORD lpcName,
+                   WINPR_ATTR_UNUSED LPDWORD lpReserved, WINPR_ATTR_UNUSED LPWSTR lpClass,
+                   WINPR_ATTR_UNUSED LPDWORD lpcClass,
+                   WINPR_ATTR_UNUSED PFILETIME lpftLastWriteTime)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegEnumKeyExA(HKEY hKey, DWORD dwIndex, LPSTR lpName, LPDWORD lpcName, LPDWORD lpReserved,
-                   LPSTR lpClass, LPDWORD lpcClass, PFILETIME lpftLastWriteTime)
+LONG RegEnumKeyExA(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED DWORD dwIndex,
+                   WINPR_ATTR_UNUSED LPSTR lpName, WINPR_ATTR_UNUSED LPDWORD lpcName,
+                   WINPR_ATTR_UNUSED LPDWORD lpReserved, WINPR_ATTR_UNUSED LPSTR lpClass,
+                   WINPR_ATTR_UNUSED LPDWORD lpcClass,
+                   WINPR_ATTR_UNUSED PFILETIME lpftLastWriteTime)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegEnumValueW(HKEY hKey, DWORD dwIndex, LPWSTR lpValueName, LPDWORD lpcchValueName,
-                   LPDWORD lpReserved, LPDWORD lpType, LPBYTE lpData, LPDWORD lpcbData)
+LONG RegEnumValueW(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED DWORD dwIndex,
+                   WINPR_ATTR_UNUSED LPWSTR lpValueName, WINPR_ATTR_UNUSED LPDWORD lpcchValueName,
+                   WINPR_ATTR_UNUSED LPDWORD lpReserved, WINPR_ATTR_UNUSED LPDWORD lpType,
+                   WINPR_ATTR_UNUSED LPBYTE lpData, WINPR_ATTR_UNUSED LPDWORD lpcbData)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegEnumValueA(HKEY hKey, DWORD dwIndex, LPSTR lpValueName, LPDWORD lpcchValueName,
-                   LPDWORD lpReserved, LPDWORD lpType, LPBYTE lpData, LPDWORD lpcbData)
+LONG RegEnumValueA(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED DWORD dwIndex,
+                   WINPR_ATTR_UNUSED LPSTR lpValueName, WINPR_ATTR_UNUSED LPDWORD lpcchValueName,
+                   WINPR_ATTR_UNUSED LPDWORD lpReserved, WINPR_ATTR_UNUSED LPDWORD lpType,
+                   WINPR_ATTR_UNUSED LPBYTE lpData, WINPR_ATTR_UNUSED LPDWORD lpcbData)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegFlushKey(HKEY hKey)
+LONG RegFlushKey(WINPR_ATTR_UNUSED HKEY hKey)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegGetKeySecurity(HKEY hKey, SECURITY_INFORMATION SecurityInformation,
-                       PSECURITY_DESCRIPTOR pSecurityDescriptor, LPDWORD lpcbSecurityDescriptor)
+LONG RegGetKeySecurity(WINPR_ATTR_UNUSED HKEY hKey,
+                       WINPR_ATTR_UNUSED SECURITY_INFORMATION SecurityInformation,
+                       WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor,
+                       WINPR_ATTR_UNUSED LPDWORD lpcbSecurityDescriptor)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegGetValueW(HKEY hkey, LPCWSTR lpSubKey, LPCWSTR lpValue, DWORD dwFlags, LPDWORD pdwType,
-                  PVOID pvData, LPDWORD pcbData)
+LONG RegGetValueW(WINPR_ATTR_UNUSED HKEY hkey, WINPR_ATTR_UNUSED LPCWSTR lpSubKey,
+                  WINPR_ATTR_UNUSED LPCWSTR lpValue, WINPR_ATTR_UNUSED DWORD dwFlags,
+                  WINPR_ATTR_UNUSED LPDWORD pdwType, WINPR_ATTR_UNUSED PVOID pvData,
+                  WINPR_ATTR_UNUSED LPDWORD pcbData)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegGetValueA(HKEY hkey, LPCSTR lpSubKey, LPCSTR lpValue, DWORD dwFlags, LPDWORD pdwType,
-                  PVOID pvData, LPDWORD pcbData)
+LONG RegGetValueA(WINPR_ATTR_UNUSED HKEY hkey, WINPR_ATTR_UNUSED LPCSTR lpSubKey,
+                  WINPR_ATTR_UNUSED LPCSTR lpValue, WINPR_ATTR_UNUSED DWORD dwFlags,
+                  WINPR_ATTR_UNUSED LPDWORD pdwType, WINPR_ATTR_UNUSED PVOID pvData,
+                  WINPR_ATTR_UNUSED LPDWORD pcbData)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegLoadAppKeyW(LPCWSTR lpFile, PHKEY phkResult, REGSAM samDesired, DWORD dwOptions,
-                    DWORD Reserved)
+LONG RegLoadAppKeyW(WINPR_ATTR_UNUSED LPCWSTR lpFile, WINPR_ATTR_UNUSED PHKEY phkResult,
+                    WINPR_ATTR_UNUSED REGSAM samDesired, WINPR_ATTR_UNUSED DWORD dwOptions,
+                    WINPR_ATTR_UNUSED DWORD Reserved)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegLoadAppKeyA(LPCSTR lpFile, PHKEY phkResult, REGSAM samDesired, DWORD dwOptions,
-                    DWORD Reserved)
+LONG RegLoadAppKeyA(WINPR_ATTR_UNUSED LPCSTR lpFile, WINPR_ATTR_UNUSED PHKEY phkResult,
+                    WINPR_ATTR_UNUSED REGSAM samDesired, WINPR_ATTR_UNUSED DWORD dwOptions,
+                    WINPR_ATTR_UNUSED DWORD Reserved)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegLoadKeyW(HKEY hKey, LPCWSTR lpSubKey, LPCWSTR lpFile)
+LONG RegLoadKeyW(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCWSTR lpSubKey,
+                 WINPR_ATTR_UNUSED LPCWSTR lpFile)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegLoadKeyA(HKEY hKey, LPCSTR lpSubKey, LPCSTR lpFile)
+LONG RegLoadKeyA(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCSTR lpSubKey,
+                 WINPR_ATTR_UNUSED LPCSTR lpFile)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegLoadMUIStringW(HKEY hKey, LPCWSTR pszValue, LPWSTR pszOutBuf, DWORD cbOutBuf,
-                       LPDWORD pcbData, DWORD Flags, LPCWSTR pszDirectory)
+LONG RegLoadMUIStringW(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCWSTR pszValue,
+                       WINPR_ATTR_UNUSED LPWSTR pszOutBuf, WINPR_ATTR_UNUSED DWORD cbOutBuf,
+                       WINPR_ATTR_UNUSED LPDWORD pcbData, WINPR_ATTR_UNUSED DWORD Flags,
+                       WINPR_ATTR_UNUSED LPCWSTR pszDirectory)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegLoadMUIStringA(HKEY hKey, LPCSTR pszValue, LPSTR pszOutBuf, DWORD cbOutBuf, LPDWORD pcbData,
-                       DWORD Flags, LPCSTR pszDirectory)
+LONG RegLoadMUIStringA(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCSTR pszValue,
+                       WINPR_ATTR_UNUSED LPSTR pszOutBuf, WINPR_ATTR_UNUSED DWORD cbOutBuf,
+                       WINPR_ATTR_UNUSED LPDWORD pcbData, WINPR_ATTR_UNUSED DWORD Flags,
+                       WINPR_ATTR_UNUSED LPCSTR pszDirectory)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegNotifyChangeKeyValue(HKEY hKey, BOOL bWatchSubtree, DWORD dwNotifyFilter, HANDLE hEvent,
-                             BOOL fAsynchronous)
+LONG RegNotifyChangeKeyValue(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED BOOL bWatchSubtree,
+                             WINPR_ATTR_UNUSED DWORD dwNotifyFilter,
+                             WINPR_ATTR_UNUSED HANDLE hEvent, WINPR_ATTR_UNUSED BOOL fAsynchronous)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegOpenCurrentUser(REGSAM samDesired, PHKEY phkResult)
+LONG RegOpenCurrentUser(WINPR_ATTR_UNUSED REGSAM samDesired, WINPR_ATTR_UNUSED PHKEY phkResult)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
@@ -247,7 +280,8 @@ LONG RegOpenKeyExW(HKEY hKey, LPCWSTR lpSubKey, DWORD ulOptions, REGSAM samDesir
 	return rc;
 }
 
-LONG RegOpenKeyExA(HKEY hKey, LPCSTR lpSubKey, DWORD ulOptions, REGSAM samDesired, PHKEY phkResult)
+LONG RegOpenKeyExA(HKEY hKey, LPCSTR lpSubKey, WINPR_ATTR_UNUSED DWORD ulOptions,
+                   WINPR_ATTR_UNUSED REGSAM samDesired, PHKEY phkResult)
 {
 	Reg* reg = RegGetInstance();
 
@@ -281,25 +315,36 @@ LONG RegOpenKeyExA(HKEY hKey, LPCSTR lpSubKey, DWORD ulOptions, REGSAM samDesire
 	return ERROR_FILE_NOT_FOUND;
 }
 
-LONG RegOpenUserClassesRoot(HANDLE hToken, DWORD dwOptions, REGSAM samDesired, PHKEY phkResult)
+LONG RegOpenUserClassesRoot(WINPR_ATTR_UNUSED HANDLE hToken, WINPR_ATTR_UNUSED DWORD dwOptions,
+                            WINPR_ATTR_UNUSED REGSAM samDesired, WINPR_ATTR_UNUSED PHKEY phkResult)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegQueryInfoKeyW(HKEY hKey, LPWSTR lpClass, LPDWORD lpcClass, LPDWORD lpReserved,
-                      LPDWORD lpcSubKeys, LPDWORD lpcMaxSubKeyLen, LPDWORD lpcMaxClassLen,
-                      LPDWORD lpcValues, LPDWORD lpcMaxValueNameLen, LPDWORD lpcMaxValueLen,
-                      LPDWORD lpcbSecurityDescriptor, PFILETIME lpftLastWriteTime)
+LONG RegQueryInfoKeyW(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPWSTR lpClass,
+                      WINPR_ATTR_UNUSED LPDWORD lpcClass, WINPR_ATTR_UNUSED LPDWORD lpReserved,
+                      WINPR_ATTR_UNUSED LPDWORD lpcSubKeys,
+                      WINPR_ATTR_UNUSED LPDWORD lpcMaxSubKeyLen,
+                      WINPR_ATTR_UNUSED LPDWORD lpcMaxClassLen, WINPR_ATTR_UNUSED LPDWORD lpcValues,
+                      WINPR_ATTR_UNUSED LPDWORD lpcMaxValueNameLen,
+                      WINPR_ATTR_UNUSED LPDWORD lpcMaxValueLen,
+                      WINPR_ATTR_UNUSED LPDWORD lpcbSecurityDescriptor,
+                      WINPR_ATTR_UNUSED PFILETIME lpftLastWriteTime)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegQueryInfoKeyA(HKEY hKey, LPSTR lpClass, LPDWORD lpcClass, LPDWORD lpReserved,
-                      LPDWORD lpcSubKeys, LPDWORD lpcMaxSubKeyLen, LPDWORD lpcMaxClassLen,
-                      LPDWORD lpcValues, LPDWORD lpcMaxValueNameLen, LPDWORD lpcMaxValueLen,
-                      LPDWORD lpcbSecurityDescriptor, PFILETIME lpftLastWriteTime)
+LONG RegQueryInfoKeyA(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPSTR lpClass,
+                      WINPR_ATTR_UNUSED LPDWORD lpcClass, WINPR_ATTR_UNUSED LPDWORD lpReserved,
+                      WINPR_ATTR_UNUSED LPDWORD lpcSubKeys,
+                      WINPR_ATTR_UNUSED LPDWORD lpcMaxSubKeyLen,
+                      WINPR_ATTR_UNUSED LPDWORD lpcMaxClassLen, WINPR_ATTR_UNUSED LPDWORD lpcValues,
+                      WINPR_ATTR_UNUSED LPDWORD lpcMaxValueNameLen,
+                      WINPR_ATTR_UNUSED LPDWORD lpcMaxValueLen,
+                      WINPR_ATTR_UNUSED LPDWORD lpcbSecurityDescriptor,
+                      WINPR_ATTR_UNUSED PFILETIME lpftLastWriteTime)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
@@ -497,60 +542,67 @@ LONG RegQueryValueExA(HKEY hKey, LPCSTR lpValueName, LPDWORD lpReserved, LPDWORD
 	return ERROR_FILE_NOT_FOUND;
 }
 
-LONG RegRestoreKeyW(HKEY hKey, LPCWSTR lpFile, DWORD dwFlags)
+LONG RegRestoreKeyW(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCWSTR lpFile,
+                    WINPR_ATTR_UNUSED DWORD dwFlags)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegRestoreKeyA(HKEY hKey, LPCSTR lpFile, DWORD dwFlags)
+LONG RegRestoreKeyA(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCSTR lpFile,
+                    WINPR_ATTR_UNUSED DWORD dwFlags)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegSaveKeyExW(HKEY hKey, LPCWSTR lpFile, LPSECURITY_ATTRIBUTES lpSecurityAttributes,
-                   DWORD Flags)
+LONG RegSaveKeyExW(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCWSTR lpFile,
+                   WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpSecurityAttributes,
+                   WINPR_ATTR_UNUSED DWORD Flags)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegSaveKeyExA(HKEY hKey, LPCSTR lpFile, LPSECURITY_ATTRIBUTES lpSecurityAttributes,
-                   DWORD Flags)
+LONG RegSaveKeyExA(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCSTR lpFile,
+                   WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpSecurityAttributes,
+                   WINPR_ATTR_UNUSED DWORD Flags)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegSetKeySecurity(HKEY hKey, SECURITY_INFORMATION SecurityInformation,
-                       PSECURITY_DESCRIPTOR pSecurityDescriptor)
+LONG RegSetKeySecurity(WINPR_ATTR_UNUSED HKEY hKey,
+                       WINPR_ATTR_UNUSED SECURITY_INFORMATION SecurityInformation,
+                       WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegSetValueExW(HKEY hKey, LPCWSTR lpValueName, DWORD Reserved, DWORD dwType,
-                    const BYTE* lpData, DWORD cbData)
+LONG RegSetValueExW(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCWSTR lpValueName,
+                    WINPR_ATTR_UNUSED DWORD Reserved, WINPR_ATTR_UNUSED DWORD dwType,
+                    WINPR_ATTR_UNUSED const BYTE* lpData, WINPR_ATTR_UNUSED DWORD cbData)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegSetValueExA(HKEY hKey, LPCSTR lpValueName, DWORD Reserved, DWORD dwType, const BYTE* lpData,
-                    DWORD cbData)
+LONG RegSetValueExA(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCSTR lpValueName,
+                    WINPR_ATTR_UNUSED DWORD Reserved, WINPR_ATTR_UNUSED DWORD dwType,
+                    WINPR_ATTR_UNUSED const BYTE* lpData, WINPR_ATTR_UNUSED DWORD cbData)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegUnLoadKeyW(HKEY hKey, LPCWSTR lpSubKey)
+LONG RegUnLoadKeyW(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCWSTR lpSubKey)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;
 }
 
-LONG RegUnLoadKeyA(HKEY hKey, LPCSTR lpSubKey)
+LONG RegUnLoadKeyA(WINPR_ATTR_UNUSED HKEY hKey, WINPR_ATTR_UNUSED LPCSTR lpSubKey)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return -1;

--- a/winpr/libwinpr/registry/registry_reg.c
+++ b/winpr/libwinpr/registry/registry_reg.c
@@ -305,7 +305,7 @@ static char* reg_load_peek_next_line(Reg* reg)
 	return reg->next_line;
 }
 
-static void reg_insert_key(Reg* reg, RegKey* key, RegKey* subkey)
+static void reg_insert_key(WINPR_ATTR_UNUSED Reg* reg, RegKey* key, RegKey* subkey)
 {
 	char* name = NULL;
 	char* path = NULL;
@@ -430,7 +430,7 @@ static void reg_load(Reg* reg)
 	reg_load_finish(reg);
 }
 
-static void reg_unload_value(Reg* reg, RegVal* value)
+static void reg_unload_value(WINPR_ATTR_UNUSED Reg* reg, RegVal* value)
 {
 	WINPR_ASSERT(reg);
 	WINPR_ASSERT(value);

--- a/winpr/libwinpr/rpc/rpc.c
+++ b/winpr/libwinpr/rpc/rpc.c
@@ -28,117 +28,142 @@
 #include "../log.h"
 #define TAG WINPR_TAG("rpc")
 
-RPC_STATUS RpcBindingCopy(RPC_BINDING_HANDLE SourceBinding, RPC_BINDING_HANDLE* DestinationBinding)
+RPC_STATUS RpcBindingCopy(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE SourceBinding,
+                          WINPR_ATTR_UNUSED RPC_BINDING_HANDLE* DestinationBinding)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingFree(RPC_BINDING_HANDLE* Binding)
+RPC_STATUS RpcBindingFree(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE* Binding)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingSetOption(RPC_BINDING_HANDLE hBinding, unsigned long option,
-                               ULONG_PTR optionValue)
+RPC_STATUS RpcBindingSetOption(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE hBinding,
+                               WINPR_ATTR_UNUSED unsigned long option,
+                               WINPR_ATTR_UNUSED ULONG_PTR optionValue)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingInqOption(RPC_BINDING_HANDLE hBinding, unsigned long option,
-                               ULONG_PTR* pOptionValue)
+RPC_STATUS RpcBindingInqOption(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE hBinding,
+                               WINPR_ATTR_UNUSED unsigned long option,
+                               WINPR_ATTR_UNUSED ULONG_PTR* pOptionValue)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingFromStringBindingA(RPC_CSTR StringBinding, RPC_BINDING_HANDLE* Binding)
+RPC_STATUS RpcBindingFromStringBindingA(WINPR_ATTR_UNUSED RPC_CSTR StringBinding,
+                                        WINPR_ATTR_UNUSED RPC_BINDING_HANDLE* Binding)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingFromStringBindingW(RPC_WSTR StringBinding, RPC_BINDING_HANDLE* Binding)
+RPC_STATUS RpcBindingFromStringBindingW(WINPR_ATTR_UNUSED RPC_WSTR StringBinding,
+                                        WINPR_ATTR_UNUSED RPC_BINDING_HANDLE* Binding)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcSsGetContextBinding(void* ContextHandle, RPC_BINDING_HANDLE* Binding)
+RPC_STATUS RpcSsGetContextBinding(WINPR_ATTR_UNUSED void* ContextHandle,
+                                  WINPR_ATTR_UNUSED RPC_BINDING_HANDLE* Binding)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingInqObject(RPC_BINDING_HANDLE Binding, UUID* ObjectUuid)
+RPC_STATUS RpcBindingInqObject(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                               WINPR_ATTR_UNUSED UUID* ObjectUuid)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingReset(RPC_BINDING_HANDLE Binding)
+RPC_STATUS RpcBindingReset(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingSetObject(RPC_BINDING_HANDLE Binding, UUID* ObjectUuid)
+RPC_STATUS RpcBindingSetObject(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                               WINPR_ATTR_UNUSED UUID* ObjectUuid)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcMgmtInqDefaultProtectLevel(unsigned long AuthnSvc, unsigned long* AuthnLevel)
+RPC_STATUS RpcMgmtInqDefaultProtectLevel(WINPR_ATTR_UNUSED unsigned long AuthnSvc,
+                                         WINPR_ATTR_UNUSED unsigned long* AuthnLevel)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingToStringBindingA(RPC_BINDING_HANDLE Binding, RPC_CSTR* StringBinding)
+RPC_STATUS RpcBindingToStringBindingA(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                      WINPR_ATTR_UNUSED RPC_CSTR* StringBinding)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingToStringBindingW(RPC_BINDING_HANDLE Binding, RPC_WSTR* StringBinding)
+RPC_STATUS RpcBindingToStringBindingW(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                      WINPR_ATTR_UNUSED RPC_WSTR* StringBinding)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingVectorFree(RPC_BINDING_VECTOR** BindingVector)
+RPC_STATUS RpcBindingVectorFree(WINPR_ATTR_UNUSED RPC_BINDING_VECTOR** BindingVector)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcStringBindingComposeA(RPC_CSTR ObjUuid, RPC_CSTR Protseq, RPC_CSTR NetworkAddr,
-                                    RPC_CSTR Endpoint, RPC_CSTR Options, RPC_CSTR* StringBinding)
+RPC_STATUS RpcStringBindingComposeA(WINPR_ATTR_UNUSED RPC_CSTR ObjUuid,
+                                    WINPR_ATTR_UNUSED RPC_CSTR Protseq,
+                                    WINPR_ATTR_UNUSED RPC_CSTR NetworkAddr,
+                                    WINPR_ATTR_UNUSED RPC_CSTR Endpoint,
+                                    WINPR_ATTR_UNUSED RPC_CSTR Options,
+                                    WINPR_ATTR_UNUSED RPC_CSTR* StringBinding)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcStringBindingComposeW(RPC_WSTR ObjUuid, RPC_WSTR Protseq, RPC_WSTR NetworkAddr,
-                                    RPC_WSTR Endpoint, RPC_WSTR Options, RPC_WSTR* StringBinding)
+RPC_STATUS RpcStringBindingComposeW(WINPR_ATTR_UNUSED RPC_WSTR ObjUuid,
+                                    WINPR_ATTR_UNUSED RPC_WSTR Protseq,
+                                    WINPR_ATTR_UNUSED RPC_WSTR NetworkAddr,
+                                    WINPR_ATTR_UNUSED RPC_WSTR Endpoint,
+                                    WINPR_ATTR_UNUSED RPC_WSTR Options,
+                                    WINPR_ATTR_UNUSED RPC_WSTR* StringBinding)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcStringBindingParseA(RPC_CSTR StringBinding, RPC_CSTR* ObjUuid, RPC_CSTR* Protseq,
-                                  RPC_CSTR* NetworkAddr, RPC_CSTR* Endpoint,
-                                  RPC_CSTR* NetworkOptions)
+RPC_STATUS RpcStringBindingParseA(WINPR_ATTR_UNUSED RPC_CSTR StringBinding,
+                                  WINPR_ATTR_UNUSED RPC_CSTR* ObjUuid,
+                                  WINPR_ATTR_UNUSED RPC_CSTR* Protseq,
+                                  WINPR_ATTR_UNUSED RPC_CSTR* NetworkAddr,
+                                  WINPR_ATTR_UNUSED RPC_CSTR* Endpoint,
+                                  WINPR_ATTR_UNUSED RPC_CSTR* NetworkOptions)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcStringBindingParseW(RPC_WSTR StringBinding, RPC_WSTR* ObjUuid, RPC_WSTR* Protseq,
-                                  RPC_WSTR* NetworkAddr, RPC_WSTR* Endpoint,
-                                  RPC_WSTR* NetworkOptions)
+RPC_STATUS RpcStringBindingParseW(WINPR_ATTR_UNUSED RPC_WSTR StringBinding,
+                                  WINPR_ATTR_UNUSED RPC_WSTR* ObjUuid,
+                                  WINPR_ATTR_UNUSED RPC_WSTR* Protseq,
+                                  WINPR_ATTR_UNUSED RPC_WSTR* NetworkAddr,
+                                  WINPR_ATTR_UNUSED RPC_WSTR* Endpoint,
+                                  WINPR_ATTR_UNUSED RPC_WSTR* NetworkOptions)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
@@ -160,243 +185,293 @@ RPC_STATUS RpcStringFreeW(RPC_WSTR* String)
 	return RPC_S_OK;
 }
 
-RPC_STATUS RpcIfInqId(RPC_IF_HANDLE RpcIfHandle, RPC_IF_ID* RpcIfId)
+RPC_STATUS RpcIfInqId(WINPR_ATTR_UNUSED RPC_IF_HANDLE RpcIfHandle,
+                      WINPR_ATTR_UNUSED RPC_IF_ID* RpcIfId)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcNetworkIsProtseqValidA(RPC_CSTR Protseq)
+RPC_STATUS RpcNetworkIsProtseqValidA(WINPR_ATTR_UNUSED RPC_CSTR Protseq)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcNetworkIsProtseqValidW(RPC_WSTR Protseq)
+RPC_STATUS RpcNetworkIsProtseqValidW(WINPR_ATTR_UNUSED RPC_WSTR Protseq)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcMgmtInqComTimeout(RPC_BINDING_HANDLE Binding, unsigned int* Timeout)
+RPC_STATUS RpcMgmtInqComTimeout(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                WINPR_ATTR_UNUSED unsigned int* Timeout)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcMgmtSetComTimeout(RPC_BINDING_HANDLE Binding, unsigned int Timeout)
+RPC_STATUS RpcMgmtSetComTimeout(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                WINPR_ATTR_UNUSED unsigned int Timeout)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcMgmtSetCancelTimeout(long Timeout)
+RPC_STATUS RpcMgmtSetCancelTimeout(WINPR_ATTR_UNUSED long Timeout)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcNetworkInqProtseqsA(RPC_PROTSEQ_VECTORA** ProtseqVector)
+RPC_STATUS RpcNetworkInqProtseqsA(WINPR_ATTR_UNUSED RPC_PROTSEQ_VECTORA** ProtseqVector)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcNetworkInqProtseqsW(RPC_PROTSEQ_VECTORW** ProtseqVector)
+RPC_STATUS RpcNetworkInqProtseqsW(WINPR_ATTR_UNUSED RPC_PROTSEQ_VECTORW** ProtseqVector)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcObjectInqType(UUID* ObjUuid, UUID* TypeUuid)
+RPC_STATUS RpcObjectInqType(WINPR_ATTR_UNUSED UUID* ObjUuid, WINPR_ATTR_UNUSED UUID* TypeUuid)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcObjectSetInqFn(RPC_OBJECT_INQ_FN* InquiryFn)
+RPC_STATUS RpcObjectSetInqFn(WINPR_ATTR_UNUSED RPC_OBJECT_INQ_FN* InquiryFn)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcObjectSetType(UUID* ObjUuid, UUID* TypeUuid)
+RPC_STATUS RpcObjectSetType(WINPR_ATTR_UNUSED UUID* ObjUuid, WINPR_ATTR_UNUSED UUID* TypeUuid)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcProtseqVectorFreeA(RPC_PROTSEQ_VECTORA** ProtseqVector)
+RPC_STATUS RpcProtseqVectorFreeA(WINPR_ATTR_UNUSED RPC_PROTSEQ_VECTORA** ProtseqVector)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcProtseqVectorFreeW(RPC_PROTSEQ_VECTORW** ProtseqVector)
+RPC_STATUS RpcProtseqVectorFreeW(WINPR_ATTR_UNUSED RPC_PROTSEQ_VECTORW** ProtseqVector)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerInqBindings(RPC_BINDING_VECTOR** BindingVector)
+RPC_STATUS RpcServerInqBindings(WINPR_ATTR_UNUSED RPC_BINDING_VECTOR** BindingVector)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerInqIf(RPC_IF_HANDLE IfSpec, UUID* MgrTypeUuid, RPC_MGR_EPV** MgrEpv)
+RPC_STATUS RpcServerInqIf(WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                          WINPR_ATTR_UNUSED UUID* MgrTypeUuid,
+                          WINPR_ATTR_UNUSED RPC_MGR_EPV** MgrEpv)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerListen(unsigned int MinimumCallThreads, unsigned int MaxCalls,
-                           unsigned int DontWait)
+RPC_STATUS RpcServerListen(WINPR_ATTR_UNUSED unsigned int MinimumCallThreads,
+                           WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                           WINPR_ATTR_UNUSED unsigned int DontWait)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerRegisterIf(RPC_IF_HANDLE IfSpec, UUID* MgrTypeUuid, RPC_MGR_EPV* MgrEpv)
+RPC_STATUS RpcServerRegisterIf(WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                               WINPR_ATTR_UNUSED UUID* MgrTypeUuid,
+                               WINPR_ATTR_UNUSED RPC_MGR_EPV* MgrEpv)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerRegisterIfEx(RPC_IF_HANDLE IfSpec, UUID* MgrTypeUuid, RPC_MGR_EPV* MgrEpv,
-                                 unsigned int Flags, unsigned int MaxCalls,
-                                 RPC_IF_CALLBACK_FN* IfCallback)
+RPC_STATUS RpcServerRegisterIfEx(WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                                 WINPR_ATTR_UNUSED UUID* MgrTypeUuid,
+                                 WINPR_ATTR_UNUSED RPC_MGR_EPV* MgrEpv,
+                                 WINPR_ATTR_UNUSED unsigned int Flags,
+                                 WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                 WINPR_ATTR_UNUSED RPC_IF_CALLBACK_FN* IfCallback)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerRegisterIf2(RPC_IF_HANDLE IfSpec, UUID* MgrTypeUuid, RPC_MGR_EPV* MgrEpv,
-                                unsigned int Flags, unsigned int MaxCalls, unsigned int MaxRpcSize,
-                                RPC_IF_CALLBACK_FN* IfCallbackFn)
+RPC_STATUS RpcServerRegisterIf2(WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                                WINPR_ATTR_UNUSED UUID* MgrTypeUuid,
+                                WINPR_ATTR_UNUSED RPC_MGR_EPV* MgrEpv,
+                                WINPR_ATTR_UNUSED unsigned int Flags,
+                                WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                WINPR_ATTR_UNUSED unsigned int MaxRpcSize,
+                                WINPR_ATTR_UNUSED RPC_IF_CALLBACK_FN* IfCallbackFn)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUnregisterIf(RPC_IF_HANDLE IfSpec, UUID* MgrTypeUuid,
-                                 unsigned int WaitForCallsToComplete)
+RPC_STATUS RpcServerUnregisterIf(WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                                 WINPR_ATTR_UNUSED UUID* MgrTypeUuid,
+                                 WINPR_ATTR_UNUSED unsigned int WaitForCallsToComplete)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUnregisterIfEx(RPC_IF_HANDLE IfSpec, UUID* MgrTypeUuid,
-                                   int RundownContextHandles)
+RPC_STATUS RpcServerUnregisterIfEx(WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                                   WINPR_ATTR_UNUSED UUID* MgrTypeUuid,
+                                   WINPR_ATTR_UNUSED int RundownContextHandles)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseAllProtseqs(unsigned int MaxCalls, void* SecurityDescriptor)
+RPC_STATUS RpcServerUseAllProtseqs(WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                   WINPR_ATTR_UNUSED void* SecurityDescriptor)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseAllProtseqsEx(unsigned int MaxCalls, void* SecurityDescriptor,
-                                     PRPC_POLICY Policy)
+RPC_STATUS RpcServerUseAllProtseqsEx(WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                     WINPR_ATTR_UNUSED void* SecurityDescriptor,
+                                     WINPR_ATTR_UNUSED PRPC_POLICY Policy)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseAllProtseqsIf(unsigned int MaxCalls, RPC_IF_HANDLE IfSpec,
-                                     void* SecurityDescriptor)
+RPC_STATUS RpcServerUseAllProtseqsIf(WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                     WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                                     WINPR_ATTR_UNUSED void* SecurityDescriptor)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseAllProtseqsIfEx(unsigned int MaxCalls, RPC_IF_HANDLE IfSpec,
-                                       void* SecurityDescriptor, PRPC_POLICY Policy)
+RPC_STATUS RpcServerUseAllProtseqsIfEx(WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                       WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                                       WINPR_ATTR_UNUSED void* SecurityDescriptor,
+                                       WINPR_ATTR_UNUSED PRPC_POLICY Policy)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseProtseqA(RPC_CSTR Protseq, unsigned int MaxCalls, void* SecurityDescriptor)
+RPC_STATUS RpcServerUseProtseqA(WINPR_ATTR_UNUSED RPC_CSTR Protseq,
+                                WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                WINPR_ATTR_UNUSED void* SecurityDescriptor)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseProtseqExA(RPC_CSTR Protseq, unsigned int MaxCalls, void* SecurityDescriptor,
-                                  PRPC_POLICY Policy)
+RPC_STATUS RpcServerUseProtseqExA(WINPR_ATTR_UNUSED RPC_CSTR Protseq,
+                                  WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                  WINPR_ATTR_UNUSED void* SecurityDescriptor,
+                                  WINPR_ATTR_UNUSED PRPC_POLICY Policy)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseProtseqW(RPC_WSTR Protseq, unsigned int MaxCalls, void* SecurityDescriptor)
+RPC_STATUS RpcServerUseProtseqW(WINPR_ATTR_UNUSED RPC_WSTR Protseq,
+                                WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                WINPR_ATTR_UNUSED void* SecurityDescriptor)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseProtseqExW(RPC_WSTR Protseq, unsigned int MaxCalls, void* SecurityDescriptor,
-                                  PRPC_POLICY Policy)
+RPC_STATUS RpcServerUseProtseqExW(WINPR_ATTR_UNUSED RPC_WSTR Protseq,
+                                  WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                  WINPR_ATTR_UNUSED void* SecurityDescriptor,
+                                  WINPR_ATTR_UNUSED PRPC_POLICY Policy)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseProtseqEpA(RPC_CSTR Protseq, unsigned int MaxCalls, RPC_CSTR Endpoint,
-                                  void* SecurityDescriptor)
+RPC_STATUS RpcServerUseProtseqEpA(WINPR_ATTR_UNUSED RPC_CSTR Protseq,
+                                  WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                  WINPR_ATTR_UNUSED RPC_CSTR Endpoint,
+                                  WINPR_ATTR_UNUSED void* SecurityDescriptor)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseProtseqEpExA(RPC_CSTR Protseq, unsigned int MaxCalls, RPC_CSTR Endpoint,
-                                    void* SecurityDescriptor, PRPC_POLICY Policy)
+RPC_STATUS RpcServerUseProtseqEpExA(WINPR_ATTR_UNUSED RPC_CSTR Protseq,
+                                    WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                    WINPR_ATTR_UNUSED RPC_CSTR Endpoint,
+                                    WINPR_ATTR_UNUSED void* SecurityDescriptor,
+                                    WINPR_ATTR_UNUSED PRPC_POLICY Policy)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseProtseqEpW(RPC_WSTR Protseq, unsigned int MaxCalls, RPC_WSTR Endpoint,
-                                  void* SecurityDescriptor)
+RPC_STATUS RpcServerUseProtseqEpW(WINPR_ATTR_UNUSED RPC_WSTR Protseq,
+                                  WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                  WINPR_ATTR_UNUSED RPC_WSTR Endpoint,
+                                  WINPR_ATTR_UNUSED void* SecurityDescriptor)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseProtseqEpExW(RPC_WSTR Protseq, unsigned int MaxCalls, RPC_WSTR Endpoint,
-                                    void* SecurityDescriptor, PRPC_POLICY Policy)
+RPC_STATUS RpcServerUseProtseqEpExW(WINPR_ATTR_UNUSED RPC_WSTR Protseq,
+                                    WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                    WINPR_ATTR_UNUSED RPC_WSTR Endpoint,
+                                    WINPR_ATTR_UNUSED void* SecurityDescriptor,
+                                    WINPR_ATTR_UNUSED PRPC_POLICY Policy)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseProtseqIfA(RPC_CSTR Protseq, unsigned int MaxCalls, RPC_IF_HANDLE IfSpec,
-                                  void* SecurityDescriptor)
+RPC_STATUS RpcServerUseProtseqIfA(WINPR_ATTR_UNUSED RPC_CSTR Protseq,
+                                  WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                  WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                                  WINPR_ATTR_UNUSED void* SecurityDescriptor)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseProtseqIfExA(RPC_CSTR Protseq, unsigned int MaxCalls, RPC_IF_HANDLE IfSpec,
-                                    void* SecurityDescriptor, PRPC_POLICY Policy)
+RPC_STATUS RpcServerUseProtseqIfExA(WINPR_ATTR_UNUSED RPC_CSTR Protseq,
+                                    WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                    WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                                    WINPR_ATTR_UNUSED void* SecurityDescriptor,
+                                    WINPR_ATTR_UNUSED PRPC_POLICY Policy)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseProtseqIfW(RPC_WSTR Protseq, unsigned int MaxCalls, RPC_IF_HANDLE IfSpec,
-                                  void* SecurityDescriptor)
+RPC_STATUS RpcServerUseProtseqIfW(WINPR_ATTR_UNUSED RPC_WSTR Protseq,
+                                  WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                  WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                                  WINPR_ATTR_UNUSED void* SecurityDescriptor)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerUseProtseqIfExW(RPC_WSTR Protseq, unsigned int MaxCalls, RPC_IF_HANDLE IfSpec,
-                                    void* SecurityDescriptor, PRPC_POLICY Policy)
+RPC_STATUS RpcServerUseProtseqIfExW(WINPR_ATTR_UNUSED RPC_WSTR Protseq,
+                                    WINPR_ATTR_UNUSED unsigned int MaxCalls,
+                                    WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                                    WINPR_ATTR_UNUSED void* SecurityDescriptor,
+                                    WINPR_ATTR_UNUSED PRPC_POLICY Policy)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
@@ -407,25 +482,26 @@ void RpcServerYield(void)
 	WLog_ERR(TAG, "Not implemented");
 }
 
-RPC_STATUS RpcMgmtStatsVectorFree(RPC_STATS_VECTOR** StatsVector)
+RPC_STATUS RpcMgmtStatsVectorFree(WINPR_ATTR_UNUSED RPC_STATS_VECTOR** StatsVector)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcMgmtInqStats(RPC_BINDING_HANDLE Binding, RPC_STATS_VECTOR** Statistics)
+RPC_STATUS RpcMgmtInqStats(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                           WINPR_ATTR_UNUSED RPC_STATS_VECTOR** Statistics)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcMgmtIsServerListening(RPC_BINDING_HANDLE Binding)
+RPC_STATUS RpcMgmtIsServerListening(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcMgmtStopServerListening(RPC_BINDING_HANDLE Binding)
+RPC_STATUS RpcMgmtStopServerListening(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
@@ -437,7 +513,7 @@ RPC_STATUS RpcMgmtWaitServerListen(void)
 	return 0;
 }
 
-RPC_STATUS RpcMgmtSetServerStackSize(unsigned long ThreadStackSize)
+RPC_STATUS RpcMgmtSetServerStackSize(WINPR_ATTR_UNUSED unsigned long ThreadStackSize)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
@@ -454,71 +530,79 @@ RPC_STATUS RpcMgmtEnableIdleCleanup(void)
 	return 0;
 }
 
-RPC_STATUS RpcMgmtInqIfIds(RPC_BINDING_HANDLE Binding, RPC_IF_ID_VECTOR** IfIdVector)
+RPC_STATUS RpcMgmtInqIfIds(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                           WINPR_ATTR_UNUSED RPC_IF_ID_VECTOR** IfIdVector)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcIfIdVectorFree(RPC_IF_ID_VECTOR** IfIdVector)
+RPC_STATUS RpcIfIdVectorFree(WINPR_ATTR_UNUSED RPC_IF_ID_VECTOR** IfIdVector)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcMgmtInqServerPrincNameA(RPC_BINDING_HANDLE Binding, unsigned long AuthnSvc,
-                                      RPC_CSTR* ServerPrincName)
+RPC_STATUS RpcMgmtInqServerPrincNameA(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                      WINPR_ATTR_UNUSED unsigned long AuthnSvc,
+                                      WINPR_ATTR_UNUSED RPC_CSTR* ServerPrincName)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcMgmtInqServerPrincNameW(RPC_BINDING_HANDLE Binding, unsigned long AuthnSvc,
-                                      RPC_WSTR* ServerPrincName)
+RPC_STATUS RpcMgmtInqServerPrincNameW(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                      WINPR_ATTR_UNUSED unsigned long AuthnSvc,
+                                      WINPR_ATTR_UNUSED RPC_WSTR* ServerPrincName)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerInqDefaultPrincNameA(unsigned long AuthnSvc, RPC_CSTR* PrincName)
+RPC_STATUS RpcServerInqDefaultPrincNameA(WINPR_ATTR_UNUSED unsigned long AuthnSvc,
+                                         WINPR_ATTR_UNUSED RPC_CSTR* PrincName)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerInqDefaultPrincNameW(unsigned long AuthnSvc, RPC_WSTR* PrincName)
+RPC_STATUS RpcServerInqDefaultPrincNameW(WINPR_ATTR_UNUSED unsigned long AuthnSvc,
+                                         WINPR_ATTR_UNUSED RPC_WSTR* PrincName)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcEpResolveBinding(RPC_BINDING_HANDLE Binding, RPC_IF_HANDLE IfSpec)
+RPC_STATUS RpcEpResolveBinding(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                               WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcNsBindingInqEntryNameA(RPC_BINDING_HANDLE Binding, unsigned long EntryNameSyntax,
-                                     RPC_CSTR* EntryName)
+RPC_STATUS RpcNsBindingInqEntryNameA(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                     WINPR_ATTR_UNUSED unsigned long EntryNameSyntax,
+                                     WINPR_ATTR_UNUSED RPC_CSTR* EntryName)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcNsBindingInqEntryNameW(RPC_BINDING_HANDLE Binding, unsigned long EntryNameSyntax,
-                                     RPC_WSTR* EntryName)
+RPC_STATUS RpcNsBindingInqEntryNameW(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                     WINPR_ATTR_UNUSED unsigned long EntryNameSyntax,
+                                     WINPR_ATTR_UNUSED RPC_WSTR* EntryName)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcImpersonateClient(RPC_BINDING_HANDLE BindingHandle)
+RPC_STATUS RpcImpersonateClient(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE BindingHandle)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcRevertToSelfEx(RPC_BINDING_HANDLE BindingHandle)
+RPC_STATUS RpcRevertToSelfEx(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE BindingHandle)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
@@ -530,124 +614,166 @@ RPC_STATUS RpcRevertToSelf(void)
 	return 0;
 }
 
-RPC_STATUS RpcBindingInqAuthClientA(RPC_BINDING_HANDLE ClientBinding, RPC_AUTHZ_HANDLE* Privs,
-                                    RPC_CSTR* ServerPrincName, unsigned long* AuthnLevel,
-                                    unsigned long* AuthnSvc, unsigned long* AuthzSvc)
+RPC_STATUS RpcBindingInqAuthClientA(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE ClientBinding,
+                                    WINPR_ATTR_UNUSED RPC_AUTHZ_HANDLE* Privs,
+                                    WINPR_ATTR_UNUSED RPC_CSTR* ServerPrincName,
+                                    WINPR_ATTR_UNUSED unsigned long* AuthnLevel,
+                                    WINPR_ATTR_UNUSED unsigned long* AuthnSvc,
+                                    WINPR_ATTR_UNUSED unsigned long* AuthzSvc)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingInqAuthClientW(RPC_BINDING_HANDLE ClientBinding, RPC_AUTHZ_HANDLE* Privs,
-                                    RPC_WSTR* ServerPrincName, unsigned long* AuthnLevel,
-                                    unsigned long* AuthnSvc, unsigned long* AuthzSvc)
+RPC_STATUS RpcBindingInqAuthClientW(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE ClientBinding,
+                                    WINPR_ATTR_UNUSED RPC_AUTHZ_HANDLE* Privs,
+                                    WINPR_ATTR_UNUSED RPC_WSTR* ServerPrincName,
+                                    WINPR_ATTR_UNUSED unsigned long* AuthnLevel,
+                                    WINPR_ATTR_UNUSED unsigned long* AuthnSvc,
+                                    WINPR_ATTR_UNUSED unsigned long* AuthzSvc)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingInqAuthClientExA(RPC_BINDING_HANDLE ClientBinding, RPC_AUTHZ_HANDLE* Privs,
-                                      RPC_CSTR* ServerPrincName, unsigned long* AuthnLevel,
-                                      unsigned long* AuthnSvc, unsigned long* AuthzSvc,
-                                      unsigned long Flags)
+RPC_STATUS RpcBindingInqAuthClientExA(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE ClientBinding,
+                                      WINPR_ATTR_UNUSED RPC_AUTHZ_HANDLE* Privs,
+                                      WINPR_ATTR_UNUSED RPC_CSTR* ServerPrincName,
+                                      WINPR_ATTR_UNUSED unsigned long* AuthnLevel,
+                                      WINPR_ATTR_UNUSED unsigned long* AuthnSvc,
+                                      WINPR_ATTR_UNUSED unsigned long* AuthzSvc,
+                                      WINPR_ATTR_UNUSED unsigned long Flags)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingInqAuthClientExW(RPC_BINDING_HANDLE ClientBinding, RPC_AUTHZ_HANDLE* Privs,
-                                      RPC_WSTR* ServerPrincName, unsigned long* AuthnLevel,
-                                      unsigned long* AuthnSvc, unsigned long* AuthzSvc,
-                                      unsigned long Flags)
+RPC_STATUS RpcBindingInqAuthClientExW(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE ClientBinding,
+                                      WINPR_ATTR_UNUSED RPC_AUTHZ_HANDLE* Privs,
+                                      WINPR_ATTR_UNUSED RPC_WSTR* ServerPrincName,
+                                      WINPR_ATTR_UNUSED unsigned long* AuthnLevel,
+                                      WINPR_ATTR_UNUSED unsigned long* AuthnSvc,
+                                      WINPR_ATTR_UNUSED unsigned long* AuthzSvc,
+                                      WINPR_ATTR_UNUSED unsigned long Flags)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingInqAuthInfoA(RPC_BINDING_HANDLE Binding, RPC_CSTR* ServerPrincName,
-                                  unsigned long* AuthnLevel, unsigned long* AuthnSvc,
-                                  RPC_AUTH_IDENTITY_HANDLE* AuthIdentity, unsigned long* AuthzSvc)
+RPC_STATUS RpcBindingInqAuthInfoA(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                  WINPR_ATTR_UNUSED RPC_CSTR* ServerPrincName,
+                                  WINPR_ATTR_UNUSED unsigned long* AuthnLevel,
+                                  WINPR_ATTR_UNUSED unsigned long* AuthnSvc,
+                                  WINPR_ATTR_UNUSED RPC_AUTH_IDENTITY_HANDLE* AuthIdentity,
+                                  WINPR_ATTR_UNUSED unsigned long* AuthzSvc)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingInqAuthInfoW(RPC_BINDING_HANDLE Binding, RPC_WSTR* ServerPrincName,
-                                  unsigned long* AuthnLevel, unsigned long* AuthnSvc,
-                                  RPC_AUTH_IDENTITY_HANDLE* AuthIdentity, unsigned long* AuthzSvc)
+RPC_STATUS RpcBindingInqAuthInfoW(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                  WINPR_ATTR_UNUSED RPC_WSTR* ServerPrincName,
+                                  WINPR_ATTR_UNUSED unsigned long* AuthnLevel,
+                                  WINPR_ATTR_UNUSED unsigned long* AuthnSvc,
+                                  WINPR_ATTR_UNUSED RPC_AUTH_IDENTITY_HANDLE* AuthIdentity,
+                                  WINPR_ATTR_UNUSED unsigned long* AuthzSvc)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingSetAuthInfoA(RPC_BINDING_HANDLE Binding, RPC_CSTR ServerPrincName,
-                                  unsigned long AuthnLevel, unsigned long AuthnSvc,
-                                  RPC_AUTH_IDENTITY_HANDLE AuthIdentity, unsigned long AuthzSvc)
+RPC_STATUS RpcBindingSetAuthInfoA(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                  WINPR_ATTR_UNUSED RPC_CSTR ServerPrincName,
+                                  WINPR_ATTR_UNUSED unsigned long AuthnLevel,
+                                  WINPR_ATTR_UNUSED unsigned long AuthnSvc,
+                                  WINPR_ATTR_UNUSED RPC_AUTH_IDENTITY_HANDLE AuthIdentity,
+                                  WINPR_ATTR_UNUSED unsigned long AuthzSvc)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingSetAuthInfoExA(RPC_BINDING_HANDLE Binding, RPC_CSTR ServerPrincName,
-                                    unsigned long AuthnLevel, unsigned long AuthnSvc,
-                                    RPC_AUTH_IDENTITY_HANDLE AuthIdentity, unsigned long AuthzSvc,
-                                    RPC_SECURITY_QOS* SecurityQos)
+RPC_STATUS RpcBindingSetAuthInfoExA(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                    WINPR_ATTR_UNUSED RPC_CSTR ServerPrincName,
+                                    WINPR_ATTR_UNUSED unsigned long AuthnLevel,
+                                    WINPR_ATTR_UNUSED unsigned long AuthnSvc,
+                                    WINPR_ATTR_UNUSED RPC_AUTH_IDENTITY_HANDLE AuthIdentity,
+                                    WINPR_ATTR_UNUSED unsigned long AuthzSvc,
+                                    WINPR_ATTR_UNUSED RPC_SECURITY_QOS* SecurityQos)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingSetAuthInfoW(RPC_BINDING_HANDLE Binding, RPC_WSTR ServerPrincName,
-                                  unsigned long AuthnLevel, unsigned long AuthnSvc,
-                                  RPC_AUTH_IDENTITY_HANDLE AuthIdentity, unsigned long AuthzSvc)
+RPC_STATUS RpcBindingSetAuthInfoW(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                  WINPR_ATTR_UNUSED RPC_WSTR ServerPrincName,
+                                  WINPR_ATTR_UNUSED unsigned long AuthnLevel,
+                                  WINPR_ATTR_UNUSED unsigned long AuthnSvc,
+                                  WINPR_ATTR_UNUSED RPC_AUTH_IDENTITY_HANDLE AuthIdentity,
+                                  WINPR_ATTR_UNUSED unsigned long AuthzSvc)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingSetAuthInfoExW(RPC_BINDING_HANDLE Binding, RPC_WSTR ServerPrincName,
-                                    unsigned long AuthnLevel, unsigned long AuthnSvc,
-                                    RPC_AUTH_IDENTITY_HANDLE AuthIdentity, unsigned long AuthzSvc,
-                                    RPC_SECURITY_QOS* SecurityQOS)
+RPC_STATUS RpcBindingSetAuthInfoExW(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                    WINPR_ATTR_UNUSED RPC_WSTR ServerPrincName,
+                                    WINPR_ATTR_UNUSED unsigned long AuthnLevel,
+                                    WINPR_ATTR_UNUSED unsigned long AuthnSvc,
+                                    WINPR_ATTR_UNUSED RPC_AUTH_IDENTITY_HANDLE AuthIdentity,
+                                    WINPR_ATTR_UNUSED unsigned long AuthzSvc,
+                                    WINPR_ATTR_UNUSED RPC_SECURITY_QOS* SecurityQOS)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingInqAuthInfoExA(RPC_BINDING_HANDLE Binding, RPC_CSTR* ServerPrincName,
-                                    unsigned long* AuthnLevel, unsigned long* AuthnSvc,
-                                    RPC_AUTH_IDENTITY_HANDLE* AuthIdentity, unsigned long* AuthzSvc,
-                                    unsigned long RpcQosVersion, RPC_SECURITY_QOS* SecurityQOS)
+RPC_STATUS RpcBindingInqAuthInfoExA(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                    WINPR_ATTR_UNUSED RPC_CSTR* ServerPrincName,
+                                    WINPR_ATTR_UNUSED unsigned long* AuthnLevel,
+                                    WINPR_ATTR_UNUSED unsigned long* AuthnSvc,
+                                    WINPR_ATTR_UNUSED RPC_AUTH_IDENTITY_HANDLE* AuthIdentity,
+                                    WINPR_ATTR_UNUSED unsigned long* AuthzSvc,
+                                    WINPR_ATTR_UNUSED unsigned long RpcQosVersion,
+                                    WINPR_ATTR_UNUSED RPC_SECURITY_QOS* SecurityQOS)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingInqAuthInfoExW(RPC_BINDING_HANDLE Binding, RPC_WSTR* ServerPrincName,
-                                    unsigned long* AuthnLevel, unsigned long* AuthnSvc,
-                                    RPC_AUTH_IDENTITY_HANDLE* AuthIdentity, unsigned long* AuthzSvc,
-                                    unsigned long RpcQosVersion, RPC_SECURITY_QOS* SecurityQOS)
+RPC_STATUS RpcBindingInqAuthInfoExW(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                                    WINPR_ATTR_UNUSED RPC_WSTR* ServerPrincName,
+                                    WINPR_ATTR_UNUSED unsigned long* AuthnLevel,
+                                    WINPR_ATTR_UNUSED unsigned long* AuthnSvc,
+                                    WINPR_ATTR_UNUSED RPC_AUTH_IDENTITY_HANDLE* AuthIdentity,
+                                    WINPR_ATTR_UNUSED unsigned long* AuthzSvc,
+                                    WINPR_ATTR_UNUSED unsigned long RpcQosVersion,
+                                    WINPR_ATTR_UNUSED RPC_SECURITY_QOS* SecurityQOS)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerRegisterAuthInfoA(RPC_CSTR ServerPrincName, unsigned long AuthnSvc,
-                                      RPC_AUTH_KEY_RETRIEVAL_FN GetKeyFn, void* Arg)
+RPC_STATUS RpcServerRegisterAuthInfoA(WINPR_ATTR_UNUSED RPC_CSTR ServerPrincName,
+                                      WINPR_ATTR_UNUSED unsigned long AuthnSvc,
+                                      WINPR_ATTR_UNUSED RPC_AUTH_KEY_RETRIEVAL_FN GetKeyFn,
+                                      WINPR_ATTR_UNUSED void* Arg)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerRegisterAuthInfoW(RPC_WSTR ServerPrincName, unsigned long AuthnSvc,
-                                      RPC_AUTH_KEY_RETRIEVAL_FN GetKeyFn, void* Arg)
+RPC_STATUS RpcServerRegisterAuthInfoW(WINPR_ATTR_UNUSED RPC_WSTR ServerPrincName,
+                                      WINPR_ATTR_UNUSED unsigned long AuthnSvc,
+                                      WINPR_ATTR_UNUSED RPC_AUTH_KEY_RETRIEVAL_FN GetKeyFn,
+                                      WINPR_ATTR_UNUSED void* Arg)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcBindingServerFromClient(RPC_BINDING_HANDLE ClientBinding,
-                                      RPC_BINDING_HANDLE* ServerBinding)
+RPC_STATUS RpcBindingServerFromClient(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE ClientBinding,
+                                      WINPR_ATTR_UNUSED RPC_BINDING_HANDLE* ServerBinding)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
@@ -666,19 +792,19 @@ RPC_STATUS RpcTestCancel(void)
 	return 0;
 }
 
-RPC_STATUS RpcServerTestCancel(RPC_BINDING_HANDLE BindingHandle)
+RPC_STATUS RpcServerTestCancel(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE BindingHandle)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcCancelThread(void* Thread)
+RPC_STATUS RpcCancelThread(WINPR_ATTR_UNUSED void* Thread)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcCancelThreadEx(void* Thread, long Timeout)
+RPC_STATUS RpcCancelThreadEx(WINPR_ATTR_UNUSED void* Thread, WINPR_ATTR_UNUSED long Timeout)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
@@ -725,7 +851,7 @@ RPC_STATUS UuidToStringA(const UUID* Uuid, RPC_CSTR* StringUuid)
 	return RPC_S_OK;
 }
 
-RPC_STATUS UuidToStringW(const UUID* Uuid, RPC_WSTR* StringUuid)
+RPC_STATUS UuidToStringW(WINPR_ATTR_UNUSED const UUID* Uuid, WINPR_ATTR_UNUSED RPC_WSTR* StringUuid)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
@@ -778,7 +904,7 @@ RPC_STATUS UuidFromStringA(RPC_CSTR StringUuid, UUID* Uuid)
 	return RPC_S_OK;
 }
 
-RPC_STATUS UuidFromStringW(RPC_WSTR StringUuid, UUID* Uuid)
+RPC_STATUS UuidFromStringW(WINPR_ATTR_UNUSED RPC_WSTR StringUuid, WINPR_ATTR_UNUSED UUID* Uuid)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
@@ -823,7 +949,7 @@ int UuidEqual(const UUID* Uuid1, const UUID* Uuid2, RPC_STATUS* Status)
 	return ((UuidCompare(Uuid1, Uuid2, Status) == 0) ? TRUE : FALSE);
 }
 
-unsigned short UuidHash(const UUID* Uuid, RPC_STATUS* Status)
+unsigned short UuidHash(WINPR_ATTR_UNUSED const UUID* Uuid, WINPR_ATTR_UNUSED RPC_STATUS* Status)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
@@ -834,95 +960,117 @@ int UuidIsNil(const UUID* Uuid, RPC_STATUS* Status)
 	return UuidEqual(Uuid, &UUID_NIL, Status);
 }
 
-RPC_STATUS RpcEpRegisterNoReplaceA(RPC_IF_HANDLE IfSpec, RPC_BINDING_VECTOR* BindingVector,
-                                   UUID_VECTOR* UuidVector, RPC_CSTR Annotation)
+RPC_STATUS RpcEpRegisterNoReplaceA(WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                                   WINPR_ATTR_UNUSED RPC_BINDING_VECTOR* BindingVector,
+                                   WINPR_ATTR_UNUSED UUID_VECTOR* UuidVector,
+                                   WINPR_ATTR_UNUSED RPC_CSTR Annotation)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcEpRegisterNoReplaceW(RPC_IF_HANDLE IfSpec, RPC_BINDING_VECTOR* BindingVector,
-                                   UUID_VECTOR* UuidVector, RPC_WSTR Annotation)
+RPC_STATUS RpcEpRegisterNoReplaceW(WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                                   WINPR_ATTR_UNUSED RPC_BINDING_VECTOR* BindingVector,
+                                   WINPR_ATTR_UNUSED UUID_VECTOR* UuidVector,
+                                   WINPR_ATTR_UNUSED RPC_WSTR Annotation)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcEpRegisterA(RPC_IF_HANDLE IfSpec, RPC_BINDING_VECTOR* BindingVector,
-                          UUID_VECTOR* UuidVector, RPC_CSTR Annotation)
+RPC_STATUS RpcEpRegisterA(WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                          WINPR_ATTR_UNUSED RPC_BINDING_VECTOR* BindingVector,
+                          WINPR_ATTR_UNUSED UUID_VECTOR* UuidVector,
+                          WINPR_ATTR_UNUSED RPC_CSTR Annotation)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcEpRegisterW(RPC_IF_HANDLE IfSpec, RPC_BINDING_VECTOR* BindingVector,
-                          UUID_VECTOR* UuidVector, RPC_WSTR Annotation)
+RPC_STATUS RpcEpRegisterW(WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                          WINPR_ATTR_UNUSED RPC_BINDING_VECTOR* BindingVector,
+                          WINPR_ATTR_UNUSED UUID_VECTOR* UuidVector,
+                          WINPR_ATTR_UNUSED RPC_WSTR Annotation)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcEpUnregister(RPC_IF_HANDLE IfSpec, RPC_BINDING_VECTOR* BindingVector,
-                           UUID_VECTOR* UuidVector)
+RPC_STATUS RpcEpUnregister(WINPR_ATTR_UNUSED RPC_IF_HANDLE IfSpec,
+                           WINPR_ATTR_UNUSED RPC_BINDING_VECTOR* BindingVector,
+                           WINPR_ATTR_UNUSED UUID_VECTOR* UuidVector)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS DceErrorInqTextA(RPC_STATUS RpcStatus, RPC_CSTR ErrorText)
+RPC_STATUS DceErrorInqTextA(WINPR_ATTR_UNUSED RPC_STATUS RpcStatus,
+                            WINPR_ATTR_UNUSED RPC_CSTR ErrorText)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS DceErrorInqTextW(RPC_STATUS RpcStatus, RPC_WSTR ErrorText)
+RPC_STATUS DceErrorInqTextW(WINPR_ATTR_UNUSED RPC_STATUS RpcStatus,
+                            WINPR_ATTR_UNUSED RPC_WSTR ErrorText)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcMgmtEpEltInqBegin(RPC_BINDING_HANDLE EpBinding, unsigned long InquiryType,
-                                RPC_IF_ID* IfId, unsigned long VersOption, UUID* ObjectUuid,
-                                RPC_EP_INQ_HANDLE* InquiryContext)
+RPC_STATUS RpcMgmtEpEltInqBegin(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE EpBinding,
+                                WINPR_ATTR_UNUSED unsigned long InquiryType,
+                                WINPR_ATTR_UNUSED RPC_IF_ID* IfId,
+                                WINPR_ATTR_UNUSED unsigned long VersOption,
+                                WINPR_ATTR_UNUSED UUID* ObjectUuid,
+                                WINPR_ATTR_UNUSED RPC_EP_INQ_HANDLE* InquiryContext)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcMgmtEpEltInqDone(RPC_EP_INQ_HANDLE* InquiryContext)
+RPC_STATUS RpcMgmtEpEltInqDone(WINPR_ATTR_UNUSED RPC_EP_INQ_HANDLE* InquiryContext)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcMgmtEpEltInqNextA(RPC_EP_INQ_HANDLE InquiryContext, RPC_IF_ID* IfId,
-                                RPC_BINDING_HANDLE* Binding, UUID* ObjectUuid, RPC_CSTR* Annotation)
+RPC_STATUS RpcMgmtEpEltInqNextA(WINPR_ATTR_UNUSED RPC_EP_INQ_HANDLE InquiryContext,
+                                WINPR_ATTR_UNUSED RPC_IF_ID* IfId,
+                                WINPR_ATTR_UNUSED RPC_BINDING_HANDLE* Binding,
+                                WINPR_ATTR_UNUSED UUID* ObjectUuid,
+                                WINPR_ATTR_UNUSED RPC_CSTR* Annotation)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcMgmtEpEltInqNextW(RPC_EP_INQ_HANDLE InquiryContext, RPC_IF_ID* IfId,
-                                RPC_BINDING_HANDLE* Binding, UUID* ObjectUuid, RPC_WSTR* Annotation)
+RPC_STATUS RpcMgmtEpEltInqNextW(WINPR_ATTR_UNUSED RPC_EP_INQ_HANDLE InquiryContext,
+                                WINPR_ATTR_UNUSED RPC_IF_ID* IfId,
+                                WINPR_ATTR_UNUSED RPC_BINDING_HANDLE* Binding,
+                                WINPR_ATTR_UNUSED UUID* ObjectUuid,
+                                WINPR_ATTR_UNUSED RPC_WSTR* Annotation)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcMgmtEpUnregister(RPC_BINDING_HANDLE EpBinding, RPC_IF_ID* IfId,
-                               RPC_BINDING_HANDLE Binding, UUID* ObjectUuid)
+RPC_STATUS RpcMgmtEpUnregister(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE EpBinding,
+                               WINPR_ATTR_UNUSED RPC_IF_ID* IfId,
+                               WINPR_ATTR_UNUSED RPC_BINDING_HANDLE Binding,
+                               WINPR_ATTR_UNUSED UUID* ObjectUuid)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcMgmtSetAuthorizationFn(RPC_MGMT_AUTHORIZATION_FN AuthorizationFn)
+RPC_STATUS RpcMgmtSetAuthorizationFn(WINPR_ATTR_UNUSED RPC_MGMT_AUTHORIZATION_FN AuthorizationFn)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;
 }
 
-RPC_STATUS RpcServerInqBindingHandle(RPC_BINDING_HANDLE* Binding)
+RPC_STATUS RpcServerInqBindingHandle(WINPR_ATTR_UNUSED RPC_BINDING_HANDLE* Binding)
 {
 	WLog_ERR(TAG, "Not implemented");
 	return 0;

--- a/winpr/libwinpr/security/security.c
+++ b/winpr/libwinpr/security/security.c
@@ -122,92 +122,122 @@
  */
 
 #ifndef _WIN32
-
+#include <winpr/wlog.h>
 #include "security.h"
 
-BOOL InitializeSecurityDescriptor(PSECURITY_DESCRIPTOR pSecurityDescriptor, DWORD dwRevision)
+BOOL InitializeSecurityDescriptor(WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor,
+                                  WINPR_ATTR_UNUSED DWORD dwRevision)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-DWORD GetSecurityDescriptorLength(PSECURITY_DESCRIPTOR pSecurityDescriptor)
+DWORD GetSecurityDescriptorLength(WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return 0;
 }
 
-BOOL IsValidSecurityDescriptor(PSECURITY_DESCRIPTOR pSecurityDescriptor)
+BOOL IsValidSecurityDescriptor(WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL GetSecurityDescriptorControl(PSECURITY_DESCRIPTOR pSecurityDescriptor,
-                                  PSECURITY_DESCRIPTOR_CONTROL pControl, LPDWORD lpdwRevision)
+BOOL GetSecurityDescriptorControl(WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor,
+                                  WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR_CONTROL pControl,
+                                  WINPR_ATTR_UNUSED LPDWORD lpdwRevision)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL SetSecurityDescriptorControl(PSECURITY_DESCRIPTOR pSecurityDescriptor,
-                                  SECURITY_DESCRIPTOR_CONTROL ControlBitsOfInterest,
-                                  SECURITY_DESCRIPTOR_CONTROL ControlBitsToSet)
+BOOL SetSecurityDescriptorControl(WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor,
+                                  WINPR_ATTR_UNUSED SECURITY_DESCRIPTOR_CONTROL
+                                      ControlBitsOfInterest,
+                                  WINPR_ATTR_UNUSED SECURITY_DESCRIPTOR_CONTROL ControlBitsToSet)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL GetSecurityDescriptorDacl(PSECURITY_DESCRIPTOR pSecurityDescriptor, LPBOOL lpbDaclPresent,
-                               PACL* pDacl, LPBOOL lpbDaclDefaulted)
+BOOL GetSecurityDescriptorDacl(WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor,
+                               WINPR_ATTR_UNUSED LPBOOL lpbDaclPresent,
+                               WINPR_ATTR_UNUSED PACL* pDacl,
+                               WINPR_ATTR_UNUSED LPBOOL lpbDaclDefaulted)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL SetSecurityDescriptorDacl(PSECURITY_DESCRIPTOR pSecurityDescriptor, BOOL bDaclPresent,
-                               PACL pDacl, BOOL bDaclDefaulted)
+BOOL SetSecurityDescriptorDacl(WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor,
+                               WINPR_ATTR_UNUSED BOOL bDaclPresent, WINPR_ATTR_UNUSED PACL pDacl,
+                               WINPR_ATTR_UNUSED BOOL bDaclDefaulted)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL GetSecurityDescriptorGroup(PSECURITY_DESCRIPTOR pSecurityDescriptor, PSID* pGroup,
-                                LPBOOL lpbGroupDefaulted)
+BOOL GetSecurityDescriptorGroup(WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor,
+                                WINPR_ATTR_UNUSED PSID* pGroup,
+                                WINPR_ATTR_UNUSED LPBOOL lpbGroupDefaulted)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL SetSecurityDescriptorGroup(PSECURITY_DESCRIPTOR pSecurityDescriptor, PSID pGroup,
-                                BOOL bGroupDefaulted)
+BOOL SetSecurityDescriptorGroup(WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor,
+                                WINPR_ATTR_UNUSED PSID pGroup,
+                                WINPR_ATTR_UNUSED BOOL bGroupDefaulted)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL GetSecurityDescriptorOwner(PSECURITY_DESCRIPTOR pSecurityDescriptor, PSID* pOwner,
-                                LPBOOL lpbOwnerDefaulted)
+BOOL GetSecurityDescriptorOwner(WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor,
+                                WINPR_ATTR_UNUSED PSID* pOwner,
+                                WINPR_ATTR_UNUSED LPBOOL lpbOwnerDefaulted)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL SetSecurityDescriptorOwner(PSECURITY_DESCRIPTOR pSecurityDescriptor, PSID pOwner,
-                                BOOL bOwnerDefaulted)
+BOOL SetSecurityDescriptorOwner(WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor,
+                                WINPR_ATTR_UNUSED PSID pOwner,
+                                WINPR_ATTR_UNUSED BOOL bOwnerDefaulted)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-DWORD GetSecurityDescriptorRMControl(PSECURITY_DESCRIPTOR SecurityDescriptor, PUCHAR RMControl)
+DWORD GetSecurityDescriptorRMControl(WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR SecurityDescriptor,
+                                     WINPR_ATTR_UNUSED PUCHAR RMControl)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return 0;
 }
 
-DWORD SetSecurityDescriptorRMControl(PSECURITY_DESCRIPTOR SecurityDescriptor, PUCHAR RMControl)
+DWORD SetSecurityDescriptorRMControl(WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR SecurityDescriptor,
+                                     WINPR_ATTR_UNUSED PUCHAR RMControl)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return 0;
 }
 
-BOOL GetSecurityDescriptorSacl(PSECURITY_DESCRIPTOR pSecurityDescriptor, LPBOOL lpbSaclPresent,
-                               PACL* pSacl, LPBOOL lpbSaclDefaulted)
+BOOL GetSecurityDescriptorSacl(WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor,
+                               WINPR_ATTR_UNUSED LPBOOL lpbSaclPresent,
+                               WINPR_ATTR_UNUSED PACL* pSacl,
+                               WINPR_ATTR_UNUSED LPBOOL lpbSaclDefaulted)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 
-BOOL SetSecurityDescriptorSacl(PSECURITY_DESCRIPTOR pSecurityDescriptor, BOOL bSaclPresent,
-                               PACL pSacl, BOOL bSaclDefaulted)
+BOOL SetSecurityDescriptorSacl(WINPR_ATTR_UNUSED PSECURITY_DESCRIPTOR pSecurityDescriptor,
+                               WINPR_ATTR_UNUSED BOOL bSaclPresent, WINPR_ATTR_UNUSED PACL pSacl,
+                               WINPR_ATTR_UNUSED BOOL bSaclDefaulted)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return TRUE;
 }
 

--- a/winpr/libwinpr/smartcard/smartcard.c
+++ b/winpr/libwinpr/smartcard/smartcard.c
@@ -82,7 +82,9 @@ const SCARD_IO_REQUEST g_rgSCardT0Pci = { SCARD_PROTOCOL_T0, 8 };
 const SCARD_IO_REQUEST g_rgSCardT1Pci = { SCARD_PROTOCOL_T1, 8 };
 const SCARD_IO_REQUEST g_rgSCardRawPci = { SCARD_PROTOCOL_RAW, 8 };
 
-static BOOL CALLBACK InitializeSCardApiStubs(PINIT_ONCE once, PVOID param, PVOID* context)
+static BOOL CALLBACK InitializeSCardApiStubs(WINPR_ATTR_UNUSED PINIT_ONCE once,
+                                             WINPR_ATTR_UNUSED PVOID param,
+                                             WINPR_ATTR_UNUSED PVOID* context)
 {
 #ifdef _WIN32
 	if (Windows_InitializeSCardApi() >= 0)

--- a/winpr/libwinpr/smartcard/smartcard_pcsc.c
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.c
@@ -1062,7 +1062,7 @@ static const char* findCardByAtr(LPCBYTE pbAtr)
 	return NULL;
 }
 
-static LONG WINAPI PCSC_SCardListCardsA(SCARDCONTEXT hContext, LPCBYTE pbAtr,
+static LONG WINAPI PCSC_SCardListCardsA(WINPR_ATTR_UNUSED SCARDCONTEXT hContext, LPCBYTE pbAtr,
                                         LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount,
                                         CHAR* mszCards, LPDWORD pcchCards)
 {
@@ -1115,7 +1115,7 @@ static LONG WINAPI PCSC_SCardListCardsA(SCARDCONTEXT hContext, LPCBYTE pbAtr,
 	return SCARD_S_SUCCESS;
 }
 
-static LONG WINAPI PCSC_SCardListCardsW(SCARDCONTEXT hContext, LPCBYTE pbAtr,
+static LONG WINAPI PCSC_SCardListCardsW(WINPR_ATTR_UNUSED SCARDCONTEXT hContext, LPCBYTE pbAtr,
                                         LPCGUID rgquidInterfaces, DWORD cguidInterfaceCount,
                                         WCHAR* mszCards, LPDWORD pcchCards)
 {

--- a/winpr/libwinpr/sspi/CredSSP/credssp.c
+++ b/winpr/libwinpr/sspi/CredSSP/credssp.c
@@ -32,18 +32,24 @@
 static const char* CREDSSP_PACKAGE_NAME = "CredSSP";
 
 static SECURITY_STATUS SEC_ENTRY credssp_InitializeSecurityContextW(
-    PCredHandle phCredential, PCtxtHandle phContext, SEC_WCHAR* pszTargetName, ULONG fContextReq,
-    ULONG Reserved1, ULONG TargetDataRep, PSecBufferDesc pInput, ULONG Reserved2,
-    PCtxtHandle phNewContext, PSecBufferDesc pOutput, PULONG pfContextAttr, PTimeStamp ptsExpiry)
+    WINPR_ATTR_UNUSED PCredHandle phCredential, WINPR_ATTR_UNUSED PCtxtHandle phContext,
+    WINPR_ATTR_UNUSED SEC_WCHAR* pszTargetName, WINPR_ATTR_UNUSED ULONG fContextReq,
+    WINPR_ATTR_UNUSED ULONG Reserved1, WINPR_ATTR_UNUSED ULONG TargetDataRep,
+    WINPR_ATTR_UNUSED PSecBufferDesc pInput, WINPR_ATTR_UNUSED ULONG Reserved2,
+    WINPR_ATTR_UNUSED PCtxtHandle phNewContext, WINPR_ATTR_UNUSED PSecBufferDesc pOutput,
+    WINPR_ATTR_UNUSED PULONG pfContextAttr, WINPR_ATTR_UNUSED PTimeStamp ptsExpiry)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
 static SECURITY_STATUS SEC_ENTRY credssp_InitializeSecurityContextA(
-    PCredHandle phCredential, PCtxtHandle phContext, SEC_CHAR* pszTargetName, ULONG fContextReq,
-    ULONG Reserved1, ULONG TargetDataRep, PSecBufferDesc pInput, ULONG Reserved2,
-    PCtxtHandle phNewContext, PSecBufferDesc pOutput, PULONG pfContextAttr, PTimeStamp ptsExpiry)
+    PCredHandle phCredential, PCtxtHandle phContext, WINPR_ATTR_UNUSED SEC_CHAR* pszTargetName,
+    WINPR_ATTR_UNUSED ULONG fContextReq, WINPR_ATTR_UNUSED ULONG Reserved1,
+    WINPR_ATTR_UNUSED ULONG TargetDataRep, WINPR_ATTR_UNUSED PSecBufferDesc pInput,
+    WINPR_ATTR_UNUSED ULONG Reserved2, PCtxtHandle phNewContext,
+    WINPR_ATTR_UNUSED PSecBufferDesc pOutput, WINPR_ATTR_UNUSED PULONG pfContextAttr,
+    WINPR_ATTR_UNUSED PTimeStamp ptsExpiry)
 {
 	CREDSSP_CONTEXT* context = NULL;
 	SSPI_CREDENTIALS* credentials = NULL;
@@ -100,7 +106,8 @@ void credssp_ContextFree(CREDSSP_CONTEXT* context)
 }
 
 static SECURITY_STATUS SEC_ENTRY credssp_QueryContextAttributes(PCtxtHandle phContext,
-                                                                ULONG ulAttribute, void* pBuffer)
+                                                                WINPR_ATTR_UNUSED ULONG ulAttribute,
+                                                                void* pBuffer)
 {
 	if (!phContext)
 		return SEC_E_INVALID_HANDLE;
@@ -113,18 +120,22 @@ static SECURITY_STATUS SEC_ENTRY credssp_QueryContextAttributes(PCtxtHandle phCo
 }
 
 static SECURITY_STATUS SEC_ENTRY credssp_AcquireCredentialsHandleW(
-    SEC_WCHAR* pszPrincipal, SEC_WCHAR* pszPackage, ULONG fCredentialUse, void* pvLogonID,
-    void* pAuthData, SEC_GET_KEY_FN pGetKeyFn, void* pvGetKeyArgument, PCredHandle phCredential,
-    PTimeStamp ptsExpiry)
+    WINPR_ATTR_UNUSED SEC_WCHAR* pszPrincipal, WINPR_ATTR_UNUSED SEC_WCHAR* pszPackage,
+    WINPR_ATTR_UNUSED ULONG fCredentialUse, WINPR_ATTR_UNUSED void* pvLogonID,
+    WINPR_ATTR_UNUSED void* pAuthData, WINPR_ATTR_UNUSED SEC_GET_KEY_FN pGetKeyFn,
+    WINPR_ATTR_UNUSED void* pvGetKeyArgument, WINPR_ATTR_UNUSED PCredHandle phCredential,
+    WINPR_ATTR_UNUSED PTimeStamp ptsExpiry)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
 static SECURITY_STATUS SEC_ENTRY credssp_AcquireCredentialsHandleA(
-    SEC_CHAR* pszPrincipal, SEC_CHAR* pszPackage, ULONG fCredentialUse, void* pvLogonID,
-    void* pAuthData, SEC_GET_KEY_FN pGetKeyFn, void* pvGetKeyArgument, PCredHandle phCredential,
-    PTimeStamp ptsExpiry)
+    WINPR_ATTR_UNUSED SEC_CHAR* pszPrincipal, WINPR_ATTR_UNUSED SEC_CHAR* pszPackage,
+    WINPR_ATTR_UNUSED ULONG fCredentialUse, WINPR_ATTR_UNUSED void* pvLogonID,
+    WINPR_ATTR_UNUSED void* pAuthData, WINPR_ATTR_UNUSED SEC_GET_KEY_FN pGetKeyFn,
+    WINPR_ATTR_UNUSED void* pvGetKeyArgument, WINPR_ATTR_UNUSED PCredHandle phCredential,
+    WINPR_ATTR_UNUSED PTimeStamp ptsExpiry)
 {
 	SSPI_CREDENTIALS* credentials = NULL;
 	SEC_WINNT_AUTH_IDENTITY* identity = NULL;
@@ -154,17 +165,17 @@ static SECURITY_STATUS SEC_ENTRY credssp_AcquireCredentialsHandleA(
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
-static SECURITY_STATUS SEC_ENTRY credssp_QueryCredentialsAttributesW(PCredHandle phCredential,
-                                                                     ULONG ulAttribute,
-                                                                     void* pBuffer)
+static SECURITY_STATUS SEC_ENTRY credssp_QueryCredentialsAttributesW(
+    WINPR_ATTR_UNUSED PCredHandle phCredential, WINPR_ATTR_UNUSED ULONG ulAttribute,
+    WINPR_ATTR_UNUSED void* pBuffer)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
-static SECURITY_STATUS SEC_ENTRY credssp_QueryCredentialsAttributesA(PCredHandle phCredential,
-                                                                     ULONG ulAttribute,
-                                                                     void* pBuffer)
+static SECURITY_STATUS SEC_ENTRY credssp_QueryCredentialsAttributesA(
+    WINPR_ATTR_UNUSED PCredHandle phCredential, WINPR_ATTR_UNUSED ULONG ulAttribute,
+    WINPR_ATTR_UNUSED void* pBuffer)
 {
 	if (ulAttribute == SECPKG_CRED_ATTR_NAMES)
 	{
@@ -197,31 +208,37 @@ static SECURITY_STATUS SEC_ENTRY credssp_FreeCredentialsHandle(PCredHandle phCre
 	return SEC_E_OK;
 }
 
-static SECURITY_STATUS SEC_ENTRY credssp_EncryptMessage(PCtxtHandle phContext, ULONG fQOP,
-                                                        PSecBufferDesc pMessage, ULONG MessageSeqNo)
+static SECURITY_STATUS SEC_ENTRY credssp_EncryptMessage(WINPR_ATTR_UNUSED PCtxtHandle phContext,
+                                                        WINPR_ATTR_UNUSED ULONG fQOP,
+                                                        WINPR_ATTR_UNUSED PSecBufferDesc pMessage,
+                                                        WINPR_ATTR_UNUSED ULONG MessageSeqNo)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
-static SECURITY_STATUS SEC_ENTRY credssp_DecryptMessage(PCtxtHandle phContext,
-                                                        PSecBufferDesc pMessage, ULONG MessageSeqNo,
-                                                        ULONG* pfQOP)
+static SECURITY_STATUS SEC_ENTRY credssp_DecryptMessage(WINPR_ATTR_UNUSED PCtxtHandle phContext,
+                                                        WINPR_ATTR_UNUSED PSecBufferDesc pMessage,
+                                                        WINPR_ATTR_UNUSED ULONG MessageSeqNo,
+                                                        WINPR_ATTR_UNUSED ULONG* pfQOP)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
-static SECURITY_STATUS SEC_ENTRY credssp_MakeSignature(PCtxtHandle phContext, ULONG fQOP,
-                                                       PSecBufferDesc pMessage, ULONG MessageSeqNo)
+static SECURITY_STATUS SEC_ENTRY credssp_MakeSignature(WINPR_ATTR_UNUSED PCtxtHandle phContext,
+                                                       WINPR_ATTR_UNUSED ULONG fQOP,
+                                                       WINPR_ATTR_UNUSED PSecBufferDesc pMessage,
+                                                       WINPR_ATTR_UNUSED ULONG MessageSeqNo)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
-static SECURITY_STATUS SEC_ENTRY credssp_VerifySignature(PCtxtHandle phContext,
-                                                         PSecBufferDesc pMessage,
-                                                         ULONG MessageSeqNo, ULONG* pfQOP)
+static SECURITY_STATUS SEC_ENTRY credssp_VerifySignature(WINPR_ATTR_UNUSED PCtxtHandle phContext,
+                                                         WINPR_ATTR_UNUSED PSecBufferDesc pMessage,
+                                                         WINPR_ATTR_UNUSED ULONG MessageSeqNo,
+                                                         WINPR_ATTR_UNUSED ULONG* pfQOP)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return SEC_E_UNSUPPORTED_FUNCTION;

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -201,8 +201,10 @@ static KRB_CONTEXT* kerberos_ContextNew(KRB_CREDENTIALS* credentials)
 	return context;
 }
 
-static krb5_error_code krb5_prompter(krb5_context context, void* data, const char* name,
-                                     const char* banner, int num_prompts, krb5_prompt prompts[])
+static krb5_error_code krb5_prompter(krb5_context context, void* data,
+                                     WINPR_ATTR_UNUSED const char* name,
+                                     WINPR_ATTR_UNUSED const char* banner, int num_prompts,
+                                     krb5_prompt prompts[])
 {
 	for (int i = 0; i < num_prompts; i++)
 	{
@@ -268,9 +270,10 @@ fail:
 #endif /* WITH_KRB5 */
 
 static SECURITY_STATUS SEC_ENTRY kerberos_AcquireCredentialsHandleA(
-    SEC_CHAR* pszPrincipal, SEC_CHAR* pszPackage, ULONG fCredentialUse, void* pvLogonID,
-    void* pAuthData, SEC_GET_KEY_FN pGetKeyFn, void* pvGetKeyArgument, PCredHandle phCredential,
-    PTimeStamp ptsExpiry)
+    SEC_CHAR* pszPrincipal, WINPR_ATTR_UNUSED SEC_CHAR* pszPackage, ULONG fCredentialUse,
+    WINPR_ATTR_UNUSED void* pvLogonID, void* pAuthData, WINPR_ATTR_UNUSED SEC_GET_KEY_FN pGetKeyFn,
+    WINPR_ATTR_UNUSED void* pvGetKeyArgument, PCredHandle phCredential,
+    WINPR_ATTR_UNUSED PTimeStamp ptsExpiry)
 {
 #ifdef WITH_KRB5
 	SEC_WINPR_KERBEROS_SETTINGS* krb_settings = NULL;
@@ -552,9 +555,8 @@ static SECURITY_STATUS SEC_ENTRY kerberos_FreeCredentialsHandle(PCredHandle phCr
 #endif
 }
 
-static SECURITY_STATUS SEC_ENTRY kerberos_QueryCredentialsAttributesW(PCredHandle phCredential,
-                                                                      ULONG ulAttribute,
-                                                                      void* pBuffer)
+static SECURITY_STATUS SEC_ENTRY kerberos_QueryCredentialsAttributesW(
+    WINPR_ATTR_UNUSED PCredHandle phCredential, ULONG ulAttribute, WINPR_ATTR_UNUSED void* pBuffer)
 {
 #ifdef WITH_KRB5
 	switch (ulAttribute)
@@ -908,8 +910,9 @@ static BOOL kerberos_hash_channel_bindings(WINPR_DIGEST_CTX* md5, SEC_CHANNEL_BI
 
 static SECURITY_STATUS SEC_ENTRY kerberos_InitializeSecurityContextA(
     PCredHandle phCredential, PCtxtHandle phContext, SEC_CHAR* pszTargetName, ULONG fContextReq,
-    ULONG Reserved1, ULONG TargetDataRep, PSecBufferDesc pInput, ULONG Reserved2,
-    PCtxtHandle phNewContext, PSecBufferDesc pOutput, ULONG* pfContextAttr, PTimeStamp ptsExpiry)
+    WINPR_ATTR_UNUSED ULONG Reserved1, WINPR_ATTR_UNUSED ULONG TargetDataRep, PSecBufferDesc pInput,
+    WINPR_ATTR_UNUSED ULONG Reserved2, PCtxtHandle phNewContext, PSecBufferDesc pOutput,
+    WINPR_ATTR_UNUSED ULONG* pfContextAttr, WINPR_ATTR_UNUSED PTimeStamp ptsExpiry)
 {
 #ifdef WITH_KRB5
 	PSecBuffer input_buffer = NULL;
@@ -1252,9 +1255,10 @@ static SECURITY_STATUS SEC_ENTRY kerberos_InitializeSecurityContextW(
 }
 
 static SECURITY_STATUS SEC_ENTRY kerberos_AcceptSecurityContext(
-    PCredHandle phCredential, PCtxtHandle phContext, PSecBufferDesc pInput, ULONG fContextReq,
-    ULONG TargetDataRep, PCtxtHandle phNewContext, PSecBufferDesc pOutput, ULONG* pfContextAttr,
-    PTimeStamp ptsExpity)
+    PCredHandle phCredential, PCtxtHandle phContext, PSecBufferDesc pInput,
+    WINPR_ATTR_UNUSED ULONG fContextReq, WINPR_ATTR_UNUSED ULONG TargetDataRep,
+    PCtxtHandle phNewContext, PSecBufferDesc pOutput, ULONG* pfContextAttr,
+    WINPR_ATTR_UNUSED PTimeStamp ptsExpity)
 {
 #ifdef WITH_KRB5
 	BOOL isNewContext = FALSE;
@@ -1710,16 +1714,16 @@ static SECURITY_STATUS SEC_ENTRY kerberos_QueryContextAttributesW(PCtxtHandle ph
 	return kerberos_QueryContextAttributesA(phContext, ulAttribute, pBuffer);
 }
 
-static SECURITY_STATUS SEC_ENTRY kerberos_SetContextAttributesW(PCtxtHandle phContext,
-                                                                ULONG ulAttribute, void* pBuffer,
-                                                                ULONG cbBuffer)
+static SECURITY_STATUS SEC_ENTRY kerberos_SetContextAttributesW(
+    WINPR_ATTR_UNUSED PCtxtHandle phContext, WINPR_ATTR_UNUSED ULONG ulAttribute,
+    WINPR_ATTR_UNUSED void* pBuffer, WINPR_ATTR_UNUSED ULONG cbBuffer)
 {
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
-static SECURITY_STATUS SEC_ENTRY kerberos_SetContextAttributesA(PCtxtHandle phContext,
-                                                                ULONG ulAttribute, void* pBuffer,
-                                                                ULONG cbBuffer)
+static SECURITY_STATUS SEC_ENTRY kerberos_SetContextAttributesA(
+    WINPR_ATTR_UNUSED PCtxtHandle phContext, WINPR_ATTR_UNUSED ULONG ulAttribute,
+    WINPR_ATTR_UNUSED void* pBuffer, WINPR_ATTR_UNUSED ULONG cbBuffer)
 {
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
@@ -1727,7 +1731,7 @@ static SECURITY_STATUS SEC_ENTRY kerberos_SetContextAttributesA(PCtxtHandle phCo
 static SECURITY_STATUS SEC_ENTRY kerberos_SetCredentialsAttributesX(PCredHandle phCredential,
                                                                     ULONG ulAttribute,
                                                                     void* pBuffer, ULONG cbBuffer,
-                                                                    BOOL unicode)
+                                                                    WINPR_ATTR_UNUSED BOOL unicode)
 {
 #ifdef WITH_KRB5
 	KRB_CREDENTIALS* credentials = NULL;
@@ -1998,7 +2002,8 @@ static SECURITY_STATUS SEC_ENTRY kerberos_DecryptMessage(PCtxtHandle phContext,
 #endif
 }
 
-static SECURITY_STATUS SEC_ENTRY kerberos_MakeSignature(PCtxtHandle phContext, ULONG fQOP,
+static SECURITY_STATUS SEC_ENTRY kerberos_MakeSignature(PCtxtHandle phContext,
+                                                        WINPR_ATTR_UNUSED ULONG fQOP,
                                                         PSecBufferDesc pMessage, ULONG MessageSeqNo)
 {
 #ifdef WITH_KRB5
@@ -2070,7 +2075,8 @@ static SECURITY_STATUS SEC_ENTRY kerberos_MakeSignature(PCtxtHandle phContext, U
 
 static SECURITY_STATUS SEC_ENTRY kerberos_VerifySignature(PCtxtHandle phContext,
                                                           PSecBufferDesc pMessage,
-                                                          ULONG MessageSeqNo, ULONG* pfQOP)
+                                                          ULONG MessageSeqNo,
+                                                          WINPR_ATTR_UNUSED ULONG* pfQOP)
 {
 #ifdef WITH_KRB5
 	PSecBuffer sig_buffer = NULL;

--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -357,9 +357,10 @@ static void ntlm_ContextFree(NTLM_CONTEXT* context)
 }
 
 static SECURITY_STATUS SEC_ENTRY ntlm_AcquireCredentialsHandleW(
-    SEC_WCHAR* pszPrincipal, SEC_WCHAR* pszPackage, ULONG fCredentialUse, void* pvLogonID,
-    void* pAuthData, SEC_GET_KEY_FN pGetKeyFn, void* pvGetKeyArgument, PCredHandle phCredential,
-    PTimeStamp ptsExpiry)
+    WINPR_ATTR_UNUSED SEC_WCHAR* pszPrincipal, WINPR_ATTR_UNUSED SEC_WCHAR* pszPackage,
+    ULONG fCredentialUse, WINPR_ATTR_UNUSED void* pvLogonID, void* pAuthData,
+    SEC_GET_KEY_FN pGetKeyFn, void* pvGetKeyArgument, PCredHandle phCredential,
+    WINPR_ATTR_UNUSED PTimeStamp ptsExpiry)
 {
 	SEC_WINPR_NTLM_SETTINGS* settings = NULL;
 
@@ -457,8 +458,9 @@ static SECURITY_STATUS SEC_ENTRY ntlm_FreeCredentialsHandle(PCredHandle phCreden
 	return SEC_E_OK;
 }
 
-static SECURITY_STATUS SEC_ENTRY ntlm_QueryCredentialsAttributesW(PCredHandle phCredential,
-                                                                  ULONG ulAttribute, void* pBuffer)
+static SECURITY_STATUS SEC_ENTRY ntlm_QueryCredentialsAttributesW(
+    WINPR_ATTR_UNUSED PCredHandle phCredential, WINPR_ATTR_UNUSED ULONG ulAttribute,
+    WINPR_ATTR_UNUSED void* pBuffer)
 {
 	if (ulAttribute == SECPKG_CRED_ATTR_NAMES)
 	{
@@ -478,10 +480,10 @@ static SECURITY_STATUS SEC_ENTRY ntlm_QueryCredentialsAttributesA(PCredHandle ph
 /**
  * @see http://msdn.microsoft.com/en-us/library/windows/desktop/aa374707
  */
-static SECURITY_STATUS SEC_ENTRY
-ntlm_AcceptSecurityContext(PCredHandle phCredential, PCtxtHandle phContext, PSecBufferDesc pInput,
-                           ULONG fContextReq, ULONG TargetDataRep, PCtxtHandle phNewContext,
-                           PSecBufferDesc pOutput, PULONG pfContextAttr, PTimeStamp ptsTimeStamp)
+static SECURITY_STATUS SEC_ENTRY ntlm_AcceptSecurityContext(
+    PCredHandle phCredential, PCtxtHandle phContext, PSecBufferDesc pInput, ULONG fContextReq,
+    WINPR_ATTR_UNUSED ULONG TargetDataRep, PCtxtHandle phNewContext, PSecBufferDesc pOutput,
+    WINPR_ATTR_UNUSED PULONG pfContextAttr, WINPR_ATTR_UNUSED PTimeStamp ptsTimeStamp)
 {
 	SECURITY_STATUS status = 0;
 	SSPI_CREDENTIALS* credentials = NULL;
@@ -598,15 +600,17 @@ ntlm_AcceptSecurityContext(PCredHandle phCredential, PCtxtHandle phContext, PSec
 	}
 }
 
-static SECURITY_STATUS SEC_ENTRY ntlm_ImpersonateSecurityContext(PCtxtHandle phContext)
+static SECURITY_STATUS SEC_ENTRY
+ntlm_ImpersonateSecurityContext(WINPR_ATTR_UNUSED PCtxtHandle phContext)
 {
 	return SEC_E_OK;
 }
 
 static SECURITY_STATUS SEC_ENTRY ntlm_InitializeSecurityContextW(
     PCredHandle phCredential, PCtxtHandle phContext, SEC_WCHAR* pszTargetName, ULONG fContextReq,
-    ULONG Reserved1, ULONG TargetDataRep, PSecBufferDesc pInput, ULONG Reserved2,
-    PCtxtHandle phNewContext, PSecBufferDesc pOutput, PULONG pfContextAttr, PTimeStamp ptsExpiry)
+    WINPR_ATTR_UNUSED ULONG Reserved1, WINPR_ATTR_UNUSED ULONG TargetDataRep, PSecBufferDesc pInput,
+    WINPR_ATTR_UNUSED ULONG Reserved2, PCtxtHandle phNewContext, PSecBufferDesc pOutput,
+    WINPR_ATTR_UNUSED PULONG pfContextAttr, WINPR_ATTR_UNUSED PTimeStamp ptsExpiry)
 {
 	SECURITY_STATUS status = 0;
 	SSPI_CREDENTIALS* credentials = NULL;
@@ -1024,26 +1028,27 @@ static SECURITY_STATUS SEC_ENTRY ntlm_SetContextAttributesA(PCtxtHandle phContex
 	return ntlm_SetContextAttributesW(phContext, ulAttribute, pBuffer, cbBuffer);
 }
 
-static SECURITY_STATUS SEC_ENTRY ntlm_SetCredentialsAttributesW(PCredHandle phCredential,
-                                                                ULONG ulAttribute, void* pBuffer,
-                                                                ULONG cbBuffer)
+static SECURITY_STATUS SEC_ENTRY ntlm_SetCredentialsAttributesW(
+    WINPR_ATTR_UNUSED PCredHandle phCredential, WINPR_ATTR_UNUSED ULONG ulAttribute,
+    WINPR_ATTR_UNUSED void* pBuffer, WINPR_ATTR_UNUSED ULONG cbBuffer)
 {
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
-static SECURITY_STATUS SEC_ENTRY ntlm_SetCredentialsAttributesA(PCredHandle phCredential,
-                                                                ULONG ulAttribute, void* pBuffer,
-                                                                ULONG cbBuffer)
+static SECURITY_STATUS SEC_ENTRY ntlm_SetCredentialsAttributesA(
+    WINPR_ATTR_UNUSED PCredHandle phCredential, WINPR_ATTR_UNUSED ULONG ulAttribute,
+    WINPR_ATTR_UNUSED void* pBuffer, WINPR_ATTR_UNUSED ULONG cbBuffer)
 {
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
-static SECURITY_STATUS SEC_ENTRY ntlm_RevertSecurityContext(PCtxtHandle phContext)
+static SECURITY_STATUS SEC_ENTRY ntlm_RevertSecurityContext(WINPR_ATTR_UNUSED PCtxtHandle phContext)
 {
 	return SEC_E_OK;
 }
 
-static SECURITY_STATUS SEC_ENTRY ntlm_EncryptMessage(PCtxtHandle phContext, ULONG fQOP,
+static SECURITY_STATUS SEC_ENTRY ntlm_EncryptMessage(PCtxtHandle phContext,
+                                                     WINPR_ATTR_UNUSED ULONG fQOP,
                                                      PSecBufferDesc pMessage, ULONG MessageSeqNo)
 {
 	const UINT32 SeqNo = MessageSeqNo;
@@ -1136,7 +1141,8 @@ static SECURITY_STATUS SEC_ENTRY ntlm_EncryptMessage(PCtxtHandle phContext, ULON
 }
 
 static SECURITY_STATUS SEC_ENTRY ntlm_DecryptMessage(PCtxtHandle phContext, PSecBufferDesc pMessage,
-                                                     ULONG MessageSeqNo, PULONG pfQOP)
+                                                     ULONG MessageSeqNo,
+                                                     WINPR_ATTR_UNUSED PULONG pfQOP)
 {
 	const UINT32 SeqNo = (UINT32)MessageSeqNo;
 	UINT32 value = 0;
@@ -1230,7 +1236,8 @@ static SECURITY_STATUS SEC_ENTRY ntlm_DecryptMessage(PCtxtHandle phContext, PSec
 	return SEC_E_OK;
 }
 
-static SECURITY_STATUS SEC_ENTRY ntlm_MakeSignature(PCtxtHandle phContext, ULONG fQOP,
+static SECURITY_STATUS SEC_ENTRY ntlm_MakeSignature(PCtxtHandle phContext,
+                                                    WINPR_ATTR_UNUSED ULONG fQOP,
                                                     PSecBufferDesc pMessage, ULONG MessageSeqNo)
 {
 	PSecBuffer data_buffer = NULL;
@@ -1281,7 +1288,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_MakeSignature(PCtxtHandle phContext, ULONG
 
 static SECURITY_STATUS SEC_ENTRY ntlm_VerifySignature(PCtxtHandle phContext,
                                                       PSecBufferDesc pMessage, ULONG MessageSeqNo,
-                                                      PULONG pfQOP)
+                                                      WINPR_ATTR_UNUSED PULONG pfQOP)
 {
 	PSecBuffer data_buffer = NULL;
 	PSecBuffer sig_buffer = NULL;

--- a/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
@@ -323,7 +323,8 @@ static char* get_name(COMPUTER_NAME_FORMAT type)
 	return computerName;
 }
 
-static int ntlm_get_target_computer_name(PUNICODE_STRING pName, COMPUTER_NAME_FORMAT type)
+static int ntlm_get_target_computer_name(PUNICODE_STRING pName,
+                                         WINPR_ATTR_UNUSED COMPUTER_NAME_FORMAT type)
 {
 	int status = -1;
 

--- a/winpr/libwinpr/sspi/NTLM/ntlm_message.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_message.c
@@ -448,7 +448,7 @@ static BOOL ntlm_write_negotiate_flags(wStream* s, UINT32 flags, const char* nam
 }
 
 static BOOL ntlm_read_message_integrity_check(wStream* s, size_t* offset, BYTE* data, size_t size,
-                                              const char* name)
+                                              WINPR_ATTR_UNUSED const char* name)
 {
 	WINPR_ASSERT(s);
 	WINPR_ASSERT(offset);
@@ -466,7 +466,7 @@ static BOOL ntlm_read_message_integrity_check(wStream* s, size_t* offset, BYTE* 
 }
 
 static BOOL ntlm_write_message_integrity_check(wStream* s, size_t offset, const BYTE* data,
-                                               size_t size, const char* name)
+                                               size_t size, WINPR_ATTR_UNUSED const char* name)
 {
 	size_t pos = 0;
 

--- a/winpr/libwinpr/sspi/Negotiate/negotiate.c
+++ b/winpr/libwinpr/sspi/Negotiate/negotiate.c
@@ -1244,12 +1244,14 @@ static SECURITY_STATUS SEC_ENTRY negotiate_DeleteSecurityContext(PCtxtHandle phC
 	return status;
 }
 
-static SECURITY_STATUS SEC_ENTRY negotiate_ImpersonateSecurityContext(PCtxtHandle phContext)
+static SECURITY_STATUS SEC_ENTRY
+negotiate_ImpersonateSecurityContext(WINPR_ATTR_UNUSED PCtxtHandle phContext)
 {
 	return SEC_E_OK;
 }
 
-static SECURITY_STATUS SEC_ENTRY negotiate_RevertSecurityContext(PCtxtHandle phContext)
+static SECURITY_STATUS SEC_ENTRY
+negotiate_RevertSecurityContext(WINPR_ATTR_UNUSED PCtxtHandle phContext)
 {
 	return SEC_E_OK;
 }
@@ -1484,17 +1486,17 @@ static SECURITY_STATUS SEC_ENTRY negotiate_AcquireCredentialsHandleA(
 	return SEC_E_OK;
 }
 
-static SECURITY_STATUS SEC_ENTRY negotiate_QueryCredentialsAttributesW(PCredHandle phCredential,
-                                                                       ULONG ulAttribute,
-                                                                       void* pBuffer)
+static SECURITY_STATUS SEC_ENTRY negotiate_QueryCredentialsAttributesW(
+    WINPR_ATTR_UNUSED PCredHandle phCredential, WINPR_ATTR_UNUSED ULONG ulAttribute,
+    WINPR_ATTR_UNUSED void* pBuffer)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
-static SECURITY_STATUS SEC_ENTRY negotiate_QueryCredentialsAttributesA(PCredHandle phCredential,
-                                                                       ULONG ulAttribute,
-                                                                       void* pBuffer)
+static SECURITY_STATUS SEC_ENTRY negotiate_QueryCredentialsAttributesA(
+    WINPR_ATTR_UNUSED PCredHandle phCredential, WINPR_ATTR_UNUSED ULONG ulAttribute,
+    WINPR_ATTR_UNUSED void* pBuffer)
 {
 	WLog_ERR(TAG, "TODO: Implement");
 	return SEC_E_UNSUPPORTED_FUNCTION;

--- a/winpr/libwinpr/sspi/Schannel/schannel.c
+++ b/winpr/libwinpr/sspi/Schannel/schannel.c
@@ -88,9 +88,8 @@ static ALG_ID schannel_SupportedAlgs[] = { CALG_AES_128,
 	                                       CALG_DSS_SIGN,
 	                                       CALG_ECDSA };
 
-static SECURITY_STATUS SEC_ENTRY schannel_QueryCredentialsAttributesW(PCredHandle phCredential,
-                                                                      ULONG ulAttribute,
-                                                                      void* pBuffer)
+static SECURITY_STATUS SEC_ENTRY schannel_QueryCredentialsAttributesW(
+    WINPR_ATTR_UNUSED PCredHandle phCredential, ULONG ulAttribute, void* pBuffer)
 {
 	if (ulAttribute == SECPKG_ATTR_SUPPORTED_ALGS)
 	{
@@ -126,9 +125,10 @@ static SECURITY_STATUS SEC_ENTRY schannel_QueryCredentialsAttributesA(PCredHandl
 }
 
 static SECURITY_STATUS SEC_ENTRY schannel_AcquireCredentialsHandleW(
-    SEC_WCHAR* pszPrincipal, SEC_WCHAR* pszPackage, ULONG fCredentialUse, void* pvLogonID,
-    void* pAuthData, SEC_GET_KEY_FN pGetKeyFn, void* pvGetKeyArgument, PCredHandle phCredential,
-    PTimeStamp ptsExpiry)
+    WINPR_ATTR_UNUSED SEC_WCHAR* pszPrincipal, WINPR_ATTR_UNUSED SEC_WCHAR* pszPackage,
+    ULONG fCredentialUse, WINPR_ATTR_UNUSED void* pvLogonID, void* pAuthData,
+    WINPR_ATTR_UNUSED SEC_GET_KEY_FN pGetKeyFn, WINPR_ATTR_UNUSED void* pvGetKeyArgument,
+    PCredHandle phCredential, WINPR_ATTR_UNUSED PTimeStamp ptsExpiry)
 {
 	SCHANNEL_CREDENTIALS* credentials = NULL;
 
@@ -198,9 +198,11 @@ static SECURITY_STATUS SEC_ENTRY schannel_FreeCredentialsHandle(PCredHandle phCr
 }
 
 static SECURITY_STATUS SEC_ENTRY schannel_InitializeSecurityContextW(
-    PCredHandle phCredential, PCtxtHandle phContext, SEC_WCHAR* pszTargetName, ULONG fContextReq,
-    ULONG Reserved1, ULONG TargetDataRep, PSecBufferDesc pInput, ULONG Reserved2,
-    PCtxtHandle phNewContext, PSecBufferDesc pOutput, PULONG pfContextAttr, PTimeStamp ptsExpiry)
+    PCredHandle phCredential, PCtxtHandle phContext, WINPR_ATTR_UNUSED SEC_WCHAR* pszTargetName,
+    WINPR_ATTR_UNUSED ULONG fContextReq, WINPR_ATTR_UNUSED ULONG Reserved1,
+    WINPR_ATTR_UNUSED ULONG TargetDataRep, PSecBufferDesc pInput, WINPR_ATTR_UNUSED ULONG Reserved2,
+    PCtxtHandle phNewContext, PSecBufferDesc pOutput, WINPR_ATTR_UNUSED PULONG pfContextAttr,
+    WINPR_ATTR_UNUSED PTimeStamp ptsExpiry)
 {
 	SECURITY_STATUS status = 0;
 	SCHANNEL_CONTEXT* context = NULL;
@@ -254,9 +256,10 @@ static SECURITY_STATUS SEC_ENTRY schannel_InitializeSecurityContextA(
 }
 
 static SECURITY_STATUS SEC_ENTRY schannel_AcceptSecurityContext(
-    PCredHandle phCredential, PCtxtHandle phContext, PSecBufferDesc pInput, ULONG fContextReq,
-    ULONG TargetDataRep, PCtxtHandle phNewContext, PSecBufferDesc pOutput, PULONG pfContextAttr,
-    PTimeStamp ptsTimeStamp)
+    WINPR_ATTR_UNUSED PCredHandle phCredential, PCtxtHandle phContext, PSecBufferDesc pInput,
+    WINPR_ATTR_UNUSED ULONG fContextReq, WINPR_ATTR_UNUSED ULONG TargetDataRep,
+    PCtxtHandle phNewContext, PSecBufferDesc pOutput, WINPR_ATTR_UNUSED PULONG pfContextAttr,
+    WINPR_ATTR_UNUSED PTimeStamp ptsTimeStamp)
 {
 	SECURITY_STATUS status = 0;
 	SCHANNEL_CONTEXT* context = NULL;
@@ -329,22 +332,26 @@ static SECURITY_STATUS SEC_ENTRY schannel_QueryContextAttributes(PCtxtHandle phC
 	return SEC_E_UNSUPPORTED_FUNCTION;
 }
 
-static SECURITY_STATUS SEC_ENTRY schannel_MakeSignature(PCtxtHandle phContext, ULONG fQOP,
-                                                        PSecBufferDesc pMessage, ULONG MessageSeqNo)
+static SECURITY_STATUS SEC_ENTRY schannel_MakeSignature(WINPR_ATTR_UNUSED PCtxtHandle phContext,
+                                                        WINPR_ATTR_UNUSED ULONG fQOP,
+                                                        WINPR_ATTR_UNUSED PSecBufferDesc pMessage,
+                                                        WINPR_ATTR_UNUSED ULONG MessageSeqNo)
 {
 	return SEC_E_OK;
 }
 
-static SECURITY_STATUS SEC_ENTRY schannel_VerifySignature(PCtxtHandle phContext,
-                                                          PSecBufferDesc pMessage,
-                                                          ULONG MessageSeqNo, ULONG* pfQOP)
+static SECURITY_STATUS SEC_ENTRY schannel_VerifySignature(WINPR_ATTR_UNUSED PCtxtHandle phContext,
+                                                          WINPR_ATTR_UNUSED PSecBufferDesc pMessage,
+                                                          WINPR_ATTR_UNUSED ULONG MessageSeqNo,
+                                                          WINPR_ATTR_UNUSED ULONG* pfQOP)
 {
 	return SEC_E_OK;
 }
 
-static SECURITY_STATUS SEC_ENTRY schannel_EncryptMessage(PCtxtHandle phContext, ULONG fQOP,
+static SECURITY_STATUS SEC_ENTRY schannel_EncryptMessage(WINPR_ATTR_UNUSED PCtxtHandle phContext,
+                                                         WINPR_ATTR_UNUSED ULONG fQOP,
                                                          PSecBufferDesc pMessage,
-                                                         ULONG MessageSeqNo)
+                                                         WINPR_ATTR_UNUSED ULONG MessageSeqNo)
 {
 	SECURITY_STATUS status = 0;
 	SCHANNEL_CONTEXT* context = NULL;
@@ -359,7 +366,8 @@ static SECURITY_STATUS SEC_ENTRY schannel_EncryptMessage(PCtxtHandle phContext, 
 
 static SECURITY_STATUS SEC_ENTRY schannel_DecryptMessage(PCtxtHandle phContext,
                                                          PSecBufferDesc pMessage,
-                                                         ULONG MessageSeqNo, ULONG* pfQOP)
+                                                         WINPR_ATTR_UNUSED ULONG MessageSeqNo,
+                                                         WINPR_ATTR_UNUSED ULONG* pfQOP)
 {
 	SECURITY_STATUS status = 0;
 	SCHANNEL_CONTEXT* context = NULL;

--- a/winpr/libwinpr/sspi/sspi.c
+++ b/winpr/libwinpr/sspi/sspi.c
@@ -157,7 +157,9 @@ BOOL InitializeSspiModule_Native(void)
 }
 #endif
 
-static BOOL CALLBACK InitializeSspiModuleInt(PINIT_ONCE once, PVOID param, PVOID* context)
+static BOOL CALLBACK InitializeSspiModuleInt(WINPR_ATTR_UNUSED PINIT_ONCE once,
+                                             WINPR_ATTR_UNUSED PVOID param,
+                                             WINPR_ATTR_UNUSED PVOID* context)
 {
 	BOOL status = FALSE;
 #if defined(WITH_NATIVE_SSPI)

--- a/winpr/libwinpr/sspi/sspi_winpr.c
+++ b/winpr/libwinpr/sspi/sspi_winpr.c
@@ -975,7 +975,8 @@ static BOOL WINPR_init(void)
 	return TRUE;
 }
 
-static BOOL CALLBACK sspi_init(PINIT_ONCE InitOnce, PVOID Parameter, PVOID* Context)
+static BOOL CALLBACK sspi_init(WINPR_ATTR_UNUSED PINIT_ONCE InitOnce,
+                               WINPR_ATTR_UNUSED PVOID Parameter, WINPR_ATTR_UNUSED PVOID* Context)
 {
 	winpr_InitializeSSL(WINPR_SSL_INIT_DEFAULT);
 	sspi_ContextBufferAllocTableNew();

--- a/winpr/libwinpr/sspicli/sspicli.c
+++ b/winpr/libwinpr/sspicli/sspicli.c
@@ -126,8 +126,9 @@ static HANDLE_OPS ops = { LogonUserIsHandled,
 	                      NULL,
 	                      NULL };
 
-BOOL LogonUserA(LPCSTR lpszUsername, LPCSTR lpszDomain, LPCSTR lpszPassword, DWORD dwLogonType,
-                DWORD dwLogonProvider, PHANDLE phToken)
+BOOL LogonUserA(LPCSTR lpszUsername, LPCSTR lpszDomain, WINPR_ATTR_UNUSED LPCSTR lpszPassword,
+                WINPR_ATTR_UNUSED DWORD dwLogonType, WINPR_ATTR_UNUSED DWORD dwLogonProvider,
+                PHANDLE phToken)
 {
 	if (!lpszUsername)
 		return FALSE;
@@ -182,23 +183,33 @@ fail:
 	return FALSE;
 }
 
-BOOL LogonUserW(LPCWSTR lpszUsername, LPCWSTR lpszDomain, LPCWSTR lpszPassword, DWORD dwLogonType,
-                DWORD dwLogonProvider, PHANDLE phToken)
+BOOL LogonUserW(WINPR_ATTR_UNUSED LPCWSTR lpszUsername, WINPR_ATTR_UNUSED LPCWSTR lpszDomain,
+                WINPR_ATTR_UNUSED LPCWSTR lpszPassword, WINPR_ATTR_UNUSED DWORD dwLogonType,
+                WINPR_ATTR_UNUSED DWORD dwLogonProvider, WINPR_ATTR_UNUSED PHANDLE phToken)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return TRUE;
 }
 
-BOOL LogonUserExA(LPCSTR lpszUsername, LPCSTR lpszDomain, LPCSTR lpszPassword, DWORD dwLogonType,
-                  DWORD dwLogonProvider, PHANDLE phToken, PSID* ppLogonSid, PVOID* ppProfileBuffer,
-                  LPDWORD pdwProfileLength, PQUOTA_LIMITS pQuotaLimits)
+BOOL LogonUserExA(WINPR_ATTR_UNUSED LPCSTR lpszUsername, WINPR_ATTR_UNUSED LPCSTR lpszDomain,
+                  WINPR_ATTR_UNUSED LPCSTR lpszPassword, WINPR_ATTR_UNUSED DWORD dwLogonType,
+                  WINPR_ATTR_UNUSED DWORD dwLogonProvider, WINPR_ATTR_UNUSED PHANDLE phToken,
+                  WINPR_ATTR_UNUSED PSID* ppLogonSid, WINPR_ATTR_UNUSED PVOID* ppProfileBuffer,
+                  WINPR_ATTR_UNUSED LPDWORD pdwProfileLength,
+                  WINPR_ATTR_UNUSED PQUOTA_LIMITS pQuotaLimits)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return TRUE;
 }
 
-BOOL LogonUserExW(LPCWSTR lpszUsername, LPCWSTR lpszDomain, LPCWSTR lpszPassword, DWORD dwLogonType,
-                  DWORD dwLogonProvider, PHANDLE phToken, PSID* ppLogonSid, PVOID* ppProfileBuffer,
-                  LPDWORD pdwProfileLength, PQUOTA_LIMITS pQuotaLimits)
+BOOL LogonUserExW(WINPR_ATTR_UNUSED LPCWSTR lpszUsername, WINPR_ATTR_UNUSED LPCWSTR lpszDomain,
+                  WINPR_ATTR_UNUSED LPCWSTR lpszPassword, WINPR_ATTR_UNUSED DWORD dwLogonType,
+                  WINPR_ATTR_UNUSED DWORD dwLogonProvider, WINPR_ATTR_UNUSED PHANDLE phToken,
+                  WINPR_ATTR_UNUSED PSID* ppLogonSid, WINPR_ATTR_UNUSED PVOID* ppProfileBuffer,
+                  WINPR_ATTR_UNUSED LPDWORD pdwProfileLength,
+                  WINPR_ATTR_UNUSED PQUOTA_LIMITS pQuotaLimits)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return TRUE;
 }
 

--- a/winpr/libwinpr/synch/address.c
+++ b/winpr/libwinpr/synch/address.c
@@ -29,16 +29,16 @@
 
 #ifndef _WIN32
 
-VOID WakeByAddressAll(PVOID Address)
+VOID WakeByAddressAll(WINPR_ATTR_UNUSED PVOID Address)
 {
 }
 
-VOID WakeByAddressSingle(PVOID Address)
+VOID WakeByAddressSingle(WINPR_ATTR_UNUSED PVOID Address)
 {
 }
 
-BOOL WaitOnAddress(VOID volatile* Address, PVOID CompareAddress, size_t AddressSize,
-                   DWORD dwMilliseconds)
+BOOL WaitOnAddress(WINPR_ATTR_UNUSED VOID volatile* Address, WINPR_ATTR_UNUSED PVOID CompareAddress,
+                   WINPR_ATTR_UNUSED size_t AddressSize, WINPR_ATTR_UNUSED DWORD dwMilliseconds)
 {
 	return TRUE;
 }

--- a/winpr/libwinpr/synch/critical.c
+++ b/winpr/libwinpr/synch/critical.c
@@ -102,7 +102,8 @@ BOOL InitializeCriticalSectionAndSpinCount(LPCRITICAL_SECTION lpCriticalSection,
 	return InitializeCriticalSectionEx(lpCriticalSection, dwSpinCount, 0);
 }
 
-DWORD SetCriticalSectionSpinCount(LPCRITICAL_SECTION lpCriticalSection, DWORD dwSpinCount)
+DWORD SetCriticalSectionSpinCount(WINPR_ATTR_UNUSED LPCRITICAL_SECTION lpCriticalSection,
+                                  WINPR_ATTR_UNUSED DWORD dwSpinCount)
 {
 	WINPR_ASSERT(lpCriticalSection);
 #if !defined(WINPR_CRITICAL_SECTION_DISABLE_SPINCOUNT)
@@ -121,6 +122,7 @@ DWORD SetCriticalSectionSpinCount(LPCRITICAL_SECTION lpCriticalSection, DWORD dw
 	lpCriticalSection->SpinCount = dwSpinCount;
 	return dwPreviousSpinCount;
 #else
+	// WLog_ERR("TODO", "TODO: implement");
 	return 0;
 #endif
 }

--- a/winpr/libwinpr/synch/event.c
+++ b/winpr/libwinpr/synch/event.c
@@ -423,8 +423,9 @@ BOOL ResetEvent(HANDLE hEvent)
 
 #endif
 
-HANDLE CreateFileDescriptorEventW(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL bManualReset,
-                                  BOOL bInitialState, int FileDescriptor, ULONG mode)
+HANDLE CreateFileDescriptorEventW(WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpEventAttributes,
+                                  BOOL bManualReset, WINPR_ATTR_UNUSED BOOL bInitialState,
+                                  int FileDescriptor, ULONG mode)
 {
 #ifndef _WIN32
 	WINPR_EVENT* event = NULL;

--- a/winpr/libwinpr/synch/init.c
+++ b/winpr/libwinpr/synch/init.c
@@ -29,20 +29,23 @@
 
 #if (!defined(_WIN32)) || (defined(_WIN32) && (_WIN32_WINNT < 0x0600))
 
-BOOL winpr_InitOnceBeginInitialize(LPINIT_ONCE lpInitOnce, DWORD dwFlags, PBOOL fPending,
-                                   LPVOID* lpContext)
+BOOL winpr_InitOnceBeginInitialize(WINPR_ATTR_UNUSED LPINIT_ONCE lpInitOnce,
+                                   WINPR_ATTR_UNUSED DWORD dwFlags,
+                                   WINPR_ATTR_UNUSED PBOOL fPending,
+                                   WINPR_ATTR_UNUSED LPVOID* lpContext)
 {
 	WLog_ERR(TAG, "not implemented");
 	return FALSE;
 }
 
-BOOL winpr_InitOnceComplete(LPINIT_ONCE lpInitOnce, DWORD dwFlags, LPVOID lpContext)
+BOOL winpr_InitOnceComplete(WINPR_ATTR_UNUSED LPINIT_ONCE lpInitOnce,
+                            WINPR_ATTR_UNUSED DWORD dwFlags, WINPR_ATTR_UNUSED LPVOID lpContext)
 {
 	WLog_ERR(TAG, "not implemented");
 	return FALSE;
 }
 
-VOID winpr_InitOnceInitialize(PINIT_ONCE InitOnce)
+VOID winpr_InitOnceInitialize(WINPR_ATTR_UNUSED PINIT_ONCE InitOnce)
 {
 	WLog_ERR(TAG, "not implemented");
 }

--- a/winpr/libwinpr/synch/semaphore.c
+++ b/winpr/libwinpr/synch/semaphore.c
@@ -126,8 +126,9 @@ static HANDLE_OPS ops = { SemaphoreIsHandled,
 	                      NULL,
 	                      NULL };
 
-HANDLE CreateSemaphoreW(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lInitialCount,
-                        LONG lMaximumCount, LPCWSTR lpName)
+HANDLE CreateSemaphoreW(WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpSemaphoreAttributes,
+                        LONG lInitialCount, WINPR_ATTR_UNUSED LONG lMaximumCount,
+                        WINPR_ATTR_UNUSED LPCWSTR lpName)
 {
 	HANDLE handle = NULL;
 	WINPR_SEMAPHORE* semaphore = NULL;
@@ -193,24 +194,27 @@ HANDLE CreateSemaphoreW(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lIniti
 }
 
 HANDLE CreateSemaphoreA(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lInitialCount,
-                        LONG lMaximumCount, LPCSTR lpName)
+                        LONG lMaximumCount, WINPR_ATTR_UNUSED LPCSTR lpName)
 {
 	return CreateSemaphoreW(lpSemaphoreAttributes, lInitialCount, lMaximumCount, NULL);
 }
 
-HANDLE OpenSemaphoreW(DWORD dwDesiredAccess, BOOL bInheritHandle, LPCWSTR lpName)
+HANDLE OpenSemaphoreW(WINPR_ATTR_UNUSED DWORD dwDesiredAccess,
+                      WINPR_ATTR_UNUSED BOOL bInheritHandle, WINPR_ATTR_UNUSED LPCWSTR lpName)
 {
 	WLog_ERR(TAG, "not implemented");
 	return NULL;
 }
 
-HANDLE OpenSemaphoreA(DWORD dwDesiredAccess, BOOL bInheritHandle, LPCSTR lpName)
+HANDLE OpenSemaphoreA(WINPR_ATTR_UNUSED DWORD dwDesiredAccess,
+                      WINPR_ATTR_UNUSED BOOL bInheritHandle, WINPR_ATTR_UNUSED LPCSTR lpName)
 {
 	WLog_ERR(TAG, "not implemented");
 	return NULL;
 }
 
-BOOL ReleaseSemaphore(HANDLE hSemaphore, LONG lReleaseCount, LPLONG lpPreviousCount)
+BOOL ReleaseSemaphore(HANDLE hSemaphore, LONG lReleaseCount,
+                      WINPR_ATTR_UNUSED LPLONG lpPreviousCount)
 {
 	ULONG Type = 0;
 	WINPR_HANDLE* Object = NULL;

--- a/winpr/libwinpr/synch/timer.c
+++ b/winpr/libwinpr/synch/timer.c
@@ -619,20 +619,25 @@ BOOL SetWaitableTimer(HANDLE hTimer, const LARGE_INTEGER* lpDueTime, LONG lPerio
 
 BOOL SetWaitableTimerEx(HANDLE hTimer, const LARGE_INTEGER* lpDueTime, LONG lPeriod,
                         PTIMERAPCROUTINE pfnCompletionRoutine, LPVOID lpArgToCompletionRoutine,
-                        PREASON_CONTEXT WakeContext, ULONG TolerableDelay)
+                        WINPR_ATTR_UNUSED PREASON_CONTEXT WakeContext,
+                        WINPR_ATTR_UNUSED ULONG TolerableDelay)
 {
 	return SetWaitableTimer(hTimer, lpDueTime, lPeriod, pfnCompletionRoutine,
 	                        lpArgToCompletionRoutine, FALSE);
 }
 
-HANDLE OpenWaitableTimerA(DWORD dwDesiredAccess, BOOL bInheritHandle, LPCSTR lpTimerName)
+HANDLE OpenWaitableTimerA(WINPR_ATTR_UNUSED DWORD dwDesiredAccess,
+                          WINPR_ATTR_UNUSED BOOL bInheritHandle,
+                          WINPR_ATTR_UNUSED LPCSTR lpTimerName)
 {
 	/* TODO: Implement */
 	WLog_ERR(TAG, "not implemented");
 	return NULL;
 }
 
-HANDLE OpenWaitableTimerW(DWORD dwDesiredAccess, BOOL bInheritHandle, LPCWSTR lpTimerName)
+HANDLE OpenWaitableTimerW(WINPR_ATTR_UNUSED DWORD dwDesiredAccess,
+                          WINPR_ATTR_UNUSED BOOL bInheritHandle,
+                          WINPR_ATTR_UNUSED LPCWSTR lpTimerName)
 {
 	/* TODO: Implement */
 	WLog_ERR(TAG, "not implemented");

--- a/winpr/libwinpr/sysinfo/sysinfo.c
+++ b/winpr/libwinpr/sysinfo/sysinfo.c
@@ -266,9 +266,10 @@ void GetSystemTime(LPSYSTEMTIME lpSystemTime)
 	}
 }
 
-BOOL SetSystemTime(CONST SYSTEMTIME* lpSystemTime)
+BOOL SetSystemTime(WINPR_ATTR_UNUSED CONST SYSTEMTIME* lpSystemTime)
 {
 	/* TODO: Implement */
+	WLog_ERR("TODO", "TODO: Implement");
 	return FALSE;
 }
 
@@ -296,9 +297,10 @@ VOID GetLocalTime(LPSYSTEMTIME lpSystemTime)
 	}
 }
 
-BOOL SetLocalTime(CONST SYSTEMTIME* lpSystemTime)
+BOOL SetLocalTime(WINPR_ATTR_UNUSED CONST SYSTEMTIME* lpSystemTime)
 {
 	/* TODO: Implement */
+	WLog_ERR("TODO", "TODO: Implement");
 	return FALSE;
 }
 
@@ -314,10 +316,12 @@ VOID GetSystemTimeAsFileTime(LPFILETIME lpSystemTimeAsFileTime)
 	*lpSystemTimeAsFileTime = t.ft;
 }
 
-BOOL GetSystemTimeAdjustment(PDWORD lpTimeAdjustment, PDWORD lpTimeIncrement,
-                             PBOOL lpTimeAdjustmentDisabled)
+BOOL GetSystemTimeAdjustment(WINPR_ATTR_UNUSED PDWORD lpTimeAdjustment,
+                             WINPR_ATTR_UNUSED PDWORD lpTimeIncrement,
+                             WINPR_ATTR_UNUSED PBOOL lpTimeAdjustmentDisabled)
 {
 	/* TODO: Implement */
+	WLog_ERR("TODO", "TODO: Implement");
 	return FALSE;
 }
 

--- a/winpr/libwinpr/thread/argv.c
+++ b/winpr/libwinpr/thread/argv.c
@@ -271,8 +271,9 @@ LPSTR* CommandLineToArgvA(LPCSTR lpCmdLine, int* pNumArgs)
 
 #ifndef _WIN32
 
-LPWSTR* CommandLineToArgvW(LPCWSTR lpCmdLine, int* pNumArgs)
+LPWSTR* CommandLineToArgvW(WINPR_ATTR_UNUSED LPCWSTR lpCmdLine, WINPR_ATTR_UNUSED int* pNumArgs)
 {
+	WLog_ERR("TODO", "TODO: Implement");
 	return NULL;
 }
 

--- a/winpr/libwinpr/thread/process.c
+++ b/winpr/libwinpr/thread/process.c
@@ -24,6 +24,7 @@
 #include "../handle/nonehandle.h"
 
 #include <winpr/thread.h>
+#include <winpr/wlog.h>
 
 /**
  * CreateProcessA
@@ -150,11 +151,13 @@ static char* FindApplicationPath(char* application)
 static HANDLE CreateProcessHandle(pid_t pid);
 static BOOL ProcessHandleCloseHandle(HANDLE handle);
 
-static BOOL CreateProcessExA(HANDLE hToken, DWORD dwLogonFlags, LPCSTR lpApplicationName,
-                             LPSTR lpCommandLine, LPSECURITY_ATTRIBUTES lpProcessAttributes,
-                             LPSECURITY_ATTRIBUTES lpThreadAttributes, BOOL bInheritHandles,
-                             DWORD dwCreationFlags, LPVOID lpEnvironment, LPCSTR lpCurrentDirectory,
-                             LPSTARTUPINFOA lpStartupInfo,
+static BOOL CreateProcessExA(HANDLE hToken, WINPR_ATTR_UNUSED DWORD dwLogonFlags,
+                             LPCSTR lpApplicationName, WINPR_ATTR_UNUSED LPSTR lpCommandLine,
+                             WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpProcessAttributes,
+                             WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpThreadAttributes,
+                             WINPR_ATTR_UNUSED BOOL bInheritHandles,
+                             WINPR_ATTR_UNUSED DWORD dwCreationFlags, LPVOID lpEnvironment,
+                             LPCSTR lpCurrentDirectory, LPSTARTUPINFOA lpStartupInfo,
                              LPPROCESS_INFORMATION lpProcessInformation)
 {
 	pid_t pid = 0;
@@ -377,12 +380,17 @@ BOOL CreateProcessA(LPCSTR lpApplicationName, LPSTR lpCommandLine,
 	                        lpCurrentDirectory, lpStartupInfo, lpProcessInformation);
 }
 
-BOOL CreateProcessW(LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
-                    LPSECURITY_ATTRIBUTES lpProcessAttributes,
-                    LPSECURITY_ATTRIBUTES lpThreadAttributes, BOOL bInheritHandles,
-                    DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
-                    LPSTARTUPINFOW lpStartupInfo, LPPROCESS_INFORMATION lpProcessInformation)
+BOOL CreateProcessW(WINPR_ATTR_UNUSED LPCWSTR lpApplicationName,
+                    WINPR_ATTR_UNUSED LPWSTR lpCommandLine,
+                    WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpProcessAttributes,
+                    WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpThreadAttributes,
+                    WINPR_ATTR_UNUSED BOOL bInheritHandles, WINPR_ATTR_UNUSED DWORD dwCreationFlags,
+                    WINPR_ATTR_UNUSED LPVOID lpEnvironment,
+                    WINPR_ATTR_UNUSED LPCWSTR lpCurrentDirectory,
+                    WINPR_ATTR_UNUSED LPSTARTUPINFOW lpStartupInfo,
+                    WINPR_ATTR_UNUSED LPPROCESS_INFORMATION lpProcessInformation)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
@@ -397,36 +405,50 @@ BOOL CreateProcessAsUserA(HANDLE hToken, LPCSTR lpApplicationName, LPSTR lpComma
 	                        lpCurrentDirectory, lpStartupInfo, lpProcessInformation);
 }
 
-BOOL CreateProcessAsUserW(HANDLE hToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
-                          LPSECURITY_ATTRIBUTES lpProcessAttributes,
-                          LPSECURITY_ATTRIBUTES lpThreadAttributes, BOOL bInheritHandles,
-                          DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
-                          LPSTARTUPINFOW lpStartupInfo, LPPROCESS_INFORMATION lpProcessInformation)
+BOOL CreateProcessAsUserW(WINPR_ATTR_UNUSED HANDLE hToken,
+                          WINPR_ATTR_UNUSED LPCWSTR lpApplicationName,
+                          WINPR_ATTR_UNUSED LPWSTR lpCommandLine,
+                          WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpProcessAttributes,
+                          WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpThreadAttributes,
+                          WINPR_ATTR_UNUSED BOOL bInheritHandles,
+                          WINPR_ATTR_UNUSED DWORD dwCreationFlags,
+                          WINPR_ATTR_UNUSED LPVOID lpEnvironment,
+                          WINPR_ATTR_UNUSED LPCWSTR lpCurrentDirectory,
+                          WINPR_ATTR_UNUSED LPSTARTUPINFOW lpStartupInfo,
+                          WINPR_ATTR_UNUSED LPPROCESS_INFORMATION lpProcessInformation)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
-BOOL CreateProcessWithLogonA(LPCSTR lpUsername, LPCSTR lpDomain, LPCSTR lpPassword,
-                             DWORD dwLogonFlags, LPCSTR lpApplicationName, LPSTR lpCommandLine,
-                             DWORD dwCreationFlags, LPVOID lpEnvironment, LPCSTR lpCurrentDirectory,
+BOOL CreateProcessWithLogonA(
+    WINPR_ATTR_UNUSED LPCSTR lpUsername, WINPR_ATTR_UNUSED LPCSTR lpDomain,
+    WINPR_ATTR_UNUSED LPCSTR lpPassword, WINPR_ATTR_UNUSED DWORD dwLogonFlags,
+    WINPR_ATTR_UNUSED LPCSTR lpApplicationName, WINPR_ATTR_UNUSED LPSTR lpCommandLine,
+    WINPR_ATTR_UNUSED DWORD dwCreationFlags, WINPR_ATTR_UNUSED LPVOID lpEnvironment,
+    WINPR_ATTR_UNUSED LPCSTR lpCurrentDirectory, WINPR_ATTR_UNUSED LPSTARTUPINFOA lpStartupInfo,
+    WINPR_ATTR_UNUSED LPPROCESS_INFORMATION lpProcessInformation)
+{
+	WLog_ERR("TODO", "TODO: implement");
+	return FALSE;
+}
+
+BOOL CreateProcessWithLogonW(
+    WINPR_ATTR_UNUSED LPCWSTR lpUsername, WINPR_ATTR_UNUSED LPCWSTR lpDomain,
+    WINPR_ATTR_UNUSED LPCWSTR lpPassword, WINPR_ATTR_UNUSED DWORD dwLogonFlags,
+    WINPR_ATTR_UNUSED LPCWSTR lpApplicationName, WINPR_ATTR_UNUSED LPWSTR lpCommandLine,
+    WINPR_ATTR_UNUSED DWORD dwCreationFlags, WINPR_ATTR_UNUSED LPVOID lpEnvironment,
+    WINPR_ATTR_UNUSED LPCWSTR lpCurrentDirectory, WINPR_ATTR_UNUSED LPSTARTUPINFOW lpStartupInfo,
+    WINPR_ATTR_UNUSED LPPROCESS_INFORMATION lpProcessInformation)
+{
+	WLog_ERR("TODO", "TODO: implement");
+	return FALSE;
+}
+
+BOOL CreateProcessWithTokenA(WINPR_ATTR_UNUSED HANDLE hToken, WINPR_ATTR_UNUSED DWORD dwLogonFlags,
+                             LPCSTR lpApplicationName, LPSTR lpCommandLine, DWORD dwCreationFlags,
+                             LPVOID lpEnvironment, LPCSTR lpCurrentDirectory,
                              LPSTARTUPINFOA lpStartupInfo,
-                             LPPROCESS_INFORMATION lpProcessInformation)
-{
-	return FALSE;
-}
-
-BOOL CreateProcessWithLogonW(LPCWSTR lpUsername, LPCWSTR lpDomain, LPCWSTR lpPassword,
-                             DWORD dwLogonFlags, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
-                             DWORD dwCreationFlags, LPVOID lpEnvironment,
-                             LPCWSTR lpCurrentDirectory, LPSTARTUPINFOW lpStartupInfo,
-                             LPPROCESS_INFORMATION lpProcessInformation)
-{
-	return FALSE;
-}
-
-BOOL CreateProcessWithTokenA(HANDLE hToken, DWORD dwLogonFlags, LPCSTR lpApplicationName,
-                             LPSTR lpCommandLine, DWORD dwCreationFlags, LPVOID lpEnvironment,
-                             LPCSTR lpCurrentDirectory, LPSTARTUPINFOA lpStartupInfo,
                              LPPROCESS_INFORMATION lpProcessInformation)
 {
 	return CreateProcessExA(NULL, 0, lpApplicationName, lpCommandLine, NULL, NULL, FALSE,
@@ -434,11 +456,16 @@ BOOL CreateProcessWithTokenA(HANDLE hToken, DWORD dwLogonFlags, LPCSTR lpApplica
 	                        lpProcessInformation);
 }
 
-BOOL CreateProcessWithTokenW(HANDLE hToken, DWORD dwLogonFlags, LPCWSTR lpApplicationName,
-                             LPWSTR lpCommandLine, DWORD dwCreationFlags, LPVOID lpEnvironment,
-                             LPCWSTR lpCurrentDirectory, LPSTARTUPINFOW lpStartupInfo,
-                             LPPROCESS_INFORMATION lpProcessInformation)
+BOOL CreateProcessWithTokenW(WINPR_ATTR_UNUSED HANDLE hToken, WINPR_ATTR_UNUSED DWORD dwLogonFlags,
+                             WINPR_ATTR_UNUSED LPCWSTR lpApplicationName,
+                             WINPR_ATTR_UNUSED LPWSTR lpCommandLine,
+                             WINPR_ATTR_UNUSED DWORD dwCreationFlags,
+                             WINPR_ATTR_UNUSED LPVOID lpEnvironment,
+                             WINPR_ATTR_UNUSED LPCWSTR lpCurrentDirectory,
+                             WINPR_ATTR_UNUSED LPSTARTUPINFOW lpStartupInfo,
+                             WINPR_ATTR_UNUSED LPPROCESS_INFORMATION lpProcessInformation)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return FALSE;
 }
 
@@ -465,15 +492,17 @@ BOOL GetExitCodeProcess(HANDLE hProcess, LPDWORD lpExitCode)
 
 HANDLE _GetCurrentProcess(VOID)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return NULL;
 }
 
 DWORD GetCurrentProcessId(VOID)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return ((DWORD)getpid());
 }
 
-BOOL TerminateProcess(HANDLE hProcess, UINT uExitCode)
+BOOL TerminateProcess(HANDLE hProcess, WINPR_ATTR_UNUSED UINT uExitCode)
 {
 	WINPR_PROCESS* process = NULL;
 	process = (WINPR_PROCESS*)hProcess;

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -440,7 +440,8 @@ static INIT_ONCE threads_InitOnce = INIT_ONCE_STATIC_INIT;
 static pthread_t mainThreadId;
 static DWORD currentThreadTlsIndex = TLS_OUT_OF_INDEXES;
 
-static BOOL initializeThreads(PINIT_ONCE InitOnce, PVOID Parameter, PVOID* Context)
+static BOOL initializeThreads(WINPR_ATTR_UNUSED PINIT_ONCE InitOnce,
+                              WINPR_ATTR_UNUSED PVOID Parameter, WINPR_ATTR_UNUSED PVOID* Context)
 {
 	if (!apc_init(&mainThread.apc))
 	{
@@ -680,7 +681,7 @@ BOOL SetThreadPriority(HANDLE hThread, int nPriority)
 
 HANDLE CreateThread(LPSECURITY_ATTRIBUTES lpThreadAttributes, size_t dwStackSize,
                     LPTHREAD_START_ROUTINE lpStartAddress, LPVOID lpParameter,
-                    DWORD dwCreationFlags, LPDWORD lpThreadId)
+                    DWORD dwCreationFlags, WINPR_ATTR_UNUSED LPDWORD lpThreadId)
 {
 	HANDLE handle = NULL;
 	WINPR_THREAD* thread = (WINPR_THREAD*)calloc(1, sizeof(WINPR_THREAD));
@@ -813,9 +814,13 @@ BOOL ThreadCloseHandle(HANDLE handle)
 	return TRUE;
 }
 
-HANDLE CreateRemoteThread(HANDLE hProcess, LPSECURITY_ATTRIBUTES lpThreadAttributes,
-                          size_t dwStackSize, LPTHREAD_START_ROUTINE lpStartAddress,
-                          LPVOID lpParameter, DWORD dwCreationFlags, LPDWORD lpThreadId)
+HANDLE CreateRemoteThread(WINPR_ATTR_UNUSED HANDLE hProcess,
+                          WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpThreadAttributes,
+                          WINPR_ATTR_UNUSED size_t dwStackSize,
+                          WINPR_ATTR_UNUSED LPTHREAD_START_ROUTINE lpStartAddress,
+                          WINPR_ATTR_UNUSED LPVOID lpParameter,
+                          WINPR_ATTR_UNUSED DWORD dwCreationFlags,
+                          WINPR_ATTR_UNUSED LPDWORD lpThreadId)
 {
 	WLog_ERR(TAG, "not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
@@ -1000,7 +1005,7 @@ DWORD ResumeThread(HANDLE hThread)
 	return 0;
 }
 
-DWORD SuspendThread(HANDLE hThread)
+DWORD SuspendThread(WINPR_ATTR_UNUSED HANDLE hThread)
 {
 	WLog_ERR(TAG, "not implemented");
 	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);

--- a/winpr/libwinpr/timezone/TimeZoneNameMapUtils.c
+++ b/winpr/libwinpr/timezone/TimeZoneNameMapUtils.c
@@ -398,7 +398,7 @@ static const char* map_fallback(const char* iana, TimeZoneNameType type)
 	return res;
 }
 #else
-static const char* map_fallback(const char* iana, TimeZoneNameType type)
+static const char* map_fallback(const char* iana, WINPR_ATTR_UNUSED TimeZoneNameType type)
 {
 	if (!iana)
 		return NULL;

--- a/winpr/libwinpr/utils/cmdline.c
+++ b/winpr/libwinpr/utils/cmdline.c
@@ -389,10 +389,13 @@ int CommandLineParseArgumentsA(int argc, LPSTR* argv, COMMAND_LINE_ARGUMENT_A* o
 	return status;
 }
 
-int CommandLineParseArgumentsW(int argc, LPWSTR* argv, COMMAND_LINE_ARGUMENT_W* options,
-                               DWORD flags, void* context, COMMAND_LINE_PRE_FILTER_FN_W preFilter,
-                               COMMAND_LINE_POST_FILTER_FN_W postFilter)
+int CommandLineParseArgumentsW(WINPR_ATTR_UNUSED int argc, WINPR_ATTR_UNUSED LPWSTR* argv,
+                               WINPR_ATTR_UNUSED COMMAND_LINE_ARGUMENT_W* options,
+                               WINPR_ATTR_UNUSED DWORD flags, WINPR_ATTR_UNUSED void* context,
+                               WINPR_ATTR_UNUSED COMMAND_LINE_PRE_FILTER_FN_W preFilter,
+                               WINPR_ATTR_UNUSED COMMAND_LINE_POST_FILTER_FN_W postFilter)
 {
+	WLog_ERR("TODO", "TODO: implement");
 	return 0;
 }
 

--- a/winpr/libwinpr/utils/collections/ArrayList.c
+++ b/winpr/libwinpr/utils/collections/ArrayList.c
@@ -86,7 +86,7 @@ size_t ArrayList_Items(wArrayList* arrayList, ULONG_PTR** ppItems)
  * Gets a value indicating whether the ArrayList has a fixed size.
  */
 
-BOOL ArrayList_IsFixedSized(wArrayList* arrayList)
+BOOL ArrayList_IsFixedSized(WINPR_ATTR_UNUSED wArrayList* arrayList)
 {
 	WINPR_ASSERT(arrayList);
 	return FALSE;
@@ -96,7 +96,7 @@ BOOL ArrayList_IsFixedSized(wArrayList* arrayList)
  * Gets a value indicating whether the ArrayList is read-only.
  */
 
-BOOL ArrayList_IsReadOnly(wArrayList* arrayList)
+BOOL ArrayList_IsReadOnly(WINPR_ATTR_UNUSED wArrayList* arrayList)
 {
 	WINPR_ASSERT(arrayList);
 	return FALSE;

--- a/winpr/libwinpr/utils/debug.c
+++ b/winpr/libwinpr/utils/debug.c
@@ -205,7 +205,7 @@ void winpr_log_backtrace(const char* tag, DWORD level, DWORD size)
 	winpr_log_backtrace_ex(WLog_Get(tag), level, size);
 }
 
-void winpr_log_backtrace_ex(wLog* log, DWORD level, DWORD size)
+void winpr_log_backtrace_ex(wLog* log, DWORD level, WINPR_ATTR_UNUSED DWORD size)
 {
 	size_t used = 0;
 	char** msg = NULL;

--- a/winpr/libwinpr/utils/image.c
+++ b/winpr/libwinpr/utils/image.c
@@ -26,6 +26,7 @@
 #include <winpr/wtypes.h>
 #include <winpr/crt.h>
 #include <winpr/file.h>
+#include <winpr/cast.h>
 
 #include <winpr/image.h>
 
@@ -245,7 +246,7 @@ BYTE* winpr_bitmap_construct_header(size_t width, size_t height, size_t bpp)
 			offset += sizeof(DWORD) * 3; // 3 DWORD color masks
 			break;
 		default:
-			return FALSE;
+			return NULL;
 	}
 
 	if (!writeBitmapFileHeader(s, &bf))
@@ -269,8 +270,9 @@ fail:
  */
 
 WINPR_ATTR_MALLOC(free, 1)
-static void* winpr_bitmap_write_buffer(const BYTE* data, size_t size, UINT32 width, UINT32 height,
-                                       UINT32 stride, UINT32 bpp, UINT32* pSize)
+static void* winpr_bitmap_write_buffer(const BYTE* data, WINPR_ATTR_UNUSED size_t size,
+                                       UINT32 width, UINT32 height, UINT32 stride, UINT32 bpp,
+                                       UINT32* pSize)
 {
 	WINPR_ASSERT(data || (size == 0));
 
@@ -611,8 +613,10 @@ void winpr_image_free(wImage* image, BOOL bFreeBuffer)
 	free(image);
 }
 
-static void* winpr_convert_to_jpeg(const void* data, size_t size, UINT32 width, UINT32 height,
-                                   UINT32 stride, UINT32 bpp, UINT32* pSize)
+static void* winpr_convert_to_jpeg(WINPR_ATTR_UNUSED const void* data,
+                                   WINPR_ATTR_UNUSED size_t size, WINPR_ATTR_UNUSED UINT32 width,
+                                   WINPR_ATTR_UNUSED UINT32 height, WINPR_ATTR_UNUSED UINT32 stride,
+                                   WINPR_ATTR_UNUSED UINT32 bpp, WINPR_ATTR_UNUSED UINT32* pSize)
 {
 	WINPR_ASSERT(data || (size == 0));
 	WINPR_ASSERT(pSize);
@@ -679,8 +683,11 @@ fail:
 }
 
 // NOLINTBEGIN(readability-non-const-parameter)
-SSIZE_T winpr_convert_from_jpeg(const BYTE* comp_data, size_t comp_data_bytes, UINT32* width,
-                                UINT32* height, UINT32* bpp, BYTE** ppdecomp_data)
+SSIZE_T winpr_convert_from_jpeg(WINPR_ATTR_UNUSED const BYTE* comp_data,
+                                WINPR_ATTR_UNUSED size_t comp_data_bytes,
+                                WINPR_ATTR_UNUSED UINT32* width, WINPR_ATTR_UNUSED UINT32* height,
+                                WINPR_ATTR_UNUSED UINT32* bpp,
+                                WINPR_ATTR_UNUSED BYTE** ppdecomp_data)
 // NOLINTEND(readability-non-const-parameter)
 {
 	WINPR_ASSERT(comp_data || (comp_data_bytes == 0));
@@ -706,14 +713,15 @@ SSIZE_T winpr_convert_from_jpeg(const BYTE* comp_data, size_t comp_data_bytes, U
 
 	cinfo.out_color_space = cinfo.num_components > 3 ? JCS_EXT_RGBA : JCS_EXT_BGR;
 
-	*width = cinfo.image_width;
-	*height = cinfo.image_height;
-	*bpp = cinfo.num_components * 8;
+	*width = WINPR_ASSERTING_INT_CAST(uint32_t, cinfo.image_width);
+	*height = WINPR_ASSERTING_INT_CAST(uint32_t, cinfo.image_height);
+	*bpp = WINPR_ASSERTING_INT_CAST(uint32_t, cinfo.num_components * 8);
 
 	if (!jpeg_start_decompress(&cinfo))
 		goto fail;
 
-	size_t stride = 1ULL * cinfo.image_width * cinfo.num_components;
+	size_t stride =
+	    1ULL * cinfo.image_width * WINPR_ASSERTING_INT_CAST(uint32_t, cinfo.num_components);
 
 	if ((stride == 0) || (cinfo.image_height == 0))
 		goto fail;
@@ -740,8 +748,10 @@ fail:
 #endif
 }
 
-static void* winpr_convert_to_webp(const void* data, size_t size, UINT32 width, UINT32 height,
-                                   UINT32 stride, UINT32 bpp, UINT32* pSize)
+static void* winpr_convert_to_webp(WINPR_ATTR_UNUSED const void* data,
+                                   WINPR_ATTR_UNUSED size_t size, WINPR_ATTR_UNUSED UINT32 width,
+                                   WINPR_ATTR_UNUSED UINT32 height, WINPR_ATTR_UNUSED UINT32 stride,
+                                   WINPR_ATTR_UNUSED UINT32 bpp, UINT32* pSize)
 {
 	WINPR_ASSERT(data || (size == 0));
 	WINPR_ASSERT(pSize);
@@ -781,7 +791,8 @@ static void* winpr_convert_to_webp(const void* data, size_t size, UINT32 width, 
 #endif
 }
 
-SSIZE_T winpr_convert_from_webp(const BYTE* comp_data, size_t comp_data_bytes, UINT32* width,
+SSIZE_T winpr_convert_from_webp(WINPR_ATTR_UNUSED const BYTE* comp_data,
+                                WINPR_ATTR_UNUSED size_t comp_data_bytes, UINT32* width,
                                 UINT32* height, UINT32* bpp, BYTE** ppdecomp_data)
 {
 	WINPR_ASSERT(comp_data || (comp_data_bytes == 0));
@@ -807,8 +818,8 @@ SSIZE_T winpr_convert_from_webp(const BYTE* comp_data, size_t comp_data_bytes, U
 		return -1;
 	}
 
-	*width = w;
-	*height = h;
+	*width = WINPR_ASSERTING_INT_CAST(uint32_t, w);
+	*height = WINPR_ASSERTING_INT_CAST(uint32_t, h);
 	*bpp = 32;
 	*ppdecomp_data = dst;
 	return 4ll * w * h;
@@ -848,7 +859,7 @@ static void png_write_data(png_structp png_ptr, png_bytep data, png_size_t lengt
 }
 
 /* This is optional but included to show how png_set_write_fn() is called */
-static void png_flush(png_structp png_ptr)
+static void png_flush(WINPR_ATTR_UNUSED png_structp png_ptr)
 {
 }
 
@@ -1030,8 +1041,10 @@ fail:
 }
 #endif
 
-static void* winpr_convert_to_png(const void* data, size_t size, UINT32 width, UINT32 height,
-                                  UINT32 stride, UINT32 bpp, UINT32* pSize)
+static void* winpr_convert_to_png(WINPR_ATTR_UNUSED const void* data, WINPR_ATTR_UNUSED size_t size,
+                                  WINPR_ATTR_UNUSED UINT32 width, WINPR_ATTR_UNUSED UINT32 height,
+                                  WINPR_ATTR_UNUSED UINT32 stride, WINPR_ATTR_UNUSED UINT32 bpp,
+                                  UINT32* pSize)
 {
 	WINPR_ASSERT(data || (size == 0));
 	WINPR_ASSERT(pSize);
@@ -1072,8 +1085,11 @@ static void* winpr_convert_to_png(const void* data, size_t size, UINT32 width, U
 #endif
 }
 
-SSIZE_T winpr_convert_from_png(const BYTE* comp_data, size_t comp_data_bytes, UINT32* width,
-                               UINT32* height, UINT32* bpp, BYTE** ppdecomp_data)
+SSIZE_T winpr_convert_from_png(WINPR_ATTR_UNUSED const BYTE* comp_data,
+                               WINPR_ATTR_UNUSED size_t comp_data_bytes,
+                               WINPR_ATTR_UNUSED UINT32* width, WINPR_ATTR_UNUSED UINT32* height,
+                               WINPR_ATTR_UNUSED UINT32* bpp,
+                               WINPR_ATTR_UNUSED BYTE** ppdecomp_data)
 {
 #if defined(WINPR_UTILS_IMAGE_PNG)
 	size_t len = 0;
@@ -1111,7 +1127,7 @@ BOOL winpr_image_format_is_supported(UINT32 format)
 	}
 }
 
-static BYTE* convert(const wImage* image, size_t* pstride, UINT32 flags)
+static BYTE* convert(const wImage* image, size_t* pstride, WINPR_ATTR_UNUSED UINT32 flags)
 {
 	WINPR_ASSERT(image);
 	WINPR_ASSERT(pstride);

--- a/winpr/libwinpr/utils/ini.c
+++ b/winpr/libwinpr/utils/ini.c
@@ -139,7 +139,7 @@ static FILE* IniFile_Open_File(wIniFile* ini, const char* filename)
 	WINPR_ASSERT(ini);
 
 	if (!filename)
-		return FALSE;
+		return NULL;
 
 	if (ini->readOnly)
 		return winpr_fopen(filename, "rb");

--- a/winpr/libwinpr/utils/sam.c
+++ b/winpr/libwinpr/utils/sam.c
@@ -253,7 +253,7 @@ static BOOL SamReadEntry(WINPR_SAM* sam, WINPR_SAM_ENTRY* entry)
 	return TRUE;
 }
 
-void SamFreeEntry(WINPR_SAM* sam, WINPR_SAM_ENTRY* entry)
+void SamFreeEntry(WINPR_ATTR_UNUSED WINPR_SAM* sam, WINPR_SAM_ENTRY* entry)
 {
 	if (entry)
 	{

--- a/winpr/libwinpr/utils/ssl.c
+++ b/winpr/libwinpr/utils/ssl.c
@@ -286,7 +286,8 @@ static void winpr_openssl_cleanup(void)
 	winpr_CleanupSSL(WINPR_SSL_INIT_DEFAULT);
 }
 
-static BOOL CALLBACK winpr_openssl_initialize(PINIT_ONCE once, PVOID param, PVOID* context)
+static BOOL CALLBACK winpr_openssl_initialize(WINPR_ATTR_UNUSED PINIT_ONCE once, PVOID param,
+                                              WINPR_ATTR_UNUSED PVOID* context)
 {
 	DWORD flags = param ? *(PDWORD)param : WINPR_SSL_INIT_DEFAULT;
 
@@ -355,7 +356,7 @@ BOOL winpr_InitializeSSL(DWORD flags)
 }
 
 #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
-static int unload(OSSL_PROVIDER* provider, void* data)
+static int unload(OSSL_PROVIDER* provider, WINPR_ATTR_UNUSED void* data)
 {
 	if (!provider)
 		return 1;

--- a/winpr/libwinpr/utils/wlog/BinaryAppender.c
+++ b/winpr/libwinpr/utils/wlog/BinaryAppender.c
@@ -84,7 +84,7 @@ static BOOL WLog_BinaryAppender_Open(wLog* log, wLogAppender* appender)
 	return TRUE;
 }
 
-static BOOL WLog_BinaryAppender_Close(wLog* log, wLogAppender* appender)
+static BOOL WLog_BinaryAppender_Close(WINPR_ATTR_UNUSED wLog* log, wLogAppender* appender)
 {
 	wLogBinaryAppender* binaryAppender = NULL;
 
@@ -167,14 +167,16 @@ static BOOL WLog_BinaryAppender_WriteMessage(wLog* log, wLogAppender* appender,
 	return ret;
 }
 
-static BOOL WLog_BinaryAppender_WriteDataMessage(wLog* log, wLogAppender* appender,
-                                                 wLogMessage* message)
+static BOOL WLog_BinaryAppender_WriteDataMessage(WINPR_ATTR_UNUSED wLog* log,
+                                                 WINPR_ATTR_UNUSED wLogAppender* appender,
+                                                 WINPR_ATTR_UNUSED wLogMessage* message)
 {
 	return TRUE;
 }
 
-static BOOL WLog_BinaryAppender_WriteImageMessage(wLog* log, wLogAppender* appender,
-                                                  wLogMessage* message)
+static BOOL WLog_BinaryAppender_WriteImageMessage(WINPR_ATTR_UNUSED wLog* log,
+                                                  WINPR_ATTR_UNUSED wLogAppender* appender,
+                                                  WINPR_ATTR_UNUSED wLogMessage* message)
 {
 	return TRUE;
 }
@@ -218,7 +220,7 @@ static void WLog_BinaryAppender_Free(wLogAppender* appender)
 	}
 }
 
-wLogAppender* WLog_BinaryAppender_New(wLog* log)
+wLogAppender* WLog_BinaryAppender_New(WINPR_ATTR_UNUSED wLog* log)
 {
 	wLogBinaryAppender* BinaryAppender = NULL;
 

--- a/winpr/libwinpr/utils/wlog/CallbackAppender.c
+++ b/winpr/libwinpr/utils/wlog/CallbackAppender.c
@@ -28,12 +28,14 @@ typedef struct
 	wLogCallbacks* callbacks;
 } wLogCallbackAppender;
 
-static BOOL WLog_CallbackAppender_Open(wLog* log, wLogAppender* appender)
+static BOOL WLog_CallbackAppender_Open(WINPR_ATTR_UNUSED wLog* log,
+                                       WINPR_ATTR_UNUSED wLogAppender* appender)
 {
 	return TRUE;
 }
 
-static BOOL WLog_CallbackAppender_Close(wLog* log, wLogAppender* appender)
+static BOOL WLog_CallbackAppender_Close(WINPR_ATTR_UNUSED wLog* log,
+                                        WINPR_ATTR_UNUSED wLogAppender* appender)
 {
 	return TRUE;
 }
@@ -145,7 +147,7 @@ static void WLog_CallbackAppender_Free(wLogAppender* appender)
 	free(appender);
 }
 
-wLogAppender* WLog_CallbackAppender_New(wLog* log)
+wLogAppender* WLog_CallbackAppender_New(WINPR_ATTR_UNUSED wLog* log)
 {
 	wLogCallbackAppender* CallbackAppender = NULL;
 

--- a/winpr/libwinpr/utils/wlog/ConsoleAppender.c
+++ b/winpr/libwinpr/utils/wlog/ConsoleAppender.c
@@ -38,12 +38,14 @@ typedef struct
 	int outputStream;
 } wLogConsoleAppender;
 
-static BOOL WLog_ConsoleAppender_Open(wLog* log, wLogAppender* appender)
+static BOOL WLog_ConsoleAppender_Open(WINPR_ATTR_UNUSED wLog* log,
+                                      WINPR_ATTR_UNUSED wLogAppender* appender)
 {
 	return TRUE;
 }
 
-static BOOL WLog_ConsoleAppender_Close(wLog* log, wLogAppender* appender)
+static BOOL WLog_ConsoleAppender_Close(WINPR_ATTR_UNUSED wLog* log,
+                                       WINPR_ATTR_UNUSED wLogAppender* appender)
 {
 	return TRUE;
 }
@@ -138,7 +140,8 @@ static BOOL WLog_ConsoleAppender_WriteMessage(wLog* log, wLogAppender* appender,
 
 static int g_DataId = 0;
 
-static BOOL WLog_ConsoleAppender_WriteDataMessage(wLog* log, wLogAppender* appender,
+static BOOL WLog_ConsoleAppender_WriteDataMessage(WINPR_ATTR_UNUSED wLog* log,
+                                                  WINPR_ATTR_UNUSED wLogAppender* appender,
                                                   wLogMessage* message)
 {
 #if defined(ANDROID)
@@ -160,7 +163,8 @@ static BOOL WLog_ConsoleAppender_WriteDataMessage(wLog* log, wLogAppender* appen
 
 static int g_ImageId = 0;
 
-static BOOL WLog_ConsoleAppender_WriteImageMessage(wLog* log, wLogAppender* appender,
+static BOOL WLog_ConsoleAppender_WriteImageMessage(WINPR_ATTR_UNUSED wLog* log,
+                                                   WINPR_ATTR_UNUSED wLogAppender* appender,
                                                    wLogMessage* message)
 {
 #if defined(ANDROID)
@@ -183,8 +187,8 @@ static BOOL WLog_ConsoleAppender_WriteImageMessage(wLog* log, wLogAppender* appe
 
 static int g_PacketId = 0;
 
-static BOOL WLog_ConsoleAppender_WritePacketMessage(wLog* log, wLogAppender* appender,
-                                                    wLogMessage* message)
+static BOOL WLog_ConsoleAppender_WritePacketMessage(WINPR_ATTR_UNUSED wLog* log,
+                                                    wLogAppender* appender, wLogMessage* message)
 {
 #if defined(ANDROID)
 	return FALSE;
@@ -245,7 +249,7 @@ static void WLog_ConsoleAppender_Free(wLogAppender* appender)
 	}
 }
 
-wLogAppender* WLog_ConsoleAppender_New(wLog* log)
+wLogAppender* WLog_ConsoleAppender_New(WINPR_ATTR_UNUSED wLog* log)
 {
 	wLogConsoleAppender* ConsoleAppender = NULL;
 

--- a/winpr/libwinpr/utils/wlog/FileAppender.c
+++ b/winpr/libwinpr/utils/wlog/FileAppender.c
@@ -216,7 +216,7 @@ static void WLog_FileAppender_Free(wLogAppender* appender)
 	}
 }
 
-wLogAppender* WLog_FileAppender_New(wLog* log)
+wLogAppender* WLog_FileAppender_New(WINPR_ATTR_UNUSED wLog* log)
 {
 	LPSTR env = NULL;
 	LPCSTR name = NULL;

--- a/winpr/libwinpr/utils/wlog/Layout.c
+++ b/winpr/libwinpr/utils/wlog/Layout.c
@@ -76,7 +76,7 @@ struct format_option_recurse
  * Log Layout
  */
 WINPR_ATTR_FORMAT_ARG(3, 0)
-static void WLog_PrintMessagePrefixVA(wLog* log, wLogMessage* message,
+static void WLog_PrintMessagePrefixVA(WINPR_ATTR_UNUSED wLog* log, wLogMessage* message,
                                       WINPR_FORMAT_ARG const char* format, va_list args)
 {
 	WINPR_ASSERT(message);
@@ -306,7 +306,8 @@ wLogLayout* WLog_GetLogLayout(wLog* log)
 	return appender->Layout;
 }
 
-BOOL WLog_Layout_SetPrefixFormat(wLog* log, wLogLayout* layout, const char* format)
+BOOL WLog_Layout_SetPrefixFormat(WINPR_ATTR_UNUSED wLog* log, wLogLayout* layout,
+                                 const char* format)
 {
 	free(layout->FormatString);
 	layout->FormatString = NULL;
@@ -322,7 +323,7 @@ BOOL WLog_Layout_SetPrefixFormat(wLog* log, wLogLayout* layout, const char* form
 	return TRUE;
 }
 
-wLogLayout* WLog_Layout_New(wLog* log)
+wLogLayout* WLog_Layout_New(WINPR_ATTR_UNUSED wLog* log)
 {
 	LPCSTR prefix = "WLOG_PREFIX";
 	DWORD nSize = 0;
@@ -374,7 +375,7 @@ wLogLayout* WLog_Layout_New(wLog* log)
 	return layout;
 }
 
-void WLog_Layout_Free(wLog* log, wLogLayout* layout)
+void WLog_Layout_Free(WINPR_ATTR_UNUSED wLog* log, wLogLayout* layout)
 {
 	if (layout)
 	{

--- a/winpr/libwinpr/utils/wlog/SyslogAppender.c
+++ b/winpr/libwinpr/utils/wlog/SyslogAppender.c
@@ -116,7 +116,7 @@ static void WLog_SyslogAppender_Free(wLogAppender* appender)
 	free(appender);
 }
 
-wLogAppender* WLog_SyslogAppender_New(wLog* log)
+wLogAppender* WLog_SyslogAppender_New(WINPR_ATTR_UNUSED wLog* log)
 {
 	wLogSyslogAppender* appender = NULL;
 

--- a/winpr/libwinpr/utils/wlog/UdpAppender.c
+++ b/winpr/libwinpr/utils/wlog/UdpAppender.c
@@ -35,7 +35,7 @@ typedef struct
 	SOCKET sock;
 } wLogUdpAppender;
 
-static BOOL WLog_UdpAppender_Open(wLog* log, wLogAppender* appender)
+static BOOL WLog_UdpAppender_Open(WINPR_ATTR_UNUSED wLog* log, wLogAppender* appender)
 {
 	wLogUdpAppender* udpAppender = NULL;
 	char addressString[256] = { 0 };

--- a/winpr/libwinpr/winsock/winsock.c
+++ b/winpr/libwinpr/winsock/winsock.c
@@ -730,7 +730,7 @@ BOOL WSASetEvent(HANDLE hEvent)
 	return SetEvent(hEvent);
 }
 
-BOOL WSAResetEvent(HANDLE hEvent)
+BOOL WSAResetEvent(WINPR_ATTR_UNUSED HANDLE hEvent)
 {
 	/* POSIX systems auto reset the socket,
 	 * if no more data is available. */
@@ -776,8 +776,9 @@ DWORD WSAWaitForMultipleEvents(DWORD cEvents, const HANDLE* lphEvents, BOOL fWai
 	return WaitForMultipleObjectsEx(cEvents, lphEvents, fWaitAll, dwTimeout, fAlertable);
 }
 
-SOCKET WSASocketA(int af, int type, int protocol, LPWSAPROTOCOL_INFOA lpProtocolInfo, GROUP g,
-                  DWORD dwFlags)
+SOCKET WSASocketA(int af, int type, int protocol,
+                  WINPR_ATTR_UNUSED LPWSAPROTOCOL_INFOA lpProtocolInfo, WINPR_ATTR_UNUSED GROUP g,
+                  WINPR_ATTR_UNUSED DWORD dwFlags)
 {
 	SOCKET s = 0;
 	s = _socket(af, type, protocol);
@@ -790,9 +791,10 @@ SOCKET WSASocketW(int af, int type, int protocol, LPWSAPROTOCOL_INFOW lpProtocol
 	return WSASocketA(af, type, protocol, (LPWSAPROTOCOL_INFOA)lpProtocolInfo, g, dwFlags);
 }
 
-int WSAIoctl(SOCKET s, DWORD dwIoControlCode, LPVOID lpvInBuffer, DWORD cbInBuffer,
-             LPVOID lpvOutBuffer, DWORD cbOutBuffer, LPDWORD lpcbBytesReturned,
-             LPWSAOVERLAPPED lpOverlapped, LPWSAOVERLAPPED_COMPLETION_ROUTINE lpCompletionRoutine)
+int WSAIoctl(SOCKET s, DWORD dwIoControlCode, WINPR_ATTR_UNUSED LPVOID lpvInBuffer,
+             WINPR_ATTR_UNUSED DWORD cbInBuffer, LPVOID lpvOutBuffer, DWORD cbOutBuffer,
+             LPDWORD lpcbBytesReturned, WINPR_ATTR_UNUSED LPWSAOVERLAPPED lpOverlapped,
+             WINPR_ATTR_UNUSED LPWSAOVERLAPPED_COMPLETION_ROUTINE lpCompletionRoutine)
 {
 	int fd = 0;
 	int index = 0;


### PR DESCRIPTION
* should only contain `WINPR_ATTR_UNUSED` additions and some `WLog_ERR("TODO", "TODO: implement");` log messages
* Rationale for silencing these is that the `API` requires these parameters set but we currently do not use them. Do not emit warnings during compile for these, but log something instead so that in case of use the user is warned.
* check https://ci.freerdp.com/job/code-quality-checker/9845/ we´re down to nearly nothing with regards to compiler warnings (most of the remaining being backward compatibility warnings for `C99` and such)