### PR TITLE
[client,Windows] optimize floatbar positioning and visibility behavior

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -1216,7 +1216,7 @@ static DWORD WINAPI wf_client_thread(LPVOID lpParam)
 		DWORD wait_result;
 
 		/* Start disconnection in a separate thread to prevent hang on laggy networks */
-		disconnect_thread = CreateThread(NULL, 0, wf_disconnect_thread, instance, 0, NULL);
+		disconnect_thread = CreateThread(nullptr, 0, wf_disconnect_thread, instance, 0, nullptr);
 		if (disconnect_thread)
 		{
 			/* Wait for 2 seconds, if timeout, give up and exit */
@@ -1603,7 +1603,7 @@ static int wfreerdp_client_stop(rdpContext* context)
 			TerminateThread(wfc->keyboardThread, 1);
 		}
 		(void)CloseHandle(wfc->keyboardThread);
-		wfc->keyboardThread = NULL;
+		wfc->keyboardThread = nullptr;
 		wfc->keyboardThreadId = 0;
 	}
 

--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -225,6 +225,9 @@ static BOOL wf_desktop_resize(rdpContext* context)
 		InvalidateRect(wfc->hwnd, &rect, TRUE);
 	}
 
+	if (wfc->floatbar)
+		wf_floatbar_reset_position(wfc->floatbar);
+
 	return TRUE;
 }
 
@@ -515,6 +518,25 @@ static void wf_post_disconnect(freerdp* instance)
 
 	wfc = (wfContext*)instance->context;
 	free(wfc->window_title);
+	wfc->window_title = NULL;
+
+	if (wfc->floatbar)
+	{
+		wf_floatbar_free(wfc->floatbar);
+		wfc->floatbar = NULL;
+	}
+
+	if (instance->context->gdi)
+	{
+		gdi_free(instance);
+	}
+
+	if (wfc->primary)
+	{
+		wf_image_free(wfc->primary);
+		wfc->primary = NULL;
+		wfc->drawing = NULL;
+	}
 }
 
 static CREDUI_INFOW wfUiInfo = { sizeof(CREDUI_INFOW), nullptr, L"Enter your credentials",
@@ -663,34 +685,33 @@ static BOOL wf_authenticate_ex(freerdp* instance, char** username, char** passwo
 
 static WCHAR* wf_format_text(const WCHAR* fmt, ...)
 {
-	int rc;
-	size_t size = 0;
-	WCHAR* buffer = nullptr;
+	int required;
+	size_t size;
+	WCHAR* buffer = NULL;
+	va_list ap;
 
-	do
+	va_start(ap, fmt);
+	required = _vscwprintf(fmt, ap);
+	va_end(ap);
+
+	if (required < 0)
+		return NULL;
+
+	size = (size_t)required + 1;
+	buffer = (WCHAR*)calloc(size, sizeof(WCHAR));
+
+	if (!buffer)
+		return NULL;
+
+	va_start(ap, fmt);
+	if (_vsnwprintf(buffer, size, fmt, ap) < 0)
 	{
-		WCHAR* tmp = nullptr;
-		va_list ap = WINPR_C_ARRAY_INIT;
-		va_start(ap, fmt);
-		rc = _vsnwprintf(buffer, size, fmt, ap);
 		va_end(ap);
-		if (rc <= 0)
-			goto fail;
-
-		if ((size_t)rc < size)
-			return buffer;
-
-		size = (size_t)rc + 1;
-		tmp = realloc(buffer, size * sizeof(WCHAR));
-		if (!tmp)
-			goto fail;
-
-		buffer = tmp;
-	} while (TRUE);
-
-fail:
-	free(buffer);
-	return nullptr;
+		free(buffer);
+		return NULL;
+	}
+	va_end(ap);
+	return buffer;
 }
 
 #ifdef WITH_WINDOWS_CERT_STORE
@@ -1054,6 +1075,13 @@ static BOOL wf_present_gateway_message(freerdp* instance, UINT32 type, BOOL isDi
 	return TRUE;
 }
 
+static DWORD WINAPI wf_disconnect_thread(LPVOID lpParam)
+{
+	freerdp* instance = (freerdp*)lpParam;
+	freerdp_disconnect(instance);
+	return 0;
+}
+
 static DWORD WINAPI wf_client_thread(LPVOID lpParam)
 {
 	MSG msg = WINPR_C_ARRAY_INIT;
@@ -1151,6 +1179,8 @@ static DWORD WINAPI wf_client_thread(LPVOID lpParam)
 					width = LOWORD(msg.lParam);
 					height = HIWORD(msg.lParam);
 					SetWindowPos(wfc->hwnd, HWND_TOP, 0, 0, width, height, SWP_FRAMECHANGED);
+					if (wfc->floatbar)
+						wf_floatbar_reset_position(wfc->floatbar);
 					break;
 				}
 				case WM_FREERDP_SHOWWINDOW:
@@ -1181,7 +1211,30 @@ static DWORD WINAPI wf_client_thread(LPVOID lpParam)
 	}
 
 	/* cleanup */
-	freerdp_disconnect(instance);
+	{
+		HANDLE disconnect_thread;
+		DWORD wait_result;
+
+		/* Start disconnection in a separate thread to prevent hang on laggy networks */
+		disconnect_thread = CreateThread(NULL, 0, wf_disconnect_thread, instance, 0, NULL);
+		if (disconnect_thread)
+		{
+			/* Wait for 2 seconds, if timeout, give up and exit */
+			wait_result = WaitForSingleObject(disconnect_thread, 2000);
+			if (wait_result == WAIT_TIMEOUT)
+			{
+				WLog_WARN(TAG, "Disconnection timed out (2s), abandoning connection");
+				TerminateThread(disconnect_thread, 1);
+			}
+			CloseHandle(disconnect_thread);
+		}
+		else
+		{
+			/* Fallback to sync disconnect if thread creation fails */
+			WLog_WARN(TAG, "Failed to create disconnect thread, using sync disconnect");
+			freerdp_disconnect(instance);
+		}
+	}
 
 end:
 	error = freerdp_get_last_error(instance->context);
@@ -1407,6 +1460,8 @@ static BOOL wfreerdp_client_new(freerdp* instance, rdpContext* context)
 	if (!(wfreerdp_client_global_init()))
 		return FALSE;
 
+	wf_event_init();
+
 	WINPR_ASSERT(instance);
 	instance->PreConnect = wf_pre_connect;
 	instance->PostConnect = wf_post_connect;
@@ -1443,6 +1498,8 @@ static void wfreerdp_client_free(freerdp* instance, rdpContext* context)
 #ifdef WITH_PROGRESS_BAR
 	CoUninitialize();
 #endif
+
+	wf_event_uninit();
 }
 
 static int wfreerdp_client_start(rdpContext* context)
@@ -1537,10 +1594,16 @@ static int wfreerdp_client_stop(rdpContext* context)
 
 	if (wfc->keyboardThread)
 	{
+		DWORD wait_result;
 		PostThreadMessage(wfc->keyboardThreadId, WM_QUIT, 0, 0);
-		(void)WaitForSingleObject(wfc->keyboardThread, INFINITE);
+		wait_result = WaitForSingleObject(wfc->keyboardThread, 1000);
+		if (wait_result == WAIT_TIMEOUT)
+		{
+			WLog_ERR(TAG, "Keyboard thread cleanup timeout, terminating");
+			TerminateThread(wfc->keyboardThread, 1);
+		}
 		(void)CloseHandle(wfc->keyboardThread);
-		wfc->keyboardThread = nullptr;
+		wfc->keyboardThread = NULL;
 		wfc->keyboardThreadId = 0;
 	}
 

