### PR TITLE
[client, android] Fix touch and physical mouse input handling

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -1179,8 +1179,9 @@ public class SessionActivity extends AppCompatActivity
 		                           Mouse.getLeftButtonEvent(this, down));
 	}
 
-		if (!down)
-			toggleMouseButtons = false;
+	@Override public void onSessionViewMiddleTouch(int x, int y, boolean down)
+	{
+		LibFreeRDP.sendCursorEvent(session.getInstance(), x, y, Mouse.getMiddleButtonEvent(down));
 	}
 
 	@Override public void onSessionViewRightTouch(int x, int y, boolean down)
@@ -1202,6 +1203,11 @@ public class SessionActivity extends AppCompatActivity
 	@Override public void onSessionViewScroll(boolean down)
 	{
 		LibFreeRDP.sendCursorEvent(session.getInstance(), 0, 0, Mouse.getScrollEvent(this, down));
+	}
+
+	@Override public void onSessionViewHScroll(boolean right)
+	{
+		LibFreeRDP.sendCursorEvent(session.getInstance(), 0, 0, Mouse.getHScrollEvent(this, right));
 	}
 
 	// ****************************************************************************

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -118,7 +118,6 @@ public class SessionActivity extends AppCompatActivity
 
 	private boolean connectCancelledByUser = false;
 	private boolean sessionRunning = false;
-	private boolean toggleMouseButtons = false;
 	private long backPressedTime = 0;
 
 	private LibFreeRDPBroadcastReceiver libFreeRDPBroadcastReceiver;
@@ -334,8 +333,6 @@ public class SessionActivity extends AppCompatActivity
 				zoomControls.setIsZoomInEnabled(true);
 			}
 		});
-
-		toggleMouseButtons = false;
 
 		createDialogs();
 
@@ -1179,22 +1176,27 @@ public class SessionActivity extends AppCompatActivity
 			cancelDelayedMoveEvent();
 
 		LibFreeRDP.sendCursorEvent(session.getInstance(), x, y,
-		                           toggleMouseButtons ? Mouse.getRightButtonEvent(this, down)
-		                                              : Mouse.getLeftButtonEvent(this, down));
+		                           Mouse.getLeftButtonEvent(this, down));
+	}
 
 		if (!down)
 			toggleMouseButtons = false;
 	}
 
-	public void onSessionViewRightTouch(int x, int y, boolean down)
+	@Override public void onSessionViewRightTouch(int x, int y, boolean down)
 	{
-		if (!down)
-			toggleMouseButtons = !toggleMouseButtons;
+		LibFreeRDP.sendCursorEvent(session.getInstance(), x, y,
+		                           Mouse.getRightButtonEvent(this, down));
 	}
 
 	@Override public void onSessionViewMove(int x, int y)
 	{
 		sendDelayedMoveEvent(x, y);
+	}
+
+	@Override public void onSessionViewMouseMove(int x, int y)
+	{
+		LibFreeRDP.sendCursorEvent(session.getInstance(), x, y, Mouse.getMoveEvent());
 	}
 
 	@Override public void onSessionViewScroll(boolean down)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
@@ -295,6 +295,8 @@ public class SessionView extends View
 	// Handle all physical mouse buttons here; finger taps come via onSingleTapUp.
 	@Override public boolean onGenericMotionEvent(MotionEvent event)
 	{
+		if (!event.isFromSource(InputDevice.SOURCE_MOUSE))
+			return false;
 
 		int action = event.getActionMasked();
 
@@ -321,9 +323,23 @@ public class SessionView extends View
 						sessionViewListener.onSessionViewBeginTouch();
 					sessionViewListener.onSessionViewRightTouch(x, y, down);
 					return true;
+				case MotionEvent.BUTTON_TERTIARY:
+					sessionViewListener.onSessionViewMiddleTouch(x, y, down);
+					return true;
 				default:
-					break;
+					return true; // consume unknown buttons silently
 			}
+		}
+
+		if (action == MotionEvent.ACTION_SCROLL)
+		{
+			float vScroll = event.getAxisValue(MotionEvent.AXIS_VSCROLL);
+			float hScroll = event.getAxisValue(MotionEvent.AXIS_HSCROLL);
+			if (vScroll != 0)
+				sessionViewListener.onSessionViewScroll(vScroll > 0);
+			if (hScroll != 0)
+				sessionViewListener.onSessionViewHScroll(hScroll > 0);
+			return true;
 		}
 
 		return false;
@@ -337,6 +353,8 @@ public class SessionView extends View
 
 		void onSessionViewLeftTouch(int x, int y, boolean down);
 
