### PR TITLE
[channels,rdpdr] fix off-by-one scan length in rdpdr_read_ustring

### DIFF
--- a/channels/rdpdr/server/rdpdr_main.c
+++ b/channels/rdpdr/server/rdpdr_main.c
@@ -222,7 +222,7 @@ static UINT32 g_ClientId = 0;
 
 static const WCHAR* rdpdr_read_ustring(wLog* log, wStream* s, size_t bytelen)
 {
-	const size_t charlen = (bytelen + 1) / sizeof(WCHAR);
+	const size_t charlen = bytelen / sizeof(WCHAR);
 	const WCHAR* str = Stream_ConstPointer(s);
 	if (!Stream_CheckAndLogRequiredLengthWLog(log, s, bytelen))
 		return nullptr;


### PR DESCRIPTION
The rdpdr server reads the name fields of the printer cache and device I/O directory-control PDUs through rdpdr_read_ustring, which is handed the byte length straight from the wire (PnPNameLen, PrinterNameLen, PathLength and friends). To confirm the field is NUL terminated it scans with _wcsnlen over (bytelen + 1) / sizeof(WCHAR) characters, and that rounding up is the issue: for an odd bytelen it asks _wcsnlen to look at one WCHAR more than the bytelen bytes that were just validated, so the high byte of that last character sits one byte past the checked region. The server thread parses each PDU inside the reused 4096 byte receive buffer that Stream_SetLength caps to the bytes actually received, so a request whose trailing name field ends right on the end of a packet that fills the buffer makes that scan read one byte off the end of the channel buffer. I came across it comparing this helper with the cliprdr format-name readers, which size the same scan with rest / sizeof(WCHAR) and carry no such rounding. Dropping the +1 brings it in line with those siblings; the value is identical for the even, well formed lengths and only the malformed odd case stops over-reading. It is a small change but it keeps the bound honest and the helper a little easier to reason about.
