### PR TITLE
[server,shadow] readd multi rect BitmapUpdate support

### DIFF
--- a/include/freerdp/server/shadow.h
+++ b/include/freerdp/server/shadow.h
@@ -174,6 +174,7 @@ extern "C"
 		freerdp_listener* listener;
 
 		size_t maxClientsConnected;
+		BOOL SupportMultiRectBitmapUpdates; /** @since version 3.13.0 */
 	};
 
 	struct rdp_shadow_surface

--- a/server/shadow/shadow.c
+++ b/server/shadow/shadow.c
@@ -95,6 +95,8 @@ int main(int argc, char** argv)
 		  "Allow GFX AVC420 codec" },
 		{ "gfx-avc444", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
 		  "Allow GFX AVC444 codec" },
+		{ "bitmap-compat", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
+		  "Limit BitmapUpdate to 1 rectangle (fixes broken windows 11 24H2 clients)" },
 		{ "version", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT_VERSION, NULL, NULL, NULL, -1,
 		  NULL, "Print version" },
 		{ "buildconfig", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_PRINT_BUILDCONFIG, NULL, NULL, NULL,

--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -236,6 +236,10 @@ int shadow_server_parse_command_line(rdpShadowServer* server, int argc, char** a
 		{
 			server->mayView = arg->Value ? TRUE : FALSE;
 		}
+		CommandLineSwitchCase(arg, "bitmap-compat")
+		{
+			server->SupportMultiRectBitmapUpdates = arg->Value ? FALSE : TRUE;
+		}
 		CommandLineSwitchCase(arg, "may-interact")
 		{
 			server->mayInteract = arg->Value ? TRUE : FALSE;
@@ -1001,6 +1005,7 @@ rdpShadowServer* shadow_server_new(void)
 	if (!server)
 		return NULL;
 
+	server->SupportMultiRectBitmapUpdates = TRUE;
 	server->port = 3389;
 	server->mayView = TRUE;
 	server->mayInteract = TRUE;


### PR DESCRIPTION
* Partially revert 1f83198bb1e5d7e8dfecae0e6511f88a7888c8c4
* Introduce new /bitmap-compat command line option for shadow-server
* Default to send multi rectangle BitmapUpdate