### PR TITLE
[urbdrc] Fix TRANSFER_OUT completion framing

### DIFF
--- a/channels/urbdrc/client/data_transfer.c
+++ b/channels/urbdrc/client/data_transfer.c
@@ -97,15 +97,25 @@ fail:
 	return status;
 }
 
+/* [MS-RDPEUSB] 2.2.7.2 and 2.2.7.3:
+ * Only a TRANSFER_IN_REQUEST that returns data carries an OutputBuffer.
+ * TRANSFER_OUT_REQUEST reports the transferred byte count in OutputBufferSize,
+ * but always uses URB_COMPLETION_NO_DATA. */
+static UINT32 urb_completion_payload_size(int transferDir, UINT32 outputBufferSize)
+{
+	return (transferDir == USBD_TRANSFER_DIRECTION_IN) ? outputBufferSize : 0;
+}
+
 static UINT urb_write_completion(WINPR_ATTR_UNUSED IUDEVICE* pdev,
                                  GENERIC_CHANNEL_CALLBACK* callback, BOOL noAck, wStream* out,
                                  UINT32 InterfaceId, UINT32 MessageId, UINT32 RequestId,
-                                 UINT32 usbd_status, UINT32 OutputBufferSize)
+                                 UINT32 usbd_status, UINT32 OutputBufferSize, int transferDir)
 {
 	if (!out)
 		return ERROR_INVALID_PARAMETER;
 
-	if (Stream_Capacity(out) < OutputBufferSize + 36)
+	const UINT32 payloadSize = urb_completion_payload_size(transferDir, OutputBufferSize);
+	if (Stream_Capacity(out) < payloadSize + 36ULL)
 	{
 		Stream_Free(out, TRUE);
 		return ERROR_INVALID_PARAMETER;
@@ -113,7 +123,7 @@ static UINT urb_write_completion(WINPR_ATTR_UNUSED IUDEVICE* pdev,
 
 	Stream_ResetPosition(out);
 
-	const UINT32 FunctionId = (OutputBufferSize != 0) ? URB_COMPLETION : URB_COMPLETION_NO_DATA;
+	const UINT32 FunctionId = (payloadSize != 0) ? URB_COMPLETION : URB_COMPLETION_NO_DATA;
 	if (!write_shared_message_header_with_functionid(out, InterfaceId, MessageId, FunctionId))
 	{
 		Stream_Free(out, TRUE);
@@ -131,7 +141,7 @@ static UINT urb_write_completion(WINPR_ATTR_UNUSED IUDEVICE* pdev,
 
 	Stream_Write_UINT32(out, 0);                /** HResult */
 	Stream_Write_UINT32(out, OutputBufferSize); /** OutputBufferSize */
-	Stream_Seek(out, OutputBufferSize);
+	Stream_Seek(out, payloadSize);
 
 	if (!noAck)
 		return stream_write_and_free(callback->plugin, callback->channel, out);
@@ -790,18 +800,19 @@ static UINT urb_control_transfer(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callb
 	}
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 static void urb_bulk_transfer_cb(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback, wStream* out,
                                  UINT32 InterfaceId, BOOL noAck, UINT32 MessageId, UINT32 RequestId,
                                  WINPR_ATTR_UNUSED UINT32 NumberOfPackets, UINT32 status,
                                  WINPR_ATTR_UNUSED UINT32 StartFrame,
-                                 WINPR_ATTR_UNUSED UINT32 ErrorCount, UINT32 OutputBufferSize)
+                                 WINPR_ATTR_UNUSED UINT32 ErrorCount, UINT32 OutputBufferSize,
+                                 int transferDir)
 {
 	if (!pdev->isChannelClosed(pdev))
 		urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId, status,
-		                     OutputBufferSize);
+		                     OutputBufferSize, transferDir);
 	else
 		Stream_Free(out, TRUE);
 }
@@ -841,7 +852,7 @@ static UINT urb_bulk_or_interrupt_transfer(IUDEVICE* pdev, GENERIC_CHANNEL_CALLB
 	    pdev, callback, MessageId, RequestId, EndpointAddress, TransferFlags, noAck,
 	    OutputBufferSize,
 	    (transferDir == USBD_TRANSFER_DIRECTION_OUT) ? Stream_Pointer(s) : nullptr,
-	    urb_bulk_transfer_cb, 10000);
+	    transferDir, urb_bulk_transfer_cb, 10000);
 
 	return (uint32_t)rc;
 }
