### PR TITLE
[winpr,image] honor bfOffBits when parsing bitmaps

### DIFF
--- a/winpr/libwinpr/clipboard/test/TestClipboardFormats.c
+++ b/winpr/libwinpr/clipboard/test/TestClipboardFormats.c
@@ -37,7 +37,12 @@ static BOOL test_dib_to_bmp(const BYTE* dib, size_t dibSize, size_t expectedOffs
 	    (memcmp(&bmp[sizeof(WINPR_BITMAP_FILE_HEADER)], dib, dibSize) != 0))
 		goto fail_bmp;
 
-	rc = TRUE;
+	/* The synthesized BMP must also be readable by the image conversion code. */
+	wImage* image = winpr_image_new();
+	if (!image)
+		goto fail_bmp;
+	rc = (winpr_image_read_buffer(image, bmp, bmpSize) > 0);
+	winpr_image_free(image, TRUE);
 
 fail_bmp:
 	free(bmp);

--- a/winpr/libwinpr/utils/image.c
+++ b/winpr/libwinpr/utils/image.c
@@ -459,14 +459,19 @@ static int winpr_image_bitmap_read_buffer(wImage* image, const BYTE* buffer, siz
 	image->type = WINPR_IMAGE_BITMAP;
 
 	{
+		/* bfOffBits may include color masks, a color table or padding after the
+		 * info header. It must leave room for the required color data. */
 		const size_t pos = Stream_GetPosition(s);
 		const size_t expect = bf.bfOffBits;
-		if (pos != expect)
+		if ((pos > expect) || (bmpoffset > expect - pos))
 		{
 			WLog_WARN(TAG, "pos=%" PRIuz ", expected %" PRIuz ", offset=%" PRIuz, pos, expect,
 			          bmpoffset);
 			goto fail;
 		}
+
+		if (!Stream_SafeSeek(s, expect - pos))
+			goto fail;
 	}
 
 	if (!Stream_CheckAndLogRequiredLength(TAG, s, bi.biSizeImage))

--- a/winpr/libwinpr/utils/test/TestImage.c
+++ b/winpr/libwinpr/utils/test/TestImage.c
@@ -4,6 +4,7 @@
 #include <winpr/file.h>
 #include <winpr/path.h>
 #include <winpr/image.h>
+#include <winpr/user.h>
 
 static const char test_src_filename[] = TEST_SOURCE_PATH "/rgb";
 static const char test_bin_filename[] = TEST_BINARY_PATH "/rgb";
@@ -282,6 +283,107 @@ static BOOL test_load(void)
 	return TRUE;
 }
 
+/* Pixel data may follow color masks and additional padding after BITMAPINFOHEADER. */
+static BOOL test_bmp_offbits(UINT32 compression, UINT32 padding, BOOL topDown)
+{
+	BOOL rc = FALSE;
+	const UINT32 width = 2;
+	const UINT32 height = 2;
+	const UINT32 bpp = 32;
+	const UINT32 stride = width * bpp / 8;
+	const UINT32 biSizeImage = stride * height;
+	const size_t headerSize = 54; /* 14 byte file header + 40 byte info header */
+	const size_t maskSize = (compression == BI_BITFIELDS) ? 3 * sizeof(DWORD) : 0;
+	const size_t minOffset = headerSize + maskSize;
+	const size_t offBits = minOffset + padding;
+	const size_t size = offBits + biSizeImage;
+
+	wImage* image = winpr_image_new();
+	BYTE* bmp = (BYTE*)calloc(1, size);
+	if (!image || !bmp)
+		goto fail;
+
+	bmp[0] = 'B';
+	bmp[1] = 'M';
+	put_u32(&bmp[2], (UINT32)size);                                 /* bfSize */
+	put_u32(&bmp[10], (UINT32)offBits);                             /* bfOffBits */
+	put_u32(&bmp[14], 40);                                          /* biSize */
+	put_u32(&bmp[18], width);                                       /* biWidth */
+	put_u32(&bmp[22], topDown ? (UINT32)(-(INT32)height) : height); /* biHeight */
+	put_u16(&bmp[26], 1);                                           /* biPlanes */
+	put_u16(&bmp[28], bpp);                                         /* biBitCount */
+	put_u32(&bmp[30], compression);                                 /* biCompression */
+	put_u32(&bmp[34], biSizeImage);                                 /* biSizeImage */
+	if (compression == BI_BITFIELDS)
+	{
+		put_u32(&bmp[54], 0x00FF0000); /* red color mask */
+		put_u32(&bmp[58], 0x0000FF00); /* green color mask */
+		put_u32(&bmp[62], 0x000000FF); /* blue color mask */
+	}
+
+	{
+		const BYTE pixels[16] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			                      0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18 };
+		memcpy(&bmp[offBits], pixels, sizeof(pixels));
+
+		if (winpr_image_read_buffer(image, bmp, size) <= 0)
+		{
+			(void)fprintf(stderr, "[%s] failed to read BMP at offset %" PRIuz "\n", __func__,
+			              offBits);
+			goto fail;
+		}
+
+		if ((image->width != width) || (image->height != height) || (image->bitsPerPixel != bpp) ||
+		    (image->bytesPerPixel != bpp / 8) || (image->scanline != stride) || !image->data)
+		{
+			(void)fprintf(stderr, "[%s] unexpected image layout\n", __func__);
+			goto fail;
+		}
+
+		for (size_t row = 0; row < height; row++)
+		{
+			const size_t srcRow = topDown ? row : height - 1 - row;
+			if (memcmp(&image->data[row * image->scanline], &pixels[srcRow * stride], stride) != 0)
+			{
+				(void)fprintf(stderr, "[%s] unexpected pixels in row %" PRIuz "\n", __func__, row);
+				goto fail;
+			}
+		}
+	}
+
+	/* Reject offsets overlapping headers or masks, beyond the buffer, or leaving
+	 * too few bytes for the pixel data. */
+	{
+		const UINT32 offsets[] = { 0,
+			                       (UINT32)(headerSize - 1),
+			                       (UINT32)(minOffset - 1),
+			                       (UINT32)(size - 1),
+			                       (UINT32)size,
+			                       (UINT32)(size + 1),
+			                       UINT32_MAX };
+		for (size_t x = 0; x < ARRAYSIZE(offsets); x++)
+		{
+			winpr_image_free(image, TRUE);
+			image = winpr_image_new();
+			if (!image)
+				goto fail;
+			put_u32(&bmp[10], offsets[x]); /* bfOffBits */
+			if (winpr_image_read_buffer(image, bmp, size) > 0)
+			{
+				(void)fprintf(stderr, "[%s] accepted invalid offset %" PRIu32 "\n", __func__,
+				              offsets[x]);
+				goto fail;
+			}
+		}
+	}
+
+	rc = TRUE;
+fail:
+	free(bmp);
+	winpr_image_free(image, TRUE);
+	return rc;
+}
+
 int TestImage(int argc, char* argv[])
 {
 	int rc = 0;
@@ -300,6 +402,10 @@ int TestImage(int argc, char* argv[])
 
 	if (!test_unaligned_no_overread())
 		rc -= 8;
+
+	if (!test_bmp_offbits(BI_BITFIELDS, 0, FALSE) || !test_bmp_offbits(BI_BITFIELDS, 4, TRUE) ||
+	    !test_bmp_offbits(BI_RGB, 0, FALSE) || !test_bmp_offbits(BI_RGB, 12, TRUE))
+		rc -= 16;
 
 	return rc;
 }


