### PR TITLE
[channels,audin] set error when audio_format_read fails

### DIFF
--- a/channels/audin/server/audin.c
+++ b/channels/audin/server/audin.c
@@ -146,7 +146,11 @@ static UINT audin_server_recv_formats(audin_server_context* context, wStream* s,
 		AUDIO_FORMAT* format = &pdu.SoundFormats[i];
 
 		if (!audio_format_read(s, format))
+		{
+			WLog_Print(audin->log, WLOG_ERROR, "Failed to read audio format");
+			error = ERROR_INVALID_DATA;
 			goto fail;
+		}
 
 		audio_format_print(audin->log, WLOG_DEBUG, format);
 	}


### PR DESCRIPTION
Currently, `goto fail` is called when `audio_format_read` fails, but `error` is not changed, so `CHANNEL_RC_OK` is returned. Before the 1c5c7422 commit, `ERROR_INVALID_DATA` was returned. Let's again set that error code and also restore the debug print.
