### PR TITLE
[winpr,sspi] Fix context nullptr handling

### DIFF
--- a/winpr/libwinpr/sspi/CredSSP/credssp.c
+++ b/winpr/libwinpr/sspi/CredSSP/credssp.c
@@ -194,13 +194,12 @@ static SECURITY_STATUS SEC_ENTRY credssp_QueryCredentialsAttributesA(
 
 static SECURITY_STATUS SEC_ENTRY credssp_FreeCredentialsHandle(PCredHandle phCredential)
 {
-	SSPI_CREDENTIALS* credentials = nullptr;
-
 	if (!phCredential)
 		return SEC_E_INVALID_HANDLE;
 
-	credentials = (SSPI_CREDENTIALS*)sspi_SecureHandleGetLowerPointer(phCredential);
-
+	SSPI_CREDENTIALS* credentials =
+	    (SSPI_CREDENTIALS*)sspi_SecureHandleGetLowerPointer(phCredential);
+	sspi_SecureHandleInvalidate(phCredential);
 	if (!credentials)
 		return SEC_E_INVALID_HANDLE;
 

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -595,12 +595,12 @@ static SECURITY_STATUS
 {
 #ifdef WITH_KRB5
 	KRB_CREDENTIALS* credentials = sspi_SecureHandleGetLowerPointer(phCredential);
+	sspi_SecureHandleInvalidate(phCredential);
 	if (!credentials)
 		return SEC_E_INVALID_HANDLE;
 
 	credentials_unref(credentials);
 
-	sspi_SecureHandleInvalidate(phCredential);
 	return SEC_E_OK;
 #else
 	return SEC_E_UNSUPPORTED_FUNCTION;
@@ -1276,6 +1276,7 @@ cleanup:
 				break;
 			default:
 				kerberos_ContextFree(context, TRUE);
+				sspi_SecureHandleInvalidate(phNewContext);
 				break;
 		}
 	}
@@ -1596,6 +1597,7 @@ cleanup:
 				break;
 			default:
 				kerberos_ContextFree(context, TRUE);
+				sspi_SecureHandleInvalidate(phNewContext);
 				break;
 		}
 	}
@@ -1646,6 +1648,7 @@ static SECURITY_STATUS
 {
 #ifdef WITH_KRB5
 	KRB_CONTEXT* context = get_context(phContext);
+	sspi_SecureHandleInvalidate(phContext);
 	if (!context)
 		return SEC_E_INVALID_HANDLE;
 

--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -472,7 +472,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_FreeCredentialsHandle(PCredHandle phCreden
 
 	SSPI_CREDENTIALS* credentials =
 	    (SSPI_CREDENTIALS*)sspi_SecureHandleGetLowerPointer(phCredential);
-
+	sspi_SecureHandleInvalidate(phCredential);
 	if (!credentials)
 		return SEC_E_INVALID_HANDLE;
 
@@ -783,6 +783,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_InitializeSecurityContextA(
 static SECURITY_STATUS SEC_ENTRY ntlm_DeleteSecurityContext(PCtxtHandle phContext)
 {
 	NTLM_CONTEXT* context = (NTLM_CONTEXT*)sspi_SecureHandleGetLowerPointer(phContext);
+	sspi_SecureHandleInvalidate(phContext);
 	ntlm_ContextFree(context);
 	return SEC_E_OK;
 }

--- a/winpr/libwinpr/sspi/Negotiate/negotiate.c
+++ b/winpr/libwinpr/sspi/Negotiate/negotiate.c
@@ -1282,9 +1282,9 @@ static SECURITY_STATUS SEC_ENTRY negotiate_CompleteAuthToken(PCtxtHandle phConte
 
 static SECURITY_STATUS SEC_ENTRY negotiate_DeleteSecurityContext(PCtxtHandle phContext)
 {
-	NEGOTIATE_CONTEXT* context = nullptr;
 	SECURITY_STATUS status = SEC_E_OK;
-	context = (NEGOTIATE_CONTEXT*)sspi_SecureHandleGetLowerPointer(phContext);
+	NEGOTIATE_CONTEXT* context = (NEGOTIATE_CONTEXT*)sspi_SecureHandleGetLowerPointer(phContext);
+	sspi_SecureHandleInvalidate(phContext);
 	const SecPkg* pkg = nullptr;
 
 	if (!context)
@@ -1569,6 +1569,7 @@ static SECURITY_STATUS SEC_ENTRY negotiate_QueryCredentialsAttributesA(
 static SECURITY_STATUS SEC_ENTRY negotiate_FreeCredentialsHandle(PCredHandle phCredential)
 {
 	MechCred* creds = sspi_SecureHandleGetLowerPointer(phCredential);
+	sspi_SecureHandleInvalidate(phCredential);
 	if (!creds)
 		return SEC_E_INVALID_HANDLE;
 

--- a/winpr/libwinpr/sspi/Schannel/schannel.c
+++ b/winpr/libwinpr/sspi/Schannel/schannel.c
@@ -183,13 +183,12 @@ static SECURITY_STATUS SEC_ENTRY schannel_AcquireCredentialsHandleA(
 
 static SECURITY_STATUS SEC_ENTRY schannel_FreeCredentialsHandle(PCredHandle phCredential)
 {
-	SCHANNEL_CREDENTIALS* credentials = nullptr;
-
 	if (!phCredential)
 		return SEC_E_INVALID_HANDLE;
 
-	credentials = (SCHANNEL_CREDENTIALS*)sspi_SecureHandleGetLowerPointer(phCredential);
-
+	SCHANNEL_CREDENTIALS* credentials =
+	    (SCHANNEL_CREDENTIALS*)sspi_SecureHandleGetLowerPointer(phCredential);
+	sspi_SecureHandleInvalidate(phCredential);
 	if (!credentials)
 		return SEC_E_INVALID_HANDLE;
 
@@ -289,8 +288,8 @@ static SECURITY_STATUS SEC_ENTRY schannel_AcceptSecurityContext(
 
 static SECURITY_STATUS SEC_ENTRY schannel_DeleteSecurityContext(PCtxtHandle phContext)
 {
-	SCHANNEL_CONTEXT* context = nullptr;
-	context = (SCHANNEL_CONTEXT*)sspi_SecureHandleGetLowerPointer(phContext);
+	SCHANNEL_CONTEXT* context = (SCHANNEL_CONTEXT*)sspi_SecureHandleGetLowerPointer(phContext);
+	sspi_SecureHandleInvalidate(phContext);
 
 	if (!context)
 		return SEC_E_INVALID_HANDLE;


### PR DESCRIPTION
Unify reset of PCredHandle and PCtxtHandle in all
DeleteSecurityContext and FreeCredentialsHandle implementations.