### PR TITLE
[client, android] Refactor session layer and modernize deprecated APIs

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/application/GlobalApp.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/application/GlobalApp.java
@@ -16,6 +16,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 
 import com.freerdp.freerdpcore.domain.BookmarkBase;
@@ -33,23 +35,46 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 public class GlobalApp extends Application implements LibFreeRDP.EventListener
 {
-	// event notification defines
-	public static final String EVENT_TYPE = "EVENT_TYPE";
-	public static final String EVENT_PARAM = "EVENT_PARAM";
-	public static final String EVENT_STATUS = "EVENT_STATUS";
-	public static final String EVENT_ERROR = "EVENT_ERROR";
-	public static final String ACTION_EVENT_FREERDP = "com.freerdp.freerdp.event.freerdp";
-	public static final int FREERDP_EVENT_CONNECTION_SUCCESS = 1;
-	public static final int FREERDP_EVENT_CONNECTION_FAILURE = 2;
-	public static final int FREERDP_EVENT_DISCONNECTED = 3;
 	private static final String TAG = "GlobalApp";
 	public static boolean IsMeteredNetwork = false;
 	private static Map<Long, SessionState> sessionMap;
 	private static ManualBookmarkGateway manualBookmarkGateway;
 	private static QuickConnectHistoryGateway quickConnectHistoryGateway;
+
+	/** Per-session connection event listener. Callbacks are invoked on the main thread. */
+	public interface SessionEventListener
+	{
+		void onConnectionSuccess();
+		void onConnectionFailure();
+		void onDisconnected();
+	}
+
+	private static final Map<Long, SessionEventListener> sessionListeners =
+	    new ConcurrentHashMap<>();
+	private static final Handler mainHandler = new Handler(Looper.getMainLooper());
+
+	public static void registerSessionListener(long instance, SessionEventListener listener)
+	{
+		sessionListeners.put(instance, listener);
+	}
+
+	public static void unregisterSessionListener(long instance)
+	{
+		sessionListeners.remove(instance);
+	}
+
+	private void dispatch(long instance, Consumer<SessionEventListener> action)
+	{
+		final SessionEventListener listener = sessionListeners.get(instance);
+		if (listener == null)
+			return;
+		mainHandler.post(() -> action.accept(listener));
+	}
 
 	// timer for disconnecting sessions after the screen was turned off
 	private static Timer disconnectTimer = null;
@@ -151,15 +176,6 @@ public class GlobalApp extends Application implements LibFreeRDP.EventListener
 	}
 
 	// helper to send FreeRDP notifications
-	private void sendRDPNotification(int type, long param)
-	{
-		// send broadcast
-		Intent intent = new Intent(ACTION_EVENT_FREERDP);
-		intent.putExtra(EVENT_TYPE, type);
-		intent.putExtra(EVENT_PARAM, param);
-		sendBroadcast(intent);
-	}
-
 	@Override public void OnPreConnect(long instance)
 	{
 		Log.v(TAG, "OnPreConnect");
@@ -170,15 +186,13 @@ public class GlobalApp extends Application implements LibFreeRDP.EventListener
 	public void OnConnectionSuccess(long instance)
 	{
 		Log.v(TAG, "OnConnectionSuccess");
-		sendRDPNotification(FREERDP_EVENT_CONNECTION_SUCCESS, instance);
+		dispatch(instance, SessionEventListener::onConnectionSuccess);
 	}
 
 	public void OnConnectionFailure(long instance)
 	{
 		Log.v(TAG, "OnConnectionFailure");
-
-		// send notification to session activity
-		sendRDPNotification(FREERDP_EVENT_CONNECTION_FAILURE, instance);
+		dispatch(instance, SessionEventListener::onConnectionFailure);
 	}
 
 	public void OnDisconnecting(long instance)
@@ -189,7 +203,7 @@ public class GlobalApp extends Application implements LibFreeRDP.EventListener
 	public void OnDisconnected(long instance)
 	{
 		Log.v(TAG, "OnDisconnected");
-		sendRDPNotification(FREERDP_EVENT_DISCONNECTED, instance);
+		dispatch(instance, SessionEventListener::onDisconnected);
 	}
 
 	// TimerTask for disconnecting sessions after screen was turned off

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/application/GlobalApp.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/application/GlobalApp.java
@@ -22,11 +22,7 @@ import android.util.Log;
 
 import com.freerdp.freerdpcore.domain.BookmarkBase;
 import com.freerdp.freerdpcore.presentation.ApplicationSettingsActivity;
-import com.freerdp.freerdpcore.data.AppDatabase;
-import com.freerdp.freerdpcore.data.HistoryDatabase;
 import com.freerdp.freerdpcore.services.LibFreeRDP;
-import com.freerdp.freerdpcore.services.ManualBookmarkGateway;
-import com.freerdp.freerdpcore.services.QuickConnectHistoryGateway;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -43,8 +39,6 @@ public class GlobalApp extends Application implements LibFreeRDP.EventListener
 	private static final String TAG = "GlobalApp";
 	public static boolean IsMeteredNetwork = false;
 	private static Map<Long, SessionState> sessionMap;
-	private static ManualBookmarkGateway manualBookmarkGateway;
-	private static QuickConnectHistoryGateway quickConnectHistoryGateway;
 
 	/** Per-session connection event listener. Callbacks are invoked on the main thread. */
 	public interface SessionEventListener
@@ -78,16 +72,6 @@ public class GlobalApp extends Application implements LibFreeRDP.EventListener
 
 	// timer for disconnecting sessions after the screen was turned off
 	private static Timer disconnectTimer = null;
-
-	public static ManualBookmarkGateway getManualBookmarkGateway()
-	{
-		return manualBookmarkGateway;
-	}
-
-	public static QuickConnectHistoryGateway getQuickConnectHistoryGateway()
-	{
-		return quickConnectHistoryGateway;
-	}
 
 	// Disconnect handling for Screen on/off events
 	public void startDisconnectTimer()
@@ -157,12 +141,6 @@ public class GlobalApp extends Application implements LibFreeRDP.EventListener
 		sessionMap = Collections.synchronizedMap(new HashMap<Long, SessionState>());
 
 		LibFreeRDP.setEventListener(this);
-
-		AppDatabase appDb = AppDatabase.getInstance(this);
-		manualBookmarkGateway = new ManualBookmarkGateway(appDb.bookmarkDao());
-
-		HistoryDatabase historyDb = HistoryDatabase.getInstance(this);
-		quickConnectHistoryGateway = new QuickConnectHistoryGateway(historyDb.historyDao());
 
 		IsMeteredNetwork = NetworkStateReceiver.isMeteredNetwork(this);
 		NetworkStateReceiver.registerNetworkCallback(this);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
@@ -30,13 +30,10 @@ public abstract class AppDatabase extends RoomDatabase
 			{
 				if (instance == null)
 				{
-					instance =
-					    Room.databaseBuilder(context.getApplicationContext(), AppDatabase.class,
-					                         DB_NAME)
-					        .addMigrations(MIGRATION_10_11)
-					        // TODO: remove once database access is moved to background threads.
-					        .allowMainThreadQueries()
-					        .build();
+					instance = Room.databaseBuilder(context.getApplicationContext(),
+					                                AppDatabase.class, DB_NAME)
+					               .addMigrations(MIGRATION_10_11)
+					               .build();
 				}
 			}
 		}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/HistoryDatabase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/HistoryDatabase.java
@@ -28,14 +28,11 @@ public abstract class HistoryDatabase extends RoomDatabase
 			{
 				if (instance == null)
 				{
-					instance =
-					    Room.databaseBuilder(context.getApplicationContext(), HistoryDatabase.class,
-					                         DB_NAME)
-					        .addMigrations(MIGRATION_1_2)
-					        .fallbackToDestructiveMigration()
-					        // TODO: remove once database access is moved to background threads.
-					        .allowMainThreadQueries()
-					        .build();
+					instance = Room.databaseBuilder(context.getApplicationContext(),
+					                                HistoryDatabase.class, DB_NAME)
+					               .addMigrations(MIGRATION_1_2)
+					               .fallbackToDestructiveMigration()
+					               .build();
 				}
 			}
 		}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ApplicationSettingsActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ApplicationSettingsActivity.java
@@ -262,13 +262,6 @@ public class ApplicationSettingsActivity
 		    context.getString(R.string.preference_key_accept_certificates), false);
 	}
 
-	public static boolean getHideZoomControls(Context context)
-	{
-		SharedPreferences preferences = get(context);
-		return preferences.getBoolean(
-		    context.getString(R.string.preference_key_ui_hide_zoom_controls), true);
-	}
-
 	public static boolean getSwapMouseButtons(Context context)
 	{
 		SharedPreferences preferences = get(context);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/BookmarkViewModel.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/BookmarkViewModel.java
@@ -5,18 +5,22 @@
 
 package com.freerdp.freerdpcore.presentation;
 
+import android.app.Application;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
-import androidx.lifecycle.ViewModel;
 
-import com.freerdp.freerdpcore.application.GlobalApp;
+import com.freerdp.freerdpcore.data.AppDatabase;
+import com.freerdp.freerdpcore.data.HistoryDatabase;
 import com.freerdp.freerdpcore.domain.BookmarkBase;
 import com.freerdp.freerdpcore.domain.ConnectionReference;
 import com.freerdp.freerdpcore.services.ManualBookmarkGateway;
+import com.freerdp.freerdpcore.services.QuickConnectHistoryGateway;
 import com.freerdp.freerdpcore.utils.RDPFileParser;
 
 import java.io.File;
@@ -24,7 +28,7 @@ import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-public class BookmarkViewModel extends ViewModel
+public class BookmarkViewModel extends AndroidViewModel
 {
 	private static final String TAG = "BookmarkViewModel";
 
@@ -37,6 +41,18 @@ public class BookmarkViewModel extends ViewModel
 
 	// Single-thread executor handles Room DB and File parsing off the UI thread
 	private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+	private final ManualBookmarkGateway manualBookmarkGateway;
+	private final QuickConnectHistoryGateway quickConnectHistoryGateway;
+
+	public BookmarkViewModel(@NonNull Application application)
+	{
+		super(application);
+		manualBookmarkGateway =
+		    new ManualBookmarkGateway(AppDatabase.getInstance(application).bookmarkDao());
+		quickConnectHistoryGateway =
+		    new QuickConnectHistoryGateway(HistoryDatabase.getInstance(application).historyDao());
+	}
 
 	public LiveData<BookmarkBase> getBookmarkLiveData()
 	{
@@ -92,8 +108,8 @@ public class BookmarkViewModel extends ViewModel
 
 				if (ConnectionReference.isBookmarkReference(refStr))
 				{
-					bookmark = GlobalApp.getManualBookmarkGateway().findById(
-					    ConnectionReference.getBookmarkId(refStr));
+					bookmark =
+					    manualBookmarkGateway.findById(ConnectionReference.getBookmarkId(refStr));
 					isNew = false;
 				}
 				else if (ConnectionReference.isHostnameReference(refStr))
@@ -150,16 +166,15 @@ public class BookmarkViewModel extends ViewModel
 
 			if (bookmark.getType() == BookmarkBase.TYPE_MANUAL)
 			{
-				ManualBookmarkGateway gateway = GlobalApp.getManualBookmarkGateway();
-				GlobalApp.getQuickConnectHistoryGateway().removeHistoryItem(bookmark.getHostname());
+				quickConnectHistoryGateway.removeHistoryItem(bookmark.getHostname());
 
 				if (bookmark.getId() > 0)
 				{
-					gateway.update(bookmark);
+					manualBookmarkGateway.update(bookmark);
 				}
 				else
 				{
-					gateway.insert(bookmark);
+					manualBookmarkGateway.insert(bookmark);
 				}
 			}
 

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/HomeViewModel.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/HomeViewModel.java
@@ -13,8 +13,11 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
 import com.freerdp.freerdpcore.R;
-import com.freerdp.freerdpcore.application.GlobalApp;
+import com.freerdp.freerdpcore.data.AppDatabase;
+import com.freerdp.freerdpcore.data.HistoryDatabase;
 import com.freerdp.freerdpcore.domain.BookmarkBase;
+import com.freerdp.freerdpcore.services.ManualBookmarkGateway;
+import com.freerdp.freerdpcore.services.QuickConnectHistoryGateway;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,9 +32,16 @@ public class HomeViewModel extends AndroidViewModel
 	private String currentQuery = "";
 	private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
+	private final ManualBookmarkGateway manualBookmarkGateway;
+	private final QuickConnectHistoryGateway quickConnectHistoryGateway;
+
 	public HomeViewModel(@NonNull Application application)
 	{
 		super(application);
+		manualBookmarkGateway =
+		    new ManualBookmarkGateway(AppDatabase.getInstance(application).bookmarkDao());
+		quickConnectHistoryGateway =
+		    new QuickConnectHistoryGateway(HistoryDatabase.getInstance(application).historyDao());
 	}
 
 	public LiveData<List<BookmarkBase>> getBookmarks()
@@ -57,13 +67,12 @@ public class HomeViewModel extends AndroidViewModel
 				qcBm.setHostname(currentQuery);
 				qcBm.setDirectConnect(true);
 				result.add(qcBm);
-				result.addAll(GlobalApp.getQuickConnectHistoryGateway().findHistory(currentQuery));
-				result.addAll(
-				    GlobalApp.getManualBookmarkGateway().findByLabelOrHostnameLike(currentQuery));
+				result.addAll(quickConnectHistoryGateway.findHistory(currentQuery));
+				result.addAll(manualBookmarkGateway.findByLabelOrHostnameLike(currentQuery));
 			}
 			else
 			{
-				result.addAll(GlobalApp.getManualBookmarkGateway().findAll());
+				result.addAll(manualBookmarkGateway.findAll());
 			}
 			bookmarks.postValue(result);
 		});
@@ -72,7 +81,7 @@ public class HomeViewModel extends AndroidViewModel
 	public void deleteBookmark(long id)
 	{
 		executor.execute(() -> {
-			GlobalApp.getManualBookmarkGateway().delete(id);
+			manualBookmarkGateway.delete(id);
 			loadBookmarks(currentQuery);
 		});
 	}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -26,7 +26,6 @@ import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
-import android.inputmethodservice.Keyboard;
 import android.inputmethodservice.KeyboardView;
 import android.net.Uri;
 import android.os.Build;
@@ -41,7 +40,6 @@ import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 
-import android.text.InputType;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.Menu;
@@ -52,8 +50,6 @@ import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import android.view.WindowManager;
-import android.view.inputmethod.InputMethodManager;
-import android.view.inputmethod.InputMethodSubtype;
 import android.widget.EditText;
 import android.widget.Toast;
 
@@ -64,14 +60,12 @@ import com.freerdp.freerdpcore.domain.BookmarkBase;
 import com.freerdp.freerdpcore.domain.ConnectionReference;
 import com.freerdp.freerdpcore.services.LibFreeRDP;
 import com.freerdp.freerdpcore.utils.ClipboardManagerProxy;
-import com.freerdp.freerdpcore.utils.KeyboardMapper;
 
 import java.util.Collection;
 import java.util.Iterator;
 
 public class SessionActivity extends AppCompatActivity
-    implements LibFreeRDP.UIEventListener, SessionInputManager.ActivityCallbacks,
-               ClipboardManagerProxy.OnClipboardChangedListener
+    implements LibFreeRDP.UIEventListener, ClipboardManagerProxy.OnClipboardChangedListener
 {
 	public static final String PARAM_CONNECTION_REFERENCE = "conRef";
 	public static final String PARAM_INSTANCE = "instance";
@@ -81,14 +75,6 @@ public class SessionActivity extends AppCompatActivity
 	private SessionView sessionView;
 	private TouchPointerView touchPointerView;
 	private ProgressDialog progressDialog;
-	private KeyboardView keyboardView;
-	private KeyboardView modifiersKeyboardView;
-	private KeyboardMapper keyboardMapper;
-
-	private Keyboard specialkeysKeyboard;
-	private Keyboard numpadKeyboard;
-	private Keyboard cursorKeyboard;
-	private Keyboard modifiersKeyboard;
 
 	private AlertDialog dlgVerifyCertificate;
 	private AlertDialog dlgUserCredentials;
@@ -105,9 +91,6 @@ public class SessionActivity extends AppCompatActivity
 
 	private LibFreeRDPBroadcastReceiver libFreeRDPBroadcastReceiver;
 	private ScrollView2D scrollView;
-	// keyboard visibility flags
-	private boolean sysKeyboardVisible = false;
-	private boolean extKeyboardVisible = false;
 	private ClipboardManagerProxy mClipboardManager;
 	private SessionInputManager inputManager;
 	private boolean callbackDialogResult;
@@ -271,20 +254,8 @@ public class SessionActivity extends AppCompatActivity
 
 		touchPointerView = findViewById(R.id.touchPointerView);
 
-		keyboardMapper = new KeyboardMapper();
-		keyboardMapper.init(this);
-
-		modifiersKeyboard = new Keyboard(getApplicationContext(), R.xml.modifiers_keyboard);
-		specialkeysKeyboard = new Keyboard(getApplicationContext(), R.xml.specialkeys_keyboard);
-		numpadKeyboard = new Keyboard(getApplicationContext(), R.xml.numpad_keyboard);
-		cursorKeyboard = new Keyboard(getApplicationContext(), R.xml.cursor_keyboard);
-
-		// hide keyboard below the sessionView
-		keyboardView = findViewById(R.id.extended_keyboard);
-		keyboardView.setKeyboard(specialkeysKeyboard);
-
-		modifiersKeyboardView = findViewById(R.id.extended_keyboard_header);
-		modifiersKeyboardView.setKeyboard(modifiersKeyboard);
+		KeyboardView keyboardView = findViewById(R.id.extended_keyboard);
+		KeyboardView modifiersKeyboardView = findViewById(R.id.extended_keyboard_header);
 
 		scrollView = findViewById(R.id.sessionScrollView);
 		uiHandler = new UIHandler();
@@ -293,14 +264,10 @@ public class SessionActivity extends AppCompatActivity
 		createDialogs();
 
 		// Wire up the input manager (instance is attached later in bindSession()).
-		inputManager = new SessionInputManager(
-		    this, keyboardMapper, scrollView, sessionView, touchPointerView, keyboardView,
-		    modifiersKeyboardView, modifiersKeyboard, specialkeysKeyboard, numpadKeyboard,
-		    cursorKeyboard, this);
+		inputManager = new SessionInputManager(this, scrollView, sessionView, touchPointerView,
+		                                       keyboardView, modifiersKeyboardView);
 		sessionView.setSessionViewListener(inputManager);
 		touchPointerView.setTouchPointerListener(inputManager);
-		keyboardView.setOnKeyboardActionListener(inputManager);
-		modifiersKeyboardView.setOnKeyboardActionListener(inputManager);
 		sessionView.setScaleGestureDetector(
 		    new ScaleGestureDetector(this, inputManager.getPinchZoomListener()));
 
@@ -355,7 +322,7 @@ public class SessionActivity extends AppCompatActivity
 		Log.v(TAG, "Session.onPause");
 
 		// hide any visible keyboards
-		showKeyboard(false, false);
+		inputManager.hideKeyboards();
 	}
 
 	@Override protected void onStop()
