### PR TITLE
[client,x11] honor decorations for RemoteApp windows

### DIFF
--- a/client/X11/xf_window.c
+++ b/client/X11/xf_window.c
@@ -1061,7 +1061,7 @@ BOOL xf_AppWindowCreate(xfContext* xfc, xfAppWindow* appWindow)
 	xf_FixWindowCoordinates(xfc, &appWindow->x, &appWindow->y, &appWindow->width,
 	                        &appWindow->height);
 	appWindow->shmid = -1;
-	appWindow->decorations = FALSE;
+	appWindow->decorations = xfc->decorations;
 	appWindow->fullscreen = FALSE;
 	appWindow->local_move.state = LMS_NOT_ACTIVE;
 	appWindow->is_mapped = FALSE;


### PR DESCRIPTION
Makes `+decorations` and `-decorations` apply to X11 RemoteApp windows, matching desktop sessions.

RAIL already tracks local window extents when reporting moves and resizes. Initializing each app window from `xfc->decorations` lets the window manager render the requested local frame.

Validation: `git diff --check` and a reduced X11 build of `xfreerdp-client`.