### PR TITLE
fix: promote first monitor as primary when subset excludes original primary

### DIFF
--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -2540,8 +2540,14 @@ BOOL freerdp_settings_set_monitor_def_array_sorted(rdpSettings* settings,
 
 	if (!primary)
 	{
-		WLog_ERR(TAG, "Could not find primary monitor, aborting");
-		return FALSE;
+		/* No monitor in the supplied array is marked primary, and none
+		 * is at origin (0,0). This happens when callers select a subset
+		 * of monitors via /monitors: that excludes the originally-primary
+		 * one. Promote the first entry rather than aborting so such
+		 * selections still work.
+		 */
+		WLog_WARN(TAG, "No primary monitor found in supplied array, using first entry as primary");
+		primary = &monitors[0];
 	}
 
 	if (!freerdp_settings_set_pointer_len(settings, FreeRDP_MonitorDefArray, nullptr, count))


### PR DESCRIPTION
## Problem

`freerdp_settings_set_monitor_def_array_sorted()` requires the supplied `monitors[]` array to contain a monitor marked `is_primary=TRUE` (or one at origin 0,0). If neither is found, the function aborts:

```
Could not find primary monitor, aborting
```

This breaks a legitimate CLI use case: when a user selects a subset of monitors via `/monitors:` and that subset happens to exclude the originally-primary display.

## Concrete example

4-display setup, display `3` is the SDL-detected primary:

```
sdl3-freerdp /v:host /multimon /monitors:4,5
```

Monitors 4 and 5 are a perfectly valid user selection. No per-monitor metadata is broken. But the sort function rejects the input because neither monitor 4 nor 5 is marked primary. The user has no way to proceed without including monitor 3 — even if they don't want to use it for the RDP session.

## Not "user error"

I want to distinguish this from the duplicate-primary case. If a caller passes two monitors with `is_primary=TRUE`, that is indeed malformed input. This PR doesn't touch that.

The case here is: caller passes a **non-empty, internally-consistent** array where zero monitors are marked primary. The array is valid — the caller just doesn't have an opinion on which one is the primary. Having the function silently pick one (the first) is better than forcing every caller to include the SDL-detected primary in their selection.

## Fix

Promote the first monitor in the array to primary if nothing else matches. One-line change plus a `WLog_WARN` so users can see it happened.

Callers that already pass a well-formed primary are unaffected.

## Prior discussion

This was previously part of PR #12611, which was closed due to conflating this fix with a separate change around duplicate-primary handling. This PR strictly addresses the "no primary in selection" case.