### PR TITLE
Winpr acsprintf

### DIFF
--- a/winpr/include/winpr/string.h
+++ b/winpr/include/winpr/string.h
@@ -45,6 +45,32 @@ extern "C"
 	WINPR_API int winpr_asprintf(char** s, size_t* slen, const char* templ, ...);
 	WINPR_API int winpr_vasprintf(char** s, size_t* slen, const char* templ, va_list ap);
 
+	/** @brief allocating sprintf, returns an allocated string
+	 *
+	 *  @param plen An optional pointer set to strlen(result)
+	 *  @param templ The format string
+	 *  @param ... The arguments for the format string
+	 *
+	 *  @return A '\0' terminated string if successful, \b NULL otherwise.
+	 *
+	 *  @since version 3.15.0
+	 */
+	WINPR_ATTR_MALLOC(free, 1)
+	WINPR_API char* winpr_acsprintf(size_t* plen, const char* templ, ...);
+
+	/** @brief allocating sprintf, returns an allocated string
+	 *
+	 *  @param plen An optional pointer set to strlen(result)
+	 *  @param templ The format string
+	 *  @param ap The arguments for the format string
+	 *
+	 *  @return A '\0' terminated string if successful, \b NULL otherwise.
+	 *
+	 *  @since version 3.15.0
+	 */
+	WINPR_ATTR_MALLOC(free, 1)
+	WINPR_API char* winpr_vacsprintf(size_t* plen, const char* templ, va_list ap);
+
 #ifndef _WIN32
 
 #define CSTR_LESS_THAN 1

--- a/winpr/libwinpr/crt/string.c
+++ b/winpr/libwinpr/crt/string.c
@@ -181,13 +181,37 @@ int winpr_asprintf(char** s, size_t* slen, WINPR_FORMAT_ARG const char* templ, .
 	return rc;
 }
 
+WINPR_ATTR_FORMAT_ARG(2, 3)
+char* winpr_acsprintf(size_t* plen, WINPR_FORMAT_ARG const char* templ, ...)
+{
+	va_list ap = { 0 };
+
+	va_start(ap, templ);
+	char* s = winpr_vacsprintf(plen, templ, ap);
+	va_end(ap);
+	return s;
+}
+
+WINPR_ATTR_FORMAT_ARG(2, 0)
+char* winpr_vacsprintf(size_t* plen, const char* templ, va_list ap)
+{
+	char* s = NULL;
+	(void)winpr_vasprintf(&s, plen, templ, ap);
+	return s;
+}
+
 WINPR_ATTR_FORMAT_ARG(3, 0)
 int winpr_vasprintf(char** s, size_t* slen, WINPR_FORMAT_ARG const char* templ, va_list oap)
 {
 	va_list ap = { 0 };
 
+	WINPR_ASSERT(s);
+	WINPR_ASSERT(templ);
+
 	*s = NULL;
-	*slen = 0;
+
+	if (slen)
+		*slen = 0;
 
 	va_copy(ap, oap);
 	const int length = vsnprintf(NULL, 0, templ, ap);
@@ -209,7 +233,8 @@ int winpr_vasprintf(char** s, size_t* slen, WINPR_FORMAT_ARG const char* templ, 
 		return -1;
 	}
 	*s = str;
-	*slen = (size_t)length;
+	if (slen)
+		*slen = (size_t)length;
 	return length;
 }
 


### PR DESCRIPTION
seeing #11443 I thought it might help to simplify our allocating print functions with this.
should be easier to use than the existing ones (error check is just a `NULL` check and we can still (optionally) get the correct string length.