### PR TITLE
[cmake] fix Sndio bits and not limit support to just OpenBSD

### DIFF
--- a/cmake/ConfigOptions.cmake
+++ b/cmake/ConfigOptions.cmake
@@ -174,16 +174,11 @@ if(UNIX AND NOT APPLE AND NOT ANDROID)
   find_package(ALSA)
   find_package(PulseAudio)
   find_package(OSS)
-  option(WITH_ALSA "use alsa for sound" ${ALSA_FOUND})
-  option(WITH_PULSE "use alsa for sound" ${PULSE_FOUND})
-  option(WITH_OSS "use alsa for sound" ${OSS_FOUND})
-endif()
-
-if(OPENBSD)
   find_package(SNDIO)
-  option(WITH_SNDIO "use SNDIO for sound" ${SNDIO_FOUND # OpenBSD
-         endif () }
-  )
+  option(WITH_ALSA "use ALSA for sound" ${ALSA_FOUND})
+  option(WITH_PULSE "use Pulse for sound" ${PULSE_FOUND})
+  option(WITH_OSS "use OSS for sound" ${OSS_FOUND})
+  option(WITH_SNDIO "use Sndio for sound" ${SNDIO_FOUND})
 endif()
 
 option(BUILD_FUZZERS "Use BUILD_FUZZERS to build fuzzing tests" OFF)

--- a/cmake/FindSNDIO.cmake
+++ b/cmake/FindSNDIO.cmake
@@ -1,0 +1,23 @@
+# - Try to find sndio
+# Once done this will define
+#  SNDIO_FOUND - sndio was found
+#  SNDIO_INCLUDE_DIRS - sndio include directories
+#  SNDIO_LIBRARIES - libraries needed for linking
+
+find_package(PkgConfig QUIET)
+
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_SNDIO QUIET sndio)
+endif()
+
+find_path(SNDIO_INCLUDE_DIR sndio.h HINTS ${PC_SNDIO_INCLUDEDIR} ${PC_SNDIO_INCLUDE_DIRS})
+
+find_library(SNDIO_LIBRARY NAMES sndio HINTS ${PC_SNDIO_LIBDIR} ${PC_SNDIO_LIBRARY_DIRS})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SNDIO DEFAULT_MSG SNDIO_LIBRARY SNDIO_INCLUDE_DIR)
+
+set(SNDIO_LIBRARIES ${SNDIO_LIBRARY})
+set(SNDIO_INCLUDE_DIRS ${SNDIO_INCLUDE_DIR})
+
+mark_as_advanced(SNDIO_INCLUDE_DIR SNDIO_LIBRARY)


### PR DESCRIPTION
Add missing Sndio CMake module.