### PR TITLE
[winpr,handles] allow to Close a HANDLE listed in PROC_THREAD_ATTRIBUTE_HANDLE_LIST

### DIFF
--- a/winpr/libwinpr/comm/comm.c
+++ b/winpr/libwinpr/comm/comm.c
@@ -1502,7 +1502,6 @@ BOOL CommCloseHandle(HANDLE handle)
 	if (pComm->fd_read_event > 0)
 		close(pComm->fd_read_event);
 
-	free(pComm);
 	return TRUE;
 }
 

--- a/winpr/libwinpr/file/file.c
+++ b/winpr/libwinpr/file/file.c
@@ -102,7 +102,7 @@ static BOOL FileCloseHandleInt(HANDLE handle, BOOL force)
 	}
 
 	free(file->lpFileName);
-	free(file);
+	file->lpFileName = nullptr;
 	return TRUE;
 }
 
@@ -970,6 +970,7 @@ static HANDLE FileCreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dw
 		{
 			SetLastError(map_posix_err(errno));
 			FileCloseHandle(pFile);
+			free(pFile);
 			return INVALID_HANDLE_VALUE;
 		}
 	}
@@ -1008,6 +1009,7 @@ static HANDLE FileCreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dw
 
 			SetLastError(map_posix_err(errno));
 			FileCloseHandle(pFile);
+			free(pFile);
 			return INVALID_HANDLE_VALUE;
 		}
 
@@ -1021,6 +1023,7 @@ static HANDLE FileCreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dw
 		{
 			SetLastError(map_posix_err(errno));
 			FileCloseHandle(pFile);
+			free(pFile);
 			return INVALID_HANDLE_VALUE;
 		}
 	}
@@ -1064,6 +1067,7 @@ static WINPR_FILE* FileHandle_New(FILE* fp)
 void GetStdHandle_Uninit(void)
 {
 	FileCloseHandleInt(pStdHandleFile, TRUE);
+	free(pStdHandleFile);
 }
 
 HANDLE GetStdHandle(DWORD nStdHandle)

--- a/winpr/libwinpr/file/namedPipeClient.c
+++ b/winpr/libwinpr/file/namedPipeClient.c
@@ -61,21 +61,25 @@ static BOOL NamedPipeClientCloseHandle(HANDLE handle)
 	{
 		// WLOG_DBG(TAG, "closing clientfd %d", pNamedPipe->clientfd);
 		close(pNamedPipe->clientfd);
+		pNamedPipe->clientfd = -1;
 	}
 
 	if (pNamedPipe->serverfd != -1)
 	{
 		// WLOG_DBG(TAG, "closing serverfd %d", pNamedPipe->serverfd);
 		close(pNamedPipe->serverfd);
+		pNamedPipe->serverfd = -1;
 	}
 
 	if (pNamedPipe->pfnUnrefNamedPipe)
 		pNamedPipe->pfnUnrefNamedPipe(pNamedPipe);
 
 	free(pNamedPipe->lpFileName);
+	pNamedPipe->lpFileName = nullptr;
 	free(pNamedPipe->lpFilePath);
+	pNamedPipe->lpFilePath = nullptr;
 	free(pNamedPipe->name);
-	free(pNamedPipe);
+	pNamedPipe->name = nullptr;
 	return TRUE;
 }
 

