### PR TITLE
[core,orders] fix inverted overflow guard in update_read_delta_points

### DIFF
--- a/libfreerdp/core/orders.c
+++ b/libfreerdp/core/orders.c
@@ -1108,7 +1108,7 @@ static inline BOOL update_read_delta_points(wStream* s, DELTA_POINT** points, UI
 	BYTE flags = 0;
 	UINT32 zeroBitsSize = ((number + 3) / 4);
 
-	if (SIZE_MAX / number > sizeof(DELTA_POINT))
+	if (SIZE_MAX / number <= sizeof(DELTA_POINT))
 		return FALSE;
 
 	WINPR_ASSERT(points);


### PR DESCRIPTION
**Inverted overflow guard in update_read_delta_points**

The overflow check guarding the delta-point allocation reads `SIZE_MAX / number > sizeof(DELTA_POINT)`, which is true for every realistic count, so PolyLine and PolyGon orders are rejected before a single point is read, and the surviving comparison divides by the server-supplied count. Reordered it to `number > UINT32_MAX / sizeof(DELTA_POINT)` so the bound sits on the count itself, matching the form used elsewhere in the tree and keeping the intended 32-bit overflow protection.