### PR TITLE
OSS-Fuzz: Add new fuzzer targets Client Rdp File processing

### DIFF
--- a/client/common/test/CMakeLists.txt
+++ b/client/common/test/CMakeLists.txt
@@ -7,6 +7,8 @@ disable_warnings_for_directory(${CMAKE_CURRENT_BINARY_DIR})
 
 set(${MODULE_PREFIX}_TESTS TestClientRdpFile.c TestClientChannels.c TestClientCmdLine.c)
 
+set(FUZZERS TestFuzzClientRdpFile.c)
+
 create_test_sourcelist(${MODULE_PREFIX}_SRCS ${${MODULE_PREFIX}_DRIVER} ${${MODULE_PREFIX}_TESTS})
 
 add_executable(${MODULE_NAME} ${${MODULE_PREFIX}_SRCS})
@@ -15,6 +17,9 @@ target_compile_definitions(${MODULE_NAME} PRIVATE TEST_SOURCE_DIR="${CMAKE_CURRE
 set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} freerdp-client)
 
 target_link_libraries(${MODULE_NAME} PRIVATE ${${MODULE_PREFIX}_LIBS})
+
+include(AddFuzzerTest)
+add_fuzzer_test("${FUZZERS}" "freerdp-client freerdp winpr")
 
 set_target_properties(${MODULE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${TESTING_OUTPUT_DIRECTORY}")
 

--- a/client/common/test/TestFuzzClientRdpFile.c
+++ b/client/common/test/TestFuzzClientRdpFile.c
@@ -1,0 +1,61 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * libFuzzer harness for .rdp connection file parsing
+ *
+ * A .rdp file is untrusted input: they are mailed around, published for
+ * download and shared between users, and opening one is the ordinary way a
+ * client gets configured. client/common/file.c parses that key/value format,
+ * and freerdp_client_populate_settings_from_rdp_file() then converts and range
+ * checks every option on its way into the settings store.
+ *
+ * Neither is otherwise fuzzed. The existing assistance harness covers the
+ * unrelated Remote Assistance (.msrcIncident) file format.
+ *
+ * Both the checked and the unchecked populate path run on every input, so a
+ * mutation always means a different file rather than a different code path.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <freerdp/client/file.h>
+#include <freerdp/settings.h>
+
+static void populate_settings(const rdpFile* file, BOOL unchecked)
+{
+	rdpSettings* settings = freerdp_settings_new(0);
+	if (!settings)
+		return;
+
+	if (unchecked)
+		(void)freerdp_client_populate_settings_from_rdp_file_unchecked(file, settings);
+	else
+		(void)freerdp_client_populate_settings_from_rdp_file(file, settings);
+
+	freerdp_settings_free(settings);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+	rdpFile* file = freerdp_client_rdp_file_new();
+	if (!file)
+		return 0;
+
+	char* buf = calloc(Size + 1, sizeof(char));
+	if (buf == nullptr)
+		goto err;
+	memcpy(buf, Data, Size);
+	buf[Size] = '\0';
+
+	if (freerdp_client_parse_rdp_file_buffer(file, (const BYTE*)buf, Size + 1))
+	{
+		populate_settings(file, FALSE);
+		populate_settings(file, TRUE);
+	}
+
+err:
+	freerdp_client_rdp_file_free(file);
+	free(buf);
+
+	return 0;
+}


### PR DESCRIPTION
This PR adds a new OSS-Fuzz fuzzer, targeting Client Rdp File processing with random untrusted data.