### PR TITLE
[clients] remove keyboard state sync on CAPS release

### DIFF
--- a/client/SDL/SDL3/sdl_kbd.cpp
+++ b/client/SDL/SDL3/sdl_kbd.cpp
@@ -593,10 +593,6 @@ BOOL sdlInput::keyboard_handle_event(const SDL_KeyboardEvent* ev)
 		assert(_remapTable);
 	}
 	auto scancode = freerdp_keyboard_remap_key(_remapTable, rdp_scancode);
-	if ((ev->type == SDL_EVENT_KEY_UP) && (scancode == RDP_SCANCODE_CAPSLOCK))
-	{
-		keyboard_sync_state();
-	}
 	return freerdp_input_send_keyboard_event_ex(
 	    _sdl->context()->input, ev->type == SDL_EVENT_KEY_DOWN, ev->repeat, scancode);
 }

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -726,11 +726,6 @@ void xf_keyboard_send_key(xfContext* xfc, BOOL down, BOOL repeat, const XKeyEven
 			WLog_ERR(TAG, "Unknown key with X keycode 0x%02" PRIx8 "", event->keycode);
 		else
 			(void)freerdp_input_send_keyboard_event_ex(input, down, repeat, rdp_scancode);
-
-		if ((rdp_scancode == RDP_SCANCODE_CAPSLOCK) && (down == FALSE))
-		{
-			(void)xf_sync_kbd_state(xfc);
-		}
 	}
 }
 


### PR DESCRIPTION
The keyboard state was synced in xfreerdp (and more recently sdl3-freerdp) when the CAPS key was released.
Some investigation revealed this to be a historic workaround for loss of keyboard state sync (e.g. NUK, CAPS or SCROLL getting out of sync)

This can not happen anymore as all events during windows focus are processed properly and every time the keyboard state changes outside it is synchronized when focus is gained.