### PR TITLE
[cmake] drop legacy and unused cmake_policy

### DIFF
--- a/client/Mac/CMakeLists.txt
+++ b/client/Mac/CMakeLists.txt
@@ -8,9 +8,6 @@ project(MacFreeRDP-library VERSION ${FREERDP_DEFAULT_PROJECT_VERSION})
 
 message("project ${PROJECT_NAME} is using version ${PROJECT_VERSION}")
 
-cmake_policy(SET CMP0026 OLD)
-cmake_policy(SET CMP0045 OLD)
-
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/)
 include(CommonConfigOptions)
 

--- a/client/common/CMakeLists.txt
+++ b/client/common/CMakeLists.txt
@@ -18,13 +18,6 @@
 set(MODULE_NAME "freerdp-client")
 set(MODULE_PREFIX "FREERDP_CLIENT")
 
-#  Policy CMP0022: INTERFACE_LINK_LIBRARIES defines the link
-#  interface.  Run "cmake --help-policy CMP0022" for policy details.  Use the
-#  cmake_policy command to set the policy and suppress this warning.
-if(POLICY CMP0022)
-  cmake_policy(SET CMP0022 NEW)
-endif()
-
 set(SRCS
     client.c
     cmdline.c

--- a/cmake/CommonConfigOptions.cmake
+++ b/cmake/CommonConfigOptions.cmake
@@ -19,9 +19,6 @@ endif()
 # known issue on android, thus disabled until we support newer CMake
 # https://github.com/android/ndk/issues/1444
 if(NOT ANDROID OR ("${CMAKE_VERSION}" GREATER_EQUAL "3.20.0"))
-  if(POLICY CMP0069)
-    cmake_policy(SET CMP0069 NEW)
-  endif()
   if(POLICY CMP0138)
     cmake_policy(SET CMP0138 NEW)
   endif()

--- a/server/common/CMakeLists.txt
+++ b/server/common/CMakeLists.txt
@@ -18,13 +18,6 @@
 set(MODULE_NAME "freerdp-server")
 set(MODULE_PREFIX "FREERDP_SERVER")
 
-#  Policy CMP0022: INTERFACE_LINK_LIBRARIES defines the link
-#  interface.  Run "cmake --help-policy CMP0022" for policy details.  Use the
-#  cmake_policy command to set the policy and suppress this warning.
-if(POLICY CMP0022)
-  cmake_policy(SET CMP0022 NEW)
-endif()
-
 set(${MODULE_PREFIX}_SRCS server.c)
 
 foreach(FREERDP_CHANNELS_SERVER_SRC ${FREERDP_CHANNELS_SERVER_SRCS})


### PR DESCRIPTION
Some cmake_policy settings have long been active by default (3.13 is our current baseline) or simply unused. Due to issues with CMake 4.0 lets drop them