### PR TITLE
rdpear: handle basic NTLM commands and fix server-side

### DIFF
--- a/channels/rdpear/common/ndr.c
+++ b/channels/rdpear/common/ndr.c
@@ -216,7 +216,7 @@ BOOL ndr_read_pickle(NdrContext* context, wStream* s)
 	if (!ndr_read_uint32(context, s, &v) || v != 0x20000)
 		return FALSE;
 
-	return ndr_read_uint32(context, s, &v); // padding
+	return TRUE;
 }
 
 BOOL ndr_write_pickle(NdrContext* context, wStream* s)
@@ -227,7 +227,6 @@ BOOL ndr_write_pickle(NdrContext* context, wStream* s)
 	if (!ndr_write_uint32(context, s, 0x20000))
 		return FALSE;
 
-	ndr_write_uint32(context, s, 0); /* padding */
 	return TRUE;
 }
 

--- a/channels/rdpear/common/rdpear-common/rdpear_common.h
+++ b/channels/rdpear/common/rdpear-common/rdpear_common.h
@@ -79,8 +79,9 @@ typedef enum
 	// End NTLM remote calls
 } RemoteGuardCallId;
 
-FREERDP_LOCAL RdpEarPackageType rdpear_packageType_from_name(WinPrAsn1_OctetString* package);
-FREERDP_LOCAL wStream* rdpear_encodePayload(RdpEarPackageType packageType, wStream* payload);
+FREERDP_LOCAL RdpEarPackageType rdpear_packageType_from_name(const WinPrAsn1_OctetString* package);
+WINPR_ATTR_MALLOC(Stream_Free, 1)
+FREERDP_LOCAL wStream* rdpear_encodePayload(BOOL isKerb, wStream* payload);
 
 #define RDPEAR_COMMON_MESSAGE_DECL(V)                                                            \
 	FREERDP_LOCAL BOOL ndr_read_##V(NdrContext* context, wStream* s, const void* hints, V* obj); \

--- a/channels/rdpear/common/test/TestNdrEar.c
+++ b/channels/rdpear/common/test/TestNdrEar.c
@@ -322,7 +322,7 @@ static int TestNdrEarRead(int argc, char* argv[])
 	};
 	size_t sizeofPayload4 = sizeof(payload4);
 #endif
-#if 1
+
 	size_t sizeofPayload4 = 0;
 	BYTE* payload4 = parseHexBlock("03 01 03 01 \
 		04 00 02 00 38 9e ef 6b 0c 00 02 00 18 00 02 00 \
@@ -346,7 +346,6 @@ static int TestNdrEarRead(int argc, char* argv[])
 
 	if (!payload4)
 		goto out;
-#endif
 
 	CreateApReqAuthenticatorReq createApReqAuthenticatorReq = { 0 };
 	s = Stream_StaticInit(&staticS, payload4, sizeofPayload4);

--- a/include/freerdp/peer.h
+++ b/include/freerdp/peer.h
@@ -56,8 +56,18 @@ extern "C"
 	typedef BOOL (*psPeerHasMoreToRead)(freerdp_peer* peer);
 	typedef BOOL (*psPeerClose)(freerdp_peer* peer);
 	typedef void (*psPeerDisconnect)(freerdp_peer* peer);
+
+	/** callback called when we receive remote credential guard credentials during NLA
+	 * @param peer the associated freerdp_peer
+	 * @param logonCreds the KERB_TICKET_LOGON containing the TGT and the host service ticket
+	 * @param suppCreds some MSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL containing NTLM hashes
+	 * @return if the treatment was successful
+	 * @bug before 3.19.0 suppCreds were a pointer to MSV1_0_SUPPLEMENTAL_CREDENTIAL, not
+	 * 		MSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL as now
+	 */
 	typedef BOOL (*psPeerRemoteCredentials)(freerdp_peer* peer, KERB_TICKET_LOGON* logonCreds,
-	                                        MSV1_0_SUPPLEMENTAL_CREDENTIAL* suppCreds);
+	                                        MSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL* suppCreds);
+
 	typedef BOOL (*psPeerCapabilities)(freerdp_peer* peer);
 	typedef BOOL (*psPeerPostConnect)(freerdp_peer* peer);
 	typedef BOOL (*psPeerActivate)(freerdp_peer* peer);

--- a/winpr/include/winpr/secapi.h
+++ b/winpr/include/winpr/secapi.h
@@ -70,6 +70,37 @@ typedef struct
 
 #define MSV1_0_CRED_VERSION_REMOTE 0xffff0002
 
+typedef enum _MSV1_0_CREDENTIAL_KEY_TYPE
+{
+	InvalidCredKey,
+	DeprecatedIUMCredKey,
+	DomainUserCredKey,
+	LocalUserCredKey,
+	ExternallySuppliedCredKey
+} MSV1_0_CREDENTIAL_KEY_TYPE;
+
+#define MSV1_0_CREDENTIAL_KEY_LENGTH 20
+#define MSV1_0_CRED_LM_PRESENT 0x1
+#define MSV1_0_CRED_NT_PRESENT 0x2
+#define MSV1_0_CRED_REMOVED 0x4
+#define MSV1_0_CRED_CREDKEY_PRESENT 0x8
+#define MSV1_0_CRED_SHA_PRESENT 0x10
+
+typedef struct
+{
+	UCHAR Data[MSV1_0_CREDENTIAL_KEY_LENGTH];
+} MSV1_0_CREDENTIAL_KEY, *PMSV1_0_CREDENTIAL_KEY;
+
+typedef struct
+{
+	ULONG Version;
+	ULONG Flags;
+	MSV1_0_CREDENTIAL_KEY CredentialKey;
+	MSV1_0_CREDENTIAL_KEY_TYPE CredentialKeyType;
+	ULONG EncryptedCredsSize;
+	UCHAR EncryptedCreds[1];
+} MSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL, *PMSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL;
+
 #endif /* _WIN32 */
 
 #ifndef KERB_LOGON_FLAG_REDIRECTED


### PR DESCRIPTION
This patch adds the handling of basic NTLM commands. Because there's some mysterious 4 zero bytes after pickle header in Kerberos packets, not present in NTLM commands, the patch also had to rework a bit the packet parsing / forging.

The patch also address a server-side bug when parsing supplemental creds, if the client was sending an empty list, we were considering this as an error.

And finally we also implement the parsing of MSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL. This breaks the public API, anyway this was basically unused (as not parsed before) and the previous API was wrong as what we receive is MSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL not MSV1_0_SUPPLEMENTAL_CREDENTIAL, so I guess the API breakage is ok.