### PR TITLE
[fuzzer] add NSCodec, ASN.1, NTLM, cliprdr, and drdynvc harnesses

### DIFF
--- a/channels/cliprdr/client/CMakeLists.txt
+++ b/channels/cliprdr/client/CMakeLists.txt
@@ -23,3 +23,7 @@ set(${MODULE_PREFIX}_SRCS cliprdr_format.c cliprdr_format.h cliprdr_main.c clipr
 
 set(${MODULE_PREFIX}_LIBS winpr freerdp)
 add_channel_client_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} FALSE "VirtualChannelEntryEx")
+
+if(BUILD_FUZZERS)
+  add_subdirectory(test)
+endif()

--- a/channels/cliprdr/client/test/CMakeLists.txt
+++ b/channels/cliprdr/client/test/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(FUZZER_NAME TestFuzzChannelCliprdr)
+
+add_executable(${FUZZER_NAME} TestFuzzChannelCliprdr.c ../../cliprdr_common.c)
+target_link_libraries(${FUZZER_NAME} PUBLIC freerdp winpr fuzzer_config)
+set_target_properties(${FUZZER_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${TESTING_OUTPUT_DIRECTORY}")
+add_dependencies(fuzzers ${FUZZER_NAME})
+
+set_property(TARGET ${FUZZER_NAME} PROPERTY FOLDER "Channels/cliprdr/Client/Test")

--- a/channels/cliprdr/client/test/TestFuzzChannelCliprdr.c
+++ b/channels/cliprdr/client/test/TestFuzzChannelCliprdr.c
@@ -1,0 +1,115 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * libFuzzer harness for cliprdr PDU parsing
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <winpr/crt.h>
+#include <winpr/stream.h>
+#include <winpr/wlog.h>
+
+#include <freerdp/channels/cliprdr.h>
+
+#include "../../cliprdr_common.h"
+
+static wLog* g_Log = NULL;
+
+static UINT32 fuzz_stream_len_u32(wStream* s)
+{
+	const size_t remaining = Stream_GetRemainingLength(s);
+	return (remaining > UINT32_MAX) ? UINT32_MAX : (UINT32)remaining;
+}
+
+static void fuzz_format_list(wStream* s, BOOL longNames)
+{
+	CLIPRDR_FORMAT_LIST list = { 0 };
+	list.common.dataLen = fuzz_stream_len_u32(s);
+
+	if (cliprdr_read_format_list(g_Log, s, &list, longNames) == CHANNEL_RC_OK)
+		cliprdr_free_format_list(&list);
+}
+
+static void fuzz_format_data_request(wStream* s)
+{
+	CLIPRDR_FORMAT_DATA_REQUEST request = { 0 };
+	request.common.dataLen = fuzz_stream_len_u32(s);
+	(void)cliprdr_read_format_data_request(s, &request);
+}
+
+static void fuzz_format_data_response(wStream* s)
+{
+	CLIPRDR_FORMAT_DATA_RESPONSE response = { 0 };
+	response.common.dataLen = fuzz_stream_len_u32(s);
+	(void)cliprdr_read_format_data_response(s, &response);
+}
+
+static void fuzz_file_contents_request(wStream* s)
+{
+	CLIPRDR_FILE_CONTENTS_REQUEST request = { 0 };
+	request.common.dataLen = fuzz_stream_len_u32(s);
+	(void)cliprdr_read_file_contents_request(s, &request);
+}
+
+static void fuzz_file_contents_response(wStream* s)
+{
+	CLIPRDR_FILE_CONTENTS_RESPONSE response = { 0 };
+	const UINT32 dataLen = fuzz_stream_len_u32(s);
+
+	response.common.dataLen = (dataLen >= 4) ? dataLen : 4;
+	(void)cliprdr_read_file_contents_response(s, &response);
+}
+
+static void fuzz_unlock(wStream* s)
+{
+	CLIPRDR_UNLOCK_CLIPBOARD_DATA data = { 0 };
+	data.common.dataLen = fuzz_stream_len_u32(s);
+	(void)cliprdr_read_unlock_clipdata(s, &data);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+	const uint8_t* body = NULL;
+	BOOL longNames = FALSE;
+	wStream* s = NULL;
+
+	if (size < 2)
+		return 0;
+	if (size > (1u << 20))
+		return 0;
+
+	if (!g_Log)
+		g_Log = WLog_Get("fuzz.cliprdr");
+
+	longNames = (data[1] & 0x1) ? TRUE : FALSE;
+	body = data + 2;
+	s = Stream_New((BYTE*)body, size - 2);
+	if (!s)
+		return 0;
+
+	switch (data[0] % 6)
+	{
+		case 0:
+			fuzz_format_list(s, longNames);
+			break;
+		case 1:
+			fuzz_format_data_request(s);
+			break;
+		case 2:
+			fuzz_format_data_response(s);
+			break;
+		case 3:
+			fuzz_file_contents_request(s);
+			break;
+		case 4:
+			fuzz_file_contents_response(s);
+			break;
+		case 5:
+			fuzz_unlock(s);
+			break;
+	}
+
+	Stream_Free(s, FALSE);
+	return 0;
+}

--- a/channels/drdynvc/client/CMakeLists.txt
+++ b/channels/drdynvc/client/CMakeLists.txt
@@ -20,3 +20,7 @@ define_channel_client("drdynvc")
 set(${MODULE_PREFIX}_SRCS drdynvc_main.c drdynvc_main.h)
 
 add_channel_client_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} FALSE "VirtualChannelEntryEx")
