### PR TITLE
[codec,yuv] fix pool_decode_rect loop variable reuse

### DIFF
--- a/libfreerdp/codec/yuv.c
+++ b/libfreerdp/codec/yuv.c
@@ -558,7 +558,7 @@ static BOOL pool_decode_rect(YUV_CONTEXT* WINPR_RESTRICT context, BYTE type,
 	}
 
 	/* case where we use threads */
-	for (waitCount = 0; waitCount < numRegionRects; waitCount++)
+	for (UINT32 x = 0; x < numRegionRects; x++)
 	{
 		YUV_COMBINE_WORK_PARAM* current = nullptr;
 
@@ -568,11 +568,12 @@ static BOOL pool_decode_rect(YUV_CONTEXT* WINPR_RESTRICT context, BYTE type,
 			waitCount = 0;
 		}
 		current = &context->work_combined_params[waitCount];
-		*current = pool_decode_rect_param(&regionRects[waitCount], context, type, pYUVData, iStride,
+		*current = pool_decode_rect_param(&regionRects[x], context, type, pYUVData, iStride,
 		                                  pYUVDstData, iDstStride);
 
 		if (!submit_object(&context->work_objects[waitCount], cb, current, context))
 			goto fail;
+		waitCount++;
 	}
 
 	rc = TRUE;

--- a/libfreerdp/codec/yuv.c
+++ b/libfreerdp/codec/yuv.c
@@ -817,15 +817,6 @@ static BOOL pool_encode(YUV_CONTEXT* WINPR_RESTRICT context, PTP_WORK_CALLBACK c
 		const UINT32 height = rect->bottom - rect->top;
 		const UINT32 steps = getSteps(height, context->heightStep);
 
-		waitCount += steps;
-	}
-
-	for (UINT32 x = 0; x < numRegionRects; x++)
-	{
-		const RECTANGLE_16* rect = &regionRects[x];
-		const UINT32 height = rect->bottom - rect->top;
-		const UINT32 steps = getSteps(height, context->heightStep);
-
 		for (UINT32 y = 0; y < steps; y++)
 		{
 			RECTANGLE_16 r = *rect;


### PR DESCRIPTION
Currently, `pool_decode_rect` uses `waitCount` both as the `for` loop
variable and as the worker slot index. When `numRegionRects` exceeds
`work_object_count`, resetting `waitCount` to 0 restarts the loop from
the beginning instead of continuing with the remaining rectangles,
causing it to never terminate. This was introduced by commit https://github.com/FreeRDP/FreeRDP/commit/1cc64eb58b2f5ce9e4ad8aa8610e085f696e578c.
Let's use a separate loop variable `x` to iterate over `regionRects`
so that `waitCount` only tracks the worker slot position.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>