@@ -398,17 +365,7 @@ public class SessionActivity extends AppCompatActivity
 		super.onConfigurationChanged(newConfig);
 
 		// reload keyboard resources (changed from landscape)
-		modifiersKeyboard = new Keyboard(getApplicationContext(), R.xml.modifiers_keyboard);
-		specialkeysKeyboard = new Keyboard(getApplicationContext(), R.xml.specialkeys_keyboard);
-		numpadKeyboard = new Keyboard(getApplicationContext(), R.xml.numpad_keyboard);
-		cursorKeyboard = new Keyboard(getApplicationContext(), R.xml.cursor_keyboard);
-
-		// apply loaded keyboards
-		keyboardView.setKeyboard(specialkeysKeyboard);
-		modifiersKeyboardView.setKeyboard(modifiersKeyboard);
-
-		inputManager.updateKeyboards(modifiersKeyboard, specialkeysKeyboard, numpadKeyboard,
-		                             cursorKeyboard);
+		inputManager.reloadKeyboards();
 
 		hideSystemBars();
 	}
@@ -550,67 +507,10 @@ public class SessionActivity extends AppCompatActivity
 		sessionView.onSurfaceChange(session);
 		scrollView.requestLayout();
 
-		Bitmap surface =
-		    session.getSurface() != null ? session.getSurface().getBitmap() : null;
+		Bitmap surface = session.getSurface() != null ? session.getSurface().getBitmap() : null;
 		inputManager.attachSession(session.getInstance(), surface);
 		inputManager.setScreenSize(screen_width, screen_height);
-		keyboardMapper.reset(inputManager);
 		hideSystemBars();
-	}
-
-	private void setSoftInputState(boolean state)
-	{
-		InputMethodManager mgr = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
-
-		if (state)
-		{
-			sessionView.requestFocus();
-			mgr.showSoftInput(sessionView, InputMethodManager.SHOW_IMPLICIT);
-		}
-		else
-		{
-			mgr.hideSoftInputFromWindow(sessionView.getWindowToken(), 0);
-		}
-	}
-
-	// displays either the system or the extended keyboard or non of them
-	private void showKeyboard(final boolean showSystemKeyboard, final boolean showExtendedKeyboard)
-	{
-		InputMethodManager mgr = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
-
-		if (showSystemKeyboard)
-		{
-			// hide extended keyboard
-			keyboardView.setVisibility(View.GONE);
-			// show system keyboard
-			setSoftInputState(true);
-
-			// show modifiers keyboard
-			modifiersKeyboardView.setVisibility(View.VISIBLE);
-		}
-		else if (showExtendedKeyboard)
-		{
-			// hide system keyboard
-			setSoftInputState(false);
-
-			// show extended keyboard
-			keyboardView.setKeyboard(specialkeysKeyboard);
-			keyboardView.setVisibility(View.VISIBLE);
-			modifiersKeyboardView.setVisibility(View.VISIBLE);
-		}
-		else
-		{
-			// hide both
-			setSoftInputState(false);
-			keyboardView.setVisibility(View.GONE);
-			modifiersKeyboardView.setVisibility(View.GONE);
-
-			// clear any active key modifiers)
-			keyboardMapper.clearlAllModifiers();
-		}
-
-		sysKeyboardVisible = showSystemKeyboard;
-		extKeyboardVisible = showExtendedKeyboard;
 	}
 
 	private void closeSessionActivity(int resultCode)
@@ -638,15 +538,15 @@ public class SessionActivity extends AppCompatActivity
 		}
 		else if (itemId == R.id.session_sys_keyboard)
 		{
-			showKeyboard(!sysKeyboardVisible, false);
+			inputManager.toggleSystemKeyboard();
 		}
 		else if (itemId == R.id.session_ext_keyboard)
 		{
-			showKeyboard(false, !extKeyboardVisible);
+			inputManager.toggleExtendedKeyboard();
 		}
 		else if (itemId == R.id.session_disconnect)
 		{
-			showKeyboard(false, false);
+			inputManager.hideKeyboards();
 			LibFreeRDP.disconnect(session.getInstance());
 		}
 
@@ -656,9 +556,9 @@ public class SessionActivity extends AppCompatActivity
 	public void handleBackPressed()
 	{
 		// hide keyboards (if any visible) or send alt+f4 to the session
-		if (sysKeyboardVisible || extKeyboardVisible)
+		if (inputManager.isAnyKeyboardVisible())
 		{
-			showKeyboard(false, false);
+			inputManager.hideKeyboards();
 			return;
 		}
 		if (inputManager.handleBackAsAltF4())
@@ -974,18 +874,6 @@ public class SessionActivity extends AppCompatActivity
 	}
 
 	// ****************************************************************************
-	// SessionInputManager.ActivityCallbacks
-	@Override public void toggleSystemKeyboard()
-	{
-		showKeyboard(!sysKeyboardVisible, false);
-	}
-
-	@Override public void toggleExtendedKeyboard()
-	{
-		showKeyboard(false, !extKeyboardVisible);
-	}
-
-	// ****************************************************************************
 	// ClipboardManagerProxy.OnClipboardChangedListener
 	@Override public void onClipboardChanged(String data)
 	{
@@ -1034,7 +922,6 @@ public class SessionActivity extends AppCompatActivity
 					((Dialog)msg.obj).show();
 					break;
 				}
-
 			}
 		}
 	}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -12,12 +12,9 @@ package com.freerdp.freerdpcore.presentation;
 
 import android.app.AlertDialog;
 import android.app.UiModeManager;
-import android.content.BroadcastReceiver;
-import androidx.core.content.ContextCompat;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
@@ -81,7 +78,8 @@ public class SessionActivity extends AppCompatActivity
 	private boolean sessionRunning = false;
 	private long backPressedTime = 0;
 
-	private LibFreeRDPBroadcastReceiver libFreeRDPBroadcastReceiver;
+	private LibFreeRDPSessionListener sessionEventListener;
+	private long registeredSessionInstance = 0;
 	private ScrollView2D scrollView;
 	private ClipboardManagerProxy mClipboardManager;
 	private SessionInputManager inputManager;
@@ -182,7 +180,7 @@ public class SessionActivity extends AppCompatActivity
 
 		scrollView = findViewById(R.id.sessionScrollView);
 		uiHandler = new UIHandler();
-		libFreeRDPBroadcastReceiver = new LibFreeRDPBroadcastReceiver();
+		sessionEventListener = new LibFreeRDPSessionListener();
 
 		dialogs = new SessionDialogs(this, new SessionDialogs.OnUserCancelListener() {
 			@Override public void onUserCancel()
@@ -198,12 +196,6 @@ public class SessionActivity extends AppCompatActivity
 		touchPointerView.setTouchPointerListener(inputManager);
 		sessionView.setScaleGestureDetector(
 		    new ScaleGestureDetector(this, inputManager.getPinchZoomListener()));
-
-		// register freerdp events broadcast receiver
-		IntentFilter filter = new IntentFilter();
-		filter.addAction(GlobalApp.ACTION_EVENT_FREERDP);
-		ContextCompat.registerReceiver(this, libFreeRDPBroadcastReceiver, filter,
-		                               ContextCompat.RECEIVER_EXPORTED);
 
 		mClipboardManager = ClipboardManagerProxy.getClipboardManager(this);
 		mClipboardManager.addClipboardChangedListener(this);
@@ -276,8 +268,12 @@ public class SessionActivity extends AppCompatActivity
 		for (SessionState session : sessions)
 			LibFreeRDP.disconnect(session.getInstance());
 
-		// unregister freerdp events broadcast receiver
-		unregisterReceiver(libFreeRDPBroadcastReceiver);
+		// unregister freerdp session listener
+		if (registeredSessionInstance != 0)
+		{
+			GlobalApp.unregisterSessionListener(registeredSessionInstance);
+			registeredSessionInstance = 0;
+		}
 
 		// remove clipboard listener
 		mClipboardManager.removeClipboardboardChangedListener(this);
@@ -407,6 +403,9 @@ public class SessionActivity extends AppCompatActivity
 	private void connectWithTitle(String title)
 	{
 		session.setUIEventListener(this);
+
+		registeredSessionInstance = session.getInstance();
+		GlobalApp.registerSessionListener(registeredSessionInstance, sessionEventListener);
 
 		dialogs.showProgress(title, () -> {
 			connectCancelledByUser = true;
@@ -694,31 +693,27 @@ public class SessionActivity extends AppCompatActivity
 		}
 	}
 
-	private class LibFreeRDPBroadcastReceiver extends BroadcastReceiver
+	private class LibFreeRDPSessionListener implements GlobalApp.SessionEventListener
 	{
-		@Override public void onReceive(Context context, Intent intent)
+		@Override public void onConnectionSuccess()
 		{
-			// still got a valid session?
 			if (session == null)
 				return;
+			OnConnectionSuccess(SessionActivity.this);
+		}
 
-			// is this event for the current session?
-			if (session.getInstance() != intent.getExtras().getLong(GlobalApp.EVENT_PARAM, -1))
+		@Override public void onConnectionFailure()
+		{
+			if (session == null)
 				return;
+			OnConnectionFailure(SessionActivity.this);
+		}
 
-			switch (intent.getExtras().getInt(GlobalApp.EVENT_TYPE, -1))
-			{
-				case GlobalApp.FREERDP_EVENT_CONNECTION_SUCCESS:
-					OnConnectionSuccess(context);
-					break;
-
-				case GlobalApp.FREERDP_EVENT_CONNECTION_FAILURE:
-					OnConnectionFailure(context);
-					break;
-				case GlobalApp.FREERDP_EVENT_DISCONNECTED:
-					OnDisconnected(context);
-					break;
-			}
+		@Override public void onDisconnected()
+		{
+			if (session == null)
+				return;
+			OnDisconnected(SessionActivity.this);
 		}
 
 		private void OnConnectionSuccess(Context context)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -311,23 +311,27 @@ public class SessionActivity extends AppCompatActivity
 		}
 		else if (bundle.containsKey(PARAM_CONNECTION_REFERENCE))
 		{
-			BookmarkBase bookmark = null;
 			String refStr = bundle.getString(PARAM_CONNECTION_REFERENCE);
 			if (ConnectionReference.isHostnameReference(refStr))
 			{
-				bookmark = new BookmarkBase();
+				BookmarkBase bookmark = new BookmarkBase();
 				bookmark.setHostname(ConnectionReference.getHostname(refStr));
+				connect(bookmark);
 			}
 			else if (ConnectionReference.isBookmarkReference(refStr))
 			{
-				bookmark = GlobalApp.getManualBookmarkGateway().findById(
-				    ConnectionReference.getBookmarkId(refStr));
+				sessionViewModel.loadBookmarkById(ConnectionReference.getBookmarkId(refStr),
+				                                  bookmark -> {
+					                                  if (bookmark != null)
+						                                  connect(bookmark);
+					                                  else
+						                                  closeSessionActivity(RESULT_CANCELED);
+				                                  });
 			}
-
-			if (bookmark != null)
-				connect(bookmark);
 			else
+			{
 				closeSessionActivity(RESULT_CANCELED);
+			}
 		}
 		else
 		{
@@ -744,9 +748,7 @@ public class SessionActivity extends AppCompatActivity
 			        bundle.getString(PARAM_CONNECTION_REFERENCE)))
 			{
 				assert session.getBookmark().getType() == BookmarkBase.TYPE_MANUAL;
-				String item = session.getBookmark().getHostname();
-				if (!GlobalApp.getQuickConnectHistoryGateway().historyItemExists(item))
-					GlobalApp.getQuickConnectHistoryGateway().addHistoryItem(item);
+				sessionViewModel.recordQuickConnectHistory(session.getBookmark().getHostname());
 			}
 		}
 	}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -26,6 +26,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.Message;
 
 import androidx.activity.OnBackPressedCallback;
@@ -70,7 +71,36 @@ public class SessionActivity extends AppCompatActivity
 	private SessionView sessionView;
 	private TouchPointerView touchPointerView;
 
-	private UIHandler uiHandler;
+	private static final int REFRESH_SESSIONVIEW = 1;
+	private static final int DISPLAY_TOAST = 2;
+	private static final int GRAPHICS_CHANGED = 6;
+
+	private final Handler uiHandler = new Handler(Looper.getMainLooper()) {
+		@Override public void handleMessage(Message msg)
+		{
+			switch (msg.what)
+			{
+				case GRAPHICS_CHANGED:
+				{
+					sessionView.onSurfaceChange(session);
+					scrollView.requestLayout();
+					break;
+				}
+				case REFRESH_SESSIONVIEW:
+				{
+					sessionView.invalidateRegion();
+					break;
+				}
+				case DISPLAY_TOAST:
+				{
+					Toast errorToast = Toast.makeText(getApplicationContext(), msg.obj.toString(),
+					                                  Toast.LENGTH_LONG);
+					errorToast.show();
+					break;
+				}
+			}
+		}
+	};
 
 	private int screen_width;
 	private int screen_height;
@@ -179,7 +209,6 @@ public class SessionActivity extends AppCompatActivity
 		KeyboardView modifiersKeyboardView = findViewById(R.id.extended_keyboard_header);
 
 		scrollView = findViewById(R.id.sessionScrollView);
-		uiHandler = new UIHandler();
 		sessionViewModel = new ViewModelProvider(this).get(SessionViewModel.class);
 		sessionViewModel.getState().observe(this, this::onConnectionStateChanged);
 
@@ -559,9 +588,8 @@ public class SessionActivity extends AppCompatActivity
 		BookmarkBase.ScreenSettings settings = session.getBookmark().getActiveScreenSettings();
 		if ((settings.getWidth() != width && settings.getWidth() != width + 1) ||
 		    settings.getHeight() != height || settings.getColors() != bpp)
-			uiHandler.sendMessage(
-			    Message.obtain(null, UIHandler.DISPLAY_TOAST,
-			                   getResources().getText(R.string.info_capabilities_changed)));
+			uiHandler.sendMessage(Message.obtain(
+			    null, DISPLAY_TOAST, getResources().getText(R.string.info_capabilities_changed)));
 	}
 
 	@Override public void OnGraphicsUpdate(int x, int y, int width, int height)
@@ -575,7 +603,7 @@ public class SessionActivity extends AppCompatActivity
 		 * modifications to it need to be scheduled
 		 */
 
-		uiHandler.sendEmptyMessage(UIHandler.REFRESH_SESSIONVIEW);
+		uiHandler.sendEmptyMessage(REFRESH_SESSIONVIEW);
 	}
 
 	@Override public void OnGraphicsResize(int width, int height, int bpp)
@@ -594,7 +622,7 @@ public class SessionActivity extends AppCompatActivity
 		 * since sessionView can only be modified from the UI thread any
 		 * modifications to it need to be scheduled
 		 */
-		uiHandler.sendEmptyMessage(UIHandler.GRAPHICS_CHANGED);
+		uiHandler.sendEmptyMessage(GRAPHICS_CHANGED);
 	}
 
 	@Override
@@ -653,44 +681,6 @@ public class SessionActivity extends AppCompatActivity
 	{
 		Log.v(TAG, "onClipboardChanged: " + data);
 		LibFreeRDP.sendClipboardData(session.getInstance(), data);
-	}
-
-	private class UIHandler extends Handler
-	{
-
-		public static final int REFRESH_SESSIONVIEW = 1;
-		public static final int DISPLAY_TOAST = 2;
-		public static final int GRAPHICS_CHANGED = 6;
-
-		UIHandler()
-		{
-			super();
-		}
-
-		@Override public void handleMessage(Message msg)
-		{
-			switch (msg.what)
-			{
-				case GRAPHICS_CHANGED:
-				{
-					sessionView.onSurfaceChange(session);
-					scrollView.requestLayout();
-					break;
-				}
-				case REFRESH_SESSIONVIEW:
-				{
-					sessionView.invalidateRegion();
-					break;
-				}
-				case DISPLAY_TOAST:
-				{
-					Toast errorToast = Toast.makeText(getApplicationContext(), msg.obj.toString(),
-					                                  Toast.LENGTH_LONG);
-					errorToast.show();
-					break;
-				}
-			}
-		}
 	}
 
 	private void onConnectionStateChanged(SessionViewModel.ConnectionState state)
@@ -765,9 +755,8 @@ public class SessionActivity extends AppCompatActivity
 
 		// post error message on UI thread
 		if (!connectCancelledByUser)
-			uiHandler.sendMessage(
-			    Message.obtain(null, UIHandler.DISPLAY_TOAST,
-			                   getResources().getText(R.string.error_connection_failure)));
+			uiHandler.sendMessage(Message.obtain(
+			    null, DISPLAY_TOAST, getResources().getText(R.string.error_connection_failure)));
 
 		closeSessionActivity(RESULT_CANCELED);
 	}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -11,7 +11,6 @@
 package com.freerdp.freerdpcore.presentation;
 
 import android.app.AlertDialog;
-import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.app.UiModeManager;
 import android.content.BroadcastReceiver;
@@ -50,7 +49,6 @@ import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import android.view.WindowManager;
-import android.widget.EditText;
 import android.widget.Toast;
 
 import com.freerdp.freerdpcore.R;
@@ -76,10 +74,6 @@ public class SessionActivity extends AppCompatActivity
 	private TouchPointerView touchPointerView;
 	private ProgressDialog progressDialog;
 
-	private AlertDialog dlgVerifyCertificate;
-	private AlertDialog dlgUserCredentials;
-	private View userCredView;
-
 	private UIHandler uiHandler;
 
 	private int screen_width;
@@ -93,76 +87,7 @@ public class SessionActivity extends AppCompatActivity
 	private ScrollView2D scrollView;
 	private ClipboardManagerProxy mClipboardManager;
 	private SessionInputManager inputManager;
