### PR TITLE
[client,sdl3] limit FREERDP_WLROOTS_HACK

### DIFF
--- a/client/SDL/SDL3/sdl_window.cpp
+++ b/client/SDL/SDL3/sdl_window.cpp
@@ -346,7 +346,10 @@ SDL_Rect SdlWindow::rect(SDL_Window* window, bool forceAsPrimary)
 	if (!SDL_GetWindowSizeInPixels(window, &rect.w, &rect.h))
 		return {};
 
-	if (tryFallback())
+	const auto flags = SDL_GetWindowFlags(window);
+	const auto mask = SDL_WINDOW_FULLSCREEN;
+	const auto fs = (flags & mask) == mask;
+	if (fs && tryFallback())
 	{
 		/* On wlroots compositors (Sway, river, etc.), windows that are hidden/unmapped
 		 * don't get their actual display dimensions. The dummy window returns its creation size


### PR DESCRIPTION
apply fallback only for fullscreen windows.