### PR TITLE
[client] rail: add an opt-in launch FIFO for additional RemoteApps

### DIFF
--- a/channels/rail/client/client_rails.c
+++ b/channels/rail/client/client_rails.c
@@ -63,6 +63,11 @@ UINT client_rail_server_start_cmd(RailClientContext* context)
 	if (status != CHANNEL_RC_OK)
 		return status;
 
+	const char* RemoteApplicationProgram =
+	    freerdp_settings_get_string(settings, FreeRDP_RemoteApplicationProgram);
+	if (!RemoteApplicationProgram || (RemoteApplicationProgram[0] == '\0'))
+		return CHANNEL_RC_OK;
+
 	const char* RemoteApplicationFile =
 	    freerdp_settings_get_string(settings, FreeRDP_RemoteApplicationFile);
 	const char* RemoteApplicationCmdLine =
@@ -80,8 +85,7 @@ UINT client_rail_server_start_cmd(RailClientContext* context)
 		exec.RemoteApplicationArguments = RemoteApplicationFile;
 	else
 		exec.RemoteApplicationArguments = RemoteApplicationCmdLine;
-	exec.RemoteApplicationProgram =
-	    freerdp_settings_get_string(settings, FreeRDP_RemoteApplicationProgram);
+	exec.RemoteApplicationProgram = RemoteApplicationProgram;
 	exec.RemoteApplicationWorkingDir =
 	    freerdp_settings_get_string(settings, FreeRDP_ShellWorkingDirectory);
 	return context->ClientExecute(context, &exec);

--- a/client/X11/CMakeLists.txt
+++ b/client/X11/CMakeLists.txt
@@ -43,6 +43,8 @@ set(SRCS
     xf_types.h
     xf_utils.h
     xf_utils.c
+    xf_cmdline.c
+    xf_cmdline.h
     xf_x11_utils.c
     xf_gfx.c
     xf_gfx.h
@@ -194,5 +196,9 @@ if(WITH_CLIENT_INTERFACE)
 endif()
 add_subdirectory(cli)
 add_subdirectory(man)
+
+if(BUILD_TESTING_INTERNAL OR BUILD_TESTING)
+  add_subdirectory(test)
+endif()
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER "Client/X11")

--- a/client/X11/cli/xfreerdp.c
+++ b/client/X11/cli/xfreerdp.c
@@ -29,6 +29,7 @@
 #include <freerdp/client/cmdline.h>
 
 #include "../xf_client.h"
+#include "../xf_cmdline.h"
 #include "../xfreerdp.h"
 
 static void xfreerdp_print_help(void)
@@ -74,11 +75,16 @@ int main(int argc, char* argv[])
 
 	settings = context->settings;
 	xfc = (xfContext*)context;
+	size_t customArgumentCount = 0;
+	COMMAND_LINE_ARGUMENT_A* customArguments = xf_command_line_arguments(&customArgumentCount);
 
