### PR TITLE
[client,android] Add RAIL/RemoteApp window support

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/cpp/CMakeLists.txt
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/CMakeLists.txt
@@ -130,6 +130,8 @@ set(${MODULE_PREFIX}_SRCS
     android_jni_utils.h
     android_jni_callback.c
     android_jni_callback.h
+    android_rail.c
+    android_rail.h
 )
 
 add_library(${MODULE_NAME} SHARED ${${MODULE_PREFIX}_SRCS})

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
@@ -49,6 +49,7 @@
 #include "android_jni_utils.h"
 #include "android_cliprdr.h"
 #include "android_disp.h"
+#include "android_rail.h"
 #include "android_freerdp_jni.h"
 
 #if defined(WITH_GPROF)
@@ -62,6 +63,10 @@
 
 static jclass gJavaActivityClass;
 static jmethodID gOnPointerSetMethod;
+static jmethodID gOnRailWindowUpdateMethod;
+
+static UINT android_UpdateWindowFromSurface(RdpgfxClientContext* context, gdiGfxSurface* surface);
+
 static void android_OnChannelConnectedEventHandler(void* context,
                                                    const ChannelConnectedEventArgs* e)
 {
@@ -84,6 +89,17 @@ static void android_OnChannelConnectedEventHandler(void* context,
 	else if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) == 0)
 	{
 		android_disp_init(afc, (DispClientContext*)e->pInterface);
+	}
+	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
+	{
+		android_rail_init(afc, (RailClientContext*)e->pInterface);
+	}
+	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
+	{
+		freerdp_client_OnChannelConnectedEventHandler(context, e);
+		RdpgfxClientContext* gfx = (RdpgfxClientContext*)e->pInterface;
+		if (gfx)
+			gfx->UpdateWindowFromSurface = android_UpdateWindowFromSurface;
 	}
 	else
 		freerdp_client_OnChannelConnectedEventHandler(context, e);
@@ -111,6 +127,10 @@ static void android_OnChannelDisconnectedEventHandler(void* context,
 	else if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) == 0)
 	{
 		android_disp_uninit(afc, (DispClientContext*)e->pInterface);
+	}
+	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
+	{
+		android_rail_uninit(afc, (RailClientContext*)e->pInterface);
 	}
 	else
 		freerdp_client_OnChannelDisconnectedEventHandler(context, e);
@@ -330,6 +350,59 @@ static BOOL android_Pointer_SetDefault(rdpContext* context)
 
 	freerdp_callback("OnPointerSetDefault", "(J)V", (jlong)context->instance);
 	return TRUE;
+}
+
+static UINT android_UpdateWindowFromSurface(RdpgfxClientContext* context, gdiGfxSurface* surface)
+{
+	if (!context || !surface)
+		return CHANNEL_RC_OK;
+
+	rdpGdi* gdi = (rdpGdi*)context->custom;
+	if (!gdi || !gdi->context)
+		return CHANNEL_RC_OK;
+
+	const UINT32 width = surface->mappedWidth ? surface->mappedWidth : surface->width;
+	const UINT32 height = surface->mappedHeight ? surface->mappedHeight : surface->height;
+	if (width == 0 || height == 0)
+		return CHANNEL_RC_OK;
+
+	JNIEnv* env = NULL;
+	jboolean attached = jni_attach_thread(&env);
+	if (!gJavaActivityClass || !gOnRailWindowUpdateMethod)
+		goto done;
+
+	const jsize nPixels = (jsize)(width * height);
+	jintArray pixels = (*env)->NewIntArray(env, nPixels);
+	if (!pixels)
+		goto done;
+
+	jint* dst = (*env)->GetIntArrayElements(env, pixels, NULL);
+	if (dst)
+	{
+		freerdp_image_copy((BYTE*)dst, surface->format, width * 4, 0, 0, width, height,
+		                   surface->data, surface->format, surface->scanline, 0, 0, NULL,
+		                   FREERDP_FLIP_NONE);
+
+		/* Force coloured pixels opaque (ARGB_8888 would otherwise blend the active window's
+		 * frame away), but keep transparent black so menu corners/shadows stay see-through. */
+		const size_t total = (size_t)width * height;
+		for (size_t i = 0; i < total; i++)
+		{
+			const UINT32 px = (UINT32)dst[i];
+			if ((px & 0x00FFFFFFu) != 0)
+				dst[i] = (jint)(px | 0xFF000000u);
+		}
+		(*env)->ReleaseIntArrayElements(env, pixels, dst, 0);
+	}
+
+	freerdp* inst = gdi->context->instance;
+	(*env)->CallStaticVoidMethod(env, gJavaActivityClass, gOnRailWindowUpdateMethod, (jlong)inst,
+	                             (jlong)surface->windowId, (jint)width, (jint)height, pixels);
+	(*env)->DeleteLocalRef(env, pixels);
+done:
+	if (attached)
+		jni_detach_thread();
+	return CHANNEL_RC_OK;
 }
 
 static BOOL android_register_pointer(rdpGraphics* graphics)
@@ -1167,6 +1240,13 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved)
 	gJavaActivityClass = (*env)->NewGlobalRef(env, activityClass);
 	gOnPointerSetMethod =
 	    (*env)->GetStaticMethodID(env, gJavaActivityClass, "OnPointerSet", "(J[IIIII)V");
+	gOnRailWindowUpdateMethod =
+	    (*env)->GetStaticMethodID(env, gJavaActivityClass, "OnRailWindowUpdate", "(JJII[I)V");
+	if (!gOnRailWindowUpdateMethod)
+	{
+		(*env)->ExceptionClear(env);
+		WLog_WARN(TAG, "OnRailWindowUpdate method not found, RAIL window display disabled");
+	}
 	g_JavaVm = vm;
 	return init_callback_environment(vm, env);
 }

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
@@ -423,6 +423,9 @@ static BOOL android_register_pointer(rdpGraphics* graphics)
 	return TRUE;
 }
 
