### PR TITLE
[core,rdp] Use a single GetCommonAccessToken variable

### DIFF
--- a/libfreerdp/core/aad.h
+++ b/libfreerdp/core/aad.h
@@ -42,7 +42,6 @@ FREERDP_LOCAL AAD_STATE aad_get_state(rdpAad* aad);
 FREERDP_LOCAL void aad_free(rdpAad* aad);
 
 WINPR_ATTR_MALLOC(aad_free, 1)
-FREERDP_LOCAL rdpAad* aad_new(rdpContext* context, rdpTransport* transport,
-                              pGetCommonAccessToken GetCommonAccessToken);
+FREERDP_LOCAL rdpAad* aad_new(rdpContext* context, rdpTransport* transport);
 
 #endif /* FREERDP_LIB_CORE_AAD_H */

--- a/libfreerdp/core/gateway/arm.c
+++ b/libfreerdp/core/gateway/arm.c
@@ -209,7 +209,8 @@ static wStream* arm_build_http_request(rdpArm* arm, const char* method,
 	{
 		char* token = NULL;
 
-		if (!arm->context->rdp->GetCommonAccessToken)
+		pGetCommonAccessToken GetCommonAccessToken = freerdp_get_common_access_token(arm->context);
+		if (!GetCommonAccessToken)
 		{
 			WLog_Print(arm->log, WLOG_ERROR, "No authorization token provided");
 			goto out;
@@ -218,8 +219,7 @@ static wStream* arm_build_http_request(rdpArm* arm, const char* method,
 		if (!arm_fetch_wellknown(arm))
 			goto out;
 
-		if (!arm->context->rdp->GetCommonAccessToken(arm->context, ACCESS_TOKEN_TYPE_AVD, &token,
-		                                             0))
+		if (!GetCommonAccessToken(arm->context, ACCESS_TOKEN_TYPE_AVD, &token, 0))
 		{
 			WLog_Print(arm->log, WLOG_ERROR, "Unable to obtain access token");
 			goto out;

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -2318,7 +2318,7 @@ static bool rdp_new_common(rdpRdp* rdp)
 			goto fail;
 	}
 
-	rdp->aad = aad_new(rdp->context, rdp->transport, rdp->GetCommonAccessToken);
+	rdp->aad = aad_new(rdp->context, rdp->transport);
 	if (!rdp->aad)
 		goto fail;
 


### PR DESCRIPTION
Only store the callback in rdpRdp and access it only via getter.