### PR TITLE
[client, android] Encrypt bookmark database

### DIFF
--- a/client/Android/Studio/freeRDPCore/build.gradle
+++ b/client/Android/Studio/freeRDPCore/build.gradle
@@ -74,4 +74,7 @@ dependencies {
 
     implementation "androidx.room:room-runtime:2.8.4"
     annotationProcessor "androidx.room:room-compiler:2.8.4"
+
+    implementation 'net.zetetic:sqlcipher-android:4.15.0@aar'
+    implementation 'androidx.sqlite:sqlite:2.6.2'
 }

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
@@ -5,11 +5,18 @@ package com.freerdp.freerdpcore.data;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
+
+import java.io.File;
 import androidx.room.Database;
 import androidx.room.Room;
 import androidx.room.RoomDatabase;
 import androidx.room.migration.Migration;
 import androidx.sqlite.db.SupportSQLiteDatabase;
+
+import com.freerdp.freerdpcore.security.KeystoreHelper;
+
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SupportOpenHelperFactory;
 
 @Database(entities = { BookmarkEntity.class }, version = AppDatabase.DB_VERSION,
           exportSchema = false)
@@ -17,6 +24,11 @@ public abstract class AppDatabase extends RoomDatabase
 {
 	static final int DB_VERSION = 11;
 	private static final String DB_NAME = "bookmarks.db";
+
+	static
+	{
+		System.loadLibrary("sqlcipher");
+	}
 
 	private static volatile AppDatabase instance;
 
@@ -30,14 +42,117 @@ public abstract class AppDatabase extends RoomDatabase
 			{
 				if (instance == null)
 				{
+					byte[] key = getOrCreateDbKey(context);
+					migrateUnencryptedIfNeeded(context, key);
+
 					instance = Room.databaseBuilder(context.getApplicationContext(),
 					                                AppDatabase.class, DB_NAME)
+					               .openHelperFactory(new SupportOpenHelperFactory(key))
 					               .addMigrations(MIGRATION_10_11)
 					               .build();
 				}
 			}
 		}
 		return instance;
+	}
+
+	private static byte[] getOrCreateDbKey(Context context)
+	{
+		try
+		{
+			return KeystoreHelper.getInstance(context).getOrCreateDbKey();
+		}
+		catch (KeystoreHelper.KeystoreException e)
+		{
+			throw new RuntimeException("Cannot obtain database encryption key", e);
+		}
+	}
+
+	// Converts an existing unencrypted database to SQLCipher in-place
+	private static void migrateUnencryptedIfNeeded(Context context, byte[] key)
+	{
+		File dbFile = context.getDatabasePath(DB_NAME);
+		if (!dbFile.exists())
+			return;
+
+		String path = dbFile.getAbsolutePath();
+
+		// Check if already encrypted by trying to open with the key.
+		try
+		{
+			SQLiteDatabase.openDatabase(path, key, null, SQLiteDatabase.OPEN_READONLY, null, null)
+			    .close();
+			return; // Database is already encrypted, no migration needed
+		}
+		catch (Exception ignored)
+		{
+		}
+
+		SQLiteDatabase db = null;
+		try
+		{
+			// Verify it is an unencrypted database by opening it with an empty key
+			db = SQLiteDatabase.openDatabase(path, new byte[0], null, SQLiteDatabase.OPEN_READWRITE,
+			                                 null, null);
+		}
+		catch (Exception e)
+		{
+			// If it fails, the file might be corrupted (not plaintext, not correctly encrypted)
+			SQLiteDatabase.deleteDatabase(dbFile);
+			return;
+		}
+
+		// https://www.zetetic.net/sqlcipher/sqlcipher-api/index.html#sqlcipher_export
+		// Prepare a temporary file for the encrypted database migration
+		String tmpPath = path + ".migrating";
+		File tmpFile = new File(tmpPath);
+		SQLiteDatabase.deleteDatabase(tmpFile);
+
+		try
+		{
+			// Pre-create the encrypted database to avoid CANTOPEN errors on ATTACH
+			SQLiteDatabase
+			    .openDatabase(tmpPath, key, null,
+			                  SQLiteDatabase.OPEN_READWRITE | SQLiteDatabase.CREATE_IF_NECESSARY,
+			                  null, null)
+			    .close();
+		}
+		catch (Exception ignored)
+		{
+		}
+
+		try
+		{
+			try
+			{
+				db.execSQL("ATTACH DATABASE '" + tmpPath + "' AS encrypted KEY X'" + toHex(key) +
+				           "'");
+				db.rawQuery("SELECT sqlcipher_export('encrypted')", null).moveToFirst();
+				db.execSQL("DETACH DATABASE encrypted");
+			}
+			finally
+			{
+				db.close();
+			}
+
+			// Replace the old unencrypted database with the new encrypted one
+			SQLiteDatabase.deleteDatabase(dbFile);
+			if (!tmpFile.renameTo(dbFile))
+				throw new RuntimeException("Could not replace database file after encryption");
+		}
+		catch (Exception e)
+		{
+			SQLiteDatabase.deleteDatabase(tmpFile);
+			throw new RuntimeException("Failed to encrypt existing database", e);
+		}
+	}
+
+	private static String toHex(byte[] bytes)
+	{
+		StringBuilder sb = new StringBuilder(bytes.length * 2);
+		for (byte b : bytes)
+			sb.append(String.format(java.util.Locale.US, "%02x", b));
+		return sb.toString();
 	}
 
 	// v10: tbl_manual_bookmarks + tbl_screen_settings + tbl_performance_flags (SQLiteOpenHelper)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/security/KeystoreHelper.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/security/KeystoreHelper.java
