### PR TITLE
[channels,tsmf] bound visible rect read in update_geometry_info

### DIFF
--- a/channels/tsmf/client/tsmf_ifman.c
+++ b/channels/tsmf/client/tsmf_ifman.c
@@ -508,6 +508,8 @@ UINT tsmf_ifman_update_geometry_info(TSMF_IFMAN* ifman)
 	Stream_Read_UINT32(ifman->input, Top);
 	if (!Stream_SetPosition(ifman->input, pos + numGeometryInfo))
 		return ERROR_INVALID_DATA;
+	if (!Stream_CheckAndLogRequiredLength(TAG, ifman->input, 4))
+		return ERROR_INVALID_DATA;
 	Stream_Read_UINT32(ifman->input, cbVisibleRect);
 	const UINT32 num_rects = cbVisibleRect / 16;
 	DEBUG_TSMF("numGeometryInfo %" PRIu32 " Width %" PRIu32 " Height %" PRIu32 " Left %" PRIu32
@@ -516,7 +518,12 @@ UINT tsmf_ifman_update_geometry_info(TSMF_IFMAN* ifman)
 
 	if (num_rects > 0)
 	{
+		if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, ifman->input, num_rects, 16ull))
+			return ERROR_INVALID_DATA;
+
 		rects = (RECTANGLE_32*)calloc(num_rects, sizeof(RECTANGLE_32));
+		if (!rects)
+			return ERROR_OUTOFMEMORY;
 
 		for (size_t i = 0; i < num_rects; i++)
 		{


### PR DESCRIPTION
tsmf_ifman_update_geometry_info seeks the input stream to pos + numGeometryInfo, where numGeometryInfo is a server-supplied uint32 and stream_setposition only validates the target offset, not that any bytes remain there. it then reads cbVisibleRect and walks num_rects = cbVisibleRect / 16 entries of 16 bytes each with no length check, so a media server that lands the position at or near the end of the buffer reads past it, an out-of-bounds heap read of the channel pdu. the only guard was the initial GUID_SIZE+32 check, which the seek consumes. add the missing length checks before the cbVisibleRect read and before the rect loop, and guard the calloc, so the parse stays within the received data.