### PR TITLE
[client,android] add an option to enable keeping screen on when connected

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ApplicationSettingsActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ApplicationSettingsActivity.java
@@ -236,6 +236,13 @@ public class ApplicationSettingsActivity extends AppCompatPreferenceActivity
 		    context.getString(R.string.preference_key_power_disconnect_timeout), 0);
 	}
 
+	public static boolean getKeepScreenOnWhenConnected(Context context)
+	{
+		SharedPreferences preferences = get(context);
+		return preferences.getBoolean(
+		    context.getString(R.string.preference_key_power_keep_screen_on_when_connected), false);
+	}
+
 	public static boolean getHideStatusBar(Context context)
 	{
 		SharedPreferences preferences = get(context);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -1431,6 +1431,11 @@ public class SessionActivity extends AppCompatActivity
 			// bind session
 			bindSession();
 
+			if (ApplicationSettingsActivity.getKeepScreenOnWhenConnected(context))
+			{
+				getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+			}
+
 			if (progressDialog != null)
 			{
 				progressDialog.dismiss();
@@ -1486,6 +1491,11 @@ public class SessionActivity extends AppCompatActivity
 
 			// remove pending move events
 			uiHandler.removeMessages(UIHandler.SEND_MOVE_EVENT);
+
+			if (ApplicationSettingsActivity.getKeepScreenOnWhenConnected(context))
+			{
+				getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+			}
 
 			if (progressDialog != null)
 			{

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -171,6 +171,7 @@
     <string name="settings_cat_power">Power Saving</string>
     <string name="settings_cat_client">Client</string>
     <string name="settings_power_disconnect_timeout">Close idle Connections</string>
+    <string name="settings_power_keep_screen_on_when_connected">Keep screen on when connected</string>
     <string name="settings_cat_security">Security</string>
     <string name="settings_security_accept_certificates">Accept all Certificates</string>
     <string name="settings_security_clear_certificate_cache">Clear Certificate Cache</string>
@@ -218,6 +219,7 @@
     <string name="preference_key_accept_certificates" translatable="false">security.accept_certificates</string>
     <string name="preference_key_security_clear_certificate_cache" translatable="false">security.clear_certificate_cache</string>
     <string name="preference_key_power_disconnect_timeout" translatable="false">power.disconnect_timeout</string>
+    <string name="preference_key_power_keep_screen_on_when_connected" translatable="false">power.keep_screen_on_when_connected</string>
     <string name="preference_key_ui_hide_status_bar" translatable="false">ui.hide_status_bar</string>
     <string name="preference_key_ui_ask_on_exit" translatable="false">ui.ask_on_exit</string>
     <string name="preference_key_ui_auto_scroll_touchpointer" translatable="false">ui.auto_scroll_touchpointer</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_power.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_power.xml
@@ -10,4 +10,8 @@
         freerdp:bounds_default="5"
         freerdp:bounds_max="30"
         freerdp:bounds_min="0" />
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="@string/preference_key_power_keep_screen_on_when_connected"
+        android:title="@string/settings_power_keep_screen_on_when_connected" />
 </PreferenceScreen>


### PR DESCRIPTION
When this option is enabled, the sessionactivity will set  keep_screen_on flag when session connected and clear this flag when session disconnected.


for #12134 