### PR TITLE
[settings] allow null arg in freerdp_addin_argv_new

### DIFF
--- a/libfreerdp/common/settings.c
+++ b/libfreerdp/common/settings.c
@@ -741,6 +741,8 @@ ADDIN_ARGV* freerdp_addin_argv_new(size_t argc, const char* const argv[])
 	{
 		for (size_t x = 0; x < argc; x++)
 		{
+			if (!argv[x])
+				continue;
 			args->argv[x] = _strdup(argv[x]);
 			if (!args->argv[x])
 				goto fail;


### PR DESCRIPTION
This is needed because rdpdr sets the third arg to NULL to indicate the drive is automounted.

