### PR TITLE
[channels,rdpsnd] skip unusable playback backend during selection

### DIFF
--- a/channels/rdpsnd/client/oss/rdpsnd_oss.c
+++ b/channels/rdpsnd/client/oss/rdpsnd_oss.c
@@ -207,16 +207,24 @@ static void rdpsnd_oss_open_mixer(rdpsndOssPlugin* oss)
 	}
 }
 
+/* Build the OSS PCM device path (/dev/dsp or /dev/dsp<unit>). */
+static void rdpsnd_oss_pcm_device_name(const rdpsndOssPlugin* oss, char* dev_name, size_t size)
+{
+	if (oss->dev_unit != -1)
+		(void)sprintf_s(dev_name, size, "/dev/dsp%i", oss->dev_unit);
+	else
+		(void)sprintf_s(dev_name, size, "/dev/dsp");
+}
+
 static BOOL rdpsnd_oss_open(rdpsndDevicePlugin* device, const AUDIO_FORMAT* format, UINT32 latency)
 {
-	char dev_name[PATH_MAX] = "/dev/dsp";
+	char dev_name[PATH_MAX] = { 0 };
 	rdpsndOssPlugin* oss = (rdpsndOssPlugin*)device;
 
 	if (device == nullptr || oss->pcm_handle != -1)
 		return TRUE;
 
-	if (oss->dev_unit != -1)
-		(void)sprintf_s(dev_name, PATH_MAX - 1, "/dev/dsp%i", oss->dev_unit);
+	rdpsnd_oss_pcm_device_name(oss, dev_name, sizeof(dev_name));
 
 	WLog_INFO(TAG, "open: %s", dev_name);
 
@@ -439,6 +447,25 @@ FREERDP_ENTRY_POINT(UINT VCAPITYPE oss_freerdp_rdpsnd_client_subsystem_entry(
 		free(oss);
 		return ERROR_INVALID_PARAMETER;
 	}
+
+	/* Only register the backend if the OSS device actually exists and is
+	 * writable. On systems without OSS (no /dev/dsp) this leaves rdpsnd->device
+	 * unset so subsystem selection falls through to the next available backend.
+	 * Otherwise oss gets selected and the first audio the server streams fails
+	 * to open the device, which aborts the whole RDP connection. */
+	{
+		char dev_name[PATH_MAX] = { 0 };
+		rdpsnd_oss_pcm_device_name(oss, dev_name, sizeof(dev_name));
+
+		if (access(dev_name, W_OK) != 0)
+		{
+			WLog_WARN(TAG, "OSS device %s not available (errno %d), skipping oss backend", dev_name,
+			          errno);
+			free(oss);
+			return CHANNEL_RC_INITIALIZATION_ERROR;
+		}
+	}
+
 	pEntryPoints->pRegisterRdpsndDevice(pEntryPoints->rdpsnd, (rdpsndDevicePlugin*)oss);
 	return CHANNEL_RC_OK;
 }

--- a/channels/rdpsnd/client/rdpsnd_main.c
+++ b/channels/rdpsnd/client/rdpsnd_main.c
@@ -870,10 +870,11 @@ static UINT rdpsnd_load_device_plugin(rdpsndPlugin* rdpsnd, const char* name,
 
 	error = entry(&entryPoints);
 	if (error)
-		WLog_ERR(TAG, "%s %s entry returns error %" PRIu32 "", rdpsnd_is_dyn_str(rdpsnd->dynamic),
-		         name, error);
+		WLog_WARN(TAG, "%s %s entry returns error %" PRIu32 "", rdpsnd_is_dyn_str(rdpsnd->dynamic),
+		          name, error);
+	else
+		WLog_INFO(TAG, "%s Loaded %s backend for rdpsnd", rdpsnd_is_dyn_str(rdpsnd->dynamic), name);
 
-	WLog_INFO(TAG, "%s Loaded %s backend for rdpsnd", rdpsnd_is_dyn_str(rdpsnd->dynamic), name);
 	return error;
 }
 
@@ -1084,10 +1085,10 @@ static UINT rdpsnd_process_connect(rdpsndPlugin* rdpsnd)
 			const char* device_name = backends[x].device;
 
 			if ((status = rdpsnd_load_device_plugin(rdpsnd, subsystem_name, args)))
-				WLog_ERR(TAG,
-				         "%s Unable to load sound playback subsystem %s because of error %" PRIu32
-				         "",
-				         rdpsnd_is_dyn_str(rdpsnd->dynamic), subsystem_name, status);
+				WLog_WARN(TAG,
+				          "%s Unable to load sound playback subsystem %s because of error %" PRIu32
+				          "",
+				          rdpsnd_is_dyn_str(rdpsnd->dynamic), subsystem_name, status);
 
 			if (!rdpsnd->device)
 				continue;


### PR DESCRIPTION
## What this does

On a Linux host without OSS (no `/dev/dsp`), the `oss` rdpsnd client backend still registered a playback device. `rdpsnd_process_connect` selects the first backend that registers a device, so `oss` got selected even though it can't open one. The failure only surfaced later: the first audio the server streamed failed to open the device, the wave PDU handler returned `ERROR_INTERNAL_ERROR`, and the **whole RDP connection was aborted** (`transport_read_layer … Broken pipe` → `ERRCONNECT_CONNECT_TRANSPORT_FAILED`).

The `oss` backend now verifies the device exists and is writable in its entry point before registering, so subsystem selection falls through to the next available backend (ultimately `fake`) instead of picking one that cannot play. The device-name logic shared with `rdpsnd_oss_open` is factored into a small helper.

Also fixes `rdpsnd_load_device_plugin` logging: only log `Loaded <name> backend` on success (it previously logged that even when the entry failed), and log a failed backend load at `WARN` rather than `ERROR`, since selection falls back to the next candidate.

## How to test

On a host **without OSS** (PulseAudio/PipeWire only, no `/dev/dsp`), build a client with only the oss rdpsnd backend (`-DWITH_OSS=ON -DWITH_PULSE=OFF -DWITH_ALSA=OFF`), connect, and play audio on the server.

*Before:* the connection drops:
```
rdpsnd_oss_open: sound dev open failed: 2 - No such file or directory
transport_read_layer: BIO_read ... Broken pipe
ERRCONNECT_CONNECT_TRANSPORT_FAILED
```

*After:* oss is skipped and selection falls through; the session stays connected:
```
WARN  OSS device /dev/dsp not available (errno 2), skipping oss backend
INFO  Loaded fake backend for rdpsnd
```

## Notes

- No new unit tests — this is runtime device-availability/selection behavior that needs a real audio environment to exercise.
- clang-format clean; clang-tidy and the clang static analyzer report no findings on the change.
- AI assisted with human review.
