### PR TITLE
[client,android] Add bidirectional clipboard image transfer

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/AndroidManifest.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/AndroidManifest.xml
@@ -106,6 +106,12 @@
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
             android:excludeFromRecents="true" />
 
+        <provider
+            android:name=".utils.ClipboardImageProvider"
+            android:authorities="com.freerdp.freerdpcore.clipboard"
+            android:exported="false"
+            android:grantUriPermissions="true" />
+
     </application>
 
 </manifest>

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_cliprdr.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_cliprdr.c
@@ -249,6 +249,8 @@ static UINT android_cliprdr_server_format_list(CliprdrClientContext* cliprdr,
 		}
 	}
 
+	/* Text formats take priority over image formats. Request the best available text format
+	 * first; if none is found, fall back to image. */
 	for (UINT32 index = 0; index < afc->numServerFormats; index++)
 	{
 		format = &(afc->serverFormats[index]);
@@ -259,11 +261,26 @@ static UINT android_cliprdr_server_format_list(CliprdrClientContext* cliprdr,
 			    CHANNEL_RC_OK)
 				return rc;
 
-			break;
+			return CHANNEL_RC_OK;
 		}
 		else if (format->formatId == CF_TEXT)
 		{
 			if ((rc = android_cliprdr_send_client_format_data_request(cliprdr, CF_TEXT)) !=
+			    CHANNEL_RC_OK)
+				return rc;
+
+			return CHANNEL_RC_OK;
+		}
+	}
+
+	/* No text format found — request the first available image format. */
+	for (UINT32 index = 0; index < afc->numServerFormats; index++)
+	{
+		format = &(afc->serverFormats[index]);
+
+		if (format->formatId == CF_DIB || format->formatId == CF_DIBV5)
+		{
+			if ((rc = android_cliprdr_send_client_format_data_request(cliprdr, format->formatId)) !=
 			    CHANNEL_RC_OK)
 				return rc;
 
@@ -407,20 +424,58 @@ android_cliprdr_server_format_data_response(CliprdrClientContext* cliprdr,
 
 	(void)SetEvent(afc->clipboardRequestEvent);
 
-	if ((formatId == CF_TEXT) || (formatId == CF_UNICODETEXT))
+	switch (formatId)
 	{
-		JNIEnv* env = nullptr;
-		formatId = ClipboardRegisterFormat(afc->clipboard, "text/plain");
-		char* data = (char*)ClipboardGetData(afc->clipboard, formatId, &size);
-		jboolean attached = jni_attach_thread(&env);
-		size = strnlen(data, size);
-		jstring jdata = jniNewStringUTF(env, data, size);
-		freerdp_callback("OnRemoteClipboardChanged", "(JLjava/lang/String;)V", (jlong)instance,
-		                 jdata);
-		(*env)->DeleteLocalRef(env, jdata);
+		case CF_TEXT:
+		case CF_UNICODETEXT:
+		{
+			JNIEnv* env = nullptr;
+			UINT32 plainFormatId = ClipboardRegisterFormat(afc->clipboard, "text/plain");
+			char* data = (char*)ClipboardGetData(afc->clipboard, plainFormatId, &size);
+			if (!data)
+				break;
+			jboolean attached = jni_attach_thread(&env);
+			size = strnlen(data, size);
+			jstring jdata = jniNewStringUTF(env, data, size);
+			freerdp_callback("OnRemoteClipboardChanged", "(JLjava/lang/String;)V", (jlong)instance,
+			                 jdata);
+			(*env)->DeleteLocalRef(env, jdata);
+			free(data);
 
-		if (attached == JNI_TRUE)
-			jni_detach_thread();
+			if (attached == JNI_TRUE)
+				jni_detach_thread();
+		}
+		break;
+		case CF_DIB:
+		case CF_DIBV5:
+		{
+			UINT32 pngFormatId = ClipboardRegisterFormat(afc->clipboard, "image/png");
+			BYTE* pngData = (BYTE*)ClipboardGetData(afc->clipboard, pngFormatId, &size);
+
+			if (pngData)
+			{
+				JNIEnv* env = nullptr;
+				jboolean attached = jni_attach_thread(&env);
+				jbyteArray jpngData = (*env)->NewByteArray(env, (jsize)size);
+
+				if (jpngData)
+				{
+					(*env)->SetByteArrayRegion(env, jpngData, 0, (jsize)size,
+					                           (const jbyte*)pngData);
+					freerdp_callback("OnRemoteClipboardImageChanged", "(J[B)V", (jlong)instance,
+					                 jpngData);
+					(*env)->DeleteLocalRef(env, jpngData);
+				}
+
+				free(pngData);
+
+				if (attached == JNI_TRUE)
+					jni_detach_thread();
+			}
+		}
+		break;
+		default:
+			break;
 	}
 
 	return CHANNEL_RC_OK;

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_event.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_event.c
@@ -129,7 +129,8 @@ static BOOL android_process_event(ANDROID_EVENT_QUEUE* queue, freerdp* inst)
 			case EVENT_TYPE_CLIPBOARD:
 			{
 				ANDROID_EVENT_CLIPBOARD* clipboard_event = (ANDROID_EVENT_CLIPBOARD*)event;
-				UINT32 formatId = ClipboardRegisterFormat(afc->clipboard, "text/plain");
+				const char* mimeType = clipboard_event->mimeType;
+				UINT32 formatId = ClipboardRegisterFormat(afc->clipboard, mimeType);
 				UINT32 size = clipboard_event->data_length;
 
 				if (size)
@@ -268,7 +269,8 @@ static void android_event_disconnect_free(ANDROID_EVENT* event)
 	free(event);
 }
 
-ANDROID_EVENT_CLIPBOARD* android_event_clipboard_new(const void* data, size_t data_length)
+ANDROID_EVENT_CLIPBOARD* android_event_clipboard_new(const void* data, size_t data_length,
+                                                     const char* mimeType)
 {
 	ANDROID_EVENT_CLIPBOARD* event;
 	event = (ANDROID_EVENT_CLIPBOARD*)calloc(1, sizeof(ANDROID_EVENT_CLIPBOARD));
@@ -277,19 +279,29 @@ ANDROID_EVENT_CLIPBOARD* android_event_clipboard_new(const void* data, size_t da
 		return nullptr;
 
 	event->type = EVENT_TYPE_CLIPBOARD;
+	event->mimeType = mimeType ? _strdup(mimeType) : nullptr;
 
-	if (data)
+	if (mimeType && !event->mimeType)
 	{
-		event->data = calloc(data_length + 1, sizeof(char));
+		free(event);
+		return nullptr;
+	}
+
+	if (data && data_length > 0)
+	{
+		const BOOL isText = !mimeType || strcmp(mimeType, "text/plain") == 0;
+		/* Text data needs a null terminator; image data is stored as-is. */
+		event->data = isText ? calloc(data_length + 1, sizeof(char)) : malloc(data_length);
 
 		if (!event->data)
 		{
+			free(event->mimeType);
 			free(event);
 			return nullptr;
 		}
 
 		memcpy(event->data, data, data_length);
-		event->data_length = data_length + 1;
+		event->data_length = isText ? data_length + 1 : data_length;
 	}
 
 	return event;
@@ -300,6 +312,7 @@ static void android_event_clipboard_free(ANDROID_EVENT_CLIPBOARD* event)
 	if (event)
 	{
 		free(event->data);
+		free(event->mimeType);
 		free(event);
 	}
 }

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_event.h
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_event.h
@@ -45,6 +45,7 @@ typedef struct
 	int type;
 	void* data;
 	int data_length;
+	char* mimeType;
 } ANDROID_EVENT_CLIPBOARD;
 
 typedef struct
@@ -64,8 +65,8 @@ FREERDP_LOCAL ANDROID_EVENT_KEY* android_event_key_new(int flags, UINT16 scancod
 FREERDP_LOCAL ANDROID_EVENT_KEY* android_event_unicodekey_new(UINT16 flags, UINT16 key);
 FREERDP_LOCAL ANDROID_EVENT_CURSOR* android_event_cursor_new(UINT16 flags, UINT16 x, UINT16 y);
 FREERDP_LOCAL ANDROID_EVENT* android_event_disconnect_new(void);
-FREERDP_LOCAL ANDROID_EVENT_CLIPBOARD* android_event_clipboard_new(const void* data,
-                                                                   size_t data_length);
+FREERDP_LOCAL ANDROID_EVENT_CLIPBOARD*
+android_event_clipboard_new(const void* data, size_t data_length, const char* mimeType);
 
 FREERDP_LOCAL void android_event_free(ANDROID_EVENT* event);
 

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
@@ -23,6 +23,7 @@
 #include <errno.h>
 
 #include <winpr/assert.h>
+#include <winpr/image.h>
 
 #include <freerdp/graphics.h>
 #include <freerdp/codec/rfx.h>
@@ -1017,35 +1018,68 @@ Java_com_freerdp_freerdpcore_services_LibFreeRDP_freerdp_1send_1cursor_1event(
 	return JNI_TRUE;
 }
 
+static jboolean android_push_clipboard_event(freerdp* inst, const void* data, size_t data_length,
+                                             const char* mimeType)
+{
+	ANDROID_EVENT* event = (ANDROID_EVENT*)android_event_clipboard_new(data, data_length, mimeType);
+	if (!event)
+		return JNI_FALSE;
+	if (!android_push_event(inst, event))
+	{
+		android_event_free(event);
+		return JNI_FALSE;
+	}
+	return JNI_TRUE;
+}
+
 JNIEXPORT jboolean JNICALL
 Java_com_freerdp_freerdpcore_services_LibFreeRDP_freerdp_1send_1clipboard_1data(JNIEnv* env,
                                                                                 jclass cls,
                                                                                 jlong instance,
                                                                                 jstring jdata)
 {
-	ANDROID_EVENT* event;
+	WINPR_UNUSED(cls);
 	freerdp* inst = (freerdp*)instance;
 	const char* data = jdata != nullptr ? (*env)->GetStringUTFChars(env, jdata, nullptr) : nullptr;
 	const size_t data_length = data ? (*env)->GetStringUTFLength(env, jdata) : 0;
-	jboolean ret = JNI_FALSE;
-	event = (ANDROID_EVENT*)android_event_clipboard_new((void*)data, data_length);
-
-	if (!event)
-		goto out_fail;
-
-	if (!android_push_event(inst, event))
-	{
-		android_event_free(event);
-		goto out_fail;
-	}
-
+	jboolean ret = android_push_clipboard_event(inst, data, data_length, "text/plain");
 	WLog_DBG(TAG, "send_clipboard_data: (%s)", data);
-	ret = JNI_TRUE;
-out_fail:
 
 	if (data)
 		(*env)->ReleaseStringUTFChars(env, jdata, data);
 
+	return ret;
+}
+
+static BOOL android_is_image_mime_supported(const char* mimeType)
+{
+	if (!mimeType)
+		return FALSE;
+	if (strcmp(mimeType, "image/png") == 0)
+		return winpr_image_format_is_supported(WINPR_IMAGE_PNG);
+	if (strcmp(mimeType, "image/jpeg") == 0 || strcmp(mimeType, "image/jpg") == 0)
+		return winpr_image_format_is_supported(WINPR_IMAGE_JPEG);
+	if (strcmp(mimeType, "image/webp") == 0)
+		return winpr_image_format_is_supported(WINPR_IMAGE_WEBP);
+	return FALSE;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_freerdp_freerdpcore_services_LibFreeRDP_freerdp_1send_1clipboard_1image_1data(
+    JNIEnv* env, jclass cls, jlong instance, jbyteArray jdata, jstring jmimeType)
+{
+	WINPR_UNUSED(cls);
+	freerdp* inst = (freerdp*)instance;
+	jsize data_length = (*env)->GetArrayLength(env, jdata);
+	jbyte* data = (*env)->GetByteArrayElements(env, jdata, nullptr);
+	const char* mimeType = jmimeType ? (*env)->GetStringUTFChars(env, jmimeType, nullptr) : nullptr;
+	jboolean ret = JNI_FALSE;
+	if (android_is_image_mime_supported(mimeType))
+		ret = android_push_clipboard_event(inst, data, (size_t)data_length, mimeType);
+
+	if (mimeType)
+		(*env)->ReleaseStringUTFChars(env, jmimeType, mimeType);
+	(*env)->ReleaseByteArrayElements(env, jdata, data, JNI_ABORT);
 	return ret;
 }
 

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -748,6 +748,12 @@ public class SessionActivity extends AppCompatActivity
 		mClipboardManager.setClipboardData(data);
 	}
 
+	@Override public void OnRemoteClipboardImageChanged(byte[] data)
+	{
+		Log.v(TAG, "OnRemoteClipboardImageChanged: " + data.length + " bytes");
+		mClipboardManager.setClipboardImage(data);
+	}
+
 	@Override public void OnPointerSet(int[] pixels, int width, int height, int hotX, int hotY)
 	{
 		Bundle data = new Bundle();
@@ -788,6 +794,12 @@ public class SessionActivity extends AppCompatActivity
 		Log.v(TAG, "onClipboardChanged: " + data);
 		if (session != null)
 			LibFreeRDP.sendClipboardData(session.getInstance(), data);
+	}
+
+	@Override public void onClipboardImageChanged(byte[] data, String mimeType)
+	{
+		if (session != null && data != null)
+			LibFreeRDP.sendClipboardImageData(session.getInstance(), data, mimeType);
 	}
 
 	private void onConnectionStateChanged(SessionViewModel.ConnectionState state)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -297,8 +297,10 @@ public class SessionActivity extends AppCompatActivity
 	{
 		super.onWindowFocusChanged(hasFocus);
 		if (hasFocus)
+		{
 			hideSystemBars();
-		mClipboardManager.getPrimaryClipManually();
+			mClipboardManager.getPrimaryClipManually();
+		}
 	}
 
 	@Override protected void onStart()

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -155,6 +155,9 @@ public class LibFreeRDP
 
 	private static native boolean freerdp_send_clipboard_data(long inst, String data);
 
+	private static native boolean freerdp_send_clipboard_image_data(long inst, byte[] data,
+	                                                                String mimeType);
+
 	private static native boolean freerdp_send_monitor_layout(long inst, int width, int height);
 
 	private static native String freerdp_get_last_error_string(long inst);
@@ -553,6 +556,11 @@ public class LibFreeRDP
 		return freerdp_send_clipboard_data(inst, data);
 	}
 
+	public static boolean sendClipboardImageData(long inst, byte[] data, String mimeType)
+	{
+		return freerdp_send_clipboard_image_data(inst, data, mimeType);
+	}
+
 	public static boolean sendMonitorLayout(long inst, int width, int height)
 	{
 		return freerdp_send_monitor_layout(inst, width, height);
@@ -698,6 +706,16 @@ public class LibFreeRDP
 			uiEventListener.OnRemoteClipboardChanged(data);
 	}
 
+	private static void OnRemoteClipboardImageChanged(long inst, byte[] data)
+	{
+		SessionState s = GlobalApp.getSession(inst);
+		if (s == null)
+			return;
+		UIEventListener uiEventListener = s.getUIEventListener();
+		if (uiEventListener != null)
+			uiEventListener.OnRemoteClipboardImageChanged(data);
+	}
+
 	private static void OnPointerSet(long inst, int[] pixels, int width, int height, int hotX,
 	                                 int hotY)
 	{
@@ -769,6 +787,8 @@ public class LibFreeRDP
 		void OnGraphicsResize(int width, int height, int bpp);
 
 		void OnRemoteClipboardChanged(String data);
+
+		void OnRemoteClipboardImageChanged(byte[] data);
 
 		void OnPointerSet(int[] pixels, int width, int height, int hotX, int hotY);
 

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/ClipboardImageProvider.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/ClipboardImageProvider.java
@@ -1,0 +1,96 @@
+/*
+   Android Clipboard Image ContentProvider
+
+   Copyright 2026 Ibrahim Sevinc <svncibrahim@gmail.com>
+
+   This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+   If a copy of the MPL was not distributed with this file, You can obtain one at
+   http://mozilla.org/MPL/2.0/.
+ */
+
+package com.freerdp.freerdpcore.utils;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class ClipboardImageProvider extends ContentProvider
+{
+	public static final String AUTHORITY = "com.freerdp.freerdpcore.clipboard";
+	public static final Uri CONTENT_URI = Uri.parse("content://" + AUTHORITY + "/image");
+
+	private static volatile byte[] sImageData;
+
+	public static void setImageData(byte[] data)
+	{
+		sImageData = data;
+	}
+
+	@Override public boolean onCreate()
+	{
+		return true;
+	}
+
+	@Override public ParcelFileDescriptor openFile(Uri uri, String mode)
+	{
+		byte[] data = sImageData;
+		if (data == null)
+			return null;
+
+		try
+		{
+			ParcelFileDescriptor[] pipe = ParcelFileDescriptor.createPipe();
+			final ParcelFileDescriptor writeEnd = pipe[1];
+			Thread t = new Thread(() -> {
+				try (OutputStream out = new ParcelFileDescriptor.AutoCloseOutputStream(writeEnd))
+				{
+					out.write(data);
+				}
+				catch (IOException e)
+				{
+					// pipe closed by reader
+				}
+			});
+			t.setDaemon(true);
+			t.start();
+			return pipe[0];
+		}
+		catch (IOException e)
+		{
+			return null;
+		}
+	}
+
+	@Override public String getType(Uri uri)
+	{
+		return "image/png";
+	}
+
+	@Override
+	public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs,
+	                    String sortOrder)
+	{
+		return null;
+	}
+
+	@Override public Uri insert(Uri uri, ContentValues values)
+	{
+		return null;
+	}
+
+	@Override public int delete(Uri uri, String selection, String[] selectionArgs)
+	{
+		return 0;
+	}
+
+	@Override
+	public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs)
+	{
+		return 0;
+	}
+}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/ClipboardManagerProxy.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/ClipboardManagerProxy.java
@@ -1,8 +1,25 @@
+/*
+   Android Clipboard Manager Proxy
+
+   Copyright 2013 Thincast Technologies GmbH
+   Copyright 2013 Martin Fleisz <martin.fleisz@thincast.com>
+   Copyright 2026 Ibrahim Sevinc <svncibrahim@gmail.com>
+
+   This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+   If a copy of the MPL was not distributed with this file, You can obtain one at
+   http://mozilla.org/MPL/2.0/.
+ */
+
 package com.freerdp.freerdpcore.utils;
 
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.net.Uri;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
 public abstract class ClipboardManagerProxy
 {
@@ -13,6 +30,8 @@ public abstract class ClipboardManagerProxy
 
 	public abstract void setClipboardData(String data);
 
+	public abstract void setClipboardImage(byte[] pngData);
+
 	public abstract void addClipboardChangedListener(OnClipboardChangedListener listener);
 
 	public abstract void removeClipboardboardChangedListener(OnClipboardChangedListener listener);
@@ -22,16 +41,20 @@ public abstract class ClipboardManagerProxy
 	public interface OnClipboardChangedListener
 	{
 		void onClipboardChanged(String data);
+
+		void onClipboardImageChanged(byte[] data, String mimeType);
 	}
 
 	private static class HCClipboardManager
 	    extends ClipboardManagerProxy implements ClipboardManager.OnPrimaryClipChangedListener
 	{
+		private final Context mContext;
 		private final ClipboardManager mClipboardManager;
 		private OnClipboardChangedListener mListener;
 
 		public HCClipboardManager(Context ctx)
 		{
+			mContext = ctx;
 			mClipboardManager = (ClipboardManager)ctx.getSystemService(Context.CLIPBOARD_SERVICE);
 		}
 
@@ -41,20 +64,54 @@ public abstract class ClipboardManagerProxy
 			    ClipData.newPlainText("rdp-clipboard", data == null ? "" : data));
 		}
 
+		@Override public void setClipboardImage(byte[] pngData)
+		{
+			ClipboardImageProvider.setImageData(pngData);
+			ClipData clip = new ClipData("rdp-clipboard", new String[] { "image/png" },
+			                             new ClipData.Item(ClipboardImageProvider.CONTENT_URI));
+			mClipboardManager.setPrimaryClip(clip);
+		}
+
 		@Override public void onPrimaryClipChanged()
 		{
 			ClipData clip = mClipboardManager.getPrimaryClip();
-			String data = null;
+			if (clip == null || clip.getItemCount() == 0)
+				return;
 
-			if (clip != null && clip.getItemCount() > 0)
+			ClipData.Item item = clip.getItemAt(0);
+
+			CharSequence cs = item.getText();
+			if (cs != null)
 			{
-				CharSequence cs = clip.getItemAt(0).getText();
-				if (cs != null)
-					data = cs.toString();
+				if (mListener != null)
+					mListener.onClipboardChanged(cs.toString());
+				return;
 			}
-			if (mListener != null)
+
+			Uri uri = item.getUri();
+			if (uri != null)
 			{
-				mListener.onClipboardChanged(data);
+				String mimeType = mContext.getContentResolver().getType(uri);
+				if (mimeType != null && mimeType.startsWith("image/"))
+				{
+					try (InputStream is = mContext.getContentResolver().openInputStream(uri))
+					{
+						if (is != null)
+						{
+							ByteArrayOutputStream baos = new ByteArrayOutputStream();
+							byte[] buf = new byte[8192];
+							int n;
+							while ((n = is.read(buf)) != -1)
+								baos.write(buf, 0, n);
+							if (mListener != null)
+								mListener.onClipboardImageChanged(baos.toByteArray(), mimeType);
+						}
+					}
+					catch (IOException e)
+					{
+						// not an accessible image
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
## [client,android] Add bidirectional clipboard image transfer

 - Fixes #10713

### Description
Clipboard image transfer support for aFreeRDP:

- **Server -> Android:** Incoming CF_DIB / CF_DIBV5 clipboard data is converted
  to PNG via winpr and placed on the Android clipboard using a ContentProvider.

- **Android -> Server:** Images copied on Android (PNG, JPEG, WebP) are sent to
  the server; winpr handles format conversion in both directions. Unsupported
  formats are silently ignored via `winpr_image_format_is_supported`.

Text clipboard continues to work unchanged.

### Testing Instructions
1. Copy an image on the RDP server > paste on Android > image appears in clipboard.
2. Copy an image on Android > paste on the RDP server > image appears.
3. Copy text in both directions > verify no regression.
4. Connect to a server that sends no image format > verify no crash.

### Environments Tested
- Physical Device: Android 16 (API 36)