### PR TITLE
[codec,dsp] fix fencepost error in dsp_ima_clamp_step

### DIFF
--- a/libfreerdp/codec/dsp.c
+++ b/libfreerdp/codec/dsp.c
@@ -327,8 +327,8 @@ static inline void dsp_ima_clamp_step(ADPCM* WINPR_RESTRICT adpcm, unsigned int 
 		adpcm->ima.last_step[channel] = 0;
 
 	const size_t size = ARRAYSIZE(ima_step_size_table);
-	if (adpcm->ima.last_step[channel] > size)
-		adpcm->ima.last_step[channel] = size;
+	if ((size_t)adpcm->ima.last_step[channel] >= size)
+		adpcm->ima.last_step[channel] = (INT16)(size - 1);
 }
 
 static UINT16 dsp_decode_ima_adpcm_sample(ADPCM* WINPR_RESTRICT adpcm, unsigned int channel,


### PR DESCRIPTION
Commit 9be3f03 introduced dsp_ima_clamp_step() to clamp the IMA-ADPCM step index to a valid range, but uses `> size` instead of `>= size`, allowing `last_step` to be set to `size` (89) — one past the last valid index (88) of `ima_step_size_table`.

As a result, a step index of 89 is not clamped and any value >= 90 is clamped to 89, both of which cause an out-of-bounds read on the 89-element `ima_step_size_table[]` and trigger WINPR_ASSERT in debug builds.

Fix by using `>= size` as the condition and clamping to `size - 1` (the last valid index). The `(INT16)` casts are added to avoid signed/unsigned comparison and narrowing conversion warnings.

Made-with: Cursor