### PR TITLE
Improve FIPS mode support

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -325,14 +325,30 @@ BOOL rdp_client_connect(rdpRdp* rdp)
 	/* FIPS Mode forces the following and overrides the following(by happening later
 	 * in the command line processing):
 	 * 1. Forces the only supported RDP encryption method to be FIPS.
-	 * 2. Disables NTLM authentication (not FIPS compliant due to MD4/RC4). */
+	 * 2. Disables NTLM authentication (not FIPS compliant due to MD4/RC4).
+	 * 3. Disables RDP Security if 3DES is not available in the crypto provider. */
 	if (settings->FIPSMode || winpr_FIPSMode())
 	{
+
 		settings->EncryptionMethods = ENCRYPTION_METHOD_FIPS;
+
 		if (!settings->AuthenticationPackageList)
 		{
 			if (!freerdp_settings_set_string(settings, FreeRDP_AuthenticationPackageList, "!ntlm"))
 				return FALSE;
+		}
+
+		const BYTE key[WINPR_CIPHER_MAX_KEY_LENGTH] = WINPR_C_ARRAY_INIT;
+		const BYTE iv[WINPR_CIPHER_MAX_IV_LENGTH] = WINPR_C_ARRAY_INIT;
+		WINPR_CIPHER_CTX* ctx = winpr_Cipher_NewEx(WINPR_CIPHER_DES_EDE3_CBC, WINPR_ENCRYPT, key,
+		                                           sizeof(key), iv, sizeof(iv));
+		if (ctx)
+		{
+			winpr_Cipher_Free(ctx);
+		}
+		else
+		{
+			settings->RdpSecurity = FALSE;
 		}
 	}
 

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -324,10 +324,16 @@ BOOL rdp_client_connect(rdpRdp* rdp)
 
 	/* FIPS Mode forces the following and overrides the following(by happening later
 	 * in the command line processing):
-	 * 1. Forces the only supported RDP encryption method to be FIPS. */
+	 * 1. Forces the only supported RDP encryption method to be FIPS.
+	 * 2. Disables NTLM authentication (not FIPS compliant due to MD4/RC4). */
 	if (settings->FIPSMode || winpr_FIPSMode())
 	{
 		settings->EncryptionMethods = ENCRYPTION_METHOD_FIPS;
+		if (!settings->AuthenticationPackageList)
+		{
+			if (!freerdp_settings_set_string(settings, FreeRDP_AuthenticationPackageList, "!ntlm"))
+				return FALSE;
+		}
 	}
 
 	UINT32 TcpConnectTimeout = freerdp_settings_get_uint32(settings, FreeRDP_TcpConnectTimeout);

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -28,6 +28,7 @@
 #include <winpr/assert.h>
 #include <winpr/cast.h>
 #include <winpr/json.h>
+#include <winpr/ssl.h>
 
 #include "rdp.h"
 
