### PR TITLE
[channels,video] bound frame copy to current surface size

### DIFF
--- a/channels/video/client/video_main.c
+++ b/channels/video/client/video_main.c
@@ -704,14 +704,26 @@ static void video_timer(VideoClientContext* video, UINT64 now)
 	{
 		if (presentation && (presentation->PresentationId == frame->PresentationId))
 		{
-			priv->publishedFrames++;
-			memcpy(presentation->surface->data, frame->surfaceData,
-			       1ull * frame->scanline * frame->h);
+			VideoSurface* surface = presentation->surface;
+			const size_t frameSize = 1ull * frame->scanline * frame->h;
+			const size_t surfaceSize = 1ull * surface->scanline * surface->alignedHeight;
 
-			WINPR_ASSERT(video->showSurface);
-			if (!video->showSurface(video, presentation->surface, presentation->ScaledWidth,
-			                        presentation->ScaledHeight))
-				WLog_WARN(TAG, "showSurface failed");
+			/* the presentation id is reused by the server across presentations of different
+			 * sizes, so a frame queued for a previous, larger presentation can outlive it in
+			 * the queue. copying it would write past the smaller surface->data buffer. */
+			if (frameSize > surfaceSize)
+				WLog_WARN(TAG, "dropping stale frame of %" PRIuz " bytes, surface holds %" PRIuz,
+				          frameSize, surfaceSize);
+			else
+			{
+				priv->publishedFrames++;
+				memcpy(surface->data, frame->surfaceData, frameSize);
+
+				WINPR_ASSERT(video->showSurface);
+				if (!video->showSurface(video, surface, presentation->ScaledWidth,
+				                        presentation->ScaledHeight))
+					WLog_WARN(TAG, "showSurface failed");
+			}
 		}
 		VideoFrame_free(priv, frame);
 	}


### PR DESCRIPTION
video_timer copies a queued frame into presentation->surface->data guarded only by presentation->PresentationId == frame->PresentationId, but the presentation id is an 8 bit value the server reuses and each frame is sized for the surface that existed when VideoFrame_new enqueued it. the frames queue is only drained in the channel destructor, not on TSMM_STOP_PRESENTATION nor when a presentation is replaced, so a server can start a large presentation, push video data to enqueue a frame, stop it, then start a new presentation reusing the same id with a much smaller SourceWidth/SourceHeight. surface->data is allocated as scanline*alignedHeight in VideoClient_CreateCommonContext, so when the timer later dequeues the stale frame it still passes the id check and the memcpy writes the old, larger frame into the new, smaller buffer, overrunning the heap allocation. this bounds the copy to the destination surface size and drops the frame when it no longer fits, which also looks like the right behaviour for a frame whose presentation has gone. to reproduce, drive the dynamic channel with start(id=1, 1920x1080) then video data to queue a frame, stop(id=1), start(id=1, 64x64), and let the timer fire on the still queued frame.