### PR TITLE
[client,sdl] drop WITH_DEBUG_SDL_EVENTS

### DIFF
--- a/client/SDL/CMakeLists.txt
+++ b/client/SDL/CMakeLists.txt
@@ -35,7 +35,6 @@ include(CommonConfigOptions)
 include(ConfigureFreeRDP)
 include(CXXCompilerFlags)
 
-option(WITH_DEBUG_SDL_EVENTS "[dangerous, not for release builds!] Debug SDL events" ${DEFAULT_DEBUG_OPTION})
 option(WITH_DEBUG_SDL_KBD_EVENTS "[dangerous, not for release builds!] Debug SDL keyboard events"
        ${DEFAULT_DEBUG_OPTION}
 )
@@ -49,9 +48,6 @@ else()
   set(WIN32_GUI_FLAG "WIN32")
 endif()
 
-if(WITH_DEBUG_SDL_EVENTS)
-  add_compile_definitions(WITH_DEBUG_SDL_EVENTS)
-endif()
 if(WITH_DEBUG_SDL_KBD_EVENTS)
   add_compile_definitions(WITH_DEBUG_SDL_KBD_EVENTS)
 endif()

--- a/client/SDL/SDL2/sdl_disp.cpp
+++ b/client/SDL/SDL2/sdl_disp.cpp
@@ -338,10 +338,8 @@ BOOL sdlDispContext::handle_display_event(const SDL_DisplayEvent* ev)
 BOOL sdlDispContext::handle_window_event(const SDL_WindowEvent* ev)
 {
 	WINPR_ASSERT(ev);
-#if defined(WITH_DEBUG_SDL_EVENTS)
-	SDL_Log("got windowEvent %s [0x%08" PRIx32 "]", sdl_window_event_str(ev->event).c_str(),
-	        ev->event);
-#endif
+	WLog_Print(_sdl->log, WLOG_TRACE, "got windowEvent %s [0x%08" PRIx32 "]",
+	           sdl_window_event_str(ev->event).c_str(), ev->event);
 	auto bordered = freerdp_settings_get_bool(_sdl->context()->settings, FreeRDP_Decorations)
 	                    ? SDL_TRUE
 	                    : SDL_FALSE;

--- a/client/SDL/SDL2/sdl_freerdp.cpp
+++ b/client/SDL/SDL2/sdl_freerdp.cpp
@@ -876,10 +876,8 @@ static int sdl_run(SdlContext* sdl)
 					continue;
 			}
 
-#if defined(WITH_DEBUG_SDL_EVENTS)
-			SDL_Log("got event %s [0x%08" PRIx32 "]", sdl_event_type_str(windowEvent.type),
-			        windowEvent.type);
-#endif
+			WLog_Print(sdl->log, WLOG_TRACE, "got event %s [0x%08" PRIx32 "]",
+			           sdl_event_type_str(windowEvent.type), windowEvent.type);
 			std::scoped_lock lock(sdl->critical);
 			/* The session might have been disconnected while we were waiting for a new SDL event.
 			 * In that case ignore the SDL event and terminate. */

--- a/client/SDL/SDL3/sdl_freerdp.cpp
+++ b/client/SDL/SDL3/sdl_freerdp.cpp
@@ -181,10 +181,8 @@ static void sdl_term_handler([[maybe_unused]] int signum, [[maybe_unused]] const
 						continue;
 				}
 
