### PR TITLE
[core,settings] enforce OrderSupportFlags

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -653,14 +653,39 @@ static BOOL rdp_write_order_capability_set(wLog* log, wStream* s, const rdpSetti
 
 	if (settings->BitmapCacheV3Enabled)
 	{
-		orderSupportExFlags |= CACHE_BITMAP_V3_SUPPORT;
-		orderFlags |= ORDER_FLAGS_EXTRA_SUPPORT;
+		if ((orderSupportExFlags & CACHE_BITMAP_V3_SUPPORT) == 0)
+		{
+			WLog_Print(log, WLOG_ERROR,
+			           "rdpSettings::BitmapCacheV3Enabled=TRUE, but CACHE_BITMAP_V3_SUPPORT not "
+			           "set in rdpSettings::OrderSupportEx, aborting.");
+			return FALSE;
+		}
+		if ((orderFlags & ORDER_FLAGS_EXTRA_SUPPORT) == 0)
+		{
+			WLog_Print(log, WLOG_ERROR,
+			           "rdpSettings::BitmapCacheV3Enabled=TRUE, but ORDER_FLAGS_EXTRA_SUPPORT not "
+			           "set in rdpSettings::OrderSupport, aborting.");
+			return FALSE;
+		}
 	}
 
 	if (settings->FrameMarkerCommandEnabled)
 	{
-		orderSupportExFlags |= ALTSEC_FRAME_MARKER_SUPPORT;
-		orderFlags |= ORDER_FLAGS_EXTRA_SUPPORT;
+		if ((orderSupportExFlags & ALTSEC_FRAME_MARKER_SUPPORT) == 0)
+		{
+			WLog_Print(
+			    log, WLOG_ERROR,
+			    "rdpSettings::FrameMarkerCommandEnabled=TRUE, but "
+			    "ALTSEC_FRAME_MARKER_SUPPORT not set in rdpSettings::OrderSupportEx, aborting.");
+			return FALSE;
+		}
+		if ((orderFlags & ORDER_FLAGS_EXTRA_SUPPORT) == 0)
+		{
+			WLog_Print(log, WLOG_ERROR,
+			           "rdpSettings::FrameMarkerCommandEnabled=TRUE, but ORDER_FLAGS_EXTRA_SUPPORT "
+			           "not set in rdpSettings::OrderSupport, aborting.");
+			return FALSE;
+		}
 	}
 
 	const char* dsc = freerdp_settings_get_string(settings, FreeRDP_TerminalDescriptor);

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -122,6 +122,9 @@ static int freerdp_connect_begin(freerdp* instance)
 		status = freerdp_settings_enforce_monitor_exists(settings);
 
 	if (status)
+		status = freerdp_settings_enforce_consistency(settings);
+
+	if (status)
 		status = freerdp_settings_check_client_after_preconnect(settings);
 
 	if (status)

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -806,7 +806,9 @@ static state_run_t peer_recv_callback_internal(WINPR_ATTR_UNUSED rdpTransport* t
 	switch (rdp_get_state(rdp))
 	{
 		case CONNECTION_STATE_INITIAL:
-			if (rdp_server_transition_to_state(rdp, CONNECTION_STATE_NEGO))
+			if (!freerdp_settings_enforce_consistency(settings))
+				ret = STATE_RUN_FAILED;
+			else if (rdp_server_transition_to_state(rdp, CONNECTION_STATE_NEGO))
 				ret = STATE_RUN_CONTINUE;
 			break;
 

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -1764,3 +1764,19 @@ BOOL freerdp_settings_enforce_monitor_exists(rdpSettings* settings)
 
 	return TRUE;
 }
+
+BOOL freerdp_settings_enforce_consistency(rdpSettings* settings)
+{
+	if (freerdp_settings_get_bool(settings, FreeRDP_BitmapCacheV3Enabled))
+	{
+		settings->OrderSupportFlagsEx |= CACHE_BITMAP_V3_SUPPORT;
+		settings->OrderSupportFlags |= ORDER_FLAGS_EXTRA_SUPPORT;
+	}
+
+	if (settings->FrameMarkerCommandEnabled)
+	{
+		settings->OrderSupportFlagsEx |= ALTSEC_FRAME_MARKER_SUPPORT;
+		settings->OrderSupportFlags |= ORDER_FLAGS_EXTRA_SUPPORT;
+	}
+	return TRUE;
+}

--- a/libfreerdp/core/settings.h
+++ b/libfreerdp/core/settings.h
@@ -35,6 +35,7 @@
 
 #include <string.h>
 
+FREERDP_LOCAL BOOL freerdp_settings_enforce_consistency(rdpSettings* settings);
 FREERDP_LOCAL BOOL freerdp_settings_enforce_monitor_exists(rdpSettings* settings);
 FREERDP_LOCAL void freerdp_settings_print_warnings(const rdpSettings* settings);
 FREERDP_LOCAL BOOL freerdp_settings_check_client_after_preconnect(const rdpSettings* settings);


### PR DESCRIPTION
After preConnect callback ensure that the OrderSupportFlags are consistent with the other settings