### PR TITLE
fix: wfreerdp floatbar visibility

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -1156,6 +1156,10 @@ static DWORD WINAPI wf_client_thread(LPVOID lpParam)
 				case WM_FREERDP_SHOWWINDOW:
 				{
 					ShowWindow(wfc->hwnd, SW_NORMAL);
+					if (wfc->floatbar)
+					{
+						wf_floatbar_reset_position(wfc->floatbar);
+					}
 					break;
 				}
 				default:

--- a/client/Windows/wf_floatbar.c
+++ b/client/Windows/wf_floatbar.c
@@ -731,3 +731,29 @@ BOOL wf_floatbar_toggle_fullscreen(wfFloatBar* floatbar, BOOL fullscreen)
 
 	return TRUE;
 }
+
+BOOL wf_floatbar_reset_position(wfFloatBar* floatbar)
+{
+	RECT rect = WINPR_C_ARRAY_INIT;
+	const int y = -(int)floatbar->offset;
+
+	if (!floatbar || !floatbar->parent || !floatbar->hwnd)
+		return FALSE;
+
+	if (!GetWindowRect(floatbar->parent, &rect))
+		return FALSE;
+
+	floatbar->rect.left = ((rect.right - rect.left) - floatbar->width) / 2;
+	if (floatbar->rect.left < 0)
+		floatbar->rect.left = 0;
+
+	if (!MoveWindow(floatbar->hwnd, floatbar->rect.left, y, floatbar->width, floatbar->height,
+	                TRUE))
+	{
+		DWORD err = GetLastError();
+		WLog_ERR(TAG, "MoveWindow failed with %08" PRIx32, err);
+		return FALSE;
+	}
+
+	return TRUE;
+}

--- a/client/Windows/wf_floatbar.c
+++ b/client/Windows/wf_floatbar.c
@@ -735,10 +735,11 @@ BOOL wf_floatbar_toggle_fullscreen(wfFloatBar* floatbar, BOOL fullscreen)
 BOOL wf_floatbar_reset_position(wfFloatBar* floatbar)
 {
 	RECT rect = WINPR_C_ARRAY_INIT;
-	const int y = -(int)floatbar->offset;
 
 	if (!floatbar || !floatbar->parent || !floatbar->hwnd)
 		return FALSE;
+
+	const int y = -WINPR_ASSERTING_INT_CAST(int, floatbar->offset);
 
 	if (!GetWindowRect(floatbar->parent, &rect))
 		return FALSE;

--- a/client/Windows/wf_floatbar.h
+++ b/client/Windows/wf_floatbar.h
@@ -29,5 +29,6 @@ wfFloatBar* wf_floatbar_new(wfContext* wfc, HINSTANCE window, DWORD flags);
 void wf_floatbar_free(wfFloatBar* floatbar);
 
 BOOL wf_floatbar_toggle_fullscreen(wfFloatBar* floatbar, BOOL fullscreen);
+BOOL wf_floatbar_reset_position(wfFloatBar* floatbar);
 
 #endif /* FREERDP_CLIENT_WIN_FLOATBAR_H */


### PR DESCRIPTION
- Fixes #11048 

Fix the Windows `wfreerdp` floatbar so it is repositioned correctly once the main window becomes visible.