### PR TITLE
[winpr,align] more warnings on unsupported configurations

### DIFF
--- a/channels/rail/client/test/TestFuzzChannelRail.c
+++ b/channels/rail/client/test/TestFuzzChannelRail.c
@@ -36,7 +36,7 @@ static railPlugin* alloc(void)
 		goto fail;
 
 	rail->rdpcontext->settings = freerdp_settings_new(0);
-	if (rail->rdpcontext->settings)
+	if (!rail->rdpcontext->settings)
 		goto fail;
 	return rail;
 fail:
@@ -52,6 +52,11 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 		return 0;
 
 	int rc = -1;
+
+	wLog* root = WLog_GetRoot();
+	(void)WLog_SetLogLevel(root, WLOG_TRACE);
+	(void)WLog_SetLogAppenderType(root, WLOG_APPENDER_CALLBACK);
+
 	railPlugin* g_rail = alloc();
 	RailClientContext* context = (RailClientContext*)calloc(1, sizeof(RailClientContext));
 	wStream* s = Stream_New(nullptr, size);

--- a/libfreerdp/core/rdp.c
+++ b/libfreerdp/core/rdp.c
@@ -124,6 +124,7 @@ static const char* DATA_PDU_TYPE_STRINGS[80] = {
 #define rdp_check_monitor_layout_pdu_state(rdp, expected) \
 	rdp_check_monitor_layout_pdu_state_(rdp, expected, __FILE__, __func__, __LINE__)
 
+WINPR_ATTR_NODISCARD
 static BOOL rdp_check_monitor_layout_pdu_state_(const rdpRdp* rdp, BOOL expected, const char* file,
                                                 const char* fkt, size_t line)
 {
@@ -144,6 +145,7 @@ static BOOL rdp_check_monitor_layout_pdu_state_(const rdpRdp* rdp, BOOL expected
 
 #define rdp_set_monitor_layout_pdu_state(rdp, expected) \
 	rdp_set_monitor_layout_pdu_state_(rdp, expected, __FILE__, __func__, __LINE__)
+WINPR_ATTR_NODISCARD
 static BOOL rdp_set_monitor_layout_pdu_state_(rdpRdp* rdp, BOOL value, const char* file,
                                               const char* fkt, size_t line)
 {
@@ -170,9 +172,14 @@ const char* data_pdu_type_to_string(UINT8 type)
 	return DATA_PDU_TYPE_STRINGS[type];
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL rdp_read_flow_control_pdu(rdpRdp* rdp, wStream* s, UINT16* type, UINT16* channel_id);
+
+WINPR_ATTR_NODISCARD
 static BOOL rdp_write_share_control_header(rdpRdp* rdp, wStream* s, size_t length, UINT16 type,
                                            UINT16 channel_id);
+
+WINPR_ATTR_NODISCARD
 static BOOL rdp_write_share_data_header(rdpRdp* rdp, wStream* s, size_t length, BYTE type,
                                         UINT32 share_id);
 
@@ -390,6 +397,7 @@ BOOL rdp_write_share_data_header(rdpRdp* rdp, wStream* s, size_t length, BYTE ty
 	return TRUE;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL rdp_security_stream_init(rdpRdp* rdp, wStream* s, BOOL sec_header, UINT16* sec_flags)
 {
 	WINPR_ASSERT(rdp);
@@ -718,6 +726,7 @@ BOOL rdp_write_header(rdpRdp* rdp, wStream* s, size_t length, UINT16 channelId, 
 	return TRUE;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL rdp_security_stream_out(rdpRdp* rdp, wStream* s, size_t length, UINT16 sec_flags,
                                     UINT32* pad)
 {
@@ -798,6 +807,7 @@ static BOOL rdp_security_stream_out(rdpRdp* rdp, wStream* s, size_t length, UINT
 	return TRUE;
 }
 
+WINPR_ATTR_NODISCARD
 static UINT32 rdp_get_sec_bytes(rdpRdp* rdp, UINT16 sec_flags)
 {
 	UINT32 sec_bytes = 0;
@@ -1018,12 +1028,14 @@ fail:
 	return rc;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL rdp_recv_server_shutdown_denied_pdu(WINPR_ATTR_UNUSED rdpRdp* rdp,
                                                 WINPR_ATTR_UNUSED wStream* s)
 {
 	return TRUE;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL rdp_recv_server_set_keyboard_indicators_pdu(rdpRdp* rdp, wStream* s)
 {
 	WINPR_ASSERT(rdp);
@@ -1048,6 +1060,7 @@ static BOOL rdp_recv_server_set_keyboard_indicators_pdu(rdpRdp* rdp, wStream* s)
 	return IFCALLRESULT(TRUE, context->update->SetKeyboardIndicators, context, ledFlags);
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL rdp_recv_server_set_keyboard_ime_status_pdu(rdpRdp* rdp, wStream* s)
 {
 	if (!rdp || !rdp->input)
@@ -1070,6 +1083,7 @@ static BOOL rdp_recv_server_set_keyboard_ime_status_pdu(rdpRdp* rdp, wStream* s)
 	                    imeConvMode);
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL rdp_recv_set_error_info_data_pdu(rdpRdp* rdp, wStream* s)
 {
 	UINT32 errorInfo = 0;
@@ -1081,6 +1095,7 @@ static BOOL rdp_recv_set_error_info_data_pdu(rdpRdp* rdp, wStream* s)
 	return rdp_set_error_info(rdp, errorInfo);
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL rdp_recv_server_auto_reconnect_status_pdu(rdpRdp* rdp, wStream* s)
 {
 	UINT32 arcStatus = 0;
@@ -1093,6 +1108,7 @@ static BOOL rdp_recv_server_auto_reconnect_status_pdu(rdpRdp* rdp, wStream* s)
 	return TRUE;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL rdp_recv_server_status_info_pdu(rdpRdp* rdp, wStream* s)
 {
 	UINT32 statusCode = 0;
@@ -1128,6 +1144,7 @@ static void log_monitor_configuration(wLog* log, const MONITOR_DEF* monitors, si
 	WLog_Print(log, level, "[END] RemoteMonitors[%" PRIuz "]", count);
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL rdp_recv_monitor_layout_pdu(rdpRdp* rdp, wStream* s)
 {
 	BOOL ret = TRUE;
@@ -1680,7 +1697,7 @@ const char* pdu_type_to_str(UINT16 pduType, char* buffer, size_t length)
  * @param rdp RDP module
  * @param s stream
  */
-
+WINPR_ATTR_NODISCARD
 static state_run_t rdp_recv_tpkt_pdu(rdpRdp* rdp, wStream* s)
 {
 	state_run_t rc = STATE_RUN_SUCCESS;
@@ -1822,6 +1839,7 @@ out:
 	return rc;
 }
 
+WINPR_ATTR_NODISCARD
 static state_run_t rdp_recv_fastpath_pdu(rdpRdp* rdp, wStream* s)
 {
 	UINT16 length = 0;
@@ -1853,6 +1871,7 @@ static state_run_t rdp_recv_fastpath_pdu(rdpRdp* rdp, wStream* s)
 	return fastpath_recv_updates(rdp->fastpath, s);
 }
 
+WINPR_ATTR_NODISCARD
 static state_run_t rdp_recv_pdu(rdpRdp* rdp, wStream* s)
 {
 	const int rc = tpkt_verify_header(s);
@@ -1864,6 +1883,7 @@ static state_run_t rdp_recv_pdu(rdpRdp* rdp, wStream* s)
 		return STATE_RUN_FAILED;
 }
 
+WINPR_ATTR_NODISCARD
 static state_run_t rdp_handle_sc_flags(rdpRdp* rdp, wStream* s, UINT32 flag,
                                        CONNECTION_STATE nextState)
 {
@@ -1895,6 +1915,7 @@ static state_run_t rdp_handle_sc_flags(rdpRdp* rdp, wStream* s, UINT32 flag,
 	return status;
 }
 
+WINPR_ATTR_NODISCARD
 static state_run_t rdp_client_exchange_monitor_layout(rdpRdp* rdp, wStream* s)
 {
 	WINPR_ASSERT(rdp);
@@ -1926,6 +1947,7 @@ static state_run_t rdp_client_exchange_monitor_layout(rdpRdp* rdp, wStream* s)
 	return status;
 }
 
+WINPR_ATTR_NODISCARD
 static state_run_t rdp_recv_callback_int(WINPR_ATTR_UNUSED rdpTransport* transport, wStream* s,
                                          void* extra)
 {
@@ -2337,6 +2359,7 @@ BOOL freerdp_get_stats(const rdpRdp* rdp, UINT64* inBytes, UINT64* outBytes, UIN
 	return TRUE;
 }
 
+WINPR_ATTR_NODISCARD
 static bool rdp_new_common(rdpRdp* rdp)
 {
 	WINPR_ASSERT(rdp);
@@ -2798,6 +2821,7 @@ const char* rdp_security_flag_string(UINT32 securityFlags, char* buffer, size_t 
 	return buffer;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL rdp_reset_remote_settings(rdpRdp* rdp)
 {
 	UINT32 flags = FREERDP_SETTINGS_REMOTE_MODE;
@@ -2833,6 +2857,7 @@ BOOL rdp_reset_runtime_settings(rdpRdp* rdp)
 	return rdp_reset_remote_settings(rdp);
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL starts_with(const char* tok, const char* val)
 {
 	const size_t len = strlen(val);
@@ -2843,11 +2868,13 @@ static BOOL starts_with(const char* tok, const char* val)
 	return TRUE;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL option_equals(const char* what, const char* val)
 {
 	return _stricmp(what, val) == 0;
 }
 
+WINPR_ATTR_NODISCARD
 static BOOL parse_on_off_option(const char* value)
 {
 	WINPR_ASSERT(value);
@@ -2873,7 +2900,9 @@ static BOOL parse_on_off_option(const char* value)
 
 #define STR(x) #x
 
-static BOOL option_is_runtime_checks(WINPR_ATTR_UNUSED wLog* log, const char* tok)
+WINPR_ATTR_NODISCARD
+static BOOL option_is_runtime_checks(WINPR_ATTR_UNUSED wLog* log, WINPR_ATTR_UNUSED DWORD level,
+                                     const char* tok)
 {
 	const char* experimental[] = { STR(WITH_VERBOSE_WINPR_ASSERT) };
 	for (size_t x = 0; x < ARRAYSIZE(experimental); x++)
@@ -2887,7 +2916,9 @@ static BOOL option_is_runtime_checks(WINPR_ATTR_UNUSED wLog* log, const char* to
 	return FALSE;
 }
 
-static BOOL option_is_experimental(WINPR_ATTR_UNUSED wLog* log, const char* tok)
+WINPR_ATTR_NODISCARD
+static BOOL option_is_experimental(WINPR_ATTR_UNUSED wLog* log, WINPR_ATTR_UNUSED DWORD level,
+                                   const char* tok)
 {
 	const char* experimental[] = { STR(WITH_DSP_EXPERIMENTAL), STR(WITH_FFMPEG_HWACCEL),
 		                           STR(WITH_GFX_AV1),          STR(WITH_MEDIACODEC),
@@ -2905,7 +2936,8 @@ static BOOL option_is_experimental(WINPR_ATTR_UNUSED wLog* log, const char* tok)
 	return FALSE;
 }
 
-static BOOL option_is_debug(wLog* log, const char* tok)
+WINPR_ATTR_NODISCARD
+static BOOL option_is_debug(wLog* log, WINPR_ATTR_UNUSED DWORD level, const char* tok)
 {
 	WINPR_ASSERT(log);
 	const char* debug[] = { STR(WITH_DEBUG_ALL),
@@ -2952,17 +2984,16 @@ static BOOL option_is_debug(wLog* log, const char* tok)
 
 	if (starts_with(tok, "WITH_DEBUG"))
 	{
-		WLog_Print(log, WLOG_WARN, "[BUG] Unmapped Debug-Build option '%s'.", tok);
+		WLog_Print(log, level, "[BUG] Unmapped Debug-Build option '%s'.", tok);
 		return parse_on_off_option(tok);
 	}
 
 	return FALSE;
 }
 
-static void log_build_warn(rdpRdp* rdp, const char* what, const char* msg,
-                           BOOL (*cmp)(wLog* log, const char* tok))
+static void log_build_warn(wLog* log, DWORD level, const char* what, const char* msg,
+                           BOOL (*cmp)(wLog* log, DWORD level, const char* tok))
 {
-	WINPR_ASSERT(rdp);
 	WINPR_PRAGMA_DIAG_PUSH
 	WINPR_PRAGMA_DIAG_IGNORED_OVERLENGTH_STRINGS
 
@@ -2977,7 +3008,7 @@ static void log_build_warn(rdpRdp* rdp, const char* what, const char* msg,
 		char* tok = strtok_s(config, " ", &saveptr);
 		while (tok)
 		{
-			if (cmp(rdp->log, tok))
+			if (cmp(log, level, tok))
 				winpr_str_append(tok, list, len, " ");
 
 			tok = strtok_s(nullptr, " ", &saveptr);
@@ -2989,33 +3020,32 @@ static void log_build_warn(rdpRdp* rdp, const char* what, const char* msg,
 	{
 		if (strlen(list) > 0)
 		{
-			WLog_Print(rdp->log, WLOG_WARN, "*************************************************");
-			WLog_Print(rdp->log, WLOG_WARN, "This build is using [%s] build options:", what);
+			WLog_Print(log, level, "*************************************************");
+			WLog_Print(log, level, "This build is using [%s] build options:", what);
 
 			char* saveptr = nullptr;
 			char* tok = strtok_s(list, " ", &saveptr);
 			while (tok)
 			{
-				WLog_Print(rdp->log, WLOG_WARN, "* '%s'", tok);
+				WLog_Print(log, level, "* '%s'", tok);
 				tok = strtok_s(nullptr, " ", &saveptr);
 			}
-			WLog_Print(rdp->log, WLOG_WARN, "*");
-			WLog_Print(rdp->log, WLOG_WARN, "[%s] build options %s", what, msg);
-			WLog_Print(rdp->log, WLOG_WARN, "*************************************************");
+			WLog_Print(log, level, "*");
+			WLog_Print(log, level, "[%s] build options %s", what, msg);
+			WLog_Print(log, level, "*************************************************");
 		}
 	}
 	free(list);
 }
 
-#define print_first_line(log, firstLine, what) \
-	print_first_line_int((log), (firstLine), (what), __FILE__, __func__, __LINE__)
-static void print_first_line_int(wLog* log, log_line_t* firstLine, const char* what,
+#define print_first_line(log, level, firstLine, what) \
+	print_first_line_int((log), (level), (firstLine), (what), __FILE__, __func__, __LINE__)
+static void print_first_line_int(wLog* log, DWORD level, log_line_t* firstLine, const char* what,
                                  const char* file, const char* fkt, size_t line)
 {
 	WINPR_ASSERT(firstLine);
 	if (!firstLine->fkt)
 	{
-		const DWORD level = WLOG_WARN;
 		if (WLog_IsLevelActive(log, level))
 		{
 			WLog_PrintTextMessage(log, level, line, file, fkt,
@@ -3042,8 +3072,8 @@ static void print_last_line(wLog* log, const log_line_t* firstLine)
 	}
 }
 
-static void log_build_warn_cipher(rdpRdp* rdp, log_line_t* firstLine, WINPR_CIPHER_TYPE md,
-                                  const char* what, BOOL allowFIPS)
+static void log_build_warn_cipher(wLog* log, DWORD level, log_line_t* firstLine,
+                                  WINPR_CIPHER_TYPE md, const char* what, BOOL allowFIPS)
 {
 	BOOL haveCipher = FALSE;
 
@@ -3077,12 +3107,12 @@ static void log_build_warn_cipher(rdpRdp* rdp, log_line_t* firstLine, WINPR_CIPH
 
 	if (!haveCipher)
 	{
-		print_first_line(rdp->log, firstLine, "Cipher");
-		WLog_Print(rdp->log, WLOG_WARN, "* %s: %s", winpr_cipher_type_to_string(md), what);
+		print_first_line(log, level, firstLine, "Cipher");
+		WLog_Print(log, level, "* %s: %s", winpr_cipher_type_to_string(md), what);
 	}
 }
 
-static void log_build_warn_hmac(rdpRdp* rdp, log_line_t* firstLine, WINPR_MD_TYPE md,
+static void log_build_warn_hmac(wLog* log, DWORD level, log_line_t* firstLine, WINPR_MD_TYPE md,
                                 const char* what)
 {
 	BOOL haveHmacX = FALSE;
@@ -3099,12 +3129,12 @@ static void log_build_warn_hmac(rdpRdp* rdp, log_line_t* firstLine, WINPR_MD_TYP
 
 	if (!haveHmacX)
 	{
-		print_first_line(rdp->log, firstLine, "HMAC");
-		WLog_Print(rdp->log, WLOG_WARN, " * %s: %s", winpr_md_type_to_string(md), what);
+		print_first_line(log, level, firstLine, "HMAC");
+		WLog_Print(log, level, " * %s: %s", winpr_md_type_to_string(md), what);
 	}
 }
 
-static void log_build_warn_hash(rdpRdp* rdp, log_line_t* firstLine, WINPR_MD_TYPE md,
+static void log_build_warn_hash(wLog* log, DWORD level, log_line_t* firstLine, WINPR_MD_TYPE md,
                                 const char* what, BOOL allowFIPS)
 {
 	BOOL haveDigestX = FALSE;
@@ -3120,20 +3150,18 @@ static void log_build_warn_hash(rdpRdp* rdp, log_line_t* firstLine, WINPR_MD_TYP
 
 	if (!haveDigestX)
 	{
-		print_first_line(rdp->log, firstLine, "Digest");
-		WLog_Print(rdp->log, WLOG_WARN, " * %s: %s", winpr_md_type_to_string(md), what);
+		print_first_line(log, level, firstLine, "Digest");
+		WLog_Print(log, level, " * %s: %s", winpr_md_type_to_string(md), what);
 	}
 }
 
-static void log_build_warn_ssl(rdpRdp* rdp)
+static void log_build_warn_ssl(wLog* log, DWORD level)
 {
-	WINPR_ASSERT(rdp);
-
 	const BOOL fips = winpr_FIPSMode();
 
 	if (fips)
 	{
-		WLog_Print(rdp->log, WLOG_INFO,
+		WLog_Print(log, WLOG_INFO,
 		           "FIPS mode active: non-approved algorithms are unavailable "
 		           "as expected. NTLM, autoreconnect cookies, assistance files "
 		           "with encrypted passwords and RDP security will not work.");
@@ -3142,73 +3170,81 @@ static void log_build_warn_ssl(rdpRdp* rdp)
 	log_line_t firstHashLine = WINPR_C_ARRAY_INIT;
 	if (!fips)
 	{
-		log_build_warn_hash(rdp, &firstHashLine, WINPR_MD_MD4, "NTLM support not available", FALSE);
-		log_build_warn_hash(rdp, &firstHashLine, WINPR_MD_MD5,
+		log_build_warn_hash(log, level, &firstHashLine, WINPR_MD_MD4, "NTLM support not available",
+		                    FALSE);
+		log_build_warn_hash(log, level, &firstHashLine, WINPR_MD_MD5,
 		                    "NTLM, assistance files with encrypted passwords "
 		                    " and autoreconnect cookies will not work",
 		                    FALSE);
 	}
-	log_build_warn_hash(rdp, &firstHashLine, WINPR_MD_MD5,
+	log_build_warn_hash(log, level, &firstHashLine, WINPR_MD_MD5,
 	                    "RDP licensing and RDP security will not work", TRUE);
-	log_build_warn_hash(rdp, &firstHashLine, WINPR_MD_SHA1,
+	log_build_warn_hash(log, level, &firstHashLine, WINPR_MD_SHA1,
 	                    "assistance files with encrypted passwords, Kerberos, Smartcard Logon, RDP "
 	                    "security support not available",
 	                    FALSE);
-	log_build_warn_hash(rdp, &firstHashLine, WINPR_MD_SHA256,
+	log_build_warn_hash(log, level, &firstHashLine, WINPR_MD_SHA256,
 	                    "file clipboard, AAD gateway, NLA security and certificates might not work",
 	                    FALSE);
-	print_last_line(rdp->log, &firstHashLine);
+	print_last_line(log, &firstHashLine);
 
 	if (!fips)
 	{
 		log_line_t firstHmacLine = WINPR_C_ARRAY_INIT;
-		log_build_warn_hmac(rdp, &firstHmacLine, WINPR_MD_MD5,
+		log_build_warn_hmac(log, level, &firstHmacLine, WINPR_MD_MD5,
 		                    "Autoreconnect cookie not supported");
-		log_build_warn_hmac(rdp, &firstHmacLine, WINPR_MD_SHA1, "RDP security not supported");
-		print_last_line(rdp->log, &firstHmacLine);
+		log_build_warn_hmac(log, level, &firstHmacLine, WINPR_MD_SHA1,
+		                    "RDP security not supported");
+		print_last_line(log, &firstHmacLine);
 	}
 
 	log_line_t firstCipherLine = WINPR_C_ARRAY_INIT;
 	if (!fips)
 	{
-		log_build_warn_cipher(rdp, &firstCipherLine, WINPR_CIPHER_ARC4_128,
+		log_build_warn_cipher(log, level, &firstCipherLine, WINPR_CIPHER_ARC4_128,
 		                      "assistance files with encrypted passwords, NTLM "
 		                      "and autoreconnect cookies will not work",
 		                      FALSE);
 	}
-	log_build_warn_cipher(rdp, &firstCipherLine, WINPR_CIPHER_ARC4_128,
+	log_build_warn_cipher(log, level, &firstCipherLine, WINPR_CIPHER_ARC4_128,
 	                      "RDP licensing and RDP security will not work", TRUE);
 	if (!fips)
-		log_build_warn_cipher(rdp, &firstCipherLine, WINPR_CIPHER_DES_EDE3_CBC,
+		log_build_warn_cipher(log, level, &firstCipherLine, WINPR_CIPHER_DES_EDE3_CBC,
 		                      "RDP security will not work", TRUE);
 	log_build_warn_cipher(
-	    rdp, &firstCipherLine, WINPR_CIPHER_AES_128_CBC,
+	    log, level, &firstCipherLine, WINPR_CIPHER_AES_128_CBC,
 	    "assistance file encrypted LHTicket will not work and ARM gateway might not", FALSE);
-	log_build_warn_cipher(rdp, &firstCipherLine, WINPR_CIPHER_AES_192_CBC,
+	log_build_warn_cipher(log, level, &firstCipherLine, WINPR_CIPHER_AES_192_CBC,
 	                      "ARM gateway might not work", FALSE);
-	log_build_warn_cipher(rdp, &firstCipherLine, WINPR_CIPHER_AES_256_CBC,
+	log_build_warn_cipher(log, level, &firstCipherLine, WINPR_CIPHER_AES_256_CBC,
 	                      "ARM gateway might not work", FALSE);
-	print_last_line(rdp->log, &firstCipherLine);
+	print_last_line(log, &firstCipherLine);
 }
 
-void rdp_log_build_warnings(rdpRdp* rdp)
+static void rdp_log_build_warnings_wlog(wLog* log, DWORD level)
 {
 	static unsigned count = 0;
 
-	WINPR_ASSERT(rdp);
 	/* Since this function is called in context creation routines stop logging
 	 * this issue repeatedly. This is required for proxy, which would otherwise
 	 * spam the log with these. */
 	if (count > 0)
 		return;
 	count++;
-	log_build_warn(rdp, "experimental", "might crash the application", option_is_experimental);
-	log_build_warn(rdp, "debug", "might leak sensitive information (credentials, ...)",
+	log_build_warn(log, level, "experimental", "might crash the application",
+	               option_is_experimental);
+	log_build_warn(log, level, "debug", "might leak sensitive information (credentials, ...)",
 	               option_is_debug);
-	log_build_warn(rdp, "runtime-check", "might slow down the application",
+	log_build_warn(log, level, "runtime-check", "might slow down the application",
 	               option_is_runtime_checks);
-	log_build_warn_ssl(rdp);
-	winpr_log_build_warn(rdp->log, WLOG_WARN);
+	log_build_warn_ssl(log, level);
+	winpr_log_build_warn(log, level);
+}
+
+void rdp_log_build_warnings(rdpRdp* rdp)
+{
+	WINPR_ASSERT(rdp);
+	rdp_log_build_warnings_wlog(rdp->log, WLOG_WARN);
 }
 
 size_t rdp_get_event_handles(rdpRdp* rdp, HANDLE* handles, uint32_t count)

--- a/winpr/include/winpr/cast.h
+++ b/winpr/include/winpr/cast.h
@@ -31,7 +31,7 @@
 #ifdef __cplusplus
 #define WINPR_CXX_COMPAT_CAST(t, val) static_cast<t>(val)
 #else
-#define WINPR_CXX_COMPAT_CAST(t, val) (t)(val)
+#define WINPR_CXX_COMPAT_CAST(t, val) ((t)(val))
 #endif
 
 /**! @brief Checks alignment requirements.
@@ -41,7 +41,8 @@
 #if defined(DISABLE_SUPPORTED_ARCH_CHECKS)
 #elif defined(_M_ARM) || defined(_M_ARM64)
 #if !defined(__ARM_FEATURE_UNALIGNED)
-#warning "-munaligned-access is required on arm"
+#warning \
+    "-munaligned-access is required on arm. Use -DDISABLE_SUPPORTED_ARCH_CHECKS=ON to ignore, but there will be dragons ahead!"
 #else
 #define WINPR_ARCH_SUPPORTED 1
 #endif
@@ -49,11 +50,14 @@
 #define WINPR_ARCH_SUPPORTED 1
 #elif defined(_M_RISCV32) || defined(_M_RISCV64)
 #if !defined(__riscv_misaligned_fast)
-#error "RISCV must support __riscv_misaligned_fast"
+#warning \
+    "RISCV must support __riscv_misaligned_fast. Use -DDISABLE_SUPPORTED_ARCH_CHECKS=ON to ignore, but there will be dragons ahead!"
 #else
 #define WINPR_ARCH_SUPPORTED 1
 #endif
-#else
+#endif
+
+#if !defined(WINPR_ARCH_SUPPORTED)
 #warning "unaligned pointer access not verified on platform, SIGBUS may happen!"
 #endif
 
@@ -81,12 +85,12 @@ WINPR_DO_PRAGMA(clang diagnostic warning "-Wcast-align")
 #elif defined(__GNUC__)
 WINPR_DO_PRAGMA(GCC diagnostic warning "-Wcast-align")
 #endif
+#else
 #if defined(__clang__)
 WINPR_DO_PRAGMA(clang diagnostic error "-Wcast-align")
 #elif defined(__GNUC__)
 WINPR_DO_PRAGMA(GCC diagnostic error "-Wcast-align")
 #endif
-#else
 #endif
 #define WINPR_PACKED_ALIGN_CAST(t, val) WINPR_CXX_COMPAT_CAST(t, val)
 #endif

--- a/winpr/libwinpr/clipboard/test/TestFuzzWinPRClipboard.c
+++ b/winpr/libwinpr/clipboard/test/TestFuzzWinPRClipboard.c
@@ -38,7 +38,8 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 
 	if (!loggingInitialized)
 	{
-		(void)WLog_SetLogLevel(WLog_GetRoot(), WLOG_OFF);
+		(void)WLog_SetLogLevel(WLog_GetRoot(), WLOG_TRACE);
+		(void)WLog_SetLogAppenderType(WLog_GetRoot(), WLOG_APPENDER_CALLBACK);
 		loggingInitialized = TRUE;
 	}
 

--- a/winpr/libwinpr/sspi/test/TestFuzzNTLMMessage.c
+++ b/winpr/libwinpr/sspi/test/TestFuzzNTLMMessage.c
@@ -332,6 +332,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 	if (!loggingInitialized)
 	{
 		(void)WLog_SetLogLevel(WLog_GetRoot(), WLOG_TRACE);
+		(void)WLog_SetLogAppenderType(WLog_GetRoot(), WLOG_APPENDER_CALLBACK);
 		loggingInitialized = TRUE;
 	}
 

--- a/winpr/libwinpr/utils/debug.c
+++ b/winpr/libwinpr/utils/debug.c
@@ -177,6 +177,9 @@ void winpr_log_backtrace(const char* tag, DWORD level, DWORD size)
 
 void winpr_log_backtrace_ex(wLog* log, DWORD level, WINPR_ATTR_UNUSED DWORD size)
 {
+	if (!WLog_IsLevelActive(log, level))
+		return;
+
 	size_t used = 0;
 	char** msg = nullptr;
 	void* stack = winpr_backtrace(20);

--- a/winpr/libwinpr/utils/debug.c
+++ b/winpr/libwinpr/utils/debug.c
@@ -268,16 +268,16 @@ static BOOL option_is_debug(wLog* log, DWORD level, const char* tok)
 }
 
 static void log_build_warn(wLog* log, DWORD level, const char* what, const char* msg,
-                           BOOL (*cmp)(wLog* log, DWORD level, const char* tok))
+                           BOOL (*cmp)(wLog* log, DWORD level, const char* tok), const char* input,
+                           size_t ilen)
 {
 	WINPR_ASSERT(log);
-	WINPR_PRAGMA_DIAG_PUSH
-	WINPR_PRAGMA_DIAG_IGNORED_OVERLENGTH_STRINGS
 
-	size_t len = sizeof(WINPR_BUILD_CONFIG);
-	char* list = calloc(len, sizeof(char));
-	char* config = _strdup(WINPR_BUILD_CONFIG);
-	WINPR_PRAGMA_DIAG_POP
+	if (!input || (ilen == 0))
+		return;
+
+	char* list = calloc(ilen, sizeof(char));
+	char* config = _strdup(input);
 
 	if (config && list)
 	{
@@ -285,8 +285,8 @@ static void log_build_warn(wLog* log, DWORD level, const char* what, const char*
 		char* tok = strtok_s(config, " ", &saveptr);
 		while (tok)
 		{
-			if (cmp(log, level, tok))
-				winpr_str_append(tok, list, len, " ");
+			if (!cmp || cmp(log, level, tok))
+				winpr_str_append(tok, list, ilen, " ");
 
 			tok = strtok_s(nullptr, " ", &saveptr);
 		}
@@ -317,9 +317,30 @@ static void log_build_warn(wLog* log, DWORD level, const char* what, const char*
 
 void winpr_log_build_warn(wLog* log, DWORD level)
 {
+#if !defined(WINPR_ARCH_SUPPORTED) || (WINPR_ARCH_SUPPORTED == 0) || \
+    defined(DISABLE_SUPPORTED_ARCH_CHECKS)
+#define STR(x) #x
+#endif
+
+	const char configurations[] = {
+#if !defined(WINPR_ARCH_SUPPORTED) || (WINPR_ARCH_SUPPORTED == 0)
+		STR(WINPR_ARCH_SUPPORTED) "==0 "
+#endif
+#if defined(DISABLE_SUPPORTED_ARCH_CHECKS)
+		STR(DISABLE_SUPPORTED_ARCH_CHECKS) " "
+#endif
+		                                   ""
+	};
 	WINPR_ASSERT(log);
+	log_build_warn(log, level, "experimental",
+	               "might crash, overwrite data or steal your kitten, you have been warned!",
+	               nullptr, configurations, sizeof(configurations));
+
+	WINPR_PRAGMA_DIAG_PUSH
+	WINPR_PRAGMA_DIAG_IGNORED_OVERLENGTH_STRINGS
 	log_build_warn(log, level, "debug",
 	               "might leak sensitive information (credentials, ...), slow down runtime, "
 	               "increase memory usage",
-	               option_is_debug);
+	               option_is_debug, WINPR_BUILD_CONFIG, sizeof(WINPR_BUILD_CONFIG));
+	WINPR_PRAGMA_DIAG_POP
 }

--- a/winpr/libwinpr/utils/stream.c
+++ b/winpr/libwinpr/utils/stream.c
@@ -447,15 +447,18 @@ BOOL Stream_CheckAndLogRequiredLengthWLogExVa(wLog* log, DWORD level, wStream* s
 
 	if (actual < nmemb)
 	{
-		char prefix[1024] = WINPR_C_ARRAY_INIT;
+		if (WLog_IsLevelActive(log, level))
+		{
+			char prefix[1024] = WINPR_C_ARRAY_INIT;
 
-		(void)vsnprintf(prefix, sizeof(prefix), fmt, args);
+			(void)vsnprintf(prefix, sizeof(prefix), fmt, args);
 
-		WLog_Print(log, level,
-		           "[%s] invalid length, got %" PRIuz ", require at least %" PRIuz
-		           " [element size=%" PRIuz "]",
-		           prefix, actual, nmemb, size);
-		winpr_log_backtrace_ex(log, level, 20);
+			WLog_Print(log, level,
+			           "[%s] invalid length, got %" PRIuz ", require at least %" PRIuz
+			           " [element size=%" PRIuz "]",
+			           prefix, actual, nmemb, size);
+			winpr_log_backtrace_ex(log, level, 20);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/winpr/libwinpr/utils/test/TestFuzzCredSSP_Asn1.c
+++ b/winpr/libwinpr/utils/test/TestFuzzCredSSP_Asn1.c
@@ -107,6 +107,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 	if (!loggingInitialized)
 	{
 		(void)WLog_SetLogLevel(WLog_GetRoot(), WLOG_TRACE);
+		(void)WLog_SetLogAppenderType(WLog_GetRoot(), WLOG_APPENDER_CALLBACK);
 		loggingInitialized = TRUE;
 	}
 


### PR DESCRIPTION
* Add a runtime warning for binaries build without unaligned memory access
* Add a pointer to the CMake option to skip alignment support checks to default compiler warnings/errors