--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -112,9 +112,9 @@ LRESULT CALLBACK wf_ll_kbd_proc(int nCode, WPARAM wParam, LPARAM lParam)
 	{
 		if (!IsWindow(g_main_hWnd))
 		{
-			g_main_hWnd = NULL;
-			g_focus_hWnd = NULL;
-			return CallNextHookEx(NULL, nCode, wParam, lParam);
+			g_main_hWnd = nullptr;
+			g_focus_hWnd = nullptr;
+			return CallNextHookEx(nullptr, nCode, wParam, lParam);
 		}
 
 		wfc = (wfContext*)GetWindowLongPtr(g_main_hWnd, GWLP_USERDATA);
@@ -122,7 +122,7 @@ LRESULT CALLBACK wf_ll_kbd_proc(int nCode, WPARAM wParam, LPARAM lParam)
 		if (!wfc || !wfc->common.context.instance ||
 		    freerdp_shall_disconnect_context(&wfc->common.context))
 		{
-			return CallNextHookEx(NULL, nCode, wParam, lParam);
+			return CallNextHookEx(nullptr, nCode, wParam, lParam);
 		}
 
 		GUITHREADINFO gui_thread_info;
@@ -157,7 +157,7 @@ LRESULT CALLBACK wf_ll_kbd_proc(int nCode, WPARAM wParam, LPARAM lParam)
 				if (!wfc->common.context.instance ||
 				    freerdp_shall_disconnect_context(&wfc->common.context))
 				{
-					return CallNextHookEx(NULL, nCode, wParam, lParam);
+					return CallNextHookEx(nullptr, nCode, wParam, lParam);
 				}
 
 				input = wfc->common.context.input;

--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -39,6 +39,17 @@
 static HWND g_focus_hWnd = nullptr;
 static HWND g_main_hWnd = nullptr;
 static HWND g_parent_hWnd = nullptr;
+static CRITICAL_SECTION g_event_cs;
+
+void wf_event_init(void)
+{
+	InitializeCriticalSection(&g_event_cs);
+}
+
+void wf_event_uninit(void)
+{
+	DeleteCriticalSection(&g_event_cs);
+}
 
 #define RESIZE_MIN_DELAY 200 /* minimum delay in ms between two resizes */
 
@@ -57,13 +68,24 @@ static BOOL g_keystates[256] = WINPR_C_ARRAY_INIT;
 
 static BOOL ctrl_down(void)
 {
-	return g_keystates[VK_CONTROL] || g_keystates[VK_LCONTROL] || g_keystates[VK_RCONTROL];
+	BOOL down;
+	EnterCriticalSection(&g_event_cs);
+	down = g_keystates[VK_CONTROL] || g_keystates[VK_LCONTROL] || g_keystates[VK_RCONTROL];
+	LeaveCriticalSection(&g_event_cs);
+	return down;
 }
 
 static BOOL alt_ctrl_down(void)
 {
-	const BOOL altDown = g_keystates[VK_MENU] || g_keystates[VK_LMENU] || g_keystates[VK_RMENU];
-	return altDown && ctrl_down();
+	BOOL altDown;
+	BOOL ctrlDown;
+
+	EnterCriticalSection(&g_event_cs);
+	altDown = g_keystates[VK_MENU] || g_keystates[VK_LMENU] || g_keystates[VK_RMENU];
+	ctrlDown = g_keystates[VK_CONTROL] || g_keystates[VK_LCONTROL] || g_keystates[VK_RCONTROL];
+	LeaveCriticalSection(&g_event_cs);
+
+	return altDown && ctrlDown;
 }
 
 LRESULT CALLBACK wf_ll_kbd_proc(int nCode, WPARAM wParam, LPARAM lParam)
@@ -88,7 +110,21 @@ LRESULT CALLBACK wf_ll_kbd_proc(int nCode, WPARAM wParam, LPARAM lParam)
 
 	if (g_parent_hWnd && g_main_hWnd)
 	{
+		if (!IsWindow(g_main_hWnd))
+		{
+			g_main_hWnd = NULL;
+			g_focus_hWnd = NULL;
+			return CallNextHookEx(NULL, nCode, wParam, lParam);
+		}
+
 		wfc = (wfContext*)GetWindowLongPtr(g_main_hWnd, GWLP_USERDATA);
+
+		if (!wfc || !wfc->common.context.instance ||
+		    freerdp_shall_disconnect_context(&wfc->common.context))
+		{
+			return CallNextHookEx(NULL, nCode, wParam, lParam);
+		}
+
 		GUITHREADINFO gui_thread_info;
 		gui_thread_info.cbSize = sizeof(GUITHREADINFO);
 		HWND fg_win_hwnd = GetForegroundWindow();
@@ -118,22 +154,32 @@ LRESULT CALLBACK wf_ll_kbd_proc(int nCode, WPARAM wParam, LPARAM lParam)
 				if (!wfc || !p)
 					return 1;
 
+				if (!wfc->common.context.instance ||
+				    freerdp_shall_disconnect_context(&wfc->common.context))
+				{
+					return CallNextHookEx(NULL, nCode, wParam, lParam);
+				}
+
 				input = wfc->common.context.input;
 				rdp_scancode = MAKE_RDP_SCANCODE((BYTE)p->scanCode, p->flags & LLKHF_EXTENDED);
-				keystate = g_keystates[p->scanCode & 0xFF];
+				EnterCriticalSection(&g_event_cs);
+				keystate = (p->vkCode < ARRAYSIZE(g_keystates)) ? g_keystates[p->vkCode] : FALSE;
 
 				switch (wParam)
 				{
 					case WM_KEYDOWN:
 					case WM_SYSKEYDOWN:
-						g_keystates[p->scanCode & 0xFF] = TRUE;
+						if (p->vkCode < ARRAYSIZE(g_keystates))
+							g_keystates[p->vkCode] = TRUE;
 						break;
 					case WM_KEYUP:
 					case WM_SYSKEYUP:
 					default:
-						g_keystates[p->scanCode & 0xFF] = FALSE;
+						if (p->vkCode < ARRAYSIZE(g_keystates))
+							g_keystates[p->vkCode] = FALSE;
 						break;
 				}
+				LeaveCriticalSection(&g_event_cs);
 				DEBUG_KBD("keydown %d scanCode 0x%08lX flags 0x%08lX vkCode 0x%08lX",
 				          (wParam == WM_KEYDOWN), p->scanCode, p->flags, p->vkCode);
 
@@ -256,21 +302,37 @@ static BOOL wf_event_process_WM_MOUSEWHEEL(wfContext* wfc, HWND hWnd, UINT Msg, 
 	WINPR_ASSERT(input);
 
 	DefWindowProc(hWnd, Msg, wParam, lParam);
-	delta = ((signed short)HIWORD(wParam)); /* GET_WHEEL_DELTA_WPARAM(wParam); */
+	delta = ((signed short)HIWORD(wParam));
 
 	if (horizontal)
 		flags |= PTR_FLAGS_HWHEEL;
 	else
 		flags |= PTR_FLAGS_WHEEL;
 
+	BOOL negative = FALSE;
 	if (delta < 0)
 	{
+		negative = TRUE;
 		flags |= PTR_FLAGS_WHEEL_NEGATIVE;
-		/* 9bit twos complement, delta already negative */
-		delta = 0x100 + delta;
+		delta = -delta;
 	}
 
-	flags |= delta;
+	{
+		unsigned int cval = (unsigned int)delta;
+
+		if (cval == 0)
+			cval = 1;
+
+		if (cval > 0xFF)
+			cval = 0xFF;
+
+		UINT16 val = (UINT16)cval;
+
+		if (negative)
+			val = (UINT16)(0x100 - val);
+
+		flags |= (val & 0xFF);
+	}
 	return wf_scale_mouse_event(wfc, flags, x, y);
 }
 
@@ -404,6 +466,9 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 					wfc->client_y = y;
 				}
 
+				if (wfc->floatbar)
+					wf_floatbar_reset_position(wfc->floatbar);
+
 				break;
 
 			case WM_GETMINMAXINFO:
@@ -480,11 +545,16 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 					}
 				}
 
+				if (wfc->floatbar)
+					wf_floatbar_reset_position(wfc->floatbar);
+
 				break;
 
 			case WM_EXITSIZEMOVE:
 				wf_size_scrollbars(wfc, wfc->client_width, wfc->client_height);
 				wf_send_resize(wfc);
+				if (wfc->floatbar)
+					wf_floatbar_reset_position(wfc->floatbar);
 				break;
 
 			case WM_ERASEBKGND:
@@ -775,6 +845,10 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 
 	switch (Msg)
 	{
+		case WM_CLOSE:
+			DestroyWindow(hWnd);
+			break;
+
 		case WM_DESTROY:
 			PostQuitMessage(WM_QUIT);
 			break;

--- a/client/Windows/wf_floatbar.c
+++ b/client/Windows/wf_floatbar.c
@@ -19,6 +19,8 @@
 
 #include <winpr/crt.h>
 #include <winpr/windows.h>
+#include <windowsx.h>
+#include <wchar.h>
 
 #include "wf_client.h"
 #include "wf_floatbar.h"
@@ -31,20 +33,20 @@
 
 #define TAG CLIENT_TAG("windows.floatbar")
 
-/* TIMERs */
 #define TIMER_HIDE 1
-#define TIMER_ANIMAT_SHOW 2
-#define TIMER_ANIMAT_HIDE 3
+#define TIMER_SHOW 2
 
-/* Button Type */
+#define FLOATBAR_PEEK_HEIGHT 2
+#define FLOATBAR_MIN_WIDTH 576
+#define FLOATBAR_TEXT_RIGHT_PAD 104
+#define FLOATBAR_MAX_MARGIN 20
+
 #define BUTTON_LOCKPIN 0
 #define BUTTON_MINIMIZE 1
 #define BUTTON_RESTORE 2
 #define BUTTON_CLOSE 3
 #define BTN_MAX 4
 
-/* bmp size */
-#define BACKGROUND_W 576
 #define BACKGROUND_H 27
 #define BUTTON_OFFSET 5
 #define BUTTON_Y 2
@@ -53,26 +55,24 @@
 #define BUTTON_SPACING 1
 
 #define LOCK_X (BACKGROUND_H + BUTTON_OFFSET)
-#define CLOSE_X ((BACKGROUND_W - (BACKGROUND_H + BUTTON_OFFSET)) - BUTTON_WIDTH)
-#define RESTORE_X (CLOSE_X - (BUTTON_WIDTH + BUTTON_SPACING))
-#define MINIMIZE_X (RESTORE_X - (BUTTON_WIDTH + BUTTON_SPACING))
 #define TEXT_X (BACKGROUND_H + ((BUTTON_WIDTH + BUTTON_SPACING) * 3) + 5)
 
 typedef struct
 {
 	wfFloatBar* floatbar;
 	int type;
-	int x, y, h, w;
-	int active;
+	int x;
+	int y;
+	int w;
+	int h;
+	BOOL active;
 	HBITMAP bmp;
 	HBITMAP bmp_act;
-
-	/* Lock Specified */
 	HBITMAP locked_bmp;
 	HBITMAP locked_bmp_act;
 	HBITMAP unlocked_bmp;
 	HBITMAP unlocked_bmp_act;
-} Button;
+} FloatbarButton;
 
 struct s_FloatBar
 {
@@ -81,54 +81,200 @@ struct s_FloatBar
 	HWND parent;
 	HWND hwnd;
 	RECT rect;
+	RECT textRect;
 	LONG width;
 	LONG height;
-	LONG offset;
 	wfContext* wfc;
-	Button* buttons[BTN_MAX];
+	FloatbarButton* buttons[BTN_MAX];
+	FloatbarButton* hoverButton;
 	BOOL shown;
 	BOOL locked;
+	BOOL mouseInside;
 	HDC hdcmem;
-	RECT textRect;
-	UINT_PTR animating;
+	HFONT titleFont;
 };
 
