### PR TITLE
[core,rdstls] add endpoint FedAuth token authentication

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -5298,6 +5298,11 @@ static int parse_command_line(rdpSettings* settings, const COMMAND_LINE_ARGUMENT
 			if (!freerdp_settings_set_bool(settings, FreeRDP_NegotiateSecurityLayer, enable))
 				return fail_at(arg, COMMAND_LINE_ERROR);
 		}
+		CommandLineSwitchCase(arg, "endpointfedauth")
+		{
+			if (!freerdp_settings_set_string(settings, FreeRDP_EndpointFedAuthToken, arg->Value))
+				return fail_at(arg, COMMAND_LINE_ERROR_MEMORY);
+		}
 		CommandLineSwitchCase(arg, "pcb")
 		{
 			if (!freerdp_settings_set_bool(settings, FreeRDP_SendPreconnectionPdu, TRUE))

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -167,6 +167,8 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "Encryption (experimental)" },
 	{ "encryption-methods", COMMAND_LINE_VALUE_REQUIRED, "[40,][56,][128,][FIPS]", nullptr, nullptr,
 	  -1, nullptr, "RDP standard security encryption methods" },
+	{ "endpointfedauth", COMMAND_LINE_VALUE_REQUIRED, "<token>", nullptr, nullptr, -1, nullptr,
+	  "Endpoint FedAuth token for Hyper-V VM console-connect scenarios" },
 	{ "f", COMMAND_LINE_VALUE_FLAG, nullptr, nullptr, nullptr, -1, nullptr,
 	  "Fullscreen mode (<Ctrl>+<Alt>+<Enter> toggles fullscreen)" },
 	{ "fipsmode", COMMAND_LINE_VALUE_BOOL, nullptr, nullptr, nullptr, -1, nullptr, "FIPS mode" },

--- a/client/common/file.c
+++ b/client/common/file.c
@@ -207,6 +207,8 @@ struct rdp_file
 
 	LPSTR GatewayAccessToken; /* gatewayaccesstoken */
 
+	LPSTR EndpointFedAuthToken; /* endpointfedauth */
+
 	LPSTR DrivesToRedirect;  /* drivestoredirect */
 	LPSTR DevicesToRedirect; /* devicestoredirect */
 	LPSTR WinPosStr;         /* winposstr */
@@ -246,6 +248,7 @@ static const char key_str_alternate_shell[] = "alternate shell";
 static const char key_str_shell_working_directory[] = "shell working directory";
 static const char key_str_gatewayhostname[] = "gatewayhostname";
 static const char key_str_gatewayaccesstoken[] = "gatewayaccesstoken";
+static const char key_str_endpointfedauth[] = "endpointfedauth";
 static const char key_str_resourceprovider[] = "resourceprovider";
 static const char str_resourceprovider_arm[] = "arm";
 static const char key_str_kdcproxyname[] = "kdcproxyname";
