### PR TITLE
[client,windows] Implement comprehensive thread safety for event processing

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -1367,6 +1367,8 @@ static BOOL wfreerdp_client_new(freerdp* instance, rdpContext* context)
 	if (!(wfreerdp_client_global_init()))
 		return FALSE;
 
+	wf_event_init();
+
 	WINPR_ASSERT(instance);
 	instance->PreConnect = wf_pre_connect;
 	instance->PostConnect = wf_post_connect;
@@ -1399,6 +1401,8 @@ static void wfreerdp_client_free(freerdp* instance, rdpContext* context)
 	WINPR_UNUSED(instance);
 	if (!context)
 		return;
+
+	wf_event_uninit();
 
 #ifdef WITH_PROGRESS_BAR
 	CoUninitialize();


### PR DESCRIPTION
This patch implements comprehensive thread safety mechanisms for event processing within the FreeRDP Windows client. It addresses potential race conditions and data corruption issues that can arise in a multi-threaded environment, particularly concerning keyboard state management.

Key enhancements include:
- **Critical Sections for **: Introduces a  to protect access to the shared  array, ensuring that keyboard state updates are atomic and thread-safe.
- **Thread-Safe Context Retrieval**: Implements  to safely retrieve the  within the low-level keyboard hook, preventing access to stale or invalid contexts.
- **Initialization and Cleanup**: Ensures the critical section is properly initialized in  and deleted in .
- **Protected  Access**: The low-level keyboard hook () now safely checks  under a critical section.

These changes prevent crashes and data inconsistencies that could occur when multiple threads (e.g., the main UI thread and the keyboard hook thread) simultaneously access or modify shared keyboard state data, leading to a more stable and reliable client.