### PR TITLE
Fix(wfreerdp): Refresh Windows frame after fullscreen restore

### DIFF
--- a/client/Windows/wf_gdi.c
+++ b/client/Windows/wf_gdi.c
@@ -421,7 +421,7 @@ void wf_resize_window(wfContext* wfc)
 			xpos = wfc->client_x;
 			ypos = wfc->client_y;
 		}
-		SetWindowPos(wfc->hwnd, HWND_TOP, xpos, ypos, width, height, 0 /*SWP_FRAMECHANGED*/);
+		SetWindowPos(wfc->hwnd, HWND_TOP, xpos, ypos, width, height, SWP_FRAMECHANGED);
 		// wf_size_scrollbars(wfc,  wfc->client_width, wfc->client_height);
 	}
 


### PR DESCRIPTION
### Problem
  Run wfreerdp with /f and /floatbar, /smart-sizing, and leave the full screen with the floatbar restore button, it will not refresh the window frame, so you can only switch through the taskbar to brush the frame.

```cmdline: .\wfreerdp.exe /v:[host]:[port] /p:[password] /u:[username] /f /floatbar /smart-sizing```