### PR TITLE
[winpr,sspi] fix server-side SPNEGO mechanism fallback

### DIFF
--- a/winpr/libwinpr/sspi/Negotiate/negotiate.c
+++ b/winpr/libwinpr/sspi/Negotiate/negotiate.c
@@ -1126,6 +1126,12 @@ static SECURITY_STATUS SEC_ENTRY negotiate_AcceptSecurityContext(
 			if (!init_context.spnego)
 				return status;
 
+			/* Clean up any partially created sub context before falling back to
+			 * another mechanism (mirrors the mech change handling in
+			 * negotiate_InitializeSecurityContextW) */
+			if (init_context.mech)
+				init_context.mech->pkg->table->DeleteSecurityContext(&init_context.sub_context);
+
 			init_context.mic = TRUE;
 			first_mech = init_context.mech;
 			init_context.mech = nullptr;
@@ -1213,8 +1219,15 @@ static SECURITY_STATUS SEC_ENTRY negotiate_AcceptSecurityContext(
 			if (output_buffer)
 				CopyMemory(&output_token.mechToken, output_buffer, sizeof(SecBuffer));
 
+			/* If the client's optimistic mechanism was not accepted the sub
+			 * context was never created (or was cleaned up); pass NULL so the
+			 * selected mechanism creates a fresh context instead of rejecting
+			 * the empty handle with SEC_E_INVALID_HANDLE */
+			PCtxtHandle sub_context = sspi_SecureHandleGetLowerPointer(&context->sub_context)
+			                              ? &context->sub_context
+			                              : nullptr;
 			status = context->mech->pkg->table->AcceptSecurityContext(
-			    sub_cred, &context->sub_context, &mech_input, fContextReq | context->mech->flags,
+			    sub_cred, sub_context, &mech_input, fContextReq | context->mech->flags,
 			    TargetDataRep, &context->sub_context, &mech_output, pfContextAttr, ptsTimeStamp);
 
 			if (IsSecurityStatusError(status))


### PR DESCRIPTION
> **Heads up:** the failure was hit and verified by hand against a real deployment (Windows 11 client → gnome-remote-desktop), but the root-cause analysis and this patch were identified and authored by Claude (AI assistant), with the fix hand-tested end-to-end. Please review with that in mind.

Fixes #13168

## What

Server-side `negotiate_AcceptSecurityContext` fails NLA with `SEC_E_INVALID_HANDLE` whenever round 1 ends without a created sub-context — i.e. when the client's optimistic SPNEGO mech is unsupported (NEGOEX, sent by Windows 11 Entra-joined clients), when a supported optimistic mech fails, or when the client legally sends no optimistic token at all. The next round passed the empty `sub_context` handle to the selected mechanism's `AcceptSecurityContext`, which rejects empty handles since 58a3919435 (so all 3.x affected, 2.x not).

## How

Mirrors the existing mech-change handling on the client side (`negotiate_InitializeSecurityContextW`, the "Clean up the optimistic mech" block):

1. On optimistic-mech failure, delete any partially created sub-context before falling back. Besides restoring the handle to its empty state (both `ntlm_DeleteSecurityContext` and `kerberos_DeleteSecurityContext` invalidate it), this also fixes a latent leak/type-confusion: `ntlm_AcceptSecurityContext` publishes its context into `phNewContext` before parsing and does not clean up on failure, so a failed mech-A round could feed mech A's context to fallback mech B in the next round.
2. Pass `NULL` instead of the empty handle so the selected mechanism creates a fresh context. Emptiness is tested with `sspi_SecureHandleGetLowerPointer`, which returns NULL exactly for the zeroed/invalidated handle states.

Security notes: the SPNEGO downgrade protection is unchanged (fallback still sets `mic = TRUE`; a final token without a MIC is still rejected), and the NULL-context branch is not attacker-steerable once a sub-context exists (handle emptiness only arises from "never created" or `DeleteSecurityContext`, never from client input).

## Testing

- Built against 3.30.0 and loaded into gnome-remote-desktop 50.0 (Ubuntu 26.04): a previously-failing Windows 11 Entra-joined mstsc client now completes the full CredSSP exchange (NEGOEX optimistic token declined → NTLM fallback with `request-mic` → challenge/authenticate → `mechListMIC` verified) and NLA authentication succeeds.
- Regression: non-fallback NLA login (xfreerdp → same server, NTLM optimistic token) still authenticates.
- Compile-checked against current master (both patch sites are identical between 3.30.0 and master).

Full protocol traces and analysis in #13168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