-	private boolean callbackDialogResult;
-
-	private void createDialogs()
-	{
-		// build verify certificate dialog
-		dlgVerifyCertificate =
-		    new AlertDialog.Builder(this)
-		        .setTitle(R.string.dlg_title_verify_certificate)
-		        .setPositiveButton(android.R.string.yes,
-		                           new DialogInterface.OnClickListener() {
-			                           @Override
-			                           public void onClick(DialogInterface dialog, int which)
-			                           {
-				                           callbackDialogResult = true;
-				                           synchronized (dialog)
-				                           {
-					                           dialog.notify();
-				                           }
-			                           }
-		                           })
-		        .setNegativeButton(android.R.string.no,
-		                           new DialogInterface.OnClickListener() {
-			                           @Override
-			                           public void onClick(DialogInterface dialog, int which)
-			                           {
-				                           callbackDialogResult = false;
-				                           connectCancelledByUser = true;
-				                           synchronized (dialog)
-				                           {
-					                           dialog.notify();
-				                           }
-			                           }
-		                           })
-		        .setCancelable(false)
-		        .create();
-
-		// build the dialog
-		userCredView = getLayoutInflater().inflate(R.layout.credentials, null, true);
-		dlgUserCredentials =
-		    new AlertDialog.Builder(this)
-		        .setView(userCredView)
-		        .setTitle(R.string.dlg_title_credentials)
-		        .setPositiveButton(android.R.string.ok,
-		                           new DialogInterface.OnClickListener() {
-			                           @Override
-			                           public void onClick(DialogInterface dialog, int which)
-			                           {
-				                           callbackDialogResult = true;
-				                           synchronized (dialog)
-				                           {
-					                           dialog.notify();
-				                           }
-			                           }
-		                           })
-		        .setNegativeButton(android.R.string.cancel,
-		                           new DialogInterface.OnClickListener() {
-			                           @Override
-			                           public void onClick(DialogInterface dialog, int which)
-			                           {
-				                           callbackDialogResult = false;
-				                           connectCancelledByUser = true;
-				                           synchronized (dialog)
-				                           {
-					                           dialog.notify();
-				                           }
-			                           }
-		                           })
-		        .setCancelable(false)
-		        .create();
-	}
+	private SessionDialogs authDialogs;
 
 	private void hideSystemBars()
 	{
@@ -261,7 +186,12 @@ public class SessionActivity extends AppCompatActivity
 		uiHandler = new UIHandler();
 		libFreeRDPBroadcastReceiver = new LibFreeRDPBroadcastReceiver();
 
-		createDialogs();
+		authDialogs = new SessionDialogs(this, new SessionDialogs.OnUserCancelListener() {
+			@Override public void onUserCancel()
+			{
+				connectCancelledByUser = true;
+			}
+		});
 
 		// Wire up the input manager (instance is attached later in bindSession()).
 		inputManager = new SessionInputManager(this, scrollView, sessionView, touchPointerView,
@@ -683,132 +613,23 @@ public class SessionActivity extends AppCompatActivity
 	public boolean OnAuthenticate(StringBuilder username, StringBuilder domain,
 	                              StringBuilder password)
 	{
-		// this is where the return code of our dialog will be stored
-		callbackDialogResult = false;
-
-		// set text fields
-		((EditText)userCredView.findViewById(R.id.editTextUsername)).setText(username);
-		((EditText)userCredView.findViewById(R.id.editTextDomain)).setText(domain);
-		((EditText)userCredView.findViewById(R.id.editTextPassword)).setText(password);
-
-		// start dialog in UI thread
-		uiHandler.sendMessage(Message.obtain(null, UIHandler.SHOW_DIALOG, dlgUserCredentials));
-
-		// wait for result
-		try
-		{
-			synchronized (dlgUserCredentials)
-			{
-				dlgUserCredentials.wait();
-			}
-		}
-		catch (InterruptedException e)
-		{
-		}
-
-		// clear buffers
-		username.setLength(0);
-		domain.setLength(0);
-		password.setLength(0);
-
-		// read back user credentials
-		username.append(
-		    ((EditText)userCredView.findViewById(R.id.editTextUsername)).getText().toString());
-		domain.append(
-		    ((EditText)userCredView.findViewById(R.id.editTextDomain)).getText().toString());
-		password.append(
-		    ((EditText)userCredView.findViewById(R.id.editTextPassword)).getText().toString());
-
-		return callbackDialogResult;
+		return authDialogs.promptCredentials(username, domain, password);
 	}
 
 	@Override
 	public boolean OnGatewayAuthenticate(StringBuilder username, StringBuilder domain,
 	                                     StringBuilder password)
 	{
-		// this is where the return code of our dialog will be stored
-		callbackDialogResult = false;
-
-		// set text fields
-		((EditText)userCredView.findViewById(R.id.editTextUsername)).setText(username);
-		((EditText)userCredView.findViewById(R.id.editTextDomain)).setText(domain);
-		((EditText)userCredView.findViewById(R.id.editTextPassword)).setText(password);
-
-		// start dialog in UI thread
-		uiHandler.sendMessage(Message.obtain(null, UIHandler.SHOW_DIALOG, dlgUserCredentials));
-
-		// wait for result
-		try
-		{
-			synchronized (dlgUserCredentials)
-			{
-				dlgUserCredentials.wait();
-			}
-		}
-		catch (InterruptedException e)
-		{
-		}
-
-		// clear buffers
-		username.setLength(0);
-		domain.setLength(0);
-		password.setLength(0);
-
-		// read back user credentials
-		username.append(
-		    ((EditText)userCredView.findViewById(R.id.editTextUsername)).getText().toString());
-		domain.append(
-		    ((EditText)userCredView.findViewById(R.id.editTextDomain)).getText().toString());
-		password.append(
-		    ((EditText)userCredView.findViewById(R.id.editTextPassword)).getText().toString());
-
-		return callbackDialogResult;
+		return authDialogs.promptCredentials(username, domain, password);
 	}
 
 	@Override
 	public int OnVerifiyCertificateEx(String host, long port, String commonName, String subject,
 	                                  String issuer, String fingerprint, long flags)
 	{
-		// see if global settings says accept all
 		if (ApplicationSettingsActivity.getAcceptAllCertificates(this))
 			return 0;
-
-		// this is where the return code of our dialog will be stored
-		callbackDialogResult = false;
-
-		// set message
-		String msg = getResources().getString(R.string.dlg_msg_verify_certificate);
-		String type = "RDP-Server";
-		if ((flags & LibFreeRDP.VERIFY_CERT_FLAG_GATEWAY) != 0)
-			type = "RDP-Gateway";
-		if ((flags & LibFreeRDP.VERIFY_CERT_FLAG_REDIRECT) != 0)
-			type = "RDP-Redirect";
-		msg += "\n\n" + type + ": " + host + ":" + port;
-
-		msg += "\n\nSubject: " + subject + "\nIssuer: " + issuer;
-
-		if ((flags & LibFreeRDP.VERIFY_CERT_FLAG_FP_IS_PEM) != 0)
-			msg += "\nCertificate: " + fingerprint;
-		else
-			msg += "\nFingerprint: " + fingerprint;
-		dlgVerifyCertificate.setMessage(msg);
-
-		// start dialog in UI thread
-		uiHandler.sendMessage(Message.obtain(null, UIHandler.SHOW_DIALOG, dlgVerifyCertificate));
-
-		// wait for result
-		try
-		{
-			synchronized (dlgVerifyCertificate)
-			{
-				dlgVerifyCertificate.wait();
-			}
-		}
-		catch (InterruptedException e)
-		{
-		}
-
-		return callbackDialogResult ? 1 : 0;
+		return authDialogs.verifyCertificate(host, port, subject, issuer, fingerprint, flags);
 	}
 
 	@Override
@@ -817,44 +638,9 @@ public class SessionActivity extends AppCompatActivity
 	                                        String oldSubject, String oldIssuer,
 	                                        String oldFingerprint, long flags)
 	{
-		// see if global settings says accept all
 		if (ApplicationSettingsActivity.getAcceptAllCertificates(this))
 			return 0;
-
-		// this is where the return code of our dialog will be stored
-		callbackDialogResult = false;
-
-		// set message
-		String msg = getResources().getString(R.string.dlg_msg_verify_certificate);
-		String type = "RDP-Server";
-		if ((flags & LibFreeRDP.VERIFY_CERT_FLAG_GATEWAY) != 0)
-			type = "RDP-Gateway";
-		if ((flags & LibFreeRDP.VERIFY_CERT_FLAG_REDIRECT) != 0)
-			type = "RDP-Redirect";
-		msg += "\n\n" + type + ": " + host + ":" + port;
-		msg += "\n\nSubject: " + subject + "\nIssuer: " + issuer;
-		if ((flags & LibFreeRDP.VERIFY_CERT_FLAG_FP_IS_PEM) != 0)
-			msg += "\nCertificate: " + fingerprint;
-		else
-			msg += "\nFingerprint: " + fingerprint;
-		dlgVerifyCertificate.setMessage(msg);
-
-		// start dialog in UI thread
-		uiHandler.sendMessage(Message.obtain(null, UIHandler.SHOW_DIALOG, dlgVerifyCertificate));
-
-		// wait for result
-		try
-		{
-			synchronized (dlgVerifyCertificate)
-			{
-				dlgVerifyCertificate.wait();
-			}
-		}
-		catch (InterruptedException e)
-		{
-		}
-
-		return callbackDialogResult ? 1 : 0;
+		return authDialogs.verifyChangedCertificate(host, port, subject, issuer, fingerprint, flags);
 	}
 
 	@Override public void OnRemoteClipboardChanged(String data)
@@ -886,7 +672,6 @@ public class SessionActivity extends AppCompatActivity
 
 		public static final int REFRESH_SESSIONVIEW = 1;
 		public static final int DISPLAY_TOAST = 2;
-		public static final int SHOW_DIALOG = 5;
 		public static final int GRAPHICS_CHANGED = 6;
 
 		UIHandler()
@@ -914,12 +699,6 @@ public class SessionActivity extends AppCompatActivity
 					Toast errorToast = Toast.makeText(getApplicationContext(), msg.obj.toString(),
 					                                  Toast.LENGTH_LONG);
 					errorToast.show();
-					break;
-				}
-				case SHOW_DIALOG:
-				{
-					// create and show the dialog
-					((Dialog)msg.obj).show();
 					break;
 				}
 			}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -34,6 +34,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
+import androidx.lifecycle.ViewModelProvider;
 
 import android.util.Log;
 import android.view.KeyEvent;
@@ -78,8 +79,7 @@ public class SessionActivity extends AppCompatActivity
 	private boolean sessionRunning = false;
 	private long backPressedTime = 0;
 
-	private LibFreeRDPSessionListener sessionEventListener;
-	private long registeredSessionInstance = 0;
+	private SessionViewModel sessionViewModel;
 	private ScrollView2D scrollView;
 	private ClipboardManagerProxy mClipboardManager;
 	private SessionInputManager inputManager;
@@ -180,7 +180,8 @@ public class SessionActivity extends AppCompatActivity
 
 		scrollView = findViewById(R.id.sessionScrollView);
 		uiHandler = new UIHandler();
