### PR TITLE
[cache,pointer] explicitly cast to void*

### DIFF
--- a/libfreerdp/cache/pointer.c
+++ b/libfreerdp/cache/pointer.c
@@ -390,7 +390,7 @@ BOOL pointer_cache_resize(rdpPointerCache* pointerCache)
 		pointer_free(pointerCache->context, pointer);
 	}
 
-	void* tmp = realloc(pointerCache->entries, cacheSize * sizeof(rdpPointer*));
+	void* tmp = realloc((void*)pointerCache->entries, cacheSize * sizeof(rdpPointer*));
 	if (!tmp)
 		return FALSE;
 
@@ -398,7 +398,8 @@ BOOL pointer_cache_resize(rdpPointerCache* pointerCache)
 	if (cacheSize > pointerCache->cacheSize)
 	{
 		const size_t rsize = (cacheSize - pointerCache->cacheSize) * sizeof(rdpPointer*);
-		memset(&pointerCache->entries[pointerCache->cacheSize], 0, rsize);
+		void* dst = (void*)&pointerCache->entries[pointerCache->cacheSize];
+		memset(dst, 0, rsize);
 	}
 	pointerCache->cacheSize = WINPR_ASSERTING_INT_CAST(UINT32, cacheSize);
 
@@ -408,9 +409,6 @@ BOOL pointer_cache_resize(rdpPointerCache* pointerCache)
 rdpPointerCache* pointer_cache_new(rdpContext* context)
 {
 	WINPR_ASSERT(context);
-
-	rdpSettings* settings = context->settings;
-	WINPR_ASSERT(settings);
 
 	rdpPointerCache* pointer_cache = (rdpPointerCache*)calloc(1, sizeof(rdpPointerCache));
 

--- a/libfreerdp/codec/h264_ffmpeg.c
+++ b/libfreerdp/codec/h264_ffmpeg.c
@@ -1287,6 +1287,7 @@ static BOOL load_config(H264_CONTEXT_LIBAVCODEC* sys, BOOL enabled, wLog* log)
 #else
 	WINPR_UNUSED(enabled);
 	WINPR_UNUSED(log);
+	WINPR_UNUSED(sys);
 #endif
 	return TRUE;
 }

--- a/libfreerdp/core/update.c
+++ b/libfreerdp/core/update.c
@@ -54,6 +54,7 @@
 static INIT_ONCE stats_names_once = INIT_ONCE_STATIC_INIT;
 static char stats_names[RDP_STATS_COUNT][bufferlen];
 
+WINPR_ATTR_NODISCARD
 static BOOL CALLBACK stats_names_generate(WINPR_ATTR_UNUSED PINIT_ONCE InitOnce,
                                           WINPR_ATTR_UNUSED PVOID Parameter,
                                           WINPR_ATTR_UNUSED PVOID* Context)
@@ -155,6 +156,7 @@ static BOOL CALLBACK stats_names_generate(WINPR_ATTR_UNUSED PINIT_ONCE InitOnce,
 }
 static const char* const UPDATE_TYPE_STRINGS[] = { "Orders", "Bitmap", "Palette", "Synchronize" };
 
