### PR TITLE
[NTLM] Fix UTF-8 context attribute conversion

### DIFF
--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -1209,11 +1209,33 @@ static SECURITY_STATUS utf8len(const UNICODE_STRING* str, void* pBuffer)
 	WINPR_ASSERT(str);
 	WINPR_ASSERT(pBuffer);
 	ULONG* val = (ULONG*)pBuffer;
-	const SSIZE_T rc = ConvertWCharNToUtf8(str->Buffer, str->Length, nullptr, 0);
+	const size_t wlen = str->Length / sizeof(WCHAR);
+	const SSIZE_T rc = ConvertWCharNToUtf8(str->Buffer, wlen, nullptr, 0);
 	if (rc < 0)
 		return SEC_E_INVALID_PARAMETER;
 	*val = WINPR_ASSERTING_INT_CAST(ULONG, rc);
 	return SEC_E_OK;
+}
+
+WINPR_ATTR_NODISCARD
+static SECURITY_STATUS utf8str(const UNICODE_STRING* str, void* pBuffer)
+{
+	WINPR_ASSERT(str);
+	WINPR_ASSERT(pBuffer);
+	ULONG len = 0;
+
+	const SECURITY_STATUS status = utf8len(str, &len);
+	if (status != SEC_E_OK)
+		return status;
+	if (len == 0)
+	{
+		((char*)pBuffer)[0] = '\0';
+		return SEC_E_OK;
+	}
+
+	const size_t wlen = str->Length / sizeof(WCHAR);
+	const SSIZE_T rc = ConvertWCharNToUtf8(str->Buffer, wlen, pBuffer, (size_t)len);
+	return rc < 0 ? SEC_E_INVALID_PARAMETER : SEC_E_OK;
 }
 
 WINPR_ATTR_NODISCARD
@@ -1241,35 +1263,15 @@ static SECURITY_STATUS SEC_ENTRY ntlm_QueryContextAttributesA(PCtxtHandle phCont
 		case SECPKG_ATTR_AUTH_NTLM_DNS_COMPUTER_NAME_LEN:
 			return utf8len(&context->DnsComputerName, pBuffer);
 		case SECPKG_ATTR_AUTH_NTLM_HOSTNAME:
-		{
-			ConvertWCharNToUtf8(context->Workstation.Buffer, context->Workstation.Length, pBuffer,
-			                    context->Workstation.Length);
-			return SEC_E_OK;
-		}
+			return utf8str(&context->Workstation, pBuffer);
 		case SECPKG_ATTR_AUTH_NTLM_NB_DOMAIN_NAME:
-		{
-			ConvertWCharNToUtf8(context->NbDomainName.Buffer, context->NbDomainName.Length, pBuffer,
-			                    context->NbDomainName.Length);
-			return SEC_E_OK;
-		}
+			return utf8str(&context->NbDomainName, pBuffer);
 		case SECPKG_ATTR_AUTH_NTLM_NB_COMPUTER_NAME:
-		{
-			ConvertWCharNToUtf8(context->NbComputerName.Buffer, context->NbComputerName.Length,
-			                    pBuffer, context->NbComputerName.Length);
-			return SEC_E_OK;
-		}
+			return utf8str(&context->NbComputerName, pBuffer);
 		case SECPKG_ATTR_AUTH_NTLM_DNS_DOMAIN_NAME:
-		{
-			ConvertWCharNToUtf8(context->DnsDomainName.Buffer, context->DnsDomainName.Length,
-			                    pBuffer, context->DnsDomainName.Length);
-			return SEC_E_OK;
-		}
+			return utf8str(&context->DnsDomainName, pBuffer);
 		case SECPKG_ATTR_AUTH_NTLM_DNS_COMPUTER_NAME:
-		{
-			ConvertWCharNToUtf8(context->DnsComputerName.Buffer, context->DnsComputerName.Length,
-			                    pBuffer, context->DnsComputerName.Length);
-			return SEC_E_OK;
-		}
+			return utf8str(&context->DnsComputerName, pBuffer);
 		case SECPKG_ATTR_PACKAGE_INFO:
 		{
 			SecPkgContext_PackageInfoA* PackageInfo = (SecPkgContext_PackageInfoA*)pBuffer;


### PR DESCRIPTION
Running make test from openbsd port (https://marc.info/?l=openbsd-ports&m=178779328763275&w=2),

x11/freerdp $ make retest 'TEST_ENV=MALLOC_OPTIONS=C' 'TEST_FLAGS=-R TestSspiNTLM --output-on-failure -V'
===>  Regression tests for freerdp-3.31.0
...
TestSspi(30163) in free(): canary corrupted 0x11833aa1dc0[7]@7/16

(gdb) bt
...
#7  0x0000011764f59b23 in _libc_free (ptr=0x11833aa1dc0) at /usr/src/lib/libc/stdlib/malloc.c:1729
#8  0x000001155f7e1b31 in test_attributes_read (table=0x1180f7a0320 <winpr_SecurityFunctionTableA.llvm.15257515958526039962>, context=0x1176efc2f00, expected=0x1155f7dd25c,
    expectedLen=<optimized out>) at .../freerdp-3.31.0/winpr/libwinpr/sspi/test/TestSspiNTLM.c:198
#9  test_attributes (table=0x1180f7a0320 <winpr_SecurityFunctionTableA.llvm.15257515958526039962>, context=0x1176efc2f00)
    at .../freerdp-3.31.0/winpr/libwinpr/sspi/test/TestSspiNTLM.c:255
#10 0x000001155f7e0bf8 in test_default (arg=0x72263a9c88d0, fkt=0x0) at .../freerdp-3.31.0/winpr/libwinpr/sspi/test/TestSspiNTLM.c:780
#11 0x000001155f7e04b9 in TestSspiNTLM (argc=<optimized out>, argv=<optimized out>) at .../freerdp-3.31.0/winpr/libwinpr/sspi/test/TestSspiNTLM.c:1070        
#12 0x000001155f7dfb4c in main (ac=<optimized out>, av=0x72263a9c8a70) at .../build-amd64/winpr/libwinpr/sspi/test/TestSspi.c:226

I didn't make the hard job seeking the issue but an llm does.
I carefully check the reasoning step by step and the fix looks correct.