@@ -850,14 +861,17 @@ static void urb_isoch_transfer_cb(WINPR_ATTR_UNUSED IUDEVICE* pdev,
                                   GENERIC_CHANNEL_CALLBACK* callback, wStream* out,
                                   UINT32 InterfaceId, BOOL noAck, UINT32 MessageId,
                                   UINT32 RequestId, UINT32 NumberOfPackets, UINT32 status,
-                                  UINT32 StartFrame, UINT32 ErrorCount, UINT32 OutputBufferSize)
+                                  UINT32 StartFrame, UINT32 ErrorCount, UINT32 OutputBufferSize,
+                                  int transferDir)
 {
 	if (!noAck)
 	{
 		UINT32 packetSize = (status == 0) ? NumberOfPackets * 12 : 0;
+		const UINT32 payloadSize = urb_completion_payload_size(transferDir, OutputBufferSize);
 		Stream_ResetPosition(out);
 
-		const UINT32 FunctionId = (OutputBufferSize == 0) ? URB_COMPLETION_NO_DATA : URB_COMPLETION;
+		const UINT32 FunctionId =
+		    (payloadSize != 0) ? URB_COMPLETION : URB_COMPLETION_NO_DATA;
 		if (!write_shared_message_header_with_functionid(out, InterfaceId, MessageId, FunctionId))
 		{
 			Stream_Free(out, TRUE);
@@ -890,7 +904,7 @@ static void urb_isoch_transfer_cb(WINPR_ATTR_UNUSED IUDEVICE* pdev,
 
 		Stream_Write_UINT32(out, 0);                /** HResult */
 		Stream_Write_UINT32(out, OutputBufferSize); /** OutputBufferSize */
-		Stream_Seek(out, OutputBufferSize);
+		Stream_Seek(out, payloadSize);
 
 		const UINT rc = stream_write_and_free(callback->plugin, callback->channel, out);
 		if (rc != CHANNEL_RC_OK)
@@ -947,7 +961,7 @@ static UINT urb_isoch_transfer(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callbac
 	    pdev, callback, MessageId, RequestId, EndpointAddress, TransferFlags, StartFrame,
 	    ErrorCount, noAck, packetDescriptorData, NumberOfPackets, OutputBufferSize,
 	    (transferDir == USBD_TRANSFER_DIRECTION_OUT) ? Stream_Pointer(s) : nullptr,
-	    urb_isoch_transfer_cb, 2000);
+	    transferDir, urb_isoch_transfer_cb, 2000);
 
 	if (rc < 0)
 		return ERROR_INTERNAL_ERROR;
@@ -1035,7 +1049,7 @@ static UINT urb_control_descriptor_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLB
 	}
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 static UINT urb_control_get_status_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback,
@@ -1096,7 +1110,7 @@ static UINT urb_control_get_status_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLB
 	}
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 static UINT urb_control_vendor_or_class_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback,
@@ -1185,7 +1199,7 @@ static UINT urb_control_vendor_or_class_request(IUDEVICE* pdev, GENERIC_CHANNEL_
 	}
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 static UINT urb_os_feature_descriptor_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback,
@@ -1276,7 +1290,7 @@ static UINT urb_os_feature_descriptor_request(IUDEVICE* pdev, GENERIC_CHANNEL_CA
 		WLog_Print(urbdrc->log, WLOG_DEBUG, "os_feature_descriptor_request: error num %d", ret);
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 static UINT urb_pipe_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback, wStream* s,
@@ -1360,7 +1374,7 @@ static UINT urb_pipe_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback,
 		return ERROR_OUTOFMEMORY;
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId, ret,
-	                            0);
+	                            0, transferDir);
 }
 /* [MS-RDPEUSB] 2.2.10.4 TS_URB_GET_CURRENT_FRAME_NUMBER_RESULT */
 static UINT urb_send_current_frame_number_result(GENERIC_CHANNEL_CALLBACK* callback,
@@ -1485,7 +1499,7 @@ static UINT urb_control_get_configuration_request(IUDEVICE* pdev,
 	}
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 /* Unused function for current server */
@@ -1545,7 +1559,7 @@ static UINT urb_control_get_interface_request(IUDEVICE* pdev, GENERIC_CHANNEL_CA
 	}
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 static UINT urb_control_feature_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback,
@@ -1645,7 +1659,7 @@ static UINT urb_control_feature_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK
 	}
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 static UINT urbdrc_process_transfer_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback,

--- a/channels/urbdrc/client/data_transfer.c
+++ b/channels/urbdrc/client/data_transfer.c
@@ -97,15 +97,25 @@ fail:
 	return status;
 }
 
