### PR TITLE
Clean up bugs exposed on systems with high core counts

### DIFF
--- a/libfreerdp/codec/yuv.c
+++ b/libfreerdp/codec/yuv.c
@@ -167,7 +167,8 @@ BOOL yuv_context_reset(YUV_CONTEXT* WINPR_RESTRICT context, UINT32 width, UINT32
 
 	context->width = width;
 	context->height = height;
-	context->heightStep = (height / context->nthreads);
+
+	context->heightStep = height > context->nthreads ? (height / context->nthreads) : 1;
 
 	if (context->useThreads)
 	{

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -29,11 +29,10 @@
 
 #include <winpr/thread.h>
 
-#if defined(__MACOSX__) || defined(__FreeBSD__)
+#if defined(__FreeBSD__)
 #include <pthread_np.h>
 #elif defined(__linux__)
 #include <sys/syscall.h>
-
 #endif
 
 #ifndef MIN
@@ -918,14 +917,13 @@ HANDLE _GetCurrentThread(VOID)
 
 DWORD GetCurrentThreadId(VOID)
 {
-#if defined(__FreeBSD__) || defined(__MACOSX__)
+#if defined(__FreeBSD__)
 	int tid = pthread_getthreadid_np();
 	return tid;
 #elif defined(__linux__)
 	pid_t tid = syscall(SYS_gettid);
 	return tid;
 #else
-#warning Using possibly broken GetCurrentThreadId
 	pthread_t tid = pthread_self();
 	/* Since pthread_t can be 64-bits on some systems, take just the    */
 	/* lower 32-bits of it for the thread ID returned by this function. */

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -918,11 +918,9 @@ HANDLE _GetCurrentThread(VOID)
 DWORD GetCurrentThreadId(VOID)
 {
 #if defined(__FreeBSD__)
-	int tid = WINPR_CXX_COMPAT_CAST(DWORD, pthread_getthreadid_np());
-	return tid;
+	return WINPR_CXX_COMPAT_CAST(DWORD, pthread_getthreadid_np());
 #elif defined(__linux__)
-	pid_t tid = WINPR_CXX_COMPAT_CAST(DWORD, syscall(SYS_gettid));
-	return tid;
+	return WINPR_CXX_COMPAT_CAST(DWORD, syscall(SYS_gettid));
 #else
 	pthread_t tid = pthread_self();
 	/* Since pthread_t can be 64-bits on some systems, take just the    */

--- a/winpr/libwinpr/thread/thread.c
+++ b/winpr/libwinpr/thread/thread.c
@@ -918,10 +918,10 @@ HANDLE _GetCurrentThread(VOID)
 DWORD GetCurrentThreadId(VOID)
 {
 #if defined(__FreeBSD__)
-	int tid = pthread_getthreadid_np();
+	int tid = WINPR_CXX_COMPAT_CAST(DWORD, pthread_getthreadid_np());
 	return tid;
 #elif defined(__linux__)
-	pid_t tid = syscall(SYS_gettid);
+	pid_t tid = WINPR_CXX_COMPAT_CAST(DWORD, syscall(SYS_gettid));
 	return tid;
 #else
 	pthread_t tid = pthread_self();


### PR DESCRIPTION
This PR contains two fixes for issues exposed while building and testing FreeRDP on systems with large numbers of CPU cores ( >=80 experimentally).

The first fixes a case where if the number of CPU cores is greater than the number of lines in a chunk of data to be processed with the `yuv` CODEC, the line skip size would be zero, resulting in a divide by zero error later in the processing.

The second is a fix for how winpr generates a thread ID. In the current upstream code, the thread ID is the 32 LSBs of the pointer to the current thread's `pthread_t` as returned by `pthread_self()`. This would occasionally result in a collision where two (or more) threads would have the same ID, readily reproducible with large numbers of threads when running `TestSynchCritical`. This would result in a thread incorrectly determining it holds a `CRITICAL_SECTION`, and takes the fast path assuming that it is a recursive entry into the `CRITICAL_SECTION`.

This patch replaces the (ab)use of the `pthread_self()` pointer value with an OS-provided (or runtime-provided) thread ID, for Linux, FreeBSD and macOS, For all other cases, the fallback is to XOR the 32 MSBs of the pointer returned from `pthread_self()` with the 32 LSBs, providing a bit more entropy. There is still a (distant) risk of a collision in this case, this probability is vastly diminished.

From my testing, and one other user testing, it looks like this fixes #11721.

Tested on various Linux distributions, FreeBSD 14.3 and macOS 15.