+/* Keep in sync with LibFreeRDP.EXPERIMENTAL_*. */
+#define ANDROID_EXPERIMENTAL_REMOTEAPP 0
+
 static BOOL android_post_connect(freerdp* instance)
 {
 	rdpSettings* settings;
@@ -436,6 +439,11 @@ static BOOL android_post_connect(freerdp* instance)
 
 	settings = instance->context->settings;
 	WINPR_ASSERT(settings);
+
+	if (freerdp_settings_get_bool(settings, FreeRDP_RemoteApplicationMode) &&
+	    !freerdp_callback_bool_result("OnExperimentalFeature", "(JI)Z", (jlong)instance,
+	                                  ANDROID_EXPERIMENTAL_REMOTEAPP))
+		return FALSE;
 
 	if (!gdi_init(instance, PIXEL_FORMAT_RGBX32))
 		return FALSE;

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.h
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.h
@@ -19,6 +19,7 @@
 #include <freerdp/freerdp.h>
 #include <freerdp/client/cliprdr.h>
 #include <freerdp/client/disp.h>
+#include <freerdp/client/rail.h>
 
 #include "android_event.h"
 
@@ -41,6 +42,8 @@ typedef struct
 	UINT32 clipboardCapabilities;
 
 	DispClientContext* disp;
+	RailClientContext* rail;
+	BOOL railExecSent;
 } androidContext;
 
 #endif /* FREERDP_CLIENT_ANDROID_FREERDP_H */

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_rail.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_rail.c
@@ -1,0 +1,290 @@
+/*
+   Android RAIL/RemoteApp Channel
+
+   Copyright 2026 Ibrahim Sevinc <ibrahim.sevinc.mail@gmail.com>
+
+   This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+   If a copy of the MPL was not distributed with this file, You can obtain one at
+   http://mozilla.org/MPL/2.0/.
+*/
+
+#include <freerdp/config.h>
+
+#include <stdlib.h>
+
+#include <jni.h>
+
+#include <freerdp/client/rail.h>
+#include <freerdp/settings.h>
+#include <freerdp/window.h>
+
+#include "android_jni_callback.h"
+#include "android_rail.h"
+
+#define TAG CLIENT_TAG("android.rail")
+
+static BOOL android_rail_monitored_desktop(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo,
+                                           const MONITORED_DESKTOP_ORDER* monitoredDesktop)
+{
+	if (!context || !orderInfo)
+		return FALSE;
+
+	const UINT32 flags = orderInfo->fieldFlags;
+
+	if (flags & WINDOW_ORDER_FIELD_DESKTOP_ARC_COMPLETED)
+	{
+		androidContext* afc = (androidContext*)context;
+		if (afc->rail && !afc->railExecSent)
+		{
+			const char* app =
+			    freerdp_settings_get_string(context->settings, FreeRDP_RemoteApplicationProgram);
+			if (app && *app)
+			{
+				afc->railExecSent = TRUE;
+				WLog_DBG(TAG, "RAIL ARC_COMPLETED -> sending exec");
+				UINT rc = client_rail_server_start_cmd(afc->rail);
+				if (rc != CHANNEL_RC_OK)
+				{
+					afc->railExecSent = FALSE;
+					WLog_ERR(TAG, "RAIL start cmd failed after ARC_COMPLETED: %u", rc);
+				}
+			}
+		}
+	}
+
+	/* Forward z-order and active window together (windowIds NULL / activeWindowId 0 if absent). */
+	const BOOL hasZOrder = (flags & WINDOW_ORDER_FIELD_DESKTOP_ZORDER) && monitoredDesktop &&
+	                       monitoredDesktop->numWindowIds > 0 && monitoredDesktop->windowIds;
+	const BOOL hasActive = (flags & WINDOW_ORDER_FIELD_DESKTOP_ACTIVE_WND) && monitoredDesktop;
+
+	if (hasZOrder || hasActive)
+	{
+		JNIEnv* env = NULL;
+		jboolean attached = jni_attach_thread(&env);
+		if (env)
+		{
+			jlongArray arr = NULL;
+			if (hasZOrder)
+			{
+				const jsize n = (jsize)monitoredDesktop->numWindowIds;
+				arr = (*env)->NewLongArray(env, n);
+				if (arr)
+				{
+					jlong* tmp = (*env)->GetLongArrayElements(env, arr, NULL);
+					if (tmp)
+					{
+						for (jsize i = 0; i < n; i++)
+							tmp[i] = (jlong)monitoredDesktop->windowIds[i];
+						(*env)->ReleaseLongArrayElements(env, arr, tmp, 0);
+					}
+				}
+			}
+			const jlong activeWindowId = hasActive ? (jlong)monitoredDesktop->activeWindowId : 0;
+			freerdp_callback("OnRailMonitoredDesktop", "(J[JJ)V", (jlong)context->instance, arr,
+			                 activeWindowId);
+			if (arr)
+				(*env)->DeleteLocalRef(env, arr);
+		}
+		if (attached)
+			jni_detach_thread();
+	}
+
+	return TRUE;
+}
+
+static UINT android_rail_server_system_param(RailClientContext* rail,
+                                             const RAIL_SYSPARAM_ORDER* sysparam)
+{
+	if (!rail || !sysparam)
+		return ERROR_INVALID_PARAMETER;
+
+	return CHANNEL_RC_OK;
+}
+
+static UINT android_rail_server_execute_result(RailClientContext* rail,
+                                               const RAIL_EXEC_RESULT_ORDER* execResult)
+{
+	if (!rail || !execResult)
+		return ERROR_INVALID_PARAMETER;
+
+	if (execResult->execResult != 0)
+		WLog_ERR(TAG, "RAIL execute failed: execResult=0x%04X rawResult=0x%08X",
+		         execResult->execResult, execResult->rawResult);
+	else
+		WLog_DBG(TAG, "RAIL execute success");
+
+	return CHANNEL_RC_OK;
+}
+
+static UINT android_rail_server_local_move_size(RailClientContext* rail,
+                                                const RAIL_LOCALMOVESIZE_ORDER* localMoveSize)
+{
+	if (!rail || !localMoveSize)
+		return ERROR_INVALID_PARAMETER;
+
+	WLog_DBG(TAG, "RAIL window 0x%08X %s pos=(%d,%d)", localMoveSize->windowId,
+	         localMoveSize->isMoveSizeStart ? "move/size start" : "move/size end",
+	         localMoveSize->posX, localMoveSize->posY);
+
+	if (!localMoveSize->isMoveSizeStart)
+	{
+		androidContext* afc = (androidContext*)rail->custom;
+		rdpContext* context = (rdpContext*)afc;
+		freerdp_callback("OnRailWindowMove", "(JJIIII)V", (jlong)context->instance,
+		                 (jlong)localMoveSize->windowId, (jint)localMoveSize->posX,
+		                 (jint)localMoveSize->posY, (jint)-1, (jint)-1);
+	}
+	return CHANNEL_RC_OK;
+}
+
+static UINT android_rail_server_min_max_info(RailClientContext* rail,
+                                             const RAIL_MINMAXINFO_ORDER* minMaxInfo)
+{
+	if (!rail || !minMaxInfo)
+		return ERROR_INVALID_PARAMETER;
+
+	return CHANNEL_RC_OK;
+}
+
+static UINT android_rail_server_z_order_sync(RailClientContext* rail,
+                                             const RAIL_ZORDER_SYNC* zOrderSync)
+{
+	if (!rail || !zOrderSync)
+		return ERROR_INVALID_PARAMETER;
+
+	return CHANNEL_RC_OK;
+}
+
+static UINT android_rail_server_cloak(RailClientContext* rail, const RAIL_CLOAK* cloak)
+{
+	if (!rail || !cloak)
+		return ERROR_INVALID_PARAMETER;
+
+	WLog_DBG(TAG, "RAIL window 0x%08X %s", cloak->windowId, cloak->cloak ? "cloaked" : "uncloaked");
+	return CHANNEL_RC_OK;
+}
+
+static UINT android_rail_server_language_bar_info(RailClientContext* rail,
+                                                  const RAIL_LANGBAR_INFO_ORDER* langBarInfo)
+{
+	if (!rail || !langBarInfo)
+		return ERROR_INVALID_PARAMETER;
+
+	return CHANNEL_RC_OK;
+}
+
+static UINT android_rail_server_get_appid_response(RailClientContext* rail,
+                                                   const RAIL_GET_APPID_RESP_ORDER* getAppIdResp)
+{
+	if (!rail || !getAppIdResp)
+		return ERROR_INVALID_PARAMETER;
+
+	return CHANNEL_RC_OK;
+}
+
+static BOOL android_rail_non_monitored_desktop(rdpContext* context,
+                                               const WINDOW_ORDER_INFO* orderInfo)
+{
+	if (!context)
+		return FALSE;
+
+	freerdp_callback("OnRailSessionEnd", "(J)V", (jlong)context->instance);
+	return TRUE;
+}
+
+static BOOL android_rail_window_state(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo,
+                                      const WINDOW_STATE_ORDER* windowState)
+{
+	if (!context || !orderInfo || !windowState)
+		return FALSE;
+
+	const UINT32 flags = orderInfo->fieldFlags;
+	const BOOL isNew = (flags & WINDOW_ORDER_STATE_NEW) != 0;
+	const BOOL isHidden =
+	    (flags & WINDOW_ORDER_FIELD_SHOW) && windowState->showState == WINDOW_HIDE;
+
+	if (isHidden)
+	{
+		freerdp_callback("OnRailWindowHide", "(JJ)V", (jlong)context->instance,
+		                 (jlong)orderInfo->windowId);
+		return TRUE;
+	}
+
+	const BOOL isShownAgain = !isNew && (flags & WINDOW_ORDER_FIELD_SHOW) && !isHidden &&
+	                          !(flags & WINDOW_ORDER_FIELD_WND_OFFSET);
+	if (isShownAgain)
+	{
+		freerdp_callback("OnRailWindowMove", "(JJIIII)V", (jlong)context->instance,
+		                 (jlong)orderInfo->windowId, (jint)-1, (jint)-1, (jint)-1, (jint)-1);
+		return TRUE;
+	}
+
+	if (isNew)
+	{
+		const BOOL hasOffset = (flags & WINDOW_ORDER_FIELD_WND_OFFSET) != 0;
+		const BOOL hasOffsetAndSize = hasOffset && (flags & WINDOW_ORDER_FIELD_WND_SIZE) != 0;
+		const INT32 x = hasOffset ? windowState->windowOffsetX : 0;
+		const INT32 y = hasOffset ? windowState->windowOffsetY : 0;
+		const INT32 w = hasOffsetAndSize ? (INT32)windowState->windowWidth : -1;
+		const INT32 h = hasOffsetAndSize ? (INT32)windowState->windowHeight : -1;
+		freerdp_callback("OnRailWindowMove", "(JJIIII)V", (jlong)context->instance,
+		                 (jlong)orderInfo->windowId, (jint)x, (jint)y, (jint)w, (jint)h);
+	}
+	else if (flags & WINDOW_ORDER_FIELD_WND_OFFSET)
+	{
+		const BOOL hasSize = (flags & WINDOW_ORDER_FIELD_WND_SIZE) != 0;
+		freerdp_callback("OnRailWindowMove", "(JJIIII)V", (jlong)context->instance,
+		                 (jlong)orderInfo->windowId, (jint)windowState->windowOffsetX,
+		                 (jint)windowState->windowOffsetY,
+		                 hasSize ? (jint)windowState->windowWidth : (jint)-1,
+		                 hasSize ? (jint)windowState->windowHeight : (jint)-1);
+	}
+	return TRUE;
+}
+
+static BOOL android_rail_window_delete(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo)
+{
+	if (!context || !orderInfo)
+		return FALSE;
+
+	freerdp_callback("OnRailWindowDestroy", "(JJ)V", (jlong)context->instance,
+	                 (jlong)orderInfo->windowId);
+	return TRUE;
+}
+
+BOOL android_rail_init(androidContext* afc, RailClientContext* rail)
+{
+	if (!afc || !rail)
+		return FALSE;
+
+	afc->rail = rail;
+	afc->railExecSent = FALSE;
+	rail->custom = (void*)afc;
+	rail->ServerSystemParam = android_rail_server_system_param;
+	rail->ServerExecuteResult = android_rail_server_execute_result;
+	rail->ServerLocalMoveSize = android_rail_server_local_move_size;
+	rail->ServerMinMaxInfo = android_rail_server_min_max_info;
+	rail->ServerZOrderSync = android_rail_server_z_order_sync;
+	rail->ServerCloak = android_rail_server_cloak;
+	rail->ServerLanguageBarInfo = android_rail_server_language_bar_info;
+	rail->ServerGetAppIdResponse = android_rail_server_get_appid_response;
+
+	rdpContext* context = (rdpContext*)afc;
+	context->update->window->MonitoredDesktop = android_rail_monitored_desktop;
+	context->update->window->NonMonitoredDesktop = android_rail_non_monitored_desktop;
+	context->update->window->WindowCreate = android_rail_window_state;
+	context->update->window->WindowUpdate = android_rail_window_state;
+	context->update->window->WindowDelete = android_rail_window_delete;
+	return TRUE;
+}
+
+BOOL android_rail_uninit(androidContext* afc, RailClientContext* rail)
+{
+	if (!afc || !rail)
+		return FALSE;
+
+	rail->custom = NULL;
+	afc->rail = NULL;
+	afc->railExecSent = FALSE;
+	return TRUE;
+}

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_rail.h
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_rail.h
@@ -1,0 +1,22 @@
+/*
+   Android RAIL/RemoteApp Channel
+
+   Copyright 2026 Ibrahim Sevinc <ibrahim.sevinc.mail@gmail.com>
+
+   This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+   If a copy of the MPL was not distributed with this file, You can obtain one at
+   http://mozilla.org/MPL/2.0/.
+*/
+
+#ifndef FREERDP_CLIENT_ANDROID_RAIL_H
+#define FREERDP_CLIENT_ANDROID_RAIL_H
+
+#include <freerdp/client/rail.h>
+#include <freerdp/api.h>
+
+#include "android_freerdp.h"
+
+FREERDP_LOCAL BOOL android_rail_init(androidContext* afc, RailClientContext* rail);
+FREERDP_LOCAL BOOL android_rail_uninit(androidContext* afc, RailClientContext* rail);
+
+#endif /* FREERDP_CLIENT_ANDROID_RAIL_H */

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
@@ -33,7 +33,7 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory;
           exportSchema = false)
 public abstract class AppDatabase extends RoomDatabase
 {
-	static final int DB_VERSION = 16;
+	static final int DB_VERSION = 17;
 	private static final String DB_NAME = "bookmarks.db";
 
 	static
@@ -65,6 +65,7 @@ public abstract class AppDatabase extends RoomDatabase
 					               .addMigrations(MIGRATION_13_14)
 					               .addMigrations(MIGRATION_14_15)
 					               .addMigrations(MIGRATION_15_16)
+					               .addMigrations(MIGRATION_16_17)
 					               .build();
 				}
 			}
