### PR TITLE
[core,tcp] log why a tcp connect failed

### DIFF
--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -808,7 +808,7 @@ static BOOL freerdp_tcp_is_hostname_resolvable(rdpContext* context, const char* 
 }
 
 static BOOL freerdp_tcp_connect_timeout(rdpContext* context, int sockfd, struct sockaddr* addr,
-                                        size_t addrlen, UINT32 timeout)
+                                        size_t addrlen, UINT32 timeout, INT32* connectError)
 {
 	BOOL rc = FALSE;
 	HANDLE handles[2] = WINPR_C_ARRAY_INIT;
@@ -868,6 +868,8 @@ static BOOL freerdp_tcp_connect_timeout(rdpContext* context, int sockfd, struct 
 			char ebuffer[256] = WINPR_C_ARRAY_INIT;
 			WLog_DBG(TAG, "connect failed with error: %s [%" PRId32 "]",
 			         winpr_strerror(optval, ebuffer, sizeof(ebuffer)), optval);
+			if (connectError)
+				*connectError = optval;
 			goto fail;
 		}
 	}
@@ -1230,6 +1232,7 @@ static void log_connection_address(const char* hostname, struct addrinfo* addr)
 static int freerdp_host_connect(rdpContext* context, const char* hostname, int port, DWORD timeout)
 {
 	int sockfd = -1;
+	INT32 connectError = 0;
 	struct addrinfo* addr = nullptr;
 	struct addrinfo* result = freerdp_tcp_resolve_host(hostname, port, 0);
 
@@ -1258,7 +1261,7 @@ static int freerdp_host_connect(rdpContext* context, const char* hostname, int p
 			log_connection_address(hostname, addr);
 
 			if (!freerdp_tcp_connect_timeout(context, sockfd, addr->ai_addr, addr->ai_addrlen,
-			                                 timeout))
+			                                 timeout, &connectError))
 			{
 				close(sockfd);
 				sockfd = -1;
@@ -1275,6 +1278,12 @@ static int freerdp_host_connect(rdpContext* context, const char* hostname, int p
 	} while (sockfd < 0);
 
 fail:
+	if ((sockfd < 0) && (connectError != 0))
+	{
+		char ebuffer[256] = WINPR_C_ARRAY_INIT;
+		WLog_ERR(TAG, "unable to connect to %s: %s [%" PRId32 "]", hostname,
+		         winpr_strerror(connectError, ebuffer, sizeof(ebuffer)), connectError);
+	}
 	freeaddrinfo(result);
 	return sockfd;
 }


### PR DESCRIPTION
When a TCP connection fails the client only reports a generic `ERRCONNECT_CONNECT_FAILED` with no reason. The errno is already retrieved in `freerdp_tcp_connect_timeout` but logged at `WLOG_DEBUG`, so at the default log level the user cannot tell whether the port was closed, the host was unreachable, and so on.

Thread that errno out of `freerdp_tcp_connect_timeout` and log it once at `WLOG_ERROR` in `freerdp_host_connect`, only after every resolved address has been tried. The per-attempt detail stays at debug level, so a multi-address host does not produce a line per address.

Connecting to a closed port, before:

```
[ERROR][com.freerdp.core] - [get_next_addrinfo]: ERRCONNECT_CONNECT_FAILED [0x00020006]
[ERROR][com.freerdp.core] - [freerdp_tcp_default_connect]: Couldn't get socket ip address
```

after (one line added):

```
[ERROR][com.freerdp.core] - [get_next_addrinfo]: ERRCONNECT_CONNECT_FAILED [0x00020006]
[ERROR][com.freerdp.core] - [freerdp_host_connect]: unable to connect to 127.0.0.1: Connection refused [111]
[ERROR][com.freerdp.core] - [freerdp_tcp_default_connect]: Couldn't get socket ip address
```

Only the single-host path is affected; the `TargetNetAddresses` multi-connect path is unchanged.

Tested by pointing the client at a closed port (refused, reason now shown), a reachable TCP listener (gets past TCP, no false reason logged), and an unreachable host (times out, no errno logged).

refs #5208
