### PR TITLE
[client,android] use Ingeger.decode

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/IntListPreference.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/IntListPreference.java
@@ -34,6 +34,6 @@ public class IntListPreference extends ListPreference
 
 	@Override protected boolean persistString(String value)
 	{
-		return persistInt(Integer.parseInt(value));
+		return persistInt(Integer.decode(value));
 	}
 }


### PR DESCRIPTION
Integer.parseInt only supports decimal integers, use Integer.decode to allow hex or octal as well.