### PR TITLE
[channels] bound dynamic channel message header to received length

### DIFF
--- a/channels/audin/client/audin_main.c
+++ b/channels/audin/client/audin_main.c
@@ -578,7 +578,7 @@ static UINT audin_on_data_received(IWTSVirtualChannelCallback* pChannelCallback,
 	if (!audin)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!Stream_CheckAndLogRequiredCapacity(TAG, data, 1))
+	if (!Stream_CheckAndLogRequiredLength(TAG, data, 1))
 		return ERROR_NO_DATA;
 
 	Stream_Read_UINT8(data, MessageId);

--- a/channels/rdpecam/client/camera_device_enum_main.c
+++ b/channels/rdpecam/client/camera_device_enum_main.c
@@ -225,7 +225,7 @@ static UINT ecam_on_data_received(IWTSVirtualChannelCallback* pChannelCallback, 
 	if (!ecam)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!Stream_CheckAndLogRequiredCapacity(TAG, data, CAM_HEADER_SIZE))
+	if (!Stream_CheckAndLogRequiredLength(TAG, data, CAM_HEADER_SIZE))
 		return ERROR_NO_DATA;
 
 	Stream_Read_UINT8(data, version);

--- a/channels/rdpecam/client/camera_device_main.c
+++ b/channels/rdpecam/client/camera_device_main.c
@@ -741,7 +741,7 @@ static UINT ecam_dev_on_data_received(IWTSVirtualChannelCallback* pChannelCallba
 	if (!dev)
 		return ERROR_INTERNAL_ERROR;
 
-	if (!Stream_CheckAndLogRequiredCapacity(TAG, data, CAM_HEADER_SIZE))
+	if (!Stream_CheckAndLogRequiredLength(TAG, data, CAM_HEADER_SIZE))
 		return ERROR_NO_DATA;
 
 	Stream_Read_UINT8(data, version);


### PR DESCRIPTION
Dynamic channel client message header check, e.g. camera_device_main.c:

    if (!Stream_CheckAndLogRequiredCapacity(TAG, data, CAM_HEADER_SIZE)) /* allocation */
        return ERROR_NO_DATA;
    Stream_Read_UINT8(data, version);   /* received data */
    Stream_Read_UINT8(data, messageId);

`Stream_CheckAndLogRequiredCapacity` measures the stream allocation, not the bytes actually received. drdynvc reassembles a message into a StreamPool buffer and seals it with `Stream_SealLength`, so the length is the received size while the capacity stays at the (usually larger) pool allocation. A server sending a `DATA_FIRST` that declares a total length below the header size then satisfies the capacity check with a short buffer, and the header reads step one or two bytes past the received PDU into stale pool memory.

Three client entry points have this: `ecam_dev_on_data_received` (camera_device_main.c) and `ecam_on_data_received` (camera_device_enum_main.c) read the 2 byte CAM_SHARED_MSG_HEADER, and `audin_on_data_received` (audin_main.c) reads the 1 byte SNDIN message id. The rdpecam server handler already uses `Stream_CheckAndLogRequiredLength`, so this switches the three client callbacks to the length variant to match. Behaviour for well formed PDUs is unchanged.

Tested: builds clean (audin-client compiles, both rdpecam client files pass -fsyntax-only against the tree), clang-format clean.