### PR TITLE
rdpecam: fix camera sample grabbing

### DIFF
--- a/channels/rdpecam/client/camera.h
+++ b/channels/rdpecam/client/camera.h
@@ -101,7 +101,10 @@ typedef struct
 	CAM_MEDIA_TYPE_DESCRIPTION currMediaType;
 
 	GENERIC_CHANNEL_CALLBACK* hSampleReqChannel;
-	INT nSampleCredits;
+	CRITICAL_SECTION lock;
+	volatile LONG samplesRequested;
+	wStream* pendingSample;
+	volatile BOOL haveSample;
 	wStream* sampleRespBuffer;
 
 	H264_CONTEXT* h264;


### PR DESCRIPTION
Before this patch we had a behavior where there was a credit of 8 samples that could be sent to the server with no corresponding sample request. So in the right conditions, we were having situations where the server was receiving samples that it has not requested, and so it was dropping them. The visible effect was small artifacts in the camera stream when i-frames where dropped, and more serious ones when the dropped content was containing key frames.

This issue has also been reported when xfreerdp connects on g-r-d as #11990.

This patch reworks the frame grabbing workflow: when the frame grabbing thread calls the sample callback we check if a sample is already pending, waiting to be sent to the server. If that's the case and the camera's input format supports frame dropping we just refresh the pending frame with the new one. If the input format can't drop frames (like with h264 and mjpg) we wait until the current pending frame is sent. So now frames can be sent either when we receive a sample request from the server, or when the sample callback is invoked.