### PR TITLE
[client,common] use configured AAD authority for sso-mib

### DIFF
--- a/client/common/sso_mib_tokens.c
+++ b/client/common/sso_mib_tokens.c
@@ -6,6 +6,7 @@
 #include <sso-mib/sso-mib.h>
 #include <freerdp/crypto/crypto.h>
 #include <winpr/json.h>
+#include <winpr/string.h>
 
 #include "sso_mib_tokens.h"
 
@@ -144,8 +145,31 @@ static BOOL sso_mib_get_access_token(rdpContext* context, AccessTokenType tokenT
 	{
 		const char* client_id =
 		    freerdp_settings_get_string(context->settings, FreeRDP_GatewayAvdClientID);
-		client_context->mibClientWrapper->app =
-		    mib_public_client_app_new(client_id, MIB_AUTHORITY_COMMON, nullptr, nullptr);
+
+		/* Build the authority from the configured AAD host and tenant (see
+		 * freerdp_utils_aad_get_wellknown) so broker SSO works against sovereign clouds
+		 * (e.g. login.microsoftonline.us). Defaults resolve to MIB_AUTHORITY_COMMON. */
+		const char* base =
+		    freerdp_settings_get_string(context->settings, FreeRDP_GatewayAzureActiveDirectory);
+		const BOOL useTenant =
+		    freerdp_settings_get_bool(context->settings, FreeRDP_GatewayAvdUseTenantid);
+		const char* tenantid = "common";
+		if (useTenant)
+			tenantid =
+			    freerdp_settings_get_string(context->settings, FreeRDP_GatewayAvdAadtenantid);
+
+		char* authority = nullptr;
+		if (base && tenantid)
+		{
+			size_t len = 0;
+			winpr_asprintf(&authority, &len, "https://%s/%s", base, tenantid);
+			if (!authority)
+				return FALSE;
+		}
+
+		client_context->mibClientWrapper->app = mib_public_client_app_new(
+		    client_id, authority ? authority : MIB_AUTHORITY_COMMON, nullptr, nullptr);
+		free(authority);
 	}
 
 	if (!client_context->mibClientWrapper->app)


### PR DESCRIPTION
## What it does

The sso-mib broker app is always created with `MIB_AUTHORITY_COMMON`
(`https://login.microsoftonline.com/common`), which only exists in the Azure
commercial cloud. Users of sovereign clouds (Azure US Gov, Azure China, ...)
hold their PRT under a different authority (e.g. `login.microsoftonline.us`),
so the broker account lookup misses and the client silently falls back to
browser-based authentication — which the AVD ARM gateways in those clouds
reject. Today the only workaround is binary-patching the authority string in
`libfreerdp-client`.

This change builds the authority from the settings that already exist for the
rest of the AAD flow: `FreeRDP_GatewayAzureActiveDirectory` and, when
`GatewayAvdUseTenantid` is enabled, `FreeRDP_GatewayAvdAadtenantid` — mirroring
the semantics of `freerdp_utils_aad_get_wellknown`. The defaults resolve to
`https://login.microsoftonline.com/common`, so behaviour is unchanged unless
`/azure:ad:...` is explicitly configured.

Note on lifetime: sso-mib copies the authority string internally
(`g_strdup`), so freeing it after `mib_public_client_app_new` is safe.

## How to test

Commercial cloud: no configuration change, defaults produce the identical
authority URL — no behaviour change.

Sovereign cloud (requires a microsoft-identity-broker with a PRT for the
sovereign tenant):

```
xfreerdp <workspace.rdpw> /u:<upn> /sec:aad /gateway:type:arm \
  /azure:tenantid:<tenant-guid>,use-tenantid:off,ad:login.microsoftonline.us,avd-scope:https://www.wvd.azure.us/.default
```

Before: log shows `Getting AVD token from identity broker failed, falling back
to browser-based authentication.` and the connection fails at the ARM gateway.

After: both tokens are acquired silently through the broker and the connection
proceeds. Verified against an Azure US Gov AVD deployment (RD gateway
`rdgateway-r1.wvd.azure.us`) with smartcard redirection.
