### PR TITLE
[cmake] static build: populate private

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -102,6 +102,9 @@ if(WITH_FUSE)
   freerdp_client_pc_add_requires_private("fuse3")
 endif()
 
+freerdp_client_pc_add_requires_private("freerdp${FREERDP_API_VERSION}")
+freerdp_client_pc_add_library_private("dl;pthread")
+
 list(REMOVE_DUPLICATES FREERDP_CLIENT_PC_REQUIRES_PRIVATE)
 list(JOIN FREERDP_CLIENT_PC_REQUIRES_PRIVATE " " FREERDP_CLIENT_PC_REQUIRES_PRIVATE)
 
@@ -109,6 +112,12 @@ list(REMOVE_DUPLICATES FREERDP_CLIENT_PC_LIBRARY_PRIVATE)
 list(JOIN FREERDP_CLIENT_PC_LIBRARY_PRIVATE " -l" FREERDP_CLIENT_PC_LIBRARY_PRIVATE)
 if(FREERDP_CLIENT_PC_LIBRARY_PRIVATE)
   string(PREPEND FREERDP_CLIENT_PC_LIBRARY_PRIVATE "-l")
+endif()
+
+# Do not set Requires.Private if not a static build
+if(BUILD_SHARED_LIBS)
+  set(FREERDP_CLIENT_PC_REQUIRES_PRIVATE "")
+  set(FREERDP_CLIENT_PC_LIBRARY_PRIVATE "")
 endif()
 
 include(pkg-config-install-prefix)

--- a/client/freerdp-client.pc.in
+++ b/client/freerdp-client.pc.in
@@ -9,7 +9,7 @@ Description: FreeRDP: A Remote Desktop Protocol Implementation
 URL: http://www.freerdp.com/
 Version: @FREERDP_VERSION@
 Requires: 
-Requires.private: @WINPR_PKG_CONFIG_FILENAME@ freerdp@FREERDP_VERSION_MAJOR@ @FREERDP_CLIENT_PC_REQUIRES_PRIVATE@
+Requires.private: @FREERDP_CLIENT_PC_REQUIRES_PRIVATE@
 Libs: -L${libdir} ${libs}
-Libs.private: -ldl -lpthread @FREERDP_CLIENT_PC_LIBRARY_PRIVATE@
+Libs.private: @FREERDP_CLIENT_PC_LIBRARY_PRIVATE@
 Cflags: -I${includedir}

--- a/libfreerdp/CMakeLists.txt
+++ b/libfreerdp/CMakeLists.txt
@@ -268,6 +268,8 @@ set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "FreeRDP/libfreerdp")
 
 include(pkg-config-install-prefix)
 
+freerdp_pc_add_requires_private(winpr${FREERDP_API_VERSION})
+
 list(REMOVE_DUPLICATES FREERDP_PC_REQUIRES_PRIVATE)
 list(JOIN FREERDP_PC_REQUIRES_PRIVATE " " FREERDP_PC_REQUIRES_PRIVATE)
 
@@ -276,6 +278,13 @@ list(JOIN FREERDP_PC_LIBRARY_PRIVATE " -l" FREERDP_PC_LIBRARY_PRIVATE)
 if(FREERDP_PC_LIBRARY_PRIVATE)
   string(PREPEND FREERDP_PC_LIBRARY_PRIVATE "-l")
 endif()
+
+# Do not set Requires.Private if not a static build
+if(BUILD_SHARED_LIBS)
+  set(FREERDP_PC_REQUIRES_PRIVATE "")
+  set(FREERDP_PC_LIBRARY_PRIVATE "")
+endif()
+
 cleaning_configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/freerdp.pc.in ${CMAKE_CURRENT_BINARY_DIR}/freerdp${FREERDP_VERSION_MAJOR}.pc @ONLY
 )

--- a/libfreerdp/freerdp.pc.in
+++ b/libfreerdp/freerdp.pc.in
@@ -14,7 +14,7 @@ Description: FreeRDP: A Remote Desktop Protocol Implementation
 URL: http://www.freerdp.com/
 Version: @FREERDP_VERSION@
 Requires: 
-Requires.private: winpr@FREERDP_API_VERSION@ @FREERDP_PC_REQUIRES_PRIVATE@
+Requires.private: @FREERDP_PC_REQUIRES_PRIVATE@
 Libs: -L${libdir} ${libs}
-Libs.private: -L${plugindir} -ldl -lpthread @FREERDP_PC_LIBRARY_PRIVATE@
+Libs.private: -L${plugindir} @FREERDP_PC_LIBRARY_PRIVATE@
 Cflags: -I${includedir}

--- a/rdtk/templates/CMakeLists.txt
+++ b/rdtk/templates/CMakeLists.txt
@@ -35,6 +35,11 @@ cleaning_configure_file(
 cleaning_configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/../include/rdtk/config.h)
 
 if(NOT RDTK_FORCE_STATIC_BUILD)
