### PR TITLE
fix(client/SDL): do not treat an unrecognized mouse button as fatal

### DIFF
--- a/client/SDL/SDL2/sdl_touch.cpp
+++ b/client/SDL/SDL2/sdl_touch.cpp
@@ -279,5 +279,5 @@ BOOL sdl_handle_mouse_button(SdlContext* sdl, const SDL_MouseButtonEvent* ev)
 	else if ((xflags & (~PTR_XFLAGS_DOWN)) != 0)
 		return freerdp_client_send_extended_button_event(sdl->common(), relative, xflags, x, y);
 	else
-		return FALSE;
+		return TRUE;
 }

--- a/client/SDL/SDL3/sdl_touch.cpp
+++ b/client/SDL/SDL3/sdl_touch.cpp
@@ -187,7 +187,7 @@ bool SdlTouch::handleEvent(SdlContext* sdl, const SDL_MouseButtonEvent& ev)
 	else if ((xflags & (~PTR_XFLAGS_DOWN)) != 0)
 		return freerdp_client_send_extended_button_event(sdl->common(), relative, xflags, x, y);
 	else
-		return FALSE;
+		return TRUE;
 }
 
 bool SdlTouch::handleEvent(SdlContext* sdl, const SDL_TouchFingerEvent& ev)


### PR DESCRIPTION
## Summary

`sdl_run()` treats *any* `handleEvent()` returning `false` as fatal and aborts
the connection:

```cpp
if (!sdl->handleEvent(windowEvent))
    throw ErrorMsg{ -1, windowEvent.type, "sdl->handleEvent" };
```

The mouse-button handler returns `FALSE` for any button outside 1–5. SDL maps
unrecognized buttons as `SDL_BUTTON_X1 + (button - BTN_SIDE)`, so a mouse whose
forward/back buttons report `BTN_FORWARD`/`BTN_BACK` (rather than
`BTN_SIDE`/`BTN_EXTRA`) produces SDL button **6/7**, which the handler doesn't
recognize → returns `FALSE` → `sdl_run()` throws → **the RDP session
disconnects on a single thumb-button click**. Observed with an Evoluent
VerticalMouse, but any device that emits these button codes triggers it.

Client log at the moment of the click:

```
[ERROR][com.freerdp.client.SDL] - [sdl_run]: [exception] sdl->handleEvent {SDL_EVENT_MOUSE_BUTTON_DOWN}{SDL:Invalid window}
[INFO ][com.freerdp.client.common] - [client_auto_reconnect_ex]: Network disconnect!
```

An unrecognized mouse button has nothing to send to the server, but that is not
an error — it should be ignored, not fatal. Return `TRUE` instead of `FALSE`.

Affects both the SDL2 and SDL3 clients (identical code path).

## How to test

1. Connect with `sdl-freerdp` using a mouse whose forward/back buttons are
   reported as `BTN_FORWARD`/`BTN_BACK` (SDL button 6/7). You can confirm the
   evdev codes with `evtest`.
2. Click the forward (or back) button inside the session.
   - **Before:** the session disconnects; the log shows the `[exception]
     sdl->handleEvent {SDL_EVENT_MOUSE_BUTTON_DOWN}` line above.
   - **After:** the click is ignored and the session stays connected.

Buttons 1–5 (left/middle/right/X1/X2) are unchanged.
