### PR TITLE
[core,gateway] validate auth blob length in rdg_process_extauth_sspi

### DIFF
--- a/libfreerdp/core/gateway/rdg.c
+++ b/libfreerdp/core/gateway/rdg.c
@@ -1011,6 +1011,9 @@ static BOOL rdg_process_extauth_sspi(rdpRdg* rdg, wStream* s)
 
 	WINPR_ASSERT(rdg);
 
+	if (!Stream_CheckAndLogRequiredLengthWLog(rdg->log, s, 6))
+		return FALSE;
+
 	Stream_Read_INT32(s, errorCode);
 	Stream_Read_UINT16(s, authBlobLen);
 
@@ -1031,6 +1034,9 @@ static BOOL rdg_process_extauth_sspi(rdpRdg* rdg, wStream* s)
 		}
 		return FALSE;
 	}
+
+	if (!Stream_CheckAndLogRequiredLengthWLog(rdg->log, s, authBlobLen))
+		return FALSE;
 
 	authTokenData = malloc(authBlobLen);
 	if (authTokenData == nullptr)


### PR DESCRIPTION
**Missing length check in rdg_process_extauth_sspi**

A malicious or intermediary RDG gateway can send a PKT_TYPE_EXTENDED_AUTH_MSG whose declared `authBlobLen` is larger than the data actually received, and the handler then `malloc`s that size and `Stream_Read`s it straight from the packet buffer with no validation, reading past the end of the received data. The sibling response handlers all guard their reads with `Stream_CheckAndLogRequiredLength` first, so I have added the same checks here before the header fields and before the blob copy.