### PR TITLE
missing ConnectFlags variable in license_read_platform_challenge_packet breaks in WITH_DEBUG_LICENSE builds

### DIFF
--- a/libfreerdp/core/license.c
+++ b/libfreerdp/core/license.c
@@ -1979,7 +1979,6 @@ BOOL license_read_platform_challenge_packet(rdpLicense* license, wStream* s)
 		return FALSE;
 
 #ifdef WITH_DEBUG_LICENSE
-	WLog_DBG(TAG, "ConnectFlags: 0x%08" PRIX32 "", ConnectFlags);
 	WLog_DBG(TAG, "EncryptedPlatformChallenge:");
 	winpr_HexDump(TAG, WLOG_DEBUG, license->EncryptedPlatformChallenge->data,
 	              license->EncryptedPlatformChallenge->length);


### PR DESCRIPTION
`ConnectFlags` was removed in commit 9f5a00e, but it's still being logged when building `WITH_DEBUG_LICENSE` (see [here](https://github.com/FreeRDP/FreeRDP/blob/52fec2cd037987071afca501c724c655426a1c42/libfreerdp/core/license.c#L1982))

