### PR TITLE
[core,update] filter out unused/unknown

### DIFF
--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -3680,6 +3680,10 @@ void update_dump_stats(rdpUpdate* update)
 		const char* name = rdp_stats_name_for_index(x);
 		const uint64_t val = rdp_stats_value_for_index(update, x);
 		WINPR_ASSERT(name && strnlen(name, 2) > 0);
-		WLog_Print(log, level, "%s: %" PRIu64, name, val);
+		const bool unknown = strstr(name, " UNKNOWN") != nullptr;
+		const bool unused = strstr(name, "UNUSED") != nullptr;
+		const bool sunused = strcmp("RDP_STATS_UNUSED", name) == 0;
+		if ((val != 0) || (!unknown && !sunused && !unused))
+			WLog_Print(log, level, "%s: %" PRIu64, name, val);
 	}
 }


### PR DESCRIPTION
update_dump_stats dumps a lot of variables on termination, many of which are not used by most. Filter these out unless the operation was actually used during the connection.