### PR TITLE
rdpei/server: Fix incorrect PDU length read

### DIFF
--- a/channels/rdpei/server/rdpei_main.c
+++ b/channels/rdpei/server/rdpei_main.c
@@ -718,7 +718,7 @@ UINT rdpei_server_handle_messages(RdpeiServerContext* context)
 
 		/* header case */
 		Stream_Read_UINT16(s, priv->currentMsgType);
-		Stream_Read_UINT16(s, pduLen);
+		Stream_Read_UINT32(s, pduLen);
 
 		if (pduLen < RDPINPUT_HEADER_LENGTH)
 		{


### PR DESCRIPTION
The PDU length is a 32-bit unsigned integer and not a 16-bit one.