### PR TITLE
Fix context leak in `PCSC_SCardListReadersW()` on error paths (`winpr/libwinpr/smartcard/smartcard_pcsc.c`)

### DIFF
--- a/winpr/libwinpr/smartcard/smartcard_pcsc.c
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.c
@@ -1040,7 +1040,11 @@ static LONG WINAPI PCSC_SCardListReadersW(SCARDCONTEXT hContext, LPCWSTR mszGrou
 	}
 
 	if (!PCSC_LockCardContext(hContext))
+	{
+		if (nullCardContext)
+            PCSC_SCardReleaseContext(hContext);
 		return SCARD_E_INVALID_HANDLE;
+	}
 
 	if (mszGroups)
 	{
@@ -1084,6 +1088,9 @@ static LONG WINAPI PCSC_SCardListReadersW(SCARDCONTEXT hContext, LPCWSTR mszGrou
 fail:
 	if (!PCSC_UnlockCardContext(hContext))
 		return SCARD_E_INVALID_HANDLE;
+	
+	if (nullCardContext)
+		PCSC_SCardReleaseContext(hContext);
 
 	return status;
 }


### PR DESCRIPTION
### Problem

In `PCSC_SCardListReadersW()`, a temporary smart card context may be created when the caller passes a null context (lines **1031–1040**):
``` c
if (!hContext)
{
    status = PCSC_SCardEstablishContext(SCARD_SCOPE_SYSTEM, nullptr, nullptr, &hContext);

    if (status != SCARD_S_SUCCESS)
        return status;

    nullCardContext = TRUE;
}
```
After that, there are two error paths where the temporary context may be leaked.

1. If `PCSC_LockCardContext(hContext)` fails (line **1042**), the function returns immediately:
    ``` c
    if (!PCSC_LockCardContext(hContext))
        return SCARD_E_INVALID_HANDLE;
    ```
   If the context was created earlier by `PCSC_SCardEstablishContext()`, this early return exits without calling `PCSC_SCardReleaseContext(hContext)`, causing a resource leak of the temporary smart card context.

2. After the context has been successfully created and locked, later failures may jump to the `fail:` label. However, the temporary context is only released on the normal success path (lines **1081–1082**):
    ``` c
    if (nullCardContext)
        status = PCSC_SCardReleaseContext(hContext);
    ```
   As a result, if `PCSC_SCardEstablishContext()` succeeds but a later operation fails, the function returns without releasing the temporary context, causing a resource leak.

### Fix

Ensure that the temporary context created by `PCSC_SCardEstablishContext()` is released on all error paths when `nullCardContext` is `TRUE`, including both the early return after `PCSC_LockCardContext()` fails and the `fail:` path. The implementation of this fix is included in the commit of this pull request.
