### PR TITLE
[client,android] add dynamic display resize, UI scaling, and vmconnect support

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/cpp/CMakeLists.txt
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/CMakeLists.txt
@@ -117,6 +117,8 @@ include(ExternalFreeRDP)
 set(${MODULE_PREFIX}_SRCS
     android_cliprdr.c
     android_cliprdr.h
+    android_disp.c
+    android_disp.h
     android_event.c
     android_event.h
     android_freerdp.c

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_disp.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_disp.c
@@ -48,6 +48,8 @@ BOOL android_disp_send_monitor_layout(androidContext* afc, UINT32 width, UINT32 
 		return FALSE;
 	}
 
+	rdpSettings* settings = afc->common.context.settings;
+
 	DISPLAY_CONTROL_MONITOR_LAYOUT layout = WINPR_C_ARRAY_INIT;
 	layout.Flags = DISPLAY_CONTROL_MONITOR_PRIMARY;
 	layout.Top = layout.Left = 0;
@@ -55,9 +57,9 @@ BOOL android_disp_send_monitor_layout(androidContext* afc, UINT32 width, UINT32 
 	layout.Height = height;
 	layout.PhysicalWidth = 0;
 	layout.PhysicalHeight = 0;
-	layout.Orientation = ORIENTATION_LANDSCAPE;
-	layout.DesktopScaleFactor = 100;
-	layout.DeviceScaleFactor = 100;
+	layout.Orientation = freerdp_settings_get_uint16(settings, FreeRDP_DesktopOrientation);
+	layout.DesktopScaleFactor = freerdp_settings_get_uint32(settings, FreeRDP_DesktopScaleFactor);
+	layout.DeviceScaleFactor = freerdp_settings_get_uint32(settings, FreeRDP_DeviceScaleFactor);
 
 	UINT rc = disp->SendMonitorLayout(disp, 1, &layout);
 	if (rc != CHANNEL_RC_OK)

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_disp.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_disp.c
@@ -1,0 +1,71 @@
+/*
+   Android Display Update Virtual Channel
+
+*/
+
+#include <freerdp/config.h>
+
+#include <winpr/assert.h>
+#include <winpr/wlog.h>
+
+#include <freerdp/channels/disp.h>
+#include <freerdp/client/disp.h>
+
+#include "android_disp.h"
+
+#define TAG CLIENT_TAG("android.disp")
+
+BOOL android_disp_init(androidContext* afc, DispClientContext* disp)
+{
+	WINPR_ASSERT(afc);
+	WINPR_ASSERT(disp);
+
+	afc->disp = disp;
+	disp->custom = afc;
+
+	WLog_DBG(TAG, "disp channel connected");
+	return TRUE;
+}
+
+BOOL android_disp_uninit(androidContext* afc, DispClientContext* disp)
+{
+	WINPR_ASSERT(afc);
+	WINPR_UNUSED(disp);
+
+	afc->disp = NULL;
+	WLog_DBG(TAG, "disp channel disconnected");
+	return TRUE;
+}
+
+BOOL android_disp_send_monitor_layout(androidContext* afc, UINT32 width, UINT32 height)
+{
+	WINPR_ASSERT(afc);
+
+	DispClientContext* disp = afc->disp;
+	if (!disp || !disp->SendMonitorLayout)
+	{
+		WLog_WARN(TAG, "disp channel not available");
+		return FALSE;
+	}
+
+	DISPLAY_CONTROL_MONITOR_LAYOUT layout = WINPR_C_ARRAY_INIT;
+	layout.Flags = DISPLAY_CONTROL_MONITOR_PRIMARY;
+	layout.Top = layout.Left = 0;
+	layout.Width = width;
+	layout.Height = height;
+	layout.PhysicalWidth = 0;
+	layout.PhysicalHeight = 0;
+	layout.Orientation = ORIENTATION_LANDSCAPE;
+	layout.DesktopScaleFactor = 100;
+	layout.DeviceScaleFactor = 100;
+
+	UINT rc = disp->SendMonitorLayout(disp, 1, &layout);
+	if (rc != CHANNEL_RC_OK)
+	{
+		WLog_ERR(TAG, "SendMonitorLayout failed: %" PRIu32, rc);
+		return FALSE;
+	}
+
+	WLog_DBG(TAG, "SendMonitorLayout: %" PRIu32 "x%" PRIu32, width, height);
+	return TRUE;
+}

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_disp.h
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_disp.h
@@ -1,0 +1,19 @@
+/*
+   Android Display Update Virtual Channel
+
+*/
+
+#ifndef FREERDP_CLIENT_ANDROID_DISP_H
+#define FREERDP_CLIENT_ANDROID_DISP_H
+
+#include <freerdp/client/disp.h>
+#include <freerdp/api.h>
+
+#include "android_freerdp.h"
+
+FREERDP_LOCAL BOOL android_disp_init(androidContext* afc, DispClientContext* disp);
+FREERDP_LOCAL BOOL android_disp_uninit(androidContext* afc, DispClientContext* disp);
+FREERDP_LOCAL BOOL android_disp_send_monitor_layout(androidContext* afc, UINT32 width,
+                                                    UINT32 height);
+
+#endif /* FREERDP_CLIENT_ANDROID_DISP_H */

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
@@ -47,6 +47,7 @@
 #include "android_jni_callback.h"
 #include "android_jni_utils.h"
 #include "android_cliprdr.h"
+#include "android_disp.h"
 #include "android_freerdp_jni.h"
 
 #if defined(WITH_GPROF)
@@ -79,6 +80,10 @@ static void android_OnChannelConnectedEventHandler(void* context,
 	{
 		android_cliprdr_init(afc, (CliprdrClientContext*)e->pInterface);
 	}
+	else if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) == 0)
+	{
+		android_disp_init(afc, (DispClientContext*)e->pInterface);
+	}
 	else
 		freerdp_client_OnChannelConnectedEventHandler(context, e);
 }
