### PR TITLE
[client,android] improve physical keyboard and touchpad input handling

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
@@ -969,6 +969,21 @@ Java_com_freerdp_freerdpcore_services_LibFreeRDP_freerdp_1send_1unicodekey_1even
 }
 
 JNIEXPORT jboolean JNICALL
+Java_com_freerdp_freerdpcore_services_LibFreeRDP_freerdp_1is_1unicode_1input_1supported(
+    JNIEnv* env, jclass cls, jlong instance)
+{
+	freerdp* inst = (freerdp*)instance;
+
+	if (!inst || !inst->context || !inst->context->settings)
+		return JNI_FALSE;
+
+	if (!freerdp_settings_get_bool(inst->context->settings, FreeRDP_UnicodeInput))
+		return JNI_FALSE;
+
+	return JNI_TRUE;
+}
+
+JNIEXPORT jboolean JNICALL
 Java_com_freerdp_freerdpcore_services_LibFreeRDP_freerdp_1send_1cursor_1event(
     JNIEnv* env, jclass cls, jlong instance, jint x, jint y, jint flags)
 {

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ScrollView2D.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ScrollView2D.java
@@ -25,7 +25,6 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.view.FocusFinder;
-import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.VelocityTracker;
 import android.view.View;
@@ -266,92 +265,6 @@ public class ScrollView2D extends FrameLayout
 			    (getWidth() < childWidth + getPaddingLeft() + getPaddingRight());
 		}
 		return false;
-	}
-
-	@Override public boolean dispatchKeyEvent(KeyEvent event)
-	{
-		// Let the focused view and/or our descendants get the key first
-		boolean handled = super.dispatchKeyEvent(event);
-		if (handled)
-		{
-			return true;
-		}
-		return executeKeyEvent(event);
-	}
-
-	/**
-	 * You can call this function yourself to have the scroll view perform
-	 * scrolling from a key event, just as if the event had been dispatched to
-	 * it by the view hierarchy.
-	 *
-	 * @param event The key event to execute.
-	 * @return Return true if the event was handled, else false.
-	 */
-	public boolean executeKeyEvent(KeyEvent event)
-	{
-		mTempRect.setEmpty();
-		if (!canScroll())
-		{
-			if (isFocused())
-			{
-				View currentFocused = findFocus();
-				if (currentFocused == this)
-					currentFocused = null;
-				View nextFocused =
-				    FocusFinder.getInstance().findNextFocus(this, currentFocused, View.FOCUS_DOWN);
-				return nextFocused != null && nextFocused != this &&
-				    nextFocused.requestFocus(View.FOCUS_DOWN);
-			}
-			return false;
-		}
-		boolean handled = false;
-		if (event.getAction() == KeyEvent.ACTION_DOWN)
-		{
-			switch (event.getKeyCode())
-			{
-				case KeyEvent.KEYCODE_DPAD_UP:
-					if (!event.isAltPressed())
-					{
-						handled = arrowScroll(View.FOCUS_UP, false);
-					}
-					else
-					{
-						handled = fullScroll(View.FOCUS_UP, false);
-					}
-					break;
-				case KeyEvent.KEYCODE_DPAD_DOWN:
-					if (!event.isAltPressed())
-					{
-						handled = arrowScroll(View.FOCUS_DOWN, false);
-					}
-					else
-					{
-						handled = fullScroll(View.FOCUS_DOWN, false);
-					}
-					break;
-				case KeyEvent.KEYCODE_DPAD_LEFT:
-					if (!event.isAltPressed())
-					{
-						handled = arrowScroll(View.FOCUS_LEFT, true);
-					}
-					else
-					{
-						handled = fullScroll(View.FOCUS_LEFT, true);
-					}
-					break;
-				case KeyEvent.KEYCODE_DPAD_RIGHT:
-					if (!event.isAltPressed())
-					{
-						handled = arrowScroll(View.FOCUS_RIGHT, true);
-					}
-					else
-					{
-						handled = fullScroll(View.FOCUS_RIGHT, true);
-					}
-					break;
-			}
-		}
-		return handled;
 	}
 
 	@Override public boolean onInterceptTouchEvent(MotionEvent ev)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionInputManager.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionInputManager.java
