### PR TITLE
rdpecam-v4l: stop the capture thread when streaming is cleared

### DIFF
--- a/channels/rdpecam/client/v4l/camera_v4l.c
+++ b/channels/rdpecam/client/v4l/camera_v4l.c
@@ -473,8 +473,8 @@ static DWORD WINAPI cam_v4l_stream_capture_thread(LPVOID param)
 			buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
 			buf.memory = V4L2_MEMORY_MMAP;
 
-			/* dequeue buffers until empty */
-			while (ioctl(fd, VIDIOC_DQBUF, &buf) != -1)
+			/* dequeue buffers until empty, or until we are asked to stop */
+			while (stream->streaming && ioctl(fd, VIDIOC_DQBUF, &buf) != -1)
 			{
 				const UINT error =
 				    stream->sampleCallback(stream->dev, stream->streamIndex,


### PR DESCRIPTION
If a camera fills buffers as fast as we dequeue them, the DQBUF inner loop in cam_v4l_stream_capture_thread() never returns -1 and the thread can't reach the outer `while (stream->streaming)` check. cam_v4l_stream_stop()'s WaitForSingleObject() on the capture thread therefore blocks forever, VIDIOC_STREAMOFF and close(fd) are never reached, and /dev/videoN stays open until the client process exits. As a consequence the webcam activity LED stays on after the user closes the remote app.

Re-check stream->streaming in the inner loop so the thread can unwind between two DQBUFs; the existing stop path then closes the fd within one capture-thread iteration.

Sponsored-by: Defenso

Fixes #12689