+  # Do not set Requires.Private if not a static build
+  if(NOT BUILD_SHARED_LIBS)
+    set(RDTK_PC_REQUIRES_PRIVATE "winpr${WINPR_VERSION_MAJOR} libssl")
+    set(RDTK_PC_LIBRARY_PRIVATE "")
+  endif()
   cleaning_configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/rdtk.pc.in ${CMAKE_CURRENT_BINARY_DIR}/rdtk${RDTK_VERSION_MAJOR}.pc @ONLY
   )

--- a/rdtk/templates/rdtk.pc.in
+++ b/rdtk/templates/rdtk.pc.in
@@ -9,7 +9,7 @@ Description: rdtk:
 URL: http://www.freerdp.com/
 Version: @RDTK_VERSION@
 Requires:
-Requires.private: winpr@WINPR_VERSION_MAJOR@
+Requires.private: @RDTK_PC_REQUIRES_PRIVATE@
 Libs: -L${libdir} ${libs}
-Libs.private: 
+Libs.private: @RDTK_PC_LIBRARY_PRIVATE@
 Cflags: -I${includedir}

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -77,6 +77,12 @@ foreach(FREERDP_SERVER ${FREERDP_EXTRA_SERVERS})
   add_subdirectory(${FREERDP_SERVER})
 endforeach()
 
+# Do not set Requires.Private if not a static build
+if(NOT BUILD_SHARED_LIBS)
+  set(FREERDP_SERVER_PC_REQUIRES_PRIVATE "freerdp${FREERDP_API_VERSION}")
+  set(FREERDP_SERVER_PC_LIBRARY_PRIVATE "-ldl -lpthread")
+endif()
+
 include(pkg-config-install-prefix)
 cleaning_configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/freerdp-server.pc.in

--- a/server/freerdp-server.pc.in
+++ b/server/freerdp-server.pc.in
@@ -9,7 +9,7 @@ Description: FreeRDP: A Remote Desktop Protocol Implementation
 URL: http://www.freerdp.com/
 Version: @FREERDP_VERSION@
 Requires: 
-Requires.private: @WINPR_PKG_CONFIG_FILENAME@ freerdp@FREERDP_VERSION_MAJOR@
+Requires.private: @FREERDP_SERVER_PC_REQUIRES_PRIVATE@
 Libs: -L${libdir} ${libs}
-Libs.private: -ldl -lpthread
+Libs.private: @FREERDP_SERVER_PC_LIBRARY_PRIVATE@
 Cflags: -I${includedir}

--- a/server/proxy/CMakeLists.txt
+++ b/server/proxy/CMakeLists.txt
@@ -77,6 +77,12 @@ installwithrpath(
 set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "Server/Proxy")
 
 # pkg-config
+# Do not set Requires.Private if not a static build
+if(NOT BUILD_SHARED_LIBS)
+  set(FREERDP_PROXY_PC_REQUIRES_PRIVATE "freerdp-client${FREERDP_API_VERSION} freerdp-server${FREERDP_API_VERSION}")
+  set(FREERDP_PROXY_PC_LIBS_PRIVATE "-ldl -lpthread")
+endif()
+
 include(pkg-config-install-prefix)
 cleaning_configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/freerdp-proxy.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${MODULE_NAME}${FREERDP_VERSION_MAJOR}.pc

--- a/server/proxy/freerdp-proxy.pc.in
+++ b/server/proxy/freerdp-proxy.pc.in
@@ -9,8 +9,7 @@ Description: FreeRDP: A Remote Desktop Protocol Implementation
 URL: http://www.freerdp.com/
 Version: @FREERDP_VERSION@
 Requires: 
-Requires.private: @WINPR_PKG_CONFIG_FILENAME@ freerdp@FREERDP_VERSION_MAJOR@ freerdp-server@FREERDP_VERSION_MAJOR@ freerdp-client@FREERDP_VERSION_MAJOR@
-
+Requires.private: @FREERDP_PROXY_PC_REQUIRES_PRIVATE@
 Libs: -L${libdir} ${libs}
-Libs.private: -ldl -lpthread
+Libs.private: @FREERDP_PROXY_PC_LIBS_PRIVATE@
 Cflags: -I${includedir}

--- a/server/shadow/CMakeLists.txt
+++ b/server/shadow/CMakeLists.txt
@@ -161,6 +161,12 @@ endif()
 
 set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "Server/shadow")
 
+# Do not set Requires.Private if not a static build
+if(NOT BUILD_SHARED_LIBS)
+  set(FREERDP_SHADOW_PC_REQUIRES_PRIVATE "freerdp${FREERDP_API_VERSION}")
+  set(FREERDP_SHADOW_PC_LIBRARY_PRIVATE "-ldl -lpthread")
+endif()
+
 include(pkg-config-install-prefix)
 cleaning_configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/freerdp-shadow.pc.in

--- a/server/shadow/freerdp-shadow.pc.in
+++ b/server/shadow/freerdp-shadow.pc.in
@@ -9,7 +9,7 @@ Description: FreeRDP: A Remote Desktop Protocol Implementation
 URL: http://www.freerdp.com/
 Version: @FREERDP_VERSION@
 Requires: 
