### PR TITLE
[channels,rdpecam] bound channel name read in device removed pdu

### DIFF
--- a/channels/rdpecam/server/camera_device_enumerator_main.c
+++ b/channels/rdpecam/server/camera_device_enumerator_main.c
@@ -218,30 +218,29 @@ static UINT enumerator_server_recv_device_removed_notification(CamDevEnumServerC
                                                                wStream* s,
                                                                const CAM_SHARED_MSG_HEADER* header)
 {
-	CAM_DEVICE_REMOVED_NOTIFICATION pdu;
 	UINT error = CHANNEL_RC_OK;
-	size_t remaining_length = 0;
 
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(header);
 
-	pdu.Header = *header;
-
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, 2))
 		return ERROR_NO_DATA;
 
-	pdu.VirtualChannelName = Stream_Pointer(s);
+	CAM_DEVICE_REMOVED_NOTIFICATION pdu = { .Header = *header,
+		                                    .VirtualChannelName = Stream_PointerAs(s, char) };
 
-	remaining_length = Stream_GetRemainingLength(s);
-	char* tmp = pdu.VirtualChannelName + 1;
-
-	for (size_t i = 1; i < remaining_length; ++i, ++tmp)
+	/* VirtualChannelName: Read until either no bytes left or a ANSI '\0' was found */
+	bool ansiNull = false;
+	while (Stream_GetRemainingLength(s) >= sizeof(CHAR))
 	{
-		if (*tmp == '\0')
+		const CHAR c = Stream_Get_INT8(s);
+		if (c == '\0')
+		{
+			ansiNull = true;
 			break;
+		}
 	}
-
-	if (*tmp != '\0')
+	if (!ansiNull)
 	{
 		WLog_ERR(TAG,
 		         "enumerator_server_recv_device_removed_notification: Invalid VirtualChannelName!");


### PR DESCRIPTION
The camera device enumerator server takes the VirtualChannelName of a device-removed notification straight from the channel buffer. The handler points at the start of the name and scans forward for the terminating NUL with a loop bounded by the remaining length, then dereferences the cursor once more to confirm the byte it stopped on is a terminator. When a client sends a name that runs to the end of the PDU without a NUL the loop exits at the boundary, so that final check reads one byte past the received data. The enumerator stream is reused and trimmed to the message with Stream_SetLength(BytesReturned), so on a request that fills the buffer exactly this becomes an out-of-bounds read rather than a peek at leftover bytes. I came across it while looking at the device-added handler that was reworked in 1294470 for the same issue; the removed path was left with the old scan. I have rewritten it the same way, consuming the name byte by byte while bytes remain, which keeps the termination check inside the buffer and makes the two handlers consistent.