### PR TITLE
[cmake] Fix finding ffmpeg under nonstandard prefixes

### DIFF
--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -96,12 +96,12 @@ macro(find_component _component _pkgconfig _library _header)
     endif()
   endif(NOT WIN32)
 
-  find_path(${_component}_INCLUDE_DIRS ${_header} HINTS ${PC_LIB${_component}_INCLUDEDIR}
-                                                        ${PC_LIB${_component}_INCLUDE_DIRS} PATH_SUFFIXES ffmpeg
+  find_path(${_component}_INCLUDE_DIRS ${_header} HINTS ${PC_${_component}_INCLUDEDIR}
+                                                        ${PC_${_component}_INCLUDE_DIRS} PATH_SUFFIXES ffmpeg
   )
 
   find_library(
-    ${_component}_LIBRARIES NAMES ${_library} HINTS ${PC_LIB${_component}_LIBDIR} ${PC_LIB${_component}_LIBRARY_DIRS}
+    ${_component}_LIBRARIES NAMES ${_library} HINTS ${PC_${_component}_LIBDIR} ${PC_${_component}_LIBRARY_DIRS}
   )
 
   set(${_component}_DEFINITIONS ${PC_${_component}_CFLAGS_OTHER} CACHE STRING "The ${_component} CFLAGS.")


### PR DESCRIPTION
The prefix given to pkg_check_modules is PC\_${\_component}, not PC\_LIB${\_component}, so those variables were always read as empty, thus no HINTS were passed to the find\_* functions and ffmpeg could not be found if it was not in a default path.

For reference:
https://invent.kde.org/multimedia/ffmpegthumbs/-/commit/afcc7af91967fb66145bef0c74f811b3c58da80c
https://bugs.kde.org/show_bug.cgi?id=338280