### PR TITLE
[client,x11,sdl] sync keyboard state after hotkey

### DIFF
--- a/.github/workflows/abi-checker.yml
+++ b/.github/workflows/abi-checker.yml
@@ -28,7 +28,17 @@ jobs:
           fetch-depth: 0
           ref: ${{steps.pr.outputs.merge_commit_sha}}
 
+      - name: Restore abigail tools
+        id: cache-abigail-tools-restore
+        if: always() && steps.cache-abigail-tools-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/restore@v4
+        with:
+          key: cache-abigail-tools
+          path: |
+            .
+
       - name: "Prepare abigail-tools"
+        if: always() && steps.cache-abigail-tools-restore.outputs.cache-hit != 'true'
         run: |
           mkdir deb
           cd deb
@@ -39,6 +49,15 @@ jobs:
           cd libabigail-2.6
           dpkg-buildpackage
           sudo dpkg -i ../*.deb
+
+      - name: Save abigail tools
+        id: cache-abigail-tools-save
+        if: always() && steps.cache-abigail-tools-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          key: cache-abigail-tools
+          path: |
+            .
 
       - name: "Prepare environment"
         run: |

--- a/client/SDL/SDL3/sdl_freerdp.cpp
+++ b/client/SDL/SDL3/sdl_freerdp.cpp
@@ -1068,16 +1068,22 @@ static int sdl_run(SdlContext* sdl)
 									auto win = window->second.window();
 									int w_pix{};
 									int h_pix{};
-									assert(SDL_GetWindowSizeInPixels(win, &w_pix, &h_pix));
+									[[maybe_unused]] auto rcpix =
+									    SDL_GetWindowSizeInPixels(win, &w_pix, &h_pix);
+									assert(rcpix);
 									auto scale = SDL_GetWindowDisplayScale(win);
-									assert(scale != 0);
+									assert(SDL_isnanf(scale) == 0);
+									assert(SDL_isinff(scale) == 0);
+									assert(scale > SDL_FLT_EPSILON);
 									auto w_gdi = sdl->context()->gdi->width;
 									auto h_gdi = sdl->context()->gdi->height;
 									auto pix2point = [=](int pix)
 									{ return static_cast<int>(static_cast<float>(pix) / scale); };
 									if (w_pix != w_gdi || h_pix != h_gdi)
 									{
-										SDL_SetWindowSize(win, pix2point(w_gdi), pix2point(h_gdi));
+										[[maybe_unused]] auto ssws = SDL_SetWindowSize(
+										    win, pix2point(w_gdi), pix2point(h_gdi));
+										assert(ssws);
 									}
 								}
 								break;

--- a/client/SDL/SDL3/sdl_kbd.cpp
+++ b/client/SDL/SDL3/sdl_kbd.cpp
@@ -550,6 +550,7 @@ BOOL sdlInput::keyboard_handle_event(const SDL_KeyboardEvent* ev)
 			{
 				WLog_Print(_sdl->log, WLOG_INFO, "%s+<%s> pressed, toggling fullscreen state",
 				           masktostr(_hotkeyModmask).c_str(), sdl_scancode_name(_hotkeyFullscreen));
+				keyboard_sync_state();
 				_sdl->update_fullscreen(!_sdl->fullscreen);
 				return TRUE;
 			}
@@ -557,6 +558,7 @@ BOOL sdlInput::keyboard_handle_event(const SDL_KeyboardEvent* ev)
 			{
 				WLog_Print(_sdl->log, WLOG_INFO, "%s+<%s> pressed, toggling resizeable state",
 				           masktostr(_hotkeyModmask).c_str(), sdl_scancode_name(_hotkeyResizable));
+				keyboard_sync_state();
 				_sdl->update_resizeable(!_sdl->resizeable);
 				return TRUE;
 			}
@@ -565,6 +567,7 @@ BOOL sdlInput::keyboard_handle_event(const SDL_KeyboardEvent* ev)
 			{
 				WLog_Print(_sdl->log, WLOG_INFO, "%s+<%s> pressed, toggling grab state",
 				           masktostr(_hotkeyModmask).c_str(), sdl_scancode_name(_hotkeyGrab));
+				keyboard_sync_state();
 				keyboard_grab(ev->windowID, !_sdl->grab_kbd);
 				return TRUE;
 			}
@@ -572,6 +575,7 @@ BOOL sdlInput::keyboard_handle_event(const SDL_KeyboardEvent* ev)
 			{
 				WLog_Print(_sdl->log, WLOG_INFO, "%s+<%s> pressed, disconnecting RDP session",
 				           masktostr(_hotkeyModmask).c_str(), sdl_scancode_name(_hotkeyDisconnect));
+				keyboard_sync_state();
 				freerdp_abort_connect_context(_sdl->context());
 				return TRUE;
 			}
@@ -579,6 +583,7 @@ BOOL sdlInput::keyboard_handle_event(const SDL_KeyboardEvent* ev)
 			{
 				WLog_Print(_sdl->log, WLOG_INFO, "%s+<%s> pressed, minimizing client",
 				           masktostr(_hotkeyModmask).c_str(), sdl_scancode_name(_hotkeyMinimize));
+				keyboard_sync_state();
 				_sdl->update_minimize();
 				return TRUE;
 			}

--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -1034,6 +1034,7 @@ BOOL xf_keyboard_handle_special_keys(xfContext* xfc, KeySym keysym)
 				{
 					/* Ctrl-Alt-Enter: toggle full screen */
 					WLog_INFO(TAG, "<ctrl>+<alt>+<enter> pressed, toggling fullscreen state...");
+					xf_sync_kbd_state(xfc);
 					xf_toggle_fullscreen(xfc);
 					return TRUE;
 				}
@@ -1050,6 +1051,7 @@ BOOL xf_keyboard_handle_special_keys(xfContext* xfc, KeySym keysym)
 			case XK_m:
 			case XK_M:
 				WLog_INFO(TAG, "<ctrl>+<alt>+m pressed, minimizing RDP session...");
+				xf_sync_kbd_state(xfc);
 				xf_minimize(xfc);
 				return TRUE;
 			case XK_c:
@@ -1063,6 +1065,7 @@ BOOL xf_keyboard_handle_special_keys(xfContext* xfc, KeySym keysym)
 			case XK_D:
 				/* <ctrl>+<alt>+d: disconnect session */
 				WLog_INFO(TAG, "<ctrl>+<alt>+d pressed, terminating RDP session...");
+				xf_sync_kbd_state(xfc);
 				return freerdp_abort_connect_context(&xfc->common.context);
 
 			default:
@@ -1175,6 +1178,7 @@ void xf_keyboard_handle_special_keys_release(xfContext* xfc, KeySym keysym)
 	{
 		if (!xfc->fullscreen)
 		{
+			xf_sync_kbd_state(xfc);
 			freerdp_client_encomsp_toggle_control(xfc->common.encomsp);
 		}
 


### PR DESCRIPTION
If a client side key combination was detected issue a keybard state sync to reset the server side keyboard to initial state with no keys pressed.