### PR TITLE
[codec,yuv] bound avc444v2 chroma combine to decoded frame width

### DIFF
--- a/libfreerdp/codec/yuv.c
+++ b/libfreerdp/codec/yuv.c
@@ -474,7 +474,12 @@ static void CALLBACK yuv444_combine_work_callback(PTP_CALLBACK_INSTANCE instance
 	const RECTANGLE_16* rect = &param->rect;
 	WINPR_ASSERT(rect);
 
-	const UINT32 alignedWidth = yuv->width + ((yuv->width % 32 != 0) ? 32 - yuv->width % 32 : 0);
+	/* For AVC444v2 the combine reads the V (and second half U) samples from the
+	 * decoded auxiliary plane at a fixed nTotalWidth offset. A server may send a
+	 * frame smaller than the surface, so cap the aligned width at the Y plane
+	 * stride to keep that offset inside the decoded plane. */
+	const UINT32 alignedWidth =
+	    MIN(yuv->width + ((yuv->width % 32 != 0) ? 32 - yuv->width % 32 : 0), param->iStride[0]);
 	const UINT32 alignedHeight =
 	    yuv->height + ((yuv->height % 16 != 0) ? 16 - yuv->height % 16 : 0);
 


### PR DESCRIPTION
**Out-of-bounds read in the AVC444v2 chroma combine**

The combine takes its width from the surface, but `general_ChromaV2ToYUV444` uses that value as a fixed `nTotalWidth` offset into the decoded auxiliary plane to reach the V (and second half U) samples. When a server sends an AVC444v2 frame smaller than the surface, which is already permitted elsewhere (see the krdc note in `log_decompress`), that offset lands past the decoded plane and the source heap is over-read. The rect checks bound the copied region but not this fixed offset, so it slips through.

Bounded the width to the decoded source stride so the offset stays inside the decoded plane. Full-size frames are unaffected, since the surface width stays the smaller value there.

Reachable from a malicious server through an RDPGFX AVC444v2 surface command. Existing codec unit tests (`TestFreeRDPCodecH264` and the primitive tests) still pass.