### PR TITLE
fix(sdl): GPU rendering path for wlroots multimon

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,42 @@
+# 2026-03-25 Version 3.24.1
+
+Bug and security fix release
+
+## CVE fixes
+
+We got 4 High and 2 Moderate security reports from
+* Calvin Young - eWalker Consulting
+* Enoch Chow - Isomorph Cyber
+
+and 2 Modreate reports from
+* [Sebastian Alba Vives] ***@***.***) Sebastián Alba
+
+and 1 Moderate report from
+* @prahal
+
+CVE have been requested but not assigned yet. They will be published once assigned at
+https://github.com/FreeRDP/FreeRDP/security
+
+## What's Changed
+* [channels,video] fix wrong cast (#12511)
+* [codec,openh264] reject encoder ABI mismatch on runtime-loaded library (#12510)
+* [client,sdl] create a copy of rdpPointer (#12512)
+* [codec,video] properly pass intermediate format (#12518)
+* [utils, signal] lazily initialize Windows CRITICAL_SECTION to match POSIX static mutex behavior (#12520)
+* winpr: improve libunwind backtraces (#12530)
+* [server,shadow] remember selected caps (#12528)
+* Zero credential data before free in NLA and NTLM context (#12532)
+* [server,proxy] ignore missing client in input channel (#12536)
+* [server,proxy] ignore rdpdr messages (#12537)
+* [winpr,sspi] improve kerberos logging (#12538)
+* Codec fixes (#12542)
+
+## New Contributors
+* @Kotivskyi made their first contribution in #12532
+
+For a complete and detailed change log since the last release run:
+git log 3.24.2...3.24.1
+
 # 2026-03-18 Version 3.24.1
 
 Minor bugfix release addression two regressions found in previous 3.24.0 release

--- a/channels/rdpsnd/client/opensles/opensl_io.c
+++ b/channels/rdpsnd/client/opensles/opensl_io.c
@@ -332,12 +332,11 @@ static void bqPlayerCallback(SLAndroidSimpleBufferQueueItf bq, void* context)
 // puts a buffer of size samples to the device
 int android_AudioOut(OPENSL_STREAM* p, const short* buffer, int size)
 {
-	HANDLE ev;
 	WINPR_ASSERT(p);
 	WINPR_ASSERT(buffer);
 	WINPR_ASSERT(size > 0);
 
-	ev = Queue_Event(p->queue);
+	HANDLE ev = Queue_Event(p->queue);
 	/* Assure, that the queue is not full. */
 	if (p->queuesize <= Queue_Count(p->queue) && WaitForSingleObject(ev, INFINITE) == WAIT_FAILED)
 	{
@@ -354,7 +353,11 @@ int android_AudioOut(OPENSL_STREAM* p, const short* buffer, int size)
 	}
 
 	memcpy(data, buffer, size * sizeof(short));
-	Queue_Enqueue(p->queue, data);
+	if (!Queue_Enqueue(p->queue, data))
+	{
+		free(data);
+		return -1;
+	}
 	(*p->bqPlayerBufferQueue)->Enqueue(p->bqPlayerBufferQueue, data, sizeof(short) * size);
 	return size;
 }

--- a/channels/video/client/video_main.c
+++ b/channels/video/client/video_main.c
@@ -994,7 +994,7 @@ static UINT video_control_on_close(IWTSVirtualChannelCallback* pChannelCallback)
 {
 	if (pChannelCallback)
 	{
-		GENERIC_LISTENER_CALLBACK* listener_callback = (GENERIC_LISTENER_CALLBACK*)pChannelCallback;
+		GENERIC_CHANNEL_CALLBACK* listener_callback = (GENERIC_CHANNEL_CALLBACK*)pChannelCallback;
 		VIDEO_PLUGIN* video = (VIDEO_PLUGIN*)listener_callback->plugin;
 		if (video && video->control_callback)
 		{
@@ -1010,7 +1010,7 @@ static UINT video_data_on_close(IWTSVirtualChannelCallback* pChannelCallback)
 {
 	if (pChannelCallback)
 	{
-		GENERIC_LISTENER_CALLBACK* listener_callback = (GENERIC_LISTENER_CALLBACK*)pChannelCallback;
+		GENERIC_CHANNEL_CALLBACK* listener_callback = (GENERIC_CHANNEL_CALLBACK*)pChannelCallback;
 		VIDEO_PLUGIN* video = (VIDEO_PLUGIN*)listener_callback->plugin;
 		if (video && video->data_callback)
 		{

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
@@ -342,15 +342,23 @@ static BOOL android_authenticate_int(freerdp* instance, char** username, char** 
 	return ((res == JNI_TRUE) ? TRUE : FALSE);
 }
 
-static BOOL android_authenticate(freerdp* instance, char** username, char** password, char** domain)
+static BOOL android_authenticate_ex(freerdp* instance, char** username, char** password,
+                                    char** domain, rdp_auth_reason reason)
 {
-	return android_authenticate_int(instance, username, password, domain, "OnAuthenticate");
-}
-
-static BOOL android_gw_authenticate(freerdp* instance, char** username, char** password,
-                                    char** domain)
-{
-	return android_authenticate_int(instance, username, password, domain, "OnGatewayAuthenticate");
+	switch (reason)
+	{
+		case AUTH_NLA:
+		case AUTH_TLS:
+		case AUTH_RDP:
+			return android_authenticate_int(instance, username, password, domain, "OnAuthenticate");
+		case GW_AUTH_HTTP:
+		case GW_AUTH_RDG:
+		case GW_AUTH_RPC:
+			return android_authenticate_int(instance, username, password, domain,
+			                                "OnGatewayAuthenticate");
+		default:
+			return FALSE;
+	}
 }
 
 static DWORD android_verify_certificate_ex(freerdp* instance, const char* host, UINT16 port,
@@ -532,8 +540,7 @@ static BOOL android_client_new(freerdp* instance, rdpContext* context)
 	instance->PreConnect = android_pre_connect;
 	instance->PostConnect = android_post_connect;
 	instance->PostDisconnect = android_post_disconnect;
-	instance->Authenticate = android_authenticate;
-	instance->GatewayAuthenticate = android_gw_authenticate;
+	instance->AuthenticateEx = android_authenticate_ex;
 	instance->VerifyCertificateEx = android_verify_certificate_ex;
 	instance->VerifyChangedCertificateEx = android_verify_changed_certificate_ex;
 	instance->LogonErrorInfo = nullptr;

--- a/client/SDL/SDL3/sdl_context.cpp
+++ b/client/SDL/SDL3/sdl_context.cpp
@@ -36,8 +36,9 @@
 #endif
 
 SdlContext::SdlContext(rdpContext* context)
-    : _context(context), _log(WLog_Get(CLIENT_TAG("SDL"))), _rdpThreadRunning(false),
-      _primary(nullptr, SDL_DestroySurface), _disp(this), _input(this), _clip(this), _dialog(_log)
+    : _context(context), _log(WLog_Get(CLIENT_TAG("SDL"))), _cursor(nullptr, sdl_Pointer_FreeCopy),
+      _rdpThreadRunning(false), _primary(nullptr, SDL_DestroySurface), _disp(this), _input(this),
+      _clip(this), _dialog(_log)
 {
 	WINPR_ASSERT(context);
 	setMetadata();
@@ -1483,15 +1484,15 @@ bool SdlContext::setCursor(CursorType type)
 	return restoreCursor();
 }
 
-bool SdlContext::setCursor(rdpPointer* cursor)
+bool SdlContext::setCursor(const rdpPointer* cursor)
 {
-	_cursor = cursor;
+	_cursor = { sdl_Pointer_Copy(cursor), sdl_Pointer_FreeCopy };
 	return setCursor(CURSOR_IMAGE);
 }
 
 rdpPointer* SdlContext::cursor() const
 {
-	return _cursor;
+	return _cursor.get();
 }
 
 bool SdlContext::restoreCursor()

--- a/client/SDL/SDL3/sdl_context.hpp
+++ b/client/SDL/SDL3/sdl_context.hpp
@@ -86,7 +86,7 @@ class SdlContext
 	[[nodiscard]] rdpClientContext* common() const;
 
 	[[nodiscard]] bool setCursor(CursorType type);
-	[[nodiscard]] bool setCursor(rdpPointer* cursor);
+	[[nodiscard]] bool setCursor(const rdpPointer* cursor);
 	[[nodiscard]] rdpPointer* cursor() const;
 	[[nodiscard]] bool restoreCursor();
 
@@ -193,7 +193,7 @@ class SdlContext
 
 	std::atomic<bool> _connected = false;
 	bool _cursor_visible = true;
-	rdpPointer* _cursor = nullptr;
+	std::unique_ptr<rdpPointer, void (*)(rdpPointer*)> _cursor;
 	CursorType _cursorType = CURSOR_NULL;
 	std::vector<SDL_DisplayID> _monitorIds;
 	std::mutex _queue_mux;

--- a/client/SDL/SDL3/sdl_pointer.cpp
+++ b/client/SDL/SDL3/sdl_pointer.cpp
@@ -81,17 +81,21 @@ static void sdl_Pointer_Clear(sdlPointer* ptr)
 	ptr->image = nullptr;
 }
 
-static void sdl_Pointer_Free(rdpContext* context, rdpPointer* pointer)
+static void sdl_Pointer_Free(WINPR_ATTR_UNUSED rdpContext* context, rdpPointer* pointer)
+{
+	sdl_Pointer_FreeCopy(pointer);
+}
+
+void sdl_Pointer_FreeCopy(rdpPointer* pointer)
 {
 	auto ptr = reinterpret_cast<sdlPointer*>(pointer);
-	WINPR_UNUSED(context);
 
-	if (ptr)
-	{
-		sdl_Pointer_Clear(ptr);
-		winpr_aligned_free(ptr->data);
-		ptr->data = nullptr;
-	}
+	if (!ptr)
+		return;
+
+	sdl_Pointer_Clear(ptr);
+	winpr_aligned_free(ptr->data);
+	ptr->data = nullptr;
 }
 
 [[nodiscard]] static BOOL sdl_Pointer_SetDefault(rdpContext* context)
@@ -258,4 +262,33 @@ bool sdl_register_pointer(rdpGraphics* graphics)
 		                         {} };
 	graphics_register_pointer(graphics, &pointer);
 	return true;
+}
+
+rdpPointer* sdl_Pointer_Copy(const rdpPointer* pointer)
+{
+	auto ptr = reinterpret_cast<const sdlPointer*>(pointer);
+	if (!pointer)
+		return nullptr;
+
+	auto copy = static_cast<sdlPointer*>(calloc(1, sizeof(sdlPointer)));
+	if (!copy)
+		return nullptr;
+
+	copy->pointer.xPos = pointer->xPos;
+	copy->pointer.yPos = pointer->yPos;
+	copy->pointer.width = pointer->width;
+	copy->pointer.height = pointer->height;
+	copy->pointer.xorBpp = pointer->xorBpp;
+	if (ptr->size > 0)
+	{
+		copy->data = static_cast<BYTE*>(winpr_aligned_malloc(ptr->size, 32));
+		if (!copy)
+		{
+			free(copy);
+			return nullptr;
+		}
+		copy->size = ptr->size;
+		memcpy(copy->data, ptr->data, copy->size);
+	}
+	return &copy->pointer;
 }

--- a/client/SDL/SDL3/sdl_pointer.hpp
+++ b/client/SDL/SDL3/sdl_pointer.hpp
@@ -28,3 +28,13 @@
 [[nodiscard]] bool sdl_register_pointer(rdpGraphics* graphics);
 
 [[nodiscard]] bool sdl_Pointer_Set_Process(SdlContext* sdl);
+
+void sdl_Pointer_FreeCopy(rdpPointer* pointer);
+
+/** @brief creates a copy when the \ref rdpPointer was already created in \ref PointerNew.
+ *
+ *  The copy only contains the relevant data (coordinates, bitmap data) required for the SDL client
+ * to display the cursor. Callbacks and xor/and mask data are not copied.
+ */
+WINPR_ATTR_MALLOC(sdl_Pointer_FreeCopy, 2)
+rdpPointer* sdl_Pointer_Copy(const rdpPointer* pointer);

--- a/client/SDL/SDL3/sdl_pointer.hpp
+++ b/client/SDL/SDL3/sdl_pointer.hpp
@@ -36,5 +36,5 @@ void sdl_Pointer_FreeCopy(rdpPointer* pointer);
  *  The copy only contains the relevant data (coordinates, bitmap data) required for the SDL client
  * to display the cursor. Callbacks and xor/and mask data are not copied.
  */
-WINPR_ATTR_MALLOC(sdl_Pointer_FreeCopy, 2)
+WINPR_ATTR_MALLOC(sdl_Pointer_FreeCopy, 1)
 rdpPointer* sdl_Pointer_Copy(const rdpPointer* pointer);

--- a/client/SDL/SDL3/sdl_window.cpp
+++ b/client/SDL/SDL3/sdl_window.cpp
@@ -53,18 +53,38 @@ SdlWindow::SdlWindow(SDL_DisplayID id, const std::string& title, const SDL_Rect&
 	SDL_SetHint(SDL_HINT_APP_NAME, "");
 	std::ignore = SDL_SyncWindow(_window);
 
+	_renderer = SDL_CreateRenderer(_window, nullptr);
+	if (_renderer)
+	{
+		_renderTarget = SDL_CreateTexture(_renderer, SDL_PIXELFORMAT_BGRA32,
+		                                  SDL_TEXTUREACCESS_TARGET, rect.w, rect.h);
+	}
+
 	_monitor = query(_window, id, true);
 }
 
 SdlWindow::SdlWindow(SdlWindow&& other) noexcept
-    : _window(other._window), _displayID(other._displayID), _offset_x(other._offset_x),
-      _offset_y(other._offset_y), _monitor(other._monitor)
+    : _window(other._window), _renderer(other._renderer), _renderTarget(other._renderTarget),
+      _gdiTexture(other._gdiTexture), _gdiTextureW(other._gdiTextureW),
+      _gdiTextureH(other._gdiTextureH), _displayID(other._displayID),
+      _offset_x(other._offset_x), _offset_y(other._offset_y), _monitor(other._monitor)
 {
 	other._window = nullptr;
+	other._renderer = nullptr;
+	other._renderTarget = nullptr;
+	other._gdiTexture = nullptr;
+	other._gdiTextureW = 0;
+	other._gdiTextureH = 0;
 }
 
 SdlWindow::~SdlWindow()
 {
+	if (_gdiTexture)
+		SDL_DestroyTexture(_gdiTexture);
+	if (_renderTarget)
+		SDL_DestroyTexture(_renderTarget);
+	if (_renderer)
+		SDL_DestroyRenderer(_renderer);
 	SDL_DestroyWindow(_window);
 }
 
@@ -273,6 +293,12 @@ bool SdlWindow::drawScaledRects(SDL_Surface* surface, const SDL_FPoint& scale,
 
 bool SdlWindow::fill(Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
+	if (_renderer)
+	{
+		SDL_SetRenderTarget(_renderer, _renderTarget);
+		SDL_SetRenderDrawColor(_renderer, r, g, b, a);
+		return SDL_RenderClear(_renderer);
+	}
 	return fill(_window, r, g, b, a);
 }
 
@@ -362,7 +388,34 @@ SDL_Rect SdlWindow::rect(SDL_Window* window, bool forceAsPrimary)
 		 * 200px. Workaround: If we got dimensions that are too small, query the display directly.
 		 */
 
-		const auto displayID = SDL_GetDisplayForWindow(window);
+		/* On wlroots compositors, SDL_GetDisplayForWindow may return the wrong
+		 * display for unmapped windows. Fall back to matching the window's
+		 * position against display bounds if the initial query gives a
+		 * display whose bounds are too small.
+		 */
+		auto displayID = SDL_GetDisplayForWindow(window);
+		SDL_Rect checkBounds = {};
+		if (!SDL_GetDisplayBounds(displayID, &checkBounds) ||
+		    (checkBounds.w < 200 || checkBounds.h < 200))
+		{
+			/* Wrong display — find the correct one by matching position */
+			int wx = 0, wy = 0;
+			SDL_GetWindowPosition(window, &wx, &wy);
+			int count = 0;
+			auto* displays = SDL_GetDisplays(&count);
+			for (int i = 0; i < count; i++)
+			{
+				SDL_Rect db = {};
+				if (SDL_GetDisplayBounds(displays[i], &db) &&
+				    wx >= db.x && wx < db.x + db.w &&
+				    wy >= db.y && wy < db.y + db.h)
+				{
+					displayID = displays[i];
+					break;
+				}
+			}
+			SDL_free(displays);
+		}
 		SDL_Rect displayBounds = {};
 		if (SDL_GetDisplayBounds(displayID, &displayBounds))
 		{
@@ -415,16 +468,49 @@ SdlWindow::HighDPIMode SdlWindow::isHighDPIWindowsMode(SDL_Window* window)
 
 bool SdlWindow::blit(SDL_Surface* surface, const SDL_Rect& srcRect, SDL_Rect& dstRect)
 {
-	auto screen = SDL_GetWindowSurface(_window);
-	if (!screen || !surface)
+	if (!_renderer || !surface)
 		return false;
-	if (!SDL_SetSurfaceClipRect(surface, &srcRect))
-		return true;
-	if (!SDL_SetSurfaceClipRect(screen, &dstRect))
-		return true;
-	if (!SDL_BlitSurfaceScaled(surface, &srcRect, screen, &dstRect, SDL_SCALEMODE_LINEAR))
+
+	/* Lazily create or recreate the persistent GDI texture */
+	if (!_gdiTexture || _gdiTextureW != surface->w || _gdiTextureH != surface->h)
 	{
-		SDL_LogError(SDL_LOG_CATEGORY_RENDER, "SDL_BlitScaled: %s", SDL_GetError());
+		if (_gdiTexture)
+			SDL_DestroyTexture(_gdiTexture);
+		_gdiTexture = SDL_CreateTexture(_renderer, surface->format,
+		                                SDL_TEXTUREACCESS_STREAMING,
+		                                surface->w, surface->h);
+		if (!_gdiTexture)
+		{
+			SDL_LogError(SDL_LOG_CATEGORY_RENDER, "SDL_CreateTexture: %s", SDL_GetError());
+			return false;
+		}
+		_gdiTextureW = surface->w;
+		_gdiTextureH = surface->h;
+
+		/* Upload the full surface on first creation */
+		SDL_UpdateTexture(_gdiTexture, nullptr, surface->pixels, surface->pitch);
+	}
+	else
+	{
+		/* Upload only the dirty region */
+		const auto* details = SDL_GetPixelFormatDetails(surface->format);
+		const int bpp = details ? details->bytes_per_pixel : 4;
+		const auto* pixels = static_cast<const uint8_t*>(surface->pixels) +
+		                     srcRect.y * surface->pitch +
+		                     srcRect.x * bpp;
+		SDL_UpdateTexture(_gdiTexture, &srcRect, pixels, surface->pitch);
+	}
+
+	/* Render onto persistent render target to accumulate dirty rects */
+	SDL_SetRenderTarget(_renderer, _renderTarget);
+
+	SDL_FRect fsrc = { static_cast<float>(srcRect.x), static_cast<float>(srcRect.y),
+	                   static_cast<float>(srcRect.w), static_cast<float>(srcRect.h) };
+	SDL_FRect fdst = { static_cast<float>(dstRect.x), static_cast<float>(dstRect.y),
+	                   static_cast<float>(dstRect.w), static_cast<float>(dstRect.h) };
+	if (!SDL_RenderTexture(_renderer, _gdiTexture, &fsrc, &fdst))
+	{
+		SDL_LogError(SDL_LOG_CATEGORY_RENDER, "SDL_RenderTexture: %s", SDL_GetError());
 		return false;
 	}
 	return true;
@@ -432,7 +518,13 @@ bool SdlWindow::blit(SDL_Surface* surface, const SDL_Rect& srcRect, SDL_Rect& ds
 
 void SdlWindow::updateSurface()
 {
-	SDL_UpdateWindowSurface(_window);
+	if (!_renderer)
+		return;
+
+	/* Copy accumulated render target to screen and present */
+	SDL_SetRenderTarget(_renderer, nullptr);
+	SDL_RenderTexture(_renderer, _renderTarget, nullptr, nullptr);
+	SDL_RenderPresent(_renderer);
 }
 
 SdlWindow SdlWindow::create(SDL_DisplayID id, const std::string& title, Uint32 flags, Uint32 width,
@@ -545,7 +637,7 @@ bool SdlWindow::tryFallback(bool isFullscreen)
 	{
 		const auto enabled = strcmp(wlroots_hack, "0") != 0;
 		if (strcmp(wlroots_hack, "force") == 0)
-			isFullscreen = true;
+			return enabled; /* force: always use display bounds, even for borderless/multimon */
 		return enabled && isFullscreen;
 	}
 
@@ -557,33 +649,28 @@ bool SdlWindow::tryFallback(bool isFullscreen)
 	if ((driver == nullptr) || (strcmp(driver, "wayland") != 0))
 		return false;
 
-	/* check XDG_SESSION_DESKTOP
-	 *
-	 * if set and the value is
-	 * - sway
-	 *
-	 * then we need the hack.
+	/* check XDG_SESSION_DESKTOP and XDG_CURRENT_DESKTOP for wlroots-based
+	 * compositors (Sway, Hyprland, river, etc.) where hidden/unmapped windows
+	 * return their creation size (64x64) instead of the display size.
 	 */
-	const auto xdg_session = SDL_getenv("XDG_SESSION_DESKTOP");
-	if (xdg_session != nullptr)
-	{
-		if (strcmp(xdg_session, "sway") == 0)
-			return isFullscreen;
-	}
+	auto needsHack = [](const char* value) -> bool {
+		if (!value)
+			return false;
+		/* Match known wlroots compositors */
+		if (strstr(value, "sway") || strstr(value, "Hyprland") ||
+		    strstr(value, "hyprland") || strstr(value, "river") ||
+		    strstr(value, "wlroots"))
+			return true;
+		return false;
+	};
 
-	/* check XDG_CURRENT_DESKTOP
-	 *
-	 * if set and the value is
-	 * - sway:wlroots
-	 *
-	 * then we need the hack.
-	 */
+	const auto xdg_session = SDL_getenv("XDG_SESSION_DESKTOP");
+	if (needsHack(xdg_session))
+		return true; /* always fallback on wlroots, not just fullscreen */
+
 	const auto xdg_desktop = SDL_getenv("XDG_CURRENT_DESKTOP");
-	if (xdg_desktop != nullptr)
-	{
-		if (strcmp(xdg_desktop, "sway:wlroots") == 0)
-			return isFullscreen;
-	}
+	if (needsHack(xdg_desktop))
+		return true;
 
 	return false;
 }

--- a/client/SDL/SDL3/sdl_window.hpp
+++ b/client/SDL/SDL3/sdl_window.hpp
@@ -106,6 +106,11 @@ class SdlWindow
 
   private:
 	SDL_Window* _window = nullptr;
+	SDL_Renderer* _renderer = nullptr;
+	SDL_Texture* _renderTarget = nullptr;
+	SDL_Texture* _gdiTexture = nullptr;
+	int _gdiTextureW = 0;
+	int _gdiTextureH = 0;
 	SDL_DisplayID _displayID = 0;
 	Sint32 _offset_x = 0;
 	Sint32 _offset_y = 0;

--- a/client/common/client_cliprdr_file.c
+++ b/client/common/client_cliprdr_file.c
@@ -632,6 +632,8 @@ UINT cliprdr_file_context_notify_new_server_format_list(CliprdrFileContext* file
 		return ERROR_INTERNAL_ERROR;
 	/* TODO: assign timeouts to old locks instead */
 	rc = clear_cdi_entries(file_context);
+	if (rc != CHANNEL_RC_OK)
+		return rc;
 
 	if (does_server_support_clipdata_locking(file_context))
 		rc = prepare_clip_data_entry_with_id(file_context);

--- a/cmake/GetProjectVersion.cmake
+++ b/cmake/GetProjectVersion.cmake
@@ -4,7 +4,7 @@ option(USE_GIT_FOR_REVISION "Extract git tag/commit" OFF)
 function(get_project_version VERSION_MAJOR VERSION_MINOR VERSION_REVISION VERSION_SUFFIX GIT_REVISION)
 
   # Default version, hard codec per release
-  set(RAW_VERSION_STRING "3.24.2-dev0")
+  set(RAW_VERSION_STRING "3.24.2")
 
   set(VERSION_REGEX "^(.*)([0-9]+)\\.([0-9]+)\\.([0-9]+)-?(.*)")
 

--- a/libfreerdp/cache/persistent.c
+++ b/libfreerdp/cache/persistent.c
@@ -39,6 +39,7 @@ struct rdp_persistent_cache
 	size_t bmpSize;
 };
 
+static const size_t PERSIST_ALIGN = 32;
 static const char sig_str[] = "RDP8bmp";
 
 int persistent_cache_get_version(rdpPersistentCache* persistent)
@@ -155,7 +156,7 @@ static int persistent_cache_read_entry_v3(rdpPersistentCache* persistent,
 	{
 		persistent->bmpSize = size;
 		BYTE* bmpData = (BYTE*)winpr_aligned_recalloc(persistent->bmpData, persistent->bmpSize,
-		                                              sizeof(BYTE), 32);
+		                                              sizeof(BYTE), PERSIST_ALIGN);
 
 		if (!bmpData)
 			return -1;
@@ -350,7 +351,7 @@ rdpPersistentCache* persistent_cache_new(void)
 		return nullptr;
 
 	persistent->bmpSize = 0x4000;
-	persistent->bmpData = calloc(1, persistent->bmpSize);
+	persistent->bmpData = winpr_aligned_calloc(1, persistent->bmpSize, PERSIST_ALIGN);
 
 	if (!persistent->bmpData)
 	{

--- a/libfreerdp/cache/persistent.c
+++ b/libfreerdp/cache/persistent.c
@@ -36,7 +36,7 @@ struct rdp_persistent_cache
 	int count;
 	char* filename;
 	BYTE* bmpData;
-	UINT32 bmpSize;
+	size_t bmpSize;
 };
 
 static const char sig_str[] = "RDP8bmp";
@@ -149,12 +149,11 @@ static int persistent_cache_read_entry_v3(rdpPersistentCache* persistent,
 	const UINT64 size = 4ull * entry3.width * entry3.height;
 	if (size > UINT32_MAX)
 		return -1;
-	entry->size = (UINT32)size;
 	entry->flags = 0;
 
-	if (entry->size > persistent->bmpSize)
+	if (size > persistent->bmpSize)
 	{
-		persistent->bmpSize = entry->size;
+		persistent->bmpSize = size;
 		BYTE* bmpData = (BYTE*)winpr_aligned_recalloc(persistent->bmpData, persistent->bmpSize,
 		                                              sizeof(BYTE), 32);
 
@@ -163,6 +162,7 @@ static int persistent_cache_read_entry_v3(rdpPersistentCache* persistent,
 
 		persistent->bmpData = bmpData;
 	}
+	entry->size = WINPR_ASSERTING_INT_CAST(UINT32, size);
 
 	entry->data = persistent->bmpData;
 

--- a/libfreerdp/codec/clear.c
+++ b/libfreerdp/codec/clear.c
@@ -67,6 +67,7 @@ struct S_CLEAR_CONTEXT
 	CLEAR_VBAR_ENTRY VBarStorage[CLEARCODEC_VBAR_SIZE];
 	UINT32 ShortVBarStorageCursor;
 	CLEAR_VBAR_ENTRY ShortVBarStorage[CLEARCODEC_VBAR_SHORT_SIZE];
+	wLog* log;
 };
 
 static const UINT32 CLEAR_LOG2_FLOOR[256] = {
@@ -130,15 +131,15 @@ static BOOL convert_color(BYTE* WINPR_RESTRICT dst, UINT32 nDstStep, UINT32 DstF
 	                                     FREERDP_KEEP_DST_ALPHA);
 }
 
-static BOOL clear_decompress_nscodec(NSC_CONTEXT* WINPR_RESTRICT nsc, UINT32 width, UINT32 height,
-                                     wStream* WINPR_RESTRICT s, UINT32 bitmapDataByteCount,
-                                     BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat,
-                                     UINT32 nDstStep, UINT32 nXDstRel, UINT32 nYDstRel,
-                                     UINT32 nDstWidth, UINT32 nDstHeight)
+static BOOL clear_decompress_nscodec(wLog* log, NSC_CONTEXT* WINPR_RESTRICT nsc, UINT32 width,
+                                     UINT32 height, wStream* WINPR_RESTRICT s,
+                                     UINT32 bitmapDataByteCount, BYTE* WINPR_RESTRICT pDstData,
+                                     UINT32 DstFormat, UINT32 nDstStep, UINT32 nXDstRel,
+                                     UINT32 nYDstRel, UINT32 nDstWidth, UINT32 nDstHeight)
 {
 	BOOL rc = 0;
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, bitmapDataByteCount))
+	if (!Stream_CheckAndLogRequiredLengthWLog(log, s, bitmapDataByteCount))
 		return FALSE;
 
 	rc = nsc_process_message(nsc, 32, width, height, Stream_Pointer(s), bitmapDataByteCount,
@@ -148,8 +149,8 @@ static BOOL clear_decompress_nscodec(NSC_CONTEXT* WINPR_RESTRICT nsc, UINT32 wid
 	return rc;
 }
 
-static BOOL clear_decompress_subcode_rlex(wStream* WINPR_RESTRICT s, UINT32 bitmapDataByteCount,
-                                          UINT32 width, UINT32 height,
+static BOOL clear_decompress_subcode_rlex(wLog* log, wStream* WINPR_RESTRICT s,
+                                          UINT32 bitmapDataByteCount, UINT32 width, UINT32 height,
                                           BYTE* WINPR_RESTRICT pDstData, UINT32 DstFormat,
                                           UINT32 nDstStep, UINT32 nXDstRel, UINT32 nYDstRel,
                                           UINT32 nDstWidth, UINT32 nDstHeight)
@@ -167,21 +168,21 @@ static BOOL clear_decompress_subcode_rlex(wStream* WINPR_RESTRICT s, UINT32 bitm
 	BYTE paletteCount = 0;
 	UINT32 palette[128] = WINPR_C_ARRAY_INIT;
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, bitmapDataByteCount))
+	if (!Stream_CheckAndLogRequiredLengthWLog(log, s, bitmapDataByteCount))
 		return FALSE;
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 1))
+	if (!Stream_CheckAndLogRequiredLengthWLog(log, s, 1))
 		return FALSE;
 	Stream_Read_UINT8(s, paletteCount);
 	bitmapDataOffset = 1 + (paletteCount * 3);
 
 	if ((paletteCount > 127) || (paletteCount < 1))
 	{
-		WLog_ERR(TAG, "paletteCount %" PRIu8 "", paletteCount);
+		WLog_Print(log, WLOG_ERROR, "paletteCount %" PRIu8 "", paletteCount);
 		return FALSE;
 	}
 
-	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, paletteCount, 3ull))
+	if (!Stream_CheckAndLogRequiredLengthOfSizeWLog(log, s, paletteCount, 3ull))
 		return FALSE;
 
 	for (UINT32 i = 0; i < paletteCount; i++)
@@ -205,7 +206,7 @@ static BOOL clear_decompress_subcode_rlex(wStream* WINPR_RESTRICT s, UINT32 bitm
 		UINT32 color = 0;
 		UINT32 runLengthFactor = 0;
 
-		if (!Stream_CheckAndLogRequiredLength(TAG, s, 2))
+		if (!Stream_CheckAndLogRequiredLengthWLog(log, s, 2))
 			return FALSE;
 
 		Stream_Read_UINT8(s, tmp);
@@ -217,7 +218,7 @@ static BOOL clear_decompress_subcode_rlex(wStream* WINPR_RESTRICT s, UINT32 bitm
 
 		if (runLengthFactor >= 0xFF)
 		{
-			if (!Stream_CheckAndLogRequiredLength(TAG, s, 2))
+			if (!Stream_CheckAndLogRequiredLengthWLog(log, s, 2))
 				return FALSE;
 
 			Stream_Read_UINT16(s, runLengthFactor);
@@ -225,7 +226,7 @@ static BOOL clear_decompress_subcode_rlex(wStream* WINPR_RESTRICT s, UINT32 bitm
 
 			if (runLengthFactor >= 0xFFFF)
 			{
-				if (!Stream_CheckAndLogRequiredLength(TAG, s, 4))
+				if (!Stream_CheckAndLogRequiredLengthWLog(log, s, 4))
 					return FALSE;
 
 				Stream_Read_UINT32(s, runLengthFactor);
@@ -235,15 +236,15 @@ static BOOL clear_decompress_subcode_rlex(wStream* WINPR_RESTRICT s, UINT32 bitm
 
 		if (startIndex >= paletteCount)
 		{
-			WLog_ERR(TAG, "startIndex %" PRIu8 " > paletteCount %" PRIu8 "]", startIndex,
-			         paletteCount);
+			WLog_Print(log, WLOG_ERROR, "startIndex %" PRIu8 " > paletteCount %" PRIu8 "]",
+			           startIndex, paletteCount);
 			return FALSE;
 		}
 
 		if (stopIndex >= paletteCount)
 		{
-			WLog_ERR(TAG, "stopIndex %" PRIu8 " > paletteCount %" PRIu8 "]", stopIndex,
-			         paletteCount);
+			WLog_Print(log, WLOG_ERROR, "stopIndex %" PRIu8 " > paletteCount %" PRIu8 "]",
+			           stopIndex, paletteCount);
 			return FALSE;
 		}
 
@@ -251,7 +252,7 @@ static BOOL clear_decompress_subcode_rlex(wStream* WINPR_RESTRICT s, UINT32 bitm
 
 		if (suiteIndex > 127)
 		{
-			WLog_ERR(TAG, "suiteIndex %" PRIu8 " > 127]", suiteIndex);
+			WLog_Print(log, WLOG_ERROR, "suiteIndex %" PRIu8 " > 127]", suiteIndex);
 			return FALSE;
 		}
 
@@ -259,9 +260,10 @@ static BOOL clear_decompress_subcode_rlex(wStream* WINPR_RESTRICT s, UINT32 bitm
 
 		if ((pixelIndex + runLengthFactor) > pixelCount)
 		{
-			WLog_ERR(TAG,
-			         "pixelIndex %" PRIuz " + runLengthFactor %" PRIu32 " > pixelCount %" PRIu32 "",
-			         pixelIndex, runLengthFactor, pixelCount);
+			WLog_Print(log, WLOG_ERROR,
+			           "pixelIndex %" PRIuz " + runLengthFactor %" PRIu32 " > pixelCount %" PRIu32
+			           "",
+			           pixelIndex, runLengthFactor, pixelCount);
 			return FALSE;
 		}
 
@@ -284,9 +286,9 @@ static BOOL clear_decompress_subcode_rlex(wStream* WINPR_RESTRICT s, UINT32 bitm
 
 		if ((pixelIndex + (suiteDepth + 1)) > pixelCount)
 		{
-			WLog_ERR(TAG,
-			         "pixelIndex %" PRIuz " + suiteDepth %" PRIu8 " + 1 > pixelCount %" PRIu32 "",
-			         pixelIndex, suiteDepth, pixelCount);
+			WLog_Print(log, WLOG_ERROR,
+			           "pixelIndex %" PRIuz " + suiteDepth %" PRIu8 " + 1 > pixelCount %" PRIu32 "",
+			           pixelIndex, suiteDepth, pixelCount);
 			return FALSE;
 		}
 
@@ -298,7 +300,7 @@ static BOOL clear_decompress_subcode_rlex(wStream* WINPR_RESTRICT s, UINT32 bitm
 
 			if (suiteIndex > 127)
 			{
-				WLog_ERR(TAG, "suiteIndex %" PRIu8 " > 127", suiteIndex);
+				WLog_Print(log, WLOG_ERROR, "suiteIndex %" PRIu8 " > 127", suiteIndex);
 				return FALSE;
 			}
 
@@ -319,7 +321,8 @@ static BOOL clear_decompress_subcode_rlex(wStream* WINPR_RESTRICT s, UINT32 bitm
 
 	if (pixelIndex != pixelCount)
 	{
-		WLog_ERR(TAG, "pixelIndex %" PRIuz " != pixelCount %" PRIu32 "", pixelIndex, pixelCount);
+		WLog_Print(log, WLOG_ERROR, "pixelIndex %" PRIuz " != pixelCount %" PRIu32 "", pixelIndex,
+		           pixelCount);
 		return FALSE;
 	}
 
@@ -343,8 +346,9 @@ static BOOL clear_resize_buffer(CLEAR_CONTEXT* WINPR_RESTRICT clear, UINT32 widt
 
 		if (!tmp)
 		{
-			WLog_ERR(TAG, "clear->TempBuffer winpr_aligned_recalloc failed for %" PRIu64 " bytes",
-			         size);
+			WLog_Print(clear->log, WLOG_ERROR,
+			           "clear->TempBuffer winpr_aligned_recalloc failed for %" PRIu64 " bytes",
+			           size);
 			return FALSE;
 		}
 
@@ -369,7 +373,7 @@ static BOOL clear_decompress_residual_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 	UINT32 pixelIndex = 0;
 	UINT32 pixelCount = 0;
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, residualByteCount))
+	if (!Stream_CheckAndLogRequiredLengthWLog(clear->log, s, residualByteCount))
 		return FALSE;
 
 	suboffset = 0;
@@ -389,7 +393,7 @@ static BOOL clear_decompress_residual_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 		UINT32 runLengthFactor = 0;
 		UINT32 color = 0;
 
-		if (!Stream_CheckAndLogRequiredLength(TAG, s, 4))
+		if (!Stream_CheckAndLogRequiredLengthWLog(clear->log, s, 4))
 			return FALSE;
 
 		Stream_Read_UINT8(s, b);
@@ -401,7 +405,7 @@ static BOOL clear_decompress_residual_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 		if (runLengthFactor >= 0xFF)
 		{
-			if (!Stream_CheckAndLogRequiredLength(TAG, s, 2))
+			if (!Stream_CheckAndLogRequiredLengthWLog(clear->log, s, 2))
 				return FALSE;
 
 			Stream_Read_UINT16(s, runLengthFactor);
@@ -409,7 +413,7 @@ static BOOL clear_decompress_residual_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 			if (runLengthFactor >= 0xFFFF)
 			{
-				if (!Stream_CheckAndLogRequiredLength(TAG, s, 4))
+				if (!Stream_CheckAndLogRequiredLengthWLog(clear->log, s, 4))
 					return FALSE;
 
 				Stream_Read_UINT32(s, runLengthFactor);
@@ -419,10 +423,10 @@ static BOOL clear_decompress_residual_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 		if ((pixelIndex >= pixelCount) || (runLengthFactor > (pixelCount - pixelIndex)))
 		{
-			WLog_ERR(TAG,
-			         "pixelIndex %" PRIu32 " + runLengthFactor %" PRIu32 " > pixelCount %" PRIu32
-			         "",
-			         pixelIndex, runLengthFactor, pixelCount);
+			WLog_Print(clear->log, WLOG_ERROR,
+			           "pixelIndex %" PRIu32 " + runLengthFactor %" PRIu32 " > pixelCount %" PRIu32
+			           "",
+			           pixelIndex, runLengthFactor, pixelCount);
 			return FALSE;
 		}
 
@@ -439,7 +443,8 @@ static BOOL clear_decompress_residual_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 	if (pixelIndex != pixelCount)
 	{
-		WLog_ERR(TAG, "pixelIndex %" PRIu32 " != pixelCount %" PRIu32 "", pixelIndex, pixelCount);
+		WLog_Print(clear->log, WLOG_ERROR, "pixelIndex %" PRIu32 " != pixelCount %" PRIu32 "",
+		           pixelIndex, pixelCount);
 		return FALSE;
 	}
 
@@ -458,12 +463,12 @@ static BOOL clear_decompress_subcodecs_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 {
 	UINT32 suboffset = 0;
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, subcodecByteCount))
+	if (!Stream_CheckAndLogRequiredLengthWLog(clear->log, s, subcodecByteCount))
 		return FALSE;
 
 	while (suboffset < subcodecByteCount)
 	{
-		if (!Stream_CheckAndLogRequiredLength(TAG, s, 13))
+		if (!Stream_CheckAndLogRequiredLengthWLog(clear->log, s, 13))
 			return FALSE;
 
 		const UINT16 xStart = Stream_Get_UINT16(s);
@@ -474,34 +479,38 @@ static BOOL clear_decompress_subcodecs_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 		const UINT8 subcodecId = Stream_Get_UINT8(s);
 		suboffset += 13;
 
-		if (!Stream_CheckAndLogRequiredLength(TAG, s, bitmapDataByteCount))
+		if (!Stream_CheckAndLogRequiredLengthWLog(clear->log, s, bitmapDataByteCount))
 			return FALSE;
 
 		const UINT32 nXDstRel = nXDst + xStart;
 		const UINT32 nYDstRel = nYDst + yStart;
 		if (1ull * nXDstRel + width > nDstWidth)
 		{
-			WLog_ERR(TAG, "nXDstRel %" PRIu32 " + width %" PRIu16 " > nDstWidth %" PRIu32 "",
-			         nXDstRel, width, nDstWidth);
+			WLog_Print(clear->log, WLOG_ERROR,
+			           "nXDstRel %" PRIu32 " + width %" PRIu16 " > nDstWidth %" PRIu32 "", nXDstRel,
+			           width, nDstWidth);
 			return FALSE;
 		}
 		if (1ull * nYDstRel + height > nDstHeight)
 		{
-			WLog_ERR(TAG, "nYDstRel %" PRIu32 " + height %" PRIu16 " > nDstHeight %" PRIu32 "",
-			         nYDstRel, height, nDstHeight);
+			WLog_Print(clear->log, WLOG_ERROR,
+			           "nYDstRel %" PRIu32 " + height %" PRIu16 " > nDstHeight %" PRIu32 "",
+			           nYDstRel, height, nDstHeight);
 			return FALSE;
 		}
 
 		if (1ull * xStart + width > nWidth)
 		{
-			WLog_ERR(TAG, "xStart %" PRIu16 " + width %" PRIu16 " > nWidth %" PRIu32 "", xStart,
-			         width, nWidth);
+			WLog_Print(clear->log, WLOG_ERROR,
+			           "xStart %" PRIu16 " + width %" PRIu16 " > nWidth %" PRIu32 "", xStart, width,
+			           nWidth);
 			return FALSE;
 		}
 		if (1ull * yStart + height > nHeight)
 		{
-			WLog_ERR(TAG, "yStart %" PRIu16 " + height %" PRIu16 " > nHeight %" PRIu32 "", yStart,
-			         height, nHeight);
+			WLog_Print(clear->log, WLOG_ERROR,
+			           "yStart %" PRIu16 " + height %" PRIu16 " > nHeight %" PRIu32 "", yStart,
+			           height, nHeight);
 			return FALSE;
 		}
 
@@ -517,8 +526,9 @@ static BOOL clear_decompress_subcodecs_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 				if (bitmapDataByteCount != nSrcSize)
 				{
-					WLog_ERR(TAG, "bitmapDataByteCount %" PRIu32 " != nSrcSize %" PRIuz "",
-					         bitmapDataByteCount, nSrcSize);
+					WLog_Print(clear->log, WLOG_ERROR,
+					           "bitmapDataByteCount %" PRIu32 " != nSrcSize %" PRIuz "",
+					           bitmapDataByteCount, nSrcSize);
 					return FALSE;
 				}
 
@@ -532,23 +542,23 @@ static BOOL clear_decompress_subcodecs_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 			break;
 
 			case 1: /* NSCodec */
-				if (!clear_decompress_nscodec(clear->nsc, width, height, s, bitmapDataByteCount,
-				                              pDstData, DstFormat, nDstStep, nXDstRel, nYDstRel,
-				                              nDstWidth, nDstHeight))
+				if (!clear_decompress_nscodec(clear->log, clear->nsc, width, height, s,
+				                              bitmapDataByteCount, pDstData, DstFormat, nDstStep,
+				                              nXDstRel, nYDstRel, nDstWidth, nDstHeight))
 					return FALSE;
 
 				break;
 
 			case 2: /* CLEARCODEC_SUBCODEC_RLEX */
-				if (!clear_decompress_subcode_rlex(s, bitmapDataByteCount, width, height, pDstData,
-				                                   DstFormat, nDstStep, nXDstRel, nYDstRel,
-				                                   nDstWidth, nDstHeight))
+				if (!clear_decompress_subcode_rlex(clear->log, s, bitmapDataByteCount, width,
+				                                   height, pDstData, DstFormat, nDstStep, nXDstRel,
+				                                   nYDstRel, nDstWidth, nDstHeight))
 					return FALSE;
 
 				break;
 
 			default:
-				WLog_ERR(TAG, "Unknown subcodec ID %" PRIu8 "", subcodecId);
+				WLog_Print(clear->log, WLOG_ERROR, "Unknown subcodec ID %" PRIu8 "", subcodecId);
 				return FALSE;
 		}
 
@@ -572,8 +582,9 @@ static BOOL resize_vbar_entry(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 		if (!tmp)
 		{
-			WLog_ERR(TAG, "vBarEntry->pixels winpr_aligned_recalloc %" PRIu32 " failed",
-			         vBarEntry->count * bpp);
+			WLog_Print(clear->log, WLOG_ERROR,
+			           "vBarEntry->pixels winpr_aligned_recalloc %" PRIu32 " failed",
+			           vBarEntry->count * bpp);
 			return FALSE;
 		}
 
@@ -584,8 +595,9 @@ static BOOL resize_vbar_entry(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 	if (!vBarEntry->pixels && vBarEntry->size)
 	{
-		WLog_ERR(TAG, "vBarEntry->pixels is nullptr but vBarEntry->size is %" PRIu32 "",
-		         vBarEntry->size);
+		WLog_Print(clear->log, WLOG_ERROR,
+		           "vBarEntry->pixels is nullptr but vBarEntry->size is %" PRIu32 "",
+		           vBarEntry->size);
 		return FALSE;
 	}
 
@@ -601,7 +613,7 @@ static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 {
 	UINT32 suboffset = 0;
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, bandsByteCount))
+	if (!Stream_CheckAndLogRequiredLengthWLog(clear->log, s, bandsByteCount))
 		return FALSE;
 
 	while (suboffset < bandsByteCount)
@@ -621,7 +633,7 @@ static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 		UINT32 vBarPixelCount = 0;
 		UINT32 vBarShortPixelCount = 0;
 
-		if (!Stream_CheckAndLogRequiredLength(TAG, s, 11))
+		if (!Stream_CheckAndLogRequiredLengthWLog(clear->log, s, 11))
 			return FALSE;
 
 		Stream_Read_UINT16(s, xStart);
@@ -636,13 +648,15 @@ static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 		if (xEnd < xStart)
 		{
-			WLog_ERR(TAG, "xEnd %" PRIu16 " < xStart %" PRIu16 "", xEnd, xStart);
+			WLog_Print(clear->log, WLOG_ERROR, "xEnd %" PRIu16 " < xStart %" PRIu16 "", xEnd,
+			           xStart);
 			return FALSE;
 		}
 
 		if (yEnd < yStart)
 		{
-			WLog_ERR(TAG, "yEnd %" PRIu16 " < yStart %" PRIu16 "", yEnd, yStart);
+			WLog_Print(clear->log, WLOG_ERROR, "yEnd %" PRIu16 " < yStart %" PRIu16 "", yEnd,
+			           yStart);
 			return FALSE;
 		}
 
@@ -656,7 +670,7 @@ static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 			BOOL vBarUpdate = FALSE;
 			const BYTE* cpSrcPixel = nullptr;
 
-			if (!Stream_CheckAndLogRequiredLength(TAG, s, 2))
+			if (!Stream_CheckAndLogRequiredLengthWLog(clear->log, s, 2))
 				return FALSE;
 
 			Stream_Read_UINT16(s, vBarHeader);
@@ -665,7 +679,7 @@ static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 			if (vBarHeight > 52)
 			{
-				WLog_ERR(TAG, "vBarHeight (%" PRIu32 ") > 52", vBarHeight);
+				WLog_Print(clear->log, WLOG_ERROR, "vBarHeight (%" PRIu32 ") > 52", vBarHeight);
 				return FALSE;
 			}
 
@@ -676,11 +690,12 @@ static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 				if (!vBarShortEntry)
 				{
-					WLog_ERR(TAG, "missing vBarShortEntry %" PRIu16 "", vBarIndex);
+					WLog_Print(clear->log, WLOG_ERROR, "missing vBarShortEntry %" PRIu16 "",
+					           vBarIndex);
 					return FALSE;
 				}
 
-				if (!Stream_CheckAndLogRequiredLength(TAG, s, 1))
+				if (!Stream_CheckAndLogRequiredLengthWLog(clear->log, s, 1))
 					return FALSE;
 
 				Stream_Read_UINT8(s, vBarYOn);
@@ -695,7 +710,8 @@ static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 				if (vBarYOff < vBarYOn)
 				{
-					WLog_ERR(TAG, "vBarYOff %" PRIu16 " < vBarYOn %" PRIu16 "", vBarYOff, vBarYOn);
+					WLog_Print(clear->log, WLOG_ERROR, "vBarYOff %" PRIu16 " < vBarYOn %" PRIu16 "",
+					           vBarYOff, vBarYOn);
 					return FALSE;
 				}
 
@@ -703,19 +719,21 @@ static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 				if (vBarShortPixelCount > 52)
 				{
-					WLog_ERR(TAG, "vBarShortPixelCount %" PRIu32 " > 52", vBarShortPixelCount);
+					WLog_Print(clear->log, WLOG_ERROR, "vBarShortPixelCount %" PRIu32 " > 52",
+					           vBarShortPixelCount);
 					return FALSE;
 				}
 
-				if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, s, vBarShortPixelCount, 3ull))
+				if (!Stream_CheckAndLogRequiredLengthOfSizeWLog(clear->log, s, vBarShortPixelCount,
+				                                                3ull))
 					return FALSE;
 
 				if (clear->ShortVBarStorageCursor >= CLEARCODEC_VBAR_SHORT_SIZE)
 				{
-					WLog_ERR(TAG,
-					         "clear->ShortVBarStorageCursor %" PRIu32
-					         " >= CLEARCODEC_VBAR_SHORT_SIZE (%" PRId32 ")",
-					         clear->ShortVBarStorageCursor, CLEARCODEC_VBAR_SHORT_SIZE);
+					WLog_Print(clear->log, WLOG_ERROR,
+					           "clear->ShortVBarStorageCursor %" PRIu32
+					           " >= CLEARCODEC_VBAR_SHORT_SIZE (%" PRId32 ")",
+					           clear->ShortVBarStorageCursor, CLEARCODEC_VBAR_SHORT_SIZE);
 					return FALSE;
 				}
 
@@ -755,7 +773,8 @@ static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 				/* If the cache was reset we need to fill in some dummy data. */
 				if (vBarEntry->size == 0)
 				{
-					WLog_WARN(TAG, "Empty cache index %" PRIu16 ", filling dummy data", vBarIndex);
+					WLog_Print(clear->log, WLOG_WARN,
+					           "Empty cache index %" PRIu16 ", filling dummy data", vBarIndex);
 					vBarEntry->count = vBarHeight;
 
 					if (!resize_vbar_entry(clear, vBarEntry))
@@ -764,7 +783,8 @@ static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 			}
 			else
 			{
-				WLog_ERR(TAG, "invalid vBarHeader 0x%04" PRIX16 "", vBarHeader);
+				WLog_Print(clear->log, WLOG_ERROR, "invalid vBarHeader 0x%04" PRIX16 "",
+				           vBarHeader);
 				return FALSE; /* invalid vBarHeader */
 			}
 
@@ -775,10 +795,10 @@ static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 				if (clear->VBarStorageCursor >= CLEARCODEC_VBAR_SIZE)
 				{
-					WLog_ERR(TAG,
-					         "clear->VBarStorageCursor %" PRIu32 " >= CLEARCODEC_VBAR_SIZE %" PRId32
-					         "",
-					         clear->VBarStorageCursor, CLEARCODEC_VBAR_SIZE);
+					WLog_Print(clear->log, WLOG_ERROR,
+					           "clear->VBarStorageCursor %" PRIu32
+					           " >= CLEARCODEC_VBAR_SIZE %" PRId32 "",
+					           clear->VBarStorageCursor, CLEARCODEC_VBAR_SIZE);
 					return FALSE;
 				}
 
@@ -823,7 +843,8 @@ static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 					pSrcPixel = &vBarShortEntry->pixels[offset];
 					if (offset + count > vBarShortEntry->count)
 					{
-						WLog_ERR(TAG, "offset + count > vBarShortEntry->count");
+						WLog_Print(clear->log, WLOG_ERROR,
+						           "offset + count > vBarShortEntry->count");
 						return FALSE;
 					}
 				}
@@ -860,8 +881,9 @@ static BOOL clear_decompress_bands_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 			if (vBarEntry->count != vBarHeight)
 			{
-				WLog_ERR(TAG, "vBarEntry->count %" PRIu32 " != vBarHeight %" PRIu32 "",
-				         vBarEntry->count, vBarHeight);
+				WLog_Print(clear->log, WLOG_ERROR,
+				           "vBarEntry->count %" PRIu32 " != vBarHeight %" PRIu32 "",
+				           vBarEntry->count, vBarHeight);
 				vBarEntry->count = vBarHeight;
 
 				if (!resize_vbar_entry(clear, vBarEntry))
@@ -920,7 +942,7 @@ static BOOL clear_decompress_glyph_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 	if ((glyphFlags & CLEARCODEC_FLAG_GLYPH_HIT) && !(glyphFlags & CLEARCODEC_FLAG_GLYPH_INDEX))
 	{
-		WLog_ERR(TAG, "Invalid glyph flags %08" PRIX32 "", glyphFlags);
+		WLog_Print(clear->log, WLOG_ERROR, "Invalid glyph flags %08" PRIX32 "", glyphFlags);
 		return FALSE;
 	}
 
@@ -929,18 +951,19 @@ static BOOL clear_decompress_glyph_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 	if ((nWidth * nHeight) > (1024 * 1024))
 	{
-		WLog_ERR(TAG, "glyph too large: %" PRIu32 "x%" PRIu32 "", nWidth, nHeight);
+		WLog_Print(clear->log, WLOG_ERROR, "glyph too large: %" PRIu32 "x%" PRIu32 "", nWidth,
+		           nHeight);
 		return FALSE;
 	}
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 2))
+	if (!Stream_CheckAndLogRequiredLengthWLog(clear->log, s, 2))
 		return FALSE;
 
 	Stream_Read_UINT16(s, glyphIndex);
 
 	if (glyphIndex >= 4000)
 	{
-		WLog_ERR(TAG, "Invalid glyphIndex %" PRIu16 "", glyphIndex);
+		WLog_Print(clear->log, WLOG_ERROR, "Invalid glyphIndex %" PRIu16 "", glyphIndex);
 		return FALSE;
 	}
 
@@ -952,7 +975,8 @@ static BOOL clear_decompress_glyph_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 		if (!glyphEntry)
 		{
-			WLog_ERR(TAG, "clear->GlyphCache[%" PRIu16 "]=nullptr", glyphIndex);
+			WLog_Print(clear->log, WLOG_ERROR, "clear->GlyphCache[%" PRIu16 "]=nullptr",
+			           glyphIndex);
 			return FALSE;
 		}
 
@@ -960,15 +984,16 @@ static BOOL clear_decompress_glyph_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 		if (!glyphData)
 		{
-			WLog_ERR(TAG, "clear->GlyphCache[%" PRIu16 "]->pixels=nullptr", glyphIndex);
+			WLog_Print(clear->log, WLOG_ERROR, "clear->GlyphCache[%" PRIu16 "]->pixels=nullptr",
+			           glyphIndex);
 			return FALSE;
 		}
 
 		if ((nWidth * nHeight) > glyphEntry->count)
 		{
-			WLog_ERR(TAG,
-			         "(nWidth %" PRIu32 " * nHeight %" PRIu32 ") > glyphEntry->count %" PRIu32 "",
-			         nWidth, nHeight, glyphEntry->count);
+			WLog_Print(clear->log, WLOG_ERROR,
+			           "(nWidth %" PRIu32 " * nHeight %" PRIu32 ") > glyphEntry->count %" PRIu32 "",
+			           nWidth, nHeight, glyphEntry->count);
 			return FALSE;
 		}
 
@@ -986,10 +1011,10 @@ static BOOL clear_decompress_glyph_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 		if ((nWidth == 0) || (nHeight == 0) || (hlimit < nHeight))
 		{
 			const char* exceeded = (hlimit < nHeight) ? "within" : "outside";
-			WLog_ERR(TAG,
-			         "CLEARCODEC_FLAG_GLYPH_INDEX: nWidth=%" PRIu32 ", nHeight=%" PRIu32
-			         ", nWidth * nHeight is %s allowed range",
-			         nWidth, nHeight, exceeded);
+			WLog_Print(clear->log, WLOG_ERROR,
+			           "CLEARCODEC_FLAG_GLYPH_INDEX: nWidth=%" PRIu32 ", nHeight=%" PRIu32
+			           ", nWidth * nHeight is %s allowed range",
+			           nWidth, nHeight, exceeded);
 			return FALSE;
 		}
 
@@ -999,8 +1024,9 @@ static BOOL clear_decompress_glyph_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 			if (!tmp)
 			{
-				WLog_ERR(TAG, "glyphEntry->pixels winpr_aligned_recalloc %" PRIuz " failed!",
-				         count * bpp);
+				WLog_Print(clear->log, WLOG_ERROR,
+				           "glyphEntry->pixels winpr_aligned_recalloc %" PRIuz " failed!",
+				           count * bpp);
 				return FALSE;
 			}
 
@@ -1011,7 +1037,7 @@ static BOOL clear_decompress_glyph_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 		if (!glyphEntry->pixels)
 		{
-			WLog_ERR(TAG, "glyphEntry->pixels=nullptr");
+			WLog_Print(clear->log, WLOG_ERROR, "glyphEntry->pixels=nullptr");
 			return FALSE;
 		}
 
@@ -1060,13 +1086,15 @@ INT32 clear_decompress(CLEAR_CONTEXT* WINPR_RESTRICT clear, const BYTE* WINPR_RE
 
 	if (nXDst > nDstWidth)
 	{
-		WLog_WARN(TAG, "nXDst %" PRIu32 " > nDstWidth %" PRIu32, nXDst, nDstWidth);
+		WLog_Print(clear->log, WLOG_WARN, "nXDst %" PRIu32 " > nDstWidth %" PRIu32, nXDst,
+		           nDstWidth);
 		return -1005;
 	}
 
 	if (nYDst > nDstHeight)
 	{
-		WLog_WARN(TAG, "nYDst %" PRIu32 " > nDstHeight %" PRIu32, nYDst, nDstHeight);
+		WLog_Print(clear->log, WLOG_WARN, "nYDst %" PRIu32 " > nDstHeight %" PRIu32, nYDst,
+		           nDstHeight);
 		return -1006;
 	}
 
@@ -1075,7 +1103,7 @@ INT32 clear_decompress(CLEAR_CONTEXT* WINPR_RESTRICT clear, const BYTE* WINPR_RE
 	if (!s)
 		return -2005;
 
-	if (!Stream_CheckAndLogRequiredLength(TAG, s, 2))
+	if (!Stream_CheckAndLogRequiredLengthWLog(clear->log, s, 2))
 		goto fail;
 
 	if (!updateContextFormat(clear, DstFormat))
@@ -1089,10 +1117,10 @@ INT32 clear_decompress(CLEAR_CONTEXT* WINPR_RESTRICT clear, const BYTE* WINPR_RE
 
 	if (seqNumber != clear->seqNumber)
 	{
-		WLog_ERR(TAG, "Sequence number unexpected %" PRIu8 " - %" PRIu32 "", seqNumber,
-		         clear->seqNumber);
-		WLog_ERR(TAG, "seqNumber %" PRIu8 " != clear->seqNumber %" PRIu32 "", seqNumber,
-		         clear->seqNumber);
+		WLog_Print(clear->log, WLOG_ERROR, "Sequence number unexpected %" PRIu8 " - %" PRIu32 "",
+		           seqNumber, clear->seqNumber);
+		WLog_Print(clear->log, WLOG_ERROR, "seqNumber %" PRIu8 " != clear->seqNumber %" PRIu32 "",
+		           seqNumber, clear->seqNumber);
 		goto fail;
 	}
 
@@ -1107,7 +1135,7 @@ INT32 clear_decompress(CLEAR_CONTEXT* WINPR_RESTRICT clear, const BYTE* WINPR_RE
 	                                 nDstStep, nXDst, nYDst, nDstWidth, nDstHeight, palette,
 	                                 &glyphData))
 	{
-		WLog_ERR(TAG, "clear_decompress_glyph_data failed!");
+		WLog_Print(clear->log, WLOG_ERROR, "clear_decompress_glyph_data failed!");
 		goto fail;
 	}
 
@@ -1119,10 +1147,10 @@ INT32 clear_decompress(CLEAR_CONTEXT* WINPR_RESTRICT clear, const BYTE* WINPR_RE
 		if ((glyphFlags & mask) == mask)
 			goto finish;
 
-		WLog_ERR(TAG,
-		         "invalid glyphFlags, missing flags: 0x%02" PRIx8 " & 0x%02" PRIx32
-		         " == 0x%02" PRIx32,
-		         glyphFlags, mask, glyphFlags & mask);
+		WLog_Print(clear->log, WLOG_ERROR,
+		           "invalid glyphFlags, missing flags: 0x%02" PRIx8 " & 0x%02" PRIx32
+		           " == 0x%02" PRIx32,
+		           glyphFlags, mask, glyphFlags & mask);
 		goto fail;
 	}
 
@@ -1136,7 +1164,7 @@ INT32 clear_decompress(CLEAR_CONTEXT* WINPR_RESTRICT clear, const BYTE* WINPR_RE
 		                                    DstFormat, nDstStep, nXDst, nYDst, nDstWidth,
 		                                    nDstHeight, palette))
 		{
-			WLog_ERR(TAG, "clear_decompress_residual_data failed!");
+			WLog_Print(clear->log, WLOG_ERROR, "clear_decompress_residual_data failed!");
 			goto fail;
 		}
 	}
@@ -1146,7 +1174,7 @@ INT32 clear_decompress(CLEAR_CONTEXT* WINPR_RESTRICT clear, const BYTE* WINPR_RE
 		if (!clear_decompress_bands_data(clear, s, bandsByteCount, nWidth, nHeight, pDstData,
 		                                 DstFormat, nDstStep, nXDst, nYDst, nDstWidth, nDstHeight))
 		{
-			WLog_ERR(TAG, "clear_decompress_bands_data failed!");
+			WLog_Print(clear->log, WLOG_ERROR, "clear_decompress_bands_data failed!");
 			goto fail;
 		}
 	}
@@ -1157,7 +1185,7 @@ INT32 clear_decompress(CLEAR_CONTEXT* WINPR_RESTRICT clear, const BYTE* WINPR_RE
 		                                     DstFormat, nDstStep, nXDst, nYDst, nDstWidth,
 		                                     nDstHeight, palette))
 		{
-			WLog_ERR(TAG, "clear_decompress_subcodecs_data failed!");
+			WLog_Print(clear->log, WLOG_ERROR, "clear_decompress_subcodecs_data failed!");
 			goto fail;
 		}
 	}
@@ -1167,49 +1195,51 @@ INT32 clear_decompress(CLEAR_CONTEXT* WINPR_RESTRICT clear, const BYTE* WINPR_RE
 		uint32_t w = MIN(nWidth, nDstWidth);
 		if (nXDst > nDstWidth)
 		{
-			WLog_WARN(TAG, "glyphData copy area x exceeds destination: x=%" PRIu32 " > %" PRIu32,
-			          nXDst, nDstWidth);
+			WLog_Print(clear->log, WLOG_WARN,
+			           "glyphData copy area x exceeds destination: x=%" PRIu32 " > %" PRIu32, nXDst,
+			           nDstWidth);
 			w = 0;
 		}
 		else if (nXDst + w > nDstWidth)
 		{
-			WLog_WARN(TAG,
-			          "glyphData copy area x + width exceeds destination: x=%" PRIu32 " + %" PRIu32
-			          " > %" PRIu32,
-			          nXDst, w, nDstWidth);
+			WLog_Print(clear->log, WLOG_WARN,
+			           "glyphData copy area x + width exceeds destination: x=%" PRIu32 " + %" PRIu32
+			           " > %" PRIu32,
+			           nXDst, w, nDstWidth);
 			w = nDstWidth - nXDst;
 		}
 
 		if (w != nWidth)
 		{
-			WLog_WARN(TAG,
-			          "glyphData copy area width truncated: requested=%" PRIu32
-			          ", truncated to %" PRIu32,
-			          nWidth, w);
+			WLog_Print(clear->log, WLOG_WARN,
+			           "glyphData copy area width truncated: requested=%" PRIu32
+			           ", truncated to %" PRIu32,
+			           nWidth, w);
 		}
 
 		uint32_t h = MIN(nHeight, nDstHeight);
 		if (nYDst > nDstHeight)
 		{
-			WLog_WARN(TAG, "glyphData copy area y exceeds destination: y=%" PRIu32 " > %" PRIu32,
-			          nYDst, nDstHeight);
+			WLog_Print(clear->log, WLOG_WARN,
+			           "glyphData copy area y exceeds destination: y=%" PRIu32 " > %" PRIu32, nYDst,
+			           nDstHeight);
 			h = 0;
 		}
 		else if (nYDst + h > nDstHeight)
 		{
-			WLog_WARN(TAG,
-			          "glyphData copy area y + height exceeds destination: x=%" PRIu32 " + %" PRIu32
-			          " > %" PRIu32,
-			          nYDst, h, nDstHeight);
+			WLog_Print(clear->log, WLOG_WARN,
+			           "glyphData copy area y + height exceeds destination: x=%" PRIu32
+			           " + %" PRIu32 " > %" PRIu32,
+			           nYDst, h, nDstHeight);
 			h = nDstHeight - nYDst;
 		}
 
 		if (h != nHeight)
 		{
-			WLog_WARN(TAG,
-			          "glyphData copy area height truncated: requested=%" PRIu32
-			          ", truncated to %" PRIu32,
-			          nHeight, h);
+			WLog_Print(clear->log, WLOG_WARN,
+			           "glyphData copy area height truncated: requested=%" PRIu32
+			           ", truncated to %" PRIu32,
+			           nHeight, h);
 		}
 
 		if (!freerdp_image_copy_no_overlap(glyphData, clear->format, 0, 0, 0, w, h, pDstData,
@@ -1230,7 +1260,7 @@ int clear_compress(WINPR_ATTR_UNUSED CLEAR_CONTEXT* WINPR_RESTRICT clear,
                    WINPR_ATTR_UNUSED BYTE** WINPR_RESTRICT ppDstData,
                    WINPR_ATTR_UNUSED UINT32* WINPR_RESTRICT pDstSize)
 {
-	WLog_ERR(TAG, "TODO: not implemented!");
+	WLog_Print(clear->log, WLOG_ERROR, "TODO: not implemented!");
 	return 1;
 }
 
@@ -1253,7 +1283,7 @@ CLEAR_CONTEXT* clear_context_new(BOOL Compressor)
 
 	if (!clear)
 		return nullptr;
-
+	clear->log = WLog_Get(TAG);
 	clear->Compressor = Compressor;
 	clear->nsc = nsc_context_new();
 

--- a/libfreerdp/codec/clear.c
+++ b/libfreerdp/codec/clear.c
@@ -567,7 +567,6 @@ static BOOL resize_vbar_entry(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 		const UINT32 oldPos = vBarEntry->size * bpp;
 		const UINT32 diffSize = (vBarEntry->count - vBarEntry->size) * bpp;
 
-		vBarEntry->size = vBarEntry->count;
 		BYTE* tmp =
 		    (BYTE*)winpr_aligned_recalloc(vBarEntry->pixels, vBarEntry->count, 1ull * bpp, 32);
 
@@ -580,6 +579,7 @@ static BOOL resize_vbar_entry(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 		memset(&tmp[oldPos], 0, diffSize);
 		vBarEntry->pixels = tmp;
+		vBarEntry->size = vBarEntry->count;
 	}
 
 	if (!vBarEntry->pixels && vBarEntry->size)

--- a/libfreerdp/codec/clear.c
+++ b/libfreerdp/codec/clear.c
@@ -981,20 +981,30 @@ static BOOL clear_decompress_glyph_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 	{
 		const UINT32 bpp = FreeRDPGetBytesPerPixel(clear->format);
 		CLEAR_GLYPH_ENTRY* glyphEntry = &(clear->GlyphCache[glyphIndex]);
-		glyphEntry->count = nWidth * nHeight;
-
-		if (glyphEntry->count > glyphEntry->size)
+		const size_t count = 1ull * nWidth * nHeight;
+		const size_t hlimit = SIZE_MAX / ((nWidth > 0) ? nWidth : 1);
+		if ((nWidth == 0) || (nHeight == 0) || (hlimit < nHeight))
 		{
-			BYTE* tmp =
-			    winpr_aligned_recalloc(glyphEntry->pixels, glyphEntry->count, 1ull * bpp, 32);
+			const char* exceeded = (hlimit < nHeight) ? "within" : "outside";
+			WLog_ERR(TAG,
+			         "CLEARCODEC_FLAG_GLYPH_INDEX: nWidth=%" PRIu32 ", nHeight=%" PRIu32
+			         ", nWidth * nHeight is %s allowed range",
+			         nWidth, nHeight, exceeded);
+			return FALSE;
+		}
+
+		if (count > glyphEntry->size)
+		{
+			BYTE* tmp = winpr_aligned_recalloc(glyphEntry->pixels, count, 1ull * bpp, 32);
 
 			if (!tmp)
 			{
-				WLog_ERR(TAG, "glyphEntry->pixels winpr_aligned_recalloc %" PRIu32 " failed!",
-				         glyphEntry->count * bpp);
+				WLog_ERR(TAG, "glyphEntry->pixels winpr_aligned_recalloc %" PRIuz " failed!",
+				         count * bpp);
 				return FALSE;
 			}
 
+			glyphEntry->count = WINPR_ASSERTING_INT_CAST(UINT32, count);
 			glyphEntry->size = glyphEntry->count;
 			glyphEntry->pixels = (UINT32*)tmp;
 		}

--- a/libfreerdp/codec/dsp.c
+++ b/libfreerdp/codec/dsp.c
@@ -320,6 +320,17 @@ static const INT16 ima_step_size_table[] = {
 	12635, 13899, 15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767
 };
 
+static inline void dsp_ima_clamp_step(ADPCM* WINPR_RESTRICT adpcm, unsigned int channel)
+{
+	WINPR_ASSERT(adpcm);
+	if (adpcm->ima.last_step[channel] < 0)
+		adpcm->ima.last_step[channel] = 0;
+
+	const size_t size = ARRAYSIZE(ima_step_size_table);
+	if (adpcm->ima.last_step[channel] > size)
+		adpcm->ima.last_step[channel] = size;
+}
+
 static UINT16 dsp_decode_ima_adpcm_sample(ADPCM* WINPR_RESTRICT adpcm, unsigned int channel,
                                           BYTE sample)
 {
@@ -357,10 +368,7 @@ static UINT16 dsp_decode_ima_adpcm_sample(ADPCM* WINPR_RESTRICT adpcm, unsigned 
 	WINPR_ASSERT(sample < ARRAYSIZE(ima_step_index_table));
 	adpcm->ima.last_step[channel] = adpcm->ima.last_step[channel] + ima_step_index_table[sample];
 
-	if (adpcm->ima.last_step[channel] < 0)
-		adpcm->ima.last_step[channel] = 0;
-	else if (adpcm->ima.last_step[channel] > 88)
-		adpcm->ima.last_step[channel] = 88;
+	dsp_ima_clamp_step(adpcm, channel);
 
 	return (UINT16)d;
 }
@@ -403,6 +411,9 @@ static BOOL freerdp_dsp_decode_ima_adpcm(FREERDP_DSP_CONTEXT* WINPR_RESTRICT con
 			context->adpcm.ima.last_sample[0] =
 			    (INT16)(((UINT16)(*src)) | (((UINT16)(*(src + 1))) << 8));
 			context->adpcm.ima.last_step[0] = (INT16)(*(src + 2));
+
+			dsp_ima_clamp_step(&context->adpcm, 0);
+
 			src += 4;
 			size -= 4;
 			out_size -= 16;
@@ -414,6 +425,8 @@ static BOOL freerdp_dsp_decode_ima_adpcm(FREERDP_DSP_CONTEXT* WINPR_RESTRICT con
 				context->adpcm.ima.last_sample[1] =
 				    (INT16)(((UINT16)(*src)) | (((UINT16)(*(src + 1))) << 8));
 				context->adpcm.ima.last_step[1] = (INT16)(*(src + 2));
+
+				dsp_ima_clamp_step(&context->adpcm, 1);
 				src += 4;
 				size -= 4;
 				out_size -= 16;
@@ -854,10 +867,7 @@ static BYTE dsp_encode_ima_adpcm_sample(ADPCM* WINPR_RESTRICT adpcm, size_t chan
 	WINPR_ASSERT(enc < ARRAYSIZE(ima_step_index_table));
 	adpcm->ima.last_step[channel] = adpcm->ima.last_step[channel] + ima_step_index_table[enc];
 
-	if (adpcm->ima.last_step[channel] < 0)
-		adpcm->ima.last_step[channel] = 0;
-	else if (adpcm->ima.last_step[channel] > 88)
-		adpcm->ima.last_step[channel] = 88;
+	dsp_ima_clamp_step(adpcm, channel);
 
 	return enc;
 }

--- a/libfreerdp/codec/h264.c
+++ b/libfreerdp/codec/h264.c
@@ -83,9 +83,6 @@ static BOOL yuv_ensure_buffer(H264_CONTEXT* h264, UINT32 stride, UINT32 width, U
 			h264->iStride[2] = (stride + 1) / 2;
 		}
 
-		h264->width = width;
-		h264->height = height;
-
 		for (size_t x = 0; x < nPlanes; x++)
 		{
 			BYTE* tmp1 = winpr_aligned_recalloc(h264->pYUVData[x], h264->iStride[x], pheight, 16);
@@ -98,6 +95,8 @@ static BOOL yuv_ensure_buffer(H264_CONTEXT* h264, UINT32 stride, UINT32 width, U
 			if (!tmp1 || !tmp2)
 				return FALSE;
 		}
+		h264->width = width;
+		h264->height = height;
 	}
 
 	return TRUE;

--- a/libfreerdp/codec/h264_openh264.c
+++ b/libfreerdp/codec/h264_openh264.c
@@ -565,6 +565,18 @@ static BOOL openh264_init(H264_CONTEXT* h264)
 
 		if (h264->Compressor)
 		{
+#if defined(WITH_OPENH264_LOADING)
+			if (sysContexts->version.uMajor != OPENH264_MAJOR ||
+			    sysContexts->version.uMinor != OPENH264_MINOR)
+			{
+				WLog_Print(h264->log, WLOG_WARN,
+				           "OpenH264 encoder ABI mismatch: runtime %d.%d.%d vs compiled %d.%d.%d",
+				           sysContexts->version.uMajor, sysContexts->version.uMinor,
+				           sysContexts->version.uRevision, OPENH264_MAJOR, OPENH264_MINOR,
+				           OPENH264_REVISION);
+				goto EXCEPTION;
+			}
+#endif
 			const int rc = sysContexts->WelsCreateSVCEncoder(&sys->pEncoder);
 			if (rc != 0)
 			{

--- a/libfreerdp/codec/neon/rfx_neon.c
+++ b/libfreerdp/codec/neon/rfx_neon.c
@@ -22,6 +22,7 @@
 #include <freerdp/log.h>
 
 #include "../rfx_types.h"
+#include "../rfx_quantization.h"
 #include "rfx_neon.h"
 
 #include "../../core/simd.h"
@@ -52,10 +53,20 @@ rfx_quantization_decode_block_NEON(INT16* buffer, const size_t buffer_size, cons
 	} while (buf < buf_end);
 }
 
-static void rfx_quantization_decode_NEON(INT16* buffer, const UINT32* WINPR_RESTRICT quantVals)
+WINPR_ATTR_NODISCARD
+static BOOL rfx_quantization_decode_NEON(INT16* buffer, const UINT32* WINPR_RESTRICT quantVals,
+                                         size_t nrQuantVals)
 {
 	WINPR_ASSERT(buffer);
 	WINPR_ASSERT(quantVals);
+	WINPR_ASSERT(nrQuantVals == NR_QUANT_VALUES);
+
+	for (size_t x = 0; x < nrQuantVals; x++)
+	{
+		const UINT32 val = quantVals[x];
+		if (val < 1)
+			return FALSE;
+	}
 
 	rfx_quantization_decode_block_NEON(&buffer[0], 1024, quantVals[8] - 1);    /* HL1 */
 	rfx_quantization_decode_block_NEON(&buffer[1024], 1024, quantVals[7] - 1); /* LH1 */
@@ -67,6 +78,7 @@ static void rfx_quantization_decode_NEON(INT16* buffer, const UINT32* WINPR_REST
 	rfx_quantization_decode_block_NEON(&buffer[3904], 64, quantVals[1] - 1);   /* LH3 */
 	rfx_quantization_decode_block_NEON(&buffer[3968], 64, quantVals[3] - 1);   /* HH3 */
 	rfx_quantization_decode_block_NEON(&buffer[4032], 64, quantVals[0] - 1);   /* LL3 */
+	return TRUE;
 }
 
 static inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -94,18 +94,49 @@ static inline void progressive_rfx_quant_add(const RFX_COMPONENT_CODEC_QUANT* WI
 	dst->LL3 = q1->LL3 + q2->LL3; /* LL3 */
 }
 
-static inline void progressive_rfx_quant_lsub(RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q, int val)
+WINPR_ATTR_NODISCARD
+static inline BOOL progressive_rfx_quant_lsub(RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q, int val)
 {
+	if (q->HL1 < val)
+		return FALSE;
 	q->HL1 -= val; /* HL1 */
+
+	if (q->LH1 < val)
+		return FALSE;
 	q->LH1 -= val; /* LH1 */
+
+	if (q->HH1 < val)
+		return FALSE;
 	q->HH1 -= val; /* HH1 */
+
+	if (q->HL2 < val)
+		return FALSE;
 	q->HL2 -= val; /* HL2 */
+
+	if (q->LH2 < val)
+		return FALSE;
 	q->LH2 -= val; /* LH2 */
+
+	if (q->HH2 < val)
+		return FALSE;
 	q->HH2 -= val; /* HH2 */
+
+	if (q->HL3 < val)
+		return FALSE;
 	q->HL3 -= val; /* HL3 */
+
+	if (q->LH3 < val)
+		return FALSE;
 	q->LH3 -= val; /* LH3 */
+
+	if (q->HH3 < val)
+		return FALSE;
 	q->HH3 -= val; /* HH3 */
+
+	if (q->LL3 < val)
+		return FALSE;
 	q->LL3 -= val; /* LL3 */
+	return TRUE;
 }
 
 WINPR_ATTR_NODISCARD
@@ -994,11 +1025,14 @@ progressive_decompress_tile_first(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressiv
 	progressive_rfx_quant_add(quantCb, quantProgCb, &(tile->cbBitPos));
 	progressive_rfx_quant_add(quantCr, quantProgCr, &(tile->crBitPos));
 	progressive_rfx_quant_add(quantY, quantProgY, &shiftY);
-	progressive_rfx_quant_lsub(&shiftY, 1); /* -6 + 5 = -1 */
+	if (!progressive_rfx_quant_lsub(&shiftY, 1)) /* -6 + 5 = -1 */
+		goto fail;
 	progressive_rfx_quant_add(quantCb, quantProgCb, &shiftCb);
-	progressive_rfx_quant_lsub(&shiftCb, 1); /* -6 + 5 = -1 */
+	if (!progressive_rfx_quant_lsub(&shiftCb, 1)) /* -6 + 5 = -1 */
+		goto fail;
 	progressive_rfx_quant_add(quantCr, quantProgCr, &shiftCr);
-	progressive_rfx_quant_lsub(&shiftCr, 1); /* -6 + 5 = -1 */
+	if (!progressive_rfx_quant_lsub(&shiftCr, 1)) /* -6 + 5 = -1 */
+		goto fail;
 
 	pSign[0] = (INT16*)((&tile->sign[((8192 + 32) * 0) + 16])); /* Y/R buffer */
 	pSign[1] = (INT16*)((&tile->sign[((8192 + 32) * 1) + 16])); /* Cb/G buffer */
@@ -1437,11 +1471,14 @@ progressive_decompress_tile_upgrade(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progress
 	if (!progressive_rfx_quant_sub(&(tile->crBitPos), &crBitPos, &crNumBits))
 		goto fail;
 	progressive_rfx_quant_add(quantY, quantProgY, &shiftY);
-	progressive_rfx_quant_lsub(&shiftY, 1); /* -6 + 5 = -1 */
+	if (!progressive_rfx_quant_lsub(&shiftY, 1)) /* -6 + 5 = -1 */
+		goto fail;
 	progressive_rfx_quant_add(quantCb, quantProgCb, &shiftCb);
-	progressive_rfx_quant_lsub(&shiftCb, 1); /* -6 + 5 = -1 */
+	if (!progressive_rfx_quant_lsub(&shiftCb, 1)) /* -6 + 5 = -1 */
+		goto fail;
 	progressive_rfx_quant_add(quantCr, quantProgCr, &shiftCr);
-	progressive_rfx_quant_lsub(&shiftCr, 1); /* -6 + 5 = -1 */
+	if (!progressive_rfx_quant_lsub(&shiftCr, 1)) /* -6 + 5 = -1 */
+		goto fail;
 
 	tile->yBitPos = yBitPos;
 	tile->cbBitPos = cbBitPos;

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -108,20 +108,52 @@ static inline void progressive_rfx_quant_lsub(RFX_COMPONENT_CODEC_QUANT* WINPR_R
 	q->LL3 -= val; /* LL3 */
 }
 
-static inline void progressive_rfx_quant_sub(const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q1,
+WINPR_ATTR_NODISCARD
+static inline BOOL progressive_rfx_quant_sub(const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q1,
                                              const RFX_COMPONENT_CODEC_QUANT* WINPR_RESTRICT q2,
                                              RFX_COMPONENT_CODEC_QUANT* dst)
 {
+	if (q1->HH1 < q2->HL1)
+		return FALSE;
 	dst->HL1 = q1->HL1 - q2->HL1; /* HL1 */
+
+	if (q1->LH1 < q2->LH1)
+		return FALSE;
 	dst->LH1 = q1->LH1 - q2->LH1; /* LH1 */
+
+	if (q1->HH1 < q2->HH1)
+		return FALSE;
 	dst->HH1 = q1->HH1 - q2->HH1; /* HH1 */
+
+	if (q1->HL2 < q2->HL2)
+		return FALSE;
 	dst->HL2 = q1->HL2 - q2->HL2; /* HL2 */
+
+	if (q1->LH2 < q2->LH2)
+		return FALSE;
 	dst->LH2 = q1->LH2 - q2->LH2; /* LH2 */
+
+	if (q1->HH2 < q2->HH2)
+		return FALSE;
 	dst->HH2 = q1->HH2 - q2->HH2; /* HH2 */
+
+	if (q1->HL3 < q2->HL3)
+		return FALSE;
 	dst->HL3 = q1->HL3 - q2->HL3; /* HL3 */
+
+	if (q1->LH3 < q2->LH3)
+		return FALSE;
 	dst->LH3 = q1->LH3 - q2->LH3; /* LH3 */
+
+	if (q1->HH3 < q2->HH3)
+		return FALSE;
 	dst->HH3 = q1->HH3 - q2->HH3; /* HH3 */
+
+	if (q1->LL3 < q2->LL3)
+		return FALSE;
 	dst->LL3 = q1->LL3 - q2->LL3; /* LL3 */
+
+	return TRUE;
 }
 
 static inline BOOL
@@ -1398,9 +1430,12 @@ progressive_decompress_tile_upgrade(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progress
 	progressive_rfx_quant_add(quantY, quantProgY, &yBitPos);
 	progressive_rfx_quant_add(quantCb, quantProgCb, &cbBitPos);
 	progressive_rfx_quant_add(quantCr, quantProgCr, &crBitPos);
-	progressive_rfx_quant_sub(&(tile->yBitPos), &yBitPos, &yNumBits);
-	progressive_rfx_quant_sub(&(tile->cbBitPos), &cbBitPos, &cbNumBits);
-	progressive_rfx_quant_sub(&(tile->crBitPos), &crBitPos, &crNumBits);
+	if (!progressive_rfx_quant_sub(&(tile->yBitPos), &yBitPos, &yNumBits))
+		goto fail;
+	if (!progressive_rfx_quant_sub(&(tile->cbBitPos), &cbBitPos, &cbNumBits))
+		goto fail;
+	if (!progressive_rfx_quant_sub(&(tile->crBitPos), &crBitPos, &crNumBits))
+		goto fail;
 	progressive_rfx_quant_add(quantY, quantProgY, &shiftY);
 	progressive_rfx_quant_lsub(&shiftY, 1); /* -6 + 5 = -1 */
 	progressive_rfx_quant_add(quantCb, quantProgCb, &shiftCb);

--- a/libfreerdp/codec/rfx.c
+++ b/libfreerdp/codec/rfx.c
@@ -870,8 +870,8 @@ static inline BOOL rfx_process_message_tileset(RFX_CONTEXT* WINPR_RESTRICT conte
 
 	Stream_Read_UINT32(s, tilesDataSize); /* tilesDataSize (4 bytes) */
 
-	if (!(pmem =
-	          winpr_aligned_recalloc(context->quants, context->numQuant, 10 * sizeof(UINT32), 32)))
+	if (!(pmem = winpr_aligned_recalloc(context->quants, context->numQuant,
+	                                    NR_QUANT_VALUES * sizeof(UINT32), 32)))
 		return FALSE;
 
 	quants = context->quants = (UINT32*)pmem;
@@ -898,14 +898,15 @@ static inline BOOL rfx_process_message_tileset(RFX_CONTEXT* WINPR_RESTRICT conte
 		Stream_Read_UINT8(s, quant);
 		*quants++ = (quant & 0x0F);
 		*quants++ = (quant >> 4);
-		WLog_Print(context->priv->log, WLOG_DEBUG,
-		           "quant %" PRIuz " (%" PRIu32 " %" PRIu32 " %" PRIu32 " %" PRIu32 " %" PRIu32
-		           " %" PRIu32 " %" PRIu32 " %" PRIu32 " %" PRIu32 " %" PRIu32 ").",
-		           i, context->quants[i * 10], context->quants[i * 10 + 1],
-		           context->quants[i * 10 + 2], context->quants[i * 10 + 3],
-		           context->quants[i * 10 + 4], context->quants[i * 10 + 5],
-		           context->quants[i * 10 + 6], context->quants[i * 10 + 7],
-		           context->quants[i * 10 + 8], context->quants[i * 10 + 9]);
+		WLog_Print(
+		    context->priv->log, WLOG_DEBUG,
+		    "quant %" PRIuz " (%" PRIu32 " %" PRIu32 " %" PRIu32 " %" PRIu32 " %" PRIu32 " %" PRIu32
+		    " %" PRIu32 " %" PRIu32 " %" PRIu32 " %" PRIu32 ").",
+		    i, context->quants[i * NR_QUANT_VALUES], context->quants[i * NR_QUANT_VALUES + 1],
+		    context->quants[i * NR_QUANT_VALUES + 2], context->quants[i * NR_QUANT_VALUES + 3],
+		    context->quants[i * NR_QUANT_VALUES + 4], context->quants[i * NR_QUANT_VALUES + 5],
+		    context->quants[i * NR_QUANT_VALUES + 6], context->quants[i * NR_QUANT_VALUES + 7],
+		    context->quants[i * NR_QUANT_VALUES + 8], context->quants[i * NR_QUANT_VALUES + 9]);
 	}
 
 	for (size_t i = 0; i < message->numTiles; i++)
@@ -1693,6 +1694,7 @@ RFX_MESSAGE* rfx_encode_message(RFX_CONTEXT* WINPR_RESTRICT context,
 	if (!context->numQuant)
 	{
 		WINPR_ASSERT(context->quants == nullptr);
+		WINPR_ASSERT(NR_QUANT_VALUES == ARRAYSIZE(rfx_default_quantization_values));
 		if (!(context->quants =
 		          (UINT32*)winpr_aligned_malloc(sizeof(rfx_default_quantization_values), 32)))
 			goto skip_encoding_loop;

--- a/libfreerdp/codec/rfx_decode.c
+++ b/libfreerdp/codec/rfx_decode.c
@@ -35,11 +35,13 @@
 
 #include "rfx_decode.h"
 
-static inline void rfx_decode_component(RFX_CONTEXT* WINPR_RESTRICT context,
+WINPR_ATTR_NODISCARD
+static inline BOOL rfx_decode_component(RFX_CONTEXT* WINPR_RESTRICT context,
                                         const UINT32* WINPR_RESTRICT quantization_values,
-                                        const BYTE* WINPR_RESTRICT data, size_t size,
-                                        INT16* WINPR_RESTRICT buffer)
+                                        size_t nrQuantValues, const BYTE* WINPR_RESTRICT data,
+                                        size_t size, INT16* WINPR_RESTRICT buffer)
 {
+	BOOL res = FALSE;
 	INT16* dwt_buffer = BufferPool_Take(context->priv->BufferPool, -1); /* dwt_buffer */
 	WINPR_ASSERT(dwt_buffer);
 
@@ -50,7 +52,10 @@ static inline void rfx_decode_component(RFX_CONTEXT* WINPR_RESTRICT context,
 	{
 		const int rc = context->rlgr_decode(context->mode, data, (UINT32)size, buffer, 4096);
 		if (rc < 0)
+		{
 			WLog_Print(context->priv->log, WLOG_ERROR, "context->rlgr_decode failed: %d", rc);
+			goto fail;
+		}
 	}
 
 	PROFILER_EXIT(context->priv->prof_rfx_rlgr_decode)
@@ -58,13 +63,18 @@ static inline void rfx_decode_component(RFX_CONTEXT* WINPR_RESTRICT context,
 	rfx_differential_decode(buffer + 4032, 64);
 	PROFILER_EXIT(context->priv->prof_rfx_differential_decode)
 	PROFILER_ENTER(context->priv->prof_rfx_quantization_decode)
-	context->quantization_decode(buffer, quantization_values);
+	if (!context->quantization_decode(buffer, quantization_values, nrQuantValues))
+		goto fail;
 	PROFILER_EXIT(context->priv->prof_rfx_quantization_decode)
 	PROFILER_ENTER(context->priv->prof_rfx_dwt_2d_decode)
 	context->dwt_2d_decode(buffer, dwt_buffer);
 	PROFILER_EXIT(context->priv->prof_rfx_dwt_2d_decode)
 	PROFILER_EXIT(context->priv->prof_rfx_decode_component)
+
+	res = TRUE;
+fail:
 	BufferPool_Return(context->priv->BufferPool, dwt_buffer);
+	return res;
 }
 
 /* rfx_decode_ycbcr_to_rgb code now resides in the primitives library. */
@@ -78,7 +88,7 @@ BOOL rfx_decode_rgb(RFX_CONTEXT* WINPR_RESTRICT context, const RFX_TILE* WINPR_R
 		const INT16** cpv;
 		INT16** pv;
 	} cnv;
-	BOOL rc = TRUE;
+	BOOL rc = FALSE;
 	BYTE* pBuffer = nullptr;
 	INT16* pSrcDst[3];
 	UINT32* y_quants = nullptr;
@@ -87,25 +97,34 @@ BOOL rfx_decode_rgb(RFX_CONTEXT* WINPR_RESTRICT context, const RFX_TILE* WINPR_R
 	static const prim_size_t roi_64x64 = { 64, 64 };
 	const primitives_t* prims = primitives_get();
 	PROFILER_ENTER(context->priv->prof_rfx_decode_rgb)
-	y_quants = context->quants + (10ULL * tile->quantIdxY);
-	cb_quants = context->quants + (10ULL * tile->quantIdxCb);
-	cr_quants = context->quants + (10ULL * tile->quantIdxCr);
+	y_quants = context->quants + (NR_QUANT_VALUES * tile->quantIdxY);
+	cb_quants = context->quants + (NR_QUANT_VALUES * tile->quantIdxCb);
+	cr_quants = context->quants + (NR_QUANT_VALUES * tile->quantIdxCr);
 	pBuffer = (BYTE*)BufferPool_Take(context->priv->BufferPool, -1);
 	pSrcDst[0] = (INT16*)((&pBuffer[((8192ULL + 32ULL) * 0ULL) + 16ULL]));        /* y_r_buffer */
 	pSrcDst[1] = (INT16*)((&pBuffer[((8192ULL + 32ULL) * 1ULL) + 16ULL]));        /* cb_g_buffer */
 	pSrcDst[2] = (INT16*)((&pBuffer[((8192ULL + 32ULL) * 2ULL) + 16ULL]));        /* cr_b_buffer */
-	rfx_decode_component(context, y_quants, tile->YData, tile->YLen, pSrcDst[0]); /* YData */
-	rfx_decode_component(context, cb_quants, tile->CbData, tile->CbLen, pSrcDst[1]); /* CbData */
-	rfx_decode_component(context, cr_quants, tile->CrData, tile->CrLen, pSrcDst[2]); /* CrData */
+	if (!rfx_decode_component(context, y_quants, NR_QUANT_VALUES, tile->YData, tile->YLen,
+	                          pSrcDst[0])) /* YData */
+		goto fail;
+	if (!rfx_decode_component(context, cb_quants, NR_QUANT_VALUES, tile->CbData, tile->CbLen,
+	                          pSrcDst[1])) /* CbData */
+		goto fail;
+	if (!rfx_decode_component(context, cr_quants, NR_QUANT_VALUES, tile->CrData, tile->CrLen,
+	                          pSrcDst[2])) /* CrData */
+		goto fail;
 	PROFILER_ENTER(context->priv->prof_rfx_ycbcr_to_rgb)
 
 	cnv.pv = pSrcDst;
 	if (prims->yCbCrToRGB_16s8u_P3AC4R(cnv.cpv, 64 * sizeof(INT16), rgb_buffer, stride,
 	                                   context->pixel_format, &roi_64x64) != PRIMITIVES_SUCCESS)
-		rc = FALSE;
+		goto fail;
 
 	PROFILER_EXIT(context->priv->prof_rfx_ycbcr_to_rgb)
 	PROFILER_EXIT(context->priv->prof_rfx_decode_rgb)
+
+	rc = TRUE;
+fail:
 	BufferPool_Return(context->priv->BufferPool, pBuffer);
 	return rc;
 }

--- a/libfreerdp/codec/rfx_encode.c
+++ b/libfreerdp/codec/rfx_encode.c
@@ -228,35 +228,50 @@ static void rfx_encode_format_rgb(const BYTE* WINPR_RESTRICT rgb_data, uint32_t 
 }
 
 /* rfx_encode_rgb_to_ycbcr code now resides in the primitives library. */
-
-static void rfx_encode_component(RFX_CONTEXT* WINPR_RESTRICT context,
+WINPR_ATTR_NODISCARD
+static BOOL rfx_encode_component(RFX_CONTEXT* WINPR_RESTRICT context,
                                  const UINT32* WINPR_RESTRICT quantization_values,
-                                 INT16* WINPR_RESTRICT data, BYTE* WINPR_RESTRICT buffer,
-                                 uint32_t buffer_size, uint32_t* WINPR_RESTRICT size)
+                                 size_t nrQuantValues, INT16* WINPR_RESTRICT data,
+                                 BYTE* WINPR_RESTRICT buffer, uint32_t buffer_size,
+                                 uint32_t* WINPR_RESTRICT size)
 {
+	BOOL res = FALSE;
+	int rc = -1;
 	INT16* dwt_buffer = BufferPool_Take(context->priv->BufferPool, -1); /* dwt_buffer */
+	if (!dwt_buffer)
+		return FALSE;
+
 	PROFILER_ENTER(context->priv->prof_rfx_encode_component)
 	PROFILER_ENTER(context->priv->prof_rfx_dwt_2d_encode)
 	context->dwt_2d_encode(data, dwt_buffer);
 	PROFILER_EXIT(context->priv->prof_rfx_dwt_2d_encode)
 	PROFILER_ENTER(context->priv->prof_rfx_quantization_encode)
-	context->quantization_encode(data, quantization_values);
+	if (!context->quantization_encode(data, quantization_values, nrQuantValues))
+		goto fail;
 	PROFILER_EXIT(context->priv->prof_rfx_quantization_encode)
 	PROFILER_ENTER(context->priv->prof_rfx_differential_encode)
 	rfx_differential_encode(data + 4032, 64);
 	PROFILER_EXIT(context->priv->prof_rfx_differential_encode)
 	PROFILER_ENTER(context->priv->prof_rfx_rlgr_encode)
-	const int rc = context->rlgr_encode(context->mode, data, 4096, buffer, buffer_size);
+	rc = context->rlgr_encode(context->mode, data, 4096, buffer, buffer_size);
+	if (rc < 0)
+		goto fail;
+
 	PROFILER_EXIT(context->priv->prof_rfx_rlgr_encode)
 	PROFILER_EXIT(context->priv->prof_rfx_encode_component)
+
+	res = TRUE;
+
+fail:
 	BufferPool_Return(context->priv->BufferPool, dwt_buffer);
 
 	*size = WINPR_ASSERTING_INT_CAST(uint32_t, rc);
+	return res;
 }
 
 BOOL rfx_encode_rgb(RFX_CONTEXT* WINPR_RESTRICT context, RFX_TILE* WINPR_RESTRICT tile)
 {
-	BOOL rc = TRUE;
+	BOOL rc = FALSE;
 	union
 	{
 		const INT16** cpv;
@@ -273,9 +288,9 @@ BOOL rfx_encode_rgb(RFX_CONTEXT* WINPR_RESTRICT context, RFX_TILE* WINPR_RESTRIC
 		return FALSE;
 
 	uint32_t YLen = CbLen = CrLen = 0;
-	UINT32* YQuant = context->quants + (10ULL * tile->quantIdxY);
-	UINT32* CbQuant = context->quants + (10ULL * tile->quantIdxCb);
-	UINT32* CrQuant = context->quants + (10ULL * tile->quantIdxCr);
+	UINT32* YQuant = context->quants + (NR_QUANT_VALUES * tile->quantIdxY);
+	UINT32* CbQuant = context->quants + (NR_QUANT_VALUES * tile->quantIdxCb);
+	UINT32* CrQuant = context->quants + (NR_QUANT_VALUES * tile->quantIdxCr);
 	pSrcDst[0] = (INT16*)((&pBuffer[((8192ULL + 32ULL) * 0ULL) + 16ULL])); /* y_r_buffer */
 	pSrcDst[1] = (INT16*)((&pBuffer[((8192ULL + 32ULL) * 1ULL) + 16ULL])); /* cb_g_buffer */
 	pSrcDst[2] = (INT16*)((&pBuffer[((8192ULL + 32ULL) * 2ULL) + 16ULL])); /* cr_b_buffer */
@@ -290,7 +305,8 @@ BOOL rfx_encode_rgb(RFX_CONTEXT* WINPR_RESTRICT context, RFX_TILE* WINPR_RESTRIC
 	cnv.pv = pSrcDst;
 	if (prims->RGBToYCbCr_16s16s_P3P3(cnv.cpv, 64 * sizeof(INT16), pSrcDst, 64 * sizeof(INT16),
 	                                  &roi_64x64) != PRIMITIVES_SUCCESS)
-		rc = FALSE;
+		goto fail;
+
 	PROFILER_EXIT(context->priv->prof_rfx_rgb_to_ycbcr)
 	/**
 	 * We need to clear the buffers as the RLGR encoder expects it to be initialized to zero.
@@ -299,12 +315,22 @@ BOOL rfx_encode_rgb(RFX_CONTEXT* WINPR_RESTRICT context, RFX_TILE* WINPR_RESTRIC
 	ZeroMemory(tile->YData, 4096);
 	ZeroMemory(tile->CbData, 4096);
 	ZeroMemory(tile->CrData, 4096);
-	rfx_encode_component(context, YQuant, pSrcDst[0], tile->YData, 4096, &YLen);
-	rfx_encode_component(context, CbQuant, pSrcDst[1], tile->CbData, 4096, &CbLen);
-	rfx_encode_component(context, CrQuant, pSrcDst[2], tile->CrData, 4096, &CrLen);
+	if (!rfx_encode_component(context, YQuant, NR_QUANT_VALUES, pSrcDst[0], tile->YData, 4096,
+	                          &YLen))
+		goto fail;
+	if (!rfx_encode_component(context, CbQuant, NR_QUANT_VALUES, pSrcDst[1], tile->CbData, 4096,
+	                          &CbLen))
+		goto fail;
+	if (!rfx_encode_component(context, CrQuant, NR_QUANT_VALUES, pSrcDst[2], tile->CrData, 4096,
+	                          &CrLen))
+		goto fail;
 	tile->YLen = WINPR_ASSERTING_INT_CAST(UINT16, YLen);
 	tile->CbLen = WINPR_ASSERTING_INT_CAST(UINT16, CbLen);
 	tile->CrLen = WINPR_ASSERTING_INT_CAST(UINT16, CrLen);
+
+	rc = TRUE;
+
+fail:
 	PROFILER_EXIT(context->priv->prof_rfx_encode_rgb)
 	if (!BufferPool_Return(context->priv->BufferPool, pBuffer))
 		return FALSE;

--- a/libfreerdp/codec/rfx_quantization.c
+++ b/libfreerdp/codec/rfx_quantization.c
@@ -54,12 +54,21 @@ static inline BOOL rfx_quantization_decode_block(const primitives_t* WINPR_RESTR
 	return prims->lShiftC_16s_inplace(buffer, factor, buffer_size) == PRIMITIVES_SUCCESS;
 }
 
-void rfx_quantization_decode(INT16* WINPR_RESTRICT buffer,
-                             const UINT32* WINPR_RESTRICT quantization_values)
+BOOL rfx_quantization_decode(INT16* WINPR_RESTRICT buffer,
+                             const UINT32* WINPR_RESTRICT quantization_values, size_t nrQuantValues)
 {
 	const primitives_t* prims = primitives_get();
 	WINPR_ASSERT(buffer);
 	WINPR_ASSERT(quantization_values);
+	WINPR_ASSERT(NR_QUANT_VALUES == nrQuantValues);
+
+	for (size_t x = 0; x < nrQuantValues; x++)
+	{
+		const UINT32 val = quantization_values[x];
+
+		if (val < 1)
+			return FALSE;
+	}
 
 	rfx_quantization_decode_block(prims, &buffer[0], 1024, quantization_values[8] - 1);    /* HL1 */
 	rfx_quantization_decode_block(prims, &buffer[1024], 1024, quantization_values[7] - 1); /* LH1 */
@@ -71,6 +80,7 @@ void rfx_quantization_decode(INT16* WINPR_RESTRICT buffer,
 	rfx_quantization_decode_block(prims, &buffer[3904], 64, quantization_values[1] - 1);   /* LH3 */
 	rfx_quantization_decode_block(prims, &buffer[3968], 64, quantization_values[3] - 1);   /* HH3 */
 	rfx_quantization_decode_block(prims, &buffer[4032], 64, quantization_values[0] - 1);   /* LL3 */
+	return TRUE;
 }
 
 static inline void rfx_quantization_encode_block(INT16* WINPR_RESTRICT buffer, size_t buffer_size,
@@ -87,11 +97,20 @@ static inline void rfx_quantization_encode_block(INT16* WINPR_RESTRICT buffer, s
 	}
 }
 
-void rfx_quantization_encode(INT16* WINPR_RESTRICT buffer,
-                             const UINT32* WINPR_RESTRICT quantization_values)
+WINPR_ATTR_NODISCARD
+BOOL rfx_quantization_encode(INT16* WINPR_RESTRICT buffer,
+                             const UINT32* WINPR_RESTRICT quantization_values, size_t nrQuantValues)
 {
 	WINPR_ASSERT(buffer);
 	WINPR_ASSERT(quantization_values);
+	WINPR_ASSERT(nrQuantValues == NR_QUANT_VALUES);
+
+	for (size_t x = 0; x < nrQuantValues; x++)
+	{
+		const UINT32 val = quantization_values[x];
+		if (val < 6)
+			return FALSE;
+	}
 
 	rfx_quantization_encode_block(buffer, 1024, quantization_values[8] - 6);        /* HL1 */
 	rfx_quantization_encode_block(buffer + 1024, 1024, quantization_values[7] - 6); /* LH1 */
@@ -106,4 +125,5 @@ void rfx_quantization_encode(INT16* WINPR_RESTRICT buffer,
 
 	/* The coefficients are scaled by << 5 at RGB->YCbCr phase, so we round it back here */
 	rfx_quantization_encode_block(buffer, 4096, 5);
+	return TRUE;
 }

--- a/libfreerdp/codec/rfx_quantization.h
+++ b/libfreerdp/codec/rfx_quantization.h
@@ -23,9 +23,16 @@
 #include <freerdp/codec/rfx.h>
 #include <freerdp/api.h>
 
-FREERDP_LOCAL void rfx_quantization_decode(INT16* WINPR_RESTRICT buffer,
-                                           const UINT32* WINPR_RESTRICT quantization_values);
-FREERDP_LOCAL void rfx_quantization_encode(INT16* WINPR_RESTRICT buffer,
-                                           const UINT32* WINPR_RESTRICT quantization_values);
+static const size_t NR_QUANT_VALUES = 10;
+
+WINPR_ATTR_NODISCARD
+FREERDP_LOCAL BOOL rfx_quantization_decode(INT16* WINPR_RESTRICT buffer,
+                                           const UINT32* WINPR_RESTRICT quantization_values,
+                                           size_t nrQuantValues);
+
+WINPR_ATTR_NODISCARD
+FREERDP_LOCAL BOOL rfx_quantization_encode(INT16* WINPR_RESTRICT buffer,
+                                           const UINT32* WINPR_RESTRICT quantization_values,
+                                           size_t nrQuantValues);
 
 #endif /* FREERDP_LIB_CODEC_RFX_QUANTIZATION_H */

--- a/libfreerdp/codec/rfx_types.h
+++ b/libfreerdp/codec/rfx_types.h
@@ -159,10 +159,16 @@ struct S_RFX_CONTEXT
 	struct S_RFX_MESSAGE currentMessage;
 
 	/* routines */
-	void (*quantization_decode)(INT16* WINPR_RESTRICT buffer,
-	                            const UINT32* WINPR_RESTRICT quantization_values);
-	void (*quantization_encode)(INT16* WINPR_RESTRICT buffer,
-	                            const UINT32* WINPR_RESTRICT quantization_values);
+	WINPR_ATTR_NODISCARD
+	BOOL (*quantization_decode)(INT16* WINPR_RESTRICT buffer,
+	                            const UINT32* WINPR_RESTRICT quantization_values,
+	                            size_t nrQuantValues);
+
+	WINPR_ATTR_NODISCARD
+	BOOL (*quantization_encode)(INT16* WINPR_RESTRICT buffer,
+	                            const UINT32* WINPR_RESTRICT quantization_values,
+	                            size_t nrQuantValues);
+
 	void (*dwt_2d_decode)(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer);
 	void (*dwt_2d_extrapolate_decode)(INT16* WINPR_RESTRICT src, INT16* WINPR_RESTRICT temp);
 	void (*dwt_2d_encode)(INT16* WINPR_RESTRICT buffer, INT16* WINPR_RESTRICT dwt_buffer);

--- a/libfreerdp/codec/sse/rfx_sse2.c
+++ b/libfreerdp/codec/sse/rfx_sse2.c
@@ -25,6 +25,7 @@
 
 #include "../rfx_types.h"
 #include "rfx_sse2.h"
+#include "../rfx_quantization.h"
 
 #include "../../core/simd.h"
 #include "../../primitives/sse/prim_avxsse.h"
@@ -84,11 +85,21 @@ rfx_quantization_decode_block_sse2(INT16* WINPR_RESTRICT buffer, const size_t bu
 	} while (ptr < buf_end);
 }
 
-static void rfx_quantization_decode_sse2(INT16* WINPR_RESTRICT buffer,
-                                         const UINT32* WINPR_RESTRICT quantVals)
+WINPR_ATTR_NODISCARD
+static BOOL rfx_quantization_decode_sse2(INT16* WINPR_RESTRICT buffer,
+                                         const UINT32* WINPR_RESTRICT quantVals,
+                                         size_t nrQuantValues)
 {
 	WINPR_ASSERT(buffer);
 	WINPR_ASSERT(quantVals);
+	WINPR_ASSERT(nrQuantValues == NR_QUANT_VALUES);
+
+	for (size_t x = 0; x < nrQuantValues; x++)
+	{
+		const UINT32 val = quantVals[x];
+		if (val < 1)
+			return FALSE;
+	}
 
 	mm_prefetch_buffer((char*)buffer, 4096 * sizeof(INT16));
 	rfx_quantization_decode_block_sse2(&buffer[0], 1024, quantVals[8] - 1);    /* HL1 */
@@ -101,6 +112,7 @@ static void rfx_quantization_decode_sse2(INT16* WINPR_RESTRICT buffer,
 	rfx_quantization_decode_block_sse2(&buffer[3904], 64, quantVals[1] - 1);   /* LH3 */
 	rfx_quantization_decode_block_sse2(&buffer[3968], 64, quantVals[3] - 1);   /* HH3 */
 	rfx_quantization_decode_block_sse2(&buffer[4032], 64, quantVals[0] - 1);   /* LL3 */
+	return TRUE;
 }
 
 static inline void __attribute__((ATTRIBUTES))
@@ -125,15 +137,22 @@ rfx_quantization_encode_block_sse2(INT16* WINPR_RESTRICT buffer, const unsigned 
 	} while (ptr < buf_end);
 }
 
-static void rfx_quantization_encode_sse2(INT16* WINPR_RESTRICT buffer,
-                                         const UINT32* WINPR_RESTRICT quantization_values)
+WINPR_ATTR_NODISCARD
+static BOOL rfx_quantization_encode_sse2(INT16* WINPR_RESTRICT buffer,
+                                         const UINT32* WINPR_RESTRICT quantization_values,
+                                         size_t quantVals)
 {
 	WINPR_ASSERT(buffer);
 	WINPR_ASSERT(quantization_values);
-	for (size_t x = 0; x < 10; x++)
+	WINPR_ASSERT(quantVals == NR_QUANT_VALUES);
+
+	for (size_t x = 0; x < quantVals; x++)
 	{
-		WINPR_ASSERT(quantization_values[x] >= 6);
-		WINPR_ASSERT(quantization_values[x] <= INT16_MAX + 6);
+		const UINT32 val = quantization_values[x];
+		if (val < 6)
+			return FALSE;
+		if (val > INT16_MAX)
+			return FALSE;
 	}
 
 	mm_prefetch_buffer((char*)buffer, 4096 * sizeof(INT16));
@@ -158,6 +177,7 @@ static void rfx_quantization_encode_sse2(INT16* WINPR_RESTRICT buffer,
 	rfx_quantization_encode_block_sse2(
 	    buffer + 4032, 64, WINPR_ASSERTING_INT_CAST(INT16, quantization_values[0] - 6)); /* LL3 */
 	rfx_quantization_encode_block_sse2(buffer, 4096, 5);
+	return TRUE;
 }
 
 static inline void __attribute__((ATTRIBUTES))

--- a/libfreerdp/codec/video.c
+++ b/libfreerdp/codec/video.c
@@ -96,41 +96,11 @@ static enum AVPixelFormat video_format_to_av(FREERDP_VIDEO_FORMAT format)
 
 		case FREERDP_VIDEO_FORMAT_NONE:
 		default:
+			WLog_WARN(TAG, "Could not map FREERDP_VIDEO_FORMAT %s [0x%08" PRIx32 "]",
+			          freerdp_video_format_string(format), format);
 			return AV_PIX_FMT_NONE;
 	}
 }
-
-#if defined(WITH_MJPEG_DECODER)
-/**
- * @brief Map AVPixelFormat to FREERDP_VIDEO_FORMAT
- */
-static FREERDP_VIDEO_FORMAT av_format_to_video(enum AVPixelFormat format)
-{
-	switch (format)
-	{
-		/* Planar YUV formats */
-		case AV_PIX_FMT_YUV420P:
-			return FREERDP_VIDEO_FORMAT_YUV420P;
-
-		case AV_PIX_FMT_NV12:
-			return FREERDP_VIDEO_FORMAT_NV12;
-
-		/* Packed YUV formats */
-		case AV_PIX_FMT_YUYV422:
-			return FREERDP_VIDEO_FORMAT_YUYV422;
-
-		/* RGB formats */
-		case AV_PIX_FMT_RGB24:
-			return FREERDP_VIDEO_FORMAT_RGB24;
-
-		case AV_PIX_FMT_RGB32:
-			return FREERDP_VIDEO_FORMAT_RGB32;
-
-		default:
-			return FREERDP_VIDEO_FORMAT_NONE;
-	}
-}
-#endif
 
 BOOL freerdp_video_available(void)
 {
@@ -338,10 +308,10 @@ fail:
 
 static BOOL freerdp_video_decode_mjpeg(FREERDP_VIDEO_CONTEXT* context, const BYTE* srcData,
                                        size_t srcSize, BYTE* dstData[4], int dstLineSize[4],
-                                       FREERDP_VIDEO_FORMAT* dstFormat);
+                                       enum AVPixelFormat* dstFormat);
 
 static BOOL freerdp_video_convert_to_yuv(FREERDP_VIDEO_CONTEXT* context, const BYTE* srcData[4],
-                                         const int srcLineSize[4], FREERDP_VIDEO_FORMAT srcFormat,
+                                         const int srcLineSize[4], enum AVPixelFormat srcFormat,
                                          BYTE* dstData[3], const int dstLineSize[3],
                                          FREERDP_VIDEO_FORMAT dstFormat, UINT32 width,
                                          UINT32 height);
@@ -387,7 +357,7 @@ BOOL freerdp_video_sample_convert(FREERDP_VIDEO_CONTEXT* context, FREERDP_VIDEO_
 
 	BYTE* intermediate_data[4] = WINPR_C_ARRAY_INIT;
 	int intermediate_linesize[4] = WINPR_C_ARRAY_INIT;
-	FREERDP_VIDEO_FORMAT intermediate_format = FREERDP_VIDEO_FORMAT_NONE;
+	enum AVPixelFormat intermediate_format = AV_PIX_FMT_NONE;
 
 	if (srcCompressed)
 	{
@@ -409,7 +379,7 @@ BOOL freerdp_video_sample_convert(FREERDP_VIDEO_CONTEXT* context, FREERDP_VIDEO_
 	}
 	else
 	{
-		intermediate_format = srcFormat;
+		intermediate_format = video_format_to_av(srcFormat);
 	}
 
 	if (dstFormat == FREERDP_VIDEO_FORMAT_H264)
@@ -461,9 +431,9 @@ BOOL freerdp_video_sample_convert(FREERDP_VIDEO_CONTEXT* context, FREERDP_VIDEO_
 			}
 
 			const BYTE* cSrcPlanes[4] = { srcPlanes[0], srcPlanes[1], srcPlanes[2], srcPlanes[3] };
-			if (!freerdp_video_convert_to_yuv(context, cSrcPlanes, srcStrides, srcFormat, yuvData,
-			                                  yuvLineSizes, yuvFormat, context->width,
-			                                  context->height))
+			if (!freerdp_video_convert_to_yuv(context, cSrcPlanes, srcStrides,
+			                                  video_format_to_av(srcFormat), yuvData, yuvLineSizes,
+			                                  yuvFormat, context->width, context->height))
 			{
 				WLog_ERR(TAG, "YUV conversion failed");
 				return FALSE;
@@ -500,7 +470,7 @@ BOOL freerdp_video_sample_convert(FREERDP_VIDEO_CONTEXT* context, FREERDP_VIDEO_
 
 static BOOL freerdp_video_decode_mjpeg(FREERDP_VIDEO_CONTEXT* context, const BYTE* srcData,
                                        size_t srcSize, BYTE* dstData[4], int dstLineSize[4],
-                                       FREERDP_VIDEO_FORMAT* dstFormat)
+                                       enum AVPixelFormat* dstFormat)
 {
 #if defined(WITH_MJPEG_DECODER)
 	WINPR_ASSERT(context);
@@ -539,7 +509,7 @@ static BOOL freerdp_video_decode_mjpeg(FREERDP_VIDEO_CONTEXT* context, const BYT
 	}
 
 	/* Convert pixel format */
-	*dstFormat = av_format_to_video(context->mjpegDecoder->pix_fmt);
+	*dstFormat = context->mjpegDecoder->pix_fmt;
 
 	return TRUE;
 #else
@@ -555,7 +525,7 @@ static BOOL freerdp_video_decode_mjpeg(FREERDP_VIDEO_CONTEXT* context, const BYT
 }
 
 static BOOL freerdp_video_convert_to_yuv(FREERDP_VIDEO_CONTEXT* context, const BYTE* srcData[4],
-                                         const int srcLineSize[4], FREERDP_VIDEO_FORMAT srcFormat,
+                                         const int srcLineSize[4], enum AVPixelFormat srcFormat,
                                          BYTE* dstData[3], const int dstLineSize[3],
                                          FREERDP_VIDEO_FORMAT dstFormat, UINT32 width,
                                          UINT32 height)
@@ -571,7 +541,7 @@ static BOOL freerdp_video_convert_to_yuv(FREERDP_VIDEO_CONTEXT* context, const B
 		return FALSE;
 	}
 
-	enum AVPixelFormat srcPixFmt = video_format_to_av(srcFormat);
+	enum AVPixelFormat srcPixFmt = srcFormat;
 	enum AVPixelFormat dstPixFmt = video_format_to_av(dstFormat);
 
 	if (srcPixFmt == AV_PIX_FMT_NONE || dstPixFmt == AV_PIX_FMT_NONE)

--- a/libfreerdp/codec/video.c
+++ b/libfreerdp/codec/video.c
@@ -29,6 +29,9 @@
 
 #define TAG FREERDP_TAG("codec.video")
 
+WINPR_ATTR_NODISCARD
+static const char* freerdp_video_format_string(UINT32 format);
+
 #if defined(WITH_SWSCALE)
 
 /* Forward declarations for static functions */
@@ -748,3 +751,25 @@ BOOL freerdp_video_sample_convert(WINPR_ATTR_UNUSED FREERDP_VIDEO_CONTEXT* conte
 }
 
 #endif /* WITH_SWSCALE */
+
+const char* freerdp_video_format_string(UINT32 format)
+{
+#define EVCASE(x) \
+	case x:       \
+		return #x
+
+	switch (format)
+	{
+		EVCASE(FREERDP_VIDEO_FORMAT_NONE);
+		EVCASE(FREERDP_VIDEO_FORMAT_MJPEG);
+		EVCASE(FREERDP_VIDEO_FORMAT_H264);
+		EVCASE(FREERDP_VIDEO_FORMAT_YUV420P);
+		EVCASE(FREERDP_VIDEO_FORMAT_NV12);
+		EVCASE(FREERDP_VIDEO_FORMAT_YUYV422);
+		EVCASE(FREERDP_VIDEO_FORMAT_RGB24);
+		EVCASE(FREERDP_VIDEO_FORMAT_RGB32);
+		default:
+			return "FREERDP_VIDEO_FORMAT_UNKNOWN";
+	}
+#undef EVCASE
+}

--- a/libfreerdp/codec/video.c
+++ b/libfreerdp/codec/video.c
@@ -27,7 +27,7 @@
 #include <freerdp/codec/video.h>
 #include <freerdp/codec/h264.h>
 
-#define TAG FREERDP_TAG("codec.video")
+#define VTAG FREERDP_TAG("codec.video")
 
 WINPR_ATTR_NODISCARD
 static const char* freerdp_video_format_string(UINT32 format);
@@ -35,7 +35,7 @@ static const char* freerdp_video_format_string(UINT32 format);
 #if defined(WITH_SWSCALE)
 
 /* Forward declarations for static functions */
-static BOOL freerdp_video_fill_plane_info(BYTE* data[4], int lineSize[4],
+static BOOL freerdp_video_fill_plane_info(wLog* log, BYTE* data[4], int lineSize[4],
                                           FREERDP_VIDEO_FORMAT format, UINT32 width, UINT32 height,
                                           const BYTE* buffer);
 
@@ -64,12 +64,13 @@ struct s_FREERDP_VIDEO_CONTEXT
 	UINT32 h264Framerate;
 	UINT32 h264Bitrate;
 	UINT32 h264UsageType;
+	wLog* log;
 };
 
 /**
  * @brief Map FREERDP_VIDEO_FORMAT to AVPixelFormat
  */
-static enum AVPixelFormat video_format_to_av(FREERDP_VIDEO_FORMAT format)
+static enum AVPixelFormat video_format_to_av(wLog* log, FREERDP_VIDEO_FORMAT format)
 {
 	switch (format)
 	{
@@ -96,8 +97,8 @@ static enum AVPixelFormat video_format_to_av(FREERDP_VIDEO_FORMAT format)
 
 		case FREERDP_VIDEO_FORMAT_NONE:
 		default:
-			WLog_WARN(TAG, "Could not map FREERDP_VIDEO_FORMAT %s [0x%08" PRIx32 "]",
-			          freerdp_video_format_string(format), format);
+			WLog_Print(log, WLOG_WARN, "Could not map FREERDP_VIDEO_FORMAT %s [0x%08" PRIx32 "]",
+			           freerdp_video_format_string(format), format);
 			return AV_PIX_FMT_NONE;
 	}
 }
@@ -111,9 +112,10 @@ FREERDP_VIDEO_CONTEXT* freerdp_video_context_new(UINT32 width, UINT32 height)
 {
 	FREERDP_VIDEO_CONTEXT* context = nullptr;
 
+	wLog* log = WLog_Get(VTAG);
 	if (!freerdp_video_available())
 	{
-		WLog_ERR(TAG, "Video codecs not available - FFmpeg not loaded");
+		WLog_Print(log, WLOG_ERROR, "Video codecs not available - FFmpeg not loaded");
 		return nullptr;
 	}
 
@@ -121,6 +123,7 @@ FREERDP_VIDEO_CONTEXT* freerdp_video_context_new(UINT32 width, UINT32 height)
 	if (!context)
 		return nullptr;
 
+	context->log = log;
 	context->width = width;
 	context->height = height;
 
@@ -129,14 +132,14 @@ FREERDP_VIDEO_CONTEXT* freerdp_video_context_new(UINT32 width, UINT32 height)
 	const AVCodec* codec = avcodec_find_decoder(AV_CODEC_ID_MJPEG);
 	if (!codec)
 	{
-		WLog_ERR(TAG, "avcodec_find_decoder failed to find MJPEG codec");
+		WLog_Print(context->log, WLOG_ERROR, "avcodec_find_decoder failed to find MJPEG codec");
 		goto fail;
 	}
 
 	context->mjpegDecoder = avcodec_alloc_context3(codec);
 	if (!context->mjpegDecoder)
 	{
-		WLog_ERR(TAG, "avcodec_alloc_context3 failed");
+		WLog_Print(context->log, WLOG_ERROR, "avcodec_alloc_context3 failed");
 		goto fail;
 	}
 
@@ -147,21 +150,21 @@ FREERDP_VIDEO_CONTEXT* freerdp_video_context_new(UINT32 width, UINT32 height)
 
 	if (avcodec_open2(context->mjpegDecoder, codec, nullptr) < 0)
 	{
-		WLog_ERR(TAG, "avcodec_open2 failed");
+		WLog_Print(context->log, WLOG_ERROR, "avcodec_open2 failed");
 		goto fail;
 	}
 
 	context->mjpegPacket = av_packet_alloc();
 	if (!context->mjpegPacket)
 	{
-		WLog_ERR(TAG, "av_packet_alloc failed");
+		WLog_Print(context->log, WLOG_ERROR, "av_packet_alloc failed");
 		goto fail;
 	}
 
 	context->mjpegFrame = av_frame_alloc();
 	if (!context->mjpegFrame)
 	{
-		WLog_ERR(TAG, "av_frame_alloc failed");
+		WLog_Print(context->log, WLOG_ERROR, "av_frame_alloc failed");
 		goto fail;
 	}
 #endif
@@ -210,7 +213,7 @@ void freerdp_video_context_free(FREERDP_VIDEO_CONTEXT* context)
 	free(context);
 }
 
-static UINT32 video_get_h264_bitrate(UINT32 height)
+static UINT32 video_get_h264_bitrate(wLog* log, UINT32 height)
 {
 	static struct
 	{
@@ -227,7 +230,7 @@ static UINT32 video_get_h264_bitrate(UINT32 height)
 		if (height >= bitrates[i].height)
 		{
 			UINT32 bitrate = bitrates[i].bitrate;
-			WLog_DBG(TAG, "Auto-calculated H.264 bitrate: %u kbps", bitrate);
+			WLog_Print(log, WLOG_DEBUG, "Auto-calculated H.264 bitrate: %u kbps", bitrate);
 			return bitrate * 1000;
 		}
 	}
@@ -243,19 +246,19 @@ BOOL freerdp_video_context_reconfigure(FREERDP_VIDEO_CONTEXT* context, UINT32 wi
 
 	if (width == 0 || height == 0)
 	{
-		WLog_ERR(TAG, "Invalid dimensions: %ux%u", width, height);
+		WLog_Print(context->log, WLOG_ERROR, "Invalid dimensions: %ux%u", width, height);
 		return FALSE;
 	}
 
 	if (bitrate == 0)
-		bitrate = video_get_h264_bitrate(height);
+		bitrate = video_get_h264_bitrate(context->log, height);
 
 	if (!context->h264)
 	{
 		context->h264 = h264_context_new(TRUE);
 		if (!context->h264)
 		{
-			WLog_ERR(TAG, "h264_context_new failed");
+			WLog_Print(context->log, WLOG_ERROR, "h264_context_new failed");
 			return FALSE;
 		}
 	}
@@ -283,7 +286,7 @@ BOOL freerdp_video_context_reconfigure(FREERDP_VIDEO_CONTEXT* context, UINT32 wi
 	{
 		if (!h264_context_reset(context->h264, width, height))
 		{
-			WLog_ERR(TAG, "h264_context_reset failed");
+			WLog_Print(context->log, WLOG_ERROR, "h264_context_reset failed");
 			goto fail;
 		}
 	}
@@ -334,19 +337,20 @@ BOOL freerdp_video_sample_convert(FREERDP_VIDEO_CONTEXT* context, FREERDP_VIDEO_
 
 	if (!freerdp_video_available())
 	{
-		WLog_ERR(TAG, "Video codecs not available");
+		WLog_Print(context->log, WLOG_ERROR, "Video codecs not available");
 		return FALSE;
 	}
 
 	if (srcSampleLength == 0)
 	{
-		WLog_ERR(TAG, "Invalid source sample length: 0");
+		WLog_Print(context->log, WLOG_ERROR, "Invalid source sample length: 0");
 		return FALSE;
 	}
 
 	if (!freerdp_video_conversion_supported(srcFormat, dstFormat))
 	{
-		WLog_ERR(TAG, "Conversion from format %u to %u not supported", srcFormat, dstFormat);
+		WLog_Print(context->log, WLOG_ERROR, "Conversion from format %u to %u not supported",
+		           srcFormat, dstFormat);
 		return FALSE;
 	}
 
@@ -367,26 +371,26 @@ BOOL freerdp_video_sample_convert(FREERDP_VIDEO_CONTEXT* context, FREERDP_VIDEO_
 			                                intermediate_data, intermediate_linesize,
 			                                &intermediate_format))
 			{
-				WLog_ERR(TAG, "MJPEG decoding failed");
+				WLog_Print(context->log, WLOG_ERROR, "MJPEG decoding failed");
 				return FALSE;
 			}
 		}
 		else if (srcFormat == FREERDP_VIDEO_FORMAT_H264)
 		{
-			WLog_ERR(TAG, "H264 decoding not supported");
+			WLog_Print(context->log, WLOG_ERROR, "H264 decoding not supported");
 			return FALSE;
 		}
 	}
 	else
 	{
-		intermediate_format = video_format_to_av(srcFormat);
+		intermediate_format = video_format_to_av(context->log, srcFormat);
 	}
 
 	if (dstFormat == FREERDP_VIDEO_FORMAT_H264)
 	{
 		if (!context->h264Configured)
 		{
-			WLog_ERR(TAG, "H264 encoder not configured");
+			WLog_Print(context->log, WLOG_ERROR, "H264 encoder not configured");
 			return FALSE;
 		}
 
@@ -400,7 +404,7 @@ BOOL freerdp_video_sample_convert(FREERDP_VIDEO_CONTEXT* context, FREERDP_VIDEO_
 		if (h264_get_yuv_buffer(context->h264, 0, context->width, context->height, yuvData,
 		                        yuvStrides) < 0)
 		{
-			WLog_ERR(TAG, "h264_get_yuv_buffer failed");
+			WLog_Print(context->log, WLOG_ERROR, "h264_get_yuv_buffer failed");
 			return FALSE;
 		}
 
@@ -414,7 +418,7 @@ BOOL freerdp_video_sample_convert(FREERDP_VIDEO_CONTEXT* context, FREERDP_VIDEO_
 			                                  intermediate_format, yuvData, yuvLineSizes, yuvFormat,
 			                                  context->width, context->height))
 			{
-				WLog_ERR(TAG, "YUV conversion failed");
+				WLog_Print(context->log, WLOG_ERROR, "YUV conversion failed");
 				return FALSE;
 			}
 		}
@@ -423,19 +427,20 @@ BOOL freerdp_video_sample_convert(FREERDP_VIDEO_CONTEXT* context, FREERDP_VIDEO_
 			BYTE* srcPlanes[4] = WINPR_C_ARRAY_INIT;
 			int srcStrides[4] = WINPR_C_ARRAY_INIT;
 
-			if (!freerdp_video_fill_plane_info(srcPlanes, srcStrides, srcFormat, context->width,
-			                                   context->height, (const BYTE*)srcSampleData))
+			if (!freerdp_video_fill_plane_info(context->log, srcPlanes, srcStrides, srcFormat,
+			                                   context->width, context->height,
+			                                   (const BYTE*)srcSampleData))
 			{
-				WLog_ERR(TAG, "Failed to fill plane info");
+				WLog_Print(context->log, WLOG_ERROR, "Failed to fill plane info");
 				return FALSE;
 			}
 
 			const BYTE* cSrcPlanes[4] = { srcPlanes[0], srcPlanes[1], srcPlanes[2], srcPlanes[3] };
-			if (!freerdp_video_convert_to_yuv(context, cSrcPlanes, srcStrides,
-			                                  video_format_to_av(srcFormat), yuvData, yuvLineSizes,
-			                                  yuvFormat, context->width, context->height))
+			if (!freerdp_video_convert_to_yuv(
+			        context, cSrcPlanes, srcStrides, video_format_to_av(context->log, srcFormat),
+			        yuvData, yuvLineSizes, yuvFormat, context->width, context->height))
 			{
-				WLog_ERR(TAG, "YUV conversion failed");
+				WLog_Print(context->log, WLOG_ERROR, "YUV conversion failed");
 				return FALSE;
 			}
 		}
@@ -445,13 +450,13 @@ BOOL freerdp_video_sample_convert(FREERDP_VIDEO_CONTEXT* context, FREERDP_VIDEO_
 
 		if (h264_compress(context->h264, &h264Data, &h264Size) < 0)
 		{
-			WLog_ERR(TAG, "H264 compression failed");
+			WLog_Print(context->log, WLOG_ERROR, "H264 compression failed");
 			return FALSE;
 		}
 
 		if (!Stream_EnsureRemainingCapacity(output, h264Size))
 		{
-			WLog_ERR(TAG, "Failed to ensure stream capacity");
+			WLog_Print(context->log, WLOG_ERROR, "Failed to ensure stream capacity");
 			return FALSE;
 		}
 
@@ -460,11 +465,11 @@ BOOL freerdp_video_sample_convert(FREERDP_VIDEO_CONTEXT* context, FREERDP_VIDEO_
 	}
 	else if (dstCompressed)
 	{
-		WLog_ERR(TAG, "Only H264 encoding is supported");
+		WLog_Print(context->log, WLOG_ERROR, "Only H264 encoding is supported");
 		return FALSE;
 	}
 
-	WLog_ERR(TAG, "Raw format output not yet implemented");
+	WLog_Print(context->log, WLOG_ERROR, "Raw format output not yet implemented");
 	return FALSE;
 }
 
@@ -481,7 +486,7 @@ static BOOL freerdp_video_decode_mjpeg(FREERDP_VIDEO_CONTEXT* context, const BYT
 
 	if (!context->mjpegDecoder)
 	{
-		WLog_ERR(TAG, "MJPEG decoder not initialized");
+		WLog_Print(context->log, WLOG_ERROR, "MJPEG decoder not initialized");
 		return FALSE;
 	}
 
@@ -491,13 +496,13 @@ static BOOL freerdp_video_decode_mjpeg(FREERDP_VIDEO_CONTEXT* context, const BYT
 
 	if (avcodec_send_packet(context->mjpegDecoder, context->mjpegPacket) < 0)
 	{
-		WLog_ERR(TAG, "avcodec_send_packet failed");
+		WLog_Print(context->log, WLOG_ERROR, "avcodec_send_packet failed");
 		return FALSE;
 	}
 
 	if (avcodec_receive_frame(context->mjpegDecoder, context->mjpegFrame) < 0)
 	{
-		WLog_ERR(TAG, "avcodec_receive_frame failed");
+		WLog_Print(context->log, WLOG_ERROR, "avcodec_receive_frame failed");
 		return FALSE;
 	}
 
@@ -519,7 +524,8 @@ static BOOL freerdp_video_decode_mjpeg(FREERDP_VIDEO_CONTEXT* context, const BYT
 	WINPR_UNUSED(dstData);
 	WINPR_UNUSED(dstLineSize);
 	WINPR_UNUSED(dstFormat);
-	WLog_ERR(TAG, "MJPEG decoder not available (requires direct FFmpeg linking)");
+	WLog_Print(context->log, WLOG_ERROR,
+	           "MJPEG decoder not available (requires direct FFmpeg linking)");
 	return FALSE;
 #endif
 }
@@ -537,16 +543,17 @@ static BOOL freerdp_video_convert_to_yuv(FREERDP_VIDEO_CONTEXT* context, const B
 
 	if (!freerdp_swscale_available())
 	{
-		WLog_ERR(TAG, "swscale not available - install FFmpeg to enable video processing");
+		WLog_Print(context->log, WLOG_ERROR,
+		           "swscale not available - install FFmpeg to enable video processing");
 		return FALSE;
 	}
 
 	enum AVPixelFormat srcPixFmt = srcFormat;
-	enum AVPixelFormat dstPixFmt = video_format_to_av(dstFormat);
+	enum AVPixelFormat dstPixFmt = video_format_to_av(context->log, dstFormat);
 
 	if (srcPixFmt == AV_PIX_FMT_NONE || dstPixFmt == AV_PIX_FMT_NONE)
 	{
-		WLog_ERR(TAG, "Unsupported pixel format");
+		WLog_Print(context->log, WLOG_ERROR, "Unsupported pixel format");
 		return FALSE;
 	}
 
@@ -564,7 +571,7 @@ static BOOL freerdp_video_convert_to_yuv(FREERDP_VIDEO_CONTEXT* context, const B
 		                             dstPixFmt, 0, nullptr, nullptr, nullptr);
 		if (!sws)
 		{
-			WLog_ERR(TAG, "sws_getContext failed");
+			WLog_Print(context->log, WLOG_ERROR, "sws_getContext failed");
 			return FALSE;
 		}
 
@@ -592,36 +599,36 @@ static BOOL freerdp_video_convert_to_yuv(FREERDP_VIDEO_CONTEXT* context, const B
 	return (result > 0);
 }
 
-static BOOL freerdp_video_fill_plane_info(BYTE* data[4], int lineSize[4],
+static BOOL freerdp_video_fill_plane_info(wLog* log, BYTE* data[4], int lineSize[4],
                                           FREERDP_VIDEO_FORMAT format, UINT32 width, UINT32 height,
                                           const BYTE* buffer)
 {
 	WINPR_ASSERT(data);
 	WINPR_ASSERT(lineSize);
 
-	enum AVPixelFormat pixFmt = video_format_to_av(format);
+	enum AVPixelFormat pixFmt = video_format_to_av(log, format);
 	if (pixFmt == AV_PIX_FMT_NONE)
 	{
-		WLog_ERR(TAG, "Unsupported pixel format");
+		WLog_Print(log, WLOG_ERROR, "Unsupported pixel format");
 		return FALSE;
 	}
 
 	if (!freerdp_avutil_available())
 	{
-		WLog_ERR(TAG, "avutil not available");
+		WLog_Print(log, WLOG_ERROR, "avutil not available");
 		return FALSE;
 	}
 
 	if (freerdp_av_image_fill_linesizes(lineSize, pixFmt, (int)width) < 0)
 	{
-		WLog_ERR(TAG, "av_image_fill_linesizes failed");
+		WLog_Print(log, WLOG_ERROR, "av_image_fill_linesizes failed");
 		return FALSE;
 	}
 
 	if (freerdp_av_image_fill_pointers(data, pixFmt, (int)height,
 	                                   WINPR_CAST_CONST_PTR_AWAY(buffer, BYTE*), lineSize) < 0)
 	{
-		WLog_ERR(TAG, "av_image_fill_pointers failed");
+		WLog_Print(log, WLOG_ERROR, "av_image_fill_pointers failed");
 		return FALSE;
 	}
 

--- a/libfreerdp/core/gateway/rts.c
+++ b/libfreerdp/core/gateway/rts.c
@@ -255,6 +255,15 @@ rts_pdu_status_t rts_read_common_pdu_header(wStream* s, rpcconn_common_hdr_t* he
 			          header->frag_length, sizeof(rpcconn_common_hdr_t));
 		return RTS_PDU_FAIL;
 	}
+	if (header->auth_length > header->frag_length - 8ull)
+	{
+		if (!ignoreErrors)
+			WLog_WARN(TAG,
+			          "Invalid header->auth_length(%" PRIu16 ") > header->frag_length(%" PRIu16
+			          ") - 8ull",
+			          header->frag_length, header->auth_length);
+		return RTS_PDU_FAIL;
+	}
 
 	if (!ignoreErrors)
 	{

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -1662,6 +1662,8 @@ static BOOL nla_encode_ts_smartcard_credentials(rdpNla* nla, WinPrAsn1Encoder* e
 	    (BYTE*)freerdp_settings_get_string_as_utf16(settings, FreeRDP_Password, &ss);
 	octet_string.len = ss * sizeof(WCHAR);
 	BOOL res = WinPrAsn1EncContextualOctetString(enc, 0, &octet_string) > 0;
+	if (octet_string.data)
+		memset(octet_string.data, 0, octet_string.len);
 	free(octet_string.data);
 	if (!res)
 		return FALSE;
@@ -1688,6 +1690,8 @@ static BOOL nla_encode_ts_smartcard_credentials(rdpNla* nla, WinPrAsn1Encoder* e
 		{
 			const BOOL res2 =
 			    WinPrAsn1EncContextualOctetString(enc, cspData_fields[i].tag, &octet_string) > 0;
+			if (octet_string.data)
+				memset(octet_string.data, 0, octet_string.len);
 			free(octet_string.data);
 			if (!res2)
 				return FALSE;
@@ -1705,6 +1709,8 @@ static BOOL nla_encode_ts_smartcard_credentials(rdpNla* nla, WinPrAsn1Encoder* e
 		    (BYTE*)freerdp_settings_get_string_as_utf16(settings, FreeRDP_Username, &ss);
 		octet_string.len = ss * sizeof(WCHAR);
 		res = WinPrAsn1EncContextualOctetString(enc, 2, &octet_string) > 0;
+		if (octet_string.data)
+			memset(octet_string.data, 0, octet_string.len);
 		free(octet_string.data);
 		if (!res)
 			return FALSE;
@@ -1717,6 +1723,8 @@ static BOOL nla_encode_ts_smartcard_credentials(rdpNla* nla, WinPrAsn1Encoder* e
 		    (BYTE*)freerdp_settings_get_string_as_utf16(settings, FreeRDP_Domain, &ss);
 		octet_string.len = ss * sizeof(WCHAR);
 		res = WinPrAsn1EncContextualOctetString(enc, 3, &octet_string) > 0;
+		if (octet_string.data)
+			memset(octet_string.data, 0, octet_string.len);
 		free(octet_string.data);
 		if (!res)
 			return FALSE;

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -1662,9 +1662,7 @@ static BOOL nla_encode_ts_smartcard_credentials(rdpNla* nla, WinPrAsn1Encoder* e
 	    (BYTE*)freerdp_settings_get_string_as_utf16(settings, FreeRDP_Password, &ss);
 	octet_string.len = ss * sizeof(WCHAR);
 	BOOL res = WinPrAsn1EncContextualOctetString(enc, 0, &octet_string) > 0;
-	if (octet_string.data)
-		memset(octet_string.data, 0, octet_string.len);
-	free(octet_string.data);
+	WinPrAsn1FreeOctetString(&octet_string);
 	if (!res)
 		return FALSE;
 
@@ -1690,9 +1688,7 @@ static BOOL nla_encode_ts_smartcard_credentials(rdpNla* nla, WinPrAsn1Encoder* e
 		{
 			const BOOL res2 =
 			    WinPrAsn1EncContextualOctetString(enc, cspData_fields[i].tag, &octet_string) > 0;
-			if (octet_string.data)
-				memset(octet_string.data, 0, octet_string.len);
-			free(octet_string.data);
+			WinPrAsn1FreeOctetString(&octet_string);
 			if (!res2)
 				return FALSE;
 		}
@@ -1709,9 +1705,7 @@ static BOOL nla_encode_ts_smartcard_credentials(rdpNla* nla, WinPrAsn1Encoder* e
 		    (BYTE*)freerdp_settings_get_string_as_utf16(settings, FreeRDP_Username, &ss);
 		octet_string.len = ss * sizeof(WCHAR);
 		res = WinPrAsn1EncContextualOctetString(enc, 2, &octet_string) > 0;
-		if (octet_string.data)
-			memset(octet_string.data, 0, octet_string.len);
-		free(octet_string.data);
+		WinPrAsn1FreeOctetString(&octet_string);
 		if (!res)
 			return FALSE;
 	}
@@ -1723,9 +1717,7 @@ static BOOL nla_encode_ts_smartcard_credentials(rdpNla* nla, WinPrAsn1Encoder* e
 		    (BYTE*)freerdp_settings_get_string_as_utf16(settings, FreeRDP_Domain, &ss);
 		octet_string.len = ss * sizeof(WCHAR);
 		res = WinPrAsn1EncContextualOctetString(enc, 3, &octet_string) > 0;
-		if (octet_string.data)
-			memset(octet_string.data, 0, octet_string.len);
-		free(octet_string.data);
+		WinPrAsn1FreeOctetString(&octet_string);
 		if (!res)
 			return FALSE;
 	}

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -745,7 +745,7 @@ static UINT gdi_SurfaceCommand_AVC444(rdpGdi* gdi, RdpgfxClientContext* context,
 
 	if (rc < 0)
 	{
-		WLog_WARN(TAG, "avc444_decompress failure: %" PRIu32 ", ignoring update.", status);
+		WLog_WARN(TAG, "avc444_decompress failure: %" PRId32 ", ignoring update.", rc);
 		return CHANNEL_RC_OK;
 	}
 

--- a/libfreerdp/utils/signal_win32.c
+++ b/libfreerdp/utils/signal_win32.c
@@ -15,9 +15,17 @@
 #define TAG FREERDP_TAG("utils.signal.posix")
 
 static CRITICAL_SECTION signal_lock;
+static INIT_ONCE signal_lock_init = INIT_ONCE_STATIC_INIT;
+
+static BOOL CALLBACK init_signal_lock(PINIT_ONCE InitOnce, PVOID Parameter, PVOID* Context)
+{
+	InitializeCriticalSection(&signal_lock);
+	return TRUE;
+}
 
 void fsig_lock(void)
 {
+	InitOnceExecuteOnce(&signal_lock_init, init_signal_lock, NULL, NULL);
 	EnterCriticalSection(&signal_lock);
 }
 
@@ -98,8 +106,6 @@ static void unregister_all_handlers(void)
 int freerdp_handle_signals(void)
 {
 	int rc = -1;
-	InitializeCriticalSection(&signal_lock);
-
 	fsig_lock();
 
 	WLog_DBG(TAG, "Registering signal hook...");

--- a/server/proxy/channels/pf_channel_rdpdr.c
+++ b/server/proxy/channels/pf_channel_rdpdr.c
@@ -1304,12 +1304,19 @@ BOOL pf_channel_send_client_queue(pClientContext* pc, pf_channel_client_context*
 	WINPR_ASSERT(rdpdr);
 
 	if (rdpdr->state != STATE_CLIENT_CHANNEL_RUNNING)
-		return FALSE;
+	{
+		CLIENT_TX_LOG(rdpdr->log, WLOG_WARN, "Client RDPDR channel not ready, dropping packet!");
+		return TRUE;
+	}
 
 	const UINT16 channelId =
 	    freerdp_channels_get_id_by_name(pc->context.instance, RDPDR_SVC_CHANNEL_NAME);
 	if ((channelId == 0) || (channelId == UINT16_MAX))
+	{
+		CLIENT_TX_LOG(rdpdr->log, WLOG_WARN,
+		              "Client RDPDR channel not available, dropping packet!");
 		return TRUE;
+	}
 
 	Queue_Lock(rdpdr->queue);
 	while (Queue_Count(rdpdr->queue) > 0)

--- a/server/proxy/pf_client.c
+++ b/server/proxy/pf_client.c
@@ -936,6 +936,59 @@ static int pf_client_verify_X509_certificate(freerdp* instance, const BYTE* data
 	return 1;
 }
 
+WINPR_ATTR_NODISCARD
+static BOOL pf_client_choose_smartcard(WINPR_ATTR_UNUSED freerdp* instance,
+                                       WINPR_ATTR_UNUSED SmartcardCertInfo** cert_list,
+                                       WINPR_ATTR_UNUSED DWORD count, DWORD* choice,
+                                       WINPR_ATTR_UNUSED BOOL gateway)
+{
+	if (count < 1)
+		return FALSE;
+	*choice = 0;
+	return TRUE;
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL pf_client_authenticate_ex(WINPR_ATTR_UNUSED freerdp* instance,
+                                      WINPR_ATTR_UNUSED char** username,
+                                      WINPR_ATTR_UNUSED char** password,
+                                      WINPR_ATTR_UNUSED char** domain, rdp_auth_reason reason)
+{
+	WINPR_ASSERT(instance);
+	WINPR_ASSERT(username);
+	WINPR_ASSERT(password);
+	WINPR_ASSERT(domain);
+
+	/* Here just return success, if the remote does require some non empty credentials
+	 * then it will fail, otherwise a login prompt will be shown. */
+	switch (reason)
+	{
+		case AUTH_RDSTLS:
+		case AUTH_NLA:
+		case AUTH_TLS:
+		case AUTH_RDP:
+		case AUTH_SMARTCARD_PIN: /* in this case password is pin code */
+		case GW_AUTH_HTTP:
+		case GW_AUTH_RDG:
+		case GW_AUTH_RPC:
+			return TRUE;
+		default:
+			return FALSE;
+	}
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL pf_client_present_gateway_message(WINPR_ATTR_UNUSED freerdp* instance,
+                                              WINPR_ATTR_UNUSED UINT32 type,
+                                              WINPR_ATTR_UNUSED BOOL isDisplayMandatory,
+                                              WINPR_ATTR_UNUSED BOOL isConsentMandatory,
+                                              WINPR_ATTR_UNUSED size_t length,
+                                              WINPR_ATTR_UNUSED const WCHAR* message)
+{
+	WLog_WARN(TAG, "TODO: Implement gateway message forwarding");
+	return TRUE;
+}
+
 void channel_data_free(void* obj)
 {
 	union
@@ -1008,7 +1061,14 @@ static BOOL pf_client_client_new(freerdp* instance, rdpContext* context)
 	instance->PostDisconnect = pf_client_post_disconnect;
 	instance->Redirect = pf_client_redirect;
 	instance->LogonErrorInfo = pf_logon_error_info;
+	instance->GetAccessToken = nullptr;
+	instance->RetryDialog = nullptr;
+	instance->VerifyCertificateEx = nullptr;
+	instance->VerifyChangedCertificateEx = nullptr;
 	instance->VerifyX509Certificate = pf_client_verify_X509_certificate;
+	instance->AuthenticateEx = pf_client_authenticate_ex;
+	instance->ChooseSmartcard = pf_client_choose_smartcard;
+	instance->PresentGatewayMessage = pf_client_present_gateway_message;
 
 	pc->remote_pem = Stream_New(nullptr, 4096);
 	if (!pc->remote_pem)

--- a/server/proxy/pf_input.c
+++ b/server/proxy/pf_input.c
@@ -48,16 +48,14 @@ static BOOL pf_server_check_and_sync_input_state(pClientContext* pc)
 WINPR_ATTR_NODISCARD
 static BOOL pf_server_synchronize_event(rdpInput* input, UINT32 flags)
 {
-	pServerContext* ps = nullptr;
-	pClientContext* pc = nullptr;
-
 	WINPR_ASSERT(input);
-	ps = (pServerContext*)input->context;
+	pServerContext* ps = (pServerContext*)input->context;
 	WINPR_ASSERT(ps);
 	WINPR_ASSERT(ps->pdata);
 
-	pc = ps->pdata->pc;
-	WINPR_ASSERT(pc);
+	pClientContext* pc = ps->pdata->pc;
+	if (!pc)
+		return TRUE;
 
 	pc->input_state = flags;
 	pc->input_state_sync_pending = TRUE;
@@ -70,20 +68,18 @@ static BOOL pf_server_synchronize_event(rdpInput* input, UINT32 flags)
 WINPR_ATTR_NODISCARD
 static BOOL pf_server_keyboard_event(rdpInput* input, UINT16 flags, UINT8 code)
 {
-	const proxyConfig* config = nullptr;
 	proxyKeyboardEventInfo event = WINPR_C_ARRAY_INIT;
-	pServerContext* ps = nullptr;
-	pClientContext* pc = nullptr;
 
 	WINPR_ASSERT(input);
-	ps = (pServerContext*)input->context;
+	pServerContext* ps = (pServerContext*)input->context;
 	WINPR_ASSERT(ps);
 	WINPR_ASSERT(ps->pdata);
 
-	pc = ps->pdata->pc;
-	WINPR_ASSERT(pc);
+	pClientContext* pc = ps->pdata->pc;
+	if (!pc)
+		return TRUE;
 
-	config = ps->pdata->config;
+	const proxyConfig* config = ps->pdata->config;
 	WINPR_ASSERT(config);
 
 	if (!pf_server_check_and_sync_input_state(pc))
@@ -104,20 +100,18 @@ static BOOL pf_server_keyboard_event(rdpInput* input, UINT16 flags, UINT8 code)
 WINPR_ATTR_NODISCARD
 static BOOL pf_server_unicode_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
 {
-	const proxyConfig* config = nullptr;
 	proxyUnicodeEventInfo event = WINPR_C_ARRAY_INIT;
-	pServerContext* ps = nullptr;
-	pClientContext* pc = nullptr;
 
 	WINPR_ASSERT(input);
-	ps = (pServerContext*)input->context;
+	pServerContext* ps = (pServerContext*)input->context;
 	WINPR_ASSERT(ps);
 	WINPR_ASSERT(ps->pdata);
 
-	pc = ps->pdata->pc;
-	WINPR_ASSERT(pc);
+	pClientContext* pc = ps->pdata->pc;
+	if (!pc)
+		return TRUE;
 
-	config = ps->pdata->config;
+	const proxyConfig* config = ps->pdata->config;
 	WINPR_ASSERT(config);
 
 	if (!pf_server_check_and_sync_input_state(pc))
@@ -137,19 +131,17 @@ WINPR_ATTR_NODISCARD
 static BOOL pf_server_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UINT16 y)
 {
 	proxyMouseEventInfo event = WINPR_C_ARRAY_INIT;
-	const proxyConfig* config = nullptr;
-	pServerContext* ps = nullptr;
-	pClientContext* pc = nullptr;
 
 	WINPR_ASSERT(input);
-	ps = (pServerContext*)input->context;
+	pServerContext* ps = (pServerContext*)input->context;
 	WINPR_ASSERT(ps);
 	WINPR_ASSERT(ps->pdata);
 
-	pc = ps->pdata->pc;
-	WINPR_ASSERT(pc);
+	pClientContext* pc = ps->pdata->pc;
+	if (!pc)
+		return TRUE;
 
-	config = ps->pdata->config;
+	const proxyConfig* config = ps->pdata->config;
 	WINPR_ASSERT(config);
 
 	if (!pf_server_check_and_sync_input_state(pc))
@@ -171,20 +163,19 @@ static BOOL pf_server_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UINT1
 WINPR_ATTR_NODISCARD
 static BOOL pf_server_extended_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UINT16 y)
 {
-	const proxyConfig* config = nullptr;
 	proxyMouseExEventInfo event = WINPR_C_ARRAY_INIT;
-	pServerContext* ps = nullptr;
-	pClientContext* pc = nullptr;
 
 	WINPR_ASSERT(input);
-	ps = (pServerContext*)input->context;
+
+	pServerContext* ps = (pServerContext*)input->context;
 	WINPR_ASSERT(ps);
 	WINPR_ASSERT(ps->pdata);
 
-	pc = ps->pdata->pc;
-	WINPR_ASSERT(pc);
+	pClientContext* pc = ps->pdata->pc;
+	if (!pc)
+		return TRUE;
 
-	config = ps->pdata->config;
+	const proxyConfig* config = ps->pdata->config;
 	WINPR_ASSERT(config);
 
 	if (!pf_server_check_and_sync_input_state(pc))

--- a/server/shadow/shadow_lobby.c
+++ b/server/shadow/shadow_lobby.c
@@ -40,13 +40,15 @@ BOOL shadow_client_init_lobby(rdpShadowServer* server)
 	if (!lobby)
 		return FALSE;
 
+	EnterCriticalSection(&lobby->lock);
+
 #if defined(WITH_RDTK)
+	rdtkSurface* surface = nullptr;
 	rdtkEngine* engine = rdtk_engine_new();
 	if (!engine)
-		return FALSE;
+		goto fail;
 
-	EnterCriticalSection(&lobby->lock);
-	rdtkSurface* surface =
+	surface =
 	    rdtk_surface_new(engine, lobby->data, WINPR_ASSERTING_INT_CAST(uint16_t, lobby->width),
 	                     WINPR_ASSERTING_INT_CAST(uint16_t, lobby->height), lobby->scanline);
 	if (!surface)

--- a/winpr/libwinpr/sspi/CredSSP/credssp.c
+++ b/winpr/libwinpr/sspi/CredSSP/credssp.c
@@ -194,13 +194,12 @@ static SECURITY_STATUS SEC_ENTRY credssp_QueryCredentialsAttributesA(
 
 static SECURITY_STATUS SEC_ENTRY credssp_FreeCredentialsHandle(PCredHandle phCredential)
 {
-	SSPI_CREDENTIALS* credentials = nullptr;
-
 	if (!phCredential)
 		return SEC_E_INVALID_HANDLE;
 
-	credentials = (SSPI_CREDENTIALS*)sspi_SecureHandleGetLowerPointer(phCredential);
-
+	SSPI_CREDENTIALS* credentials =
+	    (SSPI_CREDENTIALS*)sspi_SecureHandleGetLowerPointer(phCredential);
+	sspi_SecureHandleInvalidate(phCredential);
 	if (!credentials)
 		return SEC_E_INVALID_HANDLE;
 

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -126,13 +126,8 @@ struct s_KRB_CONTEXT
 static const WinPrAsn1_OID kerberos_OID = { 9, (void*)"\x2a\x86\x48\x86\xf7\x12\x01\x02\x02" };
 static const WinPrAsn1_OID kerberos_u2u_OID = { 10,
 	                                            (void*)"\x2a\x86\x48\x86\xf7\x12\x01\x02\x02\x03" };
-
-#define krb_log_exec(fkt, ctx, ...) \
-	kerberos_log_msg(ctx, fkt(ctx, ##__VA_ARGS__), #fkt, __FILE__, __func__, __LINE__)
-#define krb_log_exec_ptr(fkt, ctx, ...) \
-	kerberos_log_msg(*ctx, fkt(ctx, ##__VA_ARGS__), #fkt, __FILE__, __func__, __LINE__)
-static krb5_error_code kerberos_log_msg(krb5_context ctx, krb5_error_code code, const char* what,
-                                        const char* file, const char* fkt, size_t line)
+krb5_error_code kerberos_log_msg(krb5_context ctx, krb5_error_code code, const char* what,
+                                 const char* file, const char* fkt, size_t line)
 {
 	switch (code)
 	{
@@ -154,6 +149,22 @@ static krb5_error_code kerberos_log_msg(krb5_context ctx, krb5_error_code code, 
 		break;
 	}
 	return code;
+}
+
+void krb_log_context_encryption(krb5_context ctx, krb5_principal princ)
+{
+	krb5_get_init_creds_opt opt = WINPR_C_ARRAY_INIT;
+	krb5_enctype enctype = 0;
+	krb5_data salt = WINPR_C_ARRAY_INIT;
+	krb5_data s2kparam = WINPR_C_ARRAY_INIT;
+	char buffer[128] = WINPR_C_ARRAY_INIT;
+
+	krb5_error_code rv =
+	    krb_log_exec(krb5_get_etype_info, ctx, princ, &opt, &enctype, &salt, &s2kparam);
+	krb5_enctype_to_string(enctype, buffer, sizeof(buffer));
+	const char* msg = krb5_get_error_message(ctx, rv);
+	WLog_DBG(TAG, "[%s] enctype=%s, salt[%u]=%s, s2kparam[%u]=%s", msg, buffer, salt.length,
+	         salt.data, s2kparam.length, s2kparam.data);
 }
 
 static void credentials_unref(KRB_CREDENTIALS* credentials);

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -595,12 +595,12 @@ static SECURITY_STATUS
 {
 #ifdef WITH_KRB5
 	KRB_CREDENTIALS* credentials = sspi_SecureHandleGetLowerPointer(phCredential);
+	sspi_SecureHandleInvalidate(phCredential);
 	if (!credentials)
 		return SEC_E_INVALID_HANDLE;
 
 	credentials_unref(credentials);
 
-	sspi_SecureHandleInvalidate(phCredential);
 	return SEC_E_OK;
 #else
 	return SEC_E_UNSUPPORTED_FUNCTION;
@@ -1276,6 +1276,7 @@ cleanup:
 				break;
 			default:
 				kerberos_ContextFree(context, TRUE);
+				sspi_SecureHandleInvalidate(phNewContext);
 				break;
 		}
 	}
@@ -1647,6 +1648,7 @@ static SECURITY_STATUS
 {
 #ifdef WITH_KRB5
 	KRB_CONTEXT* context = get_context(phContext);
+	sspi_SecureHandleInvalidate(phContext);
 	if (!context)
 		return SEC_E_INVALID_HANDLE;
 

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -1596,6 +1596,7 @@ cleanup:
 				break;
 			default:
 				kerberos_ContextFree(context, TRUE);
+				sspi_SecureHandleInvalidate(phNewContext);
 				break;
 		}
 	}

--- a/winpr/libwinpr/sspi/Kerberos/krb5glue.h
+++ b/winpr/libwinpr/sspi/Kerberos/krb5glue.h
@@ -105,4 +105,13 @@ krb5_error_code krb5glue_get_init_creds(krb5_context ctx, krb5_principal princ, 
                                         krb5_prompter_fct prompter, char* password,
                                         SEC_WINPR_KERBEROS_SETTINGS* krb_settings);
 
+void krb_log_context_encryption(krb5_context ctx, krb5_principal princ);
+
+#define krb_log_exec(fkt, ctx, ...) \
+	kerberos_log_msg(ctx, fkt(ctx, ##__VA_ARGS__), #fkt, __FILE__, __func__, __LINE__)
+#define krb_log_exec_ptr(fkt, ctx, ...) \
+	kerberos_log_msg(*ctx, fkt(ctx, ##__VA_ARGS__), #fkt, __FILE__, __func__, __LINE__)
+krb5_error_code kerberos_log_msg(krb5_context ctx, krb5_error_code code, const char* what,
+                                 const char* file, const char* fkt, size_t line);
+
 #endif /* WINPR_SSPI_KERBEROS_GLUE_PRIVATE_H */

--- a/winpr/libwinpr/sspi/Kerberos/krb5glue_mit.c
+++ b/winpr/libwinpr/sspi/Kerberos/krb5glue_mit.c
@@ -133,7 +133,7 @@ krb5_error_code krb5glue_get_init_creds(krb5_context ctx, krb5_principal princ, 
 
 	WINPR_ASSERT(ctx);
 
-	rv = krb5_get_init_creds_opt_alloc(ctx, &gic_opt);
+	rv = krb_log_exec(krb5_get_init_creds_opt_alloc, ctx, &gic_opt);
 	if (rv)
 		goto cleanup;
 
@@ -150,28 +150,28 @@ krb5_error_code krb5glue_get_init_creds(krb5_context ctx, krb5_principal princ, 
 			krb5_get_init_creds_opt_set_renew_life(gic_opt, krb_settings->renewLifeTime);
 		if (krb_settings->withPac)
 		{
-			rv = krb5_get_init_creds_opt_set_pac_request(ctx, gic_opt, TRUE);
+			rv = krb_log_exec(krb5_get_init_creds_opt_set_pac_request, ctx, gic_opt, TRUE);
 			if (rv)
 				goto cleanup;
 		}
 		if (krb_settings->armorCache)
 		{
-			rv = krb5_get_init_creds_opt_set_fast_ccache_name(ctx, gic_opt,
-			                                                  krb_settings->armorCache);
+			rv = krb_log_exec(krb5_get_init_creds_opt_set_fast_ccache_name, ctx, gic_opt,
+			                  krb_settings->armorCache);
 			if (rv)
 				goto cleanup;
 		}
 		if (krb_settings->pkinitX509Identity)
 		{
-			rv = krb5_get_init_creds_opt_set_pa(ctx, gic_opt, "X509_user_identity",
-			                                    krb_settings->pkinitX509Identity);
+			rv = krb_log_exec(krb5_get_init_creds_opt_set_pa, ctx, gic_opt, "X509_user_identity",
+			                  krb_settings->pkinitX509Identity);
 			if (rv)
 				goto cleanup;
 		}
 		if (krb_settings->pkinitX509Anchors)
 		{
-			rv = krb5_get_init_creds_opt_set_pa(ctx, gic_opt, "X509_anchors",
-			                                    krb_settings->pkinitX509Anchors);
+			rv = krb_log_exec(krb5_get_init_creds_opt_set_pa, ctx, gic_opt, "X509_anchors",
+			                  krb_settings->pkinitX509Anchors);
 			if (rv)
 				goto cleanup;
 		}
@@ -182,7 +182,7 @@ krb5_error_code krb5glue_get_init_creds(krb5_context ctx, krb5_principal princ, 
 			char* kdc_url = nullptr;
 			size_t size = 0;
 
-			if ((rv = krb5_get_profile(ctx, &profile)))
+			if ((rv = krb_log_exec(krb5_get_profile, ctx, &profile)))
 				goto cleanup;
 
 			rv = ENOMEM;
@@ -231,17 +231,19 @@ krb5_error_code krb5glue_get_init_creds(krb5_context ctx, krb5_principal princ, 
 		}
 	}
 
-	if ((rv = krb5_get_init_creds_opt_set_in_ccache(ctx, gic_opt, ccache)))
+	if ((rv = krb_log_exec(krb5_get_init_creds_opt_set_in_ccache, ctx, gic_opt, ccache)))
 		goto cleanup;
 
-	if ((rv = krb5_get_init_creds_opt_set_out_ccache(ctx, gic_opt, ccache)))
+	if ((rv = krb_log_exec(krb5_get_init_creds_opt_set_out_ccache, ctx, gic_opt, ccache)))
 		goto cleanup;
 
-	if ((rv =
-	         krb5_init_creds_init(ctx, princ, prompter, password, start_time, gic_opt, &creds_ctx)))
+	if ((rv = krb_log_exec(krb5_init_creds_init, ctx, princ, prompter, password, start_time,
+	                       gic_opt, &creds_ctx)))
 		goto cleanup;
 
-	if ((rv = krb5_init_creds_get(ctx, creds_ctx)))
+	krb_log_context_encryption(ctx, princ);
+
+	if ((rv = krb_log_exec(krb5_init_creds_get, ctx, creds_ctx)))
 		goto cleanup;
 
 cleanup:

--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -361,6 +361,16 @@ static void ntlm_ContextFree(NTLM_CONTEXT* context)
 	sspi_SecBufferFree(&context->LmChallengeResponse);
 	free(context->ServicePrincipalName.Buffer);
 	free(context->Workstation.Buffer);
+
+	/* Zero sensitive key material before freeing the context */
+	memset(context->NtlmHash, 0, sizeof(context->NtlmHash));
+	memset(context->NtlmV2Hash, 0, sizeof(context->NtlmV2Hash));
+	memset(context->SessionBaseKey, 0, sizeof(context->SessionBaseKey));
+	memset(context->KeyExchangeKey, 0, sizeof(context->KeyExchangeKey));
+	memset(context->RandomSessionKey, 0, sizeof(context->RandomSessionKey));
+	memset(context->ExportedSessionKey, 0, sizeof(context->ExportedSessionKey));
+	memset(context->EncryptedRandomSessionKey, 0, sizeof(context->EncryptedRandomSessionKey));
+	memset(context->NtProofString, 0, sizeof(context->NtProofString));
 	free(context);
 }
 

--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -472,7 +472,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_FreeCredentialsHandle(PCredHandle phCreden
 
 	SSPI_CREDENTIALS* credentials =
 	    (SSPI_CREDENTIALS*)sspi_SecureHandleGetLowerPointer(phCredential);
-
+	sspi_SecureHandleInvalidate(phCredential);
 	if (!credentials)
 		return SEC_E_INVALID_HANDLE;
 
@@ -783,6 +783,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_InitializeSecurityContextA(
 static SECURITY_STATUS SEC_ENTRY ntlm_DeleteSecurityContext(PCtxtHandle phContext)
 {
 	NTLM_CONTEXT* context = (NTLM_CONTEXT*)sspi_SecureHandleGetLowerPointer(phContext);
+	sspi_SecureHandleInvalidate(phContext);
 	ntlm_ContextFree(context);
 	return SEC_E_OK;
 }

--- a/winpr/libwinpr/sspi/Negotiate/negotiate.c
+++ b/winpr/libwinpr/sspi/Negotiate/negotiate.c
@@ -1282,9 +1282,9 @@ static SECURITY_STATUS SEC_ENTRY negotiate_CompleteAuthToken(PCtxtHandle phConte
 
 static SECURITY_STATUS SEC_ENTRY negotiate_DeleteSecurityContext(PCtxtHandle phContext)
 {
-	NEGOTIATE_CONTEXT* context = nullptr;
 	SECURITY_STATUS status = SEC_E_OK;
-	context = (NEGOTIATE_CONTEXT*)sspi_SecureHandleGetLowerPointer(phContext);
+	NEGOTIATE_CONTEXT* context = (NEGOTIATE_CONTEXT*)sspi_SecureHandleGetLowerPointer(phContext);
+	sspi_SecureHandleInvalidate(phContext);
 	const SecPkg* pkg = nullptr;
 
 	if (!context)
@@ -1569,6 +1569,7 @@ static SECURITY_STATUS SEC_ENTRY negotiate_QueryCredentialsAttributesA(
 static SECURITY_STATUS SEC_ENTRY negotiate_FreeCredentialsHandle(PCredHandle phCredential)
 {
 	MechCred* creds = sspi_SecureHandleGetLowerPointer(phCredential);
+	sspi_SecureHandleInvalidate(phCredential);
 	if (!creds)
 		return SEC_E_INVALID_HANDLE;
 

--- a/winpr/libwinpr/sspi/Schannel/schannel.c
+++ b/winpr/libwinpr/sspi/Schannel/schannel.c
@@ -183,13 +183,12 @@ static SECURITY_STATUS SEC_ENTRY schannel_AcquireCredentialsHandleA(
 
 static SECURITY_STATUS SEC_ENTRY schannel_FreeCredentialsHandle(PCredHandle phCredential)
 {
-	SCHANNEL_CREDENTIALS* credentials = nullptr;
-
 	if (!phCredential)
 		return SEC_E_INVALID_HANDLE;
 
-	credentials = (SCHANNEL_CREDENTIALS*)sspi_SecureHandleGetLowerPointer(phCredential);
-
+	SCHANNEL_CREDENTIALS* credentials =
+	    (SCHANNEL_CREDENTIALS*)sspi_SecureHandleGetLowerPointer(phCredential);
+	sspi_SecureHandleInvalidate(phCredential);
 	if (!credentials)
 		return SEC_E_INVALID_HANDLE;
 
@@ -289,8 +288,8 @@ static SECURITY_STATUS SEC_ENTRY schannel_AcceptSecurityContext(
 
 static SECURITY_STATUS SEC_ENTRY schannel_DeleteSecurityContext(PCtxtHandle phContext)
 {
-	SCHANNEL_CONTEXT* context = nullptr;
-	context = (SCHANNEL_CONTEXT*)sspi_SecureHandleGetLowerPointer(phContext);
+	SCHANNEL_CONTEXT* context = (SCHANNEL_CONTEXT*)sspi_SecureHandleGetLowerPointer(phContext);
+	sspi_SecureHandleInvalidate(phContext);
 
 	if (!context)
 		return SEC_E_INVALID_HANDLE;

--- a/winpr/libwinpr/sspi/test/CMakeLists.txt
+++ b/winpr/libwinpr/sspi/test/CMakeLists.txt
@@ -6,10 +6,14 @@ disable_warnings_for_directory(${CMAKE_CURRENT_BINARY_DIR})
 set(${MODULE_PREFIX}_DRIVER ${MODULE_NAME}.c)
 
 set(${MODULE_PREFIX}_TESTS
-    TestQuerySecurityPackageInfo.c TestEnumerateSecurityPackages.c TestInitializeSecurityContext.c
-    TestAcquireCredentialsHandle.c TestCredSSP.c
+    TestQuerySecurityPackageInfo.c
+    TestEnumerateSecurityPackages.c
+    TestInitializeSecurityContext.c
+    TestAcquireCredentialsHandle.c
+    TestCredSSP.c
     #TestSchannel.c
     TestNTLM.c
+    TestCredentialZeroing.c
 )
 
 create_test_sourcelist(${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_DRIVER} ${${MODULE_PREFIX}_TESTS})

--- a/winpr/libwinpr/sspi/test/TestCredentialZeroing.c
+++ b/winpr/libwinpr/sspi/test/TestCredentialZeroing.c
@@ -21,18 +21,22 @@ static BOOL test_FreeAuthIdentity_zeroes_fields(void)
 	SEC_WINNT_AUTH_IDENTITY identity = WINPR_C_ARRAY_INIT;
 	identity.Flags = SEC_WINNT_AUTH_IDENTITY_UNICODE;
 
-	identity.User = ConvertUtf8ToWCharAlloc(testUser, &identity.UserLength);
+	size_t len = 0;
+	identity.User = ConvertUtf8ToWCharAlloc(testUser, &len);
+	identity.UserLength = WINPR_ASSERTING_INT_CAST(UINT32, len);
 	if (!identity.User)
 		return FALSE;
 
-	identity.Domain = ConvertUtf8ToWCharAlloc(testDomain, &identity.DomainLength);
+	identity.Domain = ConvertUtf8ToWCharAlloc(testDomain, &len);
+	identity.DomainLength = WINPR_ASSERTING_INT_CAST(UINT32, len);
 	if (!identity.Domain)
 	{
 		free(identity.User);
 		return FALSE;
 	}
 
-	identity.Password = ConvertUtf8ToWCharAlloc(testPassword, &identity.PasswordLength);
+	identity.Password = ConvertUtf8ToWCharAlloc(testPassword, &len);
+	identity.PasswordLength = WINPR_ASSERTING_INT_CAST(UINT32, len);
 	if (!identity.Password)
 	{
 		free(identity.User);

--- a/winpr/libwinpr/sspi/test/TestCredentialZeroing.c
+++ b/winpr/libwinpr/sspi/test/TestCredentialZeroing.c
@@ -4,6 +4,7 @@
 #include <winpr/crt.h>
 #include <winpr/assert.h>
 #include <winpr/sspi.h>
+#include <winpr/string.h>
 
 /**
  * Verify that public credential cleanup functions zero sensitive fields
@@ -17,24 +18,21 @@ static BOOL test_FreeAuthIdentity_zeroes_fields(void)
 	const char* testUser = "testuser";
 	const char* testDomain = "TESTDOMAIN";
 
-	SEC_WINNT_AUTH_IDENTITY identity = { 0 };
-	identity.Flags = SEC_WINNT_AUTH_IDENTITY_ANSI;
+	SEC_WINNT_AUTH_IDENTITY identity = WINPR_C_ARRAY_INIT;
+	identity.Flags = SEC_WINNT_AUTH_IDENTITY_UNICODE;
 
-	identity.UserLength = (UINT32)strlen(testUser);
-	identity.User = (UINT16*)strdup(testUser);
+	identity.User = ConvertUtf8ToWCharAlloc(testUser, &identity.UserLength);
 	if (!identity.User)
 		return FALSE;
 
-	identity.DomainLength = (UINT32)strlen(testDomain);
-	identity.Domain = (UINT16*)strdup(testDomain);
+	identity.Domain = ConvertUtf8ToWCharAlloc(testDomain, &identity.DomainLength);
 	if (!identity.Domain)
 	{
 		free(identity.User);
 		return FALSE;
 	}
 
-	identity.PasswordLength = (UINT32)strlen(testPassword);
-	identity.Password = (UINT16*)strdup(testPassword);
+	identity.Password = ConvertUtf8ToWCharAlloc(testPassword, &identity.PasswordLength);
 	if (!identity.Password)
 	{
 		free(identity.User);
@@ -44,19 +42,19 @@ static BOOL test_FreeAuthIdentity_zeroes_fields(void)
 
 	sspi_FreeAuthIdentity(&identity);
 
-	if (identity.User != NULL)
+	if (identity.User != nullptr)
 	{
-		printf("FAIL: identity.User not NULL after FreeAuthIdentity\n");
+		printf("FAIL: identity.User not nullptr after FreeAuthIdentity\n");
 		return FALSE;
 	}
-	if (identity.Domain != NULL)
+	if (identity.Domain != nullptr)
 	{
-		printf("FAIL: identity.Domain not NULL after FreeAuthIdentity\n");
+		printf("FAIL: identity.Domain not nullptr after FreeAuthIdentity\n");
 		return FALSE;
 	}
-	if (identity.Password != NULL)
+	if (identity.Password != nullptr)
 	{
-		printf("FAIL: identity.Password not NULL after FreeAuthIdentity\n");
+		printf("FAIL: identity.Password not nullptr after FreeAuthIdentity\n");
 		return FALSE;
 	}
 	if (identity.UserLength != 0 || identity.DomainLength != 0 || identity.PasswordLength != 0)
@@ -72,7 +70,7 @@ static BOOL test_FreeAuthIdentity_zeroes_fields(void)
 static BOOL test_SecBufferFree_zeroes_buffer(void)
 {
 	const char* testData = "sensitive-credential-data";
-	SecBuffer buffer = { 0 };
+	SecBuffer buffer = WINPR_C_ARRAY_INIT;
 
 	buffer.cbBuffer = (ULONG)strlen(testData);
 	buffer.pvBuffer = strdup(testData);
@@ -81,9 +79,9 @@ static BOOL test_SecBufferFree_zeroes_buffer(void)
 
 	sspi_SecBufferFree(&buffer);
 
-	if (buffer.pvBuffer != NULL)
+	if (buffer.pvBuffer != nullptr)
 	{
-		printf("FAIL: pvBuffer not NULL after SecBufferFree\n");
+		printf("FAIL: pvBuffer not nullptr after SecBufferFree\n");
 		return FALSE;
 	}
 	if (buffer.cbBuffer != 0)
@@ -95,19 +93,19 @@ static BOOL test_SecBufferFree_zeroes_buffer(void)
 	return TRUE;
 }
 
-/* Test NULL and empty input handling */
+/* Test nullptr and empty input handling */
 static BOOL test_null_handling(void)
 {
-	/* NULL should not crash */
-	sspi_FreeAuthIdentity(NULL);
-	sspi_SecBufferFree(NULL);
+	/* nullptr should not crash */
+	sspi_FreeAuthIdentity(nullptr);
+	sspi_SecBufferFree(nullptr);
 
 	/* Empty identity should not crash */
-	SEC_WINNT_AUTH_IDENTITY empty = { 0 };
+	SEC_WINNT_AUTH_IDENTITY empty = WINPR_C_ARRAY_INIT;
 	sspi_FreeAuthIdentity(&empty);
 
 	/* Empty buffer should not crash */
-	SecBuffer emptyBuf = { 0 };
+	SecBuffer emptyBuf = WINPR_C_ARRAY_INIT;
 	sspi_SecBufferFree(&emptyBuf);
 
 	return TRUE;

--- a/winpr/libwinpr/sspi/test/TestCredentialZeroing.c
+++ b/winpr/libwinpr/sspi/test/TestCredentialZeroing.c
@@ -1,0 +1,142 @@
+
+#include <string.h>
+
+#include <winpr/crt.h>
+#include <winpr/assert.h>
+#include <winpr/sspi.h>
+
+/**
+ * Verify that public credential cleanup functions zero sensitive fields
+ * before freeing memory, preventing credential recovery from freed heap.
+ */
+
+/* Test that sspi_FreeAuthIdentity zeroes and NULLs all fields */
+static BOOL test_FreeAuthIdentity_zeroes_fields(void)
+{
+	const char* testPassword = "S3cretP@ssw0rd!";
+	const char* testUser = "testuser";
+	const char* testDomain = "TESTDOMAIN";
+
+	SEC_WINNT_AUTH_IDENTITY identity = { 0 };
+	identity.Flags = SEC_WINNT_AUTH_IDENTITY_ANSI;
+
+	identity.UserLength = (UINT32)strlen(testUser);
+	identity.User = (UINT16*)strdup(testUser);
+	if (!identity.User)
+		return FALSE;
+
+	identity.DomainLength = (UINT32)strlen(testDomain);
+	identity.Domain = (UINT16*)strdup(testDomain);
+	if (!identity.Domain)
+	{
+		free(identity.User);
+		return FALSE;
+	}
+
+	identity.PasswordLength = (UINT32)strlen(testPassword);
+	identity.Password = (UINT16*)strdup(testPassword);
+	if (!identity.Password)
+	{
+		free(identity.User);
+		free(identity.Domain);
+		return FALSE;
+	}
+
+	sspi_FreeAuthIdentity(&identity);
+
+	if (identity.User != NULL)
+	{
+		printf("FAIL: identity.User not NULL after FreeAuthIdentity\n");
+		return FALSE;
+	}
+	if (identity.Domain != NULL)
+	{
+		printf("FAIL: identity.Domain not NULL after FreeAuthIdentity\n");
+		return FALSE;
+	}
+	if (identity.Password != NULL)
+	{
+		printf("FAIL: identity.Password not NULL after FreeAuthIdentity\n");
+		return FALSE;
+	}
+	if (identity.UserLength != 0 || identity.DomainLength != 0 || identity.PasswordLength != 0)
+	{
+		printf("FAIL: identity lengths not zeroed after FreeAuthIdentity\n");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/* Test that sspi_SecBufferFree zeroes and NULLs the buffer */
+static BOOL test_SecBufferFree_zeroes_buffer(void)
+{
+	const char* testData = "sensitive-credential-data";
+	SecBuffer buffer = { 0 };
+
+	buffer.cbBuffer = (ULONG)strlen(testData);
+	buffer.pvBuffer = strdup(testData);
+	if (!buffer.pvBuffer)
+		return FALSE;
+
+	sspi_SecBufferFree(&buffer);
+
+	if (buffer.pvBuffer != NULL)
+	{
+		printf("FAIL: pvBuffer not NULL after SecBufferFree\n");
+		return FALSE;
+	}
+	if (buffer.cbBuffer != 0)
+	{
+		printf("FAIL: cbBuffer not zero after SecBufferFree\n");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/* Test NULL and empty input handling */
+static BOOL test_null_handling(void)
+{
+	/* NULL should not crash */
+	sspi_FreeAuthIdentity(NULL);
+	sspi_SecBufferFree(NULL);
+
+	/* Empty identity should not crash */
+	SEC_WINNT_AUTH_IDENTITY empty = { 0 };
+	sspi_FreeAuthIdentity(&empty);
+
+	/* Empty buffer should not crash */
+	SecBuffer emptyBuf = { 0 };
+	sspi_SecBufferFree(&emptyBuf);
+
+	return TRUE;
+}
+
+int TestCredentialZeroing(int argc, char* argv[])
+{
+	int rc = 0;
+
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+
+	if (!test_FreeAuthIdentity_zeroes_fields())
+	{
+		printf("FAIL: test_FreeAuthIdentity_zeroes_fields\n");
+		rc = -1;
+	}
+
+	if (!test_SecBufferFree_zeroes_buffer())
+	{
+		printf("FAIL: test_SecBufferFree_zeroes_buffer\n");
+		rc = -1;
+	}
+
+	if (!test_null_handling())
+	{
+		printf("FAIL: test_null_handling\n");
+		rc = -1;
+	}
+
+	return rc;
+}

--- a/winpr/libwinpr/utils/asn1/asn1.c
+++ b/winpr/libwinpr/utils/asn1/asn1.c
@@ -84,6 +84,10 @@ void WinPrAsn1FreeOID(WinPrAsn1_OID* poid)
 
 void WinPrAsn1FreeOctetString(WinPrAsn1_OctetString* octets)
 {
+	WINPR_ASSERT(octets);
+	/* Zero sensitive data (e.g. credential UTF-16 copies) before freeing */
+	if (octets->data && octets->len > 0)
+		memset(octets->data, 0, octets->len);
 	WinPrAsn1FreeOID(octets);
 }
 

--- a/winpr/libwinpr/utils/unwind/debug.c
+++ b/winpr/libwinpr/utils/unwind/debug.c
@@ -195,9 +195,10 @@ char** winpr_unwind_backtrace_symbols(void* buffer, size_t* used)
 		cnv.cpp[x] = msg;
 
 		if (rc == 0)
-			(void)_snprintf(msg, UNWIND_MAX_LINE_SIZE, "unresolvable, address=%p", info->pc.pv);
+			(void)_snprintf(msg, UNWIND_MAX_LINE_SIZE, "address=%p, unresolvable", info->pc.pv);
 		else
-			(void)_snprintf(msg, UNWIND_MAX_LINE_SIZE, "dli_fname=%s [%p], dli_sname=%s [%p]",
+			(void)_snprintf(msg, UNWIND_MAX_LINE_SIZE,
+			                "address=%p dli_fname=%s [%p], dli_sname=%s [%p]", info->pc.pv,
 			                dlinfo.dli_fname, dlinfo.dli_fbase, dlinfo.dli_sname, dlinfo.dli_saddr);
 	}
 


### PR DESCRIPTION
## Summary

SDL3's software surface path (`SDL_GetWindowSurface` / `SDL_UpdateWindowSurface` → `wl_shm`) silently fails to commit the buffer for the 3rd+ window on wlroots-based Wayland compositors (Hyprland, Sway, river). All SDL API calls return success but the content never reaches the compositor — only the hardware cursor appears.

**Fix:** Replace the `wl_shm` software surface rendering with `SDL_Renderer` (EGL/GPU path):
- Each `SdlWindow` gets a persistent `SDL_Renderer`, render target texture, and streaming GDI texture
- `blit()` uploads only dirty pixels via `SDL_UpdateTexture` to the persistent GDI texture, then renders the dirty region to the render target
- `updateSurface()` copies the accumulated render target to screen and calls `SDL_RenderPresent`
- `fill()` uses `SDL_RenderClear` on the render target when a renderer is available

Also includes:
- **Hyprland/river/wlroots auto-detection** in `tryFallback()` — extends the existing Sway check to match `Hyprland`, `river`, and `wlroots` in `XDG_SESSION_DESKTOP` / `XDG_CURRENT_DESKTOP`
- **`FREERDP_WLROOTS_HACK=force`** mode bypasses the `isFullscreen` check, enabling the fallback for borderless multimon windows
- **Display bounds matching by window position** when `SDL_GetDisplayForWindow` returns the wrong display for unmapped windows (64×64 geometry bug on wlroots)

## Reproduction

1. Connect to an RDP server with `/multimon` from Hyprland with 3+ monitors
2. Without this fix, only 2 of 3 windows show content; the 3rd window is transparent but receives the hardware cursor
3. Debug logging confirms `SDL_BlitSurfaceScaled` and `SDL_UpdateWindowSurface` both return success for all 3 windows — the bug is in SDL3's Wayland `wl_shm` buffer commit logic

## Test plan

- [x] 3-monitor multimon on Hyprland — all windows render correctly
- [x] Performance acceptable with dirty-rect streaming texture updates
- [x] Single-monitor fullscreen mode still works
- [x] 2-monitor multimon still works
- [ ] Verify on Sway
- [ ] Verify on GNOME/KDE (renderer path should work identically)