### PR TITLE
[client,common] add /args-from:file:<name> syntax

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -5652,7 +5652,8 @@ static void warn_credential_args(const COMMAND_LINE_ARGUMENT_A* args)
 		WLog_WARN(TAG, "Passing credentials or secrets via command line might expose these in the "
 		               "process list");
 		WLog_WARN(TAG, "Consider using one of the following (more secure) alternatives:");
-		WLog_WARN(TAG, "  - /args-from: pipe in arguments from stdin, file or file descriptor");
+		WLog_WARN(TAG, "  - /args-from: pipe in arguments from stdin, file, file descriptor or "
+		               "environment variable");
 		WLog_WARN(TAG, "  - /from-stdin pass the credential via stdin");
 		WLog_WARN(TAG, "  - set environment variable FREERDP_ASKPASS to have a gui tool query for "
 		               "credentials");
@@ -6036,11 +6037,21 @@ int freerdp_client_settings_parse_command_line_arguments_ex(
 			const char* name = strchr(file, ':') + 1;
 			success = args_from_env(name, &aargc, &aargv, oargv[1], oargv[0]);
 		}
-		else if (strcmp(file, "stdin") != 0)
+		else if (strncmp(file, "file:", 5) != 0)
 		{
+			file = strchr(file, ':') + 1;
 			fp = winpr_fopen(file, "r");
 			success = args_from_fp(fp, &aargc, &aargv, file, oargv[0]);
 		}
+#if !defined(WITHOUT_FREERDP_3x_DEPRECATED)
+		else if (strcmp(file, "stdin") != 0)
+		{
+			fp = winpr_fopen(file, "r");
+			WLog_WARN(TAG, "/args-from:%s is deprecated, use /args-from:file:%s instead", file,
+			          file);
+			success = args_from_fp(fp, &aargc, &aargv, file, oargv[0]);
+		}
+#endif
 		else
 			success = args_from_fp(fp, &aargc, &aargv, file, oargv[0]);
 

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -180,7 +180,7 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  nullptr, "Use default callbacks (console) for certificate/credential/..." },
 	{ "frame-ack", COMMAND_LINE_VALUE_REQUIRED, "<number>", nullptr, nullptr, -1, nullptr,
 	  "Number of frame acknowledgement" },
-	{ "args-from", COMMAND_LINE_VALUE_REQUIRED, "<file>|stdin|fd:<number>|env:<name>", nullptr,
+	{ "args-from", COMMAND_LINE_VALUE_REQUIRED, "file:<file>|stdin|fd:<number>|env:<name>", nullptr,
 	  nullptr, -1, nullptr,
 	  "Read command line from a file, stdin or file descriptor. This argument can not be combined "
 	  "with any other. "

--- a/winpr/include/winpr/sspi.h
+++ b/winpr/include/winpr/sspi.h
@@ -857,7 +857,7 @@ typedef SecBufferDesc* PSecBufferDesc;
  *
  *  @param client An opaque pointer passed as context
  *  @param authIdentity A pointer to the identity to generate the hash for. Must not be \b nullptr
- *  @param ntproffvale A buffer containing the proof value. Must not be \b nullptr. Must be able to
+ *  @param ntproofvalue A buffer containing the proof value. Must not be \b nullptr. Must be able to
  * hold 16 bytes.
  *  @param randkey A pointer to a buffer containing random data. Must not be \b nullptr. Must be
  * able to hold 16 bytes.

--- a/winpr/libwinpr/utils/ntlm.c
+++ b/winpr/libwinpr/utils/ntlm.c
@@ -36,7 +36,7 @@ BOOL NTOWFv1W(LPCWSTR Password, UINT32 PasswordLengthInBytes, BYTE* NtHash)
 	if (!Password || !NtHash)
 		return FALSE;
 
-	if (!winpr_Digest(WINPR_MD_MD4, (BYTE*)Password, (size_t)PasswordLengthInBytes, NtHash,
+	if (!winpr_Digest(WINPR_MD_MD4, Password, PasswordLengthInBytes, NtHash,
 	                  WINPR_MD4_DIGEST_LENGTH))
 		return FALSE;
 
@@ -62,7 +62,8 @@ BOOL NTOWFv1A(LPCSTR Password, UINT32 PasswordLengthInBytes, BYTE* NtHash)
 			return FALSE;
 	}
 
-	if (!NTOWFv1W(PasswordW, (UINT32)pwdCharLength * sizeof(WCHAR), NtHash))
+	if (!NTOWFv1W(PasswordW, WINPR_ASSERTING_INT_CAST(UINT32, pwdCharLength * sizeof(WCHAR)),
+	              NtHash))
 		goto out_fail;
 
 	result = TRUE;


### PR DESCRIPTION
deprecate /args-from:<filename> to avoid (rare) name collissions