### PR TITLE
[channels,rdpsnd] reject client audio formats with zero nChannels/nBlockAlign (server-side DoS)

### DIFF
--- a/channels/rdpsnd/server/rdpsnd_main.c
+++ b/channels/rdpsnd/server/rdpsnd_main.c
@@ -241,6 +241,18 @@ static UINT rdpsnd_server_recv_formats(RdpsndServerContext* context, wStream* s)
 		Stream_Read_UINT16(s, format->wBitsPerSample);
 		Stream_Read_UINT16(s, format->cbSize);
 
+		/* nChannels and nBlockAlign are used as divisors when sending audio
+		 * (rdpsnd_server_align_wave_pdu: size % nBlockAlign; ADPCM frame sizing
+		 * divides by nChannels). A malicious client can advertise a format with
+		 * either field set to 0, causing a division by zero. No valid
+		 * WAVEFORMATEX has zero channels or zero block alignment. */
+		if ((format->nChannels == 0) || (format->nBlockAlign == 0))
+		{
+			WLog_ERR(TAG, "invalid client audio format: nChannels or nBlockAlign is 0");
+			error = ERROR_INVALID_DATA;
+			goto out_free;
+		}
+
 		if (format->cbSize > 0)
 		{
 			if (!Stream_SafeSeek(s, format->cbSize))


### PR DESCRIPTION
## Summary

A malicious RDP client can crash a FreeRDP-based RDP **server** (SIGFPE / division by zero) by sending a Client Audio Formats PDU containing an audio format whose `nChannels` or `nBlockAlign` is `0`.

`rdpsnd_server_recv_formats()` reads each `AUDIO_FORMAT` straight from the wire without validating these two fields:

```c
Stream_Read_UINT16(s, format->nChannels);     // line 237 — not validated
...
Stream_Read_UINT16(s, format->nBlockAlign);   // line 240 — not validated
```

Both are later used as **divisors** when the server sends audio:

- `rdpsnd_server_align_wave_pdu()` pads the WAVE/WAVE2 PDU with `size % format->nBlockAlign` → **division by zero if `nBlockAlign == 0`** (called from both the WAVE and WAVE2 send paths).
- The ADPCM frame-size calculation in the format-select path divides by `format->nChannels` → **division by zero if `nChannels == 0`**.

`nSamplesPerSec` is already validated (at the use site in the select path), but `nChannels`/`nBlockAlign` are not — and the public `rdpsnd_server_send_samples2()` / `formatNo` path indexes `client_formats[]` directly, bypassing the select-path checks entirely.

## Fix

Validate both fields at receipt — where the other malformed-input checks already live — and reject the PDU with `ERROR_INVALID_DATA`. No valid `WAVEFORMATEX` has a zero channel count or zero block alignment, so this rejects only malformed input and changes nothing for legitimate clients. +12 lines, one file.

## Reachability

Triggered by untrusted client input (the formats PDU) and exercised whenever the server subsequently sends audio with the offending format — i.e. a remote, pre-auth-adjacent DoS for any server that enables the rdpsnd channel.

Found while building an RDP server on top of the rdpsnd server channel.