### PR TITLE
[ci,android] default to only aarch64

### DIFF
--- a/scripts/android-build.conf
+++ b/scripts/android-build.conf
@@ -33,4 +33,4 @@ BUILD_SRC=$SRC_DIR/build
 
 CMAKE_BUILD_TYPE=Debug
 
-BUILD_ARCH="armeabi-v7a arm64-v8a"
+BUILD_ARCH="arm64-v8a"


### PR DESCRIPTION
Default to build only aarch64