### PR TITLE
[warnings] make function declaration names consistent

### DIFF
--- a/channels/cliprdr/client/cliprdr_format.h
+++ b/channels/cliprdr/client/cliprdr_format.h
@@ -53,7 +53,7 @@ UINT cliprdr_process_format_data_response(cliprdrPlugin* cliprdr, wStream* s, UI
 
 WINPR_ATTR_NODISCARD
 FREERDP_LOCAL
-CLIPRDR_FORMAT_LIST cliprdr_filter_format_list(const CLIPRDR_FORMAT_LIST* list, const UINT32 mask,
-                                               const UINT32 checkMask);
+CLIPRDR_FORMAT_LIST cliprdr_filter_format_list(const CLIPRDR_FORMAT_LIST* list, UINT32 mask,
+                                               UINT32 checkMask);
 
 #endif /* FREERDP_CHANNEL_CLIPRDR_CLIENT_FORMAT_H */

--- a/channels/urbdrc/common/msusb.c
+++ b/channels/urbdrc/common/msusb.c
@@ -142,9 +142,9 @@ BOOL msusb_msinterface_replace(MSUSB_CONFIG_DESCRIPTOR* MsConfig, BYTE Interface
 	return TRUE;
 }
 
-MSUSB_INTERFACE_DESCRIPTOR* msusb_msinterface_read(wStream* s)
+MSUSB_INTERFACE_DESCRIPTOR* msusb_msinterface_read(wStream* out)
 {
-	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 12))
+	if (!Stream_CheckAndLogRequiredCapacity(TAG, (out), 12))
 		return NULL;
 
 	MSUSB_INTERFACE_DESCRIPTOR* MsInterface = msusb_msinterface_new();
@@ -152,12 +152,12 @@ MSUSB_INTERFACE_DESCRIPTOR* msusb_msinterface_read(wStream* s)
 	if (!MsInterface)
 		return NULL;
 
-	Stream_Read_UINT16(s, MsInterface->Length);
-	Stream_Read_UINT16(s, MsInterface->NumberOfPipesExpected);
-	Stream_Read_UINT8(s, MsInterface->InterfaceNumber);
-	Stream_Read_UINT8(s, MsInterface->AlternateSetting);
-	Stream_Seek(s, 2);
-	Stream_Read_UINT32(s, MsInterface->NumberOfPipes);
+	Stream_Read_UINT16(out, MsInterface->Length);
+	Stream_Read_UINT16(out, MsInterface->NumberOfPipesExpected);
+	Stream_Read_UINT8(out, MsInterface->InterfaceNumber);
+	Stream_Read_UINT8(out, MsInterface->AlternateSetting);
+	Stream_Seek(out, 2);
+	Stream_Read_UINT32(out, MsInterface->NumberOfPipes);
 	MsInterface->InterfaceHandle = 0;
 	MsInterface->bInterfaceClass = 0;
 	MsInterface->bInterfaceSubClass = 0;
@@ -167,7 +167,7 @@ MSUSB_INTERFACE_DESCRIPTOR* msusb_msinterface_read(wStream* s)
 
 	if (MsInterface->NumberOfPipes > 0)
 	{
-		MsInterface->MsPipes = msusb_mspipes_read(s, MsInterface->NumberOfPipes);
+		MsInterface->MsPipes = msusb_mspipes_read(out, MsInterface->NumberOfPipes);
 
 		if (!MsInterface->MsPipes)
 			goto out_error;
@@ -260,22 +260,22 @@ fail:
 	return NULL;
 }
 