-		sessionEventListener = new LibFreeRDPSessionListener();
+		sessionViewModel = new ViewModelProvider(this).get(SessionViewModel.class);
+		sessionViewModel.getState().observe(this, this::onConnectionStateChanged);
 
 		dialogs = new SessionDialogs(this, new SessionDialogs.OnUserCancelListener() {
 			@Override public void onUserCancel()
@@ -269,11 +270,7 @@ public class SessionActivity extends AppCompatActivity
 			LibFreeRDP.disconnect(session.getInstance());
 
 		// unregister freerdp session listener
-		if (registeredSessionInstance != 0)
-		{
-			GlobalApp.unregisterSessionListener(registeredSessionInstance);
-			registeredSessionInstance = 0;
-		}
+		sessionViewModel.unregister();
 
 		// remove clipboard listener
 		mClipboardManager.removeClipboardboardChangedListener(this);
@@ -404,8 +401,7 @@ public class SessionActivity extends AppCompatActivity
 	{
 		session.setUIEventListener(this);
 
-		registeredSessionInstance = session.getInstance();
-		GlobalApp.registerSessionListener(registeredSessionInstance, sessionEventListener);
+		sessionViewModel.register(session.getInstance());
 
 		dialogs.showProgress(title, () -> {
 			connectCancelledByUser = true;
@@ -693,107 +689,103 @@ public class SessionActivity extends AppCompatActivity
 		}
 	}
 
-	private class LibFreeRDPSessionListener implements GlobalApp.SessionEventListener
+	private void onConnectionStateChanged(SessionViewModel.ConnectionState state)
 	{
-		@Override public void onConnectionSuccess()
+		if (session == null)
+			return;
+		switch (state)
 		{
-			if (session == null)
-				return;
-			OnConnectionSuccess(SessionActivity.this);
+			case CONNECTED:
+				onSessionConnected();
+				break;
+			case FAILED:
+				onSessionFailed();
+				break;
+			case DISCONNECTED:
+				onSessionDisconnected();
+				break;
+			default:
+				break;
 		}
+	}
 
-		@Override public void onConnectionFailure()
+	private void onSessionConnected()
+	{
+		Log.v(TAG, "onSessionConnected");
+
+		if (connectCancelledByUser)
 		{
-			if (session == null)
-				return;
-			OnConnectionFailure(SessionActivity.this);
-		}
-
-		@Override public void onDisconnected()
-		{
-			if (session == null)
-				return;
-			OnDisconnected(SessionActivity.this);
-		}
-
-		private void OnConnectionSuccess(Context context)
-		{
-			Log.v(TAG, "OnConnectionSuccess");
-
-			if (connectCancelledByUser)
-			{
-				LibFreeRDP.disconnect(session.getInstance());
-				closeSessionActivity(RESULT_CANCELED);
-				return;
-			}
-
-			// bind session
-			bindSession();
-
-			if (ApplicationSettingsActivity.getKeepScreenOnWhenConnected(context))
-			{
-				getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-			}
-
-			dialogs.dismissProgress();
-
-			if (session.getBookmark() == null)
-			{
-				// Return immediately if we launch from URI
-				return;
-			}
-
-			// add hostname to history if quick connect was used
-			Bundle bundle = getIntent().getExtras();
-			if (bundle != null && bundle.containsKey(PARAM_CONNECTION_REFERENCE))
-			{
-				if (ConnectionReference.isHostnameReference(
-				        bundle.getString(PARAM_CONNECTION_REFERENCE)))
-				{
-					assert session.getBookmark().getType() == BookmarkBase.TYPE_MANUAL;
-					String item = session.getBookmark().getHostname();
-					if (!GlobalApp.getQuickConnectHistoryGateway().historyItemExists(item))
-						GlobalApp.getQuickConnectHistoryGateway().addHistoryItem(item);
-				}
-			}
-		}
-
-		private void OnConnectionFailure(Context context)
-		{
-			Log.v(TAG, "OnConnectionFailure");
-
-			// cancel any pending input events
-			if (inputManager != null)
-				inputManager.cancelPendingEvents();
-
-			dialogs.dismissProgress();
-
-			// post error message on UI thread
-			if (!connectCancelledByUser)
-				uiHandler.sendMessage(
-				    Message.obtain(null, UIHandler.DISPLAY_TOAST,
-				                   getResources().getText(R.string.error_connection_failure)));
-
+			LibFreeRDP.disconnect(session.getInstance());
 			closeSessionActivity(RESULT_CANCELED);
+			return;
 		}
 
-		private void OnDisconnected(Context context)
+		// bind session
+		bindSession();
+
+		if (ApplicationSettingsActivity.getKeepScreenOnWhenConnected(this))
 		{
-			Log.v(TAG, "OnDisconnected");
-
-			// cancel any pending input events
-			if (inputManager != null)
-				inputManager.cancelPendingEvents();
-
-			if (ApplicationSettingsActivity.getKeepScreenOnWhenConnected(context))
-			{
-				getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-			}
-
-			dialogs.dismissProgress();
-
-			session.setUIEventListener(null);
-			closeSessionActivity(RESULT_OK);
+			getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 		}
+
+		dialogs.dismissProgress();
+
+		if (session.getBookmark() == null)
+		{
+			// Return immediately if we launch from URI
+			return;
+		}
+
+		// add hostname to history if quick connect was used
+		Bundle bundle = getIntent().getExtras();
+		if (bundle != null && bundle.containsKey(PARAM_CONNECTION_REFERENCE))
+		{
+			if (ConnectionReference.isHostnameReference(
+			        bundle.getString(PARAM_CONNECTION_REFERENCE)))
+			{
+				assert session.getBookmark().getType() == BookmarkBase.TYPE_MANUAL;
+				String item = session.getBookmark().getHostname();
+				if (!GlobalApp.getQuickConnectHistoryGateway().historyItemExists(item))
+					GlobalApp.getQuickConnectHistoryGateway().addHistoryItem(item);
+			}
+		}
+	}
+
+	private void onSessionFailed()
+	{
+		Log.v(TAG, "onSessionFailed");
+
+		// cancel any pending input events
+		if (inputManager != null)
+			inputManager.cancelPendingEvents();
+
+		dialogs.dismissProgress();
+
+		// post error message on UI thread
+		if (!connectCancelledByUser)
+			uiHandler.sendMessage(
+			    Message.obtain(null, UIHandler.DISPLAY_TOAST,
+			                   getResources().getText(R.string.error_connection_failure)));
+
+		closeSessionActivity(RESULT_CANCELED);
+	}
+
+	private void onSessionDisconnected()
+	{
+		Log.v(TAG, "onSessionDisconnected");
+
+		// cancel any pending input events
+		if (inputManager != null)
+			inputManager.cancelPendingEvents();
+
+		if (ApplicationSettingsActivity.getKeepScreenOnWhenConnected(this))
+		{
+			getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+		}
+
+		dialogs.dismissProgress();
+
+		session.setUIEventListener(null);
+		closeSessionActivity(RESULT_OK);
 	}
 }

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -11,7 +11,6 @@
 package com.freerdp.freerdpcore.presentation;
 
 import android.app.AlertDialog;
-import android.app.ProgressDialog;
 import android.app.UiModeManager;
 import android.content.BroadcastReceiver;
 import androidx.core.content.ContextCompat;
@@ -72,7 +71,6 @@ public class SessionActivity extends AppCompatActivity
 	private SessionState session;
 	private SessionView sessionView;
 	private TouchPointerView touchPointerView;
-	private ProgressDialog progressDialog;
 
 	private UIHandler uiHandler;
 
@@ -87,7 +85,7 @@ public class SessionActivity extends AppCompatActivity
 	private ScrollView2D scrollView;
 	private ClipboardManagerProxy mClipboardManager;
 	private SessionInputManager inputManager;
-	private SessionDialogs authDialogs;
+	private SessionDialogs dialogs;
 
 	private void hideSystemBars()
 	{
@@ -186,7 +184,7 @@ public class SessionActivity extends AppCompatActivity
 		uiHandler = new UIHandler();
 		libFreeRDPBroadcastReceiver = new LibFreeRDPBroadcastReceiver();
 
-		authDialogs = new SessionDialogs(this, new SessionDialogs.OnUserCancelListener() {
+		dialogs = new SessionDialogs(this, new SessionDialogs.OnUserCancelListener() {
 			@Override public void onUserCancel()
 			{
 				connectCancelledByUser = true;
@@ -410,19 +408,10 @@ public class SessionActivity extends AppCompatActivity
 	{
 		session.setUIEventListener(this);
 
-		progressDialog = new ProgressDialog(this);
-		progressDialog.setTitle(title);
-		progressDialog.setMessage(getResources().getText(R.string.dlg_msg_connecting));
-		progressDialog.setButton(
-		    ProgressDialog.BUTTON_NEGATIVE, "Cancel", new DialogInterface.OnClickListener() {
-			    @Override public void onClick(DialogInterface dialog, int which)
-			    {
-				    connectCancelledByUser = true;
-				    LibFreeRDP.cancelConnection(session.getInstance());
-			    }
-		    });
-		progressDialog.setCancelable(false);
-		progressDialog.show();
+		dialogs.showProgress(title, () -> {
+			connectCancelledByUser = true;
+			LibFreeRDP.cancelConnection(session.getInstance());
+		});
 
 		connectThread = new ConnectThread(getApplicationContext(), session);
 		connectThread.start();
@@ -613,14 +602,14 @@ public class SessionActivity extends AppCompatActivity
 	public boolean OnAuthenticate(StringBuilder username, StringBuilder domain,
 	                              StringBuilder password)
 	{
-		return authDialogs.promptCredentials(username, domain, password);
+		return dialogs.promptCredentials(username, domain, password);
 	}
 
 	@Override
 	public boolean OnGatewayAuthenticate(StringBuilder username, StringBuilder domain,
 	                                     StringBuilder password)
 	{
-		return authDialogs.promptCredentials(username, domain, password);
+		return dialogs.promptCredentials(username, domain, password);
 	}
 
 	@Override
@@ -629,7 +618,7 @@ public class SessionActivity extends AppCompatActivity
 	{
 		if (ApplicationSettingsActivity.getAcceptAllCertificates(this))
 			return 0;
-		return authDialogs.verifyCertificate(host, port, subject, issuer, fingerprint, flags);
+		return dialogs.verifyCertificate(host, port, subject, issuer, fingerprint, flags);
 	}
 
 	@Override
@@ -640,7 +629,7 @@ public class SessionActivity extends AppCompatActivity
 	{
 		if (ApplicationSettingsActivity.getAcceptAllCertificates(this))
 			return 0;
-		return authDialogs.verifyChangedCertificate(host, port, subject, issuer, fingerprint, flags);
+		return dialogs.verifyChangedCertificate(host, port, subject, issuer, fingerprint, flags);
 	}
 
 	@Override public void OnRemoteClipboardChanged(String data)
@@ -751,11 +740,7 @@ public class SessionActivity extends AppCompatActivity
 				getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 			}
 
-			if (progressDialog != null)
-			{
-				progressDialog.dismiss();
-				progressDialog = null;
-			}
+			dialogs.dismissProgress();
 
 			if (session.getBookmark() == null)
 			{
@@ -786,11 +771,7 @@ public class SessionActivity extends AppCompatActivity
 			if (inputManager != null)
 				inputManager.cancelPendingEvents();
 
-			if (progressDialog != null)
-			{
-				progressDialog.dismiss();
-				progressDialog = null;
-			}
+			dialogs.dismissProgress();
 
 			// post error message on UI thread
 			if (!connectCancelledByUser)
@@ -814,11 +795,7 @@ public class SessionActivity extends AppCompatActivity
 				getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 			}
 
-			if (progressDialog != null)
-			{
-				progressDialog.dismiss();
-				progressDialog = null;
-			}
+			dialogs.dismissProgress();
 
 			session.setUIEventListener(null);
 			closeSessionActivity(RESULT_OK);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -24,7 +24,6 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
-import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.inputmethodservice.Keyboard;
@@ -66,28 +65,17 @@ import com.freerdp.freerdpcore.domain.ConnectionReference;
 import com.freerdp.freerdpcore.services.LibFreeRDP;
 import com.freerdp.freerdpcore.utils.ClipboardManagerProxy;
 import com.freerdp.freerdpcore.utils.KeyboardMapper;
-import com.freerdp.freerdpcore.utils.Mouse;
 
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 
 public class SessionActivity extends AppCompatActivity
-    implements LibFreeRDP.UIEventListener, KeyboardView.OnKeyboardActionListener,
-               KeyboardMapper.KeyProcessingListener, SessionView.SessionViewListener,
-               TouchPointerView.TouchPointerListener,
+    implements LibFreeRDP.UIEventListener, SessionInputManager.ActivityCallbacks,
                ClipboardManagerProxy.OnClipboardChangedListener
 {
 	public static final String PARAM_CONNECTION_REFERENCE = "conRef";
 	public static final String PARAM_INSTANCE = "instance";
-	// timeout between subsequent scrolling requests when the touch-pointer is
-	// at the edge of the session view
-	private static final int SCROLLING_TIMEOUT = 50;
-	private static final int SCROLLING_DISTANCE = 20;
 	private static final String TAG = "FreeRDP.SessionActivity";
-	// variables for delayed move event sending
-	private static final int MAX_DISCARDED_MOVE_EVENTS = 3;
-	private static final int SEND_MOVE_EVENT_TIMEOUT = 150;
 	private Bitmap bitmap;
 	private SessionState session;
 	private SessionView sessionView;
@@ -120,8 +108,8 @@ public class SessionActivity extends AppCompatActivity
 	// keyboard visibility flags
 	private boolean sysKeyboardVisible = false;
 	private boolean extKeyboardVisible = false;
-	private int discardedMoveEvents = 0;
 	private ClipboardManagerProxy mClipboardManager;
+	private SessionInputManager inputManager;
 	private boolean callbackDialogResult;
 
 	private void createDialogs()
@@ -279,17 +267,12 @@ public class SessionActivity extends AppCompatActivity
 		    });
 
 		sessionView = findViewById(R.id.sessionView);
-		sessionView.setScaleGestureDetector(
-		    new ScaleGestureDetector(this, new PinchZoomListener()));
-		sessionView.setSessionViewListener(this);
 		sessionView.requestFocus();
 
 		touchPointerView = findViewById(R.id.touchPointerView);
-		touchPointerView.setTouchPointerListener(this);
 
 		keyboardMapper = new KeyboardMapper();
 		keyboardMapper.init(this);
-		keyboardMapper.reset(this);
 
 		modifiersKeyboard = new Keyboard(getApplicationContext(), R.xml.modifiers_keyboard);
 		specialkeysKeyboard = new Keyboard(getApplicationContext(), R.xml.specialkeys_keyboard);
@@ -299,17 +282,27 @@ public class SessionActivity extends AppCompatActivity
 		// hide keyboard below the sessionView
 		keyboardView = findViewById(R.id.extended_keyboard);
 		keyboardView.setKeyboard(specialkeysKeyboard);
-		keyboardView.setOnKeyboardActionListener(this);
 
 		modifiersKeyboardView = findViewById(R.id.extended_keyboard_header);
 		modifiersKeyboardView.setKeyboard(modifiersKeyboard);
-		modifiersKeyboardView.setOnKeyboardActionListener(this);
 
 		scrollView = findViewById(R.id.sessionScrollView);
 		uiHandler = new UIHandler();
 		libFreeRDPBroadcastReceiver = new LibFreeRDPBroadcastReceiver();
 
 		createDialogs();
+
+		// Wire up the input manager (instance is attached later in bindSession()).
+		inputManager = new SessionInputManager(
+		    this, keyboardMapper, scrollView, sessionView, touchPointerView, keyboardView,
+		    modifiersKeyboardView, modifiersKeyboard, specialkeysKeyboard, numpadKeyboard,
+		    cursorKeyboard, this);
+		sessionView.setSessionViewListener(inputManager);
+		touchPointerView.setTouchPointerListener(inputManager);
+		keyboardView.setOnKeyboardActionListener(inputManager);
+		modifiersKeyboardView.setOnKeyboardActionListener(inputManager);
+		sessionView.setScaleGestureDetector(
+		    new ScaleGestureDetector(this, inputManager.getPinchZoomListener()));
 
 		// register freerdp events broadcast receiver
 		IntentFilter filter = new IntentFilter();
@@ -413,6 +406,9 @@ public class SessionActivity extends AppCompatActivity
 		// apply loaded keyboards
 		keyboardView.setKeyboard(specialkeysKeyboard);
 		modifiersKeyboardView.setKeyboard(modifiersKeyboard);
+
+		inputManager.updateKeyboards(modifiersKeyboard, specialkeysKeyboard, numpadKeyboard,
+		                             cursorKeyboard);
 
 		hideSystemBars();
 	}
@@ -553,7 +549,12 @@ public class SessionActivity extends AppCompatActivity
 		session.setUIEventListener(this);
 		sessionView.onSurfaceChange(session);
 		scrollView.requestLayout();
-		keyboardMapper.reset(this);
+
+		Bitmap surface =
+		    session.getSurface() != null ? session.getSurface().getBitmap() : null;
+		inputManager.attachSession(session.getInstance(), surface);
+		inputManager.setScreenSize(screen_width, screen_height);
+		keyboardMapper.reset(inputManager);
 		hideSystemBars();
 	}
 
@@ -619,63 +620,6 @@ public class SessionActivity extends AppCompatActivity
 		finish();
 	}
 
-	// update the state of our modifier keys
-	private void updateModifierKeyStates()
-	{
-		// check if any key is in the keycodes list
-
-		List<Keyboard.Key> keys = modifiersKeyboard.getKeys();
-		for (Keyboard.Key curKey : keys)
-		{
-			// if the key is a sticky key - just set it to off
-			if (curKey.sticky)
-			{
-				switch (keyboardMapper.getModifierState(curKey.codes[0]))
-				{
-					case KeyboardMapper.KEYSTATE_ON:
-						curKey.on = true;
-						curKey.pressed = false;
-						break;
-
-					case KeyboardMapper.KEYSTATE_OFF:
-						curKey.on = false;
-						curKey.pressed = false;
-						break;
-
-					case KeyboardMapper.KEYSTATE_LOCKED:
-						curKey.on = true;
-						curKey.pressed = true;
-						break;
-				}
-			}
-		}
-
-		// refresh image
-		modifiersKeyboardView.invalidateAllKeys();
-	}
-
-	private void sendDelayedMoveEvent(int x, int y)
-	{
-		if (uiHandler.hasMessages(UIHandler.SEND_MOVE_EVENT))
-		{
-			uiHandler.removeMessages(UIHandler.SEND_MOVE_EVENT);
-			discardedMoveEvents++;
-		}
-		else
-			discardedMoveEvents = 0;
-
-		if (discardedMoveEvents > MAX_DISCARDED_MOVE_EVENTS)
-			LibFreeRDP.sendCursorEvent(session.getInstance(), x, y, Mouse.getMoveEvent());
-		else
-			uiHandler.sendMessageDelayed(Message.obtain(null, UIHandler.SEND_MOVE_EVENT, x, y),
-			                             SEND_MOVE_EVENT_TIMEOUT);
-	}
-
-	private void cancelDelayedMoveEvent()
-	{
-		uiHandler.removeMessages(UIHandler.SEND_MOVE_EVENT);
-	}
-
 	@Override public boolean onCreateOptionsMenu(Menu menu)
 	{
 		getMenuInflater().inflate(R.menu.session_menu, menu);
@@ -690,18 +634,7 @@ public class SessionActivity extends AppCompatActivity
 
 		if (itemId == R.id.session_touch_pointer)
 		{
-			// toggle touch pointer
-			if (touchPointerView.getVisibility() == View.VISIBLE)
-			{
-				touchPointerView.setVisibility(View.INVISIBLE);
-				sessionView.setTouchPointerPadding(0, 0);
-			}
-			else
-			{
-				touchPointerView.setVisibility(View.VISIBLE);
-				sessionView.setTouchPointerPadding(touchPointerView.getPointerWidth(),
-				                                   touchPointerView.getPointerHeight());
-			}
+			inputManager.toggleTouchPointer();
 		}
 		else if (itemId == R.id.session_sys_keyboard)
 		{
@@ -728,9 +661,8 @@ public class SessionActivity extends AppCompatActivity
 			showKeyboard(false, false);
 			return;
 		}
-		if (ApplicationSettingsActivity.getUseBackAsAltf4(this))
+		if (inputManager.handleBackAsAltF4())
 		{
-			keyboardMapper.sendAltF4();
 			return;
 		}
 		if (System.currentTimeMillis() - backPressedTime < 2000)
@@ -746,11 +678,8 @@ public class SessionActivity extends AppCompatActivity
 
 	@Override public boolean onKeyLongPress(int keyCode, KeyEvent event)
 	{
-		if (keyCode == KeyEvent.KEYCODE_BACK)
-		{
-			LibFreeRDP.disconnect(session.getInstance());
+		if (inputManager.onAndroidKeyLongPress(keyCode))
 			return true;
-		}
 		return super.onKeyLongPress(keyCode, event);
 	}
 
@@ -764,96 +693,25 @@ public class SessionActivity extends AppCompatActivity
 	{
 		if (keycode == KeyEvent.KEYCODE_BACK)
 			return super.onKeyDown(keycode, event);
-		return keyboardMapper.processAndroidKeyEvent(event);
+		return inputManager.onAndroidKeyEvent(event);
 	}
 
 	@Override public boolean onKeyUp(int keycode, KeyEvent event)
 	{
 		if (keycode == KeyEvent.KEYCODE_BACK)
 			return super.onKeyUp(keycode, event);
-		return keyboardMapper.processAndroidKeyEvent(event);
+		return inputManager.onAndroidKeyEvent(event);
 	}
 
 	// onKeyMultiple is called for input of some special characters like umlauts
 	// and some symbol characters
 	@Override public boolean onKeyMultiple(int keyCode, int repeatCount, KeyEvent event)
 	{
-		return keyboardMapper.processAndroidKeyEvent(event);
+		return inputManager.onAndroidKeyEvent(event);
 	}
 
 	// ****************************************************************************
-	// KeyboardView.KeyboardActionEventListener
-	@Override public void onKey(int primaryCode, int[] keyCodes)
-	{
-		keyboardMapper.processCustomKeyEvent(primaryCode);
-	}
-
-	@Override public void onText(CharSequence text)
-	{
-	}
-
-	@Override public void swipeRight()
-	{
-	}
-
-	@Override public void swipeLeft()
-	{
-	}
-
-	@Override public void swipeDown()
-	{
-	}
-
-	@Override public void swipeUp()
-	{
-	}
-
-	@Override public void onPress(int primaryCode)
-	{
-	}
-
-	@Override public void onRelease(int primaryCode)
-	{
-	}
-
-	// ****************************************************************************
-	// KeyboardMapper.KeyProcessingListener implementation
-	@Override public void processVirtualKey(int virtualKeyCode, boolean down)
-	{
-		LibFreeRDP.sendKeyEvent(session.getInstance(), virtualKeyCode, down);
-	}
-
-	@Override public void processUnicodeKey(int unicodeKey)
-	{
-		LibFreeRDP.sendUnicodeKeyEvent(session.getInstance(), unicodeKey, true);
-		LibFreeRDP.sendUnicodeKeyEvent(session.getInstance(), unicodeKey, false);
-	}
-
-	@Override public void switchKeyboard(int keyboardType)
-	{
-		switch (keyboardType)
-		{
-			case KeyboardMapper.KEYBOARD_TYPE_FUNCTIONKEYS:
-				keyboardView.setKeyboard(specialkeysKeyboard);
-				break;
-
-			case KeyboardMapper.KEYBOARD_TYPE_NUMPAD:
-				keyboardView.setKeyboard(numpadKeyboard);
-				break;
-
-			case KeyboardMapper.KEYBOARD_TYPE_CURSOR:
-				keyboardView.setKeyboard(cursorKeyboard);
-				break;
-
-			default:
-				break;
-		}
-	}
-
-	@Override public void modifiersChanged()
-	{
-		updateModifierKeyStates();
-	}
+	// KeyboardMapper.KeyProcessingListener — delegated to SessionInputManager
 
 	// ****************************************************************************
 	// LibFreeRDP UI event listener implementation
@@ -867,12 +725,14 @@ public class SessionActivity extends AppCompatActivity
 
 		session.setSurface(new BitmapDrawable(getResources(), bitmap));
 
+		if (inputManager != null)
+			inputManager.setBitmap(bitmap);
+
 		if (session.getBookmark() == null)
 		{
 			// Return immediately if we launch from URI
 			return;
 		}
-
 		// check this settings and initial settings - if they are not equal the
 		// server doesn't support our settings
 		// FIXME: the additional check (settings.getWidth() != width + 1) is for
@@ -908,6 +768,9 @@ public class SessionActivity extends AppCompatActivity
 		else
 			bitmap = Bitmap.createBitmap(width, height, Config.RGB_565);
 		session.setSurface(new BitmapDrawable(getResources(), bitmap));
+
+		if (inputManager != null)
+			inputManager.setBitmap(bitmap);
 
 		/*
 		 * since sessionView can only be modified from the UI thread any
@@ -1101,147 +964,25 @@ public class SessionActivity extends AppCompatActivity
 	}
 
 	// ****************************************************************************
-	// SessionView.SessionViewListener
-	@Override public void onSessionViewBeginTouch()
-	{
-		scrollView.setScrollEnabled(false);
-	}
-
-	@Override public void onSessionViewEndTouch()
-	{
-		scrollView.setScrollEnabled(true);
-	}
-
-	@Override public void onSessionViewLeftTouch(int x, int y, boolean down)
-	{
-		if (!down)
-			cancelDelayedMoveEvent();
-
-		LibFreeRDP.sendCursorEvent(session.getInstance(), x, y,
-		                           Mouse.getLeftButtonEvent(this, down));
-	}
-
-	@Override public void onSessionViewMiddleTouch(int x, int y, boolean down)
-	{
-		LibFreeRDP.sendCursorEvent(session.getInstance(), x, y, Mouse.getMiddleButtonEvent(down));
-	}
-
-	@Override public void onSessionViewRightTouch(int x, int y, boolean down)
-	{
-		LibFreeRDP.sendCursorEvent(session.getInstance(), x, y,
-		                           Mouse.getRightButtonEvent(this, down));
-	}
-
-	@Override public void onSessionViewMove(int x, int y)
-	{
-		sendDelayedMoveEvent(x, y);
-	}
-
-	@Override public void onSessionViewMouseMove(int x, int y)
-	{
-		LibFreeRDP.sendCursorEvent(session.getInstance(), x, y, Mouse.getMoveEvent());
-	}
-
-	@Override public void onSessionViewScroll(boolean down)
-	{
-		LibFreeRDP.sendCursorEvent(session.getInstance(), 0, 0, Mouse.getScrollEvent(this, down));
-	}
-
-	@Override public void onSessionViewHScroll(boolean right)
-	{
-		LibFreeRDP.sendCursorEvent(session.getInstance(), 0, 0, Mouse.getHScrollEvent(this, right));
-	}
-
-	// ****************************************************************************
-	// TouchPointerView.TouchPointerListener
-	@Override public void onTouchPointerClose()
-	{
-		touchPointerView.setVisibility(View.INVISIBLE);
-		sessionView.setTouchPointerPadding(0, 0);
-	}
-
-	private Point mapScreenCoordToSessionCoord(int x, int y)
-	{
-		int mappedX = (int)((float)(x + scrollView.getScrollX()) / sessionView.getZoom());
-		int mappedY = (int)((float)(y + scrollView.getScrollY()) / sessionView.getZoom());
-		if (bitmap != null)
-		{
-			if (mappedX > bitmap.getWidth())
-				mappedX = bitmap.getWidth();
-			if (mappedY > bitmap.getHeight())
-				mappedY = bitmap.getHeight();
-		}
-		return new Point(mappedX, mappedY);
-	}
-
-	@Override public void onTouchPointerLeftClick(int x, int y, boolean down)
-	{
-		Point p = mapScreenCoordToSessionCoord(x, y);
-		LibFreeRDP.sendCursorEvent(session.getInstance(), p.x, p.y,
-		                           Mouse.getLeftButtonEvent(this, down));
-	}
-
-	@Override public void onTouchPointerRightClick(int x, int y, boolean down)
-	{
-		Point p = mapScreenCoordToSessionCoord(x, y);
-		LibFreeRDP.sendCursorEvent(session.getInstance(), p.x, p.y,
-		                           Mouse.getRightButtonEvent(this, down));
-	}
-
-	@Override public void onTouchPointerMove(int x, int y)
-	{
-		Point p = mapScreenCoordToSessionCoord(x, y);
-		LibFreeRDP.sendCursorEvent(session.getInstance(), p.x, p.y, Mouse.getMoveEvent());
-
-		if (ApplicationSettingsActivity.getAutoScrollTouchPointer(this) &&
-		    !uiHandler.hasMessages(UIHandler.SCROLLING_REQUESTED))
-		{
-			Log.v(TAG, "Starting auto-scroll");
-			uiHandler.sendEmptyMessageDelayed(UIHandler.SCROLLING_REQUESTED, SCROLLING_TIMEOUT);
-		}
-	}
-
-	@Override public void onTouchPointerScroll(boolean down)
-	{
-		LibFreeRDP.sendCursorEvent(session.getInstance(), 0, 0, Mouse.getScrollEvent(this, down));
-	}
-
-	@Override public void onTouchPointerToggleKeyboard()
-	{
-		showKeyboard(!sysKeyboardVisible, false);
-	}
-
-	@Override public void onTouchPointerToggleExtKeyboard()
-	{
-		showKeyboard(false, !extKeyboardVisible);
-	}
-
-	@Override public void onTouchPointerResetScrollZoom()
-	{
-		sessionView.setZoom(1.0f);
-		scrollView.scrollTo(0, 0);
-	}
+	// SessionView.SessionViewListener and TouchPointerView.TouchPointerListener
+	// — delegated to SessionInputManager
 
 	@Override public boolean onGenericMotionEvent(MotionEvent e)
 	{
 		super.onGenericMotionEvent(e);
-		switch (e.getAction())
-		{
-			case MotionEvent.ACTION_SCROLL:
-				final float vScroll = e.getAxisValue(MotionEvent.AXIS_VSCROLL);
-				if (vScroll < 0)
-				{
-					LibFreeRDP.sendCursorEvent(session.getInstance(), 0, 0,
-					                           Mouse.getScrollEvent(this, false));
-				}
-				if (vScroll > 0)
-				{
-					LibFreeRDP.sendCursorEvent(session.getInstance(), 0, 0,
-					                           Mouse.getScrollEvent(this, true));
-				}
-				break;
-		}
-		return true;
+		return inputManager != null && inputManager.onGenericMotionEvent(e);
+	}
+
+	// ****************************************************************************
+	// SessionInputManager.ActivityCallbacks
+	@Override public void toggleSystemKeyboard()
+	{
+		showKeyboard(!sysKeyboardVisible, false);
+	}
+
+	@Override public void toggleExtendedKeyboard()
+	{
+		showKeyboard(false, !extKeyboardVisible);
 	}
 
 	// ****************************************************************************
@@ -1257,10 +998,8 @@ public class SessionActivity extends AppCompatActivity
 
 		public static final int REFRESH_SESSIONVIEW = 1;
 		public static final int DISPLAY_TOAST = 2;
-		public static final int SEND_MOVE_EVENT = 4;
 		public static final int SHOW_DIALOG = 5;
 		public static final int GRAPHICS_CHANGED = 6;
-		public static final int SCROLLING_REQUESTED = 7;
 
 		UIHandler()
 		{
@@ -1289,99 +1028,14 @@ public class SessionActivity extends AppCompatActivity
 					errorToast.show();
 					break;
 				}
-				case SEND_MOVE_EVENT:
-				{
-					LibFreeRDP.sendCursorEvent(session.getInstance(), msg.arg1, msg.arg2,
-					                           Mouse.getMoveEvent());
-					break;
-				}
 				case SHOW_DIALOG:
 				{
 					// create and show the dialog
 					((Dialog)msg.obj).show();
 					break;
 				}
-				case SCROLLING_REQUESTED:
-				{
-					int scrollX = 0;
-					int scrollY = 0;
-					float[] pointerPos = touchPointerView.getPointerPosition();
 
-					if (pointerPos[0] > (screen_width - touchPointerView.getPointerWidth()))
-						scrollX = SCROLLING_DISTANCE;
-					else if (pointerPos[0] < 0)
-						scrollX = -SCROLLING_DISTANCE;
-
-					if (pointerPos[1] > (screen_height - touchPointerView.getPointerHeight()))
-						scrollY = SCROLLING_DISTANCE;
-					else if (pointerPos[1] < 0)
-						scrollY = -SCROLLING_DISTANCE;
-
-					scrollView.scrollBy(scrollX, scrollY);
-
-					// see if we reached the min/max scroll positions
-					if (scrollView.getScrollX() == 0 ||
-					    scrollView.getScrollX() == (sessionView.getWidth() - scrollView.getWidth()))
-						scrollX = 0;
-					if (scrollView.getScrollY() == 0 ||
-					    scrollView.getScrollY() ==
-					        (sessionView.getHeight() - scrollView.getHeight()))
-						scrollY = 0;
-
-					if (scrollX != 0 || scrollY != 0)
-						uiHandler.sendEmptyMessageDelayed(SCROLLING_REQUESTED, SCROLLING_TIMEOUT);
-					else
-						Log.v(TAG, "Stopping auto-scroll");
-					break;
-				}
 			}
-		}
-	}
-
-	private class PinchZoomListener extends ScaleGestureDetector.SimpleOnScaleGestureListener
-	{
-		private float scaleFactor = 1.0f;
-
-		@Override public boolean onScaleBegin(ScaleGestureDetector detector)
-		{
-			scrollView.setScrollEnabled(false);
-			return true;
-		}
-
-		@Override public boolean onScale(ScaleGestureDetector detector)
-		{
-
-			// calc scale factor
-			scaleFactor *= detector.getScaleFactor();
-			scaleFactor = Math.max(SessionView.MIN_SCALE_FACTOR,
-			                       Math.min(scaleFactor, SessionView.MAX_SCALE_FACTOR));
-			sessionView.setZoom(scaleFactor);
-
-			if (!sessionView.isAtMinZoom() && !sessionView.isAtMaxZoom())
-			{
-				// transform scroll origin to the new zoom space
-				float transOriginX = scrollView.getScrollX() * detector.getScaleFactor();
-				float transOriginY = scrollView.getScrollY() * detector.getScaleFactor();
-
-				// transform center point to the zoomed space
-				float transCenterX =
-				    (scrollView.getScrollX() + detector.getFocusX()) * detector.getScaleFactor();
-				float transCenterY =
-				    (scrollView.getScrollY() + detector.getFocusY()) * detector.getScaleFactor();
-
-				// scroll by the difference between the distance of the
-				// transformed center/origin point and their old distance
-				// (focusX/Y)
-				scrollView.scrollBy((int)((transCenterX - transOriginX) - detector.getFocusX()),
-				                    (int)((transCenterY - transOriginY) - detector.getFocusY()));
-			}
-
-			return true;
-		}
-
-		@Override public void onScaleEnd(ScaleGestureDetector de)
-		{
-			scrollView.setScrollEnabled(true);
 		}
 	}
 
@@ -1462,8 +1116,9 @@ public class SessionActivity extends AppCompatActivity
 		{
 			Log.v(TAG, "OnConnectionFailure");
 
-			// remove pending move events
-			uiHandler.removeMessages(UIHandler.SEND_MOVE_EVENT);
+			// cancel any pending input events
+			if (inputManager != null)
+				inputManager.cancelPendingEvents();
 
 			if (progressDialog != null)
 			{
@@ -1484,8 +1139,9 @@ public class SessionActivity extends AppCompatActivity
 		{
 			Log.v(TAG, "OnDisconnected");
 
-			// remove pending move events
-			uiHandler.removeMessages(UIHandler.SEND_MOVE_EVENT);
+			// cancel any pending input events
+			if (inputManager != null)
+				inputManager.cancelPendingEvents();
 
 			if (ApplicationSettingsActivity.getKeepScreenOnWhenConnected(context))
 			{

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -57,7 +57,6 @@ import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.InputMethodSubtype;
 import android.widget.EditText;
 import android.widget.Toast;
-import android.widget.ZoomControls;
 
 import com.freerdp.freerdpcore.R;
 import com.freerdp.freerdpcore.application.GlobalApp;
@@ -75,14 +74,12 @@ import java.util.List;
 
 public class SessionActivity extends AppCompatActivity
     implements LibFreeRDP.UIEventListener, KeyboardView.OnKeyboardActionListener,
-               ScrollView2D.ScrollView2DListener, KeyboardMapper.KeyProcessingListener,
-               SessionView.SessionViewListener, TouchPointerView.TouchPointerListener,
+               KeyboardMapper.KeyProcessingListener, SessionView.SessionViewListener,
+               TouchPointerView.TouchPointerListener,
                ClipboardManagerProxy.OnClipboardChangedListener
 {
 	public static final String PARAM_CONNECTION_REFERENCE = "conRef";
 	public static final String PARAM_INSTANCE = "instance";
-	private static final float ZOOMING_STEP = 0.5f;
-	private static final int ZOOMCONTROLS_AUTOHIDE_TIMEOUT = 4000;
 	// timeout between subsequent scrolling requests when the touch-pointer is
 	// at the edge of the session view
 	private static final int SCROLLING_TIMEOUT = 50;
@@ -98,7 +95,6 @@ public class SessionActivity extends AppCompatActivity
 	private ProgressDialog progressDialog;
 	private KeyboardView keyboardView;
 	private KeyboardView modifiersKeyboardView;
-	private ZoomControls zoomControls;
 	private KeyboardMapper keyboardMapper;
 
 	private Keyboard specialkeysKeyboard;
@@ -310,28 +306,8 @@ public class SessionActivity extends AppCompatActivity
 		modifiersKeyboardView.setOnKeyboardActionListener(this);
 
 		scrollView = findViewById(R.id.sessionScrollView);
-		scrollView.setScrollViewListener(this);
 		uiHandler = new UIHandler();
 		libFreeRDPBroadcastReceiver = new LibFreeRDPBroadcastReceiver();
-
-		zoomControls = findViewById(R.id.zoomControls);
-		zoomControls.hide();
-		zoomControls.setOnZoomInClickListener(new View.OnClickListener() {
-			@Override public void onClick(View v)
-			{
-				resetZoomControlsAutoHideTimeout();
-				zoomControls.setIsZoomInEnabled(sessionView.zoomIn(ZOOMING_STEP));
-				zoomControls.setIsZoomOutEnabled(true);
-			}
-		});
-		zoomControls.setOnZoomOutClickListener(new View.OnClickListener() {
-			@Override public void onClick(View v)
-			{
-				resetZoomControlsAutoHideTimeout();
-				zoomControls.setIsZoomOutEnabled(sessionView.zoomOut(ZOOMING_STEP));
-				zoomControls.setIsZoomInEnabled(true);
-			}
-		});
 
 		createDialogs();
 
@@ -599,12 +575,6 @@ public class SessionActivity extends AppCompatActivity
 	// displays either the system or the extended keyboard or non of them
 	private void showKeyboard(final boolean showSystemKeyboard, final boolean showExtendedKeyboard)
 	{
-		// no matter what we are doing ... hide the zoom controls
-		// onScrollChange notification showing the control again ...
-		// i think check for "preference_key_ui_hide_zoom_controls" preference should be there
-		uiHandler.removeMessages(UIHandler.SHOW_ZOOMCONTROLS);
-		uiHandler.sendEmptyMessage(UIHandler.HIDE_ZOOMCONTROLS);
-
 		InputMethodManager mgr = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
 
 		if (showSystemKeyboard)
@@ -1131,30 +1101,6 @@ public class SessionActivity extends AppCompatActivity
 	}
 
 	// ****************************************************************************
-	// ScrollView2DListener implementation
-	private void resetZoomControlsAutoHideTimeout()
-	{
-		uiHandler.removeMessages(UIHandler.HIDE_ZOOMCONTROLS);
-		uiHandler.sendEmptyMessageDelayed(UIHandler.HIDE_ZOOMCONTROLS,
-		                                  ZOOMCONTROLS_AUTOHIDE_TIMEOUT);
-	}
-
-	@Override public void onScrollChanged(ScrollView2D scrollView, int x, int y, int oldx, int oldy)
-	{
-		zoomControls.setIsZoomInEnabled(!sessionView.isAtMaxZoom());
-		zoomControls.setIsZoomOutEnabled(!sessionView.isAtMinZoom());
-
-		if (sysKeyboardVisible || extKeyboardVisible)
-			return;
-
-		if (!ApplicationSettingsActivity.getHideZoomControls(this))
-		{
-			uiHandler.sendEmptyMessage(UIHandler.SHOW_ZOOMCONTROLS);
-			resetZoomControlsAutoHideTimeout();
-		}
-	}
-
-	// ****************************************************************************
 	// SessionView.SessionViewListener
 	@Override public void onSessionViewBeginTouch()
 	{
@@ -1311,12 +1257,10 @@ public class SessionActivity extends AppCompatActivity
 
 		public static final int REFRESH_SESSIONVIEW = 1;
 		public static final int DISPLAY_TOAST = 2;
-		public static final int HIDE_ZOOMCONTROLS = 3;
 		public static final int SEND_MOVE_EVENT = 4;
 		public static final int SHOW_DIALOG = 5;
 		public static final int GRAPHICS_CHANGED = 6;
 		public static final int SCROLLING_REQUESTED = 7;
-		public static final int SHOW_ZOOMCONTROLS = 8;
 
 		UIHandler()
 		{
@@ -1343,19 +1287,6 @@ public class SessionActivity extends AppCompatActivity
 					Toast errorToast = Toast.makeText(getApplicationContext(), msg.obj.toString(),
 					                                  Toast.LENGTH_LONG);
 					errorToast.show();
-					break;
-				}
-				case HIDE_ZOOMCONTROLS:
-				{
-					if (zoomControls.isShown())
-						zoomControls.hide();
-					break;
-				}
-				case SHOW_ZOOMCONTROLS:
-				{
-					if (!zoomControls.isShown())
-						zoomControls.show();
-
 					break;
 				}
 				case SEND_MOVE_EVENT:

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionDialogs.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionDialogs.java
@@ -12,7 +12,6 @@ package com.freerdp.freerdpcore.presentation;
 
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.TypedValue;
@@ -64,69 +63,51 @@ public class SessionDialogs
 		this.activity = activity;
 		this.cancelListener = cancelListener;
 
-		dlgVerifyCertificate =
-		    new AlertDialog.Builder(activity)
-		        .setTitle(R.string.dlg_title_verify_certificate)
-		        .setPositiveButton(android.R.string.yes,
-		                           new DialogInterface.OnClickListener() {
-			                           @Override
-			                           public void onClick(DialogInterface dialog, int which)
-			                           {
-				                           callbackDialogResult = true;
-				                           synchronized (dialog)
-				                           {
-					                           dialog.notify();
-				                           }
-			                           }
-		                           })
-		        .setNegativeButton(android.R.string.no,
-		                           new DialogInterface.OnClickListener() {
-			                           @Override
-			                           public void onClick(DialogInterface dialog, int which)
-			                           {
-				                           callbackDialogResult = false;
-				                           notifyCancel();
-				                           synchronized (dialog)
-				                           {
-					                           dialog.notify();
-				                           }
-			                           }
-		                           })
-		        .setCancelable(false)
-		        .create();
+		dlgVerifyCertificate = new AlertDialog.Builder(activity)
+		                           .setTitle(R.string.dlg_title_verify_certificate)
+		                           .setPositiveButton(android.R.string.yes,
+		                                              (dialog, which) -> {
+			                                              callbackDialogResult = true;
+			                                              synchronized (dialog)
+			                                              {
+				                                              dialog.notify();
+			                                              }
+		                                              })
+		                           .setNegativeButton(android.R.string.no,
+		                                              (dialog, which) -> {
+			                                              callbackDialogResult = false;
+			                                              notifyCancel();
+			                                              synchronized (dialog)
+			                                              {
+				                                              dialog.notify();
+			                                              }
+		                                              })
+		                           .setCancelable(false)
+		                           .create();
 
 		userCredView = activity.getLayoutInflater().inflate(R.layout.credentials, null, true);
-		dlgUserCredentials =
-		    new AlertDialog.Builder(activity)
-		        .setView(userCredView)
-		        .setTitle(R.string.dlg_title_credentials)
-		        .setPositiveButton(android.R.string.ok,
-		                           new DialogInterface.OnClickListener() {
-			                           @Override
-			                           public void onClick(DialogInterface dialog, int which)
-			                           {
-				                           callbackDialogResult = true;
-				                           synchronized (dialog)
-				                           {
-					                           dialog.notify();
-				                           }
-			                           }
-		                           })
-		        .setNegativeButton(android.R.string.cancel,
-		                           new DialogInterface.OnClickListener() {
-			                           @Override
-			                           public void onClick(DialogInterface dialog, int which)
-			                           {
-				                           callbackDialogResult = false;
-				                           notifyCancel();
-				                           synchronized (dialog)
-				                           {
-					                           dialog.notify();
-				                           }
-			                           }
-		                           })
-		        .setCancelable(false)
-		        .create();
+		dlgUserCredentials = new AlertDialog.Builder(activity)
+		                         .setView(userCredView)
+		                         .setTitle(R.string.dlg_title_credentials)
+		                         .setPositiveButton(android.R.string.ok,
+		                                            (dialog, which) -> {
+			                                            callbackDialogResult = true;
+			                                            synchronized (dialog)
+			                                            {
+				                                            dialog.notify();
+			                                            }
+		                                            })
+		                         .setNegativeButton(android.R.string.cancel,
+		                                            (dialog, which) -> {
+			                                            callbackDialogResult = false;
+			                                            notifyCancel();
+			                                            synchronized (dialog)
+			                                            {
+				                                            dialog.notify();
+			                                            }
+		                                            })
+		                         .setCancelable(false)
+		                         .create();
 	}
 
 	/**
@@ -225,12 +206,7 @@ public class SessionDialogs
 
 	private void showOnUiThread(final AlertDialog dialog)
 	{
-		mainHandler.post(new Runnable() {
-			@Override public void run()
-			{
-				dialog.show();
-			}
-		});
+		mainHandler.post(dialog::show);
 	}
 
 	private void notifyCancel()

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionDialogs.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionDialogs.java
@@ -15,17 +15,23 @@ import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.TypedValue;
+import android.view.Gravity;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
 
 import com.freerdp.freerdpcore.R;
 import com.freerdp.freerdpcore.services.LibFreeRDP;
 
 /**
- * Owns the credentials prompt and certificate verification dialogs that the
- * native FreeRDP session may request during connect. Each public method blocks
- * the calling (background) thread until the user dismisses the corresponding
- * dialog on the UI thread.
+ * Owns every dialog that the FreeRDP session may need: the connect-progress
+ * spinner, the credentials prompt, and the certificate verification dialogs.
+ * The auth/verify methods block the calling (background) thread until the user
+ * dismisses the dialog on the UI thread.
  */
 public class SessionDialogs
 {
@@ -35,6 +41,12 @@ public class SessionDialogs
 		void onUserCancel();
 	}
 
+	/** Notified when the user cancels the connection-progress dialog. */
+	public interface OnConnectCancelListener
+	{
+		void onConnectCancel();
+	}
+
 	private final Activity activity;
 	private final OnUserCancelListener cancelListener;
 	private final Handler mainHandler = new Handler(Looper.getMainLooper());
@@ -42,6 +54,8 @@ public class SessionDialogs
 	private final AlertDialog dlgVerifyCertificate;
 	private final AlertDialog dlgUserCredentials;
 	private final View userCredView;
+
+	private AlertDialog progressDialog;
 
 	private boolean callbackDialogResult;
 
@@ -223,5 +237,56 @@ public class SessionDialogs
 	{
 		if (cancelListener != null)
 			cancelListener.onUserCancel();
+	}
+
+	/**
+	 * Builds and shows a non-blocking connect-progress dialog. Subsequent calls
+	 * replace any previously shown progress dialog.
+	 */
+	public void showProgress(String title, final OnConnectCancelListener listener)
+	{
+		dismissProgress();
+
+		int pad = (int)TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 24,
+		                                         activity.getResources().getDisplayMetrics());
+		LinearLayout content = new LinearLayout(activity);
+		content.setOrientation(LinearLayout.HORIZONTAL);
+		content.setPadding(pad, pad, pad, pad);
+		content.setGravity(Gravity.CENTER_VERTICAL);
+
+		ProgressBar progressBar = new ProgressBar(activity);
+		progressBar.setIndeterminate(true);
+		content.addView(progressBar,
+		                new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT,
+		                                              ViewGroup.LayoutParams.WRAP_CONTENT));
+
+		TextView messageView = new TextView(activity);
+		messageView.setText(R.string.dlg_msg_connecting);
+		LinearLayout.LayoutParams textParams = new LinearLayout.LayoutParams(
+		    ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+		textParams.leftMargin = pad;
+		content.addView(messageView, textParams);
+
+		progressDialog = new AlertDialog.Builder(activity)
+		                     .setTitle(title)
+		                     .setView(content)
+		                     .setNegativeButton(android.R.string.cancel,
+		                                        (dialog, which) -> {
+			                                        if (listener != null)
+				                                        listener.onConnectCancel();
+		                                        })
+		                     .setCancelable(false)
+		                     .create();
+		progressDialog.show();
+	}
+
+	/** Dismisses the connect-progress dialog if it is currently shown. */
+	public void dismissProgress()
+	{
+		if (progressDialog != null)
+		{
+			progressDialog.dismiss();
+			progressDialog = null;
+		}
 	}
 }

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionDialogs.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionDialogs.java
@@ -1,0 +1,227 @@
+/*
+   Android Session Auth Dialogs
+
+   Copyright 2013 Thincast Technologies GmbH, Author: Martin Fleisz
+
+   This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+   If a copy of the MPL was not distributed with this file, You can obtain one at
+   http://mozilla.org/MPL/2.0/.
+ */
+
+package com.freerdp.freerdpcore.presentation;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.View;
+import android.widget.EditText;
+
+import com.freerdp.freerdpcore.R;
+import com.freerdp.freerdpcore.services.LibFreeRDP;
+
+/**
+ * Owns the credentials prompt and certificate verification dialogs that the
+ * native FreeRDP session may request during connect. Each public method blocks
+ * the calling (background) thread until the user dismisses the corresponding
+ * dialog on the UI thread.
+ */
+public class SessionDialogs
+{
+	/** Notified when the user cancels any of the dialogs. */
+	public interface OnUserCancelListener
+	{
+		void onUserCancel();
+	}
+
+	private final Activity activity;
+	private final OnUserCancelListener cancelListener;
+	private final Handler mainHandler = new Handler(Looper.getMainLooper());
+
+	private final AlertDialog dlgVerifyCertificate;
+	private final AlertDialog dlgUserCredentials;
+	private final View userCredView;
+
+	private boolean callbackDialogResult;
+
+	public SessionDialogs(Activity activity, OnUserCancelListener cancelListener)
+	{
+		this.activity = activity;
+		this.cancelListener = cancelListener;
+
+		dlgVerifyCertificate =
+		    new AlertDialog.Builder(activity)
+		        .setTitle(R.string.dlg_title_verify_certificate)
+		        .setPositiveButton(android.R.string.yes,
+		                           new DialogInterface.OnClickListener() {
+			                           @Override
+			                           public void onClick(DialogInterface dialog, int which)
+			                           {
+				                           callbackDialogResult = true;
+				                           synchronized (dialog)
+				                           {
+					                           dialog.notify();
+				                           }
+			                           }
+		                           })
+		        .setNegativeButton(android.R.string.no,
+		                           new DialogInterface.OnClickListener() {
+			                           @Override
+			                           public void onClick(DialogInterface dialog, int which)
+			                           {
+				                           callbackDialogResult = false;
+				                           notifyCancel();
+				                           synchronized (dialog)
+				                           {
+					                           dialog.notify();
+				                           }
+			                           }
+		                           })
+		        .setCancelable(false)
+		        .create();
+
+		userCredView = activity.getLayoutInflater().inflate(R.layout.credentials, null, true);
+		dlgUserCredentials =
+		    new AlertDialog.Builder(activity)
+		        .setView(userCredView)
+		        .setTitle(R.string.dlg_title_credentials)
+		        .setPositiveButton(android.R.string.ok,
+		                           new DialogInterface.OnClickListener() {
+			                           @Override
+			                           public void onClick(DialogInterface dialog, int which)
+			                           {
+				                           callbackDialogResult = true;
+				                           synchronized (dialog)
+				                           {
+					                           dialog.notify();
+				                           }
+			                           }
+		                           })
+		        .setNegativeButton(android.R.string.cancel,
+		                           new DialogInterface.OnClickListener() {
+			                           @Override
+			                           public void onClick(DialogInterface dialog, int which)
+			                           {
+				                           callbackDialogResult = false;
+				                           notifyCancel();
+				                           synchronized (dialog)
+				                           {
+					                           dialog.notify();
+				                           }
+			                           }
+		                           })
+		        .setCancelable(false)
+		        .create();
+	}
+
+	/**
+	 * Shows the credentials dialog and blocks until the user dismisses it.
+	 * On OK the buffers are overwritten with the entered values.
+	 */
+	public boolean promptCredentials(StringBuilder username, StringBuilder domain,
+	                                 StringBuilder password)
+	{
+		callbackDialogResult = false;
+
+		((EditText)userCredView.findViewById(R.id.editTextUsername)).setText(username);
+		((EditText)userCredView.findViewById(R.id.editTextDomain)).setText(domain);
+		((EditText)userCredView.findViewById(R.id.editTextPassword)).setText(password);
+
+		showOnUiThread(dlgUserCredentials);
+
+		try
+		{
+			synchronized (dlgUserCredentials)
+			{
+				dlgUserCredentials.wait();
+			}
+		}
+		catch (InterruptedException e)
+		{
+		}
+
+		username.setLength(0);
+		domain.setLength(0);
+		password.setLength(0);
+
+		username.append(
+		    ((EditText)userCredView.findViewById(R.id.editTextUsername)).getText().toString());
+		domain.append(
+		    ((EditText)userCredView.findViewById(R.id.editTextDomain)).getText().toString());
+		password.append(
+		    ((EditText)userCredView.findViewById(R.id.editTextPassword)).getText().toString());
+
+		return callbackDialogResult;
+	}
+
+	/**
+	 * Shows the certificate verification dialog. Returns 1 if accepted, 0 otherwise.
+	 */
+	public int verifyCertificate(String host, long port, String subject, String issuer,
+	                             String fingerprint, long flags)
+	{
+		String msg = activity.getResources().getString(R.string.dlg_msg_verify_certificate);
+		String type = "RDP-Server";
+		if ((flags & LibFreeRDP.VERIFY_CERT_FLAG_GATEWAY) != 0)
+			type = "RDP-Gateway";
+		if ((flags & LibFreeRDP.VERIFY_CERT_FLAG_REDIRECT) != 0)
+			type = "RDP-Redirect";
+		msg += "\n\n" + type + ": " + host + ":" + port;
+		msg += "\n\nSubject: " + subject + "\nIssuer: " + issuer;
+		if ((flags & LibFreeRDP.VERIFY_CERT_FLAG_FP_IS_PEM) != 0)
+			msg += "\nCertificate: " + fingerprint;
+		else
+			msg += "\nFingerprint: " + fingerprint;
+
+		return showVerifyDialog(msg);
+	}
+
+	/**
+	 * Shows the certificate-changed verification dialog. Returns 1 if accepted, 0 otherwise.
+	 */
+	public int verifyChangedCertificate(String host, long port, String subject, String issuer,
+	                                    String fingerprint, long flags)
+	{
+		// The "changed" variant currently shows the same information as the
+		// regular verify dialog (matches prior behaviour).
+		return verifyCertificate(host, port, subject, issuer, fingerprint, flags);
+	}
+
+	private int showVerifyDialog(String msg)
+	{
+		callbackDialogResult = false;
+		dlgVerifyCertificate.setMessage(msg);
+
+		showOnUiThread(dlgVerifyCertificate);
+
+		try
+		{
+			synchronized (dlgVerifyCertificate)
+			{
+				dlgVerifyCertificate.wait();
+			}
+		}
+		catch (InterruptedException e)
+		{
+		}
+
+		return callbackDialogResult ? 1 : 0;
+	}
+
+	private void showOnUiThread(final AlertDialog dialog)
+	{
+		mainHandler.post(new Runnable() {
+			@Override public void run()
+			{
+				dialog.show();
+			}
+		});
+	}
+
+	private void notifyCancel()
+	{
+		if (cancelListener != null)
+			cancelListener.onUserCancel();
+	}
+}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionInputManager.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionInputManager.java
@@ -17,7 +17,9 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 
+import com.freerdp.freerdpcore.R;
 import com.freerdp.freerdpcore.services.LibFreeRDP;
 import com.freerdp.freerdpcore.utils.KeyboardMapper;
 import com.freerdp.freerdpcore.utils.Mouse;
@@ -38,16 +40,6 @@ public class SessionInputManager
 	private static final int MSG_SEND_MOVE_EVENT = 1;
 	private static final int MSG_SCROLLING_REQUESTED = 2;
 
-	/**
-	 * Callback interface for actions that require Activity-level state (keyboard visibility).
-	 */
-	public interface ActivityCallbacks
-	{
-		void toggleSystemKeyboard();
-
-		void toggleExtendedKeyboard();
-	}
-
 	private final Context context;
 	private final KeyboardMapper keyboardMapper;
 	private final ScrollView2D scrollView;
@@ -55,7 +47,6 @@ public class SessionInputManager
 	private final TouchPointerView touchPointerView;
 	private final KeyboardView keyboardView;
 	private final KeyboardView modifiersKeyboardView;
-	private final ActivityCallbacks callbacks;
 	private final PinchZoomListener pinchZoomListener = new PinchZoomListener();
 
 	private Keyboard modifiersKeyboard;
@@ -70,28 +61,42 @@ public class SessionInputManager
 	private int screenHeight;
 	private int discardedMoveEvents = 0;
 
+	// keyboard visibility flags
+	private boolean sysKeyboardVisible = false;
+	private boolean extKeyboardVisible = false;
+
 	private final Handler handler;
 
-	public SessionInputManager(Context context, KeyboardMapper keyboardMapper,
-	                           ScrollView2D scrollView, SessionView sessionView,
+	public SessionInputManager(Context context, ScrollView2D scrollView, SessionView sessionView,
 	                           TouchPointerView touchPointerView, KeyboardView keyboardView,
-	                           KeyboardView modifiersKeyboardView, Keyboard modifiersKeyboard,
-	                           Keyboard specialkeysKeyboard, Keyboard numpadKeyboard,
-	                           Keyboard cursorKeyboard, ActivityCallbacks callbacks)
+	                           KeyboardView modifiersKeyboardView)
 	{
 		this.context = context;
-		this.keyboardMapper = keyboardMapper;
 		this.scrollView = scrollView;
 		this.sessionView = sessionView;
 		this.touchPointerView = touchPointerView;
 		this.keyboardView = keyboardView;
 		this.modifiersKeyboardView = modifiersKeyboardView;
-		this.modifiersKeyboard = modifiersKeyboard;
-		this.specialkeysKeyboard = specialkeysKeyboard;
-		this.numpadKeyboard = numpadKeyboard;
-		this.cursorKeyboard = cursorKeyboard;
-		this.callbacks = callbacks;
 		this.handler = new InputHandler();
+
+		this.keyboardMapper = new KeyboardMapper();
+		this.keyboardMapper.init(context);
+
+		loadKeyboards();
+		keyboardView.setKeyboard(specialkeysKeyboard);
+		modifiersKeyboardView.setKeyboard(modifiersKeyboard);
+
+		keyboardView.setOnKeyboardActionListener(this);
+		modifiersKeyboardView.setOnKeyboardActionListener(this);
+	}
+
+	private void loadKeyboards()
+	{
+		Context app = context.getApplicationContext();
+		modifiersKeyboard = new Keyboard(app, R.xml.modifiers_keyboard);
+		specialkeysKeyboard = new Keyboard(app, R.xml.specialkeys_keyboard);
+		numpadKeyboard = new Keyboard(app, R.xml.numpad_keyboard);
+		cursorKeyboard = new Keyboard(app, R.xml.cursor_keyboard);
 	}
 
 	// Binds this manager to a live FreeRDP session. Until called, all input events are dropped.
@@ -99,6 +104,7 @@ public class SessionInputManager
 	{
 		this.instance = instance;
 		this.bitmap = surface;
+		keyboardMapper.reset(this);
 	}
 
 	// Called when the session bitmap is created or replaced (OnSettingsChanged / OnGraphicsResize).
@@ -120,14 +126,91 @@ public class SessionInputManager
 		this.screenHeight = height;
 	}
 
-	// Called from onConfigurationChanged when keyboard resources are reloaded.
-	public void updateKeyboards(Keyboard modifiers, Keyboard special, Keyboard numpad,
-	                            Keyboard cursor)
+	// Called from onConfigurationChanged when keyboard resources need to be reloaded
+	// (e.g. after orientation change).
+	public void reloadKeyboards()
 	{
-		this.modifiersKeyboard = modifiers;
-		this.specialkeysKeyboard = special;
-		this.numpadKeyboard = numpad;
-		this.cursorKeyboard = cursor;
+		loadKeyboards();
+		keyboardView.setKeyboard(specialkeysKeyboard);
+		modifiersKeyboardView.setKeyboard(modifiersKeyboard);
+	}
+
+	// Toggles the system soft-keyboard (and accompanying modifiers row).
+	public void toggleSystemKeyboard()
+	{
+		showKeyboard(!sysKeyboardVisible, false);
+	}
+
+	// Toggles the extended (special keys / function / numpad / cursor) keyboard.
+	public void toggleExtendedKeyboard()
+	{
+		showKeyboard(false, !extKeyboardVisible);
+	}
+
+	// Hides any visible keyboards (called from onPause and back-press handling).
+	public void hideKeyboards()
+	{
+		showKeyboard(false, false);
+	}
+
+	// True if either the system or extended keyboard is currently shown.
+	public boolean isAnyKeyboardVisible()
+	{
+		return sysKeyboardVisible || extKeyboardVisible;
+	}
+
+	// displays either the system or the extended keyboard or none of them
+	private void showKeyboard(boolean showSystemKeyboard, boolean showExtendedKeyboard)
+	{
+		if (showSystemKeyboard)
+		{
+			// hide extended keyboard
+			keyboardView.setVisibility(View.GONE);
+			// show system keyboard
+			setSoftInputState(true);
+
+			// show modifiers keyboard
+			modifiersKeyboardView.setVisibility(View.VISIBLE);
+		}
+		else if (showExtendedKeyboard)
+		{
+			// hide system keyboard
+			setSoftInputState(false);
+
+			// show extended keyboard
+			keyboardView.setKeyboard(specialkeysKeyboard);
+			keyboardView.setVisibility(View.VISIBLE);
+			modifiersKeyboardView.setVisibility(View.VISIBLE);
+		}
+		else
+		{
+			// hide both
+			setSoftInputState(false);
+			keyboardView.setVisibility(View.GONE);
+			modifiersKeyboardView.setVisibility(View.GONE);
+
+			// clear any active key modifiers
+			keyboardMapper.clearlAllModifiers();
+		}
+
+		sysKeyboardVisible = showSystemKeyboard;
+		extKeyboardVisible = showExtendedKeyboard;
+	}
+
+	private void setSoftInputState(boolean state)
+	{
+		InputMethodManager mgr =
+		    (InputMethodManager)context.getSystemService(Context.INPUT_METHOD_SERVICE);
+
+		if (state)
+		{
+			sessionView.requestFocus();
+			mgr.showSoftInput(sessionView, InputMethodManager.SHOW_IMPLICIT);
+		}
+		else
+		{
+			mgr.hideSoftInputFromWindow(sessionView.getWindowToken(), 0);
+		}
 	}
 
 	// Cancels any pending delayed-move events; called on connection failure / disconnect.
@@ -382,12 +465,12 @@ public class SessionInputManager
 
 	@Override public void onTouchPointerToggleKeyboard()
 	{
-		callbacks.toggleSystemKeyboard();
+		toggleSystemKeyboard();
 	}
 
 	@Override public void onTouchPointerToggleExtKeyboard()
 	{
-		callbacks.toggleExtendedKeyboard();
+		toggleExtendedKeyboard();
 	}
 
 	@Override public void onTouchPointerResetScrollZoom()

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionInputManager.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionInputManager.java
@@ -11,6 +11,7 @@ import android.graphics.Point;
 import android.inputmethodservice.Keyboard;
 import android.inputmethodservice.KeyboardView;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.Message;
 import android.util.Log;
 import android.view.KeyEvent;
@@ -564,6 +565,11 @@ public class SessionInputManager
 
 	private class InputHandler extends Handler
 	{
+		InputHandler()
+		{
+			super(Looper.getMainLooper());
+		}
+
 		@Override public void handleMessage(Message msg)
 		{
 			switch (msg.what)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionInputManager.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionInputManager.java
@@ -1,0 +1,578 @@
+/*
+   Android Session Input Manager
+
+ */
+
+package com.freerdp.freerdpcore.presentation;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Point;
+import android.inputmethodservice.Keyboard;
+import android.inputmethodservice.KeyboardView;
+import android.os.Handler;
+import android.os.Message;
+import android.util.Log;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.ScaleGestureDetector;
+import android.view.View;
+
+import com.freerdp.freerdpcore.services.LibFreeRDP;
+import com.freerdp.freerdpcore.utils.KeyboardMapper;
+import com.freerdp.freerdpcore.utils.Mouse;
+
+import java.util.List;
+
+public class SessionInputManager
+    implements SessionView.SessionViewListener, TouchPointerView.TouchPointerListener,
+               KeyboardMapper.KeyProcessingListener, KeyboardView.OnKeyboardActionListener
+{
+	private static final String TAG = "FreeRDP.SessionInputManager";
+
+	private static final int SCROLLING_TIMEOUT = 50;
+	private static final int SCROLLING_DISTANCE = 20;
+	private static final int MAX_DISCARDED_MOVE_EVENTS = 3;
+	private static final int SEND_MOVE_EVENT_TIMEOUT = 150;
+
+	private static final int MSG_SEND_MOVE_EVENT = 1;
+	private static final int MSG_SCROLLING_REQUESTED = 2;
+
+	/**
+	 * Callback interface for actions that require Activity-level state (keyboard visibility).
+	 */
+	public interface ActivityCallbacks
+	{
+		void toggleSystemKeyboard();
+
+		void toggleExtendedKeyboard();
+	}
+
+	private final Context context;
+	private final KeyboardMapper keyboardMapper;
+	private final ScrollView2D scrollView;
+	private final SessionView sessionView;
+	private final TouchPointerView touchPointerView;
+	private final KeyboardView keyboardView;
+	private final KeyboardView modifiersKeyboardView;
+	private final ActivityCallbacks callbacks;
+	private final PinchZoomListener pinchZoomListener = new PinchZoomListener();
+
+	private Keyboard modifiersKeyboard;
+	private Keyboard specialkeysKeyboard;
+	private Keyboard numpadKeyboard;
+	private Keyboard cursorKeyboard;
+
+	// Native FreeRDP instance handle. 0 until attachSession() is called (i.e. before connect).
+	private long instance = 0;
+	private Bitmap bitmap;
+	private int screenWidth;
+	private int screenHeight;
+	private int discardedMoveEvents = 0;
+
+	private final Handler handler;
+
+	public SessionInputManager(Context context, KeyboardMapper keyboardMapper,
+	                           ScrollView2D scrollView, SessionView sessionView,
+	                           TouchPointerView touchPointerView, KeyboardView keyboardView,
+	                           KeyboardView modifiersKeyboardView, Keyboard modifiersKeyboard,
+	                           Keyboard specialkeysKeyboard, Keyboard numpadKeyboard,
+	                           Keyboard cursorKeyboard, ActivityCallbacks callbacks)
+	{
+		this.context = context;
+		this.keyboardMapper = keyboardMapper;
+		this.scrollView = scrollView;
+		this.sessionView = sessionView;
+		this.touchPointerView = touchPointerView;
+		this.keyboardView = keyboardView;
+		this.modifiersKeyboardView = modifiersKeyboardView;
+		this.modifiersKeyboard = modifiersKeyboard;
+		this.specialkeysKeyboard = specialkeysKeyboard;
+		this.numpadKeyboard = numpadKeyboard;
+		this.cursorKeyboard = cursorKeyboard;
+		this.callbacks = callbacks;
+		this.handler = new InputHandler();
+	}
+
+	// Binds this manager to a live FreeRDP session. Until called, all input events are dropped.
+	public void attachSession(long instance, Bitmap surface)
+	{
+		this.instance = instance;
+		this.bitmap = surface;
+	}
+
+	// Called when the session bitmap is created or replaced (OnSettingsChanged / OnGraphicsResize).
+	public void setBitmap(Bitmap bitmap)
+	{
+		this.bitmap = bitmap;
+	}
+
+	// Returns a listener that can be wired into a ScaleGestureDetector for pinch-to-zoom.
+	public ScaleGestureDetector.OnScaleGestureListener getPinchZoomListener()
+	{
+		return pinchZoomListener;
+	}
+
+	// Called once the screen dimensions are known (onGlobalLayout) and on bindSession.
+	public void setScreenSize(int width, int height)
+	{
+		this.screenWidth = width;
+		this.screenHeight = height;
+	}
+
+	// Called from onConfigurationChanged when keyboard resources are reloaded.
+	public void updateKeyboards(Keyboard modifiers, Keyboard special, Keyboard numpad,
+	                            Keyboard cursor)
+	{
+		this.modifiersKeyboard = modifiers;
+		this.specialkeysKeyboard = special;
+		this.numpadKeyboard = numpad;
+		this.cursorKeyboard = cursor;
+	}
+
+	// Cancels any pending delayed-move events; called on connection failure / disconnect.
+	public void cancelPendingEvents()
+	{
+		handler.removeMessages(MSG_SEND_MOVE_EVENT);
+	}
+
+	// Forwards a physical-mouse scroll event (e.g. external mouse wheel) into the session.
+	public boolean onGenericMotionEvent(MotionEvent e)
+	{
+		if (instance == 0)
+			return false;
+		if (e.getAction() != MotionEvent.ACTION_SCROLL)
+			return false;
+
+		final float vScroll = e.getAxisValue(MotionEvent.AXIS_VSCROLL);
+		if (vScroll < 0)
+			LibFreeRDP.sendCursorEvent(instance, 0, 0, Mouse.getScrollEvent(context, false));
+		else if (vScroll > 0)
+			LibFreeRDP.sendCursorEvent(instance, 0, 0, Mouse.getScrollEvent(context, true));
+		return true;
+	}
+
+	// Forwards an Android hardware-keyboard event into the session.
+	public boolean onAndroidKeyEvent(KeyEvent event)
+	{
+		if (instance == 0)
+			return false;
+		return keyboardMapper.processAndroidKeyEvent(event);
+	}
+
+	// Handles a long-press on the BACK key by disconnecting the active session.
+	// Returns true if the event was consumed.
+	public boolean onAndroidKeyLongPress(int keyCode)
+	{
+		if (instance == 0)
+			return false;
+		if (keyCode == KeyEvent.KEYCODE_BACK)
+		{
+			LibFreeRDP.disconnect(instance);
+			return true;
+		}
+		return false;
+	}
+
+	// If the "use back as Alt+F4" preference is enabled, sends Alt+F4 and returns true.
+	public boolean handleBackAsAltF4()
+	{
+		if (instance == 0)
+			return false;
+		if (!ApplicationSettingsActivity.getUseBackAsAltf4(context))
+			return false;
+		keyboardMapper.sendAltF4();
+		return true;
+	}
+
+	// Toggles touch-pointer overlay visibility (driven by the menu).
+	public void toggleTouchPointer()
+	{
+		if (touchPointerView.getVisibility() == View.VISIBLE)
+		{
+			touchPointerView.setVisibility(View.INVISIBLE);
+			sessionView.setTouchPointerPadding(0, 0);
+		}
+		else
+		{
+			touchPointerView.setVisibility(View.VISIBLE);
+			sessionView.setTouchPointerPadding(touchPointerView.getPointerWidth(),
+			                                   touchPointerView.getPointerHeight());
+		}
+	}
+
+	// ****************************************************************************
+	// Private helpers
+
+	private void sendDelayedMoveEvent(int x, int y)
+	{
+		if (handler.hasMessages(MSG_SEND_MOVE_EVENT))
+		{
+			handler.removeMessages(MSG_SEND_MOVE_EVENT);
+			discardedMoveEvents++;
+		}
+		else
+			discardedMoveEvents = 0;
+
+		if (discardedMoveEvents > MAX_DISCARDED_MOVE_EVENTS)
+			LibFreeRDP.sendCursorEvent(instance, x, y, Mouse.getMoveEvent());
+		else
+			handler.sendMessageDelayed(Message.obtain(null, MSG_SEND_MOVE_EVENT, x, y),
+			                           SEND_MOVE_EVENT_TIMEOUT);
+	}
+
+	private void cancelDelayedMoveEvent()
+	{
+		handler.removeMessages(MSG_SEND_MOVE_EVENT);
+	}
+
+	private Point mapScreenCoordToSessionCoord(int x, int y)
+	{
+		int mappedX = (int)((float)(x + scrollView.getScrollX()) / sessionView.getZoom());
+		int mappedY = (int)((float)(y + scrollView.getScrollY()) / sessionView.getZoom());
+		if (bitmap != null)
+		{
+			if (mappedX > bitmap.getWidth())
+				mappedX = bitmap.getWidth();
+			if (mappedY > bitmap.getHeight())
+				mappedY = bitmap.getHeight();
+		}
+		return new Point(mappedX, mappedY);
+	}
+
+	private void updateModifierKeyStates()
+	{
+		List<Keyboard.Key> keys = modifiersKeyboard.getKeys();
+		for (Keyboard.Key curKey : keys)
+		{
+			if (curKey.sticky)
+			{
+				switch (keyboardMapper.getModifierState(curKey.codes[0]))
+				{
+					case KeyboardMapper.KEYSTATE_ON:
+						curKey.on = true;
+						curKey.pressed = false;
+						break;
+
+					case KeyboardMapper.KEYSTATE_OFF:
+						curKey.on = false;
+						curKey.pressed = false;
+						break;
+
+					case KeyboardMapper.KEYSTATE_LOCKED:
+						curKey.on = true;
+						curKey.pressed = true;
+						break;
+				}
+			}
+		}
+		modifiersKeyboardView.invalidateAllKeys();
+	}
+
+	// ****************************************************************************
+	// SessionView.SessionViewListener
+
+	@Override public void onSessionViewBeginTouch()
+	{
+		scrollView.setScrollEnabled(false);
+	}
+
+	@Override public void onSessionViewEndTouch()
+	{
+		scrollView.setScrollEnabled(true);
+	}
+
+	@Override public void onSessionViewLeftTouch(int x, int y, boolean down)
+	{
+		if (instance == 0)
+			return;
+		if (!down)
+			cancelDelayedMoveEvent();
+		LibFreeRDP.sendCursorEvent(instance, x, y, Mouse.getLeftButtonEvent(context, down));
+	}
+
+	@Override public void onSessionViewMiddleTouch(int x, int y, boolean down)
+	{
+		if (instance == 0)
+			return;
+		LibFreeRDP.sendCursorEvent(instance, x, y, Mouse.getMiddleButtonEvent(down));
+	}
+
+	@Override public void onSessionViewRightTouch(int x, int y, boolean down)
+	{
+		if (instance == 0)
+			return;
+		LibFreeRDP.sendCursorEvent(instance, x, y, Mouse.getRightButtonEvent(context, down));
+	}
+
+	@Override public void onSessionViewMove(int x, int y)
+	{
+		if (instance == 0)
+			return;
+		sendDelayedMoveEvent(x, y);
+	}
+
+	@Override public void onSessionViewMouseMove(int x, int y)
+	{
+		if (instance == 0)
+			return;
+		LibFreeRDP.sendCursorEvent(instance, x, y, Mouse.getMoveEvent());
+	}
+
+	@Override public void onSessionViewScroll(boolean down)
+	{
+		if (instance == 0)
+			return;
+		LibFreeRDP.sendCursorEvent(instance, 0, 0, Mouse.getScrollEvent(context, down));
+	}
+
+	@Override public void onSessionViewHScroll(boolean right)
+	{
+		if (instance == 0)
+			return;
+		LibFreeRDP.sendCursorEvent(instance, 0, 0, Mouse.getHScrollEvent(context, right));
+	}
+
+	// ****************************************************************************
+	// TouchPointerView.TouchPointerListener
+
+	@Override public void onTouchPointerClose()
+	{
+		touchPointerView.setVisibility(View.INVISIBLE);
+		sessionView.setTouchPointerPadding(0, 0);
+	}
+
+	@Override public void onTouchPointerLeftClick(int x, int y, boolean down)
+	{
+		if (instance == 0)
+			return;
+		Point p = mapScreenCoordToSessionCoord(x, y);
+		LibFreeRDP.sendCursorEvent(instance, p.x, p.y, Mouse.getLeftButtonEvent(context, down));
+	}
+
+	@Override public void onTouchPointerRightClick(int x, int y, boolean down)
+	{
+		if (instance == 0)
+			return;
+		Point p = mapScreenCoordToSessionCoord(x, y);
+		LibFreeRDP.sendCursorEvent(instance, p.x, p.y, Mouse.getRightButtonEvent(context, down));
+	}
+
+	@Override public void onTouchPointerMove(int x, int y)
+	{
+		if (instance == 0)
+			return;
+		Point p = mapScreenCoordToSessionCoord(x, y);
+		LibFreeRDP.sendCursorEvent(instance, p.x, p.y, Mouse.getMoveEvent());
+
+		if (ApplicationSettingsActivity.getAutoScrollTouchPointer(context) &&
+		    !handler.hasMessages(MSG_SCROLLING_REQUESTED))
+		{
+			Log.v(TAG, "Starting auto-scroll");
+			handler.sendEmptyMessageDelayed(MSG_SCROLLING_REQUESTED, SCROLLING_TIMEOUT);
+		}
+	}
+
+	@Override public void onTouchPointerScroll(boolean down)
+	{
+		if (instance == 0)
+			return;
+		LibFreeRDP.sendCursorEvent(instance, 0, 0, Mouse.getScrollEvent(context, down));
+	}
+
+	@Override public void onTouchPointerToggleKeyboard()
+	{
+		callbacks.toggleSystemKeyboard();
+	}
+
+	@Override public void onTouchPointerToggleExtKeyboard()
+	{
+		callbacks.toggleExtendedKeyboard();
+	}
+
+	@Override public void onTouchPointerResetScrollZoom()
+	{
+		sessionView.setZoom(1.0f);
+		scrollView.scrollTo(0, 0);
+	}
+
+	// ****************************************************************************
+	// KeyboardMapper.KeyProcessingListener
+
+	@Override public void processVirtualKey(int virtualKeyCode, boolean down)
+	{
+		if (instance == 0)
+			return;
+		LibFreeRDP.sendKeyEvent(instance, virtualKeyCode, down);
+	}
+
+	@Override public void processUnicodeKey(int unicodeKey)
+	{
+		if (instance == 0)
+			return;
+		LibFreeRDP.sendUnicodeKeyEvent(instance, unicodeKey, true);
+		LibFreeRDP.sendUnicodeKeyEvent(instance, unicodeKey, false);
+	}
+
+	@Override public void switchKeyboard(int keyboardType)
+	{
+		switch (keyboardType)
+		{
+			case KeyboardMapper.KEYBOARD_TYPE_FUNCTIONKEYS:
+				keyboardView.setKeyboard(specialkeysKeyboard);
+				break;
+
+			case KeyboardMapper.KEYBOARD_TYPE_NUMPAD:
+				keyboardView.setKeyboard(numpadKeyboard);
+				break;
+
+			case KeyboardMapper.KEYBOARD_TYPE_CURSOR:
+				keyboardView.setKeyboard(cursorKeyboard);
+				break;
+
+			default:
+				break;
+		}
+	}
+
+	@Override public void modifiersChanged()
+	{
+		updateModifierKeyStates();
+	}
+
+	// ****************************************************************************
+	// KeyboardView.OnKeyboardActionListener (extended/modifiers keyboards)
+
+	@Override public void onKey(int primaryCode, int[] keyCodes)
+	{
+		keyboardMapper.processCustomKeyEvent(primaryCode);
+	}
+
+	@Override public void onText(CharSequence text)
+	{
+	}
+
+	@Override public void swipeRight()
+	{
+	}
+
+	@Override public void swipeLeft()
+	{
+	}
+
+	@Override public void swipeDown()
+	{
+	}
+
+	@Override public void swipeUp()
+	{
+	}
+
+	@Override public void onPress(int primaryCode)
+	{
+	}
+
+	@Override public void onRelease(int primaryCode)
+	{
+	}
+
+	// ****************************************************************************
+	// Internal delayed-event handler
+
+	private class InputHandler extends Handler
+	{
+		@Override public void handleMessage(Message msg)
+		{
+			switch (msg.what)
+			{
+				case MSG_SEND_MOVE_EVENT:
+					if (instance == 0)
+						break;
+					LibFreeRDP.sendCursorEvent(instance, msg.arg1, msg.arg2, Mouse.getMoveEvent());
+					break;
+
+				case MSG_SCROLLING_REQUESTED:
+				{
+					int scrollX = 0;
+					int scrollY = 0;
+					float[] pointerPos = touchPointerView.getPointerPosition();
+
+					if (pointerPos[0] > (screenWidth - touchPointerView.getPointerWidth()))
+						scrollX = SCROLLING_DISTANCE;
+					else if (pointerPos[0] < 0)
+						scrollX = -SCROLLING_DISTANCE;
+
+					if (pointerPos[1] > (screenHeight - touchPointerView.getPointerHeight()))
+						scrollY = SCROLLING_DISTANCE;
+					else if (pointerPos[1] < 0)
+						scrollY = -SCROLLING_DISTANCE;
+
+					scrollView.scrollBy(scrollX, scrollY);
+
+					if (scrollView.getScrollX() == 0 ||
+					    scrollView.getScrollX() == (sessionView.getWidth() - scrollView.getWidth()))
+						scrollX = 0;
+					if (scrollView.getScrollY() == 0 ||
+					    scrollView.getScrollY() ==
+					        (sessionView.getHeight() - scrollView.getHeight()))
+						scrollY = 0;
+
+					if (scrollX != 0 || scrollY != 0)
+						handler.sendEmptyMessageDelayed(MSG_SCROLLING_REQUESTED, SCROLLING_TIMEOUT);
+					else
+						Log.v(TAG, "Stopping auto-scroll");
+					break;
+				}
+			}
+		}
+	}
+
+	// ****************************************************************************
+	// Pinch-to-zoom listener (wired into SessionView's ScaleGestureDetector)
+
+	private class PinchZoomListener extends ScaleGestureDetector.SimpleOnScaleGestureListener
+	{
+		private float scaleFactor = 1.0f;
+
+		@Override public boolean onScaleBegin(ScaleGestureDetector detector)
+		{
+			scrollView.setScrollEnabled(false);
+			return true;
+		}
+
+		@Override public boolean onScale(ScaleGestureDetector detector)
+		{
+			// calc scale factor
+			scaleFactor *= detector.getScaleFactor();
+			scaleFactor = Math.max(SessionView.MIN_SCALE_FACTOR,
+			                       Math.min(scaleFactor, SessionView.MAX_SCALE_FACTOR));
+			sessionView.setZoom(scaleFactor);
+
+			if (!sessionView.isAtMinZoom() && !sessionView.isAtMaxZoom())
+			{
+				// transform scroll origin to the new zoom space
+				float transOriginX = scrollView.getScrollX() * detector.getScaleFactor();
+				float transOriginY = scrollView.getScrollY() * detector.getScaleFactor();
+
+				// transform center point to the zoomed space
+				float transCenterX =
+				    (scrollView.getScrollX() + detector.getFocusX()) * detector.getScaleFactor();
+				float transCenterY =
+				    (scrollView.getScrollY() + detector.getFocusY()) * detector.getScaleFactor();
+
+				// scroll by the difference between the distance of the
+				// transformed center/origin point and their old distance
+				// (focusX/Y)
+				scrollView.scrollBy((int)((transCenterX - transOriginX) - detector.getFocusX()),
+				                    (int)((transCenterY - transOriginY) - detector.getFocusY()));
+			}
+
+			return true;
+		}
+
+		@Override public void onScaleEnd(ScaleGestureDetector de)
+		{
+			scrollView.setScrollEnabled(true);
+		}
+	}
+}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
@@ -34,7 +34,6 @@ import android.view.inputmethod.InputConnection;
 import androidx.annotation.NonNull;
 
 import com.freerdp.freerdpcore.application.SessionState;
-import com.freerdp.freerdpcore.services.LibFreeRDP;
 import com.freerdp.freerdpcore.utils.DoubleGestureDetector;
 import com.freerdp.freerdpcore.utils.GestureDetector;
 import com.freerdp.freerdpcore.utils.Mouse;
@@ -110,8 +109,9 @@ public class SessionView extends View
 			float y = event.getY();
 			// Perform actions based on the hover position (x, y)
 			MotionEvent mappedEvent = mapTouchEvent(event);
-			LibFreeRDP.sendCursorEvent(currentSession.getInstance(), (int)mappedEvent.getX(),
-			                           (int)mappedEvent.getY(), Mouse.getMoveEvent());
+			sessionViewListener.onSessionViewMouseMove((int)mappedEvent.getX(),
+			                                           (int)mappedEvent.getY());
+			mappedEvent.recycle();
 		}
 		// Return true to indicate that you've handled the event
 		return true;

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionViewModel.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionViewModel.java
@@ -11,6 +11,8 @@
 package com.freerdp.freerdpcore.presentation;
 
 import android.app.Application;
+import android.os.Handler;
+import android.os.Looper;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
@@ -18,6 +20,15 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
 import com.freerdp.freerdpcore.application.GlobalApp;
+import com.freerdp.freerdpcore.data.AppDatabase;
+import com.freerdp.freerdpcore.data.HistoryDatabase;
+import com.freerdp.freerdpcore.domain.BookmarkBase;
+import com.freerdp.freerdpcore.services.ManualBookmarkGateway;
+import com.freerdp.freerdpcore.services.QuickConnectHistoryGateway;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
 
 public class SessionViewModel extends AndroidViewModel
 {
@@ -30,12 +41,22 @@ public class SessionViewModel extends AndroidViewModel
 		DISCONNECTED
 	}
 
-	private final MutableLiveData<ConnectionState> state = new MutableLiveData<>(ConnectionState.IDLE);
+	private final MutableLiveData<ConnectionState> state =
+	    new MutableLiveData<>(ConnectionState.IDLE);
 	private long registeredInstance = 0;
+
+	private final ExecutorService executor = Executors.newSingleThreadExecutor();
+	private final Handler mainHandler = new Handler(Looper.getMainLooper());
+	private final ManualBookmarkGateway manualBookmarkGateway;
+	private final QuickConnectHistoryGateway quickConnectHistoryGateway;
 
 	public SessionViewModel(@NonNull Application application)
 	{
 		super(application);
+		manualBookmarkGateway =
+		    new ManualBookmarkGateway(AppDatabase.getInstance(application).bookmarkDao());
+		quickConnectHistoryGateway =
+		    new QuickConnectHistoryGateway(HistoryDatabase.getInstance(application).historyDao());
 	}
 
 	public LiveData<ConnectionState> getState()
@@ -75,9 +96,32 @@ public class SessionViewModel extends AndroidViewModel
 		}
 	}
 
+	/**
+	 * Loads a bookmark by id off the UI thread and delivers the result on the main thread.
+	 */
+	public void loadBookmarkById(long bookmarkId, @NonNull Consumer<BookmarkBase> callback)
+	{
+		executor.execute(() -> {
+			final BookmarkBase bookmark = manualBookmarkGateway.findById(bookmarkId);
+			mainHandler.post(() -> callback.accept(bookmark));
+		});
+	}
+
+	/**
+	 * Inserts the given hostname into quick-connect history off the UI thread (no-op on duplicate).
+	 */
+	public void recordQuickConnectHistory(@NonNull String hostname)
+	{
+		executor.execute(() -> {
+			if (!quickConnectHistoryGateway.historyItemExists(hostname))
+				quickConnectHistoryGateway.addHistoryItem(hostname);
+		});
+	}
+
 	@Override protected void onCleared()
 	{
 		unregister();
+		executor.shutdown();
 		super.onCleared();
 	}
 }

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionViewModel.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionViewModel.java
@@ -1,0 +1,83 @@
+/*
+   SessionViewModel — exposes RDP connection state as LiveData
+
+   Copyright 2026 Thincast Technologies GmbH
+
+   This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+   If a copy of the MPL was not distributed with this file, You can obtain one at
+   http://mozilla.org/MPL/2.0/.
+*/
+
+package com.freerdp.freerdpcore.presentation;
+
+import android.app.Application;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.AndroidViewModel;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+
+import com.freerdp.freerdpcore.application.GlobalApp;
+
+public class SessionViewModel extends AndroidViewModel
+{
+	public enum ConnectionState
+	{
+		IDLE,
+		CONNECTING,
+		CONNECTED,
+		FAILED,
+		DISCONNECTED
+	}
+
+	private final MutableLiveData<ConnectionState> state = new MutableLiveData<>(ConnectionState.IDLE);
+	private long registeredInstance = 0;
+
+	public SessionViewModel(@NonNull Application application)
+	{
+		super(application);
+	}
+
+	public LiveData<ConnectionState> getState()
+	{
+		return state;
+	}
+
+	public void register(long instance)
+	{
+		unregister();
+		registeredInstance = instance;
+		state.setValue(ConnectionState.CONNECTING);
+		GlobalApp.registerSessionListener(instance, new GlobalApp.SessionEventListener() {
+			@Override public void onConnectionSuccess()
+			{
+				state.setValue(ConnectionState.CONNECTED);
+			}
+
+			@Override public void onConnectionFailure()
+			{
+				state.setValue(ConnectionState.FAILED);
+			}
+
+			@Override public void onDisconnected()
+			{
+				state.setValue(ConnectionState.DISCONNECTED);
+			}
+		});
+	}
+
+	public void unregister()
+	{
+		if (registeredInstance != 0)
+		{
+			GlobalApp.unregisterSessionListener(registeredInstance);
+			registeredInstance = 0;
+		}
+	}
+
+	@Override protected void onCleared()
+	{
+		unregister();
+		super.onCleared();
+	}
+}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ShortcutsViewModel.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ShortcutsViewModel.java
@@ -5,23 +5,35 @@
 
 package com.freerdp.freerdpcore.presentation;
 
