### PR TITLE
[winpr,sspi] log mechanisms not valid

### DIFF
--- a/winpr/libwinpr/sspi/Negotiate/negotiate.c
+++ b/winpr/libwinpr/sspi/Negotiate/negotiate.c
@@ -717,7 +717,10 @@ static SECURITY_STATUS SEC_ENTRY negotiate_InitializeSecurityContextW(
 			WINPR_ASSERT(pkg->table_w);
 
 			if (!cred->valid)
+			{
+				WLog_DBG(TAG, "Unavailable mechanism: %s", negotiate_mech_name(cred->mech->oid));
 				continue;
+			}
 
 			/* Send an optimistic token for the first valid mechanism */
 			if (!init_context.mech)


### PR DESCRIPTION
Log SSPI mechanisms that are available but not usable due to configuration.