### PR TITLE
[client,sdl] fix clipboard updates

### DIFF
--- a/client/SDL/SDL3/sdl_clip.hpp
+++ b/client/SDL/SDL3/sdl_clip.hpp
@@ -144,6 +144,7 @@ class sdlClip
 	wClipboard* _system = nullptr;
 	std::atomic<bool> _sync = false;
 	HANDLE _event;
+	Uint64 _last_timestamp = 0;
 
 	std::vector<CliprdrFormat> _serverFormats;
 	CriticalSection _lock;


### PR DESCRIPTION
* Ignore updates for our own data (use a special clipboard format to identify these)

we now use a trick to identify our own updates:
1. We insert the special mime type `x-special/freerdp-clipboard-update`
2. We update the client clipboard with `SDL_SetClipboardData` once (we use `_current_mimetypes` for that)
3. we clear `_current_mimetypes` after `SDL_SetClipboardData`, so further clipboard events will not retrigger an update
4. as long as the special mime type is available in the clipboard do not send a format list update to the server
5. if the clipboard is empty or changed from another application (our special mime type was erased) we send a format list update to the server