### PR TITLE
[core,nla] report early user auth denial as ACCESS_DENIED

### DIFF
--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -2188,12 +2188,28 @@ int nla_recv_pdu(rdpNla* nla, wStream* s)
 
 	if (nla_get_state(nla) == NLA_STATE_EARLY_USER_AUTH)
 	{
-		UINT32 code = 0;
-		Stream_Read_UINT32(s, code);
-		if (code != AUTHZ_SUCCESS)
+		if (!Stream_CheckAndLogRequiredLength(TAG, s, 4))
+			return -1;
+
+		const UINT32 authzResult = Stream_Get_UINT32(s);
+		if (authzResult != AUTHZ_SUCCESS)
 		{
-			WLog_DBG(TAG, "Early User Auth active: FAILURE code 0x%08" PRIX32 "", code);
-			code = FREERDP_ERROR_AUTHENTICATION_FAILED;
+			UINT32 code = FREERDP_ERROR_AUTHENTICATION_FAILED;
+
+			switch (authzResult)
+			{
+				case AUTHZ_ACCESS_DENIED:
+					/* The user authenticated successfully but is not authorized to open a
+					 * session on this host, e.g. it lacks the 'Allow log on through Remote
+					 * Desktop Services' right. */
+					code = FREERDP_ERROR_CONNECT_ACCESS_DENIED;
+					break;
+				default:
+					break;
+			}
+
+			WLog_ERR(TAG, "Early User Auth active: FAILURE authorization result 0x%08" PRIX32 "",
+			         authzResult);
 			freerdp_set_last_error_log(nla->rdpcontext, code);
 			return -1;
 		}


### PR DESCRIPTION
With CredSSP-EX, the early authorization result PDU [carries](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/d0e560a3-25cb-4563-8bdc-6c4cc625bbfc) either `AUTHZ_SUCCESS` of `AUTHZ_ACCESS_DENIED`. FreeRDP parses the PDU but discards it's value, every non-success is `ERRCONNECT_AUTHENTICATION_FAILED` and the actual result is only visible in `WLOG_DEBUG`:

> [DEBUG][com.freerdp.core.nla] - [nla_recv_pdu]: Early User Auth active: FAILURE code 0x00000005
> [ERROR][com.freerdp.core] - [nla_recv_pdu]: ERRCONNECT_AUTHENTICATION_FAILED [0x00020009]

It's confusing for a user, because the result implies that authentication failed. Actually it succeeded, but something prevents the server from authorizing access.

This PR:

- Maps `AUTHZ_ACCESS_DENIED` to `ERRCONNECT_ACCESS_DENIED` 
- Add a missing length check before `Stream_Read_UINT32`. The read currently relies on the transport having delivered exactly 4 bytes.
- `code` was used for both the value read off the wire and the resulting FreeRDP error so the log statement had to run before the assignment and the real value was lost afterwards. These are now separate variables, and the failure is logged at `WLOG_ERR` rather than `WLOG_DEBUG`. A connection refused by the server should not require debug logging to explain.