### PR TITLE
[winpr,cast] fix parentheses

### DIFF
--- a/winpr/include/winpr/cast.h
+++ b/winpr/include/winpr/cast.h
@@ -60,8 +60,8 @@
 #endif
 
 #if !defined(WINPR_ARCH_SUPPORTED)
-#if defined(__GNUC__) || defined(__clang__) ||                       \
-    (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 202311L))) || \
+#if defined(__GNUC__) || defined(__clang__) ||                      \
+    (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 202311L)) || \
     (defined(__cplusplus) && (__cplusplus >= 202302L))
 #warning "unaligned pointer access not verified on platform, SIGBUS may happen!"
 #endif


### PR DESCRIPTION
```
winpr/include/winpr/cast.h:64:65: error: expected end of line in preprocessor expression
   64 |     (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 202311L))) || \
```