@@ -1,0 +1,150 @@
+/*
+   AES-256-GCM key-wrapping helper backed by Android Keystore.
+
+   A random 256-bit database key is generated once, wrapped with the
+   Keystore-resident master key, and stored in SharedPreferences as
+   Base64( IV[12] || ciphertext ).
+*/
+
+package com.freerdp.freerdpcore.security;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+import android.util.Base64;
+
+import java.security.KeyStore;
+import java.security.SecureRandom;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+
+public final class KeystoreHelper
+{
+	private static final String KEYSTORE_PROVIDER = "AndroidKeyStore";
+	private static final String KEY_ALIAS = "freerdp_db_master_key";
+	private static final String PREFS_NAME = "freerdp_security_prefs";
+	private static final String PREF_ENCRYPTED_DB_KEY = "encrypted_db_key";
+	private static final String CIPHER_TRANSFORMATION = "AES/GCM/NoPadding";
+	private static final int GCM_IV_LENGTH = 12;
+	private static final int GCM_TAG_LENGTH = 128; // bits
+	private static final int DB_KEY_LENGTH = 32;   // bytes (256-bit)
+
+	private static volatile KeystoreHelper instance;
+
+	private final Context applicationContext;
+
+	private KeystoreHelper(Context context)
+	{
+		this.applicationContext = context.getApplicationContext();
+	}
+
+	public static KeystoreHelper getInstance(Context context)
+	{
+		if (instance == null)
+		{
+			synchronized (KeystoreHelper.class)
+			{
+				if (instance == null)
+				{
+					instance = new KeystoreHelper(context);
+				}
+			}
+		}
+		return instance;
+	}
+
+	public byte[] getOrCreateDbKey() throws KeystoreException
+	{
+		SharedPreferences prefs =
+		    applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+		String encoded = prefs.getString(PREF_ENCRYPTED_DB_KEY, null);
+
+		if (encoded != null)
+		{
+			return decryptDbKey(encoded);
+		}
+
+		byte[] rawKey = new byte[DB_KEY_LENGTH];
+		new SecureRandom().nextBytes(rawKey);
+		String encrypted = encryptDbKey(rawKey);
+		prefs.edit().putString(PREF_ENCRYPTED_DB_KEY, encrypted).apply();
+		return rawKey;
+	}
+
+	private String encryptDbKey(byte[] rawKey) throws KeystoreException
+	{
+		try
+		{
+			SecretKey masterKey = getOrCreateMasterKey();
+			Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+			cipher.init(Cipher.ENCRYPT_MODE, masterKey);
+			byte[] iv = cipher.getIV();
+			byte[] ciphertext = cipher.doFinal(rawKey);
+
+			// Serialise as Base64( IV[12] || ciphertext )
+			byte[] packed = new byte[GCM_IV_LENGTH + ciphertext.length];
+			System.arraycopy(iv, 0, packed, 0, GCM_IV_LENGTH);
+			System.arraycopy(ciphertext, 0, packed, GCM_IV_LENGTH, ciphertext.length);
+			return Base64.encodeToString(packed, Base64.NO_WRAP);
+		}
+		catch (Exception e)
+		{
+			throw new KeystoreException("Failed to encrypt database key", e);
+		}
+	}
+
+	private byte[] decryptDbKey(String encoded) throws KeystoreException
+	{
+		try
+		{
+			byte[] packed = Base64.decode(encoded, Base64.NO_WRAP);
+			byte[] iv = new byte[GCM_IV_LENGTH];
+			byte[] ciphertext = new byte[packed.length - GCM_IV_LENGTH];
+			System.arraycopy(packed, 0, iv, 0, GCM_IV_LENGTH);
+			System.arraycopy(packed, GCM_IV_LENGTH, ciphertext, 0, ciphertext.length);
+
+			SecretKey masterKey = getOrCreateMasterKey();
+			Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+			cipher.init(Cipher.DECRYPT_MODE, masterKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+			return cipher.doFinal(ciphertext);
+		}
+		catch (Exception e)
+		{
+			throw new KeystoreException("Failed to decrypt database key", e);
+		}
+	}
+
+	private SecretKey getOrCreateMasterKey() throws Exception
+	{
+		KeyStore keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER);
+		keyStore.load(null);
+
+		if (keyStore.containsAlias(KEY_ALIAS))
+		{
+			return ((KeyStore.SecretKeyEntry)keyStore.getEntry(KEY_ALIAS, null)).getSecretKey();
+		}
+
+		KeyGenerator keyGen =
+		    KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE_PROVIDER);
+		keyGen.init(
+		    new KeyGenParameterSpec
+		        .Builder(KEY_ALIAS, KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+		        .setKeySize(256)
+		        .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+		        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+		        .build());
+		return keyGen.generateKey();
+	}
+
+	public static final class KeystoreException extends Exception
+	{
+		public KeystoreException(String message, Throwable cause)
+		{
+			super(message, cause);
+		}
+	}
+}


