### PR TITLE
[client,sdl] fix leak with SDL_ttf usage

### DIFF
--- a/client/SDL/SDL3/dialogs/sdl_widget.cpp
+++ b/client/SDL/SDL3/dialogs/sdl_widget.cpp
@@ -43,7 +43,7 @@ static const Uint32 hpadding = 10;
 
 SdlWidget::SdlWidget(std::shared_ptr<SDL_Renderer>& renderer, const SDL_FRect& rect)
     : _renderer(renderer),
-      _engine(TTF_CreateRendererTextEngine(renderer.get()), TTF_DestroySurfaceTextEngine),
+      _engine(TTF_CreateRendererTextEngine(renderer.get()), TTF_DestroyRendererTextEngine),
       _rect(rect)
 {
 	assert(renderer);

--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -355,7 +355,7 @@ static BOOL FileFlushFileBuffers(HANDLE hFile)
 	// See: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers
 	if ((pFile->dwOpenMode & GENERIC_WRITE) == 0)
 	{
-		SetLastError(STATUS_ACCESS_DENIED);
+		SetLastError(ERROR_ACCESS_DENIED);
 		return FALSE;
 	}
 

--- a/winpr/libwinpr/file/test/TestFileWriteFile.c
+++ b/winpr/libwinpr/file/test/TestFileWriteFile.c
@@ -28,20 +28,15 @@ static BOOL get_tmp(char* path, size_t len)
 	strncmp(path, template, strnlen_s(template, len) + 1);
 	if (!mktemp_s(path))
 		return FALSE;
-	strcat_s(path, len, "\\testfile");
-	if (strnlen_s(path, len) + 10 > len)
-		return FALSE;
+	return winpr_str_append("testfile", path, len, "\\");
 #else
 	const char template[] = "/tmp/tmpdir.XXXXXX";
 	if (!strncpy(path, template, strnlen(template, len) + 1))
 		return FALSE;
 	if (!mkdtemp(path))
 		return FALSE;
-	if (strnlen(path, len) + 10 > len)
-		return FALSE;
-	strcat(path, "/testfile");
+	return winpr_str_append("testfile", path, len, "/");
 #endif
-	return TRUE;
 }
 
 static BOOL test_write(const char* filename, const char* data, size_t datalen)


### PR DESCRIPTION
use correct destroy function.

https://github.com/libsdl-org/SDL_ttf/issues/551