### PR TITLE
[input, virtualkey] Add Korean keys in XKB_KEYNAME_TABLE

### DIFF
--- a/winpr/libwinpr/input/virtualkey.c
+++ b/winpr/libwinpr/input/virtualkey.c
@@ -415,6 +415,11 @@ static XKB_KEYNAME XKB_KEYNAME_TABLE[] = {
 
 	//	{ "AE13",	VK_BACKSLASH_JP }, // JP
 	//	{ "LVL3",	0x54}
+
+	/* Korean */
+	
+	{ "HNGL", VK_HANGUL },
+	{ "HNCV", VK_HANJA },
 };
 
 const char* GetVirtualKeyName(DWORD vkcode)


### PR DESCRIPTION
This patch adds the missing `HNGL` (Hangul) and `HJCV` (Hanja) key names to the XKB_KEYNAME_TABLE for proper Korean keyboard support.

The reference file `/usr/share/X11/xkb/symbols/kr` includes these key symbols, so they should also be present in the key name table for consistency and full Korean keyboard support.


```
partial function_keys
xkb_symbols "hw_keys" {
    key <HNGL> { [ Hangul       ] };
    key <HJCV> { [ Hangul_Hanja ] };
};
```