### PR TITLE
fix locking in shadow_lobby.c

### DIFF
--- a/server/shadow/shadow_lobby.c
+++ b/server/shadow/shadow_lobby.c
@@ -40,12 +40,12 @@ BOOL shadow_client_init_lobby(rdpShadowServer* server)
 	if (!lobby)
 		return FALSE;
 
+	EnterCriticalSection(&lobby->lock);
 #if defined(WITH_RDTK)
 	rdtkEngine* engine = rdtk_engine_new();
 	if (!engine)
 		return FALSE;
 
-	EnterCriticalSection(&lobby->lock);
 	rdtkSurface* surface =
 	    rdtk_surface_new(engine, lobby->data, WINPR_ASSERTING_INT_CAST(uint16_t, lobby->width),
 	                     WINPR_ASSERTING_INT_CAST(uint16_t, lobby->height), lobby->scanline);


### PR DESCRIPTION
when WITH_RDTK is not defined, shadow_client_init_lobby unlocks a lock which has never been locked.

This regression was introduced in f4c991f902882ae46b4ab883964c02a5649bad1d the commit making RDTK optional.
