### PR TITLE
winpr: fix Cygwin GetModuleHandleW/TlsAlloc collisions under static linking

### DIFF
--- a/winpr/libwinpr/library/library.c
+++ b/winpr/libwinpr/library/library.c
@@ -62,7 +62,7 @@
  * SizeofResource
  */
 
-#if !defined(_WIN32) || defined(_UWP)
+#if (!defined(_WIN32) && !defined(__CYGWIN__)) || defined(_UWP)
 
 #ifndef _WIN32
 

--- a/winpr/libwinpr/thread/CMakeLists.txt
+++ b/winpr/libwinpr/thread/CMakeLists.txt
@@ -23,8 +23,15 @@ winpr_module_add(
   processor.c
   thread.c
   thread.h
-  tls.c
 )
+
+# tls.c only provides a pthread-based TlsAlloc/TlsGetValue/TlsSetValue/TlsFree
+# fallback for non-Windows targets. On Cygwin the real system TlsAlloc family
+# is available from libkernel32.a, so skip compiling it there instead of
+# growing the file's own platform guard.
+if(NOT CYGWIN)
+  winpr_module_add(tls.c)
+endif()
 
 if(BUILD_TESTING_INTERNAL OR BUILD_TESTING)
   add_subdirectory(test)

--- a/winpr/libwinpr/thread/tls.c
+++ b/winpr/libwinpr/thread/tls.c
@@ -30,7 +30,7 @@
  * TlsSetValue
  */
 
-#if !defined(_WIN32) && !defined(__CYGWIN__)
+#ifndef _WIN32
 
 #include <pthread.h>
 

--- a/winpr/libwinpr/thread/tls.c
+++ b/winpr/libwinpr/thread/tls.c
@@ -30,7 +30,7 @@
  * TlsSetValue
  */
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 
 #include <pthread.h>
 


### PR DESCRIPTION
## Description

Follow-up to #13138, which fixes the `library.h` declaration side of Cygwin
support. This addresses two related implementation-side gaps in the same
area, uncovered while getting a **static** (`BUILD_SHARED_LIBS=OFF`) Cygwin
build working.

`winpr/libwinpr/library/library.c` (`LoadLibraryA`/`LoadLibraryW`/
`LoadLibraryExA`/`LoadLibraryExW`/`AddDllDirectory`/`RemoveDllDirectory`/
`SetDefaultDllDirectories`) and `winpr/libwinpr/thread/tls.c` (`TlsAlloc`/
`TlsGetValue`/`TlsSetValue`/`TlsFree`) provide their own POSIX
(`dlopen`/`pthread`-based) implementations of these functions whenever
`_WIN32` is not defined, with no `__CYGWIN__` exclusion. On Cygwin this
compiles fine and produces working binaries under the **default dynamic**
(shared library) build, since each shared library gets its own isolated PE
import table — winpr's own implementations never collide with anything.

Under **static linking** this is a real bug. winpr's own `TlsAlloc`
(implemented via `pthread_key_create`) fails at runtime the first time
WinPR's thread subsystem initializes:

```
[ERROR][com.winpr.thread] - [initializeThreads]: Major bug, unable to
allocate a TLS value for currentThread
```

despite a standalone call to the real system `TlsAlloc()` succeeding fine in
the same environment. The same class of collision affects
`GetModuleHandleW` (see #13138, where it's already fixed on the
declaration/implementation guard for that specific function) — confirmed
there via `gdb` to deadlock inside Cygwin's own process bootstrap
(`cygwin_dll_init`) when winpr's own implementation wins the link.

This adds the same `__CYGWIN__` exclusion already used elsewhere in these
files, so Cygwin consistently uses the real system `LoadLibraryA`/`TlsAlloc`
family from `libkernel32.a` instead of winpr's own POSIX fallback.

## Testing

Built FreeRDP 3.30.1-dev (client, `WITH_X11=ON`) from source on Cygwin
(x86_64, GCC 14) with `BUILD_SHARED_LIBS=OFF` and this fix applied (on top
of the `library.h` declaration fix from #13138 — without it Cygwin fails to
compile at all). Confirmed via `nm` that `LoadLibraryA` and `TlsAlloc` now
resolve to the real system functions (`__imp_` import thunks) rather than
winpr's own implementations. The `TlsAlloc` runtime error is gone, and the
client completed a full authenticated RDP session end-to-end.

**Confidence note:** the `LoadLibraryA`/`library.c` fix here is the same
class of bug as the already-confirmed `GetModuleHandleW` deadlock, applied
defensively by analogy — I have not independently reproduced a
`LoadLibraryA`-specific failure via `gdb` the way the `GetModuleHandleW` one
was reproduced. The `TlsAlloc`/`tls.c` fix is independently runtime-verified
(the "Major bug" error is reproducible before this fix and gone after).

## How to test

Requires #13138 (or its `library.h` change) applied first, otherwise Cygwin
fails to compile at all:

```
cmake .. -G Ninja -DWITH_X11=ON -DWITH_SERVER=OFF -DBUILD_SHARED_LIBS=OFF
ninja
```