### PR TITLE
[client,android] Add printer channel support for Android

### DIFF
--- a/channels/printer/client/android/CMakeLists.txt
+++ b/channels/printer/client/android/CMakeLists.txt
@@ -1,7 +1,9 @@
 # FreeRDP: A Remote Desktop Protocol Implementation
 # FreeRDP cmake build script
 #
-# Copyright 2012 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+# Copyright 2019 Armin Novak <armin.novak@thincast.com>
+# Copyright 2019 Thincast Technologies GmbH
+# Copyright 2026 Ibrahim Sevinc <ibrahim.sevinc.mail@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,22 +16,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+define_channel_client_subsystem("printer" "android" "")
 
-define_channel_client("printer")
-
-set(${MODULE_PREFIX}_SRCS printer_main.c)
+set(${MODULE_PREFIX}_SRCS printer_android.c)
 
 set(${MODULE_PREFIX}_LIBS winpr freerdp)
-add_channel_client_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} TRUE "DeviceServiceEntry")
 
-if(WITH_CUPS)
-  add_channel_client_subsystem(${MODULE_PREFIX} ${CHANNEL_NAME} "cups" "")
-endif()
+include_directories(..)
 
-if(WIN32 AND NOT UWP)
-  add_channel_client_subsystem(${MODULE_PREFIX} ${CHANNEL_NAME} "win" "")
-endif()
-
-if(ANDROID)
-  add_channel_client_subsystem(${MODULE_PREFIX} ${CHANNEL_NAME} "android" "")
-endif()
+add_channel_client_subsystem_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} "" TRUE "")

