### PR TITLE
Fix dead lock in smartcard when using smartcard logon with emulated smartcard

### DIFF
--- a/channels/smartcard/client/smartcard_main.c
+++ b/channels/smartcard/client/smartcard_main.c
@@ -227,6 +227,7 @@ void smartcard_context_free(void* pCtx)
 	/* cancel blocking calls like SCardGetStatusChange */
 	WINPR_ASSERT(pContext->smartcard);
 	smartcard_call_cancel_context(pContext->smartcard->callctx, pContext->hContext);
+	smartcard_call_context_signal_stop(pContext->smartcard->callctx, FALSE);
 
 	if (pContext->IrpQueue)
 	{


### PR DESCRIPTION
When `smartcard_GetStatusChangeW_Call` is called with infinite timeout during smartcard logon,
then we are blocked in this code

```
	for (UINT32 x = 0; x < MAX(1, dwTimeOut);)
	{
		if (call->cReaders > 0)
			memcpy(rgReaderStates, call->rgReaderStates,
			       call->cReaders * sizeof(SCARD_READERSTATEW));
		{
			ret.ReturnCode = wrap(smartcard, SCardGetStatusChangeW, operation->hContext,
			                      MIN(dwTimeOut, dwTimeStep), rgReaderStates, call->cReaders);
		}
		if (ret.ReturnCode != SCARD_E_TIMEOUT)
			break;
		if (WaitForSingleObject(smartcard->stopEvent, 0) == WAIT_OBJECT_0)
			break;
		if (dwTimeOut != INFINITE)
			x += dwTimeStep;
	}
```

`smartcard_context_free` does not have access to "cancel" field used by `smartcard_call_cancel_context`.
So the the lock used by `device_foreach` is not released.

We have to use smartcard_call_context_signal_stop which set the event stopEvent parsed by smartcard_GetStatusChangeW_Call