-static BOOL floatbar_kill_timers(wfFloatBar* floatbar)
+static BOOL floatbar_is_visible_in_mode(const wfFloatBar* floatbar, BOOL fullscreen)
 {
-	UINT_PTR timers[] = { TIMER_HIDE, TIMER_ANIMAT_HIDE, TIMER_ANIMAT_SHOW };
+	const BOOL showFs = (floatbar->flags & 0x0010) != 0;
+	const BOOL showWn = (floatbar->flags & 0x0020) != 0;
+	return (showFs && fullscreen) || (showWn && !fullscreen);
+}
 
-	if (!floatbar)
+static BOOL floatbar_parent_rect(const wfFloatBar* floatbar, RECT* rect)
+{
+	POINT origin = { 0 };
+
+	if (!floatbar || !floatbar->parent || !rect)
 		return FALSE;
 
-	for (size_t x = 0; x < ARRAYSIZE(timers); x++)
-		KillTimer(floatbar->hwnd, timers[x]);
+	if (!GetClientRect(floatbar->parent, rect))
+		return FALSE;
 
-	floatbar->animating = 0;
+	if (!ClientToScreen(floatbar->parent, &origin))
+		return FALSE;
+
+	OffsetRect(rect, origin.x, origin.y);
 	return TRUE;
 }
 
-static BOOL floatbar_animation(wfFloatBar* const floatbar, const BOOL show)
+static LONG floatbar_measure_title_width(wfFloatBar* floatbar)
 {
-	UINT_PTR timer = show ? TIMER_ANIMAT_SHOW : TIMER_ANIMAT_HIDE;
+	const WCHAR* title;
+	HDC hdc = NULL;
+	HGDIOBJECT oldFont = NULL;
+	SIZE size = { 0 };
+	LONG width = 0;
+
+	if (!floatbar || !floatbar->parent || !floatbar->wfc)
+		return 0;
+
+	title = floatbar->wfc->window_title;
+	if (!title)
+		return 0;
+
+	hdc = GetDC(floatbar->parent);
+	if (!hdc)
+		return 0;
+
+	if (floatbar->titleFont)
+		oldFont = SelectObject(hdc, floatbar->titleFont);
+
+	if (GetTextExtentPoint32W(hdc, title, (int)wcslen(title), &size))
+		width = size.cx;
+
+	if (oldFont)
+		SelectObject(hdc, oldFont);
+	ReleaseDC(floatbar->parent, hdc);
+	return width;
+}
+
+static void floatbar_update_region(wfFloatBar* floatbar)
+{
+	POINT points[4];
+	HRGN region;
+
+	if (!floatbar || !floatbar->hwnd)
+		return;
+
+	points[0].x = 0;
+	points[0].y = 0;
+	points[1].x = floatbar->width;
+	points[1].y = 0;
+	points[2].x = floatbar->width - BACKGROUND_H;
+	points[2].y = BACKGROUND_H;
+	points[3].x = BACKGROUND_H;
+	points[3].y = BACKGROUND_H;
+
+	region = CreatePolygonRgn(points, ARRAYSIZE(points), ALTERNATE);
+	if (region)
+		SetWindowRgn(floatbar->hwnd, region, TRUE);
+}
+
+static void floatbar_update_layout(wfFloatBar* floatbar)
+{
+	RECT parentRect = { 0 };
+	LONG rightButtonsWidth;
+	LONG requestedWidth;
+	LONG maxWidth;
+	LONG closeX;
+	LONG restoreX;
+	LONG minimizeX;
 
 	if (!floatbar)
+		return;
+
+	rightButtonsWidth =
+	    (BACKGROUND_H + BUTTON_OFFSET) + (BUTTON_WIDTH * 3) + (BUTTON_SPACING * 2);
+	requestedWidth = TEXT_X + floatbar_measure_title_width(floatbar) + FLOATBAR_TEXT_RIGHT_PAD;
+	if (requestedWidth < FLOATBAR_MIN_WIDTH)
+		requestedWidth = FLOATBAR_MIN_WIDTH;
+
+	if (floatbar_parent_rect(floatbar, &parentRect))
+	{
+		maxWidth = (parentRect.right - parentRect.left) - FLOATBAR_MAX_MARGIN;
+		if (maxWidth > FLOATBAR_MIN_WIDTH && requestedWidth > maxWidth)
+			requestedWidth = maxWidth;
+	}
+
+	floatbar->width = requestedWidth;
+	floatbar->height = BACKGROUND_H;
+
+	closeX = floatbar->width - (BACKGROUND_H + BUTTON_OFFSET) - BUTTON_WIDTH;
+	restoreX = closeX - (BUTTON_WIDTH + BUTTON_SPACING);
+	minimizeX = restoreX - (BUTTON_WIDTH + BUTTON_SPACING);
+
+	if (floatbar->buttons[BUTTON_MINIMIZE])
+	{
+		floatbar->buttons[BUTTON_MINIMIZE]->x = minimizeX;
+		floatbar->buttons[BUTTON_MINIMIZE]->y = BUTTON_Y;
+	}
+	if (floatbar->buttons[BUTTON_RESTORE])
+	{
+		floatbar->buttons[BUTTON_RESTORE]->x = restoreX;
+		floatbar->buttons[BUTTON_RESTORE]->y = BUTTON_Y;
+	}
+	if (floatbar->buttons[BUTTON_CLOSE])
+	{
+		floatbar->buttons[BUTTON_CLOSE]->x = closeX;
+		floatbar->buttons[BUTTON_CLOSE]->y = BUTTON_Y;
+	}
+	if (floatbar->buttons[BUTTON_LOCKPIN])
+	{
+		floatbar->buttons[BUTTON_LOCKPIN]->x = LOCK_X;
+		floatbar->buttons[BUTTON_LOCKPIN]->y = BUTTON_Y;
+	}
+
+	SetRect(&floatbar->textRect, TEXT_X, 0, floatbar->width - rightButtonsWidth, BACKGROUND_H);
+
+	if (floatbar->hwnd)
+		floatbar_update_region(floatbar);
+}
+
+static BOOL floatbar_set_geometry(wfFloatBar* floatbar, LONG x, LONG y, LONG height)
+{
+	if (!floatbar || !floatbar->hwnd)
 		return FALSE;
 
-	if (floatbar->shown == show)
+	if ((floatbar->rect.left == x) && (floatbar->rect.top == y) &&
+	    ((floatbar->rect.bottom - floatbar->rect.top) == height) &&
+	    ((floatbar->rect.right - floatbar->rect.left) == floatbar->width))
 		return TRUE;
 
-	if (floatbar->animating == timer)
-		return TRUE;
-
-	floatbar->animating = timer;
-
-	if (SetTimer(floatbar->hwnd, timer, USER_TIMER_MINIMUM, nullptr) == 0)
+	if (!SetWindowPos(floatbar->hwnd, NULL, x, y, floatbar->width, height,
+	                  SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOZORDER))
 	{
-		DWORD err = GetLastError();
-		WLog_ERR(TAG, "SetTimer failed with %08" PRIx32, err);
+		WLog_ERR(TAG, "SetWindowPos failed with %08" PRIx32, GetLastError());
 		return FALSE;
 	}
 
+	floatbar->rect.left = x;
+	floatbar->rect.top = y;
+	floatbar->rect.right = x + floatbar->width;
+	floatbar->rect.bottom = y + height;
+	return TRUE;
+}
+
+static void floatbar_clear_hover(wfFloatBar* floatbar)
+{
+	if (!floatbar)
+		return;
+
+	for (size_t i = 0; i < ARRAYSIZE(floatbar->buttons); i++)
+	{
+		if (floatbar->buttons[i])
+			floatbar->buttons[i]->active = FALSE;
+	}
+	floatbar->hoverButton = NULL;
+}
+
+static BOOL floatbar_kill_timers(wfFloatBar* floatbar)
+{
+	if (!floatbar)
+		return FALSE;
+
+	KillTimer(floatbar->hwnd, TIMER_HIDE);
+	KillTimer(floatbar->hwnd, TIMER_SHOW);
 	return TRUE;
 }
 
@@ -137,12 +283,11 @@ static BOOL floatbar_trigger_hide(wfFloatBar* floatbar)
 	if (!floatbar_kill_timers(floatbar))
 		return FALSE;
 
-	if (!floatbar->locked && floatbar->shown)
+	if (!floatbar->locked && floatbar->shown && !floatbar->mouseInside)
 	{
-		if (SetTimer(floatbar->hwnd, TIMER_HIDE, 3000, nullptr) == 0)
+		if (SetTimer(floatbar->hwnd, TIMER_HIDE, 3000, NULL) == 0)
 		{
-			DWORD err = GetLastError();
-			WLog_ERR(TAG, "SetTimer failed with %08" PRIx32, err);
+			WLog_ERR(TAG, "SetTimer failed with %08" PRIx32, GetLastError());
 			return FALSE;
 		}
 	}