@@ -3043,7 +3044,7 @@ static void print_last_line(wLog* log, const log_line_t* firstLine)
 }
 
 static void log_build_warn_cipher(rdpRdp* rdp, log_line_t* firstLine, WINPR_CIPHER_TYPE md,
-                                  const char* what)
+                                  const char* what, BOOL allowFIPS)
 {
 	BOOL haveCipher = FALSE;
 
@@ -3054,7 +3055,11 @@ static void log_build_warn_cipher(rdpRdp* rdp, log_line_t* firstLine, WINPR_CIPH
 	 * winpr_Cipher_* does not support that. */
 	if (md == WINPR_CIPHER_ARC4_128)
 	{
-		WINPR_RC4_CTX* enc = winpr_RC4_New(key, sizeof(key));
+		WINPR_RC4_CTX* enc = nullptr;
+		if (allowFIPS)
+			enc = winpr_RC4_New_Allow_FIPS(key, sizeof(key));
+		else
+			enc = winpr_RC4_New(key, sizeof(key));
 		haveCipher = enc != nullptr;
 		winpr_RC4_Free(enc);
 	}
@@ -3101,13 +3106,17 @@ static void log_build_warn_hmac(rdpRdp* rdp, log_line_t* firstLine, WINPR_MD_TYP
 }
 
 static void log_build_warn_hash(rdpRdp* rdp, log_line_t* firstLine, WINPR_MD_TYPE md,
-                                const char* what)
+                                const char* what, BOOL allowFIPS)
 {
 	BOOL haveDigestX = FALSE;
-
 	WINPR_DIGEST_CTX* digest = winpr_Digest_New();
 	if (digest)
-		haveDigestX = winpr_Digest_Init(digest, md);
+	{
+		if (allowFIPS)
+			haveDigestX = winpr_Digest_Init_Allow_FIPS(digest, md);
+		else
+			haveDigestX = winpr_Digest_Init(digest, md);
+	}
 	winpr_Digest_Free(digest);
 
 	if (!haveDigestX)
@@ -3121,37 +3130,65 @@ static void log_build_warn_ssl(rdpRdp* rdp)
 {
 	WINPR_ASSERT(rdp);
 
+	const BOOL fips = winpr_FIPSMode();
+
+	if (fips)
+	{
+		WLog_Print(rdp->log, WLOG_INFO,
+		           "FIPS mode active: non-approved algorithms are unavailable "
+		           "as expected. NTLM, autoreconnect cookies, assistance files "
+		           "with encrypted passwords and RDP security will not work.");
+	}
+
 	log_line_t firstHashLine = WINPR_C_ARRAY_INIT;
-	log_build_warn_hash(rdp, &firstHashLine, WINPR_MD_MD4, "NTLM support not available");
+	if (!fips)
+	{
+		log_build_warn_hash(rdp, &firstHashLine, WINPR_MD_MD4, "NTLM support not available", FALSE);
+		log_build_warn_hash(rdp, &firstHashLine, WINPR_MD_MD5,
+		                    "NTLM, assistance files with encrypted passwords "
+		                    " and autoreconnect cookies will not work",
+		                    FALSE);
+	}
 	log_build_warn_hash(rdp, &firstHashLine, WINPR_MD_MD5,
-	                    "NTLM, assistance files with encrypted passwords, autoreconnect cookies, "
-	                    "licensing and RDP security will not work");
+	                    "RDP licensing and RDP security will not work", TRUE);
 	log_build_warn_hash(rdp, &firstHashLine, WINPR_MD_SHA1,
 	                    "assistance files with encrypted passwords, Kerberos, Smartcard Logon, RDP "
-	                    "security support not available");
-	log_build_warn_hash(
-	    rdp, &firstHashLine, WINPR_MD_SHA256,
-	    "file clipboard, AAD gateway, NLA security and certificates might not work");
+	                    "security support not available",
+	                    FALSE);
+	log_build_warn_hash(rdp, &firstHashLine, WINPR_MD_SHA256,
+	                    "file clipboard, AAD gateway, NLA security and certificates might not work",
+	                    FALSE);
 	print_last_line(rdp->log, &firstHashLine);
 
-	log_line_t firstHmacLine = WINPR_C_ARRAY_INIT;
-	log_build_warn_hmac(rdp, &firstHmacLine, WINPR_MD_MD5, "Autoreconnect cookie not supported");
-	log_build_warn_hmac(rdp, &firstHmacLine, WINPR_MD_SHA1, "RDP security not supported");
-	print_last_line(rdp->log, &firstHmacLine);
+	if (!fips)
+	{
+		log_line_t firstHmacLine = WINPR_C_ARRAY_INIT;
+		log_build_warn_hmac(rdp, &firstHmacLine, WINPR_MD_MD5,
+		                    "Autoreconnect cookie not supported");
+		log_build_warn_hmac(rdp, &firstHmacLine, WINPR_MD_SHA1, "RDP security not supported");
+		print_last_line(rdp->log, &firstHmacLine);
+	}
 
 	log_line_t firstCipherLine = WINPR_C_ARRAY_INIT;
+	if (!fips)
+	{
+		log_build_warn_cipher(rdp, &firstCipherLine, WINPR_CIPHER_ARC4_128,
+		                      "assistance files with encrypted passwords, NTLM "
+		                      "and autoreconnect cookies will not work",
+		                      FALSE);
+	}
 	log_build_warn_cipher(rdp, &firstCipherLine, WINPR_CIPHER_ARC4_128,
-	                      "assistance files with encrypted passwords, NTLM, RDP licensing and RDP "
-	                      "security will not work");
-	log_build_warn_cipher(rdp, &firstCipherLine, WINPR_CIPHER_DES_EDE3_CBC,
-	                      "RDP security FIPS mode will not work");
+	                      "RDP licensing and RDP security will not work", TRUE);
+	if (!fips)
+		log_build_warn_cipher(rdp, &firstCipherLine, WINPR_CIPHER_DES_EDE3_CBC,
+		                      "RDP security will not work", TRUE);
 	log_build_warn_cipher(
 	    rdp, &firstCipherLine, WINPR_CIPHER_AES_128_CBC,
-	    "assistance file encrypted LHTicket will not work and ARM gateway might not");
+	    "assistance file encrypted LHTicket will not work and ARM gateway might not", FALSE);
 	log_build_warn_cipher(rdp, &firstCipherLine, WINPR_CIPHER_AES_192_CBC,
-	                      "ARM gateway might not work");
+	                      "ARM gateway might not work", FALSE);
 	log_build_warn_cipher(rdp, &firstCipherLine, WINPR_CIPHER_AES_256_CBC,
-	                      "ARM gateway might not work");
+	                      "ARM gateway might not work", FALSE);
 	print_last_line(rdp->log, &firstCipherLine);
 }
 

