### PR TITLE
[winpr,wtypes] fix WINPR_C23_ENUM_TYPE

### DIFF
--- a/include/freerdp/channels/rdpgfx.h
+++ b/include/freerdp/channels/rdpgfx.h
@@ -103,7 +103,7 @@ typedef struct
 /**
  * Capability Sets [MS-RDPEGFX] 2.2.3
  */
-typedef enum WINPR_C11_ENUM_TYPE(uint32_t)
+typedef enum WINPR_C23_ENUM_TYPE(uint32_t)
 {
 #if defined(WITH_GFX_AV1)
 	RDPGFX_CAPVERSION_FRDP_1 = 0x00010000u, /**< Custom capversion for FreeRDP extensions */
@@ -140,7 +140,7 @@ typedef struct
 	UINT32 flags;
 } RDPGFX_CAPSET;
 
-typedef enum WINPR_C11_ENUM_TYPE(uint32_t)
+typedef enum WINPR_C23_ENUM_TYPE(uint32_t)
 {
 	RDPGFX_CAPS_FLAG_THINCLIENT = 0x00000001U,       /* 8.0+ */
 	RDPGFX_CAPS_FLAG_SMALL_CACHE = 0x00000002U,      /* 8.0+ */
@@ -186,7 +186,7 @@ typedef struct
 /**
  * Graphics Messages
  */
-typedef enum WINPR_C11_ENUM_TYPE(uint16_t)
+typedef enum WINPR_C23_ENUM_TYPE(uint16_t)
 {
 	RDPGFX_CODECID_UNCOMPRESSED = 0x0000u,
 #if defined(WITH_GFX_AV1)

--- a/winpr/include/winpr/wtypes.h
+++ b/winpr/include/winpr/wtypes.h
@@ -41,13 +41,13 @@
 
 #include <limits.h>
 
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
-#define WINPR_C11_ENUM_TYPE(x) : x /** 
-                               * @brief For C11 and up defines the type of the enum to the enclosed integer type
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 202311L)
+#define WINPR_C23_ENUM_TYPE(x) : x /** 
+                               * @brief For C23 and up defines the type of the enum to the enclosed integer type
                                * @since version 3.27.0
 */
 #else
-#define WINPR_C11_ENUM_TYPE(x)
+#define WINPR_C23_ENUM_TYPE(x)
 #endif
 
 #if defined(_WIN32) || defined(__MINGW32__)


### PR DESCRIPTION
Previously erroneously attributed being available with C11. Rename and guard with C23 support