--- a/channels/printer/client/android/printer_android.c
+++ b/channels/printer/client/android/printer_android.c
@@ -1,0 +1,282 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Print Virtual Channel - Android backend
+ *
+ * Copyright 2026 Ibrahim Sevinc <ibrahim.sevinc.mail@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <winpr/crt.h>
+#include <winpr/assert.h>
+#include <freerdp/client/printer.h>
+#include <freerdp/channels/log.h>
+
+#define TAG CHANNELS_TAG("printer.client.android")
+
+#define PRINT_OUTPUT_DIR "/sdcard/Download/"
+#define PRINT_OUTPUT_PREFIX "rdp_print_"
+#define ANDROID_PRINTER_NAME "aFreeRDP Print"
+#define ANDROID_PRINTER_DRIVER "Microsoft Print to PDF"
+
+typedef struct
+{
+	rdpPrinterDriver driver;
+	size_t id_sequence;
+	size_t references;
+} rdpAndroidPrinterDriver;
+
+typedef struct
+{
+	rdpPrintJob printjob;
+	FILE* file;
+	char path[256];
+} rdpAndroidPrintJob;
+
+typedef struct
+{
+	rdpPrinter printer;
+	rdpAndroidPrintJob* printjob;
+} rdpAndroidPrinter;
+
+static UINT printer_android_write_printjob(rdpPrintJob* printjob, const BYTE* data, size_t size)
+{
+	rdpAndroidPrintJob* aj = (rdpAndroidPrintJob*)printjob;
+	if (aj->file)
+	{
+		if (fwrite(data, 1, size, aj->file) != size)
+			WLog_WARN(TAG, "Short write on print job file");
+	}
+	return CHANNEL_RC_OK;
+}
+
+static void printer_android_close_printjob(rdpPrintJob* printjob)
+{
+	rdpAndroidPrintJob* aj = (rdpAndroidPrintJob*)printjob;
+	rdpAndroidPrinter* ap = (rdpAndroidPrinter*)printjob->printer;
+
+	if (aj->file)
+	{
+		fclose(aj->file);
+		aj->file = nullptr;
+		WLog_INFO(TAG, "Print job complete, saved to %s", aj->path);
+	}
+
+	ap->printjob = nullptr;
+	free(aj);
+}
+
+static rdpPrintJob* printer_android_create_printjob(rdpPrinter* printer, UINT32 id)
+{
+	rdpAndroidPrinter* ap = (rdpAndroidPrinter*)printer;
+
+	WINPR_ASSERT(ap);
+
+	if (ap->printjob != nullptr)
+	{
+		WLog_WARN(TAG, "printjob [printer '%s'] already existing, abort!", printer->name);
+		return nullptr;
+	}
+
+	rdpAndroidPrintJob* aj = calloc(1, sizeof(*aj));
+	if (!aj)
+		return nullptr;
+
+	aj->printjob.id = id;
+	aj->printjob.printer = printer;
+	aj->printjob.Write = printer_android_write_printjob;
+	aj->printjob.Close = printer_android_close_printjob;
+
+	time_t t = time(NULL);
+	snprintf(aj->path, sizeof(aj->path), PRINT_OUTPUT_DIR PRINT_OUTPUT_PREFIX "%lld.pdf",
+	         (long long)t);
+
+	aj->file = fopen(aj->path, "wb");
+	if (!aj->file)
+	{
+		WLog_ERR(TAG, "Failed to open dump file %s", aj->path);
+		free(aj);
+		return NULL;
+	}
+
+	ap->printjob = aj;
+	return &aj->printjob;
+}
+
+static rdpPrintJob* printer_android_find_printjob(rdpPrinter* printer, UINT32 id)
+{
+	rdpAndroidPrinter* ap = (rdpAndroidPrinter*)printer;
+
+	WINPR_ASSERT(ap);
+
+	if (ap->printjob == NULL)
+		return NULL;
+	if (ap->printjob->printjob.id != id)
+		return NULL;
+
+	return &ap->printjob->printjob;
+}
+
+static void printer_android_free_printer(rdpPrinter* printer)
+{
+	rdpAndroidPrinter* ap = (rdpAndroidPrinter*)printer;
+
+	WINPR_ASSERT(ap);
+
+	if (ap->printjob)
+	{
+		WINPR_ASSERT(ap->printjob->printjob.Close);
+		ap->printjob->printjob.Close(&ap->printjob->printjob);
+	}
+
+	if (printer->backend)
+	{
+		WINPR_ASSERT(printer->backend->ReleaseRef);
+		printer->backend->ReleaseRef(printer->backend);
+	}
+
+	free(printer->name);
+	free(printer->driver);
+	free(printer);
+}
+
+static void printer_android_add_ref_printer(rdpPrinter* printer)
+{
+	if (printer)
+		printer->references++;
+}
+
+static void printer_android_release_ref_printer(rdpPrinter* printer)
+{
+	if (!printer)
+		return;
+	if (printer->references <= 1)
+		printer_android_free_printer(printer);
+	else
+		printer->references--;
+}
+
+static rdpPrinter* printer_android_new_printer(rdpAndroidPrinterDriver* drv, const char* name,
+                                               const char* driverName, BOOL isDefault)
+{
+	rdpAndroidPrinter* ap = calloc(1, sizeof(*ap));
+	if (!ap)
+		return NULL;
+
+	ap->printer.backend = &drv->driver;
+	ap->printer.id = drv->id_sequence++;
+	ap->printer.name = _strdup(name ? name : ANDROID_PRINTER_NAME);
+	if (!ap->printer.name)
+		goto fail;
+
+	ap->printer.driver = _strdup(driverName ? driverName : ANDROID_PRINTER_DRIVER);
+	if (!ap->printer.driver)
+		goto fail;
+
+	ap->printer.is_default = isDefault;
+	ap->printer.CreatePrintJob = printer_android_create_printjob;
+	ap->printer.FindPrintJob = printer_android_find_printjob;
+	ap->printer.AddRef = printer_android_add_ref_printer;
+	ap->printer.ReleaseRef = printer_android_release_ref_printer;
+
+	WINPR_ASSERT(ap->printer.AddRef);
+	ap->printer.AddRef(&ap->printer);
+
+	WINPR_ASSERT(ap->printer.backend->AddRef);
+	ap->printer.backend->AddRef(ap->printer.backend);
+
+	return &ap->printer;
+
+fail:
+	printer_android_free_printer(&ap->printer);
+	return NULL;
+}
+
+static rdpPrinter** printer_android_enum_printers(rdpPrinterDriver* driver)
+{
+	rdpAndroidPrinterDriver* ad = (rdpAndroidPrinterDriver*)driver;
+	rdpPrinter** list = calloc(2, sizeof(rdpPrinter*));
+	if (!list)
+		return NULL;
+
+	list[0] = printer_android_new_printer(ad, ANDROID_PRINTER_NAME, ANDROID_PRINTER_DRIVER, TRUE);
+	list[1] = NULL;
+	return list;
+}
+
+static void printer_android_release_enum_printers(rdpPrinter** printers)
+{
+	if (!printers)
+		return;
+	for (rdpPrinter** p = printers; *p; p++)
+	{
+		if ((*p)->ReleaseRef)
+			(*p)->ReleaseRef(*p);
+	}
+	free(printers);
+}
+
+static rdpPrinter* printer_android_get_printer(rdpPrinterDriver* driver, const char* name,
+                                               const char* driverName, BOOL isDefault)
+{
+	return printer_android_new_printer((rdpAndroidPrinterDriver*)driver, name, driverName,
+	                                   isDefault);
+}
+
+static void printer_android_add_ref_driver(rdpPrinterDriver* driver)
+{
+	rdpAndroidPrinterDriver* ad = (rdpAndroidPrinterDriver*)driver;
+	if (ad)
+		ad->references++;
+}
+
+static void printer_android_release_ref_driver(rdpPrinterDriver* driver)
+{
+	rdpAndroidPrinterDriver* ad = (rdpAndroidPrinterDriver*)driver;
+
+	WINPR_ASSERT(ad);
+	if (ad->references <= 1)
+		free(ad);
+	else
+		ad->references--;
+}
+
+FREERDP_ENTRY_POINT(UINT VCAPITYPE android_freerdp_printer_client_subsystem_entry(void* arg))
+{
+	rdpPrinterDriver** ppDriver = (rdpPrinterDriver**)arg;
+
+	if (!ppDriver)
+		return ERROR_INVALID_PARAMETER;
+
+	rdpAndroidPrinterDriver* drv = calloc(1, sizeof(*drv));
+	if (!drv)
+		return ERROR_OUTOFMEMORY;
+
+	drv->driver.EnumPrinters = printer_android_enum_printers;
+	drv->driver.ReleaseEnumPrinters = printer_android_release_enum_printers;
+	drv->driver.GetPrinter = printer_android_get_printer;
+	drv->driver.AddRef = printer_android_add_ref_driver;
+	drv->driver.ReleaseRef = printer_android_release_ref_driver;
+	drv->id_sequence = 1;
+
+	WINPR_ASSERT(drv->driver.AddRef);
+	drv->driver.AddRef(&drv->driver);
+
+	*ppDriver = &drv->driver;
+	return CHANNEL_RC_OK;
+}

