### PR TITLE
[core,message] copy rail unicode string clone by length

### DIFF
--- a/libfreerdp/core/message.c
+++ b/libfreerdp/core/message.c
@@ -1232,8 +1232,17 @@ update_message_DrawGdiPlusCacheEnd(rdpContext* context,
 static RAIL_UNICODE_STRING rail_unicode_string_clone(const RAIL_UNICODE_STRING* str)
 {
 	WINPR_ASSERT(str);
-	RAIL_UNICODE_STRING clone = { .string = (BYTE*)strndup((const char*)str->string, str->length),
-		                          .length = str->length };
+
+	/* str->string holds str->length raw UTF-16 bytes and is not NUL terminated, so
+	 * it must be copied by length. strndup stops at the first embedded 0x00 while
+	 * clone.length keeps the full value, leaving the buffer shorter than declared. */
+	RAIL_UNICODE_STRING clone = { .string = nullptr, .length = str->length };
+	if (str->length > 0)
+	{
+		clone.string = (BYTE*)malloc(str->length);
+		if (clone.string)
+			CopyMemory(clone.string, str->string, str->length);
+	}
 	return clone;
 }
 


### PR DESCRIPTION
The window state order clone added in c27d4eb keeps RAIL window titles alive on the async update queue, and it duplicates the title and overlay strings with strndup. A RAIL_UNICODE_STRING is not a C string though: window.c stores it as a length plus a buffer of exactly that many raw UTF-16LE bytes with no terminator, so strndup stops at the first embedded 0x00 (every ASCII character carries one as its high byte) and returns a buffer of only a byte or two while clone.length still records the full length. When the string is later read back by length, as rail_string_to_utf8_string does through ConvertWCharNToUtf8Alloc, the decode walks off the short allocation into neighbouring heap, and a server that begins a title with 0x0000 can stretch that over-read across most of a 64k field. I noticed it comparing the new clone against the way the parser fills the buffer. Copying str->length bytes with malloc and CopyMemory restores the (string, length) invariant and, as a side benefit, stops the title being silently truncated at the first NUL. I kept the change inside rail_unicode_string_clone so both the title and overlay fields are covered and the callers stay untouched.
