### PR TITLE
peer: Disconnect if Logon() returned FALSE

### DIFF
--- a/include/freerdp/peer.h
+++ b/include/freerdp/peer.h
@@ -71,8 +71,21 @@ extern "C"
 	typedef BOOL (*psPeerCapabilities)(freerdp_peer* peer);
 	typedef BOOL (*psPeerPostConnect)(freerdp_peer* peer);
 	typedef BOOL (*psPeerActivate)(freerdp_peer* peer);
+
+	/** @brief Callback after the initial RDP authentication (NLA) succeeded or anonymous tunnel was
+	 * established (RDP, TLS, ...)
+	 *
+	 *  @param peer A pointer to a peer context to work on
+	 *  @param identity A pointer to the identity of the peer
+	 *  @param automatic \b TRUE in case the connection is already authenticated, \b FALSE in case
+	 * of \b RDP, \b TLS or similar anonymous tunnels
+	 *
+	 *  @return \b TRUE if the connection is allowed, \b FALSE if denied. Defaults to \b TRUE if the
+	 * callback is unused.
+	 */
 	typedef BOOL (*psPeerLogon)(freerdp_peer* peer, const SEC_WINNT_AUTH_IDENTITY* identity,
 	                            BOOL automatic);
+
 	typedef BOOL (*psPeerSendServerRedirection)(freerdp_peer* peer,
 	                                            const rdpRedirection* redirection);
 	typedef BOOL (*psPeerAdjustMonitorsLayout)(freerdp_peer* peer);


### PR DESCRIPTION
Returning FALSE implies the client was not authorized, but it does not have any real impact on the connection, other than setting the authorized field.

Change this by disconnecting the client if a Logon() callback returned that a client was not authorized.