### PR TITLE
[client,sdl] use a GUID to identify the clipboard

### DIFF
--- a/client/SDL/SDL3/sdl_clip.hpp
+++ b/client/SDL/SDL3/sdl_clip.hpp
@@ -112,6 +112,8 @@ class sdlClip
 	std::string getServerFormat(uint32_t id);
 	uint32_t serverIdForMime(const std::string& mime);
 
+	bool contains(const char** mime_types, Sint32 count);
+
 	static UINT MonitorReady(CliprdrClientContext* context,
 	                         const CLIPRDR_MONITOR_READY* monitorReady);
 
@@ -162,4 +164,6 @@ class sdlClip
 	};
 	std::map<std::string, cache_entry> _cache_data;
 	std::vector<const char*> _current_mimetypes;
+	std::string _uuid;
+	std::string _mime_uuid;
 };

--- a/client/SDL/SDL3/sdl_utils.cpp
+++ b/client/SDL/SDL3/sdl_utils.cpp
@@ -20,6 +20,7 @@
 #include <cassert>
 #include <sstream>
 #include <iomanip>
+#include <random>
 
 #include "sdl_utils.hpp"
 
@@ -352,4 +353,38 @@ std::string sdl::utils::rdp_orientation_to_str(uint32_t orientation)
 			return ss.str();
 		}
 	}
+}
+
+std::string sdl::utils::generate_uuid_v4()
+{
+	static std::random_device rd;
+	static std::mt19937 gen(rd());
+	static std::uniform_int_distribution<> dis(0, 255);
+	std::stringstream ss;
+	ss << std::hex << std::setfill('0') << std::setw(2);
+	for (int i = 0; i < 4; i++)
+	{
+		ss << dis(gen);
+	}
+	ss << "-";
+	for (int i = 0; i < 2; i++)
+	{
+		ss << dis(gen);
+	}
+	ss << "-";
+	for (int i = 0; i < 2; i++)
+	{
+		ss << dis(gen);
+	}
+	ss << "-";
+	for (int i = 0; i < 2; i++)
+	{
+		ss << dis(gen);
+	}
+	ss << "-";
+	for (int i = 0; i < 6; i++)
+	{
+		ss << dis(gen);
+	};
+	return ss.str();
 }

--- a/client/SDL/SDL3/sdl_utils.hpp
+++ b/client/SDL/SDL3/sdl_utils.hpp
@@ -86,4 +86,6 @@ namespace sdl::utils
 	std::string rdp_orientation_to_str(uint32_t orientation);
 	std::string sdl_orientation_to_str(SDL_DisplayOrientation orientation);
 	UINT32 orientaion_to_rdp(SDL_DisplayOrientation orientation);
+
+	std::string generate_uuid_v4();
 }


### PR DESCRIPTION
Use a clipboard mime type with a GUID to identify the specific FreeRDP instance. When running multiple clients it might confuse a clipboard update from another instance with an internal one otherwise.