### PR TITLE
[winpr,sysinfo] use a single clock to provide System and Local time

### DIFF
--- a/winpr/libwinpr/sysinfo/sysinfo.c
+++ b/winpr/libwinpr/sysinfo/sysinfo.c
@@ -248,8 +248,9 @@ void GetSystemTime(LPSYSTEMTIME lpSystemTime)
 	struct tm tres;
 	struct tm* stm = NULL;
 	WORD wMilliseconds = 0;
-	ct = time(NULL);
-	wMilliseconds = (WORD)(GetTickCount() % 1000);
+	UINT64 now = winpr_GetUnixTimeNS();
+	ct = WINPR_TIME_NS_TO_S(now);
+	wMilliseconds = (WORD)(WINPR_TIME_NS_REM_MS(now));
 	stm = gmtime_r(&ct, &tres);
 	ZeroMemory(lpSystemTime, sizeof(SYSTEMTIME));
 
@@ -279,8 +280,9 @@ VOID GetLocalTime(LPSYSTEMTIME lpSystemTime)
 	struct tm tres;
 	struct tm* ltm = NULL;
 	WORD wMilliseconds = 0;
-	ct = time(NULL);
-	wMilliseconds = (WORD)(GetTickCount() % 1000);
+	UINT64 now = winpr_GetUnixTimeNS();
+	ct = WINPR_TIME_NS_TO_S(now);
+	wMilliseconds = (WORD)(WINPR_TIME_NS_REM_MS(now));
 	ltm = localtime_r(&ct, &tres);
 	ZeroMemory(lpSystemTime, sizeof(SYSTEMTIME));
 


### PR DESCRIPTION
... rather than a different one for second and sub-second part

The sub-second is currently taken from "tick count", which (apparently) tracks (process) up-time rather than any real system time.  This then leads to "funny" timestamps in logs, which may go backwards and do not correspond to timestamps as produced by other logging.