### PR TITLE
[channels,urbdrc] give the device speed a type

### DIFF
--- a/channels/urbdrc/client/libusb/libusb_udevice.c
+++ b/channels/urbdrc/client/libusb/libusb_udevice.c
@@ -1010,7 +1010,7 @@ static int libusb_udev_os_feature_descriptor_request(IUDEVICE* idev,
 	return ERROR_SUCCESS;
 }
 
-static int libusb_udev_query_device_speed(IUDEVICE* idev)
+static enum device_speed libusb_udev_query_device_speed(IUDEVICE* idev)
 {
 	UDEVICE* pdev = (UDEVICE*)idev;
 

--- a/channels/urbdrc/client/urbdrc_main.c
+++ b/channels/urbdrc/client/urbdrc_main.c
@@ -280,10 +280,10 @@ static BOOL write_string_block(wStream* s, size_t count, const char** strings, c
 
 /* [MS-RDPEUSB] 2.2.4.2 Add Device Message (ADD_DEVICE) */
 static UINT urbdrc_send_add_device(GENERIC_CHANNEL_CALLBACK* callback, UINT32 UsbDevice,
-                                   UINT32 bcdUSB, int deviceSpeed, const char* strInstanceId,
-                                   size_t InstanceIdLen, size_t nrHwIds, const char* HardwareIds[],
-                                   const size_t HardwareIdsLen[], size_t nrCompatIds,
-                                   const char* CompatibilityIds[],
+                                   UINT32 bcdUSB, enum device_speed deviceSpeed,
+                                   const char* strInstanceId, size_t InstanceIdLen, size_t nrHwIds,
+                                   const char* HardwareIds[], const size_t HardwareIdsLen[],
+                                   size_t nrCompatIds, const char* CompatibilityIds[],
                                    const size_t CompatibilityIdsLen[], const char* strContainerId,
                                    size_t ContainerIdLen)
 {
@@ -435,7 +435,7 @@ static UINT urdbrc_send_usb_device_add(GENERIC_CHANNEL_CALLBACK* callback, IUDEV
 	const UINT32 UsbDevice = pdev->get_UsbDevice(pdev);
 	const UINT32 bcdUSB =
 	    WINPR_ASSERTING_INT_CAST(uint32_t, pdev->query_device_descriptor(pdev, BCD_USB));
-	const int deviceSpeed = pdev->query_device_speed(pdev);
+	const enum device_speed deviceSpeed = pdev->query_device_speed(pdev);
 	return urbdrc_send_add_device(callback, UsbDevice, bcdUSB, deviceSpeed, strInstanceId,
 	                              InstanceIdLen, nrHwIds, CHardwareIds, HardwareIdsLen, nrCompatIds,
 	                              CCompatibilityIds, CompatibilityIdLen, strContainerId,

--- a/channels/urbdrc/client/urbdrc_main.h
+++ b/channels/urbdrc/client/urbdrc_main.h
@@ -27,6 +27,8 @@
 
 #include <msusb.h>
 
+#include "urbdrc_types.h"
+
 #define DEVICE_HARDWARE_ID_SIZE 32
 #define DEVICE_COMPATIBILITY_ID_SIZE 36
 #define DEVICE_INSTANCE_STR_SIZE 37
@@ -139,8 +141,8 @@ struct S_IUDEVICE
 
 	WINPR_ATTR_NODISCARD int (*query_device_descriptor)(IUDEVICE* idev, int offset);
 
-	/** Negotiated bus speed, as a \ref device_speed value. */
-	WINPR_ATTR_NODISCARD int (*query_device_speed)(IUDEVICE* idev);
+	/** Negotiated bus speed. */
+	WINPR_ATTR_NODISCARD enum device_speed (*query_device_speed)(IUDEVICE* idev);
 
 	WINPR_ATTR_NODISCARD BOOL (*detach_kernel_driver)(IUDEVICE* idev);
 

--- a/channels/urbdrc/common/urbdrc_types.h
+++ b/channels/urbdrc/common/urbdrc_types.h
@@ -128,7 +128,7 @@ enum device_descriptor_table
 /**
  * Speed a redirected device enumerated at.
  */
-enum device_speed
+enum device_speed WINPR_C23_ENUM_TYPE(uint32_t)
 {
 	DEVICE_SPEED_UNKNOWN = 0,
 	DEVICE_SPEED_LOW,


### PR DESCRIPTION
Follow-up to #13345, addressing the `WINPR_C23_ENUM_TYPE` suggestion there.

query_device_speed returned int, so enum device_speed was only a set of named constants: nothing related the accessor to it, and its underlying type never reached the ABI.

Return the enum instead, and fix its underlying type with WINPR_C23_ENUM_TYPE. urbdrc_main.h now names the enum, so it includes urbdrc_types.h rather than relying on every consumer to have included it first.