### PR TITLE
[channels,rail] fix NULL deref race on server channel start

### DIFF
--- a/channels/rail/server/rail_main.c
+++ b/channels/rail/server/rail_main.c
@@ -1463,13 +1463,9 @@ static RailServerPrivate* rail_server_context_priv_new(RailServerContext* contex
 	priv->channelPduTracker = ChannelPduTracker_new(priv->rail_channel);
 	if (!priv->channelPduTracker)
 		goto fail;
-	priv->thread = CreateThread(nullptr, 0, rail_server_thread, context, 0, nullptr);
 
-	if (!priv->thread)
-	{
-		WLog_ERR(TAG, "CreateThread failed!");
-		goto fail;
-	}
+	/* The thread is started by rail_server_start after context->priv was assigned:
+	 * rail_server_thread dereferences context->priv right away. */
 	return priv;
 fail:
 	rail_server_context_priv_free(priv);
@@ -1486,9 +1482,22 @@ static UINT rail_server_start(RailServerContext* context)
 {
 	WINPR_ASSERT(context);
 
-	context->priv = rail_server_context_priv_new(context);
-	if (!context->priv)
+	RailServerPrivate* priv = rail_server_context_priv_new(context);
+	if (!priv)
 		return ERROR_INTERNAL_ERROR;
+
+	/* Publish priv before starting the thread, rail_server_thread reads context->priv
+	 * without any synchronization. */
+	context->priv = priv;
+
+	priv->thread = CreateThread(nullptr, 0, rail_server_thread, context, 0, nullptr);
+	if (!priv->thread)
+	{
+		WLog_ERR(TAG, "CreateThread failed!");
+		context->priv = nullptr;
+		rail_server_context_priv_free(priv);
+		return ERROR_INTERNAL_ERROR;
+	}
 	return CHANNEL_RC_OK;
 }
 


### PR DESCRIPTION
## Problem

`rail_server_thread()` intermittently segfaults reading address `0x8` right after the rail channel connects.

`rail_server_context_priv_new()` creates the worker thread and returns `priv`; only afterwards does its caller `rail_server_start()` store it into `context->priv`:

```c
priv->thread = CreateThread(nullptr, 0, rail_server_thread, context, 0, nullptr);
return priv;                       /* caller assigns context->priv only after this */
```

But the thread's first action is to dereference `context->priv`:

```c
RailServerPrivate* priv = context->priv;   /* still NULL in the race window */
WINPR_ASSERT(priv);                        /* compiled out with NDEBUG */
...
events[nCount++] = priv->channelEvent;
events[nCount++] = priv->stopEvent;        /* offset 0x8 -- SEGV read at 0x8 */
```

If the scheduler runs the new thread before `rail_server_start()` performs the assignment, the read hits NULL. `stopEvent` is at offset 8 of `struct s_rail_server_private`, which matches the faulting address. The `WINPR_ASSERT` does not catch it in release builds. Being timing dependent, the crash is intermittent.

ASAN reports the crashing thread as created by `rail_server_context_priv_new` <- `rail_server_start` <- channel connect callback.

## Regression

Introduced by 30cb14d8 ("[channels,rail] fix server side channel tracker"). Before that commit the thread was created in `rail_server_start()` and `priv` was allocated in `rail_server_context_new()`, so `context->priv` was always valid by the time the thread ran.

`cliprdr` and `rdpsnd` set their private data before starting their threads; rail was the only server channel left with this hole.

## Fix

Move `CreateThread()` out of `rail_server_context_priv_new()` into `rail_server_start()`, which publishes `context->priv` first and then starts the thread, unwinding the allocation if `CreateThread()` fails.

This also closes the identical window for the `rail_server_handle_messages(context)` call the thread makes, which dereferences `context->priv` too.
