### PR TITLE
[utils, signal] lazily initialize Windows CRITICAL_SECTION to match POSIX static mutex behavior

### DIFF
--- a/libfreerdp/utils/signal_win32.c
+++ b/libfreerdp/utils/signal_win32.c
@@ -15,9 +15,17 @@
 #define TAG FREERDP_TAG("utils.signal.posix")
 
 static CRITICAL_SECTION signal_lock;
+static INIT_ONCE signal_lock_init = INIT_ONCE_STATIC_INIT;
+
+static BOOL CALLBACK init_signal_lock(PINIT_ONCE InitOnce, PVOID Parameter, PVOID* Context)
+{
+	InitializeCriticalSection(&signal_lock);
+	return TRUE;
+}
 
 void fsig_lock(void)
 {
+	InitOnceExecuteOnce(&signal_lock_init, init_signal_lock, NULL, NULL);
 	EnterCriticalSection(&signal_lock);
 }
 
@@ -98,8 +106,6 @@ static void unregister_all_handlers(void)
 int freerdp_handle_signals(void)
 {
 	int rc = -1;
-	InitializeCriticalSection(&signal_lock);
-
 	fsig_lock();
 
 	WLog_DBG(TAG, "Registering signal hook...");


### PR DESCRIPTION
#12335 refactored signal handlers per-platform. On Windows, a critical section is used for locking and is initialized in `freerdp_handle_signals`.

_If_ the client does not call `freerdp_handle_signals`, this causes a segfault as soon as we try to lock the critical section, e.g.

```
fsig_lock()
freerdp_add_signal_cleanup_handler(void * context, void(*)(int, const char *, void *) handler
freerdp_connect_begin(rdp_freerdp * instance) 
freerdp_connect(rdp_freerdp * instance)
myclient_connect()
```

Note that when we're consuming freerdp as a library, we might not want it to take ownership of process-wide signal handling.

On the POSIX side, `PTHREAD_MUTEX_INITIALIZER` is a compile time constant. This PR uses `INIT_ONCE_STATIC_INIT` to achieve the same result on Windows.