### PR TITLE
[client,common] fix -mouse-motion

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -413,18 +413,12 @@ static BOOL xf_event_VisibilityNotify(xfContext* xfc, const XVisibilityEvent* ev
 	return TRUE;
 }
 
-BOOL xf_generic_MotionNotify(xfContext* xfc, int x, int y, int state, Window window, BOOL app)
+BOOL xf_generic_MotionNotify(xfContext* xfc, int x, int y, Window window, BOOL app)
 {
 	Window childWindow = None;
 
 	WINPR_ASSERT(xfc);
 	WINPR_ASSERT(xfc->common.context.settings);
-
-	if (!freerdp_settings_get_bool(xfc->common.context.settings, FreeRDP_MouseMotion))
-	{
-		if ((state & (Button1Mask | Button2Mask | Button3Mask)) == 0)
-			return TRUE;
-	}
 
 	if (app)
 	{
@@ -474,8 +468,7 @@ static BOOL xf_event_MotionNotify(xfContext* xfc, const XMotionEvent* event, BOO
 	    (xfc->common.mouse_grabbed && freerdp_client_use_relative_mouse_events(&xfc->common)))
 		return TRUE;
 
-	return xf_generic_MotionNotify(xfc, event->x, event->y,
-	                               WINPR_ASSERTING_INT_CAST(int, event->state), event->window, app);
+	return xf_generic_MotionNotify(xfc, event->x, event->y, event->window, app);
 }
 
 BOOL xf_generic_ButtonEvent(xfContext* xfc, int x, int y, int button, Window window, BOOL app,

--- a/client/X11/xf_event.h
+++ b/client/X11/xf_event.h
@@ -37,7 +37,7 @@ void xf_event_SendClientEvent(xfContext* xfc, xfWindow* window, Atom atom, unsig
 void xf_event_adjust_coordinates(xfContext* xfc, int* x, int* y);
 void xf_adjust_coordinates_to_screen(xfContext* xfc, UINT32* x, UINT32* y);
 
-BOOL xf_generic_MotionNotify(xfContext* xfc, int x, int y, int state, Window window, BOOL app);
+BOOL xf_generic_MotionNotify(xfContext* xfc, int x, int y, Window window, BOOL app);
 BOOL xf_generic_RawMotionNotify(xfContext* xfc, int x, int y, Window window, BOOL app);
 BOOL xf_generic_ButtonEvent(xfContext* xfc, int x, int y, int button, Window window, BOOL app,
                             BOOL down);

--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -788,8 +788,8 @@ int xf_input_event(xfContext* xfc, WINPR_ATTR_UNUSED const XEvent* xevent, XIDev
 
 			if (xfc->xi_event)
 			{
-				xf_generic_MotionNotify(xfc, (int)event->event_x, (int)event->event_y,
-				                        event->detail, event->event, xfc->remote_app);
+				xf_generic_MotionNotify(xfc, (int)event->event_x, (int)event->event_y, event->event,
+				                        xfc->remote_app);
 			}
 			break;
 		case XI_RawButtonPress:

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -144,7 +144,8 @@ extern "C"
 		ALIGN64 FreeRDP_PenDevice pens[FREERDP_MAX_PEN_DEVICES];           /**< (offset 9) */
 
 		ALIGN64 MIBClientWrapper* mibClientWrapper; /**< (offset 10) @since version 3.16.0 */
-		UINT64 reserved[129 - 11];                  /**< (offset 11) */
+		ALIGN64 BOOL pressed_buttons[5];            /**< (offset 11) @since version 3.17.0 */
+		UINT64 reserved[129 - 16];                  /**< (offset 16) */
 	};
 
 	/* Common client functions */
@@ -291,9 +292,6 @@ extern "C"
 	FREERDP_API BOOL freerdp_client_pen_cancel_all(rdpClientContext* cctx);
 
 	FREERDP_API BOOL freerdp_client_send_wheel_event(rdpClientContext* cctx, UINT16 mflags);
-
-	FREERDP_API BOOL freerdp_client_send_mouse_event(rdpClientContext* cctx, UINT64 mflags, INT32 x,
-	                                                 INT32 y);
 
 	/** @brief this function checks if relative mouse events are supported and enabled for this
 	 * session.


### PR DESCRIPTION
* Move code to client/common to have it in place for all clients without modification
* Remember if a button was pressed and only suppress move events if no button is pressed.