### PR TITLE
[client,sdl2,sdl3] Allow SDL hotkeys to be disabled via JSON config

### DIFF
--- a/client/SDL/SDL2/sdl_kbd.cpp
+++ b/client/SDL/SDL2/sdl_kbd.cpp
@@ -481,37 +481,40 @@ BOOL sdlInput::keyboard_handle_event(const SDL_KeyboardEvent* ev)
 {
 	WINPR_ASSERT(ev);
 	const UINT32 rdp_scancode = sdl_scancode_to_rdp(ev->keysym.scancode);
-	const SDL_Keymod mods = SDL_GetModState();
 
-	if ((mods & _hotkeyModmask) == _hotkeyModmask)
+	if (_hotkeysEnabled)
 	{
-		if (ev->type == SDL_KEYDOWN)
+		const SDL_Keymod mods = SDL_GetModState();
+		if ((mods & _hotkeyModmask) == _hotkeyModmask)
 		{
-			if (ev->keysym.scancode == _hotkeyFullscreen)
+			if (ev->type == SDL_KEYDOWN)
 			{
-				_sdl->update_fullscreen(!_sdl->fullscreen);
-				return TRUE;
-			}
-			if (ev->keysym.scancode == _hotkeyResizable)
-			{
-				_sdl->update_resizeable(!_sdl->resizeable);
-				return TRUE;
-			}
+				if (ev->keysym.scancode == _hotkeyFullscreen)
+				{
+					_sdl->update_fullscreen(!_sdl->fullscreen);
+					return TRUE;
+				}
+				if (ev->keysym.scancode == _hotkeyResizable)
+				{
+					_sdl->update_resizeable(!_sdl->resizeable);
+					return TRUE;
+				}
 
-			if (ev->keysym.scancode == _hotkeyGrab)
-			{
-				keyboard_grab(ev->windowID, !_sdl->grab_kbd);
-				return TRUE;
-			}
-			if (ev->keysym.scancode == _hotkeyDisconnect)
-			{
-				freerdp_abort_connect_context(_sdl->context());
-				return TRUE;
-			}
-			if (ev->keysym.scancode == _hotkeyMinimize)
-			{
-				_sdl->update_minimize();
-				return TRUE;
+				if (ev->keysym.scancode == _hotkeyGrab)
+				{
+					keyboard_grab(ev->windowID, !_sdl->grab_kbd);
+					return TRUE;
+				}
+				if (ev->keysym.scancode == _hotkeyDisconnect)
+				{
+					freerdp_abort_connect_context(_sdl->context());
+					return TRUE;
+				}
+				if (ev->keysym.scancode == _hotkeyMinimize)
+				{
+					_sdl->update_minimize();
+					return TRUE;
+				}
 			}
 		}
 	}
@@ -556,7 +559,9 @@ BOOL sdlInput::mouse_grab(Uint32 windowID, SDL_bool enable)
 }
 
 sdlInput::sdlInput(SdlContext* sdl)
