### PR TITLE
[utils,aad] AVD sovereign clouds: cloud table, automatic selection from the ARM gateway host, /gateway:cloud:

### DIFF
--- a/client/common/client.c
+++ b/client/common/client.c
@@ -68,9 +68,11 @@
 
 #include <freerdp/channels/rdpewa.h>
 
+/* The AVD cloud table is part of libfreerdp regardless of WITH_AAD. */
+#include <freerdp/utils/aad.h>
+
 #ifdef WITH_AAD
 #include <freerdp/utils/http.h>
-#include <freerdp/utils/aad.h>
 #endif
 
 #ifdef WITH_SSO_MIB
@@ -390,6 +392,10 @@ int freerdp_client_settings_parse_connection_file(rdpSettings* settings, const c
 	if (!freerdp_client_populate_settings_from_rdp_file(file, settings))
 		goto out;
 
+	/* Every key of the file has been mapped, so the gateway of an AVD file is known now. */
+	if (!freerdp_client_settings_apply_avd_cloud(settings))
+		goto out;
+
 	ret = 0;
 out:
 	freerdp_client_rdp_file_free(file);
@@ -407,7 +413,8 @@ int freerdp_client_settings_parse_connection_file_buffer(rdpSettings* settings, 
 		return -1;
 
 	if (freerdp_client_parse_rdp_file_buffer(file, buffer, size) &&
-	    freerdp_client_populate_settings_from_rdp_file(file, settings))
+	    freerdp_client_populate_settings_from_rdp_file(file, settings) &&
+	    freerdp_client_settings_apply_avd_cloud(settings))
 	{
 		status = 0;
 	}
@@ -482,6 +489,68 @@ int freerdp_client_settings_parse_assistance_file(rdpSettings* settings, int arg
 out:
 	freerdp_assistance_file_free(file);
 	return ret;
+}
+
+BOOL freerdp_client_settings_apply_avd_cloud(rdpSettings* settings)
+{
+	if (!settings)
+		return FALSE;
+
+	if (!freerdp_settings_get_bool(settings, FreeRDP_GatewayArmTransport))
+		return TRUE;
+
+	const char* hostname = freerdp_settings_get_string(settings, FreeRDP_GatewayHostname);
+	const FreeRDP_AadCloud* cloud = freerdp_utils_aad_cloud_for_gateway(hostname);
+	if (!cloud)
+		return TRUE;
+
+	const FreeRDP_AadCloud* commercial = freerdp_utils_aad_cloud_by_name("commercial");
+	WINPR_ASSERT(commercial);
+
+	/* Only the commercial defaults are replaced. A caller that configured an authority of its
+	 * own has configured the whole cloud, so nothing here is second-guessed. */
+	const char* authority =
+	    freerdp_settings_get_string(settings, FreeRDP_GatewayAzureActiveDirectory);
+	if (!authority || (_stricmp(authority, freerdp_utils_aad_cloud_get_authority(commercial)) != 0))
+	{
+		WLog_DBG(TAG, "skipped AVD cloud '%s': the AAD authority is customized",
+		         freerdp_utils_aad_cloud_get_name(cloud));
+		return TRUE;
+	}
+
+	const char* scope = freerdp_settings_get_string(settings, FreeRDP_GatewayAvdScope);
+	const char* redirect = freerdp_settings_get_string(settings, FreeRDP_GatewayAvdAccessAadFormat);
+	const BOOL applyScope =
+	    scope && (_stricmp(scope, freerdp_utils_aad_cloud_get_avd_scope(commercial)) == 0);
+	const BOOL applyRedirect =
+	    redirect &&
+	    (_stricmp(redirect, freerdp_utils_aad_cloud_get_avd_redirect_format(commercial)) == 0);
+
+	if (!freerdp_settings_set_string(settings, FreeRDP_GatewayAzureActiveDirectory,
+	                                 freerdp_utils_aad_cloud_get_authority(cloud)))
+		return FALSE;
+	if (applyScope && !freerdp_settings_set_string(settings, FreeRDP_GatewayAvdScope,
+	                                               freerdp_utils_aad_cloud_get_avd_scope(cloud)))
+		return FALSE;
+	if (applyRedirect &&
+	    !freerdp_settings_set_string(settings, FreeRDP_GatewayAvdAccessAadFormat,
+	                                 freerdp_utils_aad_cloud_get_avd_redirect_format(cloud)))
+		return FALSE;
+
+	/* Tenant-specific discovery is opt-in, so it is only derived while the setting is unset:
+	 * a tenant id that is not the "common" placeholder names the tenant to discover. */
+	if (!freerdp_settings_get_bool(settings, FreeRDP_GatewayAvdUseTenantid))
+	{
+		const char* tenant = freerdp_settings_get_string(settings, FreeRDP_GatewayAvdAadtenantid);
+		const BOOL useTenant = tenant && (_stricmp(tenant, "common") != 0);
+		if (!freerdp_settings_set_bool(settings, FreeRDP_GatewayAvdUseTenantid, useTenant))
+			return FALSE;
+	}
+
+	WLog_DBG(TAG, "applied AVD cloud '%s'%s%s", freerdp_utils_aad_cloud_get_name(cloud),
+	         applyScope ? "" : ", kept the customized AVD scope",
+	         applyRedirect ? "" : ", kept the customized AVD redirect format");
+	return TRUE;
 }
 
 static int client_cli_read_string(freerdp* instance, const char* what, const char* suggestion,

--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -50,6 +50,7 @@
 #include <freerdp/channels/disp.h>
 #include <freerdp/crypto/crypto.h>
 #include <freerdp/locale/keyboard.h>
+#include <freerdp/utils/aad.h>
 #include <freerdp/utils/passphrase.h>
 #include <freerdp/utils/proxy_utils.h>
 #include <freerdp/utils/string.h>
@@ -67,6 +68,7 @@
 #include <freerdp/channels/echo.h>
 
 #include <freerdp/client/cmdline.h>
+#include <freerdp/client/file.h>
 #include <freerdp/version.h>
 #include <freerdp/client/utils/smartcard_cli.h>
 
@@ -3853,10 +3855,14 @@ static int parse_app_option_program(rdpSettings* settings, const char* cmd)
 	return CHANNEL_RC_OK;
 }
 
-static int parse_aad_options(rdpSettings* settings, const COMMAND_LINE_ARGUMENT_A* arg)
+/** Parses the sub-options of \b /azure. \b useTenantidGiven is set when the \b use-tenantid
+ *  sub-option was given, so that it is not derived from the tenant id later on. */
+static int parse_aad_options(rdpSettings* settings, const COMMAND_LINE_ARGUMENT_A* arg,
+                             BOOL* useTenantidGiven)
 {
 	WINPR_ASSERT(settings);
 	WINPR_ASSERT(arg);
+	WINPR_ASSERT(useTenantidGiven);
 
 	int rc = CHANNEL_RC_OK;
 	size_t count = 0;
@@ -3900,6 +3906,7 @@ static int parse_aad_options(rdpSettings* settings, const COMMAND_LINE_ARGUMENT_
 						rc = COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 						break;
 					}
+					*useTenantidGiven = TRUE;
 				}
 				continue;
 			}
@@ -4257,13 +4264,19 @@ static char* unescape(const char* str)
 	return copy;
 }
 