@@ -101,6 +106,10 @@ static void android_OnChannelDisconnectedEventHandler(void* context,
 	if (strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0)
 	{
 		android_cliprdr_uninit(afc, (CliprdrClientContext*)e->pInterface);
+	}
+	else if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) == 0)
+	{
+		android_disp_uninit(afc, (DispClientContext*)e->pInterface);
 	}
 	else
 		freerdp_client_OnChannelDisconnectedEventHandler(context, e);
@@ -176,9 +185,13 @@ static BOOL android_desktop_resize(rdpContext* context)
 	WINPR_ASSERT(context->settings);
 	WINPR_ASSERT(context->instance);
 
-	freerdp_callback("OnGraphicsResize", "(JIII)V", (jlong)context->instance,
-	                 freerdp_settings_get_uint32(context->settings, FreeRDP_DesktopWidth),
-	                 freerdp_settings_get_uint32(context->settings, FreeRDP_DesktopHeight),
+	const UINT32 width = freerdp_settings_get_uint32(context->settings, FreeRDP_DesktopWidth);
+	const UINT32 height = freerdp_settings_get_uint32(context->settings, FreeRDP_DesktopHeight);
+
+	if (context->gdi && !gdi_resize(context->gdi, width, height))
+		return FALSE;
+
+	freerdp_callback("OnGraphicsResize", "(JIII)V", (jlong)context->instance, width, height,
 	                 freerdp_settings_get_uint32(context->settings, FreeRDP_ColorDepth));
 	return TRUE;
 }
@@ -1019,6 +1032,22 @@ out_fail:
 		(*env)->ReleaseStringUTFChars(env, jdata, data);
 
 	return ret;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_freerdp_freerdpcore_services_LibFreeRDP_freerdp_1send_1monitor_1layout(
+    JNIEnv* env, jclass cls, jlong instance, jint width, jint height)
+{
+	WINPR_UNUSED(env);
+	WINPR_UNUSED(cls);
+	freerdp* inst = (freerdp*)instance;
+
+	if (!inst || !inst->context)
+		return JNI_FALSE;
+
+	androidContext* afc = (androidContext*)inst->context;
+	return android_disp_send_monitor_layout(afc, (UINT32)width, (UINT32)height) ? JNI_TRUE
+	                                                                            : JNI_FALSE;
 }
 
 JNIEXPORT jstring JNICALL

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.h
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.h
@@ -18,6 +18,7 @@
 
 #include <freerdp/freerdp.h>
 #include <freerdp/client/cliprdr.h>
+#include <freerdp/client/disp.h>
 
 #include "android_event.h"
 
@@ -38,6 +39,8 @@ typedef struct
 	CLIPRDR_FORMAT* serverFormats;
 	CliprdrClientContext* cliprdr;
 	UINT32 clipboardCapabilities;
+
+	DispClientContext* disp;
 } androidContext;
 
 #endif /* FREERDP_CLIENT_ANDROID_FREERDP_H */

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
@@ -27,7 +27,7 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory;
           exportSchema = false)
 public abstract class AppDatabase extends RoomDatabase
 {
-	static final int DB_VERSION = 14;
+	static final int DB_VERSION = 15;
 	private static final String DB_NAME = "bookmarks.db";
 
 	static
@@ -57,6 +57,7 @@ public abstract class AppDatabase extends RoomDatabase
 					               .addMigrations(MIGRATION_11_12)
 					               .addMigrations(MIGRATION_12_13)
 					               .addMigrations(MIGRATION_13_14)
+					               .addMigrations(MIGRATION_14_15)
 					               .build();
 				}
 			}
@@ -162,6 +163,18 @@ public abstract class AppDatabase extends RoomDatabase
 			sb.append(String.format(java.util.Locale.US, "%02x", b));
 		return sb.toString();
 	}