--- a/client/Android/Studio/aFreeRDP/src/main/res/xml/file_provider_paths.xml
+++ b/client/Android/Studio/aFreeRDP/src/main/res/xml/file_provider_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <cache-path name="shared" path="." />
+    <external-path name="downloads" path="Download/" />
 </paths>

--- a/client/Android/Studio/freeRDPCore/src/main/AndroidManifest.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <supports-screens
         android:anyDensity="true"
@@ -63,7 +64,7 @@
             android:exported="true"
             android:name=".presentation.ApplicationSettingsActivity"
             android:label="@string/title_application_settings"
-            android:theme="@style/Theme.Main" />
+            android:theme="@style/Theme.Main"
             android:windowSoftInputMode="stateHidden" />
         <activity
             android:exported="true"
@@ -98,6 +99,12 @@
             android:label="@string/title_help"
             android:theme="@style/Theme.Main"
             android:configChanges="orientation|keyboardHidden|screenSize" />
+
+        <activity
+            android:exported="false"
+            android:name=".presentation.PrintProxyActivity"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:excludeFromRecents="true" />
 
     </application>
 

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/application/GlobalApp.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/application/GlobalApp.java
@@ -23,6 +23,8 @@ import android.util.Log;
 
 import com.freerdp.freerdpcore.domain.BookmarkBase;
 import com.freerdp.freerdpcore.presentation.ApplicationSettingsActivity;
+import com.freerdp.freerdpcore.presentation.PrintJobMonitor;
+import com.freerdp.freerdpcore.presentation.PrintNotificationHelper;
 import com.freerdp.freerdpcore.services.LibFreeRDP;
 
 import java.util.ArrayList;
@@ -40,6 +42,7 @@ public class GlobalApp extends Application implements LibFreeRDP.EventListener
 	private static final String TAG = "GlobalApp";
 	public static boolean IsMeteredNetwork = false;
 	private static Map<Long, SessionState> sessionMap;
