### PR TITLE
fix: prevent PostQuitMessage in RemoteApp WM_DESTROY handler

### DIFF
--- a/client/Windows/wf_rail.c
+++ b/client/Windows/wf_rail.c
@@ -400,7 +400,7 @@ LRESULT CALLBACK wf_RailWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPara
 			break;
 
 		case WM_DESTROY:
-			PostQuitMessage(0);
+			/* PostQuitMessage(0) - REMOVED: closing RemoteApp window should not quit the session */
 			break;
 
 		default:


### PR DESCRIPTION
## Summary

Fix for issue #4074: wfreerdp remoteapp unusable

### Problem

When using wfreerdp in RemoteApp mode (`/app:"||ALIAS"`), closing a RemoteApp window triggers `PostQuitMessage(0)` in the `wf_RailWndProc` WM_DESTROY handler. This unexpectedly quits the entire wfreerdp session instead of just closing the RemoteApp application window.

### Fix

Comment out `PostQuitMessage(0)` from the `wf_RailWndProc` WM_DESTROY handler. The `DestroyWindow(hWnd)` call in the WM_CLOSE handler is appropriate for RemoteApp windows -- the window should be destroyed when closed. However, `PostQuitMessage(0)` should only be called when the main FreeRDP session window is closed, not individual RemoteApp child windows.

### Changes

- `client/Windows/wf_rail.c`: Commented out `PostQuitMessage(0)` from WM_DESTROY case in `wf_RailWndProc`

Fixes #4074
