### PR TITLE
[client,x11] Fix RAIL HiDef window maximize

### DIFF
--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -664,11 +664,12 @@ static BOOL xf_rail_window_common(rdpContext* context, const WINDOW_ORDER_INFO* 
 		 */
 		if (appWindow->rail_state != WINDOW_SHOW_MINIMIZED)
 		{
-			/* Redraw window area if already in the correct position */
-			if (appWindow->x == (INT64)appWindow->windowOffsetX &&
-			    appWindow->y == (INT64)appWindow->windowOffsetY &&
-			    appWindow->width == (INT64)appWindow->windowWidth &&
-			    appWindow->height == (INT64)appWindow->windowHeight)
+			const BOOL maximized = (appWindow->dwStyle & WS_MAXIMIZE) != 0;
+			/* Leave maximized windows to the WM, which honors the work area. */
+			if (maximized || (appWindow->x == (INT64)appWindow->windowOffsetX &&
+			                  appWindow->y == (INT64)appWindow->windowOffsetY &&
+			                  appWindow->width == (INT64)appWindow->windowWidth &&
+			                  appWindow->height == (INT64)appWindow->windowHeight))
 			{
 				xf_UpdateWindowArea(xfc, appWindow, 0, 0,
 				                    WINPR_ASSERTING_INT_CAST(int, appWindow->windowWidth),
@@ -681,11 +682,15 @@ static BOOL xf_rail_window_common(rdpContext* context, const WINDOW_ORDER_INFO* 
 				              WINPR_ASSERTING_INT_CAST(int, appWindow->windowHeight));
 			}
 
-			xf_SetWindowVisibilityRects(
-			    xfc, appWindow, WINPR_ASSERTING_INT_CAST(uint32_t, visibilityRectsOffsetX),
-			    WINPR_ASSERTING_INT_CAST(uint32_t, visibilityRectsOffsetY),
-			    appWindow->visibilityRects,
-			    WINPR_ASSERTING_INT_CAST(int, appWindow->numVisibilityRects));
+			/* Show a maximized window fully; its frame-inset visibility rects would clip it. */
+			if (maximized)
+				xf_ClearWindowVisibilityRects(xfc, appWindow);
+			else
+				xf_SetWindowVisibilityRects(
+				    xfc, appWindow, WINPR_ASSERTING_INT_CAST(uint32_t, visibilityRectsOffsetX),
+				    WINPR_ASSERTING_INT_CAST(uint32_t, visibilityRectsOffsetY),
+				    appWindow->visibilityRects,
+				    WINPR_ASSERTING_INT_CAST(int, appWindow->numVisibilityRects));
 		}
 
 		if (appWindow->rail_state == WINDOW_SHOW_MAXIMIZED)

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -146,6 +146,29 @@ BOOL xf_rail_disable_remoteapp_mode(xfContext* xfc)
 	return TRUE;
 }
 
+/* Report the real work area so the server maximizes RemoteApp windows within the panel. */
+static UINT xf_rail_send_workarea(xfContext* xfc)
+{
+	WINPR_ASSERT(xfc);
+	WINPR_ASSERT(xfc->rail);
+
+	/* xf_GetWorkArea overwrites xfc->workArea; restore it (RAIL keeps it full). */
+	const xfWorkArea saved = xfc->workArea;
+	if (!xf_GetWorkArea(xfc))
+		return CHANNEL_RC_OK;
+	const INT64 right = (INT64)xfc->workArea.x + xfc->workArea.width;
+	const INT64 bottom = (INT64)xfc->workArea.y + xfc->workArea.height;
+	const RAIL_SYSPARAM_ORDER sysparam = {
+		.params = SPI_MASK_SET_WORK_AREA,
+		.workArea.left = WINPR_CXX_COMPAT_CAST(UINT16, xfc->workArea.x),
+		.workArea.top = WINPR_CXX_COMPAT_CAST(UINT16, xfc->workArea.y),
+		.workArea.right = WINPR_CXX_COMPAT_CAST(UINT16, right),
+		.workArea.bottom = WINPR_CXX_COMPAT_CAST(UINT16, bottom)
+	};
+	xfc->workArea = saved;
+	return xfc->rail->ClientSystemParam(xfc->rail, &sysparam);
+}
+
 BOOL xf_rail_send_activate(xfContext* xfc, Window xwindow, BOOL enabled)
 {
 	RAIL_ACTIVATE_ORDER activate = WINPR_C_ARRAY_INIT;
@@ -993,6 +1016,8 @@ xf_rail_monitored_desktop(WINPR_ATTR_UNUSED rdpContext* context,
 		if ((app != nullptr) && (strnlen(app, 1) > 0))
 		{
 			if (client_rail_server_start_cmd(xfc->rail) != CHANNEL_RC_OK)
+				return FALSE;
+			if (xf_rail_send_workarea(xfc) != CHANNEL_RC_OK)
 				return FALSE;
 		}
 	}

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -1361,6 +1361,16 @@ void xf_SetWindowVisibilityRects(xfContext* xfc, xfAppWindow* appWindow, UINT32 
 #endif
 }
 
+void xf_ClearWindowVisibilityRects(xfContext* xfc, xfAppWindow* appWindow)
+{
+	WINPR_ASSERT(xfc);
+	WINPR_ASSERT(appWindow);
+#ifdef WITH_XEXT
+	/* Drop the bounding shape so the whole window is visible. */
+	XShapeCombineMask(xfc->display, appWindow->handle, ShapeBounding, 0, 0, None, ShapeSet);
+#endif
+}
+
 void xf_UpdateWindowArea(xfContext* xfc, xfAppWindow* appWindow, int x, int y, int width,
                          int height)
 {
@@ -1525,20 +1535,34 @@ UINT xf_AppUpdateWindowFromSurface(xfContext* xfc, gdiGfxSurface* surface)
 		return CHANNEL_RC_OK;
 	}
 
+	const BOOL surfaceChanged = (appWindow->surfaceId != surface->surfaceId);
+	if (surfaceChanged)
+		appWindow->surfaceId = surface->surfaceId;
+
+	const BOOL maximized = (appWindow->dwStyle & WS_MAXIMIZE) != 0;
+	const UINT32 winW = WINPR_ASSERTING_INT_CAST(uint32_t, appWindow->width);
+	const UINT32 winH = WINPR_ASSERTING_INT_CAST(uint32_t, appWindow->height);
+
 	const BOOL swGdi = freerdp_settings_get_bool(xfc->common.context.settings, FreeRDP_SoftwareGdi);
 	UINT32 nrects = 0;
 	const RECTANGLE_16* rects = region16_rects(&surface->invalidRegion, &nrects);
 
+	RECTANGLE_16 fullRect = WINPR_C_ARRAY_INIT;
+	if (surfaceChanged)
+	{
+		fullRect.right = WINPR_ASSERTING_INT_CAST(UINT16, MIN(winW, surface->width));
+		fullRect.bottom = WINPR_ASSERTING_INT_CAST(UINT16, MIN(winH, surface->height));
+		if ((fullRect.right > 0) && (fullRect.bottom > 0))
+		{
+			rects = &fullRect;
+			nrects = 1;
+		}
+	}
+
 	if (swGdi)
 	{
-		if (appWindow->surfaceId != surface->surfaceId)
-		{
-			xf_AppWindowDestroyImage(appWindow);
-			appWindow->surfaceId = surface->surfaceId;
-		}
-		if (appWindow->width != (INT64)surface->width)
-			xf_AppWindowDestroyImage(appWindow);
-		if (appWindow->height != (INT64)surface->height)
+		if (surfaceChanged || (appWindow->width != (INT64)surface->width) ||
+		    (appWindow->height != (INT64)surface->height))
 			xf_AppWindowDestroyImage(appWindow);
 
 		if (!appWindow->image)
@@ -1569,18 +1593,45 @@ UINT xf_AppUpdateWindowFromSurface(xfContext* xfc, gdiGfxSurface* surface)
 		image = xfSurface->image;
 	}
 
+	/* Skip the off-screen resize-margin frame a maximized surface carries: shift the blit by the
+	 * real left/top margin so content fills from (0,0). */
+	const int insetX =
+	    (maximized && (surface->mappedWidth > winW)) ? (int)appWindow->resizeMarginLeft : 0;
+	const int insetY =
+	    (maximized && (surface->mappedHeight > winH)) ? (int)appWindow->resizeMarginTop : 0;
+
 	for (UINT32 x = 0; x < nrects; x++)
 	{
 		const RECTANGLE_16* rect = &rects[x];
-		const UINT32 width = rect->right - rect->left;
-		const UINT32 height = rect->bottom - rect->top;
+		int srcX = rect->left;
+		int srcY = rect->top;
+		int dstX = (int)rect->left - insetX;
+		int dstY = (int)rect->top - insetY;
+		int w = (int)(rect->right - rect->left);
+		int h = (int)(rect->bottom - rect->top);
 
-		LogDynAndXPutImage(xfc->log, xfc->display, appWindow->pixmap, appWindow->gc, image,
-		                   rect->left, rect->top, rect->left, rect->top, width, height);
+		if (dstX < 0)
+		{
+			srcX -= dstX;
+			w += dstX;
+			dstX = 0;
+		}
+		if (dstY < 0)
+		{
+			srcY -= dstY;
+			h += dstY;
+			dstY = 0;
+		}
+		if ((w <= 0) || (h <= 0))
+			continue;
+
+		LogDynAndXPutImage(xfc->log, xfc->display, appWindow->pixmap, appWindow->gc, image, srcX,
+		                   srcY, dstX, dstY, WINPR_ASSERTING_INT_CAST(uint32_t, w),
+		                   WINPR_ASSERTING_INT_CAST(uint32_t, h));
 
 		LogDynAndXCopyArea(xfc->log, xfc->display, appWindow->pixmap, appWindow->handle,
-		                   appWindow->gc, rect->left, rect->top, width, height, rect->left,
-		                   rect->top);
+		                   appWindow->gc, dstX, dstY, WINPR_ASSERTING_INT_CAST(uint32_t, w),
+		                   WINPR_ASSERTING_INT_CAST(uint32_t, h), dstX, dstY);
 	}
 
 	rc = CHANNEL_RC_OK;

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -1321,10 +1321,11 @@ void xf_SetWindowRects(xfContext* xfc, xfAppWindow* appWindow, RECTANGLE_16* rec
 
 	for (int i = 0; i < nrects; i++)
 	{
-		xrects[i].x = WINPR_ASSERTING_INT_CAST(short, rects[i].left);
-		xrects[i].y = WINPR_ASSERTING_INT_CAST(short, rects[i].top);
-		xrects[i].width = WINPR_ASSERTING_INT_CAST(unsigned short, rects[i].right - rects[i].left);
-		xrects[i].height = WINPR_ASSERTING_INT_CAST(unsigned short, rects[i].bottom - rects[i].top);
+		/* Coords may be negative (INT16 in UINT16 fields); cast modularly, no assert. */
+		xrects[i].x = WINPR_CXX_COMPAT_CAST(short, rects[i].left);
+		xrects[i].y = WINPR_CXX_COMPAT_CAST(short, rects[i].top);
+		xrects[i].width = WINPR_CXX_COMPAT_CAST(unsigned short, rects[i].right - rects[i].left);
+		xrects[i].height = WINPR_CXX_COMPAT_CAST(unsigned short, rects[i].bottom - rects[i].top);
 	}
 
 	XShapeCombineRectangles(xfc->display, appWindow->handle, ShapeBounding, 0, 0, xrects, nrects,
@@ -1346,10 +1347,11 @@ void xf_SetWindowVisibilityRects(xfContext* xfc, xfAppWindow* appWindow, UINT32 
 
 	for (int i = 0; i < nrects; i++)
 	{
-		xrects[i].x = WINPR_ASSERTING_INT_CAST(short, rects[i].left);
-		xrects[i].y = WINPR_ASSERTING_INT_CAST(short, rects[i].top);
-		xrects[i].width = WINPR_ASSERTING_INT_CAST(unsigned short, rects[i].right - rects[i].left);
-		xrects[i].height = WINPR_ASSERTING_INT_CAST(unsigned short, rects[i].bottom - rects[i].top);
+		/* Coords may be negative (INT16 in UINT16 fields); cast modularly, no assert. */
+		xrects[i].x = WINPR_CXX_COMPAT_CAST(short, rects[i].left);
+		xrects[i].y = WINPR_CXX_COMPAT_CAST(short, rects[i].top);
+		xrects[i].width = WINPR_CXX_COMPAT_CAST(unsigned short, rects[i].right - rects[i].left);
+		xrects[i].height = WINPR_CXX_COMPAT_CAST(unsigned short, rects[i].bottom - rects[i].top);
 	}
 
 	XShapeCombineRectangles(

--- a/client/X11/xf_window.h
+++ b/client/X11/xf_window.h
@@ -108,6 +108,7 @@ void xf_ShowWindow(xfContext* xfc, xfAppWindow* appWindow, BYTE state);
 void xf_SetWindowRects(xfContext* xfc, xfAppWindow* appWindow, RECTANGLE_16* rects, int nrects);
 void xf_SetWindowVisibilityRects(xfContext* xfc, xfAppWindow* appWindow, UINT32 rectsOffsetX,
                                  UINT32 rectsOffsetY, RECTANGLE_16* rects, int nrects);
+void xf_ClearWindowVisibilityRects(xfContext* xfc, xfAppWindow* appWindow);
 void xf_SetWindowStyle(xfContext* xfc, xfAppWindow* appWindow, UINT32 style, UINT32 ex_style);
 void xf_SetWindowActions(xfContext* xfc, xfAppWindow* appWindow);
 void xf_UpdateWindowArea(xfContext* xfc, xfAppWindow* appWindow, int x, int y, int width,


### PR DESCRIPTION
# [client,x11] Fix RAIL HiDef window maximize

Maximizing a RAIL window on the RDPGFX (HiDef) path is broken on X11: the window covers the panel, a white border surrounds the content, the content is offset down/right, and some apps (e.g. PowerPoint) abort the client.

- Fixes #9466
- Fixes #10005
- Fixes #11168
## Fixes

### **Abort on negative shape rects**
 `xf_SetWindowRects` / `xf_SetWindowVisibilityRects` convert `RECTANGLE_16` (UINT16) to `XRectangle`. The server encodes signed INT16 there (a maximized frame's top edge is `-8`, i.e. `0xFFF8`); `6701359cc` wrapped the conversion in `WINPR_ASSERTING_INT_CAST(short, ...)`, which aborts on those negative values. Use `WINPR_CXX_COMPAT_CAST` instead; it still silences `-Wsign-conversion` and wraps modularly as before.

### **Maximize ignores the work area** 
`client_rail_server_start_cmd` reports the full desktop as the work area, so the server maximizes over the panel. Send a `SPI_SET_WORK_AREA` sysparam with the real `_NET_WORKAREA` after RAIL start. The desktop resolution stays full: it is the RAIL coordinate space, and the work area only bounds maximize. Shrinking the reported desktop instead shrinks the session and desyncs the maximized surface.

### **Maximized geometry / rendering**
- `WS_MAXIMIZE`: leave placement to the WM instead of forcing the server offset via `xf_MoveWindow`; the WM honors the work area from above.
- Clear the bounding shape while maximized. Otherwise the server's frame-inset visibility rects clip the content (the white border).
- When the surface is larger than the window it carries the off-screen resize frame; shift the surface-to-window blit by the real left/top resize margin.
- Repaint the whole window once when it is bound to a different surface (no incremental damage yet).

## Testing

Notepad and PowerPoint (`/app:program:...,hidef:on`): maximize stays within the work area, no white border, content aligned, no abort; non-maximized windows unchanged (inset 0).

- GNOME 50 / mutter on Xwayland
- KDE / KWin on X11 (Xephyr)
- XFCE / xfwm4 on X11 (Xephyr)

Not tested on other WMs; the changes are WM-agnostic (`_NET_WORKAREA`, the RAIL work-area sysparam, client-side drawing).

## Notes

- `client/X11` only, no `libfreerdp` changes.
- The work area is sent once at RAIL start; a mid-session `_NET_WORKAREA` change is not re-sent (same as the generic path).