-BOOL msusb_msconfig_write(const MSUSB_CONFIG_DESCRIPTOR* MsConfg, wStream* out)
+BOOL msusb_msconfig_write(const MSUSB_CONFIG_DESCRIPTOR* MsConfig, wStream* out)
 {
-	if (!MsConfg)
+	if (!MsConfig)
 		return FALSE;
 
 	if (!Stream_EnsureRemainingCapacity(out, 8))
 		return FALSE;
 
 	/* ConfigurationHandle*/
-	Stream_Write_UINT32(out, MsConfg->ConfigurationHandle);
+	Stream_Write_UINT32(out, MsConfig->ConfigurationHandle);
 	/* NumInterfaces*/
-	Stream_Write_UINT32(out, MsConfg->NumInterfaces);
+	Stream_Write_UINT32(out, MsConfig->NumInterfaces);
 	/* Interfaces */
-	MSUSB_INTERFACE_DESCRIPTOR** MsInterfaces = MsConfg->MsInterfaces;
+	MSUSB_INTERFACE_DESCRIPTOR** MsInterfaces = MsConfig->MsInterfaces;
 
-	for (UINT32 inum = 0; inum < MsConfg->NumInterfaces; inum++)
+	for (UINT32 inum = 0; inum < MsConfig->NumInterfaces; inum++)
 	{
 		const MSUSB_INTERFACE_DESCRIPTOR* MsInterface = MsInterfaces[inum];
 

--- a/channels/urbdrc/common/msusb.h
+++ b/channels/urbdrc/common/msusb.h
@@ -79,9 +79,9 @@ extern "C"
 	FREERDP_LOCAL MSUSB_CONFIG_DESCRIPTOR* msusb_msconfig_read(wStream* s, UINT32 NumInterfaces);
 
 	WINPR_ATTR_NODISCARD
-	FREERDP_LOCAL BOOL msusb_msconfig_write(const MSUSB_CONFIG_DESCRIPTOR* MsConfg, wStream* out);
+	FREERDP_LOCAL BOOL msusb_msconfig_write(const MSUSB_CONFIG_DESCRIPTOR* MsConfig, wStream* out);
 
-	FREERDP_LOCAL void msusb_msconfig_dump(const MSUSB_CONFIG_DESCRIPTOR* MsConfg);
+	FREERDP_LOCAL void msusb_msconfig_dump(const MSUSB_CONFIG_DESCRIPTOR* MsConfig);
 
 	/* MSUSB_PIPE exported functions */
 	FREERDP_LOCAL void msusb_mspipes_replace(MSUSB_INTERFACE_DESCRIPTOR* MsInterface,

--- a/client/Wayland/wlf_disp.h
+++ b/client/Wayland/wlf_disp.h
@@ -25,8 +25,8 @@
 
 #include "wlfreerdp.h"
 
-FREERDP_API BOOL wlf_disp_init(wlfDispContext* xfDisp, DispClientContext* disp);
-FREERDP_API BOOL wlf_disp_uninit(wlfDispContext* xfDisp, DispClientContext* disp);
+FREERDP_API BOOL wlf_disp_init(wlfDispContext* wlfDisp, DispClientContext* disp);
+FREERDP_API BOOL wlf_disp_uninit(wlfDispContext* wlfDisp, DispClientContext* disp);
 
 wlfDispContext* wlf_disp_new(wlfContext* wlc);
 void wlf_disp_free(wlfDispContext* disp);

--- a/client/X11/xf_floatbar.c
+++ b/client/X11/xf_floatbar.c
@@ -315,11 +315,11 @@ xfFloatbarButton* xf_floatbar_new_button(xfFloatbar* floatbar, int type)
 	return button;
 }
 
-xfFloatbar* xf_floatbar_new(xfContext* xfc, Window window, const char* name, DWORD flags)
+xfFloatbar* xf_floatbar_new(xfContext* xfc, Window window, const char* title, DWORD flags)
 {
 	WINPR_ASSERT(xfc);
 	WINPR_ASSERT(xfc->display);
-	WINPR_ASSERT(name);
+	WINPR_ASSERT(title);
 
 	/* Floatbar not enabled */
 	if ((flags & 0x0001) == 0)
@@ -337,7 +337,7 @@ xfFloatbar* xf_floatbar_new(xfContext* xfc, Window window, const char* name, DWO
 	if (!floatbar)
 		return NULL;
 
-	floatbar->title = _strdup(name);
+	floatbar->title = _strdup(title);
 
 	if (!floatbar->title)
 		goto fail;

--- a/client/X11/xf_monitor.h
+++ b/client/X11/xf_monitor.h
@@ -27,7 +27,7 @@
 #include "xf_types.h"
 
 FREERDP_API int xf_list_monitors(xfContext* xfc);
-FREERDP_API BOOL xf_detect_monitors(xfContext* xfc, UINT32* pWidth, UINT32* pHeight);
+FREERDP_API BOOL xf_detect_monitors(xfContext* xfc, UINT32* pMaxWidth, UINT32* pMaxHeight);
 FREERDP_API void xf_monitors_free(xfContext* xfc);
 
 #endif /* FREERDP_CLIENT_X11_MONITOR_H */

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -2407,16 +2407,16 @@ BOOL freerdp_client_is_pen(rdpClientContext* cctx, INT32 deviceid)
 	return FALSE;
 }
 
-BOOL freerdp_client_use_relative_mouse_events(rdpClientContext* ccontext)
+BOOL freerdp_client_use_relative_mouse_events(rdpClientContext* cctx)
 {
-	WINPR_ASSERT(ccontext);
+	WINPR_ASSERT(cctx);
 
-	const rdpSettings* settings = ccontext->context.settings;
+	const rdpSettings* settings = cctx->context.settings;
 	const BOOL useRelative = freerdp_settings_get_bool(settings, FreeRDP_MouseUseRelativeMove);
 	const BOOL haveRelative = freerdp_settings_get_bool(settings, FreeRDP_HasRelativeMouseEvent);
 	BOOL ainput = FALSE;
 #if defined(CHANNEL_AINPUT_CLIENT)
-	ainput = ccontext->ainput != NULL;
+	ainput = cctx->ainput != NULL;
 #endif
 
 	return useRelative && (haveRelative || ainput);

--- a/include/freerdp/client/channels.h
+++ b/include/freerdp/client/channels.h
@@ -79,8 +79,8 @@ extern "C"
 	                                                                          DWORD dwFlags);
 
 	WINPR_ATTR_NODISCARD
-	FREERDP_API FREERDP_ADDIN** freerdp_channels_list_addins(LPCSTR lpName, LPCSTR lpSubsystem,
-	                                                         LPCSTR lpType, DWORD dwFlags);
+	FREERDP_API FREERDP_ADDIN** freerdp_channels_list_addins(LPCSTR pszName, LPCSTR pszSubsystem,
+	                                                         LPCSTR pszType, DWORD dwFlags);
 	FREERDP_API void freerdp_channels_addin_list_free(FREERDP_ADDIN** ppAddins);
 
 	WINPR_ATTR_NODISCARD

--- a/include/freerdp/client/client_cliprdr_file.h
+++ b/include/freerdp/client/client_cliprdr_file.h
@@ -91,12 +91,12 @@ extern "C"
 	 *
 	 * \param file the file context to update
 	 * \param data the file list
-	 * \param count the length of the file list
+	 * \param size the length of the file list
 	 *
 	 * \return \b TRUE for success, \b FALSE otherwise
 	 */
 	FREERDP_API BOOL cliprdr_file_context_update_client_data(CliprdrFileContext* file,
-	                                                         const char* data, size_t count);
+	                                                         const char* data, size_t size);
 	/** \brief updates the files the server announces to the client
 	 *
 	 * \param file the file context to update

--- a/include/freerdp/codec/region.h
+++ b/include/freerdp/codec/region.h
@@ -141,12 +141,12 @@ extern "C"
 	/** computes the intersection between a region and a rectangle
 	 * @param dst destination region
 	 * @param src the source region
-	 * @param arg2 the rectangle that intersects
+	 * @param rect the rectangle that intersects
 	 * @return if the operation was successful (false meaning out-of-memory)
 	 */
 	WINPR_ATTR_NODISCARD
 	FREERDP_API BOOL region16_intersect_rect(REGION16* dst, const REGION16* src,
-	                                         const RECTANGLE_16* arg2);
+	                                         const RECTANGLE_16* rect);
 
 	/** release internal data associated with this region
 	 * @param region the region to release

--- a/include/freerdp/codec/rfx.h
+++ b/include/freerdp/codec/rfx.h
@@ -109,9 +109,9 @@ extern "C"
 	WINPR_ATTR_NODISCARD
 	FREERDP_API BOOL rfx_compose_message(RFX_CONTEXT* WINPR_RESTRICT context,
 	                                     wStream* WINPR_RESTRICT s,
-	                                     const RFX_RECT* WINPR_RESTRICT rects, size_t num_rects,
-	                                     const BYTE* WINPR_RESTRICT image_data, UINT32 width,
-	                                     UINT32 height, UINT32 rowstride);
+	                                     const RFX_RECT* WINPR_RESTRICT rects, size_t numRects,
+	                                     const BYTE* WINPR_RESTRICT data, UINT32 width,
+	                                     UINT32 height, UINT32 scanline);
 
 	WINPR_ATTR_MALLOC(rfx_message_free, 2)
 	WINPR_ATTR_NODISCARD

--- a/include/freerdp/codec/yuv.h
+++ b/include/freerdp/codec/yuv.h
@@ -39,9 +39,9 @@ extern "C"
 
 	WINPR_ATTR_NODISCARD
 	FREERDP_API BOOL yuv420_context_encode(YUV_CONTEXT* WINPR_RESTRICT context,
-	                                       const BYTE* WINPR_RESTRICT rgbData, UINT32 srcStep,
-	                                       UINT32 srcFormat, const UINT32 iStride[3],
-	                                       BYTE* WINPR_RESTRICT yuvData[3],
+	                                       const BYTE* WINPR_RESTRICT pSrcData, UINT32 nSrcStep,
+	                                       UINT32 SrcFormat, const UINT32 iStride[3],
+	                                       BYTE* WINPR_RESTRICT pYUVData[3],
 	                                       const RECTANGLE_16* WINPR_RESTRICT regionRects,
 	                                       UINT32 numRegionRects);
 

--- a/include/freerdp/codecs.h
+++ b/include/freerdp/codecs.h
@@ -88,7 +88,7 @@ extern "C"
 	 */
 	WINPR_ATTR_MALLOC(freerdp_client_codecs_free, 1)
 	WINPR_ATTR_NODISCARD
-	FREERDP_API rdpCodecs* freerdp_client_codecs_new(UINT32 TheadingFlags);
+	FREERDP_API rdpCodecs* freerdp_client_codecs_new(UINT32 ThreadingFlags);
 
 #if !defined(WITHOUT_FREERDP_3x_DEPRECATED)
 	WINPR_DEPRECATED_VAR("[since 3.6.0] Use freerdp_client_codecs_free",

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -748,13 +748,13 @@ owned by rdpRdp */
 	FREERDP_API UINT32 freerdp_get_last_error(const rdpContext* context);
 
 	WINPR_ATTR_NODISCARD
-	FREERDP_API const char* freerdp_get_last_error_name(UINT32 error);
+	FREERDP_API const char* freerdp_get_last_error_name(UINT32 code);
 
 	WINPR_ATTR_NODISCARD
-	FREERDP_API const char* freerdp_get_last_error_string(UINT32 error);
+	FREERDP_API const char* freerdp_get_last_error_string(UINT32 code);
 
 	WINPR_ATTR_NODISCARD
-	FREERDP_API const char* freerdp_get_last_error_category(UINT32 error);
+	FREERDP_API const char* freerdp_get_last_error_category(UINT32 code);
 
 #define freerdp_set_last_error(context, lastError) \
 	freerdp_set_last_error_ex((context), (lastError), __func__, __FILE__, __LINE__)

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -145,13 +145,14 @@ extern "C"
 	 *
 	 *  \param log The logger to write to, must not be NULL.
 	 *  \param  level The WLog level to use for the log entries.
-	 *  \param src A pointer to the settings to dump. May be NULL.
+	 *  \param settings A pointer to the settings to dump. May be NULL.
 	 *  \param other A pointer to the settings to dump. May be NULL.
 	 *
 	 *  \return \b TRUE if not equal, \b FALSE otherwise
 	 */
 	WINPR_ATTR_NODISCARD
-	FREERDP_API BOOL freerdp_settings_print_diff(wLog* log, DWORD level, const rdpSettings* src,
+	FREERDP_API BOOL freerdp_settings_print_diff(wLog* log, DWORD level,
+	                                             const rdpSettings* settings,
 	                                             const rdpSettings* other);
 
 	FREERDP_API void freerdp_addin_argv_free(ADDIN_ARGV* args);
@@ -224,7 +225,7 @@ extern "C"
 	FREERDP_API RDPDR_DEVICE* freerdp_device_clone(const RDPDR_DEVICE* device);
 
 	WINPR_ATTR_NODISCARD
-	FREERDP_API BOOL freerdp_device_equal(const RDPDR_DEVICE* one, const RDPDR_DEVICE* other);
+	FREERDP_API BOOL freerdp_device_equal(const RDPDR_DEVICE* what, const RDPDR_DEVICE* other);
 
 	FREERDP_API void freerdp_device_collection_free(rdpSettings* settings);
 
@@ -271,7 +272,7 @@ extern "C"
 	FREERDP_API void freerdp_server_license_issuers_free(rdpSettings* settings);
 
 	WINPR_ATTR_NODISCARD
-	FREERDP_API BOOL freerdp_server_license_issuers_copy(rdpSettings* settings, char** addresses,
+	FREERDP_API BOOL freerdp_server_license_issuers_copy(rdpSettings* settings, char** issuers,
 	                                                     UINT32 count);
 
 	FREERDP_API void freerdp_target_net_addresses_free(rdpSettings* settings);
@@ -357,12 +358,12 @@ extern "C"
 	 *
 	 *  \param settings A pointer to the settings to query, must not be NULL.
 	 *  \param id The key to query
-	 *  \param param The value to set.
+	 *  \param val The value to set.
 	 *
 	 *  \return \b TRUE for success, \b FALSE for failure
 	 */
 	FREERDP_API BOOL freerdp_settings_set_bool(rdpSettings* settings, FreeRDP_Settings_Keys_Bool id,
-	                                           BOOL param);
+	                                           BOOL val);
 
 	/** \brief Returns a INT16 settings value
 	 *
@@ -379,12 +380,12 @@ extern "C"
 	 *
 	 *  \param settings A pointer to the settings to query, must not be NULL.
 	 *  \param id The key to query
-	 *  \param param The value to set.
+	 *  \param val The value to set.
 	 *
 	 *  \return \b TRUE for success, \b FALSE for failure
 	 */
 	FREERDP_API BOOL freerdp_settings_set_int16(rdpSettings* settings,
-	                                            FreeRDP_Settings_Keys_Int16 id, INT16 param);
+	                                            FreeRDP_Settings_Keys_Int16 id, INT16 val);
 
 	/** \brief Returns a UINT16 settings value
 	 *
@@ -401,12 +402,12 @@ extern "C"
 	 *
 	 *  \param settings A pointer to the settings to query, must not be NULL.
 	 *  \param id The key to query
-	 *  \param param The value to set.
+	 *  \param val The value to set.
 	 *
 	 *  \return \b TRUE for success, \b FALSE for failure
 	 */
 	FREERDP_API BOOL freerdp_settings_set_uint16(rdpSettings* settings,
-	                                             FreeRDP_Settings_Keys_UInt16 id, UINT16 param);
+	                                             FreeRDP_Settings_Keys_UInt16 id, UINT16 val);
 
 	/** \brief Returns a INT32 settings value
 	 *
@@ -423,12 +424,12 @@ extern "C"
 	 *
 	 *  \param settings A pointer to the settings to query, must not be NULL.
 	 *  \param id The key to query
-	 *  \param param The value to set.
+	 *  \param val The value to set.
 	 *
 	 *  \return \b TRUE for success, \b FALSE for failure
 	 */
 	FREERDP_API BOOL freerdp_settings_set_int32(rdpSettings* settings,
-	                                            FreeRDP_Settings_Keys_Int32 id, INT32 param);
+	                                            FreeRDP_Settings_Keys_Int32 id, INT32 val);
 
 	/** \brief Returns a UINT32 settings value
 	 *
@@ -445,12 +446,12 @@ extern "C"
 	 *
 	 *  \param settings A pointer to the settings to query, must not be NULL.
 	 *  \param id The key to query
-	 *  \param param The value to set.
+	 *  \param val The value to set.
 	 *
 	 *  \return \b TRUE for success, \b FALSE for failure
 	 */
 	FREERDP_API BOOL freerdp_settings_set_uint32(rdpSettings* settings,
-	                                             FreeRDP_Settings_Keys_UInt32 id, UINT32 param);
+	                                             FreeRDP_Settings_Keys_UInt32 id, UINT32 val);
 
 	/** \brief Returns a INT64 settings value
 	 *
@@ -467,12 +468,12 @@ extern "C"
 	 *
 	 *  \param settings A pointer to the settings to query, must not be NULL.
 	 *  \param id The key to query
-	 *  \param param The value to set.
+	 *  \param val The value to set.
 	 *
 	 *  \return \b TRUE for success, \b FALSE for failure
 	 */
 	FREERDP_API BOOL freerdp_settings_set_int64(rdpSettings* settings,
-	                                            FreeRDP_Settings_Keys_Int64 id, INT64 param);
+	                                            FreeRDP_Settings_Keys_Int64 id, INT64 val);
 
 	/** \brief Returns a UINT64 settings value
 	 *
@@ -489,12 +490,12 @@ extern "C"
 	 *
 	 *  \param settings A pointer to the settings to query, must not be NULL.
 	 *  \param id The key to query
-	 *  \param param The value to set.
+	 *  \param val The value to set.
 	 *
 	 *  \return \b TRUE for success, \b FALSE for failure
 	 */
 	FREERDP_API BOOL freerdp_settings_set_uint64(rdpSettings* settings,
-	                                             FreeRDP_Settings_Keys_UInt64 id, UINT64 param);
+	                                             FreeRDP_Settings_Keys_UInt64 id, UINT64 val);
 
 	/** \brief Returns a immutable string settings value
 	 *
@@ -518,30 +519,30 @@ extern "C"
 	FREERDP_API char* freerdp_settings_get_string_writable(rdpSettings* settings,
 	                                                       FreeRDP_Settings_Keys_String id);
 
-	/** \brief Sets a string settings value. The \b param is copied.
+	/** \brief Sets a string settings value. The \b val is copied.
 	 *
 	 *  \param settings A pointer to the settings to query, must not be NULL.
 	 *  \param id The key to query
-	 *  \param param The value to set. If NULL allocates an empty string buffer of \b len size,
-	 * otherwise a copy is created. \param len The length of \b param, 0 to remove the old entry.
+	 *  \param val The value to set. If NULL allocates an empty string buffer of \b len size,
+	 * otherwise a copy is created. \param len The length of \b val, 0 to remove the old entry.
 	 *
 	 *  \return \b TRUE for success, \b FALSE for failure
 	 */
 	FREERDP_API BOOL freerdp_settings_set_string_len(rdpSettings* settings,
 	                                                 FreeRDP_Settings_Keys_String id,
-	                                                 const char* param, size_t len);
+	                                                 const char* val, size_t len);
 
 	/** \brief Sets a string settings value. The \b param is copied.
 	 *
 	 *  \param settings A pointer to the settings to query, must not be NULL.
 	 *  \param id The key to query
-	 *  \param param The value to set. If NULL removes the old entry, otherwise a copy is created.
+	 *  \param val The value to set. If NULL removes the old entry, otherwise a copy is
+	 * created.
 	 *
 	 *  \return \b TRUE for success, \b FALSE for failure
 	 */
 	FREERDP_API BOOL freerdp_settings_set_string(rdpSettings* settings,
-	                                             FreeRDP_Settings_Keys_String id,
-	                                             const char* param);
+	                                             FreeRDP_Settings_Keys_String id, const char* val);
 
 	/** \brief appends a string to a settings value. The \b param is copied.
 	 *  If the initial value of the setting was not empty, @code <old value><separator><param>
@@ -618,17 +619,17 @@ extern "C"
 	FREERDP_API void* freerdp_settings_get_pointer_writable(rdpSettings* settings,
 	                                                        FreeRDP_Settings_Keys_Pointer id);
 
-	/** \brief Set a pointer to value \b data
+	/** \brief Set a pointer to value \b val
 	 *
 	 *  \param settings A pointer to the settings to query, must not be NULL.
 	 *  \param id The key to update
-	 *  \param data The data to set (direct update, no copy created, previous value overwritten)
+	 *  \param val The data to set (direct update, no copy created, previous value overwritten)
 	 *
 	 *  \return \b TRUE for success, \b FALSE for failure
 	 */
 	FREERDP_API BOOL freerdp_settings_set_pointer(rdpSettings* settings,
 	                                              FreeRDP_Settings_Keys_Pointer id,
-	                                              const void* data);
+	                                              const void* val);
 
 	/** \brief Set a pointer to value \b data
 	 *
@@ -812,8 +813,8 @@ extern "C"
 	FREERDP_API const char* freerdp_encryption_level_string(UINT32 EncryptionLevel);
 
 	WINPR_ATTR_NODISCARD
-	FREERDP_API const char* freerdp_encryption_methods_string(UINT32 EncryptionLevel, char* buffer,
-	                                                          size_t size);
+	FREERDP_API const char* freerdp_encryption_methods_string(UINT32 EncryptionMethods,
+	                                                          char* buffer, size_t size);
 
 	/** @brief returns a string representation of \b RNS_UD_XXBPP_SUPPORT values
 	 * @param mask A bitmask of supported color dephts \b RNS_UD_*
@@ -873,14 +874,14 @@ extern "C"
 
 	/** @brief A function that converts a \b JSON string to a \b rdpSettings struct
 	 *
-	 *  @param json The \b JSON string
+	 *  @param jstr The \b JSON string
 	 *  @param length The strlen of the \b JSON string
 	 *  @return An allocated \b rdpSettings struct or \b NULL in case of an error
 	 *  @since version 3.16.0
 	 */
 	WINPR_ATTR_MALLOC(freerdp_settings_free, 1)
 	WINPR_ATTR_NODISCARD