--- a/winpr/libwinpr/handle/handle.c
+++ b/winpr/libwinpr/handle/handle.c
@@ -47,22 +47,34 @@
 
 BOOL CloseHandle(HANDLE hObject)
 {
-	ULONG Type = 0;
-	WINPR_HANDLE* Object = nullptr;
+	ULONG type = 0;
+	WINPR_HANDLE* hdl = nullptr;
 
-	if (!winpr_Handle_GetInfo(hObject, &Type, &Object))
+	if (!winpr_Handle_GetInfo(hObject, &type, &hdl) || !hdl || !hdl->ops)
 		return FALSE;
 
-	if (!Object)
+	BOOL ok = TRUE;
+	if (hdl->ops->CloseHandle)
+		ok = hdl->ops->CloseHandle(hObject);
+
+	/* a type's CloseHandle op can legitimately refuse (e.g. file.c won't close the pStdHandleFile
+	 * singleton unless forced) - if it did, this handle wasn't actually closed, so leave its
+	 * refcount/memory alone entirely. */
+	if (!ok)
 		return FALSE;
 
-	if (!Object->ops)
-		return FALSE;
+	/* WINPR_THREAD manages its own close/free lifecycle: closing the handle of a still-running
+	 * thread detaches it instead of freeing it, and the free only happens later, from the
+	 * thread's own pthread routine once it actually returns (see ThreadCloseHandle() /
+	 * cleanup_handle() in thread.c). Applying the generic release-then-maybe-free sequence below
+	 * on top of that would free the struct while the thread may still be running against it. */
+	if (type == HANDLE_TYPE_THREAD)
+		return TRUE;
 
-	if (Object->ops->CloseHandle)
-		return Object->ops->CloseHandle(hObject);
+	if (!winpr_Handle_Release(hObject))
+		winpr_Handle_ConvertToNone(hObject);
 
-	return FALSE;
+	return TRUE;
 }
 
 BOOL DuplicateHandle(WINPR_ATTR_UNUSED HANDLE hSourceProcessHandle,
@@ -72,8 +84,9 @@ BOOL DuplicateHandle(WINPR_ATTR_UNUSED HANDLE hSourceProcessHandle,
                      WINPR_ATTR_UNUSED DWORD dwDesiredAccess, WINPR_ATTR_UNUSED BOOL bInheritHandle,
                      WINPR_ATTR_UNUSED DWORD dwOptions)
 {
-	*((ULONG_PTR*)lpTargetHandle) = (ULONG_PTR)hSourceHandle;
-	return TRUE;
+	WLog_ERR(TAG, "DuplicateHandle not implemented");
+	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+	return FALSE;
 }
 
 BOOL GetHandleInformation(HANDLE hObject, LPDWORD lpdwFlags)

--- a/winpr/libwinpr/handle/handle.h
+++ b/winpr/libwinpr/handle/handle.h
@@ -20,8 +20,11 @@
 #ifndef WINPR_HANDLE_PRIVATE_H
 #define WINPR_HANDLE_PRIVATE_H
 
+#include <stdlib.h>
+
 #include <winpr/handle.h>
 #include <winpr/file.h>
+#include <winpr/interlocked.h>
 #include <winpr/synch.h>
 #include <winpr/winsock.h>
 
@@ -111,6 +114,7 @@ typedef struct
 	ULONG Type;
 	ULONG Mode;
 	HANDLE_OPS* ops;
+	volatile LONG refCount;
 } WINPR_HANDLE;
 
 WINPR_ATTR_NODISCARD
@@ -140,6 +144,7 @@ static inline void WINPR_HANDLE_SET_TYPE_AND_MODE(void* _handle, ULONG _type, UL
 
 	hdl->Type = _type;
 	hdl->Mode = _mode;
+	hdl->refCount = 1;
 }
 
 WINPR_ATTR_NODISCARD
@@ -162,6 +167,39 @@ static inline BOOL winpr_Handle_GetInfo(HANDLE handle, ULONG* pType, WINPR_HANDL
 	*pType = wHandle->Type;
 	*pObject = wHandle;
 
+	return TRUE;
+}
+
+static inline void winpr_Handle_AddRef(HANDLE handle)
+{
+	ULONG type = 0;
+	WINPR_HANDLE* hdl = nullptr;
+
+	if (!winpr_Handle_GetInfo(handle, &type, &hdl) || !hdl)
+		return;
+
+	InterlockedIncrement(&hdl->refCount);
+}
+
+/* implemented in nonehandle.c: turns an already-released handle (see CloseHandle() in handle.c)
+ * into a harmless placeholder, for as long as other references to the same struct remain. */
+void winpr_Handle_ConvertToNone(HANDLE handle);
+
+/* decrements refCount and frees the struct once it reaches zero - does not touch the underlying
+ * OS resource, that's the type's real CloseHandle op's job (see CloseHandle() in handle.c).
+ * Returns TRUE if this was the last reference (the handle has been freed). */
+static inline BOOL winpr_Handle_Release(HANDLE handle)
+{
+	ULONG type = 0;
+	WINPR_HANDLE* hdl = nullptr;
+
+	if (!winpr_Handle_GetInfo(handle, &type, &hdl) || !hdl)
+		return FALSE;
+
+	if (InterlockedDecrement(&hdl->refCount) > 0)
+		return FALSE;
+
+	free(hdl);
 	return TRUE;
 }
 