+/* [MS-RDPEUSB] 2.2.7.2 and 2.2.7.3:
+ * Only a TRANSFER_IN_REQUEST that returns data carries an OutputBuffer.
+ * TRANSFER_OUT_REQUEST reports the transferred byte count in OutputBufferSize,
+ * but always uses URB_COMPLETION_NO_DATA. */
+static UINT32 urb_completion_payload_size(int transferDir, UINT32 outputBufferSize)
+{
+	return (transferDir == USBD_TRANSFER_DIRECTION_IN) ? outputBufferSize : 0;
+}
+
 static UINT urb_write_completion(WINPR_ATTR_UNUSED IUDEVICE* pdev,
                                  GENERIC_CHANNEL_CALLBACK* callback, BOOL noAck, wStream* out,
                                  UINT32 InterfaceId, UINT32 MessageId, UINT32 RequestId,
-                                 UINT32 usbd_status, UINT32 OutputBufferSize)
+                                 UINT32 usbd_status, UINT32 OutputBufferSize, int transferDir)
 {
 	if (!out)
 		return ERROR_INVALID_PARAMETER;
 
-	if (Stream_Capacity(out) < OutputBufferSize + 36)
+	const UINT32 payloadSize = urb_completion_payload_size(transferDir, OutputBufferSize);
+	if (Stream_Capacity(out) < payloadSize + 36ULL)
 	{
 		Stream_Free(out, TRUE);
 		return ERROR_INVALID_PARAMETER;
@@ -113,7 +123,7 @@ static UINT urb_write_completion(WINPR_ATTR_UNUSED IUDEVICE* pdev,
 
 	Stream_ResetPosition(out);
 
-	const UINT32 FunctionId = (OutputBufferSize != 0) ? URB_COMPLETION : URB_COMPLETION_NO_DATA;
+	const UINT32 FunctionId = (payloadSize != 0) ? URB_COMPLETION : URB_COMPLETION_NO_DATA;
 	if (!write_shared_message_header_with_functionid(out, InterfaceId, MessageId, FunctionId))
 	{
 		Stream_Free(out, TRUE);
@@ -131,7 +141,7 @@ static UINT urb_write_completion(WINPR_ATTR_UNUSED IUDEVICE* pdev,
 
 	Stream_Write_UINT32(out, 0);                /** HResult */
 	Stream_Write_UINT32(out, OutputBufferSize); /** OutputBufferSize */
-	Stream_Seek(out, OutputBufferSize);
+	Stream_Seek(out, payloadSize);
 
 	if (!noAck)
 		return stream_write_and_free(callback->plugin, callback->channel, out);
@@ -790,18 +800,19 @@ static UINT urb_control_transfer(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callb
 	}
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 static void urb_bulk_transfer_cb(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback, wStream* out,
                                  UINT32 InterfaceId, BOOL noAck, UINT32 MessageId, UINT32 RequestId,
                                  WINPR_ATTR_UNUSED UINT32 NumberOfPackets, UINT32 status,
                                  WINPR_ATTR_UNUSED UINT32 StartFrame,
-                                 WINPR_ATTR_UNUSED UINT32 ErrorCount, UINT32 OutputBufferSize)
+                                 WINPR_ATTR_UNUSED UINT32 ErrorCount, UINT32 OutputBufferSize,
+                                 int transferDir)
 {
 	if (!pdev->isChannelClosed(pdev))
 		urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId, status,
-		                     OutputBufferSize);
+		                     OutputBufferSize, transferDir);
 	else
 		Stream_Free(out, TRUE);
 }
@@ -840,7 +851,7 @@ static UINT urb_bulk_or_interrupt_transfer(IUDEVICE* pdev, GENERIC_CHANNEL_CALLB
 	const int rc = pdev->bulk_or_interrupt_transfer(
 	    pdev, callback, MessageId, RequestId, EndpointAddress, TransferFlags, noAck,
 	    OutputBufferSize,
-	    (transferDir == USBD_TRANSFER_DIRECTION_OUT) ? Stream_Pointer(s) : nullptr,
+	    (transferDir == USBD_TRANSFER_DIRECTION_OUT) ? Stream_Pointer(s) : nullptr, transferDir,
 	    urb_bulk_transfer_cb, 10000);
 
 	return (uint32_t)rc;
@@ -850,14 +861,16 @@ static void urb_isoch_transfer_cb(WINPR_ATTR_UNUSED IUDEVICE* pdev,
                                   GENERIC_CHANNEL_CALLBACK* callback, wStream* out,
                                   UINT32 InterfaceId, BOOL noAck, UINT32 MessageId,
                                   UINT32 RequestId, UINT32 NumberOfPackets, UINT32 status,
-                                  UINT32 StartFrame, UINT32 ErrorCount, UINT32 OutputBufferSize)
+                                  UINT32 StartFrame, UINT32 ErrorCount, UINT32 OutputBufferSize,
+                                  int transferDir)
 {
 	if (!noAck)
 	{
 		UINT32 packetSize = (status == 0) ? NumberOfPackets * 12 : 0;
+		const UINT32 payloadSize = urb_completion_payload_size(transferDir, OutputBufferSize);
 		Stream_ResetPosition(out);
 
-		const UINT32 FunctionId = (OutputBufferSize == 0) ? URB_COMPLETION_NO_DATA : URB_COMPLETION;
+		const UINT32 FunctionId = (payloadSize != 0) ? URB_COMPLETION : URB_COMPLETION_NO_DATA;
 		if (!write_shared_message_header_with_functionid(out, InterfaceId, MessageId, FunctionId))
 		{
 			Stream_Free(out, TRUE);
@@ -890,7 +903,7 @@ static void urb_isoch_transfer_cb(WINPR_ATTR_UNUSED IUDEVICE* pdev,
 
 		Stream_Write_UINT32(out, 0);                /** HResult */
 		Stream_Write_UINT32(out, OutputBufferSize); /** OutputBufferSize */
-		Stream_Seek(out, OutputBufferSize);
+		Stream_Seek(out, payloadSize);
 
 		const UINT rc = stream_write_and_free(callback->plugin, callback->channel, out);
 		if (rc != CHANNEL_RC_OK)
@@ -946,7 +959,7 @@ static UINT urb_isoch_transfer(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callbac
 	rc = pdev->isoch_transfer(
 	    pdev, callback, MessageId, RequestId, EndpointAddress, TransferFlags, StartFrame,
 	    ErrorCount, noAck, packetDescriptorData, NumberOfPackets, OutputBufferSize,
-	    (transferDir == USBD_TRANSFER_DIRECTION_OUT) ? Stream_Pointer(s) : nullptr,
+	    (transferDir == USBD_TRANSFER_DIRECTION_OUT) ? Stream_Pointer(s) : nullptr, transferDir,
 	    urb_isoch_transfer_cb, 2000);
 
 	if (rc < 0)
@@ -1035,7 +1048,7 @@ static UINT urb_control_descriptor_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLB
 	}
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 static UINT urb_control_get_status_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback,
@@ -1096,7 +1109,7 @@ static UINT urb_control_get_status_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLB
 	}
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 static UINT urb_control_vendor_or_class_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback,
@@ -1185,7 +1198,7 @@ static UINT urb_control_vendor_or_class_request(IUDEVICE* pdev, GENERIC_CHANNEL_
 	}
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 static UINT urb_os_feature_descriptor_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback,
@@ -1276,7 +1289,7 @@ static UINT urb_os_feature_descriptor_request(IUDEVICE* pdev, GENERIC_CHANNEL_CA
 		WLog_Print(urbdrc->log, WLOG_DEBUG, "os_feature_descriptor_request: error num %d", ret);
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 static UINT urb_pipe_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback, wStream* s,
@@ -1360,7 +1373,7 @@ static UINT urb_pipe_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback,
 		return ERROR_OUTOFMEMORY;
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId, ret,
-	                            0);
+	                            0, transferDir);
 }
 /* [MS-RDPEUSB] 2.2.10.4 TS_URB_GET_CURRENT_FRAME_NUMBER_RESULT */
 static UINT urb_send_current_frame_number_result(GENERIC_CHANNEL_CALLBACK* callback,
@@ -1485,7 +1498,7 @@ static UINT urb_control_get_configuration_request(IUDEVICE* pdev,
 	}
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 /* Unused function for current server */
@@ -1545,7 +1558,7 @@ static UINT urb_control_get_interface_request(IUDEVICE* pdev, GENERIC_CHANNEL_CA
 	}
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 static UINT urb_control_feature_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback,
@@ -1645,7 +1658,7 @@ static UINT urb_control_feature_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK
 	}
 
 	return urb_write_completion(pdev, callback, noAck, out, InterfaceId, MessageId, RequestId,
-	                            usbd_status, OutputBufferSize);
+	                            usbd_status, OutputBufferSize, transferDir);
 }
 
 static UINT urbdrc_process_transfer_request(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* callback,

--- a/channels/urbdrc/client/libusb/libusb_udevice.c
+++ b/channels/urbdrc/client/libusb/libusb_udevice.c
@@ -75,6 +75,8 @@ typedef struct
 	UINT32 ErrorCount;
 	IUDEVICE* idev;
 	UINT32 OutputBufferSize;
+	/* Completion framing depends on the outer RDPEUSB request direction. */
+	int transferDir;
 	GENERIC_CHANNEL_CALLBACK* callback;
 	t_isoch_transfer_cb cb;
 	wArrayList* queue;
@@ -202,11 +204,10 @@ const char* usb_interface_class_to_string(uint8_t c_class)
 	}
 }
 