-	FREERDP_API rdpSettings* freerdp_settings_deserialize(const char* json, size_t length);
+	FREERDP_API rdpSettings* freerdp_settings_deserialize(const char* jstr, size_t length);
 
 #ifdef __cplusplus
 }

--- a/include/freerdp/utils/ringbuffer.h
+++ b/include/freerdp/utils/ringbuffer.h
@@ -53,7 +53,7 @@ extern "C"
 	 * @return if the initialisation was successful
 	 */
 	WINPR_ATTR_NODISCARD
-	FREERDP_API BOOL ringbuffer_init(RingBuffer* rb, size_t initialSize);
+	FREERDP_API BOOL ringbuffer_init(RingBuffer* ringbuffer, size_t initialSize);
 
 	/**
 	 * destroys internal data used by this ringbuffer
@@ -82,54 +82,54 @@ extern "C"
 	/** writes some bytes in the ringbuffer, if the data doesn't fit, the ringbuffer
 	 * is resized automatically
 	 *
-	 * @param rb the ringbuffer
+	 * @param ringbuffer the ringbuffer
 	 * @param ptr a pointer on the data to add
 	 * @param sz the size of the data to add
 	 * @return if the operation was successful, it could fail in case of OOM during realloc()
 	 */
 	WINPR_ATTR_NODISCARD
-	FREERDP_API BOOL ringbuffer_write(RingBuffer* rb, const BYTE* ptr, size_t sz);
+	FREERDP_API BOOL ringbuffer_write(RingBuffer* ringbuffer, const BYTE* ptr, size_t sz);
 
 	/** ensures that we have sz bytes available at the write head, and return a pointer
 	 * on the write head
 	 *
-	 * @param rb the ring buffer
+	 * @param ringbuffer the ring buffer
 	 * @param sz the size to ensure
 	 * @return a pointer on the write head, or NULL in case of OOM
 	 */
 	WINPR_ATTR_NODISCARD
-	FREERDP_API BYTE* ringbuffer_ensure_linear_write(RingBuffer* rb, size_t sz);
+	FREERDP_API BYTE* ringbuffer_ensure_linear_write(RingBuffer* ringbuffer, size_t sz);
 
 	/** move ahead the write head in case some byte were written directly by using
 	 * a pointer retrieved via ringbuffer_ensure_linear_write(). This function is
 	 * used to commit the written bytes. The provided size should not exceed the
 	 * size ensured by ringbuffer_ensure_linear_write()
 	 *
-	 * @param rb the ring buffer
+	 * @param ringbuffer the ring buffer
 	 * @param sz the number of bytes that have been written
 	 * @return if the operation was successful, FALSE is sz is too big
 	 */
 	WINPR_ATTR_NODISCARD
-	FREERDP_API BOOL ringbuffer_commit_written_bytes(RingBuffer* rb, size_t sz);
+	FREERDP_API BOOL ringbuffer_commit_written_bytes(RingBuffer* ringbuffer, size_t sz);
 
 	/** peeks the buffer chunks for sz bytes and returns how many chunks are filled.
 	 * Note that the sum of the resulting chunks may be smaller than sz.
 	 *
-	 * @param rb the ringbuffer
+	 * @param ringbuffer the ringbuffer
 	 * @param chunks an array of data chunks that will contain data / size of chunks
 	 * @param sz the requested size
 	 * @return the number of chunks used for reading sz bytes
 	 */
 	WINPR_ATTR_NODISCARD
-	FREERDP_API int ringbuffer_peek(const RingBuffer* rb, DataChunk chunks[2], size_t sz);
+	FREERDP_API int ringbuffer_peek(const RingBuffer* ringbuffer, DataChunk chunks[2], size_t sz);
 
 	/** move ahead the read head in case some byte were read using ringbuffer_peek()
 	 * This function is used to commit the bytes that were effectively consumed.
 	 *
-	 * @param rb the ring buffer
+	 * @param ringbuffer the ring buffer
 	 * @param sz the number of bytes to read
 	 */
-	FREERDP_API void ringbuffer_commit_read_bytes(RingBuffer* rb, size_t sz);
+	FREERDP_API void ringbuffer_commit_read_bytes(RingBuffer* ringbuffer, size_t sz);
 
 #ifdef __cplusplus
 }

--- a/include/freerdp/utils/smartcard_call.h
+++ b/include/freerdp/utils/smartcard_call.h
@@ -66,7 +66,7 @@ extern "C"
 	FREERDP_API void* smartcard_call_get_context(scard_call_context* ctx, SCARDCONTEXT hContext);
 
 	WINPR_ATTR_NODISCARD