+		void onSessionViewMiddleTouch(int x, int y, boolean down);
+
 		void onSessionViewRightTouch(int x, int y, boolean down);
 
 		void onSessionViewMove(int x, int y);
@@ -344,6 +362,8 @@ public class SessionView extends View
 		void onSessionViewMouseMove(int x, int y);
 
 		void onSessionViewScroll(boolean down);
+
+		void onSessionViewHScroll(boolean right);
 	}
 
 	private class SessionGestureListener extends GestureDetector.SimpleOnGestureListener

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
@@ -18,9 +18,11 @@ import android.graphics.Matrix;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.BitmapDrawable;
+import android.os.Build;
 import android.text.InputType;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
@@ -269,9 +271,62 @@ public class SessionView extends View
 
 	@Override public boolean onTouchEvent(MotionEvent event)
 	{
+		// Physical mouse events: bypass gesture detector entirely.
+		// Buttons are handled in onGenericMotionEvent; hover moves in onHoverEvent.
+		// Only ACTION_MOVE with a button held (drag) needs handling here.
+		if (event.isFromSource(InputDevice.SOURCE_MOUSE))
+		{
+			int action = event.getActionMasked();
+			if (action == MotionEvent.ACTION_MOVE && event.getButtonState() != 0)
+			{
+				MotionEvent mapped = mapTouchEvent(event);
+				sessionViewListener.onSessionViewMouseMove((int)mapped.getX(), (int)mapped.getY());
+				mapped.recycle();
+				return true;
+			}
+			return true;
+		}
+
 		boolean res = gestureDetector.onTouchEvent(event);
 		res |= doubleGestureDetector.onTouchEvent(event);
 		return res;
+	}
+
+	// Handle all physical mouse buttons here; finger taps come via onSingleTapUp.
+	@Override public boolean onGenericMotionEvent(MotionEvent event)
+	{
+
+		int action = event.getActionMasked();
+
+		if (action == MotionEvent.ACTION_BUTTON_PRESS ||
+		    action == MotionEvent.ACTION_BUTTON_RELEASE)
+		{
+			boolean down = action == MotionEvent.ACTION_BUTTON_PRESS;
+			MotionEvent mapped = mapTouchEvent(event);
+			int x = (int)mapped.getX();
+			int y = (int)mapped.getY();
+			mapped.recycle();
+
+			switch (event.getActionButton())
+			{
+				case MotionEvent.BUTTON_PRIMARY:
+					if (down)
+						sessionViewListener.onSessionViewBeginTouch();
+					sessionViewListener.onSessionViewLeftTouch(x, y, down);
+					if (!down)
+						sessionViewListener.onSessionViewEndTouch();
+					return true;
+				case MotionEvent.BUTTON_SECONDARY:
+					if (down)
+						sessionViewListener.onSessionViewBeginTouch();
+					sessionViewListener.onSessionViewRightTouch(x, y, down);
+					return true;
+				default:
+					break;
+			}
+		}
+
+		return false;
 	}
 
 	public interface SessionViewListener
@@ -285,6 +340,8 @@ public class SessionView extends View
 		void onSessionViewRightTouch(int x, int y, boolean down);
 
 		void onSessionViewMove(int x, int y);
+
+		void onSessionViewMouseMove(int x, int y);
 
 		void onSessionViewScroll(boolean down);
 	}
@@ -348,28 +405,18 @@ public class SessionView extends View
 
 		public boolean onSingleTapUp(MotionEvent e)
 		{
-			// send single click
+			// Physical mouse buttons are handled via ACTION_BUTTON_PRESS in onGenericMotionEvent.
+			// If buttonState is non-zero this event came from a physical mouse button
+			if (e.getButtonState() != 0)
+				return false;
+
+			// Finger touch -> left click
 			MotionEvent mappedEvent = mapTouchEvent(e);
 			sessionViewListener.onSessionViewBeginTouch();
-			switch (e.getButtonState())
-			{
-				case MotionEvent.BUTTON_PRIMARY:
-					sessionViewListener.onSessionViewLeftTouch((int)mappedEvent.getX(),
-					                                           (int)mappedEvent.getY(), true);
-					sessionViewListener.onSessionViewLeftTouch((int)mappedEvent.getX(),
-					                                           (int)mappedEvent.getY(), false);
-					break;
-				case MotionEvent.BUTTON_SECONDARY:
-					sessionViewListener.onSessionViewRightTouch((int)mappedEvent.getX(),
-					                                            (int)mappedEvent.getY(), true);
-					sessionViewListener.onSessionViewRightTouch((int)mappedEvent.getX(),
-					                                            (int)mappedEvent.getY(), false);
-					sessionViewListener.onSessionViewLeftTouch((int)mappedEvent.getX(),
-					                                           (int)mappedEvent.getY(), true);
-					sessionViewListener.onSessionViewLeftTouch((int)mappedEvent.getX(),
-					                                           (int)mappedEvent.getY(), false);
-					break;
-			}
+			sessionViewListener.onSessionViewLeftTouch((int)mappedEvent.getX(),
+			                                           (int)mappedEvent.getY(), true);
+			sessionViewListener.onSessionViewLeftTouch((int)mappedEvent.getX(),
+			                                           (int)mappedEvent.getY(), false);
 			sessionViewListener.onSessionViewEndTouch();
 			return true;
 		}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/Mouse.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/Mouse.java
