### PR TITLE
[winpr,sspi] dispatch by package index instead of a mixed-width name

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -535,7 +535,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_AcquireCredentialsHandleW(
 	}
 
 	sspi_SecureHandleSetLowerPointer(phCredential, (void*)credentials);
-	sspi_SecureHandleSetUpperPointer(phCredential, (void*)NTLM_PACKAGE_NAME);
+	sspi_SecureHandleSetUpperPointer(phCredential, (void*)SSPI_PACKAGE_NTLM);
 	return SEC_E_OK;
 }
 
@@ -651,7 +651,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_AcceptSecurityContext(
 		if (!ntlm_SetContextTargetName(context, nullptr))
 			return SEC_E_INVALID_HANDLE;
 		sspi_SecureHandleSetLowerPointer(phNewContext, context);
-		sspi_SecureHandleSetUpperPointer(phNewContext, (void*)NTLM_PACKAGE_NAME);
+		sspi_SecureHandleSetUpperPointer(phNewContext, (void*)SSPI_PACKAGE_NTLM);
 	}
 
 	switch (ntlm_get_state(context))
@@ -785,7 +785,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_InitializeSecurityContextW(
 		}
 
 		sspi_SecureHandleSetLowerPointer(phNewContext, context);
-		sspi_SecureHandleSetUpperPointer(phNewContext, NTLM_SSP_NAME);
+		sspi_SecureHandleSetUpperPointer(phNewContext, (void*)SSPI_PACKAGE_NTLM);
 	}
 
 	if ((!input_buffer) || (ntlm_get_state(context) == NTLM_STATE_AUTHENTICATE))

--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -535,7 +535,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_AcquireCredentialsHandleW(
 	}
 
 	sspi_SecureHandleSetLowerPointer(phCredential, (void*)credentials);
-	sspi_SecureHandleSetUpperPointer(phCredential, (void*)NTLM_PACKAGE_NAME);
+	sspi_SecureHandleSetPackageId(phCredential, SSPI_PACKAGE_NTLM);
 	return SEC_E_OK;
 }
 
@@ -651,7 +651,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_AcceptSecurityContext(
 		if (!ntlm_SetContextTargetName(context, nullptr))
 			return SEC_E_INVALID_HANDLE;
 		sspi_SecureHandleSetLowerPointer(phNewContext, context);
-		sspi_SecureHandleSetUpperPointer(phNewContext, (void*)NTLM_PACKAGE_NAME);
+		sspi_SecureHandleSetPackageId(phNewContext, SSPI_PACKAGE_NTLM);
 	}
 
 	switch (ntlm_get_state(context))
@@ -785,7 +785,7 @@ static SECURITY_STATUS SEC_ENTRY ntlm_InitializeSecurityContextW(
 		}
 
 		sspi_SecureHandleSetLowerPointer(phNewContext, context);
-		sspi_SecureHandleSetUpperPointer(phNewContext, NTLM_SSP_NAME);
+		sspi_SecureHandleSetPackageId(phNewContext, SSPI_PACKAGE_NTLM);
 	}
 
 	if ((!input_buffer) || (ntlm_get_state(context) == NTLM_STATE_AUTHENTICATE))

--- a/winpr/libwinpr/sspi/Negotiate/negotiate.c
+++ b/winpr/libwinpr/sspi/Negotiate/negotiate.c
@@ -665,11 +665,11 @@ static SECURITY_STATUS negotiate_mic_exchange(NEGOTIATE_CONTEXT* context, NegTok
 	}
 
 	/* When using NTLM cipher states need to be reset after mic exchange */
-	const TCHAR* name = sspi_SecureHandleGetUpperPointer(&context->sub_context);
-	if (!name)
+	const uintptr_t sub_id = (uintptr_t)sspi_SecureHandleGetUpperPointer(&context->sub_context);
+	if (!sub_id)
 		return SEC_E_INTERNAL_ERROR;
 