+import android.app.Application;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
-import androidx.lifecycle.ViewModel;
 
-import com.freerdp.freerdpcore.application.GlobalApp;
+import com.freerdp.freerdpcore.data.AppDatabase;
 import com.freerdp.freerdpcore.domain.BookmarkBase;
+import com.freerdp.freerdpcore.services.ManualBookmarkGateway;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-public class ShortcutsViewModel extends ViewModel
+public class ShortcutsViewModel extends AndroidViewModel
 {
 	private final MutableLiveData<List<BookmarkBase>> bookmarks =
 	    new MutableLiveData<>(Collections.emptyList());
 	private final ExecutorService executor = Executors.newSingleThreadExecutor();
+	private final ManualBookmarkGateway manualBookmarkGateway;
+
+	public ShortcutsViewModel(@NonNull Application application)
+	{
+		super(application);
+		manualBookmarkGateway =
+		    new ManualBookmarkGateway(AppDatabase.getInstance(application).bookmarkDao());
+	}
 
 	public LiveData<List<BookmarkBase>> getBookmarks()
 	{
@@ -30,7 +42,7 @@ public class ShortcutsViewModel extends ViewModel
 
 	public void loadBookmarks()
 	{
-		executor.execute(() -> bookmarks.postValue(GlobalApp.getManualBookmarkGateway().findAll()));
+		executor.execute(() -> bookmarks.postValue(manualBookmarkGateway.findAll()));
 	}
 
 	@Override protected void onCleared()

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/TouchPointerView.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/TouchPointerView.java
@@ -14,7 +14,7 @@ import android.content.Context;
 import android.graphics.Matrix;
 import android.graphics.RectF;
 import android.os.Handler;
-import android.os.Message;
+import android.os.Looper;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.widget.ImageView;
@@ -57,7 +57,9 @@ public class TouchPointerView extends ImageView
 	private boolean pointerMoving = false;
 	private boolean pointerScrolling = false;
 	private TouchPointerListener listener = null;
-	private final UIHandler uiHandler = new UIHandler();
+	private final Handler uiHandler = new Handler(Looper.getMainLooper());
+	private final Runnable restorePointerImage =
+	    () -> setPointerImage(R.drawable.touch_pointer_default);
 	// gesture detection
 	private GestureDetector gestureDetector;
 	public TouchPointerView(Context context)
@@ -154,7 +156,8 @@ public class TouchPointerView extends ImageView
 	private void displayPointerImageAction(int resId)
 	{
 		setPointerImage(resId);
-		uiHandler.sendEmptyMessageDelayed(0, DEFAULT_TOUCH_POINTER_RESTORE_DELAY);
+		uiHandler.removeCallbacks(restorePointerImage);
+		uiHandler.postDelayed(restorePointerImage, DEFAULT_TOUCH_POINTER_RESTORE_DELAY);
 	}
 
 	private void setPointerImage(int resId)
@@ -216,20 +219,6 @@ public class TouchPointerView extends ImageView
 		void onTouchPointerToggleExtKeyboard();
 
 		void onTouchPointerResetScrollZoom();
-	}
-
-	private class UIHandler extends Handler
-	{
-
-		UIHandler()
-		{
-			super();
-		}
-
-		@Override public void handleMessage(Message msg)
-		{
-			setPointerImage(R.drawable.touch_pointer_default);
-		}
 	}
 
 	private class TouchPointerGestureListener extends GestureDetector.SimpleOnGestureListener

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/SessionRequestHandlerActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/SessionRequestHandlerActivity.java
@@ -10,10 +10,11 @@
 
 package com.freerdp.freerdpcore.services;
 
-import android.app.Activity;
 import android.app.SearchManager;
 import android.content.Intent;
 import android.os.Bundle;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.freerdp.freerdpcore.domain.ConnectionReference;
@@ -22,6 +23,11 @@ import com.freerdp.freerdpcore.presentation.SessionActivity;
 
 public class SessionRequestHandlerActivity extends AppCompatActivity
 {
+	private final ActivityResultLauncher<Intent> launcher =
+	    registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
+		    setResult(result.getResultCode());
+		    finish();
+	    });
 
 	@Override public void onCreate(Bundle savedInstanceState)
 	{
@@ -43,7 +49,7 @@ public class SessionRequestHandlerActivity extends AppCompatActivity
 		Intent sessionIntent = new Intent(this, SessionActivity.class);
 		sessionIntent.putExtras(bundle);
 
-		startActivityForResult(sessionIntent, 0);
+		launcher.launch(sessionIntent);
 	}
 
 	private void editBookmarkWithConnectionReference(String refStr)
