### PR TITLE
[channels,drive] tolerate drive_file_set_disposition_information

### DIFF
--- a/channels/drive/client/drive_file.c
+++ b/channels/drive/client/drive_file.c
@@ -775,10 +775,7 @@ static BOOL drive_file_set_disposition_information(DRIVE_FILE* file, UINT32 Leng
 	{
 		const uint32_t expect = 1;
 		if (Length != expect)
-		{
-			WLog_WARN(TAG, "Unexpected Length=%" PRIu32 ", expected %" PRIu32, Length, expect);
-			return FALSE;
-		}
+			WLog_DBG(TAG, "Unexpected Length=%" PRIu32 ", expected %" PRIu32, Length, expect);
 
 		delete_pending = Stream_Get_UINT8(input);
 	}


### PR DESCRIPTION
the length field did change a lot during the eveolution of the protocol. Be lenient on values that might occur as long as they satisfy the basic requirements.