### PR TITLE
[codec,h264] fix broken MediaFoundation decoder build

### DIFF
--- a/libfreerdp/codec/h264_mf.c
+++ b/libfreerdp/codec/h264_mf.c
@@ -191,8 +191,7 @@ static UINT32 getSrcOffset(H264_CONTEXT_MF* sys, UINT32 line, BOOL isUV)
 	offset *= sys->stride;
 	if (isUV)
 		offset /= 2u;
-	return WINPR_ASSERTING_INT_CAST(UINT32, line);
-}
+	return WINPR_ASSERTING_INT_CAST(UINT32, offset);
 }
 
 static int mf_decompress(H264_CONTEXT* WINPR_RESTRICT h264, const BYTE* WINPR_RESTRICT pSrcData,
@@ -396,15 +395,15 @@ static int mf_decompress(H264_CONTEXT* WINPR_RESTRICT h264, const BYTE* WINPR_RE
 		 */
 		for (UINT32 x = 0; x < sys->frameHeight; x++)
 		{
-			const srcOffset = getSrcOffset(sys, x, FALSE);
-			const dstOffset = iStride[0] * x;
+			const UINT32 srcOffset = getSrcOffset(sys, x, FALSE);
+			const UINT32 dstOffset = (UINT32)iStride[0] * x;
 			CopyMemory(&pYUVData[0][dstOffset], &buffer[srcOffset], sys->stride);
 		}
 		for (UINT32 x = 0; x < sys->frameHeight / 2; x++)
 		{
-			const srcOffset = getSrcOffset(sys, x, TRUE);
-			const dstUOffset = iStride[1] * x;
-			const dstVOffset = iStride[2] * x;
+			const UINT32 srcOffset = getSrcOffset(sys, x, TRUE);
+			const UINT32 dstUOffset = (UINT32)iStride[1] * x;
+			const UINT32 dstVOffset = (UINT32)iStride[2] * x;
 			CopyMemory(&pYUVData[1][dstUOffset], &buffer[srcOffset], sys->stride / 2u);
 			CopyMemory(&pYUVData[2][dstVOffset], &buffer[srcOffset], sys->stride / 2u);
 		}


### PR DESCRIPTION
## Summary

Commit 8fbe04b ("[codec,h264] fix missing stride adjustments for Media Foundation") left `libfreerdp/codec/h264_mf.c` in a state that does not compile (reproduced with MSVC 2022, ninja `FAILED: [code=2]` on `h264_mf.c`):

* a stray closing brace `}` after `getSrcOffset()`
* type-less declarations in the copy loops (`const srcOffset = ...`, `const dstOffset = ...`, `const dstUOffset/dstVOffset = ...`) — implicit int is not valid C
* `getSrcOffset()` returned `line` instead of the computed `offset`, so the stride / bottom-up adjustments never took effect

## Changes

* remove the stray closing brace
* add the missing `UINT32` type specifiers
* return the computed `offset` from `getSrcOffset()`, restoring the intended behavior of 8fbe04b

🤖 Generated with [Claude Code](https://claude.com/claude-code)