### PR TITLE
build(test): only build JSON-dependent test when JSON is available

### DIFF
--- a/winpr/libwinpr/utils/test/CMakeLists.txt
+++ b/winpr/libwinpr/utils/test/CMakeLists.txt
@@ -29,8 +29,11 @@ set(${MODULE_PREFIX}_TESTS
     TestStreamPool.c
     TestMessageQueue.c
     TestMessagePipe.c
-    TestCommandLineToCommaSeparatedValues.c
 )
+
+if(WITH_WINPR_JSON)
+  list(APPEND ${MODULE_PREFIX}_TESTS TestCommandLineToCommaSeparatedValues.c)
+endif()
 
 if(WITH_LODEPNG)
   list(APPEND ${MODULES_PREFIX}_TESTS TestImage.c)


### PR DESCRIPTION
Closes #13292

TestCommandLineToCommaSeparatedValues is a JSON test (winpr/json.h)
but winpr/libwinpr/utils/test/CMakeLists.txt always added it to
TEST_WINPR_UTILS. When no JSON backend is found, winpr falls back to
json-stub.c ("JSON support not available") and the test fails, as seen
in the Guix build without jansson.

Guard the test with WITH_WINPR_JSON, matching the winpr/utils
CMakeLists logic that only sets WITH_WINPR_JSON when jansson,
json-c or cJSON is found.