### PR TITLE
Fix duplicate declaration of wfServer* server in wf_interface.c

### DIFF
--- a/server/Windows/wf_interface.c
+++ b/server/Windows/wf_interface.c
@@ -180,7 +180,7 @@ wfServer* wfreerdp_server_new()
 	if (!WTSRegisterWtsApiFunctionTable(FreeRDP_InitWtsApi()))
 		return nullptr;
 
-	wfServer* server = (wfServer*)calloc(1, sizeof(wfServer));
+	server = (wfServer*)calloc(1, sizeof(wfServer));
 
 	if (server)
 	{


### PR DESCRIPTION
Fix duplicate declaration of `wfServer* server` in `server/Windows/wf_interface.c`