@@ -517,8 +517,13 @@ public class SessionInputManager
 	{
 		if (instance == 0)
 			return;
-		LibFreeRDP.sendUnicodeKeyEvent(instance, unicodeKey, true);
-		LibFreeRDP.sendUnicodeKeyEvent(instance, unicodeKey, false);
+		if (LibFreeRDP.isUnicodeInputSupported(instance))
+		{
+			LibFreeRDP.sendUnicodeKeyEvent(instance, unicodeKey, true);
+			LibFreeRDP.sendUnicodeKeyEvent(instance, unicodeKey, false);
+		}
+		else
+			keyboardMapper.processUnicodeFallback(unicodeKey);
 	}
 
 	@Override public void switchKeyboard(int keyboardType)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
@@ -302,13 +302,15 @@ public class SessionView extends View
 	// Handle all physical mouse buttons here; finger taps come via onSingleTapUp.
 	@Override public boolean onGenericMotionEvent(MotionEvent event)
 	{
-		if (!event.isFromSource(InputDevice.SOURCE_MOUSE))
+		final boolean isPointer = event.isFromSource(InputDevice.SOURCE_CLASS_POINTER);
+		if (!isPointer)
 			return false;
 
+		final boolean isMouse = event.isFromSource(InputDevice.SOURCE_MOUSE);
 		int action = event.getActionMasked();
 
-		if (action == MotionEvent.ACTION_BUTTON_PRESS ||
-		    action == MotionEvent.ACTION_BUTTON_RELEASE)
+		if (isMouse && (action == MotionEvent.ACTION_BUTTON_PRESS ||
+		                action == MotionEvent.ACTION_BUTTON_RELEASE))
 		{
 			boolean down = action == MotionEvent.ACTION_BUTTON_PRESS;
 			MotionEvent mapped = mapTouchEvent(event);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -151,6 +151,8 @@ public class LibFreeRDP
 	private static native boolean freerdp_send_unicodekey_event(long inst, int keycode,
 	                                                            boolean down);
 
+	private static native boolean freerdp_is_unicode_input_supported(long inst);
+
 	private static native boolean freerdp_send_clipboard_data(long inst, String data);
 
 	private static native String freerdp_get_last_error_string(long inst);
@@ -514,6 +516,11 @@ public class LibFreeRDP
 	public static boolean sendUnicodeKeyEvent(long inst, int keycode, boolean down)
 	{
 		return freerdp_send_unicodekey_event(inst, keycode, down);
+	}
+
+	public static boolean isUnicodeInputSupported(long inst)
+	{
+		return freerdp_is_unicode_input_supported(inst);
 	}
 
 	public static boolean sendClipboardData(long inst, String data)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/KeyboardMapper.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/KeyboardMapper.java
@@ -11,6 +11,7 @@
 package com.freerdp.freerdpcore.utils;
 
 import android.content.Context;
+import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 
 import com.freerdp.freerdpcore.R;
@@ -276,37 +277,72 @@ public class KeyboardMapper
 		keymapAndroid[KeyEvent.KEYCODE_ENTER] = VK_RETURN;
 		keymapAndroid[KeyEvent.KEYCODE_SPACE] = VK_SPACE;
 		keymapAndroid[KeyEvent.KEYCODE_TAB] = VK_TAB;
+		keymapAndroid[KeyEvent.KEYCODE_ESCAPE] = VK_ESCAPE;
+		keymapAndroid[KeyEvent.KEYCODE_CAPS_LOCK] = VK_CAPITAL;
 		//		keymapAndroid[KeyEvent.KEYCODE_SHIFT_LEFT] = VK_LSHIFT;
 		//		keymapAndroid[KeyEvent.KEYCODE_SHIFT_RIGHT] = VK_RSHIFT;
 
-		//		keymapAndroid[KeyEvent.KEYCODE_DPAD_DOWN] = VK_DOWN;
-		//		keymapAndroid[KeyEvent.KEYCODE_DPAD_LEFT] = VK_LEFT;
-		//		keymapAndroid[KeyEvent.KEYCODE_DPAD_RIGHT] = VK_RIGHT;
-		//		keymapAndroid[KeyEvent.KEYCODE_DPAD_UP] = VK_UP;
+		keymapAndroid[KeyEvent.KEYCODE_DPAD_DOWN] = VK_DOWN | VK_EXT_KEY;
+		keymapAndroid[KeyEvent.KEYCODE_DPAD_LEFT] = VK_LEFT | VK_EXT_KEY;
+		keymapAndroid[KeyEvent.KEYCODE_DPAD_RIGHT] = VK_RIGHT | VK_EXT_KEY;
+		keymapAndroid[KeyEvent.KEYCODE_DPAD_UP] = VK_UP | VK_EXT_KEY;
+		keymapAndroid[KeyEvent.KEYCODE_MOVE_HOME] = VK_HOME | VK_EXT_KEY;
+		keymapAndroid[KeyEvent.KEYCODE_MOVE_END] = VK_END | VK_EXT_KEY;
+		keymapAndroid[KeyEvent.KEYCODE_PAGE_UP] = VK_PRIOR | VK_EXT_KEY;
+		keymapAndroid[KeyEvent.KEYCODE_PAGE_DOWN] = VK_NEXT | VK_EXT_KEY;
+		keymapAndroid[KeyEvent.KEYCODE_FORWARD_DEL] = VK_DELETE | VK_EXT_KEY;
+		keymapAndroid[KeyEvent.KEYCODE_INSERT] = VK_INSERT | VK_EXT_KEY;
 
-		//		keymapAndroid[KeyEvent.KEYCODE_COMMA] = VK_OEM_COMMA;
-		//		keymapAndroid[KeyEvent.KEYCODE_PERIOD] = VK_OEM_PERIOD;
-		//		keymapAndroid[KeyEvent.KEYCODE_MINUS] = VK_OEM_MINUS;
-		//		keymapAndroid[KeyEvent.KEYCODE_PLUS] = VK_OEM_PLUS;
+		keymapAndroid[KeyEvent.KEYCODE_MINUS] = VK_OEM_MINUS;
+		keymapAndroid[KeyEvent.KEYCODE_EQUALS] = VK_OEM_PLUS;
+		keymapAndroid[KeyEvent.KEYCODE_LEFT_BRACKET] = VK_OEM_4;
+		keymapAndroid[KeyEvent.KEYCODE_RIGHT_BRACKET] = VK_OEM_6;
+		keymapAndroid[KeyEvent.KEYCODE_BACKSLASH] = VK_OEM_5;
+		keymapAndroid[KeyEvent.KEYCODE_SEMICOLON] = VK_OEM_1;
+		keymapAndroid[KeyEvent.KEYCODE_APOSTROPHE] = VK_OEM_7;
+		keymapAndroid[KeyEvent.KEYCODE_GRAVE] = VK_OEM_3;
+		keymapAndroid[KeyEvent.KEYCODE_COMMA] = VK_OEM_COMMA;
+		keymapAndroid[KeyEvent.KEYCODE_PERIOD] = VK_OEM_PERIOD;
+		keymapAndroid[KeyEvent.KEYCODE_SLASH] = VK_OEM_2;
 
-		//		keymapAndroid[KeyEvent.KEYCODE_ALT_LEFT] = VK_LMENU;
-		//		keymapAndroid[KeyEvent.KEYCODE_ALT_RIGHT] = VK_RMENU;
+		keymapAndroid[KeyEvent.KEYCODE_F1] = VK_F1;
+		keymapAndroid[KeyEvent.KEYCODE_F2] = VK_F2;
+		keymapAndroid[KeyEvent.KEYCODE_F3] = VK_F3;
+		keymapAndroid[KeyEvent.KEYCODE_F4] = VK_F4;
+		keymapAndroid[KeyEvent.KEYCODE_F5] = VK_F5;
+		keymapAndroid[KeyEvent.KEYCODE_F6] = VK_F6;
+		keymapAndroid[KeyEvent.KEYCODE_F7] = VK_F7;
+		keymapAndroid[KeyEvent.KEYCODE_F8] = VK_F8;
+		keymapAndroid[KeyEvent.KEYCODE_F9] = VK_F9;
+		keymapAndroid[KeyEvent.KEYCODE_F10] = VK_F10;
+		keymapAndroid[KeyEvent.KEYCODE_F11] = VK_F11;
+		keymapAndroid[KeyEvent.KEYCODE_F12] = VK_F12;
 
-		//		keymapAndroid[KeyEvent.KEYCODE_AT] = (KEY_FLAG_UNICODE | 64);
-		//		keymapAndroid[KeyEvent.KEYCODE_APOSTROPHE] = (KEY_FLAG_UNICODE | 39);
-		//		keymapAndroid[KeyEvent.KEYCODE_BACKSLASH] = (KEY_FLAG_UNICODE | 92);
-		//		keymapAndroid[KeyEvent.KEYCODE_COMMA] = (KEY_FLAG_UNICODE | 44);
-		//		keymapAndroid[KeyEvent.KEYCODE_EQUALS] = (KEY_FLAG_UNICODE | 61);
-		//		keymapAndroid[KeyEvent.KEYCODE_GRAVE] = (KEY_FLAG_UNICODE | 96);
-		//		keymapAndroid[KeyEvent.KEYCODE_LEFT_BRACKET] = (KEY_FLAG_UNICODE | 91);
-		//		keymapAndroid[KeyEvent.KEYCODE_RIGHT_BRACKET] = (KEY_FLAG_UNICODE | 93);
-		//		keymapAndroid[KeyEvent.KEYCODE_MINUS] = (KEY_FLAG_UNICODE | 45);
-		//		keymapAndroid[KeyEvent.KEYCODE_PERIOD] = (KEY_FLAG_UNICODE | 46);
-		//		keymapAndroid[KeyEvent.KEYCODE_PLUS] = (KEY_FLAG_UNICODE | 43);
-		//		keymapAndroid[KeyEvent.KEYCODE_POUND] = (KEY_FLAG_UNICODE | 35);
-		//		keymapAndroid[KeyEvent.KEYCODE_SEMICOLON] = (KEY_FLAG_UNICODE | 59);
-		//		keymapAndroid[KeyEvent.KEYCODE_SLASH] = (KEY_FLAG_UNICODE | 47);
-		//		keymapAndroid[KeyEvent.KEYCODE_STAR] = (KEY_FLAG_UNICODE | 42);
+		keymapAndroid[KeyEvent.KEYCODE_NUM_LOCK] = VK_NUMLOCK;
+		keymapAndroid[KeyEvent.KEYCODE_SCROLL_LOCK] = VK_SCROLL;
+		keymapAndroid[KeyEvent.KEYCODE_SYSRQ] = VK_SNAPSHOT | VK_EXT_KEY;
+		keymapAndroid[KeyEvent.KEYCODE_BREAK] = VK_PAUSE;
+
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_0] = VK_NUMPAD0;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_1] = VK_NUMPAD1;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_2] = VK_NUMPAD2;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_3] = VK_NUMPAD3;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_4] = VK_NUMPAD4;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_5] = VK_NUMPAD5;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_6] = VK_NUMPAD6;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_7] = VK_NUMPAD7;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_8] = VK_NUMPAD8;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_9] = VK_NUMPAD9;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_DIVIDE] = VK_DIVIDE | VK_EXT_KEY;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_MULTIPLY] = VK_MULTIPLY;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_SUBTRACT] = VK_SUBTRACT;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_ADD] = VK_ADD;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_DOT] = VK_DECIMAL;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_COMMA] = VK_DECIMAL;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_ENTER] = VK_RETURN | VK_EXT_KEY;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_EQUALS] = KEY_FLAG_UNICODE | 61;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_LEFT_PAREN] = KEY_FLAG_UNICODE | 40;
+		keymapAndroid[KeyEvent.KEYCODE_NUMPAD_RIGHT_PAREN] = KEY_FLAG_UNICODE | 41;
 
 		// special keys mapping
 		keymapExt = new int[256];
