### PR TITLE
[client, mac] fix: build error undeclared 'nullptr' in Keyboard.m

### DIFF
--- a/client/Mac/Keyboard.m
+++ b/client/Mac/Keyboard.m
@@ -24,6 +24,8 @@
 #include <IOKit/IOKitLib.h>
 #include <IOKit/hid/IOHIDManager.h>
 
+#include <winpr/platform.h>
+
 typedef struct
 {
 	uint32_t ProductId;


### PR DESCRIPTION
Fix build error when -DWITH_CLIENT_MAC=ON.
```
[489/560] Building C object client/Mac/CMakeFiles/MacFreeRDP-library.dir/Keyboard.m.o
FAILED: [code=1] client/Mac/CMakeFiles/MacFreeRDP-library.dir/Keyboard.m.o 
:
/Users/.../Documents/GitHub/FreeRDP/client/Mac/Keyboard.m:161:28: error: use of undeclared identifier 'nullptr'
  161 |         CFSetRef deviceCFSetRef = nullptr;
      |                                   ^~~~~~~
```

This patch make the code has following line
`#define nullptr NULL`