--- a/winpr/libwinpr/handle/nonehandle.c
+++ b/winpr/libwinpr/handle/nonehandle.c
@@ -26,10 +26,8 @@
 
 #include <pthread.h>
 
-static BOOL NoneHandleCloseHandle(HANDLE handle)
+static BOOL NoneHandleCloseHandle(WINPR_ATTR_UNUSED HANDLE handle)
 {
-	WINPR_NONE_HANDLE* none = (WINPR_NONE_HANDLE*)handle;
-	free(none);
 	return TRUE;
 }
 
@@ -76,7 +74,20 @@ HANDLE CreateNoneHandle(void)
 		return nullptr;
 
 	none->common.ops = &ops;
+	none->common.refCount = 1;
 	return (HANDLE)none;
+}
+
+void winpr_Handle_ConvertToNone(HANDLE handle)
+{
+	WINPR_HANDLE* hdl = (WINPR_HANDLE*)handle;
+
+	if (!hdl)
+		return;
+
+	hdl->Type = HANDLE_TYPE_NONE;
+	hdl->Mode = 0;
+	hdl->ops = &ops;
 }
 
 #endif

--- a/winpr/libwinpr/pipe/pipe.c
+++ b/winpr/libwinpr/pipe/pipe.c
@@ -106,7 +106,6 @@ static BOOL PipeCloseHandle(HANDLE handle)
 		pipe->fd = -1;
 	}
 
-	free(handle);
 	return TRUE;
 }
 
@@ -235,16 +234,24 @@ static BOOL NamedPipeCloseHandle(HANDLE handle)
 		pNamedPipe->pfnUnrefNamedPipe(pNamedPipe);
 
 	free(pNamedPipe->name);
+	pNamedPipe->name = nullptr;
 	free(pNamedPipe->lpFileName);
+	pNamedPipe->lpFileName = nullptr;
 	free(pNamedPipe->lpFilePath);
+	pNamedPipe->lpFilePath = nullptr;
 
 	if (pNamedPipe->serverfd != -1)
+	{
 		close(pNamedPipe->serverfd);
+		pNamedPipe->serverfd = -1;
+	}
 
 	if (pNamedPipe->clientfd != -1)
+	{
 		close(pNamedPipe->clientfd);
+		pNamedPipe->clientfd = -1;
+	}
 
-	free(pNamedPipe);
 	return TRUE;
 }
 
@@ -739,6 +746,7 @@ HANDLE CreateNamedPipeA(LPCSTR lpName, DWORD dwOpenMode, DWORD dwPipeMode, DWORD
 	return pNamedPipe;
 out:
 	NamedPipeCloseHandle(pNamedPipe);
+	free(pNamedPipe);
 
 	if (serverfd != -1)
 		close(serverfd);

--- a/winpr/libwinpr/sspicli/sspicli.c
+++ b/winpr/libwinpr/sspicli/sspicli.c
@@ -99,8 +99,9 @@ BOOL LogonUserCloseHandle(HANDLE handle)
 		return FALSE;
 
 	free(token->Username);
+	token->Username = nullptr;
 	free(token->Domain);
-	free(token);
+	token->Domain = nullptr;
 	return TRUE;
 }
 

--- a/winpr/libwinpr/synch/event.c
+++ b/winpr/libwinpr/synch/event.c
@@ -243,7 +243,7 @@ static BOOL EventCloseHandle_(WINPR_EVENT* event)
 	winpr_backtrace_free(event->create_stack);
 #endif
 	free(event->name);
