### PR TITLE
[client,common] do not manipulate security settings for smartcard-logon

### DIFF
--- a/client/common/client.c
+++ b/client/common/client.c
@@ -291,8 +291,6 @@ static BOOL freerdp_client_settings_post_process(rdpSettings* settings)
 	/* deal with the smartcard / smartcard logon stuff */
 	if (freerdp_settings_get_bool(settings, FreeRDP_SmartcardLogon))
 	{
-		if (!freerdp_settings_set_bool(settings, FreeRDP_TlsSecurity, TRUE))
-			goto out_error;
 		if (!freerdp_settings_set_bool(settings, FreeRDP_RedirectSmartCards, TRUE))
 			goto out_error;
 		if (!freerdp_settings_set_bool(settings, FreeRDP_DeviceRedirection, TRUE))


### PR DESCRIPTION
Enabling TLS security for smartcard logon is no longer required as NLA is supported as well. To the contrary, it might hide authentication issues with NLA if the server also allows TLS.