### PR TITLE
[client,android] Add multi-session and external display support

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/AndroidManifest.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/AndroidManifest.xml
@@ -70,7 +70,10 @@
             android:name=".presentation.SessionActivity"
             android:theme="@style/Theme.Main"
             android:configChanges="orientation|keyboard|keyboardHidden|screenSize|smallestScreenSize|density|screenLayout|navigation"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:taskAffinity="com.freerdp.session"
+            android:documentLaunchMode="always"
+            android:autoRemoveFromRecents="true">
             <!--android:configChanges="orientation|keyboardHidden|screenSize|keyboard"-->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ExternalDisplayManager.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ExternalDisplayManager.java
@@ -1,0 +1,68 @@
+/*
+   External Display Manager
+
+*/
+
+package com.freerdp.freerdpcore.presentation;
+
+import android.app.Activity;
+import android.app.ActivityOptions;
+import android.content.Intent;
+import android.hardware.display.DisplayManager;
+import android.view.Display;
+
+import androidx.appcompat.app.AlertDialog;
+
+import com.freerdp.freerdpcore.R;
+
+class ExternalDisplayManager
+{
+	private final Activity activity;
+	private final DisplayManager displayManager;
+
+	ExternalDisplayManager(Activity activity)
+	{
+		this.activity = activity;
+		this.displayManager = (DisplayManager)activity.getSystemService(Activity.DISPLAY_SERVICE);
+	}
+
+	void launchSessionWithDisplayPicker(String refStr)
+	{
+		Display[] secondary = getSecondaryDisplays();
+		if (secondary.length == 0)
+		{
+			launchSessionOnDisplay(refStr, Display.DEFAULT_DISPLAY);
+			return;
+		}
+
+		String[] labels = new String[1 + secondary.length];
+		labels[0] = activity.getString(R.string.display_main_screen);
+		for (int i = 0; i < secondary.length; i++)
+			labels[i + 1] = secondary[i].getName();
+
+		new AlertDialog.Builder(activity)
+		    .setTitle(R.string.select_display_title)
+		    .setItems(labels,
+		              (d, which) -> {
+			              int id = (which == 0) ? Display.DEFAULT_DISPLAY
+			                                    : secondary[which - 1].getDisplayId();
+			              launchSessionOnDisplay(refStr, id);
+		              })
+		    .show();
+	}
+
+	private void launchSessionOnDisplay(String refStr, int displayId)
+	{
+		Intent intent = new Intent(activity, SessionActivity.class);
+		intent.putExtra(SessionActivity.PARAM_CONNECTION_REFERENCE, refStr);
+		intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
+		ActivityOptions opts = ActivityOptions.makeBasic();
+		opts.setLaunchDisplayId(displayId);
+		activity.startActivity(intent, opts.toBundle());
+	}
+
+	private Display[] getSecondaryDisplays()
+	{
+		return displayManager.getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION);
+	}
+}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/HomeActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/HomeActivity.java
@@ -41,11 +41,15 @@ public class HomeActivity extends AppCompatActivity
 	private MenuItem searchMenuItem;
 	private SearchView searchView;
 
