### PR TITLE
[client,rdpecam,android] Add camera redirection support

### DIFF
--- a/channels/rdpecam/client/CMakeLists.txt
+++ b/channels/rdpecam/client/CMakeLists.txt
@@ -17,13 +17,15 @@
 
 define_channel_client("rdpecam")
 
-# currently camera redirect client supported for platforms with Video4Linux only
-find_package(V4L)
-if(V4L_FOUND)
-  set(WITH_V4L ON)
-  add_compile_definitions("WITH_V4L")
-else()
-  message(FATAL_ERROR "libv4l-dev required for CHANNEL_RDPECAM_CLIENT")
+# currently camera redirect client supported for platforms with Video4Linux or Android
+if(NOT ANDROID)
+  find_package(V4L)
+  if(V4L_FOUND)
+    set(WITH_V4L ON)
+    add_compile_definitions("WITH_V4L")
+  else()
+    message(FATAL_ERROR "libv4l-dev required for CHANNEL_RDPECAM_CLIENT")
+  endif()
 endif()
 
 set(${MODULE_PREFIX}_LIBS freerdp winpr)
@@ -33,6 +35,10 @@ set(${MODULE_PREFIX}_SRCS camera_device_enum_main.c camera_device_main.c encodin
 # TRUE = build as static addin (linked into libfreerdp-client), not dynamic plugin (.so)
 add_channel_client_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} TRUE "DVCPluginEntry")
 
-if(V4L_FOUND)
+if(WITH_V4L)
   add_channel_client_subsystem(${MODULE_PREFIX} ${CHANNEL_NAME} "v4l" "")
+endif()
+
+if(ANDROID)
+  add_channel_client_subsystem(${MODULE_PREFIX} ${CHANNEL_NAME} "android" "")
 endif()

--- a/channels/rdpecam/client/android/CMakeLists.txt
+++ b/channels/rdpecam/client/android/CMakeLists.txt
@@ -1,0 +1,30 @@
+# FreeRDP: A Remote Desktop Protocol Implementation
+# MS-RDPECAM Android NDK Camera2 HAL
+#
+# Copyright 2026 Ibrahim Sevinc <ibrahim.sevinc.mail@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if(ANDROID)
+
+  define_channel_client_subsystem("rdpecam" "android" "")
+
+  set(${MODULE_PREFIX}_SRCS camera_android.c)
+
+  set(${MODULE_PREFIX}_LIBS winpr freerdp camera2ndk mediandk)
+
+  include_directories(..)
+
+  add_channel_client_subsystem_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} "" TRUE "")
+
+endif()