@@ -52,7 +58,7 @@ public class SessionRequestHandlerActivity extends AppCompatActivity
 		bundle.putString(BookmarkActivity.PARAM_CONNECTION_REFERENCE, refStr);
 		Intent bookmarkIntent = new Intent(this.getApplicationContext(), BookmarkActivity.class);
 		bookmarkIntent.putExtras(bundle);
-		startActivityForResult(bookmarkIntent, 0);
+		launcher.launch(bookmarkIntent);
 	}
 
 	private void handleIntent(Intent intent)
@@ -66,12 +72,5 @@ public class SessionRequestHandlerActivity extends AppCompatActivity
 			startSessionWithConnectionReference(intent.getDataString());
 		else if (Intent.ACTION_EDIT.equals(action))
 			editBookmarkWithConnectionReference(intent.getDataString());
-	}
-
-	@Override protected void onActivityResult(int requestCode, int resultCode, Intent data)
-	{
-		super.onActivityResult(requestCode, resultCode, data);
-		this.setResult(resultCode);
-		this.finish();
 	}
 }

--- a/client/Android/Studio/freeRDPCore/src/main/res/layout/session.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/layout/session.xml
@@ -50,13 +50,6 @@
         android:src="@drawable/touch_pointer_default"
         android:visibility="invisible" />
 