-	if (_tcsncmp(name, NTLM_SSP_NAME, ARRAYSIZE(NTLM_SSP_NAME)) == 0)
+	if (sub_id == SSPI_PACKAGE_NTLM)
 	{
 		if (!ntlm_reset_cipher_state(&context->sub_context))
 			return SEC_E_INTERNAL_ERROR;
@@ -810,7 +810,7 @@ static SECURITY_STATUS SEC_ENTRY negotiate_InitializeSecurityContextW(
 			return SEC_E_INSUFFICIENT_MEMORY;
 		}
 
-		sspi_SecureHandleSetUpperPointer(phNewContext, NEGO_SSP_NAME);
+		sspi_SecureHandleSetUpperPointer(phNewContext, (void*)SSPI_PACKAGE_NEGOTIATE);
 		sspi_SecureHandleSetLowerPointer(phNewContext, context);
 
 		if (!context->spnego)
@@ -1160,7 +1160,7 @@ static SECURITY_STATUS SEC_ENTRY negotiate_AcceptSecurityContext(
 			return SEC_E_INSUFFICIENT_MEMORY;
 		}
 
-		sspi_SecureHandleSetUpperPointer(phNewContext, NEGO_SSP_NAME);
+		sspi_SecureHandleSetUpperPointer(phNewContext, (void*)SSPI_PACKAGE_NEGOTIATE);
 		sspi_SecureHandleSetLowerPointer(phNewContext, context);
 
 		if (!init_context.spnego)
@@ -1528,7 +1528,7 @@ static SECURITY_STATUS SEC_ENTRY negotiate_AcquireCredentialsHandleW(
 	}
 
 	sspi_SecureHandleSetLowerPointer(phCredential, (void*)creds);
-	sspi_SecureHandleSetUpperPointer(phCredential, (void*)NEGO_SSP_NAME);
+	sspi_SecureHandleSetUpperPointer(phCredential, (void*)SSPI_PACKAGE_NEGOTIATE);
 	return SEC_E_OK;
 }
 
@@ -1567,7 +1567,7 @@ static SECURITY_STATUS SEC_ENTRY negotiate_AcquireCredentialsHandleA(
 	}
 
 	sspi_SecureHandleSetLowerPointer(phCredential, (void*)creds);
-	sspi_SecureHandleSetUpperPointer(phCredential, (void*)NEGO_SSP_NAME);
+	sspi_SecureHandleSetUpperPointer(phCredential, (void*)SSPI_PACKAGE_NEGOTIATE);
 	return SEC_E_OK;
 }
 

--- a/winpr/libwinpr/sspi/Negotiate/negotiate.c
+++ b/winpr/libwinpr/sspi/Negotiate/negotiate.c
@@ -665,11 +665,11 @@ static SECURITY_STATUS negotiate_mic_exchange(NEGOTIATE_CONTEXT* context, NegTok
 	}
 
 	/* When using NTLM cipher states need to be reset after mic exchange */
-	const TCHAR* name = sspi_SecureHandleGetUpperPointer(&context->sub_context);
-	if (!name)
+	const SSPI_PACKAGE_ID sub_id = sspi_SecureHandleGetPackageId(&context->sub_context);
+	if (!sub_id)
 		return SEC_E_INTERNAL_ERROR;
 
-	if (_tcsncmp(name, NTLM_SSP_NAME, ARRAYSIZE(NTLM_SSP_NAME)) == 0)
+	if (sub_id == SSPI_PACKAGE_NTLM)
 	{
 		if (!ntlm_reset_cipher_state(&context->sub_context))
 			return SEC_E_INTERNAL_ERROR;
@@ -810,7 +810,7 @@ static SECURITY_STATUS SEC_ENTRY negotiate_InitializeSecurityContextW(
 			return SEC_E_INSUFFICIENT_MEMORY;
 		}
 
-		sspi_SecureHandleSetUpperPointer(phNewContext, NEGO_SSP_NAME);
+		sspi_SecureHandleSetPackageId(phNewContext, SSPI_PACKAGE_NEGOTIATE);
 		sspi_SecureHandleSetLowerPointer(phNewContext, context);
 
 		if (!context->spnego)
@@ -1166,7 +1166,7 @@ static SECURITY_STATUS SEC_ENTRY negotiate_AcceptSecurityContext(
 			return SEC_E_INSUFFICIENT_MEMORY;
 		}
 
-		sspi_SecureHandleSetUpperPointer(phNewContext, NEGO_SSP_NAME);
+		sspi_SecureHandleSetPackageId(phNewContext, SSPI_PACKAGE_NEGOTIATE);
 		sspi_SecureHandleSetLowerPointer(phNewContext, context);
 
 		if (!init_context.spnego)
@@ -1541,7 +1541,7 @@ static SECURITY_STATUS SEC_ENTRY negotiate_AcquireCredentialsHandleW(
 	}
 
 	sspi_SecureHandleSetLowerPointer(phCredential, (void*)creds);
-	sspi_SecureHandleSetUpperPointer(phCredential, (void*)NEGO_SSP_NAME);
+	sspi_SecureHandleSetPackageId(phCredential, SSPI_PACKAGE_NEGOTIATE);
 	return SEC_E_OK;
 }
 
@@ -1580,7 +1580,7 @@ static SECURITY_STATUS SEC_ENTRY negotiate_AcquireCredentialsHandleA(
 	}
 
 	sspi_SecureHandleSetLowerPointer(phCredential, (void*)creds);
