### PR TITLE
[client,common] /smartcard-logon pass PEM directly

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -965,17 +965,24 @@ fail:
 	return FALSE;
 }
 
-static BOOL read_pem_file(rdpSettings* settings, FreeRDP_Settings_Keys_String id, const char* file)
+static BOOL read_pem_file(rdpSettings* settings, FreeRDP_Settings_Keys_String id,
+                          const char* b64OrFile)
 {
-	size_t length = 0;
-	char* pem = crypto_read_pem(file, &length);
-	if (!pem || (length == 0))
+	const size_t blen = strlen(b64OrFile);
+	char* pem = nullptr;
+	size_t plen = 0;
+	crypto_base64url_decode(b64OrFile, blen, (BYTE**)&pem, &plen);
+	if (!pem)
 	{
-		free(pem);
-		return FALSE;
+		pem = crypto_read_pem(b64OrFile, &plen);
+		if (!pem || (plen == 0))
+		{
+			free(pem);
+			return FALSE;
+		}
 	}
 
-	BOOL rc = freerdp_settings_set_string_len(settings, id, pem, length);
+	BOOL rc = freerdp_settings_set_string_len(settings, id, pem, plen);
 	free(pem);
 	return rc;
 }

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -465,8 +465,10 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	{ "smartcard", COMMAND_LINE_VALUE_OPTIONAL, "<str>[,<str>...]", nullptr, nullptr, -1, nullptr,
 	  "Redirect the smartcard devices containing any of the <str> in their names." },
 	{ "smartcard-logon", COMMAND_LINE_VALUE_OPTIONAL,
-	  "[cert:<path>,key:<key>,pin:<pin>,csp:<csp name>,reader:<reader>,card:<card>]", nullptr,
-	  nullptr, -1, nullptr, "Activates Smartcard (optional certificate) Logon authentication." },
+	  "[[cert:<path>|cert:<base64(PEM)>],[key:<path>|key:<base64(PEM)>],pin:<pin>,csp:<csp "
+	  "name>,reader:<reader>,card:<card>]",
+	  nullptr, nullptr, -1, nullptr,
+	  "Activates Smartcard (optional certificate) Logon authentication." },
 	{ "sound", COMMAND_LINE_VALUE_OPTIONAL,
 	  "[sys:<sys>,][dev:<dev>,][format:<format>,][rate:<rate>,][channel:<channel>,][latency:<"
 	  "latency>,][quality:<quality>]",


### PR DESCRIPTION
Allow base64 encoded PEM data to be passed as an alternative to file paths