### PR TITLE
[channels,cliprdr] fix long format list parse

### DIFF
--- a/channels/cliprdr/cliprdr_common.c
+++ b/channels/cliprdr/cliprdr_common.c
@@ -500,7 +500,9 @@ UINT cliprdr_read_format_list(wLog* log, wStream* s, CLIPRDR_FORMAT_LIST* format
 		wStream sub2buffer = sub1buffer;
 		wStream* sub2 = &sub2buffer;
 
-		while (Stream_GetRemainingLength(sub1) > 0)
+		/* Bound must match the read pass below: some clients pad the format list with
+		 * trailing bytes that do not start another entry. */
+		while (Stream_GetRemainingLength(sub1) >= 4)
 		{
 			size_t rest = 0;
 			if (!Stream_SafeSeek(sub1, 4)) /* formatId (4 bytes) */


### PR DESCRIPTION
`cliprdr_read_format_list()` walks the long-format-name list twice: a count pass to size the `CLIPRDR_FORMAT` array and a read pass to fill it. The count pass looped while `Stream_GetRemainingLength(sub1) > 0`, the read pass while `>= 4`.

Windows rdpclip sends Format List PDUs whose `dataLen` extends 2 bytes past the last format entry, reproducible by copying a file that has a Zone.Identifier ADS, which produces the "ZoneIdentifier" / Mark-of-the-Web format list. Those 2 bytes make the count pass enter one more iteration, `Stream_SafeSeek(sub1, 4)` for the formatId fails, and the entire PDU is rejected with `ERROR_INTERNAL_ERROR` -- clipboard transfer then breaks. The read pass, with its `>= 4` bound, would simply have stopped.

MS-RDPECLIP 2.2.3.1.1.2 defines no list terminator, so these are best described as trailing bytes past the last entry rather than a defined field.

Match the count-pass bound to the read pass. Both passes now use identical arithmetic (`Stream_SafeSeek(4)` then `(_wcsnlen(...) + 1) * 2`), so `numFormats` still equals the number of entries the read pass produces and the `index >= formatList->numFormats` bail cannot trip. All reads remain bounded by `Stream_SafeSeek` on a stream statically bounded by `dataLen`; relaxing the loop entry condition only reduces the number of iterations. `client/test/TestFuzzChannelCliprdr.c` covers this path.

This is the same class of real-world leniency the function already documents for short format names ("both Windows RDSH and mstsc violate this specs").
