### PR TITLE
[client,windows] Fix magnitude overflow in wheel delta encoding

### DIFF
--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -266,11 +266,16 @@ static BOOL wf_event_process_WM_MOUSEWHEEL(wfContext* wfc, HWND hWnd, UINT Msg, 
 	if (delta < 0)
 	{
 		flags |= PTR_FLAGS_WHEEL_NEGATIVE;
-		/* 9bit twos complement, delta already negative */
-		delta = 0x100 + delta;
+		delta = -delta;
 	}
 
-	flags |= delta;
+	{
+		UINT16 val = (UINT16)delta;
+		if (val > 0xFF)
+			val = 0xFF; /* Cap at max 8-bit value to prevent flag corruption */
+		flags |= val;
+	}
+
 	return wf_scale_mouse_event(wfc, flags, x, y);
 }
 


### PR DESCRIPTION
As discussed in #12250, this PR provides a minimal and precise fix for wheel delta encoding.
Scenario: When a user rotates the mouse wheel very rapidly (e.g., flicking a high-precision wheel), Windows accumulates a large cumulative delta value that can exceed 255 or be significantly negative.

The Problem:
1. In the old implementation, the logic attempted to encode negative deltas using an incorrect 9-bit calculation (0x100 + delta).
2. When the delta magnitude was large, this calculation would overflow the 8-bit field allocated for the wheel magnitude in the RDP packet.
3. This overflow would "leak" into the upper bits where RDP protocol flags (like PTR_FLAGS_MOVE or PTR_FLAGS_WHEEL) are stored, causing packet corruption.

Resulting Symptoms:
   Session Disconnects:* The RDP server receives a malformed packet and terminates the connection due to a "Protocol Error."
   Erratic Behavior:* The server misinterprets the corrupted flags, leading to ghost clicks, stuck keys, or the mouse jumping randomly during scrolling.
   Application Crashes:* The client or server-side RDP components might crash when processing the out-of-range values.

The Solution:
By converting the delta to an absolute value and applying a strict 0xFF cutoff, we ensure that even extreme scrolling speeds never corrupt the protocol flags, maintaining session stability.

Key changes:
1. Replaced the confusing two's complement logic with clear absolute value calculation.
2. Applied a 0xFF cutoff to ensure the magnitude does not overflow into the RDP protocol flag bits during high-speed scrolling.
3. Removed all unrelated changes to maintain PR atomicity.