### PR TITLE
[winpr,string] fix building on OpenBSD

### DIFF
--- a/winpr/include/winpr/string.h
+++ b/winpr/include/winpr/string.h
@@ -21,6 +21,7 @@
 #ifndef WINPR_CRT_STRING_H
 #define WINPR_CRT_STRING_H
 
+#include <stdarg.h>
 #include <wchar.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
```
FreeRDP/winpr/include/winpr/string.h:89:75: error: unknown type name 'va_list'; did you mean '__va_list'?
   89 |         WINPR_API int winpr_vasprintf(char** s, size_t* slen, const char* templ, va_list ap);
      |                                                                                  ^~~~~~~
      |                                                                                  __va_list
/usr/include/machine/_types.h:127:27: note: '__va_list' declared here
  127 | typedef __builtin_va_list       __va_list;
      |                                 ^
```