### PR TITLE
[client,common] AAD/AVD OAuth hardening: state, PKCE, validated callback parsing, safe logging

### DIFF
--- a/client/SDL/common/aad/CMakeLists.txt
+++ b/client/SDL/common/aad/CMakeLists.txt
@@ -19,7 +19,7 @@
 option(WITH_WEBVIEW "Build with WebView support for AAD login popup browser" OFF)
 if(WITH_WEBVIEW)
   set(SRCS sdl_webview.hpp webview_impl.hpp sdl_webview.cpp)
-  set(LIBS winpr)
+  set(LIBS winpr freerdp-client)
 
   include(FetchContent)
 

--- a/client/SDL/common/aad/sdl_webview.cpp
+++ b/client/SDL/common/aad/sdl_webview.cpp
@@ -20,8 +20,10 @@
 #include <string>
 #include <sstream>
 #include <cstdlib>
+#include <cstring>
 #include <memory>
 
+#include <winpr/crt.h>
 #include <winpr/string.h>
 #include <freerdp/log.h>
 #include <freerdp/utils/aad.h>
@@ -30,6 +32,20 @@
 #include "webview_impl.hpp"
 
 #define TAG CLIENT_TAG("SDL.webview")
+
+/** @brief Release a string that held credential material
+ *
+ *  A token request body carries the authorization code and the PKCE code verifier, so it is
+ *  scrubbed before it is released, like the bodies client/common builds for the paste flow.
+ *
+ *  @param str The string to scrub and release, may be \b nullptr
+ */
+static void free_secret(char* str)
+{
+	if (str)
+		SecureZeroMemory(str, strlen(str));
+	free(str);
+}
 
 static std::string from_settings(const rdpSettings* settings, FreeRDP_Settings_Keys_String id)
 {
@@ -71,20 +87,28 @@ static BOOL sdl_webview_get_rdsaad_access_token(freerdp* instance, const char* s
 	auto settings = context->settings;
 	WINPR_ASSERT(settings);
 
-	std::shared_ptr<char> request(freerdp_client_get_aad_url((rdpClientContext*)instance->context,
-	                                                         FREERDP_CLIENT_AAD_AUTH_REQUEST,
-	                                                         scope),
-	                              free);
+	auto cctx = reinterpret_cast<rdpClientContext*>(instance->context);
+	std::shared_ptr<char> request(
+	    freerdp_client_get_aad_url(cctx, FREERDP_CLIENT_AAD_AUTH_REQUEST, scope), free);
+	if (!request)
+	{
+		WLog_ERR(TAG, "failed to build the AAD authorization request");
+		return FALSE;
+	}
+
 	const std::string title = "FreeRDP WebView - AAD access token";
 	std::string code;
-	auto rc = webview_impl_run(title, request.get(), code);
+	auto rc = webview_impl_run(title, request.get(), cctx, code);
 	if (!rc || code.empty())
 		return FALSE;
 
-	std::shared_ptr<char> token_request(
-	    freerdp_client_get_aad_url((rdpClientContext*)instance->context,
-	                               FREERDP_CLIENT_AAD_TOKEN_REQUEST, scope, code.c_str(), req_cnf),
-	    free);
+	std::shared_ptr<char> token_request(freerdp_client_get_aad_url(cctx,
+	                                                               FREERDP_CLIENT_AAD_TOKEN_REQUEST,
+	                                                               scope, code.c_str(), req_cnf),
+	                                    free_secret);
+	if (!token_request)
+		return FALSE;
+
 	return client_common_get_access_token(instance, token_request.get(), token);
 }
 
@@ -94,20 +118,27 @@ static BOOL sdl_webview_get_avd_access_token(freerdp* instance, char** token)
 	WINPR_ASSERT(instance);
 	WINPR_ASSERT(instance->context);
 
-	std::shared_ptr<char> request(freerdp_client_get_aad_url((rdpClientContext*)instance->context,
-	                                                         FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST),
-	                              free);
+	auto cctx = reinterpret_cast<rdpClientContext*>(instance->context);
+	std::shared_ptr<char> request(
+	    freerdp_client_get_aad_url(cctx, FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST), free);
+	if (!request)
+	{
+		WLog_ERR(TAG, "failed to build the AVD authorization request");
+		return FALSE;
+	}
 
 	const std::string title = "FreeRDP WebView - AVD access token";
 	std::string code;
-	auto rc = webview_impl_run(title, request.get(), code);
+	auto rc = webview_impl_run(title, request.get(), cctx, code);
 	if (!rc || code.empty())
 		return FALSE;
 
 	std::shared_ptr<char> token_request(
-	    freerdp_client_get_aad_url((rdpClientContext*)instance->context,
-	                               FREERDP_CLIENT_AAD_AVD_TOKEN_REQUEST, code.c_str()),
-	    free);
+	    freerdp_client_get_aad_url(cctx, FREERDP_CLIENT_AAD_AVD_TOKEN_REQUEST, code.c_str()),
+	    free_secret);
+	if (!token_request)
+		return FALSE;
+
 	return client_common_get_access_token(instance, token_request.get(), token);
 }
 

--- a/client/SDL/common/aad/webview_impl.cpp
+++ b/client/SDL/common/aad/webview_impl.cpp
@@ -20,129 +20,75 @@
 #include <webview.h>
 
 #include "webview_impl.hpp"
-#include <algorithm>
 #include <cassert>
-#include <cctype>
-#include <map>
-#include <regex>
-#include <sstream>
+#include <cstdlib>
+#include <cstring>
 #include <string>
-#include <vector>
 
+#include <winpr/crt.h>
 #include <freerdp/log.h>
-#include <winpr/string.h>
 
 #define TAG FREERDP_TAG("client.SDL.common.aad")
 
+/** @brief Release a string that held credential material
+ *
+ *  Scrubs the authorization code the parser handed out, like the token request bodies the SDL
+ *  AAD helper releases.
+ *
+ *  @param str The string to scrub and release, may be \b nullptr
+ */
+static void free_secret(char* str)
+{
+	if (str)
+		SecureZeroMemory(str, strlen(str));
+	free(str);
+}
+
+/** Collects the authorization code of the OAuth transaction the navigation listener watches. */
 class fkt_arg
 {
   public:
-	fkt_arg(const std::string& url)
+	explicit fkt_arg(rdpClientContext* cctx) : _cctx(cctx)
 	{
-		auto args = urlsplit(url);
-		auto redir = args.find("redirect_uri");
-		if (redir == args.end())
-		{
-			WLog_ERR(TAG,
-			         "[Webview] url %s does not contain a redirect_uri parameter, "
-			         "aborting.",
-			         url.c_str());
-		}
-		else
-		{
-			_redirect_uri = from_url_encoded_str(redir->second);
-		}
 	}
 
-	bool valid() const
-	{
-		return !_redirect_uri.empty();
-	}
-
-	bool getCode(std::string& c) const
+	[[nodiscard]] bool getCode(std::string& c) const
 	{
 		c = _code;
 		return !c.empty();
 	}
 
-	bool handle(const std::string& uri) const
+	/** @return true when the transaction has finished and the web view can be closed. */
+	[[nodiscard]] bool handle(const char* uri)
 	{
-		std::string duri = from_url_encoded_str(uri);
-		if (duri.length() < _redirect_uri.length())
-			return false;
-		auto rc = _strnicmp(duri.c_str(), _redirect_uri.c_str(), _redirect_uri.length());
-		return rc == 0;
-	}
+		char* code = nullptr;
 
-	bool parse(const std::string& uri)
-	{
-		_args = urlsplit(uri);
-		auto err = _args.find("error");
-		if (err != _args.end())
+		switch (freerdp_client_aad_parse_callback(_cctx, uri, &code))
 		{
-			auto suberr = _args.find("error_subcode");
-			WLog_ERR(TAG, "[Webview] %s: %s, %s: %s", err->first.c_str(), err->second.c_str(),
-			         suberr->first.c_str(), suberr->second.c_str());
-			return false;
+			case FREERDP_CLIENT_AAD_CALLBACK_UNRELATED:
+				return false;
+			case FREERDP_CLIENT_AAD_CALLBACK_CODE:
+				_code = code;
+				free_secret(code);
+				return true;
+			case FREERDP_CLIENT_AAD_CALLBACK_ERROR:
+				WLog_ERR(TAG, "[Webview] the authorization server declined the request");
+				return true;
+			default:
+				/* A navigation that reaches the redirect URI without a usable response is not
+				 * the end of the sign in: the redirect URI is a page of the authorization
+				 * server like any other, and anything that drives a top level navigation in
+				 * the view could otherwise abort the transaction. Keep the window open and
+				 * keep navigating, the user can still close it. The paste flow, which has one
+				 * attempt, does treat this as a failure. */
+				WLog_WARN(TAG, "[Webview] the authorization response was rejected, ignoring");
+				return false;
 		}
-		auto val = _args.find("code");
-		if (val == _args.end())
-		{
-			WLog_ERR(TAG, "[Webview] no code parameter detected in redirect URI %s", uri.c_str());
-			return false;
-		}
-
-		_code = val->second;
-		return true;
-	}
-
-  protected:
-	static std::string from_url_encoded_str(const std::string& str)
-	{
-		std::string cxxstr;
-		auto cstr = winpr_str_url_decode(str.c_str(), str.length());
-		if (cstr)
-		{
-			cxxstr = std::string(cstr);
-			free(cstr);
-		}
-		return cxxstr;
-	}
-
-	static std::vector<std::string> split(const std::string& input, const std::string& regex)
-	{
-		// passing -1 as the submatch index parameter performs splitting
-		std::regex re(regex);
-		std::sregex_token_iterator first{ input.begin(), input.end(), re, -1 };
-		std::sregex_token_iterator last;
-		return { first, last };
-	}
-
-	static std::map<std::string, std::string> urlsplit(const std::string& url)
-	{
-		auto pos = url.find('?');
-		if (pos == std::string::npos)
-			return {};
-
-		pos++; // skip '?'
-		auto surl = url.substr(pos);
-		auto args = split(surl, "&");
-
-		std::map<std::string, std::string> argmap;
-		for (const auto& arg : args)
-		{
-			auto kv = split(arg, "=");
-			if (kv.size() == 2)
-				argmap.insert({ kv[0], kv[1] });
-		}
-
-		return argmap;
 	}
 
   private:
-	std::string _redirect_uri;
+	rdpClientContext* _cctx = nullptr;
 	std::string _code;
-	std::map<std::string, std::string> _args;
 };
 
 static void fkt(webview_t webview, const char* uri, webview_navigation_event_t type, void* arg)
@@ -156,22 +102,21 @@ static void fkt(webview_t webview, const char* uri, webview_navigation_event_t t
 	if (!rcode->handle(uri))
 		return;
 
-	(void)rcode->parse(uri);
 	webview_terminate(webview);
 }
 
-bool webview_impl_run(const std::string& title, const std::string& url, std::string& code)
+bool webview_impl_run(const std::string& title, const std::string& url, rdpClientContext* cctx,
+                      std::string& code)
 {
+	if (!cctx)
+		return false;
+
 	webview::webview w(false, nullptr);
 
 	w.set_title(title);
 	w.set_size(800, 600, WEBVIEW_HINT_NONE);
 
-	fkt_arg arg(url);
-	if (!arg.valid())
-	{
-		return false;
-	}
+	fkt_arg arg(cctx);
 	w.add_navigation_listener(fkt, &arg);
 	w.navigate(url);
 	w.run();

--- a/client/SDL/common/aad/webview_impl.hpp
+++ b/client/SDL/common/aad/webview_impl.hpp
@@ -21,5 +21,16 @@
 
 #include <string>
 
+#include <freerdp/client.h>
+
+/** Show @p url in a web view until the OAuth transaction of @p cctx completes.
+ *
+ *  @param title The window title
+ *  @param url The authorization request, built with freerdp_client_get_aad_url()
+ *  @param cctx The client context the authorization request was built with
+ *  @param code Receives the authorization code
+ *
+ *  @return true if an authorization code was received
+ */
 [[nodiscard]] bool webview_impl_run(const std::string& title, const std::string& url,
-                                    std::string& code);
+                                    rdpClientContext* cctx, std::string& code);

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -23,6 +23,7 @@
 #include <freerdp/config.h>
 
 #include <string.h>
+#include <ctype.h>
 #include <errno.h>
 #include <math.h>
 #include <limits.h>
@@ -2491,10 +2492,126 @@ BOOL freerdp_client_use_relative_mouse_events(rdpClientContext* cctx)
 }
 
 #if defined(WITH_AAD)
