### PR TITLE
[client,android] add .rdp file import and share support

### DIFF
--- a/client/Android/Studio/aFreeRDP/src/main/AndroidManifest.xml
+++ b/client/Android/Studio/aFreeRDP/src/main/AndroidManifest.xml
@@ -52,10 +52,11 @@
                 <data android:scheme="content" />
                 <data android:host="*" />
 
-                <!-- Ugly hack to match all files with a dot in its name.
-                Remove if a better way is found / supported.
-                https://stackoverflow.com/questions/3400072/pathpattern-to-match-file-extension-does-not-work-if-a-period-exists-elsewhere-i/8599921#8599921
-                -->
+                <!-- API 31+: clean suffix match -->
+                <data android:pathSuffix=".rdp" />
+                <data android:pathSuffix=".rdpw" />
+
+                <!-- API 29-30 fallback: pathPattern can't skip dots, one entry per dot count -->
                 <data android:pathPattern=".*\\.rdp" />
                 <data android:pathPattern=".*\\..*\\.rdp" />
                 <data android:pathPattern=".*\\..*\\..*\\.rdp" />
@@ -65,6 +66,15 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.rdp" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.rdp" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.rdp" />
+                <data android:pathPattern=".*\\.rdpw" />
+                <data android:pathPattern=".*\\..*\\.rdpw" />
+                <data android:pathPattern=".*\\..*\\..*\\.rdpw" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.rdpw" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.rdpw" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.rdpw" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.rdpw" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.rdpw" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.rdpw" />
             </intent-filter>
         </activity>
 
@@ -83,6 +93,16 @@
         </activity>
 
         <meta-data android:name="com.samsung.android.keepalive.density" android:value="true"/>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="com.freerdp.afreerdp.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths" />
+        </provider>
 
     </application>
 

--- a/client/Android/Studio/aFreeRDP/src/main/res/xml/file_provider_paths.xml
+++ b/client/Android/Studio/aFreeRDP/src/main/res/xml/file_provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="shared" path="." />
+</paths>

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/BookmarkViewModel.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/BookmarkViewModel.java
@@ -7,6 +7,7 @@ package com.freerdp.freerdpcore.presentation;
 
 import android.app.Application;
 import android.content.SharedPreferences;
+import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 
@@ -21,7 +22,7 @@ import com.freerdp.freerdpcore.domain.BookmarkBase;
 import com.freerdp.freerdpcore.domain.ConnectionReference;
 import com.freerdp.freerdpcore.services.ManualBookmarkGateway;
 import com.freerdp.freerdpcore.services.QuickConnectHistoryGateway;
-import com.freerdp.freerdpcore.utils.RDPFileParser;
+import com.freerdp.freerdpcore.utils.RDPFileHelper;
 
 import java.io.File;
 import java.io.IOException;
@@ -121,20 +122,26 @@ public class BookmarkViewModel extends AndroidViewModel
 				}
 				else if (ConnectionReference.isFileReference(refStr))
 				{
-					String file = ConnectionReference.getFile(refStr);
+					String fileRef = ConnectionReference.getFile(refStr);
 					bookmark = new BookmarkBase();
-					bookmark.setLabel(file);
+					String name = Uri.decode(new File(fileRef).getName());
+					String lower = name.toLowerCase(java.util.Locale.ROOT);
+					if (lower.endsWith(".rdp"))
+						name = name.substring(0, name.length() - 4);
+					else if (lower.endsWith(".rdpw"))
+						name = name.substring(0, name.length() - 5);
+					bookmark.setLabel(name);
 					try
 					{
-						RDPFileParser rdpFile = new RDPFileParser(file);
-						updateBookmarkFromFile(bookmark, rdpFile);
-						bookmark.setLabel(new File(file).getName());
-						isNew = true;
+						Uri uri = Uri.parse(fileRef);
+						RDPFileHelper.importFrom(
+						    getApplication().getContentResolver().openInputStream(uri), bookmark);
 					}
 					catch (IOException e)
 					{
 						Log.e(TAG, "Failed reading RDP file", e);
 					}
+					isNew = true;
 				}
 			}
 
@@ -181,48 +188,6 @@ public class BookmarkViewModel extends AndroidViewModel
 			// Notify Activity to close
 			saveCompleteEvent.postValue(true);
 		});