@@ -19,12 +19,14 @@ public class Mouse
 
 	private final static int PTRFLAGS_LBUTTON = 0x1000;
 	private final static int PTRFLAGS_RBUTTON = 0x2000;
+	private final static int PTRFLAGS_MBUTTON = 0x4000;
 
 	private final static int PTRFLAGS_DOWN = 0x8000;
 	private final static int PTRFLAGS_MOVE = 0x0800;
 
 	private final static int PTRFLAGS_WHEEL = 0x0200;
 	private final static int PTRFLAGS_WHEEL_NEGATIVE = 0x0100;
+	private final static int PTRFLAGS_HWHEEL = 0x0400;
 
 	public static int getLeftButtonEvent(Context context, boolean down)
 	{
@@ -40,6 +42,11 @@ public class Mouse
 			return (PTRFLAGS_LBUTTON | (down ? PTRFLAGS_DOWN : 0));
 		else
 			return (PTRFLAGS_RBUTTON | (down ? PTRFLAGS_DOWN : 0));
+	}
+
+	public static int getMiddleButtonEvent(boolean down)
+	{
+		return (PTRFLAGS_MBUTTON | (down ? PTRFLAGS_DOWN : 0));
 	}
 
 	public static int getMoveEvent()
@@ -59,6 +66,20 @@ public class Mouse
 			flags |= (PTRFLAGS_WHEEL_NEGATIVE | 0x0088);
 		else
 			flags |= 0x0078;
+		return flags;
+	}
+
+	public static int getHScrollEvent(Context context, boolean right)
+	{
+		int flags = PTRFLAGS_HWHEEL;
+
+		if (ApplicationSettingsActivity.getInvertScrolling(context))
+			right = !right;
+
+		if (right)
+			flags |= 0x0078;
+		else
+			flags |= (PTRFLAGS_WHEEL_NEGATIVE | 0x0088);
 		return flags;
 	}
 }


### PR DESCRIPTION
### Name
[client, android] Fix touch and physical mouse input handling

### Description
These commits fix a major touchscreen input bug and extend physical mouse support for API 23+ devices.

- Fixes #1006
- Fixes #8253
- Fixes #4571
- Fixes #9343 

**Key Changes:**
* **Touch single tap:** Fixed an issue where single screen taps were ignored. Single taps now correctly trigger a left click (no double-tap or long press needed).
* **Mouse event routing:** Moved `ACTION_BUTTON_PRESS`/`RELEASE` to `onGenericMotionEvent` to fix dropped or failed mouse clicks.
* **Spurious clicks:** Blocked mouse events from the gesture detector to prevent unwanted left clicks when using the right or middle mouse buttons.
* **Drag support:** Handled `ACTION_MOVE` with buttons pressed for correct drag-and-drop, disabling view panning during the drag.
* **Middle button:** Mapped `BUTTON_TERTIARY` to RDP `PTR_FLAGS_BUTTON3`.
* **Scroll wheel:** Handled `ACTION_SCROLL` for both vertical and horizontal mouse wheel passthrough.

### Instructions on how to test
Build the Android client (`aFreeRDP`) and connect to an RDP session.

**Touchscreen Testing:**
1. Single finger tap on the screen registers correctly as a left click on the remote session (no double-tap or long-press required).

**Physical Mouse Testing:**
1. Single left mouse click registers correctly as a left click.
2. Right-click results in a right click only, with no spurious left click.
3. Middle click results in a middle click on the remote session.
4. Holding the left button and moving the mouse works correctly for drag and drop.
5. Mouse scroll wheel results in vertical scroll on the remote session.
6. Mouse horizontal scroll results in horizontal scroll on the remote session.

**Environments Tested:**
* **Physical Device:** Android 16 (API 36) (Tested with a Bluetooth mouse and touch)