### PR TITLE
[codec,dsp] ensure out capacity in opus encode

### DIFF
--- a/libfreerdp/codec/dsp.c
+++ b/libfreerdp/codec/dsp.c
@@ -704,7 +704,7 @@ static BOOL freerdp_dsp_encode_opus(FREERDP_DSP_CONTEXT* WINPR_RESTRICT context,
 
 	/* Max packet duration is 120ms (5760 at 48KHz) */
 	const size_t max_size = OPUS_MAX_FRAMES * context->common.format.nChannels * sizeof(int16_t);
-	if (!Stream_EnsureRemainingCapacity(context->common.buffer, max_size))
+	if (!Stream_EnsureRemainingCapacity(out, max_size))
 		return FALSE;
 
 	const size_t src_frames = size / sizeof(opus_int16) / context->common.format.nChannels;


### PR DESCRIPTION
**Wrong stream in the opus encode capacity check**

`freerdp_dsp_encode_opus` reserves `max_size` bytes on `context->common.buffer`, but `opus_encode` is handed `Stream_Pointer(out)` together with `max_size` as its output limit, so the destination stream `out` is never grown. When `out` has less remaining capacity than the packet the encoder emits, the write runs past its buffer.

Cause is the reservation targeting the scratch buffer instead of `out`. This is the encode side of the decode fix in 0ed1f95; the other encoders (adpcm, gsm610, mp3, faac) already grow `out`, so opus was the odd one out. Reachable once a peer negotiates `WAVE_FORMAT_OPUS`, where the rdpsnd server and audin client encode into a reused channel stream.

Fix reserves the space on `out`, matching the decode path a few lines above.