### PR TITLE
[cmake,compiler] disable -Wjump-misses-init

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -26,7 +26,7 @@ if(ENABLE_WARNING_VERBOSE)
   endif()
 endif()
 
-list(APPEND COMMON_COMPILER_FLAGS -Wimplicit-function-declaration -Wno-jump-misses-init)
+list(APPEND COMMON_COMPILER_FLAGS -Wimplicit-function-declaration -Wno-jump-misses-init -Wno-c++-keyword)
 
 foreach(FLAG ${COMMON_COMPILER_FLAGS})
   checkcflag(${FLAG})


### PR DESCRIPTION
like explained in
https://lists.nongnu.org/archive/html/coreutils/2018-06/msg00044.html this warning is quite useless for C (in contrast to C++) code