### PR TITLE
[crypto] gracefully handle failed BIO/SSL creation error

### DIFF
--- a/libfreerdp/crypto/tls.c
+++ b/libfreerdp/crypto/tls.c
@@ -825,7 +825,13 @@ static BOOL tls_prepare(rdpTls* tls, BIO* underlying, SSL_METHOD* method, int op
 
 	tls->bio = BIO_new_rdp_tls(tls->ctx, clientMode);
 
-	if (BIO_get_ssl(tls->bio, &tls->ssl) < 0)
+	if (!tls->bio)
+	{
+		WLog_ERR(TAG, "unable to create TLS BIO");
+		return FALSE;
+	}
+
+	if (BIO_get_ssl(tls->bio, &tls->ssl) < 0 || !tls->ssl)
 	{
 		WLog_ERR(TAG, "unable to retrieve the SSL of the connection");
 		return FALSE;


### PR DESCRIPTION
This patch fixes the following recorded crash that was detected with FreeRDP 3.20.2:

0   libssl.so.3                     0x7ff638e30415      SSL_use_PrivateKey (ssl_rsa.c:146)
1   libfreerdp3.so.3                0x7ff5fe09457c      [inlined] freerdp_tls_accept_ex (tls.c:1179)
2   libfreerdp3.so.3                0x7ff5fe09457c      [inlined] freerdp_tls_accept_ex (tls.c:1109)
3   libfreerdp3.so.3                0x7ff5fe09457c      [inlined] freerdp_tls_accept (tls.c:1093)
4   libfreerdp3.so.3                0x7ff5fe09457c      transport_default_accept_tls (transport.c:707)
5   libfreerdp3.so.3                0x7ff5fe0afa1e      [inlined] transport_accept_tls (transport.c:689)
6   libfreerdp3.so.3                0x7ff5fe0afa1e      [inlined] rdp_server_accept_nego (connection.c:1543)
7   libfreerdp3.so.3                0x7ff5fe0afa1e      [inlined] peer_recv_callback_internal (peer.c:818)
8   libfreerdp3.so.3                0x7ff5fe0afa1e      peer_recv_callback.lto_priv.0 (peer.c:1177)
9   libfreerdp3.so.3                0x7ff5fe083b28      [inlined] transport_check_fds (transport.c:1526)
10  libfreerdp3.so.3                0x7ff5fe083b28      rdp_check_fds (rdp.c:2280)
11  libfreerdp3.so.3                0x7ff5fe0a3c3c      freerdp_peer_check_fds.lto_priv.0 (peer.c:331)
[...]