@@ -170,6 +171,15 @@ public abstract class AppDatabase extends RoomDatabase
 			sb.append(String.format(java.util.Locale.US, "%02x", b));
 		return sb.toString();
 	}
+
+	private static final Migration MIGRATION_16_17 = new Migration(16, 17) {
+		@Override public void migrate(@NonNull SupportSQLiteDatabase db)
+		{
+			db.execSQL("ALTER TABLE 'bookmarks' ADD 'alternate_shell' TEXT NOT NULL DEFAULT '';");
+			db.execSQL("UPDATE bookmarks SET alternate_shell = remote_program;");
+			db.execSQL("UPDATE bookmarks SET remote_program = '';");
+		}
+	};
 
 	private static final Migration MIGRATION_15_16 = new Migration(15, 16) {
 		@Override public void migrate(@NonNull SupportSQLiteDatabase db)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkConverter.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkConverter.java
@@ -56,6 +56,7 @@ public final class BookmarkConverter
 		adv.setRedirectPrinter(e.redirectPrinter);
 		adv.setSecurity(e.security);
 		adv.setRemoteProgram(e.remoteProgram);
+		adv.setAlternateShell(e.alternateShell);
 		adv.setWorkDir(e.workDir);
 		adv.setConsoleMode(e.consoleMode);
 		adv.setTlsSecLevel(e.tlsSecLevel);
@@ -121,6 +122,7 @@ public final class BookmarkConverter
 		e.redirectPrinter = adv.getRedirectPrinter();
 		e.security = adv.getSecurity();
 		e.remoteProgram = adv.getRemoteProgram();
+		e.alternateShell = adv.getAlternateShell();
 		e.workDir = adv.getWorkDir();
 		e.consoleMode = adv.getConsoleMode();
 		e.tlsSecLevel = adv.getTlsSecLevel();

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkEntity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkEntity.java
@@ -112,6 +112,10 @@ import androidx.room.PrimaryKey;
 	@ColumnInfo(name = "remote_program", defaultValue = "")
 	public String remoteProgram = "";
 
+	@NonNull
+	@ColumnInfo(name = "alternate_shell", defaultValue = "")
+	public String alternateShell = "";
+
 	@NonNull @ColumnInfo(name = "work_dir", defaultValue = "") public String workDir = "";
 
 	@ColumnInfo(name = "console_mode", defaultValue = "false") public boolean consoleMode = false;

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/domain/BookmarkBase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/domain/BookmarkBase.java
@@ -53,6 +53,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 	private static final String keyPrinter = "bookmark.redirect_printer";
 	private static final String keySecurity = "bookmark.security";
 	private static final String keyRemoteApp = "bookmark.remote_program";
+	private static final String keyAlternateShell = "bookmark.alternate_shell";
 	private static final String keyWorkDir = "bookmark.work_dir";
 	private static final String keyConsoleMode = "bookmark.console_mode";
 	private static final String keyVmConnectMode = "bookmark.vmconnect_mode";
@@ -342,6 +343,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 		editor.putBoolean(keyPrinter, advancedSettings.getRedirectPrinter());
 		editor.putInt(keySecurity, advancedSettings.getSecurity());
 		editor.putString(keyRemoteApp, advancedSettings.getRemoteProgram());
+		editor.putString(keyAlternateShell, advancedSettings.getAlternateShell());
 		editor.putString(keyWorkDir, advancedSettings.getWorkDir());
 		editor.putBoolean(keyConsoleMode, advancedSettings.getConsoleMode());
 		editor.putBoolean(keyVmConnectMode, advancedSettings.getVmConnectMode());
@@ -399,6 +401,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 		advancedSettings.setRedirectPrinter(sharedPrefs.getBoolean(keyPrinter, false));
 		advancedSettings.setSecurity(sharedPrefs.getInt(keySecurity, 0));
 		advancedSettings.setRemoteProgram(sharedPrefs.getString(keyRemoteApp, ""));
+		advancedSettings.setAlternateShell(sharedPrefs.getString(keyAlternateShell, ""));
 		advancedSettings.setWorkDir(sharedPrefs.getString(keyWorkDir, ""));
 		advancedSettings.setConsoleMode(sharedPrefs.getBoolean(keyConsoleMode, false));
 		advancedSettings.setVmConnectMode(sharedPrefs.getBoolean(keyVmConnectMode, false));
@@ -936,6 +939,8 @@ public class BookmarkBase implements Parcelable, Cloneable
 
 		@NonNull private String remoteProgram = "";
 
+		@NonNull private String alternateShell = "";
+
 		@NonNull private String workDir = "";
 		private int tlsSecLevel = -1;
 		private int tlsMinLevel = -1;
@@ -956,6 +961,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 			vmConnectMode = parcel.readBoolean();
 			vmConnectGuid = Objects.requireNonNull(parcel.readString());
 			remoteProgram = Objects.requireNonNull(parcel.readString());
+			alternateShell = Objects.requireNonNull(parcel.readString());
 			workDir = Objects.requireNonNull(parcel.readString());
 			tlsSecLevel = parcel.readInt();
 			tlsMinLevel = parcel.readInt();
@@ -1088,6 +1094,16 @@ public class BookmarkBase implements Parcelable, Cloneable
 			this.remoteProgram = remoteProgram;
 		}
 
