### PR TITLE
[client,x11] clear errno before keyboard pipe read

### DIFF
--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1314,6 +1314,7 @@ static BOOL xf_process_pipe(rdpContext* context, const char* pipe)
 	while (!freerdp_shall_disconnect_context(context))
 	{
 		char buffer[64] = WINPR_C_ARRAY_INIT;
+		errno = 0;
 		ssize_t rd = read(fd, buffer, sizeof(buffer) - 1);
 		if (rd == 0)
 		{


### PR DESCRIPTION
`read()` can return 0 without clearing `errno`. On macOS, a stale
`ETIMEDOUT` caused the keyboard pipe reader to exit and the FIFO to be
removed.

Clear `errno` before reading so the existing EOF handling retries as
intended.

Closes #13218.

Tested by building `xfreerdp-client` with `WITH_X11=ON` on macOS.
