### PR TITLE
libfreerdp: remove SIGUSR1 and SIGUSR2 from fatal signals

### DIFF
--- a/libfreerdp/utils/signal.c
+++ b/libfreerdp/utils/signal.c
@@ -145,8 +145,8 @@ static void fatal_handler(int signum)
 
 static const int term_signals[] = { SIGINT, SIGKILL, SIGQUIT, SIGSTOP, SIGTERM };
 
-static const int fatal_signals[] = { SIGABRT,   SIGALRM, SIGBUS,  SIGFPE,  SIGHUP,  SIGILL,
-	                                 SIGSEGV,   SIGTTIN, SIGTTOU, SIGUSR1, SIGUSR2,
+static const int fatal_signals[] = { SIGABRT,   SIGALRM, SIGBUS,  SIGFPE,  SIGHUP,
+	                                 SIGILL,    SIGSEGV, SIGTTIN, SIGTTOU,
 #ifdef SIGPOLL
 	                                 SIGPOLL,
 #endif


### PR DESCRIPTION
Closes #11967 