### PR TITLE
[client,common] fix sso_mib_get_access_token return value in error case

### DIFF
--- a/client/common/sso_mib_tokens.c
+++ b/client/common/sso_mib_tokens.c
@@ -149,7 +149,7 @@ static BOOL sso_mib_get_access_token(rdpContext* context, AccessTokenType tokenT
 	}
 
 	if (!client_context->mibClientWrapper->app)
-		return ERROR_INTERNAL_ERROR;
+		return FALSE;
 
 	const char* scope = NULL;
 	const char* req_cnf = NULL;


### PR DESCRIPTION
Use `FALSE` instead of `ERROR_INTERNAL_ERROR` which could be interpreted as "truthy" at the respective call site.