### PR TITLE
[client,windows] Improve event thread safety and lifecycle

### DIFF
--- a/client/Windows/wf_event.h
+++ b/client/Windows/wf_event.h
@@ -28,6 +28,8 @@
 LRESULT CALLBACK wf_ll_kbd_proc(int nCode, WPARAM wParam, LPARAM lParam);
 LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
 
+void wf_event_init(void);
+void wf_event_uninit(void);
 void wf_event_focus_in(wfContext* wfc);
 
 #define KBD_TAG CLIENT_TAG("windows")


### PR DESCRIPTION
Summary:
- Make keystate access thread-safe with a critical section
- Add safe init/uninit lifecycle (refcounted) for the global event lock
- Ensure keyboard thread stops before uninit to avoid use-after-delete

Notes:
- Minimal, focused change; no behavior changes outside input/event safety
- Squashed into a single commit for review
