### PR TITLE
fix [resources]: remove MimeType from desktop file

### DIFF
--- a/resources/freerdp.desktop.template
+++ b/resources/freerdp.desktop.template
@@ -9,6 +9,5 @@ Terminal=true
 Type=Application
 Keywords=remote desktop;rdp;
 Categories=GTK;GNOME;X-GNOME-NetworkSettings;Network;
-MimeType=x-scheme-handler/rdp;
 StartupNotify=true
 StartupWMClass=com.freerdp.FreeRDP


### PR DESCRIPTION
freerdp-file.desktop.template contains the MimeType handler and handles the arguments.