### PR TITLE
[channels,cliprdr,server] resync read loop on garbage trailing bytes

### DIFF
--- a/channels/cliprdr/server/cliprdr_main.c
+++ b/channels/cliprdr/server/cliprdr_main.c
@@ -1236,7 +1236,17 @@ static UINT cliprdr_server_read(CliprdrServerContext* context)
 				Stream_Read_UINT16(s, header.msgType);  /* msgType (2 bytes) */
 				Stream_Read_UINT16(s, header.msgFlags); /* msgFlags (2 bytes) */
 
-				if (!header.msgType)
+				/* These 4 bytes are either padding (zeros, per
+				 * MS-RDPECLIP 2.2.1) or the start of the next PDU
+				 * header. If msgType isn't a valid CLIPRDR type
+				 * (1..CB_UNLOCK_CLIPDATA), treat them as leftover
+				 * bytes from the previous PDU's payload and discard
+				 * — keeping them would desync the stream by 4 bytes
+				 * on the next PDU's header read (the actual next
+				 * msgType+msgFlags would then be parsed as dataLen).
+				 * Observed in the wild with mstsc FILECONTENTS
+				 * responses for files inside folders. */
+				if (!header.msgType || header.msgType > CB_UNLOCK_CLIPDATA)
 				{
 					/* ignore trailing bytes */
 					Stream_ResetPosition(s);


### PR DESCRIPTION
## Problem
cliprdr_server_read desyncs after specific CLIPRDR PDUs and dies with Unexpected clipboard PDU type followed by CheckEventHandle failed with error 13. The receive thread exits and the cliprdr channel becomes one-way.

## Cause (observed)

Some peers (mstsc on Windows 11 24H2 confirmed) emit 4 extra non-zero bytes past dataLen on certain CB_FILECONTENTS_RESPONSE PDUs — specifically the partial-tail chunk of a multi-chunk transfer when the file is inside a folder. Wire capture across multiple runs shows the extra bytes have a structurally constant byte-2 value (0x14), which rules out file payload and points to an uninitialized field in mstsc's serializer.

The existing trailing-bytes check at cliprdr_main.c:1234 only resets the stream when those 4 bytes read as msgType == 0. Anything non-zero is taken as the start of the next PDU header — which then desyncs the next read by 4 bytes, causing the real next PDU's msgType+msgFlags to be parsed as dataLen.

## Fix
Tighten the check: only accept the trailing bytes as a next-header start when msgType is a valid CLIPRDR PDU type (1..CB_UNLOCK_CLIPDATA). Anything outside that range is treated as garbage/padding and the stream is reset. Matches the spec (padding is zeros), is more robust to non-spec peers, and is a minimal one-line change.

## Reproducer
from a [Mac RDP](https://github.com/HuJK/MacRDP) server based on this library, copy [this folder](https://github.com/HuJK/FreeRDP/releases/download/fix1/Loaders.7z) from a Windows mstsc client, then paste on the Mac. The receive thread dies after the tail (smaller) chunk of the file's transfer. Top-level (non-folder) file copies are unaffected because mstsc doesn't emit the trailing bytes for those.

logs with custom debug print:
```c++
T16 prevMsgType  = header.msgType;
T16 prevMsgFlags = header.msgFlags;
T32 prevDataLen  = header.dataLen;

setPosition(s);
for trailing zero bytes */
WaitForSingleObject(cliprdr->ChannelEvent, 0);

s == WAIT_FAILED)
			{
GetLastError();
(TAG, "WaitForSingleObject failed with error %" PRIu32 "", error);
rror;
			}

s == WAIT_TIMEOUT)
HANNEL_RC_OK;

rned = 0;
ad = 4;

irtualChannelRead(cliprdr->ChannelHandle, 0, Stream_Pointer(s), BytesToRead,
                  &BytesReturned))
			{
(TAG, "WTSVirtualChannelRead failed!");
RROR_INTERNAL_ERROR;
			}

Returned == 4)
			{
 grab the raw 4 bytes BEFORE Stream_Read_UINT16
ces the position. We log every PDU's trailing
 so we can see when mstsc sends garbage vs zeros
e legitimate next-PDU-header. */
TE* tail = Stream_BufferAs(s, const BYTE);

ead_UINT16(s, header.msgType);  /* msgType (2 bytes) */
ead_UINT16(s, header.msgFlags); /* msgFlags (2 bytes) */

O(TAG,
  "trailing4 after PDU msgType=0x%04" PRIX16
  " msgFlags=0x%04" PRIX16 " dataLen=%" PRIu32
  ": %02X %02X %02X %02X (as msgType=0x%04" PRIX16
  " msgFlags=0x%04" PRIX16 ")",
  prevMsgType, prevMsgFlags, prevDataLen,
  tail[0], tail[1], tail[2], tail[3],
  header.msgType, header.msgFlags);

```
in the log, [23:28:14:818] [55781:6f64b001] got strange trailing, and then FreeRDP crashes. 
This it's a defensive patch which ignores the garbage data and continue to process following data.
```
[23:27:57:011] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0007 msgFlags=0x0000 dataLen=16: 02 00 00 00 (as msgType=0x0002 msgFlags=0x0000)
[23:28:09:931] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:10:118] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:10:471] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:10:655] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:10:994] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:11:185] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:11:512] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:11:828] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:12:200] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:12:394] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:12:750] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:12:939] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:13:293] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:13:487] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:13:831] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:14:033] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:14:378] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:14:571] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:14:818] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=468032: 10 13 14 F6 (as msgType=0x1310 msgFlags=0xF614)
[23:28:15:025] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:15:383] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:15:725] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:16:074] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:16:268] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:16:614] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:16:828] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:17:193] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:17:547] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:17:745] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:18:091] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:18:292] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=1048580: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
[23:28:18:548] [55781:6f64b001] [INFO][com.freerdp.channels.cliprdr.server] - [cliprdr_server_read]: trailing4 after PDU msgType=0x0009 msgFlags=0x0001 dataLen=463188: 00 00 00 00 (as msgType=0x0000 msgFlags=0x0000)
```