### PR TITLE
[channels,remdesk] validate ctl pdu DataLength against received stream

### DIFF
--- a/channels/remdesk/server/remdesk_main.c
+++ b/channels/remdesk/server/remdesk_main.c
@@ -171,17 +171,23 @@ static UINT remdesk_recv_ctl_remote_control_desktop_pdu(RemdeskServerContext* co
 	size_t cchStringW = 0;
 	REMDESK_CTL_REMOTE_CONTROL_DESKTOP_PDU pdu = WINPR_C_ARRAY_INIT;
 	UINT error = 0;
-	UINT32 msgLength = header->DataLength - 4;
+
+	if (header->DataLength < 4)
+		return ERROR_INVALID_DATA;
+
+	size_t cchMax = header->DataLength - 4;
+	const size_t remaining = Stream_GetRemainingLength(s);
+	if (cchMax > remaining)
+		cchMax = remaining;
+	cchMax /= sizeof(WCHAR);
+
 	const WCHAR* pStringW = Stream_ConstPointer(s);
 	const WCHAR* raConnectionStringW = pStringW;
 
-	while ((msgLength > 0) && pStringW[cchStringW])
-	{
-		msgLength -= 2;
+	while ((cchStringW < cchMax) && pStringW[cchStringW])
 		cchStringW++;
-	}
 
-	if (pStringW[cchStringW] || !cchStringW)
+	if ((cchStringW >= cchMax) || !cchStringW)
 		return ERROR_INVALID_DATA;
 
 	cchStringW++;
@@ -211,32 +217,36 @@ static UINT remdesk_recv_ctl_authenticate_pdu(WINPR_ATTR_UNUSED RemdeskServerCon
 	size_t cchTmpStringW = 0;
 	const WCHAR* expertBlobW = nullptr;
 	REMDESK_CTL_AUTHENTICATE_PDU pdu = WINPR_C_ARRAY_INIT;
-	UINT32 msgLength = header->DataLength - 4;
+
+	if (header->DataLength < 4)
+		return ERROR_INVALID_DATA;
+
+	size_t cchRemaining = header->DataLength - 4;
+	const size_t remaining = Stream_GetRemainingLength(s);
+	if (cchRemaining > remaining)
+		cchRemaining = remaining;
+	cchRemaining /= sizeof(WCHAR);
+
 	const WCHAR* pStringW = Stream_ConstPointer(s);
 	const WCHAR* raConnectionStringW = pStringW;
 
-	while ((msgLength > 0) && pStringW[cchTmpStringW])
-	{
-		msgLength -= 2;
+	while ((cchTmpStringW < cchRemaining) && pStringW[cchTmpStringW])
 		cchTmpStringW++;
-	}
 
-	if (pStringW[cchTmpStringW] || !cchTmpStringW)
+	if ((cchTmpStringW >= cchRemaining) || !cchTmpStringW)
 		return ERROR_INVALID_DATA;
 
 	cchTmpStringW++;
 	const size_t cbRaConnectionStringW = cchTmpStringW * sizeof(WCHAR);
 	pStringW += cchTmpStringW;
 	expertBlobW = pStringW;
+	cchRemaining -= cchTmpStringW;
 
 	size_t cchStringW = 0;
-	while ((msgLength > 0) && pStringW[cchStringW])
-	{
-		msgLength -= 2;
+	while ((cchStringW < cchRemaining) && pStringW[cchStringW])
 		cchStringW++;
-	}
 
-	if (pStringW[cchStringW] || !cchStringW)
+	if ((cchStringW >= cchRemaining) || !cchStringW)
 		return ERROR_INVALID_DATA;
 
 	cchStringW++;
@@ -276,7 +286,10 @@ static UINT remdesk_recv_ctl_verify_password_pdu(RemdeskServerContext* context, 
 	if (header->DataLength < 4)
 		return ERROR_INVALID_PARAMETER;
 
-	const size_t cbExpertBlobW = header->DataLength - 4;
+	size_t cbExpertBlobW = header->DataLength - 4;
+	const size_t remaining = Stream_GetRemainingLength(s);
+	if (cbExpertBlobW > remaining)
+		cbExpertBlobW = remaining;
 
 	pdu.expertBlob = ConvertWCharNToUtf8Alloc(expertBlobW, cbExpertBlobW / sizeof(WCHAR), nullptr);
 	if (!pdu.expertBlob)

--- a/channels/remdesk/server/remdesk_main.c
+++ b/channels/remdesk/server/remdesk_main.c
@@ -172,9 +172,6 @@ static UINT remdesk_recv_ctl_remote_control_desktop_pdu(RemdeskServerContext* co
 	REMDESK_CTL_REMOTE_CONTROL_DESKTOP_PDU pdu = WINPR_C_ARRAY_INIT;
 	UINT error = 0;
 
-	if (header->DataLength < 4)
-		return ERROR_INVALID_DATA;
-
 	size_t cchMax = header->DataLength - 4;
 	const size_t remaining = Stream_GetRemainingLength(s);
 	if (cchMax > remaining)
@@ -217,9 +214,6 @@ static UINT remdesk_recv_ctl_authenticate_pdu(WINPR_ATTR_UNUSED RemdeskServerCon
 	size_t cchTmpStringW = 0;
 	const WCHAR* expertBlobW = nullptr;
 	REMDESK_CTL_AUTHENTICATE_PDU pdu = WINPR_C_ARRAY_INIT;
-
-	if (header->DataLength < 4)
-		return ERROR_INVALID_DATA;
 
 	size_t cchRemaining = header->DataLength - 4;
 	const size_t remaining = Stream_GetRemainingLength(s);
@@ -283,8 +277,6 @@ static UINT remdesk_recv_ctl_verify_password_pdu(RemdeskServerContext* context, 
 		return ERROR_INVALID_DATA;
 
 	const WCHAR* expertBlobW = Stream_ConstPointer(s);
-	if (header->DataLength < 4)
-		return ERROR_INVALID_PARAMETER;
 
 	size_t cbExpertBlobW = header->DataLength - 4;
 	const size_t remaining = Stream_GetRemainingLength(s);
@@ -315,6 +307,9 @@ static UINT remdesk_recv_ctl_pdu(RemdeskServerContext* context, wStream* s,
 	UINT32 msgType = 0;
 
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, 4))
+		return ERROR_INVALID_DATA;
+
+	if (header->DataLength < 4)
 		return ERROR_INVALID_DATA;
 
 	Stream_Read_UINT32(s, msgType); /* msgType (4 bytes) */


### PR DESCRIPTION
The RC_CTL control PDUs on the remdesk server channel carry a DataLength field that remdesk_read_channel_header takes straight off the wire without checking it against the bytes actually received. The three control handlers that parse the trailing UTF-16 strings (remote_control_desktop, authenticate, verify_password) then use DataLength-4 as the scan and conversion bound. Since the stream is only ever sealed to the amount the client actually sent, a client that advertises a larger DataLength than it supplies makes the null-terminator scan walk off the end of the channel buffer, and a DataLength below 4 underflows the bound outright. I noticed it while comparing these handlers against the length checks the other remdesk PDUs already carry. The fix clamps the working length to whatever Stream_GetRemainingLength reports and rewrites the scans as counted loops so the terminator test can no longer read one element past the buffer. I have kept the change inside the three handlers and left the surrounding flow untouched, which should keep it straightforward to review.