### PR TITLE
[allocations] fix growth of preallocated buffers

### DIFF
--- a/channels/drive/client/drive_file.c
+++ b/channels/drive/client/drive_file.c
@@ -1052,7 +1052,7 @@ BOOL drive_file_query_directory(DRIVE_FILE* file, UINT32 FsInformationClass, BYT
 	else if (!FindNextFileW(file->find_handle, &file->find_data))
 		goto out_fail;
 
-	length = _wcslen(file->find_data.cFileName) * 2;
+	length = _wcslen(file->find_data.cFileName) * sizeof(WCHAR);
 
 	switch (FsInformationClass)
 	{

--- a/channels/remdesk/common/remdesk_common.c
+++ b/channels/remdesk/common/remdesk_common.c
@@ -36,7 +36,7 @@ UINT remdesk_write_channel_header(wStream* s, const REMDESK_CHANNEL_HEADER* head
 	}
 
 	const size_t ChannelNameLen =
-	    (strnlen(header->ChannelName, sizeof(header->ChannelName)) + 1) * 2;
+	    (strnlen(header->ChannelName, sizeof(header->ChannelName)) + 1) * sizeof(WCHAR);
 	WINPR_ASSERT(ChannelNameLen <= ARRAYSIZE(header->ChannelName));
 
 	Stream_Write_UINT32(s, (UINT32)ChannelNameLen); /* ChannelNameLen (4 bytes) */

--- a/channels/remdesk/server/remdesk_main.c
+++ b/channels/remdesk/server/remdesk_main.c
@@ -185,7 +185,7 @@ static UINT remdesk_recv_ctl_remote_control_desktop_pdu(RemdeskServerContext* co
 		return ERROR_INVALID_DATA;
 
 	cchStringW++;
-	const size_t cbRaConnectionStringW = cchStringW * 2;
+	const size_t cbRaConnectionStringW = cchStringW * sizeof(WCHAR);
 	pdu.raConnectionString =
 	    ConvertWCharNToUtf8Alloc(raConnectionStringW, cbRaConnectionStringW / sizeof(WCHAR), NULL);
 	if (!pdu.raConnectionString)
@@ -240,7 +240,7 @@ static UINT remdesk_recv_ctl_authenticate_pdu(WINPR_ATTR_UNUSED RemdeskServerCon
 		return ERROR_INVALID_DATA;
 
 	cchStringW++;
-	const size_t cbExpertBlobW = cchStringW * 2;
+	const size_t cbExpertBlobW = cchStringW * sizeof(WCHAR);
 	pdu.raConnectionString =
 	    ConvertWCharNToUtf8Alloc(raConnectionStringW, cbRaConnectionStringW / sizeof(WCHAR), NULL);
 	if (!pdu.raConnectionString)

--- a/channels/tsmf/client/ffmpeg/tsmf_ffmpeg.c
+++ b/channels/tsmf/client/ffmpeg/tsmf_ffmpeg.c
@@ -488,12 +488,12 @@ static BOOL tsmf_ffmpeg_decode_audio(ITSMFDecoder* decoder, const BYTE* data, UI
 		if (mdecoder->decoded_size_max - mdecoder->decoded_size < MAX_AUDIO_FRAME_SIZE)
 		{
 			BYTE* tmp_data = NULL;
-			tmp_data = realloc(mdecoder->decoded_data, mdecoder->decoded_size_max * 2 + 16);
+			tmp_data = realloc(mdecoder->decoded_data, mdecoder->decoded_size_max * 2ull + 16ull);
 
 			if (!tmp_data)
 				return FALSE;
 
-			mdecoder->decoded_size_max = mdecoder->decoded_size_max * 2 + 16;
+			mdecoder->decoded_size_max = mdecoder->decoded_size_max * 2ull + 16ull;
 			mdecoder->decoded_data = tmp_data;
 			dst = (BYTE*)(((uintptr_t)mdecoder->decoded_data + 15) & ~0x0F);
 

--- a/channels/tsmf/client/tsmf_media.c
+++ b/channels/tsmf/client/tsmf_media.c
@@ -387,7 +387,7 @@ static char* guid_to_string(const BYTE* guid, char* str, size_t len)
 TSMF_PRESENTATION* tsmf_presentation_find_by_id(const BYTE* guid)
 {
 	BOOL found = FALSE;
-	char guid_str[GUID_SIZE * 2 + 1] = { 0 };
+	char guid_str[GUID_SIZE * 2ull + 1] = { 0 };
 	TSMF_PRESENTATION* presentation = NULL;
 	ArrayList_Lock(presentation_list);
 	const size_t count = ArrayList_Count(presentation_list);

--- a/channels/urbdrc/client/libusb/libusb_udevice.c
+++ b/channels/urbdrc/client/libusb/libusb_udevice.c
@@ -917,10 +917,10 @@ static UINT32 libusb_udev_control_query_device_text(IUDEVICE* idev, UINT32 TextT
 				 * So also check the string length returned as server side does
 				 * not honor strings with multi '\0' characters well.
 				 */
-				const size_t rchar = _wcsnlen((WCHAR*)&data[2], sizeof(data) / 2);
+				const size_t rchar = _wcsnlen((WCHAR*)&data[2], sizeof(data) / sizeof(WCHAR));
 				len = MIN((BYTE)ret - 2, slen);
 				len = MIN(len, inSize);
-				len = MIN(len, rchar * 2 + sizeof(WCHAR));
+				len = MIN(len, rchar * sizeof(WCHAR) + sizeof(WCHAR));
 				memcpy(Buffer, &data[2], len);
 
 				/* Just as above, the returned WCHAR string should be '\0'

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_event.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_event.c
@@ -28,10 +28,16 @@ BOOL android_push_event(freerdp* inst, ANDROID_EVENT* event)
 
 	if (aCtx->event_queue->count >= aCtx->event_queue->size)
 	{
-		int new_size;
-		void* new_events;
-		new_size = aCtx->event_queue->size * 2;
-		new_events = realloc((void*)aCtx->event_queue->events, sizeof(ANDROID_EVENT*) * new_size);
+		size_t new_size = aCtx->event_queue->size;
+		do
+		{
+			if (new_size >= SIZE_MAX - 128ull)
+				return FALSE;
+
+			new_size += 128ull;
+		} while (new_size <= aCtx->event_queue->count);
+		void* new_events =
+		    realloc((void*)aCtx->event_queue->events, sizeof(ANDROID_EVENT*) * new_size);
 
 		if (!new_events)
 			return FALSE;

--- a/client/Windows/wf_cliprdr.c
+++ b/client/Windows/wf_cliprdr.c
@@ -1122,10 +1122,13 @@ static void map_ensure_capacity(wfClipboard* clipboard)
 
 	if (clipboard->map_size >= clipboard->map_capacity)
 	{
-		size_t new_size;
-		formatMapping* new_map;
-		new_size = clipboard->map_capacity * 2;
-		new_map =
+		size_t new_size = clipboard->map_capacity;
+		do
+		{
+			WINPR_ASSERT(new_size <= SIZE_MAX - 128ull);
+			new_size += 128ull;
+		} while (new_size <= clipboard->map_size);
+		formatMapping* new_map =
 		    (formatMapping*)realloc(clipboard->format_mappings, sizeof(formatMapping) * new_size);
 
 		if (!new_map)

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -894,10 +894,8 @@ static BOOL xf_event_ConfigureNotify(xfContext* xfc, const XConfigureEvent* even
 
 		if (freerdp_settings_get_bool(settings, FreeRDP_DynamicResolutionUpdate))
 		{
-			int alignedWidth = 0;
-			int alignedHeight = 0;
-			alignedWidth = (xfc->window->width / 2) * 2;
-			alignedHeight = (xfc->window->height / 2) * 2;
+			const int alignedWidth = (xfc->window->width / 2) * 2;
+			const int alignedHeight = (xfc->window->height / 2) * 2;
 			/* ask the server to resize using the display channel */
 			xf_disp_handle_configureNotify(xfc, alignedWidth, alignedHeight);
 		}

--- a/libfreerdp/core/gcc.c
+++ b/libfreerdp/core/gcc.c
@@ -1999,7 +1999,8 @@ BOOL gcc_write_server_network_data(wStream* s, const rdpMcs* mcs)
 {
 	WINPR_ASSERT(s);
 	WINPR_ASSERT(mcs);
-	const size_t payloadLen = 8 + mcs->channelCount * 2 + (mcs->channelCount % 2 == 1 ? 2 : 0);
+	const size_t payloadLen =
+	    8ull + mcs->channelCount * 2ull + (mcs->channelCount % 2 == 1 ? 2ull : 0ull);
 
 	WINPR_ASSERT(payloadLen <= UINT16_MAX);
 	if (!gcc_write_user_data_header(s, SC_NET, (UINT16)payloadLen))

--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -3302,7 +3302,7 @@ size_t update_approximate_create_offscreen_bitmap_order(
 	deleteList = &(create_offscreen_bitmap->deleteList);
 	WINPR_ASSERT(deleteList);
 
-	return 32 + deleteList->cIndices * 2;
+	return 32ull + deleteList->cIndices * 2ull;
 }
 
 BOOL update_write_create_offscreen_bitmap_order(

--- a/libfreerdp/core/proxy.c
+++ b/libfreerdp/core/proxy.c
@@ -597,7 +597,7 @@ static BOOL http_proxy_connect(rdpContext* context, BIO* bufferedBio, const char
 
 	hostLen = strlen(hostname);
 	portLen = strnlen(port_str, sizeof(port_str));
-	reserveSize = strlen(connect) + (hostLen + 1 + portLen) * 2 + strlen(httpheader);
+	reserveSize = strlen(connect) + (hostLen + 1ull + portLen) * 2ull + strlen(httpheader);
 	s = Stream_New(NULL, reserveSize);
 	if (!s)
 		goto fail;

--- a/libfreerdp/crypto/base64.c
+++ b/libfreerdp/crypto/base64.c
@@ -313,7 +313,7 @@ static inline char* base64_encode_ex(const BYTE* WINPR_RESTRICT alphabet,
 	if (crLf)
 	{
 		size_t nCrLf = (outLen + lineSize - 1) / lineSize;
-		extra = nCrLf * 2;
+		extra = nCrLf * 2ull;
 	}
 	size_t outCounter = 0;
 

--- a/winpr/libwinpr/clipboard/synthetic_file.c
+++ b/winpr/libwinpr/clipboard/synthetic_file.c
@@ -759,7 +759,7 @@ static void* convert_filedescriptors_to_file_list(wClipboard* clipboard, UINT32 
 			alloc += ARRAYSIZE(dsc->cFileName) *
 			         8; /* Overallocate, just take the biggest value the result path can have */
 			            /* # (1 char) -> %23 (3 chars) , the first char is replaced inplace */
-			alloc += count_special_chars(dsc->cFileName) * 2;
+			alloc += count_special_chars(dsc->cFileName) * sizeof(WCHAR);
 			alloc += decoration_len;
 		}
 	}

--- a/winpr/libwinpr/crt/buffer.c
+++ b/winpr/libwinpr/crt/buffer.c
@@ -39,7 +39,7 @@ errno_t memmove_s(void* dest, size_t numberOfElements, const void* src, size_t c
 
 errno_t wmemmove_s(WCHAR* dest, size_t numberOfElements, const WCHAR* src, size_t count)
 {
-	if (count * 2 > numberOfElements)
+	if (count * sizeof(WCHAR) > numberOfElements)
 		return -1;
 
 	memmove(dest, src, count * 2);

--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -1403,7 +1403,7 @@ DWORD GetFullPathNameA(LPCSTR lpFileName, DWORD nBufferLength, LPSTR lpBuffer, L
 	free(lpFileNameW);
 	free(lpBufferW);
 
-	return dwStatus * 2;
+	return WINPR_ASSERTING_INT_CAST(DWORD, dwStatus * sizeof(WCHAR));
 }
 
 BOOL GetDiskFreeSpaceA(LPCSTR lpRootPathName, LPDWORD lpSectorsPerCluster, LPDWORD lpBytesPerSector,

--- a/winpr/libwinpr/ncrypt/ncrypt.c
+++ b/winpr/libwinpr/ncrypt/ncrypt.c
@@ -120,7 +120,7 @@ SECURITY_STATUS NCryptEnumStorageProviders(DWORD* wProviderCount,
 
 #ifdef WITH_PKCS11
 	*wProviderCount += 1;
-	stringAllocSize += (_wcslen(MS_SCARD_PROV) + 1) * 2;
+	stringAllocSize += (_wcslen(MS_SCARD_PROV) + 1) * sizeof(WCHAR);
 	stringAllocSize += sizeof(emptyComment);
 #endif
 
@@ -135,7 +135,7 @@ SECURITY_STATUS NCryptEnumStorageProviders(DWORD* wProviderCount,
 	strPtr = (LPWSTR)(ret + *wProviderCount);
 
 	ret->pszName = strPtr;
-	copyAmount = (_wcslen(MS_SCARD_PROV) + 1) * 2;
+	copyAmount = (_wcslen(MS_SCARD_PROV) + 1) * sizeof(WCHAR);
 	memcpy(strPtr, MS_SCARD_PROV, copyAmount);
 	strPtr += copyAmount / 2;
 

--- a/winpr/libwinpr/ncrypt/ncrypt_pkcs11.c
+++ b/winpr/libwinpr/ncrypt/ncrypt_pkcs11.c
@@ -821,11 +821,12 @@ static SECURITY_STATUS NCryptP11EnumKeys(NCRYPT_PROV_HANDLE hProvider, LPCWSTR p
 		{
 			/* sizeof keyName struct + "\<slotId>\<certId>" + keyName->pszAlgid */
 			DWORD algoSz = 0;
-			size_t KEYNAME_SZ =
-			    (1 + (sizeof(key->slotId) * 2) /*slotId*/ + 1 + (key->idLen * 2) + 1) * 2;
+			size_t KEYNAME_SZ = (1ull + (sizeof(key->slotId) * 2ull) /*slotId*/ + 1ull +
+			                     (key->idLen * 2ull) + 1ull) *
+			                    sizeof(WCHAR);
 
 			convertKeyType(key->keyType, NULL, 0, &algoSz);
-			KEYNAME_SZ += (1ULL + algoSz) * 2ULL;
+			KEYNAME_SZ += (1ULL + algoSz) * sizeof(WCHAR);
 
 			keyName = calloc(1, sizeof(*keyName) + KEYNAME_SZ);
 			if (!keyName)

--- a/winpr/libwinpr/path/include/PathAllocCombine.h
+++ b/winpr/libwinpr/path/include/PathAllocCombine.h
@@ -78,7 +78,7 @@ HRESULT PATH_ALLOC_COMBINE(PCWSTR pszPathIn, PCWSTR pszMore,
 	else
 	{
 		const size_t pszPathOutLength = pszPathInLength + pszMoreLength;
-		const size_t sizeOfBuffer = (pszPathOutLength + 1) * 2;
+		const size_t sizeOfBuffer = (pszPathOutLength + 1) * sizeof(WCHAR);
 		PWSTR pszPathOut = (PWSTR)calloc(sizeOfBuffer, 2);
 
 		if (!pszPathOut)
@@ -131,7 +131,7 @@ HRESULT PATH_ALLOC_COMBINE(PCSTR pszPathIn, PCSTR pszMore, WINPR_ATTR_UNUSED uns
 		if ((pszPathIn[1] == ':') && (pszPathIn[2] == CUR_PATH_SEPARATOR_CHR))
 		{
 			const size_t pszPathOutLength = 2 + pszMoreLength;
-			const size_t sizeOfBuffer = (pszPathOutLength + 1) * 2;
+			const size_t sizeOfBuffer = (pszPathOutLength + 1) * sizeof(WCHAR);
 			PSTR pszPathOut = calloc(sizeOfBuffer, 2);
 
 			if (!pszPathOut)
@@ -145,7 +145,7 @@ HRESULT PATH_ALLOC_COMBINE(PCSTR pszPathIn, PCSTR pszMore, WINPR_ATTR_UNUSED uns
 	else
 	{
 		const size_t pszPathOutLength = pszPathInLength + pszMoreLength;
-		const size_t sizeOfBuffer = (pszPathOutLength + 1) * 2;
+		const size_t sizeOfBuffer = (pszPathOutLength + 1) * sizeof(WCHAR);
 		PSTR pszPathOut = calloc(sizeOfBuffer, 2);
 
 		if (!pszPathOut)

--- a/winpr/libwinpr/sspi/NTLM/ntlm_message.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_message.c
@@ -1285,11 +1285,11 @@ SECURITY_STATUS ntlm_write_AuthenticateMessage(NTLM_CONTEXT* context, SecBuffer*
 	if (credentials->identity.DomainLength > 0)
 	{
 		message->NegotiateFlags |= NTLMSSP_NEGOTIATE_DOMAIN_SUPPLIED;
-		message->DomainName.Len = (UINT16)credentials->identity.DomainLength * 2;
+		message->DomainName.Len = (UINT16)credentials->identity.DomainLength * sizeof(WCHAR);
 		message->DomainName.Buffer = (BYTE*)credentials->identity.Domain;
 	}
 
-	message->UserName.Len = (UINT16)credentials->identity.UserLength * 2;
+	message->UserName.Len = (UINT16)credentials->identity.UserLength * sizeof(WCHAR);
 	message->UserName.Buffer = (BYTE*)credentials->identity.User;
 	message->LmChallengeResponse.Len = (UINT16)context->LmChallengeResponse.cbBuffer;
 	message->LmChallengeResponse.Buffer = (BYTE*)context->LmChallengeResponse.pvBuffer;

--- a/winpr/libwinpr/utils/collections/PubSub.c
+++ b/winpr/libwinpr/utils/collections/PubSub.c
@@ -94,13 +94,19 @@ void PubSub_AddEventTypes(wPubSub* pubSub, wEventType* events, size_t count)
 	if (pubSub->synchronized)
 		PubSub_Lock(pubSub);
 
-	while (pubSub->count + count >= pubSub->size)
-	{
-		size_t new_size = 0;
-		wEventType* new_event = NULL;
+	const size_t required = pubSub->count + count;
+	WINPR_ASSERT((required >= pubSub->count) && (required >= count));
 
-		new_size = pubSub->size * 2;
-		new_event = (wEventType*)realloc(pubSub->events, new_size * sizeof(wEventType));
+	if (required >= pubSub->size)
+	{
+		size_t new_size = pubSub->size;
+		do
+		{
+			WINPR_ASSERT(new_size <= SIZE_MAX - 128ull);
+			new_size += 128ull;
+		} while (new_size <= required);
+
+		wEventType* new_event = (wEventType*)realloc(pubSub->events, new_size * sizeof(wEventType));
 		if (!new_event)
 			goto fail;
 		pubSub->size = new_size;

--- a/winpr/libwinpr/utils/collections/Stack.c
+++ b/winpr/libwinpr/utils/collections/Stack.c
@@ -141,9 +141,15 @@ void Stack_Push(wStack* stack, void* obj)
 	if (stack->synchronized)
 		EnterCriticalSection(&stack->lock);
 
-	if ((stack->size + 1) >= stack->capacity)
+	WINPR_ASSERT(stack->size < SIZE_MAX);
+	if ((stack->size + 1ull) >= stack->capacity)
 	{
-		const size_t new_cap = stack->capacity * 2;
+		size_t new_cap = stack->capacity;
+		do
+		{
+			WINPR_ASSERT(new_cap <= SIZE_MAX - 128ull);
+			new_cap += 128ull;
+		} while (new_cap <= stack->size + 1ull);
 		void** new_arr = (void**)realloc((void*)stack->array, sizeof(void*) * new_cap);
 
 		if (!new_arr)

--- a/winpr/libwinpr/utils/stream.c
+++ b/winpr/libwinpr/utils/stream.c
@@ -46,20 +46,19 @@ BOOL Stream_EnsureCapacity(wStream* s, size_t size)
 	WINPR_ASSERT(s);
 	if (s->capacity < size)
 	{
-		size_t position = 0;
-		size_t old_capacity = 0;
-		size_t new_capacity = 0;
 		BYTE* new_buf = NULL;
 
-		old_capacity = s->capacity;
-		new_capacity = old_capacity;
+		size_t old_capacity = s->capacity;
+		size_t new_capacity = old_capacity;
 
 		do
 		{
-			new_capacity *= 2;
-		} while (new_capacity < size);
+			if (new_capacity > SIZE_MAX - 128ull)
+				return FALSE;
+			new_capacity += 128ull;
+		} while (new_capacity <= size);
 
-		position = Stream_GetPosition(s);
+		const size_t position = Stream_GetPosition(s);
 
 		if (!s->isOwner)
 		{

--- a/winpr/tools/makecert/makecert.c
+++ b/winpr/tools/makecert/makecert.c
@@ -78,12 +78,9 @@ static char* makecert_read_str(BIO* bio, size_t* pOffset)
 
 	while (offset >= length)
 	{
-		size_t new_len = 0;
 		size_t readBytes = 0;
 		char* new_str = NULL;
-		new_len = length * 2;
-		if (new_len == 0)
-			new_len = 2048;
+		size_t new_len = length + 2048ull;
 
 		if (new_len > INT_MAX)
 		{


### PR DESCRIPTION
* Replace * 2 with * sizeof(WCHAR) for string usages
* Grow streams and other buffers reasonably, e.g. add 128 elements per try and check for possible overflows
* Add constant postfix to force them to 64bit