### PR TITLE
[channels,rdpgfx] fix server frame command returning success on write failure

### DIFF
--- a/channels/rdpgfx/server/rdpgfx_main.c
+++ b/channels/rdpgfx/server/rdpgfx_main.c
@@ -952,7 +952,10 @@ rdpgfx_send_surface_frame_command(RdpgfxServerContext* context, const RDPGFX_SUR
 
 		if (!rdpgfx_write_start_frame_pdu(s, startFrame) ||
 		    !rdpgfx_server_packet_complete_header(s, position))
+		{
+			error = ERROR_INTERNAL_ERROR;
 			goto error;
+		}
 	}
 
 	/* Write RDPGFX_CMDID_WIRETOSURFACE_1 or RDPGFX_CMDID_WIRETOSURFACE_2 */
@@ -977,7 +980,10 @@ rdpgfx_send_surface_frame_command(RdpgfxServerContext* context, const RDPGFX_SUR
 		}
 
 		if (!rdpgfx_server_packet_complete_header(s, pos))
+		{
+			error = ERROR_INTERNAL_ERROR;
 			goto error;
+		}
 	}
 
 	/* Write end frame if exists */
@@ -995,7 +1001,10 @@ rdpgfx_send_surface_frame_command(RdpgfxServerContext* context, const RDPGFX_SUR
 
 		if (!rdpgfx_write_end_frame_pdu(s, endFrame) ||
 		    !rdpgfx_server_packet_complete_header(s, position))
+		{
+			error = ERROR_INTERNAL_ERROR;
 			goto error;
+		}
 	}
 
 	return rdpgfx_server_packet_send(context, s);


### PR DESCRIPTION
## Summary

`rdpgfx_send_surface_frame_command()` (channels/rdpgfx/server/rdpgfx_main.c) can return `CHANNEL_RC_OK` (success) to its caller even when serializing the frame PDU failed.

`error` is initialized to `CHANNEL_RC_OK` and is only ever assigned a meaningful value by `rdpgfx_server_packet_init_header()` and `rdpgfx_write_surface_command()`. The three `goto error` statements that guard the **BOOL-returning** helpers jump to the cleanup label **without** updating `error` first:

```c
if (!rdpgfx_write_start_frame_pdu(s, startFrame) ||
    !rdpgfx_server_packet_complete_header(s, position))
    goto error;        // error is still CHANNEL_RC_OK here
...
if (!rdpgfx_server_packet_complete_header(s, pos))
    goto error;        // error is still CHANNEL_RC_OK here
...
if (!rdpgfx_write_end_frame_pdu(s, endFrame) ||
    !rdpgfx_server_packet_complete_header(s, position))
    goto error;        // error is still CHANNEL_RC_OK here
```

The cleanup label frees the stream and `return error;` — so the caller is told the frame was sent successfully.

## Why these helpers actually fail

- `rdpgfx_write_start_frame_pdu()` / `rdpgfx_write_end_frame_pdu()` return `FALSE` when `Stream_EnsureRemainingCapacity()` fails.
- `rdpgfx_server_packet_complete_header()` returns `FALSE` on a capacity/position guard violation (`cap < start + RDPGFX_HEADER_SIZE`, `start > UINT32_MAX`, or `current < start`).

In those cases a truncated/malformed WIRETOSURFACE PDU may be flushed to the client while the server treats the send as successful, masking the failure from upper layers.

## Fix

Set `error = ERROR_INTERNAL_ERROR` before each of the three `goto error` jumps so the failure is propagated to the caller. No behavioral change on the success path; +9 lines, one file.

This was found while building an RDP server on top of the rdpgfx server channel (AVC420 surface frames), where the send path is exercised per frame.