### PR TITLE
[core,connection] abort after PROTOCOL_FAILED_NEGO

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -1562,6 +1562,12 @@ BOOL rdp_server_accept_nego(rdpRdp* rdp, wStream* s)
 	if (!nego_send_negotiation_response(nego))
 		return FALSE;
 
+	if ((SelectedProtocol & PROTOCOL_FAILED_NEGO) != 0)
+	{
+		WLog_ERR(TAG, "Protocol security negotiation failed, disconnecting.");
+		return FALSE;
+	}
+
 	SelectedProtocol = nego_get_selected_protocol(nego);
 	status = FALSE;
 


### PR DESCRIPTION
when this condition was encountered, send the failure response and terminate.