### PR TITLE
[client,windows] Correct mouse event send function return value checks

### DIFF
--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -936,7 +936,8 @@ static BOOL wf_scale_mouse_event(wfContext* wfc, UINT16 flags, INT32 x, INT32 y)
 	if (!wf_scale_mouse_pos(wfc, x, y, &px, &py))
 		return FALSE;
 
-	if (freerdp_client_send_button_event(&wfc->common, FALSE, flags, px, py))
+	/* Fix: correct return value check (TRUE means success). */
+	if (!freerdp_client_send_button_event(&wfc->common, FALSE, flags, px, py))
 		return FALSE;
 
 	return wf_pub_mouse_event(wfc, flags, px, py);
@@ -959,7 +960,8 @@ static BOOL wf_scale_mouse_event_ex(wfContext* wfc, UINT16 flags, UINT16 buttonM
 	if (!wf_scale_mouse_pos(wfc, x, y, &px, &py))
 		return FALSE;
 
-	if (freerdp_client_send_extended_button_event(&wfc->common, FALSE, flags, px, py))
+	/* Fix: correct return value check for extended mouse events. */
+	if (!freerdp_client_send_extended_button_event(&wfc->common, FALSE, flags, px, py))
 		return FALSE;
 
 	return wf_pub_mouse_event(wfc, flags, px, py);


### PR DESCRIPTION
This patch corrects an inversion in the return value checks for mouse event sending functions within the FreeRDP Windows client.

The functions  and  are expected to return  on success and  on failure. The original code incorrectly interpreted a successful event transmission as a failure, leading to  and preventing subsequent event processing.

The fix inverts the conditional check (e.g.,  instead of ), ensuring that mouse events are correctly reported as sent or failed, and that the event chain continues as intended. This resolves issues where mouse button events might not have been reliably transmitted to the RDP server.