### PR TITLE
[client,sdl] mark SDL2 as deprecated.

### DIFF
--- a/client/SDL/CMakeLists.txt
+++ b/client/SDL/CMakeLists.txt
@@ -64,7 +64,8 @@ find_package(SDL3)
 
 cmake_dependent_option(WITH_CLIENT_SDL_VERSIONED "append sdl version to client binaries" OFF WITH_CLIENT_SDL OFF)
 cmake_dependent_option(
-  WITH_CLIENT_SDL2 "[experimental] build experimental SDL2 client" ${SDL2_FOUND} WITH_CLIENT_SDL OFF
+  WITH_CLIENT_SDL2 "[deprecated,experimental] build deprecated,experimental SDL2 client" ${SDL2_FOUND} WITH_CLIENT_SDL
+  OFF
 )
 cmake_dependent_option(
   WITH_CLIENT_SDL3 "[experimental] build experimental SDL3 client" ${SDL3_FOUND} WITH_CLIENT_SDL OFF

--- a/client/SDL/SDL2/sdl_freerdp.cpp
+++ b/client/SDL/SDL2/sdl_freerdp.cpp
@@ -1644,6 +1644,7 @@ int main(int argc, char* argv[])
 	RDP_CLIENT_ENTRY_POINTS clientEntryPoints = {};
 
 	freerdp_client_warn_experimental(argc, argv);
+	freerdp_client_warn_deprecated(argc, argv);
 	WLog_WARN(SDL_TAG,
 	          "SDL2 client does not support clipboard! Only SDL3 client has (partial) support");
 

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -6220,7 +6220,7 @@ void freerdp_client_warn_deprecated(int argc, char* argv[])
 		return;
 
 	WLog_Print_unchecked(log, log_level, "[deprecated] %s client has been deprecated", app);
-	WLog_Print_unchecked(log, log_level, "As replacement there is a SDL based client available.");
+	WLog_Print_unchecked(log, log_level, "As replacement there is a SDL3 based client available.");
 	WLog_Print_unchecked(
 	    log, log_level,
 	    "If you are interested in keeping %s alive get in touch with the developers", app);

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -267,6 +267,9 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  " * layout: set the keybouard layout announced to the server\n"
 	  " * lang: set the keyboard language identifier sent to the server\n"
 	  " * fn-key: Function key value\n"
+	  " * remap: RDP scancode to another one. Use /list:kbd-scancode to get the mapping. Example: "
+	  "To switch "
+	  "'a' and 's' on a US keyboard: /kbd:remap:0x1e=0x1f,remap:0x1f=0x1e\n"
 	  " * pipe: Name of a named pipe that can be used to type text into the RDP session\n" },
 #if defined(WITH_FREERDP_DEPRECATED_COMMANDLINE)
 	{ "kbd-lang", COMMAND_LINE_VALUE_REQUIRED, "0x<id>", NULL, NULL, -1, NULL,

--- a/winpr/libwinpr/sysinfo/sysinfo.c
+++ b/winpr/libwinpr/sysinfo/sysinfo.c
@@ -790,17 +790,53 @@ BOOL IsProcessorFeaturePresent(DWORD ProcessorFeature)
 	BOOL ret = FALSE;
 #if defined(ANDROID)
 	const uint64_t features = android_getCpuFeatures();
+	const AndroidCpuFamily family = android_getCpuFamily();
+	const BOOL isArm = (family == ANDROID_CPU_FAMILY_ARM) || (family == ANDROID_CPU_FAMILY_ARM64);
+	const BOOL isX86 = (family == ANDROID_CPU_FAMILY_X86) || (family == ANDROID_CPU_FAMILY_X86_64);
 
-	switch (ProcessorFeature)
+	if (isX86)
 	{
-		case PF_ARM_NEON_INSTRUCTIONS_AVAILABLE:
-		case PF_ARM_NEON:
-			return features & ANDROID_CPU_ARM_FEATURE_NEON;
-
-		default:
-			WLog_WARN(TAG, "feature 0x%08" PRIx32 " check not implemented", ProcessorFeature);
-			return FALSE;
+		switch (ProcessorFeature)
+		{
+			case PF_MMX_INSTRUCTIONS_AVAILABLE:
+			case PF_XMMI_INSTRUCTIONS_AVAILABLE:
+			case PF_XMMI64_INSTRUCTIONS_AVAILABLE:
+			case PF_3DNOW_INSTRUCTIONS_AVAILABLE:
+			case PF_SSE3_INSTRUCTIONS_AVAILABLE:
+				return TRUE;
+			case PF_SSSE3_INSTRUCTIONS_AVAILABLE:
+				return features & ANDROID_CPU_X86_FEATURE_SSSE3;
+			case PF_SSE4_1_INSTRUCTIONS_AVAILABLE:
+				return features & ANDROID_CPU_X86_FEATURE_SSE4_1;
+			case PF_SSE4_2_INSTRUCTIONS_AVAILABLE:
+				return features & ANDROID_CPU_X86_FEATURE_SSE4_2;
+			case PF_AVX_INSTRUCTIONS_AVAILABLE:
+				return features & ANDROID_CPU_X86_FEATURE_AVX;
+			case PF_AVX2_INSTRUCTIONS_AVAILABLE:
+				return features & ANDROID_CPU_X86_FEATURE_AVX2;
+			case PF_AVX512F_INSTRUCTIONS_AVAILABLE:
+			default:
+				WLog_WARN(TAG, "feature 0x%08" PRIx32 " check not implemented", ProcessorFeature);
+				return FALSE;
+		}
 	}
+
+	if (isArm)
+	{
+		switch (ProcessorFeature)
+		{
+			case PF_ARM_NEON_INSTRUCTIONS_AVAILABLE:
+			case PF_ARM_NEON:
+				return features & ANDROID_CPU_ARM_FEATURE_NEON;
+
+			default:
+				WLog_WARN(TAG, "feature 0x%08" PRIx32 " check not implemented", ProcessorFeature);
+				return FALSE;
+		}
+	}
+
+	WLog_WARN(TAG, "Unsupported Android CPU family 0x%08" PRIx32, family);
+	return FALSE;
 
 #elif defined(_M_ARM) || defined(_M_ARM64)
 #ifdef __linux__
@@ -869,6 +905,19 @@ BOOL IsProcessorFeaturePresent(DWORD ProcessorFeature)
 				ret = TRUE;
 
 			break;
+		case PF_MMX_INSTRUCTIONS_AVAILABLE:
+		case PF_XMMI_INSTRUCTIONS_AVAILABLE:
+		case PF_XMMI64_INSTRUCTIONS_AVAILABLE:
+		case PF_3DNOW_INSTRUCTIONS_AVAILABLE:
+		case PF_SSE3_INSTRUCTIONS_AVAILABLE:
+		case PF_SSSE3_INSTRUCTIONS_AVAILABLE:
+		case PF_SSE4_1_INSTRUCTIONS_AVAILABLE:
+		case PF_SSE4_2_INSTRUCTIONS_AVAILABLE:
+		case PF_AVX_INSTRUCTIONS_AVAILABLE:
+		case PF_AVX2_INSTRUCTIONS_AVAILABLE:
+		case PF_AVX512F_INSTRUCTIONS_AVAILABLE:
+			ret = FALSE;
+			break;
 		case PF_ARM_V8_INSTRUCTIONS_AVAILABLE:
 		case PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE:
 		case PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE:
@@ -885,6 +934,19 @@ BOOL IsProcessorFeaturePresent(DWORD ProcessorFeature)
 
 	switch (ProcessorFeature)
 	{
+		case PF_MMX_INSTRUCTIONS_AVAILABLE:
+		case PF_XMMI_INSTRUCTIONS_AVAILABLE:
+		case PF_XMMI64_INSTRUCTIONS_AVAILABLE:
+		case PF_3DNOW_INSTRUCTIONS_AVAILABLE:
+		case PF_SSE3_INSTRUCTIONS_AVAILABLE:
+		case PF_SSSE3_INSTRUCTIONS_AVAILABLE:
+		case PF_SSE4_1_INSTRUCTIONS_AVAILABLE:
+		case PF_SSE4_2_INSTRUCTIONS_AVAILABLE:
+		case PF_AVX_INSTRUCTIONS_AVAILABLE:
+		case PF_AVX2_INSTRUCTIONS_AVAILABLE:
+		case PF_AVX512F_INSTRUCTIONS_AVAILABLE:
+			ret = FALSE;
+			break;
 		case PF_ARM_NEON_INSTRUCTIONS_AVAILABLE:
 		case PF_ARM_NEON:
 #ifdef __ARM_NEON


### PR DESCRIPTION
SDL2 client is a dead end due to lacking API (clipboard support, ...) so mark the SDL2 client deprecated and point out there is a SDL3 version available