### PR TITLE
[codec,color] bound icon alpha mask read to mask size

### DIFF
--- a/libfreerdp/codec/color.c
+++ b/libfreerdp/codec/color.c
@@ -477,11 +477,11 @@ BOOL freerdp_image_copy_from_icon_data(BYTE* WINPR_RESTRICT pDstData, UINT32 Dst
 		 * a multiple of 4 bytes.
 		 */
 		const size_t stride = round_up(div_ceil(nWidth, 8), 4);
-		if (cbBitsMask < stride * (nHeight - 1ULL))
+		const size_t maskSize = stride * (nHeight - 1ULL) + div_ceil(nWidth, 8);
+		if (cbBitsMask < maskSize)
 		{
-			WLog_ERR(TAG,
-			         "cbBitsMask{%" PRIu32 "} < stride{%" PRIuz "} * (nHeight{%" PRIu32 "} - 1)",
-			         cbBitsMask, stride, nHeight);
+			WLog_ERR(TAG, "cbBitsMask{%" PRIu32 "} < required mask size{%" PRIuz "}", cbBitsMask,
+			         maskSize);
 			return FALSE;
 		}
 


### PR DESCRIPTION
**Heap over-read in freerdp_image_copy_from_icon_data**

The alpha mask branch bounds `cbBitsMask` against `stride * (nHeight - 1)`, but the per-row walk reads a further `ceil(nWidth / 8)` bytes from that offset, so the last row runs off the end of the mask buffer (allocated to exactly `cbBitsMask` in `update_read_icon_info`). A server sending a RAIL icon with a short mask (trivially with `nHeight == 1`, where the old check can never fire) over-reads up to one row of heap, so I have added the final rows bytes to the required size. The cursor mask paths already bound on `step * nHeight`, so this is the only site affected.

To test: a 16x1 icon with `cbBitsMask = 1` passes the old check and reads `bitsMask[1]` past the 1-byte allocation; under ASan that is a heap-buffer-overflow read, and the tree is clean with the new bound.