### PR TITLE
[client,x11] release pointer grab when RemoteApp loses focus

### DIFF
--- a/client/X11/xf_event.c
+++ b/client/X11/xf_event.c
@@ -712,7 +712,12 @@ static BOOL xf_event_FocusOut(xfContext* xfc, const XFocusOutEvent* event, BOOL 
 
 	xf_keyboard_release_all_keypress(xfc);
 	if (app)
+	{
+		/* A pointer grab belongs to the previously focused RemoteApp window.
+		 * Keeping it would route clicks on local foreground windows back to it. */
+		xf_ungrab(xfc);
 		return xf_rail_send_activate(xfc, event->window, FALSE);
+	}
 
 	return TRUE;
 }


### PR DESCRIPTION
Fixes RemoteApp windows retaining an X11 pointer grab after they lose focus. A retained grab makes clicks intended for a local foreground window reach the background RemoteApp.

The RemoteApp FocusOut path now ungrabs the pointer before sending the RAIL deactivation order.

Validation: `git diff --check`, `git clang-format`, and a reduced X11 build of `xfreerdp-client`.