### PR TITLE
[client,x11] rail: re-send work area when it changes mid-session

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -974,6 +974,15 @@ static BOOL xf_event_PropertyNotify(xfContext* xfc, const XPropertyEvent* event,
 	WINPR_ASSERT(xfc);
 	WINPR_ASSERT(event);
 
+	const Window root = DefaultRootWindow(xfc->display);
+	if ((event->window == root) &&
+	    ((event->atom == xfc->NET_WORKAREA) || (event->atom == xfc->NET_CURRENT_DESKTOP)))
+	{
+		if (!xfc->remote_app || !xfc->rail)
+			return TRUE;
+		return xf_rail_schedule_workarea(xfc);
+	}
+
 	/*
 	 * This section handles sending the appropriate commands to the rail server
 	 * when the window has been minimized, maximized, restored locally

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -29,6 +29,7 @@
 #include <winpr/print.h>
 
 #include <freerdp/client/rail.h>
+#include <freerdp/timer.h>
 
 #include "xf_window.h"
 #include "xf_rail.h"
@@ -36,6 +37,14 @@
 
 #include <freerdp/log.h>
 #define TAG CLIENT_TAG("x11")
+/*
+ * The settle interval is also the minimum spacing between sends, because the timer disarms on fire
+ * and needs a fresh event plus a full interval to fire again. That spacing is what prevents a stale
+ * server geometry reply from overtaking the next send. 300 ms leaves roughly 60% headroom over the
+ * ~185 ms reply latency measured here, so a loaded host or server has room before replies can
+ * invert; one slower than the interval still can.
+ */
+#define WORKAREA_SETTLE_INTERVAL_NS 300000000UL
 
 static const char* error_code2str(UINT32 code)
 {
@@ -146,27 +155,120 @@ BOOL xf_rail_disable_remoteapp_mode(xfContext* xfc)
 	return TRUE;
 }
 
+static BOOL xf_rail_select_workarea_events(xfContext* xfc)
+{
+	WINPR_ASSERT(xfc);
+
+	XWindowAttributes attributes = WINPR_C_ARRAY_INIT;
+	const Window root = DefaultRootWindow(xfc->display);
+	if (!XGetWindowAttributes(xfc->display, root, &attributes))
+		return FALSE;
+
+	XSelectInput(xfc->display, root, attributes.your_event_mask | PropertyChangeMask);
+	return TRUE;
+}
+
+static BOOL xf_rail_get_workarea(xfContext* xfc, xfWorkArea* workArea)
+{
+	WINPR_ASSERT(xfc);
+	WINPR_ASSERT(workArea);
+
+	/* xf_GetWorkArea overwrites xfc->workArea; restore it (RAIL keeps it full). */
+	const xfWorkArea saved = xfc->workArea;
+	const BOOL rc = xf_GetWorkArea(xfc);
+	*workArea = xfc->workArea;
+	xfc->workArea = saved;
+	return rc;
+}
+
 /* Report the real work area so the server maximizes RemoteApp windows within the panel. */
 static UINT xf_rail_send_workarea(xfContext* xfc)
 {
 	WINPR_ASSERT(xfc);
-	WINPR_ASSERT(xfc->rail);
 
-	/* xf_GetWorkArea overwrites xfc->workArea; restore it (RAIL keeps it full). */
-	const xfWorkArea saved = xfc->workArea;
-	if (!xf_GetWorkArea(xfc))
+	if (!xfc->remote_app || !xfc->rail)
 		return CHANNEL_RC_OK;
-	const INT64 right = (INT64)xfc->workArea.x + xfc->workArea.width;
-	const INT64 bottom = (INT64)xfc->workArea.y + xfc->workArea.height;
-	const RAIL_SYSPARAM_ORDER sysparam = {
-		.params = SPI_MASK_SET_WORK_AREA,
-		.workArea.left = WINPR_CXX_COMPAT_CAST(UINT16, xfc->workArea.x),
-		.workArea.top = WINPR_CXX_COMPAT_CAST(UINT16, xfc->workArea.y),
-		.workArea.right = WINPR_CXX_COMPAT_CAST(UINT16, right),
-		.workArea.bottom = WINPR_CXX_COMPAT_CAST(UINT16, bottom)
-	};
-	xfc->workArea = saved;
-	return xfc->rail->ClientSystemParam(xfc->rail, &sysparam);
+
+	xfWorkArea current = WINPR_C_ARRAY_INIT;
+	if (!xf_rail_get_workarea(xfc, &current))
+		return CHANNEL_RC_OK;
+
+	if (xfc->railWorkAreaValid && (current.x == xfc->railWorkArea.x) &&
+	    (current.y == xfc->railWorkArea.y) && (current.width == xfc->railWorkArea.width) &&
+	    (current.height == xfc->railWorkArea.height))
+	{
+		WLog_DBG(TAG,
+		         "Suppressing work area %" PRId32 ",%" PRId32 " %" PRIu32 "x%" PRIu32 ": unchanged",
+		         current.x, current.y, current.width, current.height);
+		return CHANNEL_RC_OK;
+	}
+
+	const INT64 right = (INT64)current.x + current.width;
+	const INT64 bottom = (INT64)current.y + current.height;
+	const RAIL_SYSPARAM_ORDER sysparam = { .params = SPI_MASK_SET_WORK_AREA,
+		                                   .workArea.left =
+		                                       WINPR_CXX_COMPAT_CAST(UINT16, current.x),
+		                                   .workArea.top = WINPR_CXX_COMPAT_CAST(UINT16, current.y),
+		                                   .workArea.right = WINPR_CXX_COMPAT_CAST(UINT16, right),
+		                                   .workArea.bottom =
+		                                       WINPR_CXX_COMPAT_CAST(UINT16, bottom) };
+
+	WLog_DBG(TAG, "Sending work area %" PRId32 ",%" PRId32 " %" PRIu32 "x%" PRIu32, current.x,
+	         current.y, current.width, current.height);
+	const UINT rc = xfc->rail->ClientSystemParam(xfc->rail, &sysparam);
+	if (rc == CHANNEL_RC_OK)
+	{
+		xfc->railWorkArea = current;
+		xfc->railWorkAreaValid = TRUE;
+	}
+	return rc;
+}
+
+static uint64_t xf_rail_workarea_timer(rdpContext* context, WINPR_ATTR_UNUSED void* userdata,
+                                       FreeRDP_TimerID timerID,
+                                       WINPR_ATTR_UNUSED uint64_t timestamp,
+                                       WINPR_ATTR_UNUSED uint64_t interval)
+{
+	xfContext* xfc = (xfContext*)context;
+	WINPR_ASSERT(xfc);
+
+	if (xfc->railWorkAreaTimerId != timerID)
+		return 0;
+
+	xfc->railWorkAreaTimerId = 0;
+	const UINT rc = xf_rail_send_workarea(xfc);
+	if (rc != CHANNEL_RC_OK)
+		WLog_ERR(TAG, "Failed to send settled work area: %" PRIu32, rc);
+	return 0;
+}
+
+BOOL xf_rail_schedule_workarea(xfContext* xfc)
+{
+	WINPR_ASSERT(xfc);
+
+	xfWorkArea current = WINPR_C_ARRAY_INIT;
+	if (!xf_rail_get_workarea(xfc, &current))
+	{
+		WLog_DBG(TAG, "Suppressing work area update: current value unavailable");
+		return TRUE;
+	}
+
+	WLog_DBG(TAG,
+	         "Deferring work area %" PRId32 ",%" PRId32 " %" PRIu32 "x%" PRIu32 ": still settling",
+	         current.x, current.y, current.width, current.height);
+
+	rdpContext* context = (rdpContext*)xfc;
+	if (xfc->railWorkAreaTimerId != 0)
+	{
+		freerdp_timer_remove(context, xfc->railWorkAreaTimerId);
+		xfc->railWorkAreaTimerId = 0;
+	}
+
+	xfc->railWorkAreaTimerId = freerdp_timer_add(context, WORKAREA_SETTLE_INTERVAL_NS,
+	                                             xf_rail_workarea_timer, nullptr, true);
+	if (xfc->railWorkAreaTimerId == 0)
+		WLog_ERR(TAG, "Failed to arm work area settle timer");
+	return xfc->railWorkAreaTimerId != 0;
 }
 
 BOOL xf_rail_send_activate(xfContext* xfc, Window xwindow, BOOL enabled)
@@ -983,6 +1085,9 @@ xf_rail_monitored_desktop(WINPR_ATTR_UNUSED rdpContext* context,
 		WLog_DBG(TAG, "WINDOW_ORDER_FIELD_DESKTOP_ARC_COMPLETED -> switch to RAILS mode");
 		if (!xf_rail_enable_remoteapp_mode(xfc))
 			return FALSE;
+		xfc->railWorkAreaValid = FALSE;
+		if (!xf_rail_select_workarea_events(xfc))
+			WLog_WARN(TAG, "Failed to subscribe to root-window work-area changes");
 
 		const char* app =
 		    freerdp_settings_get_string(context->settings, FreeRDP_RemoteApplicationProgram);
@@ -1286,6 +1391,8 @@ int xf_rail_init(xfContext* xfc, RailClientContext* rail)
 		return 0;
 
 	xfc->rail = rail;
+	xfc->railWorkAreaValid = FALSE;
+	xfc->railWorkAreaTimerId = 0;
 	xf_rail_register_update_callbacks(context->update);
 	rail->custom = (void*)xfc;
 	rail->ServerExecuteResult = xf_rail_server_execute_result;
@@ -1324,6 +1431,13 @@ fail:
 int xf_rail_uninit(xfContext* xfc, RailClientContext* rail)
 {
 	WINPR_UNUSED(rail);
+	rdpContext* context = (rdpContext*)xfc;
+
+	if (xfc->railWorkAreaTimerId != 0)
+	{
+		freerdp_timer_remove(context, xfc->railWorkAreaTimerId);
+		xfc->railWorkAreaTimerId = 0;
+	}
 
 	if (xfc->rail)
 	{

--- a/client/X11/xf_rail.h
+++ b/client/X11/xf_rail.h
@@ -117,6 +117,7 @@ BOOL xf_rail_paint(xfContext* xfc, const RECTANGLE_16* rect);
 BOOL xf_rail_paint_surface(xfContext* xfc, UINT64 windowId, const RECTANGLE_16* rect);
 
 BOOL xf_rail_send_client_system_command(xfContext* xfc, UINT64 windowId, UINT16 command);
+BOOL xf_rail_schedule_workarea(xfContext* xfc);
 BOOL xf_rail_send_activate(xfContext* xfc, Window xwindow, BOOL enabled);
 BOOL xf_rail_adjust_position(xfContext* xfc, xfAppWindow* appWindow);
 BOOL xf_rail_end_local_move(xfContext* xfc, xfAppWindow* appWindow);

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -39,6 +39,7 @@
 #endif
 
 #include <freerdp/api.h>
+#include <freerdp/timer.h>
 
 #include "xf_window.h"
 #include "xf_monitor.h"
@@ -171,6 +172,9 @@ struct xf_context
 	xfAppWindow* appWindow;
 	xfPointer* pointer;
 	xfWorkArea workArea;
+	xfWorkArea railWorkArea;
+	BOOL railWorkAreaValid;
+	FreeRDP_TimerID railWorkAreaTimerId;
 	xfFullscreenMonitors fullscreenMonitors;
 	int current_desktop;
 	BOOL remote_app;


### PR DESCRIPTION
## What this fixes

`xf_rail_send_workarea()` is called once, at RAIL activation. The comment on the current code states plainly that a mid-session `_NET_WORKAREA` change is not re-sent.

The result is that after any change to the host's work area — panel resized or moved, resolution change, monitor hotplug, desktop switch — the server keeps maximizing RemoteApp windows to a work area that no longer exists, for the remainder of the session. Maximized windows either overlap the panel or stop short of the screen edge.

This is easy to hit on a long-lived session and there is currently no way to recover from it short of reconnecting.

## What it does

Subscribes to `PropertyChangeMask` on the root window — preserving any mask already selected there, since the clipboard code also selects on the root window — and watches `_NET_WORKAREA` and `_NET_CURRENT_DESKTOP`.

`_NET_CURRENT_DESKTOP` is included because `_NET_WORKAREA` is indexed by the current desktop, so switching desktops changes the effective work area while the property itself is unchanged.

Sends are coalesced rather than emitted per event. Two reasons:

1. Window managers publish several distinct, individually valid work areas while a panel is being reconfigured. On Cinnamon, restoring a 44px panel publishes the panel-less geometry first, then the settled one.
2. The server's window-geometry reply is asynchronous. A reply to an earlier send can arrive after a later send has already gone out, and the client then applies the superseded geometry. Observed directly: two sends 83 ms apart, the reply to the first arriving 102 ms after the second, leaving the window at the stale size.

So a one-shot timer is re-armed on every relevant `PropertyNotify` and only the value that survives the settle interval is sent. The timer runs in mainloop context via `freerdp_timer_add(..., mainloop=true)`, so the Xlib reads and the channel write stay on the main thread.

Because the timer disarms on fire and needs a fresh event plus a full interval to fire again, the settle interval is also the guaranteed minimum spacing between sends. 300 ms leaves roughly 60% headroom over the ~185 ms reply latency measured on this setup. A value equal to the last one successfully sent is suppressed outright.

**Known bound:** this holds while the server's geometry-reply latency stays below the settle interval. A server slow enough to exceed 300 ms could still invert replies. Fixing that in general would need request/reply correlation that `TS_RAIL_ORDER_SYSPARAM` does not provide.

Failure to subscribe to the root-window events warns and continues — work-area tracking degrades, the session does not.

## How to test

1. Start a RemoteApp session: `xfreerdp3 /v:<host> /app:program:notepad.exe`
2. Maximize the app window. It should stop at the panel edge.
3. Change your panel's height (or move it to another screen edge).
4. Maximize again — the window should respect the new work area. On master it uses the old one.
5. Repeat with a resolution change, and with a desktop switch on a multi-desktop WM.

With `/log-level:DEBUG` the client logs each decision:

```
Deferring work area 0,0 1664x936: still settling
Deferring work area 0,0 1664x892: still settling
Sending work area 0,0 1664x892
```

The transient value is visible as deferred and never sent. Repeating an unchanged value logs `Suppressing work area ...: unchanged`.

Tested on Ubuntu 26.04 / Cinnamon / X11 against Windows 11 Pro. Clipboard round-trip and a non-RAIL full-desktop connection were checked for regressions, since the change touches the root-window event mask.