+		@NonNull public String getAlternateShell()
+		{
+			return alternateShell;
+		}
+
+		public void setAlternateShell(@NonNull String alternateShell)
+		{
+			this.alternateShell = alternateShell;
+		}
+
 		@NonNull public String getWorkDir()
 		{
 			return workDir;
@@ -1135,6 +1151,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 			out.writeBoolean(vmConnectMode);
 			out.writeString(vmConnectGuid);
 			out.writeString(remoteProgram);
+			out.writeString(alternateShell);
 			out.writeString(workDir);
 			out.writeInt(tlsSecLevel);
 			out.writeInt(tlsMinLevel);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ApplicationSettingsActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/ApplicationSettingsActivity.java
@@ -200,6 +200,20 @@ public class ApplicationSettingsActivity
 		}
 	}
 
+	public static class ExperimentalFragment extends PreferenceFragmentCompat
+	{
+		@Override public void onCreatePreferences(Bundle savedInstanceState, String rootKey)
+		{
+			setPreferencesFromResource(R.xml.settings_app_experimental, rootKey);
+		}
+	}
+
+	// Preference key convention: "experimental.<feature>".
+	public static boolean isExperimentalEnabled(Context context, String feature)
+	{
+		return get(context).getBoolean("experimental." + feature, false);
+	}
+
 	public static SharedPreferences get(Context context)
 	{
 		Context appContext = context.getApplicationContext();
@@ -207,6 +221,7 @@ public class ApplicationSettingsActivity
 		PreferenceManager.setDefaultValues(appContext, R.xml.settings_app_power, false);
 		PreferenceManager.setDefaultValues(appContext, R.xml.settings_app_security, false);
 		PreferenceManager.setDefaultValues(appContext, R.xml.settings_app_ui, false);
+		PreferenceManager.setDefaultValues(appContext, R.xml.settings_app_experimental, false);
 		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(appContext);
 
 		final String key = context.getString(R.string.preference_key_client_name);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/RailWindowManager.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/RailWindowManager.java
@@ -1,0 +1,232 @@
+/*
+   Android RAIL/RemoteApp window overlay manager
+
+   Copyright 2026 Ibrahim Sevinc <ibrahim.sevinc.mail@gmail.com>
+
+   This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+   If a copy of the MPL was not distributed with this file, You can obtain one at
+   http://mozilla.org/MPL/2.0/.
+*/
+
+package com.freerdp.freerdpcore.presentation;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+
+import java.util.HashMap;
+
+class RailWindowManager
+{
+	private final Context context;
+	private final FrameLayout container;
+	private final SessionView sessionView;
+	private final Handler ui = new Handler(Looper.getMainLooper());
+
+	private final HashMap<Long, ImageView> windows = new HashMap<>();
+	private final HashMap<Long, int[]> rects = new HashMap<>();
+	private final HashMap<Long, Bitmap> bitmaps = new HashMap<>();
+	private long[] zOrder = null;
+	private long activeWindowId = 0;
+
+	RailWindowManager(Context context, FrameLayout container, SessionView sessionView)
+	{
+		this.context = context;
+		this.container = container;
+		this.sessionView = sessionView;
+		sessionView.setOnZoomChangedListener(zoom -> repositionAll());
+	}
+
+	void onWindowUpdate(long windowId, int width, int height, int[] pixels)
+	{
+		if (pixels == null)
+			return;
+		ui.post(() -> handleWindowUpdate(windowId, width, height, pixels));
+	}
+
+	void onWindowMove(long windowId, int x, int y, int w, int h)
+	{
+		ui.post(() -> handleWindowMove(windowId, x, y, w, h));
+	}
+
+	void onWindowHide(long windowId)
+	{
+		ui.post(() -> {
+			ImageView iv = windows.get(windowId);
+			if (iv != null)
+				iv.setVisibility(View.INVISIBLE);
+		});
+	}
+
+	void onWindowDestroy(long windowId)
+	{
+		ui.post(() -> handleWindowDestroy(windowId));
+	}
+
+	void onSessionEnd()
+	{
+		ui.post(() -> {
+			clearWindows();
+			sessionView.setRailMode(false);
+		});
+	}
+
+	void onMonitoredDesktop(long[] windowIds, long active)
+	{
+		ui.post(() -> handleMonitoredDesktop(windowIds, active));
+	}
+
+	// Removes all overlays; must be called on the UI thread.
+	void clear()
+	{
+		clearWindows();
+	}
+
+	private void handleWindowUpdate(long windowId, int width, int height, int[] pixels)
+	{
+		if (container == null)
+			return;
+		// Reuse the per-window bitmap; reallocate only on size change.
+		Bitmap bm = bitmaps.get(windowId);
+		boolean newBitmap = bm == null || bm.getWidth() != width || bm.getHeight() != height;
+		if (newBitmap)
+		{
+			bm = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+			bitmaps.put(windowId, bm);
+		}
+		bm.setPixels(pixels, 0, width, 0, 0, width, height);
+		ImageView iv = windows.get(windowId);
+		if (iv == null)
+		{
+			iv = new ImageView(context);
+			iv.setScaleType(ImageView.ScaleType.FIT_XY);
+			iv.setVisibility(View.INVISIBLE);
+			container.addView(iv);
+			windows.put(windowId, iv);
+			// Order may have arrived before this view existed; restack now.
+			restack();
+			newBitmap = true;
+		}
+		if (newBitmap)
+		{
+			iv.setImageBitmap(bm);
+			ViewGroup.LayoutParams lp = iv.getLayoutParams();
+			lp.width = width;
+			lp.height = height;
+			iv.requestLayout();
+		}
+		else
+		{
+			iv.invalidate();
+		}
+		if (rects.containsKey(windowId))
+		{
+			position(iv, windowId);
+			iv.setVisibility(View.VISIBLE);
+			sessionView.setRailMode(true);
+		}
+	}
+
+	private void handleWindowMove(long windowId, int x, int y, int w, int h)
+	{
+		if (x != -1 || y != -1)
+			rects.put(windowId, new int[] { x, y, w, h });
+		ImageView iv = windows.get(windowId);
+		if (iv != null)
+		{
+			if (w > 0 && h > 0)
+			{
+				ViewGroup.LayoutParams lp = iv.getLayoutParams();
+				if (lp.width != w || lp.height != h)
+				{
+					lp.width = w;
+					lp.height = h;
+					iv.requestLayout();
+				}
+			}
+			position(iv, windowId);
+			iv.setVisibility(View.VISIBLE);
+			sessionView.setRailMode(true);
+		}
+	}
+
+	private void handleWindowDestroy(long windowId)
+	{
+		rects.remove(windowId);
+		bitmaps.remove(windowId);
+		ImageView iv = windows.remove(windowId);
+		if (iv != null && container != null)
+			container.removeView(iv);
+	}
+
+	private void handleMonitoredDesktop(long[] windowIds, long active)
+	{
+		if (windowIds != null)
+		{
+			zOrder = windowIds;
+			if (windowIds.length > 0)
+				activeWindowId = windowIds[0];
+		}
+		if (active != 0)
+			activeWindowId = active;
+		restack();
+	}
+
+	// Match client stacking to the server order (input is routed server-side by coordinate).
+	private void restack()
+	{
+		if (container == null)
+			return;
+		if (zOrder != null)
+			for (int i = zOrder.length - 1; i >= 0; i--)
+			{
+				ImageView iv = windows.get(zOrder[i]);
+				if (iv != null)
+					iv.bringToFront();
+			}
+		if (activeWindowId != 0 &&
+		    (zOrder == null || zOrder.length == 0 || zOrder[0] != activeWindowId))
+		{
+			ImageView iv = windows.get(activeWindowId);
+			if (iv != null)
+				iv.bringToFront();
+		}
+	}
+
+	private void repositionAll()
+	{
+		for (HashMap.Entry<Long, ImageView> entry : windows.entrySet())
+			position(entry.getValue(), entry.getKey());
+	}
+
+	private void position(ImageView iv, long windowId)
+	{
+		int[] rect = rects.get(windowId);
+		if (rect == null)
+			return;
+		float zoom = sessionView != null ? sessionView.getZoom() : 1.0f;
+		iv.setPivotX(0);
+		iv.setPivotY(0);
+		iv.setScaleX(zoom);
+		iv.setScaleY(zoom);
+		iv.setX(rect[0] * zoom);
+		iv.setY(rect[1] * zoom);
+	}
+
+	private void clearWindows()
+	{
+		if (container != null)
+			for (ImageView iv : windows.values())
+				container.removeView(iv);
+		windows.clear();
+		rects.clear();
+		bitmaps.clear();
+		zOrder = null;
+		activeWindowId = 0;
+	}
+}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -73,6 +73,8 @@ public class SessionActivity extends AppCompatActivity
 	private static final int GRAPHICS_CHANGED = 6;
 	private static final int POINTER_SET = 7;
 
+	private RailWindowManager railManager;
+
 	private final Handler uiHandler = new Handler(Looper.getMainLooper()) {
 		@Override public void handleMessage(Message msg)
 		{
@@ -263,6 +265,8 @@ public class SessionActivity extends AppCompatActivity
 		KeyboardView modifiersKeyboardView = findViewById(R.id.extended_keyboard_header);
 
 		scrollView = findViewById(R.id.sessionScrollView);
+		scrollView.setScrollViewListener(null);
+		railManager = new RailWindowManager(this, findViewById(R.id.railContainer), sessionView);
 		sessionViewModel = new ViewModelProvider(this).get(SessionViewModel.class);
 		sessionViewModel.getState().observe(this, this::onConnectionStateChanged);
 
@@ -787,6 +791,36 @@ public class SessionActivity extends AppCompatActivity
 		sessionView.setDefaultCursor();
 	}
 
+	@Override public void OnRailWindowUpdate(long windowId, int width, int height, int[] pixels)
+	{
+		railManager.onWindowUpdate(windowId, width, height, pixels);
+	}
+
+	@Override public void OnRailWindowMove(long windowId, int x, int y, int w, int h)
+	{
+		railManager.onWindowMove(windowId, x, y, w, h);
+	}
+
+	@Override public void OnRailWindowHide(long windowId)
+	{
+		railManager.onWindowHide(windowId);
+	}
+
+	@Override public void OnRailWindowDestroy(long windowId)
+	{
+		railManager.onWindowDestroy(windowId);
+	}
+
+	@Override public void OnRailSessionEnd()
+	{
+		railManager.onSessionEnd();
+	}
+
+	@Override public void OnRailMonitoredDesktop(long[] windowIds, long activeWindowId)
+	{
+		railManager.onMonitoredDesktop(windowIds, activeWindowId);
+	}
+
 	// ****************************************************************************
 	// SessionView.SessionViewListener and TouchPointerView.TouchPointerListener
 	// — delegated to SessionInputManager
@@ -904,6 +938,8 @@ public class SessionActivity extends AppCompatActivity
 		}
 
 		dialogs.dismissProgress();
+
+		railManager.clear();
 
 		session.setUIEventListener(null);
 		closeSessionActivity(RESULT_OK);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -756,6 +756,27 @@ public class SessionActivity extends AppCompatActivity
 		return dialogs.verifyChangedCertificate(host, port, subject, issuer, fingerprint, flags);
 	}
 