-	status = freerdp_client_settings_parse_command_line(context->settings, argc, argv, FALSE);
+	status = freerdp_client_settings_parse_command_line_ex(context->settings, argc, argv, FALSE,
+	                                                       customArguments, customArgumentCount,
+	                                                       xf_command_line_handle_option, xfc);
 	if (status)
 	{
-		rc = freerdp_client_settings_command_line_status_print(settings, status, argc, argv);
+		rc = freerdp_client_settings_command_line_status_print_ex(settings, status, argc, argv,
+		                                                          customArguments);
 
 		if (freerdp_settings_get_bool(settings, FreeRDP_ListMonitors))
 			xf_list_monitors(xfc);

--- a/client/X11/man/CMakeLists.txt
+++ b/client/X11/man/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(DEPS
     ../../common/man/freerdp-global-options.1
+    xfreerdp-rail-options.1
     xfreerdp-shortcuts.1
     ../../common/man/freerdp-global-envvar.1
     ../../common/man/freerdp-global-config.1

--- a/client/X11/man/xfreerdp-rail-options.1
+++ b/client/X11/man/xfreerdp-rail-options.1
@@ -1,0 +1,24 @@
+.PP
+\fB+rail\-multi\-exec\fR, \fB\-rail\-multi\-exec\fR
+.RS 4
+Enable or disable a primary-side FIFO for launching additional RemoteApps on this connection. Disabled by default and available only in RemoteApp mode.
+.PP
+With \fB+rail\-multi\-exec\fR, the initial command-line application is optional. The first application may instead be submitted through the FIFO.
+.PP
+The FIFO is created with mode 0600 below \fBXDG_RUNTIME_DIR\fR. Its exact path is written to the client log. If another opted-in primary already owns the same session key, this client exits before opening a competing RDP connection.
+.PP
+Write a labelled UTF-8 record terminated by an empty line. Only \fBprogram\fR is required; \fBworking-directory\fR and \fBarguments\fR default to empty, and \fBflags\fR defaults to zero. Flags are an integer in decimal or 0x hexadecimal form.
+.nf
+program=||notepad
+working-directory=
+arguments=
+flags=0
+
+.fi
+.PP
+Submit each complete record, including its empty-line terminator, in one write no larger than the FIFO's \fB_PC_PIPE_BUF\fR value. This prevents conforming concurrent writers from interleaving.
+.PP
+This interface is primary-only and fire-and-forget. A successful write does not report whether the server launched the application.
+.PP
+If the server rejects a launch, the failure is logged and the multi-exec connection remains open for later records.
+.RE

--- a/client/X11/test/CMakeLists.txt
+++ b/client/X11/test/CMakeLists.txt
@@ -1,0 +1,45 @@
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(MODULE_NAME "TestXfRailIpc")
+
+  add_executable(${MODULE_NAME} TestXfRailIpc.c)
+  target_include_directories(${MODULE_NAME} PRIVATE .. ../../../channels/rail/client)
+  target_link_libraries(${MODULE_NAME} PRIVATE freerdp winpr freerdp-client xfreerdp-client)
+  set_target_properties(${MODULE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${TESTING_OUTPUT_DIRECTORY}")
+
+  add_test(NAME ${MODULE_NAME} COMMAND ${TESTING_OUTPUT_DIRECTORY}/${MODULE_NAME})
+  set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "FreeRDP/Client/X11/Test")
+
+  target_compile_options(${MODULE_NAME} PRIVATE "-fvisibility=default")
+  target_link_options(
+    ${MODULE_NAME} PRIVATE "-Wl,--wrap=XGetWindowAttributes" "-Wl,--wrap=XSelectInput" "-Wl,--wrap=XGetWindowProperty"
+  )
+
+  set(MODULE_NAME "TestXfClientRailIpc")
+
+  add_executable(${MODULE_NAME} TestXfClientRailIpc.c)
+  target_include_directories(${MODULE_NAME} PRIVATE ..)
+  target_link_libraries(${MODULE_NAME} PRIVATE freerdp winpr freerdp-client xfreerdp-client)
+  set_target_properties(${MODULE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${TESTING_OUTPUT_DIRECTORY}")
+  target_link_options(
+    ${MODULE_NAME}
+    PRIVATE
+    "-Wl,--wrap=freerdp_connect"
+    "-Wl,--wrap=freerdp_disconnect"
+    "-Wl,--wrap=freerdp_get_event_handles"
+    "-Wl,--wrap=freerdp_check_event_handles"
+    "-Wl,--wrap=XPending"
+  )
+
+  add_test(NAME ${MODULE_NAME} COMMAND ${TESTING_OUTPUT_DIRECTORY}/${MODULE_NAME})
+  set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "FreeRDP/Client/X11/Test")
+endif()
+
+set(MODULE_NAME "TestXfCmdLine")
+
+add_executable(${MODULE_NAME} TestXfCmdLine.c)
+target_include_directories(${MODULE_NAME} PRIVATE ..)
+target_link_libraries(${MODULE_NAME} PRIVATE freerdp winpr freerdp-client xfreerdp-client)
+set_target_properties(${MODULE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${TESTING_OUTPUT_DIRECTORY}")
+
+add_test(NAME ${MODULE_NAME} COMMAND ${TESTING_OUTPUT_DIRECTORY}/${MODULE_NAME})
+set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "FreeRDP/Client/X11/Test")

--- a/client/X11/test/TestXfClientRailIpc.c
+++ b/client/X11/test/TestXfClientRailIpc.c
@@ -1,0 +1,412 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * X11 RAIL launch FIFO construction tests
+ *
+ * Copyright 2026 Tony Dursun <oraturk75@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <freerdp/client.h>
+#include <freerdp/client/rail_ipc.h>
+#include <freerdp/freerdp.h>
+#include <freerdp/settings.h>
+
+#include <winpr/crt.h>
+#include <winpr/environment.h>
+#include <winpr/synch.h>
+
+#include "xf_client.h"
+#include "xfreerdp.h"
+
+static const char TEST_REMOTE_APP_PROGRAM[] = "C:\\Windows\\System32\\notepad.exe";
+
+static BOOL g_ConnectCalled = FALSE;
+static BOOL g_IpcPresentAtConnect = FALSE;
+static char g_FifoPath[512] = WINPR_C_ARRAY_INIT;
+static HANDLE g_InputEvent = nullptr;
+static HANDLE g_X11Mutex = nullptr;
+static BOOL g_DriveClientLoop = FALSE;
+static BOOL g_FreeRdpChecked = FALSE;
+static BOOL g_InjectIpcReadFailure = FALSE;
+static BOOL g_XPendingCalled = FALSE;
+static rdpContext* g_AbortContext = nullptr;
+static size_t g_ExecuteCount = 0;
+static RailClientContext g_Rail = WINPR_C_ARRAY_INIT;
+
+static BOOL write_record(const char* path)
+{
+	static const char record[] = "program=queued-before-transition.exe\n\n";
+	if (!path)
+		return FALSE;
+	const int fd = open(path, O_WRONLY | O_NONBLOCK | O_CLOEXEC);
+	if (fd < 0)
+		return FALSE;
+	ssize_t written = 0;
+	do
+	{
+		written = write(fd, record, sizeof(record) - 1U);
+	} while ((written < 0) && (errno == EINTR));
+	const int savedError = errno;
+	close(fd);
+	errno = savedError;
+	return written == (ssize_t)(sizeof(record) - 1U);
+}
+
+static BOOL lock_path_from_fifo(const char* fifoPath, char* lockPath, size_t capacity)
+{
+	static const char suffix[] = ".fifo";
+	const size_t length = strlen(fifoPath);
+	if ((length < sizeof(suffix) - 1U) ||
+	    (strcmp(fifoPath + length - (sizeof(suffix) - 1U), suffix) != 0))
+		return FALSE;
+	const size_t prefixLength = length - (sizeof(suffix) - 1U);
+	if (prefixLength > capacity - sizeof(".lock"))
+		return FALSE;
+	CopyMemory(lockPath, fifoPath, prefixLength);
+	CopyMemory(lockPath + prefixLength, ".lock", sizeof(".lock"));
+	return TRUE;
+}
+
+static BOOL remove_lock_for_fifo(const char* fifoPath)
+{
+	char lockPath[sizeof(g_FifoPath)] = WINPR_C_ARRAY_INIT;
+	if (!fifoPath || (fifoPath[0] == '\0'))
+		return TRUE;
+	if (!lock_path_from_fifo(fifoPath, lockPath, sizeof(lockPath)))
+		return FALSE;
+	if ((unlink(lockPath) < 0) && (errno != ENOENT))
+	{
+		fprintf(stderr, "could not remove test lock '%s': %s\n", lockPath, strerror(errno));
+		return FALSE;
+	}
+	return TRUE;
+}
+
+static UINT execute_record(WINPR_ATTR_UNUSED RailClientContext* rail,
+                           WINPR_ATTR_UNUSED const RAIL_EXEC_ORDER* order)
+{
+	g_ExecuteCount++;
+	return CHANNEL_RC_OK;
+}
+
+BOOL __wrap_freerdp_connect(freerdp* instance)
+{
+	WINPR_ASSERT(instance);
+	WINPR_ASSERT(instance->context);
+	xfContext* xfc = (xfContext*)instance->context;
+	g_ConnectCalled = TRUE;
+	g_IpcPresentAtConnect = xfc->railIpc != nullptr;
+	const char* path = freerdp_client_rail_ipc_get_path(xfc->railIpc);
+	if (path)
+		(void)_snprintf(g_FifoPath, sizeof(g_FifoPath), "%s", path);
+	if (g_DriveClientLoop)
+	{
+		g_InputEvent = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+		g_X11Mutex = CreateMutex(nullptr, FALSE, nullptr);
+		xfc->mutex = g_X11Mutex;
+		xfc->x11event = g_InputEvent;
+		ZeroMemory(&g_Rail, sizeof(g_Rail));
+		g_Rail.ClientExecute = execute_record;
+		if (!freerdp_client_rail_ipc_attach(xfc->railIpc, &g_Rail) ||
+		    !freerdp_client_rail_ipc_set_ready(xfc->railIpc, TRUE) || !g_InputEvent || !xfc->mutex)
+			return FALSE;
+		if (g_InjectIpcReadFailure)
+		{
+			const HANDLE event = freerdp_client_rail_ipc_get_event(xfc->railIpc);
+			if (!event)
+				return FALSE;
+			const int readFd = GetEventFileDescriptor(event);
+			const char* directory = getenv("XDG_RUNTIME_DIR");
+			if ((readFd < 0) || !directory)
+				return FALSE;
+			const int directoryFd = open(directory, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+			if (directoryFd < 0)
+				return FALSE;
+			const int replaced = dup2(directoryFd, readFd);
+			close(directoryFd);
+			if (replaced != readFd)
+				return FALSE;
+			g_AbortContext = instance->context;
+			return TRUE;
+		}
+		return write_record(path);
+	}
+	return FALSE;
+}
+
+BOOL __wrap_freerdp_disconnect(WINPR_ATTR_UNUSED freerdp* instance)
+{
+	return TRUE;
+}
+
+DWORD __wrap_freerdp_get_event_handles(rdpContext* context, HANDLE* events, DWORD count)
+{
+	if (!context || !events || (count < 1))
+		return 0;
+	events[0] = freerdp_abort_event(context);
+	return events[0] ? 1 : 0;
+}
+
+BOOL __wrap_freerdp_check_event_handles(rdpContext* context)
+{
+	WINPR_ASSERT(context);
+	if (g_DriveClientLoop)
+	{
+		xfContext* xfc = (xfContext*)context;
+		g_FreeRdpChecked = TRUE;
+		if (g_InjectIpcReadFailure)
+			return TRUE;
+		if (!freerdp_client_rail_ipc_set_ready(xfc->railIpc, FALSE))
+			return FALSE;
+		freerdp_abort_connect_context(context);
+	}
+	return TRUE;
+}
+
+int __wrap_XPending(WINPR_ATTR_UNUSED Display* display)
+{
+	if (g_InjectIpcReadFailure)
+	{
+		g_XPendingCalled = TRUE;
+		if (g_AbortContext)
+			freerdp_abort_connect_context(g_AbortContext);
+	}
+	return 0;
+}
+
+static BOOL set_test_settings(rdpSettings* settings, BOOL railMode, BOOL authenticationOnly,
+                              const char* program)
+{
+	return freerdp_settings_set_string(settings, FreeRDP_ServerHostname,
+	                                   "fifo-construction.example.invalid") &&
+	       freerdp_settings_set_uint32(settings, FreeRDP_ServerPort, 3389) &&
+	       freerdp_settings_set_string(settings, FreeRDP_Username, "fifo-user") &&
+	       freerdp_settings_set_bool(settings, FreeRDP_RemoteApplicationMode, railMode) &&
+	       freerdp_settings_set_bool(settings, FreeRDP_AuthenticationOnly, authenticationOnly) &&
+	       freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationProgram, program);
+}
+
+static BOOL run_case(const RDP_CLIENT_ENTRY_POINTS* entry, BOOL option, BOOL railMode,
+                     BOOL authenticationOnly, const char* program, BOOL expectConnect,
+                     BOOL expectIpc, DWORD* exitCode)
+{
+	WINPR_ASSERT(entry);
+	g_DriveClientLoop = FALSE;
+	g_ConnectCalled = FALSE;
+	g_IpcPresentAtConnect = FALSE;
+	ZeroMemory(g_FifoPath, sizeof(g_FifoPath));
+	rdpContext* context = freerdp_client_context_new(entry);
+	if (!context)
+		return FALSE;
+	BOOL started = FALSE;
+	BOOL rc = FALSE;
+	xfContext* xfc = (xfContext*)context;
+	xfc->railMultiExec = option;
+	if (!set_test_settings(context->settings, railMode, authenticationOnly, program) ||
+	    (freerdp_client_start(context) != 0))
+		goto out;
+	started = TRUE;
+	HANDLE thread = freerdp_client_get_thread(context);
+	DWORD code = 0;
+	if (!thread || (WaitForSingleObject(thread, 5000) != WAIT_OBJECT_0) ||
+	    !GetExitCodeThread(thread, &code))
+		goto out;
+	if (exitCode)
+		*exitCode = code;
+	rc = (g_ConnectCalled == expectConnect) &&
+	     (!expectConnect || (g_IpcPresentAtConnect == expectIpc)) && (xfc->railIpc == nullptr);
+	if (rc && expectIpc)
+	{
+		struct stat attributes = WINPR_C_ARRAY_INIT;
+		rc = (g_FifoPath[0] != '\0') && (lstat(g_FifoPath, &attributes) < 0);
+	}
+
+out:
+	if (started)
+		(void)freerdp_client_stop(context);
+	freerdp_client_context_free(context);
+	if (!remove_lock_for_fifo(g_FifoPath))
+		rc = FALSE;
+	return rc;
+}
+
+static BOOL test_freerdp_transition_wins(const RDP_CLIENT_ENTRY_POINTS* entry)
+{
+	WINPR_ASSERT(entry);
+	g_ConnectCalled = FALSE;
+	g_IpcPresentAtConnect = FALSE;
+	g_FreeRdpChecked = FALSE;
+	g_ExecuteCount = 0;
+	g_DriveClientLoop = TRUE;
+	ZeroMemory(g_FifoPath, sizeof(g_FifoPath));
+	rdpContext* context = freerdp_client_context_new(entry);
+	if (!context)
+		return FALSE;
+	BOOL started = FALSE;
+	BOOL rc = FALSE;
+	xfContext* xfc = (xfContext*)context;
+	xfc->railMultiExec = TRUE;
+	if (!set_test_settings(context->settings, TRUE, FALSE, TEST_REMOTE_APP_PROGRAM) ||
+	    (freerdp_client_start(context) != 0))
+		goto out;
+	started = TRUE;
+	HANDLE thread = freerdp_client_get_thread(context);
+	if (!thread || (WaitForSingleObject(thread, 5000) != WAIT_OBJECT_0))
+		goto out;
+	rc = g_ConnectCalled && g_IpcPresentAtConnect && g_FreeRdpChecked && (g_ExecuteCount == 0) &&
+	     (xfc->railIpc == nullptr);
+
+out:
+	if (started)
+		(void)freerdp_client_stop(context);
+	xfc->x11event = nullptr;
+	xfc->mutex = nullptr;
+	freerdp_client_context_free(context);
+	if (g_InputEvent)
+		(void)CloseHandle(g_InputEvent);
+	g_InputEvent = nullptr;
+	if (g_X11Mutex)
+		(void)CloseHandle(g_X11Mutex);
+	g_X11Mutex = nullptr;
+	if (!remove_lock_for_fifo(g_FifoPath))
+		rc = FALSE;
+	g_DriveClientLoop = FALSE;
+	return rc;
+}
+
+static BOOL test_ipc_failure_stays_in_client_loop(const RDP_CLIENT_ENTRY_POINTS* entry)
+{
+	WINPR_ASSERT(entry);
+	g_ConnectCalled = FALSE;
+	g_IpcPresentAtConnect = FALSE;
+	g_FreeRdpChecked = FALSE;
+	g_InjectIpcReadFailure = TRUE;
+	g_XPendingCalled = FALSE;
+	g_AbortContext = nullptr;
+	g_ExecuteCount = 0;
+	g_DriveClientLoop = TRUE;
+	ZeroMemory(g_FifoPath, sizeof(g_FifoPath));
+	rdpContext* context = freerdp_client_context_new(entry);
+	if (!context)
+		return FALSE;
+	BOOL started = FALSE;
+	BOOL rc = FALSE;
+	xfContext* xfc = (xfContext*)context;
+	xfc->railMultiExec = TRUE;
+	if (!set_test_settings(context->settings, TRUE, FALSE, TEST_REMOTE_APP_PROGRAM) ||
+	    (freerdp_client_start(context) != 0))
+		goto out;
+	started = TRUE;
+	HANDLE thread = freerdp_client_get_thread(context);
+	if (!thread || (WaitForSingleObject(thread, 5000) != WAIT_OBJECT_0))
+		goto out;
+	rc = g_ConnectCalled && g_IpcPresentAtConnect && g_FreeRdpChecked && g_XPendingCalled &&
+	     (g_ExecuteCount == 0) && (xfc->railIpc == nullptr);
+
+out:
+	if (started)
+		(void)freerdp_client_stop(context);
+	xfc->x11event = nullptr;
+	xfc->mutex = nullptr;
+	freerdp_client_context_free(context);
+	if (g_InputEvent)
+		(void)CloseHandle(g_InputEvent);
+	g_InputEvent = nullptr;
+	if (g_X11Mutex)
+		(void)CloseHandle(g_X11Mutex);
+	g_X11Mutex = nullptr;
+	if (!remove_lock_for_fifo(g_FifoPath))
+		rc = FALSE;
+	g_DriveClientLoop = FALSE;
+	g_InjectIpcReadFailure = FALSE;
+	g_AbortContext = nullptr;
+	return rc;
+}
+
+int main(int argc, char* argv[])
+{
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+	int rc = 1;
+	char directory[] = "/tmp/xfc.XXXXXX";
+	BOOL directoryCreated = FALSE;
+	char ownerLockPath[sizeof(g_FifoPath)] = WINPR_C_ARRAY_INIT;
+	RDP_CLIENT_ENTRY_POINTS entry = { .Size = sizeof(entry),
+		                              .Version = RDP_CLIENT_INTERFACE_VERSION };
+	RailClientIpcContext* owner = nullptr;
+	rdpSettings* ownerSettings = nullptr;
+	wLog* log = WLog_Get("com.freerdp.test.x11.rail-ipc-construction");
+
+	if (!mkdtemp(directory))
+		goto out;
+	directoryCreated = TRUE;
+	if ((chmod(directory, S_IRWXU) < 0) || !SetEnvironmentVariableA("XDG_RUNTIME_DIR", directory) ||
+	    (RdpClientEntry(&entry) != 0))
+		goto out;
+	if (!run_case(&entry, FALSE, TRUE, FALSE, TEST_REMOTE_APP_PROGRAM, TRUE, FALSE, nullptr) ||
+	    !run_case(&entry, TRUE, FALSE, FALSE, TEST_REMOTE_APP_PROGRAM, TRUE, FALSE, nullptr) ||
+	    !run_case(&entry, TRUE, TRUE, TRUE, TEST_REMOTE_APP_PROGRAM, TRUE, FALSE, nullptr) ||
+	    !run_case(&entry, TRUE, TRUE, FALSE, TEST_REMOTE_APP_PROGRAM, TRUE, TRUE, nullptr))
+		goto out;
+	printf("PASS the FIFO exists only for opted-in, non-authentication RAIL sessions\n");
+	if (!run_case(&entry, TRUE, TRUE, FALSE, "", TRUE, TRUE, nullptr))
+		goto out;
+	printf("PASS an empty initial RemoteApp program reaches connection setup with the FIFO\n");
+	if (!test_freerdp_transition_wins(&entry))
+		goto out;
+	printf("PASS FreeRDP channel transitions are processed before ready FIFO input\n");
+	if (!test_ipc_failure_stays_in_client_loop(&entry))
+		goto out;
+	printf("PASS an operational FIFO failure stays contained in the client loop\n");
+	ownerSettings = freerdp_settings_new(0);
+	if (!ownerSettings || !set_test_settings(ownerSettings, TRUE, FALSE, TEST_REMOTE_APP_PROGRAM))
+		goto out;
+	owner = freerdp_client_rail_ipc_new(ownerSettings, log);
+	if (!owner)
+		goto out;
+	const char* ownerFifoPath = freerdp_client_rail_ipc_get_path(owner);
+	if (!ownerFifoPath || !lock_path_from_fifo(ownerFifoPath, ownerLockPath, sizeof(ownerLockPath)))
+		goto out;
+	DWORD duplicateExit = 0;
+	if (!run_case(&entry, TRUE, TRUE, FALSE, TEST_REMOTE_APP_PROGRAM, FALSE, FALSE,
+	              &duplicateExit) ||
+	    (duplicateExit != XF_EXIT_PRE_CONNECT_FAILED))
+		goto out;
+	printf("PASS an active primary prevents the X11 client from connecting\n");
+	rc = 0;
+
+out:
+	freerdp_client_rail_ipc_free(owner);
+	freerdp_settings_free(ownerSettings);
+	(void)SetEnvironmentVariableA("XDG_RUNTIME_DIR", nullptr);
+	if ((ownerLockPath[0] != '\0') && (unlink(ownerLockPath) < 0) && (errno != ENOENT))
+	{
+		fprintf(stderr, "could not remove owner lock '%s': %s\n", ownerLockPath, strerror(errno));
+		rc = 1;
+	}
+	if (directoryCreated && (rmdir(directory) < 0))
+	{
+		fprintf(stderr, "could not remove test directory '%s': %s\n", directory, strerror(errno));
+		rc = 1;
+	}
+	return rc;
+}

--- a/client/X11/test/TestXfCmdLine.c
+++ b/client/X11/test/TestXfCmdLine.c
@@ -1,0 +1,159 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * X11 command-line tests
+ *
+ * Copyright 2026 Tony Dursun <oraturk75@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <freerdp/client.h>
+#include <freerdp/settings.h>
+
+#include <winpr/cmdline.h>
+#include <winpr/crt.h>
+
+#include "xf_cmdline.h"
+#include "xfreerdp.h"
+
+static int parse(xfContext* xfc, int argc, char** argv)
+{
+	size_t count = 0;
+	COMMAND_LINE_ARGUMENT_A* arguments = xf_command_line_arguments(&count);
+	(void)CommandLineClearArgumentsA(arguments);
+	return freerdp_client_settings_parse_command_line_ex(xfc->common.context.settings, argc, argv,
+	                                                     FALSE, arguments, count,
+	                                                     xf_command_line_handle_option, xfc);
+}
+
+static BOOL test_help_contains_option(void)
+{
+	BOOL rc = FALSE;
+	int saved = -1;
+	FILE* capture = nullptr;
+	rdpSettings* settings = freerdp_settings_new(0);
+	if (!settings)
+		return FALSE;
+	xfContext xfc = WINPR_C_ARRAY_INIT;
+	xfc.common.context.settings = settings;
+	char* argv[] = { "xfreerdp", "/help", nullptr };
+	const int status = parse(&xfc, 2, argv);
+	if (status != COMMAND_LINE_STATUS_PRINT_HELP)
+		goto out;
+
+	capture = tmpfile();
+	if (!capture)
+		goto out;
+	saved = dup(STDOUT_FILENO);
+	if ((saved < 0) || (fflush(stdout) != 0) || (dup2(fileno(capture), STDOUT_FILENO) < 0))
+		goto out;
+	size_t count = 0;
+	COMMAND_LINE_ARGUMENT_A* arguments = xf_command_line_arguments(&count);
+	WINPR_UNUSED(count);
+	if (freerdp_client_settings_command_line_status_print_ex(settings, status, 2, argv,
+	                                                         arguments) != 0)
+		goto restore;
+	if ((fflush(stdout) != 0) || (fseek(capture, 0, SEEK_SET) != 0))
+		goto restore;
+	char line[1024] = WINPR_C_ARRAY_INIT;
+	while (fgets(line, sizeof(line), capture))
+	{
+		if (strstr(line, "rail-multi-exec"))
+		{
+			rc = TRUE;
+			break;
+		}
+	}
+
+restore:
+	(void)fflush(stdout);
+	if (saved >= 0)
+	{
+		(void)dup2(saved, STDOUT_FILENO);
+		close(saved);
+		saved = -1;
+	}
+
+out:
+	if (saved >= 0)
+		close(saved);
+	if (capture)
+		fclose(capture);
+	freerdp_settings_free(settings);
+	return rc;
+}
+
+int main(int argc, char* argv[])
+{
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+	rdpSettings* settings = freerdp_settings_new(0);
+	if (!settings)
+		return 1;
+	xfContext xfc = WINPR_C_ARRAY_INIT;
+	xfc.common.context.settings = settings;
+
+	char* defaults[] = { "xfreerdp", "/v:test.example.invalid", nullptr };
+	if ((parse(&xfc, 2, defaults) != 0) || xfc.railMultiExec)
+	{
+		fprintf(stderr, "default-off case failed\n");
+		goto fail;
+	}
+
+	char* port[] = { "xfreerdp", "/v:test.example.invalid", "/port:3390", nullptr };
+	if ((parse(&xfc, 3, port) != 0) ||
+	    (freerdp_settings_get_uint32(settings, FreeRDP_ServerPort) != 3390))
+	{
+		fprintf(stderr, "global-option passthrough case failed\n");
+		goto fail;
+	}
+
+	char* enable[] = { "xfreerdp", "+rail-multi-exec", "/v:test.example.invalid", nullptr };
+	if ((parse(&xfc, 3, enable) != 0) || !xfc.railMultiExec)
+	{
+		fprintf(stderr, "enable case failed\n");
+		goto fail;
+	}
+
+	char* disable[] = { "xfreerdp", "-rail-multi-exec", "/v:test.example.invalid", nullptr };
+	if ((parse(&xfc, 3, disable) != 0) || xfc.railMultiExec)
+	{
+		fprintf(stderr, "disable case failed\n");
+		goto fail;
+	}
+
+	char* malformed[] = { "xfreerdp", "+rail-multi-exec:yes", "/v:test.example.invalid", nullptr };
+	if (parse(&xfc, 3, malformed) >= 0)
+	{
+		fprintf(stderr, "malformed-value case failed\n");
+		goto fail;
+	}
+
+	freerdp_settings_free(settings);
+	if (!test_help_contains_option())
+	{
+		fprintf(stderr, "help-presence case failed\n");
+		return 1;
+	}
+	printf("PASS rail-multi-exec is default-off, preserves global options, accepts +/-, rejects "
+	       "malformed syntax, and appears in /help\n");
+	return 0;
+
+fail:
+	freerdp_settings_free(settings);
+	return 1;
+}

--- a/client/X11/test/TestXfRailIpc.c
+++ b/client/X11/test/TestXfRailIpc.c
@@ -1,0 +1,678 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * X11 RAIL launch FIFO integration tests
+ *
+ * Copyright 2026 Tony Dursun <oraturk75@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <X11/Xatom.h>
+
+#include <freerdp/client.h>
+#include <freerdp/client/rail_ipc.h>
+#include <freerdp/freerdp.h>
+#include <freerdp/settings.h>
+
+#include <winpr/crt.h>
+#include <winpr/environment.h>
+#include <winpr/synch.h>
+#include <winpr/wlog.h>
+
+#include "xf_client.h"
+#include "xf_rail.h"
+#include "xfreerdp.h"
+#include "rail_main.h"
+
+#define TEST_EVENT_COUNT 32U
+#define TEST_EVENT_LENGTH 160U
+
+typedef struct
+{
+	rdpContext* context;
+	xfContext* xfc;
+	RailClientIpcContext* ipc;
+	RailClientContext rail;
+	railPlugin plugin;
+	rdpGdi gdi;
+	_XPrivDisplay display;
+	Screen screen;
+	UINT executeStatus;
+	size_t executeCount;
+	size_t eventCount;
+	char events[TEST_EVENT_COUNT][TEST_EVENT_LENGTH];
+	char lastProgram[TEST_EVENT_LENGTH];
+	char lockPath[512];
+	BOOL railInitialized;
+} testFixture;
+
+static testFixture* g_Fixture = nullptr;
+
+WINPR_API int __wrap_XGetWindowAttributes(WINPR_ATTR_UNUSED Display* display,
+                                          WINPR_ATTR_UNUSED Window window,
+                                          XWindowAttributes* attributes)
+{
+	WINPR_ASSERT(attributes);
+	ZeroMemory(attributes, sizeof(*attributes));
+	return 1;
+}
+
+WINPR_API int __wrap_XSelectInput(WINPR_ATTR_UNUSED Display* display,
+                                  WINPR_ATTR_UNUSED Window window, WINPR_ATTR_UNUSED long eventMask)
+{
+	return 1;
+}
+
+int __wrap_XGetWindowProperty(WINPR_ATTR_UNUSED Display* display, WINPR_ATTR_UNUSED Window window,
+                              Atom property, WINPR_ATTR_UNUSED long offset,
+                              WINPR_ATTR_UNUSED long length, WINPR_ATTR_UNUSED Bool deleteProperty,
+                              WINPR_ATTR_UNUSED Atom requestedType, Atom* actualType,
+                              int* actualFormat, unsigned long* itemCount,
+                              unsigned long* bytesAfter, unsigned char** value)
+{
+	WINPR_ASSERT(g_Fixture);
+	WINPR_ASSERT(actualType);
+	WINPR_ASSERT(actualFormat);
+	WINPR_ASSERT(itemCount);
+	WINPR_ASSERT(bytesAfter);
+	WINPR_ASSERT(value);
+	const size_t count = (property == g_Fixture->xfc->NET_WORKAREA) ? 4U : 1U;
+	long* data = calloc(count, sizeof(*data));
+	if (!data)
+		return BadAlloc;
+	if (property == g_Fixture->xfc->NET_NUMBER_OF_DESKTOPS)
+		data[0] = 1;
+	else if (property == g_Fixture->xfc->NET_CURRENT_DESKTOP)
+		data[0] = 0;
+	else if (property == g_Fixture->xfc->NET_WORKAREA)
+	{
+		data[2] = 1280;
+		data[3] = 720;
+	}
+	else
+	{
+		free(data);
+		return BadAtom;
+	}
+	*actualType = XA_CARDINAL;
+	*actualFormat = 32;
+	*itemCount = count;
+	*bytesAfter = 0;
+	*value = WINPR_CXX_COMPAT_CAST(unsigned char*, data);
+	return Success;
+}
+
+static BOOL record_event(const char* format, ...)
+{
+	if (!g_Fixture || (g_Fixture->eventCount >= ARRAYSIZE(g_Fixture->events)))
+		return FALSE;
+
+	va_list ap;
+	va_start(ap, format);
+	const int rc = vsnprintf(g_Fixture->events[g_Fixture->eventCount],
+	                         sizeof(g_Fixture->events[g_Fixture->eventCount]), format, ap);
+	va_end(ap);
+	if (rc < 0)
+		return FALSE;
+	g_Fixture->eventCount++;
+	return TRUE;
+}
+
+static UINT client_information(WINPR_ATTR_UNUSED RailClientContext* rail,
+                               WINPR_ATTR_UNUSED const RAIL_CLIENT_STATUS_ORDER* order)
+{
+	return record_event("client-information") ? CHANNEL_RC_OK : ERROR_INTERNAL_ERROR;
+}
+
+static UINT client_language_bar(WINPR_ATTR_UNUSED RailClientContext* rail,
+                                WINPR_ATTR_UNUSED const RAIL_LANGBAR_INFO_ORDER* order)
+{
+	return record_event("language-bar") ? CHANNEL_RC_OK : ERROR_INTERNAL_ERROR;
+}
+
+static UINT client_system_param(WINPR_ATTR_UNUSED RailClientContext* rail,
+                                const RAIL_SYSPARAM_ORDER* order)
+{
+	WINPR_ASSERT(order);
+	const char* name =
+	    (order->params == SPI_MASK_SET_WORK_AREA) ? "work-area" : "system-parameters";
+	return record_event("%s", name) ? CHANNEL_RC_OK : ERROR_INTERNAL_ERROR;
+}
+
+static UINT client_execute(WINPR_ATTR_UNUSED RailClientContext* rail, const RAIL_EXEC_ORDER* order)
+{
+	WINPR_ASSERT(g_Fixture);
+	WINPR_ASSERT(order);
+	const char* program = order->RemoteApplicationProgram ? order->RemoteApplicationProgram : "";
+	if (!record_event("execute:%s", program))
+		return ERROR_INTERNAL_ERROR;
+	(void)_snprintf(g_Fixture->lastProgram, sizeof(g_Fixture->lastProgram), "%s", program);
+	g_Fixture->executeCount++;
+	return g_Fixture->executeStatus;
+}
+
+static BOOL set_test_settings(rdpSettings* settings)
+{
+	return freerdp_settings_set_string(settings, FreeRDP_ServerHostname,
+	                                   "fifo-integration.example.invalid") &&
+	       freerdp_settings_set_uint32(settings, FreeRDP_ServerPort, 3389) &&
+	       freerdp_settings_set_string(settings, FreeRDP_Username, "fifo-user") &&
+	       freerdp_settings_set_bool(settings, FreeRDP_RemoteApplicationMode, TRUE) &&
+	       freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationProgram,
+	                                   "C:\\Windows\\System32\\notepad.exe") &&
+	       freerdp_settings_set_string(settings, FreeRDP_ShellWorkingDirectory, "C:\\Windows") &&
+	       freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationCmdLine, "/test") &&
+	       freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationFile, "payload.txt") &&
+	       freerdp_settings_set_uint32(settings, FreeRDP_DesktopWidth, 1280) &&
+	       freerdp_settings_set_uint32(settings, FreeRDP_DesktopHeight, 720);
+}
+
+static BOOL lock_path_from_fifo(const char* fifoPath, char* lockPath, size_t capacity)
+{
+	static const char suffix[] = ".fifo";
+	const size_t length = strlen(fifoPath);
+	if ((length < sizeof(suffix) - 1U) ||
+	    (strcmp(fifoPath + length - (sizeof(suffix) - 1U), suffix) != 0))
+		return FALSE;
+	const size_t prefixLength = length - (sizeof(suffix) - 1U);
+	if (prefixLength > capacity - sizeof(".lock"))
+		return FALSE;
+	CopyMemory(lockPath, fifoPath, prefixLength);
+	CopyMemory(lockPath + prefixLength, ".lock", sizeof(".lock"));
+	return TRUE;
+}
+
+static BOOL remove_lock_file(const char* lockPath)
+{
+	if (!lockPath || (lockPath[0] == '\0'))
+		return TRUE;
+	if ((unlink(lockPath) < 0) && (errno != ENOENT))
+	{
+		fprintf(stderr, "could not remove test lock '%s': %s\n", lockPath, strerror(errno));
+		return FALSE;
+	}
+	return TRUE;
+}
+
+static void fixture_free(testFixture* fixture)
+{
+	if (!fixture)
+		return;
+	if (fixture->railInitialized)
+		(void)xf_rail_uninit(fixture->xfc, &fixture->rail);
+	fixture->railInitialized = FALSE;
+	freerdp_client_rail_ipc_free(fixture->ipc);
+	fixture->ipc = nullptr;
+	if (fixture->xfc)
+	{
+		fixture->xfc->railIpc = nullptr;
+		fixture->xfc->display = nullptr;
+		fixture->context->gdi = nullptr;
+	}
+	free(fixture->display);
+	fixture->display = nullptr;
+	if (g_Fixture == fixture)
+		g_Fixture = nullptr;
+	freerdp_client_context_free(fixture->context);
+	fixture->context = nullptr;
+	fixture->xfc = nullptr;
+}
+
+static BOOL fixture_init(testFixture* fixture)
+{
+	WINPR_ASSERT(fixture);
+	ZeroMemory(fixture, sizeof(*fixture));
+	RDP_CLIENT_ENTRY_POINTS entry = { .Size = sizeof(entry),
+		                              .Version = RDP_CLIENT_INTERFACE_VERSION };
+	if (RdpClientEntry(&entry) != 0)
+		return FALSE;
+	fixture->context = freerdp_client_context_new(&entry);
+	if (!fixture->context)
+		return FALSE;
+	fixture->xfc = (xfContext*)fixture->context;
+	fixture->display = calloc(1, sizeof(*fixture->display));
+	if (!fixture->display || !set_test_settings(fixture->context->settings))
+		goto fail;
+	fixture->screen.root = 1;
+	fixture->display->screens = &fixture->screen;
+	fixture->display->nscreens = 1;
+	fixture->display->default_screen = 0;
+	fixture->xfc->display = WINPR_CXX_COMPAT_CAST(Display*, fixture->display);
+	fixture->xfc->remote_app = TRUE;
+	fixture->xfc->railMultiExec = TRUE;
+	fixture->xfc->NET_NUMBER_OF_DESKTOPS = 1;
+	fixture->xfc->NET_CURRENT_DESKTOP = 2;
+	fixture->xfc->NET_WORKAREA = 3;
+	fixture->xfc->railWorkArea.width = 1;
+	fixture->xfc->railWorkArea.height = 1;
+	fixture->context->gdi = &fixture->gdi;
+	fixture->plugin.rdpcontext = fixture->context;
+	fixture->rail.handle = &fixture->plugin;
+	fixture->rail.ClientExecute = client_execute;
+	fixture->rail.ClientInformation = client_information;
+	fixture->rail.ClientLanguageBarInfo = client_language_bar;
+	fixture->rail.ClientSystemParam = client_system_param;
+	fixture->executeStatus = CHANNEL_RC_OK;
+	g_Fixture = fixture;
+	fixture->ipc = freerdp_client_rail_ipc_new(fixture->context->settings, fixture->xfc->log);
+	if (!fixture->ipc)
+		goto fail;
+	const char* fifoPath = freerdp_client_rail_ipc_get_path(fixture->ipc);
+	if (!fifoPath || !lock_path_from_fifo(fifoPath, fixture->lockPath, sizeof(fixture->lockPath)))
+		goto fail;
+	fixture->xfc->railIpc = fixture->ipc;
+	if (xf_rail_init(fixture->xfc, &fixture->rail) != 1)
+		goto fail;
+	fixture->railInitialized = TRUE;
+	return fixture->context->update->window->MonitoredDesktop &&
+	       fixture->context->update->window->NonMonitoredDesktop &&
+	       fixture->rail.ServerExecuteResult;
+
+fail:
+	fixture_free(fixture);
+	return FALSE;
+}
+
+static BOOL write_record(const testFixture* fixture, const char* program)
+{
+	WINPR_ASSERT(fixture);
+	WINPR_ASSERT(program);
+	const char* path = freerdp_client_rail_ipc_get_path(fixture->ipc);
+	char record[512] = WINPR_C_ARRAY_INIT;
+	const int length = _snprintf(record, sizeof(record), "program=%s\n\n", program);
+	if (!path || (length < 0) || ((size_t)length >= sizeof(record)))
+		return FALSE;
+	const int fd = open(path, O_WRONLY | O_NONBLOCK | O_CLOEXEC);
+	if (fd < 0)
+		return FALSE;
+	ssize_t written = 0;
+	do
+	{
+		written = write(fd, record, (size_t)length);
+	} while ((written < 0) && (errno == EINTR));
+	const int savedError = errno;
+	close(fd);
+	errno = savedError;
+	return written == length;
+}
+
+static BOOL monitored(testFixture* fixture, UINT32 flags)
+{
+	const WINDOW_ORDER_INFO info = { .fieldFlags = WINDOW_ORDER_TYPE_DESKTOP | flags };
+	const MONITORED_DESKTOP_ORDER order = WINPR_C_ARRAY_INIT;
+	return fixture->context->update->window->MonitoredDesktop(fixture->context, &info, &order);
+}
+
+static BOOL non_monitored(testFixture* fixture)
+{
+	const WINDOW_ORDER_INFO info = { .fieldFlags = WINDOW_ORDER_TYPE_DESKTOP |
+		                                           WINDOW_ORDER_FIELD_DESKTOP_NONE };
+	fixture->xfc->remote_app = FALSE;
+	const BOOL rc = fixture->context->update->window->NonMonitoredDesktop(fixture->context, &info);
+	fixture->xfc->remote_app = TRUE;
+	return rc;
+}
+
+static BOOL post_result(testFixture* fixture, UINT16 result)
+{
+	const RAIL_EXEC_RESULT_ORDER order = { .execResult = result };
+	return fixture->rail.ServerExecuteResult(&fixture->rail, &order) == CHANNEL_RC_OK;
+}
+
+static BOOL expect_events(const testFixture* fixture, const char* const* expected, size_t count)
+{
+	if (fixture->eventCount != count)
+	{
+		fprintf(stderr, "expected %" PRIuz " events, got %" PRIuz "\n", count, fixture->eventCount);
+		return FALSE;
+	}
+	for (size_t x = 0; x < count; x++)
+	{
+		if (strcmp(fixture->events[x], expected[x]) != 0)
+		{
+			fprintf(stderr, "event %" PRIuz ": expected '%s', got '%s'\n", x, expected[x],
+			        fixture->events[x]);
+			return FALSE;
+		}
+	}
+	return TRUE;
+}
+
+static BOOL test_preamble_before_fifo(testFixture* fixture)
+{
+	static const char* const expected[] = { "client-information", "system-parameters",
+		                                    "execute:C:\\Windows\\System32\\notepad.exe",
+		                                    "work-area", "execute:queued-before-arc.exe" };
+	if (!write_record(fixture, "queued-before-arc.exe"))
+	{
+		fprintf(stderr, "could not queue the pre-ARC record\n");
+		return FALSE;
+	}
+	if (freerdp_client_rail_ipc_get_event(fixture->ipc))
+	{
+		fprintf(stderr, "FIFO event exposed before ARC_COMPLETED\n");
+		return FALSE;
+	}
+	if (!monitored(fixture, WINDOW_ORDER_FIELD_DESKTOP_ARC_COMPLETED))
+	{
+		fprintf(stderr, "ARC_COMPLETED handler failed\n");
+		return FALSE;
+	}
+	if (fixture->eventCount != ARRAYSIZE(expected) - 1U)
+	{
+		fprintf(stderr, "ARC_COMPLETED produced %" PRIuz " events, expected %" PRIuz "\n",
+		        fixture->eventCount, ARRAYSIZE(expected) - 1U);
+		for (size_t x = 0; x < fixture->eventCount; x++)
+			fprintf(stderr, "event %" PRIuz ": '%s'\n", x, fixture->events[x]);
+		return FALSE;
+	}
+	if (!freerdp_client_rail_ipc_get_event(fixture->ipc))
+	{
+		fprintf(stderr, "FIFO event hidden after ARC_COMPLETED\n");
+		return FALSE;
+	}
+	return freerdp_client_rail_ipc_check_event(fixture->ipc) &&
+	       expect_events(fixture, expected, ARRAYSIZE(expected));
+}
+
+static BOOL test_empty_program_starts_from_fifo(testFixture* fixture)
+{
+	BOOL rc = FALSE;
+	char program[TEST_EVENT_LENGTH] = WINPR_C_ARRAY_INIT;
+	static const char queuedProgram[] = "queued-while-program-empty.exe";
+	static const char* const expected[] = { "client-information", "system-parameters", "work-area",
+		                                    "execute:queued-while-program-empty.exe" };
+	const char* configured =
+	    freerdp_settings_get_string(fixture->context->settings, FreeRDP_RemoteApplicationProgram);
+	if (!configured || (_snprintf(program, sizeof(program), "%s", configured) < 0))
+		return FALSE;
+	const size_t before = fixture->executeCount;
+	fixture->eventCount = 0;
+	fixture->xfc->railWorkArea.width = 1;
+	fixture->xfc->railWorkArea.height = 1;
+
+	if (!monitored(fixture, WINDOW_ORDER_FIELD_DESKTOP_ARC_BEGAN) ||
+	    !freerdp_settings_set_string(fixture->context->settings, FreeRDP_RemoteApplicationProgram,
+	                                 "") ||
+	    !write_record(fixture, queuedProgram))
+	{
+		fprintf(stderr, "could not prepare the empty-program FIFO launch\n");
+		goto out;
+	}
+	if (freerdp_client_rail_ipc_get_event(fixture->ipc) || (fixture->executeCount != before) ||
+	    (fixture->eventCount != 0))
+	{
+		fprintf(stderr, "FIFO input became ready before the empty-program preamble\n");
+		goto out;
+	}
+	if (!monitored(fixture, WINDOW_ORDER_FIELD_DESKTOP_ARC_COMPLETED))
+	{
+		fprintf(stderr, "empty-program ARC_COMPLETED handler failed\n");
+		goto out;
+	}
+	if (!freerdp_client_rail_ipc_get_event(fixture->ipc) ||
+	    (fixture->eventCount != ARRAYSIZE(expected) - 1U) || (fixture->executeCount != before))
+	{
+		fprintf(stderr,
+		        "empty-program preamble produced %" PRIuz " events and %" PRIuz " Executes\n",
+		        fixture->eventCount, fixture->executeCount - before);
+		for (size_t x = 0; x < fixture->eventCount; x++)
+			fprintf(stderr, "event %" PRIuz ": '%s'\n", x, fixture->events[x]);
+		goto out;
+	}
+	rc = freerdp_client_rail_ipc_check_event(fixture->ipc) &&
+	     (fixture->executeCount == before + 1U) &&
+	     (strcmp(fixture->lastProgram, queuedProgram) == 0) &&
+	     expect_events(fixture, expected, ARRAYSIZE(expected));
+
+out:
+	return freerdp_settings_set_string(fixture->context->settings, FreeRDP_RemoteApplicationProgram,
+	                                   program) &&
+	       rc;
+}
+
+static BOOL test_suspend_edge(testFixture* fixture, UINT32 flags, BOOL useNonMonitored,
+                              const char* program)
+{
+	char startupEvent[TEST_EVENT_LENGTH] = WINPR_C_ARRAY_INIT;
+	char queuedEvent[TEST_EVENT_LENGTH] = WINPR_C_ARRAY_INIT;
+	const char* startupProgram =
+	    freerdp_settings_get_string(fixture->context->settings, FreeRDP_RemoteApplicationProgram);
+	if (!startupProgram ||
+	    (_snprintf(startupEvent, sizeof(startupEvent), "execute:%s", startupProgram) < 0) ||
+	    (_snprintf(queuedEvent, sizeof(queuedEvent), "execute:%s", program) < 0))
+		return FALSE;
+	const char* const expected[] = { "client-information", "system-parameters", startupEvent,
+		                             queuedEvent };
+	const size_t before = fixture->executeCount;
+	fixture->eventCount = 0;
+	if (!write_record(fixture, program))
+		return FALSE;
+	const HANDLE observed = freerdp_client_rail_ipc_get_event(fixture->ipc);
+	if (!observed || (WaitForSingleObject(observed, 1000) != WAIT_OBJECT_0))
+		return FALSE;
+	if (useNonMonitored ? !non_monitored(fixture) : !monitored(fixture, flags))
+		return FALSE;
+	if (!freerdp_client_rail_ipc_check_event(fixture->ipc))
+		return FALSE;
+	if (freerdp_client_rail_ipc_get_event(fixture->ipc) || (fixture->executeCount != before) ||
+	    (fixture->eventCount != 0))
+		return FALSE;
+	if (!monitored(fixture, WINDOW_ORDER_FIELD_DESKTOP_ARC_COMPLETED) ||
+	    !freerdp_client_rail_ipc_get_event(fixture->ipc) ||
+	    (fixture->eventCount != ARRAYSIZE(expected) - 1U) || (fixture->executeCount != before + 1U))
+		return FALSE;
+	return freerdp_client_rail_ipc_check_event(fixture->ipc) &&
+	       (fixture->executeCount == before + 2U) && (strcmp(fixture->lastProgram, program) == 0) &&
+	       expect_events(fixture, expected, ARRAYSIZE(expected));
+}
+
+static BOOL test_local_and_server_failures(testFixture* fixture)
+{
+	const size_t before = fixture->executeCount;
+	fixture->executeStatus = ERROR_INTERNAL_ERROR;
+	if (!write_record(fixture, "local-failure.exe"))
+		return FALSE;
+	if (!freerdp_client_rail_ipc_check_event(fixture->ipc))
+		return FALSE;
+	if ((fixture->executeCount != before + 1U) ||
+	    freerdp_shall_disconnect_context(fixture->context))
+		return FALSE;
+	fixture->executeStatus = CHANNEL_RC_OK;
+	if (!write_record(fixture, "after-local-failure.exe"))
+		return FALSE;
+	if (!freerdp_client_rail_ipc_check_event(fixture->ipc))
+		return FALSE;
+	if ((fixture->executeCount != before + 2U) ||
+	    (strcmp(fixture->lastProgram, "after-local-failure.exe") != 0))
+		return FALSE;
+	if (!post_result(fixture, RAIL_EXEC_S_OK) || !post_result(fixture, RAIL_EXEC_E_FILE_NOT_FOUND))
+		return FALSE;
+	return !freerdp_shall_disconnect_context(fixture->context);
+}
+
+static BOOL test_channel_teardown_wins(testFixture* fixture)
+{
+	const size_t before = fixture->executeCount;
+	if (!write_record(fixture, "queued-before-detach.exe"))
+		return FALSE;
+	const HANDLE observed = freerdp_client_rail_ipc_get_event(fixture->ipc);
+	if (!observed || (WaitForSingleObject(observed, 1000) != WAIT_OBJECT_0) ||
+	    (xf_rail_uninit(fixture->xfc, &fixture->rail) != 1))
+		return FALSE;
+	fixture->railInitialized = FALSE;
+	return freerdp_client_rail_ipc_check_event(fixture->ipc) &&
+	       !freerdp_client_rail_ipc_get_event(fixture->ipc) && (fixture->executeCount == before);
+}
+
+static BOOL test_x11_failure_callers(void)
+{
+	BOOL rc = FALSE;
+	testFixture fixture = WINPR_C_ARRAY_INIT;
+	RailClientContext other = WINPR_C_ARRAY_INIT;
+	RailClientContext blocker = WINPR_C_ARRAY_INIT;
+
+	if (!fixture_init(&fixture))
+		return FALSE;
+
+	const size_t before = fixture.executeCount;
+	if (!freerdp_client_rail_ipc_detach(fixture.ipc, &fixture.rail) ||
+	    !monitored(&fixture, WINDOW_ORDER_FIELD_DESKTOP_ARC_COMPLETED) ||
+	    (fixture.executeCount != before + 1U) || freerdp_client_rail_ipc_get_event(fixture.ipc) ||
+	    !freerdp_client_rail_ipc_attach(fixture.ipc, &fixture.rail) ||
+	    !freerdp_client_rail_ipc_set_ready(fixture.ipc, TRUE))
+		goto out;
+
+	if ((xf_rail_uninit(fixture.xfc, &other) != 1) || fixture.xfc->rail || fixture.rail.custom ||
+	    fixture.xfc->railWindows || fixture.xfc->railIconCache)
+		goto out;
+	fixture.railInitialized = FALSE;
+	if (!freerdp_client_rail_ipc_detach(fixture.ipc, &fixture.rail) ||
+	    !freerdp_client_rail_ipc_attach(fixture.ipc, &blocker))
+		goto out;
+
+	if ((xf_rail_init(fixture.xfc, &fixture.rail) != 0) || fixture.xfc->rail ||
+	    fixture.rail.custom || freerdp_client_rail_ipc_get_event(fixture.ipc) ||
+	    !freerdp_client_rail_ipc_detach(fixture.ipc, &blocker))
+		goto out;
+	rc = TRUE;
+
+out:
+	fixture_free(&fixture);
+	return rc;
+}
+
+static BOOL test_execute_result_policy(void)
+{
+	BOOL rc = FALSE;
+	testFixture fixture = WINPR_C_ARRAY_INIT;
+	if (!fixture_init(&fixture))
+		return FALSE;
+	fixture.xfc->railMultiExec = FALSE;
+	if (!post_result(&fixture, RAIL_EXEC_E_FILE_NOT_FOUND) ||
+	    !freerdp_shall_disconnect_context(fixture.context))
+		goto out;
+	fixture_free(&fixture);
+
+	if (!fixture_init(&fixture) || !monitored(&fixture, WINDOW_ORDER_FIELD_DESKTOP_ARC_COMPLETED))
+		goto out;
+	const size_t before = fixture.executeCount;
+	if (!post_result(&fixture, RAIL_EXEC_E_FILE_NOT_FOUND) ||
+	    freerdp_shall_disconnect_context(fixture.context) ||
+	    !write_record(&fixture, "after-server-failure.exe") ||
+	    !freerdp_client_rail_ipc_check_event(fixture.ipc) ||
+	    (fixture.executeCount != before + 1U) ||
+	    (strcmp(fixture.lastProgram, "after-server-failure.exe") != 0))
+		goto out;
+	fixture_free(&fixture);
+
+	if (!fixture_init(&fixture) || !post_result(&fixture, RAIL_EXEC_S_OK) ||
+	    freerdp_shall_disconnect_context(fixture.context) ||
+	    !post_result(&fixture, RAIL_EXEC_E_FILE_NOT_FOUND) ||
+	    freerdp_shall_disconnect_context(fixture.context))
+		goto out;
+	rc = TRUE;
+
+out:
+	fixture_free(&fixture);
+	return rc;
+}
+
+int main(int argc, char* argv[])
+{
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+	int rc = 1;
+	char directory[] = "/tmp/xfi.XXXXXX";
+	BOOL directoryCreated = FALSE;
+	testFixture fixture = WINPR_C_ARRAY_INIT;
+
+	if (!mkdtemp(directory))
+		goto out;
+	directoryCreated = TRUE;
+	if ((chmod(directory, S_IRWXU) < 0) || !SetEnvironmentVariableA("XDG_RUNTIME_DIR", directory) ||
+	    !fixture_init(&fixture))
+		goto out;
+	if (!test_preamble_before_fifo(&fixture))
+	{
+		fprintf(stderr, "preamble/readiness integration failed\n");
+		goto out;
+	}
+	printf("PASS ARC_COMPLETED completed the preamble and original EXEC before FIFO dispatch\n");
+	if (!test_empty_program_starts_from_fifo(&fixture))
+	{
+		fprintf(stderr, "empty-program readiness integration failed\n");
+		goto out;
+	}
+	printf("PASS an empty program sent the preamble and accepted the first FIFO launch\n");
+
+	if (!test_suspend_edge(&fixture, WINDOW_ORDER_FIELD_DESKTOP_ARC_BEGAN, FALSE,
+	                       "queued-during-arc-began.exe") ||
+	    !test_suspend_edge(&fixture, WINDOW_ORDER_FIELD_DESKTOP_HOOKED, FALSE,
+	                       "queued-during-hooked.exe") ||
+	    !test_suspend_edge(&fixture, 0, TRUE, "queued-during-non-monitored.exe"))
+	{
+		fprintf(stderr, "readiness-loss integration failed\n");
+		goto out;
+	}
+	printf("PASS every desktop readiness-loss edge stopped FIFO draining until ARC_COMPLETED\n");
+
+	if (!test_local_and_server_failures(&fixture))
+	{
+		fprintf(stderr, "failure-policy integration failed\n");
+		goto out;
+	}
+	printf("PASS local FIFO failure and a later server rejection preserved the session\n");
+
+	if (!test_channel_teardown_wins(&fixture))
+	{
+		fprintf(stderr, "channel-detach integration failed\n");
+		goto out;
+	}
+	printf("PASS a channel transition after wake prevented stale FIFO dispatch\n");
+	fixture_free(&fixture);
+	if (!test_x11_failure_callers())
+	{
+		fprintf(stderr, "X11 IPC failure handling failed\n");
+		goto out;
+	}
+	printf("PASS X11 contains readiness and detach failures and rolls back attach failure\n");
+	if (!test_execute_result_policy())
+	{
+		fprintf(stderr, "mode-based Execute failure policy failed\n");
+		goto out;
+	}
+	printf("PASS Execute failures are fatal only outside multi-exec mode\n");
+	rc = 0;
+
+out:
+	fixture_free(&fixture);
+	(void)SetEnvironmentVariableA("XDG_RUNTIME_DIR", nullptr);
+	if (!remove_lock_file(fixture.lockPath))
+		rc = 1;
+	if (directoryCreated && (rmdir(directory) < 0))
+	{
+		fprintf(stderr, "could not remove test directory '%s': %s\n", directory, strerror(errno));
+		rc = 1;
+	}
+	return rc;
+}

--- a/client/X11/xf_client.c
+++ b/client/X11/xf_client.c
@@ -1590,7 +1590,6 @@ static DWORD WINAPI xf_client_thread(LPVOID param)
 	freerdp* instance = (freerdp*)param;
 	WINPR_ASSERT(instance);
 
-	const BOOL status = freerdp_connect(instance);
 	rdpContext* context = instance->context;
 	WINPR_ASSERT(context);
 	xfContext* xfc = (xfContext*)instance->context;
@@ -1598,6 +1597,22 @@ static DWORD WINAPI xf_client_thread(LPVOID param)
 
 	rdpSettings* settings = context->settings;
 	WINPR_ASSERT(settings);
+	BOOL status = FALSE;
+
+	if (xfc->railMultiExec && freerdp_settings_get_bool(settings, FreeRDP_RemoteApplicationMode) &&
+	    !freerdp_settings_get_bool(settings, FreeRDP_AuthenticationOnly))
+	{
+		/* Execute failures are nonfatal in this mode, so a connected session must always
+		 * retain the FIFO as a working submission path. */
+		xfc->railIpc = freerdp_client_rail_ipc_new(settings, xfc->log);
+		if (!xfc->railIpc)
+		{
+			exit_code = XF_EXIT_PRE_CONNECT_FAILED;
+			goto end;
+		}
+	}
+
+	status = freerdp_connect(instance);
 
 	if (!status)
 	{
@@ -1637,6 +1652,10 @@ static DWORD WINAPI xf_client_thread(LPVOID param)
 		HANDLE handles[MAXIMUM_WAIT_OBJECTS] = WINPR_C_ARRAY_INIT;
 		DWORD nCount = 0;
 		handles[nCount++] = inputEvent;
+
+		const HANDLE railIpcEvent = freerdp_client_rail_ipc_get_event(xfc->railIpc);
+		if (railIpcEvent)
+			handles[nCount++] = railIpcEvent;
 
 		/*
 		 * win8 and server 2k12 seem to have some timing issue/race condition
@@ -1694,6 +1713,9 @@ static DWORD WINAPI xf_client_thread(LPVOID param)
 			}
 		}
 
+		if (!freerdp_client_rail_ipc_check_event(xfc->railIpc))
+			WLog_Print(xfc->log, WLOG_ERROR, "RAIL IPC failed to process launch input");
+
 		if (!handle_window_events(instance))
 			break;
 	}
@@ -1716,6 +1738,8 @@ disconnect:
 
 	freerdp_disconnect(instance);
 end:
+	freerdp_client_rail_ipc_free(xfc->railIpc);
+	xfc->railIpc = nullptr;
 	ExitThread(exit_code);
 	return exit_code;
 }

--- a/client/X11/xf_cmdline.c
+++ b/client/X11/xf_cmdline.c
@@ -1,0 +1,55 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * X11 client-specific command-line options
+ *
+ * Copyright 2026 Tony Dursun <oraturk75@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <winpr/assert.h>
+#include <winpr/crt.h>
+
+#include "xf_cmdline.h"
+#include "xfreerdp.h"
+
+static const char xfreerdp_rail_multi_exec[] = "rail-multi-exec";
+
+static COMMAND_LINE_ARGUMENT_A xfreerdp_cmd_args[] = {
+	{ xfreerdp_rail_multi_exec, COMMAND_LINE_VALUE_BOOL, nullptr, BoolValueFalse, nullptr, -1,
+	  nullptr, "a primary-side FIFO for launching additional RemoteApps on this connection" },
+	{ nullptr, 0, nullptr, nullptr, nullptr, -1, nullptr, nullptr }
+};
+
+COMMAND_LINE_ARGUMENT_A* xf_command_line_arguments(size_t* count)
+{
+	WINPR_ASSERT(count);
+	*count = ARRAYSIZE(xfreerdp_cmd_args) - 1U;
+	return xfreerdp_cmd_args;
+}
+
+int xf_command_line_handle_option(const COMMAND_LINE_ARGUMENT_A* arg, void* userData)
+{
+	xfContext* xfc = userData;
+
+	WINPR_ASSERT(arg);
+	WINPR_ASSERT(xfc);
+
+	if (arg->Name && (strcmp(arg->Name, xfreerdp_rail_multi_exec) == 0))
+	{
+		xfc->railMultiExec = arg->Value != nullptr;
+		return 0;
+	}
+
+	return 0;
+}

--- a/client/X11/xf_cmdline.h
+++ b/client/X11/xf_cmdline.h
@@ -1,0 +1,28 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * X11 client-specific command-line options
+ *
+ * Copyright 2026 Tony Dursun <oraturk75@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CLIENT_X11_XF_CMDLINE_H
+#define FREERDP_CLIENT_X11_XF_CMDLINE_H
+
+#include <winpr/cmdline.h>
+
+COMMAND_LINE_ARGUMENT_A* xf_command_line_arguments(size_t* count);
+int xf_command_line_handle_option(const COMMAND_LINE_ARGUMENT_A* arg, void* userData);
+
+#endif /* FREERDP_CLIENT_X11_XF_CMDLINE_H */

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -1049,6 +1049,10 @@ xf_rail_monitored_desktop(WINPR_ATTR_UNUSED rdpContext* context,
 		WLog_Print(xfc->log, WLOG_WARN, "WINDOW_ORDER_TYPE_DESKTOP flag missing!");
 		return FALSE;
 	}
+	if ((orderInfo->fieldFlags &
+	     (WINDOW_ORDER_FIELD_DESKTOP_ARC_BEGAN | WINDOW_ORDER_FIELD_DESKTOP_HOOKED)) &&
+	    !freerdp_client_rail_ipc_set_ready(xfc->railIpc, FALSE))
+		WLog_Print(xfc->log, WLOG_ERROR, "RAIL IPC failed to revoke launch readiness");
 
 	if ((orderInfo->fieldFlags & WINDOW_ORDER_FIELD_DESKTOP_ARC_BEGAN) &&
 	    (orderInfo->fieldFlags & WINDOW_ORDER_FIELD_DESKTOP_HOOKED))
@@ -1072,15 +1076,13 @@ xf_rail_monitored_desktop(WINPR_ATTR_UNUSED rdpContext* context,
 		if (!xf_rail_select_workarea_events(xfc))
 			return FALSE;
 
-		const char* app =
-		    freerdp_settings_get_string(context->settings, FreeRDP_RemoteApplicationProgram);
-		if ((app != nullptr) && (strnlen(app, 1) > 0))
-		{
-			if (client_rail_server_start_cmd(xfc->rail) != CHANNEL_RC_OK)
-				return FALSE;
-			if (xf_rail_send_workarea(xfc) != CHANNEL_RC_OK)
-				return FALSE;
-		}
+		if (client_rail_server_start_cmd(xfc->rail) != CHANNEL_RC_OK)
+			return FALSE;
+		if (xf_rail_send_workarea(xfc) != CHANNEL_RC_OK)
+			return FALSE;
+
+		if (!freerdp_client_rail_ipc_set_ready(xfc->railIpc, TRUE))
+			WLog_Print(xfc->log, WLOG_ERROR, "RAIL IPC failed to grant launch readiness");
 	}
 	if (orderInfo->fieldFlags & WINDOW_ORDER_FIELD_DESKTOP_ACTIVE_WND)
 	{
@@ -1112,6 +1114,8 @@ static BOOL xf_rail_non_monitored_desktop(rdpContext* context,
 		WLog_Print(xfc->log, WLOG_WARN, "TODO: implement WINDOW_ORDER_TYPE_DESKTOP");
 		return FALSE;
 	}
+	if (!freerdp_client_rail_ipc_set_ready(xfc->railIpc, FALSE))
+		WLog_Print(xfc->log, WLOG_ERROR, "RAIL IPC failed to revoke launch readiness");
 	if (orderInfo->fieldFlags & WINDOW_ORDER_FIELD_DESKTOP_NONE)
 	{
 		WLog_Print(xfc->log, WLOG_WARN, "TODO: implement WINDOW_ORDER_FIELD_DESKTOP_NONE");
@@ -1401,6 +1405,13 @@ int xf_rail_init(xfContext* xfc, RailClientContext* rail)
 	xfc->rail = rail;
 	xf_rail_register_update_callbacks(context->update);
 	rail->custom = (void*)xfc;
+	if (!freerdp_client_rail_ipc_attach(xfc->railIpc, rail))
+	{
+		WLog_Print(xfc->log, WLOG_ERROR, "RAIL IPC failed to attach the RAIL channel");
+		rail->custom = nullptr;
+		xfc->rail = nullptr;
+		return 0;
+	}
 	rail->ServerExecuteResult = xf_rail_server_execute_result;
 	rail->ServerSystemParam = xf_rail_server_system_param;
 	rail->ServerLocalMoveSize = xf_rail_server_local_move_size;
@@ -1436,10 +1447,10 @@ fail:
 
 int xf_rail_uninit(xfContext* xfc, RailClientContext* rail)
 {
-	WINPR_UNUSED(rail);
-
 	if (xfc->rail)
 	{
+		if (!freerdp_client_rail_ipc_detach(xfc->railIpc, rail))
+			WLog_Print(xfc->log, WLOG_ERROR, "RAIL IPC failed to detach the RAIL channel");
 		xfc->rail->custom = nullptr;
 		xfc->rail = nullptr;
 	}

--- a/client/X11/xf_rail.c
+++ b/client/X11/xf_rail.c
@@ -1159,13 +1159,14 @@ static UINT xf_rail_server_execute_result(RailClientContext* context,
 
 	xfContext* xfc = (xfContext*)context->custom;
 	WINPR_ASSERT(xfc);
-
 	if (execResult->execResult != RAIL_EXEC_S_OK)
 	{
 		WLog_Print(
 		    xfc->log, WLOG_ERROR, "RAIL exec error: execResult=%s [0x%08" PRIx32 "] NtError=0x%X\n",
 		    error_code2str(execResult->execResult), execResult->execResult, execResult->rawResult);
-		freerdp_abort_connect_context(&xfc->common.context);
+
+		if (!xfc->railMultiExec)
+			freerdp_abort_connect_context(&xfc->common.context);
 	}
 
 	return CHANNEL_RC_OK;

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -288,6 +288,7 @@ struct xf_context
 	xfDispContext* xfDisp;
 
 	RailClientContext* rail;
+	BOOL railMultiExec;
 	wHashTable* railWindows;
 	xfRailIconCache* railIconCache;
 

--- a/client/X11/xfreerdp.h
+++ b/client/X11/xfreerdp.h
@@ -59,6 +59,7 @@
 #include <freerdp/codec/region.h>
 #include <freerdp/locale/keyboard.h>
 #include <freerdp/client.h>
+#include <freerdp/client/rail_ipc.h>
 
 #if !defined(XcursorUInt)
 typedef unsigned int XcursorUInt;
@@ -288,6 +289,7 @@ struct xf_context
 	xfDispContext* xfDisp;
 
 	RailClientContext* rail;
+	RailClientIpcContext* railIpc;
 	BOOL railMultiExec;
 	wHashTable* railWindows;
 	xfRailIconCache* railIconCache;

--- a/client/common/CMakeLists.txt
+++ b/client/common/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SRCS
     file.c
     client_cliprdr_file.c
     geometry.c
+    rail_ipc.c
     smartcard_cli.c
 )
 

--- a/client/common/rail_ipc.c
+++ b/client/common/rail_ipc.c
@@ -1,0 +1,1190 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Common RAIL launch IPC
+ *
+ * Copyright 2026 Tony Dursun <oraturk75@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <freerdp/config.h>
+#include <freerdp/client/rail_ipc.h>
+
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if !defined(_WIN32)
+#include <fcntl.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#include <winpr/assert.h>
+#include <winpr/cast.h>
+#include <winpr/crt.h>
+#include <winpr/custom-crypto.h>
+#include <winpr/environment.h>
+#include <winpr/print.h>
+#include <winpr/string.h>
+#include <winpr/thread.h>
+
+#define RAIL_IPC_HASH_VERSION 2U
+#define RAIL_IPC_NAME_PREFIX "freerdp-rail-v1-"
+#define RAIL_IPC_NAME_CAPACITY 96U
+#define RAIL_IPC_MAX_RECORDS_PER_PASS 16U
+#define RAIL_IPC_READ_BUFFER_SIZE RAIL_IPC_MAX_RECORDS_PER_PASS
+#define RAIL_IPC_MAX_BYTES_PER_PASS (64U * 1024U)
+#define RAIL_IPC_KNOWN_EXEC_FLAGS                                                    \
+	(TS_RAIL_EXEC_FLAG_EXPAND_WORKINGDIRECTORY | TS_RAIL_EXEC_FLAG_TRANSLATE_FILES | \
+	 TS_RAIL_EXEC_FLAG_FILE | TS_RAIL_EXEC_FLAG_EXPAND_ARGUMENTS |                   \
+	 TS_RAIL_EXEC_FLAG_APP_USER_MODEL_ID)
+
+struct s_rail_client_ipc
+{
+	wLog* log;
+	DWORD ownerThreadId;
+	char* path;
+	RailClientContext* rail;
+	BOOL ready;
+	BOOL enabled;
+#if !defined(_WIN32)
+	int runtimeDirectoryFd;
+	int lockFd;
+	int readFd;
+	int heldWriteFd;
+	HANDLE readEvent;
+	char fifoName[RAIL_IPC_NAME_CAPACITY];
+	char lockName[RAIL_IPC_NAME_CAPACITY];
+	dev_t fifoDevice;
+	ino_t fifoInode;
+	uid_t fifoOwner;
+	BOOL fifoIdentityValid;
+	size_t pipeBuffer;
+	char* record;
+	size_t recordBytes;
+	BOOL atLineStart;
+	BOOL recordInvalid;
+	const char* recordError;
+#endif
+};
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_is_owner_thread(const RailClientIpcContext* ipc)
+{
+	WINPR_ASSERT(ipc);
+	return ipc->ownerThreadId == GetCurrentThreadId();
+}
+
+/* The component has no internal locking; every lifecycle entry point runs on its owner thread. */
+static void rail_ipc_assert_owner_thread(const RailClientIpcContext* ipc)
+{
+	WINPR_ASSERT(rail_ipc_is_owner_thread(ipc));
+}
+
+static void rail_ipc_write_uint32_be(BYTE data[4], UINT32 value)
+{
+	data[0] = WINPR_ASSERTING_INT_CAST(BYTE, (value >> 24U) & UINT32_C(0xFF));
+	data[1] = WINPR_ASSERTING_INT_CAST(BYTE, (value >> 16U) & UINT32_C(0xFF));
+	data[2] = WINPR_ASSERTING_INT_CAST(BYTE, (value >> 8U) & UINT32_C(0xFF));
+	data[3] = WINPR_ASSERTING_INT_CAST(BYTE, value & UINT32_C(0xFF));
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_digest_field(WINPR_DIGEST_CTX* digest, const void* data, size_t length)
+{
+	BYTE encodedLength[4] = WINPR_C_ARRAY_INIT;
+
+	if (length > UINT32_MAX)
+		return FALSE;
+
+	rail_ipc_write_uint32_be(encodedLength, WINPR_ASSERTING_INT_CAST(UINT32, length));
+	if (!winpr_Digest_Update(digest, encodedLength, sizeof(encodedLength)))
+		return FALSE;
+
+	return (length == 0) || winpr_Digest_Update(digest, data, length);
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_digest_string(WINPR_DIGEST_CTX* digest, const char* value)
+{
+	if (!value)
+		return rail_ipc_digest_field(digest, nullptr, 0);
+	return rail_ipc_digest_field(digest, value, strlen(value));
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_digest_ascii_ci_n(WINPR_DIGEST_CTX* digest, const char* value, size_t length,
+                                       BOOL stripTrailingDot)
+{
+	char* canonical = nullptr;
+	BOOL rc = FALSE;
+
+	if (!value)
+		return rail_ipc_digest_field(digest, nullptr, 0);
+	while (stripTrailingDot && (length > 0) && (value[length - 1U] == '.'))
+		length--;
+	canonical = strndup(value, length);
+	if (!canonical)
+		return FALSE;
+	for (size_t x = 0; x < length; x++)
+	{
+		if ((canonical[x] >= 'A') && (canonical[x] <= 'Z'))
+			canonical[x] = (char)(canonical[x] + ('a' - 'A'));
+	}
+	rc = rail_ipc_digest_field(digest, canonical, length);
+	free(canonical);
+	return rc;
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_digest_ascii_ci(WINPR_DIGEST_CTX* digest, const char* value,
+                                     BOOL stripTrailingDot)
+{
+	return rail_ipc_digest_ascii_ci_n(digest, value, value ? strlen(value) : 0, stripTrailingDot);
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_digest_uint32(WINPR_DIGEST_CTX* digest, UINT32 value)
+{
+	BYTE encoded[4] = WINPR_C_ARRAY_INIT;
+	rail_ipc_write_uint32_be(encoded, value);
+	return rail_ipc_digest_field(digest, encoded, sizeof(encoded));
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_digest_bool(WINPR_DIGEST_CTX* digest, BOOL value)
+{
+	const BYTE encoded = value ? 1 : 0;
+	return rail_ipc_digest_field(digest, &encoded, sizeof(encoded));
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_digest_gateway_url(WINPR_DIGEST_CTX* digest, const char* url)
+{
+	const char* host = nullptr;
+	const char* cursor = nullptr;
+	const char* path = nullptr;
+	UINT32 port = 443;
+
+	if (!url)
+		return rail_ipc_digest_bool(digest, FALSE) && rail_ipc_digest_string(digest, nullptr);
+	if (strncmp(url, "wss://", 6) == 0)
+		host = url + 6;
+	else if (strncmp(url, "https://", 8) == 0)
+		host = url + 8;
+	else
+		goto invalid;
+
+	cursor = host;
+	while ((*cursor != '\0') && (*cursor != ':') && (*cursor != '/'))
+		cursor++;
+	if (cursor == host)
+		goto invalid;
+	const size_t hostLength = WINPR_ASSERTING_INT_CAST(size_t, cursor - host);
+	if (*cursor == ':')
+	{
+		char encodedPort[6] = WINPR_C_ARRAY_INIT;
+		char* end = nullptr;
+		const char* portStart = ++cursor;
+		while ((*cursor != '\0') && (*cursor != '/'))
+			cursor++;
+		const size_t portLength = WINPR_ASSERTING_INT_CAST(size_t, cursor - portStart);
+		if ((portLength == 0) || (portLength >= sizeof(encodedPort)))
+			goto invalid;
+		CopyMemory(encodedPort, portStart, portLength);
+		const unsigned long parsed = strtoul(encodedPort, &end, 10);
+		if (!end || (*end != '\0') || (parsed == 0) || (parsed > UINT16_MAX))
+			goto invalid;
+		port = WINPR_ASSERTING_INT_CAST(UINT32, parsed);
+	}
+	path = cursor;
+	return rail_ipc_digest_bool(digest, TRUE) &&
+	       rail_ipc_digest_ascii_ci_n(digest, host, hostLength, TRUE) &&
+	       rail_ipc_digest_uint32(digest, port) && rail_ipc_digest_string(digest, path);
+
+invalid:
+	return rail_ipc_digest_bool(digest, FALSE) && rail_ipc_digest_string(digest, url);
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_digest_reconnect_cookie(WINPR_DIGEST_CTX* digest,
+                                             const ARC_SC_PRIVATE_PACKET* cookie)
+{
+	if (!rail_ipc_digest_bool(digest, cookie != nullptr))
+		return FALSE;
+	if (!cookie)
+		return TRUE;
+	return rail_ipc_digest_uint32(digest, cookie->cbLen) &&
+	       rail_ipc_digest_uint32(digest, cookie->version) &&
+	       rail_ipc_digest_uint32(digest, cookie->logonId) &&
+	       rail_ipc_digest_field(digest, cookie->arcRandomBits, sizeof(cookie->arcRandomBits));
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_build_hash(const rdpSettings* settings, BYTE hash[WINPR_SHA256_DIGEST_LENGTH])
+{
+	BOOL rc = FALSE;
+	const BYTE version = RAIL_IPC_HASH_VERSION;
+	WINPR_DIGEST_CTX* digest = nullptr;
+
+	WINPR_ASSERT(settings);
+	WINPR_ASSERT(hash);
+
+	digest = winpr_Digest_New();
+	if (!digest)
+		return FALSE;
+
+	const BOOL gatewayEnabled = freerdp_settings_get_bool(settings, FreeRDP_GatewayEnabled);
+	const BOOL armGateway =
+	    gatewayEnabled && freerdp_settings_get_bool(settings, FreeRDP_GatewayArmTransport);
+	const BOOL sendPreconnection =
+	    freerdp_settings_get_bool(settings, FreeRDP_SendPreconnectionPdu);
+	const UINT32 loadBalanceLength =
+	    freerdp_settings_get_uint32(settings, FreeRDP_LoadBalanceInfoLength);
+	const void* loadBalance = freerdp_settings_get_pointer(settings, FreeRDP_LoadBalanceInfo);
+	const ARC_SC_PRIVATE_PACKET* reconnectCookie =
+	    freerdp_settings_get_pointer(settings, FreeRDP_ServerAutoReconnectCookie);
+
+	if (!winpr_Digest_Init(digest, WINPR_MD_SHA256) ||
+	    !winpr_Digest_Update(digest, &version, sizeof(version)) ||
+	    !rail_ipc_digest_ascii_ci(
+	        digest, freerdp_settings_get_string(settings, FreeRDP_ServerHostname), TRUE) ||
+	    !rail_ipc_digest_uint32(digest,
+	                            freerdp_settings_get_uint32(settings, FreeRDP_ServerPort)) ||
+	    !rail_ipc_digest_string(digest, freerdp_settings_get_string(settings, FreeRDP_Username)) ||
+	    !rail_ipc_digest_string(digest, freerdp_settings_get_string(settings, FreeRDP_Domain)) ||
+	    !rail_ipc_digest_bool(digest,
+	                          freerdp_settings_get_bool(settings, FreeRDP_ConsoleSession)) ||
+	    !rail_ipc_digest_uint32(
+	        digest, freerdp_settings_get_uint32(settings, FreeRDP_RedirectedSessionId)) ||
+	    !rail_ipc_digest_bool(digest, freerdp_settings_get_bool(settings, FreeRDP_VmConnectMode)) ||
+	    !rail_ipc_digest_bool(digest,
+	                          freerdp_settings_get_bool(settings, FreeRDP_ConnectChildSession)) ||
+	    !rail_ipc_digest_bool(digest, sendPreconnection) ||
+	    (sendPreconnection &&
+	     (!rail_ipc_digest_uint32(digest,
+	                              freerdp_settings_get_uint32(settings, FreeRDP_PreconnectionId)) ||
+	      !rail_ipc_digest_string(
+	          digest, freerdp_settings_get_string(settings, FreeRDP_PreconnectionBlob)))) ||
+	    ((loadBalanceLength > 0) && !loadBalance) ||
+	    !rail_ipc_digest_field(digest, loadBalance, loadBalanceLength) ||
+	    !rail_ipc_digest_reconnect_cookie(digest, reconnectCookie) ||
+	    !rail_ipc_digest_bool(digest, gatewayEnabled) ||
+	    (gatewayEnabled &&
+	     (!rail_ipc_digest_uint32(digest, freerdp_get_gateway_usage_method(settings)) ||
+	      !rail_ipc_digest_ascii_ci(
+	          digest, freerdp_settings_get_string(settings, FreeRDP_GatewayHostname), TRUE) ||
+	      !rail_ipc_digest_uint32(digest,
+	                              freerdp_settings_get_uint32(settings, FreeRDP_GatewayPort)) ||
+	      !rail_ipc_digest_string(digest,
+	                              freerdp_settings_get_string(settings, FreeRDP_GatewayUsername)) ||
+	      !rail_ipc_digest_string(digest,
+	                              freerdp_settings_get_string(settings, FreeRDP_GatewayDomain)) ||
+	      !rail_ipc_digest_gateway_url(digest,
+	                                   freerdp_settings_get_string(settings, FreeRDP_GatewayUrl)) ||
+	      !rail_ipc_digest_bool(digest, armGateway) ||
+	      (armGateway &&
+	       (!rail_ipc_digest_string(digest, freerdp_settings_get_string(
+	                                            settings, FreeRDP_GatewayAzureActiveDirectory)) ||
+	        !rail_ipc_digest_bool(
+	            digest, freerdp_settings_get_bool(settings, FreeRDP_GatewayAvdUseTenantid)) ||
+	        (freerdp_settings_get_bool(settings, FreeRDP_GatewayAvdUseTenantid) &&
+	         !rail_ipc_digest_string(
+	             digest, freerdp_settings_get_string(settings, FreeRDP_GatewayAvdAadtenantid))) ||
+	        !rail_ipc_digest_string(digest, freerdp_settings_get_string(
+	                                            settings, FreeRDP_RemoteApplicationProgram)))))))
+		goto out;
+
+	rc = winpr_Digest_Final(digest, hash, WINPR_SHA256_DIGEST_LENGTH);
+
+out:
+	winpr_Digest_Free(digest);
+	return rc;
+}
+
+#if !defined(_WIN32)
+
+static void rail_ipc_log_errno(const RailClientIpcContext* ipc, DWORD level, const char* operation,
+                               int error)
+{
+	WINPR_ASSERT(ipc);
+	WINPR_ASSERT(operation);
+	WLog_Print(ipc->log, level, "RAIL IPC %s failed: %s [%d]", operation, strerror(error), error);
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_same_identity(const struct stat* left, const struct stat* right)
+{
+	WINPR_ASSERT(left);
+	WINPR_ASSERT(right);
+	return (left->st_dev == right->st_dev) && (left->st_ino == right->st_ino) &&
+	       ((left->st_mode & S_IFMT) == (right->st_mode & S_IFMT)) &&
+	       (left->st_uid == right->st_uid);
+}
+
+WINPR_ATTR_NODISCARD
+static char* rail_ipc_get_runtime_directory(void)
+{
+	const DWORD required = GetEnvironmentVariableA("XDG_RUNTIME_DIR", nullptr, 0);
+	if (required == 0)
+		return nullptr;
+
+	char* directory = calloc(required, 1);
+	if (!directory)
+		return nullptr;
+	if (GetEnvironmentVariableA("XDG_RUNTIME_DIR", directory, required) != required - 1U)
+	{
+		free(directory);
+		return nullptr;
+	}
+
+	size_t length = strlen(directory);
+	while ((length > 1U) && (directory[length - 1U] == '/'))
+		directory[--length] = '\0';
+	return directory;
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_build_names(RailClientIpcContext* ipc, const rdpSettings* settings,
+                                 const char* runtimeDirectory)
+{
+	BYTE hash[WINPR_SHA256_DIGEST_LENGTH] = WINPR_C_ARRAY_INIT;
+	char hex[WINPR_SHA256_DIGEST_LENGTH * 2U + 1U] = WINPR_C_ARRAY_INIT;
+
+	WINPR_ASSERT(ipc);
+	WINPR_ASSERT(settings);
+	WINPR_ASSERT(runtimeDirectory);
+
+	if (!rail_ipc_build_hash(settings, hash) ||
+	    (winpr_BinToHexStringBuffer(hash, sizeof(hash), hex, sizeof(hex), FALSE) !=
+	     sizeof(hash) * 2U))
+		return FALSE;
+
+	const int fifoLength =
+	    _snprintf(ipc->fifoName, sizeof(ipc->fifoName), RAIL_IPC_NAME_PREFIX "%s.fifo", hex);
+	const int lockLength =
+	    _snprintf(ipc->lockName, sizeof(ipc->lockName), RAIL_IPC_NAME_PREFIX "%s.lock", hex);
+	if ((fifoLength <= 0) || ((size_t)fifoLength >= sizeof(ipc->fifoName)) || (lockLength <= 0) ||
+	    ((size_t)lockLength >= sizeof(ipc->lockName)))
+		return FALSE;
+
+	const size_t directoryLength = strlen(runtimeDirectory);
+	const size_t nameLength = strlen(ipc->fifoName);
+	if (directoryLength > SIZE_MAX - nameLength - 2U)
+		return FALSE;
+	ipc->path = calloc(directoryLength + nameLength + 2U, 1);
+	if (!ipc->path)
+		return FALSE;
+
+	const int pathLength = _snprintf(ipc->path, directoryLength + nameLength + 2U, "%s/%s",
+	                                 runtimeDirectory, ipc->fifoName);
+	return (pathLength > 0) && ((size_t)pathLength == directoryLength + nameLength + 1U);
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_open_runtime_directory(RailClientIpcContext* ipc, const char* runtimeDirectory)
+{
+	WINPR_ASSERT(ipc);
+	WINPR_ASSERT(runtimeDirectory);
+
+	ipc->runtimeDirectoryFd =
+	    open(runtimeDirectory, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+	if (ipc->runtimeDirectoryFd < 0)
+	{
+		rail_ipc_log_errno(ipc, WLOG_ERROR, "opening XDG_RUNTIME_DIR", errno);
+		return FALSE;
+	}
+
+	struct stat attributes = WINPR_C_ARRAY_INIT;
+	if (fstat(ipc->runtimeDirectoryFd, &attributes) < 0)
+	{
+		rail_ipc_log_errno(ipc, WLOG_ERROR, "checking XDG_RUNTIME_DIR", errno);
+		return FALSE;
+	}
+	if (!S_ISDIR(attributes.st_mode) || (attributes.st_uid != getuid()) ||
+	    ((attributes.st_mode & (S_IRWXG | S_IRWXO)) != 0))
+	{
+		WLog_Print(ipc->log, WLOG_ERROR,
+		           "RAIL IPC rejected XDG_RUNTIME_DIR with unsafe type, owner, or permissions");
+		return FALSE;
+	}
+	return TRUE;
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_open_lock(RailClientIpcContext* ipc)
+{
+	WINPR_ASSERT(ipc);
+
+	BOOL created = FALSE;
+	ipc->lockFd = openat(ipc->runtimeDirectoryFd, ipc->lockName,
+	                     O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC | O_NOFOLLOW, S_IRUSR | S_IWUSR);
+	if (ipc->lockFd >= 0)
+		created = TRUE;
+	else if (errno == EEXIST)
+		ipc->lockFd =
+		    openat(ipc->runtimeDirectoryFd, ipc->lockName, O_RDWR | O_CLOEXEC | O_NOFOLLOW);
+	if (ipc->lockFd < 0)
+	{
+		rail_ipc_log_errno(ipc, WLOG_ERROR, "opening the ownership lock", errno);
+		return FALSE;
+	}
+
+	if (created && (fchmod(ipc->lockFd, S_IRUSR | S_IWUSR) < 0))
+	{
+		rail_ipc_log_errno(ipc, WLOG_ERROR, "setting ownership lock permissions", errno);
+		return FALSE;
+	}
+
+	struct stat descriptor = WINPR_C_ARRAY_INIT;
+	struct stat path = WINPR_C_ARRAY_INIT;
+	if ((fstat(ipc->lockFd, &descriptor) < 0) ||
+	    (fstatat(ipc->runtimeDirectoryFd, ipc->lockName, &path, AT_SYMLINK_NOFOLLOW) < 0))
+	{
+		rail_ipc_log_errno(ipc, WLOG_ERROR, "checking the ownership lock", errno);
+		return FALSE;
+	}
+	if (!S_ISREG(descriptor.st_mode) || (descriptor.st_uid != getuid()) ||
+	    ((descriptor.st_mode & (S_IRWXG | S_IRWXO)) != 0) ||
+	    ((descriptor.st_mode & (S_IRWXU)) != (S_IRUSR | S_IWUSR)) ||
+	    !rail_ipc_same_identity(&descriptor, &path))
+	{
+		WLog_Print(ipc->log, WLOG_ERROR,
+		           "RAIL IPC rejected the ownership lock with unsafe type, owner, permissions, or "
+		           "identity");
+		return FALSE;
+	}
+
+	for (;;)
+	{
+		if (flock(ipc->lockFd, LOCK_EX | LOCK_NB) == 0)
+			return TRUE;
+		const int error = errno;
+		if (error == EINTR)
+			continue;
+		if ((error == EWOULDBLOCK) || (error == EAGAIN))
+			WLog_Print(ipc->log, WLOG_ERROR,
+			           "RAIL IPC setup refused because another primary owns this session");
+		else
+			rail_ipc_log_errno(ipc, WLOG_ERROR, "locking primary ownership", error);
+		return FALSE;
+	}
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_validate_fifo(const RailClientIpcContext* ipc, const struct stat* attributes)
+{
+	WINPR_ASSERT(ipc);
+	WINPR_ASSERT(attributes);
+	return S_ISFIFO(attributes->st_mode) && (attributes->st_uid == getuid()) &&
+	       ((attributes->st_mode & (S_IRWXG | S_IRWXO)) == 0) &&
+	       ((attributes->st_mode & S_IRWXU) == (S_IRUSR | S_IWUSR));
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_query_pipe_buffer(RailClientIpcContext* ipc)
+{
+	WINPR_ASSERT(ipc);
+	WINPR_ASSERT(ipc->readFd >= 0);
+
+	errno = 0;
+	const long value = fpathconf(ipc->readFd, _PC_PIPE_BUF);
+	if (value > 0)
+	{
+		if ((UINT64)value > SIZE_MAX - 1U)
+			return FALSE;
+		ipc->pipeBuffer = (size_t)value;
+	}
+	else if ((value < 0) && (errno == 0))
+	{
+#if defined(PIPE_BUF)
+		ipc->pipeBuffer = PIPE_BUF;
+#elif defined(_POSIX_PIPE_BUF)
+		ipc->pipeBuffer = _POSIX_PIPE_BUF;
+#else
+		ipc->pipeBuffer = 512U;
+#endif
+	}
+	else
+	{
+		rail_ipc_log_errno(ipc, WLOG_ERROR, "querying the launch FIFO atomic-write limit", errno);
+		return FALSE;
+	}
+
+	if ((ipc->pipeBuffer == 0) || (ipc->pipeBuffer == SIZE_MAX))
+		return FALSE;
+	ipc->record = calloc(ipc->pipeBuffer + 1U, 1);
+	if (!ipc->record)
+		return FALSE;
+	ipc->atLineStart = TRUE;
+	return TRUE;
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_open_fifo(RailClientIpcContext* ipc)
+{
+	WINPR_ASSERT(ipc);
+
+	BOOL created = FALSE;
+	if (mkfifoat(ipc->runtimeDirectoryFd, ipc->fifoName, S_IRUSR | S_IWUSR) == 0)
+		created = TRUE;
+	else if (errno != EEXIST)
+	{
+		rail_ipc_log_errno(ipc, WLOG_ERROR, "creating the launch FIFO", errno);
+		return FALSE;
+	}
+
+	if (created && (fchmodat(ipc->runtimeDirectoryFd, ipc->fifoName, S_IRUSR | S_IWUSR, 0) < 0))
+	{
+		rail_ipc_log_errno(ipc, WLOG_ERROR, "setting launch FIFO permissions", errno);
+		return FALSE;
+	}
+
+	struct stat before = WINPR_C_ARRAY_INIT;
+	if (fstatat(ipc->runtimeDirectoryFd, ipc->fifoName, &before, AT_SYMLINK_NOFOLLOW) < 0)
+	{
+		rail_ipc_log_errno(ipc, WLOG_ERROR, "checking the launch FIFO", errno);
+		return FALSE;
+	}
+	if (!rail_ipc_validate_fifo(ipc, &before))
+	{
+		WLog_Print(ipc->log, WLOG_ERROR,
+		           "RAIL IPC rejected the launch FIFO with unsafe type, owner, or permissions");
+		return FALSE;
+	}
+
+	ipc->fifoDevice = before.st_dev;
+	ipc->fifoInode = before.st_ino;
+	ipc->fifoOwner = before.st_uid;
+	ipc->fifoIdentityValid = TRUE;
+
+	ipc->readFd = openat(ipc->runtimeDirectoryFd, ipc->fifoName,
+	                     O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW);
+	if (ipc->readFd < 0)
+	{
+		rail_ipc_log_errno(ipc, WLOG_ERROR, "opening the launch FIFO for reading", errno);
+		return FALSE;
+	}
+
+	struct stat readAttributes = WINPR_C_ARRAY_INIT;
+	if ((fstat(ipc->readFd, &readAttributes) < 0) ||
+	    !rail_ipc_validate_fifo(ipc, &readAttributes) ||
+	    !rail_ipc_same_identity(&before, &readAttributes))
+	{
+		WLog_Print(ipc->log, WLOG_ERROR,
+		           "RAIL IPC launch FIFO changed while it was being opened for reading");
+		return FALSE;
+	}
+
+	ipc->heldWriteFd = openat(ipc->runtimeDirectoryFd, ipc->fifoName,
+	                          O_WRONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW);
+	if (ipc->heldWriteFd < 0)
+	{
+		rail_ipc_log_errno(ipc, WLOG_ERROR, "opening the held launch FIFO writer", errno);
+		return FALSE;
+	}
+
+	struct stat writeAttributes = WINPR_C_ARRAY_INIT;
+	struct stat after = WINPR_C_ARRAY_INIT;
+	if ((fstat(ipc->heldWriteFd, &writeAttributes) < 0) ||
+	    (fstatat(ipc->runtimeDirectoryFd, ipc->fifoName, &after, AT_SYMLINK_NOFOLLOW) < 0) ||
+	    !rail_ipc_validate_fifo(ipc, &writeAttributes) || !rail_ipc_validate_fifo(ipc, &after) ||
+	    !rail_ipc_same_identity(&before, &writeAttributes) ||
+	    !rail_ipc_same_identity(&before, &after))
+	{
+		WLog_Print(ipc->log, WLOG_ERROR,
+		           "RAIL IPC launch FIFO changed while its descriptors were being opened");
+		return FALSE;
+	}
+
+	ipc->readEvent = CreateFileDescriptorEvent(nullptr, FALSE, FALSE, ipc->readFd, WINPR_FD_READ);
+	if (!ipc->readEvent)
+	{
+		WLog_Print(ipc->log, WLOG_ERROR, "RAIL IPC could not create the launch FIFO event");
+		return FALSE;
+	}
+	if (!rail_ipc_query_pipe_buffer(ipc))
+	{
+		WLog_Print(ipc->log, WLOG_ERROR,
+		           "RAIL IPC could not establish the launch FIFO atomic-write limit");
+		return FALSE;
+	}
+
+	ipc->enabled = TRUE;
+	return TRUE;
+}
+
+static void rail_ipc_remove_owned_fifo(RailClientIpcContext* ipc)
+{
+	WINPR_ASSERT(ipc);
+	if (!ipc->fifoIdentityValid || (ipc->runtimeDirectoryFd < 0))
+		return;
+
+	struct stat current = WINPR_C_ARRAY_INIT;
+	if (fstatat(ipc->runtimeDirectoryFd, ipc->fifoName, &current, AT_SYMLINK_NOFOLLOW) < 0)
+	{
+		if (errno != ENOENT)
+			rail_ipc_log_errno(ipc, WLOG_WARN, "checking the launch FIFO during cleanup", errno);
+		return;
+	}
+	if (!S_ISFIFO(current.st_mode) || (current.st_uid != ipc->fifoOwner) ||
+	    (current.st_dev != ipc->fifoDevice) || (current.st_ino != ipc->fifoInode))
+	{
+		WLog_Print(ipc->log, WLOG_WARN,
+		           "RAIL IPC left the launch FIFO in place because its identity changed");
+		return;
+	}
+	if (unlinkat(ipc->runtimeDirectoryFd, ipc->fifoName, 0) < 0)
+		rail_ipc_log_errno(ipc, WLOG_WARN, "removing the launch FIFO", errno);
+}
+
+static void rail_ipc_disable(RailClientIpcContext* ipc)
+{
+	WINPR_ASSERT(ipc);
+	rail_ipc_assert_owner_thread(ipc);
+
+	ipc->ready = FALSE;
+	ipc->enabled = FALSE;
+	if (ipc->readEvent)
+	{
+		CloseHandle(ipc->readEvent);
+		ipc->readEvent = nullptr;
+	}
+	rail_ipc_remove_owned_fifo(ipc);
+	if (ipc->heldWriteFd >= 0)
+	{
+		close(ipc->heldWriteFd);
+		ipc->heldWriteFd = -1;
+	}
+	if (ipc->readFd >= 0)
+	{
+		close(ipc->readFd);
+		ipc->readFd = -1;
+	}
+	ipc->fifoIdentityValid = FALSE;
+	free(ipc->record);
+	ipc->record = nullptr;
+	ipc->recordBytes = 0;
+	ipc->atLineStart = TRUE;
+	ipc->recordInvalid = FALSE;
+	ipc->recordError = nullptr;
+}
+
+static void rail_ipc_reject_record(const RailClientIpcContext* ipc, const char* reason)
+{
+	WINPR_ASSERT(ipc);
+	WINPR_ASSERT(reason);
+	WLog_Print(ipc->log, WLOG_WARN, "RAIL IPC rejected launch record: %s", reason);
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_parse_flags(const char* value, UINT16* flags)
+{
+	WINPR_ASSERT(value);
+	WINPR_ASSERT(flags);
+
+	if (value[0] == '\0')
+	{
+		*flags = 0;
+		return TRUE;
+	}
+	if ((value[0] < '0') || (value[0] > '9'))
+		return FALSE;
+
+	const BOOL hexadecimal = (value[0] == '0') && ((value[1] == 'x') || (value[1] == 'X'));
+	const char* start = hexadecimal ? &value[2] : value;
+	const int base = hexadecimal ? 16 : 10;
+	if (hexadecimal &&
+	    !(((start[0] >= '0') && (start[0] <= '9')) || ((start[0] >= 'a') && (start[0] <= 'f')) ||
+	      ((start[0] >= 'A') && (start[0] <= 'F'))))
+		return FALSE;
+
+	errno = 0;
+	char* end = nullptr;
+	const unsigned long parsed = strtoul(start, &end, base);
+	if ((errno != 0) || !end || (end == start) || (*end != '\0') || (parsed > UINT16_MAX))
+		return FALSE;
+	const UINT16 converted = (UINT16)parsed;
+	if ((converted & ~RAIL_IPC_KNOWN_EXEC_FLAGS) != 0)
+		return FALSE;
+	if (((converted & TS_RAIL_EXEC_FLAG_TRANSLATE_FILES) != 0) &&
+	    ((converted & TS_RAIL_EXEC_FLAG_FILE) == 0))
+		return FALSE;
+	*flags = converted;
+	return TRUE;
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_is_valid_utf8(const char* value)
+{
+	WINPR_ASSERT(value);
+	const BYTE* bytes = (const BYTE*)value;
+	const size_t length = strlen(value);
+
+	for (size_t x = 0; x < length;)
+	{
+		const BYTE first = bytes[x];
+		if (first <= 0x7F)
+		{
+			x++;
+			continue;
+		}
+
+		size_t count = 0;
+		BYTE secondMinimum = 0x80;
+		BYTE secondMaximum = 0xBF;
+		if ((first >= 0xC2) && (first <= 0xDF))
+			count = 2;
+		else if ((first >= 0xE0) && (first <= 0xEF))
+		{
+			count = 3;
+			if (first == 0xE0)
+				secondMinimum = 0xA0;
+			else if (first == 0xED)
+				secondMaximum = 0x9F;
+		}
+		else if ((first >= 0xF0) && (first <= 0xF4))
+		{
+			count = 4;
+			if (first == 0xF0)
+				secondMinimum = 0x90;
+			else if (first == 0xF4)
+				secondMaximum = 0x8F;
+		}
+		else
+			return FALSE;
+
+		if ((count > length - x) || (bytes[x + 1U] < secondMinimum) ||
+		    (bytes[x + 1U] > secondMaximum))
+			return FALSE;
+		for (size_t y = 2; y < count; y++)
+		{
+			if ((bytes[x + y] < 0x80) || (bytes[x + y] > 0xBF))
+				return FALSE;
+		}
+		x += count;
+	}
+	return TRUE;
+}
+
+WINPR_ATTR_NODISCARD
+static const char* rail_ipc_validate_order(const RAIL_EXEC_ORDER* order)
+{
+	WINPR_ASSERT(order);
+	if (!order->RemoteApplicationProgram || (order->RemoteApplicationProgram[0] == '\0'))
+		return "program is missing or empty";
+	if (!rail_ipc_is_valid_utf8(order->RemoteApplicationProgram))
+		return "program is not valid UTF-8";
+	if (!rail_ipc_is_valid_utf8(order->RemoteApplicationWorkingDir))
+		return "working directory is not valid UTF-8";
+	if (!rail_ipc_is_valid_utf8(order->RemoteApplicationArguments))
+		return "arguments are not valid UTF-8";
+
+	RAIL_UNICODE_STRING program = WINPR_C_ARRAY_INIT;
+	RAIL_UNICODE_STRING workingDirectory = WINPR_C_ARRAY_INIT;
+	RAIL_UNICODE_STRING arguments = WINPR_C_ARRAY_INIT;
+	const BOOL programConverted =
+	    utf8_string_to_rail_string(order->RemoteApplicationProgram, &program);
+	const BOOL workingDirectoryConverted =
+	    utf8_string_to_rail_string(order->RemoteApplicationWorkingDir, &workingDirectory);
+	const BOOL argumentsConverted =
+	    utf8_string_to_rail_string(order->RemoteApplicationArguments, &arguments);
+	const char* error = nullptr;
+	if (!programConverted)
+		error = "program could not be converted to RAIL encoding";
+	else if (!workingDirectoryConverted)
+		error = "working directory could not be converted to RAIL encoding";
+	else if (!argumentsConverted)
+		error = "arguments could not be converted to RAIL encoding";
+	else if ((program.length == 0) || (program.length > 520))
+		error = "converted program length is outside the RAIL limit";
+	else if (workingDirectory.length > 520)
+		error = "converted working-directory length exceeds the RAIL limit";
+	else if (arguments.length > 16000)
+		error = "converted argument length exceeds the RAIL limit";
+	rail_unicode_string_free(&program);
+	rail_unicode_string_free(&workingDirectory);
+	rail_unicode_string_free(&arguments);
+	return error;
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_dispatch_record(RailClientIpcContext* ipc)
+{
+	WINPR_ASSERT(ipc);
+	WINPR_ASSERT(ipc->record);
+	WINPR_ASSERT(ipc->recordBytes > 0);
+
+	char* program = nullptr;
+	char* workingDirectory = nullptr;
+	char* arguments = nullptr;
+	UINT16 flags = 0;
+	BOOL haveProgram = FALSE;
+	BOOL haveWorkingDirectory = FALSE;
+	BOOL haveArguments = FALSE;
+	BOOL haveFlags = FALSE;
+
+	const size_t contentLength = ipc->recordBytes - 1U;
+	size_t offset = 0;
+	while (offset < contentLength)
+	{
+		char* line = &ipc->record[offset];
+		char* newline = memchr(line, '\n', contentLength - offset);
+		if (!newline)
+		{
+			rail_ipc_reject_record(ipc, "line is not terminated");
+			return TRUE;
+		}
+		*newline = '\0';
+		offset = (size_t)(newline - ipc->record) + 1U;
+
+		char* separator = strchr(line, '=');
+		if (!separator || (separator == line))
+		{
+			rail_ipc_reject_record(ipc, "line has no valid key separator");
+			return TRUE;
+		}
+		*separator = '\0';
+		char* value = separator + 1U;
+		if (strcmp(line, "program") == 0)
+		{
+			if (haveProgram)
+			{
+				rail_ipc_reject_record(ipc, "program key is duplicated");
+				return TRUE;
+			}
+			haveProgram = TRUE;
+			program = value;
+		}
+		else if (strcmp(line, "working-directory") == 0)
+		{
+			if (haveWorkingDirectory)
+			{
+				rail_ipc_reject_record(ipc, "working-directory key is duplicated");
+				return TRUE;
+			}
+			haveWorkingDirectory = TRUE;
+			workingDirectory = value;
+		}
+		else if (strcmp(line, "arguments") == 0)
+		{
+			if (haveArguments)
+			{
+				rail_ipc_reject_record(ipc, "arguments key is duplicated");
+				return TRUE;
+			}
+			haveArguments = TRUE;
+			arguments = value;
+		}
+		else if (strcmp(line, "flags") == 0)
+		{
+			if (haveFlags)
+			{
+				rail_ipc_reject_record(ipc, "flags key is duplicated");
+				return TRUE;
+			}
+			haveFlags = TRUE;
+			if (!rail_ipc_parse_flags(value, &flags))
+			{
+				rail_ipc_reject_record(ipc, "flags value is invalid");
+				return TRUE;
+			}
+		}
+		else
+		{
+			rail_ipc_reject_record(ipc, "record contains an unknown key");
+			return TRUE;
+		}
+	}
+
+	const RAIL_EXEC_ORDER order = { .flags = flags,
+		                            .RemoteApplicationProgram = haveProgram ? program : "",
+		                            .RemoteApplicationWorkingDir =
+		                                haveWorkingDirectory ? workingDirectory : "",
+		                            .RemoteApplicationArguments = haveArguments ? arguments : "" };
+	const char* error = rail_ipc_validate_order(&order);
+	if (error)
+	{
+		rail_ipc_reject_record(ipc, error);
+		return TRUE;
+	}
+
+	WINPR_ASSERT(ipc->rail);
+	WINPR_ASSERT(ipc->rail->ClientExecute);
+	const UINT status = ipc->rail->ClientExecute(ipc->rail, &order);
+	if (status != CHANNEL_RC_OK)
+		WLog_Print(ipc->log, WLOG_WARN,
+		           "RAIL IPC ClientExecute rejected a launch locally with error %" PRIu32, status);
+	return TRUE;
+}
+
+static void rail_ipc_reset_record(RailClientIpcContext* ipc)
+{
+	WINPR_ASSERT(ipc);
+	ipc->recordBytes = 0;
+	ipc->atLineStart = TRUE;
+	ipc->recordInvalid = FALSE;
+	ipc->recordError = nullptr;
+}
+
+WINPR_ATTR_NODISCARD
+static BOOL rail_ipc_feed(RailClientIpcContext* ipc, const BYTE* data, size_t length,
+                          size_t* completedRecords)
+{
+	WINPR_ASSERT(ipc);
+	WINPR_ASSERT(data || (length == 0));
+	WINPR_ASSERT(completedRecords);
+
+	for (size_t x = 0; x < length; x++)
+	{
+		const BYTE value = data[x];
+		const BOOL terminator = (value == '\n') && ipc->atLineStart;
+		if (ipc->recordBytes < ipc->pipeBuffer)
+			ipc->record[ipc->recordBytes] = (char)value;
+		else if (!ipc->recordInvalid)
+		{
+			ipc->recordInvalid = TRUE;
+			ipc->recordError = "record exceeds the FIFO atomic-write limit";
+		}
+		if (ipc->recordBytes <= ipc->pipeBuffer)
+			ipc->recordBytes++;
+		if ((value == '\0') && !ipc->recordInvalid)
+		{
+			ipc->recordInvalid = TRUE;
+			ipc->recordError = "record contains NUL";
+		}
+		ipc->atLineStart = (value == '\n');
+
+		if (!terminator)
+			continue;
+		(*completedRecords)++;
+		if (ipc->recordInvalid)
+			rail_ipc_reject_record(ipc, ipc->recordError ? ipc->recordError : "record is invalid");
+		else
+		{
+			ipc->record[ipc->recordBytes] = '\0';
+			if (!rail_ipc_dispatch_record(ipc))
+				return FALSE;
+		}
+		rail_ipc_reset_record(ipc);
+	}
+	return TRUE;
+}
+
+#endif
+
+RailClientIpcContext* freerdp_client_rail_ipc_new(const rdpSettings* settings, wLog* log)
+{
+	if (!settings || !log)
+		return nullptr;
+
+#if defined(_WIN32)
+	WLog_Print(log, WLOG_ERROR, "RAIL IPC FIFO transport is unsupported on this platform");
+	return nullptr;
+#else
+	RailClientIpcContext* ipc = calloc(1, sizeof(*ipc));
+	if (!ipc)
+		return nullptr;
+	ipc->log = log;
+	ipc->ownerThreadId = GetCurrentThreadId();
+	ipc->runtimeDirectoryFd = -1;
+	ipc->lockFd = -1;
+	ipc->readFd = -1;
+	ipc->heldWriteFd = -1;
+
+	char* runtimeDirectory = rail_ipc_get_runtime_directory();
+	if (!runtimeDirectory)
+	{
+		WLog_Print(log, WLOG_ERROR, "RAIL IPC requires XDG_RUNTIME_DIR");
+		goto fail;
+	}
+	if (!rail_ipc_build_names(ipc, settings, runtimeDirectory) ||
+	    !rail_ipc_open_runtime_directory(ipc, runtimeDirectory) || !rail_ipc_open_lock(ipc) ||
+	    !rail_ipc_open_fifo(ipc))
+	{
+		free(runtimeDirectory);
+		goto fail;
+	}
+	free(runtimeDirectory);
+
+	WLog_Print(log, WLOG_INFO, "RAIL launch FIFO available at %s", ipc->path);
+	return ipc;
+
+fail:
+	freerdp_client_rail_ipc_free(ipc);
+	return nullptr;
+#endif
+}
+
+void freerdp_client_rail_ipc_free(RailClientIpcContext* ipc)
+{
+	if (!ipc)
+		return;
+	rail_ipc_assert_owner_thread(ipc);
+
+#if !defined(_WIN32)
+	rail_ipc_disable(ipc);
+	if (ipc->lockFd >= 0)
+	{
+		close(ipc->lockFd);
+		ipc->lockFd = -1;
+	}
+	if (ipc->runtimeDirectoryFd >= 0)
+	{
+		close(ipc->runtimeDirectoryFd);
+		ipc->runtimeDirectoryFd = -1;
+	}
+#endif
+	free(ipc->path);
+	free(ipc);
+}
+
+HANDLE freerdp_client_rail_ipc_get_event(const RailClientIpcContext* ipc)
+{
+	if (!ipc)
+		return nullptr;
+	rail_ipc_assert_owner_thread(ipc);
+#if defined(_WIN32)
+	return nullptr;
+#else
+	return (ipc->enabled && ipc->rail && ipc->ready) ? ipc->readEvent : nullptr;
+#endif
+}
+
+BOOL freerdp_client_rail_ipc_check_event(RailClientIpcContext* ipc)
+{
+	if (!ipc)
+		return TRUE;
+	rail_ipc_assert_owner_thread(ipc);
+	if (!ipc->enabled || !ipc->rail || !ipc->ready)
+		return TRUE;
+#if !defined(_WIN32)
+	if (!ipc->rail->ClientExecute)
+	{
+		WLog_Print(ipc->log, WLOG_ERROR,
+		           "RAIL IPC disabled because the attached channel cannot execute launches");
+		rail_ipc_disable(ipc);
+		return FALSE;
+	}
+
+	const DWORD waitStatus = WaitForSingleObject(ipc->readEvent, 0);
+	if (waitStatus == WAIT_TIMEOUT)
+		return TRUE;
+	if (waitStatus != WAIT_OBJECT_0)
+	{
+		WLog_Print(ipc->log, WLOG_ERROR,
+		           "RAIL IPC disabled after its launch FIFO event failed with status 0x%08" PRIx32,
+		           waitStatus);
+		rail_ipc_disable(ipc);
+		return FALSE;
+	}
+
+	size_t bytes = 0;
+	size_t completedRecords = 0;
+	while ((bytes < RAIL_IPC_MAX_BYTES_PER_PASS) &&
+	       (completedRecords < RAIL_IPC_MAX_RECORDS_PER_PASS))
+	{
+		/* Lifecycle transitions share this thread. Recheck before every read so a transition
+		 * observed between the wake and this call wins without draining the FIFO. */
+		if (!ipc->enabled || !ipc->rail || !ipc->ready)
+			break;
+
+		BYTE buffer[RAIL_IPC_READ_BUFFER_SIZE] = WINPR_C_ARRAY_INIT;
+		const size_t completionBudget = RAIL_IPC_MAX_RECORDS_PER_PASS - completedRecords;
+		const size_t byteBudget = RAIL_IPC_MAX_BYTES_PER_PASS - bytes;
+		/* Every byte can terminate at most one record. A FIFO cannot return unread bytes, so
+		 * limit read-ahead to the remaining completion budget. This enforces the record cap
+		 * without retaining complete records in a user-space queue. */
+		const size_t requested = MIN(ARRAYSIZE(buffer), MIN(completionBudget, byteBudget));
+		ssize_t readBytes = 0;
+		do
+		{
+			readBytes = read(ipc->readFd, buffer, requested);
+		} while ((readBytes < 0) && (errno == EINTR));
+		if (readBytes > 0)
+		{
+			bytes += (size_t)readBytes;
+			if (!rail_ipc_feed(ipc, buffer, (size_t)readBytes, &completedRecords))
+			{
+				rail_ipc_disable(ipc);
+				return FALSE;
+			}
+			continue;
+		}
+		if (readBytes == 0)
+		{
+			WLog_Print(ipc->log, WLOG_ERROR,
+			           "RAIL IPC disabled after an unexpected end of launch FIFO input");
+			rail_ipc_disable(ipc);
+			return FALSE;
+		}
+		if ((errno == EAGAIN) || (errno == EWOULDBLOCK))
+			break;
+		rail_ipc_log_errno(ipc, WLOG_ERROR, "reading the launch FIFO", errno);
+		rail_ipc_disable(ipc);
+		return FALSE;
+	}
+#endif
+	return TRUE;
+}
+
+BOOL freerdp_client_rail_ipc_attach(RailClientIpcContext* ipc, RailClientContext* rail)
+{
+	if (!ipc)
+		return TRUE;
+	rail_ipc_assert_owner_thread(ipc);
+	if (!rail || (ipc->rail && (ipc->rail != rail)))
+		return FALSE;
+	ipc->rail = rail;
+	ipc->ready = FALSE;
+	return TRUE;
+}
+
+BOOL freerdp_client_rail_ipc_detach(RailClientIpcContext* ipc, RailClientContext* rail)
+{
+	if (!ipc)
+		return TRUE;
+	rail_ipc_assert_owner_thread(ipc);
+	if (!rail || (ipc->rail != rail))
+		return FALSE;
+	ipc->ready = FALSE;
+	ipc->rail = nullptr;
+	return TRUE;
+}
+
+BOOL freerdp_client_rail_ipc_set_ready(RailClientIpcContext* ipc, BOOL ready)
+{
+	if (!ipc)
+		return TRUE;
+	rail_ipc_assert_owner_thread(ipc);
+	if (!ipc->enabled || !ready)
+	{
+		ipc->ready = FALSE;
+		return TRUE;
+	}
+	if (!ipc->rail)
+		return FALSE;
+	ipc->ready = TRUE;
+	return TRUE;
+}
+
+const char* freerdp_client_rail_ipc_get_path(const RailClientIpcContext* ipc)
+{
+	if (!ipc)
+		return nullptr;
+	return ipc->path;
+}

--- a/client/common/test/CMakeLists.txt
+++ b/client/common/test/CMakeLists.txt
@@ -24,3 +24,11 @@ foreach(test ${${MODULE_PREFIX}_TESTS})
 endforeach()
 
 set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "FreeRDP/Client/Test")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  add_executable(TestClientRailIpc TestClientRailIpc.c ../rail_ipc.c)
+  target_link_libraries(TestClientRailIpc PRIVATE freerdp winpr)
+  set_target_properties(TestClientRailIpc PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${TESTING_OUTPUT_DIRECTORY}")
+  add_test(TestClientRailIpc ${TESTING_OUTPUT_DIRECTORY}/TestClientRailIpc)
+  set_property(TARGET TestClientRailIpc PROPERTY FOLDER "FreeRDP/Client/Test")
+endif()

--- a/client/common/test/TestClientRailIpc.c
+++ b/client/common/test/TestClientRailIpc.c
@@ -1,0 +1,1905 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Common RAIL launch IPC tests
+ *
+ * Copyright 2026 Tony Dursun <oraturk75@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <errno.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <freerdp/client/rail_ipc.h>
+
+#include <winpr/crt.h>
+#include <winpr/environment.h>
+
+typedef enum
+{
+	CHANGE_NONE = 0,
+	CHANGE_SERVER,
+	CHANGE_SERVER_CANONICAL,
+	CHANGE_EXPLICIT_DEFAULT_PORTS,
+	CHANGE_PORT,
+	CHANGE_USER,
+	CHANGE_USER_CANONICAL,
+	CHANGE_DOMAIN,
+	CHANGE_DOMAIN_CANONICAL,
+	CHANGE_CONSOLE,
+	CHANGE_REDIRECTED_SESSION,
+	CHANGE_VMCONNECT,
+	CHANGE_CHILD_SESSION,
+	CHANGE_PRECONNECTION_ENABLED,
+	CHANGE_PRECONNECTION_ID,
+	CHANGE_PRECONNECTION_BLOB,
+	CHANGE_LOAD_BALANCE,
+	CHANGE_RECONNECT_COOKIE,
+	CHANGE_GATEWAY_DISABLED,
+	CHANGE_GATEWAY_DISABLED_DETAILS,
+	CHANGE_GATEWAY_USAGE,
+	CHANGE_GATEWAY_HOST,
+	CHANGE_GATEWAY_HOST_CANONICAL,
+	CHANGE_GATEWAY_PORT,
+	CHANGE_GATEWAY_USER,
+	CHANGE_GATEWAY_USER_CANONICAL,
+	CHANGE_GATEWAY_DOMAIN,
+	CHANGE_GATEWAY_DOMAIN_CANONICAL,
+	CHANGE_GATEWAY_URL,
+	CHANGE_GATEWAY_URL_CANONICAL,
+	CHANGE_ARM_ENABLED,
+	CHANGE_ARM_USE_TENANT,
+	CHANGE_ARM_A,
+	CHANGE_ARM_AAD,
+	CHANGE_ARM_TENANT,
+	CHANGE_ARM_PROGRAM,
+	CHANGE_PASSWORD,
+	CHANGE_APPLICATION,
+	CHANGE_WORKDIR,
+	CHANGE_ARGUMENTS,
+	CHANGE_PRESENTATION,
+	CHANGE_PROXY,
+	CHANGE_GATEWAY_SECRET,
+	CHANGE_GATEWAY_TRANSPORT,
+	CHANGE_SERVER_REDIRECTION
+} keyChange;
+
+typedef struct
+{
+	UINT16 flags;
+	char* program;
+	char* workingDirectory;
+	char* arguments;
+} capturedOrder;
+
+#define MAX_CAPTURED_ORDERS 128U
+#define TEST_RAIL_IPC_MAX_BYTES_PER_PASS (64U * 1024U)
+
+typedef struct
+{
+	capturedOrder orders[MAX_CAPTURED_ORDERS];
+	size_t count;
+	size_t rejectCall;
+	UINT rejectStatus;
+} executeCapture;
+
+static void capture_reset(executeCapture* capture)
+{
+	if (!capture)
+		return;
+	for (size_t x = 0; x < capture->count; x++)
+	{
+		free(capture->orders[x].program);
+		free(capture->orders[x].workingDirectory);
+		free(capture->orders[x].arguments);
+	}
+	ZeroMemory(capture, sizeof(*capture));
+	capture->rejectCall = SIZE_MAX;
+}
+
+static UINT capture_execute(RailClientContext* context, const RAIL_EXEC_ORDER* order)
+{
+	if (!context || !order || !context->custom)
+		return ERROR_INVALID_PARAMETER;
+	executeCapture* capture = context->custom;
+	if (capture->count >= MAX_CAPTURED_ORDERS)
+		return ERROR_INSUFFICIENT_BUFFER;
+
+	capturedOrder* copy = &capture->orders[capture->count];
+	copy->flags = order->flags;
+	copy->program = _strdup(order->RemoteApplicationProgram);
+	copy->workingDirectory = _strdup(order->RemoteApplicationWorkingDir);
+	copy->arguments = _strdup(order->RemoteApplicationArguments);
+	if (!copy->program || !copy->workingDirectory || !copy->arguments)
+	{
+		free(copy->program);
+		free(copy->workingDirectory);
+		free(copy->arguments);
+		ZeroMemory(copy, sizeof(*copy));
+		return ERROR_NOT_ENOUGH_MEMORY;
+	}
+
+	const size_t call = capture->count++;
+	return (call == capture->rejectCall) ? capture->rejectStatus : CHANNEL_RC_OK;
+}
+
+static rdpSettings* make_settings(void)
+{
+	rdpSettings* settings = freerdp_settings_new(0);
+	if (!settings)
+		return nullptr;
+	if (!freerdp_settings_set_string(settings, FreeRDP_ServerHostname,
+	                                 "ipc-test.example.invalid") ||
+	    !freerdp_settings_set_string(settings, FreeRDP_Username, "ipc-test-user") ||
+	    !freerdp_settings_set_string(settings, FreeRDP_Domain, "IPC-TEST") ||
+	    !freerdp_settings_set_bool(settings, FreeRDP_GatewayEnabled, TRUE) ||
+	    !freerdp_settings_set_uint32(settings, FreeRDP_GatewayUsageMethod, TSC_PROXY_MODE_DIRECT) ||
+	    !freerdp_settings_set_string(settings, FreeRDP_GatewayHostname,
+	                                 "gateway.example.invalid") ||
+	    !freerdp_settings_set_string(settings, FreeRDP_GatewayUsername, "gateway-user") ||
+	    !freerdp_settings_set_string(settings, FreeRDP_GatewayDomain, "GATEWAY") ||
+	    !freerdp_settings_set_string(settings, FreeRDP_GatewayUrl,
+	                                 "https://gateway.example.invalid/rdp") ||
+	    !freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationProgram,
+	                                 "C:\\Windows\\System32\\notepad.exe") ||
+	    !freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationWorkingDir,
+	                                 "C:\\Windows") ||
+	    !freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationCmdLine, "arguments"))
+	{
+		freerdp_settings_free(settings);
+		return nullptr;
+	}
+	return settings;
+}
+
+static BOOL set_arm(rdpSettings* settings)
+{
+	return freerdp_settings_set_bool(settings, FreeRDP_GatewayArmTransport, TRUE) &&
+	       freerdp_settings_set_string(settings, FreeRDP_GatewayAzureActiveDirectory,
+	                                   "login.example.invalid") &&
+	       freerdp_settings_set_bool(settings, FreeRDP_GatewayAvdUseTenantid, TRUE) &&
+	       freerdp_settings_set_string(settings, FreeRDP_GatewayAvdAadtenantid, "tenant-a");
+}
+
+static BOOL apply_change(rdpSettings* settings, keyChange change)
+{
+	switch (change)
+	{
+		case CHANGE_NONE:
+			return TRUE;
+		case CHANGE_SERVER:
+			return freerdp_settings_set_string(settings, FreeRDP_ServerHostname,
+			                                   "other.example.invalid");
+		case CHANGE_SERVER_CANONICAL:
+			return freerdp_settings_set_string(settings, FreeRDP_ServerHostname,
+			                                   "IPC-TEST.EXAMPLE.INVALID.");
+		case CHANGE_EXPLICIT_DEFAULT_PORTS:
+			return freerdp_settings_set_uint32(settings, FreeRDP_ServerPort, 3389) &&
+			       freerdp_settings_set_uint32(settings, FreeRDP_GatewayPort, 443);
+		case CHANGE_PORT:
+			return freerdp_settings_set_uint32(settings, FreeRDP_ServerPort, 3390);
+		case CHANGE_USER:
+			return freerdp_settings_set_string(settings, FreeRDP_Username, "other-user");
+		case CHANGE_USER_CANONICAL:
+			return freerdp_settings_set_string(settings, FreeRDP_Username, "IPC-TEST-USER");
+		case CHANGE_DOMAIN:
+			return freerdp_settings_set_string(settings, FreeRDP_Domain, "OTHER-DOMAIN");
+		case CHANGE_DOMAIN_CANONICAL:
+			return freerdp_settings_set_string(settings, FreeRDP_Domain, "ipc-test.");
+		case CHANGE_CONSOLE:
+			return freerdp_settings_set_bool(settings, FreeRDP_ConsoleSession, TRUE);
+		case CHANGE_REDIRECTED_SESSION:
+			return freerdp_settings_set_uint32(settings, FreeRDP_RedirectedSessionId, 42);
+		case CHANGE_VMCONNECT:
+			return freerdp_settings_set_bool(settings, FreeRDP_VmConnectMode, TRUE);
+		case CHANGE_CHILD_SESSION:
+			return freerdp_settings_set_bool(settings, FreeRDP_ConnectChildSession, TRUE);
+		case CHANGE_PRECONNECTION_ENABLED:
+			return freerdp_settings_set_bool(settings, FreeRDP_SendPreconnectionPdu, TRUE);
+		case CHANGE_PRECONNECTION_ID:
+			return freerdp_settings_set_bool(settings, FreeRDP_SendPreconnectionPdu, TRUE) &&
+			       freerdp_settings_set_uint32(settings, FreeRDP_PreconnectionId, 7);
+		case CHANGE_PRECONNECTION_BLOB:
+			return freerdp_settings_set_bool(settings, FreeRDP_SendPreconnectionPdu, TRUE) &&
+			       freerdp_settings_set_string(settings, FreeRDP_PreconnectionBlob, "vm-a");
+		case CHANGE_LOAD_BALANCE:
+		{
+			static const char data[] = "Cookie: msts=collection-a";
+			return freerdp_settings_set_pointer_len(settings, FreeRDP_LoadBalanceInfo, data,
+			                                        sizeof(data) - 1U);
+		}
+		case CHANGE_RECONNECT_COOKIE:
+		{
+			ARC_SC_PRIVATE_PACKET cookie = { .cbLen = sizeof(cookie),
+				                             .version = 1,
+				                             .logonId = 42,
+				                             .arcRandomBits = { 1, 2, 3, 4 } };
+			return freerdp_settings_set_pointer_len(settings, FreeRDP_ServerAutoReconnectCookie,
+			                                        &cookie, 1);
+		}
+		case CHANGE_GATEWAY_DISABLED:
+			return freerdp_set_gateway_usage_method(settings, TSC_PROXY_MODE_NONE_DIRECT);
+		case CHANGE_GATEWAY_DISABLED_DETAILS:
+			return freerdp_set_gateway_usage_method(settings, TSC_PROXY_MODE_NONE_DIRECT) &&
+			       freerdp_settings_set_string(settings, FreeRDP_GatewayHostname,
+			                                   "ignored.example.invalid") &&
+			       freerdp_settings_set_uint32(settings, FreeRDP_GatewayPort, 444);
+		case CHANGE_GATEWAY_USAGE:
+			return freerdp_set_gateway_usage_method(settings, TSC_PROXY_MODE_DETECT);
+		case CHANGE_GATEWAY_HOST:
+			return freerdp_settings_set_string(settings, FreeRDP_GatewayHostname,
+			                                   "other-gateway.example.invalid");
+		case CHANGE_GATEWAY_HOST_CANONICAL:
+			return freerdp_settings_set_string(settings, FreeRDP_GatewayHostname,
+			                                   "GATEWAY.EXAMPLE.INVALID.");
+		case CHANGE_GATEWAY_PORT:
+			return freerdp_settings_set_uint32(settings, FreeRDP_GatewayPort, 444);
+		case CHANGE_GATEWAY_USER:
+			return freerdp_settings_set_string(settings, FreeRDP_GatewayUsername, "other-user");
+		case CHANGE_GATEWAY_USER_CANONICAL:
+			return freerdp_settings_set_string(settings, FreeRDP_GatewayUsername, "GATEWAY-USER");
+		case CHANGE_GATEWAY_DOMAIN:
+			return freerdp_settings_set_string(settings, FreeRDP_GatewayDomain, "OTHER-GATEWAY");
+		case CHANGE_GATEWAY_DOMAIN_CANONICAL:
+			return freerdp_settings_set_string(settings, FreeRDP_GatewayDomain, "gateway.");
+		case CHANGE_GATEWAY_URL:
+			return freerdp_settings_set_string(settings, FreeRDP_GatewayUrl,
+			                                   "https://gateway.example.invalid/other");
+		case CHANGE_GATEWAY_URL_CANONICAL:
+			return freerdp_settings_set_string(settings, FreeRDP_GatewayUrl,
+			                                   "wss://GATEWAY.EXAMPLE.INVALID.:443/rdp");
+		case CHANGE_ARM_ENABLED:
+			return freerdp_settings_set_bool(settings, FreeRDP_GatewayArmTransport, TRUE);
+		case CHANGE_ARM_USE_TENANT:
+			return freerdp_settings_set_bool(settings, FreeRDP_GatewayArmTransport, TRUE) &&
+			       freerdp_settings_set_bool(settings, FreeRDP_GatewayAvdUseTenantid, TRUE);
+		case CHANGE_ARM_A:
+			return set_arm(settings);
+		case CHANGE_ARM_AAD:
+			return set_arm(settings) &&
+			       freerdp_settings_set_string(settings, FreeRDP_GatewayAzureActiveDirectory,
+			                                   "other-login.example.invalid");
+		case CHANGE_ARM_TENANT:
+			return set_arm(settings) &&
+			       freerdp_settings_set_string(settings, FreeRDP_GatewayAvdAadtenantid, "tenant-b");
+		case CHANGE_ARM_PROGRAM:
+			return set_arm(settings) &&
+			       freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationProgram,
+			                                   "C:\\Windows\\System32\\calc.exe");
+		case CHANGE_PASSWORD:
+			return freerdp_settings_set_string(settings, FreeRDP_Password, "excluded");
+		case CHANGE_APPLICATION:
+			return freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationProgram,
+			                                   "C:\\Windows\\System32\\calc.exe");
+		case CHANGE_WORKDIR:
+			return freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationWorkingDir,
+			                                   "C:\\Other");
+		case CHANGE_ARGUMENTS:
+			return freerdp_settings_set_string(settings, FreeRDP_RemoteApplicationCmdLine,
+			                                   "different arguments");
+		case CHANGE_PRESENTATION:
+			return freerdp_settings_set_uint32(settings, FreeRDP_DesktopWidth, 1920);
+		case CHANGE_PROXY:
+			return freerdp_settings_set_string(settings, FreeRDP_ProxyHostname,
+			                                   "proxy.example.invalid");
+		case CHANGE_GATEWAY_SECRET:
+			return freerdp_settings_set_string(settings, FreeRDP_GatewayPassword, "excluded") &&
+			       freerdp_settings_set_string(settings, FreeRDP_GatewayAccessToken, "excluded");
+		case CHANGE_GATEWAY_TRANSPORT:
+			return freerdp_settings_set_bool(settings, FreeRDP_GatewayRpcTransport, FALSE) &&
+			       freerdp_settings_set_bool(settings, FreeRDP_GatewayHttpTransport, TRUE);
+		case CHANGE_SERVER_REDIRECTION:
+			return freerdp_settings_set_uint32(settings, FreeRDP_RedirectionFlags,
+			                                   LB_TARGET_FQDN) &&
+			       freerdp_settings_set_string(settings, FreeRDP_RedirectionTargetFQDN,
+			                                   "redirected.example.invalid");
+		default:
+			return FALSE;
+	}
+}
+
+static BOOL copy_string(char* destination, size_t capacity, const char* source)
+{
+	if (!destination || !source)
+		return FALSE;
+	const size_t length = strlen(source);
+	if (length >= capacity)
+		return FALSE;
+	CopyMemory(destination, source, length + 1U);
+	return TRUE;
+}
+
+static BOOL lock_path_from_fifo(const char* fifoPath, char* lockPath, size_t capacity)
+{
+	static const char suffix[] = ".fifo";
+	const size_t length = strlen(fifoPath);
+	if ((length < sizeof(suffix) - 1U) ||
+	    (strcmp(fifoPath + length - (sizeof(suffix) - 1U), suffix) != 0))
+		return FALSE;
+	const size_t prefixLength = length - (sizeof(suffix) - 1U);
+	if (prefixLength > capacity - sizeof(".lock"))
+		return FALSE;
+	CopyMemory(lockPath, fifoPath, prefixLength);
+	CopyMemory(lockPath + prefixLength, ".lock", sizeof(".lock"));
+	return TRUE;
+}
+
+static void remove_artifacts(const char* fifoPath)
+{
+	char lockPath[1024] = WINPR_C_ARRAY_INIT;
+	if (!fifoPath)
+		return;
+	(void)unlink(fifoPath);
+	if (lock_path_from_fifo(fifoPath, lockPath, sizeof(lockPath)))
+		(void)unlink(lockPath);
+}
+
+static BOOL prepare_directory(char* directory)
+{
+	return mkdtemp(directory) && (chmod(directory, S_IRWXU) == 0) &&
+	       SetEnvironmentVariableA("XDG_RUNTIME_DIR", directory);
+}
+
+static BOOL discover_paths(rdpSettings* settings, wLog* log, char fifoPath[1024],
+                           char lockPath[1024])
+{
+	RailClientIpcContext* ipc = freerdp_client_rail_ipc_new(settings, log);
+	if (!ipc)
+		return FALSE;
+	const char* path = freerdp_client_rail_ipc_get_path(ipc);
+	const BOOL rc =
+	    copy_string(fifoPath, 1024, path) && lock_path_from_fifo(fifoPath, lockPath, 1024);
+	freerdp_client_rail_ipc_free(ipc);
+	return rc;
+}
+
+static BOOL test_key_pair(keyChange leftChange, keyChange rightChange, BOOL expectEqual,
+                          const char* label, wLog* log)
+{
+	BOOL rc = FALSE;
+	char directory[] = "/tmp/fri-key.XXXXXX";
+	char leftPath[1024] = WINPR_C_ARRAY_INIT;
+	char rightPath[1024] = WINPR_C_ARRAY_INIT;
+	char leftLock[1024] = WINPR_C_ARRAY_INIT;
+	char rightLock[1024] = WINPR_C_ARRAY_INIT;
+	RailClientIpcContext* ipc = nullptr;
+	rdpSettings* left = make_settings();
+	rdpSettings* right = make_settings();
+
+	if (!left || !right || !prepare_directory(directory) || !apply_change(left, leftChange) ||
+	    !apply_change(right, rightChange))
+		goto out;
+
+	ipc = freerdp_client_rail_ipc_new(left, log);
+	if (!ipc || !copy_string(leftPath, sizeof(leftPath), freerdp_client_rail_ipc_get_path(ipc)) ||
+	    !lock_path_from_fifo(leftPath, leftLock, sizeof(leftLock)))
+		goto out;
+	freerdp_client_rail_ipc_free(ipc);
+	ipc = nullptr;
+
+	ipc = freerdp_client_rail_ipc_new(right, log);
+	if (!ipc || !copy_string(rightPath, sizeof(rightPath), freerdp_client_rail_ipc_get_path(ipc)) ||
+	    !lock_path_from_fifo(rightPath, rightLock, sizeof(rightLock)))
+		goto out;
+	freerdp_client_rail_ipc_free(ipc);
+	ipc = nullptr;
+
+	rc = expectEqual == (strcmp(leftPath, rightPath) == 0);
+	if (!rc)
+		fprintf(stderr, "session-key case failed: %s\n", label);
+
+out:
+	freerdp_client_rail_ipc_free(ipc);
+	remove_artifacts(leftPath);
+	remove_artifacts(rightPath);
+	if (directory[0] != '\0')
+		(void)rmdir(directory);
+	freerdp_settings_free(left);
+	freerdp_settings_free(right);
+	return rc;
+}
+
+static BOOL test_session_keys(wLog* log)
+{
+	static const struct
+	{
+		keyChange left;
+		keyChange right;
+		BOOL equal;
+		const char* label;
+	} cases[] = {
+		{ CHANGE_NONE, CHANGE_SERVER, FALSE, "includes endpoint" },
+		{ CHANGE_NONE, CHANGE_SERVER_CANONICAL, TRUE,
+		  "canonicalizes endpoint case and trailing dot" },
+		{ CHANGE_NONE, CHANGE_EXPLICIT_DEFAULT_PORTS, TRUE,
+		  "canonicalizes implicit and explicit default ports" },
+		{ CHANGE_NONE, CHANGE_PORT, FALSE, "includes endpoint port" },
+		{ CHANGE_NONE, CHANGE_USER, FALSE, "includes user" },
+		{ CHANGE_NONE, CHANGE_USER_CANONICAL, FALSE,
+		  "keeps user case distinct for non-Windows servers" },
+		{ CHANGE_NONE, CHANGE_DOMAIN, FALSE, "includes domain" },
+		{ CHANGE_NONE, CHANGE_DOMAIN_CANONICAL, FALSE,
+		  "keeps domain spelling distinct for non-Windows servers" },
+		{ CHANGE_NONE, CHANGE_CONSOLE, FALSE, "includes console-session selection" },
+		{ CHANGE_NONE, CHANGE_REDIRECTED_SESSION, FALSE, "includes redirected session ID" },
+		{ CHANGE_NONE, CHANGE_VMCONNECT, FALSE, "includes VM-connect mode" },
+		{ CHANGE_NONE, CHANGE_CHILD_SESSION, FALSE, "includes child-session selection" },
+		{ CHANGE_NONE, CHANGE_PRECONNECTION_ENABLED, FALSE, "includes preconnection routing" },
+		{ CHANGE_PRECONNECTION_ENABLED, CHANGE_PRECONNECTION_ID, FALSE,
+		  "includes preconnection ID" },
+		{ CHANGE_PRECONNECTION_ENABLED, CHANGE_PRECONNECTION_BLOB, FALSE,
+		  "includes preconnection blob" },
+		{ CHANGE_NONE, CHANGE_LOAD_BALANCE, FALSE, "includes load-balance data" },
+		{ CHANGE_NONE, CHANGE_RECONNECT_COOKIE, FALSE, "includes reconnect session cookie" },
+		{ CHANGE_NONE, CHANGE_GATEWAY_DISABLED, FALSE, "includes gateway use" },
+		{ CHANGE_GATEWAY_DISABLED, CHANGE_GATEWAY_DISABLED_DETAILS, TRUE,
+		  "ignores inactive gateway details" },
+		{ CHANGE_NONE, CHANGE_GATEWAY_USAGE, FALSE, "includes gateway bypass policy" },
+		{ CHANGE_NONE, CHANGE_GATEWAY_HOST, FALSE, "includes gateway endpoint" },
+		{ CHANGE_NONE, CHANGE_GATEWAY_HOST_CANONICAL, TRUE,
+		  "canonicalizes gateway host case and trailing dot" },
+		{ CHANGE_NONE, CHANGE_GATEWAY_PORT, FALSE, "includes gateway port" },
+		{ CHANGE_NONE, CHANGE_GATEWAY_USER, FALSE, "includes gateway user" },
+		{ CHANGE_NONE, CHANGE_GATEWAY_USER_CANONICAL, FALSE, "keeps gateway user case distinct" },
+		{ CHANGE_NONE, CHANGE_GATEWAY_DOMAIN, FALSE, "includes gateway domain" },
+		{ CHANGE_NONE, CHANGE_GATEWAY_DOMAIN_CANONICAL, FALSE,
+		  "keeps gateway domain spelling distinct" },
+		{ CHANGE_NONE, CHANGE_GATEWAY_URL, FALSE, "includes gateway URL route" },
+		{ CHANGE_NONE, CHANGE_GATEWAY_URL_CANONICAL, TRUE,
+		  "canonicalizes gateway URL scheme, host and default port" },
+		{ CHANGE_NONE, CHANGE_ARM_ENABLED, FALSE, "includes ARM gateway mode" },
+		{ CHANGE_ARM_ENABLED, CHANGE_ARM_USE_TENANT, FALSE, "includes ARM tenant-selection mode" },
+		{ CHANGE_ARM_ENABLED, CHANGE_ARM_A, FALSE, "includes ARM authority and tenant" },
+		{ CHANGE_ARM_A, CHANGE_ARM_AAD, FALSE, "includes ARM authority" },
+		{ CHANGE_ARM_A, CHANGE_ARM_TENANT, FALSE, "includes ARM tenant" },
+		{ CHANGE_ARM_A, CHANGE_ARM_PROGRAM, FALSE, "includes ARM application route" },
+		{ CHANGE_NONE, CHANGE_PASSWORD, TRUE, "excludes credentials" },
+		{ CHANGE_NONE, CHANGE_APPLICATION, TRUE, "excludes application outside ARM routing" },
+		{ CHANGE_NONE, CHANGE_WORKDIR, TRUE, "excludes application working directory" },
+		{ CHANGE_NONE, CHANGE_ARGUMENTS, TRUE, "excludes application arguments" },
+		{ CHANGE_NONE, CHANGE_PRESENTATION, TRUE, "excludes presentation settings" },
+		{ CHANGE_NONE, CHANGE_PROXY, TRUE, "excludes proxy route" },
+		{ CHANGE_NONE, CHANGE_GATEWAY_SECRET, TRUE, "excludes gateway credentials" },
+		{ CHANGE_NONE, CHANGE_GATEWAY_TRANSPORT, TRUE,
+		  "excludes equivalent gateway transport choice" },
+		{ CHANGE_NONE, CHANGE_SERVER_REDIRECTION, TRUE,
+		  "excludes server-produced redirection state" }
+	};
+
+	for (size_t x = 0; x < ARRAYSIZE(cases); x++)
+	{
+		if (!test_key_pair(cases[x].left, cases[x].right, cases[x].equal, cases[x].label, log))
+			return FALSE;
+	}
+	return TRUE;
+}
+
+static BOOL test_primary_lifecycle(wLog* log)
+{
+	BOOL rc = FALSE;
+	char directory[] = "/tmp/fri-life.XXXXXX";
+	char firstPath[1024] = WINPR_C_ARRAY_INIT;
+	char secondPath[1024] = WINPR_C_ARRAY_INIT;
+	RailClientIpcContext* first = nullptr;
+	RailClientIpcContext* duplicate = nullptr;
+	RailClientIpcContext* other = nullptr;
+	rdpSettings* settings = make_settings();
+	rdpSettings* otherSettings = make_settings();
+	RailClientContext rail = WINPR_C_ARRAY_INIT;
+	executeCapture capture = WINPR_C_ARRAY_INIT;
+
+	capture_reset(&capture);
+	rail.custom = &capture;
+	rail.ClientExecute = capture_execute;
+
+	if (!settings || !otherSettings || !prepare_directory(directory) ||
+	    !freerdp_settings_set_uint32(otherSettings, FreeRDP_ServerPort, 3390))
+		goto out;
+	first = freerdp_client_rail_ipc_new(settings, log);
+	if (!first ||
+	    !copy_string(firstPath, sizeof(firstPath), freerdp_client_rail_ipc_get_path(first)))
+		goto out;
+
+	struct stat attributes = WINPR_C_ARRAY_INIT;
+	if ((lstat(firstPath, &attributes) < 0) || !S_ISFIFO(attributes.st_mode) ||
+	    ((attributes.st_mode & ALLPERMS) != (S_IRUSR | S_IWUSR)))
+		goto out;
+	if (!freerdp_client_rail_ipc_check_event(first))
+		goto out;
+	if (freerdp_client_rail_ipc_get_event(first))
+		goto out;
+
+	duplicate = freerdp_client_rail_ipc_new(settings, log);
+	if (duplicate)
+		goto out;
+	other = freerdp_client_rail_ipc_new(otherSettings, log);
+	if (!other ||
+	    !copy_string(secondPath, sizeof(secondPath), freerdp_client_rail_ipc_get_path(other)) ||
+	    (strcmp(firstPath, secondPath) == 0))
+		goto out;
+
+	if (!freerdp_client_rail_ipc_attach(first, &rail) ||
+	    !freerdp_client_rail_ipc_check_event(first))
+		goto out;
+	if (freerdp_client_rail_ipc_get_event(first))
+		goto out;
+	if (!freerdp_client_rail_ipc_set_ready(first, TRUE))
+		goto out;
+	HANDLE event = freerdp_client_rail_ipc_get_event(first);
+	const int readFd = GetEventFileDescriptor(event);
+	if (!freerdp_client_rail_ipc_check_event(first))
+		goto out;
+	if (!event || (readFd < 0) || ((fcntl(readFd, F_GETFD, 0) & FD_CLOEXEC) == 0))
+		goto out;
+
+	const int writer = open(firstPath, O_WRONLY | O_NONBLOCK | O_CLOEXEC);
+	static const char record[] = "program=||notepad\n\n";
+	if ((writer < 0) || ((fcntl(writer, F_GETFD, 0) & FD_CLOEXEC) == 0) ||
+	    (write(writer, record, sizeof(record) - 1U) != (ssize_t)(sizeof(record) - 1U)))
+	{
+		if (writer >= 0)
+			close(writer);
+		goto out;
+	}
+	close(writer);
+
+	if (WaitForSingleObject(event, 0) != WAIT_OBJECT_0)
+		goto out;
+	struct pollfd wait = { .fd = readFd, .events = POLLIN | POLLHUP };
+	if ((poll(&wait, 1, 0) != 1) || ((wait.revents & POLLIN) == 0))
+		goto out;
+	char received[sizeof(record)] = WINPR_C_ARRAY_INIT;
+	if ((read(readFd, received, sizeof(received)) != (ssize_t)(sizeof(record) - 1U)) ||
+	    (memcmp(received, record, sizeof(record) - 1U) != 0))
+		goto out;
+
+	for (size_t x = 0; x < 32; x++)
+	{
+		wait.revents = 0;
+		if ((poll(&wait, 1, 0) != 0) || ((wait.revents & (POLLIN | POLLHUP)) != 0))
+			goto out;
+	}
+	if (!freerdp_client_rail_ipc_detach(first, &rail) ||
+	    !freerdp_client_rail_ipc_check_event(first))
+		goto out;
+	if (freerdp_client_rail_ipc_get_event(first))
+		goto out;
+
+	freerdp_client_rail_ipc_free(first);
+	first = nullptr;
+	if ((lstat(firstPath, &attributes) == 0) || (errno != ENOENT))
+		goto out;
+	rc = TRUE;
+
+out:
+	capture_reset(&capture);
+	freerdp_client_rail_ipc_free(duplicate);
+	freerdp_client_rail_ipc_free(other);
+	freerdp_client_rail_ipc_free(first);
+	remove_artifacts(firstPath);
+	remove_artifacts(secondPath);
+	(void)rmdir(directory);
+	freerdp_settings_free(settings);
+	freerdp_settings_free(otherSettings);
+	return rc;
+}
+
+typedef struct
+{
+	char directory[64];
+	char fifoPath[1024];
+	char lockPath[1024];
+	rdpSettings* settings;
+} namedFixture;
+
+static BOOL named_fixture_init(namedFixture* fixture, wLog* log)
+{
+	WINPR_ASSERT(fixture);
+	if (!copy_string(fixture->directory, sizeof(fixture->directory), "/tmp/fri-name.XXXXXX"))
+		return FALSE;
+	fixture->settings = make_settings();
+	if (!fixture->settings || !prepare_directory(fixture->directory) ||
+	    !discover_paths(fixture->settings, log, fixture->fifoPath, fixture->lockPath))
+		return FALSE;
+	remove_artifacts(fixture->fifoPath);
+	return TRUE;
+}
+
+static void named_fixture_uninit(namedFixture* fixture)
+{
+	if (!fixture)
+		return;
+	remove_artifacts(fixture->fifoPath);
+	(void)rmdir(fixture->lockPath);
+	(void)rmdir(fixture->fifoPath);
+	(void)rmdir(fixture->directory);
+	freerdp_settings_free(fixture->settings);
+	ZeroMemory(fixture, sizeof(*fixture));
+}
+
+typedef struct
+{
+	namedFixture named;
+	RailClientIpcContext* ipc;
+	RailClientContext rail;
+	executeCapture capture;
+	int writer;
+	long pipeBuffer;
+} dispatchFixture;
+
+static BOOL dispatch_fixture_init(dispatchFixture* fixture, wLog* log)
+{
+	WINPR_ASSERT(fixture);
+	ZeroMemory(fixture, sizeof(*fixture));
+	fixture->writer = -1;
+	fixture->pipeBuffer = -1;
+	capture_reset(&fixture->capture);
+	if (!copy_string(fixture->named.directory, sizeof(fixture->named.directory),
+	                 "/tmp/fri-dispatch.XXXXXX"))
+		return FALSE;
+	fixture->named.settings = make_settings();
+	if (!fixture->named.settings || !prepare_directory(fixture->named.directory))
+		return FALSE;
+
+	fixture->ipc = freerdp_client_rail_ipc_new(fixture->named.settings, log);
+	if (!fixture->ipc ||
+	    !copy_string(fixture->named.fifoPath, sizeof(fixture->named.fifoPath),
+	                 freerdp_client_rail_ipc_get_path(fixture->ipc)) ||
+	    !lock_path_from_fifo(fixture->named.fifoPath, fixture->named.lockPath,
+	                         sizeof(fixture->named.lockPath)))
+		return FALSE;
+
+	fixture->writer = open(fixture->named.fifoPath, O_WRONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW);
+	if (fixture->writer < 0)
+		return FALSE;
+	fixture->pipeBuffer = fpathconf(fixture->writer, _PC_PIPE_BUF);
+	if (fixture->pipeBuffer <= 0)
+		return FALSE;
+
+	fixture->rail.custom = &fixture->capture;
+	fixture->rail.ClientExecute = capture_execute;
+	return TRUE;
+}
+
+static void dispatch_fixture_uninit(dispatchFixture* fixture)
+{
+	if (!fixture)
+		return;
+	if (fixture->writer >= 0)
+		close(fixture->writer);
+	freerdp_client_rail_ipc_free(fixture->ipc);
+	capture_reset(&fixture->capture);
+	fixture->ipc = nullptr;
+	fixture->writer = -1;
+	named_fixture_uninit(&fixture->named);
+}
+
+static BOOL dispatch_fixture_set_ready(dispatchFixture* fixture)
+{
+	WINPR_ASSERT(fixture);
+	return freerdp_client_rail_ipc_attach(fixture->ipc, &fixture->rail) &&
+	       freerdp_client_rail_ipc_set_ready(fixture->ipc, TRUE);
+}
+
+static BOOL write_once(int fd, const void* data, size_t length)
+{
+	ssize_t rc = 0;
+	do
+	{
+		rc = write(fd, data, length);
+	} while ((rc < 0) && (errno == EINTR));
+	return rc == (ssize_t)length;
+}
+
+static BOOL write_all(int fd, const void* data, size_t length)
+{
+	const BYTE* cursor = data;
+	size_t offset = 0;
+	while (offset < length)
+	{
+		ssize_t rc = 0;
+		do
+		{
+			rc = write(fd, &cursor[offset], length - offset);
+		} while ((rc < 0) && (errno == EINTR));
+		if (rc <= 0)
+			return FALSE;
+		offset += (size_t)rc;
+	}
+	return TRUE;
+}
+
+static BOOL read_exact(int fd, void* data, size_t length)
+{
+	BYTE* cursor = data;
+	size_t offset = 0;
+	while (offset < length)
+	{
+		ssize_t rc = 0;
+		do
+		{
+			rc = read(fd, &cursor[offset], length - offset);
+		} while ((rc < 0) && (errno == EINTR));
+		if (rc <= 0)
+			return FALSE;
+		offset += (size_t)rc;
+	}
+	return TRUE;
+}
+
+static BOOL create_cloexec_pipe(int fds[2])
+{
+	WINPR_ASSERT(fds);
+	if (pipe(fds) < 0)
+		return FALSE;
+	if ((fcntl(fds[0], F_SETFD, FD_CLOEXEC) == 0) && (fcntl(fds[1], F_SETFD, FD_CLOEXEC) == 0))
+		return TRUE;
+	close(fds[0]);
+	close(fds[1]);
+	fds[0] = -1;
+	fds[1] = -1;
+	return FALSE;
+}
+
+static BOOL captured_matches(const capturedOrder* order, const char* program,
+                             const char* workingDirectory, const char* arguments, UINT16 flags)
+{
+	return order && (order->flags == flags) && (strcmp(order->program, program) == 0) &&
+	       (strcmp(order->workingDirectory, workingDirectory) == 0) &&
+	       (strcmp(order->arguments, arguments) == 0);
+}
+
+static BOOL dispatch_expect(dispatchFixture* fixture, const void* record, size_t length,
+                            BOOL accepted)
+{
+	WINPR_ASSERT(fixture);
+	const size_t before = fixture->capture.count;
+	if (!write_once(fixture->writer, record, length))
+		return FALSE;
+	if (!freerdp_client_rail_ipc_check_event(fixture->ipc))
+		return FALSE;
+	return fixture->capture.count == before + (accepted ? 1U : 0U);
+}
+
+static char* make_repeated_field_record(const char* key, size_t valueLength, size_t* recordLength)
+{
+	WINPR_ASSERT(key);
+	WINPR_ASSERT(recordLength);
+	const BOOL isProgram = strcmp(key, "program") == 0;
+	const char* leading = isProgram ? "" : "program=p\n";
+	const size_t leadingLength = strlen(leading);
+	const size_t keyLength = strlen(key);
+	if ((leadingLength > SIZE_MAX - keyLength - 4U) ||
+	    (valueLength > SIZE_MAX - leadingLength - keyLength - 4U))
+		return nullptr;
+	*recordLength = leadingLength + keyLength + 1U + valueLength + 2U;
+	char* record = calloc(*recordLength + 1U, 1);
+	if (!record)
+		return nullptr;
+	char* cursor = record;
+	CopyMemory(cursor, leading, leadingLength);
+	cursor += leadingLength;
+	CopyMemory(cursor, key, keyLength);
+	cursor += keyLength;
+	*cursor++ = '=';
+	memset(cursor, 'a', valueLength);
+	cursor += valueLength;
+	*cursor++ = '\n';
+	*cursor++ = '\n';
+	WINPR_ASSERT((size_t)(cursor - record) == *recordLength);
+	return record;
+}
+
+static char* make_exact_record(size_t totalLength)
+{
+	static const char prefix[] = "program=p\narguments=";
+	static const char suffix[] = "\n\n";
+	if (totalLength < sizeof(prefix) - 1U + sizeof(suffix) - 1U)
+		return nullptr;
+	char* record = calloc(totalLength + 1U, 1);
+	if (!record)
+		return nullptr;
+	const size_t prefixLength = sizeof(prefix) - 1U;
+	const size_t suffixLength = sizeof(suffix) - 1U;
+	CopyMemory(record, prefix, prefixLength);
+	memset(&record[prefixLength], 'a', totalLength - prefixLength - suffixLength);
+	CopyMemory(&record[totalLength - suffixLength], suffix, suffixLength);
+	return record;
+}
+
+static BOOL test_stale_fifo_reuse(wLog* log)
+{
+	BOOL rc = FALSE;
+	namedFixture fixture = WINPR_C_ARRAY_INIT;
+	RailClientIpcContext* ipc = nullptr;
+	if (!named_fixture_init(&fixture, log))
+		goto out;
+
+	const pid_t child = fork();
+	if (child < 0)
+		goto out;
+	if (child == 0)
+	{
+		RailClientIpcContext* childIpc = freerdp_client_rail_ipc_new(fixture.settings, log);
+		_exit(childIpc ? 0 : 1);
+	}
+	int status = 0;
+	if ((waitpid(child, &status, 0) != child) || !WIFEXITED(status) || (WEXITSTATUS(status) != 0))
+		goto out;
+
+	struct stat attributes = WINPR_C_ARRAY_INIT;
+	if ((lstat(fixture.fifoPath, &attributes) < 0) || !S_ISFIFO(attributes.st_mode))
+		goto out;
+	ipc = freerdp_client_rail_ipc_new(fixture.settings, log);
+	if (!ipc || (strcmp(fixture.fifoPath, freerdp_client_rail_ipc_get_path(ipc)) != 0))
+		goto out;
+	rc = TRUE;
+
+out:
+	freerdp_client_rail_ipc_free(ipc);
+	named_fixture_uninit(&fixture);
+	return rc;
+}
+
+static BOOL test_identity_safe_cleanup(wLog* log)
+{
+	BOOL rc = FALSE;
+	namedFixture fixture = WINPR_C_ARRAY_INIT;
+	RailClientIpcContext* ipc = nullptr;
+	if (!named_fixture_init(&fixture, log))
+		goto out;
+	ipc = freerdp_client_rail_ipc_new(fixture.settings, log);
+	if (!ipc || (unlink(fixture.fifoPath) < 0) || (mkfifo(fixture.fifoPath, S_IRUSR | S_IWUSR) < 0))
+		goto out;
+	freerdp_client_rail_ipc_free(ipc);
+	ipc = nullptr;
+
+	struct stat replacement = WINPR_C_ARRAY_INIT;
+	rc = (lstat(fixture.fifoPath, &replacement) == 0) && S_ISFIFO(replacement.st_mode);
+
+out:
+	freerdp_client_rail_ipc_free(ipc);
+	named_fixture_uninit(&fixture);
+	return rc;
+}
+
+static int count_open_descriptors(void);
+
+static BOOL setup_must_fail(rdpSettings* settings, wLog* log)
+{
+	const int before = count_open_descriptors();
+	RailClientIpcContext* ipc = freerdp_client_rail_ipc_new(settings, log);
+	if (ipc)
+	{
+		freerdp_client_rail_ipc_free(ipc);
+		return FALSE;
+	}
+	const int after = count_open_descriptors();
+	return (before < 0) || (after == before);
+}
+
+static BOOL test_runtime_directory_rejection(wLog* log)
+{
+	BOOL rc = FALSE;
+	int stage = 0;
+	char directory[] = "/tmp/fri-runtime.XXXXXX";
+	rdpSettings* settings = make_settings();
+	if (!settings || !prepare_directory(directory))
+		goto out;
+
+	stage = 1;
+	if ((chmod(directory, 0755) < 0) || !setup_must_fail(settings, log) ||
+	    (chmod(directory, S_IRWXU) < 0))
+		goto out;
+	stage = 2;
+	char file[] = "/tmp/fri-runtime-file.XXXXXX";
+	const int fileFd = mkstemp(file);
+	if (fileFd < 0)
+		goto out;
+	close(fileFd);
+	if (!SetEnvironmentVariableA("XDG_RUNTIME_DIR", file) || !setup_must_fail(settings, log))
+	{
+		(void)unlink(file);
+		goto out;
+	}
+	(void)unlink(file);
+
+	stage = 3;
+	char root[] = "/tmp/fri-runtime-link.XXXXXX";
+	if (!mkdtemp(root))
+		goto out;
+	char target[128] = WINPR_C_ARRAY_INIT;
+	char link[128] = WINPR_C_ARRAY_INIT;
+	if ((_snprintf(target, sizeof(target), "%s/target", root) <= 0) ||
+	    (_snprintf(link, sizeof(link), "%s/link", root) <= 0) || (mkdir(target, S_IRWXU) < 0) ||
+	    (symlink(target, link) < 0) || !SetEnvironmentVariableA("XDG_RUNTIME_DIR", link) ||
+	    !setup_must_fail(settings, log))
+	{
+		(void)unlink(link);
+		(void)rmdir(target);
+		(void)rmdir(root);
+		goto out;
+	}
+	(void)unlink(link);
+	(void)rmdir(target);
+	(void)rmdir(root);
+	rc = TRUE;
+
+out:
+	if (!rc)
+		fprintf(stderr, "runtime-directory rejection stage %d failed\n", stage);
+	(void)chmod(directory, S_IRWXU);
+	(void)rmdir(directory);
+	freerdp_settings_free(settings);
+	return rc;
+}
+
+static BOOL test_lock_rejection_case(wLog* log, int kind)
+{
+	BOOL rc = FALSE;
+	namedFixture fixture = WINPR_C_ARRAY_INIT;
+	int fd = -1;
+	if (!named_fixture_init(&fixture, log))
+		goto out;
+
+	switch (kind)
+	{
+		case 0:
+			if (mkdir(fixture.lockPath, S_IRWXU) < 0)
+				goto out;
+			break;
+		case 1:
+			if (symlink("missing-lock-target", fixture.lockPath) < 0)
+				goto out;
+			break;
+		case 2:
+			fd = open(fixture.lockPath, O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC, 0644);
+			if ((fd < 0) || (fchmod(fd, 0644) < 0))
+				goto out;
+			close(fd);
+			fd = -1;
+			break;
+		default:
+			goto out;
+	}
+
+	rc = setup_must_fail(fixture.settings, log);
+
+out:
+	if (fd >= 0)
+		close(fd);
+	(void)unlink(fixture.lockPath);
+	(void)rmdir(fixture.lockPath);
+	named_fixture_uninit(&fixture);
+	return rc;
+}
+
+static BOOL test_fifo_rejection_case(wLog* log, int kind)
+{
+	BOOL rc = FALSE;
+	namedFixture fixture = WINPR_C_ARRAY_INIT;
+	int fd = -1;
+	if (!named_fixture_init(&fixture, log))
+		goto out;
+
+	switch (kind)
+	{
+		case 0:
+			fd = open(fixture.fifoPath, O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC, 0600);
+			if (fd < 0)
+				goto out;
+			close(fd);
+			fd = -1;
+			break;
+		case 1:
+			if (symlink("missing-fifo-target", fixture.fifoPath) < 0)
+				goto out;
+			break;
+		case 2:
+			if ((mkfifo(fixture.fifoPath, 0644) < 0) || (chmod(fixture.fifoPath, 0644) < 0))
+				goto out;
+			break;
+		default:
+			goto out;
+	}
+
+	rc = setup_must_fail(fixture.settings, log);
+
+out:
+	if (fd >= 0)
+		close(fd);
+	named_fixture_uninit(&fixture);
+	return rc;
+}
+
+static BOOL test_filesystem_rejections(wLog* log)
+{
+	if (!test_runtime_directory_rejection(log))
+	{
+		fprintf(stderr, "runtime-directory rejection case failed\n");
+		return FALSE;
+	}
+	for (int kind = 0; kind < 3; kind++)
+	{
+		if (!test_lock_rejection_case(log, kind))
+		{
+			fprintf(stderr, "lock rejection case %d failed\n", kind);
+			return FALSE;
+		}
+		if (!test_fifo_rejection_case(log, kind))
+		{
+			fprintf(stderr, "FIFO rejection case %d failed\n", kind);
+			return FALSE;
+		}
+	}
+	return TRUE;
+}
+
+static int count_open_descriptors(void)
+{
+	DIR* directory = opendir("/proc/self/fd");
+	if (!directory)
+		return -1;
+	int count = 0;
+	for (;;)
+	{
+		errno = 0;
+		const struct dirent* entry = readdir(directory);
+		if (!entry)
+			break;
+		if ((strcmp(entry->d_name, ".") != 0) && (strcmp(entry->d_name, "..") != 0))
+			count++;
+	}
+	const int error = errno;
+	closedir(directory);
+	return (error == 0) ? count : -1;
+}
+
+static BOOL test_construction_failures(wLog* log)
+{
+	BOOL rc = FALSE;
+	BOOL limitChanged = FALSE;
+	int probes[3] = { -1, -1, -1 };
+	namedFixture fixture = WINPR_C_ARRAY_INIT;
+	RailClientIpcContext* ipc = nullptr;
+	struct rlimit originalLimit = WINPR_C_ARRAY_INIT;
+	if (!named_fixture_init(&fixture, log))
+		goto out;
+
+	const int before = count_open_descriptors();
+	for (size_t x = 0; x < ARRAYSIZE(probes); x++)
+	{
+		probes[x] = open("/dev/null", O_RDONLY | O_CLOEXEC);
+		if (probes[x] < 0)
+			goto out;
+	}
+	if ((before < 0) || (getrlimit(RLIMIT_NOFILE, &originalLimit) < 0))
+		goto out;
+
+	/* Releasing the three lowest free descriptors leaves exactly three slots below the limit. */
+	struct rlimit reducedLimit = originalLimit;
+	reducedLimit.rlim_cur = (rlim_t)probes[2] + 1;
+	if (setrlimit(RLIMIT_NOFILE, &reducedLimit) < 0)
+		goto out;
+	limitChanged = TRUE;
+	for (size_t x = 0; x < ARRAYSIZE(probes); x++)
+	{
+		close(probes[x]);
+		probes[x] = -1;
+	}
+
+	struct stat lock = WINPR_C_ARRAY_INIT;
+	const BOOL heldWriterFailed = setup_must_fail(fixture.settings, log) &&
+	                              (access(fixture.fifoPath, F_OK) < 0) && (errno == ENOENT) &&
+	                              (lstat(fixture.lockPath, &lock) == 0) && S_ISREG(lock.st_mode);
+	if (setrlimit(RLIMIT_NOFILE, &originalLimit) < 0)
+		goto out;
+	limitChanged = FALSE;
+	struct rlimit restoredLimit = WINPR_C_ARRAY_INIT;
+	if (!heldWriterFailed || (getrlimit(RLIMIT_NOFILE, &restoredLimit) < 0) ||
+	    (restoredLimit.rlim_cur != originalLimit.rlim_cur) ||
+	    (restoredLimit.rlim_max != originalLimit.rlim_max) || (count_open_descriptors() != before))
+		goto out;
+
+	ipc = freerdp_client_rail_ipc_new(fixture.settings, log);
+	if (!ipc)
+		goto out;
+	rc = TRUE;
+
+out:
+	if (limitChanged && (setrlimit(RLIMIT_NOFILE, &originalLimit) < 0))
+		rc = FALSE;
+	for (size_t x = 0; x < ARRAYSIZE(probes); x++)
+	{
+		if (probes[x] >= 0)
+			close(probes[x]);
+	}
+	freerdp_client_rail_ipc_free(ipc);
+	named_fixture_uninit(&fixture);
+	return rc;
+}
+
+static BOOL test_file_byte_budget(dispatchFixture* fixture)
+{
+	WINPR_ASSERT(fixture);
+	BOOL rc = FALSE;
+	BOOL readFdReplaced = FALSE;
+	int fileFd = -1;
+	int savedReadFd = -1;
+	char path[] = "/tmp/fri-budget.XXXXXX";
+	const int before = count_open_descriptors();
+	const HANDLE event = freerdp_client_rail_ipc_get_event(fixture->ipc);
+	const int readFd = GetEventFileDescriptor(event);
+	if ((before < 0) || !event || (readFd < 0))
+		goto out;
+
+	fileFd = mkstemp(path);
+	if ((fileFd < 0) || (unlink(path) < 0))
+		goto out;
+	path[0] = '\0';
+	BYTE data[4096] = WINPR_C_ARRAY_INIT;
+	memset(data, 'x', sizeof(data));
+	size_t remaining = (2U * TEST_RAIL_IPC_MAX_BYTES_PER_PASS) + 1U;
+	while (remaining > 0)
+	{
+		const size_t length = MIN(remaining, sizeof(data));
+		if (!write_all(fileFd, data, length))
+			goto out;
+		remaining -= length;
+	}
+	if (lseek(fileFd, 0, SEEK_SET) != 0)
+		goto out;
+
+	savedReadFd = dup(readFd);
+	if ((savedReadFd < 0) || (dup2(fileFd, readFd) != readFd))
+		goto out;
+	readFdReplaced = TRUE;
+
+	/* A regular file is always readable, making the byte-budget arithmetic deterministic.
+	 * The real FIFO tests cover FIFO-specific EAGAIN behavior. */
+	if (!freerdp_client_rail_ipc_check_event(fixture->ipc) ||
+	    (lseek(fileFd, 0, SEEK_CUR) != TEST_RAIL_IPC_MAX_BYTES_PER_PASS) ||
+	    (WaitForSingleObject(event, 0) != WAIT_OBJECT_0) ||
+	    (freerdp_client_rail_ipc_get_event(fixture->ipc) != event))
+		goto out;
+	if (!freerdp_client_rail_ipc_check_event(fixture->ipc) ||
+	    (lseek(fileFd, 0, SEEK_CUR) != 2U * TEST_RAIL_IPC_MAX_BYTES_PER_PASS) ||
+	    (WaitForSingleObject(event, 0) != WAIT_OBJECT_0) ||
+	    (freerdp_client_rail_ipc_get_event(fixture->ipc) != event))
+		goto out;
+	if (dup2(savedReadFd, readFd) != readFd)
+		goto out;
+	readFdReplaced = FALSE;
+	close(savedReadFd);
+	savedReadFd = -1;
+	close(fileFd);
+	fileFd = -1;
+	if ((WaitForSingleObject(event, 0) != WAIT_TIMEOUT) || (count_open_descriptors() != before))
+		goto out;
+	rc = TRUE;
+
+out:
+	if (readFdReplaced && (savedReadFd >= 0) && (dup2(savedReadFd, readFd) != readFd))
+		rc = FALSE;
+	if (savedReadFd >= 0)
+		close(savedReadFd);
+	if (fileFd >= 0)
+		close(fileFd);
+	if (path[0] != '\0')
+		(void)unlink(path);
+	if ((before >= 0) && (count_open_descriptors() != before))
+		rc = FALSE;
+	return rc;
+}
+
+static BOOL test_protocol_fields_and_order(wLog* log)
+{
+	BOOL rc = FALSE;
+	dispatchFixture fixture = WINPR_C_ARRAY_INIT;
+	if (!dispatch_fixture_init(&fixture, log))
+		goto out;
+	if (!dispatch_fixture_set_ready(&fixture))
+		goto out;
+
+	static const char minimal[] = "program=||notepad\n\n";
+	if (!dispatch_expect(&fixture, minimal, sizeof(minimal) - 1U, TRUE) ||
+	    !captured_matches(&fixture.capture.orders[0], "||notepad", "", "", 0))
+		goto out;
+
+	static const char equals[] =
+	    "program=||app=one\nworking-directory=C:\\dir=one\narguments=--name=a=b\nflags=5\n\n";
+	if (!dispatch_expect(&fixture, equals, sizeof(equals) - 1U, TRUE) ||
+	    !captured_matches(&fixture.capture.orders[1], "||app=one", "C:\\dir=one", "--name=a=b", 5))
+		goto out;
+
+	const char* lines[] = { "program=||ordered\n", "working-directory=C:\\ordered\n",
+		                    "arguments=ordered=yes\n", "flags=0x5\n" };
+	for (size_t a = 0; a < 4; a++)
+	{
+		for (size_t b = 0; b < 4; b++)
+		{
+			if (b == a)
+				continue;
+			for (size_t c = 0; c < 4; c++)
+			{
+				if ((c == a) || (c == b))
+					continue;
+				for (size_t d = 0; d < 4; d++)
+				{
+					if ((d == a) || (d == b) || (d == c))
+						continue;
+					char record[256] = WINPR_C_ARRAY_INIT;
+					const int length = _snprintf(record, sizeof(record), "%s%s%s%s\n", lines[a],
+					                             lines[b], lines[c], lines[d]);
+					if ((length <= 0) || ((size_t)length >= sizeof(record)) ||
+					    !dispatch_expect(&fixture, record, (size_t)length, TRUE))
+						goto out;
+					const capturedOrder* order =
+					    &fixture.capture.orders[fixture.capture.count - 1U];
+					if (!captured_matches(order, "||ordered", "C:\\ordered", "ordered=yes", 5))
+						goto out;
+				}
+			}
+		}
+	}
+
+	static const char explicitEmpty[] =
+	    "arguments=\nflags=\nprogram=||empty\nworking-directory=\n\n";
+	if (!dispatch_expect(&fixture, explicitEmpty, sizeof(explicitEmpty) - 1U, TRUE) ||
+	    !captured_matches(&fixture.capture.orders[fixture.capture.count - 1U], "||empty", "", "",
+	                      0) ||
+	    !captured_matches(&fixture.capture.orders[0], "||notepad", "", "", 0))
+		goto out;
+	rc = TRUE;
+
+out:
+	dispatch_fixture_uninit(&fixture);
+	return rc;
+}
+
+static BOOL test_flags_and_grammar_rejection(wLog* log)
+{
+	BOOL rc = FALSE;
+	dispatchFixture fixture = WINPR_C_ARRAY_INIT;
+	if (!dispatch_fixture_init(&fixture, log))
+		goto out;
+	if (!dispatch_fixture_set_ready(&fixture))
+		goto out;
+
+	static const struct
+	{
+		const char* value;
+		UINT16 expected;
+	} accepted[] = { { "", 0 },  { "0", 0 },   { "1", 1 },     { "4", 4 },
+		             { "8", 8 }, { "08", 8 },  { "16", 16 },   { "016", 16 },
+		             { "6", 6 }, { "31", 31 }, { "0x1f", 31 }, { "0X1f", 31 } };
+	for (size_t x = 0; x < ARRAYSIZE(accepted); x++)
+	{
+		char record[128] = WINPR_C_ARRAY_INIT;
+		const int length =
+		    _snprintf(record, sizeof(record), "program=||flags\nflags=%s\n\n", accepted[x].value);
+		if ((length <= 0) || !dispatch_expect(&fixture, record, (size_t)length, TRUE) ||
+		    (fixture.capture.orders[fixture.capture.count - 1U].flags != accepted[x].expected))
+			goto out;
+	}
+
+	static const char* rejected[] = {
+		"program=||bad\nflags=2\n\n",          "program=||bad\nflags=010\n\n",
+		"program=||bad\nflags=32\n\n",         "program=||bad\nflags=65536\n\n",
+		"program=||bad\nflags=-1\n\n",         "program=||bad\nflags=0x\n\n",
+		"program=||bad\nflags=0b1\n\n",        "program=||bad\nflags=junk\n\n",
+		"program=||bad\nflags=0\nflags=0\n\n", "program=||bad\nprogram=||again\n\n",
+		"program=||bad\nunknown=value\n\n",    "program=||bad\nmalformed\n\n",
+		"working-directory=C:\\\n\n",          "program=\n\n"
+	};
+	for (size_t x = 0; x < ARRAYSIZE(rejected); x++)
+	{
+		if (!dispatch_expect(&fixture, rejected[x], strlen(rejected[x]), FALSE))
+			goto out;
+	}
+	rc = TRUE;
+
+out:
+	dispatch_fixture_uninit(&fixture);
+	return rc;
+}
+
+static BOOL test_encoding_and_size_limits(wLog* log)
+{
+	BOOL rc = FALSE;
+	dispatchFixture fixture = WINPR_C_ARRAY_INIT;
+	char* record = nullptr;
+	if (!dispatch_fixture_init(&fixture, log))
+		goto out;
+	if (!dispatch_fixture_set_ready(&fixture))
+		goto out;
+
+	static const BYTE invalidUtf8Continuation[] = { 'p', 'r', 'o',  'g',  'r',  'a',
+		                                            'm', '=', 0xC3, 0x28, '\n', '\n' };
+	static const BYTE invalidUtf8Overlong[] = { 'p', 'r', 'o',  'g',  'r',  'a',
+		                                        'm', '=', 0xC0, 0x80, '\n', '\n' };
+	static const BYTE invalidUtf8Surrogate[] = { 'p', 'r',  'o',  'g',  'r',  'a', 'm',
+		                                         '=', 0xED, 0xA0, 0x80, '\n', '\n' };
+	static const BYTE invalidUtf8TooLarge[] = { 'p', 'r',  'o',  'g',  'r',  'a',  'm',
+		                                        '=', 0xF4, 0x90, 0x80, 0x80, '\n', '\n' };
+	static const BYTE invalidUtf8Truncated[] = { 'p', 'r', 'o',  'g',  'r',  'a',
+		                                         'm', '=', 0xE2, 0x82, '\n', '\n' };
+	static const BYTE embeddedNul[] = { 'p', 'r', 'o', 'g', 'r',  'a', 'm',
+		                                '=', 'a', 0,   'b', '\n', '\n' };
+	static const struct
+	{
+		const BYTE* record;
+		size_t length;
+	} invalid[] = { { invalidUtf8Continuation, sizeof(invalidUtf8Continuation) },
+		            { invalidUtf8Overlong, sizeof(invalidUtf8Overlong) },
+		            { invalidUtf8Surrogate, sizeof(invalidUtf8Surrogate) },
+		            { invalidUtf8TooLarge, sizeof(invalidUtf8TooLarge) },
+		            { invalidUtf8Truncated, sizeof(invalidUtf8Truncated) },
+		            { embeddedNul, sizeof(embeddedNul) } };
+	for (size_t x = 0; x < ARRAYSIZE(invalid); x++)
+	{
+		if (!dispatch_expect(&fixture, invalid[x].record, invalid[x].length, FALSE))
+			goto out;
+	}
+
+	static const char validUtf8[] = "program=||\xC3\xA9-\xE2\x82\xAC-\xF0\x9F\x98\x80\n\n";
+	if (!dispatch_expect(&fixture, validUtf8, sizeof(validUtf8) - 1U, TRUE))
+		goto out;
+
+	size_t length = 0;
+	record = make_repeated_field_record("program", 260, &length);
+	if (!record || !dispatch_expect(&fixture, record, length, TRUE))
+		goto out;
+	free(record);
+	record = make_repeated_field_record("program", 261, &length);
+	if (!record || !dispatch_expect(&fixture, record, length, FALSE))
+		goto out;
+	free(record);
+	record = make_repeated_field_record("working-directory", 260, &length);
+	if (!record || !dispatch_expect(&fixture, record, length, TRUE))
+		goto out;
+	free(record);
+	record = make_repeated_field_record("working-directory", 261, &length);
+	if (!record || !dispatch_expect(&fixture, record, length, FALSE))
+		goto out;
+	free(record);
+	record = nullptr;
+
+	const size_t pipeBuffer = (size_t)fixture.pipeBuffer;
+	record = make_exact_record(pipeBuffer);
+	if (!record || !dispatch_expect(&fixture, record, pipeBuffer, TRUE))
+		goto out;
+	free(record);
+	record = make_exact_record(pipeBuffer + 1U);
+	if (!record || !dispatch_expect(&fixture, record, pipeBuffer + 1U, FALSE))
+		goto out;
+	free(record);
+	record = nullptr;
+	rc = TRUE;
+
+out:
+	free(record);
+	dispatch_fixture_uninit(&fixture);
+	return rc;
+}
+
+static BOOL test_streaming_resynchronisation_and_rejection(wLog* log)
+{
+	BOOL rc = FALSE;
+	dispatchFixture fixture = WINPR_C_ARRAY_INIT;
+	if (!dispatch_fixture_init(&fixture, log))
+		goto out;
+	if (!dispatch_fixture_set_ready(&fixture))
+		goto out;
+
+	static const char firstPart[] = "program=||partial\narg";
+	static const char secondPart[] = "uments=split\n\n";
+	if (!dispatch_expect(&fixture, firstPart, sizeof(firstPart) - 1U, FALSE) ||
+	    !dispatch_expect(&fixture, secondPart, sizeof(secondPart) - 1U, TRUE) ||
+	    !captured_matches(&fixture.capture.orders[0], "||partial", "", "split", 0))
+		goto out;
+
+	static const char several[] =
+	    "program=||one\n\nprogram=||two\narguments=2\n\nprogram=||three\n\n";
+	const size_t beforeSeveral = fixture.capture.count;
+	if (!write_once(fixture.writer, several, sizeof(several) - 1U) ||
+	    !freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if (fixture.capture.count != beforeSeveral + 3U)
+		goto out;
+
+	static const char malformedThenValid[] =
+	    "program=||discard\nmalformed\n\nprogram=||after-malformed\n\n";
+	const size_t beforeMalformed = fixture.capture.count;
+	if (!write_once(fixture.writer, malformedThenValid, sizeof(malformedThenValid) - 1U) ||
+	    !freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if ((fixture.capture.count != beforeMalformed + 1U) ||
+	    (strcmp(fixture.capture.orders[beforeMalformed].program, "||after-malformed") != 0))
+		goto out;
+
+	static const char truncated[] = "program=||discard-truncated\narguments";
+	static const char terminateThenValid[] = "\n\nprogram=||after-truncated\n\n";
+	const size_t beforeTruncated = fixture.capture.count;
+	if (!dispatch_expect(&fixture, truncated, sizeof(truncated) - 1U, FALSE) ||
+	    !write_once(fixture.writer, terminateThenValid, sizeof(terminateThenValid) - 1U) ||
+	    !freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if ((fixture.capture.count != beforeTruncated + 1U) ||
+	    (strcmp(fixture.capture.orders[beforeTruncated].program, "||after-truncated") != 0))
+		goto out;
+
+	static const BYTE nulThenValid[] = { 'p', 'r', 'o',  'g',  'r', 'a', 'm', '=',  'b', 'a', 'd',
+		                                 0,   'x', '\n', '\n', 'p', 'r', 'o', 'g',  'r', 'a', 'm',
+		                                 '=', '|', '|',  'g',  'o', 'o', 'd', '\n', '\n' };
+	const size_t beforeNul = fixture.capture.count;
+	if (!write_once(fixture.writer, nulThenValid, sizeof(nulThenValid)) ||
+	    !freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if ((fixture.capture.count != beforeNul + 1U) ||
+	    (strcmp(fixture.capture.orders[beforeNul].program, "||good") != 0))
+		goto out;
+
+	char mutableRecord[] = "program=||lifetime\nworking-directory=C:\\live\narguments=alive\n\n";
+	const size_t beforeLifetime = fixture.capture.count;
+	if (!dispatch_expect(&fixture, mutableRecord, sizeof(mutableRecord) - 1U, TRUE))
+		goto out;
+	memset(mutableRecord, 'x', sizeof(mutableRecord) - 1U);
+	if (!captured_matches(&fixture.capture.orders[beforeLifetime], "||lifetime", "C:\\live",
+	                      "alive", 0))
+		goto out;
+
+	fixture.capture.rejectCall = fixture.capture.count;
+	fixture.capture.rejectStatus = ERROR_BAD_COMMAND;
+	static const char rejectedThenNext[] = "program=||local-reject\n\nprogram=||after-reject\n\n";
+	const size_t beforeReject = fixture.capture.count;
+	if (!write_once(fixture.writer, rejectedThenNext, sizeof(rejectedThenNext) - 1U) ||
+	    !freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if ((fixture.capture.count != beforeReject + 2U) ||
+	    (strcmp(fixture.capture.orders[beforeReject + 1U].program, "||after-reject") != 0))
+		goto out;
+	rc = TRUE;
+
+out:
+	dispatch_fixture_uninit(&fixture);
+	return rc;
+}
+
+static BOOL test_readiness_and_drain_budgets(wLog* log)
+{
+	BOOL rc = FALSE;
+	dispatchFixture fixture = WINPR_C_ARRAY_INIT;
+	if (!dispatch_fixture_init(&fixture, log))
+		goto out;
+
+	static const char buffered[] = "program=||buffered\n\n";
+	if (!write_once(fixture.writer, buffered, sizeof(buffered) - 1U) ||
+	    freerdp_client_rail_ipc_get_event(fixture.ipc))
+		goto out;
+	if (!freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if (fixture.capture.count != 0)
+		goto out;
+	if (!freerdp_client_rail_ipc_attach(fixture.ipc, &fixture.rail))
+		goto out;
+	if (freerdp_client_rail_ipc_get_event(fixture.ipc))
+		goto out;
+	if (!freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if (fixture.capture.count != 0)
+		goto out;
+	if (!freerdp_client_rail_ipc_set_ready(fixture.ipc, TRUE))
+		goto out;
+	if (!freerdp_client_rail_ipc_get_event(fixture.ipc))
+		goto out;
+	if (!freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if ((fixture.capture.count != 1) ||
+	    (strcmp(fixture.capture.orders[0].program, "||buffered") != 0))
+		goto out;
+
+	static const char suspended[] = "program=||after-suspend\n\n";
+	if (!write_once(fixture.writer, suspended, sizeof(suspended) - 1U) ||
+	    (WaitForSingleObject(freerdp_client_rail_ipc_get_event(fixture.ipc), 0) != WAIT_OBJECT_0))
+		goto out;
+	if (!freerdp_client_rail_ipc_set_ready(fixture.ipc, FALSE) ||
+	    !freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if (fixture.capture.count != 1)
+		goto out;
+	if (!freerdp_client_rail_ipc_set_ready(fixture.ipc, TRUE) ||
+	    !freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if (fixture.capture.count != 2)
+		goto out;
+
+	static const char detached[] = "program=||after-detach\n\n";
+	if (!write_once(fixture.writer, detached, sizeof(detached) - 1U) ||
+	    (WaitForSingleObject(freerdp_client_rail_ipc_get_event(fixture.ipc), 0) != WAIT_OBJECT_0))
+		goto out;
+	if (!freerdp_client_rail_ipc_detach(fixture.ipc, &fixture.rail) ||
+	    !freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if (fixture.capture.count != 2)
+		goto out;
+	if (!dispatch_fixture_set_ready(&fixture))
+		goto out;
+	if (!freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if (fixture.capture.count != 3)
+		goto out;
+
+	char records[1024] = WINPR_C_ARRAY_INIT;
+	size_t length = 0;
+	for (size_t x = 0; x < 20; x++)
+	{
+		const int used = _snprintf(&records[length], sizeof(records) - length,
+		                           "program=||budget-%" PRIuz "\n\n", x);
+		if ((used <= 0) || ((size_t)used >= sizeof(records) - length))
+			goto out;
+		length += (size_t)used;
+	}
+	const size_t beforeBudget = fixture.capture.count;
+	if (!write_once(fixture.writer, records, length) ||
+	    !freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if ((fixture.capture.count != beforeBudget + 16U) ||
+	    (WaitForSingleObject(freerdp_client_rail_ipc_get_event(fixture.ipc), 0) != WAIT_OBJECT_0))
+		goto out;
+	if (!freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if (fixture.capture.count != beforeBudget + 20U)
+		goto out;
+
+	static const char denseCompletions[] = "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nx\n\nprogram=p\n\n";
+	const size_t beforeDense = fixture.capture.count;
+	if (!write_once(fixture.writer, denseCompletions, sizeof(denseCompletions) - 1U) ||
+	    !freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if ((fixture.capture.count != beforeDense) ||
+	    (WaitForSingleObject(freerdp_client_rail_ipc_get_event(fixture.ipc), 0) != WAIT_OBJECT_0))
+		goto out;
+	if (!freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if ((fixture.capture.count != beforeDense + 1U) ||
+	    (strcmp(fixture.capture.orders[beforeDense].program, "p") != 0))
+		goto out;
+
+	if (!test_file_byte_budget(&fixture))
+		goto out;
+	rc = TRUE;
+
+out:
+	dispatch_fixture_uninit(&fixture);
+	return rc;
+}
+
+static BOOL test_concurrent_atomic_writers(wLog* log)
+{
+	BOOL rc = FALSE;
+	dispatchFixture fixture = WINPR_C_ARRAY_INIT;
+	int readyPipe[2] = { -1, -1 };
+	int startPipe[2] = { -1, -1 };
+	pid_t children[8] = WINPR_C_ARRAY_INIT;
+	size_t started = 0;
+	if (!dispatch_fixture_init(&fixture, log))
+		goto out;
+	if (!dispatch_fixture_set_ready(&fixture))
+		goto out;
+	if (!create_cloexec_pipe(readyPipe) || !create_cloexec_pipe(startPipe))
+		goto out;
+
+	for (size_t x = 0; x < ARRAYSIZE(children); x++)
+	{
+		const pid_t child = fork();
+		if (child < 0)
+			goto release;
+		if (child == 0)
+		{
+			close(readyPipe[0]);
+			close(startPipe[1]);
+			const BYTE ready = 1;
+			BYTE start = 0;
+			if (!write_once(readyPipe[1], &ready, sizeof(ready)) ||
+			    !read_exact(startPipe[0], &start, sizeof(start)))
+				_exit(1);
+			const int writer =
+			    open(fixture.named.fifoPath, O_WRONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW);
+			char record[128] = WINPR_C_ARRAY_INIT;
+			const int length =
+			    _snprintf(record, sizeof(record),
+			              "program=||writer-%" PRIuz "\narguments=token-%" PRIuz "\n\n", x, x);
+			const BOOL written =
+			    (writer >= 0) && (length > 0) && write_once(writer, record, (size_t)length);
+			if (writer >= 0)
+				close(writer);
+			_exit(written ? 0 : 1);
+		}
+		children[started++] = child;
+	}
+
+release:
+	close(readyPipe[1]);
+	readyPipe[1] = -1;
+	close(startPipe[0]);
+	startPipe[0] = -1;
+	BYTE ready[ARRAYSIZE(children)] = WINPR_C_ARRAY_INIT;
+	if ((started != ARRAYSIZE(children)) || !read_exact(readyPipe[0], ready, started))
+		goto out;
+	BYTE start[ARRAYSIZE(children)];
+	memset(start, 1, sizeof(start));
+	if (!write_once(startPipe[1], start, started))
+		goto out;
+	close(startPipe[1]);
+	startPipe[1] = -1;
+
+	for (size_t x = 0; x < started; x++)
+	{
+		int status = 0;
+		if ((waitpid(children[x], &status, 0) != children[x]) || !WIFEXITED(status) ||
+		    (WEXITSTATUS(status) != 0))
+			goto out;
+		children[x] = 0;
+	}
+	if (!freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if (fixture.capture.count != ARRAYSIZE(children))
+		goto out;
+
+	BOOL seen[ARRAYSIZE(children)] = WINPR_C_ARRAY_INIT;
+	for (size_t x = 0; x < fixture.capture.count; x++)
+	{
+		for (size_t expected = 0; expected < ARRAYSIZE(children); expected++)
+		{
+			char program[32] = WINPR_C_ARRAY_INIT;
+			char arguments[32] = WINPR_C_ARRAY_INIT;
+			(void)_snprintf(program, sizeof(program), "||writer-%" PRIuz, expected);
+			(void)_snprintf(arguments, sizeof(arguments), "token-%" PRIuz, expected);
+			if (!seen[expected] &&
+			    captured_matches(&fixture.capture.orders[x], program, "", arguments, 0))
+			{
+				seen[expected] = TRUE;
+				break;
+			}
+		}
+	}
+	for (size_t x = 0; x < ARRAYSIZE(seen); x++)
+	{
+		if (!seen[x])
+			goto out;
+	}
+	rc = TRUE;
+
+out:
+	if (readyPipe[0] >= 0)
+		close(readyPipe[0]);
+	if (readyPipe[1] >= 0)
+		close(readyPipe[1]);
+	if (startPipe[0] >= 0)
+		close(startPipe[0]);
+	if (startPipe[1] >= 0)
+	{
+		BYTE start[ARRAYSIZE(children)];
+		memset(start, 1, sizeof(start));
+		(void)write(startPipe[1], start, started);
+		close(startPipe[1]);
+	}
+	for (size_t x = 0; x < started; x++)
+	{
+		if (children[x] > 0)
+			(void)waitpid(children[x], nullptr, 0);
+	}
+	dispatch_fixture_uninit(&fixture);
+	return rc;
+}
+
+static BOOL disabled_context_retains_ownership(dispatchFixture* fixture, wLog* log)
+{
+	WINPR_ASSERT(fixture);
+	RailClientIpcContext* duplicate = freerdp_client_rail_ipc_new(fixture->named.settings, log);
+	if (duplicate)
+	{
+		freerdp_client_rail_ipc_free(duplicate);
+		return FALSE;
+	}
+	freerdp_client_rail_ipc_free(fixture->ipc);
+	fixture->ipc = nullptr;
+	RailClientIpcContext* successor = freerdp_client_rail_ipc_new(fixture->named.settings, log);
+	if (!successor)
+		return FALSE;
+	freerdp_client_rail_ipc_free(successor);
+	return TRUE;
+}
+
+static BOOL test_result_contracts(wLog* log)
+{
+	BOOL rc = FALSE;
+	dispatchFixture fixture = WINPR_C_ARRAY_INIT;
+	RailClientContext other = WINPR_C_ARRAY_INIT;
+
+	if (!freerdp_client_rail_ipc_check_event(nullptr) ||
+	    !freerdp_client_rail_ipc_attach(nullptr, nullptr) ||
+	    !freerdp_client_rail_ipc_detach(nullptr, nullptr) ||
+	    !freerdp_client_rail_ipc_set_ready(nullptr, TRUE))
+		return FALSE;
+
+	if (!dispatch_fixture_init(&fixture, log))
+		goto out;
+	if (freerdp_client_rail_ipc_attach(fixture.ipc, nullptr) ||
+	    freerdp_client_rail_ipc_detach(fixture.ipc, nullptr) ||
+	    freerdp_client_rail_ipc_set_ready(fixture.ipc, TRUE) ||
+	    freerdp_client_rail_ipc_get_event(fixture.ipc))
+		goto out;
+	if (!freerdp_client_rail_ipc_attach(fixture.ipc, &fixture.rail) ||
+	    !freerdp_client_rail_ipc_attach(fixture.ipc, &fixture.rail) ||
+	    !freerdp_client_rail_ipc_set_ready(fixture.ipc, TRUE))
+		goto out;
+	const HANDLE event = freerdp_client_rail_ipc_get_event(fixture.ipc);
+	if (!event || freerdp_client_rail_ipc_attach(fixture.ipc, &other) ||
+	    freerdp_client_rail_ipc_detach(fixture.ipc, &other) ||
+	    freerdp_client_rail_ipc_attach(fixture.ipc, nullptr) ||
+	    freerdp_client_rail_ipc_detach(fixture.ipc, nullptr) ||
+	    (freerdp_client_rail_ipc_get_event(fixture.ipc) != event))
+		goto out;
+	if (!freerdp_client_rail_ipc_set_ready(fixture.ipc, FALSE) ||
+	    freerdp_client_rail_ipc_get_event(fixture.ipc) ||
+	    !freerdp_client_rail_ipc_set_ready(fixture.ipc, TRUE) ||
+	    !freerdp_client_rail_ipc_detach(fixture.ipc, &fixture.rail) ||
+	    freerdp_client_rail_ipc_get_event(fixture.ipc) ||
+	    freerdp_client_rail_ipc_detach(fixture.ipc, &fixture.rail))
+		goto out;
+
+	fixture.rail.ClientExecute = nullptr;
+	if (!freerdp_client_rail_ipc_attach(fixture.ipc, &fixture.rail) ||
+	    !freerdp_client_rail_ipc_set_ready(fixture.ipc, TRUE) ||
+	    !freerdp_client_rail_ipc_get_event(fixture.ipc) ||
+	    freerdp_client_rail_ipc_check_event(fixture.ipc) ||
+	    freerdp_client_rail_ipc_get_event(fixture.ipc) ||
+	    !freerdp_client_rail_ipc_check_event(fixture.ipc) ||
+	    !freerdp_client_rail_ipc_set_ready(fixture.ipc, FALSE) ||
+	    !freerdp_client_rail_ipc_set_ready(fixture.ipc, TRUE) ||
+	    !freerdp_client_rail_ipc_detach(fixture.ipc, &fixture.rail))
+		goto out;
+	if (!disabled_context_retains_ownership(&fixture, log))
+		goto out;
+	rc = TRUE;
+
+out:
+	dispatch_fixture_uninit(&fixture);
+	return rc;
+}
+
+static BOOL test_permanent_failure_disables_input(wLog* log)
+{
+	BOOL rc = FALSE;
+	dispatchFixture fixture = WINPR_C_ARRAY_INIT;
+	if (!dispatch_fixture_init(&fixture, log))
+		goto out;
+	if (!dispatch_fixture_set_ready(&fixture))
+		goto out;
+	HANDLE event = freerdp_client_rail_ipc_get_event(fixture.ipc);
+	if (!event || (SetEventFileDescriptor(event, -1, WINPR_FD_READ) < 0))
+		goto out;
+	if (freerdp_client_rail_ipc_check_event(fixture.ipc) ||
+	    freerdp_client_rail_ipc_get_event(fixture.ipc) || (fixture.capture.count != 0) ||
+	    !freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if (!freerdp_client_rail_ipc_set_ready(fixture.ipc, FALSE) ||
+	    !freerdp_client_rail_ipc_set_ready(fixture.ipc, TRUE))
+		goto out;
+	if (freerdp_client_rail_ipc_get_event(fixture.ipc) || (fixture.capture.count != 0))
+		goto out;
+	if (!freerdp_client_rail_ipc_detach(fixture.ipc, &fixture.rail))
+		goto out;
+	if (!disabled_context_retains_ownership(&fixture, log))
+		goto out;
+	dispatch_fixture_uninit(&fixture);
+
+	if (!dispatch_fixture_init(&fixture, log))
+		goto out;
+	if (!dispatch_fixture_set_ready(&fixture))
+		goto out;
+	event = freerdp_client_rail_ipc_get_event(fixture.ipc);
+	if (!event)
+		goto out;
+	const int readFd = GetEventFileDescriptor(event);
+	if (readFd < 0)
+		goto out;
+	const int directoryFd = open(fixture.named.directory, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+	if (directoryFd < 0)
+		goto out;
+	const int replaced = dup2(directoryFd, readFd);
+	close(directoryFd);
+	if ((replaced != readFd) || freerdp_client_rail_ipc_check_event(fixture.ipc) ||
+	    freerdp_client_rail_ipc_get_event(fixture.ipc) || (fixture.capture.count != 0) ||
+	    !freerdp_client_rail_ipc_check_event(fixture.ipc))
+		goto out;
+	if (!freerdp_client_rail_ipc_set_ready(fixture.ipc, FALSE) ||
+	    !freerdp_client_rail_ipc_set_ready(fixture.ipc, TRUE))
+		goto out;
+	if (freerdp_client_rail_ipc_get_event(fixture.ipc) || (fixture.capture.count != 0))
+		goto out;
+	if (!freerdp_client_rail_ipc_detach(fixture.ipc, &fixture.rail))
+		goto out;
+	if (!disabled_context_retains_ownership(&fixture, log))
+		goto out;
+	rc = TRUE;
+
+out:
+	dispatch_fixture_uninit(&fixture);
+	return rc;
+}
+
+int main(void)
+{
+	wLog* log = WLog_Get("com.freerdp.test.client.rail-ipc");
+	if (!log || !WLog_SetLogLevel(log, WLOG_OFF))
+		return 1;
+
+	if (!test_session_keys(log))
+		return 1;
+	printf("PASS session key preserves all 44 audited routing and exclusion cases\n");
+	if (!test_primary_lifecycle(log))
+		return 1;
+	printf(
+	    "PASS paths, primary exclusion, independent keys, writable FIFO and held-writer state\n");
+	if (!test_stale_fifo_reuse(log))
+		return 1;
+	printf("PASS stale FIFO is safely reused after all old descriptors close\n");
+	if (!test_identity_safe_cleanup(log))
+		return 1;
+	printf("PASS cleanup leaves a replacement FIFO whose identity does not match\n");
+	if (!test_filesystem_rejections(log))
+		return 1;
+	printf("PASS unsafe runtime directory, lock and FIFO forms are rejected\n");
+	if (!test_construction_failures(log))
+		return 1;
+	printf("PASS construction failures release descriptors and ownership without unsafe cleanup\n");
+	if (!test_protocol_fields_and_order(log))
+		return 1;
+	printf("PASS labelled fields, defaults, first-equals splitting and every key order\n");
+	if (!test_flags_and_grammar_rejection(log))
+		return 1;
+	printf("PASS flags and strict v1 grammar acceptance and rejection\n");
+	if (!test_encoding_and_size_limits(log))
+		return 1;
+	printf("PASS UTF-8, converted RAIL lengths and exact FIFO record-size limits\n");
+	if (!test_streaming_resynchronisation_and_rejection(log))
+		return 1;
+	printf("PASS partial input, multi-record reads, resynchronisation and local rejection\n");
+	if (!test_readiness_and_drain_budgets(log))
+		return 1;
+	printf("PASS detached and suspended buffering plus record and byte drain budgets\n");
+	if (!test_concurrent_atomic_writers(log))
+		return 1;
+	printf("PASS concurrent conforming writers preserve every atomic record\n");
+	if (!test_result_contracts(log))
+		return 1;
+	printf("PASS public result contracts reject invalid state without mutation\n");
+	if (!test_permanent_failure_disables_input(log))
+		return 1;
+	printf("PASS permanent event and read failures disable input while retaining ownership\n");
+	(void)SetEnvironmentVariableA("XDG_RUNTIME_DIR", nullptr);
+	return 0;
+}

--- a/include/freerdp/client/rail_ipc.h
+++ b/include/freerdp/client/rail_ipc.h
@@ -1,0 +1,93 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Common RAIL launch IPC
+ *
+ * Copyright 2026 Tony Dursun <oraturk75@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CLIENT_RAIL_IPC_H
+#define FREERDP_CLIENT_RAIL_IPC_H
+
+#include <freerdp/api.h>
+#include <freerdp/settings.h>
+#include <freerdp/client/rail.h>
+
+#include <winpr/synch.h>
+#include <winpr/wlog.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+	typedef struct s_rail_client_ipc RailClientIpcContext;
+
+	/**
+	 * Free a common RAIL launch IPC context.
+	 *
+	 * Must run on the client-loop thread that created the context.
+	 */
+	FREERDP_API void freerdp_client_rail_ipc_free(RailClientIpcContext* ipc);
+
+	/**
+	 * Create the primary-side FIFO for the session described by settings.
+	 *
+	 * Returns nullptr when the transport is unavailable, setup is unsafe, or another primary
+	 * already owns the session key. Must be called before connecting the RDP client.
+	 */
+	WINPR_ATTR_MALLOC(freerdp_client_rail_ipc_free, 1)
+	WINPR_ATTR_NODISCARD
+	FREERDP_API RailClientIpcContext* freerdp_client_rail_ipc_new(const rdpSettings* settings,
+	                                                              wLog* log);
+
+	/**
+	 * Return the FIFO event while a RAIL channel is attached and ready, otherwise nullptr.
+	 */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API HANDLE freerdp_client_rail_ipc_get_event(const RailClientIpcContext* ipc);
+
+	/**
+	 * Process ready FIFO input on the client-loop thread.
+	 *
+	 * Detached, not-ready, and permanently disabled states are successful no-ops.
+	 * Returns FALSE after an operational failure permanently disables FIFO input.
+	 */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API BOOL freerdp_client_rail_ipc_check_event(RailClientIpcContext* ipc);
+
+	/** Attach a RAIL channel on the client-loop thread. Returns FALSE for an invalid conflict. */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API BOOL freerdp_client_rail_ipc_attach(RailClientIpcContext* ipc,
+	                                                RailClientContext* rail);
+
+	/** Detach the current RAIL channel on the client-loop thread. Returns FALSE on mismatch. */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API BOOL freerdp_client_rail_ipc_detach(RailClientIpcContext* ipc,
+	                                                RailClientContext* rail);
+
+	/** Set whether the attached RAIL channel can accept Client Execute orders. Returns FALSE when
+	 * enabling input without an attached channel. */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API BOOL freerdp_client_rail_ipc_set_ready(RailClientIpcContext* ipc, BOOL ready);
+
+	/** Return the FIFO path. The pointer remains valid until the context is freed. */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API const char* freerdp_client_rail_ipc_get_path(const RailClientIpcContext* ipc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FREERDP_CLIENT_RAIL_IPC_H */


### PR DESCRIPTION
Part of #498.

## What this changes

On a server configured for one interactive session, starting a second `xfreerdp
/app:` takes the session from the first. Existing applications disappear and
return on the new connection, making multiple RemoteApp launches disruptive.

This adds a control path to the existing connection, so later launches send
another Client Execute instead of opening a new connection. MS-RDPERP permits
further Client Execute PDUs after `ExecuteApp`.

**Off by default.** The X11 client enables it with `+rail-multi-exec`, only in
RemoteApp mode.

The initial version used a Unix socket, follower mode and request/response
protocol. Following @akallabeth's review, this current version uses a reusable
common FIFO component with fire-and-forget records. It is roughly 1800 lines
smaller, with no follower, response framing, correlation or launch queue.

## FIFO protocol

`client/common/rail_ipc.c` owns a named FIFO and calls `RailClientContext::ClientExecute`
when a record arrives. Only X11 is wired in this PR, but another client can reuse
the common component with its own adapter.

The FIFO is `$XDG_RUNTIME_DIR/freerdp-rail-v1-<sha256>.fifo`, mode 0600. The key
hashes a versioned, length-prefixed serialization of the settings that identify
a session. It excludes credentials, presentation settings and values learned
after connecting.

A record is labelled UTF-8 lines terminated by one empty line:

```
program=||notepad
working-directory=
arguments=
flags=0

```

Only `program` is required. Keys may appear in any order. Duplicate or unknown
keys reject the record, and `flags` accepts decimal or `0x` hexadecimal. After
malformed input, the parser discards through the next empty line and continues.

Submit the complete record in one `write()` no larger than the FIFO's
`_PC_PIPE_BUF`, so concurrent writers cannot interleave:

```sh
printf '%s\n\n' 'program=||notepad' > "$fifo"
```

## Safety and lifetime

The runtime directory is opened once and checked for ownership and permissions,
and later operations are relative to that descriptor. The FIFO is validated
before and after opening, then removed at teardown only if its identity still
matches.

A `flock()` on a sidecar `.lock` file elects one primary `xfreerdp` process for
each session key. A second opted-in process exits before `freerdp_connect()`,
avoiding a competing connection. The lock file remains because replacing its
locked inode creates a race; the kernel releases the lock when the primary exits.

Records remain in the kernel FIFO until the RAIL channel is ready. Reads are
bounded so FIFO traffic cannot starve the RDP connection, and they pause during
desktop resynchronization or channel loss.

## Launch behavior

A write tells the writer that the kernel accepted the bytes, and nothing more.
Server and local failures appear in the FreeRDP log.

Responses are intentionally out of scope. Returning an Execute result to the
originating writer would require a separate return path, correlation, and
additional lifetime and failure handling, reintroducing much of the complexity
removed from the earlier prototype. It can be evaluated separately if a concrete
caller needs it; this PR makes no commitment to that extension.

Normal RemoteApp mode keeps its existing behavior: a rejected launch ends the
session. With `+rail-multi-exec`, a rejection is logged and the session remains
available for later records, even if no application has launched yet. This
policy follows the selected mode rather than whether an earlier launch succeeded.

The accepted cost is that a bad first path can leave the client connected with
no window until a later valid record arrives or the server's own session policy
ends it.

With `+rail-multi-exec`, the initial `/app:program:` is optional: `xfreerdp`
completes the RAIL preamble and waits for the first FIFO record. The shared
helper skips only an empty Client Execute; all non-empty Windows and Android
calls remain unchanged, while an empty Windows call still receives the preamble.

## Known limits

- Receiving side only. A later `xfreerdp` process using `+rail-multi-exec`
  currently exits before connecting instead of forwarding its `/app` request.
  Automatic submit-and-exit was deferred to keep this the primary-only
  implementation @akallabeth asked for.
- An `xfreerdp` process started without `+rail-multi-exec` does not participate
  and can still take the Windows session from the opted-in process. Launchers
  relying on connection reuse must enable the option consistently.
- Values cannot contain LF or NUL.
- Records are capped by `_PC_PIPE_BUF` (4096 bytes on Linux), below RAIL's
  16000-byte argument limit.
- POSIX only; construction reports unsupported elsewhere.
- The opt-in is an X11 command-line option rather than a FreeRDP setting.

## Testing

The common component test now builds without linker wrapping or a visibility
override. Real conditions cover descriptor exhaustion, read failure, wait
failure and the per-pass byte budget.

Synthetic ownership changes, forced failure of an allocation-only WinPR call,
the validation-to-open FIFO substitution, and a fictional `_PC_PIPE_BUF` were
removed rather than preserved behind production test seams. The production
defenses remain unchanged. Deterministic coverage of the individual ownership
clauses and the validation-to-open recheck is no longer claimed.

The X11 wrappers remain because they substitute for unavailable X and RDP
servers. Removing each one was verified to break its intended test.

The seven `client/common` and `client/X11` tests pass normally and under
AddressSanitizer with no leaks. The changed sources build without new warnings;
`clang-format`, `cmake-format` and `git diff --check` are clean.

Live against Windows 11 with one interactive session:

- an empty initial program completed the RAIL handshake without sending a
  Client Execute;
- a nonexistent first program was rejected without ending the connection;
- three applications then launched through the FIFO over one TCP connection
  and one guest session, without replacing the earlier windows or their owning
  process;
- another bad launch was contained and the following launch still worked;
- teardown removed the FIFO and retained the sidecar lock.
