### PR TITLE
[client,android] add automatic reconnect

### DIFF
--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_event.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_event.c
@@ -195,6 +195,36 @@ BOOL android_check_handle(freerdp* inst)
 	return TRUE;
 }
 
+BOOL android_check_reconnect_handle(freerdp* inst)
+{
+	androidContext* aCtx;
+
+	if (!inst || !inst->context)
+		return FALSE;
+
+	aCtx = (androidContext*)inst->context;
+	if (!aCtx->event_queue || !aCtx->event_queue->isSet)
+		return FALSE;
+
+	if (WaitForSingleObject(aCtx->event_queue->isSet, 0) != WAIT_OBJECT_0)
+		return TRUE;
+	if (!ResetEvent(aCtx->event_queue->isSet))
+		return FALSE;
+
+	/* Input queued before reconnect belongs to the failed transport. Do not replay it after the
+	 * session is reclaimed, but keep an explicit disconnect responsive during retry delays. */
+	while (android_peek_event(aCtx->event_queue))
+	{
+		ANDROID_EVENT* event = android_pop_event(aCtx->event_queue);
+		const BOOL disconnect = event && event->type == EVENT_TYPE_DISCONNECT;
+		android_event_free(event);
+		if (disconnect)
+			return FALSE;
+	}
+
+	return TRUE;
+}
+
 ANDROID_EVENT_KEY* android_event_key_new(int flags, UINT16 scancode)
 {
 	ANDROID_EVENT_KEY* event = (ANDROID_EVENT_KEY*)calloc(1, sizeof(ANDROID_EVENT_KEY));

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_event.h
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_event.h
@@ -60,6 +60,7 @@ FREERDP_LOCAL BOOL android_push_event(freerdp* inst, ANDROID_EVENT* event);
 
 FREERDP_LOCAL HANDLE android_get_handle(freerdp* inst);
 FREERDP_LOCAL BOOL android_check_handle(freerdp* inst);
+FREERDP_LOCAL BOOL android_check_reconnect_handle(freerdp* inst);
 
 FREERDP_LOCAL ANDROID_EVENT_KEY* android_event_key_new(int flags, UINT16 scancode);
 FREERDP_LOCAL ANDROID_EVENT_KEY* android_event_unicodekey_new(UINT16 flags, UINT16 key);

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.c
@@ -35,6 +35,7 @@
 #include <freerdp/codec/h264.h>
 #include <freerdp/codec/video.h>
 #include <freerdp/channels/channels.h>
+#include <freerdp/client.h>
 #include <freerdp/client/channels.h>
 #include <freerdp/client/cmdline.h>
 #include <freerdp/constants.h>
@@ -223,27 +224,34 @@ static BOOL android_pre_connect(freerdp* instance)
 	WINPR_ASSERT(instance);
 	WINPR_ASSERT(instance->context);
 
+	androidContext* ctx = (androidContext*)instance->context;
 	rdpSettings* settings = instance->context->settings;
 
 	if (!settings)
 		return FALSE;
 
-	int rc = PubSub_SubscribeChannelConnected(instance->context->pubSub,
-	                                          android_OnChannelConnectedEventHandler);
-
-	if (rc != CHANNEL_RC_OK)
+	if (!ctx->channel_connected_subscribed)
 	{
-		WLog_ERR(TAG, "Could not subscribe to connect event handler [%08X]", rc);
-		return FALSE;
+		const int rc = PubSub_SubscribeChannelConnected(instance->context->pubSub,
+		                                                android_OnChannelConnectedEventHandler);
+		if (rc != CHANNEL_RC_OK)
+		{
+			WLog_ERR(TAG, "Could not subscribe to connect event handler [%08X]", rc);
+			return FALSE;
+		}
+		ctx->channel_connected_subscribed = TRUE;
 	}
 
-	rc = PubSub_SubscribeChannelDisconnected(instance->context->pubSub,
-	                                         android_OnChannelDisconnectedEventHandler);
-
-	if (rc != CHANNEL_RC_OK)
+	if (!ctx->channel_disconnected_subscribed)
 	{
-		WLog_ERR(TAG, "Could not subscribe to disconnect event handler [%08X]", rc);
-		return FALSE;
+		const int rc = PubSub_SubscribeChannelDisconnected(
+		    instance->context->pubSub, android_OnChannelDisconnectedEventHandler);
+		if (rc != CHANNEL_RC_OK)
+		{
+			WLog_ERR(TAG, "Could not subscribe to disconnect event handler [%08X]", rc);
+			return FALSE;
+		}
+		ctx->channel_disconnected_subscribed = TRUE;
 	}
 
 	freerdp_callback("OnPreConnect", "(J)V", (jlong)instance);
@@ -587,6 +595,18 @@ static DWORD android_verify_changed_certificate_ex(freerdp* instance, const char
 	return res;
 }
 
+static BOOL android_reconnect_events(freerdp* instance)
+{
+	WINPR_ASSERT(instance);
+	WINPR_ASSERT(instance->context);
+
+	if (freerdp_shall_disconnect_context(instance->context))
+		return FALSE;
+	if (!android_check_reconnect_handle(instance))
+		return FALSE;
+	return !freerdp_shall_disconnect_context(instance->context);
+}
+
 static int android_freerdp_run(freerdp* instance)
 {
 	DWORD count;
@@ -625,10 +645,8 @@ static int android_freerdp_run(freerdp* instance)
 
 		if (!freerdp_check_event_handles(context))
 		{
-			/* TODO: Auto reconnect
-			if (xf_auto_reconnect(instance))
-			    continue;
-			    */
+			if (client_auto_reconnect_ex(instance, android_reconnect_events))
+				continue;
 			WLog_ERR(TAG, "Failed to check FreeRDP file descriptor");
 			status = GetLastError();
 			break;
@@ -716,6 +734,13 @@ static void android_client_free(freerdp* instance, rdpContext* context)
 {
 	if (!context)
 		return;
+	androidContext* ctx = (androidContext*)context;
+	if (ctx->channel_connected_subscribed)
+		PubSub_UnsubscribeChannelConnected(context->pubSub,
+		                                  android_OnChannelConnectedEventHandler);
+	if (ctx->channel_disconnected_subscribed)
+		PubSub_UnsubscribeChannelDisconnected(context->pubSub,
+		                                     android_OnChannelDisconnectedEventHandler);
 
 	android_event_queue_uninit(instance);
 }

--- a/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.h
+++ b/client/Android/Studio/freeRDPCore/src/main/cpp/android_freerdp.h
@@ -31,6 +31,8 @@ typedef struct
 	HANDLE thread;
 
 	BOOL is_connected;
+	BOOL channel_connected_subscribed;
+	BOOL channel_disconnected_subscribed;
 
 	BOOL clipboardSync;
 	wClipboard* clipboard;


### PR DESCRIPTION
## What changed

- invoke `client_auto_reconnect_ex()` when the Android event loop detects an RDP handle failure
- keep explicit Android disconnect requests responsive during the delay between reconnect attempts

## Why

The Android client can enable FreeRDP automatic reconnection and negotiate the standard reconnect cookie, but its native event loop currently exits when `freerdp_check_event_handles()` fails. The common auto-reconnect implementation is therefore never called by the Android frontend.

This patch connects Android to the existing common mechanism at the same failure boundary used by other frontends. Retry policy, retry count, delay, error filtering, and protocol-cookie handling remain in FreeRDP's common implementation.

The callback passed to `client_auto_reconnect_ex()` only checks the context abort flag. FreeRDP invokes it during the delay between failed attempts, allowing the existing Android disconnect entry point to cancel promptly without adding Android event-queue policy to the reconnect path.

Related context: #4880, #7168, #10389, and #10390.

## Validation

- rebased on current FreeRDP `master`
- Android `:freeRDPCore:externalNativeBuildDebug` passed for `arm64-v8a` and `armeabi-v7a`
- downstream JNI build passed for `arm64-v8a` and `armeabi-v7a`
- formatting and `git diff --check` passed
