### PR TITLE
core/redirection: Ensure stream has enough space for the certificate

### DIFF
--- a/libfreerdp/core/redirection.c
+++ b/libfreerdp/core/redirection.c
@@ -339,7 +339,7 @@ static BOOL rdp_target_cert_write_element(wStream* s, UINT32 Type, UINT32 Encodi
 	Stream_Write_UINT32(s, Encoding);
 	Stream_Write_UINT32(s, (UINT32)length);
 
-	if (!Stream_CheckAndLogRequiredCapacity(TAG, s, length))
+	if (!Stream_EnsureRemainingCapacity(s, length))
 		return FALSE;
 
 	Stream_Write(s, data, length);


### PR DESCRIPTION
Instead of checking whether enough space for the certificate is available, simply use Stream_EnsureRemainingCapacity() to extend the buffer size if needed. Otherwise, server redirection might fail despite having a valid certificate.

See also: https://gitlab.gnome.org/GNOME/gnome-remote-desktop/-/issues/274

CC: @joantolo