### PR TITLE
[client,android] Fix Room migration crashes

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
@@ -167,10 +167,8 @@ public abstract class AppDatabase extends RoomDatabase
 	private static final Migration MIGRATION_11_12 = new Migration(11, 12) {
 		@Override public void migrate(@NonNull SupportSQLiteDatabase db)
 		{
-			db.execSQL("ALTER TABLE 'bookmarks' ADD 'tlsSecLevel' CONSTRAINT chk_tlsSecLevel "
-			           + "CHECK (tlsSecLevel >= -1 AND tlsSecLevel <= 5) INTEGER DEFAULT -1;");
-			db.execSQL("ALTER TABLE 'bookmarks' ADD 'tlsMinLevel' CONSTRAINT chk_tlsMinLevel "
-			           + "CHECK (tlsSecLevel >= -1) INTEGER DEFAULT -1;");
+			db.execSQL("ALTER TABLE 'bookmarks' ADD 'tlsSecLevel' INTEGER NOT NULL DEFAULT -1");
+			db.execSQL("ALTER TABLE 'bookmarks' ADD 'tlsMinLevel' INTEGER NOT NULL DEFAULT -1");
 			final String list[] = { "screen_3g_colors",
 				                    "screen_3g_resolution",
 				                    "screen_3g_width",

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkEntity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkEntity.java
@@ -85,7 +85,7 @@ import androidx.room.PrimaryKey;
 
 	@ColumnInfo(name = "async_update") public boolean asyncUpdate = false;
 
-	@ColumnInfo(name = "tlsSecLevel") public int tlsSecLevel = -1;
+	@ColumnInfo(name = "tlsSecLevel", defaultValue = "-1") public int tlsSecLevel = -1;
 
-	@ColumnInfo(name = "tlsMinLevel") public int tlsMinLevel = -1;
+	@ColumnInfo(name = "tlsMinLevel", defaultValue = "-1") public int tlsMinLevel = -1;
 }

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -374,7 +374,7 @@ public class LibFreeRDP
 		}
 
 		String info = advanced.getLoadBalanceInfo();
-		if (!info.isEmpty())
+		if (info != null && !info.isEmpty())
 		{
 			args.add("/load-balance-info:" + info);
 		}


### PR DESCRIPTION
Fix three runtime crashes that only affect upgrades from existing installs.

- MIGRATION_11_12: typo in ALTER TABLE,  constraint clause was written before
  the column type, causing the migration to fail with a SQL syntax error.

- MIGRATION_11_12: Room schema validation crash, SQLite permanently records
  the DEFAULT clause, so @ColumnInfo on tlsSecLevel/tlsMinLevel must carry
  a matching defaultValue attribute.

- LibFreeRDP: NPE in setConnectionInfo(), getLoadBalanceInfo() returns null
  for bookmarks migrated from older schema versions. Add null check.

---

Error messages:
2026-05-13 09:23:25.869 20208-20372 SQLiteLog               com.freerdp.afreerdp                 E  (1) near "INTEGER": syntax error in "ALTER TABLE 'bookmarks' ADD 'tlsSecLevel' CONSTRAINT chk_tlsSecLevel CHECK (tlsSecLevel >= -1 AND tlsSecLevel <= 5) INTEGER DEFAULT -1;"
2026-05-13 09:23:25.873 20208-20372 AndroidRuntime          com.freerdp.afreerdp                 E  FATAL EXCEPTION: pool-3-thread-1
                                                                                                    Process: com.freerdp.afreerdp, PID: 20208
                                                                                                    android.database.sqlite.SQLiteException: near "INTEGER": syntax error (code 1): , while compiling: ALTER TABLE 'bookmarks' ADD 'tlsSecLevel' CONSTRAINT chk_tlsSecLevel CHECK (tlsSecLevel >= -1 AND tlsSecLevel <= 5) INTEGER DEFAULT -1;
                                                                                                    	at net.zetetic.database.sqlcipher.SQLiteConnection.nativePrepareStatement(Native Method)
                                                                                                    	at net.zetetic.database.sqlcipher.SQLiteConnection.acquirePreparedStatement(SQLiteConnection.java:973)
                                                                                                    	at net.zetetic.database.sqlcipher.SQLiteConnection.prepare(SQLiteConnection.java:537)
                                                                                                    	at net.zetetic.database.sqlcipher.SQLiteSession.prepare(SQLiteSession.java:593)
                                                                                                    	at net.zetetic.database.sqlcipher.SQLiteProgram.<init>(SQLiteProgram.java:65)
                                                                                                    	at net.zetetic.database.sqlcipher.SQLiteStatement.<init>(SQLiteStatement.java:38)
                                                                                                    	at net.zetetic.database.sqlcipher.SQLiteDatabase.executeSql(SQLiteDatabase.java:1996)
                                                                                                    	at net.zetetic.database.sqlcipher.SQLiteDatabase.execSQL(SQLiteDatabase.java:1906)
                                                                                                    	at com.freerdp.freerdpcore.data.AppDatabase$2.migrate(AppDatabase.java:170)
                                                                                                    	at androidx.room.migration.Migration.migrate(Migration.android.kt:79)
                                                                                     