### PR TITLE
[channels,rdpdr] relax state checks for PAKID_CORE_CLIENTID_CONFIRM

### DIFF
--- a/channels/rdpdr/client/rdpdr_capabilities.c
+++ b/channels/rdpdr/client/rdpdr_capabilities.c
@@ -189,7 +189,6 @@ UINT rdpdr_process_capability_request(rdpdrPlugin* rdpdr, wStream* s)
 	if (!rdpdr || !s)
 		return CHANNEL_RC_NULL_DATA;
 
-	WINPR_ASSERT(rdpdr->state == RDPDR_CHANNEL_STATE_SERVER_CAPS);
 	rdpdr_state_advance(rdpdr, RDPDR_CHANNEL_STATE_CLIENT_CAPS);
 
 	if (!Stream_CheckAndLogRequiredLengthWLog(rdpdr->log, s, 4))

--- a/channels/rdpdr/client/rdpdr_main.h
+++ b/channels/rdpdr/client/rdpdr_main.h
@@ -111,6 +111,8 @@ typedef struct
 	wLog* log;
 	BOOL async;
 	BOOL capabilities[6];
+	BOOL haveClientId;
+	BOOL haveServerCaps;
 } rdpdrPlugin;
 
 BOOL rdpdr_state_advance(rdpdrPlugin* rdpdr, enum RDPDR_CHANNEL_STATE next);


### PR DESCRIPTION
This missage might be sent before PAKID_CORE_SERVER_CAPABILITY by some servers. Do accept these.