### PR TITLE
Adjustments for building on Windows with MSVC

### DIFF
--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -381,7 +381,7 @@ static LRESULT CALLBACK hotplug_proc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM 
 									{
 										if (device_ext->automount)
 										{
-											const uint32_t ids[] = { keys[j] };
+											const uint32_t ids[] = { (uint32_t)keys[j] };
 											WINPR_ASSERT(rdpdr->context.RdpdrUnregisterDevice);
 											error = rdpdr->context.RdpdrUnregisterDevice(
 											    &rdpdr->context, ARRAYSIZE(ids), ids);
@@ -523,7 +523,6 @@ static UINT handle_hotplug(WINPR_ATTR_UNUSED RdpdrClientContext* context,
 	ULONG_PTR* keys = nullptr;
 	int size = 0;
 	UINT error = ERROR_INTERNAL_ERROR;
-	UINT32 ids[1];
 
 	DIR* pDir = opendir(szdir);
 
@@ -602,7 +601,7 @@ static UINT handle_hotplug(WINPR_ATTR_UNUSED RdpdrClientContext* context,
 
 		if (!dev_found)
 		{
-			const uint32_t ids[] = { keys[j] };
+			const uint32_t ids[] = { (uint32_t)keys[j] };
 			WINPR_ASSERT(rdpdr->context.RdpdrUnregisterDevice);
 			error = rdpdr->context.RdpdrUnregisterDevice(&rdpdr->context, ARRAYSIZE(ids), ids);
 			if (error)

--- a/cmake/JsonDetect.cmake
+++ b/cmake/JsonDetect.cmake
@@ -64,7 +64,7 @@ function(detect_package name)
 
     if(${name}_FOUND)
       # Create imported target cjson
-      add_library(${arg_CMAKE} SHARED IMPORTED)
+      add_library(${arg_CMAKE} UNKNOWN IMPORTED)
       set_property(TARGET ${arg_CMAKE} APPEND PROPERTY IMPORTED_CONFIGURATIONS NOCONFIG)
       set_target_properties(
         ${arg_CMAKE}

--- a/winpr/libwinpr/wtsapi/wtsapi.c
+++ b/winpr/libwinpr/wtsapi/wtsapi.c
@@ -50,7 +50,7 @@ static const WtsApiFunctionTable* g_WtsApi = nullptr;
 static HMODULE g_WtsApi32Module = nullptr;
 static WtsApiFunctionTable WtsApi32_WtsApiFunctionTable = WINPR_C_ARRAY_INIT;
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) || defined(_MSC_VER)
 #define WTSAPI32_LOAD_PROC(NAME, TYPE) \
 	WtsApi32_WtsApiFunctionTable.p##NAME = GetProcAddressAs(g_WtsApi32Module, "WTS" #NAME, TYPE);
 #else


### PR DESCRIPTION
## Change library type from SHARED to UNKNOWN in detect_package
Fix winpr-3.dll link bug. JsonDetect.cmake declares the target SHARED IMPORTED but sets the .lib as IMPORTED_LOCATION, and never sets IMPORTED_IMPLIB. On Windows, linking a shared imported target requires the import library via IMPORTED_IMPLIB_<CONFIG>. Since that's missing, CMake substitutes its sentinel cjson-NOTFOUND for the import library, and that flows through the file API into winpr-3.dll's link line.
When linking winpr-3.dll, the link can fail if pkg-config finds cjson. For an UNKNOWN IMPORTED library, CMake links IMPORTED_LOCATION directly as a link item on every platform, no separate import library needed. The .lib full path gets linked, cjson-NOTFOUND disappears, and it still should work on Linux/macOS (not able to test).

## Eliminate warning C5103 in WTSAPI32_LOAD_PROC macro
When building with MSVC compiler you will get many warnings:
```
C:\FreeRDP\winpr\libwinpr\wtsapi\wtsapi.c(68): warning C5103: pasting ',' and 'WTS_STOP_REMOTE_CONTROL_SESSION_FN' does not result in a valid preprocessing token
C:\FreeRDP\winpr\libwinpr\wtsapi\wtsapi.c(57): note: in expansion of macro 'WTSAPI32_LOAD_PROC'
```

## Cast keys[j] to uint32_t to eliminate warning C4244: possible loss of data
Investigated if safe to typecast away warning below:
`C:\FreeRDP\channels\rdpdr\client\rdpdr_main.c(384): warning C4244: 'initializing': conversion from 'ULONG_PTR' to 'const uint32_t', possible loss of data`