### PR TITLE
fix processImageName length check in rail get appid resp ex

### DIFF
--- a/channels/rail/client/rail_orders.c
+++ b/channels/rail/client/rail_orders.c
@@ -883,7 +883,7 @@ static UINT rail_read_get_application_id_extended_response_order(wStream* s,
 	if (!Stream_Read_UTF16_String(s, id->processImageName, ARRAYSIZE(id->processImageName)))
 		return ERROR_INVALID_DATA;
 
-	if (_wcsnlen(id->applicationID, ARRAYSIZE(id->processImageName)) >=
+	if (_wcsnlen(id->processImageName, ARRAYSIZE(id->processImageName)) >=
 	    ARRAYSIZE(id->processImageName))
 		return ERROR_INVALID_DATA;
 


### PR DESCRIPTION
**Wrong field in the processImageName terminator check**

`rail_read_get_application_id_extended_response_order` reads `processImageName` with `Stream_Read_UTF16_String`, which fills all 260 WCHARs without writing a terminator, so the `_wcsnlen` guard below it is the only thing rejecting a field that never terminates. That guard scans `id->applicationID` (already checked a few lines up) rather than `id->processImageName`, so a server response whose `processImageName` runs the full 260 WCHARs with no NUL is accepted and handed to `ServerGetAppidResponseExtended` unterminated, where reading it as a C string walks past the fixed buffer. Repointed the guard at `processImageName` so it mirrors the `applicationID` check above.