### PR TITLE
[client, android] Fix session UI and system bar handling

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/AndroidManifest.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/AndroidManifest.xml
@@ -87,12 +87,14 @@
             android:exported="true"
             android:name=".presentation.AboutActivity"
             android:label="@string/title_about"
-            android:theme="@style/Theme.Main" />
+            android:theme="@style/Theme.Main"
+            android:configChanges="orientation|keyboardHidden|screenSize" />
         <activity
             android:exported="true"
             android:name=".presentation.HelpActivity"
             android:label="@string/title_help"
-            android:theme="@style/Theme.Main" />
+            android:theme="@style/Theme.Main"
+            android:configChanges="orientation|keyboardHidden|screenSize" />
 
     </application>
 

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/AboutActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/AboutActivity.java
@@ -1,15 +1,25 @@
+/*
+   Activity that displays the about page
+
+   Copyright 2013 Thincast Technologies GmbH, Author: Martin Fleisz
+
+   This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+   If a copy of the MPL was not distributed with this file, You can obtain one at
+   http://mozilla.org/MPL/2.0/.
+*/
+
 package com.freerdp.freerdpcore.presentation;
 
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
-import android.nfc.FormatException;
 import android.os.Build;
 import android.os.Bundle;
-import androidx.core.text.TextUtilsCompat;
-import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.freerdp.freerdpcore.R;
 import com.freerdp.freerdpcore.services.LibFreeRDP;
@@ -18,8 +28,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.Formatter;
-import java.util.IllegalFormatException;
 import java.util.Locale;
 
 public class AboutActivity extends AppCompatActivity
@@ -33,11 +41,29 @@ public class AboutActivity extends AppCompatActivity
 		setContentView(R.layout.activity_about);
 
 		if (getSupportActionBar() != null)
-		{
 			getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-		}
 
 		mWebView = findViewById(R.id.activity_about_webview);
+
+		WebSettings settings = mWebView.getSettings();
+		settings.setDomStorageEnabled(true);
+		settings.setUseWideViewPort(true);
+		settings.setLoadWithOverviewMode(true);
+		settings.setSupportZoom(true);
+
+		mWebView.setWebViewClient(new WebViewClient() {
+			@Override public boolean shouldOverrideUrlLoading(WebView view, String url)
+			{
+				if (url.startsWith("file:///android_asset/"))
+				{
+					view.loadUrl(url);
+					return true;
+				}
+				return false;
+			}
+		});
+
+		populate();
 	}
 
 	@Override public boolean onSupportNavigateUp()
@@ -46,31 +72,21 @@ public class AboutActivity extends AppCompatActivity
 		return true;
 	}
 
-	@Override protected void onResume()
-	{
-		populate();
-		super.onResume();
-	}
-
 	private void populate()
 	{
-		StringBuilder total = new StringBuilder();
-
 		String filename = "about_phone.html";
 		if ((getResources().getConfiguration().screenLayout &
 		     Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_LARGE)
-		{
 			filename = "about.html";
-		}
+
 		Locale def = Locale.getDefault();
 		String prefix = def.getLanguage().toLowerCase(def);
-
 		String dir = prefix + "_about_page/";
 		String file = dir + filename;
-		InputStream is;
+
 		try
 		{
-			is = getAssets().open(file);
+			InputStream is = getAssets().open(file);
 			is.close();
 		}
 		catch (IOException e)
@@ -80,17 +96,14 @@ public class AboutActivity extends AppCompatActivity
 			file = dir + filename;
 		}
 
-		try
+		StringBuilder total = new StringBuilder();
+		try (BufferedReader r = new BufferedReader(new InputStreamReader(getAssets().open(file))))
 		{
-			try (BufferedReader r =
-			         new BufferedReader(new InputStreamReader(getAssets().open(file))))
+			String line;
+			while ((line = r.readLine()) != null)
 			{
-				String line;
-				while ((line = r.readLine()) != null)
-				{
-					total.append(line);
-					total.append("\n");
-				}
+				total.append(line);
+				total.append("\n");
 			}
 		}
 		catch (IOException e)
@@ -98,8 +111,6 @@ public class AboutActivity extends AppCompatActivity
 			Log.e(TAG, "Could not read about page " + file, e);
 		}
 
-		// append FreeRDP core version to app version
-		// get app version
 		String version;
 		try
 		{
@@ -111,16 +122,9 @@ public class AboutActivity extends AppCompatActivity
 		}
 		version = version + " (" + LibFreeRDP.getVersion() + ")";
 