-static ASYNC_TRANSFER_USER_DATA* async_transfer_user_data_new(IUDEVICE* idev, UINT32 MessageId,
-                                                              size_t offset, size_t BufferSize,
-                                                              const BYTE* data, size_t packetSize,
-                                                              BOOL NoAck, t_isoch_transfer_cb cb,
-                                                              GENERIC_CHANNEL_CALLBACK* callback)
+static ASYNC_TRANSFER_USER_DATA*
+async_transfer_user_data_new(IUDEVICE* idev, UINT32 MessageId, size_t offset, size_t BufferSize,
+                             const BYTE* data, size_t packetSize, BOOL NoAck, int transferDir,
+                             t_isoch_transfer_cb cb, GENERIC_CHANNEL_CALLBACK* callback)
 {
 	ASYNC_TRANSFER_USER_DATA* user_data = nullptr;
 	UDEVICE* pdev = (UDEVICE*)idev;
@@ -229,10 +230,9 @@ static ASYNC_TRANSFER_USER_DATA* async_transfer_user_data_new(IUDEVICE* idev, UI
 	Stream_Seek(user_data->data, offset); /* Skip header offset */
 	if (data)
 		memcpy(Stream_Pointer(user_data->data), data, BufferSize);
-	else
-		user_data->OutputBufferSize = (UINT32)BufferSize;
 
 	user_data->noack = NoAck;
+	user_data->transferDir = transferDir;
 	user_data->cb = cb;
 	user_data->callback = callback;
 	user_data->idev = idev;
@@ -291,6 +291,7 @@ static void LIBUSB_CALL func_iso_callback(struct libusb_transfer* transfer)
 					index += act_len;
 				}
 			}
