### PR TITLE
[client,sdl] fix crash when clicking 'cancel' on PIN popup

### DIFF
--- a/client/SDL/SDL3/sdl_context.cpp
+++ b/client/SDL/SDL3/sdl_context.cpp
@@ -1045,6 +1045,8 @@ bool SdlContext::moveMouseTo(const SDL_FPoint& pos)
 
 bool SdlContext::handleEvent(const SDL_MouseMotionEvent& ev)
 {
+	if (!getWindowForId(ev.windowID))
+		return true; /* Event for an untracked window (e.g. closed dialog) */
 	SDL_Event copy{};
 	copy.motion = ev;
 	if (!eventToPixelCoordinates(ev.windowID, copy))
@@ -1058,6 +1060,8 @@ bool SdlContext::handleEvent(const SDL_MouseMotionEvent& ev)
 
 bool SdlContext::handleEvent(const SDL_MouseWheelEvent& ev)
 {
+	if (!getWindowForId(ev.windowID))
+		return true;
 	SDL_Event copy{};
 	copy.wheel = ev;
 	if (!eventToPixelCoordinates(ev.windowID, copy))
@@ -1165,6 +1169,8 @@ bool SdlContext::handleEvent(const SDL_DisplayEvent& ev)
 
 bool SdlContext::handleEvent(const SDL_MouseButtonEvent& ev)
 {
+	if (!getWindowForId(ev.windowID))
+		return true;
 	SDL_Event copy = {};
 	copy.button = ev;
 	if (!eventToPixelCoordinates(ev.windowID, copy))
@@ -1176,6 +1182,8 @@ bool SdlContext::handleEvent(const SDL_MouseButtonEvent& ev)
 
 bool SdlContext::handleEvent(const SDL_TouchFingerEvent& ev)
 {
+	if (!getWindowForId(ev.windowID))
+		return true;
 	SDL_Event copy{};
 	copy.tfinger = ev;
 	if (!eventToPixelCoordinates(ev.windowID, copy))


### PR DESCRIPTION
When a PIN or password popup appears, and the user clicks 'cancel' instead of 'accept' in the SDL3 client, it crashes with an error:

[23:20:52:508] [1802465:001b80e1] [ERROR][com.freerdp.client.SDL] - [sdl_run]: [exception] sdl->handleEvent {SDL_EVENT_MOUSE_MOTION}{SDL:Parameter 'props' is invalid}{sdl_run [./client/SDL/SDL3/sdl_freerdp.cpp:192-0]}
[23:20:52:509] [1802465:001b810e] [ERROR][com.freerdp.core] - [freerdp_check_event_handles]: freerdp_check_fds() failed - 0
[23:20:52:509] [1802465:001b810e] [INFO][com.freerdp.client.common] - [client_auto_reconnect_ex]: Network disconnect!
[23:20:52:509] [1802465:001b810e] [ERROR][com.freerdp.client.SDL] - [sdl_client_thread_run]: WaitForMultipleObjects failed with 2
[23:20:52:509] [1802465:001b810e] [ERROR][com.freerdp.client.SDL] - [sdl_client_thread_run]: Failed to check FreeRDP event handles

Avoid crashing when a dialog window is closed