### PR TITLE
Fix for GHSA-j9q5-7g8m-jc9v, disable NDR pointer aliasing

### DIFF
--- a/channels/rdpear/common/ndr.c
+++ b/channels/rdpear/common/ndr.c
@@ -931,6 +931,11 @@ BOOL ndr_read_pointedMessageEx(NdrContext* context, wStream* s, ndr_refid ptrId,
 			return FALSE;
 		}
 	}
+	else
+	{
+		WLog_ERR(TAG, "aliased pointer aren't supported for now");
+		return FALSE;
+	}
 
 	*target = ret;
 	return TRUE;


### PR DESCRIPTION
The usage of aliased pointers can be used to trigger a double free, or a type confusion (using the same memory location twice and pretend it's 2 different types of objects). As pointer aliasing is never seen in practice with RDPEAR, let's just return an error when we see an aliased pointer.
