### PR TITLE
[winpr,ntlm] fix message cleanup across the SSPI lifecycle

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm_message.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_message.c
@@ -1125,24 +1125,30 @@ SECURITY_STATUS ntlm_read_AuthenticateMessage(NTLM_CONTEXT* context, PSecBuffer 
 	{
 		const SECURITY_STATUS rc = ntlm_compute_lm_v2_response(context); /* LmChallengeResponse */
 		if (rc != SEC_E_OK)
-			return rc;
+		{
+			status = rc;
+			goto fail;
+		}
 	}
 
 	{
 		const SECURITY_STATUS rc = ntlm_compute_ntlm_v2_response(context); /* NtChallengeResponse */
 		if (rc != SEC_E_OK)
-			return rc;
+		{
+			status = rc;
+			goto fail;
+		}
 	}
 
 	/* KeyExchangeKey */
 	if (!ntlm_generate_key_exchange_key(context))
-		return SEC_E_INTERNAL_ERROR;
+		goto fail;
 	/* EncryptedRandomSessionKey */
 	if (!ntlm_decrypt_random_session_key(context))
-		return SEC_E_INTERNAL_ERROR;
+		goto fail;
 	/* ExportedSessionKey */
 	if (!ntlm_generate_exported_session_key(context))
-		return SEC_E_INTERNAL_ERROR;
+		goto fail;
 
 	if (flags & MSV_AV_FLAGS_MESSAGE_INTEGRITY_CHECK)
 	{
@@ -1150,7 +1156,7 @@ SECURITY_STATUS ntlm_read_AuthenticateMessage(NTLM_CONTEXT* context, PSecBuffer 
 
 		if (!ntlm_compute_message_integrity_check(context, messageIntegrityCheck,
 		                                          sizeof(messageIntegrityCheck)))
-			return SEC_E_INTERNAL_ERROR;
+			goto fail;
 		CopyMemory(
 		    &((PBYTE)context->AuthenticateMessage.pvBuffer)[context->MessageIntegrityCheckOffset],
 		    message->MessageIntegrityCheck, sizeof(message->MessageIntegrityCheck));
@@ -1166,7 +1172,8 @@ SECURITY_STATUS ntlm_read_AuthenticateMessage(NTLM_CONTEXT* context, PSecBuffer 
 			winpr_HexDump(TAG, WLOG_ERROR, message->MessageIntegrityCheck,
 			              sizeof(message->MessageIntegrityCheck));
 #endif
-			return SEC_E_MESSAGE_ALTERED;
+			status = SEC_E_MESSAGE_ALTERED;
+			goto fail;
 		}
 	}
 	else
@@ -1195,36 +1202,42 @@ SECURITY_STATUS ntlm_read_AuthenticateMessage(NTLM_CONTEXT* context, PSecBuffer 
 			winpr_HexDump(TAG, WLOG_ERROR, context->NTLMv2Response.Response,
 			              sizeof(context->NTLMv2Response));
 #endif
-			return SEC_E_LOGON_DENIED;
+			status = SEC_E_LOGON_DENIED;
+			goto fail;
 		}
 	}
 
 	/* Generate signing keys */
 	if (!ntlm_generate_client_signing_key(context))
-		return SEC_E_INTERNAL_ERROR;
+		goto fail;
 	if (!ntlm_generate_server_signing_key(context))
-		return SEC_E_INTERNAL_ERROR;
+		goto fail;
 	/* Generate sealing keys */
 	if (!ntlm_generate_client_sealing_key(context))
-		return SEC_E_INTERNAL_ERROR;
+		goto fail;
 	if (!ntlm_generate_server_sealing_key(context))
-		return SEC_E_INTERNAL_ERROR;
+		goto fail;
 	/* Initialize RC4 seal state */
 	if (!ntlm_init_rc4_seal_states(context))
-		return SEC_E_INTERNAL_ERROR;
+		goto fail;
 #if defined(WITH_DEBUG_NTLM)
 	ntlm_print_authentication_complete(context);
 #endif
 	ntlm_change_state(context, NTLM_STATE_FINAL);
+	status = SEC_E_OK;
+
+fail:
 	ntlm_free_message_fields_buffer(&(message->DomainName));
 	ntlm_free_message_fields_buffer(&(message->UserName));
 	ntlm_free_message_fields_buffer(&(message->Workstation));
 	ntlm_free_message_fields_buffer(&(message->LmChallengeResponse));
-	ntlm_free_message_fields_buffer(&(message->NtChallengeResponse));
+	/* NtChallengeResponse.Buffer is aliased to context->NtChallengeResponse.pvBuffer at
+	 * L1048 until ntlm_compute_ntlm_v2_response() reallocates the context buffer. Only
+	 * free message->NtChallengeResponse when the alias does not hold, otherwise
+	 * ntlm_ContextFree() frees the same pointer via context->NtChallengeResponse. */
+	if (context->NtChallengeResponse.pvBuffer != message->NtChallengeResponse.Buffer)
+		ntlm_free_message_fields_buffer(&(message->NtChallengeResponse));
 	ntlm_free_message_fields_buffer(&(message->EncryptedRandomSessionKey));
-	return SEC_E_OK;
-
-fail:
 	return status;
 }
 


