### PR TITLE
[ci,freebsd] correct libressl package name

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         freebsd-version: ["15.0", "14.4"]
-        ssl: ["openssl111", "openssl36", "openssl40", "libressl"]
+        ssl: ["openssl111", "openssl36", "openssl40", "libressl-devel"]
     name: Build on FreeBSD ${{ matrix.freebsd-version }} with ${{ matrix.ssl || 'openssl' }}
     env:
       SSL: ${{ matrix.ssl }}
@@ -69,7 +69,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=/usr/lib/clang/18/lib/freebsd
           export CTEST_OUTPUT_ON_FAILURE=1
-          if [ "$SSL" == "libressl" ];
+          if [ "$SSL" == "libressl-devel" ];
           then
             export CMAKE_SSL="-DWITH_LIBRESSL=ON"
           fi


### PR DESCRIPTION
use the libressl-devel package so headers are installed as well.