### PR TITLE
[client,x11] add keysym-based fallback for keyboard mapping

### DIFF
--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -332,7 +332,8 @@ struct x11_keysym_scancode_t
 };
 
 /* clang-format off */
-static const struct x11_keysym_scancode_t KEYSYM_SCANCODE_TABLE[] = {
+static const struct x11_keysym_scancode_t KEYSYM_SCANCODE_TABLE[] = 
+{
 	{ XK_a, RDP_SCANCODE_KEY_A },
 	{ XK_b, RDP_SCANCODE_KEY_B },
 	{ XK_c, RDP_SCANCODE_KEY_C },
@@ -495,7 +496,7 @@ static const struct x11_keysym_scancode_t KEYSYM_SCANCODE_TABLE[] = {
 	{ XK_KP_Decimal, RDP_SCANCODE_DECIMAL },
 	{ XK_KP_Delete, RDP_SCANCODE_DECIMAL },
 	{ XK_KP_Separator, RDP_SCANCODE_DECIMAL },
-	{ XK_KP_Divide, RDP_SCANCODE_DIVIDE },
+	{ XK_KP_Divide, RDP_SCANCODE_DIVIDE }
 };
 /* clang-format on */
 


### PR DESCRIPTION
When using X11 forwarding from non-standard X servers (e.g. XQuartz, Xephyr), the XKB key names reported by the remote server do not match the expected evdev names, causing all keys to map to RDP_SCANCODE_UNKNOWN.

Add a keysym-to-scancode lookup table as fallback. Unlike XKB key names, keysyms are standardized across X11 implementations. The fallback only fills keycodes that remain unmapped after the XKB pass, so standard setups are unaffected.

Tested with X11 forwarding from Exegol (Docker) via XQuartz on macOS, and natively on Linux and macOS.

Related to #4215