+	private ExternalDisplayManager externalDisplayManager;
+
 	@Override public void onCreate(Bundle savedInstanceState)
 	{
 		super.onCreate(savedInstanceState);
 		binding = HomeBinding.inflate(getLayoutInflater());
 		setContentView(binding.getRoot());
+
+		externalDisplayManager = new ExternalDisplayManager(this);
 
 		long heapSize = Runtime.getRuntime().maxMemory();
 		Log.i(TAG, "Max HeapSize: " + heapSize);
@@ -76,14 +80,7 @@ public class HomeActivity extends AppCompatActivity
 				if (ConnectionReference.isBookmarkReference(refStr) ||
 				    ConnectionReference.isHostnameReference(refStr))
 				{
-					Bundle bundle = new Bundle();
-					bundle.putString(SessionActivity.PARAM_CONNECTION_REFERENCE, refStr);
-
-					Intent sessionIntent = new Intent(HomeActivity.this, SessionActivity.class);
-					sessionIntent.putExtras(bundle);
-					sessionIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK |
-					                       Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
-					startActivity(sessionIntent);
+					externalDisplayManager.launchSessionWithDisplayPicker(refStr);
 
 					if (searchView != null)
 					{

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/HomeActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/HomeActivity.java
@@ -81,6 +81,8 @@ public class HomeActivity extends AppCompatActivity
 
 					Intent sessionIntent = new Intent(HomeActivity.this, SessionActivity.class);
 					sessionIntent.putExtras(bundle);
+					sessionIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK |
+					                       Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
 					startActivity(sessionIntent);
 
 					if (searchView != null)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -56,8 +56,6 @@ import com.freerdp.freerdpcore.domain.ConnectionReference;
 import com.freerdp.freerdpcore.services.LibFreeRDP;
 import com.freerdp.freerdpcore.utils.ClipboardManagerProxy;
 
-import java.util.Collection;
-
 public class SessionActivity extends AppCompatActivity
     implements LibFreeRDP.UIEventListener, ClipboardManagerProxy.OnClipboardChangedListener
 {
@@ -348,9 +346,8 @@ public class SessionActivity extends AppCompatActivity
 		// Cancel running disconnect timers.
 		GlobalApp.cancelDisconnectTimer();
 
-		// Disconnect all remaining sessions.
-		Collection<SessionState> sessions = GlobalApp.getSessions();
-		for (SessionState session : sessions)
+		// Disconnect only this activity's session.
+		if (session != null)
 			LibFreeRDP.disconnect(session.getInstance());
 
 		// unregister freerdp session listener
@@ -599,6 +596,7 @@ public class SessionActivity extends AppCompatActivity
 		}
 		if (System.currentTimeMillis() - backPressedTime < 2000)
 		{
+			connectCancelledByUser = true;
 			LibFreeRDP.disconnect(session.getInstance());
 		}
 		else

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -334,4 +334,8 @@
 
     <string name="preference_key_h264" translatable="false">bookmark.perf_gfx_h264</string>
     <string name="settings_loadBalanceInfo">LoadBalanceInfo</string>
+
+    <!-- External display -->
+    <string name="select_display_title">Select Display</string>
+    <string name="display_main_screen">Main Screen</string>
 </resources>


### PR DESCRIPTION
## [client,android] Add multi-session and external display support

### Description
This pull request introduces concurrent multi-session RDP connections as the primary feature, along with independent support for external displays on Android.

Users can now open and run multiple RDP sessions at the same time in separate windows on devices that support multi-window mode. Additionally, when a wired external display is connected, aFreeRDP shows a picker dialog before starting a session so the user can choose the target display.

- Fixes #6117
- Fixes #7296


### Screenshots

[Multi-session on secondary display]
<img width="1000" alt="Screenshot From 2026-05-24 22-34-00" src="https://github.com/user-attachments/assets/898b52f6-436f-4d35-8a4c-4f4dc36388a2" />

### Implementation Details
* **Multi-session support**: Sessions run as independent entities. Multiple instances can operate concurrently without conflict.
* **ExternalDisplayManager**: Handles display enumeration (DISPLAY_CATEGORY_PRESENTATION) and manages session launching via `ActivityOptions.setLaunchDisplayId()` (API 26+).
* **HomeActivity**: Delegates session launch logic to the `ExternalDisplayManager`.

### Known Limitations
* **Connection type**: Only wired connections (HDMI, USB-C hubs, etc.) are supported. Wireless displays (Miracast/WiDi) do not work because Android excludes them from `DISPLAY_CATEGORY_PRESENTATION` for security reasons.
* **Samsung DeX**: Requires further testing. DeX uses a unique display and windowing architecture.
* **Hardware variability**: Performance and behavior depend heavily on the specific manufacturer's Android implementation.

### Future Development Notes
Newer Android versions introduce significant updates for window management and multi-display environments. This experimental feature builds a foundation that can be expanded using these new APIs. For reference on future improvements and best practices, see the official Android guide: [Support connected displays](https://developer.android.com/develop/adaptive-apps/guides/support-connected-displays).

### Testing Instructions

**With a physical external display:**
1. Connect the external display to your device using a wired connection.
2. Launch aFreeRDP and tap a bookmark.
3. The display picker dialog will appear. Select the target display.

**Without a physical external display:**
1. Enable **Developer Options** on your Android device.
2. Go to **Developer Options** > **Simulate secondary displays**.
3. Select a target resolution (e.g., 1080p).
4. Launch aFreeRDP and tap a bookmark. The display picker dialog will appear.

### Environments Tested
* Physical Device: Android 16 (API 36)