+
+	private static final Migration MIGRATION_14_15 = new Migration(14, 15) {
+		@Override public void migrate(@NonNull SupportSQLiteDatabase db)
+		{
+			db.execSQL("ALTER TABLE 'bookmarks' ADD 'scale_mode' TEXT NOT NULL DEFAULT '100';");
+			db.execSQL("ALTER TABLE 'bookmarks' ADD 'scale_desktop' INTEGER NOT NULL DEFAULT 100;");
+			db.execSQL("ALTER TABLE 'bookmarks' ADD 'scale_device' INTEGER NOT NULL DEFAULT 100;");
+			db.execSQL(
+			    "ALTER TABLE 'bookmarks' ADD 'vmconnect_mode' INTEGER NOT NULL DEFAULT false;");
+			db.execSQL("ALTER TABLE 'bookmarks' ADD 'vmconnect_guid' TEXT NOT NULL DEFAULT '';");
+		}
+	};
 
 	private static final Migration MIGRATION_13_14 = new Migration(13, 14) {
 		@Override public void migrate(@NonNull SupportSQLiteDatabase db)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkConverter.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkConverter.java
@@ -27,6 +27,7 @@ public final class BookmarkConverter
 		screen.setResolution(e.resolution);
 		screen.setWidth(e.width);
 		screen.setHeight(e.height);
+		screen.setScale(e.scaleMode, e.scaleDesktop, e.scaleDevice);
 
 		BookmarkBase.PerformanceFlags perf = bm.getPerformanceFlags();
 		perf.setRemoteFX(e.perfRemoteFx);
@@ -50,6 +51,8 @@ public final class BookmarkConverter
 		adv.setConsoleMode(e.consoleMode);
 		adv.setTlsSecLevel(e.tlsSecLevel);
 		adv.setTlsMinLevel(e.tlsMinLevel);
+		adv.setVmConnectMode(e.vmConnectMode);
+		adv.setVmConnectGuid(e.vmConnectGuid);
 
 		bm.setEnableGatewaySettings(e.enableGatewaySettings);
 		BookmarkBase.GatewaySettings gw = bm.getGatewaySettings();
@@ -86,6 +89,9 @@ public final class BookmarkConverter
 		e.resolution = screen.getResolution();
 		e.width = screen.getWidth();
 		e.height = screen.getHeight();
+		e.scaleMode = screen.getScaleMode();
+		e.scaleDesktop = screen.getScaleDesktop();
+		e.scaleDevice = screen.getScaleDevice();
 
 		BookmarkBase.PerformanceFlags perf = bm.getPerformanceFlags();
 		e.perfRemoteFx = perf.getRemoteFX();
@@ -109,6 +115,8 @@ public final class BookmarkConverter
 		e.consoleMode = adv.getConsoleMode();
 		e.tlsSecLevel = adv.getTlsSecLevel();
 		e.tlsMinLevel = adv.getTlsMinLevel();
+		e.vmConnectMode = adv.getVmConnectMode();
+		e.vmConnectGuid = adv.getVmConnectGuid();
 
 		e.enableGatewaySettings = bm.getEnableGatewaySettings();
 		BookmarkBase.GatewaySettings gw = bm.getGatewaySettings();

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkEntity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkEntity.java
@@ -32,6 +32,12 @@ import androidx.room.PrimaryKey;
 
 	@ColumnInfo(name = "height", defaultValue = "0") public int height = 0;
 
+	@NonNull @ColumnInfo(name = "scale_mode", defaultValue = "100") public String scaleMode = "100";
+
+	@ColumnInfo(name = "scale_desktop", defaultValue = "100") public int scaleDesktop = 100;
+
+	@ColumnInfo(name = "scale_device", defaultValue = "100") public int scaleDevice = 100;
+
 	@ColumnInfo(name = "perf_remotefx", defaultValue = "true") public boolean perfRemoteFx = true;
 
 	@ColumnInfo(name = "perf_gfx", defaultValue = "true") public boolean perfGfx = true;
@@ -110,4 +116,11 @@ import androidx.room.PrimaryKey;
 	@ColumnInfo(name = "tlsSecLevel", defaultValue = "-1") public int tlsSecLevel = -1;
 
 	@ColumnInfo(name = "tlsMinLevel", defaultValue = "-1") public int tlsMinLevel = -1;
+
+	@ColumnInfo(name = "vmconnect_mode", defaultValue = "false")
+	public boolean vmConnectMode = false;
+
+	@NonNull
+	@ColumnInfo(name = "vmconnect_guid", defaultValue = "")
+	public String vmConnectGuid = "";
 }

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/domain/BookmarkBase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/domain/BookmarkBase.java
@@ -54,6 +54,8 @@ public class BookmarkBase implements Parcelable, Cloneable
 	private static final String keyRemoteApp = "bookmark.remote_program";
 	private static final String keyWorkDir = "bookmark.work_dir";
 	private static final String keyConsoleMode = "bookmark.console_mode";
+	private static final String keyVmConnectMode = "bookmark.vmconnect_mode";
+	private static final String keyVmConnectGuid = "bookmark.vmconnect_guid";
 
 	private static final String keyAsyncChannel = "bookmark.async_channel";
 	private static final String keyAsyncUpdate = "bookmark.async_update";
@@ -340,6 +342,8 @@ public class BookmarkBase implements Parcelable, Cloneable
 		editor.putString(keyRemoteApp, advancedSettings.getRemoteProgram());
 		editor.putString(keyWorkDir, advancedSettings.getWorkDir());
 		editor.putBoolean(keyConsoleMode, advancedSettings.getConsoleMode());
