### PR TITLE
[client,sdl] throw a real exception instead of invalid bare throw

### DIFF
--- a/client/SDL/SDL2/dialogs/sdl_input_widgets.cpp
+++ b/client/SDL/SDL2/dialogs/sdl_input_widgets.cpp
@@ -146,13 +146,13 @@ int SdlInputWidgetList::run(std::vector<std::string>& result)
 		while (running)
 		{
 			if (!clear_window(_renderer))
-				throw;
+				throw std::exception();
 
 			if (!update(_renderer))
-				throw;
+				throw std::exception();
 
 			if (!_buttons.update(_renderer))
-				throw;
+				throw std::exception();
 
 			SDL_Event event = {};
 			SDL_WaitEvent(&event);
@@ -171,7 +171,7 @@ int SdlInputWidgetList::run(std::vector<std::string>& result)
 							if (cur)
 							{
 								if (!cur->remove_str(_renderer, 1))
-									throw;
+									throw std::exception();
 							}
 						}
 						break;
@@ -216,7 +216,7 @@ int SdlInputWidgetList::run(std::vector<std::string>& result)
 					if (cur)
 					{
 						if (!cur->append_str(_renderer, event.text.text))
-							throw;
+							throw std::exception();
 					}
 				}
 				break;
@@ -226,13 +226,13 @@ int SdlInputWidgetList::run(std::vector<std::string>& result)
 					for (auto& cur : _list)
 					{
 						if (!cur.set_mouseover(_renderer, false))
-							throw;
+							throw std::exception();
 					}
 					if (TextInputIndex >= 0)
 					{
 						auto& cur = _list.at(static_cast<size_t>(TextInputIndex));
 						if (!cur.set_mouseover(_renderer, true))
-							throw;
+							throw std::exception();
 					}
 
 					_buttons.set_mouseover(event.button.x, event.button.y);
@@ -275,13 +275,13 @@ int SdlInputWidgetList::run(std::vector<std::string>& result)
 			for (auto& cur : _list)
 			{
 				if (!cur.set_highlight(_renderer, false))
-					throw;
+					throw std::exception();
 			}
 			auto cur = get(CurrentActiveTextInput);
 			if (cur)
 			{
 				if (!cur->set_highlight(_renderer, true))
-					throw;
+					throw std::exception();
 			}
 
 			SDL_RenderPresent(_renderer);

--- a/client/SDL/SDL2/dialogs/sdl_selectlist.cpp
+++ b/client/SDL/SDL2/dialogs/sdl_selectlist.cpp
@@ -64,13 +64,13 @@ int SdlSelectList::run()
 		while (running)
 		{
 			if (!clear_window(_renderer))
-				throw;
+				throw std::exception();
 
 			if (!update_text())
-				throw;
+				throw std::exception();
 
 			if (!_buttons.update(_renderer))
-				throw;
+				throw std::exception();
 
 			SDL_Event event = {};
 			SDL_WaitEvent(&event);
@@ -125,7 +125,7 @@ int SdlSelectList::run()
 					{
 						auto& cur = _list.at(WINPR_ASSERTING_INT_CAST(size_t, TextInputIndex));
 						if (!cur.set_mouseover(_renderer, true))
-							throw;
+							throw std::exception();
 					}
 
 					_buttons.set_mouseover(event.button.x, event.button.y);
@@ -161,7 +161,7 @@ int SdlSelectList::run()
 			{
 				auto& cur = _list.at(WINPR_ASSERTING_INT_CAST(size_t, CurrentActiveTextInput));
 				if (!cur.set_highlight(_renderer, true))
-					throw;
+					throw std::exception();
 			}
 
 			SDL_RenderPresent(_renderer);

--- a/client/SDL/SDL3/dialogs/sdl_input_widget_pair_list.cpp
+++ b/client/SDL/SDL3/dialogs/sdl_input_widget_pair_list.cpp
@@ -162,7 +162,7 @@ int SdlInputWidgetPairList::run(std::vector<std::string>& result)
 		while (running)
 		{
 			if (!update())
-				throw;
+				throw std::exception();
 
 			SDL_Event event = {};
 			if (!SDL_WaitEventTimeout(&event, 30))
@@ -183,12 +183,12 @@ int SdlInputWidgetPairList::run(std::vector<std::string>& result)
 									if ((event.key.mod & SDL_KMOD_CTRL) != 0)
 									{
 										if (!cur->set_str(""))
-											throw;
+											throw std::exception();
 									}
 									else
 									{
 										if (!cur->remove_str(1))
-											throw;
+											throw std::exception();
 									}
 								}
 							}
@@ -214,7 +214,7 @@ int SdlInputWidgetPairList::run(std::vector<std::string>& result)
 									{
 										auto text = SDL_GetClipboardText();
 										if (!cur->set_str(text))
-											throw;
+											throw std::exception();
 									}
 								}
 								break;
@@ -229,7 +229,7 @@ int SdlInputWidgetPairList::run(std::vector<std::string>& result)
 						if (cur)
 						{
 							if (!cur->append_str(event.text.text))
-								throw;
+								throw std::exception();
 						}
 					}
 					break;
@@ -288,13 +288,13 @@ int SdlInputWidgetPairList::run(std::vector<std::string>& result)
 			for (auto& cur : m_list)
 			{
 				if (!cur->set_highlight(false))
-					throw;
+					throw std::exception();
 			}
 			auto cur = get(m_currentActiveTextInput);
 			if (cur)
 			{
 				if (!cur->set_highlight(true))
-					throw;
+					throw std::exception();
 			}
 
 			auto rc = SDL_RenderPresent(_renderer.get());

--- a/client/SDL/SDL3/dialogs/sdl_select_list.cpp
+++ b/client/SDL/SDL3/dialogs/sdl_select_list.cpp
@@ -45,7 +45,7 @@ int SdlSelectList::run()
 		while (running)
 		{
 			if (!update())
-				throw;
+				throw std::exception();
 
 			SDL_Event event = {};
 			if (!SDL_WaitEventTimeout(&event, 30))
@@ -113,7 +113,7 @@ int SdlSelectList::run()
 						{
 							auto& cur = _list.at(WINPR_ASSERTING_INT_CAST(size_t, TextInputIndex));
 							if (!cur.mouseover(true))
-								throw;
+								throw std::exception();
 						}
 
 						_buttons.set_mouseover(event.button.x, event.button.y);
@@ -150,7 +150,7 @@ int SdlSelectList::run()
 			{
 				auto& cur = _list.at(WINPR_ASSERTING_INT_CAST(size_t, CurrentActiveTextInput));
 				if (!cur.highlight(true))
-					throw;
+					throw std::exception();
 			}
 		}
 


### PR DESCRIPTION
The dialog loops bail to their catch with a bare throw; but with no exception in flight that calls std::terminate(). Throw std::exception() as sdl_disp.cpp does.
