### PR TITLE
Xorg regression: Incorrect xevent being captured and sent to RDP server

### DIFF
--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -50,8 +50,7 @@
 
 #define MIN_FINGER_DIST 5
 
-static int xf_input_event(xfContext* xfc, WINPR_ATTR_UNUSED const XEvent* xevent,
-                          XIDeviceEvent* event, int evtype);
+static int xf_input_event(xfContext* xfc, const XEvent* xevent, XIDeviceEvent* event, int evtype);
 
 #ifdef DEBUG_XINPUT
 static const char* xf_input_get_class_string(int class)
@@ -754,8 +753,7 @@ static bool xf_use_rel_mouse(xfContext* xfc)
 	return true;
 }
 
-int xf_input_event(xfContext* xfc, WINPR_ATTR_UNUSED const XEvent* xevent, XIDeviceEvent* event,
-                   int evtype)
+int xf_input_event(xfContext* xfc, const XEvent* xevent, XIDeviceEvent* event, int evtype)
 {
 	WINPR_ASSERT(xfc);
 	WINPR_ASSERT(xevent);
@@ -764,6 +762,10 @@ int xf_input_event(xfContext* xfc, WINPR_ATTR_UNUSED const XEvent* xevent, XIDev
 	xfWindow* window = xfc->window;
 	if (window)
 	{
+		/* Ignore events for other windows */
+		if (xevent->xany.window != window->handle && !xfc->remote_app)
+			return 0;
+
 		if (xf_floatbar_is_locked(window->floatbar))
 			return 0;
 	}


### PR DESCRIPTION
## Bug description

This bug appears after PR #11384

in good case, gnome-screenshot from laptop won't inject mouse events into RDP.  
in bad case, mouse events went into RDP even if it's unrelated to this X window.

`-grab-mouse /mouse:relative:off,grab:off` won't help.

### Repro steps

1. Archlinux fresh gnome-xorg installation.
2. RDP to any windows box. Tap "Print Screen", which will be handle by gnome-screenshot.
3. Drag any square.

- Expected behavior
Screenshot completes. RDP window not touched.

- Actual behavior
Screenshot completes. But mouse drag forwarded to RDP server, messed up texts.

### Regression

Good commit: `cf11b32bd527d0413a87cbf40014019d1a7bf1f5  Fri Apr 11 08:20:45 2025`  
Bad commit: `3805575c5819b59938135d4dccd35797cba11a14  Fri Apr 11 08:21:14 2025`

## About this fix

It's straightforward. Check for xevent.window before handle mouse event.

## Test Recording

(1) Good case, before PR 11384: 

https://github.com/user-attachments/assets/21ebae7d-c638-4788-935c-afc357b672a8

(2) Bad case, after PR 11384: 

https://github.com/user-attachments/assets/c08d628c-da15-48b2-b90c-17679e4eaa4d

(3) Fixed case, after PR 11384 + this fix:

https://github.com/user-attachments/assets/9289fcd1-806c-4691-850a-f2f5f504b0bd


<details><summary>Click to expand DEBUG details...</summary>
I collected some debug log using [this xf_input.c  + debug prints](https://github.com/recolic/freerdp-recolic/blob/r/debug/61fix-files/debug-version-xf_input.c):

1. I launched RDP to my server, put the X window to front
2. I carefully leave cursor outside that X window
3. I started recording stdout
4. I touched PrtScr key (mouse still outside RDP window!), moved mouse into RDP window, drag a square once, drag a square twice, touched ESC
5. I saved all log.

[Resulting log](https://github.com/recolic/freerdp-recolic/blob/r/debug/61fix-files/testres.log)

</details>