### PR TITLE
[channels,urbdrc] report the negotiated device speed

### DIFF
--- a/channels/urbdrc/client/libusb/libusb_udevice.c
+++ b/channels/urbdrc/client/libusb/libusb_udevice.c
@@ -1010,6 +1010,37 @@ static int libusb_udev_os_feature_descriptor_request(IUDEVICE* idev,
 	return ERROR_SUCCESS;
 }
 
+static int libusb_udev_query_device_speed(IUDEVICE* idev)
+{
+	UDEVICE* pdev = (UDEVICE*)idev;
+
+	if (!pdev || !pdev->libusb_dev)
+		return DEVICE_SPEED_UNKNOWN;
+
+	switch (libusb_get_device_speed(pdev->libusb_dev))
+	{
+		case LIBUSB_SPEED_LOW:
+			return DEVICE_SPEED_LOW;
+
+		case LIBUSB_SPEED_FULL:
+			return DEVICE_SPEED_FULL;
+
+		case LIBUSB_SPEED_HIGH:
+			return DEVICE_SPEED_HIGH;
+
+		case LIBUSB_SPEED_SUPER:
+			return DEVICE_SPEED_SUPER;
+
+#if LIBUSB_API_VERSION >= 0x01000106
+		case LIBUSB_SPEED_SUPER_PLUS:
+			return DEVICE_SPEED_SUPER_PLUS;
+#endif
+
+		default:
+			return DEVICE_SPEED_UNKNOWN;
+	}
+}
+
 static int libusb_udev_query_device_descriptor(IUDEVICE* idev, int offset)
 {
 	UDEVICE* pdev = (UDEVICE*)idev;
@@ -1639,6 +1670,7 @@ static void udev_load_interface(UDEVICE* pdev)
 	pdev->iface.cancel_all_transfer_request = libusb_udev_cancel_all_transfer_request;
 	pdev->iface.cancel_transfer_request = libusb_udev_cancel_transfer_request;
 	pdev->iface.query_device_descriptor = libusb_udev_query_device_descriptor;
+	pdev->iface.query_device_speed = libusb_udev_query_device_speed;
 	pdev->iface.detach_kernel_driver = libusb_udev_detach_kernel_driver;
 	pdev->iface.attach_kernel_driver = libusb_udev_attach_kernel_driver;
 	pdev->iface.query_device_port_status = libusb_udev_query_device_port_status;

--- a/channels/urbdrc/client/urbdrc_main.c
+++ b/channels/urbdrc/client/urbdrc_main.c
@@ -280,8 +280,8 @@ static BOOL write_string_block(wStream* s, size_t count, const char** strings, c
 
 /* [MS-RDPEUSB] 2.2.4.2 Add Device Message (ADD_DEVICE) */
 static UINT urbdrc_send_add_device(GENERIC_CHANNEL_CALLBACK* callback, UINT32 UsbDevice,
-                                   UINT32 bcdUSB, const char* strInstanceId, size_t InstanceIdLen,
-                                   size_t nrHwIds, const char* HardwareIds[],
+                                   UINT32 bcdUSB, int deviceSpeed, const char* strInstanceId,
+                                   size_t InstanceIdLen, size_t nrHwIds, const char* HardwareIds[],
                                    const size_t HardwareIdsLen[], size_t nrCompatIds,
                                    const char* CompatibilityIds[],
                                    const size_t CompatibilityIdsLen[], const char* strContainerId,
@@ -324,10 +324,29 @@ static UINT urbdrc_send_add_device(GENERIC_CHANNEL_CALLBACK* callback, UINT32 Us
 	Stream_Write_UINT32(out, bcdUSB);
 	Stream_Write_UINT32(out, 0x00000000); /* HcdCapabilities, MUST always be zero */
 
-	if (bcdUSB < 0x200)
-		Stream_Write_UINT32(out, 0x00000000); /* DeviceIsHighSpeed */
-	else
-		Stream_Write_UINT32(out, 0x00000001); /* DeviceIsHighSpeed */
+	/* [MS-RDPEUSB] 2.2.11 distinguishes only full from high speed, so every
+	 * faster device is reported as high speed. */
+	UINT32 DeviceIsHighSpeed = 0;
+	switch (deviceSpeed)
+	{
+		case DEVICE_SPEED_LOW:
+		case DEVICE_SPEED_FULL:
+			DeviceIsHighSpeed = 0x00000000;
+			break;
+
+		case DEVICE_SPEED_UNKNOWN:
+			/* The negotiated speed is unavailable or not recognised, so fall
+			 * back to the USB version the device claims. It only bounds the
+			 * speed, which is why it is not used when the bus can be asked. */
+			DeviceIsHighSpeed = (bcdUSB < 0x200) ? 0x00000000 : 0x00000001;
+			break;
+
+		default:
+			DeviceIsHighSpeed = 0x00000001;
+			break;
+	}
+
+	Stream_Write_UINT32(out, DeviceIsHighSpeed); /* DeviceIsHighSpeed */
 
 	Stream_Write_UINT32(out, 0x50); /* NoAckIsochWriteJitterBufferSizeInMs, >=10 or <=512 */
 	return stream_write_and_free(callback->plugin, callback->channel, out);
@@ -416,8 +435,9 @@ static UINT urdbrc_send_usb_device_add(GENERIC_CHANNEL_CALLBACK* callback, IUDEV
 	const UINT32 UsbDevice = pdev->get_UsbDevice(pdev);
 	const UINT32 bcdUSB =
 	    WINPR_ASSERTING_INT_CAST(uint32_t, pdev->query_device_descriptor(pdev, BCD_USB));
-	return urbdrc_send_add_device(callback, UsbDevice, bcdUSB, strInstanceId, InstanceIdLen,
-	                              nrHwIds, CHardwareIds, HardwareIdsLen, nrCompatIds,
+	const int deviceSpeed = pdev->query_device_speed(pdev);
+	return urbdrc_send_add_device(callback, UsbDevice, bcdUSB, deviceSpeed, strInstanceId,
+	                              InstanceIdLen, nrHwIds, CHardwareIds, HardwareIdsLen, nrCompatIds,
 	                              CCompatibilityIds, CompatibilityIdLen, strContainerId,
 	                              ContainerIdLen);
 }

--- a/channels/urbdrc/client/urbdrc_main.h
+++ b/channels/urbdrc/client/urbdrc_main.h
@@ -139,6 +139,9 @@ struct S_IUDEVICE
 
 	WINPR_ATTR_NODISCARD int (*query_device_descriptor)(IUDEVICE* idev, int offset);
 
+	/** Negotiated bus speed, as a \ref device_speed value. */
+	WINPR_ATTR_NODISCARD int (*query_device_speed)(IUDEVICE* idev);
+
 	WINPR_ATTR_NODISCARD BOOL (*detach_kernel_driver)(IUDEVICE* idev);
 
 	WINPR_ATTR_NODISCARD BOOL (*attach_kernel_driver)(IUDEVICE* idev);

--- a/channels/urbdrc/common/urbdrc_types.h
+++ b/channels/urbdrc/common/urbdrc_types.h
@@ -125,6 +125,19 @@ enum device_descriptor_table
 	B_NUM_CONFIGURATIONS = 17
 };
 
+/**
+ * Speed a redirected device enumerated at.
+ */
+enum device_speed
+{
+	DEVICE_SPEED_UNKNOWN = 0,
+	DEVICE_SPEED_LOW,
+	DEVICE_SPEED_FULL,
+	DEVICE_SPEED_HIGH,
+	DEVICE_SPEED_SUPER,
+	DEVICE_SPEED_SUPER_PLUS
+};
+
 #define PIPE_CANCEL 0
 #define PIPE_RESET 1
 


### PR DESCRIPTION
ADD_DEVICE derived DeviceIsHighSpeed from bcdUSB, which states the USB version a device complies with rather than the speed it enumerated at.

Ask the bus instead. libusb_get_device_speed reports the negotiated speed, so add IUDEVICE::query_device_speed and map its result. bcdUSB remains the fallback for a speed libusb cannot determine or this build cannot name, since it does bound the speed from above.

Note that [MS-RDPEUSB] 2.2.11 distinguishes only full from high speed, so a SuperSpeed device is still announced as high speed. That is a limit of the protocol.
