### PR TITLE
[channels,rdpear] return krb5 output buffer only after the call succeeds

### DIFF
--- a/channels/rdpear/client/rdpear_main.c
+++ b/channels/rdpear/client/rdpear_main.c
@@ -144,6 +144,11 @@ static krb5_error_code kerb_do_encrypt(krb5_context ctx, const KERB_RPC_ENCRYPTI
 	}
 
 	rv = krb5_c_encrypt(ctx, keyblock, kusage, nullptr, &data, &enc);
+	if (rv)
+	{
+		free(enc.ciphertext.data);
+		goto out;
+	}
 
 	out->data = enc.ciphertext.data;
 	out->length = enc.ciphertext.length;
@@ -184,6 +189,11 @@ static krb5_error_code kerb_do_decrypt(krb5_context ctx, const KERB_RPC_ENCRYPTI
 	}
 
 	rv = krb5_c_decrypt(ctx, keyblock, kusage, nullptr, &enc, &data);
+	if (rv)
+	{
+		free(data.data);
+		goto out;
+	}
 
 	plain->Asn1Buffer = (BYTE*)data.data;
 	plain->Asn1BufferHints.count = data.length;


### PR DESCRIPTION
**Uninitialised plaintext returned on kerberos decrypt failure**

`kerb_do_decrypt` assigns the freshly `malloc`d output buffer to `plain->Asn1Buffer` and its length regardless of the `krb5_c_decrypt` return code. When the decrypt fails early (an unknown key enctype makes `krb5_c_decrypt` return before touching the output), the RDPEAR response path still encodes that buffer and sends it back, so a malicious server driving DecryptApReply or UnpackKdcReplyBody with a bogus key can read uninitialised client heap. `kerb_do_encrypt` commits its buffer the same way and leaks it on an encrypt failure.

Both now publish the buffer only once the krb5 call has succeeded, and free it otherwise. I believe this keeps the ownership handling easier to follow, since the output fields are only ever set on the success path.