### PR TITLE
fix: correct server port assignment logic

### DIFF
--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -118,7 +118,7 @@ static BOOL pf_server_get_target_info(rdpContext* context, rdpSettings* settings
 		return FALSE;
 	}
 
-	settings->ServerPort = config->TargetPort > 0 ? 3389 : settings->ServerPort;
+	settings->ServerPort = config->TargetPort > 0 ? config->TargetPort : 3389;
 	return TRUE;
 }
 


### PR DESCRIPTION
Previously, when `config->TargetPort > 0`, the code always set `settings->ServerPort` to 3389， which ignored the user-defined target port. This patch updates the logic to properly assign `config->TargetPort` if it is valid, otherwise fallback to 3389.