### PR TITLE
[client,android] add remote hardware pointer/cursor support

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
@@ -57,6 +57,9 @@
 
 /* Defines the JNI version supported by this library. */
 #define FREERDP_JNI_VERSION FREERDP_VERSION_FULL
+
+static jclass gJavaActivityClass;
+static jmethodID gOnPointerSetMethod;
 static void android_OnChannelConnectedEventHandler(void* context,
                                                    const ChannelConnectedEventArgs* e)
 {
@@ -212,24 +215,82 @@ static BOOL android_pre_connect(freerdp* instance)
 	return TRUE;
 }
 
+typedef struct
+{
+	rdpPointer pointer;
+	size_t size;
+	void* data;
+} androidPointer;
+
 static BOOL android_Pointer_New(rdpContext* context, rdpPointer* pointer)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(pointer);
 	WINPR_ASSERT(context->gdi);
 
+	androidPointer* ptr = (androidPointer*)pointer;
+	if (!ptr)
+		return FALSE;
+
+	ptr->size = 4ULL * pointer->width * pointer->height;
+	ptr->data = winpr_aligned_malloc(ptr->size, 16);
+	if (!ptr->data)
+		return FALSE;
+
+	if (!freerdp_image_copy_from_pointer_data(
+	        ptr->data, PIXEL_FORMAT_ARGB32, 0, 0, 0, pointer->width, pointer->height,
+	        pointer->xorMaskData, pointer->lengthXorMask, pointer->andMaskData,
+	        pointer->lengthAndMask, pointer->xorBpp, &context->gdi->palette))
+	{
+		winpr_aligned_free(ptr->data);
+		ptr->data = nullptr;
+		return FALSE;
+	}
+
 	return TRUE;
 }
 
 static void android_Pointer_Free(rdpContext* context, rdpPointer* pointer)
 {
-	WINPR_ASSERT(context);
+	WINPR_UNUSED(context);
+	androidPointer* ptr = (androidPointer*)pointer;
+
+	if (ptr)
+	{
+		winpr_aligned_free(ptr->data);
+		ptr->data = nullptr;
+	}
 }
 
 static BOOL android_Pointer_Set(rdpContext* context, rdpPointer* pointer)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(pointer);
+
+	androidPointer* ptr = (androidPointer*)pointer;
+	if (!ptr->data)
+		return FALSE;
+
+	const jsize nPixels = (jsize)(pointer->width * pointer->height);
+
+	JNIEnv* env = NULL;
+	jboolean attached = jni_attach_thread(&env);
+
+	if (!gJavaActivityClass || !gOnPointerSetMethod)
+		goto done;
+
+	jintArray pixels = (*env)->NewIntArray(env, nPixels);
+	if (!pixels)
+		goto done;
+
+	(*env)->SetIntArrayRegion(env, pixels, 0, nPixels, (const jint*)ptr->data);
+	(*env)->CallStaticVoidMethod(env, gJavaActivityClass, gOnPointerSetMethod,
+	                             (jlong)context->instance, pixels, (jint)pointer->width,
+	                             (jint)pointer->height, (jint)pointer->xPos, (jint)pointer->yPos);
+	(*env)->DeleteLocalRef(env, pixels);
+done:
+	if (attached)
+		jni_detach_thread();
 
 	return TRUE;
 }
@@ -245,6 +306,7 @@ static BOOL android_Pointer_SetNull(rdpContext* context)
 {
 	WINPR_ASSERT(context);
 
+	freerdp_callback("OnPointerSetNull", "(J)V", (jlong)context->instance);
 	return TRUE;
 }
 
@@ -252,6 +314,7 @@ static BOOL android_Pointer_SetDefault(rdpContext* context)
 {
 	WINPR_ASSERT(context);
 
+	freerdp_callback("OnPointerSetDefault", "(J)V", (jlong)context->instance);
 	return TRUE;
 }
 
@@ -262,7 +325,7 @@ static BOOL android_register_pointer(rdpGraphics* graphics)
 	if (!graphics)
 		return FALSE;
 
-	pointer.size = sizeof(pointer);
+	pointer.size = sizeof(androidPointer);
 	pointer.New = android_Pointer_New;
 	pointer.Free = android_Pointer_Free;
 	pointer.Set = android_Pointer_Set;
@@ -994,8 +1057,6 @@ Java_com_freerdp_freerdpcore_services_LibFreeRDP_freerdp_1get_1build_1config(JNI
 	return (*env)->NewStringUTF(env, freerdp_get_build_config());
 }
 
-static jclass gJavaActivityClass = nullptr;
-
 jint JNI_OnLoad(JavaVM* vm, void* reserved)
 {
 	JNIEnv* env;
@@ -1026,6 +1087,8 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved)
 
 	/* create global reference for class */
 	gJavaActivityClass = (*env)->NewGlobalRef(env, activityClass);