+	@Override public boolean OnExperimentalFeature(int feature)
+	{
+		final String featureKey;
+		final String displayName;
+		switch (feature)
+		{
+			case LibFreeRDP.EXPERIMENTAL_REMOTEAPP:
+				featureKey = "remoteapp";
+				displayName = getString(R.string.experimental_feature_remoteapp);
+				break;
+			default:
+				return true;
+		}
+		if (ApplicationSettingsActivity.isExperimentalEnabled(this, featureKey))
+			return true;
+		// suppress the generic failure toast; the dialog explains the abort
+		connectCancelledByUser = true;
+		dialogs.showExperimentalBlocked(displayName);
+		return false;
+	}
+
 	@Override public void OnRemoteClipboardChanged(String data)
 	{
 		Log.v(TAG, "OnRemoteClipboardChanged: " + data);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionDialogs.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionDialogs.java
@@ -13,6 +13,7 @@ package com.freerdp.freerdpcore.presentation;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Intent;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.TypedValue;
@@ -53,6 +54,7 @@ public class SessionDialogs
 
 	private final AlertDialog dlgVerifyCertificate;
 	private final AlertDialog dlgUserCredentials;
+	private final AlertDialog dlgExperimental;
 	private final View userCredView;
 
 	private AlertDialog progressDialog;
@@ -109,6 +111,27 @@ public class SessionDialogs
 		                                            })
 		                         .setCancelable(false)
 		                         .create();