-	free(event);
+	event->name = nullptr;
 	return TRUE;
 }
 
@@ -324,6 +324,7 @@ HANDLE CreateEventA(LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL bManualReset, 
 	return (HANDLE)event;
 fail:
 	EventCloseHandle_(event);
+	free(event);
 	return nullptr;
 }
 

--- a/winpr/libwinpr/synch/mutex.c
+++ b/winpr/libwinpr/synch/mutex.c
@@ -93,7 +93,7 @@ BOOL MutexCloseHandle(HANDLE handle)
 	}
 
 	free(mutex->name);
-	free(handle);
+	mutex->name = nullptr;
 	return TRUE;
 }
 

--- a/winpr/libwinpr/synch/semaphore.c
+++ b/winpr/libwinpr/synch/semaphore.c
@@ -101,7 +101,6 @@ BOOL SemaphoreCloseHandle(HANDLE handle)
 	sem_destroy((winpr_sem_t*)semaphore->sem);
 #endif
 #endif
-	free(semaphore);
 	return TRUE;
 }
 

--- a/winpr/libwinpr/synch/timer.c
+++ b/winpr/libwinpr/synch/timer.c
@@ -126,7 +126,9 @@ static void TimerPostDelete_APC(LPVOID arg)
 {
 	TimerDeleter* deleter = (TimerDeleter*)arg;
 	WINPR_ASSERT(deleter);
-	free(deleter->timer);
+	/* releases the extra reference TimerCloseHandle() took to keep the struct alive until here
+	 * (see APC_REMOVE_DELAY_FREE below) - only actually frees once nothing else still holds it */
+	winpr_Handle_Release((HANDLE)deleter->timer);
 	deleter->apcItem.markedForFree = TRUE;
 	deleter->apcItem.markedForRemove = TRUE;
 }
@@ -158,6 +160,7 @@ BOOL TimerCloseHandle(HANDLE handle)
 #endif
 
 	free(timer->name);
+	timer->name = nullptr;
 	if (timer->apcItem.linked)
 	{
 		TimerDeleter* deleter = nullptr;
@@ -180,6 +183,11 @@ BOOL TimerCloseHandle(HANDLE handle)
 					return TRUE;
 				}
 
+				/* keeps the struct alive until TimerPostDelete_APC() runs and releases it -
+				 * without this, the winpr_Handle_Release() the generic CloseHandle() wrapper
+				 * makes right after this function returns would free it immediately, while the
+				 * APC list may still be walking it. */
+				winpr_Handle_AddRef(handle);
 				deleter->timer = timer;
 				apcItem = &deleter->apcItem;
 				apcItem->type = APC_TYPE_HANDLE_FREE;
@@ -196,7 +204,6 @@ BOOL TimerCloseHandle(HANDLE handle)
 		}
 	}
 
-	free(timer);
 	return TRUE;
 }
 
@@ -358,6 +365,7 @@ HANDLE CreateWaitableTimerA(LPSECURITY_ATTRIBUTES lpTimerAttributes, BOOL bManua
 #if defined(TIMER_IMPL_DISPATCH) || defined(TIMER_IMPL_POSIX)
 fail:
 	TimerCloseHandle(handle);
+	free(timer);
 	return nullptr;
 #endif
 }

