### PR TITLE
[client,sdl] run sdl_OnUserNotificationEventHandler on SDL thread

### DIFF
--- a/client/SDL/SDL3/sdl_channels.cpp
+++ b/client/SDL/SDL3/sdl_channels.cpp
@@ -105,9 +105,31 @@ void sdl_OnUserNotificationEventHandler(void* context, const UserNotificationEve
 	if (e->cancelPreviousNotification)
 		return;
 
-	WINPR_ASSERT(e->message);
-	auto parent = SDL_GetMouseFocus();
-	if (!parent)
-		parent = SDL_GetKeyboardFocus();
-	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, e->e.Sender, e->message, parent);
+	struct userdata
+	{
+		std::string sender;
+		std::string message;
+		uint32_t timeoutMS;
+	};
+
+	auto ud = new struct userdata;
+	if (e->message)
+		ud->message = e->message;
+	if (e->e.Sender)
+		ud->sender = e->e.Sender;
+	ud->timeoutMS = e->timeoutMS;
+
+	SDL_RunOnMainThread(
+	    [](void* userdata)
+	    {
+		    auto e = static_cast<struct userdata*>(userdata);
+		    WINPR_ASSERT(e);
+		    auto parent = SDL_GetMouseFocus();
+		    if (!parent)
+			    parent = SDL_GetKeyboardFocus();
+		    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, e->sender.c_str(),
+		                             e->message.c_str(), parent);
+		    delete e;
+	    },
+	    ud, false);
 }

--- a/client/SDL/SDL3/sdl_types.hpp
+++ b/client/SDL/SDL3/sdl_types.hpp
@@ -44,3 +44,10 @@ typedef struct
 	auto sdl = reinterpret_cast<sdl_rdp_context*>(ctx);
 	return sdl->sdl;
 }
+
+[[nodiscard]] static inline SdlContext* get_context(freerdp* instance)
+{
+	if (!instance)
+		return nullptr;
+	return get_context(instance->context);
+}


### PR DESCRIPTION
some platforms require SDL dialogs to be created on main SDL thread, so ensure we're always running the notification from that one.