@@ -152,52 +297,49 @@ static BOOL floatbar_trigger_hide(wfFloatBar* floatbar)
 
 static BOOL floatbar_hide(wfFloatBar* floatbar)
 {
+	RECT parentRect = { 0 };
+
 	if (!floatbar_kill_timers(floatbar))
 		return FALSE;
-
-	floatbar->offset = floatbar->height - 2;
-
-	if (!MoveWindow(floatbar->hwnd, floatbar->rect.left, -floatbar->offset, floatbar->width,
-	                floatbar->height, TRUE))
-	{
-		DWORD err = GetLastError();
-		WLog_ERR(TAG, "MoveWindow failed with %08" PRIx32, err);
+	if (!floatbar_parent_rect(floatbar, &parentRect))
 		return FALSE;
-	}
 
+	floatbar_update_layout(floatbar);
 	floatbar->shown = FALSE;
+	floatbar->mouseInside = FALSE;
+	floatbar_clear_hover(floatbar);
 
-	if (!floatbar_trigger_hide(floatbar))
+	if (!floatbar_set_geometry(floatbar, floatbar->rect.left, parentRect.top, FLOATBAR_PEEK_HEIGHT))
 		return FALSE;
 
+	InvalidateRect(floatbar->hwnd, NULL, FALSE);
 	return TRUE;
 }
 
 static BOOL floatbar_show(wfFloatBar* floatbar)
 {
+	RECT parentRect = { 0 };
+
 	if (!floatbar_kill_timers(floatbar))
 		return FALSE;
-
-	floatbar->offset = 0;
-
-	if (!MoveWindow(floatbar->hwnd, floatbar->rect.left, -floatbar->offset, floatbar->width,
-	                floatbar->height, TRUE))
-	{
-		DWORD err = GetLastError();
-		WLog_ERR(TAG, "MoveWindow failed with %08" PRIx32, err);
+	if (!floatbar_parent_rect(floatbar, &parentRect))
 		return FALSE;
-	}
 
+	floatbar_update_layout(floatbar);
 	floatbar->shown = TRUE;
 
-	if (!floatbar_trigger_hide(floatbar))
+	if (!floatbar_set_geometry(floatbar, floatbar->rect.left, parentRect.top, floatbar->height))
 		return FALSE;
 
-	return TRUE;
+	InvalidateRect(floatbar->hwnd, NULL, FALSE);
+	return floatbar_trigger_hide(floatbar);
 }
 
-static BOOL button_set_locked(Button* button, BOOL locked)
+static BOOL floatbar_update_locked_button(FloatbarButton* button, BOOL locked)
 {
+	if (!button)
+		return FALSE;
+
 	if (locked)
 	{
 		button->bmp = button->locked_bmp;
@@ -209,35 +351,24 @@ static BOOL button_set_locked(Button* button, BOOL locked)
 		button->bmp_act = button->unlocked_bmp_act;
 	}
 
-	InvalidateRect(button->floatbar->hwnd, nullptr, FALSE);
-	UpdateWindow(button->floatbar->hwnd);
+	InvalidateRect(button->floatbar->hwnd, NULL, FALSE);
 	return TRUE;
 }
 
-static BOOL update_locked_state(wfFloatBar* floatbar)
+static int floatbar_button_hit(FloatbarButton* button)
 {
-	Button* button;
+	wfFloatBar* floatbar;
 
-	if (!floatbar)
-		return FALSE;
+	if (!button)
+		return 0;
 
-	button = floatbar->buttons[3];
-
-	if (!button_set_locked(button, floatbar->locked))
-		return FALSE;
-
-	return TRUE;
-}
-
-static int button_hit(Button* const button)
-{
-	wfFloatBar* const floatbar = button->floatbar;
+	floatbar = button->floatbar;
 
 	switch (button->type)
 	{
 		case BUTTON_LOCKPIN:
 			floatbar->locked = !floatbar->locked;
-			update_locked_state(floatbar);
+			floatbar_update_locked_button(button, floatbar->locked);
 			break;
 
 		case BUTTON_MINIMIZE:
@@ -245,46 +376,49 @@ static int button_hit(Button* const button)
 			break;
 
 		case BUTTON_RESTORE:
+			floatbar_kill_timers(floatbar);
+			ReleaseCapture();
 			wf_toggle_fullscreen(floatbar->wfc);
 			break;
 
 		case BUTTON_CLOSE:
-			SendMessage(floatbar->parent, WM_DESTROY, 0, 0);
+			PostMessage(floatbar->parent, WM_CLOSE, 0, 0);
 			break;
 
 		default:
-			return 0;
+			break;
 	}
 
 	return 0;
 }
 