--- a/winpr/libwinpr/thread/process.c
+++ b/winpr/libwinpr/thread/process.c
@@ -220,6 +220,34 @@ static BOOL CreateProcessExA(HANDLE hToken, WINPR_ATTR_UNUSED DWORD dwLogonFlags
 	if (nullptr == filename)
 		goto finish;
 
+	/* Windows validates a PROC_THREAD_ATTRIBUTE_HANDLE_LIST's handles are still open before
+	 * creating the process at all, failing the whole call with ERROR_INVALID_PARAMETER if one
+	 * isn't (confirmed empirically: a handle CloseHandle()'d before this call, still listed here,
+	 * makes real CreateProcess fail this way rather than silently omitting it) */
+	if (bInheritHandles && lpStartupInfo && (dwCreationFlags & EXTENDED_STARTUPINFO_PRESENT))
+	{
+		const STARTUPINFOEXA* exInfo = (const STARTUPINFOEXA*)lpStartupInfo;
+		const struct WINPR_PROC_THREAD_ATTRIBUTE_LIST* list = exInfo->lpAttributeList;
+
+		for (DWORD i = 0; list && (i < list->count); i++)
+		{
+			const WINPR_PROC_THREAD_ATTRIBUTE_ENTRY* entry = &list->entries[i];
+			if (entry->Attribute != PROC_THREAD_ATTRIBUTE_HANDLE_LIST)
+				continue;
+
+			const HANDLE* handles = (const HANDLE*)entry->lpValue;
+			const size_t count = entry->cbSize / sizeof(HANDLE);
+			for (size_t h = 0; h < count; h++)
+			{
+				if (winpr_Handle_getFd(handles[h]) < 0)
+				{
+					SetLastError(ERROR_INVALID_PARAMETER);
+					goto finish;
+				}
+			}
+		}
+	}
+
 	/* block all signals so that the child can safely reset the caller's handlers */
 	sigfillset(&newSigMask);
 	restoreSigMask = !pthread_sigmask(SIG_SETMASK, &newSigMask, &oldSigMask);
@@ -416,6 +444,7 @@ static BOOL CreateProcessExA(HANDLE hToken, WINPR_ATTR_UNUSED DWORD dwLogonFlags
 	if (!thread)
 	{
 		ProcessHandleCloseHandle(process);
+		free(process);
 		goto finish;
 	}
 
@@ -679,7 +708,6 @@ static BOOL ProcessHandleCloseHandle(HANDLE handle)
 		close(process->fd);
 		process->fd = -1;
 	}
-	free(process);
 	return TRUE;
 }
 
@@ -787,6 +815,7 @@ HANDLE CreateProcessHandle(pid_t pid)
 	process->pid = pid;
 	process->common.Type = HANDLE_TYPE_PROCESS;
 	process->common.ops = &ops;
+	process->common.refCount = 1;
 	process->fd = pidfd_open(pid);
 	if (process->fd >= 0)
 		process->common.Mode = WINPR_FD_READ;

--- a/winpr/libwinpr/thread/procthreadattr.c
+++ b/winpr/libwinpr/thread/procthreadattr.c
@@ -27,6 +27,7 @@
 
 #include "thread.h"
 
+#include "../handle/handle.h"
 #include "../log.h"
 #define TAG WINPR_TAG("thread")
 
@@ -80,15 +81,38 @@ BOOL UpdateProcThreadAttribute(LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList,
 	entry->Attribute = Attribute;
 	entry->lpValue = lpValue;
 	entry->cbSize = cbSize;
+
+	if (Attribute == PROC_THREAD_ATTRIBUTE_HANDLE_LIST)
+	{
+		const HANDLE* handles = (const HANDLE*)lpValue;
+		const size_t count = cbSize / sizeof(HANDLE);
+		for (size_t i = 0; i < count; i++)
+			winpr_Handle_AddRef(handles[i]);
+	}
+
 	return TRUE;
 }
 
-VOID DeleteProcThreadAttributeList(WINPR_ATTR_UNUSED LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList)
+VOID DeleteProcThreadAttributeList(LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList)
 {
-	/* nothing to release: the caller owns the buffer it allocated to back lpAttributeList (from
-	 * the size InitializeProcThreadAttributeList reported), and none of the lpValue pointers
-	 * handed to UpdateProcThreadAttribute are ever copied or owned by us - matches real Windows,
-	 * where DeleteProcThreadAttributeList doesn't free the caller's buffer either. */
+	if (!lpAttributeList)
+		return;
+
+	/* the lpAttributeList buffer itself is still the caller's own, allocated from the size
+	 * InitializeProcThreadAttributeList() reported - matches real Windows, where
+	 * DeleteProcThreadAttributeList() doesn't free that buffer either. Only release the
+	 * references UpdateProcThreadAttribute() took on listed handles. */
+	for (DWORD i = 0; i < lpAttributeList->count; i++)
+	{
+		const WINPR_PROC_THREAD_ATTRIBUTE_ENTRY* entry = &lpAttributeList->entries[i];
+		if (entry->Attribute != PROC_THREAD_ATTRIBUTE_HANDLE_LIST)
+			continue;
+
+		const HANDLE* handles = (const HANDLE*)entry->lpValue;
+		const size_t count = entry->cbSize / sizeof(HANDLE);
+		for (size_t h = 0; h < count; h++)
+			(void)winpr_Handle_Release(handles[h]);
+	}
 }
 
 #endif

