### PR TITLE
[client,sdl] fix multimon/fullscreen on wayland

### DIFF
--- a/client/SDL/SDL3/sdl_context.cpp
+++ b/client/SDL/SDL3/sdl_context.cpp
@@ -295,7 +295,8 @@ BOOL SdlContext::postConnect(freerdp* instance)
 	if (!sdl->setResizeable(false))
 		return FALSE;
 	if (!sdl->setFullscreen(freerdp_settings_get_bool(context->settings, FreeRDP_Fullscreen) ||
-	                        freerdp_settings_get_bool(context->settings, FreeRDP_UseMultimon)))
+	                            freerdp_settings_get_bool(context->settings, FreeRDP_UseMultimon),
+	                        true))
 		return FALSE;
 	sdl->setConnected(true);
 	return TRUE;
@@ -1379,11 +1380,12 @@ std::vector<SDL_Rect> SdlContext::pop()
 	return val;
 }
 
-bool SdlContext::setFullscreen(bool enter)
+bool SdlContext::setFullscreen(bool enter, bool forceOriginalDisplay)
 {
 	for (const auto& window : _windows)
 	{
-		if (!sdl_push_user_event(SDL_EVENT_USER_WINDOW_FULLSCREEN, &window.second, enter))
+		if (!sdl_push_user_event(SDL_EVENT_USER_WINDOW_FULLSCREEN, &window.second, enter,
+		                         forceOriginalDisplay))
 			return false;
 	}
 	_fullscreen = enter;

--- a/client/SDL/SDL3/sdl_context.hpp
+++ b/client/SDL/SDL3/sdl_context.hpp
@@ -70,7 +70,7 @@ class SdlContext
 
 	[[nodiscard]] bool fullscreen() const;
 	[[nodiscard]] bool toggleFullscreen();
-	[[nodiscard]] bool setFullscreen(bool enter);
+	[[nodiscard]] bool setFullscreen(bool enter, bool forceOriginalDisplay = false);
 
 	[[nodiscard]] bool setMinimized();
 

--- a/client/SDL/SDL3/sdl_utils.cpp
+++ b/client/SDL/SDL3/sdl_utils.cpp
@@ -128,6 +128,10 @@ bool sdl_push_user_event(Uint32 type, ...)
 			event->data1 = va_arg(ap, void*);
 			break;
 		case SDL_EVENT_USER_WINDOW_FULLSCREEN:
+			event->data1 = va_arg(ap, void*);
+			event->code = va_arg(ap, int);
+			event->data2 = reinterpret_cast<void*>(static_cast<uintptr_t>(va_arg(ap, int)));
+			break;
 		case SDL_EVENT_USER_WINDOW_RESIZEABLE:
 			event->data1 = va_arg(ap, void*);
 			event->code = va_arg(ap, int);

--- a/client/SDL/SDL3/sdl_window.hpp
+++ b/client/SDL/SDL3/sdl_window.hpp
@@ -61,7 +61,7 @@ class SdlWindow
 	void setBordered(bool bordered);
 	void raise();
 	void resizeable(bool use);
-	void fullscreen(bool enter);
+	void fullscreen(bool enter, bool forceOriginalDisplay);
 	void minimize();
 
 	[[nodiscard]] bool resize(const SDL_Point& size);
@@ -80,10 +80,11 @@ class SdlWindow
 	void updateSurface();
 
   protected:
-	SdlWindow(const std::string& title, const SDL_Rect& rect, Uint32 flags);
+	SdlWindow(SDL_DisplayID id, const std::string& title, const SDL_Rect& rect, Uint32 flags);
 
   private:
 	SDL_Window* _window = nullptr;
+	SDL_DisplayID _displayID = 0;
 	Sint32 _offset_x = 0;
 	Sint32 _offset_y = 0;
 };


### PR DESCRIPTION
Help SDL identify the display to use for fullscreen even when compositors interfere with window positions. SDL respects the intent of a window if it is moved to the appropriate display just before it is made fullscreen.

When using the /f or /multimon flag, the initial fullscreen request will force the window to go fullscreen on the display that was passed to window creation. Subsequent fullscreen requests do not do that - if the user manually moves a window to a display and requests fullscreen, the window will go fullscreen on the current display.

fix for https://github.com/FreeRDP/FreeRDP/issues/12176

clang-format correctly  reformatted the switch statement in sdl_freedrp.cpp. Turn off whitespace differences to see the actual diff.