### PR TITLE
[gdi] bound hatched brush pattern index in gdi_patblt

### DIFF
--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -623,8 +623,13 @@ static BOOL gdi_patblt(rdpContext* context, PATBLT_ORDER* patblt)
 
 		case GDI_BS_HATCHED:
 		{
-			const BYTE* hatched = nullptr;
-			hatched = GDI_BS_HATCHED_PATTERNS + (8ULL * brush->hatch);
+			if (brush->hatch >= ARRAYSIZE(GDI_BS_HATCHED_PATTERNS) / 8)
+			{
+				WLog_ERR(TAG, "invalid brush hatch:%" PRIu32 "", brush->hatch);
+				goto out_error;
+			}
+
+			const BYTE* hatched = &GDI_BS_HATCHED_PATTERNS[8ULL * brush->hatch];
 
 			if (!freerdp_image_copy_from_monochrome(data, gdi->drawing->hdc->format, 0, 0, 0, 8, 8,
 			                                        hatched, backColor, foreColor, &gdi->palette))


### PR DESCRIPTION
PatBlt orders carry a brush whose hatch field is read straight off the wire as a byte in `update_read_brush`, and it is left unbounded there because the same field doubles as a cache index for cached brushes and as pattern data for pattern brushes. `gdi_patblt` then treats it as a style selector and forms a pointer with `GDI_BS_HATCHED_PATTERNS + 8 * hatch`, but that table only holds the six styles MS-RDPEGDI defines, 48 bytes in total. A server sending brushStyle 0x02 with a brushHatch of 6 or more walks off the end, and `freerdp_image_copy_from_monochrome` reads its 8 bytes from whatever follows in .rodata before they are blitted into the framebuffer as the 8x8 brush. I noticed it while looking at how the cached-brush path reuses that field and realised the hatched path never re-validates it. Rejecting an index outside the table inside `gdi_patblt` seemed the safest place, since the parser cannot bound the field without breaking the other two uses of it. Hatch styles 0 to 5 behave exactly as before.

To test, drive the client GDI with a PatBlt order whose brush style is `GDI_BS_HATCHED` and whose hatch is 6 or greater. An address-sanitiser build reports a global-buffer-overflow read 0 bytes after `GDI_BS_HATCHED_PATTERNS` (size 48) inside `freerdp_image_copy_from_monochrome`, called from `gdi_patblt`. With the patch that order is rejected and 0 to 5 still render. Full build and ctest stay green here, clang-format clean.