### PR TITLE
[emu,scard] require Lc of 2 for select-by-FID in vgids_ins_select

### DIFF
--- a/libfreerdp/emu/scard/smartcard_virtual_gids.c
+++ b/libfreerdp/emu/scard/smartcard_virtual_gids.c
@@ -751,9 +751,9 @@ static BOOL vgids_ins_select(vgidsContext* context, wStream* s, BYTE** response,
 		{
 			/* read FID from APDU */
 			UINT16 fid = 0;
-			if (lc > 2)
+			if (lc != 2)
 			{
-				WLog_ERR(TAG, "The LC byte for the file ID is greater than 2");
+				WLog_ERR(TAG, "The LC byte for the file ID must be 2");
 				status = ISO_STATUS_INVALIDLC;
 				break;
 			}


### PR DESCRIPTION
**Out-of-bounds read in vgids_ins_select select-by-FID**

The FID branch only rejects an Lc above 2, then unconditionally reads a two-byte file id with `Stream_Read_UINT16_BE`. `vgids_parse_apdu_header` guarantees only Lc bytes remain, so a SELECT APDU with P1=0x00 and Lc of 0 or 1 reads one to two bytes past the received APDU buffer. The emulated GIDS card parses server-supplied APDUs (`SCardTransmit` -> `vgids_process_apdu`), so this is reachable across the trust boundary. Constrained the branch to require Lc of 2, which is the exact file-id length and matches the exact-length checks the sibling handlers already use (`manage_security_environment` uses `lc != 6`). Behaviour for a well-formed 2-byte file id is unchanged.