### PR TITLE
[proxy,modules] ignore bitmap-filter skip remaining

### DIFF
--- a/server/proxy/modules/bitmap-filter/bitmap-filter.cpp
+++ b/server/proxy/modules/bitmap-filter/bitmap-filter.cpp
@@ -389,8 +389,9 @@ static BOOL filter_dyn_channel_intercept(proxyPlugin* plugin, proxyData* pdata, 
 		{
 			if (state->skip(inputDataLength))
 			{
-				WLog_WARN(TAG, "skipping data, but %" PRIuz " bytes left", state->remaining());
-				return FALSE;
+				WLog_DBG(TAG,
+				         "skipping data, but %" PRIuz " bytes left [stream has %" PRIuz " bytes]",
+				         state->remaining(), inputDataLength);
 			}
 
 			if (state->drop())


### PR DESCRIPTION
There might be fragmented packets that need to be dropped. Ignore remaining data on skip.