### PR TITLE
[alignment] add WINPR_PACKED_ALIGN_CAST

### DIFF
--- a/channels/cliprdr/client/cliprdr_main.c
+++ b/channels/cliprdr/client/cliprdr_main.c
@@ -581,7 +581,8 @@ static UINT cliprdr_client_capabilities(CliprdrClientContext* context,
 
 	Stream_Write_UINT16(s, 1); /* cCapabilitiesSets */
 	Stream_Write_UINT16(s, 0); /* pad1 */
-	generalCapabilitySet = (const CLIPRDR_GENERAL_CAPABILITY_SET*)capabilities->capabilitySets;
+	generalCapabilitySet = WINPR_PACKED_ALIGN_CAST(const CLIPRDR_GENERAL_CAPABILITY_SET*,
+	                                               capabilities->capabilitySets);
 	Stream_Write_UINT16(s, generalCapabilitySet->capabilitySetType);   /* capabilitySetType */
 	Stream_Write_UINT16(s, generalCapabilitySet->capabilitySetLength); /* lengthCapability */
 	Stream_Write_UINT32(s, generalCapabilitySet->version);             /* version */

--- a/channels/cliprdr/server/cliprdr_main.c
+++ b/channels/cliprdr/server/cliprdr_main.c
@@ -143,8 +143,8 @@ static UINT cliprdr_server_capabilities(CliprdrServerContext* context,
 	Stream_Write_UINT16(s, 0);                                    /* pad1 (2 bytes) */
 	for (UINT32 x = 0; x < capabilities->cCapabilitiesSets; x++)
 	{
-		const CLIPRDR_CAPABILITY_SET* cap =
-		    (const CLIPRDR_CAPABILITY_SET*)(((const BYTE*)capabilities->capabilitySets) + offset);
+		const CLIPRDR_CAPABILITY_SET* cap = WINPR_PACKED_ALIGN_CAST(
+		    const CLIPRDR_CAPABILITY_SET*, (((const BYTE*)capabilities->capabilitySets) + offset));
 		offset += cap->capabilitySetLength;
 
 		switch (cap->capabilitySetType)
@@ -152,7 +152,7 @@ static UINT cliprdr_server_capabilities(CliprdrServerContext* context,
 			case CB_CAPSTYPE_GENERAL:
 			{
 				const CLIPRDR_GENERAL_CAPABILITY_SET* generalCapabilitySet =
-				    (const CLIPRDR_GENERAL_CAPABILITY_SET*)cap;
+				    WINPR_PACKED_ALIGN_CAST(const CLIPRDR_GENERAL_CAPABILITY_SET*, cap);
 				Stream_Write_UINT16(
 				    s, generalCapabilitySet->capabilitySetType); /* capabilitySetType (2 bytes) */
 				Stream_Write_UINT16(
@@ -503,7 +503,8 @@ static BOOL cliprdr_capabilities_contain_capset(wLog* log, const CLIPRDR_CAPABIL
 	size_t byteOffset = 0;
 	for (UINT32 x = 0; x < capabilities->cCapabilitiesSets; x++)
 	{
-		const CLIPRDR_CAPABILITY_SET* cur = (const CLIPRDR_CAPABILITY_SET*)offset;
+		const CLIPRDR_CAPABILITY_SET* cur =
+		    WINPR_PACKED_ALIGN_CAST(const CLIPRDR_CAPABILITY_SET*, offset);
 		byteOffset += cur->capabilitySetLength;
 		if (byteOffset > capabilitiesSize)
 			return FALSE;
@@ -578,8 +579,8 @@ static UINT cliprdr_server_receive_capabilities(CliprdrServerContext* context, w
 
 		capabilities.capabilitySets = tmp;
 
-		CLIPRDR_CAPABILITY_SET* capSet =
-		    (CLIPRDR_CAPABILITY_SET*)(((BYTE*)capabilities.capabilitySets) + cap_set_offset);
+		CLIPRDR_CAPABILITY_SET* capSet = WINPR_PACKED_ALIGN_CAST(
+		    CLIPRDR_CAPABILITY_SET*, (((BYTE*)capabilities.capabilitySets) + cap_set_offset));
 
 		capSet->capabilitySetType = capabilitySetType;
 		capSet->capabilitySetLength = capabilitySetLength;
@@ -593,7 +594,7 @@ static UINT cliprdr_server_receive_capabilities(CliprdrServerContext* context, w
 		{
 			case CB_CAPSTYPE_GENERAL:
 				error = cliprdr_server_receive_general_capability(
-				    context, s, (CLIPRDR_GENERAL_CAPABILITY_SET*)capSet);
+				    context, s, WINPR_PACKED_ALIGN_CAST(CLIPRDR_GENERAL_CAPABILITY_SET*, capSet));
 				if (error)
 				{
 					WLog_Print(

--- a/channels/urbdrc/client/libusb/libusb_udevice.c
+++ b/channels/urbdrc/client/libusb/libusb_udevice.c
@@ -849,7 +849,7 @@ static UINT32 libusb_udev_control_query_device_text(IUDEVICE* idev, UINT32 TextT
 	BYTE device_address = 0;
 	int ret = 0;
 	URBDRC_PLUGIN* urbdrc = nullptr;
-	WCHAR* text = (WCHAR*)Buffer;
+	WCHAR* text = WINPR_PACKED_ALIGN_CAST(WCHAR*, Buffer);
 	BYTE slen = 0;
 	BYTE locale = 0;
 	const UINT8 inSize = *BufferSize;

--- a/client/Wayland/wlf_cliprdr.c
+++ b/client/Wayland/wlf_cliprdr.c
@@ -472,12 +472,13 @@ static UINT wlf_cliprdr_server_capabilities(CliprdrClientContext* context,
 
 	for (UINT32 i = 0; i < capabilities->cCapabilitiesSets; i++)
 	{
-		const CLIPRDR_CAPABILITY_SET* caps = (const CLIPRDR_CAPABILITY_SET*)capsPtr;
+		const CLIPRDR_CAPABILITY_SET* caps =
+		    WINPR_PACKED_ALIGN_CAST(const CLIPRDR_CAPABILITY_SET*, capsPtr);
 
 		if (caps->capabilitySetType == CB_CAPSTYPE_GENERAL)
 		{
 			const CLIPRDR_GENERAL_CAPABILITY_SET* generalCaps =
-			    (const CLIPRDR_GENERAL_CAPABILITY_SET*)caps;
+			    WINPR_PACKED_ALIGN_CAST(const CLIPRDR_GENERAL_CAPABILITY_SET*, caps);
 
 			if (!cliprdr_file_context_remote_set_flags(clipboard->file, generalCaps->generalFlags))
 				return ERROR_INTERNAL_ERROR;
@@ -806,7 +807,8 @@ wlf_cliprdr_server_format_data_request(CliprdrClientContext* context,
 		{
 			const UINT32 flags = cliprdr_file_context_remote_get_flags(clipboard->file);
 			const UINT32 error = cliprdr_serialize_file_list_ex(
-			    flags, (const FILEDESCRIPTORW*)data, len / sizeof(FILEDESCRIPTORW), &ddata, &dsize);
+			    flags, WINPR_PACKED_ALIGN_CAST(const FILEDESCRIPTORW*, data),
+			    len / sizeof(FILEDESCRIPTORW), &ddata, &dsize);
 			if (error)
 				goto fail;
 		}

--- a/client/X11/xf_cliprdr.c
+++ b/client/X11/xf_cliprdr.c
@@ -782,7 +782,7 @@ static CLIPRDR_FORMAT* xf_cliprdr_get_formats_from_targets(xfClipboard* clipboar
 		const uint32_t htmlFormatId = ClipboardRegisterFormat(clipboard->system, type_HtmlFormat);
 		for (unsigned long i = 0; i < proplength; i++)
 		{
-			Atom tatom = ((Atom*)data)[i];
+			Atom tatom = WINPR_PACKED_ALIGN_CAST(Atom*, data)[i];
 			const xfCliprdrFormat* format = xf_cliprdr_get_client_format_by_atom(clipboard, tatom);
 
 			if (xf_cliprdr_should_add_format(formats, *numFormats, format))
@@ -833,7 +833,7 @@ out:
 		XFree(data);
 	else if (atoms && data)
 	{
-		*atoms = (Atom*)data;
+		*atoms = WINPR_PACKED_ALIGN_CAST(Atom*, data);
 		*atomsCount = proplength;
 	}
 
@@ -1074,7 +1074,7 @@ static void xf_cliprdr_process_requested_data(xfClipboard* clipboard, BOOL hasDa
 	     ClipboardGetFormatId(clipboard->system, type_FileGroupDescriptorW)))
 	{
 		UINT error = NO_ERROR;
-		FILEDESCRIPTORW* file_array = (FILEDESCRIPTORW*)pDstData;
+		FILEDESCRIPTORW* file_array = WINPR_PACKED_ALIGN_CAST(FILEDESCRIPTORW*, pDstData);
 		UINT32 file_count = DstSize / sizeof(FILEDESCRIPTORW);
 		pDstData = nullptr;
 		DstSize = 0;
@@ -2053,12 +2053,13 @@ static UINT xf_cliprdr_server_capabilities(CliprdrClientContext* context,
 
 	for (UINT32 i = 0; i < capabilities->cCapabilitiesSets; i++)
 	{
-		const CLIPRDR_CAPABILITY_SET* caps = (const CLIPRDR_CAPABILITY_SET*)capsPtr;
+		const CLIPRDR_CAPABILITY_SET* caps =
+		    WINPR_PACKED_ALIGN_CAST(const CLIPRDR_CAPABILITY_SET*, capsPtr);
 
 		if (caps->capabilitySetType == CB_CAPSTYPE_GENERAL)
 		{
 			const CLIPRDR_GENERAL_CAPABILITY_SET* generalCaps =
-			    (const CLIPRDR_GENERAL_CAPABILITY_SET*)caps;
+			    WINPR_PACKED_ALIGN_CAST(const CLIPRDR_GENERAL_CAPABILITY_SET*, caps);
 
 			if (!cliprdr_file_context_remote_set_flags(clipboard->file, generalCaps->generalFlags))
 				return ERROR_INTERNAL_ERROR;

--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -1021,9 +1021,10 @@ static BOOL xf_event_PropertyNotify(xfContext* xfc, const XPropertyEvent* event,
 				}
 				for (unsigned long i = 0; i < nitems; i++)
 				{
-					if ((Atom)((UINT16**)prop)[i] == xfc->NET_WM_STATE_FULLSCREEN)
+					if ((Atom)WINPR_PACKED_ALIGN_CAST(UINT16**, prop)[i] ==
+					    xfc->NET_WM_STATE_FULLSCREEN)
 						fullscreen = TRUE;
-					if ((Atom)((UINT16**)prop)[i] ==
+					if ((Atom)(WINPR_PACKED_ALIGN_CAST(UINT16**, prop))[i] ==
 					    Logging_XInternAtom(xfc->log, xfc->display, "_NET_WM_STATE_MAXIMIZED_VERT",
 					                        False))
 					{
@@ -1031,7 +1032,7 @@ static BOOL xf_event_PropertyNotify(xfContext* xfc, const XPropertyEvent* event,
 							appWindow->maxVert = TRUE;
 					}
 
-					if ((Atom)((UINT16**)prop)[i] ==
+					if ((Atom)(WINPR_PACKED_ALIGN_CAST(UINT16**, prop)[i]) ==
 					    Logging_XInternAtom(xfc->log, xfc->display, "_NET_WM_STATE_MAXIMIZED_HORZ",
 					                        False))
 					{

--- a/client/X11/xf_input.c
+++ b/client/X11/xf_input.c
@@ -124,7 +124,8 @@ static BOOL register_input_events(xfContext* xfc, Window window)
 					break;
 				case XIButtonClass:
 				{
-					const XIButtonClassInfo* t = (const XIButtonClassInfo*)c_class;
+					const XIButtonClassInfo* t =
+					    WINPR_PACKED_ALIGN_CAST(const XIButtonClassInfo*, c_class);
 					WLog_DBG(TAG, "%s button device (id: %d, mode: %d)", dev->name, dev->deviceid,
 					         t->num_buttons);
 					XISetMask(masks[nmasks], XI_ButtonPress);
@@ -139,7 +140,8 @@ static BOOL register_input_events(xfContext* xfc, Window window)
 					if (!log)
 						log = WLog_Get(TAG);
 
-					const XIValuatorClassInfo* t = (const XIValuatorClassInfo*)c_class;
+					const XIValuatorClassInfo* t =
+					    WINPR_PACKED_ALIGN_CAST(const XIValuatorClassInfo*, c_class);
 					char* name =
 					    t->label ? Safe_XGetAtomName(log, xfc->display, t->label) : nullptr;
 

--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -407,7 +407,7 @@ void xf_SetWindowFullscreen(xfContext* xfc, xfWindow* window, BOOL fullscreen)
 				if (xf_GetWindowProperty(xfc, window->handle, xfc->NET_WM_STATE, 255, &nitems,
 				                         &bytes, &prop))
 				{
-					const Atom* aprop = (const Atom*)prop;
+					const Atom* aprop = WINPR_PACKED_ALIGN_CAST(const Atom*, prop);
 					state = 0;
 
 					for (size_t x = 0; x < nitems; x++)
@@ -519,7 +519,7 @@ static BOOL xf_GetNumberOfDesktops(xfContext* xfc, Window root, unsigned* pval)
 	const BOOL rc =
 	    xf_GetWindowProperty(xfc, root, xfc->NET_NUMBER_OF_DESKTOPS, 1, &nitems, &bytes, &bprop);
 
-	long* prop = (long*)bprop;
+	long* prop = WINPR_PACKED_ALIGN_CAST(long*, bprop);
 	*pval = 0;
 
 	BOOL res = FALSE;
@@ -551,7 +551,7 @@ static BOOL xf_GetCurrentDesktop(xfContext* xfc, Window root)
 	const BOOL rc =
 	    xf_GetWindowProperty(xfc, root, xfc->NET_CURRENT_DESKTOP, 1, &nitems, &bytes, &bprop);
 
-	long* prop = (long*)bprop;
+	long* prop = WINPR_PACKED_ALIGN_CAST(long*, bprop);
 	xfc->current_desktop = 0;
 	if (rc)
 		xfc->current_desktop = (int)MIN(max - 1, *prop);
@@ -569,7 +569,7 @@ static BOOL xf_GetWorkArea_NET_WORKAREA(xfContext* xfc, Window root)
 
 	const BOOL status =
 	    xf_GetWindowProperty(xfc, root, xfc->NET_WORKAREA, INT_MAX, &nitems, &bytes, &bprop);
-	long* prop = (long*)bprop;
+	long* prop = WINPR_PACKED_ALIGN_CAST(long*, bprop);
 
 	if (!status)
 		goto fail;

--- a/client/common/client_cliprdr_file.c
+++ b/client/common/client_cliprdr_file.c
@@ -1282,7 +1282,8 @@ static UINT cliprdr_file_context_server_file_contents_response(
 		DEBUG_CLIPRDR(file_context->log, "Received file size for file \"%s\" with stream id %u",
 		              fuse_request->fuse_file->filename, file_contents_response->streamId);
 
-		fuse_request->fuse_file->size = *((const UINT64*)file_contents_response->requestedData);
+		fuse_request->fuse_file->size =
+		    *(WINPR_PACKED_ALIGN_CAST(const UINT64*, file_contents_response->requestedData));
 		fuse_request->fuse_file->has_size = TRUE;
 
 		entry.ino = fuse_request->fuse_file->ino;

--- a/client/common/file.c
+++ b/client/common/file.c
@@ -968,7 +968,7 @@ BOOL freerdp_client_parse_rdp_file_buffer_ex(rdpFile* file, const BYTE* buffer, 
 
 	if ((buffer[0] == BOM_UTF16_LE[0]) && (buffer[1] == BOM_UTF16_LE[1]))
 	{
-		LPCWSTR uc = (LPCWSTR)(&buffer[2]);
+		LPCWSTR uc = WINPR_PACKED_ALIGN_CAST(LPCWSTR, (&buffer[2]));
 		const size_t charlen = size / sizeof(WCHAR) - 1;
 		copy = ConvertWCharNToUtf8Alloc(uc, charlen, &size);
 		if (!copy)

--- a/cmake/CommonCompilerFlags.cmake
+++ b/cmake/CommonCompilerFlags.cmake
@@ -16,7 +16,6 @@ if(ENABLE_WARNING_VERBOSE)
       -Wpedantic
       -Wno-padded
       -Wno-switch-enum
-      -Wno-cast-align
       -Wno-unsafe-buffer-usage
       -Wno-reserved-identifier
       -Wno-covered-switch-default

--- a/cmake/WarnExperimental.cmake
+++ b/cmake/WarnExperimental.cmake
@@ -1,5 +1,3 @@
-set(WARN_EXPERIMENTAL_LIST_PRIVATE "" CACHE INTERNAL "dependencies")
-
 function(warn_experimental name)
   set(CUR_NAMES ${name})
   if(ARGN)

--- a/libfreerdp/codec/audio.c
+++ b/libfreerdp/codec/audio.c
@@ -53,7 +53,7 @@ UINT32 audio_format_compute_time_length(const AUDIO_FORMAT* format, size_t size)
 
 			if ((format->cbSize == 2) && (format->data))
 			{
-				nSamplesPerBlock = *((UINT16*)format->data);
+				nSamplesPerBlock = *(WINPR_PACKED_ALIGN_CAST(UINT16*, format->data));
 				const size_t samples = (size / format->nBlockAlign) * nSamplesPerBlock;
 				WINPR_ASSERT(samples <= UINT32_MAX);
 				wSamples = (UINT32)samples;

--- a/libfreerdp/codec/clear.c
+++ b/libfreerdp/codec/clear.c
@@ -1031,7 +1031,7 @@ static BOOL clear_decompress_glyph_data(CLEAR_CONTEXT* WINPR_RESTRICT clear,
 
 			glyphEntry->count = WINPR_ASSERTING_INT_CAST(UINT32, count);
 			glyphEntry->size = glyphEntry->count;
-			glyphEntry->pixels = (UINT32*)tmp;
+			glyphEntry->pixels = WINPR_PACKED_ALIGN_CAST(UINT32*, tmp);
 		}
 
 		if (!glyphEntry->pixels)

--- a/libfreerdp/codec/dsp_ffmpeg.c
+++ b/libfreerdp/codec/dsp_ffmpeg.c
@@ -467,7 +467,7 @@ static BOOL ffmpeg_encode_frame(AVCodecContext* WINPR_RESTRICT context, AVFrame*
 
 		for (int y = 0; y < nr_channels; y++)
 		{
-			float* data = (float*)pp[y];
+			float* data = WINPR_PACKED_ALIGN_CAST(float*, pp[y]);
 			for (int x = 0; x < in->nb_samples; x++)
 			{
 				const float val1 = data[x];

--- a/libfreerdp/codec/interleaved.c
+++ b/libfreerdp/codec/interleaved.c
@@ -467,7 +467,8 @@ static inline void write_pixel_16(BYTE* _buf, UINT16 _pix)
 		write_pixel_16(_buf, _pix); \
 		(_buf) += 2;                \
 	} while (0)
-#define DESTREADPIXEL(_pix, _buf) _pix = ((UINT16*)(_buf))[0]
+#define DESTREADPIXEL(_pix, _buf) \
+	(_pix) = WINPR_ASSERTING_INT_CAST(UINT16, (_buf)[0] | (((_buf)[1] << 8) & 0xFF00))
 #define SRCREADPIXEL(_pix, _buf)                                                            \
 	do                                                                                      \
 	{                                                                                       \

--- a/libfreerdp/codec/neon/rfx_neon.c
+++ b/libfreerdp/codec/neon/rfx_neon.c
@@ -41,8 +41,8 @@ static inline void __attribute__((__gnu_inline__, __always_inline__, __artificia
 rfx_quantization_decode_block_NEON(INT16* buffer, const size_t buffer_size, const UINT32 factor)
 {
 	int16x8_t quantFactors = vdupq_n_s16(factor);
-	int16x8_t* buf = (int16x8_t*)buffer;
-	int16x8_t* buf_end = (int16x8_t*)(buffer + buffer_size);
+	int16x8_t* buf = WINPR_PACKED_ALIGN_CAST(int16x8_t*, buffer);
+	int16x8_t* buf_end = WINPR_PACKED_ALIGN_CAST(int16x8_t*, (buffer + buffer_size));
 
 	do
 	{

--- a/libfreerdp/codec/progressive.c
+++ b/libfreerdp/codec/progressive.c
@@ -1034,18 +1034,27 @@ progressive_decompress_tile_first(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progressiv
 	if (!progressive_rfx_quant_lsub(&shiftCr, 1)) /* -6 + 5 = -1 */
 		goto fail;
 
-	pSign[0] = (INT16*)((&tile->sign[((8192 + 32) * 0) + 16])); /* Y/R buffer */
-	pSign[1] = (INT16*)((&tile->sign[((8192 + 32) * 1) + 16])); /* Cb/G buffer */
-	pSign[2] = (INT16*)((&tile->sign[((8192 + 32) * 2) + 16])); /* Cr/B buffer */
+	pSign[0] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&tile->sign[((8192 + 32) * 0) + 16])); /* Y/R buffer */
+	pSign[1] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&tile->sign[((8192 + 32) * 1) + 16])); /* Cb/G buffer */
+	pSign[2] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&tile->sign[((8192 + 32) * 2) + 16])); /* Cr/B buffer */
 
-	pCurrent[0] = (INT16*)((&tile->current[((8192 + 32) * 0) + 16])); /* Y/R buffer */
-	pCurrent[1] = (INT16*)((&tile->current[((8192 + 32) * 1) + 16])); /* Cb/G buffer */
-	pCurrent[2] = (INT16*)((&tile->current[((8192 + 32) * 2) + 16])); /* Cr/B buffer */
+	pCurrent[0] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&tile->current[((8192 + 32) * 0) + 16])); /* Y/R buffer */
+	pCurrent[1] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&tile->current[((8192 + 32) * 1) + 16])); /* Cb/G buffer */
+	pCurrent[2] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&tile->current[((8192 + 32) * 2) + 16])); /* Cr/B buffer */
 
 	pBuffer = (BYTE*)BufferPool_Take(progressive->bufferPool, -1);
-	pSrcDst[0] = (INT16*)((&pBuffer[((8192 + 32) * 0) + 16])); /* Y/R buffer */
-	pSrcDst[1] = (INT16*)((&pBuffer[((8192 + 32) * 1) + 16])); /* Cb/G buffer */
-	pSrcDst[2] = (INT16*)((&pBuffer[((8192 + 32) * 2) + 16])); /* Cr/B buffer */
+	pSrcDst[0] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&pBuffer[((8192 + 32) * 0) + 16])); /* Y/R buffer */
+	pSrcDst[1] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&pBuffer[((8192 + 32) * 1) + 16])); /* Cb/G buffer */
+	pSrcDst[2] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&pBuffer[((8192 + 32) * 2) + 16])); /* Cr/B buffer */
 
 	rc = progressive_rfx_decode_component(progressive, &shiftY, tile->yData, tile->yLen, pSrcDst[0],
 	                                      pCurrent[0], pSign[0], diff, sub, extrapolate); /* Y */
@@ -1465,18 +1474,27 @@ progressive_decompress_tile_upgrade(PROGRESSIVE_CONTEXT* WINPR_RESTRICT progress
 	tile->cbProgQuant = *quantProgCb;
 	tile->crProgQuant = *quantProgCr;
 
-	pSign[0] = (INT16*)((&tile->sign[((8192 + 32) * 0) + 16])); /* Y/R buffer */
-	pSign[1] = (INT16*)((&tile->sign[((8192 + 32) * 1) + 16])); /* Cb/G buffer */
-	pSign[2] = (INT16*)((&tile->sign[((8192 + 32) * 2) + 16])); /* Cr/B buffer */
+	pSign[0] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&tile->sign[((8192 + 32) * 0) + 16])); /* Y/R buffer */
+	pSign[1] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&tile->sign[((8192 + 32) * 1) + 16])); /* Cb/G buffer */
+	pSign[2] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&tile->sign[((8192 + 32) * 2) + 16])); /* Cr/B buffer */
 
-	pCurrent[0] = (INT16*)((&tile->current[((8192 + 32) * 0) + 16])); /* Y/R buffer */
-	pCurrent[1] = (INT16*)((&tile->current[((8192 + 32) * 1) + 16])); /* Cb/G buffer */
-	pCurrent[2] = (INT16*)((&tile->current[((8192 + 32) * 2) + 16])); /* Cr/B buffer */
+	pCurrent[0] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&tile->current[((8192 + 32) * 0) + 16])); /* Y/R buffer */
+	pCurrent[1] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&tile->current[((8192 + 32) * 1) + 16])); /* Cb/G buffer */
+	pCurrent[2] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&tile->current[((8192 + 32) * 2) + 16])); /* Cr/B buffer */
 
 	pBuffer = (BYTE*)BufferPool_Take(progressive->bufferPool, -1);
-	pSrcDst[0] = (INT16*)((&pBuffer[((8192 + 32) * 0) + 16])); /* Y/R buffer */
-	pSrcDst[1] = (INT16*)((&pBuffer[((8192 + 32) * 1) + 16])); /* Cb/G buffer */
-	pSrcDst[2] = (INT16*)((&pBuffer[((8192 + 32) * 2) + 16])); /* Cr/B buffer */
+	pSrcDst[0] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&pBuffer[((8192 + 32) * 0) + 16])); /* Y/R buffer */
+	pSrcDst[1] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&pBuffer[((8192 + 32) * 1) + 16])); /* Cb/G buffer */
+	pSrcDst[2] =
+	    WINPR_PACKED_ALIGN_CAST(INT16*, (&pBuffer[((8192 + 32) * 2) + 16])); /* Cr/B buffer */
 
 	status = progressive_rfx_upgrade_component(progressive, &shiftY, quantProgY, &yNumBits,
 	                                           pSrcDst[0], pCurrent[0], pSign[0], tile->ySrlData,

--- a/libfreerdp/codec/rfx_decode.c
+++ b/libfreerdp/codec/rfx_decode.c
@@ -101,9 +101,12 @@ BOOL rfx_decode_rgb(RFX_CONTEXT* WINPR_RESTRICT context, const RFX_TILE* WINPR_R
 	cb_quants = context->quants + (NR_QUANT_VALUES * tile->quantIdxCb);
 	cr_quants = context->quants + (NR_QUANT_VALUES * tile->quantIdxCr);
 	pBuffer = (BYTE*)BufferPool_Take(context->priv->BufferPool, -1);
-	pSrcDst[0] = (INT16*)((&pBuffer[((8192ULL + 32ULL) * 0ULL) + 16ULL]));        /* y_r_buffer */
-	pSrcDst[1] = (INT16*)((&pBuffer[((8192ULL + 32ULL) * 1ULL) + 16ULL]));        /* cb_g_buffer */
-	pSrcDst[2] = (INT16*)((&pBuffer[((8192ULL + 32ULL) * 2ULL) + 16ULL]));        /* cr_b_buffer */
+	pSrcDst[0] = WINPR_PACKED_ALIGN_CAST(
+	    INT16*, ((&pBuffer[((8192ULL + 32ULL) * 0ULL) + 16ULL]))); /* y_r_buffer */
+	pSrcDst[1] = WINPR_PACKED_ALIGN_CAST(
+	    INT16*, ((&pBuffer[((8192ULL + 32ULL) * 1ULL) + 16ULL]))); /* cb_g_buffer */
+	pSrcDst[2] = WINPR_PACKED_ALIGN_CAST(
+	    INT16*, ((&pBuffer[((8192ULL + 32ULL) * 2ULL) + 16ULL]))); /* cr_b_buffer */
 	if (!rfx_decode_component(context, y_quants, NR_QUANT_VALUES, tile->YData, tile->YLen,
 	                          pSrcDst[0])) /* YData */
 		goto fail;

--- a/libfreerdp/codec/rfx_encode.c
+++ b/libfreerdp/codec/rfx_encode.c
@@ -291,9 +291,12 @@ BOOL rfx_encode_rgb(RFX_CONTEXT* WINPR_RESTRICT context, RFX_TILE* WINPR_RESTRIC
 	UINT32* YQuant = context->quants + (NR_QUANT_VALUES * tile->quantIdxY);
 	UINT32* CbQuant = context->quants + (NR_QUANT_VALUES * tile->quantIdxCb);
 	UINT32* CrQuant = context->quants + (NR_QUANT_VALUES * tile->quantIdxCr);
-	pSrcDst[0] = (INT16*)((&pBuffer[((8192ULL + 32ULL) * 0ULL) + 16ULL])); /* y_r_buffer */
-	pSrcDst[1] = (INT16*)((&pBuffer[((8192ULL + 32ULL) * 1ULL) + 16ULL])); /* cb_g_buffer */
-	pSrcDst[2] = (INT16*)((&pBuffer[((8192ULL + 32ULL) * 2ULL) + 16ULL])); /* cr_b_buffer */
+	pSrcDst[0] = WINPR_PACKED_ALIGN_CAST(
+	    INT16*, ((&pBuffer[((8192ULL + 32ULL) * 0ULL) + 16ULL]))); /* y_r_buffer */
+	pSrcDst[1] = WINPR_PACKED_ALIGN_CAST(
+	    INT16*, ((&pBuffer[((8192ULL + 32ULL) * 1ULL) + 16ULL]))); /* cb_g_buffer */
+	pSrcDst[2] = WINPR_PACKED_ALIGN_CAST(
+	    INT16*, ((&pBuffer[((8192ULL + 32ULL) * 2ULL) + 16ULL]))); /* cr_b_buffer */
 	PROFILER_ENTER(context->priv->prof_rfx_encode_rgb)
 	PROFILER_ENTER(context->priv->prof_rfx_encode_format_rgb)
 	rfx_encode_format_rgb(tile->data, tile->width, tile->height, tile->scanline,

--- a/libfreerdp/codec/sse/rfx_sse2.c
+++ b/libfreerdp/codec/sse/rfx_sse2.c
@@ -54,7 +54,7 @@
 static inline void __attribute__((ATTRIBUTES)) mm_prefetch_buffer(char* WINPR_RESTRICT buffer,
                                                                   size_t num_bytes)
 {
-	__m128i* buf = (__m128i*)buffer;
+	__m128i* buf = WINPR_PACKED_ALIGN_CAST(__m128i*, buffer);
 
 	for (size_t i = 0; i < (num_bytes / sizeof(__m128i)); i += (CACHE_LINE_BYTES / sizeof(__m128i)))
 	{
@@ -69,8 +69,8 @@ static inline void __attribute__((ATTRIBUTES))
 rfx_quantization_decode_block_sse2(INT16* WINPR_RESTRICT buffer, const size_t buffer_size,
                                    const UINT32 factor)
 {
-	__m128i* ptr = (__m128i*)buffer;
-	const __m128i* buf_end = (__m128i*)(buffer + buffer_size);
+	__m128i* ptr = WINPR_PACKED_ALIGN_CAST(__m128i*, buffer);
+	const __m128i* buf_end = WINPR_PACKED_ALIGN_CAST(__m128i*, (buffer + buffer_size));
 
 	if (factor == 0)
 		return;
@@ -119,8 +119,8 @@ static inline void __attribute__((ATTRIBUTES))
 rfx_quantization_encode_block_sse2(INT16* WINPR_RESTRICT buffer, const unsigned buffer_size,
                                    const INT16 factor)
 {
-	__m128i* ptr = (__m128i*)buffer;
-	const __m128i* buf_end = (const __m128i*)(buffer + buffer_size);
+	__m128i* ptr = WINPR_PACKED_ALIGN_CAST(__m128i*, buffer);
+	const __m128i* buf_end = WINPR_PACKED_ALIGN_CAST(const __m128i*, (buffer + buffer_size));
 
 	if (factor == 0)
 		return;

--- a/libfreerdp/core/childsession.c
+++ b/libfreerdp/core/childsession.c
@@ -504,7 +504,7 @@ static BOOL createChildSessionTransport(HANDLE* pFile)
 
 		{
 			const BYTE startOfPath[] = { '\\', 0, '\\', 0, '.', 0, '\\', 0 };
-			if (_wcsncmp(pipePath, (const WCHAR*)startOfPath, 4))
+			if (_wcsncmp(pipePath, WINPR_PACKED_ALIGN_CAST(const WCHAR*, startOfPath), 4))
 			{
 				/* when compiled under 32 bits, the path may miss "\\.\" at the beginning of the
 				 * string so add it if it's not there

--- a/libfreerdp/core/gateway/arm.c
+++ b/libfreerdp/core/gateway/arm.c
@@ -376,8 +376,8 @@ static WINPR_CIPHER_CTX* treatAuthBlob(wLog* log, const BYTE* pbInput, size_t cb
 	char algoName[100] = WINPR_C_ARRAY_INIT;
 
 	WINPR_ASSERT(pBlockSize);
-	SSIZE_T algoSz = ConvertWCharNToUtf8((const WCHAR*)pbInput, cbInput / sizeof(WCHAR), algoName,
-	                                     sizeof(algoName) - 1);
+	SSIZE_T algoSz = ConvertWCharNToUtf8(WINPR_PACKED_ALIGN_CAST(const WCHAR*, pbInput),
+	                                     cbInput / sizeof(WCHAR), algoName, sizeof(algoName) - 1);
 	if (algoSz <= 0)
 	{
 		WLog_Print(log, WLOG_ERROR, "invalid algoName");
@@ -601,7 +601,8 @@ static BOOL arm_pick_base64Utf16Field(wLog* log, const WINPR_JSON* json, const c
 	}
 
 	size_t len2 = 0;
-	char* output2 = ConvertWCharNToUtf8Alloc((WCHAR*)output1, len1 / sizeof(WCHAR), &len2);
+	char* output2 = ConvertWCharNToUtf8Alloc(WINPR_PACKED_ALIGN_CAST(WCHAR*, output1),
+	                                         len1 / sizeof(WCHAR), &len2);
 	free(output1);
 	if (!output2 || !len2)
 	{

--- a/libfreerdp/core/gateway/rpc_client.c
+++ b/libfreerdp/core/gateway/rpc_client.c
@@ -1191,8 +1191,8 @@ static BOOL rpc_client_resolve_gateway(rdpSettings* settings, char** host, UINT1
 		if (!result)
 			return FALSE;
 
-		*host =
-		    freerdp_tcp_address_to_string((const struct sockaddr_storage*)result->ai_addr, nullptr);
+		*host = freerdp_tcp_address_to_string(
+		    WINPR_PACKED_ALIGN_CAST(const struct sockaddr_storage*, result->ai_addr), nullptr);
 		freeaddrinfo(result);
 		return TRUE;
 	}

--- a/libfreerdp/core/license.c
+++ b/libfreerdp/core/license.c
@@ -441,10 +441,12 @@ static void license_print_product_info(wLog* log, const LICENSE_PRODUCT_INFO* pr
 	WINPR_ASSERT(productInfo->pbCompanyName);
 	WINPR_ASSERT(productInfo->pbProductId);
 
-	CompanyName = ConvertWCharNToUtf8Alloc((const WCHAR*)productInfo->pbCompanyName,
-	                                       productInfo->cbCompanyName / sizeof(WCHAR), nullptr);
-	ProductId = ConvertWCharNToUtf8Alloc((const WCHAR*)productInfo->pbProductId,
-	                                     productInfo->cbProductId / sizeof(WCHAR), nullptr);
+	CompanyName =
+	    ConvertWCharNToUtf8Alloc(WINPR_PACKED_ALIGN_CAST(const WCHAR*, productInfo->pbCompanyName),
+	                             productInfo->cbCompanyName / sizeof(WCHAR), nullptr);
+	ProductId =
+	    ConvertWCharNToUtf8Alloc(WINPR_PACKED_ALIGN_CAST(const WCHAR*, productInfo->pbProductId),
+	                             productInfo->cbProductId / sizeof(WCHAR), nullptr);
 	WLog_Print(log, WLOG_INFO, "ProductInfo:");
 	WLog_Print(log, WLOG_INFO, "\tdwVersion: 0x%08" PRIX32 "", productInfo->dwVersion);
 	WLog_Print(log, WLOG_INFO, "\tCompanyName: %s", CompanyName);

--- a/libfreerdp/core/listener.c
+++ b/libfreerdp/core/listener.c
@@ -184,10 +184,10 @@ static BOOL freerdp_listener_open(freerdp_listener* instance, const char* bind_a
 		option_value = 1;
 
 		if (ai->ai_family == AF_INET)
-			sin_addr = &(((struct sockaddr_in*)ai->ai_addr)->sin_addr);
+			sin_addr = &((WINPR_PACKED_ALIGN_CAST(struct sockaddr_in*, ai->ai_addr))->sin_addr);
 		else
 		{
-			sin_addr = &(((struct sockaddr_in6*)ai->ai_addr)->sin6_addr);
+			sin_addr = &((WINPR_PACKED_ALIGN_CAST(struct sockaddr_in6*, ai->ai_addr))->sin6_addr);
 			if (setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&option_value,
 			               sizeof(option_value)) == -1)
 				WLog_ERR(TAG, "setsockopt");

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -394,7 +394,8 @@ static BOOL nla_client_setup_identity(rdpNla* nla)
 
 		if (settings->RedirectionPassword && (settings->RedirectionPasswordLength > 0))
 		{
-			const WCHAR* wstr = (const WCHAR*)settings->RedirectionPassword;
+			const WCHAR* wstr =
+			    WINPR_PACKED_ALIGN_CAST(const WCHAR*, settings->RedirectionPassword);
 			const size_t len = _wcsnlen(wstr, settings->RedirectionPasswordLength / sizeof(WCHAR));
 
 			if (!identity_set_from_settings_with_pwd(nla->identity, settings, FreeRDP_Username,
@@ -1134,8 +1135,9 @@ static BOOL set_creds_octetstring_to_settings(WinPrAsn1Decoder* dec, WinPrAsn1_t
 	if (!WinPrAsn1DecReadContextualOctetString(dec, tagId, &error, &value, FALSE))
 		return FALSE;
 
-	return freerdp_settings_set_string_from_utf16N(settings, settingId, (const WCHAR*)value.data,
-	                                               value.len / sizeof(WCHAR));
+	return freerdp_settings_set_string_from_utf16N(
+	    settings, settingId, WINPR_PACKED_ALIGN_CAST(const WCHAR*, value.data),
+	    value.len / sizeof(WCHAR));
 }
 
 static BOOL nla_read_TSCspDataDetail(WinPrAsn1Decoder* dec, rdpSettings* settings)
@@ -1331,8 +1333,8 @@ static BOOL nla_read_TSRemoteGuardPackageCred(WINPR_ATTR_UNUSED rdpNla* nla, Win
 	if (!WinPrAsn1DecReadContextualOctetString(dec, 0, &error, &packageName, FALSE) || error)
 		return FALSE;
 
-	ConvertMszWCharNToUtf8((WCHAR*)packageName.data, packageName.len / sizeof(WCHAR),
-	                       packageNameStr, sizeof(packageNameStr));
+	ConvertMszWCharNToUtf8(WINPR_PACKED_ALIGN_CAST(WCHAR*, packageName.data),
+	                       packageName.len / sizeof(WCHAR), packageNameStr, sizeof(packageNameStr));
 	WLog_DBG(TAG, "TSRemoteGuardPackageCred(%s)", packageNameStr);
 
 	/* credBuffer [1] OCTET STRING, */

--- a/libfreerdp/core/redirection.c
+++ b/libfreerdp/core/redirection.c
@@ -173,7 +173,7 @@ static BOOL rdp_redirection_read_unicode_string(wStream* s, char** str, size_t m
 	if (!rdp_redirection_get_data(s, &length, &data))
 		return FALSE;
 
-	const WCHAR* wstr = (const WCHAR*)data;
+	const WCHAR* wstr = WINPR_PACKED_ALIGN_CAST(const WCHAR*, data);
 
 	if ((length % 2) || length < 2 || length > maxLength)
 	{
@@ -244,7 +244,7 @@ static BOOL rdp_redirection_read_base64_wchar(UINT32 flag, wStream* s, UINT32* p
 
 	if (!rdp_redirection_get_data(s, pLength, &ptr))
 		return FALSE;
-	const WCHAR* wchar = (const WCHAR*)ptr;
+	const WCHAR* wchar = WINPR_PACKED_ALIGN_CAST(const WCHAR*, ptr);
 
 	size_t utf8_len = 0;
 	char* utf8 = ConvertWCharNToUtf8Alloc(wchar, *pLength / sizeof(WCHAR), &utf8_len);
@@ -573,7 +573,7 @@ int rdp_redirection_apply_settings(rdpRdp* rdp)
 			size_t tsvlen = 0;
 
 			char* tsv =
-			    ConvertWCharNToUtf8Alloc((const WCHAR*)redirection->TsvUrl,
+			    ConvertWCharNToUtf8Alloc(WINPR_PACKED_ALIGN_CAST(const WCHAR*, redirection->TsvUrl),
 			                             redirection->TsvUrlLength / sizeof(WCHAR), &tsvlen);
 			if (!tsv || !lb)
 				valid = FALSE;
@@ -784,7 +784,8 @@ static state_run_t rdp_recv_server_redirection_pdu(rdpRdp* rdp, wStream* s)
 			}
 
 			/* Ensure the text password is '\0' terminated */
-			if (_wcsnlen((const WCHAR*)redirection->Password, charLen) == charLen)
+			if (_wcsnlen(WINPR_PACKED_ALIGN_CAST(const WCHAR*, redirection->Password), charLen) ==
+			    charLen)
 			{
 				WLog_ERR(TAG, "LB_PASSWORD: missing '\\0' termination");
 				return STATE_RUN_FAILED;

--- a/libfreerdp/core/server.c
+++ b/libfreerdp/core/server.c
@@ -1128,7 +1128,7 @@ HANDLE WINAPI FreeRDP_WTSOpenServerA(LPSTR pServerName)
 {
 	wObject queueCallbacks = WINPR_C_ARRAY_INIT;
 
-	rdpContext* context = (rdpContext*)pServerName;
+	rdpContext* context = WINPR_PACKED_ALIGN_CAST(rdpContext*, pServerName);
 
 	if (!setup() || !context)
 		return INVALID_HANDLE_VALUE;

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -476,8 +476,8 @@ static UINT32** alloc_array(size_t count)
 {
 	// NOLINTNEXTLINE(clang-analyzer-unix.MallocSizeof)
 	BYTE* array = calloc(count * sizeof(uintptr_t), count * sizeof(UINT32));
-	UINT32** dst = (UINT32**)array;
-	UINT32* val = (UINT32*)(array + count * sizeof(uintptr_t));
+	UINT32** dst = WINPR_PACKED_ALIGN_CAST(UINT32**, array);
+	UINT32* val = WINPR_PACKED_ALIGN_CAST(UINT32*, (array + count * sizeof(uintptr_t)));
 	for (size_t x = 0; x < count; x++)
 		dst[x] = &val[x];
 

--- a/libfreerdp/core/tcp.c
+++ b/libfreerdp/core/tcp.c
@@ -1241,8 +1241,8 @@ static void log_connection_address(const char* hostname, struct addrinfo* addr)
 {
 	WINPR_ASSERT(addr);
 
-	char* peerAddress =
-	    freerdp_tcp_address_to_string((const struct sockaddr_storage*)addr->ai_addr, nullptr);
+	char* peerAddress = freerdp_tcp_address_to_string(
+	    WINPR_PACKED_ALIGN_CAST(const struct sockaddr_storage*, addr->ai_addr), nullptr);
 	if (peerAddress)
 		WLog_DBG(TAG, "resolved %s: try to connect to %s", hostname, peerAddress);
 	free(peerAddress);

--- a/libfreerdp/gdi/bitmap.c
+++ b/libfreerdp/gdi/bitmap.c
@@ -51,7 +51,7 @@
 
 UINT32 gdi_GetPixel(HGDI_DC hdc, UINT32 nXPos, UINT32 nYPos)
 {
-	HGDI_BITMAP hBmp = (HGDI_BITMAP)hdc->selectedObject;
+	HGDI_BITMAP hBmp = WINPR_PACKED_ALIGN_CAST(HGDI_BITMAP, hdc->selectedObject);
 	BYTE* data =
 	    &(hBmp->data[(nYPos * hBmp->scanline) + nXPos * FreeRDPGetBytesPerPixel(hBmp->format)]);
 	return FreeRDPReadColor(data, hBmp->format);
@@ -82,7 +82,7 @@ static inline UINT32 gdi_SetPixelBmp(HGDI_BITMAP hBmp, UINT32 X, UINT32 Y, UINT3
 
 UINT32 gdi_SetPixel(HGDI_DC hdc, UINT32 X, UINT32 Y, UINT32 crColor)
 {
-	HGDI_BITMAP hBmp = (HGDI_BITMAP)hdc->selectedObject;
+	HGDI_BITMAP hBmp = WINPR_PACKED_ALIGN_CAST(HGDI_BITMAP, hdc->selectedObject);
 	return gdi_SetPixelBmp(hBmp, X, Y, crColor);
 }
 
@@ -362,7 +362,7 @@ static BOOL adjust_src_coordinates(HGDI_DC hdcSrc, INT32 nWidth, INT32 nHeight, 
 	if (!hdcSrc || (nWidth < 0) || (nHeight < 0) || !px || !py)
 		return FALSE;
 
-	hSrcBmp = (HGDI_BITMAP)hdcSrc->selectedObject;
+	hSrcBmp = WINPR_PACKED_ALIGN_CAST(HGDI_BITMAP, hdcSrc->selectedObject);
 	nXSrc = *px;
 	nYSrc = *py;
 
@@ -411,7 +411,7 @@ static BOOL adjust_src_dst_coordinates(HGDI_DC hdcDest, INT32* pnXSrc, INT32* pn
 	if (!hdcDest || !pnXSrc || !pnYSrc || !pnXDst || !pnYDst || !pnWidth || !pnHeight)
 		return FALSE;
 
-	hDstBmp = (HGDI_BITMAP)hdcDest->selectedObject;
+	hDstBmp = WINPR_PACKED_ALIGN_CAST(HGDI_BITMAP, hdcDest->selectedObject);
 	nXSrc = *pnXSrc;
 	nYSrc = *pnYSrc;
 	nXDst = *pnXDst;
@@ -619,8 +619,8 @@ BOOL gdi_BitBlt(HGDI_DC hdcDest, INT32 nXDest, INT32 nYDest, INT32 nWidth, INT32
 			if (!adjust_src_coordinates(hdcSrc, nWidth, nHeight, &nXSrc, &nYSrc))
 				return FALSE;
 
-			hSrcBmp = (HGDI_BITMAP)hdcSrc->selectedObject;
-			hDstBmp = (HGDI_BITMAP)hdcDest->selectedObject;
+			hSrcBmp = WINPR_PACKED_ALIGN_CAST(HGDI_BITMAP, hdcSrc->selectedObject);
+			hDstBmp = WINPR_PACKED_ALIGN_CAST(HGDI_BITMAP, hdcDest->selectedObject);
 
 			if (!hSrcBmp || !hDstBmp)
 				return FALSE;
@@ -638,8 +638,8 @@ BOOL gdi_BitBlt(HGDI_DC hdcDest, INT32 nXDest, INT32 nYDest, INT32 nWidth, INT32
 			break;
 
 		case GDI_DSTCOPY:
-			hSrcBmp = (HGDI_BITMAP)hdcDest->selectedObject;
-			hDstBmp = (HGDI_BITMAP)hdcDest->selectedObject;
+			hSrcBmp = WINPR_PACKED_ALIGN_CAST(HGDI_BITMAP, hdcDest->selectedObject);
+			hDstBmp = WINPR_PACKED_ALIGN_CAST(HGDI_BITMAP, hdcDest->selectedObject);
 
 			if (!adjust_src_dst_coordinates(hdcDest, &nXSrc, &nYSrc, &nXDest, &nYDest, &nWidth,
 			                                &nHeight))

--- a/libfreerdp/gdi/clipping.c
+++ b/libfreerdp/gdi/clipping.c
@@ -88,7 +88,7 @@ BOOL gdi_ClipCoords(HGDI_DC hdc, INT32* x, INT32* y, INT32* w, INT32* h, INT32* 
 	if (hdc == nullptr)
 		return FALSE;
 
-	HGDI_BITMAP hBmp = (HGDI_BITMAP)hdc->selectedObject;
+	HGDI_BITMAP hBmp = WINPR_PACKED_ALIGN_CAST(HGDI_BITMAP, hdc->selectedObject);
 
 	if (hBmp != nullptr)
 	{

--- a/libfreerdp/gdi/dc.c
+++ b/libfreerdp/gdi/dc.c
@@ -153,23 +153,23 @@ HGDIOBJECT gdi_SelectObject(HGDI_DC hdc, HGDIOBJECT hgdiobject)
 	}
 	else if (hgdiobject->objectType == GDIOBJECT_PEN)
 	{
-		previousSelectedObject = (HGDIOBJECT)hdc->pen;
-		hdc->pen = (HGDI_PEN)hgdiobject;
+		previousSelectedObject = WINPR_PACKED_ALIGN_CAST(HGDIOBJECT, hdc->pen);
+		hdc->pen = WINPR_PACKED_ALIGN_CAST(HGDI_PEN, hgdiobject);
 	}
 	else if (hgdiobject->objectType == GDIOBJECT_BRUSH)
 	{
 		previousSelectedObject = (HGDIOBJECT)hdc->brush;
-		hdc->brush = (HGDI_BRUSH)hgdiobject;
+		hdc->brush = WINPR_PACKED_ALIGN_CAST(HGDI_BRUSH, hgdiobject);
 	}
 	else if (hgdiobject->objectType == GDIOBJECT_REGION)
 	{
 		hdc->selectedObject = hgdiobject;
-		previousSelectedObject = (HGDIOBJECT)COMPLEXREGION;
+		previousSelectedObject = WINPR_PACKED_ALIGN_CAST(HGDIOBJECT, COMPLEXREGION);
 	}
 	else if (hgdiobject->objectType == GDIOBJECT_RECT)
 	{
 		hdc->selectedObject = hgdiobject;
-		previousSelectedObject = (HGDIOBJECT)SIMPLEREGION;
+		previousSelectedObject = WINPR_PACKED_ALIGN_CAST(HGDIOBJECT, SIMPLEREGION);
 	}
 	else
 	{
@@ -194,7 +194,7 @@ BOOL gdi_DeleteObject(HGDIOBJECT hgdiobject)
 
 	if (hgdiobject->objectType == GDIOBJECT_BITMAP)
 	{
-		HGDI_BITMAP hBitmap = (HGDI_BITMAP)hgdiobject;
+		HGDI_BITMAP hBitmap = WINPR_PACKED_ALIGN_CAST(HGDI_BITMAP, hgdiobject);
 
 		if (hBitmap->data && hBitmap->free)
 		{
@@ -206,12 +206,12 @@ BOOL gdi_DeleteObject(HGDIOBJECT hgdiobject)
 	}
 	else if (hgdiobject->objectType == GDIOBJECT_PEN)
 	{
-		HGDI_PEN hPen = (HGDI_PEN)hgdiobject;
+		HGDI_PEN hPen = WINPR_PACKED_ALIGN_CAST(HGDI_PEN, hgdiobject);
 		free(hPen);
 	}
 	else if (hgdiobject->objectType == GDIOBJECT_BRUSH)
 	{
-		HGDI_BRUSH hBrush = (HGDI_BRUSH)hgdiobject;
+		HGDI_BRUSH hBrush = WINPR_PACKED_ALIGN_CAST(HGDI_BRUSH, hgdiobject);
 		free(hBrush);
 	}
 	else if (hgdiobject->objectType == GDIOBJECT_REGION)

--- a/libfreerdp/gdi/gdi.h
+++ b/libfreerdp/gdi/gdi.h
@@ -39,7 +39,7 @@ FREERDP_LOCAL gdiBitmap* gdi_bitmap_new_ex(rdpGdi* gdi, int width, int height, i
 WINPR_ATTR_NODISCARD
 static inline BYTE* gdi_get_bitmap_pointer(HGDI_DC hdcBmp, INT32 x, INT32 y)
 {
-	HGDI_BITMAP hBmp = (HGDI_BITMAP)hdcBmp->selectedObject;
+	HGDI_BITMAP hBmp = WINPR_PACKED_ALIGN_CAST(HGDI_BITMAP, hdcBmp->selectedObject);
 
 	if ((x >= 0) && (y >= 0) && (x < hBmp->width) && (y < hBmp->height))
 	{

--- a/libfreerdp/gdi/line.c
+++ b/libfreerdp/gdi/line.c
@@ -156,7 +156,7 @@ BOOL gdi_LineTo(HGDI_DC hdc, INT32 nXEnd, INT32 nYEnd)
 		by2 = by1 + hdc->clip->h - 1;
 	}
 
-	HGDI_BITMAP bmp = (HGDI_BITMAP)hdc->selectedObject;
+	HGDI_BITMAP bmp = WINPR_PACKED_ALIGN_CAST(HGDI_BITMAP, hdc->selectedObject);
 	WINPR_ASSERT(bmp);
 
 	bx1 = MAX(bx1, 0);

--- a/libfreerdp/primitives/neon/prim_colors_neon.c
+++ b/libfreerdp/primitives/neon/prim_colors_neon.c
@@ -187,9 +187,9 @@ neon_RGBToRGB_16s8u_P3AC4R_X(const INT16* WINPR_RESTRICT pSrc[3], /* 16-bit R,G,
 
 	for (UINT32 y = 0; y < roi->height; y++)
 	{
-		const INT16* pr = (const INT16*)(((BYTE*)pSrc[0]) + y * srcStep);
-		const INT16* pg = (const INT16*)(((BYTE*)pSrc[1]) + y * srcStep);
-		const INT16* pb = (const INT16*)(((BYTE*)pSrc[2]) + y * srcStep);
+		const INT16* pr = WINPR_PACKED_ALIGN_CAST(const INT16*, (((BYTE*)pSrc[0]) + y * srcStep));
+		const INT16* pg = WINPR_PACKED_ALIGN_CAST(const INT16*, (((BYTE*)pSrc[1]) + y * srcStep));
+		const INT16* pb = WINPR_PACKED_ALIGN_CAST(const INT16*, (((BYTE*)pSrc[2]) + y * srcStep));
 		BYTE* dst = pDst + y * dstStep;
 
 		for (UINT32 x = 0; x < roi->width - pad; x += 8)

--- a/libfreerdp/primitives/prim_alphaComp.c
+++ b/libfreerdp/primitives/prim_alphaComp.c
@@ -37,9 +37,9 @@ static pstatus_t general_alphaComp_argb(const BYTE* WINPR_RESTRICT pSrc1, UINT32
 {
 	for (size_t y = 0; y < height; y++)
 	{
-		const UINT32* sptr1 = (const UINT32*)(pSrc1 + y * src1Step);
-		const UINT32* sptr2 = (const UINT32*)(pSrc2 + y * src2Step);
-		UINT32* dptr = (UINT32*)(pDst + y * dstStep);
+		const UINT32* sptr1 = WINPR_PACKED_ALIGN_CAST(const UINT32*, (pSrc1 + y * src1Step));
+		const UINT32* sptr2 = WINPR_PACKED_ALIGN_CAST(const UINT32*, (pSrc2 + y * src2Step));
+		UINT32* dptr = WINPR_PACKED_ALIGN_CAST(UINT32*, (pDst + y * dstStep));
 
 		for (size_t x = 0; x < width; x++)
 		{

--- a/libfreerdp/primitives/sse/prim_YUV_sse4.1.c
+++ b/libfreerdp/primitives/sse/prim_YUV_sse4.1.c
@@ -134,7 +134,7 @@ static inline pstatus_t sse41_YUV420ToRGB_BGRX(const BYTE* WINPR_RESTRICT pSrc[]
 
 	for (size_t y = 0; y < nHeight; y++)
 	{
-		__m128i* dst = (__m128i*)(pDst + dstStep * y);
+		__m128i* dst = WINPR_PACKED_ALIGN_CAST(__m128i*, (pDst + dstStep * y));
 		const BYTE* YData = pSrc[0] + y * srcStep[0];
 		const BYTE* UData = pSrc[1] + (y / 2) * srcStep[1];
 		const BYTE* VData = pSrc[2] + (y / 2) * srcStep[2];
@@ -160,7 +160,8 @@ static inline pstatus_t sse41_YUV420ToRGB_BGRX(const BYTE* WINPR_RESTRICT pSrc[]
 			const BYTE Y = *YData++;
 			const BYTE U = *UData;
 			const BYTE V = *VData;
-			dst = (__m128i*)writeYUVPixel((BYTE*)dst, PIXEL_FORMAT_BGRX32, Y, U, V, writePixelBGRX);
+			dst = WINPR_PACKED_ALIGN_CAST(
+			    __m128i*, writeYUVPixel((BYTE*)dst, PIXEL_FORMAT_BGRX32, Y, U, V, writePixelBGRX));
 
 			if (x % 2)
 			{
@@ -324,7 +325,7 @@ static inline void sse41_BGRX_fillRGB_pixel(BYTE* WINPR_RESTRICT pRGB, __m128i Y
 	const __m128i mask = mm_set_epu8(0x00, 0xFF, 0xFF, 0xFF, 0x00, 0xFF, 0xFF, 0xFF, 0x00, 0xFF,
 	                                 0xFF, 0xFF, 0x00, 0xFF, 0xFF, 0xFF);
 
-	__m128i* rgb = (__m128i*)pRGB;
+	__m128i* rgb = WINPR_PACKED_ALIGN_CAST(__m128i*, pRGB);
 	const __m128i bgrx0 = _mm_unpacklo_epi16(bg[1], rx[1]);
 	_mm_maskmoveu_si128(bgrx0, mask, (char*)&rgb[0]);
 	const __m128i bgrx1 = _mm_unpackhi_epi16(bg[1], rx[1]);
@@ -600,8 +601,8 @@ static inline void sse41_BGRX_TO_YUV(const BYTE* WINPR_RESTRICT pLine1, BYTE* WI
 static inline void sse41_RGBToYUV420_BGRX_Y(const BYTE* WINPR_RESTRICT src, BYTE* dst, UINT32 width)
 {
 	const __m128i y_factors = BGRX_Y_FACTORS;
-	const __m128i* argb = (const __m128i*)src;
-	__m128i* ydst = (__m128i*)dst;
+	const __m128i* argb = WINPR_PACKED_ALIGN_CAST(const __m128i*, src);
+	__m128i* ydst = WINPR_PACKED_ALIGN_CAST(__m128i*, dst);
 
 	UINT32 x = 0;
 
@@ -654,10 +655,10 @@ static inline void sse41_RGBToYUV420_BGRX_UV(const BYTE* WINPR_RESTRICT src1,
 
 	for (; x < width - width % 16; x += 16)
 	{
-		const __m128i* rgb1 = (const __m128i*)&src1[4ULL * x];
-		const __m128i* rgb2 = (const __m128i*)&src2[4ULL * x];
-		__m64* udst = (__m64*)&dst1[x / 2];
-		__m64* vdst = (__m64*)&dst2[x / 2];
+		const __m128i* rgb1 = WINPR_PACKED_ALIGN_CAST(const __m128i*, &src1[4ULL * x]);
+		const __m128i* rgb2 = WINPR_PACKED_ALIGN_CAST(const __m128i*, &src2[4ULL * x]);
+		__m64* udst = WINPR_PACKED_ALIGN_CAST(__m64*, &dst1[x / 2]);
+		__m64* vdst = WINPR_PACKED_ALIGN_CAST(__m64*, &dst2[x / 2]);
 
 		/* subsample 16x2 pixels into 16x1 pixels */
 		__m128i x0 = LOAD_SI128(&rgb1[0]);
@@ -788,8 +789,8 @@ static inline void sse41_RGBToAVC444YUV_BGRX_DOUBLE_ROW(
     BYTE* WINPR_RESTRICT b3, BYTE* WINPR_RESTRICT b4, BYTE* WINPR_RESTRICT b5,
     BYTE* WINPR_RESTRICT b6, BYTE* WINPR_RESTRICT b7, UINT32 width)
 {
-	const __m128i* argbEven = (const __m128i*)srcEven;
-	const __m128i* argbOdd = (const __m128i*)srcOdd;
+	const __m128i* argbEven = WINPR_PACKED_ALIGN_CAST(const __m128i*, srcEven);
+	const __m128i* argbOdd = WINPR_PACKED_ALIGN_CAST(const __m128i*, srcOdd);
 	const __m128i y_factors = BGRX_Y_FACTORS;
 	const __m128i u_factors = BGRX_U_FACTORS;
 	const __m128i v_factors = BGRX_V_FACTORS;
@@ -882,7 +883,7 @@ static inline void sse41_RGBToAVC444YUV_BGRX_DOUBLE_ROW(
 				const __m128i added = _mm_hadd_epi16(lo, hi);
 				const __m128i avg16 = _mm_srai_epi16(added, 2);
 				const __m128i avg = _mm_packus_epi16(avg16, avg16);
-				_mm_storel_epi64((__m128i*)b2, avg);
+				_mm_storel_epi64(WINPR_PACKED_ALIGN_CAST(__m128i*, b2), avg);
 			}
 			else
 			{
@@ -890,7 +891,7 @@ static inline void sse41_RGBToAVC444YUV_BGRX_DOUBLE_ROW(
 				    _mm_set_epi8((char)0x80, (char)0x80, (char)0x80, (char)0x80, (char)0x80,
 				                 (char)0x80, (char)0x80, (char)0x80, 14, 12, 10, 8, 6, 4, 2, 0);
 				const __m128i ud = _mm_shuffle_epi8(ue, mask);
-				_mm_storel_epi64((__m128i*)b2, ud);
+				_mm_storel_epi64(WINPR_PACKED_ALIGN_CAST(__m128i*, b2), ud);
 			}
 
 			b2 += 8;
@@ -907,7 +908,7 @@ static inline void sse41_RGBToAVC444YUV_BGRX_DOUBLE_ROW(
 				    _mm_set_epi8((char)0x80, (char)0x80, (char)0x80, (char)0x80, (char)0x80,
 				                 (char)0x80, (char)0x80, (char)0x80, 15, 13, 11, 9, 7, 5, 3, 1);
 				const __m128i ude = _mm_shuffle_epi8(ue, mask);
-				_mm_storel_epi64((__m128i*)b6, ude);
+				_mm_storel_epi64(WINPR_PACKED_ALIGN_CAST(__m128i*, b6), ude);
 				b6 += 8;
 			}
 		}
@@ -960,7 +961,7 @@ static inline void sse41_RGBToAVC444YUV_BGRX_DOUBLE_ROW(
 				const __m128i added = _mm_hadd_epi16(lo, hi);
 				const __m128i avg16 = _mm_srai_epi16(added, 2);
 				const __m128i avg = _mm_packus_epi16(avg16, avg16);
-				_mm_storel_epi64((__m128i*)b3, avg);
+				_mm_storel_epi64(WINPR_PACKED_ALIGN_CAST(__m128i*, b3), avg);
 			}
 			else
 			{
@@ -968,7 +969,7 @@ static inline void sse41_RGBToAVC444YUV_BGRX_DOUBLE_ROW(
 				    _mm_set_epi8((char)0x80, (char)0x80, (char)0x80, (char)0x80, (char)0x80,
 				                 (char)0x80, (char)0x80, (char)0x80, 14, 12, 10, 8, 6, 4, 2, 0);
 				const __m128i vd = _mm_shuffle_epi8(ve, mask);
-				_mm_storel_epi64((__m128i*)b3, vd);
+				_mm_storel_epi64(WINPR_PACKED_ALIGN_CAST(__m128i*, b3), vd);
 			}
 
 			b3 += 8;
@@ -985,7 +986,7 @@ static inline void sse41_RGBToAVC444YUV_BGRX_DOUBLE_ROW(
 				    _mm_set_epi8((char)0x80, (char)0x80, (char)0x80, (char)0x80, (char)0x80,
 				                 (char)0x80, (char)0x80, (char)0x80, 15, 13, 11, 9, 7, 5, 3, 1);
 				const __m128i vde = _mm_shuffle_epi8(ve, mask);
-				_mm_storel_epi64((__m128i*)b7, vde);
+				_mm_storel_epi64(WINPR_PACKED_ALIGN_CAST(__m128i*, b7), vde);
 				b7 += 8;
 			}
 		}
@@ -1080,8 +1081,8 @@ static inline void sse41_RGBToAVC444YUVv2_BGRX_DOUBLE_ROW(
     BYTE* WINPR_RESTRICT vChromaDst1, BYTE* WINPR_RESTRICT vChromaDst2, UINT32 width)
 {
 	const __m128i vector128 = CONST128_FACTORS;
-	const __m128i* argbEven = (const __m128i*)srcEven;
-	const __m128i* argbOdd = (const __m128i*)srcOdd;
+	const __m128i* argbEven = WINPR_PACKED_ALIGN_CAST(const __m128i*, srcEven);
+	const __m128i* argbOdd = WINPR_PACKED_ALIGN_CAST(const __m128i*, srcOdd);
 
 	UINT32 x = 0;
 	for (; x < width - width % 16; x += 16)
@@ -1178,7 +1179,7 @@ static inline void sse41_RGBToAVC444YUVv2_BGRX_DOUBLE_ROW(
 				    _mm_set_epi8((char)0x80, (char)0x80, (char)0x80, (char)0x80, (char)0x80,
 				                 (char)0x80, (char)0x80, (char)0x80, 15, 13, 11, 9, 7, 5, 3, 1);
 				const __m128i ude = _mm_shuffle_epi8(ue, mask);
-				_mm_storel_epi64((__m128i*)yEvenChromaDst1, ude);
+				_mm_storel_epi64(WINPR_PACKED_ALIGN_CAST(__m128i*, yEvenChromaDst1), ude);
 				yEvenChromaDst1 += 8;
 			}
 
@@ -1188,7 +1189,8 @@ static inline void sse41_RGBToAVC444YUVv2_BGRX_DOUBLE_ROW(
 				    _mm_set_epi8((char)0x80, (char)0x80, (char)0x80, (char)0x80, (char)0x80,
 				                 (char)0x80, (char)0x80, (char)0x80, 15, 13, 11, 9, 7, 5, 3, 1);
 				const __m128i udo /* codespell:ignore udo */ = _mm_shuffle_epi8(uo, mask);
-				_mm_storel_epi64((__m128i*)yOddChromaDst1, udo); // codespell:ignore udo
+				_mm_storel_epi64(WINPR_PACKED_ALIGN_CAST(__m128i*, yOddChromaDst1),
+				                 udo); // codespell:ignore udo
 				yOddChromaDst1 += 8;
 			}
 
@@ -1198,8 +1200,8 @@ static inline void sse41_RGBToAVC444YUVv2_BGRX_DOUBLE_ROW(
 				    _mm_set_epi8((char)0x80, (char)0x80, (char)0x80, (char)0x80, (char)0x80,
 				                 (char)0x80, (char)0x80, (char)0x80, 14, 10, 6, 2, 12, 8, 4, 0);
 				const __m128i ud = _mm_shuffle_epi8(uo, mask);
-				int* uDst1 = (int*)uChromaDst1;
-				int* vDst1 = (int*)vChromaDst1;
+				int* uDst1 = WINPR_PACKED_ALIGN_CAST(int*, uChromaDst1);
+				int* vDst1 = WINPR_PACKED_ALIGN_CAST(int*, vChromaDst1);
 				const int* src = (const int*)&ud;
 				_mm_stream_si32(uDst1, src[0]);
 				_mm_stream_si32(vDst1, src[1]);
@@ -1209,7 +1211,7 @@ static inline void sse41_RGBToAVC444YUVv2_BGRX_DOUBLE_ROW(
 
 			if (yLumaDstOdd)
 			{
-				_mm_storel_epi64((__m128i*)uLumaDst, uavg);
+				_mm_storel_epi64(WINPR_PACKED_ALIGN_CAST(__m128i*, uLumaDst), uavg);
 				uLumaDst += 8;
 			}
 			else
@@ -1218,7 +1220,7 @@ static inline void sse41_RGBToAVC444YUVv2_BGRX_DOUBLE_ROW(
 				    _mm_set_epi8((char)0x80, (char)0x80, (char)0x80, (char)0x80, (char)0x80,
 				                 (char)0x80, (char)0x80, (char)0x80, 14, 12, 10, 8, 6, 4, 2, 0);
 				const __m128i ud = _mm_shuffle_epi8(ue, mask);
-				_mm_storel_epi64((__m128i*)uLumaDst, ud);
+				_mm_storel_epi64(WINPR_PACKED_ALIGN_CAST(__m128i*, uLumaDst), ud);
 				uLumaDst += 8;
 			}
 		}
@@ -1269,7 +1271,7 @@ static inline void sse41_RGBToAVC444YUVv2_BGRX_DOUBLE_ROW(
 				    _mm_set_epi8((char)0x80, (char)0x80, (char)0x80, (char)0x80, (char)0x80,
 				                 (char)0x80, (char)0x80, (char)0x80, 15, 13, 11, 9, 7, 5, 3, 1);
 				__m128i vde = _mm_shuffle_epi8(ve, mask);
-				_mm_storel_epi64((__m128i*)yEvenChromaDst2, vde);
+				_mm_storel_epi64(WINPR_PACKED_ALIGN_CAST(__m128i*, yEvenChromaDst2), vde);
 				yEvenChromaDst2 += 8;
 			}
 
@@ -1279,7 +1281,7 @@ static inline void sse41_RGBToAVC444YUVv2_BGRX_DOUBLE_ROW(
 				    _mm_set_epi8((char)0x80, (char)0x80, (char)0x80, (char)0x80, (char)0x80,
 				                 (char)0x80, (char)0x80, (char)0x80, 15, 13, 11, 9, 7, 5, 3, 1);
 				__m128i vdo = _mm_shuffle_epi8(vo, mask);
-				_mm_storel_epi64((__m128i*)yOddChromaDst2, vdo);
+				_mm_storel_epi64(WINPR_PACKED_ALIGN_CAST(__m128i*, yOddChromaDst2), vdo);
 				yOddChromaDst2 += 8;
 			}
 
@@ -1289,8 +1291,8 @@ static inline void sse41_RGBToAVC444YUVv2_BGRX_DOUBLE_ROW(
 				    _mm_set_epi8((char)0x80, (char)0x80, (char)0x80, (char)0x80, (char)0x80,
 				                 (char)0x80, (char)0x80, (char)0x80, 14, 10, 6, 2, 12, 8, 4, 0);
 				const __m128i vd = _mm_shuffle_epi8(vo, mask);
-				int* uDst2 = (int*)uChromaDst2;
-				int* vDst2 = (int*)vChromaDst2;
+				int* uDst2 = WINPR_PACKED_ALIGN_CAST(int*, uChromaDst2);
+				int* vDst2 = WINPR_PACKED_ALIGN_CAST(int*, vChromaDst2);
 				const int* src = (const int*)&vd;
 				_mm_stream_si32(uDst2, src[0]);
 				_mm_stream_si32(vDst2, src[1]);
@@ -1300,7 +1302,7 @@ static inline void sse41_RGBToAVC444YUVv2_BGRX_DOUBLE_ROW(
 
 			if (yLumaDstOdd)
 			{
-				_mm_storel_epi64((__m128i*)vLumaDst, vavg);
+				_mm_storel_epi64(WINPR_PACKED_ALIGN_CAST(__m128i*, vLumaDst), vavg);
 				vLumaDst += 8;
 			}
 			else
@@ -1309,7 +1311,7 @@ static inline void sse41_RGBToAVC444YUVv2_BGRX_DOUBLE_ROW(
 				    _mm_set_epi8((char)0x80, (char)0x80, (char)0x80, (char)0x80, (char)0x80,
 				                 (char)0x80, (char)0x80, (char)0x80, 14, 12, 10, 8, 6, 4, 2, 0);
 				__m128i vd = _mm_shuffle_epi8(ve, mask);
-				_mm_storel_epi64((__m128i*)vLumaDst, vd);
+				_mm_storel_epi64(WINPR_PACKED_ALIGN_CAST(__m128i*, vLumaDst), vd);
 				vLumaDst += 8;
 			}
 		}

--- a/libfreerdp/primitives/sse/prim_add_sse3.c
+++ b/libfreerdp/primitives/sse/prim_add_sse3.c
@@ -71,10 +71,10 @@ static pstatus_t sse3_add_16s_inplace(INT16* WINPR_RESTRICT pSrcDst1,
 		/* Unaligned loads */
 		while (count--)
 		{
-			const __m128i* vsptr1 = (const __m128i*)dptr1;
-			const __m128i* vsptr2 = (const __m128i*)dptr2;
-			__m128i* vdptr1 = (__m128i*)dptr1;
-			__m128i* vdptr2 = (__m128i*)dptr2;
+			const __m128i* vsptr1 = WINPR_PACKED_ALIGN_CAST(const __m128i*, dptr1);
+			const __m128i* vsptr2 = WINPR_PACKED_ALIGN_CAST(const __m128i*, dptr2);
+			__m128i* vdptr1 = WINPR_PACKED_ALIGN_CAST(__m128i*, dptr1);
+			__m128i* vdptr2 = WINPR_PACKED_ALIGN_CAST(__m128i*, dptr2);
 
 			__m128i xmm0 = LOAD_SI128(vsptr1++);
 			__m128i xmm1 = LOAD_SI128(vsptr1++);
@@ -109,10 +109,10 @@ static pstatus_t sse3_add_16s_inplace(INT16* WINPR_RESTRICT pSrcDst1,
 		/* Aligned loads */
 		while (count--)
 		{
-			const __m128i* vsptr1 = (const __m128i*)dptr1;
-			const __m128i* vsptr2 = (const __m128i*)dptr2;
-			__m128i* vdptr1 = (__m128i*)dptr1;
-			__m128i* vdptr2 = (__m128i*)dptr2;
+			const __m128i* vsptr1 = WINPR_PACKED_ALIGN_CAST(const __m128i*, dptr1);
+			const __m128i* vsptr2 = WINPR_PACKED_ALIGN_CAST(const __m128i*, dptr2);
+			__m128i* vdptr1 = WINPR_PACKED_ALIGN_CAST(__m128i*, dptr1);
+			__m128i* vdptr2 = WINPR_PACKED_ALIGN_CAST(__m128i*, dptr2);
 
 			__m128i xmm0 = LOAD_SI128(vsptr1++);
 			__m128i xmm1 = LOAD_SI128(vsptr1++);
@@ -147,10 +147,10 @@ static pstatus_t sse3_add_16s_inplace(INT16* WINPR_RESTRICT pSrcDst1,
 	len -= count << (5 - shifts);
 	while (count--)
 	{
-		const __m128i* vsptr1 = (const __m128i*)dptr1;
-		const __m128i* vsptr2 = (const __m128i*)dptr2;
-		__m128i* vdptr1 = (__m128i*)dptr1;
-		__m128i* vdptr2 = (__m128i*)dptr2;
+		const __m128i* vsptr1 = WINPR_PACKED_ALIGN_CAST(const __m128i*, dptr1);
+		const __m128i* vsptr2 = WINPR_PACKED_ALIGN_CAST(const __m128i*, dptr2);
+		__m128i* vdptr1 = WINPR_PACKED_ALIGN_CAST(__m128i*, dptr1);
+		__m128i* vdptr2 = WINPR_PACKED_ALIGN_CAST(__m128i*, dptr2);
 
 		__m128i xmm0 = LOAD_SI128(vsptr1);
 		__m128i xmm1 = LOAD_SI128(vsptr2);

--- a/libfreerdp/primitives/sse/prim_alphaComp_sse3.c
+++ b/libfreerdp/primitives/sse/prim_alphaComp_sse3.c
@@ -43,8 +43,8 @@ static pstatus_t sse2_alphaComp_argb(const BYTE* WINPR_RESTRICT pSrc1, UINT32 sr
                                      BYTE* WINPR_RESTRICT pDst, UINT32 dstStep, UINT32 width,
                                      UINT32 height)
 {
-	const UINT32* sptr1 = (const UINT32*)pSrc1;
-	const UINT32* sptr2 = (const UINT32*)pSrc2;
+	const UINT32* sptr1 = WINPR_PACKED_ALIGN_CAST(const UINT32*, pSrc1);
+	const UINT32* sptr2 = WINPR_PACKED_ALIGN_CAST(const UINT32*, pSrc2);
 
 	if ((width <= 0) || (height <= 0))
 		return PRIMITIVES_SUCCESS;
@@ -55,7 +55,7 @@ static pstatus_t sse2_alphaComp_argb(const BYTE* WINPR_RESTRICT pSrc1, UINT32 sr
 		                               height);
 	}
 
-	UINT32* dptr = (UINT32*)pDst;
+	UINT32* dptr = WINPR_PACKED_ALIGN_CAST(UINT32*, pDst);
 	const size_t linebytes = width * sizeof(UINT32);
 	const size_t src1Jump = (src1Step - linebytes) / sizeof(UINT32);
 	const size_t src2Jump = (src2Step - linebytes) / sizeof(UINT32);

--- a/libfreerdp/primitives/sse/prim_colors_sse2.c
+++ b/libfreerdp/primitives/sse/prim_colors_sse2.c
@@ -470,12 +470,12 @@ sse2_RGBToYCbCr_16s16s_P3P3(const INT16* WINPR_RESTRICT pSrc[3], int srcStep,
                             INT16* WINPR_RESTRICT pDst[3], int dstStep,
                             const prim_size_t* WINPR_RESTRICT roi) /* region of interest */
 {
-	const __m128i* r_buf = (const __m128i*)(pSrc[0]);
-	const __m128i* g_buf = (const __m128i*)(pSrc[1]);
-	const __m128i* b_buf = (const __m128i*)(pSrc[2]);
-	__m128i* y_buf = (__m128i*)(pDst[0]);
-	__m128i* cb_buf = (__m128i*)(pDst[1]);
-	__m128i* cr_buf = (__m128i*)(pDst[2]);
+	const __m128i* r_buf = WINPR_PACKED_ALIGN_CAST(const __m128i*, (pSrc[0]));
+	const __m128i* g_buf = WINPR_PACKED_ALIGN_CAST(const __m128i*, (pSrc[1]));
+	const __m128i* b_buf = WINPR_PACKED_ALIGN_CAST(const __m128i*, (pSrc[2]));
+	__m128i* y_buf = WINPR_PACKED_ALIGN_CAST(__m128i*, (pDst[0]));
+	__m128i* cb_buf = WINPR_PACKED_ALIGN_CAST(__m128i*, (pDst[1]));
+	__m128i* cr_buf = WINPR_PACKED_ALIGN_CAST(__m128i*, (pDst[2]));
 
 	if (((ULONG_PTR)(pSrc[0]) & 0x0f) || ((ULONG_PTR)(pSrc[1]) & 0x0f) ||
 	    ((ULONG_PTR)(pSrc[2]) & 0x0f) || ((ULONG_PTR)(pDst[0]) & 0x0f) ||

--- a/libfreerdp/primitives/sse/prim_copy_avx2.c
+++ b/libfreerdp/primitives/sse/prim_copy_avx2.c
@@ -72,8 +72,9 @@ static inline pstatus_t avx2_image_copy_bgr24_bgrx32(BYTE* WINPR_RESTRICT pDstDa
 		/* Ensure alignment requirements can be met */
 		for (; x < width; x += 8)
 		{
-			const __m256i* src = (const __m256i*)&srcLine[(x + nXSrc) * srcByte];
-			__m256i* dst = (__m256i*)&dstLine[(x + nXDst) * dstByte];
+			const __m256i* src =
+			    WINPR_PACKED_ALIGN_CAST(const __m256i*, &srcLine[(x + nXSrc) * srcByte]);
+			__m256i* dst = WINPR_PACKED_ALIGN_CAST(__m256i*, &dstLine[(x + nXDst) * dstByte]);
 			const __m256i s0 = _mm256_loadu_si256(src);
 			__m256i s1 = _mm256_shuffle_epi8(s0, smask);
 
@@ -132,8 +133,9 @@ static inline pstatus_t avx2_image_copy_bgrx32_bgrx32(BYTE* WINPR_RESTRICT pDstD
 		int64_t x = 0;
 		for (; x < width; x += 8)
 		{
-			const __m256i* src = (const __m256i*)&srcLine[(x + nXSrc) * srcByte];
-			__m256i* dst = (__m256i*)&dstLine[(x + nXDst) * dstByte];
+			const __m256i* src =
+			    WINPR_PACKED_ALIGN_CAST(const __m256i*, &srcLine[(x + nXSrc) * srcByte]);
+			__m256i* dst = WINPR_PACKED_ALIGN_CAST(__m256i*, &dstLine[(x + nXDst) * dstByte]);
 			const __m256i s0 = _mm256_loadu_si256(src);
 			const __m256i s1 = _mm256_loadu_si256(dst);
 			__m256i d0 = _mm256_blendv_epi8(s1, s0, mask);

--- a/libfreerdp/primitives/sse/prim_copy_sse4_1.c
+++ b/libfreerdp/primitives/sse/prim_copy_sse4_1.c
@@ -61,8 +61,9 @@ static inline pstatus_t sse_image_copy_bgr24_bgrx32(BYTE* WINPR_RESTRICT pDstDat
 		/* Ensure alignment requirements can be met */
 		for (; x < width; x += 4)
 		{
-			const __m128i* src = (const __m128i*)&srcLine[(x + nXSrc) * srcByte];
-			__m128i* dst = (__m128i*)&dstLine[(x + nXDst) * dstByte];
+			const __m128i* src =
+			    WINPR_PACKED_ALIGN_CAST(const __m128i*, &srcLine[(x + nXSrc) * srcByte]);
+			__m128i* dst = WINPR_PACKED_ALIGN_CAST(__m128i*, &dstLine[(x + nXDst) * dstByte]);
 			const __m128i s0 = LOAD_SI128(src);
 			const __m128i s1 = _mm_shuffle_epi8(s0, smask);
 			const __m128i s2 = LOAD_SI128(dst);
@@ -111,8 +112,9 @@ static inline pstatus_t sse_image_copy_bgrx32_bgrx32(BYTE* WINPR_RESTRICT pDstDa
 		int64_t x = 0;
 		for (; x < width; x += 4)
 		{
-			const __m128i* src = (const __m128i*)&srcLine[(x + nXSrc) * srcByte];
-			__m128i* dst = (__m128i*)&dstLine[(x + nXDst) * dstByte];
+			const __m128i* src =
+			    WINPR_PACKED_ALIGN_CAST(const __m128i*, &srcLine[(x + nXSrc) * srcByte]);
+			__m128i* dst = WINPR_PACKED_ALIGN_CAST(__m128i*, &dstLine[(x + nXDst) * dstByte]);
 			const __m128i s0 = LOAD_SI128(src);
 			const __m128i s1 = LOAD_SI128(dst);
 			__m128i d0 = _mm_blendv_epi8(s1, s0, mask);

--- a/libfreerdp/primitives/sse/prim_shift_sse3.c
+++ b/libfreerdp/primitives/sse/prim_shift_sse3.c
@@ -78,7 +78,7 @@ static pstatus_t sse2_lShiftC_16s_inplace(INT16* WINPR_RESTRICT pSrcDst, UINT32 
 
 	while (count--)
 	{
-		const __m128i* src = (const __m128i*)pSrcDst;
+		const __m128i* src = WINPR_PACKED_ALIGN_CAST(const __m128i*, pSrcDst);
 
 		__m128i xmm0 = LOAD_SI128(src++);
 		__m128i xmm1 = LOAD_SI128(src++);
@@ -98,7 +98,7 @@ static pstatus_t sse2_lShiftC_16s_inplace(INT16* WINPR_RESTRICT pSrcDst, UINT32 
 		xmm6 = _mm_slli_epi16(xmm6, (int16_t)val);
 		xmm7 = _mm_slli_epi16(xmm7, (int16_t)val);
 
-		__m128i* dst = (__m128i*)pSrcDst;
+		__m128i* dst = WINPR_PACKED_ALIGN_CAST(__m128i*, pSrcDst);
 
 		STORE_SI128(dst++, xmm0);
 		STORE_SI128(dst++, xmm1);
@@ -117,12 +117,12 @@ static pstatus_t sse2_lShiftC_16s_inplace(INT16* WINPR_RESTRICT pSrcDst, UINT32 
 	len -= count << (5 - shifts);
 	while (count--)
 	{
-		const __m128i* src = (const __m128i*)pSrcDst;
+		const __m128i* src = WINPR_PACKED_ALIGN_CAST(const __m128i*, pSrcDst);
 		__m128i xmm0 = LOAD_SI128(src);
 
 		xmm0 = _mm_slli_epi16(xmm0, (int16_t)val);
 
-		__m128i* dst = (__m128i*)pSrcDst;
+		__m128i* dst = WINPR_PACKED_ALIGN_CAST(__m128i*, pSrcDst);
 		STORE_SI128(dst++, xmm0);
 		pSrcDst = (INT16*)dst;
 	}

--- a/libfreerdp/utils/channel_pdu_tracker.c
+++ b/libfreerdp/utils/channel_pdu_tracker.c
@@ -57,7 +57,8 @@ wStream* ChannelPduTracker_poll(ChannelPduTracker* tracker, BOOL* ok)
 		return nullptr;
 	}
 
-	const CHANNEL_PDU_HEADER* header = (const CHANNEL_PDU_HEADER*)tracker->buffer;
+	const CHANNEL_PDU_HEADER* header =
+	    WINPR_PACKED_ALIGN_CAST(const CHANNEL_PDU_HEADER*, tracker->buffer);
 	if (header->length > CHANNEL_CHUNK_LENGTH)
 	{
 		WLog_Print(tracker->log, WLOG_ERROR, "chunk size %" PRIu32 " is too big", header->length);

--- a/server/shadow/X11/x11_shadow.c
+++ b/server/shadow/X11/x11_shadow.c
@@ -593,7 +593,7 @@ static int x11_shadow_query_cursor(x11ShadowSubsystem* subsystem, BOOL getImage)
 		subsystem->cursorHeight = ci->height;
 		subsystem->cursorId = ci->cursor_serial;
 		n = ci->width * ci->height;
-		pDstPixel = (UINT32*)subsystem->cursorPixels;
+		pDstPixel = WINPR_PACKED_ALIGN_CAST(UINT32*, subsystem->cursorPixels);
 
 		for (int k = 0; k < n; k++)
 		{

--- a/winpr/CMakeLists.txt
+++ b/winpr/CMakeLists.txt
@@ -149,6 +149,16 @@ if(WITHOUT_WINPR_3x_DEPRECATED)
   add_compile_definitions(WITHOUT_WINPR_3x_DEPRECATED)
 endif()
 
+option(
+  DISABLE_SUPPORTED_ARCH_CHECKS
+  "[experimental,dangerous,unsupported] Build for unknown systems or such missing essential features (unaligned memory access, ...)"
+  OFF
+)
+if(DISABLE_SUPPORTED_ARCH_CHECKS)
+  include(WarnExperimental)
+  warn_experimental("Skip PlatformChecks" "-DDISABLE_SUPPORTED_ARCH_CHECKS=OFF")
+endif()
+
 # Include cmake modules
 include(CheckIncludeFiles)
 include(CheckLibraryExists)

--- a/winpr/include/config/config.h.in
+++ b/winpr/include/config/config.h.in
@@ -60,4 +60,6 @@
 #cmakedefine WITH_WINPR_DEPRECATED /** @since version 3.27.0 */
 #endif
 
+#cmakedefine DISABLE_SUPPORTED_ARCH_CHECKS /** @since version 3.32.0 */
+
 #endif /* WINPR_CONFIG_H */

--- a/winpr/include/winpr/cast.h
+++ b/winpr/include/winpr/cast.h
@@ -21,6 +21,7 @@
 
 #include <stdint.h>
 
+#include <winpr/platform.h>
 #include <winpr/assert-api.h>
 
 /**
@@ -31,6 +32,63 @@
 #define WINPR_CXX_COMPAT_CAST(t, val) static_cast<t>(val)
 #else
 #define WINPR_CXX_COMPAT_CAST(t, val) (t)(val)
+#endif
+
+/**! @brief Checks alignment requirements.
+ * - On supported platforms (arm, arm64) check that unaligned access is enabled or die
+ * - On unsupported platforms print a compiler warning
+ */
+#if defined(DISABLE_SUPPORTED_ARCH_CHECKS)
+#elif defined(_M_ARM) || defined(_M_ARM64)
+#if !defined(__ARM_FEATURE_UNALIGNED)
+#warning "-munaligned-access is required on arm"
+#else
+#define WINPR_ARCH_SUPPORTED 1
+#endif
+#elif defined(_M_IX86) || defined(_M_AMD64)
+#define WINPR_ARCH_SUPPORTED 1
+#elif defined(_M_RISCV32) || defined(_M_RISCV64)
+#if !defined(__riscv_misaligned_fast)
+#error "RISCV must support __riscv_misaligned_fast"
+#else
+#define WINPR_ARCH_SUPPORTED 1
+#endif
+#else
+#warning "unaligned pointer access not verified on platform, SIGBUS may happen!"
+#endif
+
+/**! @brief Cast to \ref t and silence Wcast-align warnings.
+ *
+ * This just silences compiler warnings on supported architectures.
+ * Support is checked at compile time.
+ *
+ * @since version 3.32.0
+ */
+#if defined(WINPR_ARCH_SUPPORTED) && !defined(_WIN32)
+#define WINPR_PACKED_ALIGN_CAST(t, val)                     \
+	__extension__({                                         \
+		WINPR_PRAGMA_DIAG_PUSH;                             \
+		WINPR_PRAGMA_DIAG_IGNORED_CAST_ALIGN;               \
+		typeof(t) aligntmp = WINPR_CXX_COMPAT_CAST(t, val); \
+		WINPR_PRAGMA_DIAG_POP;                              \
+		aligntmp;                                           \
+	})
+#else
+// Promote any -Wcast-align warnings to errors on platforms not supporting unaligned access
+#if defined(DISABLE_SUPPORTED_ARCH_CHECKS)
+#if defined(__clang__)
+WINPR_DO_PRAGMA(clang diagnostic warning "-Wcast-align")
+#elif defined(__GNUC__)
+WINPR_DO_PRAGMA(GCC diagnostic warning "-Wcast-align")
+#endif
+#if defined(__clang__)
+WINPR_DO_PRAGMA(clang diagnostic error "-Wcast-align")
+#elif defined(__GNUC__)
+WINPR_DO_PRAGMA(GCC diagnostic error "-Wcast-align")
+#endif
+#else
+#endif
+#define WINPR_PACKED_ALIGN_CAST(t, val) WINPR_CXX_COMPAT_CAST(t, val)
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/winpr/include/winpr/ncrypt.h
+++ b/winpr/include/winpr/ncrypt.h
@@ -43,103 +43,103 @@ typedef ULONG_PTR NCRYPT_HANDLE;
 typedef ULONG_PTR NCRYPT_PROV_HANDLE;
 typedef ULONG_PTR NCRYPT_KEY_HANDLE;
 
-#define MS_KEY_STORAGE_PROVIDER                   \
-	(const WCHAR*)"M\x00i\x00"                    \
-	              "c\x00r\x00o\x00s\x00o\x00"     \
-	              "f\x00t\x00 "                   \
-	              "\x00S\x00o\x00"                \
-	              "f\x00t\x00w\x00"               \
-	              "a\x00r\x00"                    \
-	              "e\x00 \x00K\x00"               \
-	              "e\x00y\x00 "                   \
-	              "\x00S\x00t\x00o\x00r\x00"      \
-	              "a\x00g\x00"                    \
-	              "e\x00 "                        \
-	              "\x00P\x00r\x00o\x00v\x00i\x00" \
-	              "d\x00"                         \
-	              "e\x00r\x00\x00"
-#define MS_SMART_CARD_KEY_STORAGE_PROVIDER        \
-	(const WCHAR*)"M\x00i\x00"                    \
-	              "c\x00r\x00o\x00s\x00o\x00"     \
-	              "f\x00t\x00 \x00S\x00m\x00"     \
-	              "a\x00r\x00t\x00 "              \
-	              "\x00"                          \
-	              "C\x00"                         \
-	              "a\x00r\x00"                    \
-	              "d\x00 \x00K\x00"               \
-	              "e\x00y\x00 "                   \
-	              "\x00S\x00t\x00o\x00r\x00"      \
-	              "a\x00g\x00"                    \
-	              "e\x00 "                        \
-	              "\x00P\x00r\x00o\x00v\x00i\x00" \
-	              "d\x00"                         \
-	              "e\x00r\x00\x00"
+#define MS_KEY_STORAGE_PROVIDER                                           \
+	WINPR_PACKED_ALIGN_CAST(const WCHAR*, "M\x00i\x00"                    \
+	                                      "c\x00r\x00o\x00s\x00o\x00"     \
+	                                      "f\x00t\x00 "                   \
+	                                      "\x00S\x00o\x00"                \
+	                                      "f\x00t\x00w\x00"               \
+	                                      "a\x00r\x00"                    \
+	                                      "e\x00 \x00K\x00"               \
+	                                      "e\x00y\x00 "                   \
+	                                      "\x00S\x00t\x00o\x00r\x00"      \
+	                                      "a\x00g\x00"                    \
+	                                      "e\x00 "                        \
+	                                      "\x00P\x00r\x00o\x00v\x00i\x00" \
+	                                      "d\x00"                         \
+	                                      "e\x00r\x00\x00")
+#define MS_SMART_CARD_KEY_STORAGE_PROVIDER                                \
+	WINPR_PACKED_ALIGN_CAST(const WCHAR*, "M\x00i\x00"                    \
+	                                      "c\x00r\x00o\x00s\x00o\x00"     \
+	                                      "f\x00t\x00 \x00S\x00m\x00"     \
+	                                      "a\x00r\x00t\x00 "              \
+	                                      "\x00"                          \
+	                                      "C\x00"                         \
+	                                      "a\x00r\x00"                    \
+	                                      "d\x00 \x00K\x00"               \
+	                                      "e\x00y\x00 "                   \
+	                                      "\x00S\x00t\x00o\x00r\x00"      \
+	                                      "a\x00g\x00"                    \
+	                                      "e\x00 "                        \
+	                                      "\x00P\x00r\x00o\x00v\x00i\x00" \
+	                                      "d\x00"                         \
+	                                      "e\x00r\x00\x00")
 
 #define MS_SCARD_PROV_A "Microsoft Base Smart Card Crypto Provider"
-#define MS_SCARD_PROV                                \
-	(const WCHAR*)("M\x00i\x00"                      \
-	               "c\x00r\x00o\x00s\x00o\x00"       \
-	               "f\x00t\x00 \x00"                 \
-	               "B\x00"                           \
-	               "a\x00s\x00"                      \
-	               "e\x00 "                          \
-	               "\x00S\x00m\x00"                  \
-	               "a\x00r\x00t\x00 \x00"            \
-	               "C\x00"                           \
-	               "a\x00r\x00"                      \
-	               "d\x00 "                          \
-	               "\x00"                            \
-	               "C\x00r\x00y\x00p\x00t\x00o\x00 " \
-	               "\x00P\x00r\x00o\x00v\x00i\x00"   \
-	               "d\x00"                           \
-	               "e\x00r\x00\x00")
+#define MS_SCARD_PROV                                                        \
+	WINPR_PACKED_ALIGN_CAST(const WCHAR*, ("M\x00i\x00"                      \
+	                                       "c\x00r\x00o\x00s\x00o\x00"       \
+	                                       "f\x00t\x00 \x00"                 \
+	                                       "B\x00"                           \
+	                                       "a\x00s\x00"                      \
+	                                       "e\x00 "                          \
+	                                       "\x00S\x00m\x00"                  \
+	                                       "a\x00r\x00t\x00 \x00"            \
+	                                       "C\x00"                           \
+	                                       "a\x00r\x00"                      \
+	                                       "d\x00 "                          \
+	                                       "\x00"                            \
+	                                       "C\x00r\x00y\x00p\x00t\x00o\x00 " \
+	                                       "\x00P\x00r\x00o\x00v\x00i\x00"   \
+	                                       "d\x00"                           \
+	                                       "e\x00r\x00\x00"))
 
-#define MS_PLATFORM_KEY_STORAGE_PROVIDER            \
-	(const WCHAR*)"M\x00i\x00"                      \
-	              "c\x00r\x00o\x00s\x00o\x00"       \
-	              "f\x00t\x00 "                     \
-	              "\x00P\x00l\x00"                  \
-	              "a\x00t\x00"                      \
-	              "f\x00o\x00r\x00m\x00 "           \
-	              "\x00"                            \
-	              "C\x00r\x00y\x00p\x00t\x00o\x00 " \
-	              "\x00P\x00r\x00o\x00v\x00i\x00"   \
-	              "d\x00"                           \
-	              "e\x00r\x00\x00"
+#define MS_PLATFORM_KEY_STORAGE_PROVIDER                                    \
+	WINPR_PACKED_ALIGN_CAST(const WCHAR*, "M\x00i\x00"                      \
+	                                      "c\x00r\x00o\x00s\x00o\x00"       \
+	                                      "f\x00t\x00 "                     \
+	                                      "\x00P\x00l\x00"                  \
+	                                      "a\x00t\x00"                      \
+	                                      "f\x00o\x00r\x00m\x00 "           \
+	                                      "\x00"                            \
+	                                      "C\x00r\x00y\x00p\x00t\x00o\x00 " \
+	                                      "\x00P\x00r\x00o\x00v\x00i\x00"   \
+	                                      "d\x00"                           \
+	                                      "e\x00r\x00\x00")
 
-#define NCRYPT_CERTIFICATE_PROPERTY \
-	(const WCHAR*)"S\x00m\x00"      \
-	              "a\x00r\x00t\x00" \
-	              "C\x00"           \
-	              "a\x00r\x00"      \
-	              "d\x00K\x00"      \
-	              "e\x00y\x00"      \
-	              "C\x00"           \
-	              "e\x00r\x00t"     \
-	              "\x00i\x00"       \
-	              "f\x00i\x00"      \
-	              "c\x00"           \
-	              "a\x00t\x00"      \
-	              "e\x00\x00"
-#define NCRYPT_NAME_PROPERTY (const WCHAR*)"N\x00a\x00m\x00e\x00\x00"
-#define NCRYPT_UNIQUE_NAME_PROPERTY           \
-	(const WCHAR*)"U\x00n\x00i\x00q\x00u\x00" \
-	              "e\x00 \x00N\x00"           \
-	              "a\x00m\x00"                \
-	              "e\x00\x00"
-#define NCRYPT_READER_PROPERTY      \
-	(const WCHAR*)"S\x00m\x00"      \
-	              "a\x00r\x00t\x00" \
-	              "C\x00"           \
-	              "a\x00r\x00"      \
-	              "d\x00R\x00"      \
-	              "e\x00"           \
-	              "a\x00"           \
-	              "d\x00"           \
-	              "e\x00r\x00\x00"
+#define NCRYPT_CERTIFICATE_PROPERTY                         \
+	WINPR_PACKED_ALIGN_CAST(const WCHAR*, "S\x00m\x00"      \
+	                                      "a\x00r\x00t\x00" \
+	                                      "C\x00"           \
+	                                      "a\x00r\x00"      \
+	                                      "d\x00K\x00"      \
+	                                      "e\x00y\x00"      \
+	                                      "C\x00"           \
+	                                      "e\x00r\x00t"     \
+	                                      "\x00i\x00"       \
+	                                      "f\x00i\x00"      \
+	                                      "c\x00"           \
+	                                      "a\x00t\x00"      \
+	                                      "e\x00\x00")
+#define NCRYPT_NAME_PROPERTY WINPR_PACKED_ALIGN_CAST(const WCHAR*, "N\x00a\x00m\x00e\x00\x00")
+#define NCRYPT_UNIQUE_NAME_PROPERTY                                   \
+	WINPR_PACKED_ALIGN_CAST(const WCHAR*, "U\x00n\x00i\x00q\x00u\x00" \
+	                                      "e\x00 \x00N\x00"           \
+	                                      "a\x00m\x00"                \
+	                                      "e\x00\x00")
+#define NCRYPT_READER_PROPERTY                              \
+	WINPR_PACKED_ALIGN_CAST(const WCHAR*, "S\x00m\x00"      \
+	                                      "a\x00r\x00t\x00" \
+	                                      "C\x00"           \
+	                                      "a\x00r\x00"      \
+	                                      "d\x00R\x00"      \
+	                                      "e\x00"           \
+	                                      "a\x00"           \
+	                                      "d\x00"           \
+	                                      "e\x00r\x00\x00")
 
 /* winpr specific properties */
-#define NCRYPT_WINPR_SLOTID (const WCHAR*)"S\x00l\x00o\x00t\x00\x00"
+#define NCRYPT_WINPR_SLOTID WINPR_PACKED_ALIGN_CAST(const WCHAR*, "S\x00l\x00o\x00t\x00\x00")
 
 #define NCRYPT_MACHINE_KEY_FLAG 0x20
 #define NCRYPT_SILENT_FLAG 0x40

--- a/winpr/include/winpr/platform.h
+++ b/winpr/include/winpr/platform.h
@@ -21,6 +21,7 @@
 #define WINPR_PLATFORM_H
 
 #include <stdlib.h>
+#include <winpr/config.h>
 
 /* MSVC only defines _Pragma if you compile with /std:c11 with no extensions
  * see
@@ -133,6 +134,8 @@
 #define WINPR_PRAGMA_DIAG_IGNORED_DEPRECATED_DECL \
 	WINPR_DO_PRAGMA(clang diagnostic ignored      \
 	                "-Wdeprecated-declarations") /** @since version 3.17.2 */
+#define WINPR_PRAGMA_DIAG_IGNORED_CAST_ALIGN \
+	WINPR_DO_PRAGMA(clang diagnostic ignored "-Wcast-align") /** @since 3.32.0 */
 
 #if __clang_major__ >= 13
 #define WINPR_PRAGMA_DIAG_IGNORED_RESERVED_IDENTIFIER \
@@ -219,6 +222,8 @@
 #define WINPR_PRAGMA_DIAG_POP WINPR_DO_PRAGMA(GCC diagnostic pop)
 #define WINPR_PRAGMA_UNROLL_LOOP \
 	WINPR_DO_PRAGMA(GCC unroll 8) WINPR_DO_PRAGMA(GCC ivdep) /** @since version 3.6.0 */
+#define WINPR_PRAGMA_DIAG_IGNORED_CAST_ALIGN \
+	WINPR_DO_PRAGMA(gcc diagnostic ignored "-Wcast-align") /** @since 3.32.0 */
 #else
 #define WINPR_PRAGMA_DIAG_PUSH
 #define WINPR_PRAGMA_DIAG_IGNORED_PEDANTIC
@@ -241,6 +246,7 @@
 #define WINPR_PRAGMA_DIAG_IGNORED_MISMATCHED_DEALLOC                 /** @since version 3.3.0 */
 #define WINPR_PRAGMA_DIAG_POP
 #define WINPR_PRAGMA_UNROLL_LOOP /** @since version 3.6.0 */
+#define WINPR_PRAGMA_DIAG_IGNORED_CAST_ALIGN /** @since 3.32.0 */
 #endif
 
 #if defined(MSVC)
@@ -377,6 +383,26 @@ WINPR_PRAGMA_DIAG_IGNORED_RESERVED_ID_MACRO
 #ifndef _M_E2K
 // NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 #define _M_E2K 1
+#endif
+#endif
+
+/* RISCV64 (_M_RISCV64) */
+
+#if defined(__riscv)
+#if defined(__riscv_xlen)
+#if __riscv_xlen == 64
+#ifndef _M_RISCV64
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+#define _M_RISCV64 1
+#endif
+#elif __riscv_xlen == 32
+#ifndef _M_RISCV32
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+#define _M_RISCV32 1
+#endif
+#else
+#error "Unknown/unsupported RISCV xlen value"
+#endif
 #endif
 #endif
 

--- a/winpr/include/winpr/stream.h
+++ b/winpr/include/winpr/stream.h
@@ -77,7 +77,7 @@ extern "C"
 	WINPR_ATTR_NODISCARD
 	WINPR_API BOOL Stream_EnsureRemainingCapacity(wStream* s, size_t size);
 
-#define WINPR_STREAM_CAST(t, val) WINPR_CXX_COMPAT_CAST(t, val)
+#define WINPR_STREAM_CAST(t, val) WINPR_PACKED_ALIGN_CAST(t, val)
 
 #define Stream_CheckAndLogRequiredCapacityOfSize(tag, s, nmemb, size)                         \
 	Stream_CheckAndLogRequiredCapacityEx(tag, WLOG_WARN, s, nmemb, size, "%s(%s:%" PRIuz ")", \

--- a/winpr/libwinpr/crt/alignment.c
+++ b/winpr/libwinpr/crt/alignment.c
@@ -191,7 +191,7 @@ WINPR_ATTR_NODISCARD static inline size_t cMIN(size_t a, size_t b)
 void* winpr_aligned_offset_recalloc(void* memblock, size_t num, size_t size, size_t alignment,
                                     size_t offset)
 {
-	char* newMemblock = nullptr;
+	void* newMemblock = nullptr;
 	WINPR_ALIGNED_MEM* pNewMem = nullptr;
 
 	if (!memblock)
@@ -226,7 +226,7 @@ void* winpr_aligned_offset_recalloc(void* memblock, size_t num, size_t size, siz
 	{
 		const size_t csize = cMIN(pMem->size, pNewMem->size);
 		memcpy(newMemblock, memblock, csize);
-		ZeroMemory(newMemblock + csize, pNewMem->size - csize);
+		ZeroMemory(((char*)newMemblock) + csize, pNewMem->size - csize);
 	}
 fail:
 	winpr_aligned_free(memblock);

--- a/winpr/libwinpr/crt/unicode_apple.m
+++ b/winpr/libwinpr/crt/unicode_apple.m
@@ -73,8 +73,8 @@ int int_MultiByteToWideChar(UINT CodePage, DWORD dwFlags, LPCSTR lpMultiByteStr,
 		return -1;
 	}
 
-	const WCHAR *utf16 =
-	    (const WCHAR *)[utf cStringUsingEncoding:NSUTF16LittleEndianStringEncoding];
+	const WCHAR *utf16 = WINPR_PACKED_ALIGN_CAST(
+	    const WCHAR *, [utf cStringUsingEncoding:NSUTF16LittleEndianStringEncoding]);
 	const size_t utf16ByteLen = [utf lengthOfBytesUsingEncoding:NSUTF16LittleEndianStringEncoding];
 	const size_t utf16CharLen = utf16ByteLen / sizeof(WCHAR);
 	if (!utf16)

--- a/winpr/libwinpr/crypto/md4.c
+++ b/winpr/libwinpr/crypto/md4.c
@@ -37,6 +37,8 @@
 
 #include <string.h>
 
+#include <winpr/cast.h>
+
 #include "md4.h"
 
 /*
@@ -81,7 +83,7 @@ static inline winpr_MD4_u32plus H(winpr_MD4_u32plus x, winpr_MD4_u32plus y, winp
  * their own translation unit avoids the problem.
  */
 #if defined(__i386__) || defined(__x86_64__) || defined(__vax__)
-#define SET(n) (*(const winpr_MD4_u32plus*)&ptr[4ULL * (n)])
+#define SET(n) (*(WINPR_PACKED_ALIGN_CAST(const winpr_MD4_u32plus*, &ptr[4ULL * (n)])))
 #define GET(n) SET(n)
 #else
 #define SET(n)                                                          \

--- a/winpr/libwinpr/crypto/md5.c
+++ b/winpr/libwinpr/crypto/md5.c
@@ -37,6 +37,8 @@
 
 #include <string.h>
 
+#include <winpr/cast.h>
+
 #include "md5.h"
 
 /*
@@ -91,7 +93,7 @@ static inline winpr_MD5_u32plus I(winpr_MD5_u32plus x, winpr_MD5_u32plus y, winp
  * their own translation unit avoids the problem.
  */
 #if defined(__i386__) || defined(__x86_64__) || defined(__vax__)
-#define SET(n) (*(const winpr_MD5_u32plus*)&ptr[4ULL * (n)])
+#define SET(n) (*(WINPR_PACKED_ALIGN_CAST(const winpr_MD5_u32plus*, &ptr[4ULL * (n)])))
 #define GET(n) SET(n)
 #else
 #define SET(n)                                                          \

--- a/winpr/libwinpr/ncrypt/ncrypt_pkcs11.c
+++ b/winpr/libwinpr/ncrypt/ncrypt_pkcs11.c
@@ -1233,7 +1233,7 @@ static SECURITY_STATUS NCryptP11KeyGetProperties(NCryptP11KeyHandle* keyHandle,
 			*pcbResult = 4;
 			if (pbOutput)
 			{
-				UINT32* ptr = (UINT32*)pbOutput;
+				UINT32* ptr = WINPR_PACKED_ALIGN_CAST(UINT32*, pbOutput);
 
 				if (cbOutput < 4)
 					return NTE_NO_MEMORY;

--- a/winpr/libwinpr/smartcard/smartcard_pcsc.c
+++ b/winpr/libwinpr/smartcard/smartcard_pcsc.c
@@ -858,7 +858,7 @@ static LONG WINAPI PCSC_SCardListReaderGroups_Internal(SCARDCONTEXT hContext, LP
 			else
 				PCSC_AddMemoryBlock(hContext, tmp);
 
-			*(LPSTR*)mszGroups = tmp;
+			*(WINPR_PACKED_ALIGN_CAST(LPSTR*, mszGroups)) = tmp;
 		}
 	}
 	else
@@ -915,7 +915,7 @@ static LONG WINAPI PCSC_SCardListReaderGroupsW(SCARDCONTEXT hContext, LPWSTR msz
 			status = SCARD_E_NO_MEMORY;
 			goto fail;
 		}
-		*(WCHAR**)mszGroups = str;
+		*(WINPR_PACKED_ALIGN_CAST(WCHAR**, mszGroups)) = str;
 		*pcchGroups = (DWORD)size;
 		PCSC_AddMemoryBlock(hContext, str);
 		PCSC_SCardFreeMemory_Internal(hContext, *pMszGroupsA);
@@ -970,7 +970,7 @@ static LONG WINAPI PCSC_SCardListReaders_Internal(SCARDCONTEXT hContext, LPCSTR 
 			else
 				PCSC_AddMemoryBlock(hContext, tmp);
 
-			*(char**)mszReaders = tmp;
+			*(WINPR_PACKED_ALIGN_CAST(char**, mszReaders)) = tmp;
 		}
 	}
 	else
@@ -1085,7 +1085,7 @@ static LONG WINAPI PCSC_SCardListReadersW(SCARDCONTEXT hContext, LPCWSTR mszGrou
 			goto fail;
 		}
 
-		*(LPWSTR*)mszReaders = str;
+		*(WINPR_PACKED_ALIGN_CAST(LPWSTR*, mszReaders)) = str;
 		*pcchReaders = (DWORD)size;
 		PCSC_AddMemoryBlock(hContext, str);
 	}
@@ -1170,7 +1170,7 @@ static LONG WINAPI PCSC_SCardListCardsA(WINPR_ATTR_UNUSED SCARDCONTEXT hContext,
 		if (!output)
 			return SCARD_E_NO_MEMORY;
 
-		*((LPSTR*)mszCards) = output;
+		*(WINPR_PACKED_ALIGN_CAST(LPSTR*, mszCards)) = output;
 	}
 	else
 	{
@@ -1223,7 +1223,7 @@ WINPR_ATTR_NODISCARD static LONG WINAPI PCSC_SCardListCardsW(
 		if (!output)
 			return SCARD_E_NO_MEMORY;
 
-		*((LPWSTR*)mszCards) = output;
+		*(WINPR_PACKED_ALIGN_CAST(LPWSTR*, mszCards)) = output;
 	}
 	else
 	{
@@ -2133,7 +2133,7 @@ WINPR_ATTR_NODISCARD static LONG WINAPI PCSC_SCardStatus_Internal(
 	if (tATR)
 	{
 		PCSC_AddMemoryBlock(hContext, tATR);
-		*(BYTE**)pbAtr = tATR;
+		*(WINPR_PACKED_ALIGN_CAST(BYTE**, pbAtr)) = tATR;
 	}
 
 	if (tReader)
@@ -2152,13 +2152,13 @@ WINPR_ATTR_NODISCARD static LONG WINAPI PCSC_SCardStatus_Internal(
 			free(tReader);
 
 			PCSC_AddMemoryBlock(hContext, tmp);
-			*(WCHAR**)mszReaderNames = tmp;
+			*(WINPR_PACKED_ALIGN_CAST(WCHAR**, mszReaderNames)) = tmp;
 		}
 		else
 		{
 			tReader[pcsc_cchReaderLen - 1] = '\0';
 			PCSC_AddMemoryBlock(hContext, tReader);
-			*(char**)mszReaderNames = tReader;
+			*(WINPR_PACKED_ALIGN_CAST(char**, mszReaderNames)) = tReader;
 		}
 	}
 
@@ -2514,7 +2514,7 @@ WINPR_ATTR_NODISCARD static LONG WINAPI PCSC_SCardGetAttrib_Internal(SCARDHANDLE
 			}
 			else
 				PCSC_AddMemoryBlock(hContext, tmp);
-			*(BYTE**)pbAttr = tmp;
+			*(WINPR_PACKED_ALIGN_CAST(BYTE**, pbAttr)) = tmp;
 		}
 	}
 	else
@@ -2588,7 +2588,7 @@ WINPR_ATTR_NODISCARD static LONG WINAPI PCSC_SCardGetAttrib_FriendlyName(SCARDHA
 			if (cbAttrLen == SCARD_AUTOALLOCATE)
 			{
 				WINPR_ASSERT(length <= UINT32_MAX / sizeof(WCHAR));
-				*(WCHAR**)pbAttr = friendlyNameW;
+				*(WINPR_PACKED_ALIGN_CAST(WCHAR**, pbAttr)) = friendlyNameW;
 				*pcbAttrLen = (UINT32)length * sizeof(WCHAR);
 				PCSC_AddMemoryBlock(hContext, friendlyNameW);
 			}
@@ -2611,7 +2611,7 @@ WINPR_ATTR_NODISCARD static LONG WINAPI PCSC_SCardGetAttrib_FriendlyName(SCARDHA
 		length++; /* Include '\0' in length */
 		if (cbAttrLen == SCARD_AUTOALLOCATE)
 		{
-			*(CHAR**)pbAttr = namePCSC;
+			*(WINPR_PACKED_ALIGN_CAST(CHAR**, pbAttr)) = namePCSC;
 			WINPR_ASSERT(length <= UINT32_MAX);
 			*pcbAttrLen = (UINT32)length;
 			PCSC_AddMemoryBlock(hContext, namePCSC);
@@ -2694,7 +2694,7 @@ static LONG PCSC_ReadDeviceSystemName(WINPR_ATTR_UNUSED SCARDCONTEXT hContext, S
 		}
 
 		*pcbAttrLen = cbAttrLen;
-		*(BYTE**)pbAttr = tmp;
+		*(WINPR_PACKED_ALIGN_CAST(BYTE**, pbAttr)) = tmp;
 		return SCARD_S_SUCCESS;
 	}
 
@@ -2732,7 +2732,7 @@ WINPR_ATTR_NODISCARD static LONG WINAPI PCSC_SCardGetAttrib(SCARDHANDLE hCard, D
 			return SCARD_E_INVALID_PARAMETER;
 
 		pcbAttrLenAlloc = TRUE;
-		*(BYTE**)pbAttr = nullptr;
+		*(WINPR_PACKED_ALIGN_CAST(BYTE**, pbAttr)) = nullptr;
 	}
 	else
 	{
@@ -2771,7 +2771,7 @@ WINPR_ATTR_NODISCARD static LONG WINAPI PCSC_SCardGetAttrib(SCARDHANDLE hCard, D
 				 */
 
 				if (pcbAttrLenAlloc)
-					vendorName = (char*)*(BYTE**)pbAttr;
+					vendorName = (char*)*(WINPR_PACKED_ALIGN_CAST(BYTE**, pbAttr));
 				else
 					vendorName = (char*)pbAttr;
 
@@ -2805,7 +2805,8 @@ WINPR_ATTR_NODISCARD static LONG WINAPI PCSC_SCardGetAttrib(SCARDHANDLE hCard, D
 						return SCARD_E_INSUFFICIENT_BUFFER;
 
 					if (pbAttr)
-						*(DWORD*)pbAttr = PCSC_ConvertProtocolsToWinSCard(dwProtocol);
+						*(WINPR_PACKED_ALIGN_CAST(DWORD*, pbAttr)) =
+						    PCSC_ConvertProtocolsToWinSCard(dwProtocol);
 					*pcbAttrLen = sizeof(DWORD);
 				}
 			}
@@ -2822,7 +2823,8 @@ WINPR_ATTR_NODISCARD static LONG WINAPI PCSC_SCardGetAttrib(SCARDHANDLE hCard, D
 
 				status = SCARD_S_SUCCESS;
 				if (pbAttr)
-					*(DWORD*)pbAttr = (channelType << 16u) | channelNumber;
+					*(WINPR_PACKED_ALIGN_CAST(DWORD*, pbAttr)) =
+					    (channelType << 16u) | channelNumber;
 				*pcbAttrLen = sizeof(DWORD);
 			}
 		}
@@ -3020,7 +3022,7 @@ WINPR_ATTR_NODISCARD static LONG WINAPI PCSC_SCardReadCacheA(SCARDCONTEXT hConte
 		}
 
 		memcpy(mem, data->data, data->len);
-		*(BYTE**)Data = mem;
+		*(WINPR_PACKED_ALIGN_CAST(BYTE**, Data)) = mem;
 	}
 	else
 	{
@@ -3074,7 +3076,7 @@ WINPR_ATTR_NODISCARD static LONG WINAPI PCSC_SCardReadCacheW(SCARDCONTEXT hConte
 		}
 
 		memcpy(mem, data->data, data->len);
-		*(BYTE**)Data = mem;
+		*(WINPR_PACKED_ALIGN_CAST(BYTE**, Data)) = mem;
 	}
 	else
 	{

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -2143,7 +2143,8 @@ static SECURITY_STATUS SEC_ENTRY kerberos_SetCredentialsAttributesX(
 
 			if (kdc_settings->ProxyServerLength > 0)
 			{
-				WCHAR* proxy = (WCHAR*)((BYTE*)pBuffer + kdc_settings->ProxyServerOffset);
+				WCHAR* proxy = WINPR_PACKED_ALIGN_CAST(
+				    WCHAR*, ((BYTE*)pBuffer + kdc_settings->ProxyServerOffset));
 
 				credentials->kdc_url = ConvertWCharNToUtf8Alloc(
 				    proxy, kdc_settings->ProxyServerLength / sizeof(WCHAR), nullptr);

--- a/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm_av_pairs.c
@@ -231,7 +231,7 @@ static NTLM_AV_PAIR* ntlm_av_pair_next(NTLM_AV_PAIR* pAvPair, size_t* pcbAvPair)
 		return nullptr;
 
 	*pcbAvPair -= offset;
-	NTLM_AV_PAIR* next = (NTLM_AV_PAIR*)((PBYTE)pAvPair + offset);
+	NTLM_AV_PAIR* next = WINPR_PACKED_ALIGN_CAST(NTLM_AV_PAIR*, ((PBYTE)pAvPair + offset));
 	if (!ntlm_av_pair_check(next, *pcbAvPair))
 		return nullptr;
 	return next;

--- a/winpr/libwinpr/sspi/sspi_winpr.c
+++ b/winpr/libwinpr/sspi/sspi_winpr.c
@@ -487,9 +487,9 @@ BOOL sspi_GetAuthIdentityUserDomainW(const void* identity, const WCHAR** pUser, 
 		const SEC_WINNT_AUTH_IDENTITY_EX2* id = (const SEC_WINNT_AUTH_IDENTITY_EX2*)identity;
 		UINT32 UserOffset = id->UserOffset;
 		UINT32 DomainOffset = id->DomainOffset;
-		*pUser = (const WCHAR*)&((const uint8_t*)identity)[UserOffset];
+		*pUser = WINPR_PACKED_ALIGN_CAST(const WCHAR*, &((const uint8_t*)identity)[UserOffset]);
 		*pUserLength = id->UserLength / 2;
-		*pDomain = (const WCHAR*)&((const uint8_t*)identity)[DomainOffset];
+		*pDomain = WINPR_PACKED_ALIGN_CAST(const WCHAR*, &((const uint8_t*)identity)[DomainOffset]);
 		*pDomainLength = id->DomainLength / 2;
 	}
 	else // SEC_WINNT_AUTH_IDENTITY
@@ -838,7 +838,8 @@ BOOL sspi_CopyAuthPackageListA(const SEC_WINNT_AUTH_IDENTITY_INFO* identity, cha
 		{
 			const SEC_WINNT_AUTH_IDENTITY_EX2* ad = (const SEC_WINNT_AUTH_IDENTITY_EX2*)pAuthData;
 			PackageListOffset = ad->PackageListOffset;
-			PackageListW = (const WCHAR*)&((const uint8_t*)pAuthData)[PackageListOffset];
+			PackageListW = WINPR_PACKED_ALIGN_CAST(const WCHAR*,
+			                                       &((const uint8_t*)pAuthData)[PackageListOffset]);
 			PackageListLength = ad->PackageListLength / 2;
 		}
 

--- a/winpr/libwinpr/thread/argv.c
+++ b/winpr/libwinpr/thread/argv.c
@@ -200,7 +200,7 @@ LPSTR* CommandLineToArgvA(LPCSTR lpCmdLine, int* pNumArgs)
 		return nullptr;
 	}
 
-	pArgs = (LPSTR*)buffer;
+	pArgs = WINPR_PACKED_ALIGN_CAST(LPSTR*, buffer);
 	pOutput = &buffer[maxNumArgs * (sizeof(char*))];
 	p = (const char*)lpCmdLine;
 

--- a/winpr/libwinpr/utils/ntlm.c
+++ b/winpr/libwinpr/utils/ntlm.c
@@ -170,7 +170,7 @@ BOOL NTOWFv2FromHashW(const BYTE* NtHashV1, LPCWSTR User, UINT32 UserLengthInByt
 
 	/* Concatenate(UpperCase(User), Domain) */
 	CopyMemory(buffer, User, UserLengthInBytes);
-	CharUpperBuffW((LPWSTR)buffer, UserLengthInBytes / 2);
+	CharUpperBuffW(WINPR_PACKED_ALIGN_CAST(LPWSTR, buffer), UserLengthInBytes / sizeof(WCHAR));
 
 	if (DomainLengthInBytes > 0)
 	{

--- a/winpr/libwinpr/utils/wlog/PacketMessage.c
+++ b/winpr/libwinpr/utils/wlog/PacketMessage.c
@@ -161,7 +161,7 @@ static UINT16 IPv4Checksum(const BYTE* ipv4, int length)
 
 	while (length > 1)
 	{
-		const UINT16 tmp16 = *((const UINT16*)ipv4);
+		const UINT16 tmp16 = *(WINPR_PACKED_ALIGN_CAST(const UINT16*, ipv4));
 		checksum += tmp16;
 		length -= 2;
 		ipv4 += 2;

--- a/winpr/libwinpr/winsock/winsock.c
+++ b/winpr/libwinpr/winsock/winsock.c
@@ -996,7 +996,7 @@ int WSAIoctl(SOCKET s, DWORD dwIoControlCode, WINPR_ATTR_UNUSED LPVOID lpvInBuff
 #else
 		ifreq_len = sizeof(*ifreq);
 #endif
-		ifreq = (struct ifreq*)&((BYTE*)ifreq)[ifreq_len];
+		ifreq = WINPR_PACKED_ALIGN_CAST(struct ifreq*, &((BYTE*)ifreq)[ifreq_len]);
 		offset += ifreq_len;
 		index++;
 	}


### PR DESCRIPTION
* Enable -Wcast-align and use this macro to silence locations already
      known.
* Add a header compiler check for support of unaligned access for known
      architectures
* Abort compilation on unknown/unsupported architectures
* Add macros to detect RISCV32/64