### PR TITLE
Azure domain

### DIFF
--- a/client/SDL/SDL3/dialogs/sdl_dialogs.cpp
+++ b/client/SDL/SDL3/dialogs/sdl_dialogs.cpp
@@ -538,7 +538,6 @@ BOOL sdl_auth_dialog_show(const SDL_UserAuthArg* args)
 {
 	const std::vector<std::string> auth = { "Username:        ", "Domain:          ",
 		                                    "Password:        " };
-	const std::vector<std::string> rdsauth = { "Username:        ", "Password:        " };
 	const std::vector<std::string> authPin = { "Device:       ", "PIN:        " };
 	const std::vector<std::string> gw = { "GatewayUsername: ", "GatewayDomain:   ",
 		                                  "GatewayPassword: " };
@@ -551,8 +550,6 @@ BOOL sdl_auth_dialog_show(const SDL_UserAuthArg* args)
 			prompt = authPin;
 			break;
 		case AUTH_RDSTLS:
-			prompt = rdsauth;
-			break;
 		case AUTH_TLS:
 		case AUTH_RDP:
 		case AUTH_NLA:

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -110,24 +110,48 @@ extern "C"
 	typedef BOOL (*pAuthenticate)(freerdp* instance, char** username, char** password,
 	                              char** domain);
 
-	/** \brief Extended authentication callback function pointer definition
+	/** @brief Extended authentication callback function pointer definition
 	 *
-	 * \param instance A pointer to the instance to work on
-	 * \param username A pointer to the username string. On input the current username, on output
-	 * the username that should be used. Must not be NULL.
-	 * \param password A pointer to the password string. On input the current password, on output
-	 * the password that sohould be used. Must not be NULL.
-	 * \param domain A pointer to the domain string. On input the current domain, on output the
-	 * domain that sohould be used. Must not be NULL.
-	 * \param reason The reason the callback was
-	 * called. (e.g. NLA, TLS, RDP, GATEWAY, ...)
+	 *  This function is called whenever not all required credentials have been supplied or the
+	 * supplied credentials were rejected.
 	 *
-	 * \return \b FALSE to abort the connection, \b TRUE otherwise.
-	 * \note To not provide valid credentials and not abort the connection return \b TRUE and empty
-	 * (as in empty string) credentials
+	 * @param instance A pointer to the instance to work on
+	 * @param username A pointer to the username string. On input the current username, on output
+	 *          the username that should be used instead. Must not be NULL.
+	 * @param password A pointer to the password string. On input the current password, on output
+	 *          the password that sohould be used. Must not be NULL.
+	 * @param domain A pointer to the domain string. On input the current domain, on output the
+	 *          domain that sohould be used. Must not be NULL.
+	 * @param reason The reason the callback was called. (e.g. NLA, TLS, RDP, GATEWAY, ...)
+	 *
+	 * @return \b FALSE to abort the connection, \b TRUE otherwise.
+	 *
+	 * @attention All strings are allocated (on input and output) and \ref free needs to be called
+	 *          before replacing the input with the output values.
+	 * @note To not provide valid credentials and not abort the connection return \b TRUE and empty
+	 *          (as in empty string) credentials
 	 */
 	typedef BOOL (*pAuthenticateEx)(freerdp* instance, char** username, char** password,
 	                                char** domain, rdp_auth_reason reason);
+
+	/** @brief Callback to select a smartcard certificate from a list of detected ones.
+	 *
+	 *  This function is called when smartcard authentication (NLA) is used and more than one
+	 * smartcard certificate is detected that could be used. The purpose of this callback is to
+	 * present the user with a list of available options and then return the selection.
+	 *
+	 *  @param instance A pointer to the instance to work on
+	 *  @param cert_list A list of smartcard certificates
+	 *  @param count The number of smartcard certificates in the list
+	 *  @param choice A pointer to an integer that will represent the selected certificate index.
+	 * Must not be \b NULL
+	 *  @param gateway A indicator if the authentication is for a session (\b FALSE) or a gateway
+	 * (\b TRUE)
+	 *
+	 *  @return \b FALSE if the selection was aborted, \b TRUE if a selection was accepted.
+	 *
+	 *  @since version 3.0.0
+	 */
 	typedef BOOL (*pChooseSmartcard)(freerdp* instance, SmartcardCertInfo** cert_list, DWORD count,
 	                                 DWORD* choice, BOOL gateway);
 

--- a/include/freerdp/utils/passphrase.h
+++ b/include/freerdp/utils/passphrase.h
@@ -31,9 +31,46 @@ extern "C"
 {
 #endif
 
-	FREERDP_API int freerdp_interruptible_getc(rdpContext* context, FILE* file);
+	/** @brief Read a single character from a stream.
+	 * This function will check \ref freerdp_shall_disconnect_context and abort when the session
+	 * terminates.
+	 *
+	 * The function will abort on any of <ctrl>+[cdz] or end of stream conditions as well as when
+	 * the RDP session terminates
+	 *
+	 * @param context The RDP context to work on
+	 * @param stream the \ref FILE to read the data from
+	 *
+	 * @return The character read or \ref EOF in case of any failures
+	 */
+	FREERDP_API int freerdp_interruptible_getc(rdpContext* context, FILE* stream);
+
+	/** @brief read a line from \ref stream with (optinal) default value that can be manipulated.
+	 * This function will check \ref freerdp_shall_disconnect_context and abort when the session
+	 * terminates.
+	 *
+	 * @param context The RDP context to work on
+	 * @param lineptr on input a suggested default value, on output the result. Must be an allocated
+	 * string on input, free the memory later with \ref free
+	 * @param size on input the \ref strlen of the suggested default, on output \ref strlen of the
+	 * result
+	 * @param stream the \ref FILE to read the data from
+	 *
+	 * @return \b -1 in case of failure, otherwise \ref strlen of the result
+	 */
 	FREERDP_API SSIZE_T freerdp_interruptible_get_line(rdpContext* context, char** lineptr,
 	                                                   size_t* size, FILE* stream);
+
+	/** @brief similar to \ref freerdp_interruptible_get_line but disables echo to terminal.
+	 *
+	 * @param context The RDP context to work on
+	 * @param prompt The prompt to show to the user
+	 * @param buf A pointer to a buffer that will receive the output
+	 * @param bufsiz The size of the buffer in bytes
+	 * @param from_stdin
+	 *
+	 * @return A pointer to \ref buf containing the password or \ref NULL in case of an error.
+	 */
 	FREERDP_API const char* freerdp_passphrase_read(rdpContext* context, const char* prompt,
 	                                                char* buf, size_t bufsiz, int from_stdin);
 


### PR DESCRIPTION
* Provide a default domain `AzureAD` if no domain was provided via `/d:domain` setting
* Modify `freerdp_interruptible_get_line` so that a suggested value can be provided which can be edited.

this way we can provide a sane default for (most) azure/entra setups while still allowing a user to override the defaults.