### PR TITLE
uwac: only use O_TMPFILE if it exists

### DIFF
--- a/uwac/CMakeLists.txt
+++ b/uwac/CMakeLists.txt
@@ -40,6 +40,7 @@ option(UWAC_HAVE_PIXMAN_REGION "Use PIXMAN or FreeRDP for region calculations" "
 include(CommonConfigOptions)
 
 include(CheckFunctionExists)
+check_function_exists(mkostemp UWAC_HAVE_MKOSTEMP)
 check_function_exists(strerror_r UWAC_HAVE_STRERROR_R)
 
 # Check for cmake compatibility (enable/disable features)

--- a/uwac/libuwac/uwac-os.c
+++ b/uwac/libuwac/uwac-os.c
@@ -42,11 +42,6 @@
 #define USE_SHM
 #endif
 
-/* uClibc and uClibc-ng don't provide O_TMPFILE */
-#if !defined(O_TMPFILE) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
-#define O_TMPFILE (020000000 | O_DIRECTORY)
-#endif
-
 #include <sys/types.h>
 #include <sys/socket.h>
 #ifdef USE_SHM
@@ -253,9 +248,9 @@ int uwac_create_anonymous_file(off_t size)
 	fd = open(path, O_TMPFILE | O_RDWR | O_EXCL, 0600);
 #else
 	/*
-	 * Some platforms (e.g. FreeBSD/OpenBSD) won't support O_TMPFILE and
-	 * can't reasonably emulate it at first blush. Opt to make them rely
-	 * on the create_tmpfile_cloexec() path instead.
+	 * Some platforms will not support O_TMPFILE and cannot
+	 * reasonably emulate it at first blush. Opt to make them
+	 * rely on the create_tmpfile_cloexec() path instead.
 	 */
 	fd = -1;
 #endif

--- a/uwac/templates/config.h.in
+++ b/uwac/templates/config.h.in
@@ -3,6 +3,7 @@
 
 /* Include files */
 #cmakedefine UWAC_HAVE_TM_GMTOFF
+#cmakedefine UWAC_HAVE_MKOSTEMP
 #cmakedefine UWAC_HAVE_POLL_H
 #cmakedefine UWAC_HAVE_SYSLOG_H
 #cmakedefine UWAC_HAVE_JOURNALD_H


### PR DESCRIPTION
use O_TMPFILE if it exists, which is a Glibc-ism, otherwise
fallback to the fallback path for other libcs.

Also add missing check for mkostemp() and setting
UWAC_HAVE_MKOSTEMP.