### PR TITLE
[core,instance] fix deprecation guards

### DIFF
--- a/libfreerdp/core/utils.c
+++ b/libfreerdp/core/utils.c
@@ -94,7 +94,7 @@ auth_status utils_authenticate_gateway(freerdp* instance, rdp_auth_reason reason
 		return AUTH_SKIP;
 	}
 
-#if !defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITHOUT_FREERDP_3x_DEPRECATED)
 	if (!instance->AuthenticateEx)
 		return AUTH_NO_CREDENTIALS;
 #else
@@ -110,7 +110,7 @@ auth_status utils_authenticate_gateway(freerdp* instance, rdp_auth_reason reason
 		if (!proceed)
 			return AUTH_CANCELLED;
 	}
-#if defined(WITH_FREERDP_DEPRECATED)
+#if !defined(WITHOUT_FREERDP_3x_DEPRECATED)
 	else
 	{
 		proceed =
@@ -198,7 +198,7 @@ auth_status utils_authenticate(freerdp* instance, rdp_auth_reason reason, BOOL o
 	}
 
 	/* If no callback is specified still continue connection */
-#if !defined(WITH_FREERDP_DEPRECATED)
+#if defined(WITHOUT_FREERDP_3x_DEPRECATED)
 	if (!instance->AuthenticateEx)
 		return AUTH_NO_CREDENTIALS;
 #else
@@ -212,7 +212,7 @@ auth_status utils_authenticate(freerdp* instance, rdp_auth_reason reason, BOOL o
 		if (!proceed)
 			return AUTH_CANCELLED;
 	}
-#if defined(WITH_FREERDP_DEPRECATED)
+#if !defined(WITHOUT_FREERDP_3x_DEPRECATED)
 	else
 	{
 		proceed = instance->Authenticate(instance, &settings->Username, &settings->Password,

--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -1864,7 +1864,7 @@ int tls_verify_certificate(rdpTls* tls, const rdpCertificate* cert, const char* 
 					if (!use_pem)
 						free(fp);
 				}
-#if defined(WITH_FREERDP_DEPRECATED)
+#if !defined(WITHOUT_FREERDP_3x_DEPRECATED)
 				else if (instance->VerifyCertificate)
 				{
 					char* fp = freerdp_certificate_get_fingerprint(cert);
@@ -1939,7 +1939,7 @@ int tls_verify_certificate(rdpTls* tls, const rdpCertificate* cert, const char* 
 					if (fpIsAllocated)
 						free(fp);
 				}
-#if defined(WITH_FREERDP_DEPRECATED)
+#if !defined(WITHOUT_FREERDP_3x_DEPRECATED)
 				else if (instance->VerifyChangedCertificate)
 				{
 					char* fp = freerdp_certificate_get_fingerprint(cert);


### PR DESCRIPTION
Call deprecated callbacks if WITHOUT_FREERDP_3x_DEPRECATED is not defined.