### PR TITLE
[client,android] Add accessibility service for physical keyboard shortcuts

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/AndroidManifest.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/AndroidManifest.xml
@@ -112,6 +112,20 @@
             android:exported="false"
             android:grantUriPermissions="true" />
 
+        <service
+            android:name=".presentation.KeyboardAccessibilityService"
+            android:label="@string/accessibility_keyboard_label"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/keyboard_accessibility_service" />
+        </service>
+
     </application>
 
 </manifest>

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/KeyboardAccessibilityService.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/KeyboardAccessibilityService.java
@@ -1,0 +1,69 @@
+/*
+   Physical Keyboard Accessibility Service
+
+   Copyright 2026 Ibrahim Sevinc <ibrahim.sevinc.mail@gmail.com>
+
+   This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+   If a copy of the MPL was not distributed with this file, You can obtain one at
+   http://mozilla.org/MPL/2.0/.
+ */
+
+package com.freerdp.freerdpcore.presentation;
+
+import android.accessibilityservice.AccessibilityService;
+import android.accessibilityservice.AccessibilityServiceInfo;
+import android.view.InputDevice;
+import android.view.KeyEvent;
+import android.view.accessibility.AccessibilityEvent;
+
+public class KeyboardAccessibilityService extends AccessibilityService
+{
+	@Override public boolean onKeyEvent(KeyEvent event)
+	{
+		SessionActivity session = SessionActivity.activeSession;
+		if (session == null)
+			return super.onKeyEvent(event);
+
+		InputDevice device = event.getDevice();
+		if (device != null &&
+		    (device.getSources() & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD)
+			return super.onKeyEvent(event);
+
+		switch (event.getKeyCode())
+		{
+			case KeyEvent.KEYCODE_VOLUME_UP:
+			case KeyEvent.KEYCODE_VOLUME_DOWN:
+			case KeyEvent.KEYCODE_POWER:
+				return super.onKeyEvent(event);
+		}
+
+		/* Some tablets map the physical ESC key to KEYCODE_BACK (scancode 1).*/
+		if (event.getScanCode() == 1 && event.getKeyCode() != KeyEvent.KEYCODE_ESCAPE)
+		{
+			event =
+			    new KeyEvent(event.getDownTime(), event.getEventTime(), event.getAction(),
+			                 KeyEvent.KEYCODE_ESCAPE, event.getRepeatCount(), event.getMetaState());
+		}
+
+		return session.handleKeyEvent(event);
+	}
+
+	@Override public void onServiceConnected()
+	{
+		AccessibilityServiceInfo info = new AccessibilityServiceInfo();
+		info.packageNames = new String[] { getApplicationContext().getPackageName() };
+		info.eventTypes = AccessibilityEvent.TYPES_ALL_MASK;
+		info.notificationTimeout = 100;
+		info.flags = AccessibilityServiceInfo.FLAG_REQUEST_FILTER_KEY_EVENTS;
+		info.feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC;
+		setServiceInfo(info);
+	}
+
+	@Override public void onAccessibilityEvent(AccessibilityEvent event)
+	{
+	}
+
+	@Override public void onInterrupt()
+	{
+	}
+}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -62,6 +62,7 @@ public class SessionActivity extends AppCompatActivity
 	public static final String PARAM_CONNECTION_REFERENCE = "conRef";
 	public static final String PARAM_INSTANCE = "instance";
 	private static final String TAG = "FreeRDP.SessionActivity";
+	static volatile SessionActivity activeSession;
 	private Bitmap bitmap;
 	private SessionState session;
 	private SessionView sessionView;
@@ -319,13 +320,15 @@ public class SessionActivity extends AppCompatActivity
 	{
 		super.onResume();
 		Log.v(TAG, "Session.onResume");
+		activeSession = this;
 	}
 
 	@Override protected void onPause()
 	{
 		super.onPause();
 		Log.v(TAG, "Session.onPause");
-
+		if (activeSession == this)
+			activeSession = null;
 		// hide any visible keyboards
 		inputManager.hideKeyboards();
 	}
@@ -613,6 +616,11 @@ public class SessionActivity extends AppCompatActivity
 		if (inputManager.onAndroidKeyLongPress(keyCode))
 			return true;
 		return super.onKeyLongPress(keyCode, event);
+	}
+
+	boolean handleKeyEvent(KeyEvent event)
+	{
+		return inputManager != null && inputManager.onAndroidKeyEvent(event);
 	}
 
 	// android keyboard input handling

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/ClipboardImageProvider.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/ClipboardImageProvider.java
@@ -1,7 +1,7 @@
 /*
    Android Clipboard Image ContentProvider
 
-   Copyright 2026 Ibrahim Sevinc <svncibrahim@gmail.com>
+   Copyright 2026 Ibrahim Sevinc <ibrahim.sevinc.mail@gmail.com>
 
    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
    If a copy of the MPL was not distributed with this file, You can obtain one at

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/ClipboardManagerProxy.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/ClipboardManagerProxy.java
@@ -3,7 +3,7 @@
 
    Copyright 2013 Thincast Technologies GmbH
    Copyright 2013 Martin Fleisz <martin.fleisz@thincast.com>
-   Copyright 2026 Ibrahim Sevinc <svncibrahim@gmail.com>
+   Copyright 2026 Ibrahim Sevinc <ibrahim.sevinc.mail@gmail.com>
 
    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
    If a copy of the MPL was not distributed with this file, You can obtain one at

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/KeyboardMapper.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/KeyboardMapper.java
@@ -227,6 +227,8 @@ public class KeyboardMapper
 	private boolean isCtrlLocked = false;
 	private boolean isAltLocked = false;
 	private boolean isWinLocked = false;
+	private boolean isWinKeyDown = false;
+	private boolean isWinComboUsed = false;
 
 	public void init(Context context)
 	{
@@ -446,6 +448,8 @@ public class KeyboardMapper
 		ctrlPressed = false;
 		altPressed = false;
 		winPressed = false;
+		isWinKeyDown = false;
+		isWinComboUsed = false;
 		setKeyProcessingListener(listener);
 	}
 
@@ -461,11 +465,37 @@ public class KeyboardMapper
 			// we only process down events
 			case KeyEvent.ACTION_UP:
 			{
+				if (event.getKeyCode() == KeyEvent.KEYCODE_META_LEFT ||
+				    event.getKeyCode() == KeyEvent.KEYCODE_META_RIGHT)
+				{
+					if (!isWinKeyDown)
+						return false;
+					isWinKeyDown = false;
+					if (!isWinComboUsed)
+					{
+						listener.processVirtualKey(VK_LWIN | VK_EXT_KEY, true);
+						listener.processVirtualKey(VK_LWIN | VK_EXT_KEY, false);
+					}
+					isWinComboUsed = false;
+					return true;
+				}
 				return false;
 			}
 
 			case KeyEvent.ACTION_DOWN:
 			{
+				/* Physical Win key: buffer until release to distinguish tap vs combo. */
+				if (event.getKeyCode() == KeyEvent.KEYCODE_META_LEFT ||
+				    event.getKeyCode() == KeyEvent.KEYCODE_META_RIGHT)
+				{
+					isWinKeyDown = true;
+					isWinComboUsed = false;
+					return true;
+				}
+
+				if (isWinKeyDown)
+					isWinComboUsed = true;
+
 				boolean modifierActive = isModifierPressed();
 				// if a modifier is pressed we will send a VK event (if possible) so that key
 				// combinations will be recognized correctly. Otherwise we will send the unicode
