### PR TITLE
(sdl3): Fix oversized window on HiDPI Wayland

### DIFF
--- a/client/SDL/SDL3/sdl_config.hpp.in
+++ b/client/SDL/SDL3/sdl_config.hpp.in
@@ -27,4 +27,4 @@ static const char SDL_CLIENT_VENDOR[] = "@VENDOR@";
 static const char SDL_CLIENT_UUID[] = "@SDL_CLIENT_UUID@";
 static const char SDL_CLIENT_COPYRIGHT[] = "FreeRDP project";
 static const char SDL_CLIENT_URL[] = "@PROJECT_URL@";
-static const char SDL_CLIENT_TYPE[] = "application"; 
+static const char SDL_CLIENT_TYPE[] = "application";

--- a/client/SDL/SDL3/sdl_context.cpp
+++ b/client/SDL/SDL3/sdl_context.cpp
@@ -1117,6 +1117,8 @@ bool SdlContext::handleEvent(const SDL_WindowEvent& ev)
 		case SDL_EVENT_WINDOW_MOUSE_ENTER:
 			return restoreCursor();
 		case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:
+			if (!resizeToScale(window))
+				return false;
 			if (isConnected())
 			{
 				if (!window->fill())
@@ -1128,6 +1130,8 @@ bool SdlContext::handleEvent(const SDL_WindowEvent& ev)
 			}
 			break;
 		case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+			if (!resizeToScale(window))
+				return false;
 			if (!window->fill())
 				return false;
 			if (!drawToWindow(*window))
@@ -1452,6 +1456,17 @@ int SdlContext::argumentHandler(const COMMAND_LINE_ARGUMENT_A* arg, void* custom
 		}
 	}
 	return 0;
+}
+
+bool SdlContext::resizeToScale(SdlWindow* window)
+{
+	if (freerdp_settings_get_bool(context()->settings, FreeRDP_SmartSizing))
+		return true;
+	if (!useLocalScale())
+		return true;
+	if (!window)
+		return false;
+	return window->resizeToScale();
 }
 
 bool SdlContext::useLocalScale() const

--- a/client/SDL/SDL3/sdl_context.hpp
+++ b/client/SDL/SDL3/sdl_context.hpp
@@ -150,6 +150,7 @@ class SdlContext
 	[[nodiscard]] static int argumentHandler(const COMMAND_LINE_ARGUMENT_A* arg, void* custom);
 
   private:
+	[[nodiscard]] bool resizeToScale(SdlWindow* window);
 	[[nodiscard]] bool useLocalScale() const;
 
 	[[nodiscard]] static BOOL preConnect(freerdp* instance);

--- a/client/SDL/SDL3/sdl_window.cpp
+++ b/client/SDL/SDL3/sdl_window.cpp
@@ -28,7 +28,7 @@
 
 SdlWindow::SdlWindow(SDL_DisplayID id, const std::string& title, const SDL_Rect& rect,
                      [[maybe_unused]] Uint32 flags)
-    : _displayID(id)
+    : _initialW(rect.w), _initialH(rect.h), _displayID(id)
 {
 	auto props = SDL_CreateProperties();
 	SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_TITLE_STRING, title.c_str());
@@ -36,6 +36,7 @@ SdlWindow::SdlWindow(SDL_DisplayID id, const std::string& title, const SDL_Rect&
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, rect.y);
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, rect.w);
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, rect.h);
+	SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_RESIZABLE_BOOLEAN, true);
 
 	if (flags & SDL_WINDOW_HIGH_PIXEL_DENSITY)
 		SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN, true);
@@ -48,12 +49,12 @@ SdlWindow::SdlWindow(SDL_DisplayID id, const std::string& title, const SDL_Rect&
 
 	_window = SDL_CreateWindowWithProperties(props);
 	SDL_DestroyProperties(props);
-
-	std::ignore = resizeToPixelSize({ rect.w, rect.h });
 	SDL_SetHint(SDL_HINT_APP_NAME, "");
 	std::ignore = SDL_SyncWindow(_window);
 
 	_renderer = SDL_CreateRenderer(_window, nullptr);
+
+	std::ignore = resizeToScale();
 
 	_monitor = query(_window, id, true);
 }
