### PR TITLE
[core,connection] use cache_resize

### DIFF
--- a/libfreerdp/core/connection.c
+++ b/libfreerdp/core/connection.c
@@ -576,9 +576,7 @@ static BOOL rdp_client_reconnect_channels(rdpRdp* rdp, BOOL redirect)
 
 		pointer_cache_register_callbacks(context->update);
 
-		WINPR_ASSERT(!context->cache);
-		context->cache = cache_new(context);
-		if (!context->cache)
+		if (!cache_resize(context))
 			return FALSE;
 
 		if (!IFCALLRESULT(FALSE, context->instance->PostConnect, context->instance))


### PR DESCRIPTION
When calling PostConnect the cache might already exist (freerdp_reconnect, freerdp_redirect, ...) so just recreate it and do not check for nullptr