### PR TITLE
rdpecam: send sample only if it's available

### DIFF
--- a/channels/rdpecam/client/camera_device_main.c
+++ b/channels/rdpecam/client/camera_device_main.c
@@ -451,7 +451,7 @@ static UINT ecam_dev_process_sample_request(CameraDevice* dev, GENERIC_CHANNEL_C
 
 	UINT ret = CHANNEL_RC_OK;
 	stream->samplesRequested++;
-	if (stream->pendingSample)
+	if (stream->haveSample)
 		ret = ecam_dev_send_pending(dev, streamIndex, stream);
 
 	LeaveCriticalSection(&stream->lock);


### PR DESCRIPTION
I have noticed that if a sample request is received from the server before the camera has provided a sample, `stream->pendingSample` has no data yet but its `length` is the one set during initialization (which is equal to `capacity`, 8294400), so it tries to send invalid/incorrect data.

Due to the size of the 'sample' this triggers an assert in `ecam_dev_send_sample_response` when executing: ` Stream_Write(stream->sampleRespBuffer, sample, size);`, as the stream's remaining capacity is not big enough (for the `memcpy` operation).

```
winpr_int_assert(const char * condstr, const char * file, const char * fkt, unsigned __int64 line) Line 30	C
Stream_Write(wStream * _s, const void * _b, unsigned __int64 _n) Line 1159	C
ecam_dev_send_sample_response(CameraDevice * dev, unsigned __int64 streamIndex, const unsigned char * sample, unsigned __int64 size) Line 108	C
ecam_dev_send_pending(CameraDevice * dev, int streamIndex, CameraDeviceStream * stream) Line 155	C
ecam_dev_process_sample_request(CameraDevice * dev, GENERIC_CHANNEL_CALLBACK * hchannel, wStream * s) Line 460	C
ecam_dev_on_data_received(s_IWTSVirtualChannelCallback * pChannelCallback, wStream * data) Line 752	C
```

This issue was introduced in #12041 (commit 32e64c1e98d9218944a054a5046fc012c15f38aa) 
cc @hardening