-static int button_paint(const Button* const button, const HDC hdc)
+static int floatbar_button_paint(const FloatbarButton* button, HDC hdc)
 {
-	if (button != nullptr)
-	{
-		wfFloatBar* floatbar = button->floatbar;
-		BLENDFUNCTION bf;
-		SelectObject(floatbar->hdcmem, button->active ? button->bmp_act : button->bmp);
-		bf.BlendOp = AC_SRC_OVER;
-		bf.BlendFlags = 0;
-		bf.SourceConstantAlpha = 255;
-		bf.AlphaFormat = AC_SRC_ALPHA;
-		AlphaBlend(hdc, button->x, button->y, button->w, button->h, floatbar->hdcmem, 0, 0,
-		           button->w, button->h, bf);
-	}
-
-	return 0;
-}
-
-static Button* floatbar_create_button(wfFloatBar* const floatbar, const int type, const int resid,
-                                      const int resid_act, const int x, const int y, const int h,
-                                      const int w)
-{
-	Button* button = (Button*)calloc(1, sizeof(Button));
+	wfFloatBar* floatbar;
+	BLENDFUNCTION blend = { 0 };
 
 	if (!button)
-		return nullptr;
+		return 0;
+
+	floatbar = button->floatbar;
+	if (!button->bmp || !button->bmp_act)
+		return 0;
+	SelectObject(floatbar->hdcmem, button->active ? button->bmp_act : button->bmp);
+	blend.BlendOp = AC_SRC_OVER;
+	blend.SourceConstantAlpha = 255;
+	blend.AlphaFormat = AC_SRC_ALPHA;
+	AlphaBlend(hdc, button->x, button->y, button->w, button->h, floatbar->hdcmem, 0, 0, button->w,
+	           button->h, blend);
+	return 0;
+}
+
+static FloatbarButton* floatbar_create_button(wfFloatBar* floatbar, int type, int resid,
+                                              int residAct, int x, int y, int h, int w)
+{
+	FloatbarButton* button = (FloatbarButton*)calloc(1, sizeof(FloatbarButton));
+
+	if (!button)
+		return NULL;
 
 	button->floatbar = floatbar;
 	button->type = type;
@@ -292,344 +426,340 @@ static Button* floatbar_create_button(wfFloatBar* const floatbar, const int type
 	button->y = y;
 	button->w = w;
 	button->h = h;
-	button->active = FALSE;
 	button->bmp = (HBITMAP)LoadImage(floatbar->root_window, MAKEINTRESOURCE(resid), IMAGE_BITMAP, 0,
 	                                 0, LR_DEFAULTCOLOR);
-	button->bmp_act = (HBITMAP)LoadImage(floatbar->root_window, MAKEINTRESOURCE(resid_act),
+	button->bmp_act = (HBITMAP)LoadImage(floatbar->root_window, MAKEINTRESOURCE(residAct),
 	                                     IMAGE_BITMAP, 0, 0, LR_DEFAULTCOLOR);
 	return button;
 }
 
-static Button* floatbar_create_lock_button(wfFloatBar* const floatbar, const int unlock_resid,
-                                           const int unlock_resid_act, const int lock_resid,
-                                           const int lock_resid_act, const int x, const int y,
-                                           const int h, const int w)
+static FloatbarButton* floatbar_create_lock_button(wfFloatBar* floatbar, int unlockResid,
+                                                   int unlockResidAct, int lockResid,
+                                                   int lockResidAct, int x, int y, int h, int w)
 {
-	Button* button = floatbar_create_button(floatbar, BUTTON_LOCKPIN, unlock_resid,
-	                                        unlock_resid_act, x, y, h, w);
+	FloatbarButton* button =
+	    floatbar_create_button(floatbar, BUTTON_LOCKPIN, unlockResid, unlockResidAct, x, y, h, w);
 
 	if (!button)
-		return nullptr;
+		return NULL;
 
 	button->unlocked_bmp = button->bmp;
 	button->unlocked_bmp_act = button->bmp_act;
-	button->locked_bmp = (HBITMAP)LoadImage(floatbar->wfc->hInstance, MAKEINTRESOURCE(lock_resid),
+	button->locked_bmp = (HBITMAP)LoadImage(floatbar->root_window, MAKEINTRESOURCE(lockResid),
 	                                        IMAGE_BITMAP, 0, 0, LR_DEFAULTCOLOR);
-	button->locked_bmp_act =
-	    (HBITMAP)LoadImage(floatbar->wfc->hInstance, MAKEINTRESOURCE(lock_resid_act), IMAGE_BITMAP,
-	                       0, 0, LR_DEFAULTCOLOR);
+	button->locked_bmp_act = (HBITMAP)LoadImage(floatbar->root_window, MAKEINTRESOURCE(lockResidAct),
+	                                            IMAGE_BITMAP, 0, 0, LR_DEFAULTCOLOR);
 	return button;
 }
 
-static Button* floatbar_get_button(const wfFloatBar* const floatbar, const int x, const int y)
+static FloatbarButton* floatbar_get_button(const wfFloatBar* floatbar, int x, int y)
 {
-	if ((y > BUTTON_Y) && (y < BUTTON_Y + BUTTON_HEIGHT))
+	if (!floatbar || !floatbar->shown)
+		return NULL;
+
+	if ((y <= BUTTON_Y) || (y >= (BUTTON_Y + BUTTON_HEIGHT)))
+		return NULL;
+
+	for (size_t i = 0; i < ARRAYSIZE(floatbar->buttons); i++)
 	{
-		for (int i = 0; i < BTN_MAX; i++)
-		{
-			if ((floatbar->buttons[i] != nullptr) && (x > floatbar->buttons[i]->x) &&
-			    (x < floatbar->buttons[i]->x + floatbar->buttons[i]->w))
-			{
-				return floatbar->buttons[i];
-			}
-		}
+		FloatbarButton* button = floatbar->buttons[i];
+		if (!button)
+			continue;
+
+		if ((x > button->x) && (x < (button->x + button->w)))
+			return button;
 	}
 
-	return nullptr;
+	return NULL;
 }
 
-static BOOL floatbar_paint(wfFloatBar* const floatbar, const HDC hdc)
+static BOOL floatbar_paint(wfFloatBar* floatbar, HDC hdc)
 {
-	HPEN hpen;
-	HGDIOBJECT orig;
-	/* paint background */
+	HPEN pen;
+	HGDIOBJECT oldPen;
+	RECT client = { 0 };
 	GRADIENT_RECT gradientRect = { 0, 1 };
 	COLORREF rgbTop = RGB(117, 154, 198);
 	COLORREF rgbBottom = RGB(6, 55, 120);
-	const int top = 0;
 	int left = 0;
-	int bottom = BACKGROUND_H - 1;
-	int right = BACKGROUND_W - 1;
+	int right = 0;
+	int bottom = 0;
+	const int top = 0;
 	const int angleOffset = BACKGROUND_H - 1;
-	TRIVERTEX triVertext[2] = { { left, top, GetRValue(rgbTop) << 8, GetGValue(rgbTop) << 8,
-		                          GetBValue(rgbTop) << 8, 0x0000 },
-		                        { right, bottom, GetRValue(rgbBottom) << 8,
-		                          GetGValue(rgbBottom) << 8, GetBValue(rgbBottom) << 8, 0x0000 } };
+	const WCHAR* title;
+	size_t titleLength;
+	TRIVERTEX vertices[2];
 
 	if (!floatbar)
 		return FALSE;
 
-	GradientFill(hdc, triVertext, 2, &gradientRect, 1, GRADIENT_FILL_RECT_V);
-	/* paint shadow */
-	hpen = CreatePen(PS_SOLID, 1, RGB(71, 71, 71));
-	orig = SelectObject(hdc, hpen);
-	MoveToEx(hdc, left, top, nullptr);
+	GetClientRect(floatbar->hwnd, &client);
+	if ((client.bottom - client.top) <= FLOATBAR_PEEK_HEIGHT)
+	{
+		HBRUSH strip = CreateSolidBrush(rgbBottom);
+		if (strip)
+		{
+			FillRect(hdc, &client, strip);
+			DeleteObject(strip);
+		}
+		return TRUE;
+	}
+
+	right = floatbar->width - 1;
+	bottom = floatbar->height - 1;
+	vertices[0].x = left;
+	vertices[0].y = top;
+	vertices[0].Red = GetRValue(rgbTop) << 8;
+	vertices[0].Green = GetGValue(rgbTop) << 8;
+	vertices[0].Blue = GetBValue(rgbTop) << 8;
+	vertices[0].Alpha = 0x0000;
+	vertices[1].x = right;
+	vertices[1].y = bottom;
+	vertices[1].Red = GetRValue(rgbBottom) << 8;
+	vertices[1].Green = GetGValue(rgbBottom) << 8;
+	vertices[1].Blue = GetBValue(rgbBottom) << 8;
+	vertices[1].Alpha = 0x0000;
+	GradientFill(hdc, vertices, 2, &gradientRect, 1, GRADIENT_FILL_RECT_V);
+
+	pen = CreatePen(PS_SOLID, 1, RGB(71, 71, 71));
+	oldPen = SelectObject(hdc, pen);
+	MoveToEx(hdc, left, top, NULL);
 	LineTo(hdc, left + angleOffset, bottom);
 	LineTo(hdc, right - angleOffset, bottom);
 	LineTo(hdc, right + 1, top - 1);
-	DeleteObject(hpen);
-	hpen = CreatePen(PS_SOLID, 1, RGB(107, 141, 184));
-	SelectObject(hdc, hpen);
+	SelectObject(hdc, oldPen);
+	DeleteObject(pen);
+
+	pen = CreatePen(PS_SOLID, 1, RGB(107, 141, 184));
+	oldPen = SelectObject(hdc, pen);
 	left += 1;
-	bottom -= 1;
 	right -= 1;
-	MoveToEx(hdc, left, top, nullptr);
-	LineTo(hdc, left + (angleOffset - 1), bottom);
-	LineTo(hdc, right - (angleOffset - 1), bottom);
+	bottom -= 1;
+	MoveToEx(hdc, left, top, NULL);
+	LineTo(hdc, left + angleOffset - 1, bottom);
+	LineTo(hdc, right - angleOffset + 1, bottom);
 	LineTo(hdc, right + 1, top - 1);
-	DeleteObject(hpen);
-	SelectObject(hdc, orig);
+	SelectObject(hdc, oldPen);
+	DeleteObject(pen);
 
-	const size_t wlen = wcslen(floatbar->wfc->window_title);
-	DrawText(hdc, floatbar->wfc->window_title, WINPR_ASSERTING_INT_CAST(int, wlen),
-	         &floatbar->textRect,
-	         DT_CENTER | DT_VCENTER | DT_END_ELLIPSIS | DT_NOPREFIX | DT_SINGLELINE);
+	SetBkMode(hdc, TRANSPARENT);
+	SetTextColor(hdc, RGB(255, 255, 255));
+	if (floatbar->titleFont)
+		SelectObject(hdc, floatbar->titleFont);
 
-	/* paint buttons */
+	title = floatbar->wfc ? floatbar->wfc->window_title : NULL;
+	titleLength = title ? wcslen(title) : 0;
+	if (titleLength > 0)
+	{
+		DrawTextW(hdc, title, (int)titleLength, &floatbar->textRect,
+		          DT_CENTER | DT_VCENTER | DT_END_ELLIPSIS | DT_NOPREFIX | DT_SINGLELINE);
+	}
 
-	for (int i = 0; i < BTN_MAX; i++)
-		button_paint(floatbar->buttons[i], hdc);
+	for (size_t i = 0; i < ARRAYSIZE(floatbar->buttons); i++)
+		floatbar_button_paint(floatbar->buttons[i], hdc);
 
 	return TRUE;
 }
 
-static LRESULT CALLBACK floatbar_proc(const HWND hWnd, const UINT Msg, const WPARAM wParam,
-                                      const LPARAM lParam)
+static LRESULT CALLBACK floatbar_proc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-	static int dragging = FALSE;
-	static int lbtn_dwn = FALSE;
-	static int btn_dwn_x = 0;
-	static wfFloatBar* floatbar;
-	static TRACKMOUSEEVENT tme;
-	PAINTSTRUCT ps;
-	Button* button;
+	static BOOL dragging = FALSE;
+	static BOOL leftButtonDown = FALSE;
+	static int dragOffsetX = 0;
+	static wfFloatBar* floatbar = NULL;
+	static TRACKMOUSEEVENT tme = { 0 };
+	PAINTSTRUCT ps = { 0 };
 	HDC hdc;
-	int pos_x;
-	int pos_y;
-	NONCLIENTMETRICS ncm;
+	FloatbarButton* button;
+	int posX;
+	int posY;
 	int xScreen = GetSystemMetrics(SM_CXSCREEN);
 
-	switch (Msg)
+	switch (msg)
 	{
 		case WM_CREATE:
+		{
+			NONCLIENTMETRICS ncm = { 0 };
+
 			floatbar = ((wfFloatBar*)((CREATESTRUCT*)lParam)->lpCreateParams);
 			floatbar->hwnd = hWnd;
-			GetWindowRect(floatbar->hwnd, &floatbar->rect);
+			GetWindowRect(hWnd, &floatbar->rect);
 			floatbar->width = floatbar->rect.right - floatbar->rect.left;
-			floatbar->height = floatbar->rect.bottom - floatbar->rect.top;
+			floatbar->height = BACKGROUND_H;
+
 			hdc = GetDC(hWnd);
 			floatbar->hdcmem = CreateCompatibleDC(hdc);
+			ncm.cbSize = sizeof(NONCLIENTMETRICS);
+			SystemParametersInfo(SPI_GETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &ncm, 0);
+			floatbar->titleFont = CreateFontIndirect(&ncm.lfCaptionFont);
 			ReleaseDC(hWnd, hdc);
+
 			tme.cbSize = sizeof(TRACKMOUSEEVENT);
 			tme.dwFlags = TME_LEAVE;
 			tme.hwndTrack = hWnd;
 			tme.dwHoverTime = HOVER_DEFAULT;
-			// Use caption font, white, draw transparent
-			GetClientRect(hWnd, &floatbar->textRect);
-			InflateRect(&floatbar->textRect, -TEXT_X, 0);
-			SetBkMode(hdc, TRANSPARENT);
-			SetTextColor(hdc, RGB(255, 255, 255));
-			ncm.cbSize = sizeof(NONCLIENTMETRICS);
-			SystemParametersInfo(SPI_GETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &ncm, 0);
-			SelectObject(hdc, CreateFontIndirect(&ncm.lfCaptionFont));
+			floatbar_update_layout(floatbar);
 			floatbar_trigger_hide(floatbar);
-			break;
+			return 0;
+		}
 
 		case WM_PAINT:
 			hdc = BeginPaint(hWnd, &ps);
 			floatbar_paint(floatbar, hdc);
 			EndPaint(hWnd, &ps);
-			break;
+			return 0;
 
 		case WM_LBUTTONDOWN:
-			pos_x = lParam & 0xffff;
-			pos_y = (lParam >> 16) & 0xffff;
-			button = floatbar_get_button(floatbar, pos_x, pos_y);
+			posX = GET_X_LPARAM(lParam);
+			posY = GET_Y_LPARAM(lParam);
+			floatbar->mouseInside = TRUE;
+			floatbar_kill_timers(floatbar);
+			TrackMouseEvent(&tme);
 
-			if (!button)
+			if (!floatbar->locked && !floatbar->shown)
+			{
+				floatbar_show(floatbar);
+				posX = GET_X_LPARAM(lParam);
+				posY = GET_Y_LPARAM(lParam);
+			}
+
+			button = floatbar_get_button(floatbar, posX, posY);
+			if (button)
+				leftButtonDown = TRUE;
+			else if (floatbar->shown)
 			{
 				SetCapture(hWnd);
 				dragging = TRUE;
-				btn_dwn_x = lParam & 0xffff;
+				dragOffsetX = posX;
 			}
-			else
-				lbtn_dwn = TRUE;
-
-			break;
+			return 0;
 
 		case WM_LBUTTONUP:
-			pos_x = lParam & 0xffff;
-			pos_y = (lParam >> 16) & 0xffff;
+			posX = GET_X_LPARAM(lParam);
+			posY = GET_Y_LPARAM(lParam);
 			ReleaseCapture();
 			dragging = FALSE;
 
-			if (lbtn_dwn)
+			if (leftButtonDown)
 			{
-				button = floatbar_get_button(floatbar, pos_x, pos_y);
-
+				button = floatbar_get_button(floatbar, posX, posY);
 				if (button)
-					button_hit(button);
-
-				lbtn_dwn = FALSE;
+					floatbar_button_hit(button);
+				leftButtonDown = FALSE;
 			}
-
-			break;
-
-		case WM_MOUSEMOVE:
-			pos_x = lParam & 0xffff;
-			pos_y = (lParam >> 16) & 0xffff;
-
-			if (!floatbar->locked)
-				floatbar_animation(floatbar, TRUE);
-
-			if (dragging)
-			{
-				floatbar->rect.left = floatbar->rect.left + (lParam & 0xffff) - btn_dwn_x;
-
-				if (floatbar->rect.left < 0)
-					floatbar->rect.left = 0;
-				else if (floatbar->rect.left > xScreen - floatbar->width)
-					floatbar->rect.left = xScreen - floatbar->width;
-
-				MoveWindow(hWnd, floatbar->rect.left, 0, floatbar->width, floatbar->height, TRUE);
-			}
-			else
-			{
-				for (int i = 0; i < BTN_MAX; i++)
-				{
-					if (floatbar->buttons[i] != nullptr)
-					{
-						floatbar->buttons[i]->active = FALSE;
-					}
-				}
-
-				button = floatbar_get_button(floatbar, pos_x, pos_y);
-
-				if (button)
-					button->active = TRUE;
-
-				InvalidateRect(hWnd, nullptr, FALSE);
-				UpdateWindow(hWnd);
-			}
-
-			TrackMouseEvent(&tme);
-			break;
+			return 0;
 
 		case WM_CAPTURECHANGED:
 			dragging = FALSE;
-			break;
+			return 0;
+
+		case WM_MOUSEMOVE:
+			posX = GET_X_LPARAM(lParam);
+			posY = GET_Y_LPARAM(lParam);
+			floatbar->mouseInside = TRUE;
+			TrackMouseEvent(&tme);
+
+			if (!floatbar->shown)
+			{
+				KillTimer(floatbar->hwnd, TIMER_HIDE);
+				if (SetTimer(floatbar->hwnd, TIMER_SHOW, 150, NULL) == 0)
+					WLog_WARN(TAG, "SetTimer failed with %08" PRIx32, GetLastError());
+			}
+			else
+			{
+				KillTimer(floatbar->hwnd, TIMER_SHOW);
+			}
+
+			if (dragging && floatbar->shown)
+			{
+				RECT parentRect = { 0 };
+				LONG leftEdge;
+				int y;
+
+				floatbar->rect.left = floatbar->rect.left + posX - dragOffsetX;
+				leftEdge = xScreen - floatbar->width;
+				if (floatbar->rect.left < 0)
+					floatbar->rect.left = 0;
+				else if (floatbar->rect.left > leftEdge)
+					floatbar->rect.left = leftEdge;
+
+				y = floatbar->rect.top;
+				if (floatbar_parent_rect(floatbar, &parentRect))
+					y = parentRect.top;
+				floatbar_set_geometry(floatbar, floatbar->rect.left, y,
+				                      floatbar->shown ? floatbar->height : FLOATBAR_PEEK_HEIGHT);
+			}
+			else
+			{
+				FloatbarButton* hover = floatbar_get_button(floatbar, posX, posY);
+				if (hover != floatbar->hoverButton)
+				{
+					floatbar_clear_hover(floatbar);
+					if (hover)
+						hover->active = TRUE;
+					floatbar->hoverButton = hover;
+					InvalidateRect(hWnd, NULL, FALSE);
+				}
+			}
+			return 0;
 
 		case WM_MOUSELEAVE:
-		{
-			for (int i = 0; i < BTN_MAX; i++)
-			{
-				if (floatbar->buttons[i] != nullptr)
-				{
-					floatbar->buttons[i]->active = FALSE;
-				}
-			}
-
-			InvalidateRect(hWnd, nullptr, FALSE);
-			UpdateWindow(hWnd);
+			floatbar->mouseInside = FALSE;
+			floatbar_clear_hover(floatbar);
+			InvalidateRect(hWnd, NULL, FALSE);
 			floatbar_trigger_hide(floatbar);
-			break;
-		}
+			return 0;
 
 		case WM_TIMER:
-			switch (wParam)
-			{
-				case TIMER_HIDE:
-					floatbar_animation(floatbar, FALSE);
-					break;
-
-				case TIMER_ANIMAT_SHOW:
-				{
-					floatbar->offset--;
-					MoveWindow(floatbar->hwnd, floatbar->rect.left, -floatbar->offset,
-					           floatbar->width, floatbar->height, TRUE);
-
-					if (floatbar->offset <= 0)
-						floatbar_show(floatbar);
-
-					break;
-				}
-
-				case TIMER_ANIMAT_HIDE:
-				{
-					floatbar->offset++;
-					MoveWindow(floatbar->hwnd, floatbar->rect.left, -floatbar->offset,
-					           floatbar->width, floatbar->height, TRUE);
-
-					if (floatbar->offset >= floatbar->height - 2)
-						floatbar_hide(floatbar);
-
-					break;
-				}
-
-				default:
-					break;
-			}
-
-			break;
+			if (wParam == TIMER_HIDE)
+				floatbar_hide(floatbar);
+			else if (wParam == TIMER_SHOW)
+				floatbar_show(floatbar);
+			return 0;
 
 		case WM_DESTROY:
+			floatbar_kill_timers(floatbar);
 			DeleteDC(floatbar->hdcmem);
-			PostQuitMessage(0);
-			break;
+			floatbar->hdcmem = NULL;
+			floatbar->hwnd = NULL;
+			return 0;
 
 		default:
-			return DefWindowProc(hWnd, Msg, wParam, lParam);
+			return DefWindowProc(hWnd, msg, wParam, lParam);
 	}
-
-	return 0;
 }
 
 static BOOL floatbar_window_create(wfFloatBar* floatbar)
 {
-	WNDCLASSEX wnd_cls;
+	WNDCLASSEX wndCls = { 0 };
 	HWND barWnd;
-	HRGN hRgn;
-	POINT pt[4];
-	RECT rect;
+	RECT parentRect = { 0 };
 	LONG x;
 
-	if (!floatbar)
+	if (!floatbar || !floatbar_parent_rect(floatbar, &parentRect))
 		return FALSE;
 
-	if (!GetWindowRect(floatbar->parent, &rect))
+	floatbar_update_layout(floatbar);
+	x = parentRect.left + ((parentRect.right - parentRect.left - floatbar->width) / 2);
+
+	wndCls.cbSize = sizeof(WNDCLASSEX);
+	wndCls.style = CS_HREDRAW | CS_VREDRAW | CS_OWNDC;
+	wndCls.lpfnWndProc = floatbar_proc;
+	wndCls.hIcon = LoadIcon(NULL, IDI_APPLICATION);
+	wndCls.hCursor = LoadCursor(NULL, IDC_ARROW);
+	wndCls.hbrBackground = NULL;
+	wndCls.lpszClassName = L"floatbar";
+	wndCls.hInstance = floatbar->root_window;
+	wndCls.hIconSm = LoadIcon(NULL, IDI_APPLICATION);
+	RegisterClassEx(&wndCls);
+
+	barWnd = CreateWindowEx(WS_EX_TOOLWINDOW, L"floatbar", L"floatbar", WS_POPUP, x, parentRect.top,
+	                        floatbar->width, BACKGROUND_H, floatbar->parent, NULL,
+	                        floatbar->root_window, floatbar);
+	if (!barWnd)
 		return FALSE;
 
-	x = (rect.right - rect.left - BACKGROUND_W) / 2;
-	wnd_cls.cbSize = sizeof(WNDCLASSEX);
-	wnd_cls.style = CS_HREDRAW | CS_VREDRAW | CS_OWNDC;
-	wnd_cls.lpfnWndProc = floatbar_proc;
-	wnd_cls.cbClsExtra = 0;
-	wnd_cls.cbWndExtra = 0;
-	wnd_cls.hIcon = LoadIcon(nullptr, IDI_APPLICATION);
-	wnd_cls.hCursor = LoadCursor(floatbar->root_window, IDC_ARROW);
-	wnd_cls.hbrBackground = nullptr;
-	wnd_cls.lpszMenuName = nullptr;
-	wnd_cls.lpszClassName = L"floatbar";
-	wnd_cls.hInstance = floatbar->root_window;
-	wnd_cls.hIconSm = LoadIcon(nullptr, IDI_APPLICATION);
-	RegisterClassEx(&wnd_cls);
-	barWnd =
-	    CreateWindowEx(WS_EX_TOPMOST, L"floatbar", L"floatbar", WS_CHILD, x, 0, BACKGROUND_W,
-	                   BACKGROUND_H, floatbar->parent, nullptr, floatbar->root_window, floatbar);
-
-	if (barWnd == nullptr)
-		return FALSE;
-
-	pt[0].x = 0;
-	pt[0].y = 0;
-	pt[1].x = BACKGROUND_W;
-	pt[1].y = 0;
-	pt[2].x = BACKGROUND_W - BACKGROUND_H;
-	pt[2].y = BACKGROUND_H;
-	pt[3].x = BACKGROUND_H;
-	pt[3].y = BACKGROUND_H;
-	hRgn = CreatePolygonRgn(pt, 4, ALTERNATE);
-	SetWindowRgn(barWnd, hRgn, TRUE);
+	floatbar_update_region(floatbar);
 	return TRUE;
 }
 
@@ -638,6 +768,27 @@ void wf_floatbar_free(wfFloatBar* floatbar)
 	if (!floatbar)
 		return;
 
+	floatbar_kill_timers(floatbar);
+	if (floatbar->hwnd)
+		DestroyWindow(floatbar->hwnd);
+
+	for (size_t i = 0; i < ARRAYSIZE(floatbar->buttons); i++)
+	{
+		FloatbarButton* button = floatbar->buttons[i];
+		if (!button)
+			continue;
+
+		DeleteObject(button->bmp);
+		DeleteObject(button->bmp_act);
+		if (button->type == BUTTON_LOCKPIN)
+		{
+			DeleteObject(button->locked_bmp);
+			DeleteObject(button->locked_bmp_act);
+		}
+		free(button);
+	}
+
+	DeleteObject(floatbar->titleFont);
 	free(floatbar);
 }
 
@@ -645,80 +796,64 @@ wfFloatBar* wf_floatbar_new(wfContext* wfc, HINSTANCE window, DWORD flags)
 {
 	wfFloatBar* floatbar;
 
-	/* Floatbar not enabled */
 	if ((flags & 0x0001) == 0)
-		return nullptr;
-
+		return NULL;
 	if (!wfc)
-		return nullptr;
+		return NULL;
 
-	// TODO: Disable for remote app
 	floatbar = (wfFloatBar*)calloc(1, sizeof(wfFloatBar));
-
 	if (!floatbar)
-		return nullptr;
+		return NULL;
 
 	floatbar->root_window = window;
 	floatbar->flags = flags;
 	floatbar->wfc = wfc;
 	floatbar->locked = (flags & 0x0002) != 0;
-	floatbar->shown = (flags & 0x0006) != 0; /* If it is loked or shown show it */
-	floatbar->hwnd = nullptr;
+	floatbar->shown = (flags & 0x0006) != 0;
 	floatbar->parent = wfc->hwnd;
-	floatbar->hdcmem = nullptr;
 
 	if (wfc->fullscreen_toggle)
 	{
-		floatbar->buttons[0] =
-		    floatbar_create_button(floatbar, BUTTON_MINIMIZE, IDB_MINIMIZE, IDB_MINIMIZE_ACT,
-		                           MINIMIZE_X, BUTTON_Y, BUTTON_HEIGHT, BUTTON_WIDTH);
-		floatbar->buttons[1] =
-		    floatbar_create_button(floatbar, BUTTON_RESTORE, IDB_RESTORE, IDB_RESTORE_ACT,
-		                           RESTORE_X, BUTTON_Y, BUTTON_HEIGHT, BUTTON_WIDTH);
-	}
-	else
-	{
-		floatbar->buttons[0] = nullptr;
-		floatbar->buttons[1] = nullptr;
+		floatbar->buttons[BUTTON_MINIMIZE] = floatbar_create_button(
+		    floatbar, BUTTON_MINIMIZE, IDB_MINIMIZE, IDB_MINIMIZE_ACT, 0, BUTTON_Y, BUTTON_HEIGHT,
+		    BUTTON_WIDTH);
+		floatbar->buttons[BUTTON_RESTORE] = floatbar_create_button(
+		    floatbar, BUTTON_RESTORE, IDB_RESTORE, IDB_RESTORE_ACT, 0, BUTTON_Y, BUTTON_HEIGHT,
+		    BUTTON_WIDTH);
 	}
 
-	floatbar->buttons[2] = floatbar_create_button(floatbar, BUTTON_CLOSE, IDB_CLOSE, IDB_CLOSE_ACT,
-	                                              CLOSE_X, BUTTON_Y, BUTTON_HEIGHT, BUTTON_WIDTH);
-	floatbar->buttons[3] =
+	floatbar->buttons[BUTTON_CLOSE] = floatbar_create_button(floatbar, BUTTON_CLOSE, IDB_CLOSE,
+	                                                         IDB_CLOSE_ACT, 0, BUTTON_Y,
+	                                                         BUTTON_HEIGHT, BUTTON_WIDTH);
+	floatbar->buttons[BUTTON_LOCKPIN] =
 	    floatbar_create_lock_button(floatbar, IDB_UNLOCK, IDB_UNLOCK_ACT, IDB_LOCK, IDB_LOCK_ACT,
 	                                LOCK_X, BUTTON_Y, BUTTON_HEIGHT, BUTTON_WIDTH);
 
+	floatbar_update_layout(floatbar);
+
 	if (!floatbar_window_create(floatbar))
 		goto fail;
-
-	if (!update_locked_state(floatbar))
+	if (!floatbar_update_locked_button(floatbar->buttons[BUTTON_LOCKPIN], floatbar->locked))
 		goto fail;
-
 	if (!wf_floatbar_toggle_fullscreen(
 	        floatbar, freerdp_settings_get_bool(wfc->common.context.settings, FreeRDP_Fullscreen)))
 		goto fail;
 
 	return floatbar;
+
 fail:
 	wf_floatbar_free(floatbar);
-	return nullptr;
+	return NULL;
 }
 
 BOOL wf_floatbar_toggle_fullscreen(wfFloatBar* floatbar, BOOL fullscreen)
 {
-	BOOL show_fs, show_wn;
-
 	if (!floatbar)
 		return FALSE;
 
-	show_fs = (floatbar->flags & 0x0010) != 0;
-	show_wn = (floatbar->flags & 0x0020) != 0;
-
-	if ((show_fs && fullscreen) || (show_wn && !fullscreen))
+	if (floatbar_is_visible_in_mode(floatbar, fullscreen))
 	{
 		ShowWindow(floatbar->hwnd, SW_SHOWNORMAL);
-		Sleep(10);
-
 		if (floatbar->shown)
 			floatbar_show(floatbar);
 		else
@@ -729,32 +864,22 @@ BOOL wf_floatbar_toggle_fullscreen(wfFloatBar* floatbar, BOOL fullscreen)
 		ShowWindow(floatbar->hwnd, SW_HIDE);
 	}
 
-	return TRUE;
+	return wf_floatbar_reset_position(floatbar);
 }
 
 BOOL wf_floatbar_reset_position(wfFloatBar* floatbar)
 {
-	RECT rect = WINPR_C_ARRAY_INIT;
+	RECT parentRect = { 0 };
+	LONG x;
+	LONG height;
 
-	if (!floatbar || !floatbar->parent || !floatbar->hwnd)
+	if (!floatbar || !floatbar->hwnd)
+		return FALSE;
+	if (!floatbar_parent_rect(floatbar, &parentRect))
 		return FALSE;
 
-	const int y = -WINPR_ASSERTING_INT_CAST(int, floatbar->offset);
-
-	if (!GetWindowRect(floatbar->parent, &rect))
-		return FALSE;
-
-	floatbar->rect.left = ((rect.right - rect.left) - floatbar->width) / 2;
-	if (floatbar->rect.left < 0)
-		floatbar->rect.left = 0;
-
-	if (!MoveWindow(floatbar->hwnd, floatbar->rect.left, y, floatbar->width, floatbar->height,
-	                TRUE))
-	{
-		DWORD err = GetLastError();
-		WLog_ERR(TAG, "MoveWindow failed with %08" PRIx32, err);
-		return FALSE;
-	}
-
-	return TRUE;
+	floatbar_update_layout(floatbar);
+	x = parentRect.left + ((parentRect.right - parentRect.left - floatbar->width) / 2);
+	height = floatbar->shown ? floatbar->height : FLOATBAR_PEEK_HEIGHT;
+	return floatbar_set_geometry(floatbar, x, parentRect.top, height);
 }

--- a/client/Windows/wf_floatbar.c
+++ b/client/Windows/wf_floatbar.c
@@ -121,8 +121,8 @@ static BOOL floatbar_parent_rect(const wfFloatBar* floatbar, RECT* rect)
 static LONG floatbar_measure_title_width(wfFloatBar* floatbar)
 {
 	const WCHAR* title;
-	HDC hdc = NULL;
-	HGDIOBJECT oldFont = NULL;
+	HDC hdc = nullptr;
+	HGDIOBJECT oldFont = nullptr;
 	SIZE size = { 0 };
 	LONG width = 0;
 
@@ -241,7 +241,7 @@ static BOOL floatbar_set_geometry(wfFloatBar* floatbar, LONG x, LONG y, LONG hei
 	    ((floatbar->rect.right - floatbar->rect.left) == floatbar->width))
 		return TRUE;
 
-	if (!SetWindowPos(floatbar->hwnd, NULL, x, y, floatbar->width, height,
+	if (!SetWindowPos(floatbar->hwnd, nullptr, x, y, floatbar->width, height,
 	                  SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOZORDER))
 	{
 		WLog_ERR(TAG, "SetWindowPos failed with %08" PRIx32, GetLastError());
@@ -265,7 +265,7 @@ static void floatbar_clear_hover(wfFloatBar* floatbar)
 		if (floatbar->buttons[i])
 			floatbar->buttons[i]->active = FALSE;
 	}
-	floatbar->hoverButton = NULL;
+	floatbar->hoverButton = nullptr;
 }
 
 static BOOL floatbar_kill_timers(wfFloatBar* floatbar)
@@ -285,7 +285,7 @@ static BOOL floatbar_trigger_hide(wfFloatBar* floatbar)
 
 	if (!floatbar->locked && floatbar->shown && !floatbar->mouseInside)
 	{
-		if (SetTimer(floatbar->hwnd, TIMER_HIDE, 3000, NULL) == 0)
+		if (SetTimer(floatbar->hwnd, TIMER_HIDE, 3000, nullptr) == 0)
 		{
 			WLog_ERR(TAG, "SetTimer failed with %08" PRIx32, GetLastError());
 			return FALSE;
@@ -312,7 +312,7 @@ static BOOL floatbar_hide(wfFloatBar* floatbar)
 	if (!floatbar_set_geometry(floatbar, floatbar->rect.left, parentRect.top, FLOATBAR_PEEK_HEIGHT))
 		return FALSE;
 
-	InvalidateRect(floatbar->hwnd, NULL, FALSE);
+	InvalidateRect(floatbar->hwnd, nullptr, FALSE);
 	return TRUE;
 }
 
@@ -331,7 +331,7 @@ static BOOL floatbar_show(wfFloatBar* floatbar)
 	if (!floatbar_set_geometry(floatbar, floatbar->rect.left, parentRect.top, floatbar->height))
 		return FALSE;
 
-	InvalidateRect(floatbar->hwnd, NULL, FALSE);
+	InvalidateRect(floatbar->hwnd, nullptr, FALSE);
 	return floatbar_trigger_hide(floatbar);
 }
 
@@ -351,7 +351,7 @@ static BOOL floatbar_update_locked_button(FloatbarButton* button, BOOL locked)
 		button->bmp_act = button->unlocked_bmp_act;
 	}
 
-	InvalidateRect(button->floatbar->hwnd, NULL, FALSE);
+	InvalidateRect(button->floatbar->hwnd, nullptr, FALSE);
 	return TRUE;
 }
 
@@ -418,7 +418,7 @@ static FloatbarButton* floatbar_create_button(wfFloatBar* floatbar, int type, in
 	FloatbarButton* button = (FloatbarButton*)calloc(1, sizeof(FloatbarButton));
 
 	if (!button)
-		return NULL;
+		return nullptr;
 
 	button->floatbar = floatbar;
 	button->type = type;
@@ -441,7 +441,7 @@ static FloatbarButton* floatbar_create_lock_button(wfFloatBar* floatbar, int unl
 	    floatbar_create_button(floatbar, BUTTON_LOCKPIN, unlockResid, unlockResidAct, x, y, h, w);
 
 	if (!button)
-		return NULL;
+		return nullptr;
 
 	button->unlocked_bmp = button->bmp;
 	button->unlocked_bmp_act = button->bmp_act;
@@ -455,10 +455,10 @@ static FloatbarButton* floatbar_create_lock_button(wfFloatBar* floatbar, int unl
 static FloatbarButton* floatbar_get_button(const wfFloatBar* floatbar, int x, int y)
 {
 	if (!floatbar || !floatbar->shown)
-		return NULL;
+		return nullptr;
 
 	if ((y <= BUTTON_Y) || (y >= (BUTTON_Y + BUTTON_HEIGHT)))
-		return NULL;
+		return nullptr;
 
 	for (size_t i = 0; i < ARRAYSIZE(floatbar->buttons); i++)
 	{
@@ -470,7 +470,7 @@ static FloatbarButton* floatbar_get_button(const wfFloatBar* floatbar, int x, in
 			return button;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 static BOOL floatbar_paint(wfFloatBar* floatbar, HDC hdc)
@@ -523,7 +523,7 @@ static BOOL floatbar_paint(wfFloatBar* floatbar, HDC hdc)
 
 	pen = CreatePen(PS_SOLID, 1, RGB(71, 71, 71));
 	oldPen = SelectObject(hdc, pen);
-	MoveToEx(hdc, left, top, NULL);
+	MoveToEx(hdc, left, top, nullptr);
 	LineTo(hdc, left + angleOffset, bottom);
 	LineTo(hdc, right - angleOffset, bottom);
 	LineTo(hdc, right + 1, top - 1);
@@ -535,7 +535,7 @@ static BOOL floatbar_paint(wfFloatBar* floatbar, HDC hdc)
 	left += 1;
 	right -= 1;
 	bottom -= 1;
-	MoveToEx(hdc, left, top, NULL);
+	MoveToEx(hdc, left, top, nullptr);
 	LineTo(hdc, left + angleOffset - 1, bottom);
 	LineTo(hdc, right - angleOffset + 1, bottom);
 	LineTo(hdc, right + 1, top - 1);
@@ -547,7 +547,7 @@ static BOOL floatbar_paint(wfFloatBar* floatbar, HDC hdc)
 	if (floatbar->titleFont)
 		SelectObject(hdc, floatbar->titleFont);
 
-	title = floatbar->wfc ? floatbar->wfc->window_title : NULL;
+	title = floatbar->wfc ? floatbar->wfc->window_title : nullptr;
 	titleLength = title ? wcslen(title) : 0;
 	if (titleLength > 0)
 	{
@@ -566,7 +566,7 @@ static LRESULT CALLBACK floatbar_proc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 	static BOOL dragging = FALSE;
 	static BOOL leftButtonDown = FALSE;
 	static int dragOffsetX = 0;
-	static wfFloatBar* floatbar = NULL;
+	static wfFloatBar* floatbar = nullptr;
 	static TRACKMOUSEEVENT tme = { 0 };
 	PAINTSTRUCT ps = { 0 };
 	HDC hdc;
@@ -662,7 +662,7 @@ static LRESULT CALLBACK floatbar_proc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 			if (!floatbar->shown)
 			{
 				KillTimer(floatbar->hwnd, TIMER_HIDE);
-				if (SetTimer(floatbar->hwnd, TIMER_SHOW, 150, NULL) == 0)
+				if (SetTimer(floatbar->hwnd, TIMER_SHOW, 150, nullptr) == 0)
 					WLog_WARN(TAG, "SetTimer failed with %08" PRIx32, GetLastError());
 			}
 			else
@@ -698,7 +698,7 @@ static LRESULT CALLBACK floatbar_proc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 					if (hover)
 						hover->active = TRUE;
 					floatbar->hoverButton = hover;
-					InvalidateRect(hWnd, NULL, FALSE);
+					InvalidateRect(hWnd, nullptr, FALSE);
 				}
 			}
 			return 0;
@@ -706,7 +706,7 @@ static LRESULT CALLBACK floatbar_proc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 		case WM_MOUSELEAVE:
 			floatbar->mouseInside = FALSE;
 			floatbar_clear_hover(floatbar);
-			InvalidateRect(hWnd, NULL, FALSE);
+			InvalidateRect(hWnd, nullptr, FALSE);
 			floatbar_trigger_hide(floatbar);
 			return 0;
 
@@ -720,8 +720,8 @@ static LRESULT CALLBACK floatbar_proc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 		case WM_DESTROY:
 			floatbar_kill_timers(floatbar);
 			DeleteDC(floatbar->hdcmem);
-			floatbar->hdcmem = NULL;
-			floatbar->hwnd = NULL;
+			floatbar->hdcmem = nullptr;
+			floatbar->hwnd = nullptr;
 			return 0;
 
 		default:
@@ -745,16 +745,16 @@ static BOOL floatbar_window_create(wfFloatBar* floatbar)
 	wndCls.cbSize = sizeof(WNDCLASSEX);
 	wndCls.style = CS_HREDRAW | CS_VREDRAW | CS_OWNDC;
 	wndCls.lpfnWndProc = floatbar_proc;
-	wndCls.hIcon = LoadIcon(NULL, IDI_APPLICATION);
-	wndCls.hCursor = LoadCursor(NULL, IDC_ARROW);
-	wndCls.hbrBackground = NULL;
+	wndCls.hIcon = LoadIcon(nullptr, IDI_APPLICATION);
+	wndCls.hCursor = LoadCursor(nullptr, IDC_ARROW);
+	wndCls.hbrBackground = nullptr;
 	wndCls.lpszClassName = L"floatbar";
 	wndCls.hInstance = floatbar->root_window;
-	wndCls.hIconSm = LoadIcon(NULL, IDI_APPLICATION);
+	wndCls.hIconSm = LoadIcon(nullptr, IDI_APPLICATION);
 	RegisterClassEx(&wndCls);
 
 	barWnd = CreateWindowEx(WS_EX_TOOLWINDOW, L"floatbar", L"floatbar", WS_POPUP, x, parentRect.top,
-	                        floatbar->width, BACKGROUND_H, floatbar->parent, NULL,
+	                        floatbar->width, BACKGROUND_H, floatbar->parent, nullptr,
 	                        floatbar->root_window, floatbar);
 	if (!barWnd)
 		return FALSE;
@@ -797,13 +797,13 @@ wfFloatBar* wf_floatbar_new(wfContext* wfc, HINSTANCE window, DWORD flags)
 	wfFloatBar* floatbar;
 
 	if ((flags & 0x0001) == 0)
-		return NULL;
+		return nullptr;
 	if (!wfc)
-		return NULL;
+		return nullptr;
 
 	floatbar = (wfFloatBar*)calloc(1, sizeof(wfFloatBar));
 	if (!floatbar)
-		return NULL;
+		return nullptr;
 
 	floatbar->root_window = window;
 	floatbar->flags = flags;
@@ -843,7 +843,7 @@ wfFloatBar* wf_floatbar_new(wfContext* wfc, HINSTANCE window, DWORD flags)
 
 fail:
 	wf_floatbar_free(floatbar);
-	return NULL;
+	return nullptr;
 }
 
 BOOL wf_floatbar_toggle_fullscreen(wfFloatBar* floatbar, BOOL fullscreen)


### PR DESCRIPTION
## Summary
- optimize floatbar positioning and visibility behavior for the Windows client on current upstream
- improve floatbar repositioning, show/hide behavior, and related state synchronization
- fix incorrect maximize/restore button visibility switching in the floatbar window

## Main changes
- route floatbar position updates through the `wf_floatbar_reset_position()` call path
- improve floatbar repositioning after desktop resize, window move, window resize, and exit-size-move
- replace the previous hide/show behavior with two stable states:
  - full bar
  - 2px strip
- adjust floatbar width dynamically based on the window title while keeping a minimum width
- fix maximize/restore button visibility switching for different window states
- improve floatbar resource cleanup on disconnect

- reorganize floatbar positioning and visibility logic around the current upstream call flow
- consolidate repositioning, visibility state switching, and lifecycle handling to reduce inconsistent states
