### PR TITLE
[client,windows] Add window handle validation in RDP_EVENT_TYPE_WINDOW_NEW

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -454,6 +454,11 @@ static BOOL wf_post_connect(freerdp* instance)
 	{
 		wfc->hwnd = CreateWindowEx(0, wfc->wndClassName, wfc->window_title, dwStyle, 0, 0, 0, 0,
 		                           wfc->hWndParent, NULL, wfc->hInstance, NULL);
+		if (!wfc->hwnd)
+		{
+			WLog_ERR(TAG, "CreateWindowEx failed with error: %lu", GetLastError());
+			return FALSE;
+		}
 		SetWindowLongPtr(wfc->hwnd, GWLP_USERDATA, (LONG_PTR)wfc);
 	}
 


### PR DESCRIPTION
This patch enhances the robustness of the FreeRDP Windows client by adding explicit validation for window handles during the processing of  events.

Specifically, in the  function within , a check () is introduced before attempting to use the newly created window handle. This ensures that subsequent operations on the window (such as updating its properties or registering it with the system) are only performed if a valid window handle was successfully created.

This prevents potential crashes or undefined behavior that could occur if  fails to return a valid window handle, improving the stability of the client when handling new RAIL windows.