### PR TITLE
[rdpsnd/server] skip sending of formats if no formats specified yet

### DIFF
--- a/channels/rdpsnd/server/rdpsnd_main.c
+++ b/channels/rdpsnd/server/rdpsnd_main.c
@@ -59,6 +59,9 @@ static UINT rdpsnd_server_send_formats(RdpsndServerContext* context)
 	BOOL status = FALSE;
 	ULONG written = 0;
 
+	if (context->num_server_formats == 0)
+		return CHANNEL_RC_OK;
+
 	if (!Stream_EnsureRemainingCapacity(s, 24))
 		return ERROR_OUTOFMEMORY;
 


### PR DESCRIPTION
... which prevents sending a problematic PDU, while allowing for more flexibility when using the server API