### PR TITLE
[client,x11] keep scancode input for Ctrl/Alt/Super combinations in /kbd:unicode mode

### DIFF
--- a/client/X11/xf_keyboard.c
+++ b/client/X11/xf_keyboard.c
@@ -967,6 +967,18 @@ static BOOL xf_keyboard_key_pressed(xfContext* xfc, KeySym keysym)
 	return xfc->KeyboardState[keycode];
 }
 
+static int xk_keyboard_get_modifier_keys(xfContext* xfc, XF_MODIFIER_KEYS* mod);
+
+static BOOL xf_keyboard_has_system_modifier(xfContext* xfc)
+{
+	XF_MODIFIER_KEYS mod = WINPR_C_ARRAY_INIT;
+
+	WINPR_ASSERT(xfc);
+
+	(void)xk_keyboard_get_modifier_keys(xfc, &mod);
+	return mod.Ctrl || mod.Alt || mod.Super;
+}
+
 void xf_keyboard_send_key(xfContext* xfc, BOOL down, BOOL repeat, const XKeyEvent* event)
 {
 	WINPR_ASSERT(xfc);
@@ -990,7 +1002,8 @@ void xf_keyboard_send_key(xfContext* xfc, BOOL down, BOOL repeat, const XKeyEven
 	}
 	else
 	{
-		if (freerdp_settings_get_bool(xfc->common.context.settings, FreeRDP_UnicodeInput))
+		if (freerdp_settings_get_bool(xfc->common.context.settings, FreeRDP_UnicodeInput) &&
+		    !xf_keyboard_has_system_modifier(xfc))
 		{
 			wchar_t buffer[32] = WINPR_C_ARRAY_INIT;
 			int xwc = -1;


### PR DESCRIPTION

Fix X11 `/kbd:unicode` handling in RemoteApp sessions: keep the scan code path for Ctrl/Alt/Super combinations, and continue using Unicode input for all other key presses so text input works across multiple layouts.

This issue was mentioned in #10591 and [winapps issue](https://github.com/Fmstrat/winapps/issues/192)  (winapps uses freerdp to display windows)

#### How to test
1. Start a RemoteApp session with `/kbd:unicode`
2. Switch between English and Russian layouts
3. Verify text input still works
4. Verify Ctrl+C / Ctrl+V / Ctrl+Z work again