### PR TITLE
[cmake] Enable CMAKE_EXPORT_COMPILE_COMMANDS by default

### DIFF
--- a/cmake/CommonConfigOptions.cmake
+++ b/cmake/CommonConfigOptions.cmake
@@ -6,6 +6,10 @@ option(WITH_BINARY_VERSIONING "Use binary versioning" OFF)
 option(WITH_RESOURCE_VERSIONING "Use resource versioning" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
+if(CMAKE_EXPORT_COMPILE_COMMANDS STREQUAL "")
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "project default" FORCE)
+endif()
+
 # We want to control the winpr assert for the whole project
 option(WITH_VERBOSE_WINPR_ASSERT "Compile with verbose WINPR_ASSERT." ON)
 if(WITH_VERBOSE_WINPR_ASSERT)

--- a/winpr/libwinpr/utils/json/json.c
+++ b/winpr/libwinpr/utils/json/json.c
@@ -32,10 +32,8 @@
 
 #if defined(WITH_CJSON)
 #if CJSON_VERSION_MAJOR == 1
-#if CJSON_VERSION_MINOR <= 7
-#if CJSON_VERSION_PATCH < 13
+#if (CJSON_VERSION_MINOR < 7) || ((CJSON_VERSION_MINOR == 7) && (CJSON_VERSION_PATCH < 13))
 #define USE_CJSON_COMPAT
-#endif
 #endif
 #endif
 #endif
@@ -617,7 +615,14 @@ BOOL WINPR_JSON_AddItemToArray(WINPR_JSON* array, WINPR_JSON* item)
 		return FALSE;
 	return TRUE;
 #elif defined(WITH_CJSON)
+#if defined(USE_CJSON_COMPAT)
+	if ((array == NULL) || (item == NULL))
+		return FALSE;
+	cJSON_AddItemToArray((cJSON*)array, (cJSON*)item);
+	return TRUE;
+#else
 	return cJSON_AddItemToArray((cJSON*)array, (cJSON*)item);
+#endif
 #else
 	WINPR_UNUSED(array);
 	WINPR_UNUSED(item);


### PR DESCRIPTION
if not set from environment or commandline default to enable the compile commands generation