### PR TITLE
[channel,rdpecam] Optional format passthrough (no H264 encoding)

### DIFF
--- a/channels/rdpecam/client/CMakeLists.txt
+++ b/channels/rdpecam/client/CMakeLists.txt
@@ -41,6 +41,12 @@ if(RDPECAM_INPUT_FORMAT_MJPG)
   add_compile_definitions("WITH_INPUT_FORMAT_MJPG")
 endif()
 
+# enable for VM environments where network bandwidth is not an issue
+option(RDPECAM_FORMAT_PASSTHROUGH "[MS-RDPECAM] Enable any format passthrough (no H264 encoding)" OFF)
+if(RDPECAM_FORMAT_PASSTHROUGH)
+  add_compile_definitions("WITH_FORMAT_PASSTHROUGH")
+endif()
+
 include_directories(SYSTEM ${SWSCALE_INCLUDE_DIRS})
 
 set(${MODULE_PREFIX}_SRCS camera_device_enum_main.c camera_device_main.c encoding.c)

--- a/channels/rdpecam/client/camera.h
+++ b/channels/rdpecam/client/camera.h
@@ -89,15 +89,8 @@ typedef struct
 
 typedef struct
 {
-	CAM_MEDIA_FORMAT inputFormat;  /* camera side */
-	CAM_MEDIA_FORMAT outputFormat; /* network side */
-
-} CAM_MEDIA_FORMAT_INFO;
-
-typedef struct
-{
 	BOOL streaming;
-	CAM_MEDIA_FORMAT_INFO formats;
+	CAM_MEDIA_FORMAT inputFormat; /* camera side */
 	CAM_MEDIA_TYPE_DESCRIPTION currMediaType;
 
 	GENERIC_CHANNEL_CALLBACK* hSampleReqChannel;
@@ -124,11 +117,16 @@ typedef struct
 
 static INLINE CAM_MEDIA_FORMAT streamInputFormat(CameraDeviceStream* stream)
 {
-	return stream->formats.inputFormat;
+	return stream->inputFormat;
 }
 static INLINE CAM_MEDIA_FORMAT streamOutputFormat(CameraDeviceStream* stream)
 {
-	return stream->formats.outputFormat;
+#if !defined(WITH_FORMAT_PASSTHROUGH)
+	return CAM_MEDIA_FORMAT_H264;
+#else
+	return (stream->inputFormat == CAM_MEDIA_FORMAT_MJPG_H264) ? CAM_MEDIA_FORMAT_H264
+	                                                           : stream->inputFormat;
+#endif
 }
 
 typedef struct
@@ -159,9 +157,8 @@ struct s_ICamHal
 	(ICamHal* ihal, ICamHalEnumCallback callback, CameraPlugin* ecam,
 	 GENERIC_CHANNEL_CALLBACK* hchannel);
 	INT16(*GetMediaTypeDescriptions)
-	(ICamHal* ihal, const char* deviceId, int streamIndex,
-	 const CAM_MEDIA_FORMAT_INFO* supportedFormats, size_t nSupportedFormats,
-	 CAM_MEDIA_TYPE_DESCRIPTION* mediaTypes, size_t* nMediaTypes);
+	(ICamHal* ihal, const char* deviceId, int streamIndex, const CAM_MEDIA_FORMAT* supportedFormats,
+	 size_t nSupportedFormats, CAM_MEDIA_TYPE_DESCRIPTION* mediaTypes, size_t* nMediaTypes);
 	UINT(*StartStream)
 	(ICamHal* ihal, CameraDevice* dev, int streamIndex, const CAM_MEDIA_TYPE_DESCRIPTION* mediaType,
 	 ICamHalSampleCapturedCallback callback);

--- a/channels/rdpecam/client/camera_device_main.c
+++ b/channels/rdpecam/client/camera_device_main.c
@@ -24,23 +24,19 @@
 
 #define TAG CHANNELS_TAG("rdpecam-device.client")
 
-/* supported formats in preference order:
+/* supported camera input formats in preference order:
  * H264, MJPG, I420 (used as input for H264 encoder), other YUV based, RGB based
  */
-static const CAM_MEDIA_FORMAT_INFO supportedFormats[] = {
-/* inputFormat, outputFormat */
+static const CAM_MEDIA_FORMAT supportedFormats[] = {
 #if defined(WITH_INPUT_FORMAT_H264)
-	{ CAM_MEDIA_FORMAT_H264, CAM_MEDIA_FORMAT_H264 }, /* passthrough */
-	{ CAM_MEDIA_FORMAT_MJPG_H264, CAM_MEDIA_FORMAT_H264 },
+	CAM_MEDIA_FORMAT_H264, /* passthrough */
+	CAM_MEDIA_FORMAT_MJPG_H264,
 #endif
 #if defined(WITH_INPUT_FORMAT_MJPG)
-	{ CAM_MEDIA_FORMAT_MJPG, CAM_MEDIA_FORMAT_H264 },
+	CAM_MEDIA_FORMAT_MJPG,
 #endif
-	{ CAM_MEDIA_FORMAT_I420, CAM_MEDIA_FORMAT_H264 },
-	{ CAM_MEDIA_FORMAT_YUY2, CAM_MEDIA_FORMAT_H264 },
-	{ CAM_MEDIA_FORMAT_NV12, CAM_MEDIA_FORMAT_H264 },
-	{ CAM_MEDIA_FORMAT_RGB24, CAM_MEDIA_FORMAT_H264 },
-	{ CAM_MEDIA_FORMAT_RGB32, CAM_MEDIA_FORMAT_H264 },
+	CAM_MEDIA_FORMAT_I420,      CAM_MEDIA_FORMAT_YUY2,  CAM_MEDIA_FORMAT_NV12,
+	CAM_MEDIA_FORMAT_RGB24,     CAM_MEDIA_FORMAT_RGB32,
 };
 static const size_t nSupportedFormats = ARRAYSIZE(supportedFormats);
 
@@ -480,7 +476,7 @@ static UINT ecam_dev_process_media_type_list_request(CameraDevice* dev,
 		goto error;
 	}
 
-	stream->formats = supportedFormats[formatIndex];
+	stream->inputFormat = supportedFormats[formatIndex];
 
 	/* replacing inputFormat with outputFormat in mediaTypes before sending response */
 	for (size_t i = 0; i < nMediaTypes; i++)

--- a/channels/rdpecam/client/v4l/camera_v4l.c
+++ b/channels/rdpecam/client/v4l/camera_v4l.c
@@ -160,12 +160,9 @@ static int cam_v4l_open_device(const char* deviceId, int flags)
  * @return -1 if error, otherwise index of supportedFormats array and mediaTypes/nMediaTypes filled
  * in
  */
-static INT16 cam_v4l_get_media_type_descriptions(ICamHal* ihal, const char* deviceId,
-                                                 int streamIndex,
-                                                 const CAM_MEDIA_FORMAT_INFO* supportedFormats,
-                                                 size_t nSupportedFormats,
-                                                 CAM_MEDIA_TYPE_DESCRIPTION* mediaTypes,
-                                                 size_t* nMediaTypes)
+static INT16 cam_v4l_get_media_type_descriptions(
+    ICamHal* ihal, const char* deviceId, int streamIndex, const CAM_MEDIA_FORMAT* supportedFormats,
+    size_t nSupportedFormats, CAM_MEDIA_TYPE_DESCRIPTION* mediaTypes, size_t* nMediaTypes)
 {
 	CamV4lHal* hal = (CamV4lHal*)ihal;
 	size_t maxMediaTypes = *nMediaTypes;
@@ -198,7 +195,7 @@ static INT16 cam_v4l_get_media_type_descriptions(ICamHal* ihal, const char* devi
 	for (; formatIndex < nSupportedFormats; formatIndex++)
 	{
 		UINT32 pixelFormat = 0;
-		if (supportedFormats[formatIndex].inputFormat == CAM_MEDIA_FORMAT_MJPG_H264)
+		if (supportedFormats[formatIndex] == CAM_MEDIA_FORMAT_MJPG_H264)
 		{
 			if (stream->h264UnitId > 0)
 				pixelFormat = V4L2_PIX_FMT_MJPEG;
@@ -207,7 +204,7 @@ static INT16 cam_v4l_get_media_type_descriptions(ICamHal* ihal, const char* devi
 		}
 		else
 		{
-			pixelFormat = ecamToV4L2PixFormat(supportedFormats[formatIndex].inputFormat);
+			pixelFormat = ecamToV4L2PixFormat(supportedFormats[formatIndex]);
 		}
 
 		WINPR_ASSERT(pixelFormat != 0);
@@ -227,7 +224,7 @@ static INT16 cam_v4l_get_media_type_descriptions(ICamHal* ihal, const char* devi
 			formatFound = TRUE;
 			mediaTypes->Width = frmsize.discrete.width;
 			mediaTypes->Height = frmsize.discrete.height;
-			mediaTypes->Format = supportedFormats[formatIndex].inputFormat;
+			mediaTypes->Format = supportedFormats[formatIndex];
 
 			/* query frame rate (1st is highest fps supported) */
 			frmival.index = 0;


### PR DESCRIPTION
Adding new cmake option:
```
 -DRDPECAM_FORMAT_PASSTHROUGH=ON
 ```
to allow any camera format passthrough without encoding to H264. Useful for virtual machine environments where network bandwidth is not an issue. Helps to close https://github.com/FreeRDP/FreeRDP/issues/10935