-	FREERDP_API LONG smartcard_irp_device_control_call(scard_call_context* context, wStream* out,
+	FREERDP_API LONG smartcard_irp_device_control_call(scard_call_context* ctx, wStream* out,
 	                                                   NTSTATUS* pIoStatus,
 	                                                   SMARTCARD_OPERATION* operation);
 

--- a/libfreerdp/cache/bitmap.h
+++ b/libfreerdp/cache/bitmap.h
@@ -57,7 +57,7 @@ extern "C"
 
 	FREERDP_LOCAL void bitmap_cache_register_callbacks(rdpUpdate* update);
 
-	FREERDP_LOCAL void bitmap_cache_free(rdpBitmapCache* bitmap_cache);
+	FREERDP_LOCAL void bitmap_cache_free(rdpBitmapCache* bitmapCache);
 
 	WINPR_ATTR_MALLOC(bitmap_cache_free, 1)
 	WINPR_ATTR_NODISCARD

--- a/libfreerdp/cache/offscreen.h
+++ b/libfreerdp/cache/offscreen.h
@@ -35,7 +35,7 @@ extern "C"
 #endif
 
 	WINPR_ATTR_NODISCARD
-	FREERDP_LOCAL rdpBitmap* offscreen_cache_get(rdpOffscreenCache* offscreen_cache, UINT32 index);
+	FREERDP_LOCAL rdpBitmap* offscreen_cache_get(rdpOffscreenCache* offscreenCache, UINT32 index);
 
 	FREERDP_LOCAL void offscreen_cache_register_callbacks(rdpUpdate* update);
 

--- a/libfreerdp/cache/palette.h
+++ b/libfreerdp/cache/palette.h
@@ -47,7 +47,7 @@ extern "C"
 
 	FREERDP_LOCAL void palette_cache_register_callbacks(rdpUpdate* update);
 
-	FREERDP_LOCAL void palette_cache_free(rdpPaletteCache* palette_cache);
+	FREERDP_LOCAL void palette_cache_free(rdpPaletteCache* paletteCache);
 
 	WINPR_ATTR_MALLOC(palette_cache_free, 1)
 	WINPR_ATTR_NODISCARD

--- a/libfreerdp/cache/pointer.c
+++ b/libfreerdp/cache/pointer.c
@@ -392,33 +392,33 @@ void pointer_cache_free(rdpPointerCache* pointer_cache)
 }
 
 POINTER_COLOR_UPDATE* copy_pointer_color_update(rdpContext* context,
-                                                const POINTER_COLOR_UPDATE* src)
+                                                const POINTER_COLOR_UPDATE* pointer)
 {
 	POINTER_COLOR_UPDATE* dst = calloc(1, sizeof(POINTER_COLOR_UPDATE));
 
-	if (!dst || !src)
+	if (!dst || !pointer)
 		goto fail;
 
-	*dst = *src;
+	*dst = *pointer;
 
-	if (src->lengthAndMask > 0)
+	if (pointer->lengthAndMask > 0)
 	{
-		dst->andMaskData = calloc(src->lengthAndMask, sizeof(BYTE));
+		dst->andMaskData = calloc(pointer->lengthAndMask, sizeof(BYTE));
 
 		if (!dst->andMaskData)
 			goto fail;
 
-		memcpy(dst->andMaskData, src->andMaskData, src->lengthAndMask);
+		memcpy(dst->andMaskData, pointer->andMaskData, pointer->lengthAndMask);
 	}
 
-	if (src->lengthXorMask > 0)
+	if (pointer->lengthXorMask > 0)
 	{
-		dst->xorMaskData = calloc(src->lengthXorMask, sizeof(BYTE));
+		dst->xorMaskData = calloc(pointer->lengthXorMask, sizeof(BYTE));
 
 		if (!dst->xorMaskData)
 			goto fail;
 
-		memcpy(dst->xorMaskData, src->xorMaskData, src->lengthXorMask);
+		memcpy(dst->xorMaskData, pointer->xorMaskData, pointer->lengthXorMask);
 	}
 
 	return dst;
@@ -440,33 +440,33 @@ void free_pointer_color_update(rdpContext* context, POINTER_COLOR_UPDATE* pointe
 }
 
 POINTER_LARGE_UPDATE* copy_pointer_large_update(rdpContext* context,
-                                                const POINTER_LARGE_UPDATE* src)
+                                                const POINTER_LARGE_UPDATE* pointer)
 {
 	POINTER_LARGE_UPDATE* dst = calloc(1, sizeof(POINTER_LARGE_UPDATE));
 
-	if (!dst || !src)
+	if (!dst || !pointer)
 		goto fail;
 
-	*dst = *src;
+	*dst = *pointer;
 
-	if (src->lengthAndMask > 0)
+	if (pointer->lengthAndMask > 0)
 	{
-		dst->andMaskData = calloc(src->lengthAndMask, sizeof(BYTE));
+		dst->andMaskData = calloc(pointer->lengthAndMask, sizeof(BYTE));
 
 		if (!dst->andMaskData)
 			goto fail;
 
-		memcpy(dst->andMaskData, src->andMaskData, src->lengthAndMask);
+		memcpy(dst->andMaskData, pointer->andMaskData, pointer->lengthAndMask);
 	}
 
-	if (src->lengthXorMask > 0)
+	if (pointer->lengthXorMask > 0)
 	{
-		dst->xorMaskData = calloc(src->lengthXorMask, sizeof(BYTE));
+		dst->xorMaskData = calloc(pointer->lengthXorMask, sizeof(BYTE));
 
 		if (!dst->xorMaskData)
 			goto fail;
 
-		memcpy(dst->xorMaskData, src->xorMaskData, src->lengthXorMask);
+		memcpy(dst->xorMaskData, pointer->xorMaskData, pointer->lengthXorMask);
 	}
 
 	return dst;
@@ -486,35 +486,35 @@ void free_pointer_large_update(rdpContext* context, POINTER_LARGE_UPDATE* pointe
 	free(pointer);
 }
 
-POINTER_NEW_UPDATE* copy_pointer_new_update(rdpContext* context, const POINTER_NEW_UPDATE* src)
+POINTER_NEW_UPDATE* copy_pointer_new_update(rdpContext* context, const POINTER_NEW_UPDATE* pointer)
 {
 	POINTER_NEW_UPDATE* dst = calloc(1, sizeof(POINTER_NEW_UPDATE));
 
-	if (!dst || !src)
+	if (!dst || !pointer)
 		goto fail;
 
-	*dst = *src;
+	*dst = *pointer;
 
-	if (src->colorPtrAttr.lengthAndMask > 0)
+	if (pointer->colorPtrAttr.lengthAndMask > 0)
 	{
-		dst->colorPtrAttr.andMaskData = calloc(src->colorPtrAttr.lengthAndMask, sizeof(BYTE));
+		dst->colorPtrAttr.andMaskData = calloc(pointer->colorPtrAttr.lengthAndMask, sizeof(BYTE));
 
 		if (!dst->colorPtrAttr.andMaskData)
 			goto fail;
 
-		memcpy(dst->colorPtrAttr.andMaskData, src->colorPtrAttr.andMaskData,
-		       src->colorPtrAttr.lengthAndMask);
+		memcpy(dst->colorPtrAttr.andMaskData, pointer->colorPtrAttr.andMaskData,
+		       pointer->colorPtrAttr.lengthAndMask);
 	}
 
-	if (src->colorPtrAttr.lengthXorMask > 0)
+	if (pointer->colorPtrAttr.lengthXorMask > 0)
 	{
-		dst->colorPtrAttr.xorMaskData = calloc(src->colorPtrAttr.lengthXorMask, sizeof(BYTE));
+		dst->colorPtrAttr.xorMaskData = calloc(pointer->colorPtrAttr.lengthXorMask, sizeof(BYTE));
 
 		if (!dst->colorPtrAttr.xorMaskData)
 			goto fail;
 
-		memcpy(dst->colorPtrAttr.xorMaskData, src->colorPtrAttr.xorMaskData,
-		       src->colorPtrAttr.lengthXorMask);
+		memcpy(dst->colorPtrAttr.xorMaskData, pointer->colorPtrAttr.xorMaskData,
+		       pointer->colorPtrAttr.lengthXorMask);
 	}
 
 	return dst;

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -734,13 +734,13 @@ static inline void progressive_rfx_dwt_2d_decode_block(INT16* WINPR_RESTRICT buf
 	                       nBandL + nBandH);
 }
 
-void rfx_dwt_2d_extrapolate_decode(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT temp)
+void rfx_dwt_2d_extrapolate_decode(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer)
 {
 	WINPR_ASSERT(buffer);
-	WINPR_ASSERT(temp);
-	progressive_rfx_dwt_2d_decode_block(&buffer[3807], temp, 3);
-	progressive_rfx_dwt_2d_decode_block(&buffer[3007], temp, 2);
-	progressive_rfx_dwt_2d_decode_block(&buffer[0], temp, 1);
+	WINPR_ASSERT(dwt_buffer);
+	progressive_rfx_dwt_2d_decode_block(&buffer[3807], dwt_buffer, 3);
+	progressive_rfx_dwt_2d_decode_block(&buffer[3007], dwt_buffer, 2);
+	progressive_rfx_dwt_2d_decode_block(&buffer[0], dwt_buffer, 1);
 }
 
 static inline int progressive_rfx_dwt_2d_decode(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressive,

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -2471,33 +2471,33 @@ const char* rfx_get_progressive_block_type_string(UINT16 blockType)
 	}
 }
 
