### PR TITLE
[client] Fix missing symbols when linking

### DIFF
--- a/channels/remdesk/client/CMakeLists.txt
+++ b/channels/remdesk/client/CMakeLists.txt
@@ -19,6 +19,6 @@ define_channel_client("remdesk")
 
 set(${MODULE_PREFIX}_SRCS remdesk_main.c remdesk_main.h)
 
-set(${MODULE_PREFIX}_LIBS winpr freerdp remdesk-common)
+set(${MODULE_PREFIX}_LIBS winpr winpr-tools freerdp remdesk-common)
 
 add_channel_client_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} FALSE "VirtualChannelEntryEx")

--- a/channels/remdesk/server/CMakeLists.txt
+++ b/channels/remdesk/server/CMakeLists.txt
@@ -19,6 +19,6 @@ define_channel_server("remdesk")
 
 set(${MODULE_PREFIX}_SRCS remdesk_main.c remdesk_main.h)
 
-set(${MODULE_PREFIX}_LIBS winpr remdesk-common)
+set(${MODULE_PREFIX}_LIBS winpr winpr-tools remdesk-common)
 
 add_channel_server_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} FALSE "VirtualChannelEntry")


### PR DESCRIPTION
Currently, the remdesk/client library is using a method in `remdesk-common` that is not found when linking the client

