### PR TITLE
[cache,glyph] clean up code, relax order checks

### DIFF
--- a/libfreerdp/cache/glyph.c
+++ b/libfreerdp/cache/glyph.c
@@ -35,13 +35,47 @@
 
 #define TAG FREERDP_TAG("cache.glyph")
 
+typedef struct
+{
+	UINT32 number;
+	UINT32 maxCellSize;
+	rdpGlyph** entries;
+} GLYPH_CACHE;
+
+typedef struct
+{
+	void* fragment;
+	UINT32 size;
+} FRAGMENT_CACHE_ENTRY;
+
+typedef struct
+{
+	FRAGMENT_CACHE_ENTRY entries[256];
+} FRAGMENT_CACHE;
+
+struct glyphCache
+{
+	FRAGMENT_CACHE fragCache;
+	GLYPH_CACHE glyphCache[10];
+
+	wLog* log;
+	rdpContext* context;
+};
+
+WINPR_ATTR_NODISCARD
 static rdpGlyph* glyph_cache_get(rdpGlyphCache* glyphCache, UINT32 id, UINT32 index);
+
+WINPR_ATTR_NODISCARD
 static BOOL glyph_cache_put(rdpGlyphCache* glyphCache, UINT32 id, UINT32 index, rdpGlyph* glyph);
 
+WINPR_ATTR_NODISCARD
 static const void* glyph_cache_fragment_get(rdpGlyphCache* glyphCache, UINT32 index, UINT32* size);
+
+WINPR_ATTR_NODISCARD
 static BOOL glyph_cache_fragment_put(rdpGlyphCache* glyphCache, UINT32 index, UINT32 size,
                                      const void* fragment);
 
