### PR TITLE
[channels,rdpsnd,mac] recover audio after AVAudioEngine config change

### DIFF
--- a/channels/rdpsnd/client/mac/rdpsnd_mac.m
+++ b/channels/rdpsnd/client/mac/rdpsnd_mac.m
@@ -285,21 +285,23 @@ static void rdpsnd_mac_start(rdpsndDevicePlugin *device)
 	{
 		rdpsndMacPlugin *mac = (rdpsndMacPlugin *)device;
 
+		if (!mac->engine.isRunning)
+		{
+			NSError *error;
+			[mac->engine connect:mac->player to:mac->engine.mainMixerNode format:nil];
+			[mac->engine prepare];
+			if (![mac->engine startAndReturnError:&error])
+			{
+				device->Close(device);
+				WLog_ERR(TAG, "Failed to start audio player %s",
+				         [error.localizedDescription UTF8String]);
+				return;
+			}
+			mac->isPlaying = FALSE; /* force [player play] below */
+		}
+
 		if (!mac->isPlaying)
 		{
-			if (!mac->engine.isRunning)
-			{
-				NSError *error;
-
-				if (![mac->engine startAndReturnError:&error])
-				{
-					device->Close(device);
-					WLog_ERR(TAG, "Failed to start audio player %s",
-					         [error.localizedDescription UTF8String]);
-					return;
-				}
-			}
-
 			[mac->player play];
 
 			mac->isPlaying = TRUE;


### PR DESCRIPTION
Closes #12957

## Summary

On macOS, rdpsnd audio output goes silent after the microphone is used in the same session and only recovers on reconnect. The output backend (`rdpsnd_mac.m`) renders through an `AVAudioEngine`; when microphone capture starts, Core Audio reconfigures the audio hardware — most visibly a Bluetooth headset switching from the A2DP output profile to the HFP headset profile — which stops the engine. The backend never restarts it, because the restart logic in `rdpsnd_mac_start()` is gated behind `if (!isPlaying)`, and `isPlaying` stays `TRUE` after the stop. As a result `rdpsnd_mac_play()` keeps scheduling buffers into a stopped engine, producing silence.

## Fix

Move the engine-health check out of the `isPlaying` guard so the engine is reconnected (`format:nil`, to adopt the new hardware format) and restarted on the next audio buffer, then clear `isPlaying` to force the subsequent `[player play]`. This restores playback across the profile switch without a reconnect.

## Testing

Reproduced and verified on macOS 15.7.3 (arm64), FreeRDP 3.27.1, with Bluetooth AirPods as both speaker and microphone:
- Without the change: play remote audio (output 48 kHz), start mic capture (output drops to 24 kHz as the headset switches A2DP→HFP), remote audio is then inaudible until reconnect.
- With the change: audio continues across the same A2DP→HFP transition, no reconnect needed.