### PR TITLE
[channel,rdpecam] UVC H.264 fix for c922 camera

### DIFF
--- a/channels/rdpecam/client/v4l/uvc_h264.c
+++ b/channels/rdpecam/client/v4l/uvc_h264.c
@@ -35,7 +35,7 @@
 static uint8_t GUID_UVCX_H264_XU[16] = { 0x41, 0x76, 0x9E, 0xA2, 0x04, 0xDE, 0xE3, 0x47,
 	                                     0x8B, 0x2B, 0xF4, 0x34, 0x1A, 0xFF, 0x00, 0x3B };
 
-#define TAG CHANNELS_TAG("uvc_h264.client")
+#define TAG CHANNELS_TAG("rdpecam-uvch264.client")
 
 /*
  * get length of xu control defined by unit id and selector


### PR DESCRIPTION
To fix https://github.com/FreeRDP/FreeRDP/issues/11198
There are 2 things required:
- change initialization order, so `set_h264_muxed_format` is called before `ioctl VIDIOC_S_FMT`;
- limit container stream resolution to fixed 640x480.

I don't have C922 camera, but I tested it on C930e and older C920 in muxed H264 mode. There's a good chance it fixes original issue.

@shmerl: please help to test with C922 and capture the trace, if still doesn't work.