--- a/winpr/libwinpr/thread/test/TestThreadCreateProcess.c
+++ b/winpr/libwinpr/thread/test/TestThreadCreateProcess.c
@@ -199,6 +199,116 @@ static int run_inherit_case(const char* exePath, const char* label, HANDLE probe
 	return result;
 }
 
+/* Regression test for a TOCTOU: PROC_THREAD_ATTRIBUTE_HANDLE_LIST only stores the raw HANDLE
+ * values handed to UpdateProcThreadAttribute() (matching real Windows' documented contract - the
+ * caller's buffer, not its individual HANDLEs' underlying objects, is what must survive). Nothing
+ * used to stop a caller from closing one of the *listed* HANDLEs before CreateProcess() actually
+ * reads the list, and the WINPR_HANDLE struct it points to could then be freed and reused before
+ * CreateProcessExA() got around to reading it via the (now stale) pointer stored in the list.
+ *
+ * CloseHandle() now always runs the handle's real close op (releasing its OS resource, e.g. the
+ * fd) immediately, but only frees the WINPR_HANDLE struct once every reference to it (including
+ * UpdateProcThreadAttribute()'s own, released by DeleteProcThreadAttributeList()) has been
+ * released - until then it's converted to a harmless placeholder (see winpr_Handle_ConvertToNone
+ * in nonehandle.c). So this must not crash or read freed memory - and, matching confirmed real
+ * Windows behavior, CreateProcess() must fail outright with ERROR_INVALID_PARAMETER rather than
+ * silently proceeding without the already-closed handle (see the pre-fork validation loop in
+ * process.c). */
+WINPR_ATTR_NODISCARD
+static int TestHandleListEarlyCloseIsSafe(const char* exePath)
+{
+	SECURITY_ATTRIBUTES saAttr = { sizeof(SECURITY_ATTRIBUTES), nullptr, TRUE };
+	HANDLE probeRead = nullptr;
+	HANDLE probeWrite = nullptr;
+	HANDLE outRead = nullptr;
+	HANDLE outWrite = nullptr;
+	int result = 1;
+
+	if (!CreatePipe(&probeRead, &probeWrite, &saAttr, 0))
+	{
+		printf("[early-close] CreatePipe(probe) failed\n");
+		return 1;
+	}
+	if (!CreatePipe(&outRead, &outWrite, &saAttr, 0))
+	{
+		printf("[early-close] CreatePipe(out) failed\n");
+		CloseHandle(probeRead);
+		CloseHandle(probeWrite);
+		return 1;
+	}
+
+	char cmdline[1024] = WINPR_C_ARRAY_INIT;
+	(void)snprintf(cmdline, sizeof(cmdline), "\"%s\" TestThreadCreateProcess --probe-handle %llu",
+	               exePath, handle_to_probe_value(probeWrite));
+
+	SIZE_T size = 0;
+	(void)InitializeProcThreadAttributeList(nullptr, 1, 0, &size);
+	LPPROC_THREAD_ATTRIBUTE_LIST attrList = (LPPROC_THREAD_ATTRIBUTE_LIST)malloc(size);
+	if (!attrList || !InitializeProcThreadAttributeList(attrList, 1, 0, &size))
+	{
+		printf("[early-close] InitializeProcThreadAttributeList failed\n");
+		free(attrList);
+		CloseHandle(probeRead);
+		CloseHandle(probeWrite);
+		CloseHandle(outRead);
+		CloseHandle(outWrite);
+		return 1;
+	}
+
+	HANDLE handles[2] = { outWrite, probeWrite };
+	if (!UpdateProcThreadAttribute(attrList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, (void*)handles,
+	                               sizeof(handles), nullptr, nullptr))
+	{
+		printf("[early-close] UpdateProcThreadAttribute failed\n");
+		DeleteProcThreadAttributeList(attrList);
+		free(attrList);
+		CloseHandle(probeRead);
+		CloseHandle(probeWrite);
+		CloseHandle(outRead);
+		CloseHandle(outWrite);
+		return 1;
+	}
+
+	/* the TOCTOU: close our own reference to probeWrite *before* CreateProcess() reads the
+	 * attribute list. The list's own reference (taken by UpdateProcThreadAttribute() above) must
+	 * be what keeps the underlying object alive from here on. */
+	CloseHandle(probeWrite);
+
+	STARTUPINFOEXA siEx = WINPR_C_ARRAY_INIT;
+	siEx.StartupInfo.cb = sizeof(siEx);
+	siEx.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+	siEx.StartupInfo.hStdOutput = outWrite;
+	siEx.StartupInfo.hStdError = outWrite;
+	siEx.lpAttributeList = attrList;
+
+	PROCESS_INFORMATION pi = WINPR_C_ARRAY_INIT;
+	const BOOL created =
+	    CreateProcessA(nullptr, cmdline, nullptr, nullptr, TRUE, EXTENDED_STARTUPINFO_PRESENT,
+	                   nullptr, nullptr, (LPSTARTUPINFOA)&siEx, &pi);
+	const DWORD lastError = GetLastError();
+
+	DeleteProcThreadAttributeList(attrList);
+	free(attrList);
+	CloseHandle(outWrite);
+	CloseHandle(probeRead);
+	CloseHandle(outRead);
+
+	if (created)
+	{
+		printf("[early-close] expected CreateProcessA to fail (a listed handle was already "
+		       "closed), but it succeeded -> FAIL\n");
+		CloseHandle(pi.hProcess);
+		CloseHandle(pi.hThread);
+		return 1;
+	}
+
+	result = (lastError != ERROR_INVALID_PARAMETER);
+	printf("[early-close] expected CreateProcessA to fail with ERROR_INVALID_PARAMETER, got "
+	       "error=%" PRIu32 " -> %s\n",
+	       lastError, result ? "FAIL" : "OK");
+	return result;
+}
+
 /* Covers the bInheritHandles / PROC_THREAD_ATTRIBUTE_HANDLE_LIST matrix documented for
  * CreateProcess() on real Windows, which winpr/libwinpr/thread/process.c replicates on
  * Linux/macOS:
@@ -236,6 +346,8 @@ static int TestHandleInheritance(void)
 
 	CloseHandle(probeRead);
 	CloseHandle(probeWrite);
+
+	rc |= TestHandleListEarlyCloseIsSafe(exePath);
 	return rc;
 }
 


### PR DESCRIPTION
The goal of this patch is to correctly track the usage of HANDLEs especially if they are referenced in a PROC_THREAD_ATTRIBUTE_HANDLE_LIST. Before the changes if you UpdateProcThreadAttribute with a list of handles to pass to a child process and close some of these handles, when CreateProcess will be executed a crash will most probably happen because it will try to access freed objects. So this patch introduces refcounting on HANDLEs, meaning that if you Close a HANDLE it does not free its associated object if the HANDLE is referenced in a PROC_THREAD_ATTRIBUTE_HANDLE_LIST.
For now we also disable the DuplicateHandle function as: it's not used anywhere in WinPR/ FreeRDP, and it doesn't reproduce the behavior of the equivalent Win32 function (for that we would need to have our HANDLEs that would "point" to internal WinPR objects with ref counters in them, so that when you Close the duplicated HANDLE it doesn't affect the original one, just unref the internal object).