### PR TITLE
[channels,urbdrc] bound msusb descriptor reads to received length

### DIFF
--- a/channels/urbdrc/common/CMakeLists.txt
+++ b/channels/urbdrc/common/CMakeLists.txt
@@ -23,3 +23,7 @@ set_property(TARGET urbdrc-common PROPERTY FOLDER "Channels/${CHANNEL_NAME}/Comm
 
 freerdp_client_pc_add_library_private(urbdrc-common)
 channel_install(urbdrc-common ${FREERDP_ADDIN_PATH} "FreeRDPTargets")
+
+if(BUILD_TESTING_INTERNAL OR BUILD_TESTING)
+  add_subdirectory(test)
+endif()

--- a/channels/urbdrc/common/msusb.c
+++ b/channels/urbdrc/common/msusb.c
@@ -60,7 +60,7 @@ static MSUSB_PIPE_DESCRIPTOR** msusb_mspipes_read(wStream* s, UINT32 NumberOfPip
 {
 	MSUSB_PIPE_DESCRIPTOR** MsPipes = nullptr;
 
-	if (!Stream_CheckAndLogRequiredCapacityOfSize(TAG, (s), NumberOfPipes, 12ull))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, (s), NumberOfPipes, 12ull))
 		return nullptr;
 
 	MsPipes = (MSUSB_PIPE_DESCRIPTOR**)calloc(NumberOfPipes, sizeof(MSUSB_PIPE_DESCRIPTOR*));
@@ -144,7 +144,7 @@ BOOL msusb_msinterface_replace(MSUSB_CONFIG_DESCRIPTOR* MsConfig, BYTE Interface
 
 MSUSB_INTERFACE_DESCRIPTOR* msusb_msinterface_read(wStream* s)
 {
-	if (!Stream_CheckAndLogRequiredCapacity(TAG, (s), 12))
+	if (!Stream_CheckAndLogRequiredLength(TAG, (s), 12))
 		return nullptr;
 
 	MSUSB_INTERFACE_DESCRIPTOR* MsInterface = msusb_msinterface_new();
@@ -307,7 +307,7 @@ MSUSB_CONFIG_DESCRIPTOR* msusb_msconfig_read(wStream* s, UINT32 NumInterfaces)
 	BYTE lenConfiguration = 0;
 	BYTE typeConfiguration = 0;
 
-	if (!Stream_CheckAndLogRequiredCapacityOfSize(TAG, (s), 3ULL + NumInterfaces, 2ULL))
+	if (!Stream_CheckAndLogRequiredLengthOfSize(TAG, (s), 3ULL + NumInterfaces, 2ULL))
 		return nullptr;
 
 	MsConfig = msusb_msconfig_new();
@@ -318,6 +318,12 @@ MSUSB_CONFIG_DESCRIPTOR* msusb_msconfig_read(wStream* s, UINT32 NumInterfaces)
 	MsConfig->MsInterfaces = msusb_msinterface_read_list(s, NumInterfaces);
 
 	if (!MsConfig->MsInterfaces)
+		goto fail;
+
+	/* Record the count now so the cleanup path frees every interface descriptor. */
+	MsConfig->NumInterfaces = NumInterfaces;
+
+	if (!Stream_CheckAndLogRequiredLength(TAG, (s), 6))
 		goto fail;
 
 	Stream_Read_UINT8(s, lenConfiguration);
@@ -333,7 +339,6 @@ MSUSB_CONFIG_DESCRIPTOR* msusb_msconfig_read(wStream* s, UINT32 NumInterfaces)
 	Stream_Read_UINT16(s, MsConfig->wTotalLength);
 	Stream_Seek(s, 1);
 	Stream_Read_UINT8(s, MsConfig->bConfigurationValue);
-	MsConfig->NumInterfaces = NumInterfaces;
 	return MsConfig;
 fail:
 	msusb_msconfig_free(MsConfig);

--- a/channels/urbdrc/common/test/CMakeLists.txt
+++ b/channels/urbdrc/common/test/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(MODULE_NAME "TestUrbdrcCommon")
+set(MODULE_PREFIX "TEST_URBDRC_COMMON")
+
+disable_warnings_for_directory(${CMAKE_CURRENT_BINARY_DIR})
+
+set(${MODULE_PREFIX}_DRIVER ${MODULE_NAME}.c)
+
+set(${MODULE_PREFIX}_TESTS TestMsUsb.c)
+
+create_test_sourcelist(${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_DRIVER} ${${MODULE_PREFIX}_TESTS})
+
+add_executable(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
+
+target_link_libraries(${MODULE_NAME} winpr urbdrc-common)
+
+set_target_properties(${MODULE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${TESTING_OUTPUT_DIRECTORY}")
+
+foreach(test ${${MODULE_PREFIX}_TESTS})
+  get_filename_component(TestName ${test} NAME_WE)
+  add_test(${TestName} ${TESTING_OUTPUT_DIRECTORY}/${MODULE_NAME} ${TestName})
+endforeach()
+
+set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "Channels/URBDRC/Test")

--- a/channels/urbdrc/common/test/TestMsUsb.c
+++ b/channels/urbdrc/common/test/TestMsUsb.c
@@ -1,0 +1,125 @@
+#include <winpr/crt.h>
+#include <winpr/stream.h>
+
+#include <msusb.h>
+
+/* One MSUSB interface descriptor with NumberOfPipes == 0 (12 bytes) followed by
+ * the 6 byte configuration descriptor trailer that msusb_msconfig_read reads. */
+static const BYTE config_one_iface[] = {
+	/* interface[0] */
+	0x12, 0x00,             /* Length */
+	0x00, 0x00,             /* NumberOfPipesExpected */
+	0x00,                   /* InterfaceNumber */
+	0x00,                   /* AlternateSetting */
+	0x00, 0x00,             /* padding */
+	0x00, 0x00, 0x00, 0x00, /* NumberOfPipes = 0 */
+	/* configuration descriptor trailer */
+	0x09,       /* lenConfiguration */
+	0x02,       /* typeConfiguration */
+	0xef, 0xbe, /* wTotalLength = 0xBEEF */
+	0x00,       /* padding */
+	0x42        /* bConfigurationValue */
+};
+
+static int test_full_config(void)
+{
+	wStream sbuffer = { 0 };
+	wStream* s = Stream_StaticConstInit(&sbuffer, config_one_iface, sizeof(config_one_iface));
+
+	MSUSB_CONFIG_DESCRIPTOR* cfg = msusb_msconfig_read(s, 1);
+	if (!cfg)
+	{
+		(void)fprintf(stderr, "msusb_msconfig_read rejected a complete descriptor\n");
+		return -1;
+	}
+
+	int rc = 0;
+	if ((cfg->wTotalLength != 0xBEEF) || (cfg->bConfigurationValue != 0x42) ||
+	    (cfg->NumInterfaces != 1))
+	{
+		(void)fprintf(stderr, "msusb_msconfig_read parsed wrong values\n");
+		rc = -1;
+	}
+	msusb_msconfig_free(cfg);
+	return rc;
+}
+
+/* The descriptor data ends right after the interface list: the 6 byte
+ * configuration trailer is missing. The reader must not walk past the end of
+ * the received data. */
+static int test_truncated_trailer(void)
+{
+	wStream sbuffer = { 0 };
+	wStream* s = Stream_StaticConstInit(&sbuffer, config_one_iface, 12);
+
+	MSUSB_CONFIG_DESCRIPTOR* cfg = msusb_msconfig_read(s, 1);
+	if (cfg)
+	{
+		(void)fprintf(stderr, "msusb_msconfig_read accepted a truncated trailer\n");
+		msusb_msconfig_free(cfg);
+		return -1;
+	}
+	return 0;
+}
+
+/* Capacity larger than the sealed length must not let the reader consume the
+ * unused tail of the (recycled) buffer. */
+static int test_capacity_exceeds_length(void)
+{
+	BYTE buffer[64] = { 0 };
+	CopyMemory(buffer, config_one_iface, sizeof(config_one_iface));
+
+	wStream sbuffer = { 0 };
+	wStream* s = Stream_StaticInit(&sbuffer, buffer, sizeof(buffer));
+	if (!Stream_SetLength(s, 12))
+		return -1;
+
+	MSUSB_CONFIG_DESCRIPTOR* cfg = msusb_msconfig_read(s, 1);
+	if (cfg)
+	{
+		(void)fprintf(stderr, "msusb_msconfig_read read past the sealed length\n");
+		msusb_msconfig_free(cfg);
+		return -1;
+	}
+	return 0;
+}
+
+/* msusb_msinterface_read claims NumberOfPipes pipes whose data is not present. */
+static int test_interface_truncated_pipes(void)
+{
+	const BYTE iface[] = {
+		0x10, 0x00,            /* Length */
+		0x01, 0x00,            /* NumberOfPipesExpected */
+		0x00,                  /* InterfaceNumber */
+		0x00,                  /* AlternateSetting */
+		0x00, 0x00,            /* padding */
+		0x04, 0x00, 0x00, 0x00 /* NumberOfPipes = 4, but no pipe data follows */
+	};
+	wStream sbuffer = { 0 };
+	wStream* s = Stream_StaticConstInit(&sbuffer, iface, sizeof(iface));
+
+	MSUSB_INTERFACE_DESCRIPTOR* desc = msusb_msinterface_read(s);
+	if (desc)
+	{
+		(void)fprintf(stderr, "msusb_msinterface_read accepted missing pipe data\n");
+		msusb_msinterface_free(desc);
+		return -1;
+	}
+	return 0;
+}
+
+int TestMsUsb(int argc, char* argv[])
+{
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+
+	if (test_full_config() != 0)
+		return -1;
+	if (test_truncated_trailer() != 0)
+		return -1;
+	if (test_capacity_exceeds_length() != 0)
+		return -1;
+	if (test_interface_truncated_pipes() != 0)
+		return -1;
+	return 0;
+}


### PR DESCRIPTION
The USB redirection channel parses the MS-RDPEUSB configuration, interface and pipe descriptors out of a SELECT_CONFIGURATION or SELECT_INTERFACE request sent by the server. The three readers in msusb.c sized their reads with Stream_CheckAndLogRequiredCapacity, which reports the room left in the underlying allocation rather than the amount of data actually received; when the channel buffer comes from the stream pool its capacity is usually larger than the sealed length, so a server that declares more interfaces or pipes than it sent walks the reader off the end of the message and into stale pool bytes that are then echoed back in the result PDU. msusb_msconfig_read is worse, because after the interface list it reads the six byte configuration trailer with no length check at all; the only guard is the initial (3 + NumInterfaces) * 2 test, well below the 12 * NumInterfaces + 6 bytes it goes on to consume, so a single interface followed by a truncated trailer already reads past the buffer (caught by the stream assertions in debug builds, a heap over-read once they are compiled out). I noticed it while checking why the URB request handlers validate with required-length but the descriptor helpers they call do not. The fix moves the three helpers to Stream_CheckAndLogRequiredLength and adds the missing trailer check, which leaves valid descriptors working and rejects the truncated ones, and should keep the parsing easier to reason about going forward.

Testing: a small TestMsUsb case under channels/urbdrc/common/test covers a complete descriptor plus the three malformed shapes; run it with `ctest -R TestMsUsb`.
