### PR TITLE
[clang,tidy] use workflow from ZedThree

### DIFF
--- a/.github/workflows/clang-tidy-post.yml
+++ b/.github/workflows/clang-tidy-post.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: akallabeth/clang-tidy-review/post@master
+      - uses: ZedThree/clang-tidy-review/post@v0.23.1
         # lgtm_comment_body, max_comments, and annotations need to be set on the posting workflow in a split setup
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v4
 
     # Run clang-tidy
-    - uses: akallabeth/clang-tidy-review@master
+    - uses: ZedThree/clang-tidy-review@v0.23.1
       id: review
       with:
         split_workflow: true


### PR DESCRIPTION
The patch required was merged long ago, so switch to upstream for the action