### PR TITLE
[winpr,json] read JSON files in binary mode

### DIFF
--- a/winpr/libwinpr/utils/json/json.c
+++ b/winpr/libwinpr/utils/json/json.c
@@ -26,7 +26,7 @@
 
 WINPR_JSON* WINPR_JSON_ParseFromFile(const char* filename)
 {
-	FILE* fp = winpr_fopen(filename, "r");
+	FILE* fp = winpr_fopen(filename, "rb");
 	if (!fp)
 		return nullptr;
 	WINPR_JSON* json = WINPR_JSON_ParseFromFileFP(fp);

--- a/winpr/libwinpr/utils/test/CMakeLists.txt
+++ b/winpr/libwinpr/utils/test/CMakeLists.txt
@@ -32,7 +32,7 @@ set(${MODULE_PREFIX}_TESTS
 )
 
 if(WITH_WINPR_JSON)
-  list(APPEND ${MODULE_PREFIX}_TESTS TestCommandLineToCommaSeparatedValues.c)
+  list(APPEND ${MODULE_PREFIX}_TESTS TestCommandLineToCommaSeparatedValues.c TestJson.c)
 endif()
 
 if(WITH_LODEPNG)

--- a/winpr/libwinpr/utils/test/TestJson.c
+++ b/winpr/libwinpr/utils/test/TestJson.c
@@ -1,0 +1,58 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <winpr/crt.h>
+#include <winpr/file.h>
+#include <winpr/json.h>
+#include <winpr/path.h>
+
+int TestJson(int argc, char* argv[])
+{
+	static const char jsonData[] = "{\r\n  \"value\": \"test\"\r\n}\r\n";
+	int rc = -1;
+	FILE* fp = nullptr;
+	WINPR_JSON* json = nullptr;
+	char* path = nullptr;
+
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+
+	path = GetCombinedPath(TEST_BINARY_PATH, "TestJson-crlf.json");
+	if (!path)
+		goto fail;
+
+	fp = winpr_fopen(path, "wb");
+	if (!fp)
+		goto fail;
+
+	if (fwrite(jsonData, sizeof(char), sizeof(jsonData) - 1, fp) != sizeof(jsonData) - 1)
+		goto fail;
+
+	if (fclose(fp) != 0)
+		goto fail;
+	fp = nullptr;
+
+	json = WINPR_JSON_ParseFromFile(path);
+	if (!json)
+		goto fail;
+
+	const WINPR_JSON* value = WINPR_JSON_GetObjectItem(json, "value");
+	if (!WINPR_JSON_IsString(value))
+		goto fail;
+
+	const char* str = WINPR_JSON_GetStringValue(value);
+	if (!str || (strcmp(str, "test") != 0))
+		goto fail;
+
+	rc = 0;
+
+fail:
+	if (fp)
+		(void)fclose(fp);
+	WINPR_JSON_Delete(json);
+	if (path)
+		(void)winpr_DeleteFile(path);
+	free(path);
+	return rc;
+}


### PR DESCRIPTION
This PR fixes reading of `sdl-freerdp.json` on Windows

Cause: text mode translates CRLF → LF on Windows (causing `fread` returns fewer bytes than the file size previously measured with `_ftelli64`)

This means that the [exact byte-count check](https://github.com/FreeRDP/FreeRDP/blob/b2a12143658cfb8667406f224488a1b5dcbd221d/winpr/libwinpr/utils/json/json.c#L58-L60) rejected valid JSON files (since the CRLF → LF translation modifies the bytes).

Fix: open files in binary mode (and add a CRLF regression test)