### PR TITLE
Fix memory leak in `vgids_read_do_fkt()` on `Stream_New` failure (`libfreerdp/emu/scard/smartcard_virtual_gids.c`)

### DIFF
--- a/libfreerdp/emu/scard/smartcard_virtual_gids.c
+++ b/libfreerdp/emu/scard/smartcard_virtual_gids.c
@@ -656,6 +656,8 @@ static BOOL vgids_read_do_fkt(void* data, size_t index, va_list ap)
 		if (vgids_ef_read_do(file, doID, &response, &responseSize))
 		{
 			context->responseData = Stream_New(response, (size_t)responseSize);
+			if (!context->responseData)
+				free(response);
 			return FALSE;
 		}
 	}


### PR DESCRIPTION
### Description

In `vgids_read_do_fkt()`, `vgids_ef_read_do()` allocates a buffer into `response` (line 656). The buffer is then passed to `Stream_New()` (line 658). If `Stream_New()` fails internally (e.g., its `calloc` for the stream struct fails), it returns `NULL` without freeing the provided buffer. Back in `vgids_read_do_fkt()`, `context->responseData` is set to `NULL` and `response` is a local variable that goes out of scope, so the allocated buffer is leaked.

- **Allocated at:** `libfreerdp/emu/scard/smartcard_virtual_gids.c:656` — `vgids_ef_read_do(file, doID, &response, &responseSize)`
- **Leaked at:** `libfreerdp/emu/scard/smartcard_virtual_gids.c:658-659` — `Stream_New()` returns `NULL`, `response` goes out of scope

### Source code

```c
// libfreerdp/emu/scard/smartcard_virtual_gids.c:656-659
if (vgids_ef_read_do(file, doID, &response, &responseSize))  // response allocated here
{
    context->responseData = Stream_New(response, (size_t)responseSize);
    return FALSE;  // leaked here if Stream_New() returns NULL
}
```

### Fix

Free `response` when `Stream_New()` returns `NULL`, before returning.
