### PR TITLE
[client,windows] honor /from-stdin in wfreerdp

### DIFF
--- a/client/Windows/wf_client.c
+++ b/client/Windows/wf_client.c
@@ -52,6 +52,7 @@
 #include <freerdp/locale/locale.h>
 #include <freerdp/locale/keyboard.h>
 #include <freerdp/codec/region.h>
+#include <freerdp/client.h>
 #include <freerdp/client/cmdline.h>
 #include <freerdp/client/channels.h>
 #include <freerdp/channels/channels.h>
@@ -542,6 +543,12 @@ static BOOL wf_authenticate_ex(freerdp* instance, char** username, char** passwo
 	WINPR_ASSERT(username);
 	WINPR_ASSERT(domain);
 	WINPR_ASSERT(password);
+
+	/* /from-stdin: delegate to the common CLI handler instead of prompting via GUI.
+	 * Settings are fully parsed by the time auth callbacks fire, so this branch
+	 * reliably observes the user's choice. */
+	if (freerdp_settings_get_bool(instance->context->settings, FreeRDP_CredentialsFromStdin))
+		return client_cli_authenticate_ex(instance, username, password, domain, reason);
 
 	const WCHAR auth[] = L"Target credentials requested";
 	const WCHAR authPin[] = L"PIN requested";

--- a/libfreerdp/utils/passphrase.c
+++ b/libfreerdp/utils/passphrase.c
@@ -29,6 +29,7 @@
 #ifdef _WIN32
 
 #include <stdio.h>
+#include <string.h>
 #include <io.h>
 #include <conio.h>
 #include <wincred.h>
@@ -52,6 +53,52 @@ int freerdp_interruptible_getc(rdpContext* context, FILE* f)
 const char* freerdp_passphrase_read(rdpContext* context, const char* prompt, char* buf,
                                     size_t bufsiz, int from_stdin)
 {
+	if (bufsiz == 0)
+	{
+		errno = EINVAL;
+		return nullptr;
+	}
+
+	/* When /from-stdin is requested, read the password from stdin. The Unix
+	 * counterpart (freerdp_passphrase_read_tty) does the same, suppressing
+	 * terminal echo via tcsetattr; suppress console echo here via SetConsoleMode
+	 * when stdin is an interactive console. On a pipe the echo bit is moot. */
+	if (from_stdin)
+	{
+		HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
+		const BOOL isTty = _isatty(_fileno(stdin)) != 0;
+		DWORD origMode = 0;
+		BOOL echoSuppressed = FALSE;
+
+		if (isTty && hStdin && hStdin != INVALID_HANDLE_VALUE && GetConsoleMode(hStdin, &origMode))
+		{
+			if (SetConsoleMode(hStdin, origMode & ~(DWORD)ENABLE_ECHO_INPUT))
+				echoSuppressed = TRUE;
+		}
+
+		if (prompt)
+		{
+			(void)fputs(prompt, stdout);
+			(void)fflush(stdout);
+		}
+
+		WINPR_ASSERT(bufsiz <= INT32_MAX);
+		const char* rc = fgets(buf, (int)bufsiz, stdin);
+
+		if (echoSuppressed)
+		{
+			(void)SetConsoleMode(hStdin, origMode);
+			(void)fputc('\n', stdout);
+			(void)fflush(stdout);
+		}
+
+		if (!rc)
+			return nullptr;
+
+		buf[strcspn(buf, "\r\n")] = '\0';
+		return buf;
+	}
+
 	WCHAR UserNameW[CREDUI_MAX_USERNAME_LENGTH + 1] = { 'p', 'r', 'e', 'f', 'i',
 		                                                'l', 'l', 'e', 'd', '\0' };
 	WCHAR PasswordW[CREDUI_MAX_PASSWORD_LENGTH + 1] = WINPR_C_ARRAY_INIT;


### PR DESCRIPTION
## Summary
  `wfreerdp.exe /from-stdin` has silently ignored piped credentials since 1e63d8c49 (Mar 2023). `echo pw | wfreerdp.exe /v:host /u:user /from-stdin` drops the password and pops the GUI
  login dialog instead. This restores the behavior originally added in 07ea60e96.

  Three stacked issues:

  1. `freerdp_passphrase_read` on Windows unconditionally invoked `CredUICmdLinePromptForCredentialsW`, which does not consume piped stdin. Now reads stdin via `fgets` when `from_stdin`
  is set, suppressing console echo via `SetConsoleMode` on an interactive tty to match the Unix `tcsetattr`-based behavior.

  2. `wf_authenticate_ex` had a `/from-stdin` branch but it was gated on `wfc->isConsole`, which `wf_has_console()` returns FALSE for piped stdin. Replaced with a delegation: when
  `/from-stdin` is set, `wf_pre_connect` overrides `instance->AuthenticateEx` with the common `client_cli_authenticate_ex`, eliminating duplicated stdin-reading logic.

  3. The `FreeConsole()` call and GUI cert/gateway callback installation lived in `wfreerdp_client_new`, which runs **before** `freerdp_client_settings_parse_command_line`. That meant
  stdin was already severed and GUI dialogs already wired up before `/from-stdin` was even visible. Moved to `wf_pre_connect`, which runs after command-line parsing.

  ## Test plan
  - [ ] Piped: `echo "mypassword" | wfreerdp.exe /v:host /u:user /from-stdin /cert:ignore` → connects without GUI prompt
  - [ ] Interactive console: `wfreerdp.exe /v:host /u:user /from-stdin /cert:ignore` from a real cmd/PowerShell → prompts on stdout, password input is not echoed, connects
  - [ ] No regression: `wfreerdp.exe /v:host /u:user` (GUI launch, no `/from-stdin`) → CredUI dialog appears as before
  - [ ] Gateway: `echo -e "user\ngwpw\npw" | wfreerdp.exe /v:host /u:user /from-stdin /g:gw /gu:gwuser` → all three credentials consumed in order
