### PR TITLE
[core] fix invalid assertion in `freerdp_get_nla_sspi_error`

### DIFF
--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -1319,11 +1319,12 @@ UINT32 freerdp_get_nla_sspi_error(const rdpContext* context)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(context->rdp);
-	WINPR_ASSERT(context->rdp->transport);
 
 	rdpNla* nla = context->rdp->nla;
-	if (!nla)
+	if (!nla && context->rdp->transport)
 		nla = transport_get_nla(context->rdp->transport);
+	if (!nla)
+		return 0;
 	return (UINT32)nla_get_sspi_error(nla);
 }
 


### PR DESCRIPTION
`context->rdp->transport` can legitimately be `NULL`, we shouldn't assert on it.

The final `nla` pointer is asserted in `nla_get_sspi_error`.

Sorry for providing an incomplete fix yesterday.