### PR TITLE
[core,credssp_auth] Fix faulty string length check in `credssp_auth_client_init_cred_attributes`

### DIFF
--- a/libfreerdp/core/credssp_auth.c
+++ b/libfreerdp/core/credssp_auth.c
@@ -207,7 +207,7 @@ static BOOL credssp_auth_client_init_cred_attributes(rdpCredsspAuth* auth)
 		SSIZE_T str_size = 0;
 
 		str_size = ConvertUtf8ToWChar(auth->kerberosSettings.kdcUrl, NULL, 0);
-		if ((str_size <= 0) || (str_size <= UINT16_MAX / 2))
+		if ((str_size <= 0) || (str_size >= UINT16_MAX / 2))
 			return FALSE;
 		str_size++;
 


### PR DESCRIPTION
[78acedb40ee275b6aadcb6a5fbfc8922ea30835a](https://github.com/FreeRDP/FreeRDP/commit/78acedb40ee275b6aadcb6a5fbfc8922ea30835a) introduced a faulty string length check which prevents using an explicit KDC URL.

The bounds check uses the `<=` operator instead of `>=`, allowing only strings _longer_ than `UINT16_MAX / 2`.