### PR TITLE
Fix memory leak in `gdi_create_bitmap()` on `gdi_CreateBitmap` failure (`libfreerdp/gdi/graphics.c`)

### DIFF
--- a/libfreerdp/gdi/graphics.c
+++ b/libfreerdp/gdi/graphics.c
@@ -68,6 +68,8 @@ HGDI_BITMAP gdi_create_bitmap(rdpGdi* gdi, UINT32 nWidth, UINT32 nHeight, UINT32
 	}
 
 	bitmap = gdi_CreateBitmap(nWidth, nHeight, gdi->dstFormat, pDstData);
+	if (!bitmap)
+		winpr_aligned_free(pDstData);
 	return bitmap;
 }
 


### PR DESCRIPTION
### Description

In `gdi_create_bitmap()`, `pDstData` is allocated via `winpr_aligned_malloc()` (line 54) and passed to `gdi_CreateBitmap()` (line 70). Internally, `gdi_CreateBitmapEx()` performs a `calloc` for the bitmap struct, if that `calloc` fails, it returns `NULL` without freeing the `pDstData` buffer. Back in `gdi_create_bitmap()`, the `NULL` return is propagated directly (line 71) without freeing `pDstData`, causing a memory leak.

- **Allocated at:** `libfreerdp/gdi/graphics.c:54` — `pDstData = winpr_aligned_malloc(1ull * nHeight * nDstStep, 16);`
- **Leaked at:** `libfreerdp/gdi/graphics.c:71` — `return bitmap;` when `gdi_CreateBitmap()` returns `NULL`

### Source code

```c
// libfreerdp/gdi/graphics.c:54
pDstData = winpr_aligned_malloc(1ull * nHeight * nDstStep, 16);  // allocated here

// libfreerdp/gdi/graphics.c:70-71
bitmap = gdi_CreateBitmap(nWidth, nHeight, gdi->dstFormat, pDstData);
return bitmap;  // leaked here if gdi_CreateBitmap() returns NULL
```

### Fix

Free `pDstData` with `winpr_aligned_free()` when `gdi_CreateBitmap()` returns `NULL`, before returning.
