### PR TITLE
[client,sdl] fix bitmap clipboard source format

### DIFF
--- a/client/SDL/SDL3/sdl_clip.cpp
+++ b/client/SDL/SDL3/sdl_clip.cpp
@@ -576,7 +576,7 @@ std::shared_ptr<BYTE> sdlClip::ReceiveFormatDataRequestHandle(
 		case CF_DIB:
 		case CF_DIBV5:
 			mime = s_mime_bitmap()[0];
-			localFormatId = ClipboardGetFormatId(clipboard->_system, mime);
+			localFormatId = formatId;
 			break;
 
 		case CF_TIFF:


### PR DESCRIPTION
Set CF_DIB as source. This format is slightly different from image/bmp and causes problems when converting to PNG
@shmerl I think you will like this :grin: 