@@ -475,43 +505,33 @@ public class KeyboardMapper
 					listener.processUnicodeKey(vkcode & (~KEY_FLAG_UNICODE));
 				// if we got a valid vkcode send it - except for letters/numbers if a modifier is
 				// active
-				else if (vkcode > 0 && (event.getMetaState() &
-				                        (KeyEvent.META_ALT_ON | KeyEvent.META_SHIFT_ON |
-				                         KeyEvent.META_SYM_ON | KeyEvent.META_CTRL_ON)) == 0)
+				else if (vkcode > 0 && !event.isSymPressed())
 				{
+					boolean sendCtrl = !ctrlPressed && event.isCtrlPressed();
+					boolean sendAlt = !altPressed && event.isAltPressed();
+					boolean sendWin = !winPressed && isWinKeyDown;
+					boolean sendShift = !shiftPressed && event.isShiftPressed();
+
+					if (sendCtrl)
+						listener.processVirtualKey(VK_LCONTROL, true);
+					if (sendAlt)
+						listener.processVirtualKey(VK_LMENU, true);
+					if (sendWin)
+						listener.processVirtualKey(VK_LWIN | VK_EXT_KEY, true);
+					if (sendShift)
+						listener.processVirtualKey(VK_LSHIFT, true);
+
 					listener.processVirtualKey(vkcode, true);
 					listener.processVirtualKey(vkcode, false);
-				}
-				else if (vkcode > 0 && !ctrlPressed &&
-				         (event.getMetaState() & KeyEvent.META_CTRL_ON) != 0)
-				{
-					listener.processVirtualKey(VK_LCONTROL, true);
-					listener.processVirtualKey(vkcode, true);
-					listener.processVirtualKey(vkcode, false);
-					listener.processVirtualKey(VK_LCONTROL, false);
-				}
-				else if (vkcode > 0 && !altPressed &&
-				         (event.getMetaState() & KeyEvent.META_ALT_ON) != 0)
-				{
-					listener.processVirtualKey(VK_LMENU, true);
-					listener.processVirtualKey(vkcode, true);
-					listener.processVirtualKey(vkcode, false);
-					listener.processVirtualKey(VK_LMENU, false);
-				}
-				else if (vkcode > 0 && !winPressed &&
-				         (event.getMetaState() & KeyEvent.META_META_ON) != 0)
-				{
-					listener.processVirtualKey(VK_LWIN | VK_EXT_KEY, true);
-					listener.processVirtualKey(vkcode, true);
-					listener.processVirtualKey(vkcode, false);
-					listener.processVirtualKey(VK_LWIN | VK_EXT_KEY, false);
-				}
-				else if (event.isShiftPressed() && vkcode != 0)
-				{
-					listener.processVirtualKey(VK_LSHIFT, true);
-					listener.processVirtualKey(vkcode, true);
-					listener.processVirtualKey(vkcode, false);
-					listener.processVirtualKey(VK_LSHIFT, false);
+
+					if (sendShift)
+						listener.processVirtualKey(VK_LSHIFT, false);
+					if (sendWin)
+						listener.processVirtualKey(VK_LWIN | VK_EXT_KEY, false);
+					if (sendAlt)
+						listener.processVirtualKey(VK_LMENU, false);
+					if (sendCtrl)
+						listener.processVirtualKey(VK_LCONTROL, false);
 				}
 				else if (event.getUnicodeChar() != 0)
 					listener.processUnicodeKey(event.getUnicodeChar());
