### PR TITLE
winpr: fix missing FreeLibrary/GetProcAddress declarations on Cygwin

### DIFF
--- a/winpr/include/winpr/library.h
+++ b/winpr/include/winpr/library.h
@@ -88,7 +88,7 @@ extern "C"
 extern "C"
 {
 #endif
-#if !defined(_WIN32) && !defined(__CYGWIN__)
+#if !defined(_WIN32)
 	WINPR_API BOOL FreeLibrary(HMODULE hLibModule);
 #endif
 
@@ -112,7 +112,7 @@ extern "C"
  */
 #define GetProcAddressAs(module, name, type) WINPR_FUNC_PTR_CAST(GetProcAddress(module, name), type)
 
-#if !defined(_WIN32) && !defined(__CYGWIN__)
+#if !defined(_WIN32)
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
## Description

`winpr/include/winpr/library.h` skips declaring `FreeLibrary`/`GetProcAddress`
(and `GetModuleHandleA`/`W`, `GetModuleFileNameA`/`W`) whenever `__CYGWIN__`
is defined, under the assumption that the real Win32 declarations from
`<windows.h>` will be visible instead.

However, `winpr/include/winpr/windows.h` (the wrapper meant to provide those
real declarations) only includes the actual system `<windows.h>` when
`_WIN32` is defined:

```c
#ifdef _WIN32
#include <windows.h>
...
#else
/* winpr's own POSIX-side type/constant definitions */
#endif
```

`_WIN32` is never defined on Cygwin (only `__CYGWIN__` is), so on that
platform neither the real Windows declarations nor winpr's own fallback ones
are available for `FreeLibrary`, `GetProcAddress`, and their consumers,
causing build failures such as:

```
error: 'FreeLibrary' undeclared here (not in a function)
error: implicit declaration of function 'FreeLibrary'
error: implicit declaration of function 'GetProcAddress'; did you mean 'GetProcAddressAs'?
```

This removes the `__CYGWIN__` exclusion from the **declarations only**, so
the prototypes are always visible on Cygwin.

**Edit:** an earlier revision of this PR also removed the matching
`__CYGWIN__` exclusion in `winpr/libwinpr/library/library.c` (the
*implementation* of `GetProcAddress`/`GetModuleHandleA`/`W`/`FreeLibrary`),
reasoning that Cygwin should consistently use winpr's own
`dlopen`/`dlclose`-based fallback like every other non-Windows platform. That
was wrong and has been dropped: a header declaration doesn't care who
provides the definition, and on Cygwin the real system functions from
`libkernel32.a` already satisfy it correctly — `library.c` already excludes
Cygwin from providing its own implementation here, and that's correct as-is.

Removing that exclusion makes winpr define its own `GetModuleHandleW` for
Cygwin too, which collides with the real one from `libkernel32.a` under
static linking (`BUILD_SHARED_LIBS=OFF`) — silently resolved to winpr's own
(wrong) implementation when `CMAKE_INTERPROCEDURAL_OPTIMIZATION=ON` (the
default for `CMAKE_BUILD_TYPE=Release`), or a hard "multiple definition" link
error when LTO is off. Either way, once winpr's implementation wins, it
deadlocks the first time anything calls `GetModuleHandleW`, inside Cygwin's
own process bootstrap (`cygwin_dll_init`) — confirmed with gdb attached to
the hung process. Under the default dynamic build this stays invisible,
since each shared library gets its own isolated import table, which is how
it went unnoticed in earlier testing of this PR.

This PR is now scoped to `library.h` only.

## Testing

Built FreeRDP 3.30.0 (client, `WITH_X11=ON`) from source on Cygwin (x86_64,
GCC 14) with this fix applied, both as the default dynamic build and with
`BUILD_SHARED_LIBS=OFF`. Completed a full authenticated RDP session
end-to-end in both configurations.

Two unrelated Cygwin build blockers exist outside the scope of this PR
(serial redirection depends on Linux-only ioctls not present on Cygwin; USB
redirection's libusb headers correctly pull in the real `<windows.h>` on
Cygwin, which then collides with winpr's own type definitions elsewhere in
the same translation unit) — worked around locally to get a full build, not
included here.

## How to test

Configure and build on Cygwin, e.g.:

```
cmake .. -G Ninja -DWITH_X11=ON -DWITH_SERVER=OFF
ninja
```

Without this fix, the build fails compiling winpr itself (`library.c`,
`ncrypt/ncrypt_pkcs11.c`, and other consumers of `GetProcAddress`/
`FreeLibrary`).