### PR TITLE
[winpr,synch] increase timeout for TestSynchCritical

### DIFF
--- a/winpr/libwinpr/synch/test/TestSynchCritical.c
+++ b/winpr/libwinpr/synch/test/TestSynchCritical.c
@@ -8,7 +8,7 @@
 #include <winpr/thread.h>
 #include <winpr/interlocked.h>
 
-#define TEST_SYNC_CRITICAL_TEST1_RUNTIME_MS 50
+#define TEST_SYNC_CRITICAL_TEST1_RUNTIME_MS 100
 #define TEST_SYNC_CRITICAL_TEST1_RUNS 4
 
 static CRITICAL_SECTION critical;


### PR DESCRIPTION
Increase the deadlock detection timeout in TestSynchCritical to accommodate longer runtime on systems with large number of CPUs/threads. The usual test run time when the threads are finishing correctly won't change.

Fixes: https://github.com/FreeRDP/FreeRDP/issues/11800

A note for the future - perhaps the timeout should be scaled based on the number of CPUs, because the number of created threads in the test is based on the number of the CPUs.