+			user_data->OutputBufferSize = index;
 		}
 			/* fallthrough */
 			WINPR_FALLTHROUGH
@@ -314,7 +315,7 @@ static void LIBUSB_CALL func_iso_callback(struct libusb_transfer* transfer)
 					              InterfaceId, user_data->noack, user_data->MessageId, RequestID,
 					              WINPR_ASSERTING_INT_CAST(uint32_t, transfer->num_iso_packets),
 					              transfer->status, user_data->StartFrame, user_data->ErrorCount,
-					              user_data->OutputBufferSize);
+					              user_data->OutputBufferSize, user_data->transferDir);
 					user_data->data = nullptr;
 				}
 				ArrayList_Remove(list, transfer);
@@ -377,7 +378,8 @@ static void LIBUSB_CALL func_bulk_transfer_cb(struct libusb_transfer* transfer)
 		              user_data->noack, user_data->MessageId, RequestID,
 		              WINPR_ASSERTING_INT_CAST(uint32_t, transfer->num_iso_packets),
 		              transfer->status, user_data->StartFrame, user_data->ErrorCount,
-		              WINPR_ASSERTING_INT_CAST(uint32_t, transfer->actual_length));
+		              WINPR_ASSERTING_INT_CAST(uint32_t, transfer->actual_length),
+		              user_data->transferDir);
 		user_data->data = nullptr;
 		ArrayList_Remove(list, transfer);
 	}
