### PR TITLE
[codec,progressive] fix underflow guard in progressive_rfx_quant_sub

### DIFF
--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -144,7 +144,7 @@ static inline BOOL progressive_rfx_quant_sub(const RFX_COMPONENT_CODEC_QUANT* WI
                                              const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q2,
                                              RFX_COMPONENT_CODEC_QUANT* dst)
 {
-	if (q1->HH1 < q2->HL1)
+	if (q1->HL1 < q2->HL1)
 		return FALSE;
 	dst->HL1 = q1->HL1 - q2->HL1; /* HL1 */
 


### PR DESCRIPTION
Currently, `progressive_rfx_quant_sub` checks `q1->HH1 < q2->HL1` before computing `q1->HL1 - q2->HL1`. This is a copy-paste error — the guard compares the wrong field (`HH1` instead of `HL1`), leaving the `HL1` subtraction unprotected against underflow. Let's fix the guard to compare `q1->HL1 < q2->HL1`.