### PR TITLE
[client,sdl] fix mouse and touchpad natural scroll setting being ignored

### DIFF
--- a/client/SDL/SDL3/sdl_touch.cpp
+++ b/client/SDL/SDL3/sdl_touch.cpp
@@ -122,9 +122,8 @@ bool SdlTouch::handleEvent(SdlContext* sdl, const SDL_MouseWheelEvent& ev)
 {
 	WINPR_ASSERT(sdl);
 
-	const BOOL flipped = (ev.direction == SDL_MOUSEWHEEL_FLIPPED);
-	const auto x = static_cast<INT32>(ev.x * (flipped ? -1.0f : 1.0f) * 120.0f);
-	const auto y = static_cast<INT32>(ev.y * (flipped ? -1.0f : 1.0f) * 120.0f);
+	const auto x = static_cast<INT32>(ev.x * 120.0f);
+	const auto y = static_cast<INT32>(ev.y * 120.0f);
 	UINT16 flags = 0;
 
 	if (y != 0)

--- a/client/SDL/SDL3/sdl_touch.cpp
+++ b/client/SDL/SDL3/sdl_touch.cpp
@@ -21,6 +21,7 @@
 
 #include "sdl_touch.hpp"
 #include "sdl_context.hpp"
+#include "sdl_prefs.hpp"
 
 #include <winpr/wtypes.h>
 #include <winpr/assert.h>
@@ -122,8 +123,10 @@ bool SdlTouch::handleEvent(SdlContext* sdl, const SDL_MouseWheelEvent& ev)
 {
 	WINPR_ASSERT(sdl);
 
-	const auto x = static_cast<INT32>(ev.x * 120.0f);
-	const auto y = static_cast<INT32>(ev.y * 120.0f);
+	const bool flipped = 
+		(ev.direction == SDL_MOUSEWHEEL_FLIPPED) && !SdlPref::instance()->get_bool("UseLocalMouseScrollDirection");
+	const auto x = static_cast<INT32>(ev.x * (flipped ? -1.0f : 1.0f) * 120.0f);
+	const auto y = static_cast<INT32>(ev.y * (flipped ? -1.0f : 1.0f) * 120.0f);
 	UINT16 flags = 0;
 
 	if (y != 0)

--- a/client/SDL/SDL3/sdl_touch.cpp
+++ b/client/SDL/SDL3/sdl_touch.cpp
@@ -123,8 +123,8 @@ bool SdlTouch::handleEvent(SdlContext* sdl, const SDL_MouseWheelEvent& ev)
 {
 	WINPR_ASSERT(sdl);
 
-	const bool flipped = 
-		(ev.direction == SDL_MOUSEWHEEL_FLIPPED) && !SdlPref::instance()->get_bool("UseLocalMouseScrollDirection");
+	const bool flipped = (ev.direction == SDL_MOUSEWHEEL_FLIPPED) &&
+	                     !SdlPref::instance()->get_bool("UseLocalMouseScrollDirection");
 	const auto x = static_cast<INT32>(ev.x * (flipped ? -1.0f : 1.0f) * 120.0f);
 	const auto y = static_cast<INT32>(ev.y * (flipped ? -1.0f : 1.0f) * 120.0f);
 	UINT16 flags = 0;


### PR DESCRIPTION
Official documentation for the SDL_MouseWheelEvent at https://wiki.libsdl.org/SDL3/SDL_MouseWheelEvent says this about `direction`:

> Set to one of the SDL_MOUSEWHEEL_* defines. When FLIPPED the values in X and Y will be opposite. Multiply by -1 to change them back


This clearly implies that the x and y values do not need to be sign-flipped for `direction == SDL_MOUSEWHEEL_FLIPPED`, but they are.

As a result, the "natural scroll" setting in Gnome 50 on Wayland is effectively ignored by FreeRDP, for both touchpad and mouse. I have not tested other SDL backends, but since the logic is universal across SDL, the problem should manifest for all of them.