### PR DESCRIPTION
`winpr_image_bitmap_read_buffer()` rejects BMPs whose pixel data does not immediately follow the parsed info header. For a 32bpp `BI_BITFIELDS` bitmap with a 40-byte `BITMAPINFOHEADER`, three color-mask DWORDs follow the header: parsing stops at byte 54, but `bfOffBits` is 66. This breaks `CF_DIB -> BMP -> image/png` conversion when pasting clipboard images with this layout from a Windows server (I observed the errors when using the Windows 11 [Snipping Tool](https://support.microsoft.com/en-us/windows/apps/use-snipping-tool-to-capture-screenshots)):

```text
[winpr_image_bitmap_read_buffer]: pos=54, expected 66, offset=12
[xf_cliprdr_server_format_data_response]: failed to get clipboard data in format image/png [source format CF_DIB]
```

The fix: Seek forward to `bfOffBits`, allowing the masks and any additional padding before the pixels. Reject offsets that overlap the parsed headers or required color masks/table. The seek checks the buffer bounds, and the existing image-size check runs at the resulting pixel position.

This fixes the strict position check introduced by 894474b161 (first released in 3.3.0). It complements #13304, which corrected the BMP offsets generated from clipboard DIB headers.

Validation:

- `TestImage` covers `BI_BITFIELDS` and `BI_RGB`, with and without padding,
  top-down and bottom-up rows, and invalid offsets overlapping headers/masks,
  leaving too little pixel data, or exceeding the buffer.
- `TestClipboardFormats` now also reads the synthesized BMPs for its existing
  legacy bitfields, V4, and indexed DIB cases.
- Both suites pass with GCC 15/C11 in Release mode, and with Clang 21/C23 in Debug
  mode with PNG, JPEG, and WebP enabled, AddressSanitizer, UndefinedBehaviorSanitizer,
  and leak detection. The new image regression fails against the upstream parser.
- Changed C files pass `clang-format --dry-run --Werror`, with no `clang-tidy`
  diagnostics on changed lines. `git diff --check` and spelling checks also pass.

To run the tests with image conversion enabled:

```sh
cmake --preset minimal-library -B build-bmp-offbits -DBUILD_TESTING=ON \
  -DWINPR_UTILS_IMAGE_PNG=ON -DWINPR_UTILS_IMAGE_JPEG=ON -DWINPR_UTILS_IMAGE_WEBP=ON
cmake --build build-bmp-offbits --target TestWinPRUtils TestClipboard
ctest --test-dir build-bmp-offbits -R '^(TestImage|TestClipboardFormats)$' --output-on-failure
```

For a manual check, connect `xfreerdp` with clipboard redirection enabled to a Windows server, copy an image from an application that supplies this `BITMAPINFOHEADER`/`BI_BITFIELDS` layout, and paste into a local application that requests `image/png`. The expected result is a successful paste without the conversion failure above.
