### PR TITLE
[winpr,nt] Fix incorrect name in FILE_INFORMATION_CLASS

### DIFF
--- a/winpr/include/winpr/nt.h
+++ b/winpr/include/winpr/nt.h
@@ -1327,7 +1327,7 @@ typedef enum
 	FileMailslotSetInformation,
 	FileCompressionInformation,
 	FileObjectIdInformation,
-	FileUnknownInformation1,
+	FileCompletionInformation,
 	FileMoveClusterInformation,
 	FileQuotaInformation,
 	FileReparsePointInformation,

--- a/winpr/libwinpr/nt/nt.c
+++ b/winpr/libwinpr/nt/nt.c
@@ -125,8 +125,8 @@ const char* FSInformationClass2Tag(FILE_INFORMATION_CLASS value)
 			return "FileCompressionInformation";
 		case FileObjectIdInformation:
 			return "FileObjectIdInformation";
-		case FileUnknownInformation1:
-			return "FileUnknownInformation1";
+		case FileCompletionInformation:
+			return "FileCompletionInformation";
 		case FileMoveClusterInformation:
 			return "FileMoveClusterInformation";
 		case FileQuotaInformation:


### PR DESCRIPTION
This renames FileUnknownInformation1 with FileCompletionInformation which is documented in https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/ne-wdm-_file_information_class
