### PR TITLE
fix: clear is_primary on non-primary monitors in sorted array

### DIFF
--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -2575,6 +2575,7 @@ BOOL freerdp_settings_set_monitor_def_array_sorted(rdpSettings* settings,
 		rdpMonitor m = monitors[x];
 		m.x -= offsetX;
 		m.y -= offsetY;
+		m.is_primary = FALSE;
 		sorted[sortpos++] = m;
 	}
 


### PR DESCRIPTION
## Problem

`freerdp_settings_set_monitor_def_array_sorted` copies the selected primary monitor to `sorted[0]` with `is_primary=TRUE`, then copies the remaining monitors. If another monitor in the input array also had `is_primary=TRUE`, that flag is preserved in the copy, resulting in multiple monitors marked as primary.

This triggers:
```
Monitor configuration contains multiple primary monitors!
```
and aborts the connection.

## Fix

Clear `is_primary` on all non-primary monitors when building the sorted array. One-line change.

## Reproduction

This can happen when a client overrides which monitor is primary (e.g. selecting a subset of monitors with `/monitors:` that doesn't include the original SDL primary, or when a future mechanism allows the user to choose which monitor is primary).