This call https://github.com/FreeRDP/FreeRDP/blob/8602a0cd349623d340a9f57e860d1b98f19c5124/channels/remdesk/common/remdesk_common.c#L85 does not get resolved at linking time, see below:
```
[519/531] Linking C shared library client\common\libfreerdp-client3.dll
FAILED: client/common/libfreerdp-client3.dll client/common/libfreerdp-client3.dll.a
C:\WINDOWS\system32\cmd.exe /C "cd . && C:\msys64\ucrt64\bin\gcc.exe -march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1 -Wno-incompatible-pointer-types -fno-omit-frame-pointer -Wredundant-decls -Wimplicit-function-declaration -O3 -DNDEBUG   -shared -o client\common\libfreerdp-client3.dll -Wl,--out-implib,client\common\libfreerdp-client3.dll.a -Wl,--major-image-version,3,--minor-image-version,12 channels/drdynvc/client/CMakeFiles/drdynvc-client.dir/drdynvc_main.c.obj channels/remdesk/client/CMakeFiles/remdesk-client.dir/remdesk_main.c.obj channels/rdpsnd/client/CMakeFiles/rdpsnd-client.dir/rdpsnd_main.c.obj channels/rdpdr/client/CMakeFiles/rdpdr-client.dir/irp.c.obj channels/rdpdr/client/CMakeFiles/rdpdr-client.dir/devman.c.obj channels/rdpdr/client/CMakeFiles/rdpdr-client.dir/rdpdr_main.c.obj channels/rdpdr/client/CMakeFiles/rdpdr-client.dir/rdpdr_capabilities.c.obj channels/rail/client/CMakeFiles/rail-client.dir/__/rail_common.c.obj channels/rail/client/CMakeFiles/rail-client.dir/client_rails.c.obj channels/rail/client/CMakeFiles/rail-client.dir/rail_main.c.obj channels/rail/client/CMakeFiles/rail-client.dir/rail_orders.c.obj channels/encomsp/client/CMakeFiles/encomsp-client.dir/encomsp_main.c.obj channels/cliprdr/client/CMakeFiles/cliprdr-client.dir/cliprdr_format.c.obj channels/cliprdr/client/CMakeFiles/cliprdr-client.dir/cliprdr_main.c.obj channels/cliprdr/client/CMakeFiles/cliprdr-client.dir/__/cliprdr_common.c.obj channels/video/client/CMakeFiles/video-client.dir/video_main.c.obj channels/urbdrc/client/CMakeFiles/urbdrc-client.dir/data_transfer.c.obj channels/urbdrc/client/CMakeFiles/urbdrc-client.dir/urbdrc_main.c.obj channels/rdpgfx/client/CMakeFiles/rdpgfx-client.dir/rdpgfx_main.c.obj channels/rdpgfx/client/CMakeFiles/rdpgfx-client.dir/rdpgfx_codec.c.obj channels/rdpgfx/client/CMakeFiles/rdpgfx-client.dir/__/rdpgfx_common.c.obj channels/rdpei/client/CMakeFiles/rdpei-client.dir/rdpei_main.c.obj channels/rdpei/client/CMakeFiles/rdpei-client.dir/__/rdpei_common.c.obj channels/location/client/CMakeFiles/location-client.dir/location_main.c.obj channels/geometry/client/CMakeFiles/geometry-client.dir/geometry_main.c.obj channels/echo/client/CMakeFiles/echo-client.dir/echo_main.c.obj channels/disp/client/CMakeFiles/disp-client.dir/disp_main.c.obj channels/disp/client/CMakeFiles/disp-client.dir/__/disp_common.c.obj channels/audin/client/CMakeFiles/audin-client.dir/audin_main.c.obj channels/ainput/client/CMakeFiles/ainput-client.dir/ainput_main.c.obj channels/smartcard/client/CMakeFiles/smartcard-client.dir/smartcard_main.c.obj channels/printer/client/CMakeFiles/printer-client.dir/printer_main.c.obj channels/drive/client/CMakeFiles/drive-client.dir/drive_file.c.obj channels/drive/client/CMakeFiles/drive-client.dir/drive_main.c.obj channels/urbdrc/client/libusb/CMakeFiles/urbdrc-client-libusb.dir/libusb_udevman.c.obj channels/urbdrc/client/libusb/CMakeFiles/urbdrc-client-libusb.dir/libusb_udevice.c.obj channels/rdpsnd/client/winmm/CMakeFiles/rdpsnd-client-winmm.dir/rdpsnd_winmm.c.obj channels/rdpsnd/client/fake/CMakeFiles/rdpsnd-client-fake.dir/rdpsnd_fake.c.obj channels/printer/client/win/CMakeFiles/printer-client-win.dir/printer_win.c.obj channels/audin/client/winmm/CMakeFiles/audin-client-winmm.dir/audin_winmm.c.obj client/common/CMakeFiles/freerdp-client.dir/client.c.obj client/common/CMakeFiles/freerdp-client.dir/cmdline.c.obj client/common/CMakeFiles/freerdp-client.dir/file.c.obj client/common/CMakeFiles/freerdp-client.dir/client_cliprdr_file.c.obj client/common/CMakeFiles/freerdp-client.dir/geometry.c.obj client/common/CMakeFiles/freerdp-client.dir/smartcard_cli.c.obj client/common/CMakeFiles/freerdp-client.dir/__/__/channels/client/tables.c.obj client/common/CMakeFiles/freerdp-client.dir/__/__/channels/client/addin.c.obj client/common/CMakeFiles/freerdp-client.dir/__/__/channels/client/generic_dynvc.c.obj client/common/CMakeFiles/freerdp-client.dir/version.rc.obj  libfreerdp/libfreerdp3.dll.a  winpr/libwinpr/libwinpr3.dll.a  -lm  channels/remdesk/common/libremdesk-common.a  channels/rdpsnd/common/librdpsnd-common.a  channels/urbdrc/common/liburbdrc-common.a  C:/msys64/ucrt64/lib/libssl.dll.a  C:/msys64/ucrt64/lib/libcrypto.dll.a  C:/msys64/ucrt64/lib/libz.dll.a  C:/msys64/ucrt64/lib/libusb-1.0.dll.a  -lcrypt32  -lshlwapi  -lncrypt  -ldbghelp  -lws2_32  -lrpcrt4  -lntdsapi  -lwinmm  -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 && cd ."
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: channels/remdesk/common/libremdesk-common.a(remdesk_common.c.obj):remdesk_common:(.text+0x5ac): undefined reference to `Stream_Read_UTF16_String_As_UTF8_Buffer'
collect2.exe: error: ld returned 1 exit status
[524/531] Building CXX object server/proxy/modules/dyn-channel-dump/CMakeFiles/proxy-dyn-channel-dump-plugin.dir/dyn-channel-dump.cpp.obj
ninja: build stopped: subcommand failed.
```
From my undestanding, anything that links `remdesk-common` should now also link `winpr-tools`, right? 
[CMakeCache.txt](https://github.com/user-attachments/files/18950883/CMakeCache.txt)
