### PR TITLE
Fix memory leak in `freerdp_settings_int_buffer_copy()` on error paths (`libfreerdp/core/settings.c`)

### DIFF
--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -1426,7 +1426,10 @@ static BOOL freerdp_settings_int_buffer_copy(rdpSettings* dst, const rdpSettings
 		if (!cert)
 			goto out_fail;
 		if (!freerdp_settings_set_pointer_len(dst, FreeRDP_RdpServerCertificate, cert, 1))
+		{
+			freerdp_certificate_free(cert);
 			goto out_fail;
+		}
 	}
 	else
 	{
@@ -1440,7 +1443,10 @@ static BOOL freerdp_settings_int_buffer_copy(rdpSettings* dst, const rdpSettings
 		if (!key)
 			goto out_fail;
 		if (!freerdp_settings_set_pointer_len(dst, FreeRDP_RdpServerRsaKey, key, 1))
+		{
+			freerdp_key_free(key);
 			goto out_fail;
+		}
 	}
 	else
 	{


### PR DESCRIPTION
### Problem

In `freerdp_settings_int_buffer_copy()`, temporary objects are allocated using `freerdp_certificate_clone()` and `freerdp_key_clone()` when copying `RdpServerCertificate` and `RdpServerRsaKey`. However, these temporary objects may not be released if a subsequent operation fails, which can lead to memory leaks.

1. In the following code, `cert` is allocated by `freerdp_certificate_clone()`. If `freerdp_settings_set_pointer_len()` fails, execution jumps to `out_fail` without freeing `cert`, resulting in a memory leak (lines **1423–1430**):
    ``` c
    if (settings->RdpServerCertificate)
	{
		rdpCertificate* cert = freerdp_certificate_clone(settings->RdpServerCertificate);
		if (!cert)
			goto out_fail;
		if (!freerdp_settings_set_pointer_len(dst, FreeRDP_RdpServerCertificate, cert, 1))
			goto out_fail;
	}
    ```
2. The same issue exists for `RdpServerRsaKey`. Here, `key` is allocated using `freerdp_key_clone()`. If `freerdp_settings_set_pointer_len()` fails, execution again jumps to `out_fail` without freeing `key`, which also results in a memory leak (lines **1437–1444**):
    ``` c
    if (settings->RdpServerRsaKey)
	{
		rdpPrivateKey* key = freerdp_key_clone(settings->RdpServerRsaKey);
		if (!key)
			goto out_fail;
		if (!freerdp_settings_set_pointer_len(dst, FreeRDP_RdpServerRsaKey, key, 1))
			goto out_fail;
	}
    ```

### Fix

Free the temporary cloned objects before jumping to `out_fail` when `freerdp_settings_set_pointer_len()` fails. The implementation of this fix is included in the commit of this pull request.
