### PR TITLE
Support NLA in shadow server when running behind a Hyper-V proxy

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -1525,7 +1525,11 @@ BOOL rdp_server_accept_nego(rdpRdp* rdp, wStream* s)
 	SelectedProtocol = nego_get_selected_protocol(nego);
 	status = FALSE;
 
-	if (SelectedProtocol & PROTOCOL_RDSTLS)
+	if (freerdp_settings_get_bool(rdp->settings, FreeRDP_VmConnectMode) &&
+	    SelectedProtocol != PROTOCOL_RDP)
+		/* When behind a Hyper-V proxy, security != RDP is handled by the host. */
+		status = TRUE;
+	else if (SelectedProtocol & PROTOCOL_RDSTLS)
 		status = transport_accept_rdstls(rdp->transport);
 	else if (SelectedProtocol & PROTOCOL_HYBRID)
 		status = transport_accept_nla(rdp->transport);

--- a/server/shadow/cli/shadow.c
+++ b/server/shadow/cli/shadow.c
@@ -64,6 +64,8 @@ int main(int argc, char** argv)
 		  "Remote credential guard" },
 		{ "restricted-admin", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
 		  "Restricted Admin" },
+		{ "vmconnect", COMMAND_LINE_VALUE_FLAG | COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse,
+		  NULL, -1, NULL, "Hyper-V console server (bind on vsock://1)" },
 		{ "may-view", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
 		  "Clients may view without prompt" },
 		{ "may-interact", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,

--- a/server/shadow/cli/shadow.c
+++ b/server/shadow/cli/shadow.c
@@ -62,6 +62,8 @@ int main(int argc, char** argv)
 		  "Clients must authenticate" },
 		{ "remote-guard", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
 		  "Remote credential guard" },
+		{ "restricted-admin", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
+		  "Restricted Admin" },
 		{ "may-view", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
 		  "Clients may view without prompt" },
 		{ "may-interact", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,

--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -389,6 +389,12 @@ int shadow_server_parse_command_line(rdpShadowServer* server, int argc, char** a
 			                               arg->Value ? TRUE : FALSE))
 				return fail_at(arg, COMMAND_LINE_ERROR);
 		}
+		CommandLineSwitchCase(arg, "restricted-admin")
+		{
+			if (!freerdp_settings_set_bool(settings, FreeRDP_RestrictedAdminModeSupported,
+			                               arg->Value ? TRUE : FALSE))
+				return fail_at(arg, COMMAND_LINE_ERROR);
+		}
 		CommandLineSwitchCase(arg, "sec")
 		{
 			if (strcmp("rdp", arg->Value) == 0) /* Standard RDP */

--- a/server/shadow/shadow_server.c
+++ b/server/shadow/shadow_server.c
@@ -395,6 +395,12 @@ int shadow_server_parse_command_line(rdpShadowServer* server, int argc, char** a
 			                               arg->Value ? TRUE : FALSE))
 				return fail_at(arg, COMMAND_LINE_ERROR);
 		}
+		CommandLineSwitchCase(arg, "vmconnect")
+		{
+			if (!freerdp_settings_set_bool(settings, FreeRDP_VmConnectMode,
+			                               arg->Value ? TRUE : FALSE))
+				return fail_at(arg, COMMAND_LINE_ERROR);
+		}
 		CommandLineSwitchCase(arg, "sec")
 		{
 			if (strcmp("rdp", arg->Value) == 0) /* Standard RDP */
@@ -597,7 +603,7 @@ int shadow_server_parse_command_line(rdpShadowServer* server, int argc, char** a
 	/* If we want to disable authentication we need to ensure that NLA security
 	 * is not activated. Only TLS and RDP security allow anonymous login.
 	 */
-	if (!server->authentication)
+	if (!server->authentication && !freerdp_settings_get_bool(settings, FreeRDP_VmConnectMode))
 	{
 		if (!freerdp_settings_set_bool(settings, FreeRDP_NlaSecurity, FALSE))
 			return COMMAND_LINE_ERROR;


### PR DESCRIPTION
**This PR requires https://github.com/FreeRDP/FreeRDP/pull/11547**

This PR adds support for other security protocols than plain RDP when using FreeRDP shadow server inside a Hyper-V VM. In this specific case, security is handled by Hyper-V, so the FreeRDP server needs to be able to advertise for NLA support (like Windows does by default), without actually handling it itself.

![Untitled Diagram](https://github.com/user-attachments/assets/21ecd28d-a165-459e-9697-3551805ba94d)
(source: me)

This just adds a `/vmconnect` flag that turns this behavior on (same name than on the client side). This was tested on Win11 24H2 using vmconnect.exe

Usage: `sudo freerdp-shadow-cli /bind-address:"vsock://1" /vmconnect`