### PR TITLE
[core,transport] fix transport written statistics overflowing.

### DIFF
--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -1198,7 +1198,8 @@ ULONG freerdp_get_transport_sent(rdpContext* context, BOOL resetCount)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(context->rdp);
-	return transport_get_bytes_sent(context->rdp->transport, resetCount);
+	UINT64 rc = transport_get_bytes_sent(context->rdp->transport, resetCount);
+	return WINPR_CXX_COMPAT_CAST(ULONG, MIN(rc, UINT32_MAX));
 }
 
 BOOL freerdp_nla_impersonate(rdpContext* context)

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -87,7 +87,7 @@ struct rdp_transport
 	BOOL GatewayEnabled;
 	CRITICAL_SECTION ReadLock;
 	CRITICAL_SECTION WriteLock;
-	ULONG written;
+	UINT64 written;
 	HANDLE rereadEvent;
 	BOOL haveMoreBytesToRead;
 	wLog* log;
@@ -1236,13 +1236,7 @@ static int transport_default_write(rdpTransport* transport, wStream* s)
 		Stream_Seek(s, ustatus);
 	}
 
-	if (writtenlength + transport->written > UINT32_MAX)
-	{
-		status = -1;
-		goto out_cleanup;
-	}
-
-	transport->written += WINPR_ASSERTING_INT_CAST(uint32_t, writtenlength);
+	transport->written += writtenlength;
 out_cleanup:
 
 	if (status < 0)
@@ -1823,9 +1817,9 @@ wStream* transport_take_from_pool(rdpTransport* transport, size_t size)
 	return StreamPool_Take(transport->ReceivePool, size);
 }
 
-ULONG transport_get_bytes_sent(rdpTransport* transport, BOOL resetCount)
+UINT64 transport_get_bytes_sent(rdpTransport* transport, BOOL resetCount)
 {
-	ULONG rc = 0;
+	UINT64 rc = 0;
 	WINPR_ASSERT(transport);
 	rc = transport->written;
 	if (resetCount)

--- a/libfreerdp/core/transport.h
+++ b/libfreerdp/core/transport.h
@@ -142,7 +142,7 @@ FREERDP_LOCAL rdpTsg* transport_get_tsg(rdpTransport* transport);
 
 FREERDP_LOCAL wStream* transport_take_from_pool(rdpTransport* transport, size_t size);
 
-FREERDP_LOCAL ULONG transport_get_bytes_sent(rdpTransport* transport, BOOL resetCount);
+FREERDP_LOCAL UINT64 transport_get_bytes_sent(rdpTransport* transport, BOOL resetCount);
 
 FREERDP_LOCAL BOOL transport_have_more_bytes_to_read(rdpTransport* transport);
 


### PR DESCRIPTION
1. It is not safe to check transport->written overflowing 32-bit because the number will easily exceed 32-bit range when running in server mode. The connection will abruptly cut off unexpectedly when this happens.
2. It is safer to use 64-bit number as internal counter. The original 32-bit API will be capped at UINT32_MAX and new 64-bit API reserved for future consideration.