### PR TITLE
[channels,drive] reject trailing '..' in contains_dotdot

### DIFF
--- a/channels/drive/client/drive_file.c
+++ b/channels/drive/client/drive_file.c
@@ -110,7 +110,7 @@ static BOOL contains_dotdot(const WCHAR* path, size_t base_length, size_t path_l
 		{
 			if (tst + 2 < path + path_length)
 			{
-				if ((tst[2] == '/') || (tst[2] == '\\'))
+				if ((tst[2] == '/') || (tst[2] == '\\') || (tst[2] == '\0'))
 					return TRUE;
 			}
 			else


### PR DESCRIPTION
**Trailing `..` slips past contains_dotdot**

The sanitiser only rejects a `..` when the next character is a separator, or when the `..` ends `path_length`. Create and rename pass `PathLength / sizeof(WCHAR)`, and [MS-RDPEFS] counts the terminating NUL in `PathLength`, so `path_length` is one wchar longer than the string and the lookahead for a final `..` lands on that NUL rather than one past the end. The sequence is then allowed, so a server can send a create/rename path ending in `\..` and reach the parent of the shared folder. Treating `\0` as a component terminator in the lookahead rejects a trailing `..` the same way as `../`; a real name ending in `..` is untouched because it is not separator-prefixed.

Testing: with the change, a path whose final component is `..` (e.g. `\..`) is rejected by `contains_dotdot`, while normal paths and names like `foo..` still pass. Drive client builds clean and clang-format reports no changes.