### PR TITLE
[winpr,ntlm] require 16 byte signature buffer before access

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -1513,6 +1513,9 @@ static SECURITY_STATUS SEC_ENTRY ntlm_EncryptMessage(PCtxtHandle phContext,
 	if (!signature_buffer)
 		return SEC_E_INVALID_TOKEN;
 
+	if (signature_buffer->cbBuffer < 16)
+		return SEC_E_INSUFFICIENT_MEMORY;
+
 	/* Copy original data buffer */
 	ULONG length = data_buffer->cbBuffer;
 	void* data = malloc(length);
@@ -1621,6 +1624,9 @@ static SECURITY_STATUS SEC_ENTRY ntlm_DecryptMessage(PCtxtHandle phContext, PSec
 		return SEC_E_INVALID_TOKEN;
 
 	if (!signature_buffer)
+		return SEC_E_INVALID_TOKEN;
+
+	if (signature_buffer->cbBuffer < 16)
 		return SEC_E_INVALID_TOKEN;
 
 	/* Copy original data buffer */
@@ -1735,6 +1741,9 @@ static SECURITY_STATUS SEC_ENTRY ntlm_MakeSignature(PCtxtHandle phContext,
 	if (!data_buffer || !sig_buffer)
 		return SEC_E_INVALID_TOKEN;
 
+	if (sig_buffer->cbBuffer < 16)
+		return SEC_E_INSUFFICIENT_MEMORY;
+
 	WINPR_HMAC_CTX* hmac = winpr_HMAC_New();
 
 	if (!winpr_HMAC_Init(hmac, WINPR_MD_MD5, context->SendSigningKey, WINPR_MD5_DIGEST_LENGTH))
@@ -1789,7 +1798,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_VerifySignature(PCtxtHandle phContext,
 			sig_buffer = &pMessage->pBuffers[i];
 	}
 
-	if (!data_buffer || !sig_buffer)
+	if (!data_buffer || !sig_buffer || (sig_buffer->cbBuffer < 16))
 		return SEC_E_INVALID_TOKEN;
 
 	WINPR_HMAC_CTX* hmac = winpr_HMAC_New();

--- a/winpr/libwinpr/sspi/test/TestSspiNTLM.c
+++ b/winpr/libwinpr/sspi/test/TestSspiNTLM.c
@@ -260,6 +260,46 @@ static BOOL test_attributes(WINPR_ATTR_UNUSED SecurityFunctionTable* table,
 }
 
 WINPR_ATTR_NODISCARD
+static BOOL test_short_signature(SecurityFunctionTable* table, CtxtHandle* context)
+{
+	BYTE data[16] = WINPR_C_ARRAY_INIT;
+	BOOL rc = FALSE;
+
+	WINPR_ASSERT(table);
+	WINPR_ASSERT(context);
+
+	/* An NTLM signature is 16 bytes. A peer may announce a shorter one, so both
+	 * MakeSignature and VerifySignature must reject the buffer instead of
+	 * accessing the missing bytes. Allocate exactly one byte so that any access
+	 * past it is detectable. */
+	BYTE* signature = malloc(1);
+	if (!signature)
+		return FALSE;
+
+	SecBuffer buffers[2] = WINPR_C_ARRAY_INIT;
+	buffers[0].BufferType = SECBUFFER_DATA;
+	buffers[0].pvBuffer = data;
+	buffers[0].cbBuffer = sizeof(data);
+	buffers[1].BufferType = SECBUFFER_TOKEN;
+	buffers[1].pvBuffer = signature;
+	buffers[1].cbBuffer = 1;
+
+	SecBufferDesc desc = { SECBUFFER_VERSION, ARRAYSIZE(buffers), buffers };
+
+	if (table->MakeSignature(context, 0, &desc, 0) == SEC_E_OK)
+		goto fail;
+
+	ULONG qop = 0;
+	if (table->VerifySignature(context, &desc, 0, &qop) == SEC_E_OK)
+		goto fail;
+
+	rc = TRUE;
+fail:
+	free(signature);
+	return rc;
+}
+
+WINPR_ATTR_NODISCARD
 static void* getServerAuthData(TEST_NTLM_SERVER* ntlm, const struct test_input_t* arg,
                                psSspiNtlmHashCallback fkt)
 {
@@ -911,6 +951,12 @@ static BOOL test_default(const struct test_input_t* arg, psSspiNtlmHashCallback 
 	if (status < 0)
 	{
 		printf("test_ntlm_server_authenticate failure\n");
+		goto fail;
+	}
+
+	if (!test_short_signature(server->table, &server->context))
+	{
+		printf("test_short_signature failure\n");
 		goto fail;
 	}
 


### PR DESCRIPTION
**Unchecked 16 byte signature access in the NTLM package**

The four signature entry points only test the `SECBUFFER_TOKEN` for NULL, yet its size is peer controlled: SPNEGO's `mechListMIC` length reaches `mic.cbBuffer` verbatim and `negotiate_mic_exchange` forwards anything non-empty, so a one byte MIC reads 15 bytes past an exactly sized token allocation, and the outgoing MIC slot carved out of the leftover output buffer can be under 16 bytes as well, which makes the sign side a write. Kerberos already rejects an undersized buffer in the same four calls, so this mirrors those checks and their status codes; `TestSspiNTLM` now covers both directions.