@@ -61,8 +62,9 @@ SdlWindow::SdlWindow(SDL_DisplayID id, const std::string& title, const SDL_Rect&
 SdlWindow::SdlWindow(SdlWindow&& other) noexcept
     : _window(other._window), _renderer(other._renderer), _renderTarget(other._renderTarget),
       _gdiTexture(other._gdiTexture), _gdiTextureW(other._gdiTextureW),
-      _gdiTextureH(other._gdiTextureH), _displayID(other._displayID), _offset_x(other._offset_x),
-      _offset_y(other._offset_y), _monitor(other._monitor)
+      _gdiTextureH(other._gdiTextureH), _initialW(other._initialW), _initialH(other._initialH),
+      _displayID(other._displayID), _offset_x(other._offset_x), _offset_y(other._offset_y),
+      _monitor(other._monitor)
 {
 	other._window = nullptr;
 	other._renderer = nullptr;
@@ -228,13 +230,29 @@ void SdlWindow::minimize()
 	std::ignore = SDL_SyncWindow(_window);
 }
 
-bool SdlWindow::resizeToPixelSize(const SDL_Point& size)
+bool SdlWindow::resizeToScale()
 {
-	auto sc = scale();
-	const int iscale = static_cast<int>(sc * 100.0f);
-	auto w = 100 * size.x / iscale;
-	auto h = 100 * size.y / iscale;
-	return resize({ w, h });
+	if (!_window || _initialW <= 0 || _initialH <= 0)
+		return false;
+	if ((SDL_GetWindowFlags(_window) & SDL_WINDOW_FULLSCREEN) != 0)
+		return true;
+
+	float pd = SDL_GetWindowPixelDensity(_window);
+	if (pd <= 0.0f)
+		pd = 1.0f;
+
+	const int targetW = static_cast<int>(std::ceil(static_cast<float>(_initialW) / pd));
+	const int targetH = static_cast<int>(std::ceil(static_cast<float>(_initialH) / pd));
+
+	int curW = 0;
+	int curH = 0;
+	if (!SDL_GetWindowSize(_window, &curW, &curH))
+		return false;
+
+	if (curW == targetW && curH == targetH)
+		return true;
+
+	return resize({ targetW, targetH });
 }
 
 bool SdlWindow::resize(const SDL_Point& size)
@@ -551,7 +569,7 @@ SdlWindow SdlWindow::create(SDL_DisplayID id, const std::string& title, Uint32 f
 
 	SdlWindow window{ id, title, rect, flags };
 
-	if ((flags & (SDL_WINDOW_FULLSCREEN)) != 0)
+	if ((flags & SDL_WINDOW_FULLSCREEN) != 0)
 	{
 		window.setOffsetX(rect.x);
 		window.setOffsetY(rect.y);

--- a/client/SDL/SDL3/sdl_window.hpp
+++ b/client/SDL/SDL3/sdl_window.hpp
@@ -67,7 +67,7 @@ class SdlWindow
 	void fullscreen(bool enter, bool forceOriginalDisplay);
 	void minimize();
 
-	[[nodiscard]] bool resizeToPixelSize(const SDL_Point& size);
+	[[nodiscard]] bool resizeToScale();
 	[[nodiscard]] bool resize(const SDL_Point& size);
 
 	[[nodiscard]] bool drawRect(SDL_Surface* surface, SDL_Point offset, const SDL_Rect& srcRect);
@@ -114,6 +114,8 @@ class SdlWindow
 	SDL_Texture* _gdiTexture = nullptr;
 	int _gdiTextureW = 0;
 	int _gdiTextureH = 0;
+	int _initialW = 0;
+	int _initialH = 0;
 	SDL_DisplayID _displayID = 0;
 	Sint32 _offset_x = 0;
 	Sint32 _offset_y = 0;


### PR DESCRIPTION
Fix oversized window on HiDPI Wayland.

On HiDPI Wayland sessions, the SDL3 FreeRDP window is created at the requested pixel count interpreted as logical pixels, which the compositor then scales up to physical pixels.

server surface appears smaller than wayland client window on windowed mode.


| Before |  After |
| ------ | ------- |
| <img width="500" alt="Before" src="https://github.com/user-attachments/assets/9c8f1fd2-5199-4e04-8bb5-95cc95824dd0" /> | <img width="500" alt="After" src="https://github.com/user-attachments/assets/fc292368-4060-4c68-9433-44a9959151d8" /> |
