### PR TITLE
[android] Fix invert scrolling default value mismatch

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ApplicationSettingsActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ApplicationSettingsActivity.java
@@ -282,7 +282,7 @@ public class ApplicationSettingsActivity extends AppCompatPreferenceActivity
 	{
 		SharedPreferences preferences = get(context);
 		return preferences.getBoolean(
-		    context.getString(R.string.preference_key_ui_invert_scrolling), false);
+		    context.getString(R.string.preference_key_ui_invert_scrolling), true);
 	}
 
 	public static boolean getAskOnExit(Context context)


### PR DESCRIPTION
The `getInvertScrolling()` fallback default was `false`, while the XML preference in `settings_app_ui.xml` defines `android:defaultValue="true"`.

On a fresh install, if `PreferenceManager.setDefaultValues()` has not yet persisted the XML defaults into SharedPreferences, the fallback value `false` is returned instead of the intended `true`. This causes the "Invert Scrolling" option to appear checked in the UI but not actually take effect until the user toggles it manually.

Change the fallback from `false` to `true` to match the XML default.

Fixes #12308