### PR TITLE
[utils,smartcard] validate cbAtr against rgbAtr size on unpack

### DIFF
--- a/libfreerdp/utils/smartcard_pack.c
+++ b/libfreerdp/utils/smartcard_pack.c
@@ -312,7 +312,27 @@ static LONG smartcard_ndr_read_atrmask(wLog* log, wStream* s, LocateCards_ATRMas
 		BYTE** ppv;
 	} u;
 	u.ppc = data;
-	return smartcard_ndr_read(log, s, u.ppv, min, sizeof(LocateCards_ATRMask), type);
+	const LONG status = smartcard_ndr_read(log, s, u.ppv, min, sizeof(LocateCards_ATRMask), type);
+	if (status != SCARD_S_SUCCESS)
+		return status;
+
+	/* [MS-RDPESC] 2.2.1.5: cbAtr is range(0..36), the number of valid bytes in the fixed
+	 * rgbAtr/rgbMask arrays. A larger value walks past them when the mask is compared byte
+	 * by byte, so reject it here rather than trusting the wire value. */
+	const LocateCards_ATRMask* masks = *data;
+	for (size_t x = 0; x < min; x++)
+	{
+		if (masks[x].cbAtr > ARRAYSIZE(masks[x].rgbAtr))
+		{
+			WLog_Print(log, WLOG_ERROR,
+			           "LocateCards_ATRMask[%" PRIuz "]::cbAtr %" PRIu32 " exceeds %" PRIuz, x,
+			           masks[x].cbAtr, (size_t)ARRAYSIZE(masks[x].rgbAtr));
+			free(*data);
+			*data = nullptr;
+			return STATUS_DATA_ERROR;
+		}
+	}
+	return SCARD_S_SUCCESS;
 }
 
 static LONG smartcard_ndr_read_fixed_string_a(wLog* log, wStream* s, CHAR** data, size_t min,
@@ -2454,6 +2474,13 @@ static LONG smartcard_unpack_reader_state_a(wLog* log, wStream* s, LPSCARD_READE
 		Stream_Read_UINT32(s, readerState->dwCurrentState); /* dwCurrentState (4 bytes) */
 		Stream_Read_UINT32(s, readerState->dwEventState);   /* dwEventState (4 bytes) */
 		Stream_Read_UINT32(s, readerState->cbAtr);          /* cbAtr (4 bytes) */
+		if (readerState->cbAtr > ARRAYSIZE(readerState->rgbAtr))
+		{
+			WLog_Print(log, WLOG_ERROR,
+			           "SCARD_READERSTATEA[%" PRIu32 "]::cbAtr %" PRIu32 " exceeds %" PRIuz, index,
+			           readerState->cbAtr, (size_t)ARRAYSIZE(readerState->rgbAtr));
+			goto fail;
+		}
 		Stream_Read(s, readerState->rgbAtr, 36);            /* rgbAtr [0..36] (36 bytes) */
 	}
 
@@ -2528,6 +2555,13 @@ static LONG smartcard_unpack_reader_state_w(wLog* log, wStream* s, LPSCARD_READE
 		Stream_Read_UINT32(s, readerState->dwCurrentState); /* dwCurrentState (4 bytes) */
 		Stream_Read_UINT32(s, readerState->dwEventState);   /* dwEventState (4 bytes) */
 		Stream_Read_UINT32(s, readerState->cbAtr);          /* cbAtr (4 bytes) */
+		if (readerState->cbAtr > ARRAYSIZE(readerState->rgbAtr))
+		{
+			WLog_Print(log, WLOG_ERROR,
+			           "SCARD_READERSTATEW[%" PRIu32 "]::cbAtr %" PRIu32 " exceeds %" PRIuz, index,
+			           readerState->cbAtr, (size_t)ARRAYSIZE(readerState->rgbAtr));
+			goto fail;
+		}
 		Stream_Read(s, readerState->rgbAtr, 36);            /* rgbAtr [0..36] (36 bytes) */
 	}
 

--- a/libfreerdp/utils/test/CMakeLists.txt
+++ b/libfreerdp/utils/test/CMakeLists.txt
@@ -5,7 +5,7 @@ disable_warnings_for_directory(${CMAKE_CURRENT_BINARY_DIR})
 
 set(${MODULE_PREFIX}_DRIVER ${MODULE_NAME}.c)
 
-set(${MODULE_PREFIX}_TESTS TestRingBuffer.c TestPodArrays.c TestEncodedTypes.c)
+set(${MODULE_PREFIX}_TESTS TestRingBuffer.c TestPodArrays.c TestEncodedTypes.c TestSmartcardPack.c)
 
 create_test_sourcelist(${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_DRIVER} ${${MODULE_PREFIX}_TESTS})
 

--- a/libfreerdp/utils/test/TestSmartcardPack.c
+++ b/libfreerdp/utils/test/TestSmartcardPack.c
@@ -1,0 +1,93 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <winpr/stream.h>
+#include <freerdp/channels/scard.h>
+#include <freerdp/utils/smartcard_pack.h>
+
+/* Build a LocateCardsByATRA call (cbContext=0, cAtrs=1, cReaders=0) holding a single
+ * LocateCards_ATRMask whose cbAtr is set to the requested value. */
+static wStream* build_locate_cards_by_atr_a(UINT32 cbAtr)
+{
+	wStream* s = Stream_New(NULL, 24 + 8 + sizeof(LocateCards_ATRMask));
+	if (!s)
+		return NULL;
+
+	Stream_Write_UINT32(s, 0);          /* cbContext = 0 */
+	Stream_Write_UINT32(s, 0);          /* pbContextNdrPtr = 0 */
+	Stream_Write_UINT32(s, 1);          /* cAtrs = 1 */
+	Stream_Write_UINT32(s, 0x00020000); /* rgAtrMasksNdrPtr */
+	Stream_Write_UINT32(s, 0);          /* cReaders = 0 */
+	Stream_Write_UINT32(s, 0);          /* rgReaderStatesNdrPtr = 0 */
+	Stream_Write_UINT32(s, 1);          /* conformant count = cAtrs */
+	Stream_Write_UINT32(s, cbAtr);      /* LocateCards_ATRMask::cbAtr */
+	Stream_Zero(s, 36);                 /* rgbAtr[36] */
+	Stream_Zero(s, 36);                 /* rgbMask[36] */
+
+	Stream_SealLength(s);
+	if (!Stream_SetPosition(s, 0))
+	{
+		Stream_Free(s, TRUE);
+		return NULL;
+	}
+	return s;
+}
+
+static BOOL run_case(UINT32 cbAtr, BOOL expectAccept)
+{
+	wStream* s = build_locate_cards_by_atr_a(cbAtr);
+	if (!s)
+		return FALSE;
+
+	LocateCardsByATRA_Call call = { 0 };
+	const LONG status = smartcard_unpack_locate_cards_by_atr_a_call(s, &call);
+	Stream_Free(s, TRUE);
+
+	const BOOL accepted = (status == SCARD_S_SUCCESS) ? TRUE : FALSE;
+	if (accepted != expectAccept)
+	{
+		printf("cbAtr=%" PRIu32 ": expected %s, unpack returned 0x%08" PRIX32 "\n", cbAtr,
+		       expectAccept ? "accept" : "reject", (UINT32)status);
+		free(call.rgAtrMasks);
+		return FALSE;
+	}
+
+	free(call.rgAtrMasks);
+	return TRUE;
+}
+
+int TestSmartcardPack(int argc, char* argv[])
+{
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+
+	/* Valid: cbAtr within the fixed 36-byte rgbAtr/rgbMask arrays. */
+	if (!run_case(0, TRUE))
+		return -1;
+	if (!run_case(36, TRUE))
+		return -1;
+
+	/* Out of range: cbAtr larger than the buffers would later overrun them. */
+	if (!run_case(37, FALSE))
+		return -1;
+	if (!run_case(0xFFFFFFFF, FALSE))
+		return -1;
+
+	return 0;
+}


### PR DESCRIPTION
**Out-of-range cbAtr in smartcard unpacking**

`cbAtr` in `LocateCards_ATRMask` and `SCARD_READERSTATE` comes straight off the wire, but the paired `rgbAtr`/`rgbMask` members are fixed 36-byte arrays. A malicious server can set it past 36, after which `smartcard_LocateCardsByATRA_Call` walks the ATR mask byte by byte beyond those buffers (the trace helpers read `rgbAtr` for `cbAtr` bytes as well). [MS-RDPESC] declares the field `range(0..36)`, so the unpackers reject a larger value rather than trust it. The added test covers the ATR mask path.