### PR TITLE
[client,sdl] sync pointer updates

### DIFF
--- a/client/SDL/SDL3/sdl_context.cpp
+++ b/client/SDL/SDL3/sdl_context.cpp
@@ -1458,6 +1458,26 @@ int SdlContext::argumentHandler(const COMMAND_LINE_ARGUMENT_A* arg, void* custom
 	return 0;
 }
 
+CriticalSection& SdlContext::lock()
+{
+	return _critical;
+}
+
+std::vector<rdpPointer*>& SdlContext::pointers()
+{
+	return _valid_pointers;
+}
+
+bool SdlContext::contains(const rdpPointer* ptr) const
+{
+	for (const auto& cur : _valid_pointers)
+	{
+		if (cur == ptr)
+			return true;
+	}
+	return false;
+}
+
 bool SdlContext::resizeToScale(SdlWindow* window)
 {
 	if (freerdp_settings_get_bool(context()->settings, FreeRDP_SmartSizing))
@@ -1581,6 +1601,10 @@ bool SdlContext::setCursor(CursorType type)
 
 bool SdlContext::setCursor(const rdpPointer* cursor)
 {
+	std::unique_lock lock(_critical);
+	if (!contains(cursor))
+		return true;
+
 	_cursor = { sdl_Pointer_Copy(cursor), sdl_PointerFreeCopyAll };
 	return setCursor(CURSOR_IMAGE);
 }

--- a/client/SDL/SDL3/sdl_context.hpp
+++ b/client/SDL/SDL3/sdl_context.hpp
@@ -20,6 +20,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <vector>
 #include <mutex>
@@ -149,6 +150,11 @@ class SdlContext
 
 	[[nodiscard]] static int argumentHandler(const COMMAND_LINE_ARGUMENT_A* arg, void* custom);
 
+	[[nodiscard]] CriticalSection& lock();
+
+	[[nodiscard]] std::vector<rdpPointer*>& pointers();
+	[[nodiscard]] bool contains(const rdpPointer* ptr) const;
+
   private:
 	[[nodiscard]] bool resizeToScale(SdlWindow* window);
 	[[nodiscard]] bool useLocalScale() const;
@@ -236,4 +242,5 @@ class SdlContext
 	WinPREvent _windowsCreatedEvent;
 	std::thread _thread;
 	std::vector<COMMAND_LINE_ARGUMENT_A> _args;
+	std::vector<rdpPointer*> _valid_pointers;
 };

--- a/client/SDL/SDL3/sdl_pointer.cpp
+++ b/client/SDL/SDL3/sdl_pointer.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include <algorithm>
+
 #include <freerdp/config.h>
 
 #include <freerdp/gdi/gdi.h>
@@ -64,10 +66,13 @@ struct sdlPointer
 [[nodiscard]] static BOOL sdl_Pointer_New(rdpContext* context, rdpPointer* pointer)
 {
 	auto ptr = reinterpret_cast<sdlPointer*>(pointer);
+	auto sdl = get_context(context);
 
-	WINPR_ASSERT(context);
+	WINPR_ASSERT(sdl);
+	std::unique_lock lock(sdl->lock());
 	if (!ptr)
 		return FALSE;
+	sdl->pointers().push_back(pointer);
 
 	return ptr->update(context);
 }
@@ -83,6 +88,13 @@ static void sdl_Pointer_Clear(sdlPointer* ptr)
 
 static void sdl_Pointer_Free(WINPR_ATTR_UNUSED rdpContext* context, rdpPointer* pointer)
 {
+	auto sdl = get_context(context);
+
+	WINPR_ASSERT(sdl);
+	std::unique_lock lock(sdl->lock());
+	auto it = std::remove(sdl->pointers().begin(), sdl->pointers().end(), pointer);
+	sdl->pointers().erase(it, sdl->pointers().end());
+
 	sdl_Pointer_FreeCopy(pointer);
 }
 
@@ -115,6 +127,7 @@ bool sdl_Pointer_Set_Process(SdlContext* sdl)
 {
 	WINPR_ASSERT(sdl);
 
+	std::unique_lock lock(sdl->lock());
 	auto context = sdl->context();
 	auto pointer = sdl->cursor();
 	auto ptr = reinterpret_cast<sdlPointer*>(pointer);


### PR DESCRIPTION
Ensure that pointer updates do only use images that are still valid. Since RDP and SDL use different threads, a pointer update requested might only be processed after the image was already deleted. Ensure that such updates are silently discarded.