--- a/channels/rdpecam/client/android/camera_android.c
+++ b/channels/rdpecam/client/android/camera_android.c
@@ -68,6 +68,8 @@ typedef struct
 
 static const char* cam_android_extract_camera_id(const char* deviceId)
 {
+	WINPR_ASSERT(deviceId);
+
 	if (strncmp(deviceId, ANDROID_CAMERA_PREFIX, ANDROID_CAMERA_PREFIX_LEN) != 0)
 		return NULL;
 	return deviceId + ANDROID_CAMERA_PREFIX_LEN;
@@ -76,6 +78,8 @@ static const char* cam_android_extract_camera_id(const char* deviceId)
 /* Tear down the capture session and its request objects. The ImageReader and device are kept. */
 static void cam_android_close_session(CamAndroidStream* stream)
 {
+	WINPR_ASSERT(stream);
+
 	if (stream->session)
 	{
 		ACameraCaptureSession_stopRepeating(stream->session);
@@ -112,6 +116,11 @@ static void cam_android_yuv420_888_to_nv12(BYTE* dst, int width, int height, con
                                            int uPixelStride, const uint8_t* vData, int vRowStride,
                                            int vPixelStride)
 {
+	WINPR_ASSERT(dst);
+	WINPR_ASSERT(yData);
+	WINPR_ASSERT(uData);
+	WINPR_ASSERT(vData);
+
 	const size_t ySize = (size_t)width * height;
 
 	/* Y plane */
@@ -179,6 +188,9 @@ static void cam_android_yuv420_888_to_nv12(BYTE* dst, int width, int height, con
 
 static void cam_android_deliver_frame(CamAndroidStream* stream, AImage* image)
 {
+	WINPR_ASSERT(stream);
+	WINPR_ASSERT(image);
+
 	int32_t width = 0;
 	int32_t height = 0;
 	if (AImage_getWidth(image, &width) != AMEDIA_OK ||
@@ -227,6 +239,8 @@ static void cam_android_deliver_frame(CamAndroidStream* stream, AImage* image)
 static void cam_android_on_image_available(void* context, AImageReader* reader)
 {
 	CamAndroidStream* stream = (CamAndroidStream*)context;
+	WINPR_ASSERT(stream);
+	WINPR_ASSERT(reader);
 
 	EnterCriticalSection(&stream->lock);
 	const BOOL streaming = stream->streaming;
@@ -293,6 +307,8 @@ static void cam_android_session_ready(void* context, ACameraCaptureSession* sess
  * configure a normal YUV session, so they must not be offered to the server. */
 static BOOL cam_android_is_backward_compatible(ACameraMetadata* characteristics)
 {
+	WINPR_ASSERT(characteristics);
+
 	ACameraMetadata_const_entry caps;
 	if (ACameraMetadata_getConstEntry(characteristics, ACAMERA_REQUEST_AVAILABLE_CAPABILITIES,
 	                                  &caps) != ACAMERA_OK)
@@ -310,6 +326,8 @@ static UINT cam_android_enumerate(ICamHal* ihal, ICamHalEnumCallback callback, C
                                   GENERIC_CHANNEL_CALLBACK* hchannel)
 {
 	CamAndroidHal* hal = (CamAndroidHal*)ihal;
+	WINPR_ASSERT(hal);
+
 	UINT count = 0;
 
 	/* NV12 capture needs FFmpeg/swscale to be encoded; without it, offer no cameras. */
@@ -327,7 +345,7 @@ static UINT cam_android_enumerate(ICamHal* ihal, ICamHalEnumCallback callback, C
 	/* Offer only the primary camera per facing direction: auxiliary back cameras (ultrawide/tele/
 	 * macro/depth) advertise resolutions but fail to configure a YUV session and freeze the
 	 * channel. Indexed by ACAMERA_LENS_FACING_* (FRONT=0, BACK=1, EXTERNAL=2). */
-	BOOL seenFacing[ACAMERA_LENS_FACING_EXTERNAL + 1] = { 0 };
+	BOOL seenFacing[ACAMERA_LENS_FACING_EXTERNAL + 1] = WINPR_C_ARRAY_INIT;
 
 	for (int i = 0; i < idList->numCameras; i++)
 	{
@@ -396,6 +414,8 @@ static UINT cam_android_enumerate(ICamHal* ihal, ICamHalEnumCallback callback, C
  * the ImageReader, or the camera service fails to unconfigure and leaves the device running. */
 static void cam_android_close_device(CamAndroidStream* stream)
 {
+	WINPR_ASSERT(stream);
+
 	EnterCriticalSection(&stream->lock);
 	stream->streaming = FALSE;
 	LeaveCriticalSection(&stream->lock);
@@ -427,6 +447,9 @@ static void cam_android_close_device(CamAndroidStream* stream)
  * one open makes the next openCamera fail with CAMERA_DISCONNECTED and freeze the channel. */
 static void cam_android_close_other_devices(CamAndroidHal* hal, const char* keepDeviceId)
 {
+	WINPR_ASSERT(hal);
+	WINPR_ASSERT(keepDeviceId);
+
 	ULONG_PTR* keys = NULL;
 	const size_t count = HashTable_GetKeys(hal->streams, &keys);
 	for (size_t i = 0; i < count; i++)
@@ -448,6 +471,10 @@ static void cam_android_close_other_devices(CamAndroidHal* hal, const char* keep
 static CamAndroidStream* cam_android_get_or_create_stream(CamAndroidHal* hal, const char* deviceId,
                                                           CAM_ERROR_CODE* errorCode)
 {
+	WINPR_ASSERT(hal);
+	WINPR_ASSERT(deviceId);
+	WINPR_ASSERT(errorCode);
+
 	CamAndroidStream* stream = (CamAndroidStream*)HashTable_GetItemValue(hal->streams, deviceId);
 	if (stream)
 		return stream;
@@ -480,6 +507,12 @@ static BOOL cam_android_open_device(CamAndroidHal* hal, CamAndroidStream* stream
                                     const char* deviceId, const char* cameraId,
                                     CAM_ERROR_CODE* errorCode)
 {
+	WINPR_ASSERT(hal);
+	WINPR_ASSERT(stream);
+	WINPR_ASSERT(deviceId);
+	WINPR_ASSERT(cameraId);
+	WINPR_ASSERT(errorCode);
+
 	/* Reopen a device left broken by a previous error. */
 	EnterCriticalSection(&stream->lock);
 	const BOOL hadError = stream->deviceError;
@@ -514,6 +547,10 @@ static BOOL cam_android_open_device(CamAndroidHal* hal, CamAndroidStream* stream
 static BOOL cam_android_activate(ICamHal* ihal, const char* deviceId, CAM_ERROR_CODE* errorCode)
 {
 	CamAndroidHal* hal = (CamAndroidHal*)ihal;
+	WINPR_ASSERT(hal);
+	WINPR_ASSERT(deviceId);
+	WINPR_ASSERT(errorCode);
+
 	*errorCode = CAM_ERROR_CODE_None;
 
 	const char* cameraId = cam_android_extract_camera_id(deviceId);
@@ -530,6 +567,10 @@ static BOOL cam_android_activate(ICamHal* ihal, const char* deviceId, CAM_ERROR_
 static BOOL cam_android_deactivate(ICamHal* ihal, const char* deviceId, CAM_ERROR_CODE* errorCode)
 {
 	CamAndroidHal* hal = (CamAndroidHal*)ihal;
+	WINPR_ASSERT(hal);
+	WINPR_ASSERT(deviceId);
+	WINPR_ASSERT(errorCode);
+
 	*errorCode = CAM_ERROR_CODE_None;
 
 	CamAndroidStream* stream = (CamAndroidStream*)HashTable_GetItemValue(hal->streams, deviceId);
@@ -549,6 +590,12 @@ static INT16 cam_android_get_media_type_descriptions(ICamHal* ihal, const char* 
 {
 	WINPR_UNUSED(streamIndex);
 	CamAndroidHal* hal = (CamAndroidHal*)ihal;
+	WINPR_ASSERT(hal);
+	WINPR_ASSERT(deviceId);
+	WINPR_ASSERT(supportedFormats || (nSupportedFormats == 0));
+	WINPR_ASSERT(mediaTypes);
+	WINPR_ASSERT(nMediaTypes);
+
 	size_t maxMediaTypes = *nMediaTypes;
 	*nMediaTypes = 0;
 
@@ -633,6 +680,11 @@ static CAM_ERROR_CODE cam_android_start_stream(ICamHal* ihal, CameraDevice* dev,
                                                ICamHalSampleCapturedCallback callback)
 {
 	CamAndroidHal* hal = (CamAndroidHal*)ihal;
+	WINPR_ASSERT(hal);
+	WINPR_ASSERT(dev);
+	WINPR_ASSERT(mediaType);
+	WINPR_ASSERT(callback);
+
 	const char* deviceId = dev->deviceId;
 
 	const char* cameraId = cam_android_extract_camera_id(deviceId);
@@ -718,6 +770,8 @@ static CAM_ERROR_CODE cam_android_stop_stream(ICamHal* ihal, const char* deviceI
 {
 	WINPR_UNUSED(streamIndex);
 	CamAndroidHal* hal = (CamAndroidHal*)ihal;
+	WINPR_ASSERT(hal);
+	WINPR_ASSERT(deviceId);
 
 	CamAndroidStream* stream = (CamAndroidStream*)HashTable_GetItemValue(hal->streams, deviceId);
 	if (!stream)

--- a/channels/rdpecam/client/android/camera_android.c
+++ b/channels/rdpecam/client/android/camera_android.c
@@ -1,0 +1,803 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * MS-RDPECAM Implementation, Android NDK Camera2 HAL
+ *
+ * Copyright 2026 Ibrahim Sevinc <ibrahim.sevinc.mail@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <camera/NdkCameraDevice.h>
+#include <camera/NdkCameraManager.h>
+#include <camera/NdkCameraMetadata.h>
+#include <camera/NdkCameraCaptureSession.h>
+#include <media/NdkImage.h>
+#include <media/NdkImageReader.h>
+
+#include "../camera.h"
+
+#define TAG CHANNELS_TAG("rdpecam-android.client")
+
+#define ANDROID_CAMERA_PREFIX "android-camera-"
+#define ANDROID_CAMERA_PREFIX_LEN (sizeof(ANDROID_CAMERA_PREFIX) - 1)
+
+#define CAM_ANDROID_FPS 30
+
+typedef struct
+{
+	ICamHal iHal;
+	ACameraManager* manager;
+	wHashTable* streams; /* key: deviceId, value: CamAndroidStream */
+} CamAndroidHal;
+
+typedef struct
+{
+	size_t streamIndex;
+
+	ACameraDevice* device;
+	ACameraCaptureSession* session;
+	ACaptureSessionOutputContainer* outputContainer;
+	ACaptureSessionOutput* sessionOutput;
+	ACameraOutputTarget* outputTarget;
+	ACaptureRequest* captureRequest;
+	AImageReader* imageReader;
+	ANativeWindow* window;
+
+	ICamHalSampleCapturedCallback sampleCallback;
+	CameraDevice* dev;
+	BOOL streaming;
+	BOOL deviceError;
+	CRITICAL_SECTION lock;
+
+	BYTE* nv12Buffer;
+	size_t nv12BufferSize;
+} CamAndroidStream;
+
+static const char* cam_android_extract_camera_id(const char* deviceId)
+{
+	if (strncmp(deviceId, ANDROID_CAMERA_PREFIX, ANDROID_CAMERA_PREFIX_LEN) != 0)
+		return NULL;
+	return deviceId + ANDROID_CAMERA_PREFIX_LEN;
+}
+
+/* Tear down the capture session and its request objects. The ImageReader and device are kept. */
+static void cam_android_close_session(CamAndroidStream* stream)
+{
+	if (stream->session)
+	{
+		ACameraCaptureSession_stopRepeating(stream->session);
+		ACameraCaptureSession_close(stream->session);
+		stream->session = NULL;
+	}
+	if (stream->captureRequest)
+	{
+		if (stream->outputTarget)
+			ACaptureRequest_removeTarget(stream->captureRequest, stream->outputTarget);
+		ACaptureRequest_free(stream->captureRequest);
+		stream->captureRequest = NULL;
+	}
+	if (stream->outputTarget)
+	{
+		ACameraOutputTarget_free(stream->outputTarget);
+		stream->outputTarget = NULL;
+	}
+	if (stream->outputContainer)
+	{
+		ACaptureSessionOutputContainer_free(stream->outputContainer);
+		stream->outputContainer = NULL;
+	}
+	if (stream->sessionOutput)
+	{
+		ACaptureSessionOutput_free(stream->sessionOutput);
+		stream->sessionOutput = NULL;
+	}
+}
+
+/* Pack a YUV_420_888 frame into NV12 (handles NV12, NV21 and planar I420 layouts). */
+static void cam_android_yuv420_888_to_nv12(BYTE* dst, int width, int height, const uint8_t* yData,
+                                           int yRowStride, const uint8_t* uData, int uRowStride,
+                                           int uPixelStride, const uint8_t* vData, int vRowStride,
+                                           int vPixelStride)
+{
+	const size_t ySize = (size_t)width * height;
+
+	/* Y plane */
+	if (yRowStride == width)
+		memcpy(dst, yData, ySize);
+	else
+	{
+		for (int row = 0; row < height; row++)
+			memcpy(dst + (size_t)row * width, yData + (size_t)row * yRowStride, (size_t)width);
+	}
+
+	/* UV planes -> interleaved NV12 */
+	BYTE* uv = dst + ySize;
+	const int uvHeight = height / 2;
+	const int uvWidth = width / 2;
+	const size_t uvRowBytes = (size_t)(uvWidth * 2);
+
+	if (uPixelStride == 2 && vPixelStride == 2)
+	{
+		/* Semi-planar: NV12 (U first) or NV21 (V first). */
+		if (uData < vData)
+		{
+			/* NV12: copy the UV block directly. */
+			if (uRowStride == (int)uvRowBytes)
+				memcpy(uv, uData, (size_t)uvHeight * uvRowBytes);
+			else
+			{
+				for (int row = 0; row < uvHeight; row++)
+					memcpy(uv + (size_t)row * uvRowBytes, uData + (size_t)row * uRowStride,
+					       uvRowBytes);
+			}
+		}
+		else
+		{
+			/* NV21: swap U and V bytes. */
+			for (int row = 0; row < uvHeight; row++)
+			{
+				const uint8_t* u = uData + (size_t)row * uRowStride;
+				const uint8_t* v = vData + (size_t)row * vRowStride;
+				BYTE* d = uv + (size_t)row * uvRowBytes;
+				for (int col = 0; col < uvWidth; col++, u += 2, v += 2, d += 2)
+				{
+					d[0] = u[0];
+					d[1] = v[0];
+				}
+			}
+		}
+	}
+	else
+	{
+		/* Planar I420: interleave U and V. */
+		for (int row = 0; row < uvHeight; row++)
+		{
+			const uint8_t* uRow = uData + (size_t)row * uRowStride;
+			const uint8_t* vRow = vData + (size_t)row * vRowStride;
+			BYTE* dstRow = uv + (size_t)row * uvRowBytes;
+			for (int col = 0; col < uvWidth; col++)
+			{
+				dstRow[col * 2] = uRow[col * uPixelStride];
+				dstRow[col * 2 + 1] = vRow[col * vPixelStride];
+			}
+		}
+	}
+}
+
+static void cam_android_deliver_frame(CamAndroidStream* stream, AImage* image)
+{
+	int32_t width = 0;
+	int32_t height = 0;
+	if (AImage_getWidth(image, &width) != AMEDIA_OK ||
+	    AImage_getHeight(image, &height) != AMEDIA_OK)
+		return;
+
+	const size_t ySize = (size_t)(width * height);
+	const size_t nv12Size = ySize + ySize / 2;
+
+	if (stream->nv12BufferSize < nv12Size)
+	{
+		BYTE* tmp = (BYTE*)realloc(stream->nv12Buffer, nv12Size);
+		if (!tmp)
+			return;
+		stream->nv12Buffer = tmp;
+		stream->nv12BufferSize = nv12Size;
+	}
+
+	/* Fetch the planes; the length out-param is required but unused. */
+	int dataLength = 0;
+	uint8_t* yData = NULL;
+	uint8_t* uData = NULL;
+	uint8_t* vData = NULL;
+	if (AImage_getPlaneData(image, 0, &yData, &dataLength) != AMEDIA_OK ||
+	    AImage_getPlaneData(image, 1, &uData, &dataLength) != AMEDIA_OK ||
+	    AImage_getPlaneData(image, 2, &vData, &dataLength) != AMEDIA_OK)
+		return;
+
+	int yRowStride = 0;
+	int uRowStride = 0;
+	int uPixelStride = 0;
+	int vRowStride = 0;
+	int vPixelStride = 0;
+	AImage_getPlaneRowStride(image, 0, &yRowStride);
+	AImage_getPlaneRowStride(image, 1, &uRowStride);
+	AImage_getPlanePixelStride(image, 1, &uPixelStride);
+	AImage_getPlaneRowStride(image, 2, &vRowStride);
+	AImage_getPlanePixelStride(image, 2, &vPixelStride);
+
+	cam_android_yuv420_888_to_nv12(stream->nv12Buffer, width, height, yData, yRowStride, uData,
+	                               uRowStride, uPixelStride, vData, vRowStride, vPixelStride);
+
+	stream->sampleCallback(stream->dev, stream->streamIndex, stream->nv12Buffer, nv12Size);
+}
+
+static void cam_android_on_image_available(void* context, AImageReader* reader)
+{
+	CamAndroidStream* stream = (CamAndroidStream*)context;
+
+	EnterCriticalSection(&stream->lock);
+	const BOOL streaming = stream->streaming;
+	LeaveCriticalSection(&stream->lock);
+
+	if (!streaming)
+		return;
+
+	AImage* image = NULL;
+	if (AImageReader_acquireLatestImage(reader, &image) == AMEDIA_OK && image)
+	{
+		cam_android_deliver_frame(stream, image);
+		AImage_delete(image);
+	}
+}
+
+/* Mark the device broken so it is reopened on next use. */
+static void cam_android_mark_device_error(CamAndroidStream* stream)
+{
+	if (!stream)
+		return;
+	EnterCriticalSection(&stream->lock);
+	stream->deviceError = TRUE;
+	stream->streaming = FALSE;
+	LeaveCriticalSection(&stream->lock);
+}
+
+static void cam_android_device_disconnected(void* context, ACameraDevice* device)
+{
+	WINPR_UNUSED(device);
+	WLog_WARN(TAG, "Camera device disconnected");
+	cam_android_mark_device_error((CamAndroidStream*)context);
+}
+
+static void cam_android_device_error(void* context, ACameraDevice* device, int error)
+{
+	WINPR_UNUSED(device);
+	WLog_ERR(TAG, "Camera device error %d", error);
+	cam_android_mark_device_error((CamAndroidStream*)context);
+}
+
+static void cam_android_session_active(void* context, ACameraCaptureSession* session)
+{
+	WINPR_UNUSED(context);
+	WINPR_UNUSED(session);
+	WLog_DBG(TAG, "Capture session active");
+}
+
+static void cam_android_session_closed(void* context, ACameraCaptureSession* session)
+{
+	WINPR_UNUSED(context);
+	WINPR_UNUSED(session);
+	WLog_DBG(TAG, "Capture session closed");
+}
+
+static void cam_android_session_ready(void* context, ACameraCaptureSession* session)
+{
+	WINPR_UNUSED(context);
+	WINPR_UNUSED(session);
+	WLog_DBG(TAG, "Capture session ready");
+}
+
+/* TRUE if the camera is BACKWARD_COMPATIBLE. Depth/IR/sub-sensor cameras lack this and cannot
+ * configure a normal YUV session, so they must not be offered to the server. */
+static BOOL cam_android_is_backward_compatible(ACameraMetadata* characteristics)
+{
+	ACameraMetadata_const_entry caps;
+	if (ACameraMetadata_getConstEntry(characteristics, ACAMERA_REQUEST_AVAILABLE_CAPABILITIES,
+	                                  &caps) != ACAMERA_OK)
+		return FALSE;
+
+	for (uint32_t i = 0; i < caps.count; i++)
+	{
+		if (caps.data.u8[i] == ACAMERA_REQUEST_AVAILABLE_CAPABILITIES_BACKWARD_COMPATIBLE)
+			return TRUE;
+	}
+	return FALSE;
+}
+
+static UINT cam_android_enumerate(ICamHal* ihal, ICamHalEnumCallback callback, CameraPlugin* ecam,
+                                  GENERIC_CHANNEL_CALLBACK* hchannel)
+{
+	CamAndroidHal* hal = (CamAndroidHal*)ihal;
+	UINT count = 0;
+
+	/* NV12 capture needs FFmpeg/swscale to be encoded; without it, offer no cameras. */
+	if (!freerdp_video_conversion_supported(FREERDP_VIDEO_FORMAT_NV12,
+	                                        FREERDP_VIDEO_FORMAT_YUV420P))
+	{
+		WLog_WARN(TAG, "Camera redirection unavailable: video conversion (FFmpeg/swscale) missing");
+		return 0;
+	}
+
+	ACameraIdList* idList = NULL;
+	if (ACameraManager_getCameraIdList(hal->manager, &idList) != ACAMERA_OK || !idList)
+		return 0;
+
+	/* Offer only the primary camera per facing direction: auxiliary back cameras (ultrawide/tele/
+	 * macro/depth) advertise resolutions but fail to configure a YUV session and freeze the
+	 * channel. Indexed by ACAMERA_LENS_FACING_* (FRONT=0, BACK=1, EXTERNAL=2). */
+	BOOL seenFacing[ACAMERA_LENS_FACING_EXTERNAL + 1] = { 0 };
+
+	for (int i = 0; i < idList->numCameras; i++)
+	{
+		const char* cameraId = idList->cameraIds[i];
+
+		ACameraMetadata* characteristics = NULL;
+		if (ACameraManager_getCameraCharacteristics(hal->manager, cameraId, &characteristics) !=
+		    ACAMERA_OK)
+			continue;
+
+		/* Skip depth/IR/sub-sensor cameras that can't configure a normal capture session. */
+		if (!cam_android_is_backward_compatible(characteristics))
+		{
+			WLog_DBG(TAG, "Skipping camera %s: not BACKWARD_COMPATIBLE", cameraId);
+			ACameraMetadata_free(characteristics);
+			continue;
+		}
+
+		ACameraMetadata_const_entry facingEntry;
+		const char* facingName = "Camera";
+		uint8_t facing = ACAMERA_LENS_FACING_EXTERNAL;
+		if (ACameraMetadata_getConstEntry(characteristics, ACAMERA_LENS_FACING, &facingEntry) ==
+		    ACAMERA_OK)
+		{
+			facing = facingEntry.data.u8[0];
+			switch (facing)
+			{
+				case ACAMERA_LENS_FACING_FRONT:
+					facingName = "Front Camera";
+					break;
+				case ACAMERA_LENS_FACING_BACK:
+					facingName = "Back Camera";
+					break;
+				default:
+					facingName = "External Camera";
+					break;
+			}
+		}
+
+		/* Bounds-guard seenFacing[] against an out-of-range facing value. */
+		if (facing <= ACAMERA_LENS_FACING_EXTERNAL)
+		{
+			if (seenFacing[facing])
+			{
+				WLog_DBG(TAG, "Skipping camera %s: already have a %s", cameraId, facingName);
+				ACameraMetadata_free(characteristics);
+				continue;
+			}
+			seenFacing[facing] = TRUE;
+		}
+
+		char deviceId[64];
+		(void)_snprintf(deviceId, sizeof(deviceId), ANDROID_CAMERA_PREFIX "%s", cameraId);
+
+		IFCALL(callback, ecam, hchannel, deviceId, facingName);
+		count++;
+
+		ACameraMetadata_free(characteristics);
+	}
+
+	ACameraManager_deleteCameraIdList(idList);
+	return count;
+}
+
+/* Stop streaming and fully release the camera. Order matters: close the session and device before
+ * the ImageReader, or the camera service fails to unconfigure and leaves the device running. */
+static void cam_android_close_device(CamAndroidStream* stream)
+{
+	EnterCriticalSection(&stream->lock);
+	stream->streaming = FALSE;
+	LeaveCriticalSection(&stream->lock);
+
+	if (stream->imageReader)
+		AImageReader_setImageListener(stream->imageReader, NULL);
+
+	cam_android_close_session(stream);
+
+	if (stream->device)
+	{
+		ACameraDevice_close(stream->device);
+		stream->device = NULL;
+	}
+
+	if (stream->imageReader)
+	{
+		AImageReader_delete(stream->imageReader);
+		stream->imageReader = NULL;
+		stream->window = NULL;
+	}
+	free(stream->nv12Buffer);
+	stream->nv12Buffer = NULL;
+	stream->nv12BufferSize = 0;
+	stream->deviceError = FALSE;
+}
+
+/* Close every open camera except keepDeviceId. Phones share camera hardware, so holding more than
+ * one open makes the next openCamera fail with CAMERA_DISCONNECTED and freeze the channel. */
+static void cam_android_close_other_devices(CamAndroidHal* hal, const char* keepDeviceId)
+{
+	ULONG_PTR* keys = NULL;
+	const size_t count = HashTable_GetKeys(hal->streams, &keys);
+	for (size_t i = 0; i < count; i++)
+	{
+		const char* id = (const char*)keys[i];
+		if (strcmp(id, keepDeviceId) == 0)
+			continue;
+
+		CamAndroidStream* other = (CamAndroidStream*)HashTable_GetItemValue(hal->streams, id);
+		if (!other || !other->device)
+			continue;
+
+		WLog_DBG(TAG, "Closing camera %s to free resources for %s", id, keepDeviceId);
+		cam_android_close_device(other);
+	}
+	free(keys);
+}
+
+static CamAndroidStream* cam_android_get_or_create_stream(CamAndroidHal* hal, const char* deviceId,
+                                                          CAM_ERROR_CODE* errorCode)
+{
+	CamAndroidStream* stream = (CamAndroidStream*)HashTable_GetItemValue(hal->streams, deviceId);
+	if (stream)
+		return stream;
+
+	stream = (CamAndroidStream*)calloc(1, sizeof(CamAndroidStream));
+	if (!stream)
+	{
+		*errorCode = CAM_ERROR_CODE_OutOfMemory;
+		return NULL;
+	}
+	if (!InitializeCriticalSectionEx(&stream->lock, 0, 0))
+	{
+		free(stream);
+		*errorCode = CAM_ERROR_CODE_UnexpectedError;
+		return NULL;
+	}
+	if (!HashTable_Insert(hal->streams, deviceId, stream))
+	{
+		DeleteCriticalSection(&stream->lock);
+		free(stream);
+		*errorCode = CAM_ERROR_CODE_UnexpectedError;
+		return NULL;
+	}
+	return stream;
+}
+
+/* Open the camera, closing any other open one first (phones keep only one open). Deferred from
+ * Activate to StartStream so media-type probing doesn't thrash the hardware. */
+static BOOL cam_android_open_device(CamAndroidHal* hal, CamAndroidStream* stream,
+                                    const char* deviceId, const char* cameraId,
+                                    CAM_ERROR_CODE* errorCode)
+{
+	/* Reopen a device left broken by a previous error. */
+	EnterCriticalSection(&stream->lock);
+	const BOOL hadError = stream->deviceError;
+	LeaveCriticalSection(&stream->lock);
+	if (stream->device && hadError)
+		cam_android_close_device(stream);
+
+	if (stream->device)
+		return TRUE; /* already open */
+
+	cam_android_close_other_devices(hal, deviceId);
+
+	ACameraDevice_StateCallbacks deviceCallbacks = {
+		.context = stream,
+		.onDisconnected = cam_android_device_disconnected,
+		.onError = cam_android_device_error,
+	};
+
+	camera_status_t status =
+	    ACameraManager_openCamera(hal->manager, cameraId, &deviceCallbacks, &stream->device);
+	if (status != ACAMERA_OK)
+	{
+		WLog_ERR(TAG, "ACameraManager_openCamera failed: %d", status);
+		*errorCode = CAM_ERROR_CODE_InvalidRequest;
+		return FALSE;
+	}
+
+	WLog_DBG(TAG, "Opened camera %s", cameraId);
+	return TRUE;
+}
+
+static BOOL cam_android_activate(ICamHal* ihal, const char* deviceId, CAM_ERROR_CODE* errorCode)
+{
+	CamAndroidHal* hal = (CamAndroidHal*)ihal;
+	*errorCode = CAM_ERROR_CODE_None;
+
+	const char* cameraId = cam_android_extract_camera_id(deviceId);
+	if (!cameraId)
+	{
+		*errorCode = CAM_ERROR_CODE_InvalidRequest;
+		return FALSE;
+	}
+
+	/* Hardware is opened lazily in StartStream, not here. */
+	return cam_android_get_or_create_stream(hal, deviceId, errorCode) != NULL;
+}
+
+static BOOL cam_android_deactivate(ICamHal* ihal, const char* deviceId, CAM_ERROR_CODE* errorCode)
+{
+	CamAndroidHal* hal = (CamAndroidHal*)ihal;
+	*errorCode = CAM_ERROR_CODE_None;
+
+	CamAndroidStream* stream = (CamAndroidStream*)HashTable_GetItemValue(hal->streams, deviceId);
+	if (!stream || !stream->device)
+		return TRUE;
+
+	cam_android_close_device(stream);
+	return TRUE;
+}
+
+static INT16 cam_android_get_media_type_descriptions(ICamHal* ihal, const char* deviceId,
+                                                     size_t streamIndex,
+                                                     const CAM_MEDIA_FORMAT_INFO* supportedFormats,
+                                                     size_t nSupportedFormats,
+                                                     CAM_MEDIA_TYPE_DESCRIPTION* mediaTypes,
+                                                     size_t* nMediaTypes)
+{
+	WINPR_UNUSED(streamIndex);
+	CamAndroidHal* hal = (CamAndroidHal*)ihal;
+	size_t maxMediaTypes = *nMediaTypes;
+	*nMediaTypes = 0;
+
+	const char* cameraId = cam_android_extract_camera_id(deviceId);
+	if (!cameraId)
+		return -1;
+
+	/* Find the NV12 format index. */
+	INT16 formatIndex = -1;
+	for (size_t i = 0; i < nSupportedFormats; i++)
+	{
+		if (supportedFormats[i].inputFormat == CAM_MEDIA_FORMAT_NV12)
+		{
+			formatIndex = (INT16)i;
+			break;
+		}
+	}
+	if (formatIndex < 0)
+	{
+		WLog_WARN(TAG, "Server does not offer NV12 format");
+		return -1;
+	}
+
+	ACameraMetadata* characteristics = NULL;
+	if (ACameraManager_getCameraCharacteristics(hal->manager, cameraId, &characteristics) !=
+	    ACAMERA_OK)
+		return -1;
+
+	/* Stream configs: [format, width, height, isInput] tuples. */
+	ACameraMetadata_const_entry entry;
+	if (ACameraMetadata_getConstEntry(
+	        characteristics, ACAMERA_SCALER_AVAILABLE_STREAM_CONFIGURATIONS, &entry) != ACAMERA_OK)
+	{
+		ACameraMetadata_free(characteristics);
+		return -1;
+	}
+
+	size_t nTypes = 0;
+	for (uint32_t i = 0; i + 3 < entry.count; i += 4)
+	{
+		const int32_t fmt = entry.data.i32[i];
+		const int32_t w = entry.data.i32[i + 1];
+		const int32_t h = entry.data.i32[i + 2];
+		const int32_t isInput = entry.data.i32[i + 3];
+
+		if (isInput != 0)
+			continue;
+		if (fmt != AIMAGE_FORMAT_YUV_420_888)
+			continue;
+		/* Skip resolutions larger than 1080p to avoid saturating the RDP link */
+		if (w > 1920 || h > 1080)
+			continue;
+
+		mediaTypes[nTypes].Format = CAM_MEDIA_FORMAT_NV12;
+		mediaTypes[nTypes].Width = (UINT32)w;
+		mediaTypes[nTypes].Height = (UINT32)h;
+		mediaTypes[nTypes].FrameRateNumerator = CAM_ANDROID_FPS;
+		mediaTypes[nTypes].FrameRateDenominator = 1;
+		mediaTypes[nTypes].PixelAspectRatioNumerator = 1;
+		mediaTypes[nTypes].PixelAspectRatioDenominator = 1;
+
+		WLog_DBG(TAG, "Camera format NV12 %dx%d @ %dfps", w, h, CAM_ANDROID_FPS);
+
+		if (++nTypes >= maxMediaTypes)
+			break;
+	}
+
+	*nMediaTypes = nTypes;
+	ACameraMetadata_free(characteristics);
+
+	if (nTypes == 0)
+	{
+		WLog_ERR(TAG, "No supported YUV resolutions found for camera %s", cameraId);
+		return -1;
+	}
+
+	return formatIndex;
+}
+
+static CAM_ERROR_CODE cam_android_start_stream(ICamHal* ihal, CameraDevice* dev, size_t streamIndex,
+                                               const CAM_MEDIA_TYPE_DESCRIPTION* mediaType,
+                                               ICamHalSampleCapturedCallback callback)
+{
+	CamAndroidHal* hal = (CamAndroidHal*)ihal;
+	const char* deviceId = dev->deviceId;
+
+	const char* cameraId = cam_android_extract_camera_id(deviceId);
+	if (!cameraId)
+		return CAM_ERROR_CODE_InvalidRequest;
+
+	CAM_ERROR_CODE errorCode = CAM_ERROR_CODE_None;
+	CamAndroidStream* stream = cam_android_get_or_create_stream(hal, deviceId, &errorCode);
+	if (!stream)
+		return errorCode;
+
+	if (!cam_android_open_device(hal, stream, deviceId, cameraId, &errorCode))
+		return errorCode;
+
+	stream->dev = dev;
+	stream->streamIndex = streamIndex;
+	stream->sampleCallback = callback;
+
+	const int32_t width = (int32_t)mediaType->Width;
+	const int32_t height = (int32_t)mediaType->Height;
+
+	if (AImageReader_new(width, height, AIMAGE_FORMAT_YUV_420_888, 4, &stream->imageReader) !=
+	    AMEDIA_OK)
+	{
+		WLog_ERR(TAG, "AImageReader_new failed");
+		return CAM_ERROR_CODE_UnexpectedError;
+	}
+
+	AImageReader_ImageListener listener = {
+		.context = stream,
+		.onImageAvailable = cam_android_on_image_available,
+	};
+	AImageReader_setImageListener(stream->imageReader, &listener);
+
+	if (AImageReader_getWindow(stream->imageReader, &stream->window) != AMEDIA_OK)
+	{
+		WLog_ERR(TAG, "AImageReader_getWindow failed");
+		goto error;
+	}
+
+	ACaptureSessionOutput_create(stream->window, &stream->sessionOutput);
+	ACaptureSessionOutputContainer_create(&stream->outputContainer);
+	ACaptureSessionOutputContainer_add(stream->outputContainer, stream->sessionOutput);
+	ACameraOutputTarget_create(stream->window, &stream->outputTarget);
+	ACameraDevice_createCaptureRequest(stream->device, TEMPLATE_RECORD, &stream->captureRequest);
+	ACaptureRequest_addTarget(stream->captureRequest, stream->outputTarget);
+
+	ACameraCaptureSession_stateCallbacks sessionCallbacks = {
+		.context = stream,
+		.onActive = cam_android_session_active,
+		.onClosed = cam_android_session_closed,
+		.onReady = cam_android_session_ready,
+	};
+
+	if (ACameraDevice_createCaptureSession(stream->device, stream->outputContainer,
+	                                       &sessionCallbacks, &stream->session) != ACAMERA_OK)
+	{
+		WLog_ERR(TAG, "ACameraDevice_createCaptureSession failed");
+		goto error;
+	}
+
+	if (ACameraCaptureSession_setRepeatingRequest(stream->session, NULL, 1, &stream->captureRequest,
+	                                              NULL) != ACAMERA_OK)
+	{
+		WLog_ERR(TAG, "ACameraCaptureSession_setRepeatingRequest failed");
+		goto error;
+	}
+
+	EnterCriticalSection(&stream->lock);
+	stream->streaming = TRUE;
+	LeaveCriticalSection(&stream->lock);
+
+	WLog_DBG(TAG, "Camera stream started: %dx%d", width, height);
+	return CAM_ERROR_CODE_None;
+
+error:
+	cam_android_close_device(stream);
+	return CAM_ERROR_CODE_UnexpectedError;
+}
+
+static CAM_ERROR_CODE cam_android_stop_stream(ICamHal* ihal, const char* deviceId,
+                                              size_t streamIndex)
+{
+	WINPR_UNUSED(streamIndex);
+	CamAndroidHal* hal = (CamAndroidHal*)ihal;
+
+	CamAndroidStream* stream = (CamAndroidStream*)HashTable_GetItemValue(hal->streams, deviceId);
+	if (!stream)
+		return CAM_ERROR_CODE_None;
+
+	cam_android_close_device(stream);
+
+	WLog_DBG(TAG, "Camera stream stopped for %s", deviceId);
+	return CAM_ERROR_CODE_None;
+}
+
+static void cam_android_stream_free(void* obj)
+{
+	CamAndroidStream* stream = (CamAndroidStream*)obj;
+	if (!stream)
+		return;
+
+	cam_android_close_device(stream);
+	DeleteCriticalSection(&stream->lock);
+	free(stream);
+}
+
+static CAM_ERROR_CODE cam_android_free(ICamHal* ihal)
+{
+	CamAndroidHal* hal = (CamAndroidHal*)ihal;
+	if (!hal)
+		return CAM_ERROR_CODE_NotInitialized;
+
+	HashTable_Free(hal->streams);
+	if (hal->manager)
+		ACameraManager_delete(hal->manager);
+	free(hal);
+	return CAM_ERROR_CODE_None;
+}
+
+FREERDP_ENTRY_POINT(UINT VCAPITYPE android_freerdp_rdpecam_client_subsystem_entry(
+    PFREERDP_CAMERA_HAL_ENTRY_POINTS pEntryPoints))
+{
+	WINPR_ASSERT(pEntryPoints);
+
+	CamAndroidHal* hal = (CamAndroidHal*)calloc(1, sizeof(CamAndroidHal));
+	if (!hal)
+		return CHANNEL_RC_NO_MEMORY;
+
+	hal->manager = ACameraManager_create();
+	if (!hal->manager)
+	{
+		free(hal);
+		return ERROR_INTERNAL_ERROR;
+	}
+
+	hal->streams = HashTable_New(FALSE);
+	if (!hal->streams)
+		goto error;
+
+	if (!HashTable_SetupForStringData(hal->streams, FALSE))
+		goto error;
+
+	wObject* obj = HashTable_ValueObject(hal->streams);
+	WINPR_ASSERT(obj);
+	obj->fnObjectFree = cam_android_stream_free;
+
+	hal->iHal.Enumerate = cam_android_enumerate;
+	hal->iHal.Activate = cam_android_activate;
+	hal->iHal.Deactivate = cam_android_deactivate;
+	hal->iHal.GetMediaTypeDescriptions = cam_android_get_media_type_descriptions;
+	hal->iHal.StartStream = cam_android_start_stream;
+	hal->iHal.StopStream = cam_android_stop_stream;
+	hal->iHal.Free = cam_android_free;
+
+	UINT ret = pEntryPoints->pRegisterCameraHal(pEntryPoints->plugin, &hal->iHal);
+	if (ret != CHANNEL_RC_OK)
+	{
+		WLog_ERR(TAG, "RegisterCameraHal failed: %" PRIu32, ret);
+		goto error;
+	}
+
+	return ret;
+
+error:
+	cam_android_free(&hal->iHal);
+	return ERROR_INTERNAL_ERROR;
+}

--- a/channels/rdpecam/client/camera_device_enum_main.c
+++ b/channels/rdpecam/client/camera_device_enum_main.c
@@ -545,9 +545,11 @@ FREERDP_ENTRY_POINT(UINT VCAPITYPE rdpecam_DVCPluginEntry(IDRDYNVC_ENTRY_POINTS*
 	ecam->iface.Attached = ecam_plugin_attached;
 	ecam->iface.Detached = ecam_plugin_detached;
 
-	/* TODO: camera redirect only supported for platforms with Video4Linux */
+	/* TODO: camera redirect only supported for platforms with Video4Linux or Android */
 #if defined(WITH_V4L)
 	ecam->subsystem = "v4l";
+#elif defined(__ANDROID__)
+	ecam->subsystem = "android";
 #else
 	ecam->subsystem = nullptr;
 #endif

--- a/client/Android/Studio/freeRDPCore/src/main/AndroidManifest.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
@@ -33,6 +33,7 @@
 #include <freerdp/client/rdpgfx.h>
 #include <freerdp/client/cliprdr.h>
 #include <freerdp/codec/h264.h>
+#include <freerdp/codec/video.h>
 #include <freerdp/channels/channels.h>
 #include <freerdp/client/channels.h>
 #include <freerdp/client/cmdline.h>
@@ -1200,6 +1201,16 @@ Java_com_freerdp_freerdpcore_services_LibFreeRDP_freerdp_1has_1h264(JNIEnv* env,
 		return JNI_FALSE;
 	h264_context_free(ctx);
 	return JNI_TRUE;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_freerdp_freerdpcore_services_LibFreeRDP_freerdp_1has_1camera_1redirection(JNIEnv* env,
+                                                                                   jclass cls)
+{
+	return freerdp_video_conversion_supported(FREERDP_VIDEO_FORMAT_NV12,
+	                                          FREERDP_VIDEO_FORMAT_YUV420P)
+	           ? JNI_TRUE
+	           : JNI_FALSE;
 }
 
 JNIEXPORT jstring JNICALL

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
@@ -425,6 +425,7 @@ static BOOL android_register_pointer(rdpGraphics* graphics)
 
 /* Keep in sync with LibFreeRDP.EXPERIMENTAL_*. */
 #define ANDROID_EXPERIMENTAL_REMOTEAPP 0
+#define ANDROID_EXPERIMENTAL_CAMERA 1
 
 static BOOL android_post_connect(freerdp* instance)
 {
@@ -443,6 +444,11 @@ static BOOL android_post_connect(freerdp* instance)
 	if (freerdp_settings_get_bool(settings, FreeRDP_RemoteApplicationMode) &&
 	    !freerdp_callback_bool_result("OnExperimentalFeature", "(JI)Z", (jlong)instance,
 	                                  ANDROID_EXPERIMENTAL_REMOTEAPP))
+		return FALSE;
+
+	if (freerdp_dynamic_channel_collection_find(settings, "rdpecam") &&
+	    !freerdp_callback_bool_result("OnExperimentalFeature", "(JI)Z", (jlong)instance,
+	                                  ANDROID_EXPERIMENTAL_CAMERA))
 		return FALSE;
 
 	if (!gdi_init(instance, PIXEL_FORMAT_RGBX32))

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/AppDatabase.java
@@ -33,7 +33,7 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory;
           exportSchema = false)
 public abstract class AppDatabase extends RoomDatabase
 {
-	static final int DB_VERSION = 17;
+	static final int DB_VERSION = 18;
 	private static final String DB_NAME = "bookmarks.db";
 
 	static
@@ -66,6 +66,7 @@ public abstract class AppDatabase extends RoomDatabase
 					               .addMigrations(MIGRATION_14_15)
 					               .addMigrations(MIGRATION_15_16)
 					               .addMigrations(MIGRATION_16_17)
+					               .addMigrations(MIGRATION_17_18)
 					               .build();
 				}
 			}
@@ -171,6 +172,14 @@ public abstract class AppDatabase extends RoomDatabase
 			sb.append(String.format(java.util.Locale.US, "%02x", b));
 		return sb.toString();
 	}
+
+	private static final Migration MIGRATION_17_18 = new Migration(17, 18) {
+		@Override public void migrate(@NonNull SupportSQLiteDatabase db)
+		{
+			db.execSQL(
+			    "ALTER TABLE 'bookmarks' ADD 'redirect_camera' INTEGER NOT NULL DEFAULT false;");
+		}
+	};
 
 	private static final Migration MIGRATION_16_17 = new Migration(16, 17) {
 		@Override public void migrate(@NonNull SupportSQLiteDatabase db)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkConverter.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkConverter.java
@@ -53,6 +53,7 @@ public final class BookmarkConverter
 		adv.setRedirectSDCard(e.redirectSdcard);
 		adv.setRedirectSound(e.redirectSound);
 		adv.setRedirectMicrophone(e.redirectMicrophone);
+		adv.setRedirectCamera(e.redirectCamera);
 		adv.setRedirectPrinter(e.redirectPrinter);
 		adv.setSecurity(e.security);
 		adv.setRemoteProgram(e.remoteProgram);
@@ -119,6 +120,7 @@ public final class BookmarkConverter
 		e.redirectSdcard = adv.getRedirectSDCard();
 		e.redirectSound = adv.getRedirectSound();
 		e.redirectMicrophone = adv.getRedirectMicrophone();
+		e.redirectCamera = adv.getRedirectCamera();
 		e.redirectPrinter = adv.getRedirectPrinter();
 		e.security = adv.getSecurity();
 		e.remoteProgram = adv.getRemoteProgram();

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkEntity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/data/BookmarkEntity.java
@@ -102,6 +102,9 @@ import androidx.room.PrimaryKey;
 	@ColumnInfo(name = "redirect_microphone", defaultValue = "false")
 	public boolean redirectMicrophone = false;
 
+	@ColumnInfo(name = "redirect_camera", defaultValue = "false")
+	public boolean redirectCamera = false;
+
 	@ColumnInfo(name = "redirect_printer", defaultValue = "false")
 	public boolean redirectPrinter = false;
 

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/domain/BookmarkBase.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/domain/BookmarkBase.java
@@ -50,6 +50,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 	private static final String keyRedirectSDCard = "bookmark.redirect_sdcard";
 	private static final String keySound = "bookmark.redirect_sound";
 	private static final String keyMicrophone = "bookmark.redirect_microphone";
+	private static final String keyCamera = "bookmark.redirect_camera";
 	private static final String keyPrinter = "bookmark.redirect_printer";
 	private static final String keySecurity = "bookmark.security";
 	private static final String keyRemoteApp = "bookmark.remote_program";
@@ -340,6 +341,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 		editor.putBoolean(keyRedirectSDCard, advancedSettings.getRedirectSDCard());
 		editor.putInt(keySound, advancedSettings.getRedirectSound());
 		editor.putBoolean(keyMicrophone, advancedSettings.getRedirectMicrophone());
+		editor.putBoolean(keyCamera, advancedSettings.getRedirectCamera());
 		editor.putBoolean(keyPrinter, advancedSettings.getRedirectPrinter());
 		editor.putInt(keySecurity, advancedSettings.getSecurity());
 		editor.putString(keyRemoteApp, advancedSettings.getRemoteProgram());
@@ -398,6 +400,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 		advancedSettings.setRedirectSDCard(sharedPrefs.getBoolean(keyRedirectSDCard, false));
 		advancedSettings.setRedirectSound(sharedPrefs.getInt(keySound, 0));
 		advancedSettings.setRedirectMicrophone(sharedPrefs.getBoolean(keyMicrophone, false));
+		advancedSettings.setRedirectCamera(sharedPrefs.getBoolean(keyCamera, false));
 		advancedSettings.setRedirectPrinter(sharedPrefs.getBoolean(keyPrinter, false));
 		advancedSettings.setSecurity(sharedPrefs.getInt(keySecurity, 0));
 		advancedSettings.setRemoteProgram(sharedPrefs.getString(keyRemoteApp, ""));
@@ -931,6 +934,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 		private boolean redirectSDCard = false;
 		private int redirectSound = 0;
 		private boolean redirectMicrophone = false;
+		private boolean redirectCamera = false;
 		private boolean redirectPrinter = false;
 		private int security = 0;
 		private boolean consoleMode = false;
@@ -955,6 +959,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 			redirectSDCard = parcel.readBoolean();
 			redirectSound = parcel.readInt();
 			redirectMicrophone = parcel.readBoolean();
+			redirectCamera = parcel.readBoolean();
 			redirectPrinter = parcel.readBoolean();
 			security = parcel.readInt();
 			consoleMode = parcel.readBoolean();
@@ -1063,6 +1068,16 @@ public class BookmarkBase implements Parcelable, Cloneable
 			this.redirectMicrophone = redirect;
 		}
 
+		public boolean getRedirectCamera()
+		{
+			return redirectCamera;
+		}
+
+		public void setRedirectCamera(boolean redirect)
+		{
+			this.redirectCamera = redirect;
+		}
+
 		public int getSecurity()
 		{
 			validate();
@@ -1145,6 +1160,7 @@ public class BookmarkBase implements Parcelable, Cloneable
 			out.writeBoolean(redirectSDCard);
 			out.writeInt(redirectSound);
 			out.writeBoolean(redirectMicrophone);
+			out.writeBoolean(redirectCamera);
 			out.writeBoolean(redirectPrinter);
 			out.writeInt(security);
 			out.writeBoolean(consoleMode);

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/BookmarkActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/BookmarkActivity.java
@@ -364,6 +364,9 @@ public class BookmarkActivity
 			getPreferenceManager().setSharedPreferencesMode(MODE_PRIVATE);
 			setPreferencesFromResource(R.xml.advanced_settings, rootKey);
 
+			if (!LibFreeRDP.hasCameraRedirectionSupport())
+				setEnabled("bookmark.redirect_camera", false);
+
 			SharedPreferences prefs = getPreferenceManager().getSharedPreferences();
 
 			// Apply initial enabled states based on saved checkbox values.

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -800,6 +800,10 @@ public class SessionActivity extends AppCompatActivity
 				featureKey = "remoteapp";
 				displayName = getString(R.string.experimental_feature_remoteapp);
 				break;
+			case LibFreeRDP.EXPERIMENTAL_CAMERA:
+				featureKey = "camera";
+				displayName = getString(R.string.experimental_feature_camera);
+				break;
 			default:
 				return true;
 		}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -526,15 +526,14 @@ public class SessionActivity extends AppCompatActivity
 			screenSettings.setWidth(screen_width);
 		}
 
-		// Collect dangerous permissions we still need before opening the session.
-		// RECORD_AUDIO: only if microphone redirect is enabled.
-		// CAMERA: always — camera redirect is server-initiated, no client-side toggle.
+		// RECORD_AUDIO / CAMERA: only if the matching redirect is enabled.
 		java.util.ArrayList<String> needed = new java.util.ArrayList<>();
 		if (bookmark.getAdvancedSettings().getRedirectMicrophone() &&
 		    checkSelfPermission(Manifest.permission.RECORD_AUDIO) !=
 		        PackageManager.PERMISSION_GRANTED)
 			needed.add(Manifest.permission.RECORD_AUDIO);
-		if (checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED)
+		if (bookmark.getAdvancedSettings().getRedirectCamera() &&
+		    checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED)
 			needed.add(Manifest.permission.CAMERA);
 
 		if (!needed.isEmpty())

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/presentation/SessionActivity.java
@@ -11,8 +11,10 @@
 
 package com.freerdp.freerdpcore.presentation;
 
+import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
@@ -72,6 +74,7 @@ public class SessionActivity extends AppCompatActivity
 	private static final int DISPLAY_TOAST = 2;
 	private static final int GRAPHICS_CHANGED = 6;
 	private static final int POINTER_SET = 7;
+	private static final int REQUEST_MEDIA_PERMISSIONS = 100;
 
 	private RailWindowManager railManager;
 
@@ -123,6 +126,7 @@ public class SessionActivity extends AppCompatActivity
 	private int screen_width;
 	private int screen_height;
 
+	private BookmarkBase pendingConnectBookmark = null;
 	private boolean connectCancelledByUser = false;
 	private boolean sessionRunning = false;
 	private long backPressedTime = 0;
@@ -522,7 +526,38 @@ public class SessionActivity extends AppCompatActivity
 			screenSettings.setWidth(screen_width);
 		}
 
+		// Collect dangerous permissions we still need before opening the session.
+		// RECORD_AUDIO: only if microphone redirect is enabled.
+		// CAMERA: always — camera redirect is server-initiated, no client-side toggle.
+		java.util.ArrayList<String> needed = new java.util.ArrayList<>();
+		if (bookmark.getAdvancedSettings().getRedirectMicrophone() &&
+		    checkSelfPermission(Manifest.permission.RECORD_AUDIO) !=
+		        PackageManager.PERMISSION_GRANTED)
+			needed.add(Manifest.permission.RECORD_AUDIO);
+		if (checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED)
+			needed.add(Manifest.permission.CAMERA);
+
+		if (!needed.isEmpty())
+		{
+			pendingConnectBookmark = bookmark;
+			requestPermissions(needed.toArray(new String[0]), REQUEST_MEDIA_PERMISSIONS);
+			return;
+		}
+
 		connectWithTitle(bookmark.getLabel());
+	}
+
+	@Override
+	public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+	                                       @NonNull int[] grantResults)
+	{
+		super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+		if (requestCode == REQUEST_MEDIA_PERMISSIONS && pendingConnectBookmark != null)
+		{
+			BookmarkBase bookmark = pendingConnectBookmark;
+			pendingConnectBookmark = null;
+			connectWithTitle(bookmark.getLabel());
+		}
 	}
 
 	private void connect(Uri openUri)

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -33,6 +33,7 @@ public class LibFreeRDP
 	private static final String TAG = "LibFreeRDP";
 	private static EventListener listener;
 	private static boolean mHasH264 = false;
+	private static boolean mHasCameraRedirection = false;
 
 	private static final LongSparseArray<Boolean> mInstanceState = new LongSparseArray<>();
 
@@ -110,8 +111,10 @@ public class LibFreeRDP
 			else
 				throw new RuntimeException("APK broken: native library version " + version +
 				                           " does not meet requirements!");
+			mHasCameraRedirection = freerdp_has_camera_redirection();
 			Log.i(TAG, "Successfully loaded native library. H264 is " +
-			               (mHasH264 ? "supported" : "not available"));
+			               (mHasH264 ? "supported" : "not available") + ", camera redirection is " +
+			               (mHasCameraRedirection ? "supported" : "not available"));
 		}
 		catch (UnsatisfiedLinkError e)
 		{
@@ -125,7 +128,14 @@ public class LibFreeRDP
 		return mHasH264;
 	}
 
+	public static boolean hasCameraRedirectionSupport()
+	{
+		return mHasCameraRedirection;
+	}
+
 	private static native boolean freerdp_has_h264();
+
+	private static native boolean freerdp_has_camera_redirection();
 
 	private static native String freerdp_get_jni_version();
 
@@ -459,7 +469,7 @@ public class LibFreeRDP
 			args.add("/microphone");
 		}
 
-		if (advanced.getRedirectCamera())
+		if (advanced.getRedirectCamera() && mHasCameraRedirection)
 		{
 			args.add("/dvc:rdpecam");
 		}

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -458,7 +458,10 @@ public class LibFreeRDP
 			args.add("/microphone");
 		}
 
-		args.add("/dvc:rdpecam");
+		if (advanced.getRedirectCamera())
+		{
+			args.add("/dvc:rdpecam");
+		}
 
 		args.add("/kbd:unicode:on");
 		args.add("/cert:ignore");

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -47,6 +47,7 @@ public class LibFreeRDP
 
 	// Keep in sync with android_freerdp.c.
 	public static final int EXPERIMENTAL_REMOTEAPP = 0;
+	public static final int EXPERIMENTAL_CAMERA = 1;
 
 	private static boolean tryLoad(String[] libraries)
 	{

--- a/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
+++ b/client/Android/Studio/freeRDPCore/src/main/java/com/freerdp/freerdpcore/services/LibFreeRDP.java
@@ -458,6 +458,8 @@ public class LibFreeRDP
 			args.add("/microphone");
 		}
 
+		args.add("/dvc:rdpecam");
+
 		args.add("/kbd:unicode:on");
 		args.add("/cert:ignore");
 		args.add("/log-level:" + debug.getDebugLevel());

--- a/client/Android/Studio/freeRDPCore/src/main/res/drawable/ic_experiment.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/drawable/ic_experiment.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M 5 21 Q 3.7 21 3.2 19.9 2.6 18.7 3.4 17.8 L 9 11 V 5 H 8 Q 7.6 5 7.3 4.7 7 4.4 7 4 7 3.6 7.3 3.3 7.6 3 8 3 h 8 Q 16.4 3 16.7 3.3 17 3.6 17 4 17 4.4 16.7 4.7 16.4 5 16 5 H 15 V 11 l 5.5 6.8 Q 21.4 18.7 20.8 19.9 20.3 21 19 21 Z M 5 19 H 19 L 13 11.7 V 5 H 11 V 11.7 Z m 7 -7 z"/>
+</vector>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -262,9 +262,13 @@
     <string name="settings_experimental_remoteapp">RemoteApp windows</string>
     <string name="settings_experimental_remoteapp_summary">Show remote programs as separate windows instead of a full desktop. Experimental, may be unstable.</string>
     <string name="experimental_feature_remoteapp">RemoteApp</string>
+    <string name="settings_experimental_camera">Camera redirection</string>
+    <string name="settings_experimental_camera_summary">Share a local camera with the remote session. Experimental, may be unstable.</string>
+    <string name="experimental_feature_camera">Camera redirection</string>
     <string name="dlg_title_experimental_feature">Experimental feature</string>
     <string name="dlg_msg_experimental_feature">%1$s is experimental. Enable it in the Experimental settings to use it.</string>
     <string name="preference_key_experimental_remoteapp" translatable="false">experimental.remoteapp</string>
+    <string name="preference_key_experimental_camera" translatable="false">experimental.camera</string>
     <string name="preference_key_client_name" translatable="false">preference_key_client_name</string>
     <string name="preference_title_client_name">Client Name</string>
     <string name="preference_default_client_name" translatable="false">aFreeRDP</string>

--- a/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/values/strings.xml
@@ -181,6 +181,7 @@
         <item>0</item>
     </string-array>
     <string name="settings_redirect_microphone">Redirect Microphone</string>
+    <string name="settings_redirect_camera">Redirect Camera</string>
     <string name="settings_redirect_printer">Redirect Printer</string>
     <string name="settings_security">Security</string>
     <string-array name="security_array">

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/advanced_settings.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/advanced_settings.xml
@@ -73,6 +73,10 @@
             android:title="@string/settings_redirect_microphone" />
 
         <CheckBoxPreference
+            android:key="bookmark.redirect_camera"
+            android:title="@string/settings_redirect_camera" />
+
+        <CheckBoxPreference
             android:key="bookmark.redirect_printer"
             android:title="@string/settings_redirect_printer" />
 

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_experimental.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_experimental.xml
@@ -5,4 +5,9 @@
         android:key="@string/preference_key_experimental_remoteapp"
         android:summary="@string/settings_experimental_remoteapp_summary"
         android:title="@string/settings_experimental_remoteapp" />
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="@string/preference_key_experimental_camera"
+        android:summary="@string/settings_experimental_camera_summary"
+        android:title="@string/settings_experimental_camera" />
 </PreferenceScreen>

--- a/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_headers.xml
+++ b/client/Android/Studio/freeRDPCore/src/main/res/xml/settings_app_headers.xml
@@ -27,7 +27,7 @@
         app:fragment="com.freerdp.freerdpcore.presentation.ApplicationSettingsActivity$SecurityFragment" />
 
     <Preference
-        android:icon="@drawable/ic_tune"
+        android:icon="@drawable/ic_experiment"
         android:key="settings.experimental"
         android:title="@string/settings_cat_experimental"
         app:fragment="com.freerdp.freerdpcore.presentation.ApplicationSettingsActivity$ExperimentalFragment" />

--- a/client/Android/cmake/ExternalFreeRDP.cmake
+++ b/client/Android/cmake/ExternalFreeRDP.cmake
@@ -36,6 +36,8 @@ set(FREERDP_EXTRA_CMAKE_ARGS
     -DWITH_CJSON_REQUIRED:BOOL=${WITH_CJSON}
     # Printer channel
     -DCHANNEL_PRINTER_CLIENT:BOOL=ON
+    # Camera redirection (Android NDK Camera2 HAL)
+    -DCHANNEL_RDPECAM_CLIENT:BOOL=ON
 )
 
 ExternalProject_Add(


### PR DESCRIPTION
## [client,rdpecam,android] Add camera redirection support

- Fixes #8649 

### Description
MS-RDPECAM camera redirection for aFreeRDP: a local camera is shared with the remote session, so remote apps (Camera, Teams, browser, …) can use the phone camera.

- Capture via Android NDK **Camera2 + AImageReader**, delivered as raw **NV12**; encoding is handled by FreeRDP's shared video pipeline (needs **FFmpeg/swscale**,   H.264).
- Enumerates one camera per facing (front/back) and skips depth/IR/sub-sensor cameras that can't configure a normal capture session.
- The camera device is opened lazily on StartStream (the server activates every camera just to probe media types) and torn down cleanly on stop, so probing and  disconnect don't thrash the shared camera hardware.
- Per-bookmark **Redirect Camera** toggle (adds `/dvc:rdpecam`) plus a runtime CAMERA permission prompt.
- Gated behind an **Experimental** app setting (opt-in); connecting with it disabled shows a notice and aborts.
- Non-camera sessions are unaffected.
- Disabled in UI when FFmpeg/swscale is unavailable (mirrors H264 check)

### Testing Instructions
1. Bookmark -> advanced settings -> enable **Redirect Camera**.
2. App Settings -> **Experimental** -> enable **Camera redirection**.
3. Connect to a Windows host and open the built-in **Camera** app -> the phone   camera feed appears.
4. With the Experimental toggle **off** -> connecting shows the experimental notice and aborts (normal sessions naffected).

### Environments Tested
- **Server:** Windows 10, verified with the built-in **Camera** app
- **Client:** Android 16 (API 36), physical device

### Note
Conflicts with #12887 (shared Experimental settings + DB version bump); I'll rebase whichever merges second.
