### PR TITLE
[crypto,x509] add missing OpenSSL include for d2i_RSA_PSS_PARAMS

### DIFF
--- a/libfreerdp/crypto/x509_utils.c
+++ b/libfreerdp/crypto/x509_utils.c
@@ -22,6 +22,7 @@
 #include <openssl/objects.h>
 #include <openssl/x509v3.h>
 #include <openssl/pem.h>
+#include <openssl/rsa.h>
 #include <openssl/err.h>
 
 #include <freerdp/config.h>


### PR DESCRIPTION
This MR fixes build on some platforms by adding a missing OpenSSL include.