### PR TITLE
[client,X11] fix residual race in xf_clipboard_formats_free

### DIFF
--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -869,13 +869,14 @@ static void xf_clipboard_formats_free(xfClipboard* clipboard)
 {
 	WINPR_ASSERT(clipboard);
 
-	/* Synchronize RDP/X11 thread with channel thread */
+	/* Synchronize RDP/X11 thread with channel thread.
+	 * Reset the pointer and count inside the lock so that
+	 * xf_clipboard_changed cannot observe a freed-but-non-NULL pointer. */
 	xf_lock_x11(clipboard->xfc);
 	xf_cliprdr_free_formats(clipboard->lastSentFormats, clipboard->lastSentNumFormats);
-	xf_unlock_x11(clipboard->xfc);
-
 	clipboard->lastSentFormats = nullptr;
 	clipboard->lastSentNumFormats = 0;
+	xf_unlock_x11(clipboard->xfc);
 }
 
 static BOOL xf_clipboard_copy_formats(xfClipboard* clipboard, const CLIPRDR_FORMAT* formats,


### PR DESCRIPTION
Commit 58409406 locked xf_cliprdr_free_formats() but reset lastSentFormats/lastSentNumFormats after releasing the lock. This left a narrow window where xf_clipboard_changed() could observe a freed-but-non-NULL pointer if the X11 event thread acquired the lock between the unlock and the reset.

Move the pointer/count reset inside the critical section so that any reader holding the lock always sees a consistent nullptr/0 or a valid allocation.

Made-with: Cursor