### PR TITLE
[channels,rdpecam] fix DeviceAdded notification for non-ASCII device names

### DIFF
--- a/channels/rdpecam/client/camera_device_enum_main.c
+++ b/channels/rdpecam/client/camera_device_enum_main.c
@@ -19,6 +19,7 @@
 
 #include <winpr/assert.h>
 #include <winpr/cast.h>
+#include <winpr/string.h>
 
 #include "camera.h"
 
@@ -123,8 +124,11 @@ static UINT ecam_send_device_added_notification(CameraPlugin* ecam,
 	Stream_Write_UINT8(s, WINPR_ASSERTING_INT_CAST(uint8_t, ecam->version));
 	Stream_Write_UINT8(s, WINPR_ASSERTING_INT_CAST(uint8_t, msg));
 
-	size_t devNameLen = strlen(deviceName);
-	if (Stream_Write_UTF16_String_From_UTF8(s, devNameLen + 1, deviceName, devNameLen, TRUE) < 0)
+	const size_t devNameLen = strlen(deviceName);
+	const SSIZE_T devNameWLen = ConvertUtf8ToWChar(deviceName, nullptr, 0);
+	if ((devNameWLen < 0) ||
+	    Stream_Write_UTF16_String_From_UTF8(s, (size_t)devNameWLen + 1, deviceName, devNameLen,
+	                                        TRUE) < 0)
 	{
 		Stream_Free(s, TRUE);
 		return ERROR_INTERNAL_ERROR;


### PR DESCRIPTION
I had problems with the webcam Microsoft LifeCam HD 5000 not working on rdpecam and wasted a lot of time in many tests and debugging (because there was issue also in other cases out of freerdp which made me assume otherwise and do useless tests), finally found the problem in the webcam name containing non-ascii characters, made this patch with claude and tested it on the rpi4 arm64 [adding it to the current trixie-backports version](https://github.com/M2Rbiz/freerdp3-pkg/commits/m2r-pkg/) and now also the ms webcam works.
I think fix the problem also for other microsoft webcam with same issue and other if name containing non-ascii characters.

Thanks a lot to the people who implement rdpecam and helped to fix, test and improve it, it's very helpful and was really needed.