+	private PrintJobMonitor printJobMonitor;
 
 	/** Per-session connection event listener. Callbacks are invoked on the main thread. */
 	public interface SessionEventListener
@@ -143,6 +146,9 @@ public class GlobalApp extends Application implements LibFreeRDP.EventListener
 		sessionMap = Collections.synchronizedMap(new HashMap<Long, SessionState>());
 
 		LibFreeRDP.setEventListener(this);
+
+		printJobMonitor = new PrintJobMonitor(file -> PrintNotificationHelper.notify(this, file));
+		printJobMonitor.startWatching();
 
 		IsMeteredNetwork = NetworkStateReceiver.isMeteredNetwork(this);
 		NetworkStateReceiver.registerNetworkCallback(this);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
@@ -27,7 +27,7 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory;
           exportSchema = false)
 public abstract class AppDatabase extends RoomDatabase
 {
-	static final int DB_VERSION = 15;
+	static final int DB_VERSION = 16;
 	private static final String DB_NAME = "bookmarks.db";
 
 	static
@@ -58,6 +58,7 @@ public abstract class AppDatabase extends RoomDatabase
 					               .addMigrations(MIGRATION_12_13)
 					               .addMigrations(MIGRATION_13_14)
 					               .addMigrations(MIGRATION_14_15)
+					               .addMigrations(MIGRATION_15_16)
 					               .build();
 				}
 			}
@@ -163,6 +164,14 @@ public abstract class AppDatabase extends RoomDatabase
 			sb.append(String.format(java.util.Locale.US, "%02x", b));
 		return sb.toString();
 	}
