### PR TITLE
[winpr,file] create global instance for GetStdHandle

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -6142,11 +6142,10 @@ BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 		}
 	}
 
-	char* RDP2TCPArgs = freerdp_settings_get_string_writable(settings, FreeRDP_RDP2TCPArgs);
-	if (RDP2TCPArgs)
 	{
-		if (!freerdp_client_load_static_channel_addin(channels, settings, RDP2TCP_DVC_CHANNEL_NAME,
-		                                              RDP2TCPArgs))
+		char* RDP2TCPArgs = freerdp_settings_get_string_writable(settings, FreeRDP_RDP2TCPArgs);
+		const char* const p[] = { RDP2TCP_DVC_CHANNEL_NAME, RDP2TCPArgs };
+		if (!freerdp_client_add_static_channel(settings, ARRAYSIZE(p), p))
 			return FALSE;
 	}
 

--- a/winpr/libwinpr/pipe/pipe.c
+++ b/winpr/libwinpr/pipe/pipe.c
@@ -473,18 +473,20 @@ static BOOL InitWinPRPipeModule(void)
 BOOL CreatePipe(PHANDLE hReadPipe, PHANDLE hWritePipe, LPSECURITY_ATTRIBUTES lpPipeAttributes,
                 DWORD nSize)
 {
-	int pipe_fd[2];
+	int pipe_fd[] = { -1, -1 };
 	WINPR_PIPE* pReadPipe = NULL;
 	WINPR_PIPE* pWritePipe = NULL;
 
 	WINPR_UNUSED(lpPipeAttributes);
 	WINPR_UNUSED(nSize);
 
-	pipe_fd[0] = -1;
-	pipe_fd[1] = -1;
-
 	if (pipe(pipe_fd) < 0)
 	{
+		if (pipe_fd[0] >= 0)
+			close(pipe_fd[0]);
+		if (pipe_fd[1] >= 0)
+			close(pipe_fd[1]);
+
 		WLog_ERR(TAG, "failed to create pipe");
 		return FALSE;
 	}
@@ -494,6 +496,10 @@ BOOL CreatePipe(PHANDLE hReadPipe, PHANDLE hWritePipe, LPSECURITY_ATTRIBUTES lpP
 
 	if (!pReadPipe || !pWritePipe)
 	{
+		if (pipe_fd[0] >= 0)
+			close(pipe_fd[0]);
+		if (pipe_fd[1] >= 0)
+			close(pipe_fd[1]);
 		free(pReadPipe);
 		free(pWritePipe);
 		return FALSE;


### PR DESCRIPTION
clean up `GetStdHandle` on close to avoid `ASAN` reports