### PR TITLE
[core,update] make the PlaySound callback non-mandatory

### DIFF
--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -355,7 +355,7 @@ BOOL update_recv_play_sound(rdpUpdate* update, wStream* s)
 	if (!update_read_play_sound(s, &play_sound))
 		return FALSE;
 
-	return IFCALLRESULT(FALSE, update->PlaySound, update->context, &play_sound);
+	return IFCALLRESULT(TRUE, update->PlaySound, update->context, &play_sound);
 }
 
 POINTER_POSITION_UPDATE* update_read_pointer_position(rdpUpdate* update, wStream* s)


### PR DESCRIPTION
If the server sends a "Play Sound" PDU but the client does not subscribe `update->PlaySound` it forces a disconnection.

I have only seen this in the wild with xrdp running the VNC backend.

All of freerdp's own clients (with the exception of `xfreerdp`) subscribe this callback but make it a no-op.

This PR makes the callback "opt in" (a client can safely leave it unsubscribed and they will not be disconnected if it's triggered).