+
+	private static final Migration MIGRATION_15_16 = new Migration(15, 16) {
+		@Override public void migrate(@NonNull SupportSQLiteDatabase db)
+		{
+			db.execSQL(
+			    "ALTER TABLE 'bookmarks' ADD 'redirect_printer' INTEGER NOT NULL DEFAULT false;");
+		}
+	};
 
 	private static final Migration MIGRATION_14_15 = new Migration(14, 15) {
 		@Override public void migrate(@NonNull SupportSQLiteDatabase db)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkConverter.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkConverter.java
@@ -45,6 +45,7 @@ public final class BookmarkConverter
 		adv.setRedirectSDCard(e.redirectSdcard);
 		adv.setRedirectSound(e.redirectSound);
 		adv.setRedirectMicrophone(e.redirectMicrophone);
+		adv.setRedirectPrinter(e.redirectPrinter);
 		adv.setSecurity(e.security);
 		adv.setRemoteProgram(e.remoteProgram);
 		adv.setWorkDir(e.workDir);
@@ -109,6 +110,7 @@ public final class BookmarkConverter
 		e.redirectSdcard = adv.getRedirectSDCard();
 		e.redirectSound = adv.getRedirectSound();
 		e.redirectMicrophone = adv.getRedirectMicrophone();
+		e.redirectPrinter = adv.getRedirectPrinter();
 		e.security = adv.getSecurity();
 		e.remoteProgram = adv.getRemoteProgram();
 		e.workDir = adv.getWorkDir();

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkEntity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkEntity.java
@@ -94,6 +94,9 @@ import androidx.room.PrimaryKey;
 	@ColumnInfo(name = "redirect_microphone", defaultValue = "false")
 	public boolean redirectMicrophone = false;
 
+	@ColumnInfo(name = "redirect_printer", defaultValue = "false")
+	public boolean redirectPrinter = false;
+
 	/** 0=auto, 1=rdp, 2=tls, 3=nla */
 	@ColumnInfo(name = "security", defaultValue = "0") public int security = 0;
 

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/domain/BookmarkBase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/domain/BookmarkBase.java
@@ -50,6 +50,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 	private static final String keyRedirectSDCard = "bookmark.redirect_sdcard";
 	private static final String keySound = "bookmark.redirect_sound";
 	private static final String keyMicrophone = "bookmark.redirect_microphone";
+	private static final String keyPrinter = "bookmark.redirect_printer";
 	private static final String keySecurity = "bookmark.security";
 	private static final String keyRemoteApp = "bookmark.remote_program";
 	private static final String keyWorkDir = "bookmark.work_dir";
@@ -338,6 +339,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 		editor.putBoolean(keyRedirectSDCard, advancedSettings.getRedirectSDCard());
 		editor.putInt(keySound, advancedSettings.getRedirectSound());
 		editor.putBoolean(keyMicrophone, advancedSettings.getRedirectMicrophone());
+		editor.putBoolean(keyPrinter, advancedSettings.getRedirectPrinter());
 		editor.putInt(keySecurity, advancedSettings.getSecurity());
 		editor.putString(keyRemoteApp, advancedSettings.getRemoteProgram());
 		editor.putString(keyWorkDir, advancedSettings.getWorkDir());
@@ -394,6 +396,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 		advancedSettings.setRedirectSDCard(sharedPrefs.getBoolean(keyRedirectSDCard, false));
 		advancedSettings.setRedirectSound(sharedPrefs.getInt(keySound, 0));
 		advancedSettings.setRedirectMicrophone(sharedPrefs.getBoolean(keyMicrophone, false));
+		advancedSettings.setRedirectPrinter(sharedPrefs.getBoolean(keyPrinter, false));
 		advancedSettings.setSecurity(sharedPrefs.getInt(keySecurity, 0));
 		advancedSettings.setRemoteProgram(sharedPrefs.getString(keyRemoteApp, ""));
 		advancedSettings.setWorkDir(sharedPrefs.getString(keyWorkDir, ""));
@@ -925,6 +928,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 		private boolean redirectSDCard = false;
 		private int redirectSound = 0;
 		private boolean redirectMicrophone = false;
+		private boolean redirectPrinter = false;
 		private int security = 0;
 		private boolean consoleMode = false;
 		private boolean vmConnectMode = false;
@@ -946,6 +950,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 			redirectSDCard = parcel.readBoolean();
 			redirectSound = parcel.readInt();
 			redirectMicrophone = parcel.readBoolean();
+			redirectPrinter = parcel.readBoolean();
 			security = parcel.readInt();
 			consoleMode = parcel.readBoolean();
 			vmConnectMode = parcel.readBoolean();
@@ -1019,6 +1024,16 @@ public class BookmarkBase implements Parcelable, Cloneable
 		public void setRedirectSDCard(boolean redirectSDCard)
 		{
 			this.redirectSDCard = redirectSDCard;
+		}
+
+		public boolean getRedirectPrinter()
+		{
+			return redirectPrinter;
+		}
+
+		public void setRedirectPrinter(boolean redirectPrinter)
+		{
+			this.redirectPrinter = redirectPrinter;
 		}
 
 		public int getRedirectSound()
@@ -1114,6 +1129,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 			out.writeBoolean(redirectSDCard);
 			out.writeInt(redirectSound);
 			out.writeBoolean(redirectMicrophone);
+			out.writeBoolean(redirectPrinter);
 			out.writeInt(security);
 			out.writeBoolean(consoleMode);
 			out.writeBoolean(vmConnectMode);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/HomeActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/HomeActivity.java
@@ -11,8 +11,11 @@
 package com.freerdp.freerdpcore.presentation;
 
 import androidx.appcompat.app.AlertDialog;
+import android.Manifest;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
@@ -57,6 +60,13 @@ public class HomeActivity extends AppCompatActivity
 		super.onCreate(savedInstanceState);
 		binding = HomeBinding.inflate(getLayoutInflater());
 		setContentView(binding.getRoot());
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+		    checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) !=
+		        PackageManager.PERMISSION_GRANTED)
+		{
+			requestPermissions(new String[] { Manifest.permission.POST_NOTIFICATIONS }, 0);
+		}
 
 		externalDisplayManager = new ExternalDisplayManager(this);
 

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/PrintJobMonitor.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/PrintJobMonitor.java
@@ -1,0 +1,50 @@
+/*
+   Print Job Monitor
+
+   Copyright 2026 Ibrahim Sevinc
+
+   This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+   If a copy of the MPL was not distributed with this file, You can obtain one at
+   http://mozilla.org/MPL/2.0/.
+*/
+
+package com.freerdp.freerdpcore.presentation;
+
+import android.os.FileObserver;
+
+import androidx.annotation.Nullable;
+
+import java.io.File;
+
+/**
+ * Watches /sdcard/Download for new rdp_print_*.pdf files written by the printer backend.
+ * Fires onPrintJobComplete when the file is fully written (CLOSE_WRITE event).
+ */
+public class PrintJobMonitor extends FileObserver
+{
+	public interface Listener
+	{
+		void onPrintJobComplete(File pdfFile);
+	}
+
+	private static final String WATCH_DIR = "/sdcard/Download";
+	private static final String PREFIX = "rdp_print_";
+	private static final String SUFFIX = ".pdf";
+
+	private final Listener listener;
+
+	public PrintJobMonitor(Listener listener)
+	{
+		super(new File(WATCH_DIR), CLOSE_WRITE);
+		this.listener = listener;
+	}
+
+	@Override public void onEvent(int event, @Nullable String path)
+	{
+		if (path == null)
+			return;
+		if (!path.startsWith(PREFIX) || !path.endsWith(SUFFIX))
+			return;
+		listener.onPrintJobComplete(new File(WATCH_DIR, path));
+	}
+}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/PrintNotificationHelper.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/PrintNotificationHelper.java
@@ -1,0 +1,85 @@
+/*
+   Print Notification Helper
+
+   Copyright 2026 Ibrahim Sevinc
+
+   This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+   If a copy of the MPL was not distributed with this file, You can obtain one at
+   http://mozilla.org/MPL/2.0/.
+*/
+
+package com.freerdp.freerdpcore.presentation;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+
+import androidx.core.app.NotificationCompat;
+import androidx.core.content.FileProvider;
+
+import com.freerdp.freerdpcore.R;
+
+import java.io.File;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class PrintNotificationHelper
+{
+	private static final String CHANNEL_ID = "rdp_print";
+	private static final String AUTHORITY = "com.freerdp.afreerdp.fileprovider";
+	private static final AtomicInteger notifId = new AtomicInteger(1000);
+
+	public static void ensureChannel(Context ctx)
+	{
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
+			return;
+		NotificationManager nm = ctx.getSystemService(NotificationManager.class);
+		if (nm.getNotificationChannel(CHANNEL_ID) != null)
+			return;
+		NotificationChannel ch =
+		    new NotificationChannel(CHANNEL_ID, ctx.getString(R.string.print_notif_channel),
+		                            NotificationManager.IMPORTANCE_HIGH);
+		nm.createNotificationChannel(ch);
+	}
+
+	public static void notify(Context ctx, File pdfFile)
+	{
+		ensureChannel(ctx);
+
+		Uri uri = FileProvider.getUriForFile(ctx, AUTHORITY, pdfFile);
+
+		PendingIntent openIntent = PendingIntent.getActivity(
+		    ctx, notifId.get(),
+		    new Intent(Intent.ACTION_VIEW)
+		        .setDataAndType(uri, "application/pdf")
+		        .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION),
+		    PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
+
+		Intent printLaunch = new Intent(ctx, PrintProxyActivity.class);
+		printLaunch.setData(uri);
+		printLaunch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_GRANT_READ_URI_PERMISSION);
+		PendingIntent printIntent = PendingIntent.getActivity(
+		    ctx, notifId.get() + 1, printLaunch,
+		    PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
+
+		Notification notif = new NotificationCompat.Builder(ctx, CHANNEL_ID)
+		                         .setSmallIcon(android.R.drawable.ic_dialog_info)
+		                         .setContentTitle(ctx.getString(R.string.print_notif_title))
+		                         .setContentText(pdfFile.getName())
+		                         .setContentIntent(openIntent)
+		                         .addAction(android.R.drawable.ic_menu_view,
+		                                    ctx.getString(R.string.print_notif_open), openIntent)
+		                         .addAction(android.R.drawable.ic_menu_send,
+		                                    ctx.getString(R.string.print_notif_print), printIntent)
+		                         .setAutoCancel(true)
+		                         .build();
+
+		NotificationManager nm =
+		    (NotificationManager)ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+		nm.notify(notifId.getAndIncrement(), notif);
+	}
+}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/PrintProxyActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/PrintProxyActivity.java
@@ -1,0 +1,134 @@
+/*
+   Print Proxy Activity
+
+   Copyright 2026 Ibrahim Sevinc
+
+   This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+   If a copy of the MPL was not distributed with this file, You can obtain one at
+   http://mozilla.org/MPL/2.0/.
+*/
+
+package com.freerdp.freerdpcore.presentation;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.ParcelFileDescriptor;
+import android.print.PageRange;
+import android.print.PrintAttributes;
+import android.print.PrintDocumentAdapter;
+import android.print.PrintDocumentInfo;
+import android.print.PrintJob;
+import android.print.PrintManager;
+
+import android.app.Activity;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Transparent activity that shows the Android print dialog for a PDF URI.
+ * Stays alive until the print job reaches a terminal state, then finishes.
+ */
+public class PrintProxyActivity extends Activity
+{
+	private PrintJob printJob;
+	private final Handler handler = new Handler(Looper.getMainLooper());
+	private final Runnable pollJob = new Runnable() {
+		@Override public void run()
+		{
+			if (printJob == null || printJob.isCompleted() || printJob.isFailed() ||
+			    printJob.isCancelled())
+			{
+				finish();
+				return;
+			}
+			handler.postDelayed(this, 500);
+		}
+	};
+
+	@Override protected void onCreate(Bundle savedInstanceState)
+	{
+		super.onCreate(savedInstanceState);
+
+		Uri uri = getIntent().getData();
+		if (uri == null)
+		{
+			finish();
+			return;
+		}
+
+		PrintManager pm = (PrintManager)getSystemService(Context.PRINT_SERVICE);
+		printJob = pm.print(uri.getLastPathSegment(), new PdfAdapter(this, uri), null);
+		handler.postDelayed(pollJob, 500);
+	}
+
+	@Override protected void onDestroy()
+	{
+		handler.removeCallbacks(pollJob);
+		super.onDestroy();
+	}
+
+	private static class PdfAdapter extends PrintDocumentAdapter
+	{
+		private final Context ctx;
+		private final Uri uri;
+
+		PdfAdapter(Context ctx, Uri uri)
+		{
+			this.ctx = ctx;
+			this.uri = uri;
+		}
+
+		@Override
+		public void onLayout(PrintAttributes oldAttr, PrintAttributes newAttr,
+		                     android.os.CancellationSignal signal, LayoutResultCallback cb,
+		                     Bundle extras)
+		{
+			if (signal.isCanceled())
+			{
+				cb.onLayoutCancelled();
+				return;
+			}
+			PrintDocumentInfo info = new PrintDocumentInfo.Builder(uri.getLastPathSegment())
+			                             .setContentType(PrintDocumentInfo.CONTENT_TYPE_DOCUMENT)
+			                             .setPageCount(PrintDocumentInfo.PAGE_COUNT_UNKNOWN)
+			                             .build();
+			cb.onLayoutFinished(info, !newAttr.equals(oldAttr));
+		}
+
+		@Override
+		public void onWrite(PageRange[] pages, ParcelFileDescriptor dest,
+		                    android.os.CancellationSignal signal, WriteResultCallback cb)
+		{
+			try (InputStream in = ctx.getContentResolver().openInputStream(uri);
+			     FileOutputStream out = new FileOutputStream(dest.getFileDescriptor()))
+			{
+				if (in == null)
+				{
+					cb.onWriteFailed("Cannot open PDF");
+					return;
+				}
+				byte[] buf = new byte[8192];
+				int n;
+				while ((n = in.read(buf)) != -1)
+				{
+					if (signal.isCanceled())
+					{
+						cb.onWriteCancelled();
+						return;
+					}
+					out.write(buf, 0, n);
+				}
+				cb.onWriteFinished(new PageRange[] { PageRange.ALL_PAGES });
+			}
+			catch (IOException e)
+			{
+				cb.onWriteFailed(e.getMessage());
+			}
+		}
+	}
+}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -404,6 +404,8 @@ public class LibFreeRDP
 		args.add("/clipboard");
 		args.add("/disp");
 