-	}
-
-	private void updateBookmarkFromFile(BookmarkBase bookmark, RDPFileParser rdpFile)
-	{
-		String s;
-		Integer i;
-
-		s = rdpFile.getString("full address");
-		if (s != null)
-		{
-			if (s.lastIndexOf(":") > s.lastIndexOf("]"))
-			{
-				try
-				{
-					bookmark.setPort(Integer.parseInt(s.substring(s.lastIndexOf(":") + 1)));
-				}
-				catch (NumberFormatException e)
-				{
-					Log.e(TAG, "Malformed address");
-				}
-				s = s.substring(0, s.lastIndexOf(":"));
-			}
-			if (s.startsWith("[") && s.endsWith("]"))
-				s = s.substring(1, s.length() - 1);
-			bookmark.setHostname(s);
-		}
-
-		i = rdpFile.getInteger("server port");
-		if (i != null)
-			bookmark.setPort(i);
-
-		s = rdpFile.getString("username");
-		if (s != null)
-			bookmark.setUsername(s);
-
-		s = rdpFile.getString("domain");
-		if (s != null)
-			bookmark.setDomain(s);
-
-		i = rdpFile.getInteger("connect to console");
-		if (i != null)
-			bookmark.getAdvancedSettings().setConsoleMode(i == 1);
 	}
 
 	@Override protected void onCleared()

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/HomeActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/HomeActivity.java
@@ -14,7 +14,9 @@ import androidx.appcompat.app.AlertDialog;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.FileProvider;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -27,8 +29,15 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 
 import com.freerdp.freerdpcore.R;
 import com.freerdp.freerdpcore.databinding.HomeBinding;
+import com.freerdp.freerdpcore.domain.BookmarkBase;
 import com.freerdp.freerdpcore.domain.ConnectionReference;
 import com.freerdp.freerdpcore.utils.BookmarkListAdapter;
+import com.freerdp.freerdpcore.utils.RDPFileHelper;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class HomeActivity extends AppCompatActivity
 {
@@ -61,7 +70,7 @@ public class HomeActivity extends AppCompatActivity
 
 		if (Intent.ACTION_VIEW.equals(caller.getAction()) && callParameter != null)
 		{
-			String refStr = ConnectionReference.getFileReference(callParameter.getPath());
+			String refStr = ConnectionReference.getFileReference(callParameter.toString());
 			Bundle bundle = new Bundle();
 			bundle.putString(BookmarkActivity.PARAM_CONNECTION_REFERENCE, refStr);
 
@@ -98,6 +107,11 @@ public class HomeActivity extends AppCompatActivity
 			@Override public void onDelete(long id)
 			{
 				viewModel.deleteBookmark(id);
+			}
+
+			@Override public void onExport(BookmarkBase bookmark)
+			{
+				shareRdpFile(bookmark);
 			}
 		});
 
@@ -185,6 +199,28 @@ public class HomeActivity extends AppCompatActivity
 		}
 
 		return true;
+	}
+
+	private void shareRdpFile(BookmarkBase bookmark)
+	{
+		String filename = bookmark.getLabel().replaceAll("[^\\w. -]", "_") + ".rdp";
+		File file = new File(getCacheDir(), filename);
+		try (FileOutputStream out = new FileOutputStream(file))
+		{
+			out.write(RDPFileHelper.toRdpString(bookmark).getBytes(StandardCharsets.UTF_8));
+		}
+		catch (IOException e)
+		{
+			Log.e(TAG, "Failed to write RDP file for sharing", e);
+			Toast.makeText(this, R.string.export_failed, Toast.LENGTH_SHORT).show();
+			return;
+		}
+		Uri uri = FileProvider.getUriForFile(this, "com.freerdp.afreerdp.fileprovider", file);
+		Intent share = new Intent(Intent.ACTION_SEND);
+		share.setType("application/x-rdp");
+		share.putExtra(Intent.EXTRA_STREAM, uri);
+		share.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+		startActivity(Intent.createChooser(share, bookmark.getLabel()));
 	}
 
 	private void setupSearchView(Menu menu)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ShortcutsActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ShortcutsActivity.java
@@ -65,6 +65,10 @@ public class ShortcutsActivity extends AppCompatActivity
 			@Override public void onDelete(long id)
 			{
 			}
+
+			@Override public void onExport(BookmarkBase bookmark)
+			{
+			}
 		});
 
 		binding.recyclerViewShortcuts.setLayoutManager(new LinearLayoutManager(this));

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/BookmarkListAdapter.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/BookmarkListAdapter.java
@@ -30,6 +30,7 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<BookmarkListAdapte
 	{
 		void onItemClick(String refStr);
 		void onDelete(long id);
+		void onExport(BookmarkBase bookmark);
 	}
 
 	private List<BookmarkBase> items = new ArrayList<>();
