### PR TITLE
[core,security] reject short server random in security_establish_keys

### DIFF
--- a/libfreerdp/core/security.c
+++ b/libfreerdp/core/security.c
@@ -630,8 +630,16 @@ BOOL security_establish_keys(rdpRdp* rdp)
 	    freerdp_settings_get_uint32(settings, FreeRDP_ClientRandomLength);
 	const UINT32 ServerRandomLength =
 	    freerdp_settings_get_uint32(settings, FreeRDP_ServerRandomLength);
-	WINPR_ASSERT(ClientRandomLength == 32);
-	WINPR_ASSERT(ServerRandomLength == 32);
+	/* The server random is peer supplied (gcc_read_server_security_data rejects only a length
+	 * of 0) while both randoms are consumed below as fixed 32 byte values, so a shorter buffer
+	 * would be read past its end. WINPR_ASSERT is compiled out in release builds, enforce the
+	 * length at runtime. */
+	if ((ClientRandomLength != 32) || (ServerRandomLength != 32))
+	{
+		WLog_ERR(TAG, "invalid client (%" PRIu32 ") or server (%" PRIu32 ") random length",
+		         ClientRandomLength, ServerRandomLength);
+		return FALSE;
+	}
 
 	if (settings->EncryptionMethods == ENCRYPTION_METHOD_FIPS)
 	{


### PR DESCRIPTION
**Out-of-bounds read of the server random in security_establish_keys**

The peer supplied `serverRandomLen` is only checked against 0 in `gcc_read_server_security_data`, so `ServerRandom` can end up stored as a buffer as small as one byte. `security_establish_keys` then consumes it as a fixed 32 byte value (the 24 byte copy into `pre_master_secret`, the 32 byte md5 input, and `server_random + 16` on the FIPS path), reading past the allocation and folding stale heap bytes into the derived session keys. The only guard was `WINPR_ASSERT(ServerRandomLength == 32)`, which is a no-op in release builds.

This turns the two asserts into a runtime check, kept next to the reads that rely on the length. The client random is generated locally at 32 bytes and RDP standard security mandates a 32 byte server random, so valid sessions should be unaffected; only a malformed peer is rejected.
