### PR TITLE
[core,info] Allow INFO_HIDEF_RAIL_SUPPORTED with RDP version RDP_VERS…

### DIFF
--- a/libfreerdp/core/info.c
+++ b/libfreerdp/core/info.c
@@ -787,7 +787,7 @@ static BOOL rdp_write_info_packet(rdpRdp* rdp, wStream* s)
 	{
 		if (settings->HiDefRemoteApp)
 		{
-			if (settings->RdpVersion >= RDP_VERSION_10_0)
+			if (settings->RdpVersion >= RDP_VERSION_5_PLUS)
 				flags |= INFO_HIDEF_RAIL_SUPPORTED;
 		}
 


### PR DESCRIPTION
…ION_5_PLUS

[MS-RDPBCGR] 2.2.1.11.1.1 Info Packet (TS_INFO_PACKET) states that INFO_HIDEF_RAIL_SUPPORTED is not understood by RDP 4.0, 5.0, 5.1, 5.2, 6.0, 6.1, 7.0, 7.1, and 8.0 servers.
Windows Server 2012 is based on windows 8.1 and already supports the flag.