### PR TITLE
[utils,smartcard] exclude ndr padding from returned buffer length

### DIFF
--- a/libfreerdp/utils/smartcard_pack.c
+++ b/libfreerdp/utils/smartcard_pack.c
@@ -205,10 +205,9 @@ static LONG smartcard_ndr_read_ex(wLog* log, wStream* s, BYTE** data, const size
 		free(r);
 		return STATUS_INVALID_PARAMETER;
 	}
-	len += (size_t)pad;
 	*data = r;
 	if (plen)
-		*plen = len;
+		*plen = len; /* payload bytes only, excluding the NDR alignment padding */
 	return STATUS_SUCCESS;
 }
 

--- a/libfreerdp/utils/test/TestSmartcardPack.c
+++ b/libfreerdp/utils/test/TestSmartcardPack.c
@@ -72,6 +72,66 @@ static BOOL run_case(UINT32 cbAtr, BOOL expectAccept)
 	return TRUE;
 }
 
+/* Build a SetAttrib call (cbContext=0, cbHandle=0) whose pbAttr NDR conformant array
+ * carries cbAttr payload bytes, with the requested cbAttrLen field. */
+static wStream* build_set_attrib(UINT32 cbAttr, UINT32 cbAttrLen)
+{
+	const UINT32 pad = (4 - (cbAttr % 4)) % 4;
+	wStream* s = Stream_New(nullptr, 28 + 4 + cbAttr + pad);
+	if (!s)
+		return nullptr;
+
+	Stream_Write_UINT32(s, 0);          /* cbContext = 0 */
+	Stream_Write_UINT32(s, 0);          /* pbContextNdrPtr = 0 */
+	Stream_Write_UINT32(s, 0);          /* cbHandle = 0 */
+	Stream_Write_UINT32(s, 0x00020000); /* pbHandleNdrPtr */
+	Stream_Write_UINT32(s, 0);          /* dwAttrId */
+	Stream_Write_UINT32(s, cbAttrLen);  /* cbAttrLen */
+	Stream_Write_UINT32(s, 0x00020004); /* pbAttrNdrPtr */
+	Stream_Write_UINT32(s, cbAttr);     /* conformant count */
+	Stream_Zero(s, cbAttr);             /* pbAttr payload */
+	if (pad)
+		Stream_Zero(s, pad); /* NDR 4-byte alignment padding */
+
+	Stream_SealLength(s);
+	if (!Stream_SetPosition(s, 0))
+	{
+		Stream_Free(s, TRUE);
+		return nullptr;
+	}
+	return s;
+}
+
+/* cbAttrLen must be clamped to the pbAttr payload length, never to the padded
+ * NDR size, otherwise SCardSetAttrib reads past the pbAttr allocation. */
+static BOOL run_set_attrib_case(UINT32 cbAttr, UINT32 cbAttrLen)
+{
+	wStream* s = build_set_attrib(cbAttr, cbAttrLen);
+	if (!s)
+		return FALSE;
+
+	SetAttrib_Call call = { 0 };
+	const LONG status = smartcard_unpack_set_attrib_call(s, &call);
+	Stream_Free(s, TRUE);
+
+	BOOL rc = TRUE;
+	if (status != SCARD_S_SUCCESS)
+	{
+		printf("set_attrib cbAttr=%" PRIu32 ": unpack returned 0x%08" PRIX32 "\n", cbAttr,
+		       (UINT32)status);
+		rc = FALSE;
+	}
+	else if (call.cbAttrLen > cbAttr)
+	{
+		printf("set_attrib cbAttr=%" PRIu32 ": cbAttrLen=%" PRIu32 " exceeds payload\n", cbAttr,
+		       call.cbAttrLen);
+		rc = FALSE;
+	}
+
+	free(call.pbAttr);
+	return rc;
+}
+
 int TestSmartcardPack(int argc, char* argv[])
 {
 	WINPR_UNUSED(argc);
@@ -87,6 +147,17 @@ int TestSmartcardPack(int argc, char* argv[])
 	if (!run_case(37, FALSE))
 		return -1;
 	if (!run_case(0xFFFFFFFF, FALSE))
+		return -1;
+
+	/* Unaligned pbAttr lengths must not let cbAttrLen reach into the NDR padding. */
+	if (!run_set_attrib_case(1, 0xFFFFFFFF))
+		return -1;
+	if (!run_set_attrib_case(5, 0xFFFFFFFF))
+		return -1;
+	/* Aligned length and a small cbAttrLen must be preserved. */
+	if (!run_set_attrib_case(4, 0xFFFFFFFF))
+		return -1;
+	if (!run_set_attrib_case(8, 2))
 		return -1;
 
 	return 0;


### PR DESCRIPTION
**Heap over-read in the smartcard SetAttrib decode path**

`smartcard_ndr_read_ex` allocates `count + sizeof(WCHAR)` bytes for the conformant array but returns `count` plus the NDR 4-byte alignment padding through `*plen`. `smartcard_unpack_set_attrib_call` is the only caller that consumes that length, using it to cap the server-controlled `cbAttrLen`; a `pbAttr` whose length is not a multiple of four therefore lets `cbAttrLen` exceed the allocation, and `SCardSetAttrib` reads past the `pbAttr` buffer. Report the payload length only; the padding is still consumed by the stream seek. The added `TestSmartcardPack` case fails against the current length.