-static BOOL parse_gateway_options(rdpSettings* settings, const COMMAND_LINE_ARGUMENT_A* arg)
+/** Parses the sub-options of \b /gateway. An explicit \b cloud: sub-option is applied right
+ *  here, so that it behaves like any other option: it overwrites what came before it and is
+ *  overwritten by what comes after it. \b cloud receives the applied AVD cloud, or stays
+ *  untouched when no \b cloud: sub-option was given. */
+static BOOL parse_gateway_options(rdpSettings* settings, const COMMAND_LINE_ARGUMENT_A* arg,
+                                  const FreeRDP_AadCloud** cloud)
 {
 	char* argval = nullptr;
 	BOOL rc = FALSE;
 
 	WINPR_ASSERT(settings);
 	WINPR_ASSERT(arg);
+	WINPR_ASSERT(cloud);
 
 	size_t count = 0;
 	char** ptr = CommandLineParseCommaSeparatedValues(arg->Value, &count);
@@ -4327,6 +4340,22 @@ static BOOL parse_gateway_options(rdpSettings* settings, const COMMAND_LINE_ARGU
 					goto fail;
 				validOption = TRUE;
 				allowHttpOpts = freerdp_settings_get_bool(settings, FreeRDP_GatewayHttpTransport);
+			}
+
+			const char* cloudname = option_starts_with("cloud:", argval);
+			if (cloudname)
+			{
+				const FreeRDP_AadCloud* selected = freerdp_utils_aad_cloud_by_name(cloudname);
+				if (!selected)
+				{
+					WLog_ERR(TAG, "unknown AVD cloud '%s'", cloudname);
+					goto fail;
+				}
+				if (!freerdp_utils_aad_apply_cloud(settings, selected))
+					goto fail;
+				*cloud = selected;
+				validOption = TRUE;
+				allowHttpOpts = FALSE;
 			}
 
 			const char* gat = option_starts_with("access-token:", argval);
@@ -4834,10 +4863,15 @@ static int parse_command_line_option_window_pos(rdpSettings* settings,
 
 static int parse_command_line(rdpSettings* settings, const COMMAND_LINE_ARGUMENT_A* arg,
                               freerdp_command_line_handle_option_t handle_option,
-                              void* handle_userdata, BOOL* promptForPassword, char** user)
+                              void* handle_userdata, BOOL* promptForPassword, char** user,
+                              const FreeRDP_AadCloud** avdCloud, BOOL* avdUseTenantidGiven)
 {
 	WINPR_ASSERT(promptForPassword);
 	WINPR_ASSERT(user);
+	WINPR_ASSERT(avdCloud);
+	WINPR_ASSERT(avdUseTenantidGiven);
+
+	const COMMAND_LINE_ARGUMENT_A* azure = nullptr;
 
 	do
 	{
@@ -5053,8 +5087,19 @@ static int parse_command_line(rdpSettings* settings, const COMMAND_LINE_ARGUMENT
 		}
 		CommandLineSwitchCase(arg, "gateway")
 		{
-			if (!parse_gateway_options(settings, arg))
+			if (!parse_gateway_options(settings, arg, avdCloud))
 				return fail_at(arg, COMMAND_LINE_ERROR);
+
+			/* Options are visited in the order of the option table, so /azure has been parsed
+			 * already. An explicit /gateway:cloud: just overwrote what it had set, so when it
+			 * was typed after the /gateway option it is applied again to keep the last option
+			 * of the command line the winning one. */
+			if (*avdCloud && azure && (azure->Index > arg->Index))
+			{
+				const int rc = parse_aad_options(settings, azure, avdUseTenantidGiven);
+				if (rc != 0)
+					return fail_at(azure, rc);
+			}
 		}
 		CommandLineSwitchCase(arg, "proxy")
 		{
@@ -5065,9 +5110,10 @@ static int parse_command_line(rdpSettings* settings, const COMMAND_LINE_ARGUMENT
 
 		CommandLineSwitchCase(arg, "azure")
 		{
-			int rc = parse_aad_options(settings, arg);
+			int rc = parse_aad_options(settings, arg, avdUseTenantidGiven);
 			if (rc != 0)
 				return fail_at(arg, rc);
+			azure = arg;
 		}
 		CommandLineSwitchCase(arg, "app")
 		{
@@ -5690,6 +5736,41 @@ static void warn_credential_args(const COMMAND_LINE_ARGUMENT_A* args)
 	}
 }
 
+/** Loads a .rdp file into \b settings, without selecting the AVD cloud.
+ *
+ *  \ref freerdp_client_settings_parse_connection_file applies the cloud, which is right for a
+ *  caller that has nothing else to add. The command line parser has: it applies the cloud once
+ *  after every option was parsed, so that a value written by the automatic selection is never
+ *  mistaken for one the user configured. */
+static BOOL load_connection_file(rdpSettings* settings, const char* filename)
+{
+	BOOL rc = FALSE;
+	rdpFile* file = freerdp_client_rdp_file_new();
+	if (!file)
+		return FALSE;
+
+	if (freerdp_client_parse_rdp_file(file, filename) &&
+	    freerdp_client_populate_settings_from_rdp_file(file, settings))
+		rc = TRUE;
+
+	freerdp_client_rdp_file_free(file);
+	return rc;
+}
+
+/** Derives \b FreeRDP_GatewayAvdUseTenantid from the tenant id, as
+ *  \ref freerdp_client_settings_apply_avd_cloud does for the automatic selection: tenant
+ *  specific discovery is opt-in, so a tenant id that is not the "common" placeholder is what
+ *  turns it on. Only called when /azure:use-tenantid was not given. */
+static BOOL derive_avd_use_tenantid(rdpSettings* settings)
+{
+	if (freerdp_settings_get_bool(settings, FreeRDP_GatewayAvdUseTenantid))
+		return TRUE;
+
+	const char* tenant = freerdp_settings_get_string(settings, FreeRDP_GatewayAvdAadtenantid);
+	const BOOL useTenantid = tenant && (_stricmp(tenant, "common") != 0);
+	return freerdp_settings_set_bool(settings, FreeRDP_GatewayAvdUseTenantid, useTenantid);
+}
+
 static int freerdp_client_settings_parse_command_line_arguments_int(
     rdpSettings* settings, int argc, char* argv[], BOOL allowUnknown,
     COMMAND_LINE_ARGUMENT_A* largs, WINPR_ATTR_UNUSED size_t count,
@@ -5702,6 +5783,8 @@ static int freerdp_client_settings_parse_command_line_arguments_int(
 	DWORD flags = 0;
 	BOOL promptForPassword = FALSE;
 	BOOL compatibility = FALSE;
+	const FreeRDP_AadCloud* avdCloud = nullptr;
+	BOOL avdUseTenantidGiven = FALSE;
 	const COMMAND_LINE_ARGUMENT_A* arg = nullptr;
 
 	/* Command line detection fails if only a .rdp or .msrcIncident file
@@ -5738,7 +5821,7 @@ static int freerdp_client_settings_parse_command_line_arguments_int(
 
 	if (ext)
 	{
-		if (freerdp_client_settings_parse_connection_file(settings, argv[1]))
+		if (!load_connection_file(settings, argv[1]))
 			return COMMAND_LINE_ERROR_UNEXPECTED_VALUE;
 	}
 
@@ -5768,7 +5851,7 @@ static int freerdp_client_settings_parse_command_line_arguments_int(
 		return COMMAND_LINE_ERROR_MEMORY;
 
 	status = parse_command_line(settings, arg, handle_option, handle_userdata, &promptForPassword,
-	                            &user);
+	                            &user, &avdCloud, &avdUseTenantidGiven);
 
 	if (user)
 	{
@@ -5849,6 +5932,25 @@ static int freerdp_client_settings_parse_command_line_arguments_int(
 
 		const UINT32 port = freerdp_settings_get_uint32(settings, FreeRDP_ServerPort);
 		WLog_INFO(TAG, "/vmconnect uses custom port %" PRIu32, port);
+	}
+
+	/* All settings are populated, including those of a .rdp file. An explicit /gateway:cloud:
+	 * has already been applied where the option was parsed and only leaves the tenant flag to
+	 * derive, otherwise the cloud of an ARM gateway is selected from its hostname. */
+	if (avdCloud)
+	{
+		if (!avdUseTenantidGiven && !derive_avd_use_tenantid(settings))
+			return COMMAND_LINE_ERROR;
+	}
+	else
+	{
+		const BOOL useTenantid = freerdp_settings_get_bool(settings, FreeRDP_GatewayAvdUseTenantid);
+		if (!freerdp_client_settings_apply_avd_cloud(settings))
+			return COMMAND_LINE_ERROR;
+		/* /azure:use-tenantid was given, so it is not a default that may be derived. */
+		if (avdUseTenantidGiven &&
+		    !freerdp_settings_set_bool(settings, FreeRDP_GatewayAvdUseTenantid, useTenantid))
+			return COMMAND_LINE_ERROR;
 	}
 
 	fill_credential_strings(largs);

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -191,7 +191,11 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "Read credentials from stdin. With <force> the prompt is done before connection, otherwise "
 	  "on server request." },
 	{ "gateway", COMMAND_LINE_VALUE_REQUIRED,
-	  "g:<gateway>[:<port>],u:<user>,d:<domain>,p:<password>,usage-method:["
+	  "g:<gateway>[:<port>],u:<user>,d:<domain>,p:<password>,"
+	  "cloud:[commercial|usgov](AAD authority, AVD scope and redirect URI of an Azure cloud, "
+	  "the last of /gateway:cloud: and /azure: wins; without it an ARM gateway hostname "
+	  "selects the cloud),"
+	  "usage-method:["
 	  "direct|detect],access-token:<"
 	  "token>,type:[rpc|http[,no-websockets][,extauth-sspi-ntlm]|auto[,no-websockets][,extauth-"
 	  "sspi-ntlm]]|arm,url:<wss://url>,bearer:<oauth2-bearer-token>",

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -192,9 +192,9 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "on server request." },
 	{ "gateway", COMMAND_LINE_VALUE_REQUIRED,
 	  "g:<gateway>[:<port>],u:<user>,d:<domain>,p:<password>,"
-	  "cloud:[commercial|usgov](AAD authority, AVD scope and redirect URI of an Azure cloud, "
-	  "the last of /gateway:cloud: and /azure: wins; without it an ARM gateway hostname "
-	  "selects the cloud),"
+	  "cloud:[commercial|usgov|<name from aad-clouds.json>](AAD authority, AVD scope and "
+	  "redirect URI of an Azure cloud, the last of /gateway:cloud: and /azure: wins; without it "
+	  "an ARM gateway hostname selects the cloud),"
 	  "usage-method:["
 	  "direct|detect],access-token:<"
 	  "token>,type:[rpc|http[,no-websockets][,extauth-sspi-ntlm]|auto[,no-websockets][,extauth-"

--- a/client/common/man/freerdp-global-config.1.in
+++ b/client/common/man/freerdp-global-config.1.in
@@ -9,6 +9,12 @@ The common certificate settings location is
 \fI@SYSCONF_DIR@/certificates\&.json\fR
 .br
 
+The optional AVD cloud table is read from
+\fI@SYSCONF_DIR@/aad\-clouds\&.json\fR
+and from
+\fI$XDG_CONFIG_HOME/freerdp/aad\-clouds\&.json\fR
+.br
+
 File format is JSON
 .RE
 .PP
@@ -79,4 +85,76 @@ a string of hex integer values representing the certificate hash, e\&.g\&.
 .RE
 .RE
 .RE
+.RE
+.PP
+AVD cloud table:
+.RS 4
+.PP
+The Azure clouds \fI/gateway:cloud:\fR selects from, and the ones an ARM gateway hostname
+selects automatically, are compiled into the library\&. The optional
+\fIaad\-clouds\&.json\fR adds to them without a rebuild: the system file is read first, the
+user file after it, and every entry is merged over the compiled table by \fIname\fR\&. An entry
+naming a compiled cloud replaces it completely, any other one adds a cloud\&. A malformed entry
+is logged and skipped, a file that does not parse is logged and ignored, and without a file the
+compiled table is used unchanged\&.
+.PP
+File format is a JSON array of objects with:
+.PP
+\fIname\fR
+.RS 4
+\fIJSON string\fR
+.br
+
+the name \fI/gateway:cloud:\fR selects the cloud with, of \fI[a\-z0\-9\-]\fR
+.RE
+.PP
+\fIactive_directory\fR
+.RS 4
+\fIJSON string\fR
+.br
+
+the AAD authority host, without scheme or path, e\&.g\&.
+\fIlogin\&.microsoftonline\&.us\fR
+.RE
+.PP
+\fIavd_scope\fR
+.RS 4
+\fIJSON string\fR
+.br
+
+the percent\-encoded AVD scope, exactly as it is passed on the wire, e\&.g\&.
+\fIhttps%3A%2F%2Fwww\&.wvd\&.azure\&.us%2F\&.default%20openid%20profile%20offline_access\fR
+.RE
+.PP
+\fIavd_redirect_format\fR
+.RS 4
+\fIJSON string\fR
+.br
+
+the redirect URI as a printf format expanded with the authority and the tenant id, so a literal
+percent sign is written \fI%%\fR and at most two \fI%s\fR are allowed
+.RE
+.PP
+\fIgateway_suffix\fR
+.RS 4
+\fIJSON string, optional\fR
+.br
+
+the gateway hostname suffix selecting this cloud automatically, starting with the \fI\&.\fR of
+a label boundary, e\&.g\&. \fI\&.wvd\&.azure\&.us\fR\&. Without it the cloud is only
+reachable by name
+.RE
+.PP
+\fIresource_manager\fR
+.RS 4
+\fIJSON string, optional\fR
+.br
+
+the ARM endpoint of the cloud\&. Accepted and ignored, no setting holds it
+.RE
+.PP
+A sample file is in the source tree as \fIdocs/aad\-clouds\&.example\&.json\fR\&.
+Note that overriding \fIcommercial\fR also changes the values the automatic selection treats as
+untouched defaults, so a connection whose settings still hold the built\-in commercial defaults
+is then seen as configured by hand\&.
 .RE

--- a/client/common/test/TestClientCmdLine.c
+++ b/client/common/test/TestClientCmdLine.c
@@ -107,6 +107,70 @@ static BOOL check_settings_smartcard_no_redirection(rdpSettings* settings)
 	return result;
 }
 
+static const char avd_commercial_scope[] =
+    "https%3A%2F%2Fwww.wvd.microsoft.com%2F.default%20openid%20profile%20offline_access";
+static const char avd_commercial_redirect[] = "https%%3A%%2F%%2F%s%%2F%s%%2Foauth2%%2Fnativeclient";
+static const char avd_usgov_scope[] =
+    "https%3A%2F%2Fwww.wvd.azure.us%2F.default%20openid%20profile%20offline_access";
+static const char avd_usgov_redirect[] =
+    "https%%3A%%2F%%2Flogin.microsoftonline.com%%2Fcommon%%2Foauth2%%2Fnativeclient";
+
+static BOOL check_avd_cloud(rdpSettings* settings, const char* authority, const char* scope,
+                            const char* redirect, BOOL useTenantid)
+{
+	const struct
+	{
+		FreeRDP_Settings_Keys_String key;
+		const char* expected;
+	} strings[] = { { FreeRDP_GatewayAzureActiveDirectory, authority },
+		            { FreeRDP_GatewayAvdScope, scope },
+		            { FreeRDP_GatewayAvdAccessAadFormat, redirect } };
+
+	for (size_t x = 0; x < ARRAYSIZE(strings); x++)
+	{
+		const char* val = freerdp_settings_get_string(settings, strings[x].key);
+		if (!val || (strcmp(val, strings[x].expected) != 0))
+		{
+			TEST_FAILURE("Expected %s = %s, but got %s!\n",
+			             freerdp_settings_get_name_for_key(strings[x].key), strings[x].expected,
+			             val ? val : "(null)");
+			return FALSE;
+		}
+	}
+
+	if (freerdp_settings_get_bool(settings, FreeRDP_GatewayAvdUseTenantid) != useTenantid)
+	{
+		TEST_FAILURE("Expected GatewayAvdUseTenantid = %d!\n", useTenantid);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static BOOL check_settings_avd_commercial(rdpSettings* settings)
+{
+	return check_avd_cloud(settings, "login.microsoftonline.com", avd_commercial_scope,
+	                       avd_commercial_redirect, FALSE);
+}
+
+static BOOL check_settings_avd_usgov(rdpSettings* settings)
+{
+	return check_avd_cloud(settings, "login.microsoftonline.us", avd_usgov_scope,
+	                       avd_usgov_redirect, FALSE);
+}
+
+static BOOL check_settings_avd_usgov_tenantid(rdpSettings* settings)
+{
+	return check_avd_cloud(settings, "login.microsoftonline.us", avd_usgov_scope,
+	                       avd_usgov_redirect, TRUE);
+}
+
+static BOOL check_settings_avd_usgov_custom_scope(rdpSettings* settings)
+{
+	return check_avd_cloud(settings, "login.microsoftonline.us", "custom-scope", avd_usgov_redirect,
+	                       FALSE);
+}
+
 typedef struct
 {
 	int expected_status;
@@ -177,6 +241,70 @@ static const test tests[] = {
 	{ COMMAND_LINE_ERROR_NO_KEYWORD,
 	  check_settings_smartcard_no_redirection,
 	  { "testfreerdp", "--invalid", nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	/* An ARM gateway of a sovereign cloud selects that cloud, unless the values it owns were
+	 * customized or /gateway:cloud: named a cloud explicitly. */
+	{ 0,
+	  check_settings_avd_usgov,
+	  { "testfreerdp", "/gateway:g:gw.wvd.azure.us,type:arm", "/v:test.freerdp.com", nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	{ 0,
+	  check_settings_avd_usgov_tenantid,
+	  { "testfreerdp", "/gateway:g:gw.WVD.AZURE.US,type:arm",
+	    "/azure:tenantid:00000000-0000-0000-0000-000000000000", "/v:test.freerdp.com", nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	{ 0,
+	  check_settings_avd_usgov,
+	  { "testfreerdp", "/gateway:g:gw.wvd.azure.us,type:arm",
+	    "/azure:tenantid:00000000-0000-0000-0000-000000000000,use-tenantid:off",
+	    "/v:test.freerdp.com", nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	{ 0,
+	  check_settings_avd_usgov_custom_scope,
+	  { "testfreerdp", "/gateway:g:gw.wvd.azure.us,type:arm", "/azure:avd-scope:custom-scope",
+	    "/v:test.freerdp.com", nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	{ 0,
+	  check_settings_avd_commercial,
+	  { "testfreerdp", "/gateway:g:gw.wvd.azure.us", "/v:test.freerdp.com", nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	{ 0,
+	  check_settings_avd_usgov,
+	  { "testfreerdp", "/gateway:g:gw.contoso.com,type:arm,cloud:usgov", "/v:test.freerdp.com",
+	    nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	{ 0,
+	  check_settings_avd_commercial,
+	  { "testfreerdp", "/gateway:g:gw.wvd.azure.us,type:arm,cloud:commercial",
+	    "/v:test.freerdp.com", nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	{ COMMAND_LINE_ERROR,
+	  nullptr,
+	  { "testfreerdp", "/gateway:g:gw.contoso.com,type:arm,cloud:unknown", "/v:test.freerdp.com",
+	    nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	/* An explicit cloud gets the same tenant handling as the automatic selection. */
+	{ 0,
+	  check_settings_avd_usgov_tenantid,
+	  { "testfreerdp", "/gateway:g:gw.contoso.com,type:arm,cloud:usgov",
+	    "/azure:tenantid:00000000-0000-0000-0000-000000000000", "/v:test.freerdp.com", nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	{ 0,
+	  check_settings_avd_usgov,
+	  { "testfreerdp", "/gateway:g:gw.contoso.com,type:arm,cloud:usgov",
+	    "/azure:tenantid:00000000-0000-0000-0000-000000000000,use-tenantid:off",
+	    "/v:test.freerdp.com", nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	/* The cloud strings are applied where cloud: is parsed, so the last option wins. */
+	{ 0,
+	  check_settings_avd_usgov_custom_scope,
+	  { "testfreerdp", "/gateway:g:gw.contoso.com,type:arm,cloud:usgov",
+	    "/azure:avd-scope:custom-scope", "/v:test.freerdp.com", nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	{ 0,
+	  check_settings_avd_usgov,
+	  { "testfreerdp", "/azure:avd-scope:custom-scope",
+	    "/gateway:g:gw.contoso.com,type:arm,cloud:usgov", "/v:test.freerdp.com", nullptr },
 	  { WINPR_C_ARRAY_INIT } },
 #if defined(WITH_FREERDP_DEPRECATED_CMDLINE)
 	{ COMMAND_LINE_STATUS_PRINT,

--- a/client/common/test/TestClientCmdLine.c
+++ b/client/common/test/TestClientCmdLine.c
@@ -171,6 +171,12 @@ static BOOL check_settings_avd_usgov_custom_scope(rdpSettings* settings)
 	                       FALSE);
 }
 
+static BOOL check_settings_avd_custom_authority(rdpSettings* settings)
+{
+	return check_avd_cloud(settings, "login.contoso.invalid", avd_commercial_scope,
+	                       avd_commercial_redirect, FALSE);
+}
+
 typedef struct
 {
 	int expected_status;
@@ -305,6 +311,27 @@ static const test tests[] = {
 	  check_settings_avd_usgov,
 	  { "testfreerdp", "/azure:avd-scope:custom-scope",
 	    "/gateway:g:gw.contoso.com,type:arm,cloud:usgov", "/v:test.freerdp.com", nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	/* A .rdp file is loaded without selecting a cloud, so the cloud is selected once, from the
+	 * settings the options left behind. */
+	{ 0,
+	  check_settings_avd_usgov_tenantid,
+	  { "testfreerdp", TEST_SOURCE_DIR "/rdp-avd/avd-usgov.rdp", nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	{ 0,
+	  check_settings_avd_commercial,
+	  { "testfreerdp", TEST_SOURCE_DIR "/rdp-avd/avd-usgov.rdp",
+	    "/gateway:g:gw.wvd.microsoft.com,type:arm", nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	{ 0,
+	  check_settings_avd_custom_authority,
+	  { "testfreerdp", TEST_SOURCE_DIR "/rdp-avd/avd-usgov.rdp", "/azure:ad:login.contoso.invalid",
+	    nullptr },
+	  { WINPR_C_ARRAY_INIT } },
+	{ 0,
+	  check_settings_avd_usgov,
+	  { "testfreerdp", TEST_SOURCE_DIR "/rdp-avd/avd-usgov.rdp", "/azure:tenantid:common",
+	    nullptr },
 	  { WINPR_C_ARRAY_INIT } },
 #if defined(WITH_FREERDP_DEPRECATED_CMDLINE)
 	{ COMMAND_LINE_STATUS_PRINT,

--- a/client/common/test/TestClientRdpFile.c
+++ b/client/common/test/TestClientRdpFile.c
@@ -8,6 +8,7 @@
 #include <winpr/path.h>
 #include <winpr/crypto.h>
 
+#include <freerdp/client.h>
 #include <freerdp/client/file.h>
 #include <freerdp/channels/rdpecam.h>
 
@@ -407,6 +408,30 @@ static rdpSettings* load_from_file(const char* name, bool unchecked)
 	return settings;
 }
 
+/* The public file API, which maps the file and then selects the AVD cloud. */
+static rdpSettings* load_from_fresh(const void* data, size_t len)
+{
+	rdpSettings* settings = freerdp_settings_new(0);
+	if (!settings ||
+	    (freerdp_client_settings_parse_connection_file_buffer(settings, data, len) != 0))
+	{
+		freerdp_settings_free(settings);
+		return nullptr;
+	}
+	return settings;
+}
+
+static rdpSettings* load_from_file_fresh(const char* name)
+{
+	size_t datalen = 0;
+	void* data = read_rdp_data(name, &datalen);
+	if (!data)
+		return nullptr;
+	rdpSettings* settings = load_from_fresh(data, datalen);
+	free(data);
+	return settings;
+}
+
 static bool test_data(const char* json, const void* data, size_t len, bool unchecked)
 {
 	bool rc = false;
@@ -542,6 +567,120 @@ static bool test_rdp_files(bool allowCreate)
 fail:
 	FindClose(hdl);
 	free(path);
+	return rc;
+}
+
+static bool string_setting_is(const rdpSettings* settings, FreeRDP_Settings_Keys_String key,
+                              const char* expected)
+{
+	const char* actual = freerdp_settings_get_string(settings, key);
+	return actual && (strcmp(actual, expected) == 0);
+}
+
+static bool test_avd_settings(void)
+{
+	static const char nonArm[] = "gatewayhostname:s:gateway.wvd.azure.us\n";
+	static const char commercialScope[] =
+	    "https%3A%2F%2Fwww.wvd.microsoft.com%2F.default%20openid%20profile%20offline_access";
+	static const char commercialRedirect[] = "https%%3A%%2F%%2F%s%%2F%s%%2Foauth2%%2Fnativeclient";
+	static const char usgovScope[] =
+	    "https%3A%2F%2Fwww.wvd.azure.us%2F.default%20openid%20profile%20offline_access";
+	static const char usgovRedirect[] =
+	    "https%%3A%%2F%%2Flogin.microsoftonline.com%%2Fcommon%%2Foauth2%%2Fnativeclient";
+
+	rdpSettings* usgov = load_from_file_fresh("rdp-avd/avd-usgov.rdp");
+	rdpSettings* commercial = load_from_file_fresh("rdp-avd/avd-commercial.rdp");
+	rdpSettings* nonArmSettings = load_from_fresh(nonArm, sizeof(nonArm) - 1);
+	bool rc = false;
+	if (!usgov || !commercial || !nonArmSettings)
+		goto fail;
+
+	if (!string_setting_is(usgov, FreeRDP_ServerHostname, "alternate.contoso.invalid") ||
+	    (freerdp_settings_get_uint32(usgov, FreeRDP_ServerPort) != 3390) ||
+	    (freerdp_get_gateway_usage_method(usgov) != TSC_PROXY_MODE_DIRECT) ||
+	    !freerdp_settings_get_bool(usgov, FreeRDP_GatewayUseSameCredentials) ||
+	    !freerdp_settings_get_bool(usgov, FreeRDP_GatewayArmTransport) ||
+	    !string_setting_is(usgov, FreeRDP_GatewayHostname, "gateway.wvd.azure.us") ||
+	    !string_setting_is(usgov, FreeRDP_GatewayAvdAadtenantid,
+	                       "00000000-0000-0000-0000-000000000000") ||
+	    !string_setting_is(usgov, FreeRDP_GatewayAvdWvdEndpointPool, "pool-contoso") ||
+	    !string_setting_is(usgov, FreeRDP_GatewayAvdGeo, "usgov") ||
+	    !string_setting_is(usgov, FreeRDP_GatewayAvdArmpath,
+	                       "/subscriptions/contoso/resourceGroups/contoso/providers/Microsoft."
+	                       "DesktopVirtualization/workspaces/contoso") ||
+	    !string_setting_is(usgov, FreeRDP_GatewayAvdDiagnosticserviceurl,
+	                       "https://diagnostics.contoso.invalid") ||
+	    !string_setting_is(usgov, FreeRDP_GatewayAvdHubdiscoverygeourl,
+	                       "https://discovery.contoso.invalid") ||
+	    !string_setting_is(usgov, FreeRDP_GatewayAvdActivityhint,
+	                       "00000000-0000-0000-0000-000000000000") ||
+	    !freerdp_settings_get_bool(usgov, FreeRDP_AadSecurity) ||
+	    (freerdp_settings_get_uint32(usgov, FreeRDP_AuthenticationLevel) != 2) ||
+	    !freerdp_settings_get_bool(usgov, FreeRDP_RedirectSmartCards) ||
+	    !freerdp_settings_get_bool(usgov, FreeRDP_RemoteApplicationMode) ||
+	    !string_setting_is(usgov, FreeRDP_RemoteApplicationProgram, "||ContosoApp") ||
+	    !string_setting_is(usgov, FreeRDP_RemoteApplicationName, "Contoso App") ||
+	    !string_setting_is(usgov, FreeRDP_RemoteApplicationGuid,
+	                       "00000000-0000-0000-0000-000000000000"))
+		goto fail;
+
+	/* The ARM gateway of the file is a US Government one, so populating the settings selected
+	 * that cloud, and its tenant id is not the "common" placeholder. */
+	if (!string_setting_is(usgov, FreeRDP_GatewayAzureActiveDirectory,
+	                       "login.microsoftonline.us") ||
+	    !string_setting_is(usgov, FreeRDP_GatewayAvdScope, usgovScope) ||
+	    !string_setting_is(usgov, FreeRDP_GatewayAvdAccessAadFormat, usgovRedirect) ||
+	    !freerdp_settings_get_bool(usgov, FreeRDP_GatewayAvdUseTenantid))
+		goto fail;
+
+	/* A commercial ARM gateway keeps the defaults. */
+	if (!freerdp_settings_get_bool(commercial, FreeRDP_GatewayArmTransport) ||
+	    !string_setting_is(commercial, FreeRDP_GatewayAzureActiveDirectory,
+	                       "login.microsoftonline.com") ||
+	    !string_setting_is(commercial, FreeRDP_GatewayAvdScope, commercialScope) ||
+	    !string_setting_is(commercial, FreeRDP_GatewayAvdAccessAadFormat, commercialRedirect) ||
+	    freerdp_settings_get_bool(commercial, FreeRDP_GatewayAvdUseTenantid))
+		goto fail;
+
+	/* Without the ARM transport the gateway hostname says nothing about the cloud. */
+	if (freerdp_settings_get_bool(nonArmSettings, FreeRDP_GatewayArmTransport) ||
+	    !string_setting_is(nonArmSettings, FreeRDP_GatewayAzureActiveDirectory,
+	                       "login.microsoftonline.com") ||
+	    !string_setting_is(nonArmSettings, FreeRDP_GatewayAvdScope, commercialScope) ||
+	    !string_setting_is(nonArmSettings, FreeRDP_GatewayAvdAccessAadFormat, commercialRedirect) ||
+	    freerdp_settings_get_bool(nonArmSettings, FreeRDP_GatewayAvdUseTenantid))
+		goto fail;
+
+	{
+		rdpFile* output = freerdp_client_rdp_file_new();
+		if (!output || !freerdp_client_populate_rdp_file_from_settings(output, usgov))
+		{
+			freerdp_client_rdp_file_free(output);
+			goto fail;
+		}
+		const char* resource =
+		    freerdp_client_rdp_file_get_string_option(output, "resourceprovider");
+		const char* tenant = freerdp_client_rdp_file_get_string_option(output, "aadtenantid");
+		const char* armpath = freerdp_client_rdp_file_get_string_option(output, "armpath");
+		if ((freerdp_client_rdp_file_get_integer_option(output, "enablerdsaadauth") != 1) ||
+		    (freerdp_client_rdp_file_get_integer_option(output, "redirectsmartcards") != 1) ||
+		    (freerdp_client_rdp_file_get_integer_option(output, "remoteapplicationmode") != 1) ||
+		    !resource || strcmp(resource, "arm") || !tenant ||
+		    strcmp(tenant, "00000000-0000-0000-0000-000000000000") || !armpath ||
+		    strcmp(armpath, "/subscriptions/contoso/resourceGroups/contoso/providers/Microsoft."
+		                    "DesktopVirtualization/workspaces/contoso"))
+		{
+			freerdp_client_rdp_file_free(output);
+			goto fail;
+		}
+		freerdp_client_rdp_file_free(output);
+	}
+
+	rc = true;
+fail:
+	freerdp_settings_free(nonArmSettings);
+	freerdp_settings_free(commercial);
+	freerdp_settings_free(usgov);
 	return rc;
 }
 
@@ -868,6 +1007,9 @@ int TestClientRdpFile(int argc, char* argv[])
 	if (!test_rdp_files(argc > 1))
 		return -1;
 #endif
+
+	if (!test_avd_settings())
+		return -1;
 
 	rdpSettings* settings = freerdp_settings_new(0);
 	if (!settings)

--- a/client/common/test/rdp-avd/avd-commercial.rdp
+++ b/client/common/test/rdp-avd/avd-commercial.rdp
@@ -1,0 +1,21 @@
+full address:s:sessionhost.contoso.invalid
+gatewayhostname:s:gateway.wvd.microsoft.com
+gatewayusagemethod:i:1
+gatewayprofileusagemethod:i:1
+gatewaycredentialssource:i:5
+promptcredentialonce:i:1
+resourceprovider:s:arm
+wvd endpoint pool:s:pool-contoso
+geo:s:commercial
+armpath:s:/subscriptions/contoso/resourceGroups/contoso/providers/Microsoft.DesktopVirtualization/workspaces/contoso
+aadtenantid:s:00000000-0000-0000-0000-000000000000
+diagnosticserviceurl:s:https://diagnostics.contoso.invalid
+hubdiscoverygeourl:s:https://discovery.contoso.invalid
+activityhint:s:00000000-0000-0000-0000-000000000000
+enablerdsaadauth:i:1
+authentication level:i:2
+redirectsmartcards:i:1
+remoteapplicationmode:i:1
+remoteapplicationprogram:s:||ContosoApp
+remoteapplicationname:s:Contoso App
+remoteapplicationguid:s:00000000-0000-0000-0000-000000000000

--- a/client/common/test/rdp-avd/avd-usgov.rdp
+++ b/client/common/test/rdp-avd/avd-usgov.rdp
@@ -1,0 +1,24 @@
+full address:s:sessionhost.contoso.invalid
+alternate full address:s:alternate.contoso.invalid
+server port:i:3390
+loadbalanceinfo:s:tsv://MS Terminal Services Plugin.1.contoso
+gatewayhostname:s:gateway.wvd.azure.us
+gatewayusagemethod:i:1
+gatewayprofileusagemethod:i:1
+gatewaycredentialssource:i:5
+promptcredentialonce:i:1
+resourceprovider:s:arm
+wvd endpoint pool:s:pool-contoso
+geo:s:usgov
+armpath:s:/subscriptions/contoso/resourceGroups/contoso/providers/Microsoft.DesktopVirtualization/workspaces/contoso
+aadtenantid:s:00000000-0000-0000-0000-000000000000
+diagnosticserviceurl:s:https://diagnostics.contoso.invalid
+hubdiscoverygeourl:s:https://discovery.contoso.invalid
+activityhint:s:00000000-0000-0000-0000-000000000000
+enablerdsaadauth:i:1
+authentication level:i:2
+redirectsmartcards:i:1
+remoteapplicationmode:i:1
+remoteapplicationprogram:s:||ContosoApp
+remoteapplicationname:s:Contoso App
+remoteapplicationguid:s:00000000-0000-0000-0000-000000000000

--- a/docs/aad-clouds.example.json
+++ b/docs/aad-clouds.example.json
@@ -1,0 +1,20 @@
+[
+	{
+		"name": "usgov",
+		"active_directory": "login.microsoftonline.us",
+		"gateway_suffix": ".wvd.azure.us",
+		"avd_scope":
+		    "https%3A%2F%2Fwww.wvd.azure.us%2F.default%20openid%20profile%20offline_access",
+		"avd_redirect_format":
+		    "https%%3A%%2F%%2Flogin.microsoftonline.com%%2Fcommon%%2Foauth2%%2Fnativeclient",
+		"resource_manager": "https://management.usgovcloudapi.net/"
+	},
+	{
+		"name": "example",
+		"active_directory": "login.example.test",
+		"gateway_suffix": ".wvd.example.test",
+		"avd_scope":
+		    "https%3A%2F%2Fwww.wvd.example.test%2F.default%20openid%20profile%20offline_access",
+		"avd_redirect_format": "https%%3A%%2F%%2F%s%%2F%s%%2Foauth2%%2Fnativeclient"
+	}
+]

--- a/include/freerdp/client.h
+++ b/include/freerdp/client.h
@@ -208,6 +208,37 @@ extern "C"
 	FREERDP_API int freerdp_client_settings_parse_assistance_file(rdpSettings* settings, int argc,
 	                                                              char* argv[]);
 
+	/** @brief Select the AVD sovereign cloud of the configured ARM gateway
+	 *
+	 *  Azure Virtual Desktop is reachable in more than one Azure cloud and each cloud has its
+	 *  own AAD authority, AVD scope and redirect URI. The settings holding them default to the
+	 *  commercial cloud, see \ref freerdp_utils_aad_cloud_by_name.
+	 *
+	 *  Does nothing unless \b FreeRDP_GatewayArmTransport is set and
+	 *  \b FreeRDP_GatewayHostname names a gateway of a known cloud. Only values that still hold
+	 *  their commercial default are replaced, so an authority configured by hand keeps every
+	 *  related setting, and an individually customized AVD scope or redirect format survives.
+	 *  \b FreeRDP_GatewayAvdUseTenantid is derived from \b FreeRDP_GatewayAvdAadtenantid when it
+	 *  is not already set.
+	 *
+	 *  Called exactly once per configuration: by
+	 *  \ref freerdp_client_settings_parse_connection_file and
+	 *  \ref freerdp_client_settings_parse_connection_file_buffer after the file was mapped, and
+	 *  by \ref freerdp_client_settings_parse_command_line_arguments after every option was
+	 *  parsed. The command line parser therefore loads a .rdp file of its own without this step,
+	 *  so that an option can still override what the file selected. It skips the automatic
+	 *  selection entirely when \b /gateway:cloud: named a cloud, which is applied where the
+	 *  option is parsed. A front end that assembles the settings itself calls this once before
+	 *  connecting.
+	 *
+	 *  @param settings The settings to inspect and update
+	 *  @return \b TRUE if nothing had to change or the cloud was applied, \b FALSE on invalid
+	 *          input or allocation failure.
+	 *  @since version 3.32.0
+	 */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API BOOL freerdp_client_settings_apply_avd_cloud(rdpSettings* settings);
+
 	WINPR_ATTR_NODISCARD
 	FREERDP_API BOOL client_cli_authenticate_ex(freerdp* instance, char** username, char** password,
 	                                            char** domain, rdp_auth_reason reason);

--- a/include/freerdp/utils/aad.h
+++ b/include/freerdp/utils/aad.h
@@ -30,6 +30,7 @@
 #include <freerdp/api.h>
 #include <freerdp/types.h>
 #include <freerdp/config.h>
+#include <freerdp/settings.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -66,6 +67,64 @@ extern "C"
 		AAD_WELLKNOWN_msgraph_host,
 		AAD_WELLKNOWN_rbac_url
 	} AAD_WELLKNOWN_VALUES;
+
+	typedef struct freerdp_aad_cloud FreeRDP_AadCloud;
+
+	/** Look up an AVD cloud by its short name.
+	 *
+	 * @param name Cloud name (currently `commercial` or `usgov`).
+	 * @return The immutable cloud description, or \b nullptr if unknown.
+	 * @since version 3.32.0
+	 */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API const FreeRDP_AadCloud* freerdp_utils_aad_cloud_by_name(const char* name);
+
+	/** Select an AVD cloud from a gateway hostname.
+	 *
+	 * @param hostname Gateway hostname to inspect.
+	 * @return The matching immutable cloud description, or \b nullptr if unknown.
+	 * @since version 3.32.0
+	 */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API const FreeRDP_AadCloud* freerdp_utils_aad_cloud_for_gateway(const char* hostname);
+
+	/** @return The cloud's short name. @since version 3.32.0 */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API const char* freerdp_utils_aad_cloud_get_name(const FreeRDP_AadCloud* cloud);
+
+	/** @return The case-insensitive gateway suffix, including its leading dot label boundary,
+	 *          or \b nullptr for a cloud without automatic gateway matching.
+	 * @since version 3.32.0
+	 */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API const char*
+	freerdp_utils_aad_cloud_get_gateway_suffix(const FreeRDP_AadCloud* cloud);
+
+	/** @return The cloud's AAD authority. @since version 3.32.0 */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API const char* freerdp_utils_aad_cloud_get_authority(const FreeRDP_AadCloud* cloud);
+
+	/** @return The cloud's percent-encoded AVD scope. @since version 3.32.0 */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API const char* freerdp_utils_aad_cloud_get_avd_scope(const FreeRDP_AadCloud* cloud);
+
+	/** @return The cloud's printf redirect format, containing at most two `%s` conversions.
+	 * @since version 3.32.0
+	 */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API const char*
+	freerdp_utils_aad_cloud_get_avd_redirect_format(const FreeRDP_AadCloud* cloud);
+
+	/** Apply an AVD cloud's authority, scope and redirect settings.
+	 *
+	 * @param settings Settings instance to update.
+	 * @param cloud Cloud description returned by a lookup helper.
+	 * @return \b TRUE on success, \b FALSE on invalid input or allocation failure.
+	 * @since version 3.32.0
+	 */
+	WINPR_ATTR_NODISCARD
+	FREERDP_API BOOL freerdp_utils_aad_apply_cloud(rdpSettings* settings,
+	                                               const FreeRDP_AadCloud* cloud);
 
 	/** Helper to retrieve the AAD access token from JSON input
 	 *

--- a/libfreerdp/core/aad.c
+++ b/libfreerdp/core/aad.c
@@ -28,8 +28,13 @@
 #include <freerdp/utils/http.h>
 #include <freerdp/utils/aad.h>
 
+#include <winpr/cast.h>
 #include <winpr/crypto.h>
 #include <winpr/json.h>
+#include <winpr/path.h>
+#include <winpr/synch.h>
+
+#include <freerdp/utils/helpers.h>
 
 #include "transport.h"
 #include "rdp.h"
@@ -62,6 +67,409 @@ static const FreeRDP_AadCloud aad_clouds[] = {
 	  "https%%3A%%2F%%2Flogin.microsoftonline.com%%2Fcommon%%2Foauth2%%2Fnativeclient" }
 };
 
+/** @brief The optional configuration file overriding or extending the compiled cloud table
+ *
+ * Looked up in the system configuration directory first, then in the user one, so that a
+ * distribution or an administrator can add a cloud without a rebuild and a user can add a
+ * private one on top of that. Entries are merged by name over the compiled table: an entry
+ * naming a compiled cloud replaces it as a whole, any other one is added.
+ */
+#define AAD_CLOUDS_CONFIG_FILE "aad-clouds.json"
+
+/** The number of '%s' conversions the redirect format is expanded with: the AAD authority and
+ * the tenant id, see get_redirect_uri() in client/common/client.c. */
+#define AAD_CLOUD_REDIRECT_CONVERSIONS 2
+
+static INIT_ONCE aad_clouds_once = INIT_ONCE_STATIC_INIT;
+
+/** The compiled table with the configured clouds merged over it, or \b nullptr while no
+ * configuration file contributed an entry. Every entry of it owns all of its strings. */
+static FreeRDP_AadCloud* aad_clouds_configured = nullptr;
+static size_t aad_clouds_configured_count = 0;
+
+/** Frees the strings of a configured entry.
+ *
+ * The fields are const because the lookups hand out immutable descriptions, but a configured
+ * entry owns its strings and nothing else points at them. The compiled entries are never
+ * passed here, they hold string literals.
+ */
+static void aad_cloud_entry_free(FreeRDP_AadCloud* cloud)
+{
+	if (!cloud)
+		return;
+
+	free(WINPR_CAST_CONST_PTR_AWAY(cloud->name, char*));
+	free(WINPR_CAST_CONST_PTR_AWAY(cloud->gateway_suffix, char*));
+	free(WINPR_CAST_CONST_PTR_AWAY(cloud->authority, char*));
+	free(WINPR_CAST_CONST_PTR_AWAY(cloud->avd_scope, char*));
+	free(WINPR_CAST_CONST_PTR_AWAY(cloud->avd_redirect_format, char*));
+
+	const FreeRDP_AadCloud empty = { nullptr, nullptr, nullptr, nullptr, nullptr };
+	*cloud = empty;
+}
+
+static void aad_cloud_table_free(FreeRDP_AadCloud* table, size_t count)
+{
+	for (size_t x = 0; x < count; x++)
+		aad_cloud_entry_free(&table[x]);
+	free(table);
+}
+
+/** Copies a cloud description into an entry owning all of its strings. */
+static BOOL aad_cloud_entry_copy(FreeRDP_AadCloud* dst, const FreeRDP_AadCloud* src)
+{
+	FreeRDP_AadCloud copy = { nullptr, nullptr, nullptr, nullptr, nullptr };
+
+	copy.name = _strdup(src->name);
+	copy.authority = _strdup(src->authority);
+	copy.avd_scope = _strdup(src->avd_scope);
+	copy.avd_redirect_format = _strdup(src->avd_redirect_format);
+	if (src->gateway_suffix)
+		copy.gateway_suffix = _strdup(src->gateway_suffix);
+
+	if (!copy.name || !copy.authority || !copy.avd_scope || !copy.avd_redirect_format ||
+	    (src->gateway_suffix && !copy.gateway_suffix))
+	{
+		aad_cloud_entry_free(&copy);
+		return FALSE;
+	}
+
+	*dst = copy;
+	return TRUE;
+}
+
+/** Fills \b ptable with owned copies of the compiled clouds, unless it already holds them. */
+static BOOL aad_cloud_table_materialize(FreeRDP_AadCloud** ptable, size_t* pcount)
+{
+	if (*ptable)
+		return TRUE;
+
+	FreeRDP_AadCloud* table = calloc(ARRAYSIZE(aad_clouds), sizeof(FreeRDP_AadCloud));
+	if (!table)
+		return FALSE;
+
+	for (size_t x = 0; x < ARRAYSIZE(aad_clouds); x++)
+	{
+		if (!aad_cloud_entry_copy(&table[x], &aad_clouds[x]))
+		{
+			aad_cloud_table_free(table, ARRAYSIZE(aad_clouds));
+			return FALSE;
+		}
+	}
+
+	*ptable = table;
+	*pcount = ARRAYSIZE(aad_clouds);
+	return TRUE;
+}
+
+/** Merges one configured cloud into the table, taking ownership of its strings on success:
+ * an entry of the same name is replaced as a whole, any other one is appended. */
+static BOOL aad_cloud_table_merge(FreeRDP_AadCloud** ptable, size_t* pcount,
+                                  const FreeRDP_AadCloud* entry)
+{
+	if (!aad_cloud_table_materialize(ptable, pcount))
+		return FALSE;
+
+	for (size_t x = 0; x < *pcount; x++)
+	{
+		FreeRDP_AadCloud* cur = &(*ptable)[x];
+		if (_stricmp(cur->name, entry->name) == 0)
+		{
+			aad_cloud_entry_free(cur);
+			*cur = *entry;
+			return TRUE;
+		}
+	}
+
+	FreeRDP_AadCloud* table = realloc(*ptable, (*pcount + 1) * sizeof(FreeRDP_AadCloud));
+	if (!table)
+		return FALSE;
+
+	table[*pcount] = *entry;
+	*ptable = table;
+	*pcount += 1;
+	return TRUE;
+}
+
+/** A cloud name is a /gateway:cloud: value, so it stays a lowercase [a-z0-9-] token. */
+static BOOL aad_cloud_valid_name(const char* value)
+{
+	if (!value || (strlen(value) == 0))
+		return FALSE;
+
+	for (const char* pos = value; *pos != '\0'; pos++)
+	{
+		const char cur = *pos;
+		if (((cur < 'a') || (cur > 'z')) && ((cur < '0') || (cur > '9')) && (cur != '-'))
+			return FALSE;
+	}
+	return TRUE;
+}
+
+/** Host names are expanded into URLs, so only the characters of a DNS name are accepted: a
+ * scheme, a port, a path or a query would end up in the middle of the URL built from it. */
+static BOOL aad_cloud_valid_host_chars(const char* value)
+{
+	if (!value || (strlen(value) == 0))
+		return FALSE;
+
+	for (const char* pos = value; *pos != '\0'; pos++)
+	{
+		const char cur = *pos;
+		if (((cur < 'a') || (cur > 'z')) && ((cur < 'A') || (cur > 'Z')) &&
+		    ((cur < '0') || (cur > '9')) && (cur != '.') && (cur != '-'))
+			return FALSE;
+	}
+	return TRUE;
+}
+
+static BOOL aad_cloud_valid_authority(const char* value)
+{
+	if (!aad_cloud_valid_host_chars(value))
+		return FALSE;
+
+	const size_t len = strlen(value);
+	return (value[0] != '.') && (value[0] != '-') && (value[len - 1] != '.') &&
+	       (value[len - 1] != '-');
+}
+
+/** The gateway suffix is matched against the end of a hostname, so it starts at a label
+ * boundary: without the leading dot 'xwvd.azure.us' would match '.wvd.azure.us'. */
+static BOOL aad_cloud_valid_gateway_suffix(const char* value)
+{
+	if (!value || (strlen(value) < 2) || (value[0] != '.'))
+		return FALSE;
+
+	return aad_cloud_valid_authority(&value[1]);
+}
+
+/** The scope and the redirect format are expanded into a URL as percent encoded values, so
+ * everything outside of printable ASCII and the characters delimiting a URL is rejected. */
+static BOOL aad_cloud_valid_url_value(const char* value)
+{
+	if (!value || (strlen(value) == 0))
+		return FALSE;
+
+	for (const char* pos = value; *pos != '\0'; pos++)
+	{
+		const char cur = *pos;
+		if ((cur <= 0x20) || (cur >= 0x7f) || strchr("&#?\"'<>\\^`{|}", cur))
+			return FALSE;
+	}
+	return TRUE;
+}
+
+/** The redirect format is passed to winpr_asprintf() as the format string, so accept literal
+ * text, '%%' and at most \ref AAD_CLOUD_REDIRECT_CONVERSIONS '%s'. Every other conversion
+ * reads past the end of the argument list, and '%n' writes through what it finds there. */
+static BOOL aad_cloud_valid_redirect_format(const char* value)
+{
+	if (!aad_cloud_valid_url_value(value))
+		return FALSE;
+
+	size_t conversions = 0;
+	for (const char* pos = strchr(value, '%'); pos; pos = strchr(pos, '%'))
+	{
+		switch (pos[1])
+		{
+			case '%':
+				break;
+			case 's':
+				conversions++;
+				break;
+			default:
+				return FALSE;
+		}
+		pos += 2;
+	}
+
+	return conversions <= AAD_CLOUD_REDIRECT_CONVERSIONS;
+}
+
+static const char* aad_cloud_json_string(const WINPR_JSON* obj, const char* key)
+{
+	WINPR_JSON* item = WINPR_JSON_GetObjectItemCaseSensitive(obj, key);
+	if (!item)
+		return nullptr;
+	return WINPR_JSON_GetStringValue(item);
+}
+
+/** Parses and validates one array element of a configuration file.
+ *
+ * @param path The file the element was read from, for the log messages
+ * @param index The index of the element in the file, for the log messages
+ * @param item The element to parse
+ * @param cloud Receives the parsed cloud, owning all of its strings
+ * @return \b TRUE if the element describes a valid cloud, \b FALSE if it was rejected
+ */
+static BOOL aad_cloud_parse_entry(const char* path, size_t index, WINPR_JSON* item,
+                                  FreeRDP_AadCloud* cloud)
+{
+	if (!WINPR_JSON_IsObject(item))
+	{
+		WLog_WARN(TAG, "[%s] entry %" PRIuz " ignored: not a JSON object", path, index);
+		return FALSE;
+	}
+
+	const char* name = aad_cloud_json_string(item, "name");
+	const char* authority = aad_cloud_json_string(item, "active_directory");
+	const char* scope = aad_cloud_json_string(item, "avd_scope");
+	const char* redirect = aad_cloud_json_string(item, "avd_redirect_format");
+	const char* suffix = aad_cloud_json_string(item, "gateway_suffix");
+
+	if (!aad_cloud_valid_name(name))
+	{
+		WLog_WARN(TAG,
+		          "[%s] entry %" PRIuz
+		          " ignored: 'name' is missing or not a [a-z0-9-] string, got '%s'",
+		          path, index, name ? name : "");
+		return FALSE;
+	}
+	if (!aad_cloud_valid_authority(authority))
+	{
+		WLog_WARN(TAG,
+		          "[%s] entry %" PRIuz " ('%s') ignored: 'active_directory' is missing or not a "
+		          "host name without scheme or path, got '%s'",
+		          path, index, name, authority ? authority : "");
+		return FALSE;
+	}
+	if (!aad_cloud_valid_url_value(scope))
+	{
+		WLog_WARN(TAG,
+		          "[%s] entry %" PRIuz
+		          " ('%s') ignored: 'avd_scope' is missing or not a percent encoded value",
+		          path, index, name);
+		return FALSE;
+	}
+	if (!aad_cloud_valid_redirect_format(redirect))
+	{
+		WLog_WARN(TAG,
+		          "[%s] entry %" PRIuz " ('%s') ignored: 'avd_redirect_format' is missing or not a "
+		          "format string of literal text, '%%%%' and at most %d '%%s'",
+		          path, index, name, AAD_CLOUD_REDIRECT_CONVERSIONS);
+		return FALSE;
+	}
+	if (WINPR_JSON_HasObjectItem(item, "gateway_suffix") && !aad_cloud_valid_gateway_suffix(suffix))
+	{
+		WLog_WARN(TAG,
+		          "[%s] entry %" PRIuz " ('%s') ignored: 'gateway_suffix' is not a host name "
+		          "starting with the '.' of a label boundary, got '%s'",
+		          path, index, name, suffix ? suffix : "");
+		return FALSE;
+	}
+
+	/* Accepted so that a file can carry the ARM endpoint of its cloud the way 'az cloud show'
+	 * spells it, but nothing reads it: no setting of libfreerdp holds an ARM endpoint. */
+	if (WINPR_JSON_HasObjectItem(item, "resource_manager"))
+	{
+		WLog_DBG(TAG,
+		         "[%s] entry %" PRIuz " ('%s'): 'resource_manager' is accepted and ignored, no "
+		         "setting holds an ARM endpoint",
+		         path, index, name);
+	}
+
+	const FreeRDP_AadCloud parsed = { name, suffix, authority, scope, redirect };
+	if (!aad_cloud_entry_copy(cloud, &parsed))
+	{
+		WLog_ERR(TAG, "[%s] entry %" PRIuz " ('%s') ignored: out of memory", path, index, name);
+		return FALSE;
+	}
+	return TRUE;
+}
+
+/** Merges the clouds of one configuration file into the table.
+ *
+ * A missing file is the normal case and leaves the table alone, and so does a file that does
+ * not parse or does not hold an array: the compiled defaults are what a broken file falls back
+ * to. A single malformed entry only costs its own cloud, its siblings are still loaded.
+ */
+static void aad_cloud_load_file(BOOL system, FreeRDP_AadCloud** ptable, size_t* pcount)
+{
+	char* path = freerdp_GetConfigFilePath(system, AAD_CLOUDS_CONFIG_FILE);
+	if (!path)
+		return;
+
+	WINPR_JSON* json = freerdp_GetJSONConfigFile(system, AAD_CLOUDS_CONFIG_FILE);
+	if (!json)
+	{
+		if (winpr_PathFileExists(path))
+			WLog_WARN(TAG, "[%s] ignored: the file does not parse as JSON", path);
+		else
+			WLog_DBG(TAG, "[%s] no AVD cloud configuration file", path);
+		goto fail;
+	}
+
+	if (!WINPR_JSON_IsArray(json))
+	{
+		WLog_WARN(TAG, "[%s] ignored: expected a JSON array of cloud objects", path);
+		goto fail;
+	}
+
+	const size_t count = WINPR_JSON_GetArraySize(json);
+	for (size_t x = 0; x < count; x++)
+	{
+		FreeRDP_AadCloud entry = { nullptr, nullptr, nullptr, nullptr, nullptr };
+		if (!aad_cloud_parse_entry(path, x, WINPR_JSON_GetArrayItem(json, x), &entry))
+			continue;
+
+		WLog_DBG(TAG, "[%s] configured AVD cloud '%s'", path, entry.name);
+		if (!aad_cloud_table_merge(ptable, pcount, &entry))
+		{
+			WLog_ERR(TAG, "[%s] entry %" PRIuz " ignored: out of memory", path, x);
+			aad_cloud_entry_free(&entry);
+		}
+	}
+
+fail:
+	WINPR_JSON_Delete(json);
+	free(path);
+}
+
+static BOOL CALLBACK aad_clouds_init(WINPR_ATTR_UNUSED PINIT_ONCE once,
+                                     WINPR_ATTR_UNUSED PVOID param,
+                                     WINPR_ATTR_UNUSED PVOID* context)
+{
+	FreeRDP_AadCloud* table = nullptr;
+	size_t count = 0;
+
+	/* The user file is merged last, so that it wins over the system one. */
+	aad_cloud_load_file(TRUE, &table, &count);
+	aad_cloud_load_file(FALSE, &table, &count);
+
+	aad_clouds_configured = table;
+	aad_clouds_configured_count = count;
+	return TRUE;
+}
+
+/** @return The table the lookups run against: the compiled one, or the configured one while a
+ * configuration file contributed an entry. */
+static const FreeRDP_AadCloud* aad_cloud_table(size_t* pcount)
+{
+	WINPR_ASSERT(pcount);
+
+	if (InitOnceExecuteOnce(&aad_clouds_once, aad_clouds_init, nullptr, nullptr) &&
+	    aad_clouds_configured)
+	{
+		*pcount = aad_clouds_configured_count;
+		return aad_clouds_configured;
+	}
+
+	*pcount = ARRAYSIZE(aad_clouds);
+	return aad_clouds;
+}
+
+void freerdp_utils_aad_cloud_table_reset(void)
+{
+	aad_cloud_table_free(aad_clouds_configured, aad_clouds_configured_count);
+	aad_clouds_configured = nullptr;
+	aad_clouds_configured_count = 0;
+
+	/* InitOnceInitialize() is a stub wherever WinPR implements the run-once itself, so the
+	 * value is assigned from a static initializer instead. */
+	const INIT_ONCE once = INIT_ONCE_STATIC_INIT;
+	aad_clouds_once = once;
+}
+
 #define AAD_CLOUD_GETTER(_name, _field)                                            \
 	const char* freerdp_utils_aad_cloud_get_##_name(const FreeRDP_AadCloud* cloud) \
 	{                                                                              \
@@ -79,10 +487,12 @@ const FreeRDP_AadCloud* freerdp_utils_aad_cloud_by_name(const char* name)
 	if (!name)
 		return nullptr;
 
-	for (size_t x = 0; x < ARRAYSIZE(aad_clouds); x++)
+	size_t count = 0;
+	const FreeRDP_AadCloud* clouds = aad_cloud_table(&count);
+	for (size_t x = 0; x < count; x++)
 	{
-		if (_stricmp(name, aad_clouds[x].name) == 0)
-			return &aad_clouds[x];
+		if (_stricmp(name, clouds[x].name) == 0)
+			return &clouds[x];
 	}
 	return nullptr;
 }
@@ -92,16 +502,18 @@ const FreeRDP_AadCloud* freerdp_utils_aad_cloud_for_gateway(const char* hostname
 	if (!hostname)
 		return nullptr;
 
+	size_t count = 0;
+	const FreeRDP_AadCloud* clouds = aad_cloud_table(&count);
 	const size_t hostlen = strlen(hostname);
-	for (size_t x = 0; x < ARRAYSIZE(aad_clouds); x++)
+	for (size_t x = 0; x < count; x++)
 	{
-		const char* suffix = aad_clouds[x].gateway_suffix;
+		const char* suffix = clouds[x].gateway_suffix;
 		if (!suffix)
 			continue;
 
 		const size_t suffixlen = strlen(suffix);
 		if ((hostlen >= suffixlen) && (_stricmp(&hostname[hostlen - suffixlen], suffix) == 0))
-			return &aad_clouds[x];
+			return &clouds[x];
 	}
 	return nullptr;
 }

--- a/libfreerdp/core/aad.c
+++ b/libfreerdp/core/aad.c
@@ -33,8 +33,108 @@
 
 #include "transport.h"
 #include "rdp.h"
+#include "settings.h"
 
 #include "aad.h"
+
+#include <freerdp/log.h>
+#define TAG FREERDP_TAG("core.aad")
+
+struct freerdp_aad_cloud
+{
+	const char* name;
+	const char* gateway_suffix;
+	const char* authority;
+	const char* avd_scope;
+	const char* avd_redirect_format;
+};
+
+static const FreeRDP_AadCloud aad_clouds[] = {
+	{ "commercial", nullptr, "login.microsoftonline.com",
+	  "https%3A%2F%2Fwww.wvd.microsoft.com%2F.default%20openid%20profile%20offline_access",
+	  "https%%3A%%2F%%2F%s%%2F%s%%2Foauth2%%2Fnativeclient" },
+	{ "usgov", ".wvd.azure.us", "login.microsoftonline.us",
+	  "https%3A%2F%2Fwww.wvd.azure.us%2F.default%20openid%20profile%20offline_access",
+	  /* Redirect URIs for this public client are fixed in the Azure registration (see #11032);
+	   * only the scope changes per cloud. Verified against a US Government tenant: the
+	   * .com/common redirect below works end to end; the sovereign login.microsoftonline.us
+	   * form is rejected by Entra with AADSTS50011 (app a85cf173-4192-42f8-81fa-777a763e6e2c). */
+	  "https%%3A%%2F%%2Flogin.microsoftonline.com%%2Fcommon%%2Foauth2%%2Fnativeclient" }
+};
+
+#define AAD_CLOUD_GETTER(_name, _field)                                            \
+	const char* freerdp_utils_aad_cloud_get_##_name(const FreeRDP_AadCloud* cloud) \
+	{                                                                              \
+		return cloud ? cloud->_field : nullptr;                                    \
+	}
+
+AAD_CLOUD_GETTER(name, name)
+AAD_CLOUD_GETTER(gateway_suffix, gateway_suffix)
+AAD_CLOUD_GETTER(authority, authority)
+AAD_CLOUD_GETTER(avd_scope, avd_scope)
+AAD_CLOUD_GETTER(avd_redirect_format, avd_redirect_format)
+
+const FreeRDP_AadCloud* freerdp_utils_aad_cloud_by_name(const char* name)
+{
+	if (!name)
+		return nullptr;
+
+	for (size_t x = 0; x < ARRAYSIZE(aad_clouds); x++)
+	{
+		if (_stricmp(name, aad_clouds[x].name) == 0)
+			return &aad_clouds[x];
+	}
+	return nullptr;
+}
+
+const FreeRDP_AadCloud* freerdp_utils_aad_cloud_for_gateway(const char* hostname)
+{
+	if (!hostname)
+		return nullptr;
+
+	const size_t hostlen = strlen(hostname);
+	for (size_t x = 0; x < ARRAYSIZE(aad_clouds); x++)
+	{
+		const char* suffix = aad_clouds[x].gateway_suffix;
+		if (!suffix)
+			continue;
+
+		const size_t suffixlen = strlen(suffix);
+		if ((hostlen >= suffixlen) && (_stricmp(&hostname[hostlen - suffixlen], suffix) == 0))
+			return &aad_clouds[x];
+	}
+	return nullptr;
+}
+
+BOOL freerdp_utils_aad_apply_cloud(rdpSettings* settings, const FreeRDP_AadCloud* cloud)
+{
+	if (!settings || !cloud)
+		return FALSE;
+
+	/* Allocate all three replacements before transferring ownership of any of them, so an
+	 * allocation failure can not leave a partially applied cloud behind. */
+	char* authority = _strdup(cloud->authority);
+	char* scope = _strdup(cloud->avd_scope);
+	char* redirect = _strdup(cloud->avd_redirect_format);
+	if (!authority || !scope || !redirect)
+	{
+		free(authority);
+		free(scope);
+		free(redirect);
+		return FALSE;
+	}
+
+	/* These ownership-transfer setters can not fail for allocated, non-null strings. */
+	BOOL rc = freerdp_settings_set_string_(settings, FreeRDP_GatewayAzureActiveDirectory, authority,
+	                                       strlen(authority));
+	WINPR_ASSERT(rc);
+	rc = freerdp_settings_set_string_(settings, FreeRDP_GatewayAvdScope, scope, strlen(scope));
+	WINPR_ASSERT(rc);
+	rc = freerdp_settings_set_string_(settings, FreeRDP_GatewayAvdAccessAadFormat, redirect,
+	                                  strlen(redirect));
+	WINPR_ASSERT(rc);
+	return TRUE;
+}
 
 struct rdp_aad
 {

--- a/libfreerdp/core/aad.h
+++ b/libfreerdp/core/aad.h
@@ -50,4 +50,14 @@ WINPR_ATTR_MALLOC(aad_free, 1)
 WINPR_ATTR_NODISCARD
 FREERDP_LOCAL rdpAad* aad_new(rdpContext* context);
 
+/** Drops the AVD cloud table loaded from the configuration files.
+ *
+ * The table is loaded once, the first time a cloud is looked up. This is a test seam: it lets a
+ * test run several configurations in one process. Core-private, so it is only linkable from
+ * tests built with BUILD_TESTING_INTERNAL, which exports all symbols.
+ *
+ * It is not thread safe and it invalidates every cloud description a lookup returned before.
+ */
+FREERDP_LOCAL void freerdp_utils_aad_cloud_table_reset(void);
+
 #endif /* FREERDP_LIB_CORE_AAD_H */

--- a/libfreerdp/core/test/CMakeLists.txt
+++ b/libfreerdp/core/test/CMakeLists.txt
@@ -13,6 +13,9 @@ if(BUILD_TESTING_INTERNAL)
   list(APPEND TESTS TestStreamDump.c TestRdstls.c TestServerChannels.c)
 endif()
 
+# The AVD cloud table is part of libfreerdp in every configuration, WITH_AAD or not.
+list(APPEND TESTS TestAadCloud.c)
+
 set(FUZZERS TestFuzzCoreClient.c TestFuzzCoreServer.c TestFuzzCryptoCertificateDataSetPEM.c)
 
 # TestFuzzServer generates a live cert via winpr-tools (makecert).

--- a/libfreerdp/core/test/TestAadCloud.c
+++ b/libfreerdp/core/test/TestAadCloud.c
@@ -1,8 +1,20 @@
+#include <stdio.h>
+
 #include <freerdp/freerdp.h>
 #include <freerdp/settings.h>
 #include <freerdp/utils/aad.h>
+#include <freerdp/utils/helpers.h>
 
 #include <winpr/crt.h>
+#include <winpr/crypto.h>
+#include <winpr/environment.h>
+#include <winpr/file.h>
+#include <winpr/path.h>
+#include <winpr/string.h>
+
+#if defined(BUILD_TESTING_INTERNAL)
+#include "../aad.h"
+#endif
 
 static const char commercial_scope[] =
     "https%3A%2F%2Fwww.wvd.microsoft.com%2F.default%20openid%20profile%20offline_access";
@@ -101,14 +113,371 @@ fail:
 	return rc;
 }
 
+/** The directory XDG_CONFIG_HOME points at while the test runs. */
+static char* config_home = nullptr;
+
+/** The user aad-clouds.json inside it, in whatever layout the build resolves it to. */
+static char* config_file = nullptr;
+
+static char* append(const char* fmt, ...)
+{
+	va_list ap = WINPR_C_ARRAY_INIT;
+
+	va_start(ap, fmt);
+	char* str = nullptr;
+	size_t len = 0;
+	const int rc = winpr_vasprintf(&str, &len, fmt, ap);
+	va_end(ap);
+
+	if (rc <= 0)
+		return nullptr;
+	return str;
+}
+
+/** Points XDG_CONFIG_HOME at an empty directory, so that the test neither reads the
+ *  configuration of the user running it nor writes into it. */
+static BOOL config_setup(void)
+{
+	UINT64 id = 0;
+	if (winpr_RAND(&id, sizeof(id)) < 0)
+		return FALSE;
+
+	char* tmp = GetKnownPath(KNOWN_PATH_TEMP);
+	if (!tmp)
+		return FALSE;
+
+	config_home = append("%s/aad-cloud-test-%" PRIx64, tmp, id);
+	free(tmp);
+
+	if (!config_home || !winpr_PathMakePath(config_home, nullptr))
+		return FALSE;
+
+	if (!SetEnvironmentVariableA("XDG_CONFIG_HOME", config_home))
+		return FALSE;
+
+	config_file = freerdp_GetConfigFilePath(FALSE, "aad-clouds.json");
+	if (!config_file)
+		return FALSE;
+
+	/* Which subdirectory of the configuration home holds the file depends on the build
+	 * options, so the directory to create is taken from the path the library resolves. */
+	char* sep = strrchr(config_file, '/');
+#if defined(_WIN32)
+	char* winsep = strrchr(config_file, '\\');
+	if (winsep > sep)
+		sep = winsep;
+#endif
+	if (!sep)
+		return FALSE;
+
+	const char separator = *sep;
+	*sep = '\0';
+	const BOOL rc = winpr_PathMakePath(config_file, nullptr);
+	*sep = separator;
+	return rc;
+}
+
+static void config_cleanup(void)
+{
+	if (config_home)
+		winpr_RemoveDirectory_RecursiveA(config_home);
+	free(config_home);
+	free(config_file);
+	config_home = nullptr;
+	config_file = nullptr;
+}
+
+#if defined(BUILD_TESTING_INTERNAL)
+/** Writes the configuration file and drops the table, which is otherwise loaded once. */
+static BOOL config_write(const char* content)
+{
+	FILE* fp = winpr_fopen(config_file, "w");
+	if (!fp)
+		return FALSE;
+
+	const size_t len = strlen(content);
+	const BOOL rc = fwrite(content, 1, len, fp) == len;
+	(void)fclose(fp);
+
+	freerdp_utils_aad_cloud_table_reset();
+	return rc;
+}
+
+static void config_remove(void)
+{
+	(void)winpr_DeleteFile(config_file);
+	freerdp_utils_aad_cloud_table_reset();
+}
+
+static BOOL check_cloud(const char* name, const char* authority, const char* suffix)
+{
+	const FreeRDP_AadCloud* cloud = freerdp_utils_aad_cloud_by_name(name);
+	if (!cloud)
+	{
+		(void)fprintf(stderr, "cloud '%s' not found\n", name);
+		return FALSE;
+	}
+
+	const char* actual = freerdp_utils_aad_cloud_get_authority(cloud);
+	if (!actual || (strcmp(actual, authority) != 0))
+	{
+		(void)fprintf(stderr, "cloud '%s' has authority '%s', expected '%s'\n", name,
+		              actual ? actual : "", authority);
+		return FALSE;
+	}
+
+	const char* gateway = freerdp_utils_aad_cloud_get_gateway_suffix(cloud);
+	if (suffix)
+	{
+		if (!gateway || (strcmp(gateway, suffix) != 0))
+		{
+			(void)fprintf(stderr, "cloud '%s' has gateway suffix '%s', expected '%s'\n", name,
+			              gateway ? gateway : "", suffix);
+			return FALSE;
+		}
+	}
+	else if (gateway)
+	{
+		(void)fprintf(stderr, "cloud '%s' has gateway suffix '%s', expected none\n", name, gateway);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/** The compiled clouds, which every case that does not override them expects to find. */
+static BOOL check_defaults(void)
+{
+	return check_cloud("commercial", "login.microsoftonline.com", nullptr) &&
+	       check_cloud("usgov", "login.microsoftonline.us", ".wvd.azure.us");
+}
+
+/** A valid entry adding a cloud, as a literal: it is an argument of append(), not a format. */
+static const char valid_entry[] =
+    "\t{\n"
+    "\t\t\"name\": \"example\",\n"
+    "\t\t\"active_directory\": \"login.example.test\",\n"
+    "\t\t\"gateway_suffix\": \".wvd.example.test\",\n"
+    "\t\t\"avd_scope\": \"https%3A%2F%2Fwww.wvd.example.test%2F.default%20openid\",\n"
+    "\t\t\"avd_redirect_format\": \"https%%3A%%2F%%2F%s%%2F%s%%2Foauth2%%2Fnativeclient\"\n"
+    "\t}";
+
+static BOOL test_config_none(void)
+{
+	/* Nothing was written yet, so this is what a missing configuration file looks like. */
+	freerdp_utils_aad_cloud_table_reset();
+	return check_defaults() && !freerdp_utils_aad_cloud_by_name("example") &&
+	       !freerdp_utils_aad_cloud_for_gateway("host.wvd.example.test");
+}
+
+static BOOL test_config_override(void)
+{
+	BOOL rc = FALSE;
+	const FreeRDP_AadCloud* example = nullptr;
+	rdpSettings* settings = nullptr;
+	char* content = append("[\n"
+	                       "\t{\n"
+	                       "\t\t\"name\": \"usgov\",\n"
+	                       "\t\t\"active_directory\": \"login.microsoftonline.test\",\n"
+	                       "\t\t\"gateway_suffix\": \".wvd.azure.us\",\n"
+	                       "\t\t\"avd_scope\": \"https%%3A%%2F%%2Fwww.wvd.azure.us%%2F.default\",\n"
+	                       "\t\t\"avd_redirect_format\": \"https%%%%3A%%%%2F%%%%2F%%s%%%%2F%%s"
+	                       "%%%%2Foauth2%%%%2Fnativeclient\",\n"
+	                       "\t\t\"resource_manager\": \"https://management.usgovcloudapi.net/\"\n"
+	                       "\t},\n"
+	                       "%s\n"
+	                       "]\n",
+	                       valid_entry);
+	if (!content)
+		return FALSE;
+
+	if (!config_write(content))
+		goto fail;
+
+	/* The entry naming a compiled cloud replaces it, the other one is added. */
+	if (!check_cloud("commercial", "login.microsoftonline.com", nullptr) ||
+	    !check_cloud("usgov", "login.microsoftonline.test", ".wvd.azure.us") ||
+	    !check_cloud("example", "login.example.test", ".wvd.example.test"))
+		goto fail;
+
+	/* A configured cloud is selected by a gateway hostname and applies like a compiled one. */
+	example = freerdp_utils_aad_cloud_by_name("example");
+	if ((freerdp_utils_aad_cloud_for_gateway("gateway.WVD.example.TEST") != example) ||
+	    (freerdp_utils_aad_cloud_for_gateway("host.wvd.azure.us") !=
+	     freerdp_utils_aad_cloud_by_name("usgov")))
+		goto fail;
+
+	settings = freerdp_settings_new(0);
+	if (!settings)
+		goto fail;
+
+	rc = freerdp_utils_aad_apply_cloud(settings, example) &&
+	     check_string(settings, FreeRDP_GatewayAzureActiveDirectory, "login.example.test");
+
+fail:
+	freerdp_settings_free(settings);
+	free(content);
+	return rc;
+}
+
+static BOOL test_config_malformed(void)
+{
+	BOOL rc = FALSE;
+	char* content = append("[\n"
+	                       "\t\"not an object\",\n"
+	                       "\t{ \"name\": \"BAD NAME\" },\n"
+	                       "\t{\n"
+	                       "\t\t\"name\": \"scheme\",\n"
+	                       "\t\t\"active_directory\": \"https://login.example.test/common\",\n"
+	                       "\t\t\"avd_scope\": \"https%%3A%%2F%%2Fwww.example.test%%2F.default\",\n"
+	                       "\t\t\"avd_redirect_format\": \"https%%%%3A%%%%2F%%%%2F%%s\"\n"
+	                       "\t},\n"
+	                       "\t{\n"
+	                       "\t\t\"name\": \"noboundary\",\n"
+	                       "\t\t\"active_directory\": \"login.example.test\",\n"
+	                       "\t\t\"gateway_suffix\": \"wvd.example.test\",\n"
+	                       "\t\t\"avd_scope\": \"https%%3A%%2F%%2Fwww.example.test%%2F.default\",\n"
+	                       "\t\t\"avd_redirect_format\": \"https%%%%3A%%%%2F%%%%2F%%s\"\n"
+	                       "\t},\n"
+	                       "%s\n"
+	                       "]\n",
+	                       valid_entry);
+	if (!content)
+		return FALSE;
+
+	if (!config_write(content))
+		goto fail;
+
+	/* Every malformed entry is skipped, its valid siblings and the defaults are kept. */
+	rc = check_defaults() && check_cloud("example", "login.example.test", ".wvd.example.test") &&
+	     !freerdp_utils_aad_cloud_by_name("scheme") &&
+	     !freerdp_utils_aad_cloud_by_name("noboundary") &&
+	     !freerdp_utils_aad_cloud_by_name("BAD NAME");
+
+fail:
+	free(content);
+	return rc;
+}
+
+static BOOL test_config_format(void)
+{
+	/* '%n' writes through whatever winpr_asprintf finds on the argument list and three '%s'
+	 * read past its end, so both are rejected, and so is a trailing '%'. */
+	const char* formats[] = { "https%%3A%%2F%%2F%n", "https%%3A%%2F%%2F%s%%2F%s%%2F%s",
+		                      "https%%3A%%2F%%2F%" };
+
+	for (size_t x = 0; x < ARRAYSIZE(formats); x++)
+	{
+		char* content = append("[\n"
+		                       "\t{\n"
+		                       "\t\t\"name\": \"example\",\n"
+		                       "\t\t\"active_directory\": \"login.example.test\",\n"
+		                       "\t\t\"avd_scope\": \"https%%3A%%2F%%2Fwww.example.test%%2F"
+		                       ".default\",\n"
+		                       "\t\t\"avd_redirect_format\": \"%s\"\n"
+		                       "\t}\n"
+		                       "]\n",
+		                       formats[x]);
+		if (!content)
+			return FALSE;
+
+		const BOOL written = config_write(content);
+		free(content);
+		if (!written)
+			return FALSE;
+
+		if (freerdp_utils_aad_cloud_by_name("example"))
+		{
+			(void)fprintf(stderr, "redirect format '%s' was accepted\n", formats[x]);
+			return FALSE;
+		}
+		if (!check_defaults())
+			return FALSE;
+	}
+
+	return TRUE;
+}
+
+static BOOL test_config_broken_file(void)
+{
+	/* A file that does not parse, and one that is not an array, are ignored as a whole. */
+	if (!config_write("this is not JSON") || !check_defaults())
+		return FALSE;
+
+	return config_write("{ \"name\": \"example\" }\n") && check_defaults() &&
+	       !freerdp_utils_aad_cloud_by_name("example");
+}
+
+static BOOL test_config_sample(void)
+{
+	/* The sample shipped with the documentation has to stay loadable. */
+	const char sample[] = TESTING_SRC_DIRECTORY "/docs/aad-clouds.example.json";
+	BOOL rc = FALSE;
+	char* content = nullptr;
+	FILE* fp = winpr_fopen(sample, "rb");
+	if (!fp)
+	{
+		(void)fprintf(stderr, "failed to open '%s'\n", sample);
+		return FALSE;
+	}
+
+	if (fseek(fp, 0, SEEK_END) != 0)
+		goto fail;
+
+	const long size = ftell(fp);
+	if ((size <= 0) || (fseek(fp, 0, SEEK_SET) != 0))
+		goto fail;
+
+	content = calloc((size_t)size + 1, sizeof(char));
+	if (!content || (fread(content, 1, (size_t)size, fp) != (size_t)size))
+		goto fail;
+
+	if (!config_write(content))
+		goto fail;
+
+	/* Its usgov entry repeats the compiled values, its example entry adds a cloud. */
+	rc = check_defaults() && check_cloud("example", "login.example.test", ".wvd.example.test");
+
+fail:
+	(void)fclose(fp);
+	free(content);
+	return rc;
+}
+
+static BOOL test_config(void)
+{
+	const BOOL rc = test_config_none() && test_config_override() && test_config_malformed() &&
+	                test_config_format() && test_config_broken_file() && test_config_sample();
+
+	/* Leave the process with the compiled table, whatever happened above. */
+	config_remove();
+	return rc;
+}
+#endif
+
 int TestAadCloud(int argc, char* argv[])
 {
 	WINPR_UNUSED(argc);
 	WINPR_UNUSED(argv);
 
+	int rc = -1;
+
+	/* Before the first lookup, so that neither the configuration of the user running the test
+	 * nor a file this test writes is read by accident. */
+	if (!config_setup())
+		goto fail;
+
 	if (!test_lookup())
-		return -1;
+		goto fail;
 	if (!test_apply())
-		return -1;
-	return 0;
+		goto fail;
+#if defined(BUILD_TESTING_INTERNAL)
+	if (!test_config())
+		goto fail;
+#endif
+
+	rc = 0;
+fail:
+	config_cleanup();
+	return rc;
 }

--- a/libfreerdp/core/test/TestAadCloud.c
+++ b/libfreerdp/core/test/TestAadCloud.c
@@ -1,0 +1,114 @@
+#include <freerdp/freerdp.h>
+#include <freerdp/settings.h>
+#include <freerdp/utils/aad.h>
+
+#include <winpr/crt.h>
+
+static const char commercial_scope[] =
+    "https%3A%2F%2Fwww.wvd.microsoft.com%2F.default%20openid%20profile%20offline_access";
+static const char commercial_redirect[] = "https%%3A%%2F%%2F%s%%2F%s%%2Foauth2%%2Fnativeclient";
+static const char usgov_scope[] =
+    "https%3A%2F%2Fwww.wvd.azure.us%2F.default%20openid%20profile%20offline_access";
+static const char usgov_redirect[] =
+    "https%%3A%%2F%%2Flogin.microsoftonline.com%%2Fcommon%%2Foauth2%%2Fnativeclient";
+
+static BOOL check_string(const rdpSettings* settings, FreeRDP_Settings_Keys_String key,
+                         const char* expected)
+{
+	const char* actual = freerdp_settings_get_string(settings, key);
+	return actual && (strcmp(actual, expected) == 0);
+}
+
+static BOOL test_lookup(void)
+{
+	const FreeRDP_AadCloud* commercial = freerdp_utils_aad_cloud_by_name("commercial");
+	const FreeRDP_AadCloud* usgov = freerdp_utils_aad_cloud_by_name("usgov");
+
+	if (!commercial || !usgov || (commercial == usgov) ||
+	    (freerdp_utils_aad_cloud_by_name("USGOV") != usgov) ||
+	    freerdp_utils_aad_cloud_by_name(nullptr) || freerdp_utils_aad_cloud_by_name("unknown"))
+		return FALSE;
+
+	/* Only a cloud with a gateway suffix takes part in the hostname lookup. */
+	if (freerdp_utils_aad_cloud_get_gateway_suffix(commercial) ||
+	    freerdp_utils_aad_cloud_for_gateway(nullptr) ||
+	    freerdp_utils_aad_cloud_for_gateway("gateway.wvd.azure.com") ||
+	    freerdp_utils_aad_cloud_for_gateway("xwvd.azure.us") ||
+	    (freerdp_utils_aad_cloud_for_gateway("gateway.WVD.AZURE.US") != usgov) ||
+	    (freerdp_utils_aad_cloud_for_gateway("gateway.wvd.azure.us") != usgov))
+		return FALSE;
+
+	if (strcmp(freerdp_utils_aad_cloud_get_name(commercial), "commercial") ||
+	    strcmp(freerdp_utils_aad_cloud_get_authority(commercial), "login.microsoftonline.com") ||
+	    strcmp(freerdp_utils_aad_cloud_get_avd_scope(commercial), commercial_scope) ||
+	    strcmp(freerdp_utils_aad_cloud_get_avd_redirect_format(commercial), commercial_redirect))
+		return FALSE;
+
+	if (strcmp(freerdp_utils_aad_cloud_get_name(usgov), "usgov") ||
+	    strcmp(freerdp_utils_aad_cloud_get_gateway_suffix(usgov), ".wvd.azure.us") ||
+	    strcmp(freerdp_utils_aad_cloud_get_authority(usgov), "login.microsoftonline.us") ||
+	    strcmp(freerdp_utils_aad_cloud_get_avd_scope(usgov), usgov_scope) ||
+	    strcmp(freerdp_utils_aad_cloud_get_avd_redirect_format(usgov), usgov_redirect))
+		return FALSE;
+
+	return !freerdp_utils_aad_cloud_get_name(nullptr) &&
+	       !freerdp_utils_aad_cloud_get_gateway_suffix(nullptr) &&
+	       !freerdp_utils_aad_cloud_get_authority(nullptr) &&
+	       !freerdp_utils_aad_cloud_get_avd_scope(nullptr) &&
+	       !freerdp_utils_aad_cloud_get_avd_redirect_format(nullptr);
+}
+
+static BOOL test_apply(void)
+{
+	const FreeRDP_AadCloud* commercial = freerdp_utils_aad_cloud_by_name("commercial");
+	const FreeRDP_AadCloud* usgov = freerdp_utils_aad_cloud_by_name("usgov");
+	rdpSettings* settings = freerdp_settings_new(0);
+	BOOL rc = FALSE;
+
+	if (!commercial || !usgov || !settings)
+		goto fail;
+
+	/* The defaults of a fresh settings instance are the commercial cloud. */
+	if (!check_string(settings, FreeRDP_GatewayAzureActiveDirectory, "login.microsoftonline.com") ||
+	    !check_string(settings, FreeRDP_GatewayAvdScope, commercial_scope) ||
+	    !check_string(settings, FreeRDP_GatewayAvdAccessAadFormat, commercial_redirect))
+		goto fail;
+
+	/* Applying a cloud writes exactly the three cloud-owned strings, unconditionally. */
+	if (!freerdp_settings_set_string(settings, FreeRDP_GatewayAvdScope, "custom-scope") ||
+	    !freerdp_settings_set_bool(settings, FreeRDP_GatewayAvdUseTenantid, TRUE) ||
+	    !freerdp_utils_aad_apply_cloud(settings, usgov) ||
+	    !check_string(settings, FreeRDP_GatewayAzureActiveDirectory, "login.microsoftonline.us") ||
+	    !check_string(settings, FreeRDP_GatewayAvdScope, usgov_scope) ||
+	    !check_string(settings, FreeRDP_GatewayAvdAccessAadFormat, usgov_redirect) ||
+	    !freerdp_settings_get_bool(settings, FreeRDP_GatewayAvdUseTenantid))
+		goto fail;
+
+	if (!freerdp_utils_aad_apply_cloud(settings, commercial) ||
+	    !check_string(settings, FreeRDP_GatewayAzureActiveDirectory, "login.microsoftonline.com") ||
+	    !check_string(settings, FreeRDP_GatewayAvdScope, commercial_scope) ||
+	    !check_string(settings, FreeRDP_GatewayAvdAccessAadFormat, commercial_redirect) ||
+	    !freerdp_settings_get_bool(settings, FreeRDP_GatewayAvdUseTenantid))
+		goto fail;
+
+	if (freerdp_utils_aad_apply_cloud(nullptr, usgov) ||
+	    freerdp_utils_aad_apply_cloud(settings, nullptr))
+		goto fail;
+
+	rc = TRUE;
+fail:
+	freerdp_settings_free(settings);
+	return rc;
+}
+
+int TestAadCloud(int argc, char* argv[])
+{
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+
+	if (!test_lookup())
+		return -1;
+	if (!test_apply())
+		return -1;
+	return 0;
+}


### PR DESCRIPTION
> **Disclosure:** This pull request, including the code and this description, was prepared with AI assistance (Anthropic Claude and OpenAI Codex agents, orchestrated by the author).
> **Status:** **Hardware-tested by the author on 2026-09-03** against Azure Virtual Desktop in Azure US Government (DoD tenant region) with a PIV smart card, using the terminal paste flow of `sdl-freerdp` built from the combined branch (Firefox handled the certificate and PIN). Cloud selection, `.us` discovery, state+PKCE on both authorization requests, callback parsing, the ARM step and RDS-AAD negotiation all succeeded and the desktop appeared. Unit tests pass on Fedora 44 (gcc 16, FreeRDP master).

Branch: `aad/sovereign-cloud` (3 commits on `upstream/master`). Independent of #13327 (ARM response timeout) and #13328 (OAuth hardening, whose PKCE is what keeps the transiting code unusable); all merge cleanly together.

> Combined branch with the ARM, OAuth and sovereign-cloud series stacked for end-to-end testing: `sjtrotter/FreeRDP` branch `avd/sovereign-oauth-upstream`.

## Why

FreeRDP only knows the commercial cloud: `libfreerdp/core/settings.c` hard-codes `login.microsoftonline.com`, the
`wvd.microsoft.com` scope, the redirect format and the AVD public client id as defaults. A `.rdpw` whose gateway lives in `*.wvd.azure.us` fails against `login.microsoftonline.us` unless every frontend carries its own copy of the Government constants (Remmina's copy is an 82-line header). The constants are public service metadata that belongs next to the commercial ones already in libfreerdp; *choosing* a cloud automatically is client policy and stays in libfreerdp-client.

## Commits

1. `[utils,aad] add sovereign cloud table for AVD authentication` (libfreerdp) — opaque `FreeRDP_AadCloud`, entries `commercial` and `usgov` only (`.wvd.azure.us` → authority `login.microsoftonline.us`, scope `https://www.wvd.azure.us/.default …`, and the `/common/oauth2/nativeclient` redirect registered for the AVD public client), `freerdp_utils_aad_cloud_by_name()`, `freerdp_utils_aad_cloud_for_gateway()` (case-insensitive suffix match on a label boundary), getters, and the explicit `freerdp_utils_aad_apply_cloud()` which writes the three cloud-owned strings, preallocating all replacements before transferring ownership so it cannot leave a partial update. `TestAadCloud` covers lookups, getters and apply. No other cloud is included; nothing unverified was added.
2. `[client,common] select the AVD sovereign cloud of an ARM gateway` (libfreerdp-client) — `freerdp_client_settings_apply_avd_cloud()` (`@since 3.32.0`): when `GatewayArmTransport` is set and the gateway host matches a cloud, apply each value only while that setting still holds the commercial default (an explicit `/azure:ad:`, `avd-scope:` or `avd-access:` is never overwritten); derive `GatewayAvdUseTenantid` from a non-default tenant id unless `/azure:use-tenantid` was given explicitly. It runs exactly once per parse: at the end of the public `.rdp` entry points for API users, and once after all command-line options (the command line loads an `.rdp` without applying, so a later option can still change the gateway or authority). New `/gateway:cloud:<commercial|usgov>`  applies a table entry at the point it is parsed (last option wins against `/azure:` on the same line), suppresses the automatic selection, and gets the same tenant derivation; an unknown name is a command-line error. API frontends call the function once before connecting. TestClientCmdLine cases cover automatic selection, mixed-case hosts, tenant derivation, `use-tenantid:off` honoured, customized scope surviving, non-ARM unchanged, explicit `cloud:` with and without a tenant id, `cloud:` versus a later or earlier `/azure:avd-scope:`, an `.rdp` followed by a commercial gateway or a custom authority on the command line, and the unknown-name error.
3. `[client,common] test AVD rdp file coverage` — synthetic `avd-usgov.rdp` / `avd-commercial.rdp` fixtures in a new `client/common/test/rdp-avd/` (outside the snapshot-scanned `rdp-testcases/`), asserting the AVD keys map as documented and that population selects the cloud for the Government file and leaves the commercial and non-ARM files alone.

## Behaviour change

ARM connections whose gateway host ends in `.wvd.azure.us` now authenticate against `login.microsoftonline.us` with the Government scope unless the operator set the authority/scope/format explicitly. Commercial behaviour is unchanged. Tenant-specific discovery is enabled for such connections only when a non-default tenant id is present and `use-tenantid` was not explicitly set.

## Design notes for reviewers

- The automatic selection was originally placed in core (`rdp_client_connect()`); two independent placement reviews argued that core can only guess intent from defaults and then needs undo state, whereas the parsers know what was given explicitly. It now lives in libfreerdp-client with an explicit override. Core keeps only data and an explicit setter.
- The Government redirect deliberately points at `login.microsoftonline.com/common/oauth2/nativeclient`: that is what the Remmina implementation validated on hardware, and FreeRDP issue #11032 documents that the AVD client's redirect is registered in Azure with only the scope changing per cloud. Re-verified on hardware on 2026-09-03 in both directions: the Government tenant issued codes to this redirect and the sign-in completed, and the sovereign form `https://login.microsoftonline.us/<tenant>/oauth2/nativeclient` was rejected by Entra with AADSTS50011 ("does not match the redirect URIs configured for the application a85cf173-…"). The commercial redirect is the only one registered for the AVD client; PKCE (companion PR) is what keeps the transiting code unusable.
- An earlier revision made any `.rdp` `aadtenantid` force `GatewayAvdUseTenantid`; dropped, because upstream made tenant use opt-in deliberately (f25be351b).

## How to test

Unit: `ctest` (TestAadCloud, TestClientCmdLine, TestClientRdpFile). Manual: `sdl-freerdp workspace.rdp` for a Government workspace; expect a DEBUG line from `freerdp_client_settings_apply_avd_cloud` and the authorize URL on `login.microsoftonline.us`. To force a cloud: `/gateway:g:<host>,type:arm,cloud:usgov`.

## Review history

Three adversarial review rounds over the combined series, a dedicated placement review (which moved the automatic selection out of core and made the cloud struct opaque), and a verification round on the split branch, which found that the explicit `cloud:` option skipped tenant derivation and that an `.rdp` followed by command-line options applied the selection twice; both fixed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
