### PR TITLE
[client,sdl] Handle requested clipboard MIME formats

### DIFF
--- a/client/SDL/SDL3/sdl_clip.cpp
+++ b/client/SDL/SDL3/sdl_clip.cpp
@@ -668,7 +668,16 @@ std::shared_ptr<BYTE> sdlClip::ReceiveFormatDataRequestHandle(
 				}
 			}
 			else
-				return data;
+			{
+				const char* formatName = ClipboardGetFormatName(clipboard->_system, formatId);
+				if (formatName && SDL_HasClipboardData(formatName))
+				{
+					localFormatId = ClipboardGetFormatId(clipboard->_system, formatName);
+					mime = formatName;
+				}
+				else
+					return data;
+			}
 	}
 
 	{


### PR DESCRIPTION
## What

When a remote peer requests a registered clipboard format whose name is also an SDL MIME type, such as `image/png`, map that request directly to `SDL_GetClipboardData(formatName)`.

## Why

The SDL client already advertises image MIME formats from local clipboard events. However, `ReceiveFormatDataRequestHandle` only mapped a few well-known formats such as `CF_DIB`, `CF_TIFF`, `HTML Format`, and file lists. If the server requested the registered MIME format itself, the request returned no data even when SDL reported that the MIME was available.

This is visible on macOS when the local clipboard contains `image/png`: SDL can report `SDL_HasClipboardData("image/png") == true`, but a remote request for the registered `image/png` format was not handled.

## Validation

- Built `sdl3-freerdp` successfully with Ninja.
- Installed locally and verified the build keeps `WITH_CLIENT_SDL3=ON`, `WITH_GFX_AV1=ON`, `WITH_AOM=ON`, and `WITH_VIDEOTOOLBOX=ON`.
- Confirmed no diagnostic-only clipboard logging is included in this patch.