### PR TITLE
[channels,rdpewa] fix crash with invalid free()

### DIFF
--- a/channels/rdpewa/client/rdpewa_fido.c
+++ b/channels/rdpewa/client/rdpewa_fido.c
@@ -57,9 +57,10 @@ typedef struct
 
 static void zfree(char* str)
 {
-	if (str)
-		while (*str != '\0')
-			*str++ = '\0';
+	if (!str)
+		return;
+
+	memset(str, 0, strlen(str));
 	free(str);
 }
 


### PR DESCRIPTION
Commit 8592765db27d7a0608e6133bcd3f2258a2eeacd9
refactored to do a manual memset and free. But it
invalidates the pointer that is then passed to free(), which crashes the client every time the user enters a PIN and presses accept.

Just use memset() to avoid invalidating the pointer.