### PR TITLE
[channel,drive] Add DELETE_PENDING Flag in drive_file_free

### DIFF
--- a/channels/drive/client/drive_file.c
+++ b/channels/drive/client/drive_file.c
@@ -374,6 +374,9 @@ BOOL drive_file_free(DRIVE_FILE* file)
 		file->find_handle = INVALID_HANDLE_VALUE;
 	}
 
+	if (file->CreateOptions & FILE_DELETE_ON_CLOSE)
+		file->delete_pending = TRUE;
+
 	if (file->delete_pending)
 	{
 		if (file->is_dir)


### PR DESCRIPTION
When opening Excel or PowerPoint files, a hidden temporary file (e.g., ~$filename.xlsx) is created in the same directory.
Typically, this temporary file is automatically deleted when the original file is closed.
However, in the current implementation, the temporary file remains after closing, which is not expected behavior.

To address the issue, I referred to section 4.3.5: [Closing a Handle (IRP_MJ_CLEANUP)](https://go.microsoft.com/fwlink/?LinkId=140636) in the Microsoft documentation and implemented the missing cleanup logic accordingly.

Please review the changes in this pull request.