### PR TITLE
[common,settings] fix add_string_or_null

### DIFF
--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -2616,7 +2616,8 @@ static BOOL add_string_or_null(WINPR_JSON* json, const char* key, const char* va
 	if (value)
 		return WINPR_JSON_AddStringToObject(json, key, value) != NULL;
 
-	return WINPR_JSON_AddNullToObject(json, key) != NULL;
+	(void)WINPR_JSON_AddNullToObject(json, key);
+	return TRUE;
 }
 
 static WINPR_JSON* json_from_device_item(const RDPDR_DEVICE* val)

--- a/libfreerdp/core/test/TestSettings.c
+++ b/libfreerdp/core/test/TestSettings.c
@@ -1718,7 +1718,7 @@ static BOOL test_serialize_pointer(DWORD flags)
 {
 	rdpSettings* src = freerdp_settings_new(flags);
 	if (!src)
-		return FALSE;
+		goto fail;
 
 	const char* argv1[] = { "foobar", "lala", "haha" };
 	const char* argv2[] = { "lala", "haha" };
@@ -1775,7 +1775,7 @@ static BOOL test_serialize_pointer(DWORD flags)
 	void* ptr = NULL;
 	winpr_RAND((void*)&ptr, sizeof(void*));
 	if (!freerdp_settings_set_pointer(src, FreeRDP_instance, ptr))
-		return FALSE;
+		goto fail;
 
 	if (!set_private_key(src))
 		goto fail;


### PR DESCRIPTION
* If the value is NULL do not check WINPR_JSON_AddNullToObject return as that is most likely also NULL
* Fix testcase, always use goto for error handling