@@ -439,12 +475,36 @@ public class KeyboardMapper
 					listener.processUnicodeKey(vkcode & (~KEY_FLAG_UNICODE));
 				// if we got a valid vkcode send it - except for letters/numbers if a modifier is
 				// active
-				else if (vkcode > 0 &&
-				         (event.getMetaState() & (KeyEvent.META_ALT_ON | KeyEvent.META_SHIFT_ON |
-				                                  KeyEvent.META_SYM_ON)) == 0)
+				else if (vkcode > 0 && (event.getMetaState() &
+				                        (KeyEvent.META_ALT_ON | KeyEvent.META_SHIFT_ON |
+				                         KeyEvent.META_SYM_ON | KeyEvent.META_CTRL_ON)) == 0)
 				{
 					listener.processVirtualKey(vkcode, true);
 					listener.processVirtualKey(vkcode, false);
+				}
+				else if (vkcode > 0 && !ctrlPressed &&
+				         (event.getMetaState() & KeyEvent.META_CTRL_ON) != 0)
+				{
+					listener.processVirtualKey(VK_LCONTROL, true);
+					listener.processVirtualKey(vkcode, true);
+					listener.processVirtualKey(vkcode, false);
+					listener.processVirtualKey(VK_LCONTROL, false);
+				}
+				else if (vkcode > 0 && !altPressed &&
+				         (event.getMetaState() & KeyEvent.META_ALT_ON) != 0)
+				{
+					listener.processVirtualKey(VK_LMENU, true);
+					listener.processVirtualKey(vkcode, true);
+					listener.processVirtualKey(vkcode, false);
+					listener.processVirtualKey(VK_LMENU, false);
+				}
+				else if (vkcode > 0 && !winPressed &&
+				         (event.getMetaState() & KeyEvent.META_META_ON) != 0)
+				{
+					listener.processVirtualKey(VK_LWIN | VK_EXT_KEY, true);
+					listener.processVirtualKey(vkcode, true);
+					listener.processVirtualKey(vkcode, false);
+					listener.processVirtualKey(VK_LWIN | VK_EXT_KEY, false);
 				}
 				else if (event.isShiftPressed() && vkcode != 0)
 				{
@@ -509,6 +569,38 @@ public class KeyboardMapper
 		}
 
 		resetModifierKeysAfterInput(false);
