### PR TITLE
[codec,h264] overallocate decoder buffers

### DIFF
--- a/libfreerdp/codec/dsp_fdk_impl.c
+++ b/libfreerdp/codec/dsp_fdk_impl.c
@@ -374,8 +374,9 @@ ssize_t fdk_aac_dsp_impl_decode_read(void* handle, void* dst, size_t dstSize, fd
 		case AAC_DEC_NOT_ENOUGH_BITS:
 			return 0;
 		default:
-			log(WLOG_ERROR, "aacDecoder_DecodeFrame failed with %s", dec_err_str(err));
-			return -1;
+			log(WLOG_WARN, "aacDecoder_DecodeFrame failed with %s, discarding...",
+			    dec_err_str(err));
+			return 0;
 	}
 }
 

--- a/libfreerdp/codec/h264.c
+++ b/libfreerdp/codec/h264.c
@@ -36,8 +36,10 @@
 
 #define TAG FREERDP_TAG("codec")
 
+WINPR_ATTR_NODISCARD
 static BOOL avc444_ensure_buffer(H264_CONTEXT* h264, DWORD nDstHeight);
 
+WINPR_ATTR_NODISCARD
 static BOOL yuv_ensure_buffer(H264_CONTEXT* h264, UINT32 stride, UINT32 width, UINT32 height)
 {
 	BOOL isNull = FALSE;
@@ -49,8 +51,9 @@ static BOOL yuv_ensure_buffer(H264_CONTEXT* h264, UINT32 stride, UINT32 width, U
 	if (stride == 0)
 		stride = width;
 
-	stride += 16 - stride % 16;
-	pheight += 16 - pheight % 16;
+	/* Add padding lines. Allows relaxing bounds checks in decoder functions */
+	stride += 32 - stride % 16;
+	pheight += 32 - pheight % 16;
 
 	const size_t nPlanes = h264->hwAccel ? 2 : 3;
 
@@ -506,7 +509,7 @@ fail:
 	return rc;
 }
 
-static BOOL avc444_ensure_buffer(H264_CONTEXT* h264, DWORD nDstHeight)
+BOOL avc444_ensure_buffer(H264_CONTEXT* h264, DWORD nDstHeight)
 {
 	WINPR_ASSERT(h264);
 
@@ -522,6 +525,9 @@ static BOOL avc444_ensure_buffer(H264_CONTEXT* h264, DWORD nDstHeight)
 
 	if (pad != 0)
 		padDstHeight += 16 - pad;
+
+	/* Add padding lines. Allows relaxing bounds checks in decoder functions */
+	padDstHeight += 16;
 
 	if ((piMainStride[0] == 0) || (padDstHeight == 0))
 		return FALSE;


### PR DESCRIPTION
Add padding lines to YUV buffers. Allows relaxing bounds checks in optimized conversion routines.