### PR TITLE
[client,sdl] Fix keyboard grab toggle logic

### DIFF
--- a/client/SDL/SDL3/sdl_kbd.cpp
+++ b/client/SDL/SDL3/sdl_kbd.cpp
@@ -476,7 +476,7 @@ BOOL sdlInput::keyboard_handle_event(const SDL_KeyboardEvent* ev)
 			if (ev->scancode == _hotkeyGrab)
 			{
 				_sdl->grab_kbd_enabled = !_sdl->grab_kbd_enabled;
-				keyboard_grab(ev->windowID, _sdl->grab_kbd);
+				keyboard_grab(ev->windowID, _sdl->grab_kbd_enabled);
 				return TRUE;
 			}
 			if (ev->scancode == _hotkeyDisconnect)


### PR DESCRIPTION
This PR fixes an issue with the logic for toggling the keyboard grab state in the SDL 3 client. Previously the `grab_kbd` field was being passed as a parameter to `keyboard_grab`, which doesn't make sense because this flag is only ever mutated in that same function using the same parameter. This makes it impossible for the field to ever be set as `true`. The `grab_kbd_enabled` field seems to be the correct input parameter, given that it is toggled immediately before the call to `keyboard_grab`.