### PR TITLE
Add VideoToolbox H.264 support for ffmpeg

### DIFF
--- a/cmake/ConfigOptions.cmake
+++ b/cmake/ConfigOptions.cmake
@@ -148,6 +148,9 @@ cmake_dependent_option(WITH_VAAPI "[experimental] Use FFMPEG VAAPI" OFF "WITH_VI
 cmake_dependent_option(
   WITH_VAAPI_H264_ENCODING "[experimental] Use FFMPEG VAAPI hardware H264 encoding" ON "WITH_VIDEO_FFMPEG" OFF
 )
+cmake_dependent_option(
+  WITH_VIDEOTOOLBOX "[experimental] Use FFMPEG VideoToolbox hardware H264 decoding" OFF "WITH_VIDEO_FFMPEG;APPLE" OFF
+)
 if(WITH_VAAPI_H264_ENCODING)
   include(WarnExperimental)
   warn_experimental("VAAPI H264 encoding" "-DWITH_VAAPI_H264_ENCODING=OFF")

--- a/include/config/config.h.in
+++ b/include/config/config.h.in
@@ -61,6 +61,7 @@
 #cmakedefine WITH_GFX_AV1
 
 #cmakedefine WITH_VAAPI
+#cmakedefine WITH_VIDEOTOOLBOX
 
 #cmakedefine WITH_CHANNELS
 #cmakedefine WITH_CLIENT_CHANNELS

--- a/libfreerdp/codec/CMakeLists.txt
+++ b/libfreerdp/codec/CMakeLists.txt
@@ -155,6 +155,11 @@ if(WITH_VIDEO_FFMPEG)
     warn_experimental("VAAPI encoder/decoder support for FFMPEG" "-DWITH_VAAPI=OFF")
   endif()
 
+  if(WITH_VIDEOTOOLBOX)
+    include(WarnExperimental)
+    warn_experimental("VideoToolbox H264 decoding support for FFMPEG" "-DWITH_VIDEOTOOLBOX=OFF")
+  endif()
+
   set(CODEC_SRCS ${CODEC_SRCS} h264_ffmpeg.c)
   include_directories(SYSTEM ${FFMPEG_INCLUDE_DIRS})
   list(APPEND CODEC_LIBS ${FFMPEG_LIBRARIES})

--- a/libfreerdp/codec/h264_ffmpeg.c
+++ b/libfreerdp/codec/h264_ffmpeg.c
@@ -28,6 +28,16 @@
 
 #include "h264.h"
 
+#ifdef WITH_VIDEOTOOLBOX
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(55, 9, 0)
+#include <libavutil/hwcontext.h>
+#else
+#pragma warning You have asked for VideoToolbox decoding, \
+    but your version of libavutil is too old !Disabling.
+#undef WITH_VIDEOTOOLBOX
+#endif
+#endif
+
 #ifdef WITH_VAAPI
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(55, 9, 0)
 #include <libavutil/hwcontext.h>
@@ -81,7 +91,7 @@ typedef struct
 	AVPacket bufferpacket;
 #endif
 	AVPacket* packet;
-#if defined(WITH_VAAPI) || defined(WITH_VAAPI_H264_ENCODING)
+#if defined(WITH_VAAPI) || defined(WITH_VAAPI_H264_ENCODING) || defined(WITH_VIDEOTOOLBOX)
 	AVBufferRef* hwctx;
 	AVFrame* hwVideoFrame;
 	enum AVPixelFormat hw_pix_fmt;
@@ -293,11 +303,11 @@ static int libavcodec_decompress(H264_CONTEXT* WINPR_RESTRICT h264,
 
 	sys->videoFrame->format = AV_PIX_FMT_YUV420P;
 
-#ifdef WITH_VAAPI
-		status = avcodec_receive_frame(sys->codecDecoderContext,
-		                               sys->hwctx ? sys->hwVideoFrame : sys->videoFrame);
+#if defined(WITH_VAAPI) || defined(WITH_VIDEOTOOLBOX)
+	status = avcodec_receive_frame(sys->codecDecoderContext,
+	                               sys->hwctx ? sys->hwVideoFrame : sys->videoFrame);
 #else
-		status = avcodec_receive_frame(sys->codecDecoderContext, sys->videoFrame);
+	status = avcodec_receive_frame(sys->codecDecoderContext, sys->videoFrame);
 #endif
 	    if (status == AVERROR(EAGAIN))
 	    {
@@ -307,7 +317,7 @@ static int libavcodec_decompress(H264_CONTEXT* WINPR_RESTRICT h264,
 
 	gotFrame = (status == 0);
 #else
-#ifdef WITH_VAAPI
+#if defined(WITH_VAAPI) || defined(WITH_VIDEOTOOLBOX)
 	status =
 	    avcodec_decode_video2(sys->codecDecoderContext,
 	                          sys->hwctx ? sys->hwVideoFrame : sys->videoFrame, &gotFrame, packet);
@@ -321,7 +331,7 @@ static int libavcodec_decompress(H264_CONTEXT* WINPR_RESTRICT h264,
 		goto fail;
 	}
 
-#ifdef WITH_VAAPI
+#if defined(WITH_VAAPI) || defined(WITH_VIDEOTOOLBOX)
 
 	if (sys->hwctx)
 	{
@@ -561,7 +571,7 @@ static void libavcodec_uninit(H264_CONTEXT* h264)
 #endif
 	}
 
-#if defined(WITH_VAAPI) || defined(WITH_VAAPI_H264_ENCODING)
+#if defined(WITH_VAAPI) || defined(WITH_VAAPI_H264_ENCODING) || defined(WITH_VIDEOTOOLBOX)
 	if (sys->hwVideoFrame)
 	{
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(55, 18, 102)
@@ -601,7 +611,7 @@ static void libavcodec_uninit(H264_CONTEXT* h264)
 	h264->pSystemData = nullptr;
 }
 
-#ifdef WITH_VAAPI
+#if defined(WITH_VAAPI) || defined(WITH_VIDEOTOOLBOX)
 static enum AVPixelFormat libavcodec_get_format(struct AVCodecContext* ctx,
                                                 const enum AVPixelFormat* fmts)
 {
@@ -727,6 +737,32 @@ static BOOL libavcodec_init(H264_CONTEXT* h264)
 	fail_hwdevice_create:
 #endif
 
+#ifdef WITH_VIDEOTOOLBOX
+
+		if (!sys->hwctx)
+		{
+			int ret = av_hwdevice_ctx_create(&sys->hwctx, AV_HWDEVICE_TYPE_VIDEOTOOLBOX, nullptr,
+			                                 nullptr, 0);
+
+			if (ret < 0)
+			{
+				WLog_Print(
+				    h264->log, WLOG_ERROR,
+				    "Could not initialize VideoToolbox decoder, falling back to software: %s",
+				    av_err2str(ret));
+				sys->hwctx = nullptr;
+				goto fail_vt_create;
+			}
+		}
+		WLog_Print(h264->log, WLOG_INFO, "Using VideoToolbox for accelerated H264 decoding");
+
+		sys->codecDecoderContext->get_format = libavcodec_get_format;
+		sys->hw_pix_fmt = AV_PIX_FMT_VIDEOTOOLBOX;
+		sys->codecDecoderContext->hw_device_ctx = av_buffer_ref(sys->hwctx);
+		sys->codecDecoderContext->opaque = (void*)h264;
+	fail_vt_create:
+#endif
+
 		if (avcodec_open2(sys->codecDecoderContext, sys->codecDecoder, nullptr) < 0)
 		{
 			WLog_Print(h264->log, WLOG_ERROR, "Failed to open libav codec");
@@ -779,7 +815,7 @@ static BOOL libavcodec_init(H264_CONTEXT* h264)
 
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(55, 18, 102)
 	sys->videoFrame = av_frame_alloc();
-#if defined(WITH_VAAPI) || defined(WITH_VAAPI_H264_ENCODING)
+#if defined(WITH_VAAPI) || defined(WITH_VAAPI_H264_ENCODING) || defined(WITH_VIDEOTOOLBOX)
 	sys->hwVideoFrame = av_frame_alloc();
 #endif
 #else
@@ -792,7 +828,7 @@ static BOOL libavcodec_init(H264_CONTEXT* h264)
 		goto EXCEPTION;
 	}
 
-#if defined(WITH_VAAPI) || defined(WITH_VAAPI_H264_ENCODING)
+#if defined(WITH_VAAPI) || defined(WITH_VAAPI_H264_ENCODING) || defined(WITH_VIDEOTOOLBOX)
 	if (!sys->hwVideoFrame)
 	{
 		WLog_Print(h264->log, WLOG_ERROR, "Failed to allocate libav hw frame");

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -2890,7 +2890,7 @@ static BOOL option_is_experimental(WINPR_ATTR_UNUSED wLog* log, const char* tok)
 		                           STR(WITH_MEDIACODEC),       STR(WITH_CLIENT_SDL2),
 		                           STR(WITH_OPENCL),           STR(WITH_LIBRESSL),
 		                           STR(WITH_MBEDTLS),          STR(WITH_MEDIA_FOUNDATION),
-		                           STR(WITH_KRB5_HEIMDAL) };
+		                           STR(WITH_KRB5_HEIMDAL),     STR(WITH_VIDEOTOOLBOX) };
 	for (size_t x = 0; x < ARRAYSIZE(experimental); x++)
 	{
 		const char* opt = experimental[x];


### PR DESCRIPTION
This is a simpler implementation than #12337 - it uses ffmpeg (setting `-hwaccel videotoolbox`) and largely mirrors `WITH_VAAPI`.

Tested by building with `-DWITH_VIDEOTOOLBOX=ON` and then connecting to a windows client on macos.