### PR TITLE
fix line clipping issue

### DIFF
--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -772,14 +772,6 @@ static BOOL gdi_line_to(rdpContext* context, const LINE_TO_ORDER* lineTo)
 	UINT32 color = 0;
 	HGDI_PEN hPen = NULL;
 	rdpGdi* gdi = context->gdi;
-	INT32 xStart = lineTo->nXStart;
-	INT32 yStart = lineTo->nYStart;
-	INT32 xEnd = lineTo->nXEnd;
-	INT32 yEnd = lineTo->nYEnd;
-	INT32 w = 0;
-	INT32 h = 0;
-	gdi_ClipCoords(gdi->drawing->hdc, &xStart, &yStart, &w, &h, NULL, NULL);
-	gdi_ClipCoords(gdi->drawing->hdc, &xEnd, &yEnd, &w, &h, NULL, NULL);
 
 	if (!gdi_decode_color(gdi, lineTo->penColor, &color, NULL))
 		return FALSE;
@@ -804,8 +796,6 @@ static BOOL gdi_polyline(rdpContext* context, const POLYLINE_ORDER* polyline)
 	HGDI_PEN hPen = NULL;
 	DELTA_POINT* points = NULL;
 	rdpGdi* gdi = context->gdi;
-	INT32 w = 0;
-	INT32 h = 0;
 
 	if (!gdi_decode_color(gdi, polyline->penColor, &color, NULL))
 		return FALSE;
@@ -817,7 +807,6 @@ static BOOL gdi_polyline(rdpContext* context, const POLYLINE_ORDER* polyline)
 	gdi_SetROP2(gdi->drawing->hdc, WINPR_ASSERTING_INT_CAST(int32_t, polyline->bRop2));
 	x = polyline->xStart;
 	y = polyline->yStart;
-	gdi_ClipCoords(gdi->drawing->hdc, &x, &y, &w, &h, NULL, NULL);
 	gdi_MoveToEx(gdi->drawing->hdc, x, y, NULL);
 	points = polyline->points;
 
@@ -825,7 +814,6 @@ static BOOL gdi_polyline(rdpContext* context, const POLYLINE_ORDER* polyline)
 	{
 		x += points[i].x;
 		y += points[i].y;
-		gdi_ClipCoords(gdi->drawing->hdc, &x, &y, &w, &h, NULL, NULL);
 		gdi_LineTo(gdi->drawing->hdc, x, y);
 		gdi_MoveToEx(gdi->drawing->hdc, x, y, NULL);
 	}


### PR DESCRIPTION
Fix incorrect line drawing clipping

before fix:
<img width="1019" height="340" alt="freerdp-before" src="https://github.com/user-attachments/assets/2de95eb7-23e7-45b8-bf5d-81557525b267" />

after fix:
<img width="1021" height="406" alt="freerdp-after" src="https://github.com/user-attachments/assets/75bc738d-448e-4483-8a1b-2a417b277a50" />

This fix remove nonsense clipping from gdi line drawing code.