+		args.add("/printer:aFreeRDP Print,Microsoft Print to PDF,default");
+
 		// Gateway enabled?
 		if (bookmark.getType() == BookmarkBase.TYPE_MANUAL && bookmark.getEnableGatewaySettings())
 		{

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -404,7 +404,8 @@ public class LibFreeRDP
 		args.add("/clipboard");
 		args.add("/disp");
 
-		args.add("/printer:aFreeRDP Print,Microsoft Print to PDF,default");
+		if (advanced.getRedirectPrinter())
+			args.add("/printer:aFreeRDP Print,Microsoft Print to PDF,default");
 
 		// Gateway enabled?
 		if (bookmark.getType() == BookmarkBase.TYPE_MANUAL && bookmark.getEnableGatewaySettings())

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/RDPFileHelper.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/RDPFileHelper.java
@@ -173,6 +173,13 @@ public final class RDPFileHelper
 		if (i != null)
 			bookmark.setEnableGatewaySettings(i == 1 || i == 2);
 
+		i = p.getInteger("redirectprinters");
+		if (i != null)
+			advanced.setRedirectPrinter(i == 1);
+		i = p.getInteger("disableprinterredirection");
+		if (i != null)
+			advanced.setRedirectPrinter(i == 0);
+
 		s = p.getString("pcb");
 		if (s != null && !s.isEmpty())
 		{
@@ -247,6 +254,9 @@ public final class RDPFileHelper
 
 		if (adv.getVmConnectMode())
 			writeString(sb, "pcb", adv.getVmConnectGuid());
+
+		if (adv.getRedirectPrinter())
+			writeInt(sb, "redirectprinters", 1);
 
 		return sb.toString();
 	}

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -340,4 +340,10 @@
     <!-- External display -->
     <string name="select_display_title">Select Display</string>
     <string name="display_main_screen">Main Screen</string>
+
+    <!-- Print notifications -->
+    <string name="print_notif_channel">Print Jobs</string>
+    <string name="print_notif_title">Print job received</string>
+    <string name="print_notif_open">Open</string>
+    <string name="print_notif_print">Print</string>
 </resources>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -198,6 +198,7 @@
         <item>0</item>
     </string-array>
     <string name="settings_redirect_microphone">Redirect Microphone</string>
+    <string name="settings_redirect_printer">Redirect Printer</string>
     <string name="settings_security">Security</string>
     <string-array name="security_array">
         <item>Automatic</item>

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/advanced_settings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/advanced_settings.xml
@@ -72,6 +72,10 @@
             android:key="bookmark.redirect_microphone"
             android:title="@string/settings_redirect_microphone" />
 
+        <CheckBoxPreference
+            android:key="bookmark.redirect_printer"
+            android:title="@string/settings_redirect_printer" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_cat_session">

--- a/client/Android/cmake/ExternalFreeRDP.cmake
+++ b/client/Android/cmake/ExternalFreeRDP.cmake
@@ -35,6 +35,8 @@ set(FREERDP_EXTRA_CMAKE_ARGS
     -DWITH_OPUS:BOOL=${WITH_OPUS}
     # JSON
     -DWITH_CJSON_REQUIRED:BOOL=${WITH_CJSON}
+    # Printer channel
+    -DCHANNEL_PRINTER_CLIENT:BOOL=ON
 )
 
 # libwebp 1.3+ splits SharpYuv into its own library; pkg-config does not pull it in.


### PR DESCRIPTION
## [client,android] Add printer channel support for Android
- Fixes  #2882 
### Description
End-to-end RDP printer redirection for aFreeRDP:

- **Backend:** New `printer_android` subsystem saves incoming print data as PDF to
  `/sdcard/Download/`. Uses `Microsoft Print to PDF:android` driver to request
  PDF output server-side.

- **Notification:** On job completion, a system notification appears with **Open**
  and **Print** actions. **Print** forwards the PDF to the Android print subsystem
  via a transparent proxy activity.

- **Setting:** Per-bookmark "Redirect Printer" toggle in Advanced Settings,
  backed by a Room DB migration (v15 -> v16).

- **WinPR ARM64 workaround:** `InterlockedPushEntrySList` silently fails on
  Android ARM64 when pointer tagging sets bit 63, causing the async thread to
  exit immediately. Async mode is disabled for the printer channel on Android as
  a temporary fix.  The proposed root fix (`#if !defined(__LP64__)` guard in
  `interlocked.c`) is tracked in #12816 .

### Testing Instructions
1. Enable **Redirect Printer** in bookmark Advanced Settings.
2. Connect and print a document from the remote session.
3. Verify notification appears with Open/Print actions.
4. Tap **Print** -> Android print dialog opens with the PDF.

### Environments Tested
- Physical Device: Android 16 (API 36)