+
+/** The longest tenant identifier accepted in a redirect URI.
+ *
+ *  Entra tenant identifiers are GUIDs or verified domain names; 128 characters is well beyond
+ *  both and keeps the value from dominating the URL.
+ */
+#define CLIENT_AAD_TENANTID_MAXLEN 128
+
+/** @brief Check a redirect URI format string taken from the settings
+ *
+ *  \b FreeRDP_GatewayAvdAccessAadFormat and \b FreeRDP_GatewayAvdAccessTokenFormat are
+ *  passed to \b winpr_asprintf as the format string, so a value that does not describe the
+ *  arguments the caller pushes reads past the end of the argument list. Accept literal text,
+ *  \c %% and at most \b conversions \c %s; reject every other conversion, including length
+ *  modifiers, positional arguments and \c %n.
+ *
+ *  Fewer conversions than expected are allowed: a cloud that publishes a fixed redirect URI
+ *  configures a format string without any conversion.
+ *
+ *  @param fmt The format string to check
+ *  @param conversions The number of \c %s conversions the caller supplies arguments for
+ *  @param key The setting \b fmt was read from, for the error message
+ *
+ *  @return \b TRUE if \b fmt is safe to expand with \b conversions string arguments
+ */
+static BOOL client_aad_check_redirect_format(const char* fmt, size_t conversions,
+                                             FreeRDP_Settings_Keys_String key)
+{
+	const char* name = freerdp_settings_get_name_for_key(key);
+
+	if (!fmt)
+	{
+		WLog_ERR(TAG, "setting %s is not set", name);
+		return FALSE;
+	}
+
+	size_t count = 0;
+	for (const char* pos = strchr(fmt, '%'); pos; pos = strchr(pos, '%'))
+	{
+		switch (pos[1])
+		{
+			case '%':
+				break;
+			case 's':
+				count++;
+				break;
+			default:
+				WLog_ERR(TAG,
+				         "setting %s uses an unsupported conversion, only '%%s' and '%%%%' "
+				         "are allowed",
+				         name);
+				return FALSE;
+		}
+		pos += 2;
+	}
+
+	if (count > conversions)
+	{
+		WLog_ERR(TAG, "setting %s has %" PRIuz " '%%s' conversions, at most %" PRIuz " are allowed",
+		         name, count, conversions);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/** @brief Check a tenant identifier before it is expanded into a URL
+ *
+ *  \b isalnum() is locale dependent and a client that called \b setlocale() can have bytes
+ *  >= 0x80 pass it, so the character class is spelled out. A label of dots only would walk the
+ *  path of the URL the tenant is expanded into.
+ *
+ *  @param tenantid The value of \b FreeRDP_GatewayAvdAadtenantid or the default tenant
+ *  @return \b TRUE if \b tenantid consists of ASCII alphanumerics, \c - and \c ., is not
+ *          only dots and is not longer than \ref CLIENT_AAD_TENANTID_MAXLEN
+ */
+static BOOL client_aad_check_tenantid(const char* tenantid)
+{
+	const char* name = freerdp_settings_get_name_for_key(FreeRDP_GatewayAvdAadtenantid);
+
+	if (!tenantid)
+	{
+		WLog_ERR(TAG, "setting %s is not set", name);
+		return FALSE;
+	}
+
+	const size_t len = strnlen(tenantid, CLIENT_AAD_TENANTID_MAXLEN + 1);
+	if ((len == 0) || (len > CLIENT_AAD_TENANTID_MAXLEN))
+	{
+		WLog_ERR(TAG, "setting %s must be 1 to %d characters long", name,
+		         CLIENT_AAD_TENANTID_MAXLEN);
+		return FALSE;
+	}
+
+	for (size_t x = 0; x < len; x++)
+	{
+		const char cur = tenantid[x];
+		const BOOL alnum = ((cur >= '0') && (cur <= '9')) || ((cur >= 'a') && (cur <= 'z')) ||
+		                   ((cur >= 'A') && (cur <= 'Z'));
+		if (alnum || (cur == '-') || (cur == '.'))
+			continue;
+
+		WLog_ERR(TAG, "setting %s must only contain ASCII alphanumerics, '-' and '.'", name);
+		return FALSE;
+	}
+
+	if (strspn(tenantid, ".") == len)
+	{
+		WLog_ERR(TAG, "setting %s must not consist of '.' only", name);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
 WINPR_ATTR_MALLOC(free, 1)
 static char* get_redirect_uri(const rdpSettings* settings)
 {
 	char* redirect_uri = nullptr;
+	size_t redirect_len = 0;
 	const bool cli = freerdp_settings_get_bool(settings, FreeRDP_UseCommonStdioCallbacks);
 	if (cli)
 	{
@@ -2505,14 +2622,22 @@ static char* get_redirect_uri(const rdpSettings* settings)
 		if (useTenant)
 			tenantid = freerdp_settings_get_string(settings, FreeRDP_GatewayAvdAadtenantid);
 
-		if (tenantid && redirect_fmt)
+		const char* url =
+		    freerdp_settings_get_string(settings, FreeRDP_GatewayAzureActiveDirectory);
+		if (!url)
 		{
-			const char* url =
-			    freerdp_settings_get_string(settings, FreeRDP_GatewayAzureActiveDirectory);
-
-			size_t redirect_len = 0;
-			winpr_asprintf(&redirect_uri, &redirect_len, redirect_fmt, url, tenantid);
+			WLog_ERR(TAG, "setting %s is not set",
+			         freerdp_settings_get_name_for_key(FreeRDP_GatewayAzureActiveDirectory));
+			return nullptr;
 		}
+
+		if (!client_aad_check_tenantid(tenantid))
+			return nullptr;
+
+		if (!client_aad_check_redirect_format(redirect_fmt, 2, FreeRDP_GatewayAvdAccessAadFormat))
+			return nullptr;
+
+		winpr_asprintf(&redirect_uri, &redirect_len, redirect_fmt, url, tenantid);
 	}
 	else
 	{
@@ -2520,7 +2645,16 @@ static char* get_redirect_uri(const rdpSettings* settings)
 		const char* redirect_fmt =
 		    freerdp_settings_get_string(settings, FreeRDP_GatewayAvdAccessTokenFormat);
 
-		size_t redirect_len = 0;
+		if (!client_id)
+		{
+			WLog_ERR(TAG, "setting %s is not set",
+			         freerdp_settings_get_name_for_key(FreeRDP_GatewayAvdClientID));
+			return nullptr;
+		}
+
+		if (!client_aad_check_redirect_format(redirect_fmt, 1, FreeRDP_GatewayAvdAccessTokenFormat))
+			return nullptr;
+
 		winpr_asprintf(&redirect_uri, &redirect_len, redirect_fmt, client_id);
 	}
 	return redirect_uri;

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -19,6 +19,7 @@
  */
 
 #include <winpr/cast.h>
+#include <winpr/string.h>
 
 #include <freerdp/config.h>
 
@@ -96,6 +97,7 @@ typedef struct client_aad_oauth
 	char* state;        /**< the 'state' value sent with the authorization request */
 	char* verifier;     /**< the PKCE code verifier sent with the token request */
 	char* redirect_uri; /**< percent decoded URI the authorization response must arrive at */
+	BOOL consumed;      /**< whether the authorization response was already seen */
 } client_aad_oauth;
 
 /** @brief Release a string that held credential material
@@ -127,6 +129,408 @@ void freerdp_client_aad_reset(rdpClientContext* cctx)
 
 	client_aad_oauth_free(cctx->aad_oauth);
 	cctx->aad_oauth = nullptr;
+}
+
+/** @brief The parts of a URI the OAuth callback check compares
+ *
+ *  \b scheme, \b host and \b path are percent decoded, \b query points into the URI that was
+ *  parsed and keeps its escapes.
+ */
+typedef struct
+{
+	char* scheme;
+	char* host;
+	char* path;
+	const char* query;
+	UINT32 port;
+	BOOL userinfo;
+	BOOL fragment;
+} client_uri;
+
+/** @brief Percent decode a URI component the callback check compares
+ *
+ *  \b winpr_str_url_decode leaves an escape that is not \c '%' HEXDIG HEXDIG in place and
+ *  decodes \c %00 to an embedded NUL, so a component could carry more than the C string it
+ *  decodes to shows: every following comparison stops at the NUL and a different host or path
+ *  would pass as the expected one. Accept only well formed escapes, reject \c %00 and verify
+ *  that the result is as long as the escapes consumed say it must be.
+ *
+ *  @param str The component to decode
+ *  @param len The number of octets of \b str that belong to the component
+ *  @return The decoded component, to be released with \b free, or \b nullptr if \b str is not
+ *          a valid percent encoding of a string without NUL
+ */
+WINPR_ATTR_MALLOC(free, 1)
+static char* client_uri_decode(const char* str, size_t len)
+{
+	size_t declen = 0;
+
+	for (size_t x = 0; x < len; x++, declen++)
+	{
+		if (str[x] != '%')
+			continue;
+
+		if (x + 2 >= len)
+			return nullptr; /* an incomplete escape */
+		if (!isxdigit((unsigned char)str[x + 1]) || !isxdigit((unsigned char)str[x + 2]))
+			return nullptr;
+		if ((str[x + 1] == '0') && (str[x + 2] == '0'))
+			return nullptr; /* a NUL would truncate every comparison */
+		x += 2;
+	}
+
+	char* decoded = winpr_str_url_decode(str, len);
+	if (!decoded)
+		return nullptr;
+
+	/* Whatever the decoder did, the result has to be the string the escapes describe. */
+	if (strlen(decoded) != declen)
+	{
+		free(decoded);
+		return nullptr;
+	}
+
+	return decoded;
+}
+
+static void client_uri_free(client_uri* uri)
+{
+	free(uri->scheme);
+	free(uri->host);
+	free(uri->path);
+	const client_uri empty = WINPR_C_ARRAY_INIT;
+	*uri = empty;
+}
+
+/** The port a scheme uses when the authority does not name one. */
+static UINT32 client_uri_default_port(const char* scheme)
+{
+	if (_stricmp(scheme, "https") == 0)
+		return 443;
+	if (_stricmp(scheme, "http") == 0)
+		return 80;
+	return 0;
+}
+
+/** @brief Split a URI into the parts the callback check compares
+ *
+ *  Only absolute \c scheme://authority[/path][?query][#fragment] URIs are accepted, which is
+ *  what an OAuth redirect URI is. Nothing here is logged: the URI can hold an authorization
+ *  code.
+ *
+ *  @param str The URI to split
+ *  @param uri Receives the parts, to be released with \b client_uri_free
+ *  @return \b TRUE if \b str is such a URI
+ */
+static BOOL client_uri_parse(const char* str, client_uri* uri)
+{
+	const client_uri empty = WINPR_C_ARRAY_INIT;
+	*uri = empty;
+
+	const char* sep = strstr(str, "://");
+	if (!sep || (sep == str))
+		return FALSE;
+
+	/* scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) */
+	if (!isalpha((unsigned char)str[0]))
+		return FALSE;
+	for (const char* pos = str; pos < sep; pos++)
+	{
+		const char cur = *pos;
+		if (!isalnum((unsigned char)cur) && (cur != '+') && (cur != '-') && (cur != '.'))
+			return FALSE;
+	}
+
+	uri->scheme = strndup(str, WINPR_ASSERTING_INT_CAST(size_t, sep - str));
+	if (!uri->scheme)
+		goto fail;
+
+	const char* authority = sep + 3;
+	const char* rest = authority + strcspn(authority, "/?#");
+
+	/* An authority may be preceded by userinfo, which a redirect URI never uses. */
+	for (const char* pos = authority; pos < rest; pos++)
+	{
+		if (*pos != '@')
+			continue;
+		uri->userinfo = TRUE;
+		authority = pos + 1;
+	}
+
+	const char* hostend = authority;
+	if (*authority == '[') /* IP-literal */
+	{
+		while ((hostend < rest) && (*hostend != ']'))
+			hostend++;
+		if (hostend == rest)
+			goto fail;
+		hostend++;
+	}
+	else
+	{
+		while ((hostend < rest) && (*hostend != ':'))
+			hostend++;
+	}
+
+	if (hostend == authority)
+		goto fail;
+
+	uri->host = client_uri_decode(authority, WINPR_ASSERTING_INT_CAST(size_t, hostend - authority));
+	if (!uri->host)
+		goto fail;
+
+	if (hostend < rest)
+	{
+		if (*hostend != ':')
+			goto fail;
+
+		uri->port = 0;
+		for (const char* pos = hostend + 1; pos < rest; pos++)
+		{
+			if (!isdigit((unsigned char)*pos) || (uri->port > UINT16_MAX))
+				goto fail;
+			uri->port = uri->port * 10 + (UINT32)(*pos - '0');
+		}
+		if (uri->port > UINT16_MAX)
+			goto fail;
+		if (hostend + 1 == rest) /* an empty port means the default port */
+			uri->port = client_uri_default_port(uri->scheme);
+	}
+	else
+		uri->port = client_uri_default_port(uri->scheme);
+
+	const char* pathend = rest + strcspn(rest, "?#");
+	uri->path = client_uri_decode(rest, WINPR_ASSERTING_INT_CAST(size_t, pathend - rest));
+	if (!uri->path)
+		goto fail;
+
+	if (*pathend == '?')
+	{
+		uri->query = pathend + 1;
+		uri->fragment = strchr(uri->query, '#') != nullptr;
+	}
+	else if (*pathend == '#')
+		uri->fragment = TRUE;
+
+	return TRUE;
+
+fail:
+	client_uri_free(uri);
+	return FALSE;
+}
+
+/** @brief Whether two URIs address the same resource
+ *
+ *  The query is deliberately not compared: the authorization response adds parameters to the
+ *  redirect URI the request was made with.
+ */
+static BOOL client_uri_same_destination(const client_uri* lhs, const client_uri* rhs)
+{
+	/* An empty path and "/" address the same resource. */
+	const char* lpath = (lhs->path[0] == '\0') ? "/" : lhs->path;
+	const char* rpath = (rhs->path[0] == '\0') ? "/" : rhs->path;
+
+	return (_stricmp(lhs->scheme, rhs->scheme) == 0) && (_stricmp(lhs->host, rhs->host) == 0) &&
+	       (lhs->port == rhs->port) && (strcmp(lpath, rpath) == 0);
+}
+
+/** @brief Result of looking a parameter up in a URI query */
+typedef enum
+{
+	CLIENT_QUERY_MISSING,
+	CLIENT_QUERY_FOUND,
+	CLIENT_QUERY_DUPLICATE
+} client_query_result;
+
+/** @brief Look one parameter up in a percent encoded URI query
+ *
+ *  A parameter given without a value counts as an occurrence, so a query can not smuggle a
+ *  second \c code or \c state past the duplicate check by leaving the value out.
+ *
+ *  @param query The query to search, may be \b nullptr
+ *  @param name The name of the parameter
+ *  @param value Receives the percent decoded value, may be \b nullptr
+ *
+ *  @return whether \b name occurs exactly once in \b query with a value that decodes
+ */
+static client_query_result client_uri_query_value(const char* query, const char* name, char** value)
+{
+	client_query_result rc = CLIENT_QUERY_MISSING;
+
+	if (value)
+		*value = nullptr;
+
+	if (!query)
+		return CLIENT_QUERY_MISSING;
+
+	for (const char* pos = query; pos; pos = strchr(pos, '&'))
+	{
+		if (*pos == '&')
+			pos++;
+
+		const size_t pairlen = strcspn(pos, "&#");
+		const size_t keylen = strcspn(pos, "=&#");
+
+		char* key = client_uri_decode(pos, keylen);
+		if (!key)
+			return CLIENT_QUERY_DUPLICATE; /* a key that does not decode makes the query unusable */
+
+		const BOOL match = strcmp(key, name) == 0;
+		free(key);
+
+		if (!match)
+			continue;
+
+		if (rc != CLIENT_QUERY_MISSING)
+		{
+			if (value)
+			{
+				free(*value);
+				*value = nullptr;
+			}
+			return CLIENT_QUERY_DUPLICATE;
+		}
+
+		rc = CLIENT_QUERY_FOUND;
+		if (keylen == pairlen) /* the parameter was given without a value */
+			continue;
+
+		if (value)
+		{
+			*value = client_uri_decode(&pos[keylen + 1], pairlen - keylen - 1);
+			if (!*value)
+				return CLIENT_QUERY_DUPLICATE; /* a value that does not decode is unusable */
+		}
+	}
+
+	return rc;
+}
+
+/** @brief Compare two strings in a time that does not depend on their contents
+ *
+ *  The 'state' value is the secret an authorization response has to know. A response that does
+ *  not carry it neither ends the transaction nor closes the web view, so a page that can drive
+ *  top level navigations may try again as often as it likes.
+ *
+ *  @param a The first string
+ *  @param b The second string
+ *  @return \b TRUE if both strings are equal
+ */
+static BOOL client_const_time_equal(const char* a, const char* b)
+{
+	const size_t alen = strlen(a);
+	const size_t blen = strlen(b);
+
+	if (alen != blen)
+		return FALSE;
+
+	BYTE acc = 0;
+	for (size_t x = 0; x < alen; x++)
+		acc |= (BYTE)a[x] ^ (BYTE)b[x];
+
+	return acc == 0;
+}
+
+static const char* client_aad_callback_result_str(freerdp_client_aad_callback_result result)
+{
+	switch (result)
+	{
+		case FREERDP_CLIENT_AAD_CALLBACK_UNRELATED:
+			return "UNRELATED";
+		case FREERDP_CLIENT_AAD_CALLBACK_CODE:
+			return "CODE";
+		case FREERDP_CLIENT_AAD_CALLBACK_ERROR:
+			return "ERROR";
+		case FREERDP_CLIENT_AAD_CALLBACK_INVALID:
+		default:
+			return "INVALID";
+	}
+}
+
+freerdp_client_aad_callback_result freerdp_client_aad_parse_callback(rdpClientContext* cctx,
+                                                                     const char* uri, char** code)
+{
+	freerdp_client_aad_callback_result result = FREERDP_CLIENT_AAD_CALLBACK_INVALID;
+	client_uri actual = WINPR_C_ARRAY_INIT;
+	client_uri expected = WINPR_C_ARRAY_INIT;
+	char* state = nullptr;
+	char* value = nullptr;
+
+	if (code)
+		*code = nullptr;
+
+	if (!cctx || !uri)
+		return FREERDP_CLIENT_AAD_CALLBACK_INVALID;
+
+	client_aad_oauth* oauth = cctx->aad_oauth;
+	if (!oauth || !oauth->state || !oauth->redirect_uri)
+	{
+		WLog_ERR(TAG, "no AAD authorization request is in flight");
+		return FREERDP_CLIENT_AAD_CALLBACK_INVALID;
+	}
+
+	/* An authorization response is answered once. A second one, whatever it carries, is a
+	 * replay of the first or a response to a request this client did not make. */
+	if (oauth->consumed)
+	{
+		WLog_ERR(TAG, "the AAD authorization request was already answered");
+		return FREERDP_CLIENT_AAD_CALLBACK_INVALID;
+	}
+
+	if (!client_uri_parse(oauth->redirect_uri, &expected))
+	{
+		WLog_ERR(TAG, "the redirect URI of the authorization request is not an absolute URI");
+		goto cleanup;
+	}
+
+	/* A web view navigates to all kinds of URIs, only the redirect URI is ours. */
+	if (!client_uri_parse(uri, &actual) || !client_uri_same_destination(&actual, &expected))
+	{
+		result = FREERDP_CLIENT_AAD_CALLBACK_UNRELATED;
+		goto cleanup;
+	}
+
+	if (actual.userinfo || actual.fragment)
+		goto cleanup;
+
+	if ((client_uri_query_value(actual.query, "state", &state) != CLIENT_QUERY_FOUND) || !state ||
+	    !client_const_time_equal(state, oauth->state))
+		goto cleanup;
+
+	const client_query_result hasCode = client_uri_query_value(actual.query, "code", &value);
+	const client_query_result hasError = client_uri_query_value(actual.query, "error", nullptr);
+
+	if ((hasCode == CLIENT_QUERY_FOUND) && (hasError == CLIENT_QUERY_MISSING))
+	{
+		if (!value || (value[0] == '\0'))
+			goto cleanup;
+
+		result = FREERDP_CLIENT_AAD_CALLBACK_CODE;
+		if (code)
+		{
+			*code = value;
+			value = nullptr;
+		}
+	}
+	else if ((hasError == CLIENT_QUERY_FOUND) && (hasCode == CLIENT_QUERY_MISSING))
+		result = FREERDP_CLIENT_AAD_CALLBACK_ERROR;
+
+cleanup:
+	/* The transaction has reached its end, only the code verifier is still needed. */
+	if ((result == FREERDP_CLIENT_AAD_CALLBACK_CODE) ||
+	    (result == FREERDP_CLIENT_AAD_CALLBACK_ERROR))
+		oauth->consumed = TRUE;
+
+	/* Never log the URI or anything parsed out of it: it can hold an authorization code and
+	 * the error description can name the account that was used. */
+	WLog_Print(WLog_Get(TAG),
+	           (result == FREERDP_CLIENT_AAD_CALLBACK_UNRELATED) ? WLOG_DEBUG : WLOG_INFO,
+	           "AAD authorization callback: %s", client_aad_callback_result_str(result));
+	free(state);
+	free(value);
+	client_uri_free(&actual);
+	client_uri_free(&expected);
+	return result;
 }
 
 static void set_default_callbacks(freerdp* instance)
@@ -1141,38 +1545,103 @@ BOOL client_cli_present_gateway_message(freerdp* instance, UINT32 type, BOOL isD
 	return TRUE;
 }
 
-static const char* extract_authorization_code(char* url)
+#if defined(WITH_AAD)
+/** @brief Strip what a terminal or a mail client wrapped around a pasted URI
+ *
+ *  A pasted line arrives with the line ending, often with leading white space and sometimes
+ *  inside the angle brackets or quotes that clients put around a URI. None of that belongs to
+ *  the URI, and one stray character is enough to fail the single attempt this flow has.
+ *
+ *  @param url The line to trim in place
+ *  @return The first character of the URI in \b url
+ */
+static char* client_trim_pasted_uri(char* url)
 {
-	WINPR_ASSERT(url);
+	char* start = url;
+	size_t len = strlen(start);
 
-	for (char* p = strchr(url, '?'); p++ != nullptr; p = strchr(p, '&'))
+	for (BOOL done = FALSE; !done;)
 	{
-		if (strncmp(p, "code=", 5) != 0)
-			continue;
+		done = TRUE;
 
-		char* end = nullptr;
-		p += 5;
+		while ((len > 0) && isspace((unsigned char)start[0]))
+		{
+			start++;
+			len--;
+			done = FALSE;
+		}
 
-		end = strchr(p, '&');
-		if (end)
-			*end = '\0';
+		while ((len > 0) && isspace((unsigned char)start[len - 1]))
+		{
+			start[--len] = '\0';
+			done = FALSE;
+		}
 
-		return p;
+		/* <https://...>, "https://..." and 'https://...' all show up in pasted lines. */
+		const char first = (len >= 2) ? start[0] : '\0';
+		const char last = (len >= 2) ? start[len - 1] : '\0';
+		if (((first == '<') && (last == '>')) ||
+		    (((first == '"') || (first == '\'')) && (last == first)))
+		{
+			start[len - 1] = '\0';
+			start++;
+			len -= 2;
+			done = FALSE;
+		}
 	}
 
-	return nullptr;
+	return start;
 }
 
-#if defined(WITH_AAD)
+/** @brief Read the redirect URI the user pasted and return the authorization code
+ *
+ *  @param instance The RDP instance to read for
+ *  @param cctx The client context the authorization request was built with
+ *  @return The percent decoded authorization code or \b nullptr
+ */
+WINPR_ATTR_MALLOC(free, 1)
+static char* client_cli_read_authorization_code(freerdp* instance, rdpClientContext* cctx)
+{
+	size_t size = 0;
+	char* url = nullptr;
+	char* code = nullptr;
+
+	printf("Paste redirect URL here: \n");
+
+	if (freerdp_interruptible_get_line(instance->context, &url, &size, stdin) < 0)
+	{
+		free(url);
+		return nullptr;
+	}
+
+	switch (freerdp_client_aad_parse_callback(cctx, client_trim_pasted_uri(url), &code))
+	{
+		case FREERDP_CLIENT_AAD_CALLBACK_CODE:
+			break;
+		case FREERDP_CLIENT_AAD_CALLBACK_ERROR:
+			WLog_ERR(TAG, "the authorization server declined the request");
+			break;
+		case FREERDP_CLIENT_AAD_CALLBACK_UNRELATED:
+			WLog_ERR(TAG, "this is not the redirect URI the request was made with");
+			break;
+		default:
+			WLog_ERR(TAG, "the authorization response was rejected");
+			break;
+	}
+
+	/* The pasted line holds the authorization code. */
+	client_free_secret(url);
+	return code;
+}
+
 static BOOL client_cli_get_rdsaad_access_token(freerdp* instance, const char* scope,
                                                const char* req_cnf, char** token)
 {
 	WINPR_ASSERT(instance);
 	WINPR_ASSERT(instance->context);
 
-	size_t size = 0;
-	char* url = nullptr;
 	char* token_request = nullptr;
+	char* code = nullptr;
 
 	WINPR_ASSERT(scope);
 	WINPR_ASSERT(req_cnf);
@@ -1181,24 +1650,20 @@ static BOOL client_cli_get_rdsaad_access_token(freerdp* instance, const char* sc
 	BOOL rc = FALSE;
 	*token = nullptr;
 
-	char* request = freerdp_client_get_aad_url((rdpClientContext*)instance->context,
-	                                           FREERDP_CLIENT_AAD_AUTH_REQUEST, scope);
+	rdpClientContext* cctx = (rdpClientContext*)instance->context;
+	char* request = freerdp_client_get_aad_url(cctx, FREERDP_CLIENT_AAD_AUTH_REQUEST, scope);
+	if (!request)
+		return FALSE;
 
 	printf("Browse to: %s\n", request);
 	free(request);
-	printf("Paste redirect URL here: \n");
 
-	if (freerdp_interruptible_get_line(instance->context, &url, &size, stdin) < 0)
+	code = client_cli_read_authorization_code(instance, cctx);
+	if (!code)
 		goto cleanup;
 
-	{
-		const char* code = extract_authorization_code(url);
-		if (!code)
-			goto cleanup;
-		token_request =
-		    freerdp_client_get_aad_url((rdpClientContext*)instance->context,
-		                               FREERDP_CLIENT_AAD_TOKEN_REQUEST, scope, code, req_cnf);
-	}
+	token_request =
+	    freerdp_client_get_aad_url(cctx, FREERDP_CLIENT_AAD_TOKEN_REQUEST, scope, code, req_cnf);
 	if (!token_request)
 		goto cleanup;
 
@@ -1206,7 +1671,7 @@ static BOOL client_cli_get_rdsaad_access_token(freerdp* instance, const char* sc
 
 cleanup:
 	client_free_secret(token_request);
-	free(url);
+	client_free_secret(code);
 	return rc && (*token != nullptr);
 }
 
@@ -1215,9 +1680,8 @@ static BOOL client_cli_get_avd_access_token(freerdp* instance, char** token)
 	WINPR_ASSERT(instance);
 	WINPR_ASSERT(instance->context);
 
-	size_t size = 0;
-	char* url = nullptr;
 	char* token_request = nullptr;
+	char* code = nullptr;
 
 	WINPR_ASSERT(token);
 
@@ -1225,25 +1689,19 @@ static BOOL client_cli_get_avd_access_token(freerdp* instance, char** token)
 
 	*token = nullptr;
 
-	char* request = freerdp_client_get_aad_url((rdpClientContext*)instance->context,
-	                                           FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST);
+	rdpClientContext* cctx = (rdpClientContext*)instance->context;
+	char* request = freerdp_client_get_aad_url(cctx, FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST);
 	if (!request)
 		return FALSE;
+
 	printf("Browse to: %s\n", request);
 	free(request);
-	printf("Paste redirect URL here: \n");
 
-	if (freerdp_interruptible_get_line(instance->context, &url, &size, stdin) < 0)
+	code = client_cli_read_authorization_code(instance, cctx);
+	if (!code)
 		goto cleanup;
 
-	{
-		const char* code = extract_authorization_code(url);
-		if (!code)
-			goto cleanup;
-		token_request = freerdp_client_get_aad_url((rdpClientContext*)instance->context,
-		                                           FREERDP_CLIENT_AAD_AVD_TOKEN_REQUEST, code);
-	}
-
+	token_request = freerdp_client_get_aad_url(cctx, FREERDP_CLIENT_AAD_AVD_TOKEN_REQUEST, code);
 	if (!token_request)
 		goto cleanup;
 
@@ -1251,7 +1709,7 @@ static BOOL client_cli_get_avd_access_token(freerdp* instance, char** token)
 
 cleanup:
 	client_free_secret(token_request);
-	free(url);
+	client_free_secret(code);
 	return rc && (*token != nullptr);
 }
 #endif

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -70,6 +70,9 @@
 #include <freerdp/channels/rdpewa.h>
 
 #ifdef WITH_AAD
+#include <winpr/custom-crypto.h>
+
+#include <freerdp/crypto/crypto.h>
 #include <freerdp/utils/http.h>
 #include <freerdp/utils/aad.h>
 #endif
@@ -80,6 +83,51 @@
 
 #include <freerdp/log.h>
 #define TAG CLIENT_TAG("common")
+
+/** @brief State of one interactive OAuth transaction
+ *
+ *  Created by an authorization request built with \ref freerdp_client_get_aad_url and kept in
+ *  \b rdpClientContext::aad_oauth until it is replaced by the next authorization request or
+ *  released by \ref freerdp_client_aad_reset. Only one transaction exists per client context
+ *  and access to it is not synchronized.
+ */
+typedef struct client_aad_oauth
+{
+	char* state;        /**< the 'state' value sent with the authorization request */
+	char* verifier;     /**< the PKCE code verifier sent with the token request */
+	char* redirect_uri; /**< percent decoded URI the authorization response must arrive at */
+} client_aad_oauth;
+
+/** @brief Release a string that held credential material
+ *
+ *  @param str The string to scrub and release, may be \b nullptr
+ */
+static void client_free_secret(char* str)
+{
+	if (str)
+		SecureZeroMemory(str, strlen(str));
+	free(str);
+}
+
+static void client_aad_oauth_free(client_aad_oauth* oauth)
+{
+	if (!oauth)
+		return;
+
+	free(oauth->state);
+	client_free_secret(oauth->verifier);
+	free(oauth->redirect_uri);
+	free(oauth);
+}
+
+void freerdp_client_aad_reset(rdpClientContext* cctx)
+{
+	if (!cctx)
+		return;
+
+	client_aad_oauth_free(cctx->aad_oauth);
+	cctx->aad_oauth = nullptr;
+}
 
 static void set_default_callbacks(freerdp* instance)
 {
@@ -137,6 +185,8 @@ static void freerdp_client_common_free(freerdp* instance, rdpContext* context)
 	pEntryPoints = instance->pClientEntryPoints;
 	WINPR_ASSERT(pEntryPoints);
 	IFCALL(pEntryPoints->ClientFree, instance, context);
+
+	freerdp_client_aad_reset((rdpClientContext*)context);
 }
 
 /* Common API */
@@ -1155,7 +1205,7 @@ static BOOL client_cli_get_rdsaad_access_token(freerdp* instance, const char* sc
 	rc = client_common_get_access_token(instance, token_request, token);
 
 cleanup:
-	free(token_request);
+	client_free_secret(token_request);
 	free(url);
 	return rc && (*token != nullptr);
 }
@@ -1200,7 +1250,7 @@ static BOOL client_cli_get_avd_access_token(freerdp* instance, char** token)
 	rc = client_common_get_access_token(instance, token_request, token);
 
 cleanup:
-	free(token_request);
+	client_free_secret(token_request);
 	free(url);
 	return rc && (*token != nullptr);
 }
@@ -2660,6 +2710,158 @@ static char* get_redirect_uri(const rdpSettings* settings)
 	return redirect_uri;
 }
 
+/** The number of random bytes behind the 'state' value and the PKCE code verifier.
+ *
+ *  32 bytes base64url encode to 43 characters, the shortest code verifier RFC 7636 allows.
+ */
+#define CLIENT_AAD_OAUTH_RANDOM_LEN 32
+
+/** @brief Fill a buffer with unpredictable bytes
+ *
+ *  A build without a crypto backend has winpr_RAND() succeed without touching the buffer, which
+ *  would make the 'state' value and the code verifier the same for every session. Reject a
+ *  result that is all zero: a real draw of this size is that only with probability 2^-256.
+ *  \b buffer is cleared first, so the check does not pass on what a previous draw left in a
+ *  buffer that is used more than once.
+ *
+ *  @param buffer The buffer to fill
+ *  @param len The size of \b buffer in bytes
+ *  @return \b TRUE if \b buffer holds \b len random bytes
+ */
+static BOOL client_aad_oauth_random(BYTE* buffer, size_t len)
+{
+	memset(buffer, 0, len);
+
+	if (winpr_RAND(buffer, len) < 0)
+		return FALSE;
+
+	BYTE acc = 0;
+	for (size_t x = 0; x < len; x++)
+		acc |= buffer[x];
+
+	if (acc == 0)
+	{
+		WLog_ERR(TAG, "the random number generator returned zeros, no crypto backend?");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/** @brief Generate the 'state' value and the PKCE code verifier of a transaction
+ *
+ *  @param oauth The transaction to fill in
+ *  @param pchallenge Receives the base64url encoded SHA-256 of the code verifier
+ *  @return \b TRUE on success
+ */
+static BOOL client_aad_oauth_generate(client_aad_oauth* oauth, char** pchallenge)
+{
+	BYTE random[CLIENT_AAD_OAUTH_RANDOM_LEN] = WINPR_C_ARRAY_INIT;
+	BYTE hash[WINPR_SHA256_DIGEST_LENGTH] = WINPR_C_ARRAY_INIT;
+
+	if (!client_aad_oauth_random(random, sizeof(random)))
+		return FALSE;
+	oauth->state = crypto_base64url_encode(random, sizeof(random));
+
+	if (!client_aad_oauth_random(random, sizeof(random)))
+		return FALSE;
+	oauth->verifier = crypto_base64url_encode(random, sizeof(random));
+
+	if (!oauth->state || !oauth->verifier)
+		return FALSE;
+
+	if (!winpr_Digest(WINPR_MD_SHA256, oauth->verifier, strlen(oauth->verifier), hash,
+	                  sizeof(hash)))
+		return FALSE;
+
+	*pchallenge = crypto_base64url_encode(hash, sizeof(hash));
+	return *pchallenge != nullptr;
+}
+
+/** @brief Start a new OAuth transaction on a client context
+ *
+ *  Replaces any transaction still attached to \b cctx.
+ *
+ *  @param cctx The client context to attach the transaction to
+ *  @param redirect_uri The percent encoded redirect URI of the authorization request
+ *  @return The query parameters to append to the authorization request or \b nullptr
+ */
+WINPR_ATTR_MALLOC(free, 1)
+static char* client_aad_oauth_start(rdpClientContext* cctx, const char* redirect_uri)
+{
+	char* challenge = nullptr;
+	char* params = nullptr;
+	size_t paramslen = 0;
+
+	freerdp_client_aad_reset(cctx);
+
+	client_aad_oauth* oauth = calloc(1, sizeof(client_aad_oauth));
+	if (!oauth)
+		return nullptr;
+
+	oauth->redirect_uri = winpr_str_url_decode(redirect_uri, strlen(redirect_uri));
+	if (!oauth->redirect_uri)
+		goto fail;
+
+	if (!client_aad_oauth_generate(oauth, &challenge))
+		goto fail;
+
+	/* The state value and the challenge are base64url, so they need no escaping. */
+	winpr_asprintf(&params, &paramslen, "&state=%s&code_challenge=%s&code_challenge_method=S256",
+	               oauth->state, challenge);
+	if (!params)
+		goto fail;
+
+	cctx->aad_oauth = oauth;
+	free(challenge);
+	return params;
+
+fail:
+	free(challenge);
+	client_aad_oauth_free(oauth);
+	return nullptr;
+}
+
+/** @brief The query parameters a token request has to carry for the running transaction
+ *
+ *  Leaves the transaction in place: it is released by \ref client_aad_oauth_token_done once the
+ *  request body was built, so a build that fails does not lose the verifier.
+ *
+ *  @param cctx The client context the authorization request was built with
+ *  @return An allocated string, empty if no transaction is in flight, or \b nullptr on error
+ */
+WINPR_ATTR_MALLOC(free, 1)
+static char* client_aad_oauth_token_params(rdpClientContext* cctx)
+{
+	const client_aad_oauth* oauth = cctx->aad_oauth;
+	if (!oauth || !oauth->verifier)
+	{
+		WLog_WARN(TAG, "no AAD authorization request was built with this client context, the "
+		               "token request carries no PKCE code verifier");
+		return _strdup("");
+	}
+
+	char* params = nullptr;
+	size_t paramslen = 0;
+	winpr_asprintf(&params, &paramslen, "&code_verifier=%s", oauth->verifier);
+	return params;
+}
+
+/** @brief Release the transaction a token request was just built for
+ *
+ *  A code verifier belongs to exactly one token request, and the authorization code it was
+ *  requested with is redeemed by that one request. Only a request that was built completely
+ *  consumes them: a build that failed sent nothing, so its transaction stays usable.
+ *
+ *  @param cctx The client context the authorization request was built with
+ *  @param request The request body that was built, or \b nullptr if the build failed
+ */
+static void client_aad_oauth_token_done(rdpClientContext* cctx, const char* request)
+{
+	if (request)
+		freerdp_client_aad_reset(cctx);
+}
+
 static char* avd_auth_request(rdpClientContext* cctx, WINPR_ATTR_UNUSED va_list ap)
 {
 	const rdpSettings* settings = cctx->context.settings;
@@ -2677,8 +2879,14 @@ static char* avd_auth_request(rdpClientContext* cctx, WINPR_ATTR_UNUSED va_list 
 
 	char* url = nullptr;
 	size_t urllen = 0;
-	winpr_asprintf(&url, &urllen, "%s?client_id=%s&response_type=code&scope=%s&redirect_uri=%s", ep,
-	               client_id, scope, redirect_uri);
+	char* oauth = client_aad_oauth_start(cctx, redirect_uri);
+	if (oauth)
+	{
+		winpr_asprintf(&url, &urllen,
+		               "%s?client_id=%s&response_type=code&scope=%s&redirect_uri=%s%s", ep,
+		               client_id, scope, redirect_uri, oauth);
+	}
+	free(oauth);
 	free(redirect_uri);
 	return url;
 }
@@ -2702,9 +2910,18 @@ static char* avd_token_request(rdpClientContext* cctx, WINPR_ATTR_UNUSED va_list
 	size_t urllen = 0;
 
 	const char* code = va_arg(ap, const char*);
-	winpr_asprintf(&url, &urllen,
-	               "grant_type=authorization_code&code=%s&client_id=%s&scope=%s&redirect_uri=%s",
-	               code, client_id, scope, redirect_uri);
+	char* oauth = client_aad_oauth_token_params(cctx);
+	char* enccode = code ? winpr_str_url_encode(code, strlen(code)) : nullptr;
+	if (oauth && enccode)
+	{
+		winpr_asprintf(
+		    &url, &urllen,
+		    "grant_type=authorization_code&code=%s&client_id=%s&scope=%s&redirect_uri=%s%s",
+		    enccode, client_id, scope, redirect_uri, oauth);
+	}
+	client_aad_oauth_token_done(cctx, url);
+	client_free_secret(enccode);
+	client_free_secret(oauth);
 	free(redirect_uri);
 	return url;
 }
@@ -2728,9 +2945,17 @@ static char* aad_auth_request(rdpClientContext* cctx, WINPR_ATTR_UNUSED va_list 
 		{
 			const char* ep = freerdp_utils_aad_get_wellknown_string(
 			    &cctx->context, AAD_WELLKNOWN_authorization_endpoint);
-			winpr_asprintf(&url, &urllen,
-			               "%s?client_id=%s&response_type=code&scope=%s&redirect_uri=%s", ep,
-			               client_id, scope, redirect_uri);
+			if (!ep)
+				goto cleanup;
+
+			char* oauth = client_aad_oauth_start(cctx, redirect_uri);
+			if (oauth)
+			{
+				winpr_asprintf(&url, &urllen,
+				               "%s?client_id=%s&response_type=code&scope=%s&redirect_uri=%s%s", ep,
+				               client_id, scope, redirect_uri, oauth);
+			}
+			free(oauth);
 		}
 	}
 
@@ -2759,10 +2984,18 @@ static char* aad_token_request(rdpClientContext* cctx, WINPR_ATTR_UNUSED va_list
 	char* url = nullptr;
 	size_t urllen = 0;
 
-	winpr_asprintf(
-	    &url, &urllen,
-	    "grant_type=authorization_code&code=%s&client_id=%s&scope=%s&redirect_uri=%s&req_cnf=%s",
-	    code, client_id, scope, redirect_uri, req_cnf);
+	char* oauth = client_aad_oauth_token_params(cctx);
+	char* enccode = winpr_str_url_encode(code, strlen(code));
+	if (oauth && enccode)
+	{
+		winpr_asprintf(&url, &urllen,
+		               "grant_type=authorization_code&code=%s&client_id=%s&scope=%s&redirect_uri=%"
+		               "s&req_cnf=%s%s",
+		               enccode, client_id, scope, redirect_uri, req_cnf, oauth);
+	}
+	client_aad_oauth_token_done(cctx, url);
+	client_free_secret(enccode);
+	client_free_secret(oauth);
 	free(redirect_uri);
 	return url;
 }

--- a/client/common/client.c
+++ b/client/common/client.c
@@ -1808,8 +1808,12 @@ BOOL client_common_get_access_token(freerdp* instance, const char* request, char
 		WLog_Print(log, WLOG_ERROR,
 		           "Server unwilling to provide access token; returned status code %s",
 		           freerdp_http_status_string_format(resp_code, buffer, sizeof(buffer)));
+
+		/* The body is the OAuth error document. It names the account the request was made
+		 * with and carries correlation identifiers, so keep it out of the log a user is
+		 * asked to attach to a bug report. */
 		if (response_length > 0)
-			WLog_Print(log, WLOG_ERROR, "[status message] %s", response);
+			WLog_Print(log, WLOG_DEBUG, "[status message] %s", response);
 		goto cleanup;
 	}
 

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -30,7 +30,10 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	{ "azure", COMMAND_LINE_VALUE_REQUIRED,
 	  "[tenantid:<id>],[use-tenantid[:[on|off]],[ad:<url>]"
 	  "[avd-access:<format string>],[avd-token:<format string>],[avd-scope:<format string>]",
-	  nullptr, nullptr, -1, nullptr, "AzureAD options" },
+	  nullptr, nullptr, -1, nullptr,
+	  "AzureAD options. avd-access is a printf format expanded with the authority and the tenant "
+	  "id, so it may hold at most two '%s' conversions and '%%' for a literal percent; avd-token "
+	  "holds at most one '%s', the client id" },
 	{ "action-script", COMMAND_LINE_VALUE_REQUIRED, "<file-name>", "~/.config/freerdp/action.sh",
 	  nullptr, -1, nullptr, "Action script" },
 	{ "admin", COMMAND_LINE_VALUE_FLAG, nullptr, nullptr, nullptr, -1, "console",

--- a/client/common/test/CMakeLists.txt
+++ b/client/common/test/CMakeLists.txt
@@ -5,7 +5,7 @@ set(${MODULE_PREFIX}_DRIVER ${MODULE_NAME}.c)
 
 disable_warnings_for_directory(${CMAKE_CURRENT_BINARY_DIR})
 
-set(${MODULE_PREFIX}_TESTS TestClientRdpFile.c TestClientChannels.c TestClientCmdLine.c)
+set(${MODULE_PREFIX}_TESTS TestClientRdpFile.c TestClientChannels.c TestClientCmdLine.c TestClientAad.c)
 
 create_test_sourcelist(${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_DRIVER} ${${MODULE_PREFIX}_TESTS})
 

--- a/client/common/test/TestClientAad.c
+++ b/client/common/test/TestClientAad.c
@@ -17,6 +17,7 @@
 
 #include <freerdp/config.h>
 
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -26,12 +27,19 @@
 #include <freerdp/client.h>
 #include <freerdp/settings.h>
 
+/* The field taken out of the reserved padding must not have changed the size of the struct. */
+WINPR_STATIC_ASSERT(sizeof(rdpClientContext) - offsetof(rdpClientContext, aad_oauth) ==
+                    (129 - 16) * sizeof(UINT64));
+
 /* Every case below needs a cached OpenID configuration to stay offline, and the only way to
  * install one is freerdp_utils_aad_set_wellknown(), which is core-private (FREERDP_LOCAL) and
  * therefore only linkable when BUILD_TESTING_INTERNAL forces EXPORT_ALL_SYMBOLS. A normal
  * BUILD_TESTING=ON build skips the whole body; CI enables BUILD_TESTING_INTERNAL. */
 #if defined(WITH_AAD) && defined(BUILD_TESTING_INTERNAL)
 
+#include <winpr/custom-crypto.h>
+
+#include <freerdp/crypto/crypto.h>
 #include <freerdp/utils/aad.h>
 
 #include "../../../libfreerdp/core/aad.h"
@@ -75,6 +83,278 @@ static rdpContext* test_context_new(void)
 	}
 
 	return context;
+}
+
+/** Returns the value of parameter @p name of the query of @p url, or of @p url itself if it
+ *  is a request body without a query separator. */
+static char* query_value(const char* url, const char* name)
+{
+	const size_t namelen = strlen(name);
+	const char* query = strchr(url, '?');
+	const char* pos = query ? query + 1 : url;
+
+	while (pos)
+	{
+		if ((strncmp(pos, name, namelen) == 0) && (pos[namelen] == '='))
+		{
+			pos += namelen + 1;
+			const char* end = strchr(pos, '&');
+			const size_t len = end ? (size_t)(end - pos) : strlen(pos);
+			return strndup(pos, len);
+		}
+
+		pos = strchr(pos, '&');
+		if (pos)
+			pos++;
+	}
+
+	return nullptr;
+}
+
+static BOOL is_base64url(const char* what, const char* str, size_t expected)
+{
+	if (!str)
+	{
+		(void)fprintf(stderr, "%s is missing\n", what);
+		return FALSE;
+	}
+
+	const size_t len = strlen(str);
+	if (len != expected)
+	{
+		(void)fprintf(stderr, "%s: expected %" PRIuz " characters, got %" PRIuz "\n", what,
+		              expected, len);
+		return FALSE;
+	}
+
+	for (size_t x = 0; x < len; x++)
+	{
+		const char cur = str[x];
+		const BOOL ok = ((cur >= 'a') && (cur <= 'z')) || ((cur >= 'A') && (cur <= 'Z')) ||
+		                ((cur >= '0') && (cur <= '9')) || (cur == '-') || (cur == '_');
+		if (!ok)
+		{
+			(void)fprintf(stderr, "%s: unexpected character\n", what);
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}
+
+/* Item 2: the authorization request carries a state value and a PKCE S256 challenge, the token
+ * request the matching verifier. */
+static BOOL test_pkce(void)
+{
+	BOOL rc = FALSE;
+	char* url = nullptr;
+	char* token = nullptr;
+	char* state = nullptr;
+	char* challenge = nullptr;
+	char* method = nullptr;
+	char* verifier = nullptr;
+	char* expected = nullptr;
+	BYTE hash[WINPR_SHA256_DIGEST_LENGTH] = WINPR_C_ARRAY_INIT;
+
+	rdpContext* context = test_context_new();
+	if (!context)
+		return FALSE;
+
+	url =
+	    freerdp_client_get_aad_url((rdpClientContext*)context, FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST);
+	if (!url)
+	{
+		(void)fprintf(stderr, "no authorization request\n");
+		goto fail;
+	}
+
+	state = query_value(url, "state");
+	challenge = query_value(url, "code_challenge");
+	method = query_value(url, "code_challenge_method");
+
+	if (!is_base64url("state", state, 43) || !is_base64url("code_challenge", challenge, 43))
+		goto fail;
+
+	if (!method || (strcmp(method, "S256") != 0))
+	{
+		(void)fprintf(stderr, "code_challenge_method is not S256\n");
+		goto fail;
+	}
+
+	token = freerdp_client_get_aad_url((rdpClientContext*)context,
+	                                   FREERDP_CLIENT_AAD_AVD_TOKEN_REQUEST, "a+b c");
+	if (!token)
+	{
+		(void)fprintf(stderr, "no token request\n");
+		goto fail;
+	}
+
+	verifier = query_value(token, "code_verifier");
+	if (!is_base64url("code_verifier", verifier, 43))
+		goto fail;
+
+	/* The challenge must be the base64url encoded SHA-256 of the verifier. */
+	if (!winpr_Digest(WINPR_MD_SHA256, verifier, strlen(verifier), hash, sizeof(hash)))
+		goto fail;
+
+	expected = crypto_base64url_encode(hash, sizeof(hash));
+	if (!expected || (strcmp(expected, challenge) != 0))
+	{
+		(void)fprintf(stderr, "the challenge is not the SHA-256 of the verifier\n");
+		goto fail;
+	}
+
+	/* The authorization code is escaped before it is put into the request body. */
+	if (!strstr(token, "code=a%2Bb%20c&"))
+	{
+		(void)fprintf(stderr, "the authorization code was not escaped\n");
+		goto fail;
+	}
+
+	rc = TRUE;
+fail:
+	free(url);
+	free(token);
+	free(state);
+	free(challenge);
+	free(method);
+	free(verifier);
+	free(expected);
+	freerdp_client_context_free(context);
+	return rc;
+}
+
+/* Item 2: every authorization request replaces the previous transaction, the verifier is sent
+ * with one token request, and a token request built without a transaction carries none. */
+static BOOL test_transaction_lifetime(void)
+{
+	BOOL rc = FALSE;
+	char* first = nullptr;
+	char* second = nullptr;
+	char* state1 = nullptr;
+	char* state2 = nullptr;
+	char* token = nullptr;
+
+	rdpContext* context = test_context_new();
+	if (!context)
+		return FALSE;
+
+	/* A caller that builds the authorization URL itself gets an unchanged token request. */
+	token = freerdp_client_get_aad_url((rdpClientContext*)context,
+	                                   FREERDP_CLIENT_AAD_AVD_TOKEN_REQUEST, "code");
+	if (!token || strstr(token, "code_verifier"))
+	{
+		(void)fprintf(stderr, "a token request without a transaction has a verifier\n");
+		goto fail;
+	}
+
+	first =
+	    freerdp_client_get_aad_url((rdpClientContext*)context, FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST);
+	second =
+	    freerdp_client_get_aad_url((rdpClientContext*)context, FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST);
+	if (!first || !second)
+		goto fail;
+
+	state1 = query_value(first, "state");
+	state2 = query_value(second, "state");
+	if (!state1 || !state2 || (strcmp(state1, state2) == 0))
+	{
+		(void)fprintf(stderr, "two authorization requests share a state value\n");
+		goto fail;
+	}
+
+	/* The token request of the transaction carries the verifier, a second one does not: the
+	 * authorization code it belongs to is redeemed once. */
+	free(token);
+	token = freerdp_client_get_aad_url((rdpClientContext*)context,
+	                                   FREERDP_CLIENT_AAD_AVD_TOKEN_REQUEST, "code");
+	if (!token || !strstr(token, "code_verifier"))
+	{
+		(void)fprintf(stderr, "the token request of a transaction has no verifier\n");
+		goto fail;
+	}
+
+	free(token);
+	token = freerdp_client_get_aad_url((rdpClientContext*)context,
+	                                   FREERDP_CLIENT_AAD_AVD_TOKEN_REQUEST, "code");
+	if (!token || strstr(token, "code_verifier"))
+	{
+		(void)fprintf(stderr, "a verifier was sent with a second token request\n");
+		goto fail;
+	}
+
+	/* After a reset no verifier is sent any more. */
+	freerdp_client_aad_reset((rdpClientContext*)context);
+	free(token);
+	token = freerdp_client_get_aad_url((rdpClientContext*)context,
+	                                   FREERDP_CLIENT_AAD_AVD_TOKEN_REQUEST, "code");
+	if (!token || strstr(token, "code_verifier"))
+	{
+		(void)fprintf(stderr, "a token request after a reset has a verifier\n");
+		goto fail;
+	}
+
+	rc = TRUE;
+fail:
+	free(first);
+	free(second);
+	free(state1);
+	free(state2);
+	free(token);
+	freerdp_client_context_free(context);
+	return rc;
+}
+
+/* Item 2: a token request that could not be built leaves the transaction in place, so the
+ * verifier is still there when the caller tries again. */
+static BOOL test_token_build_failure(void)
+{
+	BOOL rc = FALSE;
+	char* url = nullptr;
+	char* token = nullptr;
+	const char* nocode = nullptr;
+
+	rdpContext* context = test_context_new();
+	if (!context)
+		return FALSE;
+
+	url =
+	    freerdp_client_get_aad_url((rdpClientContext*)context, FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST);
+	if (!url)
+		goto fail;
+
+	/* Neither request can be built without an authorization code. */
+	token = freerdp_client_get_aad_url((rdpClientContext*)context, FREERDP_CLIENT_AAD_TOKEN_REQUEST,
+	                                   "scope", nocode, "cnf");
+	if (token)
+	{
+		(void)fprintf(stderr, "an AAD token request without an authorization code was built\n");
+		goto fail;
+	}
+
+	token = freerdp_client_get_aad_url((rdpClientContext*)context,
+	                                   FREERDP_CLIENT_AAD_AVD_TOKEN_REQUEST, nocode);
+	if (token)
+	{
+		(void)fprintf(stderr, "an AVD token request without an authorization code was built\n");
+		goto fail;
+	}
+
+	/* Nothing was sent, so the verifier of the transaction is still available. */
+	token = freerdp_client_get_aad_url((rdpClientContext*)context,
+	                                   FREERDP_CLIENT_AAD_AVD_TOKEN_REQUEST, "code");
+	if (!token || !strstr(token, "code_verifier"))
+	{
+		(void)fprintf(stderr, "a token request that failed to build lost the code verifier\n");
+		goto fail;
+	}
+
+	rc = TRUE;
+fail:
+	free(url);
+	free(token);
+	freerdp_client_context_free(context);
+	return rc;
 }
 
 /* Item 1: the redirect URI format strings are printf formats taken from settings. */
@@ -208,6 +488,12 @@ int TestClientAad(int argc, char* argv[])
 	if (!test_redirect_format())
 		return -1;
 	if (!test_tenantid())
+		return -1;
+	if (!test_pkce())
+		return -1;
+	if (!test_transaction_lifetime())
+		return -1;
+	if (!test_token_build_failure())
 		return -1;
 	return 0;
 #endif

--- a/client/common/test/TestClientAad.c
+++ b/client/common/test/TestClientAad.c
@@ -49,7 +49,8 @@ static const char wellknown[] =
     "{\"authorization_endpoint\":\"https://login.contoso.example/common/oauth2/v2.0/"
     "authorize\",\"token_endpoint\":\"https://login.contoso.example/common/oauth2/v2.0/token\"}";
 
-/* The redirect URI the tests configure, percent encoded as the settings hold it. */
+/* The redirect URI the tests configure, percent encoded as the settings hold it and decoded as
+ * it arrives in a callback. */
 static const char redirect_fmt[] = "https%%3A%%2F%%2Fcontoso.example%%2Fcallback";
 
 static rdpContext* test_context_new(void)
@@ -471,6 +472,262 @@ fail:
 	return rc;
 }
 
+/** Returns a copy of @p str with every @p placeholder replaced by @p value. */
+static char* replace_all(const char* str, char placeholder, const char* value)
+{
+	const size_t vallen = strlen(value);
+	size_t count = 0;
+	for (const char* pos = str; *pos; pos++)
+	{
+		if (*pos == placeholder)
+			count++;
+	}
+
+	char* out = calloc(strlen(str) + count * vallen + 1, sizeof(char));
+	if (!out)
+		return nullptr;
+
+	char* dst = out;
+	for (const char* pos = str; *pos; pos++)
+	{
+		if (*pos != placeholder)
+			*dst++ = *pos;
+		else
+		{
+			memcpy(dst, value, vallen);
+			dst += vallen;
+		}
+	}
+
+	return out;
+}
+
+/* Item 3: the callback parser accepts exactly the response of the running transaction. */
+static BOOL test_parse_callback(void)
+{
+	static const struct
+	{
+		const char* uri; /* '$' is replaced by the state of the transaction */
+		freerdp_client_aad_callback_result expected;
+		const char* code;
+	} tests[] = {
+		{ "https://contoso.example/callback?code=abc&state=$", FREERDP_CLIENT_AAD_CALLBACK_CODE,
+		  "abc" },
+		/* the code is returned percent decoded */
+		{ "https://contoso.example/callback?state=$&code=a%2Bb%20c",
+		  FREERDP_CLIENT_AAD_CALLBACK_CODE, "a+b c" },
+		/* scheme, host and the default port are compared without regard to case */
+		{ "HTTPS://CONTOSO.EXAMPLE/callback?code=abc&state=$", FREERDP_CLIENT_AAD_CALLBACK_CODE,
+		  "abc" },
+		{ "https://contoso.example:443/callback?code=abc&state=$", FREERDP_CLIENT_AAD_CALLBACK_CODE,
+		  "abc" },
+		/* well formed escapes are decoded, exactly once */
+		{ "https://contoso.exampl%65/call%62ack?code=abc&state=$", FREERDP_CLIENT_AAD_CALLBACK_CODE,
+		  "abc" },
+		{ "https://contoso.example/callback?code=%2541&state=$", FREERDP_CLIENT_AAD_CALLBACK_CODE,
+		  "%41" },
+		/* an error response of the transaction */
+		{ "https://contoso.example/callback?error=access_denied&state=$",
+		  FREERDP_CLIENT_AAD_CALLBACK_ERROR, nullptr },
+		{ "https://contoso.example/callback?error=access_denied&error_description=nope&state=$",
+		  FREERDP_CLIENT_AAD_CALLBACK_ERROR, nullptr },
+		/* somewhere else, the front end has to keep navigating */
+		{ "https://login.contoso.example/common/oauth2/v2.0/authorize?client_id=x",
+		  FREERDP_CLIENT_AAD_CALLBACK_UNRELATED, nullptr },
+		{ "https://evil.example/callback?code=abc&state=$", FREERDP_CLIENT_AAD_CALLBACK_UNRELATED,
+		  nullptr },
+		{ "https://contoso.example/other?code=abc&state=$", FREERDP_CLIENT_AAD_CALLBACK_UNRELATED,
+		  nullptr },
+		{ "https://contoso.example:8443/callback?code=abc&state=$",
+		  FREERDP_CLIENT_AAD_CALLBACK_UNRELATED, nullptr },
+		{ "http://contoso.example/callback?code=abc&state=$", FREERDP_CLIENT_AAD_CALLBACK_UNRELATED,
+		  nullptr },
+		{ "about:blank", FREERDP_CLIENT_AAD_CALLBACK_UNRELATED, nullptr },
+		/* the redirect URI was reached but the response can not be used */
+		{ "https://contoso.example/callback?code=abc&state=other",
+		  FREERDP_CLIENT_AAD_CALLBACK_INVALID, nullptr },
+		{ "https://contoso.example/callback?code=abc", FREERDP_CLIENT_AAD_CALLBACK_INVALID,
+		  nullptr },
+		{ "https://contoso.example/callback?code=abc&state=$&state=$",
+		  FREERDP_CLIENT_AAD_CALLBACK_INVALID, nullptr },
+		{ "https://contoso.example/callback?code=abc&code=def&state=$",
+		  FREERDP_CLIENT_AAD_CALLBACK_INVALID, nullptr },
+		{ "https://contoso.example/callback?code=abc&error=access_denied&state=$",
+		  FREERDP_CLIENT_AAD_CALLBACK_INVALID, nullptr },
+		{ "https://contoso.example/callback?state=$", FREERDP_CLIENT_AAD_CALLBACK_INVALID,
+		  nullptr },
+		{ "https://contoso.example/callback?code=&state=$", FREERDP_CLIENT_AAD_CALLBACK_INVALID,
+		  nullptr },
+		{ "https://contoso.example/callback?code=abc&state=$#fragment",
+		  FREERDP_CLIENT_AAD_CALLBACK_INVALID, nullptr },
+		{ "https://user:pass@contoso.example/callback?code=abc&state=$",
+		  FREERDP_CLIENT_AAD_CALLBACK_INVALID, nullptr },
+		/* a valueless key is an occurrence, not a parameter to skip over */
+		{ "https://contoso.example/callback?code=abc&state=$&code",
+		  FREERDP_CLIENT_AAD_CALLBACK_INVALID, nullptr },
+		{ "https://contoso.example/callback?code=abc&state", FREERDP_CLIENT_AAD_CALLBACK_INVALID,
+		  nullptr },
+		/* a percent decoded NUL would truncate the comparison of host and path */
+		{ "https://contoso.example%00.evil.example/callback?code=abc&state=$",
+		  FREERDP_CLIENT_AAD_CALLBACK_UNRELATED, nullptr },
+		{ "https://contoso.example/callback%00/evil?code=abc&state=$",
+		  FREERDP_CLIENT_AAD_CALLBACK_UNRELATED, nullptr },
+		{ "https://contoso.example/callback?code=abc&state=$%00",
+		  FREERDP_CLIENT_AAD_CALLBACK_INVALID, nullptr },
+		/* malformed escapes are rejected instead of being taken literally */
+		{ "https://contoso.example%ZZ/callback?code=abc&state=$",
+		  FREERDP_CLIENT_AAD_CALLBACK_UNRELATED, nullptr },
+		{ "https://contoso.example/callback?code=%&state=$", FREERDP_CLIENT_AAD_CALLBACK_INVALID,
+		  nullptr },
+		{ "https://contoso.example/callback?code=%ZZ&state=$", FREERDP_CLIENT_AAD_CALLBACK_INVALID,
+		  nullptr },
+		{ "https://contoso.example/callback?code=%0&state=$", FREERDP_CLIENT_AAD_CALLBACK_INVALID,
+		  nullptr }
+	};
+
+	BOOL rc = FALSE;
+	char* url = nullptr;
+	char* state = nullptr;
+
+	rdpContext* context = test_context_new();
+	if (!context)
+		return FALSE;
+
+	for (size_t x = 0; x < ARRAYSIZE(tests); x++)
+	{
+		char* code = nullptr;
+
+		/* A terminal result ends the transaction, so every case gets its own. */
+		free(url);
+		free(state);
+		state = nullptr;
+		url = freerdp_client_get_aad_url((rdpClientContext*)context,
+		                                 FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST);
+		if (!url)
+			goto fail;
+
+		state = query_value(url, "state");
+		if (!state)
+			goto fail;
+
+		/* Splice the state of the transaction into the test URI. */
+		char* uri = replace_all(tests[x].uri, '$', state);
+		if (!uri)
+			goto fail;
+
+		const freerdp_client_aad_callback_result got =
+		    freerdp_client_aad_parse_callback((rdpClientContext*)context, uri, &code);
+
+		BOOL ok = got == tests[x].expected;
+		if (ok && tests[x].code)
+			ok = code && (strcmp(code, tests[x].code) == 0);
+		else if (ok)
+			ok = code == nullptr;
+
+		if (!ok)
+			(void)fprintf(stderr, "callback [%" PRIuz "] '%s': expected %d, got %d\n", x,
+			              tests[x].uri, tests[x].expected, got);
+
+		free(uri);
+		free(code);
+		if (!ok)
+			goto fail;
+	}
+
+	/* A response is answered once: the second one is a replay, whatever it carries. */
+	free(url);
+	free(state);
+	state = nullptr;
+	url =
+	    freerdp_client_get_aad_url((rdpClientContext*)context, FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST);
+	if (!url)
+		goto fail;
+
+	state = query_value(url, "state");
+	if (!state)
+		goto fail;
+
+	{
+		char* uri = replace_all("https://contoso.example/callback?code=abc&state=$", '$', state);
+		if (!uri)
+			goto fail;
+
+		char* code = nullptr;
+		freerdp_client_aad_callback_result got =
+		    freerdp_client_aad_parse_callback((rdpClientContext*)context, uri, &code);
+		free(code);
+		code = nullptr;
+
+		if (got != FREERDP_CLIENT_AAD_CALLBACK_CODE)
+		{
+			(void)fprintf(stderr, "the authorization response was not accepted\n");
+			free(uri);
+			goto fail;
+		}
+
+		got = freerdp_client_aad_parse_callback((rdpClientContext*)context, uri, &code);
+		free(uri);
+		free(code);
+
+		if (got != FREERDP_CLIENT_AAD_CALLBACK_INVALID)
+		{
+			(void)fprintf(stderr, "an authorization response was accepted twice\n");
+			goto fail;
+		}
+	}
+
+	/* A new authorization request starts a transaction that answers again. */
+	free(url);
+	free(state);
+	state = nullptr;
+	url =
+	    freerdp_client_get_aad_url((rdpClientContext*)context, FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST);
+	if (!url)
+		goto fail;
+
+	state = query_value(url, "state");
+	if (!state)
+		goto fail;
+
+	{
+		char* uri =
+		    replace_all("https://contoso.example/callback?error=access_denied&state=$", '$', state);
+		if (!uri)
+			goto fail;
+
+		const freerdp_client_aad_callback_result got =
+		    freerdp_client_aad_parse_callback((rdpClientContext*)context, uri, nullptr);
+		free(uri);
+
+		if (got != FREERDP_CLIENT_AAD_CALLBACK_ERROR)
+		{
+			(void)fprintf(stderr, "a new authorization request did not start a transaction\n");
+			goto fail;
+		}
+	}
+
+	/* Without a transaction nothing is accepted any more. */
+	freerdp_client_aad_reset((rdpClientContext*)context);
+	if (freerdp_client_aad_parse_callback((rdpClientContext*)context,
+	                                      "https://contoso.example/callback?code=abc",
+	                                      nullptr) != FREERDP_CLIENT_AAD_CALLBACK_INVALID)
+	{
+		(void)fprintf(stderr, "a callback was accepted without a transaction\n");
+		goto fail;
+	}
+
+	if (freerdp_client_aad_parse_callback((rdpClientContext*)context, nullptr, nullptr) !=
+	    FREERDP_CLIENT_AAD_CALLBACK_INVALID)
+		goto fail;
+
+	rc = TRUE;
+fail:
+	free(url);
+	free(state);
+	freerdp_client_context_free(context);
+	return rc;
+}
+
 #endif /* WITH_AAD && BUILD_TESTING_INTERNAL */
 
 int TestClientAad(int argc, char* argv[])
@@ -494,6 +751,8 @@ int TestClientAad(int argc, char* argv[])
 	if (!test_transaction_lifetime())
 		return -1;
 	if (!test_token_build_failure())
+		return -1;
+	if (!test_parse_callback())
 		return -1;
 	return 0;
 #endif

--- a/client/common/test/TestClientAad.c
+++ b/client/common/test/TestClientAad.c
@@ -1,0 +1,214 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Tests for the client common AAD helpers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <freerdp/config.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#include <winpr/crt.h>
+#include <winpr/string.h>
+
+#include <freerdp/client.h>
+#include <freerdp/settings.h>
+
+/* Every case below needs a cached OpenID configuration to stay offline, and the only way to
+ * install one is freerdp_utils_aad_set_wellknown(), which is core-private (FREERDP_LOCAL) and
+ * therefore only linkable when BUILD_TESTING_INTERNAL forces EXPORT_ALL_SYMBOLS. A normal
+ * BUILD_TESTING=ON build skips the whole body; CI enables BUILD_TESTING_INTERNAL. */
+#if defined(WITH_AAD) && defined(BUILD_TESTING_INTERNAL)
+
+#include <freerdp/utils/aad.h>
+
+#include "../../../libfreerdp/core/aad.h"
+
+/* A synthetic OpenID configuration, so no test needs to reach the network. */
+static const char wellknown[] =
+    "{\"authorization_endpoint\":\"https://login.contoso.example/common/oauth2/v2.0/"
+    "authorize\",\"token_endpoint\":\"https://login.contoso.example/common/oauth2/v2.0/token\"}";
+
+/* The redirect URI the tests configure, percent encoded as the settings hold it. */
+static const char redirect_fmt[] = "https%%3A%%2F%%2Fcontoso.example%%2Fcallback";
+
+static rdpContext* test_context_new(void)
+{
+	RDP_CLIENT_ENTRY_POINTS entry = WINPR_C_ARRAY_INIT;
+
+	entry.Size = sizeof(entry);
+	entry.Version = RDP_CLIENT_INTERFACE_VERSION;
+	entry.ContextSize = sizeof(rdpClientContext);
+
+	rdpContext* context = freerdp_client_context_new(&entry);
+	if (!context)
+	{
+		(void)fprintf(stderr, "failed to create a client context\n");
+		return nullptr;
+	}
+
+	if (!freerdp_utils_aad_set_wellknown(context, wellknown))
+	{
+		(void)fprintf(stderr, "failed to install the wellknown document\n");
+		freerdp_client_context_free(context);
+		return nullptr;
+	}
+
+	if (!freerdp_settings_set_string(context->settings, FreeRDP_GatewayAvdAccessTokenFormat,
+	                                 redirect_fmt))
+	{
+		(void)fprintf(stderr, "failed to set the redirect URI format\n");
+		freerdp_client_context_free(context);
+		return nullptr;
+	}
+
+	return context;
+}
+
+/* Item 1: the redirect URI format strings are printf formats taken from settings. */
+static BOOL test_redirect_format(void)
+{
+	static const struct
+	{
+		const char* fmt;
+		BOOL valid;
+	} tests[] = {
+		{ "https%%3A%%2F%%2Fcontoso.example%%2Fcallback%%2F%s", TRUE }, /* one conversion */
+		{ "https%%3A%%2F%%2Fcontoso.example%%2Fcallback", TRUE },       /* fixed URI */
+		{ "%s", TRUE },
+		{ "%s%s", FALSE },                     /* more arguments than the caller pushes */
+		{ "%s%s%s", FALSE },                   /* ... */
+		{ "%d", FALSE },                       /* wrong conversion */
+		{ "%n", FALSE },                       /* writes through the argument */
+		{ "%1$s", FALSE },                     /* positional argument */
+		{ "%ls", FALSE },                      /* length modifier */
+		{ "%.100s", FALSE },                   /* precision */
+		{ "%p", FALSE },                       /* wrong conversion */
+		{ "https://contoso.example/%", FALSE } /* trailing '%' */
+	};
+
+	BOOL rc = FALSE;
+	rdpContext* context = test_context_new();
+	if (!context)
+		return FALSE;
+
+	for (size_t x = 0; x < ARRAYSIZE(tests); x++)
+	{
+		if (!freerdp_settings_set_string(context->settings, FreeRDP_GatewayAvdAccessTokenFormat,
+		                                 tests[x].fmt))
+			goto fail;
+
+		char* url = freerdp_client_get_aad_url((rdpClientContext*)context,
+		                                       FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST);
+		const BOOL got = url != nullptr;
+		free(url);
+
+		if (got != tests[x].valid)
+		{
+			(void)fprintf(stderr, "format [%" PRIuz "] '%s': expected %s, got %s\n", x,
+			              tests[x].fmt, tests[x].valid ? "accepted" : "rejected",
+			              got ? "accepted" : "rejected");
+			goto fail;
+		}
+	}
+
+	rc = TRUE;
+fail:
+	freerdp_client_context_free(context);
+	return rc;
+}
+
+/* Item 1: the tenant identifier is expanded into a URL. */
+static BOOL test_tenantid(void)
+{
+	static const struct
+	{
+		const char* tenantid;
+		BOOL valid;
+	} tests[] = {
+		{ "00000000-0000-0000-0000-000000000000", TRUE },
+		{ "contoso.example", TRUE },
+		{ "common", TRUE },
+		{ "", FALSE },
+		{ "contoso example", FALSE },   /* space */
+		{ "contoso%2Fexample", FALSE }, /* percent escape */
+		{ "contoso/example", FALSE },
+		{ "contoso?example", FALSE },
+		{ "contoso#example", FALSE },
+		{ "contoso\xc3\xa9example", FALSE }, /* not ASCII, isalnum() is locale dependent */
+		{ ".", FALSE },                      /* a path element of the URL the tenant goes into */
+		{ "..", FALSE },
+		{ "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567"
+		  "8901234567890123456789012345678901234567890",
+		  FALSE } /* 129 characters */
+	};
+
+	BOOL rc = FALSE;
+	rdpContext* context = test_context_new();
+	if (!context)
+		return FALSE;
+
+	/* The stdio callbacks select the tenant based redirect URI format. */
+	if (!freerdp_settings_set_bool(context->settings, FreeRDP_UseCommonStdioCallbacks, TRUE))
+		goto fail;
+	if (!freerdp_settings_set_bool(context->settings, FreeRDP_GatewayAvdUseTenantid, TRUE))
+		goto fail;
+
+	for (size_t x = 0; x < ARRAYSIZE(tests); x++)
+	{
+		if (!freerdp_settings_set_string(context->settings, FreeRDP_GatewayAvdAadtenantid,
+		                                 tests[x].tenantid))
+			goto fail;
+
+		char* url = freerdp_client_get_aad_url((rdpClientContext*)context,
+		                                       FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST);
+		const BOOL got = url != nullptr;
+		free(url);
+
+		if (got != tests[x].valid)
+		{
+			(void)fprintf(stderr, "tenantid [%" PRIuz "]: expected %s, got %s\n", x,
+			              tests[x].valid ? "accepted" : "rejected", got ? "accepted" : "rejected");
+			goto fail;
+		}
+	}
+
+	rc = TRUE;
+fail:
+	freerdp_client_context_free(context);
+	return rc;
+}
+
+#endif /* WITH_AAD && BUILD_TESTING_INTERNAL */
+
+int TestClientAad(int argc, char* argv[])
+{
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+
+#if !defined(WITH_AAD)
+	(void)fprintf(stderr, "Build does not support AAD authentication, skipping\n");
+	return 0;
+#elif !defined(BUILD_TESTING_INTERNAL)
+	(void)fprintf(stderr, "Build is not BUILD_TESTING_INTERNAL, skipping\n");
+	return 0;
+#else
+	if (!test_redirect_format())
+		return -1;
+	if (!test_tenantid())
+		return -1;
+	return 0;
+#endif
+}

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -114,6 +114,14 @@ extern "C"
 		ALIGN64 INT32 last_y;
 	} FreeRDP_PenDevice;
 
+	/** @brief The state of the OAuth transaction of a client context
+	 *
+	 *  Created by an authorization request built with \ref freerdp_client_get_aad_url and
+	 *  released by \ref freerdp_client_aad_reset. The layout is private to the library.
+	 *  @since version 3.32.0
+	 */
+	typedef struct client_aad_oauth rdpClientAadOAuth;
+
 	struct rdp_client_context
 	{
 		rdpContext context;
@@ -145,7 +153,11 @@ extern "C"
 
 		ALIGN64 MIBClientWrapper* mibClientWrapper; /**< (offset 10) @since version 3.16.0 */
 		ALIGN64 BOOL pressed_buttons[5];            /**< (offset 11) @since version 3.17.0 */
-		UINT64 reserved[129 - 16];                  /**< (offset 16) */
+		/** Opaque state of the OAuth transaction started by \ref freerdp_client_get_aad_url,
+		 *  released by \ref freerdp_client_aad_reset.
+		 *  (offset 16) @since version 3.32.0 */
+		ALIGN64 rdpClientAadOAuth* aad_oauth;
+		UINT64 reserved[129 - 17]; /**< (offset 17) */
 	};
 
 	/* Common client functions */
@@ -367,19 +379,52 @@ extern "C"
 #endif
 
 	/** @brief type of AAD request
-	 * @since version 3.16.0
+	 *
+	 *  Each type names the arguments \ref freerdp_client_get_aad_url expects after \b type.
+	 *  Every one of them is a \b const \b char* and none of them may be \b nullptr.
+	 *  @since version 3.16.0
 	 */
 	typedef enum
 	{
+		/** Authorization request for an AAD scope, arguments: \c scope */
 		FREERDP_CLIENT_AAD_AUTH_REQUEST,
+		/** Token request redeeming a \ref FREERDP_CLIENT_AAD_AUTH_REQUEST,
+		 *  arguments: \c scope, \c code, \c req_cnf */
 		FREERDP_CLIENT_AAD_TOKEN_REQUEST,
+		/** Authorization request for Azure Virtual Desktop, no arguments */
 		FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST,
+		/** Token request redeeming a \ref FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST,
+		 *  arguments: \c code */
 		FREERDP_CLIENT_AAD_AVD_TOKEN_REQUEST,
 	} freerdp_client_aad_type;
 
 	/** @brief helper function to construct a connection URL for AAD authentication
 	 *
+	 *  \ref FREERDP_CLIENT_AAD_AUTH_REQUEST and \ref FREERDP_CLIENT_AAD_AVD_AUTH_REQUEST
+	 *  start a new OAuth transaction on \b cctx: a fresh \c state value and a PKCE code
+	 *  verifier are generated, \c state, \c code_challenge and \c code_challenge_method are
+	 *  appended to the authorization URL and the redirect URI the response has to arrive at is
+	 *  remembered. The matching \ref FREERDP_CLIENT_AAD_TOKEN_REQUEST or
+	 *  \ref FREERDP_CLIENT_AAD_AVD_TOKEN_REQUEST appends the \c code_verifier of that
+	 *  transaction and releases it once the request was built, so a verifier is sent with
+	 *  exactly one token request and a request that could not be built can be retried. A
+	 *  token request built without a preceding authorization request carries no
+	 *  \c code_verifier and logs a warning, so callers that construct the authorization URL
+	 *  themselves keep working unchanged.
+	 *
+	 *  Only one OAuth transaction can be in flight per client context: a new authorization
+	 *  request discards the state of the previous one, and no locking is done, so a context
+	 *  must not run transactions from multiple threads at the same time.
+	 *
+	 *  The \c code argument of the token requests is the percent \b decoded authorization
+	 *  code, as \ref freerdp_client_aad_parse_callback returns it: it is percent encoded again
+	 *  when it goes into the request body. Before version 3.32.0 it was copied verbatim, so
+	 *  a caller that keeps passing the value as it appears in the callback query now sends it
+	 *  encoded twice.
+	 *
 	 *  @param cctx The client context to use
+	 *  @param type The kind of request to build
+	 *  @param ... The arguments of \b type, see \ref freerdp_client_aad_type
 	 *  @return An allocated string that can be used to connect
 	 *  @since version 3.16.0
 	 */
@@ -387,6 +432,19 @@ extern "C"
 	WINPR_ATTR_NODISCARD
 	FREERDP_API char* freerdp_client_get_aad_url(rdpClientContext* cctx,
 	                                             freerdp_client_aad_type type, ...);
+
+	/** @brief Discard the OAuth transaction of a client context
+	 *
+	 *  Releases the \c state value, the PKCE code verifier and the expected redirect URI the
+	 *  last authorization request generated. A token request built afterwards carries no
+	 *  \c code_verifier. Called automatically when a new authorization request is built,
+	 *  when the matching token request has been built and when the client context is
+	 *  freed.
+	 *
+	 *  @param cctx The client context to reset, may be \b nullptr
+	 *  @since version 3.32.0
+	 */
+	FREERDP_API void freerdp_client_aad_reset(rdpClientContext* cctx);
 
 #ifdef __cplusplus
 }

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -433,13 +433,67 @@ extern "C"
 	FREERDP_API char* freerdp_client_get_aad_url(rdpClientContext* cctx,
 	                                             freerdp_client_aad_type type, ...);
 
+	/** @brief result of \ref freerdp_client_aad_parse_callback
+	 *  @since version 3.32.0
+	 */
+	typedef enum
+	{
+		/** Not the redirect URI of the transaction, keep navigating. */
+		FREERDP_CLIENT_AAD_CALLBACK_UNRELATED,
+		/** The redirect URI was reached with a usable response, \b code was allocated. */
+		FREERDP_CLIENT_AAD_CALLBACK_CODE,
+		/** The redirect URI was reached with an \c error response, e.g. the user declined. */
+		FREERDP_CLIENT_AAD_CALLBACK_ERROR,
+		/** The redirect URI was reached but the response can not be used: no transaction is in
+		 *  flight or it was already answered, the \c state does not match, a component is not
+		 *  a valid percent encoding, the URI carries userinfo or a fragment, or the query holds
+		 *  neither or both of \c code and \c error. */
+		FREERDP_CLIENT_AAD_CALLBACK_INVALID
+	} freerdp_client_aad_callback_result;
+
+	/** @brief Check a URI observed by a front end against the running OAuth transaction
+	 *
+	 *  Front ends that show an authorization request built by
+	 *  \ref freerdp_client_get_aad_url in a web view call this for every URI the view
+	 *  navigates to, front ends that let the user paste the redirect call it once. The URI is
+	 *  accepted only if its scheme, host, port and path are the ones of the redirect URI the
+	 *  authorization request was built with (compared after percent decoding, scheme and host
+	 *  without regard to case, a missing port equal to the default port of the scheme), it
+	 *  carries neither userinfo nor a fragment, and its query holds the \c state value of the
+	 *  transaction and exactly one of \c code or \c error. A parameter given without a value
+	 *  counts as an occurrence, and a component that is not a valid percent encoding of a string
+	 *  without NUL is rejected instead of being compared as it stands.
+	 *
+	 *  The first \ref FREERDP_CLIENT_AAD_CALLBACK_CODE or \ref FREERDP_CLIENT_AAD_CALLBACK_ERROR
+	 *  ends the transaction: every later call answers \ref FREERDP_CLIENT_AAD_CALLBACK_INVALID
+	 *  until a new authorization request is built. The code verifier stays available for the
+	 *  matching token request.
+	 *
+	 *  Neither the URI nor any value parsed from it is ever logged.
+	 *
+	 *  @param cctx The client context the authorization request was built with
+	 *  @param uri The URI to check
+	 *  @param code Receives the percent decoded authorization code on
+	 *              \ref FREERDP_CLIENT_AAD_CALLBACK_CODE, to be released with \b free. Set to
+	 *              \b nullptr for every other result. May be \b nullptr to only classify the
+	 *              URI.
+	 *
+	 *  @return The classification of \b uri,
+	 *          \ref FREERDP_CLIENT_AAD_CALLBACK_INVALID if \b cctx or \b uri is \b nullptr
+	 *  @since version 3.32.0
+	 */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API freerdp_client_aad_callback_result
+	freerdp_client_aad_parse_callback(rdpClientContext* cctx, const char* uri, char** code);
+
 	/** @brief Discard the OAuth transaction of a client context
 	 *
 	 *  Releases the \c state value, the PKCE code verifier and the expected redirect URI the
 	 *  last authorization request generated. A token request built afterwards carries no
-	 *  \c code_verifier. Called automatically when a new authorization request is built,
-	 *  when the matching token request has been built and when the client context is
-	 *  freed.
+	 *  \c code_verifier and \ref freerdp_client_aad_parse_callback answers
+	 *  \ref FREERDP_CLIENT_AAD_CALLBACK_INVALID until a new authorization request is built.
+	 *  Called automatically when a new authorization request is built, when the matching token
+	 *  request has been built and when the client context is freed.
 	 *
 	 *  @param cctx The client context to reset, may be \b nullptr
 	 *  @since version 3.32.0

--- a/libfreerdp/core/aad.c
+++ b/libfreerdp/core/aad.c
@@ -915,6 +915,26 @@ BOOL aad_fetch_wellknown(wLog* log, rdpContext* context)
 	return rdp->wellknown != nullptr;
 }
 
+BOOL freerdp_utils_aad_set_wellknown(rdpContext* context, const char* json)
+{
+	WINPR_ASSERT(context);
+
+	rdpRdp* rdp = context->rdp;
+	WINPR_ASSERT(rdp);
+
+	WINPR_JSON* parsed = nullptr;
+	if (json)
+	{
+		parsed = WINPR_JSON_Parse(json);
+		if (!parsed)
+			return FALSE;
+	}
+
+	WINPR_JSON_Delete(rdp->wellknown);
+	rdp->wellknown = parsed;
+	return TRUE;
+}
+
 const char* freerdp_utils_aad_get_wellknown_string(rdpContext* context, AAD_WELLKNOWN_VALUES which)
 {
 	return freerdp_utils_aad_get_wellknown_custom_string(

--- a/libfreerdp/core/aad.c
+++ b/libfreerdp/core/aad.c
@@ -238,15 +238,15 @@ static BOOL aad_get_nonce(rdpAad* aad)
 		WLog_Print(aad->log, WLOG_ERROR,
 		           "Server unwilling to provide nonce; returned status code %li", resp_code);
 		if (response_length > 0)
-			WLog_Print(aad->log, WLOG_ERROR, "[status message] %s", response);
+			WLog_Print(aad->log, WLOG_DEBUG, "[status message] %s", response);
 		goto fail;
 	}
 
 	json = WINPR_JSON_ParseWithLength((const char*)response, response_length);
 	if (!json)
 	{
-		WLog_Print(aad->log, WLOG_ERROR, "Failed to parse nonce response: %s",
-		           WINPR_JSON_GetErrorPtr());
+		WLog_Print(aad->log, WLOG_ERROR, "Failed to parse nonce response");
+		WLog_Print(aad->log, WLOG_DEBUG, "JSON parser error: %s", WINPR_JSON_GetErrorPtr());
 		goto fail;
 	}
 

--- a/libfreerdp/core/aad.c
+++ b/libfreerdp/core/aad.c
@@ -1012,8 +1012,42 @@ WINPR_ATTR_MALLOC(WINPR_JSON_Delete, 1)
 WINPR_ATTR_NODISCARD
 WINPR_JSON* freerdp_utils_aad_get_wellknown(wLog* log, const char* base, const char* tenantid)
 {
-	WINPR_ASSERT(base);
-	WINPR_ASSERT(tenantid);
+	if (!base)
+	{
+		WLog_Print(log, WLOG_ERROR, "FreeRDP_GatewayAzureActiveDirectory must not be empty");
+		return nullptr;
+	}
+	if (!tenantid)
+	{
+		WLog_Print(log, WLOG_ERROR, "FreeRDP_GatewayAvdAadtenantid must not be empty");
+		return nullptr;
+	}
+
+	const size_t tenantlen = strlen(tenantid);
+	if ((tenantlen == 0) || (tenantlen > 128))
+	{
+		WLog_Print(log, WLOG_ERROR, "FreeRDP_GatewayAvdAadtenantid must contain 1..128 characters");
+		return nullptr;
+	}
+	BOOL hasNonDot = FALSE;
+	for (size_t x = 0; x < tenantlen; x++)
+	{
+		const unsigned char c = (unsigned char)tenantid[x];
+		const BOOL asciiAlphaNumeric =
+		    ((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z')) || ((c >= '0') && (c <= '9'));
+		if (!asciiAlphaNumeric && (c != '-') && (c != '.'))
+		{
+			WLog_Print(log, WLOG_ERROR,
+			           "FreeRDP_GatewayAvdAadtenantid contains an invalid character");
+			return nullptr;
+		}
+		hasNonDot |= c != '.';
+	}
+	if (!hasNonDot)
+	{
+		WLog_Print(log, WLOG_ERROR, "FreeRDP_GatewayAvdAadtenantid must not consist only of dots");
+		return nullptr;
+	}
 
 	char* str = nullptr;
 	size_t len = 0;

--- a/libfreerdp/core/aad.h
+++ b/libfreerdp/core/aad.h
@@ -50,4 +50,20 @@ WINPR_ATTR_MALLOC(aad_free, 1)
 WINPR_ATTR_NODISCARD
 FREERDP_LOCAL rdpAad* aad_new(rdpContext* context);
 
+/** Seeds or clears the cached OpenID configuration of a context.
+ *
+ * The document is otherwise fetched over HTTPS the first time a freerdp_utils_aad_get_wellknown_*
+ * query is made. This is a test seam: it lets the OAuth helpers of client/common be exercised
+ * without network access. Core-private, so it is only linkable from tests built with
+ * BUILD_TESTING_INTERNAL, which exports all symbols.
+ *
+ * @param context The rdpContext to install the document in
+ * @param json The OpenID configuration as JSON text, or \b nullptr to drop a cached document so
+ *             the next query fetches it again
+ * @return \b TRUE if the document was installed or dropped, \b FALSE if it could not be parsed.
+ *         The previously cached document is kept in that case.
+ */
+WINPR_ATTR_NODISCARD
+FREERDP_LOCAL BOOL freerdp_utils_aad_set_wellknown(rdpContext* context, const char* json);
+
 #endif /* FREERDP_LIB_CORE_AAD_H */

--- a/libfreerdp/core/test/CMakeLists.txt
+++ b/libfreerdp/core/test/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 set(DRIVER ${MODULE_NAME}.c)
 
-set(TESTS TestVersion.c TestSettings.c TestUtils.c)
+set(TESTS TestVersion.c TestSettings.c TestUtils.c TestAadTenant.c)
 
 if(BUILD_TESTING_INTERNAL)
   list(APPEND TESTS TestStreamDump.c TestRdstls.c TestServerChannels.c)

--- a/libfreerdp/core/test/TestAadTenant.c
+++ b/libfreerdp/core/test/TestAadTenant.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+
+#include <freerdp/freerdp.h>
+#include <freerdp/utils/aad.h>
+
+#include <winpr/crt.h>
+#include <winpr/json.h>
+
+/* freerdp_utils_aad_get_wellknown() interpolates base and tenant id into the OpenID discovery
+ * URL. Every case below has to be rejected before any request is made, so this test runs
+ * offline; a valid tenant id would reach the network and is therefore not covered here. */
+static const char* rejected_tenants[] = {
+	nullptr, "", ".", "..", "a/b", "a?b", "a#b", "a@b", "a:b", "a b", "tenant\x01",
+	/* 129 characters, one more than the accepted maximum */
+	"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+};
+
+int TestAadTenant(int argc, char* argv[])
+{
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+
+	for (size_t x = 0; x < ARRAYSIZE(rejected_tenants); x++)
+	{
+		WINPR_JSON* json = freerdp_utils_aad_get_wellknown(nullptr, "login.microsoftonline.com",
+		                                                   rejected_tenants[x]);
+		if (json)
+		{
+			WINPR_JSON_Delete(json);
+			(void)fprintf(stderr, "tenant id [%" PRIuz "] was not rejected\n", x);
+			return -1;
+		}
+	}
+
+	/* A missing authority is rejected as well, instead of being asserted on. */
+	{
+		WINPR_JSON* json = freerdp_utils_aad_get_wellknown(nullptr, nullptr, "common");
+		if (json)
+		{
+			WINPR_JSON_Delete(json);
+			(void)fprintf(stderr, "a missing authority was not rejected\n");
+			return -1;
+		}
+	}
+
+	return 0;
+}

--- a/libfreerdp/utils/CMakeLists.txt
+++ b/libfreerdp/utils/CMakeLists.txt
@@ -39,6 +39,7 @@ set(${MODULE_PREFIX}_SRCS
     smartcard_pack.c
     smartcard_call.c
     stopwatch.c
+    http.h
     http.c
 )
 

--- a/libfreerdp/utils/http.c
+++ b/libfreerdp/utils/http.c
@@ -20,6 +20,8 @@
 #include <freerdp/config.h>
 #include <freerdp/utils/http.h>
 
+#include "http.h"
+
 #include <winpr/assert.h>
 #include <winpr/string.h>
 
@@ -39,6 +41,156 @@ static const char post_header_fmt[] = "POST %s HTTP/1.1\r\n"
                                       "Content-Type: application/x-www-form-urlencoded\r\n"
                                       "Content-Length: %lu\r\n"
                                       "\r\n";
+
+/* Form fields of an OAuth token request and JSON fields of a token response whose value is a
+ * credential. Sorted, but only for reading; the lookup below is linear. */
+static const char* const redact_fields[] = { "access_token",  "assertion", "client_secret", "code",
+	                                         "code_verifier", "id_token",  "refresh_token" };
+
+static BOOL redact_is_space(char c)
+{
+	return (c == ' ') || (c == '\t') || (c == '\r') || (c == '\n');
+}
+
+/* Length of the longest field name matching at [pos], 0 if none of them does. 'code' is a prefix
+ * of 'code_verifier', so the longest match is the name. A match always leaves at least one
+ * character behind the name for the caller to check. */
+static size_t redact_field_len(const char* data, size_t length, size_t pos)
+{
+	size_t match = 0;
+	for (size_t x = 0; x < ARRAYSIZE(redact_fields); x++)
+	{
+		const size_t flen = strlen(redact_fields[x]);
+		if ((flen > match) && (length - pos > flen) &&
+		    (strncmp(&data[pos], redact_fields[x], flen) == 0))
+			match = flen;
+	}
+	return match;
+}
+
+/* name=value of an application/x-www-form-urlencoded body, at its start or behind a '&'. The
+ * value ends at the next '&' or at the end of the body. */
+static BOOL redact_form_value(const char* data, size_t length, size_t pos, size_t* start,
+                              size_t* end)
+{
+	if ((pos > 0) && (data[pos - 1] != '&'))
+		return FALSE;
+
+	const size_t flen = redact_field_len(data, length, pos);
+	if ((flen == 0) || (data[pos + flen] != '='))
+		return FALSE;
+
+	*start = pos + flen + 1;
+	for (*end = *start; (*end < length) && (data[*end] != '&'); (*end)++)
+		;
+	return TRUE;
+}
+
+/* "name": value of a JSON object. A string value keeps its quotes, any other value ends at the
+ * next delimiter. A name that is not followed by a ':' is a value itself, not a field. */
+static BOOL redact_json_value(const char* data, size_t length, size_t pos, size_t* start,
+                              size_t* end)
+{
+	if (data[pos] != '"')
+		return FALSE;
+
+	const size_t flen = redact_field_len(data, length, pos + 1);
+	if ((flen == 0) || (data[pos + 1 + flen] != '"'))
+		return FALSE;
+
+	size_t cur = pos + flen + 2;
+	for (; (cur < length) && redact_is_space(data[cur]); cur++)
+		;
+	if ((cur >= length) || (data[cur] != ':'))
+		return FALSE;
+	for (cur++; (cur < length) && redact_is_space(data[cur]); cur++)
+		;
+	if (cur >= length)
+		return FALSE;
+
+	if (data[cur] == '"')
+	{
+		*start = cur + 1;
+		for (*end = *start; (*end < length) && (data[*end] != '"'); (*end)++)
+		{
+			if (data[*end] == '\\')
+				(*end)++;
+		}
+		if (*end > length)
+			*end = length;
+	}
+	else
+	{
+		*start = cur;
+		for (*end = *start;
+		     (*end < length) && !redact_is_space(data[*end]) && !strchr(",}]", data[*end]);
+		     (*end)++)
+			;
+	}
+	return TRUE;
+}
+
+/* Appends to a buffer that starts out large enough for the whole input, so it only ever grows by
+ * the markers written in place of a value. */
+static BOOL redact_append(char** buffer, size_t* length, size_t* capacity, const char* data,
+                          size_t size)
+{
+	if (*length + size + 1 > *capacity)
+	{
+		const size_t capacity_new = *capacity + size + 1024;
+		char* tmp = realloc(*buffer, capacity_new);
+		if (!tmp)
+			return FALSE;
+		*buffer = tmp;
+		*capacity = capacity_new;
+	}
+	memcpy(&(*buffer)[*length], data, size);
+	*length += size;
+	(*buffer)[*length] = '\0';
+	return TRUE;
+}
+
+char* freerdp_http_redact_for_log(const char* data, size_t length)
+{
+	if (!data && (length > 0))
+		return nullptr;
+
+	size_t capacity = length + 1;
+	size_t used = 0;
+	char* buffer = calloc(1, capacity);
+	if (!buffer)
+		return nullptr;
+
+	for (size_t pos = 0; pos < length;)
+	{
+		size_t start = 0;
+		size_t end = 0;
+		if (redact_form_value(data, length, pos, &start, &end) ||
+		    redact_json_value(data, length, pos, &start, &end))
+		{
+			char marker[64] = WINPR_C_ARRAY_INIT;
+			const int rc =
+			    _snprintf(marker, sizeof(marker), "<redacted, %" PRIuz " bytes>", end - start);
+			if ((rc <= 0) || ((size_t)rc >= sizeof(marker)) ||
+			    !redact_append(&buffer, &used, &capacity, &data[pos], start - pos) ||
+			    !redact_append(&buffer, &used, &capacity, marker, (size_t)rc))
+				goto fail;
+			pos = end;
+		}
+		else
+		{
+			if (!redact_append(&buffer, &used, &capacity, &data[pos], 1))
+				goto fail;
+			pos++;
+		}
+	}
+
+	return buffer;
+
+fail:
+	free(buffer);
+	return nullptr;
+}
 
 #define log_errors(log, msg) log_errors_(log, msg, __FILE__, __func__, __LINE__)
 static void log_errors_(wLog* log, const char* msg, const char* file, const char* fkt, size_t line)
@@ -208,7 +360,13 @@ BOOL freerdp_http_request(const char* url, const char* body, long* status_code, 
 
 			if (body)
 			{
-				WLog_Print(log, WLOG_DEBUG, "body:\n%s", body);
+				if (WLog_IsLevelActive(log, WLOG_DEBUG))
+				{
+					char* redacted = freerdp_http_redact_for_log(body, blen);
+					WLog_Print(log, WLOG_DEBUG, "body:\n%s",
+					           redacted ? redacted : "<could not redact>");
+					free(redacted);
+				}
 
 				if (blen > INT_MAX)
 				{
@@ -305,8 +463,13 @@ BOOL freerdp_http_request(const char* url, const char* body, long* status_code, 
 		}
 	}
 
-	WLog_Print(log, WLOG_DEBUG, "response[%" PRIuz "]:\n%s", *response_length,
-	           (const char*)(*response));
+	if (WLog_IsLevelActive(log, WLOG_DEBUG))
+	{
+		char* redacted = freerdp_http_redact_for_log((const char*)(*response), *response_length);
+		WLog_Print(log, WLOG_DEBUG, "response[%" PRIuz "]:\n%s", *response_length,
+		           redacted ? redacted : "<could not redact>");
+		free(redacted);
+	}
 	ret = TRUE;
 
 out:

--- a/libfreerdp/utils/http.h
+++ b/libfreerdp/utils/http.h
@@ -1,0 +1,35 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Simple HTTP client request utility
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <freerdp/api.h>
+
+/** Replaces credential values in an HTTP request or response body by their length.
+ *
+ * Recognized are the form fields of an OAuth token request and the JSON fields of a token
+ * response that carry a credential. Everything else, a discovery document in particular, is
+ * copied through unchanged.
+ *
+ * @param data The body, may be \b nullptr if \b length is 0
+ * @param length The length of the body in bytes, without a terminator
+ * @return A newly allocated, NUL terminated copy with every credential value replaced, to be
+ *         released with free(), or \b nullptr if the copy could not be allocated.
+ */
+WINPR_ATTR_MALLOC(free, 1)
+WINPR_ATTR_NODISCARD
+FREERDP_LOCAL char* freerdp_http_redact_for_log(const char* data, size_t length);

--- a/libfreerdp/utils/test/CMakeLists.txt
+++ b/libfreerdp/utils/test/CMakeLists.txt
@@ -9,6 +9,10 @@ set(${MODULE_PREFIX}_TESTS TestRingBuffer.c TestPodArrays.c TestEncodedTypes.c T
                            TestSmartcardOperations.c
 )
 
+if(BUILD_TESTING_INTERNAL)
+  list(APPEND ${MODULE_PREFIX}_TESTS TestHttpRedact.c)
+endif()
+
 set(FUZZERS TestFuzzSmartcardOperations.c)
 
 create_test_sourcelist(${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_DRIVER} ${${MODULE_PREFIX}_TESTS})

--- a/libfreerdp/utils/test/TestHttpRedact.c
+++ b/libfreerdp/utils/test/TestHttpRedact.c
@@ -1,0 +1,150 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Tests for the HTTP debug log redaction
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <freerdp/config.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#include <winpr/crt.h>
+
+#include "../http.h"
+
+/* The shapes below are the ones observed against Azure Virtual Desktop: the token request of
+ * client_common_get_access_token(), the token response it parses, the nonce exchange of
+ * aad_get_nonce() and the OpenID discovery document of freerdp_utils_aad_get_wellknown(). */
+
+typedef struct
+{
+	const char* name;
+	const char* in;
+	const char* expected;
+} redact_test;
+
+static const redact_test tests[] = {
+	/* Authorization code redemption. The code and the PKCE verifier are credentials, the grant
+	 * type is not, even though its value ends in 'code'. */
+	{ "token request",
+	  "grant_type=authorization_code&code=0.AXkAq2ZDeF_Aut&client_id=a85cf173-4192-42f8-81fa-"
+	  "777a763e6e2c&redirect_uri=https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%"
+	  "2Fnativeclient&code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+	  "grant_type=authorization_code&code=<redacted, 16 bytes>&client_id=a85cf173-4192-42f8-81fa-"
+	  "777a763e6e2c&redirect_uri=https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%"
+	  "2Fnativeclient&code_verifier=<redacted, 43 bytes>" },
+	/* Refresh, client secret and assertion grants use the same body shape. */
+	{ "refresh request",
+	  "grant_type=refresh_token&refresh_token=0.AXkAbQ&client_secret=Xy7~8Q&assertion=eyJhbGci",
+	  "grant_type=refresh_token&refresh_token=<redacted, 8 bytes>&client_secret=<redacted, 6 "
+	  "bytes>&assertion=<redacted, 8 bytes>" },
+	/* Token response. token_type, scope and the expiry stay readable. */
+	{ "token response",
+	  "{\"token_type\":\"Bearer\",\"scope\":\"https://www.wvd.azure.us/.default\",\"expires_in\":"
+	  "3599,\"ext_expires_in\":3599,\"access_token\":\"eyJ0eXAiOiJKV1Qi\",\"refresh_token\":\"0."
+	  "AXkAq2ZDeF\",\"id_token\":\"eyJhbGciOiJub25l\"}",
+	  "{\"token_type\":\"Bearer\",\"scope\":\"https://www.wvd.azure.us/.default\",\"expires_in\":"
+	  "3599,\"ext_expires_in\":3599,\"access_token\":\"<redacted, 16 bytes>\",\"refresh_token\":"
+	  "\"<redacted, 12 bytes>\",\"id_token\":\"<redacted, 16 bytes>\"}" },
+	/* Whitespace between name, colon and value, and a value that is not a string. */
+	{ "token response, pretty printed",
+	  "{\n\t\"access_token\" : \"eyJ0\",\n\t\"expires_in\" : 3599,\n\t\"id_token\" : null\n}",
+	  "{\n\t\"access_token\" : \"<redacted, 4 bytes>\",\n\t\"expires_in\" : 3599,\n\t\"id_token\" "
+	  ": <redacted, 4 bytes>\n}" },
+	/* A quote escaped inside a token value does not end it. */
+	{ "escaped quote", "{\"access_token\":\"ey\\\"J0\",\"scope\":\"user_impersonation\"}",
+	  "{\"access_token\":\"<redacted, 6 bytes>\",\"scope\":\"user_impersonation\"}" },
+	/* Nonce exchange, no credential in either direction. */
+	{ "nonce request", "grant_type=srv_challenge", "grant_type=srv_challenge" },
+	{ "nonce response", "{\"Nonce\":\"AwABAAAAAAACAOz_BAD0_ykWQ\"}",
+	  "{\"Nonce\":\"AwABAAAAAAACAOz_BAD0_ykWQ\"}" },
+	/* Public metadata people need for troubleshooting stays intact. The field names below are
+	 * prefixed by or contain a redacted name, and 'code' appears as a value, not as a field. */
+	{ "discovery document",
+	  "{\"token_endpoint\":\"https://login.microsoftonline.us/common/oauth2/v2.0/token\","
+	  "\"response_types_supported\":[\"code\",\"id_token\",\"code id_token\"],"
+	  "\"code_challenge_methods_supported\":[\"plain\",\"S256\"],"
+	  "\"id_token_signing_alg_values_supported\":[\"RS256\"],\"claims_supported\":[\"sub\"]}",
+	  "{\"token_endpoint\":\"https://login.microsoftonline.us/common/oauth2/v2.0/token\","
+	  "\"response_types_supported\":[\"code\",\"id_token\",\"code id_token\"],"
+	  "\"code_challenge_methods_supported\":[\"plain\",\"S256\"],"
+	  "\"id_token_signing_alg_values_supported\":[\"RS256\"],\"claims_supported\":[\"sub\"]}" },
+	/* A field name is only one when it is the whole name. */
+	{ "prefix of a field name", "code_challenge=E9Melhoa2Ow&codes=1",
+	  "code_challenge=E9Melhoa2Ow&codes=1" },
+	{ "field name in a value", "state=code&scope=refresh_token", "state=code&scope=refresh_token" },
+	/* Empty and truncated bodies must not confuse the scanner. */
+	{ "empty value", "code=&code_verifier=x",
+	  "code=<redacted, 0 bytes>&code_verifier=<redacted, 1 bytes>" },
+	{ "truncated", "{\"access_token\":\"eyJ", "{\"access_token\":\"<redacted, 3 bytes>" },
+	{ "name without value", "code", "code" },
+	{ "empty body", "", "" }
+};
+
+/* Nothing that was replaced may survive anywhere in the output. */
+static const char* const secrets[] = {
+	"0.AXkAq2ZDeF_Aut", "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+	"eyJ0eXAiOiJKV1Qi", "eyJhbGciOiJub25l",
+	"eyJhbGci",         "Xy7~8Q"
+};
+
+int TestHttpRedact(int argc, char* argv[])
+{
+	int rc = 0;
+
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+
+	for (size_t x = 0; x < ARRAYSIZE(tests); x++)
+	{
+		const redact_test* test = &tests[x];
+		char* actual = freerdp_http_redact_for_log(test->in, strlen(test->in));
+		if (!actual)
+		{
+			(void)fprintf(stderr, "[%s] redaction failed\n", test->name);
+			rc = -1;
+			continue;
+		}
+
+		if (strcmp(actual, test->expected) != 0)
+		{
+			(void)fprintf(stderr, "[%s]\nexpected %s\nactual   %s\n", test->name, test->expected,
+			              actual);
+			rc = -1;
+		}
+
+		for (size_t y = 0; y < ARRAYSIZE(secrets); y++)
+		{
+			if (strstr(actual, secrets[y]))
+			{
+				(void)fprintf(stderr, "[%s] leaked '%s'\n", test->name, secrets[y]);
+				rc = -1;
+			}
+		}
+
+		free(actual);
+	}
+
+	/* An empty response is passed in as a nullptr body. */
+	char* empty = freerdp_http_redact_for_log(nullptr, 0);
+	if (!empty || (strlen(empty) != 0))
+	{
+		(void)fprintf(stderr, "[nullptr] expected an empty string\n");
+		rc = -1;
+	}
+	free(empty);
+
+	return rc;
+}


### PR DESCRIPTION
> **Disclosure:** This pull request, including the code and this description, was prepared with AI assistance (Anthropic Claude and OpenAI Codex agents, orchestrated by the author).
> **Status:** **Hardware-tested by the author on 2026-09-03** against Azure Virtual Desktop in Azure US Government (DoD tenant region) with a PIV smart card, using the terminal paste flow of `sdl-freerdp` built from the combined branch (Firefox handled the certificate and PIN). Cloud selection, `.us` discovery, state+PKCE on both authorization requests, callback parsing, the ARM step and RDS-AAD negotiation all succeeded and the desktop appeared. Unit tests pass on Fedora 44 (gcc 16, FreeRDP master).

Branch: `aad/oauth-hardening` (9 commits on `upstream/master`). Independent of #13327 (ARM response timeout) and #13329 (sovereign clouds); all merge cleanly together.

> Combined branch with the ARM, OAuth and sovereign-cloud series stacked for end-to-end testing: `sjtrotter/FreeRDP` branch `avd/sovereign-oauth-upstream`.

## Why

Since 3.16, libfreerdp-client builds the AAD/AVD authorization and token URLs (`freerdp_client_get_aad_url()`) and exchanges the code for a token (`client_common_get_access_token()`). That makes it an OAuth public client in the RFC 6749/7636/9700 sense, but it did the first half only: no `state`, no PKCE, and the callback (the URL the browser lands on) was parsed separately and loosely by every frontend. The SDL webview matched the redirect as a string prefix; the stdin flow took the first `code=` it found anywhere; Remmina accepted the first redirect it saw; KRDC has a commented-out `GetAccessToken` where someone started and stopped. We hit all of this building a Linux client for AVD with Entra sign-in, and an independent security review of the Remmina flow concluded these are properties of the library-built exchange, not of any one frontend.

Two further issues surfaced on the way: the redirect-URI *format* settings are printf format strings used unvalidated in `winpr_asprintf` (`xfreerdp /azure:avd-token:%n` is a write primitive on master), and OAuth response bodies and callback URIs were logged at ERROR, including authorization codes and `error_description` text naming the account.

The browser itself, threads, cancellation and smart-card UI stay in the frontends. The contract becomes: host a browser, hand the library every URL it navigates to, get back CODE / ERROR / UNRELATED / INVALID.

## Commits

1. `[core,aad] validate tenant IDs for discovery` — the tenant id is checked (ASCII alnum, `-`, `.`, ≤128, not dots-only) before core interpolates it into the `.well-known` URL; a missing base/tenant is an error instead of an assert. New `TestAadTenant`.
2. `[core,aad] keep AAD response bodies out of the error log` — nonce response body and JSON parser detail move from ERROR to DEBUG.
3. `[core,aad] add a test seam for the wellknown configuration` — `FREERDP_LOCAL freerdp_utils_aad_set_wellknown()` installs a parsed discovery document so the OAuth tests run offline. Not public API; the tests that use it are gated by `BUILD_TESTING_INTERNAL`.
4. `[client,common] validate AVD redirect URI format strings` — `GatewayAvdAccessAadFormat`/ GatewayAvdAccessTokenFormat` accept only literal text, `%%` and at most the expected number of `%s`; tenant id validated; `/azure` help text documents it.
5. `[client,common] add state and PKCE to AAD authorization requests` — 256-bit `state`, RFC 7636 S256, `code_verifier` on the token request. The transaction lives in one pointer taken from `rdpClientContext`'s reserved padding (`rdpClientAadOAuth* aad_oauth`; size unchanged, compile-time asserted), freed on context teardown, one per context, released once the matching token request has been built (a failed build keeps it so the request can be retried). The `code` passed to the token request types is now percent-encoded into the body, so callers pass the percent-decoded code (behaviour change, see below).
6. `[client,common] add freerdp_client_aad_parse_callback` — exact scheme/host/port/path match after strict percent-decoding (malformed escapes and `%00` rejected), no userinfo/fragment, constant-time `state` compare, exactly one of `code`/`error`, duplicates rejected, the first terminal answer consumes the transaction (replays → INVALID). Replaces the stdin-paste parser; the pasted line is trimmed of whitespace and wrapping `<>`/quotes and scrubbed after use. Neither the URI nor any parsed value is logged.
7. `[client,common] keep the token endpoint response out of the error log` — body moves from ERROR to DEBUG.
8. `[utils,http] keep OAuth credentials out of HTTP debug dumps` — found during the hardware test: `freerdp_http_request()` dumps every request and response body at DEBUG, which for the token endpoint means the authorization code, the PKCE verifier and the access, refresh and id tokens land in any DEBUG log a user attaches to a bug report. A `FREERDP_LOCAL` redaction pass now masks the values of `code`, `code_verifier`, `client_secret`, `assertion`, `refresh_token` (form bodies) and `access_token`, `refresh_token`, `id_token` (JSON bodies) as `<redacted, N bytes>`; the discovery document, the nonce exchange and the non-secret token fields  (`token_type`, `scope`, `expires_in`) stay visible. Dumps are also skipped entirely when DEBUG is not active. 14 offline test cases (`TestHttpRedact`, built with `BUILD_TESTING_INTERNAL`).
9. `[client,sdl] use validated AAD callback parsing, stop logging URIs` — the webview navigation listener uses the parser (UNRELATED and INVALID keep navigating, CODE and ERROR finish), stops logging URIs/codes/errors, scrubs the token body, and no longer passes a null pointer to `std::string` when a request could not be built.

## Why credentials in logs matter (rationale for commits 2, 7, 8 and 9)

None of this is a replay of the RDP handshake; the nonce and proof-of-possession key protect that. The risk is plain credential theft from a file that people routinely attach to bug reports, paste into chat, back up, and leave in home directories. Before this series, a DEBUG log of a successful AVD sign-in contained, verbatim:

- the **authorization code** and **PKCE verifier**, adjacent: together they let a reader who gets there first complete the sign-in;
- the **AVD access token** (`token_type: Bearer`): possession is proof, so for about an hour a reader can call the AVD ARM and gateway APIs as the user, including opening a session to their desktop, with no card, PIN or conditional-access prompt;
- the **refresh token**: long-lived (typically 90 days, rolling), not PKCE-bound, not possession-bound; a reader can mint fresh access tokens for months. This is the artifact that turns a leaked log into standing access;
- the **id token**: not a credential, but signed PII (UPN, name, tenant, object id);
- on failure paths at ERROR level, `error_description` text that names the account.

(The session-host token is `token_type: pop` and bound to an in-memory key the log does not contain, so it is not usable by a reader; the redaction covers it anyway.) We observed exactly this during hardware testing of the series: a DEBUG log of one Government sign-in held a live refresh token. Commit 8 masks the field values in the HTTP dumps, commits 2 and 7 keep response bodies out of ERROR, and commit 9 stops the SDL webview logging callback URIs, which carry the authorization code.

## Compatibility

- ABI: `rdpClientContext` gains one pointer inside reserved padding; size unchanged.
- New public API (`@since version 3.32.0`): `rdpClientAadOAuth` (opaque), `freerdp_client_aad_callback_result`, `freerdp_client_aad_parse_callback()`, `freerdp_client_aad_reset()`. The variadic arguments of each `freerdp_client_aad_type` are now documented in `include/freerdp/client.h`.
- **Behaviour change** for `freerdp_client_get_aad_url()` callers: the `code` argument of the two `*_TOKEN_REQUEST` types must be the percent-*decoded* authorization code (what `freerdp_client_aad_parse_callback()` returns). A frontend that keeps passing the raw query value would double-encode a code containing an escape. A frontend that builds its own authorization URL (Remmina today) gets no PKCE and no transaction; a token request without a preceding authorization request still works and logs a warning.
- Builds with `WITH_AAD=OFF` (the OAuth tests skip).

## How to test

Unit: `ctest`; with `-DBUILD_TESTING_INTERNAL=ON` `TestHttpRedact` and the full `TestClientAad` (format matrix, tenant matrix, PKCE binding, transaction lifetime, 30+ callback classifications incl. NUL/malformed-escape/replay cases) runs offline against a seeded discovery document.
Manual (done 2026-09-03, US Government AVD, PIV): `sdl-freerdp workspace.rdpw` built with `WITH_WEBVIEW=OFF`; both `Browse to:` URLs carried `state`, `code_challenge` and `code_challenge_method=S256`; both pasted redirects (which Entra extended with an extra `session_state` parameter) were accepted; the token exchange, ARM orchestration and RDS-AAD negotiation succeeded and the desktop appeared.

Memory: the combined series' full suite ran under AddressSanitizer + LeakSanitizer with no reports; the URI decoder/parser was fuzzed with 18 M random URIs under ASan+UBSan and the format validator against a 49-entry corpus during review.

## Review history

Three adversarial review rounds (Claude, Codex, security). Notable outcomes: strict percent-decoding and duplicate/valueless-key rejection were added after a `%00` origin-check bypass was demonstrated; the transaction became single-use with replay protection; the webview stopped aborting on the first malformed hit; the well-known setter was demoted from public API to a test seam after a placement review. The hardware test also exposed the pre-existing DEBUG dump of token bodies (fixed here as commit 8). One pre-existing, test-only bug was found along the way (`TestClientRdpFile` double-frees when `TMPDIR` is unusable); a separate one-commit fix is proposed in #13332.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
