### PR TITLE
Redirection && StreamPool usage fixes

### DIFF
--- a/libfreerdp/core/connection.h
+++ b/libfreerdp/core/connection.h
@@ -73,8 +73,8 @@ FREERDP_LOCAL const char* rdp_client_connection_state_string(UINT state);
 
 FREERDP_LOCAL BOOL rdp_channels_from_mcs(rdpSettings* settings, const rdpRdp* rdp);
 
-FREERDP_LOCAL BOOL rdp_handle_message_channel(rdpRdp* rdp, wStream* s, UINT16 channelId,
-                                              UINT16 length);
+FREERDP_LOCAL state_run_t rdp_handle_message_channel(rdpRdp* rdp, wStream* s, UINT16 channelId,
+                                                     UINT16 length);
 FREERDP_LOCAL BOOL rdp_handle_optional_rdp_decryption(rdpRdp* rdp, wStream* s, UINT16* length,
                                                       UINT16* pSecurityFlags);
 

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -317,8 +317,13 @@ BOOL freerdp_abort_connect_context(rdpContext* context)
 	/* Try to send a [MS-RDPBCGR] 1.3.1.4.1 User-Initiated on Client PDU, we don't care about
 	 * success */
 	if (context->rdp && context->rdp->mcs)
-		(void)mcs_send_disconnect_provider_ultimatum(context->rdp->mcs,
-		                                             Disconnect_Ultimatum_user_requested);
+	{
+		if (!context->ServerMode)
+		{
+			(void)mcs_send_disconnect_provider_ultimatum(context->rdp->mcs,
+			                                             Disconnect_Ultimatum_user_requested);
+		}
+	}
 	return utils_abort_connect(context->rdp);
 }
 

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -458,9 +458,7 @@ static state_run_t peer_recv_tpkt_pdu(freerdp_peer* client, wStream* s)
 
 	if (rdp_get_state(rdp) <= CONNECTION_STATE_LICENSING)
 	{
-		if (!rdp_handle_message_channel(rdp, s, channelId, length))
-			return STATE_RUN_FAILED;
-		return STATE_RUN_SUCCESS;
+		return rdp_handle_message_channel(rdp, s, channelId, length);
 	}
 
 	if (!rdp_handle_optional_rdp_decryption(rdp, s, &length, &securityFlags))

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -1635,9 +1635,7 @@ static state_run_t rdp_recv_tpkt_pdu(rdpRdp* rdp, wStream* s)
 	if (rdp->mcs->messageChannelId && (channelId == rdp->mcs->messageChannelId))
 	{
 		rdp->inPackets++;
-		if (!rdp_handle_message_channel(rdp, s, channelId, length))
-			return STATE_RUN_FAILED;
-		return STATE_RUN_SUCCESS;
+		return rdp_handle_message_channel(rdp, s, channelId, length);
 	}
 
 	if (rdp->settings->UseRdpSecurityLayer)

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -1368,7 +1368,20 @@ extern "C"
 
 	WINPR_API void StreamPool_Return(wStreamPool* pool, wStream* s);
 
+	/** @brief increment reference count of stream
+	 *
+	 *  @param s The stream to reference
+	 *  @bug versions < 3.13.0 did only handle streams returned by StreamPool_Take
+	 */
 	WINPR_API void Stream_AddRef(wStream* s);
+
+	/** @brief Release a reference to a stream.
+	 *  If the reference count reaches \b 0 it is returned to the StreamPool it was taken from or \b
+	 * Stream_Free is called.
+	 *
+	 *  @param s The stream to release
+	 *  @bug versions < 3.13.0 did only handle streams returned by StreamPool_Take
+	 */
 	WINPR_API void Stream_Release(wStream* s);
 
 	WINPR_ATTR_MALLOC(Stream_Release, 1)

--- a/winpr/libwinpr/utils/stream.c
+++ b/winpr/libwinpr/utils/stream.c
@@ -98,7 +98,7 @@ wStream* Stream_New(BYTE* buffer, size_t size)
 	if (!buffer && !size)
 		return NULL;
 
-	s = malloc(sizeof(wStream));
+	s = calloc(1, sizeof(wStream));
 	if (!s)
 		return NULL;
 
@@ -118,7 +118,7 @@ wStream* Stream_New(BYTE* buffer, size_t size)
 	s->length = size;
 
 	s->pool = NULL;
-	s->count = 0;
+	s->count = 1;
 	s->isAllocatedStream = TRUE;
 	s->isOwner = TRUE;
 	return s;
@@ -147,7 +147,7 @@ wStream* Stream_StaticInit(wStream* s, BYTE* buffer, size_t size)
 	s->buffer = s->pointer = buffer;
 	s->capacity = s->length = size;
 	s->pool = NULL;
-	s->count = 0;
+	s->count = 1;
 	s->isAllocatedStream = FALSE;
 	s->isOwner = FALSE;
 	return s;


### PR DESCRIPTION
A couple of bugs have been discovered during testing:

1. `rdp_handle_message_channel` must return the correct status in case of redirection
2. client side `mcs_send_disconnect_provider_ultimatum` must not be called if the `rdpContext` is a server side instance
3. `transport_send_stream_init` must not use the `transport->ReceivePool` as that might not be available when sending something (redirection or instance shutting down)
4. Fix handling of allocated `wStream` in `Stream_Release` and `Stream_AddRef`