### PR TITLE
Call winpr_InitializeSSL in TestWinPRUtils/TestNTLM

### DIFF
--- a/winpr/libwinpr/utils/test/TestNTLM.c
+++ b/winpr/libwinpr/utils/test/TestNTLM.c
@@ -2,6 +2,7 @@
 #include <winpr/ntlm.h>
 #include <winpr/string.h>
 #include <winpr/print.h>
+#include <winpr/ssl.h>
 
 typedef struct
 {
@@ -311,6 +312,9 @@ static BOOL testNTOWFv2FromHash(size_t x, const test_case_from_hash_t* test)
 
 int TestNTLM(WINPR_ATTR_UNUSED int argc, WINPR_ATTR_UNUSED char* argv[])
 {
+	/* Make sure we load the OpenSSL legacy provider if needed */
+	winpr_InitializeSSL(WINPR_SSL_INIT_DEFAULT);
+
 	for (size_t x = 0; x < ARRAYSIZE(ntofw1tests); x++)
 	{
 		const test_case_ntowf1_t* cur = &ntofw1tests[x];


### PR DESCRIPTION
This is needed to load the OpenSSL legacy provider when that library is in use.

Closes: https://github.com/FreeRDP/FreeRDP/issues/12744