+	gOnPointerSetMethod =
+	    (*env)->GetStaticMethodID(env, gJavaActivityClass, "OnPointerSet", "(J[IIIII)V");
 	g_JavaVm = vm;
 	return init_callback_environment(vm, env);
 }

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
@@ -238,7 +238,7 @@ static BOOL android_Pointer_New(rdpContext* context, rdpPointer* pointer)
 		return FALSE;
 
 	if (!freerdp_image_copy_from_pointer_data(
-	        ptr->data, PIXEL_FORMAT_ARGB32, 0, 0, 0, pointer->width, pointer->height,
+	        ptr->data, PIXEL_FORMAT_BGRA32, 0, 0, 0, pointer->width, pointer->height,
 	        pointer->xorMaskData, pointer->lengthXorMask, pointer->andMaskData,
 	        pointer->lengthAndMask, pointer->xorBpp, &context->gdi->palette))
 	{

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -72,6 +72,7 @@ public class SessionActivity extends AppCompatActivity
 	private static final int REFRESH_SESSIONVIEW = 1;
 	private static final int DISPLAY_TOAST = 2;
 	private static final int GRAPHICS_CHANGED = 6;
+	private static final int POINTER_SET = 7;
 
 	private final Handler uiHandler = new Handler(Looper.getMainLooper()) {
 		@Override public void handleMessage(Message msg)
@@ -94,6 +95,24 @@ public class SessionActivity extends AppCompatActivity
 					Toast errorToast = Toast.makeText(getApplicationContext(), msg.obj.toString(),
 					                                  Toast.LENGTH_LONG);
 					errorToast.show();
+					break;
+				}
+				case POINTER_SET:
+				{
+					Bundle data = msg.getData();
+					if (data != null && data.containsKey("pixels"))
+					{
+						int[] pixels = data.getIntArray("pixels");
+						int width = data.getInt("width");
+						int height = data.getInt("height");
+						int hotX = data.getInt("hotX");
+						int hotY = data.getInt("hotY");
+						sessionView.setRemoteCursor(pixels, width, height, hotX, hotY);
+					}
+					else
+					{
+						sessionView.setRemoteCursor(null, 0, 0, 0, 0);
+					}
 					break;
 				}
 			}
@@ -728,6 +747,29 @@ public class SessionActivity extends AppCompatActivity
 	{
 		Log.v(TAG, "OnRemoteClipboardChanged: " + data);
 		mClipboardManager.setClipboardData(data);
+	}
+
+	@Override public void OnPointerSet(int[] pixels, int width, int height, int hotX, int hotY)
+	{
+		Bundle data = new Bundle();
+		data.putIntArray("pixels", pixels);
+		data.putInt("width", width);
+		data.putInt("height", height);
+		data.putInt("hotX", hotX);
+		data.putInt("hotY", hotY);
+		Message msg = uiHandler.obtainMessage(POINTER_SET);
+		msg.setData(data);
+		uiHandler.sendMessage(msg);
+	}
+
+	@Override public void OnPointerSetNull()
+	{
+		uiHandler.sendEmptyMessage(POINTER_SET);
+	}
+
+	@Override public void OnPointerSetDefault()
+	{
+		sessionView.setDefaultCursor();
 	}
 
 	// ****************************************************************************

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
@@ -63,6 +63,12 @@ public class SessionView extends View
 	private GestureDetector gestureDetector;
 	private SessionState currentSession;
 
+	private int[] cursorPixels = null;
+	private int cursorWidth = 0;
+	private int cursorHeight = 0;
+	private int cursorHotX = 0;
+	private int cursorHotY = 0;
+
 	// private static final String TAG = "FreeRDP.SessionView";
 	private DoubleGestureDetector doubleGestureDetector;
 	public SessionView(Context context)
@@ -165,13 +171,13 @@ public class SessionView extends View
 
 	public void setZoom(float factor)
 	{
-		// calc scale matrix and inverse scale matrix (to correctly transform the view and moues
-		// coordinates)
 		scaleFactor = factor;
 		scaleMatrix.setScale(scaleFactor, scaleFactor);
 		invScaleMatrix.setScale(1.0f / scaleFactor, 1.0f / scaleFactor);
 
-		// update layout
+		if (cursorPixels != null)
+			applyScaledCursor();
+
 		requestLayout();
 	}
 
@@ -371,11 +377,27 @@ public class SessionView extends View
 	{
 		if (pixels == null || width == 0 || height == 0)
 		{
+			cursorPixels = null;
 			setPointerIcon(PointerIcon.getSystemIcon(getContext(), PointerIcon.TYPE_NULL));
 			return;
 		}
-		Bitmap bm = Bitmap.createBitmap(pixels, width, height, Bitmap.Config.ARGB_8888);
-		PointerIcon icon = PointerIcon.create(bm, hotX, hotY);
+		cursorPixels = pixels;
+		cursorWidth = width;
+		cursorHeight = height;
+		cursorHotX = hotX;
+		cursorHotY = hotY;
+		applyScaledCursor();
+	}
+
+	private void applyScaledCursor()
+	{
+		int scaledWidth = Math.max(1, (int)(cursorWidth * scaleFactor));
+		int scaledHeight = Math.max(1, (int)(cursorHeight * scaleFactor));
+		Bitmap bm =
+		    Bitmap.createBitmap(cursorPixels, cursorWidth, cursorHeight, Bitmap.Config.ARGB_8888);
+		Bitmap scaled = Bitmap.createScaledBitmap(bm, scaledWidth, scaledHeight, true);
+		PointerIcon icon =
+		    PointerIcon.create(scaled, cursorHotX * scaleFactor, cursorHotY * scaleFactor);
 		setPointerIcon(icon);
 	}
 

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
@@ -25,6 +25,7 @@ import android.util.Log;
 import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
