### PR TITLE
[utils] fix ChannelPduTracker partial read handling

### DIFF
--- a/libfreerdp/utils/channel_pdu_tracker.c
+++ b/libfreerdp/utils/channel_pdu_tracker.c
@@ -65,6 +65,13 @@ wStream* ChannelPduTracker_poll(ChannelPduTracker* tracker, BOOL* ok)
 	}
 
 	const size_t actual = recvSz - sizeof(CHANNEL_PDU_HEADER);
+	if (actual < header->length)
+	{
+		/* Rest of this chunk hasn't arrived over the wire yet, keep polling. */
+		*ok = TRUE;
+		return nullptr;
+	}
+
 	if (actual != header->length)
 	{
 		WLog_Print(tracker->log, WLOG_ERROR,


### PR DESCRIPTION
ChannelPduTracker_poll() treats a short read of the current chunk as
corrupted data instead of waiting for the rest, killing whichever
channel hits it (rdpdr, rail, cliprdr).

Reproduced against a local krdp build (https://invent.kde.org/plasma/krdp,
with unmerged changes) by copying a file over a few KB into the
clipboard: the cliprdr thread dies with "CheckEventHandle failed".
This is a FreeRDP bug, not krdp-specific.

Fix: only error when too much data arrives, not too little.

Tested up to 25MB, byte for byte.