### PR TITLE
[winpr,file] Fix assert fail always when removing flags

### DIFF
--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -985,7 +985,7 @@ static HANDLE FileCreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dw
 
 	if (fstat(fileno(pFile->fp), &st) == 0 && dwFlagsAndAttributes & FILE_ATTRIBUTE_READONLY)
 	{
-		st.st_mode &= WINPR_ASSERTING_INT_CAST(mode_t, ~(S_IWUSR | S_IWGRP | S_IWOTH));
+		st.st_mode &= WINPR_ASSERTING_INT_CAST(mode_t, (mode_t)(~(S_IWUSR | S_IWGRP | S_IWOTH)));
 		fchmod(fileno(pFile->fp), st.st_mode);
 	}
 


### PR DESCRIPTION
It alway fails at least on macOS clang. This fix is based on the code below which does the same operation:

https://github.com/FreeRDP/FreeRDP/blob/9bd2330c4e10d7ac2d09e671705478af38b06823/winpr/libwinpr/file/generic.c#L635

Not sure `WINPR_ASSERTING_INT_CAST` is quite necessary in this case, though.
