### PR TITLE
[cmake] Define WINPR_DEFINE_ATTR_NODISCARD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,9 @@ include(SetFreeRDPCMakeInstallDir)
 include(Doxygen)
 include(GetSysconfDir)
 
+# FreeRDP internal builds should always check results
+add_compile_definitions(WINPR_DEFINE_ATTR_NODISCARD)
+
 # Soname versioning
 set(BUILD_NUMBER 0)
 if($ENV{BUILD_NUMBER})

--- a/winpr/include/winpr/platform.h
+++ b/winpr/include/winpr/platform.h
@@ -75,10 +75,14 @@
 #define WINPR_FALLTHROUGH (void)0;
 #endif
 
+#if defined(WINPR_DEFINE_ATTR_NODISCARD)
 #if defined(__clang__)
 #define WINPR_ATTR_NODISCARD __attribute__((warn_unused_result))
 #elif defined(__GNUC__) && (__GNUC__ >= 7)
 #define WINPR_ATTR_NODISCARD __attribute__((warn_unused_result))
+#else
+#define WINPR_ATTR_NODISCARD
+#endif
 #else
 #define WINPR_ATTR_NODISCARD
 #endif


### PR DESCRIPTION
* Do not define WINPR_ATTR_NODISCARD if WINPR_DEFINE_ATTR_NODISCARD is not defined.
* Define WINPR_DEFINE_ATTR_NODISCARD via CMake to enable this for internal use only