### PR TITLE
[channels,rdpemsc] consume capability set data in read_cap_set

### DIFF
--- a/channels/rdpemsc/server/mouse_cursor_main.c
+++ b/channels/rdpemsc/server/mouse_cursor_main.c
@@ -171,6 +171,11 @@ static BOOL read_cap_set(wStream* s, wArrayList* capsSets)
 	}
 	WINPR_ASSERT(capsSet);
 
+	/* Consume the capability set data. The parsed versions carry no body fields, but the
+	 * length is client controlled: without this the trailing bytes are left in the stream and
+	 * the enclosing loop reinterprets them as further capability sets. */
+	Stream_Seek(s, capsDataSize);
+
 	capsSet->signature = signature;
 	capsSet->version = version;
 	capsSet->size = size;


### PR DESCRIPTION
**Unconsumed capability set data in read_cap_set**

The caps-advertise reader in the mouse cursor server channel validates the capability set data length (`capsDataSize = size - 12`) but only the unknown-version `default` branch skips past it. The parsed `RDP_MOUSE_CURSOR_CAPVERSION_1` branch allocates its capset and falls through to the append without advancing the stream, so a client that pads a version-1 set (`size > 12`) leaves the trailing bytes behind. `mouse_cursor_server_recv_cs_caps_advertise` loops while data remains, so those client-controlled bytes are then parsed as further capability sets and end up in the list handed to the `CapsAdvertise` callback.

Fix consumes `capsDataSize` after the switch for the parsed-version path as well, matching the `default` branch. The bytes were already length-checked a few lines above, so the seek stays within the received PDU and well-formed advertises are unaffected. It should also make the reader more robust if additional versions with a real body are added later.