### PR TITLE
[channels,urbdrc] report the real IOCONTROL_COMPLETION output size

### DIFF
--- a/channels/urbdrc/client/data_transfer.c
+++ b/channels/urbdrc/client/data_transfer.c
@@ -173,6 +173,41 @@ static wStream* urb_create_iocompletion(UINT32 InterfaceField, UINT32 MessageId,
 	return out;
 }
 
+/* [MS-RDPEUSB] 2.2.7.1 IO Control Completion (IOCONTROL_COMPLETION)
+ *
+ * The Information and OutputBufferSize fields describe the OutputBuffer that
+ * follows them, but urb_create_iocompletion() has to write both before the IO
+ * control handler has produced any output. Rewrite them once the payload is
+ * complete so that a handler which returns nothing does not announce a buffer
+ * it never sends.
+ */
+static BOOL urb_finalize_iocompletion(wStream* out)
+{
+	WINPR_ASSERT(out);
+
+	const size_t header = 12ULL /* SHARED_MSG_HEADER */ + 4ULL /* RequestId */;
+	const size_t offset = header + 4ULL /* HResult */;
+	const size_t fixed = offset + 4ULL /* Information */ + 4ULL /* OutputBufferSize */;
+	const size_t end = Stream_GetPosition(out);
+
+	if (end < fixed)
+		return FALSE;
+
+	const size_t OutputBufferSize = end - fixed;
+
+	if (OutputBufferSize > UINT32_MAX)
+		return FALSE;
+
+	const UINT32 size = WINPR_ASSERTING_INT_CAST(UINT32, OutputBufferSize);
+
+	if (!Stream_SetPosition(out, offset))
+		return FALSE;
+
+	Stream_Write_UINT32(out, size); /** Information */
+	Stream_Write_UINT32(out, size); /** OutputBufferSize */
+	return Stream_SetPosition(out, end);
+}
+
 static UINT urbdrc_process_register_request_callback(IUDEVICE* pdev,
                                                      GENERIC_CHANNEL_CALLBACK* callback, wStream* s,
                                                      IUDEVMAN* udevman)
@@ -361,6 +396,12 @@ static UINT urbdrc_process_io_control(IUDEVICE* pdev, GENERIC_CHANNEL_CALLBACK* 
 			           IoControlCode);
 			Stream_Free(out, TRUE);
 			return ERROR_INVALID_OPERATION;
+	}
+
+	if (!urb_finalize_iocompletion(out))
+	{
+		Stream_Free(out, TRUE);
+		return ERROR_INTERNAL_ERROR;
 	}
 
 	return stream_write_and_free(callback->plugin, callback->channel, out);


### PR DESCRIPTION
## Problem

`urbdrc_process_io_control()` builds every IO control completion with

```c
out = urb_create_iocompletion(InterfaceId, MessageId, RequestId, OutputBufferSize + 4);
```

and `urb_create_iocompletion()` writes that value into **both** the `Information` and the
`OutputBufferSize` field of the IOCONTROL_COMPLETION message.

Those extra four bytes are only ever produced by `IOCTL_INTERNAL_USB_GET_PORT_STATUS`. Every other
IO control — `IOCTL_INTERNAL_USB_RESET_PORT`, `IOCTL_INTERNAL_USB_CYCLE_PORT`,
`IOCTL_INTERNAL_USB_SUBMIT_URB`, `IOCTL_INTERNAL_USB_SUBMIT_IDLE_NOTIFICATION` — writes no payload at
all, so the completion announces an output buffer it never sends. `GET_PORT_STATUS` has the same
problem whenever the device has no hub handle, because `query_device_port_status()` then returns
without writing anything.

The message that goes on the wire for a port reset is 28 bytes:

```
offset  size  field               value
     0     4  InterfaceId
     4     4  MessageId
     8     4  FunctionId          IOCONTROL_COMPLETION
    12     4  RequestId
    16     4  HResult             0
    20     4  Information         4
    24     4  OutputBufferSize    4   <- four more bytes announced
    28     -  OutputBuffer            <- but the message ends here
```

The allocated capacity is 32 bytes, but the write position stops at 28 and
`stream_write_and_free()` sends `Stream_GetPosition(out)` bytes, so the announced buffer never
exists.

This violates [MS-RDPEUSB] 2.2.7.1, which defines `OutputBufferSize` as "the size, in bytes, of the
**OutputBuffer** field" and requires that its "value ... **MUST not exceed** the value of
**OutputBufferSize** field from IO_CONTROL message", and 2.2.12.1, which requires the completion for
`IOCTL_INTERNAL_USB_RESET_PORT` to be "sent with the final result of the operation and the
**OutputBufferSize** field set to zero".

## Fix

Rewrite `Information` and `OutputBufferSize` once the handler has produced its payload, so they
always describe the `OutputBuffer` that actually follows.

The size has to be pre-declared today because `IOCTL_INTERNAL_USB_GET_PORT_STATUS` writes through
`Stream_Pointer(out)` and needs the stream to exist first, so computing the length per IO control up
front is not possible without restructuring that handler. Patching the two fields afterwards covers
every case uniformly and changes no bytes on the wire other than those two fields.

`urbdrc_process_internal_io_control()` is unaffected: it declares 4 and writes 4.