### PR TITLE
[client,sdl] create a copy of rdpPointer

### DIFF
--- a/client/SDL/SDL3/sdl_context.cpp
+++ b/client/SDL/SDL3/sdl_context.cpp
@@ -36,8 +36,9 @@
 #endif
 
 SdlContext::SdlContext(rdpContext* context)
-    : _context(context), _log(WLog_Get(CLIENT_TAG("SDL"))), _rdpThreadRunning(false),
-      _primary(nullptr, SDL_DestroySurface), _disp(this), _input(this), _clip(this), _dialog(_log)
+    : _context(context), _log(WLog_Get(CLIENT_TAG("SDL"))), _cursor(nullptr, sdl_Pointer_FreeCopy),
+      _rdpThreadRunning(false), _primary(nullptr, SDL_DestroySurface), _disp(this), _input(this),
+      _clip(this), _dialog(_log)
 {
 	WINPR_ASSERT(context);
 	setMetadata();
@@ -1483,15 +1484,15 @@ bool SdlContext::setCursor(CursorType type)
 	return restoreCursor();
 }
 
-bool SdlContext::setCursor(rdpPointer* cursor)
+bool SdlContext::setCursor(const rdpPointer* cursor)
 {
-	_cursor = cursor;
+	_cursor = { sdl_Pointer_Copy(cursor), sdl_Pointer_FreeCopy };
 	return setCursor(CURSOR_IMAGE);
 }
 
 rdpPointer* SdlContext::cursor() const
 {
-	return _cursor;
+	return _cursor.get();
 }
 
 bool SdlContext::restoreCursor()

--- a/client/SDL/SDL3/sdl_context.hpp
+++ b/client/SDL/SDL3/sdl_context.hpp
@@ -86,7 +86,7 @@ class SdlContext
 	[[nodiscard]] rdpClientContext* common() const;
 
 	[[nodiscard]] bool setCursor(CursorType type);
-	[[nodiscard]] bool setCursor(rdpPointer* cursor);
+	[[nodiscard]] bool setCursor(const rdpPointer* cursor);
 	[[nodiscard]] rdpPointer* cursor() const;
 	[[nodiscard]] bool restoreCursor();
 
@@ -193,7 +193,7 @@ class SdlContext
 
 	std::atomic<bool> _connected = false;
 	bool _cursor_visible = true;
-	rdpPointer* _cursor = nullptr;
+	std::unique_ptr<rdpPointer, void (*)(rdpPointer*)> _cursor;
 	CursorType _cursorType = CURSOR_NULL;
 	std::vector<SDL_DisplayID> _monitorIds;
 	std::mutex _queue_mux;

--- a/client/SDL/SDL3/sdl_pointer.cpp
+++ b/client/SDL/SDL3/sdl_pointer.cpp
@@ -81,17 +81,21 @@ static void sdl_Pointer_Clear(sdlPointer* ptr)
 	ptr->image = nullptr;
 }
 
-static void sdl_Pointer_Free(rdpContext* context, rdpPointer* pointer)
+static void sdl_Pointer_Free(WINPR_ATTR_UNUSED rdpContext* context, rdpPointer* pointer)
+{
+	sdl_Pointer_FreeCopy(pointer);
+}
+
+void sdl_Pointer_FreeCopy(rdpPointer* pointer)
 {
 	auto ptr = reinterpret_cast<sdlPointer*>(pointer);
-	WINPR_UNUSED(context);
 
-	if (ptr)
-	{
-		sdl_Pointer_Clear(ptr);
-		winpr_aligned_free(ptr->data);
-		ptr->data = nullptr;
-	}
+	if (!ptr)
+		return;
+
+	sdl_Pointer_Clear(ptr);
+	winpr_aligned_free(ptr->data);
+	ptr->data = nullptr;
 }
 
 [[nodiscard]] static BOOL sdl_Pointer_SetDefault(rdpContext* context)
@@ -258,4 +262,33 @@ bool sdl_register_pointer(rdpGraphics* graphics)
 		                         {} };
 	graphics_register_pointer(graphics, &pointer);
 	return true;
+}
+
+rdpPointer* sdl_Pointer_Copy(const rdpPointer* pointer)
+{
+	auto ptr = reinterpret_cast<const sdlPointer*>(pointer);
+	if (!pointer)
+		return nullptr;
+
+	auto copy = static_cast<sdlPointer*>(calloc(1, sizeof(sdlPointer)));
+	if (!copy)
+		return nullptr;
+
+	copy->pointer.xPos = pointer->xPos;
+	copy->pointer.yPos = pointer->yPos;
+	copy->pointer.width = pointer->width;
+	copy->pointer.height = pointer->height;
+	copy->pointer.xorBpp = pointer->xorBpp;
+	if (ptr->size > 0)
+	{
+		copy->data = static_cast<BYTE*>(winpr_aligned_malloc(ptr->size, 32));
+		if (!copy)
+		{
+			free(copy);
+			return nullptr;
+		}
+		copy->size = ptr->size;
+		memcpy(copy->data, ptr->data, copy->size);
+	}
+	return &copy->pointer;
 }

--- a/client/SDL/SDL3/sdl_pointer.hpp
+++ b/client/SDL/SDL3/sdl_pointer.hpp
@@ -28,3 +28,13 @@
 [[nodiscard]] bool sdl_register_pointer(rdpGraphics* graphics);
 
 [[nodiscard]] bool sdl_Pointer_Set_Process(SdlContext* sdl);
+
+void sdl_Pointer_FreeCopy(rdpPointer* pointer);
+
+/** @brief creates a copy when the \ref rdpPointer was already created in \ref PointerNew.
+ *
+ *  The copy only contains the relevant data (coordinates, bitmap data) required for the SDL client
+ * to display the cursor. Callbacks and xor/and mask data are not copied.
+ */
+WINPR_ATTR_MALLOC(sdl_Pointer_FreeCopy, 2)
+rdpPointer* sdl_Pointer_Copy(const rdpPointer* pointer);


### PR DESCRIPTION
When a rdpPointer is used, ensure we use a copy of it that is valid until the next cursor is set.
Since SDL and RDP have different lifetime scopes for cursors there is a short frame where there could be access to freed memory otherwise.