+		editor.putBoolean(keyVmConnectMode, advancedSettings.getVmConnectMode());
+		editor.putString(keyVmConnectGuid, advancedSettings.getVmConnectGuid());
 
 		editor.putBoolean(keyAsyncChannel, debugSettings.getAsyncChannel());
 		editor.putBoolean(keyAsyncUpdate, debugSettings.getAsyncUpdate());
@@ -394,6 +398,8 @@ public class BookmarkBase implements Parcelable, Cloneable
 		advancedSettings.setRemoteProgram(sharedPrefs.getString(keyRemoteApp, ""));
 		advancedSettings.setWorkDir(sharedPrefs.getString(keyWorkDir, ""));
 		advancedSettings.setConsoleMode(sharedPrefs.getBoolean(keyConsoleMode, false));
+		advancedSettings.setVmConnectMode(sharedPrefs.getBoolean(keyVmConnectMode, false));
+		advancedSettings.setVmConnectGuid(sharedPrefs.getString(keyVmConnectGuid, ""));
 
 		debugSettings.setAsyncChannel(sharedPrefs.getBoolean(keyAsyncChannel, true));
 		debugSettings.setAsyncUpdate(sharedPrefs.getBoolean(keyAsyncUpdate, true));
@@ -921,6 +927,8 @@ public class BookmarkBase implements Parcelable, Cloneable
 		private boolean redirectMicrophone = false;
 		private int security = 0;
 		private boolean consoleMode = false;
+		private boolean vmConnectMode = false;
+		@NonNull private String vmConnectGuid = "";
 
 		@NonNull private String remoteProgram = "";
 
@@ -940,6 +948,8 @@ public class BookmarkBase implements Parcelable, Cloneable
 			redirectMicrophone = parcel.readBoolean();
 			security = parcel.readInt();
 			consoleMode = parcel.readBoolean();
+			vmConnectMode = parcel.readBoolean();
+			vmConnectGuid = Objects.requireNonNull(parcel.readString());
 			remoteProgram = Objects.requireNonNull(parcel.readString());
 			workDir = Objects.requireNonNull(parcel.readString());
 			tlsSecLevel = parcel.readInt();
@@ -1073,6 +1083,26 @@ public class BookmarkBase implements Parcelable, Cloneable
 			this.workDir = workDir;
 		}
 
+		public boolean getVmConnectMode()
+		{
+			return vmConnectMode;
+		}
+
+		public void setVmConnectMode(boolean vmConnectMode)
+		{
+			this.vmConnectMode = vmConnectMode;
+		}
+
+		@NonNull public String getVmConnectGuid()
+		{
+			return vmConnectGuid;
+		}
+
+		public void setVmConnectGuid(@NonNull String vmConnectGuid)
+		{
+			this.vmConnectGuid = vmConnectGuid;
+		}
+
 		@Override public int describeContents()
 		{
 			return 0;
@@ -1086,6 +1116,8 @@ public class BookmarkBase implements Parcelable, Cloneable
 			out.writeBoolean(redirectMicrophone);
 			out.writeInt(security);
 			out.writeBoolean(consoleMode);
+			out.writeBoolean(vmConnectMode);
+			out.writeString(vmConnectGuid);
 			out.writeString(remoteProgram);
 			out.writeString(workDir);
 			out.writeInt(tlsSecLevel);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/domain/BookmarkBase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/domain/BookmarkBase.java
@@ -29,6 +29,9 @@ public class BookmarkBase implements Parcelable, Cloneable
 	private static final String keyColors = "bookmark.colors";
 	private static final String keyResolution = "bookmark.resolution";
 	private static final String keyWidth = "bookmark.width";
+	private static final String keyScaleMode = "bookmark.scale_mode";
+	private static final String keyScaleDesktop = "bookmark.scale_desktop";
+	private static final String keyScaleDevice = "bookmark.scale_device";
 	private static final String keyHeight = "bookmark.height";
 
 	private static final String keyRFX = "bookmark.perf_remotefx";
@@ -312,6 +315,9 @@ public class BookmarkBase implements Parcelable, Cloneable
 		editor.putString(keyResolution, screenSettings.getResolutionString().toLowerCase(locale));
 		editor.putInt(keyWidth, screenSettings.getWidth());
 		editor.putInt(keyHeight, screenSettings.getHeight());
+		editor.putString(keyScaleMode, screenSettings.getScaleMode());
+		editor.putInt(keyScaleDesktop, screenSettings.getScaleDesktop());
+		editor.putInt(keyScaleDevice, screenSettings.getScaleDevice());
 
 		editor.putBoolean(keyRFX, performanceFlags.getRemoteFX());
 		editor.putBoolean(keyGFX, performanceFlags.getGfx());
@@ -363,6 +369,9 @@ public class BookmarkBase implements Parcelable, Cloneable
 		screenSettings.setResolution(sharedPrefs.getString(keyResolution, "automatic"),
 		                             sharedPrefs.getInt(keyWidth, 800),
 		                             sharedPrefs.getInt(keyHeight, 600));
+		screenSettings.setScale(sharedPrefs.getString(keyScaleMode, "100"),
+		                        sharedPrefs.getInt(keyScaleDesktop, 100),
+		                        sharedPrefs.getInt(keyScaleDevice, 100));
 
 		performanceFlags.setRemoteFX(sharedPrefs.getBoolean(keyRFX, false));
 		performanceFlags.setGfx(sharedPrefs.getBoolean(keyGFX, true));
@@ -579,6 +588,9 @@ public class BookmarkBase implements Parcelable, Cloneable
 		private int colors = 32;
 		private int width = 0;
 		private int height = 0;
+		private String scaleMode = "100";
+		private int scaleDesktop = 100;
+		private int scaleDevice = 100;
 
 		public ScreenSettings()
 		{
@@ -590,6 +602,9 @@ public class BookmarkBase implements Parcelable, Cloneable
 			colors = parcel.readInt();
 			width = parcel.readInt();
 			height = parcel.readInt();
+			scaleMode = parcel.readString();
+			scaleDesktop = parcel.readInt();
+			scaleDevice = parcel.readInt();
 		}
 
 		private void validate()
@@ -738,6 +753,42 @@ public class BookmarkBase implements Parcelable, Cloneable
 			this.colors = colors;
 		}
 
