### PR TITLE
only use AV_PIX_FMT_D3D12 in ffmpeg >=7

### DIFF
--- a/libfreerdp/codec/h264_ffmpeg.c
+++ b/libfreerdp/codec/h264_ffmpeg.c
@@ -301,7 +301,9 @@ static const char* av_format_str(int32_t format)
 		EVCASE(AV_PIX_FMT_P412LE);
 		EVCASE(AV_PIX_FMT_GBRAP14BE);
 		EVCASE(AV_PIX_FMT_GBRAP14LE);
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(59,16,100)
 		EVCASE(AV_PIX_FMT_D3D12);
+#endif
 		EVCASE(AV_PIX_FMT_NB);
 		default:
 			return "AV_PIX_FMT_UNKNOWN";


### PR DESCRIPTION
As we ensure freerdp builds on ffmpeg 5.1.3, make it conditioned.