### PR TITLE
[channels, rdpecam]: remove breaking ecam_sws_valid check

### DIFF
--- a/channels/rdpecam/client/encoding.c
+++ b/channels/rdpecam/client/encoding.c
@@ -328,8 +328,6 @@ static BOOL ecam_encoder_compress_h264(CameraDeviceStream* stream, const BYTE* s
 	CAM_MEDIA_FORMAT inputFormat = streamInputFormat(stream);
 	enum AVPixelFormat pixFormat = AV_PIX_FMT_NONE;
 
-	if (!ecam_sws_valid(stream))
-		return FALSE;
 
 #if defined(WITH_INPUT_FORMAT_H264)
 	if (inputFormat == CAM_MEDIA_FORMAT_MJPG_H264)


### PR DESCRIPTION
d2d4f449312ddafd4a4c6c8a4f856c7f0d44a3b5 added some additional validity and sanity checking to rdpecam which is all well and good. However, a couple of the added lines have the effect of breaking remote camera over rdpecam (at least in some cases on windows 10). This is because libswscale has not actually been initialized yet so ecam_sws_valid will always be false and the stream is never properly encoded. The same function has code further down to initialize the sws_context, so clearly it was at least previously expected that the sws_context might not yet exist when this was called. So simply delete these two lines which brings the state of this function to be exactly the same as it was before the offending commit. This allows rdpecam to actually work again.