+
+if(BUILD_FUZZERS)
+  add_subdirectory(test)
+endif()

--- a/channels/drdynvc/client/test/CMakeLists.txt
+++ b/channels/drdynvc/client/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+include(AddFuzzerTest)
+
+set(FUZZERS TestFuzzDrdynvc.c)
+
+add_fuzzer_test("${FUZZERS}" "winpr")

--- a/channels/drdynvc/client/test/TestFuzzDrdynvc.c
+++ b/channels/drdynvc/client/test/TestFuzzDrdynvc.c
@@ -1,0 +1,146 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * libFuzzer harness for DVC wire framing
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <winpr/stream.h>
+#include <winpr/wtypes.h>
+
+static UINT32 fuzz_var_uint_bytes(UINT8 cbLen)
+{
+	switch (cbLen)
+	{
+		case 0:
+			return 1;
+		case 1:
+			return 2;
+		default:
+			return 4;
+	}
+}
+
+static UINT32 fuzz_read_variable_uint(wStream* s, UINT8 cbLen)
+{
+	UINT32 value = 0;
+
+	switch (cbLen)
+	{
+		case 0:
+		{
+			UINT8 value8 = 0;
+			Stream_Read_UINT8(s, value8);
+			value = value8;
+			break;
+		}
+		case 1:
+		{
+			UINT16 value16 = 0;
+			Stream_Read_UINT16(s, value16);
+			value = value16;
+			break;
+		}
+		default:
+			Stream_Read_UINT32(s, value);
+			break;
+	}
+
+	return value;
+}
+
+enum
+{
+	CREATE_REQUEST_PDU = 0x01,
+	DATA_FIRST_PDU = 0x02,
+	DATA_PDU = 0x03,
+	CLOSE_REQUEST_PDU = 0x04,
+	CAPABILITY_REQUEST_PDU = 0x05,
+	DATA_FIRST_COMPRESSED_PDU = 0x06,
+	DATA_COMPRESSED_PDU = 0x07
+};
+
+static int fuzz_process_one_pdu(wStream* s)
+{
+	const size_t required = 1;
+	UINT8 header = 0;
+	UINT8 command = 0;
+	UINT8 spacing = 0;
+	UINT8 cbChId = 0;
+	size_t needed = 0;
+
+	if (!Stream_CheckAndLogRequiredLength("fuzz", s, required))
+		return -1;
+
+	header = Stream_Get_UINT8(s);
+	command = (header & 0xf0) >> 4;
+	spacing = (header & 0x0c) >> 2;
+	cbChId = (header & 0x03);
+	needed = fuzz_var_uint_bytes(cbChId);
+
+	switch (command)
+	{
+		case DATA_FIRST_PDU:
+		case DATA_FIRST_COMPRESSED_PDU:
+			if (!Stream_CheckAndLogRequiredLength("fuzz", s, needed + fuzz_var_uint_bytes(spacing)))
+				return -1;
+			(void)fuzz_read_variable_uint(s, cbChId);
+			(void)fuzz_read_variable_uint(s, spacing);
+			break;
+		case DATA_PDU:
+		case DATA_COMPRESSED_PDU:
+		case CLOSE_REQUEST_PDU:
+		case CREATE_REQUEST_PDU:
+			if (!Stream_CheckAndLogRequiredLength("fuzz", s, needed))
+				return -1;
+			(void)fuzz_read_variable_uint(s, cbChId);
+			break;
+		case CAPABILITY_REQUEST_PDU:
+			if (!Stream_CheckAndLogRequiredLength("fuzz", s, 2))
+				return -1;
+			Stream_Seek(s, 2);
+			break;
+		default:
+			break;
+	}
+
+	if (Stream_GetRemainingLength(s) < 2)
+		return 0;
+
+	{
+		UINT16 bodyLen = 0;
+		const size_t remaining = Stream_GetRemainingLength(s);
+
+		Stream_Read_UINT16(s, bodyLen);
+		if (bodyLen > remaining)
+			bodyLen = (UINT16)remaining;
+
+		Stream_Seek(s, bodyLen);
+	}
+
+	return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+	wStream* s = NULL;
+
+	if ((size == 0) || (size > (1u << 20)))
+		return 0;
+
+	s = Stream_New((BYTE*)data, size);
+	if (!s)
+		return 0;
+
+	for (size_t index = 0; index < 64; index++)
+	{
+		if (Stream_GetRemainingLength(s) == 0)
+			break;
+		if (fuzz_process_one_pdu(s) != 0)
+			break;
+	}
+
+	Stream_Free(s, FALSE);
+	return 0;
+}

