### PR TITLE
[smartcardlogon] Fix off-by-one error in `smartcard_hw_enumerateCerts`

### DIFF
--- a/libfreerdp/core/smartcardlogon.c
+++ b/libfreerdp/core/smartcardlogon.c
@@ -581,8 +581,8 @@ static BOOL smartcard_hw_enumerateCerts(const rdpSettings* settings, LPCWSTR csp
 		if (!scopeStr)
 			goto out;
 
-		(void)_snprintf(scopeStr, readerSz + 5, "\\\\.\\%s\\", reader);
-		scope = ConvertUtf8NToWCharAlloc(scopeStr, readerSz + 5, NULL);
+		(void)_snprintf(scopeStr, readerSz + 6, "\\\\.\\%s\\", reader);
+		scope = ConvertUtf8NToWCharAlloc(scopeStr, readerSz + 6, NULL);
 		free(scopeStr);
 
 		if (!scope)


### PR DESCRIPTION
##### Problem

The `smartcard_hw_enumerateCerts` function has an off-by-one error when constructing the scope string for smartcard readers. The desired format is \\.\ <reader>\ but the trailing backslash was intermittently missing.

For example, we sometimes see:

> [17:03:43:933] [1960:6f437001] [WARN][com.winpr.ncryptp11] - [NCryptP11EnumKeys]: Invalid scope '\\.\Yubico YubiKey OTP+FIDO+CCID'

Note the missing trailing backslash.

##### Root Cause

With reader name "Yubico YubiKey OTP+FIDO+CCID" (31 chars):

- Target string: \\.\ + reader + \ = 36 characters + null = 37 bytes
- Buffer allocated correctly: `malloc(4 + readerSz + 1 + 1)` = 37 bytes ✅ 
- **Bug**: `snprintf(scopeStr, readerSz + 5, ...)` with size=36 can only write 35 chars
    - Truncates the trailing \
    - Null terminates at position 35
    - Position 36 remains uninitialized
    - When `ConvertUtf8NToWCharAlloc(scopeStr, readerSz + 5, NULL)` is called with len=36, it reads the uninitialized byte at position 36. If that byte happened to contain \ (0x5C) from previous allocations, the scope appears correct. Otherwise, the trailing backslash is missing.

##### Fix

Change both size parameters from `readerSz + 5` to `readerSz + 6`:

- `snprintf(scopeStr, readerSz + 6, ...)` now has room for all characters
- `ConvertUtf8NToWCharAlloc(scopeStr, readerSz + 6, NULL)` reads the correct length without accessing uninitialized memory