### PR TITLE
Clear channel error prior to call channel init event proc

### DIFF
--- a/libfreerdp/core/client.c
+++ b/libfreerdp/core/client.c
@@ -881,9 +881,6 @@ UINT freerdp_channels_disconnect(rdpChannels* channels, freerdp* instance)
 			                                            CHANNEL_EVENT_DISCONNECTED, 0, 0);
 		}
 
-		if (getChannelError(instance->context) != CHANNEL_RC_OK)
-			continue;
-
 		pChannelOpenData = &channels->openDataList[index];
 		EventArgsInit(&e, "freerdp");
 		e.name = pChannelOpenData->name;


### PR DESCRIPTION
Each call to `pChannelInitEventProc[Ex]` is checked by `CHANNEL_RC_OK != getChannelError(instance->context)`.

This PR resets error code so it does not leak between different channel event.

For example, when a channel fails at CHANNEL_EVENT_CONNECTED, the channel error state remains when we send the CHANNEL_EVENT_DISCONNECTED. So tt prevents the call of `PubSub_OnChannelDisconnected(instance->context->pubSub, instance->context, &e);` even if everything goes well during that step.