### PR TITLE
fix(winpr/sspi): use ANSI NTLM_PACKAGE_NAME for the W-context package name

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -679,7 +679,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_InitializeSecurityContextW(
 		}
 
 		sspi_SecureHandleSetLowerPointer(phNewContext, context);
-		sspi_SecureHandleSetUpperPointer(phNewContext, NTLM_SSP_NAME);
+		sspi_SecureHandleSetUpperPointer(phNewContext, (void*)NTLM_PACKAGE_NAME);
 	}
 
 	if ((!input_buffer) || (ntlm_get_state(context) == NTLM_STATE_AUTHENTICATE))


### PR DESCRIPTION
## Summary

`ntlm_InitializeSecurityContextW` stores the new context's SSPI package name as the `_T()`-wide `NTLM_SSP_NAME`, while every ANSI message-dispatch function in `winpr/libwinpr/sspi/sspi_winpr.c` (`winpr_EncryptMessage` / `winpr_DecryptMessage` / `winpr_MakeSignature` / `winpr_VerifySignature` / …) reads the context's upper pointer back as `char*` and resolves the package by name via `sspi_GetSecurityFunctionTableAByNameA` (a `strcmp`).

Under a Windows UNICODE build `_T("NTLM")` is the wide string `L"NTLM"`, which read as `char*` is just `"N"` → the by-name lookup fails → `EncryptMessage` / `DecryptMessage` / `MakeSignature` return `SEC_E_SECPKG_NOT_FOUND`.

`ntlm_InitializeSecurityContextA`, the credential path in `AcquireCredentialsHandle`, and the sibling context-setup path already store the explicit `char*` `NTLM_PACKAGE_NAME` (`"NTLM"`). This one-line change makes the `W` variant consistent. The defect doesn't surface on non-Windows because there `_T(x) == x`.

## How to reproduce

Build WinPR on Windows with its **emulated** SSPI (`-DWITH_NATIVE_SSPI=OFF`) and drive NTLM directly (e.g. CredSSP/NLA forced to the `"NTLM"` package rather than `Negotiate`). `EncryptMessage` returns `SEC_E_SECPKG_NOT_FOUND`, so the CredSSP `pubKeyAuth` seal never runs and NLA fails. With this change the seal succeeds and NLA completes through to the session.

## Found via

An embedded static-WinPR NTLM/CredSSP RDP client on Windows — `EncryptMessage` failed `SEC_E_SECPKG_NOT_FOUND` on the emulated SSPI path until the context package name was switched from the `_T()`-wide constant to the ANSI `NTLM_PACKAGE_NAME` that the message-dispatch lookup expects.

---
Signed-off-by per DCO (`git` sign-off in the commit).