+		public void setScale(@NonNull String mode, int desktop, int device)
+		{
+			scaleMode = "custom".equalsIgnoreCase(mode) ? "custom" : mode;
+			scaleDesktop = desktop;
+			scaleDevice = device;
+		}
+
+		public boolean isCustomScale()
+		{
+			return "custom".equalsIgnoreCase(scaleMode);
+		}
+
+		@NonNull public String getScaleMode()
+		{
+			return scaleMode;
+		}
+
+		public int getScalePreset()
+		{
+			if ("140".equals(scaleMode))
+				return 140;
+			if ("180".equals(scaleMode))
+				return 180;
+			return 100;
+		}
+
+		public int getScaleDesktop()
+		{
+			return scaleDesktop;
+		}
+
+		public int getScaleDevice()
+		{
+			return scaleDevice;
+		}
+
 		@Override public int describeContents()
 		{
 			return 0;
@@ -749,6 +800,9 @@ public class BookmarkBase implements Parcelable, Cloneable
 			out.writeInt(colors);
 			out.writeInt(width);
 			out.writeInt(height);
+			out.writeString(scaleMode);
+			out.writeInt(scaleDesktop);
+			out.writeInt(scaleDevice);
 		}
 	}
 

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/BookmarkActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/BookmarkActivity.java
@@ -259,7 +259,7 @@ public class BookmarkActivity
 			getPreferenceManager().setSharedPreferencesName(PREFS_NAME);
 			getPreferenceManager().setSharedPreferencesMode(MODE_PRIVATE);
 			setPreferencesFromResource(R.xml.screen_settings, rootKey);
-			applyInitialResolutionState();
+			applyInitialScreenState();
 			setIntSummaryProvider();
 		}
 
@@ -276,14 +276,28 @@ public class BookmarkActivity
 					return true;
 				});
 			}
+			Preference scale = findPreference("bookmark.scale_mode");
+			if (scale != null)
+			{
+				scale.setOnPreferenceChangeListener((pref, newValue) -> {
+					boolean custom = "custom".equalsIgnoreCase((String)newValue);
+					setEnabled("bookmark.scale_desktop", custom);
+					setEnabled("bookmark.scale_device", custom);
+					return true;
+				});
+			}
 		}
 
-		private void applyInitialResolutionState()
+		private void applyInitialScreenState()
 		{
 			SharedPreferences prefs = getPreferenceManager().getSharedPreferences();
 			boolean custom = "custom".equalsIgnoreCase(prefs.getString("bookmark.resolution", ""));
 			setEnabled("bookmark.width", custom);
 			setEnabled("bookmark.height", custom);
+
+			custom = "custom".equalsIgnoreCase(prefs.getString("bookmark.scale_mode", ""));
+			setEnabled("bookmark.scale_desktop", custom);
+			setEnabled("bookmark.scale_device", custom);
 		}
 
 		private void setEnabled(String key, boolean enabled)
@@ -308,6 +322,15 @@ public class BookmarkActivity
 					if ("fitscreen".equals(res))
 						return getString(R.string.resolution_fit);
 					return res;
+				});
+			}
+
+			Preference scaleDesktopPref = findPreference("bookmark.scale_desktop");
+			if (scaleDesktopPref != null)
+			{
+				scaleDesktopPref.setSummaryProvider(preference -> {
+					SharedPreferences sp = getPreferenceManager().getSharedPreferences();
+					return sp.getInt("bookmark.scale_desktop", 100) + "%";
 				});
 			}
 		}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/BookmarkActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/BookmarkActivity.java
@@ -369,6 +369,8 @@ public class BookmarkActivity
 			// Apply initial enabled states based on saved checkbox values.
 			setEnabled("bookmark.gateway_settings",
 			           prefs.getBoolean("bookmark.enable_gateway_settings", false));
+			setEnabled("bookmark.vmconnect_guid",
+			           prefs.getBoolean("bookmark.vmconnect_mode", false));
 
 			// Hide gateway section for non-manual bookmarks.
 			BookmarkViewModel vm =
