### PR TITLE
fix(sdl): skip cursor alt image when server pre-scales for HiDPI

### DIFF
--- a/client/SDL/SDL3/sdl_pointer.cpp
+++ b/client/SDL/SDL3/sdl_pointer.cpp
@@ -193,10 +193,20 @@ bool sdl_Pointer_Set_Process(SdlContext* sdl)
 		WLog_Print(sdl->getWLog(), WLOG_ERROR, "SDL_BlitSurfaceScaled failed");
 		return false;
 	}
-	if (!SDL_AddSurfaceAlternateImage(normal.get(), ptr->image))
+	// When the server pre-scales the cursor (desktopScaleFactor > 100),
+	// the original image is already at 2x (or more) size. Adding it as an
+	// alternate image would cause SDL to double-scale on HiDPI displays —
+	// the cursor ends up at 2x the correct physical size. Skip the alt
+	// image in that case and let SDL upscale the logical-size surface.
+	const UINT32 desktopScale =
+	    freerdp_settings_get_uint32(context->settings, FreeRDP_DesktopScaleFactor);
+	if (desktopScale <= 100)
 	{
-		WLog_Print(sdl->getWLog(), WLOG_ERROR, "SDL_AddSurfaceAlternateImage failed");
-		return false;
+		if (!SDL_AddSurfaceAlternateImage(normal.get(), ptr->image))
+		{
+			WLog_Print(sdl->getWLog(), WLOG_ERROR, "SDL_AddSurfaceAlternateImage failed");
+			return false;
+		}
 	}
 
 	auto x = static_cast<int>(pos.x);


### PR DESCRIPTION
## Problem

When `desktopScaleFactor > 100` (e.g. `/scale-desktop:200`), the RDP server pre-scales cursor bitmaps — a 32×32 base cursor becomes 64×64 at 200% DPI. The current code in `sdl_Pointer_Set_Process` adds this pre-scaled original as `SDL_AddSurfaceAlternateImage` on the downscaled "normal" surface:

```cpp
SDL_BlitSurfaceScaled(ptr->image, nullptr, normal.get(), nullptr, LINEAR);
SDL_AddSurfaceAlternateImage(normal.get(), ptr->image);  // alt = pre-scaled original
```

SDL treats the alternate image as the higher-density version to use for HiDPI rendering. It then applies its own display pixel density scaling on top, so the final cursor ends up 2× larger than it should be.

## Symptom

On a scale-2 HiDPI display (e.g. a 2880×1800 laptop at 200% scale in the compositor) with `/scale-desktop:200` (so Windows uses 200% UI scaling to match), the mouse cursor renders at 2× the size of a native OS cursor — clearly oversized.

## Fix

When `desktopScaleFactor > 100`, the server is already scaling the cursor bitmap. Skip `SDL_AddSurfaceAlternateImage` — SDL's own HiDPI upscaling of the logical-size "normal" surface is sufficient, and produces a cursor at the correct physical size.

Small, targeted change (10 lines + comment). Default behavior (`desktopScaleFactor = 100`) is unchanged — the alt image is still added.

## Testing

- 2880×1800 HiDPI laptop at compositor scale 2.0 with `/scale-desktop:200`:
  - Before: cursor is visibly 2× native size.
  - After: cursor matches native OS cursor size.
- 1920×1080 external at scale 1.0 (no `/scale-desktop`): unchanged.