### PR TITLE
[channel,drive]  Fix failure when renaming non-empty directories

### DIFF
--- a/channels/drive/client/drive_file.c
+++ b/channels/drive/client/drive_file.c
@@ -755,7 +755,10 @@ BOOL drive_file_set_information(DRIVE_FILE* file, UINT32 FsInformationClass, UIN
 			/* http://msdn.microsoft.com/en-us/library/cc232098.aspx */
 			/* http://msdn.microsoft.com/en-us/library/cc241371.aspx */
 			if (file->is_dir && !PathIsDirectoryEmptyW(file->fullpath))
-				break; /* TODO: SetLastError ??? */
+			{
+				SetLastError(ERROR_DIR_NOT_EMPTY);
+				return FALSE;
+			}
 
 			if (Length)
 			{

--- a/channels/drive/client/drive_main.c
+++ b/channels/drive/client/drive_main.c
@@ -122,6 +122,10 @@ static NTSTATUS drive_map_windows_err(DWORD fs_errno)
 			rc = STATUS_OBJECT_PATH_NOT_FOUND;
 			break;
 
+		case ERROR_DIR_NOT_EMPTY:
+			rc = STATUS_DIRECTORY_NOT_EMPTY;
+			break;
+
 		default:
 			rc = STATUS_UNSUCCESSFUL;
 			WLog_ERR(TAG, "Error code not found: %" PRIu32 "", fs_errno);
@@ -435,9 +439,6 @@ static UINT drive_process_irp_set_information(DRIVE_DEVICE* drive, IRP* irp)
 	{
 		irp->IoStatus = drive_map_windows_err(GetLastError());
 	}
-
-	if (file && file->is_dir && !PathIsDirectoryEmptyW(file->fullpath))
-		irp->IoStatus = STATUS_DIRECTORY_NOT_EMPTY;
 
 	Stream_Write_UINT32(irp->output, Length);
 


### PR DESCRIPTION
**Issue:**
- When attempting to rename a directory that contains files, a pop-up message saying "Directory is not empty" is shown.

**Contents:**

The rename operation was successfully completed inside MoveFileEx, but the issue occurred afterward in `drive_process_irp_set_information`, where `PathIsDirectoryEmptyW` was called on the renamed path.

However, based on the documentation for [`FILE_RENAME_INFORMATION`](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_file_rename_information), it does not seem necessary to check whether the new path is empty after a rename operation.

Also, according to [4.3.2 Set Delete-on-close using FileDispositionInformation Information Class (IRP_MJ_SET_INFORMATION)](https://go.microsoft.com/fwlink/?LinkId=140636), PathIsDirectoryEmptyW is typically used when deleting a directory, not when renaming it. Therefore, it seems more appropriate to perform the PathIsDirectoryEmptyW check within the context of FileDispositionInformation.

Please refer to it.