+	}
+
+	public void processUnicodeFallback(int unicodeKey)
+	{
+		KeyCharacterMap kcm = KeyCharacterMap.load(KeyCharacterMap.VIRTUAL_KEYBOARD);
+		KeyEvent[] events = kcm.getEvents(new char[] { (char)unicodeKey });
+		if (events == null)
+			return;
+		for (KeyEvent event : events)
+		{
+			int vkcode = fallbackVkcode(event.getKeyCode());
+			if (vkcode > 0)
+				listener.processVirtualKey(vkcode, event.getAction() == KeyEvent.ACTION_DOWN);
+		}
+	}
+
+	private int fallbackVkcode(int keycode)
+	{
+		switch (keycode)
+		{
+			case KeyEvent.KEYCODE_SHIFT_LEFT:
+			case KeyEvent.KEYCODE_SHIFT_RIGHT:
+				return VK_LSHIFT;
+			case KeyEvent.KEYCODE_ALT_LEFT:
+			case KeyEvent.KEYCODE_ALT_RIGHT:
+				return VK_LMENU;
+			case KeyEvent.KEYCODE_CTRL_LEFT:
+			case KeyEvent.KEYCODE_CTRL_RIGHT:
+				return VK_LCONTROL;
+			default:
+				return getVirtualKeyCode(keycode);
+		}
 	}
 
 	public void sendAltF4()


