### PR TITLE
[client,sdl] do not alpha blend the remote framebuffer

### DIFF
--- a/client/SDL/SDL3/sdl_window.cpp
+++ b/client/SDL/SDL3/sdl_window.cpp
@@ -288,6 +288,13 @@ void SdlWindow::ensureRenderTarget()
 	if (!_renderTarget)
 		SDL_LogError(SDL_LOG_CATEGORY_RENDER, "SDL_CreateTexture (render target): %s",
 		             SDL_GetError());
+	else
+	{
+		/* The fourth byte of the GDI buffer is padding, not opacity. SDL3 defaults
+		 * textures that have an alpha channel to SDL_BLENDMODE_BLEND, which would
+		 * blend that padding against the backbuffer. */
+		SDL_SetTextureBlendMode(_renderTarget, SDL_BLENDMODE_NONE);
+	}
 }
 
 bool SdlWindow::drawRect(SDL_Surface* surface, SDL_Point offset, const SDL_Rect& srcRect)
@@ -506,6 +513,11 @@ bool SdlWindow::blit(SDL_Surface* surface, const SDL_Rect& srcRect, SDL_Rect& ds
 			SDL_LogError(SDL_LOG_CATEGORY_RENDER, "SDL_CreateTexture: %s", SDL_GetError());
 			return false;
 		}
+
+		/* Same reasoning as in ensureRenderTarget(): copy the remote framebuffer,
+		 * do not blend it. */
+		SDL_SetTextureBlendMode(_gdiTexture, SDL_BLENDMODE_NONE);
+
 		_gdiTextureW = surface->w;
 		_gdiTextureH = surface->h;
 	}


### PR DESCRIPTION
Fixes #13131.

## What it does

The SDL3 client creates both of its textures in a format **with an alpha channel** — `sdl_context.cpp` calls `gdi_init(instance, PIXEL_FORMAT_BGRA32)` unconditionally — but never calls `SDL_SetTextureBlendMode()`. SDL3 defaults textures that have an alpha channel to `SDL_BLENDMODE_BLEND`, so the fourth byte of the GDI buffer is used as opacity.

That byte is padding, not opacity:

| `/bpp` | alpha byte after conversion | result |
| --- | --- | --- |
| 16 | always opaque | correct |
| 24 | partly zero | horizontal stripes |
| 32 | zero | black window |

This patch sets `SDL_BLENDMODE_NONE` on both textures, so the remote framebuffer is copied rather than blended.

## Why the X11 client is not affected

`xf_get_local_color_format()` picks `PIXEL_FORMAT_BGRX32` for depth 24 — same memory layout, **X instead of A**, hence no alpha channel and no blending. The SDL3 path hard-codes `BGRA32` regardless of depth.

`sdl_context.cpp` already calls `SDL_SetSurfaceBlendMode(_primary.get(), SDL_BLENDMODE_NONE)`, which shows the intent, but that applies to the *surface* and not to the textures created from it.

## How to test

Against an xrdp server (I used xrdp 0.9.24 on Linux Mint 22.3, Xorg backend):

```
sdl-freerdp /v:<host> /u:<user> /bpp:24 /cert:ignore
```

Before: horizontal stripes. With `/bpp:32`: black window, input still working.
After: correct at 16, 24 and 32.

## Evidence

Before writing the patch I verified the cause rather than inferring it. Homebrew ships `xfreerdp` and `sdl-freerdp` from the same 3.30.0 build, so the frontend is the only variable — same server, same session, same command line:

| Variant (3.30.0, `/bpp:24`) | Result |
| --- | --- |
| `xfreerdp` (X11) | correct |
| `sdl-freerdp`, default | stripes |
| `sdl-freerdp /gdi:sw` | black |
| `sdl-freerdp /bpp:16` | correct |
| `sdl-freerdp`, blend mode forced off at runtime | **correct** |

For the last row I interposed `SDL_CreateTexture` via `DYLD_INSERT_LIBRARIES` and called `SDL_SetTextureBlendMode(t, SDL_BLENDMODE_NONE)` on every texture, changing nothing else. The stripes disappeared immediately.

The affected code is byte-identical in 3.26.0, 3.30.0 and current `master`. I have been running this patch on 3.26.0 in production for a day at 24 bpp without regressions.

## Alternative considered

Mirroring the X11 client by choosing `PIXEL_FORMAT_BGRX32` in `sdl_context.cpp` would arguably be the more principled fix, but it touches the whole GDI path. Setting the blend mode is local and matches what the surface-level code already tries to do. Happy to switch if you prefer that direction.

## Checklist

- `clang-format --style=file` reports no changes on the modified file
- No API or behaviour change beyond the blend mode
