### PR TITLE
Restore fullscreen when maximizing a toggled fullscreen window

### DIFF
--- a/client/Windows/wf_event.c
+++ b/client/Windows/wf_event.c
@@ -753,6 +753,12 @@ LRESULT CALLBACK wf_event_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 				{
 					freerdp_client_encomsp_set_control(wfc->common.encomsp, TRUE);
 				}
+				else if (((wParam & 0xfff0) == SC_MAXIMIZE) && wfc->fullscreen_toggle &&
+				         freerdp_settings_get_bool(settings, FreeRDP_Fullscreen) &&
+				         !wfc->fullscreen)
+				{
+					wf_toggle_fullscreen(wfc);
+				}
 				else
 				{
 					processed = FALSE;


### PR DESCRIPTION
### Full screen experience
  When a Windows client session starts in fullscreen mode and is toggled back to
windowed mode, pressing the window maximize button should restore fullscreen
instead of only maximizing the decorated window (like mstsc).