### PR TITLE
Fix use-after-free of the printer driver singleton

### DIFF
--- a/channels/printer/client/cups/printer_cups.c
+++ b/channels/printer/client/cups/printer_cups.c
@@ -313,6 +313,8 @@ static rdpPrinter* printer_cups_new_printer(rdpCupsPrinterDriver* cups_driver, c
 		return nullptr;
 
 	cups_printer->printer.backend = &cups_driver->driver;
+	WINPR_ASSERT(cups_printer->printer.backend->AddRef);
+	cups_printer->printer.backend->AddRef(cups_printer->printer.backend);
 
 	cups_printer->printer.id = cups_driver->id_sequence++;
 	cups_printer->printer.name = _strdup(name);
@@ -342,9 +344,6 @@ static rdpPrinter* printer_cups_new_printer(rdpCupsPrinterDriver* cups_driver, c
 
 	WINPR_ASSERT(cups_printer->printer.AddRef);
 	cups_printer->printer.AddRef(&cups_printer->printer);
-
-	WINPR_ASSERT(cups_printer->printer.backend->AddRef);
-	cups_printer->printer.backend->AddRef(cups_printer->printer.backend);
 
 	return &cups_printer->printer;
 

--- a/channels/printer/client/win/printer_win.c
+++ b/channels/printer/client/win/printer_win.c
@@ -264,11 +264,9 @@ static rdpPrinter* printer_win_new_printer(rdpWinPrinterDriver* win_driver, cons
 		return nullptr;
 
 	win_printer->printer.backend = &win_driver->driver;
+	win_printer->printer.backend->AddRef(win_printer->printer.backend);
 	win_printer->printer.id = win_driver->id_sequence++;
 	win_printer->printer.name = ConvertWCharToUtf8Alloc(name, nullptr);
-	if (!win_printer->printer.name)
-		goto fail;
-
 	if (!win_printer->printer.name)
 		goto fail;
 	win_printer->printer.is_default = is_default;
@@ -305,7 +303,6 @@ static rdpPrinter* printer_win_new_printer(rdpWinPrinterDriver* win_driver, cons
 		goto fail;
 
 	win_printer->printer.AddRef(&win_printer->printer);
-	win_printer->printer.backend->AddRef(win_printer->printer.backend);
 	return &win_printer->printer;
 
 fail:

--- a/channels/printer/client/win/printer_win.c
+++ b/channels/printer/client/win/printer_win.c
@@ -389,7 +389,7 @@ static rdpPrinter** printer_win_enum_printers(rdpPrinterDriver* driver)
 		printers[num_printers++] = current;
 	}
 
-	if (!haveDefault && (returned > 0))
+	if (printers && !haveDefault && (returned > 0))
 		printers[0]->is_default = TRUE;
 
 	GlobalFree(prninfo);


### PR DESCRIPTION
# Fix use-after-free of the printer driver singleton

## What

Fixes a reference-counting imbalance in `printer_win_new_printer()` and
`printer_cups_new_printer()` that frees the driver singleton while
`printer_DeviceServiceEntry()` still holds a pointer to it. Also guards the
`printers` array in `printer_win_enum_printers()`, matching a check
`printer_cups_enum_printers()` already has.

## Why

Both backends store the singleton in `printer.backend` without taking a
reference (`printer_win.c:266`, `printer_cups.c:315`). The matching `AddRef()`
is 42 lines later (`:308`), with seven `goto fail` statements in between, and
`printer_win_free_printer()` releases unconditionally (`:229`).

The entry point takes exactly one reference (`:476`), so one failed printer
creation is enough to free the singleton. Control returns to
`printer_DeviceServiceEntry()`, which only nulls the file-static singleton - its
local `driver` stays non-NULL, passes the `if (driver)` check at
`printer_main.c:1214`, and is dereferenced at `:1216` and called at `:1217`.

`printer_win_release_ref_driver()` frees *without* decrementing (`:444-446`), so
the freed memory still reads `references == 1` and the second call frees it
again.

On Windows this is reachable from ordinary configuration, since `OpenPrinter()`
fails with `ERROR_INVALID_PRINTER_NAME` for any name the spooler does not
resolve:

```
xfreerdp3 /v:<host> /printer:NoSuchPrinter
```

It is also reachable through `printer_win_enum_printers()` when one printer is
created successfully and a later one fails. On CUPS both `goto fail` paths are
`_strdup()` failures, so that backend needs an allocation failure to get there.

## Changes

- `printer_win.c` / `printer_cups.c`: take the reference where `backend` is
  assigned, drop the now-redundant `AddRef()` on the success path
- `printer_win.c`: drop a duplicated `if (!win_printer->printer.name)` check
- `printer_win.c`: guard `printers` before indexing it after the enumeration loop

The success path is unchanged - the `AddRef()` moves to the assignment, it is not
added. On the failure path the net becomes `0` instead of `-1`.

Deferring the `backend` assignment instead would leave the reference stranded,
since `*_free_printer()` reads `printer->backend` to decide whether to release.

## Notes

Reported to `security@freerdp.com` first; Armin confirmed an advisory is not
required since the trigger is local only, and asked for a PR instead.
