### PR TITLE
[core,server] fix length underflow in wts_read_drdynvc_pdu

### DIFF
--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -297,7 +297,7 @@ static BOOL wts_read_drdynvc_pdu(rdpPeerChannel* channel)
 	/* receiveData is allocated with a fixed chunk size and never sealed, so its stream length
 	 * is the allocation and not the number of bytes received. Parse through a substream
 	 * limited to the received data so the stream bounds checks apply to the PDU. */
-	wStream sbuffer = { 0 };
+	wStream sbuffer = WINPR_C_ARRAY_INIT;
 	wStream* s = Stream_StaticInit(&sbuffer, Stream_Buffer(channel->receiveData), length);
 
 	const UINT8 value = Stream_Get_UINT8(s);

--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -150,17 +150,18 @@ static unsigned wts_read_variable_uint(wStream* s, int cbLen, UINT32* val)
 	}
 }
 
-static BOOL wts_read_drdynvc_capabilities_response(rdpPeerChannel* channel, UINT32 length)
+static BOOL wts_read_drdynvc_capabilities_response(rdpPeerChannel* channel, wStream* s)
 {
 	UINT16 Version = 0;
 
 	WINPR_ASSERT(channel);
 	WINPR_ASSERT(channel->vcm);
-	if (length < 3)
+	WINPR_ASSERT(s);
+	if (!Stream_CheckAndLogRequiredLength(TAG, s, 3))
 		return FALSE;
 
-	Stream_Seek_UINT8(channel->receiveData); /* Pad (1 byte) */
-	Stream_Read_UINT16(channel->receiveData, Version);
+	Stream_Seek_UINT8(s); /* Pad (1 byte) */
+	Stream_Read_UINT16(s, Version);
 	DEBUG_DVC("Version: %" PRIu16 "", Version);
 
 	if (Version < 1)
@@ -178,14 +179,14 @@ static BOOL wts_read_drdynvc_capabilities_response(rdpPeerChannel* channel, UINT
 	return SetEvent(MessageQueue_Event(vcm->queue));
 }
 
-static BOOL wts_read_drdynvc_create_response(rdpPeerChannel* channel, wStream* s, UINT32 length)
+static BOOL wts_read_drdynvc_create_response(rdpPeerChannel* channel, wStream* s)
 {
 	UINT32 CreationStatus = 0;
 	BOOL status = TRUE;
 
 	WINPR_ASSERT(channel);
 	WINPR_ASSERT(s);
-	if (length < 4)
+	if (!Stream_CheckAndLogRequiredLength(TAG, s, 4))
 		return FALSE;
 
 	Stream_Read_UINT32(s, CreationStatus);
@@ -211,19 +212,14 @@ static BOOL wts_read_drdynvc_create_response(rdpPeerChannel* channel, wStream* s
 	return status;
 }
 
-static BOOL wts_read_drdynvc_data_first(rdpPeerChannel* channel, wStream* s, int cbLen,
-                                        UINT32 length)
+static BOOL wts_read_drdynvc_data_first(rdpPeerChannel* channel, wStream* s, int cbLen)
 {
 	WINPR_ASSERT(channel);
 	WINPR_ASSERT(s);
-	const UINT32 value = wts_read_variable_uint(s, cbLen, &channel->dvc_total_length);
-
-	if (value == 0)
+	if (wts_read_variable_uint(s, cbLen, &channel->dvc_total_length) == 0)
 		return FALSE;
-	if (value > length)
-		length = 0;
-	else
-		length -= value;
+
+	const size_t length = Stream_GetRemainingLength(s);
 
 	if (length > channel->dvc_total_length)
 		return FALSE;
@@ -237,12 +233,14 @@ static BOOL wts_read_drdynvc_data_first(rdpPeerChannel* channel, wStream* s, int
 	return TRUE;
 }
 
-static BOOL wts_read_drdynvc_data(rdpPeerChannel* channel, wStream* s, UINT32 length)
+static BOOL wts_read_drdynvc_data(rdpPeerChannel* channel, wStream* s)
 {
 	BOOL ret = FALSE;
 
 	WINPR_ASSERT(channel);
 	WINPR_ASSERT(s);
+	const size_t length = Stream_GetRemainingLength(s);
+
 	if (channel->dvc_total_length > 0)
 	{
 		if (Stream_GetPosition(channel->receiveData) + length > channel->dvc_total_length)
@@ -265,7 +263,8 @@ static BOOL wts_read_drdynvc_data(rdpPeerChannel* channel, wStream* s, UINT32 le
 	}
 	else
 	{
-		ret = wts_queue_receive_data(channel, Stream_ConstPointer(s), length, nullptr, 0);
+		ret = wts_queue_receive_data(channel, Stream_ConstPointer(s),
+		                             WINPR_ASSERTING_INT_CAST(UINT32, length), nullptr, 0);
 	}
 
 	return ret;
@@ -290,20 +289,24 @@ static BOOL wts_read_drdynvc_pdu(rdpPeerChannel* channel)
 	WINPR_ASSERT(channel);
 	WINPR_ASSERT(channel->vcm);
 
-	size_t length = Stream_GetPosition(channel->receiveData);
+	const size_t length = Stream_GetPosition(channel->receiveData);
 
 	if ((length < 1) || (length > UINT32_MAX))
 		return FALSE;
 
-	Stream_ResetPosition(channel->receiveData);
-	const UINT8 value = Stream_Get_UINT8(channel->receiveData);
-	length--;
+	/* receiveData is allocated with a fixed chunk size and never sealed, so its stream length
+	 * is the allocation and not the number of bytes received. Parse through a substream
+	 * limited to the received data so the stream bounds checks apply to the PDU. */
+	wStream sbuffer = { 0 };
+	wStream* s = Stream_StaticInit(&sbuffer, Stream_Buffer(channel->receiveData), length);
+
+	const UINT8 value = Stream_Get_UINT8(s);
 	Cmd = (value & 0xf0) >> 4;
 	Sp = (value & 0x0c) >> 2;
 	cbChId = (value & 0x03) >> 0;
 
 	if (Cmd == CAPABILITY_REQUEST_PDU)
-		return wts_read_drdynvc_capabilities_response(channel, (UINT32)length);
+		return wts_read_drdynvc_capabilities_response(channel, s);
 
 	if (channel->vcm->drdynvc_state == DRDYNVC_STATE_READY)
 	{
@@ -321,14 +324,11 @@ static BOOL wts_read_drdynvc_pdu(rdpPeerChannel* channel)
 
 		if (haveChannelId)
 		{
-			const unsigned val = wts_read_variable_uint(channel->receiveData, cbChId, &ChannelId);
-			if (val == 0)
+			if (wts_read_variable_uint(s, cbChId, &ChannelId) == 0)
 				return FALSE;
 
-			length -= val;
-
 			DEBUG_DVC("Cmd %s ChannelId %" PRIu32 " length %" PRIuz "",
-			          drdynvc_get_packet_type(Cmd), ChannelId, length);
+			          drdynvc_get_packet_type(Cmd), ChannelId, Stream_GetRemainingLength(s));
 			dvc = wts_get_dvc_channel_by_id(channel->vcm, ChannelId);
 			if (!dvc)
 			{
@@ -340,7 +340,7 @@ static BOOL wts_read_drdynvc_pdu(rdpPeerChannel* channel)
 		switch (Cmd)
 		{
 			case CREATE_REQUEST_PDU:
-				return wts_read_drdynvc_create_response(dvc, channel->receiveData, (UINT32)length);
+				return wts_read_drdynvc_create_response(dvc, s);
 
 			case DATA_FIRST_PDU:
 				if (dvc->dvc_open_state != DVC_OPEN_STATE_SUCCEEDED)
@@ -352,7 +352,7 @@ static BOOL wts_read_drdynvc_pdu(rdpPeerChannel* channel)
 					return TRUE;
 				}
 
-				return wts_read_drdynvc_data_first(dvc, channel->receiveData, Sp, (UINT32)length);
+				return wts_read_drdynvc_data_first(dvc, s, Sp);
 
 			case DATA_PDU:
 				if (dvc->dvc_open_state != DVC_OPEN_STATE_SUCCEEDED)
@@ -364,7 +364,7 @@ static BOOL wts_read_drdynvc_pdu(rdpPeerChannel* channel)
 					return TRUE;
 				}
 
-				return wts_read_drdynvc_data(dvc, channel->receiveData, (UINT32)length);
+				return wts_read_drdynvc_data(dvc, s);
 
 			case CLOSE_REQUEST_PDU:
 				wts_read_drdynvc_close_response(dvc);

--- a/libfreerdp/core/test/CMakeLists.txt
+++ b/libfreerdp/core/test/CMakeLists.txt
@@ -10,7 +10,7 @@ set(DRIVER ${MODULE_NAME}.c)
 set(TESTS TestVersion.c TestSettings.c TestUtils.c)
 
 if(BUILD_TESTING_INTERNAL)
-  list(APPEND TESTS TestStreamDump.c TestRdstls.c)
+  list(APPEND TESTS TestStreamDump.c TestRdstls.c TestServerChannels.c)
 endif()
 
 set(FUZZERS TestFuzzCoreClient.c TestFuzzCoreServer.c TestFuzzCryptoCertificateDataSetPEM.c)

--- a/libfreerdp/core/test/TestServerChannels.c
+++ b/libfreerdp/core/test/TestServerChannels.c
@@ -1,0 +1,107 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Server side virtual channel unit test
+ *
+ * Copyright 2026 Sayed Kaif <metsw24@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <winpr/crt.h>
+#include <winpr/wtsapi.h>
+
+#include <freerdp/peer.h>
+#include <freerdp/constants.h>
+#include <freerdp/channels/channels.h>
+#include <freerdp/channels/wtsvc.h>
+
+#include "../mcs.h"
+#include "../rdp.h"
+
+#define TEST_SVC_CHANNEL_ID 1004
+
+static BOOL recv_pdu(freerdp_peer* client, const BYTE* data, size_t size)
+{
+	return client->ReceiveChannelData(client, TEST_SVC_CHANNEL_ID, data, size,
+	                                  CHANNEL_FLAG_FIRST | CHANNEL_FLAG_LAST, size);
+}
+
+/* A DYNVC PDU that ends before its ChannelId field must be rejected, see
+ * [MS-RDPEDYC] 2.2.2. */
+static BOOL test_truncated_dynvc_pdu(void)
+{
+	BOOL rc = FALSE;
+	HANDLE vcm = INVALID_HANDLE_VALUE;
+
+	freerdp_peer* client = calloc(1, sizeof(freerdp_peer));
+	if (!client)
+		return FALSE;
+
+	client->ContextSize = sizeof(rdpContext);
+	if (!freerdp_peer_context_new(client))
+		goto fail;
+
+	rdpMcs* mcs = client->context->rdp->mcs;
+	mcs->channelCount = 1;
+	(void)strncpy(mcs->channels[0].Name, DRDYNVC_SVC_CHANNEL_NAME, CHANNEL_NAME_LEN);
+	mcs->channels[0].ChannelId = TEST_SVC_CHANNEL_ID;
+	mcs->channels[0].joined = TRUE;
+
+	vcm = WTSOpenServerA((LPSTR)client->context);
+	if (!vcm || (vcm == INVALID_HANDLE_VALUE))
+		goto fail;
+
+	if (!WTSVirtualChannelManagerOpen(vcm))
+		goto fail;
+
+	/* DYNVC_CAPS_RSP, moves the drdynvc channel to DRDYNVC_STATE_READY */
+	const BYTE capsRsp[] = { 0x50, 0x00, 0x01, 0x00 };
+	if (!recv_pdu(client, capsRsp, sizeof(capsRsp)))
+		goto fail;
+
+	HANDLE dvc = WTSVirtualChannelOpenEx(1, "testdvc", WTS_CHANNEL_OPTION_DYNAMIC);
+	if (!dvc)
+		goto fail;
+
+	/* DYNVC_CREATE_RSP for ChannelId 1, HRESULT 0 */
+	const BYTE createRsp[] = { 0x10, 0x01, 0x00, 0x00, 0x00, 0x00 };
+	if (!recv_pdu(client, createRsp, sizeof(createRsp)))
+		goto fail;
+
+	/* Same PDU truncated to its header byte: the ChannelId is no longer part of
+	 * the received data. */
+	const BYTE truncated[] = { 0x10 };
+	if (recv_pdu(client, truncated, sizeof(truncated)))
+	{
+		(void)fprintf(stderr, "truncated DYNVC PDU accepted\n");
+		goto fail;
+	}
+
+	rc = TRUE;
+fail:
+	if (vcm != INVALID_HANDLE_VALUE)
+		WTSCloseServer(vcm);
+	freerdp_peer_context_free(client);
+	free(client);
+	return rc;
+}
+
+int TestServerChannels(WINPR_ATTR_UNUSED int argc, WINPR_ATTR_UNUSED char* argv[])
+{
+	WTSRegisterWtsApiFunctionTable(FreeRDP_InitWtsApi());
+
+	if (!test_truncated_dynvc_pdu())
+		return -1;
+
+	return 0;
+}


### PR DESCRIPTION
**Length underflow in wts_read_drdynvc_pdu**

`length` tracks what is left of the received DYNVC PDU, but the variable-length ChannelId is subtracted from it without checking that the field actually fits, so a single byte PDU wraps it to `SIZE_MAX` and the truncated `0xFFFFFFFF` reaches `wts_queue_receive_data`, which then copies that many bytes out of the ~1600 byte channel buffer. The sibling `wts_read_drdynvc_data_first` already guards the same subtraction, so this mostly brings the two into line; rejecting the short PDU also stops the ChannelId being taken from stale buffer content, which the check inside `wts_read_variable_uint` does not catch because `channel->receiveData` reports its allocation as its length.

Added a regression test under `libfreerdp/core/test` that drives the server receive path with a truncated DYNVC PDU. It fails on master and passes with the change; the rest of the suite is unaffected.