@@ -954,6 +956,8 @@ static int libusb_udev_os_feature_descriptor_request(IUDEVICE* idev,
 	WINPR_ASSERT(UsbdStatus);
 	WINPR_ASSERT(BufferSize);
 	WINPR_ASSERT(*BufferSize <= UINT16_MAX);
+	const UINT16 requestedSize = (UINT16)*BufferSize;
+	*BufferSize = 0;
 
 	/*
 	pdev->request_queue->register_request(pdev->request_queue, RequestId, nullptr, 0);
@@ -972,7 +976,7 @@ static int libusb_udev_os_feature_descriptor_request(IUDEVICE* idev,
 		    pdev->libusb_handle,
 		    (uint8_t)LIBUSB_ENDPOINT_IN | (uint8_t)LIBUSB_REQUEST_TYPE_VENDOR | Recipient,
 		    bMS_Vendorcode, (UINT16)((InterfaceNumber << 8) | Ms_PageIndex), Ms_featureDescIndex,
-		    Buffer, (UINT16)*BufferSize, Timeout);
+		    Buffer, requestedSize, Timeout);
 		log_libusb_result(pdev->urbdrc->log, WLOG_DEBUG, "libusb_control_transfer", error);
 
 		if (error >= 0)
@@ -1245,7 +1249,7 @@ static int libusb_udev_isoch_transfer(IUDEVICE* idev, GENERIC_CHANNEL_CALLBACK* 
                                       UINT32 ErrorCount, BOOL NoAck,
                                       WINPR_ATTR_UNUSED const BYTE* packetDescriptorData,
                                       UINT32 NumberOfPackets, UINT32 BufferSize, const BYTE* Buffer,
-                                      t_isoch_transfer_cb cb, UINT32 Timeout)
+                                      int transferDir, t_isoch_transfer_cb cb, UINT32 Timeout)
 {
 	int rc = 0;
 	UINT32 iso_packet_size = 0;
@@ -1261,7 +1265,7 @@ static int libusb_udev_isoch_transfer(IUDEVICE* idev, GENERIC_CHANNEL_CALLBACK* 
 
 	urbdrc = pdev->urbdrc;
 	user_data = async_transfer_user_data_new(idev, MessageId, 48, BufferSize, Buffer,
-	                                         outSize + 1024, NoAck, cb, callback);
+	                                         outSize + 1024, NoAck, transferDir, cb, callback);
 
 	if (!user_data)
 		return -1;
@@ -1332,7 +1336,10 @@ static BOOL libusb_udev_control_transfer(IUDEVICE* idev, WINPR_ATTR_UNUSED UINT3
 	if (status >= 0)
 		*BufferSize = (UINT32)status;
 	else
+	{
+		*BufferSize = 0;
 		log_libusb_result(pdev->urbdrc->log, WLOG_ERROR, "libusb_control_transfer", status);
+	}
 
 	if (!func_set_usbd_status(pdev->urbdrc, pdev, UrbdStatus, status))
 		return FALSE;
@@ -1340,12 +1347,10 @@ static BOOL libusb_udev_control_transfer(IUDEVICE* idev, WINPR_ATTR_UNUSED UINT3
 	return TRUE;
 }
 
-static int libusb_udev_bulk_or_interrupt_transfer(IUDEVICE* idev,
-                                                  GENERIC_CHANNEL_CALLBACK* callback,
-                                                  UINT32 MessageId, UINT32 RequestId,
-                                                  UINT32 EndpointAddress, UINT32 TransferFlags,
-                                                  BOOL NoAck, UINT32 BufferSize, const BYTE* data,
-                                                  t_isoch_transfer_cb cb, UINT32 Timeout)
+static int libusb_udev_bulk_or_interrupt_transfer(
+    IUDEVICE* idev, GENERIC_CHANNEL_CALLBACK* callback, UINT32 MessageId, UINT32 RequestId,
+    UINT32 EndpointAddress, UINT32 TransferFlags, BOOL NoAck, UINT32 BufferSize, const BYTE* data,
+    int transferDir, t_isoch_transfer_cb cb, UINT32 Timeout)
 {
 	int rc = 0;
 	UINT32 transfer_type = 0;
@@ -1360,8 +1365,8 @@ static int libusb_udev_bulk_or_interrupt_transfer(IUDEVICE* idev,
 		return -1;
 
 	urbdrc = pdev->urbdrc;
-	user_data =
-	    async_transfer_user_data_new(idev, MessageId, 36, BufferSize, data, 0, NoAck, cb, callback);
+	user_data = async_transfer_user_data_new(idev, MessageId, 36, BufferSize, data, 0, NoAck,
+	                                         transferDir, cb, callback);
 
 	if (!user_data)
 		return -1;

--- a/channels/urbdrc/client/libusb/libusb_udevice.c
+++ b/channels/urbdrc/client/libusb/libusb_udevice.c
@@ -75,6 +75,8 @@ typedef struct
 	UINT32 ErrorCount;
 	IUDEVICE* idev;
 	UINT32 OutputBufferSize;
+	/* Completion framing depends on the outer RDPEUSB request direction. */
+	int transferDir;
 	GENERIC_CHANNEL_CALLBACK* callback;
 	t_isoch_transfer_cb cb;
 	wArrayList* queue;
@@ -205,7 +207,8 @@ const char* usb_interface_class_to_string(uint8_t c_class)
 static ASYNC_TRANSFER_USER_DATA* async_transfer_user_data_new(IUDEVICE* idev, UINT32 MessageId,
                                                               size_t offset, size_t BufferSize,
                                                               const BYTE* data, size_t packetSize,
-                                                              BOOL NoAck, t_isoch_transfer_cb cb,
+                                                              BOOL NoAck, int transferDir,
+                                                              t_isoch_transfer_cb cb,
                                                               GENERIC_CHANNEL_CALLBACK* callback)
 {
 	ASYNC_TRANSFER_USER_DATA* user_data = nullptr;
@@ -229,10 +232,9 @@ static ASYNC_TRANSFER_USER_DATA* async_transfer_user_data_new(IUDEVICE* idev, UI
 	Stream_Seek(user_data->data, offset); /* Skip header offset */
 	if (data)
 		memcpy(Stream_Pointer(user_data->data), data, BufferSize);
-	else
-		user_data->OutputBufferSize = (UINT32)BufferSize;
 
 	user_data->noack = NoAck;
+	user_data->transferDir = transferDir;
 	user_data->cb = cb;
 	user_data->callback = callback;
 	user_data->idev = idev;
@@ -291,6 +293,7 @@ static void LIBUSB_CALL func_iso_callback(struct libusb_transfer* transfer)
 					index += act_len;
 				}
 			}
+			user_data->OutputBufferSize = index;
 		}
 			/* fallthrough */
 			WINPR_FALLTHROUGH
@@ -314,7 +317,7 @@ static void LIBUSB_CALL func_iso_callback(struct libusb_transfer* transfer)
 					              InterfaceId, user_data->noack, user_data->MessageId, RequestID,
 					              WINPR_ASSERTING_INT_CAST(uint32_t, transfer->num_iso_packets),
 					              transfer->status, user_data->StartFrame, user_data->ErrorCount,
