### PR TITLE
[winpr] implement inheritable handles in CreateProcess

### DIFF
--- a/winpr/CMakeLists.txt
+++ b/winpr/CMakeLists.txt
@@ -211,6 +211,15 @@ set(WINPR_HAVE_WIN_SSIZE_T ${HAVE_WIN_SSIZE_T})
 
 check_symbol_exists(strnstr string.h WINPR_HAVE_STRNSTR)
 check_symbol_exists(strndup string.h WINPR_HAVE_STRNDUP)
+
+# pipe2()/accept4() are GNU/BSD extensions; glibc only declares them when _GNU_SOURCE is visible,
+# which this project does not set globally (see cmake/PlatformDefaults.cmake) - request it just
+# for these checks, matching the _GNU_SOURCE the actual call sites (pipe.c) define for themselves.
+set(CMAKE_REQUIRED_DEFINITIONS_SAVE ${CMAKE_REQUIRED_DEFINITIONS})
+set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")
+check_symbol_exists(pipe2 unistd.h WINPR_HAVE_PIPE2)
+check_symbol_exists(accept4 sys/socket.h WINPR_HAVE_ACCEPT4)
+set(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS_SAVE})
 check_include_files(unistd.h WINPR_HAVE_UNISTD_H)
 check_include_files(execinfo.h WINPR_HAVE_EXECINFO_HEADER)
 if(WINPR_HAVE_EXECINFO_HEADER)

--- a/winpr/include/config/config.h.in
+++ b/winpr/include/config/config.h.in
@@ -25,6 +25,8 @@
 #cmakedefine WINPR_HAVE_GETPWUID_R
 #cmakedefine WINPR_HAVE_STRNDUP
 #cmakedefine WINPR_HAVE_STRNSTR
+#cmakedefine WINPR_HAVE_PIPE2   /** @since version 3.31.0 */
+#cmakedefine WINPR_HAVE_ACCEPT4 /** @since version 3.31.0 */
 #cmakedefine WINPR_HAVE_UNWIND_H
 #cmakedefine WINPR_HAVE_SSIZE_T
 #cmakedefine WINPR_HAVE_WIN_SSIZE_T
@@ -47,9 +49,9 @@
 #cmakedefine WITH_DEBUG_MUTEX
 
 #cmakedefine WINPR_UTILS_IMAGE_DIBv5 /** @since version 3.13.0 */
-#cmakedefine WINPR_UTILS_IMAGE_WEBP /** @since version 3.3.0 */
-#cmakedefine WINPR_UTILS_IMAGE_PNG /** @since version 3.3.0 */
-#cmakedefine WINPR_UTILS_IMAGE_JPEG /** @since version 3.3.0 */
+#cmakedefine WINPR_UTILS_IMAGE_WEBP  /** @since version 3.3.0 */
+#cmakedefine WINPR_UTILS_IMAGE_PNG   /** @since version 3.3.0 */
+#cmakedefine WINPR_UTILS_IMAGE_JPEG  /** @since version 3.3.0 */
 
 #if !defined(WITHOUT_WINPR_3x_DEPRECATED)
 #cmakedefine WITHOUT_WINPR_3x_DEPRECATED /** @since version 3.27.0 */

--- a/winpr/include/winpr/thread.h
+++ b/winpr/include/winpr/thread.h
@@ -85,6 +85,59 @@ extern "C"
 	typedef LPSTARTUPINFOA LPSTARTUPINFO;
 #endif
 
+	/** @brief opaque attribute list built by InitializeProcThreadAttributeList() /
+	 *  UpdateProcThreadAttribute(), consumed by CreateProcess* when passed via a STARTUPINFOEX
+	 *  and EXTENDED_STARTUPINFO_PRESENT.
+	 *  @since version 3.31.0
+	 */
+	typedef struct WINPR_PROC_THREAD_ATTRIBUTE_LIST* LPPROC_THREAD_ATTRIBUTE_LIST;
+
+	/** @brief Attribute for UpdateProcThreadAttribute() restricting handle inheritance to
+	 *  exactly the HANDLE array passed as lpValue (each of which must itself be marked
+	 *  inheritable), overriding any other handle's own inheritable state.
+	 *  @since version 3.31.0
+	 */
+#define PROC_THREAD_ATTRIBUTE_HANDLE_LIST 0x00020002
+
+	typedef struct
+	{
+		STARTUPINFOA StartupInfo;
+		LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList;
+	} STARTUPINFOEXA, *LPSTARTUPINFOEXA;
+
+	typedef struct
+	{
+		STARTUPINFOW StartupInfo;
+		LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList;
+	} STARTUPINFOEXW, *LPSTARTUPINFOEXW;
+
+#ifdef UNICODE
+	typedef STARTUPINFOEXW STARTUPINFOEX;
+	typedef LPSTARTUPINFOEXW LPSTARTUPINFOEX;
+#else
+	typedef STARTUPINFOEXA STARTUPINFOEX;
+	typedef LPSTARTUPINFOEXA LPSTARTUPINFOEX;
+#endif
+
+	/** @brief First call: pass lpAttributeList=NULL to have lpSize receive the required buffer
+	 *  size; this call always returns FALSE (matches real Windows behavior). Second call: pass
+	 *  a caller-allocated buffer of at least that size as lpAttributeList.
+	 *  @since version 3.31.0 */
+	WINPR_ATTR_NODISCARD
+	WINPR_API BOOL InitializeProcThreadAttributeList(LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList,
+	                                                 DWORD dwAttributeCount, DWORD dwFlags,
+	                                                 PSIZE_T lpSize);
+
+	/** @since version 3.31.0 */
+	WINPR_ATTR_NODISCARD
+	WINPR_API BOOL UpdateProcThreadAttribute(LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList,
+	                                         DWORD dwFlags, DWORD_PTR Attribute, PVOID lpValue,
+	                                         SIZE_T cbSize, PVOID lpPreviousValue,
+	                                         PSIZE_T lpReturnSize);
+
+	/** @since version 3.31.0 */
+	WINPR_API VOID DeleteProcThreadAttributeList(LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList);
+
 #define STARTF_USESHOWWINDOW 0x00000001
 #define STARTF_USESIZE 0x00000002
 #define STARTF_USEPOSITION 0x00000004
@@ -104,6 +157,10 @@ extern "C"
 #define LOGON_WITH_PROFILE 0x00000001
 #define LOGON_NETCREDENTIALS_ONLY 0x00000002
 #define LOGON_ZERO_PASSWORD_BUFFER 0x80000000
