### PR TITLE
[channels,pulse] survive hot-removal of the active audio device

### DIFF
--- a/channels/audin/client/pulse/audin_pulse.c
+++ b/channels/audin/client/pulse/audin_pulse.c
@@ -327,9 +327,23 @@ static void audin_pulse_stream_request_callback(pa_stream* stream, size_t length
 	const void* data = nullptr;
 	AudinPulseDevice* pulse = (AudinPulseDevice*)userdata;
 	UINT error = CHANNEL_RC_OK;
-	pa_stream_peek(stream, &data, &length);
-	error =
-	    IFCALLRESULT(CHANNEL_RC_OK, pulse->receive, &pulse->format, data, length, pulse->user_data);
+
+	if (pa_stream_peek(stream, &data, &length) < 0)
+	{
+		WLog_Print(pulse->log, WLOG_WARN, "pa_stream_peek failed (%d)",
+		           pa_context_errno(pulse->context));
+		return;
+	}
+
+	/* length == 0: buffer empty, no fragment to drop.
+	 * data == nullptr with length > 0: a hole in the record stream (e.g. the
+	 * capture device vanished); it carries no samples, only drop it. */
+	if (length == 0)
+		return;
+
+	if (data)
+		error = IFCALLRESULT(CHANNEL_RC_OK, pulse->receive, &pulse->format, data, length,
+		                     pulse->user_data);
 	pa_stream_drop(stream);
 
 	if (error && pulse->rdpcontext)

--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -665,6 +665,19 @@ static UINT rdpsnd_pulse_play(rdpsndDevicePlugin* device, const BYTE* data, size
 		if (status < 0)
 			break;
 
+		/* A suspended or migrating stream (e.g. the default device just
+		 * changed) can hand out an empty buffer; treating it as progress
+		 * busy-loops forever with the mainloop lock held, which also stalls
+		 * the channel thread calling Play. Drop the rest of the sample
+		 * instead. */
+		if (!pa_data || (length == 0))
+		{
+			if (pa_data)
+				pa_stream_cancel_write(pulse->stream);
+			WLog_DBG(TAG, "dropping %" PRIuz " bytes, no buffer space", size);
+			break;
+		}
+
 		memcpy(pa_data, data, length);
 
 		status = pa_stream_write(pulse->stream, pa_data, length, nullptr, 0LL, PA_SEEK_RELATIVE);

--- a/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
+++ b/channels/rdpsnd/client/pulse/rdpsnd_pulse.c
@@ -178,7 +178,9 @@ static BOOL rdpsnd_pulse_connect(rdpsndDevicePlugin* device)
 		return FALSE;
 	}
 
-	for (;;)
+	/* the context state callback releases pulse->context on PA_CONTEXT_FAILED,
+	 * so it must be re-checked after every wait */
+	while (pulse->context)
 	{
 		state = pa_context_get_state(pulse->context);
 
@@ -193,18 +195,22 @@ static BOOL rdpsnd_pulse_connect(rdpsndDevicePlugin* device)
 		pa_threaded_mainloop_wait(pulse->mainloop);
 	}
 
-	o = pa_context_get_sink_info_by_index(pulse->context, 0, rdpsnd_pulse_get_sink_info, pulse);
+	if (pulse->context)
+	{
+		o = pa_context_get_sink_info_by_index(pulse->context, 0, rdpsnd_pulse_get_sink_info, pulse);
 
-	if (o)
-		pa_operation_unref(o);
+		if (o)
+			pa_operation_unref(o);
+	}
 
-	if (state == PA_CONTEXT_READY)
+	if (pulse->context && (state == PA_CONTEXT_READY))
 	{
 		rc = TRUE;
 	}
 	else
 	{
-		pa_context_disconnect(pulse->context);
+		if (pulse->context)
+			pa_context_disconnect(pulse->context);
 		rc = FALSE;
 	}
 
@@ -257,7 +263,10 @@ static void rdpsnd_pulse_stream_state_callback(pa_stream* stream, void* userdata
 
 		case PA_STREAM_FAILED:
 		case PA_STREAM_TERMINATED:
-			// Stream object is about to be destroyed, clean up our pointer
+			/* The stream is dead (e.g. its device vanished). Drop our
+			 * reference; pa_stream dispatches state callbacks under its own
+			 * ref/unref guard, so unref here is safe. */
+			pa_stream_unref(pulse->stream);
 			pulse->stream = nullptr;
 			pa_threaded_mainloop_signal(pulse->mainloop, 0);
 			break;
@@ -293,9 +302,14 @@ static void rdpsnd_pulse_close(rdpsndDevicePlugin* device)
 	{
 		rdpsnd_pulse_wait_for_operation(
 		    pulse, pa_stream_drain(pulse->stream, rdpsnd_pulse_stream_success_callback, pulse));
-		pa_stream_disconnect(pulse->stream);
-		pa_stream_unref(pulse->stream);
-		pulse->stream = nullptr;
+		/* The stream may have died while draining; the state callback then
+		 * released it and cleared pulse->stream. */
+		if (pulse->stream)
+		{
+			pa_stream_disconnect(pulse->stream);
+			pa_stream_unref(pulse->stream);
+			pulse->stream = nullptr;
+		}
 	}
 	pa_threaded_mainloop_unlock(pulse->mainloop);
 }
@@ -551,13 +565,17 @@ static UINT32 rdpsnd_pulse_get_volume(rdpsndDevicePlugin* device)
 	pa_operation* o = nullptr;
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)device;
 
