### PR TITLE
CMake: generate a .gitignore file for the build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 **/CMakeCache.txt
 **/CMakeFiles
-build
 checker
 abi-checker

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,11 @@ project(FreeRDP LANGUAGES C)
 
 add_custom_target(fuzzers COMMENT "Build fuzzers")
 
+if(NOT PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+  # Git auto-ignore out-of-source build directory
+  file(GENERATE OUTPUT .gitignore CONTENT "*")
+endif()
+
 if(NOT DEFINED VENDOR)
   set(VENDOR "FreeRDP" CACHE STRING "FreeRDP package vendor")
 endif()


### PR DESCRIPTION
As soon as a configuration step is successful, a `.gitignore` file is created inside an out-of-source build directory. Hence, there is no need to put its name into the root `.gitignore` file.