### PR TITLE
Align width and height for AVC444 decoding to 32

### DIFF
--- a/libfreerdp/codec/yuv.c
+++ b/libfreerdp/codec/yuv.c
@@ -479,7 +479,7 @@ static void CALLBACK yuv444_combine_work_callback(PTP_CALLBACK_INSTANCE instance
 	const RECTANGLE_16* rect = &param->rect;
 	WINPR_ASSERT(rect);
 
-	const UINT32 alignedWidth = yuv->width + ((yuv->width % 16 != 0) ? 16 - yuv->width % 16 : 0);
+	const UINT32 alignedWidth = yuv->width + ((yuv->width % 32 != 0) ? 32 - yuv->width % 32 : 0);
 	const UINT32 alignedHeight =
 	    yuv->height + ((yuv->height % 16 != 0) ? 16 - yuv->height % 16 : 0);
 


### PR DESCRIPTION
Windows seems to be aligning to 32 in current versions of RDP when sending AVC444 bitstreams. This can be noticed in non-standard resolutions (that are not multiple of 32 after aligning to 16), where the combination of the `AVC444_CHROMAv2` 
bitstream fails because the `nTotalWidth` argument to `general_ChromaV2ToYUV444` is incorrect.

To trigger the issue run the FreeRDP client with the cmd-line argument `/gfx:AVC444` and set a resolution where the width is not a multiple of 32 (even after the width value is aligned to 16). For example, I can reproduce the issue with: `/size:802x600`, `/size:1026x768` or `/size:1282x1024`.

<img width="798" height="603" alt="image" src="https://github.com/user-attachments/assets/3e57b2de-84c1-4812-ab63-afc1ae8b1efe" />

I've reproduced the issue in the following versions of Windows;

- Win11 25H2 (Version 10.0.26200.6584)
- Win10 22H2 (Version 10.0.19045.6332)

The following table shows the value for the first element of `iStride` (the other two elements are that value divided by 2 for a `YUV420` frame) for each resolution. This value appears to be that of the aligned value plus 64. The table shows that the `alignedWidth` that is computed in `yuv444_combine_work_callback` doesn't match that of `iStride` (after adding 64) when the alignment is 16, but it's when it's aligned to 32.

| Width | Height | iStride (0) | alignedWidth (16) | alignedWidth (32) | alignedWidth (16) + 64 | alignedWidth (32) + 64 |
|--------|---------|------------|---------------------|---------------------|---------------------------|---------------------------|
| 800 | 600 | 864 | 800 | 800 | 864 | 864 |
| 1024 | 768 | 1088 | 1024 | 1024 | 1088 | 1088 |
| 1280 | 1024 | 1344 | 1280 | 1280 | 1344 | 1344 |
| 802 | 600 | 896 | 816 | 832 | 880 (x) | 896 |
| 1026 | 768 | 1120 | 1040 | 1056 | 1104 (x) | 1120 |
| 1282 | 1024 | 1376 | 1296 | 1312 | 1360 (x) | 1376 |

# NOTES

- 16-byte alignment was initially introduced in commit 8adc2ba
- BTW, I think the 16-byte aligned values that are currently calculated in `yuv444_combine_work_callback` always match the values in `yuv->width` & `yuv->height` used as input, as they're initialized with the width & height of the surface which are 16-byte aligned in `gdi_CreateSurface` since commit 3d1cec8.
  - That is, I think the code I updated to try and address the issue was not currently necessary, but it now is (to do 32-byte alignment).
  - I also tested a fix updating the alignment used in `gdi_CreateSurface` to set it to 32, which works, but I decided to limit the potential splash damage of this PR by only adjusting the alignment in `yuv444_combine_work_callback`.
- I could not find a reference in the RDP GFX spec that indicates the alignment requirement/change.
  - I wonder if the alignment was always 32 or if this has been a change, as if it was the latter, an alternative approach may be needed to support older versions of Windows as well (`iStride[0] - 64`?)