-    : _sdl(sdl), _lastWindowID(UINT32_MAX), _hotkeyModmask(prefToMask())
+    : _sdl(sdl), _lastWindowID(UINT32_MAX),
+      _hotkeysEnabled(SdlPref::instance()->get_bool("EnableHotkeys", true)),
+      _hotkeyModmask(prefToMask())
 {
 	auto list =
 	    freerdp_settings_get_string(_sdl->context()->settings, FreeRDP_KeyboardRemappingList);

--- a/client/SDL/SDL2/sdl_kbd.hpp
+++ b/client/SDL/SDL2/sdl_kbd.hpp
@@ -67,6 +67,7 @@ class sdlInput
 	Uint32 _lastWindowID;
 
 	// hotkey handling
+	bool _hotkeysEnabled;
 	uint32_t _hotkeyModmask; // modifier keys mask
 	uint32_t _hotkeyFullscreen;
 	uint32_t _hotkeyResizable;

--- a/client/SDL/SDL3/sdl_kbd.cpp
+++ b/client/SDL/SDL3/sdl_kbd.cpp
@@ -542,49 +542,57 @@ BOOL sdlInput::keyboard_handle_event(const SDL_KeyboardEvent* ev)
 {
 	WINPR_ASSERT(ev);
 	const UINT32 rdp_scancode = scancode_to_rdp(ev->scancode);
-	const SDL_Keymod mods = SDL_GetModState();
 
-	if ((mods & _hotkeyModmask) == _hotkeyModmask)
+	if (_hotkeysEnabled)
 	{
-		if (ev->type == SDL_EVENT_KEY_DOWN)
-		{
-			if (ev->scancode == _hotkeyFullscreen)
-			{
-				WLog_Print(_sdl->log, WLOG_INFO, "%s+<%s> pressed, toggling fullscreen state",
-				           masktostr(_hotkeyModmask).c_str(), sdl_scancode_name(_hotkeyFullscreen));
-				keyboard_sync_state();
-				return _sdl->update_fullscreen(!_sdl->fullscreen);
-			}
-			if (ev->scancode == _hotkeyResizable)
-			{
-				WLog_Print(_sdl->log, WLOG_INFO, "%s+<%s> pressed, toggling resizeable state",
-				           masktostr(_hotkeyModmask).c_str(), sdl_scancode_name(_hotkeyResizable));
-				keyboard_sync_state();
-				return _sdl->update_resizeable(!_sdl->resizeable);
-			}
+		const SDL_Keymod mods = SDL_GetModState();
 
-			if (ev->scancode == _hotkeyGrab)
+		if ((mods & _hotkeyModmask) == _hotkeyModmask)
+		{
+			if (ev->type == SDL_EVENT_KEY_DOWN)
 			{
-				WLog_Print(_sdl->log, WLOG_INFO, "%s+<%s> pressed, toggling grab state",
-				           masktostr(_hotkeyModmask).c_str(), sdl_scancode_name(_hotkeyGrab));
-				keyboard_sync_state();
-				keyboard_grab(ev->windowID, !_sdl->grab_kbd);
-				return TRUE;
-			}
-			if (ev->scancode == _hotkeyDisconnect)
-			{
-				WLog_Print(_sdl->log, WLOG_INFO, "%s+<%s> pressed, disconnecting RDP session",
-				           masktostr(_hotkeyModmask).c_str(), sdl_scancode_name(_hotkeyDisconnect));
-				keyboard_sync_state();
-				freerdp_abort_connect_context(_sdl->context());
-				return TRUE;
-			}
-			if (ev->scancode == _hotkeyMinimize)
-			{
-				WLog_Print(_sdl->log, WLOG_INFO, "%s+<%s> pressed, minimizing client",
-				           masktostr(_hotkeyModmask).c_str(), sdl_scancode_name(_hotkeyMinimize));
-				keyboard_sync_state();
-				return _sdl->update_minimize();
+				if (ev->scancode == _hotkeyFullscreen)
+				{
+					WLog_Print(_sdl->log, WLOG_INFO, "%s+<%s> pressed, toggling fullscreen state",
+					           masktostr(_hotkeyModmask).c_str(),
+					           sdl_scancode_name(_hotkeyFullscreen));
+					keyboard_sync_state();
+					return _sdl->update_fullscreen(!_sdl->fullscreen);
+				}
+				if (ev->scancode == _hotkeyResizable)
+				{
+					WLog_Print(_sdl->log, WLOG_INFO, "%s+<%s> pressed, toggling resizeable state",
+					           masktostr(_hotkeyModmask).c_str(),
+					           sdl_scancode_name(_hotkeyResizable));
+					keyboard_sync_state();
+					return _sdl->update_resizeable(!_sdl->resizeable);
+				}
+
+				if (ev->scancode == _hotkeyGrab)
+				{
+					WLog_Print(_sdl->log, WLOG_INFO, "%s+<%s> pressed, toggling grab state",
+					           masktostr(_hotkeyModmask).c_str(), sdl_scancode_name(_hotkeyGrab));
+					keyboard_sync_state();
+					keyboard_grab(ev->windowID, !_sdl->grab_kbd);
+					return TRUE;
+				}
+				if (ev->scancode == _hotkeyDisconnect)
+				{
+					WLog_Print(_sdl->log, WLOG_INFO, "%s+<%s> pressed, disconnecting RDP session",
+					           masktostr(_hotkeyModmask).c_str(),
+					           sdl_scancode_name(_hotkeyDisconnect));
+					keyboard_sync_state();
+					freerdp_abort_connect_context(_sdl->context());
+					return TRUE;
+				}
+				if (ev->scancode == _hotkeyMinimize)
+				{
+					WLog_Print(_sdl->log, WLOG_INFO, "%s+<%s> pressed, minimizing client",
+					           masktostr(_hotkeyModmask).c_str(),
+					           sdl_scancode_name(_hotkeyMinimize));
+					keyboard_sync_state();
+					return _sdl->update_minimize();
+				}
 			}
 		}
 	}
@@ -651,7 +659,9 @@ BOOL sdlInput::mouse_grab(Uint32 windowID, bool enable)
 }
 
 sdlInput::sdlInput(SdlContext* sdl)
-    : _sdl(sdl), _lastWindowID(UINT32_MAX), _hotkeyModmask(prefToMask())
+    : _sdl(sdl), _lastWindowID(UINT32_MAX),
+      _hotkeysEnabled(SdlPref::instance()->get_bool("EnableHotkeys", true)),
+      _hotkeyModmask(prefToMask())
 {
 	_hotkeyFullscreen = prefKeyValue("SDL_Fullscreen", SDL_SCANCODE_RETURN);
 	_hotkeyResizable = prefKeyValue("SDL_Resizeable", SDL_SCANCODE_R);

--- a/client/SDL/SDL3/sdl_kbd.hpp
+++ b/client/SDL/SDL3/sdl_kbd.hpp
@@ -71,6 +71,7 @@ class sdlInput
 	Uint32 _lastWindowID;
 
 	// hotkey handling
+	bool _hotkeysEnabled;
 	uint32_t _hotkeyModmask; // modifier keys mask
 	uint32_t _hotkeyFullscreen;
 	uint32_t _hotkeyResizable;


### PR DESCRIPTION
## Summary
Add a new configuration attribute `EnableHotkeys` for the SDL configuration file `sdl-freerdp.json` which defaults to `true`. Setting this to `false` disables hotkey handling for the SDL2 and SDL3 clients.

## Motivation
Hotkeys used by SDL{2,3} clients can interfere with software running on the target host. Allowing those hotkeys to be disabled completely remedies that issue (see #11859).

## How to test
- Create this example configuration file at `$XDG_CONFIG_HOME/freerdp/sdl-freerdp.json`:
   ```json
   {
      "EnableHotkeys": false
   }
   ```
- Connect to a host with the SDL{2,3} client
- No hotkeys are active (for example pressing `R_SHIFT`+`D` doesn't close the client)