### PR TITLE
[winpr,clipboard] honor DIB header size in BMP offsets

### DIFF
--- a/winpr/libwinpr/clipboard/synthetic.c
+++ b/winpr/libwinpr/clipboard/synthetic.c
@@ -392,7 +392,8 @@ static void* clipboard_synthesize_cf_dibv5(wClipboard* clipboard, UINT32 formatI
 #endif
 
 static void* clipboard_prepend_bmp_header(const WINPR_BITMAP_INFO_HEADER* pInfoHeader,
-                                          const void* data, size_t size, UINT32* pSize)
+                                          size_t offset, const void* data, size_t size,
+                                          UINT32* pSize)
 {
 	WINPR_ASSERT(pInfoHeader);
 	WINPR_ASSERT(pSize);
@@ -401,8 +402,14 @@ static void* clipboard_prepend_bmp_header(const WINPR_BITMAP_INFO_HEADER* pInfoH
 	if ((pInfoHeader->biBitCount < 1) || (pInfoHeader->biBitCount > 32))
 		return nullptr;
 
+	if (size > (UINT32_MAX - sizeof(WINPR_BITMAP_FILE_HEADER)))
+		return nullptr;
 	const size_t DstSize = sizeof(WINPR_BITMAP_FILE_HEADER) + size;
-	if (DstSize > UINT32_MAX)
+	if ((pInfoHeader->biSize > size) || (offset > (size - pInfoHeader->biSize)))
+		return nullptr;
+
+	const size_t bitmapOffset = sizeof(WINPR_BITMAP_FILE_HEADER) + pInfoHeader->biSize + offset;
+	if (bitmapOffset > DstSize)
 		return nullptr;
 
 	wStream* s = Stream_New(nullptr, DstSize);
@@ -413,7 +420,7 @@ static void* clipboard_prepend_bmp_header(const WINPR_BITMAP_INFO_HEADER* pInfoH
 	fileHeader.bfType[0] = 'B';
 	fileHeader.bfType[1] = 'M';
 	fileHeader.bfSize = (UINT32)DstSize;
-	fileHeader.bfOffBits = sizeof(WINPR_BITMAP_FILE_HEADER) + sizeof(WINPR_BITMAP_INFO_HEADER);
+	fileHeader.bfOffBits = (UINT32)bitmapOffset;
 	if (!writeBitmapFileHeader(s, &fileHeader))
 		goto fail;
 
@@ -463,7 +470,7 @@ static void* clipboard_synthesize_image_bmp(WINPR_ATTR_UNUSED wClipboard* clipbo
 		if (!readBitmapInfoHeader(s, &header, &offset))
 			return nullptr;
 
-		return clipboard_prepend_bmp_header(&header, data, SrcSize, pSize);
+		return clipboard_prepend_bmp_header(&header, offset, data, SrcSize, pSize);
 	}
 #if defined(WINPR_UTILS_IMAGE_DIBv5)
 	else if (formatId == CF_DIBV5)

--- a/winpr/libwinpr/clipboard/test/TestClipboardFormats.c
+++ b/winpr/libwinpr/clipboard/test/TestClipboardFormats.c
@@ -3,6 +3,106 @@
 #include <winpr/print.h>
 #include <winpr/image.h>
 #include <winpr/clipboard.h>
+#include <winpr/stream.h>
+#include <winpr/user.h>
+
+static BOOL test_dib_to_bmp(const BYTE* dib, size_t dibSize, size_t expectedOffset)
+{
+	BOOL rc = FALSE;
+
+	wClipboard* clipboard = ClipboardCreate();
+	if (!clipboard)
+		return FALSE;
+
+	const UINT32 bmpId = ClipboardRegisterFormat(clipboard, "image/bmp");
+	if ((bmpId == 0) || (dibSize > UINT32_MAX) ||
+	    !ClipboardSetData(clipboard, CF_DIB, dib, (UINT32)dibSize))
+		goto fail;
+
+	UINT32 bmpSize = 0;
+	BYTE* bmp = ClipboardGetData(clipboard, bmpId, &bmpSize);
+	if (!bmp)
+		goto fail;
+
+	wStream bmpBuffer = WINPR_C_ARRAY_INIT;
+	wStream* s = Stream_StaticConstInit(&bmpBuffer, bmp, bmpSize);
+	if (!s || (bmpSize < sizeof(WINPR_BITMAP_FILE_HEADER)))
+		goto fail_bmp;
+
+	Stream_Seek(s, 10);
+	UINT32 bitmapOffset = 0;
+	Stream_Read_UINT32(s, bitmapOffset);
+	if ((bitmapOffset != expectedOffset) ||
+	    (bmpSize != sizeof(WINPR_BITMAP_FILE_HEADER) + dibSize) ||
+	    (memcmp(&bmp[sizeof(WINPR_BITMAP_FILE_HEADER)], dib, dibSize) != 0))
+		goto fail_bmp;
+
+	rc = TRUE;
+
+fail_bmp:
+	free(bmp);
+fail:
+	ClipboardDestroy(clipboard);
+	return rc;
+}
+
+static void write_dib_info_header(wStream* s, UINT32 size, UINT16 bpp, UINT32 compression)
+{
+	WINPR_ASSERT(s);
+
+	Stream_Write_UINT32(s, size);
+	Stream_Write_INT32(s, 1);  /* width */
+	Stream_Write_INT32(s, 1);  /* height */
+	Stream_Write_UINT16(s, 1); /* planes */
+	Stream_Write_UINT16(s, bpp);
+	Stream_Write_UINT32(s, compression);
+	Stream_Write_UINT32(s, 4); /* image size */
+	Stream_Zero(s, 16);        /* resolution and palette metadata */
+}
+
+static BOOL test_dib_offsets(void)
+{
+	BYTE v4[sizeof(BITMAPV4HEADER) + 4] = WINPR_C_ARRAY_INIT;
+	wStream sbuffer = WINPR_C_ARRAY_INIT;
+	wStream* s = Stream_StaticInit(&sbuffer, v4, sizeof(v4));
+	if (!s)
+		return FALSE;
+	write_dib_info_header(s, sizeof(BITMAPV4HEADER), 32, BI_BITFIELDS);
+
+	Stream_Write_UINT32(s, 0x00FF0000); /* red mask */
+	Stream_Write_UINT32(s, 0x0000FF00); /* green mask */
+	Stream_Write_UINT32(s, 0x000000FF); /* blue mask */
+	Stream_Write_UINT32(s, 0xFF000000); /* alpha mask */
+	Stream_Zero(s, sizeof(BITMAPV4HEADER) - Stream_GetPosition(s));
+	Stream_Write_UINT32(s, 0xFF123456); /* pixel */
+	if (!test_dib_to_bmp(v4, sizeof(v4), sizeof(WINPR_BITMAP_FILE_HEADER) + sizeof(BITMAPV4HEADER)))
+		return FALSE;
+
+	BYTE bitfields[sizeof(BITMAPINFOHEADER) + 3 * sizeof(DWORD) + 4] = WINPR_C_ARRAY_INIT;
+	s = Stream_StaticInit(&sbuffer, bitfields, sizeof(bitfields));
+	if (!s)
+		return FALSE;
+	write_dib_info_header(s, sizeof(BITMAPINFOHEADER), 32, BI_BITFIELDS);
+	Stream_Write_UINT32(s, 0x00FF0000); /* red mask */
+	Stream_Write_UINT32(s, 0x0000FF00); /* green mask */
+	Stream_Write_UINT32(s, 0x000000FF); /* blue mask */
+	Stream_Write_UINT32(s, 0xFF123456); /* pixel */
+	if (!test_dib_to_bmp(bitfields, sizeof(bitfields),
+	                     sizeof(WINPR_BITMAP_FILE_HEADER) + sizeof(BITMAPINFOHEADER) +
+	                         3 * sizeof(DWORD)))
+		return FALSE;
+
+	BYTE paletted[sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD) + 4] = WINPR_C_ARRAY_INIT;
+	s = Stream_StaticInit(&sbuffer, paletted, sizeof(paletted));
+	if (!s)
+		return FALSE;
+	write_dib_info_header(s, sizeof(BITMAPINFOHEADER), 8, BI_RGB);
+	Stream_Zero(s, 256 * sizeof(RGBQUAD));
+	Stream_Write_UINT32(s, 0); /* pixel row */
+	return test_dib_to_bmp(paletted, sizeof(paletted),
+	                       sizeof(WINPR_BITMAP_FILE_HEADER) + sizeof(BITMAPINFOHEADER) +
+	                           256 * sizeof(RGBQUAD));
+}
 
 int TestClipboardFormats(int argc, char* argv[])
 {
@@ -19,6 +119,8 @@ int TestClipboardFormats(int argc, char* argv[])
 	clipboard = ClipboardCreate();
 	if (!clipboard)
 		return -1;
+	if (!test_dib_offsets())
+		goto fail;
 
 	const char* mime_types[] = { "text/html", "text/html",  "image/bmp",
 		                         "image/png", "image/webp", "image/jpeg" };

--- a/winpr/libwinpr/utils/image.c
+++ b/winpr/libwinpr/utils/image.c
@@ -167,7 +167,7 @@ BOOL readBitmapInfoHeader(wStream* s, WINPR_BITMAP_INFO_HEADER* bi, size_t* poff
 			{
 				DWORD used = bi->biClrUsed;
 				if (used == 0)
-					used = (1u << bi->biBitCount) / 8;
+					used = 1u << bi->biBitCount;
 				offset += sizeof(RGBQUAD) * used;
 			}
 			if (bi->biSizeImage == 0)
@@ -192,7 +192,9 @@ BOOL readBitmapInfoHeader(wStream* s, WINPR_BITMAP_INFO_HEADER* bi, size_t* poff
 			}
 			break;
 		case BI_BITFIELDS:
-			offset += sizeof(DWORD) * 3; // 3 DWORD color masks
+			/* BITMAPV4HEADER and BITMAPV5HEADER include the color masks in biSize. */
+			if (bi->biSize == sizeof(WINPR_BITMAP_INFO_HEADER))
+				offset += sizeof(DWORD) * 3; // 3 DWORD color masks
 			break;
 		default:
 			WLog_ERR(TAG, "unsupported biCompression %" PRIu32, bi->biCompression);


### PR DESCRIPTION
This PR fixes copying images from Firefox through an xrdp session.

There are three issues that are bundled together:
1. Fix `clipboard_prepend_bmp_header` discarding `readBitmapInfoHeader` info (was constructing bfOffBits using a fixed size)
2. Fix support for V4/V5 headers, which already contain the color masks in biSize
3. Fix support for older BMP assets like 8-bpp images with 256-color palettes (the default indexed-color palette calculation divided the number of entries by eight, which is incorrect for these). Strictly speaking, this one isn't required to get Firefox "copy image" working in Firefox, but is fixed together  so this PR is a clean DIB pixel-offset fix

Adds regression coverage for:

- `BITMAPV4HEADER`
- Legacy `BITMAPINFOHEADER` with `BI_BITFIELDS`
- Indexed DIB palettes

I also tested on Windows manually by copying an image from Firefox through xrdp.