### PR DESCRIPTION
**Name**
[client, android] Encrypt bookmark database with SQLCipher

**Description**

- Fiexes #2042

As discussed, this PR has been split. This part only handles internal database encryption. Export/import will be provided in a separate PR.

Key Changes:

*   **Database Encryption:** The internal SQLite database is now fully encrypted using SQLCipher. We don't have to manually check or encrypt specific fields.
*   **Hardware-Bound Key:** Uses `AndroidKeyStore` to generate a key that is permanently bound to the device hardware. No user password is required.
*   **Migration:** Safely migrates existing plaintext databases to the new encrypted SQLCipher format using [sqlcipher_export()](https://www.zetetic.net/sqlcipher/sqlcipher-api/index.html#sqlcipher_export), keeping existing user bookmarks safe. 

**Instructions on how to test**
Build the Android client (aFreeRDP).

1. Upgrade from an older version of the app and verify existing bookmarks are correctly migrated and still work.
2. Add a bookmark with a password, restart the app, and verify it still connects.
3. Check the app data directory (`/data/data/com.freerdp.afreerdp/databases/`) and verify the `bookmarks.db` file is fully encrypted and no `.wal` or `.shm` files are left readable.

**Environments Tested:**
Emulators: Android 7.0 (API 24), Android 14 (API 34)
Physical Device: Android 16 (API 36)