--- a/winpr/libwinpr/crypto/cipher.c
+++ b/winpr/libwinpr/crypto/cipher.c
@@ -90,7 +90,6 @@ static WINPR_RC4_CTX* winpr_RC4_New_Internal(const BYTE* key, size_t keylen, BOO
 	if (!ctx->ictx)
 		goto fail;
 #elif defined(WITH_OPENSSL)
-	const EVP_CIPHER* evp = nullptr;
 
 	if (keylen > INT_MAX)
 		goto fail;
@@ -99,7 +98,11 @@ static WINPR_RC4_CTX* winpr_RC4_New_Internal(const BYTE* key, size_t keylen, BOO
 	if (!ctx->ctx)
 		goto fail;
 
-	evp = EVP_rc4();
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	EVP_CIPHER* evp = EVP_CIPHER_fetch(NULL, "RC4", override_fips ? "fips=no" : NULL);
+#else
+	const EVP_CIPHER* evp = EVP_rc4();
+#endif
 
 	if (!evp)
 		goto fail;
@@ -108,12 +111,16 @@ static WINPR_RC4_CTX* winpr_RC4_New_Internal(const BYTE* key, size_t keylen, BOO
 	if (EVP_EncryptInit_ex(ctx->ctx, evp, nullptr, nullptr, nullptr) != 1)
 		goto fail;
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	EVP_CIPHER_free(evp);
+
 	/* EVP_CIPH_FLAG_NON_FIPS_ALLOW does not exist before openssl 1.0.1 */
 #if !(OPENSSL_VERSION_NUMBER < 0x10001000L)
 
 	if (override_fips == TRUE)
 		EVP_CIPHER_CTX_set_flags(ctx->ctx, EVP_CIPH_FLAG_NON_FIPS_ALLOW);
 
+#endif
 #endif
 	EVP_CIPHER_CTX_set_key_length(ctx->ctx, (int)keylen);
 	if (EVP_EncryptInit_ex(ctx->ctx, nullptr, nullptr, key, nullptr) != 1)


### PR DESCRIPTION
This series improves FIPS compliance across the board:
- Disable NTLM in FIPS mode — NTLM uses MD4/RC4 which are not FIPS-approved. When FIPS is active, AuthenticationPackageList is set to "!ntlm" so only Kerberos is used for NLA.
- Fix RC4 FIPS override for OpenSSL 3 — The winpr_RC4_New_Allow_FIPS function used EVP_CIPH_FLAG_NON_FIPS_ALLOW which is no longer honored in OpenSSL 3. Use EVP_CIPHER_fetch with "fips=no" property instead, matching the existing MD5 fix.
- Disable RDP Security in FIPS mode on OpenSSL 3.4+ — The RDP FIPS encryption method uses 3DES which is no longer approved in the OpenSSL 3.4 FIPS provider. On these versions, RDP Security is disabled so only NLA/TLS (using AES) is negotiated.
- Suppress expected FIPS cipher warnings — The crypto build-time checks produced misleading warnings for algorithms that are intentionally blocked under FIPS. Test _Allow_FIPS variants where available (RC4, MD5) and silently skip algorithms expected to be unavailable (MD4, HMAC-MD5). A single INFO message now summarizes what is unavailable.