--- a/libfreerdp/codec/test/CMakeLists.txt
+++ b/libfreerdp/codec/test/CMakeLists.txt
@@ -82,7 +82,7 @@ set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "FreeRDP/Test")
 add_executable(img2bgra img2bgra.c)
 target_link_libraries(img2bgra winpr)
 
-set(FUZZERS TestFuzzCodecs.c)
+set(FUZZERS TestFuzzCodecs.c TestFuzzNSCodec.c)
 
 include(AddFuzzerTest)
 add_fuzzer_test("${FUZZERS}" "freerdp winpr")

--- a/libfreerdp/codec/test/TestFuzzNSCodec.c
+++ b/libfreerdp/codec/test/TestFuzzNSCodec.c
@@ -1,0 +1,63 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * libFuzzer harness for the NSCodec decoder
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <winpr/crt.h>
+#include <winpr/wlog.h>
+
+#include <freerdp/codec/color.h>
+#include <freerdp/codec/nsc.h>
+
+static int fuzz_nsc_message(UINT16 bpp, UINT32 width, UINT32 height, UINT32 dstFormat,
+                            const uint8_t* data, size_t size)
+{
+	SSIZE_T stride = 0;
+	BYTE* dst = NULL;
+	NSC_CONTEXT* ctx = NULL;
+
+	if (size > UINT32_MAX)
+		return 0;
+
+	ctx = nsc_context_new();
+	if (!ctx)
+		return 0;
+
+	stride = (SSIZE_T)width * FreeRDPGetBytesPerPixel(dstFormat);
+	if (stride <= 0)
+		goto fail;
+
+	dst = calloc((size_t)height, (size_t)stride);
+	if (!dst)
+		goto fail;
+
+	(void)nsc_process_message(ctx, bpp, width, height, data, (UINT32)size, dst, dstFormat,
+	                          (UINT32)stride, 0, 0, width, height, FREERDP_FLIP_NONE);
+
+fail:
+	free(dst);
+	nsc_context_free(ctx);
+	return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+	static BOOL loggingInitialized = FALSE;
+
+	if (!loggingInitialized)
+	{
+		(void)WLog_SetLogLevel(WLog_GetRoot(), WLOG_OFF);
+		loggingInitialized = TRUE;
+	}
+
+	if (size < 20)
+		return 0;
+
+	(void)fuzz_nsc_message(32, 64, 64, PIXEL_FORMAT_BGRA32, data, size);
+	(void)fuzz_nsc_message(24, 32, 32, PIXEL_FORMAT_RGBX32, data, size);
+	(void)fuzz_nsc_message(16, 17, 13, PIXEL_FORMAT_RGB16, data, size);
+	return 0;
+}

