### PR TITLE
[winpr,file] bound '?' wildcard match to file name length

### DIFF
--- a/winpr/libwinpr/file/pattern.c
+++ b/winpr/libwinpr/file/pattern.c
@@ -146,8 +146,13 @@ static BOOL FilePatternMatchSubExpressionA(LPCSTR lpFileName, size_t cchFileName
 
 		/*
 		 * State 0: match 'X'
+		 *
+		 * '?' consumes exactly one character at position cchX, so the file
+		 * name must hold at least cchX + 1 characters. Without this the
+		 * cchY != 0 branch below reads &lpFileName[cchX + 1], one past the
+		 * terminator, when cchFileName == cchX.
 		 */
-		if (cchFileName < cchX)
+		if (cchFileName < cchX + 1)
 			return FALSE;
 
 		if (_strnicmp(lpFileName, lpX, cchX) != 0)
@@ -174,9 +179,6 @@ static BOOL FilePatternMatchSubExpressionA(LPCSTR lpFileName, size_t cchFileName
 		}
 		else
 		{
-			if ((cchX + 1) > cchFileName)
-				return FALSE;
-
 			lpMatch = &lpFileName[cchX + 1];
 		}
 

--- a/winpr/libwinpr/file/test/TestFilePatternMatch.c
+++ b/winpr/libwinpr/file/test/TestFilePatternMatch.c
@@ -178,5 +178,19 @@ int TestFilePatternMatch(int argc, char* argv[])
 		return -1;
 	}
 
+	/* '?' must not match past the end of the file name.
+	 * The file name "X" is one character; the byte after its terminator
+	 * is set to 'Y' so that an out-of-bounds read in the X?Y branch would
+	 * wrongly report a match. */
+	{
+		const char shortName[] = { 'X', '\0', 'Y', '\0' };
+
+		if (FilePatternMatchA(shortName, "X?Y"))
+		{
+			printf("FilePatternMatchA error: FileName: %s Pattern: %s\n", "X", "X?Y");
+			return -1;
+		}
+	}
+
 	return 0;
 }


### PR DESCRIPTION
**Out-of-bounds read in the '?' wildcard branch**

The problem is in `FilePatternMatchSubExpressionA`, which only rejected a file name shorter than the literal prefix (`cchFileName < cchX`). The cause is that `'?'` consumes one character at position `cchX`, so when the name length equals the prefix and the pattern has a non-empty tail, the `cchY != 0` path does `strchr(&lpFileName[cchX + 1], *lpY)` one byte past the terminator; the `cchY == 0` path already guarded this, the other did not. The fix tightens the entry check so the `'?'` always has a character to consume, which keeps the search inside the name, and removes the now redundant inner check.

This is reachable through drive (rdpdr) redirection: a server supplied directory search pattern flows into `FindFirstFileW` and the POSIX `FindNextFileA`, which calls `FilePatternMatchA(d_name, pattern)` for every local entry, so a pattern whose prefix length matches a real file name reads past that entry's `d_name` buffer. There is no wide-char sibling, the drive channel converts to UTF-8 first.

Test: `TestFilePatternMatch` gains a case asserting `"X"` does not match `"X?Y"`; under ASAN it reports a heap read past the name before the change and passes after.