### PR TITLE
[core,settings] fix freerdp_device_collection_add

### DIFF
--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -1159,6 +1159,7 @@ static UINT rdpdr_process_connect(rdpdrPlugin* rdpdr)
 	{
 		const RDPDR_DEVICE* device =
 		    freerdp_settings_get_pointer_array(settings, FreeRDP_DeviceArray, index);
+		WINPR_ASSERT(device);
 
 		if (device->Type == RDPDR_DTYP_FILESYSTEM)
 		{

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -44,16 +44,13 @@
 
 BOOL freerdp_addin_argv_add_argument_ex(ADDIN_ARGV* args, const char* argument, size_t len)
 {
-	char* str = NULL;
-	char** new_argv = NULL;
-
 	if (!args || !argument)
 		return FALSE;
 
 	if (len == 0)
 		len = strlen(argument);
 
-	new_argv = (char**)realloc(
+	char** new_argv = (char**)realloc(
 	    (void*)args->argv, sizeof(char*) * (WINPR_ASSERTING_INT_CAST(uint32_t, args->argc) + 1));
 
 	if (!new_argv)
@@ -61,7 +58,7 @@ BOOL freerdp_addin_argv_add_argument_ex(ADDIN_ARGV* args, const char* argument, 
 
 	args->argv = new_argv;
 
-	str = calloc(len + 1, sizeof(char));
+	char* str = calloc(len + 1, sizeof(char));
 	if (!str)
 		return FALSE;
 	memcpy(str, argument, len);
@@ -220,23 +217,19 @@ BOOL freerdp_device_collection_add(rdpSettings* settings, RDPDR_DEVICE* device)
 	old = freerdp_settings_get_uint32(settings, FreeRDP_DeviceArraySize);
 	if (old < count)
 	{
-		UINT32 new_size = old * 2;
-		RDPDR_DEVICE** new_array = NULL;
-
-		if (new_size == 0)
-			new_size = count * 2;
-
-		new_array =
+		const size_t new_size = (old + 32);
+		RDPDR_DEVICE** new_array =
 		    (RDPDR_DEVICE**)realloc((void*)settings->DeviceArray, new_size * sizeof(RDPDR_DEVICE*));
 
 		if (!new_array)
 			return FALSE;
 
 		settings->DeviceArray = new_array;
-		for (size_t x = 0; x < new_size; x++)
+		for (size_t x = old; x < new_size; x++)
 			settings->DeviceArray[x] = NULL;
 
-		if (!freerdp_settings_set_uint32(settings, FreeRDP_DeviceArraySize, new_size))
+		if (!freerdp_settings_set_uint32(settings, FreeRDP_DeviceArraySize,
+		                                 WINPR_ASSERTING_INT_CAST(uint32_t, new_size)))
 			return FALSE;
 	}
 
@@ -625,13 +618,9 @@ BOOL freerdp_static_channel_collection_add(rdpSettings* settings, ADDIN_ARGV* ch
 	{
 		const UINT32 oldSize =
 		    freerdp_settings_get_uint32(settings, FreeRDP_StaticChannelArraySize);
-		UINT32 new_size = oldSize * 2ul;
-		ADDIN_ARGV** new_array = NULL;
-		if (new_size == 0)
-			new_size = count * 2ul;
-
-		new_array = (ADDIN_ARGV**)realloc((void*)settings->StaticChannelArray,
-		                                  new_size * sizeof(ADDIN_ARGV*));
+		const size_t new_size = oldSize + 32ul;
+		ADDIN_ARGV** new_array = (ADDIN_ARGV**)realloc((void*)settings->StaticChannelArray,
+		                                               new_size * sizeof(ADDIN_ARGV*));
 
 		if (!new_array)
 			return FALSE;
@@ -641,7 +630,8 @@ BOOL freerdp_static_channel_collection_add(rdpSettings* settings, ADDIN_ARGV* ch
 			for (size_t x = oldSize; x < new_size; x++)
 				settings->StaticChannelArray[x] = NULL;
 		}
-		if (!freerdp_settings_set_uint32(settings, FreeRDP_StaticChannelArraySize, new_size))
+		if (!freerdp_settings_set_uint32(settings, FreeRDP_StaticChannelArraySize,
+		                                 WINPR_ASSERTING_INT_CAST(uint32_t, new_size)))
 			return FALSE;
 	}
 
@@ -732,12 +722,9 @@ BOOL freerdp_dynamic_channel_collection_add(rdpSettings* settings, ADDIN_ARGV* c
 	oldSize = freerdp_settings_get_uint32(settings, FreeRDP_DynamicChannelArraySize);
 	if (oldSize < count)
 	{
-		ADDIN_ARGV** new_array = NULL;
-		UINT32 size = oldSize * 2;
-		if (size == 0)
-			size = count * 2;
 
-		new_array =
+		const size_t size = oldSize + 32;
+		ADDIN_ARGV** new_array =
 		    (ADDIN_ARGV**)realloc((void*)settings->DynamicChannelArray, sizeof(ADDIN_ARGV*) * size);
 
 		if (!new_array)
@@ -748,7 +735,8 @@ BOOL freerdp_dynamic_channel_collection_add(rdpSettings* settings, ADDIN_ARGV* c
 			for (size_t x = oldSize; x < size; x++)
 				settings->DynamicChannelArray[x] = NULL;
 		}
-		if (!freerdp_settings_set_uint32(settings, FreeRDP_DynamicChannelArraySize, size))
+		if (!freerdp_settings_set_uint32(settings, FreeRDP_DynamicChannelArraySize,
+		                                 WINPR_ASSERTING_INT_CAST(uint32_t, size)))
 			return FALSE;
 	}
 

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -1407,6 +1407,9 @@ static BOOL freerdp_settings_int_buffer_copy(rdpSettings* _settings, const rdpSe
 		    freerdp_settings_get_pointer_array(settings, FreeRDP_TargetNetAddresses, i);
 		const UINT32* port =
 		    freerdp_settings_get_pointer_array(settings, FreeRDP_TargetNetPorts, i);
+		WINPR_ASSERT(address);
+		WINPR_ASSERT(port);
+
 		if (!freerdp_settings_set_pointer_array(_settings, FreeRDP_TargetNetAddresses, i, address))
 			goto out_fail;
 		if (!freerdp_settings_set_pointer_array(_settings, FreeRDP_TargetNetPorts, i, port))
@@ -1414,7 +1417,7 @@ static BOOL freerdp_settings_int_buffer_copy(rdpSettings* _settings, const rdpSe
 	}
 
 	{
-		const UINT32 len = freerdp_settings_get_uint32(_settings, FreeRDP_DeviceArraySize);
+		const UINT32 len = freerdp_settings_get_uint32(settings, FreeRDP_DeviceArraySize);
 		const UINT32 count = freerdp_settings_get_uint32(settings, FreeRDP_DeviceCount);
 
 		if (len < count)
@@ -1428,9 +1431,12 @@ static BOOL freerdp_settings_int_buffer_copy(rdpSettings* _settings, const rdpSe
 		{
 			const RDPDR_DEVICE* argv =
 			    freerdp_settings_get_pointer_array(settings, FreeRDP_DeviceArray, index);
+			WINPR_ASSERT(argv);
 			if (!freerdp_settings_set_pointer_array(_settings, FreeRDP_DeviceArray, index, argv))
 				goto out_fail;
 		}
+		WINPR_ASSERT(_settings->DeviceArray || (len == 0));
+		WINPR_ASSERT(len >= count);
 	}
 	{
 		const UINT32 len = freerdp_settings_get_uint32(_settings, FreeRDP_StaticChannelArraySize);
@@ -1447,6 +1453,7 @@ static BOOL freerdp_settings_int_buffer_copy(rdpSettings* _settings, const rdpSe
 		{
 			const ADDIN_ARGV* argv =
 			    freerdp_settings_get_pointer_array(settings, FreeRDP_StaticChannelArray, index);
+			WINPR_ASSERT(argv);
 			if (!freerdp_settings_set_pointer_array(_settings, FreeRDP_StaticChannelArray, index,
 			                                        argv))
 				goto out_fail;
@@ -1467,6 +1474,7 @@ static BOOL freerdp_settings_int_buffer_copy(rdpSettings* _settings, const rdpSe
 		{
 			const ADDIN_ARGV* argv =
 			    freerdp_settings_get_pointer_array(settings, FreeRDP_DynamicChannelArray, index);
+			WINPR_ASSERT(argv);
 			if (!freerdp_settings_set_pointer_array(_settings, FreeRDP_DynamicChannelArray, index,
 			                                        argv))
 				goto out_fail;


### PR DESCRIPTION
* Assert usage of DeviceArray, ensure returned values are != NULL if within DeviceCount
* Only reset newly allocated DeviceArray members on resize