### PR TITLE
[client,x11] preserve requested size for ordinary windows

### DIFF
--- a/client/X11/CMakeLists.txt
+++ b/client/X11/CMakeLists.txt
@@ -192,6 +192,10 @@ target_link_libraries(${PROJECT_NAME} PRIVATE ${PRIV_LIBS})
 if(WITH_CLIENT_INTERFACE)
   installwithrpath(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
 endif()
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
+
 add_subdirectory(cli)
 add_subdirectory(man)
 

--- a/client/X11/test/CMakeLists.txt
+++ b/client/X11/test/CMakeLists.txt
@@ -1,0 +1,8 @@
+find_program(XVFB_RUN_EXECUTABLE xvfb-run)
+if(XVFB_RUN_EXECUTABLE AND WITH_XRANDR AND X11_Xrandr_FOUND)
+  add_executable(TestX11Monitor TestX11Monitor.c)
+  target_link_libraries(TestX11Monitor PRIVATE xfreerdp-client ${X11_Xrandr_LIB})
+  add_test(NAME TestX11Monitor COMMAND ${XVFB_RUN_EXECUTABLE} -a -s "-screen 0 3120x1920x24 -nolisten tcp"
+                                       $<TARGET_FILE:TestX11Monitor>
+  )
+endif()

--- a/client/X11/test/TestX11Monitor.c
+++ b/client/X11/test/TestX11Monitor.c
@@ -1,0 +1,95 @@
+#include <freerdp/config.h>
+#include <X11/extensions/Xrandr.h>
+#include "../xfreerdp.h"
+#include "../xf_monitor.h"
+
+static BOOL check_size(Display* display, const char* name, BOOL fullscreen, BOOL workarea,
+                       UINT32 percent, UINT32 width, UINT32 height)
+{
+	MONITOR_INFO monitors[16] = WINPR_C_ARRAY_INIT;
+	xfContext xfc = WINPR_C_ARRAY_INIT;
+	rdpSettings* settings = freerdp_settings_new(0);
+	if (!settings)
+		return FALSE;
+
+	xfc.display = display;
+	xfc.screen = DefaultScreenOfDisplay(display);
+	xfc.log = WLog_Get("com.freerdp.client.x11.test");
+	xfc.vscreen.monitors = monitors;
+	xfc.common.context.settings = settings;
+	BOOL rc = freerdp_settings_set_uint32(settings, FreeRDP_DesktopPosX, 1200) &&
+	          freerdp_settings_set_uint32(settings, FreeRDP_DesktopPosY, 600) &&
+	          freerdp_settings_set_uint32(settings, FreeRDP_DesktopWidth, 1900) &&
+	          freerdp_settings_set_uint32(settings, FreeRDP_DesktopHeight, 1200) &&
+	          freerdp_settings_set_bool(settings, FreeRDP_Fullscreen, fullscreen) &&
+	          freerdp_settings_set_bool(settings, FreeRDP_Workarea, workarea) &&
+	          freerdp_settings_set_uint32(settings, FreeRDP_PercentScreen, percent) &&
+	          freerdp_settings_set_bool(settings, FreeRDP_PercentScreenUseWidth, percent != 0) &&
+	          freerdp_settings_set_bool(settings, FreeRDP_PercentScreenUseHeight, percent != 0);
+	UINT32 actual_width = 0;
+	UINT32 actual_height = 0;
+	if (rc)
+		rc = xf_detect_monitors(&xfc, &actual_width, &actual_height);
+	if (!rc || actual_width != width || actual_height != height || xfc.vscreen.nmonitors != 2)
+	{
+		fprintf(stderr, "%s: expected %ux%u, got %ux%u (%u monitors)\n", name, width, height,
+		        actual_width, actual_height, xfc.vscreen.nmonitors);
+		rc = FALSE;
+	}
+	freerdp_settings_free(settings);
+	return rc;
+}
+
+int main(int argc, char* argv[])
+{
+	WINPR_UNUSED(argc);
+	WINPR_UNUSED(argv);
+	Display* display = XOpenDisplay(nullptr);
+	if (!display)
+		return 1;
+	const Window root = DefaultRootWindow(display);
+	XRRScreenResources* resources = XRRGetScreenResourcesCurrent(display, root);
+	XRRMonitorInfo* left = XRRAllocateMonitor(display, 1);
+	XRRMonitorInfo* right = XRRAllocateMonitor(display, 0);
+	int rc = 1;
+	if (!resources || resources->noutput < 1 || !left || !right)
+		goto out;
+
+	left->name = XInternAtom(display, "left", False);
+	left->primary = True;
+	left->width = 1200;
+	left->height = 1920;
+	left->mwidth = 300;
+	left->mheight = 480;
+	left->outputs[0] = resources->outputs[0];
+	right->name = XInternAtom(display, "right", False);
+	right->x = 1200;
+	right->y = 600;
+	right->width = 1920;
+	right->height = 1200;
+	right->mwidth = 480;
+	right->mheight = 300;
+	XRRSetMonitor(display, root, left);
+	XRRSetMonitor(display, root, right);
+	XWarpPointer(display, None, root, 0, 0, 0, 0, 100, 100);
+	XSync(display, False);
+
+	rc = 0;
+	if (!check_size(display, "windowed", FALSE, FALSE, 0, 1900, 1200))
+		rc = 1;
+	if (!check_size(display, "fullscreen", TRUE, FALSE, 0, 1200, 1920))
+		rc = 1;
+	if (!check_size(display, "workarea", FALSE, TRUE, 0, 1200, 1920))
+		rc = 1;
+	if (!check_size(display, "50 percent", FALSE, FALSE, 50, 600, 960))
+		rc = 1;
+out:
+	if (resources)
+		XRRFreeScreenResources(resources);
+	if (left)
+		XRRFreeMonitors(left);
+	if (right)
+		XRRFreeMonitors(right);
+	XCloseDisplay(display);
+	return rc;
+}

--- a/client/X11/xf_monitor.c
+++ b/client/X11/xf_monitor.c
@@ -659,7 +659,8 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pMaxWidth, UINT32* pMaxHeight)
 			    freerdp_settings_get_bool(settings, FreeRDP_RemoteApplicationMode))
 			{
 				*pMaxWidth = MIN(*pMaxWidth, (UINT32)vscreen->area.right - vscreen->area.left + 1);
-				*pMaxHeight = MIN(*pMaxHeight, (UINT32)vscreen->area.bottom - vscreen->area.top + 1);
+				*pMaxHeight =
+				    MIN(*pMaxHeight, (UINT32)vscreen->area.bottom - vscreen->area.top + 1);
 			}
 		}
 

