### PR TITLE
Various fixes related to smartcard logon server-side

### DIFF
--- a/winpr/libwinpr/ncrypt/ncrypt_pkcs11.c
+++ b/winpr/libwinpr/ncrypt/ncrypt_pkcs11.c
@@ -541,7 +541,8 @@ static BOOL convertKeyType(CK_KEY_TYPE k, LPWSTR dest, DWORD len, DWORD* outlen)
 			dest[0] = 0;
 		return FALSE;
 	}
-	else
+
+	if (dest)
 	{
 		if (retLen + 1 > len)
 		{
@@ -549,11 +550,8 @@ static BOOL convertKeyType(CK_KEY_TYPE k, LPWSTR dest, DWORD len, DWORD* outlen)
 			return FALSE;
 		}
 
-		if (dest)
-		{
-			memcpy(dest, r, sizeof(WCHAR) * retLen);
-			dest[retLen] = 0;
-		}
+		memcpy(dest, r, sizeof(WCHAR) * retLen);
+		dest[retLen] = 0;
 	}
 
 	return TRUE;


### PR DESCRIPTION
2 commits to:
*  remove a verbose log in ncrypt that happens because we're calling a function to know the size of the target string
* fix server-side user2user kerberos (also removed some unneeded `krb_log_exec_bool` logs)