### PR TITLE
[shadow,kerberos] Fix Shadow crashing when calling krb5_get_init_cred…

### DIFF
--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -1363,6 +1363,8 @@ static SECURITY_STATUS SEC_ENTRY kerberos_AcceptSecurityContext(
 				break;
 			if (krb_log_exec(krb5glue_free_keytab_entry_contents, credentials->ctx, &entry))
 				goto cleanup;
+
+			memset(&entry, 0, sizeof(entry));
 		} while (1);
 
 		if (krb_log_exec(krb5_kt_end_seq_get, credentials->ctx, credentials->keytab, &cur))


### PR DESCRIPTION
…s_keytab if no suitable entry is found in keytab.

In the **kerberos_AcceptSecurityContext()** function of **winpr/libwinpr/sspi/Kerberos/kerberos.c** file, there is a _do ... while_ loop iterating through the _keytab_ entries. If there are indeed entries in the _keytab_ but none are suitable, the read entries are freed with the **krb5glue_free_keytab_entry_contents()** function. But the **entry** data structure is not erased. This means that when the loop exits with the **rv == KRB5_KT_END** condition, the structure still contains invalid data (dangling pointer) and will cause **krb5_get_init_creds_keytab()** call to crash.