### PR TITLE
[client,SDL3] Fix properly handle smart-sizing with fullscreen

### DIFF
--- a/client/SDL/SDL3/sdl_context.hpp
+++ b/client/SDL/SDL3/sdl_context.hpp
@@ -208,6 +208,8 @@ class SdlContext
 
 	std::map<Uint32, SdlWindow> _windows;
 
+	uint32_t _windowWidth = 0;
+	uint32_t _windowHeigth = 0;
 	WinPREvent _windowsCreatedEvent;
 	std::thread _thread;
 };


### PR DESCRIPTION
### Fix handling of smart-sizing + fullscreen case from SDL3 client

> If /f is specified in combination with /smart-sizing:widthxheight then we run the session in the /smart-sizing dimensions scaled to full screen ([client/X11/xf_client.c#L1246](https://github.com/FreeRDP/FreeRDP/blob/341b25d508c78fedced1a7152bff14638fddc1bf/client/X11/xf_client.c#L1246))