+
+		dlgExperimental = new AlertDialog.Builder(activity)
+		                      .setTitle(R.string.dlg_title_experimental_feature)
+		                      .setPositiveButton(R.string.menu_app_settings,
+		                                         (dialog, which) -> {
+			                                         openExperimentalSettings();
+			                                         synchronized (dialog)
+			                                         {
+				                                         dialog.notify();
+			                                         }
+		                                         })
+		                      .setNegativeButton(android.R.string.cancel,
+		                                         (dialog, which) -> {
+			                                         notifyCancel();
+			                                         synchronized (dialog)
+			                                         {
+				                                         dialog.notify();
+			                                         }
+		                                         })
+		                      .setCancelable(false)
+		                      .create();
 	}
 
 	/**
@@ -182,6 +205,31 @@ public class SessionDialogs
 		// The "changed" variant currently shows the same information as the
 		// regular verify dialog (matches prior behaviour).
 		return verifyCertificate(host, port, subject, issuer, fingerprint, flags);
+	}
+
+	/** Shows an "experimental feature" notice and blocks the calling thread until dismissed. */
+	public void showExperimentalBlocked(String featureName)
+	{
+		dlgExperimental.setMessage(
+		    activity.getString(R.string.dlg_msg_experimental_feature, featureName));
+
+		showOnUiThread(dlgExperimental);
+
+		try
+		{
+			synchronized (dlgExperimental)
+			{
+				dlgExperimental.wait();
+			}
+		}
+		catch (InterruptedException e)
+		{
+		}
+	}
+
+	private void openExperimentalSettings()
+	{
+		activity.startActivity(new Intent(activity, ApplicationSettingsActivity.class));
 	}
 
 	private int showVerifyDialog(String msg)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionView.java
@@ -52,6 +52,8 @@ public class SessionView extends View
 	private int touchPointerPaddingWidth = 0;
 	private int touchPointerPaddingHeight = 0;
 	private SessionViewListener sessionViewListener = null;
+	private OnZoomChangedListener zoomChangedListener = null;
+	private boolean railMode = false;
 	// helpers for scaling gesture handling
 	private float scaleFactor = 1.0f;
 	private Matrix scaleMatrix;
@@ -166,6 +168,24 @@ public class SessionView extends View
 		return scaleFactor;
 	}
 