-	sspi_SecureHandleSetUpperPointer(phCredential, (void*)NEGO_SSP_NAME);
+	sspi_SecureHandleSetPackageId(phCredential, SSPI_PACKAGE_NEGOTIATE);
 	return SEC_E_OK;
 }
 

--- a/winpr/libwinpr/sspi/sspi.h
+++ b/winpr/libwinpr/sspi/sspi.h
@@ -55,6 +55,20 @@ void* sspi_SecureHandleGetUpperPointer(SecHandle* handle);
 void sspi_SecureHandleSetUpperPointer(SecHandle* handle, void* pointer);
 void sspi_SecureHandleFree(SecHandle* handle);
 
+/* Package identity stored (1-based; 0 == unset) in a SecHandle upper-pointer.
+ * Replaces the former mixed-width _T() name-string scheme so dispatch never
+ * depends on TCHAR/char width. Order MUST match SecPkgInfo{A,W}_LIST /
+ * SecurityFunctionTable{A,W}_NAME_LIST in sspi_winpr.c. */
+typedef enum
+{
+	SSPI_PACKAGE_NONE = 0,
+	SSPI_PACKAGE_NTLM = 1,
+	SSPI_PACKAGE_KERBEROS = 2,
+	SSPI_PACKAGE_NEGOTIATE = 3,
+	SSPI_PACKAGE_CREDSSP = 4,
+	SSPI_PACKAGE_SCHANNEL = 5
+} SSPI_PACKAGE_ID;
+
 enum SecurityFunctionTableIndex
 {
 	EnumerateSecurityPackagesIndex = 1,

--- a/winpr/libwinpr/sspi/sspi.h
+++ b/winpr/libwinpr/sspi/sspi.h
@@ -55,6 +55,26 @@ void* sspi_SecureHandleGetUpperPointer(SecHandle* handle);
 void sspi_SecureHandleSetUpperPointer(SecHandle* handle, void* pointer);
 void sspi_SecureHandleFree(SecHandle* handle);
 
+/* Package identity of a SecHandle (1-based; 0 == unset). The order MUST match
+ * SecPkgInfo{A,W}_LIST and SecurityFunctionTable{A,W}_NAME_LIST in sspi_winpr.c;
+ * that is asserted at compile time there. */
+typedef enum WINPR_C23_ENUM_TYPE(uint32_t)
+{
+	SSPI_PACKAGE_NONE = 0,
+	SSPI_PACKAGE_NTLM = 1,
+	SSPI_PACKAGE_KERBEROS = 2,
+	SSPI_PACKAGE_NEGOTIATE = 3,
+	SSPI_PACKAGE_CREDSSP = 4,
+	SSPI_PACKAGE_SCHANNEL = 5,
+	SSPI_PACKAGE_COUNT /* number of identifiers, SSPI_PACKAGE_NONE included; keep last */
+} SSPI_PACKAGE_ID;
+
+/* Typed access to the package identity. Shares the upper-pointer slot and its encoding
+ * with sspi_SecureHandleGet/SetUpperPointer, but never forms a pointer from the
+ * identifier, so no integer-to-pointer conversion appears at any call site. */
+WINPR_ATTR_NODISCARD SSPI_PACKAGE_ID sspi_SecureHandleGetPackageId(SecHandle* handle);
+void sspi_SecureHandleSetPackageId(SecHandle* handle, SSPI_PACKAGE_ID id);
+
 enum SecurityFunctionTableIndex
 {
 	EnumerateSecurityPackagesIndex = 1,

--- a/winpr/libwinpr/sspi/sspi_winpr.c
+++ b/winpr/libwinpr/sspi/sspi_winpr.c
@@ -304,6 +304,22 @@ void sspi_SecureHandleSetUpperPointer(SecHandle* handle, void* pointer)
 	handle->dwUpper = (ULONG_PTR)(~((size_t)pointer));
 }
 
+SSPI_PACKAGE_ID sspi_SecureHandleGetPackageId(SecHandle* handle)
+{
+	if (!handle || !SecIsValidHandle(handle) || !handle->dwUpper)
+		return SSPI_PACKAGE_NONE;
+
+	return (SSPI_PACKAGE_ID)(~((size_t)handle->dwUpper));
+}
+
+void sspi_SecureHandleSetPackageId(SecHandle* handle, SSPI_PACKAGE_ID id)
+{
+	if (!handle)
+		return;
+
+	handle->dwUpper = (ULONG_PTR)(~((size_t)id));
+}
+
 void sspi_SecureHandleFree(SecHandle* handle)
 {
 	free(handle);
@@ -986,6 +1002,17 @@ void sspi_GlobalInit(void)
 {
 	static INIT_ONCE once = INIT_ONCE_STATIC_INIT;
 	DWORD flags = 0;
+
+	/* Dispatch indexes these lists with SSPI_PACKAGE_ID - 1, so every one of them must have
+	 * exactly one entry per package, in the order the enum declares. Adding a package to the
+	 * enum without extending all four lists (and the W name buffers) would otherwise read past
+	 * the end or dispatch to the wrong package, silently. */
+	WINPR_STATIC_ASSERT(ARRAYSIZE(SecPkgInfoA_LIST) == SSPI_PACKAGE_COUNT - 1);
+	WINPR_STATIC_ASSERT(ARRAYSIZE(SecPkgInfoW_LIST) == SSPI_PACKAGE_COUNT - 1);
+	WINPR_STATIC_ASSERT(ARRAYSIZE(SecurityFunctionTableA_NAME_LIST) == SSPI_PACKAGE_COUNT - 1);
+	WINPR_STATIC_ASSERT(ARRAYSIZE(SecurityFunctionTableW_NAME_LIST) == SSPI_PACKAGE_COUNT - 1);
+	WINPR_STATIC_ASSERT(ARRAYSIZE(BUFFER_NAME_LIST_W) == SSPI_PACKAGE_COUNT - 1);
+
 	if (!InitOnceExecuteOnce(&once, sspi_init, &flags, nullptr))
 		WLog_ERR(TAG, "InitOnceExecuteOnce failed");
 }
@@ -1038,6 +1065,31 @@ static const SecurityFunctionTableW* sspi_GetSecurityFunctionTableWByNameA(const
 	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameW(NameW);
 	free(NameW);
 	return table;
+}
+
+/* Table lookup for the context/credential dispatch wrappers, which identify their package
+ * by the handle itself. Takes the handle rather than an index so the identifier is read in
+ * one place instead of at every call site. */
+WINPR_ATTR_NODISCARD static const SecurityFunctionTableA*
+sspi_GetSecurityFunctionTableAByHandle(SecHandle* handle)
+{
+	const SSPI_PACKAGE_ID id = sspi_SecureHandleGetPackageId(handle);
+
+	if ((id < SSPI_PACKAGE_NTLM) || (id > ARRAYSIZE(SecurityFunctionTableA_NAME_LIST)))
+		return nullptr;
+
+	return SecurityFunctionTableA_NAME_LIST[id - 1].SecurityFunctionTable;
+}
+
+WINPR_ATTR_NODISCARD static const SecurityFunctionTableW*
+sspi_GetSecurityFunctionTableWByHandle(SecHandle* handle)
+{
+	const SSPI_PACKAGE_ID id = sspi_SecureHandleGetPackageId(handle);
+
+	if ((id < SSPI_PACKAGE_NTLM) || (id > ARRAYSIZE(SecurityFunctionTableW_NAME_LIST)))
+		return nullptr;
+
+	return SecurityFunctionTableW_NAME_LIST[id - 1].SecurityFunctionTable;
 }
 
 static void FreeContextBuffer_EnumerateSecurityPackages(void* contextBuffer);
@@ -1310,12 +1362,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_ExportSecurityContext(PCtxtHandle phConte
                                                              PSecBuffer pPackedContext,
                                                              HANDLE* pToken)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1333,12 +1380,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_ExportSecurityContext(PCtxtHandle phConte
 
 static SECURITY_STATUS SEC_ENTRY winpr_FreeCredentialsHandle(PCredHandle phCredential)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phCredential);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByHandle(phCredential);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1357,12 +1399,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_ImportSecurityContextW(SEC_WCHAR* pszPack
                                                               PSecBuffer pPackedContext,
                                                               HANDLE pToken, PCtxtHandle phContext)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1382,12 +1419,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_ImportSecurityContextA(SEC_CHAR* pszPacka
                                                               PSecBuffer pPackedContext,
                                                               HANDLE pToken, PCtxtHandle phContext)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1406,12 +1438,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_ImportSecurityContextA(SEC_CHAR* pszPacka
 static SECURITY_STATUS SEC_ENTRY winpr_QueryCredentialsAttributesW(PCredHandle phCredential,
                                                                    ULONG ulAttribute, void* pBuffer)
 {
-	const WCHAR* Name = (const WCHAR*)sspi_SecureHandleGetUpperPointer(phCredential);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameW(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByHandle(phCredential);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1429,12 +1456,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_QueryCredentialsAttributesW(PCredHandle p
 static SECURITY_STATUS SEC_ENTRY winpr_QueryCredentialsAttributesA(PCredHandle phCredential,
                                                                    ULONG ulAttribute, void* pBuffer)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phCredential);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByHandle(phCredential);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1453,12 +1475,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_SetCredentialsAttributesW(PCredHandle phC
                                                                  ULONG ulAttribute, void* pBuffer,
                                                                  ULONG cbBuffer)
 {
-	const WCHAR* Name = (const WCHAR*)sspi_SecureHandleGetUpperPointer(phCredential);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameW(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByHandle(phCredential);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1478,12 +1495,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_SetCredentialsAttributesA(PCredHandle phC
                                                                  ULONG ulAttribute, void* pBuffer,
                                                                  ULONG cbBuffer)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phCredential);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByHandle(phCredential);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1506,12 +1518,7 @@ winpr_AcceptSecurityContext(PCredHandle phCredential, PCtxtHandle phContext, PSe
                             ULONG fContextReq, ULONG TargetDataRep, PCtxtHandle phNewContext,
                             PSecBufferDesc pOutput, PULONG pfContextAttr, PTimeStamp ptsTimeStamp)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phCredential);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByHandle(phCredential);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1531,12 +1538,7 @@ winpr_AcceptSecurityContext(PCredHandle phCredential, PCtxtHandle phContext, PSe
 static SECURITY_STATUS SEC_ENTRY winpr_ApplyControlToken(PCtxtHandle phContext,
                                                          PSecBufferDesc pInput)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1554,12 +1556,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_ApplyControlToken(PCtxtHandle phContext,
 static SECURITY_STATUS SEC_ENTRY winpr_CompleteAuthToken(PCtxtHandle phContext,
                                                          PSecBufferDesc pToken)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1576,12 +1573,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_CompleteAuthToken(PCtxtHandle phContext,
 
 static SECURITY_STATUS SEC_ENTRY winpr_DeleteSecurityContext(PCtxtHandle phContext)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1607,12 +1599,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_FreeContextBuffer(void* pvContextBuffer)
 
 static SECURITY_STATUS SEC_ENTRY winpr_ImpersonateSecurityContext(PCtxtHandle phContext)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1632,12 +1619,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_InitializeSecurityContextW(
     ULONG Reserved1, ULONG TargetDataRep, PSecBufferDesc pInput, ULONG Reserved2,
     PCtxtHandle phNewContext, PSecBufferDesc pOutput, PULONG pfContextAttr, PTimeStamp ptsExpiry)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phCredential);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByHandle(phCredential);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1659,12 +1641,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_InitializeSecurityContextA(
     ULONG Reserved1, ULONG TargetDataRep, PSecBufferDesc pInput, ULONG Reserved2,
     PCtxtHandle phNewContext, PSecBufferDesc pOutput, PULONG pfContextAttr, PTimeStamp ptsExpiry)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phCredential);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByHandle(phCredential);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1685,12 +1662,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_InitializeSecurityContextA(
 static SECURITY_STATUS SEC_ENTRY winpr_QueryContextAttributesW(PCtxtHandle phContext,
                                                                ULONG ulAttribute, void* pBuffer)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1708,12 +1680,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_QueryContextAttributesW(PCtxtHandle phCon
 static SECURITY_STATUS SEC_ENTRY winpr_QueryContextAttributesA(PCtxtHandle phContext,
                                                                ULONG ulAttribute, void* pBuffer)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1731,12 +1698,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_QueryContextAttributesA(PCtxtHandle phCon
 static SECURITY_STATUS SEC_ENTRY winpr_QuerySecurityContextToken(PCtxtHandle phContext,
                                                                  HANDLE* phToken)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1755,12 +1717,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_SetContextAttributesW(PCtxtHandle phConte
                                                              ULONG ulAttribute, void* pBuffer,
                                                              ULONG cbBuffer)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1780,12 +1737,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_SetContextAttributesA(PCtxtHandle phConte
                                                              ULONG ulAttribute, void* pBuffer,
                                                              ULONG cbBuffer)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1803,12 +1755,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_SetContextAttributesA(PCtxtHandle phConte
 
 static SECURITY_STATUS SEC_ENTRY winpr_RevertSecurityContext(PCtxtHandle phContext)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1830,12 +1777,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_DecryptMessage(PCtxtHandle phContext,
                                                       PSecBufferDesc pMessage, ULONG MessageSeqNo,
                                                       PULONG pfQOP)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1854,12 +1796,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_DecryptMessage(PCtxtHandle phContext,
 static SECURITY_STATUS SEC_ENTRY winpr_EncryptMessage(PCtxtHandle phContext, ULONG fQOP,
                                                       PSecBufferDesc pMessage, ULONG MessageSeqNo)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1877,12 +1814,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_EncryptMessage(PCtxtHandle phContext, ULO
 static SECURITY_STATUS SEC_ENTRY winpr_MakeSignature(PCtxtHandle phContext, ULONG fQOP,
                                                      PSecBufferDesc pMessage, ULONG MessageSeqNo)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1901,12 +1833,7 @@ static SECURITY_STATUS SEC_ENTRY winpr_VerifySignature(PCtxtHandle phContext,
                                                        PSecBufferDesc pMessage, ULONG MessageSeqNo,
                                                        PULONG pfQOP)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
-
-	if (!Name)
-		return SEC_E_SECPKG_NOT_FOUND;
-
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByHandle(phContext);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;

--- a/winpr/libwinpr/sspi/sspi_winpr.c
+++ b/winpr/libwinpr/sspi/sspi_winpr.c
@@ -995,6 +995,8 @@ void sspi_GlobalFinish(void)
 	sspi_ContextBufferAllocTableFree();
 }
 
+/* By-NAME lookups: used by callers that pass a real package name string
+ * (AcquireCredentialsHandle, QuerySecurityPackageInfo). Unchanged. */
 static const SecurityFunctionTableA* sspi_GetSecurityFunctionTableAByNameA(const SEC_CHAR* Name)
 {
 	size_t cPackages = ARRAYSIZE(SecPkgInfoA_LIST);
@@ -1038,6 +1040,26 @@ static const SecurityFunctionTableW* sspi_GetSecurityFunctionTableWByNameA(const
 	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameW(NameW);
 	free(NameW);
 	return table;
+}
+
+/* By-INDEX lookups: used ONLY by the context/credential dispatch wrappers, whose
+ * handle upper-pointer stores a 1-based SSPI_PACKAGE_ID (see sspi.h). Width-agnostic
+ * replacement for the old name-string dispatch, which mis-fired under -DUNICODE
+ * (WCHAR name read as char*). */
+static const SecurityFunctionTableA* sspi_GetSecurityFunctionTableAByIndex(UINT_PTR id)
+{
+	if ((id < SSPI_PACKAGE_NTLM) || (id > ARRAYSIZE(SecurityFunctionTableA_NAME_LIST)))
+		return nullptr;
+
+	return SecurityFunctionTableA_NAME_LIST[id - 1].SecurityFunctionTable;
+}
+
+static const SecurityFunctionTableW* sspi_GetSecurityFunctionTableWByIndex(UINT_PTR id)
+{
+	if ((id < SSPI_PACKAGE_NTLM) || (id > ARRAYSIZE(SecurityFunctionTableW_NAME_LIST)))
+		return nullptr;
+
+	return SecurityFunctionTableW_NAME_LIST[id - 1].SecurityFunctionTable;
 }
 
 static void FreeContextBuffer_EnumerateSecurityPackages(void* contextBuffer);
@@ -1310,12 +1332,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_ExportSecurityContext(PCtxtHandle phConte
                                                              PSecBuffer pPackedContext,
                                                              HANDLE* pToken)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1333,12 +1355,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_ExportSecurityContext(PCtxtHandle phConte
 
 static SECURITY_STATUS SEC_ENTRY winpr_FreeCredentialsHandle(PCredHandle phCredential)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phCredential);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phCredential);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1357,12 +1379,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_ImportSecurityContextW(SEC_WCHAR* pszPack
                                                               PSecBuffer pPackedContext,
                                                               HANDLE pToken, PCtxtHandle phContext)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1382,12 +1404,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_ImportSecurityContextA(SEC_CHAR* pszPacka
                                                               PSecBuffer pPackedContext,
                                                               HANDLE pToken, PCtxtHandle phContext)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1406,12 +1428,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_ImportSecurityContextA(SEC_CHAR* pszPacka
 static SECURITY_STATUS SEC_ENTRY winpr_QueryCredentialsAttributesW(PCredHandle phCredential,
                                                                    ULONG ulAttribute, void* pBuffer)
 {
-	const WCHAR* Name = (const WCHAR*)sspi_SecureHandleGetUpperPointer(phCredential);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phCredential);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameW(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1429,12 +1451,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_QueryCredentialsAttributesW(PCredHandle p
 static SECURITY_STATUS SEC_ENTRY winpr_QueryCredentialsAttributesA(PCredHandle phCredential,
                                                                    ULONG ulAttribute, void* pBuffer)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phCredential);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phCredential);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1453,12 +1475,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_SetCredentialsAttributesW(PCredHandle phC
                                                                  ULONG ulAttribute, void* pBuffer,
                                                                  ULONG cbBuffer)
 {
-	const WCHAR* Name = (const WCHAR*)sspi_SecureHandleGetUpperPointer(phCredential);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phCredential);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameW(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1478,12 +1500,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_SetCredentialsAttributesA(PCredHandle phC
                                                                  ULONG ulAttribute, void* pBuffer,
                                                                  ULONG cbBuffer)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phCredential);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phCredential);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1506,12 +1528,12 @@ winpr_AcceptSecurityContext(PCredHandle phCredential, PCtxtHandle phContext, PSe
                             ULONG fContextReq, ULONG TargetDataRep, PCtxtHandle phNewContext,
                             PSecBufferDesc pOutput, PULONG pfContextAttr, PTimeStamp ptsTimeStamp)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phCredential);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phCredential);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1531,12 +1553,12 @@ winpr_AcceptSecurityContext(PCredHandle phCredential, PCtxtHandle phContext, PSe
 static SECURITY_STATUS SEC_ENTRY winpr_ApplyControlToken(PCtxtHandle phContext,
                                                          PSecBufferDesc pInput)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1554,12 +1576,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_ApplyControlToken(PCtxtHandle phContext,
 static SECURITY_STATUS SEC_ENTRY winpr_CompleteAuthToken(PCtxtHandle phContext,
                                                          PSecBufferDesc pToken)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1576,12 +1598,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_CompleteAuthToken(PCtxtHandle phContext,
 
 static SECURITY_STATUS SEC_ENTRY winpr_DeleteSecurityContext(PCtxtHandle phContext)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1607,12 +1629,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_FreeContextBuffer(void* pvContextBuffer)
 
 static SECURITY_STATUS SEC_ENTRY winpr_ImpersonateSecurityContext(PCtxtHandle phContext)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1632,12 +1654,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_InitializeSecurityContextW(
     ULONG Reserved1, ULONG TargetDataRep, PSecBufferDesc pInput, ULONG Reserved2,
     PCtxtHandle phNewContext, PSecBufferDesc pOutput, PULONG pfContextAttr, PTimeStamp ptsExpiry)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phCredential);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phCredential);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1659,12 +1681,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_InitializeSecurityContextA(
     ULONG Reserved1, ULONG TargetDataRep, PSecBufferDesc pInput, ULONG Reserved2,
     PCtxtHandle phNewContext, PSecBufferDesc pOutput, PULONG pfContextAttr, PTimeStamp ptsExpiry)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phCredential);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phCredential);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1685,12 +1707,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_InitializeSecurityContextA(
 static SECURITY_STATUS SEC_ENTRY winpr_QueryContextAttributesW(PCtxtHandle phContext,
                                                                ULONG ulAttribute, void* pBuffer)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1708,12 +1730,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_QueryContextAttributesW(PCtxtHandle phCon
 static SECURITY_STATUS SEC_ENTRY winpr_QueryContextAttributesA(PCtxtHandle phContext,
                                                                ULONG ulAttribute, void* pBuffer)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1731,12 +1753,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_QueryContextAttributesA(PCtxtHandle phCon
 static SECURITY_STATUS SEC_ENTRY winpr_QuerySecurityContextToken(PCtxtHandle phContext,
                                                                  HANDLE* phToken)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1755,12 +1777,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_SetContextAttributesW(PCtxtHandle phConte
                                                              ULONG ulAttribute, void* pBuffer,
                                                              ULONG cbBuffer)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1780,12 +1802,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_SetContextAttributesA(PCtxtHandle phConte
                                                              ULONG ulAttribute, void* pBuffer,
                                                              ULONG cbBuffer)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1803,12 +1825,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_SetContextAttributesA(PCtxtHandle phConte
 
 static SECURITY_STATUS SEC_ENTRY winpr_RevertSecurityContext(PCtxtHandle phContext)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByNameA(Name);
+	const SecurityFunctionTableW* table = sspi_GetSecurityFunctionTableWByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1830,12 +1852,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_DecryptMessage(PCtxtHandle phContext,
                                                       PSecBufferDesc pMessage, ULONG MessageSeqNo,
                                                       PULONG pfQOP)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1854,12 +1876,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_DecryptMessage(PCtxtHandle phContext,
 static SECURITY_STATUS SEC_ENTRY winpr_EncryptMessage(PCtxtHandle phContext, ULONG fQOP,
                                                       PSecBufferDesc pMessage, ULONG MessageSeqNo)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1877,12 +1899,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_EncryptMessage(PCtxtHandle phContext, ULO
 static SECURITY_STATUS SEC_ENTRY winpr_MakeSignature(PCtxtHandle phContext, ULONG fQOP,
                                                      PSecBufferDesc pMessage, ULONG MessageSeqNo)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;
@@ -1901,12 +1923,12 @@ static SECURITY_STATUS SEC_ENTRY winpr_VerifySignature(PCtxtHandle phContext,
                                                        PSecBufferDesc pMessage, ULONG MessageSeqNo,
                                                        PULONG pfQOP)
 {
-	const char* Name = (const char*)sspi_SecureHandleGetUpperPointer(phContext);
+	const UINT_PTR Name = (UINT_PTR)sspi_SecureHandleGetUpperPointer(phContext);
 
 	if (!Name)
 		return SEC_E_SECPKG_NOT_FOUND;
 
-	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByNameA(Name);
+	const SecurityFunctionTableA* table = sspi_GetSecurityFunctionTableAByIndex(Name);
 
 	if (!table)
 		return SEC_E_SECPKG_NOT_FOUND;


### PR DESCRIPTION
### The problem

`sspi_winpr` stored the security package's **name** in the upper pointer of the
`SecHandle` and read it back to select the dispatch table. The value was written
and read at different character widths — stored as TCHAR/WCHAR under `-DUNICODE`,
but compared as a narrow string — so the lookup could not match the name it had
itself stored.

With `WITH_NATIVE_SSPI=OFF`, the context and credential wrappers therefore failed
to resolve their own package, and NLA aborted with `SEC_E_SECPKG_NOT_FOUND`.

`schannel.c` writes explicit `SCHANNEL_PACKAGE_NAME_A` and `_W` values into that
same field, so both widths are genuinely in use on the same handle type — the
field carries no indication of which one it currently holds.

### The change

Store a 1-based package identifier (`SSPI_PACKAGE_ID`, `sspi.h`) in the handle
instead of a name, and add by-index table lookups
(`sspi_GetSecurityFunctionTable{A,W}ByIndex`) for the dispatch wrappers. The enum
order matches `SecPkgInfo{A,W}_LIST` and `SecurityFunctionTable{A,W}_NAME_LIST`,
so dispatch no longer depends on TCHAR width in either direction.

I went with an index rather than normalising everything to one width because the
field is untyped and both the A and W paths are legitimate. A single-width
convention would have to be honoured by every writer and every reader with
nothing enforcing it at compile time, so the same class of bug would be one new
call site away.

One thing worth your opinion: the index dispatch is correct as long as the enum
stays in step with those two lists, and nothing currently enforces that. I'm
happy to add a static assertion or an init-time check if you'd rather have it
guarded.

### How to test

The existing WinPR test suite already catches this, so no new test is needed.

Configure with the internal SSPI and internal tests enabled, on Windows with
`UNICODE` defined:

```
cmake -S . -B build -G Ninja -DBUILD_TESTING_INTERNAL=ON -DWITH_NATIVE_SSPI=OFF -DWITH_INTERNAL_RC4=ON -DWITH_INTERNAL_MD4=ON -DWITH_INTERNAL_MD5=ON
cmake --build build --target TestSspi
ctest --test-dir build -R "Sspi|Credential|SecurityContext|SecurityPackage"
```

On current master (`1cf992dc2), two of those tests fail:

| Test | master | this branch |
|---|---|---|
| TestQuerySecurityPackageInfo | pass | pass |
| TestEnumerateSecurityPackages | pass | pass |
| **TestInitializeSecurityContext** | **fail** | pass |
| **TestAcquireCredentialsHandle** | **fail** | pass |
| TestSspiNTLM | pass | pass |
| TestSspiPasswordHash | pass | pass |
| TestCredentialZeroing | pass | pass |
| | 5/7, ctest exit 8 | 7/7, ctest exit 0 |

The failure on master prints the error this description names:

```
DeleteSecurityContext status: 0x80090305      (SEC_E_SECPKG_NOT_FOUND)
```

`0x80090305` appears once in the master run and not at all with this change.

The configuration is presumably why this went unnoticed: the default Windows
build uses the OS SSPI (`WITH_NATIVE_SSPI=ON`), so the internal dispatch path
these tests exercise is never reached. A CI configuration with
`WITH_NATIVE_SSPI=OFF` would have caught it.

If you would rather see it end to end, connect with NLA using
`wfreerdp /v:<host> /u:<user> /p:<password>` against a build configured the same
way: authentication fails before the change and succeeds after.

Verified on Windows x64 (MSVC, vcpkg static OpenSSL/zlib); also in use on
Windows ARM32. The change is not platform-specific — it affects any `UNICODE`
build using the internal SSPI.

### Notes

Rebased on current master, single commit, no merges. Checked locally against the
required checks: `codespell` clean on the changed files, no CMake files touched,
and no new compiler warnings at `/W4` or clang-tidy findings on the changed lines
when compared with master's own copies of the same files.
