### PR TITLE
[client,sdl] stop drawing when update queue is empty, fixes high CPU

### DIFF
--- a/client/SDL/SDL3/sdl_context.cpp
+++ b/client/SDL/SDL3/sdl_context.cpp
@@ -1508,6 +1508,9 @@ bool SdlContext::useLocalScale() const
 
 bool SdlContext::drawToWindows(const std::vector<SDL_Rect>& rects)
 {
+	if (rects.empty())
+		return true;
+
 	for (auto& window : _windows)
 	{
 		if (!drawToWindow(window.second, rects))


### PR DESCRIPTION
SdlWindow treats an empty rectangle list as a request to redraw the full surface. The SDL_EVENT_USER_UPDATE handler passed the empty result of SdlContext::pop to drawToWindows before terminating its loop.

Check for an empty result first to avoid unnecessary full-frame texture uploads, including those caused by stale update events after the queue has already been drained.

Before this patch, my CPU usage was 60% of a single core on a 3840x2400 resolution client, when idle. After the patch, it's 8%.

Assisted-by: gpt-5.6-sol