### PR TITLE
fix(sdl): BFS neighbor walk pop/begin mismatch in addOrUpdateDisplay

### DIFF
--- a/client/SDL/SDL3/sdl_context.cpp
+++ b/client/SDL/SDL3/sdl_context.cpp
@@ -1235,8 +1235,8 @@ void SdlContext::addOrUpdateDisplay(SDL_DisplayID id)
 	auto neighbors = updateDisplayOffsetsForNeighbours(primary);
 	while (!neighbors.empty())
 	{
-		auto neighbor = *neighbors.begin();
-		neighbors.pop_back();
+		auto neighbor = neighbors.front();
+		neighbors.erase(neighbors.begin());
 
 		if (std::find(handled.begin(), handled.end(), neighbor) != handled.end())
 			continue;


### PR DESCRIPTION
## Problem

`SdlContext::addOrUpdateDisplay()` in `client/SDL/SDL3/sdl_context.cpp` walks the monitor-neighbor graph BFS-style to propagate pixel coordinates. The loop reads from the front via `neighbors.begin()` but pops from the back via `neighbors.pop_back()`:

```cpp
while (!neighbors.empty())
{
    auto neighbor = *neighbors.begin();  // read front
    neighbors.pop_back();                // remove back
    ...
}
```

When the queue has more than one item these are different elements — the last item is silently discarded while the front is re-read. Some monitors never become the "current" node, so their neighbors' pixel offsets never get propagated.

## Symptom

On setups with 3+ externally-arranged monitors, a monitor further down the chain from the primary ends up with `pixel_x = 0` (inherited from default) and the RDP connection fails with:

```
Monitor configuration has gaps!
Monitor configuration has overlapping areas
Mulitimonitor mode requested, but local layout has gaps or overlapping areas!
```

Confirmed with 3 external 1920×1080 monitors arranged horizontally — only monitors 0 and 1 got correct positions; monitor 2 was stuck at (0,0) and overlapped monitor 0.

## Fix

Erase from the front to match the front read. Proper BFS. Two-line change.