### PR TITLE
channels/rdp2tcp: add option to set channel name

### DIFF
--- a/channels/rdp2tcp/client/rdp2tcp_main.c
+++ b/channels/rdp2tcp/client/rdp2tcp_main.c
@@ -43,6 +43,7 @@ typedef struct
 	CHANNEL_ENTRY_POINTS_FREERDP_EX channelEntryPoints;
 	char buffer[16 * 1024];
 	char* commandline;
+	char* channel_name;
 } Plugin;
 
 static int init_external_addin(Plugin* plugin)
@@ -95,6 +96,21 @@ static int init_external_addin(Plugin* plugin)
 	}
 
 	plugin->commandline = _strdup(args->argv[1]);
+
+	char* sep = strstr(plugin->commandline, ":");
+	if (sep)
+	{
+		sep[0] = 0;
+		plugin->channel_name = (sep + 1);
+	}
+	else
+	{
+		plugin->channel_name = RDP2TCP_DVC_CHANNEL_NAME;
+	}
+
+	WLog_DBG(TAG, "Command line: %s", plugin->commandline);
+	WLog_DBG(TAG, "Channel name: %s", plugin->channel_name);
+
 	if (!CreateProcessA(NULL,
 	                    plugin->commandline, // command line
 	                    NULL,                // process security attributes
@@ -270,7 +286,7 @@ static VOID VCAPITYPE VirtualChannelInitEventEx(LPVOID lpUserParam, LPVOID pInit
 			WINPR_ASSERT(plugin);
 			WINPR_ASSERT(plugin->channelEntryPoints.pVirtualChannelOpenEx);
 			if (plugin->channelEntryPoints.pVirtualChannelOpenEx(
-			        pInitHandle, &plugin->openHandle, RDP2TCP_DVC_CHANNEL_NAME,
+			        pInitHandle, &plugin->openHandle, plugin->channel_name,
 			        VirtualChannelOpenEventEx) != CHANNEL_RC_OK)
 				return;
 
@@ -313,7 +329,7 @@ FREERDP_ENTRY_POINT(BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS p
 	}
 
 	CHANNEL_DEF channelDef = { 0 };
-	strncpy(channelDef.name, RDP2TCP_DVC_CHANNEL_NAME, sizeof(channelDef.name));
+	strncpy(channelDef.name, plugin->channel_name, sizeof(channelDef.name));
 	channelDef.options =
 	    CHANNEL_OPTION_INITIALIZED | CHANNEL_OPTION_ENCRYPT_RDP | CHANNEL_OPTION_COMPRESS_RDP;
 

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -672,6 +672,7 @@ BOOL freerdp_client_print_command_line_help_ex(int argc, char** argv,
 #endif
 	printf("Printer Redirection: /printer:<device>,<driver>,[default]\n");
 	printf("TCP redirection: /rdp2tcp:/usr/bin/rdp2tcp\n");
+	printf("TCP redirection with custom channel name: /rdp2tcp:/usr/bin/rdp2tcp:ABCDE\n");
 	printf("\n");
 	printf("Audio Output Redirection: /sound:sys:oss,dev:1,format:1\n");
 	printf("Audio Output Redirection: /sound:sys:alsa\n");

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -393,7 +393,7 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "Pass the hash (restricted admin mode)" },
 	{ "pwidth", COMMAND_LINE_VALUE_REQUIRED, "<width>", NULL, NULL, -1, NULL,
 	  "Physical width of display (in millimeters)" },
-	{ "rdp2tcp", COMMAND_LINE_VALUE_REQUIRED, "<executable path[:arg...]>", NULL, NULL, -1, NULL,
+	{ "rdp2tcp", COMMAND_LINE_VALUE_REQUIRED, "<executable path[:channel_name]>", NULL, NULL, -1, NULL,
 	  "TCP redirection" },
 	{ "reconnect-cookie", COMMAND_LINE_VALUE_REQUIRED, "<base64-cookie>", NULL, NULL, -1, NULL,
 	  "Pass base64 reconnect cookie to the connection" },


### PR DESCRIPTION
Pass it as second arg, after executable path.

rdp2tcp (win server) allow to set custom channel name (default: "rdp2tcp").
After apply this patch FreeRDP will allow to user set custom channel name too.

