### PR TITLE
[channels,rdpdr] don't free() mntbuf in handle_platform_mounts_bsd()

### DIFF
--- a/channels/rdpdr/client/rdpdr_main.c
+++ b/channels/rdpdr/client/rdpdr_main.c
@@ -842,7 +842,6 @@ static UINT handle_platform_mounts_bsd(wLog* log, hotplug_dev* dev_array, size_t
 	{
 		handle_mountpoint(dev_array, size, mntbuf[idx].f_mntonname);
 	}
-	free(mntbuf);
 	return ERROR_SUCCESS;
 }
 #endif


### PR DESCRIPTION
The static mount table returned by getmntinfo() on FreeBSD/OpenBSD
cannot be freed.