### PR TITLE
Sdl elminiate sdl and rdp thread dependency

### DIFF
--- a/client/SDL/SDL3/dialogs/CMakeLists.txt
+++ b/client/SDL/SDL3/dialogs/CMakeLists.txt
@@ -68,6 +68,7 @@ add_subdirectory(res)
 
 add_library(sdl3-dialogs STATIC ${SRCS})
 
+set_property(TARGET sdl3-dialogs PROPERTY FOLDER "Client/SDL")
 target_link_libraries(sdl3-dialogs PRIVATE ${LIBS})
 
 if(BUILD_TESTING)

--- a/client/SDL/SDL3/dialogs/res/CMakeLists.txt
+++ b/client/SDL/SDL3/dialogs/res/CMakeLists.txt
@@ -18,6 +18,8 @@
 set(SRCS sdl3_resource_manager.cpp sdl3_resource_manager.hpp)
 
 add_library(sdl3_client_res STATIC ${SRCS})
+set_property(TARGET sdl3_client_res PROPERTY FOLDER "Client/SDL")
+
 if(NOT WITH_SDL_LINK_SHARED)
   target_link_libraries(sdl3_client_res ${SDL3_STATIC_LIBRARIES})
 else()

--- a/client/SDL/SDL3/sdl_freerdp.hpp
+++ b/client/SDL/SDL3/sdl_freerdp.hpp
@@ -23,6 +23,7 @@
 #include <thread>
 #include <map>
 #include <atomic>
+#include <queue>
 
 #include <freerdp/freerdp.h>
 #include <freerdp/client/rdpei.h>
@@ -85,7 +86,6 @@ class SdlContext
 	std::thread thread;
 	WinPREvent initialize;
 	WinPREvent initialized;
-	WinPREvent update_complete;
 	WinPREvent windows_created;
 	int exit_code = -1;
 
@@ -100,4 +100,6 @@ class SdlContext
 	std::unique_ptr<SDLConnectionDialog> connection_dialog;
 
 	std::atomic<bool> rdp_thread_running;
+
+	std::queue<std::vector<SDL_Rect>> _queue;
 };

--- a/client/SDL/common/CMakeLists.txt
+++ b/client/SDL/common/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(
   sdl-common-prefs STATIC sdl_prefs.hpp sdl_prefs.cpp scoped_guard.hpp sdl_common_utils.hpp sdl_common_utils.cpp
 )
 target_link_libraries(sdl-common-prefs winpr freerdp)
+set_property(TARGET sdl-common-prefs PROPERTY FOLDER "Client/Common")
 
 if(BUILD_TESTING_INTERNAL OR BUILD_TESTING)
   add_subdirectory(test)

--- a/client/SDL/common/aad/CMakeLists.txt
+++ b/client/SDL/common/aad/CMakeLists.txt
@@ -54,6 +54,8 @@ cleaning_configure_file(sdl_config.hpp.in sdl_config.hpp @ONLY)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_library(sdl-common-aad-view STATIC ${SRCS})
+set_property(TARGET sdl-common-aad-view PROPERTY FOLDER "Client/Common")
+
 target_include_directories(sdl-common-aad-view PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(sdl-common-aad-view PRIVATE ${LIBS})
 target_compile_definitions(sdl-common-aad-view PUBLIC ${DEFINITIONS})

--- a/client/SDL/common/res/CMakeLists.txt
+++ b/client/SDL/common/res/CMakeLists.txt
@@ -105,3 +105,4 @@ endif()
 
 add_library(sdl-common-client-res STATIC ${RES_FILES} ${SRCS} ${FACTORY_HDR} ${FACTORY_SRCS})
 set_property(TARGET sdl-common-client-res PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET sdl-common-client-res PROPERTY FOLDER "Client/Common")

--- a/client/X11/cli/CMakeLists.txt
+++ b/client/X11/cli/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SRCS xfreerdp.c)
 
 addtargetwithresourcefile(${MODULE_NAME} TRUE "${PROJECT_VERSION}" SRCS)
 set_target_properties(${MODULE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "..")
+set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER "Client/X11")
 
 list(APPEND LIBS xfreerdp-client)
 


### PR DESCRIPTION
do not wait for sdl thread to complete display update.

eliminates possible deadlocks in clipboard found in https://github.com/FreeRDP/FreeRDP/issues/11359