### PR TITLE
Avoid reallocating MonitorDefArray in enforce_monitor_exists()

### DIFF
--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -1812,8 +1812,37 @@ BOOL freerdp_settings_enforce_monitor_exists(rdpSettings* settings)
 		monitor.attributes.orientation = orientation;
 		monitor.attributes.desktopScaleFactor = desktopScaleFactor;
 		monitor.attributes.deviceScaleFactor = deviceScaleFactor;
-		if (!freerdp_settings_set_monitor_def_array_sorted(settings, &monitor, 1))
-			return FALSE;
+
+		/*
+		 * If the MonitorDefArray already has room for at least 1 entry,
+		 * write directly instead of calling set_monitor_def_array_sorted().
+		 * The latter reallocates the array (free + calloc), which invalidates
+		 * any pointer previously obtained via freerdp_settings_get_pointer().
+		 * See https://github.com/FreeRDP/FreeRDP/issues/13122
+		 */
+		const UINT32 arraySize =
+		    freerdp_settings_get_uint32(settings, FreeRDP_MonitorDefArraySize);
+		if (arraySize >= 1)
+		{
+			rdpMonitor* arr =
+			    freerdp_settings_get_pointer_writable(settings, FreeRDP_MonitorDefArray);
+			WINPR_ASSERT(arr);
+			arr[0] = monitor;
+			arr[0].x = 0;
+			arr[0].y = 0;
+			arr[0].is_primary = TRUE;
+			if (!freerdp_settings_set_int32(settings, FreeRDP_MonitorLocalShiftX,
+			                                 monitor.x))
+				return FALSE;
+			if (!freerdp_settings_set_int32(settings, FreeRDP_MonitorLocalShiftY,
+			                                 monitor.y))
+				return FALSE;
+		}
+		else
+		{
+			if (!freerdp_settings_set_monitor_def_array_sorted(settings, &monitor, 1))
+				return FALSE;
+		}
 	}
 
 	return TRUE;


### PR DESCRIPTION
## What

`freerdp_settings_enforce_monitor_exists()` called `set_monitor_def_array_sorted()` which reallocates `MonitorDefArray` via `free()`+`calloc()`. This silently invalidated any pointer previously obtained via `freerdp_settings_get_pointer()`, causing heap corruption in callers that cached the pointer.

## Root cause

See #13122 for full analysis.

## Fix

When the array already has room (always true after initialization, which allocates 32 elements), write directly to `arr[0]` instead, replicating the exact same field assignments (`x=0`, `y=0`, `is_primary=TRUE`, `MonitorLocalShiftX/Y`). Falls back to `set_monitor_def_array_sorted()` only if the array is empty (defensive edge case).

## Safety

- The direct-write path produces **identical results** to `set_monitor_def_array_sorted()` for a single primary monitor at (0,0): same struct fields, same shift values, same `MonitorCount`
- The fallback path preserves the old behavior for the impossible-but-defensive case where `MonitorDefArraySize == 0`
- No API change, no struct change, no behavioral change for callers that don't cache pointers

## Testing

Tested on Debian 13 trixie with FreeRDP 3.15.0. Remmina 1.4.39 (which caches the pointer and writes to it) no longer crashes.

Closes #13122