### PR TITLE
Fix utf-8 encoding of LS and PS in winpr_str_has_newlines

### DIFF
--- a/winpr/libwinpr/crt/string.c
+++ b/winpr/libwinpr/crt/string.c
@@ -963,16 +963,10 @@ BOOL winpr_str_has_newlines(const char* str)
 			case 0x0c:       /* FF form feed */
 			case (char)0x85: /* NEL next line */
 				return TRUE;
-			case 0x20:
+			case (char)0xE2:
 			{
-				switch (*str)
-				{
-					case 0x28: /* LS line separator */
-					case 0x29: /* PS paragraph separator */
-						return TRUE;
-					default:
-						break;
-				}
+				if ((str[0] == (char)0x80) && ((str[1] == (char)0xA8) || (str[1] == (char)0xA9)))
+					return TRUE;
 			}
 			break;
 


### PR DESCRIPTION
Old utf-8 byte codes were incorrect, assuming the unicode ID translated directly to bytes. According to https://www.compart.com/en/unicode/U+2028, the utf-8 encoding should be 0xE2 0x80 0xA8 and 0xE2 0x80 0xA9 for LS and PS respectively. This change properly checks that.