### PR TITLE
[emu,scard] bound select-by-AID compare to GIDS AID length

### DIFF
--- a/libfreerdp/emu/scard/smartcard_virtual_gids.c
+++ b/libfreerdp/emu/scard/smartcard_virtual_gids.c
@@ -714,7 +714,7 @@ static BOOL vgids_ins_select(vgidsContext* context, wStream* s, BYTE** response,
 
 			/* Check if we select MS GIDS App (only one we know) */
 			Stream_Read(s, aid, lc);
-			if (memcmp(aid, g_MsGidsAID, lc) != 0)
+			if ((lc > sizeof(g_MsGidsAID)) || (memcmp(aid, g_MsGidsAID, lc) != 0))
 			{
 				status = ISO_STATUS_FILENOTFOUND;
 				break;


### PR DESCRIPTION
**Out-of-bounds read in vgids_ins_select**
A SELECT by AID compares the APDU bytes against the 11-byte `g_MsGidsAID` using the server-supplied `Lc` as the length, and `Lc` is only capped at `ISO_AID_MAX_SIZE` (16). An `Lc` of 12 to 16 whose first 11 bytes match the AID makes the `memcmp` read past the constant. A selector longer than our AID cannot match anyway, so it now returns "file not found" before the compare.