### PR TITLE
[gdi] document cache requirement for gdi_init

### DIFF
--- a/libfreerdp/gdi/gdi.c
+++ b/libfreerdp/gdi/gdi.c
@@ -1413,6 +1413,10 @@ BOOL gdi_resize_ex(rdpGdi* gdi, UINT32 width, UINT32 height, UINT32 stride, UINT
  * @param instance A pointer to the instance to use
  * @param format The color format for the local framebuffer
  * @return \b TRUE for success, \b FALSE for failure
+ *
+ * @note Must be called after the connect sequence has completed, e.g. from the
+ * \b PostConnect callback: GDI requires the \b rdpCache created by the
+ * core during connection, after capability negotiation.
  */
 BOOL gdi_init(freerdp* instance, UINT32 format)
 {
@@ -1429,6 +1433,10 @@ BOOL gdi_init(freerdp* instance, UINT32 format)
  * @param pfree A custom function pointer to use to free the framebuffer
  *
  * @return \b TRUE for success, \b FALSE for failure
+ *
+ * @note Must be called after the connect sequence has completed, e.g. from the
+ * \b PostConnect callback: GDI requires the \b rdpCache created by the
+ * core during connection, after capability negotiation.
  */
 BOOL gdi_init_ex(freerdp* instance, UINT32 format, UINT32 stride, BYTE* buffer,
                  void (*pfree)(void*))


### PR DESCRIPTION
Per review feedback on the original patch: `gdi_init`/`gdi_init_ex` require the `rdpCache`, which since `c41d16a38` ("[core,cache] move cache from gdi to core") is created by the core during the connect sequence rather than by `gdi_init_ex` itself. Calling them outside that sequence dereferences a NULL cache through `brush_cache_register_callbacks()` and `bitmap_cache_register_callbacks()`.

Neither the header declarations nor the existing doxygen blocks carried any lifecycle note, so this documents the precondition on both functions.

No functional change.
