### PR TITLE
[scard,pack] remove incorrect stream length checks in unpack functions

### DIFF
--- a/libfreerdp/utils/smartcard_pack.c
+++ b/libfreerdp/utils/smartcard_pack.c
@@ -1899,10 +1899,6 @@ LONG smartcard_unpack_redir_scard_context_(wLog* log, wStream* s, REDIR_SCARDCON
 		return STATUS_INVALID_PARAMETER;
 	}
 
-	if (!Stream_CheckAndLogRequiredLengthWLogEx(log, WLOG_WARN, s, context->cbContext, 1,
-	                                            "%s(%s:%" PRIuz ")", file, function, line))
-		return STATUS_INVALID_PARAMETER;
-
 	*ppbContextNdrPtr = pbContextNdrPtr;
 	return SCARD_S_SUCCESS;
 }
@@ -2004,10 +2000,6 @@ LONG smartcard_unpack_redir_scard_handle_(wLog* log, wStream* s, REDIR_SCARDHAND
 		           handle->cbHandle, pbHandleNdrPtr);
 		return STATUS_INVALID_PARAMETER;
 	}
-
-	if (!Stream_CheckAndLogRequiredLengthWLogEx(log, WLOG_WARN, s, handle->cbHandle, 1,
-	                                            "%s(%s:%" PRIuz ")", file, function, line))
-		return STATUS_INVALID_PARAMETER;
 
 	return SCARD_S_SUCCESS;
 }


### PR DESCRIPTION
Remove premature Stream_CheckAndLogRequiredLengthWLogEx checks from both smartcard_unpack_redir_scard_context_() and smartcard_unpack_redir_scard_handle_(). These checks validate cbContext/cbHandle bytes are available, but the actual data is read later in the deferred ref phase. The proper validation happens in the _ref functions right before reading.

This adds the missing fix I tried to add after comment: https://github.com/FreeRDP/FreeRDP/pull/13208#discussion_r3806608821 