@@ -86,9 +87,10 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<BookmarkListAdapte
 				final String finalRefStr = refStr;
 				final long bookmarkId = bookmark.getId();
 				holder.binding.bookmarkIcon2.setOnClickListener(
-				    v -> showBookmarkMenu(v, finalRefStr, bookmarkId));
+				    v -> showBookmarkMenu(v, finalRefStr, bookmarkId, bookmark));
 				holder.itemView.setOnLongClickListener(v -> {
-					showBookmarkMenu(holder.binding.bookmarkIcon2, finalRefStr, bookmarkId);
+					showBookmarkMenu(holder.binding.bookmarkIcon2, finalRefStr, bookmarkId,
+					                 bookmark);
 					return true;
 				});
 			}
@@ -154,7 +156,8 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<BookmarkListAdapte
 		return items.size();
 	}
 
-	private void showBookmarkMenu(View anchor, String refStr, long bookmarkId)
+	private void showBookmarkMenu(View anchor, String refStr, long bookmarkId,
+	                              BookmarkBase bookmark)
 	{
 		PopupMenu popup = new PopupMenu(anchor.getContext(), anchor);
 		popup.inflate(R.menu.bookmark_context_menu);
@@ -179,6 +182,12 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<BookmarkListAdapte
 			{
 				if (callbacks != null)
 					callbacks.onDelete(bookmarkId);
+				return true;
+			}
+			else if (itemId == R.id.bookmark_export)
+			{
+				if (callbacks != null)
+					callbacks.onExport(bookmark);
 				return true;
 			}
 			return false;

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/RDPFileHelper.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/RDPFileHelper.java
@@ -1,0 +1,263 @@
+package com.freerdp.freerdpcore.utils;
+
+import android.util.Log;
+
+import com.freerdp.freerdpcore.domain.BookmarkBase;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+
+public final class RDPFileHelper
+{
+	private static final String TAG = "RDPFileHelper";
+
+	private RDPFileHelper()
+	{
+	}
+
+	public static void importFrom(InputStream in, BookmarkBase bookmark) throws IOException
+	{
+		if (in == null)
+			throw new IOException("null stream");
+
+		byte[] content;
+		try
+		{
+			ByteArrayOutputStream buf = new ByteArrayOutputStream(4096);
+			byte[] chunk = new byte[4096];
+			int n;
+			while ((n = in.read(chunk)) != -1)
+				buf.write(chunk, 0, n);
+			content = buf.toByteArray();
+		}
+		finally
+		{
+			in.close();
+		}
+
+		String text;
+		int b0 = content.length > 0 ? (content[0] & 0xFF) : -1;
+		int b1 = content.length > 1 ? (content[1] & 0xFF) : -1;
+		if (b0 == 0xFF && b1 == 0xFE)
+			text = new String(content, 2, content.length - 2, StandardCharsets.UTF_16LE);
+		else if (b0 == 0xFE && b1 == 0xFF)
+			text = new String(content, 2, content.length - 2, StandardCharsets.UTF_16BE);
+		else
+		{
+			text = new String(content, StandardCharsets.UTF_8);
+			if (text.startsWith("\uFEFF"))
+				text = text.substring(1);
+		}
+
+		RDPFileParser p = new RDPFileParser();
+		p.parse(new StringReader(text));
+
+		String s = p.getString("full address");
+		if (s != null)
+		{
+			int colonIdx = s.lastIndexOf(":");
+			if (colonIdx > s.lastIndexOf("]"))
+			{
+				try
+				{
+					bookmark.setPort(Integer.parseInt(s.substring(colonIdx + 1)));
+				}
+				catch (NumberFormatException e)
+				{
+					Log.e(TAG, "Malformed address");
+				}
+				s = s.substring(0, colonIdx);
+			}
+			if (s.startsWith("[") && s.endsWith("]"))
+				s = s.substring(1, s.length() - 1);
+			bookmark.setHostname(s);
+		}
+
+		Integer i = p.getInteger("server port");
+		if (i != null)
+			bookmark.setPort(i);
+
+		s = p.getString("username");
+		if (s != null)
+			bookmark.setUsername(s);
+
+		s = p.getString("domain");
+		if (s != null)
+			bookmark.setDomain(s);
+
+		BookmarkBase.ScreenSettings screen = bookmark.getActiveScreenSettings();
+		Integer w = p.getInteger("desktopwidth");
+		Integer h = p.getInteger("desktopheight");
+		if (w != null && h != null && w > 0 && h > 0)
+		{
+			screen.setWidth(w);
+			screen.setHeight(h);
+			screen.setResolution(BookmarkBase.ScreenSettings.CUSTOM);
+		}
+		i = p.getInteger("session bpp");
+		if (i != null)
+			screen.setColors(i);
+
+		BookmarkBase.PerformanceFlags perf = bookmark.getPerformanceFlags();
+		i = p.getInteger("disable wallpaper");
+		if (i != null)
+			perf.setWallpaper(i == 0);
+		i = p.getInteger("allow font smoothing");
+		if (i != null)
+			perf.setFontSmoothing(i == 1);
+		i = p.getInteger("allow desktop composition");
+		if (i != null)
+			perf.setDesktopComposition(i == 1);
+		i = p.getInteger("disable menu anims");
+		if (i != null)
+			perf.setMenuAnimations(i == 0);
+		i = p.getInteger("disable themes");
+		if (i != null)
+			perf.setTheming(i == 0);
+		i = p.getInteger("disable full window drag");
+		if (i != null)
+			perf.setFullWindowDrag(i == 0);
+
+		BookmarkBase.AdvancedSettings advanced = bookmark.getAdvancedSettings();
+		i = p.getInteger("connect to console");
+		if (i != null)
+			advanced.setConsoleMode(i == 1);
+
+		i = p.getInteger("audiomode");
+		if (i != null && i >= 0 && i <= 2)
+			advanced.setRedirectSound(i);
+		i = p.getInteger("audiocapturemode");
+		if (i != null)
+			advanced.setRedirectMicrophone(i == 1);
+
+		s = p.getString("loadbalanceinfo");
+		if (s != null && !s.isEmpty())
+			advanced.setLoadBalanceInfo(s);
+
+		s = p.getString("remoteapplicationprogram");
+		if (s == null || s.isEmpty())
+			s = p.getString("alternate shell");
+		if (s != null && !s.isEmpty())
+			advanced.setRemoteProgram(s);
+
+		s = p.getString("shell working directory");
+		if (s != null && !s.isEmpty())
+			advanced.setWorkDir(s);
+
+		s = p.getString("gatewayhostname");
+		if (s != null && !s.isEmpty())
+		{
+			String gwHost = s;
+			int gwPort = 443;
+			int colonIdx = s.lastIndexOf(":");
+			if (colonIdx > 0)
+			{
+				try
+				{
+					gwPort = Integer.parseInt(s.substring(colonIdx + 1));
+					gwHost = s.substring(0, colonIdx);
+				}
+				catch (NumberFormatException e)
+				{
+					Log.e(TAG, "Malformed gateway port");
+				}
+			}
+			bookmark.getGatewaySettings().setHostname(gwHost);
+			bookmark.getGatewaySettings().setPort(gwPort);
+			bookmark.setEnableGatewaySettings(true);
+		}
+		i = p.getInteger("gatewayusagemethod");
+		if (i != null)
+			bookmark.setEnableGatewaySettings(i == 1 || i == 2);
+
+		s = p.getString("pcb");
+		if (s != null && !s.isEmpty())
+		{
+			advanced.setVmConnectMode(true);
+			advanced.setVmConnectGuid(s);
+		}
+	}
+
+	public static String toRdpString(BookmarkBase bookmark)
+	{
+		StringBuilder sb = new StringBuilder();
+		BookmarkBase.ScreenSettings screen = bookmark.getActiveScreenSettings();
+		BookmarkBase.PerformanceFlags perf = bookmark.getActivePerformanceFlags();
+		BookmarkBase.AdvancedSettings adv = bookmark.getAdvancedSettings();
+
+		String host = bookmark.getHostname();
+		int port = bookmark.getPort();
+		writeString(sb, "full address", port != 3389 ? host + ":" + port : host);
+
+		String username = bookmark.getUsername();
+		if (!username.isEmpty())
+			writeString(sb, "username", username);
+
+		String domain = bookmark.getDomain();
+		if (!domain.isEmpty())
+			writeString(sb, "domain", domain);
+
+		if (screen.getResolution() == BookmarkBase.ScreenSettings.CUSTOM)
+		{
+			writeInt(sb, "desktopwidth", screen.getWidth());
+			writeInt(sb, "desktopheight", screen.getHeight());
+		}
+		writeInt(sb, "session bpp", screen.getColors());
+
+		writeInt(sb, "disable wallpaper", perf.getWallpaper() ? 0 : 1);
+		writeInt(sb, "allow font smoothing", perf.getFontSmoothing() ? 1 : 0);
+		writeInt(sb, "allow desktop composition", perf.getDesktopComposition() ? 1 : 0);
+		writeInt(sb, "disable menu anims", perf.getMenuAnimations() ? 0 : 1);
+		writeInt(sb, "disable themes", perf.getTheming() ? 0 : 1);
+		writeInt(sb, "disable full window drag", perf.getFullWindowDrag() ? 0 : 1);
+
+		if (adv.getConsoleMode())
+			writeInt(sb, "connect to console", 1);
+
+		int audioMode = adv.getRedirectSound();
+		if (audioMode != 0)
+			writeInt(sb, "audiomode", audioMode);
+
+		if (adv.getRedirectMicrophone())
+			writeInt(sb, "audiocapturemode", 1);
+
+		String lbInfo = adv.getLoadBalanceInfo();
+		if (!lbInfo.isEmpty())
+			writeString(sb, "loadbalanceinfo", lbInfo);
+
+		String remoteApp = adv.getRemoteProgram();
+		if (!remoteApp.isEmpty())
+			writeString(sb, "remoteapplicationprogram", remoteApp);
+
+		String workDir = adv.getWorkDir();
+		if (!workDir.isEmpty())
+			writeString(sb, "shell working directory", workDir);
+
+		if (bookmark.getEnableGatewaySettings())
+		{
+			BookmarkBase.GatewaySettings gw = bookmark.getGatewaySettings();
+			String gwHost = gw.getHostname();
+			int gwPort = gw.getPort();
+			writeString(sb, "gatewayhostname", gwPort != 443 ? gwHost + ":" + gwPort : gwHost);
+			writeInt(sb, "gatewayusagemethod", 2);
+		}
+
+		if (adv.getVmConnectMode())
+			writeString(sb, "pcb", adv.getVmConnectGuid());
+
+		return sb.toString();
+	}
+
+	private static void writeString(StringBuilder sb, String key, String value)
+	{
+		sb.append(key).append(":s:").append(value).append("\r\n");
+	}
+
+	private static void writeInt(StringBuilder sb, String key, int value)
+	{
+		sb.append(key).append(":i:").append(value).append("\r\n");
+	}
+}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/RDPFileParser.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/RDPFileParser.java
@@ -11,8 +11,8 @@
 package com.freerdp.freerdpcore.utils;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.util.HashMap;
 import java.util.Locale;
 
@@ -26,23 +26,12 @@ public class RDPFileParser
 
 	public RDPFileParser()
 	{
-		init();
-	}
-
-	public RDPFileParser(String filename) throws IOException
-	{
-		init();
-		parse(filename);
-	}
-
-	private void init()
-	{
 		options = new HashMap<>();
 	}
 
-	public void parse(String filename) throws IOException
+	public void parse(Reader reader) throws IOException
 	{
-		BufferedReader br = new BufferedReader(new FileReader(filename));
+		BufferedReader br = new BufferedReader(reader);
 		String line = null;
 
 		int errors = 0;

--- a/client/Android/Studio/freeRDPCore/src/main/res/menu/bookmark_context_menu.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/menu/bookmark_context_menu.xml
@@ -16,4 +16,9 @@
         android:showAsAction="ifRoom"
         android:title="@string/menu_delete" />
 
+    <item
+        android:id="@+id/bookmark_export"
+        android:showAsAction="ifRoom"
+        android:title="@string/bookmark_export" />
+
 </menu>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="menu_connect">Connect</string>
     <string name="menu_edit">Edit</string>
     <string name="menu_delete">Delete</string>
+    <string name="bookmark_export">Share</string>
+    <string name="export_failed">Failed to share bookmark</string>
     <!-- Session menu items -->
     <string name="menu_sys_keyboard">Keyboard</string>
     <string name="menu_ext_keyboard">Function Keys</string>


### PR DESCRIPTION
## [client,android] Add .rdp file import and share support
- Fixes #2053
- Fixes #12663

### Description
`.rdp` file support for aFreeRDP:

- **Import:**  Opening a `.rdp` file launches the bookmark editor pre-filled with connection
  settings. Extends the existing parser to support over 20 fields including gateway, screen settings,
  and performance flags.

- **Share:** "Share" option in the bookmark context menu opens the Android share sheet with the
  bookmark serialized as a `.rdp` file.

### Testing Instructions
1. Copy a `.rdp` file to the device > open from file manager > bookmark editor opens pre-filled.
2. Long-press a bookmark > **Share** > send and open on another device.
3. Round-trip: share a bookmark, import it back, verify fields match.

### Environments Tested
- Physical Device: Android 16 (API 36)