### PR TITLE
[core,test] ignore SIGPIPE in TestFuzzServerSeedGen

### DIFF
--- a/libfreerdp/core/test/TestFuzzServerSeedGen.c
+++ b/libfreerdp/core/test/TestFuzzServerSeedGen.c
@@ -58,6 +58,7 @@
 #include <errno.h>
 #include <netinet/in.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -404,6 +405,8 @@ static int write_seed(const char* dir, const char* name, const capture_t* c)
 
 int main(int argc, char** argv)
 {
+	(void)signal(SIGPIPE, SIG_IGN);
+
 	const char* outdir = argc > 1 ? argv[1] : ".";
 	int do_input = 1;
 	if (argc > 2)


### PR DESCRIPTION
The relay threads and the FreeRDP transport write to sockets whose peer end may already be closed during teardown. A plain write()/send() to such a socket raises SIGPIPE, which terminates the whole process with a signal (observed as exit code 141) instead of failing the call.

Ignore SIGPIPE so the write returns EPIPE and the existing error paths (relay loop breaks on a short write, transport treats it as a closed connection) handle the situation cleanly.

Needed for google/oss-fuzz#16042