-Requires.private: @WINPR_PKG_CONFIG_FILENAME@ freerdp@FREERDP_API_VERSION@
+Requires.private: @FREERDP_SHADOW_PC_REQUIRES_PRIVATE@
 Libs: -L${libdir} ${libs}
-Libs.private: -ldl -lpthread
+Libs.private: @FREERDP_SHADOW_PC_LIBRARY_PRIVATE@
 Cflags: -I${includedir}

--- a/uwac/templates/CMakeLists.txt
+++ b/uwac/templates/CMakeLists.txt
@@ -37,6 +37,12 @@ cleaning_configure_file(build-config.h.in ${CMAKE_CURRENT_BINARY_DIR}/../include
 cleaning_configure_file(config.h.in ${CMAKE_CURRENT_BINARY_DIR}/../include/uwac/config.h)
 
 if(NOT UWAC_FORCE_STATIC_BUILD)
+  # Do not set Requires.Private if not a static build
+  if(NOT BUILD_SHARED_LIBS)
+    set(UWAC_PC_REQUIRES_PRIVATE "wayland-client xkbcommon freerdp${FREERDP_VERSION_MAJOR}")
+    set(UWAC_PC_LIBRARY_PRIVATE "")
+  endif()
+
   include(pkg-config-install-prefix)
   cleaning_configure_file(uwac.pc.in ${CMAKE_CURRENT_BINARY_DIR}/uwac${UWAC_VERSION_MAJOR}.pc @ONLY)
 

--- a/uwac/templates/uwac.pc.in
+++ b/uwac/templates/uwac.pc.in
@@ -9,7 +9,7 @@ Description: uwac: using wayland as a client
 URL: http://www.freerdp.com/
 Version: @UWAC_VERSION@
 Requires:
-Requires.private: wayland-client xkbcommon freerdp@FREERDP_VERSION_MAJOR@
+Requires.private: @UWAC_PC_REQUIRES_PRIVATE@
 Libs: -L${libdir} ${libs}
-Libs.private: 
+Libs.private: @UWAC_PC_LIBRARY_PRIVATE@
 Cflags: -I${includedir}

--- a/winpr/CMakeLists.txt
+++ b/winpr/CMakeLists.txt
@@ -343,6 +343,14 @@ add_subdirectory(libwinpr)
 list(REMOVE_DUPLICATES WINPR_PC_REQUIRES_PRIVATE)
 list(JOIN WINPR_PC_REQUIRES_PRIVATE " " WINPR_PC_REQUIRES_PRIVATE)
 
+set(WINPR_PC_LIBRARY_PRIVATE "-ldl -lrt -lm -lpthread")
+
+# Do not set Requires.Private if not a static build
+if(BUILD_SHARED_LIBS)
+  set(WINPR_PC_REQUIRES_PRIVATE "")
+  set(WINPR_PC_LIBRARY_PRIVATE "")
+endif()
+
 if(WITH_WINPR_TOOLS)
   add_subdirectory(tools)
 endif()

--- a/winpr/tools/CMakeLists.txt
+++ b/winpr/tools/CMakeLists.txt
@@ -118,6 +118,12 @@ if(WITH_WINPR_TOOLS_CLI)
   add_subdirectory(hash-cli)
 endif()
 
+# Do not set Requires.Private if not a static build
+if(NOT BUILD_SHARED_LIBS)
+  set(WINPR_TOOLS_PC_REQUIRES_PRIVATE "winpr${WINPR_API_VERSION} libssl")
+  set(WINPR_TOOLS_PC_LIBRARY_PRIVATE "crypto")
+endif()
+
 include(pkg-config-install-prefix)
 cleaning_configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/winpr-tools.pc.in ${CMAKE_CURRENT_BINARY_DIR}/winpr-tools${WINPR_TOOLS_VERSION_MAJOR}.pc

--- a/winpr/tools/winpr-tools.pc.in
+++ b/winpr/tools/winpr-tools.pc.in
@@ -9,7 +9,7 @@ Description: WinPR: Windows Portable Runtime
 URL: http://www.freerdp.com/
 Version: @WINPR_TOOLS_VERSION@
 Requires:
-Requires.private: winpr@WINPR_VERSION_MAJOR@ libssl
+Requires.private: @WINPR_TOOLS_PC_REQUIRES_PRIVATE@
 Libs: -L${libdir} ${libs}
-Libs.private: -lcrypto
+Libs.private: @WINPR_TOOLS_PC_LIBRARY_PRIVATE@
 Cflags: -I${includedir}

--- a/winpr/winpr.pc.in
+++ b/winpr/winpr.pc.in
@@ -11,5 +11,5 @@ Version: @WINPR_VERSION@
 Requires:
 Requires.private: @WINPR_PC_REQUIRES_PRIVATE@
 Libs: -L${libdir} ${libs}
-Libs.private: -ldl -lrt -lm -lpthread
+Libs.private: @WINPR_PC_LIBRARY_PRIVATE@
 Cflags: -I${includedir}


### PR DESCRIPTION
in pkg-config files only add Requires.private and Libs.private if we build a static library.