### PR TITLE
[rdpsnd/client] add parameters to pulse snd device plugin

### DIFF
--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -914,7 +914,8 @@ static UINT rdpsnd_process_addin_args(rdpsndPlugin* rdpsnd, const ADDIN_ARGV* ar
 
 	if (args->argc > 1)
 	{
-		flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON;
+		flags = COMMAND_LINE_SIGIL_NONE | COMMAND_LINE_SEPARATOR_COLON |
+		        COMMAND_LINE_IGN_UNKNOWN_KEYWORD;
 		status = CommandLineParseArgumentsA(args->argc, args->argv, rdpsnd_args, flags, rdpsnd,
 		                                    NULL, NULL);
 


### PR DESCRIPTION
... to specify pulseaudio client name and stream name

This allows an application to specify some application specific name, which may then be more convenient in various PulseAudio and mixer tools (especially if multiple applications/processes are involved).