--- a/winpr/libwinpr/sspi/test/CMakeLists.txt
+++ b/winpr/libwinpr/sspi/test/CMakeLists.txt
@@ -18,6 +18,8 @@ set(${MODULE_PREFIX}_TESTS
 
 create_test_sourcelist(${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_DRIVER} ${${MODULE_PREFIX}_TESTS})
 
+set(FUZZERS TestFuzzNTLMMessage.c)
+
 include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
 
 add_executable(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
@@ -27,6 +29,9 @@ if(WIN32)
 endif()
 
 target_link_libraries(${MODULE_NAME} ${${MODULE_PREFIX}_LIBS} winpr)
+
+include(AddFuzzerTest)
+add_fuzzer_test("${FUZZERS}" "winpr")
 
 set_target_properties(${MODULE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${TESTING_OUTPUT_DIRECTORY}")
 

--- a/winpr/libwinpr/sspi/test/TestFuzzNTLMMessage.c
+++ b/winpr/libwinpr/sspi/test/TestFuzzNTLMMessage.c
@@ -1,0 +1,355 @@
+/**
+ * WinPR: Windows Portable Runtime
+ * libFuzzer harness for the NTLM SSPI lifecycle
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <winpr/crt.h>
+#include <winpr/sspi.h>
+#include <winpr/wlog.h>
+
+#include "../sspi.h"
+
+#define TEST_SSPI_INTERFACE SSPI_INTERFACE_WINPR
+#define NTLM_PACKAGE_NAME NTLM_SSP_NAME
+
+static const char* TEST_NTLM_USER = "Username";
+static const char* TEST_NTLM_DOMAIN = "Domain";
+static const char* TEST_NTLM_PASSWORD = "P4ss123!";
+static const BYTE TEST_NTLM_V2_HASH[16] = { 0x4c, 0x7f, 0x70, 0x6f, 0x7d, 0xde, 0x05, 0xa9,
+	                                        0xd1, 0xa0, 0xf4, 0xe7, 0xff, 0xe3, 0xbf, 0xb8 };
+
+typedef struct
+{
+	CtxtHandle context;
+	ULONG cbMaxToken;
+	ULONG fContextReq;
+	ULONG pfContextAttr;
+	TimeStamp expiration;
+	SecBuffer inputBuffer[1];
+	SecBuffer outputBuffer[1];
+	BOOL haveContext;
+	BOOL haveInputBuffer;
+	SecBufferDesc inputBufferDesc;
+	SecBufferDesc outputBufferDesc;
+	CredHandle credentials;
+	SecPkgInfo* pPackageInfo;
+	SecurityFunctionTable* table;
+	SEC_WINNT_AUTH_IDENTITY identity;
+} FUZZ_NTLM_CLIENT;
+
+typedef struct
+{
+	CtxtHandle context;
+	ULONG cbMaxToken;
+	ULONG fContextReq;
+	ULONG pfContextAttr;
+	TimeStamp expiration;
+	SecBuffer inputBuffer[1];
+	SecBuffer outputBuffer[1];
+	BOOL haveContext;
+	BOOL haveInputBuffer;
+	SecBufferDesc inputBufferDesc;
+	SecBufferDesc outputBufferDesc;
+	CredHandle credentials;
+	SecPkgInfo* pPackageInfo;
+	SecurityFunctionTable* table;
+} FUZZ_NTLM_SERVER;
+
+static void fuzz_ntlm_client_uninit(FUZZ_NTLM_CLIENT* client)
+{
+	if (!client)
+		return;
+
+	free(client->outputBuffer[0].pvBuffer);
+	client->outputBuffer[0].pvBuffer = NULL;
+
+	free(client->identity.User);
+	free(client->identity.Domain);
+	free(client->identity.Password);
+
+	if (client->table)
+	{
+		if (SecIsValidHandle(&client->credentials))
+			(void)client->table->FreeCredentialsHandle(&client->credentials);
+		if (client->pPackageInfo)
+			(void)client->table->FreeContextBuffer(client->pPackageInfo);
+		if (client->haveContext && SecIsValidHandle(&client->context))
+			(void)client->table->DeleteSecurityContext(&client->context);
+	}
+}
+
+static BOOL fuzz_ntlm_client_init(FUZZ_NTLM_CLIENT* client)
+{
+	SECURITY_STATUS status = SEC_E_INTERNAL_ERROR;
+
+	WINPR_ASSERT(client);
+
+	ZeroMemory(client, sizeof(*client));
+	SecInvalidateHandle(&client->context);
+	SecInvalidateHandle(&client->credentials);
+
+	client->table = InitSecurityInterfaceEx(TEST_SSPI_INTERFACE);
+	if (!client->table)
+		return FALSE;
+
+	if (sspi_SetAuthIdentity(&client->identity, TEST_NTLM_USER, TEST_NTLM_DOMAIN, TEST_NTLM_PASSWORD) < 0)
+		return FALSE;
+
+	status = client->table->QuerySecurityPackageInfo(NTLM_PACKAGE_NAME, &client->pPackageInfo);
+	if (status != SEC_E_OK)
+		return FALSE;
+
+	client->cbMaxToken = client->pPackageInfo->cbMaxToken;
+	status = client->table->AcquireCredentialsHandle(nullptr, NTLM_PACKAGE_NAME, SECPKG_CRED_OUTBOUND,
+	                                                 nullptr, &client->identity, nullptr, nullptr,
+	                                                 &client->credentials, &client->expiration);
+	if (status != SEC_E_OK)
+		return FALSE;
+
+	client->fContextReq = ISC_REQ_MUTUAL_AUTH | ISC_REQ_CONFIDENTIALITY | ISC_REQ_USE_SESSION_KEY;
+	return TRUE;
+}
+
+static SECURITY_STATUS fuzz_ntlm_client_step(FUZZ_NTLM_CLIENT* client)
+{
+	SECURITY_STATUS status = SEC_E_INTERNAL_ERROR;
+
+	WINPR_ASSERT(client);
+
+	free(client->outputBuffer[0].pvBuffer);
+	client->outputBuffer[0].pvBuffer = NULL;
+
+	client->outputBufferDesc.ulVersion = SECBUFFER_VERSION;
+	client->outputBufferDesc.cBuffers = ARRAYSIZE(client->outputBuffer);
+	client->outputBufferDesc.pBuffers = client->outputBuffer;
+	client->outputBuffer[0].BufferType = SECBUFFER_TOKEN;
+	client->outputBuffer[0].cbBuffer = client->cbMaxToken;
+	client->outputBuffer[0].pvBuffer = calloc(1, client->outputBuffer[0].cbBuffer);
+	if (!client->outputBuffer[0].pvBuffer)
+		return SEC_E_INSUFFICIENT_MEMORY;
+
+	if (client->haveInputBuffer)
+	{
+		client->inputBufferDesc.ulVersion = SECBUFFER_VERSION;
+		client->inputBufferDesc.cBuffers = ARRAYSIZE(client->inputBuffer);
+		client->inputBufferDesc.pBuffers = client->inputBuffer;
+		client->inputBuffer[0].BufferType = SECBUFFER_TOKEN;
+	}
+
+	status = client->table->InitializeSecurityContext(
+	    &client->credentials, client->haveContext ? &client->context : nullptr, nullptr,
+	    client->fContextReq, 0, SECURITY_NATIVE_DREP,
+	    client->haveInputBuffer ? &client->inputBufferDesc : nullptr, 0, &client->context,
+	    &client->outputBufferDesc, &client->pfContextAttr, &client->expiration);
+
+	if ((status == SEC_I_COMPLETE_AND_CONTINUE) || (status == SEC_I_COMPLETE_NEEDED))
+	{
+		if (client->table->CompleteAuthToken)
+			(void)client->table->CompleteAuthToken(&client->context, &client->outputBufferDesc);
+
+		if (status == SEC_I_COMPLETE_NEEDED)
+			status = SEC_E_OK;
+		else
+			status = SEC_I_CONTINUE_NEEDED;
+	}
+
+	if (!IsSecurityStatusError(status))
+		client->haveContext = TRUE;
+
+	return status;
+}
+
+static void fuzz_ntlm_server_uninit(FUZZ_NTLM_SERVER* server)
+{
+	if (!server)
+		return;
+
+	free(server->outputBuffer[0].pvBuffer);
+	server->outputBuffer[0].pvBuffer = NULL;
+
+	if (server->table)
+	{
+		if (SecIsValidHandle(&server->credentials))
+			(void)server->table->FreeCredentialsHandle(&server->credentials);
+		if (server->pPackageInfo)
+			(void)server->table->FreeContextBuffer(server->pPackageInfo);
+		if (server->haveContext && SecIsValidHandle(&server->context))
+			(void)server->table->DeleteSecurityContext(&server->context);
+	}
+}
+
+static BOOL fuzz_ntlm_server_init(FUZZ_NTLM_SERVER* server)
+{
+	SECURITY_STATUS status = SEC_E_INTERNAL_ERROR;
+
+	WINPR_ASSERT(server);
+
+	ZeroMemory(server, sizeof(*server));
+	SecInvalidateHandle(&server->context);
+	SecInvalidateHandle(&server->credentials);
+
+	server->table = InitSecurityInterfaceEx(TEST_SSPI_INTERFACE);
+	if (!server->table)
+		return FALSE;
+
+	status = server->table->QuerySecurityPackageInfo(NTLM_PACKAGE_NAME, &server->pPackageInfo);
+	if (status != SEC_E_OK)
+		return FALSE;
+
+	server->cbMaxToken = server->pPackageInfo->cbMaxToken;
+	status = server->table->AcquireCredentialsHandle(nullptr, NTLM_PACKAGE_NAME, SECPKG_CRED_INBOUND,
+	                                                 nullptr, nullptr, nullptr, nullptr,
+	                                                 &server->credentials, &server->expiration);
+	if (status != SEC_E_OK)
+		return FALSE;
+
+	server->fContextReq = ASC_REQ_MUTUAL_AUTH | ASC_REQ_CONFIDENTIALITY | ASC_REQ_CONNECTION |
+	                      ASC_REQ_USE_SESSION_KEY | ASC_REQ_REPLAY_DETECT |
+	                      ASC_REQ_SEQUENCE_DETECT | ASC_REQ_EXTENDED_ERROR;
+	return TRUE;
+}
+
+static SECURITY_STATUS fuzz_ntlm_server_step(FUZZ_NTLM_SERVER* server)
+{
+	SECURITY_STATUS status = SEC_E_INTERNAL_ERROR;
+
+	WINPR_ASSERT(server);
+
+	free(server->outputBuffer[0].pvBuffer);
+	server->outputBuffer[0].pvBuffer = NULL;
+
+	server->inputBufferDesc.ulVersion = SECBUFFER_VERSION;
+	server->inputBufferDesc.cBuffers = ARRAYSIZE(server->inputBuffer);
+	server->inputBufferDesc.pBuffers = server->inputBuffer;
+	server->inputBuffer[0].BufferType = SECBUFFER_TOKEN;
+
+	server->outputBufferDesc.ulVersion = SECBUFFER_VERSION;
+	server->outputBufferDesc.cBuffers = ARRAYSIZE(server->outputBuffer);
+	server->outputBufferDesc.pBuffers = server->outputBuffer;
+	server->outputBuffer[0].BufferType = SECBUFFER_TOKEN;
+	server->outputBuffer[0].cbBuffer = server->cbMaxToken;
+	server->outputBuffer[0].pvBuffer = calloc(1, server->outputBuffer[0].cbBuffer);
+	if (!server->outputBuffer[0].pvBuffer)
+		return SEC_E_INSUFFICIENT_MEMORY;
+
+	status = server->table->AcceptSecurityContext(
+	    &server->credentials, server->haveContext ? &server->context : nullptr, &server->inputBufferDesc,
+	    server->fContextReq, SECURITY_NATIVE_DREP, &server->context, &server->outputBufferDesc,
+	    &server->pfContextAttr, &server->expiration);
+
+	if (!IsSecurityStatusError(status))
+		server->haveContext = TRUE;
+
+	if (status == SEC_I_CONTINUE_NEEDED)
+	{
+		SecPkgContext_AuthNtlmHash hash = WINPR_C_ARRAY_INIT;
+		hash.Version = 2;
+		CopyMemory(hash.NtlmHash, TEST_NTLM_V2_HASH, sizeof(TEST_NTLM_V2_HASH));
+		(void)server->table->SetContextAttributes(&server->context, SECPKG_ATTR_AUTH_NTLM_HASH, &hash,
+		                                          sizeof(hash));
+	}
+
+	return status;
+}
+
+static void fuzz_ntlm_set_input(SecBuffer* buffer, BOOL* haveInputBuffer, const uint8_t* data, size_t size)
+{
+	WINPR_ASSERT(buffer);
+	WINPR_ASSERT(haveInputBuffer);
+
+	buffer[0].BufferType = SECBUFFER_TOKEN;
+	buffer[0].pvBuffer = (void*)data;
+	buffer[0].cbBuffer = (ULONG)size;
+	*haveInputBuffer = TRUE;
+}
+
+static void fuzz_ntlm_negotiate(const uint8_t* data, size_t size)
+{
+	FUZZ_NTLM_SERVER server = { 0 };
+
+	if (!fuzz_ntlm_server_init(&server))
+		goto fail;
+
+	fuzz_ntlm_set_input(server.inputBuffer, &server.haveInputBuffer, data, size);
+	(void)fuzz_ntlm_server_step(&server);
+
+fail:
+	fuzz_ntlm_server_uninit(&server);
+}
+
+static void fuzz_ntlm_challenge(const uint8_t* data, size_t size)
+{
+	FUZZ_NTLM_CLIENT client = { 0 };
+
+	if (!fuzz_ntlm_client_init(&client))
+		goto fail;
+
+	if (IsSecurityStatusError(fuzz_ntlm_client_step(&client)))
+		goto fail;
+
+	fuzz_ntlm_set_input(client.inputBuffer, &client.haveInputBuffer, data, size);
+	(void)fuzz_ntlm_client_step(&client);
+
+fail:
+	fuzz_ntlm_client_uninit(&client);
+}
+
+static void fuzz_ntlm_authenticate(const uint8_t* data, size_t size)
+{
+	FUZZ_NTLM_CLIENT client = { 0 };
+	FUZZ_NTLM_SERVER server = { 0 };
+
+	if (!fuzz_ntlm_client_init(&client))
+		goto fail;
+	if (!fuzz_ntlm_server_init(&server))
+		goto fail;
+
+	if (fuzz_ntlm_client_step(&client) != SEC_I_CONTINUE_NEEDED)
+		goto fail;
+
+	fuzz_ntlm_set_input(server.inputBuffer, &server.haveInputBuffer, client.outputBuffer[0].pvBuffer,
+	                    client.outputBuffer[0].cbBuffer);
+	if (fuzz_ntlm_server_step(&server) != SEC_I_CONTINUE_NEEDED)
+		goto fail;
+
+	fuzz_ntlm_set_input(server.inputBuffer, &server.haveInputBuffer, data, size);
+	(void)fuzz_ntlm_server_step(&server);
+
+fail:
+	fuzz_ntlm_client_uninit(&client);
+	fuzz_ntlm_server_uninit(&server);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+	static BOOL loggingInitialized = FALSE;
+
+	if (!loggingInitialized)
+	{
+		(void)WLog_SetLogLevel(WLog_GetRoot(), WLOG_OFF);
+		loggingInitialized = TRUE;
+	}
+
+	if (size < 2)
+		return 0;
+	if (size > (1u << 20))
+		return 0;
+
+	switch (data[0] % 3)
+	{
+		case 0:
+			fuzz_ntlm_negotiate(data + 1, size - 1);
+			break;
+		case 1:
+			fuzz_ntlm_challenge(data + 1, size - 1);
+			break;
+		case 2:
+			fuzz_ntlm_authenticate(data + 1, size - 1);
+			break;
+	}
+
+	return 0;
+}

--- a/winpr/libwinpr/utils/test/CMakeLists.txt
+++ b/winpr/libwinpr/utils/test/CMakeLists.txt
@@ -36,12 +36,17 @@ endif()
 
 create_test_sourcelist(${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_DRIVER} ${${MODULE_PREFIX}_TESTS})
 
+set(FUZZERS TestFuzzCredSSP_Asn1.c)
+
 add_compile_definitions(TEST_SOURCE_PATH="${CMAKE_CURRENT_SOURCE_DIR}")
 add_compile_definitions(TEST_BINARY_PATH="${CMAKE_CURRENT_BINARY_DIR}")
 
 add_executable(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
 
 target_link_libraries(${MODULE_NAME} winpr)
+
+include(AddFuzzerTest)
+add_fuzzer_test("${FUZZERS}" "winpr")
 
 set_target_properties(${MODULE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${TESTING_OUTPUT_DIRECTORY}")
 

--- a/winpr/libwinpr/utils/test/TestFuzzCredSSP_Asn1.c
+++ b/winpr/libwinpr/utils/test/TestFuzzCredSSP_Asn1.c
@@ -1,0 +1,138 @@
+/**
+ * WinPR: Windows Portable Runtime
+ * libFuzzer harness for the WinPrAsn1 decoder
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <winpr/asn1.h>
+#include <winpr/crt.h>
+#include <winpr/wlog.h>
+
+static void fuzz_walk_sequence(WinPrAsn1Decoder* outer, int depth);
+
+static void fuzz_consume_one(WinPrAsn1Decoder* decoder, int depth)
+{
+	WinPrAsn1Decoder inner = WinPrAsn1Decoder_init();
+	WinPrAsn1_tag tag = 0;
+	size_t len = 0;
+
+	if (depth > 6)
+		return;
+
+	if (WinPrAsn1DecReadTagLenValue(decoder, &tag, &len, &inner) == 0)
+		return;
+
+	switch (tag & ER_TAG_MASK)
+	{
+		case ER_TAG_BOOLEAN:
+		{
+			WinPrAsn1_BOOL value = 0;
+			(void)WinPrAsn1DecReadBoolean(&inner, &value);
+			break;
+		}
+		case ER_TAG_INTEGER:
+		{
+			WinPrAsn1_INTEGER value = 0;
+			(void)WinPrAsn1DecReadInteger(&inner, &value);
+			break;
+		}
+		case ER_TAG_OCTET_STRING:
+		{
+			WinPrAsn1_OctetString value = { 0 };
+			if (WinPrAsn1DecReadOctetString(&inner, &value, TRUE))
+				WinPrAsn1FreeOctetString(&value);
+			break;
+		}
+		case ER_TAG_OBJECT_IDENTIFIER:
+		{
+			WinPrAsn1_OID value = { 0 };
+			if (WinPrAsn1DecReadOID(&inner, &value, TRUE))
+				WinPrAsn1FreeOID(&value);
+			break;
+		}
+		case ER_TAG_ENUMERATED:
+		{
+			WinPrAsn1_ENUMERATED value = 0;
+			(void)WinPrAsn1DecReadEnumerated(&inner, &value);
+			break;
+		}
+		case ER_TAG_UTCTIME:
+		{
+			WinPrAsn1_UTCTIME value = { 0 };
+			(void)WinPrAsn1DecReadUtcTime(&inner, &value);
+			break;
+		}
+		case ER_TAG_IA5STRING:
+		{
+			WinPrAsn1_IA5STRING value = NULL;
+			(void)WinPrAsn1DecReadIA5String(&inner, &value);
+			free(value);
+			break;
+		}
+		case ER_TAG_NULL:
+			(void)WinPrAsn1DecReadNull(&inner);
+			break;
+		default:
+			break;
+	}
+
+	if ((tag == ER_TAG_SEQUENCE) || (tag == ER_TAG_SET))
+		fuzz_walk_sequence(&inner, depth + 1);
+	else if ((tag & 0xC0) == 0x80)
+		fuzz_walk_sequence(&inner, depth + 1);
+}
+
+static void fuzz_walk_sequence(WinPrAsn1Decoder* outer, int depth)
+{
+	if (depth > 6)
+		return;
+
+	for (size_t index = 0; index < 64; index++)
+	{
+		WinPrAsn1_tag tag = 0;
+
+		if (!WinPrAsn1DecPeekTag(outer, &tag))
+			return;
+
+		fuzz_consume_one(outer, depth);
+	}
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+	static BOOL loggingInitialized = FALSE;
+
+	if (!loggingInitialized)
+	{
+		(void)WLog_SetLogLevel(WLog_GetRoot(), WLOG_OFF);
+		loggingInitialized = TRUE;
+	}
+
+	if ((size == 0) || (size > (1u << 20)))
+		return 0;
+
+	{
+		WinPrAsn1Decoder decoder = WinPrAsn1Decoder_init();
+		WinPrAsn1Decoder_InitMem(&decoder, WINPR_ASN1_DER, data, size);
+		fuzz_walk_sequence(&decoder, 0);
+	}
+
+	{
+		WinPrAsn1Decoder decoder = WinPrAsn1Decoder_init();
+		WinPrAsn1Decoder_InitMem(&decoder, WINPR_ASN1_BER, data, size);
+		fuzz_walk_sequence(&decoder, 0);
+	}
+
+	{
+		WinPrAsn1Decoder decoder = WinPrAsn1Decoder_init();
+		WinPrAsn1Decoder sequence = WinPrAsn1Decoder_init();
+
+		WinPrAsn1Decoder_InitMem(&decoder, WINPR_ASN1_DER, data, size);
+		if (WinPrAsn1DecReadSequence(&decoder, &sequence))
+			fuzz_walk_sequence(&sequence, 1);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Follow-up to #12603.

This adds five libFuzzer harnesses and wires them into `BUILD_FUZZERS`:
- `TestFuzzNSCodec`
- `TestFuzzCredSSP_Asn1`
- `TestFuzzNTLMMessage`
- `TestFuzzChannelCliprdr`
- `TestFuzzDrdynvc`

Notes:
- `cliprdr` and `drdynvc` get fuzz-only `client/test/` directories.
- The NTLM harness uses the SSPI lifecycle instead of calling the raw parser/free path directly.
- The cliprdr harness targets the reader entrypoints present on current `master`.

Validation:
- `CCACHE_DISABLE=1 cmake --build build-fuzz-review --target TestFuzzNSCodec TestFuzzCredSSP_Asn1 TestFuzzNTLMMessage TestFuzzChannelCliprdr TestFuzzDrdynvc -j8`
- `./Testing/TestFuzzNSCodec /tmp/empty-corpus-fuzz-review -runs=0`
- `./Testing/TestFuzzCredSSP_Asn1 /tmp/empty-corpus-fuzz-review -runs=0`
- `./Testing/TestFuzzNTLMMessage /tmp/empty-corpus-fuzz-review -runs=0`
- `./Testing/TestFuzzChannelCliprdr /tmp/empty-corpus-fuzz-review -runs=0`
- `./Testing/TestFuzzDrdynvc /tmp/empty-corpus-fuzz-review -runs=0`