### PR TITLE
[crypto,x509] set comparison function for sk_ASN1_OBJECT_find in EKU check

### DIFF
--- a/libfreerdp/crypto/x509_utils.c
+++ b/libfreerdp/crypto/x509_utils.c
@@ -568,6 +568,17 @@ char* x509_utils_get_issuer(const X509* xcert)
 	return issuer;
 }
 
+static int asn1_object_cmp(const ASN1_OBJECT* const* a, const ASN1_OBJECT* const* b)
+{
+	if (!a || !b)
+		return (a == b) ? 0 : (a ? 1 : -1);
+	
+	if (!*a || !*b)
+		return (*a == *b) ? 0 : (*a ? 1 : -1);
+
+	return OBJ_cmp(*a, *b);
+}
+
 BOOL x509_utils_check_eku(const X509* xcert, int nid)
 {
 	BOOL ret = FALSE;
@@ -585,6 +596,7 @@ BOOL x509_utils_check_eku(const X509* xcert, int nid)
 	if (!oid_stack)
 		return FALSE;
 
+	sk_ASN1_OBJECT_set_cmp_func(oid_stack, asn1_object_cmp);
 	if (sk_ASN1_OBJECT_find(oid_stack, oid) >= 0)
 		ret = TRUE;
 


### PR DESCRIPTION
The `x509_utils_check_eku` function was using sk_ASN1_OBJECT_find() without setting a comparison function, which relies on pointer equality rather than content comparison.

This worked with OpenSSL by coincidence because OBJ_nid2obj() returns pointers to a global singleton table, so comparing the object from X509_get_ext_d2i() against OBJ_nid2obj() happened to match. However, with LibreSSL, objects parsed from certificates may be separate allocations, causing the pointer comparison to fail even when the OID values are identical.

The fix adds an asn1_object_cmp() wrapper function and calls sk_ASN1_OBJECT_set_cmp_func() to enable proper content-based comparison using OBJ_cmp().