### PR TITLE
bound copy-offset source read in mppc_decompress

### DIFF
--- a/libfreerdp/codec/mppc.c
+++ b/libfreerdp/codec/mppc.c
@@ -417,6 +417,16 @@ int mppc_decompress(MPPC_CONTEXT* mppc, const BYTE* pSrcData, UINT32 SrcSize,
 			return -1005;
 		}
 
+		/* CopyOffset points back into the data already decompressed since the last
+		 * reset. A value larger than that references bytes before the start of the
+		 * history; the masking below would wrap it to the tail of the buffer and the
+		 * forward copy would then read past HistoryBufferEnd. Reject such offsets. */
+		if (CopyOffset > (UINT32)(HistoryPtr - HistoryBuffer))
+		{
+			WLog_ERR(TAG, "invalid CopyOffset, references data before history start");
+			return -1006;
+		}
+
 		SrcPtr = &HistoryBuffer[(HistoryPtr - HistoryBuffer - CopyOffset) &
 		                        (CompressionLevel ? 0xFFFF : 0x1FFF)];
 

--- a/libfreerdp/codec/test/TestFreeRDPCodecMppc.c
+++ b/libfreerdp/codec/test/TestFreeRDPCodecMppc.c
@@ -1063,10 +1063,44 @@ fail:
 	return rc;
 }
 
+/*
+ * A CopyOffset that points before the start of the decompressed history must be
+ * rejected. The encoded token below (CopyOffset=1, LengthOfMatch=3) is decoded
+ * right after a PACKET_AT_FRONT reset, when no history has been produced yet, so
+ * the back-reference wraps to the tail of the 64k history buffer and the forward
+ * match copy used to read past its end.
+ */
+static int test_MppcDecompressOffsetBeforeHistory(void)
+{
+	const BYTE pSrcData[] = { 0xF8, 0x20 };
+	const BYTE* pDstData = nullptr;
+	UINT32 DstSize = 0;
+	const UINT32 Flags = PACKET_AT_FRONT | PACKET_COMPRESSED | 1;
+	MPPC_CONTEXT* mppc = mppc_context_new(1, FALSE);
+
+	if (!mppc)
+		return -1;
+
+	const int status =
+	    mppc_decompress(mppc, pSrcData, sizeof(pSrcData), &pDstData, &DstSize, Flags);
+	mppc_context_free(mppc);
+
+	if (status >= 0)
+	{
+		printf("MppcDecompressOffsetBeforeHistory: out-of-range CopyOffset was not rejected\n");
+		return -1;
+	}
+
+	return 0;
+}
+
 int TestFreeRDPCodecMppc(int argc, char* argv[])
 {
 	WINPR_UNUSED(argc);
 	WINPR_UNUSED(argv);
+
+	if (test_MppcDecompressOffsetBeforeHistory() < 0)
+		return -1;
 
 	if (test_MppcCompressIslandRdp5() < 0)
 		return -1;


### PR DESCRIPTION
**Out-of-bounds read in the mppc_decompress match copy**

A copy token whose `CopyOffset` is larger than the amount of data decompressed since the last reset (for example a copy token right after `PACKET_AT_FRONT`/`PACKET_FLUSHED`, when `HistoryPtr` still sits at offset 0) wraps the source index to the tail of the 64k history buffer. The destination write is bounded against `HistoryBufferEnd`, but `SrcPtr` is then read forward `LengthOfMatch` bytes with no source bound, so the forward copy runs past the end of `HistoryBuffer` and a malicious server can over-read up to ~64k of heap.

The cause is that the masking only keeps the start index in range; it silently turns an invalid back-reference into a tail wrap instead of rejecting it. Rejecting a `CopyOffset` that points before the start of the valid history keeps both the read and the write in bounds, and matches the sibling decoders: ncrush splits the copy at the wrap boundary and xcrush bounds both ends, so this was the only bulk decoder missing the check.

To test: `TestFreeRDPCodecMppc` gains a regression case that feeds such a token after `PACKET_AT_FRONT` and expects `mppc_decompress` to refuse it. Built with `-fsanitize=address` and `BUILD_TESTING_INTERNAL=ON`; before the change the case reports a heap-buffer-overflow read at the copy loop, after it the input is rejected and the existing decode tests still pass.