### PR TITLE
[client,common] fix POSIX command-line status options

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1968,8 +1968,8 @@ int freerdp_client_settings_command_line_status_print_ex(rdpSettings* settings, 
 	}
 	else if (status == COMMAND_LINE_STATUS_PRINT)
 	{
-		const DWORD flags =
-		    COMMAND_LINE_SEPARATOR_COLON | COMMAND_LINE_SIGIL_PLUS_MINUS | COMMAND_LINE_SIGIL_SLASH;
+		DWORD flags = 0;
+		freerdp_client_detect_command_line(argc, argv, &flags);
 
 		size_t customcount = 0;
 		{

--- a/client/common/test/CMakeLists.txt
+++ b/client/common/test/CMakeLists.txt
@@ -5,7 +5,7 @@ set(${MODULE_PREFIX}_DRIVER ${MODULE_NAME}.c)
 
 disable_warnings_for_directory(${CMAKE_CURRENT_BINARY_DIR})
 
-set(${MODULE_PREFIX}_TESTS TestClientRdpFile.c TestClientChannels.c TestClientCmdLine.c)
+set(${MODULE_PREFIX}_TESTS TestClientRdpFile.c TestClientChannels.c TestClientCmdLine.c TestClientCmdLineStatus.c)
 
 set(FUZZERS TestFuzzClientRdpFile.c)
 

--- a/client/common/test/TestClientCmdLineStatus.c
+++ b/client/common/test/TestClientCmdLineStatus.c
@@ -1,0 +1,71 @@
+#include <freerdp/client.h>
+#include <freerdp/client/cmdline.h>
+#include <freerdp/settings.h>
+#include <winpr/cmdline.h>
+#include <winpr/strlst.h>
+
+int TestClientCmdLineStatus(int argc, char* argv[])
+{
+	const struct
+	{
+		const char* args[6];
+		int expected_status;
+		BOOL list_monitors;
+	} tests[] = {
+		{ { "testfreerdp", "/list:kbd", nullptr }, 0, FALSE },
+		{ { "testfreerdp", "--list", "kbd", nullptr }, 0, FALSE },
+		{ { "testfreerdp", "-list", "kbd", nullptr }, 0, FALSE },
+		{ { "testfreerdp", "/list:monitor", nullptr }, 0, TRUE },
+		{ { "testfreerdp", "--list", "monitor", nullptr }, 0, TRUE },
+		{ { "testfreerdp", "-list", "monitor", nullptr }, 0, TRUE },
+		{ { "testfreerdp", "/log-level:ERROR", "/list:monitor", nullptr }, 0, TRUE },
+		{ { "testfreerdp", "--log-level", "ERROR", "--list", "monitor", nullptr }, 0, TRUE },
+		{ { "testfreerdp", "/list:invalid", nullptr }, COMMAND_LINE_ERROR, FALSE },
+		{ { "testfreerdp", "--list", "invalid", nullptr }, COMMAND_LINE_ERROR, FALSE },
+	};
+	int rc = 0;
+
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+
+	for (size_t i = 0; i < ARRAYSIZE(tests); i++)
+	{
+		rdpSettings* settings = freerdp_settings_new(0);
+		char** args = string_list_copy(tests[i].args);
+		if (!settings || !args)
+		{
+			freerdp_settings_free(settings);
+			string_list_free(args);
+			return -1;
+		}
+
+		const int count = string_list_length((const char* const*)args);
+		int status = freerdp_client_settings_parse_command_line(settings, count, args, FALSE);
+		if (status != COMMAND_LINE_STATUS_PRINT)
+		{
+			fprintf(stderr, "Test %zu: expected print status, got %d\n", i, status);
+			rc = -1;
+		}
+		else
+		{
+			status =
+			    freerdp_client_settings_command_line_status_print(settings, status, count, args);
+			if (status != tests[i].expected_status)
+			{
+				fprintf(stderr, "Test %zu: expected status %d, got %d\n", i,
+				        tests[i].expected_status, status);
+				rc = -1;
+			}
+			if (freerdp_settings_get_bool(settings, FreeRDP_ListMonitors) != tests[i].list_monitors)
+			{
+				fprintf(stderr, "Test %zu: unexpected ListMonitors setting\n", i);
+				rc = -1;
+			}
+		}
+
+		freerdp_settings_free(settings);
+		string_list_free(args);
+	}
+
+	return rc;
+}


### PR DESCRIPTION
`xfreerdp --list kbd` is accepted by the initial parser, but the status-print handler parses it again with hard-coded Windows syntax and rejects it. Use the existing syntax detection there too.

The new test covers `/list:...`, `--list ...` and `-list ...`, preceding options, and invalid list values. It also checks that listing monitors sets `FreeRDP_ListMonitors`.

Fixes #11594.

Tested on Linux aarch64:
- The regression test fails before the fix; all four `TestClient` tests pass after it.
- All three keyboard-list commands now exit with 0 and produce identical output. Previously, `--list kbd` exited with 23.
- Debug build of `TestClient` and `xfreerdp`; C/CMake formatting and whitespace checks pass. Optional FFmpeg/VAAPI, Kerberos, CUPS, FUSE and USB redirection were disabled in this build.
