### PR TITLE
[channels,gfx] extract remaining header length

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -2071,14 +2071,14 @@ static UINT rdpgfx_recv_pdu(GENERIC_CHANNEL_CALLBACK* callback, wStream* s)
 
 	WINPR_ASSERT(gfx);
 
-	UINT error = rdpgfx_read_header(gfx->base.log, s, &header);
+	size_t packetlen = 0;
+	UINT error = rdpgfx_read_header(gfx->base.log, s, &header, &packetlen);
 	if (error != CHANNEL_RC_OK)
 	{
 		WLog_Print(gfx->base.log, WLOG_ERROR, "rdpgfx_read_header failed with error %" PRIu32 "!",
 		           error);
 		return error;
 	}
-	const size_t start = Stream_GetPosition(s);
 
 	WLog_Print(gfx->base.log, WLOG_TRACE,
 	           "cmdId: %s (0x%04" PRIX16 ") flags: 0x%04" PRIX16 " pduLength: %" PRIu32 "",
@@ -2244,7 +2244,7 @@ static UINT rdpgfx_recv_pdu(GENERIC_CHANNEL_CALLBACK* callback, wStream* s)
 			WLog_Print(gfx->base.log, WLOG_WARN,
 			           "Command %s not implemented, skipping %" PRIu32 " bytes",
 			           rdpgfx_get_cmd_id_string(header.cmdId), header.pduLength);
-			if (!Stream_SafeSeek(s, header.pduLength - start))
+			if (!Stream_SafeSeek(s, packetlen))
 				error = ERROR_INVALID_DATA;
 			break;
 		default:

--- a/channels/rdpgfx/rdpgfx_common.c
+++ b/channels/rdpgfx/rdpgfx_common.c
@@ -32,10 +32,13 @@
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT rdpgfx_read_header(wLog* log, wStream* s, RDPGFX_HEADER* header)
+UINT rdpgfx_read_header(wLog* log, wStream* s, RDPGFX_HEADER* header, size_t* pPacketLength)
 {
 	WINPR_ASSERT(s);
 	WINPR_ASSERT(header);
+
+	if (pPacketLength)
+		*pPacketLength = 0;
 
 	if (!Stream_CheckAndLogRequiredLengthWLog(log, s, 8))
 		return ERROR_INVALID_DATA;
@@ -49,8 +52,12 @@ UINT rdpgfx_read_header(wLog* log, wStream* s, RDPGFX_HEADER* header)
 		WLog_Print(log, WLOG_ERROR, "header->pduLength %u less than 8!", header->pduLength);
 		return ERROR_INVALID_DATA;
 	}
-	if (!Stream_CheckAndLogRequiredLengthWLog(log, s, (header->pduLength - 8)))
+
+	const size_t size = (header->pduLength - 8ull);
+	if (!Stream_CheckAndLogRequiredLengthWLog(log, s, size))
 		return ERROR_INVALID_DATA;
+	if (pPacketLength)
+		*pPacketLength = size;
 
 	return CHANNEL_RC_OK;
 }

--- a/channels/rdpgfx/rdpgfx_common.h
+++ b/channels/rdpgfx/rdpgfx_common.h
@@ -31,7 +31,8 @@
 #include <freerdp/utils/gfx.h>
 
 WINPR_ATTR_NODISCARD
-FREERDP_LOCAL UINT rdpgfx_read_header(wLog* log, wStream* s, RDPGFX_HEADER* header);
+FREERDP_LOCAL UINT rdpgfx_read_header(wLog* log, wStream* s, RDPGFX_HEADER* header,
+                                      size_t* pRemainingHeaderLength);
 
 WINPR_ATTR_NODISCARD
 FREERDP_LOCAL UINT rdpgfx_write_header(wStream* s, const RDPGFX_HEADER* header);

--- a/channels/rdpgfx/server/rdpgfx_main.c
+++ b/channels/rdpgfx/server/rdpgfx_main.c
@@ -1558,7 +1558,7 @@ WINPR_ATTR_NODISCARD static UINT rdpgfx_server_receive_pdu(RdpgfxServerContext* 
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(context->priv);
 
-	if ((error = rdpgfx_read_header(context->priv->log, s, &header)))
+	if ((error = rdpgfx_read_header(context->priv->log, s, &header, nullptr)))
 	{
 		WLog_Print(context->priv->log, WLOG_ERROR,
 		           "rdpgfx_read_header failed with error %" PRIu32 "!", error);


### PR DESCRIPTION
* extract remaining header length from rdpgfx_read_header
* use that to skip unimplemented cmdid packets