### PR TITLE
[codec,planar] range-check before control byte read in plane rle

### DIFF
--- a/libfreerdp/codec/planar.c
+++ b/libfreerdp/codec/planar.c
@@ -398,14 +398,15 @@ static inline INT32 planar_decompress_plane_rle(const BYTE* WINPR_RESTRICT pSrcD
 
 		for (INT32 x = 0; x < (INT32)nWidth;)
 		{
-			const BYTE controlByte = *srcp;
-			srcp++;
-
-			if ((srcp - pSrcData) > SrcSize * 1ll)
+			const size_t cur = (srcp - pSrcData);
+			if (cur + 1 > SrcSize * 1ll)
 			{
 				WLog_ERR(TAG, "error reading input buffer");
 				return -1;
 			}
+
+			const BYTE controlByte = *srcp;
+			srcp++;
 
 			UINT32 nRunLength = PLANAR_CONTROL_BYTE_RUN_LENGTH(controlByte);
 			UINT32 cRawBytes = PLANAR_CONTROL_BYTE_RAW_BYTES(controlByte);


### PR DESCRIPTION
The two RLE plane decoders in `planar.c` are near-identical, but commit 52f1c87 tightened the input range check in `planar_decompress_plane_rle_only` and left the sibling `planar_decompress_plane_rle` untouched. The sibling still reads the control byte through `*srcp` first and only afterwards compares the advanced position against `SrcSize`, so the bounds check happens one byte too late. On a truncated or crafted plane the dereference can touch the byte just past the end of the plane buffer before the function bails out. I noticed it while reading the diff for the range-check fix and checking whether the same shape existed elsewhere. The change here is the same reorder applied in that commit: compute the offset, reject when `cur + 1` would exceed `SrcSize`, then read. It keeps the two decoders consistent and the read strictly inside the validated region; behaviour for well-formed planes is unchanged.