### PR TITLE
[codec,h264] separate YUV allocation and logical strides

### DIFF
--- a/libfreerdp/codec/h264.c
+++ b/libfreerdp/codec/h264.c
@@ -41,16 +41,28 @@ static BOOL avc444_ensure_buffer(H264_CONTEXT* h264, DWORD nDstHeight);
 static BOOL yuv_ensure_buffer(H264_CONTEXT* h264, UINT32 stride, UINT32 width, UINT32 height)
 {
 	BOOL isNull = FALSE;
-	UINT32 pheight = height;
+	UINT32 logicalStride = 0;
+	UINT32 allocationStride = 0;
+	UINT32 allocationHeight = 0;
+	UINT32 allocationStrideUV = 0;
 
 	if (!h264)
 		return FALSE;
 
 	if (stride == 0)
 		stride = width;
+	if ((stride == 0) || (height == 0) || (stride < width))
+		return FALSE;
 
-	stride += 16 - stride % 16;
-	pheight += 16 - pheight % 16;
+	const UINT32 stridePadding = 16 - stride % 16;
+	const UINT32 heightPadding = 16 - height % 16;
+	if ((stride > UINT32_MAX - stridePadding) || (height > UINT32_MAX - heightPadding))
+		return FALSE;
+
+	allocationStride = stride + stridePadding;
+	allocationHeight = height + heightPadding;
+	logicalStride = (stride % 16 == 0) ? stride : allocationStride;
+	allocationStrideUV = (allocationStride + 1) / 2;
 
 	const size_t nPlanes = h264->hwAccel ? 2 : 3;
 
@@ -60,32 +72,33 @@ static BOOL yuv_ensure_buffer(H264_CONTEXT* h264, UINT32 stride, UINT32 width, U
 			isNull = TRUE;
 	}
 
-	if (pheight == 0)
-		return FALSE;
-	if (stride == 0)
-		return FALSE;
-
 	if (isNull || (width != h264->width) || (height != h264->height) ||
-	    (stride != h264->iStride[0]))
+	    (logicalStride != h264->iStride[0]))
 	{
 		if (h264->hwAccel) /* NV12 */
 		{
-			h264->iStride[0] = stride;
-			h264->iStride[1] = stride;
+			h264->iStride[0] = logicalStride;
+			h264->iStride[1] = logicalStride;
 			h264->iStride[2] = 0;
 		}
 		else /* I420 */
 		{
-			h264->iStride[0] = stride;
-			h264->iStride[1] = (stride + 1) / 2;
-			h264->iStride[2] = (stride + 1) / 2;
+			h264->iStride[0] = logicalStride;
+			h264->iStride[1] = (logicalStride + 1) / 2;
+			h264->iStride[2] = (logicalStride + 1) / 2;
 		}
 
 		for (size_t x = 0; x < nPlanes; x++)
 		{
-			BYTE* tmp1 = winpr_aligned_recalloc(h264->pYUVData[x], h264->iStride[x], pheight, 16);
+			const size_t allocStride =
+			    (x == 0 || h264->hwAccel) ? allocationStride : allocationStrideUV;
+			if (allocationHeight > SIZE_MAX / allocStride)
+				return FALSE;
+
+			BYTE* tmp1 =
+			    winpr_aligned_recalloc(h264->pYUVData[x], allocStride, allocationHeight, 16);
 			BYTE* tmp2 =
-			    winpr_aligned_recalloc(h264->pOldYUVData[x], h264->iStride[x], pheight, 16);
+			    winpr_aligned_recalloc(h264->pOldYUVData[x], allocStride, allocationHeight, 16);
 			if (tmp1)
 				h264->pYUVData[x] = tmp1;
 			if (tmp2)
@@ -103,6 +116,55 @@ static BOOL yuv_ensure_buffer(H264_CONTEXT* h264, UINT32 stride, UINT32 width, U
 BOOL avc420_ensure_buffer(H264_CONTEXT* h264, UINT32 stride, UINT32 width, UINT32 height)
 {
 	return yuv_ensure_buffer(h264, stride, width, height);
+}
+
+BOOL h264_copy_yuv420p(BYTE* const pDstData[3], const UINT32 dstStride[3], const BYTE* pSrcData,
+                       size_t srcSize, UINT32 srcStride, UINT32 width, UINT32 height,
+                       size_t* pRequiredSize)
+{
+	if (!pDstData || !dstStride || !pSrcData || (srcStride == 0) || (width == 0) || (height == 0))
+		return FALSE;
+	if (!pDstData[0] || !pDstData[1] || !pDstData[2])
+		return FALSE;
+
+	const UINT32 chromaWidth = width / 2 + width % 2;
+	const UINT32 chromaHeight = height / 2 + height % 2;
+	const UINT32 srcChromaStride = srcStride / 2 + srcStride % 2;
+	if ((srcStride < width) || (srcChromaStride < chromaWidth))
+		return FALSE;
+	if ((dstStride[0] < srcStride) || (dstStride[1] < srcChromaStride) ||
+	    (dstStride[2] < srcChromaStride))
+		return FALSE;
+
+	if (height > SIZE_MAX / srcStride)
+		return FALSE;
+	const size_t lumaSize = (size_t)srcStride * height;
+	if (chromaHeight > SIZE_MAX / srcChromaStride)
+		return FALSE;
+	const size_t chromaSize = (size_t)srcChromaStride * chromaHeight;
+	if ((lumaSize > SIZE_MAX - chromaSize) || (lumaSize + chromaSize > SIZE_MAX - chromaSize))
+		return FALSE;
+
+	const size_t requiredSize = lumaSize + 2 * chromaSize;
+	if (pRequiredSize)
+		*pRequiredSize = requiredSize;
+	if (srcSize < requiredSize)
+		return FALSE;
+
+	const BYTE* pSrcPlanes[3] = { pSrcData, pSrcData + lumaSize, pSrcData + lumaSize + chromaSize };
+	const UINT32 srcStrides[3] = { srcStride, srcChromaStride, srcChromaStride };
+	const UINT32 rows[3] = { height, chromaHeight, chromaHeight };
+
+	for (size_t plane = 0; plane < 3; plane++)
+	{
+		for (UINT32 row = 0; row < rows[plane]; row++)
+		{
+			memcpy(pDstData[plane] + (size_t)row * dstStride[plane],
+			       pSrcPlanes[plane] + (size_t)row * srcStrides[plane], srcStrides[plane]);
+		}
+	}
+
+	return TRUE;
 }
 
 static BOOL isRectValid(UINT32 width, UINT32 height, const RECTANGLE_16* rect)

--- a/libfreerdp/codec/h264.h
+++ b/libfreerdp/codec/h264.h
@@ -94,6 +94,11 @@ extern "C"
 	FREERDP_LOCAL BOOL avc420_ensure_buffer(H264_CONTEXT* h264, UINT32 stride, UINT32 width,
 	                                        UINT32 height);
 
+	WINPR_ATTR_NODISCARD
+	FREERDP_LOCAL BOOL h264_copy_yuv420p(BYTE* const pDstData[3], const UINT32 dstStride[3],
+	                                     const BYTE* pSrcData, size_t srcSize, UINT32 srcStride,
+	                                     UINT32 width, UINT32 height, size_t* pRequiredSize);
+
 #ifdef WITH_MEDIACODEC
 	extern const H264_CONTEXT_SUBSYSTEM g_Subsystem_mediacodec;
 #endif

--- a/libfreerdp/codec/h264_mf.c
+++ b/libfreerdp/codec/h264_mf.c
@@ -84,6 +84,7 @@ typedef struct
 	IMFSample* sample;
 	UINT32 frameWidth;
 	UINT32 frameHeight;
+	UINT32 frameStride;
 	IMFSample* outputSample;
 	IMFMediaBuffer* outputBuffer;
 	HMODULE mfplat;
@@ -176,6 +177,8 @@ static int mf_decompress(H264_CONTEXT* WINPR_RESTRICT h264, const BYTE* WINPR_RE
                          UINT32 SrcSize)
 {
 	BYTE* pbBuffer = nullptr;
+	BOOL inputBufferLocked = FALSE;
+	BOOL outputBufferLocked = FALSE;
 	DWORD cbMaxLength = 0;
 	DWORD cbCurrentLength = 0;
 	DWORD outputStatus = 0;
@@ -204,6 +207,7 @@ static int mf_decompress(H264_CONTEXT* WINPR_RESTRICT h264, const BYTE* WINPR_RE
 		WLog_Print(h264->log, WLOG_ERROR, "Lock failure: 0x%08" PRIX32 "", hr);
 		goto error;
 	}
+	inputBufferLocked = TRUE;
 
 	CopyMemory(pbBuffer, pSrcData, SrcSize);
 	hr = inputBuffer->lpVtbl->SetCurrentLength(inputBuffer, SrcSize);
@@ -215,6 +219,7 @@ static int mf_decompress(H264_CONTEXT* WINPR_RESTRICT h264, const BYTE* WINPR_RE
 	}
 
 	hr = inputBuffer->lpVtbl->Unlock(inputBuffer);
+	inputBufferLocked = FALSE;
 
 	if (FAILED(hr))
 	{
@@ -230,7 +235,7 @@ static int mf_decompress(H264_CONTEXT* WINPR_RESTRICT h264, const BYTE* WINPR_RE
 		goto error;
 	}
 
-	inputSample->lpVtbl->AddBuffer(inputSample, inputBuffer);
+	hr = inputSample->lpVtbl->AddBuffer(inputSample, inputBuffer);
 
 	if (FAILED(hr))
 	{
@@ -239,6 +244,7 @@ static int mf_decompress(H264_CONTEXT* WINPR_RESTRICT h264, const BYTE* WINPR_RE
 	}
 
 	inputBuffer->lpVtbl->Release(inputBuffer);
+	inputBuffer = nullptr;
 	hr = sys->transform->lpVtbl->ProcessInput(sys->transform, 0, inputSample, 0);
 
 	if (FAILED(hr))
@@ -318,8 +324,24 @@ static int mf_decompress(H264_CONTEXT* WINPR_RESTRICT h264, const BYTE* WINPR_RE
 			goto error;
 		}
 
-		if (!avc420_ensure_buffer(h264, stride, sys->frameWidth, sys->frameHeight))
+		const INT32 signedStride = (INT32)stride;
+		if (signedStride <= 0)
+		{
+			WLog_Print(h264->log, WLOG_ERROR, "Unsupported Media Foundation IYUV stride: %" PRId32,
+			           signedStride);
 			goto error;
+		}
+
+		sys->frameStride = (UINT32)signedStride;
+		if (!avc420_ensure_buffer(h264, sys->frameStride, sys->frameWidth, sys->frameHeight))
+			goto error;
+
+		WLog_Print(h264->log, WLOG_INFO,
+		           "Media Foundation IYUV output: frame=%" PRIu32 "x%" PRIu32
+		           " source-stride=%" PRIu32 " destination-strides=%" PRIu32 ",%" PRIu32
+		           ",%" PRIu32,
+		           sys->frameWidth, sys->frameHeight, sys->frameStride, iStride[0], iStride[1],
+		           iStride[2]);
 	}
 	else if (hr == MF_E_TRANSFORM_NEED_MORE_INPUT)
 	{
@@ -331,7 +353,6 @@ static int mf_decompress(H264_CONTEXT* WINPR_RESTRICT h264, const BYTE* WINPR_RE
 	}
 	else
 	{
-		int offset = 0;
 		BYTE* buffer = nullptr;
 		DWORD bufferCount = 0;
 		DWORD cbMaxLength = 0;
@@ -343,6 +364,12 @@ static int mf_decompress(H264_CONTEXT* WINPR_RESTRICT h264, const BYTE* WINPR_RE
 			WLog_Print(h264->log, WLOG_ERROR, "GetBufferCount failure: 0x%08" PRIX32 "", hr);
 			goto error;
 		}
+		if (bufferCount != 1)
+		{
+			WLog_Print(h264->log, WLOG_ERROR,
+			           "Unexpected Media Foundation output buffer count: %" PRIu32, bufferCount);
+			goto error;
+		}
 
 		hr = sys->outputSample->lpVtbl->GetBufferByIndex(sys->outputSample, 0, &outputBuffer);
 
@@ -351,7 +378,6 @@ static int mf_decompress(H264_CONTEXT* WINPR_RESTRICT h264, const BYTE* WINPR_RE
 			WLog_Print(h264->log, WLOG_ERROR, "GetBufferByIndex failure: 0x%08" PRIX32 "", hr);
 			goto error;
 		}
-
 		hr = outputBuffer->lpVtbl->Lock(outputBuffer, &buffer, &cbMaxLength, &cbCurrentLength);
 
 		if (FAILED(hr))
@@ -359,14 +385,40 @@ static int mf_decompress(H264_CONTEXT* WINPR_RESTRICT h264, const BYTE* WINPR_RE
 			WLog_Print(h264->log, WLOG_ERROR, "Lock failure: 0x%08" PRIX32 "", hr);
 			goto error;
 		}
+		outputBufferLocked = TRUE;
 
-		CopyMemory(pYUVData[0], &buffer[offset], iStride[0] * sys->frameHeight);
-		offset += iStride[0] * sys->frameHeight;
-		CopyMemory(pYUVData[1], &buffer[offset], iStride[1] * (sys->frameHeight / 2));
-		offset += iStride[1] * (sys->frameHeight / 2);
-		CopyMemory(pYUVData[2], &buffer[offset], iStride[2] * (sys->frameHeight / 2));
-		offset += iStride[2] * (sys->frameHeight / 2);
+		if (cbCurrentLength > cbMaxLength)
+		{
+			WLog_Print(h264->log, WLOG_ERROR,
+			           "Media Foundation output length exceeds capacity: current=%" PRIu32
+			           " maximum=%" PRIu32,
+			           cbCurrentLength, cbMaxLength);
+			goto error;
+		}
+
+		size_t requiredSize = 0;
+		if (!h264_copy_yuv420p(pYUVData, iStride, buffer, cbCurrentLength, sys->frameStride,
+		                       sys->frameWidth, sys->frameHeight, &requiredSize))
+		{
+			WLog_Print(h264->log, WLOG_ERROR,
+			           "Invalid Media Foundation IYUV buffer: frame=%" PRIu32 "x%" PRIu32
+			           " source-stride=%" PRIu32 " current=%" PRIu32 " maximum=%" PRIu32
+			           " required=%" PRIuz,
+			           sys->frameWidth, sys->frameHeight, sys->frameStride, cbCurrentLength,
+			           cbMaxLength, requiredSize);
+			goto error;
+		}
+
+		const size_t lumaSize = (size_t)sys->frameStride * sys->frameHeight;
+		const size_t chromaStride = sys->frameStride / 2 + sys->frameStride % 2;
+		const size_t chromaHeight = sys->frameHeight / 2 + sys->frameHeight % 2;
+		const size_t chromaSize = chromaStride * chromaHeight;
+		WLog_Print(h264->log, WLOG_DEBUG,
+		           "Media Foundation IYUV buffer: current=%" PRIu32 " maximum=%" PRIu32
+		           " offsets=0,%" PRIuz ",%" PRIuz " required=%" PRIuz,
+		           cbCurrentLength, cbMaxLength, lumaSize, lumaSize + chromaSize, requiredSize);
 		hr = outputBuffer->lpVtbl->Unlock(outputBuffer);
+		outputBufferLocked = FALSE;
 
 		if (FAILED(hr))
 		{
@@ -375,6 +427,7 @@ static int mf_decompress(H264_CONTEXT* WINPR_RESTRICT h264, const BYTE* WINPR_RE
 		}
 
 		outputBuffer->lpVtbl->Release(outputBuffer);
+		outputBuffer = nullptr;
 		h264->YUVWidth = sys->frameWidth;
 		h264->YUVHeight = sys->frameHeight;
 	}
@@ -382,7 +435,17 @@ static int mf_decompress(H264_CONTEXT* WINPR_RESTRICT h264, const BYTE* WINPR_RE
 	inputSample->lpVtbl->Release(inputSample);
 	return 1;
 error:
-	(void)fprintf(stderr, "mf_decompress error\n");
+	if (outputBufferLocked && outputBuffer)
+		(void)outputBuffer->lpVtbl->Unlock(outputBuffer);
+	if (inputBufferLocked && inputBuffer)
+		(void)inputBuffer->lpVtbl->Unlock(inputBuffer);
+	if (outputBuffer)
+		outputBuffer->lpVtbl->Release(outputBuffer);
+	if (inputSample)
+		inputSample->lpVtbl->Release(inputSample);
+	if (inputBuffer)
+		inputBuffer->lpVtbl->Release(inputBuffer);
+	WLog_Print(h264->log, WLOG_ERROR, "mf_decompress error");
 	return -1;
 }
 

--- a/libfreerdp/codec/test/CMakeLists.txt
+++ b/libfreerdp/codec/test/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TESTS
     TestFreeRDPCodecCursor.c
     TestFreeRDPCodecClear.c
     TestFreeRDPCodecInterleaved.c
+    TestFreeRDPCodecH264Buffer.c
     TestFreeRDPCodecProgressive.c
     TestFreeRDPCodecRemoteFX.c
 )

--- a/libfreerdp/codec/test/TestFreeRDPCodecH264Buffer.c
+++ b/libfreerdp/codec/test/TestFreeRDPCodecH264Buffer.c
@@ -1,0 +1,105 @@
+#include <string.h>
+
+#include <winpr/crt.h>
+
+#include "../h264.h"
+
+static void freeYUV420Buffers(H264_CONTEXT* h264)
+{
+	WINPR_ASSERT(h264);
+	for (size_t x = 0; x < 3; x++)
+	{
+		winpr_aligned_free(h264->pYUVData[x]);
+		winpr_aligned_free(h264->pOldYUVData[x]);
+	}
+}
+
+static BOOL testYUV420BufferLayout(UINT32 sourceStride, UINT32 width, UINT32 height,
+                                   UINT32 expectedStride, UINT32 expectedAllocationStride,
+                                   UINT32 expectedAllocationHeight)
+{
+	H264_CONTEXT h264 = WINPR_C_ARRAY_INIT;
+	if (!avc420_ensure_buffer(&h264, sourceStride, width, height))
+		return FALSE;
+
+	BOOL rc = h264.iStride[0] == expectedStride;
+	rc = rc && h264.iStride[1] == (expectedStride + 1) / 2;
+	rc = rc && h264.iStride[2] == (expectedStride + 1) / 2;
+
+	const size_t expectedYSize = (size_t)expectedAllocationStride * expectedAllocationHeight;
+	const size_t expectedUVSize =
+	    (size_t)((expectedAllocationStride + 1) / 2) * expectedAllocationHeight;
+	rc = rc && winpr_aligned_msize(h264.pYUVData[0], 16, 0) >= expectedYSize;
+	rc = rc && winpr_aligned_msize(h264.pYUVData[1], 16, 0) >= expectedUVSize;
+	rc = rc && winpr_aligned_msize(h264.pYUVData[2], 16, 0) >= expectedUVSize;
+
+	freeYUV420Buffers(&h264);
+	return rc;
+}
+
+static BOOL testYUV420Copy(void)
+{
+	const UINT32 width = 5;
+	const UINT32 height = 3;
+	const UINT32 srcStride = 8;
+	const UINT32 srcChromaStride = 4;
+	const UINT32 chromaHeight = 2;
+	const size_t srcSize = (size_t)srcStride * height + 2ULL * srcChromaStride * chromaHeight;
+	BYTE src[40] = WINPR_C_ARRAY_INIT;
+	BYTE y[30] = WINPR_C_ARRAY_INIT;
+	BYTE u[12] = WINPR_C_ARRAY_INIT;
+	BYTE v[14] = WINPR_C_ARRAY_INIT;
+	BYTE* dst[3] = { y, u, v };
+	const UINT32 dstStride[3] = { 10, 6, 7 };
+
+	WINPR_ASSERT(srcSize == sizeof(src));
+	for (size_t x = 0; x < sizeof(src); x++)
+		src[x] = (BYTE)(x + 1);
+
+	size_t requiredSize = 0;
+	if (!h264_copy_yuv420p(dst, dstStride, src, srcSize, srcStride, width, height, &requiredSize))
+		return FALSE;
+	if (requiredSize != srcSize)
+		return FALSE;
+
+	for (UINT32 row = 0; row < height; row++)
+	{
+		if (memcmp(&y[(size_t)row * dstStride[0]], &src[(size_t)row * srcStride], srcStride) != 0)
+			return FALSE;
+	}
+	const size_t uOffset = (size_t)srcStride * height;
+	const size_t vOffset = uOffset + (size_t)srcChromaStride * chromaHeight;
+	for (UINT32 row = 0; row < chromaHeight; row++)
+	{
+		if (memcmp(&u[(size_t)row * dstStride[1]], &src[uOffset + (size_t)row * srcChromaStride],
+		           srcChromaStride) != 0)
+			return FALSE;
+		if (memcmp(&v[(size_t)row * dstStride[2]], &src[vOffset + (size_t)row * srcChromaStride],
+		           srcChromaStride) != 0)
+			return FALSE;
+	}
+
+	return !h264_copy_yuv420p(dst, dstStride, src, srcSize - 1, srcStride, width, height,
+	                          &requiredSize);
+}
+
+int TestFreeRDPCodecH264Buffer(int argc, char* argv[])
+{
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+
+	/* An already aligned decoder stride remains the logical stride while allocation keeps the
+	 * extra block required by decoders which pad aligned dimensions unconditionally. */
+	if (!testYUV420BufferLayout(1808, 1804, 1128, 1808, 1824, 1136))
+		return -1;
+	/* Preserve the pre-existing alignment behavior for an unaligned requested stride. */
+	if (!testYUV420BufferLayout(1804, 1804, 1128, 1808, 1808, 1136))
+		return -1;
+	/* Preserve the extra allocation row block for an already aligned height. */
+	if (!testYUV420BufferLayout(1808, 1804, 1120, 1808, 1824, 1136))
+		return -1;
+	if (!testYUV420Copy())
+		return -1;
+
+	return 0;
+}


### PR DESCRIPTION
This fixes the regression in [bea10804a](https://github.com/FreeRDP/FreeRDP/commit/bea10804af9c9356979bd1af173993ab795377a6) (which broke H.264 on my Windows machine)

<img width="1804" height="1122" alt="image" src="https://github.com/user-attachments/assets/12290f82-4352-4b16-a098-dfbfa69680ee" />

**Disclaimer**: while for my previous PRs I am able to understand what is going on and review the code, for this one I just don't have enough background knowledge on H.264 (or the codebase given the size of the diff) to confidently know whether or not this is the right fix. It does work on my machine at least. Everything below is an AI summary which I can only understand at a high level

## Motivation

Commit [bea10804a](https://github.com/FreeRDP/FreeRDP/commit/bea10804af9c9356979bd1af173993ab795377a6) intentionally changed the H.264 YUV buffers to allocate an additional alignment block.
Some decoders write aligned dimensions even when the visible dimensions are already aligned, so retaining that additional capacity is necessary for memory safety.

However, the allocation stride was also stored in `H264_CONTEXT::iStride`.
That made the amount of allocated storage and the logical layout of the decoded frame the same value, even though they represent different properties.

This is incorrect for Media Foundation output.

Microsoft defines `MF_MT_DEFAULT_STRIDE` as the number of bytes needed to advance from one image row to the next.
The value is stored as `UINT32`, but Microsoft requires consumers to interpret it as a signed 32-bit value.
For a contiguous `IMFMediaBuffer`, this attribute describes the buffer’s row layout.
See [MF_MT_DEFAULT_STRIDE](https://learn.microsoft.com/en-us/windows/win32/medfound/mf-mt-default-stride-attribute).

Microsoft also explicitly notes that buffers with identical image dimensions can have different strides.
Its recommended approach for transforms is to keep the source and destination strides separate and process the image one row at a time.
See [Image Stride](https://learn.microsoft.com/en-us/windows/win32/medfound/image-stride)

The Media Foundation backend negotiates `MFVideoFormat_IYUV`.
Microsoft defines IYUV as planar 8-bit 4:2:0 with the same memory layout as I420.
See [Video Subtype GUIDs](https://learn.microsoft.com/en-us/windows/win32/medfound/video-subtype-guids)

Consequently, allocation padding must not change the stride used to locate rows or Y, U, and V planes in the Media Foundation output buffer.

## Failure mode

The problem is reproducible with a 1804×1128 frame for which Media Foundation reports a stride of 1808 bytes.

Because 1808 is already 16-byte aligned, the unconditional alignment calculation introduced by `bea10804a` changes it to 1824.
FreeRDP then uses 1824 to interpret an output buffer whose actual row stride remains 1808.

For this frame:

- The correct Y-plane size is `1808 × 1128 = 2,039,424` bytes.
- Each chroma plane is `904 × 564 = 509,856` bytes.
- The complete valid IYUV frame is therefore `3,059,136` bytes.
- Interpreting the frame with a stride of 1824 instead attempts to consume `3,086,208` bytes.

This shifts the U and V plane offsets and attempts to read 27,072 bytes beyond the valid frame layout.
The resulting row and plane displacement appears as progressive diagonal corruption and incorrect chroma.

## Implementation

The change separates two invariants:

- `logicalStride` describes the decoded image layout exposed through `iStride`.
- `allocationStride` and `allocationHeight` describe the amount of backing storage reserved for decoder padding.

For an already-aligned decoder stride, the logical stride is preserved unchanged.
For an unaligned decoder stride, the existing round-up-to-16 behavior is preserved.
For both cases, the allocation still extends to the next alignment block exactly as required by `bea10804a`.

The Media Foundation backend now retains its reported source stride separately.
Decoded IYUV data is copied one row at a time using independent source and destination strides.
Plane offsets are calculated from the source layout rather than from the destination allocation layout.

The output length returned by `IMFMediaBuffer::Lock` is also validated before any plane is accessed.
Microsoft defines the current length as the amount of valid data in the buffer and states that readers must not read beyond it.
See [Working with Media Buffers](https://learn.microsoft.com/en-us/windows/win32/medfound/working-with-media-buffers)

The size calculations use checked arithmetic and ceiling chroma dimensions.
This also makes the helper well-defined for odd frame dimensions and rejects truncated buffers before copying.

## Regression safety

The allocation formula introduced by `bea10804a` is preserved for every valid width and height.
This change therefore does not reduce the storage available to decoders that write an additional aligned block.

The logical-stride behavior is covered separately from allocation capacity:

- An aligned source stride of 1808 remains logically 1808 while allocating an 1824-byte row.
- An unaligned source stride of 1804 continues to round up logically and physically to 1808.
- An already-aligned height continues to receive an additional 16-row allocation block.
- Independent source and destination strides are exercised by row-copy tests.
- Odd dimensions exercise ceiling chroma width and height calculations.
- A source buffer one byte shorter than the required IYUV layout is rejected.

These tests are backend-independent, so the buffer and copy invariants do not depend on Media Foundation being available on the test host.

## Testing

- Built successfully on Windows with MSVC and `WITH_MEDIA_FOUNDATION=ON`.
- `TestFreeRDPCodecH264Buffer` passes.
- `TestClipboardFormats` and `TestImage` pass.
- Manually tested with an xrdp H.264 session at 1804×1128 and a Media Foundation stride of 1808.
- The diagonal displacement and chroma corruption are no longer present.