+WINPR_ATTR_NODISCARD
 static const char* update_type_to_string(UINT16 updateType)
 {
 	if (updateType >= ARRAYSIZE(UPDATE_TYPE_STRINGS))
@@ -163,6 +165,7 @@ static const char* update_type_to_string(UINT16 updateType)
 	return UPDATE_TYPE_STRINGS[updateType];
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL update_recv_orders(rdpUpdate* update, wStream* s)
 {
 	UINT16 numberOrders = 0;
@@ -190,6 +193,7 @@ static BOOL update_recv_orders(rdpUpdate* update, wStream* s)
 	return TRUE;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL update_read_bitmap_data(rdpUpdate* update, wStream* s, BITMAP_DATA* bitmapData)
 {
 	WINPR_UNUSED(update);
@@ -254,6 +258,7 @@ static BOOL update_read_bitmap_data(rdpUpdate* update, wStream* s, BITMAP_DATA* 
 	return TRUE;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL update_write_bitmap_data_header(const BITMAP_DATA* bitmapData, wStream* s)
 {
 	WINPR_ASSERT(bitmapData);
@@ -271,6 +276,7 @@ static BOOL update_write_bitmap_data_header(const BITMAP_DATA* bitmapData, wStre
 	return TRUE;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL update_write_bitmap_data_no_comp_header(const BITMAP_DATA* bitmapData, wStream* s)
 {
 	WINPR_ASSERT(bitmapData);
@@ -291,6 +297,7 @@ static BOOL update_write_bitmap_data_no_comp_header(const BITMAP_DATA* bitmapDat
 	return TRUE;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL update_write_bitmap_data(rdpUpdate* update_pub, wStream* s, BITMAP_DATA* bitmapData)
 {
 	rdp_update_internal* update = update_cast(update_pub);
@@ -369,6 +376,7 @@ fail:
 	return nullptr;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL update_write_bitmap_update(rdpUpdate* update, wStream* s,
                                        const BITMAP_UPDATE* bitmapUpdate)
 {
@@ -429,6 +437,7 @@ fail:
 	return nullptr;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL update_read_synchronize(rdpUpdate* update, wStream* s)
 {
 	WINPR_UNUSED(update);
@@ -439,6 +448,7 @@ static BOOL update_read_synchronize(rdpUpdate* update, wStream* s)
 	                               */
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL update_read_play_sound(wStream* s, PLAY_SOUND_UPDATE* play_sound)
 {
 	WINPR_ASSERT(play_sound);
@@ -508,8 +518,9 @@ fail:
 	return nullptr;
 }
 
-static BOOL s_update_read_pointer_color(wStream* s, POINTER_COLOR_UPDATE* pointer_color,
-                                        BYTE xorBpp, UINT32 flags)
+WINPR_ATTR_NODISCARD static BOOL s_update_read_pointer_color(wStream* s,
+                                                             POINTER_COLOR_UPDATE* pointer_color,
+                                                             BYTE xorBpp, UINT32 flags)
 {
 	BYTE* newMask = nullptr;
 	UINT32 scanlineSize = 0;
@@ -658,7 +669,8 @@ fail:
 	return nullptr;
 }
 
-static BOOL s_update_read_pointer_large(wStream* s, POINTER_LARGE_UPDATE* pointer)
+WINPR_ATTR_NODISCARD static BOOL s_update_read_pointer_large(wStream* s,
+                                                             POINTER_LARGE_UPDATE* pointer)
 {
 	BYTE* newMask = nullptr;
 	UINT32 scanlineSize = 0;
@@ -1125,7 +1137,7 @@ void update_post_disconnect(rdpUpdate* update)
 	up->initialState = TRUE;
 }
 
-static BOOL s_update_begin_paint(rdpContext* context)
+WINPR_ATTR_NODISCARD static BOOL s_update_begin_paint(rdpContext* context)
 {
 	wStream* s = nullptr;
 	WINPR_ASSERT(context);
@@ -1152,7 +1164,7 @@ static BOOL s_update_begin_paint(rdpContext* context)
 	return TRUE;
 }
 
-static BOOL s_update_end_paint(rdpContext* context)
+WINPR_ATTR_NODISCARD static BOOL s_update_end_paint(rdpContext* context)
 {
 	BOOL rc = FALSE;
 
@@ -1189,7 +1201,7 @@ fail:
 	return rc;
 }
 
-static BOOL update_flush(rdpContext* context)
+WINPR_ATTR_NODISCARD static BOOL update_flush(rdpContext* context)
 {
 	rdp_update_internal* update = nullptr;
 
@@ -1207,12 +1219,12 @@ static BOOL update_flush(rdpContext* context)
 	return TRUE;
 }
 
-static BOOL update_force_flush(rdpContext* context)
+WINPR_ATTR_NODISCARD static BOOL update_force_flush(rdpContext* context)
 {
 	return update_flush(context);
 }
 
-static BOOL update_check_flush(rdpContext* context, size_t size)
+WINPR_ATTR_NODISCARD static BOOL update_check_flush(rdpContext* context, size_t size)
 {
 	WINPR_ASSERT(context);
 	rdp_update_internal* update = update_cast(context->update);
@@ -1236,7 +1248,7 @@ static BOOL update_check_flush(rdpContext* context, size_t size)
 	return TRUE;
 }
 
-static BOOL update_set_bounds(rdpContext* context, const rdpBounds* bounds)
+WINPR_ATTR_NODISCARD static BOOL update_set_bounds(rdpContext* context, const rdpBounds* bounds)
 {
 	rdp_update_internal* update = nullptr;
 
@@ -1254,14 +1266,14 @@ static BOOL update_set_bounds(rdpContext* context, const rdpBounds* bounds)
 	return TRUE;
 }
 
-static BOOL update_bounds_is_null(rdpBounds* bounds)
+WINPR_ATTR_NODISCARD static BOOL update_bounds_is_null(rdpBounds* bounds)
 {
 	WINPR_ASSERT(bounds);
 	return ((bounds->left == 0) && (bounds->top == 0) && (bounds->right == 0) &&
 	        (bounds->bottom == 0));
 }
 
-static BOOL update_bounds_equals(rdpBounds* bounds1, rdpBounds* bounds2)
+WINPR_ATTR_NODISCARD static BOOL update_bounds_equals(rdpBounds* bounds1, rdpBounds* bounds2)
 {
 	WINPR_ASSERT(bounds1);
 	WINPR_ASSERT(bounds2);
@@ -1270,7 +1282,7 @@ static BOOL update_bounds_equals(rdpBounds* bounds1, rdpBounds* bounds2)
 	        (bounds1->right == bounds2->right) && (bounds1->bottom == bounds2->bottom));
 }
 
-static size_t update_prepare_bounds(rdpContext* context, ORDER_INFO* orderInfo)
+WINPR_ATTR_NODISCARD static size_t update_prepare_bounds(rdpContext* context, ORDER_INFO* orderInfo)
 {
 	size_t length = 0;
 	rdp_update_internal* update = nullptr;
@@ -1328,8 +1340,8 @@ static size_t update_prepare_bounds(rdpContext* context, ORDER_INFO* orderInfo)
 	return length;
 }
 
-static size_t update_prepare_order_info(rdpContext* context, ORDER_INFO* orderInfo,
-                                        UINT32 orderType)
+WINPR_ATTR_NODISCARD static size_t
+update_prepare_order_info(rdpContext* context, ORDER_INFO* orderInfo, UINT32 orderType)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(orderInfo);
@@ -1392,7 +1404,8 @@ static void update_write_refresh_rect(wStream* s, BYTE count, const RECTANGLE_16
 	}
 }
 
-static BOOL update_send_refresh_rect(rdpContext* context, BYTE count, const RECTANGLE_16* areas)
+WINPR_ATTR_NODISCARD static BOOL update_send_refresh_rect(rdpContext* context, BYTE count,
+                                                          const RECTANGLE_16* areas)
 {
 	WINPR_ASSERT(context);
 	rdpRdp* rdp = context->rdp;
@@ -1431,7 +1444,8 @@ static void update_write_suppress_output(wStream* s, BYTE allow, const RECTANGLE
 	}
 }
 
-static BOOL update_send_suppress_output(rdpContext* context, BYTE allow, const RECTANGLE_16* area)
+WINPR_ATTR_NODISCARD static BOOL update_send_suppress_output(rdpContext* context, BYTE allow,
+                                                             const RECTANGLE_16* area)
 {
 	WINPR_ASSERT(context);
 	rdpRdp* rdp = context->rdp;
@@ -1455,7 +1469,7 @@ static BOOL update_send_suppress_output(rdpContext* context, BYTE allow, const R
 	return TRUE;
 }
 
-static BOOL update_send_surface_command(rdpContext* context, wStream* s)
+WINPR_ATTR_NODISCARD static BOOL update_send_surface_command(rdpContext* context, wStream* s)
 {
 	wStream* update = nullptr;
 	WINPR_ASSERT(context);
@@ -1481,8 +1495,8 @@ out:
 	return ret;
 }
 
-static BOOL update_send_surface_bits(rdpContext* context,
-                                     const SURFACE_BITS_COMMAND* surfaceBitsCommand)
+WINPR_ATTR_NODISCARD static BOOL
+update_send_surface_bits(rdpContext* context, const SURFACE_BITS_COMMAND* surfaceBitsCommand)
 {
 	wStream* s = nullptr;
 	WINPR_ASSERT(context);
@@ -1512,8 +1526,9 @@ out_fail:
 	return ret;
 }
 
-static BOOL update_send_surface_frame_marker(rdpContext* context,
-                                             const SURFACE_FRAME_MARKER* surfaceFrameMarker)
+WINPR_ATTR_NODISCARD static BOOL
+update_send_surface_frame_marker(rdpContext* context,
+                                 const SURFACE_FRAME_MARKER* surfaceFrameMarker)
 {
 	wStream* s = nullptr;
 	WINPR_ASSERT(context);
@@ -1540,8 +1555,10 @@ out_fail:
 	return ret;
 }
 
-static BOOL update_send_surface_frame_bits(rdpContext* context, const SURFACE_BITS_COMMAND* cmd,
-                                           BOOL first, BOOL last, UINT32 frameId)
+WINPR_ATTR_NODISCARD static BOOL update_send_surface_frame_bits(rdpContext* context,
+                                                                const SURFACE_BITS_COMMAND* cmd,
+                                                                BOOL first, BOOL last,
+                                                                UINT32 frameId)
 {
 	wStream* s = nullptr;
 
@@ -1584,7 +1601,7 @@ out_fail:
 	return ret;
 }
 
-static BOOL update_send_frame_acknowledge(rdpContext* context, UINT32 frameId)
+WINPR_ATTR_NODISCARD static BOOL update_send_frame_acknowledge(rdpContext* context, UINT32 frameId)
 {
 	WINPR_ASSERT(context);
 	rdpRdp* rdp = context->rdp;
@@ -1609,7 +1626,7 @@ static BOOL update_send_frame_acknowledge(rdpContext* context, UINT32 frameId)
 	return TRUE;
 }
 
-static BOOL update_send_synchronize(rdpContext* context)
+WINPR_ATTR_NODISCARD static BOOL update_send_synchronize(rdpContext* context)
 {
 	wStream* s = nullptr;
 	WINPR_ASSERT(context);
@@ -1628,13 +1645,14 @@ static BOOL update_send_synchronize(rdpContext* context)
 	return ret;
 }
 
-static BOOL update_send_desktop_resize(rdpContext* context)
+WINPR_ATTR_NODISCARD static BOOL update_send_desktop_resize(rdpContext* context)
 {
 	WINPR_ASSERT(context);
 	return rdp_server_reactivate(context->rdp);
 }
 
-static BOOL update_send_bitmap_update(rdpContext* context, const BITMAP_UPDATE* bitmapUpdate)
+WINPR_ATTR_NODISCARD static BOOL update_send_bitmap_update(rdpContext* context,
+                                                           const BITMAP_UPDATE* bitmapUpdate)
 {
 	wStream* s = nullptr;
 	WINPR_ASSERT(context);
@@ -1666,7 +1684,8 @@ out_fail:
 	return ret;
 }
 
-static BOOL update_send_play_sound(rdpContext* context, const PLAY_SOUND_UPDATE* play_sound)
+WINPR_ATTR_NODISCARD static BOOL update_send_play_sound(rdpContext* context,
+                                                        const PLAY_SOUND_UPDATE* play_sound)
 {
 	UINT16 sec_flags = 0;
 	wStream* s = nullptr;
@@ -1697,7 +1716,7 @@ static BOOL update_send_play_sound(rdpContext* context, const PLAY_SOUND_UPDATE*
  * Primary Drawing Orders
  */
 
-static BOOL update_send_dstblt(rdpContext* context, const DSTBLT_ORDER* dstblt)
+WINPR_ATTR_NODISCARD static BOOL update_send_dstblt(rdpContext* context, const DSTBLT_ORDER* dstblt)
 {
 	ORDER_INFO orderInfo = WINPR_C_ARRAY_INIT;
 
@@ -1732,7 +1751,7 @@ static BOOL update_send_dstblt(rdpContext* context, const DSTBLT_ORDER* dstblt)
 	return TRUE;
 }
 
-static BOOL update_send_patblt(rdpContext* context, PATBLT_ORDER* patblt)
+WINPR_ATTR_NODISCARD static BOOL update_send_patblt(rdpContext* context, PATBLT_ORDER* patblt)
 {
 	size_t offset = 0;
 	ORDER_INFO orderInfo = WINPR_C_ARRAY_INIT;
@@ -1765,7 +1784,7 @@ static BOOL update_send_patblt(rdpContext* context, PATBLT_ORDER* patblt)
 	return TRUE;
 }
 
-static BOOL update_send_scrblt(rdpContext* context, const SCRBLT_ORDER* scrblt)
+WINPR_ATTR_NODISCARD static BOOL update_send_scrblt(rdpContext* context, const SCRBLT_ORDER* scrblt)
 {
 	ORDER_INFO orderInfo = WINPR_C_ARRAY_INIT;
 
@@ -1797,7 +1816,8 @@ static BOOL update_send_scrblt(rdpContext* context, const SCRBLT_ORDER* scrblt)
 	return TRUE;
 }
 
-static BOOL update_send_opaque_rect(rdpContext* context, const OPAQUE_RECT_ORDER* opaque_rect)
+WINPR_ATTR_NODISCARD static BOOL update_send_opaque_rect(rdpContext* context,
+                                                         const OPAQUE_RECT_ORDER* opaque_rect)
 {
 	size_t offset = 0;
 	ORDER_INFO orderInfo = WINPR_C_ARRAY_INIT;
@@ -1831,7 +1851,8 @@ static BOOL update_send_opaque_rect(rdpContext* context, const OPAQUE_RECT_ORDER
 	return TRUE;
 }
 
-static BOOL update_send_line_to(rdpContext* context, const LINE_TO_ORDER* line_to)
+WINPR_ATTR_NODISCARD static BOOL update_send_line_to(rdpContext* context,
+                                                     const LINE_TO_ORDER* line_to)
 {
 	ORDER_INFO orderInfo = WINPR_C_ARRAY_INIT;
 
@@ -1862,7 +1883,7 @@ static BOOL update_send_line_to(rdpContext* context, const LINE_TO_ORDER* line_t
 	return TRUE;
 }
 
-static BOOL update_send_memblt(rdpContext* context, MEMBLT_ORDER* memblt)
+WINPR_ATTR_NODISCARD static BOOL update_send_memblt(rdpContext* context, MEMBLT_ORDER* memblt)
 {
 	size_t offset = 0;
 	ORDER_INFO orderInfo = WINPR_C_ARRAY_INIT;
@@ -1894,7 +1915,8 @@ static BOOL update_send_memblt(rdpContext* context, MEMBLT_ORDER* memblt)
 	return TRUE;
 }
 
-static BOOL update_send_glyph_index(rdpContext* context, GLYPH_INDEX_ORDER* glyph_index)
+WINPR_ATTR_NODISCARD static BOOL update_send_glyph_index(rdpContext* context,
+                                                         GLYPH_INDEX_ORDER* glyph_index)
 {
 	ORDER_INFO orderInfo = WINPR_C_ARRAY_INIT;
 
@@ -1931,7 +1953,8 @@ static BOOL update_send_glyph_index(rdpContext* context, GLYPH_INDEX_ORDER* glyp
  * Secondary Drawing Orders
  */
 
-static BOOL update_send_cache_bitmap(rdpContext* context, const CACHE_BITMAP_ORDER* cache_bitmap)
+WINPR_ATTR_NODISCARD static BOOL update_send_cache_bitmap(rdpContext* context,
+                                                          const CACHE_BITMAP_ORDER* cache_bitmap)
 {
 	const size_t headerLength = 6;
 	UINT16 extraFlags = 0;
@@ -1977,7 +2000,8 @@ static BOOL update_send_cache_bitmap(rdpContext* context, const CACHE_BITMAP_ORD
 	return Stream_SetPosition(s, em);
 }
 
-static BOOL update_send_cache_bitmap_v2(rdpContext* context, CACHE_BITMAP_V2_ORDER* cache_bitmap_v2)
+WINPR_ATTR_NODISCARD static BOOL update_send_cache_bitmap_v2(rdpContext* context,
+                                                             CACHE_BITMAP_V2_ORDER* cache_bitmap_v2)
 {
 	const size_t headerLength = 6;
 	UINT16 extraFlags = 0;
@@ -2028,7 +2052,8 @@ static BOOL update_send_cache_bitmap_v2(rdpContext* context, CACHE_BITMAP_V2_ORD
 	return Stream_SetPosition(s, em);
 }
 
-static BOOL update_send_cache_bitmap_v3(rdpContext* context, CACHE_BITMAP_V3_ORDER* cache_bitmap_v3)
+WINPR_ATTR_NODISCARD static BOOL update_send_cache_bitmap_v3(rdpContext* context,
+                                                             CACHE_BITMAP_V3_ORDER* cache_bitmap_v3)
 {
 	const size_t headerLength = 6;
 	UINT16 extraFlags = 0;
@@ -2072,8 +2097,8 @@ static BOOL update_send_cache_bitmap_v3(rdpContext* context, CACHE_BITMAP_V3_ORD
 	return Stream_SetPosition(s, em);
 }
 
-static BOOL update_send_cache_color_table(rdpContext* context,
-                                          const CACHE_COLOR_TABLE_ORDER* cache_color_table)
+WINPR_ATTR_NODISCARD static BOOL
+update_send_cache_color_table(rdpContext* context, const CACHE_COLOR_TABLE_ORDER* cache_color_table)
 {
 	UINT16 flags = 0;
 	size_t headerLength = 6;
@@ -2115,7 +2140,8 @@ static BOOL update_send_cache_color_table(rdpContext* context,
 	return Stream_SetPosition(s, em);
 }
 
-static BOOL update_send_cache_glyph(rdpContext* context, const CACHE_GLYPH_ORDER* cache_glyph)
+WINPR_ATTR_NODISCARD static BOOL update_send_cache_glyph(rdpContext* context,
+                                                         const CACHE_GLYPH_ORDER* cache_glyph)
 {
 	UINT16 flags = 0;
 	const size_t headerLength = 6;
@@ -2157,8 +2183,8 @@ static BOOL update_send_cache_glyph(rdpContext* context, const CACHE_GLYPH_ORDER
 	return Stream_SetPosition(s, em);
 }
 
-static BOOL update_send_cache_glyph_v2(rdpContext* context,
-                                       const CACHE_GLYPH_V2_ORDER* cache_glyph_v2)
+WINPR_ATTR_NODISCARD static BOOL
+update_send_cache_glyph_v2(rdpContext* context, const CACHE_GLYPH_V2_ORDER* cache_glyph_v2)
 {
 	UINT16 flags = 0;
 	const size_t headerLength = 6;
@@ -2200,7 +2226,8 @@ static BOOL update_send_cache_glyph_v2(rdpContext* context,
 	return Stream_SetPosition(s, em);
 }
 
-static BOOL update_send_cache_brush(rdpContext* context, const CACHE_BRUSH_ORDER* cache_brush)
+WINPR_ATTR_NODISCARD static BOOL update_send_cache_brush(rdpContext* context,
+                                                         const CACHE_BRUSH_ORDER* cache_brush)
 {
 	UINT16 flags = 0;
 	const size_t headerLength = 6;
@@ -2248,7 +2275,7 @@ static BOOL update_send_cache_brush(rdpContext* context, const CACHE_BRUSH_ORDER
  * Alternate Secondary Drawing Orders
  */
 
-static BOOL update_send_create_offscreen_bitmap_order(
+WINPR_ATTR_NODISCARD static BOOL update_send_create_offscreen_bitmap_order(
     rdpContext* context, const CREATE_OFFSCREEN_BITMAP_ORDER* create_offscreen_bitmap)
 {
 	WINPR_ASSERT(context);
@@ -2286,8 +2313,8 @@ static BOOL update_send_create_offscreen_bitmap_order(
 	return Stream_SetPosition(s, em);
 }
 
-static BOOL update_send_switch_surface_order(rdpContext* context,
-                                             const SWITCH_SURFACE_ORDER* switch_surface)
+WINPR_ATTR_NODISCARD static BOOL
+update_send_switch_surface_order(rdpContext* context, const SWITCH_SURFACE_ORDER* switch_surface)
 {
 	WINPR_ASSERT(context);
 	WINPR_ASSERT(switch_surface);
@@ -2324,8 +2351,8 @@ static BOOL update_send_switch_surface_order(rdpContext* context,
 	return Stream_SetPosition(s, em);
 }
 
-static BOOL update_send_pointer_system(rdpContext* context,
-                                       const POINTER_SYSTEM_UPDATE* pointer_system)
+WINPR_ATTR_NODISCARD static BOOL
+update_send_pointer_system(rdpContext* context, const POINTER_SYSTEM_UPDATE* pointer_system)
 {
 	wStream* s = nullptr;
 	BYTE updateCode = 0;
@@ -2350,8 +2377,8 @@ static BOOL update_send_pointer_system(rdpContext* context,
 	return ret;
 }
 
-static BOOL update_send_pointer_position(rdpContext* context,
-                                         const POINTER_POSITION_UPDATE* pointerPosition)
+WINPR_ATTR_NODISCARD static BOOL
+update_send_pointer_position(rdpContext* context, const POINTER_POSITION_UPDATE* pointerPosition)
 {
 	wStream* s = nullptr;
 	WINPR_ASSERT(context);
@@ -2377,7 +2404,8 @@ out_fail:
 	return ret;
 }
 
-static BOOL update_write_pointer_color(wStream* s, const POINTER_COLOR_UPDATE* pointer_color)
+WINPR_ATTR_NODISCARD static BOOL
+update_write_pointer_color(wStream* s, const POINTER_COLOR_UPDATE* pointer_color)
 {
 	WINPR_ASSERT(pointer_color);
 	if (!Stream_EnsureRemainingCapacity(s, 32 + pointer_color->lengthAndMask +
@@ -2402,8 +2430,8 @@ static BOOL update_write_pointer_color(wStream* s, const POINTER_COLOR_UPDATE* p
 	return TRUE;
 }
 
-static BOOL update_send_pointer_color(rdpContext* context,
-                                      const POINTER_COLOR_UPDATE* pointer_color)
+WINPR_ATTR_NODISCARD static BOOL
+update_send_pointer_color(rdpContext* context, const POINTER_COLOR_UPDATE* pointer_color)
 {
 	wStream* s = nullptr;
 
@@ -2427,7 +2455,8 @@ out_fail:
 	return ret;
 }
 
-static BOOL update_write_pointer_large(wStream* s, const POINTER_LARGE_UPDATE* pointer)
+WINPR_ATTR_NODISCARD static BOOL update_write_pointer_large(wStream* s,
+                                                            const POINTER_LARGE_UPDATE* pointer)
 {
 	WINPR_ASSERT(pointer);
 
@@ -2448,7 +2477,8 @@ static BOOL update_write_pointer_large(wStream* s, const POINTER_LARGE_UPDATE* p
 	return TRUE;
 }
 
-static BOOL update_send_pointer_large(rdpContext* context, const POINTER_LARGE_UPDATE* pointer)
+WINPR_ATTR_NODISCARD static BOOL update_send_pointer_large(rdpContext* context,
+                                                           const POINTER_LARGE_UPDATE* pointer)
 {
 	wStream* s = nullptr;
 	WINPR_ASSERT(context);
@@ -2471,7 +2501,8 @@ out_fail:
 	return ret;
 }
 
-static BOOL update_send_pointer_new(rdpContext* context, const POINTER_NEW_UPDATE* pointer_new)
+WINPR_ATTR_NODISCARD static BOOL update_send_pointer_new(rdpContext* context,
+                                                         const POINTER_NEW_UPDATE* pointer_new)
 {
 	wStream* s = nullptr;
 
@@ -2491,15 +2522,16 @@ static BOOL update_send_pointer_new(rdpContext* context, const POINTER_NEW_UPDAT
 
 	Stream_Write_UINT16(
 	    s, WINPR_ASSERTING_INT_CAST(uint16_t, pointer_new->xorBpp)); /* xorBpp (2 bytes) */
-	update_write_pointer_color(s, &pointer_new->colorPtrAttr);
+	if (!update_write_pointer_color(s, &pointer_new->colorPtrAttr))
+		goto out_fail;
 	ret = fastpath_send_update_pdu(rdp->fastpath, FASTPATH_UPDATETYPE_POINTER, s, FALSE);
 out_fail:
 	Stream_Release(s);
 	return ret;
 }
 
-static BOOL update_send_pointer_cached(rdpContext* context,
-                                       const POINTER_CACHED_UPDATE* pointer_cached)
+WINPR_ATTR_NODISCARD static BOOL
+update_send_pointer_cached(rdpContext* context, const POINTER_CACHED_UPDATE* pointer_cached)
 {
 	wStream* s = nullptr;
 
@@ -2595,7 +2627,8 @@ BOOL update_read_suppress_output(rdpUpdate* update, wStream* s)
 	return TRUE;
 }
 
-static BOOL update_send_set_keyboard_indicators(rdpContext* context, UINT16 led_flags)
+WINPR_ATTR_NODISCARD static BOOL update_send_set_keyboard_indicators(rdpContext* context,
+                                                                     UINT16 led_flags)
 {
 	UINT16 sec_flags = 0;
 	wStream* s = nullptr;
@@ -2615,8 +2648,9 @@ static BOOL update_send_set_keyboard_indicators(rdpContext* context, UINT16 led_
 	                         sec_flags);
 }
 
-static BOOL update_send_set_keyboard_ime_status(rdpContext* context, UINT16 imeId, UINT32 imeState,
-                                                UINT32 imeConvMode)
+WINPR_ATTR_NODISCARD static BOOL update_send_set_keyboard_ime_status(rdpContext* context,
+                                                                     UINT16 imeId, UINT32 imeState,
+                                                                     UINT32 imeConvMode)
 {
 	UINT16 sec_flags = 0;
 	wStream* s = nullptr;
@@ -2638,8 +2672,9 @@ static BOOL update_send_set_keyboard_ime_status(rdpContext* context, UINT16 imeI
 	                         sec_flags);
 }
 
-static UINT16 update_calculate_new_or_existing_window(const WINDOW_ORDER_INFO* orderInfo,
-                                                      const WINDOW_STATE_ORDER* stateOrder)
+WINPR_ATTR_NODISCARD static UINT16
+update_calculate_new_or_existing_window(const WINDOW_ORDER_INFO* orderInfo,
+                                        const WINDOW_STATE_ORDER* stateOrder)
 {
 	size_t orderSize = 11;
 
@@ -2719,8 +2754,8 @@ static UINT16 update_calculate_new_or_existing_window(const WINDOW_ORDER_INFO* o
 	return WINPR_ASSERTING_INT_CAST(uint16_t, orderSize);
 }
 
-static BOOL update_write_order_field_flags(UINT32 fieldFlags, const WINDOW_STATE_ORDER* stateOrder,
-                                           wStream* s)
+WINPR_ATTR_NODISCARD static BOOL
+update_write_order_field_flags(UINT32 fieldFlags, const WINDOW_STATE_ORDER* stateOrder, wStream* s)
 {
 	WINPR_ASSERT(stateOrder);
 
@@ -2844,9 +2879,9 @@ static BOOL update_write_order_field_flags(UINT32 fieldFlags, const WINDOW_STATE
 	return TRUE;
 }
 
-static BOOL update_send_new_or_existing_window(rdpContext* context,
-                                               const WINDOW_ORDER_INFO* orderInfo,
-                                               const WINDOW_STATE_ORDER* stateOrder)
+WINPR_ATTR_NODISCARD static BOOL
+update_send_new_or_existing_window(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo,
+                                   const WINDOW_STATE_ORDER* stateOrder)
 {
 	BYTE controlFlags = ORDER_SECONDARY | (ORDER_TYPE_WINDOW << 2);
 	UINT16 orderSize = update_calculate_new_or_existing_window(orderInfo, stateOrder);
@@ -2880,19 +2915,21 @@ static BOOL update_send_new_or_existing_window(rdpContext* context,
 	return TRUE;
 }
 
-static BOOL update_send_window_create(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo,
-                                      const WINDOW_STATE_ORDER* stateOrder)
+WINPR_ATTR_NODISCARD static BOOL update_send_window_create(rdpContext* context,
+                                                           const WINDOW_ORDER_INFO* orderInfo,
+                                                           const WINDOW_STATE_ORDER* stateOrder)
 {
 	return update_send_new_or_existing_window(context, orderInfo, stateOrder);
 }
 
-static BOOL update_send_window_update(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo,
-                                      const WINDOW_STATE_ORDER* stateOrder)
+WINPR_ATTR_NODISCARD static BOOL update_send_window_update(rdpContext* context,
+                                                           const WINDOW_ORDER_INFO* orderInfo,
+                                                           const WINDOW_STATE_ORDER* stateOrder)
 {
 	return update_send_new_or_existing_window(context, orderInfo, stateOrder);
 }
 
-static UINT16
+WINPR_ATTR_NODISCARD static UINT16
 update_calculate_window_icon_order(WINPR_ATTR_UNUSED const WINDOW_ORDER_INFO* orderInfo,
                                    const WINDOW_ICON_ORDER* iconOrder)
 {
@@ -2910,8 +2947,9 @@ update_calculate_window_icon_order(WINPR_ATTR_UNUSED const WINDOW_ORDER_INFO* or
 	return orderSize;
 }
 
-static BOOL update_send_window_icon(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo,
-                                    const WINDOW_ICON_ORDER* iconOrder)
+WINPR_ATTR_NODISCARD static BOOL update_send_window_icon(rdpContext* context,
+                                                         const WINDOW_ORDER_INFO* orderInfo,
+                                                         const WINDOW_ICON_ORDER* iconOrder)
 {
 	BYTE controlFlags = ORDER_SECONDARY | (ORDER_TYPE_WINDOW << 2);
 
@@ -2975,8 +3013,9 @@ static BOOL update_send_window_icon(rdpContext* context, const WINDOW_ORDER_INFO
 	return TRUE;
 }
 
-static BOOL update_send_window_cached_icon(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo,
-                                           const WINDOW_CACHED_ICON_ORDER* cachedIconOrder)
+WINPR_ATTR_NODISCARD static BOOL
+update_send_window_cached_icon(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo,
+                               const WINDOW_CACHED_ICON_ORDER* cachedIconOrder)
 {
 	BYTE controlFlags = ORDER_SECONDARY | (ORDER_TYPE_WINDOW << 2);
 	UINT16 orderSize = 14;
@@ -3014,7 +3053,8 @@ static BOOL update_send_window_cached_icon(rdpContext* context, const WINDOW_ORD
 	return TRUE;
 }
 
-static BOOL update_send_window_delete(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo)
+WINPR_ATTR_NODISCARD static BOOL update_send_window_delete(rdpContext* context,
+                                                           const WINDOW_ORDER_INFO* orderInfo)
 {
 	BYTE controlFlags = ORDER_SECONDARY | (ORDER_TYPE_WINDOW << 2);
 	UINT16 orderSize = 11;
@@ -3043,7 +3083,7 @@ static BOOL update_send_window_delete(rdpContext* context, const WINDOW_ORDER_IN
 	return TRUE;
 }
 
-static UINT16 update_calculate_new_or_existing_notification_icons_order(
+WINPR_ATTR_NODISCARD static UINT16 update_calculate_new_or_existing_notification_icons_order(
     const WINDOW_ORDER_INFO* orderInfo, const NOTIFY_ICON_STATE_ORDER* iconStateOrder)
 {
 	UINT16 orderSize = 15;
@@ -3088,7 +3128,8 @@ static UINT16 update_calculate_new_or_existing_notification_icons_order(
 	return orderSize;
 }
 
-static BOOL update_send_new_or_existing_order_icon(const ICON_INFO* iconInfo, wStream* s)
+WINPR_ATTR_NODISCARD static BOOL update_send_new_or_existing_order_icon(const ICON_INFO* iconInfo,
+                                                                        wStream* s)
 {
 	WINPR_ASSERT(iconInfo);
 
@@ -3134,7 +3175,7 @@ static BOOL update_send_new_or_existing_order_icon(const ICON_INFO* iconInfo, wS
 	return TRUE;
 }
 
-static BOOL
+WINPR_ATTR_NODISCARD static BOOL
 update_send_new_or_existing_notification_icons(rdpContext* context,
                                                const WINDOW_ORDER_INFO* orderInfo,
                                                const NOTIFY_ICON_STATE_ORDER* iconStateOrder)
@@ -3224,19 +3265,22 @@ update_send_new_or_existing_notification_icons(rdpContext* context,
 	return TRUE;
 }
 
-static BOOL update_send_notify_icon_create(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo,
-                                           const NOTIFY_ICON_STATE_ORDER* iconStateOrder)
+WINPR_ATTR_NODISCARD static BOOL
+update_send_notify_icon_create(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo,
+                               const NOTIFY_ICON_STATE_ORDER* iconStateOrder)
 {
 	return update_send_new_or_existing_notification_icons(context, orderInfo, iconStateOrder);
 }
 
-static BOOL update_send_notify_icon_update(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo,
-                                           const NOTIFY_ICON_STATE_ORDER* iconStateOrder)
+WINPR_ATTR_NODISCARD static BOOL
+update_send_notify_icon_update(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo,
+                               const NOTIFY_ICON_STATE_ORDER* iconStateOrder)
 {
 	return update_send_new_or_existing_notification_icons(context, orderInfo, iconStateOrder);
 }
 
-static BOOL update_send_notify_icon_delete(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo)
+WINPR_ATTR_NODISCARD static BOOL update_send_notify_icon_delete(rdpContext* context,
+                                                                const WINDOW_ORDER_INFO* orderInfo)
 {
 	BYTE controlFlags = ORDER_SECONDARY | (ORDER_TYPE_WINDOW << 2);
 	UINT16 orderSize = 15;
@@ -3263,8 +3307,9 @@ static BOOL update_send_notify_icon_delete(rdpContext* context, const WINDOW_ORD
 	return TRUE;
 }
 
-static UINT16 update_calculate_monitored_desktop(const WINDOW_ORDER_INFO* orderInfo,
-                                                 const MONITORED_DESKTOP_ORDER* monitoredDesktop)
+WINPR_ATTR_NODISCARD static UINT16
+update_calculate_monitored_desktop(const WINDOW_ORDER_INFO* orderInfo,
+                                   const MONITORED_DESKTOP_ORDER* monitoredDesktop)
 {
 	UINT16 orderSize = 7;
 
@@ -3284,8 +3329,9 @@ static UINT16 update_calculate_monitored_desktop(const WINDOW_ORDER_INFO* orderI
 	return orderSize;
 }
 
-static BOOL update_send_monitored_desktop(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo,
-                                          const MONITORED_DESKTOP_ORDER* monitoredDesktop)
+WINPR_ATTR_NODISCARD static BOOL
+update_send_monitored_desktop(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo,
+                              const MONITORED_DESKTOP_ORDER* monitoredDesktop)
 {
 	BYTE controlFlags = ORDER_SECONDARY | (ORDER_TYPE_WINDOW << 2);
 	UINT16 orderSize = update_calculate_monitored_desktop(orderInfo, monitoredDesktop);
@@ -3331,8 +3377,8 @@ static BOOL update_send_monitored_desktop(rdpContext* context, const WINDOW_ORDE
 	return TRUE;
 }
 
-static BOOL update_send_non_monitored_desktop(rdpContext* context,
-                                              const WINDOW_ORDER_INFO* orderInfo)
+WINPR_ATTR_NODISCARD static BOOL
+update_send_non_monitored_desktop(rdpContext* context, const WINDOW_ORDER_INFO* orderInfo)
 {
 	BYTE controlFlags = ORDER_SECONDARY | (ORDER_TYPE_WINDOW << 2);
 	UINT16 orderSize = 7;

--- a/winpr/libwinpr/handle/handle.c
+++ b/winpr/libwinpr/handle/handle.c
@@ -108,7 +108,7 @@ BOOL winpr_exportHandleToString(HANDLE h, const char* format, char* outStr, size
 		return FALSE;
 	remaining -= suffixLen;
 
-	char value[32] = { 0 };
+	char value[32] = WINPR_C_ARRAY_INIT;
 #ifdef _WIN32
 	const int valueLenInt = snprintf(value, sizeof(value), "%llx", (unsigned long long)(UINT_PTR)h);
 #else

--- a/winpr/libwinpr/sysinfo/sysinfo.c
+++ b/winpr/libwinpr/sysinfo/sysinfo.c
@@ -605,7 +605,7 @@ static BOOL sysinfo_read_sysfs_string(const char* path, char* buffer, size_t siz
 
 static BOOL sysinfo_read_sysfs_int(const char* path, long long* value)
 {
-	char buffer[64] = { 0 };
+	char buffer[64] = WINPR_C_ARRAY_INIT;
 	if (!sysinfo_read_sysfs_string(path, buffer, sizeof(buffer)))
 		return FALSE;
 
@@ -645,8 +645,8 @@ static BOOL sysinfo_get_power_status_platform(LPSYSTEM_POWER_STATUS status)
 	// NOLINTNEXTLINE(concurrency-mt-unsafe): dir is a local DIR*, not shared across threads
 	while ((entry = readdir(dir)) != nullptr)
 	{
-		char path[PATH_MAX] = { 0 };
-		char value[64] = { 0 };
+		char path[PATH_MAX] = WINPR_C_ARRAY_INIT;
+		char value[64] = WINPR_C_ARRAY_INIT;
 		long long v = 0;
 
 		if (entry->d_name[0] == '.')


### PR DESCRIPTION
pointer_cache_resize reallocates an array of rdpPointer** Explicitly cast rdpPointer** to void* so realloc does not do a multilevel pointer conversion.