### PR TITLE
Add subsystem error detail propagation

### DIFF
--- a/include/freerdp/error.h
+++ b/include/freerdp/error.h
@@ -29,6 +29,45 @@ extern "C"
 {
 #endif
 
+	/** @brief Identifies which subsystem generated a native error.
+	 *  @since version 3.x.0
+	 */
+	typedef enum
+	{
+		FREERDP_ERROR_SUBSYSTEM_NONE = 0,
+		FREERDP_ERROR_SUBSYSTEM_NLA,
+		FREERDP_ERROR_SUBSYSTEM_KERBEROS,
+		FREERDP_ERROR_SUBSYSTEM_NTLM,
+		FREERDP_ERROR_SUBSYSTEM_NEGOTIATE,
+		FREERDP_ERROR_SUBSYSTEM_TLS,
+		FREERDP_ERROR_SUBSYSTEM_GATEWAY_RPC,
+		FREERDP_ERROR_SUBSYSTEM_GATEWAY_HTTP,
+		FREERDP_ERROR_SUBSYSTEM_RDSTLS,
+		FREERDP_ERROR_SUBSYSTEM_AAD,
+		FREERDP_ERROR_SUBSYSTEM_SMARTCARD,
+		FREERDP_ERROR_SUBSYSTEM_MCS,
+		FREERDP_ERROR_SUBSYSTEM_LICENSE,
+		FREERDP_ERROR_SUBSYSTEM_TRANSPORT
+	} FREERDP_ERROR_SUBSYSTEM;
+
+	/** @brief Holds native error detail from a specific subsystem.
+	 *
+	 *  Populated via freerdp_set_error_detail() alongside the existing
+	 *  freerdp_set_last_error() call.  Clients retrieve it after a connection
+	 *  failure with freerdp_get_error_detail().
+	 *
+	 *  @since version 3.x.0
+	 */
+	typedef struct
+	{
+		FREERDP_ERROR_SUBSYSTEM subsystem; /**< which subsystem generated this error */
+		INT64 nativeError;                 /**< raw error code (SECURITY_STATUS, HRESULT,
+		                                        SSL error, SCARD_*, etc.) */
+		char nativeErrorName[128];         /**< machine-readable name, e.g.
+		                                        "SEC_E_KDC_INVALID_REQUEST" */
+		char detail[256];                  /**< human-readable detail message */
+	} rdpErrorDetail;
+
 /* Error categories */
 #define CAT_NONE "success"
 #define CAT_USE "use"

--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -344,7 +344,9 @@ extern "C"
 
 		ALIGN64 UINT32 LastError; /* 3 */
 
-		UINT64 paddingA[16 - 4]; /* 4 */
+		ALIGN64 rdpErrorDetail* errorDetail; /* 4 */
+
+		UINT64 paddingA[16 - 5]; /* 5 */
 
 		ALIGN64 int argc;    /**< (offset 16)
 		                Number of arguments given to the program at launch time.
@@ -754,6 +756,39 @@ owned by rdpRdp */
 
 	WINPR_ATTR_NODISCARD
 	FREERDP_API const char* freerdp_get_last_error_category(UINT32 code);
+
+	/** @brief Retrieve the current subsystem error detail, or NULL if none set.
+	 *  @since version 3.x.0
+	 */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API const rdpErrorDetail* freerdp_get_error_detail(const rdpContext* context);
+
+	/** @brief Return the subsystem enum name as a string (e.g. "KERBEROS").
+	 *  @since version 3.x.0
+	 */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API const char* freerdp_error_subsystem_name(FREERDP_ERROR_SUBSYSTEM subsystem);
+
+	/** Set subsystem error detail.  Overwrites any previously set detail
+	 *  (last error wins — in Negotiate fallback, NTLM error replaces Kerberos error).
+	 */
+#define freerdp_set_error_detail(context, subsys, native, name, msg) \
+	freerdp_set_error_detail_ex((context), (subsys), (native), (name), (msg), \
+	                            __func__, __FILE__, __LINE__)
+
+	/** Force-clear error detail (call between connection attempts). */
+#define freerdp_clear_error_detail(context) \
+	freerdp_clear_error_detail_ex((context), __func__, __FILE__, __LINE__)
+
+	FREERDP_API void freerdp_set_error_detail_ex(rdpContext* context,
+	                                             FREERDP_ERROR_SUBSYSTEM subsystem,
+	                                             INT64 nativeError,
+	                                             const char* nativeErrorName,
+	                                             const char* detail,
+	                                             const char* fkt, const char* file, int line);
+
+	FREERDP_API void freerdp_clear_error_detail_ex(rdpContext* context,
+	                                               const char* fkt, const char* file, int line);
 
 #define freerdp_set_last_error(context, lastError) \
 	freerdp_set_last_error_ex((context), (lastError), __func__, __FILE__, __LINE__)

--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -1007,6 +1007,9 @@ void freerdp_context_free(freerdp* instance)
 	free(ctx->errorDescription);
 	ctx->errorDescription = nullptr;
 
+	free(ctx->errorDetail);
+	ctx->errorDetail = nullptr;
+
 	freerdp_channels_free(ctx->channels);
 	ctx->channels = nullptr;
 
@@ -1170,6 +1173,7 @@ void freerdp_set_last_error_ex(rdpContext* context, UINT32 lastError, const char
 
 	if (lastError == FREERDP_ERROR_SUCCESS)
 	{
+		freerdp_clear_error_detail_ex(context, fkt, file, line);
 		if (WLog_IsLevelActive(context->log, WLOG_DEBUG))
 			WLog_PrintTextMessage(context->log, WLOG_DEBUG, (size_t)line, file, fkt,
 			                      "resetting error state");
@@ -1185,6 +1189,102 @@ void freerdp_set_last_error_ex(rdpContext* context, UINT32 lastError, const char
 		}
 	}
 	context->LastError = lastError;
+}
+
+void freerdp_set_error_detail_ex(rdpContext* context, FREERDP_ERROR_SUBSYSTEM subsystem,
+                                 INT64 nativeError, const char* nativeErrorName,
+                                 const char* detail, const char* fkt, const char* file, int line)
+{
+	WINPR_ASSERT(context);
+
+	if (!context->errorDetail)
+	{
+		context->errorDetail = calloc(1, sizeof(rdpErrorDetail));
+		if (!context->errorDetail)
+		{
+			WLog_Print(context->log, WLOG_ERROR, "Failed to allocate rdpErrorDetail");
+			return;
+		}
+	}
+
+	context->errorDetail->subsystem = subsystem;
+	context->errorDetail->nativeError = nativeError;
+
+	if (nativeErrorName)
+		(void)_snprintf(context->errorDetail->nativeErrorName,
+		                sizeof(context->errorDetail->nativeErrorName), "%s", nativeErrorName);
+	else
+		context->errorDetail->nativeErrorName[0] = '\0';
+
+	if (detail)
+		(void)_snprintf(context->errorDetail->detail, sizeof(context->errorDetail->detail), "%s",
+		                detail);
+	else
+		context->errorDetail->detail[0] = '\0';
+
+	if (WLog_IsLevelActive(context->log, WLOG_DEBUG))
+	{
+		WLog_PrintTextMessage(
+		    context->log, WLOG_DEBUG, (size_t)line, file, fkt,
+		    "[%s] %s (0x%" PRIx64 "): %s", freerdp_error_subsystem_name(subsystem),
+		    context->errorDetail->nativeErrorName, (uint64_t)nativeError,
+		    context->errorDetail->detail);
+	}
+}
+
+void freerdp_clear_error_detail_ex(rdpContext* context, const char* fkt, const char* file,
+                                   int line)
+{
+	WINPR_ASSERT(context);
+	(void)fkt;
+	(void)file;
+	(void)line;
+
+	if (context->errorDetail)
+		memset(context->errorDetail, 0, sizeof(rdpErrorDetail));
+}
+
+const rdpErrorDetail* freerdp_get_error_detail(const rdpContext* context)
+{
+	WINPR_ASSERT(context);
+	return context->errorDetail;
+}
+
+const char* freerdp_error_subsystem_name(FREERDP_ERROR_SUBSYSTEM subsystem)
+{
+	switch (subsystem)
+	{
+		case FREERDP_ERROR_SUBSYSTEM_NONE:
+			return "NONE";
+		case FREERDP_ERROR_SUBSYSTEM_NLA:
+			return "NLA";
+		case FREERDP_ERROR_SUBSYSTEM_KERBEROS:
+			return "KERBEROS";
+		case FREERDP_ERROR_SUBSYSTEM_NTLM:
+			return "NTLM";
+		case FREERDP_ERROR_SUBSYSTEM_NEGOTIATE:
+			return "NEGOTIATE";
+		case FREERDP_ERROR_SUBSYSTEM_TLS:
+			return "TLS";
+		case FREERDP_ERROR_SUBSYSTEM_GATEWAY_RPC:
+			return "GATEWAY_RPC";
+		case FREERDP_ERROR_SUBSYSTEM_GATEWAY_HTTP:
+			return "GATEWAY_HTTP";
+		case FREERDP_ERROR_SUBSYSTEM_RDSTLS:
+			return "RDSTLS";
+		case FREERDP_ERROR_SUBSYSTEM_AAD:
+			return "AAD";
+		case FREERDP_ERROR_SUBSYSTEM_SMARTCARD:
+			return "SMARTCARD";
+		case FREERDP_ERROR_SUBSYSTEM_MCS:
+			return "MCS";
+		case FREERDP_ERROR_SUBSYSTEM_LICENSE:
+			return "LICENSE";
+		case FREERDP_ERROR_SUBSYSTEM_TRANSPORT:
+			return "TRANSPORT";
+		default:
+			return "UNKNOWN";
+	}
 }
 
 const char* freerdp_get_logon_error_info_type_ex(UINT32 type, char* buffer, size_t size)

--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -823,7 +823,9 @@ static BOOL rdg_process_handshake_response(rdpRdg* rdg, wStream* s)
 	if (FAILED((HRESULT)errorCode))
 	{
 		WLog_Print(rdg->log, WLOG_ERROR, "Handshake error %s", error);
-		freerdp_set_last_error_log(rdg->context, errorCode);
+		freerdp_set_error_detail(rdg->context, FREERDP_ERROR_SUBSYSTEM_GATEWAY_HTTP,
+		                         (INT64)errorCode, error, "Handshake error");
+		freerdp_set_last_error_log(rdg->context, FREERDP_ERROR_CONNECT_TRANSPORT_FAILED);
 		return FALSE;
 	}
 
@@ -924,7 +926,9 @@ static BOOL rdg_process_tunnel_response(rdpRdg* rdg, wStream* s)
 	if (FAILED((HRESULT)errorCode))
 	{
 		WLog_Print(rdg->log, WLOG_ERROR, "Tunnel creation error %s", error);
-		freerdp_set_last_error_log(rdg->context, errorCode);
+		freerdp_set_error_detail(rdg->context, FREERDP_ERROR_SUBSYSTEM_GATEWAY_HTTP,
+		                         (INT64)errorCode, error, "Tunnel creation error");
+		freerdp_set_last_error_log(rdg->context, FREERDP_ERROR_CONNECT_TRANSPORT_FAILED);
 		return FALSE;
 	}
 
@@ -960,7 +964,9 @@ static BOOL rdg_process_tunnel_authorization_response(rdpRdg* rdg, wStream* s)
 	if (errorCode != S_OK && errorCode != E_PROXY_QUARANTINE_ACCESSDENIED)
 	{
 		WLog_Print(rdg->log, WLOG_ERROR, "Tunnel authorization error %s", error);
-		freerdp_set_last_error_log(rdg->context, errorCode);
+		freerdp_set_error_detail(rdg->context, FREERDP_ERROR_SUBSYSTEM_GATEWAY_HTTP,
+		                         (INT64)errorCode, error, "Tunnel authorization error");
+		freerdp_set_last_error_log(rdg->context, FREERDP_ERROR_CONNECT_ACCESS_DENIED);
 		return FALSE;
 	}
 
@@ -1108,7 +1114,9 @@ static BOOL rdg_process_channel_response(rdpRdg* rdg, wStream* s)
 	{
 		WLog_Print(rdg->log, WLOG_ERROR, "channel response errorCode=%s, fieldsPresent=%s", error,
 		           channel_response_fields_present_to_string(fieldsPresent));
-		freerdp_set_last_error_log(rdg->context, errorCode);
+		freerdp_set_error_detail(rdg->context, FREERDP_ERROR_SUBSYSTEM_GATEWAY_HTTP,
+		                         (INT64)errorCode, error, "Channel response error");
+		freerdp_set_last_error_log(rdg->context, FREERDP_ERROR_CONNECT_TRANSPORT_FAILED);
 		return FALSE;
 	}
 

--- a/libfreerdp/core/mcs.c
+++ b/libfreerdp/core/mcs.c
@@ -1461,6 +1461,8 @@ BOOL mcs_client_begin(rdpMcs* mcs)
 	/* First transition state, we need this to trigger session recording */
 	if (!mcs_send_connect_initial(mcs))
 	{
+		freerdp_set_error_detail(mcs->context, FREERDP_ERROR_SUBSYSTEM_MCS, 0, NULL,
+		                         "MCS Connect Initial failed");
 		freerdp_set_last_error_if_not(mcs->context, FREERDP_ERROR_MCS_CONNECT_INITIAL_ERROR);
 
 		WLog_Print(mcs->log, WLOG_ERROR, "Error: unable to send MCS Connect Initial");

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -145,6 +145,95 @@ static BOOL nla_decrypt_public_key_hash(rdpNla* nla);
 static BOOL nla_encrypt_ts_credentials(rdpNla* nla);
 static BOOL nla_decrypt_ts_credentials(rdpNla* nla);
 
+static const char* nla_sspi_status_name(INT32 status)
+{
+#define CASE_SSPI(x) \
+	case (INT32)(x): \
+		return #x
+	switch (status)
+	{
+		CASE_SSPI(SEC_E_OK);
+		CASE_SSPI(SEC_E_INSUFFICIENT_MEMORY);
+		CASE_SSPI(SEC_E_INVALID_HANDLE);
+		CASE_SSPI(SEC_E_UNSUPPORTED_FUNCTION);
+		CASE_SSPI(SEC_E_TARGET_UNKNOWN);
+		CASE_SSPI(SEC_E_INTERNAL_ERROR);
+		CASE_SSPI(SEC_E_SECPKG_NOT_FOUND);
+		CASE_SSPI(SEC_E_NOT_OWNER);
+		CASE_SSPI(SEC_E_CANNOT_INSTALL);
+		CASE_SSPI(SEC_E_INVALID_TOKEN);
+		CASE_SSPI(SEC_E_CANNOT_PACK);
+		CASE_SSPI(SEC_E_QOP_NOT_SUPPORTED);
+		CASE_SSPI(SEC_E_NO_IMPERSONATION);
+		CASE_SSPI(SEC_E_LOGON_DENIED);
+		CASE_SSPI(SEC_E_UNKNOWN_CREDENTIALS);
+		CASE_SSPI(SEC_E_NO_CREDENTIALS);
+		CASE_SSPI(SEC_E_MESSAGE_ALTERED);
+		CASE_SSPI(SEC_E_OUT_OF_SEQUENCE);
+		CASE_SSPI(SEC_E_NO_AUTHENTICATING_AUTHORITY);
+		CASE_SSPI(SEC_E_CONTEXT_EXPIRED);
+		CASE_SSPI(SEC_E_INCOMPLETE_MESSAGE);
+		CASE_SSPI(SEC_E_INCOMPLETE_CREDENTIALS);
+		CASE_SSPI(SEC_E_BUFFER_TOO_SMALL);
+		CASE_SSPI(SEC_E_WRONG_PRINCIPAL);
+		CASE_SSPI(SEC_E_TIME_SKEW);
+		CASE_SSPI(SEC_E_UNTRUSTED_ROOT);
+		CASE_SSPI(SEC_E_ILLEGAL_MESSAGE);
+		CASE_SSPI(SEC_E_CERT_UNKNOWN);
+		CASE_SSPI(SEC_E_CERT_EXPIRED);
+		CASE_SSPI(SEC_E_ENCRYPT_FAILURE);
+		CASE_SSPI(SEC_E_DECRYPT_FAILURE);
+		CASE_SSPI(SEC_E_ALGORITHM_MISMATCH);
+		CASE_SSPI(SEC_E_SECURITY_QOS_FAILED);
+		CASE_SSPI(SEC_E_NO_TGT_REPLY);
+		CASE_SSPI(SEC_E_NO_IP_ADDRESSES);
+		CASE_SSPI(SEC_E_WRONG_CREDENTIAL_HANDLE);
+		CASE_SSPI(SEC_E_CRYPTO_SYSTEM_INVALID);
+		CASE_SSPI(SEC_E_MAX_REFERRALS_EXCEEDED);
+		CASE_SSPI(SEC_E_MUST_BE_KDC);
+		CASE_SSPI(SEC_E_STRONG_CRYPTO_NOT_SUPPORTED);
+		CASE_SSPI(SEC_E_TOO_MANY_PRINCIPALS);
+		CASE_SSPI(SEC_E_NO_PA_DATA);
+		CASE_SSPI(SEC_E_PKINIT_NAME_MISMATCH);
+		CASE_SSPI(SEC_E_SMARTCARD_LOGON_REQUIRED);
+		CASE_SSPI(SEC_E_KDC_INVALID_REQUEST);
+		CASE_SSPI(SEC_E_KDC_UNABLE_TO_REFER);
+		CASE_SSPI(SEC_E_KDC_UNKNOWN_ETYPE);
+		CASE_SSPI(SEC_E_UNSUPPORTED_PREAUTH);
+		CASE_SSPI(SEC_E_DELEGATION_REQUIRED);
+		CASE_SSPI(SEC_E_BAD_BINDINGS);
+		CASE_SSPI(SEC_E_MULTIPLE_ACCOUNTS);
+		CASE_SSPI(SEC_E_NO_KERB_KEY);
+		CASE_SSPI(SEC_E_CERT_WRONG_USAGE);
+		CASE_SSPI(SEC_E_DOWNGRADE_DETECTED);
+		CASE_SSPI(SEC_E_SMARTCARD_CERT_REVOKED);
+		CASE_SSPI(SEC_E_ISSUING_CA_UNTRUSTED);
+		CASE_SSPI(SEC_E_REVOCATION_OFFLINE_C);
+		CASE_SSPI(SEC_E_PKINIT_CLIENT_FAILURE);
+		CASE_SSPI(SEC_E_SMARTCARD_CERT_EXPIRED);
+		CASE_SSPI(SEC_E_KDC_CERT_EXPIRED);
+		CASE_SSPI(SEC_E_KDC_CERT_REVOKED);
+		CASE_SSPI(SEC_E_MUTUAL_AUTH_FAILED);
+		default:
+			return "UNKNOWN";
+	}
+#undef CASE_SSPI
+}
+
+static FREERDP_ERROR_SUBSYSTEM nla_get_subsystem(const rdpNla* nla)
+{
+	const char* pkg = credssp_auth_pkg_name(nla->auth);
+
+	if (_stricmp(pkg, CREDSSP_AUTH_PKG_KERBEROS) == 0)
+		return FREERDP_ERROR_SUBSYSTEM_KERBEROS;
+	if (_stricmp(pkg, CREDSSP_AUTH_PKG_NTLM) == 0)
+		return FREERDP_ERROR_SUBSYSTEM_NTLM;
+	if (_stricmp(pkg, CREDSSP_AUTH_PKG_SPNEGO) == 0)
+		return FREERDP_ERROR_SUBSYSTEM_NEGOTIATE;
+
+	return FREERDP_ERROR_SUBSYSTEM_NLA;
+}
+
 void nla_set_early_user_auth(rdpNla* nla, BOOL earlyUserAuth)
 {
 	WINPR_ASSERT(nla);
@@ -502,7 +591,12 @@ int nla_client_begin(rdpNla* nla)
 			nla_set_state(nla, NLA_STATE_FINAL);
 			break;
 		default:
-			switch (credssp_auth_sspi_error(nla->auth))
+		{
+			const INT32 sspi_error = credssp_auth_sspi_error(nla->auth);
+			freerdp_set_error_detail(nla->rdpcontext, nla_get_subsystem(nla), (INT64)sspi_error,
+			                         nla_sspi_status_name(sspi_error), NULL);
+
+			switch (sspi_error)
 			{
 				case SEC_E_LOGON_DENIED:
 				case SEC_E_NO_CREDENTIALS:
@@ -513,6 +607,7 @@ int nla_client_begin(rdpNla* nla)
 					break;
 			}
 			return -1;
+		}
 	}
 
 	return 1;
@@ -548,7 +643,12 @@ static int nla_client_recv_nego_token(rdpNla* nla)
 		break;
 
 		default:
+		{
+			const INT32 sspi_error = credssp_auth_sspi_error(nla->auth);
+			freerdp_set_error_detail(nla->rdpcontext, nla_get_subsystem(nla), (INT64)sspi_error,
+			                         nla_sspi_status_name(sspi_error), NULL);
 			return -1;
+		}
 	}
 
 	return 1;
@@ -2198,6 +2298,8 @@ int nla_recv_pdu(rdpNla* nla, wStream* s)
 		if (nla->errorCode)
 		{
 			UINT32 code = 0;
+			const INT32 sspi_error = credssp_auth_sspi_error(nla->auth);
+			char detailBuf[256] = { 0 };
 
 			switch (nla->errorCode)
 			{
@@ -2248,6 +2350,12 @@ int nla_recv_pdu(rdpNla* nla, wStream* s)
 					code = FREERDP_ERROR_AUTHENTICATION_FAILED;
 					break;
 			}
+
+			(void)_snprintf(detailBuf, sizeof(detailBuf), "NTSTATUS: %s (0x%08" PRIx32 ")",
+			                NtStatus2Tag(nla->errorCode),
+			                WINPR_CXX_COMPAT_CAST(uint32_t, nla->errorCode));
+			freerdp_set_error_detail(nla->rdpcontext, nla_get_subsystem(nla), (INT64)sspi_error,
+			                         nla_sspi_status_name(sspi_error), detailBuf);
 
 			freerdp_set_last_error_log(nla->rdpcontext, code);
 			return -1;

--- a/libfreerdp/core/rdstls.c
+++ b/libfreerdp/core/rdstls.c
@@ -633,6 +633,9 @@ static BOOL rdstls_process_authentication_response(rdpRdstls* rdstls, wStream* s
 				break;
 		}
 
+		freerdp_set_error_detail(rdstls->context, FREERDP_ERROR_SUBSYSTEM_RDSTLS,
+		                         (INT64)resultCode, rdstls_result_code_str(resultCode),
+		                         "RDSTLS authentication response failure");
 		freerdp_set_last_error_if_not(rdstls->context, error);
 		return FALSE;
 	}

--- a/libfreerdp/core/transport.c
+++ b/libfreerdp/core/transport.c
@@ -154,6 +154,9 @@ static void transport_ssl_cb(const SSL* ssl, int where, int ret)
 				{
 					WLog_Print(transport->log, WLOG_ERROR, "where=%s ACCESS DENIED",
 					           where2str(where, buffer, sizeof(buffer)));
+					freerdp_set_error_detail(transport_get_context(transport),
+					                         FREERDP_ERROR_SUBSYSTEM_TLS, (INT64)ret,
+					                         "SSL_AD_ACCESS_DENIED", "TLS access denied alert");
 					freerdp_set_last_error_log(transport_get_context(transport),
 					                           FREERDP_ERROR_AUTHENTICATION_FAILED);
 				}
@@ -175,6 +178,10 @@ static void transport_ssl_cb(const SSL* ssl, int where, int ret)
 							kret = nla_get_error(transport->nla);
 						if (kret == 0)
 							kret = FREERDP_ERROR_CONNECT_PASSWORD_CERTAINLY_EXPIRED;
+						freerdp_set_error_detail(
+						    transport_get_context(transport), FREERDP_ERROR_SUBSYSTEM_TLS,
+						    (INT64)ret, "SSL_AD_INTERNAL_ERROR",
+						    SSL_alert_desc_string_long(ret));
 						freerdp_set_last_error_log(transport_get_context(transport), kret);
 					}
 				}
