### PR TITLE
[client,windows] Fix premature session exit when closing a RAIL window

### DIFF
--- a/client/Windows/wf_rail.c
+++ b/client/Windows/wf_rail.c
@@ -400,7 +400,6 @@ LRESULT CALLBACK wf_RailWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPara
 			break;
 
 		case WM_DESTROY:
-			PostQuitMessage(0);
 			break;
 
 		default:


### PR DESCRIPTION
### Summary
Historically, `PostQuitMessage(0)` was called in `wf_RailWndProc` upon receiving `WM_DESTROY`, following standard single-window Win32 practices. However, in RAIL (RemoteApp) mode where multiple application windows coexist, this causes the entire client session to terminate whenever any single RemoteApp window is closed.

This patch removes the unnecessary call to ensure session continuity across multiple RAIL windows.

### Changes
- Removed `PostQuitMessage(0)` from the `WM_DESTROY` handler in `wf_RailWndProc` (client/Windows/wf_rail.c).
- This ensures that closing a single RemoteApp window only destroys that specific window instead of sending a `WM_QUIT` signal to the entire application message loop.