### PR TITLE
[uwac] fix rectangular glitch around surface damage regions

### DIFF
--- a/uwac/libuwac/uwac-window.c
+++ b/uwac/libuwac/uwac-window.c
@@ -717,10 +717,10 @@ static void damage_surface(UwacWindow* window, UwacBuffer* buffer, int scale)
 
 	for (int i = 0; i < nrects; i++, box++)
 	{
-		const int x = ((int)floor(box->x1 / scale)) - 1;
-		const int y = ((int)floor(box->y1 / scale)) - 1;
-		const int w = ((int)ceil((box->x2 - box->x1) / scale)) + 2;
-		const int h = ((int)ceil((box->y2 - box->y1) / scale)) + 2;
+		const int x = (int)floor(box->x1 / scale);
+		const int y = (int)floor(box->y1 / scale);
+		const int w = (int)ceil((box->x2 - box->x1) / scale);
+		const int h = (int)ceil((box->y2 - box->y1) / scale);
 		wl_surface_damage(window->surface, x, y, w, h);
 	}
 
@@ -739,10 +739,10 @@ static void damage_surface(UwacWindow* window, UwacBuffer* buffer, int scale)
 		const double dy = floor(1.0 * box->top / scale);
 		const double dw = ceil(1.0 * (box->right - box->left) / scale);
 		const double dh = ceil(1.0 * (box->bottom - box->top) / scale);
-		const int x = ((int)dx) - 1;
-		const int y = ((int)dy) - 1;
-		const int w = ((int)dw) + 2;
-		const int h = ((int)dh) + 2;
+		const int x = (int)dx;
+		const int y = (int)dy;
+		const int w = (int)dw;
+		const int h = (int)dh;
 		wl_surface_damage(window->surface, x, y, w, h);
 	}
 


### PR DESCRIPTION
Commit 09c12699 ("[uwac] window: fix damage region dimensions (rounding errors)") added a 1-pixel expansion to the damage rect passed to wl_surface_damage() (i.e. x-=1, y-=1, w+=2, h+=2) to guard against rounding errors when a display scale factor is in use.

This causes visible rectangular glitches around every updated region. The Wayland compositor re-composites exactly the declared damage region from the attached buffer onto the screen. Because wlf_copy_image() only writes pixels for the exact update rectangle, the 1-pixel border in the buffer is never updated. With double-buffering the border pixels contain stale data from the last time that buffer was used, and the compositor faithfully composites those stale pixels, producing the artifact.

The floor/ceil rounding applied before the expansion is already sufficient to cover any sub-pixel precision lost when converting from buffer coordinates to surface coordinates. Remove the extra ±1 padding.