### PR DESCRIPTION
Fixes #12603.

## Why this change is needed

@akallabeth correctly noted that the production success path does not
leak — `ntlm_ContextFree` already releases everything owned by the
context under normal SSPI usage. The leak this patch fixes is on the
**parser failure path** only, so it never triggers for well-formed
NTLM traffic.

However it is reachable pre-auth with a malformed AUTHENTICATE token.
`ntlm_read_AuthenticateMessage`'s `fail:` label was previously a bare
`return status;`, while the success path freed six message-field
buffers. When `ntlm_read_message_fields_buffer` succeeded for earlier
fields and a later sanity check failed, every already-allocated
earlier buffer leaked. `Len` is attacker-controlled `UINT16` so up to
~320 KB per request can be leaked by an unauthenticated attacker —
unbounded remote memory pressure over many connections.

Reproducer from the linked issue (65 bytes, pre-auth); see #12603 for
full hex. Under ASan+LSan this produces:
```
[ERROR] NTLM_MESSAGE_FIELDS::Buffer offset 161 beyond received data 64
Direct leak of 8 byte(s) in 1 object(s) allocated from:
  #0 malloc
  #1 ntlm_read_message_fields_buffer  ntlm_message.c:361
  #2 ntlm_read_AuthenticateMessage    ntlm_message.c:1019
```

## Scope of the change

One function touched: `ntlm_read_AuthenticateMessage`
(`winpr/libwinpr/sspi/NTLM/ntlm_message.c`). No changes to
`ntlm_ContextFree`, no new helpers, no touching the Negotiate or
Challenge parsers, no test or harness changes bundled in.

- Move the success-path cleanup (the six `ntlm_free_message_fields_buffer` calls) into the shared `fail:` label.
- Route the remaining post-allocation `return …` statements through `goto fail` with `status` set so they also release the buffers.
- `NtChallengeResponse.Buffer` is aliased into `context->NtChallengeResponse.pvBuffer` between its mid-function assignment (~L1048) and the reallocation inside `ntlm_compute_ntlm_v2_response()`. Skip freeing the message field while that alias is live — `ntlm_ContextFree()` then frees exactly once via `sspi_SecBufferFree(&context->NtChallengeResponse)`. An explanatory comment documents the invariant.

Diff: **+30 / -17** in one function.

## Test plan

- `ninja -C build-test TestSspi`
- `ctest --output-on-failure -R 'TestNTLM|TestInitializeSecurityContext|TestCredentialZeroing'` — all pass
- `ASAN_OPTIONS=detect_leaks=1 ./fuzz/TestFuzzNTLMMessage fuzz/crashes/TestFuzzNTLMMessage/leak-001c6d5eb53b6c82bc4ad8516b4b214692df5d35` — clean (was leaking on master)
