### PR TITLE
Fix remote credential guard channel loading

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -4860,6 +4860,7 @@ static int parse_command_line(rdpSettings* settings, const COMMAND_LINE_ARGUMENT
 			if (!freerdp_settings_set_bool(settings, FreeRDP_RestrictedAdminModeRequired, enable))
 				return fail_at(arg, COMMAND_LINE_ERROR);
 		}
+#ifndef CHANNEL_RDPEAR_CLIENT
 		CommandLineSwitchCase(arg, "remoteGuard")
 		{
 			if (!freerdp_settings_set_bool(settings, FreeRDP_RemoteCredentialGuard, TRUE))
@@ -4867,6 +4868,7 @@ static int parse_command_line(rdpSettings* settings, const COMMAND_LINE_ARGUMENT
 			if (!freerdp_settings_set_bool(settings, FreeRDP_ExtSecurity, TRUE))
 				return fail_at(arg, COMMAND_LINE_ERROR);
 		}
+#endif
 		CommandLineSwitchCase(arg, "pth")
 		{
 			if (!freerdp_settings_set_bool(settings, FreeRDP_ConsoleSession, TRUE))

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -404,8 +404,10 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "connecting to a buggy server" },
 	{ "restricted-admin", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "restrictedAdmin",
 	  "Restricted admin mode" },
+#ifndef CHANNEL_RDPEAR_CLIENT
 	{ "remoteGuard", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, "remoteGuard",
 	  "Remote guard credentials" },
+#endif
 	{ "rfx", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL, "RemoteFX" },
 	{ "rfx-mode", COMMAND_LINE_VALUE_REQUIRED, "[image|video]", NULL, NULL, -1, NULL,
 	  "RemoteFX mode" },

--- a/include/config/config.h.in
+++ b/include/config/config.h.in
@@ -89,6 +89,7 @@
 #cmakedefine CHANNEL_DRIVE
 #cmakedefine CHANNEL_DRIVE_CLIENT
 #cmakedefine CHANNEL_DRIVE_SERVER
+
 #cmakedefine CHANNEL_ECHO
 #cmakedefine CHANNEL_ECHO_CLIENT
 #cmakedefine CHANNEL_ECHO_SERVER
@@ -134,6 +135,9 @@
 #cmakedefine CHANNEL_RDPECAM
 #cmakedefine CHANNEL_RDPECAM_CLIENT
 #cmakedefine CHANNEL_RDPECAM_SERVER
+#cmakedefine CHANNEL_RDPEAR
+#cmakedefine CHANNEL_RDPEAR_CLIENT
+#cmakedefine CHANNEL_RDPEAR_SERVER
 #cmakedefine CHANNEL_RDPEI
 #cmakedefine CHANNEL_RDPEI_CLIENT
 #cmakedefine CHANNEL_RDPEI_SERVER


### PR DESCRIPTION
This patch fixes the loading of the RCG channel. It also adds a guard so the `/remoteGuard` cmdline doesn't work if the channel is not built in.