### PR TITLE
[client,android] fix data corruption in MIGRATION_13_14

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
@@ -175,8 +175,7 @@ public abstract class AppDatabase extends RoomDatabase
 			{
 				db.execSQL("ALTER TABLE 'bookmarks' ADD '" + column +
 				           "_with_default' TEXT NOT NULL DEFAULT '';");
-				db.execSQL("UPDATE 'bookmarks' SET '" + column + "_with_default' = '" + column +
-				           "';");
+				db.execSQL("UPDATE bookmarks SET " + column + "_with_default = " + column);
 				db.execSQL("ALTER TABLE 'bookmarks' DROP '" + column + "';");
 				db.execSQL("ALTER TABLE 'bookmarks' RENAME COLUMN '" + column +
 				           "_with_default' to '" + column + "';");
@@ -187,8 +186,7 @@ public abstract class AppDatabase extends RoomDatabase
 			{
 				db.execSQL("ALTER TABLE 'bookmarks' ADD '" + column +
 				           "_with_default' TEXT NOT NULL DEFAULT 'INFO';");
-				db.execSQL("UPDATE 'bookmarks' SET '" + column + "_with_default' = '" + column +
-				           "';");
+				db.execSQL("UPDATE bookmarks SET " + column + "_with_default = " + column);
 				db.execSQL("ALTER TABLE 'bookmarks' DROP '" + column + "';");
 				db.execSQL("ALTER TABLE 'bookmarks' RENAME COLUMN '" + column +
 				           "_with_default' to '" + column + "';");
@@ -210,8 +208,8 @@ public abstract class AppDatabase extends RoomDatabase
 				db.execSQL("ALTER TABLE 'bookmarks' ADD '" + column.getKey() +
 				           "_with_default' INTEGER NOT NULL DEFAULT " +
 				           column.getValue().toString() + ";");
-				db.execSQL("UPDATE 'bookmarks' SET '" + column.getKey() + "_with_default' = '" +
-				           column.getKey() + "';");
+				db.execSQL("UPDATE bookmarks SET " + column.getKey() +
+				           "_with_default = " + column.getKey());
 				db.execSQL("ALTER TABLE 'bookmarks' DROP '" + column.getKey() + "';");
 				db.execSQL("ALTER TABLE 'bookmarks' RENAME COLUMN '" + column.getKey() +
 				           "_with_default' to '" + column.getKey() + "';");
@@ -239,8 +237,8 @@ public abstract class AppDatabase extends RoomDatabase
 				db.execSQL("ALTER TABLE 'bookmarks' ADD '" + column.getKey() +
 				           "_with_default' INTEGER NOT NULL DEFAULT " +
 				           column.getValue().toString() + ";");
-				db.execSQL("UPDATE 'bookmarks' SET '" + column.getKey() + "_with_default' = '" +
-				           column.getKey() + "';");
+				db.execSQL("UPDATE bookmarks SET " + column.getKey() +
+				           "_with_default = " + column.getKey());
 				db.execSQL("ALTER TABLE 'bookmarks' DROP '" + column.getKey() + "';");
 				db.execSQL("ALTER TABLE 'bookmarks' RENAME COLUMN '" + column.getKey() +
 				           "_with_default' to '" + column.getKey() + "';");

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/HistoryDatabase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/HistoryDatabase.java
@@ -11,7 +11,7 @@ import androidx.room.RoomDatabase;
 import androidx.room.migration.Migration;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 
-@Database(entities = { HistoryEntity.class }, version = 2, exportSchema = false)
+@Database(entities = { HistoryEntity.class }, version = 3, exportSchema = false)
 public abstract class HistoryDatabase extends RoomDatabase
 {
 	private static final String DB_NAME = "history.db";
@@ -30,7 +30,7 @@ public abstract class HistoryDatabase extends RoomDatabase
 				{
 					instance = Room.databaseBuilder(context.getApplicationContext(),
 					                                HistoryDatabase.class, DB_NAME)
-					               .addMigrations(MIGRATION_1_2)
+					               .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
 					               .fallbackToDestructiveMigration()
 					               .build();
 				}
@@ -38,6 +38,21 @@ public abstract class HistoryDatabase extends RoomDatabase
 		}
 		return instance;
 	}
+
+	// v3: Add DEFAULT '' to item column to match Room schema
+	private static final Migration MIGRATION_2_3 = new Migration(2, 3) {
+		@Override public void migrate(@NonNull SupportSQLiteDatabase db)
+		{
+			db.execSQL("CREATE TABLE IF NOT EXISTS `quick_connect_history_new` ("
+			           + "`item` TEXT NOT NULL DEFAULT '', "
+			           + "`timestamp` INTEGER NOT NULL DEFAULT 0, "
+			           + "PRIMARY KEY(`item`))");
+			db.execSQL("INSERT INTO `quick_connect_history_new` (item, timestamp) "
+			           + "SELECT item, timestamp FROM `quick_connect_history`");
+			db.execSQL("DROP TABLE `quick_connect_history`");
+			db.execSQL("ALTER TABLE `quick_connect_history_new` RENAME TO `quick_connect_history`");
+		}
+	};
 
 	// v1: item TEXT PRIMARY KEY, timestamp INTEGER (both nullable — old SQLiteOpenHelper schema)
 	// v2: item TEXT NOT NULL PRIMARY KEY, timestamp INTEGER NOT NULL (Room schema)


### PR DESCRIPTION
The UPDATE statements in MIGRATION_13_14 wrapped source column names in single quotes, causing SQLite to treat them as string literals. Every text field (label, hostname, username, etc.) was overwritten with its
own column name instead of the saved value after migration.

Remove the single quotes from column identifiers in all UPDATE statements.

Screenshot showing data corruption after migration, all bookmark fields display their column name (label, hostname, username, etc.) instead of the saved values.

<img  height="1000" alt="Screenshot_2026-05-13-15-52-20-18_bfe5c884e366e53e8d644a47ee8284f1" src="https://github.com/user-attachments/assets/ed0be104-95e8-417f-bb45-6768e95abc87" />
