### PR TITLE
fix use-after-free when winpr_aligned_recalloc fails

### DIFF
--- a/winpr/libwinpr/crt/alignment.c
+++ b/winpr/libwinpr/crt/alignment.c
@@ -220,7 +220,7 @@ void* winpr_aligned_offset_recalloc(void* memblock, size_t num, size_t size, siz
 	newMemblock = winpr_aligned_offset_malloc(size * num, alignment, offset);
 
 	if (!newMemblock)
-		goto fail;
+		return nullptr;
 
 	pNewMem = WINPR_ALIGNED_MEM_STRUCT_FROM_PTR(newMemblock);
 	{

--- a/winpr/libwinpr/crt/test/TestAlignment.c
+++ b/winpr/libwinpr/crt/test/TestAlignment.c
@@ -1,5 +1,6 @@
 
 #include <stdio.h>
+#include <stdint.h>
 #include <winpr/crt.h>
 #include <winpr/windows.h>
 
@@ -81,6 +82,43 @@ int TestAlignment(int argc, char* argv[])
 
 	/* _aligned_free works for both _aligned_malloc and _aligned_offset_malloc. free() should not be
 	 * used. */
+	winpr_aligned_free(ptr);
+
+	/* _aligned_recalloc must leave the original block untouched when the reallocation fails,
+	 * matching the _aligned_recalloc contract. */
+
+	ptr = winpr_aligned_malloc(128, alignment);
+
+	if (ptr == nullptr)
+	{
+		printf("Error allocating aligned memory.\n");
+		return -1;
+	}
+
+	memset(ptr, 0xAB, 128);
+
+	{
+		/* A request this large cannot be satisfied, so the allocation fails. */
+		void* failed = winpr_aligned_recalloc(ptr, 1, SIZE_MAX / 2, alignment);
+
+		if (failed != nullptr)
+		{
+			printf("Expected winpr_aligned_recalloc to fail for an oversized request.\n");
+			winpr_aligned_free(failed);
+			return -1;
+		}
+
+		/* On failure the original block is still valid and must retain its contents. */
+		for (size_t i = 0; i < 128; i++)
+		{
+			if (((const BYTE*)ptr)[i] != 0xAB)
+			{
+				printf("Original block was corrupted after a failed winpr_aligned_recalloc.\n");
+				return -1;
+			}
+		}
+	}
+
 	winpr_aligned_free(ptr);
 
 	return 0;


### PR DESCRIPTION
winpr_aligned_offset_recalloc frees the caller's original block on the allocation-failure path (the goto fail branch runs winpr_aligned_free before returning null), unlike winpr_aligned_offset_realloc just above it which returns null and leaves the block intact. every caller follows the tmp = winpr_aligned_recalloc(p, ...); if (!tmp) return idiom, so a failed grow leaves them holding a freed pointer and a stale length; nsc_context_initialize (bmp.width*bmp.height for an nscodec surface come straight off the wire) and the clearcodec glyph/temp/vbar buffers then reuse that pointer, giving a use-after-free write of attacker-supplied pixels plus a double free when the codec context is torn down. the fix returns null without touching memblock on failure so the behaviour matches realloc and the windows _aligned_recalloc contract. TestAlignment now forces the failing path and checks the original block still holds its contents.