### PR TITLE
Fix memory leak in `rdp_client_establish_keys()` on error path (`libfreerdp/core/connection.c`)

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -763,7 +763,7 @@ static BOOL rdp_client_establish_keys(rdpRdp* rdp)
 
 	if (crypto_rsa_public_encrypt(settings->ClientRandom, settings->ClientRandomLength, info,
 	                              crypt_client_random, info->ModulusLength) < 0)
-		return FALSE;
+		goto end;
 	/* send crypt client random to server */
 	const size_t length = RDP_PACKET_HEADER_MAX_LENGTH + RDP_SECURITY_HEADER_LENGTH + 4ULL +
 	                      info->ModulusLength + 8ULL;


### PR DESCRIPTION
### Problem

In `rdp_client_establish_keys()`, the buffer `crypt_client_random` is allocated using `calloc()` before performing RSA encryption of the client random (lines **759-766**).
``` c
crypt_client_random = calloc(info->ModulusLength, 1);

if (!crypt_client_random)
    return FALSE;

if (crypto_rsa_public_encrypt(settings->ClientRandom, settings->ClientRandomLength, info,
                                crypt_client_random, info->ModulusLength) < 0)
    return FALSE;
```

If `crypto_rsa_public_encrypt()` fails (lines **764-765**), the function returns immediately without freeing `crypt_client_random`. Since the cleanup logic is located at the `end:` label later in the function, this early return causes the allocated buffer to be leaked.

### Fix

Route the failure path of `crypto_rsa_public_encrypt()` through the existing cleanup block so that `crypt_client_random` is properly released. The implementation of this fix is included in the commit of this pull request.