### PR TITLE
[winpr] Put '\0' when converting empty string to wstr

### DIFF
--- a/winpr/libwinpr/crt/unicode_apple.m
+++ b/winpr/libwinpr/crt/unicode_apple.m
@@ -89,7 +89,8 @@ int int_MultiByteToWideChar(UINT CodePage, DWORD dwFlags, LPCSTR lpMultiByteStr,
 		const size_t mlen = MIN((size_t)utf16CharLen, cchWideChar);
 		const size_t len = _wcsnlen(utf16, mlen);
 		memcpy(lpWideCharStr, utf16, len * sizeof(WCHAR));
-		if ((len < (size_t)cchWideChar) && (len > 0) && (lpWideCharStr[len - 1] != '\0'))
+		if ((len < (size_t)cchWideChar) &&
+		    ((len == 0) || ((len > 0) && (lpWideCharStr[len - 1] != '\0'))))
 			lpWideCharStr[len] = '\0';
 		return utf16CharLen;
 	}


### PR DESCRIPTION
[macOS] Please, refer to the test cases below:

```c
WCHAR wstr[3];

SSIZE_T len2 = ConvertUtf8NToWChar("12", 3, wstr, 3);
assertTrue(len2 == 2);
assertTrue(wstr[0] != 0 && wstr[1] != 0 && wstr[2] == 0);

SSIZE_T len1 = ConvertUtf8NToWChar("1", 2, wstr, 2);
assertTrue(len1 == 1);
assertTrue(wstr[0] != 0 && wstr[1] == 0);

SSIZE_T len0 = ConvertUtf8NToWChar("", 1, wstr, 1);
assertTrue(len0 == 0);    // <---- fail!!  "len0 == 1"
assertTrue(wstr[0] == 0); // <---- fail!!  "wstr[0] != 0"
```