+	public void setRailMode(boolean rail)
+	{
+		if (railMode == rail)
+			return;
+		railMode = rail;
+		invalidate();
+	}
+
+	public interface OnZoomChangedListener
+	{
+		void onZoomChanged(float zoom);
+	}
+
+	public void setOnZoomChangedListener(OnZoomChangedListener l)
+	{
+		zoomChangedListener = l;
+	}
+
 	public void setZoom(float factor)
 	{
 		scaleFactor = factor;
@@ -174,6 +194,9 @@ public class SessionView extends View
 
 		if (cursorPixels != null)
 			applyScaledCursor();
+
+		if (zoomChangedListener != null)
+			zoomChangedListener.onZoomChanged(scaleFactor);
 
 		requestLayout();
 	}
@@ -245,7 +268,7 @@ public class SessionView extends View
 		canvas.save();
 		canvas.concat(scaleMatrix);
 		canvas.drawColor(Color.BLACK);
-		if (surface != null)
+		if (!railMode && surface != null)
 		{
 			surface.draw(canvas);
 		}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -45,6 +45,9 @@ public class LibFreeRDP
 	public static final long VERIFY_CERT_FLAG_MATCH_LEGACY_SHA1 = 0x100;
 	public static final long VERIFY_CERT_FLAG_FP_IS_PEM = 0x200;
 
+	// Keep in sync with android_freerdp.c.
+	public static final int EXPERIMENTAL_REMOTEAPP = 0;
+
 	private static boolean tryLoad(String[] libraries)
 	{
 		boolean success = false;
@@ -680,6 +683,17 @@ public class LibFreeRDP
 		return 0;
 	}
 
+	private static boolean OnExperimentalFeature(long inst, int feature)
+	{
+		SessionState s = GlobalApp.getSession(inst);
+		if (s == null)
+			return true;
+		UIEventListener uiEventListener = s.getUIEventListener();
+		if (uiEventListener == null)
+			return true;
+		return uiEventListener.OnExperimentalFeature(feature);
+	}
+
 	private static void OnGraphicsUpdate(long inst, int x, int y, int width, int height)
 	{
 		SessionState s = GlobalApp.getSession(inst);
@@ -846,6 +860,8 @@ public class LibFreeRDP
 		int OnVerifyChangedCertificateEx(String host, long port, String commonName, String subject, String issuer,
 		                               String fingerprint, String oldSubject, String oldIssuer,
 		                               String oldFingerprint, long flags);
+
+		boolean OnExperimentalFeature(int feature);
 
 		void OnGraphicsUpdate(int x, int y, int width, int height);
 

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -386,9 +386,12 @@ public class LibFreeRDP
 			if (!advanced.getWorkDir().isEmpty())
 				args.add("/app:workdir:" + advanced.getWorkDir());
 		}
-		else if (!advanced.getWorkDir().isEmpty())
+		else
 		{
-			args.add("/shell-dir:" + advanced.getWorkDir());
+			if (!advanced.getAlternateShell().isEmpty())
+				args.add("/shell:" + advanced.getAlternateShell());
+			if (!advanced.getWorkDir().isEmpty())
+				args.add("/shell-dir:" + advanced.getWorkDir());
 		}
 
 		args.add(addFlag("async-channels", debug.getAsyncChannel()));

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -382,10 +382,11 @@ public class LibFreeRDP
 
 		if (!advanced.getRemoteProgram().isEmpty())
 		{
-			args.add("/shell:" + advanced.getRemoteProgram());
+			args.add("/app:program:" + advanced.getRemoteProgram());
+			if (!advanced.getWorkDir().isEmpty())
+				args.add("/app:workdir:" + advanced.getWorkDir());
 		}
-
-		if (!advanced.getWorkDir().isEmpty())
+		else if (!advanced.getWorkDir().isEmpty())
 		{
 			args.add("/shell-dir:" + advanced.getWorkDir());
 		}
@@ -747,6 +748,67 @@ public class LibFreeRDP
 			uiEventListener.OnPointerSetDefault();
 	}
 
+	private static void OnRailWindowUpdate(long inst, long windowId, int width, int height,
+	                                       int[] pixels)
+	{
+		SessionState s = GlobalApp.getSession(inst);
+		if (s == null)
+			return;
+		UIEventListener uiEventListener = s.getUIEventListener();
+		if (uiEventListener != null)
+			uiEventListener.OnRailWindowUpdate(windowId, width, height, pixels);
+	}
+
+	private static void OnRailWindowMove(long inst, long windowId, int x, int y, int w, int h)
+	{
+		SessionState s = GlobalApp.getSession(inst);
+		if (s == null)
+			return;
+		UIEventListener uiEventListener = s.getUIEventListener();
+		if (uiEventListener != null)
+			uiEventListener.OnRailWindowMove(windowId, x, y, w, h);
+	}
+
+	private static void OnRailWindowHide(long inst, long windowId)
+	{
+		SessionState s = GlobalApp.getSession(inst);
+		if (s == null)
+			return;
+		UIEventListener uiEventListener = s.getUIEventListener();
+		if (uiEventListener != null)
+			uiEventListener.OnRailWindowHide(windowId);
+	}
+
+	private static void OnRailWindowDestroy(long inst, long windowId)
+	{
+		SessionState s = GlobalApp.getSession(inst);
+		if (s == null)
+			return;
+		UIEventListener uiEventListener = s.getUIEventListener();
+		if (uiEventListener != null)
+			uiEventListener.OnRailWindowDestroy(windowId);
+	}
+
+	private static void OnRailSessionEnd(long inst)
+	{
+		SessionState s = GlobalApp.getSession(inst);
+		if (s == null)
+			return;
+		UIEventListener uiEventListener = s.getUIEventListener();
+		if (uiEventListener != null)
+			uiEventListener.OnRailSessionEnd();
+	}
+
+	private static void OnRailMonitoredDesktop(long inst, long[] windowIds, long activeWindowId)
+	{
+		SessionState s = GlobalApp.getSession(inst);
+		if (s == null)
+			return;
+		UIEventListener uiEventListener = s.getUIEventListener();
+		if (uiEventListener != null)
+			uiEventListener.OnRailMonitoredDesktop(windowIds, activeWindowId);
+	}
+
 	public static String getVersion()
 	{
 		return freerdp_get_version();
@@ -795,5 +857,17 @@ public class LibFreeRDP
 		void OnPointerSetNull();
 
 		void OnPointerSetDefault();
+
+		void OnRailWindowUpdate(long windowId, int width, int height, int[] pixels);
+
+		void OnRailWindowMove(long windowId, int x, int y, int w, int h);
+
+		void OnRailWindowHide(long windowId);
+
+		void OnRailWindowDestroy(long windowId);
+
+		void OnRailSessionEnd();
+
+		void OnRailMonitoredDesktop(long[] windowIds, long activeWindowId);
 	}
 }

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/RDPFileHelper.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/RDPFileHelper.java
@@ -148,10 +148,12 @@ public final class RDPFileHelper
 			advanced.setLoadBalanceInfo(s);
 
 		s = p.getString("remoteapplicationprogram");
-		if (s == null || s.isEmpty())
-			s = p.getString("alternate shell");
 		if (s != null && !s.isEmpty())
 			advanced.setRemoteProgram(s);
