### PR TITLE
[client,x11] fix cliprdr infinite request loop

### DIFF
--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -2456,7 +2456,7 @@ xf_cliprdr_server_format_data_response(CliprdrClientContext* context,
 		const xfCliprdrFormat* cformat =
 		    xf_cliprdr_get_client_format_by_atom(clipboard, next->expectedResponse->target);
 
-		size_t index = 1;
+		size_t index = 0;
 		while ((next = ArrayList_GetItem(clipboard->queued_responses, index)) != nullptr)
 		{
 			if (next->requestedFormat->formatToRequest == nextFormatId)


### PR DESCRIPTION
`queued_responses[0]` gets read to build the next format-data request, but it never actually gets removed from the queue. Only duplicates at index 1+ get folded into `pending_responses` and resolved. So the head entry never resolves: the response comes back, `pending_responses` is empty, and we fall through to the same still-queued entry and fire the same request again. Forever.

It doesn't appear to be an edge case. `queued_responses` ends up with more than one entry any time a Format List PDU announces more than one format at once, which MS-RDPECLIP requires ("the sender MUST enumerate all of the formats currently available from the local system clipboard"). Just copying a file while there's also text on the clipboard is enough.

Tested against a server that offers text plus a file list together, connected with `xfreerdp`. Before: hundreds of thousands of duplicate requests a second, still climbing minutes later. After: 3 requests, then the logs were quiet.

Fix is one line: start the fold-in scan at index 0 instead of 1, so the head entry gets dequeued and resolved like everything else.