### PR TITLE
[core,test] do not link winpr-tools when WITH_WINPR_TOOLS=OFF

### DIFF
--- a/libfreerdp/core/test/CMakeLists.txt
+++ b/libfreerdp/core/test/CMakeLists.txt
@@ -15,7 +15,8 @@ endif()
 
 set(FUZZERS TestFuzzCoreClient.c TestFuzzCoreServer.c TestFuzzCryptoCertificateDataSetPEM.c)
 
-if(NOT WIN32)
+# TestFuzzServer generates a live cert via winpr-tools (makecert).
+if(NOT WIN32 AND WITH_WINPR_TOOLS)
   list(APPEND FUZZERS TestFuzzServer.c)
 endif()
 
@@ -44,15 +45,22 @@ endif()
 add_compile_definitions(TESTING_OUTPUT_DIRECTORY="${PROJECT_BINARY_DIR}")
 add_compile_definitions(TESTING_SRC_DIRECTORY="${PROJECT_SOURCE_DIR}")
 
-target_link_libraries(${MODULE_NAME} PRIVATE freerdp-client winpr-tools)
+# TestCore does not call winpr-tools APIs. The link was added with
+# TestFuzzServer's on-the-fly cert generation and broke -DWITH_WINPR_TOOLS=OFF.
+target_link_libraries(${MODULE_NAME} PRIVATE freerdp-client)
+if(WITH_WINPR_TOOLS)
+  set(CORE_FUZZER_LIBS "freerdp-client winpr-tools")
+else()
+  set(CORE_FUZZER_LIBS "freerdp-client")
+endif()
 
 include(AddFuzzerTest)
-add_fuzzer_test("${FUZZERS}" "freerdp-client winpr-tools")
+add_fuzzer_test("${FUZZERS}" "${CORE_FUZZER_LIBS}")
 
 # Seed corpus generator for the test TestFuzzServer, used to
-# (re)generate the seed corpus. Requires the client library and
-# POSIX sockets.
-if(NOT WIN32 AND (WITH_CLIENT_COMMON OR WITH_CLIENT))
+# (re)generate the seed corpus. Requires the client library,
+# POSIX sockets, and winpr-tools (makecert).
+if(NOT WIN32 AND WITH_WINPR_TOOLS AND (WITH_CLIENT_COMMON OR WITH_CLIENT))
   find_package(Threads REQUIRED)
   add_executable(TestFuzzServerSeedGen TestFuzzServerSeedGen.c)
   target_link_libraries(TestFuzzServerSeedGen freerdp-client winpr-tools Threads::Threads)


### PR DESCRIPTION
CMake-only fix for #13296 (`cmake -DWITH_WINPR_TOOLS=OFF` failed with `ld: cannot find -lwinpr-tools`).

`5f38a81` added an unconditional `winpr-tools` link in `libfreerdp/core/test/CMakeLists.txt` for TestCore, the core fuzzers, and TestFuzzServerSeedGen.

- TestCore sources do not call winpr-tools APIs. Drop that link.
- `TestFuzzServer` / `TestFuzzServerSeedGen` include `<winpr/tools/makecert.h>` and generate a live cert. Skip those targets when `WITH_WINPR_TOOLS=OFF`.
- Remaining fuzzers keep linking `freerdp-client` only.

This does not force `WITH_WINPR_TOOLS=ON`. `server/shadow` still uses makecert and is unchanged (the reported failure used `WITH_SERVER=OFF`).

## How to test

Configure with `-DWITH_WINPR_TOOLS=OFF` (and `-DWITH_SERVER=OFF` if matching the report). Generated TestCore / fuzzer link lines should not request `-lwinpr-tools`. With `-DWITH_WINPR_TOOLS=ON`, SeedGen should still link `winpr-tools`.

Proof on this branch (CMake configure / generated Ninja link lines, not a full package build):

- `master` + OFF still requests `-lwinpr-tools` for TestCore and TestFuzzServerSeedGen
- this branch + OFF: TestCore link is `libfreerdp-client` / `libfreerdp` / `libwinpr` / `-lm` only; `ninja -t commands | grep winpr-tools` is empty; SeedGen is not a target
- this branch + ON still builds SeedGen against `libwinpr-tools`

Fixes #13296