### PR TITLE
[core,settings] Allow FreeRDP_instance in setter

### DIFF
--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -1499,6 +1499,14 @@ BOOL freerdp_settings_set_pointer_len(rdpSettings* settings, FreeRDP_Settings_Ke
 
 	switch (id)
 	{
+		case FreeRDP_instance:
+			if ((len != 0) && (len != sizeof(void*)))
+			{
+				WLog_ERR(TAG, "FreeRDP_instance::len must be 0 or %" PRIuz, sizeof(void*));
+				return FALSE;
+			}
+			settings->instance = cnv.v;
+			return TRUE;
 		case FreeRDP_RdpServerCertificate:
 			freerdp_certificate_free(settings->RdpServerCertificate);
 

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -335,15 +335,23 @@ void freerdp_settings_free_keys(rdpSettings* dst, BOOL cleanup)
 		switch (cur->type)
 		{
 			case FREERDP_SETTINGS_TYPE_STRING: /* strings */
-				freerdp_settings_set_string_copy_(dst, (FreeRDP_Settings_Keys_String)cur->id,
-				                                  nullptr, 0, cleanup);
+				if (!freerdp_settings_set_string_copy_(dst, (FreeRDP_Settings_Keys_String)cur->id,
+				                                       nullptr, 0, cleanup))
+				{
+					WLog_WARN(TAG,
+					          "freerdp_settings_set_string_copy_(dst, %" PRIdz
+					          ", nullptr, 0, %s) failed",
+					          cur->id, cleanup ? "true" : "false");
+				}
 				break;
 			case FREERDP_SETTINGS_TYPE_POINTER: /* pointer */
 				if (!freerdp_settings_set_pointer_len(dst, (FreeRDP_Settings_Keys_Pointer)cur->id,
 				                                      nullptr, 0))
+				{
 					WLog_WARN(
 					    TAG, "freerdp_settings_set_pointer_len(dst, %" PRIdz ", nullptr, 0) failed",
 					    cur->id);
+				}
 				break;
 			default:
 				break;

--- a/libfreerdp/core/settings.h
+++ b/libfreerdp/core/settings.h
@@ -59,6 +59,7 @@ FREERDP_LOCAL BOOL freerdp_settings_set_string_(rdpSettings* settings,
                                                 FreeRDP_Settings_Keys_String id, const char* val,
                                                 size_t len);
 
+WINPR_ATTR_NODISCARD
 FREERDP_LOCAL BOOL freerdp_settings_set_string_copy_(rdpSettings* settings,
                                                      FreeRDP_Settings_Keys_String id,
                                                      const char* val, size_t len, BOOL cleanup);


### PR DESCRIPTION
Handle FreeRDP_instance in freerdp_settings_set_pointer_len to avoid warning log messages.
