### PR TITLE
uwac: disable the SHM_ANON support on DragonFlyBSD

### DIFF
--- a/uwac/libuwac/uwac-os.c
+++ b/uwac/libuwac/uwac-os.c
@@ -38,7 +38,7 @@
 #pragma clang diagnostic pop
 #endif
 
-#if defined(__FreeBSD__) || defined(__DragonFly__)
+#ifdef __FreeBSD__
 #define USE_SHM
 #endif
 


### PR DESCRIPTION
DragonFlyBSD does not have this FreeBSD extension.