### PR TITLE
[rdpei/server] fix build and channel init

### DIFF
--- a/channels/rdpei/server/rdpei_main.c
+++ b/channels/rdpei/server/rdpei_main.c
@@ -125,7 +125,7 @@ UINT rdpei_server_init(RdpeiServerContext* context)
 	    (bytesReturned != sizeof(HANDLE)))
 	{
 		WLog_ERR(TAG,
-		         "WTSVirtualChannelQuery failed or invalid invalid returned size(%" PRIu32 ")!",
+		         "WTSVirtualChannelQuery failed or invalid returned size(%" PRIu32 ")!",
 		         bytesReturned);
 		if (buffer)
 			WTSFreeMemory(buffer);

--- a/channels/server/channels.c
+++ b/channels/server/channels.c
@@ -45,7 +45,7 @@
 #include <freerdp/server/cliprdr.h>
 #include <freerdp/server/echo.h>
 #include <freerdp/server/rdpdr.h>
-#if defined(CHANNEL_RAIL_SERVER)
+#if defined(CHANNEL_RDPEI_SERVER)
 #include <freerdp/server/rdpei.h>
 #endif
 #include <freerdp/server/drdynvc.h>


### PR DESCRIPTION
In some build configurations, compilation of server-side RDPEI channel might fail (see commit for details).
Also, at runtime, the channel fails to initialize since `WTSVirtualChannelOpenEx(WTS_CURRENT_SESSION, ...)` (unconditionally) fails.  So it has been adjusted to what is used in other channels.