### PR TITLE
[core,codec] Fix invalid overlap check

### DIFF
--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -820,10 +820,10 @@ static inline BOOL overlapping(const BYTE* pDstData, UINT32 nYDst, UINT32 nDstSt
 	const uintptr_t dststart = dst + 1ULL * nDstStep * nYDst;
 	const uintptr_t dstend = dststart + 1ULL * nDstStep * nHeight;
 
-	if ((dststart >= srcstart) && (dststart <= srcend))
+	if ((dststart >= srcstart) && (dststart < srcend))
 		return TRUE;
 
-	if ((dstend >= srcstart) && (dstend <= srcend))
+	if ((dstend > srcstart) && (dstend <= srcend))
 		return TRUE;
 
 	return FALSE;


### PR DESCRIPTION
The overlap check returned true if src and dst were placed directly next to each other in memory.

`dststart` can be located directly at the address `srcend` and `dstend` can be at the exact same address as `srcstart` so do not check for equality at these two places.
