### PR TITLE
[winpr,string] fix winpr_strnstr needle length (gateway SIGSEGV)

### DIFF
--- a/winpr/libwinpr/crt/string.c
+++ b/winpr/libwinpr/crt/string.c
@@ -848,10 +848,20 @@ char* winpr_strnstr(char* haystack, const char* needle, size_t hlen)
 	WINPR_ASSERT(haystack || (hlen == 0));
 	WINPR_ASSERT(needle);
 
+	/* Keep the contract identical on the native and fallback paths: nothing to
+	 * find in an empty window, and SIZE_MAX would overflow the hlen + 1 bound
+	 * below. */
+	if (hlen == 0)
+		return nullptr;
+	if (hlen == SIZE_MAX)
+		return nullptr;
+
 #if defined(WINPR_HAVE_STRNSTR)
 	return strnstr(haystack, needle, hlen);
 #else
-	const size_t needle_len = strnlen(needle, hlen);
+	/* Bound the needle scan to the haystack: needle_len becomes hlen + 1 when
+	 * the needle is longer than hlen, which the check below rejects. */
+	const size_t needle_len = strnlen(needle, hlen + 1);
 
 	if (0 == needle_len)
 		return haystack;

--- a/winpr/libwinpr/crt/test/TestString.c
+++ b/winpr/libwinpr/crt/test/TestString.c
@@ -104,6 +104,55 @@ fail:
 	return rc;
 }
 
+static BOOL test_winpr_strnstr(void)
+{
+	struct strnstr_test
+	{
+		const char* haystack;
+		const char* needle;
+		size_t hlen;
+		int expected; /* offset of the match, or -1 when NULL is expected */
+	};
+	const struct strnstr_test tests[] = {
+		/* regression: a needle longer than hlen must never match on a prefix.
+		 * winpr_strnstr used to clamp the needle length to hlen, so these
+		 * returned the haystack instead of NULL (see gateway http_response_recv
+		 * SIGSEGV). */
+		{ "ab", "\r\n", 0, -1 },
+		{ "x!", "xy", 1, -1 },
+		{ "abc", "abc", 2, -1 },
+		/* an empty needle returns the haystack */
+		{ "abc", "", 5, 0 },
+		/* basic matches */
+		{ "a\r\nb", "\r\n", 4, 1 },
+		{ "xxab", "ab", 4, 2 },
+		{ "xxxx", "ab", 4, -1 },
+		{ "abc", "abc", 3, 0 },
+		/* hlen == 0 finds nothing */
+		{ "abc", "a", 0, -1 },
+		/* hlen == SIZE_MAX is rejected instead of scanning out of bounds */
+		{ "abc", "a", SIZE_MAX, -1 },
+	};
+
+	for (size_t i = 0; i < ARRAYSIZE(tests); i++)
+	{
+		const struct strnstr_test* t = &tests[i];
+		char haystack[32] = { 0 };
+		strncpy(haystack, t->haystack, sizeof(haystack) - 1);
+
+		char* res = winpr_strnstr(haystack, t->needle, t->hlen);
+		char* exp = (t->expected < 0) ? nullptr : haystack + t->expected;
+		if (res != exp)
+		{
+			printf("winpr_strnstr error: case %" PRIuz " (\"%s\", \"%s\", %" PRIuz "): "
+			       "actual %p, expected %p\n",
+			       i, t->haystack, t->needle, t->hlen, (void*)res, (void*)exp);
+			return FALSE;
+		}
+	}
+	return TRUE;
+}
+
 int TestString(int argc, char* argv[])
 {
 	const WCHAR* p = nullptr;
@@ -118,6 +167,9 @@ int TestString(int argc, char* argv[])
 		return -1;
 
 	if (!test_url_escape())
+		return -1;
+
+	if (!test_winpr_strnstr())
 		return -1;
 
 	/* _wcslen */


### PR DESCRIPTION
### Summary

`winpr_strnstr` (added in 3521712b6) uses `strnlen(needle, hlen)` to measure the needle. That clamps the needle length to the haystack window, so:

- the `if (hlen < needle_len) return nullptr;` guard is unreachable (`needle_len` can never exceed `hlen`), and
- a partial needle matches on its prefix; at `hlen == 0` the function returns `haystack` instead of `NULL`.

### Impact

`http_response_recv()` in `libfreerdp/core/gateway/http.c` calls `winpr_strnstr` in a loop with a shrinking `hlen`:

```c
winpr_strnstr(line, "\r\n", payloadOffset - (line - buffer) - 2)
```

When `line` reaches `buffer + payloadOffset - 2`, `hlen == 0`. Correct behavior returns `NULL` and ends the loop. The bug returns a false match, `line += 2` runs past the buffer, and the next iteration's `hlen` underflows to `~SIZE_MAX`, so `winpr_strnstr` scans far out of bounds -> SIGSEGV.

Reproduced connecting through an RD Gateway on a glibc system (fallback path, `WINPR_HAVE_STRNSTR` unset): the crash fires right after 2FA. Every gateway HTTP response drives the loop to `hlen == 0`, so it is deterministic (100%), not a race. The HTTP response is server-controlled, so this is remotely reachable (crash / OOB read, DoS-class).

Resolved backtrace:

```
winpr_strnstr        winpr/libwinpr/crt/string.c
http_response_recv   libfreerdp/core/gateway/http.c:1327
rdp_client_connect
freerdp_connect
```

Introduced in 3521712b6 (2026-06-30); master only, no release affected.

### Reproduction

Unit-level (deterministic, no network):

```c
winpr_strnstr("ab", "\r\n", 0);  /* returned "ab", must be NULL */
winpr_strnstr("x!", "xy", 1);    /* returned "x!", must be NULL */
```

### Fix

Measure the needle with `strlen(needle)`. This restores the `hlen < needle_len` guard, so the loop terminates at `hlen == 0` with no underflow. Only the fallback path (`!WINPR_HAVE_STRNSTR`, e.g. glibc) was affected; the native `strnstr` path is unchanged.

Adds `test_winpr_strnstr()` to `TestString.c` covering the regression cases and basic matches.
