### PR TITLE
[client,sdl] handle Windows E0 36 as right shift

### DIFF
--- a/client/SDL/SDL3/sdl_input.cpp
+++ b/client/SDL/SDL3/sdl_input.cpp
@@ -550,7 +550,14 @@ bool sdlInput::extract(const std::string& token, uint32_t& key, uint32_t& value)
 
 bool sdlInput::handleEvent(const SDL_KeyboardEvent& ev)
 {
-	const UINT32 rdp_scancode = scancode_to_rdp(ev.scancode);
+	UINT32 rdp_scancode = scancode_to_rdp(ev.scancode);
+#if defined(_WIN32)
+	/* CJK IMEs on Windows may set the extended bit for Right Shift, producing
+	 * the invalid scan code E0 36. SDL maps that event to SDL_SCANCODE_UNKNOWN,
+	 * so normalize it in the same way as the native Windows client. */
+	if ((rdp_scancode == RDP_SCANCODE_UNKNOWN) && (ev.raw == 0xE036))
+		rdp_scancode = RDP_SCANCODE_RSHIFT;
+#endif
 	const SDL_Keymod mods = SDL_GetModState();
 
 	if (_hotkeysEnabled && (mods & _hotkeyModmask) == _hotkeyModmask)


### PR DESCRIPTION
## Problem

On Windows with a CJK IME, Right Shift can be delivered with the extended-key bit set, producing the platform scancode `E0 36`.

SDL [preserves](https://github.com/libsdl-org/SDL/blob/main/src/video/windows/SDL_windowsevents.c) this value (doesn't convert it to a regular right-shift), but its Windows scancode table maps the extended-key bit set version (`E0 36`) to `SDL_SCANCODE_UNKNOWN` [here](https://github.com/libsdl-org/SDL/blob/main/src/events/scancodes_windows.h)

Arguably maybe this should be changed in SDL itself, but I mention it here for two reasons:
1. Other projects have handled it on their side: https://github.com/glfw/glfw/issues/2050
2. Other people have mentioned it on this repo: #11712 (note: unclear if this user was on a CJK IME and freed up right-shift using `sdl-freerdp.json` like I did, or if they just didn't realize right-shift was reserved)

Given this, I leave it up to you if you want to merge this, or just have this PR help anybody else who hits this issue find the answer

## Why `E0 36` should become `36`

Right-shift is not differentiated from shift in general in either:
- Windows (docs explicitly states that Right Shift is not an extended key [here](https://learn.microsoft.com/en-us/windows/win32/inputdev/about-keyboard-input#extended-key-flag))
- RDP spec (defines the extended-key flag for keys such as Right Alt, but not Right Shift. See [here](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/7acaec9f-c8a6-4ee9-87d6-d9b89cf56489))

## Implementation

I simply normalize the event to `RDP_SCANCODE_RSHIFT` when all of the following hold:

- the client is running on Windows;
- SDL mapped the event to `SDL_SCANCODE_UNKNOWN`
- `SDL_KeyboardEvent.raw` is `E0 36`;

## Testing

- `git diff --check` passes.
- The SDL3 client sources, including `sdl_input.cpp`, compile
  successfully with MSVC.