### PR TITLE
[client,sdl] clamp cursor hotspot

### DIFF
--- a/client/SDL/SDL3/sdl_context.cpp
+++ b/client/SDL/SDL3/sdl_context.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <algorithm>
+#include <cmath>
 
 #include "sdl_context.hpp"
 #include "sdl_config.hpp"
@@ -1300,11 +1301,19 @@ SDL_FPoint SdlContext::pixelToScreen(SDL_WindowID id, const SDL_FPoint& pos)
 	return applyLocalScaling(rpos);
 }
 
-SDL_FRect SdlContext::pixelToScreen(SDL_WindowID id, const SDL_FRect& pos)
+SDL_FRect SdlContext::pixelToScreen(SDL_WindowID id, const SDL_FRect& pos, bool round)
 {
 	const auto fpos = pixelToScreen(id, SDL_FPoint{ pos.x, pos.y });
 	const auto size = pixelToScreen(id, SDL_FPoint{ pos.w, pos.h });
-	return { fpos.x, fpos.y, size.x, size.y };
+	SDL_FRect r{ fpos.x, fpos.y, size.x, size.y };
+	if (round)
+	{
+		r.w = std::ceil(r.w);
+		r.h = std::ceil(r.h);
+		r.x = std::floor(r.x);
+		r.y = std::floor(r.y);
+	}
+	return r;
 }
 
 bool SdlContext::handleEvent(const SDL_Event& ev)

--- a/client/SDL/SDL3/sdl_context.hpp
+++ b/client/SDL/SDL3/sdl_context.hpp
@@ -139,7 +139,8 @@ class SdlContext
 	[[nodiscard]] SDL_FPoint screenToPixel(SDL_WindowID id, const SDL_FPoint& pos);
 
 	[[nodiscard]] SDL_FPoint pixelToScreen(SDL_WindowID id, const SDL_FPoint& pos);
-	[[nodiscard]] SDL_FRect pixelToScreen(SDL_WindowID id, const SDL_FRect& pos);
+	[[nodiscard]] SDL_FRect pixelToScreen(SDL_WindowID id, const SDL_FRect& pos,
+	                                      bool round = false);
 
 	[[nodiscard]] bool handleEvent(const SDL_Event& ev);
 

--- a/client/SDL/SDL3/sdl_freerdp.cpp
+++ b/client/SDL/SDL3/sdl_freerdp.cpp
@@ -659,6 +659,9 @@ int main(int argc, char* argv[])
 	SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 	SDL_SetHint(SDL_HINT_PEN_TOUCH_EVENTS, "1");
 	SDL_SetHint(SDL_HINT_TRACKPAD_IS_TOUCH_ONLY, "1");
+#if SDL_VERSION_ATLEAST(3, 4, 0)
+	SDL_SetHint(SDL_HINT_MOUSE_DPI_SCALE_CURSORS, "1");
+#endif
 
 	/* Redirect SDL log messages to wLog */
 	SDL_SetLogOutputFunction(winpr_LogOutputFunction, sdl);

--- a/client/SDL/SDL3/sdl_pointer.cpp
+++ b/client/SDL/SDL3/sdl_pointer.cpp
@@ -136,7 +136,7 @@ bool sdl_Pointer_Set_Process(SdlContext* sdl)
 	const Uint32 id = SDL_GetWindowID(window);
 
 	const SDL_FRect orig{ ix, iy, isw, ish };
-	auto pos = sdl->pixelToScreen(id, orig);
+	const auto pos = sdl->pixelToScreen(id, orig, true);
 	WLog_Print(sdl->getWLog(), WLOG_DEBUG, "cursor scale: pixel:%s, display:%s",
 	           sdl::utils::toString(orig).c_str(), sdl::utils::toString(pos).c_str());
 
@@ -181,13 +181,10 @@ bool sdl_Pointer_Set_Process(SdlContext* sdl)
 		return false;
 	}
 
-	const auto hidpi_scale =
-	    sdl->pixelToScreen(fw->id(), SDL_FPoint{ static_cast<float>(ptr->image->w),
-	                                             static_cast<float>(ptr->image->h) });
+	const auto w = static_cast<int>(pos.w);
+	const auto h = static_cast<int>(pos.h);
 	std::unique_ptr<SDL_Surface, void (*)(SDL_Surface*)> normal{
-		SDL_CreateSurface(static_cast<int>(hidpi_scale.x), static_cast<int>(hidpi_scale.y),
-		                  ptr->image->format),
-		SDL_DestroySurface
+		SDL_CreateSurface(w, h, ptr->image->format), SDL_DestroySurface
 	};
 	assert(normal);
 	if (!SDL_BlitSurfaceScaled(ptr->image, nullptr, normal.get(), nullptr,
@@ -202,8 +199,14 @@ bool sdl_Pointer_Set_Process(SdlContext* sdl)
 		return false;
 	}
 
-	ptr->cursor =
-	    SDL_CreateColorCursor(normal.get(), static_cast<int>(pos.x), static_cast<int>(pos.y));
+	auto x = static_cast<int>(pos.x);
+	auto y = static_cast<int>(pos.y);
+	if (x >= w)
+		x = w - 1;
+	if (y >= h)
+		y = h - 1;
+
+	ptr->cursor = SDL_CreateColorCursor(normal.get(), x, y);
 	if (!ptr->cursor)
 	{
 		WLog_Print(sdl->getWLog(), WLOG_ERROR, "SDL_CreateColorCursor(display:%s, pixel:%s} failed",


### PR DESCRIPTION
Scaling the mouse cursor might have rounding issues that lead to hotspot coordinates being outside the actual cursor. Ensure we're always within.
