### PR TITLE
create alpha capable GFX surfaces for XRGB_8888

### DIFF
--- a/client/X11/xf_gfx.c
+++ b/client/X11/xf_gfx.c
@@ -356,7 +356,7 @@ static UINT xf_CreateSurface(RdpgfxClientContext* context,
 			break;
 
 		case GFX_PIXEL_FORMAT_XRGB_8888:
-			surface->gdi.format = PIXEL_FORMAT_BGRX32;
+			surface->gdi.format = PIXEL_FORMAT_BGRA32;
 			break;
 
 		default:

--- a/libfreerdp/gdi/gfx.c
+++ b/libfreerdp/gdi/gfx.c
@@ -1295,7 +1295,7 @@ static UINT gdi_CreateSurface(RdpgfxClientContext* context,
 			break;
 
 		case GFX_PIXEL_FORMAT_XRGB_8888:
-			surface->format = PIXEL_FORMAT_BGRX32;
+			surface->format = PIXEL_FORMAT_BGRA32;
 			break;
 
 		default:


### PR DESCRIPTION

- Fixes #13244.

Windows 11 creates RemoteApp menu surfaces as `GFX_PIXEL_FORMAT_XRGB_8888` and then sends `RDPGFX_CODECID_ALPHA` for them. The alpha lands in the 4th byte of a `PIXEL_FORMAT_BGRX32` surface, where `FreeRDPColorHasAlpha()` is false, so the next `RDPGFX_CODECID_CAPROGRESSIVE` command drops `FREERDP_KEEP_DST_ALPHA` and overwrites it with the tile buffer's `0xFF` padding. The menu's DWM drop shadow then renders as an opaque black bar.

Both surface creation paths now map `XRGB_8888` to `PIXEL_FORMAT_BGRA32`, so the existing `FREERDP_KEEP_DST_ALPHA` guard works and the alpha survives. Both already prefill the surface with `0xFF`, so a surface that never receives alpha data stays opaque.

## Measurements

In one Explorer session `xfreerdp` created 14 XRGB surfaces and all 14 received an ALPHA command. It also created 2 ARGB ones, neither received any.

Sampling one pixel of the broken menu's surface (200x165, the one from the report) after each command, same session and same menu, only the mapping changed:

```
                              before     after
RDPGFX_CODECID_CLEARCODEC     00000000   00000000
RDPGFX_CODECID_ALPHA          03000000   03000000
RDPGFX_CODECID_CAPROGRESSIVE  FF000000   03000000
```

The sequence repeated four times per session in both runs. The black bar is visible on screen in the before run and gone in the after run.