-#if defined(WITH_DEBUG_SDL_EVENTS)
-				SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "got event %s [0x%08" PRIx32 "]",
-				             sdl::utils::toString(windowEvent.type).c_str(), windowEvent.type);
-#endif
+				WLog_Print(sdl->getWLog(), WLOG_TRACE, "got event %s [0x%08" PRIx32 "]",
+				           sdl::utils::toString(windowEvent.type).c_str(), windowEvent.type);
 				if (sdl->shallAbort(true))
 					continue;
 

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -2902,20 +2902,40 @@ static BOOL option_is_experimental(WINPR_ATTR_UNUSED wLog* log, const char* tok)
 static BOOL option_is_debug(wLog* log, const char* tok)
 {
 	WINPR_ASSERT(log);
-	const char* debug[] = {
-		STR(WITH_DEBUG_ALL),        STR(WITH_DEBUG_CERTIFICATE),    STR(WITH_DEBUG_CAPABILITIES),
-		STR(WITH_DEBUG_CHANNELS),   STR(WITH_DEBUG_CLIPRDR),        STR(WITH_DEBUG_CODECS),
-		STR(WITH_DEBUG_DVC),        STR(WITH_DEBUG_TSMF),           STR(WITH_DEBUG_KBD),
-		STR(WITH_DEBUG_LICENSE),    STR(WITH_DEBUG_NEGO),           STR(WITH_DEBUG_NLA),
-		STR(WITH_DEBUG_TSG),        STR(WITH_DEBUG_RAIL),           STR(WITH_DEBUG_RDP),
-		STR(WITH_DEBUG_RDPEI),      STR(WITH_DEBUG_REDIR),          STR(WITH_DEBUG_RDPDR),
-		STR(WITH_DEBUG_RFX),        STR(WITH_DEBUG_SCARD),          STR(WITH_DEBUG_SND),
-		STR(WITH_DEBUG_SVC),        STR(WITH_DEBUG_TRANSPORT),      STR(WITH_DEBUG_TIMEZONE),
-		STR(WITH_DEBUG_WND),        STR(WITH_DEBUG_RINGBUFFER),     STR(WITH_DEBUG_SYMBOLS),
-		STR(WITH_DEBUG_EVENTS),     STR(WITH_DEBUG_MUTEX),          STR(WITH_DEBUG_NTLM),
-		STR(WITH_DEBUG_SDL_EVENTS), STR(WITH_DEBUG_SDL_KBD_EVENTS), STR(WITH_DEBUG_THREADS),
-		STR(WITH_DEBUG_URBDRC)
-	};
+	const char* debug[] = { STR(WITH_DEBUG_ALL),
+		                    STR(WITH_DEBUG_CERTIFICATE),
+		                    STR(WITH_DEBUG_CAPABILITIES),
+		                    STR(WITH_DEBUG_CHANNELS),
+		                    STR(WITH_DEBUG_CLIPRDR),
+		                    STR(WITH_DEBUG_CODECS),
+		                    STR(WITH_DEBUG_DVC),
+		                    STR(WITH_DEBUG_TSMF),
+		                    STR(WITH_DEBUG_KBD),
+		                    STR(WITH_DEBUG_LICENSE),
+		                    STR(WITH_DEBUG_NEGO),
+		                    STR(WITH_DEBUG_NLA),
+		                    STR(WITH_DEBUG_TSG),
+		                    STR(WITH_DEBUG_RAIL),
+		                    STR(WITH_DEBUG_RDP),
+		                    STR(WITH_DEBUG_RDPEI),
+		                    STR(WITH_DEBUG_REDIR),
+		                    STR(WITH_DEBUG_RDPDR),
+		                    STR(WITH_DEBUG_RFX),
+		                    STR(WITH_DEBUG_SCARD),
+		                    STR(WITH_DEBUG_SND),
+		                    STR(WITH_DEBUG_SVC),
+		                    STR(WITH_DEBUG_TRANSPORT),
+		                    STR(WITH_DEBUG_TIMEZONE),
+		                    STR(WITH_DEBUG_WND),
+		                    STR(WITH_DEBUG_RINGBUFFER),
+		                    STR(WITH_DEBUG_SYMBOLS),
+		                    STR(WITH_DEBUG_EVENTS),
+		                    STR(WITH_DEBUG_MUTEX),
+		                    STR(WITH_DEBUG_NTLM),
+		                    STR(WITH_DEBUG_SDL_KBD_EVENTS),
+		                    STR(WITH_DEBUG_SDL_KBD_EVENTS),
+		                    STR(WITH_DEBUG_THREADS),
+		                    STR(WITH_DEBUG_URBDRC) };
 
 	for (size_t x = 0; x < ARRAYSIZE(debug); x++)
 	{


### PR DESCRIPTION
Always compile in the event debugging, but only activate with WLOG_TRACE level.