### PR TITLE
[client,common] fix rdp parser

### DIFF
--- a/client/common/file.c
+++ b/client/common/file.c
@@ -1063,8 +1063,9 @@ BOOL freerdp_client_parse_rdp_file_ex(rdpFile* file, const char* name, rdp_file_
 	return status;
 }
 
-static INLINE BOOL freerdp_client_file_string_reset(char** target)
+static INLINE void freerdp_client_file_string_reset(char** target)
 {
+	WINPR_ASSERT(target);
 	freerdp_client_file_string_check_free(*target);
 	*target = (void*)~((size_t)NULL);
 }


### PR DESCRIPTION
freerdp_client_file_string_reset used a return type but did not return any value.