### PR TITLE
[winpr] fix TestThreadCreateProcess

### DIFF
--- a/winpr/libwinpr/thread/test/TestThreadCreateProcess.c
+++ b/winpr/libwinpr/thread/test/TestThreadCreateProcess.c
@@ -109,6 +109,7 @@ static int run_inherit_case(const char* exePath, const char* label, HANDLE probe
 
 	STARTUPINFOA* siPtr = &si;
 	DWORD createFlags = 0;
+	HANDLE handles[2] = { outWrite, probeHandle };
 
 	if (useExtended)
 	{
@@ -128,7 +129,6 @@ static int run_inherit_case(const char* exePath, const char* label, HANDLE probe
 		 * outWrite isn't in it too, the child wouldn't get a usable stdout handle at all, and
 		 * this test's own OPEN/CLOSED result-capture mechanism would break. Only the probe
 		 * handle's presence is what actually varies between the two list-based cases. */
-		HANDLE handles[2] = { outWrite, probeHandle };
 		const size_t handleCount = (mode == MODE_HANDLE_LIST_WITH_PROBE) ? 2 : 1;
 		if (!UpdateProcThreadAttribute(attrList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
 		                               (void*)handles, handleCount * sizeof(HANDLE), nullptr,


### PR DESCRIPTION
In WinPR we have respected the windows API that states that values passed to UpdateProcThreadAttribute must survive until DeleteProcThreadAttributeList is called. It happens that even in C (depending on compiler settings), local variable are altered when exiting a block, so in the unitary test let's move the `handles` declaration a bit higher in the function so that it lives for the whole function.
