### PR TITLE
Support 'Restrict Credential Delegation' mode

### DIFF
--- a/include/freerdp/settings_types_private.h
+++ b/include/freerdp/settings_types_private.h
@@ -289,7 +289,8 @@ struct rdp_settings
 	SETTINGS_DEPRECATED(ALIGN64 BOOL AadSecurity);                  /* 1112 */
 	SETTINGS_DEPRECATED(ALIGN64 char* WinSCardModule);              /* 1113 */
 	SETTINGS_DEPRECATED(ALIGN64 BOOL RemoteCredentialGuard);        /* 1114 */
-	UINT64 padding1152[1152 - 1115];                                /* 1115 */
+	SETTINGS_DEPRECATED(ALIGN64 BOOL RestrictedAdminModeSupported); /* 1115 */
+	UINT64 padding1152[1152 - 1116];                                /* 1116 */
 
 	/* Connection Cookie */
 	SETTINGS_DEPRECATED(ALIGN64 BOOL MstscCookieMode);      /* 1152 */

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -493,6 +493,9 @@ BOOL freerdp_settings_get_bool(WINPR_ATTR_UNUSED const rdpSettings* settings,
 		case FreeRDP_RestrictedAdminModeRequired:
 			return settings->RestrictedAdminModeRequired;
 
+		case FreeRDP_RestrictedAdminModeSupported:
+			return settings->RestrictedAdminModeSupported;
+
 		case FreeRDP_SaltedChecksum:
 			return settings->SaltedChecksum;
 
@@ -1243,6 +1246,10 @@ BOOL freerdp_settings_set_bool(WINPR_ATTR_UNUSED rdpSettings* settings,
 
 		case FreeRDP_RestrictedAdminModeRequired:
 			settings->RestrictedAdminModeRequired = cnv.c;
+			break;
+
+		case FreeRDP_RestrictedAdminModeSupported:
+			settings->RestrictedAdminModeSupported = cnv.c;
 			break;
 
 		case FreeRDP_SaltedChecksum:

--- a/libfreerdp/common/settings_str.h
+++ b/libfreerdp/common/settings_str.h
@@ -207,6 +207,8 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_RemoteFxOnly, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_RemoteFxOnly" },
 	{ FreeRDP_RestrictedAdminModeRequired, FREERDP_SETTINGS_TYPE_BOOL,
 	  "FreeRDP_RestrictedAdminModeRequired" },
+	{ FreeRDP_RestrictedAdminModeSupported, FREERDP_SETTINGS_TYPE_BOOL,
+	  "FreeRDP_RestrictedAdminModeSupported" },
 	{ FreeRDP_SaltedChecksum, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_SaltedChecksum" },
 	{ FreeRDP_SendPreconnectionPdu, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_SendPreconnectionPdu" },
 	{ FreeRDP_ServerLicenseRequired, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_ServerLicenseRequired" },

--- a/libfreerdp/core/nego.h
+++ b/libfreerdp/core/nego.h
@@ -116,6 +116,7 @@ FREERDP_LOCAL BOOL nego_set_target(rdpNego* nego, const char* hostname, UINT16 p
 FREERDP_LOCAL void nego_set_negotiation_enabled(rdpNego* nego, BOOL NegotiateSecurityLayer);
 FREERDP_LOCAL void nego_set_restricted_admin_mode_required(rdpNego* nego,
                                                            BOOL RestrictedAdminModeRequired);
+FREERDP_LOCAL void nego_set_restricted_admin_mode_supported(rdpNego* nego, BOOL enabled);
 FREERDP_LOCAL void nego_set_RCG_required(rdpNego* nego, BOOL enabled);
 FREERDP_LOCAL void nego_set_RCG_supported(rdpNego* nego, BOOL enabled);
 FREERDP_LOCAL BOOL nego_get_remoteCredentialGuard(rdpNego* nego);

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -275,6 +275,8 @@ static BOOL freerdp_peer_initialize(freerdp_peer* client)
 	}
 
 	nego_set_RCG_supported(rdp->nego, settings->RemoteCredentialGuard);
+	nego_set_restricted_admin_mode_supported(rdp->nego, settings->RestrictedAdminModeSupported);
+
 	if (!rdp_server_transition_to_state(rdp, CONNECTION_STATE_INITIAL))
 		return FALSE;
 

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -884,6 +884,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	    !freerdp_settings_set_bool(settings, FreeRDP_RdstlsSecurity, FALSE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_NegotiateSecurityLayer, TRUE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_RestrictedAdminModeRequired, FALSE) ||
+	    !freerdp_settings_set_bool(settings, FreeRDP_RestrictedAdminModeSupported, TRUE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_MstscCookieMode, FALSE) ||
 	    !freerdp_settings_set_uint32(settings, FreeRDP_CookieMaxLength,
 	                                 DEFAULT_COOKIE_MAX_LENGTH) ||

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -148,6 +148,7 @@ static const size_t bool_list_indices[] = {
 	FreeRDP_RemoteFxImageCodec,
 	FreeRDP_RemoteFxOnly,
 	FreeRDP_RestrictedAdminModeRequired,
+	FreeRDP_RestrictedAdminModeSupported,
 	FreeRDP_SaltedChecksum,
 	FreeRDP_SendPreconnectionPdu,
 	FreeRDP_ServerLicenseRequired,


### PR DESCRIPTION
This PR fixes two issues related to RestrictedAdmin on the server side:

1. There is an inconsistency in how RestrictedMode is handled on the server side. As the following code points out, while RemoteGuard needs to be enabled explicitely, the server always considers that it supports RestrictedAdmin. (hence also why there is no RestrictedAdminSupported boolean).

https://github.com/FreeRDP/FreeRDP/blob/32956261e42ffb893c204d84c2869deeaacb7e4e/libfreerdp/core/nego.c#L1256-L1273

However, when sending the negotiation response, the server has this weird check:
https://github.com/FreeRDP/FreeRDP/blob/32956261e42ffb893c204d84c2869deeaacb7e4e/libfreerdp/core/nego.c#L1474

If my understanding is correct, and we consider that the server always supports RestrictedAdmin, it should be removed. If we don't consider that we always support RestrictedAdmin, we should fail the negotiation in the first snippet. I PR'd the first option.

2. FreeRDP's server fails to negotiate if you enable "Restrict Credential Delegation" but do not enable RemoteGuard on Freerdp.

![image](https://github.com/user-attachments/assets/8191963c-a018-4fe1-817e-a3b54b4d7600)

Enabling this feature makes the negotiation flags be 3 (RESTRICTED_ADMIN_MODE_REQUIRED + REDIRECTED_AUTHENTICATION_MODE_REQUIRED), but it actually means "OR" as shown above. This looks somewhat off-spec, but we shouldn't fail as we support RestrictedAdmin but not RemoteGuard.