### PR TITLE
[common,test] Adjust AVC and H264 expectations.

### DIFF
--- a/client/common/test/TestClientRdpFile.c
+++ b/client/common/test/TestClientRdpFile.c
@@ -416,6 +416,12 @@ static bool test_data(const char* json, const void* data, size_t len, bool unche
 	if (!settings || !expect)
 		goto fail;
 
+#ifndef WITH_GFX_H264
+	if (!freerdp_settings_set_bool(expect, FreeRDP_GfxH264, FALSE) ||
+	    !freerdp_settings_set_bool(expect, FreeRDP_GfxAVC444, FALSE) ||
+	    !freerdp_settings_set_bool(expect, FreeRDP_GfxAVC444v2, FALSE))
+		goto fail;
+#endif
 	wLog* log = WLog_Get(__func__);
 	WLog_Print(log, WLOG_INFO, "Test cast '%s'", json);
 	if (freerdp_settings_print_diff(log, WLOG_ERROR, expect, settings))


### PR DESCRIPTION
freerdp_set_connection_type_from_file is called during the test, which sets H264, AVC444 and AVC settings to match the test expectations but only WITH_GFX_H264.

This merge requests adjusts expectations correctly for builds in which that macro is undefined.

Closes #11950, https://launchpad.net/bugs/2132293.