+import android.view.PointerIcon;
 import android.view.ScaleGestureDetector;
 import android.view.View;
 import android.view.inputmethod.BaseInputConnection;
@@ -364,6 +365,23 @@ public class SessionView extends View
 		void onSessionViewScroll(boolean down);
 
 		void onSessionViewHScroll(boolean right);
+	}
+
+	public void setRemoteCursor(int[] pixels, int width, int height, int hotX, int hotY)
+	{
+		if (pixels == null || width == 0 || height == 0)
+		{
+			setPointerIcon(PointerIcon.getSystemIcon(getContext(), PointerIcon.TYPE_NULL));
+			return;
+		}
+		Bitmap bm = Bitmap.createBitmap(pixels, width, height, Bitmap.Config.ARGB_8888);
+		PointerIcon icon = PointerIcon.create(bm, hotX, hotY);
+		setPointerIcon(icon);
+	}
+
+	public void setDefaultCursor()
+	{
+		setPointerIcon(PointerIcon.getSystemIcon(getContext(), PointerIcon.TYPE_ARROW));
 	}
 
 	private class SessionGestureListener extends GestureDetector.SimpleOnGestureListener

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -661,6 +661,37 @@ public class LibFreeRDP
 			uiEventListener.OnRemoteClipboardChanged(data);
 	}
 
+	private static void OnPointerSet(long inst, int[] pixels, int width, int height, int hotX,
+	                                 int hotY)
+	{
+		SessionState s = GlobalApp.getSession(inst);
+		if (s == null)
+			return;
+		UIEventListener uiEventListener = s.getUIEventListener();
+		if (uiEventListener != null)
+			uiEventListener.OnPointerSet(pixels, width, height, hotX, hotY);
+	}
+
+	private static void OnPointerSetNull(long inst)
+	{
+		SessionState s = GlobalApp.getSession(inst);
+		if (s == null)
+			return;
+		UIEventListener uiEventListener = s.getUIEventListener();
+		if (uiEventListener != null)
+			uiEventListener.OnPointerSetNull();
+	}
+
+	private static void OnPointerSetDefault(long inst)
+	{
+		SessionState s = GlobalApp.getSession(inst);
+		if (s == null)
+			return;
+		UIEventListener uiEventListener = s.getUIEventListener();
+		if (uiEventListener != null)
+			uiEventListener.OnPointerSetDefault();
+	}
+
 	public static String getVersion()
 	{
 		return freerdp_get_version();
@@ -701,5 +732,11 @@ public class LibFreeRDP
 		void OnGraphicsResize(int width, int height, int bpp);
 
 		void OnRemoteClipboardChanged(String data);
+
+		void OnPointerSet(int[] pixels, int width, int height, int hotX, int hotY);
+
+		void OnPointerSetNull();
+
+		void OnPointerSetDefault();
 	}
 }


### PR DESCRIPTION
## Overview

Adds full hardware mouse pointer support for the Android client. The remote
cursor sent by the server is now rendered as a native Android PointerIcon,
replacing the previous no-op stub implementation.

- Resolve #2925
- Resolve #10812


### Key Changes

- **Pointer rendering:** Implemented `android_Pointer_New/Free/Set` using a
  custom `androidPointer` struct that allocates and stores cursor bitmap data
  via `freerdp_image_copy_from_pointer_data`.
- **JNI callbacks:** Added `OnPointerSet`, `OnPointerSetNull`, and
  `OnPointerSetDefault` JNI callbacks to propagate cursor changes to the Java
  layer. `SetNull` hides the cursor (`TYPE_NULL`), `SetDefault` restores the
  arrow (`TYPE_ARROW`).
- **Zoom scaling:** The cursor bitmap is scaled with the session zoom factor.
  When the user pinches to zoom in or out, the cursor resizes proportionally.

### How to Test

1. Connect to a remote Windows session with a physical mouse.
2. Verify the cursor shape changes (arrow, resize handles, text cursor, etc.).
3. Zoom in and out, confirm the cursor scales with the content.
4. Verify `SetNull`/`SetDefault` by opening a full-screen app on the remote.

### Environments Tested

- Physical Device: Android 16 (API 36)

https://github.com/user-attachments/assets/13507f2e-e1a8-4e68-afe4-781780e2c445

