### PR TITLE
FF_PROFILE Depreciation

### DIFF
--- a/libfreerdp/codec/dsp_ffmpeg.c
+++ b/libfreerdp/codec/dsp_ffmpeg.c
@@ -256,7 +256,11 @@ static BOOL ffmpeg_open_context(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context)
 			break;
 
 		case AV_CODEC_ID_AAC:
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(60, 31, 102)
 			context->context->profile = FF_PROFILE_AAC_MAIN;
+#else
+			context->context->profile = AV_PROFILE_AAC_MAIN;
+#endif
 			break;
 
 		default:


### PR DESCRIPTION
Fixes depreciated FF_PROFILE_AAC definition, replacing with AV_PROFILE_AAC, see issue #11541 