@@ -585,6 +588,8 @@ static BOOL freerdp_client_rdp_file_find_string_entry(rdpFile* file, const char*
 		*outValue = &file->activityhint;
 	else if (_stricmp(name, key_str_gatewayaccesstoken) == 0)
 		*outValue = &file->GatewayAccessToken;
+	else if (_stricmp(name, key_str_endpointfedauth) == 0)
+		*outValue = &file->EndpointFedAuthToken;
 	else if (_stricmp(name, key_str_kdcproxyname) == 0)
 		*outValue = &file->KdcProxyName;
 	else if (_stricmp(name, key_str_drivestoredirect) == 0)
@@ -831,6 +836,8 @@ static BOOL trim_strings(rdpFile* file)
 	if (!trim(&file->GatewayHostname))
 		return FALSE;
 	if (!trim(&file->GatewayAccessToken))
+		return FALSE;
+	if (!trim(&file->EndpointFedAuthToken))
 		return FALSE;
 	if (!trim(&file->RemoteApplicationName))
 		return FALSE;
@@ -1243,6 +1250,8 @@ BOOL freerdp_client_populate_rdp_file_from_settings(rdpFile* file, const rdpSett
 	file->RemoteApplicationMode = WINPR_ASSERTING_INT_CAST(
 	    UINT32, freerdp_settings_get_bool(settings, FreeRDP_RemoteApplicationMode));
 	if (!FILE_POPULATE_STRING(&file->GatewayAccessToken, settings, FreeRDP_GatewayAccessToken) ||
+	    !FILE_POPULATE_STRING(&file->EndpointFedAuthToken, settings,
+	                          FreeRDP_EndpointFedAuthToken) ||
 	    !FILE_POPULATE_STRING(&file->RemoteApplicationProgram, settings,
 	                          FreeRDP_RemoteApplicationProgram) ||
 	    !FILE_POPULATE_STRING(&file->RemoteApplicationName, settings,
@@ -1621,6 +1630,7 @@ static SSIZE_T write_string_parameters(const rdpFile* file, char* buffer, size_t
 		{ key_str_hubdiscoverygeourl, file->hubdiscoverygeourl },
 		{ key_str_activityhint, file->activityhint },
 		{ key_str_gatewayaccesstoken, file->GatewayAccessToken },
+		{ key_str_endpointfedauth, file->EndpointFedAuthToken },
 		{ key_str_kdcproxyname, file->KdcProxyName },
 		{ key_str_drivestoredirect, file->DrivesToRedirect },
 		{ key_str_devicestoredirect, file->DevicesToRedirect },
@@ -2168,6 +2178,13 @@ BOOL freerdp_client_populate_settings_from_rdp_file_unchecked(const rdpFile* fil
 	{
 		if (!freerdp_settings_set_string(settings, FreeRDP_GatewayAccessToken,
 		                                 file->GatewayAccessToken))
+			return FALSE;
+	}
+
+	if (~((size_t)file->EndpointFedAuthToken))
+	{
+		if (!freerdp_settings_set_string(settings, FreeRDP_EndpointFedAuthToken,
+		                                 file->EndpointFedAuthToken))
 			return FALSE;
 	}
 

--- a/include/freerdp/settings_types_private.h
+++ b/include/freerdp/settings_types_private.h
@@ -311,7 +311,10 @@ struct rdp_settings
 	SETTINGS_DEPRECATED(ALIGN64 UINT32 PreconnectionId);    /* 1154 */
 	SETTINGS_DEPRECATED(ALIGN64 char* PreconnectionBlob);   /* 1155 */
 	SETTINGS_DEPRECATED(ALIGN64 BOOL SendPreconnectionPdu); /* 1156 */
-	UINT64 padding1216[1216 - 1157];                        /* 1157 */
+	SETTINGS_DEPRECATED(ALIGN64 char* EndpointFedAuthToken); /** 1157
+	                                                          * @since version 3.28.0
+	                                                          */
+	UINT64 padding1216[1216 - 1158];                        /* 1158 */
 
 	/* Server Redirection */
 	SETTINGS_DEPRECATED(ALIGN64 UINT32 RedirectionFlags);                      /* 1216 */

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -2835,6 +2835,9 @@ const char* freerdp_settings_get_string(WINPR_ATTR_UNUSED const rdpSettings* set
 		case FreeRDP_DynamicDSTTimeZoneKeyName:
 			return settings->DynamicDSTTimeZoneKeyName;
 
+		case FreeRDP_EndpointFedAuthToken:
+			return settings->EndpointFedAuthToken;
+
 		case FreeRDP_GatewayAcceptedCert:
 			return settings->GatewayAcceptedCert;
 
@@ -3172,6 +3175,9 @@ char* freerdp_settings_get_string_writable(rdpSettings* settings, FreeRDP_Settin
 
 		case FreeRDP_DynamicDSTTimeZoneKeyName:
 			return settings->DynamicDSTTimeZoneKeyName;
+
+		case FreeRDP_EndpointFedAuthToken:
+			return settings->EndpointFedAuthToken;
 
 		case FreeRDP_GatewayAcceptedCert:
 			return settings->GatewayAcceptedCert;
@@ -3522,6 +3528,9 @@ BOOL freerdp_settings_set_string_(WINPR_ATTR_UNUSED rdpSettings* settings,
 
 		case FreeRDP_DynamicDSTTimeZoneKeyName:
 			return update_string_(&settings->DynamicDSTTimeZoneKeyName, cnv.c, len);
+
+		case FreeRDP_EndpointFedAuthToken:
+			return update_string_(&settings->EndpointFedAuthToken, cnv.c, len);
 
 		case FreeRDP_GatewayAcceptedCert:
 			return update_string_(&settings->GatewayAcceptedCert, cnv.c, len);
@@ -3887,6 +3896,9 @@ BOOL freerdp_settings_set_string_copy_(WINPR_ATTR_UNUSED rdpSettings* settings,
 
 		case FreeRDP_DynamicDSTTimeZoneKeyName:
 			return update_string_copy_(&settings->DynamicDSTTimeZoneKeyName, cnv.cc, len, cleanup);
+
+		case FreeRDP_EndpointFedAuthToken:
+			return update_string_copy_(&settings->EndpointFedAuthToken, cnv.cc, len, cleanup);
 
 		case FreeRDP_GatewayAcceptedCert:
 			return update_string_copy_(&settings->GatewayAcceptedCert, cnv.cc, len, cleanup);

--- a/libfreerdp/common/settings_str.h
+++ b/libfreerdp/common/settings_str.h
@@ -494,6 +494,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_DumpRemoteFxFile, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_DumpRemoteFxFile" },
 	{ FreeRDP_DynamicDSTTimeZoneKeyName, FREERDP_SETTINGS_TYPE_STRING,
 	  "FreeRDP_DynamicDSTTimeZoneKeyName" },
+	{ FreeRDP_EndpointFedAuthToken, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_EndpointFedAuthToken" },
 	{ FreeRDP_GatewayAcceptedCert, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_GatewayAcceptedCert" },
 	{ FreeRDP_GatewayAccessToken, FREERDP_SETTINGS_TYPE_STRING, "FreeRDP_GatewayAccessToken" },
 	{ FreeRDP_GatewayAvdAadtenantid, FREERDP_SETTINGS_TYPE_STRING,

--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -435,7 +435,15 @@ BOOL rdp_client_connect(rdpRdp* rdp)
 	nego_enable_tls(rdp->nego, settings->TlsSecurity);
 	nego_enable_nla(rdp->nego, settings->NlaSecurity);
 	nego_enable_ext(rdp->nego, settings->ExtSecurity);
-	nego_enable_rdstls(rdp->nego, settings->RdstlsSecurity);
+	/* An endpoint FedAuth token is delivered via RDSTLS. Enable the protocol
+	 * implicitly so the token can be used without an additional /sec flag. */
+	{
+		const char* fedAuthToken =
+		    freerdp_settings_get_string(settings, FreeRDP_EndpointFedAuthToken);
+		const BOOL enableRdstls =
+		    settings->RdstlsSecurity || (fedAuthToken && (*fedAuthToken != '\0'));
+		nego_enable_rdstls(rdp->nego, enableRdstls);
+	}
 	nego_enable_aad(rdp->nego, settings->AadSecurity);
 
 	if (settings->MstscCookieMode)

--- a/libfreerdp/core/rdstls.c
+++ b/libfreerdp/core/rdstls.c
@@ -34,6 +34,7 @@
 #include "utils.h"
 
 #define RDSTLS_VERSION_1 0x01
+#define RDSTLS_VERSION_2 0x02
 
 #define RDSTLS_TYPE_CAPABILITIES 0x01
 #define RDSTLS_TYPE_AUTHREQ 0x02
@@ -42,6 +43,7 @@
 #define RDSTLS_DATA_CAPABILITIES 0x01
 #define RDSTLS_DATA_PASSWORD_CREDS 0x01
 #define RDSTLS_DATA_AUTORECONNECT_COOKIE 0x02
+#define RDSTLS_DATA_FEDAUTH_TOKEN 0x03
 #define RDSTLS_DATA_RESULT_CODE 0x01
 
 typedef enum
@@ -350,6 +352,84 @@ static BOOL rdstls_write_authentication_request_with_cookie(WINPR_ATTR_UNUSED rd
 	return (rdstls_write_cookie(s, settings->ServerAutoReconnectCookie));
 }
 
+/*
+ * Warn if the endpoint FedAuth token targets a different virtual machine
+ * than the VM identifier passed via the .rdp `pcb` field / /pcb command
+ * line switch. The token payload starts with "VMID=<guid>&..."; a
+ * mismatch would be silently rejected by the server later on. This is a
+ * best-effort local sanity check.
+ */
+static void rdstls_check_fedauth_vmid(rdpRdstls* rdstls, const char* token, const char* selectedVm)
+{
+	WINPR_ASSERT(rdstls);
+	WINPR_ASSERT(token);
+
+	if (!selectedVm || !*selectedVm)
+		return;
+
+	const char* vmidField = strstr(token, "VMID=");
+	if (!vmidField)
+		return;
+	vmidField += 5;
+
+	const size_t vmLen = strlen(selectedVm);
+	const BOOL matches =
+	    (_strnicmp(vmidField, selectedVm, vmLen) == 0) &&
+	    (vmidField[vmLen] == '\0' || vmidField[vmLen] == '&');
+	if (!matches)
+	{
+		WLog_Print(rdstls->log, WLOG_WARN,
+		           "endpoint FedAuth token is issued for a different virtual machine "
+		           "than the one selected for connection");
+	}
+}
+
+static BOOL rdstls_write_authentication_request_with_fedauth_token(rdpRdstls* rdstls, wStream* s)
+{
+	WINPR_ASSERT(rdstls);
+	WINPR_ASSERT(rdstls->context);
+
+	WLog_Print(rdstls->log, WLOG_DEBUG, "Writing RDSTLS FedAuth token authentication message");
+
+	const rdpSettings* settings = rdstls->context->settings;
+	WINPR_ASSERT(settings);
+
+	const char* token = freerdp_settings_get_string(settings, FreeRDP_EndpointFedAuthToken);
+	if (!token || !*token)
+	{
+		WLog_Print(rdstls->log, WLOG_ERROR, "EndpointFedAuthToken not set");
+		return FALSE;
+	}
+
+	rdstls_check_fedauth_vmid(
+	    rdstls, token, freerdp_settings_get_string(settings, FreeRDP_PreconnectionBlob));
+
+	const size_t utf8Length = strlen(token);
+	/* The wire length prefix is a UINT16 counting the token in UTF-16LE
+	 * including a terminating NUL character. */
+	if (utf8Length + 1 > UINT16_MAX / sizeof(WCHAR))
+	{
+		WLog_Print(rdstls->log, WLOG_ERROR,
+		           "EndpointFedAuthToken length %" PRIuz " exceeds RDSTLS wire limit", utf8Length);
+		return FALSE;
+	}
+
+	const size_t wideLength = utf8Length + 1;
+	const size_t wideBytes = wideLength * sizeof(WCHAR);
+
+	if (!Stream_EnsureRemainingCapacity(s, 6 + wideBytes))
+		return FALSE;
+
+	Stream_Write_UINT16(s, RDSTLS_TYPE_AUTHREQ);
+	Stream_Write_UINT16(s, RDSTLS_DATA_FEDAUTH_TOKEN);
+	Stream_Write_UINT16(s, (UINT16)wideBytes);
+
+	if (Stream_Write_UTF16_String_From_UTF8(s, wideLength, token, utf8Length, TRUE) < 0)
+		return FALSE;
+
+	return TRUE;
+}
+
 static BOOL rdstls_write_authentication_response(rdpRdstls* rdstls, wStream* s)
 {
 	WINPR_ASSERT(rdstls);
@@ -655,9 +735,13 @@ static BOOL rdstls_send(WINPR_ATTR_UNUSED rdpTransport* transport, wStream* s, v
 	if (!Stream_EnsureRemainingCapacity(s, 2))
 		return FALSE;
 
-	Stream_Write_UINT16(s, RDSTLS_VERSION_1);
-
 	const RDSTLS_STATE state = rdstls_get_state(rdstls);
+	const char* fedAuthToken = freerdp_settings_get_string(settings, FreeRDP_EndpointFedAuthToken);
+	const BOOL useFedAuth =
+	    (state == RDSTLS_STATE_AUTH_REQ) && fedAuthToken && (*fedAuthToken != '\0');
+
+	Stream_Write_UINT16(s, useFedAuth ? RDSTLS_VERSION_2 : RDSTLS_VERSION_1);
+
 	switch (state)
 	{
 		case RDSTLS_STATE_CAPABILITIES:
@@ -665,7 +749,12 @@ static BOOL rdstls_send(WINPR_ATTR_UNUSED rdpTransport* transport, wStream* s, v
 				return FALSE;
 			break;
 		case RDSTLS_STATE_AUTH_REQ:
-			if (settings->RedirectionFlags & LB_PASSWORD_IS_PK_ENCRYPTED)
+			if (useFedAuth)
+			{
+				if (!rdstls_write_authentication_request_with_fedauth_token(rdstls, s))
+					return FALSE;
+			}
+			else if (settings->RedirectionFlags & LB_PASSWORD_IS_PK_ENCRYPTED)
 			{
 				if (!rdstls_write_authentication_request_with_password(rdstls, s))
 					return FALSE;
@@ -678,7 +767,8 @@ static BOOL rdstls_send(WINPR_ATTR_UNUSED rdpTransport* transport, wStream* s, v
 			else
 			{
 				WLog_Print(rdstls->log, WLOG_ERROR,
-				           "cannot authenticate with password or auto-reconnect cookie");
+				           "cannot authenticate with FedAuth token, password or "
+				           "auto-reconnect cookie");
 				return FALSE;
 			}
 			break;

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -393,6 +393,7 @@ static const size_t string_list_indices[] = {
 	FreeRDP_DrivesToRedirect,
 	FreeRDP_DumpRemoteFxFile,
 	FreeRDP_DynamicDSTTimeZoneKeyName,
+	FreeRDP_EndpointFedAuthToken,
 	FreeRDP_GatewayAcceptedCert,
 	FreeRDP_GatewayAccessToken,
 	FreeRDP_GatewayAvdAadtenantid,


### PR DESCRIPTION
Implement rdstls_write_authentication_request_with_fedauth_token so FreeRDP can authenticate against Hyper-V VM console-connect endpoints that require an endpoint FedAuth token instead of user credentials or an auto-reconnect cookie.

FedAuth token handover implemented for:
- FreeRDP_EndpointFedAuthToken settings entry
- endpointfedauth .rdp file field
- /endpointfedauth command line switch

When the token is set the RDSTLS security protocol is enabled automatically and the authentication request is sent using RDSTLS version 2 with data type 0x03. This is needed for usage of the FedAuth token method agains a Hyper-V host.

## How to test?

For testing the FedAuth against the Host you will need the following:
* System Center Virtual Machine Manager for issuing the tokens
* Hyper-V Host running at least one virtual machine
* Remote Desktop Gateway with Console Connect Federated Authentication Plugin

If a lab environment is needed for merging it please contact me.

The tokens can be generated with powershell on SCVMM:
`$tok = New-SCVMConnectFedAuth -VMMServer $vmm -VM $vm
`

Following command line parameter should be used to hand over the tokens:
```
/v:$($tok.Host):$($tok.VMRCPort)
/gateway:g:<rdp gw fqdn>,type:http,access-token:$($tok.HostToken)
/pcb:$($tok.VMID)
/endpointfedauth:$(q $tok.VMToken)
```
Beware of the quoting of the gateway access token.

## Not covered by this PR

  - Server side handling of RDSTLS_DATA_FEDAUTH_TOKEN in rdstls_process_authentication_request_* (this change only implements the client sender)
  - Session resume with an expired token, because it never works without a new token provided by the user

## Compatibility

  - New setting slot 1157 is placed in a previously padded region, guarded by SETTINGS_DEPRECATED
  - Public function signatures unchanged
  - Existing RDSTLS password and auto-reconnect-cookie paths are unmodified
  - Providing the FedAuth endpoint token is handled in a new branch
  - /sec:rdstls remains valid. Existing .rdp files that don't contain endpointfedauth work unchanged