### PR TITLE
[build,mingw] replace C++11 constructs

### DIFF
--- a/client/SDL/SDL3/sdl_window.cpp
+++ b/client/SDL/SDL3/sdl_window.cpp
@@ -318,8 +318,8 @@ bool SdlWindow::drawScaledRect(SDL_Surface* surface, const SDL_FPoint& scale,
 	SDL_Rect dstRect = {};
 	float ix = 0.0f;
 	float iy = 0.0f;
-	const auto modx = std::modff(static_cast<float>(srcRect.x) * scale.x, &ix);
-	const auto mody = std::modff(static_cast<float>(srcRect.y) * scale.y, &iy);
+	const auto modx = std::modf(static_cast<float>(srcRect.x) * scale.x, &ix);
+	const auto mody = std::modf(static_cast<float>(srcRect.y) * scale.y, &iy);
 	auto sw = std::ceil(static_cast<float>(srcRect.w) * scale.x) + std::ceil(modx);
 	auto sh = std::ceil(static_cast<float>(srcRect.h) * scale.y) + std::ceil(mody);
 	dstRect.x = static_cast<Sint32>(ix);


### PR DESCRIPTION
Some C++11 components are not supported by mingw on ubuntu 24.04. Replace these elements with ones that are available.