### PR TITLE
Add extract_chain_from_pem function for getting cert chain

### DIFF
--- a/libfreerdp/crypto/certificate.c
+++ b/libfreerdp/crypto/certificate.c
@@ -1335,19 +1335,23 @@ fail:
 	return NULL;
 }
 
-static STACK_OF(X509)* extract_chain_from_pem(const char* pem)
+static STACK_OF(X509)* extract_chain_from_pem(const char* pem, BOOL isFile)
 {
 	if (!pem)
 	{
 		return NULL;
 	}
 
-	BIO* bio = BIO_new_mem_buf(pem, strlen(pem));
+	BIO* bio = NULL;
+	if (isFile)
+		bio = BIO_new_file(pem, "rb");
+	else
+		bio = BIO_new_mem_buf(pem, strlen(pem));
+
 	if (!bio)
 	{
 		return NULL;
 	}
-
 
 	X509* leaf = PEM_read_bio_X509(bio, NULL, NULL, NULL);
 	if (!leaf)
@@ -1355,7 +1359,6 @@ static STACK_OF(X509)* extract_chain_from_pem(const char* pem)
 		BIO_free(bio);
 		return NULL;
 	}
-
 
 	STACK_OF(X509)* chain = sk_X509_new_null();
 	if (!chain)
@@ -1381,7 +1384,7 @@ static rdpCertificate* freerdp_certificate_new_from(const char* file, BOOL isFil
 	X509* x509 = x509_utils_from_pem(file, strlen(file), isFile);
 	if (!x509)
 		return NULL;
-	rdpCertificate* cert = freerdp_certificate_new_from_x509(x509, extract_chain_from_pem(file));
+	rdpCertificate* cert = freerdp_certificate_new_from_x509(x509, extract_chain_from_pem(file, isFile));
 	X509_free(x509);
 	return cert;
 }


### PR DESCRIPTION
Based on this issue:
- https://github.com/FreeRDP/FreeRDP/issues/11628

Can anyone of the admins check this PR and say is it's sufficient for fixing this chain being missing from the certificate?