--- a/client/X11/xf_monitor.c
+++ b/client/X11/xf_monitor.c
@@ -649,10 +649,18 @@ BOOL xf_detect_monitors(xfContext* xfc, UINT32* pMaxWidth, UINT32* pMaxHeight)
 				}
 			}
 
-			/* Set the desktop width and height according to the bounding rectangle around the
-			 * active monitors */
-			*pMaxWidth = MIN(*pMaxWidth, (UINT32)vscreen->area.right - vscreen->area.left + 1);
-			*pMaxHeight = MIN(*pMaxHeight, (UINT32)vscreen->area.bottom - vscreen->area.top + 1);
+			/* Monitor-based modes must fit the active monitors. A regular window can be
+			 * placed on another monitor or extend beyond the monitor under the pointer. */
+			if (freerdp_settings_get_bool(settings, FreeRDP_Fullscreen) ||
+			    freerdp_settings_get_bool(settings, FreeRDP_Workarea) ||
+			    freerdp_settings_get_uint32(settings, FreeRDP_PercentScreen) ||
+			    freerdp_settings_get_bool(settings, FreeRDP_UseMultimon) ||
+			    freerdp_settings_get_bool(settings, FreeRDP_SpanMonitors) ||
+			    freerdp_settings_get_bool(settings, FreeRDP_RemoteApplicationMode))
+			{
+				*pMaxWidth = MIN(*pMaxWidth, (UINT32)vscreen->area.right - vscreen->area.left + 1);
+				*pMaxHeight = MIN(*pMaxHeight, (UINT32)vscreen->area.bottom - vscreen->area.top + 1);
+			}
 		}
 
 		/* some 2008 server freeze at logon if we announce support for monitor layout PDU with


### PR DESCRIPTION
A window requested with `/window-position:1200x600 /size:1900x1200` is reduced to 1200 pixels wide when the pointer is on a 1200-pixel-wide monitor, even though the window belongs on the wider second monitor.

Keep the requested size for ordinary windows. Continue applying monitor bounds for fullscreen, workarea, percentage sizing, multimonitor, span and RemoteApp modes.

Fixes #12284.

Added an Xvfb test with a 1200x1920 monitor and a 1920x1200 monitor at +1200+600. It reproduces the 1200x1200 result before the fix and gets 1900x1200 after it. It also checks fullscreen, workarea and 50% sizing. The test is enabled when xvfb-run and XRandR are available.

Built `xfreerdp`, `TestClient` and `TestX11Monitor` on Linux aarch64. All four selected CTest tests pass (`ctest --test-dir build -R '^(TestClient|TestX11Monitor)' --output-on-failure`). Formatting and whitespace checks pass.