@@ -391,6 +393,15 @@ public class BookmarkActivity
 			{
 				gwCheck.setOnPreferenceChangeListener((pref, newValue) -> {
 					setEnabled("bookmark.gateway_settings", (Boolean)newValue);
+					return true;
+				});
+			}
+
+			Preference vmCheck = findPreference("bookmark.vmconnect_mode");
+			if (vmCheck != null)
+			{
+				vmCheck.setOnPreferenceChangeListener((pref, newValue) -> {
+					setEnabled("bookmark.vmconnect_guid", (Boolean)newValue);
 					return true;
 				});
 			}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -223,8 +223,10 @@ public class SessionActivity extends AppCompatActivity
 		    new OnGlobalLayoutListener() {
 			    @Override public void onGlobalLayout()
 			    {
-				    screen_width = activityRootView.getWidth();
-				    screen_height = activityRootView.getHeight();
+				    screen_width = scrollView.getWidth() - scrollView.getPaddingLeft() -
+				                   scrollView.getPaddingRight();
+				    screen_height = scrollView.getHeight() - scrollView.getPaddingTop() -
+				                    scrollView.getPaddingBottom();
 
 				    // start session
 				    if (!sessionRunning && getIntent() != null)
@@ -371,6 +373,17 @@ public class SessionActivity extends AppCompatActivity
 		inputManager.reloadKeyboards();
 
 		hideSystemBars();
+
+		// screen_width/screen_height will be updated by the next onGlobalLayout callback;
+		if (session != null && session.getBookmark() != null &&
+		    session.getBookmark().getActiveScreenSettings().isFitScreen())
+		{
+			scrollView.post(() -> {
+				if (screen_width > 0 && screen_height > 0)
+					LibFreeRDP.sendMonitorLayout(session.getInstance(), screen_width,
+					                             screen_height);
+			});
+		}
 	}
 
 	private WindowInsetsCompat onWindowInsetsChanged(View rootView, WindowInsetsCompat windowInsets)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -505,22 +505,10 @@ public class SessionActivity extends AppCompatActivity
 		Log.v(TAG, "Screen Resolution: " + screenSettings.getResolutionString());
 		if (screenSettings.isAutomatic())
 		{
-			if ((getResources().getConfiguration().screenLayout &
-			     Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_LARGE)
-			{
-				// large screen device i.e. tablet: simply use screen info
-				screenSettings.setHeight(screen_height);
-				screenSettings.setWidth(screen_width);
-			}
-			else
-			{
-				// small screen device i.e. phone:
-				// Automatic uses the largest side length of the screen and
-				// makes a 16:10 resolution setting out of it
-				int screenMax = Math.max(screen_width, screen_height);
-				screenSettings.setHeight(screenMax);
-				screenSettings.setWidth((int)((float)screenMax * 1.6f));
-			}
+			// Instead of enforcing obsolete ratios based on screen categories,
+			// directly map to actual device metrics without arbitrary multi-scaling.
+			screenSettings.setHeight(screen_height);
+			screenSettings.setWidth(screen_width);
 		}
 		if (screenSettings.isFitScreen())
 		{

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -320,6 +320,15 @@ public class LibFreeRDP
 			args.add("/admin");
 		}
 
+		if (advanced.getVmConnectMode())
+		{
+			String guid = advanced.getVmConnectGuid();
+			if (!guid.isEmpty())
+				args.add("/vmconnect:" + guid);
+			else
+				args.add("/vmconnect");
+		}
+
 		switch (advanced.getSecurity())
 		{
 			case 3: // NLA

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -305,6 +305,16 @@ public class LibFreeRDP
 		    String.format("/size:%dx%d", screenSettings.getWidth(), screenSettings.getHeight()));
 		args.add("/bpp:" + screenSettings.getColors());
 
+		if (screenSettings.isCustomScale())
+		{
+			args.add("/scale-desktop:" + screenSettings.getScaleDesktop());
+			args.add("/scale-device:" + screenSettings.getScaleDevice());
+		}
+		else
+		{
+			args.add("/scale:" + screenSettings.getScalePreset());
+		}
+
 		if (advanced.getConsoleMode())
 		{
 			args.add("/admin");

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -153,6 +153,8 @@ public class LibFreeRDP
 
 	private static native boolean freerdp_send_clipboard_data(long inst, String data);
 
+	private static native boolean freerdp_send_monitor_layout(long inst, int width, int height);
+
 	private static native String freerdp_get_last_error_string(long inst);
 
 	public static void setEventListener(EventListener l)
@@ -379,6 +381,7 @@ public class LibFreeRDP
 			args.add("/load-balance-info:" + info);
 		}
 		args.add("/clipboard");
+		args.add("/disp");
 
 		// Gateway enabled?
 		if (bookmark.getType() == BookmarkBase.TYPE_MANUAL && bookmark.getEnableGatewaySettings())
@@ -519,6 +522,11 @@ public class LibFreeRDP
 	public static boolean sendClipboardData(long inst, String data)
 	{
 		return freerdp_send_clipboard_data(inst, data);
+	}
+
+	public static boolean sendMonitorLayout(long inst, int width, int height)
+	{
+		return freerdp_send_monitor_layout(inst, width, height);
 	}
 
 	private static void OnConnectionSuccess(long inst)

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -216,6 +216,9 @@
     <string name="settings_async_channel">Async channel</string>
     <string name="settings_async_update">Async update</string>
     <string name="settings_console_mode">Console Mode</string>
+    <string name="settings_cat_hyperv">Hyper-V</string>
+    <string name="settings_vmconnect_mode">Hyper-V Console (vmconnect)</string>
+    <string name="settings_vmconnect_guid">VM ID (GUID)</string>
     <!-- App settings strings -->
     <string name="settings_password_present">*******</string>
     <string name="settings_password_empty">not set</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="settings_cat_settings">Settings</string>
     <string name="settings_screen">Screen</string>
     <string name="settings_cat_screen">Screen Settings</string>
+    <string name="settings_cat_scale">Scale Settings</string>
     <string name="settings_colors">Colors</string>
     <string-array name="colors_array">
         <item>Palette (8 Bit)</item>
@@ -105,6 +106,31 @@
     </string-array>
     <string name="settings_width">Width</string>
     <string name="settings_height">Height</string>
+    <string name="settings_scale">Scale</string>
+    <string name="settings_scale_desktop">Desktop Scale</string>
+    <string name="settings_scale_device">Device Scale</string>
+    <string-array name="scale_mode_array">
+        <item>100%</item>
+        <item>140%</item>
+        <item>180%</item>
+        <item>Custom</item>
+    </string-array>
+    <string-array name="scale_mode_values_array" translatable="false">
+        <item>100</item>
+        <item>140</item>
+        <item>180</item>
+        <item>custom</item>
+    </string-array>
+    <string-array name="scale_device_array">
+        <item>100%</item>
+        <item>140%</item>
+        <item>180%</item>
+    </string-array>
+    <string-array name="scale_device_values_array" translatable="false">
+        <item>100</item>
+        <item>140</item>
+        <item>180</item>
+    </string-array>
     <string name="settings_performance">Performance</string>
     <string name="settings_cat_performance">Performance Settings</string>
     <string name="settings_perf_remotefx">RemoteFX</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -217,6 +217,8 @@
     <string name="settings_async_update">Async update</string>
     <string name="settings_console_mode">Console Mode</string>
     <string name="settings_cat_hyperv">Hyper-V</string>
+    <string name="settings_cat_redirection">Redirection</string>
+    <string name="settings_cat_session">Session</string>
     <string name="settings_vmconnect_mode">Hyper-V Console (vmconnect)</string>
     <string name="settings_vmconnect_guid">VM ID (GUID)</string>
     <!-- App settings strings -->

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/advanced_settings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/advanced_settings.xml
@@ -10,7 +10,8 @@
  -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-    <PreferenceCategory android:title="Advanced">
+
+    <PreferenceCategory android:title="@string/settings_cat_gateway">
 
         <SwitchPreferenceCompat
             android:key="bookmark.enable_gateway_settings"
@@ -27,46 +28,66 @@
             android:title="@string/settings_loadBalanceInfo"
             app:useSimpleSummaryProvider="true" />
 
-        <com.freerdp.freerdpcore.utils.IntListPreference
-            android:entries="@array/tlsSecLevel_array"
-            android:entryValues="@array/tlsSecLevel_values_array"
-            android:key="bookmark.tlsSecLevel"
-            android:title="@string/settings_tlsSecLevel" />
+    </PreferenceCategory>
 
-        <com.freerdp.freerdpcore.utils.IntListPreference
-            android:entries="@array/tlsMinLevel_array"
-            android:entryValues="@array/tlsMinLevel_values_array"
-            android:key="bookmark.tlsMinLevel"
-            android:title="@string/settings_tlsMinLevel" />
+    <PreferenceCategory android:title="@string/settings_cat_security">
 
-        <CheckBoxPreference
-            android:key="bookmark.redirect_sdcard"
-            android:title="@string/settings_redirect_sdcard" />
-        <com.freerdp.freerdpcore.utils.IntListPreference
-            android:entries="@array/redirect_sound_array"
-            android:entryValues="@array/redirect_sound_values_array"
-            android:key="bookmark.redirect_sound"
-            android:title="@string/settings_redirect_sound"
-            app:useSimpleSummaryProvider="true" />
-        <CheckBoxPreference
-            android:key="bookmark.redirect_microphone"
-            android:title="@string/settings_redirect_microphone" />
         <com.freerdp.freerdpcore.utils.IntListPreference
             android:entries="@array/security_array"
             android:entryValues="@array/security_values_array"
             android:key="bookmark.security"
             android:title="@string/settings_security"
             app:useSimpleSummaryProvider="true" />
+
+        <com.freerdp.freerdpcore.utils.IntListPreference
+            android:entries="@array/tlsSecLevel_array"
+            android:entryValues="@array/tlsSecLevel_values_array"
+            android:key="bookmark.tlsSecLevel"
+            android:title="@string/settings_tlsSecLevel"
+            app:useSimpleSummaryProvider="true" />
+
+        <com.freerdp.freerdpcore.utils.IntListPreference
+            android:entries="@array/tlsMinLevel_array"
+            android:entryValues="@array/tlsMinLevel_values_array"
+            android:key="bookmark.tlsMinLevel"
+            android:title="@string/settings_tlsMinLevel"
+            app:useSimpleSummaryProvider="true" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/settings_cat_redirection">
+
+        <CheckBoxPreference
+            android:key="bookmark.redirect_sdcard"
+            android:title="@string/settings_redirect_sdcard" />
+
+        <com.freerdp.freerdpcore.utils.IntListPreference
+            android:entries="@array/redirect_sound_array"
+            android:entryValues="@array/redirect_sound_values_array"
+            android:key="bookmark.redirect_sound"
+            android:title="@string/settings_redirect_sound"
+            app:useSimpleSummaryProvider="true" />
+
+        <CheckBoxPreference
+            android:key="bookmark.redirect_microphone"
+            android:title="@string/settings_redirect_microphone" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/settings_cat_session">
+
         <EditTextPreference
             android:key="bookmark.remote_program"
             android:singleLine="true"
             android:title="@string/settings_remote_program"
             app:useSimpleSummaryProvider="true" />
+
         <EditTextPreference
             android:key="bookmark.work_dir"
             android:singleLine="true"
             android:title="@string/settings_work_dir"
             app:useSimpleSummaryProvider="true" />
+
         <CheckBoxPreference
             android:key="bookmark.console_mode"
             android:title="@string/settings_console_mode" />

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/advanced_settings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/advanced_settings.xml
@@ -73,4 +73,18 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/settings_cat_hyperv">
+
+        <SwitchPreferenceCompat
+            android:key="bookmark.vmconnect_mode"
+            android:title="@string/settings_vmconnect_mode" />
+
+        <EditTextPreference
+            android:key="bookmark.vmconnect_guid"
+            android:singleLine="true"
+            android:title="@string/settings_vmconnect_guid"
+            app:useSimpleSummaryProvider="true" />
+
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/screen_settings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/screen_settings.xml
@@ -41,4 +41,26 @@
             freerdp:bounds_min="480"
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
+    <PreferenceCategory android:title="@string/settings_cat_scale">
+        <ListPreference
+            android:entries="@array/scale_mode_array"
+            android:entryValues="@array/scale_mode_values_array"
+            android:key="bookmark.scale_mode"
+            android:title="@string/settings_scale"
+            app:useSimpleSummaryProvider="true" />
+        <com.freerdp.freerdpcore.utils.IntEditTextPreference
+            android:key="bookmark.scale_desktop"
+            android:title="@string/settings_scale_desktop"
+            android:singleLine="true"
+            freerdp:bounds_default="100"
+            freerdp:bounds_max="500"
+            freerdp:bounds_min="100"
+            app:useSimpleSummaryProvider="true" />
+        <com.freerdp.freerdpcore.utils.IntListPreference
+            android:entries="@array/scale_device_array"
+            android:entryValues="@array/scale_device_values_array"
+            android:key="bookmark.scale_device"
+            android:title="@string/settings_scale_device"
+            app:useSimpleSummaryProvider="true" />
+    </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
### Summary

Add display channel, per-connection scale settings, and Hyper-V vmconnect support to the Android client. These changes significantly improve the experience on modern Android devices with high-resolution displays.

- Enable dynamic display resize (`/disp`) and pass scale/orientation settings to the monitor layout. *(Note: Resolution must be set to "**Fit screen**" for dynamic resizing to trigger).*
- Add per-connection scale settings: presets (100%, 140%, 180%) via `/scale:N`, or custom mode via `/scale-desktop` and `/scale-device`.
- Add Hyper-V console toggle (`/vmconnect`) under a new "Hyper-V" category in Advanced Settings.
- Reorganize Advanced Settings into clearer categories: Gateway, Security, Redirection, Session, Hyper-V.
- Update "Automatic" resolution to use actual device screen dimensions instead of obsolete 16:10 heuristics, fixing letterboxing on modern phones.

> **Note:** vmconnect support was included in this PR to share the single database migration (v14->v15) with the scale settings fields, avoiding a separate version bump.

- Fixes #1701
- Fixes #3473
- Fixes  #8797
- Fixes #2015

### How to Test

- **Dynamic Resize:** Set resolution to "Fit screen", connect, and rotate or resize the window. Verify the remote desktop adjusts on the fly.
- **Display Scaling:** Set scale to 140%, 180%, or custom values, and verify the remote desktop UI scales accordingly.
- **Hyper-V Console:** Enable vmconnect mode with a valid VM GUID and connect to a Hyper-V host.
- **Resolution:** Set resolution to "Automatic" and verify the session maps exactly to the device's native screen dimensions.
- **Settings UI:** Open Advanced Settings and verify the new intuitive category grouping.

> **Note for vmconnect:** The Android UI, database persistence, and passing the arguments to the C core are fully tested and working. However, an actual connection needs reviewer verification. I don't have a live Hyper-V environment to test the final connection, but since it relies purely on the existing and stable FreeRDP core command-line parser, **it is highly likely to work out of the box.**

### Environments Tested

- Physical Device: Android 16 (API 36)