### PR TITLE
build: Update FindFFmpeg.cmake to support Apple frameworks with 'lib' prefix

### DIFF
--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -101,7 +101,8 @@ macro(find_component _component _pkgconfig _library _header)
   )
 
   find_library(
-    ${_component}_LIBRARIES NAMES ${_library} HINTS ${PC_${_component}_LIBDIR} ${PC_${_component}_LIBRARY_DIRS}
+    ${_component}_LIBRARIES NAMES ${_library} lib${_library} HINTS ${PC_${_component}_LIBDIR}
+                                                                   ${PC_${_component}_LIBRARY_DIRS}
   )
 
   set(${_component}_DEFINITIONS ${PC_${_component}_CFLAGS_OTHER} CACHE STRING "The ${_component} CFLAGS.")


### PR DESCRIPTION
Currently, FindFFmpeg.cmake strictly searches for FFmpeg libraries using exactly the component name (e.g., avcodec for avcodec.framework). However, on Apple platforms (macOS/iOS), several major ecosystems and package managers retain the standard Unix lib prefix when generating .framework bundles (e.g., libavcodec.framework).

Because of this strict naming expectation, FreeRDP fails to find valid FFmpeg installations in these environments.

This PR updates the find_library calls in FindFFmpeg.cmake to include lib${_library} as a fallback in the NAMES argument.

This small change significantly improves CMake's ability to locate FFmpeg across diverse build environments without breaking any existing setups (as ${_library} is still searched first).

Notable environments that utilize the lib prefix for Apple frameworks include:
  - Qt 6 (Multimedia): Qt's prebuilt FFmpeg for iOS/macOS packages them as libavcodec.framework, etc. This PR allows developers integrating FreeRDP into Qt applications to share the same FFmpeg dependency natively, eliminating binary duplication and complex deploy scripts.

Changes Made:
  - Modified FindFFmpeg.cmake to search for NAMES ${_library} lib${_library} instead of just NAMES ${_library}.