### PR TITLE
[client,windows] Fix system menu text memory leak

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -328,6 +328,8 @@ static void wf_append_item_to_system_menu(HMENU hMenu, UINT fMask, UINT wID, con
 	if (wfc)
 		item_info.dwItemData = (ULONG_PTR)wfc;
 	InsertMenuItem(hMenu, wfc->systemMenuInsertPosition++, TRUE, &item_info);
+
+	free(item_info.dwTypeData);
 }
 
 static void wf_add_system_menu(wfContext* wfc)


### PR DESCRIPTION
This patch addresses a memory leak in the FreeRDP Windows client related to the system menu text. Previously, the  function was used to copy the window title to the system menu, but the memory allocated for the  was not properly freed after use.

The fix ensures that the memory allocated for the system menu text is freed when  is called, preventing a gradual memory leak that could occur as window titles are updated or sessions are closed. This improves the long-term stability and resource management of the client.