### PR TITLE
[channels,rail] fix client handshake response

### DIFF
--- a/channels/rail/client/rail_main.c
+++ b/channels/rail/client/rail_main.c
@@ -342,13 +342,47 @@ static UINT rail_client_system_command(RailClientContext* context,
  */
 static UINT rail_client_handshake(RailClientContext* context, const RAIL_HANDSHAKE_ORDER* handshake)
 {
-	railPlugin* rail = nullptr;
-
 	if (!context || !handshake)
 		return ERROR_INVALID_PARAMETER;
 
-	rail = (railPlugin*)context->handle;
+	railPlugin* rail = (railPlugin*)context->handle;
+	WINPR_ASSERT(rail);
+	WLog_Print(rail->log, WLOG_DEBUG, "build=0x%08" PRIx32, handshake->buildNumber);
 	return rail_send_handshake_order(rail, handshake);
+}
+
+static UINT rail_server_handshake(RailClientContext* context, const RAIL_HANDSHAKE_ORDER* handshake)
+{
+	WINPR_ASSERT(context);
+	WINPR_ASSERT(handshake);
+
+	railPlugin* rail = (railPlugin*)context->handle;
+	WINPR_ASSERT(rail);
+
+	WLog_Print(rail->log, WLOG_DEBUG, "build=0x%08" PRIx32, handshake->buildNumber);
+
+	const UINT32 buildnumber =
+	    freerdp_settings_get_uint32(rail->rdpcontext->settings, FreeRDP_ClientBuild);
+	const RAIL_HANDSHAKE_ORDER clientHandshake = { buildnumber };
+	return context->ClientHandshake(context, &clientHandshake);
+}
+
+static UINT rail_server_handshake_ex(RailClientContext* context,
+                                     const RAIL_HANDSHAKE_EX_ORDER* handshakeEx)
+{
+	WINPR_ASSERT(context);
+	WINPR_ASSERT(handshakeEx);
+
+	railPlugin* rail = (railPlugin*)context->handle;
+	WINPR_ASSERT(rail);
+
+	const RAIL_HANDSHAKE_ORDER handshake = { handshakeEx->buildNumber };
+
+	char buffer[128] = WINPR_C_ARRAY_INIT;
+	WLog_Print(
+	    rail->log, WLOG_DEBUG, "build=0x%08" PRIx32 ", flags=%s", handshakeEx->buildNumber,
+	    rail_handshake_ex_flags_to_string(handshakeEx->railHandshakeFlags, buffer, sizeof(buffer)));
+	return rail_server_handshake(context, &handshake);
 }
 
 /**
@@ -571,19 +605,8 @@ static VOID VCAPITYPE rail_virtual_channel_open_event_ex(LPVOID lpUserParam, DWO
 static UINT rail_virtual_channel_event_connected(railPlugin* rail, WINPR_ATTR_UNUSED LPVOID pData,
                                                  WINPR_ATTR_UNUSED UINT32 dataLength)
 {
-	RailClientContext* context = rail_get_client_interface(rail);
-	UINT status = CHANNEL_RC_OK;
-
 	WINPR_ASSERT(rail);
 
-	if (context)
-	{
-		IFCALLRET(context->OnOpen, status, context, &rail->sendHandshake);
-
-		if (status != CHANNEL_RC_OK)
-			WLog_ERR(TAG, "context->OnOpen failed with %s [%08" PRIX32 "]",
-			         WTSErrorToString(status), status);
-	}
 	rail->MsgsHandle = channel_client_create_handler(rail->rdpcontext, rail, rail_order_recv,
 	                                                 RAIL_SVC_CHANNEL_NAME);
 	if (!rail->MsgsHandle)
@@ -692,8 +715,6 @@ FREERDP_ENTRY_POINT(BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS_E
 		return FALSE;
 	}
 
-	/* Default to automatically replying to server handshakes */
-	rail->sendHandshake = TRUE;
 	rail->channelDef.options = CHANNEL_OPTION_INITIALIZED | CHANNEL_OPTION_ENCRYPT_RDP |
 	                           CHANNEL_OPTION_COMPRESS_RDP | CHANNEL_OPTION_SHOW_PROTOCOL;
 	(void)sprintf_s(rail->channelDef.name, ARRAYSIZE(rail->channelDef.name), RAIL_SVC_CHANNEL_NAME);
@@ -718,6 +739,8 @@ FREERDP_ENTRY_POINT(BOOL VCAPITYPE VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS_E
 		context->ClientSystemParam = rail_client_system_param;
 		context->ClientSystemCommand = rail_client_system_command;
 		context->ClientHandshake = rail_client_handshake;
+		context->ServerHandshake = rail_server_handshake;
+		context->ServerHandshakeEx = rail_server_handshake_ex;
 		context->ClientNotifyEvent = rail_client_notify_event;
 		context->ClientWindowMove = rail_client_window_move;
 		context->ClientInformation = rail_client_information;

--- a/channels/rail/client/rail_main.h
+++ b/channels/rail/client/rail_main.h
@@ -51,7 +51,6 @@ typedef struct
 	DWORD channelBuildNumber;
 	DWORD channelFlags;
 	RAIL_CLIENT_STATUS_ORDER clientStatus;
-	BOOL sendHandshake;
 } railPlugin;
 
 WINPR_ATTR_NODISCARD FREERDP_LOCAL RailClientContext* rail_get_client_interface(railPlugin* rail);

--- a/channels/rail/client/rail_orders.c
+++ b/channels/rail/client/rail_orders.c
@@ -364,16 +364,6 @@ static UINT rail_recv_handshake_order(railPlugin* rail, wStream* s)
 
 	rail->channelBuildNumber = serverHandshake.buildNumber;
 
-	if (rail->sendHandshake)
-	{
-		RAIL_HANDSHAKE_ORDER clientHandshake = WINPR_C_ARRAY_INIT;
-		clientHandshake.buildNumber = 0x00001DB0;
-		error = context->ClientHandshake(context, &clientHandshake);
-	}
-
-	if (error != CHANNEL_RC_OK)
-		return error;
-
 	if (context->custom)
 	{
 		IFCALLRET(context->ServerHandshake, error, context, &serverHandshake);
@@ -485,18 +475,6 @@ static UINT rail_recv_handshake_ex_order(railPlugin* rail, wStream* s)
 		         rail_handshake_ex_flags_to_string(rail->channelFlags, buffer, sizeof(buffer)),
 		         rail->channelBuildNumber);
 	}
