### PR TITLE
[cache,glyph] bound offset read to buffer length

### DIFF
--- a/libfreerdp/cache/glyph.c
+++ b/libfreerdp/cache/glyph.c
@@ -47,6 +47,13 @@ static UINT32 update_glyph_offset(const BYTE* data, size_t length, UINT32 index,
 {
 	if ((ulCharInc == 0) && (!(flAccel & SO_CHAR_INC_EQUAL_BM_BASE)))
 	{
+		if (index >= length)
+		{
+			WLog_WARN(TAG, "glyph offset index out of bound %" PRIu32 " [max %" PRIuz "]", index,
+			          length);
+			return index;
+		}
+
 		UINT32 offset = data[index++];
 
 		if (offset & 0x80)


### PR DESCRIPTION
**Out-of-bounds read in update_glyph_offset**

The first glyph offset byte is taken from `data[index]` before `index` is compared against the buffer length; only the following extended-offset read is bounded. When a glyph fragment ends on a glyph op, `update_process_glyph_fragments` calls the helper with `index == length`, and on the `GLYPH_FRAGMENT_USE` path the buffer is a heap allocation of exactly `size` bytes (`glyph_cache_fragment_put` does `malloc(size)`), so a malicious server can provoke a one-byte heap over-read through GLYPH_INDEX/FAST_INDEX/FAST_GLYPH orders. Added the missing length check, mirroring the guard already present a few lines further down.

To test: building the helper together with the fragment loop against a `malloc(1)` fragment under ASan reports a 1-byte heap-buffer-overflow read at the unchecked access; the tree is clean afterwards.