+
+	/** @brief dwCreationFlags bit telling CreateProcess* that lpStartupInfo actually points to a
+	 *  STARTUPINFOEX (its lpAttributeList is consulted). @since version 3.31.0 */
+#define EXTENDED_STARTUPINFO_PRESENT 0x00080000
 
 	WINPR_ATTR_NODISCARD
 	WINPR_API BOOL CreateProcessA(LPCSTR lpApplicationName, LPSTR lpCommandLine,

--- a/winpr/libwinpr/CMakeLists.txt
+++ b/winpr/libwinpr/CMakeLists.txt
@@ -220,6 +220,17 @@ list(REMOVE_DUPLICATES WINPR_SYSTEM_INCLUDES)
 
 addtargetwithresourcefile(${MODULE_NAME} FALSE "${WINPR_VERSION}" WINPR_SRCS)
 
+# pipe2()/accept4() are only declared by glibc under _GNU_SOURCE (see the WINPR_HAVE_PIPE2/
+# WINPR_HAVE_ACCEPT4 detection in the top-level winpr/CMakeLists.txt, which probes for them with
+# _GNU_SOURCE forced on). Scope the define to exactly the files that call them instead of
+# enabling GNU extension visibility for the whole winpr target.
+if(WINPR_HAVE_PIPE2 OR WINPR_HAVE_ACCEPT4)
+  set_source_files_properties(pipe/pipe.c PROPERTIES COMPILE_DEFINITIONS _GNU_SOURCE)
+endif()
+if(WINPR_HAVE_PIPE2)
+  set_source_files_properties(synch/semaphore.c PROPERTIES COMPILE_DEFINITIONS _GNU_SOURCE)
+endif()
+
 if(WITH_RESOURCE_VERSIONING)
   target_compile_definitions(${MODULE_NAME} PRIVATE WITH_RESOURCE_VERSIONING)
 endif()

--- a/winpr/libwinpr/comm/comm.c
+++ b/winpr/libwinpr/comm/comm.c
@@ -44,6 +44,7 @@
 
 #include "comm_ioctl.h"
 
+#include "../handle/handle.h"
 #include "../log.h"
 #define TAG WINPR_TAG("comm")
 
@@ -1226,6 +1227,31 @@ static HANDLE_OPS ops = { CommIsHandled, CommCloseHandle, CommGetFd, nullptr, /*
 	                      nullptr,       nullptr,         nullptr,   nullptr, nullptr, nullptr,
 	                      nullptr,       nullptr,         nullptr,   nullptr, nullptr };
 
+#if defined(WINPR_HAVE_SYS_EVENTFD_H)
+/* eventfd() with EFD_NONBLOCK|EFD_CLOEXEC, falling back to the flag-less call plus separate
+ * fcntl()s on kernels older than 2.6.27 (which reject unknown flags with EINVAL) */
+WINPR_ATTR_NODISCARD
+static int comm_eventfd_cloexec(void)
+{
+	int fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+	if ((fd < 0) && (errno == EINVAL))
+	{
+		/* old kernels reject any nonzero flags argument outright, so both flags have to be
+		 * applied separately afterward - O_NONBLOCK (F_SETFL) and FD_CLOEXEC (F_SETFD) live in
+		 * different fcntl() namespaces and can't be folded into one call. No need to read the
+		 * previous flags first: this fd is brand new, so both start unset. */
+		fd = eventfd(0, 0);
+		if ((fd >= 0) &&
+		    ((fcntl(fd, F_SETFL, O_NONBLOCK) < 0) || (fcntl(fd, F_SETFD, FD_CLOEXEC) < 0)))
+		{
+			close(fd);
+			fd = -1;
+		}
+	}
+	return fd;
+}
+#endif
+
 /**
  * http://msdn.microsoft.com/en-us/library/windows/desktop/aa363198%28v=vs.85%29.aspx
  *
@@ -1333,7 +1359,7 @@ HANDLE CommCreateFileA(LPCSTR lpDeviceName, DWORD dwDesiredAccess, DWORD dwShare
 	WINPR_HANDLE_SET_TYPE_AND_MODE(pComm, HANDLE_TYPE_COMM, WINPR_FD_READ);
 	pComm->common.ops = &ops;
 	/* error_handle */
-	pComm->fd = open(devicePath, O_RDWR | O_NOCTTY | O_NONBLOCK);
+	pComm->fd = open(devicePath, O_RDWR | O_NOCTTY | O_NONBLOCK | O_CLOEXEC);
 
 	if (pComm->fd < 0)
 	{
@@ -1342,7 +1368,7 @@ HANDLE CommCreateFileA(LPCSTR lpDeviceName, DWORD dwDesiredAccess, DWORD dwShare
 		goto error_handle;
 	}
 
-	pComm->fd_read = open(devicePath, O_RDONLY | O_NOCTTY | O_NONBLOCK);
+	pComm->fd_read = open(devicePath, O_RDONLY | O_NOCTTY | O_NONBLOCK | O_CLOEXEC);
 
 	if (pComm->fd_read < 0)
 	{
@@ -1352,8 +1378,7 @@ HANDLE CommCreateFileA(LPCSTR lpDeviceName, DWORD dwDesiredAccess, DWORD dwShare
 	}
 
 #if defined(WINPR_HAVE_SYS_EVENTFD_H)
-	pComm->fd_read_event = eventfd(
-	    0, EFD_NONBLOCK); /* EFD_NONBLOCK required because a read() is not always expected */
+	pComm->fd_read_event = comm_eventfd_cloexec();
 #endif
 
 	if (pComm->fd_read_event < 0)
@@ -1364,7 +1389,7 @@ HANDLE CommCreateFileA(LPCSTR lpDeviceName, DWORD dwDesiredAccess, DWORD dwShare
 	}
 
 	InitializeCriticalSection(&pComm->ReadLock);
-	pComm->fd_write = open(devicePath, O_WRONLY | O_NOCTTY | O_NONBLOCK);
+	pComm->fd_write = open(devicePath, O_WRONLY | O_NOCTTY | O_NONBLOCK | O_CLOEXEC);
 
 	if (pComm->fd_write < 0)
 	{
@@ -1374,8 +1399,7 @@ HANDLE CommCreateFileA(LPCSTR lpDeviceName, DWORD dwDesiredAccess, DWORD dwShare
 	}
 
 #if defined(WINPR_HAVE_SYS_EVENTFD_H)
-	pComm->fd_write_event = eventfd(
-	    0, EFD_NONBLOCK); /* EFD_NONBLOCK required because a read() is not always expected */
+	pComm->fd_write_event = comm_eventfd_cloexec();
 #endif
 
 	if (pComm->fd_write_event < 0)

--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -40,6 +40,7 @@
 #include <winpr/string.h>
 
 #include "file.h"
+#include "../handle/handle.h"
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/file.h>
@@ -958,6 +959,19 @@ static HANDLE FileCreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dw
 		free(pFile->lpFileName);
 		free(pFile);
 		return INVALID_HANDLE_VALUE;
+	}
+
+	{
+		/* winpr_fopen()/freopen() give no way to request O_CLOEXEC atomically; match Windows
+		 * semantics (not inherited unless asked) by default here too. */
+		const BOOL inherit =
+		    pFile->lpSecurityAttributes && pFile->lpSecurityAttributes->bInheritHandle;
+		if (!winpr_set_cloexec(fileno(fp), !inherit))
+		{
+			SetLastError(map_posix_err(errno));
+			FileCloseHandle(pFile);
+			return INVALID_HANDLE_VALUE;
+		}
 	}
 
 	(void)setvbuf(fp, nullptr, _IONBF, 0);

--- a/winpr/libwinpr/file/namedPipeClient.c
+++ b/winpr/libwinpr/file/namedPipeClient.c
@@ -116,12 +116,13 @@ static HANDLE_OPS ops = {
 	nullptr, /* FileGetFileInformationByHandle */
 };
 
-static HANDLE
-NamedPipeClientCreateFileA(LPCSTR lpFileName, WINPR_ATTR_UNUSED DWORD dwDesiredAccess,
-                           WINPR_ATTR_UNUSED DWORD dwShareMode,
-                           WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpSecurityAttributes,
-                           WINPR_ATTR_UNUSED DWORD dwCreationDisposition,
-                           DWORD dwFlagsAndAttributes, WINPR_ATTR_UNUSED HANDLE hTemplateFile)
+WINPR_ATTR_NODISCARD
+static HANDLE NamedPipeClientCreateFileA(LPCSTR lpFileName, WINPR_ATTR_UNUSED DWORD dwDesiredAccess,
+                                         WINPR_ATTR_UNUSED DWORD dwShareMode,
+                                         LPSECURITY_ATTRIBUTES lpSecurityAttributes,
+                                         WINPR_ATTR_UNUSED DWORD dwCreationDisposition,
+                                         DWORD dwFlagsAndAttributes,
+                                         WINPR_ATTR_UNUSED HANDLE hTemplateFile)
 {
 	int status = 0;
 	struct sockaddr_un s = WINPR_C_ARRAY_INIT;
@@ -177,6 +178,12 @@ NamedPipeClientCreateFileA(LPCSTR lpFileName, WINPR_ATTR_UNUSED DWORD dwDesiredA
 	pNamedPipe->clientfd = socket(PF_LOCAL, SOCK_STREAM, 0);
 	if (pNamedPipe->clientfd < 0)
 		goto fail;
+
+	{
+		const BOOL inherit = lpSecurityAttributes && lpSecurityAttributes->bInheritHandle;
+		if (!winpr_set_cloexec(pNamedPipe->clientfd, !inherit))
+			goto fail;
+	}
 
 	pNamedPipe->serverfd = -1;
 	pNamedPipe->ServerMode = FALSE;

--- a/winpr/libwinpr/handle/handle.c
+++ b/winpr/libwinpr/handle/handle.c
@@ -24,7 +24,10 @@
 
 #ifndef _WIN32
 
+#include <errno.h>
+#include <fcntl.h>
 #include <pthread.h>
+#include <string.h>
 
 #include "../synch/synch.h"
 #include "../thread/thread.h"
@@ -39,6 +42,8 @@
 #include <winpr/assert.h>
 
 #include "../handle/handle.h"
+#include "../log.h"
+#define TAG WINPR_TAG("handle")
 
 BOOL CloseHandle(HANDLE hObject)
 {
@@ -71,17 +76,69 @@ BOOL DuplicateHandle(WINPR_ATTR_UNUSED HANDLE hSourceProcessHandle,
 	return TRUE;
 }
 
-BOOL GetHandleInformation(WINPR_ATTR_UNUSED HANDLE hObject, WINPR_ATTR_UNUSED LPDWORD lpdwFlags)
+BOOL GetHandleInformation(HANDLE hObject, LPDWORD lpdwFlags)
 {
-	WLog_ERR("TODO", "TODO: Implement");
+	if (!lpdwFlags)
+		return FALSE;
+
+	const int fd = winpr_Handle_getFd(hObject);
+	if (fd < 0)
+	{
+		WLog_ERR(TAG, "unable to resolve a file descriptor for this handle type");
+		return FALSE;
+	}
+
+	const int flags = fcntl(fd, F_GETFD);
+	if (flags < 0)
+	{
+		WLog_ERR(TAG, "fcntl(F_GETFD) failed: %s", strerror(errno));
+		return FALSE;
+	}
+
+	*lpdwFlags = (flags & FD_CLOEXEC) ? 0 : HANDLE_FLAG_INHERIT;
 	return TRUE;
 }
 
-BOOL SetHandleInformation(WINPR_ATTR_UNUSED HANDLE hObject, WINPR_ATTR_UNUSED DWORD dwMask,
-                          WINPR_ATTR_UNUSED DWORD dwFlags)
+BOOL SetHandleInformation(HANDLE hObject, DWORD dwMask, DWORD dwFlags)
 {
-	WLog_ERR("TODO", "TODO: Implement");
+	const int fd = winpr_Handle_getFd(hObject);
+	if (fd < 0)
+	{
+		WLog_ERR(TAG, "unable to resolve a file descriptor for this handle type");
+		return FALSE;
+	}
+
+	/* only HANDLE_FLAG_INHERIT is meaningful on POSIX; ignore any other bit in the mask rather
+	 * than failing, matching how Windows treats masks it doesn't recognize on other handle
+	 * types */
+	if (!(dwMask & HANDLE_FLAG_INHERIT))
+		return TRUE;
+
+	int flags = fcntl(fd, F_GETFD);
+	if (flags < 0)
+	{
+		WLog_ERR(TAG, "fcntl(F_GETFD) failed: %s", strerror(errno));
+		return FALSE;
+	}
+
+	flags = (dwFlags & HANDLE_FLAG_INHERIT) ? (flags & ~FD_CLOEXEC) : (flags | FD_CLOEXEC);
+	if (fcntl(fd, F_SETFD, flags) < 0)
+	{
+		WLog_ERR(TAG, "fcntl(F_SETFD) failed: %s", strerror(errno));
+		return FALSE;
+	}
+
 	return TRUE;
+}
+
+BOOL winpr_set_cloexec(int fd, BOOL cloexec)
+{
+	const int flags = fcntl(fd, F_GETFD);
+	if (flags < 0)
+		return FALSE;
+
+	const int newFlags = cloexec ? (flags | FD_CLOEXEC) : (flags & ~FD_CLOEXEC);
+	return fcntl(fd, F_SETFD, newFlags) >= 0;
 }
 
 #endif

--- a/winpr/libwinpr/handle/handle.h
+++ b/winpr/libwinpr/handle/handle.h
@@ -199,4 +199,7 @@ static inline DWORD winpr_Handle_cleanup(HANDLE handle)
 	return hdl->ops->CleanupHandle(handle);
 }
 
+WINPR_ATTR_NODISCARD
+BOOL winpr_set_cloexec(int fd, BOOL cloexec);
+
 #endif /* WINPR_HANDLE_PRIVATE_H */

--- a/winpr/libwinpr/pipe/pipe.c
+++ b/winpr/libwinpr/pipe/pipe.c
@@ -5,6 +5,7 @@
  * Copyright 2012 Marc-Andre Moreau <marcandre.moreau@gmail.com>
  * Copyright 2017 Armin Novak <armin.novak@thincast.com>
  * Copyright 2017 Thincast Technologies GmbH
+ * Copyright 2026 David Fort <contact@hardening-consulting.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -465,26 +466,30 @@ static BOOL InitWinPRPipeModule(void)
 /*
  * Unnamed pipe
  */
-
 BOOL CreatePipe(PHANDLE hReadPipe, PHANDLE hWritePipe, LPSECURITY_ATTRIBUTES lpPipeAttributes,
                 DWORD nSize)
 {
 	int pipe_fd[] = { -1, -1 };
 	WINPR_PIPE* pReadPipe = nullptr;
 	WINPR_PIPE* pWritePipe = nullptr;
+	const BOOL inherit = lpPipeAttributes && lpPipeAttributes->bInheritHandle;
 
-	WINPR_UNUSED(lpPipeAttributes);
 	WINPR_UNUSED(nSize);
 
-	if (pipe(pipe_fd) < 0)
+	/* match Windows semantics: handles are not inherited by a child process unless the creator
+	 * asks for it via bInheritHandle. Prefer the atomic pipe2(O_CLOEXEC) where available so
+	 * there's no window between pipe creation and marking it close-on-exec during which a
+	 * concurrent fork() elsewhere in the process could leak the fd into an unrelated child. */
+#ifdef WINPR_HAVE_PIPE2
+	const int pipe2flags = inherit ? 0 : O_CLOEXEC;
+	if (pipe2(pipe_fd, pipe2flags) < 0)
+#else
+	if (pipe(pipe_fd) < 0 || !winpr_set_cloexec(pipe_fd[0], !inherit) ||
+	    !winpr_set_cloexec(pipe_fd[1], !inherit))
+#endif
 	{
-		if (pipe_fd[0] >= 0)
-			close(pipe_fd[0]);
-		if (pipe_fd[1] >= 0)
-			close(pipe_fd[1]);
-
-		WLog_ERR(TAG, "failed to create pipe");
-		return FALSE;
+		WLog_ERR(TAG, "failed to create and set cloexec pipe");
+		goto fail_close_fd;
 	}
 
 	pReadPipe = (WINPR_PIPE*)calloc(1, sizeof(WINPR_PIPE));
@@ -492,13 +497,8 @@ BOOL CreatePipe(PHANDLE hReadPipe, PHANDLE hWritePipe, LPSECURITY_ATTRIBUTES lpP
 
 	if (!pReadPipe || !pWritePipe)
 	{
-		if (pipe_fd[0] >= 0)
-			close(pipe_fd[0]);
-		if (pipe_fd[1] >= 0)
-			close(pipe_fd[1]);
-		free(pReadPipe);
-		free(pWritePipe);
-		return FALSE;
+		WLog_ERR(TAG, "error allocating pipes");
+		goto fail_free_pipes;
 	}
 
 	pReadPipe->fd = pipe_fd[0];
@@ -510,6 +510,16 @@ BOOL CreatePipe(PHANDLE hReadPipe, PHANDLE hWritePipe, LPSECURITY_ATTRIBUTES lpP
 	pWritePipe->common.ops = &ops;
 	*((ULONG_PTR*)hWritePipe) = (ULONG_PTR)pWritePipe;
 	return TRUE;
+
+fail_free_pipes:
+	free(pReadPipe);
+	free(pWritePipe);
+fail_close_fd:
+	if (pipe_fd[0] >= 0)
+		close(pipe_fd[0]);
+	if (pipe_fd[1] >= 0)
+		close(pipe_fd[1]);
+	return FALSE;
 }
 
 /**
@@ -656,6 +666,15 @@ HANDLE CreateNamedPipeA(LPCSTR lpName, DWORD dwOpenMode, DWORD dwPipeMode, DWORD
 			goto out;
 		}
 
+		/* this is the shared listening socket kept in g_NamedPipeServerSockets, never handed out
+		 * as a HANDLE itself (each CreateNamedPipeA call gets its own close-on-exec duplicate
+		 * below) - still, it's a real fd in this process, so keep it from leaking into children */
+		if (!winpr_set_cloexec(serverfd, TRUE))
+		{
+			WLog_ERR(TAG, "CreateNamedPipeA: failed to set close-on-exec on listening socket");
+			goto out;
+		}
+
 		s.sun_family = AF_UNIX;
 		(void)sprintf_s(s.sun_path, ARRAYSIZE(s.sun_path), "%s", pNamedPipe->lpFilePath);
 
@@ -700,7 +719,10 @@ HANDLE CreateNamedPipeA(LPCSTR lpName, DWORD dwOpenMode, DWORD dwPipeMode, DWORD
 		// (void*) pNamedPipe, lpName, serverfd);
 	}
 
-	pNamedPipe->serverfd = dup(baseSocket->serverfd);
+	/* F_DUPFD_CLOEXEC rather than plain dup(): dup() always clears close-on-exec on the new fd
+	 * regardless of the source's own flags, so a plain dup() here would silently undo the
+	 * close-on-exec set on the shared listening socket above. */
+	pNamedPipe->serverfd = fcntl(baseSocket->serverfd, F_DUPFD_CLOEXEC, 0);
 	// WLog_DBG(TAG, "using serverfd %d (duplicated from %d)", pNamedPipe->serverfd,
 	// baseSocket->serverfd);
 	pNamedPipe->pfnUnrefNamedPipe = winpr_unref_named_pipe;
@@ -759,13 +781,26 @@ BOOL ConnectNamedPipe(HANDLE hNamedPipe, LPOVERLAPPED lpOverlapped)
 	{
 		struct sockaddr_un s = WINPR_C_ARRAY_INIT;
 		length = sizeof(struct sockaddr_un);
+#ifdef WINPR_HAVE_ACCEPT4
+		status = accept4(pNamedPipe->serverfd, (struct sockaddr*)&s, &length, SOCK_CLOEXEC);
+#else
 		status = accept(pNamedPipe->serverfd, (struct sockaddr*)&s, &length);
+#endif
 
 		if (status < 0)
 		{
 			WLog_ERR(TAG, "ConnectNamedPipe: accept error");
 			return FALSE;
 		}
+
+#ifndef WINPR_HAVE_ACCEPT4
+		if (!winpr_set_cloexec(status, TRUE))
+		{
+			WLog_ERR(TAG, "ConnectNamedPipe: failed to set close-on-exec on accepted socket");
+			close(status);
+			return FALSE;
+		}
+#endif
 
 		pNamedPipe->clientfd = status;
 		pNamedPipe->ServerMode = FALSE;

--- a/winpr/libwinpr/synch/event.c
+++ b/winpr/libwinpr/synch/event.c
@@ -81,7 +81,6 @@ static int eventfd_write(int fd, eventfd_t value)
 #endif
 #endif
 
-#ifndef WINPR_HAVE_SYS_EVENTFD_H
 static BOOL set_non_blocking_fd(int fd)
 {
 	int flags;
@@ -91,18 +90,40 @@ static BOOL set_non_blocking_fd(int fd)
 
 	return fcntl(fd, F_SETFL, flags | O_NONBLOCK) >= 0;
 }
-#endif /* !WINPR_HAVE_SYS_EVENTFD_H */
 
 BOOL winpr_event_init(WINPR_EVENT_IMPL* event)
 {
 #ifdef WINPR_HAVE_SYS_EVENTFD_H
 	event->fds[1] = -1;
-	event->fds[0] = eventfd(0, EFD_NONBLOCK);
+	event->fds[0] = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+
+	if ((event->fds[0] < 0) && (errno == EINVAL))
+	{
+		/* kernels older than 2.6.27 only support the flag-less eventfd() call; fall back to
+		 * that and apply non-blocking/close-on-exec separately afterward */
+		event->fds[0] = eventfd(0, 0);
+		if (event->fds[0] >= 0)
+		{
+			if (!set_non_blocking_fd(event->fds[0]) || !winpr_set_cloexec(event->fds[0], TRUE))
+			{
+				close(event->fds[0]);
+				event->fds[0] = -1;
+			}
+		}
+	}
 
 	return event->fds[0] >= 0;
 #else
+#ifdef WINPR_HAVE_PIPE2
+	if (pipe2(event->fds, O_CLOEXEC) < 0)
+		return FALSE;
+#else
 	if (pipe(event->fds) < 0)
 		return FALSE;
+
+	if (!winpr_set_cloexec(event->fds[0], TRUE) || !winpr_set_cloexec(event->fds[1], TRUE))
+		goto out_error;
+#endif
 
 	if (!set_non_blocking_fd(event->fds[0]) || !set_non_blocking_fd(event->fds[1]))
 		goto out_error;

--- a/winpr/libwinpr/synch/semaphore.c
+++ b/winpr/libwinpr/synch/semaphore.c
@@ -30,6 +30,7 @@
 #ifndef _WIN32
 
 #include <errno.h>
+#include <fcntl.h>
 #include "../handle/handle.h"
 #include "../log.h"
 #define TAG WINPR_TAG("synch.semaphore")
@@ -143,12 +144,28 @@ HANDLE CreateSemaphoreW(WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpSemaphoreAttri
 	semaphore->common.ops = &ops;
 #ifdef WINPR_PIPE_SEMAPHORE
 
+#ifdef WINPR_HAVE_PIPE2
+	if (pipe2(semaphore->pipe_fd, O_CLOEXEC) < 0)
+#else
 	if (pipe(semaphore->pipe_fd) < 0)
+#endif
 	{
 		WLog_ERR(TAG, "failed to create semaphore");
 		free(semaphore);
 		return nullptr;
 	}
+
+#ifndef WINPR_HAVE_PIPE2
+	if (!winpr_set_cloexec(semaphore->pipe_fd[0], TRUE) ||
+	    !winpr_set_cloexec(semaphore->pipe_fd[1], TRUE))
+	{
+		WLog_ERR(TAG, "failed to set close-on-exec on semaphore pipe");
+		close(semaphore->pipe_fd[0]);
+		close(semaphore->pipe_fd[1]);
+		free(semaphore);
+		return nullptr;
+	}
+#endif
 
 	while (lInitialCount > 0)
 	{

--- a/winpr/libwinpr/synch/timer.c
+++ b/winpr/libwinpr/synch/timer.c
@@ -255,7 +255,7 @@ static int InitializeWaitableTimer(WINPR_TIMER* timer)
 	int result = 0;
 
 #ifdef TIMER_IMPL_TIMERFD
-	timer->fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK);
+	timer->fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
 	if (timer->fd <= 0)
 		return -1;
 #elif defined(TIMER_IMPL_POSIX)

--- a/winpr/libwinpr/thread/CMakeLists.txt
+++ b/winpr/libwinpr/thread/CMakeLists.txt
@@ -21,6 +21,7 @@ winpr_module_add(
   argv.c
   process.c
   processor.c
+  procthreadattr.c
   thread.c
   thread.h
 )

--- a/winpr/libwinpr/thread/process.c
+++ b/winpr/libwinpr/thread/process.c
@@ -59,18 +59,19 @@
 
 #include <grp.h>
 
+#include <fcntl.h>
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 
 #ifdef __linux__
 #include <sys/syscall.h>
-#include <fcntl.h>
 #include <errno.h>
 #endif /* __linux__ */
 
 #include "thread.h"
 
+#include "../handle/handle.h"
 #include "../security/security.h"
 
 #ifndef NSIG
@@ -155,8 +156,7 @@ static BOOL CreateProcessExA(HANDLE hToken, WINPR_ATTR_UNUSED DWORD dwLogonFlags
                              LPCSTR lpApplicationName, WINPR_ATTR_UNUSED LPSTR lpCommandLine,
                              WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpProcessAttributes,
                              WINPR_ATTR_UNUSED LPSECURITY_ATTRIBUTES lpThreadAttributes,
-                             WINPR_ATTR_UNUSED BOOL bInheritHandles,
-                             WINPR_ATTR_UNUSED DWORD dwCreationFlags, LPVOID lpEnvironment,
+                             BOOL bInheritHandles, DWORD dwCreationFlags, LPVOID lpEnvironment,
                              LPCSTR lpCurrentDirectory, LPSTARTUPINFOA lpStartupInfo,
                              LPPROCESS_INFORMATION lpProcessInformation)
 {
@@ -240,6 +240,46 @@ static BOOL CreateProcessExA(HANDLE hToken, WINPR_ATTR_UNUSED DWORD dwLogonFlags
 #endif
 		sigset_t set = WINPR_C_ARRAY_INIT;
 		struct sigaction act = WINPR_C_ARRAY_INIT;
+
+		/* resolve an explicit PROC_THREAD_ATTRIBUTE_HANDLE_LIST, if the caller opted into one
+		 * via a STARTUPINFOEX + EXTENDED_STARTUPINFO_PRESENT. Per documented Windows behavior:
+		 *  - bInheritHandles == FALSE: nothing is inherited, full stop - a handle list (if any)
+		 *    is ignored too, it can only narrow inheritance, never expand it.
+		 *  - bInheritHandles == TRUE and a handle list is present: it becomes the *exclusive*
+		 *    source of truth for which extra fds survive into this child - only the listed
+		 *    handles are inherited, even other handles independently marked inheritable are not.
+		 *  - bInheritHandles == TRUE and no handle list: every fd not marked close-on-exec is
+		 *    inherited, exactly like real Windows inheriting every handle marked inheritable -
+		 *    including ones WinPR doesn't know about (e.g. opened by a linked library), since
+		 *    Windows itself has no concept of "handles the runtime knows about" either. */
+#define WINPR_MAX_INHERITED_HANDLES 64
+		int keepFds[WINPR_MAX_INHERITED_HANDLES] = { -1 };
+		size_t nKeepFds = 0;
+		BOOL haveHandleList = FALSE;
+
+		if (bInheritHandles && lpStartupInfo && (dwCreationFlags & EXTENDED_STARTUPINFO_PRESENT))
+		{
+			const STARTUPINFOEXA* exInfo = (const STARTUPINFOEXA*)lpStartupInfo;
+			const struct WINPR_PROC_THREAD_ATTRIBUTE_LIST* list = exInfo->lpAttributeList;
+
+			for (DWORD i = 0; list && (i < list->count); i++)
+			{
+				const WINPR_PROC_THREAD_ATTRIBUTE_ENTRY* entry = &list->entries[i];
+				if (entry->Attribute != PROC_THREAD_ATTRIBUTE_HANDLE_LIST)
+					continue;
+
+				haveHandleList = TRUE;
+				const HANDLE* handles = (const HANDLE*)entry->lpValue;
+				const size_t count = entry->cbSize / sizeof(HANDLE);
+				for (size_t h = 0; (h < count) && (nKeepFds < WINPR_MAX_INHERITED_HANDLES); h++)
+				{
+					const int fd = winpr_Handle_getFd(handles[h]);
+					if (fd >= 0)
+						keepFds[nKeepFds++] = fd;
+				}
+			}
+		}
+
 		/* set default signal handlers */
 		act.sa_handler = SIG_DFL;
 		act.sa_flags = 0;
@@ -272,7 +312,11 @@ static BOOL CreateProcessExA(HANDLE hToken, WINPR_ATTR_UNUSED DWORD dwLogonFlags
 		}
 
 #ifdef __sun
-		closefrom(3);
+		if (!bInheritHandles || !haveHandleList)
+			closefrom(3);
+		/* else: Solaris has no per-fd enumeration primitive as cheap as the loop below, and a
+		 * handle list is a narrow/rare case there - fall through without closing anything
+		 * rather than silently ignoring the caller's explicit allowlist. */
 #else
 #ifdef F_MAXFD // on some BSD derivates
 		maxfd = fcntl(0, F_MAXFD);
@@ -285,8 +329,36 @@ static BOOL CreateProcessExA(HANDLE hToken, WINPR_ATTR_UNUSED DWORD dwLogonFlags
 		}
 #endif
 
+		/* - bInheritHandles == FALSE: keep stays FALSE for every fd, close everything.
+		 * - bInheritHandles == TRUE, handle list present: exclusive allowlist (see above).
+		 * - bInheritHandles == TRUE, no handle list: inherit everything not close-on-exec. */
 		for (int fd = 3; fd < maxfd; fd++)
-			close(fd);
+		{
+			BOOL keep = FALSE;
+
+			if (bInheritHandles)
+			{
+				if (haveHandleList)
+				{
+					for (size_t k = 0; k < nKeepFds; k++)
+					{
+						if (keepFds[k] == fd)
+						{
+							keep = TRUE;
+							break;
+						}
+					}
+				}
+				else
+				{
+					const int flags = fcntl(fd, F_GETFD);
+					keep = (flags >= 0) && !(flags & FD_CLOEXEC);
+				}
+			}
+
+			if (!keep)
+				close(fd);
+		}
 
 #endif // __sun
 

--- a/winpr/libwinpr/thread/procthreadattr.c
+++ b/winpr/libwinpr/thread/procthreadattr.c
@@ -1,0 +1,94 @@
+/**
+ * WinPR: Windows Portable Runtime
+ * Process Thread Attribute Lists
+ *
+ * Copyright 2026 David Fort <contact@hardening-consulting.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <winpr/config.h>
+
+#include <winpr/assert.h>
+#include <winpr/error.h>
+#include <winpr/thread.h>
+
+#ifndef _WIN32
+
+#include "thread.h"
+
+#include "../log.h"
+#define TAG WINPR_TAG("thread")
+
+BOOL InitializeProcThreadAttributeList(LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList,
+                                       DWORD dwAttributeCount, DWORD dwFlags, PSIZE_T lpSize)
+{
+	WINPR_UNUSED(dwFlags);
+
+	if (!lpSize)
+	{
+		SetLastError(ERROR_INVALID_PARAMETER);
+		return FALSE;
+	}
+
+	const SIZE_T required = sizeof(struct WINPR_PROC_THREAD_ATTRIBUTE_LIST) +
+	                        dwAttributeCount * sizeof(WINPR_PROC_THREAD_ATTRIBUTE_ENTRY);
+
+	/* first call (lpAttributeList == NULL): report the required size and fail, matching real
+	 * Windows' documented two-call sizing idiom */
+	if (!lpAttributeList || (*lpSize < required))
+	{
+		*lpSize = required;
+		SetLastError(ERROR_INSUFFICIENT_BUFFER);
+		return FALSE;
+	}
+
+	lpAttributeList->capacity = dwAttributeCount;
+	lpAttributeList->count = 0;
+	return TRUE;
+}
+
+BOOL UpdateProcThreadAttribute(LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList,
+                               WINPR_ATTR_UNUSED DWORD dwFlags, DWORD_PTR Attribute, PVOID lpValue,
+                               SIZE_T cbSize, WINPR_ATTR_UNUSED PVOID lpPreviousValue,
+                               WINPR_ATTR_UNUSED PSIZE_T lpReturnSize)
+{
+	if (!lpAttributeList || !lpValue)
+	{
+		SetLastError(ERROR_INVALID_PARAMETER);
+		return FALSE;
+	}
+
+	if (lpAttributeList->count >= lpAttributeList->capacity)
+	{
+		WLog_ERR(TAG, "attribute list is full (capacity=%" PRIu32 ")", lpAttributeList->capacity);
+		SetLastError(ERROR_INSUFFICIENT_BUFFER);
+		return FALSE;
+	}
+
+	WINPR_PROC_THREAD_ATTRIBUTE_ENTRY* entry = &lpAttributeList->entries[lpAttributeList->count++];
+	entry->Attribute = Attribute;
+	entry->lpValue = lpValue;
+	entry->cbSize = cbSize;
+	return TRUE;
+}
+
+VOID DeleteProcThreadAttributeList(WINPR_ATTR_UNUSED LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList)
+{
+	/* nothing to release: the caller owns the buffer it allocated to back lpAttributeList (from
+	 * the size InitializeProcThreadAttributeList reported), and none of the lpValue pointers
+	 * handed to UpdateProcThreadAttribute are ever copied or owned by us - matches real Windows,
+	 * where DeleteProcThreadAttributeList doesn't free the caller's buffer either. */
+}
+
+#endif

--- a/winpr/libwinpr/thread/test/TestThreadCreateProcess.c
+++ b/winpr/libwinpr/thread/test/TestThreadCreateProcess.c
@@ -1,17 +1,247 @@
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <winpr/crt.h>
 #include <winpr/tchar.h>
 #include <winpr/synch.h>
 #include <winpr/thread.h>
 #include <winpr/environment.h>
 #include <winpr/pipe.h>
+#include <winpr/library.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+/* whitebox: a WinPR HANDLE for a pipe is a pointer to a heap object that does not survive
+ * exec() (the address space is replaced), so a *raw fd* - not the HANDLE value - is what needs
+ * to be handed to a re-exec'd child for the inheritance probe below. winpr_Handle_getFd() is
+ * WinPR-internal (not part of the public API) but this test lives in the same source tree and
+ * is deliberately testing that internal fd-inheritance behavior, so reaching in here is fair
+ * game. */
+#include "../../handle/handle.h"
+#endif
 
 #define TESTENV_A "HELLO=WORLD"
 #define TESTENV_T _T(TESTENV_A)
 
+#ifdef _WIN32
+WINPR_ATTR_NODISCARD
+static unsigned long long handle_to_probe_value(HANDLE h)
+{
+	return (unsigned long long)(UINT_PTR)h;
+}
+#else
+WINPR_ATTR_NODISCARD
+static unsigned long long handle_to_probe_value(HANDLE h)
+{
+	return (unsigned long long)winpr_Handle_getFd(h);
+}
+#endif
+
+/* Child-mode entry point for the handle-inheritance tests below (see run_inherit_case()): the
+ * parent re-execs this same test binary with "--probe-handle <value>", where <value> identifies
+ * the handle/fd under test. This process tries to write to it and reports OPEN/CLOSED on its own
+ * stdout - which is always wired via STARTF_USESTDHANDLES regardless of the inheritance logic
+ * under test - so the parent can read the result back. */
+WINPR_ATTR_NODISCARD
+static int probe_handle_and_report(const char* valueStr)
+{
+	BOOL ok = FALSE;
+
+#ifdef _WIN32
+	HANDLE h = (HANDLE)(UINT_PTR)strtoull(valueStr, nullptr, 10);
+	DWORD written = 0;
+	ok = WriteFile(h, "PING", 4, &written, nullptr) && (written == 4);
+#else
+	int fd = atoi(valueStr);
+	ok = (write(fd, "PING", 4) == 4);
+#endif
+
+	printf(ok ? "OPEN\n" : "CLOSED\n");
+	fflush(stdout);
+	return 0;
+}
+
+typedef enum
+{
+	MODE_NO_INHERIT,               /* bInheritHandles = FALSE */
+	MODE_INHERIT_NO_LIST,          /* bInheritHandles = TRUE, no handle list: broad inherit */
+	MODE_HANDLE_LIST_WITH_PROBE,   /* bInheritHandles = TRUE, list = [probe handle] */
+	MODE_HANDLE_LIST_WITHOUT_PROBE /* bInheritHandles = TRUE, list = [unrelated handle] */
+} InheritTestMode;
+
+/* Spawns a child (this same test binary, re-invoked in probe mode) and checks whether
+ * `probeHandle` survived into it, per `mode`, matching it against `expectOpen`. This exercises
+ * the CreateProcess() code path end to end - so it validates identical behavior on Linux, macOS
+ * (both going through winpr/libwinpr/thread/process.c) and Windows (going through the real Win32
+ * CreateProcess, which this is a conformance check of). */
+WINPR_ATTR_NODISCARD
+static int run_inherit_case(const char* exePath, const char* label, HANDLE probeHandle,
+                            InheritTestMode mode, BOOL expectOpen)
+{
+	SECURITY_ATTRIBUTES saAttr = { sizeof(SECURITY_ATTRIBUTES), nullptr, TRUE };
+	HANDLE outRead = nullptr;
+	HANDLE outWrite = nullptr;
+	int result = 1;
+
+	if (!CreatePipe(&outRead, &outWrite, &saAttr, 0))
+	{
+		printf("[%s] CreatePipe(out) failed\n", label);
+		return 1;
+	}
+
+	char cmdline[1024] = WINPR_C_ARRAY_INIT;
+	(void)snprintf(cmdline, sizeof(cmdline), "\"%s\" TestThreadCreateProcess --probe-handle %llu",
+	               exePath, handle_to_probe_value(probeHandle));
+
+	const BOOL bInheritHandles = (mode != MODE_NO_INHERIT);
+	const BOOL useExtended =
+	    (mode == MODE_HANDLE_LIST_WITH_PROBE) || (mode == MODE_HANDLE_LIST_WITHOUT_PROBE);
+
+	PROCESS_INFORMATION pi = WINPR_C_ARRAY_INIT;
+	BOOL created = FALSE;
+	LPPROC_THREAD_ATTRIBUTE_LIST attrList = nullptr;
+	STARTUPINFOEXA siEx = WINPR_C_ARRAY_INIT;
+	STARTUPINFOA si = WINPR_C_ARRAY_INIT;
+
+	STARTUPINFOA* siPtr = &si;
+	DWORD createFlags = 0;
+
+	if (useExtended)
+	{
+		SIZE_T size = 0;
+		(void)InitializeProcThreadAttributeList(nullptr, 1, 0, &size);
+		attrList = (LPPROC_THREAD_ATTRIBUTE_LIST)malloc(size);
+		if (!attrList || !InitializeProcThreadAttributeList(attrList, 1, 0, &size))
+		{
+			printf("[%s] InitializeProcThreadAttributeList failed\n", label);
+			free(attrList);
+			CloseHandle(outRead);
+			CloseHandle(outWrite);
+			return 1;
+		}
+
+		/* real Windows treats the handle list as exclusive even for hStdOutput/hStdError: if
+		 * outWrite isn't in it too, the child wouldn't get a usable stdout handle at all, and
+		 * this test's own OPEN/CLOSED result-capture mechanism would break. Only the probe
+		 * handle's presence is what actually varies between the two list-based cases. */
+		HANDLE handles[2] = { outWrite, probeHandle };
+		const size_t handleCount = (mode == MODE_HANDLE_LIST_WITH_PROBE) ? 2 : 1;
+		if (!UpdateProcThreadAttribute(attrList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, handles,
+		                               handleCount * sizeof(HANDLE), nullptr, nullptr))
+		{
+			printf("[%s] UpdateProcThreadAttribute failed\n", label);
+			DeleteProcThreadAttributeList(attrList);
+			free(attrList);
+			CloseHandle(outRead);
+			CloseHandle(outWrite);
+			return 1;
+		}
+
+		siEx.StartupInfo.cb = sizeof(siEx);
+		siEx.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+		siEx.StartupInfo.hStdOutput = outWrite;
+		siEx.StartupInfo.hStdError = outWrite;
+		siEx.lpAttributeList = attrList;
+
+		siPtr = (LPSTARTUPINFOA)&siEx;
+		createFlags = EXTENDED_STARTUPINFO_PRESENT;
+	}
+	else
+	{
+		si.cb = sizeof(si);
+		si.dwFlags = STARTF_USESTDHANDLES;
+		si.hStdOutput = outWrite;
+		si.hStdError = outWrite;
+	}
+
+	created = CreateProcessA(nullptr, cmdline, nullptr, nullptr, bInheritHandles, createFlags,
+	                         nullptr, nullptr, siPtr, &pi);
+
+	if (attrList)
+	{
+		DeleteProcThreadAttributeList(attrList);
+		free(attrList);
+	}
+
+	CloseHandle(outWrite);
+
+	if (!created)
+	{
+		printf("[%s] CreateProcessA failed, error=%" PRIu32 "\n", label, GetLastError());
+		CloseHandle(outRead);
+		return 1;
+	}
+
+	if (WaitForSingleObject(pi.hProcess, 5000) != WAIT_OBJECT_0)
+	{
+		printf("[%s] child did not exit in time\n", label);
+	}
+	else
+	{
+		char buf[64] = WINPR_C_ARRAY_INIT;
+		DWORD read_bytes = 0;
+		(void)ReadFile(outRead, buf, sizeof(buf) - 1, &read_bytes, nullptr);
+
+		const BOOL open = strstr(buf, "OPEN") != nullptr;
+		result = (open != expectOpen);
+		printf("[%s] expected %s, got '%s' -> %s\n", label, expectOpen ? "OPEN" : "CLOSED", buf,
+		       result ? "FAIL" : "OK");
+	}
+
+	CloseHandle(outRead);
+	CloseHandle(pi.hProcess);
+	CloseHandle(pi.hThread);
+	return result;
+}
+
+/* Covers the bInheritHandles / PROC_THREAD_ATTRIBUTE_HANDLE_LIST matrix documented for
+ * CreateProcess() on real Windows, which winpr/libwinpr/thread/process.c replicates on
+ * Linux/macOS:
+ *  - bInheritHandles=FALSE: nothing inherits, even a marked-inheritable handle is closed.
+ *  - bInheritHandles=TRUE, no handle list: every inheritable handle is inherited.
+ *  - bInheritHandles=TRUE, handle list present: only the listed handles are inherited, even
+ *    other inheritable handles are not. */
+WINPR_ATTR_NODISCARD
+static int TestHandleInheritance(void)
+{
+	char exePath[4096] = WINPR_C_ARRAY_INIT;
+	if (GetModuleFileNameA(nullptr, exePath, sizeof(exePath)) == 0)
+	{
+		printf("GetModuleFileNameA failed\n");
+		return 1;
+	}
+
+	SECURITY_ATTRIBUTES saAttr = { sizeof(SECURITY_ATTRIBUTES), nullptr, TRUE };
+	HANDLE probeRead = nullptr;
+	HANDLE probeWrite = nullptr;
+	if (!CreatePipe(&probeRead, &probeWrite, &saAttr, 0))
+	{
+		printf("CreatePipe(probe) failed\n");
+		return 1;
+	}
+
+	int rc = 0;
+	rc |= run_inherit_case(exePath, "bInheritHandles=FALSE", probeWrite, MODE_NO_INHERIT, FALSE);
+	rc |= run_inherit_case(exePath, "bInheritHandles=TRUE, no list", probeWrite,
+	                       MODE_INHERIT_NO_LIST, TRUE);
+	rc |= run_inherit_case(exePath, "handle list CONTAINS probe", probeWrite,
+	                       MODE_HANDLE_LIST_WITH_PROBE, TRUE);
+	rc |= run_inherit_case(exePath, "handle list does NOT contain probe", probeWrite,
+	                       MODE_HANDLE_LIST_WITHOUT_PROBE, FALSE);
+
+	CloseHandle(probeRead);
+	CloseHandle(probeWrite);
+	return rc;
+}
+
 int TestThreadCreateProcess(int argc, char* argv[])
 {
+	if ((argc >= 3) && (strcmp(argv[1], "--probe-handle") == 0))
+		return probe_handle_and_report(argv[2]);
+
 	BOOL status = 0;
 	DWORD exitCode = 0;
 	LPCTSTR lpApplicationName = nullptr;
@@ -151,6 +381,9 @@ int TestThreadCreateProcess(int argc, char* argv[])
 
 	(void)CloseHandle(ProcessInformation.hProcess);
 	(void)CloseHandle(ProcessInformation.hThread);
+
+	if (ret == 0)
+		ret = TestHandleInheritance();
 
 	return ret;
 }

--- a/winpr/libwinpr/thread/thread.h
+++ b/winpr/libwinpr/thread/thread.h
@@ -80,6 +80,23 @@ typedef struct
 	int fd;
 } WINPR_PROCESS;
 
+/* backing store for the opaque LPPROC_THREAD_ATTRIBUTE_LIST (winpr/thread.h). Shared between
+ * procthreadattr.c (which builds it) and process.c (which reads it back at CreateProcess time
+ * to resolve PROC_THREAD_ATTRIBUTE_HANDLE_LIST into fds to keep open in the child). */
+typedef struct
+{
+	DWORD_PTR Attribute;
+	PVOID lpValue;
+	SIZE_T cbSize;
+} WINPR_PROC_THREAD_ATTRIBUTE_ENTRY;
+
+struct WINPR_PROC_THREAD_ATTRIBUTE_LIST
+{
+	DWORD capacity;
+	DWORD count;
+	WINPR_PROC_THREAD_ATTRIBUTE_ENTRY entries[];
+};
+
 #endif
 
 #endif /* WINPR_THREAD_PRIVATE_H */


### PR DESCRIPTION
So first this commit introduces the marking of inheritable HANDLES by using CLOEXEC on their underlying file descriptors, so all file descriptors created by WinPR stored in a HANDLE are created with CLOEXEC set.
[Set|Get]HandleInformation are also implemented so that a HANDLE can marked with HANDLE_FLAG_INHERIT. It's the cheapest way of knowing if a HANDLE has been marked inheritable without maintaining a giant global list of HANDLEs: if the inner file descriptor is _not_ marked with CLOEXEC then this HANDLE is inheritable. If it is then it will be closed automatically by the system during an exec(). For that CLOEXEC setting, I've tried to be smart and use as much as possible the system calls that allow to open/create a file descriptor with CLOEXEC set in a single call to avoid the race where a fork/exec happens between the creation and fcntl (possible file descriptor leaking in the child).

And finally `CreateProcess` has been updated to follow the same behaviour as under Win32: if bInheritHandles is FALSE then no sharing happens and we have the old behaviour with all files closed. If bInheritHandles is TRUE, then we're gonna keep handles marked as inheritable (so lacking the CLOEXEC flag), except if a PROC_THREAD_ATTRIBUTE_HANDLE_LIST is given in startupInfo, and in this case only the HANDLEs listed here are kept in the child process.

This changes a bit the behaviour with CreateProcess that we had previously as if we just set bInheritHandles to TRUE that means that file descriptors opened by third party libraries and not marked with CLOEXEC are shared in the child process. Anyway the introduction of PROC_THREAD_ATTRIBUTE_HANDLE_LIST allows to workaround that as code that is sensible on that point can explicitly give the list of file descriptors to share.