@@ -192,6 +199,10 @@ static void transport_ssl_cb(const SSL* ssl, int where, int ret)
 				           "Unhandled SSL error (where=%s, ret=%d [%s, %s])",
 				           where2str(where, buffer, sizeof(buffer)), ret,
 				           SSL_alert_type_string_long(ret), SSL_alert_desc_string_long(ret));
+				freerdp_set_error_detail(transport_get_context(transport),
+				                         FREERDP_ERROR_SUBSYSTEM_TLS, (INT64)ret,
+				                         SSL_alert_type_string_long(ret),
+				                         SSL_alert_desc_string_long(ret));
 				break;
 		}
 	}
@@ -513,6 +524,8 @@ BOOL transport_connect_aad(rdpTransport* transport)
 	{
 		WLog_Print(transport->log, WLOG_ERROR, "AAD begin failed");
 
+		freerdp_set_error_detail(context, FREERDP_ERROR_SUBSYSTEM_AAD, 0, NULL,
+		                         "AAD authentication begin failed");
 		freerdp_set_last_error_if_not(context, FREERDP_ERROR_AUTHENTICATION_FAILED);
 
 		transport_set_aad_mode(transport, FALSE);


### PR DESCRIPTION
## Summary
- Adds `rdpErrorDetail` struct and `FREERDP_ERROR_SUBSYSTEM` enum to preserve native subsystem error information (Kerberos, TLS, Gateway, etc.) beyond the flattened `ERRCONNECT_*` code
- Instruments NLA (SSPI/Kerberos/NTLM), RD Gateway (HTTP/HRESULT), TLS (SSL alerts), AAD, MCS, and RDSTLS with subsystem-specific error capture
- Fixes pre-existing Gateway bug where raw HRESULT values were passed to `freerdp_set_last_error_log()` as `ERRCONNECT_*` codes
- Purely additive — no changes to existing API signatures or behavior; uses ABI-compatible padding slot in `rdpContext`

## Details

### New API
- `freerdp_set_error_detail(context, subsystem, nativeError, nativeErrorName, detailFmt, ...)` — set error detail
- `freerdp_get_error_detail(context)` — retrieve the `rdpErrorDetail*` (may be NULL)
- `freerdp_clear_error_detail(context)` — clear current error detail (auto-called on `freerdp_set_last_error(SUCCESS)`)
- `freerdp_error_subsystem_name(subsystem)` — get string name for subsystem enum

### Instrumented subsystems
| Subsystem | Location | What's captured |
|-----------|----------|-----------------|
| NLA/Kerberos/NTLM | `nla.c` | SSPI `SECURITY_STATUS` with ~70 named codes, package-aware subsystem |
| Gateway HTTP | `rdg.c` | HRESULT error codes from handshake, tunnel, auth, and channel |
| TLS | `transport.c` | SSL alert type/description from `transport_ssl_cb` |
| AAD | `transport.c` | AAD auth begin failure |
| MCS | `mcs.c` | Connect Initial failure |
| RDSTLS | `rdstls.c` | Authentication response result code |