### PR TITLE
[client] Fix writing of gatewayusagemethod to .rdp files

### DIFF
--- a/client/common/file.c
+++ b/client/common/file.c
@@ -1241,7 +1241,7 @@ BOOL freerdp_client_populate_rdp_file_from_settings(rdpFile* file, const rdpSett
 	file->Compression = WINPR_ASSERTING_INT_CAST(
 	    UINT32, freerdp_settings_get_bool(settings, FreeRDP_CompressionEnabled));
 	file->AuthenticationLevel = freerdp_settings_get_uint32(settings, FreeRDP_AuthenticationLevel);
-	file->GatewayUsageMethod = freerdp_settings_get_uint32(settings, FreeRDP_GatewayUsageMethod);
+	file->GatewayUsageMethod = freerdp_get_gateway_usage_method(settings);
 	file->GatewayCredentialsSource =
 	    freerdp_settings_get_uint32(settings, FreeRDP_GatewayCredentialsSource);
 	file->PromptCredentialOnce = WINPR_ASSERTING_INT_CAST(

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -285,6 +285,8 @@ extern "C"
 
 	FREERDP_API BOOL freerdp_set_gateway_usage_method(rdpSettings* settings,
 	                                                  UINT32 GatewayUsageMethod);
+	WINPR_ATTR_NODISCARD
+	FREERDP_API UINT32 freerdp_get_gateway_usage_method(rdpSettings* settings);
 	FREERDP_API void freerdp_update_gateway_usage_method(rdpSettings* settings,
 	                                                     UINT32 GatewayEnabled,
 	                                                     UINT32 GatewayBypassLocal);

--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -1156,6 +1156,18 @@ BOOL freerdp_set_gateway_usage_method(rdpSettings* settings, UINT32 GatewayUsage
 	return TRUE;
 }
 
+UINT32 freerdp_get_gateway_usage_method(rdpSettings* settings)
+{
+	if (freerdp_settings_get_bool(settings, FreeRDP_GatewayEnabled))
+	{
+		if (freerdp_settings_get_bool(settings, FreeRDP_GatewayBypassLocal))
+			return TSC_PROXY_MODE_DETECT;
+		return TSC_PROXY_MODE_DIRECT;
+	}
+
+	return freerdp_settings_get_uint32(settings, FreeRDP_GatewayUsageMethod);
+}
+
 void freerdp_update_gateway_usage_method(rdpSettings* settings, UINT32 GatewayEnabled,
                                          UINT32 GatewayBypassLocal)
 {


### PR DESCRIPTION
When loading the gatewayusagemethod setting from a .rdp file we use `freerdp_settings_set_uint32` to set FreeRDP's gateway parameters (`GatewayEnable` and `GatewayBypassLocal`).

However when writing settings back to a .rdp file we ignore these settings. This PR introduces `freerdp_get_gateway_usage_method` that will take internal gateway paramters into account and return the corresponding gatewayusagemethod.
