### PR TITLE
[client,windows] Fix Ctrl+Alt+Enter fullscreen toggle not working

### DIFF
--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -120,23 +120,18 @@ LRESULT CALLBACK wf_ll_kbd_proc(int nCode, WPARAM wParam, LPARAM lParam)
 
 				input = wfc->common.context.input;
 				rdp_scancode = MAKE_RDP_SCANCODE((BYTE)p->scanCode, p->flags & LLKHF_EXTENDED);
-				/* 修复：此前用扫描码更新/读取 g_keystates，
-				   但组合键判断使用虚拟键码，导致 Ctrl+Alt+Enter 不触发。
-				   统一改为使用虚拟键码索引，保证组合键检测一致。 */
 				keystate = g_keystates[p->vkCode & 0xFF];
 
 				switch (wParam)
 				{
 					case WM_KEYDOWN:
 					case WM_SYSKEYDOWN:
-						/* 修复：按下时按虚拟键码置位，避免扫描码/虚拟键码不一致问题 */
 						if (p->vkCode < 256)
 							g_keystates[p->vkCode] = TRUE;
 						break;
 					case WM_KEYUP:
 					case WM_SYSKEYUP:
 					default:
-						/* 修复：弹起时按虚拟键码清零 */
 						if (p->vkCode < 256)
 							g_keystates[p->vkCode] = FALSE;
 						break;


### PR DESCRIPTION
This patch resolves an issue where the Ctrl+Alt+Enter keyboard shortcut for fullscreen toggling was not consistently registered in the Windows client.

The root cause was a discrepancy in how keyboard states were managed:  was updated using scan codes, but certain combination key detections (like for Ctrl+Alt+Enter) relied on virtual key codes. This mismatch led to the shortcut failing.

The fix standardizes the use of virtual key codes () for both updating and querying the  array, ensuring accurate detection of combination key presses.