-	if (!rdpsnd_check_pulse(pulse, FALSE))
+	if (!pulse || !pulse->mainloop)
 		return 0;
 
 	pa_threaded_mainloop_lock(pulse->mainloop);
-	o = pa_context_get_sink_info_by_index(pulse->context, 0, rdpsnd_pulse_get_sink_info, pulse);
-	if (o)
-		pa_operation_unref(o);
+	/* re-check under the lock, the context is released if the connection dies */
+	if (rdpsnd_check_pulse(pulse, FALSE))
+	{
+		o = pa_context_get_sink_info_by_index(pulse->context, 0, rdpsnd_pulse_get_sink_info, pulse);
+		if (o)
+			pa_operation_unref(o);
+	}
 	pa_threaded_mainloop_unlock(pulse->mainloop);
 	return pulse->volume;
 }
@@ -582,7 +600,7 @@ static BOOL rdpsnd_pulse_set_volume(rdpsndDevicePlugin* device, UINT32 value)
 	pa_operation* operation = nullptr;
 	rdpsndPulsePlugin* pulse = (rdpsndPulsePlugin*)device;
 
-	if (!rdpsnd_check_pulse(pulse, TRUE))
+	if (!pulse || !pulse->mainloop)
 	{
 		WLog_WARN(TAG, "called before pulse backend was initialized");
 		return FALSE;
@@ -595,6 +613,16 @@ static BOOL rdpsnd_pulse_set_volume(rdpsndDevicePlugin* device, UINT32 value)
 	cv.values[0] = PA_VOLUME_MUTED + (left * (PA_VOLUME_NORM - PA_VOLUME_MUTED)) / PA_VOLUME_NORM;
 	cv.values[1] = PA_VOLUME_MUTED + (right * (PA_VOLUME_NORM - PA_VOLUME_MUTED)) / PA_VOLUME_NORM;
 	pa_threaded_mainloop_lock(pulse->mainloop);
+
+	/* the stream state must be inspected under the mainloop lock - it may be
+	 * cleared by the state callback when the stream dies */
+	if (!rdpsnd_check_pulse(pulse, TRUE))
+	{
+		pa_threaded_mainloop_unlock(pulse->mainloop);
+		WLog_WARN(TAG, "no pulse stream, not setting volume");
+		return FALSE;
+	}
+
 	operation = pa_context_set_sink_input_volume(pulse->context, pa_stream_get_index(pulse->stream),
 	                                             &cv, rdpsnd_set_volume_success_cb, pulse);
 


### PR DESCRIPTION
## What

Hardens the PulseAudio backends (rdpsnd + audin) against the active audio device changing or disappearing mid-session.

## Trigger / real-world incident

SDL3 client (master f91da730), Linux Mint 22 / PipeWire, connected to an Azure Virtual Desktop host with `/sound:sys:pulse /microphone`. During a Teams call running on the built-in audio device, the user plugged in a USB-C headset; wireplumber switched the default device and migrated the live playback + capture streams onto it, and **the session froze at that moment** (stale image, unresponsive, had to be killed). The capture stream additionally delivered holes that were fed to the AAC encoder as samples:

```
[aac @ ...] Input contains (near) NaN/+-Inf
```

(same long-standing symptom as #6072). Follow-up to the robustness work merged in #13234.

## Bugs fixed

1. **rdpsnd/pulse — the freeze**: `pa_stream_begin_write()` can succeed while returning an empty buffer (e.g. the stream is suspended or migrating because the default device changed). `rdpsnd_pulse_play()` treated that as progress: with `length == 0` the write loop never advances, spinning forever **with the threaded mainloop lock held** — which starves the pulse mainloop thread (the stream can never become writable again) and hangs the channel thread that called `Play`. Bail out and drop the remainder of the sample instead.
2. **audin/pulse**: `audin_pulse_stream_request_callback()` ignored the `pa_stream_peek()` contract — the return value was unchecked, `length == 0` still called `pa_stream_drop()`, and a hole (`data == NULL`, `length > 0`, what a vanishing/suspended capture device produces) was forwarded to the receive callback as real sample data (a NULL/garbage buffer for the DSP encoder). Now: check the return, skip empty buffers, drop holes without forwarding.
3. **rdpsnd/pulse**: the stream state callback cleared `pulse->stream` on `PA_STREAM_FAILED`/`TERMINATED` without releasing the `pa_stream_new()` reference — leaked stream object on every device death.
4. **rdpsnd/pulse**: `rdpsnd_pulse_close()` tested `pulse->stream` once, then waited for `pa_stream_drain()`. If the stream failed while draining, the state callback cleared `pulse->stream` and close continued into `pa_stream_disconnect(NULL)` — an assertion abort inside libpulse.
5. **rdpsnd/pulse**: the context state callback releases `pulse->context` on `PA_CONTEXT_FAILED`, but `rdpsnd_pulse_connect()` dereferenced the context again after `pa_threaded_mainloop_wait()` without re-checking, and `rdpsnd_pulse_get_volume()` / `rdpsnd_pulse_set_volume()` checked context/stream *before* taking the mainloop lock. All pointer checks now happen under the lock / after each wait.

## Testing

- Built on master (f91da730) with SDL3 client, `WITH_PULSE=ON`.
- Simulated device swap/unplug without hardware: load `module-null-sink`, make it the default sink and its monitor the default source (streams migrate onto it), then `pactl unload-module` while the session runs — repeated cycles against a Windows 11 25H2 host with `/sound:sys:pulse /microphone`; client stays alive and responsive, audio recovers onto the previous device.
- Regular sessions (connect, logon, sound/mic channel load, clean shutdown) unaffected.
