### PR TITLE
[client,keyboard] Implement complete keyboard indicator synchronization

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -477,10 +477,14 @@ static BOOL wf_post_connect(freerdp* instance)
 	context->update->BeginPaint = wf_begin_paint;
 	context->update->DesktopResize = wf_desktop_resize;
 	context->update->EndPaint = wf_end_paint;
+	context->update->SetKeyboardIndicators = wf_keyboard_set_indicators;
 	wf_register_pointer(context->graphics);
 
 	wfc->floatbar = wf_floatbar_new(wfc, wfc->hInstance,
 	                                freerdp_settings_get_uint32(settings, FreeRDP_Floatbar));
+
+	wf_event_focus_in(wfc);
+
 	return TRUE;
 }
 

--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -787,6 +787,7 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 
 			g_focus_hWnd = hWnd;
 			freerdp_set_focus(wfc->common.context.instance);
+			wf_event_focus_in(wfc);
 			break;
 
 		case WM_KILLFOCUS:
@@ -965,3 +966,34 @@ static BOOL wf_scale_mouse_event_ex(wfContext* wfc, UINT16 flags, UINT16 buttonM
 	return wf_pub_mouse_event(wfc, flags, px, py);
 }
 #endif
+
+BOOL wf_keyboard_set_indicators(rdpContext* context, UINT16 led_flags)
+{
+	wfContext* wfc = (wfContext*)context;
+	BYTE keyState[256];
+
+	if (!wfc || !GetKeyboardState(keyState))
+		return FALSE;
+
+	if (led_flags & KBD_SYNC_NUM_LOCK)
+		keyState[VK_NUMLOCK] |= 1;
+	else
+		keyState[VK_NUMLOCK] &= ~1;
+
+	if (led_flags & KBD_SYNC_CAPS_LOCK)
+		keyState[VK_CAPITAL] |= 1;
+	else
+		keyState[VK_CAPITAL] &= ~1;
+
+	if (led_flags & KBD_SYNC_SCROLL_LOCK)
+		keyState[VK_SCROLL] |= 1;
+	else
+		keyState[VK_SCROLL] &= ~1;
+
+	if (led_flags & KBD_SYNC_KANA_LOCK)
+		keyState[VK_KANA] |= 1;
+	else
+		keyState[VK_KANA] &= ~1;
+
+	return SetKeyboardState(keyState);
+}

--- a/client/Windows/wf_event.h
+++ b/client/Windows/wf_event.h
@@ -30,6 +30,8 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 
 void wf_event_focus_in(wfContext* wfc);
 
+BOOL wf_keyboard_set_indicators(rdpContext* context, UINT16 led_flags);
+
 #define KBD_TAG CLIENT_TAG("windows")
 #ifdef WITH_DEBUG_KBD
 #define DEBUG_KBD(...) WLog_DBG(KBD_TAG, __VA_ARGS__)


### PR DESCRIPTION
This patch implements a comprehensive synchronization mechanism for keyboard indicators (Num Lock, Caps Lock, Scroll Lock, Kana Lock) between the FreeRDP Windows client and the RDP server.

Key changes include:
- Calling  in the  handler to ensure keyboard state is synchronized when the client window gains focus.
- Implementing the  callback, which allows the RDP server to update the local client's keyboard LED states.
- Registering  in  and performing an initial keyboard state sync immediately after connection establishment.

This resolves issues where local and remote keyboard indicator states could become desynchronized, improving the user experience by ensuring consistent behavior of keyboard LEDs.