### PR TITLE
[client,x11] start with xfc->remote_app = TRUE;

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1410,6 +1410,9 @@ static BOOL xf_post_connect(freerdp* instance)
 	rdpUpdate* update = context->update;
 	WINPR_ASSERT(update);
 
+	if (freerdp_settings_get_bool(settings, FreeRDP_RemoteApplicationMode))
+		xfc->remote_app = TRUE;
+
 	if (!xf_create_window(xfc))
 		return FALSE;
 


### PR DESCRIPTION
the desktop window creation/destruction currently does not work reliable if done later on. Add this as a quick work around to get RAILS working proper again.