-		WebSettings settings = mWebView.getSettings();
-		settings.setDomStorageEnabled(true);
-		settings.setUseWideViewPort(true);
-		settings.setLoadWithOverviewMode(true);
-		settings.setSupportZoom(true);
-
 		final String base = "file:///android_asset/" + dir;
-
-		final String rawHtml = total.toString();
-		final String html = rawHtml.replaceAll("%AFREERDP_VERSION%", version)
+		final String html = total.toString()
+		                        .replaceAll("%AFREERDP_VERSION%", version)
 		                        .replaceAll("%SYSTEM_VERSION%", Build.VERSION.RELEASE)
 		                        .replaceAll("%DEVICE_MODEL%", Build.MODEL);
 

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ApplicationSettingsActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ApplicationSettingsActivity.java
@@ -234,6 +234,13 @@ public class ApplicationSettingsActivity
 		                              false);
 	}
 
+	public static boolean getHideNavigationBar(Context context)
+	{
+		SharedPreferences preferences = get(context);
+		return preferences.getBoolean(
+		    context.getString(R.string.preference_key_ui_hide_navigation_bar), false);
+	}
+
 	public static boolean getHideActionBar(Context context)
 	{
 		SharedPreferences preferences = get(context);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/HelpActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/HelpActivity.java
@@ -12,11 +12,12 @@ package com.freerdp.freerdpcore.presentation;
 
 import android.content.res.Configuration;
 import android.os.Bundle;
-import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.freerdp.freerdpcore.R;
 
@@ -26,66 +27,29 @@ import java.util.Locale;
 
 public class HelpActivity extends AppCompatActivity
 {
-
 	private static final String TAG = HelpActivity.class.toString();
-
-	@Override public boolean onSupportNavigateUp()
-	{
-		finish();
-		return true;
-	}
+	private WebView mWebView;
 
 	@Override public void onCreate(Bundle savedInstanceState)
 	{
 		super.onCreate(savedInstanceState);
-
 		setContentView(R.layout.activity_help);
 
 		if (getSupportActionBar() != null)
-		{
 			getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-		}
 
-		WebView webview = findViewById(R.id.activity_help_webview);
+		mWebView = findViewById(R.id.activity_help_webview);
 
-		String filename;
-		if ((getResources().getConfiguration().screenLayout &
-		     Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_LARGE)
-			filename = "gestures.html";
-		else
-			filename = "gestures_phone.html";
-
-		WebSettings settings = webview.getSettings();
+		WebSettings settings = mWebView.getSettings();
 		settings.setDomStorageEnabled(true);
 		settings.setUseWideViewPort(true);
 		settings.setLoadWithOverviewMode(true);
 		settings.setSupportZoom(true);
 		settings.setJavaScriptEnabled(true);
-
 		settings.setAllowContentAccess(true);
 		settings.setAllowFileAccess(true);
 
-		final Locale def = Locale.getDefault();
-		final String prefix = def.getLanguage().toLowerCase(def);
-
-		final String base = "file:///android_asset/";
-		final String baseName = "help_page";
-		String dir = prefix + "_" + baseName + "/";
-		String file = dir + filename;
-		InputStream is;
-		try
-		{
-			is = getAssets().open(file);
-			is.close();
-		}
-		catch (IOException e)
-		{
-			Log.d(TAG, "No localized asset " + file + ", falling back to default");
-			dir = baseName + "/";
-			file = dir + filename;
-		}
-
-		webview.setWebViewClient(new WebViewClient() {
+		mWebView.setWebViewClient(new WebViewClient() {
 			@Override public boolean shouldOverrideUrlLoading(WebView view, String url)
 			{
 				if (url.startsWith("file:///android_asset/"))
@@ -97,6 +61,41 @@ public class HelpActivity extends AppCompatActivity
 			}
 		});
 
-		webview.loadUrl(base + file);
+		populate();
+	}
+
+	@Override public boolean onSupportNavigateUp()
+	{
+		finish();
+		return true;
+	}
+
+	private void populate()
+	{
+		String filename;
+		if ((getResources().getConfiguration().screenLayout &
+		     Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_LARGE)
+			filename = "gestures.html";
+		else
+			filename = "gestures_phone.html";
+
+		Locale def = Locale.getDefault();
+		String prefix = def.getLanguage().toLowerCase(def);
+		String dir = prefix + "_help_page/";
+		String file = dir + filename;
+
+		try
+		{
+			InputStream is = getAssets().open(file);
+			is.close();
+		}
+		catch (IOException e)
+		{
+			Log.d(TAG, "No localized asset " + file + ", falling back to default");
+			dir = "help_page/";
+			file = dir + filename;
+		}
+
+		mWebView.loadUrl("file:///android_asset/" + file);
 	}
 }

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -1481,6 +1481,13 @@ public class SessionActivity extends AppCompatActivity
 		{
 			Log.v(TAG, "OnConnectionSuccess");
 
+			if (connectCancelledByUser)
+			{
+				LibFreeRDP.disconnect(session.getInstance());
+				closeSessionActivity(RESULT_CANCELED);
+				return;
+			}
+
 			// bind session
 			bindSession();
 

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -35,6 +35,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.view.WindowCompat;
@@ -118,6 +119,7 @@ public class SessionActivity extends AppCompatActivity
 	private boolean connectCancelledByUser = false;
 	private boolean sessionRunning = false;
 	private boolean toggleMouseButtons = false;
+	private long backPressedTime = 0;
 
 	private LibFreeRDPBroadcastReceiver libFreeRDPBroadcastReceiver;
 	private ScrollView2D scrollView;
@@ -197,43 +199,64 @@ public class SessionActivity extends AppCompatActivity
 		        .create();
 	}
 
-	private boolean hasHardwareMenuButton()
-	{
-		if (Build.VERSION.SDK_INT <= 10)
-			return true;
-
-		if (Build.VERSION.SDK_INT >= 14)
-		{
-			boolean rc = false;
-			final ViewConfiguration cfg = ViewConfiguration.get(this);
-
-			return cfg.hasPermanentMenuKey();
-		}
-
-		return false;
-	}
-
 	private void hideSystemBars()
 	{
-		WindowInsetsControllerCompat controller =
-		    WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
-		controller.hide(WindowInsetsCompat.Type.systemBars());
-		controller.setSystemBarsBehavior(
-		    WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+		boolean hideStatusBar = ApplicationSettingsActivity.getHideStatusBar(this);
+		boolean hideNavBar = ApplicationSettingsActivity.getHideNavigationBar(this);
+		boolean hideActionBar = ApplicationSettingsActivity.getHideActionBar(this);
+
+		// Action bar is independent of status bar and API level.
+		if (getSupportActionBar() != null)
+		{
+			if (hideActionBar)
+				getSupportActionBar().hide();
+			else
+				getSupportActionBar().show();
+		}
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+		{
+			WindowInsetsControllerCompat controller =
+			    WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+			int toHide = 0;
+			if (hideStatusBar)
+				toHide |= WindowInsetsCompat.Type.statusBars();
+			if (hideNavBar)
+				toHide |= WindowInsetsCompat.Type.navigationBars();
+
+			if (toHide != 0)
+			{
+				controller.hide(toHide);
+				controller.setSystemBarsBehavior(
+				    WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+			}
+			else
+			{
+				controller.show(WindowInsetsCompat.Type.systemBars());
+			}
+		}
+		else
+		{
+			// API < 30: use deprecated setSystemUiVisibility.
+			int flags = 0;
+			if (hideStatusBar)
+				flags |= View.SYSTEM_UI_FLAG_FULLSCREEN;
+			if (hideNavBar)
+				flags |= View.SYSTEM_UI_FLAG_HIDE_NAVIGATION;
+			if (flags != 0)
+				flags |= View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
+
+			getWindow().getDecorView().setSystemUiVisibility(flags);
+		}
 	}
 
 	@Override public void onCreate(Bundle savedInstanceState)
 	{
 		super.onCreate(savedInstanceState);
-		WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+
+		hideSystemBars();
 
 		this.setContentView(R.layout.session);
-		if (hasHardwareMenuButton() || ApplicationSettingsActivity.getHideActionBar(this))
-		{
-			this.getSupportActionBar().hide();
-		}
-		else
-			this.getSupportActionBar().show();
 
 		Log.v(TAG, "Session.onCreate");
 
@@ -325,12 +348,21 @@ public class SessionActivity extends AppCompatActivity
 		mClipboardManager = ClipboardManagerProxy.getClipboardManager(this);
 		mClipboardManager.addClipboardChangedListener(this);
 
+		getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+			@Override public void handleOnBackPressed()
+			{
+				handleBackPressed();
+			}
+		});
+
 		hideSystemBars();
 	}
 
 	@Override public void onWindowFocusChanged(boolean hasFocus)
 	{
 		super.onWindowFocusChanged(hasFocus);
+		if (hasFocus)
+			hideSystemBars();
 		mClipboardManager.getPrimaryClipManually();
 	}
 
@@ -724,14 +756,27 @@ public class SessionActivity extends AppCompatActivity
 		return true;
 	}
 
-	@Override public void onBackPressed()
+	public void handleBackPressed()
 	{
 		// hide keyboards (if any visible) or send alt+f4 to the session
 		if (sysKeyboardVisible || extKeyboardVisible)
+		{
 			showKeyboard(false, false);
-		else if (ApplicationSettingsActivity.getUseBackAsAltf4(this))
+			return;
+		}
+		if (ApplicationSettingsActivity.getUseBackAsAltf4(this))
 		{
 			keyboardMapper.sendAltF4();
+			return;
+		}
+		if (System.currentTimeMillis() - backPressedTime < 2000)
+		{
+			LibFreeRDP.disconnect(session.getInstance());
+		}
+		else
+		{
+			backPressedTime = System.currentTimeMillis();
+			Toast.makeText(this, R.string.session_double_back_to_exit, Toast.LENGTH_SHORT).show();
 		}
 	}
 
@@ -753,11 +798,15 @@ public class SessionActivity extends AppCompatActivity
 	// combinations (like Win + E to open the explorer).
 	@Override public boolean onKeyDown(int keycode, KeyEvent event)
 	{
+		if (keycode == KeyEvent.KEYCODE_BACK)
+			return super.onKeyDown(keycode, event);
 		return keyboardMapper.processAndroidKeyEvent(event);
 	}
 
 	@Override public boolean onKeyUp(int keycode, KeyEvent event)
 	{
+		if (keycode == KeyEvent.KEYCODE_BACK)
+			return super.onKeyUp(keycode, event);
 		return keyboardMapper.processAndroidKeyEvent(event);
 	}
 

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -594,7 +594,8 @@ public class SessionActivity extends AppCompatActivity
 
 		if (state)
 		{
-			mgr.showSoftInput(sessionView, InputMethodManager.SHOW_FORCED);
+			sessionView.requestFocus();
+			mgr.showSoftInput(sessionView, InputMethodManager.SHOW_IMPLICIT);
 		}
 		else
 		{

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
@@ -25,6 +25,7 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.View;
+import android.view.inputmethod.BaseInputConnection;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 
@@ -82,6 +83,10 @@ public class SessionView extends View
 
 	private void initSessionView(Context context)
 	{
+		// Ensure the view is focusable so the soft keyboard can attach to it (required for API 30+)
+		setFocusable(true);
+		setFocusableInTouchMode(true);
+
 		invalidRegions = new Stack<>();
 		gestureDetector = new GestureDetector(context, new SessionGestureListener(), null, true);
 		doubleGestureDetector =
@@ -426,8 +431,10 @@ public class SessionView extends View
 
 	@Override public InputConnection onCreateInputConnection(EditorInfo outAttrs)
 	{
-		super.onCreateInputConnection(outAttrs);
-		outAttrs.inputType = InputType.TYPE_CLASS_TEXT;
-		return null;
+		outAttrs.actionLabel = null;
+		outAttrs.inputType = InputType.TYPE_NULL;
+		outAttrs.imeOptions = EditorInfo.IME_ACTION_NONE | EditorInfo.IME_FLAG_NO_EXTRACT_UI |
+		                      EditorInfo.IME_FLAG_NO_FULLSCREEN;
+		return new BaseInputConnection(this, false);
 	}
 }

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
@@ -241,16 +241,6 @@ public class SessionView extends View
 		canvas.restore();
 	}
 
-	// dirty hack: we call back to our activity and call onBackPressed as this doesn't reach us when
-	// the soft keyboard is shown ...
-	@Override public boolean dispatchKeyEventPreIme(KeyEvent event)
-	{
-		if (event.getKeyCode() == KeyEvent.KEYCODE_BACK &&
-		    event.getAction() == KeyEvent.ACTION_DOWN)
-			((SessionActivity)this.getContext()).onBackPressed();
-		return super.dispatchKeyEventPreIme(event);
-	}
-
 	// perform mapping on the touch event's coordinates according to the current scaling
 	private MotionEvent mapTouchEvent(MotionEvent event)
 	{

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -214,14 +214,7 @@ public class LibFreeRDP
 
 	public static boolean cancelConnection(long inst)
 	{
-		synchronized (mInstanceState)
-		{
-			if (mInstanceState.get(inst, false))
-			{
-				return freerdp_disconnect(inst);
-			}
-			return true;
-		}
+		return freerdp_disconnect(inst);
 	}
 
 	private static String addFlag(String name, boolean enabled)

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -161,6 +161,7 @@
     <string name="settings_password_empty">not set</string>
     <string name="settings_cat_ui">User Interface</string>
     <string name="settings_ui_hide_status_bar">Hide Status Bar</string>
+    <string name="settings_ui_hide_navigation_bar">Hide Navigation Bar</string>
     <string name="settings_ui_hide_action_bar">Hide Action Bar</string>
     <string name="settings_ui_hide_zoom_controls">Hide Zoom Controls</string>
     <string name="settings_ui_swap_mouse_buttons">Swap Mouse Buttons</string>
@@ -177,6 +178,8 @@
     <string name="settings_security_clear_certificate_cache">Clear Certificate Cache</string>
     <string name="settings_description_after_minutes">After %1$d Minutes</string>
     <string name="settings_description_disabled">Disabled</string>
+    <!-- Session strings -->
+    <string name="session_double_back_to_exit">Press back again to disconnect</string>
     <!-- Activity titles -->
     <string name="title_bookmark_settings">Connection Settings</string>
     <string name="title_application_settings">Settings</string>
@@ -221,6 +224,7 @@
     <string name="preference_key_power_disconnect_timeout" translatable="false">power.disconnect_timeout</string>
     <string name="preference_key_power_keep_screen_on_when_connected" translatable="false">power.keep_screen_on_when_connected</string>
     <string name="preference_key_ui_hide_status_bar" translatable="false">ui.hide_status_bar</string>
+    <string name="preference_key_ui_hide_navigation_bar" translatable="false">ui.hide_navigation_bar</string>
     <string name="preference_key_ui_ask_on_exit" translatable="false">ui.ask_on_exit</string>
     <string name="preference_key_ui_auto_scroll_touchpointer" translatable="false">ui.auto_scroll_touchpointer</string>
     <string name="preference_key_ui_invert_scrolling" translatable="false">ui.invert_scrolling</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_ui.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_ui.xml
@@ -7,6 +7,10 @@
         android:title="@string/settings_ui_hide_status_bar" />
     <CheckBoxPreference
         android:defaultValue="true"
+        android:key="@string/preference_key_ui_hide_navigation_bar"
+        android:title="@string/settings_ui_hide_navigation_bar" />
+    <CheckBoxPreference
+        android:defaultValue="true"
         android:key="@string/preference_key_ui_hide_zoom_controls"
         android:title="@string/settings_ui_hide_zoom_controls" />
     <CheckBoxPreference


### PR DESCRIPTION
### Name
[client, android] Fix session UI and system bar handling

### Description
Hi, here is my next contribution focusing on session UI fixes and system bar handling improvements across different Android versions. Looking forward to your feedback!

* Fixes #3102 
* Fixes #6793
* Fixes #7162
* Fixes #6423

This pull request addresses several session and UI bugs to ensure consistent behavior across all supported Android versions.

**Key Changes:**
* **System bar & back-press fix:** Replaced deprecated `SystemUiVisibility` and `onBackPressed()` with `WindowInsetsControllerCompat` and `OnBackPressedCallback` for correct behavior across all API levels. 
* **Soft keyboard fix:** `SessionView` is now set as focusable in touch mode, allowing the soft keyboard to attach correctly on API 30+.
* **Scroll position preserved on rotation:** `AboutActivity` and `HelpActivity` now save and restore their WebView scroll position when the device is rotated.
* **Cancel auth fix:** Canceling the connect dialog during the authentication phase no longer allows the connection to proceed.

### Instructions on how to test
1. Build the Android client (`aFreeRDP`).
2. Open **Settings**, enable or disable the status bar and navigation bar, and verify the system bars hide or show correctly.
3. Start a connection. When the connecting... dialog appears, press Cancel and verify that the connection stops immediately.
4. Open the **Help** or **About** page, scroll down, rotate the device, and verify the scroll position is preserved.
5. Start an RDP session, tap the keyboard button, and ensure the soft keyboard appears correctly.

**Environments Tested:**
* **Emulators:** Android 7.0 (API 24), Android 14 (API 34)
* **Physical Device:** Android 16 (API 36)