### PR TITLE
fix(sdl): promote first monitor as primary when subset excludes primary

### DIFF
--- a/client/SDL/SDL3/sdl_context.cpp
+++ b/client/SDL/SDL3/sdl_context.cpp
@@ -448,6 +448,13 @@ bool SdlContext::updateWindowList()
 	for (const auto& win : _windows)
 		list.push_back(win.second.monitor(_windows.size() == 1));
 
+	// /monitors: subset may exclude the SDL primary. The library requires
+	// the array to mark one monitor as primary, so promote the first when
+	// none of the kept windows cover the original primary.
+	if (!list.empty() && std::none_of(list.cbegin(), list.cend(),
+	                                  [](const rdpMonitor& m) { return m.is_primary; }))
+		list[0].is_primary = true;
+
 	return freerdp_settings_set_monitor_def_array_sorted(context()->settings, list.data(),
 	                                                     list.size());
 }

--- a/client/SDL/SDL3/sdl_context.cpp
+++ b/client/SDL/SDL3/sdl_context.cpp
@@ -451,8 +451,8 @@ bool SdlContext::updateWindowList()
 	// /monitors: subset may exclude the SDL primary. The library requires
 	// the array to mark one monitor as primary, so promote the first when
 	// none of the kept windows cover the original primary.
-	if (!list.empty() && std::none_of(list.cbegin(), list.cend(),
-	                                  [](const rdpMonitor& m) { return m.is_primary; }))
+	if (!list.empty() &&
+	    std::none_of(list.cbegin(), list.cend(), [](const rdpMonitor& m) { return m.is_primary; }))
 		list[0].is_primary = true;
 
 	return freerdp_settings_set_monitor_def_array_sorted(context()->settings, list.data(),

--- a/client/SDL/SDL3/sdl_monitor.cpp
+++ b/client/SDL/SDL3/sdl_monitor.cpp
@@ -203,6 +203,13 @@ int sdl_list_monitors([[maybe_unused]] SdlContext* sdl)
 		const auto monitor = sdl->getDisplay(id);
 		monitors.emplace_back(monitor);
 	}
+	// /monitors: may select a subset that excludes the SDL primary. The
+	// library rejects arrays without a primary, so promote the first entry
+	// when none is marked.
+	if (!monitors.empty() &&
+	    std::none_of(monitors.cbegin(), monitors.cend(),
+	                 [](const rdpMonitor& m) { return m.is_primary; }))
+		monitors[0].is_primary = true;
 	return freerdp_settings_set_monitor_def_array_sorted(settings, monitors.data(),
 	                                                     monitors.size());
 }

--- a/client/SDL/SDL3/sdl_monitor.cpp
+++ b/client/SDL/SDL3/sdl_monitor.cpp
@@ -206,9 +206,8 @@ int sdl_list_monitors([[maybe_unused]] SdlContext* sdl)
 	// /monitors: may select a subset that excludes the SDL primary. The
 	// library rejects arrays without a primary, so promote the first entry
 	// when none is marked.
-	if (!monitors.empty() &&
-	    std::none_of(monitors.cbegin(), monitors.cend(),
-	                 [](const rdpMonitor& m) { return m.is_primary; }))
+	if (!monitors.empty() && std::none_of(monitors.cbegin(), monitors.cend(),
+	                                      [](const rdpMonitor& m) { return m.is_primary; }))
 		monitors[0].is_primary = true;
 	return freerdp_settings_set_monitor_def_array_sorted(settings, monitors.data(),
 	                                                     monitors.size());

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -339,7 +339,7 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  nullptr, "[DEPRECATED, use /list:monitor] List detected monitors" },
 #endif
 	{ "monitors", COMMAND_LINE_VALUE_REQUIRED, "<id>[,<id>[,...]]", nullptr, nullptr, -1, nullptr,
-	  "Select monitors to use (only effective in fullscreen or multimonitor mode)" },
+	  "[experimental] Select monitors to use (only effective in fullscreen or multimonitor mode)" },
 	{ "mouse-motion", COMMAND_LINE_VALUE_BOOL, nullptr, BoolValueTrue, nullptr, -1, nullptr,
 	  "Send mouse motion events" },
 	{ "mouse-relative", COMMAND_LINE_VALUE_BOOL, nullptr, BoolValueFalse, nullptr, -1, nullptr,


### PR DESCRIPTION
This is a rework of #12617, which you rejected with the (correct) note
that primary selection is the caller's responsibility, not the library's.

## Problem

When the SDL client is invoked with `/monitors:a,b` where the selected
IDs happen to exclude the SDL primary display,
`freerdp_settings_set_monitor_def_array_sorted` aborts with
"Could not find primary monitor" — even though the subset is otherwise
well-formed.

## Fix

Move the fix from the library into the caller, as you suggested.
In both call sites in the SDL3 client
(`sdl_apply_display_properties` and `SdlContext::updateWindowList`),
after building the monitor vector, promote `monitors[0].is_primary = true`
if none of the selected entries is marked primary.

The library contract is preserved exactly: callers that pass a primary
see no change in behavior; callers that build a subset now always
provide a valid array.

## Why SDL3-only

`client/SDL/SDL2/sdl_monitor.cpp` sets `is_primary = x == 0` while
iterating, so the first iteration in SDL2 always yields a primary.
SDL3 uses the SDL display's intrinsic primary flag, which can be
false for every display in a `/monitors:` subset — hence the SDL3
callers need the explicit guard.

## Test

Reproduced with the SDL3 client on a 4-display setup (display 3
is SDL primary): `sdl-freerdp /multimon /monitors:0,1 ...`
previously aborted in preConnect; with this patch the two selected
monitors are used and monitor 0 is marked primary.