### PR TITLE
[codec,openh264] reject encoder ABI mismatch on runtime-loaded library

### DIFF
--- a/libfreerdp/codec/h264_openh264.c
+++ b/libfreerdp/codec/h264_openh264.c
@@ -565,6 +565,18 @@ static BOOL openh264_init(H264_CONTEXT* h264)
 
 		if (h264->Compressor)
 		{
+#if defined(WITH_OPENH264_LOADING)
+			if (sysContexts->version.uMajor != OPENH264_MAJOR ||
+			    sysContexts->version.uMinor != OPENH264_MINOR)
+			{
+				WLog_Print(h264->log, WLOG_WARN,
+				           "OpenH264 encoder ABI mismatch: runtime %d.%d.%d vs compiled %d.%d.%d",
+				           sysContexts->version.uMajor, sysContexts->version.uMinor,
+				           sysContexts->version.uRevision, OPENH264_MAJOR, OPENH264_MINOR,
+				           OPENH264_REVISION);
+				goto EXCEPTION;
+			}
+#endif
 			const int rc = sysContexts->WelsCreateSVCEncoder(&sys->pEncoder);
 			if (rc != 0)
 			{


### PR DESCRIPTION
OpenH264 apparently doesn't follow semver, because there are ABI changes in the _encoder_ between 2.4.1 and 2.6.0 (versions tested).

This change adds a sanity check if the client is using `WITH_OPENH264_LOADING`; for encoding, the runtime version of the library must match the version we compiled against.

Decoding is unaffected. It's implicitly assumed that we're building against at least 1.6.0, and if not the preprocessor checks for `OPENH264_MAJOR` and `OPENH264_MINOR` activate different code paths anyway.