### PR TITLE
[client,rail] add /rail-local-move-size option

### DIFF
--- a/channels/rail/client/client_rails.c
+++ b/channels/rail/client/client_rails.c
@@ -22,7 +22,10 @@ UINT client_rail_server_start_cmd(RailClientContext* context)
 	const rdpSettings* settings = rail->rdpcontext->settings;
 	WINPR_ASSERT(settings);
 
-	clientStatus.flags = TS_RAIL_CLIENTSTATUS_ALLOWLOCALMOVESIZE;
+	clientStatus.flags = 0;
+
+	if (freerdp_settings_get_bool(settings, FreeRDP_RemoteAppLocalMoveSize))
+		clientStatus.flags |= TS_RAIL_CLIENTSTATUS_ALLOWLOCALMOVESIZE;
 
 	if (freerdp_settings_get_bool(settings, FreeRDP_AutoReconnectionEnabled))
 		clientStatus.flags |= TS_RAIL_CLIENTSTATUS_AUTORECONNECT;

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -5534,6 +5534,11 @@ static int parse_command_line(rdpSettings* settings, const COMMAND_LINE_ARGUMENT
 			if (rc != 0)
 				return fail_at(arg, rc);
 		}
+		CommandLineSwitchCase(arg, "rail-local-move-size")
+		{
+			if (!freerdp_settings_set_bool(settings, FreeRDP_RemoteAppLocalMoveSize, enable))
+				return fail_at(arg, COMMAND_LINE_ERROR);
+		}
 		CommandLineSwitchCase(arg, "print-reconnect-cookie")
 		{
 			if (!freerdp_settings_set_bool(settings, FreeRDP_PrintReconnectCookie, enable))

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -406,6 +406,9 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "Pass the hash (restricted admin mode)" },
 	{ "pwidth", COMMAND_LINE_VALUE_REQUIRED, "<width>", nullptr, nullptr, -1, nullptr,
 	  "Physical width of display (in millimeters)" },
+	{ "rail-local-move-size", COMMAND_LINE_VALUE_BOOL, nullptr, BoolValueTrue, nullptr, -1, nullptr,
+	  "Advertise RAIL local move/size support to the server. Disable to force server-side "
+	  "move/resize (workaround for window managers that mishandle _NET_WM_MOVERESIZE, e.g. KWin)" },
 	{ "rdp2tcp", COMMAND_LINE_VALUE_REQUIRED, "<executable path[:arg...]>", nullptr, nullptr, -1,
 	  nullptr, "TCP redirection" },
 	{ "reconnect-cookie", COMMAND_LINE_VALUE_REQUIRED, "<base64-cookie>", nullptr, nullptr, -1,

--- a/include/freerdp/settings_types_private.h
+++ b/include/freerdp/settings_types_private.h
@@ -867,7 +867,8 @@ struct rdp_settings
 	SETTINGS_DEPRECATED(ALIGN64 UINT32 Floatbar);                /* 5196 */
 	SETTINGS_DEPRECATED(ALIGN64 UINT32 TcpConnectTimeout);       /* 5197 */
 	SETTINGS_DEPRECATED(ALIGN64 UINT32 FakeMouseMotionInterval); /* 5198 */
-	UINT64 padding5312[5312 - 5199];                             /* 5199 */
+	SETTINGS_DEPRECATED(ALIGN64 BOOL RemoteAppLocalMoveSize);    /* 5199 */
+	UINT64 padding5312[5312 - 5200];                             /* 5200 */
 
 	/**
 	 * WARNING: End of ABI stable zone!

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -473,6 +473,9 @@ BOOL freerdp_settings_get_bool(WINPR_ATTR_UNUSED const rdpSettings* settings,
 		case FreeRDP_RemoteAppLanguageBarSupported:
 			return settings->RemoteAppLanguageBarSupported;
 
+		case FreeRDP_RemoteAppLocalMoveSize:
+			return settings->RemoteAppLocalMoveSize;
+
 		case FreeRDP_RemoteApplicationMode:
 			return settings->RemoteApplicationMode;
 
@@ -1223,6 +1226,10 @@ BOOL freerdp_settings_set_bool(WINPR_ATTR_UNUSED rdpSettings* settings,
 
 		case FreeRDP_RemoteAppLanguageBarSupported:
 			settings->RemoteAppLanguageBarSupported = cnv.c;
+			break;
+
+		case FreeRDP_RemoteAppLocalMoveSize:
+			settings->RemoteAppLocalMoveSize = cnv.c;
 			break;
 
 		case FreeRDP_RemoteApplicationMode:

--- a/libfreerdp/common/settings_str.h
+++ b/libfreerdp/common/settings_str.h
@@ -197,6 +197,8 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_RemdeskVirtualChannel, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_RemdeskVirtualChannel" },
 	{ FreeRDP_RemoteAppLanguageBarSupported, FREERDP_SETTINGS_TYPE_BOOL,
 	  "FreeRDP_RemoteAppLanguageBarSupported" },
+	{ FreeRDP_RemoteAppLocalMoveSize, FREERDP_SETTINGS_TYPE_BOOL,
+	  "FreeRDP_RemoteAppLocalMoveSize" },
 	{ FreeRDP_RemoteApplicationMode, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_RemoteApplicationMode" },
 	{ FreeRDP_RemoteAssistanceMode, FREERDP_SETTINGS_TYPE_BOOL, "FreeRDP_RemoteAssistanceMode" },
 	{ FreeRDP_RemoteAssistanceRequestControl, FREERDP_SETTINGS_TYPE_BOOL,

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -937,6 +937,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 	    !freerdp_settings_set_bool(settings, FreeRDP_HasQoeEvent, TRUE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_HasRelativeMouseEvent, TRUE) ||
 	    !freerdp_settings_set_bool(settings, FreeRDP_HiDefRemoteApp, TRUE) ||
+	    !freerdp_settings_set_bool(settings, FreeRDP_RemoteAppLocalMoveSize, TRUE) ||
 	    !freerdp_settings_set_uint32(
 	        settings, FreeRDP_RemoteApplicationSupportMask,
 	        RAIL_LEVEL_SUPPORTED | RAIL_LEVEL_DOCKED_LANGBAR_SUPPORTED |

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -140,6 +140,7 @@ static const size_t bool_list_indices[] = {
 	FreeRDP_RefreshRect,
 	FreeRDP_RemdeskVirtualChannel,
 	FreeRDP_RemoteAppLanguageBarSupported,
+	FreeRDP_RemoteAppLocalMoveSize,
 	FreeRDP_RemoteApplicationMode,
 	FreeRDP_RemoteAssistanceMode,
 	FreeRDP_RemoteAssistanceRequestControl,


### PR DESCRIPTION
Adds `/rail-local-move-size:[on|off]` (setting `FreeRDP_RemoteAppLocalMoveSize`,
**default `on` — no behavior change**), controlling whether the client advertises
`TS_RAIL_CLIENTSTATUS_ALLOWLOCALMOVESIZE`.

The client currently always advertises local move/size, so the server hands RemoteApp
window move/resize to the local WM via `_NET_WM_MOVERESIZE`. On some window managers
(notably KWin / KDE Plasma on X11) this handoff misbehaves and RemoteApp windows get stuck
during interactive resize (see #5909). With the option `off`, the client does not advertise it and the server
performs server-side move/resize instead.

**Testing** (KDE Plasma/KWin X11, Windows Server RemoteApp, notepad):
- default → resize hang present, `TS_RAIL_ORDER_LOCALMOVESIZE` PDUs received;
- `-rail-local-move-size` → resize works (server-side), no such PDUs.