### PR TITLE
[client,sdl] mark SDL3 as no longer experimental

### DIFF
--- a/client/SDL/CMakeLists.txt
+++ b/client/SDL/CMakeLists.txt
@@ -69,9 +69,7 @@ if(NOT WITHOUT_FREERDP_3x_DEPRECATED)
     WITH_CLIENT_SDL OFF
   )
 endif()
-cmake_dependent_option(
-  WITH_CLIENT_SDL3 "[experimental] build experimental SDL3 client" ${SDL3_FOUND} WITH_CLIENT_SDL OFF
-)
+cmake_dependent_option(WITH_CLIENT_SDL3 "build SDL3 client" ${SDL3_FOUND} WITH_CLIENT_SDL OFF)
 
 if(WITH_CLIENT_SDL2 AND WITH_CLIENT_SDL3)
   message("Building both, SDL2 and SDL3 clients, forcing WITH_CLIENT_SDL_VERSIONED=ON")

--- a/client/SDL/SDL3/sdl_freerdp.cpp
+++ b/client/SDL/SDL3/sdl_freerdp.cpp
@@ -1633,8 +1633,6 @@ int main(int argc, char* argv[])
 	int status = 0;
 	RDP_CLIENT_ENTRY_POINTS clientEntryPoints = {};
 
-	freerdp_client_warn_experimental(argc, argv);
-
 	RdpClientEntry(&clientEntryPoints);
 	std::unique_ptr<sdl_rdp_context, void (*)(sdl_rdp_context*)> sdl_rdp(
 	    reinterpret_cast<sdl_rdp_context*>(freerdp_client_context_new(&clientEntryPoints)),


### PR DESCRIPTION
Since SDL3 is now stable and the basic features of the client work remove the experimental flag.
only major feature still missing is RAILS support.