### PR TITLE
Fix WINPR_JSON_AddItemToArray compatibility with cJSON < 1.7.13

### DIFF
--- a/winpr/libwinpr/utils/json/json.c
+++ b/winpr/libwinpr/utils/json/json.c
@@ -617,7 +617,14 @@ BOOL WINPR_JSON_AddItemToArray(WINPR_JSON* array, WINPR_JSON* item)
 		return FALSE;
 	return TRUE;
 #elif defined(WITH_CJSON)
+#if defined(USE_CJSON_COMPAT)
+	if ((array == NULL) || (item == NULL))
+		return FALSE;
+	cJSON_AddItemToArray((cJSON*)array, (cJSON*)item);
+	return TRUE;
+#else
 	return cJSON_AddItemToArray((cJSON*)array, (cJSON*)item);
+#endif
 #else
 	WINPR_UNUSED(array);
 	WINPR_UNUSED(item);


### PR DESCRIPTION
Modified the WINPR_JSON_AddItemToArray function to not expect a return value from cJSON_AddItemToArray. WINPR_JSON_AddItemToArray failure is given by the same conditions that cause add_item_to_array. add_item_to_array is a private cJSON function called by cJSON_AddItemToArray. The logic analysis is based on cJSON 1.7.12, which is the last release before cJSON_AddItemToArray's signature changed to include a bool return. See https://github.com/DaveGamble/cJSON/blob/v1.7.12/cJSON.c line: 1848.

TEST 1: Build against cJSON master branch
EXPECTED: Build succeeds
RESULT: Success

TEST 2: Build against cJSON 1.7.10 (apt libcjson-dev), with changes.
EXPECTED: Build succeeds
RESULT: Success

TEST 3: Build against cJSON 1.7.10 (apt libcjson-dev), without changes.
EXPECTED: Build fails
RESULT: Success
