### PR TITLE
Fix RAIL maximize normalization on Cinnamon

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -985,6 +985,7 @@ static BOOL xf_event_PropertyNotify(xfContext* xfc, const XPropertyEvent* event,
 		BOOL status = FALSE;
 		BOOL minimized = FALSE;
 		BOOL minimizedChanged = FALSE;
+		BOOL fullscreen = FALSE;
 		unsigned long nitems = 0;
 		unsigned long bytes = 0;
 		unsigned char* prop = nullptr;
@@ -1012,6 +1013,8 @@ static BOOL xf_event_PropertyNotify(xfContext* xfc, const XPropertyEvent* event,
 				}
 				for (unsigned long i = 0; i < nitems; i++)
 				{
+					if ((Atom)((UINT16**)prop)[i] == xfc->NET_WM_STATE_FULLSCREEN)
+						fullscreen = TRUE;
 					if ((Atom)((UINT16**)prop)[i] ==
 					    Logging_XInternAtom(xfc->log, xfc->display, "_NET_WM_STATE_MAXIMIZED_VERT",
 					                        False))
@@ -1030,6 +1033,50 @@ static BOOL xf_event_PropertyNotify(xfContext* xfc, const XPropertyEvent* event,
 				}
 
 				XFree(prop);
+
+				if (appWindow && appWindow->rail_fullscreen_normalizing)
+				{
+					if (!fullscreen && appWindow->maxVert && appWindow->maxHorz)
+					{
+						/* Normal maximized state has been restored. */
+						appWindow->rail_fullscreen_normalizing = FALSE;
+					}
+					else
+					{
+						/* Ignore all transient WM states produced while Cinnamon
+						 * transitions from legacy fullscreen back to maximized. */
+						if (fullscreen)
+							xf_SendClientEvent(xfc, appWindow->handle, xfc->NET_WM_STATE, 4,
+							                   NET_WM_STATE_REMOVE, xfc->NET_WM_STATE_FULLSCREEN, 0,
+							                   0);
+
+						if (!appWindow->maxVert || !appWindow->maxHorz)
+							xf_SendClientEvent(xfc, appWindow->handle, xfc->NET_WM_STATE, 4,
+							                   NET_WM_STATE_ADD, xfc->NET_WM_STATE_MAXIMIZED_VERT,
+							                   xfc->NET_WM_STATE_MAXIMIZED_HORZ, 0);
+
+						goto fail;
+					}
+				}
+				else if (appWindow && fullscreen &&
+				         (appWindow->rail_state == WINDOW_SHOW_MAXIMIZED))
+				{
+					/* Cinnamon/Muffin incorrectly turns the server-driven RAIL
+					 * maximize resize into fullscreen. Normalize this over the
+					 * following PropertyNotify events without feeding transient
+					 * states back to the RAIL server. */
+					appWindow->rail_fullscreen_normalizing = TRUE;
+
+					xf_SendClientEvent(xfc, appWindow->handle, xfc->NET_WM_STATE, 4,
+					                   NET_WM_STATE_REMOVE, xfc->NET_WM_STATE_FULLSCREEN, 0, 0);
+
+					if (!appWindow->maxVert || !appWindow->maxHorz)
+						xf_SendClientEvent(xfc, appWindow->handle, xfc->NET_WM_STATE, 4,
+						                   NET_WM_STATE_ADD, xfc->NET_WM_STATE_MAXIMIZED_VERT,
+						                   xfc->NET_WM_STATE_MAXIMIZED_HORZ, 0);
+
+					goto fail;
+				}
 			}
 		}
 

--- a/client/X11/xf_rail.h
+++ b/client/X11/xf_rail.h
@@ -105,6 +105,7 @@ struct xf_app_window
 	BOOL maxHorz;
 	BOOL minimized;
 	BOOL rail_ignore_configure;
+	BOOL rail_fullscreen_normalizing;
 
 	Pixmap pixmap;
 	XImage* image;

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -1071,6 +1071,7 @@ BOOL xf_AppWindowCreate(xfContext* xfc, xfAppWindow* appWindow)
 	appWindow->maxHorz = FALSE;
 	appWindow->minimized = FALSE;
 	appWindow->rail_ignore_configure = FALSE;
+	appWindow->rail_fullscreen_normalizing = FALSE;
 
 	WINPR_ASSERT(xfc->depth != 0);
 	appWindow->handle = LogDynAndXCreateWindow(


### PR DESCRIPTION
## Description

Fix RAIL RemoteApp window maximization on Cinnamon/Muffin under X11.

When a RemoteApp window is maximized using the application's own maximize button, Cinnamon can transiently turn the maximized window into `_NET_WM_STATE_FULLSCREEN`.

Without this change, the observed state transition is:

```text
MAXIMIZED_HORZ + MAXIMIZED_VERT
-> MAXIMIZED_HORZ + MAXIMIZED_VERT + FULLSCREEN
-> FULLSCREEN
```

This leaves the RemoteApp in fullscreen state instead of the normal maximized state and prevents normal maximize/restore behavior.

The issue is reproducible on current FreeRDP master.

## Fix

Track the transient fullscreen normalization state for RAIL application windows.

While Cinnamon is transitioning the window from the unintended fullscreen state back to the normal maximized state, intermediate `_NET_WM_STATE` changes are not fed back into the RAIL state machine.

This prevents transient states from being interpreted as restore/maximize requests and avoids a feedback loop between the local window manager and the remote RAIL window state.

After normalization, the window ends in:

```text
_NET_WM_STATE_MAXIMIZED_HORZ
_NET_WM_STATE_MAXIMIZED_VERT
```

Normal restore and minimize behavior continues afterwards.

## Reproduction

Environment:

- Linux Mint / Cinnamon
- X11 session
- Two 3840x2160 monitors
- FreeRDP X11 client
- RemoteApp / RAIL
- `/multimon`
- `/scale:140`
- HiDef RAIL enabled

Steps:

1. Start a RemoteApp window.
2. Move it to the second monitor.
3. Click the application's normal maximize button.
4. Observe `_NET_WM_STATE` with:

```sh
xprop -spy _NET_WM_STATE
```

On unpatched current master, Cinnamon transitions the window to `FULLSCREEN`.

## Testing

Tested both before and after applying the change on current FreeRDP master.

Verified with:

- `cmd.exe`
- Microsoft Word
- Microsoft PowerPoint
- Microsoft VBA editor

Tested:

- maximize using the RemoteApp window button
- restore
- repeated maximize/restore cycles
- minimize and restore from the taskbar
- rendering across the full second monitor
- mouse/input alignment

The patched version consistently returns to the normal maximized state and all tested window operations continue to work.