### PR TITLE
[channels,rdpei] fix not sending essential touch events

### DIFF
--- a/channels/rdpei/client/rdpei_main.c
+++ b/channels/rdpei/client/rdpei_main.c
@@ -1041,6 +1041,10 @@ static UINT rdpei_add_contact(RdpeiClientContext* context, const RDPINPUT_CONTAC
 
 	EnterCriticalSection(&rdpei->lock);
 	contactPoint = &rdpei->contactPoints[contact->contactId];
+
+	if (contactPoint->dirty && contactPoint->data.contactFlags != contact->contactFlags)
+		rdpei_add_frame(context);
+
 	contactPoint->data = *contact;
 	contactPoint->dirty = TRUE;
 	(void)SetEvent(rdpei->event);


### PR DESCRIPTION
The current RDPEI implementation reads the most recently written buffer value every 20ms and transmits it to RDP. However, this approach misses some events and has two major problems.

First, when sending RDPINPUT_CONTACT_FLAG_UP to RDP, the point coordinate must match with the coordinate of the previous RDPINPUT_CONTACT_FLAG_UPDATE. The `freerdp_handle_touch_up()` function implements this, but in reality, RDPINPUT_CONTACT_FLAG_UPDATE event may not be sent, because it is overwritten by the subsequent RDPINPUT_CONTACT_FLAG_UP, which results in the mismatch of coordinates of UPDATE and UP events. As a consequence, Windows RDP host cancels the touch-and-drag.

Second, when RDPINPUT_CONTACT_FLAG_DOWN is stored in the buffer, it is possible that the subsequent RDPINPUT_CONTACT_FLAG_UPDATE overwrites it before DOWN event is sent.

Below is a video that shows the situation where touch-and-drag is canceled, along with the application log.

![RDPEI-Video](https://github.com/user-attachments/assets/a9d906d9-3990-46fa-89a8-fcf96c3b317b)

```
[10:45:04:735] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contactCount: 1
[10:45:04:735] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: frameOffset: 0x0000000000000014
[10:45:04:735] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].contactId: 0
[10:45:04:735] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].fieldsPresent: 5
[10:45:04:735] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].x: 432
[10:45:04:735] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].y: 309
[10:45:04:735] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].contactFlags: 0x0000001A
[10:45:04:735] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_print_contact_flags]:  RDPINPUT_CONTACT_FLAG_UPDATE
[10:45:04:735] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_print_contact_flags]:  RDPINPUT_CONTACT_FLAG_INRANGE
[10:45:04:735] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_print_contact_flags]:  RDPINPUT_CONTACT_FLAG_INCONTACT
[10:45:04:735] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_send_pdu]: rdpei_send_pdu: eventId: 3 (EVENTID_TOUCH) length: 29 status: 0
[10:45:04:755] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contactCount: 1
[10:45:04:755] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: frameOffset: 0x0000000000000014
[10:45:04:755] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].contactId: 0
[10:45:04:755] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].fieldsPresent: 5
[10:45:04:755] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].x: 425
[10:45:04:755] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].y: 307
[10:45:04:755] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].contactFlags: 0x0000001A
[10:45:04:755] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_print_contact_flags]:  RDPINPUT_CONTACT_FLAG_UPDATE
[10:45:04:755] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_print_contact_flags]:  RDPINPUT_CONTACT_FLAG_INRANGE
[10:45:04:755] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_print_contact_flags]:  RDPINPUT_CONTACT_FLAG_INCONTACT
[10:45:04:755] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_send_pdu]: rdpei_send_pdu: eventId: 3 (EVENTID_TOUCH) length: 29 status: 0
[10:45:04:775] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contactCount: 1
[10:45:04:775] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: frameOffset: 0x0000000000000014
[10:45:04:775] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].contactId: 0
[10:45:04:775] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].fieldsPresent: 5
[10:45:04:775] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].x: 409
[10:45:04:775] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].y: 303
[10:45:04:775] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].contactFlags: 0x0000001A
[10:45:04:775] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_print_contact_flags]:  RDPINPUT_CONTACT_FLAG_UPDATE
[10:45:04:775] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_print_contact_flags]:  RDPINPUT_CONTACT_FLAG_INRANGE
[10:45:04:775] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_print_contact_flags]:  RDPINPUT_CONTACT_FLAG_INCONTACT
[10:45:04:775] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_send_pdu]: rdpei_send_pdu: eventId: 3 (EVENTID_TOUCH) length: 29 status: 0
[10:45:04:795] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contactCount: 1
[10:45:04:795] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: frameOffset: 0x0000000000000014
[10:45:04:795] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].contactId: 0
[10:45:04:795] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].fieldsPresent: 1
[10:45:04:795] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].x: 389
[10:45:04:795] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].y: 298
[10:45:04:795] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_write_touch_frame]: contact[0].contactFlags: 0x00000004
[10:45:04:795] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_print_contact_flags]:  RDPINPUT_CONTACT_FLAG_UP
[10:45:04:795] [19445:708b7000] [DEBUG][com.freerdp.channels.rdpei.client] - [rdpei_send_pdu]: rdpei_send_pdu: eventId: 3 (EVENTID_TOUCH) length: 27 status: 0 
```




