### PR TITLE
[core,capabilities] apply HasQoeEvent from src, not settings

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -1420,7 +1420,7 @@ static BOOL rdp_apply_input_capability_set(rdpSettings* settings, const rdpSetti
 		if (settings->HasRelativeMouseEvent)
 			settings->HasRelativeMouseEvent = src->HasRelativeMouseEvent;
 		if (freerdp_settings_get_bool(settings, FreeRDP_HasQoeEvent))
-			settings->HasQoeEvent = freerdp_settings_get_bool(settings, FreeRDP_HasQoeEvent);
+			settings->HasQoeEvent = freerdp_settings_get_bool(src, FreeRDP_HasQoeEvent);
 	}
 	return TRUE;
 }


### PR DESCRIPTION
## What

`rdp_apply_input_capability_set()` copies `HasQoeEvent` from `settings` back into `settings` — a disguised self-assignment that discards the peer's announced value. The client-side merged setting (and therefore the `TS_INPUT_FLAG_QOE_TIMESTAMPS` bit written into the Confirm Active input capability set by `rdp_write_input_capability_set()`) stays at the local default regardless of what the peer advertised.

This is the same defect shape as the `FreeRDP_UnicodeInput` read two lines above it, which was fixed in 21cd3d630 (#13287). This patch applies the identical one-token fix to the remaining occurrence: read the announced value from `src`, matching every other field this function applies.

## How to test

- Inspection: after this change, every conditional apply in the `!settings->ServerMode` block of `rdp_apply_input_capability_set()` reads from `src`, per the function's own comment ("override it with the server announced support flag").
- Behavior: connect to a server that does not announce `TS_INPUT_FLAG_QOE_TIMESTAMPS` while the client default enables it. Before: the client's Confirm Active still advertises QoE timestamps. After: the flag is only advertised when both sides support it.
- We run this fix (together with the #13287 backport) in a downstream vendored build of 3.30.0 against Windows 11 25H2; full RemoteApp smoke (RAIL window mapping, input, frame pipeline, clean shutdown) passes with it applied.

## Notes

- One token changed; no formatting impact.
- The sibling fix #13287 merged 2026-08-27 and is not in 3.31.0 (shipped 2026-08-26); this completes the pair for the next release.
