### PR TITLE
fix(winpr): ncrypt_pkcs11: set correct PIV certificate labels

### DIFF
--- a/winpr/libwinpr/ncrypt/ncrypt_pkcs11.c
+++ b/winpr/libwinpr/ncrypt/ncrypt_pkcs11.c
@@ -82,6 +82,11 @@ typedef struct
 	BYTE tag[3];
 } piv_cert_tags_t;
 static const piv_cert_tags_t piv_cert_tags[] = {
+	{ "X.509 Certificate for PIV Authentication", "\x5F\xC1\x05" },
+	{ "X.509 Certificate for Digital Signature", "\x5F\xC1\x0A" },
+	{ "X.509 Certificate for Key Management", "\x5F\xC1\x0B" },
+	{ "X.509 Certificate for Card Authentication", "\x5F\xC1\x01" },
+
 	{ "Certificate for PIV Authentication", "\x5F\xC1\x05" },
 	{ "Certificate for Digital Signature", "\x5F\xC1\x0A" },
 	{ "Certificate for Key Management", "\x5F\xC1\x0B" },


### PR DESCRIPTION
Hi,

I am working on RDP smartcard logon support. I noticed that PIV certificate labels in the `winpr/libwinpr/ncrypt/ncrypt_pkcs11.c` do not match labels specified in the NIST SP 800-73 (section _4.3. Object Identifiers_).

I added new labels that correspond to the values from the specification. FreeRDP fails to construct a container name without this fix. I tested changes on a PIV-compatible smart card: YubiKey 5 Nano.