### PR TITLE
cmake: add C++ filesystem detection module

### DIFF
--- a/client/SDL/CMakeLists.txt
+++ b/client/SDL/CMakeLists.txt
@@ -31,6 +31,7 @@ message("project ${PROJECT_NAME} is using version ${PROJECT_VERSION}")
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/)
 include(ProjectCXXStandard)
 include(CommonConfigOptions)
+include(DetectCXXFilesystem)
 
 include(ConfigureFreeRDP)
 include(CXXCompilerFlags)

--- a/client/SDL/SDL3/dialogs/res/CMakeLists.txt
+++ b/client/SDL/SDL3/dialogs/res/CMakeLists.txt
@@ -26,6 +26,6 @@ else()
   target_link_libraries(sdl3_client_res ${SDL3_LIBRARIES})
 endif()
 
-target_link_libraries(sdl3_client_res sdl-common-client-res)
+target_link_libraries(sdl3_client_res sdl-common-client-res freerdp-cxx-filesystem)
 
 set_target_properties(sdl3_client_res PROPERTIES POSITION_INDEPENDENT_CODE ON INTERPROCEDURAL_OPTIMIZATION OFF)

--- a/client/SDL/common/CMakeLists.txt
+++ b/client/SDL/common/CMakeLists.txt
@@ -25,7 +25,7 @@ if(WIN32)
 endif()
 
 add_library(sdl-common-prefs STATIC ${SRCS})
-target_link_libraries(sdl-common-prefs winpr freerdp)
+target_link_libraries(sdl-common-prefs winpr freerdp freerdp-cxx-filesystem)
 set_property(TARGET sdl-common-prefs PROPERTY FOLDER "Client/Common")
 
 if(BUILD_TESTING_INTERNAL OR BUILD_TESTING)

--- a/client/SDL/common/res/CMakeLists.txt
+++ b/client/SDL/common/res/CMakeLists.txt
@@ -104,5 +104,6 @@ else()
 endif()
 
 add_library(sdl-common-client-res STATIC ${RES_FILES} ${SRCS} ${FACTORY_HDR} ${FACTORY_SRCS})
+target_link_libraries(sdl-common-client-res freerdp-cxx-filesystem)
 set_property(TARGET sdl-common-client-res PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET sdl-common-client-res PROPERTY FOLDER "Client/Common")

--- a/client/SDL/common/test/CMakeLists.txt
+++ b/client/SDL/common/test/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}/../aad")
 
 add_executable(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
 
-set(${MODULE_PREFIX}_LIBS freerdp freerdp-client winpr sdl-common-prefs sdl-common-aad-view)
+set(${MODULE_PREFIX}_LIBS freerdp freerdp-client winpr sdl-common-prefs sdl-common-aad-view freerdp-cxx-filesystem)
 
 target_link_libraries(${MODULE_NAME} ${${MODULE_PREFIX}_LIBS})
 

--- a/cmake/DetectCXXFilesystem.cmake
+++ b/cmake/DetectCXXFilesystem.cmake
@@ -1,0 +1,70 @@
+# FreeRDP: A Remote Desktop Protocol Implementation
+# FreeRDP cmake build script
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CheckCXXSourceCompiles)
+
+set(FREERDP_CXX_FILESYSTEM_TEST_SOURCE
+    "
+#ifndef __has_include
+#define __has_include(x) 0
+#endif
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#error Could not find system header \"<filesystem>\" or \"<experimental/filesystem>\"
+#endif
+
+int main()
+{
+	fs::path path{\".\"};
+	return fs::exists(path) ? 0 : 0;
+}
+"
+)
+
+set(FREERDP_CXX_FILESYSTEM_LIBRARIES "")
+check_cxx_source_compiles("${FREERDP_CXX_FILESYSTEM_TEST_SOURCE}" FREERDP_CXX_FILESYSTEM_LINKS_WITHOUT_LIB)
+
+if(NOT FREERDP_CXX_FILESYSTEM_LINKS_WITHOUT_LIB)
+  set(_FREERDP_CXX_FILESYSTEM_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}")
+
+  set(CMAKE_REQUIRED_LIBRARIES stdc++fs)
+  check_cxx_source_compiles("${FREERDP_CXX_FILESYSTEM_TEST_SOURCE}" FREERDP_CXX_FILESYSTEM_LINKS_WITH_STDCXXFS)
+  if(FREERDP_CXX_FILESYSTEM_LINKS_WITH_STDCXXFS)
+    set(FREERDP_CXX_FILESYSTEM_LIBRARIES stdc++fs)
+  else()
+    set(CMAKE_REQUIRED_LIBRARIES c++fs)
+    check_cxx_source_compiles("${FREERDP_CXX_FILESYSTEM_TEST_SOURCE}" FREERDP_CXX_FILESYSTEM_LINKS_WITH_CXXFS)
+    if(FREERDP_CXX_FILESYSTEM_LINKS_WITH_CXXFS)
+      set(FREERDP_CXX_FILESYSTEM_LIBRARIES c++fs)
+    endif()
+  endif()
+
+  set(CMAKE_REQUIRED_LIBRARIES "${_FREERDP_CXX_FILESYSTEM_REQUIRED_LIBRARIES}")
+endif()
+
+if(NOT FREERDP_CXX_FILESYSTEM_LINKS_WITHOUT_LIB AND NOT FREERDP_CXX_FILESYSTEM_LIBRARIES)
+  message(FATAL_ERROR "C++ filesystem support is required but could not be linked")
+endif()
+
+add_library(freerdp-cxx-filesystem INTERFACE)
+if(FREERDP_CXX_FILESYSTEM_LIBRARIES)
+  target_link_libraries(freerdp-cxx-filesystem INTERFACE ${FREERDP_CXX_FILESYSTEM_LIBRARIES})
+endif()


### PR DESCRIPTION
Add DetectCXXFilesystem.cmake module to detect and configure C++ filesystem support (std::filesystem or std::experimental::filesystem) with appropriate link libraries (stdc++fs, c++fs, or none).

Link freerdp-cxx-filesystem interface library to SDL client targets:
- sdl-common-prefs
- sdl-common-client-res
- sdl3_client_res
- sdl-common-test targets

This enables C++17 filesystem usage in SDL client code with proper cross-platform library linking.

Addresses review feedback from PR #12878 to split functional C++ changes from Docker test infrastructure.