### PR TITLE
[client,sdl] allow FREERDP_WLROOTS_HACK for all sessions

### DIFF
--- a/client/SDL/SDL3/man/sdl3-freerdp-envvar.1
+++ b/client/SDL/SDL3/man/sdl3-freerdp-envvar.1
@@ -1,7 +1,9 @@
 .PP
 FREERDP_WLROOTS_HACK
 .RS 4
-If defined 0 disables multimonitor detection hack entirely. Set to 1 to force enabled.
+If defined \fI0\fR disables multimonitor detection hack entirely. Set to \fI1\fR to enable it for fullscreen sessions. Set to \fIforce\fR to enable it for all sessions.
+.br
+\fIWARNING:\fR Setting \fIforce\fR only works for fullscreen or multimonitor sessions, windowed sessions will start to misbehave!
 .br
 By default fall back to detection of sway or other wlroots based compositors by evaluating \fIXDG_SESSION_DESKTOP\fR and \fIXDG_CURRENT_DESKTOP\fR.
 .br

--- a/client/SDL/SDL3/sdl_window.cpp
+++ b/client/SDL/SDL3/sdl_window.cpp
@@ -354,7 +354,7 @@ SDL_Rect SdlWindow::rect(SDL_Window* window, bool forceAsPrimary)
 	const auto flags = SDL_GetWindowFlags(window);
 	const auto mask = SDL_WINDOW_FULLSCREEN;
 	const auto fs = (flags & mask) == mask;
-	if (fs && tryFallback())
+	if (tryFallback(fs))
 	{
 		/* On wlroots compositors (Sway, river, etc.), windows that are hidden/unmapped
 		 * don't get their actual display dimensions. The dummy window returns its creation size
@@ -535,14 +535,19 @@ SDL_Rect SdlWindow::rect(SDL_DisplayID id, bool forceAsPrimary)
 	return rect(window.get(), forceAsPrimary);
 }
 
-bool SdlWindow::tryFallback()
+bool SdlWindow::tryFallback(bool isFullscreen)
 {
 	/* If we define a custom env variable to use the wlroots hack
 	 * then enable/disable according to this setting only.
 	 */
 	const auto wlroots_hack = SDL_getenv("FREERDP_WLROOTS_HACK");
 	if (wlroots_hack != nullptr)
-		return strcmp(wlroots_hack, "0") != 0;
+	{
+		const auto enabled = strcmp(wlroots_hack, "0") != 0;
+		if (strcmp(wlroots_hack, "force") == 0)
+			isFullscreen = true;
+		return enabled && isFullscreen;
+	}
 
 	const auto platform = SDL_GetPlatform();
 	if ((platform == nullptr) || (strcmp(platform, "Linux") != 0))
@@ -563,7 +568,7 @@ bool SdlWindow::tryFallback()
 	if (xdg_session != nullptr)
 	{
 		if (strcmp(xdg_session, "sway") == 0)
-			return true;
+			return isFullscreen;
 	}
 
 	/* check XDG_CURRENT_DESKTOP
@@ -577,7 +582,7 @@ bool SdlWindow::tryFallback()
 	if (xdg_desktop != nullptr)
 	{
 		if (strcmp(xdg_desktop, "sway:wlroots") == 0)
-			return true;
+			return isFullscreen;
 	}
 
 	return false;

--- a/client/SDL/SDL3/sdl_window.hpp
+++ b/client/SDL/SDL3/sdl_window.hpp
@@ -92,7 +92,7 @@ class SdlWindow
 	[[nodiscard]] static SDL_Rect rect(SDL_Window* window, bool forceAsPrimary = false);
 	[[nodiscard]] static SDL_Rect rect(SDL_DisplayID id, bool forceAsPrimary = false);
 
-	[[nodiscard]] static bool tryFallback();
+	[[nodiscard]] static bool tryFallback(bool isFullscreen);
 
 	enum HighDPIMode
 	{


### PR DESCRIPTION
Since there are some X11 variants (no window manager or such without EWMH support) that fail to properly set fullscreen add an option to set the fallback force enabled. This breaks non fullscreen sessions, but works around fullscreen issues on such systems