### PR TITLE
winpr/sspi/negotiate: NULL check sub credentials accepting context

### DIFF
--- a/winpr/libwinpr/sspi/Negotiate/negotiate.c
+++ b/winpr/libwinpr/sspi/Negotiate/negotiate.c
@@ -1115,10 +1115,13 @@ static SECURITY_STATUS SEC_ENTRY negotiate_AcceptSecurityContext(
 		{
 			sub_cred = negotiate_FindCredential(creds, init_context.mech);
 
-			status = init_context.mech->pkg->table->AcceptSecurityContext(
-			    sub_cred, nullptr, init_context.spnego ? &mech_input : pInput, fContextReq,
-			    TargetDataRep, &init_context.sub_context,
-			    init_context.spnego ? &mech_output : pOutput, pfContextAttr, ptsTimeStamp);
+			if (sub_cred)
+			{
+				status = init_context.mech->pkg->table->AcceptSecurityContext(
+				    sub_cred, nullptr, init_context.spnego ? &mech_input : pInput, fContextReq,
+				    TargetDataRep, &init_context.sub_context,
+				    init_context.spnego ? &mech_output : pOutput, pfContextAttr, ptsTimeStamp);
+			}
 		}
 
 		if (IsSecurityStatusError(status))


### PR DESCRIPTION
The sub credential might be there, but invalid, in which case NULL is returned. This might happen if e.g. krb5_init_context() doesn't succeed.

This fixes the current crash:

 3)  0x00007fc3c61ee81e in __assert_fail_base.cold
 4)  0x00007fc3c64ec1da in InterlockedIncrement
 5)  0x00007fc3c6544b0d in kerberos_ContextNew (credentials=0x0)
 6)  0x00007fc3c65483d8 in kerberos_AcceptSecurityContext
 7)  0x00007fc3c654eebe in negotiate_AcceptSecurityContext
 8)  0x00007fc3c65563ad in winpr_AcceptSecurityContext
 9)  0x00007fc3c679e8d8 in credssp_auth_authenticate (auth=0x7fc3b8070240)
 10) 0x00007fc3c66e6ef5 in nla_server_authenticate (nla=0x7fc3b80090b0)
 11) 0x00007fc3c66e71d2 in nla_authenticate (nla=0x7fc3b80090b0)
 12) 0x00007fc3c67709ae in transport_accept_nla (transport=0x3c7a40d0)
 13) 0x00007fc3c6743d7e in rdp_server_accept_nego (rdp=0x3ce77190, s=0x3c797be0)
 14) 0x00007fc3c679a966 in peer_recv_callback_internal (transport=0x3c7a40d0, s=0x3c797be0, extra=0x3c772a90)
 15) 0x00007fc3c679b7d7 in peer_recv_callback (transport=0x3c7a40d0, s=0x3c797be0, extra=0x3c772a90)
 16) 0x00007fc3c6772cae in transport_check_fds (transport=0x3c7a40d0)
 17) 0x00007fc3c675b36c in rdp_check_fds (rdp=0x3ce77190)
 18) 0x00007fc3c67990fa in freerdp_peer_check_fds (peer=0x3c772a90)

----

On a system I tested server side Kerberos authentication, if SELinux is enabled, gnome-remote-desktop crashed with the following backtrace:

```
#0  0x00007fc3c625d71c in __pthread_kill_implementation () at /lib64/libc.so.6
#1  0x00007fc3c6207096 in raise () at /lib64/libc.so.6
#2  0x00007fc3c61ee8fa in abort () at /lib64/libc.so.6
#3  0x00007fc3c61ee81e in __assert_fail_base.cold () at /lib64/libc.so.6
#4  0x00007fc3c64ec1da in InterlockedIncrement (Addend=0x0) at /home/admin/Dev/FreeRDP/winpr/libwinpr/interlocked/interlocked.c:241
#5  0x00007fc3c6544b0d in kerberos_ContextNew (credentials=0x0) at /home/admin/Dev/FreeRDP/winpr/libwinpr/sspi/Kerberos/kerberos.c:229
#6  0x00007fc3c65483d8 in kerberos_AcceptSecurityContext
    (phCredential=0x0, phContext=0x0, pInput=0x7fc3b2ffb920, fContextReq=34874, TargetDataRep=16, phNewContext=0x7fc3b2ffb9d8, pOutput=0x7fc3b2ffb910, pfContextAttr=0x7fc3b80702f8, ptsExpity=0x0)
    at /home/admin/Dev/FreeRDP/winpr/libwinpr/sspi/Kerberos/kerberos.c:1534
#7  0x00007fc3c654eebe in negotiate_AcceptSecurityContext
    (phCredential=0x7fc3b8070298, phContext=0x0, pInput=0x7fc3b2ffbb30, fContextReq=34874, TargetDataRep=16, phNewContext=0x7fc3b80702c8, pOutput=0x7fc3b2ffbb20, pfContextAttr=0x7fc3b80702f8, ptsTimeStamp=0x0)
    at /home/admin/Dev/FreeRDP/winpr/libwinpr/sspi/Negotiate/negotiate.c:1118
#8  0x00007fc3c65563ad in winpr_AcceptSecurityContext
    (phCredential=0x7fc3b8070298, phContext=0x0, pInput=0x7fc3b2ffbb30, fContextReq=34874, TargetDataRep=16, phNewContext=0x7fc3b80702c8, pOutput=0x7fc3b2ffbb20, pfContextAttr=0x7fc3b80702f8, ptsTimeStamp=0x0)
    at /home/admin/Dev/FreeRDP/winpr/libwinpr/sspi/sspi_winpr.c:1522
#9  0x00007fc3c679e8d8 in credssp_auth_authenticate (auth=0x7fc3b8070240) at /home/admin/Dev/FreeRDP/libfreerdp/core/credssp_auth.c:499
#10 0x00007fc3c66e6ef5 in nla_server_authenticate (nla=0x7fc3b80090b0) at /home/admin/Dev/FreeRDP/libfreerdp/core/nla.c:806
#11 0x00007fc3c66e71d2 in nla_authenticate (nla=0x7fc3b80090b0) at /home/admin/Dev/FreeRDP/libfreerdp/core/nla.c:911
#12 0x00007fc3c67709ae in transport_accept_nla (transport=0x3c7a40d0) at /home/admin/Dev/FreeRDP/libfreerdp/core/transport.c:739
#13 0x00007fc3c6743d7e in rdp_server_accept_nego (rdp=0x3ce77190, s=0x3c797be0) at /home/admin/Dev/FreeRDP/libfreerdp/core/connection.c:1575
#14 0x00007fc3c679a966 in peer_recv_callback_internal (transport=0x3c7a40d0, s=0x3c797be0, extra=0x3c772a90) at /home/admin/Dev/FreeRDP/libfreerdp/core/peer.c:815
#15 0x00007fc3c679b7d7 in peer_recv_callback (transport=0x3c7a40d0, s=0x3c797be0, extra=0x3c772a90) at /home/admin/Dev/FreeRDP/libfreerdp/core/peer.c:1193
#16 0x00007fc3c6772cae in transport_check_fds (transport=0x3c7a40d0) at /home/admin/Dev/FreeRDP/libfreerdp/core/transport.c:1527
#17 0x00007fc3c675b36c in rdp_check_fds (rdp=0x3ce77190) at /home/admin/Dev/FreeRDP/libfreerdp/core/rdp.c:2306
#18 0x00007fc3c67990fa in freerdp_peer_check_fds (peer=0x3c772a90) at /home/admin/Dev/FreeRDP/libfreerdp/core/peer.c:325
#19 0x0000000000490168 in socket_thread_func (data=0x3ce6ab50) at ../src/grd-session-rdp.c:1784
#20 0x00007fc3c73d4312 in g_thread_proxy () at /lib64/libglib-2.0.so.0
#21 0x00007fc3c625b7bf in start_thread () at /lib64/libc.so.6
#22 0x00007fc3c62cc33c in clone3 () at /lib64/libc.so.6
```

after the following logs had ended up in the journal:

```
Aug 21 16:17:19 c10s-fips.local gnome-remote-desktop-daemon[16196]: [16:17:19:407] [16196:00003f4d] [ERROR][com.winpr.sspi.Kerberos] - [kerberos_AcquireCredentialsHandleA]: krb5_init_context (Included profile directory could not be read [-1429577696])
Aug 21 16:17:19 c10s-fips.local gnome-remote-desktop-daemon[16196]: [16:17:19:407] [16196:00003f4d] [ERROR][com.winpr.sspi.Kerberos] - [kerberos_AcquireCredentialsHandleA]: krb5_init_context (Included profile directory could not be read [-1429577696])
```

This PR avoids the crash, but obviously doesn't make anything actually work, since SELinux doesn't allow it, but better not crash.