### PR TITLE
feat: add login through MS identity broker via sso-mib interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,6 @@ else()
 endif()
 
 if(WITH_SSO_MIB)
-  set(SSO_MIB_EXTERNAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/sso-mib")
   find_package(SSO_MIB REQUIRED)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@
 # Copyright 2011 Otavio Salvador <otavio@ossystems.com.br>
 # Copyright 2011 Marc-Andre Moreau <marcandre.moreau@gmail.com>
 # Copyright 2012 HP Development Company, LLC
+# Copyright 2025 Siemens
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -400,6 +401,17 @@ endif()
 
 if(NOT WITHOUT_FREERDP_3x_DEPRECATED)
   find_feature(Wayland ${WAYLAND_FEATURE_TYPE} ${WAYLAND_FEATURE_PURPOSE} ${WAYLAND_FEATURE_DESCRIPTION})
+endif()
+
+if(UNIX)
+  option(WITH_SSO_MIB "Build with sso-mib support" OFF)
+else()
+  set(WITH_SSO_MIB OFF CACHE INTERNAL "unsupported platform")
+endif()
+
+if(WITH_SSO_MIB)
+  set(SSO_MIB_EXTERNAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/sso-mib")
+  find_package(SSO_MIB REQUIRED)
 endif()
 
 option(WITH_LIBRESSL "build with LibreSSL" OFF)

--- a/client/common/CMakeLists.txt
+++ b/client/common/CMakeLists.txt
@@ -55,15 +55,17 @@ endif()
 
 include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
 
+addtargetwithresourcefile(${MODULE_NAME} FALSE "${FREERDP_VERSION}" SRCS)
+
 if(WITH_SSO_MIB)
-  set(SSO_MIB_EXTERNAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../external/sso-mib")
+  if(SSO_MIB_EXTERNAL_DIR)
+    add_dependencies(${MODULE_NAME} sso-mib-external)
+  endif()
 
   include_directories(${SSO_MIB_INCLUDE_DIRS})
   add_compile_definitions(WITH_SSO_MIB)
   list(APPEND LIBS ${SSO_MIB_LIBRARIES})
 endif()
-
-addtargetwithresourcefile(${MODULE_NAME} FALSE "${FREERDP_VERSION}" SRCS)
 
 list(APPEND LIBS freerdp winpr)
 

--- a/client/common/CMakeLists.txt
+++ b/client/common/CMakeLists.txt
@@ -2,6 +2,7 @@
 # FreeRDP Client Common
 #
 # Copyright 2012 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+# Copyright 2025 Siemens
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,6 +54,16 @@ if(WITH_FUSE)
 endif()
 
 include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
+
+option(WITH_SSO_MIB "Build with sso-mib support" OFF)
+if(UNIX AND WITH_SSO_MIB)
+  set(SSO_MIB_EXTERNAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../external/sso-mib")
+  find_package(SSO_MIB REQUIRED)
+
+  include_directories(${SSO_MIB_INCLUDE_DIRS})
+  add_compile_definitions(WITH_SSO_MIB)
+  list(APPEND LIBS ${SSO_MIB_LIBRARIES})
+endif()
 
 addtargetwithresourcefile(${MODULE_NAME} FALSE "${FREERDP_VERSION}" SRCS)
 

--- a/client/common/CMakeLists.txt
+++ b/client/common/CMakeLists.txt
@@ -55,10 +55,8 @@ endif()
 
 include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
 
-option(WITH_SSO_MIB "Build with sso-mib support" OFF)
-if(UNIX AND WITH_SSO_MIB)
+if(WITH_SSO_MIB)
   set(SSO_MIB_EXTERNAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../external/sso-mib")
-  find_package(SSO_MIB REQUIRED)
 
   include_directories(${SSO_MIB_INCLUDE_DIRS})
   add_compile_definitions(WITH_SSO_MIB)

--- a/client/common/CMakeLists.txt
+++ b/client/common/CMakeLists.txt
@@ -55,6 +55,10 @@ endif()
 
 include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
 
+if(WITH_SSO_MIB)
+  list(APPEND SRCS sso_mib_tokens.c)
+endif()
+
 addtargetwithresourcefile(${MODULE_NAME} FALSE "${FREERDP_VERSION}" SRCS)
 
 if(WITH_SSO_MIB)

--- a/client/common/sso_mib_tokens.c
+++ b/client/common/sso_mib_tokens.c
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright 2025 Siemens
+ */
+
+#include <sso-mib/sso-mib.h>
+#include <freerdp/crypto/crypto.h>
+#include <winpr/json.h>
+
+#include "sso_mib_tokens.h"
+
+BOOL sso_mib_get_avd_access_token(freerdp* instance, char** token)
+{
+	WINPR_ASSERT(instance);
+	WINPR_ASSERT(instance->context);
+	rdpClientContext* client_context = (rdpClientContext*)instance->context;
+	WINPR_ASSERT(client_context->mibClientWrapper);
+	WINPR_ASSERT(client_context->mibClientWrapper->app);
+	WINPR_ASSERT(token);
+
+	MIBAccount* account = NULL;
+	GSList* scopes = NULL;
+
+	BOOL rc = FALSE;
+	*token = NULL;
+
+	account = mib_client_app_get_account_by_upn(client_context->mibClientWrapper->app, NULL);
+	if (!account)
+	{
+		goto cleanup;
+	}
+
+	scopes = g_slist_append(scopes, g_strdup("https://www.wvd.microsoft.com/.default"));
+
+	MIBPrt* prt = mib_client_app_acquire_token_silent(client_context->mibClientWrapper->app,
+	                                                  account, scopes, NULL, NULL, NULL);
+	if (prt)
+	{
+		const char* access_token = mib_prt_get_access_token(prt);
+		if (access_token)
+		{
+			*token = strdup(access_token);
+		}
+		g_object_unref(prt);
+	}
+
+	rc = TRUE && *token != NULL;
+cleanup:
+	if (account)
+		g_object_unref(account);
+	g_slist_free_full(scopes, g_free);
+	return rc;
+}
+
+BOOL sso_mib_get_rdsaad_access_token(freerdp* instance, const char* scope, const char* req_cnf,
+                                     char** token)
+{
+	WINPR_ASSERT(instance);
+	WINPR_ASSERT(instance->context);
+	rdpClientContext* client_context = (rdpClientContext*)instance->context;
+	WINPR_ASSERT(client_context->mibClientWrapper);
+	WINPR_ASSERT(client_context->mibClientWrapper->app);
+	WINPR_ASSERT(scope);
+	WINPR_ASSERT(token);
+	WINPR_ASSERT(req_cnf);
+
+	GSList* scopes = NULL;
+	WINPR_JSON* json = NULL;
+	MIBPopParams* params = NULL;
+
+	BOOL rc = FALSE;
+	*token = NULL;
+	BYTE* req_cnf_dec = NULL;
+	size_t req_cnf_dec_len = 0;
+
+	scopes = g_slist_append(scopes, g_strdup(scope));
+
+	// Parse the "kid" element from req_cnf
+	crypto_base64_decode(req_cnf, strlen(req_cnf) + 1, &req_cnf_dec, &req_cnf_dec_len);
+	if (!req_cnf_dec)
+	{
+		goto cleanup;
+	}
+
+	json = WINPR_JSON_Parse((const char*)req_cnf_dec);
+	if (!json)
+	{
+		goto cleanup;
+	}
+	WINPR_JSON* prop = WINPR_JSON_GetObjectItem(json, "kid");
+	if (!prop)
+	{
+		goto cleanup;
+	}
+	const char* kid = WINPR_JSON_GetStringValue(prop);
+	if (!kid)
+	{
+		goto cleanup;
+	}
+
+	params = mib_pop_params_new(MIB_AUTH_SCHEME_POP, MIB_REQUEST_METHOD_GET, "");
+	mib_pop_params_set_kid(params, kid);
+	MIBPrt* prt = mib_client_app_acquire_token_interactive(
+	    client_context->mibClientWrapper->app, scopes, MIB_PROMPT_NONE, NULL, NULL, NULL, params);
+	if (prt)
+	{
+		*token = strdup(mib_prt_get_access_token(prt));
+		rc = TRUE;
+		g_object_unref(prt);
+	}
+
+cleanup:
+	if (params)
+		g_object_unref(params);
+	WINPR_JSON_Delete(json);
+	free(req_cnf_dec);
+	g_slist_free_full(scopes, g_free);
+	return rc;
+}

--- a/client/common/sso_mib_tokens.h
+++ b/client/common/sso_mib_tokens.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright 2025 Siemens
+ */
+
+#ifndef FREERDP_CLIENT_COMMON_SSO_MIB_TOKENS_H
+#define FREERDP_CLIENT_COMMON_SSO_MIB_TOKENS_H
+
+#include <freerdp/freerdp.h>
+#include <sso-mib/sso-mib.h>
+
+enum sso_mib_state
+{
+	SSO_MIB_STATE_INIT = 0,
+	SSO_MIB_STATE_FAILED = 1,
+	SSO_MIB_STATE_SUCCESS = 2,
+};
+
+struct MIBClientWrapper
+{
+	MIBClientApp* app;
+	enum sso_mib_state state;
+};
+
+BOOL sso_mib_get_avd_access_token(freerdp* instance, char** token);
+
+BOOL sso_mib_get_rdsaad_access_token(freerdp* instance, const char* scope, const char* req_cnf,
+                                     char** token);
+
+#endif /* FREERDP_CLIENT_COMMON_SSO_MIB_TOKENS_H */

--- a/cmake/FindSSO_MIB.cmake
+++ b/cmake/FindSSO_MIB.cmake
@@ -5,16 +5,35 @@
 # SPDX-FileCopyrightText: Copyright 2025 Siemens
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(PC_SSO_MIB sso-mib>=0.4.0)
+pkg_check_modules(PC_SSO_MIB sso-mib>=0.5.0)
 
 if(PC_SSO_MIB_FOUND)
   find_path(SSO_MIB_INCLUDE_DIR NAMES sso-mib/sso-mib.h HINTS ${PC_SSO_MIB_INCLUDEDIR})
   find_library(SSO_MIB_LIBRARY NAMES sso-mib HINTS ${PC_SSO_MIB_LIBRARYDIR})
+
+  find_package_handle_standard_args(SSO_MIB DEFAULT_MSG SSO_MIB_LIBRARY SSO_MIB_INCLUDE_DIR)
+
+  if(SSO_MIB_FOUND)
+    set(SSO_MIB_LIBRARIES ${SSO_MIB_LIBRARY} ${PC_SSO_MIB_LIBRARIES})
+    set(SSO_MIB_INCLUDE_DIRS ${SSO_MIB_INCLUDE_DIR} ${PC_SSO_MIB_INCLUDE_DIRS})
+  endif()
 else()
-  set(SSO_MIB_ROOT_DIR ${SSO_MIB_EXTERNAL_DIR})
-  message(STATUS "SSO_MIB not found through PkgConfig, trying external ${SSO_MIB_ROOT_DIR}")
-  find_path(SSO_MIB_INCLUDE_DIR NAMES sso-mib/sso-mib.h HINTS ${SSO_MIB_ROOT_DIR}/include)
-  find_library(SSO_MIB_LIBRARY NAMES sso-mib HINTS ${SSO_MIB_ROOT_DIR}/lib)
+  include(ExternalProject)
+  set(SSO_MIB_EXTERNAL_DIR ${CMAKE_BINARY_DIR}/sso-mib-external)
+
+  set(SSO_MIB_URL https://github.com/siemens/sso-mib.git)
+  set(SSO_MIB_VERSION v0.5.0)
+  message(STATUS "Adding sso-mib as ExternalProject from ${SSO_MIB_URL}, version ${SSO_MIB_VERSION}")
+
+  ExternalProject_Add(
+    sso-mib-external GIT_REPOSITORY ${SSO_MIB_URL} GIT_TAG ${SSO_MIB_VERSION} PREFIX ${SSO_MIB_EXTERNAL_DIR}
+    SOURCE_DIR ${SSO_MIB_EXTERNAL_DIR}/src BINARY_DIR ${SSO_MIB_EXTERNAL_DIR}/build TMP_DIR _deps/tmp
+    STAMP_DIR _deps/stamp CONFIGURE_COMMAND meson setup --prefix=${SSO_MIB_EXTERNAL_DIR}/install --libdir=lib/
+                                            ${SSO_MIB_EXTERNAL_DIR}/build ${SSO_MIB_EXTERNAL_DIR}/src
+    BUILD_COMMAND meson compile -C ${SSO_MIB_EXTERNAL_DIR}/build INSTALL_COMMAND meson install -C
+                                                                                 ${SSO_MIB_EXTERNAL_DIR}/build
+    UPDATE_COMMAND "" BUILD_BYPRODUCTS ${SSO_MIB_EXTERNAL_DIR}/install/lib/libsso-mib.so
+  )
 
   # Dependencies
   pkg_check_modules(GLIB REQUIRED glib-2.0)
@@ -25,13 +44,9 @@ else()
     set(PC_SSO_MIB_INCLUDE_DIRS ${GLIB_INCLUDE_DIRS} ${GIO_INCLUDE_DIRS} ${JSON_GLIB_INCLUDE_DIRS} ${UUID_INCLUDE_DIRS})
     set(PC_SSO_MIB_LIBRARIES ${GLIB_LIBRARIES} ${GIO_LIBRARIES} ${JSON_GLIB_LIBRARIES} ${UUID_LIBRARIES})
   endif()
-endif()
 
-find_package_handle_standard_args(SSO_MIB DEFAULT_MSG SSO_MIB_LIBRARY SSO_MIB_INCLUDE_DIR)
-
-if(SSO_MIB_FOUND)
-  set(SSO_MIB_LIBRARIES ${SSO_MIB_LIBRARY} ${PC_SSO_MIB_LIBRARIES})
-  set(SSO_MIB_INCLUDE_DIRS ${SSO_MIB_INCLUDE_DIR} ${PC_SSO_MIB_INCLUDE_DIRS})
+  set(SSO_MIB_INCLUDE_DIRS ${SSO_MIB_EXTERNAL_DIR}/install/include ${PC_SSO_MIB_INCLUDE_DIRS})
+  set(SSO_MIB_LIBRARIES ${SSO_MIB_EXTERNAL_DIR}/install/lib/libsso-mib.so ${PC_SSO_MIB_LIBRARIES})
 endif()
 
 mark_as_advanced(SSO_MIB_INCLUDE_DIR SSO_MIB_LIBRARY)

--- a/cmake/FindSSO_MIB.cmake
+++ b/cmake/FindSSO_MIB.cmake
@@ -1,0 +1,37 @@
+# - Find sso-mib
+# Find the sso-mib library
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright 2025 Siemens
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PC_SSO_MIB sso-mib>=0.4.0)
+
+if(PC_SSO_MIB_FOUND)
+  find_path(SSO_MIB_INCLUDE_DIR NAMES sso-mib/sso-mib.h HINTS ${PC_SSO_MIB_INCLUDEDIR})
+  find_library(SSO_MIB_LIBRARY NAMES sso-mib HINTS ${PC_SSO_MIB_LIBRARYDIR})
+else()
+  set(SSO_MIB_ROOT_DIR ${SSO_MIB_EXTERNAL_DIR})
+  message(STATUS "SSO_MIB not found through PkgConfig, trying external ${SSO_MIB_ROOT_DIR}")
+  find_path(SSO_MIB_INCLUDE_DIR NAMES sso-mib/sso-mib.h HINTS ${SSO_MIB_ROOT_DIR}/include)
+  find_library(SSO_MIB_LIBRARY NAMES sso-mib HINTS ${SSO_MIB_ROOT_DIR}/lib)
+
+  # Dependencies
+  pkg_check_modules(GLIB REQUIRED glib-2.0)
+  pkg_check_modules(GIO REQUIRED gio-2.0)
+  pkg_check_modules(JSON_GLIB REQUIRED json-glib-1.0)
+  pkg_check_modules(UUID REQUIRED uuid)
+  if(GLIB_FOUND AND GIO_FOUND AND JSON_GLIB_FOUND AND UUID_FOUND)
+    set(PC_SSO_MIB_INCLUDE_DIRS ${GLIB_INCLUDE_DIRS} ${GIO_INCLUDE_DIRS} ${JSON_GLIB_INCLUDE_DIRS} ${UUID_INCLUDE_DIRS})
+    set(PC_SSO_MIB_LIBRARIES ${GLIB_LIBRARIES} ${GIO_LIBRARIES} ${JSON_GLIB_LIBRARIES} ${UUID_LIBRARIES})
+  endif()
+endif()
+
+find_package_handle_standard_args(SSO_MIB DEFAULT_MSG SSO_MIB_LIBRARY SSO_MIB_INCLUDE_DIR)
+
+if(SSO_MIB_FOUND)
+  set(SSO_MIB_LIBRARIES ${SSO_MIB_LIBRARY} ${PC_SSO_MIB_LIBRARIES})
+  set(SSO_MIB_INCLUDE_DIRS ${SSO_MIB_INCLUDE_DIR} ${PC_SSO_MIB_INCLUDE_DIRS})
+endif()
+
+mark_as_advanced(SSO_MIB_INCLUDE_DIR SSO_MIB_LIBRARY)

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -3,6 +3,7 @@
  * Client Interface
  *
  * Copyright 2013 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+ * Copyright 2025 Siemens
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +41,8 @@
 #if defined(CHANNEL_ENCOMSP_CLIENT)
 #include <freerdp/client/encomsp.h>
 #endif
+
+typedef struct MIBClientWrapper MIBClientWrapper;
 
 #ifdef __cplusplus
 extern "C"
@@ -136,7 +139,9 @@ extern "C"
 #endif
 		ALIGN64 FreeRDP_TouchContact contacts[FREERDP_MAX_TOUCH_CONTACTS]; /**< (offset 8) */
 		ALIGN64 FreeRDP_PenDevice pens[FREERDP_MAX_PEN_DEVICES];           /**< (offset 9) */
-		UINT64 reserved[128 - 9];                                          /**< (offset 9) */
+
+		ALIGN64 MIBClientWrapper* mibClientWrapper; /**< (offset 10) */
+		UINT64 reserved[128 - 10];                  /**< (offset 10) */
 	};
 
 	/* Common client functions */


### PR DESCRIPTION
This change enables an alternative way of acquiring the necessary access tokens through a local identity broker. In the current implementation, we need to visit URLs twice and paste back the URLs we are redirected to in order to extract authorization codes and ultimately fetch the correct access tokens for RDP (described here: <0>).

As an alternative, MS also provides the Microsoft Authentication Library (MSAL) through which authentication can be handled more or less in the background when we're using a trusted device. In particular, we can request access tokens with the same parameters as we're currently doing through the URL-based scheme.

As the MSAL bindings are not available for C, we implemented a small wrapper library called sso-mib which is available at https://github.com/siemens/sso-mib. This library translates the high-level requests (such as acquire_token_interactive) to respective messages on the D-Bus messaging bus which is used to communicate with the identity broker service on Linux. The library can be built as a .deb package and subsequently be found through PkgConfig mechanisms in CMake.

When sso-mib is not available through pkg-config, it can also be placed in `external/`, with the directory structure looking like the following. `include/` is copied from the root of the sso-mib directory and `lib/` populated with the built shared library files and symlinks.

    external/
    ├── README
    └── sso-mib
        ├── include
        │   └── sso-mib
        │       ├── mib-account.h
        │       ├── mib-client-app.h
        │       ├── mib-exports.h
        │       ├── mib-pop-params.h
        │       ├── mib-prt.h
        │       ├── mib-prt-sso-cookie.h
        │       └── sso-mib.h
        └── lib
            ├── libsso-mib.so -> libsso-mib.so.0
            ├── libsso-mib.so.0 -> libsso-mib.so.0.4.0
            └── libsso-mib.so.0.4.0

This feature is currently hidden behind a configuration switch and must be enabled via `-DWITH_SSO_MIB=ON`. If the connection to the broker fails (for example, if no identity broker is installed or running on the system), we automatically fall back to the current scheme of copy-pasting URLs.

<0>: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/e967ebeb-9e9f-443e-857a-5208802943c2

If the communication with the identity broker is successful, you should not need to copy and paste URLs anymore, but instead the identity broker should open a window on the first connection attempt, asking for your password, and then ask for confirmation to allow the remote connection:

![Screenshot 2025-05-19 090115](https://github.com/user-attachments/assets/40c3ca66-b79d-4d12-9512-645b2ee5bd08)
![Screenshot 2025-05-19 090135](https://github.com/user-attachments/assets/7e7605d3-3705-4434-86a4-f797ef3b3669)

Once the connection to the same machine has been accepted, subsequent logins should require no interaction at all as the identity broker caches the token and provides it on request.