-					              user_data->OutputBufferSize);
+					              user_data->OutputBufferSize, user_data->transferDir);
 					user_data->data = nullptr;
 				}
 				ArrayList_Remove(list, transfer);
@@ -377,7 +380,8 @@ static void LIBUSB_CALL func_bulk_transfer_cb(struct libusb_transfer* transfer)
 		              user_data->noack, user_data->MessageId, RequestID,
 		              WINPR_ASSERTING_INT_CAST(uint32_t, transfer->num_iso_packets),
 		              transfer->status, user_data->StartFrame, user_data->ErrorCount,
-		              WINPR_ASSERTING_INT_CAST(uint32_t, transfer->actual_length));
+		              WINPR_ASSERTING_INT_CAST(uint32_t, transfer->actual_length),
+		              user_data->transferDir);
 		user_data->data = nullptr;
 		ArrayList_Remove(list, transfer);
 	}
@@ -954,6 +958,8 @@ static int libusb_udev_os_feature_descriptor_request(IUDEVICE* idev,
 	WINPR_ASSERT(UsbdStatus);
 	WINPR_ASSERT(BufferSize);
 	WINPR_ASSERT(*BufferSize <= UINT16_MAX);
+	const UINT16 requestedSize = (UINT16)*BufferSize;
+	*BufferSize = 0;
 
 	/*
 	pdev->request_queue->register_request(pdev->request_queue, RequestId, nullptr, 0);
@@ -972,7 +978,7 @@ static int libusb_udev_os_feature_descriptor_request(IUDEVICE* idev,
 		    pdev->libusb_handle,
 		    (uint8_t)LIBUSB_ENDPOINT_IN | (uint8_t)LIBUSB_REQUEST_TYPE_VENDOR | Recipient,
 		    bMS_Vendorcode, (UINT16)((InterfaceNumber << 8) | Ms_PageIndex), Ms_featureDescIndex,
-		    Buffer, (UINT16)*BufferSize, Timeout);
+		    Buffer, requestedSize, Timeout);
 		log_libusb_result(pdev->urbdrc->log, WLOG_DEBUG, "libusb_control_transfer", error);
 
 		if (error >= 0)
@@ -1245,7 +1251,7 @@ static int libusb_udev_isoch_transfer(IUDEVICE* idev, GENERIC_CHANNEL_CALLBACK* 
                                       UINT32 ErrorCount, BOOL NoAck,
                                       WINPR_ATTR_UNUSED const BYTE* packetDescriptorData,
                                       UINT32 NumberOfPackets, UINT32 BufferSize, const BYTE* Buffer,
-                                      t_isoch_transfer_cb cb, UINT32 Timeout)
+                                      int transferDir, t_isoch_transfer_cb cb, UINT32 Timeout)
 {
 	int rc = 0;
 	UINT32 iso_packet_size = 0;
@@ -1261,7 +1267,7 @@ static int libusb_udev_isoch_transfer(IUDEVICE* idev, GENERIC_CHANNEL_CALLBACK* 
 
 	urbdrc = pdev->urbdrc;
 	user_data = async_transfer_user_data_new(idev, MessageId, 48, BufferSize, Buffer,
-	                                         outSize + 1024, NoAck, cb, callback);
+	                                         outSize + 1024, NoAck, transferDir, cb, callback);
 
 	if (!user_data)
 		return -1;
@@ -1332,7 +1338,10 @@ static BOOL libusb_udev_control_transfer(IUDEVICE* idev, WINPR_ATTR_UNUSED UINT3
 	if (status >= 0)
 		*BufferSize = (UINT32)status;
 	else
+	{
+		*BufferSize = 0;
 		log_libusb_result(pdev->urbdrc->log, WLOG_ERROR, "libusb_control_transfer", status);
+	}
 
 	if (!func_set_usbd_status(pdev->urbdrc, pdev, UrbdStatus, status))
 		return FALSE;
@@ -1345,7 +1354,8 @@ static int libusb_udev_bulk_or_interrupt_transfer(IUDEVICE* idev,
                                                   UINT32 MessageId, UINT32 RequestId,
                                                   UINT32 EndpointAddress, UINT32 TransferFlags,
                                                   BOOL NoAck, UINT32 BufferSize, const BYTE* data,
-                                                  t_isoch_transfer_cb cb, UINT32 Timeout)
+                                                  int transferDir, t_isoch_transfer_cb cb,
+                                                  UINT32 Timeout)
 {
 	int rc = 0;
 	UINT32 transfer_type = 0;
@@ -1360,8 +1370,8 @@ static int libusb_udev_bulk_or_interrupt_transfer(IUDEVICE* idev,
 		return -1;
 
 	urbdrc = pdev->urbdrc;
-	user_data =
-	    async_transfer_user_data_new(idev, MessageId, 36, BufferSize, data, 0, NoAck, cb, callback);
+	user_data = async_transfer_user_data_new(idev, MessageId, 36, BufferSize, data, 0, NoAck,
+	                                         transferDir, cb, callback);
 
 	if (!user_data)
 		return -1;

--- a/channels/urbdrc/client/urbdrc_main.h
+++ b/channels/urbdrc/client/urbdrc_main.h
@@ -92,7 +92,8 @@ typedef struct
 typedef void (*t_isoch_transfer_cb)(IUDEVICE* idev, GENERIC_CHANNEL_CALLBACK* callback,
                                     wStream* out, UINT32 InterfaceId, BOOL noAck, UINT32 MessageId,
                                     UINT32 RequestId, UINT32 NumberOfPackets, UINT32 status,
-                                    UINT32 StartFrame, UINT32 ErrorCount, UINT32 OutputBufferSize);
+                                    UINT32 StartFrame, UINT32 ErrorCount, UINT32 OutputBufferSize,
+                                    int transferDir);
 
 struct S_IUDEVICE
 {
@@ -101,7 +102,7 @@ struct S_IUDEVICE
 	    IUDEVICE* idev, GENERIC_CHANNEL_CALLBACK* callback, UINT32 MessageId, UINT32 RequestId,
 	    UINT32 EndpointAddress, UINT32 TransferFlags, UINT32 StartFrame, UINT32 ErrorCount,
 	    BOOL NoAck, const BYTE* packetDescriptorData, UINT32 NumberOfPackets, UINT32 BufferSize,
-	    const BYTE* Buffer, t_isoch_transfer_cb cb, UINT32 Timeout);
+	    const BYTE* Buffer, int transferDir, t_isoch_transfer_cb cb, UINT32 Timeout);
 
 	WINPR_ATTR_NODISCARD BOOL (*control_transfer)(IUDEVICE* idev, UINT32 RequestId,
 	                                              UINT32 EndpointAddress, UINT32 TransferFlags,
@@ -112,7 +113,7 @@ struct S_IUDEVICE
 	WINPR_ATTR_NODISCARD int (*bulk_or_interrupt_transfer)(
 	    IUDEVICE* idev, GENERIC_CHANNEL_CALLBACK* callback, UINT32 MessageId, UINT32 RequestId,
 	    UINT32 EndpointAddress, UINT32 TransferFlags, BOOL NoAck, UINT32 BufferSize,
-	    const BYTE* data, t_isoch_transfer_cb cb, UINT32 Timeout);
+	    const BYTE* data, int transferDir, t_isoch_transfer_cb cb, UINT32 Timeout);
 
 	WINPR_ATTR_NODISCARD int (*select_configuration)(IUDEVICE* idev, UINT32 bConfigurationValue);
 


### PR DESCRIPTION
## Description

FreeRDP selected between `URB_COMPLETION` and `URB_COMPLETION_NO_DATA` based only on `OutputBufferSize`.

For a `TRANSFER_OUT_REQUEST`, this caused the input buffer sent to the USB device to be serialized again as trailing completion data.

According to MS-RDPEUSB, a TransferOut result should use `URB_COMPLETION_NO_DATA`. Its `OutputBufferSize` reports the transferred byte count, but no trailing `OutputBuffer` is present.

This change preserves the outer transfer direction through asynchronous callbacks and selects the completion framing as follows:

- TransferIn with returned data: `URB_COMPLETION`
- TransferIn without returned data: `URB_COMPLETION_NO_DATA`
- TransferOut: `URB_COMPLETION_NO_DATA`, while retaining the transferred
  byte count in `OutputBufferSize`

See:
https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/d1f22b46-0d7a-4d74-86e4-6bd8a06b702f

## Manual testing

I connected FreeRDP to a Windows Server 2022 and redirected a USB mass-storage device (a USB flash drive).

For the same 31-byte bulk TransferOut request:

```text
[READ ] TRANSFER_OUT_REQUEST ... length=67
urb_bulk_or_interrupt_transfer: ep:0x1 transfer_type 2 ... OutputBufferSize:0x1f
```

Before this change:

```text
[WRITE] URB_COMPLETION ... FunctionId=00000101, length=67
```

After this change:

```text
[WRITE] URB_COMPLETION_NO_DATA ... FunctionId=00000102, length=36
```

`0x1f` is 31 bytes, and the previous 67-byte completion consisted of the 36-byte result plus those 31 bytes as trailing data. The new completion contains only the 36-byte result.

A TransferIn returning one byte continued to use the expected framing in both versions:

```text
[WRITE] URB_COMPLETION ... FunctionId=00000101, length=37
```

No problems were observed with the redirected USB flash drive during this test. No other types of USB devices have been tested.

Full sanitized logs:

[freerdp-before.log](https://github.com/user-attachments/files/30602376/freerdp-before.log)
[freerdp-after.log](https://github.com/user-attachments/files/30602380/freerdp-after.log)

Timestamps log noise were removed.

Fixes #13112