### PR TITLE
[client,x11]#11658,when size changed of an existing appWindows, except resize the main window, resize it's pixmap also

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -1203,9 +1203,14 @@ void xf_MoveWindow(xfContext* xfc, xfAppWindow* appWindow, int x, int y, int wid
 	appWindow->height = height;
 
 	if (resize)
+	{
+		if (!xf_AppWindowResize(xfc, appWindow))
+			return;
+
 		LogDynAndXMoveResizeWindow(xfc->log, xfc->display, appWindow->handle, x, y,
 		                           WINPR_ASSERTING_INT_CAST(uint32_t, width),
 		                           WINPR_ASSERTING_INT_CAST(uint32_t, height));
+	}
 	else
 		LogDynAndXMoveWindow(xfc->log, xfc->display, appWindow->handle, x, y);
 


### PR DESCRIPTION
[xf_rail_window_common]: fieldFlags=100df00d, windowsId=1b044ad, appWindows=0x7f019c107a40
here, because appWindows is existed, no create occurred.
then in xf_MoveWindow, if size changed, just call LogDynAndXMoveResizeWindow to resize it's main window,
the pixmap not changed.