### PR TITLE
Fix Windows Shadow settings and MinGW build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,8 +126,11 @@ message("FREERDP_VERSION=${FREERDP_VERSION_FULL}")
 
 message(STATUS "Git Revision ${GIT_REVISION}")
 
-# MSVC compatibility with system headers
-add_compile_definitions(NONAMELESSUNION)
+# This macro is only required for MSVC system header compatibility. Defining it on MinGW breaks
+# access to COM anonymous-union members.
+if(MSVC)
+  add_compile_definitions(NONAMELESSUNION)
+endif()
 
 # Make the detected version available as default version for all subprojects
 set(FREERDP_DEFAULT_PROJECT_VERSION ${FREERDP_VERSION} CACHE STRING INTERNAL)

--- a/channels/remdesk/common/CMakeLists.txt
+++ b/channels/remdesk/common/CMakeLists.txt
@@ -19,6 +19,9 @@
 set(SRCS remdesk_common.h remdesk_common.c)
 
 add_library(remdesk-common STATIC ${SRCS})
+# The remdesk common implementation uses WinPR stream APIs. Propagate the dependency to preserve
+# static-library link order.
+target_link_libraries(remdesk-common PUBLIC winpr)
 set_property(TARGET remdesk-common PROPERTY FOLDER "Channels/${CHANNEL_NAME}/Common")
 
 freerdp_client_pc_add_library_private(remdesk-common)

--- a/server/shadow/Win/win_rdp.c
+++ b/server/shadow/Win/win_rdp.c
@@ -307,11 +307,13 @@ static BOOL shw_freerdp_client_new(freerdp* instance, rdpContext* context)
 		return FALSE;
 	if (!freerdp_settings_set_bool(settings, FreeRDP_BitmapCacheV3Enabled, FALSE))
 		return FALSE;
-	if (!freerdp_settings_set_bool(settings, FreeRDP_OffscreenSupportLevel, FALSE))
+	/* These capability level fields are UINT32. Using the boolean setter makes Shadow initialization
+	 * fail before the client can connect. */
+	if (!freerdp_settings_set_uint32(settings, FreeRDP_OffscreenSupportLevel, 0))
 		return FALSE;
 	if (!freerdp_settings_set_uint32(settings, FreeRDP_GlyphSupportLevel, GLYPH_SUPPORT_NONE))
 		return FALSE;
-	if (!freerdp_settings_set_bool(settings, FreeRDP_BrushSupportLevel, FALSE))
+	if (!freerdp_settings_set_uint32(settings, FreeRDP_BrushSupportLevel, 0))
 		return FALSE;
 	ZeroMemory(freerdp_settings_get_pointer_writable(settings, FreeRDP_OrderSupport), 32);
 	if (!freerdp_settings_set_bool(settings, FreeRDP_FrameMarkerCommandEnabled, TRUE))
@@ -330,7 +332,8 @@ static BOOL shw_freerdp_client_new(freerdp* instance, rdpContext* context)
 		return FALSE;
 	if (!freerdp_settings_set_bool(settings, FreeRDP_FastPathOutput, TRUE))
 		return FALSE;
-	if (!freerdp_settings_set_bool(settings, FreeRDP_LargePointerFlag, TRUE))
+	/* The large-pointer flag is also UINT32; keep the setter consistent with its settings metadata. */
+	if (!freerdp_settings_set_uint32(settings, FreeRDP_LargePointerFlag, 1))
 		return FALSE;
 	if (!freerdp_settings_set_bool(settings, FreeRDP_CompressionEnabled, FALSE))
 		return FALSE;

--- a/winpr/CMakeLists.txt
+++ b/winpr/CMakeLists.txt
@@ -47,8 +47,11 @@ if(NOT FREERDP_UNIFIED_BUILD)
     set(DEFAULT_DEBUG_OPTION "OFF" CACHE INTERNAL "debug default")
   endif()
 
-  # MSVC compatibility with system headers
-  add_compile_definitions(NONAMELESSUNION)
+  # This macro is only required for MSVC system header compatibility. Defining it on MinGW breaks
+  # access to COM anonymous-union members.
+  if(MSVC)
+    add_compile_definitions(NONAMELESSUNION)
+  endif()
 
   set(OPENSSL_FEATURE_TYPE "RECOMMENDED")
   set(OPENSSL_FEATURE_PURPOSE "cryptography")


### PR DESCRIPTION
## Summary
- scope the MSVC-specific `NONAMELESSUNION` definition to MSVC CMake builds
- use `UINT32` setting setters for Windows Shadow capability-level fields
- propagate the WinPR dependency from the Remdesk common channel

## Validation
- built the `freerdp-shadow-cli` target with MSYS2 UCRT64 and native SSPI using a server-focused configuration