### PR TITLE
[winpr,string] match winpr_strnstr fallback to native strnstr

### DIFF
--- a/winpr/libwinpr/crt/string.c
+++ b/winpr/libwinpr/crt/string.c
@@ -848,33 +848,20 @@ char* winpr_strnstr(char* haystack, const char* needle, size_t hlen)
 	WINPR_ASSERT(haystack || (hlen == 0));
 	WINPR_ASSERT(needle);
 
-	/* Keep the contract identical on the native and fallback paths: nothing to
-	 * find in an empty window, and SIZE_MAX would overflow the hlen + 1 bound
-	 * below. */
-	if (hlen == 0)
-		return nullptr;
-	if (hlen == SIZE_MAX)
-		return nullptr;
-
 #if defined(WINPR_HAVE_STRNSTR)
 	return strnstr(haystack, needle, hlen);
 #else
-	/* Bound the needle scan to the haystack: needle_len becomes hlen + 1 when
-	 * the needle is longer than hlen, which the check below rejects. */
-	const size_t needle_len = strnlen(needle, hlen + 1);
+	/* Match native strnstr semantics: search at most hlen characters and stop at
+	 * the haystack NUL terminator, whichever comes first. */
+	const size_t needle_len = strlen(needle);
 
 	if (0 == needle_len)
 		return haystack;
 
-	if (hlen < needle_len)
-		return nullptr;
-
-	for (size_t i = 0; i <= hlen - needle_len; i++)
+	for (; (*haystack != '\0') && (hlen >= needle_len); haystack++, hlen--)
 	{
 		if ((haystack[0] == needle[0]) && (0 == strncmp(haystack, needle, needle_len)))
 			return haystack;
-
-		haystack++;
 	}
 	return nullptr;
 #endif

--- a/winpr/libwinpr/crt/test/TestString.c
+++ b/winpr/libwinpr/crt/test/TestString.c
@@ -130,8 +130,8 @@ static BOOL test_winpr_strnstr(void)
 		{ "abc", "abc", 3, 0 },
 		/* hlen == 0 finds nothing */
 		{ "abc", "a", 0, -1 },
-		/* hlen == SIZE_MAX is rejected instead of scanning out of bounds */
-		{ "abc", "a", SIZE_MAX, -1 },
+		/* an hlen larger than the string just searches the whole string */
+		{ "abc", "a", SIZE_MAX, 0 },
 	};
 
 	for (size_t i = 0; i < ARRAYSIZE(tests); i++)
@@ -150,6 +150,16 @@ static BOOL test_winpr_strnstr(void)
 			return FALSE;
 		}
 	}
+
+	/* An embedded NUL terminates the search, matching native strnstr: "cd" sits
+	 * past the NUL, so it must not be found even though hlen spans it. */
+	char embedded[8] = { 'a', 'b', '\0', 'c', 'd', '\0', '\0', '\0' };
+	if (winpr_strnstr(embedded, "cd", 5) != nullptr)
+	{
+		printf("winpr_strnstr error: matched past an embedded NUL terminator\n");
+		return FALSE;
+	}
+
 	return TRUE;
 }
 


### PR DESCRIPTION
### Summary

Follow-up to #12995 (merged as 444bcbba). That PR fixed the RD Gateway
crash, but left a behavioral gap between the two code paths in
winpr_strnstr: when hlen is larger than the actual string, the fallback
kept scanning up to hlen bytes past an embedded NUL, while the native
strnstr path stops at the NUL. The fallback also needed hlen == 0 /
hlen == SIZE_MAX guards to keep the strnlen(needle, hlen + 1) bound from
overflowing.

Demonstration of the divergence on the merged code:

    winpr_strnstr("ab\0cd", "cd", 5)  // fallback: found at offset 3
                                      // native:   NULL (stops at NUL)

### Change

Rewrite the fallback to mirror native strnstr: measure the needle with
strlen and walk the haystack until the NUL terminator or hlen is
reached, whichever comes first. Both paths now behave identically for
every input, the special-case guards go away, and there is no hlen + 1
overflow to guard against.

This is a correctness/consistency fix, not a crash fix - the gateway
http_response_recv() loop is bounded by hlen and still terminates, so
the original SIGSEGV cannot recur.

### Tests

TestString.c: aligned the SIZE_MAX case with native semantics (an
over-long hlen just searches the whole string) and added an embedded-NUL
case that fails on the old fallback and passes on both paths now.