+WINPR_ATTR_NODISCARD
 static UINT32 update_glyph_offset(const BYTE* data, size_t length, UINT32 index, INT32* x, INT32* y,
                                   UINT32 ulCharInc, UINT32 flAccel)
 {
@@ -79,6 +113,7 @@ static UINT32 update_glyph_offset(const BYTE* data, size_t length, UINT32 index,
 	return index;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL update_process_glyph(rdpContext* context, const BYTE* data, UINT32 cacheIndex, INT32* x,
                                  const INT32* y, UINT32 cacheId, UINT32 flAccel, BOOL fOpRedundant,
                                  const RDP_RECT* bound)
@@ -94,7 +129,8 @@ static BOOL update_process_glyph(rdpContext* context, const BYTE* data, UINT32 c
 	rdpGlyph* glyph = glyph_cache_get(glyph_cache, cacheId, cacheIndex);
 
 	if (!glyph)
-		return FALSE;
+		return freerdp_settings_get_bool(context->settings,
+		                                 FreeRDP_AllowUnanouncedOrdersFromServer);
 
 	INT32 dx = glyph->x + *x;
 	INT32 dy = glyph->y + *y;
@@ -135,6 +171,7 @@ static BOOL update_process_glyph(rdpContext* context, const BYTE* data, UINT32 c
 	return TRUE;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL update_process_glyph_fragments(rdpContext* context, const BYTE* data, UINT32 length,
                                            UINT32 cacheId, UINT32 ulCharInc, UINT32 flAccel,
                                            UINT32 bgcolor, UINT32 fgcolor, INT32 x, INT32 y,
@@ -280,7 +317,8 @@ static BOOL update_process_glyph_fragments(rdpContext* context, const BYTE* data
 					size = data[index++];
 					if (size > length - index)
 						goto fail;
-					glyph_cache_fragment_put(glyph_cache, id, size, data);
+					if (!glyph_cache_fragment_put(glyph_cache, id, size, data))
+						goto fail;
 					break;
 
 				default:
@@ -304,6 +342,7 @@ fail:
 	return rc;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL update_gdi_glyph_index(rdpContext* context, GLYPH_INDEX_ORDER* glyphIndex)
 {
 	INT32 bkWidth = 0;
@@ -334,6 +373,7 @@ static BOOL update_gdi_glyph_index(rdpContext* context, GLYPH_INDEX_ORDER* glyph
 	    WINPR_ASSERTING_INT_CAST(int32_t, glyphIndex->fOpRedundant));
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL update_gdi_fast_index(rdpContext* context, const FAST_INDEX_ORDER* fastIndex)
 {
 	INT32 opWidth = 0;
@@ -410,6 +450,7 @@ fail:
 	return rc;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL update_gdi_fast_glyph(rdpContext* context, const FAST_GLYPH_ORDER* fastGlyph)
 {
 	INT32 x = 0;
@@ -509,6 +550,7 @@ static BOOL update_gdi_fast_glyph(rdpContext* context, const FAST_GLYPH_ORDER* f
 	    fastGlyph->bkTop, bkWidth, bkHeight, opLeft, opTop, opWidth, opHeight, FALSE);
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL update_gdi_cache_glyph(rdpContext* context, const CACHE_GLYPH_ORDER* cacheGlyph)
 {
 	if (!context || !cacheGlyph || !context->cache)
@@ -534,6 +576,7 @@ static BOOL update_gdi_cache_glyph(rdpContext* context, const CACHE_GLYPH_ORDER*
 	return TRUE;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL update_gdi_cache_glyph_v2(rdpContext* context, const CACHE_GLYPH_V2_ORDER* cacheGlyphV2)
 {
 	if (!context || !cacheGlyphV2 || !context->cache)

--- a/libfreerdp/cache/glyph.h
+++ b/libfreerdp/cache/glyph.h
@@ -24,57 +24,29 @@
 #include <freerdp/freerdp.h>
 #include <freerdp/pointer.h>
 
-typedef struct
-{
-	UINT32 number;
-	UINT32 maxCellSize;
-	rdpGlyph** entries;
-} GLYPH_CACHE;
-
-typedef struct
-{
-	void* fragment;
-	UINT32 size;
-} FRAGMENT_CACHE_ENTRY;
-
-typedef struct
-{
-	FRAGMENT_CACHE_ENTRY entries[256];
-} FRAGMENT_CACHE;
-
-typedef struct
-{
-	FRAGMENT_CACHE fragCache;
-	GLYPH_CACHE glyphCache[10];
-
-	wLog* log;
-	rdpContext* context;
-} rdpGlyphCache;
-
 #ifdef __cplusplus
 extern "C"
 {
 #endif
+
+	typedef struct glyphCache rdpGlyphCache;
 
 	FREERDP_LOCAL void glyph_cache_register_callbacks(rdpUpdate* update);
 
 	FREERDP_LOCAL void glyph_cache_free(rdpGlyphCache* glyph);
 
 	WINPR_ATTR_MALLOC(glyph_cache_free, 1)
-	WINPR_ATTR_NODISCARD
 	FREERDP_LOCAL rdpGlyphCache* glyph_cache_new(rdpContext* context);
 
 	FREERDP_LOCAL void free_cache_glyph_order(rdpContext* context, CACHE_GLYPH_ORDER* glyph);
 
 	WINPR_ATTR_MALLOC(free_cache_glyph_order, 1)
-	WINPR_ATTR_NODISCARD
 	FREERDP_LOCAL CACHE_GLYPH_ORDER* copy_cache_glyph_order(rdpContext* context,
 	                                                        const CACHE_GLYPH_ORDER* glyph);
 
 	FREERDP_LOCAL void free_cache_glyph_v2_order(rdpContext* context, CACHE_GLYPH_V2_ORDER* glyph);
 
 	WINPR_ATTR_MALLOC(free_cache_glyph_v2_order, 1)
-	WINPR_ATTR_NODISCARD
 	FREERDP_LOCAL CACHE_GLYPH_V2_ORDER*
 	copy_cache_glyph_v2_order(rdpContext* context, const CACHE_GLYPH_V2_ORDER* glyph);
 


### PR DESCRIPTION
* Clean up code, hide implementation details, use WINPR_ATTR_NODISCARD
* Allow glyphs to not exist with /relax-order-checks