-BOOL rfx_write_message_progressive_simple(RFX_CONTEXT* WINPR_RESTRICT context,
+BOOL rfx_write_message_progressive_simple(RFX_CONTEXT* WINPR_RESTRICT rfx,
                                           wStream* WINPR_RESTRICT s,
                                           const RFX_MESSAGE* WINPR_RESTRICT msg)
 {
 	WINPR_ASSERT(s);
 	WINPR_ASSERT(msg);
-	WINPR_ASSERT(context);
+	WINPR_ASSERT(rfx);
 
-	if (context->mode != RLGR1)
+	if (rfx->mode != RLGR1)
 	{
 		WLog_ERR(TAG, "error, RLGR1 mode is required!");
 		return FALSE;
 	}
 
-	if (!rfx_write_progressive_wb_sync(context, s))
+	if (!rfx_write_progressive_wb_sync(rfx, s))
 		return FALSE;
 
-	if (!rfx_write_progressive_wb_context(context, s))
+	if (!rfx_write_progressive_wb_context(rfx, s))
 		return FALSE;
 
-	if (!rfx_write_progressive_frame_begin(context, s, msg))
+	if (!rfx_write_progressive_frame_begin(rfx, s, msg))
 		return FALSE;
 
-	if (!rfx_write_progressive_region(context, s, msg))
+	if (!rfx_write_progressive_region(rfx, s, msg))
 		return FALSE;
 
-	if (!rfx_write_progressive_frame_end(context, s))
+	if (!rfx_write_progressive_frame_end(rfx, s))
 		return FALSE;
 
 	return TRUE;

--- a/libfreerdp/codec/rfx_quantization.c
+++ b/libfreerdp/codec/rfx_quantization.c
@@ -54,22 +54,23 @@ static inline BOOL rfx_quantization_decode_block(const primitives_t* WINPR_RESTR
 	return prims->lShiftC_16s_inplace(buffer, factor, buffer_size) == PRIMITIVES_SUCCESS;
 }
 
-void rfx_quantization_decode(INT16* WINPR_RESTRICT buffer, const UINT32* WINPR_RESTRICT quantVals)
+void rfx_quantization_decode(INT16* WINPR_RESTRICT buffer,
+                             const UINT32* WINPR_RESTRICT quantization_values)
 {
 	const primitives_t* prims = primitives_get();
 	WINPR_ASSERT(buffer);
-	WINPR_ASSERT(quantVals);
+	WINPR_ASSERT(quantization_values);
 
-	rfx_quantization_decode_block(prims, &buffer[0], 1024, quantVals[8] - 1);    /* HL1 */
-	rfx_quantization_decode_block(prims, &buffer[1024], 1024, quantVals[7] - 1); /* LH1 */
-	rfx_quantization_decode_block(prims, &buffer[2048], 1024, quantVals[9] - 1); /* HH1 */
-	rfx_quantization_decode_block(prims, &buffer[3072], 256, quantVals[5] - 1);  /* HL2 */
-	rfx_quantization_decode_block(prims, &buffer[3328], 256, quantVals[4] - 1);  /* LH2 */
-	rfx_quantization_decode_block(prims, &buffer[3584], 256, quantVals[6] - 1);  /* HH2 */
-	rfx_quantization_decode_block(prims, &buffer[3840], 64, quantVals[2] - 1);   /* HL3 */
-	rfx_quantization_decode_block(prims, &buffer[3904], 64, quantVals[1] - 1);   /* LH3 */
-	rfx_quantization_decode_block(prims, &buffer[3968], 64, quantVals[3] - 1);   /* HH3 */
-	rfx_quantization_decode_block(prims, &buffer[4032], 64, quantVals[0] - 1);   /* LL3 */
+	rfx_quantization_decode_block(prims, &buffer[0], 1024, quantization_values[8] - 1);    /* HL1 */
+	rfx_quantization_decode_block(prims, &buffer[1024], 1024, quantization_values[7] - 1); /* LH1 */
+	rfx_quantization_decode_block(prims, &buffer[2048], 1024, quantization_values[9] - 1); /* HH1 */
+	rfx_quantization_decode_block(prims, &buffer[3072], 256, quantization_values[5] - 1);  /* HL2 */
+	rfx_quantization_decode_block(prims, &buffer[3328], 256, quantization_values[4] - 1);  /* LH2 */
+	rfx_quantization_decode_block(prims, &buffer[3584], 256, quantization_values[6] - 1);  /* HH2 */
+	rfx_quantization_decode_block(prims, &buffer[3840], 64, quantization_values[2] - 1);   /* HL3 */
+	rfx_quantization_decode_block(prims, &buffer[3904], 64, quantization_values[1] - 1);   /* LH3 */
+	rfx_quantization_decode_block(prims, &buffer[3968], 64, quantization_values[3] - 1);   /* HH3 */
+	rfx_quantization_decode_block(prims, &buffer[4032], 64, quantization_values[0] - 1);   /* LL3 */
 }
 
 static inline void rfx_quantization_encode_block(INT16* WINPR_RESTRICT buffer, size_t buffer_size,

--- a/libfreerdp/common/assistance.c
+++ b/libfreerdp/common/assistance.c
@@ -1009,17 +1009,17 @@ fail:
 	return rc;
 }
 
-BYTE* freerdp_assistance_hex_string_to_bin(const void* raw, size_t* size)
+BYTE* freerdp_assistance_hex_string_to_bin(const void* str, size_t* size)
 {
 	BYTE* buffer = NULL;
-	if (!raw || !size)
+	if (!str || !size)
 		return NULL;
 	*size = 0;
-	const size_t length = strlen(raw);
+	const size_t length = strlen(str);
 	buffer = calloc(length, sizeof(BYTE));
 	if (!buffer)
 		return NULL;
-	const size_t rc = winpr_HexStringToBinBuffer(raw, length, buffer, length);
+	const size_t rc = winpr_HexStringToBinBuffer(str, length, buffer, length);
 	if (rc == 0)
 	{
 		free(buffer);
@@ -1029,9 +1029,9 @@ BYTE* freerdp_assistance_hex_string_to_bin(const void* raw, size_t* size)
 	return buffer;
 }
 
-char* freerdp_assistance_bin_to_hex_string(const void* raw, size_t size)
+char* freerdp_assistance_bin_to_hex_string(const void* data, size_t size)
 {
-	return winpr_BinToHexString(raw, size, FALSE);
+	return winpr_BinToHexString(data, size, FALSE);
 }
 
 static int freerdp_assistance_parse_uploadinfo(rdpAssistanceFile* file, char* uploadinfo,

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -2062,25 +2062,25 @@ BOOL freerdp_target_net_addresses_copy(rdpSettings* settings, char** addresses, 
 	return TRUE;
 }
 
-BOOL freerdp_device_equal(const RDPDR_DEVICE* what, const RDPDR_DEVICE* expect)
+BOOL freerdp_device_equal(const RDPDR_DEVICE* what, const RDPDR_DEVICE* other)
 {
-	if (!what && !expect)
+	if (!what && !other)
 		return TRUE;
-	if (!what || !expect)
+	if (!what || !other)
 		return FALSE;
 
-	if (what->Id != expect->Id)
+	if (what->Id != other->Id)
 		return FALSE;
-	if (what->Type != expect->Type)
+	if (what->Type != other->Type)
 		return FALSE;
-	if (what->Name && expect->Name)
+	if (what->Name && other->Name)
 	{
-		if (strcmp(what->Name, expect->Name) != 0)
+		if (strcmp(what->Name, other->Name) != 0)
 			return FALSE;
 	}
 	else
 	{
-		if (what->Name != expect->Name)
+		if (what->Name != other->Name)
 			return FALSE;
 	}
 
@@ -2089,7 +2089,7 @@ BOOL freerdp_device_equal(const RDPDR_DEVICE* what, const RDPDR_DEVICE* expect)
 		case RDPDR_DTYP_PRINT:
 		{
 			const RDPDR_PRINTER* a = (const RDPDR_PRINTER*)what;
-			const RDPDR_PRINTER* b = (const RDPDR_PRINTER*)expect;
+			const RDPDR_PRINTER* b = (const RDPDR_PRINTER*)other;
 			if (a->DriverName && b->DriverName)
 				return strcmp(a->DriverName, b->DriverName) == 0;
 			return a->DriverName == b->DriverName;
@@ -2098,7 +2098,7 @@ BOOL freerdp_device_equal(const RDPDR_DEVICE* what, const RDPDR_DEVICE* expect)
 		case RDPDR_DTYP_SERIAL:
 		{
 			const RDPDR_SERIAL* a = (const RDPDR_SERIAL*)what;
-			const RDPDR_SERIAL* b = (const RDPDR_SERIAL*)expect;
+			const RDPDR_SERIAL* b = (const RDPDR_SERIAL*)other;
 
 			if (a->Path && b->Path)
 			{
@@ -2123,7 +2123,7 @@ BOOL freerdp_device_equal(const RDPDR_DEVICE* what, const RDPDR_DEVICE* expect)
 		case RDPDR_DTYP_PARALLEL:
 		{
 			const RDPDR_PARALLEL* a = (const RDPDR_PARALLEL*)what;
-			const RDPDR_PARALLEL* b = (const RDPDR_PARALLEL*)expect;
+			const RDPDR_PARALLEL* b = (const RDPDR_PARALLEL*)other;
 			if (a->Path && b->Path)
 				return strcmp(a->Path, b->Path) == 0;
 			return a->Path == b->Path;
@@ -2134,7 +2134,7 @@ BOOL freerdp_device_equal(const RDPDR_DEVICE* what, const RDPDR_DEVICE* expect)
 		case RDPDR_DTYP_FILESYSTEM:
 		{
 			const RDPDR_DRIVE* a = (const RDPDR_DRIVE*)what;
-			const RDPDR_DRIVE* b = (const RDPDR_DRIVE*)expect;
+			const RDPDR_DRIVE* b = (const RDPDR_DRIVE*)other;
 			if (a->automount != b->automount)
 				return FALSE;
 			if (a->Path && b->Path)

--- a/libfreerdp/core/credssp_auth.c
+++ b/libfreerdp/core/credssp_auth.c
@@ -135,12 +135,13 @@ static BOOL credssp_auth_update_name_cache(rdpCredsspAuth* auth, TCHAR* name)
 #endif
 	return TRUE;
 }
-rdpCredsspAuth* credssp_auth_new(const rdpContext* rdp_ctx)
+rdpCredsspAuth* credssp_auth_new(const rdpContext* context)
 {
+	WINPR_ASSERT(context);
 	rdpCredsspAuth* auth = calloc(1, sizeof(rdpCredsspAuth));
 
 	if (auth)
-		auth->rdp_ctx = rdp_ctx;
+		auth->rdp_ctx = context;
 
 	return auth;
 }

--- a/libfreerdp/core/fastpath.h
+++ b/libfreerdp/core/fastpath.h
@@ -149,7 +149,7 @@ FREERDP_LOCAL wStream* fastpath_input_pdu_init(rdpFastPath* fastpath, BYTE event
 
 WINPR_ATTR_NODISCARD
 FREERDP_LOCAL BOOL fastpath_send_multiple_input_pdu(rdpFastPath* fastpath, wStream* s,
-                                                    size_t iEventCount, UINT16 sec_flags);
+                                                    size_t iNumEvents, UINT16 sec_flags);
 
 WINPR_ATTR_NODISCARD
 FREERDP_LOCAL BOOL fastpath_send_input_pdu(rdpFastPath* fastpath, wStream* s, UINT16 sec_flags);

--- a/libfreerdp/core/gateway/http.h
+++ b/libfreerdp/core/gateway/http.h
@@ -104,7 +104,7 @@ FREERDP_LOCAL BOOL http_context_set_rdg_connection_id(HttpContext* context,
 
 WINPR_ATTR_NODISCARD
 FREERDP_LOCAL BOOL http_context_set_rdg_correlation_id(HttpContext* context,
-                                                       const GUID* RdgConnectionId);
+                                                       const GUID* RdgCorrelationId);
 
 WINPR_ATTR_NODISCARD
 WINPR_ATTR_FORMAT_ARG(3, 4)

--- a/libfreerdp/core/gateway/rpc_client.h
+++ b/libfreerdp/core/gateway/rpc_client.h
@@ -29,7 +29,7 @@
 WINPR_ATTR_NODISCARD
 FREERDP_LOCAL RpcClientCall* rpc_client_call_find_by_id(RpcClient* client, UINT32 CallId);
 
-FREERDP_LOCAL void rpc_client_call_free(RpcClientCall* client_call);
+FREERDP_LOCAL void rpc_client_call_free(RpcClientCall* clientCall);
 
 WINPR_ATTR_MALLOC(rpc_client_call_free, 1)
 WINPR_ATTR_NODISCARD

--- a/libfreerdp/core/gateway/rpc_fault.h
+++ b/libfreerdp/core/gateway/rpc_fault.h
@@ -26,9 +26,9 @@
 FREERDP_LOCAL int rpc_recv_fault_pdu(UINT32 status);
 
 WINPR_ATTR_NODISCARD
-FREERDP_LOCAL const char* rpc_error_to_string(UINT32 error);
+FREERDP_LOCAL const char* rpc_error_to_string(UINT32 code);
 
 WINPR_ATTR_NODISCARD
-FREERDP_LOCAL const char* rpc_error_to_category(UINT32 error);
+FREERDP_LOCAL const char* rpc_error_to_category(UINT32 code);
 
 #endif /* FREERDP_LIB_CORE_GATEWAY_RPC_FAULT_H */

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -820,14 +820,7 @@ static UINT32 rdp_get_sec_bytes(rdpRdp* rdp, UINT16 sec_flags)
 	return sec_bytes;
 }
 
-/**
- * Send an RDP packet.
- * @param rdp RDP module
- * @param s stream
- * @param channel_id channel id
- */
-
-BOOL rdp_send(rdpRdp* rdp, wStream* s, UINT16 channel_id, UINT16 sec_flags)
+BOOL rdp_send(rdpRdp* rdp, wStream* s, UINT16 channelId, UINT16 sec_flags)
 {
 	BOOL rc = FALSE;
 	UINT32 pad = 0;
@@ -848,7 +841,7 @@ BOOL rdp_send(rdpRdp* rdp, wStream* s, UINT16 channel_id, UINT16 sec_flags)
 	{
 		size_t length = Stream_GetPosition(s);
 		Stream_SetPosition(s, 0);
-		if (!rdp_write_header(rdp, s, length, channel_id, sec_flags))
+		if (!rdp_write_header(rdp, s, length, channelId, sec_flags))
 			goto fail;
 
 		if (!rdp_security_stream_out(rdp, s, length, sec_flags, &pad))

--- a/libfreerdp/core/rdp.h
+++ b/libfreerdp/core/rdp.h
@@ -225,8 +225,8 @@ FREERDP_LOCAL BOOL rdp_read_share_control_header(rdpRdp* rdp, wStream* s, UINT16
 
 WINPR_ATTR_NODISCARD
 FREERDP_LOCAL BOOL rdp_read_share_data_header(rdpRdp* rdp, wStream* s, UINT16* length, BYTE* type,
-                                              UINT32* share_id, BYTE* compressed_type,
-                                              UINT16* compressed_len);
+                                              UINT32* shareId, BYTE* compressedType,
+                                              UINT16* compressedLength);
 
 WINPR_ATTR_NODISCARD
 FREERDP_LOCAL BOOL rdp_send(rdpRdp* rdp, wStream* s, UINT16 channelId, UINT16 sec_flags);
@@ -240,10 +240,10 @@ WINPR_ATTR_NODISCARD
 FREERDP_LOCAL wStream* rdp_send_stream_pdu_init(rdpRdp* rdp, UINT16* sec_flags);
 
 WINPR_ATTR_NODISCARD
-FREERDP_LOCAL BOOL rdp_read_header(rdpRdp* rdp, wStream* s, UINT16* length, UINT16* channel_id);
+FREERDP_LOCAL BOOL rdp_read_header(rdpRdp* rdp, wStream* s, UINT16* length, UINT16* channelId);
 
 WINPR_ATTR_NODISCARD
-FREERDP_LOCAL BOOL rdp_write_header(rdpRdp* rdp, wStream* s, size_t length, UINT16 channel_id,
+FREERDP_LOCAL BOOL rdp_write_header(rdpRdp* rdp, wStream* s, size_t length, UINT16 channelId,
                                     UINT16 sec_flags);
 
 WINPR_ATTR_NODISCARD

--- a/libfreerdp/core/smartcardlogon.c
+++ b/libfreerdp/core/smartcardlogon.c
@@ -109,18 +109,18 @@ void smartcardCertInfo_Free(SmartcardCertInfo* scCert)
 	free(scCert);
 }
 
-void smartcardCertList_Free(SmartcardCertInfo** cert_list, size_t count)
+void smartcardCertList_Free(SmartcardCertInfo** pscCert, size_t count)
 {
-	if (!cert_list)
+	if (!pscCert)
 		return;
 
 	for (size_t i = 0; i < count; i++)
 	{
-		SmartcardCertInfo* cert = cert_list[i];
+		SmartcardCertInfo* cert = pscCert[i];
 		smartcardCertInfo_Free(cert);
 	}
 
-	free((void*)cert_list);
+	free((void*)pscCert);
 }
 
 static BOOL add_cert_to_list(SmartcardCertInfo*** certInfoList, size_t* count,

--- a/libfreerdp/crypto/x509_utils.c
+++ b/libfreerdp/crypto/x509_utils.c
@@ -518,12 +518,12 @@ void x509_utils_dns_names_free(size_t count, size_t* lengths, char** dns_names)
 	}
 }
 
-char** x509_utils_get_dns_names(const X509* x509, size_t* count, size_t** lengths)
+char** x509_utils_get_dns_names(const X509* xcert, size_t* count, size_t** lengths)
 {
 	char** result = 0;
 	string_list list = WINPR_C_ARRAY_INIT;
 	string_list_initialize(&list);
-	map_subject_alt_name(x509, GEN_DNS, extract_string, &list);
+	map_subject_alt_name(xcert, GEN_DNS, extract_string, &list);
 	(*count) = list.count;
 
 	if (list.count <= 0)

--- a/libfreerdp/crypto/x509_utils.h
+++ b/libfreerdp/crypto/x509_utils.h
@@ -81,7 +81,7 @@ extern "C"
 	FREERDP_LOCAL void x509_utils_dns_names_free(size_t count, size_t* lengths, char** dns_names);
 
 	WINPR_ATTR_NODISCARD
-	FREERDP_LOCAL BOOL x509_utils_check_eku(const X509* scert, int nid);
+	FREERDP_LOCAL BOOL x509_utils_check_eku(const X509* xcert, int nid);
 
 	FREERDP_LOCAL void x509_utils_print_info(const X509* xcert);
 

--- a/libfreerdp/gdi/gdi.h
+++ b/libfreerdp/gdi/gdi.h
@@ -30,7 +30,7 @@
 WINPR_ATTR_NODISCARD
 FREERDP_LOCAL BOOL gdi_bitmap_update(rdpContext* context, const BITMAP_UPDATE* bitmapUpdate);
 
-FREERDP_LOCAL void gdi_bitmap_free_ex(gdiBitmap* gdi_bmp);
+FREERDP_LOCAL void gdi_bitmap_free_ex(gdiBitmap* bitmap);
 
 WINPR_ATTR_MALLOC(gdi_bitmap_free_ex, 1)
 WINPR_ATTR_NODISCARD

--- a/libfreerdp/utils/cliprdr_utils.c
+++ b/libfreerdp/utils/cliprdr_utils.c
@@ -111,62 +111,63 @@ out:
 	return result;
 }
 
-BOOL cliprdr_read_filedescriptor(wStream* s, FILEDESCRIPTORW* file)
+BOOL cliprdr_read_filedescriptor(wStream* s, FILEDESCRIPTORW* descriptor)
 {
 	UINT64 tmp = 0;
-	WINPR_ASSERT(file);
+	WINPR_ASSERT(descriptor);
 
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, sizeof(FILEDESCRIPTORW)))
 		return FALSE;
 
-	Stream_Read_UINT32(s, file->dwFlags); /* flags (4 bytes) */
-	Stream_Read_UINT32(s, file->clsid.Data1);
-	Stream_Read_UINT16(s, file->clsid.Data2);
-	Stream_Read_UINT16(s, file->clsid.Data3);
-	Stream_Read(s, &file->clsid.Data4, sizeof(file->clsid.Data4));
-	Stream_Read_INT32(s, file->sizel.cx);
-	Stream_Read_INT32(s, file->sizel.cy);
-	Stream_Read_INT32(s, file->pointl.x);
-	Stream_Read_INT32(s, file->pointl.y);
-	Stream_Read_UINT32(s, file->dwFileAttributes); /* fileAttributes (4 bytes) */
+	Stream_Read_UINT32(s, descriptor->dwFlags); /* flags (4 bytes) */
+	Stream_Read_UINT32(s, descriptor->clsid.Data1);
+	Stream_Read_UINT16(s, descriptor->clsid.Data2);
+	Stream_Read_UINT16(s, descriptor->clsid.Data3);
+	Stream_Read(s, &descriptor->clsid.Data4, sizeof(descriptor->clsid.Data4));
+	Stream_Read_INT32(s, descriptor->sizel.cx);
+	Stream_Read_INT32(s, descriptor->sizel.cy);
+	Stream_Read_INT32(s, descriptor->pointl.x);
+	Stream_Read_INT32(s, descriptor->pointl.y);
+	Stream_Read_UINT32(s, descriptor->dwFileAttributes); /* fileAttributes (4 bytes) */
 	Stream_Read_UINT64(s, tmp);                    /* ftCreationTime (8 bytes) */
-	file->ftCreationTime = uint64_to_filetime(tmp);
+	descriptor->ftCreationTime = uint64_to_filetime(tmp);
 	Stream_Read_UINT64(s, tmp); /* ftLastAccessTime (8 bytes) */
-	file->ftLastAccessTime = uint64_to_filetime(tmp);
+	descriptor->ftLastAccessTime = uint64_to_filetime(tmp);
 	Stream_Read_UINT64(s, tmp); /* lastWriteTime (8 bytes) */
-	file->ftLastWriteTime = uint64_to_filetime(tmp);
-	Stream_Read_UINT32(s, file->nFileSizeHigh); /* fileSizeHigh (4 bytes) */
-	Stream_Read_UINT32(s, file->nFileSizeLow);  /* fileSizeLow (4 bytes) */
-	Stream_Read_UTF16_String(s, file->cFileName,
-	                         ARRAYSIZE(file->cFileName)); /* cFileName (520 bytes) */
+	descriptor->ftLastWriteTime = uint64_to_filetime(tmp);
+	Stream_Read_UINT32(s, descriptor->nFileSizeHigh); /* fileSizeHigh (4 bytes) */
+	Stream_Read_UINT32(s, descriptor->nFileSizeLow);  /* fileSizeLow (4 bytes) */
+	Stream_Read_UTF16_String(s, descriptor->cFileName,
+	                         ARRAYSIZE(descriptor->cFileName)); /* cFileName (520 bytes) */
 	return TRUE;
 }
 
-BOOL cliprdr_write_filedescriptor(wStream* s, const FILEDESCRIPTORW* file)
+BOOL cliprdr_write_filedescriptor(wStream* s, const FILEDESCRIPTORW* descriptor)
 {
-	WINPR_ASSERT(file);
+	WINPR_ASSERT(descriptor);
 
 	if (!Stream_EnsureRemainingCapacity(s, sizeof(FILEDESCRIPTORW)))
 		return FALSE;
 
-	Stream_Write_UINT32(s, file->dwFlags); /* flags (4 bytes) */
+	Stream_Write_UINT32(s, descriptor->dwFlags); /* flags (4 bytes) */
 
-	Stream_Write_UINT32(s, file->clsid.Data1);
-	Stream_Write_UINT16(s, file->clsid.Data2);
-	Stream_Write_UINT16(s, file->clsid.Data3);
-	Stream_Write(s, &file->clsid.Data4, sizeof(file->clsid.Data4));
-	Stream_Write_INT32(s, file->sizel.cx);
-	Stream_Write_INT32(s, file->sizel.cy);
-	Stream_Write_INT32(s, file->pointl.x);
-	Stream_Write_INT32(s, file->pointl.y);
-	Stream_Write_UINT32(s, file->dwFileAttributes); /* fileAttributes (4 bytes) */
-	Stream_Write_UINT64(s, filetime_to_uint64(file->ftCreationTime));
-	Stream_Write_UINT64(s, filetime_to_uint64(file->ftLastAccessTime));
-	Stream_Write_UINT64(s, filetime_to_uint64(file->ftLastWriteTime)); /* lastWriteTime (8 bytes) */
-	Stream_Write_UINT32(s, file->nFileSizeHigh);                       /* fileSizeHigh (4 bytes) */
-	Stream_Write_UINT32(s, file->nFileSizeLow);                        /* fileSizeLow (4 bytes) */
-	Stream_Write_UTF16_String(s, file->cFileName,
-	                          ARRAYSIZE(file->cFileName)); /* cFileName (520 bytes) */
+	Stream_Write_UINT32(s, descriptor->clsid.Data1);
+	Stream_Write_UINT16(s, descriptor->clsid.Data2);
+	Stream_Write_UINT16(s, descriptor->clsid.Data3);
+	Stream_Write(s, &descriptor->clsid.Data4, sizeof(descriptor->clsid.Data4));
+	Stream_Write_INT32(s, descriptor->sizel.cx);
+	Stream_Write_INT32(s, descriptor->sizel.cy);
+	Stream_Write_INT32(s, descriptor->pointl.x);
+	Stream_Write_INT32(s, descriptor->pointl.y);
+	Stream_Write_UINT32(s, descriptor->dwFileAttributes); /* fileAttributes (4 bytes) */
+	Stream_Write_UINT64(s, filetime_to_uint64(descriptor->ftCreationTime));
+	Stream_Write_UINT64(s, filetime_to_uint64(descriptor->ftLastAccessTime));
+	Stream_Write_UINT64(
+	    s, filetime_to_uint64(descriptor->ftLastWriteTime)); /* lastWriteTime (8 bytes) */
+	Stream_Write_UINT32(s, descriptor->nFileSizeHigh);       /* fileSizeHigh (4 bytes) */
+	Stream_Write_UINT32(s, descriptor->nFileSizeLow);        /* fileSizeLow (4 bytes) */
+	Stream_Write_UTF16_String(s, descriptor->cFileName,
+	                          ARRAYSIZE(descriptor->cFileName)); /* cFileName (520 bytes) */
 	return TRUE;
 }
 

--- a/libfreerdp/utils/rdpdr_utils.c
+++ b/libfreerdp/utils/rdpdr_utils.c
@@ -496,14 +496,14 @@ static void rdpdr_dump_packet(wLog* log, DWORD lvl, wStream* s, const char* cust
 	Stream_SetPosition(s, gpos);
 }
 
-void rdpdr_dump_received_packet(wLog* log, DWORD lvl, wStream* s, const char* custom)
+void rdpdr_dump_received_packet(wLog* log, DWORD lvl, wStream* out, const char* custom)
 {
-	rdpdr_dump_packet(log, lvl, s, custom, FALSE);
+	rdpdr_dump_packet(log, lvl, out, custom, FALSE);
 }
 
-void rdpdr_dump_send_packet(wLog* log, DWORD lvl, wStream* s, const char* custom)
+void rdpdr_dump_send_packet(wLog* log, DWORD lvl, wStream* out, const char* custom)
 {
-	rdpdr_dump_packet(log, lvl, s, custom, TRUE);
+	rdpdr_dump_packet(log, lvl, out, custom, TRUE);
 }
 
 const char* rdpdr_irp_string(UINT32 major)

--- a/libfreerdp/utils/smartcard_call.c
+++ b/libfreerdp/utils/smartcard_call.c
@@ -1585,14 +1585,14 @@ static LONG smartcard_LocateCardsByATRA_Call(scard_call_context* smartcard, wStr
 	return ret.ReturnCode;
 }
 
-LONG smartcard_irp_device_control_call(scard_call_context* smartcard, wStream* out,
-                                       NTSTATUS* pIoStatus, SMARTCARD_OPERATION* operation)
+LONG smartcard_irp_device_control_call(scard_call_context* ctx, wStream* out, NTSTATUS* pIoStatus,
+                                       SMARTCARD_OPERATION* operation)
 {
 	LONG result = 0;
 	UINT32 offset = 0;
 	size_t objectBufferLength = 0;
 
-	WINPR_ASSERT(smartcard);
+	WINPR_ASSERT(ctx);
 	WINPR_ASSERT(out);
 	WINPR_ASSERT(pIoStatus);
 	WINPR_ASSERT(operation);
@@ -1619,195 +1619,195 @@ LONG smartcard_irp_device_control_call(scard_call_context* smartcard, wStream* o
 	switch (ioControlCode)
 	{
 		case SCARD_IOCTL_ESTABLISHCONTEXT:
-			result = smartcard_EstablishContext_Call(smartcard, out, operation);
+			result = smartcard_EstablishContext_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_RELEASECONTEXT:
-			result = smartcard_ReleaseContext_Call(smartcard, out, operation);
+			result = smartcard_ReleaseContext_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_ISVALIDCONTEXT:
-			result = smartcard_IsValidContext_Call(smartcard, out, operation);
+			result = smartcard_IsValidContext_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_LISTREADERGROUPSA:
-			result = smartcard_ListReaderGroupsA_Call(smartcard, out, operation);
+			result = smartcard_ListReaderGroupsA_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_LISTREADERGROUPSW:
-			result = smartcard_ListReaderGroupsW_Call(smartcard, out, operation);
+			result = smartcard_ListReaderGroupsW_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_LISTREADERSA:
-			result = smartcard_ListReadersA_Call(smartcard, out, operation);
+			result = smartcard_ListReadersA_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_LISTREADERSW:
-			result = smartcard_ListReadersW_Call(smartcard, out, operation);
+			result = smartcard_ListReadersW_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_INTRODUCEREADERGROUPA:
-			result = smartcard_IntroduceReaderGroupA_Call(smartcard, out, operation);
+			result = smartcard_IntroduceReaderGroupA_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_INTRODUCEREADERGROUPW:
-			result = smartcard_IntroduceReaderGroupW_Call(smartcard, out, operation);
+			result = smartcard_IntroduceReaderGroupW_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_FORGETREADERGROUPA:
-			result = smartcard_ForgetReaderA_Call(smartcard, out, operation);
+			result = smartcard_ForgetReaderA_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_FORGETREADERGROUPW:
-			result = smartcard_ForgetReaderW_Call(smartcard, out, operation);
+			result = smartcard_ForgetReaderW_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_INTRODUCEREADERA:
-			result = smartcard_IntroduceReaderA_Call(smartcard, out, operation);
+			result = smartcard_IntroduceReaderA_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_INTRODUCEREADERW:
-			result = smartcard_IntroduceReaderW_Call(smartcard, out, operation);
+			result = smartcard_IntroduceReaderW_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_FORGETREADERA:
-			result = smartcard_ForgetReaderA_Call(smartcard, out, operation);
+			result = smartcard_ForgetReaderA_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_FORGETREADERW:
-			result = smartcard_ForgetReaderW_Call(smartcard, out, operation);
+			result = smartcard_ForgetReaderW_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_ADDREADERTOGROUPA:
-			result = smartcard_AddReaderToGroupA_Call(smartcard, out, operation);
+			result = smartcard_AddReaderToGroupA_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_ADDREADERTOGROUPW:
-			result = smartcard_AddReaderToGroupW_Call(smartcard, out, operation);
+			result = smartcard_AddReaderToGroupW_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_REMOVEREADERFROMGROUPA:
-			result = smartcard_RemoveReaderFromGroupA_Call(smartcard, out, operation);
+			result = smartcard_RemoveReaderFromGroupA_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_REMOVEREADERFROMGROUPW:
-			result = smartcard_RemoveReaderFromGroupW_Call(smartcard, out, operation);
+			result = smartcard_RemoveReaderFromGroupW_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_LOCATECARDSA:
-			result = smartcard_LocateCardsA_Call(smartcard, out, operation);
+			result = smartcard_LocateCardsA_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_LOCATECARDSW:
-			result = smartcard_LocateCardsW_Call(smartcard, out, operation);
+			result = smartcard_LocateCardsW_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_GETSTATUSCHANGEA:
-			result = smartcard_GetStatusChangeA_Call(smartcard, out, operation);
+			result = smartcard_GetStatusChangeA_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_GETSTATUSCHANGEW:
-			result = smartcard_GetStatusChangeW_Call(smartcard, out, operation);
+			result = smartcard_GetStatusChangeW_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_CANCEL:
-			result = smartcard_Cancel_Call(smartcard, out, operation);
+			result = smartcard_Cancel_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_CONNECTA:
-			result = smartcard_ConnectA_Call(smartcard, out, operation);
+			result = smartcard_ConnectA_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_CONNECTW:
-			result = smartcard_ConnectW_Call(smartcard, out, operation);
+			result = smartcard_ConnectW_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_RECONNECT:
-			result = smartcard_Reconnect_Call(smartcard, out, operation);
+			result = smartcard_Reconnect_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_DISCONNECT:
-			result = smartcard_Disconnect_Call(smartcard, out, operation);
+			result = smartcard_Disconnect_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_BEGINTRANSACTION:
-			result = smartcard_BeginTransaction_Call(smartcard, out, operation);
+			result = smartcard_BeginTransaction_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_ENDTRANSACTION:
-			result = smartcard_EndTransaction_Call(smartcard, out, operation);
+			result = smartcard_EndTransaction_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_STATE:
-			result = smartcard_State_Call(smartcard, out, operation);
+			result = smartcard_State_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_STATUSA:
-			result = smartcard_StatusA_Call(smartcard, out, operation);
+			result = smartcard_StatusA_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_STATUSW:
-			result = smartcard_StatusW_Call(smartcard, out, operation);
+			result = smartcard_StatusW_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_TRANSMIT:
-			result = smartcard_Transmit_Call(smartcard, out, operation);
+			result = smartcard_Transmit_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_CONTROL:
-			result = smartcard_Control_Call(smartcard, out, operation);
+			result = smartcard_Control_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_GETATTRIB:
-			result = smartcard_GetAttrib_Call(smartcard, out, operation);
+			result = smartcard_GetAttrib_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_SETATTRIB:
-			result = smartcard_SetAttrib_Call(smartcard, out, operation);
+			result = smartcard_SetAttrib_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_ACCESSSTARTEDEVENT:
-			result = smartcard_AccessStartedEvent_Call(smartcard, out, operation);
+			result = smartcard_AccessStartedEvent_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_LOCATECARDSBYATRA:
-			result = smartcard_LocateCardsByATRA_Call(smartcard, out, operation);
+			result = smartcard_LocateCardsByATRA_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_LOCATECARDSBYATRW:
-			result = smartcard_LocateCardsW_Call(smartcard, out, operation);
+			result = smartcard_LocateCardsW_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_READCACHEA:
-			result = smartcard_ReadCacheA_Call(smartcard, out, operation);
+			result = smartcard_ReadCacheA_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_READCACHEW:
-			result = smartcard_ReadCacheW_Call(smartcard, out, operation);
+			result = smartcard_ReadCacheW_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_WRITECACHEA:
-			result = smartcard_WriteCacheA_Call(smartcard, out, operation);
+			result = smartcard_WriteCacheA_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_WRITECACHEW:
-			result = smartcard_WriteCacheW_Call(smartcard, out, operation);
+			result = smartcard_WriteCacheW_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_GETTRANSMITCOUNT:
-			result = smartcard_GetTransmitCount_Call(smartcard, out, operation);
+			result = smartcard_GetTransmitCount_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_RELEASETARTEDEVENT:
-			result = smartcard_ReleaseStartedEvent_Call(smartcard, out, operation);
+			result = smartcard_ReleaseStartedEvent_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_GETREADERICON:
-			result = smartcard_GetReaderIcon_Call(smartcard, out, operation);
+			result = smartcard_GetReaderIcon_Call(ctx, out, operation);
 			break;
 
 		case SCARD_IOCTL_GETDEVICETYPEID:
-			result = smartcard_GetDeviceTypeId_Call(smartcard, out, operation);
+			result = smartcard_GetDeviceTypeId_Call(ctx, out, operation);
 			break;
 
 		default:
@@ -1834,7 +1834,7 @@ LONG smartcard_irp_device_control_call(scard_call_context* smartcard, wStream* o
 	    (result != SCARD_E_NO_READERS_AVAILABLE) && (result != SCARD_E_NO_SERVICE) &&
 	    (result != SCARD_W_CACHE_ITEM_NOT_FOUND) && (result != SCARD_W_CACHE_ITEM_STALE))
 	{
-		WLog_Print(smartcard->log, WLOG_WARN,
+		WLog_Print(ctx->log, WLOG_WARN,
 		           "IRP failure: %s (0x%08" PRIX32 "), status: %s (0x%08" PRIX32 ")",
 		           scard_get_ioctl_string(ioControlCode, TRUE), ioControlCode,
 		           SCardGetErrorString(result), WINPR_CXX_COMPAT_CAST(UINT32, result));
@@ -1846,7 +1846,7 @@ LONG smartcard_irp_device_control_call(scard_call_context* smartcard, wStream* o
 	{
 		/* NTSTATUS error */
 		*pIoStatus = result;
-		WLog_Print(smartcard->log, WLOG_WARN,
+		WLog_Print(ctx->log, WLOG_WARN,
 		           "IRP failure: %s (0x%08" PRIX32 "), ntstatus: 0x%08" PRIX32 "",
 		           scard_get_ioctl_string(ioControlCode, TRUE), ioControlCode,
 		           WINPR_CXX_COMPAT_CAST(UINT32, result));
@@ -1871,7 +1871,7 @@ LONG smartcard_irp_device_control_call(scard_call_context* smartcard, wStream* o
 	 */
 	if (outputBufferLength > operation->outputBufferLength)
 	{
-		WLog_Print(smartcard->log, WLOG_WARN,
+		WLog_Print(ctx->log, WLOG_WARN,
 		           "IRP warn: expected outputBufferLength %" PRIu32 ", but current limit %" PRIuz
 		           ", respond with STATUS_BUFFER_TOO_SMALL",
 		           operation->outputBufferLength, outputBufferLength);

--- a/libfreerdp/utils/smartcard_pack.c
+++ b/libfreerdp/utils/smartcard_pack.c
@@ -3968,12 +3968,12 @@ LONG smartcard_pack_get_reader_icon_return(wStream* s, const GetReaderIcon_Retur
 	return ret->ReturnCode;
 }
 
-LONG smartcard_pack_get_transmit_count_return(wStream* s, const GetTransmitCount_Return* ret)
+LONG smartcard_pack_get_transmit_count_return(wStream* s, const GetTransmitCount_Return* call)
 {
-	WINPR_ASSERT(ret);
+	WINPR_ASSERT(call);
 	wLog* log = scard_log();
 
-	smartcard_trace_get_transmit_count_return(log, ret);
+	smartcard_trace_get_transmit_count_return(log, call);
 
 	if (!Stream_EnsureRemainingCapacity(s, 4))
 	{
@@ -3981,9 +3981,9 @@ LONG smartcard_pack_get_transmit_count_return(wStream* s, const GetTransmitCount
 		return SCARD_F_INTERNAL_ERROR;
 	}
 
-	Stream_Write_UINT32(s, ret->cTransmitCount); /* cBytes (4 cbDataLen) */
+	Stream_Write_UINT32(s, call->cTransmitCount); /* cBytes (4 cbDataLen) */
 
-	return ret->ReturnCode;
+	return call->ReturnCode;
 }
 
 LONG smartcard_pack_read_cache_return(wStream* s, const ReadCache_Return* ret)

--- a/server/proxy/pf_server.c
+++ b/server/proxy/pf_server.c
@@ -888,7 +888,7 @@ error:
 	return FALSE;
 }
 
-BOOL pf_server_start_with_peer_socket(proxyServer* server, int peer_fd)
+BOOL pf_server_start_with_peer_socket(proxyServer* server, int socket)
 {
 	struct sockaddr_storage peer_addr;
 	socklen_t len = sizeof(peer_addr);
@@ -899,11 +899,11 @@ BOOL pf_server_start_with_peer_socket(proxyServer* server, int peer_fd)
 	if (WaitForSingleObject(server->stopEvent, 0) == WAIT_OBJECT_0)
 		goto fail;
 
-	client = freerdp_peer_new(peer_fd);
+	client = freerdp_peer_new(socket);
 	if (!client)
 		goto fail;
 
-	if (getpeername(peer_fd, (struct sockaddr*)&peer_addr, &len) != 0)
+	if (getpeername(socket, (struct sockaddr*)&peer_addr, &len) != 0)
 		goto fail;
 
 	if (!freerdp_peer_set_local_and_hostname(client, &peer_addr))

--- a/winpr/include/winpr/comm.h
+++ b/winpr/include/winpr/comm.h
@@ -392,7 +392,7 @@ extern "C"
 	 */
 	WINPR_ATTR_MALLOC(CloseHandle, 1)
 	WINPR_ATTR_NODISCARD
-	WINPR_API HANDLE CommCreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode,
+	WINPR_API HANDLE CommCreateFileA(LPCSTR lpDeviceName, DWORD dwDesiredAccess, DWORD dwShareMode,
 	                                 LPSECURITY_ATTRIBUTES lpSecurityAttributes,
 	                                 DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes,
 	                                 HANDLE hTemplateFile);

--- a/winpr/libwinpr/credentials/credentials.c
+++ b/winpr/libwinpr/credentials/credentials.c
@@ -209,12 +209,12 @@ BOOL CredMarshalCredentialA(CRED_MARSHAL_TYPE CredType, PVOID Credential,
 	}
 }
 
-BOOL CredUnmarshalCredentialW(LPCWSTR cred, PCRED_MARSHAL_TYPE pcredType, PVOID* out)
+BOOL CredUnmarshalCredentialW(LPCWSTR cred, PCRED_MARSHAL_TYPE CredType, PVOID* Credential)
 {
 	char* str = NULL;
 	if (cred)
 		str = ConvertWCharToUtf8Alloc(cred, NULL);
-	const BOOL rc = CredUnmarshalCredentialA(str, pcredType, out);
+	const BOOL rc = CredUnmarshalCredentialA(str, CredType, Credential);
 	free(str);
 	return rc;
 }

--- a/winpr/libwinpr/ncrypt/ncrypt.c
+++ b/winpr/libwinpr/ncrypt/ncrypt.c
@@ -111,7 +111,7 @@ SECURITY_STATUS NCryptEnumStorageProviders(DWORD* wProviderCount,
 	size_t stringAllocSize = 0;
 #ifdef WITH_PKCS11
 	LPWSTR strPtr = NULL;
-	static const WCHAR emptyComment[] = WINPR_C_ARRAY_INIT;
+	static const WCHAR emptyComment[1] = WINPR_C_ARRAY_INIT;
 	size_t copyAmount = 0;
 #endif
 

--- a/winpr/libwinpr/utils/json/jansson.c
+++ b/winpr/libwinpr/utils/json/jansson.c
@@ -177,20 +177,20 @@ double WINPR_JSON_GetNumberValue(const WINPR_JSON* item)
 	return json_number_value(ccast(item));
 }
 
-BOOL WINPR_JSON_IsInvalid(const WINPR_JSON* json)
+BOOL WINPR_JSON_IsInvalid(const WINPR_JSON* item)
 {
-	const json_t* item = ccast(json);
-	if (WINPR_JSON_IsArray(item))
+	const json_t* jitem = ccast(item);
+	if (WINPR_JSON_IsArray(jitem))
 		return FALSE;
-	if (WINPR_JSON_IsObject(item))
+	if (WINPR_JSON_IsObject(jitem))
 		return FALSE;
-	if (WINPR_JSON_IsNull(item))
+	if (WINPR_JSON_IsNull(jitem))
 		return FALSE;
-	if (WINPR_JSON_IsNumber(item))
+	if (WINPR_JSON_IsNumber(jitem))
 		return FALSE;
-	if (WINPR_JSON_IsBool(item))
+	if (WINPR_JSON_IsBool(jitem))
 		return FALSE;
-	if (WINPR_JSON_IsString(item))
+	if (WINPR_JSON_IsString(jitem))
 		return FALSE;
 	return TRUE;
 }


### PR DESCRIPTION
Use the same parameter names for declaration and implementation.