-    <android.widget.ZoomControls
-        android:id="@+id/zoomControls"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignBottom="@id/sessionScrollView"
-        android:layout_centerHorizontal="true" />
-
     <android.inputmethodservice.KeyboardView
         android:id="@+id/extended_keyboard_header"
         android:layout_width="wrap_content"

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_ui.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_ui.xml
@@ -8,10 +8,6 @@
         android:key="@string/preference_key_ui_hide_navigation_bar"
         android:title="@string/settings_ui_hide_navigation_bar" />
     <CheckBoxPreference
-    android:defaultValue="true"
-        android:key="@string/preference_key_ui_hide_zoom_controls"
-        android:title="@string/settings_ui_hide_zoom_controls" />
-    <CheckBoxPreference
         android:key="@string/preference_key_ui_swap_mouse_buttons"
         android:title="@string/settings_ui_swap_mouse_buttons" />
     <CheckBoxPreference


### PR DESCRIPTION
## [client, android] Refactor session layer and modernize deprecated APIs

### Description
Hi, this is the next step in the Android client cleanup, following up on PR #12730.

I focused on `SessionActivity`, which was doing too much. This PR splits its responsibilities (inputs, dialogs, state) into separate classes. As before, there are no behavior changes for users,  just code modernization and making things easier to maintain.

Looking forward to your feedback.

- Fixes #12699

### Key Changes
* **Components Extracted:** Moved input logic to `SessionInputManager` and dialogs to `SessionDialogs`.
* **Architecture:** Added `SessionViewModel` for connection states. Replaced the static event bus with a simpler `UIEventListener` registry.
* **API Updates:** Dropped dead `ZoomControls`, replaced the deprecated `ProgressDialog` with `AlertDialog`, and migrated to `ActivityResultLauncher`. Fixed deprecated `Handler` constructors and moved to lambdas.
* **Database & Cleanup:** Moved Room DB queries off the main thread to a background executor. Removed static database gateways from `GlobalApp`.

### How to Test
1. Build the app (`aFreeRDP`).
2. Start an RDP session and check inputs (touch, scroll, pinch-to-zoom, system/extended keyboards).
3. Test dialogs (certificate accept/reject, credentials prompt, and cancel button on the progress dialog).
4. Rotate the device during a session to make sure it doesn't drop the connection.
5. Verify the Home screen loads bookmarks without main-thread DB violations.

### Environments Tested
* **Emulators:** Android 7.0 (API 24), Android 14 (API 34)
* **Physical Device:** Android 16 (API 36)