@@ -527,8 +547,11 @@ public class KeyboardMapper
 			case KeyEvent.ACTION_MULTIPLE:
 			{
 				String str = event.getCharacters();
-				for (int i = 0; i < str.length(); i++)
-					listener.processUnicodeKey(str.charAt(i));
+				if (str != null)
+				{
+					for (int i = 0; i < str.length(); i++)
+						listener.processUnicodeKey(str.charAt(i));
+				}
 				return true;
 			}
 

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -317,4 +317,8 @@
     <string name="print_notif_title">Print job received</string>
     <string name="print_notif_open">Open</string>
     <string name="print_notif_print">Print</string>
+    <string name="accessibility_keyboard_label">aFreeRDP Physical Keyboard</string>
+    <string name="accessibility_keyboard_description">Sends physical keyboard shortcuts (e.g. Win key) to the remote desktop.</string>
+    <string name="pref_title_keyboard_accessibility">Physical Keyboard Shortcuts</string>
+    <string name="pref_summary_keyboard_accessibility">Send Win key and system shortcuts to the remote desktop. Requires accessibility permission.</string>
 </resources>

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/keyboard_accessibility_service.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/keyboard_accessibility_service.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/accessibility_keyboard_description"
+    android:accessibilityEventTypes="typeAllMask"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagRequestFilterKeyEvents"
+    android:canRequestFilterKeyEvents="true"
+    android:notificationTimeout="100"
+    android:settingsActivity="" />

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_ui.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_ui.xml
@@ -32,4 +32,9 @@
     <CheckBoxPreference
         android:key="@string/preference_key_ui_use_back_as_altf4"
         android:title="@string/settings_ui_use_back_as_altf4" />
+    <Preference
+        android:title="@string/pref_title_keyboard_accessibility"
+        android:summary="@string/pref_summary_keyboard_accessibility">
+        <intent android:action="android.settings.ACCESSIBILITY_SETTINGS" />
+    </Preference>
 </PreferenceScreen>


### PR DESCRIPTION
## [client,android] Add accessibility service for physical keyboard shortcuts

- Fixes #10646
### Description
Physical keyboard shortcuts (Win key combos) now reach the remote desktop
instead of triggering Android system actions.

- **Win+key combos:** Win key is buffered on press and delivered as a tap on
  release if used alone, or as Win+key when combined with another key.
- **Ctrl/Alt/Shift/Win unified:** Separate per-modifier branches in
  `KeyboardMapper` replaced with a single block handling all modifiers together,
  enabling multi-modifier combos (e.g. Ctrl+Alt+Del).
- **Settings entry:** Settings -> User Interface -> Physical Keyboard Shortcuts
  opens the system accessibility settings.

### Testing Instructions
1. Enable the service from Settings -> User Interface -> Physical Keyboard Shortcuts.
2. Press Win -> Start menu opens on remote.
3. Press Win+R -> Run dialog opens on remote.
4. Press Win+Tab -> Task view opens on remote.
5. Press Ctrl+Alt+Del -> security screen opens on remote.
6. Press Ctrl+C / Ctrl+V -> verify no regression.

### Environments Tested
- Physical Device: Android 16 (API 36)