### PR TITLE
[channels,drdynvc] fix channel unref on create request send failure

### DIFF
--- a/channels/drdynvc/client/drdynvc_main.c
+++ b/channels/drdynvc/client/drdynvc_main.c
@@ -871,6 +871,7 @@ static DVCMAN_CHANNEL* dvcman_create_channel(drdynvcPlugin* drdynvc,
 		           "OnNewChannelConnection failed with error %" PRIu32 "!", *res);
 		*res = ERROR_INTERNAL_ERROR;
 		dvcman_channel_unref(channel);
+		channel = nullptr;
 		goto out;
 	}
 
@@ -1432,7 +1433,8 @@ static UINT drdynvc_process_create_request(drdynvcPlugin* drdynvc, UINT8 Sp, UIN
 	{
 		WLog_Print(drdynvc->log, WLOG_ERROR, "VirtualChannelWriteEx failed with %s [%08" PRIX32 "]",
 		           WTSErrorToString(status), status);
-		dvcman_channel_unref(channel);
+		if (channel_status == CHANNEL_RC_OK)
+			dvcman_channel_unref(channel);
 		return status;
 	}
 


### PR DESCRIPTION
**Bad channel unref on create-request send failure**

On a failed create-response send, `drdynvc_process_create_request` unrefs the channel returned by `dvcman_create_channel`, but it only owns that reference when creation actually succeeded. For a duplicate, unknown or rejected channel id the returned pointer is NULL, a live channel this call never referenced, or (on the `OnNewChannelConnection` failure branch, which unlike its sibling never cleared the pointer) an already-freed one, so the unref becomes a null dereference, a premature free of a channel still in use, or a double free, reachable from a server that sends a create request for such a channel id when the response write fails. Limited the rollback unref to the success path and cleared the freed pointer in that failure branch so the helper no longer hands back a dangling channel.