### PR TITLE
[core,nego] bound cookie tag check to remaining length

### DIFF
--- a/libfreerdp/core/nego.c
+++ b/libfreerdp/core/nego.c
@@ -902,7 +902,7 @@ static BOOL nego_read_request_token_or_cookie(rdpNego* nego, wStream* s)
 	if (remain < 15)
 		return TRUE;
 
-	if (memcmp(Stream_ConstPointer(s), "Cookie: mstshash=", 17) != 0)
+	if ((remain < 17) || (memcmp(Stream_ConstPointer(s), "Cookie: mstshash=", 17) != 0))
 	{
 		if (memcmp(Stream_ConstPointer(s), "Cookie: msts=", 13) != 0)
 		{


### PR DESCRIPTION
**Out-of-bounds read in nego_read_request_token_or_cookie**

When a server parses the optional routing token or cookie of an X.224 Connection Request, the only guard guarantees 15 remaining bytes, but the first `memcmp` against `"Cookie: mstshash="` reads 17, so a request whose token region is 15 or 16 bytes long reads one or two bytes past the buffer. Gated that compare on the remaining length; behaviour is unchanged since the cookie path already requires at least 19 bytes.