-
-	if (rail->sendHandshake)
-	{
-		RAIL_HANDSHAKE_ORDER clientHandshake = WINPR_C_ARRAY_INIT;
-		clientHandshake.buildNumber = 0x00001DB0;
-		/* 2.2.2.2.3 HandshakeEx PDU (TS_RAIL_ORDER_HANDSHAKE_EX)
-		 * Client response is really a Handshake PDU */
-		error = context->ClientHandshake(context, &clientHandshake);
-	}
-
-	if (error != CHANNEL_RC_OK)
-		return error;
 
 	if (context->custom)
 	{

--- a/include/freerdp/client/rail.h
+++ b/include/freerdp/client/rail.h
@@ -107,7 +107,25 @@ extern "C"
 		WINPR_ATTR_NODISCARD pcRailServerSystemParam ServerSystemParam;
 		WINPR_ATTR_NODISCARD pcRailClientSystemCommand ClientSystemCommand;
 		WINPR_ATTR_NODISCARD pcRailClientHandshake ClientHandshake;
+
+		/** @brief (optional) callback when a [MS-RDPERP] 2.2.2.2.1 Handshake PDU
+		 * (TS_RAIL_ORDER_HANDSHAKE) is received. A default implementation exists and responds with
+		 * the current \ref FreeRDP_ClientBuild
+		 *
+		 *  @bug before 3.27.0 the response was sent before this callback was invoked. Now the
+		 * default implementation provides this and if overridden by client implementations they
+		 * must handle the response themselves.
+		 */
 		WINPR_ATTR_NODISCARD pcRailServerHandshake ServerHandshake;
+
+		/** @brief (optional) callback when a [MS-RDPERP] 2.2.2.2.3 HandshakeEx PDU
+		 * (TS_RAIL_ORDER_HANDSHAKE_EX) is received. A default implementation exists and responds
+		 * with the current \ref FreeRDP_ClientBuild
+		 *
+		 *  @bug before 3.27.0 the response was sent before this callback was invoked. Now the
+		 * default implementation provides this and if overridden by client implementations they
+		 * must handle the response themselves.
+		 */
 		WINPR_ATTR_NODISCARD pcRailServerHandshakeEx ServerHandshakeEx;
 		WINPR_ATTR_NODISCARD pcRailClientNotifyEvent ClientNotifyEvent;
 		WINPR_ATTR_NODISCARD pcRailClientWindowMove ClientWindowMove;
@@ -129,7 +147,11 @@ extern "C"
 		WINPR_ATTR_NODISCARD pcRailClientSnapArrange ClientSnapArrange;
 		WINPR_ATTR_NODISCARD pcRailServerGetAppidResponseExtended ServerGetAppidResponseExtended;
 		WINPR_ATTR_NODISCARD pcRailClientCompartmentInfo ClientCompartmentInfo;
-		WINPR_ATTR_NODISCARD pcRailOnOpen OnOpen;
+#if !defined(WITHOUT_FREERDP_3x_DEPRECATED)
+		WINPR_DEPRECATED_VAR("[since 3.27.0] unused", WINPR_ATTR_NODISCARD pcRailOnOpen OnOpen);
+#else
+	    void* reserved;
+#endif
 		WINPR_ATTR_NODISCARD pcRailClientTextScale ClientTextScale;
 		WINPR_ATTR_NODISCARD pcRailClientCaretBlinkRate ClientCaretBlinkRate;
 	};


### PR DESCRIPTION
* Eliminate railPlugin::sendHandshake, don't send handshake response before RailClientContext::ServerHandshake or RailClientContext::ServerHandshakeEx
* Deprecate now unused OnOpen callback
* Add logging fo handshake orders
* Provide default implementations of RailClientContext::ServerHandshake and RailClientContext::ServerHandshakeEx which send a RailClientContext::ClientHandshake
* Send FreeRDP_ClientBuild as buildnumber in client response