### PR DESCRIPTION
## Summary

Fixes physical keyboard and touchpad input for Android clients

- Map punctuation keys (`[]{}|;'\`,./-=`) to correct `VK_OEM_*` scancodes
- Add system keys: NumLock, ScrollLock, PrintScreen, Pause/Break
- Add physical numpad keys to scancode map
- Add F1–F12 key support
- Add Ctrl+key, Alt+key combinations (e.g. Alt+F4, Ctrl+C)
- Fix `@` typing `2`, `#` typing `3`  modifier keys in unicode fallback were silently dropped
- Fix two-finger touchpad scroll  was blocked by `SOURCE_MOUSE` check, now uses `SOURCE_CLASS_POINTER`
- Add `isUnicodeInputSupported()` check  use unicode when server supports it, scancode fallback otherwise
---
- Fixes  #4317 
- Fixes #1369
- Fixes  #3805
- Fixes #3561

## How to Test

Connect to an RDP session with a physical keyboard and touchpad.
- Type punctuation: `[]{}@#$%^&*()`
- Test Ctrl+C, Ctrl+V, Alt+F4 and other shortcuts
- Test F1–F12 keys
- Test numpad keys
- Two-finger scroll on the touchpad
- Connect to a non-unicode server (e.g. VirtualBox RDP) and verify punctuation still works

## Environments Tested

- Physical Device: Android 16 (API 36)
- Keyboard: Logitech MX Keys Mini (USB, no numpad)