+
+		s = p.getString("alternate shell");
+		if (s != null && !s.isEmpty())
+			advanced.setAlternateShell(s);
 
 		s = p.getString("shell working directory");
 		if (s != null && !s.isEmpty())
@@ -251,6 +253,10 @@ public final class RDPFileHelper
 			writeString(sb, "remoteapplicationprogram", remoteApp);
 			writeInt(sb, "remoteapplicationmode", 1);
 		}
+
+		String alternateShell = adv.getAlternateShell();
+		if (!alternateShell.isEmpty())
+			writeString(sb, "alternate shell", alternateShell);
 
 		String workDir = adv.getWorkDir();
 		if (!workDir.isEmpty())

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/RDPFileHelper.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/utils/RDPFileHelper.java
@@ -247,7 +247,10 @@ public final class RDPFileHelper
 
 		String remoteApp = adv.getRemoteProgram();
 		if (!remoteApp.isEmpty())
+		{
 			writeString(sb, "remoteapplicationprogram", remoteApp);
+			writeInt(sb, "remoteapplicationmode", 1);
+		}
 
 		String workDir = adv.getWorkDir();
 		if (!workDir.isEmpty())

--- a/client/Android/Studio/freeRDPCore/src/main/res/layout/session.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/layout/session.xml
@@ -33,13 +33,20 @@
         android:isScrollContainer="true"
         android:scrollbars="horizontal|vertical">
 
-        <com.freerdp.freerdpcore.presentation.SessionView
-            android:id="@+id/sessionView"
+        <FrameLayout
+            android:id="@+id/railContainer"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:drawingCacheQuality="low"
-            android:focusable="true"
-            android:focusableInTouchMode="true" />
+            android:layout_height="wrap_content">
+
+            <com.freerdp.freerdpcore.presentation.SessionView
+                android:id="@+id/sessionView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:drawingCacheQuality="low"
+                android:focusable="true"
+                android:focusableInTouchMode="true" />
+
+        </FrameLayout>
 
     </com.freerdp.freerdpcore.presentation.ScrollView2D>
 

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -198,6 +198,7 @@
         <item>3</item>
     </string-array>
     <string name="settings_remote_program">Remote Program</string>
+    <string name="settings_alternate_shell">Alternate Shell</string>
     <string name="settings_work_dir">Working Directory</string>
     <string name="settings_async_channel">Async channel</string>
     <string name="settings_async_update">Async update</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -257,6 +257,13 @@
     <string name="dlg_msg_clear_cert_cache">Are you sure you want to delete all your cached certificates?</string>
     <string name="debug_level">Debug Level</string>
     <string name="settings_debug">Debug Settings</string>
+    <string name="settings_cat_experimental">Experimental</string>
+    <string name="settings_experimental_remoteapp">RemoteApp windows</string>
+    <string name="settings_experimental_remoteapp_summary">Show remote programs as separate windows instead of a full desktop. Experimental, may be unstable.</string>
+    <string name="experimental_feature_remoteapp">RemoteApp</string>
+    <string name="dlg_title_experimental_feature">Experimental feature</string>
+    <string name="dlg_msg_experimental_feature">%1$s is experimental. Enable it in the Experimental settings to use it.</string>
+    <string name="preference_key_experimental_remoteapp" translatable="false">experimental.remoteapp</string>
     <string name="preference_key_client_name" translatable="false">preference_key_client_name</string>
     <string name="preference_title_client_name">Client Name</string>
     <string name="preference_default_client_name" translatable="false">aFreeRDP</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/advanced_settings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/advanced_settings.xml
@@ -87,6 +87,12 @@
             app:useSimpleSummaryProvider="true" />
 
         <EditTextPreference
+            android:key="bookmark.alternate_shell"
+            android:singleLine="true"
+            android:title="@string/settings_alternate_shell"
+            app:useSimpleSummaryProvider="true" />
+
+        <EditTextPreference
             android:key="bookmark.work_dir"
             android:singleLine="true"
             android:title="@string/settings_work_dir"

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_experimental.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_experimental.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="@string/preference_key_experimental_remoteapp"
+        android:summary="@string/settings_experimental_remoteapp_summary"
+        android:title="@string/settings_experimental_remoteapp" />
+</PreferenceScreen>

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_headers.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_headers.xml
@@ -26,4 +26,10 @@
         android:title="@string/settings_cat_security"
         app:fragment="com.freerdp.freerdpcore.presentation.ApplicationSettingsActivity$SecurityFragment" />
 
+    <Preference
+        android:icon="@drawable/ic_tune"
+        android:key="settings.experimental"
+        android:title="@string/settings_cat_experimental"
+        app:fragment="com.freerdp.freerdpcore.presentation.ApplicationSettingsActivity$ExperimentalFragment" />
+
 </PreferenceScreen>


### PR DESCRIPTION


- Fixes #11655


## Description

RAIL (RemoteApp) support for aFreeRDP: remote application windows are shown as floating overlays instead of the full remote desktop.

- Window create/move/hide/destroy via the RAIL channel; contents from the GFX `UpdateWindowFromSurface` hook.
- Server-authoritative z-order and active window (single `OnRailMonitoredDesktop` callback), so the topmost window is the one clicks   hit.
- Remote desktop surface hidden in RemoteApp mode (no logon/wallpaper behind the windows).
- Overlays track `SessionView` zoom; input maps back via its inverse scale  matrix.
- Per-window bitmaps reused (realloc only on size change); overlay logic  isolated in `RailWindowManager`.

Non-RemoteApp sessions are unaffected.

### Supported

- Multiple windows: every top-level window the server sends is rendered as its
  own overlay, including windows opened from the launched app (e.g. starting cmd
  and launching another program from it). Z-order and the active window follow
  the server.
- Move and resize: windows can be moved and resized, and the overlays update
  accordingly.
- Menus, tooltips and popups render with their transparency (rounded corners /
  drop shadows).
- Pinch-zoom: overlays scale with the session and clicks still map to the
  correct window.
- The remote desktop background is hidden in RemoteApp mode (only the app
  windows are shown).

## Screenshot

<img width="2772" height="1272" alt="Screenshot_2026-06-14-18-11-28-90_bfe5c884e366e53e8d644a47ee8284f1" src="https://github.com/user-attachments/assets/8198c66d-b4cf-440b-9657-95cffeb47ea7" />


<img width="2772" height="1272" alt="Screenshot_2026-06-14-18-45-06-96_bfe5c884e366e53e8d644a47ee8284f1" src="https://github.com/user-attachments/assets/53cdaf61-dd75-4651-a0a3-93ccd0a1475b" />


## Testing Instructions

- In a bookmark's advanced settings, set the RemoteApp program name, then connect > the app window shows with no remote desktop background.
- Open overlapping windows (e.g. Notepad + Open dialog) > z-order correct, clicking brings the right window forward.
- Pinch-zoom > windows scale and stay aligned, clicks still land correctly.
- Normal (no RemoteApp name set) session > no regression.

## Environments Tested

- Physical Device: Android 16 (API 36)
