### PR TITLE
[core,transport] Fix core dump, when the user context memory is managed by the caller.

### DIFF
--- a/include/freerdp/transport_io.h
+++ b/include/freerdp/transport_io.h
@@ -67,7 +67,8 @@ extern "C"
 		ALIGN64 pTransportLayerFkt Close;
 		ALIGN64 pTransportLayerWait Wait;
 		ALIGN64 pTransportLayerGetEvent GetEvent;
-		UINT64 reserved[64 - 6]; /* Reserve some space for ABI compatibility */
+		ALIGN64 bool callocUserContext;
+		UINT64 reserved[64 - 7]; /* Reserve some space for ABI compatibility */
 	} rdpTransportLayer;
 
 	typedef int (*pTCPConnect)(rdpContext* context, rdpSettings* settings, const char* hostname,

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -1923,6 +1923,7 @@ rdpTransportLayer* transport_layer_new(WINPR_ATTR_UNUSED rdpTransport* transport
 			free(layer);
 			return NULL;
 		}
+		layer->callocUserContext = true;
 	}
 
 	return layer;
@@ -1934,7 +1935,8 @@ void transport_layer_free(rdpTransportLayer* layer)
 		return;
 
 	IFCALL(layer->Close, layer->userContext);
-	free(layer->userContext);
+	if(layer->callocUserContext && layer->userContext)
+        free(layer->userContext);
 	free(layer);
 }
 


### PR DESCRIPTION
Fix core dump, when the user context memory is managed by the caller.
ag:
```
    rdpTransportLayer* layer = nullptr;
    layer = transport_layer_new(freerdp_get_transport(context), 0);
    if (!layer)
        return nullptr;
    layer->userContext = this;
```

The application is core. when close.

It is recommended to modify this interface in the next major version. see: #11639 