### PR TITLE
Fix copying multiple items of the same type between xfreerdp sessions

### DIFF
--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -157,7 +157,7 @@ static const char type_FileGroupDescriptorW[] = "FileGroupDescriptorW";
 static const char type_HtmlFormat[] = "HTML Format";
 
 static void xf_cliprdr_clear_cached_data(xfClipboard* clipboard);
-static UINT xf_cliprdr_send_client_format_list(xfClipboard* clipboard, BOOL force);
+static UINT xf_cliprdr_send_client_format_list(xfClipboard* clipboard);
 static void xf_cliprdr_set_selection_owner(xfContext* xfc, xfClipboard* clipboard, Time timestamp);
 
 static void requested_format_free(RequestedFormat** ppRequestedFormat)
@@ -288,7 +288,7 @@ static BOOL xf_cliprdr_update_owner(xfClipboard* clipboard)
 static void xf_cliprdr_check_owner(xfClipboard* clipboard)
 {
 	if (xf_cliprdr_update_owner(clipboard))
-		xf_cliprdr_send_client_format_list(clipboard, FALSE);
+		xf_cliprdr_send_client_format_list(clipboard);
 }
 
 static BOOL xf_cliprdr_is_self_owned(xfClipboard* clipboard)
@@ -836,7 +836,7 @@ static void xf_cliprdr_provide_server_format_list(xfClipboard* clipboard)
 }
 
 static UINT xf_cliprdr_send_format_list(xfClipboard* clipboard, const CLIPRDR_FORMAT* formats,
-                                        UINT32 numFormats, BOOL force)
+                                        UINT32 numFormats)
 {
 	union
 	{
@@ -879,7 +879,7 @@ static void xf_cliprdr_get_requested_targets(xfClipboard* clipboard)
 {
 	UINT32 numFormats = 0;
 	CLIPRDR_FORMAT* formats = xf_cliprdr_get_client_formats(clipboard, &numFormats);
-	xf_cliprdr_send_format_list(clipboard, formats, numFormats, FALSE);
+	xf_cliprdr_send_format_list(clipboard, formats, numFormats);
 	xf_cliprdr_free_formats(formats, numFormats);
 }
 
@@ -1255,7 +1255,7 @@ static BOOL xf_cliprdr_process_selection_notify(xfClipboard* clipboard,
 	{
 		if (xevent->property == None)
 		{
-			xf_cliprdr_send_client_format_list(clipboard, FALSE);
+			xf_cliprdr_send_client_format_list(clipboard);
 		}
 		else
 		{
@@ -1721,7 +1721,7 @@ static BOOL xf_cliprdr_process_property_notify(xfClipboard* clipboard, const XPr
 
 	if (xevent->window == clipboard->root_window)
 	{
-		xf_cliprdr_send_client_format_list(clipboard, FALSE);
+		xf_cliprdr_send_client_format_list(clipboard);
 	}
 	else if ((xevent->window == xfc->drawable) && (xevent->state == PropertyNewValue) &&
 	         clipboard->incr_starts)
@@ -1837,7 +1837,7 @@ static UINT xf_cliprdr_send_client_capabilities(xfClipboard* clipboard)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-static UINT xf_cliprdr_send_client_format_list(xfClipboard* clipboard, BOOL force)
+static UINT xf_cliprdr_send_client_format_list(xfClipboard* clipboard)
 {
 	WINPR_ASSERT(clipboard);
 
@@ -1847,7 +1847,7 @@ static UINT xf_cliprdr_send_client_format_list(xfClipboard* clipboard, BOOL forc
 	UINT32 numFormats = 0;
 	CLIPRDR_FORMAT* formats = xf_cliprdr_get_client_formats(clipboard, &numFormats);
 
-	const UINT ret = xf_cliprdr_send_format_list(clipboard, formats, numFormats, force);
+	const UINT ret = xf_cliprdr_send_format_list(clipboard, formats, numFormats);
 
 	if (clipboard->owner && clipboard->owner != xfc->drawable)
 	{
@@ -1901,7 +1901,7 @@ static UINT xf_cliprdr_monitor_ready(CliprdrClientContext* context,
 	if (ret != CHANNEL_RC_OK)
 		return ret;
 
-	const UINT ret2 = xf_cliprdr_send_client_format_list(clipboard, TRUE);
+	const UINT ret2 = xf_cliprdr_send_client_format_list(clipboard);
 	if (ret2 != CHANNEL_RC_OK)
 		return ret2;
 

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -135,9 +135,6 @@ struct xf_clipboard
 	int xfixes_error_base;
 	BOOL xfixes_supported;
 
-	/* last sent data */
-	CLIPRDR_FORMAT* lastSentFormats;
-	UINT32 lastSentNumFormats;
 	CliprdrFileContext* file;
 	BOOL isImageContent;
 };
@@ -838,85 +835,6 @@ static void xf_cliprdr_provide_server_format_list(xfClipboard* clipboard)
 	Stream_Free(formats, TRUE);
 }
 
-static BOOL xf_clipboard_format_equal(const CLIPRDR_FORMAT* a, const CLIPRDR_FORMAT* b)
-{
-	WINPR_ASSERT(a);
-	WINPR_ASSERT(b);
-
-	if (a->formatId != b->formatId)
-		return FALSE;
-	if (!a->formatName && !b->formatName)
-		return TRUE;
-	if (!a->formatName || !b->formatName)
-		return FALSE;
-	return strcmp(a->formatName, b->formatName) == 0;
-}
-
-static BOOL xf_clipboard_changed(xfClipboard* clipboard, const CLIPRDR_FORMAT* formats,
-                                 UINT32 numFormats)
-{
-	WINPR_ASSERT(clipboard);
-	WINPR_ASSERT(formats || (numFormats == 0));
-
-	if (clipboard->lastSentNumFormats != numFormats)
-		return TRUE;
-
-	for (UINT32 x = 0; x < numFormats; x++)
-	{
-		const CLIPRDR_FORMAT* cur = &clipboard->lastSentFormats[x];
-		BOOL contained = FALSE;
-		for (UINT32 y = 0; y < numFormats; y++)
-		{
-			if (xf_clipboard_format_equal(cur, &formats[y]))
-			{
-				contained = TRUE;
-				break;
-			}
-		}
-		if (!contained)
-			return TRUE;
-	}
-
-	return FALSE;
-}
-
-static void xf_clipboard_formats_free(xfClipboard* clipboard)
-{
-	WINPR_ASSERT(clipboard);
-
-	/* Synchronize RDP/X11 thread with channel thread.
-	 * Reset the pointer and count inside the lock so that
-	 * xf_clipboard_changed cannot observe a freed-but-non-NULL pointer. */
-	xf_lock_x11(clipboard->xfc);
-	xf_cliprdr_free_formats(clipboard->lastSentFormats, clipboard->lastSentNumFormats);
-	clipboard->lastSentFormats = nullptr;
-	clipboard->lastSentNumFormats = 0;
-	xf_unlock_x11(clipboard->xfc);
-}
-
-static BOOL xf_clipboard_copy_formats(xfClipboard* clipboard, const CLIPRDR_FORMAT* formats,
-                                      UINT32 numFormats)
-{
-	WINPR_ASSERT(clipboard);
-	WINPR_ASSERT(formats || (numFormats == 0));
-
-	xf_clipboard_formats_free(clipboard);
-	if (numFormats > 0)
-		clipboard->lastSentFormats = calloc(numFormats, sizeof(CLIPRDR_FORMAT));
-	if (!clipboard->lastSentFormats)
-		return FALSE;
-	clipboard->lastSentNumFormats = numFormats;
-	for (UINT32 x = 0; x < numFormats; x++)
-	{
-		CLIPRDR_FORMAT* lcur = &clipboard->lastSentFormats[x];
-		const CLIPRDR_FORMAT* cur = &formats[x];
-		*lcur = *cur;
-		if (cur->formatName)
-			lcur->formatName = _strdup(cur->formatName);
-	}
-	return FALSE;
-}
-
 static UINT xf_cliprdr_send_format_list(xfClipboard* clipboard, const CLIPRDR_FORMAT* formats,
                                         UINT32 numFormats, BOOL force)
 {
@@ -934,9 +852,6 @@ static UINT xf_cliprdr_send_format_list(xfClipboard* clipboard, const CLIPRDR_FO
 	WINPR_ASSERT(clipboard);
 	WINPR_ASSERT(formats || (numFormats == 0));
 
-	if (!force && !xf_clipboard_changed(clipboard, formats, numFormats))
-		return CHANNEL_RC_OK;
-
 #if defined(WITH_DEBUG_CLIPRDR)
 	for (UINT32 x = 0; x < numFormats; x++)
 	{
@@ -946,7 +861,6 @@ static UINT xf_cliprdr_send_format_list(xfClipboard* clipboard, const CLIPRDR_FO
 	}
 #endif
 
-	xf_clipboard_copy_formats(clipboard, formats, numFormats);
 	/* Ensure all pending requests are answered. */
 	xf_cliprdr_send_data_response(clipboard, nullptr, nullptr, 0);
 
@@ -1987,8 +1901,6 @@ static UINT xf_cliprdr_monitor_ready(CliprdrClientContext* context,
 	if (ret != CHANNEL_RC_OK)
 		return ret;
 
-	xf_clipboard_formats_free(clipboard);
-
 	const UINT ret2 = xf_cliprdr_send_client_format_list(clipboard, TRUE);
 	if (ret2 != CHANNEL_RC_OK)
 		return ret2;
@@ -2106,7 +2018,6 @@ static UINT xf_cliprdr_server_format_list(CliprdrClientContext* context,
 	ArrayList_Clear(clipboard->pending_responses);
 	ArrayList_Clear(clipboard->queued_responses);
 
-	xf_clipboard_formats_free(clipboard);
 	xf_cliprdr_clear_cached_data(clipboard);
 
 	xf_clipboard_free_server_formats(clipboard);
@@ -2872,7 +2783,6 @@ void xf_clipboard_free(xfClipboard* clipboard)
 	cliprdr_file_context_free(clipboard->file);
 
 	ClipboardDestroy(clipboard->system);
-	xf_clipboard_formats_free(clipboard);
 	HashTable_Free(clipboard->cachedRawData);
 	HashTable_Free(clipboard->cachedData);
 	ArrayList_Free(clipboard->pending_responses);


### PR DESCRIPTION
# What is broken?
With two xfreerdp sessions running, copying text from one to the other always pastes the first copied text, ignoring any text that is copied after it. It also happens on other media types.

# Reproducing
- Open 2 xfreerdp sessions
- open text editors in both sessions
- in the first session, write 2 (non-identical) lines of text
- copy the first line of text and paste it into the second session
- copy the second line of text from the first session and paste it into the second session
- You will see that the first line of text is pasted again instead of the second line

## Why it doesn't work
In xf_cliprdr.c `xf_clipboard_changed` only compares the advertised selection formats. Since text is selected in both cases the selection formats are the same and no new formats are advertised to the server. 

https://github.com/FreeRDP/FreeRDP/blob/5ea7306dd4875cf1f52cef65fbd30936c626973a/client/X11/xf_cliprdr.c#L937

Sending `CLIPRDR_FORMAT_LIST` is the way the server is notified of clipboard changes on the client. If no new formats are advertised the server believes that the clipboard stayed the same on the client and won't send another `CLIPRDR_FORMAT_DATA_REQUEST` to receive the new clipboard contents.

### Why it does work with other clients
This doesn't happen when copying text in x11 clients other than xfreerdp since `xf_cliprdr_get_client_formats` returns an empty format list if the clipboard owner is not a xfreerdp window. 
https://github.com/FreeRDP/FreeRDP/blob/5ea7306dd4875cf1f52cef65fbd30936c626973a/client/X11/xf_cliprdr.c#L789
This empty list gets passed into `xf_cliprdr_send_format_list` which then calls `xf_clipboard_copy_formats` which copies it into `lastSentFormats`.
Then a `XConvertSelection` request is issued. The client owning the clipboard answers with `SelectionNotify` which contains the list of formats. This ends up in `xf_cliprdr_send_format_list` again where it is compared to the empty list. As they are not equal these formats get advertised to the server.

If the clipboard owner is a xfreerdp window the first call to `xf_cliprdr_send_format_list` is made with an already filled out list of formats so the `lastSentFormats` are not cleared and `xf_clipboard_changed` returns false on the next call, so no new formats are advertised.


# The fix
To fix this I reverted commit a51f4ccaaa8d4a2232725dc555827705ea8f0429. I believe it doesn't work in practice the way it is implemented right now. Since `xf_clipboard_changed` only compares the clipboard formats it does not notice a change when the new clipboard contents are of the same format as the old. 

Theoretically we could try fetching the clipboard contents in `xf_clipboard_changed` to see if they have changed. This would be one way of fixing the bug. 

However, I believe removing the duplicate ClientFormatList announcement filter entirely is the better way. The only case I see (please correct me if I'm wrong) in which it is useful is if the user copies the same content multiple times. In that case this code saves some packets that advertise the same formats again to the server.

---
This pull request was made as part of my work at openthinclient GmbH