### PR TITLE
[client,cmdline] fix rdp2tcp parsing

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -6144,9 +6144,12 @@ BOOL freerdp_client_load_addins(rdpChannels* channels, rdpSettings* settings)
 
 	{
 		char* RDP2TCPArgs = freerdp_settings_get_string_writable(settings, FreeRDP_RDP2TCPArgs);
-		const char* const p[] = { RDP2TCP_DVC_CHANNEL_NAME, RDP2TCPArgs };
-		if (!freerdp_client_add_static_channel(settings, ARRAYSIZE(p), p))
-			return FALSE;
+		if (RDP2TCPArgs)
+		{
+			const char* const p[] = { RDP2TCP_DVC_CHANNEL_NAME, RDP2TCPArgs };
+			if (!freerdp_client_add_static_channel(settings, ARRAYSIZE(p), p))
+				return FALSE;
+		}
 	}
 
 	/* step 4: do the static channels loading and init */


### PR DESCRIPTION
allow command lines without this channel to succeed as well.