### PR TITLE
fix(sdl): detect Hyprland and river in tryFallback()

### DIFF
--- a/client/SDL/SDL3/sdl_window.cpp
+++ b/client/SDL/SDL3/sdl_window.cpp
@@ -557,33 +557,30 @@ bool SdlWindow::tryFallback(bool isFullscreen)
 	if ((driver == nullptr) || (strcmp(driver, "wayland") != 0))
 		return false;
 
-	/* check XDG_SESSION_DESKTOP
-	 *
-	 * if set and the value is
-	 * - sway
-	 *
-	 * then we need the hack.
+	/* Check XDG_SESSION_DESKTOP and XDG_CURRENT_DESKTOP for wlroots-based
+	 * compositors. The original check only matched Sway, but other wlroots
+	 * compositors (Hyprland, river, etc.) have the same dummy-window sizing
+	 * behavior where hidden/unmapped windows return 64x64 instead of the
+	 * display size. Use strstr for substring matching since XDG_CURRENT_DESKTOP
+	 * can be a colon-separated list (e.g. "sway:wlroots", "Hyprland").
 	 */
-	const auto xdg_session = SDL_getenv("XDG_SESSION_DESKTOP");
-	if (xdg_session != nullptr)
+	auto isWlrootsCompositor = [](const char* value) -> bool
 	{
-		if (strcmp(xdg_session, "sway") == 0)
-			return isFullscreen;
-	}
+		if (!value)
+			return false;
+		if (strstr(value, "sway") || strstr(value, "Sway") || strstr(value, "Hyprland") ||
+		    strstr(value, "hyprland") || strstr(value, "river") || strstr(value, "wlroots"))
+			return true;
+		return false;
+	};
 
-	/* check XDG_CURRENT_DESKTOP
-	 *
-	 * if set and the value is
-	 * - sway:wlroots
-	 *
-	 * then we need the hack.
-	 */
+	const auto xdg_session = SDL_getenv("XDG_SESSION_DESKTOP");
+	if (isWlrootsCompositor(xdg_session))
+		return isFullscreen;
+
 	const auto xdg_desktop = SDL_getenv("XDG_CURRENT_DESKTOP");
-	if (xdg_desktop != nullptr)
-	{
-		if (strcmp(xdg_desktop, "sway:wlroots") == 0)
-			return isFullscreen;
-	}
+	if (isWlrootsCompositor(xdg_desktop))
+		return isFullscreen;
 
 	return false;
 }


### PR DESCRIPTION
## Problem

The existing wlroots workaround in `tryFallback()` only matches Sway via exact string comparison (`strcmp(xdg_session, "sway")` and `strcmp(xdg_desktop, "sway:wlroots")`). Other wlroots-based compositors — Hyprland, river, and any compositor reporting "wlroots" in its desktop string — have the same dummy-window sizing behavior (hidden/unmapped windows return 64x64 instead of display dimensions) but are not detected.

This means `sdl-freerdp` on Hyprland or river requires manually setting `FREERDP_WLROOTS_HACK=1` to work correctly.

## Fix

Replace the two `strcmp` checks with substring matching (`strstr`) for: `sway`, `Sway`, `Hyprland`, `hyprland`, `river`, `wlroots`. This covers all known wlroots compositors without requiring exact string equality, and handles the colon-separated `XDG_CURRENT_DESKTOP` format (e.g. `"sway:wlroots"`).

One file changed, no new dependencies, no behavioral change for existing Sway users.

## Testing

- Hyprland: `tryFallback()` now returns true without needing `FREERDP_WLROOTS_HACK`
- Sway: behavior unchanged (still detected via `strstr`)